### PR TITLE
fix: Improve hot-path instrumentation and low-risk streaming performance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,6 +104,22 @@ jobs:
       - name: Run contract replay tests
         run: go test -v -tags=contract -timeout=5m ./tests/contract/...
 
+  performance:
+    name: Performance Guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Run hot-path performance guard
+        # Thresholds are maintained in tests/perf/hotpath_test.go.
+        run: make perf-check
+
   docs-validate:
     name: Docs Validation
     runs-on: ubuntu-latest
@@ -122,7 +138,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, test-unit, test-e2e, integration, test-contract]
+    needs: [lint, test-unit, test-e2e, integration, test-contract, performance]
     steps:
       - uses: actions/checkout@v6
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,12 @@ repos:
         language: system
         pass_filenames: false
         files: '(\.go$|^go\.(mod|sum)$)'
+      - id: perf-hotpath-guard
+        name: hot-path performance guard (alloc/byte thresholds)
+        entry: make perf-check
+        language: system
+        pass_filenames: false
+        files: '^(internal/(auditlog|core|providers|server|usage)/.*\.go|tests/perf/.*\.go|Makefile|\.github/workflows/test\.yml)$'
 
   # 3. High-Performance Go Linter (golangci-lint)
   - repo: https://github.com/golangci/golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build run clean tidy test test-e2e test-integration test-contract test-all lint lint-fix record-api swagger install-tools
+.PHONY: all build run clean tidy test test-e2e test-integration test-contract test-all lint lint-fix record-api swagger install-tools perf-check perf-bench
 
 all: build
 
@@ -49,6 +49,12 @@ test-contract:
 
 # Run all tests including e2e, integration, and contract tests
 test-all: test test-e2e test-integration test-contract
+
+perf-check:
+	go test -run '^TestHotPathPerfGuard$$' -count=1 -v ./tests/perf/...
+
+perf-bench:
+	go test -bench=. -benchmem ./tests/perf/...
 
 # Record API responses for contract tests
 # Usage: OPENAI_API_KEY=sk-xxx make record-api

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -7,6 +7,7 @@ server:
   port: "8080"
   master_key: "your-secret-key"
   body_size_limit: "10M"
+  pprof_enabled: false # expose /debug/pprof/* for local profiling only
   enable_passthrough_routes: true # expose /p/{provider}/{endpoint} passthrough routes
   allow_passthrough_v1_alias: true # allow /p/{provider}/v1/... while keeping /p/{provider}/... canonical
   enabled_passthrough_providers: ["openai", "anthropic"] # providers enabled on /p/{provider}/...

--- a/config/config.go
+++ b/config/config.go
@@ -335,6 +335,7 @@ type ServerConfig struct {
 	MasterKey      string `yaml:"master_key" env:"GOMODEL_MASTER_KEY"`   // Optional: Master key for authentication
 	BodySizeLimit  string `yaml:"body_size_limit" env:"BODY_SIZE_LIMIT"` // Max request body size (e.g., "10M", "1024K")
 	SwaggerEnabled bool   `yaml:"swagger_enabled" env:"SWAGGER_ENABLED"` // Whether to expose the Swagger UI at /swagger/index.html
+	PprofEnabled   bool   `yaml:"pprof_enabled" env:"PPROF_ENABLED"`     // Whether to expose debug profiling routes at /debug/pprof/*
 	// EnablePassthroughRoutes exposes provider-native passthrough endpoints under
 	// /p/{provider}/{endpoint}. Default: true.
 	EnablePassthroughRoutes bool `yaml:"enable_passthrough_routes" env:"ENABLE_PASSTHROUGH_ROUTES"`
@@ -405,8 +406,9 @@ type ResilienceConfig struct {
 func buildDefaultConfig() *Config {
 	return &Config{
 		Server: ServerConfig{
-			Port:                         "8080",
-			SwaggerEnabled:               true,
+			Port:                    "8080",
+			SwaggerEnabled:          true,
+			PprofEnabled:            false,
 			EnablePassthroughRoutes: true,
 			AllowPassthroughV1Alias: true,
 			EnabledPassthroughProviders: []string{

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -189,6 +189,15 @@ func TestApplyEnvOverrides(t *testing.T) {
 			},
 		},
 		{
+			name:    "PPROF_ENABLED override",
+			envVars: map[string]string{"PPROF_ENABLED": "true"},
+			check: func(t *testing.T, cfg *Config) {
+				if !cfg.Server.PprofEnabled {
+					t.Error("Server.PprofEnabled should be true")
+				}
+			},
+		},
+		{
 			name:    "passthrough v1 normalization override",
 			envVars: map[string]string{"ALLOW_PASSTHROUGH_V1_ALIAS": "false"},
 			check: func(t *testing.T, cfg *Config) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,7 +26,7 @@ func clearProviderEnvVars(t *testing.T) {
 func clearAllConfigEnvVars(t *testing.T) {
 	t.Helper()
 	for _, key := range []string{
-		"PORT", "GOMODEL_MASTER_KEY", "BODY_SIZE_LIMIT", "ENABLE_PASSTHROUGH_ROUTES", "ALLOW_PASSTHROUGH_V1_ALIAS", "ENABLED_PASSTHROUGH_PROVIDERS",
+		"PORT", "GOMODEL_MASTER_KEY", "BODY_SIZE_LIMIT", "SWAGGER_ENABLED", "PPROF_ENABLED", "ENABLE_PASSTHROUGH_ROUTES", "ALLOW_PASSTHROUGH_V1_ALIAS", "ENABLED_PASSTHROUGH_PROVIDERS",
 		"GOMODEL_CACHE_DIR", "CACHE_REFRESH_INTERVAL",
 		"REDIS_URL", "REDIS_KEY_MODELS", "REDIS_KEY_RESPONSES", "REDIS_TTL_MODELS", "REDIS_TTL_RESPONSES",
 		"STORAGE_TYPE", "SQLITE_PATH", "POSTGRES_URL", "POSTGRES_MAX_CONNS",
@@ -66,6 +66,9 @@ func TestBuildDefaultConfig(t *testing.T) {
 
 	if cfg.Server.Port != "8080" {
 		t.Errorf("expected Server.Port=8080, got %s", cfg.Server.Port)
+	}
+	if cfg.Server.PprofEnabled {
+		t.Error("expected Server.PprofEnabled=false")
 	}
 	if !cfg.Server.EnablePassthroughRoutes {
 		t.Error("expected Server.EnablePassthroughRoutes=true")
@@ -182,6 +185,7 @@ func TestLoad_YAMLOverridesDefaults(t *testing.T) {
 		yaml := `
 server:
   port: "3000"
+  pprof_enabled: true
 cache:
   model:
     redis:
@@ -205,6 +209,9 @@ logging:
 
 		if cfg.Server.Port != "3000" {
 			t.Errorf("expected port 3000, got %s", cfg.Server.Port)
+		}
+		if !cfg.Server.PprofEnabled {
+			t.Error("expected Server.PprofEnabled=true from YAML")
 		}
 		if cfg.Cache.Model.Redis == nil {
 			t.Fatal("expected Cache.Model.Redis to be set")

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -201,6 +201,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		MetricsEnabled:               appCfg.Metrics.Enabled,
 		MetricsEndpoint:              appCfg.Metrics.Endpoint,
 		BodySizeLimit:                appCfg.Server.BodySizeLimit,
+		PprofEnabled:                 appCfg.Server.PprofEnabled,
 		AuditLogger:                  auditResult.Logger,
 		UsageLogger:                  usageResult.Logger,
 		PricingResolver:              providerResult.Registry,
@@ -243,6 +244,9 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 
 	if appCfg.Server.SwaggerEnabled {
 		slog.Info("swagger UI enabled", "path", "/swagger/index.html")
+	}
+	if appCfg.Server.PprofEnabled {
+		slog.Info("pprof enabled", "path", "/debug/pprof/")
 	}
 	if appCfg.Server.EnablePassthroughRoutes {
 		slog.Info("provider passthrough enabled", "path", "/p/{provider}/{endpoint}")

--- a/internal/auditlog/auditlog_test.go
+++ b/internal/auditlog/auditlog_test.go
@@ -413,6 +413,54 @@ func TestMiddleware_UsesIngressTooLargeFlagWithoutReadingStream(t *testing.T) {
 	}
 }
 
+func TestMiddleware_SkipsStreamingResponseWriterCapture(t *testing.T) {
+	e := echo.New()
+	logger := &capturingLogger{
+		cfg: Config{Enabled: true, LogBodies: true},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-4","stream":true}`))
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	var capture *responseBodyCapture
+	handler := Middleware(logger)(func(c *echo.Context) error {
+		var ok bool
+		capture, ok = c.Response().(*responseBodyCapture)
+		if !ok {
+			t.Fatalf("Response = %T, want *responseBodyCapture", c.Response())
+		}
+
+		MarkEntryAsStreaming(c, true)
+		EnrichEntryWithStream(c, true)
+		c.Response().Header().Set("Content-Type", "text/event-stream")
+		c.Response().WriteHeader(http.StatusOK)
+		if _, err := c.Response().Write([]byte("data: {\"id\":\"chatcmpl-test\"}\n\n")); err != nil {
+			return err
+		}
+		if _, err := c.Response().Write([]byte("data: [DONE]\n\n")); err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if err := handler(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if capture == nil {
+		t.Fatal("capture = nil, want non-nil")
+	}
+	if capture.body.Len() != 0 {
+		t.Fatalf("captured body len = %d, want 0 for streaming response", capture.body.Len())
+	}
+	if capture.truncated {
+		t.Fatal("truncated = true, want false")
+	}
+	if len(logger.entries) != 0 {
+		t.Fatalf("len(entries) = %d, want 0 because streaming wrapper should own logging", len(logger.entries))
+	}
+}
+
 func TestMiddleware_PrefersExecutionPlanOverLegacyResolution(t *testing.T) {
 	e := echo.New()
 	logger := &capturingLogger{
@@ -1051,6 +1099,31 @@ func TestResponseBodyCapture_Write_MultipleChunksOverflow(t *testing.T) {
 	}
 	if capture.body.Len() != int(MaxBodyCapture) {
 		t.Errorf("expected buffer still at %d after third chunk, got %d", MaxBodyCapture, capture.body.Len())
+	}
+}
+
+func TestResponseBodyCapture_Write_SkipsWhenDisabled(t *testing.T) {
+	capture := &responseBodyCapture{
+		ResponseWriter: &discardWriter{},
+		body:           &bytes.Buffer{},
+		shouldCapture: func() bool {
+			return false
+		},
+	}
+
+	payload := []byte(`data: {"chunk":1}` + "\n\n")
+	n, err := capture.Write(payload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != len(payload) {
+		t.Fatalf("written = %d, want %d", n, len(payload))
+	}
+	if capture.body.Len() != 0 {
+		t.Fatalf("captured body len = %d, want 0", capture.body.Len())
+	}
+	if capture.truncated {
+		t.Fatal("truncated = true, want false")
 	}
 }
 

--- a/internal/auditlog/auditlog_test.go
+++ b/internal/auditlog/auditlog_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"gomodel/internal/core"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -17,8 +18,6 @@ import (
 
 	"github.com/andybalholm/brotli"
 	"github.com/labstack/echo/v5"
-
-	"gomodel/internal/core"
 )
 
 func TestRedactHeaders(t *testing.T) {
@@ -698,9 +697,9 @@ func TestIsModelInteractionPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := IsModelInteractionPath(tt.path)
+			result := core.IsModelInteractionPath(tt.path)
 			if result != tt.expected {
-				t.Errorf("IsModelInteractionPath(%q) = %v, want %v", tt.path, result, tt.expected)
+				t.Errorf("core.IsModelInteractionPath(%q) = %v, want %v", tt.path, result, tt.expected)
 			}
 		})
 	}

--- a/internal/auditlog/constants.go
+++ b/internal/auditlog/constants.go
@@ -10,10 +10,6 @@ const (
 	// Used by StreamLogWrapper to limit reconstructed response body size.
 	MaxContentCapture = 1024 * 1024
 
-	// SSEBufferSize is the rolling buffer size for extracting usage from SSE streams.
-	// Must be large enough to capture the final usage event containing token counts.
-	SSEBufferSize = 8192
-
 	// BatchFlushThreshold is the number of entries that triggers an immediate flush.
 	// When the batch reaches this size, it's written to storage without waiting for the timer.
 	BatchFlushThreshold = 100

--- a/internal/auditlog/middleware.go
+++ b/internal/auditlog/middleware.go
@@ -99,6 +99,9 @@ func Middleware(logger LoggerInterface) echo.MiddlewareFunc {
 				responseCapture = &responseBodyCapture{
 					ResponseWriter: c.Response(),
 					body:           &bytes.Buffer{},
+					shouldCapture: func() bool {
+						return shouldCaptureResponseBody(c)
+					},
 				}
 				c.SetResponse(responseCapture)
 			}
@@ -121,7 +124,7 @@ func Middleware(logger LoggerInterface) echo.MiddlewareFunc {
 			}
 
 			// Capture response body if enabled
-			if cfg.LogBodies && responseCapture != nil && responseCapture.body.Len() > 0 {
+			if cfg.LogBodies && responseCapture != nil && shouldCaptureResponseBody(c) && responseCapture.body.Len() > 0 {
 				// Set truncation flag if response body exceeded limit
 				if responseCapture.truncated {
 					entry.Data.ResponseBodyTooBigToHandle = true
@@ -258,11 +261,15 @@ type responseBodyCapture struct {
 	http.ResponseWriter
 	body      *bytes.Buffer
 	truncated bool
+	// shouldCapture allows middleware to stop buffering once the request is
+	// known to be streaming. Streaming responses are handled by StreamLogWrapper.
+	shouldCapture func() bool
 }
 
 func (r *responseBodyCapture) Write(b []byte) (int, error) {
-	// Write to the capture buffer (limit to MaxBodyCapture to avoid memory issues)
-	if !r.truncated {
+	// Write to the capture buffer (limit to MaxBodyCapture to avoid memory issues).
+	// Streaming responses bypass this path once marked or identified as SSE.
+	if r.captureEnabled() && !r.truncated {
 		remaining := int(MaxBodyCapture) - r.body.Len()
 		if remaining > 0 {
 			if len(b) <= remaining {
@@ -277,6 +284,13 @@ func (r *responseBodyCapture) Write(b []byte) (int, error) {
 	}
 	// Write to the original response writer
 	return r.ResponseWriter.Write(b)
+}
+
+func (r *responseBodyCapture) captureEnabled() bool {
+	if r == nil || r.shouldCapture == nil {
+		return true
+	}
+	return r.shouldCapture()
 }
 
 // Flush implements http.Flusher. It delegates to the underlying ResponseWriter
@@ -300,6 +314,24 @@ func (r *responseBodyCapture) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 
 func (r *responseBodyCapture) Unwrap() http.ResponseWriter {
 	return r.ResponseWriter
+}
+
+func shouldCaptureResponseBody(c *echo.Context) bool {
+	if c == nil {
+		return true
+	}
+	if IsEntryMarkedAsStreaming(c) {
+		return false
+	}
+	return !isEventStreamContentType(c.Response().Header().Get("Content-Type"))
+}
+
+func isEventStreamContentType(contentType string) bool {
+	if contentType == "" {
+		return false
+	}
+	mediaType := strings.ToLower(strings.TrimSpace(strings.Split(contentType, ";")[0]))
+	return mediaType == "text/event-stream"
 }
 
 // extractHeaders extracts headers from a map[string][]string (http.Header or echo headers),

--- a/internal/auditlog/middleware.go
+++ b/internal/auditlog/middleware.go
@@ -40,7 +40,7 @@ func Middleware(logger LoggerInterface) echo.MiddlewareFunc {
 			cfg := logger.Config()
 
 			// Skip non-model paths if OnlyModelInteractions is enabled
-			if cfg.OnlyModelInteractions && !IsModelInteractionPath(c.Request().URL.Path) {
+			if cfg.OnlyModelInteractions && !core.IsModelInteractionPath(c.Request().URL.Path) {
 				return next(c)
 			}
 

--- a/internal/auditlog/store_postgresql.go
+++ b/internal/auditlog/store_postgresql.go
@@ -2,14 +2,35 @@ package auditlog
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+const (
+	auditLogInsertColumnCount     = 15
+	postgresMaxBindParameters     = 65535
+	auditLogInsertMaxRowsPerQuery = postgresMaxBindParameters / auditLogInsertColumnCount
+)
+
+const auditLogInsertPrefix = `
+		INSERT INTO audit_logs (id, timestamp, duration_ns, model, resolved_model, provider, alias_used, status_code,
+			request_id, client_ip, method, path, stream, error_type, data)
+		VALUES `
+
+const auditLogInsertSuffix = `
+		ON CONFLICT (id) DO NOTHING
+	`
+
+type auditLogBatchExecutor interface {
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
+}
 
 // PostgreSQLStore implements LogStore for PostgreSQL databases.
 type PostgreSQLStore struct {
@@ -114,62 +135,24 @@ func (s *PostgreSQLStore) WriteBatch(ctx context.Context, entries []*LogEntry) e
 
 // writeBatchSmall uses INSERT for small batches
 func (s *PostgreSQLStore) writeBatchSmall(ctx context.Context, entries []*LogEntry) error {
-	var errs []error
-
-	for _, e := range entries {
-		dataJSON := marshalLogData(e.Data, e.ID)
-
-		_, err := s.pool.Exec(ctx, `
-			INSERT INTO audit_logs (id, timestamp, duration_ns, model, resolved_model, provider, alias_used, status_code,
-				request_id, client_ip, method, path, stream, error_type, data)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
-			ON CONFLICT (id) DO NOTHING
-		`, e.ID, e.Timestamp, e.DurationNs, e.Model, e.ResolvedModel, e.Provider, e.AliasUsed, e.StatusCode,
-			e.RequestID, e.ClientIP, e.Method, e.Path, e.Stream, e.ErrorType, dataJSON)
-
-		if err != nil {
-			slog.Warn("failed to insert audit log", "error", err, "id", e.ID)
-			errs = append(errs, fmt.Errorf("insert %s: %w", e.ID, err))
-		}
-	}
-
-	if len(errs) > 0 {
-		return fmt.Errorf("failed to insert %d of %d audit logs: %w", len(errs), len(entries), errors.Join(errs...))
+	if err := writeAuditLogInsertChunks(ctx, s.pool, entries); err != nil {
+		slog.Warn("failed to insert audit log batch", "error", err, "count", len(entries))
+		return fmt.Errorf("failed to insert %d audit logs: %w", len(entries), err)
 	}
 	return nil
 }
 
 // writeBatchLarge uses batch insert for larger batches
 func (s *PostgreSQLStore) writeBatchLarge(ctx context.Context, entries []*LogEntry) error {
-	// For larger batches, use individual inserts in a transaction
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 	defer tx.Rollback(ctx) //nolint:errcheck
 
-	var errs []error
-
-	for _, e := range entries {
-		dataJSON := marshalLogData(e.Data, e.ID)
-
-		_, err = tx.Exec(ctx, `
-			INSERT INTO audit_logs (id, timestamp, duration_ns, model, resolved_model, provider, alias_used, status_code,
-				request_id, client_ip, method, path, stream, error_type, data)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
-			ON CONFLICT (id) DO NOTHING
-		`, e.ID, e.Timestamp, e.DurationNs, e.Model, e.ResolvedModel, e.Provider, e.AliasUsed, e.StatusCode,
-			e.RequestID, e.ClientIP, e.Method, e.Path, e.Stream, e.ErrorType, dataJSON)
-
-		if err != nil {
-			slog.Warn("failed to insert audit log in batch", "error", err, "id", e.ID)
-			errs = append(errs, fmt.Errorf("insert %s: %w", e.ID, err))
-		}
-	}
-
-	// If any inserts failed, rollback and return error (consistent with writeBatchSmall)
-	if len(errs) > 0 {
-		return fmt.Errorf("failed to insert %d of %d audit logs: %w", len(errs), len(entries), errors.Join(errs...))
+	if err := writeAuditLogInsertChunks(ctx, tx, entries); err != nil {
+		slog.Warn("failed to insert audit log batch in transaction", "error", err, "count", len(entries))
+		return fmt.Errorf("failed to insert %d audit logs: %w", len(entries), err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
@@ -177,6 +160,64 @@ func (s *PostgreSQLStore) writeBatchLarge(ctx context.Context, entries []*LogEnt
 	}
 
 	return nil
+}
+
+func writeAuditLogInsertChunks(ctx context.Context, exec auditLogBatchExecutor, entries []*LogEntry) error {
+	for start := 0; start < len(entries); start += auditLogInsertMaxRowsPerQuery {
+		end := min(start+auditLogInsertMaxRowsPerQuery, len(entries))
+		query, args := buildAuditLogInsert(entries[start:end])
+		if _, err := exec.Exec(ctx, query, args...); err != nil {
+			return fmt.Errorf("batch chunk [%d:%d): %w", start, end, err)
+		}
+	}
+	return nil
+}
+
+func buildAuditLogInsert(entries []*LogEntry) (string, []any) {
+	var builder strings.Builder
+	builder.Grow(len(auditLogInsertPrefix) + len(auditLogInsertSuffix) + len(entries)*auditLogInsertColumnCount*4)
+	builder.WriteString(auditLogInsertPrefix)
+
+	args := make([]any, 0, len(entries)*auditLogInsertColumnCount)
+	placeholder := 1
+
+	for i, entry := range entries {
+		if i > 0 {
+			builder.WriteString(", ")
+		}
+		builder.WriteByte('(')
+		for col := 0; col < auditLogInsertColumnCount; col++ {
+			if col > 0 {
+				builder.WriteString(", ")
+			}
+			builder.WriteByte('$')
+			builder.WriteString(strconv.Itoa(placeholder))
+			placeholder++
+		}
+		builder.WriteByte(')')
+
+		dataJSON := marshalLogData(entry.Data, entry.ID)
+		args = append(args,
+			entry.ID,
+			entry.Timestamp,
+			entry.DurationNs,
+			entry.Model,
+			entry.ResolvedModel,
+			entry.Provider,
+			entry.AliasUsed,
+			entry.StatusCode,
+			entry.RequestID,
+			entry.ClientIP,
+			entry.Method,
+			entry.Path,
+			entry.Stream,
+			entry.ErrorType,
+			dataJSON,
+		)
+	}
+
+	builder.WriteString(auditLogInsertSuffix)
+	return builder.String(), args
 }
 
 // Flush is a no-op for PostgreSQL as writes are synchronous.

--- a/internal/auditlog/store_postgresql_test.go
+++ b/internal/auditlog/store_postgresql_test.go
@@ -1,0 +1,82 @@
+package auditlog
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildAuditLogInsert(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+
+	query, args := buildAuditLogInsert([]*LogEntry{
+		{
+			ID:            "log-1",
+			Timestamp:     now,
+			DurationNs:    1234,
+			Model:         "gpt-4o-mini",
+			ResolvedModel: "gpt-4o-mini",
+			Provider:      "openai",
+			AliasUsed:     true,
+			StatusCode:    200,
+			RequestID:     "req-1",
+			ClientIP:      "127.0.0.1",
+			Method:        "POST",
+			Path:          "/v1/chat/completions",
+			Stream:        true,
+			ErrorType:     "",
+			Data: &LogData{
+				UserAgent: "test-agent",
+			},
+		},
+		{
+			ID:            "log-2",
+			Timestamp:     now.Add(time.Second),
+			DurationNs:    5678,
+			Model:         "gpt-4.1",
+			ResolvedModel: "gpt-4.1",
+			Provider:      "openai",
+			AliasUsed:     false,
+			StatusCode:    500,
+			RequestID:     "req-2",
+			ClientIP:      "10.0.0.1",
+			Method:        "POST",
+			Path:          "/v1/responses",
+			Stream:        false,
+			ErrorType:     "server_error",
+			Data:          nil,
+		},
+	})
+
+	normalized := strings.Join(strings.Fields(query), " ")
+	wantQuery := "INSERT INTO audit_logs (id, timestamp, duration_ns, model, resolved_model, provider, alias_used, status_code, request_id, client_ip, method, path, stream, error_type, data) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15), ($16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30) ON CONFLICT (id) DO NOTHING"
+	if normalized != wantQuery {
+		t.Fatalf("query = %q, want %q", normalized, wantQuery)
+	}
+
+	if got, want := len(args), 30; got != want {
+		t.Fatalf("len(args) = %d, want %d", got, want)
+	}
+	if got := args[0]; got != "log-1" {
+		t.Fatalf("args[0] = %v, want log-1", got)
+	}
+	if got := args[15]; got != "log-2" {
+		t.Fatalf("args[15] = %v, want log-2", got)
+	}
+	if got := string(args[14].([]byte)); got != `{"user_agent":"test-agent"}` {
+		t.Fatalf("args[14] = %q, want %q", got, `{"user_agent":"test-agent"}`)
+	}
+	dataJSON, ok := args[29].([]byte)
+	if !ok {
+		t.Fatalf("args[29] has type %T, want []byte", args[29])
+	}
+	if dataJSON != nil {
+		t.Fatalf("args[29] = %v, want nil data", dataJSON)
+	}
+}
+
+func TestAuditLogInsertMaxRowsPerQueryRespectsPostgresLimit(t *testing.T) {
+	if got := auditLogInsertMaxRowsPerQuery * auditLogInsertColumnCount; got > postgresMaxBindParameters {
+		t.Fatalf("bind parameters = %d, want <= %d", got, postgresMaxBindParameters)
+	}
+}

--- a/internal/auditlog/stream_wrapper.go
+++ b/internal/auditlog/stream_wrapper.go
@@ -16,7 +16,6 @@ import (
 type streamResponseBuilder struct {
 	// ChatCompletion fields
 	ID           string
-	Object       string
 	Model        string
 	Created      int64
 	Role         string
@@ -42,7 +41,6 @@ type StreamLogWrapper struct {
 	entry     *LogEntry
 	builder   *streamResponseBuilder
 	logBodies bool
-	path      string // request path to detect endpoint type
 	closed    bool
 	startTime time.Time
 	pending   []byte // pending partial SSE data between reads
@@ -78,7 +76,6 @@ func NewStreamLogWrapper(stream io.ReadCloser, logger LoggerInterface, entry *Lo
 		entry:      entry,
 		startTime:  startTime,
 		logBodies:  logBodies,
-		path:       path,
 		builder:    builder,
 	}
 }
@@ -158,9 +155,6 @@ func (w *StreamLogWrapper) parseChatCompletionEvent(event map[string]interface{}
 	if w.builder.ID == "" {
 		if id, ok := event["id"].(string); ok {
 			w.builder.ID = id
-		}
-		if obj, ok := event["object"].(string); ok {
-			w.builder.Object = obj
 		}
 		if model, ok := event["model"].(string); ok {
 			w.builder.Model = model

--- a/internal/auditlog/stream_wrapper.go
+++ b/internal/auditlog/stream_wrapper.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"strings"
 	"time"
-
-	"gomodel/internal/core"
 )
 
 // Note: MaxContentCapture and LogEntryStreamingKey constants are defined in constants.go
@@ -399,10 +397,4 @@ func IsEntryMarkedAsStreaming(c interface{ Get(string) interface{} }) bool {
 	}
 	streaming, _ := val.(bool)
 	return streaming
-}
-
-// IsModelInteractionPath returns true if the path is an AI model endpoint
-// Note: /v1/models is excluded as it's just a metadata listing, not a model interaction
-func IsModelInteractionPath(path string) bool {
-	return core.IsModelInteractionPath(path)
 }

--- a/internal/auditlog/stream_wrapper.go
+++ b/internal/auditlog/stream_wrapper.go
@@ -10,8 +10,7 @@ import (
 	"gomodel/internal/core"
 )
 
-// Note: MaxContentCapture, SSEBufferSize, and LogEntryStreamingKey
-// constants are defined in constants.go
+// Note: MaxContentCapture and LogEntryStreamingKey constants are defined in constants.go
 
 // streamResponseBuilder accumulates data from SSE events to reconstruct a response
 type streamResponseBuilder struct {
@@ -35,14 +34,12 @@ type streamResponseBuilder struct {
 	truncated  bool
 }
 
-// StreamLogWrapper wraps an io.ReadCloser to capture usage data from SSE streams.
-// It buffers the last portion of the stream to extract token usage from the
-// final SSE event (typically contains usage data in OpenAI-compatible APIs).
+// StreamLogWrapper wraps an io.ReadCloser to reconstruct streamed response bodies
+// for audit logging.
 type StreamLogWrapper struct {
 	io.ReadCloser
 	logger    LoggerInterface
 	entry     *LogEntry
-	buffer    bytes.Buffer // rolling 8KB buffer for usage extraction
 	builder   *streamResponseBuilder
 	logBodies bool
 	path      string // request path to detect endpoint type
@@ -51,8 +48,8 @@ type StreamLogWrapper struct {
 	pending   []byte // pending partial SSE data between reads
 }
 
-// NewStreamLogWrapper creates a wrapper around a stream to capture usage data.
-// When the stream is closed, it parses the final usage data and logs the entry.
+// NewStreamLogWrapper creates a wrapper around a stream for audit logging.
+// When the stream is closed, it logs the accumulated entry.
 // The path parameter is used to detect whether this is a ChatCompletion or Responses API request.
 func NewStreamLogWrapper(stream io.ReadCloser, logger LoggerInterface, entry *LogEntry, path string) *StreamLogWrapper {
 	// Use entry's timestamp as start time for duration calculation
@@ -86,27 +83,13 @@ func NewStreamLogWrapper(stream io.ReadCloser, logger LoggerInterface, entry *Lo
 	}
 }
 
-// Read implements io.Reader and buffers recent data to find usage.
+// Read implements io.Reader and incrementally processes SSE chunks for audit capture.
 func (w *StreamLogWrapper) Read(p []byte) (n int, err error) {
 	n, err = w.ReadCloser.Read(p)
 	if n > 0 {
 		// Parse SSE events and accumulate content if body logging is enabled
 		if w.logBodies && w.builder != nil {
 			w.processSSEData(p[:n])
-		}
-
-		// Buffer recent data to parse final usage event
-		if _, errBuf := w.buffer.Write(p[:n]); errBuf != nil {
-			return n, errBuf
-		}
-		// Keep only last SSEBufferSize bytes to find "data: [DONE]" and usage
-		if w.buffer.Len() > SSEBufferSize {
-			// Discard old data, keep recent
-			data := w.buffer.Bytes()
-			w.buffer.Reset()
-			if _, errBuf := w.buffer.Write(data[len(data)-SSEBufferSize:]); errBuf != nil {
-				return n, errBuf
-			}
 		}
 	}
 	return n, err

--- a/internal/core/request_snapshot.go
+++ b/internal/core/request_snapshot.go
@@ -3,7 +3,7 @@ package core
 // RequestSnapshot is the transport-level capture of an inbound request. It
 // preserves the request as received at the HTTP boundary so later stages can
 // extract semantics without losing fidelity while keeping mutable state behind
-// defensive-copy accessors.
+// defensive-copy accessors by default.
 type RequestSnapshot struct {
 	// Method is the inbound HTTP method.
 	Method string
@@ -54,6 +54,15 @@ func (s *RequestSnapshot) CapturedBody() []byte {
 		return nil
 	}
 	return cloneBytes(s.capturedBody)
+}
+
+// CapturedBodyView returns the captured request body bytes without cloning.
+// Callers must treat the returned slice as read-only.
+func (s *RequestSnapshot) CapturedBodyView() []byte {
+	if s == nil {
+		return nil
+	}
+	return s.capturedBody
 }
 
 // GetRouteParams returns a defensive copy of the captured route parameters.

--- a/internal/core/request_snapshot_test.go
+++ b/internal/core/request_snapshot_test.go
@@ -40,6 +40,9 @@ func TestNewRequestSnapshot_DefensivelyCopiesMutableFields(t *testing.T) {
 	if got := string(snapshot.CapturedBody()); got != `{"model":"gpt-5-mini"}` {
 		t.Fatalf("CapturedBody = %q, want original body", got)
 	}
+	if got := string(snapshot.CapturedBodyView()); got != `{"model":"gpt-5-mini"}` {
+		t.Fatalf("CapturedBodyView = %q, want original body", got)
+	}
 	if got := snapshot.GetTraceMetadata()["Traceparent"]; got != "trace-1" {
 		t.Fatalf("GetTraceMetadata Traceparent = %q, want trace-1", got)
 	}
@@ -48,5 +51,18 @@ func TestNewRequestSnapshot_DefensivelyCopiesMutableFields(t *testing.T) {
 	clonedHeaders["X-Test"][0] = "changed-again"
 	if got := snapshot.GetHeaders()["X-Test"][0]; got != "a" {
 		t.Fatalf("GetHeaders returned mutable state, got %q", got)
+	}
+
+	view := snapshot.CapturedBodyView()
+	if len(view) == 0 || len(snapshot.capturedBody) == 0 {
+		t.Fatal("captured body unexpectedly empty")
+	}
+	if &view[0] != &snapshot.capturedBody[0] {
+		t.Fatal("CapturedBodyView did not return the underlying snapshot bytes")
+	}
+
+	clonedBody := snapshot.CapturedBody()
+	if &clonedBody[0] == &snapshot.capturedBody[0] {
+		t.Fatal("CapturedBody returned underlying snapshot bytes, want defensive copy")
 	}
 }

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	httppprof "net/http/pprof"
 	"path"
 	"strings"
 
@@ -36,6 +37,7 @@ type Config struct {
 	MetricsEnabled               bool                                   // Whether to expose Prometheus metrics endpoint
 	MetricsEndpoint              string                                 // HTTP path for metrics endpoint (default: /metrics)
 	BodySizeLimit                string                                 // Max request body size (e.g., "10M", "1024K")
+	PprofEnabled                 bool                                   // Whether to expose debug profiling routes at /debug/pprof/*
 	AuditLogger                  auditlog.LoggerInterface               // Optional: Audit logger for request/response logging
 	UsageLogger                  usage.LoggerInterface                  // Optional: Usage logger for token tracking
 	PricingResolver              usage.PricingResolver                  // Optional: Resolves pricing for cost calculation
@@ -121,6 +123,9 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 	}
 	if cfg != nil && cfg.SwaggerEnabled {
 		authSkipPaths = append(authSkipPaths, "/swagger/*")
+	}
+	if cfg != nil && cfg.PprofEnabled {
+		authSkipPaths = append(authSkipPaths, "/debug/pprof", "/debug/pprof/*")
 	}
 
 	// Global middleware stack (order matters)
@@ -213,6 +218,9 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 	if cfg != nil && cfg.MetricsEnabled {
 		e.GET(metricsPath, echo.WrapHandler(promhttp.Handler()))
 	}
+	if cfg != nil && cfg.PprofEnabled {
+		registerPprofRoutes(e)
+	}
 
 	// API routes
 	if cfg == nil || !cfg.DisablePassthroughRoutes {
@@ -271,6 +279,19 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 		handler:                 handler,
 		responseCacheMiddleware: rcm,
 	}
+}
+
+func registerPprofRoutes(e *echo.Echo) {
+	e.GET("/debug/pprof", echo.WrapHandler(http.HandlerFunc(httppprof.Index)))
+	e.GET("/debug/pprof/", echo.WrapHandler(http.HandlerFunc(httppprof.Index)))
+	e.GET("/debug/pprof/cmdline", echo.WrapHandler(http.HandlerFunc(httppprof.Cmdline)))
+	e.GET("/debug/pprof/profile", echo.WrapHandler(http.HandlerFunc(httppprof.Profile)))
+	e.GET("/debug/pprof/symbol", echo.WrapHandler(http.HandlerFunc(httppprof.Symbol)))
+	e.GET("/debug/pprof/trace", echo.WrapHandler(http.HandlerFunc(httppprof.Trace)))
+	e.GET("/debug/pprof/:profile", func(c *echo.Context) error {
+		httppprof.Handler(c.Param("profile")).ServeHTTP(c.Response(), c.Request())
+		return nil
+	})
 }
 
 func passthroughV1PrefixNormalizationEnabled(cfg *Config) bool {

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -133,7 +133,7 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 	if cfg != nil && cfg.LogOnlyModelInteractions {
 		e.Use(middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
 			Skipper: func(c *echo.Context) bool {
-				return !auditlog.IsModelInteractionPath(c.Request().URL.Path)
+				return !core.IsModelInteractionPath(c.Request().URL.Path)
 			},
 			LogStatus:        true,
 			LogURI:           true,

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -530,6 +530,73 @@ func TestSwaggerDocJson_ReturnsExpectedContent(t *testing.T) {
 	}
 }
 
+func TestPprofEndpoint_Enabled(t *testing.T) {
+	mock := &mockProvider{}
+	srv := New(mock, &Config{PprofEnabled: true})
+
+	req := httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil)
+	rec := httptest.NewRecorder()
+
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "Types of profiles available:") {
+		t.Errorf("expected pprof index content, got: %s", body[:min(200, len(body))])
+	}
+	if !strings.Contains(body, "goroutine") {
+		t.Errorf("expected pprof index to list goroutine profile, got: %s", body[:min(200, len(body))])
+	}
+}
+
+func TestPprofEndpoint_Disabled(t *testing.T) {
+	mock := &mockProvider{}
+	srv := New(mock, &Config{PprofEnabled: false})
+
+	req := httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil)
+	rec := httptest.NewRecorder()
+
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected status 404, got %d", rec.Code)
+	}
+}
+
+func TestPprofEndpoint_NilConfig(t *testing.T) {
+	mock := &mockProvider{}
+	srv := New(mock, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil)
+	rec := httptest.NewRecorder()
+
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected status 404, got %d", rec.Code)
+	}
+}
+
+func TestServerWithMasterKeyAndPprof(t *testing.T) {
+	mock := &mockProvider{}
+	srv := New(mock, &Config{
+		MasterKey:    "test-secret-key",
+		PprofEnabled: true,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil)
+	rec := httptest.NewRecorder()
+
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200 for public pprof endpoint, got %d", rec.Code)
+	}
+}
+
 func TestProviderPassthroughRoute_EnabledByDefault(t *testing.T) {
 	mock := &mockProvider{
 		passthroughResponse: &core.PassthroughResponse{
@@ -582,7 +649,7 @@ func TestProviderPassthroughRoute_EnabledByDefault(t *testing.T) {
 func TestProviderPassthroughRoute_DisabledRequiresAuthBefore404(t *testing.T) {
 	mock := &mockProvider{}
 	srv := New(mock, &Config{
-		MasterKey:                  "test-secret-key",
+		MasterKey:                "test-secret-key",
 		DisablePassthroughRoutes: true,
 	})
 

--- a/internal/server/request_snapshot.go
+++ b/internal/server/request_snapshot.go
@@ -150,7 +150,7 @@ func (c *combinedReadCloser) Close() error {
 
 func requestBodyBytes(c *echo.Context) ([]byte, error) {
 	if snapshot := core.GetRequestSnapshot(c.Request().Context()); snapshot != nil {
-		if body := snapshot.CapturedBody(); body != nil {
+		if body := snapshot.CapturedBodyView(); body != nil {
 			return body, nil
 		}
 	}

--- a/internal/server/request_snapshot_test.go
+++ b/internal/server/request_snapshot_test.go
@@ -264,3 +264,38 @@ func TestRequestSnapshotCapture_ManagesFilesWithoutReadingMultipartBody(t *testi
 	assert.Equal(t, "files", capturedEnv.OperationType)
 	assert.False(t, capturedEnv.JSONBodyParsed)
 }
+
+func TestRequestBodyBytes_UsesSnapshotReadOnlyBodyView(t *testing.T) {
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Body = &explodingReadCloser{}
+	frame := core.NewRequestSnapshot(
+		http.MethodPost,
+		"/v1/chat/completions",
+		nil,
+		nil,
+		nil,
+		"application/json",
+		[]byte(`{"model":"gpt-4o-mini"}`),
+		false,
+		"req-body-bytes-123",
+		nil,
+	)
+	req = req.WithContext(core.WithRequestSnapshot(req.Context(), frame))
+
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	body, err := requestBodyBytes(c)
+	require.NoError(t, err)
+	require.NotNil(t, body)
+	assert.JSONEq(t, `{"model":"gpt-4o-mini"}`, string(body))
+
+	view := frame.CapturedBodyView()
+	require.NotNil(t, view)
+	require.NotEmpty(t, view)
+	if &body[0] != &view[0] {
+		t.Fatal("requestBodyBytes returned a cloned snapshot body, want shared read-only view")
+	}
+}

--- a/internal/server/security_test.go
+++ b/internal/server/security_test.go
@@ -321,3 +321,28 @@ func TestMetricsEndpointPathTraversal(t *testing.T) {
 		}
 	})
 }
+
+func TestPprofEndpoint_RequiresAuthWhenDisabled(t *testing.T) {
+	mock := &mockProvider{}
+	srv := New(mock, &Config{
+		MasterKey:    "secret-key",
+		PprofEnabled: false,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 before route resolution when pprof is disabled, got %d", rec.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil)
+	req.Header.Set("Authorization", "Bearer secret-key")
+	rec = httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404 after auth when pprof is disabled, got %d", rec.Code)
+	}
+}

--- a/internal/usage/store_postgresql.go
+++ b/internal/usage/store_postgresql.go
@@ -2,14 +2,36 @@ package usage
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+const (
+	usageInsertColumnCount     = 15
+	postgresMaxBindParameters  = 65535
+	usageInsertMaxRowsPerQuery = postgresMaxBindParameters / usageInsertColumnCount
+)
+
+const usageInsertPrefix = `
+		INSERT INTO usage (id, request_id, provider_id, timestamp, model, provider,
+			endpoint, input_tokens, output_tokens, total_tokens, raw_data,
+			input_cost, output_cost, total_cost, costs_calculation_caveat)
+		VALUES `
+
+const usageInsertSuffix = `
+		ON CONFLICT (id) DO NOTHING
+	`
+
+type usageBatchExecutor interface {
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
+}
 
 // PostgreSQLStore implements UsageStore for PostgreSQL databases.
 type PostgreSQLStore struct {
@@ -108,29 +130,9 @@ func (s *PostgreSQLStore) WriteBatch(ctx context.Context, entries []*UsageEntry)
 
 // writeBatchSmall uses INSERT for small batches
 func (s *PostgreSQLStore) writeBatchSmall(ctx context.Context, entries []*UsageEntry) error {
-	var errs []error
-
-	for _, e := range entries {
-		rawDataJSON := marshalRawData(e.RawData, e.ID)
-
-		_, err := s.pool.Exec(ctx, `
-			INSERT INTO usage (id, request_id, provider_id, timestamp, model, provider,
-				endpoint, input_tokens, output_tokens, total_tokens, raw_data,
-				input_cost, output_cost, total_cost, costs_calculation_caveat)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
-			ON CONFLICT (id) DO NOTHING
-		`, e.ID, e.RequestID, e.ProviderID, e.Timestamp, e.Model, e.Provider,
-			e.Endpoint, e.InputTokens, e.OutputTokens, e.TotalTokens, rawDataJSON,
-			e.InputCost, e.OutputCost, e.TotalCost, e.CostsCalculationCaveat)
-
-		if err != nil {
-			slog.Warn("failed to insert usage entry", "error", err, "id", e.ID)
-			errs = append(errs, fmt.Errorf("insert %s: %w", e.ID, err))
-		}
-	}
-
-	if len(errs) > 0 {
-		return fmt.Errorf("failed to insert %d of %d usage entries: %w", len(errs), len(entries), errors.Join(errs...))
+	if err := writeUsageInsertChunks(ctx, s.pool, entries); err != nil {
+		slog.Warn("failed to insert usage batch", "error", err, "count", len(entries))
+		return fmt.Errorf("failed to insert %d usage entries: %w", len(entries), err)
 	}
 	return nil
 }
@@ -143,29 +145,9 @@ func (s *PostgreSQLStore) writeBatchLarge(ctx context.Context, entries []*UsageE
 	}
 	defer tx.Rollback(ctx) //nolint:errcheck
 
-	var errs []error
-
-	for _, e := range entries {
-		rawDataJSON := marshalRawData(e.RawData, e.ID)
-
-		_, err = tx.Exec(ctx, `
-			INSERT INTO usage (id, request_id, provider_id, timestamp, model, provider,
-				endpoint, input_tokens, output_tokens, total_tokens, raw_data,
-				input_cost, output_cost, total_cost, costs_calculation_caveat)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
-			ON CONFLICT (id) DO NOTHING
-		`, e.ID, e.RequestID, e.ProviderID, e.Timestamp, e.Model, e.Provider,
-			e.Endpoint, e.InputTokens, e.OutputTokens, e.TotalTokens, rawDataJSON,
-			e.InputCost, e.OutputCost, e.TotalCost, e.CostsCalculationCaveat)
-
-		if err != nil {
-			slog.Warn("failed to insert usage entry in batch", "error", err, "id", e.ID)
-			errs = append(errs, fmt.Errorf("insert %s: %w", e.ID, err))
-		}
-	}
-
-	if len(errs) > 0 {
-		return fmt.Errorf("failed to insert %d of %d usage entries: %w", len(errs), len(entries), errors.Join(errs...))
+	if err := writeUsageInsertChunks(ctx, tx, entries); err != nil {
+		slog.Warn("failed to insert usage batch in transaction", "error", err, "count", len(entries))
+		return fmt.Errorf("failed to insert %d usage entries: %w", len(entries), err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
@@ -173,6 +155,64 @@ func (s *PostgreSQLStore) writeBatchLarge(ctx context.Context, entries []*UsageE
 	}
 
 	return nil
+}
+
+func writeUsageInsertChunks(ctx context.Context, exec usageBatchExecutor, entries []*UsageEntry) error {
+	for start := 0; start < len(entries); start += usageInsertMaxRowsPerQuery {
+		end := min(start+usageInsertMaxRowsPerQuery, len(entries))
+		query, args := buildUsageInsert(entries[start:end])
+		if _, err := exec.Exec(ctx, query, args...); err != nil {
+			return fmt.Errorf("batch chunk [%d:%d): %w", start, end, err)
+		}
+	}
+	return nil
+}
+
+func buildUsageInsert(entries []*UsageEntry) (string, []any) {
+	var builder strings.Builder
+	builder.Grow(len(usageInsertPrefix) + len(usageInsertSuffix) + len(entries)*usageInsertColumnCount*4)
+	builder.WriteString(usageInsertPrefix)
+
+	args := make([]any, 0, len(entries)*usageInsertColumnCount)
+	placeholder := 1
+
+	for i, entry := range entries {
+		if i > 0 {
+			builder.WriteString(", ")
+		}
+		builder.WriteByte('(')
+		for col := 0; col < usageInsertColumnCount; col++ {
+			if col > 0 {
+				builder.WriteString(", ")
+			}
+			builder.WriteByte('$')
+			builder.WriteString(strconv.Itoa(placeholder))
+			placeholder++
+		}
+		builder.WriteByte(')')
+
+		rawDataJSON := marshalRawData(entry.RawData, entry.ID)
+		args = append(args,
+			entry.ID,
+			entry.RequestID,
+			entry.ProviderID,
+			entry.Timestamp,
+			entry.Model,
+			entry.Provider,
+			entry.Endpoint,
+			entry.InputTokens,
+			entry.OutputTokens,
+			entry.TotalTokens,
+			rawDataJSON,
+			entry.InputCost,
+			entry.OutputCost,
+			entry.TotalCost,
+			entry.CostsCalculationCaveat,
+		)
+	}
+
+	builder.WriteString(usageInsertSuffix)
+	return builder.String(), args
 }
 
 // Flush is a no-op for PostgreSQL as writes are synchronous.

--- a/internal/usage/store_postgresql_test.go
+++ b/internal/usage/store_postgresql_test.go
@@ -1,0 +1,83 @@
+package usage
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildUsageInsert(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	inputCost := 0.1
+	outputCost := 0.2
+	totalCost := 0.3
+
+	query, args := buildUsageInsert([]*UsageEntry{
+		{
+			ID:                     "usage-1",
+			RequestID:              "req-1",
+			ProviderID:             "provider-1",
+			Timestamp:              now,
+			Model:                  "gpt-4o-mini",
+			Provider:               "openai",
+			Endpoint:               "/v1/chat/completions",
+			InputTokens:            10,
+			OutputTokens:           5,
+			TotalTokens:            15,
+			RawData:                map[string]any{"cached_tokens": 3},
+			InputCost:              &inputCost,
+			OutputCost:             &outputCost,
+			TotalCost:              &totalCost,
+			CostsCalculationCaveat: "none",
+		},
+		{
+			ID:                     "usage-2",
+			RequestID:              "req-2",
+			ProviderID:             "provider-2",
+			Timestamp:              now.Add(time.Second),
+			Model:                  "gpt-4.1",
+			Provider:               "openai",
+			Endpoint:               "/v1/responses",
+			InputTokens:            20,
+			OutputTokens:           8,
+			TotalTokens:            28,
+			RawData:                nil,
+			InputCost:              nil,
+			OutputCost:             nil,
+			TotalCost:              nil,
+			CostsCalculationCaveat: "missing pricing for tool tokens",
+		},
+	})
+
+	normalized := strings.Join(strings.Fields(query), " ")
+	wantQuery := "INSERT INTO usage (id, request_id, provider_id, timestamp, model, provider, endpoint, input_tokens, output_tokens, total_tokens, raw_data, input_cost, output_cost, total_cost, costs_calculation_caveat) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15), ($16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30) ON CONFLICT (id) DO NOTHING"
+	if normalized != wantQuery {
+		t.Fatalf("query = %q, want %q", normalized, wantQuery)
+	}
+
+	if got, want := len(args), 30; got != want {
+		t.Fatalf("len(args) = %d, want %d", got, want)
+	}
+	if got := args[0]; got != "usage-1" {
+		t.Fatalf("args[0] = %v, want usage-1", got)
+	}
+	if got := args[15]; got != "usage-2" {
+		t.Fatalf("args[15] = %v, want usage-2", got)
+	}
+	if got := string(args[10].([]byte)); got != `{"cached_tokens":3}` {
+		t.Fatalf("args[10] = %q, want %q", got, `{"cached_tokens":3}`)
+	}
+	rawData, ok := args[25].([]byte)
+	if !ok {
+		t.Fatalf("args[25] has type %T, want []byte", args[25])
+	}
+	if rawData != nil {
+		t.Fatalf("args[25] = %v, want nil raw_data", rawData)
+	}
+}
+
+func TestUsageInsertMaxRowsPerQueryRespectsPostgresLimit(t *testing.T) {
+	if got := usageInsertMaxRowsPerQuery * usageInsertColumnCount; got > postgresMaxBindParameters {
+		t.Fatalf("bind parameters = %d, want <= %d", got, postgresMaxBindParameters)
+	}
+}

--- a/internal/usage/stream_wrapper.go
+++ b/internal/usage/stream_wrapper.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"strings"
 
 	"gomodel/internal/core"
 )
@@ -301,18 +300,4 @@ func WrapStreamForUsage(stream io.ReadCloser, logger LoggerInterface, model, pro
 		return stream
 	}
 	return NewStreamUsageWrapper(stream, logger, model, provider, requestID, endpoint, pricingResolver)
-}
-
-// IsModelInteractionPath returns true if the path is an AI model endpoint
-func IsModelInteractionPath(path string) bool {
-	modelPaths := []string{
-		"/v1/chat/completions",
-		"/v1/responses",
-	}
-	for _, p := range modelPaths {
-		if strings.HasPrefix(path, p) {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/usage/stream_wrapper_test.go
+++ b/internal/usage/stream_wrapper_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"gomodel/internal/core"
 )
 
 // trackingLogger tracks written entries for testing
@@ -217,9 +219,9 @@ func TestIsModelInteractionPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {
-			got := IsModelInteractionPath(tt.path)
+			got := core.IsModelInteractionPath(tt.path)
 			if got != tt.want {
-				t.Errorf("IsModelInteractionPath(%q) = %v, want %v", tt.path, got, tt.want)
+				t.Errorf("core.IsModelInteractionPath(%q) = %v, want %v", tt.path, got, tt.want)
 			}
 		})
 	}

--- a/tests/perf/README.md
+++ b/tests/perf/README.md
@@ -1,0 +1,16 @@
+# Performance Checks
+
+Run the deterministic hot-path guard with:
+
+```bash
+make perf-check
+```
+
+The CI job and pre-commit hook both run this guard. The current allocation and
+byte ceilings live in `tests/perf/hotpath_test.go`.
+
+Run the underlying benchmarks with allocation output:
+
+```bash
+make perf-bench
+```

--- a/tests/perf/hotpath_test.go
+++ b/tests/perf/hotpath_test.go
@@ -1,0 +1,297 @@
+package perf
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"gomodel/internal/auditlog"
+	"gomodel/internal/core"
+	"gomodel/internal/providers"
+	"gomodel/internal/server"
+	"gomodel/internal/usage"
+)
+
+const (
+	sampleChatRequest = `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Hi"}]}`
+	sampleChatStream  = "" +
+		"data: {\"id\":\"chatcmpl-bench\",\"object\":\"chat.completion.chunk\",\"created\":1700000000,\"model\":\"gpt-4o-mini\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"Hel\"},\"finish_reason\":null}]}\n\n" +
+		"data: {\"id\":\"chatcmpl-bench\",\"object\":\"chat.completion.chunk\",\"created\":1700000000,\"model\":\"gpt-4o-mini\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"lo\"},\"finish_reason\":null}]}\n\n" +
+		"data: {\"id\":\"chatcmpl-bench\",\"object\":\"chat.completion.chunk\",\"created\":1700000000,\"model\":\"gpt-4o-mini\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":2,\"total_tokens\":7}}\n\n" +
+		"data: [DONE]\n\n"
+)
+
+type benchProvider struct{}
+
+func (benchProvider) ChatCompletion(_ context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+	model := "gpt-4o-mini"
+	if req != nil && req.Model != "" {
+		model = req.Model
+	}
+
+	return &core.ChatResponse{
+		ID:       "chatcmpl-bench",
+		Object:   "chat.completion",
+		Model:    model,
+		Provider: "mock",
+		Created:  1700000000,
+		Choices: []core.Choice{
+			{
+				Index:        0,
+				FinishReason: "stop",
+				Message: core.ResponseMessage{
+					Role:    "assistant",
+					Content: "Hello!",
+				},
+			},
+		},
+		Usage: core.Usage{
+			PromptTokens:     5,
+			CompletionTokens: 2,
+			TotalTokens:      7,
+		},
+	}, nil
+}
+
+func (benchProvider) StreamChatCompletion(_ context.Context, _ *core.ChatRequest) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader(sampleChatStream)), nil
+}
+
+func (benchProvider) ListModels(_ context.Context) (*core.ModelsResponse, error) {
+	return &core.ModelsResponse{
+		Object: "list",
+		Data: []core.Model{
+			{
+				ID:      "gpt-4o-mini",
+				Object:  "model",
+				OwnedBy: "mock",
+				Created: 1700000000,
+			},
+		},
+	}, nil
+}
+
+func (benchProvider) Responses(_ context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
+	model := "gpt-4o-mini"
+	if req != nil && req.Model != "" {
+		model = req.Model
+	}
+
+	return &core.ResponsesResponse{
+		ID:        "resp-bench",
+		Object:    "response",
+		CreatedAt: 1700000000,
+		Model:     model,
+		Provider:  "mock",
+		Status:    "completed",
+		Output: []core.ResponsesOutputItem{
+			{
+				ID:     "msg-bench",
+				Type:   "message",
+				Role:   "assistant",
+				Status: "completed",
+				Content: []core.ResponsesContentItem{
+					{
+						Type: "output_text",
+						Text: "Hello!",
+					},
+				},
+			},
+		},
+		Usage: &core.ResponsesUsage{
+			InputTokens:  5,
+			OutputTokens: 2,
+			TotalTokens:  7,
+		},
+	}, nil
+}
+
+func (benchProvider) StreamResponses(_ context.Context, _ *core.ResponsesRequest) (io.ReadCloser, error) {
+	return providers.NewOpenAIResponsesStreamConverter(io.NopCloser(strings.NewReader(sampleChatStream)), "gpt-4o-mini", "mock"), nil
+}
+
+func (benchProvider) Embeddings(_ context.Context, _ *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	return &core.EmbeddingResponse{
+		Object: "list",
+		Model:  "text-embedding-3-small",
+		Data: []core.EmbeddingData{
+			{
+				Object:    "embedding",
+				Index:     0,
+				Embedding: []byte(`[0.1,0.2,0.3]`),
+			},
+		},
+		Usage: core.EmbeddingUsage{
+			PromptTokens: 5,
+			TotalTokens:  5,
+		},
+	}, nil
+}
+
+func (benchProvider) Supports(model string) bool {
+	return strings.TrimSpace(model) != ""
+}
+
+func (benchProvider) GetProviderType(_ string) string {
+	return "mock"
+}
+
+type benchAuditLogger struct {
+	cfg auditlog.Config
+}
+
+func (l benchAuditLogger) Write(_ *auditlog.LogEntry) {}
+func (l benchAuditLogger) Config() auditlog.Config    { return l.cfg }
+func (l benchAuditLogger) Close() error               { return nil }
+
+type benchUsageLogger struct {
+	cfg usage.Config
+}
+
+func (l benchUsageLogger) Write(_ *usage.UsageEntry) {}
+func (l benchUsageLogger) Config() usage.Config      { return l.cfg }
+func (l benchUsageLogger) Close() error              { return nil }
+
+func TestMain(m *testing.M) {
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError})))
+	code := m.Run()
+	slog.SetDefault(original)
+	os.Exit(code)
+}
+
+func BenchmarkGatewayHotPathChatCompletion(b *testing.B) {
+	srv := server.New(benchProvider{}, &server.Config{LogOnlyModelInteractions: true})
+	body := []byte(sampleChatRequest)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			b.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+		}
+	}
+}
+
+func BenchmarkOpenAIResponsesStreamConverter(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		converter := providers.NewOpenAIResponsesStreamConverter(
+			io.NopCloser(strings.NewReader(sampleChatStream)),
+			"gpt-4o-mini",
+			"mock",
+		)
+
+		if _, err := io.Copy(io.Discard, converter); err != nil {
+			b.Fatalf("drain converter: %v", err)
+		}
+		if err := converter.Close(); err != nil {
+			b.Fatalf("close converter: %v", err)
+		}
+	}
+}
+
+func BenchmarkStreamingAuditAndUsageWrappers(b *testing.B) {
+	auditLogger := benchAuditLogger{cfg: auditlog.Config{Enabled: true, LogBodies: true}}
+	usageLogger := benchUsageLogger{cfg: usage.Config{Enabled: true}}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		entry := &auditlog.LogEntry{
+			ID:        "audit-bench",
+			Timestamp: time.Unix(1700000000, 0),
+			RequestID: "req-bench",
+			Method:    http.MethodPost,
+			Path:      "/v1/chat/completions",
+			Data:      &auditlog.LogData{},
+		}
+
+		stream := auditlog.WrapStreamForLogging(
+			io.NopCloser(strings.NewReader(sampleChatStream)),
+			auditLogger,
+			entry,
+			"/v1/chat/completions",
+		)
+		stream = usage.WrapStreamForUsage(
+			stream,
+			usageLogger,
+			"gpt-4o-mini",
+			"mock",
+			"req-bench",
+			"/v1/chat/completions",
+			nil,
+		)
+
+		if _, err := io.Copy(io.Discard, stream); err != nil {
+			b.Fatalf("drain wrapped stream: %v", err)
+		}
+		if err := stream.Close(); err != nil {
+			b.Fatalf("close wrapped stream: %v", err)
+		}
+	}
+}
+
+func TestHotPathPerfGuard(t *testing.T) {
+	t.Helper()
+
+	// These ceilings are intentionally generous. They are here to catch obvious
+	// allocation regressions in the hottest code paths, not to freeze the exact
+	// current profile.
+	cases := []struct {
+		name      string
+		bench     func(*testing.B)
+		maxAllocs int64
+		maxBytes  int64
+	}{
+		{
+			name:      "gateway_chat_completion_hot_path",
+			bench:     BenchmarkGatewayHotPathChatCompletion,
+			maxAllocs: 180,
+			maxBytes:  22 * 1024,
+		},
+		{
+			name:      "openai_responses_stream_converter",
+			bench:     BenchmarkOpenAIResponsesStreamConverter,
+			maxAllocs: 360,
+			maxBytes:  32 * 1024,
+		},
+		{
+			name:      "stacked_stream_audit_and_usage_wrappers",
+			bench:     BenchmarkStreamingAuditAndUsageWrappers,
+			maxAllocs: 340,
+			maxBytes:  20 * 1024,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			result := testing.Benchmark(tc.bench)
+
+			if got := result.AllocsPerOp(); got > tc.maxAllocs {
+				t.Fatalf("allocs/op = %d, want <= %d", got, tc.maxAllocs)
+			}
+			if got := result.AllocedBytesPerOp(); got > tc.maxBytes {
+				t.Fatalf("bytes/op = %d, want <= %d", got, tc.maxBytes)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add a hot-path performance guard, `perf-check`/`perf-bench`, and opt-in `pprof`
- batch PostgreSQL audit and usage inserts instead of issuing per-entry writes
- remove unnecessary streaming response buffering and extra snapshot body copying
- clean up dead streaming state and route-classification indirection in audit/usage paths

## Included changes
- add `tests/perf` hot-path benchmarks plus CI and pre-commit perf thresholds
- add debug-only `pprof` mounting behind config/env
- switch audit and usage PostgreSQL stores to chunked multi-row inserts
- stop audit middleware from buffering SSE responses on the `ResponseWriter` path
- avoid extra request snapshot body copies on read
- remove dead audit stream buffering and other dead streaming state
- use `core.IsModelInteractionPath` directly as the route-classification owner

## Verification
- `make perf-check`
- `go test ./internal/auditlog ./internal/server`
- `go test ./internal/usage ./internal/server`
- `go test ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional profiling endpoint for performance analysis and debugging (configurable via server settings).

* **Performance Improvements**
  * Optimized batch database operations for audit logs and usage tracking.
  * Enhanced streaming response handling in audit logging.

* **Quality Assurance**
  * Added performance monitoring and guardrails to CI/CD pipeline to maintain system efficiency standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->