### PR TITLE
feat: add guardrails system with system prompt injection/override/decorator

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -53,11 +53,24 @@ http:
 
 guardrails:
   enabled: false
-  system_prompt:
-    enabled: false
-    order: 0 # guardrails with the same order run in parallel; different orders run sequentially
-    mode: "inject" # "inject", "override", or "decorator"
-    content: "You are a helpful assistant."
+  rules:
+    # Each entry is a guardrail instance. Multiple instances of the same type are supported.
+    # Guardrails with the same "order" run in parallel; different orders run sequentially.
+
+    - name: "safety-prompt"
+      type: "system_prompt"
+      order: 0
+      system_prompt:
+        mode: "decorator" # "inject", "override", or "decorator"
+        content: "Always be safe and respectful."
+
+    # Example: a second system_prompt instance running at the same order (parallel)
+    # - name: "compliance-prompt"
+    #   type: "system_prompt"
+    #   order: 0
+    #   system_prompt:
+    #     mode: "inject"
+    #     content: "Follow all compliance rules."
 
 providers:
   openai:

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -53,9 +53,9 @@ http:
 
 guardrails:
   enabled: false
-  execution: "sequential" # "sequential" or "parallel"
   system_prompt:
     enabled: false
+    order: 0 # guardrails with the same order run in parallel; different orders run sequentially
     mode: "inject" # "inject", "override", or "decorator"
     content: "You are a helpful assistant."
 

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -72,6 +72,20 @@ guardrails:
     #     mode: "inject"
     #     content: "Follow all compliance rules."
 
+    # Names support spaces and unicode characters:
+    # - name: "проверка безопасности"
+    #   type: "system_prompt"
+    #   order: 0
+    #   system_prompt:
+    #     mode: "decorator"
+    #     content: "Соблюдайте все правила безопасности."
+    # - name: "安全検査"
+    #   type: "system_prompt"
+    #   order: 1
+    #   system_prompt:
+    #     mode: "inject"
+    #     content: "Follow safety guidelines."
+
 providers:
   openai:
     type: openai

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -51,6 +51,14 @@ http:
   timeout: 600 # seconds (10 minutes)
   response_header_timeout: 600
 
+guardrails:
+  enabled: false
+  execution: "sequential" # "sequential" or "parallel"
+  system_prompt:
+    enabled: false
+    mode: "inject" # "inject", "override", or "decorator"
+    content: "You are a helpful assistant."
+
 providers:
   openai:
     type: openai

--- a/config/config.go
+++ b/config/config.go
@@ -44,30 +44,41 @@ type GuardrailsConfig struct {
 	// Default: false
 	Enabled bool `yaml:"enabled" env:"GUARDRAILS_ENABLED"`
 
-	// SystemPrompt configures the system prompt guardrail
-	SystemPrompt SystemPromptGuardrailConfig `yaml:"system_prompt"`
+	// Rules is a list of guardrail instances. Each entry defines one guardrail
+	// with its own name, type, order, and type-specific settings. Multiple
+	// instances of the same type are allowed (e.g. two system_prompt guardrails
+	// with different content).
+	Rules []GuardrailRuleConfig `yaml:"rules"`
 }
 
-// SystemPromptGuardrailConfig holds configuration for the system prompt guardrail.
-type SystemPromptGuardrailConfig struct {
-	// Enabled controls whether the system prompt guardrail is active
-	// Default: false
-	Enabled bool `yaml:"enabled" env:"GUARDRAILS_SYSTEM_PROMPT_ENABLED"`
+// GuardrailRuleConfig defines a single guardrail instance.
+type GuardrailRuleConfig struct {
+	// Name is a unique identifier for this guardrail instance (used in logs and errors)
+	Name string `yaml:"name"`
+
+	// Type selects the guardrail implementation: "system_prompt"
+	Type string `yaml:"type"`
 
 	// Order controls execution ordering relative to other guardrails.
 	// Guardrails with the same order run in parallel; different orders run sequentially.
 	// Default: 0
-	Order int `yaml:"order" env:"GUARDRAILS_SYSTEM_PROMPT_ORDER"`
+	Order int `yaml:"order"`
 
+	// SystemPrompt holds settings when Type is "system_prompt"
+	SystemPrompt SystemPromptSettings `yaml:"system_prompt"`
+}
+
+// SystemPromptSettings holds the type-specific settings for a system_prompt guardrail.
+type SystemPromptSettings struct {
 	// Mode controls how the system prompt is applied: "inject", "override", or "decorator"
 	//   - inject: adds a system message only if none exists
 	//   - override: replaces all existing system messages
 	//   - decorator: prepends to the first existing system message
 	// Default: "inject"
-	Mode string `yaml:"mode" env:"GUARDRAILS_SYSTEM_PROMPT_MODE"`
+	Mode string `yaml:"mode"`
 
 	// Content is the system prompt text to apply
-	Content string `yaml:"content" env:"GUARDRAILS_SYSTEM_PROMPT_CONTENT"`
+	Content string `yaml:"content"`
 }
 
 // HTTPConfig holds HTTP client configuration for upstream API requests.
@@ -273,11 +284,7 @@ func defaultConfig() Config {
 			Timeout:               600,
 			ResponseHeaderTimeout: 600,
 		},
-		Guardrails: GuardrailsConfig{
-			SystemPrompt: SystemPromptGuardrailConfig{
-				Mode: "inject",
-			},
-		},
+		Guardrails: GuardrailsConfig{},
 		Providers: make(map[string]ProviderConfig),
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -27,14 +27,46 @@ var bodySizeLimitRegex = regexp.MustCompile(`(?i)^(\d+)([KMG])?B?$`)
 
 // Config holds the application configuration
 type Config struct {
-	Server    ServerConfig            `yaml:"server"`
-	Cache     CacheConfig             `yaml:"cache"`
-	Storage   StorageConfig           `yaml:"storage"`
-	Logging   LogConfig               `yaml:"logging"`
-	Usage     UsageConfig             `yaml:"usage"`
-	Metrics   MetricsConfig           `yaml:"metrics"`
-	HTTP      HTTPConfig              `yaml:"http"`
-	Providers map[string]ProviderConfig `yaml:"providers"`
+	Server     ServerConfig              `yaml:"server"`
+	Cache      CacheConfig               `yaml:"cache"`
+	Storage    StorageConfig             `yaml:"storage"`
+	Logging    LogConfig                 `yaml:"logging"`
+	Usage      UsageConfig               `yaml:"usage"`
+	Metrics    MetricsConfig             `yaml:"metrics"`
+	HTTP       HTTPConfig                `yaml:"http"`
+	Guardrails GuardrailsConfig          `yaml:"guardrails"`
+	Providers  map[string]ProviderConfig `yaml:"providers"`
+}
+
+// GuardrailsConfig holds configuration for the request guardrails pipeline.
+type GuardrailsConfig struct {
+	// Enabled controls whether guardrails are active
+	// Default: false
+	Enabled bool `yaml:"enabled" env:"GUARDRAILS_ENABLED"`
+
+	// Execution controls how guardrails are executed: "sequential" or "parallel"
+	// Default: "sequential"
+	Execution string `yaml:"execution" env:"GUARDRAILS_EXECUTION"`
+
+	// SystemPrompt configures the system prompt guardrail
+	SystemPrompt SystemPromptGuardrailConfig `yaml:"system_prompt"`
+}
+
+// SystemPromptGuardrailConfig holds configuration for the system prompt guardrail.
+type SystemPromptGuardrailConfig struct {
+	// Enabled controls whether the system prompt guardrail is active
+	// Default: false
+	Enabled bool `yaml:"enabled" env:"GUARDRAILS_SYSTEM_PROMPT_ENABLED"`
+
+	// Mode controls how the system prompt is applied: "inject", "override", or "decorator"
+	//   - inject: adds a system message only if none exists
+	//   - override: replaces all existing system messages
+	//   - decorator: prepends to the first existing system message
+	// Default: "inject"
+	Mode string `yaml:"mode" env:"GUARDRAILS_SYSTEM_PROMPT_MODE"`
+
+	// Content is the system prompt text to apply
+	Content string `yaml:"content" env:"GUARDRAILS_SYSTEM_PROMPT_CONTENT"`
 }
 
 // HTTPConfig holds HTTP client configuration for upstream API requests.
@@ -239,6 +271,12 @@ func defaultConfig() Config {
 		HTTP: HTTPConfig{
 			Timeout:               600,
 			ResponseHeaderTimeout: 600,
+		},
+		Guardrails: GuardrailsConfig{
+			Execution: "sequential",
+			SystemPrompt: SystemPromptGuardrailConfig{
+				Mode: "inject",
+			},
 		},
 		Providers: make(map[string]ProviderConfig),
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -44,10 +44,6 @@ type GuardrailsConfig struct {
 	// Default: false
 	Enabled bool `yaml:"enabled" env:"GUARDRAILS_ENABLED"`
 
-	// Execution controls how guardrails are executed: "sequential" or "parallel"
-	// Default: "sequential"
-	Execution string `yaml:"execution" env:"GUARDRAILS_EXECUTION"`
-
 	// SystemPrompt configures the system prompt guardrail
 	SystemPrompt SystemPromptGuardrailConfig `yaml:"system_prompt"`
 }
@@ -57,6 +53,11 @@ type SystemPromptGuardrailConfig struct {
 	// Enabled controls whether the system prompt guardrail is active
 	// Default: false
 	Enabled bool `yaml:"enabled" env:"GUARDRAILS_SYSTEM_PROMPT_ENABLED"`
+
+	// Order controls execution ordering relative to other guardrails.
+	// Guardrails with the same order run in parallel; different orders run sequentially.
+	// Default: 0
+	Order int `yaml:"order" env:"GUARDRAILS_SYSTEM_PROMPT_ORDER"`
 
 	// Mode controls how the system prompt is applied: "inject", "override", or "decorator"
 	//   - inject: adds a system message only if none exists
@@ -273,7 +274,6 @@ func defaultConfig() Config {
 			ResponseHeaderTimeout: 600,
 		},
 		Guardrails: GuardrailsConfig{
-			Execution: "sequential",
 			SystemPrompt: SystemPromptGuardrailConfig{
 				Mode: "inject",
 			},

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -14,6 +14,7 @@ import (
 	"gomodel/config"
 	"gomodel/internal/auditlog"
 	"gomodel/internal/core"
+	"gomodel/internal/guardrails"
 	"gomodel/internal/providers"
 	"gomodel/internal/server"
 	"gomodel/internal/usage"
@@ -106,6 +107,23 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 	// Log configuration status
 	app.logStartupInfo()
 
+	// Build the provider chain: router optionally wrapped with guardrails
+	var provider core.RoutableProvider = app.providers.Router
+	if cfg.AppConfig.Guardrails.Enabled {
+		pipeline, err := buildGuardrailsPipeline(cfg.AppConfig.Guardrails)
+		if err != nil {
+			closeErr := errors.Join(app.usage.Close(), app.audit.Close(), app.providers.Close())
+			if closeErr != nil {
+				return nil, fmt.Errorf("failed to build guardrails: %w (also: close error: %v)", err, closeErr)
+			}
+			return nil, fmt.Errorf("failed to build guardrails: %w", err)
+		}
+		if pipeline.Len() > 0 {
+			provider = guardrails.NewGuardedProvider(provider, pipeline)
+			slog.Info("guardrails enabled", "count", pipeline.Len(), "execution", cfg.AppConfig.Guardrails.Execution)
+		}
+	}
+
 	// Create server
 	serverCfg := &server.Config{
 		MasterKey:                cfg.AppConfig.Server.MasterKey,
@@ -116,7 +134,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		UsageLogger:              usageResult.Logger,
 		LogOnlyModelInteractions: cfg.AppConfig.Logging.OnlyModelInteractions,
 	}
-	app.server = server.New(app.providers.Router, serverCfg)
+	app.server = server.New(provider, serverCfg)
 
 	return app, nil
 }
@@ -266,4 +284,23 @@ func (a *App) logStartupInfo() {
 	} else {
 		slog.Info("usage tracking disabled")
 	}
+}
+
+// buildGuardrailsPipeline creates a guardrails pipeline from configuration.
+func buildGuardrailsPipeline(cfg config.GuardrailsConfig) (*guardrails.Pipeline, error) {
+	mode := guardrails.ExecutionMode(cfg.Execution)
+	pipeline := guardrails.NewPipeline(mode)
+
+	// System prompt guardrail
+	if cfg.SystemPrompt.Enabled {
+		spMode := guardrails.SystemPromptMode(cfg.SystemPrompt.Mode)
+		g, err := guardrails.NewSystemPromptGuardrail(spMode, cfg.SystemPrompt.Content)
+		if err != nil {
+			return nil, fmt.Errorf("system_prompt guardrail: %w", err)
+		}
+		pipeline.Add(g)
+		slog.Info("guardrail registered", "name", "system_prompt", "mode", cfg.SystemPrompt.Mode)
+	}
+
+	return pipeline, nil
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -120,7 +120,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		}
 		if pipeline.Len() > 0 {
 			provider = guardrails.NewGuardedProvider(provider, pipeline)
-			slog.Info("guardrails enabled", "count", pipeline.Len(), "execution", cfg.AppConfig.Guardrails.Execution)
+			slog.Info("guardrails enabled", "count", pipeline.Len())
 		}
 	}
 
@@ -288,8 +288,7 @@ func (a *App) logStartupInfo() {
 
 // buildGuardrailsPipeline creates a guardrails pipeline from configuration.
 func buildGuardrailsPipeline(cfg config.GuardrailsConfig) (*guardrails.Pipeline, error) {
-	mode := guardrails.ExecutionMode(cfg.Execution)
-	pipeline := guardrails.NewPipeline(mode)
+	pipeline := guardrails.NewPipeline()
 
 	// System prompt guardrail
 	if cfg.SystemPrompt.Enabled {
@@ -298,8 +297,8 @@ func buildGuardrailsPipeline(cfg config.GuardrailsConfig) (*guardrails.Pipeline,
 		if err != nil {
 			return nil, fmt.Errorf("system_prompt guardrail: %w", err)
 		}
-		pipeline.Add(g)
-		slog.Info("guardrail registered", "name", "system_prompt", "mode", cfg.SystemPrompt.Mode)
+		pipeline.Add(g, cfg.SystemPrompt.Order)
+		slog.Info("guardrail registered", "name", "system_prompt", "mode", cfg.SystemPrompt.Mode, "order", cfg.SystemPrompt.Order)
 	}
 
 	return pipeline, nil

--- a/internal/guardrails/guardrails.go
+++ b/internal/guardrails/guardrails.go
@@ -1,0 +1,42 @@
+// Package guardrails provides a pluggable pipeline for request-level guardrails.
+//
+// Guardrails intercept requests before they reach providers, allowing
+// validation, modification, or rejection. They can be executed sequentially
+// (each receives the previous guardrail's output) or in parallel (all run
+// concurrently on the original request, modifications applied in order).
+package guardrails
+
+import (
+	"context"
+
+	"gomodel/internal/core"
+)
+
+// Guardrail processes a request and returns the (possibly modified) request or an error.
+// Returning an error rejects the request before it reaches the provider.
+type Guardrail interface {
+	// Name returns a human-readable identifier for this guardrail.
+	Name() string
+
+	// ProcessChat processes a chat completion request.
+	// Return the (possibly modified) request, or an error to reject it.
+	ProcessChat(ctx context.Context, req *core.ChatRequest) (*core.ChatRequest, error)
+
+	// ProcessResponses processes a Responses API request.
+	// Return the (possibly modified) request, or an error to reject it.
+	ProcessResponses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesRequest, error)
+}
+
+// ExecutionMode defines how guardrails in a pipeline are executed.
+type ExecutionMode string
+
+const (
+	// Sequential runs guardrails one after another; each receives the output
+	// of the previous guardrail. Order matters.
+	Sequential ExecutionMode = "sequential"
+
+	// Parallel runs all guardrails concurrently on the original request.
+	// If any guardrail returns an error, the pipeline fails.
+	// Modifications are applied in registration order after all complete.
+	Parallel ExecutionMode = "parallel"
+)

--- a/internal/guardrails/pipeline.go
+++ b/internal/guardrails/pipeline.go
@@ -3,82 +3,119 @@ package guardrails
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 
 	"gomodel/internal/core"
 )
 
+// entry pairs a guardrail with its execution order.
+type entry struct {
+	guardrail Guardrail
+	order     int
+}
+
 // Pipeline orchestrates the execution of multiple guardrails.
+//
+// Guardrails are grouped by their order value. Groups execute sequentially
+// in ascending order. Within a group, all guardrails run in parallel.
+// If a group contains a single guardrail, it runs directly (no goroutine overhead).
 type Pipeline struct {
-	guardrails []Guardrail
-	mode       ExecutionMode
+	entries []entry
 }
 
-// NewPipeline creates a new guardrails pipeline with the given execution mode.
-func NewPipeline(mode ExecutionMode) *Pipeline {
-	if mode != Parallel {
-		mode = Sequential // default to sequential
-	}
-	return &Pipeline{
-		mode: mode,
-	}
+// NewPipeline creates a new empty guardrails pipeline.
+func NewPipeline() *Pipeline {
+	return &Pipeline{}
 }
 
-// Add appends a guardrail to the pipeline.
-func (p *Pipeline) Add(g Guardrail) {
-	p.guardrails = append(p.guardrails, g)
+// Add appends a guardrail with the given execution order.
+// Guardrails with the same order run in parallel; different orders run sequentially.
+func (p *Pipeline) Add(g Guardrail, order int) {
+	p.entries = append(p.entries, entry{guardrail: g, order: order})
 }
 
 // Len returns the number of guardrails in the pipeline.
 func (p *Pipeline) Len() int {
-	return len(p.guardrails)
+	return len(p.entries)
+}
+
+// groups returns entries grouped by order, sorted by ascending order value.
+// Within each group, entries appear in registration order.
+func (p *Pipeline) groups() [][]entry {
+	if len(p.entries) == 0 {
+		return nil
+	}
+
+	// Stable sort preserves registration order within same order value
+	sorted := make([]entry, len(p.entries))
+	copy(sorted, p.entries)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return sorted[i].order < sorted[j].order
+	})
+
+	var result [][]entry
+	currentOrder := sorted[0].order
+	currentGroup := []entry{sorted[0]}
+
+	for i := 1; i < len(sorted); i++ {
+		if sorted[i].order != currentOrder {
+			result = append(result, currentGroup)
+			currentOrder = sorted[i].order
+			currentGroup = []entry{sorted[i]}
+		} else {
+			currentGroup = append(currentGroup, sorted[i])
+		}
+	}
+	result = append(result, currentGroup)
+	return result
 }
 
 // ProcessChat runs all guardrails on a ChatRequest.
 func (p *Pipeline) ProcessChat(ctx context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
-	if len(p.guardrails) == 0 {
+	groups := p.groups()
+	if len(groups) == 0 {
 		return req, nil
 	}
 
-	if p.mode == Parallel {
-		return p.processChatParallel(ctx, req)
-	}
-	return p.processChatSequential(ctx, req)
-}
-
-// ProcessResponses runs all guardrails on a ResponsesRequest.
-func (p *Pipeline) ProcessResponses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesRequest, error) {
-	if len(p.guardrails) == 0 {
-		return req, nil
-	}
-
-	if p.mode == Parallel {
-		return p.processResponsesParallel(ctx, req)
-	}
-	return p.processResponsesSequential(ctx, req)
-}
-
-// processChatSequential chains guardrails: each receives the output of the previous.
-func (p *Pipeline) processChatSequential(ctx context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
 	current := req
-	for _, g := range p.guardrails {
+	for _, group := range groups {
 		var err error
-		current, err = g.ProcessChat(ctx, current)
-		if err != nil {
-			return nil, fmt.Errorf("guardrail %q: %w", g.Name(), err)
+		if len(group) == 1 {
+			current, err = group[0].guardrail.ProcessChat(ctx, current)
+			if err != nil {
+				return nil, fmt.Errorf("guardrail %q: %w", group[0].guardrail.Name(), err)
+			}
+		} else {
+			current, err = runChatGroupParallel(ctx, group, current)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	return current, nil
 }
 
-// processResponsesSequential chains guardrails: each receives the output of the previous.
-func (p *Pipeline) processResponsesSequential(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesRequest, error) {
+// ProcessResponses runs all guardrails on a ResponsesRequest.
+func (p *Pipeline) ProcessResponses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesRequest, error) {
+	groups := p.groups()
+	if len(groups) == 0 {
+		return req, nil
+	}
+
 	current := req
-	for _, g := range p.guardrails {
+	for _, group := range groups {
 		var err error
-		current, err = g.ProcessResponses(ctx, current)
-		if err != nil {
-			return nil, fmt.Errorf("guardrail %q: %w", g.Name(), err)
+		if len(group) == 1 {
+			current, err = group[0].guardrail.ProcessResponses(ctx, current)
+			if err != nil {
+				return nil, fmt.Errorf("guardrail %q: %w", group[0].guardrail.Name(), err)
+			}
+		} else {
+			current, err = runResponsesGroupParallel(ctx, group, current)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	return current, nil
@@ -86,34 +123,33 @@ func (p *Pipeline) processResponsesSequential(ctx context.Context, req *core.Res
 
 // chatResult holds the result of a parallel guardrail execution for chat.
 type chatResult struct {
-	index int
-	req   *core.ChatRequest
-	err   error
+	req *core.ChatRequest
+	err error
 }
 
-// processChatParallel runs all guardrails concurrently on the original request.
-// If any returns an error, the pipeline fails. Modifications are applied
-// sequentially in registration order after all guardrails complete.
-func (p *Pipeline) processChatParallel(ctx context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
-	results := make([]chatResult, len(p.guardrails))
+// runChatGroupParallel runs all guardrails in a group concurrently on the same input.
+// If any returns an error, the group fails. Modifications are applied
+// in registration order (slice order) after all complete.
+func runChatGroupParallel(ctx context.Context, group []entry, req *core.ChatRequest) (*core.ChatRequest, error) {
+	results := make([]chatResult, len(group))
 	var wg sync.WaitGroup
 
-	for i, g := range p.guardrails {
+	for i, e := range group {
 		wg.Add(1)
-		go func(idx int, guardrail Guardrail) {
+		go func(idx int, g Guardrail) {
 			defer wg.Done()
-			modified, err := guardrail.ProcessChat(ctx, req)
-			results[idx] = chatResult{index: idx, req: modified, err: err}
-		}(i, g)
+			modified, err := g.ProcessChat(ctx, req)
+			results[idx] = chatResult{req: modified, err: err}
+		}(i, e.guardrail)
 	}
 
 	wg.Wait()
 
-	// Check for errors and apply modifications in order
+	// Check for errors and take last successful modification (registration order)
 	current := req
 	for i, r := range results {
 		if r.err != nil {
-			return nil, fmt.Errorf("guardrail %q: %w", p.guardrails[i].Name(), r.err)
+			return nil, fmt.Errorf("guardrail %q: %w", group[i].guardrail.Name(), r.err)
 		}
 		current = r.req
 	}
@@ -122,32 +158,30 @@ func (p *Pipeline) processChatParallel(ctx context.Context, req *core.ChatReques
 
 // responsesResult holds the result of a parallel guardrail execution for responses.
 type responsesResult struct {
-	index int
-	req   *core.ResponsesRequest
-	err   error
+	req *core.ResponsesRequest
+	err error
 }
 
-// processResponsesParallel runs all guardrails concurrently on the original request.
-func (p *Pipeline) processResponsesParallel(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesRequest, error) {
-	results := make([]responsesResult, len(p.guardrails))
+// runResponsesGroupParallel runs all guardrails in a group concurrently on the same input.
+func runResponsesGroupParallel(ctx context.Context, group []entry, req *core.ResponsesRequest) (*core.ResponsesRequest, error) {
+	results := make([]responsesResult, len(group))
 	var wg sync.WaitGroup
 
-	for i, g := range p.guardrails {
+	for i, e := range group {
 		wg.Add(1)
-		go func(idx int, guardrail Guardrail) {
+		go func(idx int, g Guardrail) {
 			defer wg.Done()
-			modified, err := guardrail.ProcessResponses(ctx, req)
-			results[idx] = responsesResult{index: idx, req: modified, err: err}
-		}(i, g)
+			modified, err := g.ProcessResponses(ctx, req)
+			results[idx] = responsesResult{req: modified, err: err}
+		}(i, e.guardrail)
 	}
 
 	wg.Wait()
 
-	// Check for errors and apply modifications in order
 	current := req
 	for i, r := range results {
 		if r.err != nil {
-			return nil, fmt.Errorf("guardrail %q: %w", p.guardrails[i].Name(), r.err)
+			return nil, fmt.Errorf("guardrail %q: %w", group[i].guardrail.Name(), r.err)
 		}
 		current = r.req
 	}

--- a/internal/guardrails/pipeline.go
+++ b/internal/guardrails/pipeline.go
@@ -1,0 +1,155 @@
+package guardrails
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"gomodel/internal/core"
+)
+
+// Pipeline orchestrates the execution of multiple guardrails.
+type Pipeline struct {
+	guardrails []Guardrail
+	mode       ExecutionMode
+}
+
+// NewPipeline creates a new guardrails pipeline with the given execution mode.
+func NewPipeline(mode ExecutionMode) *Pipeline {
+	if mode != Parallel {
+		mode = Sequential // default to sequential
+	}
+	return &Pipeline{
+		mode: mode,
+	}
+}
+
+// Add appends a guardrail to the pipeline.
+func (p *Pipeline) Add(g Guardrail) {
+	p.guardrails = append(p.guardrails, g)
+}
+
+// Len returns the number of guardrails in the pipeline.
+func (p *Pipeline) Len() int {
+	return len(p.guardrails)
+}
+
+// ProcessChat runs all guardrails on a ChatRequest.
+func (p *Pipeline) ProcessChat(ctx context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
+	if len(p.guardrails) == 0 {
+		return req, nil
+	}
+
+	if p.mode == Parallel {
+		return p.processChatParallel(ctx, req)
+	}
+	return p.processChatSequential(ctx, req)
+}
+
+// ProcessResponses runs all guardrails on a ResponsesRequest.
+func (p *Pipeline) ProcessResponses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesRequest, error) {
+	if len(p.guardrails) == 0 {
+		return req, nil
+	}
+
+	if p.mode == Parallel {
+		return p.processResponsesParallel(ctx, req)
+	}
+	return p.processResponsesSequential(ctx, req)
+}
+
+// processChatSequential chains guardrails: each receives the output of the previous.
+func (p *Pipeline) processChatSequential(ctx context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
+	current := req
+	for _, g := range p.guardrails {
+		var err error
+		current, err = g.ProcessChat(ctx, current)
+		if err != nil {
+			return nil, fmt.Errorf("guardrail %q: %w", g.Name(), err)
+		}
+	}
+	return current, nil
+}
+
+// processResponsesSequential chains guardrails: each receives the output of the previous.
+func (p *Pipeline) processResponsesSequential(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesRequest, error) {
+	current := req
+	for _, g := range p.guardrails {
+		var err error
+		current, err = g.ProcessResponses(ctx, current)
+		if err != nil {
+			return nil, fmt.Errorf("guardrail %q: %w", g.Name(), err)
+		}
+	}
+	return current, nil
+}
+
+// chatResult holds the result of a parallel guardrail execution for chat.
+type chatResult struct {
+	index int
+	req   *core.ChatRequest
+	err   error
+}
+
+// processChatParallel runs all guardrails concurrently on the original request.
+// If any returns an error, the pipeline fails. Modifications are applied
+// sequentially in registration order after all guardrails complete.
+func (p *Pipeline) processChatParallel(ctx context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
+	results := make([]chatResult, len(p.guardrails))
+	var wg sync.WaitGroup
+
+	for i, g := range p.guardrails {
+		wg.Add(1)
+		go func(idx int, guardrail Guardrail) {
+			defer wg.Done()
+			modified, err := guardrail.ProcessChat(ctx, req)
+			results[idx] = chatResult{index: idx, req: modified, err: err}
+		}(i, g)
+	}
+
+	wg.Wait()
+
+	// Check for errors and apply modifications in order
+	current := req
+	for i, r := range results {
+		if r.err != nil {
+			return nil, fmt.Errorf("guardrail %q: %w", p.guardrails[i].Name(), r.err)
+		}
+		current = r.req
+	}
+	return current, nil
+}
+
+// responsesResult holds the result of a parallel guardrail execution for responses.
+type responsesResult struct {
+	index int
+	req   *core.ResponsesRequest
+	err   error
+}
+
+// processResponsesParallel runs all guardrails concurrently on the original request.
+func (p *Pipeline) processResponsesParallel(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesRequest, error) {
+	results := make([]responsesResult, len(p.guardrails))
+	var wg sync.WaitGroup
+
+	for i, g := range p.guardrails {
+		wg.Add(1)
+		go func(idx int, guardrail Guardrail) {
+			defer wg.Done()
+			modified, err := guardrail.ProcessResponses(ctx, req)
+			results[idx] = responsesResult{index: idx, req: modified, err: err}
+		}(i, g)
+	}
+
+	wg.Wait()
+
+	// Check for errors and apply modifications in order
+	current := req
+	for i, r := range results {
+		if r.err != nil {
+			return nil, fmt.Errorf("guardrail %q: %w", p.guardrails[i].Name(), r.err)
+		}
+		current = r.req
+	}
+	return current, nil
+}

--- a/internal/guardrails/pipeline_test.go
+++ b/internal/guardrails/pipeline_test.go
@@ -3,15 +3,17 @@ package guardrails
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"gomodel/internal/core"
 )
 
 // mockGuardrail is a test guardrail that can be configured to modify or reject requests.
 type mockGuardrail struct {
-	name       string
-	chatFn     func(ctx context.Context, req *core.ChatRequest) (*core.ChatRequest, error)
+	name        string
+	chatFn      func(ctx context.Context, req *core.ChatRequest) (*core.ChatRequest, error)
 	responsesFn func(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesRequest, error)
 }
 
@@ -32,7 +34,7 @@ func (m *mockGuardrail) ProcessResponses(ctx context.Context, req *core.Response
 }
 
 func TestPipeline_EmptyPipeline(t *testing.T) {
-	p := NewPipeline(Sequential)
+	p := NewPipeline()
 	req := &core.ChatRequest{Model: "gpt-4"}
 
 	result, err := p.ProcessChat(context.Background(), req)
@@ -45,22 +47,22 @@ func TestPipeline_EmptyPipeline(t *testing.T) {
 }
 
 func TestPipeline_Len(t *testing.T) {
-	p := NewPipeline(Sequential)
+	p := NewPipeline()
 	if p.Len() != 0 {
 		t.Errorf("expected 0, got %d", p.Len())
 	}
 
-	p.Add(&mockGuardrail{name: "a"})
-	p.Add(&mockGuardrail{name: "b"})
+	p.Add(&mockGuardrail{name: "a"}, 0)
+	p.Add(&mockGuardrail{name: "b"}, 1)
 	if p.Len() != 2 {
 		t.Errorf("expected 2, got %d", p.Len())
 	}
 }
 
-func TestPipeline_Sequential_Chaining(t *testing.T) {
-	p := NewPipeline(Sequential)
+func TestPipeline_DifferentOrders_RunSequentially(t *testing.T) {
+	p := NewPipeline()
 
-	// First guardrail adds a message
+	// Order 0: adds a system message
 	p.Add(&mockGuardrail{
 		name: "add_system",
 		chatFn: func(_ context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
@@ -69,9 +71,9 @@ func TestPipeline_Sequential_Chaining(t *testing.T) {
 			msgs = append(msgs, req.Messages...)
 			return &core.ChatRequest{Model: req.Model, Messages: msgs}, nil
 		},
-	})
+	}, 0)
 
-	// Second guardrail appends to messages
+	// Order 1: sees output from order 0, appends a message
 	p.Add(&mockGuardrail{
 		name: "add_context",
 		chatFn: func(_ context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
@@ -80,7 +82,7 @@ func TestPipeline_Sequential_Chaining(t *testing.T) {
 			msgs = append(msgs, core.Message{Role: "system", Content: "second"})
 			return &core.ChatRequest{Model: req.Model, Messages: msgs}, nil
 		},
-	})
+	}, 1)
 
 	req := &core.ChatRequest{
 		Model:    "gpt-4",
@@ -92,7 +94,7 @@ func TestPipeline_Sequential_Chaining(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Sequential: first adds system at start, second adds system at end
+	// Sequential: first adds system at start, second sees that and appends at end
 	if len(result.Messages) != 3 {
 		t.Fatalf("expected 3 messages, got %d", len(result.Messages))
 	}
@@ -104,25 +106,116 @@ func TestPipeline_Sequential_Chaining(t *testing.T) {
 	}
 }
 
-func TestPipeline_Sequential_ErrorStopsChain(t *testing.T) {
-	p := NewPipeline(Sequential)
+func TestPipeline_SameOrder_RunInParallel(t *testing.T) {
+	p := NewPipeline()
 
+	var started atomic.Int32
+	barrier := make(chan struct{})
+
+	// Both at order 0 — they should run concurrently
+	for i := range 2 {
+		name := fmt.Sprintf("parallel_%d", i)
+		p.Add(&mockGuardrail{
+			name: name,
+			chatFn: func(_ context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
+				started.Add(1)
+				<-barrier // wait until both have started
+				return req, nil
+			},
+		}, 0)
+	}
+
+	req := &core.ChatRequest{Model: "gpt-4"}
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = p.ProcessChat(context.Background(), req)
+		close(done)
+	}()
+
+	// Wait for both goroutines to start
+	for started.Load() < 2 {
+		time.Sleep(time.Millisecond)
+	}
+	// Both started concurrently — release them
+	close(barrier)
+
+	select {
+	case <-done:
+		// success
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out — guardrails did not run in parallel")
+	}
+}
+
+func TestPipeline_MixedOrders_GroupsExecuteCorrectly(t *testing.T) {
+	p := NewPipeline()
+
+	var trace []string
+
+	// Order 0, guardrail A
+	p.Add(&mockGuardrail{
+		name: "A",
+		chatFn: func(_ context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
+			trace = append(trace, "A")
+			return req, nil
+		},
+	}, 0)
+
+	// Order 1, guardrail B (runs after group 0 completes)
+	p.Add(&mockGuardrail{
+		name: "B",
+		chatFn: func(_ context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
+			trace = append(trace, "B")
+			return req, nil
+		},
+	}, 1)
+
+	// Order 0, guardrail C (parallel with A)
+	p.Add(&mockGuardrail{
+		name: "C",
+		chatFn: func(_ context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
+			// Note: this writes to trace inside a parallel group, so we can't assert
+			// exact ordering of A and C. But B must come after both.
+			return req, nil
+		},
+	}, 0)
+
+	req := &core.ChatRequest{Model: "gpt-4"}
+	_, err := p.ProcessChat(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// B must be last because it's order 1
+	if len(trace) < 2 {
+		t.Fatalf("expected at least 2 trace entries, got %d", len(trace))
+	}
+	if trace[len(trace)-1] != "B" {
+		t.Errorf("expected B to run last (order 1), got trace: %v", trace)
+	}
+}
+
+func TestPipeline_ErrorInGroup_StopsExecution(t *testing.T) {
+	p := NewPipeline()
+
+	// Order 0: error
 	p.Add(&mockGuardrail{
 		name: "blocker",
 		chatFn: func(_ context.Context, _ *core.ChatRequest) (*core.ChatRequest, error) {
 			return nil, fmt.Errorf("blocked")
 		},
-	})
+	}, 0)
 
-	// This should never run
+	// Order 1: should never run
 	called := false
 	p.Add(&mockGuardrail{
-		name: "second",
+		name: "after_blocker",
 		chatFn: func(_ context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
 			called = true
 			return req, nil
 		},
-	})
+	}, 1)
 
 	req := &core.ChatRequest{Model: "gpt-4"}
 	_, err := p.ProcessChat(context.Background(), req)
@@ -130,68 +223,133 @@ func TestPipeline_Sequential_ErrorStopsChain(t *testing.T) {
 		t.Fatal("expected error")
 	}
 	if called {
-		t.Error("second guardrail should not have been called")
+		t.Error("order 1 guardrail should not have run after order 0 error")
 	}
 }
 
-func TestPipeline_Parallel_AllPass(t *testing.T) {
-	p := NewPipeline(Parallel)
+func TestPipeline_ParallelGroup_OneErrors(t *testing.T) {
+	p := NewPipeline()
 
+	// Both at order 0 — one fails
 	p.Add(&mockGuardrail{
-		name: "passthrough1",
+		name: "pass",
 		chatFn: func(_ context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
 			return req, nil
 		},
-	})
+	}, 0)
 	p.Add(&mockGuardrail{
-		name: "passthrough2",
-		chatFn: func(_ context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
-			return req, nil
+		name: "blocker",
+		chatFn: func(_ context.Context, _ *core.ChatRequest) (*core.ChatRequest, error) {
+			return nil, fmt.Errorf("blocked")
 		},
-	})
+	}, 0)
+
+	req := &core.ChatRequest{Model: "gpt-4"}
+	_, err := p.ProcessChat(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error from parallel group")
+	}
+}
+
+func TestPipeline_SingleEntryGroup_NoGoroutineOverhead(t *testing.T) {
+	p := NewPipeline()
+
+	// Single guardrail at order 0 — should run directly, not via goroutine
+	p.Add(&mockGuardrail{
+		name: "single",
+		chatFn: func(_ context.Context, _ *core.ChatRequest) (*core.ChatRequest, error) {
+			return &core.ChatRequest{Model: "modified"}, nil
+		},
+	}, 0)
 
 	req := &core.ChatRequest{Model: "gpt-4"}
 	result, err := p.ProcessChat(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.Model != "gpt-4" {
-		t.Error("model should be preserved")
+	if result.Model != "modified" {
+		t.Errorf("expected 'modified', got %q", result.Model)
 	}
 }
 
-func TestPipeline_Parallel_OneErrors(t *testing.T) {
-	p := NewPipeline(Parallel)
+func TestPipeline_GroupsReceivePreviousOutput(t *testing.T) {
+	p := NewPipeline()
 
+	// Order 0: set model to "step1"
 	p.Add(&mockGuardrail{
-		name: "pass",
+		name: "step1",
+		chatFn: func(_ context.Context, _ *core.ChatRequest) (*core.ChatRequest, error) {
+			return &core.ChatRequest{Model: "step1"}, nil
+		},
+	}, 0)
+
+	// Order 1: verify it received "step1", set to "step2"
+	p.Add(&mockGuardrail{
+		name: "step2",
 		chatFn: func(_ context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
+			if req.Model != "step1" {
+				return nil, fmt.Errorf("expected model 'step1' from previous group, got %q", req.Model)
+			}
+			return &core.ChatRequest{Model: "step2"}, nil
+		},
+	}, 1)
+
+	// Order 2: verify it received "step2"
+	p.Add(&mockGuardrail{
+		name: "step3",
+		chatFn: func(_ context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
+			if req.Model != "step2" {
+				return nil, fmt.Errorf("expected model 'step2' from previous group, got %q", req.Model)
+			}
+			return &core.ChatRequest{Model: "step3"}, nil
+		},
+	}, 2)
+
+	req := &core.ChatRequest{Model: "original"}
+	result, err := p.ProcessChat(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Model != "step3" {
+		t.Errorf("expected 'step3', got %q", result.Model)
+	}
+}
+
+func TestPipeline_NegativeOrders(t *testing.T) {
+	p := NewPipeline()
+
+	var trace []string
+
+	// Negative orders run before 0
+	p.Add(&mockGuardrail{
+		name: "first",
+		chatFn: func(_ context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
+			trace = append(trace, "first")
 			return req, nil
 		},
-	})
+	}, -1)
+
 	p.Add(&mockGuardrail{
-		name: "blocker",
-		chatFn: func(_ context.Context, _ *core.ChatRequest) (*core.ChatRequest, error) {
-			return nil, fmt.Errorf("blocked")
+		name: "second",
+		chatFn: func(_ context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
+			trace = append(trace, "second")
+			return req, nil
 		},
-	})
+	}, 0)
 
 	req := &core.ChatRequest{Model: "gpt-4"}
 	_, err := p.ProcessChat(context.Background(), req)
-	if err == nil {
-		t.Fatal("expected error from parallel pipeline")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(trace) != 2 || trace[0] != "first" || trace[1] != "second" {
+		t.Errorf("expected [first, second], got %v", trace)
 	}
 }
 
-func TestPipeline_DefaultsToSequential(t *testing.T) {
-	p := NewPipeline("invalid")
-	if p.mode != Sequential {
-		t.Errorf("expected default sequential mode, got %q", p.mode)
-	}
-}
-
-func TestPipeline_Responses_Sequential(t *testing.T) {
-	p := NewPipeline(Sequential)
+func TestPipeline_Responses_DifferentOrders(t *testing.T) {
+	p := NewPipeline()
 
 	p.Add(&mockGuardrail{
 		name: "set_instructions",
@@ -202,7 +360,17 @@ func TestPipeline_Responses_Sequential(t *testing.T) {
 				Instructions: "from guardrail",
 			}, nil
 		},
-	})
+	}, 0)
+
+	p.Add(&mockGuardrail{
+		name: "verify",
+		responsesFn: func(_ context.Context, req *core.ResponsesRequest) (*core.ResponsesRequest, error) {
+			if req.Instructions != "from guardrail" {
+				return nil, fmt.Errorf("expected instructions from previous group")
+			}
+			return req, nil
+		},
+	}, 1)
 
 	req := &core.ResponsesRequest{Model: "gpt-4", Input: "hello"}
 	result, err := p.ProcessResponses(context.Background(), req)
@@ -214,25 +382,63 @@ func TestPipeline_Responses_Sequential(t *testing.T) {
 	}
 }
 
-func TestPipeline_Responses_Parallel_OneErrors(t *testing.T) {
-	p := NewPipeline(Parallel)
+func TestPipeline_Responses_ParallelGroup_OneErrors(t *testing.T) {
+	p := NewPipeline()
 
 	p.Add(&mockGuardrail{
 		name: "pass",
 		responsesFn: func(_ context.Context, req *core.ResponsesRequest) (*core.ResponsesRequest, error) {
 			return req, nil
 		},
-	})
+	}, 0)
 	p.Add(&mockGuardrail{
 		name: "blocker",
 		responsesFn: func(_ context.Context, _ *core.ResponsesRequest) (*core.ResponsesRequest, error) {
 			return nil, fmt.Errorf("blocked")
 		},
-	})
+	}, 0)
 
 	req := &core.ResponsesRequest{Model: "gpt-4", Input: "hello"}
 	_, err := p.ProcessResponses(context.Background(), req)
 	if err == nil {
 		t.Fatal("expected error from parallel pipeline")
 	}
+}
+
+func TestPipeline_Groups_InternalOrdering(t *testing.T) {
+	p := NewPipeline()
+
+	// Verify groups() returns correct structure
+	p.Add(&mockGuardrail{name: "a"}, 2)
+	p.Add(&mockGuardrail{name: "b"}, 0)
+	p.Add(&mockGuardrail{name: "c"}, 2)
+	p.Add(&mockGuardrail{name: "d"}, 1)
+
+	groups := p.groups()
+	if len(groups) != 3 {
+		t.Fatalf("expected 3 groups, got %d", len(groups))
+	}
+
+	// Group 0: order 0 → [b]
+	if len(groups[0]) != 1 || groups[0][0].guardrail.Name() != "b" {
+		t.Errorf("group 0 should be [b], got %v", groupNames(groups[0]))
+	}
+
+	// Group 1: order 1 → [d]
+	if len(groups[1]) != 1 || groups[1][0].guardrail.Name() != "d" {
+		t.Errorf("group 1 should be [d], got %v", groupNames(groups[1]))
+	}
+
+	// Group 2: order 2 → [a, c] (registration order preserved)
+	if len(groups[2]) != 2 || groups[2][0].guardrail.Name() != "a" || groups[2][1].guardrail.Name() != "c" {
+		t.Errorf("group 2 should be [a, c], got %v", groupNames(groups[2]))
+	}
+}
+
+func groupNames(group []entry) []string {
+	names := make([]string, len(group))
+	for i, e := range group {
+		names[i] = e.guardrail.Name()
+	}
+	return names
 }

--- a/internal/guardrails/pipeline_test.go
+++ b/internal/guardrails/pipeline_test.go
@@ -1,0 +1,238 @@
+package guardrails
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"gomodel/internal/core"
+)
+
+// mockGuardrail is a test guardrail that can be configured to modify or reject requests.
+type mockGuardrail struct {
+	name       string
+	chatFn     func(ctx context.Context, req *core.ChatRequest) (*core.ChatRequest, error)
+	responsesFn func(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesRequest, error)
+}
+
+func (m *mockGuardrail) Name() string { return m.name }
+
+func (m *mockGuardrail) ProcessChat(ctx context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
+	if m.chatFn != nil {
+		return m.chatFn(ctx, req)
+	}
+	return req, nil
+}
+
+func (m *mockGuardrail) ProcessResponses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesRequest, error) {
+	if m.responsesFn != nil {
+		return m.responsesFn(ctx, req)
+	}
+	return req, nil
+}
+
+func TestPipeline_EmptyPipeline(t *testing.T) {
+	p := NewPipeline(Sequential)
+	req := &core.ChatRequest{Model: "gpt-4"}
+
+	result, err := p.ProcessChat(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != req {
+		t.Error("empty pipeline should return the same request")
+	}
+}
+
+func TestPipeline_Len(t *testing.T) {
+	p := NewPipeline(Sequential)
+	if p.Len() != 0 {
+		t.Errorf("expected 0, got %d", p.Len())
+	}
+
+	p.Add(&mockGuardrail{name: "a"})
+	p.Add(&mockGuardrail{name: "b"})
+	if p.Len() != 2 {
+		t.Errorf("expected 2, got %d", p.Len())
+	}
+}
+
+func TestPipeline_Sequential_Chaining(t *testing.T) {
+	p := NewPipeline(Sequential)
+
+	// First guardrail adds a message
+	p.Add(&mockGuardrail{
+		name: "add_system",
+		chatFn: func(_ context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
+			msgs := make([]core.Message, 0, len(req.Messages)+1)
+			msgs = append(msgs, core.Message{Role: "system", Content: "first"})
+			msgs = append(msgs, req.Messages...)
+			return &core.ChatRequest{Model: req.Model, Messages: msgs}, nil
+		},
+	})
+
+	// Second guardrail appends to messages
+	p.Add(&mockGuardrail{
+		name: "add_context",
+		chatFn: func(_ context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
+			msgs := make([]core.Message, len(req.Messages))
+			copy(msgs, req.Messages)
+			msgs = append(msgs, core.Message{Role: "system", Content: "second"})
+			return &core.ChatRequest{Model: req.Model, Messages: msgs}, nil
+		},
+	})
+
+	req := &core.ChatRequest{
+		Model:    "gpt-4",
+		Messages: []core.Message{{Role: "user", Content: "hello"}},
+	}
+
+	result, err := p.ProcessChat(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Sequential: first adds system at start, second adds system at end
+	if len(result.Messages) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(result.Messages))
+	}
+	if result.Messages[0].Content != "first" {
+		t.Errorf("expected first guardrail output, got %q", result.Messages[0].Content)
+	}
+	if result.Messages[2].Content != "second" {
+		t.Errorf("expected second guardrail output, got %q", result.Messages[2].Content)
+	}
+}
+
+func TestPipeline_Sequential_ErrorStopsChain(t *testing.T) {
+	p := NewPipeline(Sequential)
+
+	p.Add(&mockGuardrail{
+		name: "blocker",
+		chatFn: func(_ context.Context, _ *core.ChatRequest) (*core.ChatRequest, error) {
+			return nil, fmt.Errorf("blocked")
+		},
+	})
+
+	// This should never run
+	called := false
+	p.Add(&mockGuardrail{
+		name: "second",
+		chatFn: func(_ context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
+			called = true
+			return req, nil
+		},
+	})
+
+	req := &core.ChatRequest{Model: "gpt-4"}
+	_, err := p.ProcessChat(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if called {
+		t.Error("second guardrail should not have been called")
+	}
+}
+
+func TestPipeline_Parallel_AllPass(t *testing.T) {
+	p := NewPipeline(Parallel)
+
+	p.Add(&mockGuardrail{
+		name: "passthrough1",
+		chatFn: func(_ context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
+			return req, nil
+		},
+	})
+	p.Add(&mockGuardrail{
+		name: "passthrough2",
+		chatFn: func(_ context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
+			return req, nil
+		},
+	})
+
+	req := &core.ChatRequest{Model: "gpt-4"}
+	result, err := p.ProcessChat(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Model != "gpt-4" {
+		t.Error("model should be preserved")
+	}
+}
+
+func TestPipeline_Parallel_OneErrors(t *testing.T) {
+	p := NewPipeline(Parallel)
+
+	p.Add(&mockGuardrail{
+		name: "pass",
+		chatFn: func(_ context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
+			return req, nil
+		},
+	})
+	p.Add(&mockGuardrail{
+		name: "blocker",
+		chatFn: func(_ context.Context, _ *core.ChatRequest) (*core.ChatRequest, error) {
+			return nil, fmt.Errorf("blocked")
+		},
+	})
+
+	req := &core.ChatRequest{Model: "gpt-4"}
+	_, err := p.ProcessChat(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error from parallel pipeline")
+	}
+}
+
+func TestPipeline_DefaultsToSequential(t *testing.T) {
+	p := NewPipeline("invalid")
+	if p.mode != Sequential {
+		t.Errorf("expected default sequential mode, got %q", p.mode)
+	}
+}
+
+func TestPipeline_Responses_Sequential(t *testing.T) {
+	p := NewPipeline(Sequential)
+
+	p.Add(&mockGuardrail{
+		name: "set_instructions",
+		responsesFn: func(_ context.Context, req *core.ResponsesRequest) (*core.ResponsesRequest, error) {
+			return &core.ResponsesRequest{
+				Model:        req.Model,
+				Input:        req.Input,
+				Instructions: "from guardrail",
+			}, nil
+		},
+	})
+
+	req := &core.ResponsesRequest{Model: "gpt-4", Input: "hello"}
+	result, err := p.ProcessResponses(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Instructions != "from guardrail" {
+		t.Errorf("expected instructions from guardrail, got %q", result.Instructions)
+	}
+}
+
+func TestPipeline_Responses_Parallel_OneErrors(t *testing.T) {
+	p := NewPipeline(Parallel)
+
+	p.Add(&mockGuardrail{
+		name: "pass",
+		responsesFn: func(_ context.Context, req *core.ResponsesRequest) (*core.ResponsesRequest, error) {
+			return req, nil
+		},
+	})
+	p.Add(&mockGuardrail{
+		name: "blocker",
+		responsesFn: func(_ context.Context, _ *core.ResponsesRequest) (*core.ResponsesRequest, error) {
+			return nil, fmt.Errorf("blocked")
+		},
+	})
+
+	req := &core.ResponsesRequest{Model: "gpt-4", Input: "hello"}
+	_, err := p.ProcessResponses(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error from parallel pipeline")
+	}
+}

--- a/internal/guardrails/provider.go
+++ b/internal/guardrails/provider.go
@@ -1,0 +1,75 @@
+package guardrails
+
+import (
+	"context"
+	"io"
+
+	"gomodel/internal/core"
+)
+
+// GuardedProvider wraps a RoutableProvider and applies the guardrails pipeline
+// before routing requests to providers. It implements core.RoutableProvider.
+type GuardedProvider struct {
+	inner    core.RoutableProvider
+	pipeline *Pipeline
+}
+
+// NewGuardedProvider creates a RoutableProvider that applies guardrails
+// before delegating to the inner provider.
+func NewGuardedProvider(inner core.RoutableProvider, pipeline *Pipeline) *GuardedProvider {
+	return &GuardedProvider{
+		inner:    inner,
+		pipeline: pipeline,
+	}
+}
+
+// Supports delegates to the inner provider.
+func (g *GuardedProvider) Supports(model string) bool {
+	return g.inner.Supports(model)
+}
+
+// GetProviderType delegates to the inner provider.
+func (g *GuardedProvider) GetProviderType(model string) string {
+	return g.inner.GetProviderType(model)
+}
+
+// ChatCompletion applies guardrails then routes the request.
+func (g *GuardedProvider) ChatCompletion(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+	modified, err := g.pipeline.ProcessChat(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return g.inner.ChatCompletion(ctx, modified)
+}
+
+// StreamChatCompletion applies guardrails then routes the streaming request.
+func (g *GuardedProvider) StreamChatCompletion(ctx context.Context, req *core.ChatRequest) (io.ReadCloser, error) {
+	modified, err := g.pipeline.ProcessChat(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return g.inner.StreamChatCompletion(ctx, modified)
+}
+
+// ListModels delegates directly to the inner provider (no guardrails needed).
+func (g *GuardedProvider) ListModels(ctx context.Context) (*core.ModelsResponse, error) {
+	return g.inner.ListModels(ctx)
+}
+
+// Responses applies guardrails then routes the request.
+func (g *GuardedProvider) Responses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
+	modified, err := g.pipeline.ProcessResponses(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return g.inner.Responses(ctx, modified)
+}
+
+// StreamResponses applies guardrails then routes the streaming request.
+func (g *GuardedProvider) StreamResponses(ctx context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
+	modified, err := g.pipeline.ProcessResponses(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return g.inner.StreamResponses(ctx, modified)
+}

--- a/internal/guardrails/provider_test.go
+++ b/internal/guardrails/provider_test.go
@@ -11,10 +11,10 @@ import (
 
 // mockRoutableProvider is a test double for core.RoutableProvider.
 type mockRoutableProvider struct {
-	supportsFn       func(model string) bool
+	supportsFn        func(model string) bool
 	getProviderTypeFn func(model string) string
-	chatReq          *core.ChatRequest
-	responsesReq     *core.ResponsesRequest
+	chatReq           *core.ChatRequest
+	responsesReq      *core.ResponsesRequest
 }
 
 func (m *mockRoutableProvider) Supports(model string) bool {
@@ -54,6 +54,8 @@ func (m *mockRoutableProvider) StreamResponses(_ context.Context, req *core.Resp
 	m.responsesReq = req
 	return io.NopCloser(strings.NewReader("data: test\n\n")), nil
 }
+
+// --- Chat adapter integration tests ---
 
 func TestGuardedProvider_ChatCompletion_AppliesGuardrails(t *testing.T) {
 	inner := &mockRoutableProvider{}
@@ -114,6 +116,51 @@ func TestGuardedProvider_StreamChatCompletion_AppliesGuardrails(t *testing.T) {
 	}
 }
 
+func TestGuardedProvider_ChatPreservesFields(t *testing.T) {
+	inner := &mockRoutableProvider{}
+	pipeline := NewPipeline()
+
+	g, _ := NewSystemPromptGuardrail("test", SystemPromptInject, "system")
+	pipeline.Add(g, 0)
+
+	guarded := NewGuardedProvider(inner, pipeline)
+
+	temp := 0.7
+	maxTok := 100
+	req := &core.ChatRequest{
+		Model:       "gpt-4",
+		Temperature: &temp,
+		MaxTokens:   &maxTok,
+		Messages:    []core.Message{{Role: "user", Content: "hello"}},
+		Stream:      true,
+		Reasoning:   &core.Reasoning{Effort: "high"},
+	}
+
+	_, err := guarded.ChatCompletion(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := inner.chatReq
+	if got.Model != "gpt-4" {
+		t.Errorf("model not preserved")
+	}
+	if got.Temperature == nil || *got.Temperature != 0.7 {
+		t.Errorf("temperature not preserved")
+	}
+	if got.MaxTokens == nil || *got.MaxTokens != 100 {
+		t.Errorf("max_tokens not preserved")
+	}
+	if !got.Stream {
+		t.Errorf("stream not preserved")
+	}
+	if got.Reasoning == nil || got.Reasoning.Effort != "high" {
+		t.Errorf("reasoning not preserved")
+	}
+}
+
+// --- Responses adapter integration tests ---
+
 func TestGuardedProvider_Responses_AppliesGuardrails(t *testing.T) {
 	inner := &mockRoutableProvider{}
 	pipeline := NewPipeline()
@@ -160,6 +207,136 @@ func TestGuardedProvider_StreamResponses_AppliesGuardrails(t *testing.T) {
 		t.Errorf("expected decorated instructions, got %q", inner.responsesReq.Instructions)
 	}
 }
+
+func TestGuardedProvider_ResponsesPreservesFields(t *testing.T) {
+	inner := &mockRoutableProvider{}
+	pipeline := NewPipeline()
+
+	g, _ := NewSystemPromptGuardrail("test", SystemPromptInject, "system")
+	pipeline.Add(g, 0)
+
+	guarded := NewGuardedProvider(inner, pipeline)
+
+	temp := 0.5
+	maxTok := 200
+	req := &core.ResponsesRequest{
+		Model:           "gpt-4",
+		Input:           "hello",
+		Temperature:     &temp,
+		MaxOutputTokens: &maxTok,
+		Tools:           []map[string]any{{"type": "function"}},
+		Metadata:        map[string]string{"key": "val"},
+		Reasoning:       &core.Reasoning{Effort: "medium"},
+	}
+
+	_, err := guarded.Responses(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := inner.responsesReq
+	if got.Model != "gpt-4" {
+		t.Errorf("model not preserved")
+	}
+	if got.Temperature == nil || *got.Temperature != 0.5 {
+		t.Errorf("temperature not preserved")
+	}
+	if got.MaxOutputTokens == nil || *got.MaxOutputTokens != 200 {
+		t.Errorf("max_output_tokens not preserved")
+	}
+	if got.Input != "hello" {
+		t.Errorf("input not preserved")
+	}
+	if len(got.Tools) != 1 {
+		t.Errorf("tools not preserved")
+	}
+	if got.Metadata["key"] != "val" {
+		t.Errorf("metadata not preserved")
+	}
+	if got.Reasoning == nil || got.Reasoning.Effort != "medium" {
+		t.Errorf("reasoning not preserved")
+	}
+}
+
+func TestGuardedProvider_Responses_OverrideClearsExisting(t *testing.T) {
+	inner := &mockRoutableProvider{}
+	pipeline := NewPipeline()
+
+	g, _ := NewSystemPromptGuardrail("test", SystemPromptOverride, "new instructions")
+	pipeline.Add(g, 0)
+
+	guarded := NewGuardedProvider(inner, pipeline)
+
+	req := &core.ResponsesRequest{
+		Model:        "gpt-4",
+		Input:        "hello",
+		Instructions: "old instructions",
+	}
+
+	_, err := guarded.Responses(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if inner.responsesReq.Instructions != "new instructions" {
+		t.Errorf("expected override, got %q", inner.responsesReq.Instructions)
+	}
+}
+
+func TestGuardedProvider_Responses_InjectSkipsExisting(t *testing.T) {
+	inner := &mockRoutableProvider{}
+	pipeline := NewPipeline()
+
+	g, _ := NewSystemPromptGuardrail("test", SystemPromptInject, "injected")
+	pipeline.Add(g, 0)
+
+	guarded := NewGuardedProvider(inner, pipeline)
+
+	req := &core.ResponsesRequest{
+		Model:        "gpt-4",
+		Input:        "hello",
+		Instructions: "existing",
+	}
+
+	_, err := guarded.Responses(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if inner.responsesReq.Instructions != "existing" {
+		t.Errorf("inject should not change existing instructions, got %q", inner.responsesReq.Instructions)
+	}
+}
+
+func TestGuardedProvider_DoesNotMutateOriginalRequest(t *testing.T) {
+	inner := &mockRoutableProvider{}
+	pipeline := NewPipeline()
+
+	g, _ := NewSystemPromptGuardrail("test", SystemPromptOverride, "new")
+	pipeline.Add(g, 0)
+
+	guarded := NewGuardedProvider(inner, pipeline)
+
+	req := &core.ChatRequest{
+		Model: "gpt-4",
+		Messages: []core.Message{
+			{Role: "system", Content: "original"},
+			{Role: "user", Content: "hello"},
+		},
+	}
+
+	_, err := guarded.ChatCompletion(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Original request must be untouched
+	if req.Messages[0].Content != "original" {
+		t.Error("original request was mutated")
+	}
+}
+
+// --- Delegation tests ---
 
 func TestGuardedProvider_ListModels_NoGuardrails(t *testing.T) {
 	inner := &mockRoutableProvider{}
@@ -211,7 +388,7 @@ func TestGuardedProvider_GuardrailError_BlocksRequest(t *testing.T) {
 	pipeline := NewPipeline()
 	pipeline.Add(&mockGuardrail{
 		name: "blocker",
-		chatFn: func(_ context.Context, _ *core.ChatRequest) (*core.ChatRequest, error) {
+		processFn: func(_ context.Context, _ []Message) ([]Message, error) {
 			return nil, core.NewInvalidRequestError("guardrail violation", nil)
 		},
 	}, 0)
@@ -231,5 +408,78 @@ func TestGuardedProvider_GuardrailError_BlocksRequest(t *testing.T) {
 	// Inner provider should not have been called
 	if inner.chatReq != nil {
 		t.Error("inner provider should not have been called when guardrail blocks")
+	}
+}
+
+// --- Adapter unit tests ---
+
+func TestChatToMessages(t *testing.T) {
+	req := &core.ChatRequest{
+		Model: "gpt-4",
+		Messages: []core.Message{
+			{Role: "system", Content: "sys"},
+			{Role: "user", Content: "hello"},
+		},
+	}
+	msgs := chatToMessages(req)
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgs))
+	}
+	if msgs[0].Role != "system" || msgs[0].Content != "sys" {
+		t.Errorf("unexpected first message: %+v", msgs[0])
+	}
+	if msgs[1].Role != "user" || msgs[1].Content != "hello" {
+		t.Errorf("unexpected second message: %+v", msgs[1])
+	}
+}
+
+func TestResponsesToMessages_WithInstructions(t *testing.T) {
+	req := &core.ResponsesRequest{
+		Model:        "gpt-4",
+		Input:        "hello",
+		Instructions: "be helpful",
+	}
+	msgs := responsesToMessages(req)
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if msgs[0].Role != "system" || msgs[0].Content != "be helpful" {
+		t.Errorf("unexpected message: %+v", msgs[0])
+	}
+}
+
+func TestResponsesToMessages_NoInstructions(t *testing.T) {
+	req := &core.ResponsesRequest{Model: "gpt-4", Input: "hello"}
+	msgs := responsesToMessages(req)
+	if len(msgs) != 0 {
+		t.Errorf("expected 0 messages, got %d", len(msgs))
+	}
+}
+
+func TestApplyMessagesToResponses_SystemToInstructions(t *testing.T) {
+	req := &core.ResponsesRequest{Model: "gpt-4", Input: "hello"}
+	msgs := []Message{
+		{Role: "system", Content: "new instructions"},
+	}
+	result := applyMessagesToResponses(req, msgs)
+	if result.Instructions != "new instructions" {
+		t.Errorf("expected 'new instructions', got %q", result.Instructions)
+	}
+	// Original untouched
+	if req.Instructions != "" {
+		t.Error("original request was mutated")
+	}
+}
+
+func TestApplyMessagesToResponses_NoSystem_ClearsInstructions(t *testing.T) {
+	req := &core.ResponsesRequest{
+		Model:        "gpt-4",
+		Input:        "hello",
+		Instructions: "old",
+	}
+	msgs := []Message{} // no system messages
+	result := applyMessagesToResponses(req, msgs)
+	if result.Instructions != "" {
+		t.Errorf("expected empty instructions, got %q", result.Instructions)
 	}
 }

--- a/internal/guardrails/provider_test.go
+++ b/internal/guardrails/provider_test.go
@@ -1,0 +1,235 @@
+package guardrails
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"gomodel/internal/core"
+)
+
+// mockRoutableProvider is a test double for core.RoutableProvider.
+type mockRoutableProvider struct {
+	supportsFn       func(model string) bool
+	getProviderTypeFn func(model string) string
+	chatReq          *core.ChatRequest
+	responsesReq     *core.ResponsesRequest
+}
+
+func (m *mockRoutableProvider) Supports(model string) bool {
+	if m.supportsFn != nil {
+		return m.supportsFn(model)
+	}
+	return true
+}
+
+func (m *mockRoutableProvider) GetProviderType(model string) string {
+	if m.getProviderTypeFn != nil {
+		return m.getProviderTypeFn(model)
+	}
+	return "mock"
+}
+
+func (m *mockRoutableProvider) ChatCompletion(_ context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+	m.chatReq = req
+	return &core.ChatResponse{Model: req.Model}, nil
+}
+
+func (m *mockRoutableProvider) StreamChatCompletion(_ context.Context, req *core.ChatRequest) (io.ReadCloser, error) {
+	m.chatReq = req
+	return io.NopCloser(strings.NewReader("data: test\n\n")), nil
+}
+
+func (m *mockRoutableProvider) ListModels(_ context.Context) (*core.ModelsResponse, error) {
+	return &core.ModelsResponse{Object: "list"}, nil
+}
+
+func (m *mockRoutableProvider) Responses(_ context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
+	m.responsesReq = req
+	return &core.ResponsesResponse{Model: req.Model}, nil
+}
+
+func (m *mockRoutableProvider) StreamResponses(_ context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
+	m.responsesReq = req
+	return io.NopCloser(strings.NewReader("data: test\n\n")), nil
+}
+
+func TestGuardedProvider_ChatCompletion_AppliesGuardrails(t *testing.T) {
+	inner := &mockRoutableProvider{}
+	pipeline := NewPipeline(Sequential)
+
+	g, _ := NewSystemPromptGuardrail(SystemPromptInject, "guardrail system")
+	pipeline.Add(g)
+
+	guarded := NewGuardedProvider(inner, pipeline)
+
+	req := &core.ChatRequest{
+		Model:    "gpt-4",
+		Messages: []core.Message{{Role: "user", Content: "hello"}},
+	}
+
+	_, err := guarded.ChatCompletion(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the inner provider received the modified request
+	if inner.chatReq == nil {
+		t.Fatal("inner provider was not called")
+	}
+	if len(inner.chatReq.Messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(inner.chatReq.Messages))
+	}
+	if inner.chatReq.Messages[0].Role != "system" || inner.chatReq.Messages[0].Content != "guardrail system" {
+		t.Errorf("expected injected system message, got %+v", inner.chatReq.Messages[0])
+	}
+}
+
+func TestGuardedProvider_StreamChatCompletion_AppliesGuardrails(t *testing.T) {
+	inner := &mockRoutableProvider{}
+	pipeline := NewPipeline(Sequential)
+
+	g, _ := NewSystemPromptGuardrail(SystemPromptOverride, "override system")
+	pipeline.Add(g)
+
+	guarded := NewGuardedProvider(inner, pipeline)
+
+	req := &core.ChatRequest{
+		Model: "gpt-4",
+		Messages: []core.Message{
+			{Role: "system", Content: "original"},
+			{Role: "user", Content: "hello"},
+		},
+	}
+
+	stream, err := guarded.StreamChatCompletion(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stream.Close()
+
+	if inner.chatReq.Messages[0].Content != "override system" {
+		t.Errorf("expected override, got %q", inner.chatReq.Messages[0].Content)
+	}
+}
+
+func TestGuardedProvider_Responses_AppliesGuardrails(t *testing.T) {
+	inner := &mockRoutableProvider{}
+	pipeline := NewPipeline(Sequential)
+
+	g, _ := NewSystemPromptGuardrail(SystemPromptInject, "guardrail instructions")
+	pipeline.Add(g)
+
+	guarded := NewGuardedProvider(inner, pipeline)
+
+	req := &core.ResponsesRequest{Model: "gpt-4", Input: "hello"}
+
+	_, err := guarded.Responses(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if inner.responsesReq.Instructions != "guardrail instructions" {
+		t.Errorf("expected injected instructions, got %q", inner.responsesReq.Instructions)
+	}
+}
+
+func TestGuardedProvider_StreamResponses_AppliesGuardrails(t *testing.T) {
+	inner := &mockRoutableProvider{}
+	pipeline := NewPipeline(Sequential)
+
+	g, _ := NewSystemPromptGuardrail(SystemPromptDecorator, "prefix")
+	pipeline.Add(g)
+
+	guarded := NewGuardedProvider(inner, pipeline)
+
+	req := &core.ResponsesRequest{
+		Model:        "gpt-4",
+		Input:        "hello",
+		Instructions: "existing",
+	}
+
+	stream, err := guarded.StreamResponses(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stream.Close()
+
+	if inner.responsesReq.Instructions != "prefix\nexisting" {
+		t.Errorf("expected decorated instructions, got %q", inner.responsesReq.Instructions)
+	}
+}
+
+func TestGuardedProvider_ListModels_NoGuardrails(t *testing.T) {
+	inner := &mockRoutableProvider{}
+	pipeline := NewPipeline(Sequential)
+	guarded := NewGuardedProvider(inner, pipeline)
+
+	resp, err := guarded.ListModels(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Object != "list" {
+		t.Errorf("expected 'list', got %q", resp.Object)
+	}
+}
+
+func TestGuardedProvider_DelegatesSupports(t *testing.T) {
+	inner := &mockRoutableProvider{
+		supportsFn: func(model string) bool {
+			return model == "gpt-4"
+		},
+	}
+	pipeline := NewPipeline(Sequential)
+	guarded := NewGuardedProvider(inner, pipeline)
+
+	if !guarded.Supports("gpt-4") {
+		t.Error("expected Supports to return true for gpt-4")
+	}
+	if guarded.Supports("unknown") {
+		t.Error("expected Supports to return false for unknown")
+	}
+}
+
+func TestGuardedProvider_DelegatesGetProviderType(t *testing.T) {
+	inner := &mockRoutableProvider{
+		getProviderTypeFn: func(_ string) string {
+			return "openai"
+		},
+	}
+	pipeline := NewPipeline(Sequential)
+	guarded := NewGuardedProvider(inner, pipeline)
+
+	if guarded.GetProviderType("gpt-4") != "openai" {
+		t.Errorf("expected 'openai', got %q", guarded.GetProviderType("gpt-4"))
+	}
+}
+
+func TestGuardedProvider_GuardrailError_BlocksRequest(t *testing.T) {
+	inner := &mockRoutableProvider{}
+	pipeline := NewPipeline(Sequential)
+	pipeline.Add(&mockGuardrail{
+		name: "blocker",
+		chatFn: func(_ context.Context, _ *core.ChatRequest) (*core.ChatRequest, error) {
+			return nil, core.NewInvalidRequestError("guardrail violation", nil)
+		},
+	})
+
+	guarded := NewGuardedProvider(inner, pipeline)
+
+	req := &core.ChatRequest{
+		Model:    "gpt-4",
+		Messages: []core.Message{{Role: "user", Content: "hello"}},
+	}
+
+	_, err := guarded.ChatCompletion(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error from guardrail")
+	}
+
+	// Inner provider should not have been called
+	if inner.chatReq != nil {
+		t.Error("inner provider should not have been called when guardrail blocks")
+	}
+}

--- a/internal/guardrails/provider_test.go
+++ b/internal/guardrails/provider_test.go
@@ -57,10 +57,10 @@ func (m *mockRoutableProvider) StreamResponses(_ context.Context, req *core.Resp
 
 func TestGuardedProvider_ChatCompletion_AppliesGuardrails(t *testing.T) {
 	inner := &mockRoutableProvider{}
-	pipeline := NewPipeline(Sequential)
+	pipeline := NewPipeline()
 
 	g, _ := NewSystemPromptGuardrail(SystemPromptInject, "guardrail system")
-	pipeline.Add(g)
+	pipeline.Add(g, 0)
 
 	guarded := NewGuardedProvider(inner, pipeline)
 
@@ -88,10 +88,10 @@ func TestGuardedProvider_ChatCompletion_AppliesGuardrails(t *testing.T) {
 
 func TestGuardedProvider_StreamChatCompletion_AppliesGuardrails(t *testing.T) {
 	inner := &mockRoutableProvider{}
-	pipeline := NewPipeline(Sequential)
+	pipeline := NewPipeline()
 
 	g, _ := NewSystemPromptGuardrail(SystemPromptOverride, "override system")
-	pipeline.Add(g)
+	pipeline.Add(g, 0)
 
 	guarded := NewGuardedProvider(inner, pipeline)
 
@@ -116,10 +116,10 @@ func TestGuardedProvider_StreamChatCompletion_AppliesGuardrails(t *testing.T) {
 
 func TestGuardedProvider_Responses_AppliesGuardrails(t *testing.T) {
 	inner := &mockRoutableProvider{}
-	pipeline := NewPipeline(Sequential)
+	pipeline := NewPipeline()
 
 	g, _ := NewSystemPromptGuardrail(SystemPromptInject, "guardrail instructions")
-	pipeline.Add(g)
+	pipeline.Add(g, 0)
 
 	guarded := NewGuardedProvider(inner, pipeline)
 
@@ -137,10 +137,10 @@ func TestGuardedProvider_Responses_AppliesGuardrails(t *testing.T) {
 
 func TestGuardedProvider_StreamResponses_AppliesGuardrails(t *testing.T) {
 	inner := &mockRoutableProvider{}
-	pipeline := NewPipeline(Sequential)
+	pipeline := NewPipeline()
 
 	g, _ := NewSystemPromptGuardrail(SystemPromptDecorator, "prefix")
-	pipeline.Add(g)
+	pipeline.Add(g, 0)
 
 	guarded := NewGuardedProvider(inner, pipeline)
 
@@ -163,7 +163,7 @@ func TestGuardedProvider_StreamResponses_AppliesGuardrails(t *testing.T) {
 
 func TestGuardedProvider_ListModels_NoGuardrails(t *testing.T) {
 	inner := &mockRoutableProvider{}
-	pipeline := NewPipeline(Sequential)
+	pipeline := NewPipeline()
 	guarded := NewGuardedProvider(inner, pipeline)
 
 	resp, err := guarded.ListModels(context.Background())
@@ -181,7 +181,7 @@ func TestGuardedProvider_DelegatesSupports(t *testing.T) {
 			return model == "gpt-4"
 		},
 	}
-	pipeline := NewPipeline(Sequential)
+	pipeline := NewPipeline()
 	guarded := NewGuardedProvider(inner, pipeline)
 
 	if !guarded.Supports("gpt-4") {
@@ -198,7 +198,7 @@ func TestGuardedProvider_DelegatesGetProviderType(t *testing.T) {
 			return "openai"
 		},
 	}
-	pipeline := NewPipeline(Sequential)
+	pipeline := NewPipeline()
 	guarded := NewGuardedProvider(inner, pipeline)
 
 	if guarded.GetProviderType("gpt-4") != "openai" {
@@ -208,13 +208,13 @@ func TestGuardedProvider_DelegatesGetProviderType(t *testing.T) {
 
 func TestGuardedProvider_GuardrailError_BlocksRequest(t *testing.T) {
 	inner := &mockRoutableProvider{}
-	pipeline := NewPipeline(Sequential)
+	pipeline := NewPipeline()
 	pipeline.Add(&mockGuardrail{
 		name: "blocker",
 		chatFn: func(_ context.Context, _ *core.ChatRequest) (*core.ChatRequest, error) {
 			return nil, core.NewInvalidRequestError("guardrail violation", nil)
 		},
-	})
+	}, 0)
 
 	guarded := NewGuardedProvider(inner, pipeline)
 

--- a/internal/guardrails/provider_test.go
+++ b/internal/guardrails/provider_test.go
@@ -59,7 +59,7 @@ func TestGuardedProvider_ChatCompletion_AppliesGuardrails(t *testing.T) {
 	inner := &mockRoutableProvider{}
 	pipeline := NewPipeline()
 
-	g, _ := NewSystemPromptGuardrail(SystemPromptInject, "guardrail system")
+	g, _ := NewSystemPromptGuardrail("test", SystemPromptInject, "guardrail system")
 	pipeline.Add(g, 0)
 
 	guarded := NewGuardedProvider(inner, pipeline)
@@ -90,7 +90,7 @@ func TestGuardedProvider_StreamChatCompletion_AppliesGuardrails(t *testing.T) {
 	inner := &mockRoutableProvider{}
 	pipeline := NewPipeline()
 
-	g, _ := NewSystemPromptGuardrail(SystemPromptOverride, "override system")
+	g, _ := NewSystemPromptGuardrail("test", SystemPromptOverride, "override system")
 	pipeline.Add(g, 0)
 
 	guarded := NewGuardedProvider(inner, pipeline)
@@ -118,7 +118,7 @@ func TestGuardedProvider_Responses_AppliesGuardrails(t *testing.T) {
 	inner := &mockRoutableProvider{}
 	pipeline := NewPipeline()
 
-	g, _ := NewSystemPromptGuardrail(SystemPromptInject, "guardrail instructions")
+	g, _ := NewSystemPromptGuardrail("test", SystemPromptInject, "guardrail instructions")
 	pipeline.Add(g, 0)
 
 	guarded := NewGuardedProvider(inner, pipeline)
@@ -139,7 +139,7 @@ func TestGuardedProvider_StreamResponses_AppliesGuardrails(t *testing.T) {
 	inner := &mockRoutableProvider{}
 	pipeline := NewPipeline()
 
-	g, _ := NewSystemPromptGuardrail(SystemPromptDecorator, "prefix")
+	g, _ := NewSystemPromptGuardrail("test", SystemPromptDecorator, "prefix")
 	pipeline.Add(g, 0)
 
 	guarded := NewGuardedProvider(inner, pipeline)

--- a/internal/guardrails/system_prompt.go
+++ b/internal/guardrails/system_prompt.go
@@ -1,0 +1,169 @@
+package guardrails
+
+import (
+	"context"
+	"fmt"
+
+	"gomodel/internal/core"
+)
+
+// SystemPromptMode defines how the system prompt guardrail modifies requests.
+type SystemPromptMode string
+
+const (
+	// SystemPromptInject adds a system message only if none exists in the request.
+	SystemPromptInject SystemPromptMode = "inject"
+
+	// SystemPromptOverride replaces all existing system messages with the configured one.
+	SystemPromptOverride SystemPromptMode = "override"
+
+	// SystemPromptDecorator prepends the configured content to the first existing
+	// system message (separated by a newline), or adds a new system message if none exists.
+	SystemPromptDecorator SystemPromptMode = "decorator"
+)
+
+// SystemPromptGuardrail injects, overrides, or decorates system messages in requests.
+type SystemPromptGuardrail struct {
+	mode    SystemPromptMode
+	content string
+}
+
+// NewSystemPromptGuardrail creates a new system prompt guardrail.
+// mode must be "inject", "override", or "decorator".
+// content is the system prompt text to apply.
+func NewSystemPromptGuardrail(mode SystemPromptMode, content string) (*SystemPromptGuardrail, error) {
+	switch mode {
+	case SystemPromptInject, SystemPromptOverride, SystemPromptDecorator:
+	default:
+		return nil, fmt.Errorf("invalid system prompt mode: %q (must be inject, override, or decorator)", mode)
+	}
+	if content == "" {
+		return nil, fmt.Errorf("system prompt content cannot be empty")
+	}
+	return &SystemPromptGuardrail{
+		mode:    mode,
+		content: content,
+	}, nil
+}
+
+// Name returns the guardrail name.
+func (g *SystemPromptGuardrail) Name() string {
+	return "system_prompt"
+}
+
+// ProcessChat applies the system prompt guardrail to a chat completion request.
+func (g *SystemPromptGuardrail) ProcessChat(ctx context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
+	messages := g.applyToMessages(req.Messages)
+	// Return a shallow copy with the new messages slice
+	return &core.ChatRequest{
+		Temperature:   req.Temperature,
+		MaxTokens:     req.MaxTokens,
+		Model:         req.Model,
+		Messages:      messages,
+		Stream:        req.Stream,
+		StreamOptions: req.StreamOptions,
+		Reasoning:     req.Reasoning,
+	}, nil
+}
+
+// ProcessResponses applies the system prompt guardrail to a Responses API request.
+// For the Responses API, the "instructions" field serves as the system prompt.
+func (g *SystemPromptGuardrail) ProcessResponses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesRequest, error) {
+	instructions := g.applyToInstructions(req.Instructions)
+	return &core.ResponsesRequest{
+		Model:           req.Model,
+		Input:           req.Input,
+		Instructions:    instructions,
+		Tools:           req.Tools,
+		Temperature:     req.Temperature,
+		MaxOutputTokens: req.MaxOutputTokens,
+		Stream:          req.Stream,
+		StreamOptions:   req.StreamOptions,
+		Metadata:        req.Metadata,
+		Reasoning:       req.Reasoning,
+	}, nil
+}
+
+// applyToMessages applies the mode logic to a slice of chat messages.
+func (g *SystemPromptGuardrail) applyToMessages(messages []core.Message) []core.Message {
+	switch g.mode {
+	case SystemPromptInject:
+		return g.injectMessages(messages)
+	case SystemPromptOverride:
+		return g.overrideMessages(messages)
+	case SystemPromptDecorator:
+		return g.decorateMessages(messages)
+	default:
+		return messages
+	}
+}
+
+// injectMessages adds a system message at the beginning only if no system message exists.
+func (g *SystemPromptGuardrail) injectMessages(messages []core.Message) []core.Message {
+	for _, m := range messages {
+		if m.Role == "system" {
+			return messages // already has a system message, leave untouched
+		}
+	}
+	// Prepend system message
+	result := make([]core.Message, 0, len(messages)+1)
+	result = append(result, core.Message{Role: "system", Content: g.content})
+	result = append(result, messages...)
+	return result
+}
+
+// overrideMessages replaces all system messages with a single one at the beginning.
+func (g *SystemPromptGuardrail) overrideMessages(messages []core.Message) []core.Message {
+	result := make([]core.Message, 0, len(messages)+1)
+	result = append(result, core.Message{Role: "system", Content: g.content})
+	for _, m := range messages {
+		if m.Role != "system" {
+			result = append(result, m)
+		}
+	}
+	return result
+}
+
+// decorateMessages prepends the configured content to the first system message,
+// or adds a new system message if none exists.
+func (g *SystemPromptGuardrail) decorateMessages(messages []core.Message) []core.Message {
+	found := false
+	result := make([]core.Message, len(messages))
+	copy(result, messages)
+
+	for i, m := range result {
+		if m.Role == "system" && !found {
+			result[i].Content = g.content + "\n" + m.Content
+			found = true
+		}
+	}
+
+	if !found {
+		// No system message found; prepend one
+		prepended := make([]core.Message, 0, len(result)+1)
+		prepended = append(prepended, core.Message{Role: "system", Content: g.content})
+		prepended = append(prepended, result...)
+		return prepended
+	}
+	return result
+}
+
+// applyToInstructions applies the mode logic to the Responses API instructions field.
+func (g *SystemPromptGuardrail) applyToInstructions(instructions string) string {
+	switch g.mode {
+	case SystemPromptInject:
+		if instructions != "" {
+			return instructions // already has instructions, leave untouched
+		}
+		return g.content
+	case SystemPromptOverride:
+		return g.content
+	case SystemPromptDecorator:
+		if instructions != "" {
+			return g.content + "\n" + instructions
+		}
+		return g.content
+	default:
+		return instructions
+	}
+}

--- a/internal/guardrails/system_prompt.go
+++ b/internal/guardrails/system_prompt.go
@@ -24,14 +24,16 @@ const (
 
 // SystemPromptGuardrail injects, overrides, or decorates system messages in requests.
 type SystemPromptGuardrail struct {
+	name    string
 	mode    SystemPromptMode
 	content string
 }
 
-// NewSystemPromptGuardrail creates a new system prompt guardrail.
+// NewSystemPromptGuardrail creates a new system prompt guardrail instance.
+// name identifies this instance (e.g. "safety-prompt", "compliance-check").
 // mode must be "inject", "override", or "decorator".
 // content is the system prompt text to apply.
-func NewSystemPromptGuardrail(mode SystemPromptMode, content string) (*SystemPromptGuardrail, error) {
+func NewSystemPromptGuardrail(name string, mode SystemPromptMode, content string) (*SystemPromptGuardrail, error) {
 	switch mode {
 	case SystemPromptInject, SystemPromptOverride, SystemPromptDecorator:
 	default:
@@ -40,15 +42,19 @@ func NewSystemPromptGuardrail(mode SystemPromptMode, content string) (*SystemPro
 	if content == "" {
 		return nil, fmt.Errorf("system prompt content cannot be empty")
 	}
+	if name == "" {
+		name = "system_prompt"
+	}
 	return &SystemPromptGuardrail{
+		name:    name,
 		mode:    mode,
 		content: content,
 	}, nil
 }
 
-// Name returns the guardrail name.
+// Name returns this instance's name.
 func (g *SystemPromptGuardrail) Name() string {
-	return "system_prompt"
+	return g.name
 }
 
 // ProcessChat applies the system prompt guardrail to a chat completion request.

--- a/internal/guardrails/system_prompt_test.go
+++ b/internal/guardrails/system_prompt_test.go
@@ -3,8 +3,6 @@ package guardrails
 import (
 	"context"
 	"testing"
-
-	"gomodel/internal/core"
 )
 
 func TestNewSystemPromptGuardrail_InvalidMode(t *testing.T) {
@@ -45,277 +43,181 @@ func TestNewSystemPromptGuardrail_EmptyNameDefaults(t *testing.T) {
 
 func TestSystemPrompt_Inject_NoExistingSystem(t *testing.T) {
 	g, _ := NewSystemPromptGuardrail("test", SystemPromptInject, "injected system prompt")
-	req := &core.ChatRequest{
-		Model: "gpt-4",
-		Messages: []core.Message{
-			{Role: "user", Content: "hello"},
-		},
+	msgs := []Message{
+		{Role: "user", Content: "hello"},
 	}
 
-	result, err := g.ProcessChat(context.Background(), req)
+	result, err := g.Process(context.Background(), msgs)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if len(result.Messages) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(result.Messages))
+	if len(result) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(result))
 	}
-	if result.Messages[0].Role != "system" || result.Messages[0].Content != "injected system prompt" {
-		t.Errorf("expected system message first, got %+v", result.Messages[0])
+	if result[0].Role != "system" || result[0].Content != "injected system prompt" {
+		t.Errorf("expected system message first, got %+v", result[0])
 	}
-	if result.Messages[1].Role != "user" {
-		t.Errorf("expected user message second, got %+v", result.Messages[1])
+	if result[1].Role != "user" {
+		t.Errorf("expected user message second, got %+v", result[1])
 	}
 }
 
 func TestSystemPrompt_Inject_ExistingSystem(t *testing.T) {
 	g, _ := NewSystemPromptGuardrail("test", SystemPromptInject, "injected system prompt")
-	req := &core.ChatRequest{
-		Model: "gpt-4",
-		Messages: []core.Message{
-			{Role: "system", Content: "original system"},
-			{Role: "user", Content: "hello"},
-		},
+	msgs := []Message{
+		{Role: "system", Content: "original system"},
+		{Role: "user", Content: "hello"},
 	}
 
-	result, err := g.ProcessChat(context.Background(), req)
+	result, err := g.Process(context.Background(), msgs)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if len(result.Messages) != 2 {
-		t.Fatalf("expected 2 messages (unchanged), got %d", len(result.Messages))
+	if len(result) != 2 {
+		t.Fatalf("expected 2 messages (unchanged), got %d", len(result))
 	}
-	if result.Messages[0].Content != "original system" {
-		t.Errorf("inject should not change existing system message, got %q", result.Messages[0].Content)
+	if result[0].Content != "original system" {
+		t.Errorf("inject should not change existing system message, got %q", result[0].Content)
 	}
 }
 
 func TestSystemPrompt_Override_NoExistingSystem(t *testing.T) {
 	g, _ := NewSystemPromptGuardrail("test", SystemPromptOverride, "override prompt")
-	req := &core.ChatRequest{
-		Model: "gpt-4",
-		Messages: []core.Message{
-			{Role: "user", Content: "hello"},
-		},
+	msgs := []Message{
+		{Role: "user", Content: "hello"},
 	}
 
-	result, err := g.ProcessChat(context.Background(), req)
+	result, err := g.Process(context.Background(), msgs)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if len(result.Messages) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(result.Messages))
+	if len(result) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(result))
 	}
-	if result.Messages[0].Role != "system" || result.Messages[0].Content != "override prompt" {
-		t.Errorf("expected override system message, got %+v", result.Messages[0])
+	if result[0].Role != "system" || result[0].Content != "override prompt" {
+		t.Errorf("expected override system message, got %+v", result[0])
 	}
 }
 
 func TestSystemPrompt_Override_ExistingSystem(t *testing.T) {
 	g, _ := NewSystemPromptGuardrail("test", SystemPromptOverride, "override prompt")
-	req := &core.ChatRequest{
-		Model: "gpt-4",
-		Messages: []core.Message{
-			{Role: "system", Content: "original system"},
-			{Role: "user", Content: "hello"},
-			{Role: "system", Content: "another system"},
-		},
+	msgs := []Message{
+		{Role: "system", Content: "original system"},
+		{Role: "user", Content: "hello"},
+		{Role: "system", Content: "another system"},
 	}
 
-	result, err := g.ProcessChat(context.Background(), req)
+	result, err := g.Process(context.Background(), msgs)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Should have: override system + user (both original system messages removed)
-	if len(result.Messages) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(result.Messages))
+	if len(result) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(result))
 	}
-	if result.Messages[0].Role != "system" || result.Messages[0].Content != "override prompt" {
-		t.Errorf("expected override system message, got %+v", result.Messages[0])
+	if result[0].Role != "system" || result[0].Content != "override prompt" {
+		t.Errorf("expected override system message, got %+v", result[0])
 	}
-	if result.Messages[1].Role != "user" {
-		t.Errorf("expected user message, got %+v", result.Messages[1])
+	if result[1].Role != "user" {
+		t.Errorf("expected user message, got %+v", result[1])
 	}
 }
 
 func TestSystemPrompt_Decorator_NoExistingSystem(t *testing.T) {
 	g, _ := NewSystemPromptGuardrail("test", SystemPromptDecorator, "prefix")
-	req := &core.ChatRequest{
-		Model: "gpt-4",
-		Messages: []core.Message{
-			{Role: "user", Content: "hello"},
-		},
+	msgs := []Message{
+		{Role: "user", Content: "hello"},
 	}
 
-	result, err := g.ProcessChat(context.Background(), req)
+	result, err := g.Process(context.Background(), msgs)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if len(result.Messages) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(result.Messages))
+	if len(result) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(result))
 	}
-	if result.Messages[0].Role != "system" || result.Messages[0].Content != "prefix" {
-		t.Errorf("decorator with no existing system should add one, got %+v", result.Messages[0])
+	if result[0].Role != "system" || result[0].Content != "prefix" {
+		t.Errorf("decorator with no existing system should add one, got %+v", result[0])
 	}
 }
 
 func TestSystemPrompt_Decorator_ExistingSystem(t *testing.T) {
 	g, _ := NewSystemPromptGuardrail("test", SystemPromptDecorator, "prefix")
-	req := &core.ChatRequest{
-		Model: "gpt-4",
-		Messages: []core.Message{
-			{Role: "system", Content: "original"},
-			{Role: "user", Content: "hello"},
-		},
+	msgs := []Message{
+		{Role: "system", Content: "original"},
+		{Role: "user", Content: "hello"},
 	}
 
-	result, err := g.ProcessChat(context.Background(), req)
+	result, err := g.Process(context.Background(), msgs)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if len(result.Messages) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(result.Messages))
+	if len(result) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(result))
 	}
 	expected := "prefix\noriginal"
-	if result.Messages[0].Content != expected {
-		t.Errorf("expected decorated content %q, got %q", expected, result.Messages[0].Content)
+	if result[0].Content != expected {
+		t.Errorf("expected decorated content %q, got %q", expected, result[0].Content)
 	}
 }
 
 func TestSystemPrompt_Decorator_OnlyFirstSystemDecorated(t *testing.T) {
 	g, _ := NewSystemPromptGuardrail("test", SystemPromptDecorator, "prefix")
-	req := &core.ChatRequest{
-		Model: "gpt-4",
-		Messages: []core.Message{
-			{Role: "system", Content: "first"},
-			{Role: "user", Content: "hello"},
-			{Role: "system", Content: "second"},
-		},
+	msgs := []Message{
+		{Role: "system", Content: "first"},
+		{Role: "user", Content: "hello"},
+		{Role: "system", Content: "second"},
 	}
 
-	result, err := g.ProcessChat(context.Background(), req)
+	result, err := g.Process(context.Background(), msgs)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if result.Messages[0].Content != "prefix\nfirst" {
-		t.Errorf("first system should be decorated, got %q", result.Messages[0].Content)
+	if result[0].Content != "prefix\nfirst" {
+		t.Errorf("first system should be decorated, got %q", result[0].Content)
 	}
-	if result.Messages[2].Content != "second" {
-		t.Errorf("second system should be untouched, got %q", result.Messages[2].Content)
+	if result[2].Content != "second" {
+		t.Errorf("second system should be untouched, got %q", result[2].Content)
 	}
 }
 
 func TestSystemPrompt_DoesNotMutateOriginal(t *testing.T) {
 	g, _ := NewSystemPromptGuardrail("test", SystemPromptOverride, "new")
-	original := &core.ChatRequest{
-		Model: "gpt-4",
-		Messages: []core.Message{
-			{Role: "system", Content: "original"},
-			{Role: "user", Content: "hello"},
-		},
+	original := []Message{
+		{Role: "system", Content: "original"},
+		{Role: "user", Content: "hello"},
 	}
 
-	result, err := g.ProcessChat(context.Background(), original)
+	result, err := g.Process(context.Background(), original)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Original should be untouched
-	if original.Messages[0].Content != "original" {
-		t.Error("original request was mutated")
+	if original[0].Content != "original" {
+		t.Error("original messages were mutated")
 	}
-	if result.Messages[0].Content != "new" {
+	if result[0].Content != "new" {
 		t.Error("result should have new system message")
 	}
 }
 
-// --- Responses API tests ---
-
-func TestSystemPrompt_Responses_Inject_NoInstructions(t *testing.T) {
+func TestSystemPrompt_EmptyMessages(t *testing.T) {
 	g, _ := NewSystemPromptGuardrail("test", SystemPromptInject, "injected")
-	req := &core.ResponsesRequest{Model: "gpt-4", Input: "hello"}
 
-	result, err := g.ProcessResponses(context.Background(), req)
+	result, err := g.Process(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.Instructions != "injected" {
-		t.Errorf("expected 'injected', got %q", result.Instructions)
-	}
-}
-
-func TestSystemPrompt_Responses_Inject_ExistingInstructions(t *testing.T) {
-	g, _ := NewSystemPromptGuardrail("test", SystemPromptInject, "injected")
-	req := &core.ResponsesRequest{Model: "gpt-4", Input: "hello", Instructions: "existing"}
-
-	result, err := g.ProcessResponses(context.Background(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if result.Instructions != "existing" {
-		t.Errorf("inject should not change existing instructions, got %q", result.Instructions)
-	}
-}
-
-func TestSystemPrompt_Responses_Override(t *testing.T) {
-	g, _ := NewSystemPromptGuardrail("test", SystemPromptOverride, "override")
-	req := &core.ResponsesRequest{Model: "gpt-4", Input: "hello", Instructions: "existing"}
-
-	result, err := g.ProcessResponses(context.Background(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if result.Instructions != "override" {
-		t.Errorf("expected 'override', got %q", result.Instructions)
-	}
-}
-
-func TestSystemPrompt_Responses_Decorator_ExistingInstructions(t *testing.T) {
-	g, _ := NewSystemPromptGuardrail("test", SystemPromptDecorator, "prefix")
-	req := &core.ResponsesRequest{Model: "gpt-4", Input: "hello", Instructions: "existing"}
-
-	result, err := g.ProcessResponses(context.Background(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	expected := "prefix\nexisting"
-	if result.Instructions != expected {
-		t.Errorf("expected %q, got %q", expected, result.Instructions)
-	}
-}
-
-func TestSystemPrompt_Responses_Decorator_NoInstructions(t *testing.T) {
-	g, _ := NewSystemPromptGuardrail("test", SystemPromptDecorator, "prefix")
-	req := &core.ResponsesRequest{Model: "gpt-4", Input: "hello"}
-
-	result, err := g.ProcessResponses(context.Background(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if result.Instructions != "prefix" {
-		t.Errorf("expected 'prefix', got %q", result.Instructions)
-	}
-}
-
-func TestSystemPrompt_Responses_DoesNotMutateOriginal(t *testing.T) {
-	g, _ := NewSystemPromptGuardrail("test", SystemPromptOverride, "new")
-	original := &core.ResponsesRequest{Model: "gpt-4", Input: "hello", Instructions: "original"}
-
-	result, err := g.ProcessResponses(context.Background(), original)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if original.Instructions != "original" {
-		t.Error("original request was mutated")
-	}
-	if result.Instructions != "new" {
-		t.Error("result should have new instructions")
+	if len(result) != 1 || result[0].Content != "injected" {
+		t.Errorf("expected injected message on empty input, got %v", result)
 	}
 }
 
@@ -339,40 +241,5 @@ func TestNewSystemPromptGuardrail_UnicodeNames(t *testing.T) {
 		if g.Name() != tc.name {
 			t.Errorf("expected name %q, got %q", tc.name, g.Name())
 		}
-	}
-}
-
-func TestSystemPrompt_PreservesOtherFields(t *testing.T) {
-	g, _ := NewSystemPromptGuardrail("test", SystemPromptInject, "system")
-	temp := 0.7
-	maxTok := 100
-	req := &core.ChatRequest{
-		Model:       "gpt-4",
-		Temperature: &temp,
-		MaxTokens:   &maxTok,
-		Messages:    []core.Message{{Role: "user", Content: "hello"}},
-		Stream:      true,
-		Reasoning:   &core.Reasoning{Effort: "high"},
-	}
-
-	result, err := g.ProcessChat(context.Background(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if result.Model != "gpt-4" {
-		t.Errorf("model not preserved")
-	}
-	if result.Temperature == nil || *result.Temperature != 0.7 {
-		t.Errorf("temperature not preserved")
-	}
-	if result.MaxTokens == nil || *result.MaxTokens != 100 {
-		t.Errorf("max_tokens not preserved")
-	}
-	if !result.Stream {
-		t.Errorf("stream not preserved")
-	}
-	if result.Reasoning == nil || result.Reasoning.Effort != "high" {
-		t.Errorf("reasoning not preserved")
 	}
 }

--- a/internal/guardrails/system_prompt_test.go
+++ b/internal/guardrails/system_prompt_test.go
@@ -319,6 +319,29 @@ func TestSystemPrompt_Responses_DoesNotMutateOriginal(t *testing.T) {
 	}
 }
 
+func TestNewSystemPromptGuardrail_UnicodeNames(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{"safety prompt"},           // spaces
+		{"compliance check v2"},     // spaces and digits
+		{"проверка безопасности"},   // Cyrillic with space
+		{"安全検査"},                // CJK (Chinese + Japanese)
+		{"sécurité-modèle"},        // accented Latin
+		{"🛡️ guardrail"},           // emoji
+	}
+	for _, tc := range tests {
+		g, err := NewSystemPromptGuardrail(tc.name, SystemPromptInject, "content")
+		if err != nil {
+			t.Errorf("unexpected error for name %q: %v", tc.name, err)
+			continue
+		}
+		if g.Name() != tc.name {
+			t.Errorf("expected name %q, got %q", tc.name, g.Name())
+		}
+	}
+}
+
 func TestSystemPrompt_PreservesOtherFields(t *testing.T) {
 	g, _ := NewSystemPromptGuardrail("test", SystemPromptInject, "system")
 	temp := 0.7

--- a/internal/guardrails/system_prompt_test.go
+++ b/internal/guardrails/system_prompt_test.go
@@ -8,14 +8,14 @@ import (
 )
 
 func TestNewSystemPromptGuardrail_InvalidMode(t *testing.T) {
-	_, err := NewSystemPromptGuardrail("bad", "content")
+	_, err := NewSystemPromptGuardrail("test", "bad", "content")
 	if err == nil {
 		t.Fatal("expected error for invalid mode")
 	}
 }
 
 func TestNewSystemPromptGuardrail_EmptyContent(t *testing.T) {
-	_, err := NewSystemPromptGuardrail(SystemPromptInject, "")
+	_, err := NewSystemPromptGuardrail("test", SystemPromptInject, "")
 	if err == nil {
 		t.Fatal("expected error for empty content")
 	}
@@ -23,18 +23,28 @@ func TestNewSystemPromptGuardrail_EmptyContent(t *testing.T) {
 
 func TestNewSystemPromptGuardrail_ValidModes(t *testing.T) {
 	for _, mode := range []SystemPromptMode{SystemPromptInject, SystemPromptOverride, SystemPromptDecorator} {
-		g, err := NewSystemPromptGuardrail(mode, "test")
+		g, err := NewSystemPromptGuardrail("my-guardrail", mode, "test")
 		if err != nil {
 			t.Fatalf("unexpected error for mode %q: %v", mode, err)
 		}
-		if g.Name() != "system_prompt" {
-			t.Errorf("expected name 'system_prompt', got %q", g.Name())
+		if g.Name() != "my-guardrail" {
+			t.Errorf("expected name 'my-guardrail', got %q", g.Name())
 		}
 	}
 }
 
+func TestNewSystemPromptGuardrail_EmptyNameDefaults(t *testing.T) {
+	g, err := NewSystemPromptGuardrail("", SystemPromptInject, "content")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if g.Name() != "system_prompt" {
+		t.Errorf("expected default name 'system_prompt', got %q", g.Name())
+	}
+}
+
 func TestSystemPrompt_Inject_NoExistingSystem(t *testing.T) {
-	g, _ := NewSystemPromptGuardrail(SystemPromptInject, "injected system prompt")
+	g, _ := NewSystemPromptGuardrail("test", SystemPromptInject, "injected system prompt")
 	req := &core.ChatRequest{
 		Model: "gpt-4",
 		Messages: []core.Message{
@@ -59,7 +69,7 @@ func TestSystemPrompt_Inject_NoExistingSystem(t *testing.T) {
 }
 
 func TestSystemPrompt_Inject_ExistingSystem(t *testing.T) {
-	g, _ := NewSystemPromptGuardrail(SystemPromptInject, "injected system prompt")
+	g, _ := NewSystemPromptGuardrail("test", SystemPromptInject, "injected system prompt")
 	req := &core.ChatRequest{
 		Model: "gpt-4",
 		Messages: []core.Message{
@@ -82,7 +92,7 @@ func TestSystemPrompt_Inject_ExistingSystem(t *testing.T) {
 }
 
 func TestSystemPrompt_Override_NoExistingSystem(t *testing.T) {
-	g, _ := NewSystemPromptGuardrail(SystemPromptOverride, "override prompt")
+	g, _ := NewSystemPromptGuardrail("test", SystemPromptOverride, "override prompt")
 	req := &core.ChatRequest{
 		Model: "gpt-4",
 		Messages: []core.Message{
@@ -104,7 +114,7 @@ func TestSystemPrompt_Override_NoExistingSystem(t *testing.T) {
 }
 
 func TestSystemPrompt_Override_ExistingSystem(t *testing.T) {
-	g, _ := NewSystemPromptGuardrail(SystemPromptOverride, "override prompt")
+	g, _ := NewSystemPromptGuardrail("test", SystemPromptOverride, "override prompt")
 	req := &core.ChatRequest{
 		Model: "gpt-4",
 		Messages: []core.Message{
@@ -132,7 +142,7 @@ func TestSystemPrompt_Override_ExistingSystem(t *testing.T) {
 }
 
 func TestSystemPrompt_Decorator_NoExistingSystem(t *testing.T) {
-	g, _ := NewSystemPromptGuardrail(SystemPromptDecorator, "prefix")
+	g, _ := NewSystemPromptGuardrail("test", SystemPromptDecorator, "prefix")
 	req := &core.ChatRequest{
 		Model: "gpt-4",
 		Messages: []core.Message{
@@ -154,7 +164,7 @@ func TestSystemPrompt_Decorator_NoExistingSystem(t *testing.T) {
 }
 
 func TestSystemPrompt_Decorator_ExistingSystem(t *testing.T) {
-	g, _ := NewSystemPromptGuardrail(SystemPromptDecorator, "prefix")
+	g, _ := NewSystemPromptGuardrail("test", SystemPromptDecorator, "prefix")
 	req := &core.ChatRequest{
 		Model: "gpt-4",
 		Messages: []core.Message{
@@ -178,7 +188,7 @@ func TestSystemPrompt_Decorator_ExistingSystem(t *testing.T) {
 }
 
 func TestSystemPrompt_Decorator_OnlyFirstSystemDecorated(t *testing.T) {
-	g, _ := NewSystemPromptGuardrail(SystemPromptDecorator, "prefix")
+	g, _ := NewSystemPromptGuardrail("test", SystemPromptDecorator, "prefix")
 	req := &core.ChatRequest{
 		Model: "gpt-4",
 		Messages: []core.Message{
@@ -202,7 +212,7 @@ func TestSystemPrompt_Decorator_OnlyFirstSystemDecorated(t *testing.T) {
 }
 
 func TestSystemPrompt_DoesNotMutateOriginal(t *testing.T) {
-	g, _ := NewSystemPromptGuardrail(SystemPromptOverride, "new")
+	g, _ := NewSystemPromptGuardrail("test", SystemPromptOverride, "new")
 	original := &core.ChatRequest{
 		Model: "gpt-4",
 		Messages: []core.Message{
@@ -228,7 +238,7 @@ func TestSystemPrompt_DoesNotMutateOriginal(t *testing.T) {
 // --- Responses API tests ---
 
 func TestSystemPrompt_Responses_Inject_NoInstructions(t *testing.T) {
-	g, _ := NewSystemPromptGuardrail(SystemPromptInject, "injected")
+	g, _ := NewSystemPromptGuardrail("test", SystemPromptInject, "injected")
 	req := &core.ResponsesRequest{Model: "gpt-4", Input: "hello"}
 
 	result, err := g.ProcessResponses(context.Background(), req)
@@ -241,7 +251,7 @@ func TestSystemPrompt_Responses_Inject_NoInstructions(t *testing.T) {
 }
 
 func TestSystemPrompt_Responses_Inject_ExistingInstructions(t *testing.T) {
-	g, _ := NewSystemPromptGuardrail(SystemPromptInject, "injected")
+	g, _ := NewSystemPromptGuardrail("test", SystemPromptInject, "injected")
 	req := &core.ResponsesRequest{Model: "gpt-4", Input: "hello", Instructions: "existing"}
 
 	result, err := g.ProcessResponses(context.Background(), req)
@@ -254,7 +264,7 @@ func TestSystemPrompt_Responses_Inject_ExistingInstructions(t *testing.T) {
 }
 
 func TestSystemPrompt_Responses_Override(t *testing.T) {
-	g, _ := NewSystemPromptGuardrail(SystemPromptOverride, "override")
+	g, _ := NewSystemPromptGuardrail("test", SystemPromptOverride, "override")
 	req := &core.ResponsesRequest{Model: "gpt-4", Input: "hello", Instructions: "existing"}
 
 	result, err := g.ProcessResponses(context.Background(), req)
@@ -267,7 +277,7 @@ func TestSystemPrompt_Responses_Override(t *testing.T) {
 }
 
 func TestSystemPrompt_Responses_Decorator_ExistingInstructions(t *testing.T) {
-	g, _ := NewSystemPromptGuardrail(SystemPromptDecorator, "prefix")
+	g, _ := NewSystemPromptGuardrail("test", SystemPromptDecorator, "prefix")
 	req := &core.ResponsesRequest{Model: "gpt-4", Input: "hello", Instructions: "existing"}
 
 	result, err := g.ProcessResponses(context.Background(), req)
@@ -281,7 +291,7 @@ func TestSystemPrompt_Responses_Decorator_ExistingInstructions(t *testing.T) {
 }
 
 func TestSystemPrompt_Responses_Decorator_NoInstructions(t *testing.T) {
-	g, _ := NewSystemPromptGuardrail(SystemPromptDecorator, "prefix")
+	g, _ := NewSystemPromptGuardrail("test", SystemPromptDecorator, "prefix")
 	req := &core.ResponsesRequest{Model: "gpt-4", Input: "hello"}
 
 	result, err := g.ProcessResponses(context.Background(), req)
@@ -294,7 +304,7 @@ func TestSystemPrompt_Responses_Decorator_NoInstructions(t *testing.T) {
 }
 
 func TestSystemPrompt_Responses_DoesNotMutateOriginal(t *testing.T) {
-	g, _ := NewSystemPromptGuardrail(SystemPromptOverride, "new")
+	g, _ := NewSystemPromptGuardrail("test", SystemPromptOverride, "new")
 	original := &core.ResponsesRequest{Model: "gpt-4", Input: "hello", Instructions: "original"}
 
 	result, err := g.ProcessResponses(context.Background(), original)
@@ -310,7 +320,7 @@ func TestSystemPrompt_Responses_DoesNotMutateOriginal(t *testing.T) {
 }
 
 func TestSystemPrompt_PreservesOtherFields(t *testing.T) {
-	g, _ := NewSystemPromptGuardrail(SystemPromptInject, "system")
+	g, _ := NewSystemPromptGuardrail("test", SystemPromptInject, "system")
 	temp := 0.7
 	maxTok := 100
 	req := &core.ChatRequest{

--- a/internal/guardrails/system_prompt_test.go
+++ b/internal/guardrails/system_prompt_test.go
@@ -1,0 +1,345 @@
+package guardrails
+
+import (
+	"context"
+	"testing"
+
+	"gomodel/internal/core"
+)
+
+func TestNewSystemPromptGuardrail_InvalidMode(t *testing.T) {
+	_, err := NewSystemPromptGuardrail("bad", "content")
+	if err == nil {
+		t.Fatal("expected error for invalid mode")
+	}
+}
+
+func TestNewSystemPromptGuardrail_EmptyContent(t *testing.T) {
+	_, err := NewSystemPromptGuardrail(SystemPromptInject, "")
+	if err == nil {
+		t.Fatal("expected error for empty content")
+	}
+}
+
+func TestNewSystemPromptGuardrail_ValidModes(t *testing.T) {
+	for _, mode := range []SystemPromptMode{SystemPromptInject, SystemPromptOverride, SystemPromptDecorator} {
+		g, err := NewSystemPromptGuardrail(mode, "test")
+		if err != nil {
+			t.Fatalf("unexpected error for mode %q: %v", mode, err)
+		}
+		if g.Name() != "system_prompt" {
+			t.Errorf("expected name 'system_prompt', got %q", g.Name())
+		}
+	}
+}
+
+func TestSystemPrompt_Inject_NoExistingSystem(t *testing.T) {
+	g, _ := NewSystemPromptGuardrail(SystemPromptInject, "injected system prompt")
+	req := &core.ChatRequest{
+		Model: "gpt-4",
+		Messages: []core.Message{
+			{Role: "user", Content: "hello"},
+		},
+	}
+
+	result, err := g.ProcessChat(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(result.Messages))
+	}
+	if result.Messages[0].Role != "system" || result.Messages[0].Content != "injected system prompt" {
+		t.Errorf("expected system message first, got %+v", result.Messages[0])
+	}
+	if result.Messages[1].Role != "user" {
+		t.Errorf("expected user message second, got %+v", result.Messages[1])
+	}
+}
+
+func TestSystemPrompt_Inject_ExistingSystem(t *testing.T) {
+	g, _ := NewSystemPromptGuardrail(SystemPromptInject, "injected system prompt")
+	req := &core.ChatRequest{
+		Model: "gpt-4",
+		Messages: []core.Message{
+			{Role: "system", Content: "original system"},
+			{Role: "user", Content: "hello"},
+		},
+	}
+
+	result, err := g.ProcessChat(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Messages) != 2 {
+		t.Fatalf("expected 2 messages (unchanged), got %d", len(result.Messages))
+	}
+	if result.Messages[0].Content != "original system" {
+		t.Errorf("inject should not change existing system message, got %q", result.Messages[0].Content)
+	}
+}
+
+func TestSystemPrompt_Override_NoExistingSystem(t *testing.T) {
+	g, _ := NewSystemPromptGuardrail(SystemPromptOverride, "override prompt")
+	req := &core.ChatRequest{
+		Model: "gpt-4",
+		Messages: []core.Message{
+			{Role: "user", Content: "hello"},
+		},
+	}
+
+	result, err := g.ProcessChat(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(result.Messages))
+	}
+	if result.Messages[0].Role != "system" || result.Messages[0].Content != "override prompt" {
+		t.Errorf("expected override system message, got %+v", result.Messages[0])
+	}
+}
+
+func TestSystemPrompt_Override_ExistingSystem(t *testing.T) {
+	g, _ := NewSystemPromptGuardrail(SystemPromptOverride, "override prompt")
+	req := &core.ChatRequest{
+		Model: "gpt-4",
+		Messages: []core.Message{
+			{Role: "system", Content: "original system"},
+			{Role: "user", Content: "hello"},
+			{Role: "system", Content: "another system"},
+		},
+	}
+
+	result, err := g.ProcessChat(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should have: override system + user (both original system messages removed)
+	if len(result.Messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(result.Messages))
+	}
+	if result.Messages[0].Role != "system" || result.Messages[0].Content != "override prompt" {
+		t.Errorf("expected override system message, got %+v", result.Messages[0])
+	}
+	if result.Messages[1].Role != "user" {
+		t.Errorf("expected user message, got %+v", result.Messages[1])
+	}
+}
+
+func TestSystemPrompt_Decorator_NoExistingSystem(t *testing.T) {
+	g, _ := NewSystemPromptGuardrail(SystemPromptDecorator, "prefix")
+	req := &core.ChatRequest{
+		Model: "gpt-4",
+		Messages: []core.Message{
+			{Role: "user", Content: "hello"},
+		},
+	}
+
+	result, err := g.ProcessChat(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(result.Messages))
+	}
+	if result.Messages[0].Role != "system" || result.Messages[0].Content != "prefix" {
+		t.Errorf("decorator with no existing system should add one, got %+v", result.Messages[0])
+	}
+}
+
+func TestSystemPrompt_Decorator_ExistingSystem(t *testing.T) {
+	g, _ := NewSystemPromptGuardrail(SystemPromptDecorator, "prefix")
+	req := &core.ChatRequest{
+		Model: "gpt-4",
+		Messages: []core.Message{
+			{Role: "system", Content: "original"},
+			{Role: "user", Content: "hello"},
+		},
+	}
+
+	result, err := g.ProcessChat(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(result.Messages))
+	}
+	expected := "prefix\noriginal"
+	if result.Messages[0].Content != expected {
+		t.Errorf("expected decorated content %q, got %q", expected, result.Messages[0].Content)
+	}
+}
+
+func TestSystemPrompt_Decorator_OnlyFirstSystemDecorated(t *testing.T) {
+	g, _ := NewSystemPromptGuardrail(SystemPromptDecorator, "prefix")
+	req := &core.ChatRequest{
+		Model: "gpt-4",
+		Messages: []core.Message{
+			{Role: "system", Content: "first"},
+			{Role: "user", Content: "hello"},
+			{Role: "system", Content: "second"},
+		},
+	}
+
+	result, err := g.ProcessChat(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.Messages[0].Content != "prefix\nfirst" {
+		t.Errorf("first system should be decorated, got %q", result.Messages[0].Content)
+	}
+	if result.Messages[2].Content != "second" {
+		t.Errorf("second system should be untouched, got %q", result.Messages[2].Content)
+	}
+}
+
+func TestSystemPrompt_DoesNotMutateOriginal(t *testing.T) {
+	g, _ := NewSystemPromptGuardrail(SystemPromptOverride, "new")
+	original := &core.ChatRequest{
+		Model: "gpt-4",
+		Messages: []core.Message{
+			{Role: "system", Content: "original"},
+			{Role: "user", Content: "hello"},
+		},
+	}
+
+	result, err := g.ProcessChat(context.Background(), original)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Original should be untouched
+	if original.Messages[0].Content != "original" {
+		t.Error("original request was mutated")
+	}
+	if result.Messages[0].Content != "new" {
+		t.Error("result should have new system message")
+	}
+}
+
+// --- Responses API tests ---
+
+func TestSystemPrompt_Responses_Inject_NoInstructions(t *testing.T) {
+	g, _ := NewSystemPromptGuardrail(SystemPromptInject, "injected")
+	req := &core.ResponsesRequest{Model: "gpt-4", Input: "hello"}
+
+	result, err := g.ProcessResponses(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Instructions != "injected" {
+		t.Errorf("expected 'injected', got %q", result.Instructions)
+	}
+}
+
+func TestSystemPrompt_Responses_Inject_ExistingInstructions(t *testing.T) {
+	g, _ := NewSystemPromptGuardrail(SystemPromptInject, "injected")
+	req := &core.ResponsesRequest{Model: "gpt-4", Input: "hello", Instructions: "existing"}
+
+	result, err := g.ProcessResponses(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Instructions != "existing" {
+		t.Errorf("inject should not change existing instructions, got %q", result.Instructions)
+	}
+}
+
+func TestSystemPrompt_Responses_Override(t *testing.T) {
+	g, _ := NewSystemPromptGuardrail(SystemPromptOverride, "override")
+	req := &core.ResponsesRequest{Model: "gpt-4", Input: "hello", Instructions: "existing"}
+
+	result, err := g.ProcessResponses(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Instructions != "override" {
+		t.Errorf("expected 'override', got %q", result.Instructions)
+	}
+}
+
+func TestSystemPrompt_Responses_Decorator_ExistingInstructions(t *testing.T) {
+	g, _ := NewSystemPromptGuardrail(SystemPromptDecorator, "prefix")
+	req := &core.ResponsesRequest{Model: "gpt-4", Input: "hello", Instructions: "existing"}
+
+	result, err := g.ProcessResponses(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := "prefix\nexisting"
+	if result.Instructions != expected {
+		t.Errorf("expected %q, got %q", expected, result.Instructions)
+	}
+}
+
+func TestSystemPrompt_Responses_Decorator_NoInstructions(t *testing.T) {
+	g, _ := NewSystemPromptGuardrail(SystemPromptDecorator, "prefix")
+	req := &core.ResponsesRequest{Model: "gpt-4", Input: "hello"}
+
+	result, err := g.ProcessResponses(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Instructions != "prefix" {
+		t.Errorf("expected 'prefix', got %q", result.Instructions)
+	}
+}
+
+func TestSystemPrompt_Responses_DoesNotMutateOriginal(t *testing.T) {
+	g, _ := NewSystemPromptGuardrail(SystemPromptOverride, "new")
+	original := &core.ResponsesRequest{Model: "gpt-4", Input: "hello", Instructions: "original"}
+
+	result, err := g.ProcessResponses(context.Background(), original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if original.Instructions != "original" {
+		t.Error("original request was mutated")
+	}
+	if result.Instructions != "new" {
+		t.Error("result should have new instructions")
+	}
+}
+
+func TestSystemPrompt_PreservesOtherFields(t *testing.T) {
+	g, _ := NewSystemPromptGuardrail(SystemPromptInject, "system")
+	temp := 0.7
+	maxTok := 100
+	req := &core.ChatRequest{
+		Model:       "gpt-4",
+		Temperature: &temp,
+		MaxTokens:   &maxTok,
+		Messages:    []core.Message{{Role: "user", Content: "hello"}},
+		Stream:      true,
+		Reasoning:   &core.Reasoning{Effort: "high"},
+	}
+
+	result, err := g.ProcessChat(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.Model != "gpt-4" {
+		t.Errorf("model not preserved")
+	}
+	if result.Temperature == nil || *result.Temperature != 0.7 {
+		t.Errorf("temperature not preserved")
+	}
+	if result.MaxTokens == nil || *result.MaxTokens != 100 {
+		t.Errorf("max_tokens not preserved")
+	}
+	if !result.Stream {
+		t.Errorf("stream not preserved")
+	}
+	if result.Reasoning == nil || result.Reasoning.Effort != "high" {
+		t.Errorf("reasoning not preserved")
+	}
+}


### PR DESCRIPTION
Implement a pluggable guardrails pipeline that intercepts requests before
they reach providers. Guardrails can be executed sequentially (chained) or
in parallel (concurrent with ordered application). The pipeline wraps the
router as a RoutableProvider decorator, keeping handler code unchanged.

The first guardrail is a system prompt guardrail with three modes:
- inject: adds a system message only if none exists
- override: replaces all existing system messages
- decorator: prepends configured content to the first system message

Both ChatCompletion and Responses API endpoints are supported. All
configuration is driven from config.yaml and environment variables.

https://claude.ai/code/session_011U6sHbthHcwY68FZhAEFVH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pluggable guardrails system to inspect, modify, or block requests before they reach providers.
  * Added system-prompt guardrails with modes: inject, override, decorator.
  * Guardrails can be ordered and grouped to run sequentially or in parallel and can wrap request routing when enabled.

* **Configuration**
  * New guardrails config block to enable/disable and declare guardrail rules with example entries.

* **Tests**
  * Comprehensive unit tests covering pipeline, provider wrapping, and system-prompt behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->