### PR TITLE
chore: added env variable for max http body size

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,10 @@
 # Server Configuration
 PORT=8080
 
+# Maximum request body size (prevents DoS attacks)
+# Accepts values like "10M", "1G", "500K" (default: 10M)
+# BODY_SIZE_LIMIT=10M
+
 # Security Configuration
 # CRITICAL: Set this to secure your gateway from unauthorized access
 # If not set, the server will run in UNSAFE MODE with a warning
@@ -40,4 +44,3 @@ CACHE_TYPE=local
 
 # Groq
 # GROQ_API_KEY=gsk_...
-

--- a/cmd/gomodel/main.go
+++ b/cmd/gomodel/main.go
@@ -172,6 +172,7 @@ func main() {
 		MasterKey:       cfg.Server.MasterKey,
 		MetricsEnabled:  cfg.Metrics.Enabled,
 		MetricsEndpoint: cfg.Metrics.Endpoint,
+		BodySizeLimit:   cfg.Server.BodySizeLimit,
 	}
 	srv := server.New(router, serverCfg)
 

--- a/config/config.go
+++ b/config/config.go
@@ -55,7 +55,7 @@ type RedisConfig struct {
 type ServerConfig struct {
 	Port          string `mapstructure:"port"`
 	MasterKey     string `mapstructure:"master_key"`      // Optional: Master key for authentication
-	BodySizeLimit int64  `mapstructure:"body_size_limit"` // Parsed max request body size in bytes (default: 10MB)
+	BodySizeLimit string `mapstructure:"body_size_limit"` // Max request body size (e.g., "10M", "1024K")
 }
 
 // MetricsConfig holds observability configuration for Prometheus metrics
@@ -110,9 +110,8 @@ func Load() (*Config, error) {
 	var cfg Config
 
 	// Read config file (optional, won't fail if not found)
-	var bodySizeLimitStr string
 	if err := viper.ReadInConfig(); err == nil {
-		// Config file found, unmarshal it (BodySizeLimit will be 0 since it's now int64)
+		// Config file found, unmarshal it
 		if err := viper.Unmarshal(&cfg); err != nil {
 			return nil, err
 		}
@@ -120,15 +119,13 @@ func Load() (*Config, error) {
 		cfg = expandEnvVars(cfg)
 		// Remove providers with unresolved environment variables
 		cfg = removeEmptyProviders(cfg)
-		// Get body size limit as string for parsing
-		bodySizeLimitStr = expandString(viper.GetString("server.body_size_limit"))
 	} else {
 		// No config file, use environment variables (legacy support)
-		bodySizeLimitStr = viper.GetString("BODY_SIZE_LIMIT")
 		cfg = Config{
 			Server: ServerConfig{
-				Port:      viper.GetString("PORT"),
-				MasterKey: viper.GetString("GOMODEL_MASTER_KEY"),
+				Port:          viper.GetString("PORT"),
+				MasterKey:     viper.GetString("GOMODEL_MASTER_KEY"),
+				BodySizeLimit: viper.GetString("BODY_SIZE_LIMIT"),
 			},
 			Metrics: MetricsConfig{
 				Enabled:  viper.GetBool("METRICS_ENABLED"),
@@ -170,12 +167,12 @@ func Load() (*Config, error) {
 		}
 	}
 
-	// Parse and validate body size limit
-	bodySize, err := ParseBodySizeLimit(bodySizeLimitStr)
-	if err != nil {
-		return nil, fmt.Errorf("invalid BODY_SIZE_LIMIT: %w", err)
+	// Validate body size limit if provided
+	if cfg.Server.BodySizeLimit != "" {
+		if err := ValidateBodySizeLimit(cfg.Server.BodySizeLimit); err != nil {
+			return nil, fmt.Errorf("invalid BODY_SIZE_LIMIT: %w", err)
+		}
 	}
-	cfg.Server.BodySizeLimit = bodySize
 
 	return &cfg, nil
 }
@@ -185,6 +182,7 @@ func expandEnvVars(cfg Config) Config {
 	// Expand server config
 	cfg.Server.Port = expandString(cfg.Server.Port)
 	cfg.Server.MasterKey = expandString(cfg.Server.MasterKey)
+	cfg.Server.BodySizeLimit = expandString(cfg.Server.BodySizeLimit)
 
 	// Expand metrics configuration
 	cfg.Metrics.Endpoint = expandString(cfg.Metrics.Endpoint)
@@ -249,23 +247,23 @@ func removeEmptyProviders(cfg Config) Config {
 	return cfg
 }
 
-// ParseBodySizeLimit parses a human-readable body size limit string into bytes.
-// Accepts formats like: "10M", "10MB", "1024K", "1024KB", "104857600", "100G"
-// Returns the size in bytes or an error if the format is invalid.
-func ParseBodySizeLimit(s string) (int64, error) {
+// ValidateBodySizeLimit validates a body size limit string.
+// Accepts formats like: "10M", "10MB", "1024K", "1024KB", "104857600"
+// Returns an error if the format is invalid or value is outside bounds (1KB - 100MB).
+func ValidateBodySizeLimit(s string) error {
 	s = strings.TrimSpace(s)
 	if s == "" {
-		return DefaultBodySizeLimit, nil
+		return nil
 	}
 
 	matches := bodySizeLimitRegex.FindStringSubmatch(s)
 	if matches == nil {
-		return 0, fmt.Errorf("invalid format %q: expected pattern like '10M', '1024K', or '104857600'", s)
+		return fmt.Errorf("invalid format %q: expected pattern like '10M', '1024K', or '104857600'", s)
 	}
 
 	value, err := strconv.ParseInt(matches[1], 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("invalid number in %q: %w", s, err)
+		return fmt.Errorf("invalid number in %q: %w", s, err)
 	}
 
 	// Apply unit multiplier (case-insensitive due to regex flag)
@@ -280,25 +278,11 @@ func ParseBodySizeLimit(s string) (int64, error) {
 
 	// Validate bounds
 	if value < MinBodySizeLimit {
-		return 0, fmt.Errorf("value %d bytes is below minimum of %d bytes (1KB)", value, MinBodySizeLimit)
+		return fmt.Errorf("value %d bytes is below minimum of %d bytes (1KB)", value, MinBodySizeLimit)
 	}
 	if value > MaxBodySizeLimit {
-		return 0, fmt.Errorf("value %d bytes exceeds maximum of %d bytes (100MB)", value, MaxBodySizeLimit)
+		return fmt.Errorf("value %d bytes exceeds maximum of %d bytes (100MB)", value, MaxBodySizeLimit)
 	}
 
-	return value, nil
-}
-
-// FormatBodySizeLimit returns a human-readable string for bytes (e.g., "10M")
-func FormatBodySizeLimit(b int64) string {
-	switch {
-	case b >= 1024*1024*1024 && b%(1024*1024*1024) == 0:
-		return fmt.Sprintf("%dG", b/(1024*1024*1024))
-	case b >= 1024*1024 && b%(1024*1024) == 0:
-		return fmt.Sprintf("%dM", b/(1024*1024))
-	case b >= 1024 && b%1024 == 0:
-		return fmt.Sprintf("%dK", b/1024)
-	default:
-		return strconv.FormatInt(b, 10)
-	}
+	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -40,8 +40,9 @@ type RedisConfig struct {
 
 // ServerConfig holds HTTP server configuration
 type ServerConfig struct {
-	Port      string `mapstructure:"port"`
-	MasterKey string `mapstructure:"master_key"` // Optional: Master key for authentication
+	Port          string `mapstructure:"port"`
+	MasterKey     string `mapstructure:"master_key"`      // Optional: Master key for authentication
+	BodySizeLimit string `mapstructure:"body_size_limit"` // Optional: Max request body size (default: 10M)
 }
 
 // MetricsConfig holds observability configuration for Prometheus metrics
@@ -109,8 +110,9 @@ func Load() (*Config, error) {
 		// No config file, use environment variables (legacy support)
 		cfg = Config{
 			Server: ServerConfig{
-				Port:      viper.GetString("PORT"),
-				MasterKey: viper.GetString("GOMODEL_MASTER_KEY"),
+				Port:          viper.GetString("PORT"),
+				MasterKey:     viper.GetString("GOMODEL_MASTER_KEY"),
+				BodySizeLimit: viper.GetString("BODY_SIZE_LIMIT"),
 			},
 			Metrics: MetricsConfig{
 				Enabled:  viper.GetBool("METRICS_ENABLED"),
@@ -157,9 +159,10 @@ func Load() (*Config, error) {
 
 // expandEnvVars expands environment variable references in configuration values
 func expandEnvVars(cfg Config) Config {
-	// Expand server port
+	// Expand server config
 	cfg.Server.Port = expandString(cfg.Server.Port)
 	cfg.Server.MasterKey = expandString(cfg.Server.MasterKey)
+	cfg.Server.BodySizeLimit = expandString(cfg.Server.BodySizeLimit)
 
 	// Expand metrics configuration
 	cfg.Metrics.Endpoint = expandString(cfg.Metrics.Endpoint)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -267,80 +267,52 @@ OPENAI_API_KEY=sk-from-dotenv-file
 	}
 }
 
-func TestParseBodySizeLimit(t *testing.T) {
+func TestValidateBodySizeLimit(t *testing.T) {
 	tests := []struct {
 		name        string
 		input       string
-		expected    int64
 		expectError bool
 	}{
 		// Valid formats
-		{"empty string returns default", "", DefaultBodySizeLimit, false},
-		{"plain number", "1048576", 1048576, false},
-		{"kilobytes lowercase", "100k", 100 * 1024, false},
-		{"kilobytes uppercase", "100K", 100 * 1024, false},
-		{"kilobytes with B suffix", "100KB", 100 * 1024, false},
-		{"megabytes lowercase", "10m", 10 * 1024 * 1024, false},
-		{"megabytes uppercase", "10M", 10 * 1024 * 1024, false},
-		{"megabytes with B suffix", "10MB", 10 * 1024 * 1024, false},
-		{"whitespace trimmed", "  10M  ", 10 * 1024 * 1024, false},
+		{"empty string is valid", "", false},
+		{"plain number", "1048576", false},
+		{"kilobytes lowercase", "100k", false},
+		{"kilobytes uppercase", "100K", false},
+		{"kilobytes with B suffix", "100KB", false},
+		{"megabytes lowercase", "10m", false},
+		{"megabytes uppercase", "10M", false},
+		{"megabytes with B suffix", "10MB", false},
+		{"whitespace trimmed", "  10M  ", false},
 
 		// Boundary values
-		{"minimum valid (1KB)", "1K", MinBodySizeLimit, false},
-		{"maximum valid (100MB)", "100M", MaxBodySizeLimit, false},
+		{"minimum valid (1KB)", "1K", false},
+		{"maximum valid (100MB)", "100M", false},
 
 		// Invalid formats
-		{"invalid format with letters", "abc", 0, true},
-		{"invalid unit", "10X", 0, true},
-		{"negative number", "-10M", 0, true},
-		{"decimal number", "10.5M", 0, true},
-		{"empty unit with B", "10B", 0, true},
+		{"invalid format with letters", "abc", true},
+		{"invalid unit", "10X", true},
+		{"negative number", "-10M", true},
+		{"decimal number", "10.5M", true},
+		{"empty unit with B", "10B", true},
 
 		// Boundary violations
-		{"below minimum (100 bytes)", "100", 0, true},
-		{"above maximum (200MB)", "200M", 0, true},
-		{"above maximum (1GB)", "1G", 0, true},
+		{"below minimum (100 bytes)", "100", true},
+		{"above maximum (200MB)", "200M", true},
+		{"above maximum (1GB)", "1G", true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := ParseBodySizeLimit(tt.input)
+			err := ValidateBodySizeLimit(tt.input)
 
 			if tt.expectError {
 				if err == nil {
-					t.Errorf("expected error for input %q, got result %d", tt.input, result)
+					t.Errorf("expected error for input %q, got nil", tt.input)
 				}
 			} else {
 				if err != nil {
 					t.Errorf("unexpected error for input %q: %v", tt.input, err)
 				}
-				if result != tt.expected {
-					t.Errorf("for input %q, expected %d, got %d", tt.input, tt.expected, result)
-				}
-			}
-		})
-	}
-}
-
-func TestFormatBodySizeLimit(t *testing.T) {
-	tests := []struct {
-		bytes    int64
-		expected string
-	}{
-		{1024, "1K"},
-		{10 * 1024, "10K"},
-		{1024 * 1024, "1M"},
-		{10 * 1024 * 1024, "10M"},
-		{1024 * 1024 * 1024, "1G"},
-		{1500, "1500"},          // Not evenly divisible by 1024
-		{1536 * 1024, "1536K"},  // Not evenly divisible by 1MB
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.expected, func(t *testing.T) {
-			result := FormatBodySizeLimit(tt.bytes)
-			if result != tt.expected {
-				t.Errorf("for %d bytes, expected %q, got %q", tt.bytes, tt.expected, result)
 			}
 		})
 	}

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -10,12 +10,21 @@ import (
 
 // AuthMiddleware creates an Echo middleware that validates the master key
 // if it's configured. If masterKey is empty, no authentication is required.
-func AuthMiddleware(masterKey string) echo.MiddlewareFunc {
+// skipPaths is a list of paths that should bypass authentication.
+func AuthMiddleware(masterKey string, skipPaths []string) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			// If no master key is configured, allow all requests
 			if masterKey == "" {
 				return next(c)
+			}
+
+			// Check if path should skip authentication
+			requestPath := c.Request().URL.Path
+			for _, skipPath := range skipPaths {
+				if requestPath == skipPath {
+					return next(c)
+				}
 			}
 
 			// Get Authorization header

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -2,10 +2,8 @@ package server
 
 import (
 	"context"
-	"log/slog"
 	"net/http"
 	"path"
-	"strings"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -33,52 +31,47 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 	e := echo.New()
 	e.HideBanner = true
 
-	// Global middleware (applies to all routes)
+	handler := NewHandler(provider)
+
+	// Build list of paths that skip authentication
+	authSkipPaths := []string{"/health"}
+
+	// Determine metrics path
+	metricsPath := "/metrics"
+	if cfg != nil && cfg.MetricsEnabled {
+		if cfg.MetricsEndpoint != "" {
+			// Normalize path to prevent traversal attacks
+			metricsPath = path.Clean(cfg.MetricsEndpoint)
+		}
+		authSkipPaths = append(authSkipPaths, metricsPath)
+	}
+
+	// Global middleware stack (order matters)
 	e.Use(middleware.RequestLogger())
 	e.Use(middleware.Recover())
 
-	handler := NewHandler(provider)
-
-	// Public routes (no authentication required)
-	// These must be registered BEFORE auth middleware is applied
-	e.GET("/health", handler.Health)
-
-	// Conditionally register metrics endpoint (public, no auth)
-	if cfg != nil && cfg.MetricsEnabled {
-		metricsPath := cfg.MetricsEndpoint
-		if metricsPath == "" {
-			metricsPath = "/metrics"
-		}
-		// Normalize path to prevent traversal attacks (e.g., /v1/../admin -> /admin)
-		// and then validate it doesn't shadow protected API routes
-		metricsPath = path.Clean(metricsPath)
-		if metricsPath == "/v1" || strings.HasPrefix(metricsPath, "/v1/") {
-			slog.Warn("metrics endpoint path conflicts with API routes, using /metrics instead",
-				"configured_path", cfg.MetricsEndpoint,
-				"normalized_path", metricsPath)
-			metricsPath = "/metrics"
-		}
-		e.GET(metricsPath, echo.WrapHandler(promhttp.Handler()))
-	}
-
-	// API routes group with authentication and body size limit
-	api := e.Group("/v1")
-
-	// Add body size limit to prevent DoS (default: 10MB)
+	// Body size limit (default: 10MB)
 	bodySizeLimit := "10M"
 	if cfg != nil && cfg.BodySizeLimit != "" {
 		bodySizeLimit = cfg.BodySizeLimit
 	}
-	api.Use(middleware.BodyLimit(bodySizeLimit))
+	e.Use(middleware.BodyLimit(bodySizeLimit))
 
-	// Add authentication middleware if master key is configured
+	// Authentication (skips public paths)
 	if cfg != nil && cfg.MasterKey != "" {
-		api.Use(AuthMiddleware(cfg.MasterKey))
+		e.Use(AuthMiddleware(cfg.MasterKey, authSkipPaths))
 	}
 
-	api.GET("/models", handler.ListModels)
-	api.POST("/chat/completions", handler.ChatCompletion)
-	api.POST("/responses", handler.Responses)
+	// Public routes
+	e.GET("/health", handler.Health)
+	if cfg != nil && cfg.MetricsEnabled {
+		e.GET(metricsPath, echo.WrapHandler(promhttp.Handler()))
+	}
+
+	// API routes
+	e.GET("/v1/models", handler.ListModels)
+	e.POST("/v1/chat/completions", handler.ChatCompletion)
+	e.POST("/v1/responses", handler.Responses)
 
 	return &Server{
 		echo:    e,

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -25,6 +25,7 @@ type Config struct {
 	MasterKey       string // Optional: Master key for authentication
 	MetricsEnabled  bool   // Whether to expose Prometheus metrics endpoint
 	MetricsEndpoint string // HTTP path for metrics endpoint (default: /metrics)
+	BodySizeLimit   string // Max request body size (default: "10M")
 }
 
 // New creates a new HTTP server
@@ -63,8 +64,12 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 	// API routes group with authentication and body size limit
 	api := e.Group("/v1")
 
-	// Add body size limit to prevent DoS (10MB max)
-	api.Use(middleware.BodyLimit("10M"))
+	// Add body size limit to prevent DoS (default: 10MB)
+	bodySizeLimit := "10M"
+	if cfg != nil && cfg.BodySizeLimit != "" {
+		bodySizeLimit = cfg.BodySizeLimit
+	}
+	api.Use(middleware.BodyLimit(bodySizeLimit))
 
 	// Add authentication middleware if master key is configured
 	if cfg != nil && cfg.MasterKey != "" {

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"net/http"
 	"path"
-	"strconv"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-	"gomodel/config"
 	"gomodel/internal/core"
 )
 
@@ -25,7 +23,7 @@ type Config struct {
 	MasterKey       string // Optional: Master key for authentication
 	MetricsEnabled  bool   // Whether to expose Prometheus metrics endpoint
 	MetricsEndpoint string // HTTP path for metrics endpoint (default: /metrics)
-	BodySizeLimit   int64  // Max request body size in bytes (default: 10MB)
+	BodySizeLimit   string // Max request body size (e.g., "10M", "1024K")
 }
 
 // New creates a new HTTP server
@@ -53,11 +51,11 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 	e.Use(middleware.Recover())
 
 	// Body size limit (default: 10MB)
-	bodySizeLimit := config.DefaultBodySizeLimit
-	if cfg != nil && cfg.BodySizeLimit > 0 {
+	bodySizeLimit := "10M"
+	if cfg != nil && cfg.BodySizeLimit != "" {
 		bodySizeLimit = cfg.BodySizeLimit
 	}
-	e.Use(middleware.BodyLimit(strconv.FormatInt(bodySizeLimit, 10)))
+	e.Use(middleware.BodyLimit(bodySizeLimit))
 
 	// Authentication (skips public paths)
 	if cfg != nil && cfg.MasterKey != "" {

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"net/http"
 	"path"
+	"strconv"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	"gomodel/config"
 	"gomodel/internal/core"
 )
 
@@ -23,7 +25,7 @@ type Config struct {
 	MasterKey       string // Optional: Master key for authentication
 	MetricsEnabled  bool   // Whether to expose Prometheus metrics endpoint
 	MetricsEndpoint string // HTTP path for metrics endpoint (default: /metrics)
-	BodySizeLimit   string // Max request body size (default: "10M")
+	BodySizeLimit   int64  // Max request body size in bytes (default: 10MB)
 }
 
 // New creates a new HTTP server
@@ -51,11 +53,11 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 	e.Use(middleware.Recover())
 
 	// Body size limit (default: 10MB)
-	bodySizeLimit := "10M"
-	if cfg != nil && cfg.BodySizeLimit != "" {
+	bodySizeLimit := config.DefaultBodySizeLimit
+	if cfg != nil && cfg.BodySizeLimit > 0 {
 		bodySizeLimit = cfg.BodySizeLimit
 	}
-	e.Use(middleware.BodyLimit(bodySizeLimit))
+	e.Use(middleware.BodyLimit(strconv.FormatInt(bodySizeLimit, 10)))
 
 	// Authentication (skips public paths)
 	if cfg != nil && cfg.MasterKey != "" {

--- a/internal/server/security_test.go
+++ b/internal/server/security_test.go
@@ -123,7 +123,7 @@ func TestConfigurableBodySizeLimit(t *testing.T) {
 
 	t.Run("custom body size limit of 1M is respected", func(t *testing.T) {
 		srv := New(mock, &Config{
-			BodySizeLimit: "1M",
+			BodySizeLimit: 1 * 1024 * 1024, // 1MB
 		})
 
 		// 500KB should be accepted
@@ -149,7 +149,7 @@ func TestConfigurableBodySizeLimit(t *testing.T) {
 
 	t.Run("custom body size limit of 20M allows larger requests", func(t *testing.T) {
 		srv := New(mock, &Config{
-			BodySizeLimit: "20M",
+			BodySizeLimit: 20 * 1024 * 1024, // 20MB
 		})
 
 		// 15MB should be accepted
@@ -175,7 +175,7 @@ func TestConfigurableBodySizeLimit(t *testing.T) {
 
 	t.Run("body size limit with kilobytes unit", func(t *testing.T) {
 		srv := New(mock, &Config{
-			BodySizeLimit: "500K",
+			BodySizeLimit: 500 * 1024, // 500KB
 		})
 
 		// 400KB should be accepted

--- a/internal/server/security_test.go
+++ b/internal/server/security_test.go
@@ -123,7 +123,7 @@ func TestConfigurableBodySizeLimit(t *testing.T) {
 
 	t.Run("custom body size limit of 1M is respected", func(t *testing.T) {
 		srv := New(mock, &Config{
-			BodySizeLimit: 1 * 1024 * 1024, // 1MB
+			BodySizeLimit: "1M",
 		})
 
 		// 500KB should be accepted
@@ -149,7 +149,7 @@ func TestConfigurableBodySizeLimit(t *testing.T) {
 
 	t.Run("custom body size limit of 20M allows larger requests", func(t *testing.T) {
 		srv := New(mock, &Config{
-			BodySizeLimit: 20 * 1024 * 1024, // 20MB
+			BodySizeLimit: "20M",
 		})
 
 		// 15MB should be accepted
@@ -175,7 +175,7 @@ func TestConfigurableBodySizeLimit(t *testing.T) {
 
 	t.Run("body size limit with kilobytes unit", func(t *testing.T) {
 		srv := New(mock, &Config{
-			BodySizeLimit: 500 * 1024, // 500KB
+			BodySizeLimit: "500K",
 		})
 
 		// 400KB should be accepted

--- a/internal/server/security_test.go
+++ b/internal/server/security_test.go
@@ -7,77 +7,39 @@ import (
 	"testing"
 )
 
-// TestMetricsEndpointPathCollision verifies that metrics endpoint paths under /v1/*
-// are rejected and fall back to /metrics to prevent auth bypass
-func TestMetricsEndpointPathCollision(t *testing.T) {
+// TestMetricsEndpointCustomPaths verifies that custom metrics paths work correctly
+func TestMetricsEndpointCustomPaths(t *testing.T) {
 	mock := &mockProvider{}
 
-	t.Run("metrics at /v1/metrics falls back to /metrics", func(t *testing.T) {
+	t.Run("custom metrics path is accessible without auth", func(t *testing.T) {
 		srv := New(mock, &Config{
 			MasterKey:       "secret-key",
 			MetricsEnabled:  true,
-			MetricsEndpoint: "/v1/metrics", // Should be rejected and fall back to /metrics
+			MetricsEndpoint: "/monitoring/metrics",
 		})
 
-		// /v1/metrics should require auth (not be the metrics endpoint)
-		req := httptest.NewRequest(http.MethodGet, "/v1/metrics", nil)
-		rec := httptest.NewRecorder()
-		srv.ServeHTTP(rec, req)
-
-		if rec.Code != http.StatusUnauthorized {
-			t.Errorf("Expected 401 for /v1/metrics (validation should reject this path), got %d", rec.Code)
-		}
-
-		// Metrics should be available at /metrics instead
-		req2 := httptest.NewRequest(http.MethodGet, "/metrics", nil)
-		rec2 := httptest.NewRecorder()
-		srv.ServeHTTP(rec2, req2)
-
-		if rec2.Code != http.StatusOK {
-			t.Errorf("Expected 200 for /metrics (fallback path), got %d", rec2.Code)
-		}
-	})
-
-	t.Run("metrics at /v1/chat/completions falls back to /metrics", func(t *testing.T) {
-		srv := New(mock, &Config{
-			MasterKey:       "secret-key",
-			MetricsEnabled:  true,
-			MetricsEndpoint: "/v1/chat/completions", // Should be rejected
-		})
-
-		// /v1/chat/completions should require auth
-		req := httptest.NewRequest(http.MethodGet, "/v1/chat/completions", nil)
-		rec := httptest.NewRecorder()
-		srv.ServeHTTP(rec, req)
-
-		if rec.Code != http.StatusUnauthorized {
-			t.Errorf("Expected 401 for /v1/chat/completions, got %d", rec.Code)
-		}
-
-		// Metrics should be at /metrics
-		req2 := httptest.NewRequest(http.MethodGet, "/metrics", nil)
-		rec2 := httptest.NewRecorder()
-		srv.ServeHTTP(rec2, req2)
-
-		if rec2.Code != http.StatusOK {
-			t.Errorf("Expected 200 for /metrics, got %d", rec2.Code)
-		}
-	})
-
-	t.Run("/v10/metrics is allowed (not under /v1/)", func(t *testing.T) {
-		srv := New(mock, &Config{
-			MasterKey:       "secret-key",
-			MetricsEnabled:  true,
-			MetricsEndpoint: "/v10/metrics", // Should be allowed - not under /v1/
-		})
-
-		// /v10/metrics should work as metrics endpoint
-		req := httptest.NewRequest(http.MethodGet, "/v10/metrics", nil)
+		req := httptest.NewRequest(http.MethodGet, "/monitoring/metrics", nil)
 		rec := httptest.NewRecorder()
 		srv.ServeHTTP(rec, req)
 
 		if rec.Code != http.StatusOK {
-			t.Errorf("Expected 200 for /v10/metrics (allowed path), got %d", rec.Code)
+			t.Errorf("Expected 200 for custom metrics path, got %d", rec.Code)
+		}
+	})
+
+	t.Run("nested metrics path works", func(t *testing.T) {
+		srv := New(mock, &Config{
+			MasterKey:       "secret-key",
+			MetricsEnabled:  true,
+			MetricsEndpoint: "/api/v2/metrics",
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v2/metrics", nil)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("Expected 200 for nested metrics path, got %d", rec.Code)
 		}
 	})
 }
@@ -238,72 +200,59 @@ func TestConfigurableBodySizeLimit(t *testing.T) {
 	})
 }
 
-// TestHealthEndpointNotAffectedByBodyLimit tests that health endpoint
-// is not subject to API group body limits
-func TestHealthEndpointNotAffectedByBodyLimit(t *testing.T) {
+// TestBodyLimitAppliesToAllRoutes tests that body limit is applied globally
+func TestBodyLimitAppliesToAllRoutes(t *testing.T) {
 	mock := &mockProvider{}
 	srv := New(mock, nil)
 
-	// Health endpoint should work even with a body (though unusual)
-	// This tests that it's truly outside the /v1 group
 	largeBody := strings.Repeat("x", 11*1024*1024)
-	req := httptest.NewRequest(http.MethodGet, "/health", strings.NewReader(largeBody))
+
+	// Body limit applies to all routes including health (DoS protection)
+	req := httptest.NewRequest(http.MethodPost, "/health", strings.NewReader(largeBody))
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
-	// Health should return 200, not 413, because it's outside the /v1 group
-	if rec.Code != http.StatusOK {
-		t.Errorf("Health endpoint should not have body limit, got status %d", rec.Code)
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("Body limit should apply globally, got status %d", rec.Code)
 	}
 }
 
-// TestMetricsEndpointPathTraversal tests that path traversal cannot bypass validation
+// TestMetricsEndpointPathTraversal tests that path traversal is normalized
 func TestMetricsEndpointPathTraversal(t *testing.T) {
 	mock := &mockProvider{}
 
-	t.Run("path traversal to /v1/ is blocked after normalization", func(t *testing.T) {
-		// /foo/../v1/admin normalizes to /v1/admin which should be rejected
+	t.Run("path traversal is normalized", func(t *testing.T) {
+		// /foo/../admin normalizes to /admin
 		srv := New(mock, &Config{
 			MasterKey:       "secret",
 			MetricsEnabled:  true,
-			MetricsEndpoint: "/foo/../v1/admin",
+			MetricsEndpoint: "/foo/../admin",
 		})
 
-		// Metrics should fall back to /metrics since normalized path is under /v1/
-		req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
-		rec := httptest.NewRecorder()
-		srv.ServeHTTP(rec, req)
-
-		if rec.Code != http.StatusOK {
-			t.Errorf("Expected metrics at /metrics after fallback, got %d", rec.Code)
-		}
-
-		// /v1/admin should require auth (not be the metrics endpoint)
-		req2 := httptest.NewRequest(http.MethodGet, "/v1/admin", nil)
-		rec2 := httptest.NewRecorder()
-		srv.ServeHTTP(rec2, req2)
-
-		if rec2.Code != http.StatusUnauthorized {
-			t.Errorf("Expected 401 for /v1/admin, got %d", rec2.Code)
-		}
-	})
-
-	t.Run("path traversing away from /v1 is allowed", func(t *testing.T) {
-		// /v1/../admin normalizes to /admin which is NOT under /v1/
-		srv := New(mock, &Config{
-			MasterKey:       "secret",
-			MetricsEnabled:  true,
-			MetricsEndpoint: "/v1/../admin",
-		})
-
-		// After normalization, /v1/../admin -> /admin, which is allowed
-		// So metrics should be served at /v1/../admin (which Echo normalizes to /admin)
+		// Normalized path /admin should serve metrics
 		req := httptest.NewRequest(http.MethodGet, "/admin", nil)
 		rec := httptest.NewRecorder()
 		srv.ServeHTTP(rec, req)
 
 		if rec.Code != http.StatusOK {
-			t.Errorf("Expected 200 for /admin (normalized path is allowed), got %d", rec.Code)
+			t.Errorf("Expected 200 for normalized path /admin, got %d", rec.Code)
+		}
+	})
+
+	t.Run("double dots are cleaned from path", func(t *testing.T) {
+		// /a/b/../c normalizes to /a/c
+		srv := New(mock, &Config{
+			MasterKey:       "secret",
+			MetricsEnabled:  true,
+			MetricsEndpoint: "/a/b/../c",
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/a/c", nil)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("Expected 200 for cleaned path /a/c, got %d", rec.Code)
 		}
 	})
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global configurable request body size limit via BODY_SIZE_LIMIT (default 10M).

* **Behavior**
  * Body size limit enforced across all routes (including health); metrics endpoint path configurable and kept separate from API routes; certain paths can bypass auth.

* **Tests**
  * Expanded tests for body-size limits, global enforcement, configurable metrics paths, path normalization, and auth skip-paths.

* **Documentation**
  * Added BODY_SIZE_LIMIT docs to env template and minor formatting cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->