### PR TITLE
feat: implemented ollama provider

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -115,3 +115,8 @@ LOGGING_ENABLED=false
 
 # Groq
 # GROQ_API_KEY=gsk_...
+
+# Ollama (local LLM server)
+# Note: Ollama doesn't require an API key
+# Set base URL to enable (default: http://localhost:11434/v1)
+# OLLAMA_BASE_URL=http://localhost:11434/v1

--- a/cmd/gomodel/main.go
+++ b/cmd/gomodel/main.go
@@ -18,6 +18,7 @@ import (
 	"gomodel/internal/providers/anthropic"
 	"gomodel/internal/providers/gemini"
 	"gomodel/internal/providers/groq"
+	"gomodel/internal/providers/ollama"
 	"gomodel/internal/providers/openai"
 	"gomodel/internal/providers/xai"
 	"gomodel/internal/version"
@@ -70,6 +71,7 @@ func main() {
 	factory.Register(anthropic.Registration)
 	factory.Register(gemini.Registration)
 	factory.Register(groq.Registration)
+	factory.Register(ollama.Registration)
 	factory.Register(xai.Registration)
 
 	// Create the application

--- a/config/config.go
+++ b/config/config.go
@@ -338,6 +338,14 @@ func Load() (*Config, error) {
 				APIKey: apiKey,
 			}
 		}
+		// Ollama (no API key required, enabled via base URL)
+		if baseURL := viper.GetString("OLLAMA_BASE_URL"); baseURL != "" {
+			cfg.Providers["ollama"] = ProviderConfig{
+				Type:    "ollama",
+				APIKey:  "", // Not required
+				BaseURL: baseURL,
+			}
+		}
 	}
 
 	// Validate body size limit if provided

--- a/config/config.go
+++ b/config/config.go
@@ -490,6 +490,11 @@ func expandString(s string) string {
 func removeEmptyProviders(cfg Config) Config {
 	filteredProviders := make(map[string]ProviderConfig)
 	for name, pCfg := range cfg.Providers {
+		// Preserve Ollama providers with a non-empty BaseURL (no API key required)
+		if pCfg.Type == "ollama" && pCfg.BaseURL != "" {
+			filteredProviders[name] = pCfg
+			continue
+		}
 		// Keep provider only if API key doesn't contain unexpanded placeholders
 		if pCfg.APIKey != "" && !strings.Contains(pCfg.APIKey, "${") {
 			filteredProviders[name] = pCfg

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -66,6 +66,12 @@ providers:
     type: "groq"
     api_key: "${GROQ_API_KEY}"
 
+  ollama:
+    type: "ollama"
+    base_url: "${OLLAMA_BASE_URL:-http://localhost:11434/v1}"
+    api_key: "${OLLAMA_API_KEY:-}" # Optional, not required by Ollama
+
+
   # Example: Groq (OpenAI-compatible)
   # groq:
   #   type: "openai"

--- a/docs/adr/0001-explicit-provider-registration.md
+++ b/docs/adr/0001-explicit-provider-registration.md
@@ -1,0 +1,28 @@
+# ADR-0001: Explicit Provider Registration
+
+## Context
+
+GOModel supports multiple LLM providers (OpenAI, Anthropic, Gemini, Groq, Ollama, xAI). Each provider must be registered with the factory before use.
+
+## Decision
+
+Use explicit registration in main.go:
+
+- Don't use `init()` functions from provider packages
+- Export `NewProviderFactory()` for creating factory instances
+- Register providers explicitly: `factory.Register(openai.Registration)`
+
+## Consequences
+
+### Positive
+
+- **Explicit control flow**: Registration order is visible and controllable
+- **No global state**: Factory is created and passed explicitly
+- **Better testability**: Tests create isolated factories without workarounds
+- **IDE navigation**: Click through to Registration instead of dead-end blank imports
+- **Conditional registration**: Easy to add feature flags for experimental providers
+- **Go best practices**: Avoids init() side effects
+
+### Negative
+
+- Slightly more boilerplate in main.go (6 explicit Register calls)

--- a/internal/core/interfaces.go
+++ b/internal/core/interfaces.go
@@ -38,6 +38,14 @@ type RoutableProvider interface {
 	GetProviderType(model string) string
 }
 
+// AvailabilityChecker is an optional interface for providers that need
+// to verify service availability before registration.
+type AvailabilityChecker interface {
+	// CheckAvailability verifies the provider's backend service is reachable.
+	// Returns nil if available, error otherwise.
+	CheckAvailability(ctx context.Context) error
+}
+
 // ModelLookup defines the interface for looking up models and their providers.
 // This abstraction allows the Router to be decoupled from the concrete ModelRegistry implementation.
 type ModelLookup interface {

--- a/internal/providers/ollama/ollama.go
+++ b/internal/providers/ollama/ollama.go
@@ -1,0 +1,255 @@
+// Package ollama provides Ollama API integration for the LLM gateway.
+package ollama
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"gomodel/internal/core"
+	"gomodel/internal/llmclient"
+	"gomodel/internal/providers"
+)
+
+// Registration provides factory registration for the Ollama provider.
+var Registration = providers.Registration{
+	Type: "ollama",
+	New:  New,
+}
+
+const (
+	defaultBaseURL = "http://localhost:11434/v1"
+)
+
+// Provider implements the core.Provider interface for Ollama
+type Provider struct {
+	client *llmclient.Client
+	apiKey string // Accepted but ignored by Ollama
+}
+
+// New creates a new Ollama provider.
+func New(apiKey string, hooks llmclient.Hooks) core.Provider {
+	p := &Provider{apiKey: apiKey}
+	cfg := llmclient.DefaultConfig("ollama", defaultBaseURL)
+	cfg.Hooks = hooks
+	p.client = llmclient.New(cfg, p.setHeaders)
+	return p
+}
+
+// NewWithHTTPClient creates a new Ollama provider with a custom HTTP client.
+// If httpClient is nil, http.DefaultClient is used.
+func NewWithHTTPClient(apiKey string, httpClient *http.Client, hooks llmclient.Hooks) *Provider {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	p := &Provider{apiKey: apiKey}
+	cfg := llmclient.DefaultConfig("ollama", defaultBaseURL)
+	cfg.Hooks = hooks
+	p.client = llmclient.NewWithHTTPClient(httpClient, cfg, p.setHeaders)
+	return p
+}
+
+// SetBaseURL allows configuring a custom base URL for the provider
+func (p *Provider) SetBaseURL(url string) {
+	p.client.SetBaseURL(url)
+}
+
+// CheckAvailability verifies that Ollama is running and accessible.
+// Makes a lightweight request to the models endpoint.
+func (p *Provider) CheckAvailability(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	_, err := p.ListModels(ctx)
+	return err
+}
+
+// setHeaders sets the required headers for Ollama API requests
+func (p *Provider) setHeaders(req *http.Request) {
+	// Ollama doesn't require authentication, but accepts Bearer token if provided
+	if p.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	}
+
+	// Forward request ID if present in context
+	if requestID := core.GetRequestID(req.Context()); requestID != "" {
+		req.Header.Set("X-Request-ID", requestID)
+	}
+}
+
+// ChatCompletion sends a chat completion request to Ollama
+func (p *Provider) ChatCompletion(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+	var resp core.ChatResponse
+	err := p.client.Do(ctx, llmclient.Request{
+		Method:   http.MethodPost,
+		Endpoint: "/chat/completions",
+		Body:     req,
+	}, &resp)
+	if err != nil {
+		return nil, err
+	}
+	resp.Provider = "ollama"
+	if resp.Model == "" {
+		resp.Model = req.Model
+	}
+	return &resp, nil
+}
+
+// StreamChatCompletion returns a raw response body for streaming (caller must close)
+func (p *Provider) StreamChatCompletion(ctx context.Context, req *core.ChatRequest) (io.ReadCloser, error) {
+	return p.client.DoStream(ctx, llmclient.Request{
+		Method:   http.MethodPost,
+		Endpoint: "/chat/completions",
+		Body:     req.WithStreaming(),
+	})
+}
+
+// ListModels retrieves the list of available models from Ollama
+func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error) {
+	var resp core.ModelsResponse
+	err := p.client.Do(ctx, llmclient.Request{
+		Method:   http.MethodGet,
+		Endpoint: "/models",
+	}, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// convertResponsesRequestToChat converts a ResponsesRequest to ChatRequest for Ollama
+func convertResponsesRequestToChat(req *core.ResponsesRequest) *core.ChatRequest {
+	chatReq := &core.ChatRequest{
+		Model:       req.Model,
+		Messages:    make([]core.Message, 0),
+		Temperature: req.Temperature,
+		Stream:      req.Stream,
+	}
+
+	if req.MaxOutputTokens != nil {
+		chatReq.MaxTokens = req.MaxOutputTokens
+	}
+
+	// Add system instruction if provided
+	if req.Instructions != "" {
+		chatReq.Messages = append(chatReq.Messages, core.Message{
+			Role:    "system",
+			Content: req.Instructions,
+		})
+	}
+
+	// Convert input to messages
+	switch input := req.Input.(type) {
+	case string:
+		chatReq.Messages = append(chatReq.Messages, core.Message{
+			Role:    "user",
+			Content: input,
+		})
+	case []interface{}:
+		for _, item := range input {
+			if msgMap, ok := item.(map[string]interface{}); ok {
+				role, _ := msgMap["role"].(string)
+				content := extractContentFromInput(msgMap["content"])
+				if role != "" && content != "" {
+					chatReq.Messages = append(chatReq.Messages, core.Message{
+						Role:    role,
+						Content: content,
+					})
+				}
+			}
+		}
+	}
+
+	return chatReq
+}
+
+// extractContentFromInput extracts text content from responses input
+func extractContentFromInput(content interface{}) string {
+	switch c := content.(type) {
+	case string:
+		return c
+	case []interface{}:
+		// Array of content parts - extract text
+		var texts []string
+		for _, part := range c {
+			if partMap, ok := part.(map[string]interface{}); ok {
+				if text, ok := partMap["text"].(string); ok {
+					texts = append(texts, text)
+				}
+			}
+		}
+		return strings.Join(texts, " ")
+	}
+	return ""
+}
+
+// convertChatResponseToResponses converts a ChatResponse to ResponsesResponse
+func convertChatResponseToResponses(resp *core.ChatResponse) *core.ResponsesResponse {
+	content := ""
+	if len(resp.Choices) > 0 {
+		content = resp.Choices[0].Message.Content
+	}
+
+	return &core.ResponsesResponse{
+		ID:        resp.ID,
+		Object:    "response",
+		CreatedAt: resp.Created,
+		Model:     resp.Model,
+		Provider:  resp.Provider,
+		Status:    "completed",
+		Output: []core.ResponsesOutputItem{
+			{
+				ID:     "msg_" + uuid.New().String(),
+				Type:   "message",
+				Role:   "assistant",
+				Status: "completed",
+				Content: []core.ResponsesContentItem{
+					{
+						Type:        "output_text",
+						Text:        content,
+						Annotations: []string{},
+					},
+				},
+			},
+		},
+		Usage: &core.ResponsesUsage{
+			InputTokens:  resp.Usage.PromptTokens,
+			OutputTokens: resp.Usage.CompletionTokens,
+			TotalTokens:  resp.Usage.TotalTokens,
+		},
+	}
+}
+
+// Responses sends a Responses API request to Ollama (converted to chat format)
+func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
+	// Convert ResponsesRequest to ChatRequest
+	chatReq := convertResponsesRequestToChat(req)
+
+	// Use the existing ChatCompletion method
+	chatResp, err := p.ChatCompletion(ctx, chatReq)
+	if err != nil {
+		return nil, err
+	}
+
+	return convertChatResponseToResponses(chatResp), nil
+}
+
+// StreamResponses returns a raw response body for streaming Responses API (caller must close)
+func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
+	// Convert ResponsesRequest to ChatRequest
+	chatReq := convertResponsesRequestToChat(req)
+	chatReq.Stream = true
+
+	// Get the streaming response from chat completions
+	stream, err := p.StreamChatCompletion(ctx, chatReq)
+	if err != nil {
+		return nil, err
+	}
+
+	// Wrap the stream to convert chat completion format to Responses API format
+	return providers.NewOpenAIResponsesStreamConverter(stream, req.Model, "ollama"), nil
+}

--- a/internal/providers/ollama/ollama_test.go
+++ b/internal/providers/ollama/ollama_test.go
@@ -1,0 +1,1024 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"gomodel/internal/core"
+	"gomodel/internal/llmclient"
+	"gomodel/internal/providers"
+)
+
+func TestNew(t *testing.T) {
+	apiKey := "test-api-key"
+	// Use NewWithHTTPClient to get concrete type for internal testing
+	provider := NewWithHTTPClient(apiKey, nil, llmclient.Hooks{})
+
+	if provider.apiKey != apiKey {
+		t.Errorf("apiKey = %q, want %q", provider.apiKey, apiKey)
+	}
+	if provider.client == nil {
+		t.Error("client should not be nil")
+	}
+}
+
+func TestNew_ReturnsProvider(t *testing.T) {
+	provider := New("test-api-key", llmclient.Hooks{})
+
+	if provider == nil {
+		t.Error("provider should not be nil")
+	}
+}
+
+func TestNew_WithoutAPIKey(t *testing.T) {
+	// Ollama doesn't require an API key
+	provider := NewWithHTTPClient("", nil, llmclient.Hooks{})
+
+	if provider.apiKey != "" {
+		t.Errorf("apiKey = %q, want empty", provider.apiKey)
+	}
+	if provider.client == nil {
+		t.Error("client should not be nil")
+	}
+}
+
+func TestChatCompletion(t *testing.T) {
+	tests := []struct {
+		name          string
+		statusCode    int
+		responseBody  string
+		expectedError bool
+		checkResponse func(*testing.T, *core.ChatResponse)
+	}{
+		{
+			name:       "successful request",
+			statusCode: http.StatusOK,
+			responseBody: `{
+				"id": "chatcmpl-123",
+				"object": "chat.completion",
+				"created": 1677652288,
+				"model": "llama3.2",
+				"choices": [{
+					"index": 0,
+					"message": {
+						"role": "assistant",
+						"content": "Hello! How can I help you today?"
+					},
+					"finish_reason": "stop"
+				}],
+				"usage": {
+					"prompt_tokens": 10,
+					"completion_tokens": 20,
+					"total_tokens": 30
+				}
+			}`,
+			expectedError: false,
+			checkResponse: func(t *testing.T, resp *core.ChatResponse) {
+				if resp.ID != "chatcmpl-123" {
+					t.Errorf("ID = %q, want %q", resp.ID, "chatcmpl-123")
+				}
+				if resp.Model != "llama3.2" {
+					t.Errorf("Model = %q, want %q", resp.Model, "llama3.2")
+				}
+				if len(resp.Choices) != 1 {
+					t.Fatalf("len(Choices) = %d, want 1", len(resp.Choices))
+				}
+				if resp.Choices[0].Message.Content != "Hello! How can I help you today?" {
+					t.Errorf("Message content = %q, want %q", resp.Choices[0].Message.Content, "Hello! How can I help you today?")
+				}
+				if resp.Usage.PromptTokens != 10 {
+					t.Errorf("PromptTokens = %d, want 10", resp.Usage.PromptTokens)
+				}
+				if resp.Usage.CompletionTokens != 20 {
+					t.Errorf("CompletionTokens = %d, want 20", resp.Usage.CompletionTokens)
+				}
+				if resp.Usage.TotalTokens != 30 {
+					t.Errorf("TotalTokens = %d, want 30", resp.Usage.TotalTokens)
+				}
+				if resp.Provider != "ollama" {
+					t.Errorf("Provider = %q, want %q", resp.Provider, "ollama")
+				}
+			},
+		},
+		{
+			name:          "server error",
+			statusCode:    http.StatusInternalServerError,
+			responseBody:  `{"error": {"message": "Internal server error"}}`,
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Verify request headers
+				if r.Header.Get("Content-Type") != "application/json" {
+					t.Errorf("Content-Type = %q, want %q", r.Header.Get("Content-Type"), "application/json")
+				}
+
+				// Verify request body
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatalf("failed to read request body: %v", err)
+				}
+				var req core.ChatRequest
+				if err := json.Unmarshal(body, &req); err != nil {
+					t.Fatalf("failed to unmarshal request: %v", err)
+				}
+
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.responseBody))
+			}))
+			defer server.Close()
+
+			provider := NewWithHTTPClient("", nil, llmclient.Hooks{})
+			provider.SetBaseURL(server.URL)
+
+			req := &core.ChatRequest{
+				Model: "llama3.2",
+				Messages: []core.Message{
+					{Role: "user", Content: "Hello"},
+				},
+			}
+
+			resp, err := provider.ChatCompletion(context.Background(), req)
+
+			if tt.expectedError {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if tt.checkResponse != nil {
+					tt.checkResponse(t, resp)
+				}
+			}
+		})
+	}
+}
+
+func TestChatCompletion_WithAPIKey(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify authorization header is set when API key is provided
+		authHeader := r.Header.Get("Authorization")
+		if !strings.HasPrefix(authHeader, "Bearer ") {
+			t.Errorf("Authorization header should start with 'Bearer '")
+		}
+		if authHeader != "Bearer test-api-key" {
+			t.Errorf("Authorization = %q, want %q", authHeader, "Bearer test-api-key")
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"id": "chatcmpl-123",
+			"object": "chat.completion",
+			"created": 1677652288,
+			"model": "llama3.2",
+			"choices": [{"index": 0, "message": {"role": "assistant", "content": "Hi"}, "finish_reason": "stop"}],
+			"usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+		}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("test-api-key", nil, llmclient.Hooks{})
+	provider.SetBaseURL(server.URL)
+
+	req := &core.ChatRequest{
+		Model:    "llama3.2",
+		Messages: []core.Message{{Role: "user", Content: "Hello"}},
+	}
+
+	_, err := provider.ChatCompletion(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestChatCompletion_WithoutAPIKey(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify no authorization header when API key is not provided
+		authHeader := r.Header.Get("Authorization")
+		if authHeader != "" {
+			t.Errorf("Authorization header should be empty, got %q", authHeader)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"id": "chatcmpl-123",
+			"object": "chat.completion",
+			"created": 1677652288,
+			"model": "llama3.2",
+			"choices": [{"index": 0, "message": {"role": "assistant", "content": "Hi"}, "finish_reason": "stop"}],
+			"usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+		}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("", nil, llmclient.Hooks{})
+	provider.SetBaseURL(server.URL)
+
+	req := &core.ChatRequest{
+		Model:    "llama3.2",
+		Messages: []core.Message{{Role: "user", Content: "Hello"}},
+	}
+
+	_, err := provider.ChatCompletion(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestStreamChatCompletion(t *testing.T) {
+	tests := []struct {
+		name          string
+		statusCode    int
+		responseBody  string
+		expectedError bool
+	}{
+		{
+			name:       "successful streaming request",
+			statusCode: http.StatusOK,
+			responseBody: `data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"llama3.2","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"llama3.2","choices":[{"index":0,"delta":{"content":"!"},"finish_reason":null}]}
+
+data: [DONE]
+`,
+			expectedError: false,
+		},
+		{
+			name:          "server error",
+			statusCode:    http.StatusInternalServerError,
+			responseBody:  `{"error": {"message": "Internal server error"}}`,
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Verify request headers
+				if r.Header.Get("Content-Type") != "application/json" {
+					t.Errorf("Content-Type = %q, want %q", r.Header.Get("Content-Type"), "application/json")
+				}
+
+				// Verify stream is set in request body
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatalf("failed to read request body: %v", err)
+				}
+				var req core.ChatRequest
+				if err := json.Unmarshal(body, &req); err != nil {
+					t.Fatalf("failed to unmarshal request: %v", err)
+				}
+				if !req.Stream {
+					t.Error("Stream should be true in request")
+				}
+
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.responseBody))
+			}))
+			defer server.Close()
+
+			provider := NewWithHTTPClient("", nil, llmclient.Hooks{})
+			provider.SetBaseURL(server.URL)
+
+			req := &core.ChatRequest{
+				Model: "llama3.2",
+				Messages: []core.Message{
+					{Role: "user", Content: "Hello"},
+				},
+			}
+
+			body, err := provider.StreamChatCompletion(context.Background(), req)
+
+			if tt.expectedError {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if body == nil {
+					t.Fatal("body should not be nil")
+				}
+				defer func() { _ = body.Close() }()
+
+				// Read and verify the streaming response
+				respBody, err := io.ReadAll(body)
+				if err != nil {
+					t.Fatalf("failed to read response body: %v", err)
+				}
+				if string(respBody) != tt.responseBody {
+					t.Errorf("response body = %q, want %q", string(respBody), tt.responseBody)
+				}
+			}
+		})
+	}
+}
+
+func TestListModels(t *testing.T) {
+	tests := []struct {
+		name          string
+		statusCode    int
+		responseBody  string
+		expectedError bool
+		checkResponse func(*testing.T, *core.ModelsResponse)
+	}{
+		{
+			name:       "successful request",
+			statusCode: http.StatusOK,
+			responseBody: `{
+				"object": "list",
+				"data": [
+					{
+						"id": "llama3.2",
+						"object": "model",
+						"created": 1687882411,
+						"owned_by": "library"
+					},
+					{
+						"id": "mistral:7b-instruct",
+						"object": "model",
+						"created": 1687882410,
+						"owned_by": "library"
+					}
+				]
+			}`,
+			expectedError: false,
+			checkResponse: func(t *testing.T, resp *core.ModelsResponse) {
+				if resp.Object != "list" {
+					t.Errorf("Object = %q, want %q", resp.Object, "list")
+				}
+				if len(resp.Data) != 2 {
+					t.Fatalf("len(Data) = %d, want 2", len(resp.Data))
+				}
+				if resp.Data[0].ID != "llama3.2" {
+					t.Errorf("Data[0].ID = %q, want %q", resp.Data[0].ID, "llama3.2")
+				}
+				if resp.Data[0].OwnedBy != "library" {
+					t.Errorf("Data[0].OwnedBy = %q, want %q", resp.Data[0].OwnedBy, "library")
+				}
+			},
+		},
+		{
+			name:          "server error",
+			statusCode:    http.StatusInternalServerError,
+			responseBody:  `{"error": {"message": "Internal server error"}}`,
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Verify request method and path
+				if r.Method != http.MethodGet {
+					t.Errorf("Method = %q, want %q", r.Method, http.MethodGet)
+				}
+				if r.URL.Path != "/models" {
+					t.Errorf("Path = %q, want %q", r.URL.Path, "/models")
+				}
+
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.responseBody))
+			}))
+			defer server.Close()
+
+			provider := NewWithHTTPClient("", nil, llmclient.Hooks{})
+			provider.SetBaseURL(server.URL)
+
+			resp, err := provider.ListModels(context.Background())
+
+			if tt.expectedError {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if tt.checkResponse != nil {
+					tt.checkResponse(t, resp)
+				}
+			}
+		})
+	}
+}
+
+func TestChatCompletionWithContext(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Simulate a slow response
+		<-r.Context().Done()
+		w.WriteHeader(http.StatusRequestTimeout)
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("", nil, llmclient.Hooks{})
+	provider.SetBaseURL(server.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	req := &core.ChatRequest{
+		Model: "llama3.2",
+		Messages: []core.Message{
+			{Role: "user", Content: "Hello"},
+		},
+	}
+
+	_, err := provider.ChatCompletion(ctx, req)
+	if err == nil {
+		t.Error("expected error when context is cancelled, got nil")
+	}
+}
+
+func TestResponses(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request path for chat completions (Ollama converts Responses to chat)
+		if r.URL.Path != "/chat/completions" {
+			t.Errorf("Path = %q, want %q", r.URL.Path, "/chat/completions")
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"id": "chatcmpl-123",
+			"object": "chat.completion",
+			"created": 1677652288,
+			"model": "llama3.2",
+			"choices": [{
+				"index": 0,
+				"message": {
+					"role": "assistant",
+					"content": "Hello! How can I help you today?"
+				},
+				"finish_reason": "stop"
+			}],
+			"usage": {
+				"prompt_tokens": 10,
+				"completion_tokens": 20,
+				"total_tokens": 30
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("", nil, llmclient.Hooks{})
+	provider.SetBaseURL(server.URL)
+
+	req := &core.ResponsesRequest{
+		Model: "llama3.2",
+		Input: "Hello",
+	}
+
+	resp, err := provider.Responses(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.ID != "chatcmpl-123" {
+		t.Errorf("ID = %q, want %q", resp.ID, "chatcmpl-123")
+	}
+	if resp.Object != "response" {
+		t.Errorf("Object = %q, want %q", resp.Object, "response")
+	}
+	if resp.Model != "llama3.2" {
+		t.Errorf("Model = %q, want %q", resp.Model, "llama3.2")
+	}
+	if resp.Status != "completed" {
+		t.Errorf("Status = %q, want %q", resp.Status, "completed")
+	}
+	if len(resp.Output) != 1 {
+		t.Fatalf("len(Output) = %d, want 1", len(resp.Output))
+	}
+	if len(resp.Output[0].Content) != 1 {
+		t.Fatalf("len(Output[0].Content) = %d, want 1", len(resp.Output[0].Content))
+	}
+	if resp.Output[0].Content[0].Text != "Hello! How can I help you today?" {
+		t.Errorf("Output text = %q, want %q", resp.Output[0].Content[0].Text, "Hello! How can I help you today?")
+	}
+	if resp.Usage == nil {
+		t.Fatal("Usage should not be nil")
+	}
+	if resp.Usage.InputTokens != 10 {
+		t.Errorf("InputTokens = %d, want 10", resp.Usage.InputTokens)
+	}
+	if resp.Usage.OutputTokens != 20 {
+		t.Errorf("OutputTokens = %d, want 20", resp.Usage.OutputTokens)
+	}
+}
+
+func TestResponsesWithArrayInput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request body is converted to chat format
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read request body: %v", err)
+		}
+
+		var req map[string]interface{}
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("failed to unmarshal request: %v", err)
+		}
+
+		// Verify messages array exists (converted from input)
+		messages, ok := req["messages"].([]interface{})
+		if !ok {
+			t.Fatal("messages should be an array")
+		}
+		// Should have system message + 2 input messages
+		if len(messages) != 3 {
+			t.Errorf("len(messages) = %d, want 3", len(messages))
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"id": "chatcmpl-123",
+			"object": "chat.completion",
+			"created": 1677652288,
+			"model": "llama3.2",
+			"choices": [{
+				"index": 0,
+				"message": {
+					"role": "assistant",
+					"content": "Hello!"
+				},
+				"finish_reason": "stop"
+			}],
+			"usage": {
+				"prompt_tokens": 10,
+				"completion_tokens": 5,
+				"total_tokens": 15
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("", nil, llmclient.Hooks{})
+	provider.SetBaseURL(server.URL)
+
+	req := &core.ResponsesRequest{
+		Model: "llama3.2",
+		Input: []interface{}{
+			map[string]interface{}{
+				"role":    "user",
+				"content": "Hello",
+			},
+			map[string]interface{}{
+				"role":    "assistant",
+				"content": "Hi there!",
+			},
+		},
+		Instructions: "Be helpful",
+	}
+
+	resp, err := provider.Responses(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.ID != "chatcmpl-123" {
+		t.Errorf("ID = %q, want %q", resp.ID, "chatcmpl-123")
+	}
+}
+
+func TestStreamResponses(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify stream is set in request body
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read request body: %v", err)
+		}
+		var req core.ChatRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("failed to unmarshal request: %v", err)
+		}
+		if !req.Stream {
+			t.Error("Stream should be true in request")
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"llama3.2","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"llama3.2","choices":[{"index":0,"delta":{"content":"!"},"finish_reason":null}]}
+
+data: [DONE]
+`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("", nil, llmclient.Hooks{})
+	provider.SetBaseURL(server.URL)
+
+	req := &core.ResponsesRequest{
+		Model: "llama3.2",
+		Input: "Hello",
+	}
+
+	body, err := provider.StreamResponses(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if body == nil {
+		t.Fatal("body should not be nil")
+	}
+	defer func() { _ = body.Close() }()
+
+	respBody, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+
+	responseStr := string(respBody)
+	if !strings.Contains(responseStr, "response.created") {
+		t.Error("response should contain response.created event")
+	}
+	if !strings.Contains(responseStr, "response.output_text.delta") {
+		t.Error("response should contain response.output_text.delta event")
+	}
+	if !strings.Contains(responseStr, "[DONE]") {
+		t.Error("response should end with [DONE]")
+	}
+}
+
+func TestResponsesWithContext(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Simulate a slow response
+		<-r.Context().Done()
+		w.WriteHeader(http.StatusRequestTimeout)
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("", nil, llmclient.Hooks{})
+	provider.SetBaseURL(server.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	req := &core.ResponsesRequest{
+		Model: "llama3.2",
+		Input: "Hello",
+	}
+
+	_, err := provider.Responses(ctx, req)
+	if err == nil {
+		t.Error("expected error when context is cancelled, got nil")
+	}
+}
+
+func TestConvertResponsesRequestToChat(t *testing.T) {
+	temp := 0.7
+	maxTokens := 1024
+
+	tests := []struct {
+		name    string
+		input   *core.ResponsesRequest
+		checkFn func(*testing.T, *core.ChatRequest)
+	}{
+		{
+			name: "string input",
+			input: &core.ResponsesRequest{
+				Model: "llama3.2",
+				Input: "Hello",
+			},
+			checkFn: func(t *testing.T, req *core.ChatRequest) {
+				if req.Model != "llama3.2" {
+					t.Errorf("Model = %q, want %q", req.Model, "llama3.2")
+				}
+				if len(req.Messages) != 1 {
+					t.Errorf("len(Messages) = %d, want 1", len(req.Messages))
+				}
+				if req.Messages[0].Role != "user" {
+					t.Errorf("Messages[0].Role = %q, want %q", req.Messages[0].Role, "user")
+				}
+				if req.Messages[0].Content != "Hello" {
+					t.Errorf("Messages[0].Content = %q, want %q", req.Messages[0].Content, "Hello")
+				}
+			},
+		},
+		{
+			name: "with instructions",
+			input: &core.ResponsesRequest{
+				Model:        "llama3.2",
+				Input:        "Hello",
+				Instructions: "Be helpful",
+			},
+			checkFn: func(t *testing.T, req *core.ChatRequest) {
+				if len(req.Messages) < 2 {
+					t.Fatalf("len(Messages) = %d, want at least 2", len(req.Messages))
+				}
+				if req.Messages[0].Role != "system" {
+					t.Errorf("Messages[0].Role = %q, want %q", req.Messages[0].Role, "system")
+				}
+				if req.Messages[0].Content != "Be helpful" {
+					t.Errorf("Messages[0].Content = %q, want %q", req.Messages[0].Content, "Be helpful")
+				}
+			},
+		},
+		{
+			name: "with parameters",
+			input: &core.ResponsesRequest{
+				Model:           "llama3.2",
+				Input:           "Hello",
+				Temperature:     &temp,
+				MaxOutputTokens: &maxTokens,
+			},
+			checkFn: func(t *testing.T, req *core.ChatRequest) {
+				if req.Temperature == nil || *req.Temperature != 0.7 {
+					t.Errorf("Temperature = %v, want 0.7", req.Temperature)
+				}
+				if req.MaxTokens == nil || *req.MaxTokens != 1024 {
+					t.Errorf("MaxTokens = %v, want 1024", req.MaxTokens)
+				}
+			},
+		},
+		{
+			name: "with streaming enabled",
+			input: &core.ResponsesRequest{
+				Model:  "llama3.2",
+				Input:  "Hello",
+				Stream: true,
+			},
+			checkFn: func(t *testing.T, req *core.ChatRequest) {
+				if !req.Stream {
+					t.Error("Stream should be true")
+				}
+			},
+		},
+		{
+			name: "array input with messages",
+			input: &core.ResponsesRequest{
+				Model: "llama3.2",
+				Input: []interface{}{
+					map[string]interface{}{
+						"role":    "user",
+						"content": "Hello",
+					},
+					map[string]interface{}{
+						"role":    "assistant",
+						"content": "Hi there!",
+					},
+				},
+			},
+			checkFn: func(t *testing.T, req *core.ChatRequest) {
+				if len(req.Messages) != 2 {
+					t.Fatalf("len(Messages) = %d, want 2", len(req.Messages))
+				}
+				if req.Messages[0].Role != "user" {
+					t.Errorf("Messages[0].Role = %q, want %q", req.Messages[0].Role, "user")
+				}
+				if req.Messages[0].Content != "Hello" {
+					t.Errorf("Messages[0].Content = %q, want %q", req.Messages[0].Content, "Hello")
+				}
+				if req.Messages[1].Role != "assistant" {
+					t.Errorf("Messages[1].Role = %q, want %q", req.Messages[1].Role, "assistant")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertResponsesRequestToChat(tt.input)
+			tt.checkFn(t, result)
+		})
+	}
+}
+
+func TestConvertChatResponseToResponses(t *testing.T) {
+	resp := &core.ChatResponse{
+		ID:      "chatcmpl-123",
+		Object:  "chat.completion",
+		Model:   "llama3.2",
+		Created: 1677652288,
+		Choices: []core.Choice{
+			{
+				Index: 0,
+				Message: core.Message{
+					Role:    "assistant",
+					Content: "Hello! How can I help you today?",
+				},
+				FinishReason: "stop",
+			},
+		},
+		Usage: core.Usage{
+			PromptTokens:     10,
+			CompletionTokens: 20,
+			TotalTokens:      30,
+		},
+	}
+
+	result := convertChatResponseToResponses(resp)
+
+	if result.ID != "chatcmpl-123" {
+		t.Errorf("ID = %q, want %q", result.ID, "chatcmpl-123")
+	}
+	if result.Object != "response" {
+		t.Errorf("Object = %q, want %q", result.Object, "response")
+	}
+	if result.Model != "llama3.2" {
+		t.Errorf("Model = %q, want %q", result.Model, "llama3.2")
+	}
+	if result.Status != "completed" {
+		t.Errorf("Status = %q, want %q", result.Status, "completed")
+	}
+	if len(result.Output) != 1 {
+		t.Fatalf("len(Output) = %d, want 1", len(result.Output))
+	}
+	if result.Output[0].Type != "message" {
+		t.Errorf("Output[0].Type = %q, want %q", result.Output[0].Type, "message")
+	}
+	if result.Output[0].Role != "assistant" {
+		t.Errorf("Output[0].Role = %q, want %q", result.Output[0].Role, "assistant")
+	}
+	if result.Output[0].Status != "completed" {
+		t.Errorf("Output[0].Status = %q, want %q", result.Output[0].Status, "completed")
+	}
+	if len(result.Output[0].Content) != 1 {
+		t.Fatalf("len(Output[0].Content) = %d, want 1", len(result.Output[0].Content))
+	}
+	if result.Output[0].Content[0].Type != "output_text" {
+		t.Errorf("Content[0].Type = %q, want %q", result.Output[0].Content[0].Type, "output_text")
+	}
+	if result.Output[0].Content[0].Text != "Hello! How can I help you today?" {
+		t.Errorf("Content[0].Text = %q, want %q", result.Output[0].Content[0].Text, "Hello! How can I help you today?")
+	}
+	if result.Usage == nil {
+		t.Fatal("Usage should not be nil")
+	}
+	if result.Usage.InputTokens != 10 {
+		t.Errorf("InputTokens = %d, want 10", result.Usage.InputTokens)
+	}
+	if result.Usage.OutputTokens != 20 {
+		t.Errorf("OutputTokens = %d, want 20", result.Usage.OutputTokens)
+	}
+	if result.Usage.TotalTokens != 30 {
+		t.Errorf("TotalTokens = %d, want 30", result.Usage.TotalTokens)
+	}
+}
+
+func TestConvertChatResponseToResponses_EmptyChoices(t *testing.T) {
+	resp := &core.ChatResponse{
+		ID:      "chatcmpl-123",
+		Object:  "chat.completion",
+		Model:   "llama3.2",
+		Created: 1677652288,
+		Choices: []core.Choice{},
+		Usage: core.Usage{
+			PromptTokens:     10,
+			CompletionTokens: 0,
+			TotalTokens:      10,
+		},
+	}
+
+	result := convertChatResponseToResponses(resp)
+
+	if len(result.Output) != 1 {
+		t.Fatalf("len(Output) = %d, want 1", len(result.Output))
+	}
+	// Content should be empty string when no choices
+	if result.Output[0].Content[0].Text != "" {
+		t.Errorf("Content[0].Text = %q, want empty string", result.Output[0].Content[0].Text)
+	}
+}
+
+func TestExtractContentFromInput(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected string
+	}{
+		{
+			name:     "string input",
+			input:    "Hello world",
+			expected: "Hello world",
+		},
+		{
+			name: "array with text parts",
+			input: []interface{}{
+				map[string]interface{}{
+					"type": "text",
+					"text": "Hello",
+				},
+				map[string]interface{}{
+					"type": "text",
+					"text": "world",
+				},
+			},
+			expected: "Hello world",
+		},
+		{
+			name:     "nil input",
+			input:    nil,
+			expected: "",
+		},
+		{
+			name:     "unsupported type",
+			input:    12345,
+			expected: "",
+		},
+		{
+			name: "array with non-text parts",
+			input: []interface{}{
+				map[string]interface{}{
+					"type": "image",
+					"url":  "http://example.com/image.png",
+				},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractContentFromInput(tt.input)
+			if result != tt.expected {
+				t.Errorf("extractContentFromInput(%v) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestOllamaResponsesStreamConverter(t *testing.T) {
+	// Test the stream converter with mock chat completion stream
+	mockStream := `data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"llama3.2","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"llama3.2","choices":[{"index":0,"delta":{"content":" world"},"finish_reason":null}]}
+
+data: [DONE]
+`
+
+	reader := io.NopCloser(strings.NewReader(mockStream))
+	converter := providers.NewOpenAIResponsesStreamConverter(reader, "llama3.2", "ollama")
+
+	// Read all data from converter
+	data, err := io.ReadAll(converter)
+	if err != nil {
+		t.Fatalf("failed to read from converter: %v", err)
+	}
+
+	result := string(data)
+
+	// Check that the stream contains expected events
+	if !strings.Contains(result, "response.created") {
+		t.Error("stream should contain response.created event")
+	}
+	if !strings.Contains(result, "response.output_text.delta") {
+		t.Error("stream should contain response.output_text.delta event")
+	}
+	if !strings.Contains(result, "Hello") {
+		t.Error("stream should contain 'Hello' content")
+	}
+	if !strings.Contains(result, " world") {
+		t.Error("stream should contain ' world' content")
+	}
+	if !strings.Contains(result, "response.done") {
+		t.Error("stream should contain response.done event")
+	}
+	if !strings.Contains(result, "[DONE]") {
+		t.Error("stream should contain [DONE] marker")
+	}
+}
+
+func TestNewWithHTTPClient(t *testing.T) {
+	customClient := &http.Client{}
+	apiKey := "test-api-key"
+
+	provider := NewWithHTTPClient(apiKey, customClient, llmclient.Hooks{})
+
+	if provider.apiKey != apiKey {
+		t.Errorf("apiKey = %q, want %q", provider.apiKey, apiKey)
+	}
+	if provider.client == nil {
+		t.Error("client should not be nil")
+	}
+}
+
+func TestSetBaseURL(t *testing.T) {
+	provider := NewWithHTTPClient("", nil, llmclient.Hooks{})
+	customURL := "http://custom.ollama.server:11434/v1"
+
+	provider.SetBaseURL(customURL)
+
+	// We can't directly check the baseURL as it's encapsulated in llmclient
+	// but we can verify the provider still works by making a test request
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
+	}))
+	defer server.Close()
+
+	provider.SetBaseURL(server.URL)
+	_, err := provider.ListModels(context.Background())
+	if err != nil {
+		t.Errorf("SetBaseURL should allow using custom URL: %v", err)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ollama as a supported LLM provider with chat completions, streaming responses, and model listing.
  * Environment template and config now include OLLAMA_BASE_URL (defaults to http://localhost:11434/v1); API key optional.

* **Behavior Changes**
  * App performs a short availability check and will only register Ollama when the local service is reachable.

* **Tests**
  * Added comprehensive test coverage for Ollama functionality.

* **Documentation**
  * Added an ADR describing explicit provider registration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->