### PR TITLE
perf: Prefer cached route hints during validation

### DIFF
--- a/internal/server/model_validation.go
+++ b/internal/server/model_validation.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"encoding/json"
 	"strings"
 
@@ -124,9 +123,6 @@ func selectorHintsForValidation(c *echo.Context) (model, provider string, parsed
 		if model, provider, ok := cachedCanonicalSelectorHints(env); ok {
 			return model, provider, true, nil
 		}
-		if model, provider, ok := decodeCanonicalSelectorHintsForValidation(ctx, env); ok {
-			return model, provider, true, nil
-		}
 		if env.JSONBodyParsed || env.RouteHints.Model != "" || env.RouteHints.Provider != "" {
 			return env.RouteHints.Model, env.RouteHints.Provider, true, nil
 		}
@@ -154,21 +150,6 @@ func selectorHintsForValidation(c *echo.Context) (model, provider string, parsed
 
 func cachedCanonicalSelectorHints(env *core.WhiteBoxPrompt) (model, provider string, ok bool) {
 	return env.CanonicalSelectorFromCachedRequest()
-}
-
-func decodeCanonicalSelectorHintsForValidation(ctx context.Context, env *core.WhiteBoxPrompt) (model, provider string, ok bool) {
-	if env == nil {
-		return "", "", false
-	}
-	snapshot := core.GetRequestSnapshot(ctx)
-	if snapshot == nil {
-		return "", "", false
-	}
-	rawBody := snapshot.CapturedBody()
-	if rawBody == nil {
-		return "", "", false
-	}
-	return core.DecodeCanonicalSelector(rawBody, env)
 }
 
 func providerPassthroughType(c *echo.Context) (string, bool) {

--- a/internal/server/model_validation_test.go
+++ b/internal/server/model_validation_test.go
@@ -650,7 +650,7 @@ func TestModelValidation_ResolvesProviderTypeFromOversizedLiveBody(t *testing.T)
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
-func TestModelValidation_CachesCanonicalChatRequestFromIngressBody(t *testing.T) {
+func TestModelValidation_DoesNotCacheCanonicalChatRequestWhenRouteHintsAlreadyExist(t *testing.T) {
 	provider := &mockProvider{supportedModels: []string{"gpt-4o-mini"}}
 
 	e := echo.New()
@@ -693,14 +693,12 @@ func TestModelValidation_CachesCanonicalChatRequestFromIngressBody(t *testing.T)
 	err := handler(c)
 	require.NoError(t, err)
 	require.NotNil(t, capturedEnv)
-	canonicalReq := capturedEnv.CachedChatRequest()
-	require.NotNil(t, canonicalReq)
-	assert.Equal(t, "gpt-4o-mini", canonicalReq.Model)
-	assert.Equal(t, "openai", canonicalReq.Provider)
-	assert.NotNil(t, canonicalReq.ExtraFields["response_format"])
+	assert.Nil(t, capturedEnv.CachedChatRequest())
+	assert.Equal(t, "gpt-4o-mini", capturedEnv.RouteHints.Model)
+	assert.Equal(t, "openai", capturedEnv.RouteHints.Provider)
 }
 
-func TestModelValidation_CachesCanonicalResponsesRequestFromIngressBody(t *testing.T) {
+func TestModelValidation_DoesNotCacheCanonicalResponsesRequestWhenRouteHintsAlreadyExist(t *testing.T) {
 	provider := &mockProvider{supportedModels: []string{"gpt-4o-mini"}}
 
 	e := echo.New()
@@ -741,13 +739,8 @@ func TestModelValidation_CachesCanonicalResponsesRequestFromIngressBody(t *testi
 	err := handler(c)
 	require.NoError(t, err)
 	require.NotNil(t, capturedEnv)
-	canonicalReq := capturedEnv.CachedResponsesRequest()
-	require.NotNil(t, canonicalReq)
-
-	input, ok := canonicalReq.Input.([]core.ResponsesInputElement)
-	require.True(t, ok)
-	require.Len(t, input, 1)
-	assert.NotNil(t, input[0].ExtraFields["x_trace"])
+	assert.Nil(t, capturedEnv.CachedResponsesRequest())
+	assert.Equal(t, "gpt-4o-mini", capturedEnv.RouteHints.Model)
 }
 
 func TestGetProviderType_EmptyWhenNotSet(t *testing.T) {


### PR DESCRIPTION
# Summary

Describe what changed and why.

## PR Title Format (required)

Use Conventional Commits in the PR title:

`type(scope): short summary`

Examples:
- `feat(cache): add Redis-backed model cache`
- `fix(streaming): flush done marker in SSE`
- `docs(config): clarify provider auto-discovery`

Allowed `type` values:
- `feat`
- `fix`
- `perf`
- `docs`
- `refactor`
- `test`
- `build`
- `ci`
- `chore`
- `revert`

Breaking changes:
- Add `!` before `:` (example: `feat(api)!: remove legacy endpoint`)

## Release Notes

- User-facing work should use `feat`, `fix`, `perf`, or `docs`.
- Internal-only work (`test`, `ci`, `build`, `chore`, many `refactor`s) is auto-labeled and excluded from release notes.
- Use `release:skip` label to explicitly exclude an item from release notes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined model validation logic to optimize request processing when route hints are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->