### PR TITLE
Feature: Add reasoning parameter to chat API

### DIFF
--- a/internal/core/responses.go
+++ b/internal/core/responses.go
@@ -12,6 +12,7 @@ type ResponsesRequest struct {
 	Stream          bool              `json:"stream,omitempty"`
 	StreamOptions   *StreamOptions    `json:"stream_options,omitempty"`
 	Metadata        map[string]string `json:"metadata,omitempty"`
+	Reasoning       *Reasoning        `json:"reasoning,omitempty"`
 }
 
 // WithStreaming returns a shallow copy of the request with Stream set to true.
@@ -27,6 +28,7 @@ func (r *ResponsesRequest) WithStreaming() *ResponsesRequest {
 		Stream:          true,
 		StreamOptions:   r.StreamOptions,
 		Metadata:        r.Metadata,
+		Reasoning:       r.Reasoning,
 	}
 }
 

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -8,6 +8,14 @@ type StreamOptions struct {
 	IncludeUsage bool `json:"include_usage,omitempty"`
 }
 
+// Reasoning configures reasoning behavior for models that support extended thinking.
+// This is used with OpenAI's o-series models and other reasoning-capable models.
+type Reasoning struct {
+	// Effort controls how much reasoning effort the model should use.
+	// Valid values are "low", "medium", and "high".
+	Effort string `json:"effort,omitempty"`
+}
+
 // ChatRequest represents the incoming chat completion request
 type ChatRequest struct {
 	Temperature   *float64       `json:"temperature,omitempty"`
@@ -16,6 +24,7 @@ type ChatRequest struct {
 	Messages      []Message      `json:"messages"`
 	Stream        bool           `json:"stream,omitempty"`
 	StreamOptions *StreamOptions `json:"stream_options,omitempty"`
+	Reasoning     *Reasoning     `json:"reasoning,omitempty"`
 }
 
 // WithStreaming returns a shallow copy of the request with Stream set to true.
@@ -28,6 +37,7 @@ func (r *ChatRequest) WithStreaming() *ChatRequest {
 		Messages:      r.Messages,
 		Stream:        true,
 		StreamOptions: r.StreamOptions,
+		Reasoning:     r.Reasoning,
 	}
 }
 

--- a/internal/providers/anthropic/anthropic.go
+++ b/internal/providers/anthropic/anthropic.go
@@ -75,6 +75,12 @@ func (p *Provider) setHeaders(req *http.Request) {
 	}
 }
 
+// anthropicThinking represents the thinking configuration for Anthropic's extended thinking
+type anthropicThinking struct {
+	Type        string `json:"type"`
+	BudgetTokens int   `json:"budget_tokens"`
+}
+
 // anthropicRequest represents the Anthropic API request format
 type anthropicRequest struct {
 	Model       string             `json:"model"`
@@ -83,6 +89,7 @@ type anthropicRequest struct {
 	Temperature *float64           `json:"temperature,omitempty"`
 	System      string             `json:"system,omitempty"`
 	Stream      bool               `json:"stream,omitempty"`
+	Thinking    *anthropicThinking `json:"thinking,omitempty"`
 }
 
 // anthropicMessage represents a message in Anthropic format
@@ -147,6 +154,20 @@ type anthropicModelsResponse struct {
 	LastID  string               `json:"last_id"`
 }
 
+// reasoningEffortToBudgetTokens maps OpenAI reasoning effort levels to Anthropic budget tokens
+func reasoningEffortToBudgetTokens(effort string) int {
+	switch effort {
+	case "low":
+		return 5000
+	case "medium":
+		return 10000
+	case "high":
+		return 20000
+	default:
+		return 10000 // Default to medium
+	}
+}
+
 // convertToAnthropicRequest converts core.ChatRequest to Anthropic format
 func convertToAnthropicRequest(req *core.ChatRequest) *anthropicRequest {
 	anthropicReq := &anthropicRequest{
@@ -159,6 +180,16 @@ func convertToAnthropicRequest(req *core.ChatRequest) *anthropicRequest {
 
 	if req.MaxTokens != nil {
 		anthropicReq.MaxTokens = *req.MaxTokens
+	}
+
+	// Map reasoning effort to Anthropic extended thinking
+	if req.Reasoning != nil && req.Reasoning.Effort != "" {
+		anthropicReq.Thinking = &anthropicThinking{
+			Type:         "enabled",
+			BudgetTokens: reasoningEffortToBudgetTokens(req.Reasoning.Effort),
+		}
+		// Extended thinking requires temperature to be unset (defaults to 1)
+		anthropicReq.Temperature = nil
 	}
 
 	// Extract system message if present and convert messages
@@ -470,6 +501,16 @@ func convertResponsesRequestToAnthropic(req *core.ResponsesRequest) *anthropicRe
 
 	if req.MaxOutputTokens != nil {
 		anthropicReq.MaxTokens = *req.MaxOutputTokens
+	}
+
+	// Map reasoning effort to Anthropic extended thinking
+	if req.Reasoning != nil && req.Reasoning.Effort != "" {
+		anthropicReq.Thinking = &anthropicThinking{
+			Type:         "enabled",
+			BudgetTokens: reasoningEffortToBudgetTokens(req.Reasoning.Effort),
+		}
+		// Extended thinking requires temperature to be unset (defaults to 1)
+		anthropicReq.Temperature = nil
 	}
 
 	// Set system instruction if provided


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reasoning configuration to requests, allowing selectable effort levels to control model thinking intensity.
  * Reasoning is preserved when creating streaming/shallow-copy request variants.
  * Extended-thinking support enabled for compatible model backends: when an effort level is supplied, the request is mapped to use extended-thinking behavior and related parameters are adjusted automatically.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->