### PR TITLE
feat(executionplans): implement policy-resolved execution plans

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -58,6 +58,9 @@ http:
   timeout: 600 # seconds (10 minutes)
   response_header_timeout: 600
 
+execution_plans:
+  refresh_interval: 1m
+
 # Global resilience settings (applied to all providers by default)
 # Individual providers can override any of these values.
 resilience:

--- a/config/config.go
+++ b/config/config.go
@@ -28,16 +28,17 @@ var bodySizeLimitRegex = regexp.MustCompile(`(?i)^(\d+)([KMG])?B?$`)
 
 // Config holds the application configuration.
 type Config struct {
-	Server     ServerConfig     `yaml:"server"`
-	Cache      CacheConfig      `yaml:"cache"`
-	Storage    StorageConfig    `yaml:"storage"`
-	Logging    LogConfig        `yaml:"logging"`
-	Usage      UsageConfig      `yaml:"usage"`
-	Metrics    MetricsConfig    `yaml:"metrics"`
-	HTTP       HTTPConfig       `yaml:"http"`
-	Admin      AdminConfig      `yaml:"admin"`
-	Guardrails GuardrailsConfig `yaml:"guardrails"`
-	Resilience ResilienceConfig `yaml:"resilience"`
+	Server         ServerConfig         `yaml:"server"`
+	Cache          CacheConfig          `yaml:"cache"`
+	Storage        StorageConfig        `yaml:"storage"`
+	Logging        LogConfig            `yaml:"logging"`
+	Usage          UsageConfig          `yaml:"usage"`
+	Metrics        MetricsConfig        `yaml:"metrics"`
+	HTTP           HTTPConfig           `yaml:"http"`
+	Admin          AdminConfig          `yaml:"admin"`
+	Guardrails     GuardrailsConfig     `yaml:"guardrails"`
+	ExecutionPlans ExecutionPlansConfig `yaml:"execution_plans"`
+	Resilience     ResilienceConfig     `yaml:"resilience"`
 }
 
 // LoadResult is returned by Load and bundles the application config with the raw
@@ -155,6 +156,13 @@ type HTTPConfig struct {
 
 	// ResponseHeaderTimeout is the time to wait for response headers in seconds (default: 600)
 	ResponseHeaderTimeout int `yaml:"response_header_timeout" env:"HTTP_RESPONSE_HEADER_TIMEOUT"`
+}
+
+// ExecutionPlansConfig holds runtime refresh behavior for persisted execution plans.
+type ExecutionPlansConfig struct {
+	// RefreshInterval controls how often the in-memory execution-plan snapshot
+	// is refreshed from storage. Default: 1m.
+	RefreshInterval time.Duration `yaml:"refresh_interval" env:"EXECUTION_PLAN_REFRESH_INTERVAL"`
 }
 
 // LogConfig holds audit logging configuration
@@ -565,6 +573,9 @@ func buildDefaultConfig() *Config {
 		HTTP: HTTPConfig{
 			Timeout:               600,
 			ResponseHeaderTimeout: 600,
+		},
+		ExecutionPlans: ExecutionPlansConfig{
+			RefreshInterval: time.Minute,
 		},
 		Resilience: ResilienceConfig{
 			Retry:          DefaultRetryConfig(),

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // clearProviderEnvVars unsets all known provider-related environment variables.
@@ -42,6 +43,7 @@ func clearAllConfigEnvVars(t *testing.T) {
 		"USAGE_BUFFER_SIZE", "USAGE_FLUSH_INTERVAL", "USAGE_RETENTION_DAYS",
 		"GUARDRAILS_ENABLED", "ENABLE_GUARDRAILS_FOR_BATCH_PROCESSING",
 		"HTTP_TIMEOUT", "HTTP_RESPONSE_HEADER_TIMEOUT",
+		"EXECUTION_PLAN_REFRESH_INTERVAL",
 	} {
 		t.Setenv(key, "")
 		os.Unsetenv(key)
@@ -147,6 +149,9 @@ func TestBuildDefaultConfig(t *testing.T) {
 	}
 	if cfg.HTTP.ResponseHeaderTimeout != 600 {
 		t.Errorf("expected HTTP.ResponseHeaderTimeout=600, got %d", cfg.HTTP.ResponseHeaderTimeout)
+	}
+	if cfg.ExecutionPlans.RefreshInterval != time.Minute {
+		t.Errorf("expected ExecutionPlans.RefreshInterval=%s, got %s", time.Minute, cfg.ExecutionPlans.RefreshInterval)
 	}
 	if cfg.Guardrails.EnableForBatchProcessing {
 		t.Error("expected Guardrails.EnableForBatchProcessing=false")
@@ -592,6 +597,50 @@ func TestLoad_HTTPConfig(t *testing.T) {
 		}
 		if result.Config.HTTP.ResponseHeaderTimeout != 60 {
 			t.Errorf("expected HTTP.ResponseHeaderTimeout=60, got %d", result.Config.HTTP.ResponseHeaderTimeout)
+		}
+	})
+}
+
+func TestLoad_ExecutionPlanRefreshInterval(t *testing.T) {
+	clearAllConfigEnvVars(t)
+
+	withTempDir(t, func(_ string) {
+		result, err := Load()
+		if err != nil {
+			t.Fatalf("Load() failed: %v", err)
+		}
+		if result.Config.ExecutionPlans.RefreshInterval != time.Minute {
+			t.Fatalf("ExecutionPlans.RefreshInterval = %s, want %s", result.Config.ExecutionPlans.RefreshInterval, time.Minute)
+		}
+	})
+
+	withTempDir(t, func(dir string) {
+		yaml := `
+execution_plans:
+  refresh_interval: 90s
+`
+		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(yaml), 0644); err != nil {
+			t.Fatalf("Failed to write config.yaml: %v", err)
+		}
+
+		result, err := Load()
+		if err != nil {
+			t.Fatalf("Load() failed: %v", err)
+		}
+		if result.Config.ExecutionPlans.RefreshInterval != 90*time.Second {
+			t.Fatalf("ExecutionPlans.RefreshInterval = %s, want %s", result.Config.ExecutionPlans.RefreshInterval, 90*time.Second)
+		}
+	})
+
+	withTempDir(t, func(_ string) {
+		t.Setenv("EXECUTION_PLAN_REFRESH_INTERVAL", "45s")
+
+		result, err := Load()
+		if err != nil {
+			t.Fatalf("Load() failed: %v", err)
+		}
+		if result.Config.ExecutionPlans.RefreshInterval != 45*time.Second {
+			t.Fatalf("ExecutionPlans.RefreshInterval = %s, want %s", result.Config.ExecutionPlans.RefreshInterval, 45*time.Second)
 		}
 	})
 }

--- a/docs/adr/0003-policy-resolved-execution-plan.md
+++ b/docs/adr/0003-policy-resolved-execution-plan.md
@@ -40,6 +40,7 @@ handlers, middleware, and provider execution code.
 The runtime object is derived from:
 
 - the matched persisted execution plan version
+- process-level feature configuration for the running gateway instance
 - request facts captured from ingress
 - request-scoped resolution results such as endpoint metadata and model
   resolution
@@ -145,8 +146,12 @@ The first required persistence surface is `audit_logs`.
 
 - `execution_plan_version_id`
 
-This id is sufficient for request explainability because the referenced
-execution-plan row is immutable.
+This id identifies the immutable execution-plan version selected for the
+request.
+
+Process-level feature switches may still disable parts of that plan for a given
+deployment. In other words, the matched plan remains traceable, but effective
+runtime behavior can also depend on deployment configuration.
 
 The first slice does not require storing the same field in `usage`.
 
@@ -205,6 +210,14 @@ V1 semantics:
 - later steps start only after the previous step fully completes
 - if `features.guardrails` is `false`, the guardrails array is ignored
 - `ref` must point to an existing named guardrail managed by the gateway
+- process-level feature configuration is a hard upper bound over plan features
+- the effective runtime feature value is `process_enabled AND plan_enabled`
+- if a process-level feature switch is disabled, the corresponding plan field is
+  ignored by that process
+
+This preserves 12-factor operational control. Operators can disable gateway
+features for one deployment through environment-backed process configuration
+without rewriting persisted execution plans.
 
 To preserve immutability, omitted feature flags may be accepted at authoring
 time, but they must be resolved to explicit booleans before an immutable plan
@@ -217,7 +230,10 @@ In other words:
   defaults
 
 This prevents the same immutable execution plan version from changing behavior
-later if process-wide defaults drift.
+later because authoring-time defaults drift.
+
+Process-level hard-disable switches remain allowed to suppress features at
+runtime for a given deployment.
 
 ### 8. Future Evolution
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"sync"
+	"time"
 
 	"gomodel/config"
 	"gomodel/internal/admin"
@@ -17,6 +18,7 @@ import (
 	"gomodel/internal/auditlog"
 	"gomodel/internal/batch"
 	"gomodel/internal/core"
+	"gomodel/internal/executionplans"
 	"gomodel/internal/guardrails"
 	"gomodel/internal/providers"
 	"gomodel/internal/responsecache"
@@ -28,13 +30,14 @@ import (
 // App represents the main application with all its dependencies.
 // It provides centralized lifecycle management for all components.
 type App struct {
-	config    *config.Config
-	providers *providers.InitResult
-	audit     *auditlog.Result
-	usage     *usage.Result
-	batch     *batch.Result
-	aliases   *aliases.Result
-	server    *server.Server
+	config         *config.Config
+	providers      *providers.InitResult
+	audit          *auditlog.Result
+	usage          *usage.Result
+	batch          *batch.Result
+	aliases        *aliases.Result
+	executionPlans *executionplans.Result
+	server         *server.Server
 
 	shutdownMu sync.Mutex
 	shutdown   bool
@@ -156,8 +159,10 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 	var provider core.RoutableProvider = app.providers.Router
 	var translatedRequestPatcher server.TranslatedRequestPatcher
 	var batchRequestPreparers []server.BatchRequestPreparer
-	if appCfg.Guardrails.Enabled {
-		pipeline, err := buildGuardrailsPipeline(appCfg.Guardrails)
+	featureCaps := runtimeExecutionFeatureCaps(appCfg)
+	var guardrailRegistry *guardrails.Registry
+	if featureCaps.Guardrails {
+		guardrailRegistry, err = buildGuardrailRegistry(appCfg.Guardrails)
 		if err != nil {
 			var (
 				aliasCloseErr error
@@ -175,14 +180,49 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 			}
 			return nil, fmt.Errorf("failed to build guardrails: %w", err)
 		}
-		if pipeline.Len() > 0 {
-			translatedRequestPatcher = guardrails.NewRequestPatcher(pipeline)
+	}
+
+	var executionPlanResult *executionplans.Result
+	sharedExecutionPlanStorage := firstSharedStorage(auditResult.Storage, usageResult.Storage, batchResult.Storage, aliasResult.Storage)
+	executionPlanCompiler := executionplans.NewCompilerWithFeatureCaps(guardrailRegistry, featureCaps)
+	if sharedExecutionPlanStorage != nil {
+		executionPlanResult, err = executionplans.NewWithSharedStorage(ctx, sharedExecutionPlanStorage, executionPlanCompiler, time.Minute)
+	} else {
+		executionPlanResult, err = executionplans.New(ctx, appCfg, executionPlanCompiler, time.Minute)
+	}
+	if err != nil {
+		closeErr := errors.Join(app.aliases.Close(), app.batch.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		if closeErr != nil {
+			return nil, fmt.Errorf("failed to initialize execution plans: %w (also: close error: %v)", err, closeErr)
+		}
+		return nil, fmt.Errorf("failed to initialize execution plans: %w", err)
+	}
+	defaultExecutionPlan := defaultExecutionPlanInput(appCfg)
+	if err := executionPlanResult.Service.EnsureDefaultGlobal(ctx, defaultExecutionPlan); err != nil {
+		closeErr := errors.Join(executionPlanResult.Close(), app.aliases.Close(), app.batch.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		if closeErr != nil {
+			return nil, fmt.Errorf("failed to seed execution plans: %w (also: close error: %v)", err, closeErr)
+		}
+		return nil, fmt.Errorf("failed to seed execution plans: %w", err)
+	}
+	if err := executionPlanResult.Service.Refresh(ctx); err != nil {
+		closeErr := errors.Join(executionPlanResult.Close(), app.aliases.Close(), app.batch.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		if closeErr != nil {
+			return nil, fmt.Errorf("failed to load execution plans: %w (also: close error: %v)", err, closeErr)
+		}
+		return nil, fmt.Errorf("failed to load execution plans: %w", err)
+	}
+	app.executionPlans = executionPlanResult
+
+	if featureCaps.Guardrails {
+		if guardrailRegistry != nil && guardrailRegistry.Len() > 0 {
+			translatedRequestPatcher = guardrails.NewPlannedRequestPatcher(executionPlanResult.Service)
 			if appCfg.Guardrails.EnableForBatchProcessing {
-				batchRequestPreparers = append(batchRequestPreparers, guardrails.NewBatchPreparer(provider, pipeline))
+				batchRequestPreparers = append(batchRequestPreparers, guardrails.NewPlannedBatchPreparer(provider, executionPlanResult.Service))
 			}
 			slog.Info(
 				"guardrails enabled",
-				"count", pipeline.Len(),
+				"count", guardrailRegistry.Len(),
 				"enable_for_batch_processing", appCfg.Guardrails.EnableForBatchProcessing,
 			)
 		}
@@ -208,6 +248,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		UsageLogger:                  usageResult.Logger,
 		PricingResolver:              providerResult.Registry,
 		ModelResolver:                app.aliases.Service,
+		ExecutionPolicyResolver:      executionPlanResult.Service,
 		TranslatedRequestPatcher:     translatedRequestPatcher,
 		GuardrailsHash:               guardrailsHash,
 		BatchRequestPreparer:         batchRequestPreparer,
@@ -260,16 +301,20 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 	rcm, err := responsecache.NewResponseCacheMiddleware(appCfg.Cache.Response, cfg.AppConfig.RawProviders)
 	if err != nil {
 		var (
-			aliasCloseErr error
-			batchCloseErr error
+			executionPlansCloseErr error
+			aliasCloseErr          error
+			batchCloseErr          error
 		)
+		if app.executionPlans != nil {
+			executionPlansCloseErr = app.executionPlans.Close()
+		}
 		if app.aliases != nil {
 			aliasCloseErr = app.aliases.Close()
 		}
 		if app.batch != nil {
 			batchCloseErr = app.batch.Close()
 		}
-		closeErr := errors.Join(aliasCloseErr, batchCloseErr, app.usage.Close(), app.audit.Close(), app.providers.Close())
+		closeErr := errors.Join(executionPlansCloseErr, aliasCloseErr, batchCloseErr, app.usage.Close(), app.audit.Close(), app.providers.Close())
 		if closeErr != nil {
 			return nil, fmt.Errorf("failed to initialize response cache: %w (also: close error: %v)", err, closeErr)
 		}
@@ -401,7 +446,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// 2. Close providers (stops background refresh and cache)
+	// 2. Close providers (stops model refresh and provider-owned resources)
 	if a.providers != nil {
 		if err := a.providers.Close(); err != nil {
 			slog.Error("providers close error", "error", err)
@@ -417,7 +462,15 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// 4. Close batch store (flushes pending entries)
+	// 4. Close execution plans subsystem.
+	if a.executionPlans != nil {
+		if err := a.executionPlans.Close(); err != nil {
+			slog.Error("execution plans close error", "error", err)
+			errs = append(errs, fmt.Errorf("execution plans close: %w", err))
+		}
+	}
+
+	// 5. Close batch store (flushes pending entries)
 	if a.batch != nil {
 		if err := a.batch.Close(); err != nil {
 			slog.Error("batch store close error", "error", err)
@@ -425,7 +478,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// 5. Close usage tracking (flushes pending entries)
+	// 6. Close usage tracking (flushes pending entries)
 	if a.usage != nil {
 		if err := a.usage.Close(); err != nil {
 			slog.Error("usage logger close error", "error", err)
@@ -433,7 +486,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// 6. Close audit logging (flushes pending logs)
+	// 7. Close audit logging (flushes pending logs)
 	if a.audit != nil {
 		if err := a.audit.Close(); err != nil {
 			slog.Error("audit logger close error", "error", err)
@@ -542,20 +595,26 @@ func initAdmin(auditStorage, usageStorage storage.Storage, registry *providers.M
 	return adminHandler, dashHandler, nil
 }
 
-// buildGuardrailsPipeline creates a guardrails pipeline from configuration.
-func buildGuardrailsPipeline(cfg config.GuardrailsConfig) (*guardrails.Pipeline, error) {
-	pipeline := guardrails.NewPipeline()
+func buildGuardrailRegistry(cfg config.GuardrailsConfig) (*guardrails.Registry, error) {
+	registry := guardrails.NewRegistry()
 
 	for i, rule := range cfg.Rules {
 		g, err := buildGuardrail(rule)
 		if err != nil {
 			return nil, fmt.Errorf("guardrail rule #%d (%q): %w", i, rule.Name, err)
 		}
-		pipeline.Add(g, rule.Order)
+		if err := registry.Register(g, responsecache.GuardrailRuleDescriptor{
+			Type:    rule.Type,
+			Order:   rule.Order,
+			Mode:    effectiveSystemPromptMode(rule.SystemPrompt.Mode),
+			Content: rule.SystemPrompt.Content,
+		}); err != nil {
+			return nil, fmt.Errorf("register guardrail %q: %w", rule.Name, err)
+		}
 		slog.Info("guardrail registered", "name", rule.Name, "type", rule.Type, "order", rule.Order)
 	}
 
-	return pipeline, nil
+	return registry, nil
 }
 
 // buildGuardrail creates a single Guardrail instance from a rule config.
@@ -566,10 +625,7 @@ func buildGuardrail(rule config.GuardrailRuleConfig) (guardrails.Guardrail, erro
 
 	switch rule.Type {
 	case "system_prompt":
-		mode := guardrails.SystemPromptMode(rule.SystemPrompt.Mode)
-		if mode == "" {
-			mode = guardrails.SystemPromptInject
-		}
+		mode := guardrails.SystemPromptMode(effectiveSystemPromptMode(rule.SystemPrompt.Mode))
 		return guardrails.NewSystemPromptGuardrail(rule.Name, mode, rule.SystemPrompt.Content)
 
 	default:
@@ -590,9 +646,71 @@ func computeGuardrailsHashFromConfig(cfg config.GuardrailsConfig) string {
 			Name:    r.Name,
 			Type:    r.Type,
 			Order:   r.Order,
-			Mode:    r.SystemPrompt.Mode,
+			Mode:    effectiveSystemPromptMode(r.SystemPrompt.Mode),
 			Content: r.SystemPrompt.Content,
 		}
 	}
 	return responsecache.ComputeGuardrailsHash(rules)
+}
+
+func effectiveSystemPromptMode(mode string) string {
+	resolved := guardrails.SystemPromptMode(mode)
+	if resolved == "" {
+		return string(guardrails.SystemPromptInject)
+	}
+	return string(resolved)
+}
+
+func defaultExecutionPlanInput(cfg *config.Config) executionplans.CreateInput {
+	payload := executionplans.Payload{
+		SchemaVersion: 1,
+		Features: executionplans.FeatureFlags{
+			Cache:      responseCacheConfigured(cfg.Cache.Response),
+			Audit:      cfg.Logging.Enabled,
+			Usage:      cfg.Usage.Enabled,
+			Guardrails: cfg.Guardrails.Enabled && len(cfg.Guardrails.Rules) > 0,
+		},
+	}
+	if payload.Features.Guardrails {
+		payload.Guardrails = make([]executionplans.GuardrailStep, 0, len(cfg.Guardrails.Rules))
+		for _, rule := range cfg.Guardrails.Rules {
+			payload.Guardrails = append(payload.Guardrails, executionplans.GuardrailStep{
+				Ref:  rule.Name,
+				Step: rule.Order,
+			})
+		}
+	}
+
+	return executionplans.CreateInput{
+		Scope:       executionplans.Scope{},
+		Activate:    true,
+		Name:        "default-global",
+		Description: "Bootstrapped from runtime configuration",
+		Payload:     payload,
+	}
+}
+
+func runtimeExecutionFeatureCaps(cfg *config.Config) core.ExecutionFeatures {
+	if cfg == nil {
+		return core.ExecutionFeatures{}
+	}
+	return core.ExecutionFeatures{
+		Cache:      responseCacheConfigured(cfg.Cache.Response),
+		Audit:      cfg.Logging.Enabled,
+		Usage:      cfg.Usage.Enabled,
+		Guardrails: cfg.Guardrails.Enabled,
+	}
+}
+
+func responseCacheConfigured(cfg config.ResponseCacheConfig) bool {
+	return (cfg.Simple.Redis != nil && cfg.Simple.Redis.URL != "") || config.SemanticCacheActive(&cfg.Semantic)
+}
+
+func firstSharedStorage(candidates ...storage.Storage) storage.Storage {
+	for _, candidate := range candidates {
+		if candidate != nil {
+			return candidate
+		}
+	}
+	return nil
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -185,10 +185,11 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 	var executionPlanResult *executionplans.Result
 	sharedExecutionPlanStorage := firstSharedStorage(auditResult.Storage, usageResult.Storage, batchResult.Storage, aliasResult.Storage)
 	executionPlanCompiler := executionplans.NewCompilerWithFeatureCaps(guardrailRegistry, featureCaps)
+	refreshInterval := executionPlanRefreshInterval(appCfg)
 	if sharedExecutionPlanStorage != nil {
-		executionPlanResult, err = executionplans.NewWithSharedStorage(ctx, sharedExecutionPlanStorage, executionPlanCompiler, time.Minute)
+		executionPlanResult, err = executionplans.NewWithSharedStorage(ctx, sharedExecutionPlanStorage, executionPlanCompiler, refreshInterval)
 	} else {
-		executionPlanResult, err = executionplans.New(ctx, appCfg, executionPlanCompiler, time.Minute)
+		executionPlanResult, err = executionplans.New(ctx, appCfg, executionPlanCompiler, refreshInterval)
 	}
 	if err != nil {
 		closeErr := errors.Join(app.aliases.Close(), app.batch.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
@@ -700,6 +701,13 @@ func runtimeExecutionFeatureCaps(cfg *config.Config) core.ExecutionFeatures {
 		Usage:      cfg.Usage.Enabled,
 		Guardrails: cfg.Guardrails.Enabled,
 	}
+}
+
+func executionPlanRefreshInterval(cfg *config.Config) time.Duration {
+	if cfg == nil || cfg.ExecutionPlans.RefreshInterval <= 0 {
+		return time.Minute
+	}
+	return cfg.ExecutionPlans.RefreshInterval
 }
 
 func responseCacheConfigured(cfg config.ResponseCacheConfig) bool {

--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -38,11 +38,12 @@ type LogEntry struct {
 	DurationNs int64 `json:"duration_ns" bson:"duration_ns"`
 
 	// Core fields (indexed for queries)
-	Model         string `json:"model" bson:"model"`
-	ResolvedModel string `json:"resolved_model,omitempty" bson:"resolved_model,omitempty"`
-	Provider      string `json:"provider" bson:"provider"`
-	AliasUsed     bool   `json:"alias_used,omitempty" bson:"alias_used,omitempty"`
-	StatusCode    int    `json:"status_code" bson:"status_code"`
+	Model                  string `json:"model" bson:"model"`
+	ResolvedModel          string `json:"resolved_model,omitempty" bson:"resolved_model,omitempty"`
+	Provider               string `json:"provider" bson:"provider"`
+	AliasUsed              bool   `json:"alias_used,omitempty" bson:"alias_used,omitempty"`
+	ExecutionPlanVersionID string `json:"execution_plan_version_id,omitempty" bson:"execution_plan_version_id,omitempty"`
+	StatusCode             int    `json:"status_code" bson:"status_code"`
 
 	// Extracted fields for efficient filtering (indexed in relational DBs)
 	RequestID string `json:"request_id,omitempty" bson:"request_id,omitempty"`

--- a/internal/auditlog/auditlog_test.go
+++ b/internal/auditlog/auditlog_test.go
@@ -1211,6 +1211,18 @@ func (t *trackingReadCloser) Close() error {
 	return nil
 }
 
+type chainReadCloser struct {
+	io.Reader
+	closer io.Closer
+}
+
+func (c *chainReadCloser) Close() error {
+	if c == nil || c.closer == nil {
+		return nil
+	}
+	return c.closer.Close()
+}
+
 // discardWriter implements http.ResponseWriter but discards all output.
 type discardWriter struct{}
 
@@ -1304,9 +1316,9 @@ func TestLimitedReaderRequestBodyCapture(t *testing.T) {
 		}
 
 		origBody := req.Body
-		req.Body = &combinedReadCloser{
+		req.Body = &chainReadCloser{
 			Reader: io.MultiReader(bytes.NewReader(bodyBytes), origBody),
-			rc:     origBody,
+			closer: origBody,
 		}
 
 		// Read full body from reconstructed reader

--- a/internal/auditlog/auditlog_test.go
+++ b/internal/auditlog/auditlog_test.go
@@ -626,6 +626,81 @@ func TestMiddleware_PassthroughExecutionPlanUsesPassthroughModel(t *testing.T) {
 	}
 }
 
+func TestMiddleware_StoresExecutionPlanVersionID(t *testing.T) {
+	e := echo.New()
+	logger := &capturingLogger{
+		cfg: Config{Enabled: true},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-5-nano"}`))
+	req = req.WithContext(core.WithExecutionPlan(req.Context(), &core.ExecutionPlan{
+		ProviderType: "openai",
+		Policy: &core.ResolvedExecutionPolicy{
+			VersionID: "plan-version-123",
+			Features:  core.DefaultExecutionFeatures(),
+		},
+		Resolution: &core.RequestModelResolution{
+			Requested:        core.NewRequestedModelSelector("gpt-5-nano", ""),
+			ResolvedSelector: core.ModelSelector{Provider: "openai", Model: "gpt-5-nano"},
+			ProviderType:     "openai",
+		},
+	}))
+
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	handler := Middleware(logger)(func(c *echo.Context) error {
+		return c.NoContent(http.StatusNoContent)
+	})
+
+	if err := handler(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if len(logger.entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1", len(logger.entries))
+	}
+	if got := logger.entries[0].ExecutionPlanVersionID; got != "plan-version-123" {
+		t.Fatalf("ExecutionPlanVersionID = %q, want plan-version-123", got)
+	}
+}
+
+func TestMiddleware_SkipsWriteWhenExecutionPlanDisablesAudit(t *testing.T) {
+	e := echo.New()
+	logger := &capturingLogger{
+		cfg: Config{Enabled: true, LogBodies: true, LogHeaders: true},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-5-nano"}`))
+	req = req.WithContext(core.WithExecutionPlan(req.Context(), &core.ExecutionPlan{
+		Policy: &core.ResolvedExecutionPolicy{
+			VersionID: "plan-version-123",
+			Features: core.ExecutionFeatures{
+				Cache:      true,
+				Audit:      false,
+				Usage:      true,
+				Guardrails: true,
+			},
+		},
+	}))
+
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	handler := Middleware(logger)(func(c *echo.Context) error {
+		if entry := c.Get(string(LogEntryKey)); entry != nil {
+			t.Fatalf("LogEntryKey = %T, want nil", entry)
+		}
+		return c.NoContent(http.StatusNoContent)
+	})
+
+	if err := handler(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if len(logger.entries) != 0 {
+		t.Fatalf("len(entries) = %d, want 0", len(logger.entries))
+	}
+}
+
 func TestLoggerClose(t *testing.T) {
 	store := &mockStore{}
 	cfg := Config{

--- a/internal/auditlog/auditlog_test.go
+++ b/internal/auditlog/auditlog_test.go
@@ -637,7 +637,12 @@ func TestMiddleware_StoresExecutionPlanVersionID(t *testing.T) {
 		ProviderType: "openai",
 		Policy: &core.ResolvedExecutionPolicy{
 			VersionID: "plan-version-123",
-			Features:  core.DefaultExecutionFeatures(),
+			Features: core.ExecutionFeatures{
+				Cache:      true,
+				Audit:      true,
+				Usage:      true,
+				Guardrails: true,
+			},
 		},
 		Resolution: &core.RequestModelResolution{
 			Requested:        core.NewRequestedModelSelector("gpt-5-nano", ""),

--- a/internal/auditlog/entry_capture.go
+++ b/internal/auditlog/entry_capture.go
@@ -1,0 +1,55 @@
+package auditlog
+
+import (
+	"net/http"
+
+	"gomodel/internal/core"
+)
+
+// PopulateRequestData copies the configured request capture fields into the log entry.
+// Streaming handlers call this before creating the detached stream entry so request
+// metadata is preserved even though the middleware finishes later.
+func PopulateRequestData(entry *LogEntry, req *http.Request, cfg Config) {
+	if entry == nil || req == nil {
+		return
+	}
+
+	data := ensureLogData(entry)
+
+	if cfg.LogHeaders {
+		data.RequestHeaders = extractHeaders(req.Header)
+	}
+
+	if !cfg.LogBodies {
+		return
+	}
+
+	snapshot := core.GetRequestSnapshot(req.Context())
+	if snapshot == nil {
+		return
+	}
+
+	switch body := snapshot.CapturedBody(); {
+	case snapshot.BodyNotCaptured:
+		data.RequestBodyTooBigToHandle = true
+	case body != nil:
+		captureLoggedRequestBody(entry, body)
+	}
+}
+
+// PopulateResponseHeaders copies response headers into the log entry when header logging is enabled.
+func PopulateResponseHeaders(entry *LogEntry, headers http.Header) {
+	if entry == nil || headers == nil {
+		return
+	}
+
+	data := ensureLogData(entry)
+	data.ResponseHeaders = extractHeaders(headers)
+}
+
+func ensureLogData(entry *LogEntry) *LogData {
+	if entry.Data == nil {
+		entry.Data = &LogData{}
+	}
+	return entry.Data
+}

--- a/internal/auditlog/middleware.go
+++ b/internal/auditlog/middleware.go
@@ -72,28 +72,6 @@ func Middleware(logger LoggerInterface) echo.MiddlewareFunc {
 				entry.Data.APIKeyHash = hashAPIKey(authHeader)
 			}
 
-			// Log request headers if enabled
-			if cfg.LogHeaders {
-				entry.Data.RequestHeaders = extractHeaders(req.Header)
-			}
-
-			// Capture request body if enabled
-			if cfg.LogBodies && req.Body != nil {
-				if snapshot := core.GetRequestSnapshot(req.Context()); snapshot != nil {
-					body := snapshot.CapturedBody()
-					switch {
-					case snapshot.BodyNotCaptured:
-						entry.Data.RequestBodyTooBigToHandle = true
-					case body != nil:
-						captureLoggedRequestBody(entry, body)
-					default:
-						captureRequestBodyForLogging(entry, req)
-					}
-				} else {
-					captureRequestBodyForLogging(entry, req)
-				}
-			}
-
 			// Store entry in context for potential enrichment by handlers
 			c.Set(string(LogEntryKey), entry)
 
@@ -104,7 +82,7 @@ func Middleware(logger LoggerInterface) echo.MiddlewareFunc {
 					ResponseWriter: c.Response(),
 					body:           &bytes.Buffer{},
 					shouldCapture: func() bool {
-						return shouldCaptureResponseBody(c)
+						return auditEnabledForContext(c.Request().Context()) && shouldCaptureResponseBody(c)
 					},
 				}
 				c.SetResponse(responseCapture)
@@ -115,6 +93,10 @@ func Middleware(logger LoggerInterface) echo.MiddlewareFunc {
 
 			applyExecutionPlan(entry, c.Request().Context())
 
+			if !auditEnabledForContext(c.Request().Context()) {
+				return err
+			}
+
 			// Calculate duration
 			entry.DurationNs = time.Since(start).Nanoseconds()
 
@@ -122,9 +104,13 @@ func Middleware(logger LoggerInterface) echo.MiddlewareFunc {
 			// suggested status codes, and errors implementing HTTPStatusCoder.
 			_, entry.StatusCode = echo.ResolveResponseStatus(c.Response(), err)
 
+			// Request capture is deferred until after next so a later-resolved
+			// Audit=false plan can skip it entirely.
+			PopulateRequestData(entry, req, cfg)
+
 			// Log response headers if enabled
 			if cfg.LogHeaders {
-				entry.Data.ResponseHeaders = extractHeaders(c.Response().Header())
+				PopulateResponseHeaders(entry, c.Response().Header())
 			}
 
 			// Capture response body if enabled
@@ -205,35 +191,6 @@ func enrichEntryWithExecutionPlan(entry *LogEntry, plan *core.ExecutionPlan) {
 	}
 }
 
-func captureRequestBodyForLogging(entry *LogEntry, req *http.Request) {
-	if req.ContentLength > MaxBodyCapture {
-		entry.Data.RequestBodyTooBigToHandle = true
-		return
-	}
-
-	// Read up to MaxBodyCapture+1 to detect overflow safely.
-	// Uses io.LimitReader to enforce the cap regardless of
-	// Content-Length (handles chunked/unknown-length requests).
-	limitedReader := io.LimitReader(req.Body, MaxBodyCapture+1)
-	bodyBytes, err := io.ReadAll(limitedReader)
-	if err != nil {
-		return
-	}
-	if int64(len(bodyBytes)) > MaxBodyCapture {
-		entry.Data.RequestBodyTooBigToHandle = true
-		// Reconstruct full body for downstream: read bytes + unread remainder
-		origBody := req.Body
-		req.Body = &combinedReadCloser{
-			Reader: io.MultiReader(bytes.NewReader(bodyBytes), origBody),
-			rc:     origBody,
-		}
-		return
-	}
-
-	captureLoggedRequestBody(entry, bodyBytes)
-	req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
-}
-
 func captureLoggedRequestBody(entry *LogEntry, bodyBytes []byte) {
 	if len(bodyBytes) == 0 {
 		return
@@ -248,17 +205,6 @@ func captureLoggedRequestBody(entry *LogEntry, bodyBytes []byte) {
 
 	// Fallback: store as valid UTF-8 string if not valid JSON
 	entry.Data.RequestBody = toValidUTF8String(bodyBytes)
-}
-
-// combinedReadCloser delegates Read to an io.Reader and Close to an io.ReadCloser.
-// Used to reconstruct a request body that preserves the original closer.
-type combinedReadCloser struct {
-	io.Reader
-	rc io.ReadCloser
-}
-
-func (c *combinedReadCloser) Close() error {
-	return c.rc.Close()
 }
 
 // responseBodyCapture wraps http.ResponseWriter to capture the response body.

--- a/internal/auditlog/middleware.go
+++ b/internal/auditlog/middleware.go
@@ -44,6 +44,10 @@ func Middleware(logger LoggerInterface) echo.MiddlewareFunc {
 				return next(c)
 			}
 
+			if !auditEnabledForContext(c.Request().Context()) {
+				return next(c)
+			}
+
 			start := time.Now()
 			req := c.Request()
 
@@ -195,6 +199,9 @@ func enrichEntryWithExecutionPlan(entry *LogEntry, plan *core.ExecutionPlan) {
 	}
 	if plan.Resolution != nil {
 		entry.AliasUsed = plan.Resolution.AliasApplied
+	}
+	if versionID := strings.TrimSpace(plan.ExecutionPlanVersionID()); versionID != "" {
+		entry.ExecutionPlanVersionID = versionID
 	}
 }
 
@@ -392,6 +399,11 @@ func EnrichEntryWithExecutionPlan(c *echo.Context, plan *core.ExecutionPlan) {
 	}
 
 	enrichEntryWithExecutionPlan(entry, plan)
+}
+
+func auditEnabledForContext(ctx context.Context) bool {
+	plan := core.GetExecutionPlan(ctx)
+	return plan == nil || plan.AuditEnabled()
 }
 
 // EnrichEntryWithError adds error information to the log entry.

--- a/internal/auditlog/middleware.go
+++ b/internal/auditlog/middleware.go
@@ -44,6 +44,10 @@ func Middleware(logger LoggerInterface) echo.MiddlewareFunc {
 				return next(c)
 			}
 
+			// This only short-circuits when an upstream component has already
+			// populated the context with an Audit=false execution plan before next(c).
+			// In the common path planning happens later, so the real gating occurs
+			// after next(c) once the final plan has been resolved.
 			if !auditEnabledForContext(c.Request().Context()) {
 				return next(c)
 			}

--- a/internal/auditlog/reader_mongodb.go
+++ b/internal/auditlog/reader_mongodb.go
@@ -17,40 +17,42 @@ type MongoDBReader struct {
 }
 
 type mongoLogRow struct {
-	ID            string    `bson:"_id"`
-	Timestamp     time.Time `bson:"timestamp"`
-	DurationNs    int64     `bson:"duration_ns"`
-	Model         string    `bson:"model"`
-	ResolvedModel string    `bson:"resolved_model"`
-	Provider      string    `bson:"provider"`
-	AliasUsed     bool      `bson:"alias_used"`
-	StatusCode    int       `bson:"status_code"`
-	RequestID     string    `bson:"request_id"`
-	ClientIP      string    `bson:"client_ip"`
-	Method        string    `bson:"method"`
-	Path          string    `bson:"path"`
-	Stream        bool      `bson:"stream"`
-	ErrorType     string    `bson:"error_type"`
-	Data          *LogData  `bson:"data"`
+	ID                     string    `bson:"_id"`
+	Timestamp              time.Time `bson:"timestamp"`
+	DurationNs             int64     `bson:"duration_ns"`
+	Model                  string    `bson:"model"`
+	ResolvedModel          string    `bson:"resolved_model"`
+	Provider               string    `bson:"provider"`
+	AliasUsed              bool      `bson:"alias_used"`
+	ExecutionPlanVersionID string    `bson:"execution_plan_version_id"`
+	StatusCode             int       `bson:"status_code"`
+	RequestID              string    `bson:"request_id"`
+	ClientIP               string    `bson:"client_ip"`
+	Method                 string    `bson:"method"`
+	Path                   string    `bson:"path"`
+	Stream                 bool      `bson:"stream"`
+	ErrorType              string    `bson:"error_type"`
+	Data                   *LogData  `bson:"data"`
 }
 
 func (r mongoLogRow) toLogEntry() *LogEntry {
 	return &LogEntry{
-		ID:            r.ID,
-		Timestamp:     r.Timestamp,
-		DurationNs:    r.DurationNs,
-		Model:         r.Model,
-		ResolvedModel: r.ResolvedModel,
-		Provider:      r.Provider,
-		AliasUsed:     r.AliasUsed,
-		StatusCode:    r.StatusCode,
-		RequestID:     r.RequestID,
-		ClientIP:      r.ClientIP,
-		Method:        r.Method,
-		Path:          r.Path,
-		Stream:        r.Stream,
-		ErrorType:     r.ErrorType,
-		Data:          sanitizeLogData(r.Data),
+		ID:                     r.ID,
+		Timestamp:              r.Timestamp,
+		DurationNs:             r.DurationNs,
+		Model:                  r.Model,
+		ResolvedModel:          r.ResolvedModel,
+		Provider:               r.Provider,
+		AliasUsed:              r.AliasUsed,
+		ExecutionPlanVersionID: r.ExecutionPlanVersionID,
+		StatusCode:             r.StatusCode,
+		RequestID:              r.RequestID,
+		ClientIP:               r.ClientIP,
+		Method:                 r.Method,
+		Path:                   r.Path,
+		Stream:                 r.Stream,
+		ErrorType:              r.ErrorType,
+		Data:                   sanitizeLogData(r.Data),
 	}
 }
 

--- a/internal/auditlog/reader_postgresql.go
+++ b/internal/auditlog/reader_postgresql.go
@@ -78,7 +78,7 @@ func (r *PostgreSQLReader) GetLogs(ctx context.Context, params LogQueryParams) (
 		return nil, fmt.Errorf("failed to count audit log entries: %w", err)
 	}
 
-	dataQuery := fmt.Sprintf(`SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, status_code, request_id,
+	dataQuery := fmt.Sprintf(`SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, status_code, request_id,
 		client_ip, method, path, stream, error_type, data
 		FROM audit_logs%s ORDER BY timestamp DESC LIMIT $%d OFFSET $%d`, where, argIdx, argIdx+1)
 	dataArgs := append(append([]any(nil), args...), limit, offset)
@@ -94,7 +94,7 @@ func (r *PostgreSQLReader) GetLogs(ctx context.Context, params LogQueryParams) (
 		var e LogEntry
 		var dataJSON *string
 
-		if err := rows.Scan(&e.ID, &e.Timestamp, &e.DurationNs, &e.Model, &e.ResolvedModel, &e.Provider, &e.AliasUsed, &e.StatusCode,
+		if err := rows.Scan(&e.ID, &e.Timestamp, &e.DurationNs, &e.Model, &e.ResolvedModel, &e.Provider, &e.AliasUsed, &e.ExecutionPlanVersionID, &e.StatusCode,
 			&e.RequestID, &e.ClientIP, &e.Method, &e.Path, &e.Stream, &e.ErrorType, &dataJSON); err != nil {
 			return nil, fmt.Errorf("failed to scan audit log row: %w", err)
 		}
@@ -125,7 +125,7 @@ func (r *PostgreSQLReader) GetLogs(ctx context.Context, params LogQueryParams) (
 
 // GetLogByID returns a single audit log entry by ID.
 func (r *PostgreSQLReader) GetLogByID(ctx context.Context, id string) (*LogEntry, error) {
-	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, status_code, request_id,
+	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, status_code, request_id,
 		client_ip, method, path, stream, error_type, data
 		FROM audit_logs WHERE id::text = $1 LIMIT 1`
 
@@ -167,7 +167,7 @@ func pgDateRangeConditions(params QueryParams, argIdx int) (conditions []string,
 }
 
 func (r *PostgreSQLReader) findByResponseID(ctx context.Context, responseID string) (*LogEntry, error) {
-	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, status_code, request_id,
+	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, status_code, request_id,
 		client_ip, method, path, stream, error_type, data
 		FROM audit_logs
 		WHERE data->'response_body'->>'id' = $1
@@ -186,7 +186,7 @@ func (r *PostgreSQLReader) findByResponseID(ctx context.Context, responseID stri
 }
 
 func (r *PostgreSQLReader) findByPreviousResponseID(ctx context.Context, previousResponseID string) (*LogEntry, error) {
-	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, status_code, request_id,
+	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, status_code, request_id,
 		client_ip, method, path, stream, error_type, data
 		FROM audit_logs
 		WHERE data->'request_body'->>'previous_response_id' = $1
@@ -210,7 +210,7 @@ func scanPostgreSQLLogEntry(rows interface {
 	var e LogEntry
 	var dataJSON *string
 
-	if err := rows.Scan(&e.ID, &e.Timestamp, &e.DurationNs, &e.Model, &e.ResolvedModel, &e.Provider, &e.AliasUsed, &e.StatusCode,
+	if err := rows.Scan(&e.ID, &e.Timestamp, &e.DurationNs, &e.Model, &e.ResolvedModel, &e.Provider, &e.AliasUsed, &e.ExecutionPlanVersionID, &e.StatusCode,
 		&e.RequestID, &e.ClientIP, &e.Method, &e.Path, &e.Stream, &e.ErrorType, &dataJSON); err != nil {
 		return nil, fmt.Errorf("failed to scan audit log row: %w", err)
 	}

--- a/internal/auditlog/reader_postgresql.go
+++ b/internal/auditlog/reader_postgresql.go
@@ -93,10 +93,14 @@ func (r *PostgreSQLReader) GetLogs(ctx context.Context, params LogQueryParams) (
 	for rows.Next() {
 		var e LogEntry
 		var dataJSON *string
+		var executionPlanVersionID *string
 
-		if err := rows.Scan(&e.ID, &e.Timestamp, &e.DurationNs, &e.Model, &e.ResolvedModel, &e.Provider, &e.AliasUsed, &e.ExecutionPlanVersionID, &e.StatusCode,
+		if err := rows.Scan(&e.ID, &e.Timestamp, &e.DurationNs, &e.Model, &e.ResolvedModel, &e.Provider, &e.AliasUsed, &executionPlanVersionID, &e.StatusCode,
 			&e.RequestID, &e.ClientIP, &e.Method, &e.Path, &e.Stream, &e.ErrorType, &dataJSON); err != nil {
 			return nil, fmt.Errorf("failed to scan audit log row: %w", err)
+		}
+		if executionPlanVersionID != nil {
+			e.ExecutionPlanVersionID = *executionPlanVersionID
 		}
 
 		if dataJSON != nil && *dataJSON != "" {
@@ -209,10 +213,14 @@ func scanPostgreSQLLogEntry(rows interface {
 }) (*LogEntry, error) {
 	var e LogEntry
 	var dataJSON *string
+	var executionPlanVersionID *string
 
-	if err := rows.Scan(&e.ID, &e.Timestamp, &e.DurationNs, &e.Model, &e.ResolvedModel, &e.Provider, &e.AliasUsed, &e.ExecutionPlanVersionID, &e.StatusCode,
+	if err := rows.Scan(&e.ID, &e.Timestamp, &e.DurationNs, &e.Model, &e.ResolvedModel, &e.Provider, &e.AliasUsed, &executionPlanVersionID, &e.StatusCode,
 		&e.RequestID, &e.ClientIP, &e.Method, &e.Path, &e.Stream, &e.ErrorType, &dataJSON); err != nil {
 		return nil, fmt.Errorf("failed to scan audit log row: %w", err)
+	}
+	if executionPlanVersionID != nil {
+		e.ExecutionPlanVersionID = *executionPlanVersionID
 	}
 
 	if dataJSON != nil && *dataJSON != "" {

--- a/internal/auditlog/reader_sqlite.go
+++ b/internal/auditlog/reader_sqlite.go
@@ -76,7 +76,7 @@ func (r *SQLiteReader) GetLogs(ctx context.Context, params LogQueryParams) (*Log
 		return nil, fmt.Errorf("failed to count audit log entries: %w", err)
 	}
 
-	dataQuery := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, status_code, request_id,
+	dataQuery := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, status_code, request_id,
 		client_ip, method, path, stream, error_type, data
 		FROM audit_logs` + where + ` ORDER BY timestamp DESC LIMIT ? OFFSET ?`
 	dataArgs := append(append([]any(nil), args...), limit, offset)
@@ -95,7 +95,7 @@ func (r *SQLiteReader) GetLogs(ctx context.Context, params LogQueryParams) (*Log
 		var streamInt int
 		var dataJSON *string
 
-		if err := rows.Scan(&e.ID, &ts, &e.DurationNs, &e.Model, &e.ResolvedModel, &e.Provider, &aliasUsedInt, &e.StatusCode,
+		if err := rows.Scan(&e.ID, &ts, &e.DurationNs, &e.Model, &e.ResolvedModel, &e.Provider, &aliasUsedInt, &e.ExecutionPlanVersionID, &e.StatusCode,
 			&e.RequestID, &e.ClientIP, &e.Method, &e.Path, &streamInt, &e.ErrorType, &dataJSON); err != nil {
 			return nil, fmt.Errorf("failed to scan audit log row: %w", err)
 		}
@@ -130,7 +130,7 @@ func (r *SQLiteReader) GetLogs(ctx context.Context, params LogQueryParams) (*Log
 
 // GetLogByID returns a single audit log entry by ID.
 func (r *SQLiteReader) GetLogByID(ctx context.Context, id string) (*LogEntry, error) {
-	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, status_code, request_id,
+	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, status_code, request_id,
 		client_ip, method, path, stream, error_type, data
 		FROM audit_logs WHERE id = ? LIMIT 1`
 
@@ -258,7 +258,7 @@ func parseSQLTimestamp(ts string, entryID string) time.Time {
 }
 
 func (r *SQLiteReader) findByResponseID(ctx context.Context, responseID string) (*LogEntry, error) {
-	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, status_code, request_id,
+	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, status_code, request_id,
 		client_ip, method, path, stream, error_type, data
 		FROM audit_logs
 		WHERE json_extract(data, '$.response_body.id') = ?
@@ -277,7 +277,7 @@ func (r *SQLiteReader) findByResponseID(ctx context.Context, responseID string) 
 }
 
 func (r *SQLiteReader) findByPreviousResponseID(ctx context.Context, previousResponseID string) (*LogEntry, error) {
-	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, status_code, request_id,
+	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, status_code, request_id,
 		client_ip, method, path, stream, error_type, data
 		FROM audit_logs
 		WHERE json_extract(data, '$.request_body.previous_response_id') = ?
@@ -302,7 +302,7 @@ func scanSQLiteLogEntry(rows *sql.Rows) (*LogEntry, error) {
 	var streamInt int
 	var dataJSON *string
 
-	if err := rows.Scan(&e.ID, &ts, &e.DurationNs, &e.Model, &e.ResolvedModel, &e.Provider, &aliasUsedInt, &e.StatusCode,
+	if err := rows.Scan(&e.ID, &ts, &e.DurationNs, &e.Model, &e.ResolvedModel, &e.Provider, &aliasUsedInt, &e.ExecutionPlanVersionID, &e.StatusCode,
 		&e.RequestID, &e.ClientIP, &e.Method, &e.Path, &streamInt, &e.ErrorType, &dataJSON); err != nil {
 		return nil, fmt.Errorf("failed to scan audit log row: %w", err)
 	}

--- a/internal/auditlog/reader_sqlite.go
+++ b/internal/auditlog/reader_sqlite.go
@@ -94,8 +94,9 @@ func (r *SQLiteReader) GetLogs(ctx context.Context, params LogQueryParams) (*Log
 		var aliasUsedInt int
 		var streamInt int
 		var dataJSON *string
+		var executionPlanVersionID sql.NullString
 
-		if err := rows.Scan(&e.ID, &ts, &e.DurationNs, &e.Model, &e.ResolvedModel, &e.Provider, &aliasUsedInt, &e.ExecutionPlanVersionID, &e.StatusCode,
+		if err := rows.Scan(&e.ID, &ts, &e.DurationNs, &e.Model, &e.ResolvedModel, &e.Provider, &aliasUsedInt, &executionPlanVersionID, &e.StatusCode,
 			&e.RequestID, &e.ClientIP, &e.Method, &e.Path, &streamInt, &e.ErrorType, &dataJSON); err != nil {
 			return nil, fmt.Errorf("failed to scan audit log row: %w", err)
 		}
@@ -103,6 +104,9 @@ func (r *SQLiteReader) GetLogs(ctx context.Context, params LogQueryParams) (*Log
 		e.AliasUsed = aliasUsedInt == 1
 		e.Stream = streamInt == 1
 		e.Timestamp = parseSQLTimestamp(ts, e.ID)
+		if executionPlanVersionID.Valid {
+			e.ExecutionPlanVersionID = executionPlanVersionID.String
+		}
 
 		if dataJSON != nil && *dataJSON != "" {
 			var data LogData
@@ -301,8 +305,9 @@ func scanSQLiteLogEntry(rows *sql.Rows) (*LogEntry, error) {
 	var aliasUsedInt int
 	var streamInt int
 	var dataJSON *string
+	var executionPlanVersionID sql.NullString
 
-	if err := rows.Scan(&e.ID, &ts, &e.DurationNs, &e.Model, &e.ResolvedModel, &e.Provider, &aliasUsedInt, &e.ExecutionPlanVersionID, &e.StatusCode,
+	if err := rows.Scan(&e.ID, &ts, &e.DurationNs, &e.Model, &e.ResolvedModel, &e.Provider, &aliasUsedInt, &executionPlanVersionID, &e.StatusCode,
 		&e.RequestID, &e.ClientIP, &e.Method, &e.Path, &streamInt, &e.ErrorType, &dataJSON); err != nil {
 		return nil, fmt.Errorf("failed to scan audit log row: %w", err)
 	}
@@ -310,6 +315,9 @@ func scanSQLiteLogEntry(rows *sql.Rows) (*LogEntry, error) {
 	e.AliasUsed = aliasUsedInt == 1
 	e.Stream = streamInt == 1
 	e.Timestamp = parseSQLTimestamp(ts, e.ID)
+	if executionPlanVersionID.Valid {
+		e.ExecutionPlanVersionID = executionPlanVersionID.String
+	}
 
 	if dataJSON != nil && *dataJSON != "" {
 		var data LogData

--- a/internal/auditlog/store_mongodb.go
+++ b/internal/auditlog/store_mongodb.go
@@ -74,6 +74,9 @@ func NewMongoDBStore(database *mongo.Database, retentionDays int) (*MongoDBStore
 			Keys: bson.D{{Key: "provider", Value: 1}},
 		},
 		{
+			Keys: bson.D{{Key: "execution_plan_version_id", Value: 1}},
+		},
+		{
 			Keys: bson.D{{Key: "request_id", Value: 1}},
 		},
 		{

--- a/internal/auditlog/store_postgresql.go
+++ b/internal/auditlog/store_postgresql.go
@@ -14,13 +14,13 @@ import (
 )
 
 const (
-	auditLogInsertColumnCount     = 15
+	auditLogInsertColumnCount     = 16
 	postgresMaxBindParameters     = 65535
 	auditLogInsertMaxRowsPerQuery = postgresMaxBindParameters / auditLogInsertColumnCount
 )
 
 const auditLogInsertPrefix = `
-		INSERT INTO audit_logs (id, timestamp, duration_ns, model, resolved_model, provider, alias_used, status_code,
+		INSERT INTO audit_logs (id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, status_code,
 			request_id, client_ip, method, path, stream, error_type, data)
 		VALUES `
 
@@ -60,6 +60,7 @@ func NewPostgreSQLStore(pool *pgxpool.Pool, retentionDays int) (*PostgreSQLStore
 			resolved_model TEXT,
 			provider TEXT,
 			alias_used BOOLEAN DEFAULT FALSE,
+			execution_plan_version_id TEXT,
 			status_code INTEGER DEFAULT 0,
 			request_id TEXT,
 			client_ip TEXT,
@@ -77,6 +78,7 @@ func NewPostgreSQLStore(pool *pgxpool.Pool, retentionDays int) (*PostgreSQLStore
 	migrations := []string{
 		"ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS resolved_model TEXT",
 		"ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS alias_used BOOLEAN DEFAULT FALSE",
+		"ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS execution_plan_version_id TEXT",
 	}
 	for _, migration := range migrations {
 		if _, err := pool.Exec(ctx, migration); err != nil {
@@ -90,6 +92,7 @@ func NewPostgreSQLStore(pool *pgxpool.Pool, retentionDays int) (*PostgreSQLStore
 		"CREATE INDEX IF NOT EXISTS idx_audit_model ON audit_logs(model)",
 		"CREATE INDEX IF NOT EXISTS idx_audit_status ON audit_logs(status_code)",
 		"CREATE INDEX IF NOT EXISTS idx_audit_provider ON audit_logs(provider)",
+		"CREATE INDEX IF NOT EXISTS idx_audit_execution_plan_version_id ON audit_logs(execution_plan_version_id)",
 		"CREATE INDEX IF NOT EXISTS idx_audit_request_id ON audit_logs(request_id)",
 		"CREATE INDEX IF NOT EXISTS idx_audit_client_ip ON audit_logs(client_ip)",
 		"CREATE INDEX IF NOT EXISTS idx_audit_path ON audit_logs(path)",
@@ -205,6 +208,7 @@ func buildAuditLogInsert(entries []*LogEntry) (string, []any) {
 			entry.ResolvedModel,
 			entry.Provider,
 			entry.AliasUsed,
+			entry.ExecutionPlanVersionID,
 			entry.StatusCode,
 			entry.RequestID,
 			entry.ClientIP,

--- a/internal/auditlog/store_postgresql_test.go
+++ b/internal/auditlog/store_postgresql_test.go
@@ -49,29 +49,29 @@ func TestBuildAuditLogInsert(t *testing.T) {
 	})
 
 	normalized := strings.Join(strings.Fields(query), " ")
-	wantQuery := "INSERT INTO audit_logs (id, timestamp, duration_ns, model, resolved_model, provider, alias_used, status_code, request_id, client_ip, method, path, stream, error_type, data) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15), ($16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30) ON CONFLICT (id) DO NOTHING"
+	wantQuery := "INSERT INTO audit_logs (id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, status_code, request_id, client_ip, method, path, stream, error_type, data) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16), ($17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32) ON CONFLICT (id) DO NOTHING"
 	if normalized != wantQuery {
 		t.Fatalf("query = %q, want %q", normalized, wantQuery)
 	}
 
-	if got, want := len(args), 30; got != want {
+	if got, want := len(args), 32; got != want {
 		t.Fatalf("len(args) = %d, want %d", got, want)
 	}
 	if got := args[0]; got != "log-1" {
 		t.Fatalf("args[0] = %v, want log-1", got)
 	}
-	if got := args[15]; got != "log-2" {
-		t.Fatalf("args[15] = %v, want log-2", got)
+	if got := args[16]; got != "log-2" {
+		t.Fatalf("args[16] = %v, want log-2", got)
 	}
-	if got := string(args[14].([]byte)); got != `{"user_agent":"test-agent"}` {
-		t.Fatalf("args[14] = %q, want %q", got, `{"user_agent":"test-agent"}`)
+	if got := string(args[15].([]byte)); got != `{"user_agent":"test-agent"}` {
+		t.Fatalf("args[15] = %q, want %q", got, `{"user_agent":"test-agent"}`)
 	}
-	dataJSON, ok := args[29].([]byte)
+	dataJSON, ok := args[31].([]byte)
 	if !ok {
-		t.Fatalf("args[29] has type %T, want []byte", args[29])
+		t.Fatalf("args[31] has type %T, want []byte", args[31])
 	}
 	if dataJSON != nil {
-		t.Fatalf("args[29] = %v, want nil data", dataJSON)
+		t.Fatalf("args[31] = %v, want nil data", dataJSON)
 	}
 }
 

--- a/internal/auditlog/store_sqlite.go
+++ b/internal/auditlog/store_sqlite.go
@@ -11,12 +11,12 @@ import (
 )
 
 // SQLite has a default limit of 999 bindable parameters per query (SQLITE_MAX_VARIABLE_NUMBER).
-// With 15 columns per log entry, we can safely insert up to 66 entries per batch (66 * 15 = 990).
+// With 16 columns per log entry, we can safely insert up to 62 entries per batch (62 * 16 = 992).
 // We chunk larger batches to avoid hitting this limit.
 const (
 	maxSQLiteParams    = 999
-	columnsPerEntry    = 15
-	maxEntriesPerBatch = maxSQLiteParams / columnsPerEntry // 66 entries
+	columnsPerEntry    = 16
+	maxEntriesPerBatch = maxSQLiteParams / columnsPerEntry // 62 entries
 )
 
 // SQLiteStore implements LogStore for SQLite databases.
@@ -45,6 +45,7 @@ func NewSQLiteStore(db *sql.DB, retentionDays int) (*SQLiteStore, error) {
 			resolved_model TEXT,
 			provider TEXT,
 			alias_used INTEGER DEFAULT 0,
+			execution_plan_version_id TEXT,
 			status_code INTEGER DEFAULT 0,
 			request_id TEXT,
 			client_ip TEXT,
@@ -62,6 +63,7 @@ func NewSQLiteStore(db *sql.DB, retentionDays int) (*SQLiteStore, error) {
 	migrations := []string{
 		"ALTER TABLE audit_logs ADD COLUMN resolved_model TEXT",
 		"ALTER TABLE audit_logs ADD COLUMN alias_used INTEGER DEFAULT 0",
+		"ALTER TABLE audit_logs ADD COLUMN execution_plan_version_id TEXT",
 	}
 	for _, migration := range migrations {
 		if _, err := db.Exec(migration); err != nil {
@@ -77,6 +79,7 @@ func NewSQLiteStore(db *sql.DB, retentionDays int) (*SQLiteStore, error) {
 		"CREATE INDEX IF NOT EXISTS idx_audit_model ON audit_logs(model)",
 		"CREATE INDEX IF NOT EXISTS idx_audit_status ON audit_logs(status_code)",
 		"CREATE INDEX IF NOT EXISTS idx_audit_provider ON audit_logs(provider)",
+		"CREATE INDEX IF NOT EXISTS idx_audit_execution_plan_version_id ON audit_logs(execution_plan_version_id)",
 		"CREATE INDEX IF NOT EXISTS idx_audit_request_id ON audit_logs(request_id)",
 		"CREATE INDEX IF NOT EXISTS idx_audit_client_ip ON audit_logs(client_ip)",
 		"CREATE INDEX IF NOT EXISTS idx_audit_path ON audit_logs(path)",
@@ -121,7 +124,7 @@ func (s *SQLiteStore) WriteBatch(ctx context.Context, entries []*LogEntry) error
 		values := make([]any, 0, len(chunk)*columnsPerEntry)
 
 		for j, e := range chunk {
-			placeholders[j] = "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+			placeholders[j] = "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 
 			dataJSON := marshalLogData(e.Data, e.ID)
 
@@ -149,6 +152,7 @@ func (s *SQLiteStore) WriteBatch(ctx context.Context, entries []*LogEntry) error
 				e.ResolvedModel,
 				e.Provider,
 				aliasUsedInt,
+				e.ExecutionPlanVersionID,
 				e.StatusCode,
 				e.RequestID,
 				e.ClientIP,
@@ -160,7 +164,7 @@ func (s *SQLiteStore) WriteBatch(ctx context.Context, entries []*LogEntry) error
 			)
 		}
 
-		query := `INSERT OR IGNORE INTO audit_logs (id, timestamp, duration_ns, model, resolved_model, provider, alias_used, status_code,
+		query := `INSERT OR IGNORE INTO audit_logs (id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, status_code,
 			request_id, client_ip, method, path, stream, error_type, data) VALUES ` +
 			strings.Join(placeholders, ",")
 

--- a/internal/auditlog/store_sqlite_test.go
+++ b/internal/auditlog/store_sqlite_test.go
@@ -274,3 +274,68 @@ func TestSQLiteStore_WriteBatch_PersistsAliasFields(t *testing.T) {
 		t.Fatal("AliasUsed = false, want true")
 	}
 }
+
+func TestSQLiteReader_AllowsNullExecutionPlanVersionID(t *testing.T) {
+	db := createTestDB(t)
+	defer db.Close()
+
+	store, err := NewSQLiteStore(db, 0)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := db.Exec(`
+		INSERT INTO audit_logs (
+			id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id,
+			status_code, request_id, client_ip, method, path, stream, error_type, data
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		"null-plan-version",
+		now,
+		0,
+		"gpt-4",
+		"",
+		"openai",
+		0,
+		nil,
+		200,
+		"req-1",
+		"127.0.0.1",
+		"POST",
+		"/v1/chat/completions",
+		0,
+		"",
+		nil,
+	); err != nil {
+		t.Fatalf("failed to insert audit log row: %v", err)
+	}
+
+	reader, err := NewSQLiteReader(db)
+	if err != nil {
+		t.Fatalf("failed to create reader: %v", err)
+	}
+
+	entry, err := reader.GetLogByID(context.Background(), "null-plan-version")
+	if err != nil {
+		t.Fatalf("GetLogByID failed: %v", err)
+	}
+	if entry == nil {
+		t.Fatal("expected log entry, got nil")
+	}
+	if entry.ExecutionPlanVersionID != "" {
+		t.Fatalf("ExecutionPlanVersionID = %q, want empty", entry.ExecutionPlanVersionID)
+	}
+
+	logs, err := reader.GetLogs(context.Background(), LogQueryParams{Limit: 10})
+	if err != nil {
+		t.Fatalf("GetLogs failed: %v", err)
+	}
+	if len(logs.Entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1", len(logs.Entries))
+	}
+	if logs.Entries[0].ExecutionPlanVersionID != "" {
+		t.Fatalf("list ExecutionPlanVersionID = %q, want empty", logs.Entries[0].ExecutionPlanVersionID)
+	}
+}

--- a/internal/batch/store.go
+++ b/internal/batch/store.go
@@ -31,6 +31,8 @@ type StoredBatch struct {
 	OriginalInputFileID       string              `json:"original_input_file_id,omitempty"`
 	RewrittenInputFileID      string              `json:"rewritten_input_file_id,omitempty"`
 	RequestID                 string              `json:"request_id,omitempty"`
+	ExecutionPlanVersionID    string              `json:"execution_plan_version_id,omitempty"`
+	UsageEnabled              *bool               `json:"usage_enabled,omitempty"`
 	UsageLoggedAt             *time.Time          `json:"usage_logged_at,omitempty"`
 }
 
@@ -176,4 +178,10 @@ func parseUsageLoggedAt(raw string) *time.Time {
 	}
 
 	return nil
+}
+
+// EffectiveUsageEnabled reports whether batch usage logging should run.
+// Nil means the value was not persisted by older versions, so usage remains enabled.
+func (s *StoredBatch) EffectiveUsageEnabled() bool {
+	return s == nil || s.UsageEnabled == nil || *s.UsageEnabled
 }

--- a/internal/core/execution_plan.go
+++ b/internal/core/execution_plan.go
@@ -1,5 +1,7 @@
 package core
 
+import "strings"
+
 // ExecutionMode describes how the gateway intends to execute a request.
 type ExecutionMode string
 
@@ -65,6 +67,64 @@ func CapabilitiesForEndpoint(desc EndpointDescriptor) CapabilitySet {
 	}
 }
 
+// ExecutionPlanSelector contains the request facts used to match one persisted
+// execution-plan version.
+type ExecutionPlanSelector struct {
+	Provider string
+	Model    string
+}
+
+// NewExecutionPlanSelector trims selector inputs for deterministic matching.
+func NewExecutionPlanSelector(provider, model string) ExecutionPlanSelector {
+	return ExecutionPlanSelector{
+		Provider: strings.TrimSpace(provider),
+		Model:    strings.TrimSpace(model),
+	}
+}
+
+// ExecutionFeatures stores resolved per-request feature flags sourced from the
+// matched persisted execution plan.
+type ExecutionFeatures struct {
+	Cache      bool
+	Audit      bool
+	Usage      bool
+	Guardrails bool
+}
+
+// ApplyUpperBound returns features with process-level caps applied.
+func (f ExecutionFeatures) ApplyUpperBound(caps ExecutionFeatures) ExecutionFeatures {
+	return ExecutionFeatures{
+		Cache:      f.Cache && caps.Cache,
+		Audit:      f.Audit && caps.Audit,
+		Usage:      f.Usage && caps.Usage,
+		Guardrails: f.Guardrails && caps.Guardrails,
+	}
+}
+
+// DefaultExecutionFeatures returns the permissive runtime default used when no
+// persisted execution plan has been attached to the request.
+func DefaultExecutionFeatures() ExecutionFeatures {
+	return ExecutionFeatures{
+		Cache:      true,
+		Audit:      true,
+		Usage:      true,
+		Guardrails: true,
+	}
+}
+
+// ResolvedExecutionPolicy is the request-scoped runtime projection of one
+// matched persisted execution-plan version.
+type ResolvedExecutionPolicy struct {
+	VersionID      string
+	Version        int
+	ScopeProvider  string
+	ScopeModel     string
+	Name           string
+	PlanHash       string
+	Features       ExecutionFeatures
+	GuardrailsHash string
+}
+
 // ExecutionPlan is the request-scoped control-plane result consumed by later
 // execution stages. It carries the resolved execution mode, endpoint
 // capabilities, and any model routing decision already made for the request.
@@ -76,6 +136,7 @@ type ExecutionPlan struct {
 	ProviderType string
 	Passthrough  *PassthroughRouteInfo
 	Resolution   *RequestModelResolution
+	Policy       *ResolvedExecutionPolicy
 }
 
 // RequestedQualifiedModel returns the requested model selector when present.
@@ -92,4 +153,47 @@ func (p *ExecutionPlan) ResolvedQualifiedModel() string {
 		return ""
 	}
 	return p.Resolution.ResolvedQualifiedModel()
+}
+
+// ExecutionPlanVersionID returns the matched immutable execution-plan version id.
+func (p *ExecutionPlan) ExecutionPlanVersionID() string {
+	if p == nil || p.Policy == nil {
+		return ""
+	}
+	return strings.TrimSpace(p.Policy.VersionID)
+}
+
+// CacheEnabled reports whether response caching is enabled for the request.
+func (p *ExecutionPlan) CacheEnabled() bool {
+	return p.featureEnabled(func(features ExecutionFeatures) bool { return features.Cache })
+}
+
+// AuditEnabled reports whether audit logging is enabled for the request.
+func (p *ExecutionPlan) AuditEnabled() bool {
+	return p.featureEnabled(func(features ExecutionFeatures) bool { return features.Audit })
+}
+
+// UsageEnabled reports whether usage tracking is enabled for the request.
+func (p *ExecutionPlan) UsageEnabled() bool {
+	return p.featureEnabled(func(features ExecutionFeatures) bool { return features.Usage })
+}
+
+// GuardrailsEnabled reports whether guardrail processing is enabled for the request.
+func (p *ExecutionPlan) GuardrailsEnabled() bool {
+	return p.featureEnabled(func(features ExecutionFeatures) bool { return features.Guardrails })
+}
+
+// GuardrailsHash returns the matched plan's guardrails hash.
+func (p *ExecutionPlan) GuardrailsHash() string {
+	if p == nil || p.Policy == nil || !p.GuardrailsEnabled() {
+		return ""
+	}
+	return strings.TrimSpace(p.Policy.GuardrailsHash)
+}
+
+func (p *ExecutionPlan) featureEnabled(pick func(ExecutionFeatures) bool) bool {
+	if p == nil || p.Policy == nil || strings.TrimSpace(p.Policy.VersionID) == "" {
+		return pick(DefaultExecutionFeatures())
+	}
+	return pick(p.Policy.Features)
 }

--- a/internal/executionplans/compiler.go
+++ b/internal/executionplans/compiler.go
@@ -1,0 +1,74 @@
+package executionplans
+
+import (
+	"fmt"
+
+	"gomodel/internal/core"
+	"gomodel/internal/guardrails"
+)
+
+type compiler struct {
+	registry    *guardrails.Registry
+	featureCaps core.ExecutionFeatures
+}
+
+// NewCompiler creates the default execution-plan compiler for the v1 payload.
+func NewCompiler(registry *guardrails.Registry) Compiler {
+	return NewCompilerWithFeatureCaps(registry, core.DefaultExecutionFeatures())
+}
+
+// NewCompilerWithFeatureCaps creates the default execution-plan compiler for the
+// v1 payload with process-level feature caps applied at compile time.
+func NewCompilerWithFeatureCaps(registry *guardrails.Registry, featureCaps core.ExecutionFeatures) Compiler {
+	return &compiler{
+		registry:    registry,
+		featureCaps: featureCaps,
+	}
+}
+
+func (c *compiler) Compile(version Version) (*CompiledPlan, error) {
+	features := core.ExecutionFeatures(version.Payload.Features).ApplyUpperBound(c.featureCaps)
+	policy := &core.ResolvedExecutionPolicy{
+		VersionID:      version.ID,
+		Version:        version.Version,
+		ScopeProvider:  version.Scope.Provider,
+		ScopeModel:     version.Scope.Model,
+		Name:           version.Name,
+		PlanHash:       version.PlanHash,
+		Features:       features,
+		GuardrailsHash: "",
+	}
+
+	var pipeline *guardrails.Pipeline
+	if policy.Features.Guardrails {
+		steps := make([]guardrails.StepReference, 0, len(version.Payload.Guardrails))
+		for _, step := range version.Payload.Guardrails {
+			steps = append(steps, guardrails.StepReference{
+				Ref:  step.Ref,
+				Step: step.Step,
+			})
+		}
+
+		var err error
+		pipeline, policy.GuardrailsHash, err = c.compileGuardrails(steps)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &CompiledPlan{
+		Version:  version,
+		Policy:   policy,
+		Pipeline: pipeline,
+	}, nil
+}
+
+func (c *compiler) compileGuardrails(steps []guardrails.StepReference) (*guardrails.Pipeline, string, error) {
+	if len(steps) == 0 {
+		return nil, "", nil
+	}
+	if c == nil || c.registry == nil {
+		return nil, "", fmt.Errorf("guardrails are enabled but no guardrail registry is configured")
+	}
+	return c.registry.BuildPipeline(steps)
+}

--- a/internal/executionplans/compiler_test.go
+++ b/internal/executionplans/compiler_test.go
@@ -1,0 +1,101 @@
+package executionplans
+
+import (
+	"testing"
+
+	"gomodel/internal/core"
+	"gomodel/internal/guardrails"
+	"gomodel/internal/responsecache"
+)
+
+func TestCompilerCompile_Guardrails(t *testing.T) {
+	registry := guardrails.NewRegistry()
+	rule, err := guardrails.NewSystemPromptGuardrail("policy-system", guardrails.SystemPromptInject, "be precise")
+	if err != nil {
+		t.Fatalf("NewSystemPromptGuardrail() error = %v", err)
+	}
+	if err := registry.Register(rule, responsecache.GuardrailRuleDescriptor{
+		Type:    "system_prompt",
+		Mode:    string(guardrails.SystemPromptInject),
+		Content: "be precise",
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	compiled, err := NewCompiler(registry).Compile(Version{
+		ID:      "plan-1",
+		Scope:   Scope{},
+		Version: 3,
+		Name:    "global",
+		Payload: Payload{
+			SchemaVersion: 1,
+			Features:      FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: true},
+			Guardrails: []GuardrailStep{
+				{Ref: "policy-system", Step: 20},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Compile() error = %v", err)
+	}
+	if compiled == nil {
+		t.Fatal("Compile() returned nil")
+	}
+	if compiled.Pipeline == nil {
+		t.Fatal("compiled pipeline is nil")
+	}
+	if compiled.Pipeline.Len() != 1 {
+		t.Fatalf("compiled pipeline len = %d, want 1", compiled.Pipeline.Len())
+	}
+	if compiled.Policy == nil {
+		t.Fatal("compiled policy is nil")
+	}
+	if compiled.Policy.GuardrailsHash == "" {
+		t.Fatal("compiled guardrails hash is empty")
+	}
+}
+
+func TestCompilerCompile_AppliesProcessFeatureCaps(t *testing.T) {
+	compiled, err := NewCompilerWithFeatureCaps(nil, core.ExecutionFeatures{
+		Cache:      false,
+		Audit:      true,
+		Usage:      false,
+		Guardrails: false,
+	}).Compile(Version{
+		ID:      "plan-1",
+		Scope:   Scope{},
+		Version: 1,
+		Name:    "global",
+		Payload: Payload{
+			SchemaVersion: 1,
+			Features:      FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: true},
+			Guardrails: []GuardrailStep{
+				{Ref: "policy-system", Step: 10},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Compile() error = %v", err)
+	}
+	if compiled == nil || compiled.Policy == nil {
+		t.Fatal("Compile() returned nil policy")
+	}
+	if compiled.Policy.Features.Cache {
+		t.Fatal("Policy.Features.Cache = true, want false")
+	}
+	if !compiled.Policy.Features.Audit {
+		t.Fatal("Policy.Features.Audit = false, want true")
+	}
+	if compiled.Policy.Features.Usage {
+		t.Fatal("Policy.Features.Usage = true, want false")
+	}
+	if compiled.Policy.Features.Guardrails {
+		t.Fatal("Policy.Features.Guardrails = true, want false")
+	}
+	if compiled.Pipeline != nil {
+		t.Fatal("compiled pipeline is not nil")
+	}
+	if compiled.Policy.GuardrailsHash != "" {
+		t.Fatalf("compiled guardrails hash = %q, want empty", compiled.Policy.GuardrailsHash)
+	}
+}

--- a/internal/executionplans/factory.go
+++ b/internal/executionplans/factory.go
@@ -1,0 +1,155 @@
+package executionplans
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+
+	"gomodel/config"
+	"gomodel/internal/storage"
+)
+
+// Result holds the initialized execution-plan service and any owned resources.
+type Result struct {
+	Service *Service
+	Store   Store
+	Storage storage.Storage
+
+	stopRefresh func()
+	closeOnce   sync.Once
+	closeErr    error
+}
+
+// Close releases resources held by the execution-plan subsystem.
+func (r *Result) Close() error {
+	if r == nil {
+		return nil
+	}
+	r.closeOnce.Do(func() {
+		if r.stopRefresh != nil {
+			r.stopRefresh()
+			r.stopRefresh = nil
+		}
+
+		var errs []error
+		if r.Store != nil {
+			if err := r.Store.Close(); err != nil {
+				errs = append(errs, fmt.Errorf("store close: %w", err))
+			}
+		}
+		if r.Storage != nil {
+			if err := r.Storage.Close(); err != nil {
+				errs = append(errs, fmt.Errorf("storage close: %w", err))
+			}
+		}
+		if len(errs) > 0 {
+			r.closeErr = fmt.Errorf("close errors: %w", errors.Join(errs...))
+		}
+	})
+	return r.closeErr
+}
+
+// New creates an execution-plan subsystem with its own storage connection.
+func New(ctx context.Context, cfg *config.Config, compiler Compiler, refreshInterval time.Duration) (*Result, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config is required")
+	}
+	storeConn, err := storage.New(ctx, buildStorageConfig(cfg))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create storage: %w", err)
+	}
+	result, err := newResult(ctx, storeConn, compiler, refreshInterval)
+	if err != nil {
+		_ = storeConn.Close()
+		return nil, err
+	}
+	result.Storage = storeConn
+	return result, nil
+}
+
+// NewWithSharedStorage creates an execution-plan subsystem using an existing storage connection.
+func NewWithSharedStorage(ctx context.Context, shared storage.Storage, compiler Compiler, refreshInterval time.Duration) (*Result, error) {
+	if shared == nil {
+		return nil, fmt.Errorf("shared storage is required")
+	}
+	return newResult(ctx, shared, compiler, refreshInterval)
+}
+
+func newResult(ctx context.Context, storeConn storage.Storage, compiler Compiler, refreshInterval time.Duration) (*Result, error) {
+	store, err := createStore(ctx, storeConn)
+	if err != nil {
+		return nil, err
+	}
+	service, err := NewService(store, compiler)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Result{
+		Service:     service,
+		Store:       store,
+		stopRefresh: service.StartBackgroundRefresh(refreshInterval),
+	}, nil
+}
+
+func buildStorageConfig(cfg *config.Config) storage.Config {
+	storageCfg := storage.Config{
+		Type: cfg.Storage.Type,
+		SQLite: storage.SQLiteConfig{
+			Path: cfg.Storage.SQLite.Path,
+		},
+		PostgreSQL: storage.PostgreSQLConfig{
+			URL:      cfg.Storage.PostgreSQL.URL,
+			MaxConns: cfg.Storage.PostgreSQL.MaxConns,
+		},
+		MongoDB: storage.MongoDBConfig{
+			URL:      cfg.Storage.MongoDB.URL,
+			Database: cfg.Storage.MongoDB.Database,
+		},
+	}
+
+	if storageCfg.Type == "" {
+		storageCfg.Type = storage.TypeSQLite
+	}
+	if storageCfg.SQLite.Path == "" {
+		storageCfg.SQLite.Path = storage.DefaultSQLitePath
+	}
+	if storageCfg.MongoDB.Database == "" {
+		storageCfg.MongoDB.Database = "gomodel"
+	}
+	return storageCfg
+}
+
+func createStore(ctx context.Context, store storage.Storage) (Store, error) {
+	switch store.Type() {
+	case storage.TypeSQLite:
+		return NewSQLiteStore(store.SQLiteDB())
+	case storage.TypePostgreSQL:
+		pool := store.PostgreSQLPool()
+		if pool == nil {
+			return nil, fmt.Errorf("PostgreSQL pool is nil")
+		}
+		pgxPool, ok := pool.(*pgxpool.Pool)
+		if !ok {
+			return nil, fmt.Errorf("invalid PostgreSQL pool type: %T", pool)
+		}
+		return NewPostgreSQLStore(ctx, pgxPool)
+	case storage.TypeMongoDB:
+		db := store.MongoDatabase()
+		if db == nil {
+			return nil, fmt.Errorf("MongoDB database is nil")
+		}
+		mongoDB, ok := db.(*mongo.Database)
+		if !ok {
+			return nil, fmt.Errorf("invalid MongoDB database type: %T", db)
+		}
+		return NewMongoDBStore(mongoDB)
+	default:
+		return nil, fmt.Errorf("unknown storage type: %s", store.Type())
+	}
+}

--- a/internal/executionplans/service.go
+++ b/internal/executionplans/service.go
@@ -1,0 +1,275 @@
+package executionplans
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"gomodel/internal/core"
+	"gomodel/internal/guardrails"
+)
+
+// CompiledPlan is the immutable runtime projection cached in the hot-path snapshot.
+type CompiledPlan struct {
+	Version  Version
+	Policy   *core.ResolvedExecutionPolicy
+	Pipeline *guardrails.Pipeline
+}
+
+// Compiler turns one persisted execution-plan version into its runtime projection.
+type Compiler interface {
+	Compile(version Version) (*CompiledPlan, error)
+}
+
+type snapshot struct {
+	global         *CompiledPlan
+	providers      map[string]*CompiledPlan
+	providerModels map[string]map[string]*CompiledPlan
+	byVersionID    map[string]*CompiledPlan
+}
+
+// Service keeps the active execution-plan set cached in memory.
+type Service struct {
+	store    Store
+	compiler Compiler
+	current  atomic.Value
+}
+
+// NewService creates an execution-plan service backed by storage.
+func NewService(store Store, compiler Compiler) (*Service, error) {
+	if store == nil {
+		return nil, fmt.Errorf("store is required")
+	}
+	if compiler == nil {
+		return nil, fmt.Errorf("compiler is required")
+	}
+
+	service := &Service{
+		store:    store,
+		compiler: compiler,
+	}
+	service.current.Store(snapshot{
+		providers:      map[string]*CompiledPlan{},
+		providerModels: map[string]map[string]*CompiledPlan{},
+		byVersionID:    map[string]*CompiledPlan{},
+	})
+	return service, nil
+}
+
+// Refresh reloads active plans from storage and atomically swaps the in-memory snapshot.
+func (s *Service) Refresh(ctx context.Context) error {
+	versions, err := s.store.ListActive(ctx)
+	if err != nil {
+		return fmt.Errorf("list active execution plans: %w", err)
+	}
+
+	next := snapshot{
+		providers:      make(map[string]*CompiledPlan),
+		providerModels: make(map[string]map[string]*CompiledPlan),
+		byVersionID:    make(map[string]*CompiledPlan),
+	}
+
+	for _, version := range versions {
+		scope, scopeKey, err := normalizeScope(version.Scope)
+		if err != nil {
+			return fmt.Errorf("load execution plan %q: %w", version.ID, err)
+		}
+		version.Scope = scope
+		version.ScopeKey = scopeKey
+
+		compiled, err := s.compiler.Compile(version)
+		if err != nil {
+			return fmt.Errorf("compile execution plan %q: %w", version.ID, err)
+		}
+		if compiled == nil || compiled.Policy == nil {
+			return fmt.Errorf("compile execution plan %q: empty compiled plan", version.ID)
+		}
+
+		next.byVersionID[compiled.Version.ID] = compiled
+
+		switch {
+		case scope.Provider == "":
+			if next.global != nil {
+				return fmt.Errorf("duplicate active global execution plans: %q and %q", next.global.Version.ID, version.ID)
+			}
+			next.global = compiled
+		case scope.Model == "":
+			if existing := next.providers[scope.Provider]; existing != nil {
+				return fmt.Errorf("duplicate active provider execution plans for %q: %q and %q", scope.Provider, existing.Version.ID, version.ID)
+			}
+			next.providers[scope.Provider] = compiled
+		default:
+			models := next.providerModels[scope.Provider]
+			if models == nil {
+				models = make(map[string]*CompiledPlan)
+				next.providerModels[scope.Provider] = models
+			}
+			if existing := models[scope.Model]; existing != nil {
+				return fmt.Errorf("duplicate active provider-model execution plans for %q/%q: %q and %q", scope.Provider, scope.Model, existing.Version.ID, version.ID)
+			}
+			models[scope.Model] = compiled
+		}
+	}
+
+	if next.global == nil {
+		return fmt.Errorf("missing active global execution plan")
+	}
+
+	s.current.Store(next)
+	return nil
+}
+
+// EnsureDefaultGlobal seeds one active global execution plan when none exists.
+func (s *Service) EnsureDefaultGlobal(ctx context.Context, input CreateInput) error {
+	normalized, _, _, err := normalizeCreateInput(input)
+	if err != nil {
+		return err
+	}
+	if normalized.Scope.Provider != "" || normalized.Scope.Model != "" {
+		return newValidationError("default execution plan must use global scope", nil)
+	}
+
+	versions, err := s.store.ListActive(ctx)
+	if err != nil {
+		return fmt.Errorf("list active execution plans: %w", err)
+	}
+	for _, version := range versions {
+		scope, _, err := normalizeScope(version.Scope)
+		if err != nil {
+			return fmt.Errorf("load execution plan %q: %w", version.ID, err)
+		}
+		if scope.Provider == "" && scope.Model == "" {
+			return nil
+		}
+	}
+
+	if !normalized.Activate {
+		normalized.Activate = true
+	}
+	if _, err := s.store.Create(ctx, normalized); err != nil {
+		return fmt.Errorf("seed default global execution plan: %w", err)
+	}
+	return nil
+}
+
+// Match returns the most-specific compiled execution policy for one request.
+func (s *Service) Match(selector core.ExecutionPlanSelector) (*core.ResolvedExecutionPolicy, error) {
+	compiled, err := s.matchCompiled(selector)
+	if err != nil || compiled == nil {
+		return nil, err
+	}
+	policy := *compiled.Policy
+	return &policy, nil
+}
+
+// PipelineForContext resolves the active guardrails pipeline for the request context.
+func (s *Service) PipelineForContext(ctx context.Context) *guardrails.Pipeline {
+	if s == nil || ctx == nil {
+		return nil
+	}
+	plan := core.GetExecutionPlan(ctx)
+	if plan == nil {
+		return nil
+	}
+	return s.PipelineForExecutionPlan(plan)
+}
+
+// PipelineForExecutionPlan resolves the active guardrails pipeline for one request plan.
+func (s *Service) PipelineForExecutionPlan(plan *core.ExecutionPlan) *guardrails.Pipeline {
+	if s == nil || plan == nil || plan.Policy == nil || !plan.GuardrailsEnabled() {
+		return nil
+	}
+	versionID := strings.TrimSpace(plan.Policy.VersionID)
+	if versionID == "" {
+		return nil
+	}
+	current := s.snapshot()
+	compiled := current.byVersionID[versionID]
+	if compiled == nil {
+		return nil
+	}
+	return compiled.Pipeline
+}
+
+// StartBackgroundRefresh periodically reloads active execution plans until stopped.
+func (s *Service) StartBackgroundRefresh(interval time.Duration) func() {
+	if interval <= 0 {
+		interval = time.Minute
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	var once sync.Once
+
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				refreshCtx, refreshCancel := context.WithTimeout(ctx, 30*time.Second)
+				if err := s.Refresh(refreshCtx); err != nil {
+					slog.Warn("execution plan refresh failed", "error", err)
+				}
+				refreshCancel()
+			}
+		}
+	}()
+
+	return func() {
+		once.Do(func() {
+			cancel()
+			<-done
+		})
+	}
+}
+
+func (s *Service) matchCompiled(selector core.ExecutionPlanSelector) (*CompiledPlan, error) {
+	if s == nil {
+		return nil, nil
+	}
+	selector = core.NewExecutionPlanSelector(selector.Provider, selector.Model)
+	current := s.snapshot()
+
+	if selector.Provider != "" && selector.Model != "" {
+		if models := current.providerModels[selector.Provider]; models != nil {
+			if compiled := models[selector.Model]; compiled != nil {
+				return compiled, nil
+			}
+		}
+	}
+	if selector.Provider != "" {
+		if compiled := current.providers[selector.Provider]; compiled != nil {
+			return compiled, nil
+		}
+	}
+	if current.global == nil {
+		return nil, fmt.Errorf("missing active global execution plan")
+	}
+	return current.global, nil
+}
+
+func (s *Service) snapshot() snapshot {
+	if s == nil {
+		return snapshot{
+			providers:      map[string]*CompiledPlan{},
+			providerModels: map[string]map[string]*CompiledPlan{},
+			byVersionID:    map[string]*CompiledPlan{},
+		}
+	}
+	if current, ok := s.current.Load().(snapshot); ok {
+		return current
+	}
+	return snapshot{
+		providers:      map[string]*CompiledPlan{},
+		providerModels: map[string]map[string]*CompiledPlan{},
+		byVersionID:    map[string]*CompiledPlan{},
+	}
+}

--- a/internal/executionplans/service.go
+++ b/internal/executionplans/service.go
@@ -214,11 +214,13 @@ func (s *Service) StartBackgroundRefresh(interval time.Duration) func() {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				refreshCtx, refreshCancel := context.WithTimeout(ctx, 30*time.Second)
-				if err := s.Refresh(refreshCtx); err != nil {
-					slog.Warn("execution plan refresh failed", "error", err)
-				}
-				refreshCancel()
+				func() {
+					refreshCtx, refreshCancel := context.WithTimeout(ctx, 30*time.Second)
+					defer refreshCancel()
+					if err := s.Refresh(refreshCtx); err != nil {
+						slog.Warn("execution plan refresh failed", "error", err)
+					}
+				}()
 			}
 		}
 	}()

--- a/internal/executionplans/service_test.go
+++ b/internal/executionplans/service_test.go
@@ -1,0 +1,130 @@
+package executionplans
+
+import (
+	"context"
+	"testing"
+
+	"gomodel/internal/core"
+)
+
+type staticStore struct {
+	versions []Version
+}
+
+func (s *staticStore) ListActive(context.Context) ([]Version, error) { return s.versions, nil }
+func (s *staticStore) Get(context.Context, string) (*Version, error) { return nil, ErrNotFound }
+func (s *staticStore) Create(_ context.Context, input CreateInput) (*Version, error) {
+	input, scopeKey, planHash, err := normalizeCreateInput(input)
+	if err != nil {
+		return nil, err
+	}
+	version := Version{
+		ID:          "created-global",
+		Scope:       input.Scope,
+		ScopeKey:    scopeKey,
+		Version:     1,
+		Active:      input.Activate,
+		Name:        input.Name,
+		Description: input.Description,
+		Payload:     input.Payload,
+		PlanHash:    planHash,
+	}
+	s.versions = append(s.versions, version)
+	return &version, nil
+}
+func (s *staticStore) Close() error { return nil }
+
+func TestServiceMatch_MostSpecificWins(t *testing.T) {
+	store := &staticStore{
+		versions: []Version{
+			{
+				ID:       "global",
+				Scope:    Scope{},
+				ScopeKey: "global",
+				Version:  1,
+				Active:   true,
+				Name:     "global",
+				Payload: Payload{
+					SchemaVersion: 1,
+					Features:      FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
+				},
+			},
+			{
+				ID:       "provider",
+				Scope:    Scope{Provider: "openai"},
+				ScopeKey: "provider:openai",
+				Version:  1,
+				Active:   true,
+				Name:     "provider",
+				Payload: Payload{
+					SchemaVersion: 1,
+					Features:      FeatureFlags{Cache: false, Audit: true, Usage: true, Guardrails: false},
+				},
+			},
+			{
+				ID:       "provider-model",
+				Scope:    Scope{Provider: "openai", Model: "gpt-5"},
+				ScopeKey: "provider_model:openai:gpt-5",
+				Version:  1,
+				Active:   true,
+				Name:     "provider-model",
+				Payload: Payload{
+					SchemaVersion: 1,
+					Features:      FeatureFlags{Cache: false, Audit: false, Usage: true, Guardrails: false},
+				},
+			},
+		},
+	}
+
+	service, err := NewService(store, NewCompiler(nil))
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	assertMatch := func(name string, selector core.ExecutionPlanSelector, wantVersionID string) {
+		t.Helper()
+		policy, err := service.Match(selector)
+		if err != nil {
+			t.Fatalf("%s: Match() error = %v", name, err)
+		}
+		if policy == nil {
+			t.Fatalf("%s: Match() returned nil policy", name)
+		}
+		if policy.VersionID != wantVersionID {
+			t.Fatalf("%s: VersionID = %q, want %q", name, policy.VersionID, wantVersionID)
+		}
+	}
+
+	assertMatch("provider+model", core.NewExecutionPlanSelector("openai", "gpt-5"), "provider-model")
+	assertMatch("provider", core.NewExecutionPlanSelector("openai", "gpt-4o"), "provider")
+	assertMatch("global", core.NewExecutionPlanSelector("anthropic", "claude-sonnet-4"), "global")
+}
+
+func TestServiceEnsureDefaultGlobal_CreatesWhenMissing(t *testing.T) {
+	store := &staticStore{}
+	service, err := NewService(store, NewCompiler(nil))
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	err = service.EnsureDefaultGlobal(context.Background(), CreateInput{
+		Activate: true,
+		Name:     "default-global",
+		Payload: Payload{
+			SchemaVersion: 1,
+			Features:      FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
+		},
+	})
+	if err != nil {
+		t.Fatalf("EnsureDefaultGlobal() error = %v", err)
+	}
+	if len(store.versions) != 1 {
+		t.Fatalf("len(store.versions) = %d, want 1", len(store.versions))
+	}
+	if got := store.versions[0].ScopeKey; got != "global" {
+		t.Fatalf("ScopeKey = %q, want global", got)
+	}
+}

--- a/internal/executionplans/store.go
+++ b/internal/executionplans/store.go
@@ -1,0 +1,47 @@
+package executionplans
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrNotFound indicates a requested execution-plan version was not found.
+var ErrNotFound = errors.New("execution plan version not found")
+
+// ValidationError indicates invalid execution-plan input or state.
+type ValidationError struct {
+	Message string
+	Err     error
+}
+
+func (e *ValidationError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Message
+}
+
+func (e *ValidationError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func newValidationError(message string, err error) error {
+	return &ValidationError{Message: message, Err: err}
+}
+
+// IsValidationError reports whether err is a validation error.
+func IsValidationError(err error) bool {
+	_, ok := errors.AsType[*ValidationError](err)
+	return ok
+}
+
+// Store defines persistence operations for immutable execution-plan versions.
+type Store interface {
+	ListActive(ctx context.Context) ([]Version, error)
+	Get(ctx context.Context, id string) (*Version, error)
+	Create(ctx context.Context, input CreateInput) (*Version, error)
+	Close() error
+}

--- a/internal/executionplans/store_helpers.go
+++ b/internal/executionplans/store_helpers.go
@@ -1,0 +1,28 @@
+package executionplans
+
+import "fmt"
+
+type versionRowScanner interface {
+	Scan(dest ...any) error
+}
+
+type versionRowIterator interface {
+	versionRowScanner
+	Next() bool
+	Err() error
+}
+
+func collectVersions(rows versionRowIterator, scan func(versionRowScanner) (Version, error)) ([]Version, error) {
+	versions := make([]Version, 0)
+	for rows.Next() {
+		version, err := scan(rows)
+		if err != nil {
+			return nil, err
+		}
+		versions = append(versions, version)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate execution plans: %w", err)
+	}
+	return versions, nil
+}

--- a/internal/executionplans/store_mongodb.go
+++ b/internal/executionplans/store_mongodb.go
@@ -1,0 +1,177 @@
+package executionplans
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+type mongoVersionDocument struct {
+	ID            string    `bson:"_id"`
+	ScopeProvider string    `bson:"scope_provider,omitempty"`
+	ScopeModel    string    `bson:"scope_model,omitempty"`
+	ScopeKey      string    `bson:"scope_key"`
+	Version       int       `bson:"version"`
+	Active        bool      `bson:"active"`
+	Name          string    `bson:"name"`
+	Description   string    `bson:"description,omitempty"`
+	PlanPayload   Payload   `bson:"plan_payload"`
+	PlanHash      string    `bson:"plan_hash"`
+	CreatedAt     time.Time `bson:"created_at"`
+}
+
+// MongoDBStore stores immutable execution-plan versions in MongoDB.
+type MongoDBStore struct {
+	collection *mongo.Collection
+}
+
+// NewMongoDBStore creates collection indexes if needed.
+func NewMongoDBStore(database *mongo.Database) (*MongoDBStore, error) {
+	if database == nil {
+		return nil, fmt.Errorf("database is required")
+	}
+
+	collection := database.Collection("execution_plan_versions")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	indexes := []mongo.IndexModel{
+		{
+			Keys:    bson.D{{Key: "scope_key", Value: 1}, {Key: "version", Value: 1}},
+			Options: options.Index().SetUnique(true),
+		},
+		{
+			Keys:    bson.D{{Key: "scope_key", Value: 1}},
+			Options: options.Index().SetUnique(true).SetPartialFilterExpression(bson.D{{Key: "active", Value: true}}),
+		},
+		{
+			Keys: bson.D{{Key: "active", Value: 1}, {Key: "created_at", Value: -1}},
+		},
+	}
+	if _, err := collection.Indexes().CreateMany(ctx, indexes); err != nil {
+		return nil, fmt.Errorf("create execution plan indexes: %w", err)
+	}
+
+	return &MongoDBStore{collection: collection}, nil
+}
+
+func (s *MongoDBStore) ListActive(ctx context.Context) ([]Version, error) {
+	cursor, err := s.collection.Find(ctx,
+		bson.D{{Key: "active", Value: true}},
+		options.Find().SetSort(bson.D{{Key: "created_at", Value: -1}, {Key: "_id", Value: -1}}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list active execution plans: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	versions := make([]Version, 0)
+	for cursor.Next(ctx) {
+		var doc mongoVersionDocument
+		if err := cursor.Decode(&doc); err != nil {
+			return nil, fmt.Errorf("decode execution plan: %w", err)
+		}
+		versions = append(versions, versionFromMongo(doc))
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, fmt.Errorf("iterate execution plans: %w", err)
+	}
+	return versions, nil
+}
+
+func (s *MongoDBStore) Get(ctx context.Context, id string) (*Version, error) {
+	var doc mongoVersionDocument
+	if err := s.collection.FindOne(ctx, bson.D{{Key: "_id", Value: id}}).Decode(&doc); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get execution plan: %w", err)
+	}
+	version := versionFromMongo(doc)
+	return &version, nil
+}
+
+func (s *MongoDBStore) Create(ctx context.Context, input CreateInput) (*Version, error) {
+	input, scopeKey, planHash, err := normalizeCreateInput(input)
+	if err != nil {
+		return nil, err
+	}
+
+	var latest struct {
+		Version int `bson:"version"`
+	}
+	findOpts := options.FindOne().SetSort(bson.D{{Key: "version", Value: -1}})
+	err = s.collection.FindOne(ctx, bson.D{{Key: "scope_key", Value: scopeKey}}, findOpts).Decode(&latest)
+	if err != nil && !errors.Is(err, mongo.ErrNoDocuments) {
+		return nil, fmt.Errorf("load latest execution plan version: %w", err)
+	}
+
+	if input.Activate {
+		if _, err := s.collection.UpdateMany(ctx,
+			bson.D{{Key: "scope_key", Value: scopeKey}, {Key: "active", Value: true}},
+			bson.D{{Key: "$set", Value: bson.D{{Key: "active", Value: false}}}},
+		); err != nil {
+			return nil, fmt.Errorf("deactivate current execution plan version: %w", err)
+		}
+	}
+
+	now := time.Now().UTC()
+	version := &Version{
+		ID:          uuid.NewString(),
+		Scope:       input.Scope,
+		ScopeKey:    scopeKey,
+		Version:     latest.Version + 1,
+		Active:      input.Activate,
+		Name:        input.Name,
+		Description: input.Description,
+		Payload:     input.Payload,
+		PlanHash:    planHash,
+		CreatedAt:   now,
+	}
+
+	if _, err := s.collection.InsertOne(ctx, mongoVersionDocument{
+		ID:            version.ID,
+		ScopeProvider: version.Scope.Provider,
+		ScopeModel:    version.Scope.Model,
+		ScopeKey:      version.ScopeKey,
+		Version:       version.Version,
+		Active:        version.Active,
+		Name:          version.Name,
+		Description:   version.Description,
+		PlanPayload:   version.Payload,
+		PlanHash:      version.PlanHash,
+		CreatedAt:     version.CreatedAt,
+	}); err != nil {
+		return nil, fmt.Errorf("insert execution plan version: %w", err)
+	}
+
+	return version, nil
+}
+
+func (s *MongoDBStore) Close() error {
+	return nil
+}
+
+func versionFromMongo(doc mongoVersionDocument) Version {
+	return Version{
+		ID: doc.ID,
+		Scope: Scope{
+			Provider: doc.ScopeProvider,
+			Model:    doc.ScopeModel,
+		},
+		ScopeKey:    doc.ScopeKey,
+		Version:     doc.Version,
+		Active:      doc.Active,
+		Name:        doc.Name,
+		Description: doc.Description,
+		Payload:     doc.PlanPayload,
+		PlanHash:    doc.PlanHash,
+		CreatedAt:   doc.CreatedAt.UTC(),
+	}
+}

--- a/internal/executionplans/store_mongodb.go
+++ b/internal/executionplans/store_mongodb.go
@@ -103,54 +103,74 @@ func (s *MongoDBStore) Create(ctx context.Context, input CreateInput) (*Version,
 		return nil, err
 	}
 
-	var latest struct {
-		Version int `bson:"version"`
+	session, err := s.collection.Database().Client().StartSession()
+	if err != nil {
+		return nil, fmt.Errorf("start execution plan session: %w", err)
 	}
-	findOpts := options.FindOne().SetSort(bson.D{{Key: "version", Value: -1}})
-	err = s.collection.FindOne(ctx, bson.D{{Key: "scope_key", Value: scopeKey}}, findOpts).Decode(&latest)
-	if err != nil && !errors.Is(err, mongo.ErrNoDocuments) {
-		return nil, fmt.Errorf("load latest execution plan version: %w", err)
-	}
+	defer session.EndSession(ctx)
 
-	if input.Activate {
-		if _, err := s.collection.UpdateMany(ctx,
-			bson.D{{Key: "scope_key", Value: scopeKey}, {Key: "active", Value: true}},
-			bson.D{{Key: "$set", Value: bson.D{{Key: "active", Value: false}}}},
-		); err != nil {
-			return nil, fmt.Errorf("deactivate current execution plan version: %w", err)
+	result, err := session.WithTransaction(ctx, func(sessionCtx context.Context) (any, error) {
+		var latest struct {
+			Version int `bson:"version"`
 		}
+		findOpts := options.FindOne().SetSort(bson.D{{Key: "version", Value: -1}})
+		err := s.collection.FindOne(sessionCtx, bson.D{{Key: "scope_key", Value: scopeKey}}, findOpts).Decode(&latest)
+		if err != nil && !errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, fmt.Errorf("load latest execution plan version: %w", err)
+		}
+
+		if input.Activate {
+			if _, err := s.collection.UpdateMany(sessionCtx,
+				bson.D{{Key: "scope_key", Value: scopeKey}, {Key: "active", Value: true}},
+				bson.D{{Key: "$set", Value: bson.D{{Key: "active", Value: false}}}},
+			); err != nil {
+				return nil, fmt.Errorf("deactivate current execution plan version: %w", err)
+			}
+		}
+
+		now := time.Now().UTC()
+		version := &Version{
+			ID:          uuid.NewString(),
+			Scope:       input.Scope,
+			ScopeKey:    scopeKey,
+			Version:     latest.Version + 1,
+			Active:      input.Activate,
+			Name:        input.Name,
+			Description: input.Description,
+			Payload:     input.Payload,
+			PlanHash:    planHash,
+			CreatedAt:   now,
+		}
+
+		if _, err := s.collection.InsertOne(sessionCtx, mongoVersionDocument{
+			ID:            version.ID,
+			ScopeProvider: version.Scope.Provider,
+			ScopeModel:    version.Scope.Model,
+			ScopeKey:      version.ScopeKey,
+			Version:       version.Version,
+			Active:        version.Active,
+			Name:          version.Name,
+			Description:   version.Description,
+			PlanPayload:   version.Payload,
+			PlanHash:      version.PlanHash,
+			CreatedAt:     version.CreatedAt,
+		}); err != nil {
+			if mongo.IsDuplicateKeyError(err) {
+				return nil, fmt.Errorf("insert execution plan version: duplicate key: %w", err)
+			}
+			return nil, fmt.Errorf("insert execution plan version: %w", err)
+		}
+
+		return version, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
-	now := time.Now().UTC()
-	version := &Version{
-		ID:          uuid.NewString(),
-		Scope:       input.Scope,
-		ScopeKey:    scopeKey,
-		Version:     latest.Version + 1,
-		Active:      input.Activate,
-		Name:        input.Name,
-		Description: input.Description,
-		Payload:     input.Payload,
-		PlanHash:    planHash,
-		CreatedAt:   now,
+	version, ok := result.(*Version)
+	if !ok {
+		return nil, fmt.Errorf("unexpected execution plan transaction result: %T", result)
 	}
-
-	if _, err := s.collection.InsertOne(ctx, mongoVersionDocument{
-		ID:            version.ID,
-		ScopeProvider: version.Scope.Provider,
-		ScopeModel:    version.Scope.Model,
-		ScopeKey:      version.ScopeKey,
-		Version:       version.Version,
-		Active:        version.Active,
-		Name:          version.Name,
-		Description:   version.Description,
-		PlanPayload:   version.Payload,
-		PlanHash:      version.PlanHash,
-		CreatedAt:     version.CreatedAt,
-	}); err != nil {
-		return nil, fmt.Errorf("insert execution plan version: %w", err)
-	}
-
 	return version, nil
 }
 

--- a/internal/executionplans/store_postgresql.go
+++ b/internal/executionplans/store_postgresql.go
@@ -1,0 +1,215 @@
+package executionplans
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// PostgreSQLStore stores immutable execution-plan versions in PostgreSQL.
+type PostgreSQLStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgreSQLStore creates the execution-plan table and indexes if needed.
+func NewPostgreSQLStore(ctx context.Context, pool *pgxpool.Pool) (*PostgreSQLStore, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("context is required")
+	}
+	if pool == nil {
+		return nil, fmt.Errorf("connection pool is required")
+	}
+
+	statements := []string{
+		`CREATE TABLE IF NOT EXISTS execution_plan_versions (
+			id UUID PRIMARY KEY,
+			scope_provider TEXT,
+			scope_model TEXT,
+			scope_key TEXT NOT NULL,
+			version INTEGER NOT NULL,
+			active BOOLEAN NOT NULL DEFAULT TRUE,
+			name TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			plan_payload JSONB NOT NULL,
+			plan_hash TEXT NOT NULL,
+			created_at TIMESTAMPTZ NOT NULL,
+			CHECK (scope_provider IS NOT NULL OR scope_model IS NULL)
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_execution_plan_versions_scope_version
+			ON execution_plan_versions(scope_key, version)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_execution_plan_versions_active_scope
+			ON execution_plan_versions(scope_key) WHERE active = TRUE`,
+		`CREATE INDEX IF NOT EXISTS idx_execution_plan_versions_active_created_at
+			ON execution_plan_versions(active, created_at DESC)`,
+	}
+	for _, statement := range statements {
+		if _, err := pool.Exec(ctx, statement); err != nil {
+			return nil, fmt.Errorf("initialize execution plan versions table: %w", err)
+		}
+	}
+
+	return &PostgreSQLStore{pool: pool}, nil
+}
+
+func (s *PostgreSQLStore) ListActive(ctx context.Context) ([]Version, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, scope_provider, scope_model, scope_key, version, active, name, description, plan_payload, plan_hash, created_at
+		FROM execution_plan_versions
+		WHERE active = TRUE
+		ORDER BY created_at DESC, id DESC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list active execution plans: %w", err)
+	}
+	defer rows.Close()
+	return collectVersions(rows, func(scanner versionRowScanner) (Version, error) {
+		return scanPostgreSQLVersion(scanner)
+	})
+}
+
+func (s *PostgreSQLStore) Get(ctx context.Context, id string) (*Version, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT id, scope_provider, scope_model, scope_key, version, active, name, description, plan_payload, plan_hash, created_at
+		FROM execution_plan_versions
+		WHERE id::text = $1
+	`, id)
+	version, err := scanPostgreSQLVersion(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &version, nil
+}
+
+func (s *PostgreSQLStore) Create(ctx context.Context, input CreateInput) (*Version, error) {
+	input, scopeKey, planHash, err := normalizeCreateInput(input)
+	if err != nil {
+		return nil, err
+	}
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin execution plan transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	var nextVersion int
+	if err := tx.QueryRow(ctx,
+		`SELECT COALESCE(MAX(version), 0) + 1 FROM execution_plan_versions WHERE scope_key = $1`,
+		scopeKey,
+	).Scan(&nextVersion); err != nil {
+		return nil, fmt.Errorf("select next execution plan version: %w", err)
+	}
+
+	if input.Activate {
+		if _, err := tx.Exec(ctx,
+			`UPDATE execution_plan_versions SET active = FALSE WHERE scope_key = $1 AND active = TRUE`,
+			scopeKey,
+		); err != nil {
+			return nil, fmt.Errorf("deactivate current execution plan version: %w", err)
+		}
+	}
+
+	payloadJSON, err := json.Marshal(input.Payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal execution plan payload: %w", err)
+	}
+
+	now := time.Now().UTC()
+	version := &Version{
+		ID:          uuid.NewString(),
+		Scope:       input.Scope,
+		ScopeKey:    scopeKey,
+		Version:     nextVersion,
+		Active:      input.Activate,
+		Name:        input.Name,
+		Description: input.Description,
+		Payload:     input.Payload,
+		PlanHash:    planHash,
+		CreatedAt:   now,
+	}
+
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO execution_plan_versions (
+			id, scope_provider, scope_model, scope_key, version, active, name, description, plan_payload, plan_hash, created_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+	`,
+		version.ID,
+		nullIfEmpty(version.Scope.Provider),
+		nullIfEmpty(version.Scope.Model),
+		version.ScopeKey,
+		version.Version,
+		version.Active,
+		version.Name,
+		version.Description,
+		payloadJSON,
+		version.PlanHash,
+		version.CreatedAt,
+	); err != nil {
+		return nil, fmt.Errorf("insert execution plan version: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit execution plan version: %w", err)
+	}
+	return version, nil
+}
+
+func (s *PostgreSQLStore) Close() error {
+	return nil
+}
+
+func scanPostgreSQLVersion(scanner interface {
+	Scan(dest ...any) error
+}) (Version, error) {
+	var (
+		version       Version
+		scopeProvider *string
+		scopeModel    *string
+		payloadJSON   []byte
+	)
+
+	if err := scanner.Scan(
+		&version.ID,
+		&scopeProvider,
+		&scopeModel,
+		&version.ScopeKey,
+		&version.Version,
+		&version.Active,
+		&version.Name,
+		&version.Description,
+		&payloadJSON,
+		&version.PlanHash,
+		&version.CreatedAt,
+	); err != nil {
+		return Version{}, err
+	}
+
+	if scopeProvider != nil {
+		version.Scope.Provider = *scopeProvider
+	}
+	if scopeModel != nil {
+		version.Scope.Model = *scopeModel
+	}
+	if err := json.Unmarshal(payloadJSON, &version.Payload); err != nil {
+		return Version{}, fmt.Errorf("decode execution plan payload %q: %w", version.ID, err)
+	}
+	return version, nil
+}
+
+func nullIfEmpty(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
+}

--- a/internal/executionplans/store_postgresql.go
+++ b/internal/executionplans/store_postgresql.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -95,6 +96,21 @@ func (s *PostgreSQLStore) Create(ctx context.Context, input CreateInput) (*Versi
 		return nil, err
 	}
 
+	var lastErr error
+	for range 5 {
+		version, err := s.createVersion(ctx, input, scopeKey, planHash)
+		if err == nil {
+			return version, nil
+		}
+		if !isPostgreSQLUniqueViolation(err) {
+			return nil, err
+		}
+		lastErr = err
+	}
+	return nil, fmt.Errorf("insert execution plan version after concurrent retries: %w", lastErr)
+}
+
+func (s *PostgreSQLStore) createVersion(ctx context.Context, input CreateInput, scopeKey, planHash string) (*Version, error) {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("begin execution plan transaction: %w", err)
@@ -212,4 +228,9 @@ func nullIfEmpty(value string) *string {
 		return nil
 	}
 	return &value
+}
+
+func isPostgreSQLUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
 }

--- a/internal/executionplans/store_sqlite.go
+++ b/internal/executionplans/store_sqlite.go
@@ -1,0 +1,220 @@
+package executionplans
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// SQLiteStore stores immutable execution-plan versions in SQLite.
+type SQLiteStore struct {
+	db *sql.DB
+}
+
+// NewSQLiteStore creates the execution-plan table and indexes if needed.
+func NewSQLiteStore(db *sql.DB) (*SQLiteStore, error) {
+	if db == nil {
+		return nil, fmt.Errorf("database connection is required")
+	}
+
+	statements := []string{
+		`CREATE TABLE IF NOT EXISTS execution_plan_versions (
+			id TEXT PRIMARY KEY,
+			scope_provider TEXT,
+			scope_model TEXT,
+			scope_key TEXT NOT NULL,
+			version INTEGER NOT NULL,
+			active INTEGER NOT NULL DEFAULT 1,
+			name TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			plan_payload JSON NOT NULL,
+			plan_hash TEXT NOT NULL,
+			created_at INTEGER NOT NULL,
+			CHECK (scope_provider IS NOT NULL OR scope_model IS NULL)
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_execution_plan_versions_scope_version
+			ON execution_plan_versions(scope_key, version)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_execution_plan_versions_active_scope
+			ON execution_plan_versions(scope_key) WHERE active = 1`,
+		`CREATE INDEX IF NOT EXISTS idx_execution_plan_versions_active_created_at
+			ON execution_plan_versions(active, created_at DESC)`,
+	}
+	for _, statement := range statements {
+		if _, err := db.Exec(statement); err != nil {
+			return nil, fmt.Errorf("initialize execution plan versions table: %w", err)
+		}
+	}
+
+	return &SQLiteStore{db: db}, nil
+}
+
+func (s *SQLiteStore) ListActive(ctx context.Context) ([]Version, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, scope_provider, scope_model, scope_key, version, active, name, description, plan_payload, plan_hash, created_at
+		FROM execution_plan_versions
+		WHERE active = 1
+		ORDER BY created_at DESC, id DESC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list active execution plans: %w", err)
+	}
+	defer rows.Close()
+	return collectVersions(rows, func(scanner versionRowScanner) (Version, error) {
+		return scanSQLiteVersion(scanner)
+	})
+}
+
+func (s *SQLiteStore) Get(ctx context.Context, id string) (*Version, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, scope_provider, scope_model, scope_key, version, active, name, description, plan_payload, plan_hash, created_at
+		FROM execution_plan_versions
+		WHERE id = ?
+	`, id)
+	version, err := scanSQLiteVersion(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &version, nil
+}
+
+func (s *SQLiteStore) Create(ctx context.Context, input CreateInput) (*Version, error) {
+	input, scopeKey, planHash, err := normalizeCreateInput(input)
+	if err != nil {
+		return nil, err
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin execution plan transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	var nextVersion int
+	if err := tx.QueryRowContext(ctx,
+		`SELECT COALESCE(MAX(version), 0) + 1 FROM execution_plan_versions WHERE scope_key = ?`,
+		scopeKey,
+	).Scan(&nextVersion); err != nil {
+		return nil, fmt.Errorf("select next execution plan version: %w", err)
+	}
+
+	if input.Activate {
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE execution_plan_versions SET active = 0 WHERE scope_key = ? AND active = 1`,
+			scopeKey,
+		); err != nil {
+			return nil, fmt.Errorf("deactivate current execution plan version: %w", err)
+		}
+	}
+
+	payloadJSON, err := json.Marshal(input.Payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal execution plan payload: %w", err)
+	}
+
+	now := time.Now().UTC()
+	version := &Version{
+		ID:          uuid.NewString(),
+		Scope:       input.Scope,
+		ScopeKey:    scopeKey,
+		Version:     nextVersion,
+		Active:      input.Activate,
+		Name:        input.Name,
+		Description: input.Description,
+		Payload:     input.Payload,
+		PlanHash:    planHash,
+		CreatedAt:   now,
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO execution_plan_versions (
+			id, scope_provider, scope_model, scope_key, version, active, name, description, plan_payload, plan_hash, created_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		version.ID,
+		nullableString(version.Scope.Provider),
+		nullableString(version.Scope.Model),
+		version.ScopeKey,
+		version.Version,
+		boolToSQLite(version.Active),
+		version.Name,
+		version.Description,
+		string(payloadJSON),
+		version.PlanHash,
+		version.CreatedAt.Unix(),
+	); err != nil {
+		return nil, fmt.Errorf("insert execution plan version: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit execution plan version: %w", err)
+	}
+	return version, nil
+}
+
+func (s *SQLiteStore) Close() error {
+	return nil
+}
+
+func scanSQLiteVersion(scanner interface {
+	Scan(dest ...any) error
+}) (Version, error) {
+	var (
+		version       Version
+		scopeProvider sql.NullString
+		scopeModel    sql.NullString
+		active        int
+		payloadJSON   string
+		createdAtUnix int64
+	)
+
+	if err := scanner.Scan(
+		&version.ID,
+		&scopeProvider,
+		&scopeModel,
+		&version.ScopeKey,
+		&version.Version,
+		&active,
+		&version.Name,
+		&version.Description,
+		&payloadJSON,
+		&version.PlanHash,
+		&createdAtUnix,
+	); err != nil {
+		return Version{}, err
+	}
+
+	version.Scope = Scope{
+		Provider: scopeProvider.String,
+		Model:    scopeModel.String,
+	}
+	version.Active = active != 0
+	version.CreatedAt = time.Unix(createdAtUnix, 0).UTC()
+	if err := json.Unmarshal([]byte(payloadJSON), &version.Payload); err != nil {
+		return Version{}, fmt.Errorf("decode execution plan payload %q: %w", version.ID, err)
+	}
+	return version, nil
+}
+
+func nullableString(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+func boolToSQLite(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}

--- a/internal/executionplans/store_sqlite.go
+++ b/internal/executionplans/store_sqlite.go
@@ -91,16 +91,26 @@ func (s *SQLiteStore) Create(ctx context.Context, input CreateInput) (*Version, 
 		return nil, err
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
+	conn, err := s.db.Conn(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("begin execution plan transaction: %w", err)
+		return nil, fmt.Errorf("acquire execution plan connection: %w", err)
 	}
 	defer func() {
-		_ = tx.Rollback()
+		_ = conn.Close()
+	}()
+	if _, err := conn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
+		return nil, fmt.Errorf("begin execution plan transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if committed {
+			return
+		}
+		_, _ = conn.ExecContext(context.Background(), `ROLLBACK`)
 	}()
 
 	var nextVersion int
-	if err := tx.QueryRowContext(ctx,
+	if err := conn.QueryRowContext(ctx,
 		`SELECT COALESCE(MAX(version), 0) + 1 FROM execution_plan_versions WHERE scope_key = ?`,
 		scopeKey,
 	).Scan(&nextVersion); err != nil {
@@ -108,7 +118,7 @@ func (s *SQLiteStore) Create(ctx context.Context, input CreateInput) (*Version, 
 	}
 
 	if input.Activate {
-		if _, err := tx.ExecContext(ctx,
+		if _, err := conn.ExecContext(ctx,
 			`UPDATE execution_plan_versions SET active = 0 WHERE scope_key = ? AND active = 1`,
 			scopeKey,
 		); err != nil {
@@ -135,7 +145,7 @@ func (s *SQLiteStore) Create(ctx context.Context, input CreateInput) (*Version, 
 		CreatedAt:   now,
 	}
 
-	if _, err := tx.ExecContext(ctx, `
+	if _, err := conn.ExecContext(ctx, `
 		INSERT INTO execution_plan_versions (
 			id, scope_provider, scope_model, scope_key, version, active, name, description, plan_payload, plan_hash, created_at
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -155,9 +165,10 @@ func (s *SQLiteStore) Create(ctx context.Context, input CreateInput) (*Version, 
 		return nil, fmt.Errorf("insert execution plan version: %w", err)
 	}
 
-	if err := tx.Commit(); err != nil {
+	if _, err := conn.ExecContext(ctx, `COMMIT`); err != nil {
 		return nil, fmt.Errorf("commit execution plan version: %w", err)
 	}
+	committed = true
 	return version, nil
 }
 

--- a/internal/executionplans/types.go
+++ b/internal/executionplans/types.go
@@ -1,0 +1,153 @@
+package executionplans
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+	"strings"
+	"time"
+)
+
+const currentSchemaVersion = 1
+
+// Scope identifies the request selector a persisted execution plan applies to.
+type Scope struct {
+	Provider string `json:"scope_provider,omitempty" bson:"scope_provider,omitempty"`
+	Model    string `json:"scope_model,omitempty" bson:"scope_model,omitempty"`
+}
+
+// Payload is the immutable persisted execution-plan JSON document.
+type Payload struct {
+	SchemaVersion int             `json:"schema_version" bson:"schema_version"`
+	Features      FeatureFlags    `json:"features" bson:"features"`
+	Guardrails    []GuardrailStep `json:"guardrails,omitempty" bson:"guardrails,omitempty"`
+}
+
+// FeatureFlags configures gateway-owned behaviors for a request.
+type FeatureFlags struct {
+	Cache      bool `json:"cache" bson:"cache"`
+	Audit      bool `json:"audit" bson:"audit"`
+	Usage      bool `json:"usage" bson:"usage"`
+	Guardrails bool `json:"guardrails" bson:"guardrails"`
+}
+
+// GuardrailStep references one named guardrail and its execution step.
+type GuardrailStep struct {
+	Ref  string `json:"ref" bson:"ref"`
+	Step int    `json:"step" bson:"step"`
+}
+
+// Version is one immutable persisted execution-plan version row.
+type Version struct {
+	ID          string    `json:"id" bson:"_id"`
+	Scope       Scope     `json:"scope" bson:"-"`
+	ScopeKey    string    `json:"scope_key" bson:"scope_key"`
+	Version     int       `json:"version" bson:"version"`
+	Active      bool      `json:"active" bson:"active"`
+	Name        string    `json:"name" bson:"name"`
+	Description string    `json:"description,omitempty" bson:"description,omitempty"`
+	Payload     Payload   `json:"plan_payload" bson:"plan_payload"`
+	PlanHash    string    `json:"plan_hash" bson:"plan_hash"`
+	CreatedAt   time.Time `json:"created_at" bson:"created_at"`
+}
+
+// CreateInput is the authoring input for one new immutable execution-plan version.
+type CreateInput struct {
+	Scope       Scope
+	Activate    bool
+	Name        string
+	Description string
+	Payload     Payload
+}
+
+func normalizeScope(scope Scope) (Scope, string, error) {
+	scope.Provider = strings.TrimSpace(scope.Provider)
+	scope.Model = strings.TrimSpace(scope.Model)
+	if scope.Provider == "" && scope.Model != "" {
+		return Scope{}, "", newValidationError("scope_model requires scope_provider", nil)
+	}
+	return scope, scopeKey(scope), nil
+}
+
+func scopeKey(scope Scope) string {
+	switch {
+	case scope.Provider == "":
+		return "global"
+	case scope.Model == "":
+		return "provider:" + scope.Provider
+	default:
+		return "provider_model:" + scope.Provider + ":" + scope.Model
+	}
+}
+
+func normalizePayload(payload Payload) (Payload, string, error) {
+	if payload.SchemaVersion == 0 {
+		payload.SchemaVersion = currentSchemaVersion
+	}
+	if payload.SchemaVersion != currentSchemaVersion {
+		return Payload{}, "", newValidationError("unsupported schema_version", nil)
+	}
+
+	type indexedGuardrail struct {
+		step  GuardrailStep
+		index int
+	}
+
+	indexed := make([]indexedGuardrail, 0, len(payload.Guardrails))
+	seenRefs := make(map[string]struct{}, len(payload.Guardrails))
+	for i, guardrail := range payload.Guardrails {
+		guardrail.Ref = strings.TrimSpace(guardrail.Ref)
+		if guardrail.Ref == "" {
+			return Payload{}, "", newValidationError("guardrail ref is required", nil)
+		}
+		if _, exists := seenRefs[guardrail.Ref]; exists {
+			return Payload{}, "", newValidationError("duplicate guardrail ref: "+guardrail.Ref, nil)
+		}
+		seenRefs[guardrail.Ref] = struct{}{}
+		indexed = append(indexed, indexedGuardrail{step: guardrail, index: i})
+	}
+
+	sort.SliceStable(indexed, func(i, j int) bool {
+		if indexed[i].step.Step != indexed[j].step.Step {
+			return indexed[i].step.Step < indexed[j].step.Step
+		}
+		if indexed[i].step.Ref != indexed[j].step.Ref {
+			return indexed[i].step.Ref < indexed[j].step.Ref
+		}
+		return indexed[i].index < indexed[j].index
+	})
+
+	payload.Guardrails = payload.Guardrails[:0]
+	for _, item := range indexed {
+		payload.Guardrails = append(payload.Guardrails, item.step)
+	}
+
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return Payload{}, "", newValidationError("marshal plan payload", err)
+	}
+	sum := sha256.Sum256(raw)
+	return payload, hex.EncodeToString(sum[:]), nil
+}
+
+func normalizeCreateInput(input CreateInput) (CreateInput, string, string, error) {
+	scope, scopeKey, err := normalizeScope(input.Scope)
+	if err != nil {
+		return CreateInput{}, "", "", err
+	}
+
+	payload, planHash, err := normalizePayload(input.Payload)
+	if err != nil {
+		return CreateInput{}, "", "", err
+	}
+
+	input.Scope = scope
+	input.Name = strings.TrimSpace(input.Name)
+	input.Description = strings.TrimSpace(input.Description)
+	input.Payload = payload
+	if input.Name == "" {
+		return CreateInput{}, "", "", newValidationError("name is required", nil)
+	}
+	return input, scopeKey, planHash, nil
+}

--- a/internal/executionplans/types.go
+++ b/internal/executionplans/types.go
@@ -67,6 +67,9 @@ func normalizeScope(scope Scope) (Scope, string, error) {
 	if scope.Provider == "" && scope.Model != "" {
 		return Scope{}, "", newValidationError("scope_model requires scope_provider", nil)
 	}
+	if strings.Contains(scope.Provider, ":") || strings.Contains(scope.Model, ":") {
+		return Scope{}, "", newValidationError("scope fields cannot contain ':'", nil)
+	}
 	return scope, scopeKey(scope), nil
 }
 

--- a/internal/executionplans/types_test.go
+++ b/internal/executionplans/types_test.go
@@ -1,0 +1,27 @@
+package executionplans
+
+import "testing"
+
+func TestNormalizeScope_RejectsColonDelimitedFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []Scope{
+		{Provider: "openai:beta"},
+		{Provider: "openai", Model: "gpt:5"},
+	}
+
+	for _, scope := range tests {
+		scope := scope
+		t.Run(scope.Provider+"|"+scope.Model, func(t *testing.T) {
+			t.Parallel()
+
+			_, _, err := normalizeScope(scope)
+			if err == nil {
+				t.Fatal("normalizeScope() error = nil, want validation error")
+			}
+			if !IsValidationError(err) {
+				t.Fatalf("normalizeScope() error = %T, want validation error", err)
+			}
+		})
+	}
+}

--- a/internal/guardrails/planned_executor.go
+++ b/internal/guardrails/planned_executor.go
@@ -1,0 +1,76 @@
+package guardrails
+
+import (
+	"context"
+
+	"gomodel/internal/core"
+)
+
+// ContextPipelineResolver resolves a request-scoped guardrails pipeline.
+type ContextPipelineResolver interface {
+	PipelineForContext(ctx context.Context) *Pipeline
+}
+
+// PlannedRequestPatcher applies the guardrails pipeline selected by the current execution plan.
+type PlannedRequestPatcher struct {
+	resolver ContextPipelineResolver
+}
+
+// NewPlannedRequestPatcher creates a translated-request patcher that resolves
+// its pipeline from the request context on each call.
+func NewPlannedRequestPatcher(resolver ContextPipelineResolver) *PlannedRequestPatcher {
+	return &PlannedRequestPatcher{resolver: resolver}
+}
+
+// PatchChatRequest applies the request-scoped guardrails pipeline to a translated chat request.
+func (p *PlannedRequestPatcher) PatchChatRequest(ctx context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
+	return processGuardedChat(ctx, p.pipeline(ctx), req)
+}
+
+// PatchResponsesRequest applies the request-scoped guardrails pipeline to a translated responses request.
+func (p *PlannedRequestPatcher) PatchResponsesRequest(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesRequest, error) {
+	return processGuardedResponses(ctx, p.pipeline(ctx), req)
+}
+
+func (p *PlannedRequestPatcher) pipeline(ctx context.Context) *Pipeline {
+	if p == nil || p.resolver == nil {
+		return nil
+	}
+	return p.resolver.PipelineForContext(ctx)
+}
+
+// PlannedBatchPreparer applies the guardrails pipeline selected by the current execution plan.
+type PlannedBatchPreparer struct {
+	provider core.RoutableProvider
+	resolver ContextPipelineResolver
+}
+
+// NewPlannedBatchPreparer creates a native-batch preparer that resolves its pipeline per request.
+func NewPlannedBatchPreparer(provider core.RoutableProvider, resolver ContextPipelineResolver) *PlannedBatchPreparer {
+	return &PlannedBatchPreparer{
+		provider: provider,
+		resolver: resolver,
+	}
+}
+
+// PrepareBatchRequest applies the request-scoped guardrails pipeline to native batch items.
+func (p *PlannedBatchPreparer) PrepareBatchRequest(ctx context.Context, providerType string, req *core.BatchRequest) (*core.BatchRewriteResult, error) {
+	return processGuardedBatchRequest(ctx, providerType, req, p.pipeline(ctx), p.batchFileTransport())
+}
+
+func (p *PlannedBatchPreparer) batchFileTransport() core.BatchFileTransport {
+	if p == nil || p.provider == nil {
+		return nil
+	}
+	if files, ok := p.provider.(core.NativeFileRoutableProvider); ok {
+		return files
+	}
+	return nil
+}
+
+func (p *PlannedBatchPreparer) pipeline(ctx context.Context) *Pipeline {
+	if p == nil || p.resolver == nil {
+		return nil
+	}
+	return p.resolver.PipelineForContext(ctx)
+}

--- a/internal/guardrails/registry.go
+++ b/internal/guardrails/registry.go
@@ -1,0 +1,88 @@
+package guardrails
+
+import (
+	"fmt"
+	"strings"
+
+	"gomodel/internal/responsecache"
+)
+
+// StepReference points to one named guardrail and the step it should run at.
+type StepReference struct {
+	Ref  string
+	Step int
+}
+
+type registryEntry struct {
+	guardrail  Guardrail
+	descriptor responsecache.GuardrailRuleDescriptor
+}
+
+// Registry stores named guardrails so execution plans can reference them by id.
+type Registry struct {
+	entries map[string]registryEntry
+}
+
+// NewRegistry creates an empty named guardrail registry.
+func NewRegistry() *Registry {
+	return &Registry{entries: make(map[string]registryEntry)}
+}
+
+// Len returns the number of registered named guardrails.
+func (r *Registry) Len() int {
+	if r == nil {
+		return 0
+	}
+	return len(r.entries)
+}
+
+// Register adds one named guardrail and its hashing descriptor.
+func (r *Registry) Register(g Guardrail, descriptor responsecache.GuardrailRuleDescriptor) error {
+	if r == nil {
+		return fmt.Errorf("registry is required")
+	}
+	if g == nil {
+		return fmt.Errorf("guardrail is required")
+	}
+	name := strings.TrimSpace(g.Name())
+	if name == "" {
+		return fmt.Errorf("guardrail name is required")
+	}
+	if _, exists := r.entries[name]; exists {
+		return fmt.Errorf("duplicate guardrail registration: %q", name)
+	}
+	descriptor.Name = name
+	r.entries[name] = registryEntry{
+		guardrail:  g,
+		descriptor: descriptor,
+	}
+	return nil
+}
+
+// BuildPipeline resolves named guardrail references into an executable pipeline and hash.
+func (r *Registry) BuildPipeline(steps []StepReference) (*Pipeline, string, error) {
+	if len(steps) == 0 {
+		return nil, "", nil
+	}
+	if r == nil {
+		return nil, "", fmt.Errorf("guardrail registry is required")
+	}
+
+	pipeline := NewPipeline()
+	descriptors := make([]responsecache.GuardrailRuleDescriptor, 0, len(steps))
+	for _, step := range steps {
+		name := strings.TrimSpace(step.Ref)
+		if name == "" {
+			return nil, "", fmt.Errorf("guardrail ref is required")
+		}
+		entry, ok := r.entries[name]
+		if !ok {
+			return nil, "", fmt.Errorf("unknown guardrail ref: %q", name)
+		}
+		pipeline.Add(entry.guardrail, step.Step)
+		descriptor := entry.descriptor
+		descriptor.Order = step.Step
+		descriptors = append(descriptors, descriptor)
+	}
+	return pipeline, responsecache.ComputeGuardrailsHash(descriptors), nil
+}

--- a/internal/responsecache/middleware_test.go
+++ b/internal/responsecache/middleware_test.go
@@ -241,6 +241,59 @@ func TestSimpleCacheMiddleware_SkipsPartialTranslatedPlan(t *testing.T) {
 	}
 }
 
+func TestSimpleCacheMiddleware_SkipsWhenExecutionPlanDisablesCache(t *testing.T) {
+	store := cache.NewMapStore()
+	defer store.Close()
+	mw := NewResponseCacheMiddlewareWithStore(store, time.Hour)
+	e := echo.New()
+	e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c *echo.Context) error {
+			desc := core.DescribeEndpoint(c.Request().Method, c.Request().URL.Path)
+			ctx := core.WithExecutionPlan(c.Request().Context(), &core.ExecutionPlan{
+				Endpoint:     desc,
+				Mode:         core.ExecutionModeTranslated,
+				Capabilities: core.CapabilitiesForEndpoint(desc),
+				Resolution: &core.RequestModelResolution{
+					ResolvedSelector: core.ModelSelector{Provider: "openai", Model: "gpt-4"},
+					ProviderType:     "openai",
+				},
+				Policy: &core.ResolvedExecutionPolicy{
+					VersionID: "plan-cache-off",
+					Features: core.ExecutionFeatures{
+						Cache:      false,
+						Audit:      true,
+						Usage:      true,
+						Guardrails: true,
+					},
+				},
+			})
+			c.SetRequest(c.Request().WithContext(ctx))
+			return next(c)
+		}
+	})
+	e.Use(mw.Middleware())
+	callCount := 0
+	e.POST("/v1/chat/completions", func(c *echo.Context) error {
+		callCount++
+		return c.JSON(http.StatusOK, map[string]string{"n": "1"})
+	})
+
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}`)
+	for range 2 {
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		if rec.Header().Get("X-Cache") != "" {
+			t.Fatalf("cache-disabled plan should bypass cache, got X-Cache=%q", rec.Header().Get("X-Cache"))
+		}
+	}
+
+	if callCount != 2 {
+		t.Fatalf("cache-disabled plan should bypass cache, handler called %d times", callCount)
+	}
+}
+
 func TestSimpleCacheMiddleware_UsesCapturedSnapshotBodyWithoutReadingLiveBody(t *testing.T) {
 	store := cache.NewMapStore()
 	defer store.Close()

--- a/internal/responsecache/middleware_test.go
+++ b/internal/responsecache/middleware_test.go
@@ -70,11 +70,33 @@ func (s *concurrentTrackingStore) Close() error {
 	return nil
 }
 
+func installResolvedExecutionPlan(e *echo.Echo, providerType, model string) {
+	e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c *echo.Context) error {
+			desc := core.DescribeEndpoint(c.Request().Method, c.Request().URL.Path)
+			ctx := core.WithExecutionPlan(c.Request().Context(), &core.ExecutionPlan{
+				Endpoint:     desc,
+				Mode:         core.ExecutionModeTranslated,
+				Capabilities: core.CapabilitiesForEndpoint(desc),
+				ProviderType: providerType,
+				Resolution: &core.RequestModelResolution{
+					Requested:        core.NewRequestedModelSelector(model, providerType),
+					ResolvedSelector: core.ModelSelector{Provider: providerType, Model: model},
+					ProviderType:     providerType,
+				},
+			})
+			c.SetRequest(c.Request().WithContext(ctx))
+			return next(c)
+		}
+	})
+}
+
 func TestSimpleCacheMiddleware_CacheHit(t *testing.T) {
 	store := cache.NewMapStore()
 	defer store.Close()
 	mw := NewResponseCacheMiddlewareWithStore(store, time.Hour)
 	e := echo.New()
+	installResolvedExecutionPlan(e, "openai", "gpt-4")
 	e.Use(mw.Middleware())
 	e.POST("/v1/chat/completions", func(c *echo.Context) error {
 		return c.JSON(http.StatusOK, map[string]string{"result": "cached"})
@@ -116,6 +138,7 @@ func TestSimpleCacheMiddleware_DifferentBodyDifferentKey(t *testing.T) {
 	defer store.Close()
 	mw := NewResponseCacheMiddlewareWithStore(store, time.Hour)
 	e := echo.New()
+	installResolvedExecutionPlan(e, "openai", "gpt-4")
 	e.Use(mw.Middleware())
 	e.POST("/v1/chat/completions", func(c *echo.Context) error {
 		return c.JSON(http.StatusOK, map[string]string{"msg": c.Request().URL.Path})
@@ -299,6 +322,7 @@ func TestSimpleCacheMiddleware_UsesCapturedSnapshotBodyWithoutReadingLiveBody(t 
 	defer store.Close()
 	mw := NewResponseCacheMiddlewareWithStore(store, time.Hour)
 	e := echo.New()
+	installResolvedExecutionPlan(e, "openai", "gpt-4")
 	e.Use(mw.Middleware())
 	callCount := 0
 	e.POST("/v1/chat/completions", func(c *echo.Context) error {
@@ -389,6 +413,38 @@ func TestSimpleCacheMiddleware_BypassesCacheWhenBodyWasNotCaptured(t *testing.T)
 
 	if callCount != 2 {
 		t.Fatalf("expected uncaptured-body requests to bypass cache, handler called %d times", callCount)
+	}
+}
+
+func TestSimpleCacheMiddleware_BypassesCacheWithoutExecutionPlan(t *testing.T) {
+	store := cache.NewMapStore()
+	defer store.Close()
+	mw := NewResponseCacheMiddlewareWithStore(store, time.Hour)
+	e := echo.New()
+	e.Use(mw.Middleware())
+
+	callCount := 0
+	e.POST("/v1/chat/completions", func(c *echo.Context) error {
+		callCount++
+		return c.JSON(http.StatusOK, map[string]string{"result": "ok"})
+	})
+
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}`)
+	for i := range 2 {
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("request %d: got status %d", i+1, rec.Code)
+		}
+		if got := rec.Header().Get("X-Cache"); got != "" {
+			t.Fatalf("expected nil-plan request to bypass cache, got X-Cache=%q", got)
+		}
+	}
+
+	if callCount != 2 {
+		t.Fatalf("expected nil-plan requests to bypass cache, handler called %d times", callCount)
 	}
 }
 
@@ -605,6 +661,7 @@ func TestSimpleCacheMiddleware_CloseWaitsForPendingWrites(t *testing.T) {
 	store := cache.NewMapStore()
 	mw := NewResponseCacheMiddlewareWithStore(store, time.Hour)
 	e := echo.New()
+	installResolvedExecutionPlan(e, "openai", "gpt-4")
 	e.Use(mw.Middleware())
 	e.POST("/v1/chat/completions", func(c *echo.Context) error {
 		return c.JSON(http.StatusOK, map[string]string{"result": "ok"})
@@ -631,6 +688,7 @@ func TestSimpleCacheMiddleware_LimitsConcurrentCacheWrites(t *testing.T) {
 	store := newConcurrentTrackingStore()
 	mw := NewResponseCacheMiddlewareWithStore(store, time.Hour)
 	e := echo.New()
+	installResolvedExecutionPlan(e, "openai", "gpt-4")
 	e.Use(mw.Middleware())
 	e.POST("/v1/chat/completions", func(c *echo.Context) error {
 		return c.JSON(http.StatusOK, map[string]string{"result": "ok"})

--- a/internal/responsecache/simple.go
+++ b/internal/responsecache/simple.go
@@ -193,7 +193,13 @@ func (m *simpleCacheMiddleware) enqueueWrite(job cacheWriteJob) {
 }
 
 func shouldSkipCacheForExecutionPlan(plan *core.ExecutionPlan) bool {
-	return plan != nil && plan.Mode == core.ExecutionModeTranslated && plan.Resolution == nil
+	if plan == nil {
+		return false
+	}
+	if !plan.CacheEnabled() {
+		return true
+	}
+	return plan.Mode == core.ExecutionModeTranslated && plan.Resolution == nil
 }
 
 func requestBodyForCache(req *http.Request) ([]byte, bool, error) {

--- a/internal/responsecache/simple.go
+++ b/internal/responsecache/simple.go
@@ -194,7 +194,7 @@ func (m *simpleCacheMiddleware) enqueueWrite(job cacheWriteJob) {
 
 func shouldSkipCacheForExecutionPlan(plan *core.ExecutionPlan) bool {
 	if plan == nil {
-		return false
+		return true
 	}
 	if !plan.CacheEnabled() {
 		return true

--- a/internal/server/execution_plan_helpers.go
+++ b/internal/server/execution_plan_helpers.go
@@ -12,6 +12,7 @@ func ensureTranslatedRequestPlan(
 	c *echo.Context,
 	provider core.RoutableProvider,
 	resolver RequestModelResolver,
+	policyResolver RequestExecutionPolicyResolver,
 	model,
 	providerHint *string,
 ) (*core.ExecutionPlan, error) {
@@ -19,7 +20,7 @@ func ensureTranslatedRequestPlan(
 		return nil, core.NewInvalidRequestError("model selector targets are required", nil)
 	}
 
-	plan, err := ensureTranslatedExecutionPlan(c, provider, resolver)
+	plan, err := ensureTranslatedExecutionPlan(c, provider, resolver, policyResolver)
 	if err != nil {
 		return nil, err
 	}
@@ -30,7 +31,10 @@ func ensureTranslatedRequestPlan(
 		if err != nil {
 			return nil, err
 		}
-		plan = translatedExecutionPlanForRequest(c, resolution)
+		plan, err = translatedExecutionPlanForRequest(c, resolution, policyResolver)
+		if err != nil {
+			return nil, err
+		}
 		storeExecutionPlan(c, plan)
 	}
 
@@ -38,12 +42,17 @@ func ensureTranslatedRequestPlan(
 	return plan, nil
 }
 
-func ensureTranslatedExecutionPlan(c *echo.Context, provider core.RoutableProvider, resolver RequestModelResolver) (*core.ExecutionPlan, error) {
+func ensureTranslatedExecutionPlan(
+	c *echo.Context,
+	provider core.RoutableProvider,
+	resolver RequestModelResolver,
+	policyResolver RequestExecutionPolicyResolver,
+) (*core.ExecutionPlan, error) {
 	if plan := currentTranslatedExecutionPlan(c); plan != nil {
 		return plan, nil
 	}
 
-	plan, err := deriveExecutionPlan(c, provider, resolver)
+	plan, err := deriveExecutionPlanWithPolicy(c, provider, resolver, policyResolver)
 	if err != nil || plan == nil {
 		return plan, err
 	}
@@ -86,9 +95,10 @@ func applyResolvedSelector(model, providerHint *string, resolution *core.Request
 func translatedExecutionPlanForRequest(
 	c *echo.Context,
 	resolution *core.RequestModelResolution,
-) *core.ExecutionPlan {
+	policyResolver RequestExecutionPolicyResolver,
+) (*core.ExecutionPlan, error) {
 	if c == nil {
-		return nil
+		return nil, nil
 	}
 
 	requestID := requestIDFromContextOrHeader(c.Request())
@@ -116,6 +126,9 @@ func translatedExecutionPlanForRequest(
 	plan.Capabilities = core.CapabilitiesForEndpoint(desc)
 	plan.ProviderType = strings.TrimSpace(resolution.ProviderType)
 	plan.Resolution = resolution
+	if err := applyExecutionPolicy(plan, policyResolver, core.NewExecutionPlanSelector(plan.ProviderType, resolution.ResolvedSelector.Model)); err != nil {
+		return nil, err
+	}
 
-	return plan
+	return plan, nil
 }

--- a/internal/server/execution_plan_helpers_test.go
+++ b/internal/server/execution_plan_helpers_test.go
@@ -35,7 +35,7 @@ func TestEnsureTranslatedRequestPlan_CompletesPartialPlanFromDecodedSelector(t *
 	model := "gpt-4o-mini"
 	providerHint := ""
 
-	plan, err := ensureTranslatedRequestPlan(c, provider, nil, &model, &providerHint)
+	plan, err := ensureTranslatedRequestPlan(c, provider, nil, nil, &model, &providerHint)
 	require.NoError(t, err)
 	require.NotNil(t, plan)
 

--- a/internal/server/execution_policy.go
+++ b/internal/server/execution_policy.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"github.com/labstack/echo/v5"
+
+	"gomodel/internal/core"
+)
+
+// RequestExecutionPolicyResolver matches persisted execution-plan versions for requests.
+type RequestExecutionPolicyResolver interface {
+	Match(selector core.ExecutionPlanSelector) (*core.ResolvedExecutionPolicy, error)
+}
+
+func applyExecutionPolicy(plan *core.ExecutionPlan, resolver RequestExecutionPolicyResolver, selector core.ExecutionPlanSelector) error {
+	if plan == nil || resolver == nil {
+		return nil
+	}
+	policy, err := resolver.Match(selector)
+	if err != nil {
+		return err
+	}
+	plan.Policy = policy
+	return nil
+}
+
+func cloneCurrentExecutionPlan(c *echo.Context) *core.ExecutionPlan {
+	if c == nil {
+		return nil
+	}
+	if existing := core.GetExecutionPlan(c.Request().Context()); existing != nil {
+		cloned := *existing
+		return &cloned
+	}
+	return &core.ExecutionPlan{}
+}
+
+func executionPlanVersionID(plan *core.ExecutionPlan) string {
+	if plan == nil {
+		return ""
+	}
+	return plan.ExecutionPlanVersionID()
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}

--- a/internal/server/execution_policy.go
+++ b/internal/server/execution_policy.go
@@ -1,6 +1,9 @@
 package server
 
 import (
+	"errors"
+	"net/http"
+
 	"github.com/labstack/echo/v5"
 
 	"gomodel/internal/core"
@@ -17,10 +20,20 @@ func applyExecutionPolicy(plan *core.ExecutionPlan, resolver RequestExecutionPol
 	}
 	policy, err := resolver.Match(selector)
 	if err != nil {
-		return err
+		return normalizeExecutionPolicyError(err)
 	}
 	plan.Policy = policy
 	return nil
+}
+
+func normalizeExecutionPolicyError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if gatewayErr, ok := errors.AsType[*core.GatewayError](err); ok {
+		return gatewayErr
+	}
+	return core.NewProviderError("", http.StatusInternalServerError, "failed to resolve execution policy", err)
 }
 
 func cloneCurrentExecutionPlan(c *echo.Context) *core.ExecutionPlan {

--- a/internal/server/execution_policy_test.go
+++ b/internal/server/execution_policy_test.go
@@ -1,0 +1,122 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+
+	"gomodel/internal/core"
+)
+
+type requestExecutionPolicyResolverFunc func(selector core.ExecutionPlanSelector) (*core.ResolvedExecutionPolicy, error)
+
+func (f requestExecutionPolicyResolverFunc) Match(selector core.ExecutionPlanSelector) (*core.ResolvedExecutionPolicy, error) {
+	return f(selector)
+}
+
+type countingBatchResolver struct {
+	calls    int
+	resolved core.ModelSelector
+}
+
+func (r *countingBatchResolver) ResolveModel(requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
+	r.calls++
+	return r.resolved, false, nil
+}
+
+func TestApplyExecutionPolicy_NormalizesResolverErrors(t *testing.T) {
+	t.Parallel()
+
+	plan := &core.ExecutionPlan{}
+	err := applyExecutionPolicy(plan, requestExecutionPolicyResolverFunc(func(core.ExecutionPlanSelector) (*core.ResolvedExecutionPolicy, error) {
+		return nil, errors.New("storage unavailable")
+	}), core.NewExecutionPlanSelector("openai", "gpt-4o-mini"))
+	if err == nil {
+		t.Fatal("applyExecutionPolicy() error = nil, want gateway error")
+	}
+
+	var gatewayErr *core.GatewayError
+	if !errors.As(err, &gatewayErr) {
+		t.Fatalf("applyExecutionPolicy() error = %T, want *core.GatewayError", err)
+	}
+	if gatewayErr.Type != core.ErrorTypeProvider {
+		t.Fatalf("gateway error type = %q, want %q", gatewayErr.Type, core.ErrorTypeProvider)
+	}
+	if gatewayErr.HTTPStatusCode() != http.StatusInternalServerError {
+		t.Fatalf("gateway error status = %d, want %d", gatewayErr.HTTPStatusCode(), http.StatusInternalServerError)
+	}
+}
+
+func TestDetermineBatchExecutionSelection_UsesSingleResolutionPass(t *testing.T) {
+	t.Parallel()
+
+	provider := &mockProvider{
+		supportedModels: []string{"gpt-4o-mini"},
+		providerTypes:   map[string]string{"openai/gpt-4o-mini": "openai"},
+	}
+	resolver := &countingBatchResolver{
+		resolved: core.ModelSelector{Provider: "openai", Model: "gpt-4o-mini"},
+	}
+	req := &core.BatchRequest{
+		Endpoint: "/v1/chat/completions",
+		Requests: []core.BatchRequestItem{
+			{
+				Method: http.MethodPost,
+				Body:   json.RawMessage(`{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}`),
+			},
+			{
+				Method: http.MethodPost,
+				Body:   json.RawMessage(`{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}`),
+			},
+		},
+	}
+
+	selection, err := determineBatchExecutionSelection(provider, resolver, req)
+	if err != nil {
+		t.Fatalf("determineBatchExecutionSelection() error = %v", err)
+	}
+	if selection.providerType != "openai" {
+		t.Fatalf("providerType = %q, want openai", selection.providerType)
+	}
+	if selection.selector.Provider != "openai" || selection.selector.Model != "gpt-4o-mini" {
+		t.Fatalf("selector = %+v, want openai/gpt-4o-mini", selection.selector)
+	}
+	if resolver.calls != len(req.Requests) {
+		t.Fatalf("resolver calls = %d, want %d", resolver.calls, len(req.Requests))
+	}
+}
+
+func TestNativeBatchService_StoreExecutionPlanForBatch_NormalizesPolicyErrors(t *testing.T) {
+	t.Parallel()
+
+	svc := &nativeBatchService{
+		executionPolicyResolver: requestExecutionPolicyResolverFunc(func(core.ExecutionPlanSelector) (*core.ResolvedExecutionPolicy, error) {
+			return nil, errors.New("resolver backend unavailable")
+		}),
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/batches", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	_, err := svc.storeExecutionPlanForBatch(c, batchExecutionSelection{
+		providerType: "openai",
+		selector:     core.NewExecutionPlanSelector("openai", "gpt-4o-mini"),
+	})
+	if err == nil {
+		t.Fatal("storeExecutionPlanForBatch() error = nil, want gateway error")
+	}
+
+	var gatewayErr *core.GatewayError
+	if !errors.As(err, &gatewayErr) {
+		t.Fatalf("storeExecutionPlanForBatch() error = %T, want *core.GatewayError", err)
+	}
+	if gatewayErr.Type != core.ErrorTypeProvider {
+		t.Fatalf("gateway error type = %q, want %q", gatewayErr.Type, core.ErrorTypeProvider)
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -18,6 +18,7 @@ import (
 type Handler struct {
 	provider                     core.RoutableProvider
 	modelResolver                RequestModelResolver
+	executionPolicyResolver      RequestExecutionPolicyResolver
 	translatedRequestPatcher     TranslatedRequestPatcher
 	batchRequestPreparer         BatchRequestPreparer
 	exposedModelLister           ExposedModelLister
@@ -36,7 +37,7 @@ type Handler struct {
 
 // NewHandler creates a new handler with the given routable provider (typically the Router)
 func NewHandler(provider core.RoutableProvider, logger auditlog.LoggerInterface, usageLogger usage.LoggerInterface, pricingResolver usage.PricingResolver) *Handler {
-	return newHandler(provider, logger, usageLogger, pricingResolver, nil, nil)
+	return newHandler(provider, logger, usageLogger, pricingResolver, nil, nil, nil)
 }
 
 func newHandler(
@@ -45,11 +46,13 @@ func newHandler(
 	usageLogger usage.LoggerInterface,
 	pricingResolver usage.PricingResolver,
 	modelResolver RequestModelResolver,
+	executionPolicyResolver RequestExecutionPolicyResolver,
 	translatedRequestPatcher TranslatedRequestPatcher,
 ) *Handler {
 	return &Handler{
 		provider:                     provider,
 		modelResolver:                modelResolver,
+		executionPolicyResolver:      executionPolicyResolver,
 		translatedRequestPatcher:     translatedRequestPatcher,
 		logger:                       logger,
 		usageLogger:                  usageLogger,
@@ -74,6 +77,7 @@ func (h *Handler) translatedInference() *translatedInferenceService {
 		s := &translatedInferenceService{
 			provider:                 h.provider,
 			modelResolver:            h.modelResolver,
+			executionPolicyResolver:  h.executionPolicyResolver,
 			translatedRequestPatcher: h.translatedRequestPatcher,
 			logger:                   h.logger,
 			usageLogger:              h.usageLogger,
@@ -91,6 +95,7 @@ func (h *Handler) nativeBatch() *nativeBatchService {
 	return &nativeBatchService{
 		provider:                             h.provider,
 		modelResolver:                        h.modelResolver,
+		executionPolicyResolver:              h.executionPolicyResolver,
 		batchRequestPreparer:                 h.batchRequestPreparer,
 		batchStore:                           h.batchStore,
 		loadBatch:                            h.loadBatch,

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -1333,7 +1333,7 @@ func TestChatCompletion_UsesExplicitAliasResolverWithoutProviderDecorator(t *tes
 	}
 
 	e := echo.New()
-	handler := newHandler(inner, nil, nil, nil, service, nil)
+	handler := newHandler(inner, nil, nil, nil, service, nil, nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
 	req.Header.Set("Content-Type", "application/json")
@@ -1444,7 +1444,7 @@ func TestChatCompletion_UsesExplicitAliasResolverWithAliasProviderInventoryOnly(
 	})
 
 	e := echo.New()
-	handler := newHandler(provider, nil, nil, nil, service, nil)
+	handler := newHandler(provider, nil, nil, nil, service, nil, nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
 	req.Header.Set("Content-Type", "application/json")
@@ -1524,7 +1524,7 @@ func TestChatCompletion_UsesExplicitTranslatedRequestPatcher(t *testing.T) {
 	patcher := guardrails.NewRequestPatcher(pipeline)
 
 	e := echo.New()
-	handler := newHandler(inner, nil, nil, nil, nil, patcher)
+	handler := newHandler(inner, nil, nil, nil, nil, nil, patcher)
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
 	req.Header.Set("Content-Type", "application/json")
@@ -2007,7 +2007,7 @@ func TestHandleStreamingResponse_FlushesEachChunk(t *testing.T) {
 		},
 	}
 
-	err := handler.translatedInference().handleStreamingResponse(c, "gpt-4o-mini", "openai", func() (io.ReadCloser, error) {
+	err := handler.translatedInference().handleStreamingResponse(c, nil, "gpt-4o-mini", "openai", func() (io.ReadCloser, error) {
 		return stream, nil
 	})
 	if err != nil {
@@ -2099,7 +2099,7 @@ func TestHandleStreamingResponse_RecordsStreamingError(t *testing.T) {
 		Data:      &auditlog.LogData{},
 	})
 
-	err := handler.translatedInference().handleStreamingResponse(c, "gpt-4o-mini", "openai", func() (io.ReadCloser, error) {
+	err := handler.translatedInference().handleStreamingResponse(c, nil, "gpt-4o-mini", "openai", func() (io.ReadCloser, error) {
 		return &erroringReadCloser{
 			data: []byte("data: {\"id\":\"1\"}\n\n"),
 			err:  expectedErr,

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -43,6 +43,7 @@ type Config struct {
 	UsageLogger                  usage.LoggerInterface                  // Optional: Usage logger for token tracking
 	PricingResolver              usage.PricingResolver                  // Optional: Resolves pricing for cost calculation
 	ModelResolver                RequestModelResolver                   // Optional: explicit model resolver used during request planning
+	ExecutionPolicyResolver      RequestExecutionPolicyResolver         // Optional: persisted execution-plan resolver used during request planning
 	TranslatedRequestPatcher     TranslatedRequestPatcher               // Optional: request patcher for translated routes after planning
 	BatchRequestPreparer         BatchRequestPreparer                   // Optional: batch request preparer before native provider submission
 	ExposedModelLister           ExposedModelLister                     // Optional: additional public models to merge into GET /v1/models
@@ -77,13 +78,15 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 	}
 
 	var modelResolver RequestModelResolver
+	var executionPolicyResolver RequestExecutionPolicyResolver
 	var translatedRequestPatcher TranslatedRequestPatcher
 	if cfg != nil {
 		modelResolver = cfg.ModelResolver
+		executionPolicyResolver = cfg.ExecutionPolicyResolver
 		translatedRequestPatcher = cfg.TranslatedRequestPatcher
 	}
 
-	handler := newHandler(provider, auditLogger, usageLogger, pricingResolver, modelResolver, translatedRequestPatcher)
+	handler := newHandler(provider, auditLogger, usageLogger, pricingResolver, modelResolver, executionPolicyResolver, translatedRequestPatcher)
 	if cfg != nil {
 		handler.batchRequestPreparer = cfg.BatchRequestPreparer
 		handler.exposedModelLister = cfg.ExposedModelLister
@@ -193,7 +196,17 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 	// Ingress capture (before auth/audit/model validation so they can consume shared raw request state)
 	e.Use(RequestSnapshotCapture())
 
-	// Audit logging middleware (before authentication to capture all requests)
+	if cfg != nil && len(cfg.PassthroughSemanticEnrichers) > 0 {
+		e.Use(PassthroughSemanticEnrichment(cfg.PassthroughSemanticEnrichers, passthroughV1PrefixNormalizationEnabled(cfg)))
+	}
+
+	// Request planning must run before audit so per-request feature flags can
+	// suppress audit capture entirely.
+	e.Use(ExecutionPlanningWithResolverAndPolicy(provider, modelResolver, executionPolicyResolver))
+
+	// Audit logging middleware runs after planning so Audit=false can bypass
+	// request/response capture, but still before authentication so rejected model
+	// requests are logged when auditing is enabled for the matched plan.
 	if cfg != nil && cfg.AuditLogger != nil && cfg.AuditLogger.Config().Enabled {
 		e.Use(auditlog.Middleware(cfg.AuditLogger))
 	}
@@ -202,13 +215,6 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 	if cfg != nil && cfg.MasterKey != "" {
 		e.Use(AuthMiddleware(cfg.MasterKey, authSkipPaths))
 	}
-
-	if cfg != nil && len(cfg.PassthroughSemanticEnrichers) > 0 {
-		e.Use(PassthroughSemanticEnrichment(cfg.PassthroughSemanticEnrichers, passthroughV1PrefixNormalizationEnabled(cfg)))
-	}
-
-	// Request planning (skips non-model paths via IsModelInteractionPath)
-	e.Use(ExecutionPlanningWithResolver(provider, modelResolver))
 
 	// Public routes
 	e.GET("/health", handler.Health)

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -200,16 +200,18 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 		e.Use(PassthroughSemanticEnrichment(cfg.PassthroughSemanticEnrichers, passthroughV1PrefixNormalizationEnabled(cfg)))
 	}
 
-	// Request planning must run before audit so per-request feature flags can
-	// suppress audit capture entirely.
-	e.Use(ExecutionPlanningWithResolverAndPolicy(provider, modelResolver, executionPolicyResolver))
-
-	// Audit logging middleware runs after planning so Audit=false can bypass
-	// request/response capture, but still before authentication so rejected model
-	// requests are logged when auditing is enabled for the matched plan.
+	// Audit logging runs before request planning so early planning/validation
+	// failures are still logged. The middleware defers request capture and
+	// dynamically gates response capture on the final resolved execution plan, so
+	// Audit=false still suppresses per-request capture work.
 	if cfg != nil && cfg.AuditLogger != nil && cfg.AuditLogger.Config().Enabled {
 		e.Use(auditlog.Middleware(cfg.AuditLogger))
 	}
+
+	// Request planning resolves the request-scoped execution plan before auth and
+	// handler execution. This keeps rejected model requests loggable and lets
+	// downstream stages consume a shared policy decision.
+	e.Use(ExecutionPlanningWithResolverAndPolicy(provider, modelResolver, executionPolicyResolver))
 
 	// Authentication (skips public paths)
 	if cfg != nil && cfg.MasterKey != "" {

--- a/internal/server/model_validation.go
+++ b/internal/server/model_validation.go
@@ -19,20 +19,30 @@ type modelCountProvider interface {
 // provider type, and any early model routing decision that downstream handlers
 // or middleware need to consume.
 func ExecutionPlanning(provider core.RoutableProvider) echo.MiddlewareFunc {
-	return ExecutionPlanningWithResolver(provider, nil)
+	return ExecutionPlanningWithResolverAndPolicy(provider, nil, nil)
 }
 
 // ExecutionPlanningWithResolver resolves request-scoped execution plans using
 // an explicit selector resolver when provided. This lets request planning own
 // alias policy instead of depending on provider decorators.
 func ExecutionPlanningWithResolver(provider core.RoutableProvider, resolver RequestModelResolver) echo.MiddlewareFunc {
+	return ExecutionPlanningWithResolverAndPolicy(provider, resolver, nil)
+}
+
+// ExecutionPlanningWithResolverAndPolicy resolves request-scoped execution plans
+// and matches one persisted execution policy when configured.
+func ExecutionPlanningWithResolverAndPolicy(
+	provider core.RoutableProvider,
+	resolver RequestModelResolver,
+	policyResolver RequestExecutionPolicyResolver,
+) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c *echo.Context) error {
 			path := c.Request().URL.Path
 			if !core.IsModelInteractionPath(path) {
 				return next(c)
 			}
-			plan, err := deriveExecutionPlan(c, provider, resolver)
+			plan, err := deriveExecutionPlanWithPolicy(c, provider, resolver, policyResolver)
 			if err != nil {
 				return handleError(c, err)
 			}
@@ -45,6 +55,15 @@ func ExecutionPlanningWithResolver(provider core.RoutableProvider, resolver Requ
 }
 
 func deriveExecutionPlan(c *echo.Context, provider core.RoutableProvider, resolver RequestModelResolver) (*core.ExecutionPlan, error) {
+	return deriveExecutionPlanWithPolicy(c, provider, resolver, nil)
+}
+
+func deriveExecutionPlanWithPolicy(
+	c *echo.Context,
+	provider core.RoutableProvider,
+	resolver RequestModelResolver,
+	policyResolver RequestExecutionPolicyResolver,
+) (*core.ExecutionPlan, error) {
 	if c == nil {
 		return nil, nil
 	}
@@ -79,15 +98,23 @@ func deriveExecutionPlan(c *echo.Context, provider core.RoutableProvider, resolv
 		plan.Mode = core.ExecutionModePassthrough
 		plan.ProviderType = providerType
 		plan.Passthrough = passthrough
-		auditlog.EnrichEntryWithExecutionPlan(c, plan)
+		if err := applyExecutionPolicy(plan, policyResolver, core.NewExecutionPlanSelector(providerType, passthrough.Model)); err != nil {
+			return nil, err
+		}
 		return plan, nil
 
 	case core.OperationBatches:
 		plan.Mode = core.ExecutionModeNativeBatch
+		if err := applyExecutionPolicy(plan, policyResolver, core.ExecutionPlanSelector{}); err != nil {
+			return nil, err
+		}
 		return plan, nil
 
 	case core.OperationFiles:
 		plan.Mode = core.ExecutionModeNativeFile
+		if err := applyExecutionPolicy(plan, policyResolver, core.ExecutionPlanSelector{}); err != nil {
+			return nil, err
+		}
 		return plan, nil
 
 	case core.OperationChatCompletions, core.OperationResponses, core.OperationEmbeddings:
@@ -97,11 +124,16 @@ func deriveExecutionPlan(c *echo.Context, provider core.RoutableProvider, resolv
 			return nil, err
 		}
 		if !parsed || resolution == nil {
+			if err := applyExecutionPolicy(plan, policyResolver, core.ExecutionPlanSelector{}); err != nil {
+				return nil, err
+			}
 			return plan, nil
 		}
 		plan.ProviderType = resolution.ProviderType
 		plan.Resolution = resolution
-		auditlog.EnrichEntryWithExecutionPlan(c, plan)
+		if err := applyExecutionPolicy(plan, policyResolver, core.NewExecutionPlanSelector(resolution.ProviderType, resolution.ResolvedSelector.Model)); err != nil {
+			return nil, err
+		}
 		return plan, nil
 
 	default:
@@ -113,6 +145,7 @@ func storeExecutionPlan(c *echo.Context, plan *core.ExecutionPlan) {
 	if c == nil || plan == nil {
 		return
 	}
+	auditlog.EnrichEntryWithExecutionPlan(c, plan)
 	ctx := core.WithExecutionPlan(c.Request().Context(), plan)
 	c.SetRequest(c.Request().WithContext(ctx))
 }

--- a/internal/server/model_validation.go
+++ b/internal/server/model_validation.go
@@ -54,10 +54,6 @@ func ExecutionPlanningWithResolverAndPolicy(
 	}
 }
 
-func deriveExecutionPlan(c *echo.Context, provider core.RoutableProvider, resolver RequestModelResolver) (*core.ExecutionPlan, error) {
-	return deriveExecutionPlanWithPolicy(c, provider, resolver, nil)
-}
-
 func deriveExecutionPlanWithPolicy(
 	c *echo.Context,
 	provider core.RoutableProvider,

--- a/internal/server/model_validation_test.go
+++ b/internal/server/model_validation_test.go
@@ -31,6 +31,17 @@ type modelCountingValidationProvider struct {
 	modelCount int
 }
 
+type staticExecutionPolicyResolver struct {
+	match func(core.ExecutionPlanSelector) (*core.ResolvedExecutionPolicy, error)
+}
+
+func (r *staticExecutionPolicyResolver) Match(selector core.ExecutionPlanSelector) (*core.ResolvedExecutionPolicy, error) {
+	if r == nil || r.match == nil {
+		return nil, nil
+	}
+	return r.match(selector)
+}
+
 func (explodingValidationReadCloser) Read([]byte) (int, error) {
 	return 0, errors.New("live request body should not be read")
 }
@@ -270,6 +281,56 @@ func TestModelValidation_StoresExecutionPlan(t *testing.T) {
 			assert.Equal(t, "gpt-4o-mini", capturedPlan.Resolution.Requested.Model)
 			assert.Equal(t, "gpt-4o-mini", capturedPlan.Resolution.ResolvedSelector.Model)
 		}
+	}
+}
+
+func TestModelValidation_StoresMatchedExecutionPolicy(t *testing.T) {
+	provider := &mockProvider{supportedModels: []string{"gpt-4o-mini"}}
+
+	e := echo.New()
+	var capturedPlan *core.ExecutionPlan
+
+	policyResolver := &staticExecutionPolicyResolver{
+		match: func(selector core.ExecutionPlanSelector) (*core.ResolvedExecutionPolicy, error) {
+			if selector.Provider == "mock" && selector.Model == "gpt-4o-mini" {
+				return &core.ResolvedExecutionPolicy{
+					VersionID:      "plan-openai-gpt-4o-mini-v3",
+					Version:        3,
+					ScopeProvider:  "mock",
+					ScopeModel:     "gpt-4o-mini",
+					Name:           "provider-model",
+					PlanHash:       "hash-123",
+					Features:       core.DefaultExecutionFeatures(),
+					GuardrailsHash: "guardrails-123",
+				}, nil
+			}
+			return &core.ResolvedExecutionPolicy{
+				VersionID: "plan-global-v1",
+				Version:   1,
+				Name:      "global",
+				Features:  core.DefaultExecutionFeatures(),
+			}, nil
+		},
+	}
+
+	middleware := ExecutionPlanningWithResolverAndPolicy(provider, nil, policyResolver)
+	handler := middleware(func(c *echo.Context) error {
+		capturedPlan = core.GetExecutionPlan(c.Request().Context())
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler(c)
+	require.NoError(t, err)
+
+	if assert.NotNil(t, capturedPlan) && assert.NotNil(t, capturedPlan.Policy) {
+		assert.Equal(t, "plan-openai-gpt-4o-mini-v3", capturedPlan.Policy.VersionID)
+		assert.Equal(t, "guardrails-123", capturedPlan.Policy.GuardrailsHash)
 	}
 }
 

--- a/internal/server/native_batch_service.go
+++ b/internal/server/native_batch_service.go
@@ -22,6 +22,7 @@ import (
 type nativeBatchService struct {
 	provider                             core.RoutableProvider
 	modelResolver                        RequestModelResolver
+	executionPolicyResolver              RequestExecutionPolicyResolver
 	batchRequestPreparer                 BatchRequestPreparer
 	batchStore                           batchstore.Store
 	loadBatch                            func(*echo.Context, string) (*batchstore.StoredBatch, error)
@@ -46,6 +47,10 @@ func (s *nativeBatchService) Batches(c *echo.Context) error {
 	}
 
 	providerType, err := determineBatchProviderType(s.provider, s.modelResolver, req)
+	if err != nil {
+		return handleError(c, err)
+	}
+	plan, err := s.storeExecutionPlanForBatch(c, req, providerType)
 	if err != nil {
 		return handleError(c, err)
 	}
@@ -124,6 +129,8 @@ func (s *nativeBatchService) Batches(c *echo.Context) error {
 			OriginalInputFileID:       batchPreparation.OriginalInputFileID,
 			RewrittenInputFileID:      batchPreparation.RewrittenInputFileID,
 			RequestID:                 requestID,
+			ExecutionPlanVersionID:    executionPlanVersionID(plan),
+			UsageEnabled:              boolPtr(plan == nil || plan.UsageEnabled()),
 		}
 		if err := s.batchStore.Create(ctx, stored); err != nil {
 			s.rollbackPreparedBatch(ctx, providerType, batchPreparation, providerBatchID)
@@ -143,6 +150,32 @@ func (s *nativeBatchService) rollbackPreparedBatch(ctx context.Context, provider
 	}
 	s.clearUpstreamBatchResultHints(providerType, providerBatchID)
 	s.cancelUpstreamBatch(ctx, providerType, providerBatchID)
+}
+
+func (s *nativeBatchService) storeExecutionPlanForBatch(
+	c *echo.Context,
+	req *core.BatchRequest,
+	providerType string,
+) (*core.ExecutionPlan, error) {
+	plan := cloneCurrentExecutionPlan(c)
+	if plan == nil {
+		return nil, nil
+	}
+	plan.Mode = core.ExecutionModeNativeBatch
+	plan.ProviderType = strings.TrimSpace(providerType)
+
+	if s.executionPolicyResolver != nil {
+		selector, err := determineBatchExecutionSelector(s.provider, s.modelResolver, req, providerType)
+		if err != nil {
+			return nil, err
+		}
+		if err := applyExecutionPolicy(plan, s.executionPolicyResolver, selector); err != nil {
+			return nil, err
+		}
+	}
+
+	storeExecutionPlan(c, plan)
+	return plan, nil
 }
 
 func (s *nativeBatchService) clearUpstreamBatchResultHints(providerType, batchID string) {

--- a/internal/server/native_batch_service.go
+++ b/internal/server/native_batch_service.go
@@ -46,11 +46,12 @@ func (s *nativeBatchService) Batches(c *echo.Context) error {
 		return handleError(c, core.NewInvalidRequestError("batch routing is not supported by the current provider router", nil))
 	}
 
-	providerType, err := determineBatchProviderType(s.provider, s.modelResolver, req)
+	selection, err := determineBatchExecutionSelection(s.provider, s.modelResolver, req)
 	if err != nil {
 		return handleError(c, err)
 	}
-	plan, err := s.storeExecutionPlanForBatch(c, req, providerType)
+	providerType := selection.providerType
+	plan, err := s.storeExecutionPlanForBatch(c, selection)
 	if err != nil {
 		return handleError(c, err)
 	}
@@ -152,24 +153,16 @@ func (s *nativeBatchService) rollbackPreparedBatch(ctx context.Context, provider
 	s.cancelUpstreamBatch(ctx, providerType, providerBatchID)
 }
 
-func (s *nativeBatchService) storeExecutionPlanForBatch(
-	c *echo.Context,
-	req *core.BatchRequest,
-	providerType string,
-) (*core.ExecutionPlan, error) {
+func (s *nativeBatchService) storeExecutionPlanForBatch(c *echo.Context, selection batchExecutionSelection) (*core.ExecutionPlan, error) {
 	plan := cloneCurrentExecutionPlan(c)
 	if plan == nil {
 		return nil, nil
 	}
 	plan.Mode = core.ExecutionModeNativeBatch
-	plan.ProviderType = strings.TrimSpace(providerType)
+	plan.ProviderType = strings.TrimSpace(selection.providerType)
 
 	if s.executionPolicyResolver != nil {
-		selector, err := determineBatchExecutionSelector(s.provider, s.modelResolver, req, providerType)
-		if err != nil {
-			return nil, err
-		}
-		if err := applyExecutionPolicy(plan, s.executionPolicyResolver, selector); err != nil {
+		if err := applyExecutionPolicy(plan, s.executionPolicyResolver, selection.selector); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/server/native_batch_support.go
+++ b/internal/server/native_batch_support.go
@@ -86,6 +86,49 @@ func determineBatchProviderType(provider core.RoutableProvider, resolver Request
 	return providerType, nil
 }
 
+func determineBatchExecutionSelector(
+	provider core.RoutableProvider,
+	resolver RequestModelResolver,
+	req *core.BatchRequest,
+	providerType string,
+) (core.ExecutionPlanSelector, error) {
+	selector := core.NewExecutionPlanSelector(providerType, "")
+	if req == nil || providerType == "" || strings.TrimSpace(req.InputFileID) != "" || len(req.Requests) == 0 {
+		return selector, nil
+	}
+
+	resolver = effectiveRequestModelResolver(provider, resolver)
+	commonModel := ""
+	for i, item := range req.Requests {
+		requested, err := core.BatchItemRequestedModelSelector(req.Endpoint, item)
+		if err != nil {
+			return core.ExecutionPlanSelector{}, core.NewInvalidRequestError(fmt.Sprintf("batch item %d: %s", i, err.Error()), err)
+		}
+		resolved, err := requested.Normalize()
+		if err != nil {
+			return core.ExecutionPlanSelector{}, core.NewInvalidRequestError(fmt.Sprintf("batch item %d: %s", i, err.Error()), err)
+		}
+		if resolver != nil {
+			resolved, _, err = resolver.ResolveModel(requested)
+			if err != nil {
+				return core.ExecutionPlanSelector{}, core.NewInvalidRequestError(fmt.Sprintf("batch item %d: %s", i, err.Error()), err)
+			}
+		}
+		model := strings.TrimSpace(resolved.Model)
+		if model == "" {
+			return selector, nil
+		}
+		if commonModel == "" {
+			commonModel = model
+			continue
+		}
+		if commonModel != model {
+			return selector, nil
+		}
+	}
+	return core.NewExecutionPlanSelector(providerType, commonModel), nil
+}
+
 func mergeBatchRequestEndpointHints(left, right map[string]string) map[string]string {
 	if len(left) == 0 {
 		if len(right) == 0 {
@@ -132,6 +175,9 @@ func (h *Handler) loadBatch(c *echo.Context, id string) (*batchstore.StoredBatch
 
 func (h *Handler) logBatchUsageFromBatchResults(stored *batchstore.StoredBatch, result *core.BatchResultsResponse, fallbackRequestID string) bool {
 	if h.usageLogger == nil || !h.usageLogger.Config().Enabled || stored == nil || stored.Batch == nil || result == nil || len(result.Data) == 0 {
+		return false
+	}
+	if !stored.EffectiveUsageEnabled() {
 		return false
 	}
 	if stored.UsageLoggedAt != nil {

--- a/internal/server/native_batch_support.go
+++ b/internal/server/native_batch_support.go
@@ -26,107 +26,96 @@ var batchResultsPending404Providers = map[string]struct{}{
 	"anthropic": {},
 }
 
-func determineBatchProviderType(provider core.RoutableProvider, resolver RequestModelResolver, req *core.BatchRequest) (string, error) {
+type batchExecutionSelection struct {
+	providerType string
+	selector     core.ExecutionPlanSelector
+}
+
+func determineBatchExecutionSelection(provider core.RoutableProvider, resolver RequestModelResolver, req *core.BatchRequest) (batchExecutionSelection, error) {
 	if provider == nil {
-		return "", core.NewInvalidRequestError("provider is not configured", nil)
+		return batchExecutionSelection{}, core.NewInvalidRequestError("provider is not configured", nil)
 	}
 
 	if strings.TrimSpace(req.InputFileID) != "" {
 		if req.Metadata == nil {
-			return "", core.NewInvalidRequestError("metadata.provider is required for input_file_id batches", nil)
+			return batchExecutionSelection{}, core.NewInvalidRequestError("metadata.provider is required for input_file_id batches", nil)
 		}
 		providerType := strings.TrimSpace(req.Metadata["provider"])
 		if providerType == "" {
-			return "", core.NewInvalidRequestError("metadata.provider is required for input_file_id batches", nil)
+			return batchExecutionSelection{}, core.NewInvalidRequestError("metadata.provider is required for input_file_id batches", nil)
 		}
-		return providerType, nil
+		return batchExecutionSelection{
+			providerType: providerType,
+			selector:     core.NewExecutionPlanSelector(providerType, ""),
+		}, nil
 	}
 
 	if len(req.Requests) == 0 {
-		return "", core.NewInvalidRequestError("requests is required and must not be empty", nil)
+		return batchExecutionSelection{}, core.NewInvalidRequestError("requests is required and must not be empty", nil)
 	}
 
-	var providerType string
+	var (
+		providerType   string
+		commonModel    string
+		hasCommonModel = true
+	)
 	resolver = effectiveRequestModelResolver(provider, resolver)
 	for i, item := range req.Requests {
 		requested, err := core.BatchItemRequestedModelSelector(req.Endpoint, item)
 		if err != nil {
-			return "", core.NewInvalidRequestError(fmt.Sprintf("batch item %d: %s", i, err.Error()), err)
+			return batchExecutionSelection{}, core.NewInvalidRequestError(fmt.Sprintf("batch item %d: %s", i, err.Error()), err)
 		}
-		selector, err := requested.Normalize()
+		resolvedSelector, err := requested.Normalize()
 		if err != nil {
-			return "", core.NewInvalidRequestError(fmt.Sprintf("batch item %d: %s", i, err.Error()), err)
+			return batchExecutionSelection{}, core.NewInvalidRequestError(fmt.Sprintf("batch item %d: %s", i, err.Error()), err)
 		}
 		if resolver != nil {
-			selector, _, err = resolver.ResolveModel(requested)
+			resolvedSelector, _, err = resolver.ResolveModel(requested)
 			if err != nil {
-				return "", core.NewInvalidRequestError(fmt.Sprintf("batch item %d: %s", i, err.Error()), err)
+				return batchExecutionSelection{}, core.NewInvalidRequestError(fmt.Sprintf("batch item %d: %s", i, err.Error()), err)
 			}
 		}
-		model := selector.QualifiedModel()
+		model := resolvedSelector.QualifiedModel()
 		if model == "" {
-			return "", core.NewInvalidRequestError(fmt.Sprintf("batch item %d: model is required", i), nil)
+			return batchExecutionSelection{}, core.NewInvalidRequestError(fmt.Sprintf("batch item %d: model is required", i), nil)
 		}
 		if !provider.Supports(model) {
-			return "", core.NewInvalidRequestError("unsupported model: "+model, nil)
+			return batchExecutionSelection{}, core.NewInvalidRequestError("unsupported model: "+model, nil)
 		}
 		itemProvider := provider.GetProviderType(model)
 		if providerType == "" {
 			providerType = itemProvider
+		} else if providerType != itemProvider {
+			return batchExecutionSelection{}, core.NewInvalidRequestError("native batch supports a single provider per batch; split mixed-provider requests", nil)
+		}
+
+		if !hasCommonModel {
 			continue
 		}
-		if providerType != itemProvider {
-			return "", core.NewInvalidRequestError("native batch supports a single provider per batch; split mixed-provider requests", nil)
+		resolvedModel := strings.TrimSpace(resolvedSelector.Model)
+		if resolvedModel == "" {
+			hasCommonModel = false
+			continue
+		}
+		if commonModel == "" {
+			commonModel = resolvedModel
+			continue
+		}
+		if commonModel != resolvedModel {
+			hasCommonModel = false
 		}
 	}
 
 	if providerType == "" {
-		return "", core.NewInvalidRequestError("unable to resolve provider for batch", nil)
+		return batchExecutionSelection{}, core.NewInvalidRequestError("unable to resolve provider for batch", nil)
 	}
-	return providerType, nil
-}
-
-func determineBatchExecutionSelector(
-	provider core.RoutableProvider,
-	resolver RequestModelResolver,
-	req *core.BatchRequest,
-	providerType string,
-) (core.ExecutionPlanSelector, error) {
-	selector := core.NewExecutionPlanSelector(providerType, "")
-	if req == nil || providerType == "" || strings.TrimSpace(req.InputFileID) != "" || len(req.Requests) == 0 {
-		return selector, nil
+	if !hasCommonModel {
+		commonModel = ""
 	}
-
-	resolver = effectiveRequestModelResolver(provider, resolver)
-	commonModel := ""
-	for i, item := range req.Requests {
-		requested, err := core.BatchItemRequestedModelSelector(req.Endpoint, item)
-		if err != nil {
-			return core.ExecutionPlanSelector{}, core.NewInvalidRequestError(fmt.Sprintf("batch item %d: %s", i, err.Error()), err)
-		}
-		resolved, err := requested.Normalize()
-		if err != nil {
-			return core.ExecutionPlanSelector{}, core.NewInvalidRequestError(fmt.Sprintf("batch item %d: %s", i, err.Error()), err)
-		}
-		if resolver != nil {
-			resolved, _, err = resolver.ResolveModel(requested)
-			if err != nil {
-				return core.ExecutionPlanSelector{}, core.NewInvalidRequestError(fmt.Sprintf("batch item %d: %s", i, err.Error()), err)
-			}
-		}
-		model := strings.TrimSpace(resolved.Model)
-		if model == "" {
-			return selector, nil
-		}
-		if commonModel == "" {
-			commonModel = model
-			continue
-		}
-		if commonModel != model {
-			return selector, nil
-		}
-	}
-	return core.NewExecutionPlanSelector(providerType, commonModel), nil
+	return batchExecutionSelection{
+		providerType: providerType,
+		selector:     core.NewExecutionPlanSelector(providerType, commonModel),
+	}, nil
 }
 
 func mergeBatchRequestEndpointHints(left, right map[string]string) map[string]string {

--- a/internal/server/passthrough_support.go
+++ b/internal/server/passthrough_support.go
@@ -264,10 +264,13 @@ func (s *passthroughService) proxyPassthroughResponse(c *echo.Context, providerT
 		model = resolvedModelFromPlan(core.GetExecutionPlan(c.Request().Context()), model)
 
 		observers := make([]streaming.Observer, 0, 2)
-		if observer := auditlog.NewStreamLogObserver(s.logger, streamEntry, auditPath); observer != nil {
-			observers = append(observers, observer)
+		plan := core.GetExecutionPlan(c.Request().Context())
+		if (plan == nil || plan.AuditEnabled()) && streamEntry != nil {
+			if observer := auditlog.NewStreamLogObserver(s.logger, streamEntry, auditPath); observer != nil {
+				observers = append(observers, observer)
+			}
 		}
-		if s.usageLogger != nil && s.usageLogger.Config().Enabled {
+		if s.usageLogger != nil && s.usageLogger.Config().Enabled && (plan == nil || plan.UsageEnabled()) {
 			if observer := usage.NewStreamUsageObserver(s.usageLogger, model, providerType, requestID, usagePath, s.pricingResolver); observer != nil {
 				observers = append(observers, observer)
 			}

--- a/internal/server/passthrough_support.go
+++ b/internal/server/passthrough_support.go
@@ -244,11 +244,19 @@ func (s *passthroughService) proxyPassthroughResponse(c *echo.Context, providerT
 	if isSSEContentType(resp.Headers) {
 		auditlog.MarkEntryAsStreaming(c, true)
 		auditlog.EnrichEntryWithStream(c, true)
+		plan := core.GetExecutionPlan(c.Request().Context())
+		auditEnabled := s.logger != nil && s.logger.Config().Enabled && (plan == nil || plan.AuditEnabled())
 
 		entry := auditlog.GetStreamEntryFromContext(c)
+		if auditEnabled && entry != nil {
+			auditlog.PopulateRequestData(entry, c.Request(), s.logger.Config())
+		}
 		streamEntry := auditlog.CreateStreamEntry(entry)
 		if streamEntry != nil {
 			streamEntry.StatusCode = resp.StatusCode
+		}
+		if auditEnabled && streamEntry != nil && s.logger.Config().LogHeaders {
+			auditlog.PopulateResponseHeaders(streamEntry, c.Response().Header())
 		}
 
 		requestID := requestIDFromContextOrHeader(c.Request())
@@ -261,11 +269,10 @@ func (s *passthroughService) proxyPassthroughResponse(c *echo.Context, providerT
 		if info != nil {
 			model = strings.TrimSpace(info.Model)
 		}
-		model = resolvedModelFromPlan(core.GetExecutionPlan(c.Request().Context()), model)
+		model = resolvedModelFromPlan(plan, model)
 
 		observers := make([]streaming.Observer, 0, 2)
-		plan := core.GetExecutionPlan(c.Request().Context())
-		if (plan == nil || plan.AuditEnabled()) && streamEntry != nil {
+		if auditEnabled && streamEntry != nil {
 			if observer := auditlog.NewStreamLogObserver(s.logger, streamEntry, auditPath); observer != nil {
 				observers = append(observers, observer)
 			}

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -332,6 +332,10 @@ func (s *translatedInferenceService) handleStreamingResponse(
 	auditlog.EnrichEntryWithStream(c, true)
 
 	entry := auditlog.GetStreamEntryFromContext(c)
+	auditEnabled := s.logger != nil && s.logger.Config().Enabled && (plan == nil || plan.AuditEnabled())
+	if auditEnabled && entry != nil {
+		auditlog.PopulateRequestData(entry, c.Request(), s.logger.Config())
+	}
 	streamEntry := auditlog.CreateStreamEntry(entry)
 	if streamEntry != nil {
 		streamEntry.StatusCode = http.StatusOK
@@ -340,7 +344,7 @@ func (s *translatedInferenceService) handleStreamingResponse(
 	requestID := requestIDFromContextOrHeader(c.Request())
 	endpoint := c.Request().URL.Path
 	observers := make([]streaming.Observer, 0, 2)
-	if s.logger != nil && s.logger.Config().Enabled && streamEntry != nil && (plan == nil || plan.AuditEnabled()) {
+	if auditEnabled && streamEntry != nil {
 		observers = append(observers, auditlog.NewStreamLogObserver(s.logger, streamEntry, endpoint))
 	}
 	if s.usageLogger != nil && s.usageLogger.Config().Enabled && (plan == nil || plan.UsageEnabled()) {
@@ -356,12 +360,8 @@ func (s *translatedInferenceService) handleStreamingResponse(
 	c.Response().Header().Set("Cache-Control", "no-cache")
 	c.Response().Header().Set("Connection", "keep-alive")
 
-	if streamEntry != nil && streamEntry.Data != nil {
-		streamEntry.Data.ResponseHeaders = map[string]string{
-			"Content-Type":  "text/event-stream",
-			"Cache-Control": "no-cache",
-			"Connection":    "keep-alive",
-		}
+	if auditEnabled && streamEntry != nil && s.logger.Config().LogHeaders {
+		auditlog.PopulateResponseHeaders(streamEntry, c.Response().Header())
 	}
 
 	c.Response().WriteHeader(http.StatusOK)

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -22,6 +22,7 @@ import (
 type translatedInferenceService struct {
 	provider                 core.RoutableProvider
 	modelResolver            RequestModelResolver
+	executionPolicyResolver  RequestExecutionPolicyResolver
 	translatedRequestPatcher TranslatedRequestPatcher
 	logger                   auditlog.LoggerInterface
 	usageLogger              usage.LoggerInterface
@@ -80,7 +81,7 @@ func (s *translatedInferenceService) dispatchChatCompletion(c *echo.Context, req
 	requestID := requestIDFromContextOrHeader(c.Request())
 
 	if req.Stream {
-		return s.handleStreamingResponse(c, usageModel, providerType, func() (io.ReadCloser, error) {
+		return s.handleStreamingResponse(c, plan, usageModel, providerType, func() (io.ReadCloser, error) {
 			return s.provider.StreamChatCompletion(ctx, streamReq)
 		})
 	}
@@ -90,7 +91,7 @@ func (s *translatedInferenceService) dispatchChatCompletion(c *echo.Context, req
 		return handleError(c, err)
 	}
 
-	s.logUsage(resp.Model, providerType, func(pricing *core.ModelPricing) *usage.UsageEntry {
+	s.logUsage(plan, resp.Model, providerType, func(pricing *core.ModelPricing) *usage.UsageEntry {
 		return usage.ExtractFromChatResponse(resp, requestID, providerType, "/v1/chat/completions", pricing)
 	})
 
@@ -117,7 +118,7 @@ func handleTranslatedInference[R any](
 		return handleError(c, core.NewInvalidRequestError("invalid request body: "+err.Error(), err))
 	}
 	modelPtr, providerPtr := modelProvider(req)
-	plan, err := ensureTranslatedRequestPlan(c, s.provider, s.modelResolver, modelPtr, providerPtr)
+	plan, err := ensureTranslatedRequestPlan(c, s.provider, s.modelResolver, s.executionPolicyResolver, modelPtr, providerPtr)
 	if err != nil {
 		return handleError(c, err)
 	}
@@ -144,12 +145,16 @@ func handleWithCache[R any](
 	plan *core.ExecutionPlan,
 	dispatch func(*echo.Context, R, *core.ExecutionPlan) error,
 ) error {
-	if s.guardrailsHash != "" {
-		ctx := core.WithGuardrailsHash(c.Request().Context(), s.guardrailsHash)
+	guardrailsHash := s.guardrailsHash
+	if plan != nil && plan.Policy != nil {
+		guardrailsHash = plan.GuardrailsHash()
+	}
+	if guardrailsHash != "" {
+		ctx := core.WithGuardrailsHash(c.Request().Context(), guardrailsHash)
 		c.SetRequest(c.Request().WithContext(ctx))
 	}
 
-	if s.responseCache != nil && !stream {
+	if s.responseCache != nil && !stream && (plan == nil || plan.CacheEnabled()) {
 		body, marshalErr := marshalRequestBody(req)
 		if marshalErr != nil {
 			slog.Debug("marshalRequestBody failed", "err", marshalErr)
@@ -169,10 +174,10 @@ func (s *translatedInferenceService) dispatchResponses(c *echo.Context, req *cor
 	requestID := requestIDFromContextOrHeader(c.Request())
 
 	if req.Stream {
-		if s.shouldEnforceReturningUsageData() {
+		if (plan == nil || plan.UsageEnabled()) && s.shouldEnforceReturningUsageData() {
 			ctx = core.WithEnforceReturningUsageData(ctx, true)
 		}
-		return s.handleStreamingResponse(c, usageModel, providerType, func() (io.ReadCloser, error) {
+		return s.handleStreamingResponse(c, plan, usageModel, providerType, func() (io.ReadCloser, error) {
 			return s.provider.StreamResponses(ctx, req)
 		})
 	}
@@ -182,7 +187,7 @@ func (s *translatedInferenceService) dispatchResponses(c *echo.Context, req *cor
 		return handleError(c, err)
 	}
 
-	s.logUsage(resp.Model, providerType, func(pricing *core.ModelPricing) *usage.UsageEntry {
+	s.logUsage(plan, resp.Model, providerType, func(pricing *core.ModelPricing) *usage.UsageEntry {
 		return usage.ExtractFromResponsesResponse(resp, requestID, providerType, "/v1/responses", pricing)
 	})
 
@@ -194,7 +199,7 @@ func (s *translatedInferenceService) Embeddings(c *echo.Context) error {
 	if err != nil {
 		return handleError(c, core.NewInvalidRequestError("invalid request body: "+err.Error(), err))
 	}
-	plan, err := ensureTranslatedRequestPlan(c, s.provider, s.modelResolver, &req.Model, &req.Provider)
+	plan, err := ensureTranslatedRequestPlan(c, s.provider, s.modelResolver, s.executionPolicyResolver, &req.Model, &req.Provider)
 	if err != nil {
 		return handleError(c, err)
 	}
@@ -208,14 +213,19 @@ func (s *translatedInferenceService) Embeddings(c *echo.Context) error {
 		return handleError(c, err)
 	}
 
-	s.logUsage(resp.Model, providerType, func(pricing *core.ModelPricing) *usage.UsageEntry {
+	s.logUsage(plan, resp.Model, providerType, func(pricing *core.ModelPricing) *usage.UsageEntry {
 		return usage.ExtractFromEmbeddingResponse(resp, requestID, providerType, "/v1/embeddings", pricing)
 	})
 
 	return c.JSON(http.StatusOK, resp)
 }
 
-func (s *translatedInferenceService) handleStreamingResponse(c *echo.Context, model, provider string, streamFn func() (io.ReadCloser, error)) error {
+func (s *translatedInferenceService) handleStreamingResponse(
+	c *echo.Context,
+	plan *core.ExecutionPlan,
+	model, provider string,
+	streamFn func() (io.ReadCloser, error),
+) error {
 	stream, err := streamFn()
 	if err != nil {
 		return handleError(c, err)
@@ -233,10 +243,10 @@ func (s *translatedInferenceService) handleStreamingResponse(c *echo.Context, mo
 	requestID := requestIDFromContextOrHeader(c.Request())
 	endpoint := c.Request().URL.Path
 	observers := make([]streaming.Observer, 0, 2)
-	if s.logger != nil && s.logger.Config().Enabled && streamEntry != nil {
+	if s.logger != nil && s.logger.Config().Enabled && streamEntry != nil && (plan == nil || plan.AuditEnabled()) {
 		observers = append(observers, auditlog.NewStreamLogObserver(s.logger, streamEntry, endpoint))
 	}
-	if s.usageLogger != nil && s.usageLogger.Config().Enabled {
+	if s.usageLogger != nil && s.usageLogger.Config().Enabled && (plan == nil || plan.UsageEnabled()) {
 		observers = append(observers, usage.NewStreamUsageObserver(s.usageLogger, model, provider, requestID, endpoint, s.pricingResolver))
 	}
 	wrappedStream := streaming.NewObservedSSEStream(stream, observers...)
@@ -264,8 +274,12 @@ func (s *translatedInferenceService) handleStreamingResponse(c *echo.Context, mo
 	return nil
 }
 
-func (s *translatedInferenceService) logUsage(model, providerType string, extractFn func(*core.ModelPricing) *usage.UsageEntry) {
-	if s.usageLogger == nil || !s.usageLogger.Config().Enabled {
+func (s *translatedInferenceService) logUsage(
+	plan *core.ExecutionPlan,
+	model, providerType string,
+	extractFn func(*core.ModelPricing) *usage.UsageEntry,
+) {
+	if s.usageLogger == nil || !s.usageLogger.Config().Enabled || (plan != nil && !plan.UsageEnabled()) {
 		return
 	}
 	var pricing *core.ModelPricing
@@ -295,7 +309,7 @@ func (s *translatedInferenceService) resolveProviderAndModelFromPlan(
 	}
 
 	model := resolvedModelFromPlan(plan, fallbackModel)
-	if req == nil || !req.Stream || !s.shouldEnforceReturningUsageData() {
+	if req == nil || !req.Stream || (plan != nil && !plan.UsageEnabled()) || !s.shouldEnforceReturningUsageData() {
 		return req, providerType, model
 	}
 

--- a/internal/server/translated_inference_service_test.go
+++ b/internal/server/translated_inference_service_test.go
@@ -1,0 +1,47 @@
+package server
+
+import (
+	"testing"
+
+	"gomodel/internal/core"
+	"gomodel/internal/usage"
+)
+
+type usageCaptureLogger struct {
+	config  usage.Config
+	entries []*usage.UsageEntry
+}
+
+func (l *usageCaptureLogger) Write(entry *usage.UsageEntry) {
+	l.entries = append(l.entries, entry)
+}
+
+func (l *usageCaptureLogger) Config() usage.Config { return l.config }
+func (l *usageCaptureLogger) Close() error         { return nil }
+
+func TestTranslatedInferenceService_LogUsageSkipsWhenExecutionPlanDisablesUsage(t *testing.T) {
+	logger := &usageCaptureLogger{
+		config: usage.Config{Enabled: true},
+	}
+	service := &translatedInferenceService{
+		usageLogger: logger,
+	}
+
+	service.logUsage(&core.ExecutionPlan{
+		Policy: &core.ResolvedExecutionPolicy{
+			VersionID: "plan-usage-off",
+			Features: core.ExecutionFeatures{
+				Cache:      true,
+				Audit:      true,
+				Usage:      false,
+				Guardrails: true,
+			},
+		},
+	}, "gpt-5-nano", "openai", func(*core.ModelPricing) *usage.UsageEntry {
+		return &usage.UsageEntry{ID: "usage-1"}
+	})
+
+	if len(logger.entries) != 0 {
+		t.Fatalf("len(entries) = %d, want 0", len(logger.entries))
+	}
+}

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -123,7 +124,7 @@ func setupMongoDB(ctx context.Context) error {
 	var err error
 
 	log.Println("Starting MongoDB container...")
-	mongoContainer, err = mongodb.Run(ctx, "mongo:7")
+	mongoContainer, err = mongodb.Run(ctx, "mongo:7", mongodb.WithReplicaSet("rs"))
 	if err != nil {
 		return fmt.Errorf("failed to start MongoDB container: %w", err)
 	}
@@ -133,11 +134,15 @@ func setupMongoDB(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to get MongoDB connection string: %w", err)
 	}
+	mongoURL, err = withDirectMongoConnection(mongoURL)
+	if err != nil {
+		return fmt.Errorf("failed to normalize MongoDB connection string: %w", err)
+	}
 
 	log.Printf("MongoDB URL: %s", mongoURL)
 
 	// Create client
-	mongoClient, err = mongo.Connect(options.Client().ApplyURI(mongoURL))
+	mongoClient, err = mongo.Connect(options.Client().ApplyURI(mongoURL).SetDirect(true))
 	if err != nil {
 		return fmt.Errorf("failed to create MongoDB client: %w", err)
 	}
@@ -212,4 +217,15 @@ func GetMongoURL() string {
 // GetTestContext returns the shared test context.
 func GetTestContext() context.Context {
 	return testCtx
+}
+
+func withDirectMongoConnection(rawURL string) (string, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+	query := parsed.Query()
+	query.Set("directConnection", "true")
+	parsed.RawQuery = query.Encode()
+	return parsed.String(), nil
 }

--- a/tests/integration/setup_test.go
+++ b/tests/integration/setup_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -83,6 +84,8 @@ func SetupTestServer(t *testing.T, cfg TestServerConfig) *TestServerFixture {
 
 	ctx, cancel := context.WithCancel(GetTestContext())
 
+	resetIntegrationStorage(t, cfg.DBType)
+
 	// Create mock LLM server
 	mockLLM := NewMockLLMServer()
 
@@ -136,6 +139,68 @@ func SetupTestServer(t *testing.T, cfg TestServerConfig) *TestServerFixture {
 	}
 
 	return fixture
+}
+
+func resetIntegrationStorage(t *testing.T, dbType string) {
+	t.Helper()
+
+	switch dbType {
+	case "postgresql":
+		resetPostgreSQLStorage(t)
+	case "mongodb":
+		resetMongoDBStorage(t)
+	}
+}
+
+func resetPostgreSQLStorage(t *testing.T) {
+	t.Helper()
+
+	pool := GetPostgreSQLPool()
+	require.NotNil(t, pool, "postgresql pool must be initialized")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	tables := []string{
+		"audit_logs",
+		"usage",
+		"execution_plan_versions",
+		"aliases",
+		"batches",
+	}
+	for _, table := range tables {
+		_, err := pool.Exec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", table))
+		require.NoError(t, err, "failed to reset table %s", table)
+	}
+}
+
+func resetMongoDBStorage(t *testing.T) {
+	t.Helper()
+
+	db := GetMongoDatabase()
+	require.NotNil(t, db, "mongodb database must be initialized")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	collections := []string{
+		"audit_logs",
+		"usage",
+		"execution_plan_versions",
+		"aliases",
+		"batches",
+	}
+	for _, collection := range collections {
+		err := db.Collection(collection).Drop(ctx)
+		if err == nil {
+			continue
+		}
+		var cmdErr mongo.CommandError
+		if errors.As(err, &cmdErr) && cmdErr.Code == 26 {
+			continue
+		}
+		require.NoError(t, err, "failed to reset collection %s", collection)
+	}
 }
 
 // FlushAndClose flushes all pending log entries and closes loggers.

--- a/tests/integration/setup_test.go
+++ b/tests/integration/setup_test.go
@@ -149,6 +149,8 @@ func resetIntegrationStorage(t *testing.T, dbType string) {
 		resetPostgreSQLStorage(t)
 	case "mongodb":
 		resetMongoDBStorage(t)
+	default:
+		t.Fatalf("unknown db type: %s", dbType)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add persisted, versioned execution plans with in-memory matching and per-request policy resolution
- wire execution-plan feature flags through guardrails, cache, audit, usage, and batch handling
- update ADR-0003 so process-level env/config flags are hard upper bounds over plan features

## Verification
- go test ./...
- repository commit hooks passed (fmt, unit tests, perf guard, golangci-lint)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Execution Plans: versioned per-request controls for cache, audit, usage, and guardrails; runtime policy resolution applies plan features per request.
  * Guardrails: per-request guardrail pipelines can be applied when enabled by a plan.

* **Behavior Changes**
  * Cache, audit, and usage honor effective execution-plan features (process-level caps may hard-disable features); absent plans bypass caching.
  * Batch requests persist execution-plan version and respect per-plan usage settings.

* **Configuration**
  * New execution_plans.refresh_interval (default 1m).

* **Tests**
  * Expanded coverage for execution-plan compiler, service, stores, middleware, cache bypass, and policy handling.

* **Documentation**
  * ADR clarified immutability and process-level feature caps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->