### PR TITLE
docs: add observability flags to Quick Start docker command

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,7 @@
 # Server Configuration
 # PORT=8080
+# Log output format: "json" (default) or "text" (human-readable, colored in TTY)
+# LOG_FORMAT=json
 
 # Maximum request body size (prevents DoS attacks)
 # Accepts values like "10M", "1G", "500K" (default: 10M)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ A high-performance AI gateway written in Go, providing a unified OpenAI-compatib
 
 ```bash
 docker run --rm -p 8080:8080 \
+  -e LOGGING_ENABLED=true \
+  -e LOGGING_LOG_BODIES=true \
+  -e LOG_FORMAT=text \
+  -e LOGGING_LOG_HEADERS=true \
   -e OPENAI_API_KEY="your-openai-key" \
   enterpilot/gomodel
 ```

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -13,6 +13,10 @@ admin visibility in one place.
 
 ```bash
 docker run --rm -p 8080:8080 \
+  -e LOGGING_ENABLED=true \
+  -e LOGGING_LOG_BODIES=true \
+  -e LOG_FORMAT=text \
+  -e LOGGING_LOG_HEADERS=true \
   -e GOMODEL_MASTER_KEY="change-me" \
   -e OPENAI_API_KEY="sk-..." \
   enterpilot/gomodel


### PR DESCRIPTION
## Summary
- Update the primary Quick Start `docker run` example to include full observability flags (`LOGGING_ENABLED`, `LOGGING_LOG_BODIES`, `LOG_FORMAT=text`, `LOGGING_LOG_HEADERS`)
- New users now get logging and request/response capture out of the box
- The multi-provider docker run example is left unchanged

## Test plan
- [ ] Verify the README renders correctly on GitHub
- [ ] Confirm the docker command runs successfully with the new flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker Quick Start guide with new logging configuration environment variable options for enhanced control over logging behavior and output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->