### PR TITLE
fix: resolve goreleaser v2.6 archives.format deprecation

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -47,6 +47,8 @@ changelog:
   filters:
     exclude:
       - "^docs:"
+      - "^doc:"
+      - "^Docs:"
       - "^test:"
       - "^tests:"
       - "^refactor:"
@@ -54,6 +56,9 @@ changelog:
       - "^chore:"
       - "^build:"
       - "^style:"
+      - "^perf:"
+      - "^Revert"
+      - "^Merge"
 
 release:
   footer: |

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,13 +24,15 @@ builds:
       - -X gomodel/internal/version.Date={{.Date}}
 
 archives:
-  - format: tar.gz
-    # this name template makes the archive look like: gomodel_1.0.0_linux_amd64.tar.gz
+  - formats: ['tar.gz']
     name_template: >-
       {{ .ProjectName }}_
       {{- .Version }}_
       {{- .Os }}_
       {{- .Arch }}
+    format_overrides:
+      - goos: windows
+        formats: ['zip']
 
 checksum:
   name_template: "checksums.txt"
@@ -39,10 +41,20 @@ snapshot:
   version_template: "{{ .Tag }}-next"
 
 changelog:
+  use: github
   sort: asc
+  abbrev: -1
   filters:
     exclude:
       - "^docs:"
       - "^test:"
-      - "^refactor:"
       - "^tests:"
+      - "^refactor:"
+      - "^ci:"
+      - "^chore:"
+      - "^build:"
+      - "^style:"
+
+release:
+  footer: |
+    **Full Changelog**: https://github.com/ENTERPILOT/GOModel/compare/{{ .PreviousTag }}...{{ .Tag }}


### PR DESCRIPTION
Replace deprecated `format` with `formats` list, add Windows zip override, improve changelog config with GitHub attribution and expanded noise filters, and add release footer with changelog link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized release archive formats—tar.gz for most platforms and zip for Windows.
  * Enhanced release changelog with improved filtering and added direct link to full changelog history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->