### PR TITLE
refactor: fix OCP violation in usage cost mapping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,8 @@ helm/                  # Kubernetes Helm charts
 
 1. Create `internal/providers/{name}/` implementing `core.Provider`
 2. Export a `Registration` variable: `var Registration = providers.Registration{Type: "{name}", New: New}`
+   - Optionally add `CostMappings: []core.TokenCostMapping{...}` for provider-specific token cost fields (cached tokens, reasoning tokens, etc.)
+   - Optionally add `InformationalFields: []string{...}` for known token breakdown fields that don't need separate pricing
 3. Register in `cmd/gomodel/main.go` via `factory.Add({name}.Registration)`
 4. Add API key env var to `.env.template` and to `knownProviders` in `config/config.go`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Client → Echo Middleware (logger → recover → body limit → audit log → 
 - `internal/observability/metrics.go` — Prometheus metrics via hooks injected at factory level: `gomodel_requests_total`, `gomodel_request_duration_seconds`, `gomodel_requests_in_flight`.
 - `internal/cache/` — Local file or Redis cache backends for model registry.
 
-**Startup:** Config load (defaults → YAML → env vars) → Register providers with factory → Init providers (cache → async model load → background refresh → router) → Init audit logging → Init usage tracking (shares storage if same backend) → Build guardrails pipeline → Create server → Start listening
+**Startup:** Config load (defaults → YAML → env vars) → Register providers with factory → Init providers (cache → async model load → background refresh → router) → Register cost mappings (`RegisterCostMappings`) → Init audit logging → Init usage tracking (shares storage if same backend) → Build guardrails pipeline → Create server → Start listening
 
 **Shutdown (in order):** HTTP server (stop accepting) → Providers (stop refresh + close cache) → Usage tracking (flush buffer) → Audit logging (flush buffer)
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -216,8 +216,9 @@ func (a *App) Start(addr string) error {
 // Shutdown gracefully shuts down all components in the correct order.
 // It ensures proper cleanup of resources:
 // 1. HTTP server (stop accepting new requests)
-// 2. Background refresh goroutine and cache
-// 3. Audit logging
+// 2. Providers (stop background refresh goroutine and close cache)
+// 3. Usage tracking (flush pending entries)
+// 4. Audit logging (flush pending logs)
 //
 // Safe to call multiple times; subsequent calls are no-ops.
 func (a *App) Shutdown(ctx context.Context) error {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -72,6 +72,10 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 	}
 	app.providers = providerResult
 
+	// Register provider cost mappings for usage tracking
+	costMappings, informationalFields := cfg.Factory.CostRegistry()
+	usage.RegisterCostMappings(costMappings, informationalFields)
+
 	// Initialize audit logging
 	auditResult, err := auditlog.New(ctx, appCfg)
 	if err != nil {

--- a/internal/core/cost_mapping.go
+++ b/internal/core/cost_mapping.go
@@ -4,7 +4,8 @@ package core
 type CostSide int
 
 const (
-	CostSideInput  CostSide = iota
+	CostSideUnknown CostSide = iota // zero value; must not be used in mappings
+	CostSideInput
 	CostSideOutput
 )
 
@@ -12,14 +13,20 @@ const (
 type CostUnit int
 
 const (
-	CostUnitPerMtok CostUnit = iota // divide token count by 1M, multiply by rate
+	CostUnitUnknown CostUnit = iota // zero value; must not be used in mappings
+	CostUnitPerMtok                 // divide token count by 1M, multiply by rate
 	CostUnitPerItem                 // multiply count directly by rate
 )
 
-// TokenCostMapping maps a RawData key to a pricing field and cost side.
+// TokenCostMapping maps a provider-specific RawData key to a pricing field and cost side.
 type TokenCostMapping struct {
-	RawDataKey   string
+	// RawDataKey is the key in the usage RawData map (e.g. "cached_tokens").
+	RawDataKey string
+	// PricingField returns a pointer to the relevant rate from ModelPricing, or nil
+	// if the base rate already covers this token type.
 	PricingField func(p *ModelPricing) *float64
-	Side         CostSide
-	Unit         CostUnit
+	// Side indicates whether this cost contributes to input or output.
+	Side CostSide
+	// Unit indicates the pricing unit (per million tokens or per item).
+	Unit CostUnit
 }

--- a/internal/core/cost_mapping.go
+++ b/internal/core/cost_mapping.go
@@ -1,0 +1,25 @@
+package core
+
+// CostSide indicates whether a token cost contributes to input or output.
+type CostSide int
+
+const (
+	CostSideInput  CostSide = iota
+	CostSideOutput
+)
+
+// CostUnit indicates how the pricing field is applied.
+type CostUnit int
+
+const (
+	CostUnitPerMtok CostUnit = iota // divide token count by 1M, multiply by rate
+	CostUnitPerItem                 // multiply count directly by rate
+)
+
+// TokenCostMapping maps a RawData key to a pricing field and cost side.
+type TokenCostMapping struct {
+	RawDataKey   string
+	PricingField func(p *ModelPricing) *float64
+	Side         CostSide
+	Unit         CostUnit
+}

--- a/internal/providers/anthropic/anthropic.go
+++ b/internal/providers/anthropic/anthropic.go
@@ -507,12 +507,7 @@ func (sc *streamConverter) convertEvent(event *anthropicStreamEvent) string {
 					"completion_tokens": event.Usage.OutputTokens,
 					"total_tokens":      event.Usage.InputTokens + event.Usage.OutputTokens,
 				}
-				if event.Usage.CacheReadInputTokens > 0 {
-					usageMap["cache_read_input_tokens"] = event.Usage.CacheReadInputTokens
-				}
-				if event.Usage.CacheCreationInputTokens > 0 {
-					usageMap["cache_creation_input_tokens"] = event.Usage.CacheCreationInputTokens
-				}
+				appendCacheFields(usageMap, event.Usage)
 				chunk["usage"] = usageMap
 			}
 			jsonData, err := json.Marshal(chunk)
@@ -679,6 +674,16 @@ func convertAnthropicResponseToResponses(resp *anthropicResponse, model string) 
 	}
 }
 
+// appendCacheFields adds non-zero cache token fields from anthropicUsage to the given map.
+func appendCacheFields(m map[string]interface{}, u *anthropicUsage) {
+	if u.CacheReadInputTokens > 0 {
+		m["cache_read_input_tokens"] = u.CacheReadInputTokens
+	}
+	if u.CacheCreationInputTokens > 0 {
+		m["cache_creation_input_tokens"] = u.CacheCreationInputTokens
+	}
+}
+
 // buildAnthropicRawUsage extracts cache fields from anthropicUsage into a RawData map.
 func buildAnthropicRawUsage(u anthropicUsage) map[string]any {
 	raw := make(map[string]any)
@@ -800,12 +805,7 @@ func (sc *responsesStreamConverter) Read(p []byte) (n int, err error) {
 							"output_tokens": sc.cachedUsage.OutputTokens,
 							"total_tokens":  sc.cachedUsage.InputTokens + sc.cachedUsage.OutputTokens,
 						}
-						if sc.cachedUsage.CacheReadInputTokens > 0 {
-							usageMap["cache_read_input_tokens"] = sc.cachedUsage.CacheReadInputTokens
-						}
-						if sc.cachedUsage.CacheCreationInputTokens > 0 {
-							usageMap["cache_creation_input_tokens"] = sc.cachedUsage.CacheCreationInputTokens
-						}
+						appendCacheFields(usageMap, sc.cachedUsage)
 						responseData["usage"] = usageMap
 					}
 					doneEvent := map[string]interface{}{

--- a/internal/providers/anthropic/anthropic.go
+++ b/internal/providers/anthropic/anthropic.go
@@ -24,6 +24,10 @@ import (
 var Registration = providers.Registration{
 	Type: "anthropic",
 	New:  New,
+	CostMappings: []core.TokenCostMapping{
+		{RawDataKey: "cache_read_input_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, Side: core.CostSideInput, Unit: core.CostUnitPerMtok},
+		{RawDataKey: "cache_creation_input_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.CacheWritePerMtok }, Side: core.CostSideInput, Unit: core.CostUnitPerMtok},
+	},
 }
 
 const (

--- a/internal/providers/anthropic/anthropic.go
+++ b/internal/providers/anthropic/anthropic.go
@@ -502,11 +502,18 @@ func (sc *streamConverter) convertEvent(event *anthropicStreamEvent) string {
 			}
 			// Include usage data if present (OpenAI format)
 			if event.Usage != nil {
-				chunk["usage"] = map[string]interface{}{
+				usageMap := map[string]interface{}{
 					"prompt_tokens":     event.Usage.InputTokens,
 					"completion_tokens": event.Usage.OutputTokens,
 					"total_tokens":      event.Usage.InputTokens + event.Usage.OutputTokens,
 				}
+				if event.Usage.CacheReadInputTokens > 0 {
+					usageMap["cache_read_input_tokens"] = event.Usage.CacheReadInputTokens
+				}
+				if event.Usage.CacheCreationInputTokens > 0 {
+					usageMap["cache_creation_input_tokens"] = event.Usage.CacheCreationInputTokens
+				}
+				chunk["usage"] = usageMap
 			}
 			jsonData, err := json.Marshal(chunk)
 			if err != nil {
@@ -788,11 +795,18 @@ func (sc *responsesStreamConverter) Read(p []byte) (n int, err error) {
 					}
 					// Include usage data if captured from message_delta
 					if sc.cachedUsage != nil {
-						responseData["usage"] = map[string]interface{}{
+						usageMap := map[string]interface{}{
 							"input_tokens":  sc.cachedUsage.InputTokens,
 							"output_tokens": sc.cachedUsage.OutputTokens,
 							"total_tokens":  sc.cachedUsage.InputTokens + sc.cachedUsage.OutputTokens,
 						}
+						if sc.cachedUsage.CacheReadInputTokens > 0 {
+							usageMap["cache_read_input_tokens"] = sc.cachedUsage.CacheReadInputTokens
+						}
+						if sc.cachedUsage.CacheCreationInputTokens > 0 {
+							usageMap["cache_creation_input_tokens"] = sc.cachedUsage.CacheCreationInputTokens
+						}
+						responseData["usage"] = usageMap
 					}
 					doneEvent := map[string]interface{}{
 						"type":     "response.completed",

--- a/internal/providers/factory.go
+++ b/internal/providers/factory.go
@@ -21,21 +21,23 @@ type ProviderConstructor func(apiKey string, opts ProviderOptions) core.Provider
 
 // Registration contains metadata for registering a provider with the factory.
 type Registration struct {
-	Type string
-	New  ProviderConstructor
+	Type                string
+	New                 ProviderConstructor
+	CostMappings        []core.TokenCostMapping // optional: provider-specific token cost mappings
+	InformationalFields []string                // optional: known breakdown fields that need no separate pricing
 }
 
 // ProviderFactory manages provider registration and creation.
 type ProviderFactory struct {
-	mu       sync.RWMutex
-	builders map[string]ProviderConstructor
-	hooks    llmclient.Hooks
+	mu            sync.RWMutex
+	registrations map[string]Registration
+	hooks         llmclient.Hooks
 }
 
 // NewProviderFactory creates a new provider factory instance.
 func NewProviderFactory() *ProviderFactory {
 	return &ProviderFactory{
-		builders: make(map[string]ProviderConstructor),
+		registrations: make(map[string]Registration),
 	}
 }
 
@@ -58,13 +60,13 @@ func (f *ProviderFactory) Add(reg Registration) {
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.builders[reg.Type] = reg.New
+	f.registrations[reg.Type] = reg
 }
 
 // Create instantiates a provider based on its resolved configuration.
 func (f *ProviderFactory) Create(cfg ProviderConfig) (core.Provider, error) {
 	f.mu.RLock()
-	builder, ok := f.builders[cfg.Type]
+	reg, ok := f.registrations[cfg.Type]
 	hooks := f.hooks
 	f.mu.RUnlock()
 
@@ -77,7 +79,7 @@ func (f *ProviderFactory) Create(cfg ProviderConfig) (core.Provider, error) {
 		Resilience: cfg.Resilience,
 	}
 
-	p := builder(cfg.APIKey, opts)
+	p := reg.New(cfg.APIKey, opts)
 
 	if cfg.BaseURL != "" {
 		if setter, ok := p.(interface{ SetBaseURL(string) }); ok {
@@ -93,9 +95,33 @@ func (f *ProviderFactory) RegisteredTypes() []string {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
-	types := make([]string, 0, len(f.builders))
-	for t := range f.builders {
+	types := make([]string, 0, len(f.registrations))
+	for t := range f.registrations {
 		types = append(types, t)
 	}
 	return types
+}
+
+// CostRegistry returns aggregated cost mappings and informational fields from all
+// registered providers. The returned map is keyed by provider type.
+func (f *ProviderFactory) CostRegistry() (mappings map[string][]core.TokenCostMapping, informationalFields []string) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	mappings = make(map[string][]core.TokenCostMapping)
+	seen := make(map[string]struct{})
+
+	for _, reg := range f.registrations {
+		if len(reg.CostMappings) > 0 {
+			mappings[reg.Type] = reg.CostMappings
+		}
+		for _, field := range reg.InformationalFields {
+			if _, ok := seen[field]; !ok {
+				seen[field] = struct{}{}
+				informationalFields = append(informationalFields, field)
+			}
+		}
+	}
+
+	return mappings, informationalFields
 }

--- a/internal/providers/factory.go
+++ b/internal/providers/factory.go
@@ -3,6 +3,7 @@ package providers
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 
 	"gomodel/config"
@@ -123,5 +124,6 @@ func (f *ProviderFactory) CostRegistry() (mappings map[string][]core.TokenCostMa
 		}
 	}
 
+	sort.Strings(informationalFields)
 	return mappings, informationalFields
 }

--- a/internal/providers/factory_test.go
+++ b/internal/providers/factory_test.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"context"
 	"io"
+	"sort"
 	"testing"
 	"time"
 
@@ -341,5 +342,58 @@ func TestProviderFactory_Create_PassesResilienceConfig(t *testing.T) {
 	}
 	if r.JitterFactor != 0.5 {
 		t.Errorf("JitterFactor = %f, want 0.5", r.JitterFactor)
+	}
+}
+
+func TestProviderFactory_CostRegistry(t *testing.T) {
+	factory := NewProviderFactory()
+
+	factory.Add(Registration{
+		Type: "provider-a",
+		New:  func(_ string, _ ProviderOptions) core.Provider { return &factoryMockProvider{} },
+		CostMappings: []core.TokenCostMapping{
+			{RawDataKey: "cached_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, Side: core.CostSideInput, Unit: core.CostUnitPerMtok},
+		},
+		InformationalFields: []string{"prompt_text_tokens"},
+	})
+
+	factory.Add(Registration{
+		Type: "provider-b",
+		New:  func(_ string, _ ProviderOptions) core.Provider { return &factoryMockProvider{} },
+		CostMappings: []core.TokenCostMapping{
+			{RawDataKey: "thought_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, Side: core.CostSideOutput, Unit: core.CostUnitPerMtok},
+		},
+		InformationalFields: []string{"prompt_text_tokens", "prompt_image_tokens"},
+	})
+
+	// Provider with no cost mappings
+	factory.Add(Registration{
+		Type: "provider-c",
+		New:  func(_ string, _ ProviderOptions) core.Provider { return &factoryMockProvider{} },
+	})
+
+	mappings, informational := factory.CostRegistry()
+
+	// Check mappings
+	if len(mappings) != 2 {
+		t.Fatalf("expected 2 provider mappings, got %d", len(mappings))
+	}
+	if len(mappings["provider-a"]) != 1 {
+		t.Errorf("provider-a: expected 1 mapping, got %d", len(mappings["provider-a"]))
+	}
+	if len(mappings["provider-b"]) != 1 {
+		t.Errorf("provider-b: expected 1 mapping, got %d", len(mappings["provider-b"]))
+	}
+	if _, ok := mappings["provider-c"]; ok {
+		t.Error("provider-c should not have mappings")
+	}
+
+	// Check informational fields are deduplicated
+	sort.Strings(informational)
+	if len(informational) != 2 {
+		t.Fatalf("expected 2 informational fields (deduplicated), got %d: %v", len(informational), informational)
+	}
+	if informational[0] != "prompt_image_tokens" || informational[1] != "prompt_text_tokens" {
+		t.Errorf("unexpected informational fields: %v", informational)
 	}
 }

--- a/internal/providers/gemini/gemini.go
+++ b/internal/providers/gemini/gemini.go
@@ -19,6 +19,10 @@ import (
 var Registration = providers.Registration{
 	Type: "gemini",
 	New:  New,
+	CostMappings: []core.TokenCostMapping{
+		{RawDataKey: "cached_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, Side: core.CostSideInput, Unit: core.CostUnitPerMtok},
+		{RawDataKey: "thought_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, Side: core.CostSideOutput, Unit: core.CostUnitPerMtok},
+	},
 }
 
 const (

--- a/internal/providers/openai/openai.go
+++ b/internal/providers/openai/openai.go
@@ -16,6 +16,20 @@ import (
 var Registration = providers.Registration{
 	Type: "openai",
 	New:  New,
+	CostMappings: []core.TokenCostMapping{
+		{RawDataKey: "cached_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, Side: core.CostSideInput, Unit: core.CostUnitPerMtok},
+		{RawDataKey: "prompt_cached_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, Side: core.CostSideInput, Unit: core.CostUnitPerMtok},
+		{RawDataKey: "reasoning_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, Side: core.CostSideOutput, Unit: core.CostUnitPerMtok},
+		{RawDataKey: "completion_reasoning_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, Side: core.CostSideOutput, Unit: core.CostUnitPerMtok},
+		{RawDataKey: "prompt_audio_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.AudioInputPerMtok }, Side: core.CostSideInput, Unit: core.CostUnitPerMtok},
+		{RawDataKey: "completion_audio_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.AudioOutputPerMtok }, Side: core.CostSideOutput, Unit: core.CostUnitPerMtok},
+	},
+	InformationalFields: []string{
+		"prompt_text_tokens",
+		"prompt_image_tokens",
+		"completion_accepted_prediction_tokens",
+		"completion_rejected_prediction_tokens",
+	},
 }
 
 const (

--- a/internal/providers/xai/xai.go
+++ b/internal/providers/xai/xai.go
@@ -15,6 +15,13 @@ import (
 var Registration = providers.Registration{
 	Type: "xai",
 	New:  New,
+	CostMappings: []core.TokenCostMapping{
+		{RawDataKey: "cached_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, Side: core.CostSideInput, Unit: core.CostUnitPerMtok},
+		{RawDataKey: "prompt_cached_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, Side: core.CostSideInput, Unit: core.CostUnitPerMtok},
+		{RawDataKey: "reasoning_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, Side: core.CostSideOutput, Unit: core.CostUnitPerMtok},
+		{RawDataKey: "completion_reasoning_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, Side: core.CostSideOutput, Unit: core.CostUnitPerMtok},
+		{RawDataKey: "image_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.InputPerImage }, Side: core.CostSideInput, Unit: core.CostUnitPerItem},
+	},
 }
 
 const (

--- a/internal/usage/cost.go
+++ b/internal/usage/cost.go
@@ -16,79 +16,43 @@ type CostResult struct {
 	Caveat     string
 }
 
-// costSide indicates whether a token cost contributes to input or output.
-type costSide int
-
-const (
-	sideInput  costSide = iota
-	sideOutput
-)
-
-// costUnit indicates how the pricing field is applied.
-type costUnit int
-
-const (
-	unitPerMtok costUnit = iota // divide token count by 1M, multiply by rate
-	unitPerItem                 // multiply count directly by rate
-)
-
-// tokenCostMapping maps a RawData key to a pricing field and cost side.
-type tokenCostMapping struct {
-	rawDataKey   string
-	pricingField func(p *core.ModelPricing) *float64
-	side         costSide
-	unit         costUnit
+// costRegistry holds provider-specific cost mappings and informational fields,
+// populated at startup via RegisterCostMappings.
+type costRegistry struct {
+	providerMappings    map[string][]core.TokenCostMapping
+	informationalFields map[string]struct{}
+	extendedFieldSet    map[string]struct{}
 }
 
-// providerMappings defines the per-provider RawData key to pricing field mappings.
-var providerMappings = map[string][]tokenCostMapping{
-	"openai": {
-		{rawDataKey: "cached_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, side: sideInput, unit: unitPerMtok},
-		{rawDataKey: "prompt_cached_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, side: sideInput, unit: unitPerMtok},
-		{rawDataKey: "reasoning_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, side: sideOutput, unit: unitPerMtok},
-		{rawDataKey: "completion_reasoning_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, side: sideOutput, unit: unitPerMtok},
-		{rawDataKey: "prompt_audio_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.AudioInputPerMtok }, side: sideInput, unit: unitPerMtok},
-		{rawDataKey: "completion_audio_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.AudioOutputPerMtok }, side: sideOutput, unit: unitPerMtok},
-	},
-	"anthropic": {
-		{rawDataKey: "cache_read_input_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, side: sideInput, unit: unitPerMtok},
-		{rawDataKey: "cache_creation_input_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.CacheWritePerMtok }, side: sideInput, unit: unitPerMtok},
-	},
-	"gemini": {
-		{rawDataKey: "cached_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, side: sideInput, unit: unitPerMtok},
-		{rawDataKey: "thought_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, side: sideOutput, unit: unitPerMtok},
-	},
-	"xai": {
-		{rawDataKey: "cached_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, side: sideInput, unit: unitPerMtok},
-		{rawDataKey: "prompt_cached_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, side: sideInput, unit: unitPerMtok},
-		{rawDataKey: "reasoning_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, side: sideOutput, unit: unitPerMtok},
-		{rawDataKey: "completion_reasoning_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, side: sideOutput, unit: unitPerMtok},
-		{rawDataKey: "image_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.InputPerImage }, side: sideInput, unit: unitPerItem},
-	},
+// defaultCostRegistry is the package-level registry used by CalculateGranularCost
+// and stream_wrapper.go. Populated by RegisterCostMappings at startup.
+var defaultCostRegistry = &costRegistry{
+	providerMappings:    make(map[string][]core.TokenCostMapping),
+	informationalFields: make(map[string]struct{}),
+	extendedFieldSet:    make(map[string]struct{}),
 }
 
-// informationalFields are token fields that are known breakdowns of the base
-// input/output counts. They never need separate pricing and should not trigger
-// "unmapped token field" caveats.
-var informationalFields = map[string]struct{}{
-	"prompt_text_tokens":                    {},
-	"prompt_image_tokens":                   {},
-	"completion_accepted_prediction_tokens": {},
-	"completion_rejected_prediction_tokens": {},
-}
+// RegisterCostMappings populates the cost registry with provider-specific mappings
+// and informational fields. Called once at startup after providers are registered.
+func RegisterCostMappings(mappings map[string][]core.TokenCostMapping, informational []string) {
+	reg := &costRegistry{
+		providerMappings:    mappings,
+		informationalFields: make(map[string]struct{}, len(informational)),
+		extendedFieldSet:    make(map[string]struct{}),
+	}
 
-// extendedFieldSet is derived from providerMappings and contains all RawData keys
-// that providers may report. Used by stream_wrapper.go to extract extended fields
-// from SSE usage data without maintaining a separate hard-coded list.
-var extendedFieldSet = func() map[string]struct{} {
-	set := make(map[string]struct{})
-	for _, mappings := range providerMappings {
-		for _, m := range mappings {
-			set[m.rawDataKey] = struct{}{}
+	for _, f := range informational {
+		reg.informationalFields[f] = struct{}{}
+	}
+
+	for _, ms := range mappings {
+		for _, m := range ms {
+			reg.extendedFieldSet[m.RawDataKey] = struct{}{}
 		}
 	}
-	return set
-}()
+
+	defaultCostRegistry = reg
+}
 
 // CalculateGranularCost computes input, output, and total costs from token counts,
 // raw provider-specific data, and pricing information. It accounts for cached tokens,
@@ -100,6 +64,8 @@ func CalculateGranularCost(inputTokens, outputTokens int, rawData map[string]any
 	if pricing == nil {
 		return CostResult{}
 	}
+
+	reg := defaultCostRegistry
 
 	var inputCost, outputCost float64
 	var hasInput, hasOutput bool
@@ -125,15 +91,15 @@ func CalculateGranularCost(inputTokens, outputTokens int, rawData map[string]any
 	// rawData keys map to the same pricing field (e.g. cached_tokens and prompt_cached_tokens
 	// both map to CachedInputPerMtok).
 	appliedFields := make(map[*float64]bool)
-	if mappings, ok := providerMappings[providerType]; ok {
+	if mappings, ok := reg.providerMappings[providerType]; ok {
 		for _, m := range mappings {
-			count := extractInt(rawData, m.rawDataKey)
+			count := extractInt(rawData, m.RawDataKey)
 			if count == 0 {
 				continue
 			}
-			mappedKeys[m.rawDataKey] = true
+			mappedKeys[m.RawDataKey] = true
 
-			rate := m.pricingField(pricing)
+			rate := m.PricingField(pricing)
 			if rate == nil {
 				continue // Base rate covers this token type; no adjustment needed
 			}
@@ -144,18 +110,18 @@ func CalculateGranularCost(inputTokens, outputTokens int, rawData map[string]any
 			appliedFields[rate] = true
 
 			var cost float64
-			switch m.unit {
-			case unitPerMtok:
+			switch m.Unit {
+			case core.CostUnitPerMtok:
 				cost = float64(count) * *rate / 1_000_000
-			case unitPerItem:
+			case core.CostUnitPerItem:
 				cost = float64(count) * *rate
 			}
 
-			switch m.side {
-			case sideInput:
+			switch m.Side {
+			case core.CostSideInput:
 				inputCost += cost
 				hasInput = true
-			case sideOutput:
+			case core.CostSideOutput:
 				outputCost += cost
 				hasOutput = true
 			}
@@ -167,7 +133,7 @@ func CalculateGranularCost(inputTokens, outputTokens int, rawData map[string]any
 		if mappedKeys[key] {
 			continue
 		}
-		if _, ok := informationalFields[key]; ok {
+		if _, ok := reg.informationalFields[key]; ok {
 			continue // Known breakdown of base counts, not separately priced
 		}
 		if isTokenField(key) {

--- a/internal/usage/setup_test.go
+++ b/internal/usage/setup_test.go
@@ -1,0 +1,45 @@
+package usage
+
+import (
+	"os"
+	"testing"
+
+	"gomodel/internal/core"
+)
+
+func TestMain(m *testing.M) {
+	// Register cost mappings that were previously hardcoded in cost.go.
+	// This mirrors the data that providers supply via their Registration vars.
+	RegisterCostMappings(map[string][]core.TokenCostMapping{
+		"openai": {
+			{RawDataKey: "cached_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, Side: core.CostSideInput, Unit: core.CostUnitPerMtok},
+			{RawDataKey: "prompt_cached_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, Side: core.CostSideInput, Unit: core.CostUnitPerMtok},
+			{RawDataKey: "reasoning_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, Side: core.CostSideOutput, Unit: core.CostUnitPerMtok},
+			{RawDataKey: "completion_reasoning_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, Side: core.CostSideOutput, Unit: core.CostUnitPerMtok},
+			{RawDataKey: "prompt_audio_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.AudioInputPerMtok }, Side: core.CostSideInput, Unit: core.CostUnitPerMtok},
+			{RawDataKey: "completion_audio_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.AudioOutputPerMtok }, Side: core.CostSideOutput, Unit: core.CostUnitPerMtok},
+		},
+		"anthropic": {
+			{RawDataKey: "cache_read_input_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, Side: core.CostSideInput, Unit: core.CostUnitPerMtok},
+			{RawDataKey: "cache_creation_input_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.CacheWritePerMtok }, Side: core.CostSideInput, Unit: core.CostUnitPerMtok},
+		},
+		"gemini": {
+			{RawDataKey: "cached_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, Side: core.CostSideInput, Unit: core.CostUnitPerMtok},
+			{RawDataKey: "thought_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, Side: core.CostSideOutput, Unit: core.CostUnitPerMtok},
+		},
+		"xai": {
+			{RawDataKey: "cached_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, Side: core.CostSideInput, Unit: core.CostUnitPerMtok},
+			{RawDataKey: "prompt_cached_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, Side: core.CostSideInput, Unit: core.CostUnitPerMtok},
+			{RawDataKey: "reasoning_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, Side: core.CostSideOutput, Unit: core.CostUnitPerMtok},
+			{RawDataKey: "completion_reasoning_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, Side: core.CostSideOutput, Unit: core.CostUnitPerMtok},
+			{RawDataKey: "image_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.InputPerImage }, Side: core.CostSideInput, Unit: core.CostUnitPerItem},
+		},
+	}, []string{
+		"prompt_text_tokens",
+		"prompt_image_tokens",
+		"completion_accepted_prediction_tokens",
+		"completion_rejected_prediction_tokens",
+	})
+
+	os.Exit(m.Run())
+}

--- a/internal/usage/setup_test.go
+++ b/internal/usage/setup_test.go
@@ -5,41 +5,21 @@ import (
 	"testing"
 
 	"gomodel/internal/core"
+	"gomodel/internal/providers/anthropic"
+	"gomodel/internal/providers/gemini"
+	"gomodel/internal/providers/openai"
+	"gomodel/internal/providers/xai"
 )
 
 func TestMain(m *testing.M) {
-	// Register cost mappings that were previously hardcoded in cost.go.
-	// This mirrors the data that providers supply via their Registration vars.
+	// Register cost mappings from the authoritative provider Registration vars
+	// so tests use the single source of truth rather than duplicated data.
 	RegisterCostMappings(map[string][]core.TokenCostMapping{
-		"openai": {
-			{RawDataKey: "cached_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, Side: core.CostSideInput, Unit: core.CostUnitPerMtok},
-			{RawDataKey: "prompt_cached_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, Side: core.CostSideInput, Unit: core.CostUnitPerMtok},
-			{RawDataKey: "reasoning_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, Side: core.CostSideOutput, Unit: core.CostUnitPerMtok},
-			{RawDataKey: "completion_reasoning_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, Side: core.CostSideOutput, Unit: core.CostUnitPerMtok},
-			{RawDataKey: "prompt_audio_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.AudioInputPerMtok }, Side: core.CostSideInput, Unit: core.CostUnitPerMtok},
-			{RawDataKey: "completion_audio_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.AudioOutputPerMtok }, Side: core.CostSideOutput, Unit: core.CostUnitPerMtok},
-		},
-		"anthropic": {
-			{RawDataKey: "cache_read_input_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, Side: core.CostSideInput, Unit: core.CostUnitPerMtok},
-			{RawDataKey: "cache_creation_input_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.CacheWritePerMtok }, Side: core.CostSideInput, Unit: core.CostUnitPerMtok},
-		},
-		"gemini": {
-			{RawDataKey: "cached_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, Side: core.CostSideInput, Unit: core.CostUnitPerMtok},
-			{RawDataKey: "thought_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, Side: core.CostSideOutput, Unit: core.CostUnitPerMtok},
-		},
-		"xai": {
-			{RawDataKey: "cached_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, Side: core.CostSideInput, Unit: core.CostUnitPerMtok},
-			{RawDataKey: "prompt_cached_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, Side: core.CostSideInput, Unit: core.CostUnitPerMtok},
-			{RawDataKey: "reasoning_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, Side: core.CostSideOutput, Unit: core.CostUnitPerMtok},
-			{RawDataKey: "completion_reasoning_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, Side: core.CostSideOutput, Unit: core.CostUnitPerMtok},
-			{RawDataKey: "image_tokens", PricingField: func(p *core.ModelPricing) *float64 { return p.InputPerImage }, Side: core.CostSideInput, Unit: core.CostUnitPerItem},
-		},
-	}, []string{
-		"prompt_text_tokens",
-		"prompt_image_tokens",
-		"completion_accepted_prediction_tokens",
-		"completion_rejected_prediction_tokens",
-	})
+		openai.Registration.Type:    openai.Registration.CostMappings,
+		anthropic.Registration.Type: anthropic.Registration.CostMappings,
+		gemini.Registration.Type:    gemini.Registration.CostMappings,
+		xai.Registration.Type:       xai.Registration.CostMappings,
+	}, openai.Registration.InformationalFields)
 
 	os.Exit(m.Run())
 }

--- a/internal/usage/stream_wrapper.go
+++ b/internal/usage/stream_wrapper.go
@@ -233,7 +233,7 @@ func (w *StreamUsageWrapper) extractUsageFromJSON(data []byte) *UsageEntry {
 
 	// Extract extended usage data (provider-specific) using the field set
 	// derived from providerMappings in cost.go (single source of truth).
-	for field := range extendedFieldSet {
+	for field := range defaultCostRegistry.extendedFieldSet {
 		if v, ok := usageMap[field].(float64); ok && v > 0 {
 			rawData[field] = int(v)
 		}

--- a/internal/usage/stream_wrapper.go
+++ b/internal/usage/stream_wrapper.go
@@ -233,7 +233,7 @@ func (w *StreamUsageWrapper) extractUsageFromJSON(data []byte) *UsageEntry {
 
 	// Extract extended usage data (provider-specific) using the field set
 	// derived from providerMappings in cost.go (single source of truth).
-	for field := range defaultCostRegistry.extendedFieldSet {
+	for field := range loadCostRegistry().extendedFieldSet {
 		if v, ok := usageMap[field].(float64); ok && v > 0 {
 			rawData[field] = int(v)
 		}


### PR DESCRIPTION
Move provider-specific cost mapping data out of usage/cost.go and into each provider's Registration var, wired through the factory at startup. This ensures adding a new provider no longer requires editing the usage package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider-specific token cost mappings and informational token fields added for finer-grained cost attribution.
  * Usage payloads and stream responses now include additional cache and token breakdowns.

* **Refactor**
  * Centralized provider registration and a startup-initialized cost registry to publish per-provider mappings and informational fields.
  * Startup/shutdown sequencing adjusted to register and clean up cost/usage components.

* **Tests**
  * New tests and test startup wiring validating the cost registry and provider mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->