### PR TITLE
docs: adjust docs for quicker start

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,25 @@
+# Development
+
+## Testing
+
+```bash
+make test          # Unit tests
+make test-e2e      # End-to-end tests
+make test-all      # All tests
+```
+
+## Linting
+
+Requires [golangci-lint](https://golangci-lint.run/welcome/install/).
+
+```bash
+make lint          # Check code quality
+make lint-fix      # Auto-fix issues
+```
+
+## Pre-commit
+
+```bash
+pip install pre-commit
+pre-commit install
+```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 ```bash
 make test          # Unit tests
-make test-e2e      # End-to-end tests
+make test-e2e      # End-to-end tests (requires -tags=e2e; uses in-process mock servers, no Docker)
 make test-all      # All tests
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ curl http://localhost:8080/v1/chat/completions \
 
 ### Supported Providers
 
+Example model identifiers are illustrative and subject to change; consult provider catalogs for current models.
+
 <table>
   <tr>
     <th colspan="3">Provider</th>
@@ -69,7 +71,7 @@ curl http://localhost:8080/v1/chat/completions \
   <tr>
     <td>Anthropic</td>
     <td><code>ANTHROPIC_API_KEY</code></td>
-    <td><code>claude&#8209;3&#8209;5&#8209;sonnet&#8209;20241022</code></td>
+    <td><code>claude&#8209;sonnet&#8209;4&#8209;20250514</code></td>
     <td>✅</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td>
   </tr>
   <tr>

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ curl http://localhost:8080/v1/chat/completions \
     <th colspan="8">Features</th>
   </tr>
   <tr>
-    <th style="white-space: nowrap">Name</th>
+    <th>Name</th>
     <th>Credential</th>
-    <th style="white-space: nowrap">Example Model</th>
+    <th>Example&nbsp;Model</th>
     <th>Chat</th>
     <th>Passthru</th>
     <th>Voice</th>
@@ -63,37 +63,37 @@ curl http://localhost:8080/v1/chat/completions \
   <tr>
     <td>OpenAI</td>
     <td><code>OPENAI_API_KEY</code></td>
-    <td style="white-space: nowrap"><code>gpt-4o-mini</code></td>
+    <td><code>gpt-4o-mini</code></td>
     <td>✅</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td>
   </tr>
   <tr>
     <td>Anthropic</td>
     <td><code>ANTHROPIC_API_KEY</code></td>
-    <td style="white-space: nowrap"><code>claude-3-5-sonnet-20241022</code></td>
+    <td><code>claude-3-5-sonnet-20241022</code></td>
     <td>✅</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td>
   </tr>
   <tr>
-    <td style="white-space: nowrap">Google Gemini</td>
+    <td>Google&nbsp;Gemini</td>
     <td><code>GEMINI_API_KEY</code></td>
-    <td style="white-space: nowrap"><code>gemini-2.5-flash</code></td>
+    <td><code>gemini-2.5-flash</code></td>
     <td>✅</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td>
   </tr>
   <tr>
     <td>Groq</td>
     <td><code>GROQ_API_KEY</code></td>
-    <td style="white-space: nowrap"><code>llama-3.3-70b-versatile</code></td>
+    <td><code>llama-3.3-70b-versatile</code></td>
     <td>✅</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td>
   </tr>
   <tr>
-    <td style="white-space: nowrap">xAI (Grok)</td>
+    <td>xAI&nbsp;(Grok)</td>
     <td><code>XAI_API_KEY</code></td>
-    <td style="white-space: nowrap"><code>grok-2</code></td>
+    <td><code>grok-2</code></td>
     <td>✅</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td>
   </tr>
   <tr>
     <td>Ollama</td>
     <td><code>OLLAMA_BASE_URL</code></td>
-    <td style="white-space: nowrap"><code>llama3.2</code></td>
+    <td><code>llama3.2</code></td>
     <td>✅</td><td>🚧</td><td>🚧</td><td>—</td><td>—</td><td>🚧</td><td>🚧</td><td>🚧</td>
   </tr>
 </table>
@@ -210,21 +210,23 @@ pre-commit install
 
 ## Features
 
-| Feature                    | Basic support     | Full support      |
-| -------------------------- | ----------------- | ----------------- |
-| Billing Management         | 🚧 Coming soon... | 🚧 Coming soon... |
-| Full-observability         | 🚧 Coming soon... | 🚧 Coming soon... |
-| Budget management          | 🚧 Coming soon... | 🚧 Coming soon... |
-| Many keys support          | 🚧 Coming soon... | 🚧 Coming soon... |
-| Administrative endpoints   | 🚧 Coming soon... | 🚧 Coming soon... |
-| Guardrails                 | 🚧 Coming soon... | 🚧 Coming soon... |
-| SSO                        | 🚧 Coming soon... | 🚧 Coming soon... |
-| System Prompt (GuardRails) | 🚧 Coming soon... | 🚧 Coming soon... |
+| Feature                    | Basic | Full |
+| -------------------------- |:-----:|:----:|
+| Billing Management         | 🚧   | 🚧   |
+| Full-observability         | 🚧   | 🚧   |
+| Budget management          | 🚧   | 🚧   |
+| Many keys support          | 🚧   | 🚧   |
+| Administrative endpoints   | 🚧   | 🚧   |
+| Guardrails                 | 🚧   | 🚧   |
+| SSO                        | 🚧   | 🚧   |
+| System Prompt (GuardRails) | 🚧   | 🚧   |
 
 ## Integrations
 
-| Integration   | Basic integration | Full support      |
-| ------------- | ----------------- | ----------------- |
-| Prometheus    | ✅                | 🚧 Coming soon... |
-| DataDog       | 🚧 Coming soon... | 🚧 Coming soon... |
-| OpenTelemetry | 🚧 Coming soon... | 🚧 Coming soon... |
+| Integration   | Basic | Full |
+| ------------- |:-----:|:----:|
+| Prometheus    | ✅    | 🚧   |
+| DataDog       | 🚧   | 🚧   |
+| OpenTelemetry | 🚧   | 🚧   |
+
+✅ Supported  🚧 Coming soon

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A high-performance AI gateway written in Go, providing a unified OpenAI-compatib
 
 ```bash
 docker run --rm -p 8080:8080 \
-  -e GEMINI_API_KEY="your-gemini-key" \
+  -e OPENAI_API_KEY="your-openai-key" \
   enterpilot/gomodel
 ```
 
@@ -33,7 +33,7 @@ docker run --rm -p 8080:8080 \
 curl http://localhost:8080/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "gemini-2.5-flash",
+    "model": "gpt-5-chat-latest",
     "messages": [{"role": "user", "content": "Hello!"}]
   }'
 ```
@@ -178,31 +178,7 @@ Key settings:
 
 ---
 
-## Development
-
-### Testing
-
-```bash
-make test          # Unit tests
-make test-e2e      # End-to-end tests
-make test-all      # All tests
-```
-
-### Linting
-
-Requires [golangci-lint](https://golangci-lint.run/welcome/install/).
-
-```bash
-make lint          # Check code quality
-make lint-fix      # Auto-fix issues
-```
-
-### Pre-commit
-
-```bash
-pip install pre-commit
-pre-commit install
-```
+See [DEVELOPMENT.md](DEVELOPMENT.md) for testing, linting, and pre-commit setup.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ docker run --rm -p 8080:8080 \
   enterpilot/gomodel
 ```
 
-Avoid passing secrets via `-e` on the command line—they can leak via shell history and process lists. For production, use `docker run --env-file .env` to load API keys from a file instead.
+⚠️ Avoid passing secrets via `-e` on the command line—they can leak via shell history and process lists. For production, use `docker run --env-file .env` to load API keys from a file instead.
 
 **Step 2:** Make your first API call
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GOModel
 
-A high-performance AI gateway written in Go. Unified OpenAI-compatible API for multiple LLM providers.
+A high-performance AI gateway written in Go, providing a unified OpenAI-compatible API for multiple AI model providers, full-observability and more.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -42,14 +42,63 @@ curl http://localhost:8080/v1/chat/completions \
 
 ### Supported Providers
 
-| Provider | Credential / Env Variable | Example Model |
-|----------|---------------------|---------------|
-| OpenAI | `OPENAI_API_KEY` | `gpt-4o-mini` |
-| Anthropic | `ANTHROPIC_API_KEY` | `claude-3-5-sonnet-20241022` |
-| Google Gemini | `GEMINI_API_KEY` | `gemini-2.5-flash` |
-| Groq | `GROQ_API_KEY` | `llama-3.3-70b-versatile` |
-| xAI (Grok) | `XAI_API_KEY` | `grok-2` |
-| Ollama | `OLLAMA_BASE_URL` | `llama3.2` |
+<table>
+  <tr>
+    <th colspan="3">Provider</th>
+    <th colspan="8">Features</th>
+  </tr>
+  <tr>
+    <th style="white-space: nowrap">Name</th>
+    <th>Credential</th>
+    <th style="white-space: nowrap">Example Model</th>
+    <th>Chat</th>
+    <th>Passthru</th>
+    <th>Voice</th>
+    <th>Image</th>
+    <th>Video</th>
+    <th>/responses</th>
+    <th>Embed</th>
+    <th>Cache</th>
+  </tr>
+  <tr>
+    <td>OpenAI</td>
+    <td><code>OPENAI_API_KEY</code></td>
+    <td style="white-space: nowrap"><code>gpt-4o-mini</code></td>
+    <td>✅</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td>
+  </tr>
+  <tr>
+    <td>Anthropic</td>
+    <td><code>ANTHROPIC_API_KEY</code></td>
+    <td style="white-space: nowrap"><code>claude-3-5-sonnet-20241022</code></td>
+    <td>✅</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td>
+  </tr>
+  <tr>
+    <td style="white-space: nowrap">Google Gemini</td>
+    <td><code>GEMINI_API_KEY</code></td>
+    <td style="white-space: nowrap"><code>gemini-2.5-flash</code></td>
+    <td>✅</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td>
+  </tr>
+  <tr>
+    <td>Groq</td>
+    <td><code>GROQ_API_KEY</code></td>
+    <td style="white-space: nowrap"><code>llama-3.3-70b-versatile</code></td>
+    <td>✅</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td>
+  </tr>
+  <tr>
+    <td style="white-space: nowrap">xAI (Grok)</td>
+    <td><code>XAI_API_KEY</code></td>
+    <td style="white-space: nowrap"><code>grok-2</code></td>
+    <td>✅</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td>
+  </tr>
+  <tr>
+    <td>Ollama</td>
+    <td><code>OLLAMA_BASE_URL</code></td>
+    <td style="white-space: nowrap"><code>llama3.2</code></td>
+    <td>✅</td><td>🚧</td><td>🚧</td><td>—</td><td>—</td><td>🚧</td><td>🚧</td><td>🚧</td>
+  </tr>
+</table>
+
+✅ Supported  🚧 Coming soon  — Not applicable
 
 ---
 
@@ -158,16 +207,6 @@ pre-commit install
 ---
 
 # Roadmap
-
-## Supported Providers
-
-| Provider      | Basic support | Pass-through      | Voice models      | Image gen         | Video gen         | Full /responses API | Embedding         | Caching           |
-| ------------- | ------------- | ----------------- | ----------------- | ----------------- | ----------------- | ------------------- | ----------------- | ----------------- |
-| OpenAI        | ✅            | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon...   | 🚧 Coming soon... | 🚧 Coming soon... |
-| Anthropic     | ✅            | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon...   | 🚧 Coming soon... | 🚧 Coming soon... |
-| Google Gemini | ✅            | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon...   | 🚧 Coming soon... | 🚧 Coming soon... |
-| Groq          | ✅            | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon...   | 🚧 Coming soon... | 🚧 Coming soon... |
-| xAI           | ✅            | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon...   | 🚧 Coming soon... | 🚧 Coming soon... |
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ docker run --rm -p 8080:8080 \
   enterpilot/gomodel
 ```
 
-Pass only the API keys you need (at least one required):
+Pass only the provider credentials or base URL you need (at least one required):
 
 ```bash
 docker run --rm -p 8080:8080 \
@@ -20,8 +20,12 @@ docker run --rm -p 8080:8080 \
   -e ANTHROPIC_API_KEY="your-anthropic-key" \
   -e GEMINI_API_KEY="your-gemini-key" \
   -e GROQ_API_KEY="your-groq-key" \
+  -e XAI_API_KEY="your-xai-key" \
+  -e OLLAMA_BASE_URL="http://host.docker.internal:11434/v1" \
   enterpilot/gomodel
 ```
+
+Avoid passing secrets via `-e` on the command line—they can leak via shell history and process lists. For production, use `docker run --env-file .env` to load API keys from a file instead.
 
 **Step 2:** Make your first API call
 
@@ -34,11 +38,11 @@ curl http://localhost:8080/v1/chat/completions \
   }'
 ```
 
-**That's it!** GOModel automatically detects which providers are available based on the API keys you supply.
+**That's it!** GOModel automatically detects which providers are available based on the credentials you supply.
 
 ### Supported Providers
 
-| Provider | Environment Variable | Example Model |
+| Provider | Credential / Env Variable | Example Model |
 |----------|---------------------|---------------|
 | OpenAI | `OPENAI_API_KEY` | `gpt-4o-mini` |
 | Anthropic | `ANTHROPIC_API_KEY` | `claude-3-5-sonnet-20241022` |
@@ -89,7 +93,7 @@ docker compose up -d
 
 ```bash
 docker build -t gomodel .
-docker run --rm -p 8080:8080 -e GEMINI_API_KEY="your-key" gomodel
+docker run --rm -p 8080:8080 --env-file .env gomodel
 ```
 
 ---
@@ -120,6 +124,8 @@ Key settings:
 | `STORAGE_TYPE` | `sqlite` | Storage backend (`sqlite`, `postgresql`, `mongodb`) |
 | `METRICS_ENABLED` | `false` | Enable Prometheus metrics |
 | `LOGGING_ENABLED` | `false` | Enable audit logging |
+
+**Quick Start — Authentication:** By default `GOMODEL_MASTER_KEY` is unset. Without this key, API endpoints are unprotected and anyone can call them. This is insecure for production. **Strongly recommend** setting a strong secret before exposing the service. Add `GOMODEL_MASTER_KEY` to your `.env` or environment for production deployments.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -151,23 +151,22 @@ pre-commit install
 
 ---
 
-## Roadmap
+# Roadmap
 
-### Supported Providers
+## Supported Providers
 
-| Provider | Basic support | Pass-through | Voice models | Image gen | Video gen | Full /responses API | Embedding | Caching |
-|----------|---------------|--------------|--------------|-----------|-----------|---------------------|-----------|---------|
-| OpenAI | ✅ | 🚧 | 🚧 | 🚧 | 🚧 | 🚧 | 🚧 | 🚧 |
-| Anthropic | ✅ | 🚧 | 🚧 | 🚧 | 🚧 | 🚧 | 🚧 | 🚧 |
-| Google Gemini | ✅ | 🚧 | 🚧 | 🚧 | 🚧 | 🚧 | 🚧 | 🚧 |
-| OpenRouter | 🚧 | 🚧 | 🚧 | 🚧 | 🚧 | 🚧 | 🚧 | 🚧 |
-| Groq | ✅ | 🚧 | 🚧 | 🚧 | 🚧 | 🚧 | 🚧 | 🚧 |
-| xAI | ✅ | 🚧 | 🚧 | 🚧 | 🚧 | 🚧 | 🚧 | 🚧 |
+| Provider      | Basic support | Pass-through      | Voice models      | Image gen         | Video gen         | Full /responses API | Embedding         | Caching           |
+| ------------- | ------------- | ----------------- | ----------------- | ----------------- | ----------------- | ------------------- | ----------------- | ----------------- |
+| OpenAI        | ✅            | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon...   | 🚧 Coming soon... | 🚧 Coming soon... |
+| Anthropic     | ✅            | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon...   | 🚧 Coming soon... | 🚧 Coming soon... |
+| Google Gemini | ✅            | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon...   | 🚧 Coming soon... | 🚧 Coming soon... |
+| Groq          | ✅            | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon...   | 🚧 Coming soon... | 🚧 Coming soon... |
+| xAI           | ✅            | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon... | 🚧 Coming soon...   | 🚧 Coming soon... | 🚧 Coming soon... |
 
-### Features
+## Features
 
-| Feature                    | Basic support      | Full support       |
-| -------------------------- | ------------------ | ------------------ |
+| Feature                    | Basic support     | Full support      |
+| -------------------------- | ----------------- | ----------------- |
 | Billing Management         | 🚧 Coming soon... | 🚧 Coming soon... |
 | Full-observability         | 🚧 Coming soon... | 🚧 Coming soon... |
 | Budget management          | 🚧 Coming soon... | 🚧 Coming soon... |
@@ -177,10 +176,10 @@ pre-commit install
 | SSO                        | 🚧 Coming soon... | 🚧 Coming soon... |
 | System Prompt (GuardRails) | 🚧 Coming soon... | 🚧 Coming soon... |
 
-### Integrations
+## Integrations
 
-| Integration   | Basic integration  | Full support       |
-| ------------- | ------------------ | ------------------ |
-| Prometheus    | ✅                 | 🚧 Coming soon... |
+| Integration   | Basic integration | Full support      |
+| ------------- | ----------------- | ----------------- |
+| Prometheus    | ✅                | 🚧 Coming soon... |
 | DataDog       | 🚧 Coming soon... | 🚧 Coming soon... |
 | OpenTelemetry | 🚧 Coming soon... | 🚧 Coming soon... |

--- a/README.md
+++ b/README.md
@@ -166,20 +166,21 @@ pre-commit install
 
 ### Features
 
-| Feature | Status |
-|---------|--------|
-| Billing Management | 🚧 Coming soon |
-| Full Observability | 🚧 Coming soon |
-| Budget Management | 🚧 Coming soon |
-| Multiple Keys per Provider | 🚧 Coming soon |
-| Admin Endpoints | 🚧 Coming soon |
-| Guardrails | 🚧 Coming soon |
-| SSO | 🚧 Coming soon |
+| Feature                    | Basic support      | Full support       |
+| -------------------------- | ------------------ | ------------------ |
+| Billing Management         | 🚧 Coming soon... | 🚧 Coming soon... |
+| Full-observability         | 🚧 Coming soon... | 🚧 Coming soon... |
+| Budget management          | 🚧 Coming soon... | 🚧 Coming soon... |
+| Many keys support          | 🚧 Coming soon... | 🚧 Coming soon... |
+| Administrative endpoints   | 🚧 Coming soon... | 🚧 Coming soon... |
+| Guardrails                 | 🚧 Coming soon... | 🚧 Coming soon... |
+| SSO                        | 🚧 Coming soon... | 🚧 Coming soon... |
+| System Prompt (GuardRails) | 🚧 Coming soon... | 🚧 Coming soon... |
 
 ### Integrations
 
-| Integration | Status |
-|-------------|--------|
-| Prometheus | ✅ Basic |
-| Datadog | 🚧 Coming soon |
-| OpenTelemetry | 🚧 Coming soon |
+| Integration   | Basic integration  | Full support       |
+| ------------- | ------------------ | ------------------ |
+| Prometheus    | ✅                 | 🚧 Coming soon... |
+| DataDog       | 🚧 Coming soon... | 🚧 Coming soon... |
+| OpenTelemetry | 🚧 Coming soon... | 🚧 Coming soon... |

--- a/README.md
+++ b/README.md
@@ -63,31 +63,31 @@ curl http://localhost:8080/v1/chat/completions \
   <tr>
     <td>OpenAI</td>
     <td><code>OPENAI_API_KEY</code></td>
-    <td><code>gpt-4o-mini</code></td>
+    <td><code>gpt&#8209;4o&#8209;mini</code></td>
     <td>✅</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td>
   </tr>
   <tr>
     <td>Anthropic</td>
     <td><code>ANTHROPIC_API_KEY</code></td>
-    <td><code>claude-3-5-sonnet-20241022</code></td>
+    <td><code>claude&#8209;3&#8209;5&#8209;sonnet&#8209;20241022</code></td>
     <td>✅</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td>
   </tr>
   <tr>
     <td>Google&nbsp;Gemini</td>
     <td><code>GEMINI_API_KEY</code></td>
-    <td><code>gemini-2.5-flash</code></td>
+    <td><code>gemini&#8209;2.5&#8209;flash</code></td>
     <td>✅</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td>
   </tr>
   <tr>
     <td>Groq</td>
     <td><code>GROQ_API_KEY</code></td>
-    <td><code>llama-3.3-70b-versatile</code></td>
+    <td><code>llama&#8209;3.3&#8209;70b&#8209;versatile</code></td>
     <td>✅</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td>
   </tr>
   <tr>
     <td>xAI&nbsp;(Grok)</td>
     <td><code>XAI_API_KEY</code></td>
-    <td><code>grok-2</code></td>
+    <td><code>grok&#8209;2</code></td>
     <td>✅</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td><td>🚧</td>
   </tr>
   <tr>


### PR DESCRIPTION
- Moved Docker `docker run` to the top as the primary Quick Start method, using the `enterpilot/gomodel` image with API keys passed via `-e` flags
- Added a provider reference table (env var + example model) right below Quick Start
- Moved "Running from Source" (`make run`) and "Docker Compose (Full Stack)" into a lower "Alternative Setup Methods" section
- Added API Endpoints and Configuration reference sections
- Removed the old `golang:1.24-alpine` + go run dev-mode Docker example in favor of the proper multi-stage built image
- Removed OpenRouter from the providers list (no implementation exists)
- Merged supported provider tables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote Quick Start into a clear two-step Docker flow with examples and secret-handling guidance
  * Added Supported Providers table, API endpoints reference, Alternative Setup Methods, configuration/auth guidance, and updated Roadmap/Features/Integrations
  * Expanded developer docs with testing, linting, and pre-commit setup and simplified dev/test commands
<!-- end of auto-generated comment: release notes by coderabbit.ai -->