### PR TITLE
Feature: Add feature flag for token usage tracking

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -80,9 +80,14 @@ LOGGING_ENABLED=false
 # Token Usage Tracking Configuration
 # =============================================================================
 
-# Enable/disable token usage tracking (default: false)
+# Enable/disable token usage tracking (default: true)
 # When enabled, token usage is tracked separately from audit logs
-# USAGE_ENABLED=false
+# USAGE_ENABLED=true
+
+# Enforce returning usage data in streaming responses (default: true)
+# When true, stream_options: {"include_usage": true} is automatically added
+# to streaming requests for OpenAI-compatible providers
+# ENFORCE_RETURNING_USAGE_DATA=true
 
 # In-memory buffer size before flushing to storage (default: 1000)
 # USAGE_BUFFER_SIZE=1000

--- a/internal/core/responses.go
+++ b/internal/core/responses.go
@@ -10,6 +10,7 @@ type ResponsesRequest struct {
 	Temperature     *float64          `json:"temperature,omitempty"`
 	MaxOutputTokens *int              `json:"max_output_tokens,omitempty"`
 	Stream          bool              `json:"stream,omitempty"`
+	StreamOptions   *StreamOptions    `json:"stream_options,omitempty"`
 	Metadata        map[string]string `json:"metadata,omitempty"`
 }
 
@@ -24,6 +25,7 @@ func (r *ResponsesRequest) WithStreaming() *ResponsesRequest {
 		Temperature:     r.Temperature,
 		MaxOutputTokens: r.MaxOutputTokens,
 		Stream:          true,
+		StreamOptions:   r.StreamOptions,
 		Metadata:        r.Metadata,
 	}
 }

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -1,23 +1,33 @@
 package core
 
+// StreamOptions controls streaming behavior options.
+// This is used to request usage data in streaming responses.
+type StreamOptions struct {
+	// IncludeUsage requests token usage information in streaming responses.
+	// When true, the final streaming chunk will include usage statistics.
+	IncludeUsage bool `json:"include_usage,omitempty"`
+}
+
 // ChatRequest represents the incoming chat completion request
 type ChatRequest struct {
-	Temperature *float64  `json:"temperature,omitempty"`
-	MaxTokens   *int      `json:"max_tokens,omitempty"`
-	Model       string    `json:"model"`
-	Messages    []Message `json:"messages"`
-	Stream      bool      `json:"stream,omitempty"`
+	Temperature   *float64       `json:"temperature,omitempty"`
+	MaxTokens     *int           `json:"max_tokens,omitempty"`
+	Model         string         `json:"model"`
+	Messages      []Message      `json:"messages"`
+	Stream        bool           `json:"stream,omitempty"`
+	StreamOptions *StreamOptions `json:"stream_options,omitempty"`
 }
 
 // WithStreaming returns a shallow copy of the request with Stream set to true.
 // This avoids mutating the caller's request object.
 func (r *ChatRequest) WithStreaming() *ChatRequest {
 	return &ChatRequest{
-		Temperature: r.Temperature,
-		MaxTokens:   r.MaxTokens,
-		Model:       r.Model,
-		Messages:    r.Messages,
-		Stream:      true,
+		Temperature:   r.Temperature,
+		MaxTokens:     r.MaxTokens,
+		Model:         r.Model,
+		Messages:      r.Messages,
+		Stream:        true,
+		StreamOptions: r.StreamOptions,
 	}
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -95,6 +95,13 @@ func (h *Handler) ChatCompletion(c echo.Context) error {
 
 	// Handle streaming: proxy the raw SSE stream
 	if req.Stream {
+		// Enforce returning usage data in streaming responses if configured
+		if h.usageLogger != nil && h.usageLogger.Config().EnforceReturningUsageData {
+			if req.StreamOptions == nil {
+				req.StreamOptions = &core.StreamOptions{}
+			}
+			req.StreamOptions.IncludeUsage = true
+		}
 		return h.handleStreamingResponse(c, req.Model, providerType, func() (io.ReadCloser, error) {
 			return h.provider.StreamChatCompletion(c.Request().Context(), &req)
 		})
@@ -154,6 +161,13 @@ func (h *Handler) Responses(c echo.Context) error {
 
 	// Handle streaming: proxy the raw SSE stream
 	if req.Stream {
+		// Enforce returning usage data in streaming responses if configured
+		if h.usageLogger != nil && h.usageLogger.Config().EnforceReturningUsageData {
+			if req.StreamOptions == nil {
+				req.StreamOptions = &core.StreamOptions{}
+			}
+			req.StreamOptions.IncludeUsage = true
+		}
 		return h.handleStreamingResponse(c, req.Model, providerType, func() (io.ReadCloser, error) {
 			return h.provider.StreamResponses(c.Request().Context(), &req)
 		})

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -59,6 +59,11 @@ type Config struct {
 	// Enabled controls whether usage tracking is active
 	Enabled bool
 
+	// EnforceReturningUsageData controls whether to enforce returning usage data in streaming responses.
+	// When true, stream_options: {"include_usage": true} is automatically added to streaming requests.
+	// Default: true
+	EnforceReturningUsageData bool
+
 	// BufferSize is the number of usage entries to buffer before flushing
 	BufferSize int
 
@@ -72,9 +77,10 @@ type Config struct {
 // DefaultConfig returns a Config with sensible defaults
 func DefaultConfig() Config {
 	return Config{
-		Enabled:       false,
-		BufferSize:    1000,
-		FlushInterval: 5 * time.Second,
-		RetentionDays: 90,
+		Enabled:                   false,
+		EnforceReturningUsageData: true,
+		BufferSize:                1000,
+		FlushInterval:             5 * time.Second,
+		RetentionDays:             90,
 	}
 }


### PR DESCRIPTION
Add a new configuration flag that automatically adds stream_options: {"include_usage": true} to streaming requests for OpenAI-compatible providers. This ensures usage data is always returned in streaming responses when the flag is enabled (default: true).

Changes:
- Add StreamOptions struct to core/types.go for stream_options param
- Add StreamOptions field to ChatRequest and ResponsesRequest
- Update WithStreaming() methods to preserve StreamOptions
- Add EnforceReturningUsageData to usage.Config and config.UsageConfig
- Update handlers to set StreamOptions when flag is enabled
- Document ENFORCE_RETURNING_USAGE_DATA in .env.template

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to control usage data inclusion in streaming responses.
  * Introduced `ENFORCE_RETURNING_USAGE_DATA` environment variable (defaults to enabled) to configure whether usage data is returned when streaming.
  * Updated default behavior to enforce returning usage data in streaming responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->