### PR TITLE
feat: add admin API and dashboard with feature flags

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -106,6 +106,16 @@
 # USAGE_RETENTION_DAYS=90
 
 # =============================================================================
+# Admin API & Dashboard Configuration
+# =============================================================================
+
+# Enable/disable admin REST API (default: true)
+# ADMIN_API_ENABLED=true
+
+# Enable/disable admin dashboard SPA (default: true, requires ADMIN_API_ENABLED=true)
+# ADMIN_DASHBOARD_ENABLED=true
+
+# =============================================================================
 # Provider API Keys (uncomment and set the ones you need)
 # =============================================================================
 # OpenAI

--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,11 @@
 # Helm chart dependencies
 **/charts/*.tgz
 
+# Dashboard build artifacts
+web/dashboard/node_modules/
+web/dashboard/dist/
+internal/server/dashboard_dist/*
+!internal/server/dashboard_dist/index.html
+
 # OpenCode config - ignore because it might contain private servers URLs
 /opencode.json

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run clean tidy test test-e2e test-integration test-contract test-all lint lint-fix record-api
+.PHONY: build build-no-dashboard build-dashboard dev-dashboard run clean tidy test test-e2e test-integration test-contract test-all lint lint-fix record-api
 
 # Get version info
 VERSION ?= $(shell git describe --tags --always --dirty)
@@ -10,8 +10,23 @@ LDFLAGS := -X "gomodel/internal/version.Version=$(VERSION)" \
            -X "gomodel/internal/version.Commit=$(COMMIT)" \
            -X "gomodel/internal/version.Date=$(DATE)"
 
-build:
+build: build-dashboard
 	go build -ldflags '$(LDFLAGS)' -o bin/gomodel ./cmd/gomodel
+
+# Build Go binary only (skip dashboard build)
+build-no-dashboard:
+	go build -ldflags '$(LDFLAGS)' -o bin/gomodel ./cmd/gomodel
+
+# Build the dashboard SPA and copy output to the embedded directory
+build-dashboard:
+	cd web/dashboard && npm ci && npm run build
+	rm -rf internal/server/dashboard_dist/*
+	cp -r web/dashboard/dist/* internal/server/dashboard_dist/
+
+# Start the Vite dev server for dashboard development (with HMR)
+dev-dashboard:
+	cd web/dashboard && npm run dev
+
 # Run the application
 run:
 	go run ./cmd/gomodel

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -51,6 +51,12 @@ http:
   timeout: 600 # seconds (10 minutes)
   response_header_timeout: 600
 
+admin:
+  api:
+    enabled: true
+  dashboard:
+    enabled: true
+
 guardrails:
   enabled: false
   rules:

--- a/config/config.go
+++ b/config/config.go
@@ -35,7 +35,24 @@ type Config struct {
 	Metrics    MetricsConfig             `yaml:"metrics"`
 	HTTP       HTTPConfig                `yaml:"http"`
 	Guardrails GuardrailsConfig          `yaml:"guardrails"`
+	Admin      AdminConfig               `yaml:"admin"`
 	Providers  map[string]ProviderConfig `yaml:"providers"`
+}
+
+// AdminConfig holds configuration for the admin API and dashboard.
+type AdminConfig struct {
+	API       AdminAPIConfig       `yaml:"api"`
+	Dashboard AdminDashboardConfig `yaml:"dashboard"`
+}
+
+// AdminAPIConfig holds configuration for the admin REST API.
+type AdminAPIConfig struct {
+	Enabled bool `yaml:"enabled" env:"ADMIN_API_ENABLED"`
+}
+
+// AdminDashboardConfig holds configuration for the admin dashboard SPA.
+type AdminDashboardConfig struct {
+	Enabled bool `yaml:"enabled" env:"ADMIN_DASHBOARD_ENABLED"`
 }
 
 // GuardrailsConfig holds configuration for the request guardrails pipeline.
@@ -285,6 +302,10 @@ func defaultConfig() Config {
 			ResponseHeaderTimeout: 600,
 		},
 		Guardrails: GuardrailsConfig{},
+		Admin: AdminConfig{
+			API:       AdminAPIConfig{Enabled: true},
+			Dashboard: AdminDashboardConfig{Enabled: true},
+		},
 		Providers: make(map[string]ProviderConfig),
 	}
 }

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -1,0 +1,31 @@
+// Package admin provides HTTP handlers for the admin API.
+package admin
+
+import (
+	"time"
+
+	"gomodel/internal/core"
+)
+
+// RegistryInfo provides read-only access to model registry data.
+// *providers.ModelRegistry satisfies this interface.
+type RegistryInfo interface {
+	ModelCount() int
+	ProviderCount() int
+	ListModels() []core.Model
+	GetProviderType(model string) string
+}
+
+// AdminHandler serves admin API endpoints.
+type AdminHandler struct {
+	registry  RegistryInfo
+	startTime time.Time
+}
+
+// NewAdminHandler creates a new AdminHandler.
+func NewAdminHandler(registry RegistryInfo) *AdminHandler {
+	return &AdminHandler{
+		registry:  registry,
+		startTime: time.Now(),
+	}
+}

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -1,0 +1,125 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"gomodel/internal/core"
+)
+
+// mockRegistry implements RegistryInfo for testing.
+type mockRegistry struct {
+	models    []core.Model
+	providers map[string]string // model ID -> provider type
+}
+
+func (m *mockRegistry) ModelCount() int { return len(m.models) }
+func (m *mockRegistry) ProviderCount() int {
+	seen := map[string]bool{}
+	for _, pt := range m.providers {
+		seen[pt] = true
+	}
+	return len(seen)
+}
+func (m *mockRegistry) ListModels() []core.Model { return m.models }
+func (m *mockRegistry) GetProviderType(model string) string {
+	return m.providers[model]
+}
+
+func newTestHandler() *AdminHandler {
+	reg := &mockRegistry{
+		models: []core.Model{
+			{ID: "gpt-4", OwnedBy: "openai"},
+			{ID: "claude-3-opus", OwnedBy: "anthropic"},
+			{ID: "gemini-pro", OwnedBy: "google"},
+		},
+		providers: map[string]string{
+			"gpt-4":        "openai",
+			"claude-3-opus": "anthropic",
+			"gemini-pro":   "gemini",
+		},
+	}
+	return NewAdminHandler(reg)
+}
+
+func TestOverview(t *testing.T) {
+	h := newTestHandler()
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/api/v1/overview", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := h.Overview(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp OverviewResponse
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, resp.ModelCount)
+	assert.Equal(t, 3, resp.ProviderCount)
+	assert.NotEmpty(t, resp.Uptime)
+	assert.NotEmpty(t, resp.Version)
+	assert.NotEmpty(t, resp.GoVersion)
+}
+
+func TestModels(t *testing.T) {
+	h := newTestHandler()
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/api/v1/models", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := h.Models(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp ModelsResponse
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, resp.Total)
+	assert.Len(t, resp.Models, 3)
+
+	// Verify model entries have provider types
+	providersByModel := map[string]string{}
+	for _, m := range resp.Models {
+		providersByModel[m.ID] = m.Provider
+	}
+	assert.Equal(t, "openai", providersByModel["gpt-4"])
+	assert.Equal(t, "anthropic", providersByModel["claude-3-opus"])
+	assert.Equal(t, "gemini", providersByModel["gemini-pro"])
+}
+
+func TestModelsEmpty(t *testing.T) {
+	reg := &mockRegistry{
+		models:    []core.Model{},
+		providers: map[string]string{},
+	}
+	h := NewAdminHandler(reg)
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/api/v1/models", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := h.Models(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp ModelsResponse
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, resp.Total)
+	assert.Empty(t, resp.Models)
+}

--- a/internal/admin/models.go
+++ b/internal/admin/models.go
@@ -1,0 +1,26 @@
+package admin
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+// Models handles GET /admin/api/v1/models.
+func (h *AdminHandler) Models(c echo.Context) error {
+	coreModels := h.registry.ListModels()
+
+	entries := make([]AdminModelEntry, 0, len(coreModels))
+	for _, m := range coreModels {
+		entries = append(entries, AdminModelEntry{
+			ID:       m.ID,
+			Provider: h.registry.GetProviderType(m.ID),
+			OwnedBy:  m.OwnedBy,
+		})
+	}
+
+	return c.JSON(http.StatusOK, ModelsResponse{
+		Models: entries,
+		Total:  len(entries),
+	})
+}

--- a/internal/admin/overview.go
+++ b/internal/admin/overview.go
@@ -1,0 +1,24 @@
+package admin
+
+import (
+	"net/http"
+	"runtime"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"gomodel/internal/version"
+)
+
+// Overview handles GET /admin/api/v1/overview.
+func (h *AdminHandler) Overview(c echo.Context) error {
+	uptime := time.Since(h.startTime).Round(time.Second)
+
+	return c.JSON(http.StatusOK, OverviewResponse{
+		ModelCount:    h.registry.ModelCount(),
+		ProviderCount: h.registry.ProviderCount(),
+		Uptime:        uptime.String(),
+		Version:       version.Version,
+		GoVersion:     runtime.Version(),
+	})
+}

--- a/internal/admin/types.go
+++ b/internal/admin/types.go
@@ -1,0 +1,23 @@
+package admin
+
+// OverviewResponse is the JSON response for GET /admin/api/v1/overview.
+type OverviewResponse struct {
+	ModelCount    int    `json:"model_count"`
+	ProviderCount int    `json:"provider_count"`
+	Uptime        string `json:"uptime"`
+	Version       string `json:"version"`
+	GoVersion     string `json:"go_version"`
+}
+
+// AdminModelEntry represents a single model in the admin models list.
+type AdminModelEntry struct {
+	ID       string `json:"id"`
+	Provider string `json:"provider"`
+	OwnedBy  string `json:"owned_by"`
+}
+
+// ModelsResponse is the JSON response for GET /admin/api/v1/models.
+type ModelsResponse struct {
+	Models []AdminModelEntry `json:"models"`
+	Total  int               `json:"total"`
+}

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -10,8 +10,9 @@ import (
 
 // AuthMiddleware creates an Echo middleware that validates the master key
 // if it's configured. If masterKey is empty, no authentication is required.
-// skipPaths is a list of paths that should bypass authentication.
-func AuthMiddleware(masterKey string, skipPaths []string) echo.MiddlewareFunc {
+// skipPaths is a list of paths that should bypass authentication (exact match).
+// skipPrefixes is a list of path prefixes that should bypass authentication.
+func AuthMiddleware(masterKey string, skipPaths []string, skipPrefixes []string) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			// If no master key is configured, allow all requests
@@ -19,10 +20,17 @@ func AuthMiddleware(masterKey string, skipPaths []string) echo.MiddlewareFunc {
 				return next(c)
 			}
 
-			// Check if path should skip authentication
+			// Check if path should skip authentication (exact match)
 			requestPath := c.Request().URL.Path
 			for _, skipPath := range skipPaths {
 				if requestPath == skipPath {
+					return next(c)
+				}
+			}
+
+			// Check if path should skip authentication (prefix match)
+			for _, prefix := range skipPrefixes {
+				if strings.HasPrefix(requestPath, prefix) {
 					return next(c)
 				}
 			}

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -81,7 +81,7 @@ func TestAuthMiddleware(t *testing.T) {
 			}
 
 			// Wrap the handler with auth middleware
-			handler := AuthMiddleware(tt.masterKey, nil)(testHandler)
+			handler := AuthMiddleware(tt.masterKey, nil, nil)(testHandler)
 
 			// Create request
 			req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -112,7 +112,7 @@ func TestAuthMiddleware(t *testing.T) {
 func TestAuthMiddleware_Integration(t *testing.T) {
 	t.Run("with master key - protects all routes", func(t *testing.T) {
 		e := echo.New()
-		e.Use(AuthMiddleware("my-secret-key", nil))
+		e.Use(AuthMiddleware("my-secret-key", nil, nil))
 
 		e.GET("/test", func(c echo.Context) error {
 			return c.String(http.StatusOK, "success")
@@ -135,7 +135,7 @@ func TestAuthMiddleware_Integration(t *testing.T) {
 
 	t.Run("without master key - allows all routes", func(t *testing.T) {
 		e := echo.New()
-		e.Use(AuthMiddleware("", nil))
+		e.Use(AuthMiddleware("", nil, nil))
 
 		e.GET("/test", func(c echo.Context) error {
 			return c.String(http.StatusOK, "success")
@@ -153,7 +153,7 @@ func TestAuthMiddleware_Integration(t *testing.T) {
 func TestAuthMiddleware_SkipPaths(t *testing.T) {
 	t.Run("skips authentication for specified paths", func(t *testing.T) {
 		e := echo.New()
-		e.Use(AuthMiddleware("my-secret-key", []string{"/health", "/metrics"}))
+		e.Use(AuthMiddleware("my-secret-key", []string{"/health", "/metrics"}, nil))
 
 		e.GET("/health", func(c echo.Context) error {
 			return c.String(http.StatusOK, "healthy")
@@ -196,7 +196,7 @@ func TestAuthMiddleware_SkipPaths(t *testing.T) {
 
 	t.Run("empty skip paths requires auth for all routes", func(t *testing.T) {
 		e := echo.New()
-		e.Use(AuthMiddleware("my-secret-key", []string{}))
+		e.Use(AuthMiddleware("my-secret-key", []string{}, nil))
 
 		e.GET("/health", func(c echo.Context) error {
 			return c.String(http.StatusOK, "healthy")
@@ -267,7 +267,7 @@ func TestAuthMiddleware_ConstantTimeComparison(t *testing.T) {
 				}
 
 				// Wrap with auth middleware
-				handler := AuthMiddleware(tc.masterKey, nil)(testHandler)
+				handler := AuthMiddleware(tc.masterKey, nil, nil)(testHandler)
 
 				// Create request
 				req := httptest.NewRequest(http.MethodGet, "/", nil)

--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"embed"
+	"io/fs"
+	"net/http"
+	"path"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+)
+
+//go:embed dashboard_dist
+var dashboardFS embed.FS
+
+// RegisterDashboard mounts the embedded SPA under /admin/.
+// It serves static files from the embedded filesystem and falls back
+// to index.html for client-side routing.
+func RegisterDashboard(e *echo.Echo) {
+	// Strip the "dashboard_dist" prefix so files are served from root
+	sub, err := fs.Sub(dashboardFS, "dashboard_dist")
+	if err != nil {
+		panic("failed to create sub filesystem for dashboard: " + err.Error())
+	}
+
+	handler := spaHandler(sub)
+	e.GET("/admin/*", handler)
+	e.GET("/admin", func(c echo.Context) error {
+		return c.Redirect(http.StatusMovedPermanently, "/admin/")
+	})
+}
+
+// spaHandler returns an Echo handler that serves files from the given FS.
+// If the requested file doesn't exist, it falls back to index.html
+// to support client-side routing.
+func spaHandler(fsys fs.FS) echo.HandlerFunc {
+	fileServer := http.FileServer(http.FS(fsys))
+
+	return func(c echo.Context) error {
+		// Get the path relative to /admin/
+		reqPath := c.Param("*")
+		if reqPath == "" {
+			reqPath = "index.html"
+		}
+
+		// Clean the path to prevent directory traversal
+		reqPath = path.Clean(reqPath)
+		reqPath = strings.TrimPrefix(reqPath, "/")
+
+		// Check if the file exists in the embedded FS
+		f, err := fsys.Open(reqPath)
+		if err != nil {
+			// File not found — serve index.html for client-side routing
+			reqPath = "index.html"
+		} else {
+			f.Close()
+		}
+
+		// Rewrite request path for the file server
+		c.Request().URL.Path = "/" + reqPath
+		fileServer.ServeHTTP(c.Response(), c.Request())
+		return nil
+	}
+}

--- a/internal/server/dashboard_dist/index.html
+++ b/internal/server/dashboard_dist/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><title>GOModel Dashboard</title></head>
+<body>
+<p>Dashboard not built. Run <code>make build-dashboard</code></p>
+</body>
+</html>

--- a/web/dashboard/index.html
+++ b/web/dashboard/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>GOModel Dashboard</title>
+</head>
+<body class="bg-gray-50 text-gray-900">
+  <div id="app"></div>
+  <script type="module" src="/src/index.jsx"></script>
+</body>
+</html>

--- a/web/dashboard/package.json
+++ b/web/dashboard/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "gomodel-dashboard",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "preact": "^10.25.4",
+    "preact-router": "^4.1.2",
+    "chart.js": "^4.4.7"
+  },
+  "devDependencies": {
+    "@preact/preset-vite": "^2.9.4",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.17",
+    "vite": "^6.0.7"
+  }
+}

--- a/web/dashboard/postcss.config.js
+++ b/web/dashboard/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/web/dashboard/src/api.js
+++ b/web/dashboard/src/api.js
@@ -1,0 +1,17 @@
+const BASE = '/admin/api/v1';
+
+async function fetchJSON(path) {
+  const res = await fetch(`${BASE}${path}`);
+  if (!res.ok) {
+    throw new Error(`API error: ${res.status} ${res.statusText}`);
+  }
+  return res.json();
+}
+
+export function getOverview() {
+  return fetchJSON('/overview');
+}
+
+export function getModels() {
+  return fetchJSON('/models');
+}

--- a/web/dashboard/src/app.jsx
+++ b/web/dashboard/src/app.jsx
@@ -1,0 +1,19 @@
+import Router from 'preact-router';
+import Sidebar from './components/Sidebar';
+import Overview from './pages/Overview';
+import Models from './pages/Models';
+
+export default function App() {
+  return (
+    <div class="flex min-h-screen">
+      <Sidebar />
+      <main class="flex-1 p-6 ml-64">
+        <Router>
+          <Overview path="/admin/" />
+          <Overview path="/admin" />
+          <Models path="/admin/models" />
+        </Router>
+      </main>
+    </div>
+  );
+}

--- a/web/dashboard/src/components/ModelTable.jsx
+++ b/web/dashboard/src/components/ModelTable.jsx
@@ -1,0 +1,99 @@
+import { useState, useMemo } from 'preact/hooks';
+
+export default function ModelTable({ models }) {
+  const [search, setSearch] = useState('');
+  const [sortKey, setSortKey] = useState('id');
+  const [sortAsc, setSortAsc] = useState(true);
+
+  const filtered = useMemo(() => {
+    const q = search.toLowerCase();
+    let list = models.filter(
+      (m) =>
+        m.id.toLowerCase().includes(q) ||
+        m.provider.toLowerCase().includes(q) ||
+        m.owned_by.toLowerCase().includes(q)
+    );
+
+    list.sort((a, b) => {
+      const aVal = a[sortKey] || '';
+      const bVal = b[sortKey] || '';
+      const cmp = aVal.localeCompare(bVal);
+      return sortAsc ? cmp : -cmp;
+    });
+
+    return list;
+  }, [models, search, sortKey, sortAsc]);
+
+  function handleSort(key) {
+    if (sortKey === key) {
+      setSortAsc(!sortAsc);
+    } else {
+      setSortKey(key);
+      setSortAsc(true);
+    }
+  }
+
+  function SortHeader({ label, field }) {
+    const active = sortKey === field;
+    return (
+      <th
+        class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:text-gray-700 select-none"
+        onClick={() => handleSort(field)}
+      >
+        {label}
+        {active && (
+          <span class="ml-1">{sortAsc ? '\u2191' : '\u2193'}</span>
+        )}
+      </th>
+    );
+  }
+
+  return (
+    <div>
+      <div class="mb-4">
+        <input
+          type="text"
+          placeholder="Search models..."
+          value={search}
+          onInput={(e) => setSearch(e.target.value)}
+          class="w-full max-w-md px-4 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+        />
+      </div>
+      <div class="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+        <table class="min-w-full divide-y divide-gray-200">
+          <thead class="bg-gray-50">
+            <tr>
+              <SortHeader label="Model ID" field="id" />
+              <SortHeader label="Provider" field="provider" />
+              <SortHeader label="Owned By" field="owned_by" />
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-200">
+            {filtered.length === 0 ? (
+              <tr>
+                <td colspan="3" class="px-4 py-8 text-center text-sm text-gray-500">
+                  {search ? 'No models match your search.' : 'No models available.'}
+                </td>
+              </tr>
+            ) : (
+              filtered.map((m) => (
+                <tr key={m.id} class="hover:bg-gray-50">
+                  <td class="px-4 py-3 text-sm font-mono text-gray-900">{m.id}</td>
+                  <td class="px-4 py-3 text-sm">
+                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                      {m.provider}
+                    </span>
+                  </td>
+                  <td class="px-4 py-3 text-sm text-gray-500">{m.owned_by}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+        <div class="px-4 py-3 bg-gray-50 text-xs text-gray-500 border-t border-gray-200">
+          {filtered.length} of {models.length} models
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/dashboard/src/components/Sidebar.jsx
+++ b/web/dashboard/src/components/Sidebar.jsx
@@ -1,0 +1,59 @@
+import { useRoute } from 'preact-router';
+
+const navItems = [
+  { href: '/admin/', label: 'Overview', icon: HomeIcon },
+  { href: '/admin/models', label: 'Models', icon: ModelsIcon },
+];
+
+function HomeIcon() {
+  return (
+    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+        d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-4 0h4" />
+    </svg>
+  );
+}
+
+function ModelsIcon() {
+  return (
+    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+        d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+    </svg>
+  );
+}
+
+export default function Sidebar() {
+  return (
+    <aside class="fixed left-0 top-0 h-full w-64 bg-gray-900 text-white flex flex-col">
+      <div class="p-5 border-b border-gray-700">
+        <h1 class="text-xl font-bold tracking-tight">GOModel</h1>
+        <p class="text-xs text-gray-400 mt-1">Admin Dashboard</p>
+      </div>
+      <nav class="flex-1 py-4">
+        {navItems.map((item) => (
+          <NavLink key={item.href} href={item.href} label={item.label} Icon={item.icon} />
+        ))}
+      </nav>
+    </aside>
+  );
+}
+
+function NavLink({ href, label, Icon }) {
+  const [matches] = useRoute(href);
+  const active = matches;
+
+  return (
+    <a
+      href={href}
+      class={`flex items-center gap-3 px-5 py-2.5 text-sm transition-colors ${
+        active
+          ? 'bg-gray-800 text-white border-r-2 border-blue-500'
+          : 'text-gray-300 hover:bg-gray-800 hover:text-white'
+      }`}
+    >
+      <Icon />
+      {label}
+    </a>
+  );
+}

--- a/web/dashboard/src/components/StatsCard.jsx
+++ b/web/dashboard/src/components/StatsCard.jsx
@@ -1,0 +1,11 @@
+export default function StatsCard({ title, value, subtitle }) {
+  return (
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+      <p class="text-sm font-medium text-gray-500">{title}</p>
+      <p class="mt-2 text-3xl font-semibold text-gray-900">{value}</p>
+      {subtitle && (
+        <p class="mt-1 text-sm text-gray-400">{subtitle}</p>
+      )}
+    </div>
+  );
+}

--- a/web/dashboard/src/index.css
+++ b/web/dashboard/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/web/dashboard/src/index.jsx
+++ b/web/dashboard/src/index.jsx
@@ -1,0 +1,5 @@
+import { render } from 'preact';
+import App from './app';
+import './index.css';
+
+render(<App />, document.getElementById('app'));

--- a/web/dashboard/src/pages/Models.jsx
+++ b/web/dashboard/src/pages/Models.jsx
@@ -1,0 +1,33 @@
+import { useState, useEffect } from 'preact/hooks';
+import { getModels } from '../api';
+import ModelTable from '../components/ModelTable';
+
+export default function Models() {
+  const [data, setData] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    getModels()
+      .then(setData)
+      .catch((err) => setError(err.message));
+  }, []);
+
+  if (error) {
+    return (
+      <div class="p-4 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
+        Failed to load models: {error}
+      </div>
+    );
+  }
+
+  if (!data) {
+    return <p class="text-gray-500 text-sm">Loading...</p>;
+  }
+
+  return (
+    <div>
+      <h2 class="text-2xl font-bold text-gray-900 mb-6">Models</h2>
+      <ModelTable models={data.models} />
+    </div>
+  );
+}

--- a/web/dashboard/src/pages/Overview.jsx
+++ b/web/dashboard/src/pages/Overview.jsx
@@ -1,0 +1,38 @@
+import { useState, useEffect } from 'preact/hooks';
+import { getOverview } from '../api';
+import StatsCard from '../components/StatsCard';
+
+export default function Overview() {
+  const [data, setData] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    getOverview()
+      .then(setData)
+      .catch((err) => setError(err.message));
+  }, []);
+
+  if (error) {
+    return (
+      <div class="p-4 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
+        Failed to load overview: {error}
+      </div>
+    );
+  }
+
+  if (!data) {
+    return <p class="text-gray-500 text-sm">Loading...</p>;
+  }
+
+  return (
+    <div>
+      <h2 class="text-2xl font-bold text-gray-900 mb-6">Overview</h2>
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        <StatsCard title="Models" value={data.model_count} />
+        <StatsCard title="Providers" value={data.provider_count} />
+        <StatsCard title="Uptime" value={data.uptime} />
+        <StatsCard title="Version" value={data.version} subtitle={data.go_version} />
+      </div>
+    </div>
+  );
+}

--- a/web/dashboard/tailwind.config.js
+++ b/web/dashboard/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{js,jsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/web/dashboard/vite.config.js
+++ b/web/dashboard/vite.config.js
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import preact from '@preact/preset-vite';
+
+export default defineConfig({
+  plugins: [preact()],
+  base: '/admin/',
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+  },
+  server: {
+    proxy: {
+      '/admin/api': 'http://localhost:8080',
+    },
+  },
+});


### PR DESCRIPTION
Add admin REST API (/admin/api/v1/) for gateway monitoring with overview and models endpoints, plus an embedded Preact SPA dashboard served at /admin/. Both are behind independent feature flags (ADMIN_API_ENABLED, ADMIN_DASHBOARD_ENABLED) defaulting to true. Dashboard auto-disables when API is disabled. Auth middleware extended with prefix-based skipping so dashboard paths bypass auth while API-only mode requires master key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Admin API endpoints for system overview and model information
  * Added Admin dashboard interface for viewing system metrics and models
  * Added configuration options to enable/disable admin features

* **Tests**
  * Added test coverage for admin functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->