### PR TITLE
Add "Who We Are" page to docs about section

### DIFF
--- a/docs/about/who-we-are.mdx
+++ b/docs/about/who-we-are.mdx
@@ -1,0 +1,68 @@
+---
+title: "Who We Are"
+description: "The people and organization behind GOModel, and how it relates to Enterpilot."
+---
+
+## Jakub Wąsek
+
+GOModel is created and maintained by **Jakub Wąsek**, who is also the founder of
+[Enterpilot.io](https://enterpilot.io).
+
+Both projects share a single vision: make it easier for teams to build on top of
+large language models without getting locked into one provider or one vendor's
+pricing.
+
+## Enterpilot
+
+[Enterpilot](https://enterpilot.io) is a commercial product that uses GOModel at
+its core. It adds enterprise features — team management, advanced analytics,
+compliance tooling — on top of the open-source gateway.
+
+Revenue from Enterpilot is what funds continued development of GOModel. This is a
+deliberate choice: the gateway stays open, the business builds on top.
+
+## Why open source
+
+GOModel is open source because an AI gateway is infrastructure. Infrastructure
+works best when people can read it, audit it, and extend it.
+
+We want the community to use GOModel freely, contribute improvements, and trust
+that the project will keep shipping.
+
+## On licensing
+
+Today GOModel ships under an open-source license, and we intend to keep it that
+way for individual developers, startups, and most organizations.
+
+That said, we are watching how the industry treats open-source projects. There is
+a pattern where large cloud providers take open-source software, offer it as a
+managed service, and give nothing back to the maintainers who built it.
+
+This has happened before:
+
+- [MongoDB changed to the SSPL](https://www.mongodb.com/blog/post/mongodb-now-released-under-the-server-side-public-license)
+  after AWS launched DocumentDB, a compatible managed service built on
+  MongoDB's work.
+- [Elastic moved to a dual license](https://www.elastic.co/blog/why-license-change-was-necessary)
+  after AWS launched its own Elasticsearch service under the OpenSearch name.
+- [Redis switched to a source-available license](https://redis.io/blog/redis-adopts-dual-source-available-licensing/)
+  citing similar concerns about cloud providers.
+
+We do not want to follow that path if we do not have to. But we are honest about
+the possibility. If we ever need to adjust the license, the goal will be narrow:
+protect the project from extraction by companies that can afford to contribute
+but choose not to, while keeping GOModel fully usable for everyone else.
+
+<Note>
+  If you are an individual developer, a startup, or an organization using
+  GOModel in good faith, licensing changes will not affect you. We are building
+  this for you.
+</Note>
+
+## How to reach us
+
+- **GitHub:** [ENTERPILOT/GOModel](https://github.com/ENTERPILOT/GOModel)
+- **Enterpilot:** [enterpilot.io](https://enterpilot.io)
+
+If you want to contribute, report a bug, or just say hello, open an issue on
+GitHub. We read every one.

--- a/docs/about/who-we-are.mdx
+++ b/docs/about/who-we-are.mdx
@@ -32,9 +32,6 @@ broader product:
 
 Upcoming integrations include Slack, Microsoft Teams, and SSO support.
 
-Revenue from Enterpilot is what funds continued development of GOModel. This is a
-deliberate choice: the gateway stays open, the business builds on top.
-
 ## Why open source
 
 GOModel is open source because an AI gateway is infrastructure. Infrastructure

--- a/docs/about/who-we-are.mdx
+++ b/docs/about/who-we-are.mdx
@@ -14,9 +14,27 @@ pricing.
 
 ## Enterpilot
 
-[Enterpilot](https://enterpilot.io) is a commercial product that uses GOModel at
-its core. It adds enterprise features — team management, advanced analytics,
-compliance tooling — on top of the open-source gateway.
+[Enterpilot](https://enterpilot.io) is a commercial AI access and traffic
+management platform for teams — think [Dust.tt](https://dust.tt) but with full
+control over routing, budgets, and data privacy.
+
+GOModel powers the gateway layer inside Enterpilot, but Enterpilot is a much
+broader product:
+
+- **Chat interface** — a provider-independent chat UI where teams can talk to
+  GPT, Claude, Gemini, and other models without needing personal accounts.
+  Conversation history is stored on your own infrastructure.
+- **API interface** — a single API endpoint that routes to any supported model,
+  with per-user and per-team budget controls.
+- **Security and data protection** — PII anonymization, data redaction, and
+  locally-run guard models to prevent sensitive data from leaving your network.
+- **Cost management** — hard traffic limits, per-team budgets, and easy
+  model-switching as cheaper alternatives become available.
+- **Observability** — full visibility into requests, prompts, and responses,
+  with integrations for Datadog and Prometheus.
+- **Deployment flexibility** — SaaS, on-premises, or bring-your-own-cloud.
+
+Upcoming integrations include Slack, Microsoft Teams, and SSO support.
 
 Revenue from Enterpilot is what funds continued development of GOModel. This is a
 deliberate choice: the gateway stays open, the business builds on top.

--- a/docs/about/who-we-are.mdx
+++ b/docs/about/who-we-are.mdx
@@ -43,27 +43,13 @@ that the project will keep shipping.
 
 ## On licensing
 
-Today GOModel ships under an open-source license, and we intend to keep it that
-way for individual developers, startups, and most organizations.
+GOModel is open source and we want it to stay that way. Building this project
+is how we make a living, so we need it to be sustainable — but we believe open
+source and sustainability can coexist.
 
-That said, we are watching how the industry treats open-source projects. There is
-a pattern where large cloud providers take open-source software, offer it as a
-managed service, and give nothing back to the maintainers who built it.
-
-This has happened before:
-
-- [MongoDB changed to the SSPL](https://www.mongodb.com/blog/post/mongodb-now-released-under-the-server-side-public-license)
-  after AWS launched DocumentDB, a compatible managed service built on
-  MongoDB's work.
-- [Elastic moved to a dual license](https://www.elastic.co/blog/why-license-change-was-necessary)
-  after AWS launched its own Elasticsearch service under the OpenSearch name.
-- [Redis switched to a source-available license](https://redis.io/blog/redis-adopts-dual-source-available-licensing/)
-  citing similar concerns about cloud providers.
-
-We do not want to follow that path if we do not have to. But we are honest about
-the possibility. If we ever need to adjust the license, the goal will be narrow:
-protect the project from extraction by companies that can afford to contribute
-but choose not to, while keeping GOModel fully usable for everyone else.
+If we ever need to adjust the license, the goal will be narrow: protect the
+project from extraction by companies that can afford to contribute but choose
+not to, while keeping GOModel fully usable for everyone else.
 
 ## Links
 

--- a/docs/about/who-we-are.mdx
+++ b/docs/about/who-we-are.mdx
@@ -14,7 +14,7 @@ large language models without getting locked into one provider.
 ## Enterpilot
 
 [Enterpilot](https://enterpilot.io) is a commercial AI access and traffic
-management platform for teams — think [Dust.tt](https://dust.tt) but with full
+management platform for teams — think Dust.tt but with full
 control over routing, budgets, and data privacy.
 
 GOModel powers the gateway layer inside Enterpilot, but Enterpilot is a much

--- a/docs/about/who-we-are.mdx
+++ b/docs/about/who-we-are.mdx
@@ -47,6 +47,18 @@ GOModel is open source and we want it to stay that way. Building this project
 is how we make a living, so we need it to be sustainable — but we believe open
 source and sustainability can coexist.
 
+That said, there is a pattern in the industry where large cloud providers take
+open-source software, offer it as a managed service, and give nothing back to
+the maintainers who built it. This has happened before:
+
+- [MongoDB changed to the SSPL](https://www.mongodb.com/blog/post/mongodb-now-released-under-the-server-side-public-license)
+  after AWS launched DocumentDB, a compatible managed service built on
+  MongoDB's work.
+- [Elastic moved to a dual license](https://www.elastic.co/blog/why-license-change-was-necessary)
+  after AWS launched its own Elasticsearch service under the OpenSearch name.
+- [Redis switched to a source-available license](https://redis.io/blog/redis-adopts-dual-source-available-licensing/)
+  citing similar concerns about cloud providers.
+
 If we ever need to adjust the license, the goal will be narrow: protect the
 project from extraction by companies that can afford to contribute but choose
 not to, while keeping GOModel fully usable for everyone else.

--- a/docs/about/who-we-are.mdx
+++ b/docs/about/who-we-are.mdx
@@ -24,15 +24,11 @@ broader product:
 - **Chat interface** — a provider-independent chat UI where teams can talk to
   GPT, Claude, Gemini, and other models without needing personal accounts.
   Conversation history is stored on your own infrastructure.
-- **API interface** — a single API endpoint that routes to any supported model,
-  with per-user and per-team budget controls.
-- **Security and data protection** — PII anonymization, data redaction, and
-  locally-run guard models to prevent sensitive data from leaving your network.
-- **Cost management** — hard traffic limits, per-team budgets, and easy
-  model-switching as cheaper alternatives become available.
-- **Observability** — full visibility into requests, prompts, and responses,
-  with integrations for Datadog and Prometheus.
-- **Deployment flexibility** — SaaS, on-premises, or bring-your-own-cloud.
+- **Knowledge base integration** — connect internal company knowledge bases
+  (Confluence, Notion, SharePoint, Google Drive, and custom sources) so teams
+  can query proprietary documents and data through the same chat and API
+  interface. Retrieval-augmented generation (RAG) pipelines run on your own
+  infrastructure, keeping sensitive content in-house.
 
 Upcoming integrations include Slack, Microsoft Teams, and SSO support.
 

--- a/docs/about/who-we-are.mdx
+++ b/docs/about/who-we-are.mdx
@@ -37,13 +37,17 @@ that the project will keep shipping.
 
 ## On licensing
 
-GOModel is open source and we want it to stay that way. Building this project
-is how we make a living, so we need it to be sustainable — but we believe open
-source and sustainability can coexist.
+An AI gateway is infrastructure. It sits between every request your application
+makes and every model it talks to. That kind of component should be something
+you can read, audit, extend, and trust — which is why GOModel is open source
+today, with no asterisks.
 
-That said, there is a pattern in the industry where large cloud providers take
-open-source software, offer it as a managed service, and give nothing back to
-the maintainers who built it. This has happened before:
+That said, we want to be upfront about the future. There are two reasons the
+license could change down the road.
+
+**Protecting the project.** There is a well-documented pattern where large cloud
+providers take open-source infrastructure, ship it as a managed service, and
+give nothing back. It has forced other projects to react:
 
 - [MongoDB changed to the SSPL](https://www.mongodb.com/blog/post/mongodb-now-released-under-the-server-side-public-license)
   after AWS launched DocumentDB, a compatible managed service built on
@@ -53,9 +57,14 @@ the maintainers who built it. This has happened before:
 - [Redis switched to a source-available license](https://redis.io/blog/redis-adopts-dual-source-available-licensing/)
   citing similar concerns about cloud providers.
 
-If we ever need to adjust the license, the goal will be narrow: protect the
-project from extraction by companies that can afford to contribute but choose
-not to, while keeping GOModel fully usable for everyone else.
+If GOModel grows to a point where this becomes a real risk, we may adjust the
+license to prevent extraction — while keeping the project fully usable for
+everyone else.
+
+**Sustainability.** Building GOModel is how we make a living. Right now the
+project is fully open source and we intend to keep it that way for as long as
+possible. But if we ever need to introduce a commercial layer to keep the
+project shipping, we will do it openly and with the community in mind.
 
 ## Links
 

--- a/docs/about/who-we-are.mdx
+++ b/docs/about/who-we-are.mdx
@@ -69,4 +69,4 @@ project — not individual developers or small teams building with it.
 ## Links
 
 - **Enterpilot:** [enterpilot.io](https://enterpilot.io)
-- **README:** [github.com/ENTERPILOT/GOModel](https://github.com/ENTERPILOT/GOModel) — includes a Discord invite link
+- **Discord:** [Join our server](https://discord.gg/gaEB9BQSPH)

--- a/docs/about/who-we-are.mdx
+++ b/docs/about/who-we-are.mdx
@@ -71,12 +71,6 @@ the possibility. If we ever need to adjust the license, the goal will be narrow:
 protect the project from extraction by companies that can afford to contribute
 but choose not to, while keeping GOModel fully usable for everyone else.
 
-<Note>
-  If you are an individual developer, a startup, or an organization using
-  GOModel in good faith, licensing changes will not affect you. We are building
-  this for you.
-</Note>
-
 ## How to reach us
 
 - **GitHub:** [ENTERPILOT/GOModel](https://github.com/ENTERPILOT/GOModel)

--- a/docs/about/who-we-are.mdx
+++ b/docs/about/who-we-are.mdx
@@ -9,8 +9,7 @@ GOModel is created and maintained by **Jakub Wąsek**, who is also the founder o
 [Enterpilot.io](https://enterpilot.io).
 
 Both projects share a single vision: make it easier for teams to build on top of
-large language models without getting locked into one provider or one vendor's
-pricing.
+large language models without getting locked into one provider.
 
 ## Enterpilot
 

--- a/docs/about/who-we-are.mdx
+++ b/docs/about/who-we-are.mdx
@@ -30,7 +30,8 @@ broader product:
   interface. Retrieval-augmented generation (RAG) pipelines run on your own
   infrastructure, keeping sensitive content in-house.
 
-Upcoming integrations include Slack, Microsoft Teams, and SSO support.
+Upcoming integrations include knowledge base integration, Slack, Microsoft Teams,
+and SSO support.
 
 ## Why open source
 

--- a/docs/about/who-we-are.mdx
+++ b/docs/about/who-we-are.mdx
@@ -52,7 +52,7 @@ give nothing back. It has forced other projects to react:
 - [MongoDB changed to the SSPL](https://www.mongodb.com/blog/post/mongodb-now-released-under-the-server-side-public-license)
   after AWS launched DocumentDB, a compatible managed service built on
   MongoDB's work.
-- [Elastic moved to a dual license](https://www.elastic.co/blog/why-license-change-was-necessary)
+- [Elastic moved to a dual license](https://www.elastic.co/blog/licensing-change)
   after AWS launched its own Elasticsearch service under the OpenSearch name.
 - [Redis switched to a source-available license](https://redis.io/blog/redis-adopts-dual-source-available-licensing/)
   citing similar concerns about cloud providers.

--- a/docs/about/who-we-are.mdx
+++ b/docs/about/who-we-are.mdx
@@ -24,14 +24,9 @@ broader product:
 - **Chat interface** — a provider-independent chat UI where teams can talk to
   GPT, Claude, Gemini, and other models without needing personal accounts.
   Conversation history is stored on your own infrastructure.
-- **Knowledge base integration** — connect internal company knowledge bases
-  (Confluence, Notion, SharePoint, Google Drive, and custom sources) so teams
-  can query proprietary documents and data through the same chat and API
-  interface. Retrieval-augmented generation (RAG) pipelines run on your own
-  infrastructure, keeping sensitive content in-house.
-
-Upcoming integrations include knowledge base integration, Slack, Microsoft Teams,
-and SSO support.
+Upcoming features include knowledge base integration (Confluence, Notion,
+SharePoint, Google Drive, and custom sources with RAG pipelines running on your
+own infrastructure), Slack, Microsoft Teams, and SSO support.
 
 ## Why open source
 

--- a/docs/about/who-we-are.mdx
+++ b/docs/about/who-we-are.mdx
@@ -63,8 +63,8 @@ everyone else.
 
 **Sustainability.** Building GOModel is how we make a living. Right now the
 project is fully open source and we intend to keep it that way for as long as
-possible. But if we ever need to introduce a commercial layer to keep the
-project shipping, we will do it openly and with the community in mind.
+possible. If that ever happens, the target will be companies that profit from the
+project — not individual developers or small teams building with it.
 
 ## Links
 

--- a/docs/about/who-we-are.mdx
+++ b/docs/about/who-we-are.mdx
@@ -23,9 +23,9 @@ broader product:
 - **Chat interface** — a provider-independent chat UI where teams can talk to
   GPT, Claude, Gemini, and other models without needing personal accounts.
   Conversation history is stored on your own infrastructure.
-Upcoming features include knowledge base integration (Confluence, Notion,
-SharePoint, Google Drive, and custom sources with RAG pipelines running on your
-own infrastructure), Slack, Microsoft Teams, and SSO support.
+- **Upcoming features** — knowledge base integration (Confluence, Notion,
+  SharePoint, Google Drive, and custom sources with RAG pipelines running on
+  your own infrastructure), Slack, Microsoft Teams, and SSO support.
 
 ## Why open source
 

--- a/docs/about/who-we-are.mdx
+++ b/docs/about/who-we-are.mdx
@@ -64,10 +64,7 @@ the possibility. If we ever need to adjust the license, the goal will be narrow:
 protect the project from extraction by companies that can afford to contribute
 but choose not to, while keeping GOModel fully usable for everyone else.
 
-## How to reach us
+## Links
 
-- **GitHub:** [ENTERPILOT/GOModel](https://github.com/ENTERPILOT/GOModel)
 - **Enterpilot:** [enterpilot.io](https://enterpilot.io)
-
-If you want to contribute, report a bug, or just say hello, open an issue on
-GitHub. We read every one.
+- **README:** [github.com/ENTERPILOT/GOModel](https://github.com/ENTERPILOT/GOModel) — includes a Discord invite link

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -21,7 +21,7 @@
             },
             {
                 "group": "About",
-                "pages": ["about/values", "about/technical-philosophy", "about/benchmarks"]
+                "pages": ["about/who-we-are", "about/values", "about/technical-philosophy", "about/benchmarks"]
             }
         ]
     }


### PR DESCRIPTION
Introduces the people and organization behind GOModel, explains the relationship with Enterpilot, and addresses open-source licensing intentions with references to MongoDB/Elastic/Redis precedents.

https://claude.ai/code/session_01QKDe5a73tpRkmsouevuCNs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Who We Are" page in the About section detailing the project's creator, relationship with Enterpilot, open-source philosophy, licensing stance, and contact/reach information.
  * Updated site navigation to surface the new "Who We Are" page at the start of the About group, ahead of the existing Values page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->