### PR TITLE
chore(release): rebuild automatic release notes pipeline

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-## Summary
+# Summary
 
 Describe what changed and why.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+## Summary
+
+Describe what changed and why.
+
+## PR Title Format (required)
+
+Use Conventional Commits in the PR title:
+
+`type(scope): short summary`
+
+Examples:
+- `feat(cache): add Redis-backed model cache`
+- `fix(streaming): flush done marker in SSE`
+- `docs(config): clarify provider auto-discovery`
+
+Allowed `type` values:
+- `feat`
+- `fix`
+- `perf`
+- `docs`
+- `refactor`
+- `test`
+- `build`
+- `ci`
+- `chore`
+- `revert`
+
+Breaking changes:
+- Add `!` before `:` (example: `feat(api)!: remove legacy endpoint`)
+
+## Release Notes
+
+- User-facing work should use `feat`, `fix`, `perf`, or `docs`.
+- Internal-only work (`test`, `ci`, `build`, `chore`, many `refactor`s) is auto-labeled and excluded from release notes.
+- Use `release:skip` label to explicitly exclude an item from release notes.

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,31 @@
+changelog:
+  exclude:
+    labels:
+      - release:skip
+      - release:internal
+      - skip-release-notes
+  categories:
+    - title: Breaking Changes
+      labels:
+        - release:breaking
+    - title: Features
+      labels:
+        - release:feature
+    - title: Bug Fixes
+      labels:
+        - release:fix
+    - title: Performance
+      labels:
+        - release:performance
+    - title: Documentation
+      labels:
+        - release:docs
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: Maintenance
+      labels:
+        - release:maintenance
+    - title: Other Changes
+      labels:
+        - release:other

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,31 @@
+name: PR Title
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  semantic-pr-title:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title (Conventional Commits)
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            docs
+            test
+            build
+            ci
+            chore
+            revert

--- a/.github/workflows/release-labels.yml
+++ b/.github/workflows/release-labels.yml
@@ -1,0 +1,109 @@
+name: Release Labels
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  apply-release-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Map PR title to release labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const title = pr.title || "";
+            const match = title.match(/^([a-z]+)(\([^)]+\))?(!)?:\s.+/);
+            const type = match ? match[1] : "";
+            const isBreaking = Boolean(match && match[3]);
+
+            const typeToPrimaryLabel = {
+              feat: "release:feature",
+              fix: "release:fix",
+              perf: "release:performance",
+              docs: "release:docs",
+              refactor: "release:internal",
+              test: "release:internal",
+              build: "release:internal",
+              ci: "release:internal",
+              chore: "release:internal",
+              revert: "release:other",
+            };
+
+            const labelDefinitions = [
+              { name: "release:feature", color: "1d76db", description: "User-visible feature for release notes" },
+              { name: "release:fix", color: "d73a4a", description: "User-visible bug fix for release notes" },
+              { name: "release:performance", color: "5319e7", description: "Performance improvement for release notes" },
+              { name: "release:docs", color: "0075ca", description: "Documentation change for release notes" },
+              { name: "release:other", color: "fbca04", description: "Other release-noteworthy changes" },
+              { name: "release:internal", color: "cfd3d7", description: "Internal changes excluded from release notes" },
+              { name: "release:maintenance", color: "bfdadc", description: "Maintenance changes for release notes" },
+              { name: "release:breaking", color: "b60205", description: "Breaking change" },
+              { name: "release:skip", color: "ffffff", description: "Explicitly exclude from release notes" },
+            ];
+
+            for (const label of labelDefinitions) {
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                  color: label.color,
+                  description: label.description,
+                });
+              } catch (error) {
+                if (error.status !== 422) {
+                  throw error;
+                }
+              }
+            }
+
+            const primaryLabel = typeToPrimaryLabel[type] || "release:other";
+            const desired = [primaryLabel];
+            if (isBreaking) desired.push("release:breaking");
+
+            const managedLabels = [
+              "release:feature",
+              "release:fix",
+              "release:performance",
+              "release:docs",
+              "release:other",
+              "release:internal",
+              "release:breaking",
+            ];
+
+            const currentLabels = pr.labels.map((label) => label.name);
+            const toRemove = managedLabels.filter(
+              (label) => currentLabels.includes(label) && !desired.includes(label),
+            );
+
+            for (const label of toRemove) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  name: label,
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+            }
+
+            const toAdd = desired.filter((label) => !currentLabels.includes(label));
+            if (toAdd.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                labels: toAdd,
+              });
+            }

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,24 +41,9 @@ snapshot:
   version_template: "{{ .Tag }}-next"
 
 changelog:
-  use: github
-  sort: asc
-  abbrev: -1
-  filters:
-    exclude:
-      - "^docs:"
-      - "^doc:"
-      - "^Docs:"
-      - "^test:"
-      - "^tests:"
-      - "^refactor:"
-      - "^ci:"
-      - "^chore:"
-      - "^build:"
-      - "^style:"
-      - "^perf:"
-      - "^Revert"
-      - "^Merge"
+  # Use GitHub's release notes generator (PR-based) instead of commit-based notes.
+  # This makes release entries cleaner and aligned with .github/release.yml categories.
+  use: github-native
 
 release:
   footer: |

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -35,6 +35,16 @@ make lint          # Check code quality
 make lint-fix      # Auto-fix issues
 ```
 
+## Release Hygiene
+
+Releases are generated automatically from merged PRs, categorized by labels and PR titles.
+
+- PR titles are validated in CI using Conventional Commit format (`type(scope): summary`)
+- Release labels are auto-applied from PR title type (`feat` -> feature, `fix` -> bug fix, etc.)
+- Internal changes (`chore`, `ci`, `build`, `test`, most `refactor`) are excluded from release notes by default
+- Prefer **Squash and merge** so each PR lands as one commit aligned with the PR title
+- If needed, apply `release:skip` on a PR to force exclusion from release notes
+
 ## Log output
 
 Log format is chosen automatically based on the environment:


### PR DESCRIPTION
## Summary
- switch GoReleaser changelog generation to GitHub native PR release notes
- add release categories/exclusions via .github/release.yml
- enforce Conventional Commit PR titles in CI
- auto-apply release labels from PR title type
- document release hygiene and add PR template guidance

## Validation
- pre-commit run check-yaml --files .goreleaser.yaml .github/release.yml .github/workflows/pr-title.yml .github/workflows/release-labels.yml
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/*.yml
- go run github.com/goreleaser/goreleaser/v2@latest check --config .goreleaser.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated release process: enforced PR title format, automatic release labeling, and more consistent changelog generation for clearer release notes.
* **Documentation**
  * Added release hygiene guidance describing PR title conventions, label usage, and how to exclude changes from release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->