### PR TITLE
feat(dashboard): add dashboard functions to the exectution plan/workflow feature

### DIFF
--- a/internal/admin/dashboard/dashboard_test.go
+++ b/internal/admin/dashboard/dashboard_test.go
@@ -50,6 +50,9 @@ func TestIndex_ReturnsHTML(t *testing.T) {
 	if !strings.Contains(body, "audit logs") {
 		t.Errorf("expected audit logs navigation item in page HTML")
 	}
+	if !strings.Contains(body, "workflows") {
+		t.Errorf("expected workflows navigation item in page HTML")
+	}
 	if !strings.Contains(body, `x-data="dashboard()"`) {
 		t.Errorf("expected alpine dashboard root in page HTML")
 	}
@@ -147,6 +150,29 @@ func TestStatic_ServesAliasesModuleJS(t *testing.T) {
 	}
 	if rec.Body.Len() == 0 {
 		t.Error("expected non-empty body for aliases module JS file")
+	}
+}
+
+func TestStatic_ServesExecutionPlansModuleJS(t *testing.T) {
+	h, err := New()
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/admin/static/js/modules/execution-plans.js", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.Static(c); err != nil {
+		t.Fatalf("Static() returned error: %v", err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	if rec.Body.Len() == 0 {
+		t.Error("expected non-empty body for execution plans module JS file")
 	}
 }
 

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -2485,7 +2485,7 @@ body.conversation-drawer-open {
 .ep-node-icon svg {
     width: 15px;
     height: 15px;
-    stroke: currentColor;
+    stroke: currentcolor;
     fill: none;
     stroke-width: 2;
     stroke-linecap: round;
@@ -2653,17 +2653,6 @@ body.conversation-drawer-open {
     padding: 12px 16px;
     border-radius: var(--radius);
     gap: 6px;
-}
-
-.ep-node-ai .ep-node-icon {
-    width: 32px;
-    height: 32px;
-    border-radius: var(--radius);
-}
-
-.ep-node-ai .ep-node-icon svg {
-    width: 17px;
-    height: 17px;
 }
 
 /* AI skipped — cache hit absorbed the request */

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -1187,6 +1187,177 @@ td.col-price {
     opacity: 0.72;
 }
 
+/* Execution Plans */
+.execution-plan-page-note {
+    margin-top: 6px;
+    color: var(--text-muted);
+    font-size: 14px;
+}
+
+.execution-plans-layout {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.execution-plans-layout.is-editor-open {
+    align-items: stretch;
+}
+
+.execution-plans-list {
+    min-width: 0;
+}
+
+.execution-plan-card-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 16px;
+}
+
+.execution-plan-card {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 20px;
+}
+
+.execution-plan-card-head,
+.execution-plan-section-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.execution-plan-card-footer {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+}
+
+.execution-plan-card-head h3,
+.execution-plan-section-head h4 {
+    font-size: 18px;
+    font-weight: 700;
+}
+
+.execution-plan-section-head h4 {
+    font-size: 14px;
+}
+
+.execution-plan-card-badges,
+.execution-plan-card-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: flex-end;
+}
+
+.execution-plan-card-meta-footer {
+    justify-content: flex-start;
+}
+
+.execution-plan-card-footer .alias-actions-cell {
+    align-self: flex-end;
+}
+
+.execution-plan-card-description {
+    color: var(--text-muted);
+    font-size: 14px;
+}
+
+.execution-plan-heading {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.execution-plan-help {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    border: 1px solid var(--border);
+    background: var(--bg);
+    color: var(--text-muted);
+    font-size: 12px;
+    font-weight: 700;
+    cursor: help;
+}
+
+.execution-plan-guardrails,
+.execution-plan-guardrail-editor {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.execution-plan-guardrail-list,
+.execution-plan-guardrail-list-editor {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.execution-plan-guardrail-item,
+.execution-plan-guardrail-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 10px 12px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--bg);
+}
+
+.execution-plan-guardrail-row {
+    justify-content: stretch;
+}
+
+.execution-plan-editor {
+    margin-bottom: 0;
+    width: 100%;
+}
+
+.execution-plan-input {
+    max-width: none;
+    width: 100%;
+}
+
+.execution-plan-step-input {
+    max-width: 120px;
+}
+
+.execution-plan-feature-toggles {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+}
+
+.execution-plan-feature-toggle {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 12px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--bg);
+    font-size: 14px;
+    font-weight: 500;
+}
+
+.execution-plan-feature-toggle input {
+    width: 16px;
+    height: 16px;
+}
+
 /* Usage Mode Toggle */
 .usage-mode-toggle {
     display: inline-flex;
@@ -2082,6 +2253,24 @@ body.conversation-drawer-open {
     .alias-form-grid {
         grid-template-columns: 1fr;
     }
+    .execution-plan-card-grid,
+    .execution-plan-feature-toggles {
+        grid-template-columns: 1fr;
+    }
+    .execution-plan-card-head,
+    .execution-plan-card-footer,
+    .execution-plan-section-head,
+    .execution-plan-card-badges,
+    .execution-plan-card-meta,
+    .execution-plan-guardrail-item,
+    .execution-plan-guardrail-row {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+    .execution-plan-step-input {
+        max-width: none;
+        width: 100%;
+    }
     .table-toolbar {
         flex-direction: column;
         align-items: stretch;
@@ -2172,4 +2361,389 @@ body.conversation-drawer-open {
     .dp-nav-prev-mobile {
         display: flex;
     }
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   Execution Pipeline Visualization
+   ═══════════════════════════════════════════════════════════════ */
+
+.exec-pipeline {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    padding: 18px 20px 20px;
+    border-radius: 16px;
+    border: 1px solid var(--border);
+    background: var(--bg);
+}
+
+/* ─── Main pipeline row ─── */
+
+.exec-pipeline-row {
+    display: flex;
+    align-items: center;
+    width: 100%;
+}
+
+/* Left/right halves — equal width keeps AI centered */
+.ep-left,
+.ep-right {
+    display: flex;
+    align-items: center;
+    flex: 1;
+    min-width: 0;
+}
+
+.ep-right {
+    justify-content: flex-end;
+}
+
+/* Optional step wrapper (connector + node shown/hidden together) */
+.ep-step {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+}
+
+/* ─── Connectors ─── */
+
+.ep-conn {
+    flex-shrink: 0;
+    position: relative;
+    width: 32px;
+    height: 2px;
+    background: color-mix(in srgb, var(--accent) 44%, var(--border));
+}
+
+/* Growing connector — fills remaining half to keep AI centered */
+.ep-conn-grow {
+    flex: 1;
+    min-width: 16px;
+    width: auto;
+}
+
+.ep-conn::after {
+    content: "";
+    position: absolute;
+    right: -1px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 7px;
+    height: 9px;
+    background: color-mix(in srgb, var(--accent) 44%, var(--border));
+    clip-path: polygon(0 0, 100% 50%, 0 100%);
+}
+
+/* Green connector — cache hit path */
+.ep-conn-hit {
+    background: color-mix(in srgb, var(--success) 58%, var(--border));
+}
+
+.ep-conn-hit::after {
+    background: color-mix(in srgb, var(--success) 58%, var(--border));
+}
+
+/* Dimmed connector — path not taken */
+.ep-conn-dim {
+    background: color-mix(in srgb, var(--border) 75%, transparent);
+    opacity: 0.4;
+}
+
+.ep-conn-dim::after {
+    background: color-mix(in srgb, var(--border) 75%, transparent);
+}
+
+/* ─── Base node ─── */
+
+.ep-node {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+    padding: 10px 14px;
+    border-radius: 12px;
+    border: 1px solid var(--border);
+    background: var(--bg-surface);
+    min-width: 72px;
+    text-align: center;
+    flex-shrink: 0;
+}
+
+.ep-node-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 8px;
+    background: var(--bg);
+    color: var(--text-muted);
+}
+
+.ep-node-icon svg {
+    width: 15px;
+    height: 15px;
+    stroke: currentColor;
+    fill: none;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+.ep-node-label {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.03em;
+    color: var(--text);
+    white-space: nowrap;
+    line-height: 1.2;
+}
+
+.ep-node-sub {
+    font-size: 10px;
+    font-weight: 500;
+    color: var(--text-muted);
+    white-space: nowrap;
+    max-width: 120px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    line-height: 1.2;
+    font-family: var(--font-mono, ui-monospace, monospace);
+}
+
+.ep-node-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 7px;
+    border-radius: 999px;
+    font-size: 9px;
+    font-weight: 800;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    white-space: nowrap;
+    border: 1px solid var(--border);
+    background: var(--bg);
+    color: var(--text-muted);
+    line-height: 1.5;
+}
+
+/* ─── Endpoint nodes (Client / Response) ─── */
+
+.ep-node-endpoint {
+    flex-direction: row;
+    padding: 8px 16px;
+    border-radius: 999px;
+    min-width: auto;
+    gap: 7px;
+    border-color: color-mix(in srgb, var(--border) 70%, transparent);
+    background: color-mix(in srgb, var(--bg-surface) 60%, var(--bg));
+}
+
+.ep-node-endpoint .ep-node-icon {
+    width: 20px;
+    height: 20px;
+    background: transparent;
+    border-radius: 4px;
+    color: var(--text-muted);
+}
+
+.ep-node-endpoint .ep-node-icon svg {
+    width: 14px;
+    height: 14px;
+}
+
+.ep-node-endpoint .ep-node-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-muted);
+}
+
+/* ─── Guardrails node ─── */
+
+.ep-node-guardrails {
+    border-color: color-mix(in srgb, var(--warning) 46%, var(--border));
+    background: color-mix(in srgb, var(--warning) 8%, var(--bg-surface));
+}
+
+.ep-node-guardrails .ep-node-icon {
+    background: color-mix(in srgb, var(--warning) 16%, var(--bg));
+    color: color-mix(in srgb, var(--warning) 90%, var(--text));
+}
+
+.ep-node-guardrails .ep-node-label {
+    color: color-mix(in srgb, var(--warning) 80%, var(--text));
+}
+
+.ep-node-guardrails .ep-node-sub {
+    color: color-mix(in srgb, var(--warning) 60%, var(--text-muted));
+}
+
+/* ─── Cache node ─── */
+
+.ep-node-cache {
+    border-color: color-mix(in srgb, var(--accent) 46%, var(--border));
+    background: color-mix(in srgb, var(--accent) 8%, var(--bg-surface));
+}
+
+.ep-node-cache .ep-node-icon {
+    background: color-mix(in srgb, var(--accent) 16%, var(--bg));
+    color: var(--accent);
+}
+
+.ep-node-cache .ep-node-label {
+    color: var(--accent);
+}
+
+/* Cache — runtime: exact hit */
+.ep-node-cache-hit {
+    border-color: color-mix(in srgb, var(--success) 52%, var(--border));
+    background: color-mix(in srgb, var(--success) 9%, var(--bg-surface));
+}
+
+.ep-node-cache-hit .ep-node-icon {
+    background: color-mix(in srgb, var(--success) 18%, var(--bg));
+    color: var(--success);
+}
+
+.ep-node-cache-hit .ep-node-label {
+    color: color-mix(in srgb, var(--success) 85%, var(--text));
+}
+
+.ep-node-cache-hit .ep-node-badge {
+    background: color-mix(in srgb, var(--success) 14%, var(--bg));
+    border-color: color-mix(in srgb, var(--success) 38%, var(--border));
+    color: var(--success);
+}
+
+/* Cache — runtime: semantic hit */
+.ep-node-cache-semantic {
+    border-color: color-mix(in srgb, #a78bfa 46%, var(--border));
+    background: color-mix(in srgb, #a78bfa 8%, var(--bg-surface));
+}
+
+.ep-node-cache-semantic .ep-node-icon {
+    background: color-mix(in srgb, #a78bfa 16%, var(--bg));
+    color: #a78bfa;
+}
+
+.ep-node-cache-semantic .ep-node-label {
+    color: #a78bfa;
+}
+
+.ep-node-cache-semantic .ep-node-badge {
+    background: color-mix(in srgb, #a78bfa 14%, var(--bg));
+    border-color: color-mix(in srgb, #a78bfa 38%, var(--border));
+    color: #a78bfa;
+}
+
+/* Cache — runtime: miss badge only */
+.ep-node-cache-miss .ep-node-badge {
+    color: var(--text-muted);
+    border-color: var(--border);
+}
+
+/* ─── AI node ─── */
+
+.ep-node-ai {
+    min-width: 96px;
+    padding: 12px 16px;
+    border-radius: 14px;
+    gap: 6px;
+}
+
+.ep-node-ai .ep-node-icon {
+    width: 32px;
+    height: 32px;
+    border-radius: 10px;
+}
+
+.ep-node-ai .ep-node-icon svg {
+    width: 17px;
+    height: 17px;
+}
+
+/* AI skipped — cache hit absorbed the request */
+.ep-node-ai-skipped {
+    opacity: 0.28;
+}
+
+/* ─── Async connector ─── */
+
+/*
+ * Async nodes live after Response in the same row, connected by a dashed
+ * line — they fire after the response is returned to the client.
+ *
+ * [AI] ──────→ [Response] - - → [Audit Log] - - → [Usage]
+ */
+
+/* Dashed connector for async nodes */
+.ep-conn-async {
+    background: repeating-linear-gradient(
+        to right,
+        color-mix(in srgb, var(--text-muted) 45%, var(--border)) 0,
+        color-mix(in srgb, var(--text-muted) 45%, var(--border)) 5px,
+        transparent 5px,
+        transparent 9px
+    );
+    width: 20px;
+    flex-shrink: 0;
+}
+
+.ep-conn-async::after {
+    background: color-mix(in srgb, var(--text-muted) 45%, var(--border));
+}
+
+/* Async nodes — horizontal inline pills */
+.ep-node-async {
+    flex-direction: row;
+    padding: 7px 12px;
+    border-radius: 10px;
+    border-style: dashed;
+    min-width: auto;
+    gap: 7px;
+}
+
+.ep-node-async .ep-node-icon {
+    width: 20px;
+    height: 20px;
+    border-radius: 5px;
+}
+
+.ep-node-async .ep-node-icon svg {
+    width: 12px;
+    height: 12px;
+}
+
+.ep-node-async .ep-node-label {
+    font-size: 10px;
+    font-weight: 700;
+}
+
+.ep-node-async-audit {
+    border-color: color-mix(in srgb, var(--success) 40%, var(--border));
+    background: color-mix(in srgb, var(--success) 7%, var(--bg-surface));
+}
+
+.ep-node-async-audit .ep-node-icon {
+    background: color-mix(in srgb, var(--success) 14%, var(--bg));
+    color: var(--success);
+}
+
+.ep-node-async-audit .ep-node-label {
+    color: color-mix(in srgb, var(--success) 75%, var(--text-muted));
+}
+
+.ep-node-async-usage {
+    border-color: color-mix(in srgb, #60a5fa 40%, var(--border));
+    background: color-mix(in srgb, #60a5fa 7%, var(--bg-surface));
+}
+
+.ep-node-async-usage .ep-node-icon {
+    background: color-mix(in srgb, #60a5fa 14%, var(--bg));
+    color: #60a5fa;
+}
+
+.ep-node-async-usage .ep-node-label {
+    color: color-mix(in srgb, #60a5fa 75%, var(--text-muted));
 }

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -2372,7 +2372,8 @@ body.conversation-drawer-open {
     flex-direction: column;
     gap: 0;
     padding: 18px 20px 20px;
-    border-radius: 16px;
+    margin-bottom: 12px;
+    border-radius: var(--radius);
     border: 1px solid var(--border);
     background: var(--bg);
 }
@@ -2462,7 +2463,7 @@ body.conversation-drawer-open {
     justify-content: center;
     gap: 5px;
     padding: 10px 14px;
-    border-radius: 12px;
+    border-radius: var(--radius);
     border: 1px solid var(--border);
     background: var(--bg-surface);
     min-width: 72px;
@@ -2476,7 +2477,7 @@ body.conversation-drawer-open {
     justify-content: center;
     width: 28px;
     height: 28px;
-    border-radius: 8px;
+    border-radius: var(--radius);
     background: var(--bg);
     color: var(--text-muted);
 }
@@ -2516,7 +2517,7 @@ body.conversation-drawer-open {
     display: inline-flex;
     align-items: center;
     padding: 2px 7px;
-    border-radius: 999px;
+    border-radius: var(--radius);
     font-size: 9px;
     font-weight: 800;
     letter-spacing: 0.06em;
@@ -2532,23 +2533,25 @@ body.conversation-drawer-open {
 
 .ep-node-endpoint {
     flex-direction: row;
-    padding: 8px 16px;
-    border-radius: 999px;
+    padding: 10px 14px;
+    border-radius: var(--radius);
     min-width: auto;
     gap: 7px;
-    border-color: color-mix(in srgb, var(--border) 70%, transparent);
-    background: color-mix(in srgb, var(--bg-surface) 60%, var(--bg));
+    border-color: var(--border);
+    background: var(--bg-surface);
 }
 
-.ep-node-endpoint .ep-node-icon {
-    width: 20px;
-    height: 20px;
+.ep-node-icon-endpoint {
+    width: auto;
+    height: auto;
+    justify-content: flex-start;
+    padding: 0;
     background: transparent;
-    border-radius: 4px;
+    border-radius: var(--radius);
     color: var(--text-muted);
 }
 
-.ep-node-endpoint .ep-node-icon svg {
+.ep-node-icon-endpoint svg {
     width: 14px;
     height: 14px;
 }
@@ -2562,21 +2565,21 @@ body.conversation-drawer-open {
 /* ─── Guardrails node ─── */
 
 .ep-node-guardrails {
-    border-color: color-mix(in srgb, var(--warning) 46%, var(--border));
-    background: color-mix(in srgb, var(--warning) 8%, var(--bg-surface));
+    border-color: color-mix(in srgb, var(--accent) 46%, var(--border));
+    background: color-mix(in srgb, var(--accent) 8%, var(--bg-surface));
 }
 
 .ep-node-guardrails .ep-node-icon {
-    background: color-mix(in srgb, var(--warning) 16%, var(--bg));
-    color: color-mix(in srgb, var(--warning) 90%, var(--text));
+    background: color-mix(in srgb, var(--accent) 16%, var(--bg));
+    color: var(--accent);
 }
 
 .ep-node-guardrails .ep-node-label {
-    color: color-mix(in srgb, var(--warning) 80%, var(--text));
+    color: var(--accent);
 }
 
 .ep-node-guardrails .ep-node-sub {
-    color: color-mix(in srgb, var(--warning) 60%, var(--text-muted));
+    color: color-mix(in srgb, var(--accent) 70%, var(--text-muted));
 }
 
 /* ─── Cache node ─── */
@@ -2648,14 +2651,14 @@ body.conversation-drawer-open {
 .ep-node-ai {
     min-width: 96px;
     padding: 12px 16px;
-    border-radius: 14px;
+    border-radius: var(--radius);
     gap: 6px;
 }
 
 .ep-node-ai .ep-node-icon {
     width: 32px;
     height: 32px;
-    border-radius: 10px;
+    border-radius: var(--radius);
 }
 
 .ep-node-ai .ep-node-icon svg {
@@ -2727,7 +2730,7 @@ body.conversation-drawer-open {
     position: absolute;
     right: 0;
     bottom: 1px;
-    height: 24px;
+    height: 16px;
     border-right: 2px dashed color-mix(in srgb, var(--text-muted) 40%, var(--border));
 }
 
@@ -2764,7 +2767,7 @@ body.conversation-drawer-open {
 .ep-node-async {
     flex-direction: row;
     padding: 7px 12px;
-    border-radius: 10px;
+    border-radius: var(--radius);
     border-style: dashed;
     min-width: auto;
     gap: 7px;
@@ -2773,7 +2776,7 @@ body.conversation-drawer-open {
 .ep-node-async .ep-node-icon {
     width: 20px;
     height: 20px;
-    border-radius: 5px;
+    border-radius: var(--radius);
 }
 
 .ep-node-async .ep-node-icon svg {
@@ -2787,31 +2790,31 @@ body.conversation-drawer-open {
 }
 
 .ep-node-async-audit {
-    border-color: color-mix(in srgb, var(--success) 40%, var(--border));
-    background: color-mix(in srgb, var(--success) 7%, var(--bg-surface));
+    border-color: color-mix(in srgb, var(--accent) 46%, var(--border));
+    background: color-mix(in srgb, var(--accent) 8%, var(--bg-surface));
 }
 
 .ep-node-async-audit .ep-node-icon {
-    background: color-mix(in srgb, var(--success) 14%, var(--bg));
-    color: var(--success);
+    background: color-mix(in srgb, var(--accent) 16%, var(--bg));
+    color: var(--accent);
 }
 
 .ep-node-async-audit .ep-node-label {
-    color: color-mix(in srgb, var(--success) 75%, var(--text-muted));
+    color: var(--accent);
 }
 
 .ep-node-async-usage {
-    border-color: color-mix(in srgb, #60a5fa 40%, var(--border));
-    background: color-mix(in srgb, #60a5fa 7%, var(--bg-surface));
+    border-color: color-mix(in srgb, var(--accent) 46%, var(--border));
+    background: color-mix(in srgb, var(--accent) 8%, var(--bg-surface));
 }
 
 .ep-node-async-usage .ep-node-icon {
-    background: color-mix(in srgb, #60a5fa 14%, var(--bg));
-    color: #60a5fa;
+    background: color-mix(in srgb, var(--accent) 16%, var(--bg));
+    color: var(--accent);
 }
 
 .ep-node-async-usage .ep-node-label {
-    color: color-mix(in srgb, #60a5fa 75%, var(--text-muted));
+    color: var(--accent);
 }
 
 /* "ASYNC" label inline on the right of the branch */

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -2668,30 +2668,96 @@ body.conversation-drawer-open {
     opacity: 0.28;
 }
 
-/* ─── Async connector ─── */
+/* ─── Async section ─── */
 
 /*
- * Async nodes live after Response in the same row, connected by a dashed
- * line — they fire after the response is returned to the client.
+ * Async nodes fire after the response is returned to the client.
+ * They drop below the main row via an L-turn from Response, then
+ * flow right-to-left: Audit Log on the right, Usage on the left.
  *
- * [AI] ──────→ [Response] - - → [Audit Log] - - → [Usage]
+ * [Client] ──→ [Cache?] ──── [AI] ──────── [Response]
+ *                                               │
+ *                                               │ (dashed drop)
+ *                                               │
+ *                         [Usage] ← ─ ─ [Audit Log]
  */
 
-/* Dashed connector for async nodes */
-.ep-conn-async {
+/* Container — full-width branch lane below the main row */
+.ep-async-section {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0;
+    min-width: 0;
+    padding-right: 20px;
+}
+
+/* L-turn connector: centered horizontal leg plus vertical rise back to Response */
+.ep-async-turn {
+    flex: 0 0 28px;
+    width: 28px;
+    position: relative; /* for arrowhead + vertical rise */
+    height: 2px;
     background: repeating-linear-gradient(
-        to right,
+        to left,
         color-mix(in srgb, var(--text-muted) 45%, var(--border)) 0,
         color-mix(in srgb, var(--text-muted) 45%, var(--border)) 5px,
         transparent 5px,
         transparent 9px
     );
-    width: 20px;
+}
+
+/* Left-pointing arrowhead at the end of the horizontal L-turn line */
+.ep-async-turn::before {
+    content: "";
+    position: absolute;
+    left: -7px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 7px;
+    height: 9px;
+    background: color-mix(in srgb, var(--text-muted) 40%, var(--border));
+    clip-path: polygon(100% 0, 0 50%, 100% 100%);
+}
+
+/* Vertical dashed rise that connects the inline turn back up to Response */
+.ep-async-turn::after {
+    content: "";
+    position: absolute;
+    right: 0;
+    bottom: 1px;
+    height: 24px;
+    border-right: 2px dashed color-mix(in srgb, var(--text-muted) 40%, var(--border));
+}
+
+/* RTL async row — Audit Log right, Usage left */
+.ep-async-row {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+    margin-right: 7px;
+}
+
+/* Dashed left-pointing connector between async nodes */
+.ep-conn-async {
+    background: repeating-linear-gradient(
+        to left,
+        color-mix(in srgb, var(--text-muted) 45%, var(--border)) 0,
+        color-mix(in srgb, var(--text-muted) 45%, var(--border)) 5px,
+        transparent 5px,
+        transparent 9px
+    );
+    width: 24px;
     flex-shrink: 0;
 }
 
+/* Left-pointing arrowhead (overrides ep-conn::after right-pointing default) */
 .ep-conn-async::after {
     background: color-mix(in srgb, var(--text-muted) 45%, var(--border));
+    left: -1px;
+    right: auto;
+    clip-path: polygon(100% 0, 0 50%, 100% 100%);
 }
 
 /* Async nodes — horizontal inline pills */
@@ -2746,4 +2812,19 @@ body.conversation-drawer-open {
 
 .ep-node-async-usage .ep-node-label {
     color: color-mix(in srgb, #60a5fa 75%, var(--text-muted));
+}
+
+/* "ASYNC" label inline on the right of the branch */
+.ep-async-label {
+    display: inline-flex;
+    align-items: center;
+    margin-left: 8px;
+    font-size: 9px;
+    font-weight: 800;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    opacity: 0.55;
+    white-space: nowrap;
+    flex-shrink: 0;
 }

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -76,7 +76,14 @@ function dashboard() {
             const path = pathname.replace(/\/$/, '');
             const rest = path.replace('/admin/dashboard', '').replace(/^\//, '');
             const parts = rest.split('/');
-            const page = (['overview', 'usage', 'models', 'audit'].includes(parts[0])) ? parts[0] : 'overview';
+            let page = parts[0];
+            if (page === 'execution-plans') {
+                page = 'workflows';
+            }
+            if (page === 'audit') {
+                page = 'audit-logs';
+            }
+            page = (['overview', 'usage', 'models', 'workflows', 'audit-logs'].includes(page)) ? page : 'overview';
             const sub = parts[1] || null;
             return { page, sub };
         },
@@ -90,7 +97,7 @@ function dashboard() {
             const { page, sub } = this._parseRoute(window.location.pathname);
             this.page = page;
             if (page === 'usage' && sub === 'costs') this.usageMode = 'costs';
-            if (page === 'audit') this.fetchAuditLog(true);
+            if (page === 'audit-logs') this.fetchAuditLog(true);
 
             window.addEventListener('popstate', () => {
                 const { page: p, sub: s } = this._parseRoute(window.location.pathname);
@@ -100,7 +107,10 @@ function dashboard() {
                     this.fetchUsagePage();
                 }
                 if (p === 'overview') this.renderChart();
-                if (p === 'audit') this.fetchAuditLog(true);
+                if (p === 'audit-logs') this.fetchAuditLog(true);
+                if (p === 'workflows' && typeof this.fetchExecutionPlansPage === 'function') {
+                    this.fetchExecutionPlansPage();
+                }
             });
 
             window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
@@ -124,7 +134,8 @@ function dashboard() {
             history.pushState(null, '', '/admin/dashboard/' + page);
             if (page === 'overview') this.renderChart();
             if (page === 'usage') this.fetchUsagePage();
-            if (page === 'audit') this.fetchAuditLog(true);
+            if (page === 'workflows' && typeof this.fetchExecutionPlansPage === 'function') this.fetchExecutionPlansPage();
+            if (page === 'audit-logs') this.fetchAuditLog(true);
         },
 
         setTheme(t) {
@@ -186,6 +197,9 @@ function dashboard() {
             const requests = [this.fetchUsage(), this.fetchModels(), this.fetchCategories()];
             if (typeof this.fetchAliases === 'function') {
                 requests.push(this.fetchAliases());
+            }
+            if (typeof this.fetchExecutionPlansPage === 'function') {
+                requests.push(this.fetchExecutionPlansPage());
             }
             if (this.hasCalendarModule && typeof this.fetchCalendarData === 'function') {
                 requests.push(this.fetchCalendarData());
@@ -329,6 +343,7 @@ function dashboard() {
         typeof dashboardUsageModule === 'function' ? dashboardUsageModule : null,
         typeof dashboardAuditListModule === 'function' ? dashboardAuditListModule : null,
         typeof dashboardAliasesModule === 'function' ? dashboardAliasesModule : null,
+        typeof dashboardExecutionPlansModule === 'function' ? dashboardExecutionPlansModule : null,
         typeof dashboardConversationDrawerModule === 'function' ? dashboardConversationDrawerModule : null,
         calendarModuleFactory,
         typeof dashboardChartsModule === 'function' ? dashboardChartsModule : null

--- a/internal/admin/dashboard/static/js/modules/execution-plans-layout.test.js
+++ b/internal/admin/dashboard/static/js/modules/execution-plans-layout.test.js
@@ -97,6 +97,39 @@ test('workflow nodes use endpoint and feature color groups consistently', () => 
     }
 });
 
+test('execution plan authoring inputs expose stable accessible names', () => {
+    const template = readFixture('../../../templates/index.html');
+
+    assert.match(
+        template,
+        /x-model="executionPlanFilter"[^>]*aria-label="Filter workflows by scope, name, hash, or guardrail"/
+    );
+    assert.match(
+        template,
+        /x-model="step\.ref"[^>]*aria-label="Guardrail reference"/
+    );
+    assert.match(
+        template,
+        /x-model\.number="step\.step"[^>]*aria-label="Guardrail step"/
+    );
+});
+
+test('guardrails node only renders a sublabel when step detail exists', () => {
+    const template = readFixture('../../../templates/index.html');
+
+    assert.match(
+        template,
+        /<span class="ep-node-label">Guardrails<\/span>\s*<span class="ep-node-sub" x-show="epGuardrailLabel\(plan\)" x-text="epGuardrailLabel\(plan\)"><\/span>/
+    );
+});
+
+test('execution pipeline icons use lowercase currentcolor keyword', () => {
+    const css = readFixture('../../css/dashboard.css');
+    const iconRule = readCSSRule(css, '.ep-node-icon svg');
+
+    assert.match(iconRule, /stroke:\s*currentcolor;/);
+});
+
 test('exec pipeline has bottom spacing so adjacent cards do not touch it', () => {
     const css = readFixture('../../css/dashboard.css');
     const pipelineRule = readCSSRule(css, '.exec-pipeline');
@@ -115,7 +148,6 @@ test('execution pipeline uses var(--radius) for chart-local corners', () => {
         '.ep-node-endpoint',
         '.ep-node-icon-endpoint',
         '.ep-node-ai',
-        '.ep-node-ai .ep-node-icon',
         '.ep-node-async',
         '.ep-node-async .ep-node-icon'
     ];
@@ -124,6 +156,14 @@ test('execution pipeline uses var(--radius) for chart-local corners', () => {
         const rule = readCSSRule(css, selector);
         assert.match(rule, /border-radius:\s*var\(--radius\)/);
     }
+});
+
+test('AI node renders as a text-only card without an icon', () => {
+    const template = readFixture('../../../templates/index.html');
+    const css = readFixture('../../css/dashboard.css');
+
+    assert.doesNotMatch(template, /class="ep-node ep-node-ai[^"]*"[^>]*>\s*<div class="ep-node-icon">/);
+    assert.doesNotMatch(css, /\.ep-node-ai \.ep-node-icon\s*\{/);
 });
 
 test('endpoint pills use dedicated flush-left icons and tighter right padding', () => {

--- a/internal/admin/dashboard/static/js/modules/execution-plans-layout.test.js
+++ b/internal/admin/dashboard/static/js/modules/execution-plans-layout.test.js
@@ -114,6 +114,19 @@ test('execution plan authoring inputs expose stable accessible names', () => {
     );
 });
 
+test('execution plan card actions expose plan-specific accessible names', () => {
+    const template = readFixture('../../../templates/index.html');
+
+    assert.match(
+        template,
+        /class="table-action-btn table-action-btn-danger"[\s\S]*?:aria-label="'Deactivate workflow ' \+ workflowDisplayName\(plan\)"/
+    );
+    assert.match(
+        template,
+        /class="table-action-btn"[^>]*:aria-label="'Edit workflow ' \+ workflowDisplayName\(plan\)"/
+    );
+});
+
 test('guardrails node only renders a sublabel when step detail exists', () => {
     const template = readFixture('../../../templates/index.html');
 

--- a/internal/admin/dashboard/static/js/modules/execution-plans-layout.test.js
+++ b/internal/admin/dashboard/static/js/modules/execution-plans-layout.test.js
@@ -1,0 +1,59 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+function readFixture(relativePath) {
+    return fs.readFileSync(path.join(__dirname, relativePath), 'utf8');
+}
+
+function readCSSRule(source, selector) {
+    const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const match = source.match(new RegExp(`${escapedSelector}\\s*\\{([\\s\\S]*?)\\n\\}`, 'm'));
+    assert.ok(match, `Expected CSS rule for ${selector}`);
+    return match[1];
+}
+
+test('async pipeline branch spans full width and keeps the turn inline', () => {
+    const template = readFixture('../../../templates/index.html');
+    const css = readFixture('../../css/dashboard.css');
+
+    assert.match(
+        template,
+        /<div class="ep-async-section"[\s\S]*?<div class="ep-async-row">[\s\S]*?<\/div>\s*<div class="ep-async-turn"><\/div>/
+    );
+
+    const asyncSectionRule = readCSSRule(css, '.ep-async-section');
+    assert.match(asyncSectionRule, /width:\s*100%/);
+    assert.doesNotMatch(asyncSectionRule, /flex-direction:\s*column/);
+    assert.match(asyncSectionRule, /align-items:\s*center/);
+    assert.doesNotMatch(asyncSectionRule, /margin-top:\s*[1-9]/);
+
+    const asyncTurnRule = readCSSRule(css, '.ep-async-turn');
+    assert.match(asyncTurnRule, /width:\s*\d/);
+    assert.match(asyncTurnRule, /height:\s*2px/);
+    assert.doesNotMatch(asyncTurnRule, /border-bottom:/);
+    assert.doesNotMatch(asyncTurnRule, /border-right:/);
+
+    const asyncRowRule = readCSSRule(css, '.ep-async-row');
+    assert.match(asyncRowRule, /display:\s*flex/);
+    assert.match(asyncRowRule, /margin-right:\s*7px/);
+
+    const asyncTurnVerticalRule = readCSSRule(css, '.ep-async-turn::after');
+    assert.match(asyncTurnVerticalRule, /border-right:/);
+    assert.match(asyncTurnVerticalRule, /bottom:\s*1px/);
+    assert.doesNotMatch(asyncTurnVerticalRule, /transform:/);
+});
+
+test('async label stays inline on the right side of the branch', () => {
+    const template = readFixture('../../../templates/index.html');
+    const css = readFixture('../../css/dashboard.css');
+
+    assert.match(
+        template,
+        /<div class="ep-async-row">[\s\S]*ep-node-async-usage[\s\S]*ep-conn-async[\s\S]*ep-node-async-audit[\s\S]*<\/div>\s*<div class="ep-async-turn"><\/div>\s*<span class="ep-async-label">Async<\/span>/
+    );
+
+    const asyncLabelRule = readCSSRule(css, '.ep-async-label');
+    assert.doesNotMatch(asyncLabelRule, /position:\s*absolute/);
+});

--- a/internal/admin/dashboard/static/js/modules/execution-plans-layout.test.js
+++ b/internal/admin/dashboard/static/js/modules/execution-plans-layout.test.js
@@ -106,11 +106,11 @@ test('execution plan authoring inputs expose stable accessible names', () => {
     );
     assert.match(
         template,
-        /x-model="step\.ref"[^>]*aria-label="Guardrail reference"/
+        /x-model="step\.ref"[^>]*:aria-label="'Guardrail reference ' \+ \(index \+ 1\)"/
     );
     assert.match(
         template,
-        /x-model\.number="step\.step"[^>]*aria-label="Guardrail step"/
+        /x-model\.number="step\.step"[^>]*:aria-label="'Guardrail step ' \+ \(index \+ 1\)"/
     );
 });
 

--- a/internal/admin/dashboard/static/js/modules/execution-plans-layout.test.js
+++ b/internal/admin/dashboard/static/js/modules/execution-plans-layout.test.js
@@ -57,3 +57,87 @@ test('async label stays inline on the right side of the branch', () => {
     const asyncLabelRule = readCSSRule(css, '.ep-async-label');
     assert.doesNotMatch(asyncLabelRule, /position:\s*absolute/);
 });
+
+test('workflow nodes use endpoint and feature color groups consistently', () => {
+    const css = readFixture('../../css/dashboard.css');
+
+    const endpointRule = readCSSRule(css, '.ep-node-endpoint');
+    assert.match(endpointRule, /background:\s*var\(--bg-surface\)/);
+
+    const featureSelectors = [
+        '.ep-node-guardrails',
+        '.ep-node-async-audit',
+        '.ep-node-async-usage'
+    ];
+    for (const selector of featureSelectors) {
+        const rule = readCSSRule(css, selector);
+        assert.match(rule, /border-color:\s*color-mix\(in srgb, var\(--accent\) 46%, var\(--border\)\)/);
+        assert.match(rule, /background:\s*color-mix\(in srgb, var\(--accent\) 8%, var\(--bg-surface\)\)/);
+    }
+
+    const featureIconSelectors = [
+        '.ep-node-guardrails .ep-node-icon',
+        '.ep-node-async-audit .ep-node-icon',
+        '.ep-node-async-usage .ep-node-icon'
+    ];
+    for (const selector of featureIconSelectors) {
+        const rule = readCSSRule(css, selector);
+        assert.match(rule, /background:\s*color-mix\(in srgb, var\(--accent\) 16%, var\(--bg\)\)/);
+        assert.match(rule, /color:\s*var\(--accent\)/);
+    }
+
+    const featureLabelSelectors = [
+        '.ep-node-guardrails .ep-node-label',
+        '.ep-node-async-audit .ep-node-label',
+        '.ep-node-async-usage .ep-node-label'
+    ];
+    for (const selector of featureLabelSelectors) {
+        const rule = readCSSRule(css, selector);
+        assert.match(rule, /color:\s*var\(--accent\)/);
+    }
+});
+
+test('exec pipeline has bottom spacing so adjacent cards do not touch it', () => {
+    const css = readFixture('../../css/dashboard.css');
+    const pipelineRule = readCSSRule(css, '.exec-pipeline');
+
+    assert.match(pipelineRule, /margin-bottom:\s*\d+px/);
+});
+
+test('execution pipeline uses var(--radius) for chart-local corners', () => {
+    const css = readFixture('../../css/dashboard.css');
+
+    const radiusSelectors = [
+        '.exec-pipeline',
+        '.ep-node',
+        '.ep-node-icon',
+        '.ep-node-badge',
+        '.ep-node-endpoint',
+        '.ep-node-icon-endpoint',
+        '.ep-node-ai',
+        '.ep-node-ai .ep-node-icon',
+        '.ep-node-async',
+        '.ep-node-async .ep-node-icon'
+    ];
+
+    for (const selector of radiusSelectors) {
+        const rule = readCSSRule(css, selector);
+        assert.match(rule, /border-radius:\s*var\(--radius\)/);
+    }
+});
+
+test('endpoint pills use dedicated flush-left icons and tighter right padding', () => {
+    const template = readFixture('../../../templates/index.html');
+    const css = readFixture('../../css/dashboard.css');
+
+    assert.match(template, /class="ep-node-icon ep-node-icon-endpoint"/);
+
+    const endpointRule = readCSSRule(css, '.ep-node-endpoint');
+    assert.match(endpointRule, /padding:\s*10px 14px/);
+
+    const endpointIconRule = readCSSRule(css, '.ep-node-icon-endpoint');
+    assert.match(endpointIconRule, /width:\s*auto/);
+    assert.match(endpointIconRule, /height:\s*auto/);
+    assert.match(endpointIconRule, /justify-content:\s*flex-start/);
+    assert.match(endpointIconRule, /padding:\s*0/);
+});

--- a/internal/admin/dashboard/static/js/modules/execution-plans.js
+++ b/internal/admin/dashboard/static/js/modules/execution-plans.js
@@ -321,8 +321,8 @@
                     if (!step.ref) {
                         return 'Each guardrail step needs a guardrail ref.';
                     }
-                    if (!Number.isInteger(step.step)) {
-                        return 'Each guardrail step must use an integer step number.';
+                    if (!Number.isInteger(step.step) || step.step < 0) {
+                        return 'Each guardrail step must use a non-negative integer step number.';
                     }
                     if (seen.has(step.ref)) {
                         return 'Each guardrail ref may appear only once in a plan.';
@@ -524,7 +524,7 @@
 
             async deactivateExecutionPlan(plan) {
                 const planID = String(plan && plan.id || '').trim();
-                if (!planID || !this.canDeactivateExecutionPlan(plan)) {
+                if (!planID || this.executionPlanDeactivatingID || !this.canDeactivateExecutionPlan(plan)) {
                     return;
                 }
                 const workflowName = this.workflowDisplayName(plan);

--- a/internal/admin/dashboard/static/js/modules/execution-plans.js
+++ b/internal/admin/dashboard/static/js/modules/execution-plans.js
@@ -1,0 +1,557 @@
+(function(global) {
+    function dashboardExecutionPlansModule() {
+        return {
+            executionPlans: [],
+            executionPlansAvailable: true,
+            executionPlansLoading: false,
+            executionPlanError: '',
+            executionPlanNotice: '',
+            executionPlanFilter: '',
+            executionPlanFormOpen: false,
+            executionPlanSubmitting: false,
+            executionPlanDeactivatingID: '',
+            executionPlanFormError: '',
+            guardrailRefs: [],
+            executionPlanForm: {
+                scope_provider: '',
+                scope_model: '',
+                name: '',
+                description: '',
+                features: {
+                    cache: true,
+                    audit: true,
+                    usage: true,
+                    guardrails: false
+                },
+                guardrails: []
+            },
+
+            defaultExecutionPlanForm() {
+                return {
+                    scope_provider: '',
+                    scope_model: '',
+                    name: '',
+                    description: '',
+                    features: {
+                        cache: true,
+                        audit: true,
+                        usage: true,
+                        guardrails: false
+                    },
+                    guardrails: []
+                };
+            },
+
+            defaultExecutionPlanGuardrailStep(step) {
+                return {
+                    ref: '',
+                    step: Number.isFinite(step) ? step : 10
+                };
+            },
+
+            get filteredExecutionPlans() {
+                if (!this.executionPlanFilter) {
+                    return this.executionPlans;
+                }
+                const filter = this.executionPlanFilter.toLowerCase();
+                return this.executionPlans.filter((plan) => {
+                    const fields = [
+                        plan.name,
+                        plan.description,
+                        plan.scope_display,
+                        plan.scope_type,
+                        plan.scope && plan.scope.scope_provider,
+                        plan.scope && plan.scope.scope_model,
+                        plan.plan_hash,
+                        ...(Array.isArray(plan.plan_payload && plan.plan_payload.guardrails)
+                            ? plan.plan_payload.guardrails.map((step) => step.ref)
+                            : [])
+                    ];
+                    return fields.some((value) => String(value || '').toLowerCase().includes(filter));
+                });
+            },
+
+            executionPlanProviderOptions() {
+                const options = new Set();
+                this.models.forEach((model) => {
+                    const providerType = String(model && model.provider_type || '').trim();
+                    if (providerType) {
+                        options.add(providerType);
+                    }
+                });
+                return [...options].sort();
+            },
+
+            executionPlanModelOptions(providerType) {
+                const wantedProvider = String(providerType || '').trim();
+                const options = new Set();
+                this.models.forEach((model) => {
+                    if (wantedProvider && String(model && model.provider_type || '').trim() !== wantedProvider) {
+                        return;
+                    }
+                    const modelID = String(model && model.model && model.model.id || '').trim();
+                    if (modelID) {
+                        options.add(modelID);
+                    }
+                });
+                return [...options].sort();
+            },
+
+            planScopeTypeLabel(plan) {
+                const scopeType = String(plan && plan.scope_type || '').trim();
+                if (scopeType === 'provider_model') return 'Provider + Model';
+                if (scopeType === 'provider') return 'Provider';
+                return 'Global';
+            },
+
+            planScopeLabel(plan) {
+                return String(plan && plan.scope_display || 'global').trim() || 'global';
+            },
+
+            workflowDisplayName(plan) {
+                const explicitName = String(plan && plan.name || '').trim();
+                if (explicitName) {
+                    return explicitName;
+                }
+                const scopeLabel = this.planScopeLabel(plan);
+                if (scopeLabel === 'global') {
+                    return 'All models';
+                }
+                return scopeLabel;
+            },
+
+            executionPlanSourceFeatures(source) {
+                const raw = source && source.plan_payload && source.plan_payload.features
+                    ? source.plan_payload.features
+                    : source && source.features
+                        ? source.features
+                        : {};
+                return {
+                    cache: !!raw.cache,
+                    audit: !!raw.audit,
+                    usage: !!raw.usage,
+                    guardrails: !!raw.guardrails
+                };
+            },
+
+            executionPlanSourceGuardrails(source) {
+                const raw = Array.isArray(source && source.plan_payload && source.plan_payload.guardrails)
+                    ? source.plan_payload.guardrails
+                    : Array.isArray(source && source.guardrails)
+                        ? source.guardrails
+                        : [];
+                return raw
+                    .map((step) => ({
+                        ref: String(step && step.ref || '').trim(),
+                        step: Number(step && step.step)
+                    }))
+                    .filter((step) => Number.isFinite(step.step));
+            },
+
+            canDeactivateExecutionPlan(plan) {
+                return String(plan && plan.scope_type || '').trim() !== 'global';
+            },
+
+            executionPlanEditorScrollTarget() {
+                if (!global.document || typeof global.document.querySelector !== 'function') {
+                    return null;
+                }
+                return global.document.querySelector('.execution-plan-editor');
+            },
+
+            scrollExecutionPlanFormIntoView() {
+                const scroll = () => {
+                    const editor = this.executionPlanEditorScrollTarget();
+                    if (editor && typeof editor.scrollIntoView === 'function') {
+                        editor.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                    }
+                };
+                if (typeof global.requestAnimationFrame === 'function') {
+                    global.requestAnimationFrame(scroll);
+                    return;
+                }
+                scroll();
+            },
+
+            planGuardrails(plan) {
+                return Array.isArray(plan && plan.plan_payload && plan.plan_payload.guardrails)
+                    ? plan.plan_payload.guardrails
+                    : [];
+            },
+
+            shortHash(value) {
+                const hash = String(value || '').trim();
+                if (!hash) return '\u2014';
+                if (hash.length <= 14) return hash;
+                return hash.slice(0, 12) + '\u2026';
+            },
+
+            openExecutionPlanCreate(plan) {
+                this.executionPlanFormOpen = true;
+                this.executionPlanSubmitting = false;
+                this.executionPlanFormError = '';
+                this.executionPlanNotice = '';
+
+                if (!plan) {
+                    this.executionPlanForm = this.defaultExecutionPlanForm();
+                    this.scrollExecutionPlanFormIntoView();
+                    return;
+                }
+
+                const features = plan && plan.plan_payload && plan.plan_payload.features ? plan.plan_payload.features : {};
+                this.executionPlanForm = {
+                    scope_provider: String(plan.scope && plan.scope.scope_provider || ''),
+                    scope_model: String(plan.scope && plan.scope.scope_model || ''),
+                    name: String(plan.name || ''),
+                    description: String(plan.description || ''),
+                    features: {
+                        cache: !!features.cache,
+                        audit: !!features.audit,
+                        usage: !!features.usage,
+                        guardrails: !!features.guardrails
+                    },
+                    guardrails: this.planGuardrails(plan).map((step) => ({
+                        ref: String(step && step.ref || ''),
+                        step: Number.isFinite(step && step.step) ? step.step : 10
+                    }))
+                };
+                this.scrollExecutionPlanFormIntoView();
+            },
+
+            closeExecutionPlanForm() {
+                this.executionPlanFormOpen = false;
+                this.executionPlanSubmitting = false;
+                this.executionPlanFormError = '';
+                this.executionPlanForm = this.defaultExecutionPlanForm();
+            },
+
+            setExecutionPlanProvider(provider) {
+                this.executionPlanForm.scope_provider = String(provider || '').trim();
+                if (!this.executionPlanForm.scope_provider) {
+                    this.executionPlanForm.scope_provider = '';
+                    this.executionPlanForm.scope_model = '';
+                    return;
+                }
+                const modelOptions = this.executionPlanModelOptions(this.executionPlanForm.scope_provider);
+                if (!modelOptions.includes(String(this.executionPlanForm.scope_model || '').trim())) {
+                    this.executionPlanForm.scope_model = '';
+                }
+            },
+
+            addExecutionPlanGuardrailStep() {
+                const steps = Array.isArray(this.executionPlanForm.guardrails) ? this.executionPlanForm.guardrails : [];
+                const nextStep = steps.reduce((maxStep, step) => {
+                    const parsed = Number(step && step.step);
+                    return Number.isFinite(parsed) ? Math.max(maxStep, parsed) : maxStep;
+                }, 0) + 10;
+                this.executionPlanForm.guardrails.push(this.defaultExecutionPlanGuardrailStep(nextStep));
+            },
+
+            removeExecutionPlanGuardrailStep(index) {
+                if (!Array.isArray(this.executionPlanForm.guardrails)) return;
+                this.executionPlanForm.guardrails.splice(index, 1);
+            },
+
+            buildExecutionPlanRequest() {
+                const form = this.executionPlanForm || this.defaultExecutionPlanForm();
+                const provider = String(form.scope_provider || '').trim();
+                const model = provider ? String(form.scope_model || '').trim() : '';
+                const features = form.features || {};
+
+                const guardrails = !!features.guardrails
+                    ? (Array.isArray(form.guardrails) ? form.guardrails : []).map((step) => ({
+                        ref: String(step && step.ref || '').trim(),
+                        step: Number(step && step.step)
+                    }))
+                    : [];
+
+                return {
+                    scope_provider: provider,
+                    scope_model: model,
+                    name: String(form.name || '').trim(),
+                    description: String(form.description || '').trim(),
+                    plan_payload: {
+                        schema_version: 1,
+                        features: {
+                            cache: !!features.cache,
+                            audit: !!features.audit,
+                            usage: !!features.usage,
+                            guardrails: !!features.guardrails
+                        },
+                        guardrails
+                    }
+                };
+            },
+
+            validateExecutionPlanRequest(payload) {
+                if (payload.scope_provider) {
+                    const providers = this.executionPlanProviderOptions();
+                    if (!providers.includes(payload.scope_provider)) {
+                        return 'Choose a registered provider.';
+                    }
+                }
+                if (payload.scope_model && !payload.scope_provider) {
+                    return 'Model selection requires a provider.';
+                }
+                if (payload.scope_model) {
+                    const models = this.executionPlanModelOptions(payload.scope_provider);
+                    if (!models.includes(payload.scope_model)) {
+                        return 'Choose a registered model for the selected provider.';
+                    }
+                }
+
+                const features = payload.plan_payload && payload.plan_payload.features ? payload.plan_payload.features : {};
+                const guardrails = Array.isArray(payload.plan_payload && payload.plan_payload.guardrails)
+                    ? payload.plan_payload.guardrails
+                    : [];
+                if (!features.guardrails) {
+                    return '';
+                }
+
+                const seen = new Set();
+                for (const step of guardrails) {
+                    if (!step.ref) {
+                        return 'Each guardrail step needs a guardrail ref.';
+                    }
+                    if (!Number.isInteger(step.step)) {
+                        return 'Each guardrail step must use an integer step number.';
+                    }
+                    if (seen.has(step.ref)) {
+                        return 'Each guardrail ref may appear only once in a plan.';
+                    }
+                    seen.add(step.ref);
+                }
+
+                return '';
+            },
+
+            async executionPlanResponseMessage(res, fallback) {
+                try {
+                    const payload = await res.json();
+                    if (payload && payload.error && payload.error.message) {
+                        return payload.error.message;
+                    }
+                } catch (_) {
+                    // Ignore invalid or empty responses and return the fallback message.
+                }
+                return fallback;
+            },
+
+            async fetchExecutionPlans() {
+                this.executionPlansLoading = true;
+                this.executionPlanError = '';
+                try {
+                    const res = await fetch('/admin/api/v1/execution-plans', { headers: this.headers() });
+                    if (res.status === 503) {
+                        this.executionPlansAvailable = false;
+                        this.executionPlans = [];
+                        return;
+                    }
+                    this.executionPlansAvailable = true;
+                    if (!this.handleFetchResponse(res, 'workflows')) {
+                        this.executionPlans = [];
+                        return;
+                    }
+                    const payload = await res.json();
+                    this.executionPlans = Array.isArray(payload) ? payload : [];
+                } catch (e) {
+                    console.error('Failed to fetch workflows:', e);
+                    this.executionPlans = [];
+                    this.executionPlanError = 'Unable to load workflows.';
+                } finally {
+                    this.executionPlansLoading = false;
+                }
+            },
+
+            async fetchExecutionPlanGuardrails() {
+                try {
+                    const res = await fetch('/admin/api/v1/execution-plans/guardrails', { headers: this.headers() });
+                    if (!this.handleFetchResponse(res, 'workflow guardrails')) {
+                        this.guardrailRefs = [];
+                        return;
+                    }
+                    const payload = await res.json();
+                    this.guardrailRefs = Array.isArray(payload) ? payload : [];
+                } catch (e) {
+                    console.error('Failed to fetch workflow guardrails:', e);
+                    this.guardrailRefs = [];
+                }
+            },
+
+            async fetchExecutionPlansPage() {
+                await Promise.all([this.fetchExecutionPlans(), this.fetchExecutionPlanGuardrails()]);
+            },
+
+            async submitExecutionPlanForm() {
+                this.executionPlanFormError = '';
+                this.executionPlanNotice = '';
+
+                const payload = this.buildExecutionPlanRequest();
+                const validationError = this.validateExecutionPlanRequest(payload);
+                if (validationError) {
+                    this.executionPlanFormError = validationError;
+                    return;
+                }
+
+                this.executionPlanSubmitting = true;
+                try {
+                    const res = await fetch('/admin/api/v1/execution-plans', {
+                        method: 'POST',
+                        headers: this.headers(),
+                        body: JSON.stringify(payload)
+                    });
+
+                    if (res.status === 401) {
+                        this.handleFetchResponse(res, 'create workflow');
+                        return;
+                    }
+                    if (!res.ok) {
+                        this.executionPlanFormError = await this.executionPlanResponseMessage(res, 'Unable to create workflow.');
+                        return;
+                    }
+
+                    this.executionPlanNotice = 'Workflow created and activated.';
+                    this.closeExecutionPlanForm();
+                    await this.fetchExecutionPlansPage();
+                } catch (e) {
+                    console.error('Failed to create workflow:', e);
+                    this.executionPlanFormError = 'Unable to create workflow.';
+                } finally {
+                    this.executionPlanSubmitting = false;
+                }
+            },
+
+            // ─── Execution Pipeline helpers ───
+
+            epHasGuardrails(source) {
+                return !!this.executionPlanSourceFeatures(source).guardrails;
+            },
+
+            epHasCache(source) {
+                return !!this.executionPlanSourceFeatures(source).cache;
+            },
+
+            epHasAudit(source) {
+                return !!this.executionPlanSourceFeatures(source).audit;
+            },
+
+            epHasUsage(source) {
+                return !!this.executionPlanSourceFeatures(source).usage;
+            },
+
+            epHasAsync(source) {
+                const f = this.executionPlanSourceFeatures(source);
+                return !!(f.audit || f.usage);
+            },
+
+            epGuardrailLabel(source) {
+                const count = this.executionPlanSourceGuardrails(source).length;
+                if (count === 0) return 'Guardrails';
+                return count === 1 ? '1 step' : count + ' steps';
+            },
+
+            epAiLabel(source, runtime) {
+                if (runtime && runtime.provider) return runtime.provider;
+                const provider = source && source.scope && source.scope.scope_provider;
+                return provider || 'AI';
+            },
+
+            epAiSublabel(source, runtime) {
+                if (runtime && runtime.model) return runtime.model;
+                return source && source.scope && source.scope.scope_model || null;
+            },
+
+            // runtime shape: { cacheHit: bool|null, cacheType: 'exact'|'semantic'|null, provider, model }
+            epRuntimeHasCache(runtime) {
+                return !!(runtime && runtime.cacheHit !== null && runtime.cacheHit !== undefined);
+            },
+
+            epShowCacheStep(source, runtime) {
+                return this.epHasCache(source) || this.epRuntimeHasCache(runtime);
+            },
+
+            epCacheNodeClass(runtime) {
+                if (!this.epRuntimeHasCache(runtime)) return '';
+                if (runtime.cacheHit && runtime.cacheType === 'semantic') return 'ep-node-cache-semantic';
+                if (runtime.cacheHit) return 'ep-node-cache-hit';
+                return 'ep-node-cache-miss';
+            },
+
+            epCacheConnClass(runtime) {
+                if (!this.epRuntimeHasCache(runtime)) return '';
+                return runtime.cacheHit ? 'ep-conn-hit' : '';
+            },
+
+            epCacheStatusLabel(runtime) {
+                if (!this.epRuntimeHasCache(runtime)) return null;
+                if (runtime.cacheHit && runtime.cacheType === 'semantic') return 'Semantic';
+                return runtime.cacheHit ? 'Hit' : 'Miss';
+            },
+
+            epAiConnClass(runtime) {
+                if (!this.epRuntimeHasCache(runtime)) return '';
+                return runtime.cacheHit ? 'ep-conn-dim' : '';
+            },
+
+            epAiNodeClass(runtime) {
+                if (!this.epRuntimeHasCache(runtime)) return '';
+                return runtime.cacheHit ? 'ep-node-ai-skipped' : '';
+            },
+
+            epRuntimeFromEntry(entry) {
+                if (!entry) return null;
+                const cacheHit = (entry.cache_hit !== undefined && entry.cache_hit !== null)
+                    ? !!entry.cache_hit
+                    : null;
+                return {
+                    cacheHit,
+                    cacheType: entry.cache_type || null,
+                    provider: entry.provider || null,
+                    model: entry.model || null
+                };
+            },
+
+            async deactivateExecutionPlan(plan) {
+                const planID = String(plan && plan.id || '').trim();
+                if (!planID || !this.canDeactivateExecutionPlan(plan)) {
+                    return;
+                }
+                const workflowName = this.workflowDisplayName(plan);
+                if (typeof global.confirm === 'function' && !global.confirm(
+                    'Deactivate workflow "' + workflowName + '"? Requests will fall back to the next active workflow for this scope.'
+                )) {
+                    return;
+                }
+
+                this.executionPlanError = '';
+                this.executionPlanNotice = '';
+                this.executionPlanDeactivatingID = planID;
+                try {
+                    const res = await fetch('/admin/api/v1/execution-plans/' + encodeURIComponent(planID) + '/deactivate', {
+                        method: 'POST',
+                        headers: this.headers()
+                    });
+
+                    if (res.status === 401) {
+                        this.handleFetchResponse(res, 'deactivate workflow');
+                        return;
+                    }
+                    if (!res.ok) {
+                        this.executionPlanError = await this.executionPlanResponseMessage(res, 'Unable to deactivate workflow.');
+                        return;
+                    }
+
+                    this.executionPlanNotice = 'Workflow deactivated.';
+                    await this.fetchExecutionPlansPage();
+                } catch (e) {
+                    console.error('Failed to deactivate workflow:', e);
+                    this.executionPlanError = 'Unable to deactivate workflow.';
+                } finally {
+                    this.executionPlanDeactivatingID = '';
+                }
+            }
+        };
+    }
+
+    global.dashboardExecutionPlansModule = dashboardExecutionPlansModule;
+})(window);

--- a/internal/admin/dashboard/static/js/modules/execution-plans.js
+++ b/internal/admin/dashboard/static/js/modules/execution-plans.js
@@ -446,7 +446,7 @@
 
             epGuardrailLabel(source) {
                 const count = this.executionPlanSourceGuardrails(source).length;
-                if (count === 0) return 'Guardrails';
+                if (count === 0) return '';
                 return count === 1 ? '1 step' : count + ' steps';
             },
 

--- a/internal/admin/dashboard/static/js/modules/execution-plans.js
+++ b/internal/admin/dashboard/static/js/modules/execution-plans.js
@@ -11,6 +11,10 @@
             executionPlanSubmitting: false,
             executionPlanDeactivatingID: '',
             executionPlanFormError: '',
+            executionPlanHydratedScope: {
+                scope_provider: '',
+                scope_model: ''
+            },
             guardrailRefs: [],
             executionPlanForm: {
                 scope_provider: '',
@@ -73,7 +77,12 @@
 
             executionPlanProviderOptions() {
                 const options = new Set();
-                this.models.forEach((model) => {
+                const preservedProvider = String(this.executionPlanHydratedScope && this.executionPlanHydratedScope.scope_provider || '').trim();
+                if (preservedProvider) {
+                    options.add(preservedProvider);
+                }
+                const models = Array.isArray(this.models) ? this.models : [];
+                models.forEach((model) => {
                     const providerType = String(model && model.provider_type || '').trim();
                     if (providerType) {
                         options.add(providerType);
@@ -85,7 +94,13 @@
             executionPlanModelOptions(providerType) {
                 const wantedProvider = String(providerType || '').trim();
                 const options = new Set();
-                this.models.forEach((model) => {
+                const preservedProvider = String(this.executionPlanHydratedScope && this.executionPlanHydratedScope.scope_provider || '').trim();
+                const preservedModel = String(this.executionPlanHydratedScope && this.executionPlanHydratedScope.scope_model || '').trim();
+                if (wantedProvider && wantedProvider === preservedProvider && preservedModel) {
+                    options.add(preservedModel);
+                }
+                const models = Array.isArray(this.models) ? this.models : [];
+                models.forEach((model) => {
                     if (wantedProvider && String(model && model.provider_type || '').trim() !== wantedProvider) {
                         return;
                     }
@@ -193,11 +208,19 @@
                 this.executionPlanNotice = '';
 
                 if (!plan) {
+                    this.executionPlanHydratedScope = {
+                        scope_provider: '',
+                        scope_model: ''
+                    };
                     this.executionPlanForm = this.defaultExecutionPlanForm();
                     this.scrollExecutionPlanFormIntoView();
                     return;
                 }
 
+                this.executionPlanHydratedScope = {
+                    scope_provider: String(plan.scope && plan.scope.scope_provider || '').trim(),
+                    scope_model: String(plan.scope && plan.scope.scope_model || '').trim()
+                };
                 const features = this.executionPlanSourceFeatures(plan);
                 const guardrails = this.executionPlanSourceGuardrails(plan);
                 this.executionPlanForm = {
@@ -223,6 +246,10 @@
                 this.executionPlanFormOpen = false;
                 this.executionPlanSubmitting = false;
                 this.executionPlanFormError = '';
+                this.executionPlanHydratedScope = {
+                    scope_provider: '',
+                    scope_model: ''
+                };
                 this.executionPlanForm = this.defaultExecutionPlanForm();
             },
 
@@ -292,9 +319,12 @@
             },
 
             validateExecutionPlanRequest(payload) {
+                const preservedProvider = String(this.executionPlanHydratedScope && this.executionPlanHydratedScope.scope_provider || '').trim();
+                const preservedModel = String(this.executionPlanHydratedScope && this.executionPlanHydratedScope.scope_model || '').trim();
+
                 if (payload.scope_provider) {
                     const providers = this.executionPlanProviderOptions();
-                    if (!providers.includes(payload.scope_provider)) {
+                    if (!providers.includes(payload.scope_provider) && payload.scope_provider !== preservedProvider) {
                         return 'Choose a registered provider.';
                     }
                 }
@@ -303,7 +333,8 @@
                 }
                 if (payload.scope_model) {
                     const models = this.executionPlanModelOptions(payload.scope_provider);
-                    if (!models.includes(payload.scope_model)) {
+                    const isPreservedModel = payload.scope_provider === preservedProvider && payload.scope_model === preservedModel;
+                    if (!models.includes(payload.scope_model) && !isPreservedModel) {
                         return 'Choose a registered model for the selected provider.';
                     }
                 }

--- a/internal/admin/dashboard/static/js/modules/execution-plans.js
+++ b/internal/admin/dashboard/static/js/modules/execution-plans.js
@@ -379,8 +379,16 @@
             async fetchExecutionPlans() {
                 this.executionPlansLoading = true;
                 this.executionPlanError = '';
+                const controller = typeof AbortController === 'function' ? new AbortController() : null;
+                const timeoutID = controller && typeof setTimeout === 'function'
+                    ? setTimeout(() => controller.abort(), 10000)
+                    : null;
                 try {
-                    const res = await fetch('/admin/api/v1/execution-plans', { headers: this.headers() });
+                    const request = { headers: this.headers() };
+                    if (controller) {
+                        request.signal = controller.signal;
+                    }
+                    const res = await fetch('/admin/api/v1/execution-plans', request);
                     if (res.status === 503) {
                         this.executionPlansAvailable = false;
                         this.executionPlans = [];
@@ -396,8 +404,13 @@
                 } catch (e) {
                     console.error('Failed to fetch workflows:', e);
                     this.executionPlans = [];
-                    this.executionPlanError = 'Unable to load workflows.';
+                    this.executionPlanError = e && e.name === 'AbortError'
+                        ? 'Loading workflows timed out.'
+                        : 'Unable to load workflows.';
                 } finally {
+                    if (timeoutID !== null && typeof clearTimeout === 'function') {
+                        clearTimeout(timeoutID);
+                    }
                     this.executionPlansLoading = false;
                 }
             },

--- a/internal/admin/dashboard/static/js/modules/execution-plans.js
+++ b/internal/admin/dashboard/static/js/modules/execution-plans.js
@@ -198,7 +198,8 @@
                     return;
                 }
 
-                const features = plan && plan.plan_payload && plan.plan_payload.features ? plan.plan_payload.features : {};
+                const features = this.executionPlanSourceFeatures(plan);
+                const guardrails = this.executionPlanSourceGuardrails(plan);
                 this.executionPlanForm = {
                     scope_provider: String(plan.scope && plan.scope.scope_provider || ''),
                     scope_model: String(plan.scope && plan.scope.scope_model || ''),
@@ -210,7 +211,7 @@
                         usage: !!features.usage,
                         guardrails: !!features.guardrails
                     },
-                    guardrails: this.planGuardrails(plan).map((step) => ({
+                    guardrails: guardrails.map((step) => ({
                         ref: String(step && step.ref || ''),
                         step: Number.isFinite(step && step.step) ? step.step : 10
                     }))
@@ -259,10 +260,17 @@
                 const features = form.features || {};
 
                 const guardrails = !!features.guardrails
-                    ? (Array.isArray(form.guardrails) ? form.guardrails : []).map((step) => ({
-                        ref: String(step && step.ref || '').trim(),
-                        step: Number(step && step.step)
-                    }))
+                    ? (Array.isArray(form.guardrails) ? form.guardrails : []).map((step) => {
+                        const rawStep = step && step.step;
+                        const trimmedStep = rawStep === null || rawStep === undefined ? '' : String(rawStep).trim();
+                        const parsedStep = trimmedStep !== '' && Number.isFinite(Number(trimmedStep))
+                            ? Number(trimmedStep)
+                            : Number.NaN;
+                        return {
+                            ref: String(step && step.ref || '').trim(),
+                            step: parsedStep
+                        };
+                    })
                     : [];
 
                 return {
@@ -383,6 +391,9 @@
             },
 
             async submitExecutionPlanForm() {
+                if (this.executionPlanSubmitting) {
+                    return;
+                }
                 this.executionPlanFormError = '';
                 this.executionPlanNotice = '';
 

--- a/internal/admin/dashboard/static/js/modules/execution-plans.test.js
+++ b/internal/admin/dashboard/static/js/modules/execution-plans.test.js
@@ -170,6 +170,40 @@ test('workflowDisplayName falls back to scope label or All models', () => {
     );
 });
 
+test('epGuardrailLabel only shows a sublabel when guardrail steps exist', () => {
+    const module = createExecutionPlansModule();
+
+    assert.equal(
+        module.epGuardrailLabel({
+            plan_payload: {
+                guardrails: []
+            }
+        }),
+        ''
+    );
+
+    assert.equal(
+        module.epGuardrailLabel({
+            plan_payload: {
+                guardrails: [{ ref: 'policy-system', step: 10 }]
+            }
+        }),
+        '1 step'
+    );
+
+    assert.equal(
+        module.epGuardrailLabel({
+            plan_payload: {
+                guardrails: [
+                    { ref: 'policy-system', step: 10 },
+                    { ref: 'pii', step: 20 }
+                ]
+            }
+        }),
+        '2 steps'
+    );
+});
+
 test('deactivateExecutionPlan requires confirmation before posting', async () => {
     let fetchCalled = false;
     const module = createExecutionPlansModule({

--- a/internal/admin/dashboard/static/js/modules/execution-plans.test.js
+++ b/internal/admin/dashboard/static/js/modules/execution-plans.test.js
@@ -1,0 +1,197 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function loadExecutionPlansModuleFactory(overrides = {}) {
+    const source = fs.readFileSync(path.join(__dirname, 'execution-plans.js'), 'utf8');
+    const window = {
+        ...(overrides.window || {})
+    };
+    const context = {
+        console,
+        ...overrides,
+        window
+    };
+    vm.createContext(context);
+    vm.runInContext(source, context);
+    return context.window.dashboardExecutionPlansModule;
+}
+
+function createExecutionPlansModule(overrides) {
+    const factory = loadExecutionPlansModuleFactory(overrides);
+    return factory();
+}
+
+test('executionPlanProviderOptions returns unique sorted provider types', () => {
+    const module = createExecutionPlansModule();
+    module.models = [
+        { provider_type: 'anthropic', model: { id: 'claude-3-7' } },
+        { provider_type: 'openai', model: { id: 'gpt-5' } },
+        { provider_type: 'openai', model: { id: 'gpt-4o-mini' } }
+    ];
+
+    assert.equal(
+        JSON.stringify(module.executionPlanProviderOptions()),
+        JSON.stringify(['anthropic', 'openai'])
+    );
+});
+
+test('buildExecutionPlanRequest emits provider-model payload and strips guardrails when disabled', () => {
+    const module = createExecutionPlansModule();
+    module.executionPlanForm = {
+        scope_provider: 'openai',
+        scope_model: 'gpt-5',
+        name: 'OpenAI GPT-5',
+        description: 'Primary translated requests',
+        features: {
+            cache: true,
+            audit: true,
+            usage: true,
+            guardrails: false
+        },
+        guardrails: [
+            { ref: 'policy-system', step: 10 }
+        ]
+    };
+
+    assert.equal(
+        JSON.stringify(module.buildExecutionPlanRequest()),
+        JSON.stringify({
+            scope_provider: 'openai',
+            scope_model: 'gpt-5',
+            name: 'OpenAI GPT-5',
+            description: 'Primary translated requests',
+            plan_payload: {
+                schema_version: 1,
+                features: {
+                    cache: true,
+                    audit: true,
+                    usage: true,
+                    guardrails: false
+                },
+                guardrails: []
+            }
+        })
+    );
+});
+
+test('validateExecutionPlanRequest rejects duplicate guardrail refs', () => {
+    const module = createExecutionPlansModule();
+    const payload = {
+        scope_provider: '',
+        scope_model: '',
+        name: 'Global',
+        plan_payload: {
+            schema_version: 1,
+            features: {
+                cache: true,
+                audit: true,
+                usage: true,
+                guardrails: true
+            },
+            guardrails: [
+                { ref: 'policy-system', step: 10 },
+                { ref: 'policy-system', step: 20 }
+            ]
+        }
+    };
+
+    assert.equal(
+        module.validateExecutionPlanRequest(payload),
+        'Each guardrail ref may appear only once in a plan.'
+    );
+});
+
+test('setExecutionPlanProvider clears model when provider changes', () => {
+    const module = createExecutionPlansModule();
+    module.models = [
+        { provider_type: 'openai', model: { id: 'gpt-5' } },
+        { provider_type: 'anthropic', model: { id: 'claude-3-7' } }
+    ];
+    module.executionPlanForm = module.defaultExecutionPlanForm();
+    module.executionPlanForm.scope_provider = 'openai';
+    module.executionPlanForm.scope_model = 'gpt-5';
+
+    module.setExecutionPlanProvider('anthropic');
+
+    assert.equal(module.executionPlanForm.scope_provider, 'anthropic');
+    assert.equal(module.executionPlanForm.scope_model, '');
+});
+
+test('validateExecutionPlanRequest rejects unregistered provider-model selections', () => {
+    const module = createExecutionPlansModule();
+    module.models = [
+        { provider_type: 'openai', model: { id: 'gpt-5' } }
+    ];
+
+    assert.equal(
+        module.validateExecutionPlanRequest({
+            scope_provider: 'anthropic',
+            scope_model: '',
+            plan_payload: {
+                schema_version: 1,
+                features: { cache: true, audit: true, usage: true, guardrails: false },
+                guardrails: []
+            }
+        }),
+        'Choose a registered provider.'
+    );
+
+    assert.equal(
+        module.validateExecutionPlanRequest({
+            scope_provider: 'openai',
+            scope_model: 'gpt-4o-mini',
+            plan_payload: {
+                schema_version: 1,
+                features: { cache: true, audit: true, usage: true, guardrails: false },
+                guardrails: []
+            }
+        }),
+        'Choose a registered model for the selected provider.'
+    );
+});
+
+test('workflowDisplayName falls back to scope label or All models', () => {
+    const module = createExecutionPlansModule();
+
+    assert.equal(
+        module.workflowDisplayName({ name: '', scope_display: 'global' }),
+        'All models'
+    );
+    assert.equal(
+        module.workflowDisplayName({ name: '', scope_display: 'openai/gpt-5' }),
+        'openai/gpt-5'
+    );
+    assert.equal(
+        module.workflowDisplayName({ name: 'Primary workflow', scope_display: 'openai/gpt-5' }),
+        'Primary workflow'
+    );
+});
+
+test('deactivateExecutionPlan requires confirmation before posting', async () => {
+    let fetchCalled = false;
+    const module = createExecutionPlansModule({
+        window: {
+            confirm(message) {
+                assert.match(message, /Deactivate workflow "Primary workflow"\?/);
+                return false;
+            }
+        },
+        fetch() {
+            fetchCalled = true;
+            throw new Error('fetch should not be called when deactivation is cancelled');
+        }
+    });
+    module.headers = () => ({});
+
+    await module.deactivateExecutionPlan({
+        id: 'workflow-1',
+        name: 'Primary workflow',
+        scope_type: 'provider'
+    });
+
+    assert.equal(fetchCalled, false);
+    assert.equal(module.executionPlanDeactivatingID, '');
+});

--- a/internal/admin/dashboard/static/js/modules/execution-plans.test.js
+++ b/internal/admin/dashboard/static/js/modules/execution-plans.test.js
@@ -151,7 +151,33 @@ test('buildExecutionPlanRequest preserves blank guardrail steps as invalid so va
     assert.ok(Number.isNaN(payload.plan_payload.guardrails[0].step));
     assert.equal(
         module.validateExecutionPlanRequest(payload),
-        'Each guardrail step must use an integer step number.'
+        'Each guardrail step must use a non-negative integer step number.'
+    );
+});
+
+test('validateExecutionPlanRequest rejects negative guardrail step numbers', () => {
+    const module = createExecutionPlansModule();
+    const payload = {
+        scope_provider: '',
+        scope_model: '',
+        name: 'Global',
+        plan_payload: {
+            schema_version: 1,
+            features: {
+                cache: true,
+                audit: true,
+                usage: true,
+                guardrails: true
+            },
+            guardrails: [
+                { ref: 'policy-system', step: -1 }
+            ]
+        }
+    };
+
+    assert.equal(
+        module.validateExecutionPlanRequest(payload),
+        'Each guardrail step must use a non-negative integer step number.'
     );
 });
 
@@ -306,6 +332,35 @@ test('deactivateExecutionPlan requires confirmation before posting', async () =>
 
     assert.equal(fetchCalled, false);
     assert.equal(module.executionPlanDeactivatingID, '');
+});
+
+test('deactivateExecutionPlan ignores duplicate clicks while another deactivation is in flight', async () => {
+    let confirmCalled = false;
+    let fetchCalled = false;
+    const module = createExecutionPlansModule({
+        window: {
+            confirm() {
+                confirmCalled = true;
+                return true;
+            }
+        },
+        fetch() {
+            fetchCalled = true;
+            throw new Error('fetch should not be called while another deactivation is already in flight');
+        }
+    });
+    module.executionPlanDeactivatingID = 'workflow-1';
+    module.headers = () => ({});
+
+    await module.deactivateExecutionPlan({
+        id: 'workflow-1',
+        name: 'Primary workflow',
+        scope_type: 'provider'
+    });
+
+    assert.equal(confirmCalled, false);
+    assert.equal(fetchCalled, false);
+    assert.equal(module.executionPlanDeactivatingID, 'workflow-1');
 });
 
 test('submitExecutionPlanForm ignores duplicate submissions while a request is already in flight', async () => {

--- a/internal/admin/dashboard/static/js/modules/execution-plans.test.js
+++ b/internal/admin/dashboard/static/js/modules/execution-plans.test.js
@@ -77,6 +77,84 @@ test('buildExecutionPlanRequest emits provider-model payload and strips guardrai
     );
 });
 
+test('openExecutionPlanCreate hydrates features and guardrails via shared normalizers', () => {
+    const module = createExecutionPlansModule();
+    module.executionPlanSourceFeatures = () => ({
+        cache: false,
+        audit: false,
+        usage: true,
+        guardrails: true
+    });
+    module.executionPlanSourceGuardrails = () => ([
+        { ref: 'policy-system', step: 30 }
+    ]);
+    module.scrollExecutionPlanFormIntoView = () => {};
+
+    module.openExecutionPlanCreate({
+        scope: {
+            scope_provider: 'openai',
+            scope_model: 'gpt-5'
+        },
+        name: 'Hydrated workflow',
+        description: 'Uses helper normalization',
+        plan_payload: {
+            features: {
+                cache: true,
+                audit: true,
+                usage: false,
+                guardrails: false
+            },
+            guardrails: [
+                { ref: 'wrong-source', step: 10 }
+            ]
+        }
+    });
+
+    assert.equal(
+        JSON.stringify(module.executionPlanForm.features),
+        JSON.stringify({
+            cache: false,
+            audit: false,
+            usage: true,
+            guardrails: true
+        })
+    );
+    assert.equal(
+        JSON.stringify(module.executionPlanForm.guardrails),
+        JSON.stringify([{ ref: 'policy-system', step: 30 }])
+    );
+});
+
+test('buildExecutionPlanRequest preserves blank guardrail steps as invalid so validation rejects them', () => {
+    const module = createExecutionPlansModule();
+    module.models = [
+        { provider_type: 'openai', model: { id: 'gpt-5' } }
+    ];
+    module.executionPlanForm = {
+        scope_provider: 'openai',
+        scope_model: 'gpt-5',
+        name: 'OpenAI GPT-5',
+        description: 'Primary translated requests',
+        features: {
+            cache: true,
+            audit: true,
+            usage: true,
+            guardrails: true
+        },
+        guardrails: [
+            { ref: 'policy-system', step: '   ' }
+        ]
+    };
+
+    const payload = module.buildExecutionPlanRequest();
+
+    assert.ok(Number.isNaN(payload.plan_payload.guardrails[0].step));
+    assert.equal(
+        module.validateExecutionPlanRequest(payload),
+        'Each guardrail step must use an integer step number.'
+    );
+});
+
 test('validateExecutionPlanRequest rejects duplicate guardrail refs', () => {
     const module = createExecutionPlansModule();
     const payload = {
@@ -228,4 +306,42 @@ test('deactivateExecutionPlan requires confirmation before posting', async () =>
 
     assert.equal(fetchCalled, false);
     assert.equal(module.executionPlanDeactivatingID, '');
+});
+
+test('submitExecutionPlanForm ignores duplicate submissions while a request is already in flight', async () => {
+    let fetchCalled = false;
+    const module = createExecutionPlansModule({
+        fetch() {
+            fetchCalled = true;
+            return Promise.resolve({
+                ok: true,
+                status: 201
+            });
+        }
+    });
+    module.models = [
+        { provider_type: 'openai', model: { id: 'gpt-5' } }
+    ];
+    module.executionPlanSubmitting = true;
+    module.executionPlanForm = {
+        scope_provider: 'openai',
+        scope_model: 'gpt-5',
+        name: 'OpenAI GPT-5',
+        description: 'Primary translated requests',
+        features: {
+            cache: true,
+            audit: true,
+            usage: true,
+            guardrails: false
+        },
+        guardrails: []
+    };
+    module.headers = () => ({});
+    module.closeExecutionPlanForm = () => {};
+    module.fetchExecutionPlansPage = async () => {};
+
+    await module.submitExecutionPlanForm();
+
+    assert.equal(fetchCalled, false);
+    assert.equal(module.executionPlanSubmitting, true);
 });

--- a/internal/admin/dashboard/static/js/modules/execution-plans.test.js
+++ b/internal/admin/dashboard/static/js/modules/execution-plans.test.js
@@ -125,6 +125,49 @@ test('openExecutionPlanCreate hydrates features and guardrails via shared normal
     );
 });
 
+test('editing a cloned workflow preserves retired provider and model options', () => {
+    const module = createExecutionPlansModule();
+    module.models = [
+        { provider_type: 'openai', model: { id: 'gpt-5' } }
+    ];
+    module.scrollExecutionPlanFormIntoView = () => {};
+
+    module.openExecutionPlanCreate({
+        scope: {
+            scope_provider: 'anthropic',
+            scope_model: 'claude-retired'
+        },
+        name: 'Retired workflow',
+        description: 'Cloned from an older deployment',
+        plan_payload: {
+            features: {
+                cache: true,
+                audit: true,
+                usage: true,
+                guardrails: false
+            },
+            guardrails: []
+        }
+    });
+
+    assert.equal(
+        JSON.stringify(module.executionPlanProviderOptions()),
+        JSON.stringify(['anthropic', 'openai'])
+    );
+    assert.equal(
+        JSON.stringify(module.executionPlanModelOptions('anthropic')),
+        JSON.stringify(['claude-retired'])
+    );
+    assert.equal(module.validateExecutionPlanRequest(module.buildExecutionPlanRequest()), '');
+
+    const invalidPayload = module.buildExecutionPlanRequest();
+    invalidPayload.scope_model = 'different-retired-model';
+    assert.equal(
+        module.validateExecutionPlanRequest(invalidPayload),
+        'Choose a registered model for the selected provider.'
+    );
+});
+
 test('buildExecutionPlanRequest preserves blank guardrail steps as invalid so validation rejects them', () => {
     const module = createExecutionPlansModule();
     module.models = [

--- a/internal/admin/dashboard/static/js/modules/execution-plans.test.js
+++ b/internal/admin/dashboard/static/js/modules/execution-plans.test.js
@@ -406,6 +406,44 @@ test('deactivateExecutionPlan ignores duplicate clicks while another deactivatio
     assert.equal(module.executionPlanDeactivatingID, 'workflow-1');
 });
 
+test('fetchExecutionPlans aborts hung requests and clears loading state', async () => {
+    let timeoutCleared = false;
+    class AbortControllerStub {
+        constructor() {
+            this.signal = { aborted: false };
+        }
+
+        abort() {
+            this.signal.aborted = true;
+        }
+    }
+
+    const module = createExecutionPlansModule({
+        AbortController: AbortControllerStub,
+        setTimeout(fn) {
+            fn();
+            return 42;
+        },
+        clearTimeout(id) {
+            assert.equal(id, 42);
+            timeoutCleared = true;
+        },
+        fetch(_url, options) {
+            assert.equal(options.headers.authorization, 'Bearer token');
+            assert.equal(options.signal.aborted, true);
+            return Promise.reject(Object.assign(new Error('timed out'), { name: 'AbortError' }));
+        }
+    });
+    module.headers = () => ({ authorization: 'Bearer token' });
+
+    await module.fetchExecutionPlans();
+
+    assert.equal(JSON.stringify(module.executionPlans), JSON.stringify([]));
+    assert.equal(module.executionPlanError, 'Loading workflows timed out.');
+    assert.equal(module.executionPlansLoading, false);
+    assert.equal(timeoutCleared, true);
+});
+
 test('submitExecutionPlanForm ignores duplicate submissions while a request is already in flight', async () => {
     let fetchCalled = false;
     const module = createExecutionPlansModule({

--- a/internal/admin/dashboard/static/js/modules/usage.js
+++ b/internal/admin/dashboard/static/js/modules/usage.js
@@ -34,7 +34,7 @@
                     this.daily = await dailyRes.json();
                     this.renderChart();
                     if (this.page === 'usage') this.fetchUsagePage();
-                    if (this.page === 'audit') this.fetchAuditLog(true);
+                    if (this.page === 'audit-logs') this.fetchAuditLog(true);
                 } catch (e) {
                     console.error('Failed to fetch usage:', e);
                 }

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -870,10 +870,14 @@
                                 <button type="button"
                                         class="table-action-btn table-action-btn-danger"
                                         :disabled="executionPlanDeactivatingID === plan.id || !canDeactivateExecutionPlan(plan)"
+                                        :aria-label="'Deactivate workflow ' + workflowDisplayName(plan)"
                                         :title="canDeactivateExecutionPlan(plan) ? 'Deactivate active workflow' : 'The global workflow cannot be deactivated.'"
                                         @click="deactivateExecutionPlan(plan)"
                                         x-text="executionPlanDeactivatingID === plan.id ? 'Deactivating...' : 'Deactivate'"></button>
-                                <button type="button" class="table-action-btn" @click="openExecutionPlanCreate(plan)">Edit</button>
+                                <button type="button"
+                                        class="table-action-btn"
+                                        :aria-label="'Edit workflow ' + workflowDisplayName(plan)"
+                                        @click="openExecutionPlanCreate(plan)">Edit</button>
                             </div>
                             <div class="execution-plan-card-meta execution-plan-card-meta-footer">
                                 <span class="provider-badge mono" x-text="'version: v' + plan.version"></span>

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -612,8 +612,292 @@
     <p class="empty-state" x-show="displayModels.length > 0 && filteredDisplayModels.length === 0 && modelFilter">No models match your filter.</p>
 </div>
 
+<!-- Workflows Page -->
+<div x-show="page==='workflows'">
+    <div class="page-header">
+        <div>
+            <h2>Workflows</h2>
+            <p class="execution-plan-page-note">Active workflows are matched with most-specific-wins precedence: provider + model, then provider, then global.</p>
+        </div>
+        <div class="page-header-controls">
+            <button type="button" class="pagination-btn pagination-btn-primary" x-show="executionPlansAvailable" @click="openExecutionPlanCreate()">Create Workflow</button>
+        </div>
+    </div>
+
+    <div class="alert alert-warning" x-show="authError">
+        Authentication required. Enter your API key in the sidebar to view data.
+    </div>
+    <div class="alert alert-warning" x-show="!executionPlansAvailable && !authError">
+        Workflows feature is unavailable.
+    </div>
+    <div class="alert alert-warning" x-show="executionPlanError && !authError" x-text="executionPlanError"></div>
+    <div class="alert alert-success" x-show="executionPlanNotice" x-text="executionPlanNotice"></div>
+
+    <div class="table-toolbar" x-show="executionPlansAvailable">
+        <div class="table-toolbar-main">
+            <input type="text" placeholder="Filter by scope, name, hash, or guardrail..." x-model="executionPlanFilter" class="filter-input">
+        </div>
+        <div class="table-toolbar-actions">
+            <span class="model-count" x-text="filteredExecutionPlans.length + ' active scopes'"></span>
+        </div>
+    </div>
+
+    <div class="execution-plans-layout" :class="{ 'is-editor-open': executionPlanFormOpen }">
+        <section class="model-alias-editor execution-plan-editor" x-show="executionPlanFormOpen">
+            <form class="alias-form" @submit.prevent="submitExecutionPlanForm()">
+                <div class="aliases-editor-header">
+                    <div>
+                        <div class="execution-plan-heading">
+                            <h3>Workflow</h3>
+                            <span class="execution-plan-help" title="Create immutable version. Submitting activates it for the selected scope.">?</span>
+                        </div>
+                    </div>
+                    <button type="button" class="table-action-btn alias-close-btn" aria-label="Close workflow editor" @click="closeExecutionPlanForm()">
+                        <span aria-hidden="true">X</span>
+                    </button>
+                </div>
+
+                <div class="alert alert-warning" x-show="executionPlanFormError" x-text="executionPlanFormError"></div>
+
+                <div class="alias-form-grid">
+                    <label class="alias-form-field">
+                        <span>Provider</span>
+                        <select class="usage-log-select execution-plan-input" x-model="executionPlanForm.scope_provider" @change="setExecutionPlanProvider(executionPlanForm.scope_provider)">
+                            <option value="">All providers and models</option>
+                            <template x-for="providerType in executionPlanProviderOptions()" :key="providerType">
+                                <option :value="providerType" x-text="providerType"></option>
+                            </template>
+                        </select>
+                    </label>
+
+                    <label class="alias-form-field" x-show="executionPlanForm.scope_provider">
+                        <span>Model</span>
+                        <select class="usage-log-select execution-plan-input" x-model="executionPlanForm.scope_model">
+                            <option value="">All models for provider</option>
+                            <template x-for="modelID in executionPlanModelOptions(executionPlanForm.scope_provider)" :key="executionPlanForm.scope_provider + '-' + modelID">
+                                <option :value="modelID" x-text="modelID"></option>
+                            </template>
+                        </select>
+                    </label>
+
+                    <label class="alias-form-field">
+                        <span>Name</span>
+                        <input type="text" class="filter-input execution-plan-input" placeholder="Optional. Defaults to scope label." x-model="executionPlanForm.name">
+                    </label>
+                </div>
+
+                <p class="alias-form-hint">Leave provider empty to target all providers and models. Select a provider without a model to target all models for that provider.</p>
+                <p class="alias-form-hint">If you leave the name empty, the workflow will display as the matched provider/model scope or “All models”.</p>
+
+                <label class="alias-form-field">
+                    <span>Description</span>
+                    <textarea class="alias-form-textarea" placeholder="Optional operator note for why this version exists." x-model="executionPlanForm.description"></textarea>
+                </label>
+
+                <div class="execution-plan-feature-toggles">
+                    <label class="execution-plan-feature-toggle">
+                        <input type="checkbox" x-model="executionPlanForm.features.cache">
+                        <span>Cache</span>
+                    </label>
+                    <label class="execution-plan-feature-toggle">
+                        <input type="checkbox" x-model="executionPlanForm.features.audit">
+                        <span>Audit</span>
+                    </label>
+                    <label class="execution-plan-feature-toggle">
+                        <input type="checkbox" x-model="executionPlanForm.features.usage">
+                        <span>Usage</span>
+                    </label>
+                    <label class="execution-plan-feature-toggle">
+                        <input type="checkbox" x-model="executionPlanForm.features.guardrails">
+                        <span>Guardrails</span>
+                    </label>
+                </div>
+
+                <div class="execution-plan-guardrail-editor" x-show="executionPlanForm.features.guardrails">
+                    <div class="execution-plan-section-head">
+                        <div>
+                            <h4>Guardrail Steps</h4>
+                            <p class="alias-form-hint">Guardrails in the same numeric step run together. Later steps wait for earlier ones to finish.</p>
+                        </div>
+                        <button type="button" class="table-action-btn" @click="addExecutionPlanGuardrailStep()">Add Step</button>
+                    </div>
+
+                    <div class="alert alert-warning" x-show="guardrailRefs.length === 0">
+                        No named guardrails are currently registered on this deployment. You can still draft a plan, but guardrail-backed creation may be rejected.
+                    </div>
+
+                    <div class="execution-plan-guardrail-list-editor" x-show="executionPlanForm.guardrails.length > 0">
+                        <template x-for="(step, index) in executionPlanForm.guardrails" :key="'execution-plan-form-guardrail-' + index">
+                            <div class="execution-plan-guardrail-row">
+                                <input type="text" class="filter-input execution-plan-input" list="execution-plan-guardrail-options" placeholder="Guardrail ref" x-model="step.ref">
+                                <input type="number" class="filter-input execution-plan-step-input" min="0" step="10" placeholder="Step" x-model.number="step.step">
+                                <button type="button" class="table-action-btn table-action-btn-danger" @click="removeExecutionPlanGuardrailStep(index)">Remove</button>
+                            </div>
+                        </template>
+                    </div>
+
+                    <p class="alias-form-hint" x-show="executionPlanForm.guardrails.length === 0">No guardrail steps configured yet.</p>
+                </div>
+
+                <div class="alias-form-actions">
+                    <button type="button" class="pagination-btn" @click="closeExecutionPlanForm()">Cancel</button>
+                    <button type="submit" class="pagination-btn pagination-btn-primary" :disabled="executionPlanSubmitting" x-text="executionPlanSubmitting ? 'Creating...' : 'Create Workflow'"></button>
+                </div>
+            </form>
+        </section>
+
+        <section class="execution-plans-list">
+            <p class="empty-state" x-show="executionPlansLoading && !authError">Loading workflows...</p>
+
+            <div class="execution-plan-card-grid" x-show="filteredExecutionPlans.length > 0">
+                <template x-for="plan in filteredExecutionPlans" :key="plan.id">
+                    <article class="execution-plan-card">
+                        <div class="execution-plan-card-head">
+                            <div>
+                                <p class="alias-form-kicker" x-text="planScopeTypeLabel(plan)"></p>
+                                <h3 x-text="workflowDisplayName(plan)"></h3>
+                            </div>
+                            <div class="execution-plan-card-badges">
+                                <span class="provider-badge" x-text="planScopeLabel(plan)"></span>
+                            </div>
+                        </div>
+
+                        <p class="execution-plan-card-description" x-show="plan.description" x-text="plan.description"></p>
+
+                        <!-- Execution Pipeline -->
+                        <div class="exec-pipeline">
+                            <div class="exec-pipeline-row">
+
+                                <!-- Left half: Client + optional steps + growing connector -->
+                                <div class="ep-left">
+                                    <div class="ep-node ep-node-endpoint">
+                                        <div class="ep-node-icon">
+                                            <svg viewBox="0 0 24 24"><circle cx="12" cy="7" r="4"/><path d="M4 21v-1a8 8 0 0 1 16 0v1"/></svg>
+                                        </div>
+                                        <span class="ep-node-label">Client</span>
+                                    </div>
+
+                                    <!-- Guardrails step (optional) -->
+                                    <div class="ep-step" x-show="epHasGuardrails(plan)">
+                                        <div class="ep-conn"></div>
+                                        <div class="ep-node ep-node-guardrails">
+                                            <div class="ep-node-icon">
+                                                <svg viewBox="0 0 24 24"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+                                            </div>
+                                            <span class="ep-node-label">Guardrails</span>
+                                            <span class="ep-node-sub" x-text="epGuardrailLabel(plan)"></span>
+                                        </div>
+                                    </div>
+
+                                    <!-- Cache step (optional) -->
+                                    <div class="ep-step" x-show="epHasCache(plan)">
+                                        <div class="ep-conn"></div>
+                                        <div class="ep-node ep-node-cache">
+                                            <div class="ep-node-icon">
+                                                <svg viewBox="0 0 24 24"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg>
+                                            </div>
+                                            <span class="ep-node-label">Cache</span>
+                                        </div>
+                                    </div>
+
+                                    <!-- Growing connector → AI -->
+                                    <div class="ep-conn ep-conn-grow"></div>
+                                </div>
+
+                                <!-- AI node (centered by equal halves) -->
+                                <div class="ep-node ep-node-ai">
+                                    <div class="ep-node-icon">
+                                        <svg viewBox="0 0 24 24"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+                                    </div>
+                                    <span class="ep-node-label" x-text="epAiLabel(plan, null)"></span>
+                                    <span class="ep-node-sub" x-show="epAiSublabel(plan, null)" x-text="epAiSublabel(plan, null)"></span>
+                                </div>
+
+                                <!-- Right half: growing connector + Response + async nodes -->
+                                <div class="ep-right">
+                                    <div class="ep-conn ep-conn-grow"></div>
+                                    <div class="ep-node ep-node-endpoint">
+                                        <div class="ep-node-icon">
+                                            <svg viewBox="0 0 24 24"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
+                                        </div>
+                                        <span class="ep-node-label">Response</span>
+                                    </div>
+
+                                    <!-- Async nodes — fire after response is returned -->
+                                    <div class="ep-step" x-show="epHasAudit(plan)">
+                                        <div class="ep-conn ep-conn-async"></div>
+                                        <div class="ep-node ep-node-async ep-node-async-audit">
+                                            <div class="ep-node-icon">
+                                                <svg viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
+                                            </div>
+                                            <span class="ep-node-label">Audit Log</span>
+                                        </div>
+                                    </div>
+                                    <div class="ep-step" x-show="epHasUsage(plan)">
+                                        <div class="ep-conn ep-conn-async"></div>
+                                        <div class="ep-node ep-node-async ep-node-async-usage">
+                                            <div class="ep-node-icon">
+                                                <svg viewBox="0 0 24 24"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
+                                            </div>
+                                            <span class="ep-node-label">Usage</span>
+                                        </div>
+                                    </div>
+                                </div>
+
+                            </div>
+                        </div>
+
+                        <div class="execution-plan-guardrails">
+                            <div class="execution-plan-section-head">
+                                <h4>Guardrails</h4>
+                                <span class="provider-badge" x-text="planGuardrails(plan).length ? planGuardrails(plan).length + ' steps' : 'None'"></span>
+                            </div>
+                            <div class="execution-plan-guardrail-list" x-show="planGuardrails(plan).length > 0">
+                                <template x-for="(step, stepIndex) in planGuardrails(plan)" :key="plan.id + '-guardrail-' + stepIndex">
+                                    <div class="execution-plan-guardrail-item">
+                                        <span class="mono" x-text="step.ref"></span>
+                                        <span class="provider-badge" x-text="'step ' + step.step"></span>
+                                    </div>
+                                </template>
+                            </div>
+                            <p class="alias-form-hint" x-show="planGuardrails(plan).length === 0">No guardrails configured for this plan.</p>
+                        </div>
+
+                        <div class="execution-plan-card-footer">
+                            <div class="alias-actions-cell">
+                                <button type="button"
+                                        class="table-action-btn table-action-btn-danger"
+                                        :disabled="executionPlanDeactivatingID === plan.id || !canDeactivateExecutionPlan(plan)"
+                                        :title="canDeactivateExecutionPlan(plan) ? 'Deactivate active workflow' : 'The global workflow cannot be deactivated.'"
+                                        @click="deactivateExecutionPlan(plan)"
+                                        x-text="executionPlanDeactivatingID === plan.id ? 'Deactivating...' : 'Deactivate'"></button>
+                                <button type="button" class="table-action-btn" @click="openExecutionPlanCreate(plan)">Edit</button>
+                            </div>
+                            <div class="execution-plan-card-meta execution-plan-card-meta-footer">
+                                <span class="provider-badge mono" x-text="'version: v' + plan.version"></span>
+                                <span class="provider-badge mono" x-text="'created: ' + formatTimestamp(plan.created_at)"></span>
+                                <span class="provider-badge mono" x-text="'hash: ' + shortHash(plan.plan_hash)"></span>
+                            </div>
+                        </div>
+                    </article>
+                </template>
+            </div>
+
+            <p class="empty-state" x-show="executionPlans.length === 0 && !executionPlansLoading && !authError && executionPlansAvailable">No active workflows found.</p>
+            <p class="empty-state" x-show="executionPlans.length > 0 && filteredExecutionPlans.length === 0 && !executionPlansLoading">No workflows match your filter.</p>
+        </section>
+
+    </div>
+
+    <datalist id="execution-plan-guardrail-options">
+        <template x-for="guardrailRef in guardrailRefs" :key="guardrailRef">
+            <option :value="guardrailRef"></option>
+        </template>
+    </datalist>
+</div>
+
 <!-- Audit Logs Page -->
-<div x-show="page==='audit'">
+<div x-show="page==='audit-logs'">
     <div class="page-header">
         <h2>Audit Logs</h2>
         <div class="page-header-controls">
@@ -700,6 +984,58 @@
                             <span class="provider-badge mono" x-show="entry.client_ip" x-text="'ip: ' + entry.client_ip"></span>
                             <span class="provider-badge" x-show="entry.stream">stream</span>
                             <span class="provider-badge" x-show="entry.error_type" x-text="entry.error_type"></span>
+                        </div>
+
+                        <!-- Execution Pipeline (runtime view) -->
+                        <div class="exec-pipeline">
+                            <div class="exec-pipeline-row">
+
+                                <!-- Left half: Client + optional steps + growing connector -->
+                                <div class="ep-left">
+                                    <div class="ep-node ep-node-endpoint">
+                                        <div class="ep-node-icon">
+                                            <svg viewBox="0 0 24 24"><circle cx="12" cy="7" r="4"/><path d="M4 21v-1a8 8 0 0 1 16 0v1"/></svg>
+                                        </div>
+                                        <span class="ep-node-label">Client</span>
+                                    </div>
+
+                                    <!-- Cache step — shown when runtime has cache data -->
+                                    <div class="ep-step" x-show="epShowCacheStep(null, epRuntimeFromEntry(entry))">
+                                        <div class="ep-conn" :class="epCacheConnClass(epRuntimeFromEntry(entry))"></div>
+                                        <div class="ep-node ep-node-cache" :class="epCacheNodeClass(epRuntimeFromEntry(entry))">
+                                            <div class="ep-node-icon">
+                                                <svg viewBox="0 0 24 24"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg>
+                                            </div>
+                                            <span class="ep-node-label">Cache</span>
+                                            <span class="ep-node-badge" x-show="epCacheStatusLabel(epRuntimeFromEntry(entry))" x-text="epCacheStatusLabel(epRuntimeFromEntry(entry))"></span>
+                                        </div>
+                                    </div>
+
+                                    <!-- Growing connector → AI -->
+                                    <div class="ep-conn ep-conn-grow" :class="epAiConnClass(epRuntimeFromEntry(entry))"></div>
+                                </div>
+
+                                <!-- AI node (centered by equal halves) -->
+                                <div class="ep-node ep-node-ai" :class="epAiNodeClass(epRuntimeFromEntry(entry))">
+                                    <div class="ep-node-icon">
+                                        <svg viewBox="0 0 24 24"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+                                    </div>
+                                    <span class="ep-node-label" x-text="epAiLabel(null, epRuntimeFromEntry(entry))"></span>
+                                    <span class="ep-node-sub" x-show="epAiSublabel(null, epRuntimeFromEntry(entry))" x-text="epAiSublabel(null, epRuntimeFromEntry(entry))"></span>
+                                </div>
+
+                                <!-- Right half: growing connector + Response -->
+                                <div class="ep-right">
+                                    <div class="ep-conn ep-conn-grow"></div>
+                                    <div class="ep-node ep-node-endpoint">
+                                        <div class="ep-node-icon">
+                                            <svg viewBox="0 0 24 24"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
+                                        </div>
+                                        <span class="ep-node-label">Response</span>
+                                    </div>
+                                </div>
+
+                            </div>
                         </div>
 
                         <div class="audit-request-response">

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -635,7 +635,7 @@
 
     <div class="table-toolbar" x-show="executionPlansAvailable">
         <div class="table-toolbar-main">
-            <input type="text" placeholder="Filter by scope, name, hash, or guardrail..." x-model="executionPlanFilter" class="filter-input">
+            <input type="text" placeholder="Filter by scope, name, hash, or guardrail..." x-model="executionPlanFilter" class="filter-input" aria-label="Filter workflows by scope, name, hash, or guardrail">
         </div>
         <div class="table-toolbar-actions">
             <span class="model-count" x-text="filteredExecutionPlans.length + ' active scopes'"></span>
@@ -729,8 +729,8 @@
                     <div class="execution-plan-guardrail-list-editor" x-show="executionPlanForm.guardrails.length > 0">
                         <template x-for="(step, index) in executionPlanForm.guardrails" :key="'execution-plan-form-guardrail-' + index">
                             <div class="execution-plan-guardrail-row">
-                                <input type="text" class="filter-input execution-plan-input" list="execution-plan-guardrail-options" placeholder="Guardrail ref" x-model="step.ref">
-                                <input type="number" class="filter-input execution-plan-step-input" min="0" step="10" placeholder="Step" x-model.number="step.step">
+                                <input type="text" class="filter-input execution-plan-input" list="execution-plan-guardrail-options" placeholder="Guardrail ref" x-model="step.ref" aria-label="Guardrail reference">
+                                <input type="number" class="filter-input execution-plan-step-input" min="0" step="10" placeholder="Step" x-model.number="step.step" aria-label="Guardrail step">
                                 <button type="button" class="table-action-btn table-action-btn-danger" @click="removeExecutionPlanGuardrailStep(index)">Remove</button>
                             </div>
                         </template>
@@ -785,7 +785,7 @@
                                                 <svg viewBox="0 0 24 24"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
                                             </div>
                                             <span class="ep-node-label">Guardrails</span>
-                                            <span class="ep-node-sub" x-text="epGuardrailLabel(plan)"></span>
+                                            <span class="ep-node-sub" x-show="epGuardrailLabel(plan)" x-text="epGuardrailLabel(plan)"></span>
                                         </div>
                                     </div>
 
@@ -806,9 +806,6 @@
 
                                 <!-- AI node (centered by equal halves) -->
                                 <div class="ep-node ep-node-ai">
-                                    <div class="ep-node-icon">
-                                        <svg viewBox="0 0 24 24"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
-                                    </div>
                                     <span class="ep-node-label" x-text="epAiLabel(plan, null)"></span>
                                     <span class="ep-node-sub" x-show="epAiSublabel(plan, null)" x-text="epAiSublabel(plan, null)"></span>
                                 </div>
@@ -1022,9 +1019,6 @@
 
                                 <!-- AI node (centered by equal halves) -->
                                 <div class="ep-node ep-node-ai" :class="epAiNodeClass(epRuntimeFromEntry(entry))">
-                                    <div class="ep-node-icon">
-                                        <svg viewBox="0 0 24 24"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
-                                    </div>
                                     <span class="ep-node-label" x-text="epAiLabel(null, epRuntimeFromEntry(entry))"></span>
                                     <span class="ep-node-sub" x-show="epAiSublabel(null, epRuntimeFromEntry(entry))" x-text="epAiSublabel(null, epRuntimeFromEntry(entry))"></span>
                                 </div>

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -729,8 +729,8 @@
                     <div class="execution-plan-guardrail-list-editor" x-show="executionPlanForm.guardrails.length > 0">
                         <template x-for="(step, index) in executionPlanForm.guardrails" :key="'execution-plan-form-guardrail-' + index">
                             <div class="execution-plan-guardrail-row">
-                                <input type="text" class="filter-input execution-plan-input" list="execution-plan-guardrail-options" placeholder="Guardrail ref" x-model="step.ref" aria-label="Guardrail reference">
-                                <input type="number" class="filter-input execution-plan-step-input" min="0" step="10" placeholder="Step" x-model.number="step.step" aria-label="Guardrail step">
+                                <input type="text" class="filter-input execution-plan-input" list="execution-plan-guardrail-options" placeholder="Guardrail ref" x-model="step.ref" :aria-label="'Guardrail reference ' + (index + 1)">
+                                <input type="number" class="filter-input execution-plan-step-input" min="0" step="10" placeholder="Step" x-model.number="step.step" :aria-label="'Guardrail step ' + (index + 1)">
                                 <button type="button" class="table-action-btn table-action-btn-danger" @click="removeExecutionPlanGuardrailStep(index)">Remove</button>
                             </div>
                         </template>

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -813,7 +813,7 @@
                                     <span class="ep-node-sub" x-show="epAiSublabel(plan, null)" x-text="epAiSublabel(plan, null)"></span>
                                 </div>
 
-                                <!-- Right half: growing connector + Response + async nodes -->
+                                <!-- Right half: growing connector + Response -->
                                 <div class="ep-right">
                                     <div class="ep-conn ep-conn-grow"></div>
                                     <div class="ep-node ep-node-endpoint">
@@ -822,29 +822,34 @@
                                         </div>
                                         <span class="ep-node-label">Response</span>
                                     </div>
-
-                                    <!-- Async nodes — fire after response is returned -->
-                                    <div class="ep-step" x-show="epHasAudit(plan)">
-                                        <div class="ep-conn ep-conn-async"></div>
-                                        <div class="ep-node ep-node-async ep-node-async-audit">
-                                            <div class="ep-node-icon">
-                                                <svg viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
-                                            </div>
-                                            <span class="ep-node-label">Audit Log</span>
-                                        </div>
-                                    </div>
-                                    <div class="ep-step" x-show="epHasUsage(plan)">
-                                        <div class="ep-conn ep-conn-async"></div>
-                                        <div class="ep-node ep-node-async ep-node-async-usage">
-                                            <div class="ep-node-icon">
-                                                <svg viewBox="0 0 24 24"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
-                                            </div>
-                                            <span class="ep-node-label">Usage</span>
-                                        </div>
-                                    </div>
                                 </div>
 
                             </div>
+
+                            <!-- Async section — inline row, branch turn, then label on the right -->
+                            <div class="ep-async-section" x-show="epHasAsync(plan)">
+                                <div class="ep-async-row">
+                                    <!-- Usage on the left (visual), Audit Log on the right -->
+                                    <div class="ep-node ep-node-async ep-node-async-usage" x-show="epHasUsage(plan)">
+                                        <div class="ep-node-icon">
+                                            <svg viewBox="0 0 24 24"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
+                                        </div>
+                                        <span class="ep-node-label">Usage</span>
+                                    </div>
+                                    <div class="ep-step" x-show="epHasUsage(plan) && epHasAudit(plan)">
+                                        <div class="ep-conn ep-conn-async"></div>
+                                    </div>
+                                    <div class="ep-node ep-node-async ep-node-async-audit" x-show="epHasAudit(plan)">
+                                        <div class="ep-node-icon">
+                                            <svg viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
+                                        </div>
+                                        <span class="ep-node-label">Audit Log</span>
+                                    </div>
+                                </div>
+                                <div class="ep-async-turn"></div>
+                                <span class="ep-async-label">Async</span>
+                            </div>
+
                         </div>
 
                         <div class="execution-plan-guardrails">

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -771,7 +771,7 @@
                                 <!-- Left half: Client + optional steps + growing connector -->
                                 <div class="ep-left">
                                     <div class="ep-node ep-node-endpoint">
-                                        <div class="ep-node-icon">
+                                        <div class="ep-node-icon ep-node-icon-endpoint">
                                             <svg viewBox="0 0 24 24"><circle cx="12" cy="7" r="4"/><path d="M4 21v-1a8 8 0 0 1 16 0v1"/></svg>
                                         </div>
                                         <span class="ep-node-label">Client</span>
@@ -817,7 +817,7 @@
                                 <div class="ep-right">
                                     <div class="ep-conn ep-conn-grow"></div>
                                     <div class="ep-node ep-node-endpoint">
-                                        <div class="ep-node-icon">
+                                        <div class="ep-node-icon ep-node-icon-endpoint">
                                             <svg viewBox="0 0 24 24"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
                                         </div>
                                         <span class="ep-node-label">Response</span>
@@ -998,7 +998,7 @@
                                 <!-- Left half: Client + optional steps + growing connector -->
                                 <div class="ep-left">
                                     <div class="ep-node ep-node-endpoint">
-                                        <div class="ep-node-icon">
+                                        <div class="ep-node-icon ep-node-icon-endpoint">
                                             <svg viewBox="0 0 24 24"><circle cx="12" cy="7" r="4"/><path d="M4 21v-1a8 8 0 0 1 16 0v1"/></svg>
                                         </div>
                                         <span class="ep-node-label">Client</span>
@@ -1033,7 +1033,7 @@
                                 <div class="ep-right">
                                     <div class="ep-conn ep-conn-grow"></div>
                                     <div class="ep-node ep-node-endpoint">
-                                        <div class="ep-node-icon">
+                                        <div class="ep-node-icon ep-node-icon-endpoint">
                                             <svg viewBox="0 0 24 24"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
                                         </div>
                                         <span class="ep-node-label">Response</span>

--- a/internal/admin/dashboard/templates/layout.html
+++ b/internal/admin/dashboard/templates/layout.html
@@ -40,7 +40,11 @@
                     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z"/></svg>
                     <span>Models</span>
                 </a>
-                <a href="/admin/dashboard/audit" class="nav-item" :class="{ active: page === 'audit' }" title="Audit Logs" @click.prevent="navigate('audit')">
+                <a href="/admin/dashboard/workflows" class="nav-item" :class="{ active: page === 'workflows' }" title="Workflows" @click.prevent="navigate('workflows')">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 6h16M4 12h16M4 18h10"/><path d="M17 15l3 3-3 3"/></svg>
+                    <span>Workflows</span>
+                </a>
+                <a href="/admin/dashboard/audit-logs" class="nav-item" :class="{ active: page === 'audit-logs' }" title="Audit Logs" @click.prevent="navigate('audit-logs')">
                     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 6v6l4 2"/><circle cx="12" cy="12" r="9"/><path d="M9 3h6"/></svg>
                     <span>Audit Logs</span>
                 </a>
@@ -87,6 +91,7 @@
     <script src="/admin/static/js/modules/usage.js"></script>
     <script src="/admin/static/js/modules/audit-list.js"></script>
     <script src="/admin/static/js/modules/aliases.js"></script>
+    <script src="/admin/static/js/modules/execution-plans.js"></script>
     <script src="/admin/static/js/modules/conversation-drawer.js"></script>
     <script src="/admin/static/js/modules/contribution-calendar.js"></script>
     <script src="/admin/static/js/modules/charts.js"></script>

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -16,6 +16,8 @@ import (
 	"gomodel/internal/aliases"
 	"gomodel/internal/auditlog"
 	"gomodel/internal/core"
+	"gomodel/internal/executionplans"
+	"gomodel/internal/guardrails"
 	"gomodel/internal/providers"
 	"gomodel/internal/usage"
 )
@@ -26,6 +28,8 @@ type Handler struct {
 	auditReader auditlog.Reader
 	registry    *providers.ModelRegistry
 	aliases     *aliases.Service
+	plans       *executionplans.Service
+	guardrails  *guardrails.Registry
 }
 
 // Option configures the admin API handler.
@@ -42,6 +46,20 @@ func WithAuditReader(reader auditlog.Reader) Option {
 func WithAliases(service *aliases.Service) Option {
 	return func(h *Handler) {
 		h.aliases = service
+	}
+}
+
+// WithExecutionPlans enables execution-plan administration endpoints.
+func WithExecutionPlans(service *executionplans.Service) Option {
+	return func(h *Handler) {
+		h.plans = service
+	}
+}
+
+// WithGuardrailsRegistry enables listing valid guardrail references for plan authoring.
+func WithGuardrailsRegistry(registry *guardrails.Registry) Option {
+	return func(h *Handler) {
+		h.guardrails = registry
 	}
 }
 
@@ -515,9 +533,25 @@ type upsertAliasRequest struct {
 	Enabled        *bool  `json:"enabled,omitempty"`
 }
 
-func (h *Handler) aliasesUnavailableError() error {
-	return core.NewInvalidRequestErrorWithStatus(http.StatusServiceUnavailable, "aliases feature is unavailable", nil).
+type createExecutionPlanRequest struct {
+	ScopeProvider string                 `json:"scope_provider,omitempty"`
+	ScopeModel    string                 `json:"scope_model,omitempty"`
+	Name          string                 `json:"name"`
+	Description   string                 `json:"description,omitempty"`
+	Payload       executionplans.Payload `json:"plan_payload"`
+}
+
+func featureUnavailableError(message string) error {
+	return core.NewInvalidRequestErrorWithStatus(http.StatusServiceUnavailable, message, nil).
 		WithCode("feature_unavailable")
+}
+
+func (h *Handler) aliasesUnavailableError() error {
+	return featureUnavailableError("aliases feature is unavailable")
+}
+
+func (h *Handler) executionPlansUnavailableError() error {
+	return featureUnavailableError("execution plans feature is unavailable")
 }
 
 func aliasWriteError(err error) error {
@@ -525,6 +559,16 @@ func aliasWriteError(err error) error {
 		return nil
 	}
 	if aliases.IsValidationError(err) {
+		return core.NewInvalidRequestError(err.Error(), err)
+	}
+	return err
+}
+
+func executionPlanWriteError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if executionplans.IsValidationError(err) {
 		return core.NewInvalidRequestError(err.Error(), err)
 	}
 	return err
@@ -601,6 +645,109 @@ func (h *Handler) DeleteAlias(c *echo.Context) error {
 		return handleError(c, aliasWriteError(err))
 	}
 	return c.NoContent(http.StatusNoContent)
+}
+
+// ListExecutionPlans handles GET /admin/api/v1/execution-plans
+func (h *Handler) ListExecutionPlans(c *echo.Context) error {
+	if h.plans == nil {
+		return handleError(c, h.executionPlansUnavailableError())
+	}
+
+	views, err := h.plans.ListViews(c.Request().Context())
+	if err != nil {
+		return handleError(c, err)
+	}
+	if views == nil {
+		views = []executionplans.View{}
+	}
+	return c.JSON(http.StatusOK, views)
+}
+
+// ListExecutionPlanGuardrails handles GET /admin/api/v1/execution-plans/guardrails
+func (h *Handler) ListExecutionPlanGuardrails(c *echo.Context) error {
+	if h.guardrails == nil {
+		return c.JSON(http.StatusOK, []string{})
+	}
+
+	return c.JSON(http.StatusOK, h.guardrails.Names())
+}
+
+// CreateExecutionPlan handles POST /admin/api/v1/execution-plans
+func (h *Handler) CreateExecutionPlan(c *echo.Context) error {
+	if h.plans == nil {
+		return handleError(c, h.executionPlansUnavailableError())
+	}
+
+	var req createExecutionPlanRequest
+	if err := c.Bind(&req); err != nil {
+		return handleError(c, core.NewInvalidRequestError("invalid request body: "+err.Error(), err))
+	}
+
+	if err := h.validateExecutionPlanGuardrails(req.Payload); err != nil {
+		return handleError(c, err)
+	}
+
+	version, err := h.plans.Create(c.Request().Context(), executionplans.CreateInput{
+		Scope: executionplans.Scope{
+			Provider: req.ScopeProvider,
+			Model:    req.ScopeModel,
+		},
+		Activate:    true,
+		Name:        req.Name,
+		Description: req.Description,
+		Payload:     req.Payload,
+	})
+	if err != nil {
+		return handleError(c, executionPlanWriteError(err))
+	}
+	if version == nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+	return c.JSON(http.StatusCreated, version)
+}
+
+// DeactivateExecutionPlan handles POST /admin/api/v1/execution-plans/:id/deactivate
+func (h *Handler) DeactivateExecutionPlan(c *echo.Context) error {
+	if h.plans == nil {
+		return handleError(c, h.executionPlansUnavailableError())
+	}
+
+	id := strings.TrimSpace(c.Param("id"))
+	if id == "" {
+		return handleError(c, core.NewInvalidRequestError("execution plan id is required", nil))
+	}
+
+	if err := h.plans.Deactivate(c.Request().Context(), id); err != nil {
+		if errors.Is(err, executionplans.ErrNotFound) {
+			return handleError(c, core.NewNotFoundError("workflow not found: "+id))
+		}
+		return handleError(c, executionPlanWriteError(err))
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+func (h *Handler) validateExecutionPlanGuardrails(payload executionplans.Payload) error {
+	if !payload.Features.Guardrails || len(payload.Guardrails) == 0 {
+		return nil
+	}
+	if h.guardrails == nil {
+		return featureUnavailableError("guardrail registry is unavailable for plan authoring")
+	}
+
+	known := make(map[string]struct{}, h.guardrails.Len())
+	for _, name := range h.guardrails.Names() {
+		known[name] = struct{}{}
+	}
+	for _, step := range payload.Guardrails {
+		ref := strings.TrimSpace(step.Ref)
+		if ref == "" {
+			continue
+		}
+		if _, ok := known[ref]; !ok {
+			return core.NewInvalidRequestError("unknown guardrail ref: "+ref, nil)
+		}
+	}
+	return nil
 }
 
 func decodeAliasPathName(raw string) (string, error) {

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -683,6 +683,10 @@ func (h *Handler) CreateExecutionPlan(c *echo.Context) error {
 		return handleError(c, core.NewInvalidRequestError("invalid request body: "+err.Error(), err))
 	}
 
+	if err := h.validateExecutionPlanScope(req.ScopeProvider, req.ScopeModel); err != nil {
+		return handleError(c, err)
+	}
+
 	if err := h.validateExecutionPlanGuardrails(req.Payload); err != nil {
 		return handleError(c, err)
 	}
@@ -748,6 +752,34 @@ func (h *Handler) validateExecutionPlanGuardrails(payload executionplans.Payload
 		}
 	}
 	return nil
+}
+
+func (h *Handler) validateExecutionPlanScope(scopeProvider, scopeModel string) error {
+	scopeProvider = strings.TrimSpace(scopeProvider)
+	scopeModel = strings.TrimSpace(scopeModel)
+
+	if scopeProvider == "" {
+		if scopeModel != "" {
+			return core.NewInvalidRequestError("scope_model requires scope_provider", nil)
+		}
+		return nil
+	}
+	if h.registry == nil {
+		return core.NewInvalidRequestError("provider registry is unavailable for workflow scope validation", nil)
+	}
+	if !slices.Contains(h.registry.ProviderTypes(), scopeProvider) {
+		return core.NewInvalidRequestError("unknown provider type: "+scopeProvider, nil)
+	}
+	if scopeModel == "" {
+		return nil
+	}
+
+	for _, model := range h.registry.ListModelsWithProvider() {
+		if model.ProviderType == scopeProvider && model.Model.ID == scopeModel {
+			return nil
+		}
+	}
+	return core.NewInvalidRequestError("unknown model for provider "+scopeProvider+": "+scopeModel, nil)
 }
 
 func decodeAliasPathName(raw string) (string, error) {

--- a/internal/admin/handler_executionplans_test.go
+++ b/internal/admin/handler_executionplans_test.go
@@ -1,0 +1,603 @@
+package admin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+
+	"gomodel/internal/core"
+	"gomodel/internal/executionplans"
+	"gomodel/internal/guardrails"
+	"gomodel/internal/responsecache"
+)
+
+type executionPlanTestStore struct {
+	versions []executionplans.Version
+}
+
+func (s *executionPlanTestStore) ListActive(context.Context) ([]executionplans.Version, error) {
+	result := make([]executionplans.Version, 0, len(s.versions))
+	for _, version := range s.versions {
+		if version.Active {
+			result = append(result, version)
+		}
+	}
+	return result, nil
+}
+
+func (s *executionPlanTestStore) Get(_ context.Context, id string) (*executionplans.Version, error) {
+	for _, version := range s.versions {
+		if version.ID == id {
+			copy := version
+			return &copy, nil
+		}
+	}
+	return nil, executionplans.ErrNotFound
+}
+
+func (s *executionPlanTestStore) Create(_ context.Context, input executionplans.CreateInput) (*executionplans.Version, error) {
+	var scopeKey string
+	switch {
+	case input.Scope.Provider == "":
+		scopeKey = "global"
+	case input.Scope.Model == "":
+		scopeKey = "provider:" + input.Scope.Provider
+	default:
+		scopeKey = "provider_model:" + input.Scope.Provider + ":" + input.Scope.Model
+	}
+	planHash := "hash-created"
+
+	version := executionplans.Version{
+		ID:          "plan-created",
+		Scope:       input.Scope,
+		ScopeKey:    scopeKey,
+		Version:     len(s.versions) + 1,
+		Active:      input.Activate,
+		Name:        input.Name,
+		Description: input.Description,
+		Payload:     input.Payload,
+		PlanHash:    planHash,
+	}
+
+	if input.Activate {
+		for i := range s.versions {
+			if s.versions[i].ScopeKey == scopeKey {
+				s.versions[i].Active = false
+			}
+		}
+	}
+
+	s.versions = append(s.versions, version)
+	return &version, nil
+}
+
+func (s *executionPlanTestStore) Deactivate(_ context.Context, id string) error {
+	for i := range s.versions {
+		if s.versions[i].ID == id && s.versions[i].Active {
+			s.versions[i].Active = false
+			return nil
+		}
+	}
+	return executionplans.ErrNotFound
+}
+
+func (s *executionPlanTestStore) Close() error { return nil }
+
+func newExecutionPlanRegistry(t *testing.T) *guardrails.Registry {
+	t.Helper()
+
+	registry := guardrails.NewRegistry()
+	rule, err := guardrails.NewSystemPromptGuardrail("policy-system", guardrails.SystemPromptInject, "be precise")
+	if err != nil {
+		t.Fatalf("NewSystemPromptGuardrail() error = %v", err)
+	}
+	if err := registry.Register(rule, responsecache.GuardrailRuleDescriptor{
+		Type:    "system_prompt",
+		Mode:    string(guardrails.SystemPromptInject),
+		Content: "be precise",
+	}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	return registry
+}
+
+func newExecutionPlanHandler(t *testing.T, store executionplans.Store, registry *guardrails.Registry) *Handler {
+	t.Helper()
+
+	service, err := executionplans.NewService(store, executionplans.NewCompiler(registry))
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	return NewHandler(nil, nil, WithExecutionPlans(service), WithGuardrailsRegistry(registry))
+}
+
+func TestListExecutionPlans(t *testing.T) {
+	store := &executionPlanTestStore{
+		versions: []executionplans.Version{
+			{
+				ID:       "global-plan",
+				Scope:    executionplans.Scope{},
+				ScopeKey: "global",
+				Version:  1,
+				Active:   true,
+				Name:     "global",
+				Payload: executionplans.Payload{
+					SchemaVersion: 1,
+					Features:      executionplans.FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
+				},
+				PlanHash: "hash-global",
+			},
+		},
+	}
+
+	h := newExecutionPlanHandler(t, store, nil)
+	c, rec := newHandlerContext("/admin/api/v1/execution-plans")
+
+	if err := h.ListExecutionPlans(c); err != nil {
+		t.Fatalf("ListExecutionPlans() error = %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	var body []executionplans.View
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(body) != 1 {
+		t.Fatalf("len(body) = %d, want 1", len(body))
+	}
+	if body[0].ScopeType != "global" {
+		t.Fatalf("scope type = %q, want global", body[0].ScopeType)
+	}
+	if body[0].ScopeDisplay != "global" {
+		t.Fatalf("scope display = %q, want global", body[0].ScopeDisplay)
+	}
+	if !body[0].EffectiveFeatures.Cache || !body[0].EffectiveFeatures.Audit || !body[0].EffectiveFeatures.Usage {
+		t.Fatalf("effective features = %+v, want cache/audit/usage enabled", body[0].EffectiveFeatures)
+	}
+}
+
+func TestExecutionPlansEndpointsReturn503WhenServiceUnavailable(t *testing.T) {
+	h := NewHandler(nil, nil)
+	e := echo.New()
+
+	listCtx, listRec := newHandlerContext("/admin/api/v1/execution-plans")
+	if err := h.ListExecutionPlans(listCtx); err != nil {
+		t.Fatalf("ListExecutionPlans() error = %v", err)
+	}
+	if listRec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("list status = %d, want 503", listRec.Code)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/execution-plans", bytes.NewBufferString(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	if err := h.CreateExecutionPlan(c); err != nil {
+		t.Fatalf("CreateExecutionPlan() error = %v", err)
+	}
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("create status = %d, want 503", rec.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/admin/api/v1/execution-plans/test-plan/deactivate", nil)
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec)
+	c.SetPath("/admin/api/v1/execution-plans/:id/deactivate")
+	c.SetPathValues(echo.PathValues{{Name: "id", Value: "test-plan"}})
+	if err := h.DeactivateExecutionPlan(c); err != nil {
+		t.Fatalf("DeactivateExecutionPlan() error = %v", err)
+	}
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("deactivate status = %d, want 503", rec.Code)
+	}
+}
+
+func TestListExecutionPlanGuardrails(t *testing.T) {
+	registry := newExecutionPlanRegistry(t)
+	h := NewHandler(nil, nil, WithGuardrailsRegistry(registry))
+	c, rec := newHandlerContext("/admin/api/v1/execution-plans/guardrails")
+
+	if err := h.ListExecutionPlanGuardrails(c); err != nil {
+		t.Fatalf("ListExecutionPlanGuardrails() error = %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	var body []string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(body) != 1 || body[0] != "policy-system" {
+		t.Fatalf("body = %#v, want [policy-system]", body)
+	}
+}
+
+func TestCreateExecutionPlan(t *testing.T) {
+	store := &executionPlanTestStore{
+		versions: []executionplans.Version{
+			{
+				ID:       "global-plan",
+				Scope:    executionplans.Scope{},
+				ScopeKey: "global",
+				Version:  1,
+				Active:   true,
+				Name:     "global",
+				Payload: executionplans.Payload{
+					SchemaVersion: 1,
+					Features:      executionplans.FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
+				},
+				PlanHash: "hash-global",
+			},
+		},
+	}
+
+	h := newExecutionPlanHandler(t, store, nil)
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/execution-plans", bytes.NewBufferString(`{
+		"scope_provider":"openai",
+		"scope_model":"gpt-5",
+		"name":"openai gpt-5",
+		"description":"provider-model plan",
+		"plan_payload":{
+			"schema_version":1,
+			"features":{"cache":false,"audit":true,"usage":true,"guardrails":false},
+			"guardrails":[]
+		}
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.CreateExecutionPlan(c); err != nil {
+		t.Fatalf("CreateExecutionPlan() error = %v", err)
+	}
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201", rec.Code)
+	}
+
+	var body executionplans.Version
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if body.Scope.Provider != "openai" || body.Scope.Model != "gpt-5" {
+		t.Fatalf("scope = %#v, want openai/gpt-5", body.Scope)
+	}
+	if body.Name != "openai gpt-5" {
+		t.Fatalf("name = %q, want openai gpt-5", body.Name)
+	}
+
+	views, err := h.plans.ListViews(context.Background())
+	if err != nil {
+		t.Fatalf("ListViews() error = %v", err)
+	}
+	if len(views) != 2 {
+		t.Fatalf("len(views) = %d, want 2", len(views))
+	}
+}
+
+func TestCreateExecutionPlan_AllowsEmptyName(t *testing.T) {
+	store := &executionPlanTestStore{
+		versions: []executionplans.Version{
+			{
+				ID:       "global-plan",
+				Scope:    executionplans.Scope{},
+				ScopeKey: "global",
+				Version:  1,
+				Active:   true,
+				Name:     "",
+				Payload: executionplans.Payload{
+					SchemaVersion: 1,
+					Features:      executionplans.FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
+				},
+				PlanHash: "hash-global",
+			},
+		},
+	}
+
+	h := newExecutionPlanHandler(t, store, nil)
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/execution-plans", bytes.NewBufferString(`{
+		"scope_provider":"openai",
+		"scope_model":"gpt-5",
+		"description":"provider-model plan",
+		"plan_payload":{
+			"schema_version":1,
+			"features":{"cache":false,"audit":true,"usage":true,"guardrails":false},
+			"guardrails":[]
+		}
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.CreateExecutionPlan(c); err != nil {
+		t.Fatalf("CreateExecutionPlan() error = %v", err)
+	}
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201", rec.Code)
+	}
+
+	var body executionplans.Version
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if body.Name != "" {
+		t.Fatalf("name = %q, want empty", body.Name)
+	}
+}
+
+func TestCreateExecutionPlanRejectsUnknownGuardrail(t *testing.T) {
+	store := &executionPlanTestStore{
+		versions: []executionplans.Version{
+			{
+				ID:       "global-plan",
+				Scope:    executionplans.Scope{},
+				ScopeKey: "global",
+				Version:  1,
+				Active:   true,
+				Name:     "global",
+				Payload: executionplans.Payload{
+					SchemaVersion: 1,
+					Features:      executionplans.FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
+				},
+				PlanHash: "hash-global",
+			},
+		},
+	}
+	registry := newExecutionPlanRegistry(t)
+	h := newExecutionPlanHandler(t, store, registry)
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/execution-plans", bytes.NewBufferString(`{
+		"name":"guardrail plan",
+		"plan_payload":{
+			"schema_version":1,
+			"features":{"cache":true,"audit":true,"usage":true,"guardrails":true},
+			"guardrails":[{"ref":"missing-guardrail","step":10}]
+		}
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.CreateExecutionPlan(c); err != nil {
+		t.Fatalf("CreateExecutionPlan() error = %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+
+	var body map[string]map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if got := body["error"]["message"]; got != "unknown guardrail ref: missing-guardrail" {
+		t.Fatalf("error message = %v, want unknown guardrail ref", got)
+	}
+}
+
+func TestCreateExecutionPlanReturnsValidationErrors(t *testing.T) {
+	store := &executionPlanTestStore{
+		versions: []executionplans.Version{
+			{
+				ID:       "global-plan",
+				Scope:    executionplans.Scope{},
+				ScopeKey: "global",
+				Version:  1,
+				Active:   true,
+				Name:     "global",
+				Payload: executionplans.Payload{
+					SchemaVersion: 1,
+					Features:      executionplans.FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
+				},
+				PlanHash: "hash-global",
+			},
+		},
+	}
+
+	h := newExecutionPlanHandler(t, store, nil)
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/execution-plans", bytes.NewBufferString(`{
+		"scope_model":"gpt-5",
+		"name":"invalid scope",
+		"plan_payload":{
+			"schema_version":1,
+			"features":{"cache":true,"audit":true,"usage":true,"guardrails":false},
+			"guardrails":[]
+		}
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.CreateExecutionPlan(c); err != nil {
+		t.Fatalf("CreateExecutionPlan() error = %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+
+	var body map[string]map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if got := body["error"]["type"]; got != "invalid_request_error" {
+		t.Fatalf("error type = %v, want invalid_request_error", got)
+	}
+}
+
+func TestExecutionPlanViewReflectsFeatureCaps(t *testing.T) {
+	store := &executionPlanTestStore{
+		versions: []executionplans.Version{
+			{
+				ID:       "global-plan",
+				Scope:    executionplans.Scope{},
+				ScopeKey: "global",
+				Version:  1,
+				Active:   true,
+				Name:     "global",
+				Payload: executionplans.Payload{
+					SchemaVersion: 1,
+					Features:      executionplans.FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: true},
+				},
+				PlanHash: "hash-global",
+			},
+		},
+	}
+
+	service, err := executionplans.NewService(store, executionplans.NewCompilerWithFeatureCaps(nil, core.ExecutionFeatures{
+		Cache:      false,
+		Audit:      true,
+		Usage:      true,
+		Guardrails: false,
+	}))
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	h := NewHandler(nil, nil, WithExecutionPlans(service))
+	c, rec := newHandlerContext("/admin/api/v1/execution-plans")
+
+	if err := h.ListExecutionPlans(c); err != nil {
+		t.Fatalf("ListExecutionPlans() error = %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	var body []executionplans.View
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(body) != 1 {
+		t.Fatalf("len(body) = %d, want 1", len(body))
+	}
+	if body[0].EffectiveFeatures.Cache {
+		t.Fatal("effective cache feature = true, want false")
+	}
+	if body[0].EffectiveFeatures.Guardrails {
+		t.Fatal("effective guardrails feature = true, want false")
+	}
+}
+
+func TestDeactivateExecutionPlan(t *testing.T) {
+	store := &executionPlanTestStore{
+		versions: []executionplans.Version{
+			{
+				ID:       "global-plan",
+				Scope:    executionplans.Scope{},
+				ScopeKey: "global",
+				Version:  1,
+				Active:   true,
+				Name:     "global",
+				Payload: executionplans.Payload{
+					SchemaVersion: 1,
+					Features:      executionplans.FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
+				},
+				PlanHash: "hash-global",
+			},
+			{
+				ID:       "provider-plan",
+				Scope:    executionplans.Scope{Provider: "openai"},
+				ScopeKey: "provider:openai",
+				Version:  1,
+				Active:   true,
+				Name:     "openai",
+				Payload: executionplans.Payload{
+					SchemaVersion: 1,
+					Features:      executionplans.FeatureFlags{Cache: false, Audit: true, Usage: true, Guardrails: false},
+				},
+				PlanHash: "hash-provider",
+			},
+		},
+	}
+
+	h := newExecutionPlanHandler(t, store, nil)
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/execution-plans/provider-plan/deactivate", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/admin/api/v1/execution-plans/:id/deactivate")
+	c.SetPathValues(echo.PathValues{{Name: "id", Value: "provider-plan"}})
+
+	if err := h.DeactivateExecutionPlan(c); err != nil {
+		t.Fatalf("DeactivateExecutionPlan() error = %v", err)
+	}
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rec.Code)
+	}
+
+	views, err := h.plans.ListViews(context.Background())
+	if err != nil {
+		t.Fatalf("ListViews() error = %v", err)
+	}
+	if len(views) != 1 {
+		t.Fatalf("len(views) = %d, want 1", len(views))
+	}
+	if views[0].ID != "global-plan" {
+		t.Fatalf("remaining view = %q, want global-plan", views[0].ID)
+	}
+}
+
+func TestDeactivateExecutionPlanRejectsGlobalWorkflow(t *testing.T) {
+	store := &executionPlanTestStore{
+		versions: []executionplans.Version{
+			{
+				ID:       "global-plan",
+				Scope:    executionplans.Scope{},
+				ScopeKey: "global",
+				Version:  1,
+				Active:   true,
+				Name:     "global",
+				Payload: executionplans.Payload{
+					SchemaVersion: 1,
+					Features:      executionplans.FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
+				},
+				PlanHash: "hash-global",
+			},
+		},
+	}
+
+	h := newExecutionPlanHandler(t, store, nil)
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/execution-plans/global-plan/deactivate", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/admin/api/v1/execution-plans/:id/deactivate")
+	c.SetPathValues(echo.PathValues{{Name: "id", Value: "global-plan"}})
+
+	if err := h.DeactivateExecutionPlan(c); err != nil {
+		t.Fatalf("DeactivateExecutionPlan() error = %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+
+	var body map[string]map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if got := body["error"]["message"]; got != "cannot deactivate the global workflow" {
+		t.Fatalf("error message = %v, want cannot deactivate the global workflow", got)
+	}
+}

--- a/internal/admin/handler_executionplans_test.go
+++ b/internal/admin/handler_executionplans_test.go
@@ -13,11 +13,21 @@ import (
 	"gomodel/internal/core"
 	"gomodel/internal/executionplans"
 	"gomodel/internal/guardrails"
+	"gomodel/internal/providers"
 	"gomodel/internal/responsecache"
 )
 
 type executionPlanTestStore struct {
 	versions []executionplans.Version
+}
+
+type executionPlanErrorEnvelope struct {
+	Error struct {
+		Type    string  `json:"type"`
+		Message string  `json:"message"`
+		Param   *string `json:"param"`
+		Code    *string `json:"code"`
+	} `json:"error"`
 }
 
 func (s *executionPlanTestStore) ListActive(context.Context) ([]executionplans.Version, error) {
@@ -106,10 +116,42 @@ func newExecutionPlanRegistry(t *testing.T) *guardrails.Registry {
 	return registry
 }
 
-func newExecutionPlanHandler(t *testing.T, store executionplans.Store, registry *guardrails.Registry) *Handler {
+func newExecutionPlanModelRegistry(t *testing.T) *providers.ModelRegistry {
 	t.Helper()
 
-	service, err := executionplans.NewService(store, executionplans.NewCompiler(registry))
+	registry := providers.NewModelRegistry()
+	registry.RegisterProviderWithType(&handlerMockProvider{
+		models: &core.ModelsResponse{
+			Object: "list",
+			Data: []core.Model{
+				{ID: "gpt-5", Object: "model", OwnedBy: "openai"},
+			},
+		},
+	}, "openai")
+	if err := registry.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	return registry
+}
+
+func decodeExecutionPlanErrorEnvelope(t *testing.T, body []byte) executionPlanErrorEnvelope {
+	t.Helper()
+
+	var envelope executionPlanErrorEnvelope
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	return envelope
+}
+
+func newExecutionPlanHandler(t *testing.T, store executionplans.Store, registry *guardrails.Registry) *Handler {
+	return newExecutionPlanHandlerWithModelRegistry(t, store, newExecutionPlanModelRegistry(t), registry)
+}
+
+func newExecutionPlanHandlerWithModelRegistry(t *testing.T, store executionplans.Store, modelRegistry *providers.ModelRegistry, guardrailRegistry *guardrails.Registry) *Handler {
+	t.Helper()
+
+	service, err := executionplans.NewService(store, executionplans.NewCompiler(guardrailRegistry))
 	if err != nil {
 		t.Fatalf("NewService() error = %v", err)
 	}
@@ -117,7 +159,7 @@ func newExecutionPlanHandler(t *testing.T, store executionplans.Store, registry 
 		t.Fatalf("Refresh() error = %v", err)
 	}
 
-	return NewHandler(nil, nil, WithExecutionPlans(service), WithGuardrailsRegistry(registry))
+	return NewHandler(nil, modelRegistry, WithExecutionPlans(service), WithGuardrailsRegistry(guardrailRegistry))
 }
 
 func TestListExecutionPlans(t *testing.T) {
@@ -381,12 +423,18 @@ func TestCreateExecutionPlanRejectsUnknownGuardrail(t *testing.T) {
 		t.Fatalf("status = %d, want 400", rec.Code)
 	}
 
-	var body map[string]map[string]any
-	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
-		t.Fatalf("unmarshal response: %v", err)
+	body := decodeExecutionPlanErrorEnvelope(t, rec.Body.Bytes())
+	if body.Error.Type != "invalid_request_error" {
+		t.Fatalf("error type = %q, want invalid_request_error", body.Error.Type)
 	}
-	if got := body["error"]["message"]; got != "unknown guardrail ref: missing-guardrail" {
-		t.Fatalf("error message = %v, want unknown guardrail ref", got)
+	if body.Error.Message != "unknown guardrail ref: missing-guardrail" {
+		t.Fatalf("error message = %q, want unknown guardrail ref", body.Error.Message)
+	}
+	if body.Error.Param != nil {
+		t.Fatalf("error param = %v, want nil", *body.Error.Param)
+	}
+	if body.Error.Code != nil {
+		t.Fatalf("error code = %v, want nil", *body.Error.Code)
 	}
 }
 
@@ -432,12 +480,102 @@ func TestCreateExecutionPlanReturnsValidationErrors(t *testing.T) {
 		t.Fatalf("status = %d, want 400", rec.Code)
 	}
 
-	var body map[string]map[string]any
-	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
-		t.Fatalf("unmarshal response: %v", err)
+	body := decodeExecutionPlanErrorEnvelope(t, rec.Body.Bytes())
+	if body.Error.Type != "invalid_request_error" {
+		t.Fatalf("error type = %q, want invalid_request_error", body.Error.Type)
 	}
-	if got := body["error"]["type"]; got != "invalid_request_error" {
-		t.Fatalf("error type = %v, want invalid_request_error", got)
+	if body.Error.Param != nil {
+		t.Fatalf("error param = %v, want nil", *body.Error.Param)
+	}
+	if body.Error.Code != nil {
+		t.Fatalf("error code = %v, want nil", *body.Error.Code)
+	}
+}
+
+func TestCreateExecutionPlanRejectsUnknownProviderOrModelScope(t *testing.T) {
+	store := &executionPlanTestStore{
+		versions: []executionplans.Version{
+			{
+				ID:       "global-plan",
+				Scope:    executionplans.Scope{},
+				ScopeKey: "global",
+				Version:  1,
+				Active:   true,
+				Name:     "global",
+				Payload: executionplans.Payload{
+					SchemaVersion: 1,
+					Features:      executionplans.FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
+				},
+				PlanHash: "hash-global",
+			},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		body        string
+		wantMessage string
+	}{
+		{
+			name: "unknown provider",
+			body: `{
+				"scope_provider":"anthropic",
+				"name":"invalid provider",
+				"plan_payload":{
+					"schema_version":1,
+					"features":{"cache":true,"audit":true,"usage":true,"guardrails":false},
+					"guardrails":[]
+				}
+			}`,
+			wantMessage: "unknown provider type: anthropic",
+		},
+		{
+			name: "unknown model for provider",
+			body: `{
+				"scope_provider":"openai",
+				"scope_model":"gpt-4o-mini",
+				"name":"invalid model",
+				"plan_payload":{
+					"schema_version":1,
+					"features":{"cache":true,"audit":true,"usage":true,"guardrails":false},
+					"guardrails":[]
+				}
+			}`,
+			wantMessage: "unknown model for provider openai: gpt-4o-mini",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newExecutionPlanHandler(t, store, nil)
+			e := echo.New()
+
+			req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/execution-plans", bytes.NewBufferString(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			if err := h.CreateExecutionPlan(c); err != nil {
+				t.Fatalf("CreateExecutionPlan() error = %v", err)
+			}
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", rec.Code)
+			}
+
+			body := decodeExecutionPlanErrorEnvelope(t, rec.Body.Bytes())
+			if body.Error.Type != "invalid_request_error" {
+				t.Fatalf("error type = %q, want invalid_request_error", body.Error.Type)
+			}
+			if body.Error.Message != tt.wantMessage {
+				t.Fatalf("error message = %q, want %q", body.Error.Message, tt.wantMessage)
+			}
+			if body.Error.Param != nil {
+				t.Fatalf("error param = %v, want nil", *body.Error.Param)
+			}
+			if body.Error.Code != nil {
+				t.Fatalf("error code = %v, want nil", *body.Error.Code)
+			}
+		})
 	}
 }
 
@@ -593,11 +731,17 @@ func TestDeactivateExecutionPlanRejectsGlobalWorkflow(t *testing.T) {
 		t.Fatalf("status = %d, want 400", rec.Code)
 	}
 
-	var body map[string]map[string]any
-	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
-		t.Fatalf("unmarshal response: %v", err)
+	body := decodeExecutionPlanErrorEnvelope(t, rec.Body.Bytes())
+	if body.Error.Type != "invalid_request_error" {
+		t.Fatalf("error type = %q, want invalid_request_error", body.Error.Type)
 	}
-	if got := body["error"]["message"]; got != "cannot deactivate the global workflow" {
-		t.Fatalf("error message = %v, want cannot deactivate the global workflow", got)
+	if body.Error.Message != "cannot deactivate the global workflow" {
+		t.Fatalf("error message = %q, want cannot deactivate the global workflow", body.Error.Message)
+	}
+	if body.Error.Param != nil {
+		t.Fatalf("error param = %v, want nil", *body.Error.Param)
+	}
+	if body.Error.Code != nil {
+		t.Fatalf("error code = %v, want nil", *body.Error.Code)
 	}
 }

--- a/internal/admin/handler_executionplans_test.go
+++ b/internal/admin/handler_executionplans_test.go
@@ -220,6 +220,19 @@ func TestExecutionPlansEndpointsReturn503WhenServiceUnavailable(t *testing.T) {
 	if listRec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("list status = %d, want 503", listRec.Code)
 	}
+	listEnvelope := decodeExecutionPlanErrorEnvelope(t, listRec.Body.Bytes())
+	if listEnvelope.Error.Type != "invalid_request_error" {
+		t.Fatalf("list error type = %q, want invalid_request_error", listEnvelope.Error.Type)
+	}
+	if listEnvelope.Error.Message != "execution plans feature is unavailable" {
+		t.Fatalf("list error message = %q, want execution plans feature is unavailable", listEnvelope.Error.Message)
+	}
+	if listEnvelope.Error.Param != nil {
+		t.Fatalf("list error param = %v, want nil", *listEnvelope.Error.Param)
+	}
+	if listEnvelope.Error.Code == nil || *listEnvelope.Error.Code != "feature_unavailable" {
+		t.Fatalf("list error code = %v, want feature_unavailable", listEnvelope.Error.Code)
+	}
 
 	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/execution-plans", bytes.NewBufferString(`{}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -230,6 +243,19 @@ func TestExecutionPlansEndpointsReturn503WhenServiceUnavailable(t *testing.T) {
 	}
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("create status = %d, want 503", rec.Code)
+	}
+	createEnvelope := decodeExecutionPlanErrorEnvelope(t, rec.Body.Bytes())
+	if createEnvelope.Error.Type != "invalid_request_error" {
+		t.Fatalf("create error type = %q, want invalid_request_error", createEnvelope.Error.Type)
+	}
+	if createEnvelope.Error.Message != "execution plans feature is unavailable" {
+		t.Fatalf("create error message = %q, want execution plans feature is unavailable", createEnvelope.Error.Message)
+	}
+	if createEnvelope.Error.Param != nil {
+		t.Fatalf("create error param = %v, want nil", *createEnvelope.Error.Param)
+	}
+	if createEnvelope.Error.Code == nil || *createEnvelope.Error.Code != "feature_unavailable" {
+		t.Fatalf("create error code = %v, want feature_unavailable", createEnvelope.Error.Code)
 	}
 
 	req = httptest.NewRequest(http.MethodPost, "/admin/api/v1/execution-plans/test-plan/deactivate", nil)
@@ -242,6 +268,19 @@ func TestExecutionPlansEndpointsReturn503WhenServiceUnavailable(t *testing.T) {
 	}
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("deactivate status = %d, want 503", rec.Code)
+	}
+	deactivateEnvelope := decodeExecutionPlanErrorEnvelope(t, rec.Body.Bytes())
+	if deactivateEnvelope.Error.Type != "invalid_request_error" {
+		t.Fatalf("deactivate error type = %q, want invalid_request_error", deactivateEnvelope.Error.Type)
+	}
+	if deactivateEnvelope.Error.Message != "execution plans feature is unavailable" {
+		t.Fatalf("deactivate error message = %q, want execution plans feature is unavailable", deactivateEnvelope.Error.Message)
+	}
+	if deactivateEnvelope.Error.Param != nil {
+		t.Fatalf("deactivate error param = %v, want nil", *deactivateEnvelope.Error.Param)
+	}
+	if deactivateEnvelope.Error.Code == nil || *deactivateEnvelope.Error.Code != "feature_unavailable" {
+		t.Fatalf("deactivate error code = %v, want feature_unavailable", deactivateEnvelope.Error.Code)
 	}
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -270,7 +270,15 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		adminCfg.UIEnabled = false
 	}
 	if adminCfg.EndpointsEnabled {
-		adminHandler, dashHandler, adminErr := initAdmin(auditResult.Storage, usageResult.Storage, providerResult.Registry, app.aliases.Service, adminCfg.UIEnabled)
+		adminHandler, dashHandler, adminErr := initAdmin(
+			auditResult.Storage,
+			usageResult.Storage,
+			providerResult.Registry,
+			app.aliases.Service,
+			executionPlanResult.Service,
+			guardrailRegistry,
+			adminCfg.UIEnabled,
+		)
 		if adminErr != nil {
 			slog.Warn("failed to initialize admin", "error", adminErr)
 		} else {
@@ -552,7 +560,14 @@ func (a *App) logStartupInfo() {
 
 // initAdmin creates the admin API handler and optionally the dashboard handler.
 // Returns nil dashboard handler if uiEnabled is false.
-func initAdmin(auditStorage, usageStorage storage.Storage, registry *providers.ModelRegistry, aliasService *aliases.Service, uiEnabled bool) (*admin.Handler, *dashboard.Handler, error) {
+func initAdmin(
+	auditStorage, usageStorage storage.Storage,
+	registry *providers.ModelRegistry,
+	aliasService *aliases.Service,
+	executionPlanService *executionplans.Service,
+	guardrailRegistry *guardrails.Registry,
+	uiEnabled bool,
+) (*admin.Handler, *dashboard.Handler, error) {
 	// Find a storage connection for reading usage data
 	var store storage.Storage
 	if auditStorage != nil {
@@ -582,7 +597,14 @@ func initAdmin(auditStorage, usageStorage storage.Storage, registry *providers.M
 		}
 	}
 
-	adminHandler := admin.NewHandler(reader, registry, admin.WithAuditReader(auditReader), admin.WithAliases(aliasService))
+	adminHandler := admin.NewHandler(
+		reader,
+		registry,
+		admin.WithAuditReader(auditReader),
+		admin.WithAliases(aliasService),
+		admin.WithExecutionPlans(executionPlanService),
+		admin.WithGuardrailsRegistry(guardrailRegistry),
+	)
 
 	var dashHandler *dashboard.Handler
 	if uiEnabled {

--- a/internal/executionplans/service.go
+++ b/internal/executionplans/service.go
@@ -176,7 +176,8 @@ func (s *Service) Create(ctx context.Context, input CreateInput) (*Version, erro
 	if err != nil {
 		return nil, err
 	}
-	if err := s.validateCreateCandidate(normalized, scopeKey, planHash); err != nil {
+	previewCompiled, err := s.validateCreateCandidate(normalized, scopeKey, planHash)
+	if err != nil {
 		return nil, err
 	}
 
@@ -187,10 +188,8 @@ func (s *Service) Create(ctx context.Context, input CreateInput) (*Version, erro
 	if err != nil {
 		return nil, fmt.Errorf("create execution plan: %w", err)
 	}
-	refreshCtx, refreshCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer refreshCancel()
-	if err := s.refreshLocked(refreshCtx); err != nil {
-		return nil, fmt.Errorf("refresh execution plans: %w", err)
+	if version != nil && version.Active {
+		s.storeActivatedCompiledLocked(compiledPlanForVersion(previewCompiled, *version))
 	}
 	return version, nil
 }
@@ -236,11 +235,7 @@ func (s *Service) Deactivate(ctx context.Context, id string) error {
 		}
 		return fmt.Errorf("deactivate execution plan %q: %w", version.ID, err)
 	}
-	refreshCtx, refreshCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer refreshCancel()
-	if err := s.refreshLocked(refreshCtx); err != nil {
-		return fmt.Errorf("refresh execution plans: %w", err)
-	}
+	s.storeDeactivatedVersionLocked(*version)
 	return nil
 }
 
@@ -384,7 +379,7 @@ func (s *Service) matchCompiled(selector core.ExecutionPlanSelector) (*CompiledP
 	return current.global, nil
 }
 
-func (s *Service) validateCreateCandidate(input CreateInput, scopeKey, planHash string) error {
+func (s *Service) validateCreateCandidate(input CreateInput, scopeKey, planHash string) (*CompiledPlan, error) {
 	version := Version{
 		ID:          "preview",
 		Scope:       input.Scope,
@@ -399,12 +394,12 @@ func (s *Service) validateCreateCandidate(input CreateInput, scopeKey, planHash 
 	}
 	compiled, err := s.compiler.Compile(version)
 	if err != nil {
-		return newValidationError(err.Error(), err)
+		return nil, newValidationError(err.Error(), err)
 	}
 	if compiled == nil || compiled.Policy == nil {
-		return newValidationError("compiled plan is empty or missing policy", nil)
+		return nil, newValidationError("compiled plan is empty or missing policy", nil)
 	}
-	return nil
+	return compiled, nil
 }
 
 func (s *Service) viewForVersion(version Version) (View, error) {
@@ -483,4 +478,110 @@ func (s *Service) snapshot() snapshot {
 		providerModels: map[string]map[string]*CompiledPlan{},
 		byVersionID:    map[string]*CompiledPlan{},
 	}
+}
+
+func cloneSnapshot(current snapshot) snapshot {
+	next := snapshot{
+		global:         current.global,
+		providers:      make(map[string]*CompiledPlan, len(current.providers)),
+		providerModels: make(map[string]map[string]*CompiledPlan, len(current.providerModels)),
+		byVersionID:    make(map[string]*CompiledPlan, len(current.byVersionID)),
+	}
+	for provider, compiled := range current.providers {
+		next.providers[provider] = compiled
+	}
+	for provider, models := range current.providerModels {
+		copied := make(map[string]*CompiledPlan, len(models))
+		for model, compiled := range models {
+			copied[model] = compiled
+		}
+		next.providerModels[provider] = copied
+	}
+	for versionID, compiled := range current.byVersionID {
+		next.byVersionID[versionID] = compiled
+	}
+	return next
+}
+
+func compiledPlanForVersion(compiled *CompiledPlan, version Version) *CompiledPlan {
+	if compiled == nil {
+		return nil
+	}
+	next := &CompiledPlan{
+		Version:  version,
+		Pipeline: compiled.Pipeline,
+	}
+	if compiled.Policy != nil {
+		policy := *compiled.Policy
+		policy.VersionID = version.ID
+		policy.Version = version.Version
+		policy.ScopeProvider = version.Scope.Provider
+		policy.ScopeModel = version.Scope.Model
+		policy.Name = version.Name
+		policy.PlanHash = version.PlanHash
+		next.Policy = &policy
+	}
+	return next
+}
+
+func (s *Service) storeActivatedCompiledLocked(compiled *CompiledPlan) {
+	if s == nil || compiled == nil {
+		return
+	}
+	next := cloneSnapshot(s.snapshot())
+	scope := compiled.Version.Scope
+
+	switch {
+	case scope.Provider == "":
+		if next.global != nil {
+			delete(next.byVersionID, next.global.Version.ID)
+		}
+		next.global = compiled
+	case scope.Model == "":
+		if existing := next.providers[scope.Provider]; existing != nil {
+			delete(next.byVersionID, existing.Version.ID)
+		}
+		next.providers[scope.Provider] = compiled
+	default:
+		models := next.providerModels[scope.Provider]
+		if models == nil {
+			models = make(map[string]*CompiledPlan)
+			next.providerModels[scope.Provider] = models
+		}
+		if existing := models[scope.Model]; existing != nil {
+			delete(next.byVersionID, existing.Version.ID)
+		}
+		models[scope.Model] = compiled
+	}
+
+	next.byVersionID[compiled.Version.ID] = compiled
+	s.current.Store(next)
+}
+
+func (s *Service) storeDeactivatedVersionLocked(version Version) {
+	if s == nil {
+		return
+	}
+	next := cloneSnapshot(s.snapshot())
+	scope := version.Scope
+
+	delete(next.byVersionID, version.ID)
+
+	switch {
+	case scope.Provider == "":
+		next.global = nil
+	case scope.Model == "":
+		delete(next.providers, scope.Provider)
+	default:
+		models := next.providerModels[scope.Provider]
+		if models == nil {
+			break
+		}
+		delete(models, scope.Model)
+		if len(models) == 0 {
+			delete(next.providerModels, scope.Provider)
+		}
+	}
+
+	s.current.Store(next)
 }

--- a/internal/executionplans/service.go
+++ b/internal/executionplans/service.go
@@ -36,9 +36,10 @@ type snapshot struct {
 
 // Service keeps the active execution-plan set cached in memory.
 type Service struct {
-	store    Store
-	compiler Compiler
-	current  atomic.Value
+	store     Store
+	compiler  Compiler
+	current   atomic.Value
+	refreshMu sync.Mutex
 }
 
 // NewService creates an execution-plan service backed by storage.
@@ -64,6 +65,12 @@ func NewService(store Store, compiler Compiler) (*Service, error) {
 
 // Refresh reloads active plans from storage and atomically swaps the in-memory snapshot.
 func (s *Service) Refresh(ctx context.Context) error {
+	s.refreshMu.Lock()
+	defer s.refreshMu.Unlock()
+	return s.refreshLocked(ctx)
+}
+
+func (s *Service) refreshLocked(ctx context.Context) error {
 	versions, err := s.store.ListActive(ctx)
 	if err != nil {
 		return fmt.Errorf("list active execution plans: %w", err)
@@ -173,11 +180,14 @@ func (s *Service) Create(ctx context.Context, input CreateInput) (*Version, erro
 		return nil, err
 	}
 
+	s.refreshMu.Lock()
+	defer s.refreshMu.Unlock()
+
 	version, err := s.store.Create(ctx, normalized)
 	if err != nil {
 		return nil, fmt.Errorf("create execution plan: %w", err)
 	}
-	if err := s.Refresh(ctx); err != nil {
+	if err := s.refreshLocked(ctx); err != nil {
 		return nil, fmt.Errorf("refresh execution plans: %w", err)
 	}
 	return version, nil
@@ -215,13 +225,16 @@ func (s *Service) Deactivate(ctx context.Context, id string) error {
 		return newValidationError("workflow is already inactive", nil)
 	}
 
+	s.refreshMu.Lock()
+	defer s.refreshMu.Unlock()
+
 	if err := s.store.Deactivate(ctx, version.ID); err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return err
 		}
 		return fmt.Errorf("deactivate execution plan %q: %w", version.ID, err)
 	}
-	if err := s.Refresh(ctx); err != nil {
+	if err := s.refreshLocked(ctx); err != nil {
 		return fmt.Errorf("refresh execution plans: %w", err)
 	}
 	return nil

--- a/internal/executionplans/service.go
+++ b/internal/executionplans/service.go
@@ -2,8 +2,10 @@ package executionplans
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -156,6 +158,113 @@ func (s *Service) EnsureDefaultGlobal(ctx context.Context, input CreateInput) er
 	return nil
 }
 
+// Create inserts a new immutable execution-plan version and refreshes the
+// in-memory snapshot so future requests can match it immediately.
+func (s *Service) Create(ctx context.Context, input CreateInput) (*Version, error) {
+	if s == nil {
+		return nil, fmt.Errorf("execution plan service is required")
+	}
+
+	normalized, scopeKey, planHash, err := normalizeCreateInput(input)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.validateCreateCandidate(normalized, scopeKey, planHash); err != nil {
+		return nil, err
+	}
+
+	version, err := s.store.Create(ctx, normalized)
+	if err != nil {
+		return nil, fmt.Errorf("create execution plan: %w", err)
+	}
+	if err := s.Refresh(ctx); err != nil {
+		return nil, fmt.Errorf("refresh execution plans: %w", err)
+	}
+	return version, nil
+}
+
+// Deactivate turns off one active execution-plan version and refreshes the
+// in-memory snapshot so future requests stop matching it immediately.
+func (s *Service) Deactivate(ctx context.Context, id string) error {
+	if s == nil {
+		return fmt.Errorf("execution plan service is required")
+	}
+
+	version, err := s.store.Get(ctx, strings.TrimSpace(id))
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return err
+		}
+		return fmt.Errorf("load execution plan %q: %w", id, err)
+	}
+	if version == nil {
+		return ErrNotFound
+	}
+
+	scope, scopeKey, err := normalizeScope(version.Scope)
+	if err != nil {
+		return fmt.Errorf("load execution plan %q: %w", id, err)
+	}
+	version.Scope = scope
+	version.ScopeKey = scopeKey
+
+	if scope.Provider == "" && scope.Model == "" {
+		return newValidationError("cannot deactivate the global workflow", nil)
+	}
+	if !version.Active {
+		return newValidationError("workflow is already inactive", nil)
+	}
+
+	if err := s.store.Deactivate(ctx, version.ID); err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return err
+		}
+		return fmt.Errorf("deactivate execution plan %q: %w", version.ID, err)
+	}
+	if err := s.Refresh(ctx); err != nil {
+		return fmt.Errorf("refresh execution plans: %w", err)
+	}
+	return nil
+}
+
+// ListViews returns the active execution plans together with their effective
+// runtime features after process-level caps are applied.
+func (s *Service) ListViews(ctx context.Context) ([]View, error) {
+	if s == nil {
+		return []View{}, nil
+	}
+
+	versions, err := s.store.ListActive(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list active execution plans: %w", err)
+	}
+
+	views := make([]View, 0, len(versions))
+	for _, version := range versions {
+		view, err := s.viewForVersion(version)
+		if err != nil {
+			return nil, err
+		}
+		views = append(views, view)
+	}
+
+	sort.SliceStable(views, func(i, j int) bool {
+		left, right := views[i], views[j]
+		if leftSpecificity, rightSpecificity := scopeSpecificity(left.Scope), scopeSpecificity(right.Scope); leftSpecificity != rightSpecificity {
+			return leftSpecificity < rightSpecificity
+		}
+		if left.ScopeDisplay != right.ScopeDisplay {
+			return left.ScopeDisplay < right.ScopeDisplay
+		}
+		if !left.CreatedAt.Equal(right.CreatedAt) {
+			return left.CreatedAt.After(right.CreatedAt)
+		}
+		return left.ID < right.ID
+	})
+
+	return views, nil
+}
+
 // Match returns the most-specific compiled execution policy for one request.
 func (s *Service) Match(selector core.ExecutionPlanSelector) (*core.ResolvedExecutionPolicy, error) {
 	compiled, err := s.matchCompiled(selector)
@@ -256,6 +365,85 @@ func (s *Service) matchCompiled(selector core.ExecutionPlanSelector) (*CompiledP
 		return nil, fmt.Errorf("missing active global execution plan")
 	}
 	return current.global, nil
+}
+
+func (s *Service) validateCreateCandidate(input CreateInput, scopeKey, planHash string) error {
+	version := Version{
+		ID:          "preview",
+		Scope:       input.Scope,
+		ScopeKey:    scopeKey,
+		Version:     1,
+		Active:      input.Activate,
+		Name:        input.Name,
+		Description: input.Description,
+		Payload:     input.Payload,
+		PlanHash:    planHash,
+		CreatedAt:   time.Unix(0, 0).UTC(),
+	}
+	if _, err := s.compiler.Compile(version); err != nil {
+		return newValidationError(err.Error(), err)
+	}
+	return nil
+}
+
+func (s *Service) viewForVersion(version Version) (View, error) {
+	scope, scopeKey, err := normalizeScope(version.Scope)
+	if err != nil {
+		return View{}, fmt.Errorf("load execution plan %q: %w", version.ID, err)
+	}
+	version.Scope = scope
+	if strings.TrimSpace(version.ScopeKey) == "" {
+		version.ScopeKey = scopeKey
+	}
+
+	compiled, err := s.compiler.Compile(version)
+	if err != nil {
+		return View{}, fmt.Errorf("compile execution plan %q: %w", version.ID, err)
+	}
+	if compiled == nil || compiled.Policy == nil {
+		return View{}, fmt.Errorf("compile execution plan %q: empty compiled plan", version.ID)
+	}
+
+	return View{
+		Version:           version,
+		ScopeType:         scopeType(scope),
+		ScopeDisplay:      scopeDisplay(scope),
+		EffectiveFeatures: compiled.Policy.Features,
+		GuardrailsHash:    compiled.Policy.GuardrailsHash,
+	}, nil
+}
+
+func scopeType(scope Scope) string {
+	switch {
+	case strings.TrimSpace(scope.Provider) == "":
+		return "global"
+	case strings.TrimSpace(scope.Model) == "":
+		return "provider"
+	default:
+		return "provider_model"
+	}
+}
+
+func scopeDisplay(scope Scope) string {
+	switch scopeType(scope) {
+	case "global":
+		return "global"
+	case "provider":
+		return scope.Provider
+	default:
+		return scope.Provider + "/" + scope.Model
+	}
+}
+
+func scopeSpecificity(scope Scope) int {
+	switch scopeType(scope) {
+	case "global":
+		return 0
+	case "provider":
+		return 1
+	default:
+		return 2
+	}
 }
 
 func (s *Service) snapshot() snapshot {

--- a/internal/executionplans/service.go
+++ b/internal/executionplans/service.go
@@ -255,14 +255,16 @@ func (s *Service) ListViews(ctx context.Context) ([]View, error) {
 	for _, version := range versions {
 		view, err := s.viewForVersion(version)
 		if err != nil {
-			return nil, err
+			slog.Warn("execution plan view build failed", "version_id", strings.TrimSpace(version.ID), "error", err)
+			views = append(views, viewWithError(version, err))
+			continue
 		}
 		views = append(views, view)
 	}
 
 	sort.SliceStable(views, func(i, j int) bool {
 		left, right := views[i], views[j]
-		if leftSpecificity, rightSpecificity := scopeSpecificity(left.Scope), scopeSpecificity(right.Scope); leftSpecificity != rightSpecificity {
+		if leftSpecificity, rightSpecificity := viewScopeSpecificity(left.ScopeType), viewScopeSpecificity(right.ScopeType); leftSpecificity != rightSpecificity {
 			return leftSpecificity < rightSpecificity
 		}
 		if left.ScopeDisplay != right.ScopeDisplay {
@@ -429,6 +431,48 @@ func (s *Service) viewForVersion(version Version) (View, error) {
 	}, nil
 }
 
+func viewWithError(version Version, err error) View {
+	scope := Scope{
+		Provider: strings.TrimSpace(version.Scope.Provider),
+		Model:    strings.TrimSpace(version.Scope.Model),
+	}
+	version.Scope = scope
+
+	return View{
+		Version:      version,
+		ScopeType:    rawScopeType(scope),
+		ScopeDisplay: rawScopeDisplay(scope),
+		CompileError: err.Error(),
+	}
+}
+
+func rawScopeType(scope Scope) string {
+	switch {
+	case strings.TrimSpace(scope.Provider) == "" && strings.TrimSpace(scope.Model) == "":
+		return "global"
+	case strings.TrimSpace(scope.Provider) != "" && strings.TrimSpace(scope.Model) == "":
+		return "provider"
+	default:
+		return "provider_model"
+	}
+}
+
+func rawScopeDisplay(scope Scope) string {
+	provider := strings.TrimSpace(scope.Provider)
+	model := strings.TrimSpace(scope.Model)
+
+	switch {
+	case provider == "" && model == "":
+		return "global"
+	case provider != "" && model == "":
+		return provider
+	case provider == "" && model != "":
+		return model
+	default:
+		return provider + "/" + model
+	}
+}
+
 func scopeType(scope Scope) string {
 	switch {
 	case strings.TrimSpace(scope.Provider) == "":
@@ -453,6 +497,17 @@ func scopeDisplay(scope Scope) string {
 
 func scopeSpecificity(scope Scope) int {
 	switch scopeType(scope) {
+	case "global":
+		return 0
+	case "provider":
+		return 1
+	default:
+		return 2
+	}
+}
+
+func viewScopeSpecificity(scopeType string) int {
+	switch strings.TrimSpace(scopeType) {
 	case "global":
 		return 0
 	case "provider":

--- a/internal/executionplans/service.go
+++ b/internal/executionplans/service.go
@@ -187,7 +187,9 @@ func (s *Service) Create(ctx context.Context, input CreateInput) (*Version, erro
 	if err != nil {
 		return nil, fmt.Errorf("create execution plan: %w", err)
 	}
-	if err := s.refreshLocked(ctx); err != nil {
+	refreshCtx, refreshCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer refreshCancel()
+	if err := s.refreshLocked(refreshCtx); err != nil {
 		return nil, fmt.Errorf("refresh execution plans: %w", err)
 	}
 	return version, nil
@@ -234,7 +236,9 @@ func (s *Service) Deactivate(ctx context.Context, id string) error {
 		}
 		return fmt.Errorf("deactivate execution plan %q: %w", version.ID, err)
 	}
-	if err := s.refreshLocked(ctx); err != nil {
+	refreshCtx, refreshCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer refreshCancel()
+	if err := s.refreshLocked(refreshCtx); err != nil {
 		return fmt.Errorf("refresh execution plans: %w", err)
 	}
 	return nil
@@ -393,8 +397,12 @@ func (s *Service) validateCreateCandidate(input CreateInput, scopeKey, planHash 
 		PlanHash:    planHash,
 		CreatedAt:   time.Unix(0, 0).UTC(),
 	}
-	if _, err := s.compiler.Compile(version); err != nil {
+	compiled, err := s.compiler.Compile(version)
+	if err != nil {
 		return newValidationError(err.Error(), err)
+	}
+	if compiled == nil || compiled.Policy == nil {
+		return newValidationError("compiled plan is empty or missing policy", nil)
 	}
 	return nil
 }

--- a/internal/executionplans/service.go
+++ b/internal/executionplans/service.go
@@ -495,17 +495,6 @@ func scopeDisplay(scope Scope) string {
 	}
 }
 
-func scopeSpecificity(scope Scope) int {
-	switch scopeType(scope) {
-	case "global":
-		return 0
-	case "provider":
-		return 1
-	default:
-		return 2
-	}
-}
-
 func viewScopeSpecificity(scopeType string) int {
 	switch strings.TrimSpace(scopeType) {
 	case "global":

--- a/internal/executionplans/service_test.go
+++ b/internal/executionplans/service_test.go
@@ -2,6 +2,7 @@ package executionplans
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -186,6 +187,11 @@ type contextCancelingStore struct {
 	cancelOnDeactivate context.CancelFunc
 }
 
+type refreshFailingStore struct {
+	staticStore
+	failListActive error
+}
+
 func (s *contextCancelingStore) ListActive(ctx context.Context) ([]Version, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -205,6 +211,29 @@ func (s *contextCancelingStore) Deactivate(ctx context.Context, id string) error
 	err := s.staticStore.Deactivate(ctx, id)
 	if err == nil && s.cancelOnDeactivate != nil {
 		s.cancelOnDeactivate()
+	}
+	return err
+}
+
+func (s *refreshFailingStore) ListActive(ctx context.Context) ([]Version, error) {
+	if s.failListActive != nil {
+		return nil, s.failListActive
+	}
+	return s.staticStore.ListActive(ctx)
+}
+
+func (s *refreshFailingStore) Create(ctx context.Context, input CreateInput) (*Version, error) {
+	version, err := s.staticStore.Create(ctx, input)
+	if err == nil {
+		s.failListActive = errors.New("list active failed after create")
+	}
+	return version, err
+}
+
+func (s *refreshFailingStore) Deactivate(ctx context.Context, id string) error {
+	err := s.staticStore.Deactivate(ctx, id)
+	if err == nil {
+		s.failListActive = errors.New("list active failed after deactivate")
 	}
 	return err
 }
@@ -692,6 +721,61 @@ func TestServiceCreateRefreshIgnoresRequestContextCancellationAfterPersist(t *te
 	}
 }
 
+func TestServiceCreateReturnsSuccessWhenReloadRefreshFailsAfterPersist(t *testing.T) {
+	store := &refreshFailingStore{
+		staticStore: staticStore{
+			versions: []Version{
+				{
+					ID:       "global-v1",
+					Scope:    Scope{},
+					ScopeKey: "global",
+					Version:  1,
+					Active:   true,
+					Name:     "global",
+					Payload: Payload{
+						SchemaVersion: 1,
+						Features:      FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
+					},
+				},
+			},
+		},
+	}
+	service, err := NewService(store, NewCompiler(nil))
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	created, err := service.Create(context.Background(), CreateInput{
+		Scope:    Scope{Provider: "openai"},
+		Activate: true,
+		Name:     "openai",
+		Payload: Payload{
+			SchemaVersion: 1,
+			Features:      FeatureFlags{Cache: false, Audit: true, Usage: true, Guardrails: false},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if created == nil {
+		t.Fatal("Create() returned nil version")
+	}
+
+	policy, err := service.Match(core.NewExecutionPlanSelector("openai", "gpt-5"))
+	if err != nil {
+		t.Fatalf("Match() error = %v", err)
+	}
+	if policy == nil {
+		t.Fatal("Match() returned nil policy")
+	}
+	if policy.VersionID != created.ID {
+		t.Fatalf("VersionID = %q, want %q", policy.VersionID, created.ID)
+	}
+}
+
 func TestServiceDeactivateRefreshIgnoresRequestContextCancellationAfterPersist(t *testing.T) {
 	store := &contextCancelingStore{
 		staticStore: staticStore{
@@ -735,6 +819,61 @@ func TestServiceDeactivateRefreshIgnoresRequestContextCancellationAfterPersist(t
 	store.cancelOnDeactivate = cancel
 
 	if err := service.Deactivate(ctx, "provider-v1"); err != nil {
+		t.Fatalf("Deactivate() error = %v", err)
+	}
+
+	policy, err := service.Match(core.NewExecutionPlanSelector("openai", "gpt-5"))
+	if err != nil {
+		t.Fatalf("Match() error = %v", err)
+	}
+	if policy == nil {
+		t.Fatal("Match() returned nil policy")
+	}
+	if policy.VersionID != "global-v1" {
+		t.Fatalf("VersionID = %q, want global-v1", policy.VersionID)
+	}
+}
+
+func TestServiceDeactivateReturnsSuccessWhenReloadRefreshFailsAfterPersist(t *testing.T) {
+	store := &refreshFailingStore{
+		staticStore: staticStore{
+			versions: []Version{
+				{
+					ID:       "global-v1",
+					Scope:    Scope{},
+					ScopeKey: "global",
+					Version:  1,
+					Active:   true,
+					Name:     "global",
+					Payload: Payload{
+						SchemaVersion: 1,
+						Features:      FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
+					},
+				},
+				{
+					ID:       "provider-v1",
+					Scope:    Scope{Provider: "openai"},
+					ScopeKey: "provider:openai",
+					Version:  1,
+					Active:   true,
+					Name:     "openai",
+					Payload: Payload{
+						SchemaVersion: 1,
+						Features:      FeatureFlags{Cache: false, Audit: true, Usage: true, Guardrails: false},
+					},
+				},
+			},
+		},
+	}
+	service, err := NewService(store, NewCompiler(nil))
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	if err := service.Deactivate(context.Background(), "provider-v1"); err != nil {
 		t.Fatalf("Deactivate() error = %v", err)
 	}
 

--- a/internal/executionplans/service_test.go
+++ b/internal/executionplans/service_test.go
@@ -11,12 +11,35 @@ type staticStore struct {
 	versions []Version
 }
 
-func (s *staticStore) ListActive(context.Context) ([]Version, error) { return s.versions, nil }
-func (s *staticStore) Get(context.Context, string) (*Version, error) { return nil, ErrNotFound }
+func (s *staticStore) ListActive(context.Context) ([]Version, error) {
+	result := make([]Version, 0, len(s.versions))
+	for _, version := range s.versions {
+		if version.Active {
+			result = append(result, version)
+		}
+	}
+	return result, nil
+}
+func (s *staticStore) Get(_ context.Context, id string) (*Version, error) {
+	for _, version := range s.versions {
+		if version.ID == id {
+			copy := version
+			return &copy, nil
+		}
+	}
+	return nil, ErrNotFound
+}
 func (s *staticStore) Create(_ context.Context, input CreateInput) (*Version, error) {
 	input, scopeKey, planHash, err := normalizeCreateInput(input)
 	if err != nil {
 		return nil, err
+	}
+	if input.Activate {
+		for i := range s.versions {
+			if s.versions[i].ScopeKey == scopeKey {
+				s.versions[i].Active = false
+			}
+		}
 	}
 	version := Version{
 		ID:          "created-global",
@@ -31,6 +54,15 @@ func (s *staticStore) Create(_ context.Context, input CreateInput) (*Version, er
 	}
 	s.versions = append(s.versions, version)
 	return &version, nil
+}
+func (s *staticStore) Deactivate(_ context.Context, id string) error {
+	for i := range s.versions {
+		if s.versions[i].ID == id && s.versions[i].Active {
+			s.versions[i].Active = false
+			return nil
+		}
+	}
+	return ErrNotFound
 }
 func (s *staticStore) Close() error { return nil }
 
@@ -126,5 +158,193 @@ func TestServiceEnsureDefaultGlobal_CreatesWhenMissing(t *testing.T) {
 	}
 	if got := store.versions[0].ScopeKey; got != "global" {
 		t.Fatalf("ScopeKey = %q, want global", got)
+	}
+}
+
+func TestServiceCreate_RefreshesSnapshot(t *testing.T) {
+	store := &staticStore{
+		versions: []Version{
+			{
+				ID:       "global-v1",
+				Scope:    Scope{},
+				ScopeKey: "global",
+				Version:  1,
+				Active:   true,
+				Name:     "global",
+				Payload: Payload{
+					SchemaVersion: 1,
+					Features:      FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
+				},
+			},
+		},
+	}
+	service, err := NewService(store, NewCompiler(nil))
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	created, err := service.Create(context.Background(), CreateInput{
+		Scope:    Scope{Provider: "openai"},
+		Activate: true,
+		Name:     "openai",
+		Payload: Payload{
+			SchemaVersion: 1,
+			Features:      FeatureFlags{Cache: false, Audit: true, Usage: true, Guardrails: false},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if created == nil {
+		t.Fatal("Create() returned nil version")
+	}
+
+	policy, err := service.Match(core.NewExecutionPlanSelector("openai", "gpt-5"))
+	if err != nil {
+		t.Fatalf("Match() error = %v", err)
+	}
+	if policy == nil {
+		t.Fatal("Match() returned nil policy")
+	}
+	if policy.VersionID != created.ID {
+		t.Fatalf("VersionID = %q, want %q", policy.VersionID, created.ID)
+	}
+}
+
+func TestServiceListViews_IncludesEffectiveFeatures(t *testing.T) {
+	store := &staticStore{
+		versions: []Version{
+			{
+				ID:       "global-v1",
+				Scope:    Scope{},
+				ScopeKey: "global",
+				Version:  1,
+				Active:   true,
+				Name:     "global",
+				Payload: Payload{
+					SchemaVersion: 1,
+					Features:      FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: true},
+				},
+			},
+		},
+	}
+	service, err := NewService(store, NewCompilerWithFeatureCaps(nil, core.ExecutionFeatures{
+		Cache:      false,
+		Audit:      true,
+		Usage:      true,
+		Guardrails: false,
+	}))
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	views, err := service.ListViews(context.Background())
+	if err != nil {
+		t.Fatalf("ListViews() error = %v", err)
+	}
+	if len(views) != 1 {
+		t.Fatalf("len(views) = %d, want 1", len(views))
+	}
+	if views[0].ScopeType != "global" {
+		t.Fatalf("ScopeType = %q, want global", views[0].ScopeType)
+	}
+	if views[0].EffectiveFeatures.Cache {
+		t.Fatal("EffectiveFeatures.Cache = true, want false")
+	}
+	if views[0].EffectiveFeatures.Guardrails {
+		t.Fatal("EffectiveFeatures.Guardrails = true, want false")
+	}
+}
+
+func TestServiceDeactivate_RefreshesSnapshot(t *testing.T) {
+	store := &staticStore{
+		versions: []Version{
+			{
+				ID:       "global-v1",
+				Scope:    Scope{},
+				ScopeKey: "global",
+				Version:  1,
+				Active:   true,
+				Name:     "global",
+				Payload: Payload{
+					SchemaVersion: 1,
+					Features:      FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
+				},
+			},
+			{
+				ID:       "provider-v1",
+				Scope:    Scope{Provider: "openai"},
+				ScopeKey: "provider:openai",
+				Version:  1,
+				Active:   true,
+				Name:     "openai",
+				Payload: Payload{
+					SchemaVersion: 1,
+					Features:      FeatureFlags{Cache: false, Audit: true, Usage: true, Guardrails: false},
+				},
+			},
+		},
+	}
+	service, err := NewService(store, NewCompiler(nil))
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	if err := service.Deactivate(context.Background(), "provider-v1"); err != nil {
+		t.Fatalf("Deactivate() error = %v", err)
+	}
+
+	policy, err := service.Match(core.NewExecutionPlanSelector("openai", "gpt-5"))
+	if err != nil {
+		t.Fatalf("Match() error = %v", err)
+	}
+	if policy == nil {
+		t.Fatal("Match() returned nil policy")
+	}
+	if policy.VersionID != "global-v1" {
+		t.Fatalf("VersionID = %q, want global-v1", policy.VersionID)
+	}
+}
+
+func TestServiceDeactivate_RejectsGlobalWorkflow(t *testing.T) {
+	store := &staticStore{
+		versions: []Version{
+			{
+				ID:       "global-v1",
+				Scope:    Scope{},
+				ScopeKey: "global",
+				Version:  1,
+				Active:   true,
+				Name:     "global",
+				Payload: Payload{
+					SchemaVersion: 1,
+					Features:      FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
+				},
+			},
+		},
+	}
+	service, err := NewService(store, NewCompiler(nil))
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	err = service.Deactivate(context.Background(), "global-v1")
+	if err == nil {
+		t.Fatal("Deactivate() error = nil, want validation error")
+	}
+	if !IsValidationError(err) {
+		t.Fatalf("Deactivate() error = %v, want validation error", err)
 	}
 }

--- a/internal/executionplans/service_test.go
+++ b/internal/executionplans/service_test.go
@@ -2,7 +2,10 @@ package executionplans
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"gomodel/internal/core"
 )
@@ -65,6 +68,106 @@ func (s *staticStore) Deactivate(_ context.Context, id string) error {
 	return ErrNotFound
 }
 func (s *staticStore) Close() error { return nil }
+
+type concurrentStore struct {
+	mu           sync.Mutex
+	versions     []Version
+	createCalled chan struct{}
+}
+
+func (s *concurrentStore) ListActive(context.Context) ([]Version, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	result := make([]Version, 0, len(s.versions))
+	for _, version := range s.versions {
+		if version.Active {
+			result = append(result, version)
+		}
+	}
+	return result, nil
+}
+
+func (s *concurrentStore) Get(_ context.Context, id string) (*Version, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, version := range s.versions {
+		if version.ID == id {
+			copy := version
+			return &copy, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
+func (s *concurrentStore) Create(_ context.Context, input CreateInput) (*Version, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	input, scopeKey, planHash, err := normalizeCreateInput(input)
+	if err != nil {
+		return nil, err
+	}
+	if input.Activate {
+		for i := range s.versions {
+			if s.versions[i].ScopeKey == scopeKey {
+				s.versions[i].Active = false
+			}
+		}
+	}
+	version := Version{
+		ID:          "created-provider",
+		Scope:       input.Scope,
+		ScopeKey:    scopeKey,
+		Version:     len(s.versions) + 1,
+		Active:      input.Activate,
+		Name:        input.Name,
+		Description: input.Description,
+		Payload:     input.Payload,
+		PlanHash:    planHash,
+	}
+	s.versions = append(s.versions, version)
+	if s.createCalled != nil {
+		select {
+		case s.createCalled <- struct{}{}:
+		default:
+		}
+	}
+	return &version, nil
+}
+
+func (s *concurrentStore) Deactivate(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for i := range s.versions {
+		if s.versions[i].ID == id && s.versions[i].Active {
+			s.versions[i].Active = false
+			return nil
+		}
+	}
+	return ErrNotFound
+}
+
+func (s *concurrentStore) Close() error { return nil }
+
+type blockingCompiler struct {
+	delegate  Compiler
+	blockCall int32
+	callCount int32
+	blocked   chan struct{}
+	release   chan struct{}
+}
+
+func (c *blockingCompiler) Compile(version Version) (*CompiledPlan, error) {
+	call := atomic.AddInt32(&c.callCount, 1)
+	if call == c.blockCall {
+		close(c.blocked)
+		<-c.release
+	}
+	return c.delegate.Compile(version)
+}
 
 func TestServiceMatch_MostSpecificWins(t *testing.T) {
 	store := &staticStore{
@@ -346,5 +449,93 @@ func TestServiceDeactivate_RejectsGlobalWorkflow(t *testing.T) {
 	}
 	if !IsValidationError(err) {
 		t.Fatalf("Deactivate() error = %v, want validation error", err)
+	}
+}
+
+func TestServiceCreateWaitsForInFlightRefreshBeforePersisting(t *testing.T) {
+	store := &concurrentStore{
+		versions: []Version{
+			{
+				ID:       "global-v1",
+				Scope:    Scope{},
+				ScopeKey: "global",
+				Version:  1,
+				Active:   true,
+				Name:     "global",
+				Payload: Payload{
+					SchemaVersion: 1,
+					Features:      FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
+				},
+			},
+		},
+		createCalled: make(chan struct{}, 1),
+	}
+	compiler := &blockingCompiler{
+		delegate:  NewCompiler(nil),
+		blockCall: 2,
+		blocked:   make(chan struct{}),
+		release:   make(chan struct{}),
+	}
+	service, err := NewService(store, compiler)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	refreshDone := make(chan error, 1)
+	go func() {
+		refreshDone <- service.Refresh(context.Background())
+	}()
+
+	<-compiler.blocked
+
+	type createResult struct {
+		version *Version
+		err     error
+	}
+	createDone := make(chan createResult, 1)
+	go func() {
+		version, err := service.Create(context.Background(), CreateInput{
+			Scope:    Scope{Provider: "openai"},
+			Activate: true,
+			Name:     "openai",
+			Payload: Payload{
+				SchemaVersion: 1,
+				Features:      FeatureFlags{Cache: false, Audit: true, Usage: true, Guardrails: false},
+			},
+		})
+		createDone <- createResult{version: version, err: err}
+	}()
+
+	select {
+	case <-store.createCalled:
+		t.Fatal("Create() persisted a new version while an older refresh was still rebuilding the snapshot")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(compiler.release)
+
+	if err := <-refreshDone; err != nil {
+		t.Fatalf("background Refresh() error = %v", err)
+	}
+	result := <-createDone
+	if result.err != nil {
+		t.Fatalf("Create() error = %v", result.err)
+	}
+	if result.version == nil {
+		t.Fatal("Create() returned nil version")
+	}
+
+	policy, err := service.Match(core.NewExecutionPlanSelector("openai", "gpt-5"))
+	if err != nil {
+		t.Fatalf("Match() error = %v", err)
+	}
+	if policy == nil {
+		t.Fatal("Match() returned nil policy")
+	}
+	if policy.VersionID != result.version.ID {
+		t.Fatalf("VersionID = %q, want %q", policy.VersionID, result.version.ID)
 	}
 }

--- a/internal/executionplans/service_test.go
+++ b/internal/executionplans/service_test.go
@@ -181,6 +181,19 @@ func (c *previewEmptyCompiler) Compile(version Version) (*CompiledPlan, error) {
 	return c.delegate.Compile(version)
 }
 
+type versionFailingCompiler struct {
+	delegate Compiler
+	version  string
+	err      error
+}
+
+func (c *versionFailingCompiler) Compile(version Version) (*CompiledPlan, error) {
+	if version.ID == c.version {
+		return nil, c.err
+	}
+	return c.delegate.Compile(version)
+}
+
 type contextCancelingStore struct {
 	staticStore
 	cancelOnCreate     context.CancelFunc
@@ -431,6 +444,73 @@ func TestServiceListViews_IncludesEffectiveFeatures(t *testing.T) {
 	}
 	if views[0].EffectiveFeatures.Guardrails {
 		t.Fatal("EffectiveFeatures.Guardrails = true, want false")
+	}
+}
+
+func TestServiceListViews_AnnotatesCompileFailuresPerRow(t *testing.T) {
+	store := &staticStore{
+		versions: []Version{
+			{
+				ID:       "global-v1",
+				Scope:    Scope{},
+				ScopeKey: "global",
+				Version:  1,
+				Active:   true,
+				Name:     "global",
+				Payload: Payload{
+					SchemaVersion: 1,
+					Features:      FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
+				},
+			},
+			{
+				ID:       "provider-v1",
+				Scope:    Scope{Provider: "openai"},
+				ScopeKey: "provider:openai",
+				Version:  1,
+				Active:   true,
+				Name:     "broken-provider",
+				Payload: Payload{
+					SchemaVersion: 1,
+					Features:      FeatureFlags{Cache: false, Audit: true, Usage: true, Guardrails: false},
+				},
+			},
+		},
+	}
+	service, err := NewService(store, &versionFailingCompiler{
+		delegate: NewCompiler(nil),
+		version:  "provider-v1",
+		err:      errors.New("compile failed for provider-v1"),
+	})
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	views, err := service.ListViews(context.Background())
+	if err != nil {
+		t.Fatalf("ListViews() error = %v, want nil", err)
+	}
+	if len(views) != 2 {
+		t.Fatalf("len(views) = %d, want 2", len(views))
+	}
+
+	if views[0].ID != "global-v1" {
+		t.Fatalf("views[0].ID = %q, want global-v1", views[0].ID)
+	}
+	if views[0].CompileError != "" {
+		t.Fatalf("views[0].CompileError = %q, want empty", views[0].CompileError)
+	}
+
+	if views[1].ID != "provider-v1" {
+		t.Fatalf("views[1].ID = %q, want provider-v1", views[1].ID)
+	}
+	if views[1].CompileError != "compile execution plan \"provider-v1\": compile failed for provider-v1" {
+		t.Fatalf("views[1].CompileError = %q, want wrapped compile failure", views[1].CompileError)
+	}
+	if views[1].ScopeType != "provider" {
+		t.Fatalf("views[1].ScopeType = %q, want provider", views[1].ScopeType)
+	}
+	if views[1].ScopeDisplay != "openai" {
+		t.Fatalf("views[1].ScopeDisplay = %q, want openai", views[1].ScopeDisplay)
 	}
 }
 

--- a/internal/executionplans/service_test.go
+++ b/internal/executionplans/service_test.go
@@ -169,6 +169,46 @@ func (c *blockingCompiler) Compile(version Version) (*CompiledPlan, error) {
 	return c.delegate.Compile(version)
 }
 
+type previewEmptyCompiler struct {
+	delegate Compiler
+}
+
+func (c *previewEmptyCompiler) Compile(version Version) (*CompiledPlan, error) {
+	if version.ID == "preview" {
+		return nil, nil
+	}
+	return c.delegate.Compile(version)
+}
+
+type contextCancelingStore struct {
+	staticStore
+	cancelOnCreate     context.CancelFunc
+	cancelOnDeactivate context.CancelFunc
+}
+
+func (s *contextCancelingStore) ListActive(ctx context.Context) ([]Version, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return s.staticStore.ListActive(ctx)
+}
+
+func (s *contextCancelingStore) Create(ctx context.Context, input CreateInput) (*Version, error) {
+	version, err := s.staticStore.Create(ctx, input)
+	if err == nil && s.cancelOnCreate != nil {
+		s.cancelOnCreate()
+	}
+	return version, err
+}
+
+func (s *contextCancelingStore) Deactivate(ctx context.Context, id string) error {
+	err := s.staticStore.Deactivate(ctx, id)
+	if err == nil && s.cancelOnDeactivate != nil {
+		s.cancelOnDeactivate()
+	}
+	return err
+}
+
 func TestServiceMatch_MostSpecificWins(t *testing.T) {
 	store := &staticStore{
 		versions: []Version{
@@ -537,5 +577,175 @@ func TestServiceCreateWaitsForInFlightRefreshBeforePersisting(t *testing.T) {
 	}
 	if policy.VersionID != result.version.ID {
 		t.Fatalf("VersionID = %q, want %q", policy.VersionID, result.version.ID)
+	}
+}
+
+func TestServiceCreateRejectsEmptyCompiledPreviewBeforePersisting(t *testing.T) {
+	store := &concurrentStore{
+		versions: []Version{
+			{
+				ID:       "global-v1",
+				Scope:    Scope{},
+				ScopeKey: "global",
+				Version:  1,
+				Active:   true,
+				Name:     "global",
+				Payload: Payload{
+					SchemaVersion: 1,
+					Features:      FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
+				},
+			},
+		},
+		createCalled: make(chan struct{}, 1),
+	}
+	service, err := NewService(store, &previewEmptyCompiler{delegate: NewCompiler(nil)})
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	created, err := service.Create(context.Background(), CreateInput{
+		Scope:    Scope{Provider: "openai"},
+		Activate: true,
+		Name:     "openai",
+		Payload: Payload{
+			SchemaVersion: 1,
+			Features:      FeatureFlags{Cache: false, Audit: true, Usage: true, Guardrails: false},
+		},
+	})
+	if err == nil {
+		t.Fatal("Create() error = nil, want validation error")
+	}
+	if !IsValidationError(err) {
+		t.Fatalf("Create() error = %v, want validation error", err)
+	}
+	if err.Error() != "compiled plan is empty or missing policy" {
+		t.Fatalf("Create() error = %q, want compiled plan is empty or missing policy", err.Error())
+	}
+	if created != nil {
+		t.Fatalf("Create() version = %#v, want nil", created)
+	}
+	select {
+	case <-store.createCalled:
+		t.Fatal("Create() persisted a version even though preview compilation was empty")
+	default:
+	}
+}
+
+func TestServiceCreateRefreshIgnoresRequestContextCancellationAfterPersist(t *testing.T) {
+	store := &contextCancelingStore{
+		staticStore: staticStore{
+			versions: []Version{
+				{
+					ID:       "global-v1",
+					Scope:    Scope{},
+					ScopeKey: "global",
+					Version:  1,
+					Active:   true,
+					Name:     "global",
+					Payload: Payload{
+						SchemaVersion: 1,
+						Features:      FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
+					},
+				},
+			},
+		},
+	}
+	service, err := NewService(store, NewCompiler(nil))
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	store.cancelOnCreate = cancel
+
+	created, err := service.Create(ctx, CreateInput{
+		Scope:    Scope{Provider: "openai"},
+		Activate: true,
+		Name:     "openai",
+		Payload: Payload{
+			SchemaVersion: 1,
+			Features:      FeatureFlags{Cache: false, Audit: true, Usage: true, Guardrails: false},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if created == nil {
+		t.Fatal("Create() returned nil version")
+	}
+
+	policy, err := service.Match(core.NewExecutionPlanSelector("openai", "gpt-5"))
+	if err != nil {
+		t.Fatalf("Match() error = %v", err)
+	}
+	if policy == nil {
+		t.Fatal("Match() returned nil policy")
+	}
+	if policy.VersionID != created.ID {
+		t.Fatalf("VersionID = %q, want %q", policy.VersionID, created.ID)
+	}
+}
+
+func TestServiceDeactivateRefreshIgnoresRequestContextCancellationAfterPersist(t *testing.T) {
+	store := &contextCancelingStore{
+		staticStore: staticStore{
+			versions: []Version{
+				{
+					ID:       "global-v1",
+					Scope:    Scope{},
+					ScopeKey: "global",
+					Version:  1,
+					Active:   true,
+					Name:     "global",
+					Payload: Payload{
+						SchemaVersion: 1,
+						Features:      FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
+					},
+				},
+				{
+					ID:       "provider-v1",
+					Scope:    Scope{Provider: "openai"},
+					ScopeKey: "provider:openai",
+					Version:  1,
+					Active:   true,
+					Name:     "openai",
+					Payload: Payload{
+						SchemaVersion: 1,
+						Features:      FeatureFlags{Cache: false, Audit: true, Usage: true, Guardrails: false},
+					},
+				},
+			},
+		},
+	}
+	service, err := NewService(store, NewCompiler(nil))
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	store.cancelOnDeactivate = cancel
+
+	if err := service.Deactivate(ctx, "provider-v1"); err != nil {
+		t.Fatalf("Deactivate() error = %v", err)
+	}
+
+	policy, err := service.Match(core.NewExecutionPlanSelector("openai", "gpt-5"))
+	if err != nil {
+		t.Fatalf("Match() error = %v", err)
+	}
+	if policy == nil {
+		t.Fatal("Match() returned nil policy")
+	}
+	if policy.VersionID != "global-v1" {
+		t.Fatalf("VersionID = %q, want global-v1", policy.VersionID)
 	}
 }

--- a/internal/executionplans/service_test.go
+++ b/internal/executionplans/service_test.go
@@ -27,8 +27,8 @@ func (s *staticStore) ListActive(context.Context) ([]Version, error) {
 func (s *staticStore) Get(_ context.Context, id string) (*Version, error) {
 	for _, version := range s.versions {
 		if version.ID == id {
-			copy := version
-			return &copy, nil
+			versionCopy := version
+			return &versionCopy, nil
 		}
 	}
 	return nil, ErrNotFound
@@ -95,8 +95,8 @@ func (s *concurrentStore) Get(_ context.Context, id string) (*Version, error) {
 
 	for _, version := range s.versions {
 		if version.ID == id {
-			copy := version
-			return &copy, nil
+			versionCopy := version
+			return &versionCopy, nil
 		}
 	}
 	return nil, ErrNotFound

--- a/internal/executionplans/store.go
+++ b/internal/executionplans/store.go
@@ -43,5 +43,6 @@ type Store interface {
 	ListActive(ctx context.Context) ([]Version, error)
 	Get(ctx context.Context, id string) (*Version, error)
 	Create(ctx context.Context, input CreateInput) (*Version, error)
+	Deactivate(ctx context.Context, id string) error
 	Close() error
 }

--- a/internal/executionplans/store_mongodb.go
+++ b/internal/executionplans/store_mongodb.go
@@ -174,6 +174,20 @@ func (s *MongoDBStore) Create(ctx context.Context, input CreateInput) (*Version,
 	return version, nil
 }
 
+func (s *MongoDBStore) Deactivate(ctx context.Context, id string) error {
+	result, err := s.collection.UpdateOne(ctx,
+		bson.D{{Key: "_id", Value: id}, {Key: "active", Value: true}},
+		bson.D{{Key: "$set", Value: bson.D{{Key: "active", Value: false}}}},
+	)
+	if err != nil {
+		return fmt.Errorf("deactivate execution plan version: %w", err)
+	}
+	if result.MatchedCount == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 func (s *MongoDBStore) Close() error {
 	return nil
 }

--- a/internal/executionplans/store_postgresql.go
+++ b/internal/executionplans/store_postgresql.go
@@ -181,6 +181,21 @@ func (s *PostgreSQLStore) createVersion(ctx context.Context, input CreateInput, 
 	return version, nil
 }
 
+func (s *PostgreSQLStore) Deactivate(ctx context.Context, id string) error {
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE execution_plan_versions
+		SET active = FALSE
+		WHERE id::text = $1 AND active = TRUE
+	`, id)
+	if err != nil {
+		return fmt.Errorf("deactivate execution plan version: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 func (s *PostgreSQLStore) Close() error {
 	return nil
 }

--- a/internal/executionplans/store_sqlite.go
+++ b/internal/executionplans/store_sqlite.go
@@ -172,6 +172,25 @@ func (s *SQLiteStore) Create(ctx context.Context, input CreateInput) (*Version, 
 	return version, nil
 }
 
+func (s *SQLiteStore) Deactivate(ctx context.Context, id string) error {
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE execution_plan_versions
+		SET active = 0
+		WHERE id = ? AND active = 1
+	`, id)
+	if err != nil {
+		return fmt.Errorf("deactivate execution plan version: %w", err)
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("deactivate execution plan version rows affected: %w", err)
+	}
+	if rowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 func (s *SQLiteStore) Close() error {
 	return nil
 }

--- a/internal/executionplans/types.go
+++ b/internal/executionplans/types.go
@@ -149,8 +149,5 @@ func normalizeCreateInput(input CreateInput) (CreateInput, string, string, error
 	input.Name = strings.TrimSpace(input.Name)
 	input.Description = strings.TrimSpace(input.Description)
 	input.Payload = payload
-	if input.Name == "" {
-		return CreateInput{}, "", "", newValidationError("name is required", nil)
-	}
 	return input, scopeKey, planHash, nil
 }

--- a/internal/executionplans/types_test.go
+++ b/internal/executionplans/types_test.go
@@ -25,3 +25,29 @@ func TestNormalizeScope_RejectsColonDelimitedFields(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeCreateInput_AllowsEmptyName(t *testing.T) {
+	t.Parallel()
+
+	input, scopeKey, planHash, err := normalizeCreateInput(CreateInput{
+		Scope:    Scope{},
+		Activate: true,
+		Name:     "",
+		Payload: Payload{
+			SchemaVersion: 1,
+			Features:      FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
+		},
+	})
+	if err != nil {
+		t.Fatalf("normalizeCreateInput() error = %v", err)
+	}
+	if input.Name != "" {
+		t.Fatalf("Name = %q, want empty", input.Name)
+	}
+	if scopeKey != "global" {
+		t.Fatalf("scopeKey = %q, want global", scopeKey)
+	}
+	if planHash == "" {
+		t.Fatal("planHash is empty")
+	}
+}

--- a/internal/executionplans/view.go
+++ b/internal/executionplans/view.go
@@ -1,0 +1,14 @@
+package executionplans
+
+import "gomodel/internal/core"
+
+// View is the admin-facing representation of one active execution-plan version.
+// It includes both the persisted payload and the effective runtime features after
+// process-level feature caps are applied.
+type View struct {
+	Version
+	ScopeType         string                 `json:"scope_type"`
+	ScopeDisplay      string                 `json:"scope_display"`
+	EffectiveFeatures core.ExecutionFeatures `json:"effective_features"`
+	GuardrailsHash    string                 `json:"guardrails_hash,omitempty"`
+}

--- a/internal/executionplans/view.go
+++ b/internal/executionplans/view.go
@@ -4,11 +4,14 @@ import "gomodel/internal/core"
 
 // View is the admin-facing representation of one active execution-plan version.
 // It includes both the persisted payload and the effective runtime features after
-// process-level feature caps are applied.
+// process-level feature caps are applied. Broken rows are still returned with
+// CompileError populated so the admin API can inspect persisted workflows that
+// no longer compile cleanly.
 type View struct {
 	Version
 	ScopeType         string                 `json:"scope_type"`
 	ScopeDisplay      string                 `json:"scope_display"`
 	EffectiveFeatures core.ExecutionFeatures `json:"effective_features"`
 	GuardrailsHash    string                 `json:"guardrails_hash,omitempty"`
+	CompileError      string                 `json:"compile_error,omitempty"`
 }

--- a/internal/guardrails/registry.go
+++ b/internal/guardrails/registry.go
@@ -2,6 +2,7 @@ package guardrails
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"gomodel/internal/responsecache"
@@ -34,6 +35,20 @@ func (r *Registry) Len() int {
 		return 0
 	}
 	return len(r.entries)
+}
+
+// Names returns the registered guardrail names in sorted order.
+func (r *Registry) Names() []string {
+	if r == nil || len(r.entries) == 0 {
+		return []string{}
+	}
+
+	names := make([]string, 0, len(r.entries))
+	for name := range r.entries {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // Register adds one named guardrail and its hashing descriptor.

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -278,6 +278,10 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 		adminAPI.GET("/aliases", cfg.AdminHandler.ListAliases)
 		adminAPI.PUT("/aliases/:name", cfg.AdminHandler.UpsertAlias)
 		adminAPI.DELETE("/aliases/:name", cfg.AdminHandler.DeleteAlias)
+		adminAPI.GET("/execution-plans", cfg.AdminHandler.ListExecutionPlans)
+		adminAPI.GET("/execution-plans/guardrails", cfg.AdminHandler.ListExecutionPlanGuardrails)
+		adminAPI.POST("/execution-plans", cfg.AdminHandler.CreateExecutionPlan)
+		adminAPI.POST("/execution-plans/:id/deactivate", cfg.AdminHandler.DeactivateExecutionPlan)
 	}
 
 	// Admin dashboard UI routes (behind ADMIN_UI_ENABLED flag)

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -297,6 +297,33 @@ func TestAdminEndpoints_Enabled(t *testing.T) {
 	}
 }
 
+func TestAdminExecutionPlanEndpoints_AreRegistered(t *testing.T) {
+	mock := &mockProvider{}
+	adminHandler := admin.NewHandler(nil, nil)
+	srv := New(mock, &Config{
+		AdminEndpointsEnabled: true,
+		AdminHandler:          adminHandler,
+	})
+
+	for _, tc := range []struct {
+		method string
+		path   string
+	}{
+		{method: http.MethodGet, path: "/admin/api/v1/execution-plans"},
+		{method: http.MethodGet, path: "/admin/api/v1/execution-plans/guardrails"},
+		{method: http.MethodPost, path: "/admin/api/v1/execution-plans"},
+		{method: http.MethodPost, path: "/admin/api/v1/execution-plans/test-plan/deactivate"},
+	} {
+		req := httptest.NewRequest(tc.method, tc.path, nil)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code == http.StatusNotFound {
+			t.Fatalf("%s %s returned 404, want registered route", tc.method, tc.path)
+		}
+	}
+}
+
 func TestAdminEndpoints_Disabled(t *testing.T) {
 	mock := &mockProvider{}
 	srv := New(mock, &Config{


### PR DESCRIPTION
## Summary
- move workflow async nodes into a dedicated branch under the response node
- align the inline async L-turn and label so Usage <- Audit Log <-| Async renders consistently
- add regression coverage for the execution-plan async layout structure and connector geometry

## Test Plan
- [x] node --test internal/admin/dashboard/static/js/modules/execution-plans-layout.test.js internal/admin/dashboard/static/js/modules/execution-plans.test.js
- [x] go test ./...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflows page to create, edit, deactivate and filter execution plans with provider/model scoping, guardrail steps, and server-backed APIs
  * Execution pipeline visualization added to workflows and audit details (cache, guardrails, AI, async branches)
  * Configurable feature toggles (cache, audit, usage, guardrails) and guardrail selection list

* **UX / Style**
  * Responsive dashboard styles and updated sidebar navigation separating Workflows and Audit Logs

* **Chores**
  * Admin API endpoints for managing execution plans and guardrails registered

* **Tests**
  * New client and server tests covering layout, module logic, handlers, endpoints, and static assets
<!-- end of auto-generated comment: release notes by coderabbit.ai -->