### PR TITLE
fix: accept structured annotations in responses output

### DIFF
--- a/internal/core/responses.go
+++ b/internal/core/responses.go
@@ -99,11 +99,13 @@ type ResponsesOutputItem struct {
 
 // ResponsesContentItem represents a content item in the output.
 type ResponsesContentItem struct {
-	Type        string             `json:"type"` // "output_text", "input_image", "input_audio", etc.
-	Text        string             `json:"text,omitempty"`
-	ImageURL    *ImageURLContent   `json:"image_url,omitempty"`
-	InputAudio  *InputAudioContent `json:"input_audio,omitempty"`
-	Annotations []string           `json:"annotations,omitempty"`
+	Type       string             `json:"type"` // "output_text", "input_image", "input_audio", etc.
+	Text       string             `json:"text,omitempty"`
+	ImageURL   *ImageURLContent   `json:"image_url,omitempty"`
+	InputAudio *InputAudioContent `json:"input_audio,omitempty"`
+	// Providers can return structured annotation objects here (for example
+	// citations from native tools), so keep the payload shape liberal.
+	Annotations []json.RawMessage `json:"annotations,omitempty"`
 }
 
 // ResponsesUsage represents token usage for the Responses API.

--- a/internal/core/responses_json_test.go
+++ b/internal/core/responses_json_test.go
@@ -389,6 +389,68 @@ func TestResponsesRequestJSON_PreservesUnknownFields(t *testing.T) {
 	}
 }
 
+func TestResponsesResponseJSON_AcceptsStructuredAnnotations(t *testing.T) {
+	var resp ResponsesResponse
+	if err := json.Unmarshal([]byte(`{
+		"id":"resp_123",
+		"object":"response",
+		"created_at":1677652288,
+		"model":"gpt-4o-mini",
+		"status":"completed",
+		"output":[{
+			"id":"msg_123",
+			"type":"message",
+			"role":"assistant",
+			"status":"completed",
+			"content":[{
+				"type":"output_text",
+				"text":"Found a result.",
+				"annotations":[{
+					"type":"url_citation",
+					"title":"Example Domain",
+					"url":"https://example.com"
+				}]
+			}]
+		}]
+	}`), &resp); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if len(resp.Output) != 1 || len(resp.Output[0].Content) != 1 {
+		t.Fatalf("unexpected output shape: %+v", resp.Output)
+	}
+	annotations := resp.Output[0].Content[0].Annotations
+	if len(annotations) != 1 {
+		t.Fatalf("len(Annotations) = %d, want 1", len(annotations))
+	}
+
+	var annotation map[string]any
+	if err := json.Unmarshal(annotations[0], &annotation); err != nil {
+		t.Fatalf("json.Unmarshal(annotation) error = %v", err)
+	}
+	if annotation["type"] != "url_citation" {
+		t.Fatalf("annotation.type = %#v, want url_citation", annotation["type"])
+	}
+
+	body, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal(roundTrip) error = %v", err)
+	}
+
+	output := decoded["output"].([]any)
+	content := output[0].(map[string]any)["content"].([]any)
+	roundTripAnnotations := content[0].(map[string]any)["annotations"].([]any)
+	firstAnnotation := roundTripAnnotations[0].(map[string]any)
+	if firstAnnotation["url"] != "https://example.com" {
+		t.Fatalf("roundTrip annotation.url = %#v, want https://example.com", firstAnnotation["url"])
+	}
+}
+
 func TestResponsesInputElementMarshalJSON_FunctionCall(t *testing.T) {
 	elem := ResponsesInputElement{
 		Type:      "function_call",

--- a/internal/providers/openai/openai_test.go
+++ b/internal/providers/openai/openai_test.go
@@ -793,6 +793,50 @@ func TestResponses(t *testing.T) {
 			},
 		},
 		{
+			name:       "successful request with structured annotations",
+			statusCode: http.StatusOK,
+			responseBody: `{
+				"id": "resp_annotated",
+				"object": "response",
+				"created_at": 1677652288,
+				"model": "gpt-4o",
+				"status": "completed",
+				"output": [{
+					"id": "msg_annotated",
+					"type": "message",
+					"role": "assistant",
+					"status": "completed",
+					"content": [{
+						"type": "output_text",
+						"text": "Search result summary",
+						"annotations": [{
+							"type": "url_citation",
+							"title": "Example Domain",
+							"url": "https://example.com"
+						}]
+					}]
+				}]
+			}`,
+			checkResponse: func(t *testing.T, resp *core.ResponsesResponse) {
+				if len(resp.Output) != 1 || len(resp.Output[0].Content) != 1 {
+					t.Fatalf("unexpected output shape: %+v", resp.Output)
+				}
+
+				annotations := resp.Output[0].Content[0].Annotations
+				if len(annotations) != 1 {
+					t.Fatalf("len(Annotations) = %d, want 1", len(annotations))
+				}
+
+				var annotation map[string]any
+				if err := json.Unmarshal(annotations[0], &annotation); err != nil {
+					t.Fatalf("json.Unmarshal(annotation) error = %v", err)
+				}
+				if annotation["type"] != "url_citation" {
+					t.Fatalf("annotation.type = %#v, want url_citation", annotation["type"])
+				}
+			},
+		},
+		{
 			name:          "API error - unauthorized",
 			statusCode:    http.StatusUnauthorized,
 			responseBody:  `{"error": {"message": "Invalid API key"}}`,

--- a/internal/providers/responses_adapter.go
+++ b/internal/providers/responses_adapter.go
@@ -810,7 +810,7 @@ func buildResponsesMessageContent(content any) []core.ResponsesContentItem {
 			{
 				Type:        "output_text",
 				Text:        c,
-				Annotations: []string{},
+				Annotations: []json.RawMessage{},
 			},
 		}
 	case []core.ContentPart:
@@ -830,7 +830,7 @@ func buildResponsesMessageContent(content any) []core.ResponsesContentItem {
 			{
 				Type:        "output_text",
 				Text:        text,
-				Annotations: []string{},
+				Annotations: []json.RawMessage{},
 			},
 		}
 	}
@@ -844,7 +844,7 @@ func buildResponsesContentItemsFromParts(parts []core.ContentPart) []core.Respon
 			items = append(items, core.ResponsesContentItem{
 				Type:        "output_text",
 				Text:        part.Text,
-				Annotations: []string{},
+				Annotations: []json.RawMessage{},
 			})
 		case "image_url":
 			if part.ImageURL == nil {
@@ -895,7 +895,7 @@ func BuildResponsesOutputItems(msg core.ResponseMessage) []core.ResponsesOutputI
 				{
 					Type:        "output_text",
 					Text:        "",
-					Annotations: []string{},
+					Annotations: []json.RawMessage{},
 				},
 			}
 		}
@@ -933,7 +933,7 @@ func ConvertChatResponseToResponses(resp *core.ChatResponse) *core.ResponsesResp
 				{
 					Type:        "output_text",
 					Text:        "",
-					Annotations: []string{},
+					Annotations: []json.RawMessage{},
 				},
 			},
 		},

--- a/internal/providers/responses_output_state.go
+++ b/internal/providers/responses_output_state.go
@@ -85,7 +85,7 @@ func (s *ResponsesOutputEventState) AssistantMessageItem(status string, includeC
 			{
 				"type":        "output_text",
 				"text":        s.assistantText.String(),
-				"annotations": []string{},
+				"annotations": []json.RawMessage{},
 			},
 		}
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended annotation support to accept structured JSON payloads, enabling richer annotation data beyond simple text strings.

* **Tests**
  * Added test coverage for structured annotations handling and serialization round-trip validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->