### PR TITLE
fix(me/gom-33): anthropic reasoning error when i request an opus model

### DIFF
--- a/internal/providers/anthropic/anthropic.go
+++ b/internal/providers/anthropic/anthropic.go
@@ -90,7 +90,7 @@ type anthropicThinking struct {
 
 // anthropicOutputConfig controls effort level for adaptive thinking on 4.6 models.
 type anthropicOutputConfig struct {
-	Effort string `json:"effort"`
+	Effort string `json:"effort,omitempty"`
 }
 
 // anthropicRequest represents the Anthropic API request format

--- a/internal/providers/anthropic/anthropic.go
+++ b/internal/providers/anthropic/anthropic.go
@@ -204,8 +204,11 @@ func applyReasoning(req *anthropicRequest, model, effort string) {
 	}
 
 	if req.Temperature != nil {
-		slog.Warn("temperature overridden to nil, reasoning requires unset temperature")
-		req.Temperature = nil
+		if *req.Temperature != 1.0 {
+			slog.Warn("temperature overridden to nil; extended thinking requires temperature=1",
+				"original_temperature", *req.Temperature)
+			req.Temperature = nil
+		}
 	}
 }
 

--- a/internal/providers/anthropic/anthropic.go
+++ b/internal/providers/anthropic/anthropic.go
@@ -246,10 +246,7 @@ func convertToAnthropicRequest(req *core.ChatRequest) *anthropicRequest {
 
 // convertFromAnthropicResponse converts Anthropic response to core.ChatResponse
 func convertFromAnthropicResponse(resp *anthropicResponse) *core.ChatResponse {
-	content := ""
-	if len(resp.Content) > 0 {
-		content = resp.Content[0].Text
-	}
+	content := extractTextContent(resp.Content)
 
 	finishReason := resp.StopReason
 	if finishReason == "" {
@@ -594,12 +591,23 @@ func extractContentFromResponsesInput(content interface{}) string {
 	return ""
 }
 
+// extractTextContent returns the text from the first "text" content block,
+// skipping "thinking" blocks that appear when extended thinking is enabled.
+func extractTextContent(blocks []anthropicContent) string {
+	for _, b := range blocks {
+		if b.Type == "text" {
+			return b.Text
+		}
+	}
+	if len(blocks) > 0 {
+		return blocks[0].Text
+	}
+	return ""
+}
+
 // convertAnthropicResponseToResponses converts an Anthropic response to ResponsesResponse
 func convertAnthropicResponseToResponses(resp *anthropicResponse, model string) *core.ResponsesResponse {
-	content := ""
-	if len(resp.Content) > 0 {
-		content = resp.Content[0].Text
-	}
+	content := extractTextContent(resp.Content)
 
 	return &core.ResponsesResponse{
 		ID:        resp.ID,

--- a/internal/providers/anthropic/anthropic.go
+++ b/internal/providers/anthropic/anthropic.go
@@ -610,20 +610,12 @@ func extractContentFromResponsesInput(content interface{}) string {
 // Taking the last text block ensures we get the actual answer, not the empty preamble.
 func extractTextContent(blocks []anthropicContent) string {
 	last := ""
-	found := false
 	for _, b := range blocks {
 		if b.Type == "text" {
 			last = b.Text
-			found = true
 		}
 	}
-	if found {
-		return last
-	}
-	if len(blocks) > 0 {
-		return blocks[0].Text
-	}
-	return ""
+	return last
 }
 
 // convertAnthropicResponseToResponses converts an Anthropic response to ResponsesResponse

--- a/internal/providers/anthropic/anthropic.go
+++ b/internal/providers/anthropic/anthropic.go
@@ -105,8 +105,19 @@ type anthropicRequest struct {
 	OutputConfig *anthropicOutputConfig `json:"output_config,omitempty"`
 }
 
+var adaptiveThinkingPrefixes = []string{
+	"claude-opus-4-6",
+	"claude-sonnet-4-6",
+	"claude-haiku-4-6",
+}
+
 func isAdaptiveThinkingModel(model string) bool {
-	return strings.Contains(model, "4-6") || strings.Contains(model, "4.6")
+	for _, prefix := range adaptiveThinkingPrefixes {
+		if model == prefix || strings.HasPrefix(model, prefix+"-") {
+			return true
+		}
+	}
+	return false
 }
 
 // anthropicMessage represents a message in Anthropic format

--- a/internal/providers/anthropic/anthropic.go
+++ b/internal/providers/anthropic/anthropic.go
@@ -591,13 +591,20 @@ func extractContentFromResponsesInput(content interface{}) string {
 	return ""
 }
 
-// extractTextContent returns the text from the first "text" content block,
-// skipping "thinking" blocks that appear when extended thinking is enabled.
+// extractTextContent returns the text from the last "text" content block.
+// When extended thinking is enabled, Anthropic returns: [text("\n\n"), thinking(...), text(answer)].
+// Taking the last text block ensures we get the actual answer, not the empty preamble.
 func extractTextContent(blocks []anthropicContent) string {
+	last := ""
+	found := false
 	for _, b := range blocks {
 		if b.Type == "text" {
-			return b.Text
+			last = b.Text
+			found = true
 		}
+	}
+	if found {
+		return last
 	}
 	if len(blocks) > 0 {
 		return blocks[0].Text
@@ -847,3 +854,4 @@ func (sc *responsesStreamConverter) convertEvent(event *anthropicStreamEvent) st
 
 	return ""
 }
+

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -1191,215 +1191,294 @@ func TestConvertAnthropicResponseToResponses(t *testing.T) {
 	}
 }
 
-// TestConvertToAnthropicRequest_ReasoningEffort tests handling of reasoning effort parameter
 func TestConvertToAnthropicRequest_ReasoningEffort(t *testing.T) {
 	tests := []struct {
-name                string
-reasoning           *core.Reasoning
-maxTokens           *int
-expectedThinking    bool
-expectedBudget      int
-expectedMaxTokens   int
-expectedTemperature *float64
-}{
-{
-name:                "reasoning nil - no thinking enabled",
-reasoning:           nil,
-maxTokens:           intPtr(1000),
-expectedThinking:    false,
-expectedMaxTokens:   1000,
-expectedTemperature: nil,
-},
-{
-name:                "reasoning with empty effort - no thinking enabled",
-reasoning:           &core.Reasoning{Effort: ""},
-maxTokens:           intPtr(1000),
-expectedThinking:    false,
-expectedMaxTokens:   1000,
-expectedTemperature: nil,
-},
-{
-name:                "reasoning with low effort",
-reasoning:           &core.Reasoning{Effort: "low"},
-maxTokens:           intPtr(10000),
-expectedThinking:    true,
-expectedBudget:      5000,
-expectedMaxTokens:   10000,
-expectedTemperature: nil, // Should be unset for reasoning
-},
-{
-name:                "reasoning with medium effort",
-reasoning:           &core.Reasoning{Effort: "medium"},
-maxTokens:           intPtr(15000),
-expectedThinking:    true,
-expectedBudget:      10000,
-expectedMaxTokens:   15000,
-expectedTemperature: nil,
-},
-{
-name:                "reasoning with high effort",
-reasoning:           &core.Reasoning{Effort: "high"},
-maxTokens:           intPtr(25000),
-expectedThinking:    true,
-expectedBudget:      20000,
-expectedMaxTokens:   25000,
-expectedTemperature: nil,
-},
-{
-name:                "reasoning with invalid effort - defaults to low",
-reasoning:           &core.Reasoning{Effort: "invalid"},
-maxTokens:           intPtr(10000),
-expectedThinking:    true,
-expectedBudget:      5000, // Defaults to low
-expectedMaxTokens:   10000,
-expectedTemperature: nil,
-},
-{
-name:                "reasoning bumps up max_tokens when too low",
-reasoning:           &core.Reasoning{Effort: "high"},
-maxTokens:           intPtr(1000), // Lower than budget
-expectedThinking:    true,
-expectedBudget:      20000,
-expectedMaxTokens:   20000, // Should be bumped to budget
-expectedTemperature: nil,
-},
-{
-name:                "reasoning removes temperature when set",
-reasoning:           &core.Reasoning{Effort: "medium"},
-maxTokens:           intPtr(15000),
-expectedThinking:    true,
-expectedBudget:      10000,
-expectedMaxTokens:   15000,
-expectedTemperature: nil, // Should be removed even if originally set
-},
+		name                string
+		model               string
+		reasoning           *core.Reasoning
+		maxTokens           *int
+		setTemperature      bool
+		expectedThinkType   string
+		expectedBudget      int
+		expectedEffort      string
+		expectedMaxTokens   int
+		expectNilTemp       bool
+	}{
+		{
+			name:              "reasoning nil - no thinking",
+			model:             "claude-3-5-sonnet-20241022",
+			reasoning:         nil,
+			maxTokens:         intPtr(1000),
+			expectedMaxTokens: 1000,
+		},
+		{
+			name:              "empty effort - no thinking",
+			model:             "claude-3-5-sonnet-20241022",
+			reasoning:         &core.Reasoning{Effort: ""},
+			maxTokens:         intPtr(1000),
+			expectedMaxTokens: 1000,
+		},
+		{
+			name:              "legacy model - low effort",
+			model:             "claude-3-5-sonnet-20241022",
+			reasoning:         &core.Reasoning{Effort: "low"},
+			maxTokens:         intPtr(10000),
+			expectedThinkType: "enabled",
+			expectedBudget:    5000,
+			expectedMaxTokens: 10000,
+			expectNilTemp:     true,
+		},
+		{
+			name:              "legacy model - medium effort",
+			model:             "claude-3-5-sonnet-20241022",
+			reasoning:         &core.Reasoning{Effort: "medium"},
+			maxTokens:         intPtr(15000),
+			expectedThinkType: "enabled",
+			expectedBudget:    10000,
+			expectedMaxTokens: 15000,
+			expectNilTemp:     true,
+		},
+		{
+			name:              "legacy model - high effort",
+			model:             "claude-3-5-sonnet-20241022",
+			reasoning:         &core.Reasoning{Effort: "high"},
+			maxTokens:         intPtr(25000),
+			expectedThinkType: "enabled",
+			expectedBudget:    20000,
+			expectedMaxTokens: 25000,
+			expectNilTemp:     true,
+		},
+		{
+			name:              "legacy model - invalid effort defaults to low",
+			model:             "claude-3-5-sonnet-20241022",
+			reasoning:         &core.Reasoning{Effort: "invalid"},
+			maxTokens:         intPtr(10000),
+			expectedThinkType: "enabled",
+			expectedBudget:    5000,
+			expectedMaxTokens: 10000,
+			expectNilTemp:     true,
+		},
+		{
+			name:              "legacy model - bumps max_tokens when too low",
+			model:             "claude-3-5-sonnet-20241022",
+			reasoning:         &core.Reasoning{Effort: "high"},
+			maxTokens:         intPtr(1000),
+			expectedThinkType: "enabled",
+			expectedBudget:    20000,
+			expectedMaxTokens: 21024,
+			expectNilTemp:     true,
+		},
+		{
+			name:              "legacy model - removes temperature",
+			model:             "claude-3-5-sonnet-20241022",
+			reasoning:         &core.Reasoning{Effort: "medium"},
+			maxTokens:         intPtr(15000),
+			setTemperature:    true,
+			expectedThinkType: "enabled",
+			expectedBudget:    10000,
+			expectedMaxTokens: 15000,
+			expectNilTemp:     true,
+		},
+		{
+			name:              "4.6 model - adaptive thinking with high effort",
+			model:             "claude-opus-4-6",
+			reasoning:         &core.Reasoning{Effort: "high"},
+			maxTokens:         intPtr(4096),
+			expectedThinkType: "adaptive",
+			expectedEffort:    "high",
+			expectedMaxTokens: 4096,
+			expectNilTemp:     true,
+		},
+		{
+			name:              "4.6 model - adaptive thinking with low effort",
+			model:             "claude-sonnet-4-6-20260301",
+			reasoning:         &core.Reasoning{Effort: "low"},
+			maxTokens:         intPtr(4096),
+			expectedThinkType: "adaptive",
+			expectedEffort:    "low",
+			expectedMaxTokens: 4096,
+			expectNilTemp:     true,
+		},
+		{
+			name:              "4.6 model - does not bump max_tokens",
+			model:             "claude-opus-4-6",
+			reasoning:         &core.Reasoning{Effort: "high"},
+			maxTokens:         intPtr(1000),
+			expectedThinkType: "adaptive",
+			expectedEffort:    "high",
+			expectedMaxTokens: 1000,
+			expectNilTemp:     true,
+		},
+		{
+			name:              "4.6 model - removes temperature",
+			model:             "claude-opus-4-6",
+			reasoning:         &core.Reasoning{Effort: "medium"},
+			maxTokens:         intPtr(4096),
+			setTemperature:    true,
+			expectedThinkType: "adaptive",
+			expectedEffort:    "medium",
+			expectedMaxTokens: 4096,
+			expectNilTemp:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &core.ChatRequest{
+				Model:     tt.model,
+				Messages:  []core.Message{{Role: "user", Content: "test"}},
+				MaxTokens: tt.maxTokens,
+				Reasoning: tt.reasoning,
+			}
+			if tt.setTemperature {
+				temp := 0.7
+				req.Temperature = &temp
+			}
+
+			result := convertToAnthropicRequest(req)
+
+			if tt.expectedThinkType == "" {
+				if result.Thinking != nil {
+					t.Errorf("Thinking should be nil but got %+v", result.Thinking)
+				}
+			} else {
+				if result.Thinking == nil {
+					t.Fatal("Thinking should not be nil")
+				}
+				if result.Thinking.Type != tt.expectedThinkType {
+					t.Errorf("Thinking.Type = %q, want %q", result.Thinking.Type, tt.expectedThinkType)
+				}
+				if tt.expectedThinkType == "enabled" {
+					if result.Thinking.BudgetTokens != tt.expectedBudget {
+						t.Errorf("BudgetTokens = %d, want %d", result.Thinking.BudgetTokens, tt.expectedBudget)
+					}
+				}
+				if tt.expectedThinkType == "adaptive" {
+					if result.OutputConfig == nil {
+						t.Fatal("OutputConfig should not be nil for adaptive thinking")
+					}
+					if result.OutputConfig.Effort != tt.expectedEffort {
+						t.Errorf("OutputConfig.Effort = %q, want %q", result.OutputConfig.Effort, tt.expectedEffort)
+					}
+				}
+			}
+
+			if result.MaxTokens != tt.expectedMaxTokens {
+				t.Errorf("MaxTokens = %d, want %d", result.MaxTokens, tt.expectedMaxTokens)
+			}
+
+			if tt.expectNilTemp && result.Temperature != nil {
+				t.Errorf("Temperature should be nil but is %v", *result.Temperature)
+			}
+		})
+	}
 }
 
-for _, tt := range tests {
-t.Run(tt.name, func(t *testing.T) {
-req := &core.ChatRequest{
-Model:     "claude-3-5-sonnet-20241022",
-Messages:  []core.Message{{Role: "user", Content: "test"}},
-MaxTokens: tt.maxTokens,
-Reasoning: tt.reasoning,
-}
-
-// Set temperature for the test case about temperature removal
-if tt.name == "reasoning removes temperature when set" {
-temp := 0.7
-req.Temperature = &temp
-}
-
-result := convertToAnthropicRequest(req)
-
-// Check thinking field
-if tt.expectedThinking {
-if result.Thinking == nil {
-t.Error("Thinking should be enabled but is nil")
-} else {
-if result.Thinking.Type != "enabled" {
-t.Errorf("Thinking.Type = %q, want %q", result.Thinking.Type, "enabled")
-}
-if result.Thinking.BudgetTokens != tt.expectedBudget {
-t.Errorf("Thinking.BudgetTokens = %d, want %d", result.Thinking.BudgetTokens, tt.expectedBudget)
-}
-}
-} else {
-if result.Thinking != nil {
-t.Errorf("Thinking should be nil but got %+v", result.Thinking)
-}
-}
-
-// Check max_tokens
-if result.MaxTokens != tt.expectedMaxTokens {
-t.Errorf("MaxTokens = %d, want %d", result.MaxTokens, tt.expectedMaxTokens)
-}
-
-// Check temperature
-if result.Temperature != tt.expectedTemperature {
-if result.Temperature == nil && tt.expectedTemperature != nil {
-t.Errorf("Temperature should be %v but is nil", *tt.expectedTemperature)
-} else if result.Temperature != nil && tt.expectedTemperature == nil {
-t.Errorf("Temperature should be nil but is %v", *result.Temperature)
-} else if result.Temperature != nil && tt.expectedTemperature != nil && *result.Temperature != *tt.expectedTemperature {
-t.Errorf("Temperature = %v, want %v", *result.Temperature, *tt.expectedTemperature)
-}
-}
-})
-}
-}
-
-// TestConvertResponsesRequestToAnthropic_ReasoningEffort tests reasoning in Responses API
 func TestConvertResponsesRequestToAnthropic_ReasoningEffort(t *testing.T) {
 	tests := []struct {
-name              string
-reasoning         *core.Reasoning
-maxOutputTokens   *int
-expectedThinking  bool
-expectedBudget    int
-expectedMaxTokens int
-}{
-{
-name:              "no reasoning",
-reasoning:         nil,
-maxOutputTokens:   intPtr(1000),
-expectedThinking:  false,
-expectedMaxTokens: 1000,
-},
-{
-name:              "empty effort",
-reasoning:         &core.Reasoning{Effort: ""},
-maxOutputTokens:   intPtr(1000),
-expectedThinking:  false,
-expectedMaxTokens: 1000,
-},
-{
-name:              "low effort bumps max tokens",
-reasoning:         &core.Reasoning{Effort: "low"},
-maxOutputTokens:   intPtr(1000),
-expectedThinking:  true,
-expectedBudget:    5000,
-expectedMaxTokens: 5000, // Bumped from 1000
-},
-{
-name:              "high effort with sufficient tokens",
-reasoning:         &core.Reasoning{Effort: "high"},
-maxOutputTokens:   intPtr(25000),
-expectedThinking:  true,
-expectedBudget:    20000,
-expectedMaxTokens: 25000,
-},
-}
+		name              string
+		model             string
+		reasoning         *core.Reasoning
+		maxOutputTokens   *int
+		expectedThinkType string
+		expectedBudget    int
+		expectedEffort    string
+		expectedMaxTokens int
+	}{
+		{
+			name:              "no reasoning",
+			model:             "claude-3-5-sonnet-20241022",
+			reasoning:         nil,
+			maxOutputTokens:   intPtr(1000),
+			expectedMaxTokens: 1000,
+		},
+		{
+			name:              "empty effort",
+			model:             "claude-3-5-sonnet-20241022",
+			reasoning:         &core.Reasoning{Effort: ""},
+			maxOutputTokens:   intPtr(1000),
+			expectedMaxTokens: 1000,
+		},
+		{
+			name:              "legacy model - low effort bumps max tokens",
+			model:             "claude-3-5-sonnet-20241022",
+			reasoning:         &core.Reasoning{Effort: "low"},
+			maxOutputTokens:   intPtr(1000),
+			expectedThinkType: "enabled",
+			expectedBudget:    5000,
+			expectedMaxTokens: 6024,
+		},
+		{
+			name:              "legacy model - high effort with sufficient tokens",
+			model:             "claude-3-5-sonnet-20241022",
+			reasoning:         &core.Reasoning{Effort: "high"},
+			maxOutputTokens:   intPtr(25000),
+			expectedThinkType: "enabled",
+			expectedBudget:    20000,
+			expectedMaxTokens: 25000,
+		},
+		{
+			name:              "4.6 model - adaptive thinking",
+			model:             "claude-opus-4-6",
+			reasoning:         &core.Reasoning{Effort: "high"},
+			maxOutputTokens:   intPtr(4096),
+			expectedThinkType: "adaptive",
+			expectedEffort:    "high",
+			expectedMaxTokens: 4096,
+		},
+		{
+			name:              "4.6 model - does not bump max_tokens",
+			model:             "claude-opus-4-6",
+			reasoning:         &core.Reasoning{Effort: "high"},
+			maxOutputTokens:   intPtr(1000),
+			expectedThinkType: "adaptive",
+			expectedEffort:    "high",
+			expectedMaxTokens: 1000,
+		},
+	}
 
-for _, tt := range tests {
-t.Run(tt.name, func(t *testing.T) {
-req := &core.ResponsesRequest{
-Model:            "claude-3-5-sonnet-20241022",
-Input:            "test input",
-MaxOutputTokens:  tt.maxOutputTokens,
-Reasoning:        tt.reasoning,
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &core.ResponsesRequest{
+				Model:           tt.model,
+				Input:           "test input",
+				MaxOutputTokens: tt.maxOutputTokens,
+				Reasoning:       tt.reasoning,
+			}
 
-result := convertResponsesRequestToAnthropic(req)
+			result := convertResponsesRequestToAnthropic(req)
 
-if tt.expectedThinking {
-if result.Thinking == nil {
-t.Error("Thinking should be enabled but is nil")
-} else {
-if result.Thinking.BudgetTokens != tt.expectedBudget {
-t.Errorf("Thinking.BudgetTokens = %d, want %d", result.Thinking.BudgetTokens, tt.expectedBudget)
-}
-}
-} else {
-if result.Thinking != nil {
-t.Errorf("Thinking should be nil but got %+v", result.Thinking)
-}
-}
+			if tt.expectedThinkType == "" {
+				if result.Thinking != nil {
+					t.Errorf("Thinking should be nil but got %+v", result.Thinking)
+				}
+			} else {
+				if result.Thinking == nil {
+					t.Fatal("Thinking should not be nil")
+				}
+				if result.Thinking.Type != tt.expectedThinkType {
+					t.Errorf("Thinking.Type = %q, want %q", result.Thinking.Type, tt.expectedThinkType)
+				}
+				if tt.expectedThinkType == "enabled" {
+					if result.Thinking.BudgetTokens != tt.expectedBudget {
+						t.Errorf("BudgetTokens = %d, want %d", result.Thinking.BudgetTokens, tt.expectedBudget)
+					}
+				}
+				if tt.expectedThinkType == "adaptive" {
+					if result.OutputConfig == nil {
+						t.Fatal("OutputConfig should not be nil for adaptive thinking")
+					}
+					if result.OutputConfig.Effort != tt.expectedEffort {
+						t.Errorf("OutputConfig.Effort = %q, want %q", result.OutputConfig.Effort, tt.expectedEffort)
+					}
+				}
+			}
 
-if result.MaxTokens != tt.expectedMaxTokens {
-t.Errorf("MaxTokens = %d, want %d", result.MaxTokens, tt.expectedMaxTokens)
-}
-})
-}
+			if result.MaxTokens != tt.expectedMaxTokens {
+				t.Errorf("MaxTokens = %d, want %d", result.MaxTokens, tt.expectedMaxTokens)
+			}
+		})
+	}
 }
 
 // Helper function to create int pointer

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -1499,6 +1499,16 @@ func TestConvertToAnthropicRequest_ReasoningEffort(t *testing.T) {
 			expectedMaxTokens: 4096,
 			expectNilTemp:     true,
 		},
+		{
+			name:              "4.6 model - invalid effort normalizes to low",
+			model:             "claude-opus-4-6",
+			reasoning:         &core.Reasoning{Effort: "extreme"},
+			maxTokens:         intPtr(4096),
+			expectedThinkType: "adaptive",
+			expectedEffort:    "low",
+			expectedMaxTokens: 4096,
+			expectNilTemp:     true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1642,6 +1652,16 @@ func TestConvertResponsesRequestToAnthropic_ReasoningEffort(t *testing.T) {
 			setTemperature:    true,
 			expectedThinkType: "adaptive",
 			expectedEffort:    "medium",
+			expectedMaxTokens: 4096,
+			expectNilTemp:     true,
+		},
+		{
+			name:              "4.6 model - invalid effort normalizes to low",
+			model:             "claude-opus-4-6",
+			reasoning:         &core.Reasoning{Effort: "extreme"},
+			maxOutputTokens:   intPtr(4096),
+			expectedThinkType: "adaptive",
+			expectedEffort:    "low",
 			expectedMaxTokens: 4096,
 			expectNilTemp:     true,
 		},

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -1365,6 +1365,9 @@ func TestConvertAnthropicResponseToResponses_WithThinkingBlocks(t *testing.T) {
 			if len(result.Output) != 1 {
 				t.Fatalf("len(Output) = %d, want 1", len(result.Output))
 			}
+			if len(result.Output[0].Content) == 0 {
+				t.Fatalf("len(Output[0].Content) = 0, want at least 1")
+			}
 			if result.Output[0].Content[0].Text != tt.expectedText {
 				t.Errorf("expected %q, got %q", tt.expectedText, result.Output[0].Content[0].Text)
 			}
@@ -1736,8 +1739,8 @@ func TestIsAdaptiveThinkingModel(t *testing.T) {
 		{"claude-opus-4-6-20260301", true},
 		{"claude-sonnet-4-6", true},
 		{"claude-sonnet-4-6-20260301", true},
-		{"claude-haiku-4-6", true},
-		{"claude-haiku-4-6-20260501", true},
+		{"claude-haiku-4-6", false},
+		{"claude-haiku-4-6-20260501", false},
 		{"claude-3-5-sonnet-20241022", false},
 		{"claude-opus-4-5-20251101", false},
 		{"claude-4-60", false},

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -720,9 +720,14 @@ func TestExtractTextContent(t *testing.T) {
 			expected: "",
 		},
 		{
-			name:     "no type field - falls back to first block",
+			name:     "only thinking blocks - returns empty",
+			blocks:   []anthropicContent{{Type: "thinking", Text: "some reasoning"}},
+			expected: "",
+		},
+		{
+			name:     "no type field - returns empty",
 			blocks:   []anthropicContent{{Text: "legacy response"}},
-			expected: "legacy response",
+			expected: "",
 		},
 	}
 

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -653,6 +653,9 @@ func TestConvertFromAnthropicResponse_WithThinkingBlocks(t *testing.T) {
 
 			result := convertFromAnthropicResponse(resp)
 
+			if len(result.Choices) == 0 {
+				t.Fatalf("expected at least 1 choice, got 0")
+			}
 			if result.Choices[0].Message.Content != tt.expectedText {
 				t.Errorf("expected %q, got %q", tt.expectedText, result.Choices[0].Message.Content)
 			}

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -1655,7 +1655,35 @@ func TestConvertResponsesRequestToAnthropic_ReasoningEffort(t *testing.T) {
 	}
 }
 
-// Helper function to create int pointer
+func TestIsAdaptiveThinkingModel(t *testing.T) {
+	tests := []struct {
+		model    string
+		expected bool
+	}{
+		{"claude-opus-4-6", true},
+		{"claude-opus-4-6-20260301", true},
+		{"claude-sonnet-4-6", true},
+		{"claude-sonnet-4-6-20260301", true},
+		{"claude-haiku-4-6", true},
+		{"claude-haiku-4-6-20260501", true},
+		{"claude-3-5-sonnet-20241022", false},
+		{"claude-opus-4-5-20251101", false},
+		{"claude-4-60", false},
+		{"claude-opus-4-6x", false},
+		{"claude-opus-4-65", false},
+		{"something-claude-opus-4-6", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			if got := isAdaptiveThinkingModel(tt.model); got != tt.expected {
+				t.Errorf("isAdaptiveThinkingModel(%q) = %v, want %v", tt.model, got, tt.expected)
+			}
+		})
+	}
+}
+
 func intPtr(i int) *int {
-return &i
+	return &i
 }

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -725,6 +725,11 @@ func TestExtractTextContent(t *testing.T) {
 			expected: "",
 		},
 		{
+			name:     "only thinking blocks with empty text - returns empty",
+			blocks:   []anthropicContent{{Type: "thinking", Text: ""}},
+			expected: "",
+		},
+		{
 			name:     "no type field - returns empty",
 			blocks:   []anthropicContent{{Text: "legacy response"}},
 			expected: "",


### PR DESCRIPTION
Two issues were fixed for Anthropic's newer 4.6 models (e.g. `claude-opus-4-6`):

1. `max_tokens` **error with reasoning** — The 4.6 models support a new adaptive thinking mode with output_config.effort instead of the legacy budget_tokens approach. The code was applying the legacy path to all models, which caused Anthropic to reject requests with `"max_tokens must be greater than thinking.budget_tokens"`. The fix adds model detection (`isAdaptiveThinkingModel`) and uses the appropriate API format per model generation.

2. **Empty response with reasoning enabled** — When adaptive thinking is active, Anthropic can return multiple content blocks: possibly a preamble text block (in our case, just `\n\n`), a thinking block, and the actual answer text block. The fix introduces extractTextContent which picks the last text block — matching Anthropic's pattern of preamble → thinking → answer.

After the fix:

```
{
  "id": "msg_019HyRtW4EDkQgSAK5ShsH1a",
  "object": "response",
  "created_at": 1771623447,
  "model": "claude-opus-4-6",
  "provider": "anthropic",
  "status": "completed",
  "output": [
    {
      "id": "msg_291c31c4-38ab-4cd0-bdbe-c3d7000901a1",
      "type": "message",
      "role": "assistant",
      "status": "completed",
      "content": [
        {
          "type": "output_text",
          "text": "# Bash Matrix Transpose Script\n\n```bash\n#!/bin/bash\n\n# Usage: ./transpose.sh \"[1,2],[3,4],[5,6]\"\n# Output: [1,3,5],[2,4,6]\n\ninput=\"$1\"\n\nif [[ -z \"$input\" ]]; then\n    echo \"Usage: $0 \\\"[1,2],[3,4],[5,6]\\\"\"\n    exit 1\nfi\n\n# ---------------------------------------------------------------------------\n# 1. Parse: turn \"[1,2],[3,4],[5,6]\" into a clean \"1,2;3,4;5,6\" form\n#    - replace ],[ with ;   (row delimiter)\n#    - strip the leading [ and trailing ]\n# ---------------------------------------------------------------------------\ncleaned=$(echo \"$input\" | sed 's/\\],\\[/;/g' | sed 's/^\\[//' | sed 's/\\]$//')\n\n# ---------------------------------------------------------------------------\n# 2. Read into a flat array that simulates a 2-D matrix\n# ---------------------------------------------------------------------------\nIFS=';' read -ra rows <<< \"$cleaned\"\nnum_rows=${#rows[@]}\nnum_cols=0\n\ndeclare -a matrix\n\nfor ((i = 0; i < num_rows; i++)); do\n    IFS=',' read -ra cols <<< \"${rows[$i]}\"\n    # Set column count from the first row\n    if (( i == 0 )); then\n        num_cols=${#cols[@]}\n    fi\n    for ((j = 0; j < ${#cols[@]}; j++)); do\n        matrix=$(( i * num_cols + j ))          # flat index\n        matrix[$((i * num_cols + j))]=\"${cols[$j]}\"\n    done\ndone\n\n# ---------------------------------------------------------------------------\n# 3. Build the transposed output\n#    Original  : num_rows × num_cols\n#    Transposed: num_cols × num_rows\n# ---------------------------------------------------------------------------\nresult=\"\"\n\nfor ((j = 0; j < num_cols; j++)); do\n    row=\"[\"\n    for ((i = 0; i < num_rows; i++)); do\n        (( i > 0 )) && row+=\",\"\n        row+=\"${matrix[$((i * num_cols + j))]}\"\n    done\n    row+=\"]\"\n\n    if [[ -n \"$result\" ]]; then\n        result+=\",$row\"\n    else\n        result=\"$row\"\n    fi\ndone\n\necho \"$result\"\n```\n\n## How it works\n\n| Step | What happens | Example value |\n|------|-------------|---------------|\n| **Input** | Raw matrix string | `[1,2],[3,4],[5,6]` |\n| **Clean** | Replace `],[` → `;`, strip outer `[]` | `1,2;3,4;5,6` |\n| **Split rows** | Split on `;` | `[\"1,2\", \"3,4\", \"5,6\"]` |\n| **Flat array** | Store elements row-major | `matrix = [1,2,3,4,5,6]` (3×2) |\n| **Transpose** | Iterate columns-first, rows-second | Swap `(i,j)` → `(j,i)` |\n| **Output** | Rebuild bracket format | `[1,3,5],[2,4,6]` |\n\n## Test runs\n\n```bash\n$ ./transpose.sh \"[1,2],[3,4],[5,6]\"\n[1,3,5],[2,4,6]\n\n$ ./transpose.sh \"[1,2,3],[4,5,6]\"\n[1,4],[2,5],[3,6]\n\n$ ./transpose.sh \"[1],[2],[3]\"\n[1,2,3]\n\n$ ./transpose.sh \"[1,2,3]\"\n[1],[2],[3]\n\n$ ./transpose.sh \"[10,20,30],[40,50,60],[70,80,90]\"\n[10,40,70],[20,50,80],[30,60,90]\n```\n\nThe key insight is that **transposing** simply means iterating **column-first, then row** instead of the original row-first order, which swaps the `(i, j)` indices to `(j, i)`."
        }
      ]
    }
  ],
  "usage": {
    "input_tokens": 61,
    "output_tokens": 1866,
    "total_tokens": 1927
  }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for adaptive "thinking" modes on newer models with configurable effort and output options.

* **Improvements**
  * More reliable extraction of assistant text from responses that include intermediate thinking blocks.
  * Centralized reasoning handling with model-aware behavior, token adjustments, and cleaner request formatting.

* **Tests**
  * Added tests covering thinking-block extraction and adaptive-model recognition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->