### PR TITLE
fix: guarantee usage rows for streamed /v1/responses

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -196,8 +196,8 @@ type UsageConfig struct {
 	// Default: true
 	Enabled bool `yaml:"enabled" env:"USAGE_ENABLED"`
 
-	// EnforceReturningUsageData controls whether to enforce returning usage data in streaming responses.
-	// When true, stream_options: {"include_usage": true} is automatically added to streaming requests.
+	// EnforceReturningUsageData controls whether to ask streaming providers to return usage data when possible.
+	// When true, stream_options: {"include_usage": true} is added for provider paths that support it.
 	// Default: true
 	EnforceReturningUsageData bool `yaml:"enforce_returning_usage_data" env:"ENFORCE_RETURNING_USAGE_DATA"`
 

--- a/internal/core/context.go
+++ b/internal/core/context.go
@@ -12,6 +12,9 @@ const (
 	ingressFrameKey contextKey = "ingress-frame"
 	// semanticEnvelopeKey stores the best-effort semantic extraction for the request.
 	semanticEnvelopeKey contextKey = "semantic-envelope"
+	// enforceReturningUsageDataKey stores whether streaming requests should ask providers
+	// to include usage when the provider supports it.
+	enforceReturningUsageDataKey contextKey = "enforce-returning-usage-data"
 )
 
 // WithRequestID returns a new context with the request ID attached.
@@ -58,4 +61,20 @@ func GetSemanticEnvelope(ctx context.Context) *SemanticEnvelope {
 		}
 	}
 	return nil
+}
+
+// WithEnforceReturningUsageData returns a new context with the streaming usage policy attached.
+func WithEnforceReturningUsageData(ctx context.Context, enforce bool) context.Context {
+	return context.WithValue(ctx, enforceReturningUsageDataKey, enforce)
+}
+
+// GetEnforceReturningUsageData reports whether the request should ask providers
+// to include usage in streaming responses when possible.
+func GetEnforceReturningUsageData(ctx context.Context) bool {
+	if v := ctx.Value(enforceReturningUsageDataKey); v != nil {
+		if enforce, ok := v.(bool); ok {
+			return enforce
+		}
+	}
+	return false
 }

--- a/internal/providers/responses_adapter.go
+++ b/internal/providers/responses_adapter.go
@@ -37,7 +37,7 @@ func ConvertResponsesRequestToChat(req *core.ResponsesRequest) (*core.ChatReques
 		ParallelToolCalls: req.ParallelToolCalls,
 		Temperature:       req.Temperature,
 		Stream:            req.Stream,
-		StreamOptions:     req.StreamOptions,
+		StreamOptions:     cloneStreamOptions(req.StreamOptions),
 		Reasoning:         req.Reasoning,
 		ExtraFields:       core.CloneRawJSONMap(req.ExtraFields),
 	}
@@ -60,6 +60,14 @@ func ConvertResponsesRequestToChat(req *core.ResponsesRequest) (*core.ChatReques
 	chatReq.Messages = append(chatReq.Messages, messages...)
 
 	return chatReq, nil
+}
+
+func cloneStreamOptions(src *core.StreamOptions) *core.StreamOptions {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	return &cloned
 }
 
 func normalizeResponsesToolsForChat(tools []map[string]any) []map[string]any {
@@ -981,6 +989,12 @@ func StreamResponsesViaChat(ctx context.Context, p ChatProvider, req *core.Respo
 	chatReq, err := ConvertResponsesRequestToChat(req)
 	if err != nil {
 		return nil, err
+	}
+	if core.GetEnforceReturningUsageData(ctx) {
+		if chatReq.StreamOptions == nil {
+			chatReq.StreamOptions = &core.StreamOptions{}
+		}
+		chatReq.StreamOptions.IncludeUsage = true
 	}
 
 	stream, err := p.StreamChatCompletion(ctx, chatReq)

--- a/internal/providers/responses_adapter_test.go
+++ b/internal/providers/responses_adapter_test.go
@@ -1,13 +1,33 @@
 package providers
 
 import (
+	"context"
 	"encoding/json"
+	"io"
 	"math"
 	"strings"
 	"testing"
 
 	"gomodel/internal/core"
 )
+
+type capturingChatProvider struct {
+	capturedReq *core.ChatRequest
+	streamData  string
+	streamErr   error
+}
+
+func (p *capturingChatProvider) ChatCompletion(_ context.Context, _ *core.ChatRequest) (*core.ChatResponse, error) {
+	return nil, nil
+}
+
+func (p *capturingChatProvider) StreamChatCompletion(_ context.Context, req *core.ChatRequest) (io.ReadCloser, error) {
+	p.capturedReq = req
+	if p.streamErr != nil {
+		return nil, p.streamErr
+	}
+	return io.NopCloser(strings.NewReader(p.streamData)), nil
+}
 
 func TestResponsesFunctionCallIDs(t *testing.T) {
 	t.Run("preserve explicit call id", func(t *testing.T) {
@@ -760,6 +780,92 @@ func TestExtractContentFromInput(t *testing.T) {
 				t.Fatalf("ExtractContentFromInput(%v) = %q, want %q", tt.input, got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestConvertResponsesRequestToChat_ClonesStreamOptions(t *testing.T) {
+	req := &core.ResponsesRequest{
+		Model:         "test-model",
+		Input:         "hello",
+		Stream:        true,
+		StreamOptions: &core.StreamOptions{IncludeUsage: false},
+	}
+
+	chatReq, err := ConvertResponsesRequestToChat(req)
+	if err != nil {
+		t.Fatalf("ConvertResponsesRequestToChat() error = %v", err)
+	}
+	if chatReq.StreamOptions == nil {
+		t.Fatal("StreamOptions = nil, want cloned value")
+	}
+	if chatReq.StreamOptions == req.StreamOptions {
+		t.Fatal("StreamOptions pointer was reused")
+	}
+	if chatReq.StreamOptions.IncludeUsage {
+		t.Fatalf("IncludeUsage = %v, want false", chatReq.StreamOptions.IncludeUsage)
+	}
+}
+
+func TestStreamResponsesViaChat_InjectsUsageWhenPolicyEnabled(t *testing.T) {
+	provider := &capturingChatProvider{
+		streamData: "data: [DONE]\n\n",
+	}
+	req := &core.ResponsesRequest{
+		Model:         "gemini-2.0-flash",
+		Input:         "hello",
+		Stream:        true,
+		StreamOptions: &core.StreamOptions{IncludeUsage: false},
+	}
+	ctx := core.WithEnforceReturningUsageData(context.Background(), true)
+
+	stream, err := StreamResponsesViaChat(ctx, provider, req, "gemini")
+	if err != nil {
+		t.Fatalf("StreamResponsesViaChat() error = %v", err)
+	}
+	defer func() {
+		_ = stream.Close()
+	}()
+
+	if provider.capturedReq == nil {
+		t.Fatal("capturedReq = nil")
+	}
+	if provider.capturedReq.StreamOptions == nil {
+		t.Fatal("captured StreamOptions = nil")
+	}
+	if !provider.capturedReq.StreamOptions.IncludeUsage {
+		t.Fatal("captured IncludeUsage = false, want true")
+	}
+	if req.StreamOptions == nil {
+		t.Fatal("original StreamOptions unexpectedly nil")
+	}
+	if req.StreamOptions.IncludeUsage {
+		t.Fatal("original request was mutated")
+	}
+}
+
+func TestStreamResponsesViaChat_DoesNotInjectUsageWhenPolicyDisabled(t *testing.T) {
+	provider := &capturingChatProvider{
+		streamData: "data: [DONE]\n\n",
+	}
+	req := &core.ResponsesRequest{
+		Model:  "gemini-2.0-flash",
+		Input:  "hello",
+		Stream: true,
+	}
+
+	stream, err := StreamResponsesViaChat(context.Background(), provider, req, "gemini")
+	if err != nil {
+		t.Fatalf("StreamResponsesViaChat() error = %v", err)
+	}
+	defer func() {
+		_ = stream.Close()
+	}()
+
+	if provider.capturedReq == nil {
+		t.Fatal("capturedReq = nil")
+	}
+	if provider.capturedReq.StreamOptions != nil {
+		t.Fatalf("captured StreamOptions = %+v, want nil", provider.capturedReq.StreamOptions)
 	}
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -228,6 +228,22 @@ func (h *Handler) logUsage(model, providerType string, extractFn func(*core.Mode
 	}
 }
 
+func (h *Handler) shouldEnforceReturningUsageData() bool {
+	return h.usageLogger != nil && h.usageLogger.Config().EnforceReturningUsageData
+}
+
+func cloneChatRequestForStreamUsage(req *core.ChatRequest) *core.ChatRequest {
+	if req == nil {
+		return nil
+	}
+	cloned := *req
+	if req.StreamOptions != nil {
+		streamOptions := *req.StreamOptions
+		cloned.StreamOptions = &streamOptions
+	}
+	return &cloned
+}
+
 func resolveModelSelector(ctx context.Context, model, provider *string) error {
 	return core.NormalizeModelSelector(core.GetSemanticEnvelope(ctx), model, provider)
 }
@@ -560,14 +576,16 @@ func (h *Handler) ChatCompletion(c *echo.Context) error {
 	ctx = core.WithRequestID(ctx, requestID)
 
 	if req.Stream {
-		if h.usageLogger != nil && h.usageLogger.Config().EnforceReturningUsageData {
-			if req.StreamOptions == nil {
-				req.StreamOptions = &core.StreamOptions{}
+		streamReq := req
+		if h.shouldEnforceReturningUsageData() {
+			streamReq = cloneChatRequestForStreamUsage(req)
+			if streamReq.StreamOptions == nil {
+				streamReq.StreamOptions = &core.StreamOptions{}
 			}
-			req.StreamOptions.IncludeUsage = true
+			streamReq.StreamOptions.IncludeUsage = true
 		}
-		return h.handleStreamingResponse(c, req.Model, providerType, func() (io.ReadCloser, error) {
-			return h.provider.StreamChatCompletion(ctx, req)
+		return h.handleStreamingResponse(c, streamReq.Model, providerType, func() (io.ReadCloser, error) {
+			return h.provider.StreamChatCompletion(ctx, streamReq)
 		})
 	}
 
@@ -1040,6 +1058,9 @@ func (h *Handler) Responses(c *echo.Context) error {
 	requestID := c.Request().Header.Get("X-Request-ID")
 
 	if req.Stream {
+		if h.shouldEnforceReturningUsageData() {
+			ctx = core.WithEnforceReturningUsageData(ctx, true)
+		}
 		return h.handleStreamingResponse(c, req.Model, providerType, func() (io.ReadCloser, error) {
 			return h.provider.StreamResponses(ctx, req)
 		})

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -19,6 +19,7 @@ import (
 
 	"gomodel/internal/auditlog"
 	"gomodel/internal/core"
+	provideradapter "gomodel/internal/providers"
 	"gomodel/internal/usage"
 )
 
@@ -2806,6 +2807,16 @@ func (c *capturingProvider) StreamResponses(_ context.Context, req *core.Respons
 	return io.NopCloser(strings.NewReader(c.streamData)), nil
 }
 
+type chatBackedResponsesProvider struct {
+	capturingProvider
+	providerName string
+}
+
+func (p *chatBackedResponsesProvider) StreamResponses(ctx context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
+	p.capturedResponsesReq = req
+	return provideradapter.StreamResponsesViaChat(ctx, p, req, p.providerName)
+}
+
 func (c *capturingProvider) Embeddings(_ context.Context, req *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
 	c.capturedEmbeddingReq = req
 	if c.embeddingErr != nil {
@@ -2817,7 +2828,100 @@ func (c *capturingProvider) Embeddings(_ context.Context, req *core.EmbeddingReq
 	return c.embeddingResponse, nil
 }
 
-func TestStreamingResponses_DoesNotInjectStreamOptions(t *testing.T) {
+func TestStreamingResponses_ChatBackedProviderInjectsUsageWhenEnforced(t *testing.T) {
+	streamData := strings.Join([]string{
+		`data: {"id":"chatcmpl-1","choices":[{"delta":{"content":"hi"}}]}`,
+		`data: {"id":"chatcmpl-1","choices":[],"usage":{"prompt_tokens":7,"completion_tokens":3,"total_tokens":10}}`,
+		`data: [DONE]`,
+		"",
+	}, "\n\n")
+	provider := &chatBackedResponsesProvider{
+		capturingProvider: capturingProvider{
+			mockProvider: mockProvider{
+				supportedModels: []string{"gpt-4o-mini"},
+				streamData:      streamData,
+			},
+		},
+		providerName: "gemini",
+	}
+
+	usageLog := &mockUsageLogger{
+		config: usage.Config{
+			Enabled:                   true,
+			EnforceReturningUsageData: true,
+		},
+	}
+
+	e := echo.New()
+	handler := NewHandler(provider, nil, usageLog, nil)
+
+	reqBody := `{"model":"gpt-4o-mini","input":"Hello","stream":true}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(providerTypeKey), "mock")
+
+	if err := handler.Responses(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+	if provider.capturedResponsesReq == nil {
+		t.Fatal("capturedResponsesReq = nil")
+	}
+	if provider.capturedResponsesReq.StreamOptions != nil {
+		t.Fatalf("responses request was mutated: %+v", provider.capturedResponsesReq.StreamOptions)
+	}
+	if provider.capturedChatReq == nil {
+		t.Fatal("capturedChatReq = nil")
+	}
+	if provider.capturedChatReq.StreamOptions == nil || !provider.capturedChatReq.StreamOptions.IncludeUsage {
+		t.Fatalf("captured chat StreamOptions = %+v, want include_usage=true", provider.capturedChatReq.StreamOptions)
+	}
+}
+
+func TestStreamingResponses_ChatBackedProviderDoesNotInjectUsageWhenDisabled(t *testing.T) {
+	provider := &chatBackedResponsesProvider{
+		capturingProvider: capturingProvider{
+			mockProvider: mockProvider{
+				supportedModels: []string{"gpt-4o-mini"},
+				streamData:      "data: [DONE]\n\n",
+			},
+		},
+		providerName: "gemini",
+	}
+
+	usageLog := &mockUsageLogger{
+		config: usage.Config{
+			Enabled:                   true,
+			EnforceReturningUsageData: false,
+		},
+	}
+
+	e := echo.New()
+	handler := NewHandler(provider, nil, usageLog, nil)
+
+	reqBody := `{"model":"gpt-4o-mini","input":"Hello","stream":true}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(providerTypeKey), "mock")
+
+	if err := handler.Responses(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if provider.capturedChatReq == nil {
+		t.Fatal("capturedChatReq = nil")
+	}
+	if provider.capturedChatReq.StreamOptions != nil {
+		t.Fatalf("captured chat StreamOptions = %+v, want nil", provider.capturedChatReq.StreamOptions)
+	}
+}
+
+func TestStreamingResponses_NativeProviderRequestRemainsUnchanged(t *testing.T) {
 	streamData := "data: {\"type\":\"response.completed\"}\n\ndata: [DONE]\n\n"
 	provider := &capturingProvider{
 		mockProvider: mockProvider{
@@ -2836,27 +2940,79 @@ func TestStreamingResponses_DoesNotInjectStreamOptions(t *testing.T) {
 	e := echo.New()
 	handler := NewHandler(provider, nil, usageLog, nil)
 
-	// Streaming Responses request should NOT have StreamOptions injected
 	reqBody := `{"model":"gpt-4o-mini","input":"Hello","stream":true}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(reqBody))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
+	c.Set(string(providerTypeKey), "mock")
 
-	err := handler.Responses(c)
-	if err != nil {
+	if err := handler.Responses(c); err != nil {
 		t.Fatalf("handler returned error: %v", err)
 	}
-
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d", rec.Code)
 	}
-
 	if provider.capturedResponsesReq == nil {
-		t.Fatalf("expected capturedResponsesReq to be set, got nil")
+		t.Fatal("capturedResponsesReq = nil")
 	}
 	if provider.capturedResponsesReq.StreamOptions != nil {
-		t.Errorf("Responses streaming should NOT have StreamOptions injected, got: %+v", provider.capturedResponsesReq.StreamOptions)
+		t.Fatalf("native responses request should remain unchanged, got %+v", provider.capturedResponsesReq.StreamOptions)
+	}
+}
+
+func TestStreamingResponses_ChatBackedProviderWritesExactlyOneUsageEntry(t *testing.T) {
+	streamData := strings.Join([]string{
+		`data: {"id":"chatcmpl-1","model":"gemini-2.0-flash","choices":[{"delta":{"content":"hi"}}]}`,
+		`data: {"id":"chatcmpl-1","model":"gemini-2.0-flash","choices":[],"usage":{"prompt_tokens":11,"completion_tokens":5,"total_tokens":16}}`,
+		`data: [DONE]`,
+		"",
+	}, "\n\n")
+	provider := &chatBackedResponsesProvider{
+		capturingProvider: capturingProvider{
+			mockProvider: mockProvider{
+				supportedModels: []string{"gemini-2.0-flash"},
+				streamData:      streamData,
+			},
+		},
+		providerName: "gemini",
+	}
+	usageLog := &collectingUsageLogger{
+		config: usage.Config{
+			Enabled:                   true,
+			EnforceReturningUsageData: true,
+		},
+	}
+
+	e := echo.New()
+	handler := NewHandler(provider, nil, usageLog, nil)
+
+	reqBody := `{"model":"gemini-2.0-flash","input":"Hello","stream":true}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Request-ID", "req-stream-responses-1")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(providerTypeKey), "mock")
+
+	if err := handler.Responses(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if len(usageLog.entries) != 1 {
+		t.Fatalf("expected exactly 1 usage entry, got %d", len(usageLog.entries))
+	}
+	entry := usageLog.entries[0]
+	if entry.RequestID != "req-stream-responses-1" {
+		t.Fatalf("RequestID = %q, want req-stream-responses-1", entry.RequestID)
+	}
+	if entry.Provider != "mock" {
+		t.Fatalf("Provider = %q, want mock", entry.Provider)
+	}
+	if entry.Endpoint != "/v1/responses" {
+		t.Fatalf("Endpoint = %q, want /v1/responses", entry.Endpoint)
+	}
+	if entry.InputTokens != 11 || entry.OutputTokens != 5 || entry.TotalTokens != 16 {
+		t.Fatalf("usage entry = %+v, want 11/5/16 tokens", entry)
 	}
 }
 

--- a/internal/usage/factory.go
+++ b/internal/usage/factory.go
@@ -49,7 +49,7 @@ func New(ctx context.Context, cfg *config.Config) (*Result, error) {
 	// Return noop if usage tracking is disabled
 	if !cfg.Usage.Enabled {
 		return &Result{
-			Logger:  &NoopLogger{},
+			Logger:  NewNoopLogger(buildLoggerConfig(cfg.Usage)),
 			Storage: nil,
 		}, nil
 	}
@@ -86,7 +86,7 @@ func NewWithSharedStorage(ctx context.Context, cfg *config.Config, store storage
 	// Return noop if usage tracking is disabled
 	if !cfg.Usage.Enabled {
 		return &Result{
-			Logger:  &NoopLogger{},
+			Logger:  NewNoopLogger(buildLoggerConfig(cfg.Usage)),
 			Storage: nil,
 		}, nil
 	}

--- a/internal/usage/logger.go
+++ b/internal/usage/logger.go
@@ -184,14 +184,29 @@ func (l *Logger) flushBatch(batch []*UsageEntry) {
 }
 
 // NoopLogger is a logger that does nothing (used when usage tracking is disabled)
-type NoopLogger struct{}
+type NoopLogger struct {
+	config     Config
+	configured bool
+}
+
+// NewNoopLogger creates a disabled logger that still carries policy config such as
+// whether streaming requests should ask providers to include usage.
+func NewNoopLogger(cfg Config) *NoopLogger {
+	cfg.Enabled = false
+	return &NoopLogger{config: cfg, configured: true}
+}
 
 // Write does nothing
 func (l *NoopLogger) Write(_ *UsageEntry) {}
 
-// Config returns an empty config
+// Config returns the effective config with logging disabled.
 func (l *NoopLogger) Config() Config {
-	return Config{Enabled: false}
+	cfg := l.config
+	if !l.configured {
+		cfg = DefaultConfig()
+	}
+	cfg.Enabled = false
+	return cfg
 }
 
 // Close does nothing

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -68,8 +68,8 @@ type Config struct {
 	// Enabled controls whether usage tracking is active
 	Enabled bool
 
-	// EnforceReturningUsageData controls whether to enforce returning usage data in streaming responses.
-	// When true, stream_options: {"include_usage": true} is automatically added to streaming requests.
+	// EnforceReturningUsageData controls whether to ask streaming providers to return usage data when possible.
+	// When true, stream_options: {"include_usage": true} is added for provider paths that support it.
 	// Default: true
 	EnforceReturningUsageData bool
 

--- a/internal/usage/usage_test.go
+++ b/internal/usage/usage_test.go
@@ -170,10 +170,28 @@ func TestNoopLogger(t *testing.T) {
 	if cfg.Enabled {
 		t.Error("NoopLogger should report disabled")
 	}
+	if !cfg.EnforceReturningUsageData {
+		t.Error("NoopLogger should preserve default stream usage policy")
+	}
 
 	// Close should not error
 	if err := logger.Close(); err != nil {
 		t.Errorf("NoopLogger close error: %v", err)
+	}
+}
+
+func TestNewNoopLogger_PreservesConfiguredUsagePolicy(t *testing.T) {
+	logger := NewNoopLogger(Config{
+		Enabled:                   true,
+		EnforceReturningUsageData: false,
+	})
+
+	cfg := logger.Config()
+	if cfg.Enabled {
+		t.Error("NewNoopLogger should report disabled")
+	}
+	if cfg.EnforceReturningUsageData {
+		t.Error("NewNoopLogger should preserve false enforcement setting")
 	}
 }
 


### PR DESCRIPTION
## Summary
- move streamed `/v1/responses` usage enforcement into the chat-backed responses adapter
- force `include_usage=true` when `ENFORCE_RETURNING_USAGE_DATA` is enabled without mutating the canonical request
- preserve the policy on the noop usage logger path and add regression coverage for chat-backed, native, and end-to-end streamed usage persistence

## Validation
- go test ./config ./internal/usage ./internal/providers ./internal/server
- direct Gemini curl check confirmed streamed chat usage is returned only when `stream_options.include_usage=true`
- end-to-end GOModel + Gemini run wrote exactly one `/v1/responses` usage row to SQLite

Refs GOM-89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for requesting usage data in streaming responses from compatible providers based on configuration policy.

* **Bug Fixes**
  * Improved stream options handling to prevent unintended mutation of original requests during streaming operations.

* **Tests**
  * Added comprehensive tests covering conditional usage data injection and stream options cloning behavior.

* **Refactor**
  * Enhanced internal streaming logic to centralize and conditionally apply usage data enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->