### PR TITLE
fix: metrics are env variable sensitive

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -134,6 +134,8 @@ func Load() (*Config, error) {
 			Providers: make(map[string]ProviderConfig),
 		}
 
+		// TODO: There should be iteration over all providers in config.yaml
+		// TODO: Similarly for ENV variables. All ENV variables like *_API_KEY should be taken and iterated over
 		// Add providers from environment variables if available
 		if apiKey := viper.GetString("OPENAI_API_KEY"); apiKey != "" {
 			cfg.Providers["openai-primary"] = ProviderConfig{
@@ -185,6 +187,10 @@ func expandEnvVars(cfg Config) Config {
 	cfg.Server.BodySizeLimit = expandString(cfg.Server.BodySizeLimit)
 
 	// Expand metrics configuration
+	// Check METRICS_ENABLED env var - it should override YAML config
+	if metricsEnabled := os.Getenv("METRICS_ENABLED"); metricsEnabled != "" {
+		cfg.Metrics.Enabled = strings.EqualFold(metricsEnabled, "true") || metricsEnabled == "1"
+	}
 	cfg.Metrics.Endpoint = expandString(cfg.Metrics.Endpoint)
 
 	// Expand cache configuration

--- a/config/config.go
+++ b/config/config.go
@@ -134,7 +134,6 @@ func Load() (*Config, error) {
 			Providers: make(map[string]ProviderConfig),
 		}
 
-		// TODO: There should be iteration over all providers in config.yaml
 		// TODO: Similarly for ENV variables. All ENV variables like *_API_KEY should be taken and iterated over
 		// Add providers from environment variables if available
 		if apiKey := viper.GetString("OPENAI_API_KEY"); apiKey != "" {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -25,7 +25,7 @@ metrics:
   # When disabled, no metrics are collected and the /metrics endpoint returns 404
   # Default: false
   # TODO: the default value should be taken here from ENV variable METRICS_ENABLED explicitly
-  # Note: It should be commented out, because it overrides the ENV variable in th current form
+  # Note: It should be commented out, because it overrides the ENV variable in the current form
   # enabled: false
 
   # HTTP endpoint path where metrics are exposed

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -25,7 +25,8 @@ metrics:
   # When disabled, no metrics are collected and the /metrics endpoint returns 404
   # Default: false
   # TODO: the default value should be taken here from ENV variable METRICS_ENABLED explicitly
-  enabled: false
+  # Note: It should be commented out, because it overrides the ENV variable in th current form
+  # enabled: false
 
   # HTTP endpoint path where metrics are exposed
   # Default: /metrics


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metrics can be enabled at runtime via the METRICS_ENABLED environment variable ("true" or "1", case-insensitive), which now takes precedence over configuration file values.

* **Chores**
  * The default config no longer sets an active metrics enabled value to avoid overriding the environment.
  * Added a developer TODO to improve environment-based provider population.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->