### PR TITLE
Fix half-open circuit breaker retry handling

### DIFF
--- a/internal/llmclient/client.go
+++ b/internal/llmclient/client.go
@@ -238,12 +238,16 @@ func (c *Client) DoRaw(ctx context.Context, req Request) (*Response, error) {
 		}
 	}
 
-	// Check circuit breaker
-	if c.circuitBreaker != nil && !c.circuitBreaker.Allow() {
-		err := core.NewProviderError(c.config.ProviderName, http.StatusServiceUnavailable,
-			"circuit breaker is open - provider temporarily unavailable", nil)
-		callEndHook(http.StatusServiceUnavailable, err)
-		return nil, err
+	halfOpenProbe := false
+	if c.circuitBreaker != nil {
+		allowed, probe := c.circuitBreaker.acquire()
+		if !allowed {
+			err := core.NewProviderError(c.config.ProviderName, http.StatusServiceUnavailable,
+				"circuit breaker is open - provider temporarily unavailable", nil)
+			callEndHook(http.StatusServiceUnavailable, err)
+			return nil, err
+		}
+		halfOpenProbe = probe
 	}
 
 	var lastErr error
@@ -273,6 +277,10 @@ func (c *Client) DoRaw(ctx context.Context, req Request) (*Response, error) {
 			if c.circuitBreaker != nil {
 				c.circuitBreaker.RecordFailure()
 			}
+			if halfOpenProbe {
+				callEndHook(lastStatusCode, lastErr)
+				return nil, lastErr
+			}
 			continue
 		}
 
@@ -283,6 +291,10 @@ func (c *Client) DoRaw(ctx context.Context, req Request) (*Response, error) {
 			}
 			lastErr = core.ParseProviderError(c.config.ProviderName, resp.StatusCode, resp.Body, nil)
 			lastStatusCode = resp.StatusCode
+			if halfOpenProbe {
+				callEndHook(lastStatusCode, lastErr)
+				return nil, lastErr
+			}
 			continue
 		}
 
@@ -622,16 +634,15 @@ func newCircuitBreaker(failureThreshold, successThreshold int, timeout time.Dura
 	}
 }
 
-// Allow checks if a request should be allowed through the circuit breaker.
-// In half-open state, only one request is allowed through at a time to prevent
-// thundering herd when the circuit first transitions from open to half-open.
-func (cb *circuitBreaker) Allow() bool {
+// acquire checks if a request should be allowed through the circuit breaker.
+// The second return value reports whether the caller is the single half-open probe.
+func (cb *circuitBreaker) acquire() (bool, bool) {
 	cb.mu.Lock()
 	defer cb.mu.Unlock()
 
 	switch cb.state {
 	case circuitClosed:
-		return true
+		return true, false
 	case circuitOpen:
 		// Check if timeout has passed
 		if time.Since(cb.lastFailure) > cb.timeout {
@@ -639,7 +650,7 @@ func (cb *circuitBreaker) Allow() bool {
 			cb.successes = 0
 			cb.halfOpenAllowed = true // Allow the first probe request
 		} else {
-			return false
+			return false, false
 		}
 		// Fall through to half-open handling
 		fallthrough
@@ -648,11 +659,17 @@ func (cb *circuitBreaker) Allow() bool {
 		// This prevents thundering herd when transitioning from open
 		if cb.halfOpenAllowed {
 			cb.halfOpenAllowed = false
-			return true
+			return true, true
 		}
-		return false
+		return false, false
 	}
-	return true
+	return true, false
+}
+
+// Allow reports whether any request may proceed.
+func (cb *circuitBreaker) Allow() bool {
+	allowed, _ := cb.acquire()
+	return allowed
 }
 
 // RecordSuccess records a successful request

--- a/internal/llmclient/client_test.go
+++ b/internal/llmclient/client_test.go
@@ -218,6 +218,53 @@ func TestClient_Do_Retries(t *testing.T) {
 	}
 }
 
+func TestClient_Do_RetriesContinueAfterCircuitTrips(t *testing.T) {
+	var attempts int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&attempts, 1)
+		if count < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error":{"message":"temporary failure"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true}`))
+	}))
+	defer server.Close()
+
+	config := DefaultConfig("test", server.URL)
+	config.Retry.MaxRetries = 2
+	config.Retry.InitialBackoff = 10 * time.Millisecond
+	config.Retry.MaxBackoff = 10 * time.Millisecond
+	config.Retry.BackoffFactor = 1
+	config.Retry.JitterFactor = 0
+	config.CircuitBreaker = goconfig.CircuitBreakerConfig{
+		FailureThreshold: 1,
+		SuccessThreshold: 1,
+		Timeout:          time.Minute,
+	}
+	client := New(config, nil)
+
+	var result struct {
+		Success bool `json:"success"`
+	}
+	err := client.Do(context.Background(), Request{
+		Method:   http.MethodGet,
+		Endpoint: "/test",
+	}, &result)
+
+	if err != nil {
+		t.Fatalf("expected retries to continue after circuit trips, got: %v", err)
+	}
+	if !result.Success {
+		t.Fatal("expected success response after retries")
+	}
+	if got := atomic.LoadInt32(&attempts); got != 3 {
+		t.Fatalf("expected request to use full retry budget after circuit trips, got %d attempts", got)
+	}
+}
+
 func TestClient_Do_RetriesExhausted(t *testing.T) {
 	var attempts int32
 
@@ -668,6 +715,82 @@ func TestCircuitBreaker_HalfOpenPreventsThunderingHerd(t *testing.T) {
 	// Most requests should be rejected by the circuit breaker
 	if rejections == 0 && successes == 10 {
 		t.Log("Warning: all requests succeeded, circuit breaker may not have been in half-open state")
+	}
+}
+
+func TestCircuitBreaker_HalfOpenProbeDoesNotRetry(t *testing.T) {
+	var attempts int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":{"message":"temporary failure"}}`))
+	}))
+	defer server.Close()
+
+	config := DefaultConfig("test", server.URL)
+	config.Retry.MaxRetries = 2
+	config.Retry.InitialBackoff = 30 * time.Millisecond
+	config.Retry.MaxBackoff = 30 * time.Millisecond
+	config.Retry.BackoffFactor = 1
+	config.Retry.JitterFactor = 0
+	config.CircuitBreaker = goconfig.CircuitBreakerConfig{
+		FailureThreshold: 1,
+		SuccessThreshold: 1,
+		Timeout:          20 * time.Millisecond,
+	}
+	client := New(config, nil)
+
+	client.circuitBreaker.mu.Lock()
+	client.circuitBreaker.state = circuitOpen
+	client.circuitBreaker.failures = client.circuitBreaker.failureThreshold
+	client.circuitBreaker.successes = 0
+	client.circuitBreaker.lastFailure = time.Now().Add(-client.circuitBreaker.timeout - time.Millisecond)
+	client.circuitBreaker.halfOpenAllowed = true
+	client.circuitBreaker.mu.Unlock()
+
+	err := client.Do(context.Background(), Request{
+		Method:   http.MethodGet,
+		Endpoint: "/test",
+	}, nil)
+	if err == nil {
+		t.Fatal("expected provider error from half-open probe")
+	}
+
+	gatewayErr, ok := err.(*core.GatewayError)
+	if !ok {
+		t.Fatalf("expected GatewayError, got %T", err)
+	}
+	if gatewayErr.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected status %d, got %d", http.StatusServiceUnavailable, gatewayErr.StatusCode)
+	}
+	if strings.Contains(gatewayErr.Message, "circuit breaker is open") {
+		t.Fatalf("expected original upstream error, got circuit breaker error: %s", gatewayErr.Message)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Fatalf("expected exactly 1 upstream attempt in half-open state, got %d", got)
+	}
+	if state := client.circuitBreaker.State(); state != "open" {
+		t.Fatalf("expected circuit to reopen after failed half-open probe, got %q", state)
+	}
+
+	err = client.Do(context.Background(), Request{
+		Method:   http.MethodGet,
+		Endpoint: "/test",
+	}, nil)
+	if err == nil {
+		t.Fatal("expected circuit breaker rejection after failed half-open probe")
+	}
+
+	gatewayErr, ok = err.(*core.GatewayError)
+	if !ok {
+		t.Fatalf("expected GatewayError, got %T", err)
+	}
+	if !strings.Contains(gatewayErr.Message, "circuit breaker is open") {
+		t.Fatalf("expected circuit breaker error after failed half-open probe, got %s", gatewayErr.Message)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Fatalf("expected follow-up request to be blocked without another upstream attempt, got %d attempts", got)
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Request retries now work more reliably during transient service failures, improving overall system resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->