### PR TITLE
refactor(core): streamline model selector resolution

### DIFF
--- a/internal/aliases/batch_preparer.go
+++ b/internal/aliases/batch_preparer.go
@@ -50,31 +50,29 @@ type aliasModelProviderTypeChecker interface {
 	GetProviderType(string) string
 }
 
-func resolveAliasModel(service *Service, model, provider string) (core.ModelSelector, bool, error) {
+func resolveAliasModel(service *Service, requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
+	requested = core.NewRequestedModelSelector(requested.Model, requested.ProviderHint)
 	if service == nil {
-		selector, err := core.ParseModelSelector(model, provider)
+		selector, err := requested.Normalize()
 		return selector, false, err
 	}
-	resolution, ok, err := service.Resolve(model, provider)
-	if err != nil {
-		return core.ModelSelector{}, false, err
-	}
-	return resolution.Resolved, ok, nil
+	return service.ResolveModel(requested)
 }
 
-func resolveAliasRequestSelector(service *Service, model, provider string) (core.ModelSelector, error) {
-	selector, changed, err := resolveAliasModel(service, model, provider)
+func resolveAliasRequestSelector(service *Service, requested core.RequestedModelSelector) (core.ModelSelector, error) {
+	requested = core.NewRequestedModelSelector(requested.Model, requested.ProviderHint)
+	selector, changed, err := resolveAliasModel(service, requested)
 	if err != nil {
 		return core.ModelSelector{}, err
 	}
 	if changed {
 		return selector, nil
 	}
-	return core.ParseModelSelector(model, provider)
+	return requested.Normalize()
 }
 
-func resolveAliasRoutableSelector(service *Service, checker aliasModelSupportChecker, model, provider, expectedProviderType string) (core.ModelSelector, error) {
-	selector, err := resolveAliasRequestSelector(service, model, provider)
+func resolveAliasRoutableSelector(service *Service, checker aliasModelSupportChecker, requested core.RequestedModelSelector, expectedProviderType string) (core.ModelSelector, error) {
+	selector, err := resolveAliasRequestSelector(service, requested)
 	if err != nil {
 		return core.ModelSelector{}, err
 	}
@@ -98,11 +96,9 @@ func validateResolvedProviderType(checker aliasModelSupportChecker, selector cor
 		return nil
 	}
 
-	actualProviderType := strings.TrimSpace(selector.Provider)
-	if actualProviderType == "" {
-		if typed, ok := checker.(aliasModelProviderTypeChecker); ok {
-			actualProviderType = strings.TrimSpace(typed.GetProviderType(selector.QualifiedModel()))
-		}
+	actualProviderType := ""
+	if typed, ok := checker.(aliasModelProviderTypeChecker); ok {
+		actualProviderType = strings.TrimSpace(typed.GetProviderType(selector.QualifiedModel()))
 	}
 	if actualProviderType == "" || actualProviderType == expectedProviderType {
 		return nil
@@ -122,7 +118,7 @@ func rewriteAliasChatRequest(service *Service, checker aliasModelSupportChecker,
 	if req == nil {
 		return nil, nil
 	}
-	selector, err := resolveAliasRoutableSelector(service, checker, req.Model, req.Provider, expectedProviderType)
+	selector, err := resolveAliasRoutableSelector(service, checker, core.NewRequestedModelSelector(req.Model, req.Provider), expectedProviderType)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +132,7 @@ func rewriteAliasResponsesRequest(service *Service, checker aliasModelSupportChe
 	if req == nil {
 		return nil, nil
 	}
-	selector, err := resolveAliasRoutableSelector(service, checker, req.Model, req.Provider, expectedProviderType)
+	selector, err := resolveAliasRoutableSelector(service, checker, core.NewRequestedModelSelector(req.Model, req.Provider), expectedProviderType)
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +146,7 @@ func rewriteAliasEmbeddingRequest(service *Service, checker aliasModelSupportChe
 	if req == nil {
 		return nil, nil
 	}
-	selector, err := resolveAliasRoutableSelector(service, checker, req.Model, req.Provider, expectedProviderType)
+	selector, err := resolveAliasRoutableSelector(service, checker, core.NewRequestedModelSelector(req.Model, req.Provider), expectedProviderType)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/aliases/batch_preparer.go
+++ b/internal/aliases/batch_preparer.go
@@ -51,7 +51,6 @@ type aliasModelProviderTypeChecker interface {
 }
 
 func resolveAliasModel(service *Service, requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
-	requested = core.NewRequestedModelSelector(requested.Model, requested.ProviderHint)
 	if service == nil {
 		selector, err := requested.Normalize()
 		return selector, false, err
@@ -60,7 +59,6 @@ func resolveAliasModel(service *Service, requested core.RequestedModelSelector) 
 }
 
 func resolveAliasRequestSelector(service *Service, requested core.RequestedModelSelector) (core.ModelSelector, error) {
-	requested = core.NewRequestedModelSelector(requested.Model, requested.ProviderHint)
 	selector, changed, err := resolveAliasModel(service, requested)
 	if err != nil {
 		return core.ModelSelector{}, err

--- a/internal/aliases/provider.go
+++ b/internal/aliases/provider.go
@@ -46,9 +46,9 @@ func NewProviderWithOptions(inner core.RoutableProvider, service *Service, optio
 	return &Provider{inner: inner, service: service, options: options}
 }
 
-// ResolveModel resolves a model/provider pair through the alias table.
-func (p *Provider) ResolveModel(model, provider string) (core.ModelSelector, bool, error) {
-	return resolveAliasModel(p.service, model, provider)
+// ResolveModel resolves a requested selector through the alias table.
+func (p *Provider) ResolveModel(requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
+	return resolveAliasModel(p.service, requested)
 }
 
 func (p *Provider) ChatCompletion(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {

--- a/internal/aliases/provider.go
+++ b/internal/aliases/provider.go
@@ -36,9 +36,13 @@ type Options struct {
 	DisableNativeBatchPreparation bool
 }
 
-// NewProvider creates an alias-aware provider wrapper.
+// NewProvider creates an alias-aware provider wrapper that exposes alias
+// inventory and native batch preparation without owning translated-route model
+// resolution by default.
 func NewProvider(inner core.RoutableProvider, service *Service) *Provider {
-	return NewProviderWithOptions(inner, service, Options{})
+	return NewProviderWithOptions(inner, service, Options{
+		DisableTranslatedRequestProcessing: true,
+	})
 }
 
 // NewProviderWithOptions creates an alias-aware provider wrapper with explicit options.

--- a/internal/aliases/provider_test.go
+++ b/internal/aliases/provider_test.go
@@ -164,7 +164,7 @@ func TestProviderResolvesRequestsAndExposesAliasModels(t *testing.T) {
 	if got := provider.GetProviderType("smart"); got != "openai" {
 		t.Fatalf("GetProviderType(smart) = %q, want openai", got)
 	}
-	selector, changed, err := provider.ResolveModel("smart", "")
+	selector, changed, err := provider.ResolveModel(core.NewRequestedModelSelector("smart", ""))
 	if err != nil {
 		t.Fatalf("ResolveModel() error = %v", err)
 	}
@@ -264,7 +264,7 @@ func TestProviderCanDisableTranslatedRequestRewriting(t *testing.T) {
 	if got := provider.GetProviderType("smart"); got != "openai" {
 		t.Fatalf("GetProviderType(smart) = %q, want openai", got)
 	}
-	selector, changed, err := provider.ResolveModel("smart", "")
+	selector, changed, err := provider.ResolveModel(core.NewRequestedModelSelector("smart", ""))
 	if err != nil {
 		t.Fatalf("ResolveModel() error = %v", err)
 	}

--- a/internal/aliases/provider_test.go
+++ b/internal/aliases/provider_test.go
@@ -150,7 +150,7 @@ func TestProviderResolvesRequestsAndExposesAliasModels(t *testing.T) {
 	inner.providerType["gpt-4o"] = "openai"
 	inner.modelsResp = &core.ModelsResponse{Object: "list", Data: []core.Model{{ID: "gpt-4o", Object: "model"}}}
 
-	provider := NewProvider(inner, service)
+	provider := NewProviderWithOptions(inner, service, Options{})
 
 	if _, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{Model: "smart"}); err != nil {
 		t.Fatalf("ChatCompletion() error = %v", err)
@@ -207,7 +207,7 @@ func TestProviderMaskingAliasOverridesConcreteModelEntry(t *testing.T) {
 		{ID: "gpt-4o-mini", Object: "model", Metadata: &core.ModelMetadata{DisplayName: "GPT-4o mini"}},
 	}}
 
-	provider := NewProvider(inner, service)
+	provider := NewProviderWithOptions(inner, service, Options{})
 
 	if _, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{Model: "gpt-4o"}); err != nil {
 		t.Fatalf("ChatCompletion() error = %v", err)
@@ -228,6 +228,38 @@ func TestProviderMaskingAliasOverridesConcreteModelEntry(t *testing.T) {
 	}
 	if models.Data[0].Metadata == nil || models.Data[0].Metadata.DisplayName != "GPT-4o mini" {
 		t.Fatalf("masked model metadata = %#v, want alias target metadata", models.Data[0].Metadata)
+	}
+}
+
+func TestProviderDefaultsToInventoryAndBatchPreparationOnly(t *testing.T) {
+	catalog := newTestCatalog()
+	catalog.add("gpt-4o", "openai", core.Model{ID: "gpt-4o", Object: "model", OwnedBy: "openai"})
+
+	service, err := NewService(newMemoryStore(Alias{Name: "smart", TargetModel: "gpt-4o", Enabled: true}), catalog)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	inner := newProviderMock()
+	inner.supported["gpt-4o"] = true
+	inner.providerType["gpt-4o"] = "openai"
+
+	provider := NewProvider(inner, service)
+
+	if _, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{Model: "smart"}); err != nil {
+		t.Fatalf("ChatCompletion() error = %v", err)
+	}
+	if inner.chatReq == nil || inner.chatReq.Model != "smart" {
+		t.Fatalf("inner.chatReq = %#v, want untranslated alias model smart", inner.chatReq)
+	}
+	if !provider.Supports("smart") {
+		t.Fatal("Supports(smart) = false, want true")
+	}
+	if got := provider.GetProviderType("smart"); got != "openai" {
+		t.Fatalf("GetProviderType(smart) = %q, want openai", got)
 	}
 }
 
@@ -328,7 +360,7 @@ func TestProviderRewritesBatchItemBodies(t *testing.T) {
 
 	inner := newProviderMock()
 	inner.supported["openai/gpt-4o"] = true
-	provider := NewProvider(inner, service)
+	provider := NewProviderWithOptions(inner, service, Options{})
 
 	body := json.RawMessage(`{"model":"smart","messages":[{"role":"user","content":"hi"}]}`)
 	_, err = provider.CreateBatch(context.Background(), "openai", &core.BatchRequest{
@@ -374,7 +406,7 @@ func TestProviderRewritesBatchInputFiles(t *testing.T) {
 		Data:     []byte("{\"custom_id\":\"1\",\"method\":\"POST\",\"url\":\"/v1/chat/completions\",\"body\":{\"model\":\"smart\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}}\n"),
 	}
 	inner.fileObject = &core.FileObject{ID: "file_rewritten", Object: "file", Filename: "batch.jsonl", Purpose: "batch"}
-	provider := NewProvider(inner, service)
+	provider := NewProviderWithOptions(inner, service, Options{})
 
 	_, err = provider.CreateBatch(context.Background(), "openai", &core.BatchRequest{
 		InputFileID: "file_source",
@@ -416,7 +448,7 @@ func TestProviderBatchInputFileSkipsUploadWhenUnchanged(t *testing.T) {
 		Filename: "batch.jsonl",
 		Data:     []byte("{\"custom_id\":\"1\",\"method\":\"POST\",\"url\":\"/v1/chat/completions\",\"body\":{\"model\":\"gpt-4o\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}}\n"),
 	}
-	provider := NewProvider(inner, service)
+	provider := NewProviderWithOptions(inner, service, Options{})
 
 	_, err = provider.CreateBatch(context.Background(), "openai", &core.BatchRequest{
 		InputFileID: "file_source",
@@ -455,7 +487,7 @@ func TestProviderRejectsDisabledAliasInBatchInputFiles(t *testing.T) {
 		Filename: "batch.jsonl",
 		Data:     []byte("{\"custom_id\":\"1\",\"method\":\"POST\",\"url\":\"/v1/chat/completions\",\"body\":{\"model\":\"smart\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}}\n"),
 	}
-	provider := NewProvider(inner, service)
+	provider := NewProviderWithOptions(inner, service, Options{})
 
 	_, err = provider.CreateBatch(context.Background(), "openai", &core.BatchRequest{
 		InputFileID: "file_source",
@@ -496,7 +528,7 @@ func TestProviderDeletesRewrittenBatchInputFileOnCreateFailure(t *testing.T) {
 		Data:     []byte("{\"custom_id\":\"1\",\"method\":\"POST\",\"url\":\"/v1/chat/completions\",\"body\":{\"model\":\"smart\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}}\n"),
 	}
 	inner.fileObject = &core.FileObject{ID: "file_rewritten", Object: "file", Filename: "batch.jsonl", Purpose: "batch"}
-	provider := NewProvider(inner, service)
+	provider := NewProviderWithOptions(inner, service, Options{})
 
 	_, err = provider.CreateBatch(context.Background(), "openai", &core.BatchRequest{
 		InputFileID: "file_source",

--- a/internal/aliases/service.go
+++ b/internal/aliases/service.go
@@ -116,44 +116,32 @@ func (s *Service) Get(name string) (*Alias, bool) {
 	return &copy, true
 }
 
-// ResolveSelector resolves a selector through the alias table.
-// Explicit provider selection bypasses aliases.
-func (s *Service) ResolveSelector(selector core.ModelSelector) (Resolution, bool) {
-	resolution := Resolution{Requested: selector, Resolved: selector}
-	if strings.TrimSpace(selector.Provider) != "" {
-		return resolution, false
-	}
-
-	aliasResolution, ok := s.resolveAlias(selector.QualifiedModel())
-	if !ok {
-		return resolution, false
-	}
-	aliasResolution.Requested = selector
-	return aliasResolution, true
-}
-
 // Resolve resolves raw model/provider inputs through the alias table.
 func (s *Service) Resolve(model, provider string) (Resolution, bool, error) {
-	if strings.TrimSpace(provider) == "" {
-		if resolution, ok := s.resolveAlias(model); ok {
+	return s.resolveRequested(core.NewRequestedModelSelector(model, provider))
+}
+
+func (s *Service) resolveRequested(requested core.RequestedModelSelector) (Resolution, bool, error) {
+	requested = core.NewRequestedModelSelector(requested.Model, requested.ProviderHint)
+	if !requested.ExplicitProvider {
+		if resolution, ok := s.resolveAlias(requested.Model); ok {
 			return resolution, true, nil
 		}
 	}
 
-	selector, err := core.ParseModelSelector(model, provider)
+	selector, err := requested.Normalize()
 	if err != nil {
 		return Resolution{}, false, err
 	}
-	resolution, ok := s.ResolveSelector(selector)
-	return resolution, ok, nil
+	return Resolution{Requested: selector, Resolved: selector}, false, nil
 }
 
 // ResolveModel resolves raw model/provider inputs and returns the concrete
 // selector chosen for execution. This allows alias policy to be consumed as an
 // explicit planning dependency without requiring the provider chain itself to
 // own alias behavior.
-func (s *Service) ResolveModel(model, provider string) (core.ModelSelector, bool, error) {
-	resolution, changed, err := s.Resolve(model, provider)
+func (s *Service) ResolveModel(requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
+	resolution, changed, err := s.resolveRequested(requested)
 	if err != nil {
 		return core.ModelSelector{}, false, err
 	}
@@ -162,15 +150,7 @@ func (s *Service) ResolveModel(model, provider string) (core.ModelSelector, bool
 
 // Supports reports whether an alias currently resolves to a concrete model.
 func (s *Service) Supports(model string) bool {
-	if _, ok := s.resolveAlias(model); ok {
-		return true
-	}
-
-	selector, err := core.ParseModelSelector(model, "")
-	if err != nil {
-		return false
-	}
-	_, ok := s.ResolveSelector(selector)
+	_, ok := s.resolveAlias(model)
 	return ok
 }
 
@@ -179,16 +159,7 @@ func (s *Service) GetProviderType(model string) string {
 	if resolution, ok := s.resolveAlias(model); ok {
 		return strings.TrimSpace(s.catalog.GetProviderType(resolution.Resolved.QualifiedModel()))
 	}
-
-	selector, err := core.ParseModelSelector(model, "")
-	if err != nil {
-		return ""
-	}
-	resolution, ok := s.ResolveSelector(selector)
-	if !ok {
-		return ""
-	}
-	return strings.TrimSpace(s.catalog.GetProviderType(resolution.Resolved.QualifiedModel()))
+	return ""
 }
 
 // ExposedModels returns enabled aliases projected as model-list entries.

--- a/internal/aliases/service.go
+++ b/internal/aliases/service.go
@@ -122,7 +122,6 @@ func (s *Service) Resolve(model, provider string) (Resolution, bool, error) {
 }
 
 func (s *Service) resolveRequested(requested core.RequestedModelSelector) (Resolution, bool, error) {
-	requested = core.NewRequestedModelSelector(requested.Model, requested.ProviderHint)
 	if !requested.ExplicitProvider {
 		if resolution, ok := s.resolveAlias(requested.Model); ok {
 			return resolution, true, nil
@@ -136,10 +135,10 @@ func (s *Service) resolveRequested(requested core.RequestedModelSelector) (Resol
 	return Resolution{Requested: selector, Resolved: selector}, false, nil
 }
 
-// ResolveModel resolves raw model/provider inputs and returns the concrete
-// selector chosen for execution. This allows alias policy to be consumed as an
-// explicit planning dependency without requiring the provider chain itself to
-// own alias behavior.
+// ResolveModel resolves a requested selector and returns the concrete selector
+// chosen for execution. This allows alias policy to be consumed as an explicit
+// planning dependency without requiring the provider chain itself to own alias
+// behavior.
 func (s *Service) ResolveModel(requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
 	resolution, changed, err := s.resolveRequested(requested)
 	if err != nil {

--- a/internal/auditlog/auditlog_test.go
+++ b/internal/auditlog/auditlog_test.go
@@ -471,7 +471,7 @@ func TestMiddleware_PrefersExecutionPlanOverLegacyResolution(t *testing.T) {
 	req = req.WithContext(core.WithExecutionPlan(req.Context(), &core.ExecutionPlan{
 		ProviderType: "openai",
 		Resolution: &core.RequestModelResolution{
-			RequestedModel:   "anthropic/claude-opus-4-6",
+			Requested:        core.NewRequestedModelSelector("anthropic/claude-opus-4-6", ""),
 			ResolvedSelector: core.ModelSelector{Provider: "openai", Model: "gpt-5-nano"},
 			ProviderType:     "openai",
 			AliasApplied:     true,
@@ -520,7 +520,7 @@ func TestMiddleware_UsesExecutionPlanRequestID(t *testing.T) {
 		RequestID:    "plan-req-id",
 		ProviderType: "openai",
 		Resolution: &core.RequestModelResolution{
-			RequestedModel:   "gpt-5-nano",
+			Requested:        core.NewRequestedModelSelector("gpt-5-nano", ""),
 			ResolvedSelector: core.ModelSelector{Provider: "openai", Model: "gpt-5-nano"},
 			ProviderType:     "openai",
 		},

--- a/internal/core/batch_semantic.go
+++ b/internal/core/batch_semantic.go
@@ -63,14 +63,24 @@ func (decoded *DecodedBatchItemRequest) EmbeddingRequest() *EmbeddingRequest {
 // item. It returns an error when the receiver is nil, when the decoded request
 // type is unsupported, or when the canonical selector cannot be parsed.
 func (decoded *DecodedBatchItemRequest) ModelSelector() (ModelSelector, error) {
+	requested, err := decoded.RequestedModelSelector()
+	if err != nil {
+		return ModelSelector{}, err
+	}
+	return requested.Normalize()
+}
+
+// RequestedModelSelector returns the raw selector requested by the decoded batch
+// item, preserving whether the provider came from the explicit field.
+func (decoded *DecodedBatchItemRequest) RequestedModelSelector() (RequestedModelSelector, error) {
 	if decoded == nil {
-		return ModelSelector{}, fmt.Errorf("decoded batch request is required")
+		return RequestedModelSelector{}, fmt.Errorf("decoded batch request is required")
 	}
 	model, provider, ok := semanticSelectorFromCanonicalRequest(decoded.Request)
 	if !ok {
-		return ModelSelector{}, fmt.Errorf("unsupported batch item url: %s", decoded.Endpoint)
+		return RequestedModelSelector{}, fmt.Errorf("unsupported batch item url: %s", decoded.Endpoint)
 	}
-	return ParseModelSelector(model, provider)
+	return NewRequestedModelSelector(model, provider), nil
 }
 
 // DispatchDecodedBatchItem routes a decoded batch item to the matching typed
@@ -207,4 +217,14 @@ func BatchItemModelSelector(defaultEndpoint string, item BatchRequestItem) (Mode
 		return ModelSelector{}, err
 	}
 	return decoded.ModelSelector()
+}
+
+// BatchItemRequestedModelSelector derives the raw requested selector for a
+// known JSON batch subrequest.
+func BatchItemRequestedModelSelector(defaultEndpoint string, item BatchRequestItem) (RequestedModelSelector, error) {
+	decoded, err := DecodeKnownBatchItemRequest(defaultEndpoint, item)
+	if err != nil {
+		return RequestedModelSelector{}, err
+	}
+	return decoded.RequestedModelSelector()
 }

--- a/internal/core/request_model_resolution.go
+++ b/internal/core/request_model_resolution.go
@@ -3,11 +3,10 @@ package core
 // RequestModelResolution captures the requested model selector at ingress and
 // the concrete selector chosen for execution after alias resolution.
 type RequestModelResolution struct {
-	RequestedModel    string
-	RequestedProvider string
-	ResolvedSelector  ModelSelector
-	ProviderType      string
-	AliasApplied      bool
+	Requested        RequestedModelSelector
+	ResolvedSelector ModelSelector
+	ProviderType     string
+	AliasApplied     bool
 }
 
 // RequestedQualifiedModel reconstructs the raw requested selector.
@@ -15,13 +14,7 @@ func (r *RequestModelResolution) RequestedQualifiedModel() string {
 	if r == nil {
 		return ""
 	}
-	if r.RequestedProvider == "" {
-		return r.RequestedModel
-	}
-	if selector, err := ParseModelSelector(r.RequestedModel, r.RequestedProvider); err == nil {
-		return selector.QualifiedModel()
-	}
-	return r.RequestedProvider + "/" + r.RequestedModel
+	return r.Requested.RequestedQualifiedModel()
 }
 
 // ResolvedQualifiedModel returns the concrete qualified model selected for execution.

--- a/internal/core/request_model_resolution.go
+++ b/internal/core/request_model_resolution.go
@@ -9,7 +9,7 @@ type RequestModelResolution struct {
 	AliasApplied     bool
 }
 
-// RequestedQualifiedModel reconstructs the raw requested selector.
+// RequestedQualifiedModel returns the canonical requested selector.
 func (r *RequestModelResolution) RequestedQualifiedModel() string {
 	if r == nil {
 		return ""

--- a/internal/core/request_model_resolution_test.go
+++ b/internal/core/request_model_resolution_test.go
@@ -11,31 +11,28 @@ func TestRequestModelResolutionRequestedQualifiedModel(t *testing.T) {
 		{
 			name: "raw alias with slash and no explicit provider stays raw",
 			in: &RequestModelResolution{
-				RequestedModel: "anthropic/claude-opus-4-6",
+				Requested: NewRequestedModelSelector("anthropic/claude-opus-4-6", ""),
 			},
 			want: "anthropic/claude-opus-4-6",
 		},
 		{
 			name: "explicit provider with provider-prefixed model normalizes once",
 			in: &RequestModelResolution{
-				RequestedModel:    "openai/gpt-4o",
-				RequestedProvider: "openai",
+				Requested: NewRequestedModelSelector("openai/gpt-4o", "openai"),
 			},
 			want: "openai/gpt-4o",
 		},
 		{
 			name: "explicit provider without prefix becomes qualified model",
 			in: &RequestModelResolution{
-				RequestedModel:    "gpt-4o",
-				RequestedProvider: "openai",
+				Requested: NewRequestedModelSelector("gpt-4o", "openai"),
 			},
 			want: "openai/gpt-4o",
 		},
 		{
 			name: "explicit provider preserves raw slash model",
 			in: &RequestModelResolution{
-				RequestedModel:    "openai/gpt-oss-120b",
-				RequestedProvider: "groq",
+				Requested: NewRequestedModelSelector("openai/gpt-oss-120b", "groq"),
 			},
 			want: "groq/openai/gpt-oss-120b",
 		},

--- a/internal/core/requested_model_selector.go
+++ b/internal/core/requested_model_selector.go
@@ -1,0 +1,43 @@
+package core
+
+import "strings"
+
+// RequestedModelSelector captures the raw selector as provided by a caller
+// before alias resolution or provider routing.
+type RequestedModelSelector struct {
+	Model            string
+	ProviderHint     string
+	ExplicitProvider bool
+}
+
+// NewRequestedModelSelector normalizes raw selector input while preserving
+// whether the provider came from an explicit field rather than model syntax.
+func NewRequestedModelSelector(model, providerHint string) RequestedModelSelector {
+	model = strings.TrimSpace(model)
+	providerHint = strings.TrimSpace(providerHint)
+	return RequestedModelSelector{
+		Model:            model,
+		ProviderHint:     providerHint,
+		ExplicitProvider: providerHint != "",
+	}
+}
+
+// Normalize returns the canonical routing selector for this request input.
+func (s RequestedModelSelector) Normalize() (ModelSelector, error) {
+	return ParseModelSelector(s.Model, s.ProviderHint)
+}
+
+// RequestedQualifiedModel returns the canonical requested selector string used
+// for audit and execution-plan reporting.
+func (s RequestedModelSelector) RequestedQualifiedModel() string {
+	if !s.ExplicitProvider {
+		return s.Model
+	}
+	if selector, err := s.Normalize(); err == nil {
+		return selector.QualifiedModel()
+	}
+	if s.ProviderHint == "" {
+		return s.Model
+	}
+	return s.ProviderHint + "/" + s.Model
+}

--- a/internal/core/responses.go
+++ b/internal/core/responses.go
@@ -10,8 +10,8 @@ import "encoding/json"
 // should be preferred when available.
 type ResponsesRequest struct {
 	Model    string `json:"model"`
-	Provider string `json:"provider,omitempty"`
-	Input    any    `json:"input"` // string or []ResponsesInputElement — see docs for array form
+	Provider string `json:"provider,omitempty"` // Gateway routing hint; stripped before upstream execution.
+	Input    any    `json:"input"`              // string or []ResponsesInputElement — see docs for array form
 	//nolint:govet // Intentional duplicate json tag for Swagger docs: input is string OR []ResponsesInputElement.
 	InputSchema       []ResponsesInputElement `json:"input,omitempty" extensions:"x-oneOf=[{\"type\":\"string\"},{\"type\":\"array\",\"items\":{\"$ref\":\"#/definitions/core.ResponsesInputElement\"}}]"`
 	Instructions      string                  `json:"instructions,omitempty"`

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -23,7 +23,7 @@ type ChatRequest struct {
 	Temperature       *float64          `json:"temperature,omitempty"`
 	MaxTokens         *int              `json:"max_tokens,omitempty"`
 	Model             string            `json:"model"`
-	Provider          string            `json:"provider,omitempty"`
+	Provider          string            `json:"provider,omitempty"` // Gateway routing hint; stripped before upstream execution.
 	Messages          []Message         `json:"messages"`
 	Tools             []map[string]any  `json:"tools,omitempty"`
 	ToolChoice        any               `json:"tool_choice,omitempty"` // string or object
@@ -264,7 +264,7 @@ type ModelsResponse struct {
 // EmbeddingRequest represents the incoming embeddings request (OpenAI-compatible).
 type EmbeddingRequest struct {
 	Model          string            `json:"model"`
-	Provider       string            `json:"provider,omitempty"`
+	Provider       string            `json:"provider,omitempty"` // Gateway routing hint; stripped before upstream execution.
 	Input          any               `json:"input"`
 	EncodingFormat string            `json:"encoding_format,omitempty"`
 	Dimensions     *int              `json:"dimensions,omitempty"`

--- a/internal/providers/router.go
+++ b/internal/providers/router.go
@@ -65,11 +65,11 @@ func (r *Router) checkReady() error {
 }
 
 // resolveProvider validates readiness, parses the model selector, and finds the target provider.
-func (r *Router) resolveProvider(model, provider string) (core.Provider, core.ModelSelector, error) {
+func (r *Router) resolveProvider(model, providerHint string) (core.Provider, core.ModelSelector, error) {
 	if err := r.checkReady(); err != nil {
 		return nil, core.ModelSelector{}, registryUnavailableError(err)
 	}
-	selector, err := core.ParseModelSelector(model, provider)
+	selector, err := core.ParseModelSelector(model, providerHint)
 	if err != nil {
 		return nil, core.ModelSelector{}, core.NewInvalidRequestError(err.Error(), err)
 	}
@@ -147,11 +147,11 @@ func routeResolvedModelCall[Req any, Resp any](
 	r *Router,
 	ctx context.Context,
 	model string,
-	provider string,
+	providerHint string,
 	buildForward func(core.ModelSelector) Req,
 	call func(context.Context, core.Provider, Req) (Resp, error),
 ) (Resp, string, error) {
-	p, selector, err := r.resolveProvider(model, provider)
+	p, selector, err := r.resolveProvider(model, providerHint)
 	if err != nil {
 		var zero Resp
 		return zero, "", err
@@ -165,11 +165,11 @@ func routeStampedModelResponse[Req any, Resp any](
 	r *Router,
 	ctx context.Context,
 	model string,
-	provider string,
+	providerHint string,
 	buildForward func(core.ModelSelector) Req,
 	call func(context.Context, core.Provider, Req) (Resp, error),
 ) (Resp, error) {
-	resp, providerType, err := routeResolvedModelCall(r, ctx, model, provider, buildForward, call)
+	resp, providerType, err := routeResolvedModelCall(r, ctx, model, providerHint, buildForward, call)
 	if err != nil {
 		var zero Resp
 		return zero, err
@@ -221,6 +221,8 @@ func stampProvider[T any](resp T, providerType string) T {
 	return resp
 }
 
+// Provider is gateway routing metadata on OpenAI-compatible request structs and
+// must be removed before dispatching to an upstream provider implementation.
 func forwardChatRequest(req *core.ChatRequest, selector core.ModelSelector) *core.ChatRequest {
 	forwardReq := *req
 	forwardReq.Model = selector.Model

--- a/internal/server/execution_plan_helpers_test.go
+++ b/internal/server/execution_plan_helpers_test.go
@@ -44,7 +44,7 @@ func TestEnsureTranslatedRequestPlan_CompletesPartialPlanFromDecodedSelector(t *
 	assert.Equal(t, core.ExecutionModeTranslated, plan.Mode)
 	assert.Equal(t, "mock", plan.ProviderType)
 	if assert.NotNil(t, plan.Resolution) {
-		assert.Equal(t, "gpt-4o-mini", plan.Resolution.RequestedModel)
+		assert.Equal(t, "gpt-4o-mini", plan.Resolution.Requested.Model)
 		assert.Equal(t, "gpt-4o-mini", plan.Resolution.ResolvedSelector.Model)
 	}
 

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -1214,7 +1214,7 @@ func TestChatCompletion_ResolvesQualifiedMaskingAliasBeforeHandlerRouting(t *tes
 		},
 	}
 
-	provider := aliases.NewProvider(inner, service)
+	provider := aliases.NewProviderWithOptions(inner, service, aliases.Options{})
 
 	e := echo.New()
 	handler := NewHandler(provider, nil, nil, nil)

--- a/internal/server/model_validation_test.go
+++ b/internal/server/model_validation_test.go
@@ -267,7 +267,7 @@ func TestModelValidation_StoresExecutionPlan(t *testing.T) {
 		assert.True(t, capturedPlan.Capabilities.AliasResolution)
 		assert.True(t, capturedPlan.Capabilities.ResponseCaching)
 		if assert.NotNil(t, capturedPlan.Resolution) {
-			assert.Equal(t, "gpt-4o-mini", capturedPlan.Resolution.RequestedModel)
+			assert.Equal(t, "gpt-4o-mini", capturedPlan.Resolution.Requested.Model)
 			assert.Equal(t, "gpt-4o-mini", capturedPlan.Resolution.ResolvedSelector.Model)
 		}
 	}

--- a/internal/server/native_batch_support.go
+++ b/internal/server/native_batch_support.go
@@ -49,12 +49,16 @@ func determineBatchProviderType(provider core.RoutableProvider, resolver Request
 	var providerType string
 	resolver = effectiveRequestModelResolver(provider, resolver)
 	for i, item := range req.Requests {
-		selector, err := core.BatchItemModelSelector(req.Endpoint, item)
+		requested, err := core.BatchItemRequestedModelSelector(req.Endpoint, item)
+		if err != nil {
+			return "", core.NewInvalidRequestError(fmt.Sprintf("batch item %d: %s", i, err.Error()), err)
+		}
+		selector, err := requested.Normalize()
 		if err != nil {
 			return "", core.NewInvalidRequestError(fmt.Sprintf("batch item %d: %s", i, err.Error()), err)
 		}
 		if resolver != nil {
-			selector, _, err = resolver.ResolveModel(selector.Model, selector.Provider)
+			selector, _, err = resolver.ResolveModel(requested)
 			if err != nil {
 				return "", core.NewInvalidRequestError(fmt.Sprintf("batch item %d: %s", i, err.Error()), err)
 			}

--- a/internal/server/request_model_resolution.go
+++ b/internal/server/request_model_resolution.go
@@ -12,7 +12,7 @@ import (
 // RequestModelResolver resolves raw request selectors into concrete model
 // selectors before provider execution.
 type RequestModelResolver interface {
-	ResolveModel(model, provider string) (core.ModelSelector, bool, error)
+	ResolveModel(requested core.RequestedModelSelector) (core.ModelSelector, bool, error)
 }
 
 func effectiveRequestModelResolver(provider core.RoutableProvider, resolver RequestModelResolver) RequestModelResolver {
@@ -25,9 +25,8 @@ func effectiveRequestModelResolver(provider core.RoutableProvider, resolver Requ
 	return nil
 }
 
-func resolveRequestModel(provider core.RoutableProvider, resolver RequestModelResolver, model, providerHint string) (*core.RequestModelResolution, error) {
-	model = strings.TrimSpace(model)
-	providerHint = strings.TrimSpace(providerHint)
+func resolveRequestModel(provider core.RoutableProvider, resolver RequestModelResolver, requested core.RequestedModelSelector) (*core.RequestModelResolution, error) {
+	requested = core.NewRequestedModelSelector(requested.Model, requested.ProviderHint)
 
 	var (
 		resolvedSelector core.ModelSelector
@@ -36,9 +35,9 @@ func resolveRequestModel(provider core.RoutableProvider, resolver RequestModelRe
 	)
 
 	if effectiveResolver := effectiveRequestModelResolver(provider, resolver); effectiveResolver != nil {
-		resolvedSelector, aliasApplied, err = effectiveResolver.ResolveModel(model, providerHint)
+		resolvedSelector, aliasApplied, err = effectiveResolver.ResolveModel(requested)
 	} else {
-		resolvedSelector, err = core.ParseModelSelector(model, providerHint)
+		resolvedSelector, err = requested.Normalize()
 	}
 	if err != nil {
 		return nil, core.NewInvalidRequestError(err.Error(), err)
@@ -53,11 +52,10 @@ func resolveRequestModel(provider core.RoutableProvider, resolver RequestModelRe
 	}
 
 	return &core.RequestModelResolution{
-		RequestedModel:    model,
-		RequestedProvider: providerHint,
-		ResolvedSelector:  resolvedSelector,
-		ProviderType:      strings.TrimSpace(provider.GetProviderType(resolvedModel)),
-		AliasApplied:      aliasApplied,
+		Requested:        requested,
+		ResolvedSelector: resolvedSelector,
+		ProviderType:     strings.TrimSpace(provider.GetProviderType(resolvedModel)),
+		AliasApplied:     aliasApplied,
 	}, nil
 }
 
@@ -113,9 +111,10 @@ func resolveAndStoreRequestModelResolution(
 	resolver RequestModelResolver,
 	model, providerHint string,
 ) (*core.RequestModelResolution, error) {
-	enrichAuditEntryWithRequestedModel(c, model, providerHint)
+	requested := core.NewRequestedModelSelector(model, providerHint)
+	enrichAuditEntryWithRequestedModel(c, requested)
 
-	resolution, err := resolveRequestModel(provider, resolver, model, providerHint)
+	resolution, err := resolveRequestModel(provider, resolver, requested)
 	if err != nil {
 		return nil, err
 	}
@@ -123,13 +122,12 @@ func resolveAndStoreRequestModelResolution(
 	return resolution, nil
 }
 
-func enrichAuditEntryWithRequestedModel(c *echo.Context, model, providerHint string) {
+func enrichAuditEntryWithRequestedModel(c *echo.Context, requested core.RequestedModelSelector) {
 	if c == nil {
 		return
 	}
-	model = strings.TrimSpace(model)
-	providerHint = strings.TrimSpace(providerHint)
-	if model == "" {
+	requested = core.NewRequestedModelSelector(requested.Model, requested.ProviderHint)
+	if requested.Model == "" {
 		return
 	}
 	plan := &core.ExecutionPlan{}
@@ -138,8 +136,7 @@ func enrichAuditEntryWithRequestedModel(c *echo.Context, model, providerHint str
 		plan = &cloned
 	}
 	plan.Resolution = &core.RequestModelResolution{
-		RequestedModel:    model,
-		RequestedProvider: providerHint,
+		Requested: requested,
 	}
 	auditlog.EnrichEntryWithExecutionPlan(c, plan)
 }


### PR DESCRIPTION
## Summary
- preserve requested selector provenance with an explicit requested-selector type instead of loose model/provider strings
- make alias resolution and batch planning consume that typed selector so explicit provider hints and prefixed model syntax are not conflated
- disable translated alias rewriting by default in the alias provider wrapper so explicit server-side planning remains the primary execution path
- clarify in code and comments that request `provider` is a gateway routing hint that is stripped before upstream execution

## Testing
- go test ./internal/core ./internal/server ./internal/aliases ./internal/auditlog ./internal/providers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified request selector flow for model resolution, producing more consistent normalization, per-item batch validation with indexed errors, and updated default behavior that skips translated-route rewriting unless enabled.

* **Documentation**
  * Clarified Provider fields are gateway routing hints and are cleared before upstream execution.

* **Tests**
  * Updated tests to align with the new selector-based request shape and default provider-handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->