### PR TITLE
fix: Request Id was empty whehn audit logs were disabled +remove redundant request ID logic from audit log middleware 

### DIFF
--- a/internal/auditlog/middleware.go
+++ b/internal/auditlog/middleware.go
@@ -45,17 +45,8 @@ func Middleware(logger LoggerInterface) echo.MiddlewareFunc {
 			start := time.Now()
 			req := c.Request()
 
-			// Generate request ID if not present
+			// Read request ID (always set by the request ID middleware in http.go)
 			requestID := req.Header.Get("X-Request-ID")
-			if requestID == "" {
-				requestID = uuid.NewString()
-			}
-
-			// Set request ID in both request and response headers
-			// Request header: for internal components to read consistently
-			// Response header: for clients to receive in the response
-			req.Header.Set("X-Request-ID", requestID)
-			c.Response().Header().Set("X-Request-ID", requestID)
 
 			// Create initial log entry
 			entry := &LogEntry{


### PR DESCRIPTION
The request ID middleware in http.go now always runs before audit logging, making the ID generation in middleware.go dead code. Also moves the response header echo outside the `if` block so client-provided IDs are echoed back for correlation — matching the previous audit log behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced request tracking with automatic request ID generation and propagation across the system.

* **Tests**
  * Added test coverage for request ID middleware, validating both automatic ID generation and header preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->