### PR TITLE
fix(providers): reduce metadata enrichment log noise

### DIFF
--- a/internal/modeldata/enricher.go
+++ b/internal/modeldata/enricher.go
@@ -1,8 +1,6 @@
 package modeldata
 
 import (
-	"log/slog"
-
 	"gomodel/internal/core"
 )
 
@@ -18,11 +16,17 @@ type ModelInfoAccessor interface {
 	SetMetadata(modelID string, meta *core.ModelMetadata)
 }
 
+// EnrichStats summarizes one metadata enrichment pass.
+type EnrichStats struct {
+	Enriched int
+	Total    int
+}
+
 // Enrich iterates all models accessible via the accessor and attaches resolved
 // metadata from the model list. Models not found in the list are left unchanged.
-func Enrich(accessor ModelInfoAccessor, list *ModelList) {
+func Enrich(accessor ModelInfoAccessor, list *ModelList) EnrichStats {
 	if list == nil || accessor == nil {
-		return
+		return EnrichStats{}
 	}
 
 	var enriched int
@@ -37,8 +41,8 @@ func Enrich(accessor ModelInfoAccessor, list *ModelList) {
 		}
 	}
 
-	slog.Info("enriched models with metadata",
-		"enriched", enriched,
-		"total", len(ids),
-	)
+	return EnrichStats{
+		Enriched: enriched,
+		Total:    len(ids),
+	}
 }

--- a/internal/providers/init.go
+++ b/internal/providers/init.go
@@ -114,16 +114,18 @@ func Init(ctx context.Context, result *config.LoadResult, factory *ProviderFacto
 			}
 
 			registry.SetModelList(list, raw)
-			registry.EnrichModels()
+			metadataStats := registry.enrichModels()
 
 			if err := registry.SaveToCache(fetchCtx); err != nil {
 				slog.Warn("failed to save cache after model list fetch", "error", err)
 			}
-			slog.Info("model list loaded",
+			attrs := []any{
 				"models", len(list.Models),
 				"providers", len(list.Providers),
 				"provider_models", len(list.ProviderModels),
-			)
+			}
+			attrs = append(attrs, metadataStats.slogAttrs()...)
+			slog.Info("model list loaded", attrs...)
 		}()
 	}
 

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -50,6 +50,20 @@ type ModelRegistry struct {
 	categoryCache            map[core.ModelCategory][]ModelWithProvider
 }
 
+type metadataEnrichmentStats struct {
+	Enriched  int
+	Total     int
+	Providers int
+}
+
+func (s metadataEnrichmentStats) slogAttrs() []any {
+	return []any{
+		"metadata_enriched", s.Enriched,
+		"metadata_total", s.Total,
+		"metadata_providers", s.Providers,
+	}
+}
+
 // NewModelRegistry creates a new model registry
 func NewModelRegistry() *ModelRegistry {
 	return &ModelRegistry{
@@ -190,8 +204,9 @@ func (r *ModelRegistry) Initialize(ctx context.Context) error {
 	r.mu.RLock()
 	list := r.modelList
 	r.mu.RUnlock()
+	metadataStats := metadataEnrichmentStats{}
 	if list != nil {
-		enrichProviderModelMaps(list, providerTypes, newModelsByProvider, nil)
+		metadataStats = enrichProviderModelMaps(list, providerTypes, newModelsByProvider, nil)
 	}
 
 	// Atomically swap the models map and invalidate sorted caches
@@ -206,11 +221,13 @@ func (r *ModelRegistry) Initialize(ctx context.Context) error {
 	r.initialized = true
 	r.initMu.Unlock()
 
-	slog.Info("model registry initialized",
+	attrs := []any{
 		"total_models", totalModels,
 		"providers", len(providers),
 		"failed_providers", failedProviders,
-	)
+	}
+	attrs = append(attrs, metadataStats.slogAttrs()...)
+	slog.Info("model registry initialized", attrs...)
 
 	return nil
 }
@@ -297,8 +314,9 @@ func (r *ModelRegistry) LoadFromCache(ctx context.Context) (int, error) {
 	}
 
 	// Enrich cached models with model list metadata
+	metadataStats := metadataEnrichmentStats{}
 	if list != nil {
-		enrichProviderModelMaps(list, r.snapshotProviderTypes(), newModelsByProvider, nil)
+		metadataStats = enrichProviderModelMaps(list, r.snapshotProviderTypes(), newModelsByProvider, nil)
 	}
 
 	r.mu.Lock()
@@ -311,10 +329,12 @@ func (r *ModelRegistry) LoadFromCache(ctx context.Context) (int, error) {
 	}
 	r.mu.Unlock()
 
-	slog.Info("loaded models from cache",
+	attrs := []any{
 		"models", len(newModels),
 		"cache_updated_at", modelCache.UpdatedAt,
-	)
+	}
+	attrs = append(attrs, metadataStats.slogAttrs()...)
+	slog.Info("loaded models from cache", attrs...)
 
 	return len(newModels), nil
 }
@@ -902,24 +922,29 @@ func (r *ModelRegistry) SetModelList(list *modeldata.ModelList, raw json.RawMess
 // entries instead of mutating them in place so concurrent readers can safely keep
 // using older snapshots after unlocking.
 func (r *ModelRegistry) EnrichModels() {
+	_ = r.enrichModels()
+}
+
+func (r *ModelRegistry) enrichModels() metadataEnrichmentStats {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	if r.modelList == nil || len(r.models) == 0 {
-		return
+		return metadataEnrichmentStats{}
 	}
 
 	providerTypes := make(map[core.Provider]string, len(r.providerTypes))
 	maps.Copy(providerTypes, r.providerTypes)
 
 	replacements := make(map[*ModelInfo]*ModelInfo, len(r.models))
-	enrichProviderModelMaps(r.modelList, providerTypes, r.modelsByProvider, replacements)
+	stats := enrichProviderModelMaps(r.modelList, providerTypes, r.modelsByProvider, replacements)
 	for modelID, info := range r.models {
 		if replacement, ok := replacements[info]; ok {
 			r.models[modelID] = replacement
 		}
 	}
 	r.invalidateSortedCaches()
+	return stats
 }
 
 // ResolveMetadata resolves metadata for a model directly via the stored model list,
@@ -976,21 +1001,26 @@ func enrichProviderModelMaps(
 	providerTypes map[core.Provider]string,
 	modelsByProvider map[string]map[string]*ModelInfo,
 	replacements map[*ModelInfo]*ModelInfo,
-) {
+) metadataEnrichmentStats {
 	if list == nil {
-		return
+		return metadataEnrichmentStats{}
 	}
+	stats := metadataEnrichmentStats{}
 	for _, providerModels := range modelsByProvider {
 		if len(providerModels) == 0 {
 			continue
 		}
+		stats.Providers++
 		accessor := &registryAccessor{
 			models:        providerModels,
 			providerTypes: providerTypes,
 			replacements:  replacements,
 		}
-		modeldata.Enrich(accessor, list)
+		enrichStats := modeldata.Enrich(accessor, list)
+		stats.Enriched += enrichStats.Enriched
+		stats.Total += enrichStats.Total
 	}
+	return stats
 }
 
 // registryAccessor implements modeldata.ModelInfoAccessor.
@@ -1104,14 +1134,16 @@ func (r *ModelRegistry) refreshModelList(ctx context.Context, url string) {
 	}
 
 	r.SetModelList(list, raw)
-	r.EnrichModels()
+	metadataStats := r.enrichModels()
 
 	if err := r.SaveToCache(fetchCtx); err != nil {
 		if !isBenignBackgroundRefreshError(ctx, err) {
 			slog.Warn("failed to save cache after model list refresh", "error", err)
 		}
 	}
-	slog.Debug("model list refreshed", "models", len(list.Models))
+	attrs := []any{"models", len(list.Models)}
+	attrs = append(attrs, metadataStats.slogAttrs()...)
+	slog.Debug("model list refreshed", attrs...)
 }
 
 func isBenignBackgroundRefreshError(parent context.Context, err error) bool {

--- a/internal/providers/registry_test.go
+++ b/internal/providers/registry_test.go
@@ -1,11 +1,14 @@
 package providers
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -606,6 +609,92 @@ func TestModelRegistry(t *testing.T) {
 			t.Errorf("expected empty provider type for unknown model, got '%s'", pType)
 		}
 	})
+}
+
+func TestInitialize_LogsSingleMetadataSummaryPerCycle(t *testing.T) {
+	registry := NewModelRegistry()
+
+	openAIProvider := &registryMockProvider{
+		name: "openai-primary",
+		modelsResponse: &core.ModelsResponse{
+			Object: "list",
+			Data: []core.Model{
+				{ID: "gpt-test", Object: "model", OwnedBy: "openai"},
+			},
+		},
+	}
+	anthropicProvider := &registryMockProvider{
+		name: "anthropic-primary",
+		modelsResponse: &core.ModelsResponse{
+			Object: "list",
+			Data: []core.Model{
+				{ID: "claude-test", Object: "model", OwnedBy: "anthropic"},
+			},
+		},
+	}
+	registry.RegisterProviderWithNameAndType(openAIProvider, "openai-primary", "openai")
+	registry.RegisterProviderWithNameAndType(anthropicProvider, "anthropic-primary", "anthropic")
+
+	raw := []byte(`{
+		"version": 1,
+		"updated_at": "2025-01-01T00:00:00Z",
+		"providers": {
+			"openai": {
+				"display_name": "OpenAI",
+				"api_type": "openai",
+				"supported_modes": ["chat"]
+			},
+			"anthropic": {
+				"display_name": "Anthropic",
+				"api_type": "openai",
+				"supported_modes": ["chat"]
+			}
+		},
+		"models": {
+			"gpt-test": {
+				"display_name": "GPT Test",
+				"modes": ["chat"]
+			},
+			"claude-test": {
+				"display_name": "Claude Test",
+				"modes": ["chat"]
+			}
+		},
+		"provider_models": {}
+	}`)
+	list, err := modeldata.Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	registry.SetModelList(list, raw)
+
+	var buf bytes.Buffer
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() {
+		slog.SetDefault(original)
+	})
+
+	if err := registry.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	logs := buf.String()
+	if got := strings.Count(logs, `"msg":"enriched models with metadata"`); got != 0 {
+		t.Fatalf("expected no standalone enrichment info logs, got %d:\n%s", got, logs)
+	}
+	if got := strings.Count(logs, `"msg":"model registry initialized"`); got != 1 {
+		t.Fatalf("expected one initialization summary log, got %d:\n%s", got, logs)
+	}
+	if !strings.Contains(logs, `"metadata_enriched":2`) {
+		t.Fatalf("expected initialization log to include metadata_enriched=2:\n%s", logs)
+	}
+	if !strings.Contains(logs, `"metadata_total":2`) {
+		t.Fatalf("expected initialization log to include metadata_total=2:\n%s", logs)
+	}
+	if !strings.Contains(logs, `"metadata_providers":2`) {
+		t.Fatalf("expected initialization log to include metadata_providers=2:\n%s", logs)
+	}
 }
 
 func TestListModelsWithProvider_Empty(t *testing.T) {


### PR DESCRIPTION
## Summary
- move metadata enrichment logging to cycle-level summaries instead of per-provider INFO logs
- include metadata enrichment counts on cache/init/model-list summary logs
- add a regression test covering the single-summary logging behavior

## Test Plan
- go test ./...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced model registry initialization logging to include metadata enrichment statistics, showing the count of models enriched and total models processed for better visibility into the enrichment process.

* **Tests**
  * Added test coverage for metadata enrichment statistics logging during model registry initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->