### PR TITLE
fix(fallback): reject null manual rules and cover responses guards

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -842,8 +843,15 @@ func loadFallbackConfig(cfg *FallbackConfig) error {
 		}
 		seenKeys[key] = struct{}{}
 
+		var rawModels json.RawMessage
+		if err := decoder.Decode(&rawModels); err != nil {
+			return fmt.Errorf("fallback.manual_rules_path: failed to parse %q: %w", path, err)
+		}
+		if bytes.Equal(bytes.TrimSpace(rawModels), []byte("null")) {
+			return fmt.Errorf("fallback.manual_rules_path: null not allowed for %q in %q", key, path)
+		}
 		var models []string
-		if err := decoder.Decode(&models); err != nil {
+		if err := json.Unmarshal(rawModels, &models); err != nil {
 			return fmt.Errorf("fallback.manual_rules_path: failed to parse %q: %w", path, err)
 		}
 		decoded[key] = models

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -503,6 +503,44 @@ func TestLoad_FallbackManualRulesRejectsDuplicateRawJSONKeys(t *testing.T) {
 	})
 }
 
+func TestLoad_FallbackManualRulesRejectsNullValues(t *testing.T) {
+	clearAllConfigEnvVars(t)
+
+	withTempDir(t, func(dir string) {
+		manualRulesPath := filepath.Join(dir, "fallback.json")
+		if err := os.WriteFile(manualRulesPath, []byte(`{
+			"gpt-4o": null
+		}`), 0644); err != nil {
+			t.Fatalf("Failed to write fallback rules: %v", err)
+		}
+
+		type yamlConfig struct {
+			Fallback struct {
+				ManualRulesPath string `yaml:"manual_rules_path"`
+			} `yaml:"fallback"`
+		}
+
+		yamlCfg := yamlConfig{}
+		yamlCfg.Fallback.ManualRulesPath = manualRulesPath
+		yamlData, err := yaml.Marshal(yamlCfg)
+		if err != nil {
+			t.Fatalf("Failed to marshal config.yaml: %v", err)
+		}
+
+		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), yamlData, 0644); err != nil {
+			t.Fatalf("Failed to write config.yaml: %v", err)
+		}
+
+		_, err = Load()
+		if err == nil {
+			t.Fatal("expected Load() to fail for null fallback manual rule values")
+		}
+		if !strings.Contains(err.Error(), `fallback.manual_rules_path: null not allowed for "gpt-4o"`) {
+			t.Fatalf("Load() error = %v, want null manual rule value error", err)
+		}
+	})
+}
+
 func TestLoad_FeatureFallbackModeEnvOverridesFallbackDefaultMode(t *testing.T) {
 	clearAllConfigEnvVars(t)
 	t.Setenv("FEATURE_FALLBACK_MODE", "auto")

--- a/internal/server/fallback_test.go
+++ b/internal/server/fallback_test.go
@@ -452,6 +452,93 @@ func TestResponses_StreamFallsBackToAlternateModel(t *testing.T) {
 	}
 }
 
+func TestResponses_StreamDoesNotFallbackOnNonAvailabilityError(t *testing.T) {
+	provider := &fallbackProvider{
+		responsesStreams: map[string]string{
+			"azure/gpt-4o": "data: {\"type\":\"response.output_text.delta\",\"delta\":\"fallback response\"}\n\ndata: [DONE]\n\n",
+		},
+		responsesErrors: map[string]error{
+			"gpt-4o": core.NewInvalidRequestError("temperature must be between 0 and 2", nil),
+		},
+		supportedModels: map[string]string{
+			"gpt-4o":       "openai",
+			"azure/gpt-4o": "azure",
+		},
+	}
+
+	handler := newHandler(provider, nil, nil, nil, nil, nil, fallbackResolverStub{
+		selectors: []core.ModelSelector{{Provider: "azure", Model: "gpt-4o"}},
+	}, nil)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-4o","stream":true,"input":"hi"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := handler.Responses(c); err != nil {
+		t.Fatalf("handler.Responses() error = %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if len(provider.responsesCalls) != 1 || provider.responsesCalls[0] != "gpt-4o" {
+		t.Fatalf("responses calls = %v, want only the primary model", provider.responsesCalls)
+	}
+	if core.GetFallbackUsed(c.Request().Context()) {
+		t.Fatal("expected request context to remain unmarked for fallback")
+	}
+}
+
+func TestResponses_StreamDoesNotFallbackWhenExecutionPolicyDisablesFallback(t *testing.T) {
+	provider := &fallbackProvider{
+		responsesStreams: map[string]string{
+			"azure/gpt-4o": "data: {\"type\":\"response.output_text.delta\",\"delta\":\"fallback response\"}\n\ndata: [DONE]\n\n",
+		},
+		responsesErrors: map[string]error{
+			"gpt-4o": core.NewProviderError("openai", http.StatusServiceUnavailable, "model temporarily unavailable", nil),
+		},
+		supportedModels: map[string]string{
+			"gpt-4o":       "openai",
+			"azure/gpt-4o": "azure",
+		},
+	}
+
+	handler := newHandler(provider, nil, nil, nil, nil, requestExecutionPolicyResolverFunc(func(core.ExecutionPlanSelector) (*core.ResolvedExecutionPolicy, error) {
+		return &core.ResolvedExecutionPolicy{
+			VersionID: "plan-fallback-off",
+			Features: core.ExecutionFeatures{
+				Cache:      true,
+				Audit:      true,
+				Usage:      true,
+				Guardrails: true,
+				Fallback:   false,
+			},
+		}, nil
+	}), fallbackResolverStub{
+		selectors: []core.ModelSelector{{Provider: "azure", Model: "gpt-4o"}},
+	}, nil)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-4o","stream":true,"input":"hi"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := handler.Responses(c); err != nil {
+		t.Fatalf("handler.Responses() error = %v", err)
+	}
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusServiceUnavailable, rec.Body.String())
+	}
+	if len(provider.responsesCalls) != 1 || provider.responsesCalls[0] != "gpt-4o" {
+		t.Fatalf("responses calls = %v, want only the primary model", provider.responsesCalls)
+	}
+	if core.GetFallbackUsed(c.Request().Context()) {
+		t.Fatal("expected request context to remain unmarked for fallback")
+	}
+}
+
 func TestChatCompletion_DoesNotFallbackOnNonModelNotFound(t *testing.T) {
 	provider := &fallbackProvider{
 		chatErrors: map[string]error{


### PR DESCRIPTION
## Summary
- reject null values in fallback manual rules instead of silently treating them as empty chains
- add config coverage for null manual rule entries
- add negative Responses fallback tests for non-availability errors and execution-policy-disabled fallback

## Verification
- go test ./config ./internal/server
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Configuration validation now enforces stricter rules for fallback manual configuration, explicitly rejecting null values to prevent invalid settings from being loaded.

* **Tests**
  * Added test coverage for configuration validation with null value handling. Added tests verifying fallback behavior correctly does not trigger under non-availability errors or when features are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->