### PR TITLE
feat: add multi-platform Docker builds (amd64, arm64, arm/v7)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Set up QEMU (for multi-platform builds)
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -65,6 +68,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM --platform=$BUILDPLATFORM golang:1.24-alpine3.23 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
+ARG TARGETVARIANT
 
 WORKDIR /app
 
@@ -15,7 +16,7 @@ RUN go mod download
 
 # Copy source and cross-compile for the target platform
 COPY . .
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-s -w" -o /gomodel ./cmd/gomodel
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -ldflags="-s -w" -o /gomodel ./cmd/gomodel
 
 # Create cache directory for runtime (with placeholder for COPY)
 RUN mkdir -p /app/.cache && touch /app/.cache/.keep


### PR DESCRIPTION
Add QEMU setup and multi-platform support to the release workflow so the Docker image works on Apple Silicon, AWS Graviton, and ARM devices. Optimize Dockerfile for cross-compilation using BUILDPLATFORM/TARGETARCH to avoid slow QEMU emulation during Go builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added multi-platform build support for linux/amd64, linux/arm64, and linux/arm/v7, enabling the application to run on a wider range of systems.
  * Enabled cross-compilation in the build to produce platform-specific binaries.
  * Added QEMU setup in the CI to support multi-platform container builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->