### PR TITLE
feat: add admin dashboard and API behind ADMIN_ENDPOINTS_ENABLED and ADMIN_UI_ENABLED feature flags

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -17,7 +17,8 @@
       "WebFetch(domain:docs.anthropic.com)",
       "mcp__linear-server__list_projects",
       "mcp__linear-server__list_issues",
-      "mcp__linear-server__get_issue"
+      "mcp__linear-server__get_issue",
+      "Bash(make build:*)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -20,7 +20,9 @@
       "mcp__linear-server__get_issue",
       "Bash(make build:*)",
       "Bash(git add:*)",
-      "Bash(git commit:*)"
+      "Bash(git commit:*)",
+      "Bash(git push)",
+      "Bash(git -C:*)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,7 +18,9 @@
       "mcp__linear-server__list_projects",
       "mcp__linear-server__list_issues",
       "mcp__linear-server__get_issue",
-      "Bash(make build:*)"
+      "Bash(make build:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)"
     ],
     "deny": [],
     "ask": []

--- a/.env.template
+++ b/.env.template
@@ -37,12 +37,18 @@
 # GOMODEL_CACHE_DIR=.cache
 
 # =============================================================================
-# Admin Dashboard & API Configuration
+# Admin API & Dashboard Configuration
 # =============================================================================
 
-# Enable/disable admin dashboard and API (default: true)
-# When enabled, provides /admin/dashboard UI and /admin/api/v1/* REST endpoints
-# ADMIN_ENABLED=true
+# Enable/disable admin REST API endpoints (default: true)
+# When enabled, provides /admin/api/v1/* REST endpoints
+# ADMIN_ENDPOINTS_ENABLED=true
+
+# Enable/disable admin dashboard UI (default: true)
+# When enabled, provides /admin/dashboard UI
+# Requires ADMIN_ENDPOINTS_ENABLED=true — if endpoints are disabled
+# and UI is enabled, a warning is logged and UI is forced to disabled
+# ADMIN_UI_ENABLED=true
 
 # =============================================================================
 # Storage Configuration (used by audit logging, usage tracking, future IAM, etc.)

--- a/.env.template
+++ b/.env.template
@@ -37,6 +37,14 @@
 # GOMODEL_CACHE_DIR=.cache
 
 # =============================================================================
+# Admin Dashboard & API Configuration
+# =============================================================================
+
+# Enable/disable admin dashboard and API (default: true)
+# When enabled, provides /admin/dashboard UI and /admin/api/v1/* REST endpoints
+# ADMIN_ENABLED=true
+
+# =============================================================================
 # Storage Configuration (used by audit logging, usage tracking, future IAM, etc.)
 # =============================================================================
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,23 @@ Full reference: `.env.template` and `config/config.yaml`
 - **Guardrails:** Configured via `config/config.yaml` only (except `GUARDRAILS_ENABLED` env var)
 - **Providers:** `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `XAI_API_KEY`, `GROQ_API_KEY`, `OLLAMA_BASE_URL`
 
+## Documentation Maintenance
+
+After completing any code change, routinely check whether documentation needs updating. This applies to all three documentation layers:
+
+1. **README files** (`README.md`, `helm/README.md`, `tests/contract/README.md`) — Update when adding/removing features, changing setup steps, modifying CLI flags, or altering configuration options.
+2. **In-code documentation** (Go doc comments on exported types, functions, interfaces) — Update when changing public APIs, adding new exported symbols, or modifying function signatures/behavior.
+3. **Mintlify / technical docs** (`docs/` directory) — Update `docs/advanced/*.mdx` pages when changing configuration options or guardrails behavior. Update `docs/adr/` when making significant architectural decisions. Update `docs/plans/` if implementation diverges from existing plans. Check `docs.json` if new pages need to be added to the navigation.
+
+**When to update:**
+- Adding a new provider, endpoint, config option, or feature
+- Changing existing behavior, defaults, or API contracts
+- Renaming or removing configuration variables
+- Adding or modifying middleware, guardrails, or storage backends
+- Changing build/test commands or requirements
+
+**How to check:** After making changes, scan the affected documentation layers for stale or missing information. Do not add speculative documentation for unimplemented features — only document what exists.
+
 ## Key Details
 
 1. Providers are registered explicitly via `factory.Register()` in main.go — order matters, first registered wins for duplicate model names

--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ docker run --rm -p 8080:8080 --env-file .env gomodel
 | `/v1/models` | GET | List available models |
 | `/health` | GET | Health check |
 | `/metrics` | GET | Prometheus metrics (when enabled) |
+| `/admin/api/v1/usage/summary` | GET | Aggregate token usage statistics |
+| `/admin/api/v1/usage/daily` | GET | Per-period token usage breakdown |
+| `/admin/api/v1/models` | GET | List models with provider type |
+| `/admin/dashboard` | GET | Admin dashboard UI |
 
 ---
 
@@ -194,10 +198,10 @@ See [DEVELOPMENT.md](DEVELOPMENT.md) for testing, linting, and pre-commit setup.
 | Full-observability         | 🚧   | 🚧   |
 | Budget management          | 🚧   | 🚧   |
 | Many keys support          | 🚧   | 🚧   |
-| Administrative endpoints   | 🚧   | 🚧   |
-| Guardrails                 | 🚧   | 🚧   |
+| Administrative endpoints   | ✅   | 🚧   |
+| Guardrails                 | ✅   | 🚧   |
 | SSO                        | 🚧   | 🚧   |
-| System Prompt (GuardRails) | 🚧   | 🚧   |
+| System Prompt (GuardRails) | ✅   | 🚧   |
 
 ## Integrations
 

--- a/config/config.go
+++ b/config/config.go
@@ -39,11 +39,17 @@ type Config struct {
 	Providers  map[string]ProviderConfig `yaml:"providers"`
 }
 
-// AdminConfig holds configuration for the admin dashboard and API.
+// AdminConfig holds configuration for the admin API and dashboard UI.
 type AdminConfig struct {
-	// Enabled controls whether the admin API and dashboard are active
+	// EndpointsEnabled controls whether the admin REST API is active
 	// Default: true
-	Enabled bool `yaml:"enabled" env:"ADMIN_ENABLED"`
+	EndpointsEnabled bool `yaml:"endpoints_enabled" env:"ADMIN_ENDPOINTS_ENABLED"`
+
+	// UIEnabled controls whether the admin dashboard UI is active
+	// Requires EndpointsEnabled — if endpoints are disabled and UI is enabled,
+	// a warning is logged and UI is forced to false.
+	// Default: true
+	UIEnabled bool `yaml:"ui_enabled" env:"ADMIN_UI_ENABLED"`
 }
 
 // GuardrailsConfig holds configuration for the request guardrails pipeline.
@@ -292,7 +298,7 @@ func defaultConfig() Config {
 			Timeout:               600,
 			ResponseHeaderTimeout: 600,
 		},
-		Admin:      AdminConfig{Enabled: true},
+		Admin:      AdminConfig{EndpointsEnabled: true, UIEnabled: true},
 		Guardrails: GuardrailsConfig{},
 		Providers:  make(map[string]ProviderConfig),
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -34,8 +34,16 @@ type Config struct {
 	Usage      UsageConfig               `yaml:"usage"`
 	Metrics    MetricsConfig             `yaml:"metrics"`
 	HTTP       HTTPConfig                `yaml:"http"`
+	Admin      AdminConfig               `yaml:"admin"`
 	Guardrails GuardrailsConfig          `yaml:"guardrails"`
 	Providers  map[string]ProviderConfig `yaml:"providers"`
+}
+
+// AdminConfig holds configuration for the admin dashboard and API.
+type AdminConfig struct {
+	// Enabled controls whether the admin API and dashboard are active
+	// Default: true
+	Enabled bool `yaml:"enabled" env:"ADMIN_ENABLED"`
 }
 
 // GuardrailsConfig holds configuration for the request guardrails pipeline.
@@ -215,7 +223,7 @@ type RedisConfig struct {
 // ServerConfig holds HTTP server configuration
 type ServerConfig struct {
 	Port          string `yaml:"port" env:"PORT"`
-	MasterKey     string `yaml:"master_key" env:"GOMODEL_MASTER_KEY"`         // Optional: Master key for authentication
+	MasterKey     string `yaml:"master_key" env:"GOMODEL_MASTER_KEY"`   // Optional: Master key for authentication
 	BodySizeLimit string `yaml:"body_size_limit" env:"BODY_SIZE_LIMIT"` // Max request body size (e.g., "10M", "1024K")
 }
 
@@ -284,8 +292,9 @@ func defaultConfig() Config {
 			Timeout:               600,
 			ResponseHeaderTimeout: 600,
 		},
+		Admin:      AdminConfig{Enabled: true},
 		Guardrails: GuardrailsConfig{},
-		Providers: make(map[string]ProviderConfig),
+		Providers:  make(map[string]ProviderConfig),
 	}
 }
 

--- a/docs/advanced/admin-endpoints.mdx
+++ b/docs/advanced/admin-endpoints.mdx
@@ -1,0 +1,176 @@
+---
+title: "Admin Endpoints"
+description: "Built-in REST API and dashboard for monitoring usage, models, and gateway health."
+---
+
+## Philosophy
+
+GOModel ships with admin endpoints **enabled by default**. The goal is simple: you should be able to deploy GOModel and immediately have visibility into what's happening — no extra services, no separate monitoring stack, no configuration.
+
+The admin layer is split into two independently controllable pieces:
+
+1. **Admin REST API** (`/admin/api/v1/*`) — machine-readable JSON endpoints for usage data and model inventory. Protected by `GOMODEL_MASTER_KEY` like all other API routes.
+2. **Admin Dashboard UI** (`/admin/dashboard`) — a lightweight, embedded HTML dashboard that visualizes the same data. No external dependencies, no JavaScript frameworks to install — it's compiled into the binary.
+
+Both are on by default because observability shouldn't be opt-in. If you don't need them, turn them off with a single environment variable.
+
+## Configuration
+
+| Variable                  | Description                          | Default |
+| ------------------------- | ------------------------------------ | ------- |
+| `ADMIN_ENDPOINTS_ENABLED` | Enable the admin REST API            | `true`  |
+| `ADMIN_UI_ENABLED`        | Enable the admin dashboard UI        | `true`  |
+
+Or in YAML:
+
+```yaml
+admin:
+  endpoints_enabled: true
+  ui_enabled: true
+```
+
+<Note>
+  The dashboard UI requires the REST API to be enabled. If you set
+  `ADMIN_ENDPOINTS_ENABLED=false` but leave `ADMIN_UI_ENABLED=true`, the UI
+  will be automatically disabled with a warning in the logs.
+</Note>
+
+## Authentication
+
+The admin REST API endpoints (`/admin/api/v1/*`) are protected by the same `GOMODEL_MASTER_KEY` authentication as the main API routes. Include the key as a Bearer token:
+
+```bash
+curl -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
+  http://localhost:8080/admin/api/v1/usage/summary
+```
+
+The dashboard UI pages (`/admin/dashboard`) and static assets (`/admin/static/*`) **skip authentication** so the dashboard is accessible without configuring API keys in the browser.
+
+<Warning>
+  If your GOModel instance is publicly accessible, be aware that the dashboard
+  UI is unauthenticated. Disable it with `ADMIN_UI_ENABLED=false` or restrict
+  access at the network level.
+</Warning>
+
+## REST API Endpoints
+
+All admin API endpoints are mounted under `/admin/api/v1`.
+
+### GET /admin/api/v1/usage/summary
+
+Returns aggregate token usage statistics over a configurable time window.
+
+**Query parameters:**
+
+| Parameter | Type | Description               | Default |
+| --------- | ---- | ------------------------- | ------- |
+| `days`    | int  | Number of days to look back | `30`  |
+
+**Response:**
+
+```json
+{
+  "total_requests": 1542,
+  "total_input_tokens": 2450000,
+  "total_output_tokens": 890000,
+  "total_tokens": 3340000
+}
+```
+
+If usage tracking is disabled, returns zeroed values.
+
+### GET /admin/api/v1/usage/daily
+
+Returns per-day token usage breakdown over a configurable time window.
+
+**Query parameters:**
+
+| Parameter | Type | Description               | Default |
+| --------- | ---- | ------------------------- | ------- |
+| `days`    | int  | Number of days to look back | `30`  |
+
+**Response:**
+
+```json
+[
+  {
+    "date": "2026-02-17",
+    "requests": 84,
+    "input_tokens": 120000,
+    "output_tokens": 45000,
+    "total_tokens": 165000
+  },
+  {
+    "date": "2026-02-16",
+    "requests": 102,
+    "input_tokens": 155000,
+    "output_tokens": 58000,
+    "total_tokens": 213000
+  }
+]
+```
+
+Returns an empty array if usage tracking is disabled or no data exists for the period.
+
+### GET /admin/api/v1/models
+
+Returns all registered models with their provider type.
+
+**Response:**
+
+```json
+[
+  {
+    "model": {
+      "id": "gpt-4o",
+      "object": "model",
+      "created": 1715367049,
+      "owned_by": "system"
+    },
+    "provider_type": "openai"
+  },
+  {
+    "model": {
+      "id": "claude-sonnet-4-5-20250929",
+      "object": "model",
+      "created": 1727568000,
+      "owned_by": "system"
+    },
+    "provider_type": "anthropic"
+  }
+]
+```
+
+This differs from the standard `/v1/models` endpoint: the admin version includes `provider_type` for each model, making it useful for understanding which provider serves which model.
+
+## Admin Dashboard
+
+The dashboard is a server-rendered HTML page embedded in the GOModel binary. Access it at:
+
+```
+http://localhost:8080/admin/dashboard
+```
+
+It provides a visual overview of usage statistics and registered models using the same data as the REST API endpoints above.
+
+## Disabling Admin Features
+
+To disable all admin features:
+
+```bash
+export ADMIN_ENDPOINTS_ENABLED=false
+```
+
+This disables both the REST API and the dashboard UI. To keep the API but hide the dashboard:
+
+```bash
+export ADMIN_ENDPOINTS_ENABLED=true
+export ADMIN_UI_ENABLED=false
+```
+
+<Tip>
+  The admin layer is designed to degrade gracefully. If usage tracking is off,
+  the usage endpoints return empty results instead of errors. If the model
+  registry isn't ready, the models endpoint returns an empty array. The gateway
+  keeps running regardless.
+</Tip>

--- a/docs/advanced/admin-endpoints.mdx
+++ b/docs/advanced/admin-endpoints.mdx
@@ -62,9 +62,13 @@ Returns aggregate token usage statistics over a configurable time window.
 
 **Query parameters:**
 
-| Parameter | Type | Description               | Default |
-| --------- | ---- | ------------------------- | ------- |
-| `days`    | int  | Number of days to look back | `30`  |
+| Parameter    | Type   | Description                                              | Default              |
+| ------------ | ------ | -------------------------------------------------------- | -------------------- |
+| `start_date` | string | Range start in `YYYY-MM-DD` format                       | 29 days before end   |
+| `end_date`   | string | Range end in `YYYY-MM-DD` format                         | Today                |
+| `days`       | int    | Shorthand for look-back window (ignored if dates are set) | `30`                |
+
+Use `start_date`/`end_date` for explicit ranges or `days` as a shorthand. When both are provided, `start_date`/`end_date` take priority.
 
 **Response:**
 
@@ -81,13 +85,18 @@ If usage tracking is disabled, returns zeroed values.
 
 ### GET /admin/api/v1/usage/daily
 
-Returns per-day token usage breakdown over a configurable time window.
+Returns per-period token usage breakdown over a configurable time window, grouped by the specified interval.
 
 **Query parameters:**
 
-| Parameter | Type | Description               | Default |
-| --------- | ---- | ------------------------- | ------- |
-| `days`    | int  | Number of days to look back | `30`  |
+| Parameter    | Type   | Description                                              | Default              |
+| ------------ | ------ | -------------------------------------------------------- | -------------------- |
+| `start_date` | string | Range start in `YYYY-MM-DD` format                       | 29 days before end   |
+| `end_date`   | string | Range end in `YYYY-MM-DD` format                         | Today                |
+| `days`       | int    | Shorthand for look-back window (ignored if dates are set) | `30`                |
+| `interval`   | string | Grouping: `daily`, `weekly`, `monthly`, `yearly`         | `daily`              |
+
+The `date` field in the response changes format based on the interval: `YYYY-MM-DD` (daily), `YYYY-Www` (weekly), `YYYY-MM` (monthly), or `YYYY` (yearly).
 
 **Response:**
 

--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -101,6 +101,13 @@ Storage is shared by audit logging, usage tracking, and future features like IAM
 | `METRICS_ENABLED`  | Enable Prometheus metrics | `false`    |
 | `METRICS_ENDPOINT` | HTTP path for metrics     | `/metrics` |
 
+#### Admin
+
+| Variable                  | Description                   | Default |
+| ------------------------- | ----------------------------- | ------- |
+| `ADMIN_ENDPOINTS_ENABLED` | Enable the admin REST API     | `true`  |
+| `ADMIN_UI_ENABLED`        | Enable the admin dashboard UI | `true`  |
+
 #### HTTP Client
 
 These control timeouts for upstream API requests to LLM providers.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -9,7 +9,7 @@
         "pages": [
             {
                 "group": "Advanced",
-                "pages": ["advanced/configuration", "advanced/guardrails"]
+                "pages": ["advanced/configuration", "advanced/guardrails", "advanced/admin-endpoints"]
             }
         ]
     }

--- a/internal/admin/dashboard/dashboard.go
+++ b/internal/admin/dashboard/dashboard.go
@@ -2,6 +2,7 @@
 package dashboard
 
 import (
+	"bytes"
 	"embed"
 	"html/template"
 	"io/fs"
@@ -39,8 +40,14 @@ func New() (*Handler, error) {
 
 // Index serves GET /admin/dashboard — the main dashboard page.
 func (h *Handler) Index(c echo.Context) error {
+	var buf bytes.Buffer
+	if err := h.indexTmpl.ExecuteTemplate(&buf, "layout", nil); err != nil {
+		return err
+	}
 	c.Response().Header().Set("Content-Type", "text/html; charset=utf-8")
-	return h.indexTmpl.ExecuteTemplate(c.Response().Writer, "layout", nil)
+	c.Response().WriteHeader(http.StatusOK)
+	_, err := buf.WriteTo(c.Response().Writer)
+	return err
 }
 
 // Static serves GET /admin/static/* — embedded CSS/JS assets.

--- a/internal/admin/dashboard/dashboard.go
+++ b/internal/admin/dashboard/dashboard.go
@@ -10,7 +10,7 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-//go:embed templates/*.html static/css/*.css static/js/*.js
+//go:embed templates/*.html static/css/*.css static/js/*.js static/*.svg
 var content embed.FS
 
 // Handler serves the admin dashboard UI.

--- a/internal/admin/dashboard/dashboard.go
+++ b/internal/admin/dashboard/dashboard.go
@@ -1,0 +1,50 @@
+// Package dashboard provides the embedded admin dashboard UI for GOModel.
+package dashboard
+
+import (
+	"embed"
+	"html/template"
+	"io/fs"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+//go:embed templates/*.html static/css/*.css static/js/*.js
+var content embed.FS
+
+// Handler serves the admin dashboard UI.
+type Handler struct {
+	indexTmpl *template.Template
+	staticFS  http.Handler
+}
+
+// New creates a new dashboard handler with parsed templates and static file server.
+func New() (*Handler, error) {
+	tmpl, err := template.ParseFS(content, "templates/layout.html", "templates/index.html")
+	if err != nil {
+		return nil, err
+	}
+
+	staticSub, err := fs.Sub(content, "static")
+	if err != nil {
+		return nil, err
+	}
+
+	return &Handler{
+		indexTmpl: tmpl,
+		staticFS:  http.StripPrefix("/admin/static/", http.FileServer(http.FS(staticSub))),
+	}, nil
+}
+
+// Index serves GET /admin/dashboard — the main dashboard page.
+func (h *Handler) Index(c echo.Context) error {
+	c.Response().Header().Set("Content-Type", "text/html; charset=utf-8")
+	return h.indexTmpl.ExecuteTemplate(c.Response().Writer, "layout", nil)
+}
+
+// Static serves GET /admin/static/* — embedded CSS/JS assets.
+func (h *Handler) Static(c echo.Context) error {
+	h.staticFS.ServeHTTP(c.Response().Writer, c.Request())
+	return nil
+}

--- a/internal/admin/dashboard/dashboard_test.go
+++ b/internal/admin/dashboard/dashboard_test.go
@@ -1,0 +1,139 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+func TestNew(t *testing.T) {
+	h, err := New()
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+	if h == nil {
+		t.Fatal("New() returned nil handler")
+	}
+}
+
+func TestIndex_ReturnsHTML(t *testing.T) {
+	h, err := New()
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/admin/dashboard", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.Index(c); err != nil {
+		t.Fatalf("Index() returned error: %v", err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+
+	contentType := rec.Header().Get("Content-Type")
+	if contentType != "text/html; charset=utf-8" {
+		t.Errorf("expected Content-Type text/html; charset=utf-8, got %s", contentType)
+	}
+
+	body := strings.ToLower(rec.Body.String())
+	if !strings.Contains(body, "<!doctype html") && !strings.Contains(body, "<html") {
+		t.Errorf("expected HTML content, got: %.200s", rec.Body.String())
+	}
+}
+
+func TestStatic_ServesCSS(t *testing.T) {
+	h, err := New()
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/admin/static/css/dashboard.css", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.Static(c); err != nil {
+		t.Fatalf("Static() returned error: %v", err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	if rec.Body.Len() == 0 {
+		t.Error("expected non-empty body for CSS file")
+	}
+}
+
+func TestStatic_ServesJS(t *testing.T) {
+	h, err := New()
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/admin/static/js/dashboard.js", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.Static(c); err != nil {
+		t.Fatalf("Static() returned error: %v", err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	if rec.Body.Len() == 0 {
+		t.Error("expected non-empty body for JS file")
+	}
+}
+
+func TestStatic_ServesFavicon(t *testing.T) {
+	h, err := New()
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/admin/static/favicon.svg", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.Static(c); err != nil {
+		t.Fatalf("Static() returned error: %v", err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	if rec.Body.Len() == 0 {
+		t.Error("expected non-empty body for favicon")
+	}
+}
+
+func TestStatic_NotFound(t *testing.T) {
+	h, err := New()
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/admin/static/nonexistent.txt", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.Static(c); err != nil {
+		t.Fatalf("Static() returned error: %v", err)
+	}
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", rec.Code)
+	}
+}

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -271,7 +271,7 @@ body {
 }
 
 .sidebar-toggle:hover {
-    background: var(--accent);
+    background: color-mix(in srgb, var(--accent) 15%, transparent);
 }
 
 .sidebar-toggle.collapsed {

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -1,5 +1,7 @@
 /* GOModel Dashboard Styles */
 
+/* TODO: It might be optimized once the css preprocessor is added. Intentional duplication for now */
+
 /* Dark mode (default) — matches gomodel.enterpilot.io */
 :root {
     --bg: #111110;

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -1,4 +1,6 @@
 /* GOModel Dashboard Styles */
+
+/* Dark mode (default) */
 :root {
     --bg: #0f1117;
     --bg-surface: #161923;
@@ -13,6 +15,56 @@
     --danger: #ef4444;
     --sidebar-width: 240px;
     --radius: 8px;
+    --chart-grid: #2a2d3e;
+    --chart-text: #8b8fa3;
+    --chart-tooltip-bg: #161923;
+    --chart-tooltip-border: #2a2d3e;
+    --chart-tooltip-text: #e4e6f0;
+    color-scheme: dark;
+}
+
+/* Light mode */
+[data-theme="light"] {
+    --bg: #f4f5f7;
+    --bg-surface: #ffffff;
+    --bg-surface-hover: #f0f1f3;
+    --border: #d8dbe3;
+    --text: #1a1d2b;
+    --text-muted: #6b7085;
+    --accent: #4f46e5;
+    --accent-hover: #6366f1;
+    --success: #16a34a;
+    --warning: #d97706;
+    --danger: #dc2626;
+    --chart-grid: #e5e7eb;
+    --chart-text: #6b7085;
+    --chart-tooltip-bg: #ffffff;
+    --chart-tooltip-border: #d8dbe3;
+    --chart-tooltip-text: #1a1d2b;
+    color-scheme: light;
+}
+
+/* System preference: light */
+@media (prefers-color-scheme: light) {
+    :root:not([data-theme="dark"]) {
+        --bg: #f4f5f7;
+        --bg-surface: #ffffff;
+        --bg-surface-hover: #f0f1f3;
+        --border: #d8dbe3;
+        --text: #1a1d2b;
+        --text-muted: #6b7085;
+        --accent: #4f46e5;
+        --accent-hover: #6366f1;
+        --success: #16a34a;
+        --warning: #d97706;
+        --danger: #dc2626;
+        --chart-grid: #e5e7eb;
+        --chart-text: #6b7085;
+        --chart-tooltip-bg: #ffffff;
+        --chart-tooltip-border: #d8dbe3;
+        --chart-tooltip-text: #1a1d2b;
+        color-scheme: light;
+    }
 }
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -126,6 +178,44 @@ body {
     border-color: var(--accent);
 }
 
+/* Theme toggle */
+.theme-toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 0;
+    margin-bottom: 8px;
+}
+
+.theme-toggle label {
+    margin-bottom: 0;
+}
+
+.theme-btn {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--text-muted);
+    padding: 6px 10px;
+    cursor: pointer;
+    font-size: 12px;
+    font-weight: 500;
+    transition: all 0.15s;
+    flex: 1;
+    text-align: center;
+}
+
+.theme-btn:hover {
+    color: var(--text);
+    border-color: var(--accent);
+}
+
+.theme-btn.active {
+    background: var(--accent);
+    color: #fff;
+    border-color: var(--accent);
+}
+
 /* Content */
 .content {
     flex: 1;
@@ -147,8 +237,7 @@ body {
     letter-spacing: -0.3px;
 }
 
-.period-select select,
-.filter-select {
+.period-select select {
     padding: 8px 12px;
     background: var(--bg-surface);
     border: 1px solid var(--border);
@@ -231,7 +320,7 @@ body {
 
 .filter-input {
     flex: 1;
-    max-width: 320px;
+    max-width: 420px;
     padding: 8px 12px;
     background: var(--bg-surface);
     border: 1px solid var(--border);

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -260,6 +260,7 @@ body {
 /* Content */
 .content {
     flex: 1;
+    min-width: 0;
     margin-left: var(--sidebar-width);
     padding: 32px;
     max-width: 1200px;

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -1,0 +1,314 @@
+/* GOModel Dashboard Styles */
+:root {
+    --bg: #0f1117;
+    --bg-surface: #161923;
+    --bg-surface-hover: #1e2132;
+    --border: #2a2d3e;
+    --text: #e4e6f0;
+    --text-muted: #8b8fa3;
+    --accent: #6366f1;
+    --accent-hover: #818cf8;
+    --success: #22c55e;
+    --warning: #f59e0b;
+    --danger: #ef4444;
+    --sidebar-width: 240px;
+    --radius: 8px;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.5;
+}
+
+.app {
+    display: flex;
+    min-height: 100vh;
+}
+
+/* Sidebar */
+.sidebar {
+    width: var(--sidebar-width);
+    background: var(--bg-surface);
+    border-right: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    z-index: 10;
+}
+
+.sidebar-header {
+    padding: 20px;
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.sidebar-header h1 {
+    font-size: 18px;
+    font-weight: 700;
+    letter-spacing: -0.3px;
+}
+
+.badge {
+    background: var(--accent);
+    color: #fff;
+    font-size: 10px;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.sidebar-nav {
+    padding: 12px;
+    flex: 1;
+}
+
+.nav-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 12px;
+    border-radius: var(--radius);
+    color: var(--text-muted);
+    text-decoration: none;
+    font-size: 14px;
+    font-weight: 500;
+    transition: all 0.15s;
+}
+
+.nav-item:hover {
+    background: var(--bg-surface-hover);
+    color: var(--text);
+}
+
+.nav-item.active {
+    background: var(--accent);
+    color: #fff;
+}
+
+.sidebar-footer {
+    padding: 16px;
+    border-top: 1px solid var(--border);
+}
+
+.api-key-section label {
+    display: block;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+    margin-bottom: 6px;
+}
+
+.api-key-section input {
+    width: 100%;
+    padding: 8px 10px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--text);
+    font-size: 13px;
+    outline: none;
+}
+
+.api-key-section input:focus {
+    border-color: var(--accent);
+}
+
+/* Content */
+.content {
+    flex: 1;
+    margin-left: var(--sidebar-width);
+    padding: 32px;
+    max-width: 1200px;
+}
+
+.page-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 24px;
+}
+
+.page-header h2 {
+    font-size: 22px;
+    font-weight: 700;
+    letter-spacing: -0.3px;
+}
+
+.period-select select,
+.filter-select {
+    padding: 8px 12px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--text);
+    font-size: 13px;
+    cursor: pointer;
+    outline: none;
+}
+
+.model-count {
+    color: var(--text-muted);
+    font-size: 14px;
+}
+
+/* Summary Cards */
+.cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 16px;
+    margin-bottom: 28px;
+}
+
+.card {
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 20px;
+}
+
+.card-label {
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+    margin-bottom: 8px;
+}
+
+.card-value {
+    font-size: 28px;
+    font-weight: 700;
+    letter-spacing: -0.5px;
+}
+
+/* Chart */
+.chart-container {
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 24px;
+}
+
+.chart-container h3 {
+    font-size: 16px;
+    font-weight: 600;
+    margin-bottom: 16px;
+}
+
+/* Alert */
+.alert {
+    padding: 12px 16px;
+    border-radius: var(--radius);
+    margin-bottom: 20px;
+    font-size: 14px;
+}
+
+.alert-warning {
+    background: rgba(245, 158, 11, 0.1);
+    border: 1px solid rgba(245, 158, 11, 0.3);
+    color: var(--warning);
+}
+
+/* Table */
+.table-toolbar {
+    display: flex;
+    gap: 12px;
+    margin-bottom: 16px;
+}
+
+.filter-input {
+    flex: 1;
+    max-width: 320px;
+    padding: 8px 12px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--text);
+    font-size: 13px;
+    outline: none;
+}
+
+.filter-input:focus {
+    border-color: var(--accent);
+}
+
+.table-wrapper {
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow: hidden;
+}
+
+.data-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 14px;
+}
+
+.data-table th {
+    text-align: left;
+    padding: 12px 16px;
+    font-weight: 600;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+    background: var(--bg);
+    border-bottom: 1px solid var(--border);
+}
+
+.data-table td {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
+}
+
+.data-table tr:last-child td {
+    border-bottom: none;
+}
+
+.data-table tr:hover td {
+    background: var(--bg-surface-hover);
+}
+
+.mono {
+    font-family: 'SF Mono', 'Menlo', 'Consolas', monospace;
+    font-size: 13px;
+}
+
+.provider-badge {
+    display: inline-block;
+    padding: 2px 10px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    font-size: 12px;
+    font-weight: 500;
+}
+
+.empty-state {
+    text-align: center;
+    color: var(--text-muted);
+    padding: 48px 0;
+    font-size: 14px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .sidebar { width: 60px; }
+    .sidebar-header h1, .sidebar-nav .nav-item span, .sidebar-footer { display: none; }
+    .content { margin-left: 60px; padding: 20px; }
+    .cards { grid-template-columns: repeat(2, 1fr); }
+}

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -134,6 +134,9 @@ body {
 }
 
 .sidebar-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
     padding: 12px;
     flex: 1;
 }

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -1,68 +1,68 @@
 /* GOModel Dashboard Styles */
 
-/* Dark mode (default) */
+/* Dark mode (default) — matches gomodel.enterpilot.io */
 :root {
-    --bg: #0f1117;
-    --bg-surface: #161923;
-    --bg-surface-hover: #1e2132;
-    --border: #2a2d3e;
-    --text: #e4e6f0;
-    --text-muted: #8b8fa3;
-    --accent: #6366f1;
-    --accent-hover: #818cf8;
-    --success: #22c55e;
+    --bg: #111110;
+    --bg-surface: #1e1d1c;
+    --bg-surface-hover: #2a2420;
+    --border: #2a2826;
+    --text: #e8e0d6;
+    --text-muted: #9a918a;
+    --accent: #b8956e;
+    --accent-hover: #d4b896;
+    --success: #34d399;
     --warning: #f59e0b;
     --danger: #ef4444;
     --sidebar-width: 240px;
     --radius: 8px;
-    --chart-grid: #2a2d3e;
-    --chart-text: #8b8fa3;
-    --chart-tooltip-bg: #161923;
-    --chart-tooltip-border: #2a2d3e;
-    --chart-tooltip-text: #e4e6f0;
+    --chart-grid: #2a2826;
+    --chart-text: #9a918a;
+    --chart-tooltip-bg: #1e1d1c;
+    --chart-tooltip-border: #2a2826;
+    --chart-tooltip-text: #e8e0d6;
     color-scheme: dark;
 }
 
-/* Light mode */
+/* Light mode — matches gomodel.enterpilot.io */
 [data-theme="light"] {
-    --bg: #f4f5f7;
+    --bg: #f5f0ea;
     --bg-surface: #ffffff;
-    --bg-surface-hover: #f0f1f3;
-    --border: #d8dbe3;
-    --text: #1a1d2b;
-    --text-muted: #6b7085;
-    --accent: #4f46e5;
-    --accent-hover: #6366f1;
-    --success: #16a34a;
+    --bg-surface-hover: #ece5dc;
+    --border: #e8e0d6;
+    --text: #2d2519;
+    --text-muted: #7a7068;
+    --accent: #755c3d;
+    --accent-hover: #9a7d5a;
+    --success: #34d399;
     --warning: #d97706;
     --danger: #dc2626;
-    --chart-grid: #e5e7eb;
-    --chart-text: #6b7085;
+    --chart-grid: #e8e0d6;
+    --chart-text: #7a7068;
     --chart-tooltip-bg: #ffffff;
-    --chart-tooltip-border: #d8dbe3;
-    --chart-tooltip-text: #1a1d2b;
+    --chart-tooltip-border: #e8e0d6;
+    --chart-tooltip-text: #2d2519;
     color-scheme: light;
 }
 
 /* System preference: light */
 @media (prefers-color-scheme: light) {
     :root:not([data-theme="dark"]) {
-        --bg: #f4f5f7;
+        --bg: #f5f0ea;
         --bg-surface: #ffffff;
-        --bg-surface-hover: #f0f1f3;
-        --border: #d8dbe3;
-        --text: #1a1d2b;
-        --text-muted: #6b7085;
-        --accent: #4f46e5;
-        --accent-hover: #6366f1;
-        --success: #16a34a;
+        --bg-surface-hover: #ece5dc;
+        --border: #e8e0d6;
+        --text: #2d2519;
+        --text-muted: #7a7068;
+        --accent: #755c3d;
+        --accent-hover: #9a7d5a;
+        --success: #34d399;
         --warning: #d97706;
         --danger: #dc2626;
-        --chart-grid: #e5e7eb;
-        --chart-text: #6b7085;
+        --chart-grid: #e8e0d6;
+        --chart-text: #7a7068;
         --chart-tooltip-bg: #ffffff;
-        --chart-tooltip-border: #d8dbe3;
-        --chart-tooltip-text: #1a1d2b;
+        --chart-tooltip-border: #e8e0d6;
+        --chart-tooltip-text: #2d2519;
         color-scheme: light;
     }
 }
@@ -70,7 +70,7 @@
 * { box-sizing: border-box; margin: 0; padding: 0; }
 
 body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     background: var(--bg);
     color: var(--text);
     line-height: 1.5;
@@ -101,6 +101,17 @@ body {
     display: flex;
     align-items: center;
     gap: 10px;
+}
+
+.sidebar-logo {
+    width: 28px;
+    height: 28px;
+    flex-shrink: 0;
+}
+
+.sidebar-logo svg {
+    width: 100%;
+    height: 100%;
 }
 
 .sidebar-header h1 {
@@ -178,42 +189,43 @@ body {
     border-color: var(--accent);
 }
 
-/* Theme toggle */
+/* Theme toggle — compact pill */
 .theme-toggle {
-    display: flex;
+    display: inline-flex;
     align-items: center;
-    gap: 8px;
-    padding: 8px 0;
-    margin-bottom: 8px;
-}
-
-.theme-toggle label {
-    margin-bottom: 0;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 2px;
+    margin-bottom: 10px;
 }
 
 .theme-btn {
-    background: var(--bg);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 24px;
+    background: transparent;
+    border: none;
+    border-radius: 4px;
     color: var(--text-muted);
-    padding: 6px 10px;
     cursor: pointer;
-    font-size: 12px;
-    font-weight: 500;
     transition: all 0.15s;
-    flex: 1;
-    text-align: center;
+}
+
+.theme-btn svg {
+    width: 14px;
+    height: 14px;
 }
 
 .theme-btn:hover {
     color: var(--text);
-    border-color: var(--accent);
 }
 
 .theme-btn.active {
     background: var(--accent);
     color: #fff;
-    border-color: var(--accent);
 }
 
 /* Content */

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -297,6 +297,11 @@ body {
     margin-bottom: 16px;
 }
 
+.chart-wrapper {
+    position: relative;
+    height: 300px;
+}
+
 /* Alert */
 .alert {
     padding: 12px 16px;

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -95,6 +95,7 @@ body {
     left: 0;
     bottom: 0;
     z-index: 10;
+    transition: width 0.2s;
 }
 
 .sidebar-header {
@@ -257,6 +258,68 @@ body {
     height: 16px;
 }
 
+/* Sidebar toggle handle */
+.sidebar-toggle {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: var(--sidebar-width);
+    width: 6px;
+    cursor: w-resize;
+    z-index: 11;
+    transition: left 0.2s, background 0.15s;
+}
+
+.sidebar-toggle:hover {
+    background: var(--accent);
+}
+
+.sidebar-toggle.collapsed {
+    left: 60px;
+    cursor: e-resize;
+}
+
+/* Collapsed sidebar (desktop) */
+.sidebar.sidebar-collapsed {
+    width: 60px;
+}
+
+.sidebar.sidebar-collapsed .sidebar-header {
+    justify-content: center;
+    padding: 16px;
+}
+
+.sidebar.sidebar-collapsed .sidebar-header h1,
+.sidebar.sidebar-collapsed .badge {
+    display: none;
+}
+
+.sidebar.sidebar-collapsed .sidebar-nav .nav-item {
+    justify-content: center;
+    padding: 10px;
+}
+
+.sidebar.sidebar-collapsed .sidebar-nav .nav-item span {
+    display: none;
+}
+
+.sidebar.sidebar-collapsed .sidebar-footer {
+    padding: 8px;
+}
+
+.sidebar.sidebar-collapsed .sidebar-footer .api-key-section {
+    display: none;
+}
+
+.sidebar.sidebar-collapsed .sidebar-footer .theme-toggle {
+    display: none;
+}
+
+.sidebar.sidebar-collapsed .sidebar-footer .theme-toggle-mobile {
+    display: flex;
+    margin: 0 auto;
+}
+
 /* Content */
 .content {
     flex: 1;
@@ -264,6 +327,11 @@ body {
     margin-left: var(--sidebar-width);
     padding: 32px;
     max-width: 1200px;
+    transition: margin-left 0.2s;
+}
+
+.content.content-collapsed {
+    margin-left: 60px;
 }
 
 .page-header {
@@ -452,6 +520,7 @@ body {
     .sidebar-footer .api-key-section { display: none; }
     .sidebar-footer .theme-toggle { display: none; }
     .sidebar-footer .theme-toggle-mobile { display: flex; margin: 0 auto; }
+    .sidebar-toggle { display: none; }
     .content { margin-left: 60px; padding: 20px; }
     .cards { grid-template-columns: repeat(2, 1fr); }
 }

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -499,6 +499,16 @@ body {
     color: var(--text);
 }
 
+.dp-nav-btn:disabled {
+    opacity: 0.3;
+    cursor: default;
+    pointer-events: none;
+}
+
+.dp-nav-prev-mobile {
+    display: none;
+}
+
 .dp-weekdays {
     display: grid;
     grid-template-columns: repeat(7, 1fr);
@@ -586,6 +596,13 @@ body {
     pointer-events: none;
 }
 
+
+/* Page Header Controls (interval + date picker wrapper) */
+.page-header-controls {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
 
 /* Interval Picker */
 .interval-picker {
@@ -789,6 +806,20 @@ body {
     .content { margin-left: 60px; padding: 20px; }
     .cards { grid-template-columns: repeat(2, 1fr); }
 
+    /* Page header stacking */
+    .page-header {
+        flex-wrap: wrap;
+        gap: 12px;
+    }
+    .page-header h2 {
+        width: 100%;
+    }
+    .page-header-controls {
+        width: 100%;
+        justify-content: space-between;
+        flex-wrap: wrap;
+    }
+
     /* Interval picker mobile */
     .interval-btn {
         padding: 4px 8px;
@@ -798,8 +829,8 @@ body {
     /* Date picker mobile */
     .date-picker-dropdown {
         flex-direction: column;
-        right: -16px;
-        left: -16px;
+        right: 0;
+        left: 0;
         position: fixed;
         top: auto;
         bottom: 0;
@@ -809,7 +840,9 @@ body {
     }
     .date-picker-presets {
         flex-direction: row;
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
         border-right: none;
         border-bottom: 1px solid var(--border);
         min-width: 0;
@@ -819,5 +852,8 @@ body {
     }
     .dp-calendar:first-child {
         display: none;
+    }
+    .dp-nav-prev-mobile {
+        display: flex;
     }
 }

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -347,15 +347,280 @@ body {
     letter-spacing: -0.3px;
 }
 
-.period-select select {
+/* Date Picker */
+.date-picker {
+    position: relative;
+}
+
+.date-picker-trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
     padding: 8px 12px;
     background: var(--bg-surface);
     border: 1px solid var(--border);
     border-radius: var(--radius);
     color: var(--text);
     font-size: 13px;
+    font-family: inherit;
     cursor: pointer;
-    outline: none;
+    transition: all 0.15s;
+    white-space: nowrap;
+}
+
+.date-picker-trigger:hover {
+    background: var(--bg-surface-hover);
+}
+
+.date-picker-trigger svg {
+    flex-shrink: 0;
+    color: var(--text-muted);
+}
+
+.date-picker-chevron {
+    transition: transform 0.15s;
+}
+
+.date-picker-chevron.open {
+    transform: rotate(180deg);
+}
+
+.date-picker-dropdown {
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 0;
+    z-index: 100;
+    display: flex;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+    overflow: hidden;
+}
+
+.date-picker-presets {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 8px;
+    border-right: 1px solid var(--border);
+    min-width: 140px;
+}
+
+.preset-btn {
+    padding: 8px 12px;
+    background: transparent;
+    border: none;
+    border-radius: 6px;
+    color: var(--text);
+    font-size: 13px;
+    font-family: inherit;
+    text-align: left;
+    cursor: pointer;
+    transition: all 0.15s;
+    white-space: nowrap;
+}
+
+.preset-btn:hover {
+    background: var(--bg-surface-hover);
+}
+
+.preset-btn.active {
+    background: var(--accent);
+    color: #fff;
+}
+
+.date-picker-calendars {
+    display: flex;
+    flex-wrap: nowrap;
+    padding: 12px;
+    gap: 16px;
+}
+
+.dp-cursor-hint {
+    position: fixed;
+    pointer-events: none;
+    z-index: 101;
+    background: var(--bg-surface);
+    color: var(--text);
+    border: 1px solid var(--accent);
+    font-size: 11px;
+    font-weight: 500;
+    padding: 3px 8px;
+    border-radius: 4px;
+    white-space: nowrap;
+    transform: translate(12px, -50%);
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.dp-cursor-hint svg {
+    width: 12px;
+    height: 12px;
+    color: var(--accent);
+    flex-shrink: 0;
+}
+
+.dp-calendar {
+    width: 224px;
+    flex-shrink: 0;
+}
+
+.dp-cal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 8px;
+    padding: 0 4px;
+}
+
+.dp-cal-title {
+    font-size: 13px;
+    font-weight: 600;
+}
+
+.dp-nav-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    background: transparent;
+    border: none;
+    border-radius: 6px;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: all 0.15s;
+}
+
+.dp-nav-btn:hover {
+    background: var(--bg-surface-hover);
+    color: var(--text);
+}
+
+.dp-weekdays {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    text-align: center;
+    margin-bottom: 4px;
+}
+
+.dp-weekdays span {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-muted);
+    padding: 4px 0;
+}
+
+.dp-days {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 1px;
+}
+
+.dp-day {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    background: transparent;
+    border: none;
+    border-radius: 6px;
+    color: var(--text);
+    font-size: 12px;
+    font-family: inherit;
+    cursor: pointer;
+    transition: all 0.1s;
+}
+
+.dp-day:hover:not(.disabled):not(.other-month) {
+    background: var(--bg-surface-hover);
+}
+
+.dp-day.other-month {
+    color: var(--text-muted);
+    opacity: 0.3;
+    cursor: default;
+}
+
+.dp-day.today {
+    color: var(--accent);
+    font-weight: 700;
+    box-shadow: inset 0 0 0 1.5px var(--accent);
+}
+
+.dp-day.in-range {
+    background: color-mix(in srgb, var(--accent) 15%, transparent);
+    border-radius: 0;
+}
+
+.dp-day.range-start {
+    background: var(--accent);
+    color: #fff;
+    border-radius: 6px 0 0 6px;
+    font-weight: 600;
+}
+
+.dp-day.range-start.range-end {
+    border-radius: 6px;
+}
+
+.dp-day.range-end {
+    background: var(--accent);
+    color: #fff;
+    border-radius: 0 6px 6px 0;
+    font-weight: 600;
+}
+
+.dp-day.range-start.today,
+.dp-day.range-end.today {
+    box-shadow: none;
+}
+
+.dp-day.disabled {
+    color: var(--text-muted);
+    opacity: 0.3;
+    cursor: default;
+    pointer-events: none;
+}
+
+
+/* Interval Picker */
+.interval-picker {
+    display: inline-flex;
+    align-items: center;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 2px;
+}
+
+.interval-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 5px 12px;
+    background: transparent;
+    border: none;
+    border-radius: 4px;
+    color: var(--text-muted);
+    font-size: 12px;
+    font-family: inherit;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s;
+    white-space: nowrap;
+}
+
+.interval-btn:hover {
+    color: var(--text);
+}
+
+.interval-btn.active {
+    background: var(--accent);
+    color: #fff;
 }
 
 .model-count {
@@ -523,4 +788,36 @@ body {
     .sidebar-toggle { display: none; }
     .content { margin-left: 60px; padding: 20px; }
     .cards { grid-template-columns: repeat(2, 1fr); }
+
+    /* Interval picker mobile */
+    .interval-btn {
+        padding: 4px 8px;
+        font-size: 11px;
+    }
+
+    /* Date picker mobile */
+    .date-picker-dropdown {
+        flex-direction: column;
+        right: -16px;
+        left: -16px;
+        position: fixed;
+        top: auto;
+        bottom: 0;
+        border-radius: var(--radius) var(--radius) 0 0;
+        max-height: 80vh;
+        overflow-y: auto;
+    }
+    .date-picker-presets {
+        flex-direction: row;
+        flex-wrap: wrap;
+        border-right: none;
+        border-bottom: 1px solid var(--border);
+        min-width: 0;
+    }
+    .date-picker-calendars {
+        justify-content: center;
+    }
+    .dp-calendar:first-child {
+        display: none;
+    }
 }

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -416,7 +416,11 @@ body {
 /* Responsive */
 @media (max-width: 768px) {
     .sidebar { width: 60px; }
-    .sidebar-header h1, .sidebar-nav .nav-item span, .sidebar-footer { display: none; }
+    .sidebar-header { justify-content: center; padding: 16px; }
+    .sidebar-header h1, .badge { display: none; }
+    .sidebar-nav .nav-item { justify-content: center; padding: 10px; }
+    .sidebar-nav .nav-item span { display: none; }
+    .sidebar-footer { display: none; }
     .content { margin-left: 60px; padding: 20px; }
     .cards { grid-template-columns: repeat(2, 1fr); }
 }

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -230,6 +230,30 @@ body {
     color: #fff;
 }
 
+/* Theme toggle — single button for mobile */
+.theme-toggle-mobile {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: all 0.15s;
+}
+
+.theme-toggle-mobile:hover {
+    color: var(--text);
+}
+
+.theme-toggle-mobile svg {
+    width: 16px;
+    height: 16px;
+}
+
 /* Content */
 .content {
     flex: 1;
@@ -420,7 +444,10 @@ body {
     .sidebar-header h1, .badge { display: none; }
     .sidebar-nav .nav-item { justify-content: center; padding: 10px; }
     .sidebar-nav .nav-item span { display: none; }
-    .sidebar-footer { display: none; }
+    .sidebar-footer { padding: 8px; }
+    .sidebar-footer .api-key-section { display: none; }
+    .sidebar-footer .theme-toggle { display: none; }
+    .sidebar-footer .theme-toggle-mobile { display: flex; margin: 0 auto; }
     .content { margin-left: 60px; padding: 20px; }
     .cards { grid-template-columns: repeat(2, 1fr); }
 }

--- a/internal/admin/dashboard/static/favicon.svg
+++ b/internal/admin/dashboard/static/favicon.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg">
+  <path d="M15 3L25.39 9L25.39 21L15 27L4.61 21L4.61 9Z" stroke="#755c3d" stroke-width="2" fill="none"/>
+  <circle cx="15" cy="15" r="4" fill="#755c3d" opacity="0.3"/>
+  <path d="M15 9.5L15 6M15 20.5L15 24M19.76 12.25L22.79 10.5M10.24 17.75L7.21 19.5M19.76 17.75L22.79 19.5M10.24 12.25L7.21 10.5" stroke="#755c3d" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -62,11 +62,11 @@ function dashboard() {
         chartColors() {
             const dark = this.isDark();
             return {
-                grid: dark ? '#2a2d3e' : '#e5e7eb',
-                text: dark ? '#8b8fa3' : '#6b7085',
-                tooltipBg: dark ? '#161923' : '#ffffff',
-                tooltipBorder: dark ? '#2a2d3e' : '#d8dbe3',
-                tooltipText: dark ? '#e4e6f0' : '#1a1d2b',
+                grid: dark ? '#2a2826' : '#e8e0d6',
+                text: dark ? '#9a918a' : '#7a7068',
+                tooltipBg: dark ? '#1e1d1c' : '#ffffff',
+                tooltipBorder: dark ? '#2a2826' : '#e8e0d6',
+                tooltipText: dark ? '#e8e0d6' : '#2d2519',
             };
         },
 
@@ -167,8 +167,8 @@ function dashboard() {
                         {
                             label: 'Input Tokens',
                             data: inputData,
-                            borderColor: '#6366f1',
-                            backgroundColor: 'rgba(99, 102, 241, 0.1)',
+                            borderColor: '#b8956e',
+                            backgroundColor: 'rgba(184, 149, 110, 0.1)',
                             fill: true,
                             tension: 0.3,
                             pointRadius: 3,
@@ -177,8 +177,8 @@ function dashboard() {
                         {
                             label: 'Output Tokens',
                             data: outputData,
-                            borderColor: '#22c55e',
-                            backgroundColor: 'rgba(34, 197, 94, 0.1)',
+                            borderColor: '#34d399',
+                            backgroundColor: 'rgba(52, 211, 153, 0.1)',
                             fill: true,
                             tension: 0.3,
                             pointRadius: 3,

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -1,0 +1,194 @@
+// GOModel Dashboard — Alpine.js + Chart.js logic
+
+function dashboard() {
+    return {
+        // State
+        page: 'overview',
+        days: '30',
+        loading: false,
+        authError: false,
+        needsAuth: false,
+        apiKey: '',
+
+        // Data
+        summary: { total_requests: 0, total_input_tokens: 0, total_output_tokens: 0, total_tokens: 0 },
+        daily: [],
+        models: [],
+
+        // Filters
+        modelFilter: '',
+        providerFilter: '',
+
+        // Chart
+        chart: null,
+
+        init() {
+            this.apiKey = localStorage.getItem('gomodel_api_key') || '';
+            this.fetchAll();
+        },
+
+        saveApiKey() {
+            if (this.apiKey) {
+                localStorage.setItem('gomodel_api_key', this.apiKey);
+            } else {
+                localStorage.removeItem('gomodel_api_key');
+            }
+        },
+
+        headers() {
+            const h = { 'Content-Type': 'application/json' };
+            if (this.apiKey) {
+                h['Authorization'] = 'Bearer ' + this.apiKey;
+            }
+            return h;
+        },
+
+        async fetchAll() {
+            this.loading = true;
+            this.authError = false;
+            await Promise.all([this.fetchUsage(), this.fetchModels()]);
+            this.loading = false;
+        },
+
+        async fetchUsage() {
+            try {
+                const [summaryRes, dailyRes] = await Promise.all([
+                    fetch('/admin/api/v1/usage/summary?days=' + this.days, { headers: this.headers() }),
+                    fetch('/admin/api/v1/usage/daily?days=' + this.days, { headers: this.headers() })
+                ]);
+
+                if (summaryRes.status === 401 || dailyRes.status === 401) {
+                    this.authError = true;
+                    this.needsAuth = true;
+                    return;
+                }
+
+                this.summary = await summaryRes.json();
+                this.daily = await dailyRes.json();
+                this.renderChart();
+            } catch (e) {
+                console.error('Failed to fetch usage:', e);
+            }
+        },
+
+        async fetchModels() {
+            try {
+                const res = await fetch('/admin/api/v1/models', { headers: this.headers() });
+                if (res.status === 401) {
+                    this.authError = true;
+                    this.needsAuth = true;
+                    return;
+                }
+                this.models = await res.json();
+            } catch (e) {
+                console.error('Failed to fetch models:', e);
+            }
+        },
+
+        renderChart() {
+            const ctx = document.getElementById('usageChart');
+            if (!ctx) return;
+
+            if (this.chart) {
+                this.chart.destroy();
+            }
+
+            if (this.daily.length === 0) return;
+
+            const labels = this.daily.map(d => d.date);
+            const inputData = this.daily.map(d => d.input_tokens);
+            const outputData = this.daily.map(d => d.output_tokens);
+
+            this.chart = new Chart(ctx, {
+                type: 'line',
+                data: {
+                    labels: labels,
+                    datasets: [
+                        {
+                            label: 'Input Tokens',
+                            data: inputData,
+                            borderColor: '#6366f1',
+                            backgroundColor: 'rgba(99, 102, 241, 0.1)',
+                            fill: true,
+                            tension: 0.3,
+                            pointRadius: 3,
+                            pointHoverRadius: 5
+                        },
+                        {
+                            label: 'Output Tokens',
+                            data: outputData,
+                            borderColor: '#22c55e',
+                            backgroundColor: 'rgba(34, 197, 94, 0.1)',
+                            fill: true,
+                            tension: 0.3,
+                            pointRadius: 3,
+                            pointHoverRadius: 5
+                        }
+                    ]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    interaction: { mode: 'index', intersect: false },
+                    plugins: {
+                        legend: {
+                            labels: { color: '#8b8fa3', font: { size: 12 } }
+                        },
+                        tooltip: {
+                            backgroundColor: '#161923',
+                            borderColor: '#2a2d3e',
+                            borderWidth: 1,
+                            titleColor: '#e4e6f0',
+                            bodyColor: '#e4e6f0',
+                            callbacks: {
+                                label: function(ctx) {
+                                    return ctx.dataset.label + ': ' + ctx.parsed.y.toLocaleString();
+                                }
+                            }
+                        }
+                    },
+                    scales: {
+                        x: {
+                            grid: { color: '#2a2d3e' },
+                            ticks: { color: '#8b8fa3', font: { size: 11 }, maxTicksLimit: 10 }
+                        },
+                        y: {
+                            grid: { color: '#2a2d3e' },
+                            ticks: {
+                                color: '#8b8fa3',
+                                font: { size: 11 },
+                                callback: function(value) {
+                                    if (value >= 1000000) return (value / 1000000).toFixed(1) + 'M';
+                                    if (value >= 1000) return (value / 1000).toFixed(1) + 'K';
+                                    return value;
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+        },
+
+        get filteredModels() {
+            let result = this.models;
+            if (this.modelFilter) {
+                const f = this.modelFilter.toLowerCase();
+                result = result.filter(m => m.model.id.toLowerCase().includes(f));
+            }
+            if (this.providerFilter) {
+                result = result.filter(m => m.provider_type === this.providerFilter);
+            }
+            return result;
+        },
+
+        get providerList() {
+            const providers = new Set(this.models.map(m => m.provider_type));
+            return [...providers].sort();
+        },
+
+        formatNumber(n) {
+            if (n == null || n === undefined) return '-';
+            return n.toLocaleString();
+        }
+    };
+}

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -10,6 +10,7 @@ function dashboard() {
         needsAuth: false,
         apiKey: '',
         theme: 'system', // 'system', 'light', 'dark'
+        sidebarCollapsed: false,
 
         // Data
         summary: { total_requests: 0, total_input_tokens: 0, total_output_tokens: 0, total_tokens: 0 },
@@ -25,6 +26,7 @@ function dashboard() {
         init() {
             this.apiKey = localStorage.getItem('gomodel_api_key') || '';
             this.theme = localStorage.getItem('gomodel_theme') || 'system';
+            this.sidebarCollapsed = localStorage.getItem('gomodel_sidebar_collapsed') === 'true';
             this.applyTheme();
 
             // Parse initial page from URL path
@@ -48,6 +50,13 @@ function dashboard() {
             });
 
             this.fetchAll();
+        },
+
+        toggleSidebar() {
+            this.sidebarCollapsed = !this.sidebarCollapsed;
+            localStorage.setItem('gomodel_sidebar_collapsed', this.sidebarCollapsed);
+            // Re-render chart after CSS transition so Chart.js picks up the new width
+            setTimeout(() => this.renderChart(), 220);
         },
 
         navigate(page) {

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -27,6 +27,19 @@ function dashboard() {
             this.theme = localStorage.getItem('gomodel_theme') || 'system';
             this.applyTheme();
 
+            // Parse initial page from URL path
+            const path = window.location.pathname.replace(/\/$/, '');
+            const slug = path.split('/').pop();
+            this.page = (slug === 'models') ? 'models' : 'overview';
+
+            // Handle browser back/forward
+            window.addEventListener('popstate', () => {
+                const p = window.location.pathname.replace(/\/$/, '');
+                const s = p.split('/').pop();
+                this.page = (s === 'models') ? 'models' : 'overview';
+                if (this.page === 'overview') this.renderChart();
+            });
+
             // Re-render chart when system theme changes (only matters in 'system' mode)
             window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
                 if (this.theme === 'system') {
@@ -35,6 +48,12 @@ function dashboard() {
             });
 
             this.fetchAll();
+        },
+
+        navigate(page) {
+            this.page = page;
+            history.pushState(null, '', '/admin/dashboard/' + page);
+            if (page === 'overview') this.renderChart();
         },
 
         setTheme(t) {

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -44,6 +44,11 @@ function dashboard() {
             this.renderChart();
         },
 
+        toggleTheme() {
+            const order = ['light', 'system', 'dark'];
+            this.setTheme(order[(order.indexOf(this.theme) + 1) % order.length]);
+        },
+
         applyTheme() {
             const root = document.documentElement;
             if (this.theme === 'system') {

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -128,6 +128,21 @@ function dashboard() {
             }
         },
 
+        fillMissingDays(daily) {
+            if (daily.length === 0) return daily;
+            const byDate = {};
+            daily.forEach(d => { byDate[d.date] = d; });
+            const dates = daily.map(d => d.date).sort();
+            const start = new Date(dates[0] + 'T00:00:00');
+            const end = new Date(dates[dates.length - 1] + 'T00:00:00');
+            const result = [];
+            for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+                const key = d.toISOString().slice(0, 10);
+                result.push(byDate[key] || { date: key, input_tokens: 0, output_tokens: 0, total_tokens: 0, requests: 0 });
+            }
+            return result;
+        },
+
         renderChart() {
             const ctx = document.getElementById('usageChart');
             if (!ctx) return;
@@ -139,9 +154,10 @@ function dashboard() {
             if (this.daily.length === 0) return;
 
             const colors = this.chartColors();
-            const labels = this.daily.map(d => d.date);
-            const inputData = this.daily.map(d => d.input_tokens);
-            const outputData = this.daily.map(d => d.output_tokens);
+            const filled = this.fillMissingDays(this.daily);
+            const labels = filled.map(d => d.date);
+            const inputData = filled.map(d => d.input_tokens);
+            const outputData = filled.map(d => d.output_tokens);
 
             this.chart = new Chart(ctx, {
                 type: 'line',

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -197,6 +197,7 @@ function dashboard() {
                             ticks: { color: colors.text, font: { size: 11 }, maxTicksLimit: 10 }
                         },
                         y: {
+                            beginAtZero: true,
                             grid: { color: colors.grid },
                             ticks: {
                                 color: colors.text,

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -348,6 +348,7 @@ function dashboard() {
         async fetchAll() {
             this.loading = true;
             this.authError = false;
+            this.needsAuth = false;
             await Promise.all([this.fetchUsage(), this.fetchModels()]);
             this.loading = false;
         },

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -12,6 +12,18 @@ function dashboard() {
         theme: 'system', // 'system', 'light', 'dark'
         sidebarCollapsed: false,
 
+        // Date picker
+        datePickerOpen: false,
+        selectedPreset: '30',
+        customStartDate: null,
+        customEndDate: null,
+        selectingDate: 'start', // 'start' or 'end'
+        calendarMonth: new Date(),
+        cursorHint: { show: false, x: 0, y: 0 },
+
+        // Interval
+        interval: 'daily',
+
         // Data
         summary: { total_requests: 0, total_input_tokens: 0, total_output_tokens: 0, total_tokens: 0 },
         daily: [],
@@ -57,6 +69,217 @@ function dashboard() {
             localStorage.setItem('gomodel_sidebar_collapsed', this.sidebarCollapsed);
             // Re-render chart after CSS transition so Chart.js picks up the new width
             setTimeout(() => this.renderChart(), 220);
+        },
+
+        // Date picker methods
+        toggleDatePicker() {
+            this.datePickerOpen = !this.datePickerOpen;
+            if (this.datePickerOpen) {
+                this.calendarMonth = new Date();
+                this.selectingDate = 'start';
+            }
+        },
+
+        closeDatePicker() {
+            this.datePickerOpen = false;
+            this.cursorHint.show = false;
+        },
+
+        onCalendarMouseMove(e) {
+            this.cursorHint = { show: true, x: e.clientX, y: e.clientY };
+        },
+
+        onCalendarMouseLeave() {
+            this.cursorHint.show = false;
+        },
+
+        selectPreset(days) {
+            this.selectedPreset = days;
+            this.customStartDate = null;
+            this.customEndDate = null;
+            this.selectingDate = 'start';
+            this.days = days;
+            this.fetchUsage();
+            this.closeDatePicker();
+        },
+
+        selectionHint() {
+            return this.selectingDate === 'end' ? 'Select end date' : 'Select start date';
+        },
+
+        dateRangeLabel() {
+            if (this.selectedPreset) return 'Last ' + this.selectedPreset + ' days';
+            if (this.customStartDate && this.customEndDate) {
+                return this.formatDateShort(this.customStartDate) + ' \u2013 ' + this.formatDateShort(this.customEndDate);
+            }
+            if (this.customStartDate) {
+                return this.formatDateShort(this.customStartDate) + ' \u2013 ...';
+            }
+            return 'Last 30 days';
+        },
+
+        formatDateShort(date) {
+            const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+            return months[date.getMonth()] + ' ' + date.getDate() + ', ' + date.getFullYear();
+        },
+
+        calendarTitle(offset) {
+            const d = new Date(this.calendarMonth.getFullYear(), this.calendarMonth.getMonth() + offset, 1);
+            const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+            return months[d.getMonth()] + ' ' + d.getFullYear();
+        },
+
+        calendarDays(offset) {
+            const year = this.calendarMonth.getFullYear();
+            const month = this.calendarMonth.getMonth() + offset;
+            const first = new Date(year, month, 1);
+            const last = new Date(year, month + 1, 0);
+            // Monday = 0, Sunday = 6
+            let startDay = (first.getDay() + 6) % 7;
+            const days = [];
+
+            // Padding days from previous month
+            const prevLast = new Date(year, month, 0);
+            for (let i = startDay - 1; i >= 0; i--) {
+                const d = prevLast.getDate() - i;
+                days.push({ day: d, date: new Date(year, month - 1, d), current: false, key: 'p' + d });
+            }
+
+            // Current month days
+            for (let d = 1; d <= last.getDate(); d++) {
+                days.push({ day: d, date: new Date(year, month, d), current: true, key: 'c' + d });
+            }
+
+            // Padding days from next month
+            const remaining = 42 - days.length;
+            for (let d = 1; d <= remaining; d++) {
+                days.push({ day: d, date: new Date(year, month + 1, d), current: false, key: 'n' + d });
+            }
+
+            return days;
+        },
+
+        prevMonth() {
+            this.calendarMonth = new Date(this.calendarMonth.getFullYear(), this.calendarMonth.getMonth() - 1, 1);
+        },
+
+        nextMonth() {
+            const next = new Date(this.calendarMonth.getFullYear(), this.calendarMonth.getMonth() + 1, 1);
+            const today = new Date();
+            // Don't navigate past current month
+            if (next.getFullYear() < today.getFullYear() ||
+                (next.getFullYear() === today.getFullYear() && next.getMonth() <= today.getMonth())) {
+                this.calendarMonth = next;
+            }
+        },
+
+        selectCalendarDay(day) {
+            if (!day.current || this.isFutureDay(day)) return;
+            const clicked = new Date(day.date);
+            clicked.setHours(0, 0, 0, 0);
+            this.selectedPreset = null;
+
+            if (this.selectingDate === 'start') {
+                this.customStartDate = clicked;
+                // Keep existing end date; if it's now before start, move it to start
+                if (this.customEndDate && this.customEndDate < clicked) {
+                    this.customEndDate = clicked;
+                }
+                // If no end date yet, default to today
+                if (!this.customEndDate) {
+                    const today = new Date();
+                    today.setHours(0, 0, 0, 0);
+                    this.customEndDate = today;
+                }
+                this.selectingDate = 'end';
+                this.fetchUsage();
+            } else {
+                // Selecting end date
+                if (clicked < this.customStartDate) {
+                    // Swap: treat click as new start, old start becomes end
+                    this.customEndDate = this.customStartDate;
+                    this.customStartDate = clicked;
+                } else {
+                    this.customEndDate = clicked;
+                }
+                this.selectingDate = 'start';
+                this.fetchUsage();
+                this.closeDatePicker();
+            }
+        },
+
+        isToday(day) {
+            if (!day.current) return false;
+            const today = new Date();
+            return day.date.getFullYear() === today.getFullYear() &&
+                   day.date.getMonth() === today.getMonth() &&
+                   day.date.getDate() === today.getDate();
+        },
+
+        isFutureDay(day) {
+            const today = new Date();
+            today.setHours(23, 59, 59, 999);
+            return day.date > today;
+        },
+
+        isRangeStart(day) {
+            if (!day.current) return false;
+            const start = this._rangeStart();
+            if (!start) return false;
+            return day.date.getFullYear() === start.getFullYear() &&
+                   day.date.getMonth() === start.getMonth() &&
+                   day.date.getDate() === start.getDate();
+        },
+
+        isRangeEnd(day) {
+            if (!day.current) return false;
+            const end = this._rangeEnd();
+            if (!end) return false;
+            return day.date.getFullYear() === end.getFullYear() &&
+                   day.date.getMonth() === end.getMonth() &&
+                   day.date.getDate() === end.getDate();
+        },
+
+        isInRange(day) {
+            if (!day.current) return false;
+            const start = this._rangeStart();
+            const end = this._rangeEnd();
+            if (!start || !end) return false;
+            const dayDate = new Date(day.date);
+            dayDate.setHours(0, 0, 0, 0);
+            return dayDate >= start && dayDate <= end;
+        },
+
+        _rangeStart() {
+            if (this.customStartDate) return this.customStartDate;
+            if (this.selectedPreset) {
+                const s = new Date();
+                s.setHours(0, 0, 0, 0);
+                s.setDate(s.getDate() - (parseInt(this.selectedPreset, 10) - 1));
+                return s;
+            }
+            return null;
+        },
+
+        _rangeEnd() {
+            if (this.customEndDate) return this.customEndDate;
+            if (this.customStartDate || this.selectedPreset) {
+                const t = new Date();
+                t.setHours(0, 0, 0, 0);
+                return t;
+            }
+            return null;
+        },
+
+        // Interval methods
+        setInterval(val) {
+            this.interval = val;
+            this.fetchUsage();
+        },
+
+        chartTitle() {
+            const titles = { daily: 'Daily', weekly: 'Weekly', monthly: 'Monthly', yearly: 'Yearly' };
+            return (titles[this.interval] || 'Daily') + ' Token Usage';
         },
 
         navigate(page) {
@@ -136,11 +359,26 @@ function dashboard() {
             return true;
         },
 
+        _formatDate(date) {
+            return date.getFullYear() + '-' +
+                String(date.getMonth() + 1).padStart(2, '0') + '-' +
+                String(date.getDate()).padStart(2, '0');
+        },
+
         async fetchUsage() {
             try {
+                var queryStr;
+                if (this.customStartDate && this.customEndDate) {
+                    queryStr = 'start_date=' + this._formatDate(this.customStartDate) +
+                               '&end_date=' + this._formatDate(this.customEndDate);
+                } else {
+                    queryStr = 'days=' + this.days;
+                }
+                queryStr += '&interval=' + this.interval;
+
                 const [summaryRes, dailyRes] = await Promise.all([
-                    fetch('/admin/api/v1/usage/summary?days=' + this.days, { headers: this.headers() }),
-                    fetch('/admin/api/v1/usage/daily?days=' + this.days, { headers: this.headers() })
+                    fetch('/admin/api/v1/usage/summary?' + queryStr, { headers: this.headers() }),
+                    fetch('/admin/api/v1/usage/daily?' + queryStr, { headers: this.headers() })
                 ]);
 
                 if (!this.handleFetchResponse(summaryRes, 'usage summary') ||
@@ -171,12 +409,19 @@ function dashboard() {
         },
 
         fillMissingDays(daily) {
+            // For non-daily intervals, return data as-is (no gap filling)
+            if (this.interval !== 'daily') {
+                return daily;
+            }
+
             const byDate = {};
             daily.forEach(d => { byDate[d.date] = d; });
-            const end = new Date();
+            const end = this.customEndDate ? new Date(this.customEndDate) : new Date();
             end.setHours(0, 0, 0, 0);
-            const start = new Date(end);
-            start.setDate(start.getDate() - (parseInt(this.days, 10) - 1));
+            const start = this.customStartDate ? new Date(this.customStartDate) : new Date(end);
+            if (!this.customStartDate) {
+                start.setDate(start.getDate() - (parseInt(this.days, 10) - 1));
+            }
             const result = [];
             for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
                 const key = d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -173,6 +173,12 @@ function dashboard() {
             }
         },
 
+        isCurrentMonth() {
+            const today = new Date();
+            return this.calendarMonth.getFullYear() === today.getFullYear()
+                && this.calendarMonth.getMonth() === today.getMonth();
+        },
+
         selectCalendarDay(day) {
             if (!day.current || this.isFutureDay(day)) return;
             const clicked = new Date(day.date);

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -41,7 +41,9 @@
     <!-- Usage Chart -->
     <div class="chart-container">
         <h3>Daily Token Usage</h3>
-        <canvas id="usageChart" height="300"></canvas>
+        <div class="chart-wrapper">
+            <canvas id="usageChart"></canvas>
+        </div>
         <p class="empty-state" x-show="daily.length === 0 && !loading && !authError">No usage data yet.</p>
     </div>
 </div>

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -3,7 +3,7 @@
 <div x-show="page==='overview'">
     <div class="page-header">
         <h2>Usage Overview</h2>
-        <div style="display:flex;align-items:center;gap:12px;">
+        <div class="page-header-controls">
             <div class="interval-picker">
                 <button class="interval-btn" :class="{active: interval==='daily'}" @click="setInterval('daily')">Daily</button>
                 <button class="interval-btn" :class="{active: interval==='weekly'}" @click="setInterval('weekly')">Weekly</button>
@@ -58,9 +58,11 @@
                     <!-- Right calendar (current month) -->
                     <div class="dp-calendar">
                         <div class="dp-cal-header">
-                            <span></span>
+                            <button class="dp-nav-btn dp-nav-prev-mobile" @click="prevMonth()">
+                                <svg width="14" height="14" viewBox="0 0 14 14" fill="none"><path d="M8.5 3.5L5 7l3.5 3.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                            </button>
                             <span class="dp-cal-title" x-text="calendarTitle(0)"></span>
-                            <button class="dp-nav-btn" @click="nextMonth()">
+                            <button class="dp-nav-btn" @click="nextMonth()" :disabled="isCurrentMonth()">
                                 <svg width="14" height="14" viewBox="0 0 14 14" fill="none"><path d="M5.5 3.5L9 7l-3.5 3.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
                             </button>
                         </div>

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -3,13 +3,100 @@
 <div x-show="page==='overview'">
     <div class="page-header">
         <h2>Usage Overview</h2>
-        <div class="period-select">
-            <select x-model="days" @change="fetchUsage()">
-                <option value="7">Last 7 days</option>
-                <option value="14">Last 14 days</option>
-                <option value="30" selected>Last 30 days</option>
-                <option value="90">Last 90 days</option>
-            </select>
+        <div style="display:flex;align-items:center;gap:12px;">
+            <div class="interval-picker">
+                <button class="interval-btn" :class="{active: interval==='daily'}" @click="setInterval('daily')">Daily</button>
+                <button class="interval-btn" :class="{active: interval==='weekly'}" @click="setInterval('weekly')">Weekly</button>
+                <button class="interval-btn" :class="{active: interval==='monthly'}" @click="setInterval('monthly')">Monthly</button>
+                <button class="interval-btn" :class="{active: interval==='yearly'}" @click="setInterval('yearly')">Yearly</button>
+            </div>
+            <div class="date-picker" @click.outside="closeDatePicker()">
+            <button class="date-picker-trigger" @click="toggleDatePicker()">
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M5 1v2M11 1v2M2 6h12M3 3h10a1 1 0 011 1v9a1 1 0 01-1 1H3a1 1 0 01-1-1V4a1 1 0 011-1z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                <span x-text="dateRangeLabel()">Last 30 days</span>
+                <svg class="date-picker-chevron" :class="{ open: datePickerOpen }" width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M3 4.5l3 3 3-3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </button>
+            <div class="date-picker-dropdown" x-show="datePickerOpen" x-transition.opacity.duration.150ms>
+                <div class="date-picker-presets">
+                    <button class="preset-btn" :class="{ active: selectedPreset === '3' }" @click="selectPreset('3')">Last 3 days</button>
+                    <button class="preset-btn" :class="{ active: selectedPreset === '7' }" @click="selectPreset('7')">Last 7 days</button>
+                    <button class="preset-btn" :class="{ active: selectedPreset === '14' }" @click="selectPreset('14')">Last 14 days</button>
+                    <button class="preset-btn" :class="{ active: selectedPreset === '30' }" @click="selectPreset('30')">Last 30 days</button>
+                    <button class="preset-btn" :class="{ active: selectedPreset === '90' }" @click="selectPreset('90')">Last 90 days</button>
+                </div>
+                <div class="date-picker-calendars" @mousemove="onCalendarMouseMove($event)" @mouseleave="onCalendarMouseLeave()">
+                    <!-- Left calendar (previous month) -->
+                    <div class="dp-calendar">
+                        <div class="dp-cal-header">
+                            <button class="dp-nav-btn" @click="prevMonth()">
+                                <svg width="14" height="14" viewBox="0 0 14 14" fill="none"><path d="M8.5 3.5L5 7l3.5 3.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                            </button>
+                            <span class="dp-cal-title" x-text="calendarTitle(-1)"></span>
+                            <span></span>
+                        </div>
+                        <div class="dp-weekdays">
+                            <span>Mo</span><span>Tu</span><span>We</span><span>Th</span><span>Fr</span><span>Sa</span><span>Su</span>
+                        </div>
+                        <div class="dp-days">
+                            <template x-for="day in calendarDays(-1)" :key="day.key">
+                                <button class="dp-day"
+                                    :class="{
+                                        'other-month': !day.current,
+                                        'today': isToday(day),
+                                        'range-start': isRangeStart(day),
+                                        'range-end': isRangeEnd(day),
+                                        'in-range': isInRange(day),
+                                        'disabled': isFutureDay(day)
+                                    }"
+                                    :disabled="isFutureDay(day) || !day.current"
+                                    @click="selectCalendarDay(day)"
+                                    x-text="day.day">
+                                </button>
+                            </template>
+                        </div>
+                    </div>
+                    <!-- Right calendar (current month) -->
+                    <div class="dp-calendar">
+                        <div class="dp-cal-header">
+                            <span></span>
+                            <span class="dp-cal-title" x-text="calendarTitle(0)"></span>
+                            <button class="dp-nav-btn" @click="nextMonth()">
+                                <svg width="14" height="14" viewBox="0 0 14 14" fill="none"><path d="M5.5 3.5L9 7l-3.5 3.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                            </button>
+                        </div>
+                        <div class="dp-weekdays">
+                            <span>Mo</span><span>Tu</span><span>We</span><span>Th</span><span>Fr</span><span>Sa</span><span>Su</span>
+                        </div>
+                        <div class="dp-days">
+                            <template x-for="day in calendarDays(0)" :key="day.key">
+                                <button class="dp-day"
+                                    :class="{
+                                        'other-month': !day.current,
+                                        'today': isToday(day),
+                                        'range-start': isRangeStart(day),
+                                        'range-end': isRangeEnd(day),
+                                        'in-range': isInRange(day),
+                                        'disabled': isFutureDay(day)
+                                    }"
+                                    :disabled="isFutureDay(day) || !day.current"
+                                    @click="selectCalendarDay(day)"
+                                    x-text="day.day">
+                                </button>
+                            </template>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="dp-cursor-hint" x-show="cursorHint.show" :style="'left:'+cursorHint.x+'px;top:'+cursorHint.y+'px'">
+                <template x-if="selectingDate==='start'">
+                    <svg viewBox="0 0 12 12" fill="none"><path d="M2 2v8M2 6h7M6.5 3.5L9 6 6.5 8.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                </template>
+                <template x-if="selectingDate==='end'">
+                    <svg viewBox="0 0 12 12" fill="none"><path d="M10 2v8M3 6h7M5.5 3.5L3 6l2.5 2.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                </template>
+                <span x-text="selectionHint()"></span>
+            </div>
+        </div>
         </div>
     </div>
 
@@ -40,7 +127,7 @@
 
     <!-- Usage Chart -->
     <div class="chart-container">
-        <h3>Daily Token Usage</h3>
+        <h3 x-text="chartTitle()">Daily Token Usage</h3>
         <div class="chart-wrapper">
             <canvas id="usageChart"></canvas>
         </div>

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -10,7 +10,7 @@
                 <button class="interval-btn" :class="{active: interval==='monthly'}" @click="setInterval('monthly')">Monthly</button>
                 <button class="interval-btn" :class="{active: interval==='yearly'}" @click="setInterval('yearly')">Yearly</button>
             </div>
-            <div class="date-picker" @click.outside="closeDatePicker()">
+            <div class="date-picker" @click.outside="closeDatePicker()" @keydown.escape.window="closeDatePicker()">
             <button class="date-picker-trigger" @click="toggleDatePicker()">
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M5 1v2M11 1v2M2 6h12M3 3h10a1 1 0 011 1v9a1 1 0 01-1 1H3a1 1 0 01-1-1V4a1 1 0 011-1z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
                 <span x-text="dateRangeLabel()">Last 30 days</span>

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -51,7 +51,7 @@
     <div class="page-header">
         <h2>Registered Models</h2>
         <div class="model-count" x-show="models.length > 0">
-            <span x-text="models.length"></span> models
+            <span x-text="modelFilter ? filteredModels.length + ' / ' + models.length : models.length"></span> models
         </div>
     </div>
 
@@ -62,13 +62,7 @@
 
     <!-- Filter -->
     <div class="table-toolbar" x-show="models.length > 0">
-        <input type="text" placeholder="Filter models..." x-model="modelFilter" class="filter-input">
-        <select x-model="providerFilter" class="filter-select">
-            <option value="">All providers</option>
-            <template x-for="p in providerList" :key="p">
-                <option :value="p" x-text="p"></option>
-            </template>
-        </select>
+        <input type="text" placeholder="Filter by model, provider, or owner..." x-model="modelFilter" class="filter-input">
     </div>
 
     <!-- Models Table -->

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -1,0 +1,97 @@
+{{define "index"}}
+<!-- Overview Page -->
+<div x-show="page==='overview'">
+    <div class="page-header">
+        <h2>Usage Overview</h2>
+        <div class="period-select">
+            <select x-model="days" @change="fetchUsage()">
+                <option value="7">Last 7 days</option>
+                <option value="14">Last 14 days</option>
+                <option value="30" selected>Last 30 days</option>
+                <option value="90">Last 90 days</option>
+            </select>
+        </div>
+    </div>
+
+    <!-- Auth Error Banner -->
+    <div class="alert alert-warning" x-show="authError">
+        Authentication required. Enter your API key in the sidebar to view data.
+    </div>
+
+    <!-- Summary Cards -->
+    <div class="cards">
+        <div class="card">
+            <div class="card-label">Total Requests</div>
+            <div class="card-value" x-text="formatNumber(summary.total_requests)">-</div>
+        </div>
+        <div class="card">
+            <div class="card-label">Input Tokens</div>
+            <div class="card-value" x-text="formatNumber(summary.total_input_tokens)">-</div>
+        </div>
+        <div class="card">
+            <div class="card-label">Output Tokens</div>
+            <div class="card-value" x-text="formatNumber(summary.total_output_tokens)">-</div>
+        </div>
+        <div class="card">
+            <div class="card-label">Total Tokens</div>
+            <div class="card-value" x-text="formatNumber(summary.total_tokens)">-</div>
+        </div>
+    </div>
+
+    <!-- Usage Chart -->
+    <div class="chart-container">
+        <h3>Daily Token Usage</h3>
+        <canvas id="usageChart" height="300"></canvas>
+        <p class="empty-state" x-show="daily.length === 0 && !loading && !authError">No usage data yet.</p>
+    </div>
+</div>
+
+<!-- Models Page -->
+<div x-show="page==='models'">
+    <div class="page-header">
+        <h2>Registered Models</h2>
+        <div class="model-count" x-show="models.length > 0">
+            <span x-text="models.length"></span> models
+        </div>
+    </div>
+
+    <!-- Auth Error Banner -->
+    <div class="alert alert-warning" x-show="authError">
+        Authentication required. Enter your API key in the sidebar to view data.
+    </div>
+
+    <!-- Filter -->
+    <div class="table-toolbar" x-show="models.length > 0">
+        <input type="text" placeholder="Filter models..." x-model="modelFilter" class="filter-input">
+        <select x-model="providerFilter" class="filter-select">
+            <option value="">All providers</option>
+            <template x-for="p in providerList" :key="p">
+                <option :value="p" x-text="p"></option>
+            </template>
+        </select>
+    </div>
+
+    <!-- Models Table -->
+    <div class="table-wrapper" x-show="models.length > 0">
+        <table class="data-table">
+            <thead>
+                <tr>
+                    <th>Model ID</th>
+                    <th>Provider</th>
+                    <th>Owned By</th>
+                </tr>
+            </thead>
+            <tbody>
+                <template x-for="m in filteredModels" :key="m.model.id">
+                    <tr>
+                        <td class="mono" x-text="m.model.id"></td>
+                        <td><span class="provider-badge" x-text="m.provider_type"></span></td>
+                        <td x-text="m.model.owned_by || '-'"></td>
+                    </tr>
+                </template>
+            </tbody>
+        </table>
+    </div>
+    <p class="empty-state" x-show="models.length === 0 && !loading && !authError">No models registered.</p>
+</div>
+{{end}}

--- a/internal/admin/dashboard/templates/layout.html
+++ b/internal/admin/dashboard/templates/layout.html
@@ -28,11 +28,11 @@
                 <span class="badge">Admin</span>
             </div>
             <nav class="sidebar-nav">
-                <a href="#overview" class="nav-item active" title="Overview" @click.prevent="page='overview'; renderChart(); $el.closest('.sidebar-nav').querySelectorAll('.nav-item').forEach(n=>n.classList.remove('active')); $el.classList.add('active')">
+                <a href="/admin/dashboard/overview" class="nav-item" :class="{ active: page === 'overview' }" title="Overview" @click.prevent="navigate('overview')">
                     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
                     <span>Overview</span>
                 </a>
-                <a href="#models" class="nav-item" title="Models" @click.prevent="page='models'; $el.closest('.sidebar-nav').querySelectorAll('.nav-item').forEach(n=>n.classList.remove('active')); $el.classList.add('active')">
+                <a href="/admin/dashboard/models" class="nav-item" :class="{ active: page === 'models' }" title="Models" @click.prevent="navigate('models')">
                     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z"/></svg>
                     <span>Models</span>
                 </a>

--- a/internal/admin/dashboard/templates/layout.html
+++ b/internal/admin/dashboard/templates/layout.html
@@ -48,6 +48,17 @@
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>
                     </button>
                 </div>
+                <button class="theme-toggle-mobile" @click="toggleTheme()" :title="theme === 'light' ? 'Light' : theme === 'dark' ? 'Dark' : 'System'">
+                    <template x-if="theme === 'light'">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
+                    </template>
+                    <template x-if="theme === 'system'">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
+                    </template>
+                    <template x-if="theme === 'dark'">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>
+                    </template>
+                </button>
                 <div class="api-key-section" x-show="needsAuth">
                     <label for="apiKey">API Key</label>
                     <input id="apiKey" type="password" placeholder="Bearer token" x-model="apiKey" @change="saveApiKey(); fetchAll()">

--- a/internal/admin/dashboard/templates/layout.html
+++ b/internal/admin/dashboard/templates/layout.html
@@ -67,7 +67,7 @@
             </div>
         </aside>
         <div class="sidebar-toggle"
-             @click="toggleSidebar()"
+             @mousedown="toggleSidebar()"
              :class="{ collapsed: sidebarCollapsed }"
              :title="sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'"></div>
         <main class="content" :class="{ 'content-collapsed': sidebarCollapsed }">

--- a/internal/admin/dashboard/templates/layout.html
+++ b/internal/admin/dashboard/templates/layout.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>GOModel Dashboard</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.8/dist/cdn.min.js"></script>
     <script src="https://unpkg.com/htmx.org@2.0.8/dist/htmx.min.js"></script>
@@ -13,6 +16,13 @@
     <div class="app">
         <aside class="sidebar">
             <div class="sidebar-header">
+                <div class="sidebar-logo">
+                    <svg viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M15 3L25.39 9L25.39 21L15 27L4.61 21L4.61 9Z" stroke="currentColor" stroke-width="2" fill="none"/>
+                        <circle cx="15" cy="15" r="4" fill="currentColor" opacity="0.3"/>
+                        <path d="M15 9.5L15 6M15 20.5L15 24M19.76 12.25L22.79 10.5M10.24 17.75L7.21 19.5M19.76 17.75L22.79 19.5M10.24 12.25L7.21 10.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+                    </svg>
+                </div>
                 <h1>GOModel</h1>
                 <span class="badge">Admin</span>
             </div>
@@ -28,9 +38,15 @@
             </nav>
             <div class="sidebar-footer">
                 <div class="theme-toggle">
-                    <button class="theme-btn" :class="{ active: theme === 'light' }" @click="setTheme('light')">Light</button>
-                    <button class="theme-btn" :class="{ active: theme === 'system' }" @click="setTheme('system')">Auto</button>
-                    <button class="theme-btn" :class="{ active: theme === 'dark' }" @click="setTheme('dark')">Dark</button>
+                    <button class="theme-btn" :class="{ active: theme === 'light' }" @click="setTheme('light')" title="Light">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
+                    </button>
+                    <button class="theme-btn" :class="{ active: theme === 'system' }" @click="setTheme('system')" title="System">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
+                    </button>
+                    <button class="theme-btn" :class="{ active: theme === 'dark' }" @click="setTheme('dark')" title="Dark">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>
+                    </button>
                 </div>
                 <div class="api-key-section" x-show="needsAuth">
                     <label for="apiKey">API Key</label>

--- a/internal/admin/dashboard/templates/layout.html
+++ b/internal/admin/dashboard/templates/layout.html
@@ -39,17 +39,17 @@
             </nav>
             <div class="sidebar-footer">
                 <div class="theme-toggle">
-                    <button class="theme-btn" :class="{ active: theme === 'light' }" @click="setTheme('light')" title="Light">
+                    <button class="theme-btn" :class="{ active: theme === 'light' }" @click="setTheme('light')" title="Light" tabindex="-1">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
                     </button>
-                    <button class="theme-btn" :class="{ active: theme === 'system' }" @click="setTheme('system')" title="System">
+                    <button class="theme-btn" :class="{ active: theme === 'system' }" @click="setTheme('system')" title="System" tabindex="-1">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
                     </button>
-                    <button class="theme-btn" :class="{ active: theme === 'dark' }" @click="setTheme('dark')" title="Dark">
+                    <button class="theme-btn" :class="{ active: theme === 'dark' }" @click="setTheme('dark')" title="Dark" tabindex="-1">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>
                     </button>
                 </div>
-                <button class="theme-toggle-mobile" @click="toggleTheme()" :title="theme === 'light' ? 'Light' : theme === 'dark' ? 'Dark' : 'System'">
+                <button class="theme-toggle-mobile" @click="toggleTheme()" :title="theme === 'light' ? 'Light' : theme === 'dark' ? 'Dark' : 'System'" tabindex="-1">
                     <template x-if="theme === 'light'">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
                     </template>

--- a/internal/admin/dashboard/templates/layout.html
+++ b/internal/admin/dashboard/templates/layout.html
@@ -27,6 +27,11 @@
                 </a>
             </nav>
             <div class="sidebar-footer">
+                <div class="theme-toggle">
+                    <button class="theme-btn" :class="{ active: theme === 'light' }" @click="setTheme('light')">Light</button>
+                    <button class="theme-btn" :class="{ active: theme === 'system' }" @click="setTheme('system')">Auto</button>
+                    <button class="theme-btn" :class="{ active: theme === 'dark' }" @click="setTheme('dark')">Dark</button>
+                </div>
                 <div class="api-key-section" x-show="needsAuth">
                     <label for="apiKey">API Key</label>
                     <input id="apiKey" type="password" placeholder="Bearer token" x-model="apiKey" @change="saveApiKey(); fetchAll()">

--- a/internal/admin/dashboard/templates/layout.html
+++ b/internal/admin/dashboard/templates/layout.html
@@ -27,13 +27,13 @@
                 <span class="badge">Admin</span>
             </div>
             <nav class="sidebar-nav">
-                <a href="#overview" class="nav-item active" @click.prevent="page='overview'; $el.closest('.sidebar-nav').querySelectorAll('.nav-item').forEach(n=>n.classList.remove('active')); $el.classList.add('active')">
+                <a href="#overview" class="nav-item active" title="Overview" @click.prevent="page='overview'; $el.closest('.sidebar-nav').querySelectorAll('.nav-item').forEach(n=>n.classList.remove('active')); $el.classList.add('active')">
                     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
-                    Overview
+                    <span>Overview</span>
                 </a>
-                <a href="#models" class="nav-item" @click.prevent="page='models'; $el.closest('.sidebar-nav').querySelectorAll('.nav-item').forEach(n=>n.classList.remove('active')); $el.classList.add('active')">
+                <a href="#models" class="nav-item" title="Models" @click.prevent="page='models'; $el.closest('.sidebar-nav').querySelectorAll('.nav-item').forEach(n=>n.classList.remove('active')); $el.classList.add('active')">
                     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z"/></svg>
-                    Models
+                    <span>Models</span>
                 </a>
             </nav>
             <div class="sidebar-footer">

--- a/internal/admin/dashboard/templates/layout.html
+++ b/internal/admin/dashboard/templates/layout.html
@@ -1,0 +1,42 @@
+{{define "layout"}}<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GOModel Dashboard</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.8/dist/cdn.min.js"></script>
+    <script src="https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js"></script>
+    <link rel="stylesheet" href="/admin/static/css/dashboard.css">
+</head>
+<body x-data="dashboard()" x-init="init()">
+    <div class="app">
+        <aside class="sidebar">
+            <div class="sidebar-header">
+                <h1>GOModel</h1>
+                <span class="badge">Admin</span>
+            </div>
+            <nav class="sidebar-nav">
+                <a href="#overview" class="nav-item active" @click.prevent="page='overview'; $el.closest('.sidebar-nav').querySelectorAll('.nav-item').forEach(n=>n.classList.remove('active')); $el.classList.add('active')">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+                    Overview
+                </a>
+                <a href="#models" class="nav-item" @click.prevent="page='models'; $el.closest('.sidebar-nav').querySelectorAll('.nav-item').forEach(n=>n.classList.remove('active')); $el.classList.add('active')">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z"/></svg>
+                    Models
+                </a>
+            </nav>
+            <div class="sidebar-footer">
+                <div class="api-key-section" x-show="needsAuth">
+                    <label for="apiKey">API Key</label>
+                    <input id="apiKey" type="password" placeholder="Bearer token" x-model="apiKey" @change="saveApiKey(); fetchAll()">
+                </div>
+            </div>
+        </aside>
+        <main class="content">
+            {{template "index" .}}
+        </main>
+    </div>
+    <script src="/admin/static/js/dashboard.js"></script>
+</body>
+</html>{{end}}

--- a/internal/admin/dashboard/templates/layout.html
+++ b/internal/admin/dashboard/templates/layout.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>GOModel Dashboard</title>
+    <link rel="icon" type="image/svg+xml" href="/admin/static/favicon.svg">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -27,7 +28,7 @@
                 <span class="badge">Admin</span>
             </div>
             <nav class="sidebar-nav">
-                <a href="#overview" class="nav-item active" title="Overview" @click.prevent="page='overview'; $el.closest('.sidebar-nav').querySelectorAll('.nav-item').forEach(n=>n.classList.remove('active')); $el.classList.add('active')">
+                <a href="#overview" class="nav-item active" title="Overview" @click.prevent="page='overview'; renderChart(); $el.closest('.sidebar-nav').querySelectorAll('.nav-item').forEach(n=>n.classList.remove('active')); $el.classList.add('active')">
                     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
                     <span>Overview</span>
                 </a>

--- a/internal/admin/dashboard/templates/layout.html
+++ b/internal/admin/dashboard/templates/layout.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>GOModel Dashboard</title>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
-    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.8/dist/cdn.min.js"></script>
-    <script src="https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.8/dist/cdn.min.js"></script>
+    <script src="https://unpkg.com/htmx.org@2.0.8/dist/htmx.min.js"></script>
     <link rel="stylesheet" href="/admin/static/css/dashboard.css">
 </head>
 <body x-data="dashboard()" x-init="init()">

--- a/internal/admin/dashboard/templates/layout.html
+++ b/internal/admin/dashboard/templates/layout.html
@@ -15,7 +15,7 @@
 </head>
 <body x-data="dashboard()" x-init="init()">
     <div class="app">
-        <aside class="sidebar">
+        <aside class="sidebar" :class="{ 'sidebar-collapsed': sidebarCollapsed }">
             <div class="sidebar-header">
                 <div class="sidebar-logo">
                     <svg viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -66,7 +66,11 @@
                 </div>
             </div>
         </aside>
-        <main class="content">
+        <div class="sidebar-toggle"
+             @click="toggleSidebar()"
+             :class="{ collapsed: sidebarCollapsed }"
+             :title="sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'"></div>
+        <main class="content" :class="{ 'content-collapsed': sidebarCollapsed }">
             {{template "index" .}}
         </main>
     </div>

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -1,0 +1,91 @@
+// Package admin provides the admin REST API and dashboard for GOModel.
+package admin
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/labstack/echo/v4"
+
+	"gomodel/internal/providers"
+	"gomodel/internal/usage"
+)
+
+// Handler serves admin API endpoints.
+type Handler struct {
+	usageReader usage.UsageReader
+	registry    *providers.ModelRegistry
+}
+
+// NewHandler creates a new admin API handler.
+// usageReader may be nil if usage tracking is not available.
+func NewHandler(reader usage.UsageReader, registry *providers.ModelRegistry) *Handler {
+	return &Handler{
+		usageReader: reader,
+		registry:    registry,
+	}
+}
+
+// UsageSummary handles GET /admin/api/v1/usage/summary?days=30
+func (h *Handler) UsageSummary(c echo.Context) error {
+	if h.usageReader == nil {
+		return c.JSON(http.StatusOK, usage.UsageSummary{})
+	}
+
+	days := 30
+	if d := c.QueryParam("days"); d != "" {
+		if parsed, err := strconv.Atoi(d); err == nil && parsed > 0 {
+			days = parsed
+		}
+	}
+
+	summary, err := h.usageReader.GetSummary(c.Request().Context(), days)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{
+			"error": "failed to fetch usage summary",
+		})
+	}
+
+	return c.JSON(http.StatusOK, summary)
+}
+
+// DailyUsage handles GET /admin/api/v1/usage/daily?days=30
+func (h *Handler) DailyUsage(c echo.Context) error {
+	if h.usageReader == nil {
+		return c.JSON(http.StatusOK, []usage.DailyUsage{})
+	}
+
+	days := 30
+	if d := c.QueryParam("days"); d != "" {
+		if parsed, err := strconv.Atoi(d); err == nil && parsed > 0 {
+			days = parsed
+		}
+	}
+
+	daily, err := h.usageReader.GetDailyUsage(c.Request().Context(), days)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{
+			"error": "failed to fetch daily usage",
+		})
+	}
+
+	if daily == nil {
+		daily = []usage.DailyUsage{}
+	}
+
+	return c.JSON(http.StatusOK, daily)
+}
+
+// ListModels handles GET /admin/api/v1/models
+func (h *Handler) ListModels(c echo.Context) error {
+	if h.registry == nil {
+		return c.JSON(http.StatusOK, []providers.ModelWithProvider{})
+	}
+
+	models := h.registry.ListModelsWithProvider()
+	if models == nil {
+		models = []providers.ModelWithProvider{}
+	}
+
+	return c.JSON(http.StatusOK, models)
+}

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -4,6 +4,7 @@ package admin
 import (
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/labstack/echo/v4"
 
@@ -26,20 +27,77 @@ func NewHandler(reader usage.UsageReader, registry *providers.ModelRegistry) *Ha
 	}
 }
 
-// UsageSummary handles GET /admin/api/v1/usage/summary?days=30
+var validIntervals = map[string]bool{
+	"daily":   true,
+	"weekly":  true,
+	"monthly": true,
+	"yearly":  true,
+}
+
+// parseUsageParams extracts UsageQueryParams from the request query string.
+func parseUsageParams(c echo.Context) usage.UsageQueryParams {
+	var params usage.UsageQueryParams
+
+	now := time.Now().UTC()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+
+	startStr := c.QueryParam("start_date")
+	endStr := c.QueryParam("end_date")
+
+	var startParsed, endParsed bool
+
+	if startStr != "" {
+		if t, err := time.Parse("2006-01-02", startStr); err == nil {
+			params.StartDate = t
+			startParsed = true
+		}
+	}
+
+	if endStr != "" {
+		if t, err := time.Parse("2006-01-02", endStr); err == nil {
+			params.EndDate = t
+			endParsed = true
+		}
+	}
+
+	if startParsed || endParsed {
+		// Fill in missing side
+		if !startParsed {
+			params.StartDate = params.EndDate.AddDate(0, 0, -29)
+		}
+		if !endParsed {
+			params.EndDate = today
+		}
+	} else {
+		// Fall back to days param
+		days := 30
+		if d := c.QueryParam("days"); d != "" {
+			if parsed, err := strconv.Atoi(d); err == nil && parsed > 0 {
+				days = parsed
+			}
+		}
+		params.EndDate = today
+		params.StartDate = today.AddDate(0, 0, -(days - 1))
+	}
+
+	// Parse interval
+	params.Interval = c.QueryParam("interval")
+	if !validIntervals[params.Interval] {
+		params.Interval = "daily"
+	}
+
+	return params
+}
+
+// UsageSummary handles GET /admin/api/v1/usage/summary
 func (h *Handler) UsageSummary(c echo.Context) error {
 	if h.usageReader == nil {
 		return c.JSON(http.StatusOK, usage.UsageSummary{})
 	}
 
-	days := 30
-	if d := c.QueryParam("days"); d != "" {
-		if parsed, err := strconv.Atoi(d); err == nil && parsed > 0 {
-			days = parsed
-		}
-	}
+	params := parseUsageParams(c)
 
-	summary, err := h.usageReader.GetSummary(c.Request().Context(), days)
+	summary, err := h.usageReader.GetSummary(c.Request().Context(), params)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": "failed to fetch usage summary",
@@ -49,20 +107,15 @@ func (h *Handler) UsageSummary(c echo.Context) error {
 	return c.JSON(http.StatusOK, summary)
 }
 
-// DailyUsage handles GET /admin/api/v1/usage/daily?days=30
+// DailyUsage handles GET /admin/api/v1/usage/daily
 func (h *Handler) DailyUsage(c echo.Context) error {
 	if h.usageReader == nil {
 		return c.JSON(http.StatusOK, []usage.DailyUsage{})
 	}
 
-	days := 30
-	if d := c.QueryParam("days"); d != "" {
-		if parsed, err := strconv.Atoi(d); err == nil && parsed > 0 {
-			days = parsed
-		}
-	}
+	params := parseUsageParams(c)
 
-	daily, err := h.usageReader.GetDailyUsage(c.Request().Context(), days)
+	daily, err := h.usageReader.GetDailyUsage(c.Request().Context(), params)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": "failed to fetch daily usage",

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -1,6 +1,10 @@
 package admin
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -8,8 +12,407 @@ import (
 
 	"github.com/labstack/echo/v4"
 
+	"gomodel/internal/core"
+	"gomodel/internal/providers"
 	"gomodel/internal/usage"
 )
+
+// mockUsageReader implements usage.UsageReader for testing.
+type mockUsageReader struct {
+	summary    *usage.UsageSummary
+	daily      []usage.DailyUsage
+	summaryErr error
+	dailyErr   error
+}
+
+func (m *mockUsageReader) GetSummary(_ context.Context, _ usage.UsageQueryParams) (*usage.UsageSummary, error) {
+	if m.summaryErr != nil {
+		return nil, m.summaryErr
+	}
+	return m.summary, nil
+}
+
+func (m *mockUsageReader) GetDailyUsage(_ context.Context, _ usage.UsageQueryParams) ([]usage.DailyUsage, error) {
+	if m.dailyErr != nil {
+		return nil, m.dailyErr
+	}
+	return m.daily, nil
+}
+
+// handlerMockProvider implements core.Provider for ListModels registry testing.
+type handlerMockProvider struct {
+	models *core.ModelsResponse
+}
+
+func (m *handlerMockProvider) ChatCompletion(_ context.Context, _ *core.ChatRequest) (*core.ChatResponse, error) {
+	return nil, nil
+}
+func (m *handlerMockProvider) StreamChatCompletion(_ context.Context, _ *core.ChatRequest) (io.ReadCloser, error) {
+	return nil, nil
+}
+func (m *handlerMockProvider) ListModels(_ context.Context) (*core.ModelsResponse, error) {
+	return m.models, nil
+}
+func (m *handlerMockProvider) Responses(_ context.Context, _ *core.ResponsesRequest) (*core.ResponsesResponse, error) {
+	return nil, nil
+}
+func (m *handlerMockProvider) StreamResponses(_ context.Context, _ *core.ResponsesRequest) (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func newHandlerContext(path string) (echo.Context, *httptest.ResponseRecorder) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	rec := httptest.NewRecorder()
+	return e.NewContext(req, rec), rec
+}
+
+// --- UsageSummary handler tests ---
+
+func TestUsageSummary_NilReader(t *testing.T) {
+	h := NewHandler(nil, nil)
+	c, rec := newHandlerContext("/admin/api/v1/usage/summary")
+
+	if err := h.UsageSummary(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	var summary usage.UsageSummary
+	if err := json.Unmarshal(rec.Body.Bytes(), &summary); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if summary.TotalRequests != 0 || summary.TotalInput != 0 || summary.TotalOutput != 0 || summary.TotalTokens != 0 {
+		t.Errorf("expected zeroed summary, got %+v", summary)
+	}
+}
+
+func TestUsageSummary_Success(t *testing.T) {
+	reader := &mockUsageReader{
+		summary: &usage.UsageSummary{
+			TotalRequests: 42,
+			TotalInput:    1000,
+			TotalOutput:   500,
+			TotalTokens:   1500,
+		},
+	}
+	h := NewHandler(reader, nil)
+	c, rec := newHandlerContext("/admin/api/v1/usage/summary?days=30")
+
+	if err := h.UsageSummary(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	var summary usage.UsageSummary
+	if err := json.Unmarshal(rec.Body.Bytes(), &summary); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if summary.TotalRequests != 42 {
+		t.Errorf("expected 42 requests, got %d", summary.TotalRequests)
+	}
+	if summary.TotalTokens != 1500 {
+		t.Errorf("expected 1500 total tokens, got %d", summary.TotalTokens)
+	}
+}
+
+func TestUsageSummary_GatewayError(t *testing.T) {
+	reader := &mockUsageReader{
+		summaryErr: core.NewProviderError("test", http.StatusBadGateway, "upstream failed", nil),
+	}
+	h := NewHandler(reader, nil)
+	c, rec := newHandlerContext("/admin/api/v1/usage/summary")
+
+	if err := h.UsageSummary(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusBadGateway {
+		t.Errorf("expected 502, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !containsString(body, "provider_error") {
+		t.Errorf("expected provider_error in body, got: %s", body)
+	}
+}
+
+func TestUsageSummary_GenericError(t *testing.T) {
+	reader := &mockUsageReader{
+		summaryErr: errors.New("database connection lost"),
+	}
+	h := NewHandler(reader, nil)
+	c, rec := newHandlerContext("/admin/api/v1/usage/summary")
+
+	if err := h.UsageSummary(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !containsString(body, "internal_error") {
+		t.Errorf("expected internal_error in body, got: %s", body)
+	}
+	if containsString(body, "database connection lost") {
+		t.Errorf("original error message should be hidden, got: %s", body)
+	}
+	if !containsString(body, "an unexpected error occurred") {
+		t.Errorf("expected generic message, got: %s", body)
+	}
+}
+
+// --- DailyUsage handler tests ---
+
+func TestDailyUsage_NilReader(t *testing.T) {
+	h := NewHandler(nil, nil)
+	c, rec := newHandlerContext("/admin/api/v1/usage/daily")
+
+	if err := h.DailyUsage(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	// Should be [] not null
+	if rec.Body.String() != "[]\n" {
+		t.Errorf("expected empty JSON array, got: %q", rec.Body.String())
+	}
+}
+
+func TestDailyUsage_Success(t *testing.T) {
+	reader := &mockUsageReader{
+		daily: []usage.DailyUsage{
+			{Date: "2026-02-01", Requests: 10, InputTokens: 100, OutputTokens: 50, TotalTokens: 150},
+			{Date: "2026-02-02", Requests: 20, InputTokens: 200, OutputTokens: 100, TotalTokens: 300},
+		},
+	}
+	h := NewHandler(reader, nil)
+	c, rec := newHandlerContext("/admin/api/v1/usage/daily?days=7")
+
+	if err := h.DailyUsage(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	var daily []usage.DailyUsage
+	if err := json.Unmarshal(rec.Body.Bytes(), &daily); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if len(daily) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(daily))
+	}
+}
+
+func TestDailyUsage_NilResult(t *testing.T) {
+	reader := &mockUsageReader{
+		daily: nil, // reader returns nil slice
+	}
+	h := NewHandler(reader, nil)
+	c, rec := newHandlerContext("/admin/api/v1/usage/daily")
+
+	if err := h.DailyUsage(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	// Should be [] not null
+	if rec.Body.String() != "[]\n" {
+		t.Errorf("expected empty JSON array, got: %q", rec.Body.String())
+	}
+}
+
+func TestDailyUsage_Error(t *testing.T) {
+	reader := &mockUsageReader{
+		dailyErr: core.NewRateLimitError("test", "too many requests"),
+	}
+	h := NewHandler(reader, nil)
+	c, rec := newHandlerContext("/admin/api/v1/usage/daily")
+
+	if err := h.DailyUsage(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusTooManyRequests {
+		t.Errorf("expected 429, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !containsString(body, "rate_limit_error") {
+		t.Errorf("expected rate_limit_error in body, got: %s", body)
+	}
+}
+
+// --- ListModels handler tests ---
+
+func TestListModels_NilRegistry(t *testing.T) {
+	h := NewHandler(nil, nil)
+	c, rec := newHandlerContext("/admin/api/v1/models")
+
+	if err := h.ListModels(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	if rec.Body.String() != "[]\n" {
+		t.Errorf("expected empty JSON array, got: %q", rec.Body.String())
+	}
+}
+
+func TestListModels_WithModels(t *testing.T) {
+	registry := providers.NewModelRegistry()
+	mock := &handlerMockProvider{
+		models: &core.ModelsResponse{
+			Object: "list",
+			Data: []core.Model{
+				{ID: "gpt-4", Object: "model", OwnedBy: "openai"},
+				{ID: "claude-3", Object: "model", OwnedBy: "anthropic"},
+			},
+		},
+	}
+	registry.RegisterProviderWithType(mock, "test")
+	if err := registry.Initialize(context.Background()); err != nil {
+		t.Fatalf("failed to initialize registry: %v", err)
+	}
+
+	h := NewHandler(nil, registry)
+	c, rec := newHandlerContext("/admin/api/v1/models")
+
+	if err := h.ListModels(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+
+	var models []providers.ModelWithProvider
+	if err := json.Unmarshal(rec.Body.Bytes(), &models); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("expected 2 models, got %d", len(models))
+	}
+	// Should be sorted by model ID
+	if models[0].Model.ID != "claude-3" {
+		t.Errorf("expected first model to be claude-3, got %s", models[0].Model.ID)
+	}
+	if models[1].Model.ID != "gpt-4" {
+		t.Errorf("expected second model to be gpt-4, got %s", models[1].Model.ID)
+	}
+	if models[0].ProviderType != "test" {
+		t.Errorf("expected provider type 'test', got %s", models[0].ProviderType)
+	}
+}
+
+func TestListModels_EmptyRegistry(t *testing.T) {
+	// A registry with no providers initialized — ListModelsWithProvider returns nil
+	registry := providers.NewModelRegistry()
+
+	h := NewHandler(nil, registry)
+	c, rec := newHandlerContext("/admin/api/v1/models")
+
+	if err := h.ListModels(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	if rec.Body.String() != "[]\n" {
+		t.Errorf("expected empty JSON array, got: %q", rec.Body.String())
+	}
+}
+
+// --- handleError tests ---
+
+func TestHandleError_GatewayErrors(t *testing.T) {
+	tests := []struct {
+		name           string
+		err            error
+		expectedStatus int
+		expectedType   string
+	}{
+		{
+			name:           "provider_error → 502",
+			err:            core.NewProviderError("test", http.StatusBadGateway, "upstream error", nil),
+			expectedStatus: http.StatusBadGateway,
+			expectedType:   "provider_error",
+		},
+		{
+			name:           "rate_limit_error → 429",
+			err:            core.NewRateLimitError("test", "rate limited"),
+			expectedStatus: http.StatusTooManyRequests,
+			expectedType:   "rate_limit_error",
+		},
+		{
+			name:           "invalid_request_error → 400",
+			err:            core.NewInvalidRequestError("bad input", nil),
+			expectedStatus: http.StatusBadRequest,
+			expectedType:   "invalid_request_error",
+		},
+		{
+			name:           "authentication_error → 401",
+			err:            core.NewAuthenticationError("test", "invalid key"),
+			expectedStatus: http.StatusUnauthorized,
+			expectedType:   "authentication_error",
+		},
+		{
+			name:           "not_found_error → 404",
+			err:            core.NewNotFoundError("model not found"),
+			expectedStatus: http.StatusNotFound,
+			expectedType:   "not_found_error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, rec := newHandlerContext("/test")
+
+			if err := handleError(c, tt.err); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if rec.Code != tt.expectedStatus {
+				t.Errorf("expected status %d, got %d", tt.expectedStatus, rec.Code)
+			}
+			body := rec.Body.String()
+			if !containsString(body, tt.expectedType) {
+				t.Errorf("expected %s in body, got: %s", tt.expectedType, body)
+			}
+		})
+	}
+}
+
+func TestHandleError_UnexpectedError(t *testing.T) {
+	c, rec := newHandlerContext("/test")
+
+	if err := handleError(c, errors.New("something broke")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !containsString(body, "an unexpected error occurred") {
+		t.Errorf("expected generic message, got: %s", body)
+	}
+	if containsString(body, "something broke") {
+		t.Errorf("original error should be hidden, got: %s", body)
+	}
+}
+
+// containsString is a small helper to check substring presence.
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && stringContains(s, substr))
+}
+
+func stringContains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
 
 func newContext(query string) echo.Context {
 	e := echo.New()

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -1,0 +1,163 @@
+package admin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"gomodel/internal/usage"
+)
+
+func newContext(query string) echo.Context {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/test?"+query, nil)
+	rec := httptest.NewRecorder()
+	return e.NewContext(req, rec)
+}
+
+func TestParseUsageParams_DaysDefault(t *testing.T) {
+	c := newContext("")
+	params := parseUsageParams(c)
+
+	if params.Interval != "daily" {
+		t.Errorf("expected interval 'daily', got %q", params.Interval)
+	}
+
+	today := time.Now().UTC()
+	expectedEnd := time.Date(today.Year(), today.Month(), today.Day(), 0, 0, 0, 0, time.UTC)
+	expectedStart := expectedEnd.AddDate(0, 0, -29)
+
+	if !params.EndDate.Equal(expectedEnd) {
+		t.Errorf("expected end date %v, got %v", expectedEnd, params.EndDate)
+	}
+	if !params.StartDate.Equal(expectedStart) {
+		t.Errorf("expected start date %v, got %v", expectedStart, params.StartDate)
+	}
+}
+
+func TestParseUsageParams_DaysExplicit(t *testing.T) {
+	c := newContext("days=7")
+	params := parseUsageParams(c)
+
+	today := time.Now().UTC()
+	expectedEnd := time.Date(today.Year(), today.Month(), today.Day(), 0, 0, 0, 0, time.UTC)
+	expectedStart := expectedEnd.AddDate(0, 0, -6)
+
+	if !params.StartDate.Equal(expectedStart) {
+		t.Errorf("expected start date %v, got %v", expectedStart, params.StartDate)
+	}
+	if !params.EndDate.Equal(expectedEnd) {
+		t.Errorf("expected end date %v, got %v", expectedEnd, params.EndDate)
+	}
+}
+
+func TestParseUsageParams_StartAndEndDate(t *testing.T) {
+	c := newContext("start_date=2026-01-01&end_date=2026-01-31")
+	params := parseUsageParams(c)
+
+	expectedStart := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	expectedEnd := time.Date(2026, 1, 31, 0, 0, 0, 0, time.UTC)
+
+	if !params.StartDate.Equal(expectedStart) {
+		t.Errorf("expected start date %v, got %v", expectedStart, params.StartDate)
+	}
+	if !params.EndDate.Equal(expectedEnd) {
+		t.Errorf("expected end date %v, got %v", expectedEnd, params.EndDate)
+	}
+}
+
+func TestParseUsageParams_OnlyStartDate(t *testing.T) {
+	c := newContext("start_date=2026-01-15")
+	params := parseUsageParams(c)
+
+	expectedStart := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+	today := time.Now().UTC()
+	expectedEnd := time.Date(today.Year(), today.Month(), today.Day(), 0, 0, 0, 0, time.UTC)
+
+	if !params.StartDate.Equal(expectedStart) {
+		t.Errorf("expected start date %v, got %v", expectedStart, params.StartDate)
+	}
+	if !params.EndDate.Equal(expectedEnd) {
+		t.Errorf("expected end date %v, got %v", expectedEnd, params.EndDate)
+	}
+}
+
+func TestParseUsageParams_OnlyEndDate(t *testing.T) {
+	c := newContext("end_date=2026-02-10")
+	params := parseUsageParams(c)
+
+	expectedEnd := time.Date(2026, 2, 10, 0, 0, 0, 0, time.UTC)
+	expectedStart := expectedEnd.AddDate(0, 0, -29)
+
+	if !params.StartDate.Equal(expectedStart) {
+		t.Errorf("expected start date %v, got %v", expectedStart, params.StartDate)
+	}
+	if !params.EndDate.Equal(expectedEnd) {
+		t.Errorf("expected end date %v, got %v", expectedEnd, params.EndDate)
+	}
+}
+
+func TestParseUsageParams_InvalidDates(t *testing.T) {
+	c := newContext("start_date=invalid&end_date=also-invalid")
+	params := parseUsageParams(c)
+
+	// Should fall back to days=30 default
+	today := time.Now().UTC()
+	expectedEnd := time.Date(today.Year(), today.Month(), today.Day(), 0, 0, 0, 0, time.UTC)
+	expectedStart := expectedEnd.AddDate(0, 0, -29)
+
+	if !params.StartDate.Equal(expectedStart) {
+		t.Errorf("expected start date %v, got %v", expectedStart, params.StartDate)
+	}
+	if !params.EndDate.Equal(expectedEnd) {
+		t.Errorf("expected end date %v, got %v", expectedEnd, params.EndDate)
+	}
+}
+
+func TestParseUsageParams_IntervalWeekly(t *testing.T) {
+	c := newContext("interval=weekly")
+	params := parseUsageParams(c)
+
+	if params.Interval != "weekly" {
+		t.Errorf("expected interval 'weekly', got %q", params.Interval)
+	}
+}
+
+func TestParseUsageParams_IntervalMonthly(t *testing.T) {
+	c := newContext("interval=monthly")
+	params := parseUsageParams(c)
+
+	if params.Interval != "monthly" {
+		t.Errorf("expected interval 'monthly', got %q", params.Interval)
+	}
+}
+
+func TestParseUsageParams_IntervalInvalid(t *testing.T) {
+	c := newContext("interval=hourly")
+	params := parseUsageParams(c)
+
+	if params.Interval != "daily" {
+		t.Errorf("expected default interval 'daily', got %q", params.Interval)
+	}
+}
+
+func TestParseUsageParams_IntervalEmpty(t *testing.T) {
+	c := newContext("")
+	params := parseUsageParams(c)
+
+	if params.Interval != "daily" {
+		t.Errorf("expected default interval 'daily', got %q", params.Interval)
+	}
+}
+
+// Ensure usage.UsageQueryParams is the type used (compile check)
+var _ = func() usage.UsageQueryParams {
+	return usage.UsageQueryParams{
+		StartDate: time.Time{},
+		EndDate:   time.Time{},
+		Interval:  "daily",
+	}
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -316,7 +316,7 @@ func (a *App) logStartupInfo() {
 		slog.Info("admin API disabled")
 	}
 	if cfg.Admin.UIEnabled && cfg.Admin.EndpointsEnabled {
-		slog.Info("admin UI enabled", "url", "/admin/dashboard")
+		slog.Info("admin UI enabled", "url", fmt.Sprintf("http://localhost:%s/admin/dashboard", cfg.Server.Port))
 	} else {
 		slog.Info("admin UI disabled")
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -151,11 +151,15 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		} else {
 			serverCfg.AdminEndpointsEnabled = true
 			serverCfg.AdminHandler = adminHandler
+			slog.Info("admin API enabled", "api", "/admin/api/v1")
 			if adminCfg.UIEnabled {
 				serverCfg.AdminUIEnabled = true
 				serverCfg.DashboardHandler = dashHandler
+				slog.Info("admin UI enabled", "url", fmt.Sprintf("http://localhost:%s/admin/dashboard", cfg.AppConfig.Server.Port))
 			}
 		}
+	} else {
+		slog.Info("admin API disabled")
 	}
 
 	app.server = server.New(provider, serverCfg)
@@ -309,17 +313,6 @@ func (a *App) logStartupInfo() {
 		slog.Info("usage tracking disabled")
 	}
 
-	// Admin configuration
-	if cfg.Admin.EndpointsEnabled {
-		slog.Info("admin API enabled", "api", "/admin/api/v1")
-	} else {
-		slog.Info("admin API disabled")
-	}
-	if cfg.Admin.UIEnabled && cfg.Admin.EndpointsEnabled {
-		slog.Info("admin UI enabled", "url", fmt.Sprintf("http://localhost:%s/admin/dashboard", cfg.Server.Port))
-	} else {
-		slog.Info("admin UI disabled")
-	}
 }
 
 // initAdmin creates the admin API handler and optionally the dashboard handler.

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -355,6 +355,32 @@ func (r *ModelRegistry) GetProviderType(model string) string {
 	return r.providerTypes[info.Provider]
 }
 
+// ModelWithProvider holds a model alongside its provider type string.
+type ModelWithProvider struct {
+	Model        core.Model `json:"model"`
+	ProviderType string     `json:"provider_type"`
+}
+
+// ListModelsWithProvider returns all models with their provider types, sorted by model ID.
+func (r *ModelRegistry) ListModelsWithProvider() []ModelWithProvider {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make([]ModelWithProvider, 0, len(r.models))
+	for _, info := range r.models {
+		result = append(result, ModelWithProvider{
+			Model:        info.Model,
+			ProviderType: r.providerTypes[info.Provider],
+		})
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Model.ID < result[j].Model.ID
+	})
+
+	return result
+}
+
 // ProviderCount returns the number of registered providers
 func (r *ModelRegistry) ProviderCount() int {
 	r.mu.RLock()

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -19,10 +19,16 @@ func AuthMiddleware(masterKey string, skipPaths []string) echo.MiddlewareFunc {
 				return next(c)
 			}
 
-			// Check if path should skip authentication
+			// Check if path should skip authentication.
+			// Paths ending with "/*" are treated as prefix matches.
 			requestPath := c.Request().URL.Path
 			for _, skipPath := range skipPaths {
-				if requestPath == skipPath {
+				if strings.HasSuffix(skipPath, "/*") {
+					prefix := strings.TrimSuffix(skipPath, "*")
+					if strings.HasPrefix(requestPath, prefix) {
+						return next(c)
+					}
+				} else if requestPath == skipPath {
 					return next(c)
 				}
 			}

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -76,7 +76,7 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 
 	// Admin dashboard pages and static assets skip auth (/* enables prefix matching)
 	if cfg != nil && cfg.AdminUIEnabled && cfg.DashboardHandler != nil {
-		authSkipPaths = append(authSkipPaths, "/admin/dashboard", "/admin/static/*")
+		authSkipPaths = append(authSkipPaths, "/admin/dashboard", "/admin/dashboard/*", "/admin/static/*")
 	}
 
 	// Global middleware stack (order matters)
@@ -155,6 +155,7 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 	// Admin dashboard UI routes (behind ADMIN_UI_ENABLED flag)
 	if cfg != nil && cfg.AdminUIEnabled && cfg.DashboardHandler != nil {
 		e.GET("/admin/dashboard", cfg.DashboardHandler.Index)
+		e.GET("/admin/dashboard/*", cfg.DashboardHandler.Index)
 		e.GET("/admin/static/*", cfg.DashboardHandler.Static)
 	}
 

--- a/internal/usage/reader.go
+++ b/internal/usage/reader.go
@@ -1,6 +1,16 @@
 package usage
 
-import "context"
+import (
+	"context"
+	"time"
+)
+
+// UsageQueryParams specifies the query parameters for usage data retrieval.
+type UsageQueryParams struct {
+	StartDate time.Time // Inclusive start (day precision)
+	EndDate   time.Time // Inclusive end (day precision)
+	Interval  string    // "daily", "weekly", "monthly", "yearly"
+}
 
 // UsageSummary holds aggregated usage statistics over a time period.
 type UsageSummary struct {
@@ -10,9 +20,11 @@ type UsageSummary struct {
 	TotalTokens   int64 `json:"total_tokens"`
 }
 
-// DailyUsage holds usage statistics for a single day.
+// DailyUsage holds usage statistics for a single period.
+// Date holds the period label: YYYY-MM-DD for daily, YYYY-Www for weekly,
+// YYYY-MM for monthly, or YYYY for yearly intervals.
 type DailyUsage struct {
-	Date         string `json:"date"` // YYYY-MM-DD
+	Date         string `json:"date"`
 	Requests     int    `json:"requests"`
 	InputTokens  int64  `json:"input_tokens"`
 	OutputTokens int64  `json:"output_tokens"`
@@ -21,11 +33,11 @@ type DailyUsage struct {
 
 // UsageReader provides read access to usage data for the admin API.
 type UsageReader interface {
-	// GetSummary returns aggregated usage statistics for the last N days.
-	// If days <= 0, returns all-time statistics.
-	GetSummary(ctx context.Context, days int) (*UsageSummary, error)
+	// GetSummary returns aggregated usage statistics for the given date range.
+	// If both StartDate and EndDate are zero, returns all-time statistics.
+	GetSummary(ctx context.Context, params UsageQueryParams) (*UsageSummary, error)
 
-	// GetDailyUsage returns daily usage statistics for the last N days.
-	// If days <= 0, returns all available daily data.
-	GetDailyUsage(ctx context.Context, days int) ([]DailyUsage, error)
+	// GetDailyUsage returns usage statistics grouped by the specified interval.
+	// If both StartDate and EndDate are zero, returns all available data.
+	GetDailyUsage(ctx context.Context, params UsageQueryParams) ([]DailyUsage, error)
 }

--- a/internal/usage/reader.go
+++ b/internal/usage/reader.go
@@ -1,0 +1,31 @@
+package usage
+
+import "context"
+
+// UsageSummary holds aggregated usage statistics over a time period.
+type UsageSummary struct {
+	TotalRequests int   `json:"total_requests"`
+	TotalInput    int64 `json:"total_input_tokens"`
+	TotalOutput   int64 `json:"total_output_tokens"`
+	TotalTokens   int64 `json:"total_tokens"`
+}
+
+// DailyUsage holds usage statistics for a single day.
+type DailyUsage struct {
+	Date         string `json:"date"` // YYYY-MM-DD
+	Requests     int    `json:"requests"`
+	InputTokens  int64  `json:"input_tokens"`
+	OutputTokens int64  `json:"output_tokens"`
+	TotalTokens  int64  `json:"total_tokens"`
+}
+
+// UsageReader provides read access to usage data for the admin API.
+type UsageReader interface {
+	// GetSummary returns aggregated usage statistics for the last N days.
+	// If days <= 0, returns all-time statistics.
+	GetSummary(ctx context.Context, days int) (*UsageSummary, error)
+
+	// GetDailyUsage returns daily usage statistics for the last N days.
+	// If days <= 0, returns all available daily data.
+	GetDailyUsage(ctx context.Context, days int) ([]DailyUsage, error)
+}

--- a/internal/usage/reader_mongodb.go
+++ b/internal/usage/reader_mongodb.go
@@ -109,6 +109,10 @@ func (r *MongoDBReader) GetDailyUsage(ctx context.Context, params UsageQueryPara
 		pipeline = append(pipeline, bson.D{{Key: "$match", Value: bson.D{
 			{Key: "timestamp", Value: bson.D{{Key: "$gte", Value: params.StartDate.UTC()}}},
 		}}})
+	} else if !endZero {
+		pipeline = append(pipeline, bson.D{{Key: "$match", Value: bson.D{
+			{Key: "timestamp", Value: bson.D{{Key: "$lt", Value: params.EndDate.AddDate(0, 0, 1).UTC()}}},
+		}}})
 	}
 
 	dateFormat := mongoDateFormat(interval)

--- a/internal/usage/reader_mongodb.go
+++ b/internal/usage/reader_mongodb.go
@@ -1,0 +1,125 @@
+package usage
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+// MongoDBReader implements UsageReader for MongoDB.
+type MongoDBReader struct {
+	collection *mongo.Collection
+}
+
+// NewMongoDBReader creates a new MongoDB usage reader.
+func NewMongoDBReader(database *mongo.Database) (*MongoDBReader, error) {
+	if database == nil {
+		return nil, fmt.Errorf("database is required")
+	}
+	return &MongoDBReader{collection: database.Collection("usage")}, nil
+}
+
+func (r *MongoDBReader) GetSummary(ctx context.Context, days int) (*UsageSummary, error) {
+	pipeline := bson.A{}
+
+	if days > 0 {
+		cutoff := time.Now().AddDate(0, 0, -days).UTC()
+		pipeline = append(pipeline, bson.D{{Key: "$match", Value: bson.D{
+			{Key: "timestamp", Value: bson.D{{Key: "$gte", Value: cutoff}}},
+		}}})
+	}
+
+	pipeline = append(pipeline, bson.D{{Key: "$group", Value: bson.D{
+		{Key: "_id", Value: nil},
+		{Key: "total_requests", Value: bson.D{{Key: "$sum", Value: 1}}},
+		{Key: "total_input", Value: bson.D{{Key: "$sum", Value: "$input_tokens"}}},
+		{Key: "total_output", Value: bson.D{{Key: "$sum", Value: "$output_tokens"}}},
+		{Key: "total_tokens", Value: bson.D{{Key: "$sum", Value: "$total_tokens"}}},
+	}}})
+
+	cursor, err := r.collection.Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil, fmt.Errorf("failed to aggregate usage summary: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	summary := &UsageSummary{}
+	if cursor.Next(ctx) {
+		var result struct {
+			TotalRequests int   `bson:"total_requests"`
+			TotalInput    int64 `bson:"total_input"`
+			TotalOutput   int64 `bson:"total_output"`
+			TotalTokens   int64 `bson:"total_tokens"`
+		}
+		if err := cursor.Decode(&result); err != nil {
+			return nil, fmt.Errorf("failed to decode usage summary: %w", err)
+		}
+		summary.TotalRequests = result.TotalRequests
+		summary.TotalInput = result.TotalInput
+		summary.TotalOutput = result.TotalOutput
+		summary.TotalTokens = result.TotalTokens
+	}
+
+	return summary, nil
+}
+
+func (r *MongoDBReader) GetDailyUsage(ctx context.Context, days int) ([]DailyUsage, error) {
+	pipeline := bson.A{}
+
+	if days > 0 {
+		cutoff := time.Now().AddDate(0, 0, -days).UTC()
+		pipeline = append(pipeline, bson.D{{Key: "$match", Value: bson.D{
+			{Key: "timestamp", Value: bson.D{{Key: "$gte", Value: cutoff}}},
+		}}})
+	}
+
+	pipeline = append(pipeline,
+		bson.D{{Key: "$group", Value: bson.D{
+			{Key: "_id", Value: bson.D{{Key: "$dateToString", Value: bson.D{
+				{Key: "format", Value: "%Y-%m-%d"},
+				{Key: "date", Value: "$timestamp"},
+			}}}},
+			{Key: "requests", Value: bson.D{{Key: "$sum", Value: 1}}},
+			{Key: "input_tokens", Value: bson.D{{Key: "$sum", Value: "$input_tokens"}}},
+			{Key: "output_tokens", Value: bson.D{{Key: "$sum", Value: "$output_tokens"}}},
+			{Key: "total_tokens", Value: bson.D{{Key: "$sum", Value: "$total_tokens"}}},
+		}}},
+		bson.D{{Key: "$sort", Value: bson.D{{Key: "_id", Value: 1}}}},
+	)
+
+	cursor, err := r.collection.Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil, fmt.Errorf("failed to aggregate daily usage: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	var result []DailyUsage
+	for cursor.Next(ctx) {
+		var row struct {
+			Date         string `bson:"_id"`
+			Requests     int    `bson:"requests"`
+			InputTokens  int64  `bson:"input_tokens"`
+			OutputTokens int64  `bson:"output_tokens"`
+			TotalTokens  int64  `bson:"total_tokens"`
+		}
+		if err := cursor.Decode(&row); err != nil {
+			return nil, fmt.Errorf("failed to decode daily usage row: %w", err)
+		}
+		result = append(result, DailyUsage{
+			Date:         row.Date,
+			Requests:     row.Requests,
+			InputTokens:  row.InputTokens,
+			OutputTokens: row.OutputTokens,
+			TotalTokens:  row.TotalTokens,
+		})
+	}
+
+	if err := cursor.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating daily usage cursor: %w", err)
+	}
+
+	return result, nil
+}

--- a/internal/usage/reader_postgresql.go
+++ b/internal/usage/reader_postgresql.go
@@ -28,11 +28,11 @@ func (r *PostgreSQLReader) GetSummary(ctx context.Context, days int) (*UsageSumm
 	if days > 0 {
 		cutoff := time.Now().AddDate(0, 0, -days).UTC()
 		query = `SELECT COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)
-			FROM usage WHERE timestamp >= $1`
+			FROM "usage" WHERE timestamp >= $1`
 		args = append(args, cutoff)
 	} else {
 		query = `SELECT COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)
-			FROM usage`
+			FROM "usage"`
 	}
 
 	summary := &UsageSummary{}
@@ -53,12 +53,12 @@ func (r *PostgreSQLReader) GetDailyUsage(ctx context.Context, days int) ([]Daily
 	if days > 0 {
 		cutoff := time.Now().AddDate(0, 0, -days).UTC()
 		query = `SELECT DATE(timestamp AT TIME ZONE 'UTC') as day, COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)
-			FROM usage WHERE timestamp >= $1
+			FROM "usage" WHERE timestamp >= $1
 			GROUP BY DATE(timestamp AT TIME ZONE 'UTC') ORDER BY day`
 		args = append(args, cutoff)
 	} else {
 		query = `SELECT DATE(timestamp AT TIME ZONE 'UTC') as day, COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)
-			FROM usage GROUP BY DATE(timestamp AT TIME ZONE 'UTC') ORDER BY day`
+			FROM "usage" GROUP BY DATE(timestamp AT TIME ZONE 'UTC') ORDER BY day`
 	}
 
 	rows, err := r.pool.Query(ctx, query, args...)

--- a/internal/usage/reader_postgresql.go
+++ b/internal/usage/reader_postgresql.go
@@ -94,7 +94,7 @@ func (r *PostgreSQLReader) GetDailyUsage(ctx context.Context, params UsageQueryP
 	}
 	defer rows.Close()
 
-	var result []DailyUsage
+	result := make([]DailyUsage, 0)
 	for rows.Next() {
 		var d DailyUsage
 		if err := rows.Scan(&d.Date, &d.Requests, &d.InputTokens, &d.OutputTokens, &d.TotalTokens); err != nil {

--- a/internal/usage/reader_postgresql.go
+++ b/internal/usage/reader_postgresql.go
@@ -1,0 +1,86 @@
+package usage
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// PostgreSQLReader implements UsageReader for PostgreSQL databases.
+type PostgreSQLReader struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgreSQLReader creates a new PostgreSQL usage reader.
+func NewPostgreSQLReader(pool *pgxpool.Pool) (*PostgreSQLReader, error) {
+	if pool == nil {
+		return nil, fmt.Errorf("connection pool is required")
+	}
+	return &PostgreSQLReader{pool: pool}, nil
+}
+
+func (r *PostgreSQLReader) GetSummary(ctx context.Context, days int) (*UsageSummary, error) {
+	var query string
+	var args []interface{}
+
+	if days > 0 {
+		cutoff := time.Now().AddDate(0, 0, -days).UTC()
+		query = `SELECT COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)
+			FROM usage WHERE timestamp >= $1`
+		args = append(args, cutoff)
+	} else {
+		query = `SELECT COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)
+			FROM usage`
+	}
+
+	summary := &UsageSummary{}
+	err := r.pool.QueryRow(ctx, query, args...).Scan(
+		&summary.TotalRequests, &summary.TotalInput, &summary.TotalOutput, &summary.TotalTokens,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query usage summary: %w", err)
+	}
+
+	return summary, nil
+}
+
+func (r *PostgreSQLReader) GetDailyUsage(ctx context.Context, days int) ([]DailyUsage, error) {
+	var query string
+	var args []interface{}
+
+	if days > 0 {
+		cutoff := time.Now().AddDate(0, 0, -days).UTC()
+		query = `SELECT DATE(timestamp AT TIME ZONE 'UTC') as day, COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)
+			FROM usage WHERE timestamp >= $1
+			GROUP BY DATE(timestamp AT TIME ZONE 'UTC') ORDER BY day`
+		args = append(args, cutoff)
+	} else {
+		query = `SELECT DATE(timestamp AT TIME ZONE 'UTC') as day, COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)
+			FROM usage GROUP BY DATE(timestamp AT TIME ZONE 'UTC') ORDER BY day`
+	}
+
+	rows, err := r.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query daily usage: %w", err)
+	}
+	defer rows.Close()
+
+	var result []DailyUsage
+	for rows.Next() {
+		var d DailyUsage
+		var day time.Time
+		if err := rows.Scan(&day, &d.Requests, &d.InputTokens, &d.OutputTokens, &d.TotalTokens); err != nil {
+			return nil, fmt.Errorf("failed to scan daily usage row: %w", err)
+		}
+		d.Date = day.Format("2006-01-02")
+		result = append(result, d)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating daily usage rows: %w", err)
+	}
+
+	return result, nil
+}

--- a/internal/usage/reader_sqlite.go
+++ b/internal/usage/reader_sqlite.go
@@ -1,0 +1,83 @@
+package usage
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// SQLiteReader implements UsageReader for SQLite databases.
+type SQLiteReader struct {
+	db *sql.DB
+}
+
+// NewSQLiteReader creates a new SQLite usage reader.
+func NewSQLiteReader(db *sql.DB) (*SQLiteReader, error) {
+	if db == nil {
+		return nil, fmt.Errorf("database connection is required")
+	}
+	return &SQLiteReader{db: db}, nil
+}
+
+func (r *SQLiteReader) GetSummary(ctx context.Context, days int) (*UsageSummary, error) {
+	var query string
+	var args []interface{}
+
+	if days > 0 {
+		cutoff := time.Now().AddDate(0, 0, -days).UTC().Format(time.RFC3339Nano)
+		query = `SELECT COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)
+			FROM usage WHERE timestamp >= ?`
+		args = append(args, cutoff)
+	} else {
+		query = `SELECT COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)
+			FROM usage`
+	}
+
+	summary := &UsageSummary{}
+	err := r.db.QueryRowContext(ctx, query, args...).Scan(
+		&summary.TotalRequests, &summary.TotalInput, &summary.TotalOutput, &summary.TotalTokens,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query usage summary: %w", err)
+	}
+
+	return summary, nil
+}
+
+func (r *SQLiteReader) GetDailyUsage(ctx context.Context, days int) ([]DailyUsage, error) {
+	var query string
+	var args []interface{}
+
+	if days > 0 {
+		cutoff := time.Now().AddDate(0, 0, -days).UTC().Format(time.RFC3339Nano)
+		query = `SELECT DATE(timestamp) as day, COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)
+			FROM usage WHERE timestamp >= ?
+			GROUP BY DATE(timestamp) ORDER BY day`
+		args = append(args, cutoff)
+	} else {
+		query = `SELECT DATE(timestamp) as day, COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)
+			FROM usage GROUP BY DATE(timestamp) ORDER BY day`
+	}
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query daily usage: %w", err)
+	}
+	defer rows.Close()
+
+	var result []DailyUsage
+	for rows.Next() {
+		var d DailyUsage
+		if err := rows.Scan(&d.Date, &d.Requests, &d.InputTokens, &d.OutputTokens, &d.TotalTokens); err != nil {
+			return nil, fmt.Errorf("failed to scan daily usage row: %w", err)
+		}
+		result = append(result, d)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating daily usage rows: %w", err)
+	}
+
+	return result, nil
+}

--- a/internal/usage/reader_sqlite.go
+++ b/internal/usage/reader_sqlite.go
@@ -93,7 +93,7 @@ func (r *SQLiteReader) GetDailyUsage(ctx context.Context, params UsageQueryParam
 	}
 	defer rows.Close()
 
-	var result []DailyUsage
+	result := make([]DailyUsage, 0)
 	for rows.Next() {
 		var d DailyUsage
 		if err := rows.Scan(&d.Date, &d.Requests, &d.InputTokens, &d.OutputTokens, &d.TotalTokens); err != nil {

--- a/internal/usage/reader_sqlite.go
+++ b/internal/usage/reader_sqlite.go
@@ -53,7 +53,7 @@ func (r *SQLiteReader) GetSummary(ctx context.Context, params UsageQueryParams) 
 func sqliteGroupExpr(interval string) string {
 	switch interval {
 	case "weekly":
-		return `strftime('%Y-W%W', timestamp)`
+		return `strftime('%G-W%V', timestamp)`
 	case "monthly":
 		return `strftime('%Y-%m', timestamp)`
 	case "yearly":

--- a/tests/integration/admin_test.go
+++ b/tests/integration/admin_test.go
@@ -123,6 +123,9 @@ func TestAdminUsageSummary_MongoDB(t *testing.T) {
 		OnlyModelInteractions: false,
 	})
 
+	// Clear existing usage entries
+	dbassert.ClearUsageMongo(t, fixture.MongoDb)
+
 	// Send 2 chat requests
 	for i := 0; i < 2; i++ {
 		payload := newChatRequest("gpt-4", "Hello!")

--- a/tests/integration/admin_test.go
+++ b/tests/integration/admin_test.go
@@ -1,0 +1,230 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"gomodel/internal/providers"
+	"gomodel/internal/usage"
+	"gomodel/tests/integration/dbassert"
+)
+
+func TestAdminUsageSummary_PostgreSQL(t *testing.T) {
+	fixture := SetupTestServer(t, TestServerConfig{
+		DBType:                "postgresql",
+		UsageEnabled:          true,
+		AdminEndpointsEnabled: true,
+		OnlyModelInteractions: false,
+	})
+
+	// Clear existing usage entries
+	dbassert.ClearUsage(t, fixture.PgPool)
+
+	// Send 2 chat requests
+	for i := 0; i < 2; i++ {
+		payload := newChatRequest("gpt-4", "Hello!")
+		resp := sendChatRequest(t, fixture.ServerURL, payload)
+		require.Equal(t, 200, resp.StatusCode)
+		closeBody(resp)
+	}
+
+	// Wait for usage buffer to flush (flush interval is 1s in tests)
+	time.Sleep(2 * time.Second)
+
+	// Query admin API
+	resp, err := http.Get(fixture.ServerURL + "/admin/api/v1/usage/summary?days=30")
+	require.NoError(t, err)
+	defer closeBody(resp)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var summary usage.UsageSummary
+	require.NoError(t, json.Unmarshal(body, &summary))
+
+	assert.Equal(t, 2, summary.TotalRequests, "expected 2 total requests")
+	assert.Equal(t, int64(20), summary.TotalInput, "expected 20 input tokens (2 * 10)")
+	assert.Equal(t, int64(16), summary.TotalOutput, "expected 16 output tokens (2 * 8)")
+	assert.Equal(t, int64(36), summary.TotalTokens, "expected 36 total tokens (2 * 18)")
+
+	fixture.FlushAndClose(t)
+}
+
+func TestAdminDailyUsage_PostgreSQL(t *testing.T) {
+	fixture := SetupTestServer(t, TestServerConfig{
+		DBType:                "postgresql",
+		UsageEnabled:          true,
+		AdminEndpointsEnabled: true,
+		OnlyModelInteractions: false,
+	})
+
+	// Clear existing usage entries
+	dbassert.ClearUsage(t, fixture.PgPool)
+
+	// Send requests
+	for i := 0; i < 2; i++ {
+		payload := newChatRequest("gpt-4", "Hello!")
+		resp := sendChatRequest(t, fixture.ServerURL, payload)
+		require.Equal(t, 200, resp.StatusCode)
+		closeBody(resp)
+	}
+
+	// Wait for usage buffer to flush
+	time.Sleep(2 * time.Second)
+
+	// Query admin API
+	resp, err := http.Get(fixture.ServerURL + "/admin/api/v1/usage/daily?days=30")
+	require.NoError(t, err)
+	defer closeBody(resp)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var daily []usage.DailyUsage
+	require.NoError(t, json.Unmarshal(body, &daily))
+
+	require.NotEmpty(t, daily, "expected at least one daily entry")
+
+	// Find today's entry
+	today := time.Now().UTC().Format("2006-01-02")
+	var todayEntry *usage.DailyUsage
+	for i := range daily {
+		if daily[i].Date == today {
+			todayEntry = &daily[i]
+			break
+		}
+	}
+	require.NotNil(t, todayEntry, "expected entry for today %s", today)
+	assert.Equal(t, 2, todayEntry.Requests, "expected 2 requests today")
+	assert.Equal(t, int64(20), todayEntry.InputTokens, "expected 20 input tokens")
+	assert.Equal(t, int64(16), todayEntry.OutputTokens, "expected 16 output tokens")
+	assert.Equal(t, int64(36), todayEntry.TotalTokens, "expected 36 total tokens")
+
+	fixture.FlushAndClose(t)
+}
+
+func TestAdminUsageSummary_MongoDB(t *testing.T) {
+	fixture := SetupTestServer(t, TestServerConfig{
+		DBType:                "mongodb",
+		UsageEnabled:          true,
+		AdminEndpointsEnabled: true,
+		OnlyModelInteractions: false,
+	})
+
+	// Send 2 chat requests
+	for i := 0; i < 2; i++ {
+		payload := newChatRequest("gpt-4", "Hello!")
+		resp := sendChatRequest(t, fixture.ServerURL, payload)
+		require.Equal(t, 200, resp.StatusCode)
+		closeBody(resp)
+	}
+
+	// Wait for usage buffer to flush
+	time.Sleep(2 * time.Second)
+
+	// Query admin API
+	resp, err := http.Get(fixture.ServerURL + "/admin/api/v1/usage/summary?days=30")
+	require.NoError(t, err)
+	defer closeBody(resp)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var summary usage.UsageSummary
+	require.NoError(t, json.Unmarshal(body, &summary))
+
+	assert.Equal(t, 2, summary.TotalRequests, "expected 2 total requests")
+	assert.Equal(t, int64(20), summary.TotalInput, "expected 20 input tokens (2 * 10)")
+	assert.Equal(t, int64(16), summary.TotalOutput, "expected 16 output tokens (2 * 8)")
+	assert.Equal(t, int64(36), summary.TotalTokens, "expected 36 total tokens (2 * 18)")
+
+	fixture.FlushAndClose(t)
+}
+
+func TestAdminDailyUsage_WithInterval_PostgreSQL(t *testing.T) {
+	fixture := SetupTestServer(t, TestServerConfig{
+		DBType:                "postgresql",
+		UsageEnabled:          true,
+		AdminEndpointsEnabled: true,
+		OnlyModelInteractions: false,
+	})
+
+	// Send a request so there's data
+	payload := newChatRequest("gpt-4", "Hello!")
+	resp := sendChatRequest(t, fixture.ServerURL, payload)
+	require.Equal(t, 200, resp.StatusCode)
+	closeBody(resp)
+
+	// Wait for usage buffer to flush
+	time.Sleep(2 * time.Second)
+
+	// Query with weekly interval
+	resp, err := http.Get(fixture.ServerURL + "/admin/api/v1/usage/daily?interval=weekly")
+	require.NoError(t, err)
+	defer closeBody(resp)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var daily []usage.DailyUsage
+	require.NoError(t, json.Unmarshal(body, &daily))
+
+	// Should return valid JSON array (may be empty or have entries)
+	assert.True(t, json.Valid(body), "response should be valid JSON")
+
+	fixture.FlushAndClose(t)
+}
+
+func TestAdminModels_PostgreSQL(t *testing.T) {
+	fixture := SetupTestServer(t, TestServerConfig{
+		DBType:                "postgresql",
+		UsageEnabled:          false,
+		AdminEndpointsEnabled: true,
+		OnlyModelInteractions: false,
+	})
+
+	// Query admin models endpoint
+	resp, err := http.Get(fixture.ServerURL + "/admin/api/v1/models")
+	require.NoError(t, err)
+	defer closeBody(resp)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var models []providers.ModelWithProvider
+	require.NoError(t, json.Unmarshal(body, &models))
+
+	require.NotEmpty(t, models, "expected at least one model")
+
+	// Should be sorted by model ID
+	for i := 1; i < len(models); i++ {
+		assert.True(t, models[i-1].Model.ID < models[i].Model.ID,
+			"models should be sorted, but %s >= %s", models[i-1].Model.ID, models[i].Model.ID)
+	}
+
+	// Each model should have model.id and provider_type
+	for _, m := range models {
+		assert.NotEmpty(t, m.Model.ID, "model.id should not be empty")
+		assert.NotEmpty(t, m.ProviderType, "provider_type should not be empty")
+	}
+
+	fixture.FlushAndClose(t)
+}

--- a/tests/integration/dbassert/usage.go
+++ b/tests/integration/dbassert/usage.go
@@ -117,6 +117,16 @@ func ClearUsage(t *testing.T, pool *pgxpool.Pool) {
 	require.NoError(t, err, "failed to clear usage entries")
 }
 
+// ClearUsageMongo deletes all usage entries from MongoDB.
+func ClearUsageMongo(t *testing.T, db *mongo.Database) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := db.Collection("usage").DeleteMany(ctx, bson.M{})
+	require.NoError(t, err, "failed to clear usage entries from MongoDB")
+}
+
 // SumTokensByModel returns total token usage grouped by model from PostgreSQL.
 func SumTokensByModel(t *testing.T, pool *pgxpool.Pool) map[string]TokenSummary {
 	t.Helper()

--- a/tests/integration/setup_test.go
+++ b/tests/integration/setup_test.go
@@ -44,6 +44,15 @@ type TestServerConfig struct {
 
 	// OnlyModelInteractions limits logging to model endpoints only
 	OnlyModelInteractions bool
+
+	// AdminEndpointsEnabled enables admin API endpoints
+	AdminEndpointsEnabled bool
+
+	// AdminUIEnabled enables admin dashboard UI
+	AdminUIEnabled bool
+
+	// MasterKey sets the authentication master key (empty = unsafe mode)
+	MasterKey string
 }
 
 // TestServerFixture holds test server resources.
@@ -172,8 +181,12 @@ func buildAppConfig(t *testing.T, cfg TestServerConfig, mockLLMURL string, port 
 
 	appCfg := &config.Config{
 		Server: config.ServerConfig{
-			Port: fmt.Sprintf("%d", port),
-			// No master key for tests (unsafe mode)
+			Port:      fmt.Sprintf("%d", port),
+			MasterKey: cfg.MasterKey,
+		},
+		Admin: config.AdminConfig{
+			EndpointsEnabled: cfg.AdminEndpointsEnabled,
+			UIEnabled:        cfg.AdminUIEnabled,
 		},
 		Cache: config.CacheConfig{
 			Type: "local",


### PR DESCRIPTION
Adds a lightweight admin dashboard UI and standalone REST API for monitoring GOModel usage metrics and registered models. Both are behind the ADMIN_ENDPOINTS_ENABLED and ADMIN_UI_ENABLED feature flags (defaults to true).

Architecture:
- Admin API (/admin/api/v1/*) - auth-protected REST endpoints usable by any client
- Dashboard UI (/admin/dashboard) - embedded HTML with HTMX + Alpine.js + Chart.js
- UsageReader interface with SQLite/PostgreSQL/MongoDB implementations for querying usage data
- Dashboard pages skip auth; API respects GOMODEL_MASTER_KEY

New endpoints:
- GET /admin/api/v1/usage/summary?days=30
- GET /admin/api/v1/usage/daily?days=30
- GET /admin/api/v1/models
- GET /admin/dashboard (UI)

https://claude.ai/code/session_01XAusvt4hnbcb8Z2xebQmkX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedded Admin dashboard UI with usage analytics, charts, model inventory/filtering, and static assets
  * Admin API endpoints for usage summary, daily usage, and model listings
  * New environment flags: ADMIN_ENDPOINTS_ENABLED and ADMIN_UI_ENABLED

* **Improvements**
  * Usage reader now supports SQLite, PostgreSQL, and MongoDB backends
  * Auth skipping supports prefix-based paths; admin components initialize conditionally and log status

* **Documentation**
  * New admin endpoints guide and configuration docs; README updated

* **Tests**
  * Extensive unit, integration, and e2e tests covering admin API and dashboard
<!-- end of auto-generated comment: release notes by coderabbit.ai -->