### PR TITLE
perf(cache): replace MarshalIndent with Marshal in local cache

### DIFF
--- a/internal/cache/modelcache/local.go
+++ b/internal/cache/modelcache/local.go
@@ -63,7 +63,7 @@ func (c *LocalCache) Set(ctx context.Context, cache *ModelCache) error {
 		return fmt.Errorf("failed to create cache directory: %w", err)
 	}
 
-	data, err := json.MarshalIndent(cache, "", "  ")
+	data, err := json.Marshal(cache)
 	if err != nil {
 		return fmt.Errorf("failed to marshal cache: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Replace `json.MarshalIndent` with `json.Marshal` in local model cache `Set()` — the cache file is only read by the application, never by humans
- Eliminates unnecessary buffer growth from indentation formatting on every cache refresh cycle
- Identified via pprof profiling: `SaveToCache` → `MarshalIndent` accounted for ~7.8 MB of allocations across 500 requests

## Test plan
- [x] Existing `TestLocalCache` tests pass (round-trip Get/Set verified)
- [x] All pre-commit hooks pass (unit tests, golangci-lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized internal cache storage to reduce file size and improve efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->