### PR TITLE
Fix: SSE flushing and responses done markers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,9 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           version: v2.6
+          # Temporary workaround: config verification fetches the remote JSON schema and
+          # intermittently times out in CI before lint runs. Re-enable by 2026-04-01 once
+          # the schema fetch is reliable again; track in this PR/branch discussion.
           verify: false
 
   test-unit:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           version: v2.6
+          verify: false
 
   test-unit:
     name: Unit Tests

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -613,9 +613,8 @@ console.log(embedding.data[0].embedding.slice(0, 5)); // first 5 dimensions
 
 1. **Model routing**: The gateway automatically routes requests to the correct provider based on the model name — no configuration needed. Just use any model name from the list above.
 2. **API compatibility**: The gateway exposes an OpenAI-compatible API. Existing OpenAI client libraries work unchanged for all providers.
-3. **Streaming**: All providers support streaming. The gateway normalises provider-specific formats to OpenAI's SSE format.
+3. **Streaming**: All providers support streaming. SSE chunks are flushed incrementally, and streaming responses terminate with `data: [DONE]`.
 4. **System messages**: Anthropic's system message format is handled automatically. Gemini uses Google's OpenAI-compatible endpoint, which also handles system messages natively.
 5. **Max tokens**: Anthropic requires `max_tokens` to be set. If not provided, the gateway defaults to 4096. OpenAI and Gemini treat it as optional.
 6. **Responses API**: The `/v1/responses` endpoint provides a unified interface across all providers. Providers that do not natively support the Responses API convert requests internally.
 7. **Embeddings**: The `/v1/embeddings` endpoint is supported by OpenAI, Gemini, Groq, xAI, and Ollama. Anthropic does not offer embeddings natively.
-

--- a/internal/providers/openai/openai.go
+++ b/internal/providers/openai/openai.go
@@ -189,11 +189,16 @@ func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*
 
 // StreamResponses returns a raw response body for streaming Responses API (caller must close)
 func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
-	return p.client.DoStream(ctx, llmclient.Request{
+	stream, err := p.client.DoStream(ctx, llmclient.Request{
 		Method:   http.MethodPost,
 		Endpoint: "/responses",
 		Body:     req.WithStreaming(),
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	return providers.EnsureResponsesDone(stream), nil
 }
 
 // Embeddings sends an embeddings request to OpenAI

--- a/internal/providers/openai/openai.go
+++ b/internal/providers/openai/openai.go
@@ -187,7 +187,11 @@ func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*
 	return &resp, nil
 }
 
-// StreamResponses returns a raw response body for streaming Responses API (caller must close)
+// StreamResponses returns a normalized streaming Responses API body.
+// The returned io.ReadCloser is wrapped by providers.EnsureResponsesDone, so
+// callers must not assume it contains verbatim upstream bytes; the wrapper may
+// synthesize a terminal `data: [DONE]` marker on completed streams. Callers
+// remain responsible for closing the returned stream.
 func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
 	stream, err := p.client.DoStream(ctx, llmclient.Request{
 		Method:   http.MethodPost,

--- a/internal/providers/openai/openai_test.go
+++ b/internal/providers/openai/openai_test.go
@@ -623,8 +623,6 @@ data: {"type":"response.output_text.delta","delta":"!"}
 
 event: response.completed
 data: {"type":"response.completed","response":{"id":"resp_123","object":"response","status":"completed","model":"gpt-4o"}}
-
-data: [DONE]
 `,
 			expectedError: false,
 			checkStream: func(t *testing.T, body io.ReadCloser) {
@@ -952,8 +950,8 @@ data: [DONE]
 	provider.SetBaseURL(server.URL)
 
 	req := &core.ChatRequest{
-		Model:    "o4-mini",
-		Messages: []core.Message{{Role: "user", Content: "Hello"}},
+		Model:     "o4-mini",
+		Messages:  []core.Message{{Role: "user", Content: "Hello"}},
 		MaxTokens: &maxTokens,
 	}
 

--- a/internal/providers/responses_done_wrapper.go
+++ b/internal/providers/responses_done_wrapper.go
@@ -135,12 +135,8 @@ func (w *responsesDoneWrapper) processLine(line []byte) {
 	}
 
 	if bytes.HasPrefix(line, responsesDataPrefix) {
-		payload := line[len(responsesDataPrefix):]
-		for _, pattern := range responsesCompletionPatterns {
-			if bytes.Contains(payload, pattern) {
-				w.eventCompletedCandidate = true
-				break
-			}
+		if isCompletedDataLine(line) {
+			w.eventCompletedCandidate = true
 		}
 	}
 
@@ -154,6 +150,10 @@ func (w *responsesDoneWrapper) synthesizeDoneSuffix() []byte {
 
 	if w.eventCompletedCandidate && len(w.lineBuf) == 0 {
 		return append([]byte{'\n'}, responsesDoneMarker...)
+	}
+
+	if isCompletedDataLine(w.lineBuf) {
+		return append([]byte("\n\n"), responsesDoneMarker...)
 	}
 
 	if !w.completedEventReadyForDone {
@@ -182,4 +182,20 @@ func isDoneLinePrefix(line []byte) bool {
 	}
 
 	return bytes.Equal(line, responsesDoneLine[:len(line)])
+}
+
+func isCompletedDataLine(line []byte) bool {
+	line = bytes.TrimSuffix(line, []byte("\r"))
+	if !bytes.HasPrefix(line, responsesDataPrefix) {
+		return false
+	}
+
+	payload := line[len(responsesDataPrefix):]
+	for _, pattern := range responsesCompletionPatterns {
+		if bytes.Contains(payload, pattern) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/providers/responses_done_wrapper.go
+++ b/internal/providers/responses_done_wrapper.go
@@ -1,0 +1,93 @@
+package providers
+
+import (
+	"bytes"
+	"io"
+)
+
+var responsesDoneMarker = []byte("data: [DONE]\n\n")
+
+// EnsureResponsesDone normalizes Responses API streams so clients always receive
+// a terminal data: [DONE] marker, even when the upstream stream ends at EOF.
+func EnsureResponsesDone(stream io.ReadCloser) io.ReadCloser {
+	if stream == nil {
+		return nil
+	}
+
+	return &responsesDoneWrapper{
+		ReadCloser: stream,
+		tail:       make([]byte, 0, len(responsesDoneMarker)-1),
+	}
+}
+
+type responsesDoneWrapper struct {
+	io.ReadCloser
+	tail    []byte
+	pending []byte
+	sawDone bool
+	emitted bool
+}
+
+func (w *responsesDoneWrapper) Read(p []byte) (int, error) {
+	if len(w.pending) > 0 {
+		n := copy(p, w.pending)
+		w.pending = w.pending[n:]
+		if len(w.pending) == 0 {
+			w.emitted = true
+		}
+		return n, nil
+	}
+
+	if w.emitted {
+		return 0, io.EOF
+	}
+
+	n, err := w.ReadCloser.Read(p)
+	if n > 0 {
+		w.trackDone(p[:n])
+	}
+
+	if err == io.EOF {
+		if w.sawDone {
+			if n > 0 {
+				return n, nil
+			}
+			return 0, io.EOF
+		}
+
+		if n > 0 {
+			w.pending = append(w.pending[:0], responsesDoneMarker...)
+			return n, nil
+		}
+
+		n = copy(p, responsesDoneMarker)
+		if n < len(responsesDoneMarker) {
+			w.pending = append(w.pending[:0], responsesDoneMarker[n:]...)
+			return n, nil
+		}
+
+		w.emitted = true
+		return n, nil
+	}
+
+	return n, err
+}
+
+func (w *responsesDoneWrapper) trackDone(data []byte) {
+	if w.sawDone {
+		return
+	}
+
+	combined := append(append([]byte(nil), w.tail...), data...)
+	if bytes.Contains(combined, responsesDoneMarker) {
+		w.sawDone = true
+		return
+	}
+
+	overlap := len(responsesDoneMarker) - 1
+	if len(combined) > overlap {
+		combined = combined[len(combined)-overlap:]
+	}
+
+	w.tail = append(w.tail[:0], combined...)
+}

--- a/internal/providers/responses_done_wrapper.go
+++ b/internal/providers/responses_done_wrapper.go
@@ -9,6 +9,8 @@ var responsesDoneMarker = []byte("data: [DONE]\n\n")
 
 var responsesDoneLine = []byte("data: [DONE]")
 
+var responsesDataPrefix = []byte("data: ")
+
 var responsesCompletionPatterns = [][]byte{
 	[]byte(`"type":"response.completed"`),
 	[]byte(`"type":"response.done"`),
@@ -23,18 +25,22 @@ func EnsureResponsesDone(stream io.ReadCloser) io.ReadCloser {
 	}
 
 	return &responsesDoneWrapper{
-		ReadCloser: stream,
-		tail:       make([]byte, 0, responsesDoneTrackOverlap()),
+		ReadCloser:                 stream,
+		atEventBoundary:            true,
+		currentLineAtEventBoundary: true,
 	}
 }
 
 type responsesDoneWrapper struct {
 	io.ReadCloser
-	tail         []byte
-	pending      []byte
-	sawDone      bool
-	sawCompleted bool
-	emitted      bool
+	lineBuf                    []byte
+	pending                    []byte
+	sawDone                    bool
+	eventCompletedCandidate    bool
+	completedEventReadyForDone bool
+	atEventBoundary            bool
+	currentLineAtEventBoundary bool
+	emitted                    bool
 }
 
 func (w *responsesDoneWrapper) Read(p []byte) (int, error) {
@@ -53,7 +59,7 @@ func (w *responsesDoneWrapper) Read(p []byte) (int, error) {
 
 	n, err := w.ReadCloser.Read(p)
 	if n > 0 {
-		w.trackDone(p[:n])
+		w.trackStream(p[:n])
 	}
 
 	if err == io.EOF {
@@ -64,7 +70,8 @@ func (w *responsesDoneWrapper) Read(p []byte) (int, error) {
 			return 0, io.EOF
 		}
 
-		if !w.sawCompleted {
+		missingSuffix := w.synthesizeDoneSuffix()
+		if len(missingSuffix) == 0 {
 			if n > 0 {
 				return n, nil
 			}
@@ -72,13 +79,13 @@ func (w *responsesDoneWrapper) Read(p []byte) (int, error) {
 		}
 
 		if n > 0 {
-			w.pending = append(w.pending[:0], responsesDoneMarker...)
+			w.pending = append(w.pending[:0], missingSuffix...)
 			return n, nil
 		}
 
-		n = copy(p, responsesDoneMarker)
-		if n < len(responsesDoneMarker) {
-			w.pending = append(w.pending[:0], responsesDoneMarker[n:]...)
+		n = copy(p, missingSuffix)
+		if n < len(missingSuffix) {
+			w.pending = append(w.pending[:0], missingSuffix[n:]...)
 			return n, nil
 		}
 
@@ -89,38 +96,90 @@ func (w *responsesDoneWrapper) Read(p []byte) (int, error) {
 	return n, err
 }
 
-func (w *responsesDoneWrapper) trackDone(data []byte) {
-	if w.sawDone && w.sawCompleted {
+func (w *responsesDoneWrapper) trackStream(data []byte) {
+	start := 0
+	for i, b := range data {
+		if b != '\n' {
+			continue
+		}
+
+		w.lineBuf = append(w.lineBuf, data[start:i]...)
+		w.processLine(w.lineBuf)
+		w.lineBuf = w.lineBuf[:0]
+		start = i + 1
+		w.currentLineAtEventBoundary = w.atEventBoundary
+	}
+
+	if start < len(data) {
+		w.lineBuf = append(w.lineBuf, data[start:]...)
+	}
+}
+
+func (w *responsesDoneWrapper) processLine(line []byte) {
+	line = bytes.TrimSuffix(line, []byte("\r"))
+	if len(line) == 0 {
+		if w.eventCompletedCandidate {
+			w.completedEventReadyForDone = true
+		}
+		w.eventCompletedCandidate = false
+		w.atEventBoundary = true
 		return
 	}
 
-	combined := append(append([]byte(nil), w.tail...), data...)
-	if !w.sawDone && bytes.Contains(combined, responsesDoneLine) {
+	if w.completedEventReadyForDone && (!w.currentLineAtEventBoundary || !bytes.Equal(line, responsesDoneLine)) {
+		w.completedEventReadyForDone = false
+	}
+
+	if w.currentLineAtEventBoundary && bytes.Equal(line, responsesDoneLine) {
 		w.sawDone = true
 	}
-	if !w.sawCompleted {
+
+	if bytes.HasPrefix(line, responsesDataPrefix) {
+		payload := line[len(responsesDataPrefix):]
 		for _, pattern := range responsesCompletionPatterns {
-			if bytes.Contains(combined, pattern) {
-				w.sawCompleted = true
+			if bytes.Contains(payload, pattern) {
+				w.eventCompletedCandidate = true
 				break
 			}
 		}
 	}
 
-	overlap := responsesDoneTrackOverlap()
-	if len(combined) > overlap {
-		combined = combined[len(combined)-overlap:]
-	}
-
-	w.tail = append(w.tail[:0], combined...)
+	w.atEventBoundary = false
 }
 
-func responsesDoneTrackOverlap() int {
-	overlap := len(responsesDoneLine) - 1
-	for _, pattern := range responsesCompletionPatterns {
-		if n := len(pattern) - 1; n > overlap {
-			overlap = n
-		}
+func (w *responsesDoneWrapper) synthesizeDoneSuffix() []byte {
+	if w.sawDone {
+		return nil
 	}
-	return overlap
+
+	if w.eventCompletedCandidate && len(w.lineBuf) == 0 {
+		return append([]byte{'\n'}, responsesDoneMarker...)
+	}
+
+	if !w.completedEventReadyForDone {
+		return nil
+	}
+
+	if len(w.lineBuf) == 0 {
+		if w.atEventBoundary {
+			return append([]byte(nil), responsesDoneMarker...)
+		}
+		return nil
+	}
+
+	if !w.currentLineAtEventBoundary || !isDoneLinePrefix(w.lineBuf) {
+		return nil
+	}
+
+	suffix := append([]byte(nil), responsesDoneLine[len(w.lineBuf):]...)
+	suffix = append(suffix, '\n', '\n')
+	return suffix
+}
+
+func isDoneLinePrefix(line []byte) bool {
+	if len(line) > len(responsesDoneLine) {
+		return false
+	}
+
+	return bytes.Equal(line, responsesDoneLine[:len(line)])
 }

--- a/internal/providers/responses_done_wrapper.go
+++ b/internal/providers/responses_done_wrapper.go
@@ -7,8 +7,16 @@ import (
 
 var responsesDoneMarker = []byte("data: [DONE]\n\n")
 
+var responsesDoneLine = []byte("data: [DONE]")
+
+var responsesCompletionPatterns = [][]byte{
+	[]byte(`"type":"response.completed"`),
+	[]byte(`"type":"response.done"`),
+}
+
 // EnsureResponsesDone normalizes Responses API streams so clients always receive
-// a terminal data: [DONE] marker, even when the upstream stream ends at EOF.
+// a terminal data: [DONE] marker when the upstream stream reaches a completed
+// Responses event but closes at EOF before sending the final marker.
 func EnsureResponsesDone(stream io.ReadCloser) io.ReadCloser {
 	if stream == nil {
 		return nil
@@ -16,16 +24,17 @@ func EnsureResponsesDone(stream io.ReadCloser) io.ReadCloser {
 
 	return &responsesDoneWrapper{
 		ReadCloser: stream,
-		tail:       make([]byte, 0, len(responsesDoneMarker)-1),
+		tail:       make([]byte, 0, responsesDoneTrackOverlap()),
 	}
 }
 
 type responsesDoneWrapper struct {
 	io.ReadCloser
-	tail    []byte
-	pending []byte
-	sawDone bool
-	emitted bool
+	tail         []byte
+	pending      []byte
+	sawDone      bool
+	sawCompleted bool
+	emitted      bool
 }
 
 func (w *responsesDoneWrapper) Read(p []byte) (int, error) {
@@ -55,6 +64,13 @@ func (w *responsesDoneWrapper) Read(p []byte) (int, error) {
 			return 0, io.EOF
 		}
 
+		if !w.sawCompleted {
+			if n > 0 {
+				return n, nil
+			}
+			return 0, io.EOF
+		}
+
 		if n > 0 {
 			w.pending = append(w.pending[:0], responsesDoneMarker...)
 			return n, nil
@@ -74,20 +90,37 @@ func (w *responsesDoneWrapper) Read(p []byte) (int, error) {
 }
 
 func (w *responsesDoneWrapper) trackDone(data []byte) {
-	if w.sawDone {
+	if w.sawDone && w.sawCompleted {
 		return
 	}
 
 	combined := append(append([]byte(nil), w.tail...), data...)
-	if bytes.Contains(combined, responsesDoneMarker) {
+	if !w.sawDone && bytes.Contains(combined, responsesDoneLine) {
 		w.sawDone = true
-		return
+	}
+	if !w.sawCompleted {
+		for _, pattern := range responsesCompletionPatterns {
+			if bytes.Contains(combined, pattern) {
+				w.sawCompleted = true
+				break
+			}
+		}
 	}
 
-	overlap := len(responsesDoneMarker) - 1
+	overlap := responsesDoneTrackOverlap()
 	if len(combined) > overlap {
 		combined = combined[len(combined)-overlap:]
 	}
 
 	w.tail = append(w.tail[:0], combined...)
+}
+
+func responsesDoneTrackOverlap() int {
+	overlap := len(responsesDoneLine) - 1
+	for _, pattern := range responsesCompletionPatterns {
+		if n := len(pattern) - 1; n > overlap {
+			overlap = n
+		}
+	}
+	return overlap
 }

--- a/internal/providers/responses_done_wrapper_test.go
+++ b/internal/providers/responses_done_wrapper_test.go
@@ -57,6 +57,21 @@ func TestEnsureResponsesDone_InsertsEventSeparatorBeforeDoneMarker(t *testing.T)
 	}
 }
 
+func TestEnsureResponsesDone_HandlesCompletedDataLineAtEOFWithoutTrailingNewline(t *testing.T) {
+	stream := io.NopCloser(strings.NewReader("event: response.completed\ndata: {\"type\":\"response.completed\"}"))
+
+	data, err := io.ReadAll(EnsureResponsesDone(stream))
+	if err != nil {
+		t.Fatalf("read stream: %v", err)
+	}
+
+	got := string(data)
+	want := "event: response.completed\ndata: {\"type\":\"response.completed\"}\n\ndata: [DONE]\n\n"
+	if got != want {
+		t.Fatalf("expected EOF-terminated completed line to still get a done marker, got %q", got)
+	}
+}
+
 func TestEnsureResponsesDone_PreservesExistingDoneMarker(t *testing.T) {
 	stream := io.NopCloser(strings.NewReader("event: response.completed\ndata: {\"type\":\"response.completed\"}\n\ndata: [DONE]\n\n"))
 

--- a/internal/providers/responses_done_wrapper_test.go
+++ b/internal/providers/responses_done_wrapper_test.go
@@ -42,6 +42,21 @@ func TestEnsureResponsesDone_AppendsDoneMarker(t *testing.T) {
 	}
 }
 
+func TestEnsureResponsesDone_InsertsEventSeparatorBeforeDoneMarker(t *testing.T) {
+	stream := io.NopCloser(strings.NewReader("event: response.completed\ndata: {\"type\":\"response.completed\"}\n"))
+
+	data, err := io.ReadAll(EnsureResponsesDone(stream))
+	if err != nil {
+		t.Fatalf("read stream: %v", err)
+	}
+
+	got := string(data)
+	want := "event: response.completed\ndata: {\"type\":\"response.completed\"}\n\ndata: [DONE]\n\n"
+	if got != want {
+		t.Fatalf("expected wrapper to terminate the completed SSE event before [DONE], got %q", got)
+	}
+}
+
 func TestEnsureResponsesDone_PreservesExistingDoneMarker(t *testing.T) {
 	stream := io.NopCloser(strings.NewReader("event: response.completed\ndata: {\"type\":\"response.completed\"}\n\ndata: [DONE]\n\n"))
 
@@ -108,5 +123,47 @@ func TestEnsureResponsesDone_PreservesEOFTerminatedDoneMarker(t *testing.T) {
 	}
 	if strings.Count(got, "[DONE]") != 1 {
 		t.Fatalf("expected exactly one done marker, got %q", got)
+	}
+}
+
+func TestEnsureResponsesDone_CompletesPartialDonePrefixWithoutDuplication(t *testing.T) {
+	stream := &chunkedReadCloser{
+		chunks: [][]byte{
+			[]byte("event: response.completed\ndata: {\"type\":\"response.completed\"}\n\n"),
+			[]byte("data: [DO"),
+		},
+	}
+
+	data, err := io.ReadAll(EnsureResponsesDone(stream))
+	if err != nil {
+		t.Fatalf("read stream: %v", err)
+	}
+
+	got := string(data)
+	want := "event: response.completed\ndata: {\"type\":\"response.completed\"}\n\ndata: [DONE]\n\n"
+	if got != want {
+		t.Fatalf("expected partial done prefix to be completed in place, got %q", got)
+	}
+}
+
+func TestEnsureResponsesDone_IgnoresDoneSubstringInsideJSONPayload(t *testing.T) {
+	stream := io.NopCloser(strings.NewReader(
+		"event: response.output_text.delta\n" +
+			"data: {\"type\":\"response.output_text.delta\",\"delta\":\"data: [DONE]\"}\n\n" +
+			"event: response.completed\n" +
+			"data: {\"type\":\"response.completed\"}\n",
+	))
+
+	data, err := io.ReadAll(EnsureResponsesDone(stream))
+	if err != nil {
+		t.Fatalf("read stream: %v", err)
+	}
+
+	got := string(data)
+	if !strings.Contains(got, "\"delta\":\"data: [DONE]\"") {
+		t.Fatalf("expected model text containing done literal to be preserved, got %q", got)
+	}
+	if !strings.HasSuffix(got, "\n\ndata: [DONE]\n\n") {
+		t.Fatalf("expected a real terminal done event at EOF, got %q", got)
 	}
 }

--- a/internal/providers/responses_done_wrapper_test.go
+++ b/internal/providers/responses_done_wrapper_test.go
@@ -1,0 +1,80 @@
+package providers
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+type chunkedReadCloser struct {
+	chunks [][]byte
+	index  int
+}
+
+func (r *chunkedReadCloser) Read(p []byte) (int, error) {
+	if r.index >= len(r.chunks) {
+		return 0, io.EOF
+	}
+
+	n := copy(p, r.chunks[r.index])
+	r.index++
+	return n, nil
+}
+
+func (r *chunkedReadCloser) Close() error {
+	return nil
+}
+
+func TestEnsureResponsesDone_AppendsDoneMarker(t *testing.T) {
+	stream := io.NopCloser(strings.NewReader("event: response.completed\ndata: {\"type\":\"response.completed\"}\n\n"))
+
+	data, err := io.ReadAll(EnsureResponsesDone(stream))
+	if err != nil {
+		t.Fatalf("read stream: %v", err)
+	}
+
+	got := string(data)
+	if !strings.HasSuffix(got, "data: [DONE]\n\n") {
+		t.Fatalf("expected stream to end with done marker, got %q", got)
+	}
+	if strings.Count(got, "[DONE]") != 1 {
+		t.Fatalf("expected exactly one done marker, got %q", got)
+	}
+}
+
+func TestEnsureResponsesDone_PreservesExistingDoneMarker(t *testing.T) {
+	stream := io.NopCloser(strings.NewReader("event: response.completed\ndata: {\"type\":\"response.completed\"}\n\ndata: [DONE]\n\n"))
+
+	data, err := io.ReadAll(EnsureResponsesDone(stream))
+	if err != nil {
+		t.Fatalf("read stream: %v", err)
+	}
+
+	got := string(data)
+	if strings.Count(got, "[DONE]") != 1 {
+		t.Fatalf("expected existing done marker to be preserved without duplication, got %q", got)
+	}
+}
+
+func TestEnsureResponsesDone_PreservesSplitDoneMarker(t *testing.T) {
+	stream := &chunkedReadCloser{
+		chunks: [][]byte{
+			[]byte("event: response.completed\ndata: {\"type\":\"response.completed\"}\n\ndata: [DO"),
+			[]byte("NE]\n\n"),
+		},
+	}
+
+	data, err := io.ReadAll(EnsureResponsesDone(stream))
+	if err != nil {
+		t.Fatalf("read stream: %v", err)
+	}
+
+	got := string(data)
+	want := "event: response.completed\ndata: {\"type\":\"response.completed\"}\n\ndata: [DONE]\n\n"
+	if got != want {
+		t.Fatalf("expected split done marker to pass through unchanged, got %q", got)
+	}
+	if strings.Count(got, "[DONE]") != 1 {
+		t.Fatalf("expected exactly one done marker, got %q", got)
+	}
+}

--- a/internal/providers/responses_done_wrapper_test.go
+++ b/internal/providers/responses_done_wrapper_test.go
@@ -78,3 +78,35 @@ func TestEnsureResponsesDone_PreservesSplitDoneMarker(t *testing.T) {
 		t.Fatalf("expected exactly one done marker, got %q", got)
 	}
 }
+
+func TestEnsureResponsesDone_DoesNotMaskIncompleteStream(t *testing.T) {
+	stream := io.NopCloser(strings.NewReader("event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"hel\"}\n\n"))
+
+	data, err := io.ReadAll(EnsureResponsesDone(stream))
+	if err != nil {
+		t.Fatalf("read stream: %v", err)
+	}
+
+	got := string(data)
+	if strings.Contains(got, "[DONE]") {
+		t.Fatalf("expected incomplete stream to remain incomplete, got %q", got)
+	}
+}
+
+func TestEnsureResponsesDone_PreservesEOFTerminatedDoneMarker(t *testing.T) {
+	stream := io.NopCloser(strings.NewReader("event: response.completed\ndata: {\"type\":\"response.completed\"}\n\ndata: [DONE]\n"))
+
+	data, err := io.ReadAll(EnsureResponsesDone(stream))
+	if err != nil {
+		t.Fatalf("read stream: %v", err)
+	}
+
+	got := string(data)
+	want := "event: response.completed\ndata: {\"type\":\"response.completed\"}\n\ndata: [DONE]\n"
+	if got != want {
+		t.Fatalf("expected EOF-terminated done marker to pass through unchanged, got %q", got)
+	}
+	if strings.Count(got, "[DONE]") != 1 {
+		t.Fatalf("expected exactly one done marker, got %q", got)
+	}
+}

--- a/internal/providers/xai/xai.go
+++ b/internal/providers/xai/xai.go
@@ -127,7 +127,11 @@ func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*
 	return &resp, nil
 }
 
-// StreamResponses returns a raw response body for streaming Responses API (caller must close)
+// StreamResponses returns a normalized streaming Responses API body.
+// The returned io.ReadCloser is wrapped by providers.EnsureResponsesDone, so
+// callers must not assume it contains verbatim upstream bytes; the wrapper may
+// synthesize a terminal `data: [DONE]` marker on completed streams. Callers
+// remain responsible for closing the returned stream.
 func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
 	stream, err := p.client.DoStream(ctx, llmclient.Request{
 		Method:   http.MethodPost,

--- a/internal/providers/xai/xai.go
+++ b/internal/providers/xai/xai.go
@@ -129,11 +129,16 @@ func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*
 
 // StreamResponses returns a raw response body for streaming Responses API (caller must close)
 func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
-	return p.client.DoStream(ctx, llmclient.Request{
+	stream, err := p.client.DoStream(ctx, llmclient.Request{
 		Method:   http.MethodPost,
 		Endpoint: "/responses",
 		Body:     req.WithStreaming(),
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	return providers.EnsureResponsesDone(stream), nil
 }
 
 // Embeddings sends an embeddings request to xAI

--- a/internal/providers/xai/xai_test.go
+++ b/internal/providers/xai/xai_test.go
@@ -642,8 +642,6 @@ data: {"type":"response.output_text.delta","delta":"!"}
 
 event: response.completed
 data: {"type":"response.completed","response":{"id":"resp_123","object":"response","status":"completed","model":"grok-2"}}
-
-data: [DONE]
 `,
 			expectedError: false,
 			checkStream: func(t *testing.T, body io.ReadCloser) {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -107,8 +107,31 @@ func (h *Handler) handleStreamingResponse(c echo.Context, model, provider string
 	}
 
 	c.Response().WriteHeader(http.StatusOK)
-	_, _ = io.Copy(c.Response().Writer, wrappedStream)
+	flushStream(c.Response().Writer, wrappedStream)
 	return nil
+}
+
+func flushStream(w io.Writer, stream io.Reader) {
+	flusher, canFlush := w.(http.Flusher)
+	if canFlush {
+		flusher.Flush()
+	}
+
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := stream.Read(buf)
+		if n > 0 {
+			if _, writeErr := w.Write(buf[:n]); writeErr != nil {
+				return
+			}
+			if canFlush {
+				flusher.Flush()
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
 }
 
 func (h *Handler) logUsage(model, providerType string, extractFn func(*core.ModelPricing) *usage.UsageEntry) {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -107,11 +107,13 @@ func (h *Handler) handleStreamingResponse(c echo.Context, model, provider string
 	}
 
 	c.Response().WriteHeader(http.StatusOK)
-	flushStream(c.Response().Writer, wrappedStream)
+	if err := flushStream(c.Response().Writer, wrappedStream); err != nil {
+		recordStreamingError(streamEntry, model, provider, c.Request().URL.Path, requestID, err)
+	}
 	return nil
 }
 
-func flushStream(w io.Writer, stream io.Reader) {
+func flushStream(w io.Writer, stream io.Reader) error {
 	flusher, canFlush := w.(http.Flusher)
 	if canFlush {
 		flusher.Flush()
@@ -122,16 +124,37 @@ func flushStream(w io.Writer, stream io.Reader) {
 		n, err := stream.Read(buf)
 		if n > 0 {
 			if _, writeErr := w.Write(buf[:n]); writeErr != nil {
-				return
+				return writeErr
 			}
 			if canFlush {
 				flusher.Flush()
 			}
 		}
 		if err != nil {
-			return
+			if err == io.EOF {
+				return nil
+			}
+			return err
 		}
 	}
+}
+
+func recordStreamingError(streamEntry *auditlog.LogEntry, model, provider, path, requestID string, err error) {
+	if streamEntry != nil {
+		streamEntry.ErrorType = "stream_error"
+		if streamEntry.Data == nil {
+			streamEntry.Data = &auditlog.LogData{}
+		}
+		streamEntry.Data.ErrorMessage = err.Error()
+	}
+
+	slog.Warn("stream terminated abnormally",
+		"error", err,
+		"model", model,
+		"provider", provider,
+		"path", path,
+		"request_id", requestID,
+	)
 }
 
 func (h *Handler) logUsage(model, providerType string, extractFn func(*core.ModelPricing) *usage.UsageEntry) {

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -10,12 +10,82 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 
 	"gomodel/internal/core"
 	"gomodel/internal/usage"
 )
+
+type chunkedReadCloser struct {
+	chunks [][]byte
+	index  int
+}
+
+func (r *chunkedReadCloser) Read(p []byte) (int, error) {
+	if r.index >= len(r.chunks) {
+		return 0, io.EOF
+	}
+
+	n := copy(p, r.chunks[r.index])
+	r.index++
+	return n, nil
+}
+
+func (r *chunkedReadCloser) Close() error {
+	return nil
+}
+
+type flushCountingRecorder struct {
+	*httptest.ResponseRecorder
+	flushes int
+}
+
+func (r *flushCountingRecorder) Flush() {
+	r.flushes++
+	r.ResponseRecorder.Flush()
+}
+
+type delayedChunkReadCloser struct {
+	chunks []delayedChunk
+	index  int
+}
+
+type delayedChunk struct {
+	data  []byte
+	delay time.Duration
+}
+
+func (r *delayedChunkReadCloser) Read(p []byte) (int, error) {
+	if r.index >= len(r.chunks) {
+		return 0, io.EOF
+	}
+
+	chunk := r.chunks[r.index]
+	r.index++
+	if chunk.delay > 0 {
+		time.Sleep(chunk.delay)
+	}
+
+	return copy(p, chunk.data), nil
+}
+
+func (r *delayedChunkReadCloser) Close() error {
+	return nil
+}
+
+type streamingProviderWithCustomReader struct {
+	mockProvider
+	reader io.ReadCloser
+}
+
+func (p *streamingProviderWithCustomReader) StreamChatCompletion(_ context.Context, _ *core.ChatRequest) (io.ReadCloser, error) {
+	if p.err != nil {
+		return nil, p.err
+	}
+	return p.reader, nil
+}
 
 // mockProvider implements core.RoutableProvider for testing
 type mockProvider struct {
@@ -405,6 +475,95 @@ data: [DONE]
 	}
 	if !strings.Contains(body, "[DONE]") {
 		t.Errorf("response should contain [DONE], got: %s", body)
+	}
+}
+
+func TestHandleStreamingResponse_FlushesEachChunk(t *testing.T) {
+	e := echo.New()
+	handler := NewHandler(&mockProvider{}, nil, nil, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	rec := &flushCountingRecorder{ResponseRecorder: httptest.NewRecorder()}
+	c := e.NewContext(req, rec)
+
+	stream := &chunkedReadCloser{
+		chunks: [][]byte{
+			[]byte("data: {\"id\":\"1\"}\n\n"),
+			[]byte("data: {\"id\":\"2\"}\n\n"),
+			[]byte("data: [DONE]\n\n"),
+		},
+	}
+
+	err := handler.handleStreamingResponse(c, "gpt-4o-mini", "openai", func() (io.ReadCloser, error) {
+		return stream, nil
+	})
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	if rec.flushes != 4 {
+		t.Fatalf("expected 4 flushes (headers + 3 chunks), got %d", rec.flushes)
+	}
+
+	if got := rec.Body.String(); got != "data: {\"id\":\"1\"}\n\ndata: {\"id\":\"2\"}\n\ndata: [DONE]\n\n" {
+		t.Fatalf("unexpected body %q", got)
+	}
+}
+
+func TestChatCompletionStreaming_FlushesBeforeNextChunkArrives(t *testing.T) {
+	const secondChunkDelay = 250 * time.Millisecond
+
+	provider := &streamingProviderWithCustomReader{
+		mockProvider: mockProvider{
+			supportedModels: []string{"gpt-4o-mini"},
+		},
+		reader: &delayedChunkReadCloser{
+			chunks: []delayedChunk{
+				{data: []byte("data: {\"id\":\"1\"}\n\n")},
+				{data: []byte("data: [DONE]\n\n"), delay: secondChunkDelay},
+			},
+		},
+	}
+
+	e := echo.New()
+	handler := NewHandler(provider, nil, nil, nil)
+	e.POST("/v1/chat/completions", handler.ChatCompletion)
+
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+
+	reqBody := `{"model":"gpt-4o-mini","stream":true,"messages":[{"role":"user","content":"Hi"}]}`
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/v1/chat/completions", strings.NewReader(reqBody))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("stream request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	start := time.Now()
+	buf := make([]byte, 64)
+	n, err := resp.Body.Read(buf)
+	if err != nil {
+		t.Fatalf("read first chunk: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	if elapsed >= secondChunkDelay/2 {
+		t.Fatalf("first chunk arrived too late: got %v, want < %v", elapsed, secondChunkDelay/2)
+	}
+
+	firstChunk := string(buf[:n])
+	if !strings.Contains(firstChunk, `"id":"1"`) {
+		t.Fatalf("expected first streamed chunk before delayed tail, got %q", firstChunk)
 	}
 }
 

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 
+	"gomodel/internal/auditlog"
 	"gomodel/internal/core"
 	"gomodel/internal/usage"
 )
@@ -85,6 +87,53 @@ func (p *streamingProviderWithCustomReader) StreamChatCompletion(_ context.Conte
 		return nil, p.err
 	}
 	return p.reader, nil
+}
+
+type erroringReadCloser struct {
+	data []byte
+	err  error
+	read bool
+}
+
+func (r *erroringReadCloser) Read(p []byte) (int, error) {
+	if r.read {
+		return 0, r.err
+	}
+	r.read = true
+	n := copy(p, r.data)
+	if r.err != nil {
+		return n, r.err
+	}
+	return n, io.EOF
+}
+
+func (r *erroringReadCloser) Close() error {
+	return nil
+}
+
+type capturingAuditLogger struct {
+	config  auditlog.Config
+	entries []*auditlog.LogEntry
+}
+
+func (l *capturingAuditLogger) Write(entry *auditlog.LogEntry) {
+	l.entries = append(l.entries, entry)
+}
+
+func (l *capturingAuditLogger) Config() auditlog.Config {
+	return l.config
+}
+
+func (l *capturingAuditLogger) Close() error {
+	return nil
+}
+
+type erroringWriter struct {
+	err error
+}
+
+func (w *erroringWriter) Write([]byte) (int, error) {
+	return 0, w.err
 }
 
 // mockProvider implements core.RoutableProvider for testing
@@ -511,6 +560,74 @@ func TestHandleStreamingResponse_FlushesEachChunk(t *testing.T) {
 
 	if got := rec.Body.String(); got != "data: {\"id\":\"1\"}\n\ndata: {\"id\":\"2\"}\n\ndata: [DONE]\n\n" {
 		t.Fatalf("unexpected body %q", got)
+	}
+}
+
+func TestFlushStream_ReturnsReadError(t *testing.T) {
+	expectedErr := errors.New("stream read failed")
+	stream := &erroringReadCloser{
+		data: []byte("data: {\"id\":\"1\"}\n\n"),
+		err:  expectedErr,
+	}
+
+	err := flushStream(io.Discard, stream)
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected read error %v, got %v", expectedErr, err)
+	}
+}
+
+func TestFlushStream_ReturnsWriteError(t *testing.T) {
+	expectedErr := errors.New("client write failed")
+	stream := io.NopCloser(strings.NewReader("data: {\"id\":\"1\"}\n\n"))
+
+	err := flushStream(&erroringWriter{err: expectedErr}, stream)
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected write error %v, got %v", expectedErr, err)
+	}
+}
+
+func TestHandleStreamingResponse_RecordsStreamingError(t *testing.T) {
+	expectedErr := errors.New("upstream stream failed")
+	logger := &capturingAuditLogger{
+		config: auditlog.Config{Enabled: true},
+	}
+
+	e := echo.New()
+	handler := NewHandler(&mockProvider{}, logger, nil, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("X-Request-ID", "req-stream-1")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(auditlog.LogEntryKey), &auditlog.LogEntry{
+		ID:        "entry-1",
+		Timestamp: time.Now(),
+		RequestID: "req-stream-1",
+		Method:    http.MethodPost,
+		Path:      "/v1/chat/completions",
+		Data:      &auditlog.LogData{},
+	})
+
+	err := handler.handleStreamingResponse(c, "gpt-4o-mini", "openai", func() (io.ReadCloser, error) {
+		return &erroringReadCloser{
+			data: []byte("data: {\"id\":\"1\"}\n\n"),
+			err:  expectedErr,
+		}, nil
+	})
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	if len(logger.entries) != 1 {
+		t.Fatalf("expected 1 audit log entry, got %d", len(logger.entries))
+	}
+
+	entry := logger.entries[0]
+	if entry.ErrorType != "stream_error" {
+		t.Fatalf("expected stream_error, got %q", entry.ErrorType)
+	}
+	if entry.Data == nil || entry.Data.ErrorMessage != expectedErr.Error() {
+		t.Fatalf("expected error message %q, got %+v", expectedErr.Error(), entry.Data)
 	}
 }
 

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -55,8 +55,10 @@ type delayedChunkReadCloser struct {
 }
 
 type delayedChunk struct {
-	data  []byte
-	delay time.Duration
+	data    []byte
+	delay   time.Duration
+	started chan<- struct{}
+	release <-chan struct{}
 }
 
 func (r *delayedChunkReadCloser) Read(p []byte) (int, error) {
@@ -66,8 +68,15 @@ func (r *delayedChunkReadCloser) Read(p []byte) (int, error) {
 
 	chunk := r.chunks[r.index]
 	r.index++
+	if chunk.started != nil {
+		close(chunk.started)
+		r.chunks[r.index-1].started = nil
+	}
 	if chunk.delay > 0 {
 		time.Sleep(chunk.delay)
+	}
+	if chunk.release != nil {
+		<-chunk.release
 	}
 
 	return copy(p, chunk.data), nil
@@ -632,7 +641,8 @@ func TestHandleStreamingResponse_RecordsStreamingError(t *testing.T) {
 }
 
 func TestChatCompletionStreaming_FlushesBeforeNextChunkArrives(t *testing.T) {
-	const secondChunkDelay = 250 * time.Millisecond
+	secondChunkStarted := make(chan struct{})
+	releaseSecondChunk := make(chan struct{})
 
 	provider := &streamingProviderWithCustomReader{
 		mockProvider: mockProvider{
@@ -641,7 +651,11 @@ func TestChatCompletionStreaming_FlushesBeforeNextChunkArrives(t *testing.T) {
 		reader: &delayedChunkReadCloser{
 			chunks: []delayedChunk{
 				{data: []byte("data: {\"id\":\"1\"}\n\n")},
-				{data: []byte("data: [DONE]\n\n"), delay: secondChunkDelay},
+				{
+					data:    []byte("data: [DONE]\n\n"),
+					started: secondChunkStarted,
+					release: releaseSecondChunk,
+				},
 			},
 		},
 	}
@@ -666,19 +680,45 @@ func TestChatCompletionStreaming_FlushesBeforeNextChunkArrives(t *testing.T) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	start := time.Now()
-	buf := make([]byte, 64)
-	n, err := resp.Body.Read(buf)
-	if err != nil {
-		t.Fatalf("read first chunk: %v", err)
-	}
-	elapsed := time.Since(start)
+	readResult := make(chan struct {
+		n   int
+		err error
+		buf []byte
+	}, 1)
+	go func() {
+		buf := make([]byte, 64)
+		n, err := resp.Body.Read(buf)
+		readResult <- struct {
+			n   int
+			err error
+			buf []byte
+		}{n: n, err: err, buf: buf}
+	}()
 
-	if elapsed >= secondChunkDelay/2 {
-		t.Fatalf("first chunk arrived too late: got %v, want < %v", elapsed, secondChunkDelay/2)
+	select {
+	case <-secondChunkStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for server to start reading the delayed second chunk")
 	}
 
-	firstChunk := string(buf[:n])
+	var result struct {
+		n   int
+		err error
+		buf []byte
+	}
+	select {
+	case result = <-readResult:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first chunk to reach the client before releasing the second chunk")
+	}
+
+	close(releaseSecondChunk)
+
+	if result.err != nil {
+		t.Fatalf("read first chunk: %v", result.err)
+	}
+
+	firstChunk := string(result.buf[:result.n])
 	if !strings.Contains(firstChunk, `"id":"1"`) {
 		t.Fatalf("expected first streamed chunk before delayed tail, got %q", firstChunk)
 	}

--- a/tests/contract/testdata/golden/openai/responses_stream.golden.json
+++ b/tests/contract/testdata/golden/openai/responses_stream.golden.json
@@ -319,6 +319,11 @@
         "sequence_number": 11,
         "type": "response.completed"
       }
+    },
+    {
+      "Done": true,
+      "Name": "",
+      "Payload": null
     }
   ],
   "text": "Hello, World!"

--- a/tests/contract/testdata/golden/xai/responses_stream.golden.json
+++ b/tests/contract/testdata/golden/xai/responses_stream.golden.json
@@ -2544,6 +2544,11 @@
         "sequence_number": 195,
         "type": "response.completed"
       }
+    },
+    {
+      "Done": true,
+      "Name": "",
+      "Payload": null
     }
   ],
   "text": "Hello, World!"


### PR DESCRIPTION
Bug fix:
- **Streaming is broken.** SSE tokens buffer at 4KB instead of flushing incrementally (C-04). The stream termination signal `[DONE]` is lost before delivery (C-06). Users see frozen output followed by bursts. This is the defining failure mode for an AI gateway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streamed responses now reliably end with the terminal data: [DONE] marker and better handle upstream EOFs and streaming errors to avoid truncated outputs.
  * Improved incremental delivery to clients with buffered flush behavior for smoother real-time streaming.

* **Documentation**
  * Clarified streaming semantics in Getting Started and Tips: SSE chunks flush incrementally and streams terminate with data: [DONE].

* **Tests**
  * Added tests for marker handling, chunked/split markers, flushing, timing, and streaming error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->