### PR TITLE
fix(gom-41): pre-create data/ dir for nonroot user in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -ldflags="-s -w" -o /gomodel ./cmd/gomodel
 
 # Create cache directory for runtime (with placeholder for COPY)
-RUN mkdir -p /app/.cache && touch /app/.cache/.keep
+RUN mkdir -p /app/.cache /app/data && touch /app/.cache/.keep /app/data/.keep
 
 # Runtime stage
 FROM gcr.io/distroless/static-debian12:nonroot
@@ -31,6 +31,7 @@ COPY --from=builder /app/config/*.yaml /app/config/
 
 # Create writable cache directory for SQLite storage (nonroot user UID=65532)
 COPY --from=builder --chown=65532:65532 /app/.cache /app/.cache
+COPY --from=builder --chown=65532:65532 /app/data /app/data
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -ldflags="-s -w" -o /gomodel ./cmd/gomodel
 
-# Create cache directory for runtime (with placeholder for COPY)
+# Create .cache and data directories for runtime (with placeholder for COPY)
 RUN mkdir -p /app/.cache /app/data && touch /app/.cache/.keep /app/data/.keep
 
 # Runtime stage
@@ -29,7 +29,7 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /gomodel /gomodel
 COPY --from=builder /app/config/*.yaml /app/config/
 
-# Create writable cache directory for SQLite storage (nonroot user UID=65532)
+# Create writable .cache and data directories for nonroot user (UID=65532)
 COPY --from=builder --chown=65532:65532 /app/.cache /app/.cache
 COPY --from=builder --chown=65532:65532 /app/data /app/data
 


### PR DESCRIPTION
The distroless nonroot runtime image (UID 65532) cannot create directories under /app at runtime. Pre-create data/ with correct ownership, matching the existing pattern used for .cache/.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Container build updated to create and expose a separate writable data directory alongside cache storage at runtime. Placeholder files and ownership are set so the application can manage and persist runtime data with appropriate permissions for non-root execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->