### PR TITLE
feat(fallback): add model fallback routing

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -104,6 +104,15 @@ guardrails:
     #     mode: "inject"
     #     content: "Follow safety guidelines."
 
+fallback:
+  default_mode: off # "off", "manual", or "auto"
+  manual_rules_path: "config/fallback.example.json" # optional JSON map: {"model": ["fallback-1", "provider/model"]}
+  overrides:
+    "gpt-4o":
+      mode: manual # use only manual fallbacks for this model
+    "claude-sonnet-4":
+      mode: off # disable fallback just for this model
+
 providers:
   openai:
     type: openai

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -108,13 +108,13 @@ guardrails:
     #     content: "Follow safety guidelines."
 
 fallback:
-  default_mode: off # "off", "manual", or "auto"
+  default_mode: "off" # "off", "manual", or "auto"
   manual_rules_path: "config/fallback.example.json" # optional JSON map: {"model": ["fallback-1", "provider/model"]}
   overrides:
     "gpt-4o":
-      mode: manual # use only manual fallbacks for this model
+      mode: "manual" # use only manual fallbacks for this model
     "claude-sonnet-4":
-      mode: off # disable fallback just for this model
+      mode: "off" # disable fallback just for this model
 
 providers:
   openai:

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -109,10 +109,10 @@ guardrails:
 
 fallback:
   default_mode: "off" # "off", "manual", or "auto"
-  manual_rules_path: "config/fallback.example.json" # optional JSON map: {"model": ["fallback-1", "provider/model"]}
+  manual_rules_path: "config/fallback.example.json" # optional JSON map: {"model": ["fallback-1", "provider/model"]}; required when fallback.default_mode or any fallback.overrides.*.mode is "manual"
   overrides:
     "gpt-4o":
-      mode: "manual" # use only manual fallbacks for this model
+      mode: "manual" # use only manual fallbacks for this model; requires manual_rules_path
     "claude-sonnet-4":
       mode: "off" # disable fallback just for this model
 

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"os"
@@ -37,6 +38,7 @@ type Config struct {
 	HTTP       HTTPConfig       `yaml:"http"`
 	Admin      AdminConfig      `yaml:"admin"`
 	Guardrails GuardrailsConfig `yaml:"guardrails"`
+	Fallback   FallbackConfig   `yaml:"fallback"`
 	Resilience ResilienceConfig `yaml:"resilience"`
 }
 
@@ -83,6 +85,53 @@ type RawRetryConfig struct {
 	MaxBackoff     *time.Duration `yaml:"max_backoff"`
 	BackoffFactor  *float64       `yaml:"backoff_factor"`
 	JitterFactor   *float64       `yaml:"jitter_factor"`
+}
+
+// FallbackMode controls how alternate models are selected when the primary
+// model is unavailable.
+type FallbackMode string
+
+const (
+	FallbackModeOff    FallbackMode = "off"
+	FallbackModeManual FallbackMode = "manual"
+	FallbackModeAuto   FallbackMode = "auto"
+)
+
+// Valid reports whether mode is one of the supported fallback modes.
+func (m FallbackMode) Valid() bool {
+	switch normalizeFallbackMode(m) {
+	case FallbackModeOff, FallbackModeManual, FallbackModeAuto:
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeFallbackMode(mode FallbackMode) FallbackMode {
+	return FallbackMode(strings.ToLower(strings.TrimSpace(string(mode))))
+}
+
+// FallbackModelOverride holds per-model mode overrides.
+type FallbackModelOverride struct {
+	Mode FallbackMode `yaml:"mode" json:"mode"`
+}
+
+// FallbackConfig holds translated-route model fallback policy.
+type FallbackConfig struct {
+	// DefaultMode controls the fallback behavior when no per-model override exists.
+	// Supported values: "auto", "manual", "off". Default: "off".
+	DefaultMode FallbackMode `yaml:"default_mode" env:"FALLBACK_DEFAULT_MODE"`
+
+	// ManualRulesPath points to a JSON file that maps source model selectors to
+	// ordered fallback model selector lists. Empty disables manual rules.
+	ManualRulesPath string `yaml:"manual_rules_path" env:"FALLBACK_MANUAL_RULES_PATH"`
+
+	// Overrides controls per-model mode overrides. Keys may be bare models
+	// ("gpt-4o") or provider-qualified public selectors ("azure/gpt-4o").
+	Overrides map[string]FallbackModelOverride `yaml:"overrides"`
+
+	// Manual holds the parsed manual fallback lists loaded from ManualRulesPath.
+	Manual map[string][]string `yaml:"-"`
 }
 
 // AdminConfig holds configuration for the admin API and dashboard UI.
@@ -566,6 +615,9 @@ func buildDefaultConfig() *Config {
 			Timeout:               600,
 			ResponseHeaderTimeout: 600,
 		},
+		Fallback: FallbackConfig{
+			DefaultMode: FallbackModeOff,
+		},
 		Resilience: ResilienceConfig{
 			Retry:          DefaultRetryConfig(),
 			CircuitBreaker: DefaultCircuitBreakerConfig(),
@@ -593,6 +645,10 @@ func Load() (*LoadResult, error) {
 	}
 
 	if err := applyEnvOverrides(cfg); err != nil {
+		return nil, err
+	}
+
+	if err := loadFallbackConfig(&cfg.Fallback); err != nil {
 		return nil, err
 	}
 
@@ -660,6 +716,71 @@ func applyYAML(cfg *Config) (map[string]RawProviderConfig, error) {
 	}
 
 	return rawProviders, nil
+}
+
+func loadFallbackConfig(cfg *FallbackConfig) error {
+	if cfg == nil {
+		return nil
+	}
+
+	cfg.DefaultMode = normalizeFallbackMode(cfg.DefaultMode)
+	if cfg.DefaultMode == "" {
+		cfg.DefaultMode = FallbackModeOff
+	}
+	if !cfg.DefaultMode.Valid() {
+		return fmt.Errorf("fallback.default_mode must be one of: auto, manual, off")
+	}
+
+	if len(cfg.Overrides) > 0 {
+		normalized := make(map[string]FallbackModelOverride, len(cfg.Overrides))
+		for key, override := range cfg.Overrides {
+			key = strings.TrimSpace(key)
+			if key == "" {
+				return fmt.Errorf("fallback.overrides: model key cannot be empty")
+			}
+			override.Mode = normalizeFallbackMode(override.Mode)
+			if override.Mode != "" && !override.Mode.Valid() {
+				return fmt.Errorf("fallback.overrides[%q].mode must be one of: auto, manual, off", key)
+			}
+			normalized[key] = override
+		}
+		cfg.Overrides = normalized
+	}
+
+	path := strings.TrimSpace(cfg.ManualRulesPath)
+	if path == "" {
+		cfg.Manual = nil
+		return nil
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("fallback.manual_rules_path: failed to read %q: %w", path, err)
+	}
+
+	var decoded map[string][]string
+	if err := json.Unmarshal([]byte(expandString(string(raw))), &decoded); err != nil {
+		return fmt.Errorf("fallback.manual_rules_path: failed to parse %q: %w", path, err)
+	}
+
+	manual := make(map[string][]string, len(decoded))
+	for key, models := range decoded {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return fmt.Errorf("fallback.manual_rules_path: model key cannot be empty")
+		}
+		normalized := make([]string, 0, len(models))
+		for _, model := range models {
+			model = strings.TrimSpace(model)
+			if model == "" {
+				continue
+			}
+			normalized = append(normalized, model)
+		}
+		manual[key] = normalized
+	}
+	cfg.Manual = manual
+	return nil
 }
 
 // applyEnvOverrides walks cfg's struct fields and applies env var overrides

--- a/config/config.go
+++ b/config/config.go
@@ -766,6 +766,16 @@ func loadFallbackConfig(cfg *FallbackConfig) error {
 
 	path := strings.TrimSpace(cfg.ManualRulesPath)
 	if path == "" {
+		if cfg.DefaultMode == FallbackModeManual {
+			return fmt.Errorf("fallback.manual_rules_path must be set when fallback.default_mode or any fallback.overrides[].mode is 'manual'")
+		}
+		for _, override := range cfg.Overrides {
+			if override.Mode == FallbackModeManual {
+				return fmt.Errorf("fallback.manual_rules_path must be set when fallback.default_mode or any fallback.overrides[].mode is 'manual'")
+			}
+		}
+	}
+	if path == "" {
 		cfg.Manual = nil
 		return nil
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -749,6 +749,9 @@ func loadFallbackConfig(cfg *FallbackConfig) error {
 			if key == "" {
 				return fmt.Errorf("fallback.overrides: model key cannot be empty")
 			}
+			if _, exists := normalized[key]; exists {
+				return fmt.Errorf("fallback.overrides: duplicate model key after trimming: %q", key)
+			}
 			override.Mode = normalizeFallbackMode(override.Mode)
 			if override.Mode == "" {
 				return fmt.Errorf("fallback.overrides[%q].mode must be one of: auto, manual, off", key)
@@ -782,6 +785,9 @@ func loadFallbackConfig(cfg *FallbackConfig) error {
 		key = strings.TrimSpace(key)
 		if key == "" {
 			return fmt.Errorf("fallback.manual_rules_path: model key cannot be empty")
+		}
+		if _, exists := manual[key]; exists {
+			return fmt.Errorf("fallback.manual_rules_path: duplicate manual rule key after trimming: %q", key)
 		}
 		normalized := make([]string, 0, len(models))
 		for _, model := range models {

--- a/config/config.go
+++ b/config/config.go
@@ -739,7 +739,10 @@ func loadFallbackConfig(cfg *FallbackConfig) error {
 				return fmt.Errorf("fallback.overrides: model key cannot be empty")
 			}
 			override.Mode = normalizeFallbackMode(override.Mode)
-			if override.Mode != "" && !override.Mode.Valid() {
+			if override.Mode == "" {
+				return fmt.Errorf("fallback.overrides[%q].mode must be one of: auto, manual, off", key)
+			}
+			if !override.Mode.Valid() {
 				return fmt.Errorf("fallback.overrides[%q].mode must be one of: auto, manual, off", key)
 			}
 			normalized[key] = override

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"math"
 	"os"
 	"reflect"
@@ -785,9 +786,56 @@ func loadFallbackConfig(cfg *FallbackConfig) error {
 		return fmt.Errorf("fallback.manual_rules_path: failed to read %q: %w", path, err)
 	}
 
-	var decoded map[string][]string
-	if err := json.Unmarshal([]byte(expandString(string(raw))), &decoded); err != nil {
+	expanded := expandString(string(raw))
+	decoded := make(map[string][]string)
+	decoder := json.NewDecoder(strings.NewReader(expanded))
+
+	token, err := decoder.Token()
+	if err != nil {
 		return fmt.Errorf("fallback.manual_rules_path: failed to parse %q: %w", path, err)
+	}
+	delim, ok := token.(json.Delim)
+	if !ok || delim != '{' {
+		return fmt.Errorf("fallback.manual_rules_path: failed to parse %q: top-level JSON value must be an object", path)
+	}
+
+	seenKeys := make(map[string]struct{})
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return fmt.Errorf("fallback.manual_rules_path: failed to parse %q: %w", path, err)
+		}
+		key, ok := token.(string)
+		if !ok {
+			return fmt.Errorf("fallback.manual_rules_path: failed to parse %q: object key must be a string", path)
+		}
+		if _, exists := seenKeys[key]; exists {
+			return fmt.Errorf("fallback.manual_rules_path: duplicate JSON key %q in %q", key, path)
+		}
+		seenKeys[key] = struct{}{}
+
+		var models []string
+		if err := decoder.Decode(&models); err != nil {
+			return fmt.Errorf("fallback.manual_rules_path: failed to parse %q: %w", path, err)
+		}
+		decoded[key] = models
+	}
+
+	token, err = decoder.Token()
+	if err != nil {
+		return fmt.Errorf("fallback.manual_rules_path: failed to parse %q: %w", path, err)
+	}
+	delim, ok = token.(json.Delim)
+	if !ok || delim != '}' {
+		return fmt.Errorf("fallback.manual_rules_path: failed to parse %q: top-level JSON value must be an object", path)
+	}
+
+	var trailing json.RawMessage
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err != nil {
+			return fmt.Errorf("fallback.manual_rules_path: failed to parse %q: %w", path, err)
+		}
+		return fmt.Errorf("fallback.manual_rules_path: failed to parse %q: unexpected trailing JSON content", path)
 	}
 
 	manual := make(map[string][]string, len(decoded))

--- a/config/config.go
+++ b/config/config.go
@@ -121,7 +121,7 @@ type FallbackModelOverride struct {
 type FallbackConfig struct {
 	// DefaultMode controls the fallback behavior when no per-model override exists.
 	// Supported values: "auto", "manual", "off". Default: "off".
-	DefaultMode FallbackMode `yaml:"default_mode" env:"FALLBACK_DEFAULT_MODE"`
+	DefaultMode FallbackMode `yaml:"default_mode" env:"FEATURE_FALLBACK_MODE"`
 
 	// ManualRulesPath points to a JSON file that maps source model selectors to
 	// ordered fallback model selector lists. Empty disables manual rules.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -353,6 +353,52 @@ fallback:
 	})
 }
 
+func TestLoad_ManualFallbackModeRequiresManualRulesPath(t *testing.T) {
+	clearAllConfigEnvVars(t)
+
+	withTempDir(t, func(dir string) {
+		yaml := `
+fallback:
+  default_mode: manual
+`
+		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(yaml), 0644); err != nil {
+			t.Fatalf("Failed to write config.yaml: %v", err)
+		}
+
+		_, err := Load()
+		if err == nil {
+			t.Fatal("expected Load() to fail when manual fallback mode has no manual rules path")
+		}
+		if !strings.Contains(err.Error(), "fallback.manual_rules_path must be set") {
+			t.Fatalf("Load() error = %v, want manual rules path validation", err)
+		}
+	})
+}
+
+func TestLoad_ManualFallbackOverrideRequiresManualRulesPath(t *testing.T) {
+	clearAllConfigEnvVars(t)
+
+	withTempDir(t, func(dir string) {
+		yaml := `
+fallback:
+  overrides:
+    "gpt-4o":
+      mode: manual
+`
+		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(yaml), 0644); err != nil {
+			t.Fatalf("Failed to write config.yaml: %v", err)
+		}
+
+		_, err := Load()
+		if err == nil {
+			t.Fatal("expected Load() to fail when manual fallback override has no manual rules path")
+		}
+		if !strings.Contains(err.Error(), "fallback.manual_rules_path must be set") {
+			t.Fatalf("Load() error = %v, want manual rules path validation", err)
+		}
+	})
+}
+
 func TestLoad_FallbackOverrideDuplicateKeyAfterTrim(t *testing.T) {
 	clearAllConfigEnvVars(t)
 
@@ -544,11 +590,11 @@ func TestLoad_ConfigExample_UsesNestedModelCacheSettings(t *testing.T) {
 	}
 
 	withTempDir(t, func(dir string) {
-		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), exampleData, 0644); err != nil {
-			t.Fatalf("Failed to write config.yaml: %v", err)
-		}
 		if err := os.MkdirAll(filepath.Join(dir, "config"), 0755); err != nil {
 			t.Fatalf("Failed to create config directory: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "config", "config.yaml"), exampleData, 0644); err != nil {
+			t.Fatalf("Failed to write config/config.yaml: %v", err)
 		}
 		if err := os.WriteFile(filepath.Join(dir, "config", "fallback.example.json"), fallbackExampleData, 0644); err != nil {
 			t.Fatalf("Failed to write fallback.example.json: %v", err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 // clearProviderEnvVars unsets all known provider-related environment variables.
@@ -265,15 +267,26 @@ func TestLoad_FallbackManualRules(t *testing.T) {
 			t.Fatalf("Failed to write fallback rules: %v", err)
 		}
 
-		yaml := `
-fallback:
-  default_mode: auto
-  manual_rules_path: "` + manualRulesPath + `"
-  overrides:
-    "gpt-4o":
-      mode: manual
-`
-		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(yaml), 0644); err != nil {
+		type yamlConfig struct {
+			Fallback struct {
+				DefaultMode     string                       `yaml:"default_mode"`
+				ManualRulesPath string                       `yaml:"manual_rules_path"`
+				Overrides       map[string]map[string]string `yaml:"overrides"`
+			} `yaml:"fallback"`
+		}
+
+		yamlCfg := yamlConfig{}
+		yamlCfg.Fallback.DefaultMode = "auto"
+		yamlCfg.Fallback.ManualRulesPath = manualRulesPath
+		yamlCfg.Fallback.Overrides = map[string]map[string]string{
+			"gpt-4o": {"mode": "manual"},
+		}
+
+		yamlData, err := yaml.Marshal(yamlCfg)
+		if err != nil {
+			t.Fatalf("Failed to marshal config.yaml: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), yamlData, 0644); err != nil {
 			t.Fatalf("Failed to write config.yaml: %v", err)
 		}
 
@@ -311,6 +324,25 @@ fallback:
 
 		if _, err := Load(); err == nil {
 			t.Fatal("expected Load() to fail for invalid fallback mode")
+		}
+	})
+}
+
+func TestLoad_EmptyFallbackOverrideMode(t *testing.T) {
+	clearAllConfigEnvVars(t)
+
+	withTempDir(t, func(dir string) {
+		yaml := `
+fallback:
+  overrides:
+    "gpt-4o": {}
+`
+		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(yaml), 0644); err != nil {
+			t.Fatalf("Failed to write config.yaml: %v", err)
+		}
+
+		if _, err := Load(); err == nil {
+			t.Fatal("expected Load() to fail for empty fallback override mode")
 		}
 	})
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -348,6 +349,71 @@ fallback:
 
 		if _, err := Load(); err == nil {
 			t.Fatal("expected Load() to fail for empty fallback override mode")
+		}
+	})
+}
+
+func TestLoad_FallbackOverrideDuplicateKeyAfterTrim(t *testing.T) {
+	clearAllConfigEnvVars(t)
+
+	withTempDir(t, func(dir string) {
+		yaml := `
+fallback:
+  overrides:
+    "gpt-4o":
+      mode: manual
+    " gpt-4o ":
+      mode: auto
+`
+		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(yaml), 0644); err != nil {
+			t.Fatalf("Failed to write config.yaml: %v", err)
+		}
+
+		_, err := Load()
+		if err == nil {
+			t.Fatal("expected Load() to fail for duplicate fallback override keys after trimming")
+		}
+		if !strings.Contains(err.Error(), `fallback.overrides: duplicate model key after trimming: "gpt-4o"`) {
+			t.Fatalf("Load() error = %v, want duplicate trimmed override key error", err)
+		}
+	})
+}
+
+func TestLoad_FallbackManualRulesDuplicateKeyAfterTrim(t *testing.T) {
+	clearAllConfigEnvVars(t)
+
+	withTempDir(t, func(dir string) {
+		manualRulesPath := filepath.Join(dir, "fallback.json")
+		if err := os.WriteFile(manualRulesPath, []byte(`{
+			"gpt-4o": ["azure/gpt-4o"],
+			" gpt-4o ": ["gemini/gemini-2.5-pro"]
+		}`), 0644); err != nil {
+			t.Fatalf("Failed to write fallback rules: %v", err)
+		}
+
+		type yamlConfig struct {
+			Fallback struct {
+				ManualRulesPath string `yaml:"manual_rules_path"`
+			} `yaml:"fallback"`
+		}
+
+		yamlCfg := yamlConfig{}
+		yamlCfg.Fallback.ManualRulesPath = manualRulesPath
+		yamlData, err := yaml.Marshal(yamlCfg)
+		if err != nil {
+			t.Fatalf("Failed to marshal config.yaml: %v", err)
+		}
+
+		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), yamlData, 0644); err != nil {
+			t.Fatalf("Failed to write config.yaml: %v", err)
+		}
+
+		_, err = Load()
+		if err == nil {
+			t.Fatal("expected Load() to fail for duplicate fallback manual rule keys after trimming")
+		}
+		if !strings.Contains(err.Error(), `fallback.manual_rules_path: duplicate manual rule key after trimming: "gpt-4o"`) {
+			t.Fatalf("Load() error = %v, want duplicate trimmed manual rule key error", err)
 		}
 	})
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -41,6 +41,7 @@ func clearAllConfigEnvVars(t *testing.T) {
 		"USAGE_ENABLED", "ENFORCE_RETURNING_USAGE_DATA",
 		"USAGE_BUFFER_SIZE", "USAGE_FLUSH_INTERVAL", "USAGE_RETENTION_DAYS",
 		"GUARDRAILS_ENABLED", "ENABLE_GUARDRAILS_FOR_BATCH_PROCESSING",
+		"FALLBACK_DEFAULT_MODE", "FALLBACK_MANUAL_RULES_PATH",
 		"HTTP_TIMEOUT", "HTTP_RESPONSE_HEADER_TIMEOUT",
 	} {
 		t.Setenv(key, "")
@@ -151,6 +152,9 @@ func TestBuildDefaultConfig(t *testing.T) {
 	if cfg.Guardrails.EnableForBatchProcessing {
 		t.Error("expected Guardrails.EnableForBatchProcessing=false")
 	}
+	if cfg.Fallback.DefaultMode != FallbackModeOff {
+		t.Errorf("expected Fallback.DefaultMode=off, got %q", cfg.Fallback.DefaultMode)
+	}
 
 	expectedRetry := DefaultRetryConfig()
 	if cfg.Resilience.Retry != expectedRetry {
@@ -245,6 +249,68 @@ logging:
 		}
 		if cfg.Storage.Type != "sqlite" {
 			t.Errorf("expected Storage.Type=sqlite (default), got %s", cfg.Storage.Type)
+		}
+	})
+}
+
+func TestLoad_FallbackManualRules(t *testing.T) {
+	clearAllConfigEnvVars(t)
+
+	withTempDir(t, func(dir string) {
+		manualRulesPath := filepath.Join(dir, "fallback.json")
+		if err := os.WriteFile(manualRulesPath, []byte(`{
+			"gpt-4o": ["azure/gpt-4o", "gemini/gemini-2.5-pro"],
+			"claude-sonnet-4": ["openai/gpt-5-mini"]
+		}`), 0644); err != nil {
+			t.Fatalf("Failed to write fallback rules: %v", err)
+		}
+
+		yaml := `
+fallback:
+  default_mode: auto
+  manual_rules_path: "` + manualRulesPath + `"
+  overrides:
+    "gpt-4o":
+      mode: manual
+`
+		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(yaml), 0644); err != nil {
+			t.Fatalf("Failed to write config.yaml: %v", err)
+		}
+
+		result, err := Load()
+		if err != nil {
+			t.Fatalf("Load() failed: %v", err)
+		}
+
+		cfg := result.Config
+		if cfg.Fallback.DefaultMode != FallbackModeAuto {
+			t.Fatalf("Fallback.DefaultMode = %q, want %q", cfg.Fallback.DefaultMode, FallbackModeAuto)
+		}
+		if cfg.Fallback.Overrides["gpt-4o"].Mode != FallbackModeManual {
+			t.Fatalf("Fallback.Overrides[gpt-4o].Mode = %q, want %q", cfg.Fallback.Overrides["gpt-4o"].Mode, FallbackModeManual)
+		}
+		got := cfg.Fallback.Manual["gpt-4o"]
+		want := []string{"azure/gpt-4o", "gemini/gemini-2.5-pro"}
+		if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+			t.Fatalf("Fallback.Manual[gpt-4o] = %v, want %v", got, want)
+		}
+	})
+}
+
+func TestLoad_InvalidFallbackMode(t *testing.T) {
+	clearAllConfigEnvVars(t)
+
+	withTempDir(t, func(dir string) {
+		yaml := `
+fallback:
+  default_mode: invalid
+`
+		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(yaml), 0644); err != nil {
+			t.Fatalf("Failed to write config.yaml: %v", err)
+		}
+
+		if _, err := Load(); err == nil {
+			t.Fatal("expected Load() to fail for invalid fallback mode")
 		}
 	})
 }
@@ -350,10 +416,24 @@ func TestLoad_ConfigExample_UsesNestedModelCacheSettings(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to read config.example.yaml: %v", err)
 	}
+	fallbackExamplePath, err := filepath.Abs("fallback.example.json")
+	if err != nil {
+		t.Fatalf("Failed to resolve fallback.example.json path: %v", err)
+	}
+	fallbackExampleData, err := os.ReadFile(fallbackExamplePath)
+	if err != nil {
+		t.Fatalf("Failed to read fallback.example.json: %v", err)
+	}
 
 	withTempDir(t, func(dir string) {
 		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), exampleData, 0644); err != nil {
 			t.Fatalf("Failed to write config.yaml: %v", err)
+		}
+		if err := os.MkdirAll(filepath.Join(dir, "config"), 0755); err != nil {
+			t.Fatalf("Failed to create config directory: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "config", "fallback.example.json"), fallbackExampleData, 0644); err != nil {
+			t.Fatalf("Failed to write fallback.example.json: %v", err)
 		}
 
 		result, err := Load()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -44,7 +44,7 @@ func clearAllConfigEnvVars(t *testing.T) {
 		"USAGE_ENABLED", "ENFORCE_RETURNING_USAGE_DATA",
 		"USAGE_BUFFER_SIZE", "USAGE_FLUSH_INTERVAL", "USAGE_RETENTION_DAYS",
 		"GUARDRAILS_ENABLED", "ENABLE_GUARDRAILS_FOR_BATCH_PROCESSING",
-		"FALLBACK_DEFAULT_MODE", "FALLBACK_MANUAL_RULES_PATH",
+		"FEATURE_FALLBACK_MODE", "FALLBACK_MANUAL_RULES_PATH",
 		"HTTP_TIMEOUT", "HTTP_RESPONSE_HEADER_TIMEOUT",
 		"EXECUTION_PLAN_REFRESH_INTERVAL",
 	} {
@@ -348,6 +348,21 @@ fallback:
 
 		if _, err := Load(); err == nil {
 			t.Fatal("expected Load() to fail for empty fallback override mode")
+		}
+	})
+}
+
+func TestLoad_FeatureFallbackModeEnvOverridesFallbackDefaultMode(t *testing.T) {
+	clearAllConfigEnvVars(t)
+	t.Setenv("FEATURE_FALLBACK_MODE", "auto")
+
+	withTempDir(t, func(_ string) {
+		result, err := Load()
+		if err != nil {
+			t.Fatalf("Load() failed: %v", err)
+		}
+		if result.Config.Fallback.DefaultMode != FallbackModeAuto {
+			t.Fatalf("Fallback.DefaultMode = %q, want %q", result.Config.Fallback.DefaultMode, FallbackModeAuto)
 		}
 	})
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -464,6 +464,45 @@ func TestLoad_FallbackManualRulesDuplicateKeyAfterTrim(t *testing.T) {
 	})
 }
 
+func TestLoad_FallbackManualRulesRejectsDuplicateRawJSONKeys(t *testing.T) {
+	clearAllConfigEnvVars(t)
+
+	withTempDir(t, func(dir string) {
+		manualRulesPath := filepath.Join(dir, "fallback.json")
+		if err := os.WriteFile(manualRulesPath, []byte(`{
+			"gpt-4o": ["azure/gpt-4o"],
+			"gpt-4o": ["gemini/gemini-2.5-pro"]
+		}`), 0644); err != nil {
+			t.Fatalf("Failed to write fallback rules: %v", err)
+		}
+
+		type yamlConfig struct {
+			Fallback struct {
+				ManualRulesPath string `yaml:"manual_rules_path"`
+			} `yaml:"fallback"`
+		}
+
+		yamlCfg := yamlConfig{}
+		yamlCfg.Fallback.ManualRulesPath = manualRulesPath
+		yamlData, err := yaml.Marshal(yamlCfg)
+		if err != nil {
+			t.Fatalf("Failed to marshal config.yaml: %v", err)
+		}
+
+		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), yamlData, 0644); err != nil {
+			t.Fatalf("Failed to write config.yaml: %v", err)
+		}
+
+		_, err = Load()
+		if err == nil {
+			t.Fatal("expected Load() to fail for duplicate raw JSON keys in fallback manual rules")
+		}
+		if !strings.Contains(err.Error(), `fallback.manual_rules_path: duplicate JSON key "gpt-4o"`) {
+			t.Fatalf("Load() error = %v, want duplicate raw JSON key error", err)
+		}
+	})
+}
+
 func TestLoad_FeatureFallbackModeEnvOverridesFallbackDefaultMode(t *testing.T) {
 	clearAllConfigEnvVars(t)
 	t.Setenv("FEATURE_FALLBACK_MODE", "auto")

--- a/config/failover.yaml
+++ b/config/failover.yaml
@@ -1,2 +1,0 @@
-#failover:
-#  "gpt-5": [gemini-1.5-pro, gemini2.5-pro]

--- a/config/fallback.example.json
+++ b/config/fallback.example.json
@@ -1,0 +1,10 @@
+{
+  "gpt-4o": [
+    "azure/gpt-4o",
+    "gemini/gemini-2.5-pro"
+  ],
+  "claude-sonnet-4": [
+    "openai/gpt-5-mini",
+    "gemini/gemini-2.5-pro"
+  ]
+}

--- a/config/fallback.yaml
+++ b/config/fallback.yaml
@@ -1,8 +1,0 @@
-fallback:
-  default_mode: auto
-  manual_rules_path: "config/fallback.example.json"
-  overrides:
-    "gpt-4o":
-      mode: manual
-    "claude-sonnet-4":
-      mode: off

--- a/config/fallback.yaml
+++ b/config/fallback.yaml
@@ -1,0 +1,8 @@
+fallback:
+  default_mode: auto
+  manual_rules_path: "config/fallback.example.json"
+  overrides:
+    "gpt-4o":
+      mode: manual
+    "claude-sonnet-4":
+      mode: off

--- a/docs/adr/0004-capability-model-and-provider-attempts.md
+++ b/docs/adr/0004-capability-model-and-provider-attempts.md
@@ -6,7 +6,7 @@ Not every route or provider interaction can safely support the same gateway feat
 
 Examples:
 
-- `/v1/chat/completions` can usually support aliases, guardrails, and failover
+- `/v1/chat/completions` can usually support aliases, guardrails, and fallback
 - `/v1/responses` can usually support similar features
 - `/p/openai/responses` may support partial semantic extraction and selected policies
 - `/p/{provider}/{unknown-endpoint}` may support only authentication, auditing, and raw pass-through
@@ -14,7 +14,7 @@ Examples:
 The gateway also needs a clean execution model for:
 
 - retries
-- failover
+- fallback
 - translated provider calls
 - raw pass-through calls
 - future async media jobs and result artifacts
@@ -36,7 +36,7 @@ Examples include:
 
 - semantic extraction supported
 - guardrails supported
-- failover supported
+- fallback supported
 - alias resolution supported
 - request patching supported
 - usage extraction supported
@@ -52,7 +52,7 @@ A single request may produce one or more attempts:
 
 - one translated call to the primary provider
 - a retried call
-- a failover call to an alternate provider
+- a fallback call to an alternate provider
 - a raw pass-through call
 
 For async or media-oriented providers, an attempt may also produce:
@@ -66,7 +66,7 @@ For async or media-oriented providers, an attempt may also produce:
 ### Positive
 
 - **Safer feature gating**: The gateway will not try to apply unsupported features to opaque or provider-native routes
-- **Cleaner failover model**: Alternate calls become explicit attempts rather than hidden control flow
+- **Cleaner fallback model**: Alternate calls become explicit attempts rather than hidden control flow
 - **Better observability**: Audit logs and debugging can show which upstream attempts were made
 - **Media and async ready**: Video, audio, and task-based provider APIs fit naturally into an attempt-oriented execution model
 - **Clearer provider boundaries**: Capability declarations make route behavior predictable

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -17,6 +17,7 @@ import (
 	"gomodel/internal/auditlog"
 	"gomodel/internal/batch"
 	"gomodel/internal/core"
+	"gomodel/internal/fallback"
 	"gomodel/internal/guardrails"
 	"gomodel/internal/providers"
 	"gomodel/internal/responsecache"
@@ -208,6 +209,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		UsageLogger:                  usageResult.Logger,
 		PricingResolver:              providerResult.Registry,
 		ModelResolver:                app.aliases.Service,
+		FallbackResolver:             fallback.NewResolver(appCfg.Fallback, providerResult.Registry),
 		TranslatedRequestPatcher:     translatedRequestPatcher,
 		GuardrailsHash:               guardrailsHash,
 		BatchRequestPreparer:         batchRequestPreparer,

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -665,6 +666,7 @@ func effectiveSystemPromptMode(mode string) string {
 }
 
 func defaultExecutionPlanInput(cfg *config.Config) executionplans.CreateInput {
+	fallbackEnabled := fallbackFeatureEnabledGlobally(cfg)
 	payload := executionplans.Payload{
 		SchemaVersion: 1,
 		Features: executionplans.FeatureFlags{
@@ -672,6 +674,7 @@ func defaultExecutionPlanInput(cfg *config.Config) executionplans.CreateInput {
 			Audit:      cfg.Logging.Enabled,
 			Usage:      cfg.Usage.Enabled,
 			Guardrails: cfg.Guardrails.Enabled && len(cfg.Guardrails.Rules) > 0,
+			Fallback:   &fallbackEnabled,
 		},
 	}
 	if payload.Features.Guardrails {
@@ -702,6 +705,7 @@ func runtimeExecutionFeatureCaps(cfg *config.Config) core.ExecutionFeatures {
 		Audit:      cfg.Logging.Enabled,
 		Usage:      cfg.Usage.Enabled,
 		Guardrails: cfg.Guardrails.Enabled,
+		Fallback:   fallbackFeatureEnabledGlobally(cfg),
 	}
 }
 
@@ -714,6 +718,30 @@ func executionPlanRefreshInterval(cfg *config.Config) time.Duration {
 
 func responseCacheConfigured(cfg config.ResponseCacheConfig) bool {
 	return (cfg.Simple.Redis != nil && cfg.Simple.Redis.URL != "") || config.SemanticCacheActive(&cfg.Semantic)
+}
+
+func fallbackFeatureEnabledGlobally(cfg *config.Config) bool {
+	if cfg == nil {
+		return false
+	}
+	if fallbackModeEnabled(cfg.Fallback.DefaultMode) {
+		return true
+	}
+	for _, override := range cfg.Fallback.Overrides {
+		if fallbackModeEnabled(override.Mode) {
+			return true
+		}
+	}
+	return false
+}
+
+func fallbackModeEnabled(mode config.FallbackMode) bool {
+	switch strings.ToLower(strings.TrimSpace(string(mode))) {
+	case string(config.FallbackModeAuto), string(config.FallbackModeManual):
+		return true
+	default:
+		return false
+	}
 }
 
 func firstSharedStorage(candidates ...storage.Storage) storage.Storage {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,0 +1,39 @@
+package app
+
+import (
+	"testing"
+
+	"gomodel/config"
+)
+
+func TestRuntimeExecutionFeatureCaps_EnableFallbackFromOverride(t *testing.T) {
+	cfg := &config.Config{
+		Fallback: config.FallbackConfig{
+			DefaultMode: config.FallbackModeOff,
+			Overrides: map[string]config.FallbackModelOverride{
+				"gpt-4o": {Mode: config.FallbackModeManual},
+			},
+		},
+	}
+
+	caps := runtimeExecutionFeatureCaps(cfg)
+	if !caps.Fallback {
+		t.Fatal("runtimeExecutionFeatureCaps().Fallback = false, want true")
+	}
+}
+
+func TestDefaultExecutionPlanInput_SetsFallbackFeature(t *testing.T) {
+	cfg := &config.Config{
+		Fallback: config.FallbackConfig{
+			DefaultMode: config.FallbackModeAuto,
+		},
+	}
+
+	input := defaultExecutionPlanInput(cfg)
+	if input.Payload.Features.Fallback == nil {
+		t.Fatal("defaultExecutionPlanInput().Payload.Features.Fallback = nil, want non-nil")
+	}
+	if !*input.Payload.Features.Fallback {
+		t.Fatal("defaultExecutionPlanInput().Payload.Features.Fallback = false, want true")
+	}
+}

--- a/internal/core/context.go
+++ b/internal/core/context.go
@@ -25,6 +25,12 @@ const (
 	// for the current request. Set by the translated inference handlers after
 	// PatchChatRequest; consumed by the semantic cache to build params_hash.
 	guardrailsHashKey contextKey = "guardrails-hash"
+
+	// fallbackUsedKey stores whether the translated execution path successfully
+	// served the request from a fallback model rather than the primary selector.
+	// Response cache writers use this to avoid storing fallback responses under
+	// the primary request key.
+	fallbackUsedKey contextKey = "fallback-used"
 )
 
 // WithRequestID returns a new context with the request ID attached.
@@ -135,4 +141,19 @@ func GetGuardrailsHash(ctx context.Context) string {
 		}
 	}
 	return ""
+}
+
+// WithFallbackUsed returns a new context marked as having used a fallback model.
+func WithFallbackUsed(ctx context.Context) context.Context {
+	return context.WithValue(ctx, fallbackUsedKey, true)
+}
+
+// GetFallbackUsed reports whether the request was served by a fallback model.
+func GetFallbackUsed(ctx context.Context) bool {
+	if v := ctx.Value(fallbackUsedKey); v != nil {
+		if used, ok := v.(bool); ok {
+			return used
+		}
+	}
+	return false
 }

--- a/internal/core/execution_plan.go
+++ b/internal/core/execution_plan.go
@@ -89,6 +89,7 @@ type ExecutionFeatures struct {
 	Audit      bool
 	Usage      bool
 	Guardrails bool
+	Fallback   bool
 }
 
 // ApplyUpperBound returns features with process-level caps applied.
@@ -98,6 +99,7 @@ func (f ExecutionFeatures) ApplyUpperBound(caps ExecutionFeatures) ExecutionFeat
 		Audit:      f.Audit && caps.Audit,
 		Usage:      f.Usage && caps.Usage,
 		Guardrails: f.Guardrails && caps.Guardrails,
+		Fallback:   f.Fallback && caps.Fallback,
 	}
 }
 
@@ -109,6 +111,7 @@ func DefaultExecutionFeatures() ExecutionFeatures {
 		Audit:      true,
 		Usage:      true,
 		Guardrails: true,
+		Fallback:   true,
 	}
 }
 
@@ -181,6 +184,11 @@ func (p *ExecutionPlan) UsageEnabled() bool {
 // GuardrailsEnabled reports whether guardrail processing is enabled for the request.
 func (p *ExecutionPlan) GuardrailsEnabled() bool {
 	return p.featureEnabled(func(features ExecutionFeatures) bool { return features.Guardrails })
+}
+
+// FallbackEnabled reports whether translated-route fallback is enabled for the request.
+func (p *ExecutionPlan) FallbackEnabled() bool {
+	return p.featureEnabled(func(features ExecutionFeatures) bool { return features.Fallback })
 }
 
 // GuardrailsHash returns the matched plan's guardrails hash.

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -152,16 +152,24 @@ type Model struct {
 
 // ModelMetadata holds enriched metadata from the external model registry.
 type ModelMetadata struct {
-	DisplayName     string          `json:"display_name,omitempty"`
-	Description     string          `json:"description,omitempty"`
-	Family          string          `json:"family,omitempty"`
-	Modes           []string        `json:"modes,omitempty"`
-	Categories      []ModelCategory `json:"categories,omitempty"`
-	Tags            []string        `json:"tags,omitempty"`
-	ContextWindow   *int            `json:"context_window,omitempty"`
-	MaxOutputTokens *int            `json:"max_output_tokens,omitempty"`
-	Capabilities    map[string]bool `json:"capabilities,omitempty"`
-	Pricing         *ModelPricing   `json:"pricing,omitempty"`
+	DisplayName     string                  `json:"display_name,omitempty"`
+	Description     string                  `json:"description,omitempty"`
+	Family          string                  `json:"family,omitempty"`
+	Modes           []string                `json:"modes,omitempty"`
+	Categories      []ModelCategory         `json:"categories,omitempty"`
+	Tags            []string                `json:"tags,omitempty"`
+	ContextWindow   *int                    `json:"context_window,omitempty"`
+	MaxOutputTokens *int                    `json:"max_output_tokens,omitempty"`
+	Capabilities    map[string]bool         `json:"capabilities,omitempty"`
+	Rankings        map[string]ModelRanking `json:"rankings,omitempty"`
+	Pricing         *ModelPricing           `json:"pricing,omitempty"`
+}
+
+// ModelRanking holds one benchmark or leaderboard entry for a model.
+type ModelRanking struct {
+	Elo  *float64 `json:"elo,omitempty"`
+	Rank *int     `json:"rank,omitempty"`
+	AsOf string   `json:"as_of,omitempty"`
 }
 
 // ModelCategory represents a model's functional category for UI grouping.

--- a/internal/executionplans/compiler.go
+++ b/internal/executionplans/compiler.go
@@ -27,7 +27,7 @@ func NewCompilerWithFeatureCaps(registry *guardrails.Registry, featureCaps core.
 }
 
 func (c *compiler) Compile(version Version) (*CompiledPlan, error) {
-	features := core.ExecutionFeatures(version.Payload.Features).ApplyUpperBound(c.featureCaps)
+	features := version.Payload.Features.runtimeFeatures().ApplyUpperBound(c.featureCaps)
 	policy := &core.ResolvedExecutionPolicy{
 		VersionID:      version.ID,
 		Version:        version.Version,

--- a/internal/executionplans/compiler_test.go
+++ b/internal/executionplans/compiler_test.go
@@ -56,11 +56,13 @@ func TestCompilerCompile_Guardrails(t *testing.T) {
 }
 
 func TestCompilerCompile_AppliesProcessFeatureCaps(t *testing.T) {
+	fallbackEnabled := true
 	compiled, err := NewCompilerWithFeatureCaps(nil, core.ExecutionFeatures{
 		Cache:      false,
 		Audit:      true,
 		Usage:      false,
 		Guardrails: false,
+		Fallback:   false,
 	}).Compile(Version{
 		ID:      "plan-1",
 		Scope:   Scope{},
@@ -68,7 +70,7 @@ func TestCompilerCompile_AppliesProcessFeatureCaps(t *testing.T) {
 		Name:    "global",
 		Payload: Payload{
 			SchemaVersion: 1,
-			Features:      FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: true},
+			Features:      FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: true, Fallback: &fallbackEnabled},
 			Guardrails: []GuardrailStep{
 				{Ref: "policy-system", Step: 10},
 			},
@@ -92,10 +94,40 @@ func TestCompilerCompile_AppliesProcessFeatureCaps(t *testing.T) {
 	if compiled.Policy.Features.Guardrails {
 		t.Fatal("Policy.Features.Guardrails = true, want false")
 	}
+	if compiled.Policy.Features.Fallback {
+		t.Fatal("Policy.Features.Fallback = true, want false")
+	}
 	if compiled.Pipeline != nil {
 		t.Fatal("compiled pipeline is not nil")
 	}
 	if compiled.Policy.GuardrailsHash != "" {
 		t.Fatalf("compiled guardrails hash = %q, want empty", compiled.Policy.GuardrailsHash)
+	}
+}
+
+func TestCompilerCompile_DefaultsFallbackEnabledWhenUnset(t *testing.T) {
+	compiled, err := NewCompilerWithFeatureCaps(nil, core.DefaultExecutionFeatures()).Compile(Version{
+		ID:      "plan-1",
+		Scope:   Scope{},
+		Version: 1,
+		Name:    "global",
+		Payload: Payload{
+			SchemaVersion: 1,
+			Features: FeatureFlags{
+				Cache:      true,
+				Audit:      true,
+				Usage:      true,
+				Guardrails: false,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Compile() error = %v", err)
+	}
+	if compiled == nil || compiled.Policy == nil {
+		t.Fatal("Compile() returned nil policy")
+	}
+	if !compiled.Policy.Features.Fallback {
+		t.Fatal("Policy.Features.Fallback = false, want true")
 	}
 }

--- a/internal/executionplans/types.go
+++ b/internal/executionplans/types.go
@@ -35,7 +35,17 @@ type FeatureFlags struct {
 	Fallback   *bool `json:"fallback,omitempty" bson:"fallback,omitempty"`
 }
 
+func (f FeatureFlags) canonicalize() FeatureFlags {
+	if f.Fallback != nil {
+		return f
+	}
+	fallbackEnabled := true
+	f.Fallback = &fallbackEnabled
+	return f
+}
+
 func (f FeatureFlags) runtimeFeatures() core.ExecutionFeatures {
+	f = f.canonicalize()
 	fallback := true
 	if f.Fallback != nil {
 		fallback = *f.Fallback
@@ -108,6 +118,7 @@ func normalizePayload(payload Payload) (Payload, string, error) {
 	if payload.SchemaVersion != currentSchemaVersion {
 		return Payload{}, "", newValidationError("unsupported schema_version", nil)
 	}
+	payload.Features = payload.Features.canonicalize()
 
 	type indexedGuardrail struct {
 		step  GuardrailStep

--- a/internal/executionplans/types.go
+++ b/internal/executionplans/types.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"gomodel/internal/core"
 )
 
 const currentSchemaVersion = 1
@@ -26,10 +28,25 @@ type Payload struct {
 
 // FeatureFlags configures gateway-owned behaviors for a request.
 type FeatureFlags struct {
-	Cache      bool `json:"cache" bson:"cache"`
-	Audit      bool `json:"audit" bson:"audit"`
-	Usage      bool `json:"usage" bson:"usage"`
-	Guardrails bool `json:"guardrails" bson:"guardrails"`
+	Cache      bool  `json:"cache" bson:"cache"`
+	Audit      bool  `json:"audit" bson:"audit"`
+	Usage      bool  `json:"usage" bson:"usage"`
+	Guardrails bool  `json:"guardrails" bson:"guardrails"`
+	Fallback   *bool `json:"fallback,omitempty" bson:"fallback,omitempty"`
+}
+
+func (f FeatureFlags) runtimeFeatures() core.ExecutionFeatures {
+	fallback := true
+	if f.Fallback != nil {
+		fallback = *f.Fallback
+	}
+	return core.ExecutionFeatures{
+		Cache:      f.Cache,
+		Audit:      f.Audit,
+		Usage:      f.Usage,
+		Guardrails: f.Guardrails,
+		Fallback:   fallback,
+	}
 }
 
 // GuardrailStep references one named guardrail and its execution step.

--- a/internal/executionplans/types_test.go
+++ b/internal/executionplans/types_test.go
@@ -38,3 +38,44 @@ func TestFeatureFlagsRuntimeFeatures_FallbackDefaultsToTrue(t *testing.T) {
 		t.Fatal("runtimeFeatures().Fallback = false, want true")
 	}
 }
+
+func TestNormalizePayload_CanonicalizesFallbackForStablePlanHash(t *testing.T) {
+	explicitTrue := true
+
+	implicitPayload, implicitHash, err := normalizePayload(Payload{
+		SchemaVersion: 1,
+		Features: FeatureFlags{
+			Cache:      true,
+			Audit:      true,
+			Usage:      true,
+			Guardrails: false,
+		},
+	})
+	if err != nil {
+		t.Fatalf("normalizePayload() error = %v", err)
+	}
+
+	explicitPayload, explicitHash, err := normalizePayload(Payload{
+		SchemaVersion: 1,
+		Features: FeatureFlags{
+			Cache:      true,
+			Audit:      true,
+			Usage:      true,
+			Guardrails: false,
+			Fallback:   &explicitTrue,
+		},
+	})
+	if err != nil {
+		t.Fatalf("normalizePayload() error = %v", err)
+	}
+
+	if implicitPayload.Features.Fallback == nil || !*implicitPayload.Features.Fallback {
+		t.Fatalf("implicit payload fallback = %v, want explicit true", implicitPayload.Features.Fallback)
+	}
+	if explicitPayload.Features.Fallback == nil || !*explicitPayload.Features.Fallback {
+		t.Fatalf("explicit payload fallback = %v, want explicit true", explicitPayload.Features.Fallback)
+	}
+	if implicitHash != explicitHash {
+		t.Fatalf("plan hash mismatch: implicit=%q explicit=%q", implicitHash, explicitHash)
+	}
+}

--- a/internal/executionplans/types_test.go
+++ b/internal/executionplans/types_test.go
@@ -25,3 +25,16 @@ func TestNormalizeScope_RejectsColonDelimitedFields(t *testing.T) {
 		})
 	}
 }
+
+func TestFeatureFlagsRuntimeFeatures_FallbackDefaultsToTrue(t *testing.T) {
+	features := FeatureFlags{
+		Cache:      true,
+		Audit:      true,
+		Usage:      true,
+		Guardrails: false,
+	}.runtimeFeatures()
+
+	if !features.Fallback {
+		t.Fatal("runtimeFeatures().Fallback = false, want true")
+	}
+}

--- a/internal/fallback/resolver.go
+++ b/internal/fallback/resolver.go
@@ -1,0 +1,416 @@
+package fallback
+
+import (
+	"math"
+	"sort"
+	"strings"
+
+	"gomodel/config"
+	"gomodel/internal/core"
+	"gomodel/internal/providers"
+)
+
+const maxAutoFallbackCandidates = 5
+
+var preferredRankingNames = []string{
+	"chatbot_arena",
+	"chatbot_arena_coding",
+	"chatbot_arena_math",
+	"chatbot_arena_creative_writing",
+	"chatbot_arena_vision",
+}
+
+// Registry is the minimal provider inventory surface needed for fallback
+// candidate resolution.
+type Registry interface {
+	GetModel(model string) *providers.ModelInfo
+	ListModelsWithProvider() []providers.ModelWithProvider
+}
+
+// Resolver computes fallback model chains for translated routes.
+type Resolver struct {
+	defaultMode config.FallbackMode
+	manual      map[string][]string
+	overrides   map[string]config.FallbackModelOverride
+	registry    Registry
+}
+
+// NewResolver builds a fallback resolver from config and the current model
+// inventory. Returns nil when fallback is effectively disabled.
+func NewResolver(cfg config.FallbackConfig, registry Registry) *Resolver {
+	if registry == nil {
+		return nil
+	}
+
+	mode := cfg.DefaultMode
+	if mode == "" {
+		mode = config.FallbackModeOff
+	}
+	if mode == config.FallbackModeOff && len(cfg.Manual) == 0 && len(cfg.Overrides) == 0 {
+		return nil
+	}
+
+	manual := make(map[string][]string, len(cfg.Manual))
+	for key, models := range cfg.Manual {
+		copyModels := append([]string(nil), models...)
+		manual[key] = copyModels
+	}
+
+	overrides := make(map[string]config.FallbackModelOverride, len(cfg.Overrides))
+	for key, override := range cfg.Overrides {
+		overrides[key] = override
+	}
+
+	return &Resolver{
+		defaultMode: mode,
+		manual:      manual,
+		overrides:   overrides,
+		registry:    registry,
+	}
+}
+
+// ResolveFallbacks returns the ordered fallback chain for a resolved request.
+// Manual fallbacks preserve configured order; auto candidates are appended after
+// manual candidates when the effective mode is "auto".
+func (r *Resolver) ResolveFallbacks(resolution *core.RequestModelResolution, op core.Operation) []core.ModelSelector {
+	if r == nil || resolution == nil || r.registry == nil {
+		return nil
+	}
+
+	source := r.sourceModelInfo(resolution)
+	mode := r.modeFor(resolution, source)
+	if mode == config.FallbackModeOff {
+		return nil
+	}
+
+	sourceKey := r.sourceKey(resolution, source)
+	seen := make(map[string]struct{})
+
+	result := r.manualSelectorsFor(resolution, source, sourceKey, seen)
+	if mode != config.FallbackModeAuto {
+		return result
+	}
+
+	requiredCategory := requiredCategoryForOperation(op)
+	return append(result, r.autoSelectorsFor(source, sourceKey, requiredCategory, seen)...)
+}
+
+func (r *Resolver) sourceModelInfo(resolution *core.RequestModelResolution) *providers.ModelInfo {
+	if resolution == nil || r.registry == nil {
+		return nil
+	}
+
+	keys := []string{
+		resolution.ResolvedQualifiedModel(),
+		resolution.ResolvedSelector.Model,
+		resolution.RequestedQualifiedModel(),
+		resolution.Requested.Model,
+	}
+	for _, key := range keys {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		if info := r.registry.GetModel(key); info != nil {
+			return info
+		}
+	}
+	return nil
+}
+
+func (r *Resolver) modeFor(resolution *core.RequestModelResolution, source *providers.ModelInfo) config.FallbackMode {
+	mode := r.defaultMode
+	for _, key := range r.matchKeys(resolution, source) {
+		override, ok := r.overrides[key]
+		if !ok || override.Mode == "" {
+			continue
+		}
+		return override.Mode
+	}
+	return mode
+}
+
+func (r *Resolver) manualSelectorsFor(
+	resolution *core.RequestModelResolution,
+	source *providers.ModelInfo,
+	sourceKey string,
+	seen map[string]struct{},
+) []core.ModelSelector {
+	for _, key := range r.matchKeys(resolution, source) {
+		models, ok := r.manual[key]
+		if !ok {
+			continue
+		}
+		result := make([]core.ModelSelector, 0, len(models))
+		for _, model := range models {
+			selector, candidateKey, ok := r.resolveSelector(model)
+			if !ok || candidateKey == sourceKey {
+				continue
+			}
+			if _, exists := seen[candidateKey]; exists {
+				continue
+			}
+			seen[candidateKey] = struct{}{}
+			result = append(result, selector)
+		}
+		return result
+	}
+	return nil
+}
+
+func (r *Resolver) autoSelectorsFor(
+	source *providers.ModelInfo,
+	sourceKey string,
+	requiredCategory core.ModelCategory,
+	seen map[string]struct{},
+) []core.ModelSelector {
+	if source == nil || source.Model.Metadata == nil {
+		return nil
+	}
+
+	sourceRankingName, sourceRanking, ok := preferredRanking(source.Model.Metadata.Rankings)
+	if !ok {
+		return nil
+	}
+
+	type scoredCandidate struct {
+		selector          core.ModelSelector
+		key               string
+		sameModelID       bool
+		sameFamily        bool
+		scoreDiff         float64
+		hasScoreDiff      bool
+		rankDiff          int
+		hasRankDiff       bool
+		capabilityOverlap int
+	}
+
+	sourceMeta := source.Model.Metadata
+	candidates := make([]scoredCandidate, 0)
+	for _, candidate := range r.registry.ListModelsWithProvider() {
+		key := strings.TrimSpace(candidate.Selector)
+		if key == "" || key == sourceKey {
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+
+		meta := candidate.Model.Metadata
+		if meta == nil {
+			continue
+		}
+		if !supportsCategory(meta, requiredCategory) {
+			continue
+		}
+
+		candidateRanking, ok := rankingByName(meta.Rankings, sourceRankingName)
+		if !ok {
+			continue
+		}
+
+		entry := scoredCandidate{
+			selector: core.ModelSelector{
+				Model:    candidate.Model.ID,
+				Provider: candidate.ProviderName,
+			},
+			key:               key,
+			sameModelID:       candidate.Model.ID == source.Model.ID,
+			sameFamily:        sameFamily(sourceMeta, meta),
+			capabilityOverlap: capabilityOverlap(sourceMeta.Capabilities, meta.Capabilities),
+		}
+		if sourceRanking.Elo != nil && candidateRanking.Elo != nil {
+			entry.hasScoreDiff = true
+			entry.scoreDiff = math.Abs(*candidateRanking.Elo - *sourceRanking.Elo)
+		}
+		if sourceRanking.Rank != nil && candidateRanking.Rank != nil {
+			entry.hasRankDiff = true
+			entry.rankDiff = absInt(*candidateRanking.Rank - *sourceRanking.Rank)
+		}
+		candidates = append(candidates, entry)
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		a := candidates[i]
+		b := candidates[j]
+		if a.sameModelID != b.sameModelID {
+			return a.sameModelID
+		}
+		if a.sameFamily != b.sameFamily {
+			return a.sameFamily
+		}
+		if a.hasScoreDiff != b.hasScoreDiff {
+			return a.hasScoreDiff
+		}
+		if a.hasScoreDiff && a.scoreDiff != b.scoreDiff {
+			return a.scoreDiff < b.scoreDiff
+		}
+		if a.hasRankDiff != b.hasRankDiff {
+			return a.hasRankDiff
+		}
+		if a.hasRankDiff && a.rankDiff != b.rankDiff {
+			return a.rankDiff < b.rankDiff
+		}
+		if a.capabilityOverlap != b.capabilityOverlap {
+			return a.capabilityOverlap > b.capabilityOverlap
+		}
+		return a.key < b.key
+	})
+
+	limit := maxAutoFallbackCandidates
+	if len(candidates) < limit {
+		limit = len(candidates)
+	}
+
+	result := make([]core.ModelSelector, 0, limit)
+	for i := 0; i < limit; i++ {
+		seen[candidates[i].key] = struct{}{}
+		result = append(result, candidates[i].selector)
+	}
+	return result
+}
+
+func (r *Resolver) resolveSelector(model string) (core.ModelSelector, string, bool) {
+	model = strings.TrimSpace(model)
+	if model == "" || r.registry == nil {
+		return core.ModelSelector{}, "", false
+	}
+
+	info := r.registry.GetModel(model)
+	if info == nil {
+		return core.ModelSelector{}, "", false
+	}
+
+	selector := core.ModelSelector{
+		Model:    info.Model.ID,
+		Provider: info.ProviderName,
+	}
+	return selector, selector.QualifiedModel(), true
+}
+
+func (r *Resolver) sourceKey(resolution *core.RequestModelResolution, source *providers.ModelInfo) string {
+	if source != nil && source.ProviderName != "" && source.Model.ID != "" {
+		return source.ProviderName + "/" + source.Model.ID
+	}
+	return strings.TrimSpace(resolution.ResolvedQualifiedModel())
+}
+
+func (r *Resolver) matchKeys(resolution *core.RequestModelResolution, source *providers.ModelInfo) []string {
+	keys := []string{
+		resolution.RequestedQualifiedModel(),
+		resolution.Requested.Model,
+	}
+	if source != nil && source.ProviderName != "" && source.Model.ID != "" {
+		keys = append(keys, source.ProviderName+"/"+source.Model.ID)
+	}
+	keys = append(keys,
+		resolution.ResolvedQualifiedModel(),
+		resolution.ResolvedSelector.Model,
+	)
+
+	seen := make(map[string]struct{}, len(keys))
+	result := make([]string, 0, len(keys))
+	for _, key := range keys {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, key)
+	}
+	return result
+}
+
+func requiredCategoryForOperation(op core.Operation) core.ModelCategory {
+	switch op {
+	case core.OperationChatCompletions, core.OperationResponses:
+		return core.CategoryTextGeneration
+	case core.OperationEmbeddings:
+		return core.CategoryEmbedding
+	default:
+		return ""
+	}
+}
+
+func supportsCategory(meta *core.ModelMetadata, required core.ModelCategory) bool {
+	if meta == nil {
+		return false
+	}
+	if required == "" {
+		return true
+	}
+	for _, category := range meta.Categories {
+		if category == required {
+			return true
+		}
+	}
+	return false
+}
+
+func preferredRanking(rankings map[string]core.ModelRanking) (string, core.ModelRanking, bool) {
+	if len(rankings) == 0 {
+		return "", core.ModelRanking{}, false
+	}
+	for _, name := range preferredRankingNames {
+		if ranking, ok := rankingByName(rankings, name); ok {
+			return name, ranking, true
+		}
+	}
+
+	keys := make([]string, 0, len(rankings))
+	for name := range rankings {
+		keys = append(keys, name)
+	}
+	sort.Strings(keys)
+	for _, name := range keys {
+		if ranking, ok := rankingByName(rankings, name); ok {
+			return name, ranking, true
+		}
+	}
+	return "", core.ModelRanking{}, false
+}
+
+func rankingByName(rankings map[string]core.ModelRanking, name string) (core.ModelRanking, bool) {
+	ranking, ok := rankings[name]
+	if !ok {
+		return core.ModelRanking{}, false
+	}
+	if ranking.Elo == nil && ranking.Rank == nil {
+		return core.ModelRanking{}, false
+	}
+	return ranking, true
+}
+
+func sameFamily(source, candidate *core.ModelMetadata) bool {
+	if source == nil || candidate == nil {
+		return false
+	}
+	if strings.TrimSpace(source.Family) == "" || strings.TrimSpace(candidate.Family) == "" {
+		return false
+	}
+	return source.Family == candidate.Family
+}
+
+func capabilityOverlap(source, candidate map[string]bool) int {
+	if len(source) == 0 || len(candidate) == 0 {
+		return 0
+	}
+	overlap := 0
+	for key, enabled := range source {
+		if !enabled || !candidate[key] {
+			continue
+		}
+		overlap++
+	}
+	return overlap
+}
+
+func absInt(value int) int {
+	if value < 0 {
+		return -value
+	}
+	return value
+}

--- a/internal/fallback/resolver.go
+++ b/internal/fallback/resolver.go
@@ -77,6 +77,11 @@ func (r *Resolver) ResolveFallbacks(resolution *core.RequestModelResolution, op 
 		return nil
 	}
 
+	requiredCategory := requiredCategoryForOperation(op)
+	if requiredCategory == core.CategoryEmbedding {
+		return nil
+	}
+
 	source := r.sourceModelInfo(resolution)
 	mode := r.modeFor(resolution, source)
 	if mode == config.FallbackModeOff {
@@ -91,7 +96,6 @@ func (r *Resolver) ResolveFallbacks(resolution *core.RequestModelResolution, op 
 		return result
 	}
 
-	requiredCategory := requiredCategoryForOperation(op)
 	return append(result, r.autoSelectorsFor(source, sourceKey, requiredCategory, seen)...)
 }
 
@@ -296,16 +300,24 @@ func (r *Resolver) sourceKey(resolution *core.RequestModelResolution, source *pr
 }
 
 func (r *Resolver) matchKeys(resolution *core.RequestModelResolution, source *providers.ModelInfo) []string {
-	keys := []string{
-		resolution.RequestedQualifiedModel(),
-		resolution.Requested.Model,
+	requestedQualified := resolution.RequestedQualifiedModel()
+	resolvedQualified := resolution.ResolvedQualifiedModel()
+
+	keys := make([]string, 0, 6)
+	if selectorHasProvider(requestedQualified) {
+		keys = append(keys, requestedQualified)
 	}
 	if source != nil && source.ProviderName != "" && source.Model.ID != "" {
 		keys = append(keys, source.ProviderName+"/"+source.Model.ID)
 	}
+	if selectorHasProvider(resolvedQualified) {
+		keys = append(keys, resolvedQualified)
+	}
 	keys = append(keys,
-		resolution.ResolvedQualifiedModel(),
+		resolution.Requested.Model,
 		resolution.ResolvedSelector.Model,
+		requestedQualified,
+		resolvedQualified,
 	)
 
 	seen := make(map[string]struct{}, len(keys))
@@ -322,6 +334,11 @@ func (r *Resolver) matchKeys(resolution *core.RequestModelResolution, source *pr
 		result = append(result, key)
 	}
 	return result
+}
+
+func selectorHasProvider(selector string) bool {
+	parsed, err := core.ParseModelSelector(strings.TrimSpace(selector), "")
+	return err == nil && parsed.Provider != ""
 }
 
 func requiredCategoryForOperation(op core.Operation) core.ModelCategory {

--- a/internal/fallback/resolver.go
+++ b/internal/fallback/resolver.go
@@ -388,10 +388,12 @@ func sameFamily(source, candidate *core.ModelMetadata) bool {
 	if source == nil || candidate == nil {
 		return false
 	}
-	if strings.TrimSpace(source.Family) == "" || strings.TrimSpace(candidate.Family) == "" {
+	sourceFamily := strings.TrimSpace(source.Family)
+	candidateFamily := strings.TrimSpace(candidate.Family)
+	if sourceFamily == "" || candidateFamily == "" {
 		return false
 	}
-	return source.Family == candidate.Family
+	return sourceFamily == candidateFamily
 }
 
 func capabilityOverlap(source, candidate map[string]bool) int {

--- a/internal/fallback/resolver.go
+++ b/internal/fallback/resolver.go
@@ -304,13 +304,13 @@ func (r *Resolver) matchKeys(resolution *core.RequestModelResolution, source *pr
 	resolvedQualified := resolution.ResolvedQualifiedModel()
 
 	keys := make([]string, 0, 6)
-	if selectorHasProvider(requestedQualified) {
+	if strings.TrimSpace(resolution.Requested.ProviderHint) != "" {
 		keys = append(keys, requestedQualified)
 	}
 	if source != nil && source.ProviderName != "" && source.Model.ID != "" {
 		keys = append(keys, source.ProviderName+"/"+source.Model.ID)
 	}
-	if selectorHasProvider(resolvedQualified) {
+	if strings.TrimSpace(resolution.ResolvedSelector.Provider) != "" {
 		keys = append(keys, resolvedQualified)
 	}
 	keys = append(keys,
@@ -334,11 +334,6 @@ func (r *Resolver) matchKeys(resolution *core.RequestModelResolution, source *pr
 		result = append(result, key)
 	}
 	return result
-}
-
-func selectorHasProvider(selector string) bool {
-	parsed, err := core.ParseModelSelector(strings.TrimSpace(selector), "")
-	return err == nil && parsed.Provider != ""
 }
 
 func requiredCategoryForOperation(op core.Operation) core.ModelCategory {

--- a/internal/fallback/resolver_test.go
+++ b/internal/fallback/resolver_test.go
@@ -117,6 +117,63 @@ func TestResolverOverrideOffDisablesFallbacks(t *testing.T) {
 	}
 }
 
+func TestResolverDoesNotReturnFallbacksForEmbeddings(t *testing.T) {
+	registry := newFakeRegistry(
+		modelInfoWithCategories("text-embedding-3-small", "openai", "openai", 1287, "text-embedding-3", core.CategoryEmbedding),
+		modelInfoWithCategories("text-embedding-3-large", "azure", "azure", 1288, "text-embedding-3", core.CategoryEmbedding),
+	)
+
+	resolver := NewResolver(config.FallbackConfig{
+		DefaultMode: config.FallbackModeAuto,
+		Manual: map[string][]string{
+			"text-embedding-3-small": []string{"azure/text-embedding-3-large"},
+		},
+	}, registry)
+
+	got := resolver.ResolveFallbacks(&core.RequestModelResolution{
+		Requested:        core.NewRequestedModelSelector("text-embedding-3-small", ""),
+		ResolvedSelector: core.ModelSelector{Model: "text-embedding-3-small", Provider: "openai"},
+		ProviderType:     "openai",
+	}, core.OperationEmbeddings)
+
+	if len(got) != 0 {
+		t.Fatalf("len(got) = %d, want 0", len(got))
+	}
+}
+
+func TestResolverPrefersProviderQualifiedOverrideForBareRequests(t *testing.T) {
+	registry := newFakeRegistry(
+		modelInfo("gpt-4o", "openai", "openai", 1287, "gpt-4o"),
+		modelInfo("gpt-4o", "azure", "azure", 1287, "gpt-4o"),
+		modelInfo("gemini-2.5-pro", "gemini", "gemini", 1290, "gemini-2.5-pro"),
+	)
+
+	resolver := NewResolver(config.FallbackConfig{
+		DefaultMode: config.FallbackModeAuto,
+		Manual: map[string][]string{
+			"gpt-4o":        []string{"gemini/gemini-2.5-pro"},
+			"openai/gpt-4o": []string{"azure/gpt-4o"},
+		},
+		Overrides: map[string]config.FallbackModelOverride{
+			"gpt-4o":        {Mode: config.FallbackModeOff},
+			"openai/gpt-4o": {Mode: config.FallbackModeManual},
+		},
+	}, registry)
+
+	got := resolver.ResolveFallbacks(&core.RequestModelResolution{
+		Requested:        core.NewRequestedModelSelector("gpt-4o", ""),
+		ResolvedSelector: core.ModelSelector{Model: "gpt-4o", Provider: "openai"},
+		ProviderType:     "openai",
+	}, core.OperationChatCompletions)
+
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	if got[0].QualifiedModel() != "azure/gpt-4o" {
+		t.Fatalf("got[0] = %q, want %q", got[0].QualifiedModel(), "azure/gpt-4o")
+	}
+}
+
 func TestSameFamily_IgnoresSurroundingWhitespace(t *testing.T) {
 	source := &core.ModelMetadata{Family: " gpt-4o "}
 	candidate := &core.ModelMetadata{Family: "gpt-4o"}
@@ -149,12 +206,21 @@ func newFakeRegistry(infos ...*providers.ModelInfo) *fakeRegistry {
 }
 
 func modelInfo(id, providerName, providerType string, elo float64, family string) *providers.ModelInfo {
+	return modelInfoWithCategories(id, providerName, providerType, elo, family, core.CategoryTextGeneration)
+}
+
+func modelInfoWithCategories(
+	id, providerName, providerType string,
+	elo float64,
+	family string,
+	categories ...core.ModelCategory,
+) *providers.ModelInfo {
 	return &providers.ModelInfo{
 		Model: core.Model{
 			ID: id,
 			Metadata: &core.ModelMetadata{
 				Family:     family,
-				Categories: []core.ModelCategory{core.CategoryTextGeneration},
+				Categories: append([]core.ModelCategory(nil), categories...),
 				Capabilities: map[string]bool{
 					"streaming": true,
 				},

--- a/internal/fallback/resolver_test.go
+++ b/internal/fallback/resolver_test.go
@@ -174,6 +174,37 @@ func TestResolverPrefersProviderQualifiedOverrideForBareRequests(t *testing.T) {
 	}
 }
 
+func TestResolverTreatsBareModelIDsContainingSlashAsGenericKeys(t *testing.T) {
+	registry := newFakeRegistry(
+		modelInfo("meta-llama/Meta-Llama-3-70B", "openrouter", "openrouter", 1287, "llama-3"),
+		modelInfo("meta-llama/Meta-Llama-3-70B", "groq", "groq", 1287, "llama-3"),
+	)
+
+	resolver := NewResolver(config.FallbackConfig{
+		DefaultMode: config.FallbackModeAuto,
+		Manual: map[string][]string{
+			"openrouter/meta-llama/Meta-Llama-3-70B": {"groq/meta-llama/Meta-Llama-3-70B"},
+		},
+		Overrides: map[string]config.FallbackModelOverride{
+			"meta-llama/Meta-Llama-3-70B":            {Mode: config.FallbackModeOff},
+			"openrouter/meta-llama/Meta-Llama-3-70B": {Mode: config.FallbackModeManual},
+		},
+	}, registry)
+
+	got := resolver.ResolveFallbacks(&core.RequestModelResolution{
+		Requested:        core.NewRequestedModelSelector("meta-llama/Meta-Llama-3-70B", ""),
+		ResolvedSelector: core.ModelSelector{Model: "meta-llama/Meta-Llama-3-70B", Provider: "openrouter"},
+		ProviderType:     "openrouter",
+	}, core.OperationChatCompletions)
+
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	if got[0].QualifiedModel() != "groq/meta-llama/Meta-Llama-3-70B" {
+		t.Fatalf("got[0] = %q, want %q", got[0].QualifiedModel(), "groq/meta-llama/Meta-Llama-3-70B")
+	}
+}
+
 func TestSameFamily_IgnoresSurroundingWhitespace(t *testing.T) {
 	source := &core.ModelMetadata{Family: " gpt-4o "}
 	candidate := &core.ModelMetadata{Family: "gpt-4o"}

--- a/internal/fallback/resolver_test.go
+++ b/internal/fallback/resolver_test.go
@@ -1,0 +1,168 @@
+package fallback
+
+import (
+	"testing"
+
+	"gomodel/config"
+	"gomodel/internal/core"
+	"gomodel/internal/providers"
+)
+
+type fakeRegistry struct {
+	byKey  map[string]*providers.ModelInfo
+	models []providers.ModelWithProvider
+}
+
+func (r *fakeRegistry) GetModel(model string) *providers.ModelInfo {
+	return r.byKey[model]
+}
+
+func (r *fakeRegistry) ListModelsWithProvider() []providers.ModelWithProvider {
+	return append([]providers.ModelWithProvider(nil), r.models...)
+}
+
+func TestResolverManualModeUsesConfiguredFallbacks(t *testing.T) {
+	registry := newFakeRegistry(
+		modelInfo("gpt-4o", "openai", "openai", 1287, "gpt-4o"),
+		modelInfo("gpt-4o", "azure", "azure", 1287, "gpt-4o"),
+		modelInfo("gemini-2.5-pro", "gemini", "gemini", 1290, "gemini-2.5-pro"),
+	)
+
+	resolver := NewResolver(config.FallbackConfig{
+		DefaultMode: config.FallbackModeOff,
+		Manual: map[string][]string{
+			"gpt-4o": []string{"azure/gpt-4o", "gemini/gemini-2.5-pro"},
+		},
+		Overrides: map[string]config.FallbackModelOverride{
+			"gpt-4o": {Mode: config.FallbackModeManual},
+		},
+	}, registry)
+
+	got := resolver.ResolveFallbacks(&core.RequestModelResolution{
+		Requested:        core.NewRequestedModelSelector("gpt-4o", ""),
+		ResolvedSelector: core.ModelSelector{Model: "gpt-4o"},
+		ProviderType:     "openai",
+	}, core.OperationChatCompletions)
+
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d, want 2", len(got))
+	}
+	if got[0].QualifiedModel() != "azure/gpt-4o" {
+		t.Fatalf("got[0] = %q, want %q", got[0].QualifiedModel(), "azure/gpt-4o")
+	}
+	if got[1].QualifiedModel() != "gemini/gemini-2.5-pro" {
+		t.Fatalf("got[1] = %q, want %q", got[1].QualifiedModel(), "gemini/gemini-2.5-pro")
+	}
+}
+
+func TestResolverAutoModeAppendsRankingCandidates(t *testing.T) {
+	registry := newFakeRegistry(
+		modelInfo("gpt-4o", "openai", "openai", 1287, "gpt-4o"),
+		modelInfo("gpt-4o", "azure", "azure", 1287, "gpt-4o"),
+		modelInfo("gemini-2.5-pro", "gemini", "gemini", 1290, "gemini-2.5-pro"),
+		modelInfo("claude-sonnet-4", "anthropic", "anthropic", 1305, "claude-sonnet"),
+	)
+
+	resolver := NewResolver(config.FallbackConfig{
+		DefaultMode: config.FallbackModeAuto,
+		Manual: map[string][]string{
+			"gpt-4o": []string{"azure/gpt-4o"},
+		},
+	}, registry)
+
+	got := resolver.ResolveFallbacks(&core.RequestModelResolution{
+		Requested:        core.NewRequestedModelSelector("gpt-4o", ""),
+		ResolvedSelector: core.ModelSelector{Model: "gpt-4o"},
+		ProviderType:     "openai",
+	}, core.OperationChatCompletions)
+
+	if len(got) < 3 {
+		t.Fatalf("len(got) = %d, want at least 3", len(got))
+	}
+	if got[0].QualifiedModel() != "azure/gpt-4o" {
+		t.Fatalf("got[0] = %q, want %q", got[0].QualifiedModel(), "azure/gpt-4o")
+	}
+	if got[1].QualifiedModel() != "gemini/gemini-2.5-pro" {
+		t.Fatalf("got[1] = %q, want %q", got[1].QualifiedModel(), "gemini/gemini-2.5-pro")
+	}
+	if got[2].QualifiedModel() != "anthropic/claude-sonnet-4" {
+		t.Fatalf("got[2] = %q, want %q", got[2].QualifiedModel(), "anthropic/claude-sonnet-4")
+	}
+}
+
+func TestResolverOverrideOffDisablesFallbacks(t *testing.T) {
+	registry := newFakeRegistry(
+		modelInfo("gpt-4o", "openai", "openai", 1287, "gpt-4o"),
+		modelInfo("gpt-4o", "azure", "azure", 1287, "gpt-4o"),
+	)
+
+	resolver := NewResolver(config.FallbackConfig{
+		DefaultMode: config.FallbackModeAuto,
+		Manual: map[string][]string{
+			"gpt-4o": []string{"azure/gpt-4o"},
+		},
+		Overrides: map[string]config.FallbackModelOverride{
+			"gpt-4o": {Mode: config.FallbackModeOff},
+		},
+	}, registry)
+
+	got := resolver.ResolveFallbacks(&core.RequestModelResolution{
+		Requested:        core.NewRequestedModelSelector("gpt-4o", ""),
+		ResolvedSelector: core.ModelSelector{Model: "gpt-4o"},
+		ProviderType:     "openai",
+	}, core.OperationChatCompletions)
+
+	if len(got) != 0 {
+		t.Fatalf("len(got) = %d, want 0", len(got))
+	}
+}
+
+func newFakeRegistry(infos ...*providers.ModelInfo) *fakeRegistry {
+	registry := &fakeRegistry{
+		byKey:  make(map[string]*providers.ModelInfo),
+		models: make([]providers.ModelWithProvider, 0, len(infos)),
+	}
+
+	for _, info := range infos {
+		if _, exists := registry.byKey[info.Model.ID]; !exists {
+			registry.byKey[info.Model.ID] = info
+		}
+		registry.byKey[info.ProviderName+"/"+info.Model.ID] = info
+		registry.models = append(registry.models, providers.ModelWithProvider{
+			Model:        info.Model,
+			ProviderType: info.ProviderType,
+			ProviderName: info.ProviderName,
+			Selector:     info.ProviderName + "/" + info.Model.ID,
+		})
+	}
+
+	return registry
+}
+
+func modelInfo(id, providerName, providerType string, elo float64, family string) *providers.ModelInfo {
+	return &providers.ModelInfo{
+		Model: core.Model{
+			ID: id,
+			Metadata: &core.ModelMetadata{
+				Family:     family,
+				Categories: []core.ModelCategory{core.CategoryTextGeneration},
+				Capabilities: map[string]bool{
+					"streaming": true,
+				},
+				Rankings: map[string]core.ModelRanking{
+					"chatbot_arena": {
+						Elo:  &elo,
+						Rank: intPtr(1),
+						AsOf: "2026-02-22",
+					},
+				},
+			},
+		},
+		ProviderName: providerName,
+		ProviderType: providerType,
+	}
+}
+
+func intPtr(v int) *int {
+	return &v
+}

--- a/internal/fallback/resolver_test.go
+++ b/internal/fallback/resolver_test.go
@@ -117,6 +117,15 @@ func TestResolverOverrideOffDisablesFallbacks(t *testing.T) {
 	}
 }
 
+func TestSameFamily_IgnoresSurroundingWhitespace(t *testing.T) {
+	source := &core.ModelMetadata{Family: " gpt-4o "}
+	candidate := &core.ModelMetadata{Family: "gpt-4o"}
+
+	if !sameFamily(source, candidate) {
+		t.Fatal("expected sameFamily to compare trimmed family values")
+	}
+}
+
 func newFakeRegistry(infos ...*providers.ModelInfo) *fakeRegistry {
 	registry := &fakeRegistry{
 		byKey:  make(map[string]*providers.ModelInfo),

--- a/internal/modeldata/fetcher_test.go
+++ b/internal/modeldata/fetcher_test.go
@@ -190,6 +190,44 @@ func TestParse_BuildsReverseIndex(t *testing.T) {
 	}
 }
 
+func TestParse_BuildsReverseIndexFromProviderModelID(t *testing.T) {
+	raw := []byte(`{
+		"version": 1,
+		"updated_at": "2025-01-01T00:00:00Z",
+		"providers": {},
+		"models": {
+			"gpt-4o": {
+				"display_name": "GPT-4o",
+				"modes": ["chat"],
+				"rankings": {
+					"chatbot_arena": {
+						"elo": 1287,
+						"rank": 3,
+						"as_of": "2026-02-01"
+					}
+				}
+			}
+		},
+		"provider_models": {
+			"openai/gpt-4o": {
+				"model_ref": "gpt-4o",
+				"provider_model_id": "gpt-4o-2024-11-20",
+				"enabled": true
+			}
+		}
+	}`)
+	list, err := Parse(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := list.providerModelByActualID["openai/gpt-4o-2024-11-20"]; got != "openai/gpt-4o" {
+		t.Fatalf("reverse index = %q, want %q", got, "openai/gpt-4o")
+	}
+	if list.Models["gpt-4o"].Rankings["chatbot_arena"].Elo == nil {
+		t.Fatal("expected elo ranking to be parsed")
+	}
+}
+
 func TestParse_InvalidJSON(t *testing.T) {
 	_, err := Parse([]byte("not json"))
 	if err == nil {

--- a/internal/modeldata/merger.go
+++ b/internal/modeldata/merger.go
@@ -170,6 +170,7 @@ func buildMetadata(model *ModelEntry, pm *ProviderModelEntry) *core.ModelMetadat
 		meta.ContextWindow = model.ContextWindow
 		meta.MaxOutputTokens = model.MaxOutputTokens
 		meta.Capabilities = model.Capabilities
+		meta.Rankings = buildRankings(model.Rankings)
 		meta.Pricing = model.Pricing
 	}
 
@@ -190,4 +191,27 @@ func buildMetadata(model *ModelEntry, pm *ProviderModelEntry) *core.ModelMetadat
 	}
 
 	return meta
+}
+
+func buildRankings(rankings map[string]RankingEntry) map[string]core.ModelRanking {
+	if len(rankings) == 0 {
+		return nil
+	}
+
+	result := make(map[string]core.ModelRanking, len(rankings))
+	for name, ranking := range rankings {
+		entry := core.ModelRanking{
+			Rank: ranking.Rank,
+		}
+		if ranking.Elo != nil {
+			entry.Elo = ranking.Elo
+		} else if ranking.Score != nil {
+			entry.Elo = ranking.Score
+		}
+		if ranking.AsOf != nil {
+			entry.AsOf = *ranking.AsOf
+		}
+		result[name] = entry
+	}
+	return result
 }

--- a/internal/modeldata/merger_test.go
+++ b/internal/modeldata/merger_test.go
@@ -148,6 +148,43 @@ func TestResolve_ProviderModelOverride(t *testing.T) {
 	}
 }
 
+func TestResolve_MapsRankingsIntoMetadata(t *testing.T) {
+	list := &ModelList{
+		Models: map[string]ModelEntry{
+			"gpt-4o": {
+				DisplayName: "GPT-4o",
+				Modes:       []string{"chat"},
+				Rankings: map[string]RankingEntry{
+					"chatbot_arena": {
+						Elo:  new(1287.0),
+						Rank: new(3),
+						AsOf: new("2026-02-01"),
+					},
+				},
+			},
+		},
+		ProviderModels: map[string]ProviderModelEntry{},
+	}
+
+	meta := Resolve(list, "openai", "gpt-4o")
+	if meta == nil {
+		t.Fatal("expected non-nil metadata")
+	}
+	ranking, ok := meta.Rankings["chatbot_arena"]
+	if !ok {
+		t.Fatal("expected chatbot_arena ranking in metadata")
+	}
+	if ranking.Elo == nil || *ranking.Elo != 1287.0 {
+		t.Fatalf("ranking.Elo = %v, want 1287.0", ranking.Elo)
+	}
+	if ranking.Rank == nil || *ranking.Rank != 3 {
+		t.Fatalf("ranking.Rank = %v, want 3", ranking.Rank)
+	}
+	if ranking.AsOf != "2026-02-01" {
+		t.Fatalf("ranking.AsOf = %q, want %q", ranking.AsOf, "2026-02-01")
+	}
+}
+
 func TestResolve_ProviderModelWithoutBaseModel(t *testing.T) {
 	list := &ModelList{
 		Models: map[string]ModelEntry{},

--- a/internal/modeldata/types.go
+++ b/internal/modeldata/types.go
@@ -53,8 +53,8 @@ func (l *ModelList) buildReverseIndex() {
 	}
 
 	for compositeKey, pm := range l.ProviderModels {
-		actualID := pm.actualModelID()
-		if actualID == "" {
+		actualID, ok := pm.actualModelID()
+		if !ok {
 			continue
 		}
 		// compositeKey is "providerType/modelID"
@@ -153,14 +153,14 @@ type ProviderModelEntry struct {
 	Regions         []string           `json:"regions"`
 }
 
-func (e ProviderModelEntry) actualModelID() string {
-	if e.ProviderModelID != nil && *e.ProviderModelID != "" {
-		return *e.ProviderModelID
+func (e ProviderModelEntry) actualModelID() (string, bool) {
+	if e.ProviderModelID != nil && strings.TrimSpace(*e.ProviderModelID) != "" {
+		return strings.TrimSpace(*e.ProviderModelID), true
 	}
-	if e.CustomModelID != nil && *e.CustomModelID != "" {
-		return *e.CustomModelID
+	if e.CustomModelID != nil && strings.TrimSpace(*e.CustomModelID) != "" {
+		return strings.TrimSpace(*e.CustomModelID), true
 	}
-	return ""
+	return "", false
 }
 
 // ParameterSpec describes a model parameter's constraints.
@@ -176,7 +176,9 @@ type ParameterSpec struct {
 // RankingEntry holds a model's score in a benchmark or ranking.
 type RankingEntry struct {
 	Score *float64 `json:"score"`
+	Elo   *float64 `json:"elo"`
 	Rank  *int     `json:"rank"`
+	AsOf  *string  `json:"as_of"`
 }
 
 // AuthConfig describes provider authentication configuration.

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -21,8 +21,10 @@ import (
 
 // ModelInfo holds information about a model and its provider
 type ModelInfo struct {
-	Model    core.Model
-	Provider core.Provider
+	Model        core.Model
+	Provider     core.Provider
+	ProviderName string
+	ProviderType string
 }
 
 // ModelRegistry manages the mapping of models to their providers.
@@ -154,8 +156,10 @@ func (r *ModelRegistry) Initialize(ctx context.Context) error {
 
 		for _, model := range resp.Data {
 			info := &ModelInfo{
-				Model:    model,
-				Provider: provider,
+				Model:        model,
+				Provider:     provider,
+				ProviderName: providerName,
+				ProviderType: providerTypes[provider],
 			}
 			newModelsByProvider[providerName][model.ID] = info
 
@@ -264,7 +268,9 @@ func (r *ModelRegistry) LoadFromCache(ctx context.Context) (int, error) {
 					OwnedBy: cachedProv.OwnedBy,
 					Created: cached.Created,
 				},
-				Provider: provider,
+				Provider:     provider,
+				ProviderName: providerName,
+				ProviderType: cachedProv.ProviderType,
 			}
 			providerModels[cached.ID] = info
 			if _, exists := newModels[cached.ID]; !exists {
@@ -586,7 +592,7 @@ func (r *ModelRegistry) GetProviderType(model string) string {
 	if providerName != "" {
 		if providerModels, ok := r.modelsByProvider[providerName]; ok {
 			if info, exists := providerModels[modelID]; exists {
-				return r.providerTypes[info.Provider]
+				return info.ProviderType
 			}
 		}
 		if r.hasConfiguredProviderNameLocked(providerName) {
@@ -596,7 +602,7 @@ func (r *ModelRegistry) GetProviderType(model string) string {
 	}
 
 	if info, ok := r.models[model]; ok {
-		return r.providerTypes[info.Provider]
+		return info.ProviderType
 	}
 	return ""
 }
@@ -719,11 +725,15 @@ func (r *ModelRegistry) ListModelsWithProvider() []ModelWithProvider {
 	result := make([]ModelWithProvider, 0, total)
 	for providerName, providerModels := range r.modelsByProvider {
 		for modelID, info := range providerModels {
+			publicProviderName := providerName
+			if info.ProviderName != "" {
+				publicProviderName = info.ProviderName
+			}
 			result = append(result, ModelWithProvider{
 				Model:        info.Model,
-				ProviderType: r.providerTypes[info.Provider],
-				ProviderName: providerName,
-				Selector:     qualifyPublicModelID(providerName, modelID),
+				ProviderType: info.ProviderType,
+				ProviderName: publicProviderName,
+				Selector:     qualifyPublicModelID(publicProviderName, modelID),
 			})
 		}
 	}

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -245,8 +245,10 @@ func (r *ModelRegistry) LoadFromCache(ctx context.Context) (int, error) {
 	// Build lookup maps from configured providers.
 	r.mu.RLock()
 	nameToProvider := make(map[string]core.Provider, len(r.providerNames))
+	nameToProviderType := make(map[string]string, len(r.providerNames))
 	for provider, pName := range r.providerNames {
 		nameToProvider[pName] = provider
+		nameToProviderType[pName] = r.providerTypes[provider]
 	}
 	r.mu.RUnlock()
 
@@ -259,6 +261,10 @@ func (r *ModelRegistry) LoadFromCache(ctx context.Context) (int, error) {
 			// Provider not configured, skip all its models
 			continue
 		}
+		providerType := strings.TrimSpace(cachedProv.ProviderType)
+		if providerType == "" {
+			providerType = strings.TrimSpace(nameToProviderType[providerName])
+		}
 		providerModels := make(map[string]*ModelInfo, len(cachedProv.Models))
 		for _, cached := range cachedProv.Models {
 			info := &ModelInfo{
@@ -270,7 +276,7 @@ func (r *ModelRegistry) LoadFromCache(ctx context.Context) (int, error) {
 				},
 				Provider:     provider,
 				ProviderName: providerName,
-				ProviderType: cachedProv.ProviderType,
+				ProviderType: providerType,
 			}
 			providerModels[cached.ID] = info
 			if _, exists := newModels[cached.ID]; !exists {

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -261,9 +261,9 @@ func (r *ModelRegistry) LoadFromCache(ctx context.Context) (int, error) {
 			// Provider not configured, skip all its models
 			continue
 		}
-		providerType := strings.TrimSpace(cachedProv.ProviderType)
+		providerType := strings.TrimSpace(nameToProviderType[providerName])
 		if providerType == "" {
-			providerType = strings.TrimSpace(nameToProviderType[providerName])
+			providerType = strings.TrimSpace(cachedProv.ProviderType)
 		}
 		providerModels := make(map[string]*ModelInfo, len(cachedProv.Models))
 		for _, cached := range cachedProv.Models {

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -792,16 +792,16 @@ func (r *ModelRegistry) ListModelsWithProviderByCategory(category core.ModelCate
 	}
 
 	result := make([]ModelWithProvider, 0)
-	for providerName, providerModels := range r.modelsByProvider {
+	for _, providerModels := range r.modelsByProvider {
 		for modelID, info := range providerModels {
 			if info.Model.Metadata == nil || !hasCategory(info.Model.Metadata.Categories, category) {
 				continue
 			}
 			result = append(result, ModelWithProvider{
 				Model:        info.Model,
-				ProviderType: r.providerTypes[info.Provider],
-				ProviderName: providerName,
-				Selector:     qualifyPublicModelID(providerName, modelID),
+				ProviderType: info.ProviderType,
+				ProviderName: info.ProviderName,
+				Selector:     qualifyPublicModelID(info.ProviderName, modelID),
 			})
 		}
 	}

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -191,8 +191,7 @@ func (r *ModelRegistry) Initialize(ctx context.Context) error {
 	list := r.modelList
 	r.mu.RUnlock()
 	if list != nil {
-		accessor := &registryAccessor{models: newModels, providerTypes: r.snapshotProviderTypes()}
-		modeldata.Enrich(accessor, list)
+		enrichProviderModelMaps(list, providerTypes, newModelsByProvider, nil)
 	}
 
 	// Atomically swap the models map and invalidate sorted caches
@@ -299,8 +298,7 @@ func (r *ModelRegistry) LoadFromCache(ctx context.Context) (int, error) {
 
 	// Enrich cached models with model list metadata
 	if list != nil {
-		accessor := &registryAccessor{models: newModels, providerTypes: r.snapshotProviderTypes()}
-		modeldata.Enrich(accessor, list)
+		enrichProviderModelMaps(list, r.snapshotProviderTypes(), newModelsByProvider, nil)
 	}
 
 	r.mu.Lock()
@@ -350,13 +348,18 @@ func (r *ModelRegistry) SaveToCache(ctx context.Context) error {
 		// Determine provider type and owned_by from any model in this provider group.
 		var pType, ownedBy string
 		for _, info := range models {
-			t, ok := providerTypes[info.Provider]
-			if !ok {
-				continue
+			if ownedBy == "" {
+				ownedBy = info.Model.OwnedBy
 			}
-			pType = t
-			ownedBy = info.Model.OwnedBy
-			break
+			if pType == "" {
+				pType = strings.TrimSpace(info.ProviderType)
+				if pType == "" {
+					pType = strings.TrimSpace(providerTypes[info.Provider])
+				}
+			}
+			if pType != "" && ownedBy != "" {
+				break
+			}
 		}
 		if pType == "" {
 			// No known provider type for this provider, skip entirely.
@@ -909,14 +912,11 @@ func (r *ModelRegistry) EnrichModels() {
 	providerTypes := make(map[core.Provider]string, len(r.providerTypes))
 	maps.Copy(providerTypes, r.providerTypes)
 
-	accessor := &registryAccessor{models: r.models, providerTypes: providerTypes}
-	accessor.replacements = make(map[*ModelInfo]*ModelInfo, len(r.models))
-	modeldata.Enrich(accessor, r.modelList)
-	for _, providerModels := range r.modelsByProvider {
-		for modelID, info := range providerModels {
-			if replacement, ok := accessor.replacements[info]; ok {
-				providerModels[modelID] = replacement
-			}
+	replacements := make(map[*ModelInfo]*ModelInfo, len(r.models))
+	enrichProviderModelMaps(r.modelList, providerTypes, r.modelsByProvider, replacements)
+	for modelID, info := range r.models {
+		if replacement, ok := replacements[info]; ok {
+			r.models[modelID] = replacement
 		}
 	}
 	r.invalidateSortedCaches()
@@ -971,6 +971,28 @@ func (r *ModelRegistry) snapshotProviderTypes() map[core.Provider]string {
 	return m
 }
 
+func enrichProviderModelMaps(
+	list *modeldata.ModelList,
+	providerTypes map[core.Provider]string,
+	modelsByProvider map[string]map[string]*ModelInfo,
+	replacements map[*ModelInfo]*ModelInfo,
+) {
+	if list == nil {
+		return
+	}
+	for _, providerModels := range modelsByProvider {
+		if len(providerModels) == 0 {
+			continue
+		}
+		accessor := &registryAccessor{
+			models:        providerModels,
+			providerTypes: providerTypes,
+			replacements:  replacements,
+		}
+		modeldata.Enrich(accessor, list)
+	}
+}
+
 // registryAccessor implements modeldata.ModelInfoAccessor.
 // The models map may be either an unpublished snapshot (Initialize, LoadFromCache)
 // or the live registry map (EnrichModels, which uses replacements to preserve
@@ -994,7 +1016,10 @@ func (a *registryAccessor) GetProviderType(modelID string) string {
 	if !ok {
 		return ""
 	}
-	return a.providerTypes[info.Provider]
+	if providerType := strings.TrimSpace(info.ProviderType); providerType != "" {
+		return providerType
+	}
+	return strings.TrimSpace(a.providerTypes[info.Provider])
 }
 
 func (a *registryAccessor) SetMetadata(modelID string, meta *core.ModelMetadata) {

--- a/internal/providers/registry_cache_test.go
+++ b/internal/providers/registry_cache_test.go
@@ -247,6 +247,51 @@ func TestCacheFile(t *testing.T) {
 		}
 	})
 
+	t.Run("LoadFromCachePrefersConfiguredProviderTypeOverCachedValue", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cacheFile := filepath.Join(tmpDir, "models.json")
+
+		modelCache := modelcache.ModelCache{
+			UpdatedAt: time.Now().UTC(),
+			Providers: map[string]modelcache.CachedProvider{
+				"openai-main": {
+					ProviderType: "stale-type",
+					OwnedBy:      "openai",
+					Models: []modelcache.CachedModel{
+						{ID: "gpt-4o"},
+					},
+				},
+			},
+		}
+		data, _ := json.Marshal(modelCache)
+		if err := os.WriteFile(cacheFile, data, 0o644); err != nil {
+			t.Fatalf("failed to write cache file: %v", err)
+		}
+
+		registry := NewModelRegistry()
+		localCache := modelcache.NewLocalCache(cacheFile)
+		registry.SetCache(localCache)
+
+		openaiMock := &registryMockProvider{name: "openai"}
+		registry.RegisterProviderWithNameAndType(openaiMock, "openai-main", "openai")
+
+		loaded, err := registry.LoadFromCache(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if loaded != 1 {
+			t.Fatalf("expected 1 model loaded, got %d", loaded)
+		}
+
+		models := registry.ListModelsWithProvider()
+		if len(models) != 1 {
+			t.Fatalf("expected 1 model with provider, got %d", len(models))
+		}
+		if models[0].ProviderType != "openai" {
+			t.Fatalf("ProviderType = %q, want %q", models[0].ProviderType, "openai")
+		}
+	})
+
 	t.Run("LoadFromCacheSkipsUnconfiguredProviders", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		cacheFile := filepath.Join(tmpDir, "models.json")

--- a/internal/providers/registry_cache_test.go
+++ b/internal/providers/registry_cache_test.go
@@ -203,6 +203,50 @@ func TestCacheFile(t *testing.T) {
 		}
 	})
 
+	t.Run("LoadFromCacheBackfillsMissingProviderTypeFromConfiguredProvider", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cacheFile := filepath.Join(tmpDir, "models.json")
+
+		modelCache := modelcache.ModelCache{
+			UpdatedAt: time.Now().UTC(),
+			Providers: map[string]modelcache.CachedProvider{
+				"openai-main": {
+					OwnedBy: "openai",
+					Models: []modelcache.CachedModel{
+						{ID: "gpt-4o"},
+					},
+				},
+			},
+		}
+		data, _ := json.Marshal(modelCache)
+		if err := os.WriteFile(cacheFile, data, 0o644); err != nil {
+			t.Fatalf("failed to write cache file: %v", err)
+		}
+
+		registry := NewModelRegistry()
+		localCache := modelcache.NewLocalCache(cacheFile)
+		registry.SetCache(localCache)
+
+		openaiMock := &registryMockProvider{name: "openai"}
+		registry.RegisterProviderWithNameAndType(openaiMock, "openai-main", "openai")
+
+		loaded, err := registry.LoadFromCache(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if loaded != 1 {
+			t.Fatalf("expected 1 model loaded, got %d", loaded)
+		}
+
+		models := registry.ListModelsWithProvider()
+		if len(models) != 1 {
+			t.Fatalf("expected 1 model with provider, got %d", len(models))
+		}
+		if models[0].ProviderType != "openai" {
+			t.Fatalf("ProviderType = %q, want %q", models[0].ProviderType, "openai")
+		}
+	})
+
 	t.Run("LoadFromCacheSkipsUnconfiguredProviders", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		cacheFile := filepath.Join(tmpDir, "models.json")

--- a/internal/providers/registry_cache_test.go
+++ b/internal/providers/registry_cache_test.go
@@ -292,6 +292,120 @@ func TestCacheFile(t *testing.T) {
 		}
 	})
 
+	t.Run("LoadFromCacheUsesStoredProviderTypeForMetadataEnrichment", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cacheFile := filepath.Join(tmpDir, "models.json")
+
+		raw := []byte(`{
+			"version": 1,
+			"updated_at": "2025-01-01T00:00:00Z",
+			"providers": {
+				"openrouter": {"display_name": "OpenRouter", "api_type": "openai", "supported_modes": ["chat"]}
+			},
+			"models": {
+				"shared-model": {"display_name": "Shared Model", "modes": ["chat"]}
+			},
+			"provider_models": {
+				"openrouter/shared-model": {"model_ref": "shared-model", "enabled": true, "context_window": 222222}
+			}
+		}`)
+
+		modelCache := modelcache.ModelCache{
+			UpdatedAt:     time.Now().UTC(),
+			ModelListData: raw,
+			Providers: map[string]modelcache.CachedProvider{
+				"openrouter-main": {
+					ProviderType: "openrouter",
+					OwnedBy:      "openrouter",
+					Models: []modelcache.CachedModel{
+						{ID: "shared-model"},
+					},
+				},
+			},
+		}
+		data, _ := json.Marshal(modelCache)
+		if err := os.WriteFile(cacheFile, data, 0o644); err != nil {
+			t.Fatalf("failed to write cache file: %v", err)
+		}
+
+		registry := NewModelRegistry()
+		localCache := modelcache.NewLocalCache(cacheFile)
+		registry.SetCache(localCache)
+
+		openrouterMock := &registryMockProvider{name: "openrouter"}
+		registry.RegisterProviderWithNameAndType(openrouterMock, "openrouter-main", "")
+
+		loaded, err := registry.LoadFromCache(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if loaded != 1 {
+			t.Fatalf("expected 1 model loaded, got %d", loaded)
+		}
+
+		info := registry.GetModel("openrouter-main/shared-model")
+		if info == nil || info.Model.Metadata == nil {
+			t.Fatal("expected cached model metadata to be present")
+		}
+		if info.Model.Metadata.ContextWindow == nil || *info.Model.Metadata.ContextWindow != 222222 {
+			t.Fatalf("ContextWindow = %v, want 222222", info.Model.Metadata.ContextWindow)
+		}
+	})
+
+	t.Run("SaveToCachePrefersStoredProviderTypeOverConfiguredFallback", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cacheFile := filepath.Join(tmpDir, "models.json")
+
+		modelCache := modelcache.ModelCache{
+			UpdatedAt: time.Now().UTC(),
+			Providers: map[string]modelcache.CachedProvider{
+				"openrouter-main": {
+					ProviderType: "openrouter",
+					OwnedBy:      "openrouter",
+					Models: []modelcache.CachedModel{
+						{ID: "shared-model"},
+					},
+				},
+			},
+		}
+		data, _ := json.Marshal(modelCache)
+		if err := os.WriteFile(cacheFile, data, 0o644); err != nil {
+			t.Fatalf("failed to write cache file: %v", err)
+		}
+
+		registry := NewModelRegistry()
+		localCache := modelcache.NewLocalCache(cacheFile)
+		registry.SetCache(localCache)
+
+		openrouterMock := &registryMockProvider{name: "openrouter"}
+		registry.RegisterProviderWithNameAndType(openrouterMock, "openrouter-main", "")
+
+		if _, err := registry.LoadFromCache(context.Background()); err != nil {
+			t.Fatalf("LoadFromCache() error = %v", err)
+		}
+		if err := registry.SaveToCache(context.Background()); err != nil {
+			t.Fatalf("SaveToCache() error = %v", err)
+		}
+
+		saved, err := os.ReadFile(cacheFile)
+		if err != nil {
+			t.Fatalf("failed to read cache file: %v", err)
+		}
+
+		var rewritten modelcache.ModelCache
+		if err := json.Unmarshal(saved, &rewritten); err != nil {
+			t.Fatalf("failed to unmarshal saved cache: %v", err)
+		}
+
+		provider, ok := rewritten.Providers["openrouter-main"]
+		if !ok {
+			t.Fatal("expected openrouter-main provider in saved cache")
+		}
+		if provider.ProviderType != "openrouter" {
+			t.Fatalf("ProviderType = %q, want %q", provider.ProviderType, "openrouter")
+		}
+	})
+
 	t.Run("LoadFromCacheSkipsUnconfiguredProviders", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		cacheFile := filepath.Join(tmpDir, "models.json")

--- a/internal/providers/registry_test.go
+++ b/internal/providers/registry_test.go
@@ -1129,6 +1129,43 @@ func TestListModelsWithProviderByCategory(t *testing.T) {
 	})
 }
 
+func TestListModelsWithProviderByCategory_UsesStoredProviderMetadata(t *testing.T) {
+	registry := NewModelRegistry()
+	registry.modelsByProvider = map[string]map[string]*ModelInfo{
+		"internal-provider-key": {
+			"gpt-4o": {
+				Model: core.Model{
+					ID: "gpt-4o",
+					Metadata: &core.ModelMetadata{
+						Categories: []core.ModelCategory{core.CategoryTextGeneration},
+					},
+				},
+				ProviderName: "public-openai",
+				ProviderType: "openai",
+			},
+		},
+	}
+
+	allModels := registry.ListModelsWithProvider()
+	if len(allModels) != 1 {
+		t.Fatalf("expected 1 model from full listing, got %d", len(allModels))
+	}
+
+	filtered := registry.ListModelsWithProviderByCategory(core.CategoryTextGeneration)
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 model from category listing, got %d", len(filtered))
+	}
+	if filtered[0].ProviderName != allModels[0].ProviderName {
+		t.Fatalf("ProviderName = %q, want %q", filtered[0].ProviderName, allModels[0].ProviderName)
+	}
+	if filtered[0].ProviderType != allModels[0].ProviderType {
+		t.Fatalf("ProviderType = %q, want %q", filtered[0].ProviderType, allModels[0].ProviderType)
+	}
+	if filtered[0].Selector != allModels[0].Selector {
+		t.Fatalf("Selector = %q, want %q", filtered[0].Selector, allModels[0].Selector)
+	}
+}
+
 func TestGetCategoryCounts_CountsProviderBackedModels(t *testing.T) {
 	registry := NewModelRegistry()
 

--- a/internal/providers/registry_test.go
+++ b/internal/providers/registry_test.go
@@ -1228,8 +1228,8 @@ func TestListModelsWithProviderByCategory_UsesStoredProviderMetadata(t *testing.
 	if filtered[0].ProviderType != allModels[0].ProviderType {
 		t.Fatalf("ProviderType = %q, want %q", filtered[0].ProviderType, allModels[0].ProviderType)
 	}
-	if filtered[0].Selector != allModels[0].Selector {
-		t.Fatalf("Selector = %q, want %q", filtered[0].Selector, allModels[0].Selector)
+	if filtered[0].Selector != "public-openai/gpt-4o" {
+		t.Fatalf("Selector = %q, want %q", filtered[0].Selector, "public-openai/gpt-4o")
 	}
 }
 

--- a/internal/providers/registry_test.go
+++ b/internal/providers/registry_test.go
@@ -696,6 +696,73 @@ func TestListModelsWithProvider_IncludesProviderType(t *testing.T) {
 	}
 }
 
+func TestInitialize_EnrichesAllProviderSpecificModels(t *testing.T) {
+	registry := NewModelRegistry()
+
+	openAI := &registryMockProvider{
+		name: "provider-openai",
+		modelsResponse: &core.ModelsResponse{
+			Object: "list",
+			Data: []core.Model{
+				{ID: "shared-model", Object: "model", OwnedBy: "openai"},
+			},
+		},
+	}
+	openRouter := &registryMockProvider{
+		name: "provider-openrouter",
+		modelsResponse: &core.ModelsResponse{
+			Object: "list",
+			Data: []core.Model{
+				{ID: "shared-model", Object: "model", OwnedBy: "openrouter"},
+			},
+		},
+	}
+
+	registry.RegisterProviderWithNameAndType(openAI, "openai-main", "openai")
+	registry.RegisterProviderWithNameAndType(openRouter, "openrouter-main", "openrouter")
+
+	raw := []byte(`{
+		"version": 1,
+		"updated_at": "2025-01-01T00:00:00Z",
+		"providers": {
+			"openai": {"display_name": "OpenAI", "api_type": "openai", "supported_modes": ["chat"]},
+			"openrouter": {"display_name": "OpenRouter", "api_type": "openai", "supported_modes": ["chat"]}
+		},
+		"models": {
+			"shared-model": {"display_name": "Shared Model", "modes": ["chat"]}
+		},
+		"provider_models": {
+			"openai/shared-model": {"model_ref": "shared-model", "enabled": true, "context_window": 111111},
+			"openrouter/shared-model": {"model_ref": "shared-model", "enabled": true, "context_window": 222222}
+		}
+	}`)
+	list, err := modeldata.Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	registry.SetModelList(list, raw)
+
+	if err := registry.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	openAIInfo := registry.GetModel("openai-main/shared-model")
+	if openAIInfo == nil || openAIInfo.Model.Metadata == nil {
+		t.Fatal("expected openai-main/shared-model metadata to be present")
+	}
+	if openAIInfo.Model.Metadata.ContextWindow == nil || *openAIInfo.Model.Metadata.ContextWindow != 111111 {
+		t.Fatalf("openai context window = %v, want 111111", openAIInfo.Model.Metadata.ContextWindow)
+	}
+
+	openRouterInfo := registry.GetModel("openrouter-main/shared-model")
+	if openRouterInfo == nil || openRouterInfo.Model.Metadata == nil {
+		t.Fatal("expected openrouter-main/shared-model metadata to be present")
+	}
+	if openRouterInfo.Model.Metadata.ContextWindow == nil || *openRouterInfo.Model.Metadata.ContextWindow != 222222 {
+		t.Fatalf("openrouter context window = %v, want 222222", openRouterInfo.Model.Metadata.ContextWindow)
+	}
+}
+
 func TestListPublicModels_UsesConfiguredProviderNamesAndIncludesDuplicates(t *testing.T) {
 	registry := NewModelRegistry()
 

--- a/internal/responsecache/handle_request_test.go
+++ b/internal/responsecache/handle_request_test.go
@@ -11,6 +11,7 @@ import (
 
 	"gomodel/config"
 	"gomodel/internal/cache"
+	"gomodel/internal/core"
 )
 
 func TestHandleRequest_SemanticMissPopulatesExactCache(t *testing.T) {
@@ -67,5 +68,65 @@ func TestHandleRequest_SemanticMissPopulatesExactCache(t *testing.T) {
 	}
 	if handlerCalls != 1 {
 		t.Fatalf("exact hit should not call handler again, handlerCalls=%d", handlerCalls)
+	}
+}
+
+func TestHandleRequest_FallbackUsedSkipsCacheWrites(t *testing.T) {
+	store := cache.NewMapStore()
+	defer store.Close()
+
+	emb := &mockEmbedder{vector: []float32{1, 0, 0}}
+	vecStore := NewMapVecStore()
+	semCfg := config.SemanticCacheConfig{
+		Enabled:                 true,
+		SimilarityThreshold:     0.90,
+		TTL:                     3600,
+		MaxConversationMessages: 10,
+	}
+
+	m := &ResponseCacheMiddleware{
+		simple:   newSimpleCacheMiddleware(store, time.Hour),
+		semantic: newSemanticCacheMiddleware(emb, vecStore, semCfg),
+	}
+
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"fallback-skip-cache"}]}`)
+	e := echo.New()
+	handlerCalls := 0
+
+	run := func(markFallback bool) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		if err := m.HandleRequest(c, body, func() error {
+			handlerCalls++
+			if markFallback {
+				c.SetRequest(c.Request().WithContext(core.WithFallbackUsed(c.Request().Context())))
+			}
+			return c.JSON(http.StatusOK, map[string]string{"n": "1"})
+		}); err != nil {
+			t.Fatalf("HandleRequest: %v", err)
+		}
+		return rec
+	}
+
+	rec1 := run(true)
+	if rec1.Header().Get("X-Cache") != "" {
+		t.Fatalf("fallback-served response should not be cached, got X-Cache=%q", rec1.Header().Get("X-Cache"))
+	}
+	if handlerCalls != 1 {
+		t.Fatalf("expected 1 handler invocation after first request, got %d", handlerCalls)
+	}
+
+	m.simple.wg.Wait()
+	m.semantic.wg.Wait()
+
+	rec2 := run(false)
+	if rec2.Header().Get("X-Cache") != "" {
+		t.Fatalf("fallback-served response should not populate cache, got X-Cache=%q", rec2.Header().Get("X-Cache"))
+	}
+	if handlerCalls != 2 {
+		t.Fatalf("expected second request to execute handler again, got %d calls", handlerCalls)
 	}
 }

--- a/internal/responsecache/semantic.go
+++ b/internal/responsecache/semantic.go
@@ -127,6 +127,9 @@ func (m *semanticCacheMiddleware) Handle(c *echo.Context, body []byte, next func
 	if capture.status != http.StatusOK || capture.body.Len() == 0 {
 		return nil
 	}
+	if core.GetFallbackUsed(c.Request().Context()) {
+		return nil
+	}
 
 	data := bytes.Clone(capture.body.Bytes())
 	ttl := time.Duration(m.cfg.TTL) * time.Second

--- a/internal/responsecache/simple.go
+++ b/internal/responsecache/simple.go
@@ -137,6 +137,9 @@ func (m *simpleCacheMiddleware) StoreAfter(c *echo.Context, body []byte, next fu
 		return err
 	}
 	if capture.status == http.StatusOK && capture.body.Len() > 0 {
+		if core.GetFallbackUsed(c.Request().Context()) {
+			return nil
+		}
 		data := bytes.Clone(capture.body.Bytes())
 		m.enqueueWrite(cacheWriteJob{key: key, data: data})
 	}

--- a/internal/server/fallback_test.go
+++ b/internal/server/fallback_test.go
@@ -23,8 +23,10 @@ func (s fallbackResolverStub) ResolveFallbacks(_ *core.RequestModelResolution, _
 
 type fallbackProvider struct {
 	chatResponses      map[string]*core.ChatResponse
+	chatStreams        map[string]string
 	chatErrors         map[string]error
 	responsesResponses map[string]*core.ResponsesResponse
+	responsesStreams   map[string]string
 	responsesErrors    map[string]error
 	embeddingResponses map[string]*core.EmbeddingResponse
 	embeddingErrors    map[string]error
@@ -49,6 +51,9 @@ func (p *fallbackProvider) StreamChatCompletion(_ context.Context, req *core.Cha
 	if err := p.chatErrors[key]; err != nil {
 		return nil, err
 	}
+	if stream := p.chatStreams[key]; stream != "" {
+		return io.NopCloser(strings.NewReader(stream)), nil
+	}
 	return io.NopCloser(strings.NewReader("data: [DONE]\n\n")), nil
 }
 
@@ -70,6 +75,9 @@ func (p *fallbackProvider) StreamResponses(_ context.Context, req *core.Response
 	p.responsesCalls = append(p.responsesCalls, key)
 	if err := p.responsesErrors[key]; err != nil {
 		return nil, err
+	}
+	if stream := p.responsesStreams[key]; stream != "" {
+		return io.NopCloser(strings.NewReader(stream)), nil
 	}
 	return io.NopCloser(strings.NewReader("data: [DONE]\n\n")), nil
 }
@@ -242,6 +250,96 @@ func TestChatCompletion_DoesNotFallbackWhenExecutionPolicyDisablesFallback(t *te
 	}
 }
 
+func TestChatCompletion_StreamFallsBackToAlternateModel(t *testing.T) {
+	provider := &fallbackProvider{
+		chatStreams: map[string]string{
+			"azure/gpt-4o": "data: {\"choices\":[{\"delta\":{\"content\":\"fallback ok\"}}]}\n\ndata: [DONE]\n\n",
+		},
+		chatErrors: map[string]error{
+			"gpt-4o": core.NewProviderError("openai", http.StatusServiceUnavailable, "model temporarily unavailable", nil),
+		},
+		supportedModels: map[string]string{
+			"gpt-4o":       "openai",
+			"azure/gpt-4o": "azure",
+		},
+	}
+
+	handler := newHandler(provider, nil, nil, nil, nil, nil, fallbackResolverStub{
+		selectors: []core.ModelSelector{{Provider: "azure", Model: "gpt-4o"}},
+	}, nil)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-4o","stream":true,"messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := handler.ChatCompletion(c); err != nil {
+		t.Fatalf("handler.ChatCompletion() error = %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if len(provider.chatCalls) != 2 {
+		t.Fatalf("chat calls = %v, want 2 attempts", provider.chatCalls)
+	}
+	if provider.chatCalls[0] != "gpt-4o" || provider.chatCalls[1] != "azure/gpt-4o" {
+		t.Fatalf("chat calls = %v, want [gpt-4o azure/gpt-4o]", provider.chatCalls)
+	}
+	if !strings.Contains(rec.Body.String(), "fallback ok") {
+		t.Fatalf("response body = %s, want fallback stream content", rec.Body.String())
+	}
+	if !core.GetFallbackUsed(c.Request().Context()) {
+		t.Fatal("expected request context to be marked as fallback-used")
+	}
+}
+
+func TestChatCompletion_StreamDoesNotFallbackWhenExecutionPolicyDisablesFallback(t *testing.T) {
+	provider := &fallbackProvider{
+		chatStreams: map[string]string{
+			"azure/gpt-4o": "data: {\"choices\":[{\"delta\":{\"content\":\"fallback ok\"}}]}\n\ndata: [DONE]\n\n",
+		},
+		chatErrors: map[string]error{
+			"gpt-4o": core.NewProviderError("openai", http.StatusServiceUnavailable, "model temporarily unavailable", nil),
+		},
+		supportedModels: map[string]string{
+			"gpt-4o":       "openai",
+			"azure/gpt-4o": "azure",
+		},
+	}
+
+	handler := newHandler(provider, nil, nil, nil, nil, requestExecutionPolicyResolverFunc(func(core.ExecutionPlanSelector) (*core.ResolvedExecutionPolicy, error) {
+		return &core.ResolvedExecutionPolicy{
+			VersionID: "plan-fallback-off",
+			Features: core.ExecutionFeatures{
+				Cache:      true,
+				Audit:      true,
+				Usage:      true,
+				Guardrails: true,
+				Fallback:   false,
+			},
+		}, nil
+	}), fallbackResolverStub{
+		selectors: []core.ModelSelector{{Provider: "azure", Model: "gpt-4o"}},
+	}, nil)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-4o","stream":true,"messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := handler.ChatCompletion(c); err != nil {
+		t.Fatalf("handler.ChatCompletion() error = %v", err)
+	}
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusServiceUnavailable, rec.Body.String())
+	}
+	if len(provider.chatCalls) != 1 || provider.chatCalls[0] != "gpt-4o" {
+		t.Fatalf("chat calls = %v, want only the primary model", provider.chatCalls)
+	}
+}
+
 func TestResponses_FallsBackToAlternateModel(t *testing.T) {
 	provider := &fallbackProvider{
 		responsesResponses: map[string]*core.ResponsesResponse{
@@ -293,6 +391,81 @@ func TestResponses_FallsBackToAlternateModel(t *testing.T) {
 	}
 }
 
+func TestResponses_StreamFallsBackToAlternateModel(t *testing.T) {
+	provider := &fallbackProvider{
+		responsesStreams: map[string]string{
+			"azure/gpt-4o": "data: {\"type\":\"response.output_text.delta\",\"delta\":\"fallback response\"}\n\ndata: [DONE]\n\n",
+		},
+		responsesErrors: map[string]error{
+			"gpt-4o": core.NewNotFoundError("model not found"),
+		},
+		supportedModels: map[string]string{
+			"gpt-4o":       "openai",
+			"azure/gpt-4o": "azure",
+		},
+	}
+
+	handler := newHandler(provider, nil, nil, nil, nil, nil, fallbackResolverStub{
+		selectors: []core.ModelSelector{{Provider: "azure", Model: "gpt-4o"}},
+	}, nil)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-4o","stream":true,"input":"hi"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := handler.Responses(c); err != nil {
+		t.Fatalf("handler.Responses() error = %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if len(provider.responsesCalls) != 2 {
+		t.Fatalf("responses calls = %v, want 2 attempts", provider.responsesCalls)
+	}
+	if provider.responsesCalls[0] != "gpt-4o" || provider.responsesCalls[1] != "azure/gpt-4o" {
+		t.Fatalf("responses calls = %v, want [gpt-4o azure/gpt-4o]", provider.responsesCalls)
+	}
+	if !strings.Contains(rec.Body.String(), "fallback response") {
+		t.Fatalf("response body = %s, want fallback stream content", rec.Body.String())
+	}
+	if !core.GetFallbackUsed(c.Request().Context()) {
+		t.Fatal("expected request context to be marked as fallback-used")
+	}
+}
+
+func TestChatCompletion_DoesNotFallbackOnNonModelNotFound(t *testing.T) {
+	provider := &fallbackProvider{
+		chatErrors: map[string]error{
+			"gpt-4o": core.NewProviderError("openai", http.StatusNotFound, "endpoint not found", nil),
+		},
+		supportedModels: map[string]string{
+			"gpt-4o":       "openai",
+			"azure/gpt-4o": "azure",
+		},
+	}
+
+	handler := newHandler(provider, nil, nil, nil, nil, nil, fallbackResolverStub{
+		selectors: []core.ModelSelector{{Provider: "azure", Model: "gpt-4o"}},
+	}, nil)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := handler.ChatCompletion(c); err != nil {
+		t.Fatalf("handler.ChatCompletion() error = %v", err)
+	}
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusNotFound, rec.Body.String())
+	}
+	if len(provider.chatCalls) != 1 || provider.chatCalls[0] != "gpt-4o" {
+		t.Fatalf("chat calls = %v, want only the primary model", provider.chatCalls)
+	}
+}
 func TestEmbeddings_DoesNotFallback(t *testing.T) {
 	provider := &fallbackProvider{
 		embeddingResponses: map[string]*core.EmbeddingResponse{

--- a/internal/server/fallback_test.go
+++ b/internal/server/fallback_test.go
@@ -389,6 +389,9 @@ func TestResponses_FallsBackToAlternateModel(t *testing.T) {
 	if len(provider.responsesCalls) != 2 {
 		t.Fatalf("responses calls = %v, want 2 attempts", provider.responsesCalls)
 	}
+	if !core.GetFallbackUsed(c.Request().Context()) {
+		t.Fatal("expected request context to be marked as fallback-used")
+	}
 }
 
 func TestResponses_StreamFallsBackToAlternateModel(t *testing.T) {

--- a/internal/server/fallback_test.go
+++ b/internal/server/fallback_test.go
@@ -1,0 +1,290 @@
+package server
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+
+	"gomodel/internal/core"
+)
+
+type fallbackResolverStub struct {
+	selectors []core.ModelSelector
+}
+
+func (s fallbackResolverStub) ResolveFallbacks(_ *core.RequestModelResolution, _ core.Operation) []core.ModelSelector {
+	return append([]core.ModelSelector(nil), s.selectors...)
+}
+
+type fallbackProvider struct {
+	chatResponses      map[string]*core.ChatResponse
+	chatErrors         map[string]error
+	responsesResponses map[string]*core.ResponsesResponse
+	responsesErrors    map[string]error
+	embeddingResponses map[string]*core.EmbeddingResponse
+	embeddingErrors    map[string]error
+	supportedModels    map[string]string
+	chatCalls          []string
+	responsesCalls     []string
+	embeddingCalls     []string
+}
+
+func (p *fallbackProvider) ChatCompletion(_ context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+	key := requestSelector(req.Model, req.Provider)
+	p.chatCalls = append(p.chatCalls, key)
+	if err := p.chatErrors[key]; err != nil {
+		return nil, err
+	}
+	return p.chatResponses[key], nil
+}
+
+func (p *fallbackProvider) StreamChatCompletion(_ context.Context, req *core.ChatRequest) (io.ReadCloser, error) {
+	key := requestSelector(req.Model, req.Provider)
+	p.chatCalls = append(p.chatCalls, key)
+	if err := p.chatErrors[key]; err != nil {
+		return nil, err
+	}
+	return io.NopCloser(strings.NewReader("data: [DONE]\n\n")), nil
+}
+
+func (p *fallbackProvider) ListModels(_ context.Context) (*core.ModelsResponse, error) {
+	return &core.ModelsResponse{Object: "list"}, nil
+}
+
+func (p *fallbackProvider) Responses(_ context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
+	key := requestSelector(req.Model, req.Provider)
+	p.responsesCalls = append(p.responsesCalls, key)
+	if err := p.responsesErrors[key]; err != nil {
+		return nil, err
+	}
+	return p.responsesResponses[key], nil
+}
+
+func (p *fallbackProvider) StreamResponses(_ context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
+	key := requestSelector(req.Model, req.Provider)
+	p.responsesCalls = append(p.responsesCalls, key)
+	if err := p.responsesErrors[key]; err != nil {
+		return nil, err
+	}
+	return io.NopCloser(strings.NewReader("data: [DONE]\n\n")), nil
+}
+
+func (p *fallbackProvider) Embeddings(_ context.Context, req *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	key := requestSelector(req.Model, req.Provider)
+	p.embeddingCalls = append(p.embeddingCalls, key)
+	if err := p.embeddingErrors[key]; err != nil {
+		return nil, err
+	}
+	return p.embeddingResponses[key], nil
+}
+
+func (p *fallbackProvider) Supports(model string) bool {
+	selector, err := core.ParseModelSelector(model, "")
+	if err == nil {
+		model = selector.QualifiedModel()
+	}
+	_, ok := p.supportedModels[model]
+	return ok
+}
+
+func (p *fallbackProvider) GetProviderType(model string) string {
+	selector, err := core.ParseModelSelector(model, "")
+	if err == nil {
+		model = selector.QualifiedModel()
+	}
+	return p.supportedModels[model]
+}
+
+func TestChatCompletion_FallsBackToAlternateModel(t *testing.T) {
+	provider := &fallbackProvider{
+		chatResponses: map[string]*core.ChatResponse{
+			"azure/gpt-4o": {
+				ID:       "chatcmpl-fallback",
+				Object:   "chat.completion",
+				Model:    "gpt-4o",
+				Provider: "azure",
+				Choices: []core.Choice{{
+					Index:        0,
+					Message:      core.ResponseMessage{Role: "assistant", Content: "fallback ok"},
+					FinishReason: "stop",
+				}},
+			},
+		},
+		chatErrors: map[string]error{
+			"gpt-4o": core.NewProviderError("openai", http.StatusServiceUnavailable, "model temporarily unavailable", nil),
+		},
+		supportedModels: map[string]string{
+			"gpt-4o":       "openai",
+			"azure/gpt-4o": "azure",
+		},
+	}
+
+	handler := newHandler(provider, nil, nil, nil, nil, fallbackResolverStub{
+		selectors: []core.ModelSelector{{Provider: "azure", Model: "gpt-4o"}},
+	}, nil)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := handler.ChatCompletion(c); err != nil {
+		t.Fatalf("handler.ChatCompletion() error = %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if len(provider.chatCalls) != 2 {
+		t.Fatalf("chat calls = %v, want 2 attempts", provider.chatCalls)
+	}
+	if provider.chatCalls[0] != "gpt-4o" || provider.chatCalls[1] != "azure/gpt-4o" {
+		t.Fatalf("chat calls = %v, want [gpt-4o azure/gpt-4o]", provider.chatCalls)
+	}
+	if !strings.Contains(rec.Body.String(), "fallback ok") {
+		t.Fatalf("response body = %s, want fallback response", rec.Body.String())
+	}
+	if !core.GetFallbackUsed(c.Request().Context()) {
+		t.Fatal("expected request context to be marked as fallback-used")
+	}
+}
+
+func TestChatCompletion_DoesNotFallbackOnNonAvailabilityError(t *testing.T) {
+	provider := &fallbackProvider{
+		chatErrors: map[string]error{
+			"gpt-4o": core.NewInvalidRequestError("temperature must be between 0 and 2", nil),
+		},
+		supportedModels: map[string]string{
+			"gpt-4o":       "openai",
+			"azure/gpt-4o": "azure",
+		},
+	}
+
+	handler := newHandler(provider, nil, nil, nil, nil, fallbackResolverStub{
+		selectors: []core.ModelSelector{{Provider: "azure", Model: "gpt-4o"}},
+	}, nil)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := handler.ChatCompletion(c); err != nil {
+		t.Fatalf("handler.ChatCompletion() error = %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if len(provider.chatCalls) != 1 || provider.chatCalls[0] != "gpt-4o" {
+		t.Fatalf("chat calls = %v, want only the primary model", provider.chatCalls)
+	}
+}
+
+func TestResponses_FallsBackToAlternateModel(t *testing.T) {
+	provider := &fallbackProvider{
+		responsesResponses: map[string]*core.ResponsesResponse{
+			"azure/gpt-4o": {
+				ID:       "resp-fallback",
+				Object:   "response",
+				Model:    "gpt-4o",
+				Provider: "azure",
+				Status:   "completed",
+				Output: []core.ResponsesOutputItem{{
+					ID:     "out-1",
+					Type:   "message",
+					Role:   "assistant",
+					Status: "completed",
+					Content: []core.ResponsesContentItem{{
+						Type: "output_text",
+						Text: "fallback response",
+					}},
+				}},
+			},
+		},
+		responsesErrors: map[string]error{
+			"gpt-4o": core.NewNotFoundError("model not found"),
+		},
+		supportedModels: map[string]string{
+			"gpt-4o":       "openai",
+			"azure/gpt-4o": "azure",
+		},
+	}
+
+	handler := newHandler(provider, nil, nil, nil, nil, fallbackResolverStub{
+		selectors: []core.ModelSelector{{Provider: "azure", Model: "gpt-4o"}},
+	}, nil)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-4o","input":"hi"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := handler.Responses(c); err != nil {
+		t.Fatalf("handler.Responses() error = %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if len(provider.responsesCalls) != 2 {
+		t.Fatalf("responses calls = %v, want 2 attempts", provider.responsesCalls)
+	}
+}
+
+func TestEmbeddings_DoesNotFallback(t *testing.T) {
+	provider := &fallbackProvider{
+		embeddingResponses: map[string]*core.EmbeddingResponse{
+			"azure/text-embedding-3-small": {
+				Object:   "list",
+				Model:    "text-embedding-3-small",
+				Provider: "azure",
+				Data: []core.EmbeddingData{{
+					Object:    "embedding",
+					Embedding: []byte(`[0.1,0.2]`),
+					Index:     0,
+				}},
+			},
+		},
+		embeddingErrors: map[string]error{
+			"text-embedding-3-small": core.NewProviderError("openai", http.StatusServiceUnavailable, "model temporarily unavailable", nil),
+		},
+		supportedModels: map[string]string{
+			"text-embedding-3-small":       "openai",
+			"azure/text-embedding-3-small": "azure",
+		},
+	}
+
+	handler := newHandler(provider, nil, nil, nil, nil, fallbackResolverStub{
+		selectors: []core.ModelSelector{{Provider: "azure", Model: "text-embedding-3-small"}},
+	}, nil)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/embeddings", strings.NewReader(`{"model":"text-embedding-3-small","input":"hi"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := handler.Embeddings(c); err != nil {
+		t.Fatalf("handler.Embeddings() error = %v", err)
+	}
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusServiceUnavailable, rec.Body.String())
+	}
+	if len(provider.embeddingCalls) != 1 || provider.embeddingCalls[0] != "text-embedding-3-small" {
+		t.Fatalf("embedding calls = %v, want only the primary model", provider.embeddingCalls)
+	}
+}
+
+func requestSelector(model, provider string) string {
+	selector, err := core.ParseModelSelector(model, provider)
+	if err != nil {
+		return strings.TrimSpace(model)
+	}
+	return selector.QualifiedModel()
+}

--- a/internal/server/fallback_test.go
+++ b/internal/server/fallback_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -388,6 +389,19 @@ func TestResponses_FallsBackToAlternateModel(t *testing.T) {
 	}
 	if len(provider.responsesCalls) != 2 {
 		t.Fatalf("responses calls = %v, want 2 attempts", provider.responsesCalls)
+	}
+	if provider.responsesCalls[0] != "gpt-4o" || provider.responsesCalls[1] != "azure/gpt-4o" {
+		t.Fatalf("responses calls = %v, want [gpt-4o azure/gpt-4o]", provider.responsesCalls)
+	}
+	var resp core.ResponsesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("response body is not valid JSON: %v body=%s", err, rec.Body.String())
+	}
+	if resp.ID != "resp-fallback" || resp.Provider != "azure" || resp.Model != "gpt-4o" || resp.Status != "completed" {
+		t.Fatalf("response = %+v, want fallback response metadata", resp)
+	}
+	if len(resp.Output) != 1 || len(resp.Output[0].Content) != 1 || resp.Output[0].Content[0].Text != "fallback response" {
+		t.Fatalf("response output = %+v, want fallback response content", resp.Output)
 	}
 	if !core.GetFallbackUsed(c.Request().Context()) {
 		t.Fatal("expected request context to be marked as fallback-used")

--- a/internal/server/fallback_test.go
+++ b/internal/server/fallback_test.go
@@ -186,6 +186,62 @@ func TestChatCompletion_DoesNotFallbackOnNonAvailabilityError(t *testing.T) {
 	}
 }
 
+func TestChatCompletion_DoesNotFallbackWhenExecutionPolicyDisablesFallback(t *testing.T) {
+	provider := &fallbackProvider{
+		chatResponses: map[string]*core.ChatResponse{
+			"azure/gpt-4o": {
+				ID:       "chatcmpl-fallback",
+				Object:   "chat.completion",
+				Model:    "gpt-4o",
+				Provider: "azure",
+				Choices: []core.Choice{{
+					Index:        0,
+					Message:      core.ResponseMessage{Role: "assistant", Content: "fallback ok"},
+					FinishReason: "stop",
+				}},
+			},
+		},
+		chatErrors: map[string]error{
+			"gpt-4o": core.NewProviderError("openai", http.StatusServiceUnavailable, "model temporarily unavailable", nil),
+		},
+		supportedModels: map[string]string{
+			"gpt-4o":       "openai",
+			"azure/gpt-4o": "azure",
+		},
+	}
+
+	handler := newHandler(provider, nil, nil, nil, nil, requestExecutionPolicyResolverFunc(func(core.ExecutionPlanSelector) (*core.ResolvedExecutionPolicy, error) {
+		return &core.ResolvedExecutionPolicy{
+			VersionID: "plan-fallback-off",
+			Features: core.ExecutionFeatures{
+				Cache:      true,
+				Audit:      true,
+				Usage:      true,
+				Guardrails: true,
+				Fallback:   false,
+			},
+		}, nil
+	}), fallbackResolverStub{
+		selectors: []core.ModelSelector{{Provider: "azure", Model: "gpt-4o"}},
+	}, nil)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := handler.ChatCompletion(c); err != nil {
+		t.Fatalf("handler.ChatCompletion() error = %v", err)
+	}
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusServiceUnavailable, rec.Body.String())
+	}
+	if len(provider.chatCalls) != 1 || provider.chatCalls[0] != "gpt-4o" {
+		t.Fatalf("chat calls = %v, want only the primary model", provider.chatCalls)
+	}
+}
+
 func TestResponses_FallsBackToAlternateModel(t *testing.T) {
 	provider := &fallbackProvider{
 		responsesResponses: map[string]*core.ResponsesResponse{

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -18,6 +18,7 @@ import (
 type Handler struct {
 	provider                     core.RoutableProvider
 	modelResolver                RequestModelResolver
+	fallbackResolver             RequestFallbackResolver
 	translatedRequestPatcher     TranslatedRequestPatcher
 	batchRequestPreparer         BatchRequestPreparer
 	exposedModelLister           ExposedModelLister
@@ -36,7 +37,7 @@ type Handler struct {
 
 // NewHandler creates a new handler with the given routable provider (typically the Router)
 func NewHandler(provider core.RoutableProvider, logger auditlog.LoggerInterface, usageLogger usage.LoggerInterface, pricingResolver usage.PricingResolver) *Handler {
-	return newHandler(provider, logger, usageLogger, pricingResolver, nil, nil)
+	return newHandler(provider, logger, usageLogger, pricingResolver, nil, nil, nil)
 }
 
 func newHandler(
@@ -45,11 +46,13 @@ func newHandler(
 	usageLogger usage.LoggerInterface,
 	pricingResolver usage.PricingResolver,
 	modelResolver RequestModelResolver,
+	fallbackResolver RequestFallbackResolver,
 	translatedRequestPatcher TranslatedRequestPatcher,
 ) *Handler {
 	return &Handler{
 		provider:                     provider,
 		modelResolver:                modelResolver,
+		fallbackResolver:             fallbackResolver,
 		translatedRequestPatcher:     translatedRequestPatcher,
 		logger:                       logger,
 		usageLogger:                  usageLogger,
@@ -74,6 +77,7 @@ func (h *Handler) translatedInference() *translatedInferenceService {
 		s := &translatedInferenceService{
 			provider:                 h.provider,
 			modelResolver:            h.modelResolver,
+			fallbackResolver:         h.fallbackResolver,
 			translatedRequestPatcher: h.translatedRequestPatcher,
 			logger:                   h.logger,
 			usageLogger:              h.usageLogger,

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -1333,7 +1333,7 @@ func TestChatCompletion_UsesExplicitAliasResolverWithoutProviderDecorator(t *tes
 	}
 
 	e := echo.New()
-	handler := newHandler(inner, nil, nil, nil, service, nil)
+	handler := newHandler(inner, nil, nil, nil, service, nil, nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
 	req.Header.Set("Content-Type", "application/json")
@@ -1444,7 +1444,7 @@ func TestChatCompletion_UsesExplicitAliasResolverWithAliasProviderInventoryOnly(
 	})
 
 	e := echo.New()
-	handler := newHandler(provider, nil, nil, nil, service, nil)
+	handler := newHandler(provider, nil, nil, nil, service, nil, nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
 	req.Header.Set("Content-Type", "application/json")
@@ -1524,7 +1524,7 @@ func TestChatCompletion_UsesExplicitTranslatedRequestPatcher(t *testing.T) {
 	patcher := guardrails.NewRequestPatcher(pipeline)
 
 	e := echo.New()
-	handler := newHandler(inner, nil, nil, nil, nil, patcher)
+	handler := newHandler(inner, nil, nil, nil, nil, nil, patcher)
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
 	req.Header.Set("Content-Type", "application/json")

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -43,6 +43,7 @@ type Config struct {
 	UsageLogger                  usage.LoggerInterface                  // Optional: Usage logger for token tracking
 	PricingResolver              usage.PricingResolver                  // Optional: Resolves pricing for cost calculation
 	ModelResolver                RequestModelResolver                   // Optional: explicit model resolver used during request planning
+	FallbackResolver             RequestFallbackResolver                // Optional: translated-route fallback resolver
 	TranslatedRequestPatcher     TranslatedRequestPatcher               // Optional: request patcher for translated routes after planning
 	BatchRequestPreparer         BatchRequestPreparer                   // Optional: batch request preparer before native provider submission
 	ExposedModelLister           ExposedModelLister                     // Optional: additional public models to merge into GET /v1/models
@@ -77,13 +78,15 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 	}
 
 	var modelResolver RequestModelResolver
+	var fallbackResolver RequestFallbackResolver
 	var translatedRequestPatcher TranslatedRequestPatcher
 	if cfg != nil {
 		modelResolver = cfg.ModelResolver
+		fallbackResolver = cfg.FallbackResolver
 		translatedRequestPatcher = cfg.TranslatedRequestPatcher
 	}
 
-	handler := newHandler(provider, auditLogger, usageLogger, pricingResolver, modelResolver, translatedRequestPatcher)
+	handler := newHandler(provider, auditLogger, usageLogger, pricingResolver, modelResolver, fallbackResolver, translatedRequestPatcher)
 	if cfg != nil {
 		handler.batchRequestPreparer = cfg.BatchRequestPreparer
 		handler.exposedModelLister = cfg.ExposedModelLister

--- a/internal/server/request_model_resolution.go
+++ b/internal/server/request_model_resolution.go
@@ -15,6 +15,12 @@ type RequestModelResolver interface {
 	ResolveModel(requested core.RequestedModelSelector) (core.ModelSelector, bool, error)
 }
 
+// RequestFallbackResolver resolves alternate concrete model selectors for a
+// translated request after the primary selector has already been resolved.
+type RequestFallbackResolver interface {
+	ResolveFallbacks(resolution *core.RequestModelResolution, op core.Operation) []core.ModelSelector
+}
+
 func effectiveRequestModelResolver(provider core.RoutableProvider, resolver RequestModelResolver) RequestModelResolver {
 	if resolver != nil {
 		return resolver

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -88,9 +88,12 @@ func (s *translatedInferenceService) dispatchChatCompletion(c *echo.Context, req
 				return err
 			}
 		}
-		stream, resolvedProviderType, resolvedUsageModel, err := s.streamChatCompletion(ctx, plan, streamReq, providerType, usageModel)
+		stream, resolvedProviderType, resolvedUsageModel, usedFallback, err := s.streamChatCompletion(ctx, plan, streamReq, providerType, usageModel)
 		if err != nil {
 			return handleError(c, err)
+		}
+		if usedFallback {
+			markRequestFallbackUsed(c)
 		}
 		return s.handleStreamingReadCloser(c, plan, resolvedUsageModel, resolvedProviderType, stream)
 	}
@@ -189,9 +192,12 @@ func (s *translatedInferenceService) dispatchResponses(c *echo.Context, req *cor
 		if (plan == nil || plan.UsageEnabled()) && s.shouldEnforceReturningUsageData() {
 			ctx = core.WithEnforceReturningUsageData(ctx, true)
 		}
-		stream, resolvedProviderType, resolvedUsageModel, err := s.streamResponses(ctx, plan, req, providerType, usageModel)
+		stream, resolvedProviderType, resolvedUsageModel, usedFallback, err := s.streamResponses(ctx, plan, req, providerType, usageModel)
 		if err != nil {
 			return handleError(c, err)
+		}
+		if usedFallback {
+			markRequestFallbackUsed(c)
 		}
 		return s.handleStreamingReadCloser(c, plan, resolvedUsageModel, resolvedProviderType, stream)
 	}
@@ -414,13 +420,13 @@ func (s *translatedInferenceService) streamChatCompletion(
 	plan *core.ExecutionPlan,
 	req *core.ChatRequest,
 	providerType, usageModel string,
-) (io.ReadCloser, string, string, error) {
+) (io.ReadCloser, string, string, bool, error) {
 	stream, err := s.provider.StreamChatCompletion(ctx, req)
 	if err == nil {
-		return stream, providerType, usageModel, nil
+		return stream, providerType, usageModel, false, nil
 	}
 
-	return tryFallbackStream(ctx, s, plan, req.Model, req.Provider, err,
+	stream, resolvedProviderType, resolvedUsageModel, err := tryFallbackStream(ctx, s, plan, req.Model, req.Provider, err,
 		func(selector core.ModelSelector, providerType string) (io.ReadCloser, string, string, error) {
 			stream, err := s.provider.StreamChatCompletion(ctx, cloneChatRequestForSelector(req, selector))
 			if err != nil {
@@ -429,6 +435,10 @@ func (s *translatedInferenceService) streamChatCompletion(
 			return stream, providerType, selector.Model, nil
 		},
 	)
+	if err != nil {
+		return nil, "", "", false, err
+	}
+	return stream, resolvedProviderType, resolvedUsageModel, true, nil
 }
 
 //nolint:dupl // typed wrapper over the shared translated fallback executor
@@ -453,13 +463,13 @@ func (s *translatedInferenceService) streamResponses(
 	plan *core.ExecutionPlan,
 	req *core.ResponsesRequest,
 	providerType, usageModel string,
-) (io.ReadCloser, string, string, error) {
+) (io.ReadCloser, string, string, bool, error) {
 	stream, err := s.provider.StreamResponses(ctx, req)
 	if err == nil {
-		return stream, providerType, usageModel, nil
+		return stream, providerType, usageModel, false, nil
 	}
 
-	return tryFallbackStream(ctx, s, plan, req.Model, req.Provider, err,
+	stream, resolvedProviderType, resolvedUsageModel, err := tryFallbackStream(ctx, s, plan, req.Model, req.Provider, err,
 		func(selector core.ModelSelector, providerType string) (io.ReadCloser, string, string, error) {
 			stream, err := s.provider.StreamResponses(ctx, cloneResponsesRequestForSelector(req, selector))
 			if err != nil {
@@ -468,6 +478,10 @@ func (s *translatedInferenceService) streamResponses(
 			return stream, providerType, selector.Model, nil
 		},
 	)
+	if err != nil {
+		return nil, "", "", false, err
+	}
+	return stream, resolvedProviderType, resolvedUsageModel, true, nil
 }
 
 func (s *translatedInferenceService) executeEmbeddings(
@@ -525,6 +539,9 @@ func (s *translatedInferenceService) fallbackSelectors(plan *core.ExecutionPlan)
 
 func (s *translatedInferenceService) providerTypeForSelector(selector core.ModelSelector, fallback string) string {
 	fallback = strings.TrimSpace(fallback)
+	if provider := strings.TrimSpace(selector.Provider); provider != "" {
+		return provider
+	}
 	if s.provider == nil {
 		return fallback
 	}
@@ -809,7 +826,7 @@ func shouldAttemptFallback(err error) bool {
 	}
 
 	status := gatewayErr.HTTPStatusCode()
-	if status >= http.StatusInternalServerError || status == http.StatusTooManyRequests || status == http.StatusNotFound {
+	if status >= http.StatusInternalServerError || status == http.StatusTooManyRequests {
 		return true
 	}
 

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -22,6 +23,7 @@ import (
 type translatedInferenceService struct {
 	provider                 core.RoutableProvider
 	modelResolver            RequestModelResolver
+	fallbackResolver         RequestFallbackResolver
 	translatedRequestPatcher TranslatedRequestPatcher
 	logger                   auditlog.LoggerInterface
 	usageLogger              usage.LoggerInterface
@@ -76,21 +78,27 @@ func (s *translatedInferenceService) ChatCompletion(c *echo.Context) error {
 
 func (s *translatedInferenceService) dispatchChatCompletion(c *echo.Context, req *core.ChatRequest, plan *core.ExecutionPlan) error {
 	ctx := c.Request().Context()
-	streamReq, providerType, usageModel := s.resolveProviderAndModelFromPlan(c, plan, req.Model, req)
 	requestID := requestIDFromContextOrHeader(c.Request())
 
 	if req.Stream {
-		if handled, err := s.tryFastPathStreamingChatPassthrough(c, plan, req); handled {
-			return err
+		if len(s.fallbackSelectors(plan)) == 0 {
+			if handled, err := s.tryFastPathStreamingChatPassthrough(c, plan, req); handled {
+				return err
+			}
 		}
-		return s.handleStreamingResponse(c, usageModel, providerType, func() (io.ReadCloser, error) {
-			return s.provider.StreamChatCompletion(ctx, streamReq)
-		})
+		stream, providerType, usageModel, err := s.streamChatCompletion(ctx, plan, req)
+		if err != nil {
+			return handleError(c, err)
+		}
+		return s.handleStreamingReadCloser(c, usageModel, providerType, stream)
 	}
 
-	resp, err := s.provider.ChatCompletion(ctx, req)
+	resp, providerType, usedFallback, err := s.executeChatCompletion(ctx, plan, req)
 	if err != nil {
 		return handleError(c, err)
+	}
+	if usedFallback {
+		markRequestFallbackUsed(c)
 	}
 
 	s.logUsage(resp.Model, providerType, func(pricing *core.ModelPricing) *usage.UsageEntry {
@@ -168,21 +176,25 @@ func handleWithCache[R any](
 
 func (s *translatedInferenceService) dispatchResponses(c *echo.Context, req *core.ResponsesRequest, plan *core.ExecutionPlan) error {
 	ctx := c.Request().Context()
-	_, providerType, usageModel := s.resolveProviderAndModelFromPlan(c, plan, req.Model, nil)
 	requestID := requestIDFromContextOrHeader(c.Request())
 
 	if req.Stream {
 		if s.shouldEnforceReturningUsageData() {
 			ctx = core.WithEnforceReturningUsageData(ctx, true)
 		}
-		return s.handleStreamingResponse(c, usageModel, providerType, func() (io.ReadCloser, error) {
-			return s.provider.StreamResponses(ctx, req)
-		})
+		stream, providerType, usageModel, err := s.streamResponses(ctx, plan, req)
+		if err != nil {
+			return handleError(c, err)
+		}
+		return s.handleStreamingReadCloser(c, usageModel, providerType, stream)
 	}
 
-	resp, err := s.provider.Responses(ctx, req)
+	resp, providerType, usedFallback, err := s.executeResponses(ctx, plan, req)
 	if err != nil {
 		return handleError(c, err)
+	}
+	if usedFallback {
+		markRequestFallbackUsed(c)
 	}
 
 	s.logUsage(resp.Model, providerType, func(pricing *core.ModelPricing) *usage.UsageEntry {
@@ -297,10 +309,9 @@ func (s *translatedInferenceService) Embeddings(c *echo.Context) error {
 	}
 
 	ctx := c.Request().Context()
-	_, providerType, _ := s.resolveProviderAndModelFromPlan(c, plan, req.Model, nil)
 	requestID := requestIDFromContextOrHeader(c.Request())
 
-	resp, err := s.provider.Embeddings(ctx, req)
+	resp, providerType, err := s.executeEmbeddings(ctx, plan, req)
 	if err != nil {
 		return handleError(c, err)
 	}
@@ -312,12 +323,7 @@ func (s *translatedInferenceService) Embeddings(c *echo.Context) error {
 	return c.JSON(http.StatusOK, resp)
 }
 
-func (s *translatedInferenceService) handleStreamingResponse(c *echo.Context, model, provider string, streamFn func() (io.ReadCloser, error)) error {
-	stream, err := streamFn()
-	if err != nil {
-		return handleError(c, err)
-	}
-
+func (s *translatedInferenceService) handleStreamingReadCloser(c *echo.Context, model, provider string, stream io.ReadCloser) error {
 	auditlog.MarkEntryAsStreaming(c, true)
 	auditlog.EnrichEntryWithStream(c, true)
 
@@ -361,6 +367,128 @@ func (s *translatedInferenceService) handleStreamingResponse(c *echo.Context, mo
 	return nil
 }
 
+func (s *translatedInferenceService) handleStreamingResponse(c *echo.Context, model, provider string, streamFn func() (io.ReadCloser, error)) error {
+	stream, err := streamFn()
+	if err != nil {
+		return handleError(c, err)
+	}
+	return s.handleStreamingReadCloser(c, model, provider, stream)
+}
+
+//nolint:dupl // typed wrapper over the shared translated fallback executor
+func (s *translatedInferenceService) executeChatCompletion(
+	ctx context.Context,
+	plan *core.ExecutionPlan,
+	req *core.ChatRequest,
+) (*core.ChatResponse, string, bool, error) {
+	return executeTranslatedWithFallback(ctx, s, plan, req, req.Model, req.Provider, cloneChatRequestForSelector,
+		func(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, string, error) {
+			resp, err := s.provider.ChatCompletion(ctx, req)
+			if err != nil {
+				return nil, "", err
+			}
+			return resp, resp.Provider, nil
+		},
+	)
+}
+
+func (s *translatedInferenceService) streamChatCompletion(
+	ctx context.Context,
+	plan *core.ExecutionPlan,
+	req *core.ChatRequest,
+) (io.ReadCloser, string, string, error) {
+	attemptReq := req
+	if req != nil && req.Stream && s.shouldEnforceReturningUsageData() {
+		attemptReq = cloneChatRequestForStreamUsage(req)
+		if attemptReq.StreamOptions == nil {
+			attemptReq.StreamOptions = &core.StreamOptions{}
+		}
+		attemptReq.StreamOptions.IncludeUsage = true
+	}
+
+	providerType := providerTypeFromPlan(plan)
+	usageModel := resolvedModelFromPlan(plan, req.Model)
+	stream, err := s.provider.StreamChatCompletion(ctx, attemptReq)
+	if err == nil {
+		return stream, providerType, usageModel, nil
+	}
+
+	return tryFallbackStream(ctx, s, plan, attemptReq.Model, attemptReq.Provider, err,
+		func(selector core.ModelSelector, providerType string) (io.ReadCloser, string, string, error) {
+			stream, err := s.provider.StreamChatCompletion(ctx, cloneChatRequestForSelector(attemptReq, selector))
+			if err != nil {
+				return nil, "", "", err
+			}
+			return stream, providerType, selector.Model, nil
+		},
+	)
+}
+
+//nolint:dupl // typed wrapper over the shared translated fallback executor
+func (s *translatedInferenceService) executeResponses(
+	ctx context.Context,
+	plan *core.ExecutionPlan,
+	req *core.ResponsesRequest,
+) (*core.ResponsesResponse, string, bool, error) {
+	return executeTranslatedWithFallback(ctx, s, plan, req, req.Model, req.Provider, cloneResponsesRequestForSelector,
+		func(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, string, error) {
+			resp, err := s.provider.Responses(ctx, req)
+			if err != nil {
+				return nil, "", err
+			}
+			return resp, resp.Provider, nil
+		},
+	)
+}
+
+func (s *translatedInferenceService) streamResponses(
+	ctx context.Context,
+	plan *core.ExecutionPlan,
+	req *core.ResponsesRequest,
+) (io.ReadCloser, string, string, error) {
+	providerType := providerTypeFromPlan(plan)
+	usageModel := resolvedModelFromPlan(plan, req.Model)
+	stream, err := s.provider.StreamResponses(ctx, req)
+	if err == nil {
+		return stream, providerType, usageModel, nil
+	}
+
+	return tryFallbackStream(ctx, s, plan, req.Model, req.Provider, err,
+		func(selector core.ModelSelector, providerType string) (io.ReadCloser, string, string, error) {
+			stream, err := s.provider.StreamResponses(ctx, cloneResponsesRequestForSelector(req, selector))
+			if err != nil {
+				return nil, "", "", err
+			}
+			return stream, providerType, selector.Model, nil
+		},
+	)
+}
+
+func (s *translatedInferenceService) executeEmbeddings(
+	ctx context.Context,
+	plan *core.ExecutionPlan,
+	req *core.EmbeddingRequest,
+) (*core.EmbeddingResponse, string, error) {
+	providerType := providerTypeFromPlan(plan)
+	resp, err := s.provider.Embeddings(ctx, req)
+	if err == nil {
+		return resp, responseProviderType(providerType, resp.Provider), nil
+	}
+
+	return s.tryFallbackEmbeddings(ctx, plan, req, err)
+}
+
+func (s *translatedInferenceService) tryFallbackEmbeddings(
+	ctx context.Context,
+	plan *core.ExecutionPlan,
+	req *core.EmbeddingRequest,
+	primaryErr error,
+) (*core.EmbeddingResponse, string, error) {
+	// Embeddings fallback is intentionally disabled until the shared model
+	// contract can prove vector-size compatibility for alternates.
+	return nil, "", primaryErr
+}
+
 func (s *translatedInferenceService) logUsage(model, providerType string, extractFn func(*core.ModelPricing) *usage.UsageEntry) {
 	if s.usageLogger == nil || !s.usageLogger.Config().Enabled {
 		return
@@ -378,30 +506,22 @@ func (s *translatedInferenceService) shouldEnforceReturningUsageData() bool {
 	return s.usageLogger != nil && s.usageLogger.Config().EnforceReturningUsageData
 }
 
-func (s *translatedInferenceService) resolveProviderAndModelFromPlan(
-	c *echo.Context,
-	plan *core.ExecutionPlan,
-	fallbackModel string,
-	req *core.ChatRequest,
-) (*core.ChatRequest, string, string) {
-	providerType := GetProviderType(c)
-	if plan != nil {
-		if plannedProviderType := strings.TrimSpace(plan.ProviderType); plannedProviderType != "" {
-			providerType = plannedProviderType
-		}
+func (s *translatedInferenceService) fallbackSelectors(plan *core.ExecutionPlan) []core.ModelSelector {
+	if s.fallbackResolver == nil || plan == nil || plan.Resolution == nil {
+		return nil
 	}
+	return s.fallbackResolver.ResolveFallbacks(plan.Resolution, plan.Endpoint.Operation)
+}
 
-	model := resolvedModelFromPlan(plan, fallbackModel)
-	if req == nil || !req.Stream || !s.shouldEnforceReturningUsageData() {
-		return req, providerType, model
+func (s *translatedInferenceService) providerTypeForSelector(selector core.ModelSelector, fallback string) string {
+	fallback = strings.TrimSpace(fallback)
+	if s.provider == nil {
+		return fallback
 	}
-
-	streamReq := cloneChatRequestForStreamUsage(req)
-	if streamReq.StreamOptions == nil {
-		streamReq.StreamOptions = &core.StreamOptions{}
+	if providerType := strings.TrimSpace(s.provider.GetProviderType(selector.QualifiedModel())); providerType != "" {
+		return providerType
 	}
-	streamReq.StreamOptions.IncludeUsage = true
-	return streamReq, providerType, model
+	return fallback
 }
 
 func recordStreamingError(streamEntry *auditlog.LogEntry, model, provider, path, requestID string, err error) {
@@ -434,6 +554,41 @@ func cloneChatRequestForStreamUsage(req *core.ChatRequest) *core.ChatRequest {
 	return &cloned
 }
 
+func cloneChatRequestForSelector(req *core.ChatRequest, selector core.ModelSelector) *core.ChatRequest {
+	if req == nil {
+		return nil
+	}
+	cloned := *req
+	cloned.Model = selector.Model
+	cloned.Provider = selector.Provider
+	if req.StreamOptions != nil {
+		streamOptions := *req.StreamOptions
+		cloned.StreamOptions = &streamOptions
+	}
+	return &cloned
+}
+
+func cloneResponsesRequestForSelector(req *core.ResponsesRequest, selector core.ModelSelector) *core.ResponsesRequest {
+	if req == nil {
+		return nil
+	}
+	cloned := *req
+	cloned.Model = selector.Model
+	cloned.Provider = selector.Provider
+	if req.StreamOptions != nil {
+		streamOptions := *req.StreamOptions
+		cloned.StreamOptions = &streamOptions
+	}
+	return &cloned
+}
+
+func markRequestFallbackUsed(c *echo.Context) {
+	if c == nil || c.Request() == nil {
+		return
+	}
+	c.SetRequest(c.Request().WithContext(core.WithFallbackUsed(c.Request().Context())))
+}
+
 func resolvedModelFromPlan(plan *core.ExecutionPlan, fallback string) string {
 	fallback = strings.TrimSpace(fallback)
 	if plan == nil || plan.Resolution == nil {
@@ -449,4 +604,207 @@ func resolvedModelFromPlan(plan *core.ExecutionPlan, fallback string) string {
 // Returns an error only on marshalling failure; callers bypass cache on error.
 func marshalRequestBody(req any) ([]byte, error) {
 	return json.Marshal(req)
+}
+
+func providerTypeFromPlan(plan *core.ExecutionPlan) string {
+	if plan == nil {
+		return ""
+	}
+	return strings.TrimSpace(plan.ProviderType)
+}
+
+func currentSelectorForPlan(plan *core.ExecutionPlan, model, provider string) string {
+	if plan != nil && plan.Resolution != nil {
+		if resolved := strings.TrimSpace(plan.Resolution.ResolvedQualifiedModel()); resolved != "" {
+			return resolved
+		}
+	}
+	selector, err := core.ParseModelSelector(model, provider)
+	if err != nil {
+		return strings.TrimSpace(model)
+	}
+	return selector.QualifiedModel()
+}
+
+func responseProviderType(fallback, responseProvider string) string {
+	responseProvider = strings.TrimSpace(responseProvider)
+	if responseProvider != "" {
+		return responseProvider
+	}
+	return strings.TrimSpace(fallback)
+}
+
+func tryFallbackResponse[T any](
+	ctx context.Context,
+	s *translatedInferenceService,
+	plan *core.ExecutionPlan,
+	model, provider string,
+	primaryErr error,
+	call func(selector core.ModelSelector, providerType string) (T, string, error),
+) (T, string, bool, error) {
+	var zero T
+
+	fallbacks := s.fallbackSelectors(plan)
+	if len(fallbacks) == 0 || !shouldAttemptFallback(primaryErr) {
+		return zero, "", false, primaryErr
+	}
+
+	requestID := strings.TrimSpace(core.GetRequestID(ctx))
+	primaryModel := currentSelectorForPlan(plan, model, provider)
+	lastErr := primaryErr
+	for _, selector := range fallbacks {
+		qualified := selector.QualifiedModel()
+		providerType := s.providerTypeForSelector(selector, providerTypeFromPlan(plan))
+		slog.Warn("primary model attempt failed, trying fallback",
+			"request_id", requestID,
+			"from", primaryModel,
+			"to", qualified,
+			"provider_type", providerType,
+			"error", lastErr,
+		)
+
+		resp, resolvedProviderType, err := call(selector, providerType)
+		if err == nil {
+			slog.Info("fallback model attempt succeeded",
+				"request_id", requestID,
+				"from", primaryModel,
+				"to", qualified,
+				"provider_type", resolvedProviderType,
+			)
+			return resp, resolvedProviderType, true, nil
+		}
+		lastErr = err
+	}
+
+	return zero, "", false, lastErr
+}
+
+func executeWithFallbackResponse[T any](
+	ctx context.Context,
+	s *translatedInferenceService,
+	plan *core.ExecutionPlan,
+	model, provider string,
+	primary func() (T, string, error),
+	fallback func(selector core.ModelSelector, providerType string) (T, string, error),
+) (T, string, bool, error) {
+	resp, resolvedProviderType, err := primary()
+	if err == nil {
+		return resp, resolvedProviderType, false, nil
+	}
+	return tryFallbackResponse(ctx, s, plan, model, provider, err, fallback)
+}
+
+func executeTranslatedWithFallback[Req any, Resp any](
+	ctx context.Context,
+	s *translatedInferenceService,
+	plan *core.ExecutionPlan,
+	req Req,
+	model, provider string,
+	cloneForSelector func(Req, core.ModelSelector) Req,
+	call func(context.Context, Req) (Resp, string, error),
+) (Resp, string, bool, error) {
+	return executeWithFallbackResponse(ctx, s, plan, model, provider,
+		func() (Resp, string, error) {
+			resp, responseProvider, err := call(ctx, req)
+			if err != nil {
+				var zero Resp
+				return zero, "", err
+			}
+			return resp, responseProviderType(providerTypeFromPlan(plan), responseProvider), nil
+		},
+		func(selector core.ModelSelector, providerType string) (Resp, string, error) {
+			resp, responseProvider, err := call(ctx, cloneForSelector(req, selector))
+			if err != nil {
+				var zero Resp
+				return zero, "", err
+			}
+			return resp, responseProviderType(providerType, responseProvider), nil
+		},
+	)
+}
+
+func tryFallbackStream(
+	ctx context.Context,
+	s *translatedInferenceService,
+	plan *core.ExecutionPlan,
+	model, provider string,
+	primaryErr error,
+	call func(selector core.ModelSelector, providerType string) (io.ReadCloser, string, string, error),
+) (io.ReadCloser, string, string, error) {
+	fallbacks := s.fallbackSelectors(plan)
+	if len(fallbacks) == 0 || !shouldAttemptFallback(primaryErr) {
+		return nil, "", "", primaryErr
+	}
+
+	requestID := strings.TrimSpace(core.GetRequestID(ctx))
+	primaryModel := currentSelectorForPlan(plan, model, provider)
+	lastErr := primaryErr
+	for _, selector := range fallbacks {
+		qualified := selector.QualifiedModel()
+		providerType := s.providerTypeForSelector(selector, providerTypeFromPlan(plan))
+		slog.Warn("primary model attempt failed, trying fallback stream",
+			"request_id", requestID,
+			"from", primaryModel,
+			"to", qualified,
+			"provider_type", providerType,
+			"error", lastErr,
+		)
+
+		stream, resolvedProviderType, usageModel, err := call(selector, providerType)
+		if err == nil {
+			slog.Info("fallback stream attempt succeeded",
+				"request_id", requestID,
+				"from", primaryModel,
+				"to", qualified,
+				"provider_type", resolvedProviderType,
+			)
+			return stream, resolvedProviderType, usageModel, nil
+		}
+		lastErr = err
+	}
+
+	return nil, "", "", lastErr
+}
+
+func shouldAttemptFallback(err error) bool {
+	var gatewayErr *core.GatewayError
+	if !errors.As(err, &gatewayErr) || gatewayErr == nil {
+		return false
+	}
+
+	status := gatewayErr.HTTPStatusCode()
+	if status >= http.StatusInternalServerError || status == http.StatusTooManyRequests || status == http.StatusNotFound {
+		return true
+	}
+
+	code := ""
+	if gatewayErr.Code != nil {
+		code = strings.ToLower(strings.TrimSpace(*gatewayErr.Code))
+	}
+	if code != "" && strings.Contains(code, "model") &&
+		(strings.Contains(code, "not_found") || strings.Contains(code, "unsupported") || strings.Contains(code, "unavailable")) {
+		return true
+	}
+
+	message := strings.ToLower(strings.TrimSpace(gatewayErr.Message))
+	if !strings.Contains(message, "model") {
+		return false
+	}
+
+	for _, fragment := range []string{
+		"not found",
+		"does not exist",
+		"unsupported",
+		"unavailable",
+		"not available",
+		"deprecated",
+		"retired",
+		"disabled",
+	} {
+		if strings.Contains(message, fragment) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -517,7 +517,7 @@ func (s *translatedInferenceService) shouldEnforceReturningUsageData() bool {
 }
 
 func (s *translatedInferenceService) fallbackSelectors(plan *core.ExecutionPlan) []core.ModelSelector {
-	if s.fallbackResolver == nil || plan == nil || plan.Resolution == nil {
+	if s.fallbackResolver == nil || plan == nil || plan.Resolution == nil || !plan.FallbackEnabled() {
 		return nil
 	}
 	return s.fallbackResolver.ResolveFallbacks(plan.Resolution, plan.Endpoint.Operation)

--- a/internal/server/translated_inference_service_test.go
+++ b/internal/server/translated_inference_service_test.go
@@ -45,3 +45,14 @@ func TestTranslatedInferenceService_LogUsageSkipsWhenExecutionPlanDisablesUsage(
 		t.Fatalf("len(entries) = %d, want 0", len(logger.entries))
 	}
 }
+
+func TestTranslatedInferenceService_ProviderTypeForSelectorPrefersExplicitProvider(t *testing.T) {
+	service := &translatedInferenceService{
+		provider: &mockProvider{},
+	}
+
+	got := service.providerTypeForSelector(core.ModelSelector{Provider: "azure", Model: "gpt-4o"}, "openai")
+	if got != "azure" {
+		t.Fatalf("providerTypeForSelector() = %q, want %q", got, "azure")
+	}
+}


### PR DESCRIPTION
## Summary
- add translated-route model fallback with `off`, `manual`, and `auto` modes
- load manual fallback chains from JSON and resolve auto candidates from model ranking metadata
- harden the feature by skipping cache writes for fallback-served responses and disabling embeddings fallback until vector compatibility is modeled

## Testing
- `go test ./...`
- pre-commit hooks during `git commit` (fmt, unit tests, hot-path guard, golangci-lint)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable model fallback: global default, per-model overrides, optional manual-rule file; auto/manual/off modes with ranked, provider-aware candidates
  * Runtime fallback for Chat and Responses (streaming and non-streaming); Embeddings remain without fallback
  * Requests flagged when fallback is used so cache inserts are skipped

* **Documentation**
  * Terminology updated: “failover” → “fallback”

* **Tests**
  * Expanded coverage for fallback config, resolver, ranking, provider metadata, and cache-skipping behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->