### PR TITLE
fix: increase HTTP client timeouts to prevent API timeout errors

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -5,6 +5,13 @@ PORT=8080
 # Accepts values like "10M", "1G", "500K" (default: 10M)
 # BODY_SIZE_LIMIT=10M
 
+# HTTP Client Configuration (for upstream API requests)
+# Overall request timeout (default: 600s / 10 minutes, matches OpenAI/Anthropic SDKs)
+# HTTP_TIMEOUT=600s
+# Time to wait for response headers (default: 600s)
+# Increase if you see "http2: timeout awaiting response headers" errors
+# HTTP_RESPONSE_HEADER_TIMEOUT=600s
+
 # Security Configuration
 # CRITICAL: Set this to secure your gateway from unauthorized access
 # If not set, the server will run in UNSAFE MODE with a warning

--- a/.env.template
+++ b/.env.template
@@ -6,11 +6,11 @@ PORT=8080
 # BODY_SIZE_LIMIT=10M
 
 # HTTP Client Configuration (for upstream API requests)
-# Overall request timeout (default: 600s / 10 minutes, matches OpenAI/Anthropic SDKs)
-# HTTP_TIMEOUT=600s
-# Time to wait for response headers (default: 600s)
-# Increase if you see "http2: timeout awaiting response headers" errors
-# HTTP_RESPONSE_HEADER_TIMEOUT=600s
+# Values in seconds (or Go duration format like "10m", "1h30m")
+# Overall request timeout (default: 600 = 10 minutes, matches OpenAI/Anthropic SDKs)
+# HTTP_TIMEOUT=600
+# Time to wait for response headers (default: 600)
+# HTTP_RESPONSE_HEADER_TIMEOUT=600
 
 # Security Configuration
 # CRITICAL: Set this to secure your gateway from unauthorized access

--- a/internal/httpclient/client_test.go
+++ b/internal/httpclient/client_test.go
@@ -2,7 +2,6 @@ package httpclient
 
 import (
 	"net/http"
-	"os"
 	"testing"
 	"time"
 )
@@ -47,12 +46,8 @@ func TestDefaultConfig(t *testing.T) {
 
 func TestDefaultConfigWithEnvOverrides(t *testing.T) {
 	// Set environment variables using plain integers (seconds)
-	os.Setenv("HTTP_TIMEOUT", "120")
-	os.Setenv("HTTP_RESPONSE_HEADER_TIMEOUT", "90")
-	defer func() {
-		os.Unsetenv("HTTP_TIMEOUT")
-		os.Unsetenv("HTTP_RESPONSE_HEADER_TIMEOUT")
-	}()
+	t.Setenv("HTTP_TIMEOUT", "120")
+	t.Setenv("HTTP_RESPONSE_HEADER_TIMEOUT", "90")
 
 	config := DefaultConfig()
 
@@ -72,8 +67,7 @@ func TestDefaultConfigWithEnvOverrides(t *testing.T) {
 
 func TestDefaultConfigWithDurationFormat(t *testing.T) {
 	// Test Go duration format still works
-	os.Setenv("HTTP_TIMEOUT", "2m")
-	defer os.Unsetenv("HTTP_TIMEOUT")
+	t.Setenv("HTTP_TIMEOUT", "2m")
 
 	config := DefaultConfig()
 
@@ -84,8 +78,7 @@ func TestDefaultConfigWithDurationFormat(t *testing.T) {
 
 func TestDefaultConfigWithInvalidEnv(t *testing.T) {
 	// Set invalid environment variable
-	os.Setenv("HTTP_TIMEOUT", "invalid")
-	defer os.Unsetenv("HTTP_TIMEOUT")
+	t.Setenv("HTTP_TIMEOUT", "invalid")
 
 	config := DefaultConfig()
 

--- a/internal/httpclient/client_test.go
+++ b/internal/httpclient/client_test.go
@@ -46,9 +46,9 @@ func TestDefaultConfig(t *testing.T) {
 }
 
 func TestDefaultConfigWithEnvOverrides(t *testing.T) {
-	// Set environment variables
-	os.Setenv("HTTP_TIMEOUT", "120s")
-	os.Setenv("HTTP_RESPONSE_HEADER_TIMEOUT", "90s")
+	// Set environment variables using plain integers (seconds)
+	os.Setenv("HTTP_TIMEOUT", "120")
+	os.Setenv("HTTP_RESPONSE_HEADER_TIMEOUT", "90")
 	defer func() {
 		os.Unsetenv("HTTP_TIMEOUT")
 		os.Unsetenv("HTTP_RESPONSE_HEADER_TIMEOUT")
@@ -67,6 +67,18 @@ func TestDefaultConfigWithEnvOverrides(t *testing.T) {
 	// Other values should remain unchanged
 	if config.DialTimeout != 30*time.Second {
 		t.Errorf("Expected DialTimeout to be 30s, got %v", config.DialTimeout)
+	}
+}
+
+func TestDefaultConfigWithDurationFormat(t *testing.T) {
+	// Test Go duration format still works
+	os.Setenv("HTTP_TIMEOUT", "2m")
+	defer os.Unsetenv("HTTP_TIMEOUT")
+
+	config := DefaultConfig()
+
+	if config.Timeout != 2*time.Minute {
+		t.Errorf("Expected Timeout to be 2m from env, got %v", config.Timeout)
 	}
 }
 


### PR DESCRIPTION
Change default Timeout and ResponseHeaderTimeout from 30s/10s to 600s (10 minutes) to match OpenAI/Anthropic SDK defaults.

The previous 10s ResponseHeaderTimeout was causing "http2: timeout awaiting response headers" errors for long LLM responses.

Add environment variable overrides:
- HTTP_TIMEOUT: overall request timeout (default: 600s)
- HTTP_RESPONSE_HEADER_TIMEOUT: time to wait for headers (default: 600s)

https://claude.ai/code/session_01FPiparDKMk4hCmSKWVkqWA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timeouts configurable via environment variables (HTTP_TIMEOUT, HTTP_RESPONSE_HEADER_TIMEOUT); accepts seconds or duration strings; invalid values fall back safely.

* **Configuration**
  * Default HTTP timeout values set to 600 seconds for Timeout and ResponseHeaderTimeout.

* **Tests**
  * Added tests covering env-based overrides, duration-string parsing, and fallback behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->