### PR TITLE
chore: upgrade Go 1.25.0 to 1.26.1

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -52,7 +52,7 @@
 
 # External model metadata registry (provides pricing, capabilities, context window, etc.)
 # Set to empty string to disable (default: ENTERPILOT/ai-model-list on GitHub)
-# MODEL_LIST_URL=https://raw.githubusercontent.com/ENTERPILOT/ai-model-list/refs/heads/main/models.json
+# MODEL_LIST_URL=https://raw.githubusercontent.com/ENTERPILOT/ai-model-list/refs/heads/main/models.min.json
 
 # =============================================================================
 # Admin API & Dashboard Configuration

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.6
+          version: v2.11
           # Temporary workaround: config verification fetches the remote JSON schema and
           # intermittently times out in CI before lint runs. Re-enable by 2026-04-01 once
           # the schema fetch is reliable again; track in this PR/branch discussion.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.25"
+  GO_VERSION: "1.26"
 
 # Restrict token permissions to minimum required
 permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Guidance for AI models (like Claude) working with this codebase.
 
 **GOModel** is a high-performance AI gateway in Go that routes requests to multiple AI model providers (OpenAI, Anthropic, Gemini, Groq, xAI, Ollama). LiteLLM killer.
 
-**Go:** 1.25.0
+**Go:** 1.26.1
 **Repo:** https://github.com/ENTERPILOT/GOModel
 
 - **Stage:** Development - backward compatibility is not a concern

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage — run on the build host's native arch for speed, cross-compile for target
-FROM --platform=$BUILDPLATFORM golang:1.25-alpine3.23 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine3.23 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Example model identifiers are illustrative and subject to change; consult provid
 
 ### Running from Source
 
-**Prerequisites:** Go 1.22+
+**Prerequisites:** Go 1.26+
 
 1. Create a `.env` file:
 

--- a/cmd/recordapi/main.go
+++ b/cmd/recordapi/main.go
@@ -63,12 +63,12 @@ var providerConfigs = map[string]struct {
 var endpointConfigs = map[string]struct {
 	path        string
 	method      string
-	requestBody map[string]interface{}
+	requestBody map[string]any
 }{
 	"chat": {
 		path:   "/v1/chat/completions",
 		method: http.MethodPost,
-		requestBody: map[string]interface{}{
+		requestBody: map[string]any{
 			"model": "gpt-4o-mini",
 			"messages": []map[string]string{
 				{"role": "user", "content": "Say 'Hello, World!' and nothing else."},
@@ -79,7 +79,7 @@ var endpointConfigs = map[string]struct {
 	"chat_stream": {
 		path:   "/v1/chat/completions",
 		method: http.MethodPost,
-		requestBody: map[string]interface{}{
+		requestBody: map[string]any{
 			"model": "gpt-4o-mini",
 			"messages": []map[string]string{
 				{"role": "user", "content": "Say 'Hello, World!' and nothing else."},
@@ -95,7 +95,7 @@ var endpointConfigs = map[string]struct {
 	"responses": {
 		path:   "/v1/responses",
 		method: http.MethodPost,
-		requestBody: map[string]interface{}{
+		requestBody: map[string]any{
 			"model": "gpt-4o-mini",
 			"input": "Say 'Hello, World!' and nothing else.",
 		},
@@ -103,7 +103,7 @@ var endpointConfigs = map[string]struct {
 	"responses_stream": {
 		path:   "/v1/responses",
 		method: http.MethodPost,
-		requestBody: map[string]interface{}{
+		requestBody: map[string]any{
 			"model":  "gpt-4o-mini",
 			"input":  "Say 'Hello, World!' and nothing else.",
 			"stream": true,
@@ -275,7 +275,7 @@ func main() {
 	fmt.Printf("Response saved to %s\n", *output)
 
 	// Print response summary
-	var respMap map[string]interface{}
+	var respMap map[string]any
 	if err := json.Unmarshal(body, &respMap); err == nil {
 		if id, ok := respMap["id"].(string); ok {
 			fmt.Printf("Response ID: %s\n", id)
@@ -287,8 +287,8 @@ func main() {
 }
 
 // adjustForAnthropic converts OpenAI-style request to Anthropic format
-func adjustForAnthropic(req map[string]interface{}) map[string]interface{} {
-	result := make(map[string]interface{})
+func adjustForAnthropic(req map[string]any) map[string]any {
+	result := make(map[string]any)
 
 	// Copy model
 	if model, ok := req["model"].(string); ok {

--- a/config/config.go
+++ b/config/config.go
@@ -572,7 +572,6 @@ func hasEnvDescendants(t reflect.Type) bool {
 		return false
 	}
 	for f := range t.Fields() {
-		f := f
 		if f.Tag.Get("env") != "" {
 			return true
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -421,7 +421,7 @@ func buildDefaultConfig() *Config {
 			Model: ModelCacheConfig{
 				RefreshInterval: 3600,
 				ModelList: ModelListConfig{
-					URL: "https://raw.githubusercontent.com/ENTERPILOT/ai-model-list/refs/heads/main/models.json",
+					URL: "https://raw.githubusercontent.com/ENTERPILOT/ai-model-list/refs/heads/main/models.min.json",
 				},
 				Local: nil,
 				Redis: nil,
@@ -571,13 +571,13 @@ func hasEnvDescendants(t reflect.Type) bool {
 	if t.Kind() != reflect.Struct {
 		return false
 	}
-	for i := 0; i < t.NumField(); i++ {
-		f := t.Field(i)
+	for f := range t.Fields() {
+		f := f
 		if f.Tag.Get("env") != "" {
 			return true
 		}
 		ft := f.Type
-		if ft.Kind() == reflect.Ptr {
+		if ft.Kind() == reflect.Pointer {
 			ft = ft.Elem()
 		}
 		if ft.Kind() == reflect.Struct && hasEnvDescendants(ft) {
@@ -602,7 +602,7 @@ func applyEnvOverridesValue(v reflect.Value) error {
 			}
 			continue
 		}
-		if field.Type.Kind() == reflect.Ptr {
+		if field.Type.Kind() == reflect.Pointer {
 			if fieldVal.IsNil() {
 				// Only allocate if the pointed-to struct has env-tagged descendants;
 				// otherwise leave it nil so optional config sections stay absent.
@@ -662,7 +662,7 @@ func applyEnvOverridesValue(v reflect.Value) error {
 			}
 			fieldVal.SetInt(int64(n))
 		case reflect.Int64:
-			if field.Type == reflect.TypeOf(time.Duration(0)) {
+			if field.Type == reflect.TypeFor[time.Duration]() {
 				// time.Duration is represented as int64; accept Go duration strings (e.g. "1s", "500ms").
 				d, err := time.ParseDuration(envVal)
 				if err != nil {
@@ -696,9 +696,9 @@ func expandString(s string) string {
 		varname := key
 		defaultValue := ""
 		hasDefault := false
-		if idx := strings.Index(key, ":-"); idx >= 0 {
-			varname = key[:idx]
-			defaultValue = key[idx+2:]
+		if before, after, ok := strings.Cut(key, ":-"); ok {
+			varname = before
+			defaultValue = after
 			hasDefault = true
 		}
 		value := os.Getenv(varname)

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -209,7 +209,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       # Unit + E2E (no external dependencies)
       - run: make test-all

--- a/docs/about/benchmark-tools/bench_main.go
+++ b/docs/about/benchmark-tools/bench_main.go
@@ -236,9 +236,7 @@ func main() {
 
 	start := time.Now()
 	for i := 0; i < *concurrency; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for range jobs {
 				reqCtx, cancel := context.WithTimeout(context.Background(), *requestTimeout)
 				req, reqErr := http.NewRequestWithContext(reqCtx, http.MethodPost, strings.TrimRight(*baseURL, "/")+"/v1/chat/completions", bytes.NewReader(bodyBytes))
@@ -300,7 +298,7 @@ func main() {
 				results = append(results, r)
 				resultsMu.Unlock()
 			}
-		}()
+		})
 	}
 
 	for i := 0; i < *requests; i++ {

--- a/docs/about/benchmarks.mdx
+++ b/docs/about/benchmarks.mdx
@@ -76,7 +76,7 @@ All the tooling used in the published benchmark is available in this repository.
 
 ### Prerequisites
 
-- Go 1.25+
+- Go 1.26+
 - Python 3.10+ with `matplotlib` and `numpy`
 - `jq`, `curl`
 - A Groq API key (or any OpenAI-compatible provider — adjust the script)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gomodel
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/andybalholm/brotli v1.2.0

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -141,13 +142,12 @@ func parseDateRangeParams(c *echo.Context) (usage.UsageQueryParams, error) {
 // handleError converts errors to appropriate HTTP responses, matching the
 // format used by the main API handlers in the server package.
 func handleError(c *echo.Context, err error) error {
-	var gatewayErr *core.GatewayError
-	if errors.As(err, &gatewayErr) {
+	if gatewayErr, ok := errors.AsType[*core.GatewayError](err); ok {
 		return c.JSON(gatewayErr.HTTPStatusCode(), gatewayErr.ToJSON())
 	}
 
-	return c.JSON(http.StatusInternalServerError, map[string]interface{}{
-		"error": map[string]interface{}{
+	return c.JSON(http.StatusInternalServerError, map[string]any{
+		"error": map[string]any{
 			"type":    "internal_error",
 			"message": "an unexpected error occurred",
 		},
@@ -487,12 +487,7 @@ func (h *Handler) ListModels(c *echo.Context) error {
 
 // isValidCategory returns true if cat is a recognized model category.
 func isValidCategory(cat core.ModelCategory) bool {
-	for _, c := range core.AllCategories() {
-		if c == cat {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(core.AllCategories(), cat)
 }
 
 // ListCategories handles GET /admin/api/v1/models/categories

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -146,12 +146,13 @@ func handleError(c *echo.Context, err error) error {
 		return c.JSON(gatewayErr.HTTPStatusCode(), gatewayErr.ToJSON())
 	}
 
-	return c.JSON(http.StatusInternalServerError, map[string]any{
-		"error": map[string]any{
-			"type":    "internal_error",
-			"message": "an unexpected error occurred",
-		},
-	})
+	fallback := &core.GatewayError{
+		Type:       "internal_error",
+		Message:    "an unexpected error occurred",
+		StatusCode: http.StatusInternalServerError,
+		Err:        err,
+	}
+	return c.JSON(fallback.HTTPStatusCode(), fallback.ToJSON())
 }
 
 // UsageSummary handles GET /admin/api/v1/usage/summary

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -248,7 +248,7 @@ func TestUsageSummary_WithPersistedCosts(t *testing.T) {
 		t.Errorf("expected 200, got %d", rec.Code)
 	}
 
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
 		t.Fatalf("failed to unmarshal: %v", err)
 	}
@@ -281,7 +281,7 @@ func TestUsageSummary_NilCosts(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
 		t.Fatalf("failed to unmarshal: %v", err)
 	}

--- a/internal/aliases/provider.go
+++ b/internal/aliases/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"maps"
 	"sort"
 	"strings"
 
@@ -362,18 +363,12 @@ func mergeBatchHints(left, right map[string]string) map[string]string {
 			return nil
 		}
 		merged := make(map[string]string, len(right))
-		for key, value := range right {
-			merged[key] = value
-		}
+		maps.Copy(merged, right)
 		return merged
 	}
 	merged := make(map[string]string, len(left))
-	for key, value := range left {
-		merged[key] = value
-	}
-	for key, value := range right {
-		merged[key] = value
-	}
+	maps.Copy(merged, left)
+	maps.Copy(merged, right)
 	return merged
 }
 

--- a/internal/aliases/store.go
+++ b/internal/aliases/store.go
@@ -35,8 +35,8 @@ func newValidationError(message string, err error) error {
 
 // IsValidationError reports whether err is a validation error.
 func IsValidationError(err error) bool {
-	var validationErr *ValidationError
-	return errors.As(err, &validationErr)
+	_, ok := errors.AsType[*ValidationError](err)
+	return ok
 }
 
 // Store defines persistence operations for aliases.

--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -79,8 +79,8 @@ type LogData struct {
 	// Optional bodies (when LOGGING_LOG_BODIES=true)
 	// Stored as interface{} so MongoDB serializes as native BSON documents (queryable/readable)
 	// instead of BSON Binary (base64 in Compass)
-	RequestBody  interface{} `json:"request_body,omitempty" bson:"request_body,omitempty"`
-	ResponseBody interface{} `json:"response_body,omitempty" bson:"response_body,omitempty"`
+	RequestBody  any `json:"request_body,omitempty" bson:"request_body,omitempty"`
+	ResponseBody any `json:"response_body,omitempty" bson:"response_body,omitempty"`
 
 	// Body capture status flags (set when body exceeds 1MB limit)
 	RequestBodyTooBigToHandle  bool `json:"request_body_too_big_to_handle,omitempty" bson:"request_body_too_big_to_handle,omitempty"`

--- a/internal/auditlog/auditlog_test.go
+++ b/internal/auditlog/auditlog_test.go
@@ -175,13 +175,13 @@ func TestLogEntryJSON(t *testing.T) {
 
 func TestLogDataWithBodies(t *testing.T) {
 	// Use interface{} types (maps) for bodies - this is how they're stored now
-	requestBody := map[string]interface{}{
+	requestBody := map[string]any{
 		"model":    "gpt-4",
-		"messages": []interface{}{},
+		"messages": []any{},
 	}
-	responseBody := map[string]interface{}{
+	responseBody := map[string]any{
 		"id":      "resp-123",
-		"choices": []interface{}{},
+		"choices": []any{},
 	}
 
 	data := &LogData{
@@ -202,7 +202,7 @@ func TestLogDataWithBodies(t *testing.T) {
 	}
 
 	// Verify bodies are preserved (decoded as map[string]interface{})
-	decodedReqBody, ok := decoded.RequestBody.(map[string]interface{})
+	decodedReqBody, ok := decoded.RequestBody.(map[string]any)
 	if !ok {
 		t.Fatalf("RequestBody is not a map, got %T", decoded.RequestBody)
 	}
@@ -210,7 +210,7 @@ func TestLogDataWithBodies(t *testing.T) {
 		t.Errorf("RequestBody model mismatch: expected gpt-4, got %v", decodedReqBody["model"])
 	}
 
-	decodedRespBody, ok := decoded.ResponseBody.(map[string]interface{})
+	decodedRespBody, ok := decoded.ResponseBody.(map[string]any)
 	if !ok {
 		t.Fatalf("ResponseBody is not a map, got %T", decoded.ResponseBody)
 	}
@@ -302,7 +302,7 @@ func TestLogger(t *testing.T) {
 	defer logger.Close()
 
 	// Write some entries
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		logger.Write(&LogEntry{
 			ID:        fmt.Sprintf("entry-%d", i),
 			Timestamp: time.Now(),
@@ -1156,7 +1156,7 @@ func TestLimitedReaderRequestBodyCapture(t *testing.T) {
 			t.Fatal("body should be under limit")
 		}
 
-		var parsed interface{}
+		var parsed any
 		if jsonErr := json.Unmarshal(bodyBytes, &parsed); jsonErr == nil {
 			entry.Data.RequestBody = parsed
 		}

--- a/internal/auditlog/conversation_helpers.go
+++ b/internal/auditlog/conversation_helpers.go
@@ -100,9 +100,9 @@ func extractPreviousResponseID(entry *LogEntry) string {
 	return extractStringField(entry.Data.RequestBody, "previous_response_id")
 }
 
-func extractStringField(v interface{}, key string) string {
+func extractStringField(v any, key string) string {
 	switch obj := v.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		return extractTrimmedString(obj[key])
 	case bson.M:
 		return extractTrimmedString(obj[key])
@@ -118,7 +118,7 @@ func extractStringField(v interface{}, key string) string {
 	}
 }
 
-func extractTrimmedString(raw interface{}) string {
+func extractTrimmedString(raw any) string {
 	if raw == nil {
 		return ""
 	}

--- a/internal/auditlog/conversation_helpers_test.go
+++ b/internal/auditlog/conversation_helpers_test.go
@@ -11,13 +11,13 @@ func TestExtractStringField(t *testing.T) {
 
 	tests := []struct {
 		name string
-		v    interface{}
+		v    any
 		key  string
 		want string
 	}{
 		{
 			name: "map payload",
-			v: map[string]interface{}{
+			v: map[string]any{
 				"id": " resp_1 ",
 			},
 			key:  "id",
@@ -58,7 +58,6 @@ func TestExtractStringField(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			if got := extractStringField(tc.v, tc.key); got != tc.want {

--- a/internal/auditlog/middleware.go
+++ b/internal/auditlog/middleware.go
@@ -140,7 +140,7 @@ func Middleware(logger LoggerInterface) echo.MiddlewareFunc {
 				}
 
 				// Parse JSON to interface{} for native BSON storage in MongoDB
-				var parsed interface{}
+				var parsed any
 				if jsonErr := json.Unmarshal(bodyBytes, &parsed); jsonErr == nil {
 					entry.Data.ResponseBody = parsed
 				} else {
@@ -233,7 +233,7 @@ func captureLoggedRequestBody(entry *LogEntry, bodyBytes []byte) {
 	}
 
 	// Parse JSON to interface{} for native BSON storage in MongoDB
-	var parsed interface{}
+	var parsed any
 	if jsonErr := json.Unmarshal(bodyBytes, &parsed); jsonErr == nil {
 		entry.Data.RequestBody = parsed
 		return

--- a/internal/auditlog/middleware.go
+++ b/internal/auditlog/middleware.go
@@ -139,7 +139,7 @@ func Middleware(logger LoggerInterface) echo.MiddlewareFunc {
 					}
 				}
 
-				// Parse JSON to interface{} for native BSON storage in MongoDB
+				// Parse JSON to any for native BSON storage in MongoDB
 				var parsed any
 				if jsonErr := json.Unmarshal(bodyBytes, &parsed); jsonErr == nil {
 					entry.Data.ResponseBody = parsed
@@ -232,7 +232,7 @@ func captureLoggedRequestBody(entry *LogEntry, bodyBytes []byte) {
 		return
 	}
 
-	// Parse JSON to interface{} for native BSON storage in MongoDB
+	// Parse JSON to any for native BSON storage in MongoDB
 	var parsed any
 	if jsonErr := json.Unmarshal(bodyBytes, &parsed); jsonErr == nil {
 		entry.Data.RequestBody = parsed

--- a/internal/auditlog/reader_postgresql.go
+++ b/internal/auditlog/reader_postgresql.go
@@ -81,7 +81,7 @@ func (r *PostgreSQLReader) GetLogs(ctx context.Context, params LogQueryParams) (
 	dataQuery := fmt.Sprintf(`SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, status_code, request_id,
 		client_ip, method, path, stream, error_type, data
 		FROM audit_logs%s ORDER BY timestamp DESC LIMIT $%d OFFSET $%d`, where, argIdx, argIdx+1)
-	dataArgs := append(append([]interface{}(nil), args...), limit, offset)
+	dataArgs := append(append([]any(nil), args...), limit, offset)
 
 	rows, err := r.pool.Query(ctx, dataQuery, dataArgs...)
 	if err != nil {
@@ -151,7 +151,7 @@ func (r *PostgreSQLReader) GetConversation(ctx context.Context, logID string, li
 	return buildConversationThread(ctx, logID, limit, r.GetLogByID, r.findByResponseID, r.findByPreviousResponseID)
 }
 
-func pgDateRangeConditions(params QueryParams, argIdx int) (conditions []string, args []interface{}, nextIdx int) {
+func pgDateRangeConditions(params QueryParams, argIdx int) (conditions []string, args []any, nextIdx int) {
 	nextIdx = argIdx
 	if !params.StartDate.IsZero() {
 		conditions = append(conditions, fmt.Sprintf("timestamp >= $%d", nextIdx))
@@ -205,7 +205,7 @@ func (r *PostgreSQLReader) findByPreviousResponseID(ctx context.Context, previou
 }
 
 func scanPostgreSQLLogEntry(rows interface {
-	Scan(dest ...interface{}) error
+	Scan(dest ...any) error
 }) (*LogEntry, error) {
 	var e LogEntry
 	var dataJSON *string

--- a/internal/auditlog/reader_sqlite.go
+++ b/internal/auditlog/reader_sqlite.go
@@ -79,7 +79,7 @@ func (r *SQLiteReader) GetLogs(ctx context.Context, params LogQueryParams) (*Log
 	dataQuery := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, status_code, request_id,
 		client_ip, method, path, stream, error_type, data
 		FROM audit_logs` + where + ` ORDER BY timestamp DESC LIMIT ? OFFSET ?`
-	dataArgs := append(append([]interface{}(nil), args...), limit, offset)
+	dataArgs := append(append([]any(nil), args...), limit, offset)
 
 	rows, err := r.db.QueryContext(ctx, dataQuery, dataArgs...)
 	if err != nil {
@@ -230,7 +230,7 @@ func (r *SQLiteReader) GetConversation(ctx context.Context, logID string, limit 
 	}, nil
 }
 
-func sqliteDateRangeConditions(params QueryParams) (conditions []string, args []interface{}) {
+func sqliteDateRangeConditions(params QueryParams) (conditions []string, args []any) {
 	if !params.StartDate.IsZero() {
 		conditions = append(conditions, "timestamp >= ?")
 		args = append(args, params.StartDate.UTC().Format("2006-01-02"))

--- a/internal/auditlog/store_mongodb.go
+++ b/internal/auditlog/store_mongodb.go
@@ -127,7 +127,7 @@ func (s *MongoDBStore) WriteBatch(ctx context.Context, entries []*LogEntry) erro
 	}
 
 	// Convert entries to BSON documents
-	docs := make([]interface{}, len(entries))
+	docs := make([]any, len(entries))
 	for i, e := range entries {
 		docs[i] = e
 	}
@@ -137,8 +137,7 @@ func (s *MongoDBStore) WriteBatch(ctx context.Context, entries []*LogEntry) erro
 	_, err := s.collection.InsertMany(ctx, docs, opts)
 	if err != nil {
 		// Check if it's a bulk write error with some successes
-		var bulkErr *mongo.BulkWriteException
-		if errors.As(err, &bulkErr) {
+		if bulkErr, ok := errors.AsType[*mongo.BulkWriteException](err); ok {
 			failedCount := len(bulkErr.WriteErrors)
 			// Log for visibility
 			slog.Warn("partial audit log insert failure",

--- a/internal/auditlog/store_postgresql.go
+++ b/internal/auditlog/store_postgresql.go
@@ -186,7 +186,7 @@ func buildAuditLogInsert(entries []*LogEntry) (string, []any) {
 			builder.WriteString(", ")
 		}
 		builder.WriteByte('(')
-		for col := 0; col < auditLogInsertColumnCount; col++ {
+		for col := range auditLogInsertColumnCount {
 			if col > 0 {
 				builder.WriteString(", ")
 			}

--- a/internal/auditlog/store_sqlite.go
+++ b/internal/auditlog/store_sqlite.go
@@ -113,15 +113,12 @@ func (s *SQLiteStore) WriteBatch(ctx context.Context, entries []*LogEntry) error
 
 	// Process entries in chunks to stay within SQLite's parameter limit
 	for i := 0; i < len(entries); i += maxEntriesPerBatch {
-		end := i + maxEntriesPerBatch
-		if end > len(entries) {
-			end = len(entries)
-		}
+		end := min(i+maxEntriesPerBatch, len(entries))
 		chunk := entries[i:end]
 
 		// Build batch insert query for this chunk
 		placeholders := make([]string, len(chunk))
-		values := make([]interface{}, 0, len(chunk)*columnsPerEntry)
+		values := make([]any, 0, len(chunk)*columnsPerEntry)
 
 		for j, e := range chunk {
 			placeholders[j] = "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
@@ -139,7 +136,7 @@ func (s *SQLiteStore) WriteBatch(ctx context.Context, entries []*LogEntry) error
 			}
 
 			// Handle NULL for data field: nil becomes SQL NULL, non-nil becomes JSON string
-			var dataValue interface{}
+			var dataValue any
 			if dataJSON != nil {
 				dataValue = string(dataJSON)
 			}

--- a/internal/auditlog/store_sqlite_test.go
+++ b/internal/auditlog/store_sqlite_test.go
@@ -102,7 +102,7 @@ func TestSQLiteStore_WriteBatch_Chunking(t *testing.T) {
 	// Using 150 entries to ensure we need at least 3 batches
 	numEntries := 150
 	entries := make([]*LogEntry, numEntries)
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		entries[i] = &LogEntry{
 			ID:         fmt.Sprintf("entry-%03d", i),
 			Timestamp:  time.Now(),
@@ -181,7 +181,7 @@ func TestSQLiteStore_WriteBatch_ExactBatchBoundary(t *testing.T) {
 	// Test with exactly maxEntriesPerBatch entries
 	numEntries := maxEntriesPerBatch
 	entries := make([]*LogEntry, numEntries)
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		entries[i] = &LogEntry{
 			ID:        fmt.Sprintf("exact-%03d", i),
 			Timestamp: time.Now(),

--- a/internal/auditlog/stream_observer.go
+++ b/internal/auditlog/stream_observer.go
@@ -38,7 +38,7 @@ func NewStreamLogObserver(logger LoggerInterface, entry *LogEntry, path string) 
 	}
 }
 
-func (o *StreamLogObserver) OnJSONEvent(event map[string]interface{}) {
+func (o *StreamLogObserver) OnJSONEvent(event map[string]any) {
 	if !o.logBodies || o.builder == nil {
 		return
 	}
@@ -73,7 +73,7 @@ func (o *StreamLogObserver) OnStreamClose() {
 	}
 }
 
-func (o *StreamLogObserver) parseChatCompletionEvent(event map[string]interface{}) {
+func (o *StreamLogObserver) parseChatCompletionEvent(event map[string]any) {
 	if o.builder == nil {
 		return
 	}
@@ -90,13 +90,13 @@ func (o *StreamLogObserver) parseChatCompletionEvent(event map[string]interface{
 		}
 	}
 
-	if choices, ok := event["choices"].([]interface{}); ok && len(choices) > 0 {
-		if choice, ok := choices[0].(map[string]interface{}); ok {
+	if choices, ok := event["choices"].([]any); ok && len(choices) > 0 {
+		if choice, ok := choices[0].(map[string]any); ok {
 			if fr, ok := choice["finish_reason"].(string); ok && fr != "" {
 				o.builder.FinishReason = fr
 			}
 
-			if delta, ok := choice["delta"].(map[string]interface{}); ok {
+			if delta, ok := choice["delta"].(map[string]any); ok {
 				if role, ok := delta["role"].(string); ok {
 					o.builder.Role = role
 				}
@@ -108,7 +108,7 @@ func (o *StreamLogObserver) parseChatCompletionEvent(event map[string]interface{
 	}
 }
 
-func (o *StreamLogObserver) parseResponsesAPIEvent(event map[string]interface{}) {
+func (o *StreamLogObserver) parseResponsesAPIEvent(event map[string]any) {
 	if o.builder == nil {
 		return
 	}
@@ -116,7 +116,7 @@ func (o *StreamLogObserver) parseResponsesAPIEvent(event map[string]interface{})
 	eventType, _ := event["type"].(string)
 	switch eventType {
 	case "response.created", "response.completed", "response.done":
-		if resp, ok := event["response"].(map[string]interface{}); ok {
+		if resp, ok := event["response"].(map[string]any); ok {
 			if id, ok := resp["id"].(string); ok {
 				o.builder.ResponseID = id
 			}

--- a/internal/auditlog/stream_wrapper.go
+++ b/internal/auditlog/stream_wrapper.go
@@ -1,6 +1,7 @@
 package auditlog
 
 import (
+	"maps"
 	"strings"
 )
 
@@ -28,16 +29,16 @@ type streamResponseBuilder struct {
 }
 
 // buildChatCompletionResponse constructs a ChatCompletion response from accumulated data
-func (b *streamResponseBuilder) buildChatCompletionResponse() map[string]interface{} {
-	return map[string]interface{}{
+func (b *streamResponseBuilder) buildChatCompletionResponse() map[string]any {
+	return map[string]any{
 		"id":      b.ID,
 		"object":  "chat.completion",
 		"model":   b.Model,
 		"created": b.Created,
-		"choices": []map[string]interface{}{
+		"choices": []map[string]any{
 			{
 				"index": 0,
-				"message": map[string]interface{}{
+				"message": map[string]any{
 					"role":    b.Role,
 					"content": b.Content.String(),
 				},
@@ -48,18 +49,18 @@ func (b *streamResponseBuilder) buildChatCompletionResponse() map[string]interfa
 }
 
 // buildResponsesAPIResponse constructs a Responses API response from accumulated data
-func (b *streamResponseBuilder) buildResponsesAPIResponse() map[string]interface{} {
-	return map[string]interface{}{
+func (b *streamResponseBuilder) buildResponsesAPIResponse() map[string]any {
+	return map[string]any{
 		"id":         b.ResponseID,
 		"object":     "response",
 		"model":      b.Model,
 		"created_at": b.CreatedAt,
 		"status":     b.Status,
-		"output": []map[string]interface{}{
+		"output": []map[string]any{
 			{
 				"type": "message",
 				"role": "assistant",
-				"content": []map[string]interface{}{
+				"content": []map[string]any{
 					{
 						"type": "output_text",
 						"text": b.Content.String(),
@@ -117,15 +118,13 @@ func copyMap(m map[string]string) map[string]string {
 		return nil
 	}
 	result := make(map[string]string, len(m))
-	for k, v := range m {
-		result[k] = v
-	}
+	maps.Copy(result, m)
 	return result
 }
 
 // GetStreamEntryFromContext retrieves the log entry from Echo context for streaming.
 // This allows handlers to get the entry for wrapping streams.
-func GetStreamEntryFromContext(c interface{ Get(string) interface{} }) *LogEntry {
+func GetStreamEntryFromContext(c interface{ Get(string) any }) *LogEntry {
 	entryVal := c.Get(string(LogEntryKey))
 	if entryVal == nil {
 		return nil
@@ -141,12 +140,12 @@ func GetStreamEntryFromContext(c interface{ Get(string) interface{} }) *LogEntry
 
 // MarkEntryAsStreaming marks the entry as a streaming request so the middleware
 // knows not to log it (the stream observer path will handle logging).
-func MarkEntryAsStreaming(c interface{ Set(string, interface{}) }, isStreaming bool) {
+func MarkEntryAsStreaming(c interface{ Set(string, any) }, isStreaming bool) {
 	c.Set(string(LogEntryStreamingKey), isStreaming)
 }
 
 // IsEntryMarkedAsStreaming checks if the entry is marked as streaming.
-func IsEntryMarkedAsStreaming(c interface{ Get(string) interface{} }) bool {
+func IsEntryMarkedAsStreaming(c interface{ Get(string) any }) bool {
 	val := c.Get(string(LogEntryStreamingKey))
 	if val == nil {
 		return false

--- a/internal/batch/store_memory.go
+++ b/internal/batch/store_memory.go
@@ -93,10 +93,7 @@ func (s *MemoryStore) List(_ context.Context, limit int, after string) ([]*Store
 	if start >= len(all) {
 		return []*StoredBatch{}, nil
 	}
-	end := start + limit
-	if end > len(all) {
-		end = len(all)
-	}
+	end := min(start+limit, len(all))
 	return all[start:end], nil
 }
 

--- a/internal/core/batch_preparation.go
+++ b/internal/core/batch_preparation.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"strings"
 )
@@ -270,8 +271,7 @@ func wrapBatchInputFileLineError(lineNo int, err error) error {
 	if err == nil {
 		return nil
 	}
-	var gatewayErr *GatewayError
-	if errors.As(err, &gatewayErr) {
+	if gatewayErr, ok := errors.AsType[*GatewayError](err); ok {
 		if gatewayErr.Type == ErrorTypeInvalidRequest {
 			return NewInvalidRequestError(fmt.Sprintf("batch input file line %d: %s", lineNo, gatewayErr.Message), err)
 		}
@@ -295,9 +295,7 @@ func mergeBatchEndpointHints(dst, src map[string]string) {
 	if len(src) == 0 {
 		return
 	}
-	for customID, endpoint := range src {
-		dst[customID] = endpoint
-	}
+	maps.Copy(dst, src)
 }
 
 func cloneBatchRequest(req *BatchRequest) *BatchRequest {
@@ -336,9 +334,7 @@ func cloneBatchStringMap(src map[string]string) map[string]string {
 		return nil
 	}
 	cloned := make(map[string]string, len(src))
-	for key, value := range src {
-		cloned[key] = value
-	}
+	maps.Copy(cloned, src)
 	return cloned
 }
 

--- a/internal/core/batch_semantic_test.go
+++ b/internal/core/batch_semantic_test.go
@@ -53,7 +53,6 @@ func TestBatchItemModelSelector(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/core/chat_content.go
+++ b/internal/core/chat_content.go
@@ -241,7 +241,7 @@ func NormalizeMessageContent(content any) (any, error) {
 			parts[i] = normalized
 		}
 		return parts, nil
-	case []interface{}:
+	case []any:
 		parts := make([]ContentPart, len(c))
 		for i, part := range c {
 			normalized, err := normalizeContentPartValue(part)
@@ -264,7 +264,7 @@ func ExtractTextContent(content any) string {
 		return c
 	case []ContentPart:
 		return joinTextParts(partsText(c))
-	case []interface{}:
+	case []any:
 		return joinTextParts(interfacePartsText(c))
 	default:
 		return ""
@@ -276,7 +276,7 @@ func HasStructuredContent(content any) bool {
 	switch c := content.(type) {
 	case []ContentPart:
 		return len(c) > 0
-	case []interface{}:
+	case []any:
 		return len(c) > 0
 	default:
 		return false
@@ -330,10 +330,10 @@ func partsText(parts []ContentPart) []string {
 	return texts
 }
 
-func interfacePartsText(parts []interface{}) []string {
+func interfacePartsText(parts []any) []string {
 	texts := make([]string, 0, len(parts))
 	for _, part := range parts {
-		partMap, ok := part.(map[string]interface{})
+		partMap, ok := part.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -450,14 +450,14 @@ func normalizeContentPartValue(part any) (ContentPart, error) {
 	switch v := part.(type) {
 	case ContentPart:
 		return normalizeTypedContentPart(v)
-	case map[string]interface{}:
+	case map[string]any:
 		return normalizeContentPartMap(v)
 	default:
 		return ContentPart{}, fmt.Errorf("content part must be an object")
 	}
 }
 
-func normalizeContentPartMap(partMap map[string]interface{}) (ContentPart, error) {
+func normalizeContentPartMap(partMap map[string]any) (ContentPart, error) {
 	rawPart, err := json.Marshal(partMap)
 	if err != nil {
 		return ContentPart{}, fmt.Errorf("content part must be an object")

--- a/internal/core/chat_content_test.go
+++ b/internal/core/chat_content_test.go
@@ -187,8 +187,8 @@ func TestMessageUnmarshalJSON_RejectsEmptyJSONTextPart(t *testing.T) {
 }
 
 func TestNormalizeMessageContent_RejectsEmptyMapTextPart(t *testing.T) {
-	_, err := NormalizeMessageContent([]interface{}{
-		map[string]interface{}{
+	_, err := NormalizeMessageContent([]any{
+		map[string]any{
 			"type": "text",
 			"text": "",
 		},
@@ -308,10 +308,10 @@ func TestNormalizeMessageContent_RejectsNilInputAudio(t *testing.T) {
 }
 
 func TestNormalizeMessageContent_InputAudioFromMap(t *testing.T) {
-	result, err := NormalizeMessageContent([]interface{}{
-		map[string]interface{}{
+	result, err := NormalizeMessageContent([]any{
+		map[string]any{
 			"type":        "input_audio",
-			"input_audio": map[string]interface{}{"data": "abc", "format": "wav"},
+			"input_audio": map[string]any{"data": "abc", "format": "wav"},
 		},
 	})
 	if err != nil {
@@ -334,10 +334,10 @@ func TestNormalizeMessageContent_InputAudioFromMap(t *testing.T) {
 }
 
 func TestNormalizeMessageContent_RejectsInputAudioFromMapMissingFields(t *testing.T) {
-	_, err := NormalizeMessageContent([]interface{}{
-		map[string]interface{}{
+	_, err := NormalizeMessageContent([]any{
+		map[string]any{
 			"type":        "input_audio",
-			"input_audio": map[string]interface{}{"data": "", "format": "wav"},
+			"input_audio": map[string]any{"data": "", "format": "wav"},
 		},
 	})
 	if err == nil {

--- a/internal/core/errors.go
+++ b/internal/core/errors.go
@@ -71,19 +71,19 @@ func (e *GatewayError) HTTPStatusCode() int {
 }
 
 // ToJSON converts the error to a JSON-compatible map
-func (e *GatewayError) ToJSON() map[string]interface{} {
-	var param interface{}
+func (e *GatewayError) ToJSON() map[string]any {
+	var param any
 	if e.Param != nil {
 		param = *e.Param
 	}
 
-	var code interface{}
+	var code any
 	if e.Code != nil {
 		code = *e.Code
 	}
 
-	return map[string]interface{}{
-		"error": map[string]interface{}{
+	return map[string]any{
+		"error": map[string]any{
 			"type":    e.Type,
 			"message": e.Message,
 			"param":   param,

--- a/internal/core/errors_test.go
+++ b/internal/core/errors_test.go
@@ -132,7 +132,7 @@ func TestGatewayError_ToJSON(t *testing.T) {
 
 	result := err.ToJSON()
 
-	errorData, ok := result["error"].(map[string]interface{})
+	errorData, ok := result["error"].(map[string]any)
 	if !ok {
 		t.Fatal("ToJSON() should return map with 'error' key")
 	}
@@ -161,7 +161,7 @@ func TestGatewayError_ToJSON_DefaultsParamAndCodeToNull(t *testing.T) {
 	}
 
 	result := err.ToJSON()
-	errorData := result["error"].(map[string]interface{})
+	errorData := result["error"].(map[string]any)
 
 	if value, ok := errorData["param"]; !ok || value != nil {
 		t.Fatalf("ToJSON() param = %v, want nil", value)
@@ -348,8 +348,8 @@ func TestParseProviderError(t *testing.T) {
 			body:           []byte(`{"error": {"message": "Model not found", "type": "not_found", "param": "model", "code": "model_not_found"}}`),
 			expectedType:   ErrorTypeInvalidRequest,
 			expectedStatus: http.StatusBadRequest,
-			expectedParam:  ptr("model"),
-			expectedCode:   ptr("model_not_found"),
+			expectedParam:  new("model"),
+			expectedCode:   new("model_not_found"),
 		},
 	}
 
@@ -382,10 +382,6 @@ func TestParseProviderError(t *testing.T) {
 			}
 		})
 	}
-}
-
-func ptr(value string) *string {
-	return &value
 }
 
 func equalStringPointers(a, b *string) bool {

--- a/internal/core/request_snapshot.go
+++ b/internal/core/request_snapshot.go
@@ -1,5 +1,7 @@
 package core
 
+import "maps"
+
 // RequestSnapshot is the transport-level capture of an inbound request. It
 // preserves the request as received at the HTTP boundary so later stages can
 // extract semantics without losing fidelity while keeping mutable state behind
@@ -111,9 +113,7 @@ func cloneStringMap(src map[string]string) map[string]string {
 		return nil
 	}
 	dst := make(map[string]string, len(src))
-	for key, value := range src {
-		dst[key] = value
-	}
+	maps.Copy(dst, src)
 	return dst
 }
 

--- a/internal/core/responses.go
+++ b/internal/core/responses.go
@@ -9,9 +9,9 @@ import "encoding/json"
 // can round-trip extensions; Swagger ignores ExtraFields, and typed fields
 // should be preferred when available.
 type ResponsesRequest struct {
-	Model    string      `json:"model"`
-	Provider string      `json:"provider,omitempty"`
-	Input    interface{} `json:"input"` // string or []ResponsesInputElement — see docs for array form
+	Model    string `json:"model"`
+	Provider string `json:"provider,omitempty"`
+	Input    any    `json:"input"` // string or []ResponsesInputElement — see docs for array form
 	//nolint:govet // Intentional duplicate json tag for Swagger docs: input is string OR []ResponsesInputElement.
 	InputSchema       []ResponsesInputElement    `json:"input,omitempty" extensions:"x-oneOf=[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/core.ResponsesInputElement\"}}]"`
 	Instructions      string                     `json:"instructions,omitempty"`
@@ -56,9 +56,9 @@ type ResponsesInputElement struct {
 	Type string `json:"type,omitempty"` // "message", "function_call", "function_call_output"
 
 	// Message fields (type="" or "message")
-	Role    string      `json:"role,omitempty"`
-	Status  string      `json:"status,omitempty"`
-	Content interface{} `json:"content,omitempty"` // Can be string or []ContentPart
+	Role    string `json:"role,omitempty"`
+	Status  string `json:"status,omitempty"`
+	Content any    `json:"content,omitempty"` // Can be string or []ContentPart
 	//nolint:govet // Intentional duplicate json tag for Swagger docs: content is string OR []ContentPart.
 	ContentSchema []ContentPart `json:"content,omitempty" extensions:"x-oneOf=[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/core.ContentPart\"}}]"`
 

--- a/internal/core/responses_json_test.go
+++ b/internal/core/responses_json_test.go
@@ -86,7 +86,7 @@ func TestResponsesRequestUnmarshalJSON_PreservesToolCallingControls(t *testing.T
 		t.Fatalf("json.Unmarshal() error = %v", err)
 	}
 
-	toolChoice, ok := req.ToolChoice.(map[string]interface{})
+	toolChoice, ok := req.ToolChoice.(map[string]any)
 	if !ok {
 		t.Fatalf("ToolChoice = %#v, want object", req.ToolChoice)
 	}
@@ -101,11 +101,11 @@ func TestResponsesRequestUnmarshalJSON_PreservesToolCallingControls(t *testing.T
 func TestResponsesRequestMarshalJSON_PreservesInput(t *testing.T) {
 	body, err := json.Marshal(ResponsesRequest{
 		Model: "gpt-4o-mini",
-		Input: []interface{}{
-			map[string]interface{}{
+		Input: []any{
+			map[string]any{
 				"role": "user",
-				"content": []interface{}{
-					map[string]interface{}{
+				"content": []any{
+					map[string]any{
 						"type": "input_text",
 						"text": "hello",
 					},
@@ -117,7 +117,7 @@ func TestResponsesRequestMarshalJSON_PreservesInput(t *testing.T) {
 		t.Fatalf("json.Marshal() error = %v", err)
 	}
 
-	var decoded map[string]interface{}
+	var decoded map[string]any
 	if err := json.Unmarshal(body, &decoded); err != nil {
 		t.Fatalf("json.Unmarshal() error = %v", err)
 	}
@@ -126,12 +126,12 @@ func TestResponsesRequestMarshalJSON_PreservesInput(t *testing.T) {
 		t.Fatalf("marshal output missing input: %s", string(body))
 	}
 
-	input, ok := inputRaw.([]interface{})
+	input, ok := inputRaw.([]any)
 	if !ok || len(input) != 1 {
 		t.Fatalf("decoded input = %#v, want []interface{} len=1", inputRaw)
 	}
 
-	firstMsg, ok := input[0].(map[string]interface{})
+	firstMsg, ok := input[0].(map[string]any)
 	if !ok {
 		t.Fatalf("first input item = %#v, want object", input[0])
 	}
@@ -143,12 +143,12 @@ func TestResponsesRequestMarshalJSON_PreservesInput(t *testing.T) {
 	if !ok {
 		t.Fatalf("first input missing content: %#v", firstMsg)
 	}
-	content, ok := contentRaw.([]interface{})
+	content, ok := contentRaw.([]any)
 	if !ok || len(content) != 1 {
 		t.Fatalf("first input content = %#v, want []interface{} len=1", contentRaw)
 	}
 
-	firstPart, ok := content[0].(map[string]interface{})
+	firstPart, ok := content[0].(map[string]any)
 	if !ok {
 		t.Fatalf("first content part = %#v, want object", content[0])
 	}
@@ -177,12 +177,12 @@ func TestResponsesRequestMarshalJSON_PreservesToolCallingControls(t *testing.T) 
 		t.Fatalf("json.Marshal() error = %v", err)
 	}
 
-	var decoded map[string]interface{}
+	var decoded map[string]any
 	if err := json.Unmarshal(body, &decoded); err != nil {
 		t.Fatalf("json.Unmarshal() error = %v", err)
 	}
 
-	toolChoice, ok := decoded["tool_choice"].(map[string]interface{})
+	toolChoice, ok := decoded["tool_choice"].(map[string]any)
 	if !ok {
 		t.Fatalf("decoded tool_choice = %#v, want object", decoded["tool_choice"])
 	}
@@ -209,17 +209,17 @@ func TestResponsesRequestMarshalJSON_PreservesTypedInputElementContent(t *testin
 		t.Fatalf("json.Marshal() error = %v", err)
 	}
 
-	var decoded map[string]interface{}
+	var decoded map[string]any
 	if err := json.Unmarshal(body, &decoded); err != nil {
 		t.Fatalf("json.Unmarshal() error = %v", err)
 	}
 
-	input, ok := decoded["input"].([]interface{})
+	input, ok := decoded["input"].([]any)
 	if !ok || len(input) != 1 {
 		t.Fatalf("decoded input = %#v, want []interface{} len=1", decoded["input"])
 	}
 
-	first, ok := input[0].(map[string]interface{})
+	first, ok := input[0].(map[string]any)
 	if !ok {
 		t.Fatalf("decoded first input item = %#v, want object", input[0])
 	}
@@ -464,7 +464,7 @@ func TestResponsesInputElementMarshalJSON_FunctionCall(t *testing.T) {
 		t.Fatalf("json.Marshal() error = %v", err)
 	}
 
-	var decoded map[string]interface{}
+	var decoded map[string]any
 	if err := json.Unmarshal(body, &decoded); err != nil {
 		t.Fatalf("json.Unmarshal() error = %v", err)
 	}
@@ -499,7 +499,7 @@ func TestResponsesInputElementMarshalJSON_FunctionCallOutput(t *testing.T) {
 		t.Fatalf("json.Marshal() error = %v", err)
 	}
 
-	var decoded map[string]interface{}
+	var decoded map[string]any
 	if err := json.Unmarshal(body, &decoded); err != nil {
 		t.Fatalf("json.Unmarshal() error = %v", err)
 	}

--- a/internal/core/responses_json_test.go
+++ b/internal/core/responses_json_test.go
@@ -128,7 +128,7 @@ func TestResponsesRequestMarshalJSON_PreservesInput(t *testing.T) {
 
 	input, ok := inputRaw.([]any)
 	if !ok || len(input) != 1 {
-		t.Fatalf("decoded input = %#v, want []interface{} len=1", inputRaw)
+		t.Fatalf("decoded input = %#v, want []any len=1", inputRaw)
 	}
 
 	firstMsg, ok := input[0].(map[string]any)
@@ -145,7 +145,7 @@ func TestResponsesRequestMarshalJSON_PreservesInput(t *testing.T) {
 	}
 	content, ok := contentRaw.([]any)
 	if !ok || len(content) != 1 {
-		t.Fatalf("first input content = %#v, want []interface{} len=1", contentRaw)
+		t.Fatalf("first input content = %#v, want []any len=1", contentRaw)
 	}
 
 	firstPart, ok := content[0].(map[string]any)
@@ -216,7 +216,7 @@ func TestResponsesRequestMarshalJSON_PreservesTypedInputElementContent(t *testin
 
 	input, ok := decoded["input"].([]any)
 	if !ok || len(input) != 1 {
-		t.Fatalf("decoded input = %#v, want []interface{} len=1", decoded["input"])
+		t.Fatalf("decoded input = %#v, want []any len=1", decoded["input"])
 	}
 
 	first, ok := input[0].(map[string]any)

--- a/internal/core/types_test.go
+++ b/internal/core/types_test.go
@@ -87,7 +87,7 @@ func TestMessageMarshalJSON_ContentWinsOverContentNull(t *testing.T) {
 		t.Fatalf("json.Marshal() error = %v, want nil", err)
 	}
 
-	var raw map[string]interface{}
+	var raw map[string]any
 	if err := json.Unmarshal(payload, &raw); err != nil {
 		t.Fatalf("json.Unmarshal() error = %v", err)
 	}

--- a/internal/guardrails/provider.go
+++ b/internal/guardrails/provider.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"log/slog"
+	"maps"
 	"strings"
 
 	"gomodel/internal/core"
@@ -544,18 +545,12 @@ func mergeBatchHints(left, right map[string]string) map[string]string {
 			return nil
 		}
 		merged := make(map[string]string, len(right))
-		for key, value := range right {
-			merged[key] = value
-		}
+		maps.Copy(merged, right)
 		return merged
 	}
 	merged := make(map[string]string, len(left))
-	for key, value := range left {
-		merged[key] = value
-	}
-	for key, value := range right {
-		merged[key] = value
-	}
+	maps.Copy(merged, left)
+	maps.Copy(merged, right)
 	return merged
 }
 
@@ -673,10 +668,7 @@ func applyMessagesToChatPreservingEnvelope(req *core.ChatRequest, msgs []Message
 }
 
 func tailMatchedSystemOffsets(originalSystemCount, modifiedSystemCount int) (matchStart, originalStart int) {
-	matched := originalSystemCount
-	if modifiedSystemCount < matched {
-		matched = modifiedSystemCount
-	}
+	matched := min(modifiedSystemCount, originalSystemCount)
 	return modifiedSystemCount - matched, originalSystemCount - matched
 }
 

--- a/internal/llmclient/client.go
+++ b/internal/llmclient/client.go
@@ -155,8 +155,8 @@ func (c *Client) getBaseURL() string {
 type Request struct {
 	Method   string
 	Endpoint string
-	Body     interface{} // Will be JSON marshaled if not nil
-	RawBody  []byte      // Used as-is (e.g., multipart form bodies). Mutually exclusive with Body and RawBodyReader.
+	Body     any    // Will be JSON marshaled if not nil
+	RawBody  []byte // Used as-is (e.g., multipart form bodies). Mutually exclusive with Body and RawBodyReader.
 	// RawBodyReader streams the request body without buffering it in memory.
 	// It is intended for one-shot passthrough requests and is not replayable for retries.
 	RawBodyReader io.Reader
@@ -272,7 +272,7 @@ func (c *Client) waitForRetry(ctx context.Context, attempt int) error {
 }
 
 // Do executes a request with retries and circuit breaking, then unmarshals the response
-func (c *Client) Do(ctx context.Context, req Request, result interface{}) error {
+func (c *Client) Do(ctx context.Context, req Request, result any) error {
 	resp, err := c.DoRaw(ctx, req)
 	if err != nil {
 		return err
@@ -493,7 +493,7 @@ func (c *Client) DoPassthrough(ctx context.Context, req Request) (*http.Response
 }
 
 // extractModel attempts to extract the model name from a request body
-func extractModel(body interface{}) string {
+func extractModel(body any) string {
 	if body == nil {
 		return "unknown"
 	}

--- a/internal/llmclient/client_test.go
+++ b/internal/llmclient/client_test.go
@@ -49,7 +49,7 @@ func TestClient_Do_Success(t *testing.T) {
 }
 
 func TestClient_Do_WithRequestBody(t *testing.T) {
-	var receivedBody map[string]interface{}
+	var receivedBody map[string]any
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Content-Type") != "application/json" {
@@ -745,7 +745,7 @@ func TestCircuitBreaker_OpensAfterFailures(t *testing.T) {
 	client := New(config, nil)
 
 	// Make requests until circuit opens
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		_ = client.Do(context.Background(), Request{
 			Method:   http.MethodGet,
 			Endpoint: "/test",
@@ -804,7 +804,7 @@ func TestCircuitBreaker_ClosesAfterTimeout(t *testing.T) {
 	client := New(config, nil)
 
 	// Trigger circuit breaker to open
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		_ = client.Do(context.Background(), Request{
 			Method:   http.MethodGet,
 			Endpoint: "/test",
@@ -887,16 +887,14 @@ func TestCircuitBreaker_HalfOpenPreventsThunderingHerd(t *testing.T) {
 	var wg sync.WaitGroup
 	results := make(chan error, 10)
 
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 10 {
+		wg.Go(func() {
 			err := client.Do(context.Background(), Request{
 				Method:   http.MethodGet,
 				Endpoint: "/test",
 			}, nil)
 			results <- err
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -1082,7 +1080,7 @@ func TestCircuitBreaker_RateLimitDoesNotOpenCircuit(t *testing.T) {
 	}
 	client := New(config, nil)
 
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		err := client.Do(context.Background(), Request{
 			Method:   http.MethodGet,
 			Endpoint: "/test",
@@ -1180,7 +1178,7 @@ func TestCircuitBreaker_State(t *testing.T) {
 	}
 
 	// Record failures to open circuit
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		cb.RecordFailure()
 	}
 	if state := cb.State(); state != "open" {
@@ -1259,7 +1257,7 @@ func TestClient_SetBaseURL_Concurrent(t *testing.T) {
 	client := New(DefaultConfig("test", "https://original.com"), nil)
 
 	var wg sync.WaitGroup
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		wg.Add(2)
 		go func(i int) {
 			defer wg.Done()
@@ -1340,7 +1338,7 @@ func TestBackoffCalculation_WithJitter(t *testing.T) {
 	client := New(config, nil)
 
 	// With 50% jitter on 100ms base, result should be between 50ms and 150ms
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		result := client.calculateBackoff(1)
 		if result < 50*time.Millisecond || result > 150*time.Millisecond {
 			t.Errorf("backoff %v outside expected range [50ms, 150ms]", result)

--- a/internal/modeldata/enricher_test.go
+++ b/internal/modeldata/enricher_test.go
@@ -24,9 +24,11 @@ func newMockAccessor(models map[string]string) *mockAccessor {
 	return a
 }
 
-func (a *mockAccessor) ModelIDs() []string                                  { return a.ids }
-func (a *mockAccessor) GetProviderType(modelID string) string               { return a.providerTypes[modelID] }
-func (a *mockAccessor) SetMetadata(modelID string, meta *core.ModelMetadata) { a.metadata[modelID] = meta }
+func (a *mockAccessor) ModelIDs() []string                    { return a.ids }
+func (a *mockAccessor) GetProviderType(modelID string) string { return a.providerTypes[modelID] }
+func (a *mockAccessor) SetMetadata(modelID string, meta *core.ModelMetadata) {
+	a.metadata[modelID] = meta
+}
 
 func TestEnrich_MatchedAndUnmatched(t *testing.T) {
 	list := &ModelList{
@@ -34,11 +36,11 @@ func TestEnrich_MatchedAndUnmatched(t *testing.T) {
 			"gpt-4o": {
 				DisplayName:   "GPT-4o",
 				Modes:         []string{"chat"},
-				ContextWindow: ptr(128000),
+				ContextWindow: new(128000),
 				Pricing: &core.ModelPricing{
 					Currency:      "USD",
-					InputPerMtok:  ptr(2.50),
-					OutputPerMtok: ptr(10.00),
+					InputPerMtok:  new(2.50),
+					OutputPerMtok: new(10.00),
 				},
 			},
 		},
@@ -92,18 +94,18 @@ func TestEnrich_ReverseCustomModelIDLookup(t *testing.T) {
 			"gpt-4o": {
 				DisplayName:   "GPT-4o",
 				Modes:         []string{"chat"},
-				ContextWindow: ptr(128000),
+				ContextWindow: new(128000),
 				Pricing: &core.ModelPricing{
 					Currency:      "USD",
-					InputPerMtok:  ptr(2.50),
-					OutputPerMtok: ptr(10.00),
+					InputPerMtok:  new(2.50),
+					OutputPerMtok: new(10.00),
 				},
 			},
 		},
 		ProviderModels: map[string]ProviderModelEntry{
 			"openai/gpt-4o": {
 				ModelRef:      "gpt-4o",
-				CustomModelID: ptr("gpt-4o-2024-08-06"),
+				CustomModelID: new("gpt-4o-2024-08-06"),
 				Enabled:       true,
 			},
 		},
@@ -135,14 +137,14 @@ func TestEnrich_ProviderModelOverride(t *testing.T) {
 			"gpt-4o": {
 				DisplayName:   "GPT-4o",
 				Modes:         []string{"chat"},
-				ContextWindow: ptr(128000),
+				ContextWindow: new(128000),
 			},
 		},
 		ProviderModels: map[string]ProviderModelEntry{
 			"azure/gpt-4o": {
 				ModelRef:      "gpt-4o",
 				Enabled:       true,
-				ContextWindow: ptr(64000),
+				ContextWindow: new(64000),
 			},
 		},
 	}

--- a/internal/modeldata/merger_test.go
+++ b/internal/modeldata/merger_test.go
@@ -6,8 +6,6 @@ import (
 	"gomodel/internal/core"
 )
 
-func ptr[T any](v T) *T { return &v }
-
 func TestResolve_NilList(t *testing.T) {
 	meta := Resolve(nil, "openai", "gpt-4o")
 	if meta != nil {
@@ -31,12 +29,12 @@ func TestResolve_DirectModelMatch(t *testing.T) {
 		Models: map[string]ModelEntry{
 			"gpt-4o": {
 				DisplayName:     "GPT-4o",
-				Description:     ptr("Flagship model"),
-				Family:          ptr("gpt-4o"),
+				Description:     new("Flagship model"),
+				Family:          new("gpt-4o"),
 				Modes:           []string{"chat"},
 				Tags:            []string{"flagship", "multimodal"},
-				ContextWindow:   ptr(128000),
-				MaxOutputTokens: ptr(16384),
+				ContextWindow:   new(128000),
+				MaxOutputTokens: new(16384),
 				Capabilities: map[string]bool{
 					"function_calling": true,
 					"streaming":        true,
@@ -44,8 +42,8 @@ func TestResolve_DirectModelMatch(t *testing.T) {
 				},
 				Pricing: &core.ModelPricing{
 					Currency:      "USD",
-					InputPerMtok:  ptr(2.50),
-					OutputPerMtok: ptr(10.00),
+					InputPerMtok:  new(2.50),
+					OutputPerMtok: new(10.00),
 				},
 			},
 		},
@@ -101,12 +99,12 @@ func TestResolve_ProviderModelOverride(t *testing.T) {
 			"gpt-4o": {
 				DisplayName:     "GPT-4o",
 				Modes:           []string{"chat"},
-				ContextWindow:   ptr(128000),
-				MaxOutputTokens: ptr(16384),
+				ContextWindow:   new(128000),
+				MaxOutputTokens: new(16384),
 				Pricing: &core.ModelPricing{
 					Currency:      "USD",
-					InputPerMtok:  ptr(2.50),
-					OutputPerMtok: ptr(10.00),
+					InputPerMtok:  new(2.50),
+					OutputPerMtok: new(10.00),
 				},
 			},
 		},
@@ -114,11 +112,11 @@ func TestResolve_ProviderModelOverride(t *testing.T) {
 			"azure/gpt-4o": {
 				ModelRef:      "gpt-4o",
 				Enabled:       true,
-				ContextWindow: ptr(64000),
+				ContextWindow: new(64000),
 				Pricing: &core.ModelPricing{
 					Currency:      "USD",
-					InputPerMtok:  ptr(5.00),
-					OutputPerMtok: ptr(15.00),
+					InputPerMtok:  new(5.00),
+					OutputPerMtok: new(15.00),
 				},
 			},
 		},
@@ -157,11 +155,11 @@ func TestResolve_ProviderModelWithoutBaseModel(t *testing.T) {
 			"custom/my-model": {
 				ModelRef:      "nonexistent",
 				Enabled:       true,
-				ContextWindow: ptr(32000),
+				ContextWindow: new(32000),
 				Pricing: &core.ModelPricing{
 					Currency:      "USD",
-					InputPerMtok:  ptr(1.00),
-					OutputPerMtok: ptr(2.00),
+					InputPerMtok:  new(1.00),
+					OutputPerMtok: new(2.00),
 				},
 			},
 		},
@@ -258,21 +256,21 @@ func TestResolve_ThreeLayerMerge(t *testing.T) {
 		Models: map[string]ModelEntry{
 			"claude-sonnet-4-20250514": {
 				DisplayName:     "Claude Sonnet 4",
-				Description:     ptr("Fast, intelligent model"),
-				Family:          ptr("claude-sonnet"),
+				Description:     new("Fast, intelligent model"),
+				Family:          new("claude-sonnet"),
 				Modes:           []string{"chat"},
 				Tags:            []string{"flagship"},
-				ContextWindow:   ptr(200000),
-				MaxOutputTokens: ptr(16384),
+				ContextWindow:   new(200000),
+				MaxOutputTokens: new(16384),
 				Capabilities: map[string]bool{
 					"function_calling": true,
 					"vision":           true,
 				},
 				Pricing: &core.ModelPricing{
 					Currency:           "USD",
-					InputPerMtok:       ptr(3.00),
-					OutputPerMtok:      ptr(15.00),
-					CachedInputPerMtok: ptr(0.30),
+					InputPerMtok:       new(3.00),
+					OutputPerMtok:      new(15.00),
+					CachedInputPerMtok: new(0.30),
 				},
 			},
 		},
@@ -280,12 +278,12 @@ func TestResolve_ThreeLayerMerge(t *testing.T) {
 			"bedrock/claude-sonnet-4-20250514": {
 				ModelRef:        "claude-sonnet-4-20250514",
 				Enabled:         true,
-				MaxOutputTokens: ptr(8192),
+				MaxOutputTokens: new(8192),
 				Pricing: &core.ModelPricing{
 					Currency:           "USD",
-					InputPerMtok:       ptr(3.00),
-					OutputPerMtok:      ptr(15.00),
-					CachedInputPerMtok: ptr(0.30),
+					InputPerMtok:       new(3.00),
+					OutputPerMtok:      new(15.00),
+					CachedInputPerMtok: new(0.30),
 				},
 			},
 		},
@@ -320,18 +318,18 @@ func TestResolve_ReverseCustomModelIDLookup(t *testing.T) {
 			"gpt-4o": {
 				DisplayName:   "GPT-4o",
 				Modes:         []string{"chat"},
-				ContextWindow: ptr(128000),
+				ContextWindow: new(128000),
 				Pricing: &core.ModelPricing{
 					Currency:      "USD",
-					InputPerMtok:  ptr(2.50),
-					OutputPerMtok: ptr(10.00),
+					InputPerMtok:  new(2.50),
+					OutputPerMtok: new(10.00),
 				},
 			},
 		},
 		ProviderModels: map[string]ProviderModelEntry{
 			"openai/gpt-4o": {
 				ModelRef:      "gpt-4o",
-				CustomModelID: ptr("gpt-4o-2024-08-06"),
+				CustomModelID: new("gpt-4o-2024-08-06"),
 				Enabled:       true,
 			},
 		},
@@ -365,7 +363,7 @@ func TestResolve_ReverseIndexNotBuilt(t *testing.T) {
 		ProviderModels: map[string]ProviderModelEntry{
 			"openai/gpt-4o": {
 				ModelRef:      "gpt-4o",
-				CustomModelID: ptr("gpt-4o-2024-08-06"),
+				CustomModelID: new("gpt-4o-2024-08-06"),
 				Enabled:       true,
 			},
 		},
@@ -384,23 +382,23 @@ func TestResolve_ReverseIndexWithProviderModelOverride(t *testing.T) {
 			"gpt-4o": {
 				DisplayName:   "GPT-4o",
 				Modes:         []string{"chat"},
-				ContextWindow: ptr(128000),
+				ContextWindow: new(128000),
 				Pricing: &core.ModelPricing{
 					Currency:      "USD",
-					InputPerMtok:  ptr(2.50),
-					OutputPerMtok: ptr(10.00),
+					InputPerMtok:  new(2.50),
+					OutputPerMtok: new(10.00),
 				},
 			},
 		},
 		ProviderModels: map[string]ProviderModelEntry{
 			"openai/gpt-4o": {
 				ModelRef:      "gpt-4o",
-				CustomModelID: ptr("gpt-4o-2024-08-06"),
+				CustomModelID: new("gpt-4o-2024-08-06"),
 				Enabled:       true,
 				Pricing: &core.ModelPricing{
 					Currency:      "USD",
-					InputPerMtok:  ptr(3.00),
-					OutputPerMtok: ptr(12.00),
+					InputPerMtok:  new(3.00),
+					OutputPerMtok: new(12.00),
 				},
 			},
 		},

--- a/internal/providers/anthropic/anthropic.go
+++ b/internal/providers/anthropic/anthropic.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -151,9 +152,7 @@ func (p *Provider) getBatchResultEndpoints(batchID string) map[string]string {
 		return nil
 	}
 	cloned := make(map[string]string, len(endpoints))
-	for customID, endpoint := range endpoints {
-		cloned[customID] = endpoint
-	}
+	maps.Copy(cloned, endpoints)
 	return cloned
 }
 
@@ -880,7 +879,7 @@ func (sc *streamConverter) convertEvent(event *anthropicStreamEvent) string {
 		}
 		// Emit chunk if we have stop_reason or usage data
 		if (event.Delta != nil && event.Delta.StopReason != "") || event.Usage != nil {
-			var finishReason interface{}
+			var finishReason any
 			if event.Delta != nil && event.Delta.StopReason != "" {
 				finishReason = sc.mapStreamStopReason(event.Delta.StopReason)
 			}
@@ -1516,7 +1515,7 @@ func (sc *responsesStreamConverter) Read(p []byte) (n int, err error) {
 				if !sc.sentDone {
 					sc.sentDone = true
 					prefix := sc.output.CompleteAssistantOutput(0)
-					responseData := map[string]interface{}{
+					responseData := map[string]any{
 						"id":         sc.responseID,
 						"object":     "response",
 						"status":     "completed",
@@ -1528,7 +1527,7 @@ func (sc *responsesStreamConverter) Read(p []byte) (n int, err error) {
 					if sc.hasUsage {
 						responseData["usage"] = anthropicResponsesUsagePayload(&sc.usage)
 					}
-					doneEvent := map[string]interface{}{
+					doneEvent := map[string]any{
 						"type":     "response.completed",
 						"response": responseData,
 					}
@@ -1610,9 +1609,9 @@ func (sc *responsesStreamConverter) convertEvent(event *anthropicStreamEvent) st
 			sc.hasUsage = true
 		}
 		// Send response.created event
-		createdEvent := map[string]interface{}{
+		createdEvent := map[string]any{
 			"type": "response.created",
-			"response": map[string]interface{}{
+			"response": map[string]any{
 				"id":         sc.responseID,
 				"object":     "response",
 				"status":     "in_progress",
@@ -1661,7 +1660,7 @@ func (sc *responsesStreamConverter) convertEvent(event *anthropicStreamEvent) st
 				sc.reserveAssistantMessageOutput()
 				prefix := sc.output.StartAssistantOutput(0)
 				sc.output.AppendAssistantText(event.Delta.Text)
-				deltaEvent := map[string]interface{}{
+				deltaEvent := map[string]any{
 					"type":  "response.output_text.delta",
 					"delta": event.Delta.Text,
 				}

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -617,11 +617,11 @@ data: {"type":"message_stop"}
 			continue
 		}
 
-		choices, ok := event.Payload["choices"].([]interface{})
+		choices, ok := event.Payload["choices"].([]any)
 		if !ok || len(choices) == 0 {
 			continue
 		}
-		choice, ok := choices[0].(map[string]interface{})
+		choice, ok := choices[0].(map[string]any)
 		if !ok {
 			continue
 		}
@@ -630,19 +630,19 @@ data: {"type":"message_stop"}
 			foundFinish = true
 		}
 
-		delta, ok := choice["delta"].(map[string]interface{})
+		delta, ok := choice["delta"].(map[string]any)
 		if !ok {
 			continue
 		}
-		toolCalls, ok := delta["tool_calls"].([]interface{})
+		toolCalls, ok := delta["tool_calls"].([]any)
 		if !ok || len(toolCalls) == 0 {
 			continue
 		}
-		toolCall, ok := toolCalls[0].(map[string]interface{})
+		toolCall, ok := toolCalls[0].(map[string]any)
 		if !ok {
 			continue
 		}
-		function, _ := toolCall["function"].(map[string]interface{})
+		function, _ := toolCall["function"].(map[string]any)
 
 		if toolCall["id"] == "toolu_123" && function["name"] == "lookup_weather" {
 			foundToolStart = true
@@ -719,24 +719,24 @@ data: {"type":"message_stop"}
 		if event.Done {
 			continue
 		}
-		choices, ok := event.Payload["choices"].([]interface{})
+		choices, ok := event.Payload["choices"].([]any)
 		if !ok || len(choices) == 0 {
 			continue
 		}
-		choice, ok := choices[0].(map[string]interface{})
+		choice, ok := choices[0].(map[string]any)
 		if !ok {
 			continue
 		}
 		if finishReason, _ := choice["finish_reason"].(string); finishReason == "tool_calls" {
 			foundFinish = true
 		}
-		delta, _ := choice["delta"].(map[string]interface{})
-		toolCalls, _ := delta["tool_calls"].([]interface{})
+		delta, _ := choice["delta"].(map[string]any)
+		toolCalls, _ := delta["tool_calls"].([]any)
 		if len(toolCalls) == 0 {
 			continue
 		}
-		toolCall, _ := toolCalls[0].(map[string]interface{})
-		function, _ := toolCall["function"].(map[string]interface{})
+		toolCall, _ := toolCalls[0].(map[string]any)
+		function, _ := toolCall["function"].(map[string]any)
 		if toolCall["id"] == "toolu_123" && function["name"] == "lookup_weather" && function["arguments"] == "{}" {
 			foundToolCall = true
 		}
@@ -794,11 +794,11 @@ data: {"type":"message_stop"}
 			continue
 		}
 
-		choices, ok := event.Payload["choices"].([]interface{})
+		choices, ok := event.Payload["choices"].([]any)
 		if !ok || len(choices) == 0 {
 			continue
 		}
-		choice, ok := choices[0].(map[string]interface{})
+		choice, ok := choices[0].(map[string]any)
 		if !ok {
 			continue
 		}
@@ -806,7 +806,7 @@ data: {"type":"message_stop"}
 			t.Fatalf("finish_reason = %#v, want %q", choice["finish_reason"], "tool_use")
 		}
 
-		delta, _ := choice["delta"].(map[string]interface{})
+		delta, _ := choice["delta"].(map[string]any)
 		if _, ok := delta["tool_calls"]; ok {
 			t.Fatalf("did not expect tool_calls in malformed stream fallback, got %#v", delta["tool_calls"])
 		}
@@ -873,7 +873,7 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
 
 type testSSEEvent struct {
 	Name    string
-	Payload map[string]interface{}
+	Payload map[string]any
 	Done    bool
 }
 
@@ -889,8 +889,8 @@ func parseTestSSEEvents(t *testing.T, raw string) []testSSEEvent {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "event:") {
-			currentEventName = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		if after, ok := strings.CutPrefix(line, "event:"); ok {
+			currentEventName = strings.TrimSpace(after)
 			continue
 		}
 		if !strings.HasPrefix(line, "data:") {
@@ -904,7 +904,7 @@ func parseTestSSEEvents(t *testing.T, raw string) []testSSEEvent {
 			continue
 		}
 
-		var payload map[string]interface{}
+		var payload map[string]any
 		if err := json.Unmarshal([]byte(data), &payload); err != nil {
 			t.Fatalf("failed to unmarshal SSE payload %q: %v", data, err)
 		}
@@ -2280,12 +2280,12 @@ func TestResponsesWithArrayInput(t *testing.T) {
 
 	req := &core.ResponsesRequest{
 		Model: "claude-sonnet-4-5-20250929",
-		Input: []interface{}{
-			map[string]interface{}{
+		Input: []any{
+			map[string]any{
 				"role":    "user",
 				"content": "Hello",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"role":    "assistant",
 				"content": "Hi there!",
 			},
@@ -2614,7 +2614,7 @@ data: {"type":"message_stop"}
 		}
 		switch event.Name {
 		case "response.output_item.added":
-			item, _ := event.Payload["item"].(map[string]interface{})
+			item, _ := event.Payload["item"].(map[string]any)
 			if item["type"] == "message" && item["role"] == "assistant" && event.Payload["output_index"] == float64(0) {
 				foundAssistantAdded = true
 			}
@@ -2622,7 +2622,7 @@ data: {"type":"message_stop"}
 				foundAdded = true
 			}
 		case "response.output_item.done":
-			item, _ := event.Payload["item"].(map[string]interface{})
+			item, _ := event.Payload["item"].(map[string]any)
 			if item["type"] == "message" && item["role"] == "assistant" && event.Payload["output_index"] == float64(0) {
 				foundAssistantDone = true
 			}
@@ -2723,7 +2723,7 @@ data: {"type":"message_stop"}
 		}
 		switch event.Name {
 		case "response.output_item.added":
-			item, _ := event.Payload["item"].(map[string]interface{})
+			item, _ := event.Payload["item"].(map[string]any)
 			if item["type"] == "function_call" && item["arguments"] == "{}" {
 				foundAdded = true
 			}
@@ -2884,15 +2884,15 @@ func TestConvertResponsesRequestToAnthropic(t *testing.T) {
 			name: "array input with content parts",
 			input: &core.ResponsesRequest{
 				Model: "claude-sonnet-4-5-20250929",
-				Input: []interface{}{
-					map[string]interface{}{
+				Input: []any{
+					map[string]any{
 						"role": "user",
-						"content": []interface{}{
-							map[string]interface{}{
+						"content": []any{
+							map[string]any{
 								"type": "text",
 								"text": "Hello",
 							},
-							map[string]interface{}{
+							map[string]any{
 								"type": "text",
 								"text": "World",
 							},
@@ -2944,17 +2944,17 @@ func TestConvertResponsesRequestToAnthropic(t *testing.T) {
 			name: "with function call loop input items",
 			input: &core.ResponsesRequest{
 				Model: "claude-sonnet-4-5-20250929",
-				Input: []interface{}{
-					map[string]interface{}{
+				Input: []any{
+					map[string]any{
 						"type":      "function_call",
 						"call_id":   "call_123",
 						"name":      "lookup_weather",
 						"arguments": `{"city":"Warsaw"}`,
 					},
-					map[string]interface{}{
+					map[string]any{
 						"type":    "function_call_output",
 						"call_id": "call_123",
-						"output":  map[string]interface{}{"temperature_c": 21},
+						"output":  map[string]any{"temperature_c": 21},
 					},
 				},
 			},
@@ -2999,8 +2999,8 @@ func TestConvertResponsesRequestToAnthropic(t *testing.T) {
 func TestConvertResponsesRequestToAnthropic_InvalidToolArguments(t *testing.T) {
 	_, err := convertResponsesRequestToAnthropic(&core.ResponsesRequest{
 		Model: "claude-sonnet-4-5-20250929",
-		Input: []interface{}{
-			map[string]interface{}{
+		Input: []any{
+			map[string]any{
 				"type":      "function_call",
 				"call_id":   "call_123",
 				"name":      "lookup_weather",
@@ -3026,8 +3026,8 @@ func TestConvertResponsesRequestToAnthropic_InvalidToolArguments(t *testing.T) {
 func TestConvertResponsesRequestToAnthropic_RejectsTrailingToolArgumentContent(t *testing.T) {
 	_, err := convertResponsesRequestToAnthropic(&core.ResponsesRequest{
 		Model: "claude-sonnet-4-5-20250929",
-		Input: []interface{}{
-			map[string]interface{}{
+		Input: []any{
+			map[string]any{
 				"type":      "function_call",
 				"call_id":   "call_123",
 				"name":      "lookup_weather",
@@ -3474,21 +3474,21 @@ func TestConvertToAnthropicRequest_ReasoningEffort(t *testing.T) {
 			name:              "reasoning nil - no thinking",
 			model:             "claude-3-5-sonnet-20241022",
 			reasoning:         nil,
-			maxTokens:         intPtr(1000),
+			maxTokens:         new(1000),
 			expectedMaxTokens: 1000,
 		},
 		{
 			name:              "empty effort - no thinking",
 			model:             "claude-3-5-sonnet-20241022",
 			reasoning:         &core.Reasoning{Effort: ""},
-			maxTokens:         intPtr(1000),
+			maxTokens:         new(1000),
 			expectedMaxTokens: 1000,
 		},
 		{
 			name:              "legacy model - low effort",
 			model:             "claude-3-5-sonnet-20241022",
 			reasoning:         &core.Reasoning{Effort: "low"},
-			maxTokens:         intPtr(10000),
+			maxTokens:         new(10000),
 			expectedThinkType: "enabled",
 			expectedBudget:    5000,
 			expectedMaxTokens: 10000,
@@ -3498,7 +3498,7 @@ func TestConvertToAnthropicRequest_ReasoningEffort(t *testing.T) {
 			name:              "legacy model - medium effort",
 			model:             "claude-3-5-sonnet-20241022",
 			reasoning:         &core.Reasoning{Effort: "medium"},
-			maxTokens:         intPtr(15000),
+			maxTokens:         new(15000),
 			expectedThinkType: "enabled",
 			expectedBudget:    10000,
 			expectedMaxTokens: 15000,
@@ -3508,7 +3508,7 @@ func TestConvertToAnthropicRequest_ReasoningEffort(t *testing.T) {
 			name:              "legacy model - high effort",
 			model:             "claude-3-5-sonnet-20241022",
 			reasoning:         &core.Reasoning{Effort: "high"},
-			maxTokens:         intPtr(25000),
+			maxTokens:         new(25000),
 			expectedThinkType: "enabled",
 			expectedBudget:    20000,
 			expectedMaxTokens: 25000,
@@ -3518,7 +3518,7 @@ func TestConvertToAnthropicRequest_ReasoningEffort(t *testing.T) {
 			name:              "legacy model - invalid effort defaults to low",
 			model:             "claude-3-5-sonnet-20241022",
 			reasoning:         &core.Reasoning{Effort: "invalid"},
-			maxTokens:         intPtr(10000),
+			maxTokens:         new(10000),
 			expectedThinkType: "enabled",
 			expectedBudget:    5000,
 			expectedMaxTokens: 10000,
@@ -3528,7 +3528,7 @@ func TestConvertToAnthropicRequest_ReasoningEffort(t *testing.T) {
 			name:              "legacy model - bumps max_tokens when too low",
 			model:             "claude-3-5-sonnet-20241022",
 			reasoning:         &core.Reasoning{Effort: "high"},
-			maxTokens:         intPtr(1000),
+			maxTokens:         new(1000),
 			expectedThinkType: "enabled",
 			expectedBudget:    20000,
 			expectedMaxTokens: 21024,
@@ -3538,7 +3538,7 @@ func TestConvertToAnthropicRequest_ReasoningEffort(t *testing.T) {
 			name:              "legacy model - removes temperature",
 			model:             "claude-3-5-sonnet-20241022",
 			reasoning:         &core.Reasoning{Effort: "medium"},
-			maxTokens:         intPtr(15000),
+			maxTokens:         new(15000),
 			setTemperature:    true,
 			expectedThinkType: "enabled",
 			expectedBudget:    10000,
@@ -3549,19 +3549,19 @@ func TestConvertToAnthropicRequest_ReasoningEffort(t *testing.T) {
 			name:              "legacy model - preserves temperature=1.0 with reasoning",
 			model:             "claude-3-5-sonnet-20241022",
 			reasoning:         &core.Reasoning{Effort: "medium"},
-			maxTokens:         intPtr(15000),
+			maxTokens:         new(15000),
 			setTemperatureOne: true,
 			expectedThinkType: "enabled",
 			expectedBudget:    10000,
 			expectedMaxTokens: 15000,
 			expectNilTemp:     false,
-			expectedTemp:      float64Ptr(1.0),
+			expectedTemp:      new(1.0),
 		},
 		{
 			name:              "4.6 model - adaptive thinking with high effort",
 			model:             "claude-opus-4-6",
 			reasoning:         &core.Reasoning{Effort: "high"},
-			maxTokens:         intPtr(4096),
+			maxTokens:         new(4096),
 			expectedThinkType: "adaptive",
 			expectedEffort:    "high",
 			expectedMaxTokens: 4096,
@@ -3571,7 +3571,7 @@ func TestConvertToAnthropicRequest_ReasoningEffort(t *testing.T) {
 			name:              "4.6 model - adaptive thinking with low effort",
 			model:             "claude-sonnet-4-6-20260301",
 			reasoning:         &core.Reasoning{Effort: "low"},
-			maxTokens:         intPtr(4096),
+			maxTokens:         new(4096),
 			expectedThinkType: "adaptive",
 			expectedEffort:    "low",
 			expectedMaxTokens: 4096,
@@ -3581,7 +3581,7 @@ func TestConvertToAnthropicRequest_ReasoningEffort(t *testing.T) {
 			name:              "4.6 model - does not bump max_tokens",
 			model:             "claude-opus-4-6",
 			reasoning:         &core.Reasoning{Effort: "high"},
-			maxTokens:         intPtr(1000),
+			maxTokens:         new(1000),
 			expectedThinkType: "adaptive",
 			expectedEffort:    "high",
 			expectedMaxTokens: 1000,
@@ -3591,7 +3591,7 @@ func TestConvertToAnthropicRequest_ReasoningEffort(t *testing.T) {
 			name:              "4.6 model - removes temperature",
 			model:             "claude-opus-4-6",
 			reasoning:         &core.Reasoning{Effort: "medium"},
-			maxTokens:         intPtr(4096),
+			maxTokens:         new(4096),
 			setTemperature:    true,
 			expectedThinkType: "adaptive",
 			expectedEffort:    "medium",
@@ -3602,7 +3602,7 @@ func TestConvertToAnthropicRequest_ReasoningEffort(t *testing.T) {
 			name:              "4.6 model - invalid effort normalizes to low",
 			model:             "claude-opus-4-6",
 			reasoning:         &core.Reasoning{Effort: "extreme"},
-			maxTokens:         intPtr(4096),
+			maxTokens:         new(4096),
 			expectedThinkType: "adaptive",
 			expectedEffort:    "low",
 			expectedMaxTokens: 4096,
@@ -3695,21 +3695,21 @@ func TestConvertResponsesRequestToAnthropic_ReasoningEffort(t *testing.T) {
 			name:              "no reasoning",
 			model:             "claude-3-5-sonnet-20241022",
 			reasoning:         nil,
-			maxOutputTokens:   intPtr(1000),
+			maxOutputTokens:   new(1000),
 			expectedMaxTokens: 1000,
 		},
 		{
 			name:              "empty effort",
 			model:             "claude-3-5-sonnet-20241022",
 			reasoning:         &core.Reasoning{Effort: ""},
-			maxOutputTokens:   intPtr(1000),
+			maxOutputTokens:   new(1000),
 			expectedMaxTokens: 1000,
 		},
 		{
 			name:              "legacy model - low effort bumps max tokens",
 			model:             "claude-3-5-sonnet-20241022",
 			reasoning:         &core.Reasoning{Effort: "low"},
-			maxOutputTokens:   intPtr(1000),
+			maxOutputTokens:   new(1000),
 			expectedThinkType: "enabled",
 			expectedBudget:    5000,
 			expectedMaxTokens: 6024,
@@ -3719,7 +3719,7 @@ func TestConvertResponsesRequestToAnthropic_ReasoningEffort(t *testing.T) {
 			name:              "legacy model - high effort with sufficient tokens",
 			model:             "claude-3-5-sonnet-20241022",
 			reasoning:         &core.Reasoning{Effort: "high"},
-			maxOutputTokens:   intPtr(25000),
+			maxOutputTokens:   new(25000),
 			expectedThinkType: "enabled",
 			expectedBudget:    20000,
 			expectedMaxTokens: 25000,
@@ -3729,7 +3729,7 @@ func TestConvertResponsesRequestToAnthropic_ReasoningEffort(t *testing.T) {
 			name:              "legacy model - removes temperature",
 			model:             "claude-3-5-sonnet-20241022",
 			reasoning:         &core.Reasoning{Effort: "medium"},
-			maxOutputTokens:   intPtr(15000),
+			maxOutputTokens:   new(15000),
 			setTemperature:    true,
 			expectedThinkType: "enabled",
 			expectedBudget:    10000,
@@ -3740,7 +3740,7 @@ func TestConvertResponsesRequestToAnthropic_ReasoningEffort(t *testing.T) {
 			name:              "4.6 model - adaptive thinking",
 			model:             "claude-opus-4-6",
 			reasoning:         &core.Reasoning{Effort: "high"},
-			maxOutputTokens:   intPtr(4096),
+			maxOutputTokens:   new(4096),
 			expectedThinkType: "adaptive",
 			expectedEffort:    "high",
 			expectedMaxTokens: 4096,
@@ -3750,7 +3750,7 @@ func TestConvertResponsesRequestToAnthropic_ReasoningEffort(t *testing.T) {
 			name:              "4.6 model - does not bump max_tokens",
 			model:             "claude-opus-4-6",
 			reasoning:         &core.Reasoning{Effort: "high"},
-			maxOutputTokens:   intPtr(1000),
+			maxOutputTokens:   new(1000),
 			expectedThinkType: "adaptive",
 			expectedEffort:    "high",
 			expectedMaxTokens: 1000,
@@ -3760,7 +3760,7 @@ func TestConvertResponsesRequestToAnthropic_ReasoningEffort(t *testing.T) {
 			name:              "4.6 model - removes temperature",
 			model:             "claude-opus-4-6",
 			reasoning:         &core.Reasoning{Effort: "medium"},
-			maxOutputTokens:   intPtr(4096),
+			maxOutputTokens:   new(4096),
 			setTemperature:    true,
 			expectedThinkType: "adaptive",
 			expectedEffort:    "medium",
@@ -3771,7 +3771,7 @@ func TestConvertResponsesRequestToAnthropic_ReasoningEffort(t *testing.T) {
 			name:              "4.6 model - invalid effort normalizes to low",
 			model:             "claude-opus-4-6",
 			reasoning:         &core.Reasoning{Effort: "extreme"},
-			maxOutputTokens:   intPtr(4096),
+			maxOutputTokens:   new(4096),
 			expectedThinkType: "adaptive",
 			expectedEffort:    "low",
 			expectedMaxTokens: 4096,
@@ -4150,20 +4150,20 @@ func TestConvertToAnthropicRequest_RejectsInvalidRemoteImageURLs(t *testing.T) {
 func TestConvertResponsesRequestToAnthropic_RejectsInvalidInputItems(t *testing.T) {
 	tests := []struct {
 		name  string
-		input []interface{}
+		input []any
 	}{
 		{
 			name: "non-object item",
-			input: []interface{}{
+			input: []any{
 				"bad-item",
 			},
 		},
 		{
 			name: "missing role",
-			input: []interface{}{
-				map[string]interface{}{
-					"content": []interface{}{
-						map[string]interface{}{
+			input: []any{
+				map[string]any{
+					"content": []any{
+						map[string]any{
 							"type": "input_text",
 							"text": "hello",
 						},
@@ -4173,11 +4173,11 @@ func TestConvertResponsesRequestToAnthropic_RejectsInvalidInputItems(t *testing.
 		},
 		{
 			name: "invalid content",
-			input: []interface{}{
-				map[string]interface{}{
+			input: []any{
+				map[string]any{
 					"role": "user",
-					"content": []interface{}{
-						map[string]interface{}{
+					"content": []any{
+						map[string]any{
 							"type": "unknown",
 						},
 					},
@@ -4218,8 +4218,8 @@ func TestConvertResponsesRequestToAnthropic_RejectsUnsupportedInputType(t *testi
 func TestConvertResponsesRequestToAnthropic_TrimsRoleBeforeAppend(t *testing.T) {
 	req, err := convertResponsesRequestToAnthropic(&core.ResponsesRequest{
 		Model: "claude-sonnet-4-5-20250929",
-		Input: []interface{}{
-			map[string]interface{}{
+		Input: []any{
+			map[string]any{
 				"role":    "  user  ",
 				"content": "hello",
 			},
@@ -4305,17 +4305,17 @@ func TestConvertResponsesRequestToAnthropic_TypedInputPromotesSystemRole(t *test
 func TestConvertResponsesRequestToAnthropic_PreservesMultimodalImageInput(t *testing.T) {
 	req, err := convertResponsesRequestToAnthropic(&core.ResponsesRequest{
 		Model: "claude-sonnet-4-5-20250929",
-		Input: []interface{}{
-			map[string]interface{}{
+		Input: []any{
+			map[string]any{
 				"role": "user",
-				"content": []interface{}{
-					map[string]interface{}{
+				"content": []any{
+					map[string]any{
 						"type": "input_text",
 						"text": "Describe the image.",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"type": "input_image",
-						"image_url": map[string]interface{}{
+						"image_url": map[string]any{
 							"url": "data:image/png;base64,ZmFrZQ==",
 						},
 					},
@@ -4428,14 +4428,6 @@ func TestConvertToAnthropicRequest_NormalizesInputTextType(t *testing.T) {
 	if blocks[1].Text != "Second part." {
 		t.Errorf("blocks[1].Text = %q, want \"Second part.\"", blocks[1].Text)
 	}
-}
-
-func intPtr(i int) *int {
-	return &i
-}
-
-func float64Ptr(f float64) *float64 {
-	return &f
 }
 
 func TestPassthrough(t *testing.T) {

--- a/internal/providers/anthropic/request_translation.go
+++ b/internal/providers/anthropic/request_translation.go
@@ -530,8 +530,7 @@ func validateAnthropicToolChoice(toolChoice *anthropicToolChoice, tools []anthro
 }
 
 func prefixAnthropicBatchItemError(index int, err error) error {
-	var gatewayErr *core.GatewayError
-	if errors.As(err, &gatewayErr) {
+	if gatewayErr, ok := errors.AsType[*core.GatewayError](err); ok {
 		prefixed := *gatewayErr
 		prefixed.Message = fmt.Sprintf("batch item %d: %s", index, gatewayErr.Message)
 		return &prefixed

--- a/internal/providers/config.go
+++ b/internal/providers/config.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"maps"
 	"os"
 	"strings"
 
@@ -54,9 +55,7 @@ func resolveProviders(raw map[string]config.RawProviderConfig, global config.Res
 // Env var values always win over YAML values for the same provider name.
 func applyProviderEnvVars(raw map[string]config.RawProviderConfig) map[string]config.RawProviderConfig {
 	result := make(map[string]config.RawProviderConfig, len(raw))
-	for k, v := range raw {
-		result[k] = v
-	}
+	maps.Copy(result, raw)
 
 	for _, kp := range knownProviderEnvs {
 		apiKey := os.Getenv(kp.apiKeyEnv)

--- a/internal/providers/config_test.go
+++ b/internal/providers/config_test.go
@@ -7,9 +7,6 @@ import (
 	"gomodel/config"
 )
 
-//go:fix inline
-func durPtr(v time.Duration) *time.Duration { return new(v) }
-
 var globalRetry = config.RetryConfig{
 	MaxRetries:     3,
 	InitialBackoff: 1 * time.Second,
@@ -86,8 +83,8 @@ func TestBuildProviderConfig_FullOverride(t *testing.T) {
 		Resilience: &config.RawResilienceConfig{
 			Retry: &config.RawRetryConfig{
 				MaxRetries:     new(7),
-				InitialBackoff: durPtr(500 * time.Millisecond),
-				MaxBackoff:     durPtr(10 * time.Second),
+				InitialBackoff: new(500 * time.Millisecond),
+				MaxBackoff:     new(10 * time.Second),
 				BackoffFactor:  new(1.5),
 				JitterFactor:   new(0.3),
 			},

--- a/internal/providers/config_test.go
+++ b/internal/providers/config_test.go
@@ -7,10 +7,8 @@ import (
 	"gomodel/config"
 )
 
-// ptr helpers
-func intPtr(v int) *int                     { return &v }
-func durPtr(v time.Duration) *time.Duration { return &v }
-func f64Ptr(v float64) *float64             { return &v }
+//go:fix inline
+func durPtr(v time.Duration) *time.Duration { return new(v) }
 
 var globalRetry = config.RetryConfig{
 	MaxRetries:     3,
@@ -64,7 +62,7 @@ func TestBuildProviderConfig_PartialOverride(t *testing.T) {
 		APIKey: "sk-ant",
 		Resilience: &config.RawResilienceConfig{
 			Retry: &config.RawRetryConfig{
-				MaxRetries: intPtr(10),
+				MaxRetries: new(10),
 			},
 		},
 	}
@@ -87,11 +85,11 @@ func TestBuildProviderConfig_FullOverride(t *testing.T) {
 		APIKey: "sk-gem",
 		Resilience: &config.RawResilienceConfig{
 			Retry: &config.RawRetryConfig{
-				MaxRetries:     intPtr(7),
+				MaxRetries:     new(7),
 				InitialBackoff: durPtr(500 * time.Millisecond),
 				MaxBackoff:     durPtr(10 * time.Second),
-				BackoffFactor:  f64Ptr(1.5),
-				JitterFactor:   f64Ptr(0.3),
+				BackoffFactor:  new(1.5),
+				JitterFactor:   new(0.3),
 			},
 		},
 	}
@@ -121,7 +119,7 @@ func TestBuildProviderConfig_ZeroValueOverride(t *testing.T) {
 		APIKey: "sk-groq",
 		Resilience: &config.RawResilienceConfig{
 			Retry: &config.RawRetryConfig{
-				MaxRetries: intPtr(0),
+				MaxRetries: new(0),
 			},
 		},
 	}

--- a/internal/providers/gemini/gemini.go
+++ b/internal/providers/gemini/gemini.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -263,13 +264,7 @@ func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error)
 				}
 			}
 
-			supportsEmbed := false
-			for _, method := range gm.SupportedMethods {
-				if method == "embedContent" {
-					supportsEmbed = true
-					break
-				}
-			}
+			supportsEmbed := slices.Contains(gm.SupportedMethods, "embedContent")
 
 			isOpenAICompatModel := strings.HasPrefix(modelID, "gemini-") || strings.HasPrefix(modelID, "text-embedding-")
 			if (supportsGenerate || supportsEmbed) && isOpenAICompatModel {

--- a/internal/providers/groq/groq_test.go
+++ b/internal/providers/groq/groq_test.go
@@ -464,13 +464,13 @@ func TestResponsesWithArrayInput(t *testing.T) {
 			t.Fatalf("failed to read request body: %v", err)
 		}
 
-		var req map[string]interface{}
+		var req map[string]any
 		if err := json.Unmarshal(body, &req); err != nil {
 			t.Fatalf("failed to unmarshal request: %v", err)
 		}
 
 		// Verify messages array exists (converted from input)
-		messages, ok := req["messages"].([]interface{})
+		messages, ok := req["messages"].([]any)
 		if !ok {
 			t.Fatal("messages should be an array")
 		}
@@ -507,12 +507,12 @@ func TestResponsesWithArrayInput(t *testing.T) {
 
 	req := &core.ResponsesRequest{
 		Model: "llama-3.3-70b-versatile",
-		Input: []interface{}{
-			map[string]interface{}{
+		Input: []any{
+			map[string]any{
 				"role":    "user",
 				"content": "Hello",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"role":    "assistant",
 				"content": "Hi there!",
 			},

--- a/internal/providers/init_test.go
+++ b/internal/providers/init_test.go
@@ -44,7 +44,7 @@ func TestInitResultClose_IsIdempotentAndConcurrentSafe(t *testing.T) {
 	errs := make(chan error, goroutines)
 	var wg sync.WaitGroup
 	wg.Add(goroutines)
-	for i := 0; i < goroutines; i++ {
+	for range goroutines {
 		go func() {
 			defer wg.Done()
 			errs <- result.Close()

--- a/internal/providers/ollama/ollama_test.go
+++ b/internal/providers/ollama/ollama_test.go
@@ -524,13 +524,13 @@ func TestResponsesWithArrayInput(t *testing.T) {
 			t.Fatalf("failed to read request body: %v", err)
 		}
 
-		var req map[string]interface{}
+		var req map[string]any
 		if err := json.Unmarshal(body, &req); err != nil {
 			t.Fatalf("failed to unmarshal request: %v", err)
 		}
 
 		// Verify messages array exists (converted from input)
-		messages, ok := req["messages"].([]interface{})
+		messages, ok := req["messages"].([]any)
 		if !ok {
 			t.Fatal("messages should be an array")
 		}
@@ -567,12 +567,12 @@ func TestResponsesWithArrayInput(t *testing.T) {
 
 	req := &core.ResponsesRequest{
 		Model: "llama3.2",
-		Input: []interface{}{
-			map[string]interface{}{
+		Input: []any{
+			map[string]any{
 				"role":    "user",
 				"content": "Hello",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"role":    "assistant",
 				"content": "Hi there!",
 			},
@@ -673,7 +673,6 @@ func TestResponsesWithContext(t *testing.T) {
 		t.Error("expected error when context is cancelled, got nil")
 	}
 }
-
 
 func TestOllamaResponsesStreamConverter(t *testing.T) {
 	// Test the stream converter with mock chat completion stream

--- a/internal/providers/openai/compatible_provider.go
+++ b/internal/providers/openai/compatible_provider.go
@@ -83,7 +83,7 @@ func (p *CompatibleProvider) prepareRequest(req llmclient.Request) llmclient.Req
 	return req
 }
 
-func (p *CompatibleProvider) Do(ctx context.Context, req llmclient.Request, result interface{}) error {
+func (p *CompatibleProvider) Do(ctx context.Context, req llmclient.Request, result any) error {
 	return p.client.Do(ctx, p.prepareRequest(req), result)
 }
 

--- a/internal/providers/openai/openai_test.go
+++ b/internal/providers/openai/openai_test.go
@@ -414,27 +414,27 @@ func TestChatCompletion_PreservesMultimodalContent(t *testing.T) {
 			t.Fatalf("failed to read request body: %v", err)
 		}
 
-		var req map[string]interface{}
+		var req map[string]any
 		if err := json.Unmarshal(body, &req); err != nil {
 			t.Fatalf("failed to unmarshal request: %v", err)
 		}
 
-		messages, ok := req["messages"].([]interface{})
+		messages, ok := req["messages"].([]any)
 		if !ok || len(messages) != 1 {
 			t.Fatalf("messages = %#v, want single message", req["messages"])
 		}
-		message, ok := messages[0].(map[string]interface{})
+		message, ok := messages[0].(map[string]any)
 		if !ok {
 			t.Fatalf("message type = %T", messages[0])
 		}
-		content, ok := message["content"].([]interface{})
+		content, ok := message["content"].([]any)
 		if !ok {
 			t.Fatalf("content type = %T, want []interface{}", message["content"])
 		}
 		if len(content) != 2 {
 			t.Fatalf("len(content) = %d, want 2", len(content))
 		}
-		second, ok := content[1].(map[string]interface{})
+		second, ok := content[1].(map[string]any)
 		if !ok {
 			t.Fatalf("second part type = %T", content[1])
 		}
@@ -1163,13 +1163,13 @@ func TestResponsesWithArrayInput(t *testing.T) {
 			t.Fatalf("failed to read request body: %v", err)
 		}
 
-		var req map[string]interface{}
+		var req map[string]any
 		if err := json.Unmarshal(body, &req); err != nil {
 			t.Fatalf("failed to unmarshal request: %v", err)
 		}
 
 		// Verify input is an array
-		input, ok := req["input"].([]interface{})
+		input, ok := req["input"].([]any)
 		if !ok {
 			t.Fatal("input should be an array")
 		}
@@ -1203,12 +1203,12 @@ func TestResponsesWithArrayInput(t *testing.T) {
 
 	req := &core.ResponsesRequest{
 		Model: "gpt-4o",
-		Input: []interface{}{
-			map[string]interface{}{
+		Input: []any{
+			map[string]any{
 				"role":    "user",
 				"content": "Hello",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"role":    "assistant",
 				"content": "Hi there!",
 			},
@@ -1481,7 +1481,7 @@ func TestChatCompletion_ReasoningModel_AdaptsParameters(t *testing.T) {
 			t.Fatalf("failed to read request body: %v", err)
 		}
 
-		var raw map[string]interface{}
+		var raw map[string]any
 		if err := json.Unmarshal(body, &raw); err != nil {
 			t.Fatalf("failed to unmarshal request: %v", err)
 		}
@@ -1545,7 +1545,7 @@ func TestChatCompletion_NonReasoningModel_PassesMaxTokens(t *testing.T) {
 			t.Fatalf("failed to read request body: %v", err)
 		}
 
-		var raw map[string]interface{}
+		var raw map[string]any
 		if err := json.Unmarshal(body, &raw); err != nil {
 			t.Fatalf("failed to unmarshal request: %v", err)
 		}
@@ -1607,21 +1607,21 @@ func TestChatCompletion_NonReasoningModel_PreservesToolConfiguration(t *testing.
 			t.Fatalf("failed to read request body: %v", err)
 		}
 
-		var raw map[string]interface{}
+		var raw map[string]any
 		if err := json.Unmarshal(body, &raw); err != nil {
 			t.Fatalf("failed to unmarshal request: %v", err)
 		}
 
-		tools, ok := raw["tools"].([]interface{})
+		tools, ok := raw["tools"].([]any)
 		if !ok || len(tools) != 1 {
 			t.Fatalf("tools = %#v, want one tool", raw["tools"])
 		}
 
-		toolChoice, ok := raw["tool_choice"].(map[string]interface{})
+		toolChoice, ok := raw["tool_choice"].(map[string]any)
 		if !ok {
 			t.Fatalf("tool_choice = %#v, want object", raw["tool_choice"])
 		}
-		function, ok := toolChoice["function"].(map[string]interface{})
+		function, ok := toolChoice["function"].(map[string]any)
 		if !ok || function["name"] != "lookup_weather" {
 			t.Fatalf("tool_choice.function = %#v, want lookup_weather", toolChoice["function"])
 		}
@@ -1692,7 +1692,7 @@ func TestStreamChatCompletion_ReasoningModel_AdaptsParameters(t *testing.T) {
 			t.Fatalf("failed to read request body: %v", err)
 		}
 
-		var raw map[string]interface{}
+		var raw map[string]any
 		if err := json.Unmarshal(body, &raw); err != nil {
 			t.Fatalf("failed to unmarshal request: %v", err)
 		}
@@ -1753,21 +1753,21 @@ func TestChatCompletion_ReasoningModel_PreservesToolConfiguration(t *testing.T) 
 			t.Fatalf("failed to read request body: %v", err)
 		}
 
-		var raw map[string]interface{}
+		var raw map[string]any
 		if err := json.Unmarshal(body, &raw); err != nil {
 			t.Fatalf("failed to unmarshal request: %v", err)
 		}
 
-		tools, ok := raw["tools"].([]interface{})
+		tools, ok := raw["tools"].([]any)
 		if !ok || len(tools) != 1 {
 			t.Fatalf("tools = %#v, want one tool", raw["tools"])
 		}
 
-		toolChoice, ok := raw["tool_choice"].(map[string]interface{})
+		toolChoice, ok := raw["tool_choice"].(map[string]any)
 		if !ok {
 			t.Fatalf("tool_choice = %#v, want object", raw["tool_choice"])
 		}
-		function, ok := toolChoice["function"].(map[string]interface{})
+		function, ok := toolChoice["function"].(map[string]any)
 		if !ok || function["name"] != "lookup_weather" {
 			t.Fatalf("tool_choice.function = %#v, want lookup_weather", toolChoice["function"])
 		}

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -123,12 +125,8 @@ func (r *ModelRegistry) Initialize(ctx context.Context) error {
 	r.mu.RLock()
 	providerTypes := make(map[core.Provider]string, len(r.providerTypes))
 	providerNames := make(map[core.Provider]string, len(r.providerNames))
-	for p, t := range r.providerTypes {
-		providerTypes[p] = t
-	}
-	for p, n := range r.providerNames {
-		providerNames[p] = n
-	}
+	maps.Copy(providerTypes, r.providerTypes)
+	maps.Copy(providerNames, r.providerNames)
 	r.mu.RUnlock()
 
 	for _, provider := range providers {
@@ -318,14 +316,10 @@ func (r *ModelRegistry) SaveToCache(ctx context.Context) error {
 	modelsByProvider := make(map[string]map[string]*ModelInfo, len(r.modelsByProvider))
 	for providerName, models := range r.modelsByProvider {
 		modelsByProvider[providerName] = make(map[string]*ModelInfo, len(models))
-		for modelID, info := range models {
-			modelsByProvider[providerName][modelID] = info
-		}
+		maps.Copy(modelsByProvider[providerName], models)
 	}
 	providerTypes := make(map[core.Provider]string, len(r.providerTypes))
-	for k, v := range r.providerTypes {
-		providerTypes[k] = v
-	}
+	maps.Copy(providerTypes, r.providerTypes)
 	modelListRaw := r.modelListRaw
 	r.mu.RUnlock()
 
@@ -808,12 +802,7 @@ func (r *ModelRegistry) ListModelsWithProviderByCategory(category core.ModelCate
 
 // hasCategory returns true if the category slice contains the target category.
 func hasCategory(cats []core.ModelCategory, target core.ModelCategory) bool {
-	for _, c := range cats {
-		if c == target {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(cats, target)
 }
 
 // CategoryCount holds a model category and the number of models in it.
@@ -902,9 +891,7 @@ func (r *ModelRegistry) EnrichModels() {
 	}
 
 	providerTypes := make(map[core.Provider]string, len(r.providerTypes))
-	for k, v := range r.providerTypes {
-		providerTypes[k] = v
-	}
+	maps.Copy(providerTypes, r.providerTypes)
 
 	accessor := &registryAccessor{models: r.models, providerTypes: providerTypes}
 	accessor.replacements = make(map[*ModelInfo]*ModelInfo, len(r.models))
@@ -964,9 +951,7 @@ func (r *ModelRegistry) snapshotProviderTypes() map[core.Provider]string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	m := make(map[core.Provider]string, len(r.providerTypes))
-	for k, v := range r.providerTypes {
-		m[k] = v
-	}
+	maps.Copy(m, r.providerTypes)
 	return m
 }
 

--- a/internal/providers/registry_race_test.go
+++ b/internal/providers/registry_race_test.go
@@ -61,9 +61,7 @@ func TestRegistry_Concurrency(t *testing.T) {
 	defer cancel()
 
 	// 1. Background Refresher (Writer)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for {
 			select {
 			case <-ctx.Done():
@@ -73,13 +71,11 @@ func TestRegistry_Concurrency(t *testing.T) {
 				time.Sleep(15 * time.Millisecond)
 			}
 		}
-	}()
+	})
 
 	// 2. Heavy Readers
-	for i := 0; i < 50; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 50 {
+		wg.Go(func() {
 			for {
 				select {
 				case <-ctx.Done():
@@ -91,7 +87,7 @@ func TestRegistry_Concurrency(t *testing.T) {
 					time.Sleep(1 * time.Millisecond)
 				}
 			}
-		}()
+		})
 	}
 
 	// Let it run for 1 second

--- a/internal/providers/registry_test.go
+++ b/internal/providers/registry_test.go
@@ -458,7 +458,7 @@ func TestModelRegistry(t *testing.T) {
 		registry.RegisterProvider(mock)
 		_ = registry.Initialize(context.Background())
 
-		for i := 0; i < 5; i++ {
+		for range 5 {
 			models := registry.ListModels()
 			if len(models) != 3 {
 				t.Fatalf("expected 3 models, got %d", len(models))

--- a/internal/providers/responses_adapter.go
+++ b/internal/providers/responses_adapter.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"strings"
 
 	"github.com/google/uuid"
@@ -141,27 +142,25 @@ func cloneStringAnyMap(src map[string]any) map[string]any {
 		return nil
 	}
 	dst := make(map[string]any, len(src))
-	for key, value := range src {
-		dst[key] = value
-	}
+	maps.Copy(dst, src)
 	return dst
 }
 
 // ConvertResponsesInputToMessages converts a Responses API input payload into Chat API messages.
-func ConvertResponsesInputToMessages(input interface{}) ([]core.Message, error) {
+func ConvertResponsesInputToMessages(input any) ([]core.Message, error) {
 	switch in := input.(type) {
 	case string:
 		return []core.Message{{Role: "user", Content: in}}, nil
 	case []map[string]any:
-		items := make([]interface{}, 0, len(in))
+		items := make([]any, 0, len(in))
 		for _, item := range in {
 			items = append(items, item)
 		}
 		return convertResponsesInputItems(items)
-	case []interface{}:
+	case []any:
 		return convertResponsesInputItems(in)
 	case []core.ResponsesInputElement:
-		items := make([]interface{}, 0, len(in))
+		items := make([]any, 0, len(in))
 		for _, item := range in {
 			items = append(items, item)
 		}
@@ -173,7 +172,7 @@ func ConvertResponsesInputToMessages(input interface{}) ([]core.Message, error) 
 	}
 }
 
-func convertResponsesInputItems(items []interface{}) ([]core.Message, error) {
+func convertResponsesInputItems(items []any) ([]core.Message, error) {
 	messages := make([]core.Message, 0, len(items))
 	var pendingAssistant *core.Message
 
@@ -216,11 +215,11 @@ func convertResponsesInputItems(items []interface{}) ([]core.Message, error) {
 	return messages, nil
 }
 
-func convertResponsesInputItem(item interface{}, index int) (core.Message, string, error) {
+func convertResponsesInputItem(item any, index int) (core.Message, string, error) {
 	switch typed := item.(type) {
 	case core.ResponsesInputElement:
 		return convertResponsesInputElement(typed, index)
-	case map[string]interface{}:
+	case map[string]any:
 		return convertResponsesInputMap(typed, index)
 	default:
 		return core.Message{}, "", core.NewInvalidRequestError(fmt.Sprintf("invalid responses input item at index %d: expected object", index), nil)
@@ -286,7 +285,7 @@ func convertResponsesInputElement(item core.ResponsesInputElement, index int) (c
 	}
 }
 
-func convertResponsesInputMap(item map[string]interface{}, index int) (core.Message, string, error) {
+func convertResponsesInputMap(item map[string]any, index int) (core.Message, string, error) {
 	itemType, _ := item["type"].(string)
 	switch itemType {
 	case "function_call":
@@ -405,17 +404,17 @@ func isAssistantToolCallOnlyMessage(msg core.Message) bool {
 // ConvertResponsesContentToChatContent maps Responses input content to Chat content.
 // Text-only arrays are flattened to strings for broader provider compatibility.
 // Any non-text part preserves the array form so multimodal payloads survive routing.
-func ConvertResponsesContentToChatContent(content interface{}) (any, bool) {
+func ConvertResponsesContentToChatContent(content any) (any, bool) {
 	switch c := content.(type) {
 	case string:
 		return c, true
 	case []map[string]any:
-		items := make([]interface{}, 0, len(c))
+		items := make([]any, 0, len(c))
 		for _, item := range c {
 			items = append(items, item)
 		}
 		return convertResponsesContentParts(items)
-	case []interface{}:
+	case []any:
 		return convertResponsesContentParts(c)
 	case []core.ContentPart:
 		parts := make([]core.ContentPart, 0, len(c))
@@ -438,11 +437,11 @@ func ConvertResponsesContentToChatContent(content interface{}) (any, bool) {
 	}
 }
 
-func convertResponsesContentParts(parts []interface{}) (any, bool) {
+func convertResponsesContentParts(parts []any) (any, bool) {
 	typedParts := make([]core.ContentPart, 0, len(parts))
 
 	for _, part := range parts {
-		partMap, ok := part.(map[string]interface{})
+		partMap, ok := part.(map[string]any)
 		if !ok {
 			return nil, false
 		}
@@ -578,7 +577,7 @@ func canFlattenResponsesPartsToText(parts []core.ContentPart) bool {
 	return true
 }
 
-func normalizeResponsesImageURLForChat(value interface{}) (*core.ImageURLContent, bool) {
+func normalizeResponsesImageURLForChat(value any) (*core.ImageURLContent, bool) {
 	switch v := value.(type) {
 	case string:
 		url := strings.TrimSpace(v)
@@ -597,7 +596,7 @@ func normalizeResponsesImageURLForChat(value interface{}) (*core.ImageURLContent
 			MediaType:   strings.TrimSpace(v["media_type"]),
 			ExtraFields: rawJSONMapFromUnknownStringKeys(v, "url", "detail", "media_type"),
 		}, true
-	case map[string]interface{}:
+	case map[string]any:
 		url, _ := v["url"].(string)
 		url = strings.TrimSpace(url)
 		if url == "" {
@@ -616,7 +615,7 @@ func normalizeResponsesImageURLForChat(value interface{}) (*core.ImageURLContent
 	}
 }
 
-func normalizeResponsesInputAudioForChat(value interface{}) (*core.InputAudioContent, bool) {
+func normalizeResponsesInputAudioForChat(value any) (*core.InputAudioContent, bool) {
 	switch v := value.(type) {
 	case map[string]string:
 		data := strings.TrimSpace(v["data"])
@@ -629,7 +628,7 @@ func normalizeResponsesInputAudioForChat(value interface{}) (*core.InputAudioCon
 			Format:      format,
 			ExtraFields: rawJSONMapFromUnknownStringKeys(v, "data", "format"),
 		}, true
-	case map[string]interface{}:
+	case map[string]any:
 		data, _ := v["data"].(string)
 		format, _ := v["format"].(string)
 		data = strings.TrimSpace(data)
@@ -670,7 +669,7 @@ func cloneResponsesContentPart(part core.ContentPart) core.ContentPart {
 	return cloned
 }
 
-func rawJSONMapFromUnknownKeys(src map[string]interface{}, knownKeys ...string) map[string]json.RawMessage {
+func rawJSONMapFromUnknownKeys(src map[string]any, knownKeys ...string) map[string]json.RawMessage {
 	if len(src) == 0 {
 		return nil
 	}
@@ -701,14 +700,14 @@ func rawJSONMapFromUnknownStringKeys(src map[string]string, knownKeys ...string)
 		return nil
 	}
 
-	converted := make(map[string]interface{}, len(src))
+	converted := make(map[string]any, len(src))
 	for key, value := range src {
 		converted[key] = value
 	}
 	return rawJSONMapFromUnknownKeys(converted, knownKeys...)
 }
 
-func firstNonEmptyString(item map[string]interface{}, keys ...string) string {
+func firstNonEmptyString(item map[string]any, keys ...string) string {
 	for _, key := range keys {
 		value, _ := item[key].(string)
 		if strings.TrimSpace(value) != "" {
@@ -718,7 +717,7 @@ func firstNonEmptyString(item map[string]interface{}, keys ...string) string {
 	return ""
 }
 
-func stringifyResponsesInputValue(value interface{}) string {
+func stringifyResponsesInputValue(value any) string {
 	encoded, err := stringifyResponsesInputValueWithError(value)
 	if err != nil {
 		return ""
@@ -726,7 +725,7 @@ func stringifyResponsesInputValue(value interface{}) string {
 	return encoded
 }
 
-func stringifyResponsesInputValueWithError(value interface{}) (string, error) {
+func stringifyResponsesInputValueWithError(value any) (string, error) {
 	switch v := value.(type) {
 	case nil:
 		return "", nil
@@ -742,7 +741,7 @@ func stringifyResponsesInputValueWithError(value interface{}) (string, error) {
 }
 
 // ExtractContentFromInput extracts text content from responses input.
-func ExtractContentFromInput(content interface{}) string {
+func ExtractContentFromInput(content any) string {
 	switch c := content.(type) {
 	case string:
 		return c
@@ -756,10 +755,10 @@ func ExtractContentFromInput(content interface{}) string {
 		return strings.Join(texts, " ")
 	case []map[string]any:
 		return extractTextFromMapSlice(c)
-	case []interface{}:
+	case []any:
 		texts := make([]string, 0, len(c))
 		for _, part := range c {
-			if partMap, ok := part.(map[string]interface{}); ok {
+			if partMap, ok := part.(map[string]any); ok {
 				if text := extractTextFromInputMap(partMap); text != "" {
 					texts = append(texts, text)
 				}
@@ -823,7 +822,7 @@ func buildResponsesMessageContent(content any) []core.ResponsesContentItem {
 		}
 	case []core.ContentPart:
 		return buildResponsesContentItemsFromParts(c)
-	case []interface{}:
+	case []any:
 		parts, ok := core.NormalizeContentParts(c)
 		if !ok {
 			return nil

--- a/internal/providers/responses_adapter_test.go
+++ b/internal/providers/responses_adapter_test.go
@@ -105,7 +105,7 @@ func TestConvertResponsesRequestToChat(t *testing.T) {
 				StreamOptions:     &core.StreamOptions{IncludeUsage: includeUsage},
 				Tools:             []map[string]any{{"type": "function", "function": map[string]any{"name": "lookup_weather"}}},
 				ToolChoice:        map[string]any{"type": "function", "function": map[string]any{"name": "lookup_weather"}},
-				ParallelToolCalls: boolPtr(false),
+				ParallelToolCalls: new(false),
 			},
 			checkFn: func(t *testing.T, req *core.ChatRequest) {
 				if len(req.Messages) != 2 || req.Messages[0].Role != "system" {
@@ -220,17 +220,17 @@ func TestConvertResponsesRequestToChat(t *testing.T) {
 			name: "function call loop items",
 			input: &core.ResponsesRequest{
 				Model: "test-model",
-				Input: []interface{}{
-					map[string]interface{}{
+				Input: []any{
+					map[string]any{
 						"type":      "function_call",
 						"call_id":   "call_123",
 						"name":      "lookup_weather",
 						"arguments": `{"city":"Warsaw"}`,
 					},
-					map[string]interface{}{
+					map[string]any{
 						"type":    "function_call_output",
 						"call_id": "call_123",
-						"output":  map[string]interface{}{"temperature_c": 21},
+						"output":  map[string]any{"temperature_c": 21},
 					},
 				},
 			},
@@ -279,16 +279,16 @@ func TestConvertResponsesRequestToChat(t *testing.T) {
 			name: "assistant text merges with later function call item",
 			input: &core.ResponsesRequest{
 				Model: "test-model",
-				Input: []interface{}{
-					map[string]interface{}{
+				Input: []any{
+					map[string]any{
 						"type":   "message",
 						"role":   "assistant",
 						"status": "completed",
-						"content": []map[string]interface{}{
+						"content": []map[string]any{
 							{"type": "output_text", "text": "I'll check that for you."},
 						},
 					},
-					map[string]interface{}{
+					map[string]any{
 						"type":      "function_call",
 						"call_id":   "call_123",
 						"name":      "lookup_weather",
@@ -312,17 +312,17 @@ func TestConvertResponsesRequestToChat(t *testing.T) {
 			name: "assistant structured content merges with later function call item",
 			input: &core.ResponsesRequest{
 				Model: "test-model",
-				Input: []interface{}{
-					map[string]interface{}{
+				Input: []any{
+					map[string]any{
 						"type":   "message",
 						"role":   "assistant",
 						"status": "completed",
-						"content": []map[string]interface{}{
+						"content": []map[string]any{
 							{"type": "output_text", "text": "I'll check that for you."},
-							{"type": "input_image", "image_url": map[string]interface{}{"url": "https://example.com/image.png"}},
+							{"type": "input_image", "image_url": map[string]any{"url": "https://example.com/image.png"}},
 						},
 					},
-					map[string]interface{}{
+					map[string]any{
 						"type":      "function_call",
 						"call_id":   "call_123",
 						"name":      "lookup_weather",
@@ -350,11 +350,11 @@ func TestConvertResponsesRequestToChat(t *testing.T) {
 			name: "invalid content fails",
 			input: &core.ResponsesRequest{
 				Model: "test-model",
-				Input: []interface{}{
-					map[string]interface{}{
+				Input: []any{
+					map[string]any{
 						"role": "user",
-						"content": []interface{}{
-							map[string]interface{}{"type": "unknown"},
+						"content": []any{
+							map[string]any{"type": "unknown"},
 						},
 					},
 				},
@@ -444,14 +444,14 @@ func TestConvertResponsesRequestToChat_RejectsWhitespaceOnlyMediaFields(t *testi
 		},
 		{
 			name: "map input audio",
-			input: []interface{}{
-				map[string]interface{}{
+			input: []any{
+				map[string]any{
 					"type": "message",
 					"role": "user",
-					"content": []map[string]interface{}{
+					"content": []map[string]any{
 						{
 							"type":        "input_audio",
-							"input_audio": map[string]interface{}{"data": "  ", "format": "wav"},
+							"input_audio": map[string]any{"data": "  ", "format": "wav"},
 						},
 					},
 				},
@@ -527,25 +527,25 @@ func TestConvertResponsesRequestToChat_PreservesOpaqueExtras(t *testing.T) {
 func TestConvertResponsesRequestToChat_PreservesUnknownMapFields(t *testing.T) {
 	req := &core.ResponsesRequest{
 		Model: "test-model",
-		Input: []interface{}{
-			map[string]interface{}{
+		Input: []any{
+			map[string]any{
 				"type":      "function_call",
 				"call_id":   "call_123",
 				"name":      "lookup_weather",
 				"arguments": `{"city":"Warsaw"}`,
-				"x_trace":   map[string]interface{}{"attempt": 2},
+				"x_trace":   map[string]any{"attempt": 2},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"type":    "message",
 				"role":    "user",
-				"content": []map[string]interface{}{{"type": "output_text", "text": "hello", "cache_control": map[string]interface{}{"type": "ephemeral"}}},
+				"content": []map[string]any{{"type": "output_text", "text": "hello", "cache_control": map[string]any{"type": "ephemeral"}}},
 				"x_meta":  "keep-me",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"type": "message",
 				"role": "user",
-				"content": []interface{}{
-					map[string]interface{}{
+				"content": []any{
+					map[string]any{
 						"type": "input_image",
 						"image_url": map[string]string{
 							"url":        "https://example.com/image.png",
@@ -554,7 +554,7 @@ func TestConvertResponsesRequestToChat_PreservesUnknownMapFields(t *testing.T) {
 							"x_nested":   "keep-image",
 						},
 					},
-					map[string]interface{}{
+					map[string]any{
 						"type": "input_audio",
 						"input_audio": map[string]string{
 							"data":     "aGVsbG8=",
@@ -735,8 +735,8 @@ func TestConvertChatResponseToResponses_PreservesStructuredAssistantContent(t *t
 func TestConvertResponsesRequestToChat_RejectsNonSerializableFunctionCallOutputMap(t *testing.T) {
 	_, err := ConvertResponsesRequestToChat(&core.ResponsesRequest{
 		Model: "test-model",
-		Input: []interface{}{
-			map[string]interface{}{
+		Input: []any{
+			map[string]any{
 				"type":    "function_call_output",
 				"call_id": "call_123",
 				"output":  math.Inf(1),
@@ -754,7 +754,7 @@ func TestConvertResponsesRequestToChat_RejectsNonSerializableFunctionCallOutputM
 func TestExtractContentFromInput(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    interface{}
+		input    any
 		expected string
 	}{
 		{name: "string input", input: "Hello world", expected: "Hello world"},
@@ -765,7 +765,7 @@ func TestExtractContentFromInput(t *testing.T) {
 					"type": "message",
 					"content": []map[string]any{
 						{"type": "output_text", "text": "Hello"},
-						{"type": "wrapper", "content": []interface{}{map[string]any{"type": "output_text", "text": "world"}}},
+						{"type": "wrapper", "content": []any{map[string]any{"type": "output_text", "text": "world"}}},
 					},
 				},
 			},
@@ -867,8 +867,4 @@ func TestStreamResponsesViaChat_DoesNotInjectUsageWhenPolicyDisabled(t *testing.
 	if provider.capturedReq.StreamOptions != nil {
 		t.Fatalf("captured StreamOptions = %+v, want nil", provider.capturedReq.StreamOptions)
 	}
-}
-
-func boolPtr(v bool) *bool {
-	return &v
 }

--- a/internal/providers/responses_converter.go
+++ b/internal/providers/responses_converter.go
@@ -28,7 +28,7 @@ type OpenAIResponsesStreamConverter struct {
 	closed      bool
 	sentCreate  bool
 	sentDone    bool
-	cachedUsage map[string]interface{} // Stores usage from final chunk for inclusion in response.completed
+	cachedUsage map[string]any // Stores usage from final chunk for inclusion in response.completed
 }
 
 // NewOpenAIResponsesStreamConverter creates a new converter that transforms
@@ -47,7 +47,7 @@ func NewOpenAIResponsesStreamConverter(reader io.ReadCloser, model, provider str
 	}
 }
 
-func normalizeToolCallIndex(value interface{}) (int, bool) {
+func normalizeToolCallIndex(value any) (int, bool) {
 	switch v := value.(type) {
 	case int:
 		return v, true
@@ -116,7 +116,7 @@ func (sc *OpenAIResponsesStreamConverter) completePendingToolCalls() string {
 	return out.String()
 }
 
-func (sc *OpenAIResponsesStreamConverter) handleToolCallDeltas(toolCalls []interface{}) string {
+func (sc *OpenAIResponsesStreamConverter) handleToolCallDeltas(toolCalls []any) string {
 	var out bytes.Buffer
 
 	if sc.output.AssistantStarted() && !sc.output.AssistantDone() {
@@ -124,7 +124,7 @@ func (sc *OpenAIResponsesStreamConverter) handleToolCallDeltas(toolCalls []inter
 	}
 
 	for _, item := range toolCalls {
-		toolCall, ok := item.(map[string]interface{})
+		toolCall, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -138,7 +138,7 @@ func (sc *OpenAIResponsesStreamConverter) handleToolCallDeltas(toolCalls []inter
 			state.CallID = callID
 		}
 
-		function, _ := toolCall["function"].(map[string]interface{})
+		function, _ := toolCall["function"].(map[string]any)
 		if name, _ := function["name"].(string); name != "" {
 			state.Name = name
 		}
@@ -186,9 +186,9 @@ func (sc *OpenAIResponsesStreamConverter) Read(p []byte) (n int, err error) {
 	// Send response.created event first
 	if !sc.sentCreate {
 		sc.sentCreate = true
-		createdEvent := map[string]interface{}{
+		createdEvent := map[string]any{
 			"type": "response.created",
-			"response": map[string]interface{}{
+			"response": map[string]any{
 				"id":         sc.responseID,
 				"object":     "response",
 				"status":     "in_progress",
@@ -230,15 +230,15 @@ func (sc *OpenAIResponsesStreamConverter) Read(p []byte) (n int, err error) {
 				continue
 			}
 
-			if bytes.HasPrefix(line, []byte("data: ")) {
-				data := bytes.TrimPrefix(line, []byte("data: "))
+			if after, ok := bytes.CutPrefix(line, []byte("data: ")); ok {
+				data := after
 				if bytes.Equal(data, []byte("[DONE]")) {
 					// Send done event
 					if !sc.sentDone {
 						sc.sentDone = true
 						sc.buffer = append(sc.buffer, []byte(sc.output.CompleteAssistantOutput(0))...)
 						sc.buffer = append(sc.buffer, []byte(sc.completePendingToolCalls())...)
-						responseData := map[string]interface{}{
+						responseData := map[string]any{
 							"id":         sc.responseID,
 							"object":     "response",
 							"status":     "completed",
@@ -250,7 +250,7 @@ func (sc *OpenAIResponsesStreamConverter) Read(p []byte) (n int, err error) {
 						if sc.cachedUsage != nil {
 							responseData["usage"] = sc.cachedUsage
 						}
-						doneEvent := map[string]interface{}{
+						doneEvent := map[string]any{
 							"type":     "response.completed",
 							"response": responseData,
 						}
@@ -266,25 +266,25 @@ func (sc *OpenAIResponsesStreamConverter) Read(p []byte) (n int, err error) {
 				}
 
 				// Parse the chat completion chunk
-				var chunk map[string]interface{}
+				var chunk map[string]any
 				if err := json.Unmarshal(data, &chunk); err != nil {
 					continue
 				}
 
 				// Capture usage data if present (OpenAI sends this in the final chunk)
-				if usage, ok := chunk["usage"].(map[string]interface{}); ok {
+				if usage, ok := chunk["usage"].(map[string]any); ok {
 					sc.cachedUsage = usage
 				}
 
 				// Extract content delta
-				if choices, ok := chunk["choices"].([]interface{}); ok && len(choices) > 0 {
-					if choice, ok := choices[0].(map[string]interface{}); ok {
-						if delta, ok := choice["delta"].(map[string]interface{}); ok {
+				if choices, ok := chunk["choices"].([]any); ok && len(choices) > 0 {
+					if choice, ok := choices[0].(map[string]any); ok {
+						if delta, ok := choice["delta"].(map[string]any); ok {
 							if content, ok := delta["content"].(string); ok && content != "" {
 								sc.reserveAssistantOutput()
 								sc.buffer = append(sc.buffer, []byte(sc.output.StartAssistantOutput(0))...)
 								sc.output.AppendAssistantText(content)
-								deltaEvent := map[string]interface{}{
+								deltaEvent := map[string]any{
 									"type":  "response.output_text.delta",
 									"delta": content,
 								}
@@ -293,9 +293,9 @@ func (sc *OpenAIResponsesStreamConverter) Read(p []byte) (n int, err error) {
 									slog.Error("failed to marshal content delta event", "error", err, "response_id", sc.responseID)
 									continue
 								}
-								sc.buffer = append(sc.buffer, []byte(fmt.Sprintf("event: response.output_text.delta\ndata: %s\n\n", jsonData))...)
+								sc.buffer = append(sc.buffer, fmt.Appendf(nil, "event: response.output_text.delta\ndata: %s\n\n", jsonData)...)
 							}
-							if toolCalls, ok := delta["tool_calls"].([]interface{}); ok && len(toolCalls) > 0 {
+							if toolCalls, ok := delta["tool_calls"].([]any); ok && len(toolCalls) > 0 {
 								sc.buffer = append(sc.buffer, []byte(sc.handleToolCallDeltas(toolCalls))...)
 							}
 						}
@@ -315,7 +315,7 @@ func (sc *OpenAIResponsesStreamConverter) Read(p []byte) (n int, err error) {
 				sc.sentDone = true
 				sc.buffer = append(sc.buffer, []byte(sc.output.CompleteAssistantOutput(0))...)
 				sc.buffer = append(sc.buffer, []byte(sc.completePendingToolCalls())...)
-				responseData := map[string]interface{}{
+				responseData := map[string]any{
 					"id":         sc.responseID,
 					"object":     "response",
 					"status":     "completed",
@@ -327,7 +327,7 @@ func (sc *OpenAIResponsesStreamConverter) Read(p []byte) (n int, err error) {
 				if sc.cachedUsage != nil {
 					responseData["usage"] = sc.cachedUsage
 				}
-				doneEvent := map[string]interface{}{
+				doneEvent := map[string]any{
 					"type":     "response.completed",
 					"response": responseData,
 				}

--- a/internal/providers/responses_converter_test.go
+++ b/internal/providers/responses_converter_test.go
@@ -9,7 +9,7 @@ import (
 
 type testSSEEvent struct {
 	Name    string
-	Payload map[string]interface{}
+	Payload map[string]any
 	Done    bool
 }
 
@@ -45,7 +45,7 @@ data: [DONE]
 		}
 		switch event.Name {
 		case "response.output_item.added":
-			item, _ := event.Payload["item"].(map[string]interface{})
+			item, _ := event.Payload["item"].(map[string]any)
 			if item["type"] == "function_call" && item["call_id"] == "call_123" && item["name"] == "lookup_weather" {
 				foundAdded = true
 			}
@@ -58,7 +58,7 @@ data: [DONE]
 				foundArgumentsDone = true
 			}
 		case "response.output_item.done":
-			item, _ := event.Payload["item"].(map[string]interface{})
+			item, _ := event.Payload["item"].(map[string]any)
 			if item["type"] == "function_call" && item["arguments"] == `{"city":"Warsaw"}` {
 				foundItemDone = true
 			}
@@ -109,7 +109,7 @@ data: [DONE]
 		}
 		switch event.Name {
 		case "response.output_item.added":
-			item, _ := event.Payload["item"].(map[string]interface{})
+			item, _ := event.Payload["item"].(map[string]any)
 			if item["type"] == "message" && item["role"] == "assistant" && event.Payload["output_index"] == float64(0) {
 				foundAssistantAdded = true
 			}
@@ -117,7 +117,7 @@ data: [DONE]
 				foundToolAddedAtIndexOne = true
 			}
 		case "response.output_item.done":
-			item, _ := event.Payload["item"].(map[string]interface{})
+			item, _ := event.Payload["item"].(map[string]any)
 			if item["type"] == "message" && item["role"] == "assistant" && event.Payload["output_index"] == float64(0) {
 				foundAssistantDone = true
 			}
@@ -170,7 +170,7 @@ data: [DONE]
 		}
 		switch event.Name {
 		case "response.output_item.added":
-			item, _ := event.Payload["item"].(map[string]interface{})
+			item, _ := event.Payload["item"].(map[string]any)
 			if item["type"] == "function_call" {
 				addedCount++
 				if item["call_id"] != "call_123" {
@@ -207,8 +207,8 @@ func parseTestSSEEvents(t *testing.T, raw string) []testSSEEvent {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "event:") {
-			currentEventName = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		if after, ok := strings.CutPrefix(line, "event:"); ok {
+			currentEventName = strings.TrimSpace(after)
 			continue
 		}
 		if !strings.HasPrefix(line, "data:") {
@@ -222,7 +222,7 @@ func parseTestSSEEvents(t *testing.T, raw string) []testSSEEvent {
 			continue
 		}
 
-		var payload map[string]interface{}
+		var payload map[string]any
 		if err := json.Unmarshal([]byte(data), &payload); err != nil {
 			t.Fatalf("failed to unmarshal SSE payload %q: %v", data, err)
 		}

--- a/internal/providers/router_test.go
+++ b/internal/providers/router_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"maps"
 	"net/http"
 	"strings"
 	"testing"
@@ -189,9 +190,7 @@ func (m *mockBatchProvider) GetBatchResultsWithHints(_ context.Context, batchID 
 	m.capturedBatchID = batchID
 	if len(endpointByCustomID) > 0 {
 		m.capturedBatchHints = make(map[string]string, len(endpointByCustomID))
-		for customID, endpoint := range endpointByCustomID {
-			m.capturedBatchHints[customID] = endpoint
-		}
+		maps.Copy(m.capturedBatchHints, endpointByCustomID)
 	}
 	if m.hintedBatchResults != nil {
 		return m.hintedBatchResults, nil

--- a/internal/responsecache/middleware_test.go
+++ b/internal/responsecache/middleware_test.go
@@ -135,7 +135,7 @@ func TestSimpleCacheMiddleware_SkipsStreaming(t *testing.T) {
 	})
 
 	body := []byte(`{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"hi"}]}`)
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()
@@ -171,7 +171,7 @@ func TestSimpleCacheMiddleware_SkipsPartialTranslatedPlan(t *testing.T) {
 	})
 
 	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}`)
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()
@@ -253,7 +253,7 @@ func TestSimpleCacheMiddleware_NonCacheablePath(t *testing.T) {
 	})
 
 	body := []byte(`{}`)
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		req := httptest.NewRequest(http.MethodPost, "/v1/models", bytes.NewReader(body))
 		rec := httptest.NewRecorder()
 		e.ServeHTTP(rec, req)

--- a/internal/responsecache/middleware_test.go
+++ b/internal/responsecache/middleware_test.go
@@ -323,7 +323,7 @@ func TestSimpleCacheMiddleware_BypassesCacheWhenBodyWasNotCaptured(t *testing.T)
 		return req.WithContext(core.WithRequestSnapshot(req.Context(), frame))
 	}
 
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		rec := httptest.NewRecorder()
 		e.ServeHTTP(rec, makeRequest())
 		if rec.Code != http.StatusOK {
@@ -586,10 +586,8 @@ func TestSimpleCacheMiddleware_LimitsConcurrentCacheWrites(t *testing.T) {
 	const requestCount = cacheWriteWorkerCount * 2
 
 	var reqWG sync.WaitGroup
-	for i := 0; i < requestCount; i++ {
-		reqWG.Add(1)
-		go func() {
-			defer reqWG.Done()
+	for range requestCount {
+		reqWG.Go(func() {
 			body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}`)
 			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")
@@ -598,10 +596,10 @@ func TestSimpleCacheMiddleware_LimitsConcurrentCacheWrites(t *testing.T) {
 			if rec.Code != http.StatusOK {
 				t.Errorf("expected 200, got %d", rec.Code)
 			}
-		}()
+		})
 	}
 
-	for i := 0; i < cacheWriteWorkerCount; i++ {
+	for i := range cacheWriteWorkerCount {
 		select {
 		case <-store.enterCh:
 		case <-time.After(2 * time.Second):
@@ -613,7 +611,7 @@ func TestSimpleCacheMiddleware_LimitsConcurrentCacheWrites(t *testing.T) {
 		t.Fatalf("expected at most %d concurrent cache writes, got %d", cacheWriteWorkerCount, got)
 	}
 
-	for i := 0; i < requestCount; i++ {
+	for range requestCount {
 		store.releaseCh <- struct{}{}
 	}
 	reqWG.Wait()

--- a/internal/responsecache/simple.go
+++ b/internal/responsecache/simple.go
@@ -132,9 +132,7 @@ func (m *simpleCacheMiddleware) close() error {
 
 func (m *simpleCacheMiddleware) startWorkers() {
 	for range cacheWriteWorkerCount {
-		m.workers.Add(1)
-		go func() {
-			defer m.workers.Done()
+		m.workers.Go(func() {
 			for job := range m.jobs {
 				storeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 				err := m.store.Set(storeCtx, job.key, job.data, m.ttl)
@@ -144,7 +142,7 @@ func (m *simpleCacheMiddleware) startWorkers() {
 				}
 				m.wg.Done()
 			}
-		}()
+		})
 	}
 }
 

--- a/internal/responsecache/simple.go
+++ b/internal/responsecache/simple.go
@@ -87,15 +87,13 @@ func (m *simpleCacheMiddleware) Middleware() echo.MiddlewareFunc {
 			}
 			if capture.status == http.StatusOK && capture.body.Len() > 0 {
 				data := bytes.Clone(capture.body.Bytes())
-				m.wg.Add(1)
-				go func() {
-					defer m.wg.Done()
+				m.wg.Go(func() {
 					storeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 					defer cancel()
 					if err := m.store.Set(storeCtx, key, data, m.ttl); err != nil {
 						slog.Warn("response cache write failed", "key", key, "err", err)
 					}
-				}()
+				})
 			}
 			return nil
 		}
@@ -117,8 +115,8 @@ func shouldSkipCache(req *http.Request) bool {
 	if cc == "" {
 		return false
 	}
-	directives := strings.Split(strings.ToLower(cc), ",")
-	for _, d := range directives {
+	directives := strings.SplitSeq(strings.ToLower(cc), ",")
+	for d := range directives {
 		d = strings.TrimSpace(d)
 		if d == "no-cache" || d == "no-store" {
 			return true

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -36,8 +36,8 @@ func AuthMiddleware(masterKey string, skipPaths []string) echo.MiddlewareFunc {
 			// Get Authorization header
 			authHeader := c.Request().Header.Get("Authorization")
 			if authHeader == "" {
-				return c.JSON(http.StatusUnauthorized, map[string]interface{}{
-					"error": map[string]interface{}{
+				return c.JSON(http.StatusUnauthorized, map[string]any{
+					"error": map[string]any{
 						"type":    "authentication_error",
 						"message": "missing authorization header",
 					},
@@ -47,8 +47,8 @@ func AuthMiddleware(masterKey string, skipPaths []string) echo.MiddlewareFunc {
 			// Extract Bearer token
 			const prefix = "Bearer "
 			if !strings.HasPrefix(authHeader, prefix) {
-				return c.JSON(http.StatusUnauthorized, map[string]interface{}{
-					"error": map[string]interface{}{
+				return c.JSON(http.StatusUnauthorized, map[string]any{
+					"error": map[string]any{
 						"type":    "authentication_error",
 						"message": "invalid authorization header format, expected 'Bearer <token>'",
 					},
@@ -57,8 +57,8 @@ func AuthMiddleware(masterKey string, skipPaths []string) echo.MiddlewareFunc {
 
 			token := strings.TrimPrefix(authHeader, prefix)
 			if subtle.ConstantTimeCompare([]byte(token), []byte(masterKey)) != 1 {
-				return c.JSON(http.StatusUnauthorized, map[string]interface{}{
-					"error": map[string]interface{}{
+				return c.JSON(http.StatusUnauthorized, map[string]any{
+					"error": map[string]any{
 						"type":    "authentication_error",
 						"message": "invalid master key",
 					},

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -2,10 +2,11 @@ package server
 
 import (
 	"crypto/subtle"
-	"net/http"
 	"strings"
 
 	"github.com/labstack/echo/v5"
+
+	"gomodel/internal/core"
 )
 
 // AuthMiddleware creates an Echo middleware that validates the master key
@@ -36,33 +37,21 @@ func AuthMiddleware(masterKey string, skipPaths []string) echo.MiddlewareFunc {
 			// Get Authorization header
 			authHeader := c.Request().Header.Get("Authorization")
 			if authHeader == "" {
-				return c.JSON(http.StatusUnauthorized, map[string]any{
-					"error": map[string]any{
-						"type":    "authentication_error",
-						"message": "missing authorization header",
-					},
-				})
+				authErr := core.NewAuthenticationError("", "missing authorization header")
+				return c.JSON(authErr.HTTPStatusCode(), authErr.ToJSON())
 			}
 
 			// Extract Bearer token
 			const prefix = "Bearer "
 			if !strings.HasPrefix(authHeader, prefix) {
-				return c.JSON(http.StatusUnauthorized, map[string]any{
-					"error": map[string]any{
-						"type":    "authentication_error",
-						"message": "invalid authorization header format, expected 'Bearer <token>'",
-					},
-				})
+				authErr := core.NewAuthenticationError("", "invalid authorization header format, expected 'Bearer <token>'")
+				return c.JSON(authErr.HTTPStatusCode(), authErr.ToJSON())
 			}
 
 			token := strings.TrimPrefix(authHeader, prefix)
 			if subtle.ConstantTimeCompare([]byte(token), []byte(masterKey)) != 1 {
-				return c.JSON(http.StatusUnauthorized, map[string]any{
-					"error": map[string]any{
-						"type":    "authentication_error",
-						"message": "invalid master key",
-					},
-				})
+				authErr := core.NewAuthenticationError("", "invalid master key")
+				return c.JSON(authErr.HTTPStatusCode(), authErr.ToJSON())
 			}
 
 			// Authentication successful, proceed to next handler

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -39,21 +39,21 @@ func TestAuthMiddleware(t *testing.T) {
 			masterKey:      "secret-key-123",
 			authHeader:     "",
 			expectedStatus: http.StatusUnauthorized,
-			expectedBody:   `{"error":{"message":"missing authorization header","type":"authentication_error"}}`,
+			expectedBody:   `{"error":{"message":"missing authorization header","type":"authentication_error","param":null,"code":null}}`,
 		},
 		{
 			name:           "invalid authorization format - denies request",
 			masterKey:      "secret-key-123",
 			authHeader:     "secret-key-123",
 			expectedStatus: http.StatusUnauthorized,
-			expectedBody:   `{"error":{"message":"invalid authorization header format, expected 'Bearer \u003ctoken\u003e'","type":"authentication_error"}}`,
+			expectedBody:   `{"error":{"message":"invalid authorization header format, expected 'Bearer \u003ctoken\u003e'","type":"authentication_error","param":null,"code":null}}`,
 		},
 		{
 			name:           "invalid master key - denies request",
 			masterKey:      "secret-key-123",
 			authHeader:     "Bearer wrong-key",
 			expectedStatus: http.StatusUnauthorized,
-			expectedBody:   `{"error":{"message":"invalid master key","type":"authentication_error"}}`,
+			expectedBody:   `{"error":{"message":"invalid master key","type":"authentication_error","param":null,"code":null}}`,
 		},
 		{
 			name:           "bearer prefix case sensitive - allows request",
@@ -67,7 +67,7 @@ func TestAuthMiddleware(t *testing.T) {
 			masterKey:      "secret-key-123",
 			authHeader:     "Bearer ",
 			expectedStatus: http.StatusUnauthorized,
-			expectedBody:   `{"error":{"message":"invalid master key","type":"authentication_error"}}`,
+			expectedBody:   `{"error":{"message":"invalid master key","type":"authentication_error","param":null,"code":null}}`,
 		},
 	}
 

--- a/internal/server/error_support.go
+++ b/internal/server/error_support.go
@@ -12,13 +12,12 @@ import (
 
 // handleError converts gateway errors to appropriate HTTP responses.
 func handleError(c *echo.Context, err error) error {
-	var gatewayErr *core.GatewayError
-	if errors.As(err, &gatewayErr) {
+	if gatewayErr, ok := errors.AsType[*core.GatewayError](err); ok {
 		auditlog.EnrichEntryWithError(c, string(gatewayErr.Type), gatewayErr.Message)
 		return c.JSON(gatewayErr.HTTPStatusCode(), gatewayErr.ToJSON())
 	}
 
-	gatewayErr = core.NewProviderError("", http.StatusInternalServerError, "an unexpected error occurred", err)
+	gatewayErr := core.NewProviderError("", http.StatusInternalServerError, "an unexpected error occurred", err)
 	auditlog.EnrichEntryWithError(c, string(gatewayErr.Type), gatewayErr.Message)
 	return c.JSON(gatewayErr.HTTPStatusCode(), gatewayErr.ToJSON())
 }

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -6,10 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"maps"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -374,12 +376,7 @@ func (m *mockProvider) Supports(model string) bool {
 	if err == nil {
 		model = selector.Model
 	}
-	for _, supported := range m.supportedModels {
-		if model == supported {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(m.supportedModels, model)
 }
 
 func (m *mockProvider) GetProviderType(model string) string {
@@ -560,9 +557,7 @@ func (m *mockProvider) CreateBatchWithHints(ctx context.Context, providerType st
 		return resp, nil, nil
 	}
 	hints := make(map[string]string, len(m.batchCreateHints))
-	for customID, endpoint := range m.batchCreateHints {
-		hints[customID] = endpoint
-	}
+	maps.Copy(hints, m.batchCreateHints)
 	return resp, hints, nil
 }
 
@@ -624,9 +619,7 @@ func (m *mockProvider) GetBatchResultsWithHints(ctx context.Context, providerTyp
 	m.capturedBatchHintsBatchID = batchID
 	if len(endpointByCustomID) > 0 {
 		m.capturedBatchHints = make(map[string]string, len(endpointByCustomID))
-		for customID, endpoint := range endpointByCustomID {
-			m.capturedBatchHints[customID] = endpoint
-		}
+		maps.Copy(m.capturedBatchHints, endpointByCustomID)
 	}
 	if m.batchResultsHinted != nil {
 		return m.batchResultsHinted, nil

--- a/internal/server/native_batch_support.go
+++ b/internal/server/native_batch_support.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"math"
 	"net/http"
 	"strconv"
@@ -87,19 +88,13 @@ func mergeBatchRequestEndpointHints(left, right map[string]string) map[string]st
 			return nil
 		}
 		merged := make(map[string]string, len(right))
-		for key, value := range right {
-			merged[key] = value
-		}
+		maps.Copy(merged, right)
 		return merged
 	}
 
 	merged := make(map[string]string, len(left))
-	for key, value := range left {
-		merged[key] = value
-	}
-	for key, value := range right {
-		merged[key] = value
-	}
+	maps.Copy(merged, left)
+	maps.Copy(merged, right)
 	return merged
 }
 
@@ -503,9 +498,7 @@ func mergeStoredBatchFromUpstream(stored *batchstore.StoredBatch, upstream *core
 			}
 			stored.Batch.Metadata[key] = value
 		}
-		for key, value := range preservedGatewayMetadata {
-			stored.Batch.Metadata[key] = value
-		}
+		maps.Copy(stored.Batch.Metadata, preservedGatewayMetadata)
 		stored.Batch.Metadata = sanitizePublicBatchMetadata(stored.Batch.Metadata)
 	}
 }
@@ -564,8 +557,8 @@ func isNativeBatchResultsPending(
 	providerType, providerBatchID string,
 	err error,
 ) (bool, *core.BatchResponse) {
-	var gatewayErr *core.GatewayError
-	if !errors.As(err, &gatewayErr) {
+	gatewayErr, ok := errors.AsType[*core.GatewayError](err)
+	if !ok {
 		return false, nil
 	}
 	if gatewayErr.HTTPStatusCode() != http.StatusNotFound {

--- a/internal/server/native_file_service.go
+++ b/internal/server/native_file_service.go
@@ -243,13 +243,13 @@ func (s *nativeFileService) GetFileContent(c *echo.Context) error {
 }
 
 func isNotFoundGatewayError(err error) bool {
-	var gatewayErr *core.GatewayError
-	return errors.As(err, &gatewayErr) && gatewayErr.HTTPStatusCode() == http.StatusNotFound
+	gatewayErr, ok := errors.AsType[*core.GatewayError](err)
+	return ok && gatewayErr.HTTPStatusCode() == http.StatusNotFound
 }
 
 func isUnsupportedNativeFilesError(err error) bool {
-	var gatewayErr *core.GatewayError
-	if !errors.As(err, &gatewayErr) {
+	gatewayErr, ok := errors.AsType[*core.GatewayError](err)
+	if !ok {
 		return false
 	}
 	if gatewayErr.HTTPStatusCode() != http.StatusBadRequest {

--- a/internal/server/passthrough_support.go
+++ b/internal/server/passthrough_support.go
@@ -132,7 +132,7 @@ func passthroughConnectionHeaders(headers http.Header) map[string]struct{} {
 			continue
 		}
 		for _, value := range values {
-			for _, token := range strings.Split(value, ",") {
+			for token := range strings.SplitSeq(value, ",") {
 				canonicalKey := http.CanonicalHeaderKey(strings.TrimSpace(token))
 				if canonicalKey == "" {
 					continue

--- a/internal/storage/mongodb.go
+++ b/internal/storage/mongodb.go
@@ -59,11 +59,11 @@ func (s *mongoStorage) SQLiteDB() *sql.DB {
 	return nil
 }
 
-func (s *mongoStorage) PostgreSQLPool() interface{} {
+func (s *mongoStorage) PostgreSQLPool() any {
 	return nil
 }
 
-func (s *mongoStorage) MongoDatabase() interface{} {
+func (s *mongoStorage) MongoDatabase() any {
 	return s.database
 }
 

--- a/internal/storage/postgresql.go
+++ b/internal/storage/postgresql.go
@@ -29,10 +29,7 @@ func NewPostgreSQL(ctx context.Context, cfg PostgreSQLConfig) (Storage, error) {
 
 	// Set connection pool size
 	if cfg.MaxConns > 0 {
-		maxConns := cfg.MaxConns
-		if maxConns > math.MaxInt32 {
-			maxConns = math.MaxInt32
-		}
+		maxConns := min(cfg.MaxConns, math.MaxInt32)
 		poolCfg.MaxConns = int32(maxConns)
 	} else {
 		poolCfg.MaxConns = 10 // default
@@ -61,11 +58,11 @@ func (s *postgresStorage) SQLiteDB() *sql.DB {
 	return nil
 }
 
-func (s *postgresStorage) PostgreSQLPool() interface{} {
+func (s *postgresStorage) PostgreSQLPool() any {
 	return s.pool
 }
 
-func (s *postgresStorage) MongoDatabase() interface{} {
+func (s *postgresStorage) MongoDatabase() any {
 	return nil
 }
 

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -65,11 +65,11 @@ func (s *sqliteStorage) SQLiteDB() *sql.DB {
 	return s.db
 }
 
-func (s *sqliteStorage) PostgreSQLPool() interface{} {
+func (s *sqliteStorage) PostgreSQLPool() any {
 	return nil
 }
 
-func (s *sqliteStorage) MongoDatabase() interface{} {
+func (s *sqliteStorage) MongoDatabase() any {
 	return nil
 }
 

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -35,7 +35,7 @@ func TestSQLiteConcurrentWriteSafety(t *testing.T) {
 	errs := make(chan error, goroutines*insertsPerGoroutine*2)
 
 	// Half the goroutines write to test_audit, half to test_usage — mirrors real workload.
-	for i := 0; i < goroutines; i++ {
+	for i := range goroutines {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
@@ -43,7 +43,7 @@ func TestSQLiteConcurrentWriteSafety(t *testing.T) {
 			if id%2 == 1 {
 				table = "test_usage"
 			}
-			for j := 0; j < insertsPerGoroutine; j++ {
+			for j := range insertsPerGoroutine {
 				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 				_, err := db.ExecContext(ctx, fmt.Sprintf(`INSERT INTO %s (id, data) VALUES (?, ?)`, table),
 					fmt.Sprintf("%d-%d", id, j), "payload")

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -69,12 +69,12 @@ type Storage interface {
 	// PostgreSQLPool returns the connection pool for PostgreSQL.
 	// Returns nil if not using PostgreSQL.
 	// The actual type is *pgxpool.Pool but we use interface{} to avoid import cycles.
-	PostgreSQLPool() interface{}
+	PostgreSQLPool() any
 
 	// MongoDatabase returns the MongoDB database.
 	// Returns nil if not using MongoDB.
 	// The actual type is *mongo.Database but we use interface{} to avoid import cycles.
-	MongoDatabase() interface{}
+	MongoDatabase() any
 
 	// Close releases all resources held by the storage.
 	Close() error

--- a/internal/streaming/observed_sse_stream.go
+++ b/internal/streaming/observed_sse_stream.go
@@ -19,7 +19,7 @@ var (
 // Observer receives parsed JSON SSE payloads in stream order.
 // Implementations must treat the payload as read-only.
 type Observer interface {
-	OnJSONEvent(payload map[string]interface{})
+	OnJSONEvent(payload map[string]any)
 	OnStreamClose()
 }
 
@@ -182,7 +182,7 @@ func (s *ObservedSSEStream) processEvent(event []byte) {
 		return
 	}
 
-	var payload map[string]interface{}
+	var payload map[string]any
 	if err := json.Unmarshal(jsonData, &payload); err != nil {
 		return
 	}
@@ -258,10 +258,7 @@ func nextJoinedEventBoundary(prefix, data []byte) (idx int, sepLen int) {
 
 func nextBoundaryAcrossJoin(prefix, data []byte) (idx int, sepLen int) {
 	idx = -1
-	start := len(prefix) - maxBoundaryTailBytes
-	if start < 0 {
-		start = 0
-	}
+	start := max(len(prefix)-maxBoundaryTailBytes, 0)
 
 	for offset := start; offset < len(prefix); offset++ {
 		for _, boundary := range [][]byte{lfEventBoundary, crlfEventBoundary} {
@@ -319,10 +316,7 @@ func joinedSuffix(prefix, data []byte, n int) []byte {
 		return append([]byte(nil), data[len(data)-n:]...)
 	}
 
-	needPrefix := n - len(data)
-	if needPrefix > len(prefix) {
-		needPrefix = len(prefix)
-	}
+	needPrefix := min(n-len(data), len(prefix))
 
 	result := make([]byte, needPrefix+len(data))
 	copy(result, prefix[len(prefix)-needPrefix:])

--- a/internal/streaming/observed_sse_stream_test.go
+++ b/internal/streaming/observed_sse_stream_test.go
@@ -10,11 +10,11 @@ import (
 type trackingObserver struct {
 	eventCount  int
 	lastID      string
-	lastPayload map[string]interface{}
+	lastPayload map[string]any
 	closed      bool
 }
 
-func (o *trackingObserver) OnJSONEvent(payload map[string]interface{}) {
+func (o *trackingObserver) OnJSONEvent(payload map[string]any) {
 	o.eventCount++
 	o.lastPayload = payload
 	if id, _ := payload["id"].(string); id != "" {
@@ -112,7 +112,7 @@ func TestObservedSSEStream_ReassemblesMultilineDataEvent(t *testing.T) {
 	if observer.lastID != "chatcmpl-multiline" {
 		t.Fatalf("lastID = %q, want chatcmpl-multiline", observer.lastID)
 	}
-	usage, ok := observer.lastPayload["usage"].(map[string]interface{})
+	usage, ok := observer.lastPayload["usage"].(map[string]any)
 	if !ok {
 		t.Fatalf("usage = %#v, want object", observer.lastPayload["usage"])
 	}

--- a/internal/usage/cost_test.go
+++ b/internal/usage/cost_test.go
@@ -7,8 +7,6 @@ import (
 	"gomodel/internal/core"
 )
 
-func ptr(f float64) *float64 { return &f }
-
 func TestCalculateGranularCost_NilPricing(t *testing.T) {
 	result := CalculateGranularCost(100, 50, nil, "openai", nil)
 	if result.InputCost != nil || result.OutputCost != nil || result.TotalCost != nil {
@@ -21,8 +19,8 @@ func TestCalculateGranularCost_NilPricing(t *testing.T) {
 
 func TestCalculateGranularCost_BaseOnly(t *testing.T) {
 	pricing := &core.ModelPricing{
-		InputPerMtok:  ptr(3.0),
-		OutputPerMtok: ptr(15.0),
+		InputPerMtok:  new(3.0),
+		OutputPerMtok: new(15.0),
 	}
 	result := CalculateGranularCost(1_000_000, 500_000, nil, "openai", pricing)
 
@@ -36,10 +34,10 @@ func TestCalculateGranularCost_BaseOnly(t *testing.T) {
 
 func TestCalculateGranularCost_OpenAI_CachedAndReasoning(t *testing.T) {
 	pricing := &core.ModelPricing{
-		InputPerMtok:           ptr(2.50),
-		OutputPerMtok:          ptr(10.0),
-		CachedInputPerMtok:     ptr(1.25),
-		ReasoningOutputPerMtok: ptr(15.0),
+		InputPerMtok:           new(2.50),
+		OutputPerMtok:          new(10.0),
+		CachedInputPerMtok:     new(1.25),
+		ReasoningOutputPerMtok: new(15.0),
 	}
 	rawData := map[string]any{
 		"cached_tokens":    200_000,
@@ -59,10 +57,10 @@ func TestCalculateGranularCost_OpenAI_CachedAndReasoning(t *testing.T) {
 
 func TestCalculateGranularCost_OpenAI_AudioTokens(t *testing.T) {
 	pricing := &core.ModelPricing{
-		InputPerMtok:       ptr(2.50),
-		OutputPerMtok:      ptr(10.0),
-		AudioInputPerMtok:  ptr(100.0),
-		AudioOutputPerMtok: ptr(200.0),
+		InputPerMtok:       new(2.50),
+		OutputPerMtok:      new(10.0),
+		AudioInputPerMtok:  new(100.0),
+		AudioOutputPerMtok: new(200.0),
 	}
 	rawData := map[string]any{
 		"prompt_audio_tokens":     50_000,
@@ -78,10 +76,10 @@ func TestCalculateGranularCost_OpenAI_AudioTokens(t *testing.T) {
 
 func TestCalculateGranularCost_Anthropic_CacheTokens(t *testing.T) {
 	pricing := &core.ModelPricing{
-		InputPerMtok:       ptr(3.0),
-		OutputPerMtok:      ptr(15.0),
-		CachedInputPerMtok: ptr(0.30),
-		CacheWritePerMtok:  ptr(3.75),
+		InputPerMtok:       new(3.0),
+		OutputPerMtok:      new(15.0),
+		CachedInputPerMtok: new(0.30),
+		CacheWritePerMtok:  new(3.75),
 	}
 	rawData := map[string]any{
 		"cache_read_input_tokens":     int64(100_000),
@@ -97,10 +95,10 @@ func TestCalculateGranularCost_Anthropic_CacheTokens(t *testing.T) {
 
 func TestCalculateGranularCost_Gemini_ThoughtTokens(t *testing.T) {
 	pricing := &core.ModelPricing{
-		InputPerMtok:           ptr(1.25),
-		OutputPerMtok:          ptr(5.0),
-		CachedInputPerMtok:     ptr(0.3125),
-		ReasoningOutputPerMtok: ptr(10.0),
+		InputPerMtok:           new(1.25),
+		OutputPerMtok:          new(5.0),
+		CachedInputPerMtok:     new(0.3125),
+		ReasoningOutputPerMtok: new(10.0),
 	}
 	rawData := map[string]any{
 		"cached_tokens":  50_000,
@@ -116,9 +114,9 @@ func TestCalculateGranularCost_Gemini_ThoughtTokens(t *testing.T) {
 
 func TestCalculateGranularCost_XAI_ImageTokens(t *testing.T) {
 	pricing := &core.ModelPricing{
-		InputPerMtok:  ptr(2.0),
-		OutputPerMtok: ptr(10.0),
-		InputPerImage: ptr(0.05), // $0.05 per image
+		InputPerMtok:  new(2.0),
+		OutputPerMtok: new(10.0),
+		InputPerImage: new(0.05), // $0.05 per image
 	}
 	rawData := map[string]any{
 		"image_tokens": 3,
@@ -131,8 +129,8 @@ func TestCalculateGranularCost_XAI_ImageTokens(t *testing.T) {
 
 func TestCalculateGranularCost_NilPricingFieldNoCaveat(t *testing.T) {
 	pricing := &core.ModelPricing{
-		InputPerMtok:  ptr(2.50),
-		OutputPerMtok: ptr(10.0),
+		InputPerMtok:  new(2.50),
+		OutputPerMtok: new(10.0),
 		// CachedInputPerMtok is nil — base rate already covers cached tokens
 	}
 	rawData := map[string]any{
@@ -150,8 +148,8 @@ func TestCalculateGranularCost_NilPricingFieldNoCaveat(t *testing.T) {
 
 func TestCalculateGranularCost_UnmappedTokenField(t *testing.T) {
 	pricing := &core.ModelPricing{
-		InputPerMtok:  ptr(2.50),
-		OutputPerMtok: ptr(10.0),
+		InputPerMtok:  new(2.50),
+		OutputPerMtok: new(10.0),
 	}
 	rawData := map[string]any{
 		"some_new_tokens": 100,
@@ -168,9 +166,9 @@ func TestCalculateGranularCost_UnmappedTokenField(t *testing.T) {
 
 func TestCalculateGranularCost_PerRequestFee(t *testing.T) {
 	pricing := &core.ModelPricing{
-		InputPerMtok:  ptr(0.0),
-		OutputPerMtok: ptr(0.0),
-		PerRequest:    ptr(0.01),
+		InputPerMtok:  new(0.0),
+		OutputPerMtok: new(0.0),
+		PerRequest:    new(0.01),
 	}
 	result := CalculateGranularCost(100, 50, nil, "openai", pricing)
 
@@ -180,8 +178,8 @@ func TestCalculateGranularCost_PerRequestFee(t *testing.T) {
 
 func TestCalculateGranularCost_UnknownProvider(t *testing.T) {
 	pricing := &core.ModelPricing{
-		InputPerMtok:  ptr(1.0),
-		OutputPerMtok: ptr(2.0),
+		InputPerMtok:  new(1.0),
+		OutputPerMtok: new(2.0),
 	}
 	rawData := map[string]any{
 		"custom_tokens": 100,
@@ -199,8 +197,8 @@ func TestCalculateGranularCost_UnknownProvider(t *testing.T) {
 
 func TestCalculateGranularCost_ZeroTokenRawData(t *testing.T) {
 	pricing := &core.ModelPricing{
-		InputPerMtok:  ptr(2.50),
-		OutputPerMtok: ptr(10.0),
+		InputPerMtok:  new(2.50),
+		OutputPerMtok: new(10.0),
 	}
 	rawData := map[string]any{
 		"cached_tokens": 0,
@@ -214,8 +212,8 @@ func TestCalculateGranularCost_ZeroTokenRawData(t *testing.T) {
 
 func TestCalculateGranularCost_NonTokenField(t *testing.T) {
 	pricing := &core.ModelPricing{
-		InputPerMtok:  ptr(2.50),
-		OutputPerMtok: ptr(10.0),
+		InputPerMtok:  new(2.50),
+		OutputPerMtok: new(10.0),
 	}
 	rawData := map[string]any{
 		"some_flag": true,
@@ -273,10 +271,10 @@ func TestIsTokenField(t *testing.T) {
 
 func TestCalculateGranularCost_XAI_PrefixedKeys(t *testing.T) {
 	pricing := &core.ModelPricing{
-		InputPerMtok:           ptr(2.0),
-		OutputPerMtok:          ptr(10.0),
-		CachedInputPerMtok:     ptr(0.50),
-		ReasoningOutputPerMtok: ptr(15.0),
+		InputPerMtok:           new(2.0),
+		OutputPerMtok:          new(10.0),
+		CachedInputPerMtok:     new(0.50),
+		ReasoningOutputPerMtok: new(15.0),
 	}
 	rawData := map[string]any{
 		"prompt_cached_tokens":        200_000,
@@ -296,10 +294,10 @@ func TestCalculateGranularCost_XAI_PrefixedKeys(t *testing.T) {
 
 func TestCalculateGranularCost_XAI_ReasoningTokensAreAdditionalOutput(t *testing.T) {
 	pricing := &core.ModelPricing{
-		InputPerMtok:           ptr(0.3),
-		OutputPerMtok:          ptr(0.5),
-		CachedInputPerMtok:     ptr(0.075),
-		ReasoningOutputPerMtok: ptr(1.5),
+		InputPerMtok:           new(0.3),
+		OutputPerMtok:          new(0.5),
+		CachedInputPerMtok:     new(0.075),
+		ReasoningOutputPerMtok: new(1.5),
 	}
 	rawData := map[string]any{
 		"prompt_cached_tokens":        4,
@@ -317,8 +315,8 @@ func TestCalculateGranularCost_XAI_ReasoningTokensAreAdditionalOutput(t *testing
 
 func TestCalculateGranularCost_InformationalFieldsNoCaveat(t *testing.T) {
 	pricing := &core.ModelPricing{
-		InputPerMtok:  ptr(2.50),
-		OutputPerMtok: ptr(10.0),
+		InputPerMtok:  new(2.50),
+		OutputPerMtok: new(10.0),
 	}
 	rawData := map[string]any{
 		"prompt_text_tokens":                    80_000,
@@ -338,8 +336,8 @@ func TestCalculateGranularCost_InformationalFieldsNoCaveat(t *testing.T) {
 func TestCalculateGranularCost_ReasoningModelNoCaveat(t *testing.T) {
 	// Simulates the exact RawData produced by buildRawUsageFromDetails for o3-mini / grok-3-mini
 	pricing := &core.ModelPricing{
-		InputPerMtok:  ptr(1.10),
-		OutputPerMtok: ptr(4.40),
+		InputPerMtok:  new(1.10),
+		OutputPerMtok: new(4.40),
 		// No CachedInputPerMtok or ReasoningOutputPerMtok — base rate covers all
 	}
 	rawData := map[string]any{
@@ -360,7 +358,7 @@ func TestCalculateGranularCost_ReasoningModelNoCaveat(t *testing.T) {
 
 func TestCalculateGranularCost_InputOnlyPricing(t *testing.T) {
 	pricing := &core.ModelPricing{
-		InputPerMtok: ptr(3.0),
+		InputPerMtok: new(3.0),
 		// OutputPerMtok is nil — no output pricing
 	}
 	result := CalculateGranularCost(1_000_000, 500_000, nil, "openai", pricing)
@@ -376,7 +374,7 @@ func TestCalculateGranularCost_InputOnlyPricing(t *testing.T) {
 func TestCalculateGranularCost_OutputOnlyPricing(t *testing.T) {
 	pricing := &core.ModelPricing{
 		// InputPerMtok is nil — no input pricing
-		OutputPerMtok: ptr(15.0),
+		OutputPerMtok: new(15.0),
 	}
 	result := CalculateGranularCost(1_000_000, 500_000, nil, "openai", pricing)
 

--- a/internal/usage/extractor.go
+++ b/internal/usage/extractor.go
@@ -1,6 +1,7 @@
 package usage
 
 import (
+	"maps"
 	"strings"
 	"time"
 
@@ -102,9 +103,7 @@ func cloneRawData(src map[string]any) map[string]any {
 		return nil
 	}
 	dst := make(map[string]any, len(src))
-	for k, v := range src {
-		dst[k] = v
-	}
+	maps.Copy(dst, src)
 	return dst
 }
 

--- a/internal/usage/extractor_test.go
+++ b/internal/usage/extractor_test.go
@@ -341,12 +341,10 @@ func TestExtractFromResponsesResponse_WithDetails(t *testing.T) {
 	}
 }
 
-func f64Ptr(v float64) *float64 { return &v }
-
 func TestExtractFromChatResponse_WithPricing(t *testing.T) {
 	pricing := &core.ModelPricing{
-		InputPerMtok:  f64Ptr(3.0),  // $3 per million input tokens
-		OutputPerMtok: f64Ptr(15.0), // $15 per million output tokens
+		InputPerMtok:  new(3.0),  // $3 per million input tokens
+		OutputPerMtok: new(15.0), // $15 per million output tokens
 	}
 
 	resp := &core.ChatResponse{
@@ -391,8 +389,8 @@ func TestExtractFromChatResponse_WithPricing(t *testing.T) {
 
 func TestExtractFromResponsesResponse_WithPricing(t *testing.T) {
 	pricing := &core.ModelPricing{
-		InputPerMtok:  f64Ptr(2.5),
-		OutputPerMtok: f64Ptr(10.0),
+		InputPerMtok:  new(2.5),
+		OutputPerMtok: new(10.0),
 	}
 
 	resp := &core.ResponsesResponse{
@@ -484,10 +482,10 @@ func TestExtractFromSSEUsageEmptyRawData(t *testing.T) {
 
 func TestExtractFromChatResponse_WithBatchPricingEndpoint(t *testing.T) {
 	pricing := &core.ModelPricing{
-		InputPerMtok:       f64Ptr(4.0),
-		OutputPerMtok:      f64Ptr(8.0),
-		BatchInputPerMtok:  f64Ptr(1.0),
-		BatchOutputPerMtok: f64Ptr(2.0),
+		InputPerMtok:       new(4.0),
+		OutputPerMtok:      new(8.0),
+		BatchInputPerMtok:  new(1.0),
+		BatchOutputPerMtok: new(2.0),
 	}
 
 	resp := &core.ChatResponse{
@@ -521,10 +519,10 @@ func TestExtractFromChatResponse_WithBatchPricingEndpoint(t *testing.T) {
 
 func TestExtractFromChatResponse_WithBatchPricingSubpathEndpoint(t *testing.T) {
 	pricing := &core.ModelPricing{
-		InputPerMtok:       f64Ptr(4.0),
-		OutputPerMtok:      f64Ptr(8.0),
-		BatchInputPerMtok:  f64Ptr(1.0),
-		BatchOutputPerMtok: f64Ptr(2.0),
+		InputPerMtok:       new(4.0),
+		OutputPerMtok:      new(8.0),
+		BatchInputPerMtok:  new(1.0),
+		BatchOutputPerMtok: new(2.0),
 	}
 
 	resp := &core.ChatResponse{
@@ -558,8 +556,8 @@ func TestExtractFromChatResponse_WithBatchPricingSubpathEndpoint(t *testing.T) {
 
 func TestExtractFromEmbeddingResponse_WithBatchPricingEndpoint(t *testing.T) {
 	pricing := &core.ModelPricing{
-		InputPerMtok:      f64Ptr(3.0),
-		BatchInputPerMtok: f64Ptr(1.5),
+		InputPerMtok:      new(3.0),
+		BatchInputPerMtok: new(1.5),
 	}
 
 	resp := &core.EmbeddingResponse{
@@ -585,10 +583,10 @@ func TestExtractFromEmbeddingResponse_WithBatchPricingEndpoint(t *testing.T) {
 
 func TestExtractFromChatResponse_BatchPrefixOvermatchUsesStandardPricing(t *testing.T) {
 	pricing := &core.ModelPricing{
-		InputPerMtok:       f64Ptr(4.0),
-		OutputPerMtok:      f64Ptr(8.0),
-		BatchInputPerMtok:  f64Ptr(1.0),
-		BatchOutputPerMtok: f64Ptr(2.0),
+		InputPerMtok:       new(4.0),
+		OutputPerMtok:      new(8.0),
+		BatchInputPerMtok:  new(1.0),
+		BatchOutputPerMtok: new(2.0),
 	}
 
 	resp := &core.ChatResponse{

--- a/internal/usage/reader_postgresql.go
+++ b/internal/usage/reader_postgresql.go
@@ -110,7 +110,7 @@ func (r *PostgreSQLReader) GetUsageLog(ctx context.Context, params UsageLogParam
 	dataQuery := fmt.Sprintf(`SELECT id, request_id, provider_id, timestamp, model, provider, endpoint,
 		input_tokens, output_tokens, total_tokens, COALESCE(input_cost, 0), COALESCE(output_cost, 0), COALESCE(total_cost, 0), raw_data, COALESCE(costs_calculation_caveat, '')
 		FROM "usage"%s ORDER BY timestamp DESC LIMIT $%d OFFSET $%d`, where, argIdx, argIdx+1)
-	dataArgs := append(append([]interface{}(nil), args...), limit, offset)
+	dataArgs := append(append([]any(nil), args...), limit, offset)
 
 	rows, err := r.pool.Query(ctx, dataQuery, dataArgs...)
 	if err != nil {
@@ -148,7 +148,7 @@ func (r *PostgreSQLReader) GetUsageLog(ctx context.Context, params UsageLogParam
 
 // pgDateRangeConditions returns WHERE conditions and args for a date range.
 // argIdx is the starting $N placeholder index; nextIdx is the next available index.
-func pgDateRangeConditions(params UsageQueryParams, argIdx int) (conditions []string, args []interface{}, nextIdx int) {
+func pgDateRangeConditions(params UsageQueryParams, argIdx int) (conditions []string, args []any, nextIdx int) {
 	nextIdx = argIdx
 	if !params.StartDate.IsZero() {
 		conditions = append(conditions, fmt.Sprintf("timestamp >= $%d", nextIdx))

--- a/internal/usage/reader_sqlite.go
+++ b/internal/usage/reader_sqlite.go
@@ -107,7 +107,7 @@ func (r *SQLiteReader) GetUsageLog(ctx context.Context, params UsageLogParams) (
 	dataQuery := `SELECT id, request_id, provider_id, timestamp, model, provider, endpoint,
 		input_tokens, output_tokens, total_tokens, COALESCE(input_cost, 0), COALESCE(output_cost, 0), COALESCE(total_cost, 0), raw_data, COALESCE(costs_calculation_caveat, '')
 		FROM usage` + where + ` ORDER BY timestamp DESC LIMIT ? OFFSET ?`
-	dataArgs := append(append([]interface{}(nil), args...), limit, offset)
+	dataArgs := append(append([]any(nil), args...), limit, offset)
 
 	rows, err := r.db.QueryContext(ctx, dataQuery, dataArgs...)
 	if err != nil {
@@ -159,7 +159,7 @@ func (r *SQLiteReader) GetUsageLog(ctx context.Context, params UsageLogParams) (
 
 // sqliteDateRangeConditions returns WHERE conditions and args for a date range.
 // Dates are formatted as "2006-01-02" strings for SQLite text comparison.
-func sqliteDateRangeConditions(params UsageQueryParams) (conditions []string, args []interface{}) {
+func sqliteDateRangeConditions(params UsageQueryParams) (conditions []string, args []any) {
 	if !params.StartDate.IsZero() {
 		conditions = append(conditions, "timestamp >= ?")
 		args = append(args, params.StartDate.UTC().Format("2006-01-02"))

--- a/internal/usage/store_mongodb.go
+++ b/internal/usage/store_mongodb.go
@@ -115,7 +115,7 @@ func (s *MongoDBStore) WriteBatch(ctx context.Context, entries []*UsageEntry) er
 	}
 
 	// Convert entries to BSON documents
-	docs := make([]interface{}, len(entries))
+	docs := make([]any, len(entries))
 	for i, e := range entries {
 		docs[i] = e
 	}
@@ -125,8 +125,7 @@ func (s *MongoDBStore) WriteBatch(ctx context.Context, entries []*UsageEntry) er
 	_, err := s.collection.InsertMany(ctx, docs, opts)
 	if err != nil {
 		// Check if it's a bulk write error with some successes
-		var bulkErr *mongo.BulkWriteException
-		if errors.As(err, &bulkErr) {
+		if bulkErr, ok := errors.AsType[*mongo.BulkWriteException](err); ok {
 			failedCount := len(bulkErr.WriteErrors)
 			// Log for visibility
 			slog.Warn("partial usage insert failure",

--- a/internal/usage/store_postgresql.go
+++ b/internal/usage/store_postgresql.go
@@ -181,7 +181,7 @@ func buildUsageInsert(entries []*UsageEntry) (string, []any) {
 			builder.WriteString(", ")
 		}
 		builder.WriteByte('(')
-		for col := 0; col < usageInsertColumnCount; col++ {
+		for col := range usageInsertColumnCount {
 			if col > 0 {
 				builder.WriteString(", ")
 			}

--- a/internal/usage/store_sqlite.go
+++ b/internal/usage/store_sqlite.go
@@ -108,15 +108,12 @@ func (s *SQLiteStore) WriteBatch(ctx context.Context, entries []*UsageEntry) err
 
 	// Process entries in chunks to stay within SQLite's parameter limit
 	for i := 0; i < len(entries); i += maxEntriesPerBatch {
-		end := i + maxEntriesPerBatch
-		if end > len(entries) {
-			end = len(entries)
-		}
+		end := min(i+maxEntriesPerBatch, len(entries))
 		chunk := entries[i:end]
 
 		// Build batch insert query for this chunk
 		placeholders := make([]string, len(chunk))
-		values := make([]interface{}, 0, len(chunk)*columnsPerUsageEntry)
+		values := make([]any, 0, len(chunk)*columnsPerUsageEntry)
 
 		for j, e := range chunk {
 			placeholders[j] = "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
@@ -124,7 +121,7 @@ func (s *SQLiteStore) WriteBatch(ctx context.Context, entries []*UsageEntry) err
 			rawDataJSON := marshalRawData(e.RawData, e.ID)
 
 			// Handle NULL for raw_data field
-			var rawDataValue interface{}
+			var rawDataValue any
 			if rawDataJSON != nil {
 				rawDataValue = string(rawDataJSON)
 			}

--- a/internal/usage/stream_observer.go
+++ b/internal/usage/stream_observer.go
@@ -28,7 +28,7 @@ func NewStreamUsageObserver(logger LoggerInterface, model, provider, requestID, 
 	}
 }
 
-func (o *StreamUsageObserver) OnJSONEvent(chunk map[string]interface{}) {
+func (o *StreamUsageObserver) OnJSONEvent(chunk map[string]any) {
 	entry := o.extractUsageFromEvent(chunk)
 	if entry != nil {
 		o.cachedEntry = entry
@@ -45,7 +45,7 @@ func (o *StreamUsageObserver) OnStreamClose() {
 	}
 }
 
-func (o *StreamUsageObserver) extractUsageFromEvent(chunk map[string]interface{}) *UsageEntry {
+func (o *StreamUsageObserver) extractUsageFromEvent(chunk map[string]any) *UsageEntry {
 	providerID, _ := chunk["id"].(string)
 
 	model := o.model
@@ -56,7 +56,7 @@ func (o *StreamUsageObserver) extractUsageFromEvent(chunk map[string]interface{}
 	usageRaw, ok := chunk["usage"]
 	if !ok {
 		if eventType, _ := chunk["type"].(string); eventType == "response.completed" || eventType == "response.done" {
-			if response, respOK := chunk["response"].(map[string]interface{}); respOK {
+			if response, respOK := chunk["response"].(map[string]any); respOK {
 				usageRaw, ok = response["usage"]
 				if id, idOK := response["id"].(string); idOK && id != "" {
 					providerID = id
@@ -71,7 +71,7 @@ func (o *StreamUsageObserver) extractUsageFromEvent(chunk map[string]interface{}
 		return nil
 	}
 
-	usageMap, ok := usageRaw.(map[string]interface{})
+	usageMap, ok := usageRaw.(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -101,14 +101,14 @@ func (o *StreamUsageObserver) extractUsageFromEvent(chunk map[string]interface{}
 		}
 	}
 
-	if details, ok := usageMap["prompt_tokens_details"].(map[string]interface{}); ok {
+	if details, ok := usageMap["prompt_tokens_details"].(map[string]any); ok {
 		for k, v := range details {
 			if fv, ok := v.(float64); ok && fv > 0 {
 				rawData["prompt_"+k] = int(fv)
 			}
 		}
 	}
-	if details, ok := usageMap["completion_tokens_details"].(map[string]interface{}); ok {
+	if details, ok := usageMap["completion_tokens_details"].(map[string]any); ok {
 		for k, v := range details {
 			if fv, ok := v.(float64); ok && fv > 0 {
 				rawData["completion_"+k] = int(fv)

--- a/internal/usage/stream_observer_test.go
+++ b/internal/usage/stream_observer_test.go
@@ -88,17 +88,17 @@ data: [DONE]
 func TestStreamUsageObserverWithExtendedUsage(t *testing.T) {
 	logger := &trackingLogger{enabled: true}
 	observer := NewStreamUsageObserver(logger, "o1-preview", "openai", "req-456", "/v1/chat/completions", nil)
-	observer.OnJSONEvent(map[string]interface{}{
+	observer.OnJSONEvent(map[string]any{
 		"id":    "chatcmpl-456",
 		"model": "o1-preview",
-		"usage": map[string]interface{}{
+		"usage": map[string]any{
 			"prompt_tokens":     float64(100),
 			"completion_tokens": float64(50),
 			"total_tokens":      float64(150),
-			"prompt_tokens_details": map[string]interface{}{
+			"prompt_tokens_details": map[string]any{
 				"cached_tokens": float64(20),
 			},
-			"completion_tokens_details": map[string]interface{}{
+			"completion_tokens_details": map[string]any{
 				"reasoning_tokens": float64(10),
 			},
 		},
@@ -151,9 +151,9 @@ data: [DONE]
 func TestStreamUsageObserverDoubleClose(t *testing.T) {
 	logger := &trackingLogger{enabled: true}
 	observer := NewStreamUsageObserver(logger, "gpt-4", "openai", "req-123", "/v1/chat/completions", nil)
-	observer.OnJSONEvent(map[string]interface{}{
+	observer.OnJSONEvent(map[string]any{
 		"id": "chatcmpl-123",
-		"usage": map[string]interface{}{
+		"usage": map[string]any{
 			"prompt_tokens":     float64(10),
 			"completion_tokens": float64(5),
 			"total_tokens":      float64(15),

--- a/internal/usage/usage_test.go
+++ b/internal/usage/usage_test.go
@@ -52,7 +52,7 @@ func TestLogger(t *testing.T) {
 	logger := NewLogger(store, cfg)
 
 	// Write some entries
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		logger.Write(&UsageEntry{
 			ID:           "test-" + string(rune('0'+i)),
 			RequestID:    "req-" + string(rune('0'+i)),
@@ -105,7 +105,7 @@ func TestLoggerClose(t *testing.T) {
 	logger := NewLogger(store, cfg)
 
 	// Write entries
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		logger.Write(&UsageEntry{
 			ID:        "test-" + string(rune('0'+i)),
 			RequestID: "req-" + string(rune('0'+i)),
@@ -210,7 +210,7 @@ func TestLoggerBufferFull(t *testing.T) {
 	var written atomic.Int32
 
 	// Try to write more than buffer size
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		logger.Write(&UsageEntry{ID: "test-" + string(rune('0'+i))})
 		written.Add(1)
 	}

--- a/tests/perf/hotpath_test.go
+++ b/tests/perf/hotpath_test.go
@@ -280,7 +280,6 @@ func TestHotPathPerfGuard(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			result := testing.Benchmark(tc.bench)
 


### PR DESCRIPTION
## Summary

- Upgrade Go from 1.25.0 to 1.26.1 (latest patch, includes security fixes for `crypto/x509`, `html/template`, `net/url`, `os`)
- Apply `go fix` modernizers across the codebase: `interface{}` → `any`, manual map copies → `maps.Copy`, linear searches → `slices.Contains`, ptr helpers → `new(expr)`
- Adopt `errors.AsType[T]()` in 9 production error-handling sites for cleaner, faster type assertions
- Remove 7 now-unused ptr/intPtr/float64Ptr helper functions that were fully inlined by `go fix`
- Switch default model list URL from `models.json` to `models.min.json`

### Automatic performance wins (no code changes needed)

| Improvement | Impact |
|---|---|
| Green Tea GC (default) | 10-40% less GC overhead |
| `io.ReadAll()` | ~2x faster, ~50% less memory (36 call sites) |
| `fmt.Errorf()` without `%w` | reduced allocations (167 call sites) |
| Stack-allocated slices | compiler optimization |
| cgo overhead | ~30% reduction (SQLite via modernc) |

### Version bumps

`go.mod`, `Dockerfile`, `.github/workflows/test.yml`, `CLAUDE.md`, `README.md`, `docs/TESTING_STRATEGY.md`, `docs/about/benchmarks.mdx`

## Test plan

- [x] `go build ./cmd/gomodel` — compiles cleanly
- [x] `make lint` — 0 issues across all build tags
- [x] `make test` — all unit tests pass
- [x] `make test-e2e` — all E2E tests pass
- [x] `make test-contract` — all contract replay tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Go requirement and toolchain from 1.25 → 1.26 across builds, CI, containers, and docs.
  * Switched external model registry to the minified models.min.json for metadata fetching.
  * Modernized codebase to use newer Go language/stdlib idioms for clearer internals and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->