### PR TITLE
Added correct minimal golang version in readme docker run

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ docker run --rm -it \
   -e OPENAI_API_KEY="your-openai-key" \
   -e ANTHROPIC_API_KEY="your-anthropic-key" \
   -e GEMINI_API_KEY="your-gemini-key" \
-  golang:1.21-alpine \
+  golang:1.24-alpine \
   go run ./cmd/gomodel
 ```
 


### PR DESCRIPTION
* Updated due to problem:
  * `go: go.mod requires go >= 1.24.0 (running go 1.21.13; GOTOOLCHAIN=local)`