### PR TITLE
feat: GitHub-style contribution calendar heatmap

### DIFF
--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -22,6 +22,11 @@
     --chart-tooltip-bg: #1e1d1c;
     --chart-tooltip-border: #2a2826;
     --chart-tooltip-text: #e8e0d6;
+    --cal-level-0: #161b22;
+    --cal-level-1: #0e4429;
+    --cal-level-2: #006d32;
+    --cal-level-3: #26a641;
+    --cal-level-4: #39d353;
     color-scheme: dark;
 }
 
@@ -43,6 +48,11 @@
     --chart-tooltip-bg: #ffffff;
     --chart-tooltip-border: #e8e0d6;
     --chart-tooltip-text: #2d2519;
+    --cal-level-0: #ebedf0;
+    --cal-level-1: #9be9a8;
+    --cal-level-2: #40c463;
+    --cal-level-3: #30a14e;
+    --cal-level-4: #216e39;
     color-scheme: light;
 }
 
@@ -65,6 +75,11 @@
         --chart-tooltip-bg: #ffffff;
         --chart-tooltip-border: #e8e0d6;
         --chart-tooltip-text: #2d2519;
+        --cal-level-0: #ebedf0;
+        --cal-level-1: #9be9a8;
+        --cal-level-2: #40c463;
+        --cal-level-3: #30a14e;
+        --cal-level-4: #216e39;
         color-scheme: light;
     }
 }
@@ -1547,6 +1562,135 @@ body.conversation-drawer-open {
     cursor: default;
 }
 
+/* Contribution Calendar */
+.contribution-calendar-section {
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 24px;
+    margin-top: 24px;
+}
+
+.contribution-calendar-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 16px;
+}
+
+.contribution-calendar-header h3 {
+    font-size: 16px;
+    font-weight: 600;
+}
+
+.contribution-calendar-grid-wrapper {
+    display: flex;
+    gap: 8px;
+}
+
+.contribution-calendar-day-labels {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding-top: 22px;
+}
+
+.contribution-calendar-day-labels span {
+    height: 13px;
+    font-size: 10px;
+    line-height: 13px;
+    color: var(--text-muted);
+    text-align: right;
+    min-width: 28px;
+}
+
+.contribution-calendar-scroll {
+    flex: 1;
+    overflow-x: auto;
+    min-width: 0;
+}
+
+.contribution-calendar-months {
+    display: grid;
+    grid-auto-columns: 15px;
+    grid-auto-flow: column;
+    gap: 2px;
+    margin-bottom: 6px;
+    height: 16px;
+}
+
+.contribution-calendar-month-label {
+    font-size: 10px;
+    color: var(--text-muted);
+    white-space: nowrap;
+}
+
+.contribution-calendar-grid {
+    display: flex;
+    gap: 2px;
+}
+
+.contribution-calendar-week {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.contribution-calendar-cell {
+    width: 13px;
+    height: 13px;
+    border-radius: 2px;
+    background: var(--cal-level-0);
+}
+
+.contribution-calendar-cell.level-1 { background: var(--cal-level-1); }
+.contribution-calendar-cell.level-2 { background: var(--cal-level-2); }
+.contribution-calendar-cell.level-3 { background: var(--cal-level-3); }
+.contribution-calendar-cell.level-4 { background: var(--cal-level-4); }
+.contribution-calendar-cell.empty { background: transparent; }
+
+.contribution-calendar-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 12px;
+}
+
+.contribution-calendar-summary {
+    font-size: 12px;
+    color: var(--text-muted);
+}
+
+.contribution-calendar-legend {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+    color: var(--text-muted);
+}
+
+.contribution-calendar-legend .contribution-calendar-cell {
+    width: 11px;
+    height: 11px;
+    cursor: default;
+}
+
+.contribution-calendar-tooltip {
+    position: fixed;
+    z-index: 200;
+    background: var(--bg-surface);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 4px 8px;
+    font-size: 12px;
+    font-family: 'SF Mono', Menlo, Consolas, monospace;
+    white-space: nowrap;
+    pointer-events: none;
+    transform: translateX(-50%);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
 /* Responsive */
 @media (max-width: 768px) {
     .sidebar { width: 60px; }
@@ -1637,6 +1781,10 @@ body.conversation-drawer-open {
     .chat-message {
         max-width: 100%;
     }
+
+    /* Contribution calendar mobile */
+    .contribution-calendar-day-labels { display: none; }
+    .contribution-calendar-section { padding: 16px; }
 
     /* Date picker mobile */
     .date-picker-dropdown {

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -106,6 +106,7 @@ function dashboard() {
             });
 
             this.fetchAll();
+            this.fetchCalendarData();
         },
 
         toggleSidebar() {
@@ -315,6 +316,7 @@ function dashboard() {
         typeof dashboardUsageModule === 'function' ? dashboardUsageModule : null,
         typeof dashboardAuditListModule === 'function' ? dashboardAuditListModule : null,
         typeof dashboardConversationDrawerModule === 'function' ? dashboardConversationDrawerModule : null,
+        typeof dashboardContributionCalendarModule === 'function' ? dashboardContributionCalendarModule : null,
         typeof dashboardChartsModule === 'function' ? dashboardChartsModule : null
     ];
 

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -1,6 +1,9 @@
 // GOModel Dashboard — Alpine.js + Chart.js logic
 
 function dashboard() {
+    const calendarModuleFactory =
+        typeof dashboardContributionCalendarModule === 'function' ? dashboardContributionCalendarModule : null;
+
     const base = {
         // State
         page: 'overview',
@@ -30,6 +33,7 @@ function dashboard() {
         models: [],
         categories: [],
         activeCategory: 'all',
+        hasCalendarModule: calendarModuleFactory !== null,
 
         // Filters
         modelFilter: '',
@@ -106,7 +110,6 @@ function dashboard() {
             });
 
             this.fetchAll();
-            this.fetchCalendarData();
         },
 
         toggleSidebar() {
@@ -180,7 +183,11 @@ function dashboard() {
             this.loading = true;
             this.authError = false;
             this.needsAuth = false;
-            await Promise.all([this.fetchUsage(), this.fetchModels(), this.fetchCategories()]);
+            const requests = [this.fetchUsage(), this.fetchModels(), this.fetchCategories()];
+            if (this.hasCalendarModule && typeof this.fetchCalendarData === 'function') {
+                requests.push(this.fetchCalendarData());
+            }
+            await Promise.all(requests);
             this.loading = false;
         },
 
@@ -316,7 +323,7 @@ function dashboard() {
         typeof dashboardUsageModule === 'function' ? dashboardUsageModule : null,
         typeof dashboardAuditListModule === 'function' ? dashboardAuditListModule : null,
         typeof dashboardConversationDrawerModule === 'function' ? dashboardConversationDrawerModule : null,
-        typeof dashboardContributionCalendarModule === 'function' ? dashboardContributionCalendarModule : null,
+        calendarModuleFactory,
         typeof dashboardChartsModule === 'function' ? dashboardChartsModule : null
     ];
 

--- a/internal/admin/dashboard/static/js/modules/charts.js
+++ b/internal/admin/dashboard/static/js/modules/charts.js
@@ -17,7 +17,7 @@
                 const result = [];
                 for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
                     const key = d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
-                    result.push(byDate[key] || { date: key, input_tokens: 0, output_tokens: 0, total_tokens: 0, requests: 0 });
+                    result.push(byDate[key] || { date: key, input_tokens: 0, output_tokens: 0, total_tokens: 0, requests: 0, input_cost: null, output_cost: null, total_cost: null });
                 }
                 return result;
             },

--- a/internal/admin/dashboard/static/js/modules/contribution-calendar.js
+++ b/internal/admin/dashboard/static/js/modules/contribution-calendar.js
@@ -1,0 +1,170 @@
+(function(global) {
+    function dashboardContributionCalendarModule() {
+        return {
+            calendarData: [],
+            calendarMode: 'tokens',
+            calendarLoading: false,
+            calendarTooltip: { show: false, x: 0, y: 0, text: '' },
+
+            async fetchCalendarData() {
+                this.calendarLoading = true;
+                try {
+                    const res = await fetch('/admin/api/v1/usage/daily?days=365&interval=daily', { headers: this.headers() });
+                    if (!this.handleFetchResponse(res, 'calendar')) {
+                        this.calendarData = [];
+                        return;
+                    }
+                    this.calendarData = await res.json();
+                } catch (e) {
+                    console.error('Failed to fetch calendar data:', e);
+                    this.calendarData = [];
+                } finally {
+                    this.calendarLoading = false;
+                }
+            },
+
+            buildCalendarGrid() {
+                var byDate = {};
+                (this.calendarData || []).forEach(function(d) { byDate[d.date] = d; });
+
+                var today = new Date();
+                today.setHours(0, 0, 0, 0);
+
+                var start = new Date(today);
+                start.setDate(start.getDate() - 364);
+
+                // Align start to Monday (ISO week start)
+                var dayOfWeek = start.getDay();
+                var diff = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+                start.setDate(start.getDate() + diff);
+
+                var mode = this.calendarMode;
+                var days = [];
+                for (var d = new Date(start); d <= today; d.setDate(d.getDate() + 1)) {
+                    var key = d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
+                    var entry = byDate[key];
+                    var value = 0;
+                    if (entry) {
+                        if (mode === 'costs') {
+                            value = entry.total_cost != null ? entry.total_cost : 0;
+                        } else {
+                            value = entry.total_tokens || 0;
+                        }
+                    }
+                    days.push({ dateStr: key, value: value, level: 0, empty: false });
+                }
+
+                // Calculate levels based on non-zero values
+                var nonZero = days.filter(function(d) { return d.value > 0; }).map(function(d) { return d.value; });
+                nonZero.sort(function(a, b) { return a - b; });
+                var max = nonZero.length > 0 ? nonZero[nonZero.length - 1] : 0;
+
+                for (var i = 0; i < days.length; i++) {
+                    days[i].level = this.calendarLevel(days[i].value, max, nonZero);
+                }
+
+                // Build weeks (columns)
+                var weeks = [];
+                var week = [];
+                for (var j = 0; j < days.length; j++) {
+                    week.push(days[j]);
+                    if (week.length === 7) {
+                        weeks.push(week);
+                        week = [];
+                    }
+                }
+                if (week.length > 0) {
+                    // Pad remaining week with empty slots
+                    while (week.length < 7) {
+                        week.push({ dateStr: '', value: 0, level: 0, empty: true });
+                    }
+                    weeks.push(week);
+                }
+
+                return weeks;
+            },
+
+            calendarLevel(value, max, sortedNonZero) {
+                if (value === 0 || max === 0) return 0;
+                if (!sortedNonZero || sortedNonZero.length === 0) return 0;
+                var len = sortedNonZero.length;
+                var q1 = sortedNonZero[Math.floor(len * 0.25)];
+                var q2 = sortedNonZero[Math.floor(len * 0.5)];
+                var q3 = sortedNonZero[Math.floor(len * 0.75)];
+                if (value <= q1) return 1;
+                if (value <= q2) return 2;
+                if (value <= q3) return 3;
+                return 4;
+            },
+
+            toggleCalendarMode(mode) {
+                this.calendarMode = mode;
+            },
+
+            calendarMonthLabels() {
+                var today = new Date();
+                today.setHours(0, 0, 0, 0);
+                var start = new Date(today);
+                start.setDate(start.getDate() - 364);
+                var dayOfWeek = start.getDay();
+                var diff = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+                start.setDate(start.getDate() + diff);
+
+                var months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+                var labels = [];
+                var lastMonth = -1;
+                var weekIdx = 0;
+
+                for (var d = new Date(start); d <= today; ) {
+                    var m = d.getMonth();
+                    if (m !== lastMonth) {
+                        labels.push({ label: months[m], col: weekIdx, key: m + '-' + d.getFullYear() });
+                        lastMonth = m;
+                    }
+                    d.setDate(d.getDate() + 7);
+                    weekIdx++;
+                }
+
+                return labels;
+            },
+
+            calendarSummaryText() {
+                var weeks = this.buildCalendarGrid();
+                var total = 0;
+                for (var i = 0; i < weeks.length; i++) {
+                    for (var j = 0; j < weeks[i].length; j++) {
+                        if (!weeks[i][j].empty) {
+                            total += weeks[i][j].value;
+                        }
+                    }
+                }
+                if (this.calendarMode === 'costs') {
+                    return '$' + total.toFixed(2) + ' in the last year';
+                }
+                return total.toLocaleString() + ' tokens in the last year';
+            },
+
+            showCalendarTooltip(event, day) {
+                if (day.empty) return;
+                var label = '';
+                if (this.calendarMode === 'costs') {
+                    label = '$' + (day.value || 0).toFixed(4) + ' on ' + day.dateStr;
+                } else {
+                    label = (day.value || 0).toLocaleString() + ' tokens on ' + day.dateStr;
+                }
+                this.calendarTooltip = {
+                    show: true,
+                    x: event.clientX,
+                    y: event.clientY,
+                    text: label
+                };
+            },
+
+            hideCalendarTooltip() {
+                this.calendarTooltip = { show: false, x: 0, y: 0, text: '' };
+            }
+        };
+    }
+
+    global.dashboardContributionCalendarModule = dashboardContributionCalendarModule;
+})(window);

--- a/internal/admin/dashboard/static/js/modules/contribution-calendar.js
+++ b/internal/admin/dashboard/static/js/modules/contribution-calendar.js
@@ -129,13 +129,21 @@
             },
 
             calendarSummaryText() {
-                var weeks = this.buildCalendarGrid();
                 var total = 0;
-                for (var i = 0; i < weeks.length; i++) {
-                    for (var j = 0; j < weeks[i].length; j++) {
-                        if (!weeks[i][j].empty) {
-                            total += weeks[i][j].value;
+                var data = this.calendarData || [];
+                for (var i = 0; i < data.length; i++) {
+                    var entry = data[i];
+                    if (!entry) {
+                        continue;
+                    }
+                    if (this.calendarMode === 'costs') {
+                        if (entry.total_cost) {
+                            total += entry.total_cost;
                         }
+                        continue;
+                    }
+                    if (entry.total_tokens) {
+                        total += entry.total_tokens;
                     }
                 }
                 if (this.calendarMode === 'costs') {

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -51,6 +51,63 @@
         </div>
         <p class="empty-state" x-show="daily.length === 0 && !loading && !authError">No usage data yet.</p>
     </div>
+
+    <!-- Contribution Calendar -->
+    <div class="contribution-calendar-section">
+        <div class="contribution-calendar-header">
+            <h3>Activity</h3>
+            <div class="usage-mode-toggle">
+                <button class="usage-mode-btn" :class="{active: calendarMode==='tokens'}" @click="toggleCalendarMode('tokens')">Tokens</button>
+                <button class="usage-mode-btn" :class="{active: calendarMode==='costs'}" @click="toggleCalendarMode('costs')">Costs</button>
+            </div>
+        </div>
+        <div class="contribution-calendar-grid-wrapper">
+            <div class="contribution-calendar-day-labels">
+                <span></span>
+                <span>Mon</span>
+                <span></span>
+                <span>Wed</span>
+                <span></span>
+                <span>Fri</span>
+                <span></span>
+            </div>
+            <div class="contribution-calendar-scroll">
+                <div class="contribution-calendar-months">
+                    <template x-for="ml in calendarMonthLabels()" :key="ml.key">
+                        <span class="contribution-calendar-month-label" :style="'grid-column: ' + (ml.col + 1)" x-text="ml.label"></span>
+                    </template>
+                </div>
+                <div class="contribution-calendar-grid">
+                    <template x-for="(week, wi) in buildCalendarGrid()" :key="wi">
+                        <div class="contribution-calendar-week">
+                            <template x-for="(day, di) in week" :key="wi + '-' + di">
+                                <div class="contribution-calendar-cell"
+                                     :class="[day.empty ? 'empty' : 'level-' + day.level]"
+                                     @mouseenter="showCalendarTooltip($event, day)"
+                                     @mouseleave="hideCalendarTooltip()"></div>
+                            </template>
+                        </div>
+                    </template>
+                </div>
+            </div>
+        </div>
+        <div class="contribution-calendar-footer">
+            <span class="contribution-calendar-summary" x-text="calendarSummaryText()"></span>
+            <div class="contribution-calendar-legend">
+                <span>Less</span>
+                <div class="contribution-calendar-cell level-0"></div>
+                <div class="contribution-calendar-cell level-1"></div>
+                <div class="contribution-calendar-cell level-2"></div>
+                <div class="contribution-calendar-cell level-3"></div>
+                <div class="contribution-calendar-cell level-4"></div>
+                <span>More</span>
+            </div>
+        </div>
+    </div>
+    <div class="contribution-calendar-tooltip"
+         x-show="calendarTooltip.show"
+         x-text="calendarTooltip.text"
+         :style="'left: ' + calendarTooltip.x + 'px; top: ' + (calendarTooltip.y - 40) + 'px'"></div>
 </div>
 
 <!-- Usage Page -->

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -57,8 +57,8 @@
         <div class="contribution-calendar-header">
             <h3>Activity</h3>
             <div class="usage-mode-toggle">
-                <button class="usage-mode-btn" :class="{active: calendarMode==='tokens'}" @click="toggleCalendarMode('tokens')">Tokens</button>
-                <button class="usage-mode-btn" :class="{active: calendarMode==='costs'}" @click="toggleCalendarMode('costs')">Costs</button>
+                <button type="button" class="usage-mode-btn" :class="{active: calendarMode==='tokens'}" @click="toggleCalendarMode('tokens')">Tokens</button>
+                <button type="button" class="usage-mode-btn" :class="{active: calendarMode==='costs'}" @click="toggleCalendarMode('costs')">Costs</button>
             </div>
         </div>
         <div class="contribution-calendar-grid-wrapper">

--- a/internal/admin/dashboard/templates/layout.html
+++ b/internal/admin/dashboard/templates/layout.html
@@ -87,6 +87,7 @@
     <script src="/admin/static/js/modules/usage.js"></script>
     <script src="/admin/static/js/modules/audit-list.js"></script>
     <script src="/admin/static/js/modules/conversation-drawer.js"></script>
+    <script src="/admin/static/js/modules/contribution-calendar.js"></script>
     <script src="/admin/static/js/modules/charts.js"></script>
     <script src="/admin/static/js/dashboard.js"></script>
 </body>

--- a/internal/usage/reader.go
+++ b/internal/usage/reader.go
@@ -38,11 +38,14 @@ type ModelUsage struct {
 // Date holds the period label: YYYY-MM-DD for daily, YYYY-Www for weekly,
 // YYYY-MM for monthly, or YYYY for yearly intervals.
 type DailyUsage struct {
-	Date         string `json:"date"`
-	Requests     int    `json:"requests"`
-	InputTokens  int64  `json:"input_tokens"`
-	OutputTokens int64  `json:"output_tokens"`
-	TotalTokens  int64  `json:"total_tokens"`
+	Date         string   `json:"date"`
+	Requests     int      `json:"requests"`
+	InputTokens  int64    `json:"input_tokens"`
+	OutputTokens int64    `json:"output_tokens"`
+	TotalTokens  int64    `json:"total_tokens"`
+	InputCost    *float64 `json:"input_cost"`
+	OutputCost   *float64 `json:"output_cost"`
+	TotalCost    *float64 `json:"total_cost"`
 }
 
 // UsageLogParams specifies query parameters for paginated usage log retrieval.

--- a/internal/usage/reader.go
+++ b/internal/usage/reader.go
@@ -14,13 +14,13 @@ type UsageQueryParams struct {
 
 // UsageSummary holds aggregated usage statistics over a time period.
 type UsageSummary struct {
-	TotalRequests  int      `json:"total_requests"`
-	TotalInput     int64    `json:"total_input_tokens"`
-	TotalOutput    int64    `json:"total_output_tokens"`
-	TotalTokens    int64    `json:"total_tokens"`
-	TotalInputCost *float64 `json:"total_input_cost"`
+	TotalRequests   int      `json:"total_requests"`
+	TotalInput      int64    `json:"total_input_tokens"`
+	TotalOutput     int64    `json:"total_output_tokens"`
+	TotalTokens     int64    `json:"total_tokens"`
+	TotalInputCost  *float64 `json:"total_input_cost"`
 	TotalOutputCost *float64 `json:"total_output_cost"`
-	TotalCost      *float64 `json:"total_cost"`
+	TotalCost       *float64 `json:"total_cost"`
 }
 
 // ModelUsage holds per-model token usage aggregates.
@@ -50,28 +50,28 @@ type DailyUsage struct {
 
 // UsageLogParams specifies query parameters for paginated usage log retrieval.
 type UsageLogParams struct {
-	UsageQueryParams                // embed date range
-	Model            string         // filter by model (optional)
-	Provider         string         // filter by provider (optional)
-	Search           string         // free-text search on model/provider/request_id
-	Limit            int            // page size (default 50, max 200)
-	Offset           int            // pagination offset
+	UsageQueryParams        // embed date range
+	Model            string // filter by model (optional)
+	Provider         string // filter by provider (optional)
+	Search           string // free-text search on model/provider/request_id
+	Limit            int    // page size (default 50, max 200)
+	Offset           int    // pagination offset
 }
 
 // UsageLogEntry represents a single usage record in the request log.
 type UsageLogEntry struct {
-	ID                     string    `json:"id"`
-	RequestID              string    `json:"request_id"`
-	ProviderID             string    `json:"provider_id"`
-	Timestamp              time.Time `json:"timestamp"`
-	Model                  string    `json:"model"`
-	Provider               string    `json:"provider"`
-	Endpoint               string    `json:"endpoint"`
-	InputTokens            int       `json:"input_tokens"`
-	OutputTokens           int       `json:"output_tokens"`
-	TotalTokens            int       `json:"total_tokens"`
-	InputCost              *float64  `json:"input_cost"`
-	OutputCost             *float64  `json:"output_cost"`
+	ID                     string         `json:"id"`
+	RequestID              string         `json:"request_id"`
+	ProviderID             string         `json:"provider_id"`
+	Timestamp              time.Time      `json:"timestamp"`
+	Model                  string         `json:"model"`
+	Provider               string         `json:"provider"`
+	Endpoint               string         `json:"endpoint"`
+	InputTokens            int            `json:"input_tokens"`
+	OutputTokens           int            `json:"output_tokens"`
+	TotalTokens            int            `json:"total_tokens"`
+	InputCost              *float64       `json:"input_cost"`
+	OutputCost             *float64       `json:"output_cost"`
 	TotalCost              *float64       `json:"total_cost"`
 	RawData                map[string]any `json:"raw_data,omitempty"`
 	CostsCalculationCaveat string         `json:"costs_calculation_caveat,omitempty"`

--- a/internal/usage/reader_mongodb.go
+++ b/internal/usage/reader_mongodb.go
@@ -323,6 +323,10 @@ func (r *MongoDBReader) GetDailyUsage(ctx context.Context, params UsageQueryPara
 			{Key: "input_tokens", Value: bson.D{{Key: "$sum", Value: "$input_tokens"}}},
 			{Key: "output_tokens", Value: bson.D{{Key: "$sum", Value: "$output_tokens"}}},
 			{Key: "total_tokens", Value: bson.D{{Key: "$sum", Value: "$total_tokens"}}},
+			{Key: "input_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$ifNull", Value: bson.A{"$input_cost", 0}}}}}},
+			{Key: "output_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$ifNull", Value: bson.A{"$output_cost", 0}}}}}},
+			{Key: "total_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$ifNull", Value: bson.A{"$total_cost", 0}}}}}},
+			{Key: "has_costs", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$cond", Value: bson.A{bson.D{{Key: "$gt", Value: bson.A{"$total_cost", nil}}}, 1, 0}}}}}},
 		}}},
 		bson.D{{Key: "$sort", Value: bson.D{{Key: "_id", Value: 1}}}},
 	)
@@ -336,22 +340,32 @@ func (r *MongoDBReader) GetDailyUsage(ctx context.Context, params UsageQueryPara
 	result := make([]DailyUsage, 0)
 	for cursor.Next(ctx) {
 		var row struct {
-			Date         string `bson:"_id"`
-			Requests     int    `bson:"requests"`
-			InputTokens  int64  `bson:"input_tokens"`
-			OutputTokens int64  `bson:"output_tokens"`
-			TotalTokens  int64  `bson:"total_tokens"`
+			Date         string  `bson:"_id"`
+			Requests     int     `bson:"requests"`
+			InputTokens  int64   `bson:"input_tokens"`
+			OutputTokens int64   `bson:"output_tokens"`
+			TotalTokens  int64   `bson:"total_tokens"`
+			InputCost    float64 `bson:"input_cost"`
+			OutputCost   float64 `bson:"output_cost"`
+			TotalCost    float64 `bson:"total_cost"`
+			HasCosts     int     `bson:"has_costs"`
 		}
 		if err := cursor.Decode(&row); err != nil {
 			return nil, fmt.Errorf("failed to decode daily usage row: %w", err)
 		}
-		result = append(result, DailyUsage{
+		d := DailyUsage{
 			Date:         row.Date,
 			Requests:     row.Requests,
 			InputTokens:  row.InputTokens,
 			OutputTokens: row.OutputTokens,
 			TotalTokens:  row.TotalTokens,
-		})
+		}
+		if row.HasCosts > 0 {
+			d.InputCost = &row.InputCost
+			d.OutputCost = &row.OutputCost
+			d.TotalCost = &row.TotalCost
+		}
+		result = append(result, d)
 	}
 
 	if err := cursor.Err(); err != nil {

--- a/internal/usage/reader_postgresql.go
+++ b/internal/usage/reader_postgresql.go
@@ -187,7 +187,8 @@ func (r *PostgreSQLReader) GetDailyUsage(ctx context.Context, params UsageQueryP
 	conditions, args, _ := pgDateRangeConditions(params, 1)
 	where := buildWhereClause(conditions)
 
-	query := fmt.Sprintf(`SELECT %s as period, COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)
+	costCols := `, COALESCE(SUM(input_cost),0), COALESCE(SUM(output_cost),0), COALESCE(SUM(total_cost),0)`
+	query := fmt.Sprintf(`SELECT %s as period, COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)`+costCols+`
 		FROM "usage"%s GROUP BY %s ORDER BY period`, groupExpr, where, groupExpr)
 
 	rows, err := r.pool.Query(ctx, query, args...)
@@ -199,7 +200,7 @@ func (r *PostgreSQLReader) GetDailyUsage(ctx context.Context, params UsageQueryP
 	result := make([]DailyUsage, 0)
 	for rows.Next() {
 		var d DailyUsage
-		if err := rows.Scan(&d.Date, &d.Requests, &d.InputTokens, &d.OutputTokens, &d.TotalTokens); err != nil {
+		if err := rows.Scan(&d.Date, &d.Requests, &d.InputTokens, &d.OutputTokens, &d.TotalTokens, &d.InputCost, &d.OutputCost, &d.TotalCost); err != nil {
 			return nil, fmt.Errorf("failed to scan daily usage row: %w", err)
 		}
 		result = append(result, d)

--- a/internal/usage/reader_postgresql.go
+++ b/internal/usage/reader_postgresql.go
@@ -27,7 +27,7 @@ func (r *PostgreSQLReader) GetSummary(ctx context.Context, params UsageQueryPara
 	conditions, args, _ := pgDateRangeConditions(params, 1)
 	where := buildWhereClause(conditions)
 
-	costCols := `, COALESCE(SUM(input_cost),0), COALESCE(SUM(output_cost),0), COALESCE(SUM(total_cost),0)`
+	costCols := `, SUM(input_cost), SUM(output_cost), SUM(total_cost)`
 	query := `SELECT COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)` + costCols + `
 			FROM "usage"` + where
 
@@ -48,7 +48,7 @@ func (r *PostgreSQLReader) GetUsageByModel(ctx context.Context, params UsageQuer
 	conditions, args, _ := pgDateRangeConditions(params, 1)
 	where := buildWhereClause(conditions)
 
-	costCols := `, COALESCE(SUM(input_cost),0), COALESCE(SUM(output_cost),0), COALESCE(SUM(total_cost),0)`
+	costCols := `, SUM(input_cost), SUM(output_cost), SUM(total_cost)`
 	query := `SELECT model, provider, COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0)` + costCols + `
 			FROM "usage"` + where + ` GROUP BY model, provider`
 
@@ -187,7 +187,7 @@ func (r *PostgreSQLReader) GetDailyUsage(ctx context.Context, params UsageQueryP
 	conditions, args, _ := pgDateRangeConditions(params, 1)
 	where := buildWhereClause(conditions)
 
-	costCols := `, COALESCE(SUM(input_cost),0), COALESCE(SUM(output_cost),0), COALESCE(SUM(total_cost),0)`
+	costCols := `, SUM(input_cost), SUM(output_cost), SUM(total_cost)`
 	query := fmt.Sprintf(`SELECT %s as period, COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)`+costCols+`
 		FROM "usage"%s GROUP BY %s ORDER BY period`, groupExpr, where, groupExpr)
 

--- a/internal/usage/reader_sqlite.go
+++ b/internal/usage/reader_sqlite.go
@@ -195,7 +195,8 @@ func (r *SQLiteReader) GetDailyUsage(ctx context.Context, params UsageQueryParam
 	conditions, args := sqliteDateRangeConditions(params)
 	where := buildWhereClause(conditions)
 
-	query := fmt.Sprintf(`SELECT %s as period, COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)
+	costCols := `, COALESCE(SUM(input_cost),0), COALESCE(SUM(output_cost),0), COALESCE(SUM(total_cost),0)`
+	query := fmt.Sprintf(`SELECT %s as period, COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)`+costCols+`
 		FROM usage%s GROUP BY %s ORDER BY period`, groupExpr, where, groupExpr)
 
 	rows, err := r.db.QueryContext(ctx, query, args...)
@@ -207,7 +208,7 @@ func (r *SQLiteReader) GetDailyUsage(ctx context.Context, params UsageQueryParam
 	result := make([]DailyUsage, 0)
 	for rows.Next() {
 		var d DailyUsage
-		if err := rows.Scan(&d.Date, &d.Requests, &d.InputTokens, &d.OutputTokens, &d.TotalTokens); err != nil {
+		if err := rows.Scan(&d.Date, &d.Requests, &d.InputTokens, &d.OutputTokens, &d.TotalTokens, &d.InputCost, &d.OutputCost, &d.TotalCost); err != nil {
 			return nil, fmt.Errorf("failed to scan daily usage row: %w", err)
 		}
 		result = append(result, d)

--- a/internal/usage/reader_sqlite.go
+++ b/internal/usage/reader_sqlite.go
@@ -27,7 +27,7 @@ func (r *SQLiteReader) GetSummary(ctx context.Context, params UsageQueryParams) 
 	conditions, args := sqliteDateRangeConditions(params)
 	where := buildWhereClause(conditions)
 
-	costCols := `, COALESCE(SUM(input_cost),0), COALESCE(SUM(output_cost),0), COALESCE(SUM(total_cost),0)`
+	costCols := `, SUM(input_cost), SUM(output_cost), SUM(total_cost)`
 	query := `SELECT COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)` + costCols + `
 			FROM usage` + where
 
@@ -48,7 +48,7 @@ func (r *SQLiteReader) GetUsageByModel(ctx context.Context, params UsageQueryPar
 	conditions, args := sqliteDateRangeConditions(params)
 	where := buildWhereClause(conditions)
 
-	costCols := `, COALESCE(SUM(input_cost),0), COALESCE(SUM(output_cost),0), COALESCE(SUM(total_cost),0)`
+	costCols := `, SUM(input_cost), SUM(output_cost), SUM(total_cost)`
 	query := `SELECT model, provider, COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0)` + costCols + `
 			FROM usage` + where + ` GROUP BY model, provider`
 
@@ -195,7 +195,7 @@ func (r *SQLiteReader) GetDailyUsage(ctx context.Context, params UsageQueryParam
 	conditions, args := sqliteDateRangeConditions(params)
 	where := buildWhereClause(conditions)
 
-	costCols := `, COALESCE(SUM(input_cost),0), COALESCE(SUM(output_cost),0), COALESCE(SUM(total_cost),0)`
+	costCols := `, SUM(input_cost), SUM(output_cost), SUM(total_cost)`
 	query := fmt.Sprintf(`SELECT %s as period, COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)`+costCols+`
 		FROM usage%s GROUP BY %s ORDER BY period`, groupExpr, where, groupExpr)
 


### PR DESCRIPTION
## Summary
- Add a year-long GitHub-style contribution calendar heatmap to the dashboard Overview page showing daily token consumption or cost data
- Extend `DailyUsage` struct with `InputCost`, `OutputCost`, `TotalCost` fields and update all three database readers (SQLite, PostgreSQL, MongoDB) to aggregate cost data
- New `contribution-calendar.js` module with independent data fetching (`/admin/api/v1/usage/daily?days=365`), switchable Tokens/Costs modes, quartile-based intensity levels, hover tooltips, and month labels
- Full dark/light theme support using GitHub's green heatmap palette, responsive layout with horizontal scroll on mobile

## Test plan
- [x] `make test` — all 23 packages pass, all pre-commit hooks pass
- [ ] `make run` — verify calendar renders on `/admin/dashboard/overview`
- [ ] Toggle between Tokens and Costs modes
- [ ] Hover cells to verify tooltip shows date + value
- [ ] Switch dark/light theme — verify heatmap colors adapt
- [ ] Check mobile layout — calendar scrolls horizontally, day labels hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Yearly contribution calendar added to the admin dashboard showing daily activity.
  * Toggle between Tokens and Costs views, with interactive tooltips and month/day labels.
  * Daily usage now shows input, output, and total costs alongside token metrics.
  * Mobile-responsive calendar layout and compact adjustments for small screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->