### PR TITLE
docs: add agent integration guides

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -13,7 +13,12 @@
             },
             {
                 "group": "Guides",
-                "pages": ["guides/openclaw"]
+                "pages": [
+                    "guides/openclaw",
+                    "guides/claude-code",
+                    "guides/codex",
+                    "guides/opencode-and-other-agents"
+                ]
             },
             {
                 "group": "Advanced",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2,6 +2,10 @@
     "$schema": "https://mintlify.com/docs.json",
     "theme": "maple",
     "name": "GoModel",
+    "logo": {
+        "light": "/logo.svg",
+        "dark": "/logo.svg"
+    },
     "colors": {
         "primary": "#755c3d"
     },

--- a/docs/guides/claude-code.mdx
+++ b/docs/guides/claude-code.mdx
@@ -10,20 +10,6 @@ Flow:
 
 `Claude Code -> GoModel -> Anthropic`
 
-## Validated on March 10, 2026
-
-This guide was validated against:
-
-- a local GoModel instance on `http://localhost:8080`
-- a GoModel branch exposing `/p/{provider}/v1/...`
-- Claude Code `2.1.72`
-
-Local validation confirmed:
-
-- `GET /p/anthropic/v1/models` returned `200 OK`
-- `POST /p/anthropic/v1/messages` returned `200 OK`
-- `claude` returned `ok` when pointed at GoModel
-
 ## Before you start
 
 - Install Claude Code on your machine.
@@ -50,20 +36,6 @@ settings.
   Claude paid plans (Pro, Max, Team, Enterprise) and Claude API Console billing
   are separate. API key usage is billed as API usage.
 </Warning>
-
-## How to avoid API charges from your subscription workflow
-
-If you want Claude Code to use included subscription usage and avoid API key
-billing, keep `ANTHROPIC_API_KEY` unset in your Claude Code shell environment.
-
-Check active auth method in Claude Code with:
-
-```text
-/status
-```
-
-For this GoModel passthrough integration specifically, GoModel still needs an
-upstream `ANTHROPIC_API_KEY`, so Anthropic API billing applies to gateway calls.
 
 ## 1. Run GoModel
 
@@ -154,3 +126,17 @@ can keep following your GoModel traffic and usage.
 - Claude Help: [Managing API key environment variables in Claude Code](https://support.claude.com/en/articles/12304248-managing-api-key-environment-variables-in-claude-code)
 - Claude Help: [Paid Claude plans vs API Console billing](https://support.claude.com/en/articles/9876003-i-have-a-paid-claude-subscription-pro-max-team-or-enterprise-plans-why-do-i-have-to-pay-separately-to-use-the-claude-api-and-console)
 - Claude API docs: [API overview (keys from Console account settings)](https://docs.anthropic.com/en/api/getting-started)
+
+## Validated on March 10, 2026
+
+This guide was validated against:
+
+- a local GoModel instance on `http://localhost:8080`
+- a GoModel branch exposing `/p/{provider}/v1/...`
+- Claude Code `2.1.72`
+
+Local validation confirmed:
+
+- `GET /p/anthropic/v1/models` returned `200 OK`
+- `POST /p/anthropic/v1/messages` returned `200 OK`
+- `claude` returned `ok` when pointed at GoModel

--- a/docs/guides/claude-code.mdx
+++ b/docs/guides/claude-code.mdx
@@ -1,106 +1,125 @@
 ---
 title: "Using GoModel with Claude Code"
-description: "Validated Claude Code setup for GoModel, including Anthropic passthrough paths, audit visibility, and current usage-tracking limitations."
+description: "Step-by-step guide for routing Claude Code through GoModel with Anthropic passthrough."
 ---
 
-## Tested on March 10, 2026
+GoModel can sit in front of Claude Code so every request goes through your own
+gateway first.
+
+Flow:
+
+`Claude Code -> GoModel -> Anthropic`
+
+## Validated on March 10, 2026
 
 This guide was validated against:
 
 - a local GoModel instance on `http://localhost:8080`
-- a passthrough branch exposing `/p/{provider}/...`
+- a GoModel branch exposing `/p/{provider}/v1/...`
 - Claude Code `2.1.72`
 
-## Short Answer
+Local validation confirmed:
 
-Claude Code works on the tested GoModel instance when you point it at Anthropic passthrough:
+- `GET /p/anthropic/v1/models` returned `200 OK`
+- `POST /p/anthropic/v1/messages` returned `200 OK`
+- `claude` returned `ok` when pointed at GoModel
+
+## Before you start
+
+- Install Claude Code on your machine.
+- Choose a GoModel master key, for example `change-me`.
+- Make sure GoModel has an Anthropic upstream credential.
+
+<Note>
+  Claude Code can be routed through GoModel whether or not you personally use a
+  Claude Code subscription. For gateway mode, Claude Code talks to GoModel with
+  `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN`. GoModel still needs its own
+  `ANTHROPIC_API_KEY` to reach Anthropic upstream.
+</Note>
+
+## 1. Run GoModel
+
+Start GoModel with a master key and an Anthropic provider key:
 
 ```bash
-export ANTHROPIC_BASE_URL=http://localhost:8080/p/anthropic
-export ANTHROPIC_AUTH_TOKEN="$GOMODEL_MASTER_KEY"
+docker run --rm -p 8080:8080 \
+  -e GOMODEL_MASTER_KEY="change-me" \
+  -e ANTHROPIC_API_KEY="sk-ant-..." \
+  enterpilot/gomodel
 ```
 
-Claude Code then calls:
+## 2. Confirm Anthropic passthrough with curl
 
-- `GET /p/anthropic/v1/models`
-- `POST /p/anthropic/v1/messages`
-
-Both paths returned `200 OK` in local testing.
-
-## What We Validated
-
-### Raw passthrough with curl
-
-These both succeeded:
+Check that the Anthropic passthrough models endpoint responds:
 
 ```bash
-curl -s http://localhost:8080/p/anthropic/v1/models
+curl -s http://localhost:8080/p/anthropic/v1/models \
+  -H "Authorization: Bearer change-me"
 ```
+
+Then send one small test message:
 
 ```bash
 curl -s http://localhost:8080/p/anthropic/v1/messages \
+  -H "Authorization: Bearer change-me" \
   -H "Content-Type: application/json" \
   -H "anthropic-version: 2023-06-01" \
-  -d '{"model":"claude-3-haiku-20240307","max_tokens":16,"messages":[{"role":"user","content":"Reply with exactly: ok"}]}'
+  -d '{
+    "model": "claude-3-haiku-20240307",
+    "max_tokens": 16,
+    "messages": [
+      {
+        "role": "user",
+        "content": "Reply with exactly ok"
+      }
+    ]
+  }'
 ```
 
-### Real Claude Code CLI
+If the gateway is wired correctly, the response will contain `ok`.
 
-This also worked:
+## 3. Configure Claude Code to use GoModel
+
+Point Claude Code at GoModel's Anthropic passthrough:
 
 ```bash
-ANTHROPIC_BASE_URL=http://localhost:8080/p/anthropic \
-ANTHROPIC_AUTH_TOKEN=dummy \
-CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1 \
+export ANTHROPIC_BASE_URL=http://localhost:8080/p/anthropic
+export ANTHROPIC_AUTH_TOKEN=change-me
+export CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1
+```
+
+If GoModel is not running on your local machine, replace `localhost:8080` with
+the correct host and port.
+
+## 4. Run a Claude Code test prompt
+
+```bash
 claude -p --output-format text --model claude-3-haiku-20240307 \
   'Reply with exactly ok and no punctuation.'
 ```
 
-The response was `ok`.
+The validated result was:
 
-## Authentication
-
-If your gateway expects Bearer auth, prefer:
-
-```bash
-export ANTHROPIC_AUTH_TOKEN="$GOMODEL_MASTER_KEY"
+```text
+ok
 ```
 
-If your gateway accepts native Anthropic-style API key headers, you can also try:
+## 5. Check the traffic in GoModel
 
-```bash
-export ANTHROPIC_API_KEY="$GOMODEL_MASTER_KEY"
-```
+Open the GoModel dashboard audit logs:
 
-## Tracking and Guardrails
+[http://localhost:8080/admin/dashboard/audit](http://localhost:8080/admin/dashboard/audit)
 
-What local testing showed:
+This is the easiest place to confirm that Claude Code is reaching GoModel and
+to inspect the full request and response trail. From the same dashboard, you
+can keep following your GoModel traffic and usage.
 
-- Claude Code passthrough traffic appeared in `GET /admin/api/v1/audit/log`
-- the same traffic did **not** increment `GET /admin/api/v1/usage/summary`
-- the same traffic did **not** appear in `GET /admin/api/v1/usage/log`
+## Current status
 
-So Claude Code is now operational through GoModel passthrough, but on the tested branch it is still **audit-visible, not usage-accounted**.
-
-If you need GoModel platform features such as:
-
-- token and cost tracking
-- usage reports
-- stronger guardrail coverage
-
-prefer clients that can use GoModel's standard `/v1/*` API instead of provider passthrough.
-
-This mirrors Anthropic's own Claude Code gateway guidance for LiteLLM: the unified endpoint is the recommended path, and provider pass-through is the fallback.
-
-## Admin Endpoints
-
-Use these to inspect Claude Code traffic:
-
-```bash
-curl -s 'http://localhost:8080/admin/api/v1/audit/log?days=1&limit=20&offset=0'
-curl -s 'http://localhost:8080/admin/api/v1/usage/log?days=1&limit=20&offset=0'
-curl -s http://localhost:8080/admin/api/v1/usage/summary
-```
+- Claude Code works today through `http://localhost:8080/p/anthropic`
+- the validated Claude Code flow used Anthropic-native `/v1/messages`
+- GoModel still needs its own Anthropic upstream key even if you already use a
+  Claude Code subscription
 
 ## References
 

--- a/docs/guides/claude-code.mdx
+++ b/docs/guides/claude-code.mdx
@@ -1,0 +1,108 @@
+---
+title: "Using GoModel with Claude Code"
+description: "Validated Claude Code setup for GoModel, including Anthropic passthrough paths, audit visibility, and current usage-tracking limitations."
+---
+
+## Tested on March 10, 2026
+
+This guide was validated against:
+
+- a local GoModel instance on `http://localhost:8080`
+- a passthrough branch exposing `/p/{provider}/...`
+- Claude Code `2.1.72`
+
+## Short Answer
+
+Claude Code works on the tested GoModel instance when you point it at Anthropic passthrough:
+
+```bash
+export ANTHROPIC_BASE_URL=http://localhost:8080/p/anthropic
+export ANTHROPIC_AUTH_TOKEN="$GOMODEL_MASTER_KEY"
+```
+
+Claude Code then calls:
+
+- `GET /p/anthropic/v1/models`
+- `POST /p/anthropic/v1/messages`
+
+Both paths returned `200 OK` in local testing.
+
+## What We Validated
+
+### Raw passthrough with curl
+
+These both succeeded:
+
+```bash
+curl -s http://localhost:8080/p/anthropic/v1/models
+```
+
+```bash
+curl -s http://localhost:8080/p/anthropic/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{"model":"claude-3-haiku-20240307","max_tokens":16,"messages":[{"role":"user","content":"Reply with exactly: ok"}]}'
+```
+
+### Real Claude Code CLI
+
+This also worked:
+
+```bash
+ANTHROPIC_BASE_URL=http://localhost:8080/p/anthropic \
+ANTHROPIC_AUTH_TOKEN=dummy \
+CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1 \
+claude -p --output-format text --model claude-3-haiku-20240307 \
+  'Reply with exactly ok and no punctuation.'
+```
+
+The response was `ok`.
+
+## Authentication
+
+If your gateway expects Bearer auth, prefer:
+
+```bash
+export ANTHROPIC_AUTH_TOKEN="$GOMODEL_MASTER_KEY"
+```
+
+If your gateway accepts native Anthropic-style API key headers, you can also try:
+
+```bash
+export ANTHROPIC_API_KEY="$GOMODEL_MASTER_KEY"
+```
+
+## Tracking and Guardrails
+
+What local testing showed:
+
+- Claude Code passthrough traffic appeared in `GET /admin/api/v1/audit/log`
+- the same traffic did **not** increment `GET /admin/api/v1/usage/summary`
+- the same traffic did **not** appear in `GET /admin/api/v1/usage/log`
+
+So Claude Code is now operational through GoModel passthrough, but on the tested branch it is still **audit-visible, not usage-accounted**.
+
+If you need GoModel platform features such as:
+
+- token and cost tracking
+- usage reports
+- stronger guardrail coverage
+
+prefer clients that can use GoModel's standard `/v1/*` API instead of provider passthrough.
+
+This mirrors Anthropic's own Claude Code gateway guidance for LiteLLM: the unified endpoint is the recommended path, and provider pass-through is the fallback.
+
+## Admin Endpoints
+
+Use these to inspect Claude Code traffic:
+
+```bash
+curl -s 'http://localhost:8080/admin/api/v1/audit/log?days=1&limit=20&offset=0'
+curl -s 'http://localhost:8080/admin/api/v1/usage/log?days=1&limit=20&offset=0'
+curl -s http://localhost:8080/admin/api/v1/usage/summary
+```
+
+## References
+
+- Anthropic Claude Code gateway docs: [LLM gateway](https://code.claude.com/docs/en/llm-gateway)
+- Anthropic Claude Code settings: [Settings](https://code.claude.com/docs/en/settings)

--- a/docs/guides/claude-code.mdx
+++ b/docs/guides/claude-code.mdx
@@ -37,6 +37,34 @@ Local validation confirmed:
   `ANTHROPIC_API_KEY` to reach Anthropic upstream.
 </Note>
 
+## How to get `ANTHROPIC_API_KEY`
+
+1. Open the Claude Console and sign in to your API account.
+2. Go to account settings in Console, then create an API key.
+3. Copy the key once and set it for GoModel as `ANTHROPIC_API_KEY`.
+
+Anthropic's API docs state that API keys are created in Console account
+settings.
+
+<Warning>
+  Claude paid plans (Pro, Max, Team, Enterprise) and Claude API Console billing
+  are separate. API key usage is billed as API usage.
+</Warning>
+
+## How to avoid API charges from your subscription workflow
+
+If you want Claude Code to use included subscription usage and avoid API key
+billing, keep `ANTHROPIC_API_KEY` unset in your Claude Code shell environment.
+
+Check active auth method in Claude Code with:
+
+```text
+/status
+```
+
+For this GoModel passthrough integration specifically, GoModel still needs an
+upstream `ANTHROPIC_API_KEY`, so Anthropic API billing applies to gateway calls.
+
 ## 1. Run GoModel
 
 Start GoModel with a master key and an Anthropic provider key:
@@ -88,6 +116,11 @@ export ANTHROPIC_AUTH_TOKEN=change-me
 export CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1
 ```
 
+Short Claude Code doc summary: for gateway mode, set `ANTHROPIC_BASE_URL` to
+your gateway URL and `ANTHROPIC_AUTH_TOKEN` to your gateway token, then run
+Claude Code normally. See the official guide:
+[Claude Code LLM gateway docs](https://code.claude.com/docs/en/llm-gateway).
+
 If GoModel is not running on your local machine, replace `localhost:8080` with
 the correct host and port.
 
@@ -114,14 +147,10 @@ This is the easiest place to confirm that Claude Code is reaching GoModel and
 to inspect the full request and response trail. From the same dashboard, you
 can keep following your GoModel traffic and usage.
 
-## Current status
-
-- Claude Code works today through `http://localhost:8080/p/anthropic`
-- the validated Claude Code flow used Anthropic-native `/v1/messages`
-- GoModel still needs its own Anthropic upstream key even if you already use a
-  Claude Code subscription
-
 ## References
 
 - Anthropic Claude Code gateway docs: [LLM gateway](https://code.claude.com/docs/en/llm-gateway)
 - Anthropic Claude Code settings: [Settings](https://code.claude.com/docs/en/settings)
+- Claude Help: [Managing API key environment variables in Claude Code](https://support.claude.com/en/articles/12304248-managing-api-key-environment-variables-in-claude-code)
+- Claude Help: [Paid Claude plans vs API Console billing](https://support.claude.com/en/articles/9876003-i-have-a-paid-claude-subscription-pro-max-team-or-enterprise-plans-why-do-i-have-to-pay-separately-to-use-the-claude-api-and-console)
+- Claude API docs: [API overview (keys from Console account settings)](https://docs.anthropic.com/en/api/getting-started)

--- a/docs/guides/codex.mdx
+++ b/docs/guides/codex.mdx
@@ -10,20 +10,6 @@ Flow:
 
 `Codex -> GoModel -> OpenAI`
 
-## Validated on March 10, 2026
-
-This guide was validated against:
-
-- a local GoModel instance on `http://localhost:8080`
-- Codex CLI `0.113.0`
-
-Local validation confirmed:
-
-- `POST /v1/responses` returned `200 OK` with `curl`
-- Codex sent requests to `POST /v1/responses`
-- the tested GoModel instance does not yet accept Codex's `Content-Encoding: zstd`
-  request bodies
-
 ## Before you start
 
 - Install Codex on your machine.
@@ -43,8 +29,12 @@ docker run --rm -p 8080:8080 \
 
 ## 2. Confirm the Responses API with curl
 
-Before testing Codex itself, verify that GoModel answers a normal Responses API
-request:
+Before testing Codex itself, you can optionally verify that GoModel answers a
+normal Responses API request:
+
+This step is optional. If you are sure you have configured a valid
+`OPENAI_API_KEY` in GoModel, you can skip it and go straight to
+[step 3](#3-configure-codex-to-use-gomodel).
 
 ```bash
 curl -s http://localhost:8080/v1/responses \
@@ -81,17 +71,8 @@ wire_api = "responses"
 ## 4. Run a Codex test prompt
 
 ```bash
-codex exec -m gpt-4.1-mini \
+codex exec -m gpt-4.1-mini --disable enable_request_compression \
   'Reply with exactly ok and no punctuation.'
-```
-
-In the March 10, 2026 validation, Codex reached the correct GoModel endpoint
-but the request failed because Codex compressed the body with `zstd`.
-
-The observed error from GoModel was:
-
-```json
-{"error":{"message":"invalid request body: invalid character '(' looking for beginning of value","type":"invalid_request_error"}}
 ```
 
 ## 5. Check the traffic in GoModel
@@ -114,3 +95,35 @@ and usage as the integration matures.
 ## References
 
 - OpenAI Codex discussion: [Deprecating `chat/completions` support in Codex](https://github.com/openai/codex/discussions/7782)
+
+## Validated on March 10, 2026
+
+This guide was validated against:
+
+- a local GoModel instance on `http://localhost:8080`
+- Codex CLI `0.113.0`
+
+Local validation confirmed:
+
+- `POST /v1/responses` returned `200 OK` with `curl`
+- Codex sent requests to `POST /v1/responses`
+- the tested GoModel instance does not yet accept Codex's `Content-Encoding: zstd`
+  request bodies
+
+## Known issues
+
+In the March 10, 2026 validation, Codex reached the correct GoModel endpoint,
+but the request failed because Codex compressed the body with `zstd`.
+
+The observed error from GoModel was:
+
+```json
+{"error":{"message":"invalid request body: invalid character '(' looking for beginning of value","type":"invalid_request_error"}}
+```
+
+Workaround: disable request compression in Codex CLI:
+
+```bash
+codex exec -m gpt-4.1-mini --disable enable_request_compression \
+  'Reply with exactly ok and no punctuation.'
+```

--- a/docs/guides/codex.mdx
+++ b/docs/guides/codex.mdx
@@ -1,0 +1,113 @@
+---
+title: "Using GoModel with Codex"
+description: "Validated Codex findings for GoModel, including the correct Responses API target and the current zstd request-body blocker."
+---
+
+## Tested on March 10, 2026
+
+This guide was validated against:
+
+- a local GoModel instance on `http://localhost:8080`
+- Codex CLI `0.113.0`
+
+## Short Answer
+
+Codex is **not directly compatible yet** with the tested GoModel instance, but the integration path is clear:
+
+- target GoModel standard `/v1/*`, not passthrough
+- use the OpenAI Responses API
+- add request decompression support for `Content-Encoding: zstd`
+
+The intended target is:
+
+```bash
+export OPENAI_BASE_URL=http://localhost:8080/v1
+export OPENAI_API_KEY="$GOMODEL_MASTER_KEY"
+```
+
+## What We Validated
+
+### GoModel standard Responses API works
+
+This worked with `curl`:
+
+```bash
+curl -s http://localhost:8080/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4.1-mini","input":"Reply with exactly: ok","max_output_tokens":16}'
+```
+
+That request showed up in:
+
+- `GET /admin/api/v1/usage/summary`
+- `GET /admin/api/v1/usage/log`
+- `GET /admin/api/v1/audit/log`
+
+So `/v1/responses` is the correct GoModel surface for Codex if you want usage tracking, cost tracking, audit logs, and guardrails.
+
+### Real Codex CLI call
+
+This is the command shape that Codex used:
+
+```bash
+OPENAI_BASE_URL=http://localhost:8080/v1 \
+OPENAI_API_KEY=dummy \
+codex exec -m gpt-4.1-mini 'Reply with exactly ok and no punctuation.'
+```
+
+In local testing, Codex correctly sent:
+
+- `POST /v1/responses`
+
+But it also sent:
+
+- `Content-Encoding: zstd`
+
+The tested GoModel instance tried to parse the compressed bytes as raw JSON and returned:
+
+```json
+{"error":{"message":"invalid request body: invalid character '(' looking for beginning of value","type":"invalid_request_error"}}
+```
+
+## What Needs To Change
+
+One of these needs to exist before Codex will work cleanly:
+
+- GoModel support for request-body decompression when `Content-Encoding: zstd` is present
+- a front proxy that decompresses requests before forwarding to GoModel
+- a confirmed Codex configuration that truly disables request compression
+
+## Recommended Codex Provider Config
+
+Codex is moving to the Responses API. If you define a custom provider, it should look like this:
+
+```toml
+[model_providers.gomodel]
+name = "GoModel"
+base_url = "http://localhost:8080/v1"
+env_key = "OPENAI_API_KEY"
+wire_api = "responses"
+```
+
+## Why Standard `/v1` Matters
+
+On the tested instance:
+
+- `/v1/responses` produced usage records and audit records
+- passthrough traffic did not consistently produce usage records
+
+So Codex should integrate against standard GoModel `/v1/*`, not `/p/openai/...`.
+
+## Admin Endpoints
+
+Use these after testing Codex:
+
+```bash
+curl -s http://localhost:8080/admin/api/v1/usage/summary
+curl -s 'http://localhost:8080/admin/api/v1/usage/log?days=1&limit=20&offset=0'
+curl -s 'http://localhost:8080/admin/api/v1/audit/log?days=1&limit=20&offset=0'
+```
+
+## References
+
+- OpenAI Codex provider discussion: [Deprecating `chat/completions` support in Codex](https://github.com/openai/codex/discussions/7782)

--- a/docs/guides/codex.mdx
+++ b/docs/guides/codex.mdx
@@ -1,85 +1,74 @@
 ---
 title: "Using GoModel with Codex"
-description: "Validated Codex findings for GoModel, including the correct Responses API target and the current zstd request-body blocker."
+description: "Step-by-step guide for trying Codex with GoModel and understanding the current limitation."
 ---
 
-## Tested on March 10, 2026
+GoModel is a good fit for Codex because Codex already targets the OpenAI
+Responses API.
+
+Flow:
+
+`Codex -> GoModel -> OpenAI`
+
+## Validated on March 10, 2026
 
 This guide was validated against:
 
 - a local GoModel instance on `http://localhost:8080`
 - Codex CLI `0.113.0`
 
-## Short Answer
+Local validation confirmed:
 
-Codex is **not directly compatible yet** with the tested GoModel instance, but the integration path is clear:
+- `POST /v1/responses` returned `200 OK` with `curl`
+- Codex sent requests to `POST /v1/responses`
+- the tested GoModel instance does not yet accept Codex's `Content-Encoding: zstd`
+  request bodies
 
-- target GoModel standard `/v1/*`, not passthrough
-- use the OpenAI Responses API
-- add request decompression support for `Content-Encoding: zstd`
+## Before you start
 
-The intended target is:
+- Install Codex on your machine.
+- Choose a GoModel master key, for example `change-me`.
+- Make sure GoModel has the upstream provider key for the models you want to use.
+
+## 1. Run GoModel
+
+Start GoModel with a master key and an OpenAI provider key:
 
 ```bash
-export OPENAI_BASE_URL=http://localhost:8080/v1
-export OPENAI_API_KEY="$GOMODEL_MASTER_KEY"
+docker run --rm -p 8080:8080 \
+  -e GOMODEL_MASTER_KEY="change-me" \
+  -e OPENAI_API_KEY="sk-..." \
+  enterpilot/gomodel
 ```
 
-## What We Validated
+## 2. Confirm the Responses API with curl
 
-### GoModel standard Responses API works
-
-This worked with `curl`:
+Before testing Codex itself, verify that GoModel answers a normal Responses API
+request:
 
 ```bash
 curl -s http://localhost:8080/v1/responses \
+  -H "Authorization: Bearer change-me" \
   -H "Content-Type: application/json" \
-  -d '{"model":"gpt-4.1-mini","input":"Reply with exactly: ok","max_output_tokens":16}'
+  -d '{
+    "model": "gpt-4.1-mini",
+    "input": "Reply with exactly ok",
+    "max_output_tokens": 16
+  }'
 ```
 
-That request showed up in:
+If the gateway is wired correctly, the response will contain `ok`.
 
-- `GET /admin/api/v1/usage/summary`
-- `GET /admin/api/v1/usage/log`
-- `GET /admin/api/v1/audit/log`
+## 3. Configure Codex to use GoModel
 
-So `/v1/responses` is the correct GoModel surface for Codex if you want usage tracking, cost tracking, audit logs, and guardrails.
-
-### Real Codex CLI call
-
-This is the command shape that Codex used:
+Point Codex at GoModel's standard OpenAI-compatible API:
 
 ```bash
-OPENAI_BASE_URL=http://localhost:8080/v1 \
-OPENAI_API_KEY=dummy \
-codex exec -m gpt-4.1-mini 'Reply with exactly ok and no punctuation.'
+export OPENAI_BASE_URL=http://localhost:8080/v1
+export OPENAI_API_KEY=change-me
 ```
 
-In local testing, Codex correctly sent:
-
-- `POST /v1/responses`
-
-But it also sent:
-
-- `Content-Encoding: zstd`
-
-The tested GoModel instance tried to parse the compressed bytes as raw JSON and returned:
-
-```json
-{"error":{"message":"invalid request body: invalid character '(' looking for beginning of value","type":"invalid_request_error"}}
-```
-
-## What Needs To Change
-
-One of these needs to exist before Codex will work cleanly:
-
-- GoModel support for request-body decompression when `Content-Encoding: zstd` is present
-- a front proxy that decompresses requests before forwarding to GoModel
-- a confirmed Codex configuration that truly disables request compression
-
-## Recommended Codex Provider Config
-
-Codex is moving to the Responses API. If you define a custom provider, it should look like this:
+If you keep a Codex provider config file, use a Responses-based provider:
 
 ```toml
 [model_providers.gomodel]
@@ -89,25 +78,39 @@ env_key = "OPENAI_API_KEY"
 wire_api = "responses"
 ```
 
-## Why Standard `/v1` Matters
-
-On the tested instance:
-
-- `/v1/responses` produced usage records and audit records
-- passthrough traffic did not consistently produce usage records
-
-So Codex should integrate against standard GoModel `/v1/*`, not `/p/openai/...`.
-
-## Admin Endpoints
-
-Use these after testing Codex:
+## 4. Run a Codex test prompt
 
 ```bash
-curl -s http://localhost:8080/admin/api/v1/usage/summary
-curl -s 'http://localhost:8080/admin/api/v1/usage/log?days=1&limit=20&offset=0'
-curl -s 'http://localhost:8080/admin/api/v1/audit/log?days=1&limit=20&offset=0'
+codex exec -m gpt-4.1-mini \
+  'Reply with exactly ok and no punctuation.'
 ```
+
+In the March 10, 2026 validation, Codex reached the correct GoModel endpoint
+but the request failed because Codex compressed the body with `zstd`.
+
+The observed error from GoModel was:
+
+```json
+{"error":{"message":"invalid request body: invalid character '(' looking for beginning of value","type":"invalid_request_error"}}
+```
+
+## 5. Check the traffic in GoModel
+
+Open the GoModel dashboard audit logs:
+
+[http://localhost:8080/admin/dashboard/audit](http://localhost:8080/admin/dashboard/audit)
+
+This lets you confirm that Codex is reaching GoModel even before full support is
+finished. From the same dashboard, you can keep following your GoModel traffic
+and usage as the integration matures.
+
+## Current status
+
+- the target integration path is correct: standard `http://localhost:8080/v1`
+- Codex already uses `POST /v1/responses`, which is what GoModel should support
+- the missing piece on the tested GoModel instance is request decompression for
+  `Content-Encoding: zstd`
 
 ## References
 
-- OpenAI Codex provider discussion: [Deprecating `chat/completions` support in Codex](https://github.com/openai/codex/discussions/7782)
+- OpenAI Codex discussion: [Deprecating `chat/completions` support in Codex](https://github.com/openai/codex/discussions/7782)

--- a/docs/guides/opencode-and-other-agents.mdx
+++ b/docs/guides/opencode-and-other-agents.mdx
@@ -1,9 +1,16 @@
 ---
-title: "Using GoModel with OpenCode and Other OpenAI-Compatible Agents"
-description: "Validated OpenCode setup for GoModel and implementation notes for other OpenAI-compatible coding agents such as Cline, Roo Code, and Kilo Code."
+title: "Using GoModel with OpenCode, Cline, Roo Code, and Kilo Code"
+description: "Step-by-step guide for OpenAI-compatible coding agents with GoModel."
 ---
 
-## Tested on March 10, 2026
+Most coding agents outside Claude Code are easiest to connect to GoModel
+through the standard OpenAI-compatible API.
+
+Flow:
+
+`OpenCode / Cline / Roo Code / Kilo Code -> GoModel -> your upstream providers`
+
+## Validated on March 10, 2026
 
 This guide combines:
 
@@ -11,28 +18,60 @@ This guide combines:
 - local validation with OpenCode `1.1.36`
 - official documentation for Cline, Roo Code, and Kilo Code
 
-## Short Answer
+Local validation confirmed:
 
-| Client | Status | Best target |
-| --- | --- | --- |
-| OpenCode | Validated locally | `http://localhost:8080/v1` |
-| Cline | Docs-backed, not locally executed here | `http://localhost:8080/v1` |
-| Roo Code | Docs-backed, not locally executed here | `http://localhost:8080/v1` |
-| Kilo Code | Docs-backed, not locally executed here | `http://localhost:8080/v1` or full endpoint URL |
+- OpenCode worked against `http://localhost:8080/v1`
+- the validated OpenCode request used `POST /v1/chat/completions`
+- GoModel dashboard audit logs showed the OpenCode traffic immediately
 
-The important pattern is:
+## Before you start
 
-- these clients are generally **OpenAI-compatible**, not provider-passthrough clients
-- that makes them a better fit for GoModel standard `/v1/*`
-- standard `/v1/*` is where GoModel usage tracking and audit logging worked in local testing
+- Choose a GoModel master key, for example `change-me`.
+- Start GoModel with at least one upstream provider key.
+- Use GoModel standard `http://localhost:8080/v1` unless your client
+  specifically requires a full endpoint URL.
 
-## OpenCode
+## 1. Run GoModel
 
-### What We Validated
+Start GoModel with a master key and at least one upstream provider:
 
-OpenCode worked against GoModel with a custom OpenAI-compatible provider configuration.
+```bash
+docker run --rm -p 8080:8080 \
+  -e GOMODEL_MASTER_KEY="change-me" \
+  -e OPENAI_API_KEY="sk-..." \
+  enterpilot/gomodel
+```
 
-This temporary `opencode.json` worked in local testing:
+<Note>
+  You can swap `OPENAI_API_KEY` for another provider key if that is what your
+  target models use. The important part is that GoModel has at least one
+  upstream provider configured.
+</Note>
+
+## 2. Confirm the OpenAI-compatible API with curl
+
+```bash
+curl -s http://localhost:8080/v1/chat/completions \
+  -H "Authorization: Bearer change-me" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4.1-mini",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Reply with exactly ok"
+      }
+    ]
+  }'
+```
+
+If the gateway is wired correctly, the response will contain `ok`.
+
+## 3. Configure your coding agent
+
+### OpenCode
+
+Create an `opencode.json` file with a GoModel provider:
 
 ```json
 {
@@ -59,112 +98,91 @@ This temporary `opencode.json` worked in local testing:
 }
 ```
 
-Then:
+Then export the GoModel key:
 
 ```bash
-export OPENAI_API_KEY="$GOMODEL_MASTER_KEY"
-
-opencode run -m gomodel/gpt-4.1-mini \
-  'Reply with exactly ok and no punctuation.'
+export OPENAI_API_KEY=change-me
 ```
 
-returned `ok`.
+### Cline
 
-### What Endpoint OpenCode Used
-
-OpenCode hit:
-
-- `POST /v1/chat/completions`
-
-not `/v1/responses`.
-
-That is still a good fit for GoModel because local testing showed:
-
-- audit logging worked
-- usage tracking worked
-- usage summary incremented
-
-The validated OpenCode request also sent a very large system prompt and tool schema, which produced a much larger token count than the user prompt alone. That is exactly the kind of agent behavior GoModel usage tracking helps developers understand.
-
-## Cline
-
-Cline's official docs describe an **OpenAI Compatible** provider mode with these fields:
-
-- Base URL
-- API Key
-- Model ID
-
-For GoModel, the intended setup is:
+In Cline, choose:
 
 - API Provider: `OpenAI Compatible`
 - Base URL: `http://localhost:8080/v1`
-- API Key: `GOMODEL_MASTER_KEY`
-- Model: any GoModel-served OpenAI-compatible model
+- API Key: `change-me`
+- Model ID: a model returned by `GET /v1/models`
 
-Because Cline is OpenAI-compatible rather than Anthropic-native, it should target GoModel standard `/v1/*`, not passthrough.
+### Roo Code
 
-## Roo Code
-
-Roo Code also has an **OpenAI Compatible** provider mode with:
-
-- Base URL
-- API Key
-- Model ID
-
-For GoModel, the intended setup is the same:
+In Roo Code, choose:
 
 - API Provider: `OpenAI Compatible`
 - Base URL: `http://localhost:8080/v1`
-- API Key: `GOMODEL_MASTER_KEY`
-- Model: a GoModel-served model
+- API Key: `change-me`
+- Model ID: a model returned by `GET /v1/models`
 
-Important: Roo Code's docs explicitly require **native tool calling** for the selected model/provider path. If you use Roo Code, choose models and provider paths that support OpenAI-compatible tool calling well.
+<Note>
+  Roo Code requires native tool calling. Choose a model and provider path that
+  support OpenAI-compatible tool calling.
+</Note>
 
-## Kilo Code
+### Kilo Code
 
-Kilo Code's docs also support an **OpenAI Compatible** provider mode with:
+In Kilo Code, choose:
 
-- Base URL
-- API Key
-- Model ID
+- API Provider: `OpenAI Compatible`
+- Base URL: `http://localhost:8080/v1`
+- API Key: `change-me`
+- Model ID: a model returned by `GET /v1/models`
 
-Kilo Code adds one useful detail: it supports **full endpoint URLs** in the Base URL field.
-
-That means both of these are viable:
-
-```text
-http://localhost:8080/v1
-```
+Kilo Code also supports a full endpoint URL if you need it:
 
 ```text
 http://localhost:8080/v1/chat/completions
 ```
 
-In most cases, prefer the simpler base URL:
+Start with the simpler base URL first and only switch to a full endpoint URL if
+your setup requires it.
 
-```text
-http://localhost:8080/v1
-```
+## 4. Run a test prompt
 
-## Recommendation
-
-Use this decision rule:
-
-1. If the client supports OpenAI-compatible configuration, point it at GoModel standard `/v1/*`
-2. If the client specifically speaks Anthropic native wire format, use `/p/anthropic/...`
-3. If you care about usage tracking, cost tracking, audit logs, and guardrails, prefer standard `/v1/*`
-
-For OpenCode, Cline, Roo Code, and Kilo Code, standard `/v1/*` is the right first choice.
-
-## Admin Endpoints
-
-After testing these clients, inspect:
+For OpenCode, this validated command worked:
 
 ```bash
-curl -s http://localhost:8080/admin/api/v1/usage/summary
-curl -s 'http://localhost:8080/admin/api/v1/usage/log?days=1&limit=20&offset=0'
-curl -s 'http://localhost:8080/admin/api/v1/audit/log?days=1&limit=20&offset=0'
+opencode run -m gomodel/gpt-4.1-mini \
+  'Reply with exactly ok and no punctuation.'
 ```
+
+The validated result was:
+
+```text
+ok
+```
+
+For Cline, Roo Code, and Kilo Code, save the provider settings above and send a
+small prompt such as:
+
+```text
+Reply with exactly ok and no punctuation.
+```
+
+## 5. Check the traffic in GoModel
+
+Open the GoModel dashboard audit logs:
+
+[http://localhost:8080/admin/dashboard/audit](http://localhost:8080/admin/dashboard/audit)
+
+This is the quickest way to confirm that your coding agent is reaching GoModel
+and to inspect each interaction. From the same dashboard, you can keep
+following your GoModel traffic and usage.
+
+## Current status
+
+- OpenCode was validated locally and worked against standard `http://localhost:8080/v1`
+- Cline, Roo Code, and Kilo Code follow the same OpenAI-compatible setup model
+- Roo Code needs native tool calling support from the selected model
+- Kilo Code can use either a base URL or a full endpoint URL
 
 ## References
 

--- a/docs/guides/opencode-and-other-agents.mdx
+++ b/docs/guides/opencode-and-other-agents.mdx
@@ -10,20 +10,6 @@ Flow:
 
 `OpenCode / Cline / Roo Code / Kilo Code -> GoModel -> your upstream providers`
 
-## Validated on March 10, 2026
-
-This guide combines:
-
-- local validation against a GoModel instance on `http://localhost:8080`
-- local validation with OpenCode `1.1.36`
-- official documentation for Cline, Roo Code, and Kilo Code
-
-Local validation confirmed:
-
-- OpenCode worked against `http://localhost:8080/v1`
-- the validated OpenCode request used `POST /v1/chat/completions`
-- GoModel dashboard audit logs showed the OpenCode traffic immediately
-
 ## Before you start
 
 - Choose a GoModel master key, for example `change-me`.
@@ -190,3 +176,17 @@ following your GoModel traffic and usage.
 - Cline OpenAI-compatible provider docs: [OpenAI Compatible](https://docs.cline.bot/provider-config/openai-compatible)
 - Roo Code OpenAI-compatible provider docs: [OpenAI Compatible](https://docs.roocode.com/providers/openai-compatible)
 - Kilo Code OpenAI-compatible provider docs: [OpenAI Compatible](https://kilo.ai/docs/providers/openai-compatible)
+
+## Validated on March 10, 2026
+
+This guide combines:
+
+- local validation against a GoModel instance on `http://localhost:8080`
+- local validation with OpenCode `1.1.36`
+- official documentation for Cline, Roo Code, and Kilo Code
+
+Local validation confirmed:
+
+- OpenCode worked against `http://localhost:8080/v1`
+- the validated OpenCode request used `POST /v1/chat/completions`
+- GoModel dashboard audit logs showed the OpenCode traffic immediately

--- a/docs/guides/opencode-and-other-agents.mdx
+++ b/docs/guides/opencode-and-other-agents.mdx
@@ -1,0 +1,174 @@
+---
+title: "Using GoModel with OpenCode and Other OpenAI-Compatible Agents"
+description: "Validated OpenCode setup for GoModel and implementation notes for other OpenAI-compatible coding agents such as Cline, Roo Code, and Kilo Code."
+---
+
+## Tested on March 10, 2026
+
+This guide combines:
+
+- local validation against a GoModel instance on `http://localhost:8080`
+- local validation with OpenCode `1.1.36`
+- official documentation for Cline, Roo Code, and Kilo Code
+
+## Short Answer
+
+| Client | Status | Best target |
+| --- | --- | --- |
+| OpenCode | Validated locally | `http://localhost:8080/v1` |
+| Cline | Docs-backed, not locally executed here | `http://localhost:8080/v1` |
+| Roo Code | Docs-backed, not locally executed here | `http://localhost:8080/v1` |
+| Kilo Code | Docs-backed, not locally executed here | `http://localhost:8080/v1` or full endpoint URL |
+
+The important pattern is:
+
+- these clients are generally **OpenAI-compatible**, not provider-passthrough clients
+- that makes them a better fit for GoModel standard `/v1/*`
+- standard `/v1/*` is where GoModel usage tracking and audit logging worked in local testing
+
+## OpenCode
+
+### What We Validated
+
+OpenCode worked against GoModel with a custom OpenAI-compatible provider configuration.
+
+This temporary `opencode.json` worked in local testing:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "gomodel": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "GoModel",
+      "options": {
+        "baseURL": "http://localhost:8080/v1",
+        "apiKey": "{env:OPENAI_API_KEY}"
+      },
+      "models": {
+        "gpt-4.1-mini": {
+          "name": "GPT-4.1 Mini",
+          "limit": {
+            "context": 200000,
+            "output": 32768
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Then:
+
+```bash
+export OPENAI_API_KEY="$GOMODEL_MASTER_KEY"
+
+opencode run -m gomodel/gpt-4.1-mini \
+  'Reply with exactly ok and no punctuation.'
+```
+
+returned `ok`.
+
+### What Endpoint OpenCode Used
+
+OpenCode hit:
+
+- `POST /v1/chat/completions`
+
+not `/v1/responses`.
+
+That is still a good fit for GoModel because local testing showed:
+
+- audit logging worked
+- usage tracking worked
+- usage summary incremented
+
+The validated OpenCode request also sent a very large system prompt and tool schema, which produced a much larger token count than the user prompt alone. That is exactly the kind of agent behavior GoModel usage tracking helps developers understand.
+
+## Cline
+
+Cline's official docs describe an **OpenAI Compatible** provider mode with these fields:
+
+- Base URL
+- API Key
+- Model ID
+
+For GoModel, the intended setup is:
+
+- API Provider: `OpenAI Compatible`
+- Base URL: `http://localhost:8080/v1`
+- API Key: `GOMODEL_MASTER_KEY`
+- Model: any GoModel-served OpenAI-compatible model
+
+Because Cline is OpenAI-compatible rather than Anthropic-native, it should target GoModel standard `/v1/*`, not passthrough.
+
+## Roo Code
+
+Roo Code also has an **OpenAI Compatible** provider mode with:
+
+- Base URL
+- API Key
+- Model ID
+
+For GoModel, the intended setup is the same:
+
+- API Provider: `OpenAI Compatible`
+- Base URL: `http://localhost:8080/v1`
+- API Key: `GOMODEL_MASTER_KEY`
+- Model: a GoModel-served model
+
+Important: Roo Code's docs explicitly require **native tool calling** for the selected model/provider path. If you use Roo Code, choose models and provider paths that support OpenAI-compatible tool calling well.
+
+## Kilo Code
+
+Kilo Code's docs also support an **OpenAI Compatible** provider mode with:
+
+- Base URL
+- API Key
+- Model ID
+
+Kilo Code adds one useful detail: it supports **full endpoint URLs** in the Base URL field.
+
+That means both of these are viable:
+
+```text
+http://localhost:8080/v1
+```
+
+```text
+http://localhost:8080/v1/chat/completions
+```
+
+In most cases, prefer the simpler base URL:
+
+```text
+http://localhost:8080/v1
+```
+
+## Recommendation
+
+Use this decision rule:
+
+1. If the client supports OpenAI-compatible configuration, point it at GoModel standard `/v1/*`
+2. If the client specifically speaks Anthropic native wire format, use `/p/anthropic/...`
+3. If you care about usage tracking, cost tracking, audit logs, and guardrails, prefer standard `/v1/*`
+
+For OpenCode, Cline, Roo Code, and Kilo Code, standard `/v1/*` is the right first choice.
+
+## Admin Endpoints
+
+After testing these clients, inspect:
+
+```bash
+curl -s http://localhost:8080/admin/api/v1/usage/summary
+curl -s 'http://localhost:8080/admin/api/v1/usage/log?days=1&limit=20&offset=0'
+curl -s 'http://localhost:8080/admin/api/v1/audit/log?days=1&limit=20&offset=0'
+```
+
+## References
+
+- OpenCode providers docs: [Providers](https://opencode.ai/docs/providers/)
+- Cline OpenAI-compatible provider docs: [OpenAI Compatible](https://docs.cline.bot/provider-config/openai-compatible)
+- Roo Code OpenAI-compatible provider docs: [OpenAI Compatible](https://docs.roocode.com/providers/openai-compatible)
+- Kilo Code OpenAI-compatible provider docs: [OpenAI Compatible](https://kilo.ai/docs/providers/openai-compatible)

--- a/docs/logo.svg
+++ b/docs/logo.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M15 3L25.39 9L25.39 21L15 27L4.61 21L4.61 9Z" stroke="#755c3d" stroke-width="2" fill="none"/>
+  <circle cx="15" cy="15" r="4" fill="#755c3d" opacity="0.3"/>
+  <path d="M15 9.5L15 6M15 20.5L15 24M19.76 12.25L22.79 10.5M10.24 17.75L7.21 19.5M19.76 17.75L22.79 19.5M10.24 12.25L7.21 10.5" stroke="#755c3d" stroke-width="1.5" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added logo configuration to documentation portal
  * Expanded Guides section with new integration guides
  * Added step-by-step guide for routing Claude Code through GoModel with Anthropic passthrough
  * Added integration guide for Codex with GoModel via OpenAI-compatible API
  * Added integration guide for OpenCode, Cline, Roo Code, and Kilo Code with GoModel

<!-- end of auto-generated comment: release notes by coderabbit.ai -->