### PR TITLE
Document OpenAI tool-call finish_reason behavior

### DIFF
--- a/internal/providers/openai/openai.go
+++ b/internal/providers/openai/openai.go
@@ -147,13 +147,17 @@ func (p *Provider) ChatCompletion(ctx context.Context, req *core.ChatRequest) (*
 	if err != nil {
 		return nil, err
 	}
+	// OpenAI can return assistant tool_calls with finish_reason="stop" instead of
+	// "tool_calls". Preserve the upstream finish_reason as-is for API parity.
 	if resp.Model == "" {
 		resp.Model = req.Model
 	}
 	return &resp, nil
 }
 
-// StreamChatCompletion returns a raw response body for streaming (caller must close)
+// StreamChatCompletion returns a raw response body for streaming (caller must close).
+// OpenAI can emit tool_calls while the final chunk still carries finish_reason="stop";
+// this provider forwards the upstream SSE stream unchanged for API parity.
 func (p *Provider) StreamChatCompletion(ctx context.Context, req *core.ChatRequest) (io.ReadCloser, error) {
 	streamReq := req.WithStreaming()
 	return p.client.DoStream(ctx, llmclient.Request{


### PR DESCRIPTION
## Summary
- document that OpenAI may return tool calls with `finish_reason: "stop"`
- note that the gateway preserves this upstream behavior for API parity

## Validation
- verified directly against the OpenAI API that chat tool-call responses for `gpt-3.5-turbo` and `gpt-4o-mini` can include tool calls while still returning `finish_reason: "stop"`
- ran the repo commit hooks on this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No user-visible changes in this release. This update includes internal documentation improvements to clarify API behavior related to tool interactions and response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->