### PR TITLE
refactor(storage): narrow backend interfaces

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -261,6 +261,34 @@ type MongoDBStorageConfig struct {
 	Database string `yaml:"database" env:"MONGODB_DATABASE"`
 }
 
+// BackendConfig converts the application storage config into the internal storage config.
+func (c StorageConfig) BackendConfig() storage.Config {
+	cfg := storage.Config{
+		Type: c.Type,
+		SQLite: storage.SQLiteConfig{
+			Path: c.SQLite.Path,
+		},
+		PostgreSQL: storage.PostgreSQLConfig{
+			URL:      c.PostgreSQL.URL,
+			MaxConns: c.PostgreSQL.MaxConns,
+		},
+		MongoDB: storage.MongoDBConfig{
+			URL:      c.MongoDB.URL,
+			Database: c.MongoDB.Database,
+		},
+	}
+	if cfg.Type == "" {
+		cfg.Type = storage.TypeSQLite
+	}
+	if cfg.SQLite.Path == "" {
+		cfg.SQLite.Path = storage.DefaultSQLitePath
+	}
+	if cfg.MongoDB.Database == "" {
+		cfg.MongoDB.Database = "gomodel"
+	}
+	return cfg
+}
+
 // CacheConfig holds model and response cache configuration.
 type CacheConfig struct {
 	Model    ModelCacheConfig    `yaml:"model"`

--- a/internal/aliases/factory.go
+++ b/internal/aliases/factory.go
@@ -2,10 +2,14 @@ package aliases
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"sync"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 
 	"gomodel/config"
 	"gomodel/internal/storage"
@@ -106,14 +110,10 @@ func newResult(ctx context.Context, cfg *config.Config, storeConn storage.Storag
 }
 
 func createStore(ctx context.Context, store storage.Storage) (Store, error) {
-	switch store := store.(type) {
-	case storage.SQLiteStorage:
-		return NewSQLiteStore(store.DB())
-	case storage.PostgreSQLStorage:
-		return NewPostgreSQLStore(ctx, store.Pool())
-	case storage.MongoDBStorage:
-		return NewMongoDBStore(store.Database())
-	default:
-		return nil, fmt.Errorf("unsupported storage backend %T", store)
-	}
+	return storage.ResolveBackend[Store](
+		store,
+		func(db *sql.DB) (Store, error) { return NewSQLiteStore(db) },
+		func(pool *pgxpool.Pool) (Store, error) { return NewPostgreSQLStore(ctx, pool) },
+		func(db *mongo.Database) (Store, error) { return NewMongoDBStore(db) },
+	)
 }

--- a/internal/aliases/factory.go
+++ b/internal/aliases/factory.go
@@ -7,9 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgxpool"
-	"go.mongodb.org/mongo-driver/v2/mongo"
-
 	"gomodel/config"
 	"gomodel/internal/storage"
 )
@@ -59,7 +56,7 @@ func New(ctx context.Context, cfg *config.Config, catalog Catalog) (*Result, err
 	if cfg == nil {
 		return nil, fmt.Errorf("config is required")
 	}
-	storeConn, err := storage.New(ctx, buildStorageConfig(cfg))
+	storeConn, err := storage.New(ctx, cfg.Storage.BackendConfig())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create storage: %w", err)
 	}
@@ -108,59 +105,15 @@ func newResult(ctx context.Context, cfg *config.Config, storeConn storage.Storag
 	}, nil
 }
 
-func buildStorageConfig(cfg *config.Config) storage.Config {
-	storageCfg := storage.Config{
-		Type: cfg.Storage.Type,
-		SQLite: storage.SQLiteConfig{
-			Path: cfg.Storage.SQLite.Path,
-		},
-		PostgreSQL: storage.PostgreSQLConfig{
-			URL:      cfg.Storage.PostgreSQL.URL,
-			MaxConns: cfg.Storage.PostgreSQL.MaxConns,
-		},
-		MongoDB: storage.MongoDBConfig{
-			URL:      cfg.Storage.MongoDB.URL,
-			Database: cfg.Storage.MongoDB.Database,
-		},
-	}
-
-	if storageCfg.Type == "" {
-		storageCfg.Type = storage.TypeSQLite
-	}
-	if storageCfg.SQLite.Path == "" {
-		storageCfg.SQLite.Path = storage.DefaultSQLitePath
-	}
-	if storageCfg.MongoDB.Database == "" {
-		storageCfg.MongoDB.Database = "gomodel"
-	}
-	return storageCfg
-}
-
 func createStore(ctx context.Context, store storage.Storage) (Store, error) {
-	switch store.Type() {
-	case storage.TypeSQLite:
-		return NewSQLiteStore(store.SQLiteDB())
-	case storage.TypePostgreSQL:
-		pool := store.PostgreSQLPool()
-		if pool == nil {
-			return nil, fmt.Errorf("PostgreSQL pool is nil")
-		}
-		pgxPool, ok := pool.(*pgxpool.Pool)
-		if !ok {
-			return nil, fmt.Errorf("invalid PostgreSQL pool type: %T", pool)
-		}
-		return NewPostgreSQLStore(ctx, pgxPool)
-	case storage.TypeMongoDB:
-		db := store.MongoDatabase()
-		if db == nil {
-			return nil, fmt.Errorf("MongoDB database is nil")
-		}
-		mongoDB, ok := db.(*mongo.Database)
-		if !ok {
-			return nil, fmt.Errorf("invalid MongoDB database type: %T", db)
-		}
-		return NewMongoDBStore(mongoDB)
+	switch store := store.(type) {
+	case storage.SQLiteStorage:
+		return NewSQLiteStore(store.DB())
+	case storage.PostgreSQLStorage:
+		return NewPostgreSQLStore(ctx, store.Pool())
+	case storage.MongoDBStorage:
+		return NewMongoDBStore(store.Database())
 	default:
-		return nil, fmt.Errorf("unknown storage type: %s", store.Type())
+		return nil, fmt.Errorf("unsupported storage backend %T", store)
 	}
 }

--- a/internal/auditlog/factory.go
+++ b/internal/auditlog/factory.go
@@ -2,9 +2,13 @@ package auditlog
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 
 	"gomodel/config"
 	"gomodel/internal/storage"
@@ -78,16 +82,12 @@ func New(ctx context.Context, cfg *config.Config) (*Result, error) {
 
 // createLogStore creates the appropriate LogStore for the given storage backend.
 func createLogStore(store storage.Storage, retentionDays int) (LogStore, error) {
-	switch store := store.(type) {
-	case storage.SQLiteStorage:
-		return NewSQLiteStore(store.DB(), retentionDays)
-	case storage.PostgreSQLStorage:
-		return NewPostgreSQLStore(store.Pool(), retentionDays)
-	case storage.MongoDBStorage:
-		return NewMongoDBStore(store.Database(), retentionDays)
-	default:
-		return nil, fmt.Errorf("unsupported storage backend %T", store)
-	}
+	return storage.ResolveBackend[LogStore](
+		store,
+		func(db *sql.DB) (LogStore, error) { return NewSQLiteStore(db, retentionDays) },
+		func(pool *pgxpool.Pool) (LogStore, error) { return NewPostgreSQLStore(pool, retentionDays) },
+		func(db *mongo.Database) (LogStore, error) { return NewMongoDBStore(db, retentionDays) },
+	)
 }
 
 // buildLoggerConfig creates an auditlog.Config from config.LogConfig.

--- a/internal/auditlog/factory.go
+++ b/internal/auditlog/factory.go
@@ -6,9 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgxpool"
-	"go.mongodb.org/mongo-driver/v2/mongo"
-
 	"gomodel/config"
 	"gomodel/internal/storage"
 )
@@ -55,7 +52,7 @@ func New(ctx context.Context, cfg *config.Config) (*Result, error) {
 	}
 
 	// Create storage configuration
-	storageCfg := buildStorageConfig(cfg)
+	storageCfg := cfg.Storage.BackendConfig()
 
 	// Create storage connection
 	store, err := storage.New(ctx, storageCfg)
@@ -79,67 +76,17 @@ func New(ctx context.Context, cfg *config.Config) (*Result, error) {
 	}, nil
 }
 
-// buildStorageConfig creates a storage.Config from the application config.
-func buildStorageConfig(cfg *config.Config) storage.Config {
-	storageCfg := storage.Config{
-		Type: cfg.Storage.Type,
-		SQLite: storage.SQLiteConfig{
-			Path: cfg.Storage.SQLite.Path,
-		},
-		PostgreSQL: storage.PostgreSQLConfig{
-			URL:      cfg.Storage.PostgreSQL.URL,
-			MaxConns: cfg.Storage.PostgreSQL.MaxConns,
-		},
-		MongoDB: storage.MongoDBConfig{
-			URL:      cfg.Storage.MongoDB.URL,
-			Database: cfg.Storage.MongoDB.Database,
-		},
-	}
-
-	// Apply defaults
-	if storageCfg.Type == "" {
-		storageCfg.Type = storage.TypeSQLite
-	}
-	if storageCfg.SQLite.Path == "" {
-		storageCfg.SQLite.Path = storage.DefaultSQLitePath
-	}
-	if storageCfg.MongoDB.Database == "" {
-		storageCfg.MongoDB.Database = "gomodel"
-	}
-
-	return storageCfg
-}
-
 // createLogStore creates the appropriate LogStore for the given storage backend.
 func createLogStore(store storage.Storage, retentionDays int) (LogStore, error) {
-	switch store.Type() {
-	case storage.TypeSQLite:
-		return NewSQLiteStore(store.SQLiteDB(), retentionDays)
-
-	case storage.TypePostgreSQL:
-		pool := store.PostgreSQLPool()
-		if pool == nil {
-			return nil, fmt.Errorf("PostgreSQL pool is nil")
-		}
-		pgxPool, ok := pool.(*pgxpool.Pool)
-		if !ok {
-			return nil, fmt.Errorf("invalid PostgreSQL pool type: %T", pool)
-		}
-		return NewPostgreSQLStore(pgxPool, retentionDays)
-
-	case storage.TypeMongoDB:
-		db := store.MongoDatabase()
-		if db == nil {
-			return nil, fmt.Errorf("MongoDB database is nil")
-		}
-		mongoDB, ok := db.(*mongo.Database)
-		if !ok {
-			return nil, fmt.Errorf("invalid MongoDB database type: %T", db)
-		}
-		return NewMongoDBStore(mongoDB, retentionDays)
-
+	switch store := store.(type) {
+	case storage.SQLiteStorage:
+		return NewSQLiteStore(store.DB(), retentionDays)
+	case storage.PostgreSQLStorage:
+		return NewPostgreSQLStore(store.Pool(), retentionDays)
+	case storage.MongoDBStorage:
+		return NewMongoDBStore(store.Database(), retentionDays)
 	default:
-		return nil, fmt.Errorf("unknown storage type: %s", store.Type())
+		return nil, fmt.Errorf("unsupported storage backend %T", store)
 	}
 }
 

--- a/internal/auditlog/reader_factory.go
+++ b/internal/auditlog/reader_factory.go
@@ -1,7 +1,10 @@
 package auditlog
 
 import (
-	"fmt"
+	"database/sql"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 
 	"gomodel/internal/storage"
 )
@@ -13,14 +16,10 @@ func NewReader(store storage.Storage) (Reader, error) {
 		return nil, nil
 	}
 
-	switch store := store.(type) {
-	case storage.SQLiteStorage:
-		return NewSQLiteReader(store.DB())
-	case storage.PostgreSQLStorage:
-		return NewPostgreSQLReader(store.Pool())
-	case storage.MongoDBStorage:
-		return NewMongoDBReader(store.Database())
-	default:
-		return nil, fmt.Errorf("unsupported storage backend %T", store)
-	}
+	return storage.ResolveBackend[Reader](
+		store,
+		func(db *sql.DB) (Reader, error) { return NewSQLiteReader(db) },
+		func(pool *pgxpool.Pool) (Reader, error) { return NewPostgreSQLReader(pool) },
+		func(db *mongo.Database) (Reader, error) { return NewMongoDBReader(db) },
+	)
 }

--- a/internal/auditlog/reader_factory.go
+++ b/internal/auditlog/reader_factory.go
@@ -3,9 +3,6 @@ package auditlog
 import (
 	"fmt"
 
-	"github.com/jackc/pgx/v5/pgxpool"
-	"go.mongodb.org/mongo-driver/v2/mongo"
-
 	"gomodel/internal/storage"
 )
 
@@ -16,33 +13,14 @@ func NewReader(store storage.Storage) (Reader, error) {
 		return nil, nil
 	}
 
-	switch store.Type() {
-	case storage.TypeSQLite:
-		return NewSQLiteReader(store.SQLiteDB())
-
-	case storage.TypePostgreSQL:
-		pool := store.PostgreSQLPool()
-		if pool == nil {
-			return nil, fmt.Errorf("PostgreSQL pool is nil")
-		}
-		pgxPool, ok := pool.(*pgxpool.Pool)
-		if !ok {
-			return nil, fmt.Errorf("invalid PostgreSQL pool type: %T", pool)
-		}
-		return NewPostgreSQLReader(pgxPool)
-
-	case storage.TypeMongoDB:
-		db := store.MongoDatabase()
-		if db == nil {
-			return nil, fmt.Errorf("MongoDB database is nil")
-		}
-		mongoDB, ok := db.(*mongo.Database)
-		if !ok {
-			return nil, fmt.Errorf("invalid MongoDB database type: %T", db)
-		}
-		return NewMongoDBReader(mongoDB)
-
+	switch store := store.(type) {
+	case storage.SQLiteStorage:
+		return NewSQLiteReader(store.DB())
+	case storage.PostgreSQLStorage:
+		return NewPostgreSQLReader(store.Pool())
+	case storage.MongoDBStorage:
+		return NewMongoDBReader(store.Database())
 	default:
-		return nil, fmt.Errorf("unknown storage type: %s", store.Type())
+		return nil, fmt.Errorf("unsupported storage backend %T", store)
 	}
 }

--- a/internal/batch/factory.go
+++ b/internal/batch/factory.go
@@ -2,8 +2,12 @@ package batch
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 
 	"gomodel/config"
 	"gomodel/internal/storage"
@@ -72,14 +76,10 @@ func NewWithSharedStorage(ctx context.Context, shared storage.Storage) (*Result,
 }
 
 func createStore(ctx context.Context, store storage.Storage) (Store, error) {
-	switch store := store.(type) {
-	case storage.SQLiteStorage:
-		return NewSQLiteStore(store.DB())
-	case storage.PostgreSQLStorage:
-		return NewPostgreSQLStore(ctx, store.Pool())
-	case storage.MongoDBStorage:
-		return NewMongoDBStore(store.Database())
-	default:
-		return nil, fmt.Errorf("unsupported storage backend %T", store)
-	}
+	return storage.ResolveBackend[Store](
+		store,
+		func(db *sql.DB) (Store, error) { return NewSQLiteStore(db) },
+		func(pool *pgxpool.Pool) (Store, error) { return NewPostgreSQLStore(ctx, pool) },
+		func(db *mongo.Database) (Store, error) { return NewMongoDBStore(db) },
+	)
 }

--- a/internal/batch/factory.go
+++ b/internal/batch/factory.go
@@ -5,9 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/jackc/pgx/v5/pgxpool"
-	"go.mongodb.org/mongo-driver/v2/mongo"
-
 	"gomodel/config"
 	"gomodel/internal/storage"
 )
@@ -42,7 +39,7 @@ func New(ctx context.Context, cfg *config.Config) (*Result, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("config is required")
 	}
-	storageCfg := buildStorageConfig(cfg)
+	storageCfg := cfg.Storage.BackendConfig()
 	store, err := storage.New(ctx, storageCfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create storage: %w", err)
@@ -74,59 +71,15 @@ func NewWithSharedStorage(ctx context.Context, shared storage.Storage) (*Result,
 	}, nil
 }
 
-func buildStorageConfig(cfg *config.Config) storage.Config {
-	storageCfg := storage.Config{
-		Type: cfg.Storage.Type,
-		SQLite: storage.SQLiteConfig{
-			Path: cfg.Storage.SQLite.Path,
-		},
-		PostgreSQL: storage.PostgreSQLConfig{
-			URL:      cfg.Storage.PostgreSQL.URL,
-			MaxConns: cfg.Storage.PostgreSQL.MaxConns,
-		},
-		MongoDB: storage.MongoDBConfig{
-			URL:      cfg.Storage.MongoDB.URL,
-			Database: cfg.Storage.MongoDB.Database,
-		},
-	}
-
-	if storageCfg.Type == "" {
-		storageCfg.Type = storage.TypeSQLite
-	}
-	if storageCfg.SQLite.Path == "" {
-		storageCfg.SQLite.Path = storage.DefaultSQLitePath
-	}
-	if storageCfg.MongoDB.Database == "" {
-		storageCfg.MongoDB.Database = "gomodel"
-	}
-	return storageCfg
-}
-
 func createStore(ctx context.Context, store storage.Storage) (Store, error) {
-	switch store.Type() {
-	case storage.TypeSQLite:
-		return NewSQLiteStore(store.SQLiteDB())
-	case storage.TypePostgreSQL:
-		pool := store.PostgreSQLPool()
-		if pool == nil {
-			return nil, fmt.Errorf("PostgreSQL pool is nil")
-		}
-		pgxPool, ok := pool.(*pgxpool.Pool)
-		if !ok {
-			return nil, fmt.Errorf("invalid PostgreSQL pool type: %T", pool)
-		}
-		return NewPostgreSQLStore(ctx, pgxPool)
-	case storage.TypeMongoDB:
-		db := store.MongoDatabase()
-		if db == nil {
-			return nil, fmt.Errorf("MongoDB database is nil")
-		}
-		mongoDB, ok := db.(*mongo.Database)
-		if !ok {
-			return nil, fmt.Errorf("invalid MongoDB database type: %T", db)
-		}
-		return NewMongoDBStore(mongoDB)
+	switch store := store.(type) {
+	case storage.SQLiteStorage:
+		return NewSQLiteStore(store.DB())
+	case storage.PostgreSQLStorage:
+		return NewPostgreSQLStore(ctx, store.Pool())
+	case storage.MongoDBStorage:
+		return NewMongoDBStore(store.Database())
 	default:
-		return nil, fmt.Errorf("unknown storage type: %s", store.Type())
+		return nil, fmt.Errorf("unsupported storage backend %T", store)
 	}
 }

--- a/internal/batch/store_sqlite_test.go
+++ b/internal/batch/store_sqlite_test.go
@@ -16,7 +16,7 @@ func TestSQLiteStoreLifecycle(t *testing.T) {
 	}
 	defer st.Close()
 
-	store, err := NewSQLiteStore(st.SQLiteDB())
+	store, err := NewSQLiteStore(st.DB())
 	if err != nil {
 		t.Fatalf("new sqlite batch store: %v", err)
 	}

--- a/internal/executionplans/factory.go
+++ b/internal/executionplans/factory.go
@@ -2,10 +2,14 @@ package executionplans
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"sync"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 
 	"gomodel/config"
 	"gomodel/internal/storage"
@@ -95,14 +99,10 @@ func newResult(ctx context.Context, storeConn storage.Storage, compiler Compiler
 }
 
 func createStore(ctx context.Context, store storage.Storage) (Store, error) {
-	switch store := store.(type) {
-	case storage.SQLiteStorage:
-		return NewSQLiteStore(store.DB())
-	case storage.PostgreSQLStorage:
-		return NewPostgreSQLStore(ctx, store.Pool())
-	case storage.MongoDBStorage:
-		return NewMongoDBStore(store.Database())
-	default:
-		return nil, fmt.Errorf("unsupported storage backend %T", store)
-	}
+	return storage.ResolveBackend[Store](
+		store,
+		func(db *sql.DB) (Store, error) { return NewSQLiteStore(db) },
+		func(pool *pgxpool.Pool) (Store, error) { return NewPostgreSQLStore(ctx, pool) },
+		func(db *mongo.Database) (Store, error) { return NewMongoDBStore(db) },
+	)
 }

--- a/internal/executionplans/factory.go
+++ b/internal/executionplans/factory.go
@@ -7,9 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgxpool"
-	"go.mongodb.org/mongo-driver/v2/mongo"
-
 	"gomodel/config"
 	"gomodel/internal/storage"
 )
@@ -59,7 +56,7 @@ func New(ctx context.Context, cfg *config.Config, compiler Compiler, refreshInte
 	if cfg == nil {
 		return nil, fmt.Errorf("config is required")
 	}
-	storeConn, err := storage.New(ctx, buildStorageConfig(cfg))
+	storeConn, err := storage.New(ctx, cfg.Storage.BackendConfig())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create storage: %w", err)
 	}
@@ -97,59 +94,15 @@ func newResult(ctx context.Context, storeConn storage.Storage, compiler Compiler
 	}, nil
 }
 
-func buildStorageConfig(cfg *config.Config) storage.Config {
-	storageCfg := storage.Config{
-		Type: cfg.Storage.Type,
-		SQLite: storage.SQLiteConfig{
-			Path: cfg.Storage.SQLite.Path,
-		},
-		PostgreSQL: storage.PostgreSQLConfig{
-			URL:      cfg.Storage.PostgreSQL.URL,
-			MaxConns: cfg.Storage.PostgreSQL.MaxConns,
-		},
-		MongoDB: storage.MongoDBConfig{
-			URL:      cfg.Storage.MongoDB.URL,
-			Database: cfg.Storage.MongoDB.Database,
-		},
-	}
-
-	if storageCfg.Type == "" {
-		storageCfg.Type = storage.TypeSQLite
-	}
-	if storageCfg.SQLite.Path == "" {
-		storageCfg.SQLite.Path = storage.DefaultSQLitePath
-	}
-	if storageCfg.MongoDB.Database == "" {
-		storageCfg.MongoDB.Database = "gomodel"
-	}
-	return storageCfg
-}
-
 func createStore(ctx context.Context, store storage.Storage) (Store, error) {
-	switch store.Type() {
-	case storage.TypeSQLite:
-		return NewSQLiteStore(store.SQLiteDB())
-	case storage.TypePostgreSQL:
-		pool := store.PostgreSQLPool()
-		if pool == nil {
-			return nil, fmt.Errorf("PostgreSQL pool is nil")
-		}
-		pgxPool, ok := pool.(*pgxpool.Pool)
-		if !ok {
-			return nil, fmt.Errorf("invalid PostgreSQL pool type: %T", pool)
-		}
-		return NewPostgreSQLStore(ctx, pgxPool)
-	case storage.TypeMongoDB:
-		db := store.MongoDatabase()
-		if db == nil {
-			return nil, fmt.Errorf("MongoDB database is nil")
-		}
-		mongoDB, ok := db.(*mongo.Database)
-		if !ok {
-			return nil, fmt.Errorf("invalid MongoDB database type: %T", db)
-		}
-		return NewMongoDBStore(mongoDB)
+	switch store := store.(type) {
+	case storage.SQLiteStorage:
+		return NewSQLiteStore(store.DB())
+	case storage.PostgreSQLStorage:
+		return NewPostgreSQLStore(ctx, store.Pool())
+	case storage.MongoDBStorage:
+		return NewMongoDBStore(store.Database())
 	default:
-		return nil, fmt.Errorf("unknown storage type: %s", store.Type())
+		return nil, fmt.Errorf("unsupported storage backend %T", store)
 	}
 }

--- a/internal/storage/mongodb.go
+++ b/internal/storage/mongodb.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 
 	"go.mongodb.org/mongo-driver/v2/mongo"
@@ -16,7 +15,7 @@ type mongoStorage struct {
 }
 
 // NewMongoDB creates a new MongoDB storage connection.
-func NewMongoDB(ctx context.Context, cfg MongoDBConfig) (Storage, error) {
+func NewMongoDB(ctx context.Context, cfg MongoDBConfig) (MongoDBStorage, error) {
 	if cfg.URL == "" {
 		return nil, fmt.Errorf("MongoDB URL is required")
 	}
@@ -49,22 +48,6 @@ func NewMongoDB(ctx context.Context, cfg MongoDBConfig) (Storage, error) {
 		client:   client,
 		database: database,
 	}, nil
-}
-
-func (s *mongoStorage) Type() string {
-	return TypeMongoDB
-}
-
-func (s *mongoStorage) SQLiteDB() *sql.DB {
-	return nil
-}
-
-func (s *mongoStorage) PostgreSQLPool() any {
-	return nil
-}
-
-func (s *mongoStorage) MongoDatabase() any {
-	return s.database
 }
 
 func (s *mongoStorage) Close() error {

--- a/internal/storage/postgresql.go
+++ b/internal/storage/postgresql.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"math"
 
@@ -16,7 +15,7 @@ type postgresStorage struct {
 
 // NewPostgreSQL creates a new PostgreSQL storage connection.
 // It creates a connection pool for efficient connection reuse.
-func NewPostgreSQL(ctx context.Context, cfg PostgreSQLConfig) (Storage, error) {
+func NewPostgreSQL(ctx context.Context, cfg PostgreSQLConfig) (PostgreSQLStorage, error) {
 	if cfg.URL == "" {
 		return nil, fmt.Errorf("PostgreSQL URL is required")
 	}
@@ -48,22 +47,6 @@ func NewPostgreSQL(ctx context.Context, cfg PostgreSQLConfig) (Storage, error) {
 	}
 
 	return &postgresStorage{pool: pool}, nil
-}
-
-func (s *postgresStorage) Type() string {
-	return TypePostgreSQL
-}
-
-func (s *postgresStorage) SQLiteDB() *sql.DB {
-	return nil
-}
-
-func (s *postgresStorage) PostgreSQLPool() any {
-	return s.pool
-}
-
-func (s *postgresStorage) MongoDatabase() any {
-	return nil
 }
 
 func (s *postgresStorage) Close() error {

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -16,7 +16,7 @@ type sqliteStorage struct {
 
 // NewSQLite creates a new SQLite storage connection.
 // It enables WAL mode for better concurrent read/write performance.
-func NewSQLite(cfg SQLiteConfig) (Storage, error) {
+func NewSQLite(cfg SQLiteConfig) (SQLiteStorage, error) {
 	if cfg.Path == "" {
 		cfg.Path = DefaultSQLitePath
 	}
@@ -57,20 +57,8 @@ func NewSQLite(cfg SQLiteConfig) (Storage, error) {
 	return &sqliteStorage{db: db}, nil
 }
 
-func (s *sqliteStorage) Type() string {
-	return TypeSQLite
-}
-
-func (s *sqliteStorage) SQLiteDB() *sql.DB {
+func (s *sqliteStorage) DB() *sql.DB {
 	return s.db
-}
-
-func (s *sqliteStorage) PostgreSQLPool() any {
-	return nil
-}
-
-func (s *sqliteStorage) MongoDatabase() any {
-	return nil
 }
 
 func (s *sqliteStorage) Close() error {

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -16,7 +16,7 @@ func TestSQLiteConcurrentWriteSafety(t *testing.T) {
 	}
 	defer store.Close()
 
-	db := store.SQLiteDB()
+	db := store.DB()
 
 	// Create two tables to simulate audit log and usage tracking writing concurrently.
 	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS test_audit (id TEXT PRIMARY KEY, data TEXT)`)

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -82,6 +82,36 @@ type MongoDBStorage interface {
 	Database() *mongo.Database
 }
 
+// ResolveBackend dispatches to the callback matching the concrete storage backend.
+func ResolveBackend[T any](
+	store Storage,
+	sqlite func(*sql.DB) (T, error),
+	postgresql func(*pgxpool.Pool) (T, error),
+	mongodb func(*mongo.Database) (T, error),
+) (T, error) {
+	var zero T
+
+	switch store := store.(type) {
+	case SQLiteStorage:
+		if sqlite == nil {
+			return zero, fmt.Errorf("sqlite handler is nil")
+		}
+		return sqlite(store.DB())
+	case PostgreSQLStorage:
+		if postgresql == nil {
+			return zero, fmt.Errorf("postgresql handler is nil")
+		}
+		return postgresql(store.Pool())
+	case MongoDBStorage:
+		if mongodb == nil {
+			return zero, fmt.Errorf("mongodb handler is nil")
+		}
+		return mongodb(store.Database())
+	default:
+		return zero, fmt.Errorf("unsupported storage backend %T", store)
+	}
+}
+
 // New creates a new Storage based on the configuration.
 // It validates the configuration and establishes the database connection.
 func New(ctx context.Context, cfg Config) (Storage, error) {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -7,6 +7,9 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
 // Type constants for storage backends
@@ -56,28 +59,27 @@ type MongoDBConfig struct {
 	Database string
 }
 
-// Storage provides a unified interface for database connections.
-// Implementations must be safe for concurrent use.
+// Storage manages the lifecycle of a shared storage backend.
 type Storage interface {
-	// Type returns the storage type ("sqlite", "postgresql", or "mongodb")
-	Type() string
-
-	// SQLiteDB returns the *sql.DB connection for SQLite.
-	// Returns nil if not using SQLite.
-	SQLiteDB() *sql.DB
-
-	// PostgreSQLPool returns the connection pool for PostgreSQL.
-	// Returns nil if not using PostgreSQL.
-	// The actual type is *pgxpool.Pool but we use interface{} to avoid import cycles.
-	PostgreSQLPool() any
-
-	// MongoDatabase returns the MongoDB database.
-	// Returns nil if not using MongoDB.
-	// The actual type is *mongo.Database but we use interface{} to avoid import cycles.
-	MongoDatabase() any
-
-	// Close releases all resources held by the storage.
 	Close() error
+}
+
+// SQLiteStorage exposes a SQLite database handle.
+type SQLiteStorage interface {
+	Storage
+	DB() *sql.DB
+}
+
+// PostgreSQLStorage exposes a PostgreSQL connection pool.
+type PostgreSQLStorage interface {
+	Storage
+	Pool() *pgxpool.Pool
+}
+
+// MongoDBStorage exposes a MongoDB database handle.
+type MongoDBStorage interface {
+	Storage
+	Database() *mongo.Database
 }
 
 // New creates a new Storage based on the configuration.

--- a/internal/usage/factory.go
+++ b/internal/usage/factory.go
@@ -2,9 +2,13 @@ package usage
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 
 	"gomodel/config"
 	"gomodel/internal/storage"
@@ -114,30 +118,22 @@ func NewReader(store storage.Storage) (UsageReader, error) {
 		return nil, nil
 	}
 
-	switch store := store.(type) {
-	case storage.SQLiteStorage:
-		return NewSQLiteReader(store.DB())
-	case storage.PostgreSQLStorage:
-		return NewPostgreSQLReader(store.Pool())
-	case storage.MongoDBStorage:
-		return NewMongoDBReader(store.Database())
-	default:
-		return nil, fmt.Errorf("unsupported storage backend %T", store)
-	}
+	return storage.ResolveBackend[UsageReader](
+		store,
+		func(db *sql.DB) (UsageReader, error) { return NewSQLiteReader(db) },
+		func(pool *pgxpool.Pool) (UsageReader, error) { return NewPostgreSQLReader(pool) },
+		func(db *mongo.Database) (UsageReader, error) { return NewMongoDBReader(db) },
+	)
 }
 
 // createUsageStore creates the appropriate UsageStore for the given storage backend.
 func createUsageStore(store storage.Storage, retentionDays int) (UsageStore, error) {
-	switch store := store.(type) {
-	case storage.SQLiteStorage:
-		return NewSQLiteStore(store.DB(), retentionDays)
-	case storage.PostgreSQLStorage:
-		return NewPostgreSQLStore(store.Pool(), retentionDays)
-	case storage.MongoDBStorage:
-		return NewMongoDBStore(store.Database(), retentionDays)
-	default:
-		return nil, fmt.Errorf("unsupported storage backend %T", store)
-	}
+	return storage.ResolveBackend[UsageStore](
+		store,
+		func(db *sql.DB) (UsageStore, error) { return NewSQLiteStore(db, retentionDays) },
+		func(pool *pgxpool.Pool) (UsageStore, error) { return NewPostgreSQLStore(pool, retentionDays) },
+		func(db *mongo.Database) (UsageStore, error) { return NewMongoDBStore(db, retentionDays) },
+	)
 }
 
 // buildLoggerConfig creates a usage.Config from config.UsageConfig.

--- a/internal/usage/factory.go
+++ b/internal/usage/factory.go
@@ -6,9 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgxpool"
-	"go.mongodb.org/mongo-driver/v2/mongo"
-
 	"gomodel/config"
 	"gomodel/internal/storage"
 )
@@ -55,7 +52,7 @@ func New(ctx context.Context, cfg *config.Config) (*Result, error) {
 	}
 
 	// Create storage configuration - reuse the same storage backend as logging
-	storageCfg := buildStorageConfig(cfg)
+	storageCfg := cfg.Storage.BackendConfig()
 
 	// Create storage connection
 	store, err := storage.New(ctx, storageCfg)
@@ -117,98 +114,29 @@ func NewReader(store storage.Storage) (UsageReader, error) {
 		return nil, nil
 	}
 
-	switch store.Type() {
-	case storage.TypeSQLite:
-		return NewSQLiteReader(store.SQLiteDB())
-
-	case storage.TypePostgreSQL:
-		pool := store.PostgreSQLPool()
-		if pool == nil {
-			return nil, fmt.Errorf("PostgreSQL pool is nil")
-		}
-		pgxPool, ok := pool.(*pgxpool.Pool)
-		if !ok {
-			return nil, fmt.Errorf("invalid PostgreSQL pool type: %T", pool)
-		}
-		return NewPostgreSQLReader(pgxPool)
-
-	case storage.TypeMongoDB:
-		db := store.MongoDatabase()
-		if db == nil {
-			return nil, fmt.Errorf("MongoDB database is nil")
-		}
-		mongoDB, ok := db.(*mongo.Database)
-		if !ok {
-			return nil, fmt.Errorf("invalid MongoDB database type: %T", db)
-		}
-		return NewMongoDBReader(mongoDB)
-
+	switch store := store.(type) {
+	case storage.SQLiteStorage:
+		return NewSQLiteReader(store.DB())
+	case storage.PostgreSQLStorage:
+		return NewPostgreSQLReader(store.Pool())
+	case storage.MongoDBStorage:
+		return NewMongoDBReader(store.Database())
 	default:
-		return nil, fmt.Errorf("unknown storage type: %s", store.Type())
+		return nil, fmt.Errorf("unsupported storage backend %T", store)
 	}
-}
-
-// buildStorageConfig creates a storage.Config from the application config.
-func buildStorageConfig(cfg *config.Config) storage.Config {
-	storageCfg := storage.Config{
-		Type: cfg.Storage.Type,
-		SQLite: storage.SQLiteConfig{
-			Path: cfg.Storage.SQLite.Path,
-		},
-		PostgreSQL: storage.PostgreSQLConfig{
-			URL:      cfg.Storage.PostgreSQL.URL,
-			MaxConns: cfg.Storage.PostgreSQL.MaxConns,
-		},
-		MongoDB: storage.MongoDBConfig{
-			URL:      cfg.Storage.MongoDB.URL,
-			Database: cfg.Storage.MongoDB.Database,
-		},
-	}
-
-	// Apply defaults
-	if storageCfg.Type == "" {
-		storageCfg.Type = storage.TypeSQLite
-	}
-	if storageCfg.SQLite.Path == "" {
-		storageCfg.SQLite.Path = storage.DefaultSQLitePath
-	}
-	if storageCfg.MongoDB.Database == "" {
-		storageCfg.MongoDB.Database = "gomodel"
-	}
-
-	return storageCfg
 }
 
 // createUsageStore creates the appropriate UsageStore for the given storage backend.
 func createUsageStore(store storage.Storage, retentionDays int) (UsageStore, error) {
-	switch store.Type() {
-	case storage.TypeSQLite:
-		return NewSQLiteStore(store.SQLiteDB(), retentionDays)
-
-	case storage.TypePostgreSQL:
-		pool := store.PostgreSQLPool()
-		if pool == nil {
-			return nil, fmt.Errorf("PostgreSQL pool is nil")
-		}
-		pgxPool, ok := pool.(*pgxpool.Pool)
-		if !ok {
-			return nil, fmt.Errorf("invalid PostgreSQL pool type: %T", pool)
-		}
-		return NewPostgreSQLStore(pgxPool, retentionDays)
-
-	case storage.TypeMongoDB:
-		db := store.MongoDatabase()
-		if db == nil {
-			return nil, fmt.Errorf("MongoDB database is nil")
-		}
-		mongoDB, ok := db.(*mongo.Database)
-		if !ok {
-			return nil, fmt.Errorf("invalid MongoDB database type: %T", db)
-		}
-		return NewMongoDBStore(mongoDB, retentionDays)
-
+	switch store := store.(type) {
+	case storage.SQLiteStorage:
+		return NewSQLiteStore(store.DB(), retentionDays)
+	case storage.PostgreSQLStorage:
+		return NewPostgreSQLStore(store.Pool(), retentionDays)
+	case storage.MongoDBStorage:
+		return NewMongoDBStore(store.Database(), retentionDays)
 	default:
-		return nil, fmt.Errorf("unknown storage type: %s", store.Type())
+		return nil, fmt.Errorf("unsupported storage backend %T", store)
 	}
 }
 


### PR DESCRIPTION
## Summary
- shrink `storage.Storage` to lifecycle-only and replace backend-specific `Type()`/`any` accessors with narrow typed interfaces
- remove repeated storage config translation from feature factories by centralizing it in `config.StorageConfig.BackendConfig()`
- update auditlog, usage, batch, aliases, and executionplans factories/readers to dispatch on typed backends directly

## Validation
- `go test ./...`
- `make test-e2e`
- `make lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized storage configuration and sensible defaults for SQLite/Postgres/MongoDB to ensure consistent backend setup.
  * Unified backend selection and dispatch across components for more consistent behavior when initializing storage backends.
  * Split generic storage API into backend-specific interfaces (typed accessors) to clarify connections and simplify lifecycle handling.
  * Tests updated to use the new backend accessors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->