### PR TITLE
fix(mongodb): run as replica set in docker-compose to enable transactions

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -68,12 +68,13 @@ services:
       - "27017:27017"
     volumes:
       - mongodb_data:/data/db
+    command: ["--replSet", "rs0", "--bind_ip_all"]
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
+      test: ["CMD", "mongosh", "--quiet", "--eval", "try { rs.status() } catch(e) { rs.initiate({_id:'rs0',members:[{_id:0,host:'localhost:27017'}]}) }; if (!db.hello().isWritablePrimary) { quit(1) }"]
+      interval: 5s
+      timeout: 10s
+      retries: 10
       start_period: 10s
 
   adminer:

--- a/internal/executionplans/store_mongodb.go
+++ b/internal/executionplans/store_mongodb.go
@@ -103,74 +103,57 @@ func (s *MongoDBStore) Create(ctx context.Context, input CreateInput) (*Version,
 		return nil, err
 	}
 
-	session, err := s.collection.Database().Client().StartSession()
-	if err != nil {
-		return nil, fmt.Errorf("start execution plan session: %w", err)
+	var latest struct {
+		Version int `bson:"version"`
 	}
-	defer session.EndSession(ctx)
-
-	result, err := session.WithTransaction(ctx, func(sessionCtx context.Context) (any, error) {
-		var latest struct {
-			Version int `bson:"version"`
-		}
-		findOpts := options.FindOne().SetSort(bson.D{{Key: "version", Value: -1}})
-		err := s.collection.FindOne(sessionCtx, bson.D{{Key: "scope_key", Value: scopeKey}}, findOpts).Decode(&latest)
-		if err != nil && !errors.Is(err, mongo.ErrNoDocuments) {
-			return nil, fmt.Errorf("load latest execution plan version: %w", err)
-		}
-
-		if input.Activate {
-			if _, err := s.collection.UpdateMany(sessionCtx,
-				bson.D{{Key: "scope_key", Value: scopeKey}, {Key: "active", Value: true}},
-				bson.D{{Key: "$set", Value: bson.D{{Key: "active", Value: false}}}},
-			); err != nil {
-				return nil, fmt.Errorf("deactivate current execution plan version: %w", err)
-			}
-		}
-
-		now := time.Now().UTC()
-		version := &Version{
-			ID:          uuid.NewString(),
-			Scope:       input.Scope,
-			ScopeKey:    scopeKey,
-			Version:     latest.Version + 1,
-			Active:      input.Activate,
-			Name:        input.Name,
-			Description: input.Description,
-			Payload:     input.Payload,
-			PlanHash:    planHash,
-			CreatedAt:   now,
-		}
-
-		if _, err := s.collection.InsertOne(sessionCtx, mongoVersionDocument{
-			ID:            version.ID,
-			ScopeProvider: version.Scope.Provider,
-			ScopeModel:    version.Scope.Model,
-			ScopeKey:      version.ScopeKey,
-			Version:       version.Version,
-			Active:        version.Active,
-			Name:          version.Name,
-			Description:   version.Description,
-			PlanPayload:   version.Payload,
-			PlanHash:      version.PlanHash,
-			CreatedAt:     version.CreatedAt,
-		}); err != nil {
-			if mongo.IsDuplicateKeyError(err) {
-				return nil, fmt.Errorf("insert execution plan version: duplicate key: %w", err)
-			}
-			return nil, fmt.Errorf("insert execution plan version: %w", err)
-		}
-
-		return version, nil
-	})
-	if err != nil {
-		return nil, err
+	findOpts := options.FindOne().SetSort(bson.D{{Key: "version", Value: -1}})
+	err = s.collection.FindOne(ctx, bson.D{{Key: "scope_key", Value: scopeKey}}, findOpts).Decode(&latest)
+	if err != nil && !errors.Is(err, mongo.ErrNoDocuments) {
+		return nil, fmt.Errorf("load latest execution plan version: %w", err)
 	}
 
-	version, ok := result.(*Version)
-	if !ok {
-		return nil, fmt.Errorf("unexpected execution plan transaction result: %T", result)
+	if input.Activate {
+		if _, err := s.collection.UpdateMany(ctx,
+			bson.D{{Key: "scope_key", Value: scopeKey}, {Key: "active", Value: true}},
+			bson.D{{Key: "$set", Value: bson.D{{Key: "active", Value: false}}}},
+		); err != nil {
+			return nil, fmt.Errorf("deactivate current execution plan version: %w", err)
+		}
 	}
+
+	now := time.Now().UTC()
+	version := &Version{
+		ID:          uuid.NewString(),
+		Scope:       input.Scope,
+		ScopeKey:    scopeKey,
+		Version:     latest.Version + 1,
+		Active:      input.Activate,
+		Name:        input.Name,
+		Description: input.Description,
+		Payload:     input.Payload,
+		PlanHash:    planHash,
+		CreatedAt:   now,
+	}
+
+	if _, err := s.collection.InsertOne(ctx, mongoVersionDocument{
+		ID:            version.ID,
+		ScopeProvider: version.Scope.Provider,
+		ScopeModel:    version.Scope.Model,
+		ScopeKey:      version.ScopeKey,
+		Version:       version.Version,
+		Active:        version.Active,
+		Name:          version.Name,
+		Description:   version.Description,
+		PlanPayload:   version.Payload,
+		PlanHash:      version.PlanHash,
+		CreatedAt:     version.CreatedAt,
+	}); err != nil {
+		if mongo.IsDuplicateKeyError(err) {
+			return nil, fmt.Errorf("insert execution plan version: duplicate key: %w", err)
+		}
+		return nil, fmt.Errorf("insert execution plan version: %w", err)
+	}
+
 	return version, nil
 }
 

--- a/internal/executionplans/store_mongodb.go
+++ b/internal/executionplans/store_mongodb.go
@@ -103,57 +103,74 @@ func (s *MongoDBStore) Create(ctx context.Context, input CreateInput) (*Version,
 		return nil, err
 	}
 
-	var latest struct {
-		Version int `bson:"version"`
+	session, err := s.collection.Database().Client().StartSession()
+	if err != nil {
+		return nil, fmt.Errorf("start execution plan session: %w", err)
 	}
-	findOpts := options.FindOne().SetSort(bson.D{{Key: "version", Value: -1}})
-	err = s.collection.FindOne(ctx, bson.D{{Key: "scope_key", Value: scopeKey}}, findOpts).Decode(&latest)
-	if err != nil && !errors.Is(err, mongo.ErrNoDocuments) {
-		return nil, fmt.Errorf("load latest execution plan version: %w", err)
-	}
+	defer session.EndSession(ctx)
 
-	if input.Activate {
-		if _, err := s.collection.UpdateMany(ctx,
-			bson.D{{Key: "scope_key", Value: scopeKey}, {Key: "active", Value: true}},
-			bson.D{{Key: "$set", Value: bson.D{{Key: "active", Value: false}}}},
-		); err != nil {
-			return nil, fmt.Errorf("deactivate current execution plan version: %w", err)
+	result, err := session.WithTransaction(ctx, func(sessionCtx context.Context) (any, error) {
+		var latest struct {
+			Version int `bson:"version"`
 		}
-	}
-
-	now := time.Now().UTC()
-	version := &Version{
-		ID:          uuid.NewString(),
-		Scope:       input.Scope,
-		ScopeKey:    scopeKey,
-		Version:     latest.Version + 1,
-		Active:      input.Activate,
-		Name:        input.Name,
-		Description: input.Description,
-		Payload:     input.Payload,
-		PlanHash:    planHash,
-		CreatedAt:   now,
-	}
-
-	if _, err := s.collection.InsertOne(ctx, mongoVersionDocument{
-		ID:            version.ID,
-		ScopeProvider: version.Scope.Provider,
-		ScopeModel:    version.Scope.Model,
-		ScopeKey:      version.ScopeKey,
-		Version:       version.Version,
-		Active:        version.Active,
-		Name:          version.Name,
-		Description:   version.Description,
-		PlanPayload:   version.Payload,
-		PlanHash:      version.PlanHash,
-		CreatedAt:     version.CreatedAt,
-	}); err != nil {
-		if mongo.IsDuplicateKeyError(err) {
-			return nil, fmt.Errorf("insert execution plan version: duplicate key: %w", err)
+		findOpts := options.FindOne().SetSort(bson.D{{Key: "version", Value: -1}})
+		err := s.collection.FindOne(sessionCtx, bson.D{{Key: "scope_key", Value: scopeKey}}, findOpts).Decode(&latest)
+		if err != nil && !errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, fmt.Errorf("load latest execution plan version: %w", err)
 		}
-		return nil, fmt.Errorf("insert execution plan version: %w", err)
+
+		if input.Activate {
+			if _, err := s.collection.UpdateMany(sessionCtx,
+				bson.D{{Key: "scope_key", Value: scopeKey}, {Key: "active", Value: true}},
+				bson.D{{Key: "$set", Value: bson.D{{Key: "active", Value: false}}}},
+			); err != nil {
+				return nil, fmt.Errorf("deactivate current execution plan version: %w", err)
+			}
+		}
+
+		now := time.Now().UTC()
+		version := &Version{
+			ID:          uuid.NewString(),
+			Scope:       input.Scope,
+			ScopeKey:    scopeKey,
+			Version:     latest.Version + 1,
+			Active:      input.Activate,
+			Name:        input.Name,
+			Description: input.Description,
+			Payload:     input.Payload,
+			PlanHash:    planHash,
+			CreatedAt:   now,
+		}
+
+		if _, err := s.collection.InsertOne(sessionCtx, mongoVersionDocument{
+			ID:            version.ID,
+			ScopeProvider: version.Scope.Provider,
+			ScopeModel:    version.Scope.Model,
+			ScopeKey:      version.ScopeKey,
+			Version:       version.Version,
+			Active:        version.Active,
+			Name:          version.Name,
+			Description:   version.Description,
+			PlanPayload:   version.Payload,
+			PlanHash:      version.PlanHash,
+			CreatedAt:     version.CreatedAt,
+		}); err != nil {
+			if mongo.IsDuplicateKeyError(err) {
+				return nil, fmt.Errorf("insert execution plan version: duplicate key: %w", err)
+			}
+			return nil, fmt.Errorf("insert execution plan version: %w", err)
+		}
+
+		return version, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
+	version, ok := result.(*Version)
+	if !ok {
+		return nil, fmt.Errorf("unexpected execution plan transaction result: %T", result)
+	}
 	return version, nil
 }
 


### PR DESCRIPTION
## Summary

Configure the docker-compose MongoDB service to run as a single-node replica set (`--replSet rs0`) with a healthcheck that auto-initializes the RS and waits for primary election before marking the container healthy.

This fixes the startup failure:
> `(IllegalOperation) Transaction numbers are only allowed on a replica set member or mongos`

## What changed

**`docker-compose.yaml`** only — the Go code is unchanged.

- Added `command: ["--replSet", "rs0", "--bind_ip_all"]` to the `mongodb` service
- Replaced the simple `db.adminCommand('ping')` healthcheck with one that:
  1. Calls `rs.initiate()` on first startup (idempotent — errors on subsequent runs are swallowed)
  2. Checks `db.hello().isWritablePrimary` — fails until primary is elected, so dependent services only start once the RS is ready

## Why not remove the transaction?

A code review on the first commit correctly identified that removing `WithTransaction` creates a partial-failure window: if `InsertOne` fails after `UpdateMany` succeeds, the scope is left with no active version. `BulkWrite` is not a substitute — it does not provide multi-document atomicity without a session. The transaction is necessary for the same reason the PostgreSQL store uses one.

## Compatibility

| Deployment | Before | After |
|---|---|---|
| docker-compose (standalone) | ❌ startup crash | ✅ auto-initializes RS |
| Single-node replica set | ✅ | ✅ |
| Multi-node cluster | ✅ | ✅ |

Connecting from the host (`mongodb://localhost:27017/gomodel`) continues to work — the RS is initialized with `localhost:27017` so the driver discovers it normally.

## Test plan

- [ ] `make test` passes
- [ ] `docker-compose up mongodb` from a clean state — verify container reaches `healthy` without manual `rs.initiate()`
- [ ] Run S55 from `release-e2e-scenarios.md` (MongoDB smoke) against the stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)