### PR TITLE
docs: add benchmark reproduction tooling

### DIFF
--- a/docs/about/benchmark-tools/bench_main.go
+++ b/docs/about/benchmark-tools/bench_main.go
@@ -1,0 +1,415 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type usage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+type chatResponse struct {
+	Usage usage `json:"usage"`
+}
+
+type errorResponse struct {
+	Error struct {
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+type requestResult struct {
+	LatencyMS        float64 `json:"latency_ms"`
+	StatusCode       int     `json:"status_code"`
+	Error            string  `json:"error,omitempty"`
+	PromptTokens     int     `json:"prompt_tokens"`
+	CompletionTokens int     `json:"completion_tokens"`
+	TotalTokens      int     `json:"total_tokens"`
+}
+
+type processSample struct {
+	CPUPercent float64 `json:"cpu_percent"`
+	RSSMB      float64 `json:"rss_mb"`
+}
+
+type summary struct {
+	Timestamp   string  `json:"timestamp"`
+	Gateway     string  `json:"gateway"`
+	BaseURL     string  `json:"base_url"`
+	Model       string  `json:"model"`
+	Requests    int     `json:"requests"`
+	Concurrency int     `json:"concurrency"`
+	DurationSec float64 `json:"duration_sec"`
+
+	Success   int     `json:"success"`
+	Failures  int     `json:"failures"`
+	ErrorRate float64 `json:"error_rate"`
+	ReqPerSec float64 `json:"req_per_sec"`
+
+	LatencyMS struct {
+		Min float64 `json:"min"`
+		P50 float64 `json:"p50"`
+		P90 float64 `json:"p90"`
+		P95 float64 `json:"p95"`
+		P99 float64 `json:"p99"`
+		Max float64 `json:"max"`
+		Avg float64 `json:"avg"`
+	} `json:"latency_ms"`
+
+	Tokens struct {
+		Prompt             int     `json:"prompt"`
+		Completion         int     `json:"completion"`
+		Total              int     `json:"total"`
+		AvgTotalPerRequest float64 `json:"avg_total_per_request"`
+		CompletionTPS      float64 `json:"completion_tps"`
+	} `json:"tokens"`
+
+	Process struct {
+		Samples  int     `json:"samples"`
+		CPUAvg   float64 `json:"cpu_avg"`
+		CPUMax   float64 `json:"cpu_max"`
+		RSSAvgMB float64 `json:"rss_avg_mb"`
+		RSSMaxMB float64 `json:"rss_max_mb"`
+	} `json:"process"`
+
+	ErrorBreakdown map[string]int `json:"error_breakdown"`
+}
+
+func percentile(sorted []float64, p float64) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	if p <= 0 {
+		return sorted[0]
+	}
+	if p >= 100 {
+		return sorted[len(sorted)-1]
+	}
+	pos := (p / 100) * float64(len(sorted)-1)
+	lower := int(math.Floor(pos))
+	upper := int(math.Ceil(pos))
+	if lower == upper {
+		return sorted[lower]
+	}
+	weight := pos - float64(lower)
+	return sorted[lower]*(1-weight) + sorted[upper]*weight
+}
+
+func sampleProcess(pid int) (processSample, error) {
+	cmd := exec.Command("ps", "-o", "%cpu=,rss=", "-p", strconv.Itoa(pid))
+	out, err := cmd.Output()
+	if err != nil {
+		return processSample{}, err
+	}
+	line := strings.TrimSpace(string(out))
+	if line == "" {
+		return processSample{}, fmt.Errorf("no process sample")
+	}
+	parts := strings.Fields(line)
+	if len(parts) < 2 {
+		return processSample{}, fmt.Errorf("unexpected ps output: %q", line)
+	}
+	cpu, err := strconv.ParseFloat(parts[0], 64)
+	if err != nil {
+		return processSample{}, err
+	}
+	rssKB, err := strconv.ParseFloat(parts[1], 64)
+	if err != nil {
+		return processSample{}, err
+	}
+	return processSample{
+		CPUPercent: cpu,
+		RSSMB:      rssKB / 1024.0,
+	}, nil
+}
+
+func main() {
+	var (
+		gateway        = flag.String("gateway", "gateway", "Gateway name label")
+		baseURL        = flag.String("base-url", "http://127.0.0.1:8080", "Gateway base URL")
+		model          = flag.String("model", "", "Model name")
+		requests       = flag.Int("requests", 100, "Total number of requests")
+		concurrency    = flag.Int("concurrency", 4, "Number of workers")
+		prompt         = flag.String("prompt", "Reply with: OK", "User prompt")
+		maxTokens      = flag.Int("max-tokens", 8, "max_tokens")
+		temperature    = flag.Float64("temperature", 0, "temperature")
+		requestTimeout = flag.Duration("request-timeout", 45*time.Second, "Per-request timeout")
+		outputFile     = flag.String("output", "", "Output JSON file path")
+		apiKey         = flag.String("api-key", "", "Optional bearer token for Authorization header")
+		pid            = flag.Int("pid", 0, "Optional PID of gateway process to sample")
+		sampleEvery    = flag.Duration("sample-every", 500*time.Millisecond, "Process sample interval")
+	)
+	flag.Parse()
+
+	if *model == "" {
+		fmt.Fprintln(os.Stderr, "missing required -model")
+		os.Exit(1)
+	}
+	if *requests <= 0 || *concurrency <= 0 {
+		fmt.Fprintln(os.Stderr, "-requests and -concurrency must be > 0")
+		os.Exit(1)
+	}
+
+	type payloadType struct {
+		Model       string  `json:"model"`
+		Messages    []any   `json:"messages"`
+		MaxTokens   int     `json:"max_tokens"`
+		Temperature float64 `json:"temperature"`
+	}
+
+	payload := payloadType{
+		Model: *model,
+		Messages: []any{
+			map[string]string{"role": "user", "content": *prompt},
+		},
+		MaxTokens:   *maxTokens,
+		Temperature: *temperature,
+	}
+	bodyBytes, err := json.Marshal(payload)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "marshal payload: %v\n", err)
+		os.Exit(1)
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			MaxIdleConns:        512,
+			MaxIdleConnsPerHost: 512,
+			MaxConnsPerHost:     512,
+			IdleConnTimeout:     90 * time.Second,
+		},
+	}
+
+	var (
+		resultsMu sync.Mutex
+		results   = make([]requestResult, 0, *requests)
+
+		procMu      sync.Mutex
+		procSamples = make([]processSample, 0, 128)
+	)
+
+	stopSampling := make(chan struct{})
+	if *pid > 0 {
+		go func() {
+			if sample, sampleErr := sampleProcess(*pid); sampleErr == nil {
+				procMu.Lock()
+				procSamples = append(procSamples, sample)
+				procMu.Unlock()
+			}
+			ticker := time.NewTicker(*sampleEvery)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-stopSampling:
+					return
+				case <-ticker.C:
+					sample, sampleErr := sampleProcess(*pid)
+					if sampleErr != nil {
+						continue
+					}
+					procMu.Lock()
+					procSamples = append(procSamples, sample)
+					procMu.Unlock()
+				}
+			}
+		}()
+	}
+
+	jobs := make(chan int, *requests)
+	var wg sync.WaitGroup
+
+	start := time.Now()
+	for i := 0; i < *concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range jobs {
+				reqCtx, cancel := context.WithTimeout(context.Background(), *requestTimeout)
+				req, reqErr := http.NewRequestWithContext(reqCtx, http.MethodPost, strings.TrimRight(*baseURL, "/")+"/v1/chat/completions", bytes.NewReader(bodyBytes))
+				if reqErr != nil {
+					cancel()
+					resultsMu.Lock()
+					results = append(results, requestResult{Error: reqErr.Error()})
+					resultsMu.Unlock()
+					continue
+				}
+				req.Header.Set("Content-Type", "application/json")
+				if *apiKey != "" {
+					req.Header.Set("Authorization", "Bearer "+*apiKey)
+				}
+
+				reqStart := time.Now()
+				resp, doErr := client.Do(req)
+				latencyMS := float64(time.Since(reqStart).Microseconds()) / 1000.0
+				if doErr != nil {
+					cancel()
+					resultsMu.Lock()
+					results = append(results, requestResult{
+						LatencyMS:  latencyMS,
+						StatusCode: 0,
+						Error:      doErr.Error(),
+					})
+					resultsMu.Unlock()
+					continue
+				}
+
+				respBody, _ := ioReadAllLimit(resp.Body, 1<<20)
+				cancel()
+
+				r := requestResult{
+					LatencyMS:  latencyMS,
+					StatusCode: resp.StatusCode,
+				}
+
+				if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+					var parsed chatResponse
+					if unmarshalErr := json.Unmarshal(respBody, &parsed); unmarshalErr == nil {
+						r.PromptTokens = parsed.Usage.PromptTokens
+						r.CompletionTokens = parsed.Usage.CompletionTokens
+						r.TotalTokens = parsed.Usage.TotalTokens
+					}
+				} else {
+					errLabel := fmt.Sprintf("status_%d", resp.StatusCode)
+					var er errorResponse
+					if unmarshalErr := json.Unmarshal(respBody, &er); unmarshalErr == nil {
+						msg := strings.TrimSpace(er.Error.Message)
+						if msg != "" {
+							errLabel = errLabel + ": " + msg
+						}
+					}
+					r.Error = errLabel
+				}
+
+				resultsMu.Lock()
+				results = append(results, r)
+				resultsMu.Unlock()
+			}
+		}()
+	}
+
+	for i := 0; i < *requests; i++ {
+		jobs <- i
+	}
+	close(jobs)
+	wg.Wait()
+	duration := time.Since(start)
+	close(stopSampling)
+
+	s := summary{
+		Timestamp:      time.Now().Format(time.RFC3339),
+		Gateway:        *gateway,
+		BaseURL:        *baseURL,
+		Model:          *model,
+		Requests:       *requests,
+		Concurrency:    *concurrency,
+		DurationSec:    duration.Seconds(),
+		ErrorBreakdown: map[string]int{},
+	}
+
+	latencies := make([]float64, 0, len(results))
+	var (
+		totalLatencyMS     float64
+		totalPromptTokens  int
+		totalCompTokens    int
+		totalAllTokens     int
+		successfulRequests int
+	)
+	for _, r := range results {
+		if r.StatusCode >= 200 && r.StatusCode < 300 {
+			successfulRequests++
+			latencies = append(latencies, r.LatencyMS)
+			totalLatencyMS += r.LatencyMS
+			totalPromptTokens += r.PromptTokens
+			totalCompTokens += r.CompletionTokens
+			totalAllTokens += r.TotalTokens
+		} else {
+			key := r.Error
+			if key == "" {
+				key = fmt.Sprintf("status_%d", r.StatusCode)
+			}
+			s.ErrorBreakdown[key]++
+		}
+	}
+
+	s.Success = successfulRequests
+	s.Failures = s.Requests - s.Success
+	if s.Requests > 0 {
+		s.ErrorRate = float64(s.Failures) / float64(s.Requests)
+		s.ReqPerSec = float64(s.Success) / s.DurationSec
+	}
+
+	sort.Float64s(latencies)
+	if len(latencies) > 0 {
+		s.LatencyMS.Min = latencies[0]
+		s.LatencyMS.P50 = percentile(latencies, 50)
+		s.LatencyMS.P90 = percentile(latencies, 90)
+		s.LatencyMS.P95 = percentile(latencies, 95)
+		s.LatencyMS.P99 = percentile(latencies, 99)
+		s.LatencyMS.Max = latencies[len(latencies)-1]
+		s.LatencyMS.Avg = totalLatencyMS / float64(len(latencies))
+	}
+
+	s.Tokens.Prompt = totalPromptTokens
+	s.Tokens.Completion = totalCompTokens
+	s.Tokens.Total = totalAllTokens
+	if s.Success > 0 {
+		s.Tokens.AvgTotalPerRequest = float64(totalAllTokens) / float64(s.Success)
+	}
+	if s.DurationSec > 0 {
+		s.Tokens.CompletionTPS = float64(totalCompTokens) / s.DurationSec
+	}
+
+	procMu.Lock()
+	defer procMu.Unlock()
+	s.Process.Samples = len(procSamples)
+	if len(procSamples) > 0 {
+		var cpuSum, rssSum float64
+		for _, sample := range procSamples {
+			cpuSum += sample.CPUPercent
+			rssSum += sample.RSSMB
+			if sample.CPUPercent > s.Process.CPUMax {
+				s.Process.CPUMax = sample.CPUPercent
+			}
+			if sample.RSSMB > s.Process.RSSMaxMB {
+				s.Process.RSSMaxMB = sample.RSSMB
+			}
+		}
+		s.Process.CPUAvg = cpuSum / float64(len(procSamples))
+		s.Process.RSSAvgMB = rssSum / float64(len(procSamples))
+	}
+
+	out, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "marshal summary: %v\n", err)
+		os.Exit(1)
+	}
+	if *outputFile != "" {
+		if err := os.WriteFile(*outputFile, out, 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "write output: %v\n", err)
+			os.Exit(1)
+		}
+	}
+	fmt.Println(string(out))
+}
+
+func ioReadAllLimit(body io.ReadCloser, max int64) ([]byte, error) {
+	defer func() { _ = body.Close() }()
+	limited := &io.LimitedReader{R: body, N: max}
+	return io.ReadAll(limited)
+}

--- a/docs/about/benchmark-tools/compare.sh
+++ b/docs/about/benchmark-tools/compare.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${ENV_FILE:-${ROOT_DIR}/../gomodel/.env}"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+RESULTS_DIR="${RESULTS_DIR:-${ROOT_DIR}/benchmark-results/${STAMP}}"
+LOG_DIR="${RESULTS_DIR}/logs"
+
+REQUESTS="${REQUESTS:-60}"
+CONCURRENCIES="${CONCURRENCIES:-1 4 8}"
+read -r -a CONCURRENCY_ARRAY <<<"${CONCURRENCIES}"
+WARMUP_REQUESTS="${WARMUP_REQUESTS:-3}"
+MAX_TOKENS="${MAX_TOKENS:-8}"
+PROMPT="${PROMPT:-Reply with exactly: OK}"
+REQUEST_TIMEOUT="${REQUEST_TIMEOUT:-45s}"
+SAMPLE_EVERY="${SAMPLE_EVERY:-500ms}"
+COOLDOWN_SECONDS="${COOLDOWN_SECONDS:-0}"
+RUN_DIRECT_BASELINE="${RUN_DIRECT_BASELINE:-1}"
+
+GOMODEL_PORT="${GOMODEL_PORT:-38080}"
+LITELLM_PORT="${LITELLM_PORT:-34000}"
+
+mkdir -p "${LOG_DIR}"
+
+GOMODEL_PID=""
+LITELLM_PID=""
+
+cleanup() {
+  if [[ -n "${GOMODEL_PID}" ]] && kill -0 "${GOMODEL_PID}" >/dev/null 2>&1; then
+    kill "${GOMODEL_PID}" >/dev/null 2>&1 || true
+    wait "${GOMODEL_PID}" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${LITELLM_PID}" ]] && kill -0 "${LITELLM_PID}" >/dev/null 2>&1; then
+    kill "${LITELLM_PID}" >/dev/null 2>&1 || true
+    wait "${LITELLM_PID}" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd go
+require_cmd jq
+require_cmd curl
+require_cmd python3
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+  echo "env file not found: ${ENV_FILE}" >&2
+  exit 1
+fi
+
+set -a
+source "${ENV_FILE}"
+set +a
+
+if [[ -z "${GROQ_API_KEY:-}" ]]; then
+  echo "GROQ_API_KEY is required in ${ENV_FILE}" >&2
+  exit 1
+fi
+
+# Ensure fairness: compare with a single provider enabled on both gateways.
+unset OPENAI_API_KEY ANTHROPIC_API_KEY GEMINI_API_KEY XAI_API_KEY OLLAMA_BASE_URL
+
+if ! python3 -m pip show litellm >/dev/null 2>&1; then
+  echo "litellm is not installed. Installing litellm[proxy]..." >&2
+  python3 -m pip install "litellm[proxy]==1.82.0"
+fi
+require_cmd litellm
+
+PREFERRED_MODELS=(
+  "llama-3.1-8b-instant"
+  "openai/gpt-oss-20b"
+  "qwen/qwen3-32b"
+  "llama-3.3-70b-versatile"
+)
+
+discover_model() {
+  local models
+  models="$(curl -fsS https://api.groq.com/openai/v1/models \
+    -H "Authorization: Bearer ${GROQ_API_KEY}" | jq -r '.data[].id')"
+
+  if [[ -z "${models}" ]]; then
+    echo "failed to discover Groq models" >&2
+    exit 1
+  fi
+
+  if [[ -n "${MODEL:-}" ]] && grep -Fxq "${MODEL}" <<<"${models}"; then
+    echo "${MODEL}"
+    return
+  fi
+
+  local preferred
+  for preferred in "${PREFERRED_MODELS[@]}"; do
+    if grep -Fxq "${preferred}" <<<"${models}"; then
+      echo "${preferred}"
+      return
+    fi
+  done
+
+  echo "${models}" | head -n 1
+}
+
+MODEL="$(discover_model)"
+
+echo "Using model: ${MODEL}"
+echo "Results dir: ${RESULTS_DIR}"
+
+mkdir -p "${ROOT_DIR}/bin"
+(cd "${ROOT_DIR}" && go build -o bin/gomodel ./cmd/gomodel)
+(cd "${ROOT_DIR}" && go build -o bin/bench ./cmd/bench)
+
+LITELLM_CONFIG="${RESULTS_DIR}/litellm_config.yaml"
+cat >"${LITELLM_CONFIG}" <<EOF
+model_list:
+  - model_name: "${MODEL}"
+    litellm_params:
+      model: "groq/${MODEL}"
+      api_key: os.environ/GROQ_API_KEY
+EOF
+
+wait_for_models() {
+  local base_url="$1"
+  local label="$2"
+  local i
+  for i in $(seq 1 90); do
+    if curl -fsS "${base_url}/v1/models" >/dev/null 2>&1; then
+      return
+    fi
+    sleep 1
+  done
+  echo "${label} did not become ready in time" >&2
+  exit 1
+}
+
+start_gomodel() {
+  local log_file="${LOG_DIR}/gomodel.log"
+  (
+    cd "${ROOT_DIR}"
+    exec env \
+      PORT="${GOMODEL_PORT}" \
+      GOMODEL_MASTER_KEY="" \
+      LOGGING_ENABLED=false \
+      METRICS_ENABLED=false \
+      ./bin/gomodel >"${log_file}" 2>&1
+  ) &
+  GOMODEL_PID=$!
+  wait_for_models "http://127.0.0.1:${GOMODEL_PORT}" "GoModel"
+  sleep 2
+}
+
+start_litellm() {
+  local log_file="${LOG_DIR}/litellm.log"
+  (
+    cd "${ROOT_DIR}"
+    exec env \
+      LITELLM_LOG=ERROR \
+      litellm --config "${LITELLM_CONFIG}" --host 127.0.0.1 --port "${LITELLM_PORT}" >"${log_file}" 2>&1
+  ) &
+  LITELLM_PID=$!
+  wait_for_models "http://127.0.0.1:${LITELLM_PORT}" "LiteLLM"
+  sleep 2
+}
+
+run_bench_matrix() {
+  local gateway="$1"
+  local base_url="$2"
+  local pid="$3"
+
+  echo "Warmup ${gateway}..."
+  "${ROOT_DIR}/bin/bench" \
+    -gateway "${gateway}" \
+    -base-url "${base_url}" \
+    -model "${MODEL}" \
+    -requests "${WARMUP_REQUESTS}" \
+    -concurrency 1 \
+    -max-tokens "${MAX_TOKENS}" \
+    -prompt "${PROMPT}" \
+    -request-timeout "${REQUEST_TIMEOUT}" \
+    -sample-every "${SAMPLE_EVERY}" \
+    >/dev/null
+
+  local c idx
+  for idx in "${!CONCURRENCY_ARRAY[@]}"; do
+    c="${CONCURRENCY_ARRAY[$idx]}"
+    local out_file="${RESULTS_DIR}/${gateway}_c${c}.json"
+    echo "Benchmark ${gateway} c=${c} req=${REQUESTS}"
+    "${ROOT_DIR}/bin/bench" \
+      -gateway "${gateway}" \
+      -base-url "${base_url}" \
+      -model "${MODEL}" \
+      -requests "${REQUESTS}" \
+      -concurrency "${c}" \
+      -max-tokens "${MAX_TOKENS}" \
+      -prompt "${PROMPT}" \
+      -request-timeout "${REQUEST_TIMEOUT}" \
+      -sample-every "${SAMPLE_EVERY}" \
+      -pid "${pid}" \
+      -output "${out_file}" \
+      >/dev/null
+
+    if [[ "${COOLDOWN_SECONDS}" -gt 0 ]] && [[ "${idx}" -lt "$(( ${#CONCURRENCY_ARRAY[@]} - 1 ))" ]]; then
+      echo "Cooldown ${gateway}: ${COOLDOWN_SECONDS}s"
+      sleep "${COOLDOWN_SECONDS}"
+    fi
+  done
+}
+
+echo "Starting GoModel..."
+start_gomodel
+run_bench_matrix "gomodel" "http://127.0.0.1:${GOMODEL_PORT}" "${GOMODEL_PID}"
+kill "${GOMODEL_PID}" >/dev/null 2>&1 || true
+wait "${GOMODEL_PID}" >/dev/null 2>&1 || true
+GOMODEL_PID=""
+
+echo "Starting LiteLLM..."
+start_litellm
+run_bench_matrix "litellm" "http://127.0.0.1:${LITELLM_PORT}" "${LITELLM_PID}"
+kill "${LITELLM_PID}" >/dev/null 2>&1 || true
+wait "${LITELLM_PID}" >/dev/null 2>&1 || true
+LITELLM_PID=""
+
+if [[ "${RUN_DIRECT_BASELINE}" == "1" ]]; then
+  local_c=1
+  for local_c in "${CONCURRENCY_ARRAY[@]}"; do
+    out_file="${RESULTS_DIR}/direct_groq_c${local_c}.json"
+    echo "Benchmark direct Groq c=${local_c} req=${REQUESTS}"
+    "${ROOT_DIR}/bin/bench" \
+      -gateway "direct-groq" \
+      -base-url "https://api.groq.com/openai" \
+      -model "${MODEL}" \
+      -requests "${REQUESTS}" \
+      -concurrency "${local_c}" \
+      -max-tokens "${MAX_TOKENS}" \
+      -prompt "${PROMPT}" \
+      -request-timeout "${REQUEST_TIMEOUT}" \
+      -sample-every "${SAMPLE_EVERY}" \
+      -api-key "${GROQ_API_KEY}" \
+      -output "${out_file}" \
+      >/dev/null
+  done
+fi
+
+{
+  echo "# GoModel vs LiteLLM Benchmark"
+  echo
+  echo "- Timestamp: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  echo "- Model: \`${MODEL}\`"
+  echo "- Requests per run: ${REQUESTS}"
+  echo "- Concurrency set: \`${CONCURRENCIES}\`"
+  echo "- Prompt: \`${PROMPT}\`"
+  echo "- Max tokens: ${MAX_TOKENS}"
+  echo
+  echo "## Results"
+  echo
+  echo "| Gateway | C | Success | Failure | Error % | Req/s | p50 ms | p95 ms | p99 ms | CPU avg % | CPU max % | RSS avg MB | RSS max MB |"
+  echo "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|"
+
+  for file in "${RESULTS_DIR}"/*.json; do
+    jq -r '
+      [
+        .gateway,
+        .concurrency,
+        .success,
+        .failures,
+        (.error_rate * 100),
+        .req_per_sec,
+        .latency_ms.p50,
+        .latency_ms.p95,
+        .latency_ms.p99,
+        .process.cpu_avg,
+        .process.cpu_max,
+        .process.rss_avg_mb,
+        .process.rss_max_mb
+      ] | @tsv
+    ' "${file}"
+  done | sort -k1,1 -k2,2n | while IFS=$'\t' read -r gateway c success failures error_rate reqs p50 p95 p99 cpu_avg cpu_max rss_avg rss_max; do
+    printf '| %s | %s | %s | %s | %.2f | %.2f | %.1f | %.1f | %.1f | %.2f | %.2f | %.1f | %.1f |\n' \
+      "${gateway}" "${c}" "${success}" "${failures}" \
+      "${error_rate}" "${reqs}" "${p50}" "${p95}" "${p99}" \
+      "${cpu_avg}" "${cpu_max}" "${rss_avg}" "${rss_max}"
+  done
+} >"${RESULTS_DIR}/REPORT.md"
+
+echo
+echo "Benchmark completed."
+echo "Artifacts:"
+echo "- JSON: ${RESULTS_DIR}/*.json"
+echo "- Report: ${RESULTS_DIR}/REPORT.md"
+echo "- Logs: ${LOG_DIR}"

--- a/docs/about/benchmark-tools/plot_benchmark_charts.py
+++ b/docs/about/benchmark-tools/plot_benchmark_charts.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+import argparse
+import json
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def load_rows(results_dir: Path):
+    rows = []
+    for path in sorted(results_dir.glob("*_c*.json")):
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        rows.append(
+            {
+                "gateway": data["gateway"],
+                "c": int(data["concurrency"]),
+                "req_per_sec": float(data["req_per_sec"]),
+                "p95_ms": float(data["latency_ms"]["p95"]),
+                "rss_mb": float(data["process"]["rss_avg_mb"]),
+                "cpu_pct": float(data["process"]["cpu_avg"]),
+                "error_rate": float(data["error_rate"]) * 100.0,
+            }
+        )
+    return rows
+
+
+def split_by_gateway(rows):
+    grouped = {}
+    for row in rows:
+        grouped.setdefault(row["gateway"], []).append(row)
+    for key in grouped:
+        grouped[key] = sorted(grouped[key], key=lambda r: r["c"])
+    return grouped
+
+
+def extract_xy(rows, key):
+    x = np.array([r["c"] for r in rows], dtype=int)
+    y = np.array([r[key] for r in rows], dtype=float)
+    return x, y
+
+
+def plot_metric(ax, grouped, key, title, ylabel, colors):
+    for gateway, rows in grouped.items():
+        x, y = extract_xy(rows, key)
+        ax.plot(
+            x,
+            y,
+            marker="o",
+            linewidth=2.5,
+            markersize=7,
+            label=gateway.upper(),
+            color=colors.get(gateway, None),
+        )
+        for xi, yi in zip(x, y):
+            ax.annotate(f"{yi:.1f}", (xi, yi), textcoords="offset points", xytext=(0, 7), ha="center", fontsize=8)
+    ax.set_title(title, fontsize=12, weight="bold")
+    ax.set_xlabel("Concurrency")
+    ax.set_ylabel(ylabel)
+    ax.set_xticks(sorted({r["c"] for rows in grouped.values() for r in rows}))
+    ax.grid(alpha=0.25)
+    ax.legend(frameon=True)
+
+
+def save_single_plot(results_dir: Path, grouped, key, title, ylabel, filename, colors):
+    fig, ax = plt.subplots(figsize=(8.5, 4.8), constrained_layout=True)
+    plot_metric(ax, grouped, key, title, ylabel, colors)
+    fig.savefig(results_dir / "charts" / filename, dpi=180)
+    plt.close(fig)
+
+
+def render_dashboard(results_dir: Path, grouped, colors):
+    fig, axes = plt.subplots(2, 2, figsize=(14, 9), constrained_layout=True)
+    fig.suptitle("GoModel vs LiteLLM Benchmark Dashboard", fontsize=18, weight="bold")
+
+    plot_metric(axes[0, 0], grouped, "req_per_sec", "Throughput", "Req/s", colors)
+    plot_metric(axes[0, 1], grouped, "p95_ms", "Latency (p95)", "Milliseconds", colors)
+    plot_metric(axes[1, 0], grouped, "rss_mb", "Memory Footprint", "RSS Avg (MB)", colors)
+    plot_metric(axes[1, 1], grouped, "cpu_pct", "CPU Usage", "CPU Avg (%)", colors)
+
+    fig.savefig(results_dir / "charts" / "dashboard.png", dpi=180)
+    plt.close(fig)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate benchmark charts from result JSON files.")
+    parser.add_argument("results_dir", type=Path, help="Path to a benchmark result directory")
+    args = parser.parse_args()
+
+    results_dir = args.results_dir.resolve()
+    charts_dir = results_dir / "charts"
+    charts_dir.mkdir(parents=True, exist_ok=True)
+
+    rows = load_rows(results_dir)
+    if not rows:
+        raise SystemExit(f"No benchmark JSON files found in {results_dir}")
+
+    grouped = split_by_gateway(rows)
+    colors = {"gomodel": "#0A84FF", "litellm": "#FF6B35"}
+
+    plt.style.use("seaborn-v0_8-whitegrid")
+
+    save_single_plot(
+        results_dir,
+        grouped,
+        key="req_per_sec",
+        title="Throughput vs Concurrency",
+        ylabel="Req/s",
+        filename="throughput_reqps.png",
+        colors=colors,
+    )
+    save_single_plot(
+        results_dir,
+        grouped,
+        key="p95_ms",
+        title="P95 Latency vs Concurrency",
+        ylabel="Milliseconds",
+        filename="latency_p95_ms.png",
+        colors=colors,
+    )
+    save_single_plot(
+        results_dir,
+        grouped,
+        key="rss_mb",
+        title="Memory (RSS Avg) vs Concurrency",
+        ylabel="MB",
+        filename="memory_rss_mb.png",
+        colors=colors,
+    )
+    save_single_plot(
+        results_dir,
+        grouped,
+        key="cpu_pct",
+        title="CPU (Avg) vs Concurrency",
+        ylabel="Percent",
+        filename="cpu_avg_pct.png",
+        colors=colors,
+    )
+    render_dashboard(results_dir, grouped, colors)
+
+    print(f"Charts saved to {charts_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/about/benchmarks.mdx
+++ b/docs/about/benchmarks.mdx
@@ -76,7 +76,7 @@ All the tooling used in the published benchmark is available in this repository.
 
 ### Prerequisites
 
-- Go 1.22+
+- Go 1.25+
 - Python 3.10+ with `matplotlib` and `numpy`
 - `jq`, `curl`
 - A Groq API key (or any OpenAI-compatible provider — adjust the script)

--- a/docs/about/benchmarks.mdx
+++ b/docs/about/benchmarks.mdx
@@ -70,6 +70,57 @@ Some useful reads from that March 5, 2026 run:
 At the highest tested concurrency, GOModel reached `52.75 req/s` versus
 LiteLLM at `35.81 req/s`.
 
+## Reproduce it yourself
+
+All the tooling used in the published benchmark is available in this repository.
+
+### Prerequisites
+
+- Go 1.22+
+- Python 3.10+ with `matplotlib` and `numpy`
+- `jq`, `curl`
+- A Groq API key (or any OpenAI-compatible provider — adjust the script)
+- `litellm[proxy]` (`pip install "litellm[proxy]"`)
+
+### Scripts
+
+The benchmark suite lives in [`docs/about/benchmark-tools/`](./benchmark-tools/):
+
+| File | Purpose |
+| --- | --- |
+| [`compare.sh`](./benchmark-tools/compare.sh) | Builds GoModel, starts both gateways, runs the full benchmark matrix, and writes a `REPORT.md` |
+| [`bench_main.go`](./benchmark-tools/bench_main.go) | Source for the `bench` CLI that sends requests and collects latency + process metrics |
+| [`plot_benchmark_charts.py`](./benchmark-tools/plot_benchmark_charts.py) | Generates per-metric charts and a combined dashboard from the JSON results |
+
+### Quick start
+
+```bash
+# 1. Clone GoModel and set up your .env with GROQ_API_KEY
+git clone https://github.com/enterpilot/gomodel.git
+cd gomodel
+echo "GROQ_API_KEY=gsk_..." > .env
+
+# 2. Run the full comparison (builds GoModel, starts LiteLLM, benchmarks both)
+bash docs/about/benchmark-tools/compare.sh
+
+# 3. Generate charts from the latest result
+pip install matplotlib numpy
+python3 docs/about/benchmark-tools/plot_benchmark_charts.py benchmark-results/<timestamp>
+```
+
+The script creates a timestamped directory under `benchmark-results/` containing
+JSON result files, gateway logs, and a `REPORT.md` with the results table.
+
+### Tuning
+
+You can override defaults via environment variables:
+
+```bash
+REQUESTS=100 CONCURRENCIES="1 4 8 16" MAX_TOKENS=16 bash docs/about/benchmark-tools/compare.sh
+```
+
+See the top of `compare.sh` for the full list of knobs.
+
 ## Why this page is short
 
 This page is intentionally shorter and more operational than the blog version.


### PR DESCRIPTION
## Summary
- Add benchmark scripts (`compare.sh`, `bench_main.go`, `plot_benchmark_charts.py`) to `docs/about/benchmark-tools/`
- Update `docs/about/benchmarks.mdx` Mintlify page with a "Reproduce it yourself" section including prerequisites, quick start, script reference table, and tuning instructions

## Test plan
- [ ] Verify `compare.sh` runs successfully with a valid `GROQ_API_KEY`
- [ ] Verify `plot_benchmark_charts.py` generates charts from JSON results
- [ ] Verify the Mintlify docs page renders correctly with the new section and file links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Reproduce it yourself" section with prerequisites, quick start, and tuning guidance for running local benchmarks.

* **New Features**
  * Introduced end-to-end benchmarking tools: high-concurrency gateway comparisons, optional process sampling, JSON result export, and automated chart generation summarizing throughput, latency percentiles, memory, CPU, and error metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->