### PR TITLE
fix: ensure MaxTokens >= budget when extended thinking is enabled

### DIFF
--- a/internal/providers/anthropic/anthropic.go
+++ b/internal/providers/anthropic/anthropic.go
@@ -169,6 +169,14 @@ func reasoningEffortToBudgetTokens(effort string) int {
 	}
 }
 
+// logMaxTokensAdjustment logs when MaxTokens is adjusted to meet Anthropic requirements
+func logMaxTokensAdjustment(original, adjusted int, reason string) {
+	slog.Info("MaxTokens adjusted to meet Anthropic extended thinking requirements",
+		"original", original,
+		"adjusted", adjusted,
+		"reason", reason)
+}
+
 // convertToAnthropicRequest converts core.ChatRequest to Anthropic format
 func convertToAnthropicRequest(req *core.ChatRequest) *anthropicRequest {
 	anthropicReq := &anthropicRequest{
@@ -192,6 +200,8 @@ func convertToAnthropicRequest(req *core.ChatRequest) *anthropicRequest {
 		}
 		// Ensure MaxTokens is at least the budget tokens
 		if anthropicReq.MaxTokens < budget {
+			logMaxTokensAdjustment(anthropicReq.MaxTokens, budget,
+				"extended thinking budget_tokens must be <= max_tokens")
 			anthropicReq.MaxTokens = budget
 		}
 		// Extended thinking requires temperature to be unset (defaults to 1)
@@ -521,6 +531,8 @@ func convertResponsesRequestToAnthropic(req *core.ResponsesRequest) *anthropicRe
 		}
 		// Ensure MaxTokens is at least the budget tokens
 		if anthropicReq.MaxTokens < budget {
+			logMaxTokensAdjustment(anthropicReq.MaxTokens, budget,
+				"extended thinking budget_tokens must be <= max_tokens")
 			anthropicReq.MaxTokens = budget
 		}
 		// Extended thinking requires temperature to be unset (defaults to 1)

--- a/internal/providers/anthropic/anthropic.go
+++ b/internal/providers/anthropic/anthropic.go
@@ -185,9 +185,14 @@ func convertToAnthropicRequest(req *core.ChatRequest) *anthropicRequest {
 
 	// Map reasoning effort to Anthropic extended thinking
 	if req.Reasoning != nil && req.Reasoning.Effort != "" {
+		budget := reasoningEffortToBudgetTokens(req.Reasoning.Effort)
 		anthropicReq.Thinking = &anthropicThinking{
 			Type:         "enabled",
-			BudgetTokens: reasoningEffortToBudgetTokens(req.Reasoning.Effort),
+			BudgetTokens: budget,
+		}
+		// Ensure MaxTokens is at least the budget tokens
+		if anthropicReq.MaxTokens < budget {
+			anthropicReq.MaxTokens = budget
 		}
 		// Extended thinking requires temperature to be unset (defaults to 1)
 		if anthropicReq.Temperature != nil {
@@ -509,9 +514,14 @@ func convertResponsesRequestToAnthropic(req *core.ResponsesRequest) *anthropicRe
 
 	// Map reasoning effort to Anthropic extended thinking
 	if req.Reasoning != nil && req.Reasoning.Effort != "" {
+		budget := reasoningEffortToBudgetTokens(req.Reasoning.Effort)
 		anthropicReq.Thinking = &anthropicThinking{
 			Type:         "enabled",
-			BudgetTokens: reasoningEffortToBudgetTokens(req.Reasoning.Effort),
+			BudgetTokens: budget,
+		}
+		// Ensure MaxTokens is at least the budget tokens
+		if anthropicReq.MaxTokens < budget {
+			anthropicReq.MaxTokens = budget
 		}
 		// Extended thinking requires temperature to be unset (defaults to 1)
 		if anthropicReq.Temperature != nil {


### PR DESCRIPTION
When extended thinking is enabled via the reasoning parameter, Anthropic requires max_tokens to be at least the thinking budget_tokens. This fix ensures MaxTokens is bumped to the budget value when it's lower, in both ChatRequest and ResponsesRequest conversion paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal reasoning effort computation to reduce redundant calculations.
  * Added validation to ensure token limits meet minimum requirements for Anthropic API requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->