### PR TITLE
feat: add model aliases feature

### DIFF
--- a/internal/admin/dashboard/dashboard_test.go
+++ b/internal/admin/dashboard/dashboard_test.go
@@ -121,6 +121,29 @@ func TestStatic_ServesModuleJS(t *testing.T) {
 	}
 }
 
+func TestStatic_ServesAliasesModuleJS(t *testing.T) {
+	h, err := New()
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/admin/static/js/modules/aliases.js", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.Static(c); err != nil {
+		t.Fatalf("Static() returned error: %v", err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	if rec.Body.Len() == 0 {
+		t.Error("expected non-empty body for aliases module JS file")
+	}
+}
+
 func TestStatic_ServesFavicon(t *testing.T) {
 	h, err := New()
 	if err != nil {

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -781,6 +781,12 @@ body {
     color: var(--warning);
 }
 
+.alert-success {
+    background: rgba(52, 211, 153, 0.12);
+    border: 1px solid rgba(52, 211, 153, 0.28);
+    color: var(--success);
+}
+
 /* Table */
 .table-toolbar {
     display: flex;
@@ -872,6 +878,260 @@ td.col-price {
     color: var(--text-muted);
     padding: 48px 0;
     font-size: 14px;
+}
+
+.table-action-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 6px 12px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text);
+    font-size: 12px;
+    font-family: inherit;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s;
+}
+
+.table-action-btn:hover:not(:disabled) {
+    background: var(--bg-surface-hover);
+}
+
+.table-action-btn:disabled {
+    opacity: 0.45;
+    cursor: default;
+}
+
+.table-action-btn-danger {
+    color: var(--danger);
+    border-color: color-mix(in srgb, var(--danger) 50%, var(--border));
+}
+
+.model-alias-editor {
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 24px;
+    margin-bottom: 16px;
+}
+
+.model-name-cell {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.model-name-primary {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+}
+
+.model-name-secondary {
+    font-size: 12px;
+    color: var(--text-muted);
+}
+
+.alias-kind-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    min-height: 24px;
+    padding: 0 10px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: var(--bg);
+    color: var(--accent);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.2px;
+    text-transform: uppercase;
+    border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+}
+
+.inline-link {
+    padding: 0;
+    border: none;
+    background: transparent;
+    color: var(--accent);
+    cursor: pointer;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+}
+
+.alias-form h3 {
+    font-size: 20px;
+    font-weight: 700;
+}
+
+.alias-form-kicker,
+.alias-form-hint {
+    color: var(--text-muted);
+    font-size: 13px;
+}
+
+.alias-actions-cell {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+}
+
+.alias-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: var(--bg);
+    color: var(--text);
+    font-size: 12px;
+    font-family: inherit;
+    cursor: pointer;
+    transition: all 0.15s;
+}
+
+.alias-toggle:hover:not(:disabled) {
+    background: var(--bg-surface-hover);
+}
+
+.alias-toggle:disabled {
+    opacity: 0.45;
+    cursor: default;
+}
+
+.alias-toggle-track {
+    position: relative;
+    width: 34px;
+    height: 20px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--border) 80%, var(--bg));
+    transition: background 0.15s;
+}
+
+.alias-toggle-thumb {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--text-muted);
+    transition: transform 0.15s, background 0.15s;
+}
+
+.alias-toggle.enabled {
+    border-color: color-mix(in srgb, var(--success) 50%, var(--border));
+}
+
+.alias-toggle.enabled .alias-toggle-track {
+    background: color-mix(in srgb, var(--success) 55%, var(--bg));
+}
+
+.alias-toggle.enabled .alias-toggle-thumb {
+    transform: translateX(14px);
+    background: #fff;
+}
+
+.aliases-editor-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 20px;
+}
+
+.alias-form {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.alias-form-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+}
+
+.alias-form-field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.alias-form-field > span {
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+}
+
+.alias-form-textarea {
+    width: 100%;
+    min-height: 110px;
+    resize: vertical;
+    padding: 10px 12px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--text);
+    font-size: 13px;
+    font-family: inherit;
+    outline: none;
+}
+
+.alias-form-textarea:focus {
+    border-color: var(--accent);
+}
+
+.alias-checkbox {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 14px;
+}
+
+.alias-checkbox input {
+    width: 16px;
+    height: 16px;
+}
+
+.alias-form-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.model-row-actions {
+    width: 170px;
+}
+
+.model-row-actions-empty {
+    color: var(--text-muted);
+}
+
+.data-table tr.alias-row td {
+    background: color-mix(in srgb, var(--accent) 10%, var(--bg-surface));
+}
+
+.data-table tr.alias-row:hover td {
+    background: color-mix(in srgb, var(--accent) 16%, var(--bg-surface-hover));
+}
+
+.data-table tr.masked-model-row td {
+    opacity: 0.58;
+}
+
+.data-table tr.masked-model-row:hover td {
+    opacity: 0.72;
 }
 
 /* Usage Mode Toggle */
@@ -1749,6 +2009,23 @@ body.conversation-drawer-open {
     .usage-mode-btn {
         padding: 4px 8px;
         font-size: 11px;
+    }
+
+    .alias-form-grid {
+        grid-template-columns: 1fr;
+    }
+    .model-alias-editor {
+        padding: 16px;
+    }
+    .alias-actions-cell,
+    .aliases-editor-header,
+    .model-name-primary {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+    .alias-actions-cell .table-action-btn,
+    .aliases-editor-header .table-action-btn {
+        width: 100%;
     }
 
     /* Audit page mobile */

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -873,6 +873,12 @@ td.col-price {
     font-weight: 500;
 }
 
+.audit-alias-badge {
+    background: color-mix(in srgb, var(--accent) 14%, var(--bg));
+    border-color: color-mix(in srgb, var(--accent) 28%, var(--border));
+    color: var(--accent-strong);
+}
+
 .empty-state {
     text-align: center;
     color: var(--text-muted);

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -27,6 +27,8 @@
     --cal-level-2: #006d32;
     --cal-level-3: #26a641;
     --cal-level-4: #39d353;
+    --alias-row-valid-bg: color-mix(in srgb, var(--bg-surface-hover) 86%, #fff 14%);
+    --alias-row-valid-bg-hover: color-mix(in srgb, var(--bg-surface-hover) 72%, #fff 28%);
     color-scheme: dark;
 }
 
@@ -53,6 +55,8 @@
     --cal-level-2: #40c463;
     --cal-level-3: #30a14e;
     --cal-level-4: #216e39;
+    --alias-row-valid-bg: color-mix(in srgb, var(--bg-surface) 96%, var(--accent) 4%);
+    --alias-row-valid-bg-hover: color-mix(in srgb, var(--bg-surface) 90%, var(--accent) 10%);
     color-scheme: light;
 }
 
@@ -80,6 +84,8 @@
         --cal-level-2: #40c463;
         --cal-level-3: #30a14e;
         --cal-level-4: #216e39;
+        --alias-row-valid-bg: color-mix(in srgb, var(--bg-surface) 96%, var(--accent) 4%);
+        --alias-row-valid-bg-hover: color-mix(in srgb, var(--bg-surface) 90%, var(--accent) 10%);
         color-scheme: light;
     }
 }
@@ -792,6 +798,18 @@ body {
     display: flex;
     gap: 12px;
     margin-bottom: 16px;
+    align-items: center;
+}
+
+.table-toolbar-main {
+    flex: 1;
+    min-width: 0;
+}
+
+.table-toolbar-actions {
+    margin-left: auto;
+    display: flex;
+    justify-content: flex-end;
 }
 
 .filter-input {
@@ -1054,6 +1072,16 @@ td.col-price {
     margin-bottom: 20px;
 }
 
+.alias-close-btn {
+    width: 36px;
+    min-width: 36px;
+    height: 36px;
+    padding: 0;
+    border-radius: 999px;
+    font-size: 14px;
+    font-weight: 700;
+}
+
 .alias-form {
     display: flex;
     flex-direction: column;
@@ -1085,7 +1113,7 @@ td.col-price {
     min-height: 110px;
     resize: vertical;
     padding: 10px 12px;
-    background: var(--bg);
+    background: var(--bg-surface);
     border: 1px solid var(--border);
     border-radius: var(--radius);
     color: var(--text);
@@ -1114,6 +1142,7 @@ td.col-price {
     display: flex;
     flex-wrap: wrap;
     gap: 8px;
+    justify-content: flex-end;
 }
 
 .model-row-actions {
@@ -1124,12 +1153,30 @@ td.col-price {
     color: var(--text-muted);
 }
 
-.data-table tr.alias-row td {
+.data-table tr.alias-row.is-valid td {
+    background: var(--alias-row-valid-bg);
+}
+
+.data-table tr.alias-row.is-valid:hover td {
+    background: var(--alias-row-valid-bg-hover);
+}
+
+.data-table tr.alias-row:not(.is-valid) td {
     background: color-mix(in srgb, var(--accent) 10%, var(--bg-surface));
 }
 
-.data-table tr.alias-row:hover td {
+.data-table tr.alias-row:not(.is-valid):hover td {
     background: color-mix(in srgb, var(--accent) 16%, var(--bg-surface-hover));
+}
+
+.data-table tr.alias-row.is-disabled td {
+    background: var(--bg-surface);
+    opacity: 0.58;
+}
+
+.data-table tr.alias-row.is-disabled:hover td {
+    background: var(--bg-surface-hover);
+    opacity: 0.72;
 }
 
 .data-table tr.masked-model-row td {
@@ -1823,6 +1870,19 @@ body.conversation-drawer-open {
     background: var(--bg-surface-hover);
 }
 
+.pagination-btn-primary {
+    background: var(--accent);
+    border-color: color-mix(in srgb, var(--accent) 70%, #000 10%);
+    color: #fff;
+    font-weight: 600;
+    box-shadow: 0 10px 22px rgba(59, 130, 246, 0.18);
+}
+
+.pagination-btn-primary:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--accent) 90%, #fff 10%);
+    border-color: color-mix(in srgb, var(--accent) 78%, #000 12%);
+}
+
 .pagination-btn:disabled {
     opacity: 0.4;
     cursor: default;
@@ -2019,6 +2079,17 @@ body.conversation-drawer-open {
 
     .alias-form-grid {
         grid-template-columns: 1fr;
+    }
+    .table-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    .table-toolbar-actions {
+        margin-left: 0;
+        justify-content: stretch;
+    }
+    .table-toolbar-actions .pagination-btn {
+        width: 100%;
     }
     .model-alias-editor {
         padding: 16px;

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -184,6 +184,9 @@ function dashboard() {
             this.authError = false;
             this.needsAuth = false;
             const requests = [this.fetchUsage(), this.fetchModels(), this.fetchCategories()];
+            if (typeof this.fetchAliases === 'function') {
+                requests.push(this.fetchAliases());
+            }
             if (this.hasCalendarModule && typeof this.fetchCalendarData === 'function') {
                 requests.push(this.fetchCalendarData());
             }
@@ -322,6 +325,7 @@ function dashboard() {
         typeof dashboardDatePickerModule === 'function' ? dashboardDatePickerModule : null,
         typeof dashboardUsageModule === 'function' ? dashboardUsageModule : null,
         typeof dashboardAuditListModule === 'function' ? dashboardAuditListModule : null,
+        typeof dashboardAliasesModule === 'function' ? dashboardAliasesModule : null,
         typeof dashboardConversationDrawerModule === 'function' ? dashboardConversationDrawerModule : null,
         calendarModuleFactory,
         typeof dashboardChartsModule === 'function' ? dashboardChartsModule : null
@@ -329,6 +333,7 @@ function dashboard() {
 
     return moduleFactories.reduce((app, factory) => {
         if (!factory) return app;
-        return Object.assign(app, factory());
+        Object.defineProperties(app, Object.getOwnPropertyDescriptors(factory()));
+        return app;
     }, base);
 }

--- a/internal/admin/dashboard/static/js/modules/aliases.js
+++ b/internal/admin/dashboard/static/js/modules/aliases.js
@@ -1,0 +1,543 @@
+(function(global) {
+    function dashboardAliasesModule() {
+        return {
+            aliases: [],
+            aliasesAvailable: true,
+            aliasLoading: false,
+            aliasError: '',
+            aliasFormError: '',
+            aliasNotice: '',
+            aliasFormOpen: false,
+            aliasSubmitting: false,
+            aliasTogglingName: '',
+            aliasDeletingName: '',
+            aliasFormMode: 'create',
+            aliasFormOriginalName: '',
+            aliasForm: {
+                name: '',
+                target_model: '',
+                description: '',
+                enabled: true
+            },
+
+            get displayModels() {
+                const rows = this.models.map((model) => ({
+                    key: 'model:' + this.qualifiedModelName(model),
+                    display_name: this.qualifiedModelName(model),
+                    secondary_name: '',
+                    provider_type: model.provider_type || '',
+                    model: model.model,
+                    is_alias: false,
+                    alias: null,
+                    kind_badge: '',
+                    masking_alias: null,
+                    alias_state_class: '',
+                    alias_state_text: ''
+                }));
+
+                if (!this.aliasesAvailable) {
+                    return rows;
+                }
+
+                const maskingAliases = new Map();
+                for (const alias of this.aliases) {
+                    const aliasName = String(alias && alias.name || '').trim().toLowerCase();
+                    if (!aliasName || alias.enabled === false || !alias.valid) {
+                        continue;
+                    }
+                    maskingAliases.set(aliasName, alias);
+                }
+
+                for (const row of rows) {
+                    for (const key of this.modelIdentifierKeys(row.model && row.model.id, row.provider_type)) {
+                        if (maskingAliases.has(key)) {
+                            row.masking_alias = maskingAliases.get(key);
+                            break;
+                        }
+                    }
+                }
+
+                for (const alias of this.aliases) {
+                    const targetModel = this.findConcreteModelForAlias(alias);
+                    if (!targetModel && this.activeCategory && this.activeCategory !== 'all') {
+                        continue;
+                    }
+
+                    rows.push({
+                        key: 'alias:' + alias.name,
+                        display_name: alias.name,
+                        secondary_name: this.aliasTargetLabel(alias),
+                        provider_type: targetModel ? (targetModel.provider_type || alias.provider_type || '') : (alias.provider_type || ''),
+                        model: targetModel ? targetModel.model : { id: alias.name, object: 'model' },
+                        is_alias: true,
+                        alias,
+                        kind_badge: 'Alias',
+                        masking_alias: null,
+                        alias_state_class: this.aliasStateClass(alias),
+                        alias_state_text: this.aliasStateText(alias)
+                    });
+                }
+
+                return rows.sort((a, b) => {
+                    if (a.is_alias !== b.is_alias) {
+                        return a.is_alias ? -1 : 1;
+                    }
+                    return String(a.display_name || '').localeCompare(String(b.display_name || ''));
+                });
+            },
+
+            get filteredDisplayModels() {
+                if (!this.modelFilter) return this.displayModels;
+                const filter = this.modelFilter.toLowerCase();
+                return this.displayModels.filter((row) => {
+                    const fields = [
+                        row.display_name,
+                        row.secondary_name,
+                        row.provider_type,
+                        row.model && row.model.owned_by,
+                        row.alias && row.alias.description,
+                        row.alias && row.alias_state_text,
+                        row.model && row.model.metadata && row.model.metadata.modes ? row.model.metadata.modes.join(',') : '',
+                        row.model && row.model.metadata && row.model.metadata.categories ? row.model.metadata.categories.join(',') : ''
+                    ];
+                    return fields.some((value) => String(value || '').toLowerCase().includes(filter));
+                });
+            },
+
+            defaultAliasForm() {
+                return {
+                    name: '',
+                    target_model: '',
+                    description: '',
+                    enabled: true
+                };
+            },
+
+            async fetchAliases() {
+                this.aliasLoading = true;
+                this.aliasError = '';
+                try {
+                    const res = await fetch('/admin/api/v1/aliases', { headers: this.headers() });
+                    if (res.status === 503) {
+                        this.aliasesAvailable = false;
+                        this.aliases = [];
+                        return;
+                    }
+                    this.aliasesAvailable = true;
+                    if (!this.handleFetchResponse(res, 'aliases')) {
+                        this.aliases = [];
+                        return;
+                    }
+                    const payload = await res.json();
+                    this.aliases = Array.isArray(payload) ? payload : [];
+                } catch (e) {
+                    console.error('Failed to fetch aliases:', e);
+                    this.aliases = [];
+                    this.aliasError = 'Unable to load aliases.';
+                } finally {
+                    this.aliasLoading = false;
+                }
+            },
+
+            qualifiedModelName(model) {
+                if (!model || !model.model || !model.model.id) {
+                    return '';
+                }
+                const modelID = String(model.model.id || '').trim();
+                const providerType = String(model.provider_type || '').trim();
+                if (!providerType || modelID.includes('/')) {
+                    return modelID;
+                }
+                return providerType + '/' + modelID;
+            },
+
+            displayRowClass(row) {
+                if (!row) return '';
+                const classes = [];
+                if (row.is_alias) {
+                    classes.push('alias-row', this.aliasStateClass(row.alias));
+                }
+                if (!row.is_alias && row.masking_alias) {
+                    classes.push('masked-model-row');
+                }
+                return classes.join(' ');
+            },
+
+            rowAnchorID(row) {
+                if (!row) return '';
+                if (row.is_alias && row.alias && row.alias.name) {
+                    return 'alias-row-' + String(row.alias.name).replace(/[^a-zA-Z0-9_-]+/g, '-');
+                }
+                return '';
+            },
+
+            filterByAlias(aliasName) {
+                this.modelFilter = String(aliasName || '').trim();
+            },
+
+            openAliasCreate(model) {
+                this.aliasFormOpen = true;
+                this.aliasFormMode = 'create';
+                this.aliasFormOriginalName = '';
+                this.aliasFormError = '';
+                this.aliasNotice = '';
+                this.aliasForm = this.defaultAliasForm();
+                if (model && model.model && model.model.id) {
+                    this.aliasForm.target_model = this.qualifiedModelName(model);
+                }
+            },
+
+            openAliasEdit(alias) {
+                this.aliasFormOpen = true;
+                this.aliasFormMode = 'edit';
+                this.aliasFormOriginalName = alias.name || '';
+                this.aliasFormError = '';
+                this.aliasNotice = '';
+                this.aliasForm = {
+                    name: alias.name || '',
+                    target_model: alias.target_provider ? alias.target_provider + '/' + alias.target_model : (alias.target_model || ''),
+                    description: alias.description || '',
+                    enabled: alias.enabled !== false
+                };
+            },
+
+            closeAliasForm() {
+                this.aliasFormOpen = false;
+                this.aliasFormMode = 'create';
+                this.aliasFormOriginalName = '';
+                this.aliasFormError = '';
+                this.aliasForm = this.defaultAliasForm();
+            },
+
+            async aliasResponseMessage(res, fallback) {
+                try {
+                    const payload = await res.json();
+                    if (payload && payload.error && payload.error.message) {
+                        return payload.error.message;
+                    }
+                } catch (_) {
+                    // Ignore invalid or empty responses and return the fallback message.
+                }
+                return fallback;
+            },
+
+            aliasTargetLabel(alias) {
+                if (alias.resolved_model) return alias.resolved_model;
+                if (alias.target_provider) return alias.target_provider + '/' + alias.target_model;
+                return alias.target_model || '\u2014';
+            },
+
+            aliasStateClass(alias) {
+                if (alias.enabled === false) return 'is-disabled';
+                if (!alias.valid) return 'is-invalid';
+                return 'is-valid';
+            },
+
+            aliasStateText(alias) {
+                if (alias.enabled === false) return 'Disabled';
+                if (!alias.valid) return 'Invalid';
+                return 'Active';
+            },
+
+            async toggleAliasEnabled(alias) {
+                if (!alias || !alias.name || this.aliasTogglingName === alias.name) {
+                    return;
+                }
+
+                this.aliasTogglingName = alias.name;
+                this.aliasError = '';
+                this.aliasNotice = '';
+                this.aliasFormError = '';
+
+                const payload = {
+                    target_model: alias.target_provider ? alias.target_provider + '/' + alias.target_model : alias.target_model,
+                    description: String(alias.description || '').trim(),
+                    enabled: alias.enabled === false
+                };
+
+                try {
+                    const res = await fetch('/admin/api/v1/aliases/' + encodeURIComponent(alias.name), {
+                        method: 'PUT',
+                        headers: this.headers(),
+                        body: JSON.stringify(payload)
+                    });
+                    if (res.status === 503) {
+                        this.aliasesAvailable = false;
+                        this.aliasError = 'Aliases feature is unavailable.';
+                        return;
+                    }
+                    if (res.status === 401) {
+                        this.authError = true;
+                        this.needsAuth = true;
+                        this.aliasError = 'Authentication required.';
+                        return;
+                    }
+                    if (!res.ok) {
+                        this.aliasError = await this.aliasResponseMessage(res, 'Failed to update alias state.');
+                        return;
+                    }
+
+                    await this.fetchAliases();
+                    this.aliasNotice = payload.enabled ? 'Alias enabled.' : 'Alias disabled.';
+                    if (this.aliasFormOpen && this.aliasFormOriginalName === alias.name) {
+                        this.closeAliasForm();
+                    }
+                } catch (e) {
+                    console.error('Failed to toggle alias state:', e);
+                    this.aliasError = 'Failed to update alias state.';
+                } finally {
+                    this.aliasTogglingName = '';
+                }
+            },
+
+            modelKeys(model) {
+                return this.modelIdentifierKeys(
+                    model && model.model ? model.model.id : '',
+                    model ? model.provider_type : ''
+                );
+            },
+
+            modelIdentifierKeys(modelID, providerType) {
+                const keys = new Set();
+                const normalizedModelID = String(modelID || '').trim().toLowerCase();
+                const provider = String(providerType || '').trim().toLowerCase();
+                if (!normalizedModelID) {
+                    return keys;
+                }
+
+                keys.add(normalizedModelID);
+                if (provider && !normalizedModelID.includes('/')) {
+                    keys.add(provider + '/' + normalizedModelID);
+                }
+
+                const parts = normalizedModelID.split('/');
+                if (parts.length === 2 && parts[1]) {
+                    keys.add(parts[1]);
+                }
+
+                return keys;
+            },
+
+            aliasKeys(alias) {
+                const keys = new Set();
+                const resolved = String(alias.resolved_model || '').trim().toLowerCase();
+                const targetModel = String(alias.target_model || '').trim().toLowerCase();
+                const targetProvider = String(alias.target_provider || '').trim().toLowerCase();
+                if (resolved) {
+                    keys.add(resolved);
+                    const resolvedParts = resolved.split('/');
+                    if (resolvedParts.length === 2 && resolvedParts[1]) {
+                        keys.add(resolvedParts[1]);
+                    }
+                }
+                if (targetModel) {
+                    keys.add(targetModel);
+                    const targetParts = targetModel.split('/');
+                    if (targetParts.length === 2 && targetParts[1]) {
+                        keys.add(targetParts[1]);
+                    }
+                }
+                if (targetModel && targetProvider) {
+                    keys.add(targetProvider + '/' + targetModel);
+                }
+                return keys;
+            },
+
+            findConcreteModelForAlias(alias) {
+                for (const model of this.models) {
+                    const modelKeys = this.modelKeys(model);
+                    for (const key of this.aliasKeys(alias)) {
+                        if (modelKeys.has(key)) {
+                            return model;
+                        }
+                    }
+                }
+                return null;
+            },
+
+            normalizedAliasName(name) {
+                return String(name || '').trim().toLowerCase();
+            },
+
+            sameAliasName(left, right) {
+                const normalizedLeft = this.normalizedAliasName(left);
+                const normalizedRight = this.normalizedAliasName(right);
+                return normalizedLeft !== '' && normalizedLeft === normalizedRight;
+            },
+
+            findExistingAliasByName(name) {
+                const normalizedName = this.normalizedAliasName(name);
+                if (!normalizedName) {
+                    return null;
+                }
+
+                for (const alias of this.aliases) {
+                    if (this.sameAliasName(alias && alias.name, normalizedName)) {
+                        return alias;
+                    }
+                }
+                return null;
+            },
+
+            findConcreteModelByName(name) {
+                const normalizedName = this.normalizedAliasName(name);
+                if (!normalizedName) {
+                    return null;
+                }
+
+                for (const model of this.models) {
+                    if (this.modelKeys(model).has(normalizedName)) {
+                        return model;
+                    }
+                }
+                return null;
+            },
+
+            async submitAliasForm() {
+                const name = String(this.aliasForm.name || '').trim();
+                const targetModel = String(this.aliasForm.target_model || '').trim();
+                let originalName = String(this.aliasFormOriginalName || '').trim();
+
+                if (!name) {
+                    this.aliasFormError = 'Alias name is required.';
+                    return;
+                }
+                if (!targetModel) {
+                    this.aliasFormError = 'Target model is required.';
+                    return;
+                }
+
+                this.aliasFormError = '';
+                this.aliasError = '';
+                this.aliasNotice = '';
+
+                const existingAlias = this.findExistingAliasByName(name);
+                if (existingAlias && !this.sameAliasName(existingAlias.name, originalName)) {
+                    const overwriteMessage = originalName
+                        ? 'An alias named "' + existingAlias.name + '" already exists. Saving will overwrite it and remove "' + originalName + '". Continue?'
+                        : 'An alias named "' + existingAlias.name + '" already exists. Saving will update that alias. Continue?';
+                    if (!window.confirm(overwriteMessage)) {
+                        this.aliasFormError = originalName
+                            ? 'Choose a different alias name to avoid overwriting an existing alias.'
+                            : 'Choose a different alias name or use Edit on the existing alias.';
+                        return;
+                    }
+                    if (!originalName) {
+                        this.aliasFormMode = 'edit';
+                        this.aliasFormOriginalName = existingAlias.name || name;
+                        originalName = this.aliasFormOriginalName;
+                    }
+                }
+
+                const matchingModel = this.findConcreteModelByName(name);
+                if (!existingAlias && matchingModel && !this.sameAliasName(name, originalName)) {
+                    const modelName = this.qualifiedModelName(matchingModel) || String(matchingModel.model && matchingModel.model.id || '').trim();
+                    if (!window.confirm('A model named "' + modelName + '" already exists. Creating this alias will mask that model in the list. Continue?')) {
+                        this.aliasFormError = 'Choose a different alias name to avoid masking an existing model.';
+                        return;
+                    }
+                }
+
+                this.aliasSubmitting = true;
+
+                const payload = {
+                    target_model: targetModel,
+                    description: String(this.aliasForm.description || '').trim(),
+                    enabled: Boolean(this.aliasForm.enabled)
+                };
+
+                try {
+                    const saveRes = await fetch('/admin/api/v1/aliases/' + encodeURIComponent(name), {
+                        method: 'PUT',
+                        headers: this.headers(),
+                        body: JSON.stringify(payload)
+                    });
+
+                    if (saveRes.status === 503) {
+                        this.aliasesAvailable = false;
+                        this.aliasFormError = 'Aliases feature is unavailable.';
+                        return;
+                    }
+                    if (saveRes.status === 401) {
+                        this.authError = true;
+                        this.needsAuth = true;
+                        this.aliasFormError = 'Authentication required.';
+                        return;
+                    }
+                    if (!saveRes.ok) {
+                        this.aliasFormError = await this.aliasResponseMessage(saveRes, 'Failed to save alias.');
+                        return;
+                    }
+
+                    if (originalName && originalName !== name) {
+                        const deleteRes = await fetch('/admin/api/v1/aliases/' + encodeURIComponent(originalName), {
+                            method: 'DELETE',
+                            headers: this.headers()
+                        });
+                        if (deleteRes.status !== 404 && !deleteRes.ok) {
+                            this.aliasFormError = await this.aliasResponseMessage(deleteRes, 'The alias was saved with the new name, but the previous alias could not be removed.');
+                            await this.fetchAliases();
+                            return;
+                        }
+                    }
+
+                    await this.fetchAliases();
+                    this.closeAliasForm();
+                    this.aliasNotice = originalName && originalName !== name ? 'Alias renamed.' : 'Alias saved.';
+                } catch (e) {
+                    console.error('Failed to save alias:', e);
+                    this.aliasFormError = 'Failed to save alias.';
+                } finally {
+                    this.aliasSubmitting = false;
+                }
+            },
+
+            async deleteAlias(alias) {
+                if (!alias || !alias.name) return;
+                if (!window.confirm('Delete alias "' + alias.name + '"? This cannot be undone.')) {
+                    return;
+                }
+
+                this.aliasDeletingName = alias.name;
+                this.aliasError = '';
+                this.aliasNotice = '';
+                this.aliasFormError = '';
+
+                try {
+                    const res = await fetch('/admin/api/v1/aliases/' + encodeURIComponent(alias.name), {
+                        method: 'DELETE',
+                        headers: this.headers()
+                    });
+                    if (res.status === 503) {
+                        this.aliasesAvailable = false;
+                        this.aliasError = 'Aliases feature is unavailable.';
+                        return;
+                    }
+                    if (res.status === 401) {
+                        this.authError = true;
+                        this.needsAuth = true;
+                        this.aliasError = 'Authentication required.';
+                        return;
+                    }
+                    if (!res.ok) {
+                        this.aliasError = await this.aliasResponseMessage(res, 'Failed to remove alias.');
+                        return;
+                    }
+
+                    await this.fetchAliases();
+                    if (this.aliasFormOriginalName === alias.name) {
+                        this.closeAliasForm();
+                    }
+                    this.aliasNotice = 'Alias removed.';
+                } catch (e) {
+                    console.error('Failed to delete alias:', e);
+                    this.aliasError = 'Failed to remove alias.';
+                } finally {
+                    this.aliasDeletingName = '';
+                }
+            }
+        };
+    }
+
+    global.dashboardAliasesModule = dashboardAliasesModule;
+})(window);

--- a/internal/admin/dashboard/static/js/modules/aliases.js
+++ b/internal/admin/dashboard/static/js/modules/aliases.js
@@ -222,6 +222,7 @@
             },
 
             aliasTargetLabel(alias) {
+                if (!alias) return '\u2014';
                 if (alias.resolved_model) return alias.resolved_model;
                 if (alias.target_provider) return alias.target_provider + '/' + alias.target_model;
                 return alias.target_model || '\u2014';

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -280,6 +280,10 @@
                 <textarea rows="3" class="alias-form-textarea" placeholder="Optional description" x-model="aliasForm.description"></textarea>
             </label>
 
+            <p class="alias-form-hint">
+                Aliases are not supported on pass-through endpoints.
+            </p>
+
             <label class="alias-checkbox">
                 <input type="checkbox" x-model="aliasForm.enabled">
                 <span>Alias is enabled</span>

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -685,6 +685,8 @@
                         <div class="audit-entry-context">
                             <span class="provider-badge" x-text="entry.provider || '-'"></span>
                             <span class="provider-badge mono" x-text="entry.model || '-'"></span>
+                            <span class="provider-badge audit-alias-badge" x-show="entry.alias_used">alias</span>
+                            <span class="provider-badge mono" x-show="entry.alias_used && entry.resolved_model" x-text="'resolved: ' + entry.resolved_model"></span>
                             <span class="provider-badge mono" x-text="'request_id: ' + (entry.request_id || '-')"></span>
                             <span class="provider-badge mono" x-show="entry.client_ip" x-text="'ip: ' + entry.client_ip"></span>
                             <span class="provider-badge" x-show="entry.stream">stream</span>

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -210,8 +210,8 @@
 <div x-show="page==='models'">
     <div class="page-header">
         <h2>Registered Models</h2>
-        <div class="model-count" x-show="models.length > 0">
-            <span x-text="modelFilter ? filteredModels.length + ' / ' + models.length : models.length"></span> models
+        <div class="model-count" x-show="displayModels.length > 0">
+            <span x-text="modelFilter ? filteredDisplayModels.length + ' / ' + displayModels.length : displayModels.length"></span> models
         </div>
     </div>
 
@@ -219,6 +219,11 @@
     <div class="alert alert-warning" x-show="authError">
         Authentication required. Enter your API key in the sidebar to view data.
     </div>
+    <div class="alert alert-warning" x-show="!aliasesAvailable && !authError">
+        Aliases feature is unavailable.
+    </div>
+    <div class="alert alert-warning" x-show="aliasError && !authError" x-text="aliasError"></div>
+    <div class="alert alert-success" x-show="aliasNotice" x-text="aliasNotice"></div>
 
     <!-- Category Tabs -->
     <div class="category-tabs" x-show="categories.length > 0">
@@ -231,32 +236,111 @@
     </div>
 
     <!-- Filter -->
-    <div class="table-toolbar" x-show="models.length > 0 || modelFilter">
-        <input type="text" placeholder="Filter by model, provider, or owner..." x-model="modelFilter" class="filter-input">
+    <div class="table-toolbar" x-show="displayModels.length > 0 || modelFilter || aliasesAvailable">
+        <input type="text" placeholder="Filter by provider/model, alias, or owner..." x-model="modelFilter" class="filter-input">
+        <button type="button" class="pagination-btn" x-show="aliasesAvailable" @click="openAliasCreate()">Add Alias</button>
+    </div>
+
+    <div class="model-alias-editor" x-show="aliasFormOpen">
+        <form class="alias-form" @submit.prevent="submitAliasForm()">
+            <div class="aliases-editor-header">
+                <div>
+                    <p class="alias-form-kicker" x-text="aliasFormMode === 'edit' ? 'Edit alias' : 'Create alias'"></p>
+                    <h3 x-text="aliasFormMode === 'edit' ? (aliasForm.name || aliasFormOriginalName) : 'New Alias'"></h3>
+                </div>
+                <button type="button" class="table-action-btn" @click="closeAliasForm()">Close</button>
+            </div>
+
+            <div class="alias-form-grid">
+                <label class="alias-form-field">
+                    <span>Alias name</span>
+                    <input type="text" class="filter-input mono" placeholder="smart" x-model="aliasForm.name">
+                </label>
+
+                <label class="alias-form-field">
+                    <span>Target model</span>
+                    <input type="text" list="alias-model-options" class="filter-input mono" placeholder="openai/gpt-4o" x-model="aliasForm.target_model">
+                </label>
+            </div>
+
+            <datalist id="alias-model-options">
+                <template x-for="m in models" :key="qualifiedModelName(m)">
+                    <option :value="qualifiedModelName(m)" x-text="qualifiedModelName(m)"></option>
+                </template>
+            </datalist>
+
+            <label class="alias-form-field">
+                <span>Description</span>
+                <textarea rows="3" class="alias-form-textarea" placeholder="Optional description" x-model="aliasForm.description"></textarea>
+            </label>
+
+            <label class="alias-checkbox">
+                <input type="checkbox" x-model="aliasForm.enabled">
+                <span>Alias is enabled</span>
+            </label>
+
+            <p class="alias-form-hint" x-show="aliasFormMode === 'edit'">
+                Renaming an alias creates the new name first, then removes the old one.
+            </p>
+
+            <div class="alert alert-warning" x-show="aliasFormError" x-text="aliasFormError"></div>
+
+            <div class="alias-form-actions">
+                <button type="submit" class="pagination-btn" :disabled="aliasSubmitting" x-text="aliasSubmitting ? 'Saving...' : (aliasFormMode === 'edit' ? 'Save Alias' : 'Create Alias')"></button>
+                <button type="button" class="pagination-btn" @click="closeAliasForm()">Cancel</button>
+            </div>
+        </form>
     </div>
 
     <!-- Models Table: All / Text Generation -->
-    <div class="table-wrapper" x-show="(models.length > 0 || modelFilter) && (activeCategory === 'all' || activeCategory === 'text_generation')">
+    <div class="table-wrapper" x-show="(displayModels.length > 0 || modelFilter) && (activeCategory === 'all' || activeCategory === 'text_generation')">
         <table class="data-table">
             <thead>
                 <tr>
-                    <th>Model ID</th>
-                    <th>Provider</th>
+                    <th>Model</th>
                     <th>Modes</th>
-                    <th class="col-price">Input $/MTok</th>
-                    <th class="col-price">Output $/MTok</th>
+                    <th class="col-price">Input<br>$/MTok</th>
+                    <th class="col-price">Output<br>$/MTok</th>
                     <th class="col-price" x-show="activeCategory === 'text_generation'">Cached $/MTok</th>
+                    <th>Actions</th>
                 </tr>
             </thead>
             <tbody>
-                <template x-for="m in filteredModels" :key="m.model.id">
-                    <tr>
-                        <td class="mono" x-text="m.model.id"></td>
-                        <td><span class="provider-badge" x-text="m.provider_type"></span></td>
-                        <td x-text="(m.model.metadata?.modes ?? []).join(', ') || '-'"></td>
-                        <td class="col-price" x-text="formatPrice(m.model.metadata?.pricing?.input_per_mtok)"></td>
-                        <td class="col-price" x-text="formatPrice(m.model.metadata?.pricing?.output_per_mtok)"></td>
-                        <td class="col-price" x-show="activeCategory === 'text_generation'" x-text="formatPrice(m.model.metadata?.pricing?.cached_input_per_mtok)"></td>
+                <template x-for="row in filteredDisplayModels" :key="row.key">
+                    <tr :id="rowAnchorID(row)" :class="displayRowClass(row)">
+                        <td>
+                            <div class="model-name-cell">
+                                <div class="model-name-primary">
+                                    <span class="mono" x-text="row.display_name"></span>
+                                    <span class="alias-kind-badge" x-show="row.is_alias" x-text="row.kind_badge"></span>
+                                </div>
+                                <div class="model-name-secondary" x-show="row.is_alias">
+                                    Targets <span class="mono" x-text="row.secondary_name"></span>
+                                </div>
+                                <div class="model-name-secondary" x-show="!row.is_alias && row.masking_alias">
+                                    Masked by alias to <span class="mono" x-text="aliasTargetLabel(row.masking_alias)"></span>
+                                </div>
+                            </div>
+                        </td>
+                        <td x-text="(row.model.metadata?.modes ?? []).join(', ') || '-'"></td>
+                        <td class="col-price" x-text="formatPrice(row.model.metadata?.pricing?.input_per_mtok)"></td>
+                        <td class="col-price" x-text="formatPrice(row.model.metadata?.pricing?.output_per_mtok)"></td>
+                        <td class="col-price" x-show="activeCategory === 'text_generation'" x-text="formatPrice(row.model.metadata?.pricing?.cached_input_per_mtok)"></td>
+                        <td class="model-row-actions">
+                            <template x-if="row.is_alias">
+                                <div class="alias-actions-cell">
+                                    <button type="button" class="alias-toggle" :class="{ enabled: row.alias.enabled !== false }" :disabled="aliasTogglingName === row.alias.name" @click="toggleAliasEnabled(row.alias)">
+                                        <span class="alias-toggle-track"><span class="alias-toggle-thumb"></span></span>
+                                        <span x-text="aliasTogglingName === row.alias.name ? 'Updating...' : (row.alias.enabled !== false ? 'Active' : 'Disabled')"></span>
+                                    </button>
+                                    <button type="button" class="table-action-btn" @click="openAliasEdit(row.alias)">Edit</button>
+                                    <button type="button" class="table-action-btn table-action-btn-danger" :disabled="aliasDeletingName === row.alias.name" @click="deleteAlias(row.alias)" x-text="aliasDeletingName === row.alias.name ? 'Removing...' : 'Remove'"></button>
+                                </div>
+                            </template>
+                            <template x-if="!row.is_alias">
+                                <span class="model-row-actions-empty">—</span>
+                            </template>
+                        </td>
                     </tr>
                 </template>
             </tbody>
@@ -264,21 +348,48 @@
     </div>
 
     <!-- Models Table: Embeddings -->
-    <div class="table-wrapper" x-show="(models.length > 0 || modelFilter) && activeCategory === 'embedding'">
+    <div class="table-wrapper" x-show="(displayModels.length > 0 || modelFilter) && activeCategory === 'embedding'">
         <table class="data-table">
             <thead>
                 <tr>
-                    <th>Model ID</th>
-                    <th>Provider</th>
-                    <th class="col-price">Input $/MTok</th>
+                    <th>Model</th>
+                    <th class="col-price">Input<br>$/MTok</th>
+                    <th>Actions</th>
                 </tr>
             </thead>
             <tbody>
-                <template x-for="m in filteredModels" :key="m.model.id">
-                    <tr>
-                        <td class="mono" x-text="m.model.id"></td>
-                        <td><span class="provider-badge" x-text="m.provider_type"></span></td>
-                        <td class="col-price" x-text="formatPrice(m.model.metadata?.pricing?.input_per_mtok)"></td>
+                <template x-for="row in filteredDisplayModels" :key="row.key">
+                    <tr :id="rowAnchorID(row)" :class="displayRowClass(row)">
+                        <td>
+                            <div class="model-name-cell">
+                                <div class="model-name-primary">
+                                    <span class="mono" x-text="row.display_name"></span>
+                                    <span class="alias-kind-badge" x-show="row.is_alias" x-text="row.kind_badge"></span>
+                                </div>
+                                <div class="model-name-secondary" x-show="row.is_alias">
+                                    Targets <span class="mono" x-text="row.secondary_name"></span>
+                                </div>
+                                <div class="model-name-secondary" x-show="!row.is_alias && row.masking_alias">
+                                    Masked by alias to <span class="mono" x-text="aliasTargetLabel(row.masking_alias)"></span>
+                                </div>
+                            </div>
+                        </td>
+                        <td class="col-price" x-text="formatPrice(row.model.metadata?.pricing?.input_per_mtok)"></td>
+                        <td class="model-row-actions">
+                            <template x-if="row.is_alias">
+                                <div class="alias-actions-cell">
+                                    <button type="button" class="alias-toggle" :class="{ enabled: row.alias.enabled !== false }" :disabled="aliasTogglingName === row.alias.name" @click="toggleAliasEnabled(row.alias)">
+                                        <span class="alias-toggle-track"><span class="alias-toggle-thumb"></span></span>
+                                        <span x-text="aliasTogglingName === row.alias.name ? 'Updating...' : (row.alias.enabled !== false ? 'Active' : 'Disabled')"></span>
+                                    </button>
+                                    <button type="button" class="table-action-btn" @click="openAliasEdit(row.alias)">Edit</button>
+                                    <button type="button" class="table-action-btn table-action-btn-danger" :disabled="aliasDeletingName === row.alias.name" @click="deleteAlias(row.alias)" x-text="aliasDeletingName === row.alias.name ? 'Removing...' : 'Remove'"></button>
+                                </div>
+                            </template>
+                            <template x-if="!row.is_alias">
+                                <span class="model-row-actions-empty">—</span>
+                            </template>
+                        </td>
                     </tr>
                 </template>
             </tbody>
@@ -286,21 +397,48 @@
     </div>
 
     <!-- Models Table: Image -->
-    <div class="table-wrapper" x-show="(models.length > 0 || modelFilter) && activeCategory === 'image'">
+    <div class="table-wrapper" x-show="(displayModels.length > 0 || modelFilter) && activeCategory === 'image'">
         <table class="data-table">
             <thead>
                 <tr>
-                    <th>Model ID</th>
-                    <th>Provider</th>
+                    <th>Model</th>
                     <th class="col-price">$/Image</th>
+                    <th>Actions</th>
                 </tr>
             </thead>
             <tbody>
-                <template x-for="m in filteredModels" :key="m.model.id">
-                    <tr>
-                        <td class="mono" x-text="m.model.id"></td>
-                        <td><span class="provider-badge" x-text="m.provider_type"></span></td>
-                        <td class="col-price" x-text="formatPriceFine(m.model.metadata?.pricing?.per_image)"></td>
+                <template x-for="row in filteredDisplayModels" :key="row.key">
+                    <tr :id="rowAnchorID(row)" :class="displayRowClass(row)">
+                        <td>
+                            <div class="model-name-cell">
+                                <div class="model-name-primary">
+                                    <span class="mono" x-text="row.display_name"></span>
+                                    <span class="alias-kind-badge" x-show="row.is_alias" x-text="row.kind_badge"></span>
+                                </div>
+                                <div class="model-name-secondary" x-show="row.is_alias">
+                                    Targets <span class="mono" x-text="row.secondary_name"></span>
+                                </div>
+                                <div class="model-name-secondary" x-show="!row.is_alias && row.masking_alias">
+                                    Masked by alias to <span class="mono" x-text="aliasTargetLabel(row.masking_alias)"></span>
+                                </div>
+                            </div>
+                        </td>
+                        <td class="col-price" x-text="formatPriceFine(row.model.metadata?.pricing?.per_image)"></td>
+                        <td class="model-row-actions">
+                            <template x-if="row.is_alias">
+                                <div class="alias-actions-cell">
+                                    <button type="button" class="alias-toggle" :class="{ enabled: row.alias.enabled !== false }" :disabled="aliasTogglingName === row.alias.name" @click="toggleAliasEnabled(row.alias)">
+                                        <span class="alias-toggle-track"><span class="alias-toggle-thumb"></span></span>
+                                        <span x-text="aliasTogglingName === row.alias.name ? 'Updating...' : (row.alias.enabled !== false ? 'Active' : 'Disabled')"></span>
+                                    </button>
+                                    <button type="button" class="table-action-btn" @click="openAliasEdit(row.alias)">Edit</button>
+                                    <button type="button" class="table-action-btn table-action-btn-danger" :disabled="aliasDeletingName === row.alias.name" @click="deleteAlias(row.alias)" x-text="aliasDeletingName === row.alias.name ? 'Removing...' : 'Remove'"></button>
+                                </div>
+                            </template>
+                            <template x-if="!row.is_alias">
+                                <span class="model-row-actions-empty">—</span>
+                            </template>
+                        </td>
                     </tr>
                 </template>
             </tbody>
@@ -308,23 +446,50 @@
     </div>
 
     <!-- Models Table: Audio -->
-    <div class="table-wrapper" x-show="(models.length > 0 || modelFilter) && activeCategory === 'audio'">
+    <div class="table-wrapper" x-show="(displayModels.length > 0 || modelFilter) && activeCategory === 'audio'">
         <table class="data-table">
             <thead>
                 <tr>
-                    <th>Model ID</th>
-                    <th>Provider</th>
+                    <th>Model</th>
                     <th class="col-price">$/Second</th>
                     <th class="col-price">$/Character</th>
+                    <th>Actions</th>
                 </tr>
             </thead>
             <tbody>
-                <template x-for="m in filteredModels" :key="m.model.id">
-                    <tr>
-                        <td class="mono" x-text="m.model.id"></td>
-                        <td><span class="provider-badge" x-text="m.provider_type"></span></td>
-                        <td class="col-price" x-text="formatPriceFine(m.model.metadata?.pricing?.per_second_input)"></td>
-                        <td class="col-price" x-text="formatPriceFine(m.model.metadata?.pricing?.per_character_input)"></td>
+                <template x-for="row in filteredDisplayModels" :key="row.key">
+                    <tr :id="rowAnchorID(row)" :class="displayRowClass(row)">
+                        <td>
+                            <div class="model-name-cell">
+                                <div class="model-name-primary">
+                                    <span class="mono" x-text="row.display_name"></span>
+                                    <span class="alias-kind-badge" x-show="row.is_alias" x-text="row.kind_badge"></span>
+                                </div>
+                                <div class="model-name-secondary" x-show="row.is_alias">
+                                    Targets <span class="mono" x-text="row.secondary_name"></span>
+                                </div>
+                                <div class="model-name-secondary" x-show="!row.is_alias && row.masking_alias">
+                                    Masked by alias to <span class="mono" x-text="aliasTargetLabel(row.masking_alias)"></span>
+                                </div>
+                            </div>
+                        </td>
+                        <td class="col-price" x-text="formatPriceFine(row.model.metadata?.pricing?.per_second_input)"></td>
+                        <td class="col-price" x-text="formatPriceFine(row.model.metadata?.pricing?.per_character_input)"></td>
+                        <td class="model-row-actions">
+                            <template x-if="row.is_alias">
+                                <div class="alias-actions-cell">
+                                    <button type="button" class="alias-toggle" :class="{ enabled: row.alias.enabled !== false }" :disabled="aliasTogglingName === row.alias.name" @click="toggleAliasEnabled(row.alias)">
+                                        <span class="alias-toggle-track"><span class="alias-toggle-thumb"></span></span>
+                                        <span x-text="aliasTogglingName === row.alias.name ? 'Updating...' : (row.alias.enabled !== false ? 'Active' : 'Disabled')"></span>
+                                    </button>
+                                    <button type="button" class="table-action-btn" @click="openAliasEdit(row.alias)">Edit</button>
+                                    <button type="button" class="table-action-btn table-action-btn-danger" :disabled="aliasDeletingName === row.alias.name" @click="deleteAlias(row.alias)" x-text="aliasDeletingName === row.alias.name ? 'Removing...' : 'Remove'"></button>
+                                </div>
+                            </template>
+                            <template x-if="!row.is_alias">
+                                <span class="model-row-actions-empty">—</span>
+                            </template>
+                        </td>
                     </tr>
                 </template>
             </tbody>
@@ -332,23 +497,50 @@
     </div>
 
     <!-- Models Table: Video -->
-    <div class="table-wrapper" x-show="(models.length > 0 || modelFilter) && activeCategory === 'video'">
+    <div class="table-wrapper" x-show="(displayModels.length > 0 || modelFilter) && activeCategory === 'video'">
         <table class="data-table">
             <thead>
                 <tr>
-                    <th>Model ID</th>
-                    <th>Provider</th>
+                    <th>Model</th>
                     <th class="col-price">$/Second (In)</th>
                     <th class="col-price">$/Second (Out)</th>
+                    <th>Actions</th>
                 </tr>
             </thead>
             <tbody>
-                <template x-for="m in filteredModels" :key="m.model.id">
-                    <tr>
-                        <td class="mono" x-text="m.model.id"></td>
-                        <td><span class="provider-badge" x-text="m.provider_type"></span></td>
-                        <td class="col-price" x-text="formatPriceFine(m.model.metadata?.pricing?.per_second_input)"></td>
-                        <td class="col-price" x-text="formatPriceFine(m.model.metadata?.pricing?.per_second_output)"></td>
+                <template x-for="row in filteredDisplayModels" :key="row.key">
+                    <tr :id="rowAnchorID(row)" :class="displayRowClass(row)">
+                        <td>
+                            <div class="model-name-cell">
+                                <div class="model-name-primary">
+                                    <span class="mono" x-text="row.display_name"></span>
+                                    <span class="alias-kind-badge" x-show="row.is_alias" x-text="row.kind_badge"></span>
+                                </div>
+                                <div class="model-name-secondary" x-show="row.is_alias">
+                                    Targets <span class="mono" x-text="row.secondary_name"></span>
+                                </div>
+                                <div class="model-name-secondary" x-show="!row.is_alias && row.masking_alias">
+                                    Masked by alias to <span class="mono" x-text="aliasTargetLabel(row.masking_alias)"></span>
+                                </div>
+                            </div>
+                        </td>
+                        <td class="col-price" x-text="formatPriceFine(row.model.metadata?.pricing?.per_second_input)"></td>
+                        <td class="col-price" x-text="formatPriceFine(row.model.metadata?.pricing?.per_second_output)"></td>
+                        <td class="model-row-actions">
+                            <template x-if="row.is_alias">
+                                <div class="alias-actions-cell">
+                                    <button type="button" class="alias-toggle" :class="{ enabled: row.alias.enabled !== false }" :disabled="aliasTogglingName === row.alias.name" @click="toggleAliasEnabled(row.alias)">
+                                        <span class="alias-toggle-track"><span class="alias-toggle-thumb"></span></span>
+                                        <span x-text="aliasTogglingName === row.alias.name ? 'Updating...' : (row.alias.enabled !== false ? 'Active' : 'Disabled')"></span>
+                                    </button>
+                                    <button type="button" class="table-action-btn" @click="openAliasEdit(row.alias)">Edit</button>
+                                    <button type="button" class="table-action-btn table-action-btn-danger" :disabled="aliasDeletingName === row.alias.name" @click="deleteAlias(row.alias)" x-text="aliasDeletingName === row.alias.name ? 'Removing...' : 'Remove'"></button>
+                                </div>
+                            </template>
+                            <template x-if="!row.is_alias">
+                                <span class="model-row-actions-empty">—</span>
+                            </template>
+                        </td>
                     </tr>
                 </template>
             </tbody>
@@ -356,32 +548,59 @@
     </div>
 
     <!-- Models Table: Utility -->
-    <div class="table-wrapper" x-show="(models.length > 0 || modelFilter) && activeCategory === 'utility'">
+    <div class="table-wrapper" x-show="(displayModels.length > 0 || modelFilter) && activeCategory === 'utility'">
         <table class="data-table">
             <thead>
                 <tr>
-                    <th>Model ID</th>
-                    <th>Provider</th>
+                    <th>Model</th>
                     <th class="col-price">$/Page</th>
                     <th class="col-price">$/Request</th>
+                    <th>Actions</th>
                 </tr>
             </thead>
             <tbody>
-                <template x-for="m in filteredModels" :key="m.model.id">
-                    <tr>
-                        <td class="mono" x-text="m.model.id"></td>
-                        <td><span class="provider-badge" x-text="m.provider_type"></span></td>
-                        <td class="col-price" x-text="formatPriceFine(m.model.metadata?.pricing?.per_page)"></td>
-                        <td class="col-price" x-text="formatPriceFine(m.model.metadata?.pricing?.per_request)"></td>
+                <template x-for="row in filteredDisplayModels" :key="row.key">
+                    <tr :id="rowAnchorID(row)" :class="displayRowClass(row)">
+                        <td>
+                            <div class="model-name-cell">
+                                <div class="model-name-primary">
+                                    <span class="mono" x-text="row.display_name"></span>
+                                    <span class="alias-kind-badge" x-show="row.is_alias" x-text="row.kind_badge"></span>
+                                </div>
+                                <div class="model-name-secondary" x-show="row.is_alias">
+                                    Targets <span class="mono" x-text="row.secondary_name"></span>
+                                </div>
+                                <div class="model-name-secondary" x-show="!row.is_alias && row.masking_alias">
+                                    Masked by alias to <span class="mono" x-text="aliasTargetLabel(row.masking_alias)"></span>
+                                </div>
+                            </div>
+                        </td>
+                        <td class="col-price" x-text="formatPriceFine(row.model.metadata?.pricing?.per_page)"></td>
+                        <td class="col-price" x-text="formatPriceFine(row.model.metadata?.pricing?.per_request)"></td>
+                        <td class="model-row-actions">
+                            <template x-if="row.is_alias">
+                                <div class="alias-actions-cell">
+                                    <button type="button" class="alias-toggle" :class="{ enabled: row.alias.enabled !== false }" :disabled="aliasTogglingName === row.alias.name" @click="toggleAliasEnabled(row.alias)">
+                                        <span class="alias-toggle-track"><span class="alias-toggle-thumb"></span></span>
+                                        <span x-text="aliasTogglingName === row.alias.name ? 'Updating...' : (row.alias.enabled !== false ? 'Active' : 'Disabled')"></span>
+                                    </button>
+                                    <button type="button" class="table-action-btn" @click="openAliasEdit(row.alias)">Edit</button>
+                                    <button type="button" class="table-action-btn table-action-btn-danger" :disabled="aliasDeletingName === row.alias.name" @click="deleteAlias(row.alias)" x-text="aliasDeletingName === row.alias.name ? 'Removing...' : 'Remove'"></button>
+                                </div>
+                            </template>
+                            <template x-if="!row.is_alias">
+                                <span class="model-row-actions-empty">—</span>
+                            </template>
+                        </td>
                     </tr>
                 </template>
             </tbody>
         </table>
     </div>
 
-    <p class="empty-state" x-show="models.length === 0 && !loading && !authError && !modelFilter && (activeCategory === 'all' || !activeCategory)">No models registered.</p>
-    <p class="empty-state" x-show="models.length === 0 && !loading && !authError && !modelFilter && activeCategory && activeCategory !== 'all'">No models in this category.</p>
-    <p class="empty-state" x-show="models.length > 0 && filteredModels.length === 0 && modelFilter">No models match your filter.</p>
+    <p class="empty-state" x-show="displayModels.length === 0 && !loading && !authError && !modelFilter && (activeCategory === 'all' || !activeCategory)">No models registered.</p>
+    <p class="empty-state" x-show="displayModels.length === 0 && !loading && !authError && !modelFilter && activeCategory && activeCategory !== 'all'">No models in this category.</p>
+    <p class="empty-state" x-show="displayModels.length > 0 && filteredDisplayModels.length === 0 && modelFilter">No models match your filter.</p>
 </div>
 
 <!-- Audit Logs Page -->

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -237,8 +237,12 @@
 
     <!-- Filter -->
     <div class="table-toolbar" x-show="displayModels.length > 0 || modelFilter || aliasesAvailable">
-        <input type="text" placeholder="Filter by provider/model, alias, or owner..." x-model="modelFilter" class="filter-input">
-        <button type="button" class="pagination-btn" x-show="aliasesAvailable" @click="openAliasCreate()">Add Alias</button>
+        <div class="table-toolbar-main">
+            <input type="text" placeholder="Filter by provider/model, alias, or owner..." x-model="modelFilter" class="filter-input">
+        </div>
+        <div class="table-toolbar-actions">
+            <button type="button" class="pagination-btn pagination-btn-primary" x-show="aliasesAvailable" @click="openAliasCreate()">Create Alias</button>
+        </div>
     </div>
 
     <div class="model-alias-editor" x-show="aliasFormOpen">
@@ -248,7 +252,9 @@
                     <p class="alias-form-kicker" x-text="aliasFormMode === 'edit' ? 'Edit alias' : 'Create alias'"></p>
                     <h3 x-text="aliasFormMode === 'edit' ? (aliasForm.name || aliasFormOriginalName) : 'New Alias'"></h3>
                 </div>
-                <button type="button" class="table-action-btn" @click="closeAliasForm()">Close</button>
+                <button type="button" class="table-action-btn alias-close-btn" aria-label="Close alias editor" @click="closeAliasForm()">
+                    <span aria-hidden="true">X</span>
+                </button>
             </div>
 
             <div class="alias-form-grid">
@@ -286,8 +292,7 @@
             <div class="alert alert-warning" x-show="aliasFormError" x-text="aliasFormError"></div>
 
             <div class="alias-form-actions">
-                <button type="submit" class="pagination-btn" :disabled="aliasSubmitting" x-text="aliasSubmitting ? 'Saving...' : (aliasFormMode === 'edit' ? 'Save Alias' : 'Create Alias')"></button>
-                <button type="button" class="pagination-btn" @click="closeAliasForm()">Cancel</button>
+                <button type="submit" class="pagination-btn pagination-btn-primary" :disabled="aliasSubmitting" x-text="aliasSubmitting ? 'Saving...' : (aliasFormMode === 'edit' ? 'Save Alias' : 'Create Alias')"></button>
             </div>
         </form>
     </div>

--- a/internal/admin/dashboard/templates/layout.html
+++ b/internal/admin/dashboard/templates/layout.html
@@ -86,6 +86,7 @@
     <script src="/admin/static/js/modules/date-picker.js"></script>
     <script src="/admin/static/js/modules/usage.js"></script>
     <script src="/admin/static/js/modules/audit-list.js"></script>
+    <script src="/admin/static/js/modules/aliases.js"></script>
     <script src="/admin/static/js/modules/conversation-drawer.js"></script>
     <script src="/admin/static/js/modules/contribution-calendar.js"></script>
     <script src="/admin/static/js/modules/charts.js"></script>

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -563,6 +563,9 @@ func (h *Handler) UpsertAlias(c *echo.Context) error {
 	}
 
 	enabled := true
+	if existing, ok := h.aliases.Get(name); ok && existing != nil {
+		enabled = existing.Enabled
+	}
 	if req.Enabled != nil {
 		enabled = *req.Enabled
 	}

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -523,6 +523,16 @@ func (h *Handler) aliasesUnavailableError() error {
 		WithCode("feature_unavailable")
 }
 
+func aliasWriteError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if aliases.IsValidationError(err) {
+		return core.NewInvalidRequestError(err.Error(), err)
+	}
+	return err
+}
+
 // ListAliases handles GET /admin/api/v1/aliases
 func (h *Handler) ListAliases(c *echo.Context) error {
 	if h.aliases == nil {
@@ -563,7 +573,7 @@ func (h *Handler) UpsertAlias(c *echo.Context) error {
 		Description:    req.Description,
 		Enabled:        enabled,
 	}); err != nil {
-		return handleError(c, core.NewInvalidRequestError(err.Error(), err))
+		return handleError(c, aliasWriteError(err))
 	}
 
 	alias, ok := h.aliases.Get(name)
@@ -588,7 +598,7 @@ func (h *Handler) DeleteAlias(c *echo.Context) error {
 		if errors.Is(err, aliases.ErrNotFound) {
 			return handleError(c, core.NewNotFoundError("alias not found: "+name))
 		}
-		return handleError(c, core.NewInvalidRequestError(err.Error(), err))
+		return handleError(c, aliasWriteError(err))
 	}
 	return c.NoContent(http.StatusNoContent)
 }

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -551,9 +552,9 @@ func (h *Handler) UpsertAlias(c *echo.Context) error {
 		return handleError(c, h.aliasesUnavailableError())
 	}
 
-	name := strings.TrimSpace(c.Param("name"))
-	if name == "" {
-		return handleError(c, core.NewInvalidRequestError("alias name is required", nil))
+	name, err := decodeAliasPathName(c.Param("name"))
+	if err != nil {
+		return handleError(c, err)
 	}
 
 	var req upsertAliasRequest
@@ -589,9 +590,9 @@ func (h *Handler) DeleteAlias(c *echo.Context) error {
 		return handleError(c, h.aliasesUnavailableError())
 	}
 
-	name := strings.TrimSpace(c.Param("name"))
-	if name == "" {
-		return handleError(c, core.NewInvalidRequestError("alias name is required", nil))
+	name, err := decodeAliasPathName(c.Param("name"))
+	if err != nil {
+		return handleError(c, err)
 	}
 
 	if err := h.aliases.Delete(c.Request().Context(), name); err != nil {
@@ -601,4 +602,16 @@ func (h *Handler) DeleteAlias(c *echo.Context) error {
 		return handleError(c, aliasWriteError(err))
 	}
 	return c.NoContent(http.StatusNoContent)
+}
+
+func decodeAliasPathName(raw string) (string, error) {
+	name, err := url.PathUnescape(strings.TrimSpace(raw))
+	if err != nil {
+		return "", core.NewInvalidRequestError("invalid alias name", err)
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", core.NewInvalidRequestError("alias name is required", nil)
+	}
+	return name, nil
 }

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/labstack/echo/v5"
 
+	"gomodel/internal/aliases"
 	"gomodel/internal/auditlog"
 	"gomodel/internal/core"
 	"gomodel/internal/providers"
@@ -22,6 +23,7 @@ type Handler struct {
 	usageReader usage.UsageReader
 	auditReader auditlog.Reader
 	registry    *providers.ModelRegistry
+	aliases     *aliases.Service
 }
 
 // Option configures the admin API handler.
@@ -31,6 +33,13 @@ type Option func(*Handler)
 func WithAuditReader(reader auditlog.Reader) Option {
 	return func(h *Handler) {
 		h.auditReader = reader
+	}
+}
+
+// WithAliases enables alias administration endpoints.
+func WithAliases(service *aliases.Service) Option {
+	return func(h *Handler) {
+		h.aliases = service
 	}
 }
 
@@ -500,4 +509,85 @@ func (h *Handler) ListCategories(c *echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, h.registry.GetCategoryCounts())
+}
+
+type upsertAliasRequest struct {
+	TargetModel    string `json:"target_model"`
+	TargetProvider string `json:"target_provider,omitempty"`
+	Description    string `json:"description,omitempty"`
+	Enabled        *bool  `json:"enabled,omitempty"`
+}
+
+func (h *Handler) aliasesUnavailableError() error {
+	return core.NewProviderError("aliases", http.StatusInternalServerError, "aliases service is unavailable", nil)
+}
+
+// ListAliases handles GET /admin/api/v1/aliases
+func (h *Handler) ListAliases(c *echo.Context) error {
+	if h.aliases == nil {
+		return c.JSON(http.StatusOK, []aliases.View{})
+	}
+	views := h.aliases.ListViews()
+	if views == nil {
+		views = []aliases.View{}
+	}
+	return c.JSON(http.StatusOK, views)
+}
+
+// UpsertAlias handles PUT /admin/api/v1/aliases/{name}
+func (h *Handler) UpsertAlias(c *echo.Context) error {
+	if h.aliases == nil {
+		return handleError(c, h.aliasesUnavailableError())
+	}
+
+	name := strings.TrimSpace(c.Param("name"))
+	if name == "" {
+		return handleError(c, core.NewInvalidRequestError("alias name is required", nil))
+	}
+
+	var req upsertAliasRequest
+	if err := c.Bind(&req); err != nil {
+		return handleError(c, core.NewInvalidRequestError("invalid request body: "+err.Error(), err))
+	}
+
+	enabled := true
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
+
+	if err := h.aliases.Upsert(c.Request().Context(), aliases.Alias{
+		Name:           name,
+		TargetModel:    req.TargetModel,
+		TargetProvider: req.TargetProvider,
+		Description:    req.Description,
+		Enabled:        enabled,
+	}); err != nil {
+		return handleError(c, core.NewInvalidRequestError(err.Error(), err))
+	}
+
+	alias, ok := h.aliases.Get(name)
+	if !ok {
+		return c.NoContent(http.StatusNoContent)
+	}
+	return c.JSON(http.StatusOK, alias)
+}
+
+// DeleteAlias handles DELETE /admin/api/v1/aliases/{name}
+func (h *Handler) DeleteAlias(c *echo.Context) error {
+	if h.aliases == nil {
+		return handleError(c, h.aliasesUnavailableError())
+	}
+
+	name := strings.TrimSpace(c.Param("name"))
+	if name == "" {
+		return handleError(c, core.NewInvalidRequestError("alias name is required", nil))
+	}
+
+	if err := h.aliases.Delete(c.Request().Context(), name); err != nil {
+		if errors.Is(err, aliases.ErrNotFound) {
+			return handleError(c, core.NewNotFoundError("alias not found: "+name))
+		}
+		return handleError(c, core.NewInvalidRequestError(err.Error(), err))
+	}
+	return c.NoContent(http.StatusNoContent)
 }

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -519,13 +519,14 @@ type upsertAliasRequest struct {
 }
 
 func (h *Handler) aliasesUnavailableError() error {
-	return core.NewProviderError("aliases", http.StatusInternalServerError, "aliases service is unavailable", nil)
+	return core.NewInvalidRequestErrorWithStatus(http.StatusServiceUnavailable, "aliases feature is unavailable", nil).
+		WithCode("feature_unavailable")
 }
 
 // ListAliases handles GET /admin/api/v1/aliases
 func (h *Handler) ListAliases(c *echo.Context) error {
 	if h.aliases == nil {
-		return c.JSON(http.StatusOK, []aliases.View{})
+		return handleError(c, h.aliasesUnavailableError())
 	}
 	views := h.aliases.ListViews()
 	if views == nil {

--- a/internal/admin/handler_aliases_test.go
+++ b/internal/admin/handler_aliases_test.go
@@ -226,6 +226,32 @@ func TestUpsertAliasAndDeleteAlias(t *testing.T) {
 	}
 }
 
+func TestUpsertAliasDecodesQualifiedAliasName(t *testing.T) {
+	h := newAliasHandler(t)
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodPut, "/admin/api/v1/aliases/openai%2Fsmart", bytes.NewBufferString(`{"target_model":"gpt-4o"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPathValues(echo.PathValues{{Name: "name", Value: "openai%2Fsmart"}})
+
+	if err := h.UpsertAlias(c); err != nil {
+		t.Fatalf("UpsertAlias() error = %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	var body aliases.Alias
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if body.Name != "openai/smart" {
+		t.Fatalf("alias name = %q, want openai/smart", body.Name)
+	}
+}
+
 func TestUpsertAliasReturns500OnStoreFailure(t *testing.T) {
 	h := newAliasHandlerWithStore(t, &failingAliasStore{
 		upsertErr: errors.New("disk full"),

--- a/internal/admin/handler_aliases_test.go
+++ b/internal/admin/handler_aliases_test.go
@@ -252,6 +252,40 @@ func TestUpsertAliasDecodesQualifiedAliasName(t *testing.T) {
 	}
 }
 
+func TestUpsertAliasPreservesEnabledWhenOmitted(t *testing.T) {
+	h := newAliasHandler(t, aliases.Alias{
+		Name:        "smart",
+		TargetModel: "gpt-4o",
+		Description: "before",
+		Enabled:     false,
+	})
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodPut, "/admin/api/v1/aliases/smart", bytes.NewBufferString(`{"target_model":"gpt-4o","description":"after"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPathValues(echo.PathValues{{Name: "name", Value: "smart"}})
+
+	if err := h.UpsertAlias(c); err != nil {
+		t.Fatalf("UpsertAlias() error = %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	var body aliases.Alias
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if body.Enabled {
+		t.Fatalf("enabled = %v, want false", body.Enabled)
+	}
+	if body.Description != "after" {
+		t.Fatalf("description = %q, want after", body.Description)
+	}
+}
+
 func TestUpsertAliasReturns500OnStoreFailure(t *testing.T) {
 	h := newAliasHandlerWithStore(t, &failingAliasStore{
 		upsertErr: errors.New("disk full"),

--- a/internal/admin/handler_aliases_test.go
+++ b/internal/admin/handler_aliases_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -58,6 +59,21 @@ func (s *aliasTestStore) Delete(_ context.Context, name string) error {
 
 func (s *aliasTestStore) Close() error { return nil }
 
+type failingAliasStore struct {
+	listErr   error
+	getErr    error
+	upsertErr error
+	deleteErr error
+}
+
+func (s *failingAliasStore) List(_ context.Context) ([]aliases.Alias, error) { return nil, s.listErr }
+func (s *failingAliasStore) Get(_ context.Context, _ string) (*aliases.Alias, error) {
+	return nil, s.getErr
+}
+func (s *failingAliasStore) Upsert(_ context.Context, _ aliases.Alias) error { return s.upsertErr }
+func (s *failingAliasStore) Delete(_ context.Context, _ string) error        { return s.deleteErr }
+func (s *failingAliasStore) Close() error                                    { return nil }
+
 type aliasTestCatalog struct {
 	providerTypes map[string]string
 	models        map[string]core.Model
@@ -98,6 +114,20 @@ func newAliasHandler(t *testing.T, items ...aliases.Alias) *Handler {
 	catalog := newAliasTestCatalog()
 	catalog.add("gpt-4o", "openai")
 	service, err := aliases.NewService(newAliasTestStore(items...), catalog)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+	return NewHandler(nil, nil, WithAliases(service))
+}
+
+func newAliasHandlerWithStore(t *testing.T, store aliases.Store) *Handler {
+	t.Helper()
+	catalog := newAliasTestCatalog()
+	catalog.add("gpt-4o", "openai")
+	service, err := aliases.NewService(store, catalog)
 	if err != nil {
 		t.Fatalf("NewService() error = %v", err)
 	}
@@ -193,5 +223,71 @@ func TestUpsertAliasAndDeleteAlias(t *testing.T) {
 	}
 	if deleteRec.Code != http.StatusNoContent {
 		t.Fatalf("delete status = %d, want 204", deleteRec.Code)
+	}
+}
+
+func TestUpsertAliasReturns500OnStoreFailure(t *testing.T) {
+	h := newAliasHandlerWithStore(t, &failingAliasStore{
+		upsertErr: errors.New("disk full"),
+	})
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodPut, "/admin/api/v1/aliases/smart", bytes.NewBufferString(`{"target_model":"gpt-4o"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPathValues(echo.PathValues{{Name: "name", Value: "smart"}})
+
+	if err := h.UpsertAlias(c); err != nil {
+		t.Fatalf("UpsertAlias() error = %v", err)
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	if !containsString(rec.Body.String(), "internal_error") {
+		t.Fatalf("body = %s, want internal_error", rec.Body.String())
+	}
+}
+
+func TestUpsertAliasReturns400OnValidationError(t *testing.T) {
+	h := newAliasHandler(t)
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodPut, "/admin/api/v1/aliases/smart", bytes.NewBufferString(`{"description":"missing target"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPathValues(echo.PathValues{{Name: "name", Value: "smart"}})
+
+	if err := h.UpsertAlias(c); err != nil {
+		t.Fatalf("UpsertAlias() error = %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if !containsString(rec.Body.String(), "invalid_request_error") {
+		t.Fatalf("body = %s, want invalid_request_error", rec.Body.String())
+	}
+}
+
+func TestDeleteAliasReturns500OnStoreFailure(t *testing.T) {
+	h := newAliasHandlerWithStore(t, &failingAliasStore{
+		deleteErr: errors.New("disk full"),
+	})
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodDelete, "/admin/api/v1/aliases/smart", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPathValues(echo.PathValues{{Name: "name", Value: "smart"}})
+
+	if err := h.DeleteAlias(c); err != nil {
+		t.Fatalf("DeleteAlias() error = %v", err)
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	if !containsString(rec.Body.String(), "internal_error") {
+		t.Fatalf("body = %s, want internal_error", rec.Body.String())
 	}
 }

--- a/internal/admin/handler_aliases_test.go
+++ b/internal/admin/handler_aliases_test.go
@@ -1,0 +1,158 @@
+package admin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+
+	"gomodel/internal/aliases"
+	"gomodel/internal/core"
+)
+
+type aliasTestStore struct {
+	items map[string]aliases.Alias
+}
+
+func newAliasTestStore(items ...aliases.Alias) *aliasTestStore {
+	store := &aliasTestStore{items: make(map[string]aliases.Alias, len(items))}
+	for _, item := range items {
+		store.items[item.Name] = item
+	}
+	return store
+}
+
+func (s *aliasTestStore) List(_ context.Context) ([]aliases.Alias, error) {
+	result := make([]aliases.Alias, 0, len(s.items))
+	for _, item := range s.items {
+		result = append(result, item)
+	}
+	return result, nil
+}
+
+func (s *aliasTestStore) Get(_ context.Context, name string) (*aliases.Alias, error) {
+	item, ok := s.items[name]
+	if !ok {
+		return nil, aliases.ErrNotFound
+	}
+	copy := item
+	return &copy, nil
+}
+
+func (s *aliasTestStore) Upsert(_ context.Context, alias aliases.Alias) error {
+	s.items[alias.Name] = alias
+	return nil
+}
+
+func (s *aliasTestStore) Delete(_ context.Context, name string) error {
+	if _, ok := s.items[name]; !ok {
+		return aliases.ErrNotFound
+	}
+	delete(s.items, name)
+	return nil
+}
+
+func (s *aliasTestStore) Close() error { return nil }
+
+type aliasTestCatalog struct {
+	providerTypes map[string]string
+	models        map[string]core.Model
+}
+
+func newAliasTestCatalog() *aliasTestCatalog {
+	return &aliasTestCatalog{
+		providerTypes: map[string]string{},
+		models:        map[string]core.Model{},
+	}
+}
+
+func (c *aliasTestCatalog) add(model, providerType string) {
+	c.providerTypes[model] = providerType
+	c.models[model] = core.Model{ID: model, Object: "model"}
+}
+
+func (c *aliasTestCatalog) Supports(model string) bool {
+	_, ok := c.models[model]
+	return ok
+}
+
+func (c *aliasTestCatalog) GetProviderType(model string) string {
+	return c.providerTypes[model]
+}
+
+func (c *aliasTestCatalog) LookupModel(model string) (*core.Model, bool) {
+	value, ok := c.models[model]
+	if !ok {
+		return nil, false
+	}
+	copy := value
+	return &copy, true
+}
+
+func newAliasHandler(t *testing.T, items ...aliases.Alias) *Handler {
+	t.Helper()
+	catalog := newAliasTestCatalog()
+	catalog.add("gpt-4o", "openai")
+	service, err := aliases.NewService(newAliasTestStore(items...), catalog)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+	return NewHandler(nil, nil, WithAliases(service))
+}
+
+func TestListAliases(t *testing.T) {
+	h := newAliasHandler(t, aliases.Alias{Name: "smart", TargetModel: "gpt-4o", Enabled: true})
+	c, rec := newHandlerContext("/admin/api/v1/aliases")
+
+	if err := h.ListAliases(c); err != nil {
+		t.Fatalf("ListAliases() error = %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	var body []aliases.View
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(body) != 1 || body[0].Name != "smart" || !body[0].Valid {
+		t.Fatalf("response = %#v, want one valid alias", body)
+	}
+}
+
+func TestUpsertAliasAndDeleteAlias(t *testing.T) {
+	h := newAliasHandler(t)
+	e := echo.New()
+
+	putReq := httptest.NewRequest(http.MethodPut, "/admin/api/v1/aliases/smart", bytes.NewBufferString(`{"target_model":"gpt-4o","description":"primary"}`))
+	putReq.Header.Set("Content-Type", "application/json")
+	putRec := httptest.NewRecorder()
+	putCtx := e.NewContext(putReq, putRec)
+	putCtx.SetPathValues(echo.PathValues{{Name: "name", Value: "smart"}})
+
+	if err := h.UpsertAlias(putCtx); err != nil {
+		t.Fatalf("UpsertAlias() error = %v", err)
+	}
+	if putRec.Code != http.StatusOK {
+		t.Fatalf("put status = %d, want 200", putRec.Code)
+	}
+
+	deleteReq := httptest.NewRequest(http.MethodDelete, "/admin/api/v1/aliases/smart", nil)
+	deleteRec := httptest.NewRecorder()
+	deleteCtx := e.NewContext(deleteReq, deleteRec)
+	deleteCtx.SetPathValues(echo.PathValues{{Name: "name", Value: "smart"}})
+
+	if err := h.DeleteAlias(deleteCtx); err != nil {
+		t.Fatalf("DeleteAlias() error = %v", err)
+	}
+	if deleteRec.Code != http.StatusNoContent {
+		t.Fatalf("delete status = %d, want 204", deleteRec.Code)
+	}
+}

--- a/internal/admin/handler_aliases_test.go
+++ b/internal/admin/handler_aliases_test.go
@@ -127,6 +127,45 @@ func TestListAliases(t *testing.T) {
 	}
 }
 
+func TestAliasesEndpointsReturn503WhenServiceUnavailable(t *testing.T) {
+	h := NewHandler(nil, nil)
+	e := echo.New()
+
+	assertUnavailable := func(name string, err error, rec *httptest.ResponseRecorder) {
+		t.Helper()
+		if err != nil {
+			t.Fatalf("%s error = %v", name, err)
+		}
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Fatalf("%s status = %d, want 503", name, rec.Code)
+		}
+
+		var body map[string]map[string]any
+		if decodeErr := json.Unmarshal(rec.Body.Bytes(), &body); decodeErr != nil {
+			t.Fatalf("%s decode error = %v", name, decodeErr)
+		}
+		if got := body["error"]["code"]; got != "feature_unavailable" {
+			t.Fatalf("%s error code = %v, want feature_unavailable", name, got)
+		}
+	}
+
+	listCtx, listRec := newHandlerContext("/admin/api/v1/aliases")
+	assertUnavailable("ListAliases", h.ListAliases(listCtx), listRec)
+
+	putReq := httptest.NewRequest(http.MethodPut, "/admin/api/v1/aliases/smart", bytes.NewBufferString(`{"target_model":"gpt-4o"}`))
+	putReq.Header.Set("Content-Type", "application/json")
+	putRec := httptest.NewRecorder()
+	putCtx := e.NewContext(putReq, putRec)
+	putCtx.SetPathValues(echo.PathValues{{Name: "name", Value: "smart"}})
+	assertUnavailable("UpsertAlias", h.UpsertAlias(putCtx), putRec)
+
+	deleteReq := httptest.NewRequest(http.MethodDelete, "/admin/api/v1/aliases/smart", nil)
+	deleteRec := httptest.NewRecorder()
+	deleteCtx := e.NewContext(deleteReq, deleteRec)
+	deleteCtx.SetPathValues(echo.PathValues{{Name: "name", Value: "smart"}})
+	assertUnavailable("DeleteAlias", h.DeleteAlias(deleteCtx), deleteRec)
+}
+
 func TestUpsertAliasAndDeleteAlias(t *testing.T) {
 	h := newAliasHandler(t)
 	e := echo.New()

--- a/internal/aliases/factory.go
+++ b/internal/aliases/factory.go
@@ -1,0 +1,166 @@
+package aliases
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+
+	"gomodel/config"
+	"gomodel/internal/storage"
+)
+
+// Result holds the initialized aliases service and any owned resources.
+type Result struct {
+	Service *Service
+	Store   Store
+	Storage storage.Storage
+
+	stopRefresh func()
+	closeOnce   sync.Once
+	closeErr    error
+}
+
+// Close releases resources held by the aliases subsystem.
+func (r *Result) Close() error {
+	if r == nil {
+		return nil
+	}
+	r.closeOnce.Do(func() {
+		if r.stopRefresh != nil {
+			r.stopRefresh()
+			r.stopRefresh = nil
+		}
+
+		var errs []error
+		if r.Store != nil {
+			if err := r.Store.Close(); err != nil {
+				errs = append(errs, fmt.Errorf("store close: %w", err))
+			}
+		}
+		if r.Storage != nil {
+			if err := r.Storage.Close(); err != nil {
+				errs = append(errs, fmt.Errorf("storage close: %w", err))
+			}
+		}
+		if len(errs) > 0 {
+			r.closeErr = fmt.Errorf("close errors: %w", errors.Join(errs...))
+		}
+	})
+	return r.closeErr
+}
+
+// New creates an aliases subsystem with its own storage connection.
+func New(ctx context.Context, cfg *config.Config, catalog Catalog) (*Result, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config is required")
+	}
+	storeConn, err := storage.New(ctx, buildStorageConfig(cfg))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create storage: %w", err)
+	}
+	result, err := newResult(ctx, cfg, storeConn, catalog)
+	if err != nil {
+		_ = storeConn.Close()
+		return nil, err
+	}
+	result.Storage = storeConn
+	return result, nil
+}
+
+// NewWithSharedStorage creates an aliases subsystem using an existing storage connection.
+func NewWithSharedStorage(ctx context.Context, cfg *config.Config, shared storage.Storage, catalog Catalog) (*Result, error) {
+	if shared == nil {
+		return nil, fmt.Errorf("shared storage is required")
+	}
+	if cfg == nil {
+		return nil, fmt.Errorf("config is required")
+	}
+	return newResult(ctx, cfg, shared, catalog)
+}
+
+func newResult(ctx context.Context, cfg *config.Config, storeConn storage.Storage, catalog Catalog) (*Result, error) {
+	store, err := createStore(ctx, storeConn)
+	if err != nil {
+		return nil, err
+	}
+	service, err := NewService(store, catalog)
+	if err != nil {
+		return nil, err
+	}
+	if err := service.Refresh(ctx); err != nil {
+		return nil, err
+	}
+
+	refreshInterval := time.Duration(cfg.Cache.Model.RefreshInterval) * time.Second
+	if refreshInterval <= 0 {
+		refreshInterval = time.Hour
+	}
+
+	return &Result{
+		Service:     service,
+		Store:       store,
+		stopRefresh: service.StartBackgroundRefresh(refreshInterval),
+	}, nil
+}
+
+func buildStorageConfig(cfg *config.Config) storage.Config {
+	storageCfg := storage.Config{
+		Type: cfg.Storage.Type,
+		SQLite: storage.SQLiteConfig{
+			Path: cfg.Storage.SQLite.Path,
+		},
+		PostgreSQL: storage.PostgreSQLConfig{
+			URL:      cfg.Storage.PostgreSQL.URL,
+			MaxConns: cfg.Storage.PostgreSQL.MaxConns,
+		},
+		MongoDB: storage.MongoDBConfig{
+			URL:      cfg.Storage.MongoDB.URL,
+			Database: cfg.Storage.MongoDB.Database,
+		},
+	}
+
+	if storageCfg.Type == "" {
+		storageCfg.Type = storage.TypeSQLite
+	}
+	if storageCfg.SQLite.Path == "" {
+		storageCfg.SQLite.Path = storage.DefaultSQLitePath
+	}
+	if storageCfg.MongoDB.Database == "" {
+		storageCfg.MongoDB.Database = "gomodel"
+	}
+	return storageCfg
+}
+
+func createStore(ctx context.Context, store storage.Storage) (Store, error) {
+	switch store.Type() {
+	case storage.TypeSQLite:
+		return NewSQLiteStore(store.SQLiteDB())
+	case storage.TypePostgreSQL:
+		pool := store.PostgreSQLPool()
+		if pool == nil {
+			return nil, fmt.Errorf("PostgreSQL pool is nil")
+		}
+		pgxPool, ok := pool.(*pgxpool.Pool)
+		if !ok {
+			return nil, fmt.Errorf("invalid PostgreSQL pool type: %T", pool)
+		}
+		return NewPostgreSQLStore(ctx, pgxPool)
+	case storage.TypeMongoDB:
+		db := store.MongoDatabase()
+		if db == nil {
+			return nil, fmt.Errorf("MongoDB database is nil")
+		}
+		mongoDB, ok := db.(*mongo.Database)
+		if !ok {
+			return nil, fmt.Errorf("invalid MongoDB database type: %T", db)
+		}
+		return NewMongoDBStore(mongoDB)
+	default:
+		return nil, fmt.Errorf("unknown storage type: %s", store.Type())
+	}
+}

--- a/internal/aliases/provider.go
+++ b/internal/aliases/provider.go
@@ -282,7 +282,7 @@ func (p *Provider) rewriteChatRequest(req *core.ChatRequest, mode requestRewrite
 	if req == nil {
 		return nil, nil
 	}
-	selector, err := p.resolveRequestSelector(req.Model, req.Provider)
+	selector, err := p.resolveRoutableSelector(req.Model, req.Provider)
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +296,7 @@ func (p *Provider) rewriteResponsesRequest(req *core.ResponsesRequest, mode requ
 	if req == nil {
 		return nil, nil
 	}
-	selector, err := p.resolveRequestSelector(req.Model, req.Provider)
+	selector, err := p.resolveRoutableSelector(req.Model, req.Provider)
 	if err != nil {
 		return nil, err
 	}
@@ -310,7 +310,7 @@ func (p *Provider) rewriteEmbeddingRequest(req *core.EmbeddingRequest, mode requ
 	if req == nil {
 		return nil, nil
 	}
-	selector, err := p.resolveRequestSelector(req.Model, req.Provider)
+	selector, err := p.resolveRoutableSelector(req.Model, req.Provider)
 	if err != nil {
 		return nil, err
 	}
@@ -435,6 +435,22 @@ func (p *Provider) resolveRequestSelector(model, provider string) (core.ModelSel
 		return selector, nil
 	}
 	return core.ParseModelSelector(model, provider)
+}
+
+func (p *Provider) resolveRoutableSelector(model, provider string) (core.ModelSelector, error) {
+	selector, err := p.resolveRequestSelector(model, provider)
+	if err != nil {
+		return core.ModelSelector{}, err
+	}
+
+	resolvedModel := strings.TrimSpace(selector.QualifiedModel())
+	if resolvedModel == "" {
+		return core.ModelSelector{}, core.NewInvalidRequestError("model is required", nil)
+	}
+	if !p.inner.Supports(resolvedModel) {
+		return core.ModelSelector{}, core.NewInvalidRequestError("unsupported model: "+resolvedModel, nil)
+	}
+	return selector, nil
 }
 
 func providerValueForMode(selector core.ModelSelector, mode requestRewriteMode) string {

--- a/internal/aliases/provider.go
+++ b/internal/aliases/provider.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"sort"
+	"strings"
 
 	"gomodel/internal/core"
 )
@@ -152,7 +154,13 @@ func (p *Provider) CreateBatch(ctx context.Context, providerType string, req *co
 		return nil, err
 	}
 	p.recordBatchPreparation(ctx, req, result.Request)
-	return native.CreateBatch(ctx, providerType, result.Request)
+	resp, err := native.CreateBatch(ctx, providerType, result.Request)
+	if err != nil {
+		p.cleanupBatchRewriteFile(ctx, providerType, result.RewrittenInputFileID)
+		return nil, err
+	}
+	p.cleanupSupersededBatchRewriteFile(ctx, providerType, result.RewrittenInputFileID)
+	return resp, nil
 }
 
 func (p *Provider) GetBatch(ctx context.Context, providerType, id string) (*core.BatchResponse, error) {
@@ -199,8 +207,10 @@ func (p *Provider) CreateBatchWithHints(ctx context.Context, providerType string
 	p.recordBatchPreparation(ctx, req, result.Request)
 	resp, hints, err := hinted.CreateBatchWithHints(ctx, providerType, result.Request)
 	if err != nil {
+		p.cleanupBatchRewriteFile(ctx, providerType, result.RewrittenInputFileID)
 		return nil, nil, err
 	}
+	p.cleanupSupersededBatchRewriteFile(ctx, providerType, result.RewrittenInputFileID)
 	return resp, mergeBatchHints(result.RequestEndpointHints, hints), nil
 }
 
@@ -364,6 +374,35 @@ func (p *Provider) recordBatchPreparation(ctx context.Context, original, rewritt
 		return
 	}
 	metadata.RecordInputFileRewrite(original.InputFileID, rewritten.InputFileID)
+}
+
+func (p *Provider) cleanupSupersededBatchRewriteFile(ctx context.Context, providerType, localRewrittenFileID string) {
+	localRewrittenFileID = strings.TrimSpace(localRewrittenFileID)
+	if localRewrittenFileID == "" {
+		return
+	}
+	metadata := core.GetBatchPreparationMetadata(ctx)
+	if metadata == nil {
+		return
+	}
+	if strings.TrimSpace(metadata.RewrittenInputFileID) == localRewrittenFileID {
+		return
+	}
+	p.cleanupBatchRewriteFile(ctx, providerType, localRewrittenFileID)
+}
+
+func (p *Provider) cleanupBatchRewriteFile(ctx context.Context, providerType, fileID string) {
+	fileID = strings.TrimSpace(fileID)
+	if fileID == "" {
+		return
+	}
+	files, err := p.nativeFileRouter()
+	if err != nil {
+		return
+	}
+	if _, err := files.DeleteFile(ctx, providerType, fileID); err != nil {
+		slog.Warn("failed to delete rewritten batch input file", "provider", providerType, "file_id", fileID, "error", err)
+	}
 }
 
 func mergeBatchHints(left, right map[string]string) map[string]string {

--- a/internal/aliases/provider.go
+++ b/internal/aliases/provider.go
@@ -377,7 +377,7 @@ func mergeBatchHints(left, right map[string]string) map[string]string {
 		}
 		return merged
 	}
-	merged := make(map[string]string, len(left)+len(right))
+	merged := make(map[string]string, len(left))
 	for key, value := range left {
 		merged[key] = value
 	}

--- a/internal/aliases/provider.go
+++ b/internal/aliases/provider.go
@@ -16,6 +16,13 @@ type Provider struct {
 	service *Service
 }
 
+type requestRewriteMode int
+
+const (
+	rewriteForRouting requestRewriteMode = iota
+	rewriteForUpstream
+)
+
 // NewProvider creates an alias-aware provider wrapper.
 func NewProvider(inner core.RoutableProvider, service *Service) *Provider {
 	return &Provider{inner: inner, service: service}
@@ -35,7 +42,7 @@ func (p *Provider) ResolveModel(model, provider string) (core.ModelSelector, boo
 }
 
 func (p *Provider) ChatCompletion(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
-	forward, err := p.rewriteChatRequest(req)
+	forward, err := p.rewriteChatRequest(req, rewriteForRouting)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +50,7 @@ func (p *Provider) ChatCompletion(ctx context.Context, req *core.ChatRequest) (*
 }
 
 func (p *Provider) StreamChatCompletion(ctx context.Context, req *core.ChatRequest) (io.ReadCloser, error) {
-	forward, err := p.rewriteChatRequest(req)
+	forward, err := p.rewriteChatRequest(req, rewriteForRouting)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +88,7 @@ func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error)
 }
 
 func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
-	forward, err := p.rewriteResponsesRequest(req)
+	forward, err := p.rewriteResponsesRequest(req, rewriteForRouting)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +96,7 @@ func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*
 }
 
 func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
-	forward, err := p.rewriteResponsesRequest(req)
+	forward, err := p.rewriteResponsesRequest(req, rewriteForRouting)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +104,7 @@ func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesReque
 }
 
 func (p *Provider) Embeddings(ctx context.Context, req *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
-	forward, err := p.rewriteEmbeddingRequest(req)
+	forward, err := p.rewriteEmbeddingRequest(req, rewriteForRouting)
 	if err != nil {
 		return nil, err
 	}
@@ -125,6 +132,15 @@ func (p *Provider) ModelCount() int {
 		return counted.ModelCount()
 	}
 	return -1
+}
+
+// NativeFileProviderTypes delegates provider capability inventory to the inner
+// provider when available.
+func (p *Provider) NativeFileProviderTypes() []string {
+	if typed, ok := p.inner.(core.NativeFileProviderTypeLister); ok {
+		return typed.NativeFileProviderTypes()
+	}
+	return nil
 }
 
 func (p *Provider) CreateBatch(ctx context.Context, providerType string, req *core.BatchRequest) (*core.BatchResponse, error) {
@@ -247,45 +263,45 @@ func (p *Provider) Passthrough(ctx context.Context, providerType string, req *co
 	return passthrough.Passthrough(ctx, providerType, req)
 }
 
-func (p *Provider) rewriteChatRequest(req *core.ChatRequest) (*core.ChatRequest, error) {
+func (p *Provider) rewriteChatRequest(req *core.ChatRequest, mode requestRewriteMode) (*core.ChatRequest, error) {
 	if req == nil {
 		return nil, nil
 	}
-	selector, changed, err := p.ResolveModel(req.Model, req.Provider)
-	if err != nil || !changed {
-		return req, err
+	selector, err := p.resolveRequestSelector(req.Model, req.Provider)
+	if err != nil {
+		return nil, err
 	}
 	forward := *req
 	forward.Model = selector.Model
-	forward.Provider = selector.Provider
+	forward.Provider = providerValueForMode(selector, mode)
 	return &forward, nil
 }
 
-func (p *Provider) rewriteResponsesRequest(req *core.ResponsesRequest) (*core.ResponsesRequest, error) {
+func (p *Provider) rewriteResponsesRequest(req *core.ResponsesRequest, mode requestRewriteMode) (*core.ResponsesRequest, error) {
 	if req == nil {
 		return nil, nil
 	}
-	selector, changed, err := p.ResolveModel(req.Model, req.Provider)
-	if err != nil || !changed {
-		return req, err
+	selector, err := p.resolveRequestSelector(req.Model, req.Provider)
+	if err != nil {
+		return nil, err
 	}
 	forward := *req
 	forward.Model = selector.Model
-	forward.Provider = selector.Provider
+	forward.Provider = providerValueForMode(selector, mode)
 	return &forward, nil
 }
 
-func (p *Provider) rewriteEmbeddingRequest(req *core.EmbeddingRequest) (*core.EmbeddingRequest, error) {
+func (p *Provider) rewriteEmbeddingRequest(req *core.EmbeddingRequest, mode requestRewriteMode) (*core.EmbeddingRequest, error) {
 	if req == nil {
 		return nil, nil
 	}
-	selector, changed, err := p.ResolveModel(req.Model, req.Provider)
-	if err != nil || !changed {
-		return req, err
+	selector, err := p.resolveRequestSelector(req.Model, req.Provider)
+	if err != nil {
+		return nil, err
 	}
 	forward := *req
 	forward.Model = selector.Model
-	forward.Provider = selector.Provider
+	forward.Provider = providerValueForMode(selector, mode)
 	return &forward, nil
 }
 
@@ -310,7 +326,7 @@ func (p *Provider) rewriteBatchRequest(req *core.BatchRequest) (*core.BatchReque
 		var body []byte
 		switch typed := decoded.Request.(type) {
 		case *core.ChatRequest:
-			modified, err := p.rewriteChatRequest(typed)
+			modified, err := p.rewriteChatRequest(typed, rewriteForUpstream)
 			if err != nil {
 				return nil, err
 			}
@@ -319,7 +335,7 @@ func (p *Provider) rewriteBatchRequest(req *core.BatchRequest) (*core.BatchReque
 				return nil, core.NewInvalidRequestError("failed to encode batch item", err)
 			}
 		case *core.ResponsesRequest:
-			modified, err := p.rewriteResponsesRequest(typed)
+			modified, err := p.rewriteResponsesRequest(typed, rewriteForUpstream)
 			if err != nil {
 				return nil, err
 			}
@@ -328,7 +344,7 @@ func (p *Provider) rewriteBatchRequest(req *core.BatchRequest) (*core.BatchReque
 				return nil, core.NewInvalidRequestError("failed to encode batch item", err)
 			}
 		case *core.EmbeddingRequest:
-			modified, err := p.rewriteEmbeddingRequest(typed)
+			modified, err := p.rewriteEmbeddingRequest(typed, rewriteForUpstream)
 			if err != nil {
 				return nil, err
 			}
@@ -342,6 +358,24 @@ func (p *Provider) rewriteBatchRequest(req *core.BatchRequest) (*core.BatchReque
 		forward.Requests[i].Body = body
 	}
 	return &forward, nil
+}
+
+func (p *Provider) resolveRequestSelector(model, provider string) (core.ModelSelector, error) {
+	selector, changed, err := p.ResolveModel(model, provider)
+	if err != nil {
+		return core.ModelSelector{}, err
+	}
+	if changed {
+		return selector, nil
+	}
+	return core.ParseModelSelector(model, provider)
+}
+
+func providerValueForMode(selector core.ModelSelector, mode requestRewriteMode) string {
+	if mode == rewriteForUpstream {
+		return ""
+	}
+	return selector.Provider
 }
 
 func (p *Provider) nativeBatchRouter() (core.NativeBatchRoutableProvider, error) {

--- a/internal/aliases/provider.go
+++ b/internal/aliases/provider.go
@@ -3,7 +3,6 @@ package aliases
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"sort"
 
@@ -148,11 +147,12 @@ func (p *Provider) CreateBatch(ctx context.Context, providerType string, req *co
 	if err != nil {
 		return nil, err
 	}
-	forward, err := p.rewriteBatchRequest(req)
+	result, err := p.rewriteBatchSource(ctx, providerType, req)
 	if err != nil {
 		return nil, err
 	}
-	return native.CreateBatch(ctx, providerType, forward)
+	p.recordBatchPreparation(ctx, req, result.Request)
+	return native.CreateBatch(ctx, providerType, result.Request)
 }
 
 func (p *Provider) GetBatch(ctx context.Context, providerType, id string) (*core.BatchResponse, error) {
@@ -192,11 +192,16 @@ func (p *Provider) CreateBatchWithHints(ctx context.Context, providerType string
 	if err != nil {
 		return nil, nil, err
 	}
-	forward, err := p.rewriteBatchRequest(req)
+	result, err := p.rewriteBatchSource(ctx, providerType, req)
 	if err != nil {
 		return nil, nil, err
 	}
-	return hinted.CreateBatchWithHints(ctx, providerType, forward)
+	p.recordBatchPreparation(ctx, req, result.Request)
+	resp, hints, err := hinted.CreateBatchWithHints(ctx, providerType, result.Request)
+	if err != nil {
+		return nil, nil, err
+	}
+	return resp, mergeBatchHints(result.RequestEndpointHints, hints), nil
 }
 
 func (p *Provider) GetBatchResultsWithHints(ctx context.Context, providerType, id string, endpointByCustomID map[string]string) (*core.BatchResultsResponse, error) {
@@ -305,59 +310,81 @@ func (p *Provider) rewriteEmbeddingRequest(req *core.EmbeddingRequest, mode requ
 	return &forward, nil
 }
 
-func (p *Provider) rewriteBatchRequest(req *core.BatchRequest) (*core.BatchRequest, error) {
-	if req == nil || len(req.Requests) == 0 {
-		return req, nil
+func (p *Provider) rewriteBatchSource(ctx context.Context, providerType string, req *core.BatchRequest) (*core.BatchRewriteResult, error) {
+	files, err := p.nativeFileRouter()
+	if err != nil {
+		files = nil
 	}
+	return core.RewriteBatchSource(ctx, providerType, req, files, []string{"chat_completions", "responses", "embeddings"}, p.rewriteBatchDecodedItem)
+}
 
-	forward := *req
-	forward.Requests = make([]core.BatchRequestItem, len(req.Requests))
-	copy(forward.Requests, req.Requests)
-
-	for i, item := range forward.Requests {
-		decoded, handled, err := core.MaybeDecodeKnownBatchItemRequest(req.Endpoint, item, "chat_completions", "responses", "embeddings")
+func (p *Provider) rewriteBatchDecodedItem(_ context.Context, _ core.BatchRequestItem, decoded *core.DecodedBatchItemRequest) (json.RawMessage, error) {
+	switch typed := decoded.Request.(type) {
+	case *core.ChatRequest:
+		modified, err := p.rewriteChatRequest(typed, rewriteForUpstream)
 		if err != nil {
-			return nil, core.NewInvalidRequestError(fmt.Sprintf("batch item %d: %s", i, err.Error()), err)
+			return nil, err
 		}
-		if !handled {
-			continue
+		body, err := json.Marshal(modified)
+		if err != nil {
+			return nil, core.NewInvalidRequestError("failed to encode batch item", err)
 		}
-
-		var body []byte
-		switch typed := decoded.Request.(type) {
-		case *core.ChatRequest:
-			modified, err := p.rewriteChatRequest(typed, rewriteForUpstream)
-			if err != nil {
-				return nil, err
-			}
-			body, err = json.Marshal(modified)
-			if err != nil {
-				return nil, core.NewInvalidRequestError("failed to encode batch item", err)
-			}
-		case *core.ResponsesRequest:
-			modified, err := p.rewriteResponsesRequest(typed, rewriteForUpstream)
-			if err != nil {
-				return nil, err
-			}
-			body, err = json.Marshal(modified)
-			if err != nil {
-				return nil, core.NewInvalidRequestError("failed to encode batch item", err)
-			}
-		case *core.EmbeddingRequest:
-			modified, err := p.rewriteEmbeddingRequest(typed, rewriteForUpstream)
-			if err != nil {
-				return nil, err
-			}
-			body, err = json.Marshal(modified)
-			if err != nil {
-				return nil, core.NewInvalidRequestError("failed to encode batch item", err)
-			}
-		default:
-			continue
+		return body, nil
+	case *core.ResponsesRequest:
+		modified, err := p.rewriteResponsesRequest(typed, rewriteForUpstream)
+		if err != nil {
+			return nil, err
 		}
-		forward.Requests[i].Body = body
+		body, err := json.Marshal(modified)
+		if err != nil {
+			return nil, core.NewInvalidRequestError("failed to encode batch item", err)
+		}
+		return body, nil
+	case *core.EmbeddingRequest:
+		modified, err := p.rewriteEmbeddingRequest(typed, rewriteForUpstream)
+		if err != nil {
+			return nil, err
+		}
+		body, err := json.Marshal(modified)
+		if err != nil {
+			return nil, core.NewInvalidRequestError("failed to encode batch item", err)
+		}
+		return body, nil
+	default:
+		return nil, core.NewInvalidRequestError("unsupported batch item url: "+decoded.Endpoint, nil)
 	}
-	return &forward, nil
+}
+
+func (p *Provider) recordBatchPreparation(ctx context.Context, original, rewritten *core.BatchRequest) {
+	if ctx == nil || original == nil || rewritten == nil {
+		return
+	}
+	metadata := core.GetBatchPreparationMetadata(ctx)
+	if metadata == nil {
+		return
+	}
+	metadata.RecordInputFileRewrite(original.InputFileID, rewritten.InputFileID)
+}
+
+func mergeBatchHints(left, right map[string]string) map[string]string {
+	if len(left) == 0 {
+		if len(right) == 0 {
+			return nil
+		}
+		merged := make(map[string]string, len(right))
+		for key, value := range right {
+			merged[key] = value
+		}
+		return merged
+	}
+	merged := make(map[string]string, len(left)+len(right))
+	for key, value := range left {
+		merged[key] = value
+	}
+	for key, value := range right {
+		merged[key] = value
+	}
+	return merged
 }
 
 func (p *Provider) resolveRequestSelector(model, provider string) (core.ModelSelector, error) {

--- a/internal/aliases/provider.go
+++ b/internal/aliases/provider.go
@@ -1,0 +1,377 @@
+package aliases
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+
+	"gomodel/internal/core"
+)
+
+// Provider wraps a routable provider and resolves aliases before delegating.
+type Provider struct {
+	inner   core.RoutableProvider
+	service *Service
+}
+
+// NewProvider creates an alias-aware provider wrapper.
+func NewProvider(inner core.RoutableProvider, service *Service) *Provider {
+	return &Provider{inner: inner, service: service}
+}
+
+// ResolveModel resolves a model/provider pair through the alias table.
+func (p *Provider) ResolveModel(model, provider string) (core.ModelSelector, bool, error) {
+	if p.service == nil {
+		selector, err := core.ParseModelSelector(model, provider)
+		return selector, false, err
+	}
+	resolution, ok, err := p.service.Resolve(model, provider)
+	if err != nil {
+		return core.ModelSelector{}, false, err
+	}
+	return resolution.Resolved, ok, nil
+}
+
+func (p *Provider) ChatCompletion(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+	forward, err := p.rewriteChatRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	return p.inner.ChatCompletion(ctx, forward)
+}
+
+func (p *Provider) StreamChatCompletion(ctx context.Context, req *core.ChatRequest) (io.ReadCloser, error) {
+	forward, err := p.rewriteChatRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	return p.inner.StreamChatCompletion(ctx, forward)
+}
+
+func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error) {
+	resp, err := p.inner.ListModels(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		resp = &core.ModelsResponse{Object: "list", Data: []core.Model{}}
+	}
+	if p.service == nil {
+		return resp, nil
+	}
+
+	dataByID := make(map[string]core.Model, len(resp.Data))
+	for _, model := range resp.Data {
+		dataByID[model.ID] = model
+	}
+	for _, aliasModel := range p.service.ExposedModels() {
+		dataByID[aliasModel.ID] = aliasModel
+	}
+	data := make([]core.Model, 0, len(dataByID))
+	for _, model := range dataByID {
+		data = append(data, model)
+	}
+	sort.Slice(data, func(i, j int) bool { return data[i].ID < data[j].ID })
+
+	cloned := *resp
+	cloned.Data = data
+	return &cloned, nil
+}
+
+func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
+	forward, err := p.rewriteResponsesRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	return p.inner.Responses(ctx, forward)
+}
+
+func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
+	forward, err := p.rewriteResponsesRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	return p.inner.StreamResponses(ctx, forward)
+}
+
+func (p *Provider) Embeddings(ctx context.Context, req *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	forward, err := p.rewriteEmbeddingRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	return p.inner.Embeddings(ctx, forward)
+}
+
+func (p *Provider) Supports(model string) bool {
+	if p.service != nil && p.service.Supports(model) {
+		return true
+	}
+	return p.inner.Supports(model)
+}
+
+func (p *Provider) GetProviderType(model string) string {
+	if p.service != nil {
+		if providerType := p.service.GetProviderType(model); providerType != "" {
+			return providerType
+		}
+	}
+	return p.inner.GetProviderType(model)
+}
+
+func (p *Provider) ModelCount() int {
+	if counted, ok := p.inner.(interface{ ModelCount() int }); ok {
+		return counted.ModelCount()
+	}
+	return -1
+}
+
+func (p *Provider) CreateBatch(ctx context.Context, providerType string, req *core.BatchRequest) (*core.BatchResponse, error) {
+	native, err := p.nativeBatchRouter()
+	if err != nil {
+		return nil, err
+	}
+	forward, err := p.rewriteBatchRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	return native.CreateBatch(ctx, providerType, forward)
+}
+
+func (p *Provider) GetBatch(ctx context.Context, providerType, id string) (*core.BatchResponse, error) {
+	native, err := p.nativeBatchRouter()
+	if err != nil {
+		return nil, err
+	}
+	return native.GetBatch(ctx, providerType, id)
+}
+
+func (p *Provider) ListBatches(ctx context.Context, providerType string, limit int, after string) (*core.BatchListResponse, error) {
+	native, err := p.nativeBatchRouter()
+	if err != nil {
+		return nil, err
+	}
+	return native.ListBatches(ctx, providerType, limit, after)
+}
+
+func (p *Provider) CancelBatch(ctx context.Context, providerType, id string) (*core.BatchResponse, error) {
+	native, err := p.nativeBatchRouter()
+	if err != nil {
+		return nil, err
+	}
+	return native.CancelBatch(ctx, providerType, id)
+}
+
+func (p *Provider) GetBatchResults(ctx context.Context, providerType, id string) (*core.BatchResultsResponse, error) {
+	native, err := p.nativeBatchRouter()
+	if err != nil {
+		return nil, err
+	}
+	return native.GetBatchResults(ctx, providerType, id)
+}
+
+func (p *Provider) CreateBatchWithHints(ctx context.Context, providerType string, req *core.BatchRequest) (*core.BatchResponse, map[string]string, error) {
+	hinted, err := p.nativeBatchHintRouter()
+	if err != nil {
+		return nil, nil, err
+	}
+	forward, err := p.rewriteBatchRequest(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	return hinted.CreateBatchWithHints(ctx, providerType, forward)
+}
+
+func (p *Provider) GetBatchResultsWithHints(ctx context.Context, providerType, id string, endpointByCustomID map[string]string) (*core.BatchResultsResponse, error) {
+	hinted, err := p.nativeBatchHintRouter()
+	if err != nil {
+		return nil, err
+	}
+	return hinted.GetBatchResultsWithHints(ctx, providerType, id, endpointByCustomID)
+}
+
+func (p *Provider) ClearBatchResultHints(providerType, batchID string) {
+	hinted, err := p.nativeBatchHintRouter()
+	if err != nil {
+		return
+	}
+	hinted.ClearBatchResultHints(providerType, batchID)
+}
+
+func (p *Provider) CreateFile(ctx context.Context, providerType string, req *core.FileCreateRequest) (*core.FileObject, error) {
+	files, err := p.nativeFileRouter()
+	if err != nil {
+		return nil, err
+	}
+	return files.CreateFile(ctx, providerType, req)
+}
+
+func (p *Provider) ListFiles(ctx context.Context, providerType, purpose string, limit int, after string) (*core.FileListResponse, error) {
+	files, err := p.nativeFileRouter()
+	if err != nil {
+		return nil, err
+	}
+	return files.ListFiles(ctx, providerType, purpose, limit, after)
+}
+
+func (p *Provider) GetFile(ctx context.Context, providerType, id string) (*core.FileObject, error) {
+	files, err := p.nativeFileRouter()
+	if err != nil {
+		return nil, err
+	}
+	return files.GetFile(ctx, providerType, id)
+}
+
+func (p *Provider) DeleteFile(ctx context.Context, providerType, id string) (*core.FileDeleteResponse, error) {
+	files, err := p.nativeFileRouter()
+	if err != nil {
+		return nil, err
+	}
+	return files.DeleteFile(ctx, providerType, id)
+}
+
+func (p *Provider) GetFileContent(ctx context.Context, providerType, id string) (*core.FileContentResponse, error) {
+	files, err := p.nativeFileRouter()
+	if err != nil {
+		return nil, err
+	}
+	return files.GetFileContent(ctx, providerType, id)
+}
+
+func (p *Provider) Passthrough(ctx context.Context, providerType string, req *core.PassthroughRequest) (*core.PassthroughResponse, error) {
+	passthrough, err := p.passthroughRouter()
+	if err != nil {
+		return nil, err
+	}
+	return passthrough.Passthrough(ctx, providerType, req)
+}
+
+func (p *Provider) rewriteChatRequest(req *core.ChatRequest) (*core.ChatRequest, error) {
+	if req == nil {
+		return nil, nil
+	}
+	selector, changed, err := p.ResolveModel(req.Model, req.Provider)
+	if err != nil || !changed {
+		return req, err
+	}
+	forward := *req
+	forward.Model = selector.Model
+	forward.Provider = selector.Provider
+	return &forward, nil
+}
+
+func (p *Provider) rewriteResponsesRequest(req *core.ResponsesRequest) (*core.ResponsesRequest, error) {
+	if req == nil {
+		return nil, nil
+	}
+	selector, changed, err := p.ResolveModel(req.Model, req.Provider)
+	if err != nil || !changed {
+		return req, err
+	}
+	forward := *req
+	forward.Model = selector.Model
+	forward.Provider = selector.Provider
+	return &forward, nil
+}
+
+func (p *Provider) rewriteEmbeddingRequest(req *core.EmbeddingRequest) (*core.EmbeddingRequest, error) {
+	if req == nil {
+		return nil, nil
+	}
+	selector, changed, err := p.ResolveModel(req.Model, req.Provider)
+	if err != nil || !changed {
+		return req, err
+	}
+	forward := *req
+	forward.Model = selector.Model
+	forward.Provider = selector.Provider
+	return &forward, nil
+}
+
+func (p *Provider) rewriteBatchRequest(req *core.BatchRequest) (*core.BatchRequest, error) {
+	if req == nil || len(req.Requests) == 0 {
+		return req, nil
+	}
+
+	forward := *req
+	forward.Requests = make([]core.BatchRequestItem, len(req.Requests))
+	copy(forward.Requests, req.Requests)
+
+	for i, item := range forward.Requests {
+		decoded, handled, err := core.MaybeDecodeKnownBatchItemRequest(req.Endpoint, item, "chat_completions", "responses", "embeddings")
+		if err != nil {
+			return nil, core.NewInvalidRequestError(fmt.Sprintf("batch item %d: %s", i, err.Error()), err)
+		}
+		if !handled {
+			continue
+		}
+
+		var body []byte
+		switch typed := decoded.Request.(type) {
+		case *core.ChatRequest:
+			modified, err := p.rewriteChatRequest(typed)
+			if err != nil {
+				return nil, err
+			}
+			body, err = json.Marshal(modified)
+			if err != nil {
+				return nil, core.NewInvalidRequestError("failed to encode batch item", err)
+			}
+		case *core.ResponsesRequest:
+			modified, err := p.rewriteResponsesRequest(typed)
+			if err != nil {
+				return nil, err
+			}
+			body, err = json.Marshal(modified)
+			if err != nil {
+				return nil, core.NewInvalidRequestError("failed to encode batch item", err)
+			}
+		case *core.EmbeddingRequest:
+			modified, err := p.rewriteEmbeddingRequest(typed)
+			if err != nil {
+				return nil, err
+			}
+			body, err = json.Marshal(modified)
+			if err != nil {
+				return nil, core.NewInvalidRequestError("failed to encode batch item", err)
+			}
+		default:
+			continue
+		}
+		forward.Requests[i].Body = body
+	}
+	return &forward, nil
+}
+
+func (p *Provider) nativeBatchRouter() (core.NativeBatchRoutableProvider, error) {
+	native, ok := p.inner.(core.NativeBatchRoutableProvider)
+	if !ok {
+		return nil, core.NewInvalidRequestError("batch routing is not supported by the current provider router", nil)
+	}
+	return native, nil
+}
+
+func (p *Provider) nativeBatchHintRouter() (core.NativeBatchHintRoutableProvider, error) {
+	hinted, ok := p.inner.(core.NativeBatchHintRoutableProvider)
+	if !ok {
+		return nil, core.NewInvalidRequestError("batch hint routing is not supported by the current provider router", nil)
+	}
+	return hinted, nil
+}
+
+func (p *Provider) nativeFileRouter() (core.NativeFileRoutableProvider, error) {
+	files, ok := p.inner.(core.NativeFileRoutableProvider)
+	if !ok {
+		return nil, core.NewInvalidRequestError("file routing is not supported by the current provider router", nil)
+	}
+	return files, nil
+}
+
+func (p *Provider) passthroughRouter() (core.RoutablePassthrough, error) {
+	passthrough, ok := p.inner.(core.RoutablePassthrough)
+	if !ok {
+		return nil, core.NewInvalidRequestError("passthrough routing is not supported by the current provider router", nil)
+	}
+	return passthrough, nil
+}

--- a/internal/aliases/provider_test.go
+++ b/internal/aliases/provider_test.go
@@ -235,6 +235,7 @@ func TestProviderRewritesBatchItemBodies(t *testing.T) {
 	}
 
 	inner := newProviderMock()
+	inner.supported["openai/gpt-4o"] = true
 	provider := NewProvider(inner, service)
 
 	body := json.RawMessage(`{"model":"smart","messages":[{"role":"user","content":"hi"}]}`)
@@ -274,6 +275,7 @@ func TestProviderRewritesBatchInputFiles(t *testing.T) {
 	}
 
 	inner := newProviderMock()
+	inner.supported["openai/gpt-4o"] = true
 	inner.fileContent = &core.FileContentResponse{
 		ID:       "file_source",
 		Filename: "batch.jsonl",
@@ -316,6 +318,7 @@ func TestProviderBatchInputFileSkipsUploadWhenUnchanged(t *testing.T) {
 	}
 
 	inner := newProviderMock()
+	inner.supported["gpt-4o"] = true
 	inner.fileContent = &core.FileContentResponse{
 		ID:       "file_source",
 		Filename: "batch.jsonl",
@@ -341,6 +344,45 @@ func TestProviderBatchInputFileSkipsUploadWhenUnchanged(t *testing.T) {
 	}
 }
 
+func TestProviderRejectsDisabledAliasInBatchInputFiles(t *testing.T) {
+	catalog := newTestCatalog()
+	catalog.add("openai/gpt-4o", "openai", core.Model{ID: "gpt-4o", Object: "model"})
+
+	service, err := NewService(newMemoryStore(Alias{Name: "smart", TargetModel: "gpt-4o", TargetProvider: "openai", Enabled: false}), catalog)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	inner := newProviderMock()
+	inner.supported["gpt-4o"] = true
+	inner.fileContent = &core.FileContentResponse{
+		ID:       "file_source",
+		Filename: "batch.jsonl",
+		Data:     []byte("{\"custom_id\":\"1\",\"method\":\"POST\",\"url\":\"/v1/chat/completions\",\"body\":{\"model\":\"smart\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}}\n"),
+	}
+	provider := NewProvider(inner, service)
+
+	_, err = provider.CreateBatch(context.Background(), "openai", &core.BatchRequest{
+		InputFileID: "file_source",
+		Endpoint:    "/v1/chat/completions",
+	})
+	if err == nil {
+		t.Fatal("CreateBatch() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported model: smart") {
+		t.Fatalf("CreateBatch() error = %v, want unsupported model: smart", err)
+	}
+	if inner.batchReq != nil {
+		t.Fatalf("captured batch request = %#v, want nil", inner.batchReq)
+	}
+	if len(inner.fileCreates) != 0 {
+		t.Fatalf("len(fileCreates) = %d, want 0", len(inner.fileCreates))
+	}
+}
+
 func TestProviderDeletesRewrittenBatchInputFileOnCreateFailure(t *testing.T) {
 	catalog := newTestCatalog()
 	catalog.add("openai/gpt-4o", "openai", core.Model{ID: "gpt-4o", Object: "model"})
@@ -354,6 +396,7 @@ func TestProviderDeletesRewrittenBatchInputFileOnCreateFailure(t *testing.T) {
 	}
 
 	inner := newProviderMock()
+	inner.supported["openai/gpt-4o"] = true
 	inner.createBatchErr = context.Canceled
 	inner.fileContent = &core.FileContentResponse{
 		ID:       "file_source",

--- a/internal/aliases/provider_test.go
+++ b/internal/aliases/provider_test.go
@@ -11,16 +11,18 @@ import (
 )
 
 type providerMock struct {
-	chatReq      *core.ChatRequest
-	responsesReq *core.ResponsesRequest
-	embeddingReq *core.EmbeddingRequest
-	batchReq     *core.BatchRequest
-	fileContent  *core.FileContentResponse
-	fileCreates  []*core.FileCreateRequest
-	fileObject   *core.FileObject
-	modelsResp   *core.ModelsResponse
-	supported    map[string]bool
-	providerType map[string]string
+	chatReq        *core.ChatRequest
+	responsesReq   *core.ResponsesRequest
+	embeddingReq   *core.EmbeddingRequest
+	batchReq       *core.BatchRequest
+	createBatchErr error
+	fileContent    *core.FileContentResponse
+	fileCreates    []*core.FileCreateRequest
+	fileDeletes    []string
+	fileObject     *core.FileObject
+	modelsResp     *core.ModelsResponse
+	supported      map[string]bool
+	providerType   map[string]string
 }
 
 func newProviderMock() *providerMock {
@@ -70,6 +72,9 @@ func (m *providerMock) GetProviderType(model string) string {
 
 func (m *providerMock) CreateBatch(_ context.Context, _ string, req *core.BatchRequest) (*core.BatchResponse, error) {
 	m.batchReq = req
+	if m.createBatchErr != nil {
+		return nil, m.createBatchErr
+	}
 	return &core.BatchResponse{ID: "batch_1", Object: "batch"}, nil
 }
 
@@ -108,6 +113,7 @@ func (m *providerMock) GetFile(_ context.Context, _ string, id string) (*core.Fi
 }
 
 func (m *providerMock) DeleteFile(_ context.Context, _ string, id string) (*core.FileDeleteResponse, error) {
+	m.fileDeletes = append(m.fileDeletes, id)
 	return &core.FileDeleteResponse{ID: id, Object: "file", Deleted: true}, nil
 }
 
@@ -332,5 +338,39 @@ func TestProviderBatchInputFileSkipsUploadWhenUnchanged(t *testing.T) {
 	}
 	if len(inner.fileCreates) != 0 {
 		t.Fatalf("len(fileCreates) = %d, want 0", len(inner.fileCreates))
+	}
+}
+
+func TestProviderDeletesRewrittenBatchInputFileOnCreateFailure(t *testing.T) {
+	catalog := newTestCatalog()
+	catalog.add("openai/gpt-4o", "openai", core.Model{ID: "gpt-4o", Object: "model"})
+
+	service, err := NewService(newMemoryStore(Alias{Name: "smart", TargetModel: "gpt-4o", TargetProvider: "openai", Enabled: true}), catalog)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	inner := newProviderMock()
+	inner.createBatchErr = context.Canceled
+	inner.fileContent = &core.FileContentResponse{
+		ID:       "file_source",
+		Filename: "batch.jsonl",
+		Data:     []byte("{\"custom_id\":\"1\",\"method\":\"POST\",\"url\":\"/v1/chat/completions\",\"body\":{\"model\":\"smart\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}}\n"),
+	}
+	inner.fileObject = &core.FileObject{ID: "file_rewritten", Object: "file", Filename: "batch.jsonl", Purpose: "batch"}
+	provider := NewProvider(inner, service)
+
+	_, err = provider.CreateBatch(context.Background(), "openai", &core.BatchRequest{
+		InputFileID: "file_source",
+		Endpoint:    "/v1/chat/completions",
+	})
+	if err == nil {
+		t.Fatal("CreateBatch() error = nil, want non-nil")
+	}
+	if len(inner.fileDeletes) != 1 || inner.fileDeletes[0] != "file_rewritten" {
+		t.Fatalf("fileDeletes = %v, want [file_rewritten]", inner.fileDeletes)
 	}
 }

--- a/internal/aliases/provider_test.go
+++ b/internal/aliases/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"strings"
 	"testing"
 
 	"gomodel/internal/core"
@@ -14,6 +15,9 @@ type providerMock struct {
 	responsesReq *core.ResponsesRequest
 	embeddingReq *core.EmbeddingRequest
 	batchReq     *core.BatchRequest
+	fileContent  *core.FileContentResponse
+	fileCreates  []*core.FileCreateRequest
+	fileObject   *core.FileObject
 	modelsResp   *core.ModelsResponse
 	supported    map[string]bool
 	providerType map[string]string
@@ -83,6 +87,35 @@ func (m *providerMock) CancelBatch(_ context.Context, _ string, _ string) (*core
 
 func (m *providerMock) GetBatchResults(_ context.Context, _ string, _ string) (*core.BatchResultsResponse, error) {
 	return &core.BatchResultsResponse{Object: "list", BatchID: "batch_1"}, nil
+}
+
+func (m *providerMock) CreateFile(_ context.Context, _ string, req *core.FileCreateRequest) (*core.FileObject, error) {
+	copy := *req
+	copy.Content = append([]byte(nil), req.Content...)
+	m.fileCreates = append(m.fileCreates, &copy)
+	if m.fileObject != nil {
+		return m.fileObject, nil
+	}
+	return &core.FileObject{ID: "file_rewritten", Object: "file", Filename: req.Filename, Purpose: req.Purpose}, nil
+}
+
+func (m *providerMock) ListFiles(_ context.Context, _ string, _ string, _ int, _ string) (*core.FileListResponse, error) {
+	return &core.FileListResponse{Object: "list"}, nil
+}
+
+func (m *providerMock) GetFile(_ context.Context, _ string, id string) (*core.FileObject, error) {
+	return &core.FileObject{ID: id, Object: "file"}, nil
+}
+
+func (m *providerMock) DeleteFile(_ context.Context, _ string, id string) (*core.FileDeleteResponse, error) {
+	return &core.FileDeleteResponse{ID: id, Object: "file", Deleted: true}, nil
+}
+
+func (m *providerMock) GetFileContent(_ context.Context, _ string, id string) (*core.FileContentResponse, error) {
+	if m.fileContent != nil {
+		return m.fileContent, nil
+	}
+	return &core.FileContentResponse{ID: id, Filename: "batch.jsonl", Data: []byte("{}\n")}, nil
 }
 
 func TestProviderResolvesRequestsAndExposesAliasModels(t *testing.T) {
@@ -219,5 +252,85 @@ func TestProviderRewritesBatchItemBodies(t *testing.T) {
 	}
 	if _, exists := rewritten["provider"]; exists {
 		t.Fatalf("rewritten batch item unexpectedly preserved provider hint: %s", inner.batchReq.Requests[0].Body)
+	}
+}
+
+func TestProviderRewritesBatchInputFiles(t *testing.T) {
+	catalog := newTestCatalog()
+	catalog.add("openai/gpt-4o", "openai", core.Model{ID: "gpt-4o", Object: "model"})
+
+	service, err := NewService(newMemoryStore(Alias{Name: "smart", TargetModel: "gpt-4o", TargetProvider: "openai", Enabled: true}), catalog)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	inner := newProviderMock()
+	inner.fileContent = &core.FileContentResponse{
+		ID:       "file_source",
+		Filename: "batch.jsonl",
+		Data:     []byte("{\"custom_id\":\"1\",\"method\":\"POST\",\"url\":\"/v1/chat/completions\",\"body\":{\"model\":\"smart\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}}\n"),
+	}
+	inner.fileObject = &core.FileObject{ID: "file_rewritten", Object: "file", Filename: "batch.jsonl", Purpose: "batch"}
+	provider := NewProvider(inner, service)
+
+	_, err = provider.CreateBatch(context.Background(), "openai", &core.BatchRequest{
+		InputFileID: "file_source",
+		Endpoint:    "/v1/chat/completions",
+	})
+	if err != nil {
+		t.Fatalf("CreateBatch() error = %v", err)
+	}
+	if inner.batchReq == nil {
+		t.Fatal("captured batch request = nil")
+	}
+	if inner.batchReq.InputFileID != "file_rewritten" {
+		t.Fatalf("rewritten input_file_id = %q, want file_rewritten", inner.batchReq.InputFileID)
+	}
+	if len(inner.fileCreates) != 1 {
+		t.Fatalf("len(fileCreates) = %d, want 1", len(inner.fileCreates))
+	}
+	if got := string(inner.fileCreates[0].Content); !strings.Contains(got, "\"model\":\"gpt-4o\"") {
+		t.Fatalf("rewritten file content = %s, want concrete model", got)
+	}
+}
+
+func TestProviderBatchInputFileSkipsUploadWhenUnchanged(t *testing.T) {
+	catalog := newTestCatalog()
+	catalog.add("openai/gpt-4o", "openai", core.Model{ID: "gpt-4o", Object: "model"})
+
+	service, err := NewService(newMemoryStore(Alias{Name: "smart", TargetModel: "gpt-4o", TargetProvider: "openai", Enabled: true}), catalog)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	inner := newProviderMock()
+	inner.fileContent = &core.FileContentResponse{
+		ID:       "file_source",
+		Filename: "batch.jsonl",
+		Data:     []byte("{\"custom_id\":\"1\",\"method\":\"POST\",\"url\":\"/v1/chat/completions\",\"body\":{\"model\":\"gpt-4o\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}}\n"),
+	}
+	provider := NewProvider(inner, service)
+
+	_, err = provider.CreateBatch(context.Background(), "openai", &core.BatchRequest{
+		InputFileID: "file_source",
+		Endpoint:    "/v1/chat/completions",
+	})
+	if err != nil {
+		t.Fatalf("CreateBatch() error = %v", err)
+	}
+	if inner.batchReq == nil {
+		t.Fatal("captured batch request = nil")
+	}
+	if inner.batchReq.InputFileID != "file_source" {
+		t.Fatalf("input_file_id = %q, want file_source", inner.batchReq.InputFileID)
+	}
+	if len(inner.fileCreates) != 0 {
+		t.Fatalf("len(fileCreates) = %d, want 0", len(inner.fileCreates))
 	}
 }

--- a/internal/aliases/provider_test.go
+++ b/internal/aliases/provider_test.go
@@ -185,9 +185,9 @@ func TestProviderMaskingAliasOverridesConcreteModelEntry(t *testing.T) {
 
 func TestProviderRewritesBatchItemBodies(t *testing.T) {
 	catalog := newTestCatalog()
-	catalog.add("gpt-4o", "openai", core.Model{ID: "gpt-4o", Object: "model"})
+	catalog.add("openai/gpt-4o", "openai", core.Model{ID: "gpt-4o", Object: "model"})
 
-	service, err := NewService(newMemoryStore(Alias{Name: "smart", TargetModel: "gpt-4o", Enabled: true}), catalog)
+	service, err := NewService(newMemoryStore(Alias{Name: "smart", TargetModel: "gpt-4o", TargetProvider: "openai", Enabled: true}), catalog)
 	if err != nil {
 		t.Fatalf("NewService() error = %v", err)
 	}
@@ -210,13 +210,14 @@ func TestProviderRewritesBatchItemBodies(t *testing.T) {
 		t.Fatalf("captured batch request = %#v, want one request", inner.batchReq)
 	}
 
-	var rewritten struct {
-		Model string `json:"model"`
-	}
+	var rewritten map[string]json.RawMessage
 	if err := json.Unmarshal(inner.batchReq.Requests[0].Body, &rewritten); err != nil {
 		t.Fatalf("unmarshal rewritten batch item: %v", err)
 	}
-	if rewritten.Model != "gpt-4o" {
-		t.Fatalf("rewritten batch model = %q, want gpt-4o", rewritten.Model)
+	if got := string(rewritten["model"]); got != `"gpt-4o"` {
+		t.Fatalf("rewritten batch model = %s, want gpt-4o", got)
+	}
+	if _, exists := rewritten["provider"]; exists {
+		t.Fatalf("rewritten batch item unexpectedly preserved provider hint: %s", inner.batchReq.Requests[0].Body)
 	}
 }

--- a/internal/aliases/provider_test.go
+++ b/internal/aliases/provider_test.go
@@ -1,0 +1,222 @@
+package aliases
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"gomodel/internal/core"
+)
+
+type providerMock struct {
+	chatReq      *core.ChatRequest
+	responsesReq *core.ResponsesRequest
+	embeddingReq *core.EmbeddingRequest
+	batchReq     *core.BatchRequest
+	modelsResp   *core.ModelsResponse
+	supported    map[string]bool
+	providerType map[string]string
+}
+
+func newProviderMock() *providerMock {
+	return &providerMock{
+		supported:    map[string]bool{},
+		providerType: map[string]string{},
+		modelsResp:   &core.ModelsResponse{Object: "list", Data: []core.Model{}},
+	}
+}
+
+func (m *providerMock) ChatCompletion(_ context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+	m.chatReq = req
+	return &core.ChatResponse{Model: req.Model}, nil
+}
+
+func (m *providerMock) StreamChatCompletion(_ context.Context, req *core.ChatRequest) (io.ReadCloser, error) {
+	m.chatReq = req
+	return io.NopCloser(nil), nil
+}
+
+func (m *providerMock) ListModels(_ context.Context) (*core.ModelsResponse, error) {
+	return m.modelsResp, nil
+}
+
+func (m *providerMock) Responses(_ context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
+	m.responsesReq = req
+	return &core.ResponsesResponse{Model: req.Model}, nil
+}
+
+func (m *providerMock) StreamResponses(_ context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
+	m.responsesReq = req
+	return io.NopCloser(nil), nil
+}
+
+func (m *providerMock) Embeddings(_ context.Context, req *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	m.embeddingReq = req
+	return &core.EmbeddingResponse{Model: req.Model}, nil
+}
+
+func (m *providerMock) Supports(model string) bool {
+	return m.supported[model]
+}
+
+func (m *providerMock) GetProviderType(model string) string {
+	return m.providerType[model]
+}
+
+func (m *providerMock) CreateBatch(_ context.Context, _ string, req *core.BatchRequest) (*core.BatchResponse, error) {
+	m.batchReq = req
+	return &core.BatchResponse{ID: "batch_1", Object: "batch"}, nil
+}
+
+func (m *providerMock) GetBatch(_ context.Context, _ string, _ string) (*core.BatchResponse, error) {
+	return &core.BatchResponse{ID: "batch_1", Object: "batch"}, nil
+}
+
+func (m *providerMock) ListBatches(_ context.Context, _ string, _ int, _ string) (*core.BatchListResponse, error) {
+	return &core.BatchListResponse{Object: "list"}, nil
+}
+
+func (m *providerMock) CancelBatch(_ context.Context, _ string, _ string) (*core.BatchResponse, error) {
+	return &core.BatchResponse{ID: "batch_1", Object: "batch", Status: "cancelled"}, nil
+}
+
+func (m *providerMock) GetBatchResults(_ context.Context, _ string, _ string) (*core.BatchResultsResponse, error) {
+	return &core.BatchResultsResponse{Object: "list", BatchID: "batch_1"}, nil
+}
+
+func TestProviderResolvesRequestsAndExposesAliasModels(t *testing.T) {
+	catalog := newTestCatalog()
+	catalog.add("gpt-4o", "openai", core.Model{ID: "gpt-4o", Object: "model", OwnedBy: "openai"})
+
+	service, err := NewService(newMemoryStore(Alias{Name: "smart", TargetModel: "gpt-4o", Enabled: true}), catalog)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	inner := newProviderMock()
+	inner.supported["gpt-4o"] = true
+	inner.providerType["gpt-4o"] = "openai"
+	inner.modelsResp = &core.ModelsResponse{Object: "list", Data: []core.Model{{ID: "gpt-4o", Object: "model"}}}
+
+	provider := NewProvider(inner, service)
+
+	if _, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{Model: "smart"}); err != nil {
+		t.Fatalf("ChatCompletion() error = %v", err)
+	}
+	if inner.chatReq == nil || inner.chatReq.Model != "gpt-4o" {
+		t.Fatalf("inner.chatReq = %#v, want rewritten model gpt-4o", inner.chatReq)
+	}
+	if !provider.Supports("smart") {
+		t.Fatal("Supports(smart) = false, want true")
+	}
+	if got := provider.GetProviderType("smart"); got != "openai" {
+		t.Fatalf("GetProviderType(smart) = %q, want openai", got)
+	}
+	selector, changed, err := provider.ResolveModel("smart", "")
+	if err != nil {
+		t.Fatalf("ResolveModel() error = %v", err)
+	}
+	if !changed || selector.QualifiedModel() != "gpt-4o" {
+		t.Fatalf("ResolveModel() = (%q, %v), want gpt-4o,true", selector.QualifiedModel(), changed)
+	}
+
+	models, err := provider.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels() error = %v", err)
+	}
+	if len(models.Data) != 2 {
+		t.Fatalf("len(ListModels().Data) = %d, want 2", len(models.Data))
+	}
+	if models.Data[0].ID != "gpt-4o" || models.Data[1].ID != "smart" {
+		t.Fatalf("ListModels().Data = %#v, want concrete model plus alias", models.Data)
+	}
+}
+
+func TestProviderMaskingAliasOverridesConcreteModelEntry(t *testing.T) {
+	catalog := newTestCatalog()
+	catalog.add("gpt-4o", "openai", core.Model{ID: "gpt-4o", Object: "model", OwnedBy: "openai"})
+	catalog.add("gpt-4o-mini", "openai", core.Model{ID: "gpt-4o-mini", Object: "model", OwnedBy: "openai", Metadata: &core.ModelMetadata{DisplayName: "GPT-4o mini"}})
+
+	service, err := NewService(newMemoryStore(Alias{Name: "gpt-4o", TargetModel: "gpt-4o-mini", Enabled: true}), catalog)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	inner := newProviderMock()
+	inner.supported["gpt-4o"] = true
+	inner.supported["gpt-4o-mini"] = true
+	inner.providerType["gpt-4o"] = "openai"
+	inner.providerType["gpt-4o-mini"] = "openai"
+	inner.modelsResp = &core.ModelsResponse{Object: "list", Data: []core.Model{
+		{ID: "gpt-4o", Object: "model", Metadata: &core.ModelMetadata{DisplayName: "GPT-4o"}},
+		{ID: "gpt-4o-mini", Object: "model", Metadata: &core.ModelMetadata{DisplayName: "GPT-4o mini"}},
+	}}
+
+	provider := NewProvider(inner, service)
+
+	if _, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{Model: "gpt-4o"}); err != nil {
+		t.Fatalf("ChatCompletion() error = %v", err)
+	}
+	if inner.chatReq == nil || inner.chatReq.Model != "gpt-4o-mini" {
+		t.Fatalf("masked chat request = %#v, want rewritten model gpt-4o-mini", inner.chatReq)
+	}
+
+	models, err := provider.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels() error = %v", err)
+	}
+	if len(models.Data) != 2 {
+		t.Fatalf("len(ListModels().Data) = %d, want 2", len(models.Data))
+	}
+	if models.Data[0].ID != "gpt-4o" {
+		t.Fatalf("first model id = %q, want gpt-4o", models.Data[0].ID)
+	}
+	if models.Data[0].Metadata == nil || models.Data[0].Metadata.DisplayName != "GPT-4o mini" {
+		t.Fatalf("masked model metadata = %#v, want alias target metadata", models.Data[0].Metadata)
+	}
+}
+
+func TestProviderRewritesBatchItemBodies(t *testing.T) {
+	catalog := newTestCatalog()
+	catalog.add("gpt-4o", "openai", core.Model{ID: "gpt-4o", Object: "model"})
+
+	service, err := NewService(newMemoryStore(Alias{Name: "smart", TargetModel: "gpt-4o", Enabled: true}), catalog)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	inner := newProviderMock()
+	provider := NewProvider(inner, service)
+
+	body := json.RawMessage(`{"model":"smart","messages":[{"role":"user","content":"hi"}]}`)
+	_, err = provider.CreateBatch(context.Background(), "openai", &core.BatchRequest{
+		Endpoint: "/v1/chat/completions",
+		Requests: []core.BatchRequestItem{{CustomID: "1", Body: body}},
+	})
+	if err != nil {
+		t.Fatalf("CreateBatch() error = %v", err)
+	}
+	if inner.batchReq == nil || len(inner.batchReq.Requests) != 1 {
+		t.Fatalf("captured batch request = %#v, want one request", inner.batchReq)
+	}
+
+	var rewritten struct {
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal(inner.batchReq.Requests[0].Body, &rewritten); err != nil {
+		t.Fatalf("unmarshal rewritten batch item: %v", err)
+	}
+	if rewritten.Model != "gpt-4o" {
+		t.Fatalf("rewritten batch model = %q, want gpt-4o", rewritten.Model)
+	}
+}

--- a/internal/aliases/service.go
+++ b/internal/aliases/service.go
@@ -124,26 +124,22 @@ func (s *Service) ResolveSelector(selector core.ModelSelector) (Resolution, bool
 		return resolution, false
 	}
 
-	alias, ok := s.Get(selector.Model)
-	if !ok || !alias.Enabled {
+	aliasResolution, ok := s.resolveAlias(selector.QualifiedModel())
+	if !ok {
 		return resolution, false
 	}
-
-	target, err := alias.TargetSelector()
-	if err != nil {
-		return resolution, false
-	}
-	if !s.catalog.Supports(target.QualifiedModel()) {
-		return resolution, false
-	}
-
-	resolution.Resolved = target
-	resolution.Alias = alias
-	return resolution, true
+	aliasResolution.Requested = selector
+	return aliasResolution, true
 }
 
 // Resolve resolves raw model/provider inputs through the alias table.
 func (s *Service) Resolve(model, provider string) (Resolution, bool, error) {
+	if strings.TrimSpace(provider) == "" {
+		if resolution, ok := s.resolveAlias(model); ok {
+			return resolution, true, nil
+		}
+	}
+
 	selector, err := core.ParseModelSelector(model, provider)
 	if err != nil {
 		return Resolution{}, false, err
@@ -154,6 +150,10 @@ func (s *Service) Resolve(model, provider string) (Resolution, bool, error) {
 
 // Supports reports whether an alias currently resolves to a concrete model.
 func (s *Service) Supports(model string) bool {
+	if _, ok := s.resolveAlias(model); ok {
+		return true
+	}
+
 	selector, err := core.ParseModelSelector(model, "")
 	if err != nil {
 		return false
@@ -164,6 +164,10 @@ func (s *Service) Supports(model string) bool {
 
 // GetProviderType returns the resolved provider type for an alias, or empty if unresolved.
 func (s *Service) GetProviderType(model string) string {
+	if resolution, ok := s.resolveAlias(model); ok {
+		return strings.TrimSpace(s.catalog.GetProviderType(resolution.Resolved.QualifiedModel()))
+	}
+
 	selector, err := core.ParseModelSelector(model, "")
 	if err != nil {
 		return ""
@@ -237,21 +241,47 @@ func (s *Service) validate(alias Alias) error {
 	if err != nil {
 		return newValidationError("invalid target selector: "+err.Error(), err)
 	}
-	if alias.Name == target.Model && target.Provider == "" {
+	if alias.Name == target.QualifiedModel() {
 		return newValidationError(fmt.Sprintf("alias %q cannot target itself", alias.Name), nil)
 	}
 
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	if target.Provider == "" {
-		if existing, ok := s.snapshot.aliases[target.Model]; ok && existing.Name != alias.Name {
-			return newValidationError(fmt.Sprintf("alias target %q refers to another alias", target.Model), nil)
-		}
+	if existing, ok := s.snapshot.aliases[target.QualifiedModel()]; ok && existing.Name != alias.Name {
+		return newValidationError(fmt.Sprintf("alias target %q refers to another alias", target.QualifiedModel()), nil)
 	}
 	if !s.catalog.Supports(target.QualifiedModel()) {
 		return newValidationError("target model not found: "+target.QualifiedModel(), nil)
 	}
 	return nil
+}
+
+func (s *Service) resolveAlias(name string) (Resolution, bool) {
+	name = normalizeName(name)
+	resolution := Resolution{
+		Requested: core.ModelSelector{Model: name},
+		Resolved:  core.ModelSelector{Model: name},
+	}
+	if name == "" {
+		return resolution, false
+	}
+
+	alias, ok := s.Get(name)
+	if !ok || !alias.Enabled {
+		return resolution, false
+	}
+
+	target, err := alias.TargetSelector()
+	if err != nil {
+		return resolution, false
+	}
+	if !s.catalog.Supports(target.QualifiedModel()) {
+		return resolution, false
+	}
+
+	resolution.Resolved = target
+	resolution.Alias = alias
+	return resolution, true
 }
 
 // StartBackgroundRefresh periodically reloads aliases from storage until stopped.

--- a/internal/aliases/service.go
+++ b/internal/aliases/service.go
@@ -221,7 +221,7 @@ func (s *Service) Upsert(ctx context.Context, alias Alias) error {
 func (s *Service) Delete(ctx context.Context, name string) error {
 	name = normalizeName(name)
 	if name == "" {
-		return fmt.Errorf("alias name is required")
+		return newValidationError("alias name is required", nil)
 	}
 	if err := s.store.Delete(ctx, name); err != nil {
 		return fmt.Errorf("delete alias: %w", err)
@@ -235,21 +235,21 @@ func (s *Service) Delete(ctx context.Context, name string) error {
 func (s *Service) validate(alias Alias) error {
 	target, err := alias.TargetSelector()
 	if err != nil {
-		return fmt.Errorf("invalid target selector: %w", err)
+		return newValidationError("invalid target selector: "+err.Error(), err)
 	}
 	if alias.Name == target.Model && target.Provider == "" {
-		return fmt.Errorf("alias %q cannot target itself", alias.Name)
+		return newValidationError(fmt.Sprintf("alias %q cannot target itself", alias.Name), nil)
 	}
 
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if target.Provider == "" {
 		if existing, ok := s.snapshot.aliases[target.Model]; ok && existing.Name != alias.Name {
-			return fmt.Errorf("alias target %q refers to another alias", target.Model)
+			return newValidationError(fmt.Sprintf("alias target %q refers to another alias", target.Model), nil)
 		}
 	}
 	if !s.catalog.Supports(target.QualifiedModel()) {
-		return fmt.Errorf("target model not found: %s", target.QualifiedModel())
+		return newValidationError("target model not found: "+target.QualifiedModel(), nil)
 	}
 	return nil
 }

--- a/internal/aliases/service.go
+++ b/internal/aliases/service.go
@@ -1,0 +1,289 @@
+package aliases
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"gomodel/internal/core"
+)
+
+// Catalog exposes the concrete model catalog used to validate alias targets.
+type Catalog interface {
+	Supports(model string) bool
+	GetProviderType(model string) string
+	LookupModel(model string) (*core.Model, bool)
+}
+
+type snapshot struct {
+	aliases map[string]Alias
+	order   []string
+}
+
+// Service keeps aliases cached in memory and refreshes them from storage.
+type Service struct {
+	store   Store
+	catalog Catalog
+
+	mu       sync.RWMutex
+	snapshot snapshot
+}
+
+// NewService creates an alias service backed by the provided store and catalog.
+func NewService(store Store, catalog Catalog) (*Service, error) {
+	if store == nil {
+		return nil, fmt.Errorf("store is required")
+	}
+	if catalog == nil {
+		return nil, fmt.Errorf("catalog is required")
+	}
+	return &Service{store: store, catalog: catalog}, nil
+}
+
+// Refresh reloads aliases from storage and atomically swaps the in-memory snapshot.
+func (s *Service) Refresh(ctx context.Context) error {
+	aliases, err := s.store.List(ctx)
+	if err != nil {
+		return fmt.Errorf("list aliases: %w", err)
+	}
+
+	next := snapshot{
+		aliases: make(map[string]Alias, len(aliases)),
+		order:   make([]string, 0, len(aliases)),
+	}
+	for _, alias := range aliases {
+		normalized, err := normalizeAlias(alias)
+		if err != nil {
+			return fmt.Errorf("load alias %q: %w", alias.Name, err)
+		}
+		next.aliases[normalized.Name] = normalized
+		next.order = append(next.order, normalized.Name)
+	}
+	sort.Strings(next.order)
+
+	s.mu.Lock()
+	s.snapshot = next
+	s.mu.Unlock()
+	return nil
+}
+
+// List returns all cached aliases sorted by name.
+func (s *Service) List() []Alias {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	result := make([]Alias, 0, len(s.snapshot.order))
+	for _, name := range s.snapshot.order {
+		result = append(result, s.snapshot.aliases[name])
+	}
+	return result
+}
+
+// ListViews returns aliases with current validity derived from the concrete model catalog.
+func (s *Service) ListViews() []View {
+	aliases := s.List()
+	views := make([]View, 0, len(aliases))
+	for _, alias := range aliases {
+		view := View{Alias: alias}
+		selector, err := alias.TargetSelector()
+		if err == nil {
+			view.ResolvedModel = selector.QualifiedModel()
+			view.ProviderType = strings.TrimSpace(s.catalog.GetProviderType(view.ResolvedModel))
+			view.Valid = s.catalog.Supports(view.ResolvedModel)
+		}
+		views = append(views, view)
+	}
+	return views
+}
+
+// Get returns one cached alias by name.
+func (s *Service) Get(name string) (*Alias, bool) {
+	name = normalizeName(name)
+	if name == "" {
+		return nil, false
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	alias, ok := s.snapshot.aliases[name]
+	if !ok {
+		return nil, false
+	}
+	copy := alias
+	return &copy, true
+}
+
+// ResolveSelector resolves a selector through the alias table.
+// Explicit provider selection bypasses aliases.
+func (s *Service) ResolveSelector(selector core.ModelSelector) (Resolution, bool) {
+	resolution := Resolution{Requested: selector, Resolved: selector}
+	if strings.TrimSpace(selector.Provider) != "" {
+		return resolution, false
+	}
+
+	alias, ok := s.Get(selector.Model)
+	if !ok || !alias.Enabled {
+		return resolution, false
+	}
+
+	target, err := alias.TargetSelector()
+	if err != nil {
+		return resolution, false
+	}
+	if !s.catalog.Supports(target.QualifiedModel()) {
+		return resolution, false
+	}
+
+	resolution.Resolved = target
+	resolution.Alias = alias
+	return resolution, true
+}
+
+// Resolve resolves raw model/provider inputs through the alias table.
+func (s *Service) Resolve(model, provider string) (Resolution, bool, error) {
+	selector, err := core.ParseModelSelector(model, provider)
+	if err != nil {
+		return Resolution{}, false, err
+	}
+	resolution, ok := s.ResolveSelector(selector)
+	return resolution, ok, nil
+}
+
+// Supports reports whether an alias currently resolves to a concrete model.
+func (s *Service) Supports(model string) bool {
+	selector, err := core.ParseModelSelector(model, "")
+	if err != nil {
+		return false
+	}
+	_, ok := s.ResolveSelector(selector)
+	return ok
+}
+
+// GetProviderType returns the resolved provider type for an alias, or empty if unresolved.
+func (s *Service) GetProviderType(model string) string {
+	selector, err := core.ParseModelSelector(model, "")
+	if err != nil {
+		return ""
+	}
+	resolution, ok := s.ResolveSelector(selector)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(s.catalog.GetProviderType(resolution.Resolved.QualifiedModel()))
+}
+
+// ExposedModels returns enabled aliases projected as model-list entries.
+func (s *Service) ExposedModels() []core.Model {
+	aliases := s.List()
+	result := make([]core.Model, 0, len(aliases))
+	for _, alias := range aliases {
+		if !alias.Enabled {
+			continue
+		}
+		selector, err := alias.TargetSelector()
+		if err != nil {
+			continue
+		}
+		model, ok := s.catalog.LookupModel(selector.QualifiedModel())
+		if !ok || model == nil {
+			continue
+		}
+		cloned := *model
+		cloned.ID = alias.Name
+		result = append(result, cloned)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].ID < result[j].ID })
+	return result
+}
+
+// Upsert validates and stores an alias, then refreshes the in-memory snapshot.
+func (s *Service) Upsert(ctx context.Context, alias Alias) error {
+	normalized, err := normalizeAlias(alias)
+	if err != nil {
+		return err
+	}
+	if err := s.validate(normalized); err != nil {
+		return err
+	}
+	if err := s.store.Upsert(ctx, normalized); err != nil {
+		return fmt.Errorf("upsert alias: %w", err)
+	}
+	if err := s.Refresh(ctx); err != nil {
+		return fmt.Errorf("refresh aliases: %w", err)
+	}
+	return nil
+}
+
+// Delete removes an alias from storage and refreshes the in-memory snapshot.
+func (s *Service) Delete(ctx context.Context, name string) error {
+	name = normalizeName(name)
+	if name == "" {
+		return fmt.Errorf("alias name is required")
+	}
+	if err := s.store.Delete(ctx, name); err != nil {
+		return fmt.Errorf("delete alias: %w", err)
+	}
+	if err := s.Refresh(ctx); err != nil {
+		return fmt.Errorf("refresh aliases: %w", err)
+	}
+	return nil
+}
+
+func (s *Service) validate(alias Alias) error {
+	target, err := alias.TargetSelector()
+	if err != nil {
+		return fmt.Errorf("invalid target selector: %w", err)
+	}
+	if alias.Name == target.Model && target.Provider == "" {
+		return fmt.Errorf("alias %q cannot target itself", alias.Name)
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if target.Provider == "" {
+		if existing, ok := s.snapshot.aliases[target.Model]; ok && existing.Name != alias.Name {
+			return fmt.Errorf("alias target %q refers to another alias", target.Model)
+		}
+	}
+	if !s.catalog.Supports(target.QualifiedModel()) {
+		return fmt.Errorf("target model not found: %s", target.QualifiedModel())
+	}
+	return nil
+}
+
+// StartBackgroundRefresh periodically reloads aliases from storage until stopped.
+func (s *Service) StartBackgroundRefresh(interval time.Duration) func() {
+	if interval <= 0 {
+		interval = time.Hour
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	var once sync.Once
+
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				refreshCtx, refreshCancel := context.WithTimeout(ctx, 30*time.Second)
+				_ = s.Refresh(refreshCtx)
+				refreshCancel()
+			}
+		}
+	}()
+
+	return func() {
+		once.Do(func() {
+			cancel()
+			<-done
+		})
+	}
+}

--- a/internal/aliases/service_test.go
+++ b/internal/aliases/service_test.go
@@ -162,3 +162,60 @@ func TestServiceUpsertRejectsAliasChainAndAllowsMasking(t *testing.T) {
 		t.Fatalf("masked model resolved to %q, want gpt-4o-mini", got)
 	}
 }
+
+func TestServiceSupportsQualifiedAliasNames(t *testing.T) {
+	catalog := newTestCatalog()
+	catalog.add("gpt-4o", "openai", core.Model{ID: "gpt-4o", Object: "model"})
+
+	service, err := NewService(newMemoryStore(Alias{Name: "openai/smart", TargetModel: "gpt-4o", Enabled: true}), catalog)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	resolution, ok, err := service.Resolve("openai/smart", "")
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("Resolve() ok = false, want true")
+	}
+	if resolution.Alias == nil || resolution.Alias.Name != "openai/smart" {
+		t.Fatalf("resolved alias = %#v, want openai/smart", resolution.Alias)
+	}
+	if got := resolution.Resolved.QualifiedModel(); got != "gpt-4o" {
+		t.Fatalf("resolved selector = %q, want gpt-4o", got)
+	}
+	if !service.Supports("openai/smart") {
+		t.Fatal("Supports(openai/smart) = false, want true")
+	}
+	if got := service.GetProviderType("openai/smart"); got != "openai" {
+		t.Fatalf("GetProviderType(openai/smart) = %q, want openai", got)
+	}
+}
+
+func TestServiceUpsertRejectsQualifiedAliasChainsAndSelfTargets(t *testing.T) {
+	catalog := newTestCatalog()
+	catalog.add("gpt-4o", "openai", core.Model{ID: "gpt-4o", Object: "model"})
+	catalog.add("gpt-4o-mini", "openai", core.Model{ID: "gpt-4o-mini", Object: "model"})
+
+	service, err := NewService(newMemoryStore(Alias{Name: "openai/front", TargetModel: "gpt-4o", Enabled: true}), catalog)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	err = service.Upsert(context.Background(), Alias{Name: "qualified-second", TargetModel: "front", TargetProvider: "openai", Enabled: true})
+	if err == nil || !strings.Contains(err.Error(), "refers to another alias") {
+		t.Fatalf("Upsert(qualified alias chain) error = %v, want alias-chain validation error", err)
+	}
+
+	err = service.Upsert(context.Background(), Alias{Name: "openai/self", TargetModel: "self", TargetProvider: "openai", Enabled: true})
+	if err == nil || !strings.Contains(err.Error(), "cannot target itself") {
+		t.Fatalf("Upsert(qualified self target) error = %v, want self-target validation error", err)
+	}
+}

--- a/internal/aliases/service_test.go
+++ b/internal/aliases/service_test.go
@@ -1,0 +1,164 @@
+package aliases
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"gomodel/internal/core"
+)
+
+type memoryStore struct {
+	items map[string]Alias
+}
+
+func newMemoryStore(items ...Alias) *memoryStore {
+	store := &memoryStore{items: make(map[string]Alias, len(items))}
+	for _, item := range items {
+		store.items[item.Name] = item
+	}
+	return store
+}
+
+func (s *memoryStore) List(_ context.Context) ([]Alias, error) {
+	result := make([]Alias, 0, len(s.items))
+	for _, item := range s.items {
+		result = append(result, item)
+	}
+	return result, nil
+}
+
+func (s *memoryStore) Get(_ context.Context, name string) (*Alias, error) {
+	item, ok := s.items[name]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	copy := item
+	return &copy, nil
+}
+
+func (s *memoryStore) Upsert(_ context.Context, alias Alias) error {
+	s.items[alias.Name] = alias
+	return nil
+}
+
+func (s *memoryStore) Delete(_ context.Context, name string) error {
+	if _, ok := s.items[name]; !ok {
+		return ErrNotFound
+	}
+	delete(s.items, name)
+	return nil
+}
+
+func (s *memoryStore) Close() error { return nil }
+
+type testCatalog struct {
+	providerTypes map[string]string
+	models        map[string]core.Model
+}
+
+func newTestCatalog() *testCatalog {
+	return &testCatalog{
+		providerTypes: map[string]string{},
+		models:        map[string]core.Model{},
+	}
+}
+
+func (c *testCatalog) add(model string, providerType string, value core.Model) {
+	c.providerTypes[model] = providerType
+	c.models[model] = value
+}
+
+func (c *testCatalog) Supports(model string) bool {
+	_, ok := c.models[model]
+	return ok
+}
+
+func (c *testCatalog) GetProviderType(model string) string {
+	return c.providerTypes[model]
+}
+
+func (c *testCatalog) LookupModel(model string) (*core.Model, bool) {
+	value, ok := c.models[model]
+	if !ok {
+		return nil, false
+	}
+	copy := value
+	return &copy, true
+}
+
+func TestServiceResolveAndExposeModels(t *testing.T) {
+	catalog := newTestCatalog()
+	catalog.add("gpt-4o", "openai", core.Model{ID: "gpt-4o", Object: "model", OwnedBy: "openai", Metadata: &core.ModelMetadata{DisplayName: "GPT-4o"}})
+
+	service, err := NewService(newMemoryStore(Alias{Name: "smart", TargetModel: "gpt-4o", Enabled: true}), catalog)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	resolution, ok, err := service.Resolve("smart", "")
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("Resolve() ok = false, want true")
+	}
+	if got := resolution.Resolved.QualifiedModel(); got != "gpt-4o" {
+		t.Fatalf("resolved selector = %q, want gpt-4o", got)
+	}
+	if !service.Supports("smart") {
+		t.Fatal("Supports(smart) = false, want true")
+	}
+	if got := service.GetProviderType("smart"); got != "openai" {
+		t.Fatalf("GetProviderType(smart) = %q, want openai", got)
+	}
+
+	models := service.ExposedModels()
+	if len(models) != 1 {
+		t.Fatalf("len(ExposedModels()) = %d, want 1", len(models))
+	}
+	if models[0].ID != "smart" {
+		t.Fatalf("alias model id = %q, want smart", models[0].ID)
+	}
+	if models[0].Metadata == nil || models[0].Metadata.DisplayName != "GPT-4o" {
+		t.Fatalf("alias metadata = %#v, want copied target metadata", models[0].Metadata)
+	}
+}
+
+func TestServiceUpsertRejectsAliasChainAndAllowsMasking(t *testing.T) {
+	catalog := newTestCatalog()
+	catalog.add("gpt-4o", "openai", core.Model{ID: "gpt-4o", Object: "model"})
+	catalog.add("gpt-4o-mini", "openai", core.Model{ID: "gpt-4o-mini", Object: "model"})
+
+	service, err := NewService(newMemoryStore(Alias{Name: "front", TargetModel: "gpt-4o", Enabled: true}), catalog)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	err = service.Upsert(context.Background(), Alias{Name: "second", TargetModel: "front", Enabled: true})
+	if err == nil || !strings.Contains(err.Error(), "refers to another alias") {
+		t.Fatalf("Upsert(alias chain) error = %v, want alias-chain validation error", err)
+	}
+
+	err = service.Upsert(context.Background(), Alias{Name: "gpt-4o", TargetModel: "gpt-4o-mini", Enabled: true})
+	if err != nil {
+		t.Fatalf("Upsert(masking alias) error = %v, want nil", err)
+	}
+
+	resolution, ok, err := service.Resolve("gpt-4o", "")
+	if err != nil {
+		t.Fatalf("Resolve(masked model) error = %v", err)
+	}
+	if !ok {
+		t.Fatal("Resolve(masked model) ok = false, want true")
+	}
+	if got := resolution.Resolved.QualifiedModel(); got != "gpt-4o-mini" {
+		t.Fatalf("masked model resolved to %q, want gpt-4o-mini", got)
+	}
+}

--- a/internal/aliases/store.go
+++ b/internal/aliases/store.go
@@ -10,6 +10,36 @@ import (
 // ErrNotFound indicates a requested alias was not found.
 var ErrNotFound = errors.New("alias not found")
 
+// ValidationError indicates invalid alias input or invalid alias state.
+type ValidationError struct {
+	Message string
+	Err     error
+}
+
+func (e *ValidationError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Message
+}
+
+func (e *ValidationError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func newValidationError(message string, err error) error {
+	return &ValidationError{Message: message, Err: err}
+}
+
+// IsValidationError reports whether err is a validation error.
+func IsValidationError(err error) bool {
+	var validationErr *ValidationError
+	return errors.As(err, &validationErr)
+}
+
 // Store defines persistence operations for aliases.
 type Store interface {
 	List(ctx context.Context) ([]Alias, error)
@@ -40,16 +70,16 @@ func normalizeAlias(alias Alias) (Alias, error) {
 	alias.Description = strings.TrimSpace(alias.Description)
 
 	if alias.Name == "" {
-		return Alias{}, fmt.Errorf("alias name is required")
+		return Alias{}, newValidationError("alias name is required", nil)
 	}
 	if strings.Contains(alias.Name, "/") {
-		return Alias{}, fmt.Errorf("alias name %q must be unqualified", alias.Name)
+		return Alias{}, newValidationError(fmt.Sprintf("alias name %q must be unqualified", alias.Name), nil)
 	}
 	if alias.TargetModel == "" {
-		return Alias{}, fmt.Errorf("target_model is required")
+		return Alias{}, newValidationError("target_model is required", nil)
 	}
 	if _, err := alias.TargetSelector(); err != nil {
-		return Alias{}, fmt.Errorf("invalid target selector: %w", err)
+		return Alias{}, newValidationError("invalid target selector: "+err.Error(), err)
 	}
 	return alias, nil
 }

--- a/internal/aliases/store.go
+++ b/internal/aliases/store.go
@@ -3,7 +3,6 @@ package aliases
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 )
 
@@ -71,9 +70,6 @@ func normalizeAlias(alias Alias) (Alias, error) {
 
 	if alias.Name == "" {
 		return Alias{}, newValidationError("alias name is required", nil)
-	}
-	if strings.Contains(alias.Name, "/") {
-		return Alias{}, newValidationError(fmt.Sprintf("alias name %q must be unqualified", alias.Name), nil)
 	}
 	if alias.TargetModel == "" {
 		return Alias{}, newValidationError("target_model is required", nil)

--- a/internal/aliases/store.go
+++ b/internal/aliases/store.go
@@ -1,0 +1,70 @@
+package aliases
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrNotFound indicates a requested alias was not found.
+var ErrNotFound = errors.New("alias not found")
+
+// Store defines persistence operations for aliases.
+type Store interface {
+	List(ctx context.Context) ([]Alias, error)
+	Get(ctx context.Context, name string) (*Alias, error)
+	Upsert(ctx context.Context, alias Alias) error
+	Delete(ctx context.Context, name string) error
+	Close() error
+}
+
+type aliasScanner interface {
+	Scan(dest ...any) error
+}
+
+type aliasRows interface {
+	aliasScanner
+	Next() bool
+	Err() error
+}
+
+func normalizeName(name string) string {
+	return strings.TrimSpace(name)
+}
+
+func normalizeAlias(alias Alias) (Alias, error) {
+	alias.Name = normalizeName(alias.Name)
+	alias.TargetModel = strings.TrimSpace(alias.TargetModel)
+	alias.TargetProvider = strings.TrimSpace(alias.TargetProvider)
+	alias.Description = strings.TrimSpace(alias.Description)
+
+	if alias.Name == "" {
+		return Alias{}, fmt.Errorf("alias name is required")
+	}
+	if strings.Contains(alias.Name, "/") {
+		return Alias{}, fmt.Errorf("alias name %q must be unqualified", alias.Name)
+	}
+	if alias.TargetModel == "" {
+		return Alias{}, fmt.Errorf("target_model is required")
+	}
+	if _, err := alias.TargetSelector(); err != nil {
+		return Alias{}, fmt.Errorf("invalid target selector: %w", err)
+	}
+	return alias, nil
+}
+
+func collectAliases(rows aliasRows, scan func(aliasScanner) (Alias, error)) ([]Alias, error) {
+	result := make([]Alias, 0)
+	for rows.Next() {
+		alias, err := scan(rows)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, alias)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/internal/aliases/store_mongodb.go
+++ b/internal/aliases/store_mongodb.go
@@ -21,6 +21,10 @@ type mongoAliasDocument struct {
 	UpdatedAt      time.Time `bson:"updated_at"`
 }
 
+type mongoAliasIDFilter struct {
+	ID string `bson:"_id"`
+}
+
 // MongoDBStore stores aliases in MongoDB.
 type MongoDBStore struct {
 	collection *mongo.Collection
@@ -68,7 +72,7 @@ func (s *MongoDBStore) List(ctx context.Context) ([]Alias, error) {
 
 func (s *MongoDBStore) Get(ctx context.Context, name string) (*Alias, error) {
 	var doc mongoAliasDocument
-	err := s.collection.FindOne(ctx, bson.M{"_id": normalizeName(name)}).Decode(&doc)
+	err := s.collection.FindOne(ctx, mongoAliasIDFilter{ID: normalizeName(name)}).Decode(&doc)
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
 			return nil, ErrNotFound
@@ -102,7 +106,7 @@ func (s *MongoDBStore) Upsert(ctx context.Context, alias Alias) error {
 			"created_at": alias.CreatedAt,
 		},
 	}
-	_, err = s.collection.UpdateOne(ctx, bson.M{"_id": alias.Name}, update, options.UpdateOne().SetUpsert(true))
+	_, err = s.collection.UpdateOne(ctx, mongoAliasIDFilter{ID: alias.Name}, update, options.UpdateOne().SetUpsert(true))
 	if err != nil {
 		return fmt.Errorf("upsert alias: %w", err)
 	}
@@ -110,7 +114,7 @@ func (s *MongoDBStore) Upsert(ctx context.Context, alias Alias) error {
 }
 
 func (s *MongoDBStore) Delete(ctx context.Context, name string) error {
-	result, err := s.collection.DeleteOne(ctx, bson.M{"_id": normalizeName(name)})
+	result, err := s.collection.DeleteOne(ctx, mongoAliasIDFilter{ID: normalizeName(name)})
 	if err != nil {
 		return fmt.Errorf("delete alias: %w", err)
 	}

--- a/internal/aliases/store_mongodb.go
+++ b/internal/aliases/store_mongodb.go
@@ -1,0 +1,137 @@
+package aliases
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+type mongoAliasDocument struct {
+	Name           string    `bson:"_id"`
+	TargetModel    string    `bson:"target_model"`
+	TargetProvider string    `bson:"target_provider,omitempty"`
+	Description    string    `bson:"description,omitempty"`
+	Enabled        bool      `bson:"enabled"`
+	CreatedAt      time.Time `bson:"created_at"`
+	UpdatedAt      time.Time `bson:"updated_at"`
+}
+
+// MongoDBStore stores aliases in MongoDB.
+type MongoDBStore struct {
+	collection *mongo.Collection
+}
+
+// NewMongoDBStore creates collection indexes if needed.
+func NewMongoDBStore(database *mongo.Database) (*MongoDBStore, error) {
+	if database == nil {
+		return nil, fmt.Errorf("database is required")
+	}
+	coll := database.Collection("aliases")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	indexes := []mongo.IndexModel{
+		{Keys: bson.D{{Key: "enabled", Value: 1}}},
+		{Keys: bson.D{{Key: "updated_at", Value: -1}}},
+	}
+	if _, err := coll.Indexes().CreateMany(ctx, indexes); err != nil {
+		return nil, fmt.Errorf("create aliases indexes: %w", err)
+	}
+	return &MongoDBStore{collection: coll}, nil
+}
+
+func (s *MongoDBStore) List(ctx context.Context) ([]Alias, error) {
+	cursor, err := s.collection.Find(ctx, bson.M{}, options.Find().SetSort(bson.D{{Key: "_id", Value: 1}}))
+	if err != nil {
+		return nil, fmt.Errorf("list aliases: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	result := make([]Alias, 0)
+	for cursor.Next(ctx) {
+		var doc mongoAliasDocument
+		if err := cursor.Decode(&doc); err != nil {
+			return nil, fmt.Errorf("decode alias: %w", err)
+		}
+		result = append(result, aliasFromMongo(doc))
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, fmt.Errorf("iterate aliases: %w", err)
+	}
+	return result, nil
+}
+
+func (s *MongoDBStore) Get(ctx context.Context, name string) (*Alias, error) {
+	var doc mongoAliasDocument
+	err := s.collection.FindOne(ctx, bson.M{"_id": normalizeName(name)}).Decode(&doc)
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get alias: %w", err)
+	}
+	alias := aliasFromMongo(doc)
+	return &alias, nil
+}
+
+func (s *MongoDBStore) Upsert(ctx context.Context, alias Alias) error {
+	alias, err := normalizeAlias(alias)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	if alias.CreatedAt.IsZero() {
+		alias.CreatedAt = now
+	}
+	alias.UpdatedAt = now
+
+	update := bson.M{
+		"$set": bson.M{
+			"target_model":    alias.TargetModel,
+			"target_provider": alias.TargetProvider,
+			"description":     alias.Description,
+			"enabled":         alias.Enabled,
+			"updated_at":      alias.UpdatedAt,
+		},
+		"$setOnInsert": bson.M{
+			"created_at": alias.CreatedAt,
+		},
+	}
+	_, err = s.collection.UpdateOne(ctx, bson.M{"_id": alias.Name}, update, options.UpdateOne().SetUpsert(true))
+	if err != nil {
+		return fmt.Errorf("upsert alias: %w", err)
+	}
+	return nil
+}
+
+func (s *MongoDBStore) Delete(ctx context.Context, name string) error {
+	result, err := s.collection.DeleteOne(ctx, bson.M{"_id": normalizeName(name)})
+	if err != nil {
+		return fmt.Errorf("delete alias: %w", err)
+	}
+	if result.DeletedCount == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *MongoDBStore) Close() error {
+	return nil
+}
+
+func aliasFromMongo(doc mongoAliasDocument) Alias {
+	return Alias{
+		Name:           doc.Name,
+		TargetModel:    doc.TargetModel,
+		TargetProvider: doc.TargetProvider,
+		Description:    doc.Description,
+		Enabled:        doc.Enabled,
+		CreatedAt:      doc.CreatedAt.UTC(),
+		UpdatedAt:      doc.UpdatedAt.UTC(),
+	}
+}

--- a/internal/aliases/store_postgresql.go
+++ b/internal/aliases/store_postgresql.go
@@ -1,0 +1,143 @@
+package aliases
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// PostgreSQLStore stores aliases in PostgreSQL.
+type PostgreSQLStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgreSQLStore creates the aliases table and indexes if needed.
+func NewPostgreSQLStore(ctx context.Context, pool *pgxpool.Pool) (*PostgreSQLStore, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("context is required")
+	}
+	if pool == nil {
+		return nil, fmt.Errorf("connection pool is required")
+	}
+
+	_, err := pool.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS aliases (
+			name TEXT PRIMARY KEY,
+			target_model TEXT NOT NULL,
+			target_provider TEXT NOT NULL DEFAULT '',
+			description TEXT NOT NULL DEFAULT '',
+			enabled BOOLEAN NOT NULL DEFAULT TRUE,
+			created_at BIGINT NOT NULL,
+			updated_at BIGINT NOT NULL
+		)
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create aliases table: %w", err)
+	}
+	if _, err := pool.Exec(ctx, `CREATE INDEX IF NOT EXISTS idx_aliases_enabled ON aliases(enabled)`); err != nil {
+		return nil, fmt.Errorf("failed to create aliases enabled index: %w", err)
+	}
+	if _, err := pool.Exec(ctx, `CREATE INDEX IF NOT EXISTS idx_aliases_updated_at ON aliases(updated_at DESC)`); err != nil {
+		return nil, fmt.Errorf("failed to create aliases updated_at index: %w", err)
+	}
+	return &PostgreSQLStore{pool: pool}, nil
+}
+
+func (s *PostgreSQLStore) List(ctx context.Context) ([]Alias, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT name, target_model, target_provider, description, enabled, created_at, updated_at
+		FROM aliases
+		ORDER BY name ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list aliases: %w", err)
+	}
+	defer rows.Close()
+	result, err := collectAliases(rows, scanPostgreSQLAlias)
+	if err != nil {
+		return nil, fmt.Errorf("iterate aliases: %w", err)
+	}
+	return result, nil
+}
+
+func (s *PostgreSQLStore) Get(ctx context.Context, name string) (*Alias, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT name, target_model, target_provider, description, enabled, created_at, updated_at
+		FROM aliases
+		WHERE name = $1
+	`, normalizeName(name))
+	alias, err := scanPostgreSQLAlias(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &alias, nil
+}
+
+func (s *PostgreSQLStore) Upsert(ctx context.Context, alias Alias) error {
+	alias, err := normalizeAlias(alias)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC().Unix()
+	if alias.CreatedAt.IsZero() {
+		alias.CreatedAt = time.Unix(now, 0).UTC()
+	}
+	alias.UpdatedAt = time.Unix(now, 0).UTC()
+
+	_, err = s.pool.Exec(ctx, `
+		INSERT INTO aliases (name, target_model, target_provider, description, enabled, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		ON CONFLICT(name) DO UPDATE SET
+			target_model = excluded.target_model,
+			target_provider = excluded.target_provider,
+			description = excluded.description,
+			enabled = excluded.enabled,
+			updated_at = excluded.updated_at
+	`, alias.Name, alias.TargetModel, alias.TargetProvider, alias.Description, alias.Enabled, alias.CreatedAt.Unix(), alias.UpdatedAt.Unix())
+	if err != nil {
+		return fmt.Errorf("upsert alias: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgreSQLStore) Delete(ctx context.Context, name string) error {
+	cmd, err := s.pool.Exec(ctx, `DELETE FROM aliases WHERE name = $1`, normalizeName(name))
+	if err != nil {
+		return fmt.Errorf("delete alias: %w", err)
+	}
+	if cmd.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *PostgreSQLStore) Close() error {
+	return nil
+}
+
+func scanPostgreSQLAlias(scanner aliasScanner) (Alias, error) {
+	var alias Alias
+	var createdAt int64
+	var updatedAt int64
+	if err := scanner.Scan(
+		&alias.Name,
+		&alias.TargetModel,
+		&alias.TargetProvider,
+		&alias.Description,
+		&alias.Enabled,
+		&createdAt,
+		&updatedAt,
+	); err != nil {
+		return Alias{}, err
+	}
+	alias.CreatedAt = time.Unix(createdAt, 0).UTC()
+	alias.UpdatedAt = time.Unix(updatedAt, 0).UTC()
+	return alias, nil
+}

--- a/internal/aliases/store_sqlite.go
+++ b/internal/aliases/store_sqlite.go
@@ -1,0 +1,151 @@
+package aliases
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// SQLiteStore stores aliases in SQLite.
+type SQLiteStore struct {
+	db *sql.DB
+}
+
+// NewSQLiteStore creates the aliases table and indexes if needed.
+func NewSQLiteStore(db *sql.DB) (*SQLiteStore, error) {
+	if db == nil {
+		return nil, fmt.Errorf("database connection is required")
+	}
+
+	_, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS aliases (
+			name TEXT PRIMARY KEY,
+			target_model TEXT NOT NULL,
+			target_provider TEXT NOT NULL DEFAULT '',
+			description TEXT NOT NULL DEFAULT '',
+			enabled INTEGER NOT NULL DEFAULT 1,
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		)
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create aliases table: %w", err)
+	}
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_aliases_enabled ON aliases(enabled)`); err != nil {
+		return nil, fmt.Errorf("failed to create aliases enabled index: %w", err)
+	}
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_aliases_updated_at ON aliases(updated_at DESC)`); err != nil {
+		return nil, fmt.Errorf("failed to create aliases updated_at index: %w", err)
+	}
+	return &SQLiteStore{db: db}, nil
+}
+
+func (s *SQLiteStore) List(ctx context.Context) ([]Alias, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT name, target_model, target_provider, description, enabled, created_at, updated_at
+		FROM aliases
+		ORDER BY name ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list aliases: %w", err)
+	}
+	defer rows.Close()
+	result, err := collectAliases(rows, scanSQLiteAlias)
+	if err != nil {
+		return nil, fmt.Errorf("iterate aliases: %w", err)
+	}
+	return result, nil
+}
+
+func (s *SQLiteStore) Get(ctx context.Context, name string) (*Alias, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT name, target_model, target_provider, description, enabled, created_at, updated_at
+		FROM aliases
+		WHERE name = ?
+	`, normalizeName(name))
+	alias, err := scanSQLiteAlias(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &alias, nil
+}
+
+func (s *SQLiteStore) Upsert(ctx context.Context, alias Alias) error {
+	alias, err := normalizeAlias(alias)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC().Unix()
+	if alias.CreatedAt.IsZero() {
+		alias.CreatedAt = time.Unix(now, 0).UTC()
+	}
+	alias.UpdatedAt = time.Unix(now, 0).UTC()
+
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO aliases (name, target_model, target_provider, description, enabled, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(name) DO UPDATE SET
+			target_model = excluded.target_model,
+			target_provider = excluded.target_provider,
+			description = excluded.description,
+			enabled = excluded.enabled,
+			updated_at = excluded.updated_at
+	`, alias.Name, alias.TargetModel, alias.TargetProvider, alias.Description, boolToSQLite(alias.Enabled), alias.CreatedAt.Unix(), alias.UpdatedAt.Unix())
+	if err != nil {
+		return fmt.Errorf("upsert alias: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) Delete(ctx context.Context, name string) error {
+	result, err := s.db.ExecContext(ctx, `DELETE FROM aliases WHERE name = ?`, normalizeName(name))
+	if err != nil {
+		return fmt.Errorf("delete alias: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read delete rows affected: %w", err)
+	}
+	if affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *SQLiteStore) Close() error {
+	return nil
+}
+
+func scanSQLiteAlias(scanner aliasScanner) (Alias, error) {
+	var alias Alias
+	var enabled int
+	var createdAt int64
+	var updatedAt int64
+	if err := scanner.Scan(
+		&alias.Name,
+		&alias.TargetModel,
+		&alias.TargetProvider,
+		&alias.Description,
+		&enabled,
+		&createdAt,
+		&updatedAt,
+	); err != nil {
+		return Alias{}, err
+	}
+	alias.Enabled = enabled != 0
+	alias.CreatedAt = time.Unix(createdAt, 0).UTC()
+	alias.UpdatedAt = time.Unix(updatedAt, 0).UTC()
+	return alias, nil
+}
+
+func boolToSQLite(v bool) int {
+	if v {
+		return 1
+	}
+	return 0
+}

--- a/internal/aliases/types.go
+++ b/internal/aliases/types.go
@@ -1,0 +1,38 @@
+package aliases
+
+import (
+	"time"
+
+	"gomodel/internal/core"
+)
+
+// Alias maps a gateway-visible alias name to a concrete model selector.
+type Alias struct {
+	Name           string    `json:"name" bson:"name"`
+	TargetModel    string    `json:"target_model" bson:"target_model"`
+	TargetProvider string    `json:"target_provider,omitempty" bson:"target_provider,omitempty"`
+	Description    string    `json:"description,omitempty" bson:"description,omitempty"`
+	Enabled        bool      `json:"enabled" bson:"enabled"`
+	CreatedAt      time.Time `json:"created_at" bson:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at" bson:"updated_at"`
+}
+
+// TargetSelector returns the concrete selector this alias points to.
+func (a Alias) TargetSelector() (core.ModelSelector, error) {
+	return core.ParseModelSelector(a.TargetModel, a.TargetProvider)
+}
+
+// Resolution captures the requested selector and the concrete selector chosen after alias resolution.
+type Resolution struct {
+	Requested core.ModelSelector `json:"requested"`
+	Resolved  core.ModelSelector `json:"resolved"`
+	Alias     *Alias             `json:"alias,omitempty"`
+}
+
+// View is the admin-facing representation of an alias with current validity status.
+type View struct {
+	Alias
+	ResolvedModel string `json:"resolved_model"`
+	ProviderType  string `json:"provider_type,omitempty"`
+	Valid         bool   `json:"valid"`
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -13,6 +13,7 @@ import (
 	"gomodel/config"
 	"gomodel/internal/admin"
 	"gomodel/internal/admin/dashboard"
+	"gomodel/internal/aliases"
 	"gomodel/internal/auditlog"
 	"gomodel/internal/batch"
 	"gomodel/internal/core"
@@ -32,6 +33,7 @@ type App struct {
 	audit     *auditlog.Result
 	usage     *usage.Result
 	batch     *batch.Result
+	aliases   *aliases.Result
 	server    *server.Server
 
 	shutdownMu sync.Mutex
@@ -126,6 +128,26 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 	}
 	app.batch = batchResult
 
+	// Initialize aliases using shared storage when already available.
+	var aliasResult *aliases.Result
+	if auditResult.Storage != nil {
+		aliasResult, err = aliases.NewWithSharedStorage(ctx, appCfg, auditResult.Storage, providerResult.Registry)
+	} else if usageResult.Storage != nil {
+		aliasResult, err = aliases.NewWithSharedStorage(ctx, appCfg, usageResult.Storage, providerResult.Registry)
+	} else if batchResult.Storage != nil {
+		aliasResult, err = aliases.NewWithSharedStorage(ctx, appCfg, batchResult.Storage, providerResult.Registry)
+	} else {
+		aliasResult, err = aliases.New(ctx, appCfg, providerResult.Registry)
+	}
+	if err != nil {
+		closeErr := errors.Join(app.batch.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		if closeErr != nil {
+			return nil, fmt.Errorf("failed to initialize aliases: %w (also: close error: %v)", err, closeErr)
+		}
+		return nil, fmt.Errorf("failed to initialize aliases: %w", err)
+	}
+	app.aliases = aliasResult
+
 	// Log configuration status
 	app.logStartupInfo()
 
@@ -134,11 +156,17 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 	if appCfg.Guardrails.Enabled {
 		pipeline, err := buildGuardrailsPipeline(appCfg.Guardrails)
 		if err != nil {
-			var batchCloseErr error
+			var (
+				aliasCloseErr error
+				batchCloseErr error
+			)
+			if app.aliases != nil {
+				aliasCloseErr = app.aliases.Close()
+			}
 			if app.batch != nil {
 				batchCloseErr = app.batch.Close()
 			}
-			closeErr := errors.Join(batchCloseErr, app.usage.Close(), app.audit.Close(), app.providers.Close())
+			closeErr := errors.Join(aliasCloseErr, batchCloseErr, app.usage.Close(), app.audit.Close(), app.providers.Close())
 			if closeErr != nil {
 				return nil, fmt.Errorf("failed to build guardrails: %w (also: close error: %v)", err, closeErr)
 			}
@@ -155,23 +183,26 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 			)
 		}
 	}
+	if app.aliases != nil && app.aliases.Service != nil {
+		provider = aliases.NewProvider(provider, app.aliases.Service)
+	}
 
 	// Create server
 	allowPassthroughV1Alias := appCfg.Server.AllowPassthroughV1Alias
 	serverCfg := &server.Config{
-		MasterKey:                              appCfg.Server.MasterKey,
-		MetricsEnabled:                         appCfg.Metrics.Enabled,
-		MetricsEndpoint:                        appCfg.Metrics.Endpoint,
-		BodySizeLimit:                          appCfg.Server.BodySizeLimit,
-		AuditLogger:                            auditResult.Logger,
-		UsageLogger:                            usageResult.Logger,
-		PricingResolver:                        providerResult.Registry,
-		BatchStore:                             batchResult.Store,
-		LogOnlyModelInteractions:               appCfg.Logging.OnlyModelInteractions,
-		DisablePassthroughRoutes:               !appCfg.Server.EnablePassthroughRoutes,
-		EnabledPassthroughProviders:            appCfg.Server.EnabledPassthroughProviders,
-		AllowPassthroughV1Alias:                &allowPassthroughV1Alias,
-		SwaggerEnabled:                         appCfg.Server.SwaggerEnabled,
+		MasterKey:                   appCfg.Server.MasterKey,
+		MetricsEnabled:              appCfg.Metrics.Enabled,
+		MetricsEndpoint:             appCfg.Metrics.Endpoint,
+		BodySizeLimit:               appCfg.Server.BodySizeLimit,
+		AuditLogger:                 auditResult.Logger,
+		UsageLogger:                 usageResult.Logger,
+		PricingResolver:             providerResult.Registry,
+		BatchStore:                  batchResult.Store,
+		LogOnlyModelInteractions:    appCfg.Logging.OnlyModelInteractions,
+		DisablePassthroughRoutes:    !appCfg.Server.EnablePassthroughRoutes,
+		EnabledPassthroughProviders: appCfg.Server.EnabledPassthroughProviders,
+		AllowPassthroughV1Alias:     &allowPassthroughV1Alias,
+		SwaggerEnabled:              appCfg.Server.SwaggerEnabled,
 	}
 
 	// Initialize admin API and dashboard (behind separate feature flags)
@@ -181,7 +212,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		adminCfg.UIEnabled = false
 	}
 	if adminCfg.EndpointsEnabled {
-		adminHandler, dashHandler, adminErr := initAdmin(auditResult.Storage, usageResult.Storage, providerResult.Registry, adminCfg.UIEnabled)
+		adminHandler, dashHandler, adminErr := initAdmin(auditResult.Storage, usageResult.Storage, providerResult.Registry, app.aliases.Service, adminCfg.UIEnabled)
 		if adminErr != nil {
 			slog.Warn("failed to initialize admin", "error", adminErr)
 		} else {
@@ -209,11 +240,17 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 
 	rcm, err := responsecache.NewResponseCacheMiddleware(appCfg.Cache.Response)
 	if err != nil {
-		var batchCloseErr error
+		var (
+			aliasCloseErr error
+			batchCloseErr error
+		)
+		if app.aliases != nil {
+			aliasCloseErr = app.aliases.Close()
+		}
 		if app.batch != nil {
 			batchCloseErr = app.batch.Close()
 		}
-		closeErr := errors.Join(batchCloseErr, app.usage.Close(), app.audit.Close(), app.providers.Close())
+		closeErr := errors.Join(aliasCloseErr, batchCloseErr, app.usage.Close(), app.audit.Close(), app.providers.Close())
 		if closeErr != nil {
 			return nil, fmt.Errorf("failed to initialize response cache: %w (also: close error: %v)", err, closeErr)
 		}
@@ -346,7 +383,15 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// 3. Close batch store (flushes pending entries)
+	// 3. Close aliases subsystem.
+	if a.aliases != nil {
+		if err := a.aliases.Close(); err != nil {
+			slog.Error("aliases close error", "error", err)
+			errs = append(errs, fmt.Errorf("aliases close: %w", err))
+		}
+	}
+
+	// 4. Close batch store (flushes pending entries)
 	if a.batch != nil {
 		if err := a.batch.Close(); err != nil {
 			slog.Error("batch store close error", "error", err)
@@ -354,7 +399,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// 4. Close usage tracking (flushes pending entries)
+	// 5. Close usage tracking (flushes pending entries)
 	if a.usage != nil {
 		if err := a.usage.Close(); err != nil {
 			slog.Error("usage logger close error", "error", err)
@@ -362,7 +407,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// 5. Close audit logging (flushes pending logs)
+	// 6. Close audit logging (flushes pending logs)
 	if a.audit != nil {
 		if err := a.audit.Close(); err != nil {
 			slog.Error("audit logger close error", "error", err)
@@ -427,7 +472,7 @@ func (a *App) logStartupInfo() {
 
 // initAdmin creates the admin API handler and optionally the dashboard handler.
 // Returns nil dashboard handler if uiEnabled is false.
-func initAdmin(auditStorage, usageStorage storage.Storage, registry *providers.ModelRegistry, uiEnabled bool) (*admin.Handler, *dashboard.Handler, error) {
+func initAdmin(auditStorage, usageStorage storage.Storage, registry *providers.ModelRegistry, aliasService *aliases.Service, uiEnabled bool) (*admin.Handler, *dashboard.Handler, error) {
 	// Find a storage connection for reading usage data
 	var store storage.Storage
 	if auditStorage != nil {
@@ -457,7 +502,7 @@ func initAdmin(auditStorage, usageStorage storage.Storage, registry *providers.M
 		}
 	}
 
-	adminHandler := admin.NewHandler(reader, registry, admin.WithAuditReader(auditReader))
+	adminHandler := admin.NewHandler(reader, registry, admin.WithAuditReader(auditReader), admin.WithAliases(aliasService))
 
 	var dashHandler *dashboard.Handler
 	if uiEnabled {

--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -38,9 +38,11 @@ type LogEntry struct {
 	DurationNs int64 `json:"duration_ns" bson:"duration_ns"`
 
 	// Core fields (indexed for queries)
-	Model      string `json:"model" bson:"model"`
-	Provider   string `json:"provider" bson:"provider"`
-	StatusCode int    `json:"status_code" bson:"status_code"`
+	Model         string `json:"model" bson:"model"`
+	ResolvedModel string `json:"resolved_model,omitempty" bson:"resolved_model,omitempty"`
+	Provider      string `json:"provider" bson:"provider"`
+	AliasUsed     bool   `json:"alias_used,omitempty" bson:"alias_used,omitempty"`
+	StatusCode    int    `json:"status_code" bson:"status_code"`
 
 	// Extracted fields for efficient filtering (indexed in relational DBs)
 	RequestID string `json:"request_id,omitempty" bson:"request_id,omitempty"`

--- a/internal/auditlog/auditlog_test.go
+++ b/internal/auditlog/auditlog_test.go
@@ -119,17 +119,19 @@ func TestRedactHeaders(t *testing.T) {
 
 func TestLogEntryJSON(t *testing.T) {
 	entry := &LogEntry{
-		ID:         "test-id-123",
-		Timestamp:  time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC),
-		DurationNs: 1500000,
-		Model:      "gpt-4",
-		Provider:   "openai",
-		StatusCode: 200,
-		RequestID:  "req-123",
-		ClientIP:   "192.168.1.1",
-		Method:     "POST",
-		Path:       "/v1/chat/completions",
-		Stream:     false,
+		ID:            "test-id-123",
+		Timestamp:     time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC),
+		DurationNs:    1500000,
+		Model:         "friendly-alias",
+		ResolvedModel: "openai/gpt-4",
+		Provider:      "openai",
+		AliasUsed:     true,
+		StatusCode:    200,
+		RequestID:     "req-123",
+		ClientIP:      "192.168.1.1",
+		Method:        "POST",
+		Path:          "/v1/chat/completions",
+		Stream:        false,
 		Data: &LogData{
 			UserAgent: "test-agent",
 		},
@@ -156,6 +158,12 @@ func TestLogEntryJSON(t *testing.T) {
 	}
 	if decoded.Provider != entry.Provider {
 		t.Errorf("Provider mismatch: expected %q, got %q", entry.Provider, decoded.Provider)
+	}
+	if decoded.ResolvedModel != entry.ResolvedModel {
+		t.Errorf("ResolvedModel mismatch: expected %q, got %q", entry.ResolvedModel, decoded.ResolvedModel)
+	}
+	if decoded.AliasUsed != entry.AliasUsed {
+		t.Errorf("AliasUsed mismatch: expected %v, got %v", entry.AliasUsed, decoded.AliasUsed)
 	}
 	if decoded.StatusCode != entry.StatusCode {
 		t.Errorf("StatusCode mismatch: expected %d, got %d", entry.StatusCode, decoded.StatusCode)
@@ -405,6 +413,50 @@ func TestMiddleware_UsesIngressTooLargeFlagWithoutReadingStream(t *testing.T) {
 	}
 }
 
+func TestMiddleware_AppliesRequestModelResolution(t *testing.T) {
+	e := echo.New()
+	logger := &capturingLogger{
+		cfg: Config{Enabled: true},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"anthropic/claude-opus-4-6"}`))
+	req = req.WithContext(core.WithRequestModelResolution(req.Context(), &core.RequestModelResolution{
+		RequestedModel:   "anthropic/claude-opus-4-6",
+		ResolvedSelector: core.ModelSelector{Provider: "openai", Model: "gpt-5-nano"},
+		ProviderType:     "openai",
+		AliasApplied:     true,
+	}))
+
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	handler := Middleware(logger)(func(c *echo.Context) error {
+		EnrichEntry(c, "placeholder", "placeholder")
+		return c.NoContent(http.StatusNoContent)
+	})
+
+	if err := handler(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if len(logger.entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1", len(logger.entries))
+	}
+
+	entry := logger.entries[0]
+	if entry.Model != "anthropic/claude-opus-4-6" {
+		t.Fatalf("Model = %q, want requested alias", entry.Model)
+	}
+	if entry.ResolvedModel != "openai/gpt-5-nano" {
+		t.Fatalf("ResolvedModel = %q, want openai/gpt-5-nano", entry.ResolvedModel)
+	}
+	if entry.Provider != "openai" {
+		t.Fatalf("Provider = %q, want openai", entry.Provider)
+	}
+	if !entry.AliasUsed {
+		t.Fatal("AliasUsed = false, want true")
+	}
+}
+
 func TestLoggerClose(t *testing.T) {
 	store := &mockStore{}
 	cfg := Config{
@@ -563,17 +615,19 @@ func TestCreateStreamEntry(t *testing.T) {
 
 	// Test with valid entry
 	baseEntry := &LogEntry{
-		ID:         "test-id",
-		Timestamp:  time.Now(),
-		DurationNs: 1000,
-		Model:      "gpt-4",
-		Provider:   "openai",
-		StatusCode: 200,
-		RequestID:  "req-123",
-		ClientIP:   "127.0.0.1",
-		Method:     "POST",
-		Path:       "/v1/chat/completions",
-		Stream:     false,
+		ID:            "test-id",
+		Timestamp:     time.Now(),
+		DurationNs:    1000,
+		Model:         "claude-opus-4-6",
+		ResolvedModel: "openai/gpt-5-nano",
+		Provider:      "openai",
+		AliasUsed:     true,
+		StatusCode:    200,
+		RequestID:     "req-123",
+		ClientIP:      "127.0.0.1",
+		Method:        "POST",
+		Path:          "/v1/chat/completions",
+		Stream:        false,
 		Data: &LogData{
 			UserAgent: "test",
 			RequestHeaders: map[string]string{
@@ -594,6 +648,12 @@ func TestCreateStreamEntry(t *testing.T) {
 	}
 	if streamEntry.Model != baseEntry.Model {
 		t.Errorf("Model mismatch")
+	}
+	if streamEntry.ResolvedModel != baseEntry.ResolvedModel {
+		t.Errorf("ResolvedModel mismatch")
+	}
+	if streamEntry.AliasUsed != baseEntry.AliasUsed {
+		t.Errorf("AliasUsed mismatch")
 	}
 	if !streamEntry.Stream {
 		t.Error("Stream should be true")

--- a/internal/auditlog/middleware.go
+++ b/internal/auditlog/middleware.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/flate"
 	"compress/gzip"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -72,19 +73,19 @@ func Middleware(logger LoggerInterface) echo.MiddlewareFunc {
 				entry.Data.RequestHeaders = extractHeaders(req.Header)
 			}
 
-				// Capture request body if enabled
-				if cfg.LogBodies && req.Body != nil {
-					if snapshot := core.GetRequestSnapshot(req.Context()); snapshot != nil {
-						body := snapshot.CapturedBody()
-						switch {
-						case snapshot.BodyNotCaptured:
-							entry.Data.RequestBodyTooBigToHandle = true
-						case body != nil:
-							captureLoggedRequestBody(entry, body)
-						default:
-							captureRequestBodyForLogging(entry, req)
-						}
-					} else {
+			// Capture request body if enabled
+			if cfg.LogBodies && req.Body != nil {
+				if snapshot := core.GetRequestSnapshot(req.Context()); snapshot != nil {
+					body := snapshot.CapturedBody()
+					switch {
+					case snapshot.BodyNotCaptured:
+						entry.Data.RequestBodyTooBigToHandle = true
+					case body != nil:
+						captureLoggedRequestBody(entry, body)
+					default:
+						captureRequestBodyForLogging(entry, req)
+					}
+				} else {
 					captureRequestBodyForLogging(entry, req)
 				}
 			}
@@ -104,6 +105,8 @@ func Middleware(logger LoggerInterface) echo.MiddlewareFunc {
 
 			// Execute the handler
 			err := next(c)
+
+			applyRequestModelResolution(entry, c.Request().Context())
 
 			// Calculate duration
 			entry.DurationNs = time.Since(start).Nanoseconds()
@@ -151,6 +154,36 @@ func Middleware(logger LoggerInterface) echo.MiddlewareFunc {
 			return err
 		}
 	}
+}
+
+func applyRequestModelResolution(entry *LogEntry, ctx context.Context) {
+	if entry == nil || ctx == nil {
+		return
+	}
+
+	resolution := core.GetRequestModelResolution(ctx)
+	if resolution == nil {
+		return
+	}
+
+	enrichEntryWithResolution(entry, resolution)
+}
+
+func enrichEntryWithResolution(entry *LogEntry, resolution *core.RequestModelResolution) {
+	if entry == nil || resolution == nil {
+		return
+	}
+
+	if requestedModel := resolution.RequestedQualifiedModel(); requestedModel != "" {
+		entry.Model = requestedModel
+	}
+	if resolvedModel := resolution.ResolvedQualifiedModel(); resolvedModel != "" {
+		entry.ResolvedModel = resolvedModel
+	}
+	if strings.TrimSpace(resolution.ProviderType) != "" {
+		entry.Provider = strings.TrimSpace(resolution.ProviderType)
+	}
+	entry.AliasUsed = resolution.AliasApplied
 }
 
 func captureRequestBodyForLogging(entry *LogEntry, req *http.Request) {
@@ -301,6 +334,22 @@ func EnrichEntry(c *echo.Context, model, provider string) {
 
 	entry.Model = model
 	entry.Provider = provider
+}
+
+// EnrichEntryWithResolution attaches resolved model and alias metadata to the live audit entry.
+// This is used before handler execution completes so streaming audit entries inherit the same data.
+func EnrichEntryWithResolution(c *echo.Context, resolution *core.RequestModelResolution) {
+	entryVal := c.Get(string(LogEntryKey))
+	if entryVal == nil {
+		return
+	}
+
+	entry, ok := entryVal.(*LogEntry)
+	if !ok || entry == nil {
+		return
+	}
+
+	enrichEntryWithResolution(entry, resolution)
 }
 
 // EnrichEntryWithError adds error information to the log entry.

--- a/internal/auditlog/reader_mongodb.go
+++ b/internal/auditlog/reader_mongodb.go
@@ -17,36 +17,40 @@ type MongoDBReader struct {
 }
 
 type mongoLogRow struct {
-	ID         string    `bson:"_id"`
-	Timestamp  time.Time `bson:"timestamp"`
-	DurationNs int64     `bson:"duration_ns"`
-	Model      string    `bson:"model"`
-	Provider   string    `bson:"provider"`
-	StatusCode int       `bson:"status_code"`
-	RequestID  string    `bson:"request_id"`
-	ClientIP   string    `bson:"client_ip"`
-	Method     string    `bson:"method"`
-	Path       string    `bson:"path"`
-	Stream     bool      `bson:"stream"`
-	ErrorType  string    `bson:"error_type"`
-	Data       *LogData  `bson:"data"`
+	ID            string    `bson:"_id"`
+	Timestamp     time.Time `bson:"timestamp"`
+	DurationNs    int64     `bson:"duration_ns"`
+	Model         string    `bson:"model"`
+	ResolvedModel string    `bson:"resolved_model"`
+	Provider      string    `bson:"provider"`
+	AliasUsed     bool      `bson:"alias_used"`
+	StatusCode    int       `bson:"status_code"`
+	RequestID     string    `bson:"request_id"`
+	ClientIP      string    `bson:"client_ip"`
+	Method        string    `bson:"method"`
+	Path          string    `bson:"path"`
+	Stream        bool      `bson:"stream"`
+	ErrorType     string    `bson:"error_type"`
+	Data          *LogData  `bson:"data"`
 }
 
 func (r mongoLogRow) toLogEntry() *LogEntry {
 	return &LogEntry{
-		ID:         r.ID,
-		Timestamp:  r.Timestamp,
-		DurationNs: r.DurationNs,
-		Model:      r.Model,
-		Provider:   r.Provider,
-		StatusCode: r.StatusCode,
-		RequestID:  r.RequestID,
-		ClientIP:   r.ClientIP,
-		Method:     r.Method,
-		Path:       r.Path,
-		Stream:     r.Stream,
-		ErrorType:  r.ErrorType,
-		Data:       sanitizeLogData(r.Data),
+		ID:            r.ID,
+		Timestamp:     r.Timestamp,
+		DurationNs:    r.DurationNs,
+		Model:         r.Model,
+		ResolvedModel: r.ResolvedModel,
+		Provider:      r.Provider,
+		AliasUsed:     r.AliasUsed,
+		StatusCode:    r.StatusCode,
+		RequestID:     r.RequestID,
+		ClientIP:      r.ClientIP,
+		Method:        r.Method,
+		Path:          r.Path,
+		Stream:        r.Stream,
+		ErrorType:     r.ErrorType,
+		Data:          sanitizeLogData(r.Data),
 	}
 }
 

--- a/internal/auditlog/reader_postgresql.go
+++ b/internal/auditlog/reader_postgresql.go
@@ -78,7 +78,7 @@ func (r *PostgreSQLReader) GetLogs(ctx context.Context, params LogQueryParams) (
 		return nil, fmt.Errorf("failed to count audit log entries: %w", err)
 	}
 
-	dataQuery := fmt.Sprintf(`SELECT id, timestamp, duration_ns, model, provider, status_code, request_id,
+	dataQuery := fmt.Sprintf(`SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, status_code, request_id,
 		client_ip, method, path, stream, error_type, data
 		FROM audit_logs%s ORDER BY timestamp DESC LIMIT $%d OFFSET $%d`, where, argIdx, argIdx+1)
 	dataArgs := append(append([]interface{}(nil), args...), limit, offset)
@@ -94,7 +94,7 @@ func (r *PostgreSQLReader) GetLogs(ctx context.Context, params LogQueryParams) (
 		var e LogEntry
 		var dataJSON *string
 
-		if err := rows.Scan(&e.ID, &e.Timestamp, &e.DurationNs, &e.Model, &e.Provider, &e.StatusCode,
+		if err := rows.Scan(&e.ID, &e.Timestamp, &e.DurationNs, &e.Model, &e.ResolvedModel, &e.Provider, &e.AliasUsed, &e.StatusCode,
 			&e.RequestID, &e.ClientIP, &e.Method, &e.Path, &e.Stream, &e.ErrorType, &dataJSON); err != nil {
 			return nil, fmt.Errorf("failed to scan audit log row: %w", err)
 		}
@@ -125,7 +125,7 @@ func (r *PostgreSQLReader) GetLogs(ctx context.Context, params LogQueryParams) (
 
 // GetLogByID returns a single audit log entry by ID.
 func (r *PostgreSQLReader) GetLogByID(ctx context.Context, id string) (*LogEntry, error) {
-	query := `SELECT id, timestamp, duration_ns, model, provider, status_code, request_id,
+	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, status_code, request_id,
 		client_ip, method, path, stream, error_type, data
 		FROM audit_logs WHERE id::text = $1 LIMIT 1`
 
@@ -167,7 +167,7 @@ func pgDateRangeConditions(params QueryParams, argIdx int) (conditions []string,
 }
 
 func (r *PostgreSQLReader) findByResponseID(ctx context.Context, responseID string) (*LogEntry, error) {
-	query := `SELECT id, timestamp, duration_ns, model, provider, status_code, request_id,
+	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, status_code, request_id,
 		client_ip, method, path, stream, error_type, data
 		FROM audit_logs
 		WHERE data->'response_body'->>'id' = $1
@@ -186,7 +186,7 @@ func (r *PostgreSQLReader) findByResponseID(ctx context.Context, responseID stri
 }
 
 func (r *PostgreSQLReader) findByPreviousResponseID(ctx context.Context, previousResponseID string) (*LogEntry, error) {
-	query := `SELECT id, timestamp, duration_ns, model, provider, status_code, request_id,
+	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, status_code, request_id,
 		client_ip, method, path, stream, error_type, data
 		FROM audit_logs
 		WHERE data->'request_body'->>'previous_response_id' = $1
@@ -210,7 +210,7 @@ func scanPostgreSQLLogEntry(rows interface {
 	var e LogEntry
 	var dataJSON *string
 
-	if err := rows.Scan(&e.ID, &e.Timestamp, &e.DurationNs, &e.Model, &e.Provider, &e.StatusCode,
+	if err := rows.Scan(&e.ID, &e.Timestamp, &e.DurationNs, &e.Model, &e.ResolvedModel, &e.Provider, &e.AliasUsed, &e.StatusCode,
 		&e.RequestID, &e.ClientIP, &e.Method, &e.Path, &e.Stream, &e.ErrorType, &dataJSON); err != nil {
 		return nil, fmt.Errorf("failed to scan audit log row: %w", err)
 	}

--- a/internal/auditlog/reader_sqlite.go
+++ b/internal/auditlog/reader_sqlite.go
@@ -76,7 +76,7 @@ func (r *SQLiteReader) GetLogs(ctx context.Context, params LogQueryParams) (*Log
 		return nil, fmt.Errorf("failed to count audit log entries: %w", err)
 	}
 
-	dataQuery := `SELECT id, timestamp, duration_ns, model, provider, status_code, request_id,
+	dataQuery := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, status_code, request_id,
 		client_ip, method, path, stream, error_type, data
 		FROM audit_logs` + where + ` ORDER BY timestamp DESC LIMIT ? OFFSET ?`
 	dataArgs := append(append([]interface{}(nil), args...), limit, offset)
@@ -91,14 +91,16 @@ func (r *SQLiteReader) GetLogs(ctx context.Context, params LogQueryParams) (*Log
 	for rows.Next() {
 		var e LogEntry
 		var ts string
+		var aliasUsedInt int
 		var streamInt int
 		var dataJSON *string
 
-		if err := rows.Scan(&e.ID, &ts, &e.DurationNs, &e.Model, &e.Provider, &e.StatusCode,
+		if err := rows.Scan(&e.ID, &ts, &e.DurationNs, &e.Model, &e.ResolvedModel, &e.Provider, &aliasUsedInt, &e.StatusCode,
 			&e.RequestID, &e.ClientIP, &e.Method, &e.Path, &streamInt, &e.ErrorType, &dataJSON); err != nil {
 			return nil, fmt.Errorf("failed to scan audit log row: %w", err)
 		}
 
+		e.AliasUsed = aliasUsedInt == 1
 		e.Stream = streamInt == 1
 		e.Timestamp = parseSQLTimestamp(ts, e.ID)
 
@@ -128,7 +130,7 @@ func (r *SQLiteReader) GetLogs(ctx context.Context, params LogQueryParams) (*Log
 
 // GetLogByID returns a single audit log entry by ID.
 func (r *SQLiteReader) GetLogByID(ctx context.Context, id string) (*LogEntry, error) {
-	query := `SELECT id, timestamp, duration_ns, model, provider, status_code, request_id,
+	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, status_code, request_id,
 		client_ip, method, path, stream, error_type, data
 		FROM audit_logs WHERE id = ? LIMIT 1`
 
@@ -256,7 +258,7 @@ func parseSQLTimestamp(ts string, entryID string) time.Time {
 }
 
 func (r *SQLiteReader) findByResponseID(ctx context.Context, responseID string) (*LogEntry, error) {
-	query := `SELECT id, timestamp, duration_ns, model, provider, status_code, request_id,
+	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, status_code, request_id,
 		client_ip, method, path, stream, error_type, data
 		FROM audit_logs
 		WHERE json_extract(data, '$.response_body.id') = ?
@@ -275,7 +277,7 @@ func (r *SQLiteReader) findByResponseID(ctx context.Context, responseID string) 
 }
 
 func (r *SQLiteReader) findByPreviousResponseID(ctx context.Context, previousResponseID string) (*LogEntry, error) {
-	query := `SELECT id, timestamp, duration_ns, model, provider, status_code, request_id,
+	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, status_code, request_id,
 		client_ip, method, path, stream, error_type, data
 		FROM audit_logs
 		WHERE json_extract(data, '$.request_body.previous_response_id') = ?
@@ -296,14 +298,16 @@ func (r *SQLiteReader) findByPreviousResponseID(ctx context.Context, previousRes
 func scanSQLiteLogEntry(rows *sql.Rows) (*LogEntry, error) {
 	var e LogEntry
 	var ts string
+	var aliasUsedInt int
 	var streamInt int
 	var dataJSON *string
 
-	if err := rows.Scan(&e.ID, &ts, &e.DurationNs, &e.Model, &e.Provider, &e.StatusCode,
+	if err := rows.Scan(&e.ID, &ts, &e.DurationNs, &e.Model, &e.ResolvedModel, &e.Provider, &aliasUsedInt, &e.StatusCode,
 		&e.RequestID, &e.ClientIP, &e.Method, &e.Path, &streamInt, &e.ErrorType, &dataJSON); err != nil {
 		return nil, fmt.Errorf("failed to scan audit log row: %w", err)
 	}
 
+	e.AliasUsed = aliasUsedInt == 1
 	e.Stream = streamInt == 1
 	e.Timestamp = parseSQLTimestamp(ts, e.ID)
 

--- a/internal/auditlog/store_postgresql.go
+++ b/internal/auditlog/store_postgresql.go
@@ -36,7 +36,9 @@ func NewPostgreSQLStore(pool *pgxpool.Pool, retentionDays int) (*PostgreSQLStore
 			timestamp TIMESTAMPTZ NOT NULL,
 			duration_ns BIGINT DEFAULT 0,
 			model TEXT,
+			resolved_model TEXT,
 			provider TEXT,
+			alias_used BOOLEAN DEFAULT FALSE,
 			status_code INTEGER DEFAULT 0,
 			request_id TEXT,
 			client_ip TEXT,
@@ -49,6 +51,16 @@ func NewPostgreSQLStore(pool *pgxpool.Pool, retentionDays int) (*PostgreSQLStore
 	`)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create audit_logs table: %w", err)
+	}
+
+	migrations := []string{
+		"ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS resolved_model TEXT",
+		"ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS alias_used BOOLEAN DEFAULT FALSE",
+	}
+	for _, migration := range migrations {
+		if _, err := pool.Exec(ctx, migration); err != nil {
+			return nil, fmt.Errorf("failed to run migration %q: %w", migration, err)
+		}
 	}
 
 	// Create indexes for common queries
@@ -108,11 +120,11 @@ func (s *PostgreSQLStore) writeBatchSmall(ctx context.Context, entries []*LogEnt
 		dataJSON := marshalLogData(e.Data, e.ID)
 
 		_, err := s.pool.Exec(ctx, `
-			INSERT INTO audit_logs (id, timestamp, duration_ns, model, provider, status_code,
+			INSERT INTO audit_logs (id, timestamp, duration_ns, model, resolved_model, provider, alias_used, status_code,
 				request_id, client_ip, method, path, stream, error_type, data)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
 			ON CONFLICT (id) DO NOTHING
-		`, e.ID, e.Timestamp, e.DurationNs, e.Model, e.Provider, e.StatusCode,
+		`, e.ID, e.Timestamp, e.DurationNs, e.Model, e.ResolvedModel, e.Provider, e.AliasUsed, e.StatusCode,
 			e.RequestID, e.ClientIP, e.Method, e.Path, e.Stream, e.ErrorType, dataJSON)
 
 		if err != nil {
@@ -142,11 +154,11 @@ func (s *PostgreSQLStore) writeBatchLarge(ctx context.Context, entries []*LogEnt
 		dataJSON := marshalLogData(e.Data, e.ID)
 
 		_, err = tx.Exec(ctx, `
-			INSERT INTO audit_logs (id, timestamp, duration_ns, model, provider, status_code,
+			INSERT INTO audit_logs (id, timestamp, duration_ns, model, resolved_model, provider, alias_used, status_code,
 				request_id, client_ip, method, path, stream, error_type, data)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
 			ON CONFLICT (id) DO NOTHING
-		`, e.ID, e.Timestamp, e.DurationNs, e.Model, e.Provider, e.StatusCode,
+		`, e.ID, e.Timestamp, e.DurationNs, e.Model, e.ResolvedModel, e.Provider, e.AliasUsed, e.StatusCode,
 			e.RequestID, e.ClientIP, e.Method, e.Path, e.Stream, e.ErrorType, dataJSON)
 
 		if err != nil {

--- a/internal/auditlog/store_sqlite.go
+++ b/internal/auditlog/store_sqlite.go
@@ -11,12 +11,12 @@ import (
 )
 
 // SQLite has a default limit of 999 bindable parameters per query (SQLITE_MAX_VARIABLE_NUMBER).
-// With 13 columns per log entry, we can safely insert up to 76 entries per batch (76 * 13 = 988).
+// With 15 columns per log entry, we can safely insert up to 66 entries per batch (66 * 15 = 990).
 // We chunk larger batches to avoid hitting this limit.
 const (
 	maxSQLiteParams    = 999
-	columnsPerEntry    = 13
-	maxEntriesPerBatch = maxSQLiteParams / columnsPerEntry // 76 entries
+	columnsPerEntry    = 15
+	maxEntriesPerBatch = maxSQLiteParams / columnsPerEntry // 66 entries
 )
 
 // SQLiteStore implements LogStore for SQLite databases.
@@ -42,7 +42,9 @@ func NewSQLiteStore(db *sql.DB, retentionDays int) (*SQLiteStore, error) {
 			timestamp DATETIME NOT NULL,
 			duration_ns INTEGER DEFAULT 0,
 			model TEXT,
+			resolved_model TEXT,
 			provider TEXT,
+			alias_used INTEGER DEFAULT 0,
 			status_code INTEGER DEFAULT 0,
 			request_id TEXT,
 			client_ip TEXT,
@@ -55,6 +57,18 @@ func NewSQLiteStore(db *sql.DB, retentionDays int) (*SQLiteStore, error) {
 	`)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create audit_logs table: %w", err)
+	}
+
+	migrations := []string{
+		"ALTER TABLE audit_logs ADD COLUMN resolved_model TEXT",
+		"ALTER TABLE audit_logs ADD COLUMN alias_used INTEGER DEFAULT 0",
+	}
+	for _, migration := range migrations {
+		if _, err := db.Exec(migration); err != nil {
+			if !strings.Contains(err.Error(), "duplicate column") {
+				return nil, fmt.Errorf("failed to run migration %q: %w", migration, err)
+			}
+		}
 	}
 
 	// Create indexes for common queries
@@ -110,7 +124,7 @@ func (s *SQLiteStore) WriteBatch(ctx context.Context, entries []*LogEntry) error
 		values := make([]interface{}, 0, len(chunk)*columnsPerEntry)
 
 		for j, e := range chunk {
-			placeholders[j] = "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+			placeholders[j] = "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 
 			dataJSON := marshalLogData(e.Data, e.ID)
 
@@ -118,6 +132,10 @@ func (s *SQLiteStore) WriteBatch(ctx context.Context, entries []*LogEntry) error
 			streamInt := 0
 			if e.Stream {
 				streamInt = 1
+			}
+			aliasUsedInt := 0
+			if e.AliasUsed {
+				aliasUsedInt = 1
 			}
 
 			// Handle NULL for data field: nil becomes SQL NULL, non-nil becomes JSON string
@@ -131,7 +149,9 @@ func (s *SQLiteStore) WriteBatch(ctx context.Context, entries []*LogEntry) error
 				e.Timestamp.UTC().Format(time.RFC3339Nano),
 				e.DurationNs,
 				e.Model,
+				e.ResolvedModel,
 				e.Provider,
+				aliasUsedInt,
 				e.StatusCode,
 				e.RequestID,
 				e.ClientIP,
@@ -143,7 +163,7 @@ func (s *SQLiteStore) WriteBatch(ctx context.Context, entries []*LogEntry) error
 			)
 		}
 
-		query := `INSERT OR IGNORE INTO audit_logs (id, timestamp, duration_ns, model, provider, status_code,
+		query := `INSERT OR IGNORE INTO audit_logs (id, timestamp, duration_ns, model, resolved_model, provider, alias_used, status_code,
 			request_id, client_ip, method, path, stream, error_type, data) VALUES ` +
 			strings.Join(placeholders, ",")
 

--- a/internal/auditlog/store_sqlite_test.go
+++ b/internal/auditlog/store_sqlite_test.go
@@ -178,7 +178,7 @@ func TestSQLiteStore_WriteBatch_ExactBatchBoundary(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Test with exactly maxEntriesPerBatch entries (62)
+	// Test with exactly maxEntriesPerBatch entries
 	numEntries := maxEntriesPerBatch
 	entries := make([]*LogEntry, numEntries)
 	for i := 0; i < numEntries; i++ {
@@ -201,7 +201,7 @@ func TestSQLiteStore_WriteBatch_ExactBatchBoundary(t *testing.T) {
 		t.Errorf("expected %d entries, got %d", numEntries, count)
 	}
 
-	// Test with maxEntriesPerBatch + 1 entries (63) - should require 2 batches
+	// Test with maxEntriesPerBatch + 1 entries - should require 2 batches
 	entries = make([]*LogEntry, maxEntriesPerBatch+1)
 	for i := 0; i <= maxEntriesPerBatch; i++ {
 		entries[i] = &LogEntry{
@@ -221,5 +221,56 @@ func TestSQLiteStore_WriteBatch_ExactBatchBoundary(t *testing.T) {
 	expectedTotal := numEntries + maxEntriesPerBatch + 1
 	if count != expectedTotal {
 		t.Errorf("expected %d entries, got %d", expectedTotal, count)
+	}
+}
+
+func TestSQLiteStore_WriteBatch_PersistsAliasFields(t *testing.T) {
+	db := createTestDB(t)
+	defer db.Close()
+
+	store, err := NewSQLiteStore(db, 0)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	entry := &LogEntry{
+		ID:            "alias-entry",
+		Timestamp:     time.Now(),
+		Model:         "anthropic/claude-opus-4-6",
+		ResolvedModel: "openai/gpt-5-nano",
+		Provider:      "openai",
+		AliasUsed:     true,
+		StatusCode:    200,
+	}
+
+	if err := store.WriteBatch(ctx, []*LogEntry{entry}); err != nil {
+		t.Fatalf("WriteBatch failed: %v", err)
+	}
+
+	reader, err := NewSQLiteReader(db)
+	if err != nil {
+		t.Fatalf("failed to create reader: %v", err)
+	}
+
+	logEntry, err := reader.GetLogByID(ctx, entry.ID)
+	if err != nil {
+		t.Fatalf("GetLogByID failed: %v", err)
+	}
+	if logEntry == nil {
+		t.Fatal("expected log entry, got nil")
+	}
+	if logEntry.Model != entry.Model {
+		t.Fatalf("Model = %q, want %q", logEntry.Model, entry.Model)
+	}
+	if logEntry.ResolvedModel != entry.ResolvedModel {
+		t.Fatalf("ResolvedModel = %q, want %q", logEntry.ResolvedModel, entry.ResolvedModel)
+	}
+	if logEntry.Provider != entry.Provider {
+		t.Fatalf("Provider = %q, want %q", logEntry.Provider, entry.Provider)
+	}
+	if !logEntry.AliasUsed {
+		t.Fatal("AliasUsed = false, want true")
 	}
 }

--- a/internal/auditlog/stream_wrapper.go
+++ b/internal/auditlog/stream_wrapper.go
@@ -349,12 +349,14 @@ func CreateStreamEntry(baseEntry *LogEntry) *LogEntry {
 	// Create a copy of the entry for the stream
 	// The stream wrapper will complete and write it when the stream closes
 	entryCopy := &LogEntry{
-		ID:         baseEntry.ID,
-		Timestamp:  baseEntry.Timestamp,
-		DurationNs: baseEntry.DurationNs,
-		Model:      baseEntry.Model,
-		Provider:   baseEntry.Provider,
-		StatusCode: baseEntry.StatusCode,
+		ID:            baseEntry.ID,
+		Timestamp:     baseEntry.Timestamp,
+		DurationNs:    baseEntry.DurationNs,
+		Model:         baseEntry.Model,
+		ResolvedModel: baseEntry.ResolvedModel,
+		Provider:      baseEntry.Provider,
+		AliasUsed:     baseEntry.AliasUsed,
+		StatusCode:    baseEntry.StatusCode,
 		// Copy extracted fields
 		RequestID: baseEntry.RequestID,
 		ClientIP:  baseEntry.ClientIP,

--- a/internal/batch/store.go
+++ b/internal/batch/store.go
@@ -28,6 +28,8 @@ const (
 type StoredBatch struct {
 	Batch                     *core.BatchResponse `json:"batch"`
 	RequestEndpointByCustomID map[string]string   `json:"request_endpoint_by_custom_id,omitempty"`
+	OriginalInputFileID       string              `json:"original_input_file_id,omitempty"`
+	RewrittenInputFileID      string              `json:"rewritten_input_file_id,omitempty"`
 	RequestID                 string              `json:"request_id,omitempty"`
 	UsageLoggedAt             *time.Time          `json:"usage_logged_at,omitempty"`
 }

--- a/internal/batch/store_test.go
+++ b/internal/batch/store_test.go
@@ -39,6 +39,8 @@ func TestSerializeBatchPreservesRequestEndpointHints(t *testing.T) {
 			"resp-1": "/v1/responses",
 			"chat-1": "/v1/chat/completions",
 		},
+		OriginalInputFileID:  "file_original",
+		RewrittenInputFileID: "file_rewritten",
 	})
 	if err != nil {
 		t.Fatalf("serializeBatch() error = %v", err)
@@ -57,6 +59,12 @@ func TestSerializeBatchPreservesRequestEndpointHints(t *testing.T) {
 	if got := decoded.RequestEndpointByCustomID["chat-1"]; got != "/v1/chat/completions" {
 		t.Fatalf("RequestEndpointByCustomID[chat-1] = %q, want /v1/chat/completions", got)
 	}
+	if decoded.OriginalInputFileID != "file_original" {
+		t.Fatalf("OriginalInputFileID = %q, want file_original", decoded.OriginalInputFileID)
+	}
+	if decoded.RewrittenInputFileID != "file_rewritten" {
+		t.Fatalf("RewrittenInputFileID = %q, want file_rewritten", decoded.RewrittenInputFileID)
+	}
 }
 
 func TestSerializeBatchStripsGatewayOnlyMetadata(t *testing.T) {
@@ -65,9 +73,9 @@ func TestSerializeBatchStripsGatewayOnlyMetadata(t *testing.T) {
 		Batch: &core.BatchResponse{
 			ID: "batch_123",
 			Metadata: map[string]string{
-				"visible":                  "keep",
-				RequestIDMetadataKey:      "req_123",
-				UsageLoggedAtMetadataKey:  strconv.FormatInt(loggedAt.Unix(), 10),
+				"visible":                "keep",
+				RequestIDMetadataKey:     "req_123",
+				UsageLoggedAtMetadataKey: strconv.FormatInt(loggedAt.Unix(), 10),
 			},
 		},
 	})

--- a/internal/core/batch_preparation.go
+++ b/internal/core/batch_preparation.go
@@ -73,11 +73,7 @@ func RewriteBatchSource(
 		return nil, NewInvalidRequestError("batch rewrite function is required", nil)
 	}
 
-	forward, err := cloneBatchRequest(req)
-	if err != nil {
-		return nil, NewInvalidRequestError("failed to clone batch request", err)
-	}
-
+	forward := cloneBatchRequest(req)
 	result := &BatchRewriteResult{Request: forward}
 	hints := map[string]string{}
 
@@ -304,16 +300,46 @@ func mergeBatchEndpointHints(dst, src map[string]string) {
 	}
 }
 
-func cloneBatchRequest(req *BatchRequest) (*BatchRequest, error) {
-	raw, err := json.Marshal(req)
-	if err != nil {
-		return nil, err
+func cloneBatchRequest(req *BatchRequest) *BatchRequest {
+	if req == nil {
+		return nil
 	}
-	var cloned BatchRequest
-	if err := json.Unmarshal(raw, &cloned); err != nil {
-		return nil, err
+
+	cloned := &BatchRequest{
+		InputFileID:      req.InputFileID,
+		Endpoint:         req.Endpoint,
+		CompletionWindow: req.CompletionWindow,
+		Metadata:         cloneBatchStringMap(req.Metadata),
+		ExtraFields:      CloneRawJSONMap(req.ExtraFields),
 	}
-	return &cloned, nil
+	if req.Requests != nil {
+		cloned.Requests = make([]BatchRequestItem, len(req.Requests))
+		for i, item := range req.Requests {
+			cloned.Requests[i] = cloneBatchRequestItem(item)
+		}
+	}
+	return cloned
+}
+
+func cloneBatchRequestItem(item BatchRequestItem) BatchRequestItem {
+	return BatchRequestItem{
+		CustomID:    item.CustomID,
+		Method:      item.Method,
+		URL:         item.URL,
+		Body:        CloneRawJSON(item.Body),
+		ExtraFields: CloneRawJSONMap(item.ExtraFields),
+	}
+}
+
+func cloneBatchStringMap(src map[string]string) map[string]string {
+	if src == nil {
+		return nil
+	}
+	cloned := make(map[string]string, len(src))
+	for key, value := range src {
+		cloned[key] = value
+	}
+	return cloned
 }
 
 func jsonSemanticallyEqual(left, right []byte) bool {

--- a/internal/core/batch_preparation.go
+++ b/internal/core/batch_preparation.go
@@ -1,0 +1,338 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// BatchPreparationMetadata captures request-scoped batch preprocessing effects
+// that are useful for persistence and debugging but should not be exposed as
+// public API fields automatically.
+type BatchPreparationMetadata struct {
+	OriginalInputFileID  string
+	RewrittenInputFileID string
+}
+
+// RecordInputFileRewrite tracks the first user-supplied provider file id and
+// the latest derived provider file id submitted upstream.
+func (m *BatchPreparationMetadata) RecordInputFileRewrite(original, rewritten string) {
+	if m == nil {
+		return
+	}
+	original = strings.TrimSpace(original)
+	rewritten = strings.TrimSpace(rewritten)
+	if original == "" || rewritten == "" || original == rewritten {
+		return
+	}
+	if m.OriginalInputFileID == "" {
+		m.OriginalInputFileID = original
+	}
+	m.RewrittenInputFileID = rewritten
+}
+
+// BatchFileTransport is the minimal provider-native file API surface needed to
+// preprocess file-backed batch requests.
+type BatchFileTransport interface {
+	GetFileContent(ctx context.Context, providerType, id string) (*FileContentResponse, error)
+	CreateFile(ctx context.Context, providerType string, req *FileCreateRequest) (*FileObject, error)
+}
+
+// BatchItemRewriteFunc rewrites a decoded batch item body for provider submission.
+// The original batch item is provided so callers can preserve non-semantic JSON
+// structure when needed.
+type BatchItemRewriteFunc func(context.Context, BatchRequestItem, *DecodedBatchItemRequest) (json.RawMessage, error)
+
+// BatchRewriteResult captures the normalized request plus any gateway-only
+// metadata derived while rewriting inline or file-backed batch sources.
+type BatchRewriteResult struct {
+	Request              *BatchRequest
+	RequestEndpointHints map[string]string
+	OriginalInputFileID  string
+	RewrittenInputFileID string
+}
+
+// RewriteBatchSource normalizes both inline and file-backed batch sources
+// using the same typed per-item rewrite callback.
+func RewriteBatchSource(
+	ctx context.Context,
+	providerType string,
+	req *BatchRequest,
+	fileTransport BatchFileTransport,
+	operations []string,
+	rewrite BatchItemRewriteFunc,
+) (*BatchRewriteResult, error) {
+	if req == nil {
+		return nil, NewInvalidRequestError("batch request is required", nil)
+	}
+	if rewrite == nil {
+		return nil, NewInvalidRequestError("batch rewrite function is required", nil)
+	}
+
+	forward, err := cloneBatchRequest(req)
+	if err != nil {
+		return nil, NewInvalidRequestError("failed to clone batch request", err)
+	}
+
+	result := &BatchRewriteResult{Request: forward}
+	hints := map[string]string{}
+
+	if len(forward.Requests) > 0 {
+		inlineHints, err := rewriteInlineBatchItems(ctx, forward, operations, rewrite)
+		if err != nil {
+			return nil, err
+		}
+		mergeBatchEndpointHints(hints, inlineHints)
+	}
+
+	if strings.TrimSpace(forward.InputFileID) != "" {
+		if fileTransport == nil {
+			return nil, NewInvalidRequestError("file routing is not supported by the current provider router", nil)
+		}
+		fileResult, err := rewriteInputFileBatch(ctx, providerType, forward, fileTransport, operations, rewrite)
+		if err != nil {
+			return nil, err
+		}
+		result.OriginalInputFileID = fileResult.OriginalInputFileID
+		result.RewrittenInputFileID = fileResult.RewrittenInputFileID
+		mergeBatchEndpointHints(hints, fileResult.RequestEndpointHints)
+	}
+
+	if len(hints) > 0 {
+		result.RequestEndpointHints = hints
+	}
+	return result, nil
+}
+
+func rewriteInlineBatchItems(ctx context.Context, req *BatchRequest, operations []string, rewrite BatchItemRewriteFunc) (map[string]string, error) {
+	hints := map[string]string{}
+	for i := range req.Requests {
+		item := req.Requests[i]
+		recordBatchEndpointHint(hints, req.Endpoint, item)
+
+		decoded, handled, err := MaybeDecodeKnownBatchItemRequest(req.Endpoint, item, operations...)
+		if err != nil {
+			return nil, NewInvalidRequestError(fmt.Sprintf("batch item %d: %s", i, err.Error()), err)
+		}
+		if !handled {
+			continue
+		}
+
+		body, err := rewrite(ctx, item, decoded)
+		if err != nil {
+			return nil, err
+		}
+		req.Requests[i].Body = CloneRawJSON(body)
+	}
+	if len(hints) == 0 {
+		return nil, nil
+	}
+	return hints, nil
+}
+
+func rewriteInputFileBatch(
+	ctx context.Context,
+	providerType string,
+	req *BatchRequest,
+	fileTransport BatchFileTransport,
+	operations []string,
+	rewrite BatchItemRewriteFunc,
+) (*BatchRewriteResult, error) {
+	resp, err := fileTransport.GetFileContent(ctx, providerType, req.InputFileID)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, NewProviderError(providerType, http.StatusBadGateway, "provider returned empty file content response", nil)
+	}
+
+	rewrittenContent, hints, changed, err := rewriteBatchJSONLContent(ctx, req.Endpoint, resp.Data, operations, rewrite)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &BatchRewriteResult{
+		OriginalInputFileID: req.InputFileID,
+	}
+	if len(hints) > 0 {
+		result.RequestEndpointHints = hints
+	}
+	if !changed {
+		return result, nil
+	}
+
+	filename := strings.TrimSpace(resp.Filename)
+	if filename == "" {
+		filename = "batch-input.jsonl"
+	}
+
+	created, err := fileTransport.CreateFile(ctx, providerType, &FileCreateRequest{
+		Purpose:  "batch",
+		Filename: filename,
+		Content:  rewrittenContent,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if created == nil || strings.TrimSpace(created.ID) == "" {
+		return nil, NewProviderError(providerType, http.StatusBadGateway, "provider returned empty file object for rewritten batch input", nil)
+	}
+
+	req.InputFileID = created.ID
+	result.RewrittenInputFileID = created.ID
+	return result, nil
+}
+
+func rewriteBatchJSONLContent(
+	ctx context.Context,
+	defaultEndpoint string,
+	data []byte,
+	operations []string,
+	rewrite BatchItemRewriteFunc,
+) ([]byte, map[string]string, bool, error) {
+	if len(data) == 0 {
+		return data, nil, false, nil
+	}
+
+	lines := bytes.SplitAfter(data, []byte("\n"))
+	if len(lines) > 0 && len(lines[len(lines)-1]) == 0 {
+		lines = lines[:len(lines)-1]
+	}
+
+	hints := map[string]string{}
+	var out bytes.Buffer
+	changed := false
+
+	for i, rawLine := range lines {
+		lineNo := i + 1
+		hasNewline := bytes.HasSuffix(rawLine, []byte("\n"))
+		line := rawLine
+		if hasNewline {
+			line = line[:len(line)-1]
+		}
+		if len(line) > 0 && line[len(line)-1] == '\r' {
+			line = line[:len(line)-1]
+		}
+		if len(bytes.TrimSpace(line)) == 0 {
+			out.Write(rawLine)
+			continue
+		}
+
+		var item BatchRequestItem
+		if err := json.Unmarshal(line, &item); err != nil {
+			return nil, nil, false, NewInvalidRequestError(
+				fmt.Sprintf("invalid batch input file line %d: %s", lineNo, err.Error()),
+				err,
+			)
+		}
+		recordBatchEndpointHint(hints, defaultEndpoint, item)
+
+		decoded, handled, err := MaybeDecodeKnownBatchItemRequest(defaultEndpoint, item, operations...)
+		if err != nil {
+			return nil, nil, false, wrapBatchInputFileLineError(lineNo, err)
+		}
+		if !handled {
+			out.Write(rawLine)
+			continue
+		}
+
+		body, err := rewrite(ctx, item, decoded)
+		if err != nil {
+			return nil, nil, false, wrapBatchInputFileLineError(lineNo, err)
+		}
+		if jsonSemanticallyEqual(item.Body, body) {
+			out.Write(rawLine)
+			continue
+		}
+
+		item.Body = CloneRawJSON(body)
+		encoded, err := json.Marshal(item)
+		if err != nil {
+			return nil, nil, false, NewInvalidRequestError(
+				fmt.Sprintf("failed to encode batch input file line %d", lineNo),
+				err,
+			)
+		}
+		out.Write(encoded)
+		if hasNewline {
+			out.WriteByte('\n')
+		}
+		changed = true
+	}
+
+	if len(hints) == 0 {
+		hints = nil
+	}
+	return out.Bytes(), hints, changed, nil
+}
+
+func wrapBatchInputFileLineError(lineNo int, err error) error {
+	if err == nil {
+		return nil
+	}
+	var gatewayErr *GatewayError
+	if errors.As(err, &gatewayErr) {
+		if gatewayErr.Type == ErrorTypeInvalidRequest {
+			return NewInvalidRequestError(fmt.Sprintf("batch input file line %d: %s", lineNo, gatewayErr.Message), err)
+		}
+		return err
+	}
+	return NewInvalidRequestError(fmt.Sprintf("batch input file line %d: %s", lineNo, err.Error()), err)
+}
+
+func recordBatchEndpointHint(hints map[string]string, defaultEndpoint string, item BatchRequestItem) {
+	if hints == nil || strings.TrimSpace(item.CustomID) == "" {
+		return
+	}
+	endpoint := NormalizeOperationPath(ResolveBatchItemEndpoint(defaultEndpoint, item.URL))
+	if endpoint == "" {
+		return
+	}
+	hints[item.CustomID] = endpoint
+}
+
+func mergeBatchEndpointHints(dst, src map[string]string) {
+	if len(src) == 0 {
+		return
+	}
+	for customID, endpoint := range src {
+		dst[customID] = endpoint
+	}
+}
+
+func cloneBatchRequest(req *BatchRequest) (*BatchRequest, error) {
+	raw, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	var cloned BatchRequest
+	if err := json.Unmarshal(raw, &cloned); err != nil {
+		return nil, err
+	}
+	return &cloned, nil
+}
+
+func jsonSemanticallyEqual(left, right []byte) bool {
+	var leftValue any
+	if err := json.Unmarshal(left, &leftValue); err != nil {
+		return bytes.Equal(bytes.TrimSpace(left), bytes.TrimSpace(right))
+	}
+	var rightValue any
+	if err := json.Unmarshal(right, &rightValue); err != nil {
+		return bytes.Equal(bytes.TrimSpace(left), bytes.TrimSpace(right))
+	}
+	return reflectDeepEqualJSON(leftValue, rightValue)
+}
+
+func reflectDeepEqualJSON(left, right any) bool {
+	leftJSON, leftErr := json.Marshal(left)
+	rightJSON, rightErr := json.Marshal(right)
+	if leftErr != nil || rightErr != nil {
+		return false
+	}
+	return bytes.Equal(leftJSON, rightJSON)
+}

--- a/internal/core/batch_preparation_test.go
+++ b/internal/core/batch_preparation_test.go
@@ -1,0 +1,60 @@
+package core
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCloneBatchRequestDeepCopiesNestedFields(t *testing.T) {
+	original := &BatchRequest{
+		InputFileID:      "file_source",
+		Endpoint:         "/v1/chat/completions",
+		CompletionWindow: "24h",
+		Metadata: map[string]string{
+			"provider": "openai",
+		},
+		Requests: []BatchRequestItem{
+			{
+				CustomID: "chat-1",
+				Method:   "POST",
+				URL:      "/v1/chat/completions",
+				Body:     json.RawMessage(`{"model":"smart","messages":[{"role":"user","content":"hi"}]}`),
+				ExtraFields: map[string]json.RawMessage{
+					"x_item": json.RawMessage(`{"trace":true}`),
+				},
+			},
+		},
+		ExtraFields: map[string]json.RawMessage{
+			"x_top": json.RawMessage(`{"debug":true}`),
+		},
+	}
+
+	cloned := cloneBatchRequest(original)
+	if cloned == nil {
+		t.Fatal("cloneBatchRequest() returned nil")
+	}
+
+	cloned.Metadata["provider"] = "anthropic"
+	cloned.Requests[0].CustomID = "chat-2"
+	cloned.Requests[0].Body[10] = 'X'
+	itemExtra := cloned.Requests[0].ExtraFields["x_item"]
+	itemExtra[9] = 'f'
+	topExtra := cloned.ExtraFields["x_top"]
+	topExtra[9] = 'f'
+
+	if got := original.Metadata["provider"]; got != "openai" {
+		t.Fatalf("original metadata mutated to %q", got)
+	}
+	if got := original.Requests[0].CustomID; got != "chat-1" {
+		t.Fatalf("original custom_id mutated to %q", got)
+	}
+	if got := string(original.Requests[0].Body); got != `{"model":"smart","messages":[{"role":"user","content":"hi"}]}` {
+		t.Fatalf("original body mutated to %s", got)
+	}
+	if got := string(original.Requests[0].ExtraFields["x_item"]); got != `{"trace":true}` {
+		t.Fatalf("original item extra mutated to %s", got)
+	}
+	if got := string(original.ExtraFields["x_top"]); got != `{"debug":true}` {
+		t.Fatalf("original top extra mutated to %s", got)
+	}
+}

--- a/internal/core/context.go
+++ b/internal/core/context.go
@@ -12,6 +12,8 @@ const (
 	requestSnapshotKey contextKey = "request-snapshot"
 	// whiteBoxPromptKey stores the best-effort semantic extraction for the request.
 	whiteBoxPromptKey contextKey = "white-box-prompt"
+	// requestModelResolutionKey stores the resolved request selector chosen for execution.
+	requestModelResolutionKey contextKey = "request-model-resolution"
 
 	// enforceReturningUsageDataKey stores whether streaming requests should ask providers
 	// to include usage when the provider supports it.
@@ -59,6 +61,21 @@ func GetWhiteBoxPrompt(ctx context.Context) *WhiteBoxPrompt {
 	if v := ctx.Value(whiteBoxPromptKey); v != nil {
 		if prompt, ok := v.(*WhiteBoxPrompt); ok {
 			return prompt
+		}
+	}
+	return nil
+}
+
+// WithRequestModelResolution returns a new context with the resolved request selector attached.
+func WithRequestModelResolution(ctx context.Context, resolution *RequestModelResolution) context.Context {
+	return context.WithValue(ctx, requestModelResolutionKey, resolution)
+}
+
+// GetRequestModelResolution retrieves the resolved request selector from the context.
+func GetRequestModelResolution(ctx context.Context) *RequestModelResolution {
+	if v := ctx.Value(requestModelResolutionKey); v != nil {
+		if resolution, ok := v.(*RequestModelResolution); ok {
+			return resolution
 		}
 	}
 	return nil

--- a/internal/core/context.go
+++ b/internal/core/context.go
@@ -14,6 +14,8 @@ const (
 	whiteBoxPromptKey contextKey = "white-box-prompt"
 	// requestModelResolutionKey stores the resolved request selector chosen for execution.
 	requestModelResolutionKey contextKey = "request-model-resolution"
+	// batchPreparationMetadataKey stores request-scoped batch preprocessing metadata.
+	batchPreparationMetadataKey contextKey = "batch-preparation-metadata"
 
 	// enforceReturningUsageDataKey stores whether streaming requests should ask providers
 	// to include usage when the provider supports it.
@@ -76,6 +78,21 @@ func GetRequestModelResolution(ctx context.Context) *RequestModelResolution {
 	if v := ctx.Value(requestModelResolutionKey); v != nil {
 		if resolution, ok := v.(*RequestModelResolution); ok {
 			return resolution
+		}
+	}
+	return nil
+}
+
+// WithBatchPreparationMetadata returns a new context with batch preprocessing metadata attached.
+func WithBatchPreparationMetadata(ctx context.Context, metadata *BatchPreparationMetadata) context.Context {
+	return context.WithValue(ctx, batchPreparationMetadataKey, metadata)
+}
+
+// GetBatchPreparationMetadata retrieves batch preprocessing metadata from the context.
+func GetBatchPreparationMetadata(ctx context.Context) *BatchPreparationMetadata {
+	if v := ctx.Value(batchPreparationMetadataKey); v != nil {
+		if metadata, ok := v.(*BatchPreparationMetadata); ok {
+			return metadata
 		}
 	}
 	return nil

--- a/internal/core/interfaces.go
+++ b/internal/core/interfaces.go
@@ -86,6 +86,13 @@ type NativeFileRoutableProvider interface {
 	GetFileContent(ctx context.Context, providerType, id string) (*FileContentResponse, error)
 }
 
+// NativeFileProviderTypeLister exposes registered provider types that support
+// native file operations. This is an internal capability inventory and must not
+// depend on the public model catalog.
+type NativeFileProviderTypeLister interface {
+	NativeFileProviderTypes() []string
+}
+
 // RoutableProvider extends Provider with routing capability.
 // This is implemented by the Router which uses a model registry
 // to determine if a model is supported.

--- a/internal/core/request_model_resolution.go
+++ b/internal/core/request_model_resolution.go
@@ -18,6 +18,9 @@ func (r *RequestModelResolution) RequestedQualifiedModel() string {
 	if r.RequestedProvider == "" {
 		return r.RequestedModel
 	}
+	if selector, err := ParseModelSelector(r.RequestedModel, r.RequestedProvider); err == nil {
+		return selector.QualifiedModel()
+	}
 	return r.RequestedProvider + "/" + r.RequestedModel
 }
 

--- a/internal/core/request_model_resolution.go
+++ b/internal/core/request_model_resolution.go
@@ -1,0 +1,30 @@
+package core
+
+// RequestModelResolution captures the requested model selector at ingress and
+// the concrete selector chosen for execution after alias resolution.
+type RequestModelResolution struct {
+	RequestedModel    string
+	RequestedProvider string
+	ResolvedSelector  ModelSelector
+	ProviderType      string
+	AliasApplied      bool
+}
+
+// RequestedQualifiedModel reconstructs the raw requested selector.
+func (r *RequestModelResolution) RequestedQualifiedModel() string {
+	if r == nil {
+		return ""
+	}
+	if r.RequestedProvider == "" {
+		return r.RequestedModel
+	}
+	return r.RequestedProvider + "/" + r.RequestedModel
+}
+
+// ResolvedQualifiedModel returns the concrete qualified model selected for execution.
+func (r *RequestModelResolution) ResolvedQualifiedModel() string {
+	if r == nil {
+		return ""
+	}
+	return r.ResolvedSelector.QualifiedModel()
+}

--- a/internal/core/request_model_resolution_test.go
+++ b/internal/core/request_model_resolution_test.go
@@ -1,0 +1,43 @@
+package core
+
+import "testing"
+
+func TestRequestModelResolutionRequestedQualifiedModel(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *RequestModelResolution
+		want string
+	}{
+		{
+			name: "raw alias with slash and no explicit provider stays raw",
+			in: &RequestModelResolution{
+				RequestedModel: "anthropic/claude-opus-4-6",
+			},
+			want: "anthropic/claude-opus-4-6",
+		},
+		{
+			name: "explicit provider with provider-prefixed model normalizes once",
+			in: &RequestModelResolution{
+				RequestedModel:    "openai/gpt-4o",
+				RequestedProvider: "openai",
+			},
+			want: "openai/gpt-4o",
+		},
+		{
+			name: "explicit provider without prefix becomes qualified model",
+			in: &RequestModelResolution{
+				RequestedModel:    "gpt-4o",
+				RequestedProvider: "openai",
+			},
+			want: "openai/gpt-4o",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.in.RequestedQualifiedModel(); got != tt.want {
+				t.Fatalf("RequestedQualifiedModel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/guardrails/provider.go
+++ b/internal/guardrails/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"strings"
 
 	"gomodel/internal/core"
@@ -377,7 +378,13 @@ func (g *GuardedProvider) CreateBatch(ctx context.Context, providerType string, 
 		return nil, err
 	}
 	g.recordBatchPreparation(ctx, req, result.Request)
-	return bp.CreateBatch(ctx, providerType, result.Request)
+	resp, err := bp.CreateBatch(ctx, providerType, result.Request)
+	if err != nil {
+		g.cleanupBatchRewriteFile(ctx, providerType, result.RewrittenInputFileID)
+		return nil, err
+	}
+	g.cleanupSupersededBatchRewriteFile(ctx, providerType, result.RewrittenInputFileID)
+	return resp, nil
 }
 
 // CreateBatchWithHints delegates hint-aware native batch creation while preserving
@@ -398,8 +405,10 @@ func (g *GuardedProvider) CreateBatchWithHints(ctx context.Context, providerType
 	g.recordBatchPreparation(ctx, req, result.Request)
 	resp, hints, err := hinted.CreateBatchWithHints(ctx, providerType, result.Request)
 	if err != nil {
+		g.cleanupBatchRewriteFile(ctx, providerType, result.RewrittenInputFileID)
 		return nil, nil, err
 	}
+	g.cleanupSupersededBatchRewriteFile(ctx, providerType, result.RewrittenInputFileID)
 	return resp, mergeBatchHints(result.RequestEndpointHints, hints), nil
 }
 
@@ -511,6 +520,35 @@ func (g *GuardedProvider) recordBatchPreparation(ctx context.Context, original, 
 		return
 	}
 	metadata.RecordInputFileRewrite(original.InputFileID, rewritten.InputFileID)
+}
+
+func (g *GuardedProvider) cleanupSupersededBatchRewriteFile(ctx context.Context, providerType, localRewrittenFileID string) {
+	localRewrittenFileID = strings.TrimSpace(localRewrittenFileID)
+	if localRewrittenFileID == "" {
+		return
+	}
+	metadata := core.GetBatchPreparationMetadata(ctx)
+	if metadata == nil {
+		return
+	}
+	if strings.TrimSpace(metadata.RewrittenInputFileID) == localRewrittenFileID {
+		return
+	}
+	g.cleanupBatchRewriteFile(ctx, providerType, localRewrittenFileID)
+}
+
+func (g *GuardedProvider) cleanupBatchRewriteFile(ctx context.Context, providerType, fileID string) {
+	fileID = strings.TrimSpace(fileID)
+	if fileID == "" {
+		return
+	}
+	files, err := g.nativeFileRouter()
+	if err != nil {
+		return
+	}
+	if _, err := files.DeleteFile(ctx, providerType, fileID); err != nil {
+		slog.Warn("failed to delete rewritten batch input file", "provider", providerType, "file_id", fileID, "error", err)
+	}
 }
 
 func mergeBatchHints(left, right map[string]string) map[string]string {

--- a/internal/guardrails/provider.go
+++ b/internal/guardrails/provider.go
@@ -524,7 +524,7 @@ func mergeBatchHints(left, right map[string]string) map[string]string {
 		}
 		return merged
 	}
-	merged := make(map[string]string, len(left)+len(right))
+	merged := make(map[string]string, len(left))
 	for key, value := range left {
 		merged[key] = value
 	}

--- a/internal/guardrails/provider.go
+++ b/internal/guardrails/provider.go
@@ -59,6 +59,15 @@ func (g *GuardedProvider) ModelCount() int {
 	return -1
 }
 
+// NativeFileProviderTypes delegates provider capability inventory to the inner
+// provider when available.
+func (g *GuardedProvider) NativeFileProviderTypes() []string {
+	if typed, ok := g.inner.(core.NativeFileProviderTypeLister); ok {
+		return typed.NativeFileProviderTypes()
+	}
+	return nil
+}
+
 // ChatCompletion extracts messages, applies guardrails, then routes the request.
 func (g *GuardedProvider) ChatCompletion(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
 	modified, err := g.processChat(ctx, req)

--- a/internal/guardrails/provider.go
+++ b/internal/guardrails/provider.go
@@ -122,6 +122,14 @@ func (g *GuardedProvider) nativeBatchRouter() (core.NativeBatchRoutableProvider,
 	return bp, nil
 }
 
+func (g *GuardedProvider) nativeBatchHintRouter() (core.NativeBatchHintRoutableProvider, error) {
+	hinted, ok := g.inner.(core.NativeBatchHintRoutableProvider)
+	if !ok {
+		return nil, core.NewInvalidRequestError("batch hint routing is not supported by the current provider router", nil)
+	}
+	return hinted, nil
+}
+
 func (g *GuardedProvider) nativeFileRouter() (core.NativeFileRoutableProvider, error) {
 	fp, ok := g.inner.(core.NativeFileRoutableProvider)
 	if !ok {
@@ -138,61 +146,40 @@ func (g *GuardedProvider) passthroughRouter() (core.RoutablePassthrough, error) 
 	return pp, nil
 }
 
-func (g *GuardedProvider) processBatchRequest(ctx context.Context, req *core.BatchRequest) (*core.BatchRequest, error) {
-	if req == nil || len(req.Requests) == 0 {
-		return req, nil
+func (g *GuardedProvider) processBatchRequest(ctx context.Context, providerType string, req *core.BatchRequest) (*core.BatchRewriteResult, error) {
+	files, err := g.nativeFileRouter()
+	if err != nil {
+		files = nil
 	}
+	return core.RewriteBatchSource(ctx, providerType, req, files, []string{"chat_completions", "responses"}, g.rewriteBatchDecodedItem)
+}
 
-	out := *req
-	out.Requests = make([]core.BatchRequestItem, len(req.Requests))
-	copy(out.Requests, req.Requests)
-
-	for i := range out.Requests {
-		item := out.Requests[i]
-		decoded, handled, err := core.MaybeDecodeKnownBatchItemRequest(req.Endpoint, item, "chat_completions", "responses")
-		if err != nil {
-			operation := core.DescribeEndpointPath(core.NormalizeOperationPath(core.ResolveBatchItemEndpoint(req.Endpoint, item.URL))).Operation
-			label := strings.TrimSpace(strings.ReplaceAll(operation, "_", " "))
-			if label == "" {
-				return nil, core.NewInvalidRequestError("invalid batch item request", err)
+func (g *GuardedProvider) rewriteBatchDecodedItem(ctx context.Context, item core.BatchRequestItem, decoded *core.DecodedBatchItemRequest) (json.RawMessage, error) {
+	itemBody := core.CloneRawJSON(item.Body)
+	return core.DispatchDecodedBatchItem(decoded, core.DecodedBatchItemHandlers[json.RawMessage]{
+		Chat: func(original *core.ChatRequest) (json.RawMessage, error) {
+			modified, err := g.processChat(ctx, original)
+			if err != nil {
+				return nil, err
 			}
-			return nil, core.NewInvalidRequestError("invalid "+label+" request in batch item", err)
-		}
-		if !handled {
-			continue
-		}
-
-		body, err := core.DispatchDecodedBatchItem(decoded, core.DecodedBatchItemHandlers[json.RawMessage]{
-			Chat: func(original *core.ChatRequest) (json.RawMessage, error) {
-				modified, err := g.processChat(ctx, original)
-				if err != nil {
-					return nil, err
-				}
-				body, err := rewriteGuardedChatBatchBody(item.Body, original, modified)
-				if err != nil {
-					return nil, core.NewInvalidRequestError("failed to encode guarded chat batch item", err)
-				}
-				return body, nil
-			},
-			Responses: func(original *core.ResponsesRequest) (json.RawMessage, error) {
-				modified, err := g.processResponses(ctx, original)
-				if err != nil {
-					return nil, err
-				}
-				body, err := rewriteGuardedResponsesBatchBody(item.Body, modified)
-				if err != nil {
-					return nil, core.NewInvalidRequestError("failed to encode guarded responses batch item", err)
-				}
-				return body, nil
-			},
-		})
-		if err != nil {
-			return nil, err
-		}
-		out.Requests[i].Body = body
-	}
-
-	return &out, nil
+			body, err := rewriteGuardedChatBatchBody(itemBody, original, modified)
+			if err != nil {
+				return nil, core.NewInvalidRequestError("failed to encode guarded chat batch item", err)
+			}
+			return body, nil
+		},
+		Responses: func(original *core.ResponsesRequest) (json.RawMessage, error) {
+			modified, err := g.processResponses(ctx, original)
+			if err != nil {
+				return nil, err
+			}
+			body, err := rewriteGuardedResponsesBatchBody(itemBody, modified)
+			if err != nil {
+				return nil, core.NewInvalidRequestError("failed to encode guarded responses batch item", err)
+			}
+			return body, nil
+		},
+	})
 }
 
 func rewriteGuardedChatBatchBody(originalBody json.RawMessage, original *core.ChatRequest, modified *core.ChatRequest) (json.RawMessage, error) {
@@ -385,11 +372,35 @@ func (g *GuardedProvider) CreateBatch(ctx context.Context, providerType string, 
 		return bp.CreateBatch(ctx, providerType, req)
 	}
 
-	modifiedReq, err := g.processBatchRequest(ctx, req)
+	result, err := g.processBatchRequest(ctx, providerType, req)
 	if err != nil {
 		return nil, err
 	}
-	return bp.CreateBatch(ctx, providerType, modifiedReq)
+	g.recordBatchPreparation(ctx, req, result.Request)
+	return bp.CreateBatch(ctx, providerType, result.Request)
+}
+
+// CreateBatchWithHints delegates hint-aware native batch creation while preserving
+// guardrail batch processing when enabled.
+func (g *GuardedProvider) CreateBatchWithHints(ctx context.Context, providerType string, req *core.BatchRequest) (*core.BatchResponse, map[string]string, error) {
+	hinted, err := g.nativeBatchHintRouter()
+	if err != nil {
+		return nil, nil, err
+	}
+	if !g.options.EnableForBatchProcessing {
+		return hinted.CreateBatchWithHints(ctx, providerType, req)
+	}
+
+	result, err := g.processBatchRequest(ctx, providerType, req)
+	if err != nil {
+		return nil, nil, err
+	}
+	g.recordBatchPreparation(ctx, req, result.Request)
+	resp, hints, err := hinted.CreateBatchWithHints(ctx, providerType, result.Request)
+	if err != nil {
+		return nil, nil, err
+	}
+	return resp, mergeBatchHints(result.RequestEndpointHints, hints), nil
 }
 
 // GetBatch delegates native batch retrieval.
@@ -426,6 +437,24 @@ func (g *GuardedProvider) GetBatchResults(ctx context.Context, providerType, id 
 		return nil, err
 	}
 	return bp.GetBatchResults(ctx, providerType, id)
+}
+
+// GetBatchResultsWithHints delegates hint-aware native batch results retrieval.
+func (g *GuardedProvider) GetBatchResultsWithHints(ctx context.Context, providerType, id string, endpointByCustomID map[string]string) (*core.BatchResultsResponse, error) {
+	hinted, err := g.nativeBatchHintRouter()
+	if err != nil {
+		return nil, err
+	}
+	return hinted.GetBatchResultsWithHints(ctx, providerType, id, endpointByCustomID)
+}
+
+// ClearBatchResultHints delegates cleanup of transient provider-side result hints.
+func (g *GuardedProvider) ClearBatchResultHints(providerType, batchID string) {
+	hinted, err := g.nativeBatchHintRouter()
+	if err != nil {
+		return
+	}
+	hinted.ClearBatchResultHints(providerType, batchID)
 }
 
 // CreateFile delegates native file upload.
@@ -471,6 +500,38 @@ func (g *GuardedProvider) GetFileContent(ctx context.Context, providerType, id s
 		return nil, err
 	}
 	return fp.GetFileContent(ctx, providerType, id)
+}
+
+func (g *GuardedProvider) recordBatchPreparation(ctx context.Context, original, rewritten *core.BatchRequest) {
+	if ctx == nil || original == nil || rewritten == nil {
+		return
+	}
+	metadata := core.GetBatchPreparationMetadata(ctx)
+	if metadata == nil {
+		return
+	}
+	metadata.RecordInputFileRewrite(original.InputFileID, rewritten.InputFileID)
+}
+
+func mergeBatchHints(left, right map[string]string) map[string]string {
+	if len(left) == 0 {
+		if len(right) == 0 {
+			return nil
+		}
+		merged := make(map[string]string, len(right))
+		for key, value := range right {
+			merged[key] = value
+		}
+		return merged
+	}
+	merged := make(map[string]string, len(left)+len(right))
+	for key, value := range left {
+		merged[key] = value
+	}
+	for key, value := range right {
+		merged[key] = value
+	}
+	return merged
 }
 
 // Passthrough delegates opaque provider-native requests without semantic guardrail processing.

--- a/internal/guardrails/provider_test.go
+++ b/internal/guardrails/provider_test.go
@@ -18,8 +18,10 @@ type mockRoutableProvider struct {
 	chatReq           *core.ChatRequest
 	responsesReq      *core.ResponsesRequest
 	batchReq          *core.BatchRequest
+	createBatchErr    error
 	fileContent       *core.FileContentResponse
 	fileCreates       []*core.FileCreateRequest
+	fileDeletes       []string
 	fileObject        *core.FileObject
 	passthroughReq    *core.PassthroughRequest
 	passthroughType   string
@@ -69,6 +71,9 @@ func (m *mockRoutableProvider) Embeddings(_ context.Context, req *core.Embedding
 
 func (m *mockRoutableProvider) CreateBatch(_ context.Context, _ string, req *core.BatchRequest) (*core.BatchResponse, error) {
 	m.batchReq = req
+	if m.createBatchErr != nil {
+		return nil, m.createBatchErr
+	}
 	return &core.BatchResponse{ID: "batch_1", Object: "batch", Status: "in_progress"}, nil
 }
 
@@ -118,6 +123,7 @@ func (m *mockRoutableProvider) GetFile(_ context.Context, _ string, id string) (
 }
 
 func (m *mockRoutableProvider) DeleteFile(_ context.Context, _ string, id string) (*core.FileDeleteResponse, error) {
+	m.fileDeletes = append(m.fileDeletes, id)
 	return &core.FileDeleteResponse{ID: id, Object: "file", Deleted: true}, nil
 }
 
@@ -1146,6 +1152,33 @@ func TestGuardedProvider_CreateBatch_BatchGuardrailsEnabled_InputFile(t *testing
 	}
 	if got := string(inner.fileCreates[0].Content); !strings.Contains(got, "\"role\":\"system\"") {
 		t.Fatalf("rewritten file content = %s, want injected system message", got)
+	}
+}
+
+func TestGuardedProvider_CreateBatch_BatchGuardrailsEnabled_InputFileCleansUpOnFailure(t *testing.T) {
+	inner := &mockRoutableProvider{
+		createBatchErr: context.Canceled,
+		fileContent: &core.FileContentResponse{
+			ID:       "file_source",
+			Filename: "batch.jsonl",
+			Data:     []byte("{\"custom_id\":\"chat-1\",\"method\":\"POST\",\"url\":\"/v1/chat/completions\",\"body\":{\"model\":\"gpt-4\",\"messages\":[{\"role\":\"user\",\"content\":\"hello\"}]}}\n"),
+		},
+		fileObject: &core.FileObject{ID: "file_rewritten", Object: "file", Filename: "batch.jsonl", Purpose: "batch"},
+	}
+	pipeline := NewPipeline()
+	gr, _ := NewSystemPromptGuardrail("test", SystemPromptInject, "guardrail system")
+	pipeline.Add(gr, 0)
+	guarded := NewGuardedProviderWithOptions(inner, pipeline, Options{EnableForBatchProcessing: true})
+
+	_, err := guarded.CreateBatch(context.Background(), "mock", &core.BatchRequest{
+		InputFileID: "file_source",
+		Endpoint:    "/v1/chat/completions",
+	})
+	if err == nil {
+		t.Fatal("CreateBatch() error = nil, want non-nil")
+	}
+	if len(inner.fileDeletes) != 1 || inner.fileDeletes[0] != "file_rewritten" {
+		t.Fatalf("fileDeletes = %v, want [file_rewritten]", inner.fileDeletes)
 	}
 }
 

--- a/internal/guardrails/provider_test.go
+++ b/internal/guardrails/provider_test.go
@@ -18,6 +18,9 @@ type mockRoutableProvider struct {
 	chatReq           *core.ChatRequest
 	responsesReq      *core.ResponsesRequest
 	batchReq          *core.BatchRequest
+	fileContent       *core.FileContentResponse
+	fileCreates       []*core.FileCreateRequest
+	fileObject        *core.FileObject
 	passthroughReq    *core.PassthroughRequest
 	passthroughType   string
 }
@@ -83,6 +86,46 @@ func (m *mockRoutableProvider) CancelBatch(_ context.Context, _, _ string) (*cor
 
 func (m *mockRoutableProvider) GetBatchResults(_ context.Context, _, _ string) (*core.BatchResultsResponse, error) {
 	return &core.BatchResultsResponse{Object: "list", BatchID: "batch_1"}, nil
+}
+
+func (m *mockRoutableProvider) CreateBatchWithHints(ctx context.Context, providerType string, req *core.BatchRequest) (*core.BatchResponse, map[string]string, error) {
+	resp, err := m.CreateBatch(ctx, providerType, req)
+	return resp, map[string]string{"chat-1": "/v1/chat/completions"}, err
+}
+
+func (m *mockRoutableProvider) GetBatchResultsWithHints(_ context.Context, _, _ string, _ map[string]string) (*core.BatchResultsResponse, error) {
+	return &core.BatchResultsResponse{Object: "list", BatchID: "batch_1"}, nil
+}
+
+func (m *mockRoutableProvider) ClearBatchResultHints(_ string, _ string) {}
+
+func (m *mockRoutableProvider) CreateFile(_ context.Context, _ string, req *core.FileCreateRequest) (*core.FileObject, error) {
+	copy := *req
+	copy.Content = append([]byte(nil), req.Content...)
+	m.fileCreates = append(m.fileCreates, &copy)
+	if m.fileObject != nil {
+		return m.fileObject, nil
+	}
+	return &core.FileObject{ID: "file_rewritten", Object: "file", Filename: req.Filename, Purpose: req.Purpose}, nil
+}
+
+func (m *mockRoutableProvider) ListFiles(_ context.Context, _ string, _ string, _ int, _ string) (*core.FileListResponse, error) {
+	return &core.FileListResponse{Object: "list"}, nil
+}
+
+func (m *mockRoutableProvider) GetFile(_ context.Context, _ string, id string) (*core.FileObject, error) {
+	return &core.FileObject{ID: id, Object: "file"}, nil
+}
+
+func (m *mockRoutableProvider) DeleteFile(_ context.Context, _ string, id string) (*core.FileDeleteResponse, error) {
+	return &core.FileDeleteResponse{ID: id, Object: "file", Deleted: true}, nil
+}
+
+func (m *mockRoutableProvider) GetFileContent(_ context.Context, _ string, id string) (*core.FileContentResponse, error) {
+	if m.fileContent != nil {
+		return m.fileContent, nil
+	}
+	return &core.FileContentResponse{ID: id, Filename: "batch.jsonl", Data: []byte("{}\n")}, nil
 }
 
 func (m *mockRoutableProvider) Passthrough(_ context.Context, providerType string, req *core.PassthroughRequest) (*core.PassthroughResponse, error) {
@@ -1068,6 +1111,41 @@ func TestGuardedProvider_CreateBatch_BatchGuardrailsEnabled(t *testing.T) {
 	}
 	if len(chatReq.Messages) != 2 || chatReq.Messages[0].Role != "system" {
 		t.Fatalf("expected guarded batch chat request, got: %+v", chatReq.Messages)
+	}
+}
+
+func TestGuardedProvider_CreateBatch_BatchGuardrailsEnabled_InputFile(t *testing.T) {
+	inner := &mockRoutableProvider{
+		fileContent: &core.FileContentResponse{
+			ID:       "file_source",
+			Filename: "batch.jsonl",
+			Data:     []byte("{\"custom_id\":\"chat-1\",\"method\":\"POST\",\"url\":\"/v1/chat/completions\",\"body\":{\"model\":\"gpt-4\",\"messages\":[{\"role\":\"user\",\"content\":\"hello\"}]}}\n"),
+		},
+		fileObject: &core.FileObject{ID: "file_rewritten", Object: "file", Filename: "batch.jsonl", Purpose: "batch"},
+	}
+	pipeline := NewPipeline()
+	gr, _ := NewSystemPromptGuardrail("test", SystemPromptInject, "guardrail system")
+	pipeline.Add(gr, 0)
+	guarded := NewGuardedProviderWithOptions(inner, pipeline, Options{EnableForBatchProcessing: true})
+
+	_, err := guarded.CreateBatch(context.Background(), "mock", &core.BatchRequest{
+		InputFileID: "file_source",
+		Endpoint:    "/v1/chat/completions",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inner.batchReq == nil {
+		t.Fatal("expected delegated batch request")
+	}
+	if inner.batchReq.InputFileID != "file_rewritten" {
+		t.Fatalf("input_file_id = %q, want file_rewritten", inner.batchReq.InputFileID)
+	}
+	if len(inner.fileCreates) != 1 {
+		t.Fatalf("len(fileCreates) = %d, want 1", len(inner.fileCreates))
+	}
+	if got := string(inner.fileCreates[0].Content); !strings.Contains(got, "\"role\":\"system\"") {
+		t.Fatalf("rewritten file content = %s, want injected system message", got)
 	}
 }
 

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -446,7 +446,8 @@ func (r *ModelRegistry) GetProvider(model string) core.Provider {
 	return nil
 }
 
-// GetModel returns the model info for the given model, or nil if not found
+// GetModel returns the registry-backed model info for the given model, or nil if not found.
+// Callers must treat the returned data as read-only.
 func (r *ModelRegistry) GetModel(model string) *ModelInfo {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -467,15 +468,28 @@ func (r *ModelRegistry) GetModel(model string) *ModelInfo {
 	return nil
 }
 
-// LookupModel returns a defensive copy of the concrete model for the given selector.
+// LookupModel returns a shallow copy of the concrete model for the given selector.
 // Qualified selectors use the configured provider name prefix when present.
 func (r *ModelRegistry) LookupModel(model string) (*core.Model, bool) {
-	info := r.GetModel(model)
-	if info == nil {
-		return nil, false
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	providerName, modelID := splitModelSelector(model)
+	if providerName != "" {
+		if providerModels, ok := r.modelsByProvider[providerName]; ok {
+			if info, exists := providerModels[modelID]; exists {
+				cloned := info.Model
+				return &cloned, true
+			}
+		}
+		// Fall through: the slash may be part of the model ID
 	}
-	cloned := info.Model
-	return &cloned, true
+
+	if info, ok := r.models[model]; ok {
+		cloned := info.Model
+		return &cloned, true
+	}
+	return nil, false
 }
 
 // Supports returns true if the registry has a provider for the given model
@@ -768,8 +782,9 @@ func (r *ModelRegistry) SetModelList(list *modeldata.ModelList, raw json.RawMess
 
 // EnrichModels re-applies model list metadata to all currently registered models.
 // Call this after SetModelList to update existing models with the new metadata.
-// Holds the write lock for the entire operation to prevent races with concurrent
-// readers (e.g. ListModels) that may read Model.Metadata.
+// Holds the write lock for the entire operation and replaces published ModelInfo
+// entries instead of mutating them in place so concurrent readers can safely keep
+// using older snapshots after unlocking.
 func (r *ModelRegistry) EnrichModels() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -784,7 +799,15 @@ func (r *ModelRegistry) EnrichModels() {
 	}
 
 	accessor := &registryAccessor{models: r.models, providerTypes: providerTypes}
+	accessor.replacements = make(map[*ModelInfo]*ModelInfo, len(r.models))
 	modeldata.Enrich(accessor, r.modelList)
+	for _, providerModels := range r.modelsByProvider {
+		for modelID, info := range providerModels {
+			if replacement, ok := accessor.replacements[info]; ok {
+				providerModels[modelID] = replacement
+			}
+		}
+	}
 	r.invalidateSortedCaches()
 }
 
@@ -840,11 +863,13 @@ func (r *ModelRegistry) snapshotProviderTypes() map[core.Provider]string {
 }
 
 // registryAccessor implements modeldata.ModelInfoAccessor.
-// The models map may be either a snapshot (Initialize, LoadFromCache) or the live
-// registry map (EnrichModels, which holds the write lock for the entire operation).
+// The models map may be either an unpublished snapshot (Initialize, LoadFromCache)
+// or the live registry map (EnrichModels, which uses replacements to preserve
+// immutability of already-published ModelInfo values).
 type registryAccessor struct {
 	models        map[string]*ModelInfo
 	providerTypes map[core.Provider]string
+	replacements  map[*ModelInfo]*ModelInfo
 }
 
 func (a *registryAccessor) ModelIDs() []string {
@@ -865,6 +890,14 @@ func (a *registryAccessor) GetProviderType(modelID string) string {
 
 func (a *registryAccessor) SetMetadata(modelID string, meta *core.ModelMetadata) {
 	if info, ok := a.models[modelID]; ok {
+		if a.replacements != nil {
+			cloned := *info
+			cloned.Model.Metadata = meta
+			replacement := &cloned
+			a.models[modelID] = replacement
+			a.replacements[info] = replacement
+			return
+		}
 		info.Model.Metadata = meta
 	}
 }

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -587,6 +587,29 @@ func (r *ModelRegistry) ProviderByType(providerType string) core.Provider {
 	return nil
 }
 
+// ProviderTypes returns the unique registered provider types in sorted order.
+// This inventory is independent of discovered models.
+func (r *ModelRegistry) ProviderTypes() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	seen := make(map[string]struct{}, len(r.providerTypes))
+	result := make([]string, 0, len(r.providerTypes))
+	for _, provider := range r.providers {
+		providerType := strings.TrimSpace(r.providerTypes[provider])
+		if providerType == "" {
+			continue
+		}
+		if _, exists := seen[providerType]; exists {
+			continue
+		}
+		seen[providerType] = struct{}{}
+		result = append(result, providerType)
+	}
+	sort.Strings(result)
+	return result
+}
+
 func splitModelSelector(model string) (providerName, modelID string) {
 	model = strings.TrimSpace(model)
 	if model == "" {

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -467,6 +467,17 @@ func (r *ModelRegistry) GetModel(model string) *ModelInfo {
 	return nil
 }
 
+// LookupModel returns a defensive copy of the concrete model for the given selector.
+// Qualified selectors use the configured provider name prefix when present.
+func (r *ModelRegistry) LookupModel(model string) (*core.Model, bool) {
+	info := r.GetModel(model)
+	if info == nil {
+		return nil, false
+	}
+	cloned := info.Model
+	return &cloned, true
+}
+
 // Supports returns true if the registry has a provider for the given model
 func (r *ModelRegistry) Supports(model string) bool {
 	r.mu.RLock()

--- a/internal/providers/registry_test.go
+++ b/internal/providers/registry_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"gomodel/internal/core"
+	"gomodel/internal/modeldata"
 )
 
 // registryMockProvider is a mock implementation of core.Provider for Registry testing.
@@ -217,6 +218,88 @@ func TestModelRegistry(t *testing.T) {
 		unknownInfo := registry.GetModel("unknown-model")
 		if unknownInfo != nil {
 			t.Errorf("expected nil for unknown model, got %+v", unknownInfo)
+		}
+	})
+
+	t.Run("EnrichModelsReplacesPublishedModelInfo", func(t *testing.T) {
+		registry := NewModelRegistry()
+
+		mock := &registryMockProvider{
+			name: "test-provider",
+			modelsResponse: &core.ModelsResponse{
+				Object: "list",
+				Data: []core.Model{
+					{
+						ID:      "test-model",
+						Object:  "model",
+						OwnedBy: "test-provider",
+					},
+				},
+			},
+		}
+		registry.RegisterProviderWithType(mock, "openai")
+		_ = registry.Initialize(context.Background())
+
+		before := registry.GetModel("test-model")
+		if before == nil {
+			t.Fatal("expected GetModel to return a published ModelInfo")
+		}
+		if before.Model.Metadata != nil {
+			t.Fatalf("expected initial metadata to be nil, got %#v", before.Model.Metadata)
+		}
+
+		raw := []byte(`{
+			"version": 1,
+			"updated_at": "2025-01-01T00:00:00Z",
+			"providers": {
+				"openai": {
+					"display_name": "OpenAI",
+					"api_type": "openai",
+					"supported_modes": ["chat"]
+				}
+			},
+			"models": {
+				"test-model": {
+					"display_name": "Test Model",
+					"modes": ["chat"]
+				}
+			},
+			"provider_models": {}
+		}`)
+		list, err := modeldata.Parse(raw)
+		if err != nil {
+			t.Fatalf("Parse() error = %v", err)
+		}
+		registry.SetModelList(list, raw)
+		registry.EnrichModels()
+
+		if before.Model.Metadata != nil {
+			t.Fatalf("expected previously published ModelInfo to remain unchanged, got %#v", before.Model.Metadata)
+		}
+
+		after := registry.GetModel("test-model")
+		if after == nil {
+			t.Fatal("expected GetModel to return an enriched ModelInfo")
+		}
+		if after == before {
+			t.Fatal("expected EnrichModels to replace the published ModelInfo pointer")
+		}
+		if after.Model.Metadata == nil {
+			t.Fatal("expected enriched metadata to be present")
+		}
+		if after.Model.Metadata.DisplayName != "Test Model" {
+			t.Fatalf("registry display name = %q, want Test Model", after.Model.Metadata.DisplayName)
+		}
+
+		lookup, ok := registry.LookupModel("test-model")
+		if !ok || lookup == nil {
+			t.Fatal("expected LookupModel to return the enriched model")
+		}
+		if lookup.Metadata == nil {
+			t.Fatal("expected LookupModel metadata to be present")
+		}
+		if lookup.Metadata.DisplayName != "Test Model" {
+			t.Fatalf("lookup display name = %q, want Test Model", lookup.Metadata.DisplayName)
 		}
 	})
 

--- a/internal/providers/router.go
+++ b/internal/providers/router.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 
 	"gomodel/internal/core"
@@ -28,6 +29,10 @@ type providerTypeRegistry interface {
 
 type initializedLookup interface {
 	IsInitialized() bool
+}
+
+type providerTypeLister interface {
+	ProviderTypes() []string
 }
 
 func registryUnavailableError(err error) error {
@@ -382,6 +387,47 @@ func (r *Router) providerByTypeRegistry(providerType string) core.Provider {
 		}
 	}
 	return r.providerByType(providerType)
+}
+
+func (r *Router) providerTypes() []string {
+	if typed, ok := r.lookup.(providerTypeLister); ok {
+		return typed.ProviderTypes()
+	}
+
+	seen := make(map[string]struct{})
+	result := make([]string, 0)
+	for _, model := range r.lookup.ListModels() {
+		providerType := strings.TrimSpace(r.lookup.GetProviderType(model.ID))
+		if providerType == "" {
+			continue
+		}
+		if _, exists := seen[providerType]; exists {
+			continue
+		}
+		seen[providerType] = struct{}{}
+		result = append(result, providerType)
+	}
+	sort.Strings(result)
+	return result
+}
+
+// NativeFileProviderTypes returns the registered provider types that support
+// native file operations. This inventory is independent of the public model
+// catalog whenever the underlying lookup can expose provider types directly.
+func (r *Router) NativeFileProviderTypes() []string {
+	providerTypes := r.providerTypes()
+	result := make([]string, 0, len(providerTypes))
+	for _, providerType := range providerTypes {
+		provider := r.providerByTypeRegistry(providerType)
+		if provider == nil {
+			continue
+		}
+		if _, ok := provider.(core.NativeFileProvider); !ok {
+			continue
+		}
+		result = append(result, providerType)
+	}
+	return result
 }
 
 // Passthrough routes an opaque provider-native request by provider type.

--- a/internal/responsecache/middleware_test.go
+++ b/internal/responsecache/middleware_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/labstack/echo/v5"
 
 	"gomodel/internal/cache"
+	"gomodel/internal/core"
 )
 
 func TestSimpleCacheMiddleware_CacheHit(t *testing.T) {
@@ -82,6 +83,21 @@ func TestSimpleCacheMiddleware_DifferentBodyDifferentKey(t *testing.T) {
 	e.ServeHTTP(rec2, req2)
 	if rec2.Header().Get("X-Cache") != "" {
 		t.Fatal("different body should miss cache")
+	}
+}
+
+func TestHashRequest_ResolvedModelChangesKey(t *testing.T) {
+	body := []byte(`{"model":"anthropic/claude-opus-4-6","messages":[{"role":"user","content":"hi"}]}`)
+
+	first := hashRequest("/v1/chat/completions", body, &core.RequestModelResolution{
+		ResolvedSelector: core.ModelSelector{Provider: "openai", Model: "gpt-5-nano"},
+	})
+	second := hashRequest("/v1/chat/completions", body, &core.RequestModelResolution{
+		ResolvedSelector: core.ModelSelector{Provider: "anthropic", Model: "claude-opus-4-6"},
+	})
+
+	if first == second {
+		t.Fatal("resolved model should affect cache key")
 	}
 }
 

--- a/internal/responsecache/simple.go
+++ b/internal/responsecache/simple.go
@@ -16,6 +16,7 @@ import (
 	"github.com/labstack/echo/v5"
 
 	"gomodel/internal/cache"
+	"gomodel/internal/core"
 )
 
 var cacheablePaths = map[string]bool{
@@ -55,7 +56,7 @@ func (m *simpleCacheMiddleware) Middleware() echo.MiddlewareFunc {
 			if isStreamingRequest(path, body) {
 				return next(c)
 			}
-			key := hashRequest(path, body)
+			key := hashRequest(path, body, core.GetRequestModelResolution(c.Request().Context()))
 			ctx := c.Request().Context()
 			cached, err := m.store.Get(ctx, key)
 			if err != nil {
@@ -131,10 +132,14 @@ func isStreamingRequest(path string, body []byte) bool {
 	return p.Stream != nil && *p.Stream
 }
 
-func hashRequest(path string, body []byte) string {
+func hashRequest(path string, body []byte, resolution *core.RequestModelResolution) string {
 	h := sha256.New()
 	h.Write([]byte(path))
 	h.Write([]byte{0})
+	if resolution != nil {
+		h.Write([]byte(resolution.ResolvedQualifiedModel()))
+		h.Write([]byte{0})
+	}
 	h.Write(body)
 	return hex.EncodeToString(h.Sum(nil))
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -41,10 +41,6 @@ type Handler struct {
 	enabledPassthroughProviders  map[string]struct{}
 }
 
-type resolvedModelProvider interface {
-	ResolveModel(model, provider string) (core.ModelSelector, bool, error)
-}
-
 // NewHandler creates a new handler with the given routable provider (typically the Router)
 func NewHandler(provider core.RoutableProvider, logger auditlog.LoggerInterface, usageLogger usage.LoggerInterface, pricingResolver usage.PricingResolver) *Handler {
 	return &Handler{
@@ -259,10 +255,6 @@ func cloneChatRequestForStreamUsage(req *core.ChatRequest) *core.ChatRequest {
 		cloned.StreamOptions = &streamOptions
 	}
 	return &cloned
-}
-
-func resolveModelSelector(ctx context.Context, model, provider *string) error {
-	return core.NormalizeModelSelector(core.GetWhiteBoxPrompt(ctx), model, provider)
 }
 
 func isEnabledPassthroughProvider(providerType string, enabledPassthroughProviders map[string]struct{}) bool {
@@ -584,7 +576,7 @@ func (h *Handler) ChatCompletion(c *echo.Context) error {
 	if err != nil {
 		return handleError(c, core.NewInvalidRequestError("invalid request body: "+err.Error(), err))
 	}
-	if err := resolveModelSelector(c.Request().Context(), &req.Model, &req.Provider); err != nil {
+	if err := applyRequestModelResolution(c, h.provider, &req.Model, &req.Provider); err != nil {
 		return handleError(c, err)
 	}
 
@@ -1054,7 +1046,7 @@ func (h *Handler) Responses(c *echo.Context) error {
 	if err != nil {
 		return handleError(c, core.NewInvalidRequestError("invalid request body: "+err.Error(), err))
 	}
-	if err := resolveModelSelector(c.Request().Context(), &req.Model, &req.Provider); err != nil {
+	if err := applyRequestModelResolution(c, h.provider, &req.Model, &req.Provider); err != nil {
 		return handleError(c, err)
 	}
 
@@ -1105,7 +1097,7 @@ func (h *Handler) Embeddings(c *echo.Context) error {
 	if err != nil {
 		return handleError(c, core.NewInvalidRequestError("invalid request body: "+err.Error(), err))
 	}
-	if err := resolveModelSelector(c.Request().Context(), &req.Model, &req.Provider); err != nil {
+	if err := applyRequestModelResolution(c, h.provider, &req.Model, &req.Provider); err != nil {
 		return handleError(c, err)
 	}
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -665,32 +665,11 @@ func (h *Handler) nativeFileRouter() (core.NativeFileRoutableProvider, error) {
 }
 
 func (h *Handler) fileProviderTypes(ctx *echo.Context) ([]string, error) {
-	if typed, ok := h.provider.(core.NativeFileProviderTypeLister); ok {
-		return typed.NativeFileProviderTypes(), nil
+	typed, ok := h.provider.(core.NativeFileProviderTypeLister)
+	if !ok {
+		return nil, core.NewProviderError("", http.StatusInternalServerError, "file provider inventory is unavailable", nil)
 	}
-
-	resp, err := h.provider.ListModels(ctx.Request().Context())
-	if err != nil {
-		return nil, err
-	}
-	if resp == nil {
-		return []string{}, nil
-	}
-	seen := make(map[string]struct{})
-	providers := make([]string, 0)
-	for _, model := range resp.Data {
-		providerType := strings.TrimSpace(h.provider.GetProviderType(model.ID))
-		if providerType == "" {
-			continue
-		}
-		if _, exists := seen[providerType]; exists {
-			continue
-		}
-		seen[providerType] = struct{}{}
-		providers = append(providers, providerType)
-	}
-	sort.Strings(providers)
-	return providers, nil
+	return typed.NativeFileProviderTypes(), nil
 }
 
 func (h *Handler) fileByID(

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1182,6 +1182,7 @@ func (h *Handler) Batches(c *echo.Context) error {
 	resp.ProviderBatchID = providerBatchID
 	resp.ID = "batch_" + uuid.NewString()
 	resp.Object = "batch"
+	resp.InputFileID = firstNonEmpty(req.InputFileID, batchPreparation.OriginalInputFileID, resp.InputFileID)
 	if resp.Endpoint == "" {
 		resp.Endpoint = core.NormalizeOperationPath(req.Endpoint)
 	}
@@ -1329,8 +1330,15 @@ func (h *Handler) GetBatch(c *echo.Context) error {
 	if err != nil {
 		return handleError(c, err)
 	}
+	updated := false
 	if latest != nil {
-		mergeStoredBatchFromUpstream(resp.Batch, latest)
+		mergeStoredBatchFromUpstream(resp, latest)
+		updated = true
+	}
+	if isTerminalBatchStatus(resp.Batch.Status) && h.cleanupStoredBatchRewrittenInputFile(ctx, resp) {
+		updated = true
+	}
+	if updated {
 		if err := h.batchStore.Update(c.Request().Context(), resp); err != nil && !errors.Is(err, batchstore.ErrNotFound) {
 			return handleError(c, core.NewProviderError("batch_store", http.StatusInternalServerError, "failed to persist refreshed batch", err))
 		}
@@ -1459,7 +1467,10 @@ func (h *Handler) CancelBatch(c *echo.Context) error {
 		return handleError(c, err)
 	}
 	if latest != nil {
-		mergeStoredBatchFromUpstream(resp.Batch, latest)
+		mergeStoredBatchFromUpstream(resp, latest)
+	}
+	if isTerminalBatchStatus(resp.Batch.Status) {
+		h.cleanupStoredBatchRewrittenInputFile(ctx, resp)
 	}
 
 	if err := h.batchStore.Update(c.Request().Context(), resp); err != nil {
@@ -1528,7 +1539,7 @@ func (h *Handler) BatchResults(c *echo.Context) error {
 	if err != nil {
 		if isNativeBatchResultsPending(err) {
 			if latest, getErr := nativeRouter.GetBatch(ctx, stored.Batch.Provider, stored.Batch.ProviderBatchID); getErr == nil && latest != nil {
-				mergeStoredBatchFromUpstream(stored.Batch, latest)
+				mergeStoredBatchFromUpstream(stored, latest)
 				if updateErr := h.batchStore.Update(c.Request().Context(), stored); updateErr != nil && !errors.Is(updateErr, batchstore.ErrNotFound) {
 					slog.Warn(
 						"failed to update batch store after refreshing pending results",
@@ -1561,7 +1572,8 @@ func (h *Handler) BatchResults(c *echo.Context) error {
 	if len(result.Data) > 0 {
 		stored.Batch.Results = result.Data
 	}
-	if len(result.Data) > 0 || usageLogged {
+	cleanedRewrittenInput := h.cleanupStoredBatchRewrittenInputFile(ctx, stored)
+	if len(result.Data) > 0 || usageLogged || cleanedRewrittenInput {
 		if updateErr := h.batchStore.Update(c.Request().Context(), stored); updateErr != nil {
 			slog.Warn(
 				"failed to update batch store after receiving batch results",
@@ -1897,30 +1909,32 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
-func mergeStoredBatchFromUpstream(stored, upstream *core.BatchResponse) {
-	if stored == nil || upstream == nil {
+func mergeStoredBatchFromUpstream(stored *batchstore.StoredBatch, upstream *core.BatchResponse) {
+	if stored == nil || stored.Batch == nil || upstream == nil {
 		return
 	}
 
-	stored.Status = upstream.Status
-	stored.Endpoint = upstream.Endpoint
-	stored.InputFileID = upstream.InputFileID
-	stored.CompletionWindow = upstream.CompletionWindow
-	stored.RequestCounts = upstream.RequestCounts
-	stored.Usage = upstream.Usage
-	stored.Results = upstream.Results
-	stored.InProgressAt = upstream.InProgressAt
-	stored.CompletedAt = upstream.CompletedAt
-	stored.FailedAt = upstream.FailedAt
-	stored.CancellingAt = upstream.CancellingAt
-	stored.CancelledAt = upstream.CancelledAt
+	stored.Batch.Status = upstream.Status
+	stored.Batch.Endpoint = upstream.Endpoint
+	if strings.TrimSpace(stored.Batch.InputFileID) == "" {
+		stored.Batch.InputFileID = firstNonEmpty(stored.OriginalInputFileID, upstream.InputFileID)
+	}
+	stored.Batch.CompletionWindow = upstream.CompletionWindow
+	stored.Batch.RequestCounts = upstream.RequestCounts
+	stored.Batch.Usage = upstream.Usage
+	stored.Batch.Results = upstream.Results
+	stored.Batch.InProgressAt = upstream.InProgressAt
+	stored.Batch.CompletedAt = upstream.CompletedAt
+	stored.Batch.FailedAt = upstream.FailedAt
+	stored.Batch.CancellingAt = upstream.CancellingAt
+	stored.Batch.CancelledAt = upstream.CancelledAt
 	if upstream.Metadata != nil {
-		if stored.Metadata == nil {
-			stored.Metadata = map[string]string{}
+		if stored.Batch.Metadata == nil {
+			stored.Batch.Metadata = map[string]string{}
 		}
 		preservedGatewayMetadata := map[string]string{}
 		for _, key := range []string{"provider", "provider_batch_id"} {
-			if value, exists := stored.Metadata[key]; exists {
+			if value, exists := stored.Batch.Metadata[key]; exists {
 				preservedGatewayMetadata[key] = value
 			}
 		}
@@ -1928,13 +1942,48 @@ func mergeStoredBatchFromUpstream(stored, upstream *core.BatchResponse) {
 			if _, preserve := preservedGatewayMetadata[key]; preserve {
 				continue
 			}
-			stored.Metadata[key] = value
+			stored.Batch.Metadata[key] = value
 		}
 		for key, value := range preservedGatewayMetadata {
-			stored.Metadata[key] = value
+			stored.Batch.Metadata[key] = value
 		}
-		stored.Metadata = sanitizePublicBatchMetadata(stored.Metadata)
+		stored.Batch.Metadata = sanitizePublicBatchMetadata(stored.Batch.Metadata)
 	}
+}
+
+func isTerminalBatchStatus(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "completed", "failed", "cancelled", "canceled", "expired":
+		return true
+	default:
+		return false
+	}
+}
+
+func (h *Handler) cleanupStoredBatchRewrittenInputFile(ctx context.Context, stored *batchstore.StoredBatch) bool {
+	if stored == nil || stored.Batch == nil {
+		return false
+	}
+	fileID := strings.TrimSpace(stored.RewrittenInputFileID)
+	if fileID == "" {
+		return false
+	}
+	nativeFiles, err := h.nativeFileRouter()
+	if err != nil {
+		return false
+	}
+	if _, err := nativeFiles.DeleteFile(ctx, stored.Batch.Provider, fileID); err != nil {
+		slog.Warn(
+			"failed to delete rewritten batch input file",
+			"batch_id", stored.Batch.ID,
+			"provider", stored.Batch.Provider,
+			"file_id", fileID,
+			"error", err,
+		)
+		return false
+	}
+	stored.RewrittenInputFileID = ""
+	return true
 }
 
 func isNativeBatchResultsPending(err error) bool {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1139,6 +1139,8 @@ func (h *Handler) Batches(c *echo.Context) error {
 	}
 
 	ctx, requestID := requestContextWithRequestID(c.Request())
+	batchPreparation := &core.BatchPreparationMetadata{}
+	ctx = core.WithBatchPreparationMetadata(ctx, batchPreparation)
 
 	nativeRouter, ok := h.provider.(core.NativeBatchRoutableProvider)
 	if !ok {
@@ -1200,6 +1202,8 @@ func (h *Handler) Batches(c *echo.Context) error {
 		stored := &batchstore.StoredBatch{
 			Batch:                     &resp,
 			RequestEndpointByCustomID: hints,
+			OriginalInputFileID:       batchPreparation.OriginalInputFileID,
+			RewrittenInputFileID:      batchPreparation.RewrittenInputFileID,
 			RequestID:                 requestID,
 		}
 		if err := h.batchStore.Create(ctx, stored); err != nil {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -32,25 +32,29 @@ var defaultEnabledPassthroughProviders = []string{"openai", "anthropic"}
 
 // Handler holds the HTTP handlers
 type Handler struct {
-	provider                      core.RoutableProvider
-	logger                        auditlog.LoggerInterface
-	usageLogger                   usage.LoggerInterface
-	pricingResolver               usage.PricingResolver
-	batchStore                    batchstore.Store
-	normalizePassthroughV1Prefix  bool
-	enabledPassthroughProviders map[string]struct{}
+	provider                     core.RoutableProvider
+	logger                       auditlog.LoggerInterface
+	usageLogger                  usage.LoggerInterface
+	pricingResolver              usage.PricingResolver
+	batchStore                   batchstore.Store
+	normalizePassthroughV1Prefix bool
+	enabledPassthroughProviders  map[string]struct{}
+}
+
+type resolvedModelProvider interface {
+	ResolveModel(model, provider string) (core.ModelSelector, bool, error)
 }
 
 // NewHandler creates a new handler with the given routable provider (typically the Router)
 func NewHandler(provider core.RoutableProvider, logger auditlog.LoggerInterface, usageLogger usage.LoggerInterface, pricingResolver usage.PricingResolver) *Handler {
 	return &Handler{
-		provider:                      provider,
-		logger:                        logger,
-		usageLogger:                   usageLogger,
-		pricingResolver:               pricingResolver,
-		batchStore:                    batchstore.NewMemoryStore(),
-		normalizePassthroughV1Prefix:  true,
-		enabledPassthroughProviders: normalizeEnabledPassthroughProviders(defaultEnabledPassthroughProviders),
+		provider:                     provider,
+		logger:                       logger,
+		usageLogger:                  usageLogger,
+		pricingResolver:              pricingResolver,
+		batchStore:                   batchstore.NewMemoryStore(),
+		normalizePassthroughV1Prefix: true,
+		enabledPassthroughProviders:  normalizeEnabledPassthroughProviders(defaultEnabledPassthroughProviders),
 	}
 }
 
@@ -193,6 +197,19 @@ func requestContextWithRequestID(req *http.Request) (context.Context, string) {
 	}
 
 	return ctx, requestID
+}
+
+func (h *Handler) streamingUsageModel(model, provider string) (string, error) {
+	if resolver, ok := h.provider.(resolvedModelProvider); ok {
+		selector, _, err := resolver.ResolveModel(model, provider)
+		if err != nil {
+			return "", err
+		}
+		if selector.Model != "" {
+			return selector.Model, nil
+		}
+	}
+	return model, nil
 }
 
 func sanitizePublicBatchMetadata(metadata map[string]string) map[string]string {
@@ -584,7 +601,11 @@ func (h *Handler) ChatCompletion(c *echo.Context) error {
 			}
 			streamReq.StreamOptions.IncludeUsage = true
 		}
-		return h.handleStreamingResponse(c, streamReq.Model, providerType, func() (io.ReadCloser, error) {
+		usageModel, err := h.streamingUsageModel(streamReq.Model, streamReq.Provider)
+		if err != nil {
+			return handleError(c, err)
+		}
+		return h.handleStreamingResponse(c, usageModel, providerType, func() (io.ReadCloser, error) {
 			return h.provider.StreamChatCompletion(ctx, streamReq)
 		})
 	}
@@ -1061,7 +1082,11 @@ func (h *Handler) Responses(c *echo.Context) error {
 		if h.shouldEnforceReturningUsageData() {
 			ctx = core.WithEnforceReturningUsageData(ctx, true)
 		}
-		return h.handleStreamingResponse(c, req.Model, providerType, func() (io.ReadCloser, error) {
+		usageModel, err := h.streamingUsageModel(req.Model, req.Provider)
+		if err != nil {
+			return handleError(c, err)
+		}
+		return h.handleStreamingResponse(c, usageModel, providerType, func() (io.ReadCloser, error) {
 			return h.provider.StreamResponses(ctx, req)
 		})
 	}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1572,7 +1572,10 @@ func (h *Handler) BatchResults(c *echo.Context) error {
 	if len(result.Data) > 0 {
 		stored.Batch.Results = result.Data
 	}
-	cleanedRewrittenInput := h.cleanupStoredBatchRewrittenInputFile(ctx, stored)
+	cleanedRewrittenInput := false
+	if isTerminalBatchStatus(stored.Batch.Status) {
+		cleanedRewrittenInput = h.cleanupStoredBatchRewrittenInputFile(ctx, stored)
+	}
 	if len(result.Data) > 0 || usageLogged || cleanedRewrittenInput {
 		if updateErr := h.batchStore.Update(c.Request().Context(), stored); updateErr != nil {
 			slog.Warn(
@@ -1914,20 +1917,36 @@ func mergeStoredBatchFromUpstream(stored *batchstore.StoredBatch, upstream *core
 		return
 	}
 
-	stored.Batch.Status = upstream.Status
-	stored.Batch.Endpoint = upstream.Endpoint
+	stored.Batch.Status = firstNonEmpty(upstream.Status, stored.Batch.Status)
+	stored.Batch.Endpoint = firstNonEmpty(upstream.Endpoint, stored.Batch.Endpoint)
 	if strings.TrimSpace(stored.Batch.InputFileID) == "" {
 		stored.Batch.InputFileID = firstNonEmpty(stored.OriginalInputFileID, upstream.InputFileID)
 	}
-	stored.Batch.CompletionWindow = upstream.CompletionWindow
-	stored.Batch.RequestCounts = upstream.RequestCounts
-	stored.Batch.Usage = upstream.Usage
-	stored.Batch.Results = upstream.Results
-	stored.Batch.InProgressAt = upstream.InProgressAt
-	stored.Batch.CompletedAt = upstream.CompletedAt
-	stored.Batch.FailedAt = upstream.FailedAt
-	stored.Batch.CancellingAt = upstream.CancellingAt
-	stored.Batch.CancelledAt = upstream.CancelledAt
+	stored.Batch.CompletionWindow = firstNonEmpty(upstream.CompletionWindow, stored.Batch.CompletionWindow)
+	if hasBatchRequestCounts(upstream.RequestCounts) {
+		stored.Batch.RequestCounts = upstream.RequestCounts
+	}
+	if hasBatchUsageSummary(upstream.Usage) {
+		stored.Batch.Usage = upstream.Usage
+	}
+	if len(upstream.Results) > 0 {
+		stored.Batch.Results = upstream.Results
+	}
+	if upstream.InProgressAt != nil {
+		stored.Batch.InProgressAt = upstream.InProgressAt
+	}
+	if upstream.CompletedAt != nil {
+		stored.Batch.CompletedAt = upstream.CompletedAt
+	}
+	if upstream.FailedAt != nil {
+		stored.Batch.FailedAt = upstream.FailedAt
+	}
+	if upstream.CancellingAt != nil {
+		stored.Batch.CancellingAt = upstream.CancellingAt
+	}
+	if upstream.CancelledAt != nil {
+		stored.Batch.CancelledAt = upstream.CancelledAt
+	}
 	if upstream.Metadata != nil {
 		if stored.Batch.Metadata == nil {
 			stored.Batch.Metadata = map[string]string{}
@@ -1949,6 +1968,19 @@ func mergeStoredBatchFromUpstream(stored *batchstore.StoredBatch, upstream *core
 		}
 		stored.Batch.Metadata = sanitizePublicBatchMetadata(stored.Batch.Metadata)
 	}
+}
+
+func hasBatchRequestCounts(counts core.BatchRequestCounts) bool {
+	return counts.Total != 0 || counts.Completed != 0 || counts.Failed != 0
+}
+
+func hasBatchUsageSummary(usage core.BatchUsageSummary) bool {
+	return usage.InputTokens != 0 ||
+		usage.OutputTokens != 0 ||
+		usage.TotalTokens != 0 ||
+		usage.InputCost != nil ||
+		usage.OutputCost != nil ||
+		usage.TotalCost != nil
 }
 
 func isTerminalBatchStatus(status string) bool {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -665,6 +665,10 @@ func (h *Handler) nativeFileRouter() (core.NativeFileRoutableProvider, error) {
 }
 
 func (h *Handler) fileProviderTypes(ctx *echo.Context) ([]string, error) {
+	if typed, ok := h.provider.(core.NativeFileProviderTypeLister); ok {
+		return typed.NativeFileProviderTypes(), nil
+	}
+
 	resp, err := h.provider.ListModels(ctx.Request().Context())
 	if err != nil {
 		return nil, err

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -1065,6 +1065,115 @@ func TestChatCompletion_NormalizesSemanticSelectorHints(t *testing.T) {
 	}
 }
 
+func TestChatCompletion_ResolvesQualifiedMaskingAliasBeforeHandlerRouting(t *testing.T) {
+	catalog := aliasesTestCatalog{
+		supported: map[string]bool{
+			"anthropic/claude-opus-4-6": true,
+			"openai/gpt-5-nano":         true,
+		},
+		providerTypes: map[string]string{
+			"anthropic/claude-opus-4-6": "anthropic",
+			"openai/gpt-5-nano":         "openai",
+		},
+		models: map[string]core.Model{
+			"anthropic/claude-opus-4-6": {ID: "claude-opus-4-6", Object: "model"},
+			"openai/gpt-5-nano":         {ID: "gpt-5-nano", Object: "model"},
+		},
+	}
+
+	service, err := aliases.NewService(newAliasesTestStore(
+		aliases.Alias{Name: "anthropic/claude-opus-4-6", TargetModel: "gpt-5-nano", TargetProvider: "openai", Enabled: true},
+	), &catalog)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	inner := &capturingProvider{
+		mockProvider: mockProvider{
+			supportedModels: []string{"gpt-5-nano"},
+			providerTypes: map[string]string{
+				"openai/gpt-5-nano": "openai",
+			},
+			response: &core.ChatResponse{
+				ID:       "chatcmpl_alias_123",
+				Object:   "chat.completion",
+				Model:    "gpt-5-nano",
+				Provider: "openai",
+				Choices: []core.Choice{
+					{
+						Index:        0,
+						FinishReason: "stop",
+						Message: core.ResponseMessage{
+							Role:    "assistant",
+							Content: "ok",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	provider := aliases.NewProvider(inner, service)
+
+	e := echo.New()
+	handler := NewHandler(provider, nil, nil, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("Content-Type", "application/json")
+	req.Body = &explodingReadCloser{}
+
+	frame := core.NewRequestSnapshot(
+		http.MethodPost,
+		"/v1/chat/completions",
+		nil,
+		nil,
+		nil,
+		"application/json",
+		[]byte(`{
+			"model":"anthropic/claude-opus-4-6",
+			"messages":[{"role":"user","content":"return json"}]
+		}`),
+		false,
+		"",
+		nil,
+	)
+	req = withRequestSnapshotAndPrompt(req, frame)
+
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err = handler.ChatCompletion(c)
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if inner.capturedChatReq == nil {
+		t.Fatal("expected chat request to be captured")
+	}
+	if inner.capturedChatReq.Model != "gpt-5-nano" {
+		t.Fatalf("captured model = %q, want gpt-5-nano", inner.capturedChatReq.Model)
+	}
+	if inner.capturedChatReq.Provider != "openai" {
+		t.Fatalf("captured provider = %q, want openai", inner.capturedChatReq.Provider)
+	}
+
+	resolution := core.GetRequestModelResolution(c.Request().Context())
+	if resolution == nil {
+		t.Fatal("expected request model resolution in context")
+	}
+	if !resolution.AliasApplied {
+		t.Fatal("expected alias resolution to be marked as applied")
+	}
+	if resolution.ResolvedQualifiedModel() != "openai/gpt-5-nano" {
+		t.Fatalf("resolved model = %q, want openai/gpt-5-nano", resolution.ResolvedQualifiedModel())
+	}
+}
+
 func TestResponses_UsesIngressFrameForDecoding(t *testing.T) {
 	provider := &capturingProvider{
 		mockProvider: mockProvider{

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -2543,6 +2543,10 @@ func TestBatches_InputFileRewritesAliasesAndPersistsBatchPreparation(t *testing.
 	require.NoError(t, service.Refresh(context.Background()))
 
 	inner := &mockProvider{
+		supportedModels: []string{"gpt-4o"},
+		providerTypes: map[string]string{
+			"openai/gpt-4o": "openai",
+		},
 		fileContentResponse: &core.FileContentResponse{
 			ID:       "file_source",
 			Filename: "batch.jsonl",
@@ -2602,6 +2606,57 @@ func TestBatches_InputFileRewritesAliasesAndPersistsBatchPreparation(t *testing.
 	require.Equal(t, "file_source", stored.Batch.InputFileID)
 	require.Equal(t, "file_source", stored.OriginalInputFileID)
 	require.Equal(t, "file_rewritten", stored.RewrittenInputFileID)
+}
+
+func TestBatches_InputFileRejectsDisabledAlias(t *testing.T) {
+	store := newAliasesTestStore(aliases.Alias{Name: "smart", TargetModel: "gpt-4o", TargetProvider: "openai", Enabled: false})
+	catalog := &aliasesTestCatalog{
+		supported: map[string]bool{
+			"openai/gpt-4o": true,
+		},
+		providerTypes: map[string]string{
+			"openai/gpt-4o": "openai",
+		},
+		models: map[string]core.Model{
+			"openai/gpt-4o": {ID: "gpt-4o", Object: "model"},
+		},
+	}
+	service, err := aliases.NewService(store, catalog)
+	require.NoError(t, err)
+	require.NoError(t, service.Refresh(context.Background()))
+
+	inner := &mockProvider{
+		supportedModels: []string{"gpt-4o"},
+		providerTypes: map[string]string{
+			"openai/gpt-4o": "openai",
+		},
+		fileContentResponse: &core.FileContentResponse{
+			ID:       "file_source",
+			Filename: "batch.jsonl",
+			Data:     []byte("{\"custom_id\":\"chat-1\",\"method\":\"POST\",\"url\":\"/v1/chat/completions\",\"body\":{\"model\":\"smart\",\"messages\":[{\"role\":\"user\",\"content\":\"Hi\"}]}}\n"),
+		},
+	}
+
+	provider := aliases.NewProvider(inner, service)
+	handler := NewHandler(provider, nil, nil, nil)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/batches", strings.NewReader(`{
+	  "input_file_id":"file_source",
+	  "endpoint":"/v1/chat/completions",
+	  "completion_window":"24h",
+	  "metadata":{"provider":"openai"}
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err = handler.Batches(c)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "unsupported model: smart")
+	require.Nil(t, inner.capturedBatchReq)
+	require.Empty(t, inner.capturedFileCreateReqs)
 }
 
 func TestGetBatch_PreservesClientInputFileIDAndCleansUpRewrittenFile(t *testing.T) {

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -349,6 +349,62 @@ func (m *mockProvider) NativeFileProviderTypes() []string {
 	return result
 }
 
+type providerWithoutFileInventory struct {
+	inner *mockProvider
+}
+
+func (p *providerWithoutFileInventory) ChatCompletion(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+	return p.inner.ChatCompletion(ctx, req)
+}
+
+func (p *providerWithoutFileInventory) StreamChatCompletion(ctx context.Context, req *core.ChatRequest) (io.ReadCloser, error) {
+	return p.inner.StreamChatCompletion(ctx, req)
+}
+
+func (p *providerWithoutFileInventory) ListModels(ctx context.Context) (*core.ModelsResponse, error) {
+	return p.inner.ListModels(ctx)
+}
+
+func (p *providerWithoutFileInventory) Responses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
+	return p.inner.Responses(ctx, req)
+}
+
+func (p *providerWithoutFileInventory) StreamResponses(ctx context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
+	return p.inner.StreamResponses(ctx, req)
+}
+
+func (p *providerWithoutFileInventory) Embeddings(ctx context.Context, req *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	return p.inner.Embeddings(ctx, req)
+}
+
+func (p *providerWithoutFileInventory) Supports(model string) bool {
+	return p.inner.Supports(model)
+}
+
+func (p *providerWithoutFileInventory) GetProviderType(model string) string {
+	return p.inner.GetProviderType(model)
+}
+
+func (p *providerWithoutFileInventory) CreateFile(ctx context.Context, providerType string, req *core.FileCreateRequest) (*core.FileObject, error) {
+	return p.inner.CreateFile(ctx, providerType, req)
+}
+
+func (p *providerWithoutFileInventory) ListFiles(ctx context.Context, providerType, purpose string, limit int, after string) (*core.FileListResponse, error) {
+	return p.inner.ListFiles(ctx, providerType, purpose, limit, after)
+}
+
+func (p *providerWithoutFileInventory) GetFile(ctx context.Context, providerType, id string) (*core.FileObject, error) {
+	return p.inner.GetFile(ctx, providerType, id)
+}
+
+func (p *providerWithoutFileInventory) DeleteFile(ctx context.Context, providerType, id string) (*core.FileDeleteResponse, error) {
+	return p.inner.DeleteFile(ctx, providerType, id)
+}
+
+func (p *providerWithoutFileInventory) GetFileContent(ctx context.Context, providerType, id string) (*core.FileContentResponse, error) {
+	return p.inner.GetFileContent(ctx, providerType, id)
+}
+
 func (m *mockProvider) ChatCompletion(_ context.Context, _ *core.ChatRequest) (*core.ChatResponse, error) {
 	if m.err != nil {
 		return nil, m.err
@@ -3625,6 +3681,50 @@ func TestGetFileWithoutProviderUsesProviderInventoryWhenAliasMasksModel(t *testi
 	}
 	if !strings.Contains(rec.Body.String(), "\"provider\":\"openai\"") {
 		t.Fatalf("unexpected response body: %s", rec.Body.String())
+	}
+}
+
+func TestGetFileWithoutProviderRequiresFileProviderInventory(t *testing.T) {
+	base := &mockProvider{
+		supportedModels: []string{"gpt-4o"},
+		providerTypes: map[string]string{
+			"gpt-4o": "openai",
+		},
+		fileGetByProvider: map[string]*core.FileObject{
+			"openai": {
+				ID:        "file_ok_1",
+				Object:    "file",
+				Bytes:     10,
+				CreatedAt: 1000,
+				Filename:  "a.jsonl",
+				Purpose:   "batch",
+				Provider:  "openai",
+			},
+		},
+	}
+
+	provider := &providerWithoutFileInventory{inner: base}
+	e := echo.New()
+	handler := NewHandler(provider, nil, nil, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/files/file_ok_1", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/v1/files/:id")
+	setPathParam(c, "id", "file_ok_1")
+
+	if err := handler.GetFile(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "provider_error") {
+		t.Fatalf("expected provider_error body, got: %s", body)
+	}
+	if !strings.Contains(body, "file provider inventory is unavailable") {
+		t.Fatalf("unexpected response body: %s", body)
 	}
 }
 

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -267,7 +267,9 @@ type mockProvider struct {
 	clearedBatchHintID         string
 
 	fileCreateResponse     *core.FileObject
+	fileCreateResponses    []*core.FileObject
 	capturedFileCreateReqs []*core.FileCreateRequest
+	capturedFileDeleteIDs  []string
 	fileGetResponse        *core.FileObject
 	fileDeleteResponse     *core.FileDeleteResponse
 	fileListResponse       *core.FileListResponse
@@ -574,6 +576,11 @@ func (m *mockProvider) CreateFile(_ context.Context, providerType string, req *c
 	copy := *req
 	copy.Content = append([]byte(nil), req.Content...)
 	m.capturedFileCreateReqs = append(m.capturedFileCreateReqs, &copy)
+	if len(m.fileCreateResponses) > 0 {
+		resp := m.fileCreateResponses[0]
+		m.fileCreateResponses = m.fileCreateResponses[1:]
+		return resp, nil
+	}
 	if m.fileCreateResponse != nil {
 		return m.fileCreateResponse, nil
 	}
@@ -658,6 +665,7 @@ func (m *mockProvider) DeleteFile(_ context.Context, providerType string, id str
 	if m.fileErr != nil {
 		return nil, m.fileErr
 	}
+	m.capturedFileDeleteIDs = append(m.capturedFileDeleteIDs, id)
 	if m.fileDeleteResponse != nil {
 		return m.fileDeleteResponse, nil
 	}
@@ -2586,12 +2594,64 @@ func TestBatches_InputFileRewritesAliasesAndPersistsBatchPreparation(t *testing.
 
 	var created core.BatchResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &created))
+	require.Equal(t, "file_source", created.InputFileID)
 
 	stored, err := batchStore.Get(context.Background(), created.ID)
 	require.NoError(t, err)
 	require.NotNil(t, stored)
+	require.Equal(t, "file_source", stored.Batch.InputFileID)
 	require.Equal(t, "file_source", stored.OriginalInputFileID)
 	require.Equal(t, "file_rewritten", stored.RewrittenInputFileID)
+}
+
+func TestGetBatch_PreservesClientInputFileIDAndCleansUpRewrittenFile(t *testing.T) {
+	provider := &mockProvider{
+		batchGetResponse: &core.BatchResponse{
+			ID:              "provider-batch-1",
+			Object:          "batch",
+			Status:          "completed",
+			InputFileID:     "file_hidden",
+			ProviderBatchID: "provider-batch-1",
+		},
+	}
+
+	handler := NewHandler(provider, nil, nil, nil)
+	store := batchstore.NewMemoryStore()
+	handler.SetBatchStore(store)
+	require.NoError(t, store.Create(context.Background(), &batchstore.StoredBatch{
+		Batch: &core.BatchResponse{
+			ID:              "batch_1",
+			Object:          "batch",
+			Provider:        "openai",
+			ProviderBatchID: "provider-batch-1",
+			Status:          "in_progress",
+			InputFileID:     "file_source",
+		},
+		OriginalInputFileID:  "file_source",
+		RewrittenInputFileID: "file_hidden",
+	}))
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/v1/batches/batch_1", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/v1/batches/:id")
+	setPathParam(c, "id", "batch_1")
+
+	err := handler.GetBatch(c)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, []string{"file_hidden"}, provider.capturedFileDeleteIDs)
+
+	var resp core.BatchResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, "file_source", resp.InputFileID)
+	require.Equal(t, "completed", resp.Status)
+
+	stored, err := store.Get(context.Background(), "batch_1")
+	require.NoError(t, err)
+	require.Equal(t, "", stored.RewrittenInputFileID)
+	require.Equal(t, "file_source", stored.Batch.InputFileID)
 }
 
 func TestBatches_EmptyRequests(t *testing.T) {
@@ -3920,18 +3980,24 @@ func TestGetFileWithoutProviderRequiresFileProviderInventory(t *testing.T) {
 }
 
 func TestMergeStoredBatchFromUpstreamPreservesGatewayMetadata(t *testing.T) {
-	stored := &core.BatchResponse{
-		ID:              "batch_1",
-		Provider:        "openai",
-		ProviderBatchID: "provider-batch-1",
-		Metadata: map[string]string{
-			"provider":          "openai",
-			"provider_batch_id": "provider-batch-1",
-			"existing":          "keep-me",
+	stored := &batchstore.StoredBatch{
+		Batch: &core.BatchResponse{
+			ID:              "batch_1",
+			Provider:        "openai",
+			ProviderBatchID: "provider-batch-1",
+			InputFileID:     "file_source",
+			Metadata: map[string]string{
+				"provider":          "openai",
+				"provider_batch_id": "provider-batch-1",
+				"existing":          "keep-me",
+			},
 		},
+		OriginalInputFileID:  "file_source",
+		RewrittenInputFileID: "file_hidden",
 	}
 	upstream := &core.BatchResponse{
-		Status: "completed",
+		Status:      "completed",
+		InputFileID: "file_hidden",
 		Metadata: map[string]string{
 			"provider":          "anthropic",
 			"provider_batch_id": "other-id",
@@ -3942,17 +4008,20 @@ func TestMergeStoredBatchFromUpstreamPreservesGatewayMetadata(t *testing.T) {
 
 	mergeStoredBatchFromUpstream(stored, upstream)
 
-	if stored.Metadata["provider"] != "openai" {
-		t.Fatalf("provider metadata overwritten: %q", stored.Metadata["provider"])
+	if stored.Batch.Metadata["provider"] != "openai" {
+		t.Fatalf("provider metadata overwritten: %q", stored.Batch.Metadata["provider"])
 	}
-	if stored.Metadata["provider_batch_id"] != "provider-batch-1" {
-		t.Fatalf("provider_batch_id metadata overwritten: %q", stored.Metadata["provider_batch_id"])
+	if stored.Batch.Metadata["provider_batch_id"] != "provider-batch-1" {
+		t.Fatalf("provider_batch_id metadata overwritten: %q", stored.Batch.Metadata["provider_batch_id"])
 	}
-	if stored.Metadata["existing"] != "upstream-overwrite" {
-		t.Fatalf("expected non-gateway key overwrite from upstream, got %q", stored.Metadata["existing"])
+	if stored.Batch.Metadata["existing"] != "upstream-overwrite" {
+		t.Fatalf("expected non-gateway key overwrite from upstream, got %q", stored.Batch.Metadata["existing"])
 	}
-	if stored.Metadata["new_key"] != "new-value" {
-		t.Fatalf("expected merged upstream key, got %q", stored.Metadata["new_key"])
+	if stored.Batch.Metadata["new_key"] != "new-value" {
+		t.Fatalf("expected merged upstream key, got %q", stored.Batch.Metadata["new_key"])
+	}
+	if stored.Batch.InputFileID != "file_source" {
+		t.Fatalf("input_file_id overwritten: %q", stored.Batch.InputFileID)
 	}
 }
 

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -20,6 +20,7 @@ import (
 
 	"gomodel/internal/aliases"
 	"gomodel/internal/auditlog"
+	batchstore "gomodel/internal/batch"
 	"gomodel/internal/core"
 	provideradapter "gomodel/internal/providers"
 	"gomodel/internal/usage"
@@ -265,16 +266,17 @@ type mockProvider struct {
 	clearedBatchHintProvider   string
 	clearedBatchHintID         string
 
-	fileCreateResponse  *core.FileObject
-	fileGetResponse     *core.FileObject
-	fileDeleteResponse  *core.FileDeleteResponse
-	fileListResponse    *core.FileListResponse
-	fileContentResponse *core.FileContentResponse
-	fileErr             error
-	fileListByProvider  map[string]*core.FileListResponse
-	fileErrByProvider   map[string]error
-	fileGetByProvider   map[string]*core.FileObject
-	fileContentByProv   map[string]*core.FileContentResponse
+	fileCreateResponse     *core.FileObject
+	capturedFileCreateReqs []*core.FileCreateRequest
+	fileGetResponse        *core.FileObject
+	fileDeleteResponse     *core.FileDeleteResponse
+	fileListResponse       *core.FileListResponse
+	fileContentResponse    *core.FileContentResponse
+	fileErr                error
+	fileListByProvider     map[string]*core.FileListResponse
+	fileErrByProvider      map[string]error
+	fileGetByProvider      map[string]*core.FileObject
+	fileContentByProv      map[string]*core.FileContentResponse
 
 	passthroughResponse     *core.PassthroughResponse
 	passthroughErr          error
@@ -569,6 +571,9 @@ func (m *mockProvider) CreateFile(_ context.Context, providerType string, req *c
 	if m.fileErr != nil {
 		return nil, m.fileErr
 	}
+	copy := *req
+	copy.Content = append([]byte(nil), req.Content...)
+	m.capturedFileCreateReqs = append(m.capturedFileCreateReqs, &copy)
 	if m.fileCreateResponse != nil {
 		return m.fileCreateResponse, nil
 	}
@@ -2510,6 +2515,83 @@ func TestBatches_MixedProviderRejected(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected status 400, got %d", rec.Code)
 	}
+}
+
+func TestBatches_InputFileRewritesAliasesAndPersistsBatchPreparation(t *testing.T) {
+	store := newAliasesTestStore(aliases.Alias{Name: "smart", TargetModel: "gpt-4o", TargetProvider: "openai", Enabled: true})
+	catalog := &aliasesTestCatalog{
+		supported: map[string]bool{
+			"openai/gpt-4o": true,
+		},
+		providerTypes: map[string]string{
+			"openai/gpt-4o": "openai",
+		},
+		models: map[string]core.Model{
+			"openai/gpt-4o": {ID: "gpt-4o", Object: "model"},
+		},
+	}
+	service, err := aliases.NewService(store, catalog)
+	require.NoError(t, err)
+	require.NoError(t, service.Refresh(context.Background()))
+
+	inner := &mockProvider{
+		fileContentResponse: &core.FileContentResponse{
+			ID:       "file_source",
+			Filename: "batch.jsonl",
+			Data:     []byte("{\"custom_id\":\"chat-1\",\"method\":\"POST\",\"url\":\"/v1/chat/completions\",\"body\":{\"model\":\"smart\",\"messages\":[{\"role\":\"user\",\"content\":\"Hi\"}]}}\n"),
+		},
+		fileCreateResponse: &core.FileObject{
+			ID:       "file_rewritten",
+			Object:   "file",
+			Filename: "batch.jsonl",
+			Purpose:  "batch",
+			Provider: "openai",
+		},
+		batchCreateResponse: &core.BatchResponse{
+			ID:          "provider-batch-1",
+			Object:      "batch",
+			Status:      "validating",
+			Endpoint:    "/v1/chat/completions",
+			CreatedAt:   1234567890,
+			InputFileID: "file_rewritten",
+			RequestCounts: core.BatchRequestCounts{
+				Total: 1,
+			},
+		},
+	}
+
+	provider := aliases.NewProvider(inner, service)
+	handler := NewHandler(provider, nil, nil, nil)
+	batchStore := batchstore.NewMemoryStore()
+	handler.SetBatchStore(batchStore)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/batches", strings.NewReader(`{
+	  "input_file_id":"file_source",
+	  "endpoint":"/v1/chat/completions",
+	  "completion_window":"24h",
+	  "metadata":{"provider":"openai"}
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err = handler.Batches(c)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, inner.capturedBatchReq)
+	require.Equal(t, "file_rewritten", inner.capturedBatchReq.InputFileID)
+	require.Len(t, inner.capturedFileCreateReqs, 1)
+	require.Contains(t, string(inner.capturedFileCreateReqs[0].Content), `"model":"gpt-4o"`)
+
+	var created core.BatchResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &created))
+
+	stored, err := batchStore.Get(context.Background(), created.ID)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	require.Equal(t, "file_source", stored.OriginalInputFileID)
+	require.Equal(t, "file_rewritten", stored.RewrittenInputFileID)
 }
 
 func TestBatches_EmptyRequests(t *testing.T) {

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -3020,6 +3020,51 @@ func TestBatchResults_PendingReturnsConflict(t *testing.T) {
 	}
 }
 
+func TestBatchResults_DoesNotCleanupRewrittenFileBeforeTerminalStatus(t *testing.T) {
+	mock := &mockProvider{
+		batchResults: &core.BatchResultsResponse{
+			Object:  "list",
+			BatchID: "provider-batch-1",
+			Data: []core.BatchResultItem{
+				{Index: 0, StatusCode: 200, CustomID: "partial-1"},
+			},
+		},
+	}
+
+	handler := NewHandler(mock, nil, nil, nil)
+	store := batchstore.NewMemoryStore()
+	handler.SetBatchStore(store)
+	require.NoError(t, store.Create(context.Background(), &batchstore.StoredBatch{
+		Batch: &core.BatchResponse{
+			ID:              "batch_1",
+			Object:          "batch",
+			Provider:        "openai",
+			ProviderBatchID: "provider-batch-1",
+			Status:          "in_progress",
+			InputFileID:     "file_source",
+		},
+		OriginalInputFileID:  "file_source",
+		RewrittenInputFileID: "file_hidden",
+	}))
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/v1/batches/batch_1/results", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/v1/batches/:id/results")
+	setPathParam(c, "id", "batch_1")
+
+	err := handler.BatchResults(c)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Empty(t, mock.capturedFileDeleteIDs)
+
+	stored, err := store.Get(context.Background(), "batch_1")
+	require.NoError(t, err)
+	require.Equal(t, "file_hidden", stored.RewrittenInputFileID)
+	require.Len(t, stored.Batch.Results, 1)
+}
+
 func TestBatchResults_LogsUsageOnce(t *testing.T) {
 	mock := &mockProvider{
 		supportedModels: []string{"claude-3-haiku-20240307"},
@@ -4077,6 +4122,89 @@ func TestMergeStoredBatchFromUpstreamPreservesGatewayMetadata(t *testing.T) {
 	}
 	if stored.Batch.InputFileID != "file_source" {
 		t.Fatalf("input_file_id overwritten: %q", stored.Batch.InputFileID)
+	}
+}
+
+func TestMergeStoredBatchFromUpstreamPreservesExistingValuesOnSparseUpstream(t *testing.T) {
+	inProgressAt := int64(1001)
+	completedAt := int64(1002)
+	inputCost := 0.11
+	totalCost := 0.22
+
+	stored := &batchstore.StoredBatch{
+		Batch: &core.BatchResponse{
+			ID:               "batch_1",
+			Status:           "in_progress",
+			Endpoint:         "/v1/chat/completions",
+			InputFileID:      "file_source",
+			CompletionWindow: "24h",
+			RequestCounts: core.BatchRequestCounts{
+				Total:     10,
+				Completed: 4,
+				Failed:    1,
+			},
+			Usage: core.BatchUsageSummary{
+				InputTokens:  100,
+				OutputTokens: 50,
+				TotalTokens:  150,
+				InputCost:    &inputCost,
+				TotalCost:    &totalCost,
+			},
+			Results: []core.BatchResultItem{
+				{Index: 0, CustomID: "keep-me", StatusCode: 200},
+			},
+			InProgressAt: &inProgressAt,
+			CompletedAt:  &completedAt,
+			Metadata: map[string]string{
+				"provider": "openai",
+			},
+		},
+		OriginalInputFileID: "file_source",
+	}
+
+	upstream := &core.BatchResponse{
+		Status:        "",
+		Endpoint:      "",
+		InputFileID:   "",
+		RequestCounts: core.BatchRequestCounts{},
+		Usage:         core.BatchUsageSummary{},
+		Results:       nil,
+		Metadata: map[string]string{
+			"upstream_only": "value",
+		},
+	}
+
+	mergeStoredBatchFromUpstream(stored, upstream)
+
+	if got := stored.Batch.Status; got != "in_progress" {
+		t.Fatalf("Status = %q, want in_progress", got)
+	}
+	if got := stored.Batch.Endpoint; got != "/v1/chat/completions" {
+		t.Fatalf("Endpoint = %q, want /v1/chat/completions", got)
+	}
+	if got := stored.Batch.InputFileID; got != "file_source" {
+		t.Fatalf("InputFileID = %q, want file_source", got)
+	}
+	if got := stored.Batch.CompletionWindow; got != "24h" {
+		t.Fatalf("CompletionWindow = %q, want 24h", got)
+	}
+	if got := stored.Batch.RequestCounts; got != (core.BatchRequestCounts{Total: 10, Completed: 4, Failed: 1}) {
+		t.Fatalf("RequestCounts = %#v, want preserved counts", got)
+	}
+	if got := stored.Batch.Usage; got.InputTokens != 100 || got.OutputTokens != 50 || got.TotalTokens != 150 || got.InputCost == nil || *got.InputCost != inputCost || got.TotalCost == nil || *got.TotalCost != totalCost {
+		t.Fatalf("Usage = %#v, want preserved usage", got)
+	}
+	if len(stored.Batch.Results) != 1 || stored.Batch.Results[0].CustomID != "keep-me" {
+		t.Fatalf("Results = %#v, want preserved results", stored.Batch.Results)
+	}
+	if stored.Batch.InProgressAt == nil || *stored.Batch.InProgressAt != inProgressAt {
+		t.Fatalf("InProgressAt = %#v, want %d", stored.Batch.InProgressAt, inProgressAt)
+	}
+	if stored.Batch.CompletedAt == nil || *stored.Batch.CompletedAt != completedAt {
+		t.Fatalf("CompletedAt = %#v, want %d", stored.Batch.CompletedAt, completedAt)
+	}
+	if got := stored.Batch.Metadata["upstream_only"]; got != "value" {
+		t.Fatalf("metadata[upstream_only] = %q, want value", got)
 	}
 }
 

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -9,6 +9,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -17,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"gomodel/internal/aliases"
 	"gomodel/internal/auditlog"
 	"gomodel/internal/core"
 	provideradapter "gomodel/internal/providers"
@@ -32,6 +34,76 @@ func withRequestSnapshotAndPrompt(req *http.Request, frame *core.RequestSnapshot
 		ctx = core.WithWhiteBoxPrompt(ctx, prompt)
 	}
 	return req.WithContext(ctx)
+}
+
+type aliasesTestStore struct {
+	aliases []aliases.Alias
+}
+
+func newAliasesTestStore(aliasesList ...aliases.Alias) *aliasesTestStore {
+	return &aliasesTestStore{aliases: append([]aliases.Alias(nil), aliasesList...)}
+}
+
+func (s *aliasesTestStore) List(_ context.Context) ([]aliases.Alias, error) {
+	return append([]aliases.Alias(nil), s.aliases...), nil
+}
+
+func (s *aliasesTestStore) Get(_ context.Context, name string) (*aliases.Alias, error) {
+	for _, alias := range s.aliases {
+		if alias.Name == name {
+			copy := alias
+			return &copy, nil
+		}
+	}
+	return nil, aliases.ErrNotFound
+}
+
+func (s *aliasesTestStore) Upsert(_ context.Context, alias aliases.Alias) error {
+	for i := range s.aliases {
+		if s.aliases[i].Name == alias.Name {
+			s.aliases[i] = alias
+			return nil
+		}
+	}
+	s.aliases = append(s.aliases, alias)
+	return nil
+}
+
+func (s *aliasesTestStore) Delete(_ context.Context, name string) error {
+	for i := range s.aliases {
+		if s.aliases[i].Name == name {
+			s.aliases = append(s.aliases[:i], s.aliases[i+1:]...)
+			return nil
+		}
+	}
+	return aliases.ErrNotFound
+}
+
+func (s *aliasesTestStore) Close() error {
+	return nil
+}
+
+type aliasesTestCatalog struct {
+	supported     map[string]bool
+	providerTypes map[string]string
+	models        map[string]core.Model
+}
+
+func (c *aliasesTestCatalog) Supports(model string) bool {
+	return c.supported[model]
+}
+
+func (c *aliasesTestCatalog) GetProviderType(model string) string {
+	return c.providerTypes[model]
+}
+
+func (c *aliasesTestCatalog) LookupModel(model string) (*core.Model, bool) {
+	entry, ok := c.models[model]
+	if !ok {
+		return nil, false
+	}
+	copy := entry
+	return &copy, true
 }
 
 type chunkedReadCloser struct {
@@ -258,6 +330,23 @@ func (m *mockProvider) GetProviderType(model string) string {
 		return "mock"
 	}
 	return ""
+}
+
+func (m *mockProvider) NativeFileProviderTypes() []string {
+	seen := make(map[string]struct{})
+	result := make([]string, 0, len(m.providerTypes))
+	for _, providerType := range m.providerTypes {
+		if providerType == "" {
+			continue
+		}
+		if _, exists := seen[providerType]; exists {
+			continue
+		}
+		seen[providerType] = struct{}{}
+		result = append(result, providerType)
+	}
+	sort.Strings(result)
+	return result
 }
 
 func (m *mockProvider) ChatCompletion(_ context.Context, _ *core.ChatRequest) (*core.ChatResponse, error) {
@@ -1156,12 +1245,12 @@ func TestGetBatch_UsesSemanticEnvelopeRouteMetadata(t *testing.T) {
 	createCtx := e.NewContext(createReq, createRec)
 	require.NoError(t, handler.Batches(createCtx))
 
-		var created core.BatchResponse
-		require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &created))
+	var created core.BatchResponse
+	require.NoError(t, json.Unmarshal(createRec.Body.Bytes(), &created))
 
-		getReq := httptest.NewRequest(http.MethodGet, "/v1/batches/wrong-id", nil)
-		frame := core.NewRequestSnapshot(http.MethodGet, "/v1/batches/"+created.ID, map[string]string{"id": created.ID}, nil, nil, "", nil, false, "", nil)
-		getReq = withRequestSnapshotAndPrompt(getReq, frame)
+	getReq := httptest.NewRequest(http.MethodGet, "/v1/batches/wrong-id", nil)
+	frame := core.NewRequestSnapshot(http.MethodGet, "/v1/batches/"+created.ID, map[string]string{"id": created.ID}, nil, nil, "", nil, false, "", nil)
+	getReq = withRequestSnapshotAndPrompt(getReq, frame)
 
 	getRec := httptest.NewRecorder()
 	getCtx := e.NewContext(getReq, getRec)
@@ -1200,10 +1289,10 @@ func TestListBatches_UsesSemanticEnvelopeQueryMetadata(t *testing.T) {
 	createCtx := e.NewContext(createReq, createRec)
 	require.NoError(t, handler.Batches(createCtx))
 
-		listReq := httptest.NewRequest(http.MethodGet, "/v1/batches?limit=bad", nil)
-		frame := core.NewRequestSnapshot(
-			http.MethodGet,
-			"/v1/batches",
+	listReq := httptest.NewRequest(http.MethodGet, "/v1/batches?limit=bad", nil)
+	frame := core.NewRequestSnapshot(
+		http.MethodGet,
+		"/v1/batches",
 		nil,
 		map[string][]string{
 			"limit": {"1"},
@@ -1212,10 +1301,10 @@ func TestListBatches_UsesSemanticEnvelopeQueryMetadata(t *testing.T) {
 		"",
 		nil,
 		false,
-			"",
-			nil,
-		)
-		listReq = withRequestSnapshotAndPrompt(listReq, frame)
+		"",
+		nil,
+	)
+	listReq = withRequestSnapshotAndPrompt(listReq, frame)
 
 	listRec := httptest.NewRecorder()
 	listCtx := e.NewContext(listReq, listRec)
@@ -3459,6 +3548,82 @@ func TestGetFileWithoutProviderSkipsProviderErrors(t *testing.T) {
 		t.Fatalf("expected status 200, got %d", rec.Code)
 	}
 	if !strings.Contains(rec.Body.String(), "\"id\":\"file_ok_1\"") {
+		t.Fatalf("unexpected response body: %s", rec.Body.String())
+	}
+}
+
+func TestGetFileWithoutProviderUsesProviderInventoryWhenAliasMasksModel(t *testing.T) {
+	catalog := aliasesTestCatalog{
+		supported: map[string]bool{
+			"gpt-4o":         true,
+			"claude-3-haiku": true,
+		},
+		providerTypes: map[string]string{
+			"gpt-4o":         "openai",
+			"claude-3-haiku": "anthropic",
+		},
+		models: map[string]core.Model{
+			"gpt-4o":         {ID: "gpt-4o", Object: "model"},
+			"claude-3-haiku": {ID: "claude-3-haiku", Object: "model"},
+		},
+	}
+
+	service, err := aliases.NewService(newAliasesTestStore(
+		aliases.Alias{Name: "gpt-4o", TargetModel: "claude-3-haiku", Enabled: true},
+	), &catalog)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	mock := &mockProvider{
+		supportedModels: []string{"gpt-4o", "claude-3-haiku"},
+		providerTypes: map[string]string{
+			"gpt-4o":         "openai",
+			"claude-3-haiku": "anthropic",
+		},
+		modelsResponse: &core.ModelsResponse{
+			Object: "list",
+			Data: []core.Model{
+				{ID: "gpt-4o", Object: "model"},
+				{ID: "claude-3-haiku", Object: "model"},
+			},
+		},
+		fileErrByProvider: map[string]error{
+			"anthropic": core.NewNotFoundError(""),
+		},
+		fileGetByProvider: map[string]*core.FileObject{
+			"openai": {
+				ID:        "file_ok_1",
+				Object:    "file",
+				Bytes:     10,
+				CreatedAt: 1000,
+				Filename:  "a.jsonl",
+				Purpose:   "batch",
+				Provider:  "openai",
+			},
+		},
+	}
+
+	provider := aliases.NewProvider(mock, service)
+	e := echo.New()
+	handler := NewHandler(provider, nil, nil, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/files/file_ok_1", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/v1/files/:id")
+	setPathParam(c, "id", "file_ok_1")
+
+	if err := handler.GetFile(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "\"provider\":\"openai\"") {
 		t.Fatalf("unexpected response body: %s", rec.Body.String())
 	}
 }

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -32,24 +32,24 @@ type Server struct {
 
 // Config holds server configuration options
 type Config struct {
-	MasterKey                              string                                 // Optional: Master key for authentication
-	MetricsEnabled                         bool                                   // Whether to expose Prometheus metrics endpoint
-	MetricsEndpoint                        string                                 // HTTP path for metrics endpoint (default: /metrics)
-	BodySizeLimit                          string                                 // Max request body size (e.g., "10M", "1024K")
-	AuditLogger                            auditlog.LoggerInterface               // Optional: Audit logger for request/response logging
-	UsageLogger                            usage.LoggerInterface                  // Optional: Usage logger for token tracking
-	PricingResolver                        usage.PricingResolver                  // Optional: Resolves pricing for cost calculation
-	BatchStore                             batchstore.Store                       // Optional: Batch lifecycle persistence store
-	LogOnlyModelInteractions               bool                                   // Only log AI model endpoints (default: true)
-	DisablePassthroughRoutes      bool     // Disable /p/{provider}/{endpoint} route registration
-	EnabledPassthroughProviders   []string // Provider types enabled on /p/{provider}/... passthrough routes
-	AllowPassthroughV1Alias       *bool    // Allow /p/{provider}/v1/... aliases; nil defaults to true
-	AdminEndpointsEnabled                  bool                                   // Whether admin API endpoints are enabled
-	AdminUIEnabled                         bool                                   // Whether admin dashboard UI is enabled
-	AdminHandler                           *admin.Handler                         // Admin API handler (nil if disabled)
-	DashboardHandler                       *dashboard.Handler                     // Dashboard UI handler (nil if disabled)
-	SwaggerEnabled                         bool                                   // Whether to expose the Swagger UI at /swagger/index.html
-	ResponseCacheMiddleware                *responsecache.ResponseCacheMiddleware // Optional: response cache middleware for cacheable endpoints
+	MasterKey                   string                                 // Optional: Master key for authentication
+	MetricsEnabled              bool                                   // Whether to expose Prometheus metrics endpoint
+	MetricsEndpoint             string                                 // HTTP path for metrics endpoint (default: /metrics)
+	BodySizeLimit               string                                 // Max request body size (e.g., "10M", "1024K")
+	AuditLogger                 auditlog.LoggerInterface               // Optional: Audit logger for request/response logging
+	UsageLogger                 usage.LoggerInterface                  // Optional: Usage logger for token tracking
+	PricingResolver             usage.PricingResolver                  // Optional: Resolves pricing for cost calculation
+	BatchStore                  batchstore.Store                       // Optional: Batch lifecycle persistence store
+	LogOnlyModelInteractions    bool                                   // Only log AI model endpoints (default: true)
+	DisablePassthroughRoutes    bool                                   // Disable /p/{provider}/{endpoint} route registration
+	EnabledPassthroughProviders []string                               // Provider types enabled on /p/{provider}/... passthrough routes
+	AllowPassthroughV1Alias     *bool                                  // Allow /p/{provider}/v1/... aliases; nil defaults to true
+	AdminEndpointsEnabled       bool                                   // Whether admin API endpoints are enabled
+	AdminUIEnabled              bool                                   // Whether admin dashboard UI is enabled
+	AdminHandler                *admin.Handler                         // Admin API handler (nil if disabled)
+	DashboardHandler            *dashboard.Handler                     // Dashboard UI handler (nil if disabled)
+	SwaggerEnabled              bool                                   // Whether to expose the Swagger UI at /swagger/index.html
+	ResponseCacheMiddleware     *responsecache.ResponseCacheMiddleware // Optional: response cache middleware for cacheable endpoints
 }
 
 // New creates a new HTTP server
@@ -230,6 +230,9 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 		adminAPI.GET("/audit/conversation", cfg.AdminHandler.AuditConversation)
 		adminAPI.GET("/models", cfg.AdminHandler.ListModels)
 		adminAPI.GET("/models/categories", cfg.AdminHandler.ListCategories)
+		adminAPI.GET("/aliases", cfg.AdminHandler.ListAliases)
+		adminAPI.PUT("/aliases/:name", cfg.AdminHandler.UpsertAlias)
+		adminAPI.DELETE("/aliases/:name", cfg.AdminHandler.DeleteAlias)
 	}
 
 	// Admin dashboard UI routes (behind ADMIN_UI_ENABLED flag)

--- a/internal/server/model_validation.go
+++ b/internal/server/model_validation.go
@@ -43,28 +43,19 @@ func ModelValidation(provider core.RoutableProvider) echo.MiddlewareFunc {
 				return next(c)
 			}
 
-			model, providerHint, parsed, err := selectorHintsForValidation(c)
+			resolution, parsed, err := ensureRequestModelResolution(c, provider)
 			if err != nil {
-				return handleError(c, core.NewInvalidRequestError(err.Error(), err))
+				return handleError(c, err)
 			}
-			if !parsed {
+			if !parsed || resolution == nil {
 				return next(c)
-			}
-			selector, err := core.ParseModelSelector(model, providerHint)
-			if err != nil {
-				return handleError(c, core.NewInvalidRequestError(err.Error(), err))
 			}
 			if counted, ok := provider.(modelCountProvider); ok && counted.ModelCount() == 0 {
 				return handleError(c, core.NewProviderError("", 0, "model registry not initialized", nil))
 			}
 
-			if !provider.Supports(selector.QualifiedModel()) {
-				return handleError(c, core.NewInvalidRequestError("unsupported model: "+selector.QualifiedModel(), nil))
-			}
-
-			providerType := provider.GetProviderType(selector.QualifiedModel())
-			c.Set(string(providerTypeKey), providerType)
-			auditlog.EnrichEntry(c, selector.Model, providerType)
+			c.Set(string(providerTypeKey), resolution.ProviderType)
+			auditlog.EnrichEntry(c, auditModelName(resolution), resolution.ProviderType)
 
 			requestID := c.Request().Header.Get("X-Request-ID")
 			ctx := core.WithRequestID(c.Request().Context(), requestID)
@@ -154,6 +145,9 @@ func providerPassthroughType(c *echo.Context) (string, bool) {
 func GetProviderType(c *echo.Context) string {
 	if v, ok := c.Get(string(providerTypeKey)).(string); ok {
 		return v
+	}
+	if resolution := core.GetRequestModelResolution(c.Request().Context()); resolution != nil {
+		return resolution.ProviderType
 	}
 	return ""
 }

--- a/internal/server/model_validation.go
+++ b/internal/server/model_validation.go
@@ -55,7 +55,7 @@ func ModelValidation(provider core.RoutableProvider) echo.MiddlewareFunc {
 			}
 
 			c.Set(string(providerTypeKey), resolution.ProviderType)
-			auditlog.EnrichEntry(c, auditModelName(resolution), resolution.ProviderType)
+			auditlog.EnrichEntryWithResolution(c, resolution)
 
 			requestID := c.Request().Header.Get("X-Request-ID")
 			ctx := core.WithRequestID(c.Request().Context(), requestID)

--- a/internal/server/model_validation_test.go
+++ b/internal/server/model_validation_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"gomodel/internal/aliases"
 	"gomodel/internal/core"
 )
 
@@ -321,8 +323,8 @@ func TestModelValidation_DoesNotReadLiveBodyWhenSelectorHintsAlreadyExist(t *tes
 	frame := core.NewRequestSnapshot(http.MethodPost, "/v1/chat/completions", nil, nil, nil, "application/json", nil, false, "", nil)
 	ctx := core.WithRequestSnapshot(req.Context(), frame)
 	ctx = core.WithWhiteBoxPrompt(ctx, &core.WhiteBoxPrompt{
-		RouteType:        "openai_compat",
-		OperationType:      "chat_completions",
+		RouteType:      "openai_compat",
+		OperationType:  "chat_completions",
 		JSONBodyParsed: true,
 		RouteHints: core.RouteHints{
 			Model: "gpt-4o-mini",
@@ -574,4 +576,70 @@ func TestGetProviderType_EmptyWhenNotSet(t *testing.T) {
 	c := e.NewContext(req, rec)
 
 	assert.Equal(t, "", GetProviderType(c))
+}
+
+func TestModelValidation_ResolvesQualifiedMaskingAliasBeforeProviderParsing(t *testing.T) {
+	catalog := aliasesTestCatalog{
+		supported: map[string]bool{
+			"anthropic/claude-opus-4-6": true,
+			"openai/gpt-5-nano":         true,
+		},
+		providerTypes: map[string]string{
+			"anthropic/claude-opus-4-6": "anthropic",
+			"openai/gpt-5-nano":         "openai",
+		},
+		models: map[string]core.Model{
+			"anthropic/claude-opus-4-6": {ID: "claude-opus-4-6", Object: "model"},
+			"openai/gpt-5-nano":         {ID: "gpt-5-nano", Object: "model"},
+		},
+	}
+
+	service, err := aliases.NewService(newAliasesTestStore(
+		aliases.Alias{Name: "anthropic/claude-opus-4-6", TargetModel: "gpt-5-nano", TargetProvider: "openai", Enabled: true},
+	), &catalog)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	inner := &mockProvider{
+		supportedModels: []string{"claude-opus-4-6", "gpt-5-nano"},
+		providerTypes: map[string]string{
+			"anthropic/claude-opus-4-6": "anthropic",
+			"openai/gpt-5-nano":         "openai",
+		},
+	}
+	provider := aliases.NewProvider(inner, service)
+
+	e := echo.New()
+	var (
+		capturedProviderType string
+		capturedResolution   *core.RequestModelResolution
+	)
+
+	middleware := ModelValidation(provider)
+	handler := middleware(func(c *echo.Context) error {
+		capturedProviderType = GetProviderType(c)
+		capturedResolution = core.GetRequestModelResolution(c.Request().Context())
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"anthropic/claude-opus-4-6","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err = handler(c)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "openai", capturedProviderType)
+	if assert.NotNil(t, capturedResolution) {
+		assert.True(t, capturedResolution.AliasApplied)
+		assert.Equal(t, "anthropic/claude-opus-4-6", capturedResolution.RequestedQualifiedModel())
+		assert.Equal(t, "openai/gpt-5-nano", capturedResolution.ResolvedQualifiedModel())
+	}
 }

--- a/internal/server/model_validation_test.go
+++ b/internal/server/model_validation_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"gomodel/internal/aliases"
+	"gomodel/internal/auditlog"
 	"gomodel/internal/core"
 )
 
@@ -409,6 +410,59 @@ func TestModelValidation_RegistryNotInitializedReturnsGatewayError(t *testing.T)
 	assert.False(t, handlerCalled)
 	assert.Equal(t, http.StatusBadGateway, rec.Code)
 	assert.Contains(t, rec.Body.String(), "model registry not initialized")
+}
+
+func TestModelValidation_EnrichesAuditEntryWithRequestedModelOnResolutionError(t *testing.T) {
+	store := newAliasesTestStore(aliases.Alias{Name: "smart", TargetModel: "gpt-4o", TargetProvider: "openai", Enabled: false})
+	catalog := &aliasesTestCatalog{
+		supported: map[string]bool{
+			"openai/gpt-4o": true,
+		},
+		providerTypes: map[string]string{
+			"openai/gpt-4o": "openai",
+		},
+		models: map[string]core.Model{
+			"openai/gpt-4o": {ID: "gpt-4o", Object: "model"},
+		},
+	}
+	service, err := aliases.NewService(store, catalog)
+	require.NoError(t, err)
+	require.NoError(t, service.Refresh(context.Background()))
+
+	inner := &mockProvider{
+		supportedModels: []string{"gpt-4o"},
+		providerTypes: map[string]string{
+			"openai/gpt-4o": "openai",
+		},
+	}
+	provider := aliases.NewProvider(inner, service)
+
+	e := echo.New()
+	handlerCalled := false
+
+	middleware := ModelValidation(provider)
+	handler := middleware(func(c *echo.Context) error {
+		handlerCalled = true
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"smart","input":"hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	entry := &auditlog.LogEntry{Data: &auditlog.LogData{}}
+	c.Set(string(auditlog.LogEntryKey), entry)
+
+	err = handler(c)
+	require.NoError(t, err)
+
+	assert.False(t, handlerCalled)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "unsupported model: smart")
+	assert.Equal(t, "smart", entry.Model)
+	assert.Equal(t, "", entry.ResolvedModel)
+	assert.Equal(t, "", entry.Provider)
+	assert.Equal(t, "invalid_request_error", entry.ErrorType)
 }
 
 func TestModelValidation_ResolvesProviderTypeFromOversizedLiveBody(t *testing.T) {

--- a/internal/server/model_validation_test.go
+++ b/internal/server/model_validation_test.go
@@ -384,7 +384,7 @@ func TestModelValidation_UsesIngressBodyForMissingSelectorHints(t *testing.T) {
 
 func TestModelValidation_RegistryNotInitializedReturnsGatewayError(t *testing.T) {
 	provider := &modelCountingValidationProvider{
-		mockProvider: &mockProvider{supportedModels: []string{"gpt-4o-mini"}},
+		mockProvider: &mockProvider{},
 		modelCount:   0,
 	}
 

--- a/internal/server/request_model_resolution.go
+++ b/internal/server/request_model_resolution.go
@@ -98,13 +98,3 @@ func applyRequestModelResolution(c *echo.Context, provider core.RoutableProvider
 	*providerHint = resolution.ResolvedSelector.Provider
 	return nil
 }
-
-func auditModelName(resolution *core.RequestModelResolution) string {
-	if resolution == nil {
-		return ""
-	}
-	if resolution.AliasApplied {
-		return resolution.RequestedQualifiedModel()
-	}
-	return resolution.ResolvedSelector.Model
-}

--- a/internal/server/request_model_resolution.go
+++ b/internal/server/request_model_resolution.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/labstack/echo/v5"
 
+	"gomodel/internal/auditlog"
 	"gomodel/internal/core"
 )
 
@@ -73,6 +74,7 @@ func ensureRequestModelResolution(c *echo.Context, provider core.RoutableProvide
 	if err != nil || !parsed {
 		return nil, parsed, err
 	}
+	enrichAuditEntryWithRequestedModel(c, model, providerHint)
 
 	resolution, err := resolveRequestModel(provider, model, providerHint)
 	if err != nil {
@@ -89,6 +91,7 @@ func applyRequestModelResolution(c *echo.Context, provider core.RoutableProvider
 
 	resolution := core.GetRequestModelResolution(c.Request().Context())
 	if resolution == nil {
+		enrichAuditEntryWithRequestedModel(c, *model, *providerHint)
 		var err error
 		resolution, err = resolveRequestModel(provider, *model, *providerHint)
 		if err != nil {
@@ -100,4 +103,19 @@ func applyRequestModelResolution(c *echo.Context, provider core.RoutableProvider
 	*model = resolution.ResolvedSelector.Model
 	*providerHint = resolution.ResolvedSelector.Provider
 	return nil
+}
+
+func enrichAuditEntryWithRequestedModel(c *echo.Context, model, providerHint string) {
+	if c == nil {
+		return
+	}
+	model = strings.TrimSpace(model)
+	providerHint = strings.TrimSpace(providerHint)
+	if model == "" {
+		return
+	}
+	auditlog.EnrichEntryWithResolution(c, &core.RequestModelResolution{
+		RequestedModel:    model,
+		RequestedProvider: providerHint,
+	})
 }

--- a/internal/server/request_model_resolution.go
+++ b/internal/server/request_model_resolution.go
@@ -1,0 +1,110 @@
+package server
+
+import (
+	"strings"
+
+	"github.com/labstack/echo/v5"
+
+	"gomodel/internal/core"
+)
+
+type resolvedModelProvider interface {
+	ResolveModel(model, provider string) (core.ModelSelector, bool, error)
+}
+
+func resolveRequestModel(provider core.RoutableProvider, model, providerHint string) (*core.RequestModelResolution, error) {
+	model = strings.TrimSpace(model)
+	providerHint = strings.TrimSpace(providerHint)
+
+	var (
+		resolvedSelector core.ModelSelector
+		aliasApplied     bool
+		err              error
+	)
+
+	if resolver, ok := provider.(resolvedModelProvider); ok {
+		resolvedSelector, aliasApplied, err = resolver.ResolveModel(model, providerHint)
+	} else {
+		resolvedSelector, err = core.ParseModelSelector(model, providerHint)
+	}
+	if err != nil {
+		return nil, core.NewInvalidRequestError(err.Error(), err)
+	}
+
+	resolvedModel := resolvedSelector.QualifiedModel()
+	if !provider.Supports(resolvedModel) {
+		return nil, core.NewInvalidRequestError("unsupported model: "+resolvedModel, nil)
+	}
+
+	return &core.RequestModelResolution{
+		RequestedModel:    model,
+		RequestedProvider: providerHint,
+		ResolvedSelector:  resolvedSelector,
+		ProviderType:      strings.TrimSpace(provider.GetProviderType(resolvedModel)),
+		AliasApplied:      aliasApplied,
+	}, nil
+}
+
+func storeRequestModelResolution(c *echo.Context, resolution *core.RequestModelResolution) {
+	if c == nil || resolution == nil {
+		return
+	}
+
+	ctx := core.WithRequestModelResolution(c.Request().Context(), resolution)
+	if env := core.GetWhiteBoxPrompt(ctx); env != nil {
+		env.RouteHints.Model = resolution.ResolvedSelector.Model
+		env.RouteHints.Provider = resolution.ResolvedSelector.Provider
+	}
+	c.SetRequest(c.Request().WithContext(ctx))
+}
+
+func ensureRequestModelResolution(c *echo.Context, provider core.RoutableProvider) (*core.RequestModelResolution, bool, error) {
+	if c == nil {
+		return nil, false, nil
+	}
+	if resolution := core.GetRequestModelResolution(c.Request().Context()); resolution != nil {
+		return resolution, true, nil
+	}
+
+	model, providerHint, parsed, err := selectorHintsForValidation(c)
+	if err != nil || !parsed {
+		return nil, parsed, err
+	}
+
+	resolution, err := resolveRequestModel(provider, model, providerHint)
+	if err != nil {
+		return nil, true, err
+	}
+	storeRequestModelResolution(c, resolution)
+	return resolution, true, nil
+}
+
+func applyRequestModelResolution(c *echo.Context, provider core.RoutableProvider, model, providerHint *string) error {
+	if model == nil || providerHint == nil {
+		return core.NewInvalidRequestError("model selector targets are required", nil)
+	}
+
+	resolution := core.GetRequestModelResolution(c.Request().Context())
+	if resolution == nil {
+		var err error
+		resolution, err = resolveRequestModel(provider, *model, *providerHint)
+		if err != nil {
+			return err
+		}
+		storeRequestModelResolution(c, resolution)
+	}
+
+	*model = resolution.ResolvedSelector.Model
+	*providerHint = resolution.ResolvedSelector.Provider
+	return nil
+}
+
+func auditModelName(resolution *core.RequestModelResolution) string {
+	if resolution == nil {
+		return ""
+	}
+	if resolution.AliasApplied {
+		return resolution.RequestedQualifiedModel()
+	}
+	return resolution.ResolvedSelector.Model
+}

--- a/internal/server/request_model_resolution.go
+++ b/internal/server/request_model_resolution.go
@@ -32,6 +32,9 @@ func resolveRequestModel(provider core.RoutableProvider, model, providerHint str
 	}
 
 	resolvedModel := resolvedSelector.QualifiedModel()
+	if counted, ok := provider.(modelCountProvider); ok && counted.ModelCount() == 0 {
+		return nil, core.NewProviderError("", 0, "model registry not initialized", nil)
+	}
 	if !provider.Supports(resolvedModel) {
 		return nil, core.NewInvalidRequestError("unsupported model: "+resolvedModel, nil)
 	}


### PR DESCRIPTION
## Summary
- add a dedicated aliases subsystem with DB-backed storage adapters and in-memory request-time caching
- wrap the provider chain so aliases resolve before the concrete registry, including masking real model IDs and rewriting inline batch items
- add admin alias CRUD endpoints and expose enabled aliases through `/v1/models`

## Testing
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model aliases: admin UI + API to list/create/update/enable/disable/delete aliases; aliases appear in model listings, can mask or expose models, and resolve transparently for routing, providers, caching, and file-backed batch inputs.
  * Alias-aware provider integration: provider wrapper that resolves and rewrites requests/models.
  * Batch preprocessing: provider-aware rewriting for inline and file-backed batches with per-item endpoint hints and input-file rewrite tracking.
  * Audit logs: include resolved model and flag when an alias was used.

* **Tests**
  * Extensive tests covering alias storage/service, provider rewriting, admin endpoints, validation, background refresh, batch rewriting, and UI assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->