### PR TITLE
fix(gom-43): remove stream_options injection from Responses API handler

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -172,13 +172,6 @@ func (h *Handler) Responses(c echo.Context) error {
 
 	// Handle streaming: proxy the raw SSE stream
 	if req.Stream {
-		// Enforce returning usage data in streaming responses if configured
-		if h.usageLogger != nil && h.usageLogger.Config().EnforceReturningUsageData {
-			if req.StreamOptions == nil {
-				req.StreamOptions = &core.StreamOptions{}
-			}
-			req.StreamOptions.IncludeUsage = true
-		}
 		return h.handleStreamingResponse(c, req.Model, providerType, func() (io.ReadCloser, error) {
 			return h.provider.StreamResponses(ctx, &req)
 		})

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/labstack/echo/v4"
 
 	"gomodel/internal/core"
+	"gomodel/internal/usage"
 )
 
 // mockProvider implements core.Provider for testing
@@ -547,5 +548,115 @@ func TestListModels_TypedError(t *testing.T) {
 	}
 	if !strings.Contains(body, "failed to list models") {
 		t.Errorf("response should contain error message, got: %s", body)
+	}
+}
+
+// mockUsageLogger implements usage.LoggerInterface for testing.
+type mockUsageLogger struct {
+	config usage.Config
+}
+
+func (m *mockUsageLogger) Write(_ *usage.UsageEntry) {}
+func (m *mockUsageLogger) Config() usage.Config       { return m.config }
+func (m *mockUsageLogger) Close() error               { return nil }
+
+// capturingProvider is a mockProvider that captures the request passed to StreamResponses/StreamChatCompletion.
+type capturingProvider struct {
+	mockProvider
+	capturedChatReq      *core.ChatRequest
+	capturedResponsesReq *core.ResponsesRequest
+}
+
+func (c *capturingProvider) StreamChatCompletion(_ context.Context, req *core.ChatRequest) (io.ReadCloser, error) {
+	c.capturedChatReq = req
+	return io.NopCloser(strings.NewReader(c.streamData)), nil
+}
+
+func (c *capturingProvider) StreamResponses(_ context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
+	c.capturedResponsesReq = req
+	return io.NopCloser(strings.NewReader(c.streamData)), nil
+}
+
+func TestStreamingResponses_DoesNotInjectStreamOptions(t *testing.T) {
+	streamData := "data: {\"type\":\"response.done\"}\n\ndata: [DONE]\n\n"
+	provider := &capturingProvider{
+		mockProvider: mockProvider{
+			supportedModels: []string{"gpt-4o-mini"},
+			streamData:      streamData,
+		},
+	}
+
+	usageLog := &mockUsageLogger{
+		config: usage.Config{
+			Enabled:                   true,
+			EnforceReturningUsageData: true,
+		},
+	}
+
+	e := echo.New()
+	handler := NewHandler(provider, nil, usageLog)
+
+	// Streaming Responses request should NOT have StreamOptions injected
+	reqBody := `{"model":"gpt-4o-mini","input":"Hello","stream":true}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler.Responses(c)
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	if provider.capturedResponsesReq.StreamOptions != nil {
+		t.Errorf("Responses streaming should NOT have StreamOptions injected, got: %+v", provider.capturedResponsesReq.StreamOptions)
+	}
+}
+
+func TestStreamingChatCompletion_InjectsStreamOptions(t *testing.T) {
+	streamData := "data: {\"id\":\"chatcmpl-1\",\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n"
+	provider := &capturingProvider{
+		mockProvider: mockProvider{
+			supportedModels: []string{"gpt-4o-mini"},
+			streamData:      streamData,
+		},
+	}
+
+	usageLog := &mockUsageLogger{
+		config: usage.Config{
+			Enabled:                   true,
+			EnforceReturningUsageData: true,
+		},
+	}
+
+	e := echo.New()
+	handler := NewHandler(provider, nil, usageLog)
+
+	// Streaming ChatCompletion request SHOULD have StreamOptions injected
+	reqBody := `{"model":"gpt-4o-mini","stream":true,"messages":[{"role":"user","content":"Hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler.ChatCompletion(c)
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	if provider.capturedChatReq.StreamOptions == nil {
+		t.Fatal("ChatCompletion streaming should have StreamOptions injected")
+	}
+
+	if !provider.capturedChatReq.StreamOptions.IncludeUsage {
+		t.Error("ChatCompletion streaming should have IncludeUsage=true")
 	}
 }

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -609,9 +609,12 @@ func TestStreamingResponses_DoesNotInjectStreamOptions(t *testing.T) {
 	}
 
 	if rec.Code != http.StatusOK {
-		t.Errorf("expected status 200, got %d", rec.Code)
+		t.Fatalf("expected status 200, got %d", rec.Code)
 	}
 
+	if provider.capturedResponsesReq == nil {
+		t.Fatalf("expected capturedResponsesReq to be set, got nil")
+	}
 	if provider.capturedResponsesReq.StreamOptions != nil {
 		t.Errorf("Responses streaming should NOT have StreamOptions injected, got: %+v", provider.capturedResponsesReq.StreamOptions)
 	}


### PR DESCRIPTION
The Responses API does not accept stream_options.include_usage — it's a Chat Completions-only parameter. The Responses API already returns usage data unconditionally in the response.done SSE event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming responses no longer automatically include usage data based on configuration.

* **Tests**
  * Added tests to verify streaming behavior and ensure usage data is not injected into streamed responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->