### PR TITLE
chore(deps): bump CI and Docker Go pins

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version: 1.26.1
           cache: true
 
       - name: Run GoReleaser

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.26"
+  GO_VERSION: "1.26.1"
 
 # Restrict token permissions to minimum required
 permissions:
@@ -53,7 +53,7 @@ jobs:
         run: go test -v -race -coverprofile=coverage.out ./internal/... ./config/...
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: ./coverage.out
           fail_ci_if_error: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ Backward compatibility is not a primary constraint in the current development st
 
 1. Make small, focused changes.
 2. Run format/lint/tests relevant to the change.
+3. Do not hide work in detached goroutines; respect context synchronously and return typed `core.GatewayError` values.
 
 ## Commit Format
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ Prefer squash-and-merge to keep the merged commit subject aligned with the PR ti
 ## Error Handling
 
 - All errors returned to clients must be instances of `core.GatewayError`.
+- Do not hide work in detached goroutines; respect context synchronously and return typed `core.GatewayError` values.
 - Use the typed client-facing categories `provider_error`, `rate_limit_error`, `invalid_request_error`, `authentication_error`, and `not_found_error`.
 - Public error responses must use the OpenAI-compatible shape:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage — run on the build host's native arch for speed, cross-compile for target
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine3.23 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.1-alpine3.23 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/internal/embedding/embedding.go
+++ b/internal/embedding/embedding.go
@@ -7,10 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"time"
-
-	all_minilm "github.com/clems4ever/all-minilm-l6-v2-go/all_minilm_l6_v2"
 
 	"gomodel/config"
 )
@@ -55,55 +52,6 @@ func NewEmbedder(cfg config.EmbedderConfig, rawProviders map[string]config.RawPr
 		model:      model,
 		httpClient: &http.Client{Timeout: defaultTimeout},
 	}, nil
-}
-
-// MiniLMEmbedder uses the local all-MiniLM-L6-v2 ONNX model.
-// No network calls are made; the model runs in-process.
-type miniLMEmbedder struct {
-	model *all_minilm.Model
-}
-
-func newMiniLMEmbedder(runtimePath string) (*miniLMEmbedder, error) {
-	if runtimePath == "" {
-		runtimePath = os.Getenv("ONNXRUNTIME_LIB_PATH")
-	}
-	var opts []all_minilm.ModelOption
-	if runtimePath != "" {
-		opts = append(opts, all_minilm.WithRuntimePath(runtimePath))
-	}
-	m, err := all_minilm.NewModel(opts...)
-	if err != nil {
-		return nil, fmt.Errorf("embedding: failed to load local MiniLM model: %w", err)
-	}
-	return &miniLMEmbedder{model: m}, nil
-}
-
-func (e *miniLMEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
-	type result struct {
-		vec []float32
-		err error
-	}
-	ch := make(chan result, 1)
-	go func() {
-		vec, err := e.model.Compute(text, true)
-		ch <- result{vec, err}
-	}()
-	select {
-	case <-ctx.Done():
-		return nil, fmt.Errorf("embedding: MiniLM compute failed: %w", ctx.Err())
-	case r := <-ch:
-		if r.err != nil {
-			return nil, fmt.Errorf("embedding: MiniLM compute failed: %w", r.err)
-		}
-		return r.vec, nil
-	}
-}
-
-func (e *miniLMEmbedder) Close() error {
-	if e.model != nil {
-		e.model.Close()
-	}
-	return nil
 }
 
 // apiEmbedder calls POST /v1/embeddings on any OpenAI-compatible endpoint.

--- a/internal/embedding/embedding_minilm_cgo.go
+++ b/internal/embedding/embedding_minilm_cgo.go
@@ -4,16 +4,24 @@ package embedding
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 
 	all_minilm "github.com/clems4ever/all-minilm-l6-v2-go/all_minilm_l6_v2"
+
+	"gomodel/internal/core"
 )
 
 // MiniLMEmbedder uses the local all-MiniLM-L6-v2 ONNX model.
 // No network calls are made; the model runs in-process.
 type miniLMEmbedder struct {
 	model *all_minilm.Model
+}
+
+var miniLMModelCompute = func(model *all_minilm.Model, text string) ([]float32, error) {
+	return model.Compute(text, true)
 }
 
 func newMiniLMEmbedder(runtimePath string) (*miniLMEmbedder, error) {
@@ -32,24 +40,21 @@ func newMiniLMEmbedder(runtimePath string) (*miniLMEmbedder, error) {
 }
 
 func (e *miniLMEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
-	type result struct {
-		vec []float32
-		err error
+	if err := ctx.Err(); err != nil {
+		return nil, core.NewInvalidRequestError("embedding: MiniLM compute canceled", err)
 	}
-	ch := make(chan result, 1)
-	go func() {
-		vec, err := e.model.Compute(text, true)
-		ch <- result{vec, err}
-	}()
-	select {
-	case <-ctx.Done():
-		return nil, fmt.Errorf("embedding: MiniLM compute failed: %w", ctx.Err())
-	case r := <-ch:
-		if r.err != nil {
-			return nil, fmt.Errorf("embedding: MiniLM compute failed: %w", r.err)
+
+	vec, err := miniLMModelCompute(e.model, text)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, core.NewInvalidRequestError("embedding: MiniLM compute canceled", errors.Join(ctxErr, err))
 		}
-		return r.vec, nil
+		return nil, core.NewProviderError("local", http.StatusBadGateway, "embedding: MiniLM compute failed", err)
 	}
+	if err := ctx.Err(); err != nil {
+		return nil, core.NewInvalidRequestError("embedding: MiniLM compute canceled", err)
+	}
+	return vec, nil
 }
 
 func (e *miniLMEmbedder) Close() error {

--- a/internal/embedding/embedding_minilm_cgo.go
+++ b/internal/embedding/embedding_minilm_cgo.go
@@ -1,0 +1,60 @@
+//go:build cgo
+
+package embedding
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	all_minilm "github.com/clems4ever/all-minilm-l6-v2-go/all_minilm_l6_v2"
+)
+
+// MiniLMEmbedder uses the local all-MiniLM-L6-v2 ONNX model.
+// No network calls are made; the model runs in-process.
+type miniLMEmbedder struct {
+	model *all_minilm.Model
+}
+
+func newMiniLMEmbedder(runtimePath string) (*miniLMEmbedder, error) {
+	if runtimePath == "" {
+		runtimePath = os.Getenv("ONNXRUNTIME_LIB_PATH")
+	}
+	var opts []all_minilm.ModelOption
+	if runtimePath != "" {
+		opts = append(opts, all_minilm.WithRuntimePath(runtimePath))
+	}
+	m, err := all_minilm.NewModel(opts...)
+	if err != nil {
+		return nil, fmt.Errorf("embedding: failed to load local MiniLM model: %w", err)
+	}
+	return &miniLMEmbedder{model: m}, nil
+}
+
+func (e *miniLMEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	type result struct {
+		vec []float32
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		vec, err := e.model.Compute(text, true)
+		ch <- result{vec, err}
+	}()
+	select {
+	case <-ctx.Done():
+		return nil, fmt.Errorf("embedding: MiniLM compute failed: %w", ctx.Err())
+	case r := <-ch:
+		if r.err != nil {
+			return nil, fmt.Errorf("embedding: MiniLM compute failed: %w", r.err)
+		}
+		return r.vec, nil
+	}
+}
+
+func (e *miniLMEmbedder) Close() error {
+	if e.model != nil {
+		e.model.Close()
+	}
+	return nil
+}

--- a/internal/embedding/embedding_minilm_cgo_test.go
+++ b/internal/embedding/embedding_minilm_cgo_test.go
@@ -1,0 +1,103 @@
+//go:build cgo
+
+package embedding
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	all_minilm "github.com/clems4ever/all-minilm-l6-v2-go/all_minilm_l6_v2"
+
+	"gomodel/internal/core"
+)
+
+func TestMiniLMEmbedderEmbed_ContextAlreadyDone(t *testing.T) {
+	orig := miniLMModelCompute
+	t.Cleanup(func() { miniLMModelCompute = orig })
+
+	called := false
+	miniLMModelCompute = func(_ *all_minilm.Model, _ string) ([]float32, error) {
+		called = true
+		return nil, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := (&miniLMEmbedder{}).Embed(ctx, "ignored")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if called {
+		t.Fatal("compute should not be called when context is already done")
+	}
+
+	gatewayErr, ok := err.(*core.GatewayError)
+	if !ok {
+		t.Fatalf("error type = %T, want *core.GatewayError", err)
+	}
+	if gatewayErr.Type != core.ErrorTypeInvalidRequest {
+		t.Fatalf("gatewayErr.Type = %q, want %q", gatewayErr.Type, core.ErrorTypeInvalidRequest)
+	}
+	if !errors.Is(gatewayErr, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", gatewayErr)
+	}
+}
+
+func TestMiniLMEmbedderEmbed_ComputeFailure(t *testing.T) {
+	orig := miniLMModelCompute
+	t.Cleanup(func() { miniLMModelCompute = orig })
+
+	computeErr := errors.New("compute failed")
+	miniLMModelCompute = func(_ *all_minilm.Model, _ string) ([]float32, error) {
+		return nil, computeErr
+	}
+
+	_, err := (&miniLMEmbedder{}).Embed(context.Background(), "ignored")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	gatewayErr, ok := err.(*core.GatewayError)
+	if !ok {
+		t.Fatalf("error type = %T, want *core.GatewayError", err)
+	}
+	if gatewayErr.Type != core.ErrorTypeProvider {
+		t.Fatalf("gatewayErr.Type = %q, want %q", gatewayErr.Type, core.ErrorTypeProvider)
+	}
+	if !errors.Is(gatewayErr, computeErr) {
+		t.Fatalf("expected wrapped compute error, got %v", gatewayErr)
+	}
+}
+
+func TestMiniLMEmbedderEmbed_ContextDoneDuringCompute(t *testing.T) {
+	orig := miniLMModelCompute
+	t.Cleanup(func() { miniLMModelCompute = orig })
+
+	computeErr := errors.New("compute interrupted")
+	ctx, cancel := context.WithCancel(context.Background())
+	miniLMModelCompute = func(_ *all_minilm.Model, _ string) ([]float32, error) {
+		cancel()
+		return nil, computeErr
+	}
+
+	_, err := (&miniLMEmbedder{}).Embed(ctx, "ignored")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	gatewayErr, ok := err.(*core.GatewayError)
+	if !ok {
+		t.Fatalf("error type = %T, want *core.GatewayError", err)
+	}
+	if gatewayErr.Type != core.ErrorTypeInvalidRequest {
+		t.Fatalf("gatewayErr.Type = %q, want %q", gatewayErr.Type, core.ErrorTypeInvalidRequest)
+	}
+	if !errors.Is(gatewayErr, context.Canceled) {
+		t.Fatalf("expected wrapped context cancellation, got %v", gatewayErr)
+	}
+	if !errors.Is(gatewayErr, computeErr) {
+		t.Fatalf("expected wrapped compute error, got %v", gatewayErr)
+	}
+}

--- a/internal/embedding/embedding_minilm_nocgo.go
+++ b/internal/embedding/embedding_minilm_nocgo.go
@@ -1,0 +1,20 @@
+//go:build !cgo
+
+package embedding
+
+import (
+	"context"
+	"fmt"
+)
+
+func newMiniLMEmbedder(string) (*miniLMEmbedder, error) {
+	return nil, fmt.Errorf("embedding: local MiniLM embedder requires cgo-enabled builds")
+}
+
+type miniLMEmbedder struct{}
+
+func (*miniLMEmbedder) Embed(context.Context, string) ([]float32, error) {
+	return nil, fmt.Errorf("embedding: local MiniLM embedder requires cgo-enabled builds")
+}
+
+func (*miniLMEmbedder) Close() error { return nil }


### PR DESCRIPTION
## Summary
- bump `codecov/codecov-action` from v5 to v6
- pin GitHub Actions and the Docker builder image to Go 1.26.1
- split the local MiniLM embedder into cgo and non-cgo paths so static Docker builds keep passing
- leave `github.com/ncruces/go-sqlite3` unchanged because the newer release breaks the current `sqlite-vec` integration

## Validation
- `go test ./...`
- `CGO_ENABLED=0 go build ./cmd/gomodel`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/test.yml .github/workflows/release.yml`
- `docker build -t gomodel-deps-check .`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain to 1.26.1 across builds and CI
  * Upgraded Codecov integration to v6

* **Refactor**
  * Reworked local embedding implementation to require cgo-enabled builds for the native MiniLM backend

* **Documentation**
  * Clarified agent error-handling guidance: avoid detached goroutines and return typed gateway errors

* **Tests**
  * Added tests covering local embedder error and cancellation behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->