### PR TITLE
fix(ci): add least-privilege permissions to docker job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,8 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     needs: goreleaser # Wait for GoReleaser to succeed
+    permissions:
+      contents: read # Override workflow-level write permission (least privilege)
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Apply CodeRabbit suggestion to override workflow-level contents:write permission with contents:read for the docker job, following the principle of least privilege.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security by implementing least privilege permissions in the release workflow, restricting access to only what is necessary for job execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->