### PR TITLE
feat(dashboard): add managed API keys page

### DIFF
--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -1142,6 +1142,7 @@ td.col-price {
     flex-wrap: wrap;
     gap: 8px;
     justify-content: flex-end;
+    margin-top: 16px;
 }
 
 .model-row-actions {
@@ -2823,6 +2824,40 @@ body.conversation-drawer-open {
 .ep-node-cache-miss .ep-node-badge {
     color: var(--text-muted);
     border-color: var(--border);
+}
+
+/* ─── Auth node ─── */
+
+.ep-node-auth-success {
+    border-color: color-mix(in srgb, var(--success) 52%, var(--border));
+    background: color-mix(in srgb, var(--success) 9%, var(--bg-surface));
+}
+
+.ep-node-auth-success .ep-node-icon {
+    background: color-mix(in srgb, var(--success) 18%, var(--bg));
+    color: var(--success);
+}
+
+.ep-node-auth-success .ep-node-label {
+    color: color-mix(in srgb, var(--success) 85%, var(--text));
+}
+
+.ep-node-auth-success .ep-node-sub {
+    color: color-mix(in srgb, var(--success) 70%, var(--text-muted));
+}
+
+.ep-node-auth-error {
+    border-color: color-mix(in srgb, var(--danger) 52%, var(--border));
+    background: color-mix(in srgb, var(--danger) 9%, var(--bg-surface));
+}
+
+.ep-node-auth-error .ep-node-icon {
+    background: color-mix(in srgb, var(--danger) 14%, var(--bg));
+    color: var(--danger);
+}
+
+.ep-node-auth-error .ep-node-label {
+    color: color-mix(in srgb, var(--danger) 85%, var(--text));
 }
 
 /* ─── AI node ─── */

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -3012,3 +3012,87 @@ body.conversation-drawer-open {
     white-space: nowrap;
     flex-shrink: 0;
 }
+
+/* --- API Keys page --- */
+.auth-keys-help-notice {
+    margin-bottom: 20px;
+}
+
+.auth-key-issued-banner {
+    background: color-mix(in srgb, var(--success) 8%, var(--bg-surface));
+    border: 1px solid color-mix(in srgb, var(--success) 30%, var(--border));
+    border-radius: var(--radius);
+    padding: 16px;
+    margin-bottom: 20px;
+}
+
+.auth-key-issued-warning {
+    font-size: 13px;
+    font-weight: 600;
+    margin-bottom: 12px;
+    color: color-mix(in srgb, var(--success) 80%, var(--text));
+}
+
+.auth-key-issued-value-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 12px;
+    flex-wrap: wrap;
+}
+
+.auth-key-issued-token {
+    flex: 1;
+    min-width: 0;
+    overflow-x: auto;
+    padding: 8px 12px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    font-size: 13px;
+    word-break: break-all;
+}
+
+.auth-key-redacted {
+    color: var(--text-muted);
+    font-size: 13px;
+}
+
+.auth-key-description {
+    color: var(--text-muted);
+    font-size: 13px;
+    max-width: 220px;
+}
+
+.auth-key-status-badge {
+    display: inline-block;
+    padding: 2px 10px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.auth-key-status-active {
+    background: color-mix(in srgb, var(--success) 12%, var(--bg));
+    border: 1px solid color-mix(in srgb, var(--success) 30%, var(--border));
+    color: var(--success);
+}
+
+.auth-key-status-inactive {
+    background: color-mix(in srgb, var(--danger) 10%, var(--bg));
+    border: 1px solid color-mix(in srgb, var(--danger) 30%, var(--border));
+    color: var(--danger);
+}
+
+.auth-key-copy-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    transition: background-color 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.auth-key-copy-btn-copied {
+    background: color-mix(in srgb, var(--success) 12%, var(--bg));
+    border-color: color-mix(in srgb, var(--success) 40%, var(--border));
+    color: var(--success);
+}

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -99,7 +99,7 @@ function dashboard() {
             if (page === 'audit') {
                 page = 'audit-logs';
             }
-            page = (['overview', 'usage', 'models', 'workflows', 'audit-logs', 'settings'].includes(page)) ? page : 'overview';
+            page = (['overview', 'usage', 'models', 'workflows', 'audit-logs', 'auth-keys', 'settings'].includes(page)) ? page : 'overview';
             const sub = parts[1] || null;
             return { page, sub };
         },
@@ -117,6 +117,7 @@ function dashboard() {
             this.page = page;
             if (page === 'usage' && sub === 'costs') this.usageMode = 'costs';
             if (page === 'audit-logs') this.fetchAuditLog(true);
+            if (page === 'auth-keys' && typeof this.fetchAuthKeys === 'function') this.fetchAuthKeys();
             if (page === 'settings' && typeof this.ensureTimezoneOptions === 'function') this.ensureTimezoneOptions();
 
             window.addEventListener('popstate', () => {
@@ -128,6 +129,7 @@ function dashboard() {
                 }
                 if (p === 'overview') this.renderChart();
                 if (p === 'audit-logs') this.fetchAuditLog(true);
+                if (p === 'auth-keys' && typeof this.fetchAuthKeys === 'function') this.fetchAuthKeys();
                 if (p === 'workflows' && typeof this.fetchExecutionPlansPage === 'function') {
                     this.fetchExecutionPlansPage();
                 }
@@ -159,6 +161,7 @@ function dashboard() {
             if (page === 'usage') this.fetchUsagePage();
             if (page === 'workflows' && typeof this.fetchExecutionPlansPage === 'function') this.fetchExecutionPlansPage();
             if (page === 'audit-logs') this.fetchAuditLog(true);
+            if (page === 'auth-keys' && typeof this.fetchAuthKeys === 'function') this.fetchAuthKeys();
             if (page === 'settings' && typeof this.ensureTimezoneOptions === 'function') this.ensureTimezoneOptions();
         },
 
@@ -428,6 +431,15 @@ function dashboard() {
                 String(d.getSeconds()).padStart(2, '0');
         },
 
+        formatDateUTC(ts) {
+            if (!ts) return '-';
+            const d = new Date(ts);
+            if (Number.isNaN(d.getTime())) return '-';
+            return d.getUTCFullYear() + '-' +
+                String(d.getUTCMonth() + 1).padStart(2, '0') + '-' +
+                String(d.getUTCDate()).padStart(2, '0');
+        },
+
         formatTimestampUTC(ts) {
             if (!ts) return '-';
             const d = new Date(ts);
@@ -458,6 +470,10 @@ function dashboard() {
         resolveModuleFactory(
             typeof dashboardAliasesModule === 'function' ? dashboardAliasesModule : null,
             'dashboardAliasesModule'
+        ),
+        resolveModuleFactory(
+            typeof dashboardAuthKeysModule === 'function' ? dashboardAuthKeysModule : null,
+            'dashboardAuthKeysModule'
         ),
         resolveModuleFactory(
             typeof dashboardExecutionPlansModule === 'function' ? dashboardExecutionPlansModule : null,

--- a/internal/admin/dashboard/static/js/modules/auth-keys.js
+++ b/internal/admin/dashboard/static/js/modules/auth-keys.js
@@ -35,7 +35,9 @@
                     }
                     this.authKeysAvailable = true;
                     if (!this.handleFetchResponse(res, 'auth keys')) {
-                        this.authKeys = [];
+                        if (res.status !== 401) {
+                            this.authKeyError = await this._authKeyResponseMessage(res, 'Unable to load API keys.');
+                        }
                         return;
                     }
                     const payload = await res.json();
@@ -50,20 +52,28 @@
             },
 
             openAuthKeyForm() {
+                if (this.authKeyFormSubmitting || this.authKeyFormOpen) {
+                    return;
+                }
                 this.authKeyFormOpen = true;
                 this.authKeyError = '';
                 this.authKeyNotice = '';
-                this.authKeyIssuedValue = '';
-                this.resetAuthKeyCopyFeedback();
-                this.authKeyForm = this.defaultAuthKeyForm();
+                if (!this.authKeyIssuedValue) {
+                    this.resetAuthKeyCopyFeedback();
+                    this.authKeyForm = this.defaultAuthKeyForm();
+                }
             },
 
             closeAuthKeyForm() {
+                if (!this.authKeyFormOpen) {
+                    return;
+                }
                 this.authKeyFormOpen = false;
                 this.authKeyError = '';
-                this.authKeyIssuedValue = '';
                 this.resetAuthKeyCopyFeedback();
-                this.authKeyForm = this.defaultAuthKeyForm();
+                if (!this.authKeyFormSubmitting && !this.authKeyIssuedValue) {
+                    this.authKeyForm = this.defaultAuthKeyForm();
+                }
             },
 
             clearAuthKeyCopyResetTimer() {
@@ -208,6 +218,8 @@
                     }
                     const issued = await res.json();
                     this.authKeyIssuedValue = issued.value || '';
+                    this.authKeyFormOpen = true;
+                    this.resetAuthKeyCopyFeedback();
                     this.authKeyForm = this.defaultAuthKeyForm();
                     await this.fetchAuthKeys();
                 } catch (e) {

--- a/internal/admin/dashboard/static/js/modules/auth-keys.js
+++ b/internal/admin/dashboard/static/js/modules/auth-keys.js
@@ -1,0 +1,188 @@
+(function(global) {
+    function dashboardAuthKeysModule() {
+        return {
+            authKeys: [],
+            authKeysAvailable: true,
+            authKeysLoading: false,
+            authKeyError: '',
+            authKeyNotice: '',
+            authKeyFormOpen: false,
+            authKeyFormSubmitting: false,
+            authKeyIssuedValue: '',
+            authKeyDeactivatingID: '',
+            authKeyCopied: false,
+            authKeyForm: {
+                name: '',
+                description: '',
+                expires_at: ''
+            },
+
+            defaultAuthKeyForm() {
+                return { name: '', description: '', expires_at: '' };
+            },
+
+            async fetchAuthKeys() {
+                this.authKeysLoading = true;
+                this.authKeyError = '';
+                try {
+                    const res = await fetch('/admin/api/v1/auth-keys', { headers: this.headers() });
+                    if (res.status === 503) {
+                        this.authKeysAvailable = false;
+                        this.authKeys = [];
+                        return;
+                    }
+                    this.authKeysAvailable = true;
+                    if (!this.handleFetchResponse(res, 'auth keys')) {
+                        this.authKeys = [];
+                        return;
+                    }
+                    const payload = await res.json();
+                    this.authKeys = Array.isArray(payload) ? payload : [];
+                } catch (e) {
+                    console.error('Failed to fetch auth keys:', e);
+                    this.authKeys = [];
+                    this.authKeyError = 'Unable to load API keys.';
+                } finally {
+                    this.authKeysLoading = false;
+                }
+            },
+
+            openAuthKeyForm() {
+                this.authKeyFormOpen = true;
+                this.authKeyError = '';
+                this.authKeyNotice = '';
+                this.authKeyIssuedValue = '';
+                this.authKeyForm = this.defaultAuthKeyForm();
+            },
+
+            closeAuthKeyForm() {
+                this.authKeyFormOpen = false;
+                this.authKeyError = '';
+                this.authKeyIssuedValue = '';
+                this.authKeyCopied = false;
+                this.authKeyForm = this.defaultAuthKeyForm();
+            },
+
+            copyAuthKeyValue() {
+                navigator.clipboard.writeText(this.authKeyIssuedValue).then(() => {
+                    this.authKeyCopied = true;
+                    setTimeout(() => { this.authKeyCopied = false; }, 2000);
+                });
+            },
+
+            dismissIssuedKey() {
+                this.authKeyIssuedValue = '';
+                this.authKeyCopied = false;
+                this.authKeyForm = this.defaultAuthKeyForm();
+            },
+
+            async _authKeyResponseMessage(res, fallback) {
+                try {
+                    const payload = await res.json();
+                    if (payload && payload.error && payload.error.message) {
+                        return payload.error.message;
+                    }
+                } catch (_) {
+                    // Ignore invalid or empty responses and return the fallback message.
+                }
+                return fallback;
+            },
+
+            async submitAuthKeyForm() {
+                const name = String(this.authKeyForm.name || '').trim();
+                if (!name) {
+                    this.authKeyError = 'Name is required.';
+                    return;
+                }
+
+                this.authKeyError = '';
+                this.authKeyNotice = '';
+                this.authKeyFormSubmitting = true;
+
+                const payload = {
+                    name,
+                    description: String(this.authKeyForm.description || '').trim() || undefined
+                };
+                if (this.authKeyForm.expires_at) {
+                    payload.expires_at = this.authKeyForm.expires_at + 'T23:59:59Z';
+                }
+
+                try {
+                    const res = await fetch('/admin/api/v1/auth-keys', {
+                        method: 'POST',
+                        headers: this.headers(),
+                        body: JSON.stringify(payload)
+                    });
+                    if (res.status === 503) {
+                        this.authKeysAvailable = false;
+                        this.authKeyError = 'Auth keys feature is unavailable.';
+                        return;
+                    }
+                    if (res.status === 401) {
+                        this.authError = true;
+                        this.needsAuth = true;
+                        this.authKeyError = 'Authentication required.';
+                        return;
+                    }
+                    if (res.status !== 201) {
+                        this.authKeyError = await this._authKeyResponseMessage(res, 'Failed to create API key.');
+                        return;
+                    }
+                    const issued = await res.json();
+                    this.authKeyIssuedValue = issued.value || '';
+                    this.authKeyForm = this.defaultAuthKeyForm();
+                    await this.fetchAuthKeys();
+                } catch (e) {
+                    console.error('Failed to issue auth key:', e);
+                    this.authKeyError = 'Failed to create API key.';
+                } finally {
+                    this.authKeyFormSubmitting = false;
+                }
+            },
+
+            async deactivateAuthKey(key) {
+                if (!key || !key.active) {
+                    return;
+                }
+                if (!window.confirm('Deactivate key "' + key.name + '"? This cannot be undone.')) {
+                    return;
+                }
+
+                this.authKeyDeactivatingID = key.id;
+                this.authKeyError = '';
+                this.authKeyNotice = '';
+
+                try {
+                    const res = await fetch('/admin/api/v1/auth-keys/' + encodeURIComponent(key.id) + '/deactivate', {
+                        method: 'POST',
+                        headers: this.headers()
+                    });
+                    if (res.status === 503) {
+                        this.authKeysAvailable = false;
+                        this.authKeyError = 'Auth keys feature is unavailable.';
+                        return;
+                    }
+                    if (res.status === 401) {
+                        this.authError = true;
+                        this.needsAuth = true;
+                        this.authKeyError = 'Authentication required.';
+                        return;
+                    }
+                    if (res.status !== 204) {
+                        this.authKeyError = await this._authKeyResponseMessage(res, 'Failed to deactivate key.');
+                        return;
+                    }
+                    await this.fetchAuthKeys();
+                    this.authKeyNotice = 'Key "' + key.name + '" deactivated.';
+                } catch (e) {
+                    console.error('Failed to deactivate auth key:', e);
+                    this.authKeyError = 'Failed to deactivate key.';
+                } finally {
+                    this.authKeyDeactivatingID = '';
+                }
+            }
+        };
+    }
+
+    global.dashboardAuthKeysModule = dashboardAuthKeysModule;
+})(window);

--- a/internal/admin/dashboard/static/js/modules/auth-keys.js
+++ b/internal/admin/dashboard/static/js/modules/auth-keys.js
@@ -11,6 +11,8 @@
             authKeyIssuedValue: '',
             authKeyDeactivatingID: '',
             authKeyCopied: false,
+            authKeyCopyError: false,
+            authKeyCopyResetTimer: null,
             authKeyForm: {
                 name: '',
                 description: '',
@@ -52,6 +54,7 @@
                 this.authKeyError = '';
                 this.authKeyNotice = '';
                 this.authKeyIssuedValue = '';
+                this.resetAuthKeyCopyFeedback();
                 this.authKeyForm = this.defaultAuthKeyForm();
             },
 
@@ -59,20 +62,95 @@
                 this.authKeyFormOpen = false;
                 this.authKeyError = '';
                 this.authKeyIssuedValue = '';
-                this.authKeyCopied = false;
+                this.resetAuthKeyCopyFeedback();
                 this.authKeyForm = this.defaultAuthKeyForm();
             },
 
+            clearAuthKeyCopyResetTimer() {
+                if (this.authKeyCopyResetTimer !== null) {
+                    clearTimeout(this.authKeyCopyResetTimer);
+                    this.authKeyCopyResetTimer = null;
+                }
+            },
+
+            scheduleAuthKeyCopyFeedbackReset() {
+                this.clearAuthKeyCopyResetTimer();
+                this.authKeyCopyResetTimer = setTimeout(() => {
+                    this.authKeyCopied = false;
+                    this.authKeyCopyError = false;
+                    this.authKeyCopyResetTimer = null;
+                }, 2000);
+            },
+
+            resetAuthKeyCopyFeedback() {
+                this.clearAuthKeyCopyResetTimer();
+                this.authKeyCopied = false;
+                this.authKeyCopyError = false;
+            },
+
+            setAuthKeyCopyFeedback(copied, hasError) {
+                this.authKeyCopied = copied;
+                this.authKeyCopyError = hasError;
+                this.scheduleAuthKeyCopyFeedbackReset();
+            },
+
             copyAuthKeyValue() {
-                navigator.clipboard.writeText(this.authKeyIssuedValue).then(() => {
-                    this.authKeyCopied = true;
-                    setTimeout(() => { this.authKeyCopied = false; }, 2000);
-                });
+                const value = String(this.authKeyIssuedValue || '');
+                const clipboard = global.navigator && global.navigator.clipboard;
+
+                this.resetAuthKeyCopyFeedback();
+
+                if (clipboard && typeof clipboard.writeText === 'function') {
+                    return clipboard.writeText(value).then(() => {
+                        this.setAuthKeyCopyFeedback(true, false);
+                    }).catch((error) => {
+                        console.error('Failed to copy auth key:', error);
+                        this.setAuthKeyCopyFeedback(false, true);
+                    });
+                }
+
+                const doc = global.document;
+                if (!doc || !doc.body || typeof doc.createElement !== 'function' || typeof doc.execCommand !== 'function') {
+                    this.setAuthKeyCopyFeedback(false, true);
+                    return Promise.resolve();
+                }
+
+                const textarea = doc.createElement('textarea');
+                textarea.value = value;
+                textarea.setAttribute('readonly', '');
+                textarea.style.position = 'fixed';
+                textarea.style.top = '0';
+                textarea.style.left = '0';
+                textarea.style.opacity = '0';
+
+                try {
+                    doc.body.appendChild(textarea);
+                    if (typeof textarea.focus === 'function') {
+                        textarea.focus();
+                    }
+                    if (typeof textarea.select === 'function') {
+                        textarea.select();
+                    }
+                    if (typeof textarea.setSelectionRange === 'function') {
+                        textarea.setSelectionRange(0, textarea.value.length);
+                    }
+                    const copied = !!doc.execCommand('copy');
+                    this.setAuthKeyCopyFeedback(copied, !copied);
+                } catch (error) {
+                    console.error('Failed to copy auth key:', error);
+                    this.setAuthKeyCopyFeedback(false, true);
+                } finally {
+                    if (textarea.parentNode) {
+                        textarea.parentNode.removeChild(textarea);
+                    }
+                }
+
+                return Promise.resolve();
             },
 
             dismissIssuedKey() {
                 this.authKeyIssuedValue = '';
-                this.authKeyCopied = false;
+                this.resetAuthKeyCopyFeedback();
                 this.authKeyForm = this.defaultAuthKeyForm();
             },
 

--- a/internal/admin/dashboard/static/js/modules/auth-keys.test.js
+++ b/internal/admin/dashboard/static/js/modules/auth-keys.test.js
@@ -192,3 +192,110 @@ test('copyAuthKeyValue falls back to document.execCommand when clipboard API is 
     assert.equal(module.authKeyCopied, true);
     assert.equal(module.authKeyCopyError, false);
 });
+
+test('fetchAuthKeys preserves existing rows and surfaces non-auth HTTP errors', async () => {
+    const module = createAuthKeysModule({
+        fetch: async () => ({
+            status: 500,
+            ok: false,
+            statusText: 'Internal Server Error',
+            async json() {
+                return {
+                    error: {
+                        message: 'storage unavailable'
+                    }
+                };
+            }
+        }),
+        console: {
+            error() {}
+        }
+    });
+
+    module.authKeys = [{ id: 'existing-key' }];
+    module.headers = () => ({});
+    module.handleFetchResponse = () => false;
+
+    await module.fetchAuthKeys();
+
+    assert.deepEqual(module.authKeys, [{ id: 'existing-key' }]);
+    assert.equal(module.authKeyError, 'storage unavailable');
+});
+
+test('fetchAuthKeys preserves existing rows on authentication failures handled by handleFetchResponse', async () => {
+    const module = createAuthKeysModule({
+        fetch: async () => ({
+            status: 401,
+            ok: false,
+            statusText: 'Unauthorized'
+        })
+    });
+
+    module.authKeys = [{ id: 'existing-key' }];
+    module.headers = () => ({});
+    module.handleFetchResponse = (res) => {
+        if (res.status === 401) {
+            module.authError = true;
+            module.needsAuth = true;
+        }
+        return false;
+    };
+
+    await module.fetchAuthKeys();
+
+    assert.deepEqual(module.authKeys, [{ id: 'existing-key' }]);
+    assert.equal(module.authKeyError, '');
+    assert.equal(module.authError, true);
+    assert.equal(module.needsAuth, true);
+});
+
+test('openAuthKeyForm and closeAuthKeyForm preserve an issued key instead of clearing it', () => {
+    const module = createAuthKeysModule();
+    module.authKeyIssuedValue = 'sk_gom_once';
+
+    module.openAuthKeyForm();
+    assert.equal(module.authKeyFormOpen, true);
+    assert.equal(module.authKeyIssuedValue, 'sk_gom_once');
+
+    module.closeAuthKeyForm();
+    assert.equal(module.authKeyFormOpen, false);
+    assert.equal(module.authKeyIssuedValue, 'sk_gom_once');
+});
+
+test('submitAuthKeyForm reopens the editor if issuance finishes after a manual close', async () => {
+    let resolveResponse;
+    const responsePromise = new Promise((resolve) => {
+        resolveResponse = resolve;
+    });
+    const module = createAuthKeysModule({
+        fetch: async () => responsePromise
+    });
+
+    module.headers = () => ({ 'Content-Type': 'application/json' });
+    module.fetchAuthKeys = async () => {};
+    module.authKeyFormOpen = true;
+    module.authKeyForm = {
+        name: 'ci-deploy',
+        description: '',
+        expires_at: ''
+    };
+
+    const submitPromise = module.submitAuthKeyForm();
+    module.closeAuthKeyForm();
+
+    assert.equal(module.authKeyFormOpen, false);
+    assert.equal(module.authKeyFormSubmitting, true);
+
+    resolveResponse({
+        status: 201,
+        async json() {
+            return { value: 'sk_gom_async' };
+        }
+    });
+
+    await submitPromise;
+
+    assert.equal(module.authKeyFormOpen, true);
+    assert.equal(module.authKeyIssuedValue, 'sk_gom_async');
+    assert.equal(module.authKeyFormSubmitting, false);
+});

--- a/internal/admin/dashboard/static/js/modules/auth-keys.test.js
+++ b/internal/admin/dashboard/static/js/modules/auth-keys.test.js
@@ -26,6 +26,26 @@ function createAuthKeysModule(overrides) {
     return factory();
 }
 
+function createTimerHarness() {
+    let nextID = 1;
+    const timers = new Map();
+    return {
+        setTimeout(callback, _delay) {
+            const id = nextID++;
+            timers.set(id, callback);
+            return id;
+        },
+        clearTimeout(id) {
+            timers.delete(id);
+        },
+        runAll() {
+            const callbacks = Array.from(timers.values());
+            timers.clear();
+            callbacks.forEach((callback) => callback());
+        }
+    };
+}
+
 test('submitAuthKeyForm serializes date-only expirations to the end of the selected UTC day', async () => {
     const requests = [];
     const module = createAuthKeysModule({
@@ -56,4 +76,119 @@ test('submitAuthKeyForm serializes date-only expirations to the end of the selec
         JSON.parse(requests[0].options.body).expires_at,
         '2026-04-01T23:59:59Z'
     );
+});
+
+test('copyAuthKeyValue uses navigator.clipboard when available and resets feedback', async () => {
+    const timers = createTimerHarness();
+    const writes = [];
+    const module = createAuthKeysModule({
+        setTimeout: timers.setTimeout,
+        clearTimeout: timers.clearTimeout,
+        window: {
+            navigator: {
+                clipboard: {
+                    writeText(value) {
+                        writes.push(value);
+                        return Promise.resolve();
+                    }
+                }
+            }
+        }
+    });
+
+    module.authKeyIssuedValue = 'sk_gom_test';
+
+    await module.copyAuthKeyValue();
+
+    assert.deepEqual(writes, ['sk_gom_test']);
+    assert.equal(module.authKeyCopied, true);
+    assert.equal(module.authKeyCopyError, false);
+
+    timers.runAll();
+
+    assert.equal(module.authKeyCopied, false);
+    assert.equal(module.authKeyCopyError, false);
+});
+
+test('copyAuthKeyValue sets an error flag when navigator.clipboard rejects', async () => {
+    const timers = createTimerHarness();
+    const module = createAuthKeysModule({
+        console: {
+            error() {}
+        },
+        setTimeout: timers.setTimeout,
+        clearTimeout: timers.clearTimeout,
+        window: {
+            navigator: {
+                clipboard: {
+                    writeText() {
+                        return Promise.reject(new Error('denied'));
+                    }
+                }
+            }
+        }
+    });
+
+    module.authKeyIssuedValue = 'sk_gom_test';
+
+    await module.copyAuthKeyValue();
+
+    assert.equal(module.authKeyCopied, false);
+    assert.equal(module.authKeyCopyError, true);
+
+    timers.runAll();
+
+    assert.equal(module.authKeyCopied, false);
+    assert.equal(module.authKeyCopyError, false);
+});
+
+test('copyAuthKeyValue falls back to document.execCommand when clipboard API is unavailable', async () => {
+    const timers = createTimerHarness();
+    const appended = [];
+    const removed = [];
+    const fakeBody = {
+        appendChild(node) {
+            node.parentNode = fakeBody;
+            appended.push(node);
+        },
+        removeChild(node) {
+            removed.push(node);
+            node.parentNode = null;
+        }
+    };
+    const fakeDocument = {
+        body: fakeBody,
+        createElement() {
+            return {
+                value: '',
+                style: {},
+                setAttribute() {},
+                focus() {},
+                select() {},
+                setSelectionRange() {},
+                parentNode: null
+            };
+        },
+        execCommand(command) {
+            assert.equal(command, 'copy');
+            return true;
+        }
+    };
+    const module = createAuthKeysModule({
+        setTimeout: timers.setTimeout,
+        clearTimeout: timers.clearTimeout,
+        window: {
+            document: fakeDocument
+        }
+    });
+
+    module.authKeyIssuedValue = 'sk_gom_test';
+
+    await module.copyAuthKeyValue();
+
+    assert.equal(appended.length, 1);
+    assert.equal(removed.length, 1);
+    assert.equal(appended[0].value, 'sk_gom_test');
+    assert.equal(module.authKeyCopied, true);
+    assert.equal(module.authKeyCopyError, false);
 });

--- a/internal/admin/dashboard/static/js/modules/auth-keys.test.js
+++ b/internal/admin/dashboard/static/js/modules/auth-keys.test.js
@@ -1,0 +1,59 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function loadAuthKeysModuleFactory(overrides = {}) {
+    const source = fs.readFileSync(path.join(__dirname, 'auth-keys.js'), 'utf8');
+    const window = {
+        ...(overrides.window || {})
+    };
+    const context = {
+        console,
+        setTimeout,
+        clearTimeout,
+        ...overrides,
+        window
+    };
+    vm.createContext(context);
+    vm.runInContext(source, context);
+    return context.window.dashboardAuthKeysModule;
+}
+
+function createAuthKeysModule(overrides) {
+    const factory = loadAuthKeysModuleFactory(overrides);
+    return factory();
+}
+
+test('submitAuthKeyForm serializes date-only expirations to the end of the selected UTC day', async () => {
+    const requests = [];
+    const module = createAuthKeysModule({
+        fetch: async (url, options) => {
+            requests.push({ url, options });
+            return {
+                status: 201,
+                async json() {
+                    return { value: 'sk_gom_test' };
+                }
+            };
+        }
+    });
+
+    module.headers = () => ({ 'Content-Type': 'application/json' });
+    module.fetchAuthKeys = async () => {};
+    module.authKeyForm = {
+        name: 'ci-deploy',
+        description: '',
+        expires_at: '2026-04-01'
+    };
+
+    await module.submitAuthKeyForm();
+
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0].url, '/admin/api/v1/auth-keys');
+    assert.equal(
+        JSON.parse(requests[0].options.body).expires_at,
+        '2026-04-01T23:59:59Z'
+    );
+});

--- a/internal/admin/dashboard/static/js/modules/dashboard-layout.test.js
+++ b/internal/admin/dashboard/static/js/modules/dashboard-layout.test.js
@@ -94,6 +94,9 @@ test('auth key expirations render as a UTC date with the full UTC timestamp in t
 
     assert.match(indexTemplate, /x-text="key\.expires_at \? formatDateUTC\(key\.expires_at\) : '\\u2014'"/);
     assert.match(indexTemplate, /:title="key\.expires_at \? formatTimestampUTC\(key\.expires_at\) : ''"/);
+    assert.match(indexTemplate, /:disabled="authKeyFormSubmitting"/);
+    assert.match(indexTemplate, /@click="if \(!authKeyFormSubmitting\) openAuthKeyForm\(\)"/);
+    assert.match(indexTemplate, /x-show="authKeys\.length === 0 && !authKeysLoading && !authError && !authKeyError && authKeysAvailable"/);
 });
 
 test('usage and audit pages reuse a shared pagination template', () => {

--- a/internal/admin/dashboard/static/js/modules/dashboard-layout.test.js
+++ b/internal/admin/dashboard/static/js/modules/dashboard-layout.test.js
@@ -82,11 +82,18 @@ test('dashboard pages reuse a shared auth banner template', () => {
     );
 
     const authBannerCalls = indexTemplate.match(/{{template "auth-banner" \.}}/g) || [];
-    assert.equal(authBannerCalls.length, 5);
+    assert.equal(authBannerCalls.length, 6);
     assert.doesNotMatch(
         indexTemplate,
         /<div class="alert alert-warning" x-show="authError">[\s\S]*Authentication required\. Enter your API key in the sidebar to view data\.[\s\S]*<\/div>/
     );
+});
+
+test('auth key expirations render as a UTC date with the full UTC timestamp in the hover title', () => {
+    const indexTemplate = readFixture('../../../templates/index.html');
+
+    assert.match(indexTemplate, /x-text="key\.expires_at \? formatDateUTC\(key\.expires_at\) : '\\u2014'"/);
+    assert.match(indexTemplate, /:title="key\.expires_at \? formatTimestampUTC\(key\.expires_at\) : ''"/);
 });
 
 test('usage and audit pages reuse a shared pagination template', () => {

--- a/internal/admin/dashboard/static/js/modules/execution-plans-layout.test.js
+++ b/internal/admin/dashboard/static/js/modules/execution-plans-layout.test.js
@@ -217,7 +217,7 @@ test('workflow editor renders a live preview card from the draft workflow state'
     );
     assert.match(
         chartTemplate,
-        /{{define "execution-plan-chart"}}[\s\S]*x-show="{{\.}}\.showGuardrails"[\s\S]*x-show="{{\.}}\.showCache"[\s\S]*x-text="{{\.}}\.aiLabel"/
+        /{{define "execution-plan-chart"}}[\s\S]*<span class="ep-node-label">Auth<\/span>[\s\S]*x-text="{{\.}}\.authNodeSublabel"[\s\S]*x-show="{{\.}}\.showGuardrails"[\s\S]*x-show="{{\.}}\.showCache"[\s\S]*x-text="{{\.}}\.aiLabel"/
     );
 });
 
@@ -231,7 +231,7 @@ test('audit log pipeline always renders cache and binds runtime highlight classe
     );
     assert.match(
         template,
-        /x-show="{{\.}}\.showGuardrails"[\s\S]*x-show="{{\.}}\.showUsage"[\s\S]*x-show="{{\.}}\.showAudit"/
+        /:class="{{\.}}\.authNodeClass"[\s\S]*x-show="{{\.}}\.showGuardrails"[\s\S]*x-show="{{\.}}\.showUsage"[\s\S]*x-show="{{\.}}\.showAudit"/
     );
     assert.match(
         template,
@@ -253,6 +253,14 @@ test('audit log pipeline always renders cache and binds runtime highlight classe
     const semanticCacheRule = readCSSRule(css, '.ep-node-cache-semantic');
     assert.match(semanticCacheRule, /border-color:\s*color-mix\(in srgb, var\(--success\) 52%, var\(--border\)\)/);
     assert.match(semanticCacheRule, /background:\s*color-mix\(in srgb, var\(--success\) 9%, var\(--bg-surface\)\)/);
+
+    const authSuccessRule = readCSSRule(css, '.ep-node-auth-success');
+    assert.match(authSuccessRule, /border-color:\s*color-mix\(in srgb, var\(--success\) 52%, var\(--border\)\)/);
+    assert.match(authSuccessRule, /background:\s*color-mix\(in srgb, var\(--success\) 9%, var\(--bg-surface\)\)/);
+
+    const authErrorRule = readCSSRule(css, '.ep-node-auth-error');
+    assert.match(authErrorRule, /border-color:\s*color-mix\(in srgb, var\(--danger\) 52%, var\(--border\)\)/);
+    assert.match(authErrorRule, /background:\s*color-mix\(in srgb, var\(--danger\) 9%, var\(--bg-surface\)\)/);
 
     const skippedAiRule = readCSSRule(css, '.ep-node-ai-skipped');
     assert.match(skippedAiRule, /position:\s*relative/);

--- a/internal/admin/dashboard/static/js/modules/execution-plans.js
+++ b/internal/admin/dashboard/static/js/modules/execution-plans.js
@@ -966,6 +966,8 @@
 	                    aiNodeClass: this.epAiNodeClass(runtime),
 	                    responseConnClass: this.epResponseConnClass(runtime),
 	                    responseNodeClass: this.epResponseNodeClass(runtime),
+				    authNodeClass: this.epAuthNodeClass(runtime),
+				    authNodeSublabel: this.epAuthNodeSublabel(runtime),
 	                    showAsync,
 	                    showUsage,
 	                    showAudit
@@ -1043,6 +1045,18 @@
                 return runtime.responseSuccess ? 'ep-node-endpoint-success' : '';
             },
 
+            epAuthNodeClass(runtime) {
+                if (!runtime) return '';
+                if (runtime.authError) return 'ep-node-auth-error';
+                if (runtime.authMethod === 'api_key' || runtime.authMethod === 'master_key') return 'ep-node-auth-success';
+                return '';
+            },
+
+            epAuthNodeSublabel(runtime) {
+                if (!runtime || !runtime.authMethod) return null;
+                return runtime.authMethod;
+            },
+
             epRuntimeFromEntry(entry) {
                 if (!entry) return null;
                 const normalizedCacheType = (() => {
@@ -1063,6 +1077,8 @@
                         ? !!entry.cache_hit
                         : false;
                 const responseSuccess = Number.isFinite(statusCode) && statusCode >= 200 && statusCode < 300;
+                const authError = String(entry.error_type || '').trim().toLowerCase() === 'authentication_error';
+                const authMethod = String(entry.auth_method || '').trim().toLowerCase() || null;
                 return {
                     cacheHit,
                     cacheType: normalizedCacheType || null,
@@ -1070,7 +1086,9 @@
                     model: entry.model || null,
                     statusCode,
                     responseSuccess,
-                    aiSuccess: responseSuccess && !cacheHit
+                    aiSuccess: responseSuccess && !cacheHit,
+                    authError,
+                    authMethod
                 };
             },
 

--- a/internal/admin/dashboard/static/js/modules/execution-plans.test.js
+++ b/internal/admin/dashboard/static/js/modules/execution-plans.test.js
@@ -154,6 +154,8 @@ test('executionPlanWorkflowChart returns the shared chart contract for workflow 
             aiNodeClass: '',
             responseConnClass: '',
             responseNodeClass: '',
+            authNodeClass: '',
+            authNodeSublabel: null,
             showAsync: true,
             showUsage: false,
             showAudit: true
@@ -204,6 +206,8 @@ test('executionPlanWorkflowChart masks globally disabled workflow features from 
             aiNodeClass: '',
             responseConnClass: '',
             responseNodeClass: '',
+            authNodeClass: '',
+            authNodeSublabel: null,
             showAsync: false,
             showUsage: false,
             showAudit: false
@@ -256,6 +260,8 @@ test('executionPlanAuditChart returns the shared chart contract for audit runtim
             aiNodeClass: 'ep-node-ai-skipped',
             responseConnClass: 'ep-conn-dim',
             responseNodeClass: 'ep-node-endpoint-success',
+            authNodeClass: '',
+            authNodeSublabel: null,
             showAsync: true,
             showUsage: true,
             showAudit: true
@@ -287,6 +293,8 @@ test('executionPlanAuditChart forces audit nodes even when the workflow version 
             aiNodeClass: 'ep-node-ai-skipped',
             responseConnClass: 'ep-conn-dim',
             responseNodeClass: 'ep-node-endpoint-success',
+            authNodeClass: '',
+            authNodeSublabel: null,
             showAsync: true,
             showUsage: false,
             showAudit: true
@@ -1248,7 +1256,9 @@ test('epRuntimeFromEntry derives cache hit state from cache_type without relying
             model: 'gpt-5',
             statusCode: null,
             responseSuccess: false,
-            aiSuccess: false
+            aiSuccess: false,
+            authError: false,
+            authMethod: null
         })
     );
 
@@ -1261,7 +1271,9 @@ test('epRuntimeFromEntry derives cache hit state from cache_type without relying
             model: null,
             statusCode: null,
             responseSuccess: false,
-            aiSuccess: false
+            aiSuccess: false,
+            authError: false,
+            authMethod: null
         })
     );
 
@@ -1274,7 +1286,9 @@ test('epRuntimeFromEntry derives cache hit state from cache_type without relying
             model: null,
             statusCode: null,
             responseSuccess: false,
-            aiSuccess: false
+            aiSuccess: false,
+            authError: false,
+            authMethod: null
         })
     );
 });
@@ -1324,9 +1338,29 @@ test('epRuntimeFromEntry treats any uncached 2xx status as a successful AI and r
             model: 'gpt-5',
             statusCode: 204,
             responseSuccess: true,
-            aiSuccess: true
+            aiSuccess: true,
+            authError: false,
+            authMethod: null
         })
     );
+});
+
+test('auth runtime highlights auth node state from audit entries', () => {
+    const module = createExecutionPlansModule();
+
+    const failedAuth = module.epRuntimeFromEntry({
+        auth_method: 'api_key',
+        error_type: 'authentication_error'
+    });
+    assert.equal(module.epAuthNodeClass(failedAuth), 'ep-node-auth-error');
+    assert.equal(module.epAuthNodeSublabel(failedAuth), 'api_key');
+
+    const masterKeyAuth = module.epRuntimeFromEntry({
+        auth_method: 'master_key',
+        status_code: 200
+    });
+    assert.equal(module.epAuthNodeClass(masterKeyAuth), 'ep-node-auth-success');
+    assert.equal(module.epAuthNodeSublabel(masterKeyAuth), 'master_key');
 });
 
 test('auditEntryExecutionPlan prefers an exact historical workflow version cache over active workflows', () => {

--- a/internal/admin/dashboard/static/js/modules/timestamp-format.test.js
+++ b/internal/admin/dashboard/static/js/modules/timestamp-format.test.js
@@ -100,3 +100,14 @@ test('formatTimestamp uses the effective timezone override for dashboard rows', 
         formatInZone(timestamp, 'America/New_York')
     );
 });
+
+test('formatDateUTC keeps expiration dates on their stored UTC calendar day', () => {
+    const app = loadDashboardApp();
+    app.detectedTimezone = 'Europe/Warsaw';
+    app.timezoneOverride = 'America/Los_Angeles';
+
+    assert.equal(
+        app.formatDateUTC('2026-04-01T23:59:59Z'),
+        '2026-04-01'
+    );
+});

--- a/internal/admin/dashboard/templates/execution-plan-chart.html
+++ b/internal/admin/dashboard/templates/execution-plan-chart.html
@@ -9,6 +9,17 @@
                 <span class="ep-node-label">Client</span>
             </div>
 
+            <div class="ep-step">
+                <div class="ep-conn"></div>
+                <div class="ep-node ep-node-auth" :class="{{.}}.authNodeClass">
+                    <div class="ep-node-icon">
+                        <svg viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+                    </div>
+                    <span class="ep-node-label">Auth</span>
+                    <span class="ep-node-sub" x-show="{{.}}.authNodeSublabel" x-text="{{.}}.authNodeSublabel"></span>
+                </div>
+            </div>
+
             <div class="ep-step" x-show="{{.}}.showGuardrails">
                 <div class="ep-conn"></div>
                 <div class="ep-node ep-node-guardrails">

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -237,7 +237,8 @@
         <div class="page-header-controls">
             <button type="button" class="pagination-btn pagination-btn-primary"
                 x-show="authKeysAvailable && !authError"
-                @click="openAuthKeyForm()">Create API Key</button>
+                :disabled="authKeyFormSubmitting"
+                @click="if (!authKeyFormSubmitting) openAuthKeyForm()">Create API Key</button>
         </div>
     </div>
 
@@ -360,7 +361,7 @@
     </div>
 
     <p class="empty-state"
-        x-show="authKeys.length === 0 && !authKeysLoading && !authError && authKeysAvailable">
+        x-show="authKeys.length === 0 && !authKeysLoading && !authError && !authKeyError && authKeysAvailable">
         No API keys yet. Issue a key to get started.
     </p>
 </div>

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -227,6 +227,138 @@
     </div>
 </div>
 
+<!-- API Keys Page -->
+<div x-show="page==='auth-keys'">
+    <div class="page-header">
+        <h2>API Keys</h2>
+        <div class="page-header-controls">
+            <button type="button" class="pagination-btn pagination-btn-primary"
+                x-show="authKeysAvailable && !authError"
+                @click="openAuthKeyForm()">Create API Key</button>
+        </div>
+    </div>
+
+    {{template "auth-banner" .}}
+
+    <div class="alert alert-warning" x-show="!authKeysAvailable && !authError">
+        API key management is unavailable.
+    </div>
+    <p class="alias-form-error" x-show="authKeyError && !authError" x-text="authKeyError"></p>
+    <p class="alias-form-hint" x-show="authKeyNotice && !authKeyFormOpen" x-text="authKeyNotice"></p>
+
+    <p class="alias-form-hint auth-keys-help-notice" x-show="authKeysAvailable && !authError">
+        Managed API keys authenticate requests to the gateway. Deactivation is permanent — create a new key if access needs to be restored.
+    </p>
+
+    <div class="model-alias-editor" x-show="authKeyFormOpen">
+        <form class="alias-form" @submit.prevent="submitAuthKeyForm()">
+            <div class="aliases-editor-header">
+                <div>
+                    <p class="alias-form-kicker">Managed key</p>
+                    <h3>Create API Key</h3>
+                </div>
+                <button type="button" class="table-action-btn alias-close-btn"
+                    aria-label="Close" @click="closeAuthKeyForm()">&#x2715;</button>
+            </div>
+
+            <div class="auth-key-issued-banner" x-show="authKeyIssuedValue">
+                <p class="auth-key-issued-warning">
+                    Store this key securely &mdash; it won&rsquo;t be shown again.
+                </p>
+                <div class="auth-key-issued-value-row">
+                    <code class="auth-key-issued-token" x-text="authKeyIssuedValue"></code>
+                    <button type="button" class="pagination-btn auth-key-copy-btn"
+                        :class="{ 'auth-key-copy-btn-copied': authKeyCopied }"
+                        @click="copyAuthKeyValue()">
+                        <template x-if="!authKeyCopied">
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                        </template>
+                        <template x-if="authKeyCopied">
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 12l3 3 5-5"/></svg>
+                        </template>
+                        <span x-text="authKeyCopied ? 'Copied' : 'Copy'"></span>
+                    </button>
+                </div>
+                <div class="alias-form-actions">
+                    <button type="button" class="pagination-btn pagination-btn-primary"
+                        @click="dismissIssuedKey()">Done, I&rsquo;ve stored it</button>
+                </div>
+            </div>
+
+            <div x-show="!authKeyIssuedValue">
+                <div class="alias-form-grid">
+                    <label class="alias-form-field">
+                        <span>Name <span class="alias-form-hint">(required)</span></span>
+                        <input type="text" class="filter-input" placeholder="e.g. ci-deploy"
+                            x-model="authKeyForm.name" autocomplete="off">
+                    </label>
+                    <label class="alias-form-field">
+                        <span>Expires <span class="alias-form-hint">(optional, valid through the selected date)</span></span>
+                        <input type="date" class="filter-input" x-model="authKeyForm.expires_at">
+                    </label>
+                </div>
+                <label class="alias-form-field">
+                    <span>Description (optional)</span>
+                    <textarea rows="2" class="alias-form-textarea"
+                        placeholder="What is this key used for?"
+                        x-model="authKeyForm.description"></textarea>
+                </label>
+                <p class="alias-form-error" x-show="authKeyError" x-text="authKeyError"></p>
+                <div class="alias-form-actions">
+                    <button type="submit" class="pagination-btn pagination-btn-primary"
+                        :disabled="authKeyFormSubmitting"
+                        x-text="authKeyFormSubmitting ? 'Creating...' : 'Create API Key'"></button>
+                </div>
+            </div>
+        </form>
+    </div>
+
+    <div class="table-wrapper" x-show="authKeys.length > 0 && authKeysAvailable">
+        <table class="data-table">
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Description</th>
+                    <th>Token</th>
+                    <th>Status</th>
+                    <th>Expires</th>
+                    <th>Created</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                <template x-for="key in authKeys" :key="key.id">
+                    <tr>
+                        <td x-text="key.name"></td>
+                        <td class="auth-key-description" x-text="key.description || '\u2014'"></td>
+                        <td><code class="auth-key-redacted" x-text="key.redacted_value"></code></td>
+                        <td>
+                            <span class="auth-key-status-badge"
+                                :class="key.active ? 'auth-key-status-active' : 'auth-key-status-inactive'"
+                                x-text="key.active ? 'Active' : 'Inactive'"></span>
+                        </td>
+                        <td :title="key.expires_at ? formatTimestampUTC(key.expires_at) : ''"
+                            x-text="key.expires_at ? formatDateUTC(key.expires_at) : '\u2014'"></td>
+                        <td x-text="formatTimestamp(key.created_at)"></td>
+                        <td>
+                            <button type="button" class="table-action-btn table-action-btn-danger"
+                                x-show="key.active"
+                                :disabled="authKeyDeactivatingID === key.id"
+                                @click="deactivateAuthKey(key)"
+                                x-text="authKeyDeactivatingID === key.id ? 'Deactivating...' : 'Deactivate'"></button>
+                        </td>
+                    </tr>
+                </template>
+            </tbody>
+        </table>
+    </div>
+
+    <p class="empty-state"
+        x-show="authKeys.length === 0 && !authKeysLoading && !authError && authKeysAvailable">
+        No API keys yet. Issue a key to get started.
+    </p>
+</div>
+
 <!-- Models Page -->
 <div x-show="page==='models'">
     <div class="page-header">

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -282,6 +282,9 @@
                         <span x-text="authKeyCopied ? 'Copied' : 'Copy'"></span>
                     </button>
                 </div>
+                <p class="alias-form-error" x-show="authKeyCopyError">
+                    Unable to copy the key automatically. Copy it manually.
+                </p>
                 <div class="alias-form-actions">
                     <button type="button" class="pagination-btn pagination-btn-primary"
                         @click="dismissIssuedKey()">Done, I&rsquo;ve stored it</button>

--- a/internal/admin/dashboard/templates/layout.html
+++ b/internal/admin/dashboard/templates/layout.html
@@ -48,6 +48,10 @@
                     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 6v6l4 2"/><circle cx="12" cy="12" r="9"/><path d="M9 3h6"/></svg>
                     <span>Audit Logs</span>
                 </a>
+                <a href="/admin/dashboard/auth-keys" class="nav-item" :class="{ active: page === 'auth-keys' }" title="API Keys" @click.prevent="navigate('auth-keys')">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg>
+                    <span>API Keys</span>
+                </a>
                 <a href="/admin/dashboard/settings" class="nav-item" :class="{ active: page === 'settings' }" title="Settings" @click.prevent="navigate('settings')">
                     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h.01a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h.01a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v.01a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
                     <span>Settings</span>
@@ -97,6 +101,7 @@
     <script src="/admin/static/js/modules/audit-list.js"></script>
     <script src="/admin/static/js/modules/aliases.js"></script>
     <script src="/admin/static/js/modules/execution-plans.js"></script>
+    <script src="/admin/static/js/modules/auth-keys.js"></script>
     <script src="/admin/static/js/modules/conversation-drawer.js"></script>
     <script src="/admin/static/js/modules/contribution-calendar.js"></script>
     <script src="/admin/static/js/modules/charts.js"></script>

--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -28,6 +28,10 @@ type LogStore interface {
 const (
 	CacheTypeExact    = "exact"
 	CacheTypeSemantic = "semantic"
+
+	AuthMethodAPIKey    = "api_key"
+	AuthMethodMasterKey = "master_key"
+	AuthMethodNoKey     = "no_key"
 )
 
 // LogEntry represents a single audit log entry.
@@ -53,7 +57,8 @@ type LogEntry struct {
 
 	// Extracted fields for efficient filtering (indexed in relational DBs)
 	RequestID string `json:"request_id,omitempty" bson:"request_id,omitempty"`
-	AuthKeyID string `json:"auth_key_id,omitempty" bson:"auth_key_id,omitempty"`
+	AuthKeyID  string `json:"auth_key_id,omitempty" bson:"auth_key_id,omitempty"`
+	AuthMethod string `json:"auth_method,omitempty" bson:"auth_method,omitempty"`
 	ClientIP  string `json:"client_ip,omitempty" bson:"client_ip,omitempty"`
 	Method    string `json:"method,omitempty" bson:"method,omitempty"`
 	Path      string `json:"path,omitempty" bson:"path,omitempty"`

--- a/internal/auditlog/middleware.go
+++ b/internal/auditlog/middleware.go
@@ -383,6 +383,19 @@ func EnrichEntryWithCacheType(c *echo.Context, cacheType string) {
 	entry.CacheType = cacheType
 }
 
+// EnrichEntryWithAuthMethod records which authentication mechanism was used for the request.
+func EnrichEntryWithAuthMethod(c *echo.Context, method string) {
+	entryVal := c.Get(string(LogEntryKey))
+	if entryVal == nil {
+		return
+	}
+	entry, ok := entryVal.(*LogEntry)
+	if !ok || entry == nil {
+		return
+	}
+	entry.AuthMethod = method
+}
+
 // EnrichEntryWithAuthKeyID attaches the authenticated managed auth key id to the live audit entry.
 func EnrichEntryWithAuthKeyID(c *echo.Context, authKeyID string) {
 	entryVal := c.Get(string(LogEntryKey))

--- a/internal/auditlog/middleware.go
+++ b/internal/auditlog/middleware.go
@@ -398,6 +398,12 @@ func EnrichEntryWithAuthMethod(c *echo.Context, method string) {
 	if !ok || entry == nil {
 		return
 	}
+	method = strings.ToLower(strings.TrimSpace(method))
+	switch method {
+	case AuthMethodAPIKey, AuthMethodMasterKey, AuthMethodNoKey, "unknown":
+	default:
+		return
+	}
 	entry.AuthMethod = method
 }
 

--- a/internal/auditlog/middleware_auth_method_test.go
+++ b/internal/auditlog/middleware_auth_method_test.go
@@ -25,6 +25,16 @@ func TestEnrichEntryWithAuthMethodTrimsAndValidatesAllowedValues(t *testing.T) {
 	if entry.AuthMethod != AuthMethodMasterKey {
 		t.Fatalf("entry auth method = %q, want %q", entry.AuthMethod, AuthMethodMasterKey)
 	}
+
+	EnrichEntryWithAuthMethod(c, "no_key")
+	if entry.AuthMethod != AuthMethodNoKey {
+		t.Fatalf("entry auth method = %q, want %q", entry.AuthMethod, AuthMethodNoKey)
+	}
+
+	EnrichEntryWithAuthMethod(c, "unknown")
+	if entry.AuthMethod != "unknown" {
+		t.Fatalf("entry auth method = %q, want %q", entry.AuthMethod, "unknown")
+	}
 }
 
 func TestEnrichEntryWithAuthMethodIgnoresBlankAndUnsupportedValues(t *testing.T) {

--- a/internal/auditlog/middleware_auth_method_test.go
+++ b/internal/auditlog/middleware_auth_method_test.go
@@ -1,0 +1,47 @@
+package auditlog
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+)
+
+func TestEnrichEntryWithAuthMethodTrimsAndValidatesAllowedValues(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	entry := &LogEntry{}
+	c.Set(string(LogEntryKey), entry)
+
+	EnrichEntryWithAuthMethod(c, "  API_KEY  ")
+	if entry.AuthMethod != AuthMethodAPIKey {
+		t.Fatalf("entry auth method = %q, want %q", entry.AuthMethod, AuthMethodAPIKey)
+	}
+
+	EnrichEntryWithAuthMethod(c, "master_key")
+	if entry.AuthMethod != AuthMethodMasterKey {
+		t.Fatalf("entry auth method = %q, want %q", entry.AuthMethod, AuthMethodMasterKey)
+	}
+}
+
+func TestEnrichEntryWithAuthMethodIgnoresBlankAndUnsupportedValues(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	entry := &LogEntry{}
+	c.Set(string(LogEntryKey), entry)
+
+	EnrichEntryWithAuthMethod(c, "   ")
+	if entry.AuthMethod != "" {
+		t.Fatalf("entry auth method = %q, want empty", entry.AuthMethod)
+	}
+
+	EnrichEntryWithAuthMethod(c, "oauth")
+	if entry.AuthMethod != "" {
+		t.Fatalf("entry auth method = %q, want empty", entry.AuthMethod)
+	}
+}

--- a/internal/auditlog/reader_mongodb.go
+++ b/internal/auditlog/reader_mongodb.go
@@ -29,6 +29,7 @@ type mongoLogRow struct {
 	StatusCode             int       `bson:"status_code"`
 	RequestID              string    `bson:"request_id"`
 	AuthKeyID              string    `bson:"auth_key_id"`
+	AuthMethod             string    `bson:"auth_method"`
 	ClientIP               string    `bson:"client_ip"`
 	Method                 string    `bson:"method"`
 	Path                   string    `bson:"path"`
@@ -51,6 +52,7 @@ func (r mongoLogRow) toLogEntry() *LogEntry {
 		StatusCode:             r.StatusCode,
 		RequestID:              r.RequestID,
 		AuthKeyID:              r.AuthKeyID,
+		AuthMethod:             r.AuthMethod,
 		ClientIP:               r.ClientIP,
 		Method:                 r.Method,
 		Path:                   r.Path,

--- a/internal/auditlog/reader_postgresql.go
+++ b/internal/auditlog/reader_postgresql.go
@@ -78,7 +78,7 @@ func (r *PostgreSQLReader) GetLogs(ctx context.Context, params LogQueryParams) (
 		return nil, fmt.Errorf("failed to count audit log entries: %w", err)
 	}
 
-	dataQuery := fmt.Sprintf(`SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, cache_type, status_code, request_id, auth_key_id,
+	dataQuery := fmt.Sprintf(`SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, cache_type, status_code, request_id, auth_key_id, auth_method,
 		client_ip, method, path, stream, error_type, data
 		FROM audit_logs%s ORDER BY timestamp DESC LIMIT $%d OFFSET $%d`, where, argIdx, argIdx+1)
 	dataArgs := append(append([]any(nil), args...), limit, offset)
@@ -137,7 +137,7 @@ func (r *PostgreSQLReader) GetLogs(ctx context.Context, params LogQueryParams) (
 
 // GetLogByID returns a single audit log entry by ID.
 func (r *PostgreSQLReader) GetLogByID(ctx context.Context, id string) (*LogEntry, error) {
-	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, cache_type, status_code, request_id, auth_key_id,
+	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, cache_type, status_code, request_id, auth_key_id, auth_method,
 		client_ip, method, path, stream, error_type, data
 		FROM audit_logs WHERE id::text = $1 LIMIT 1`
 
@@ -179,7 +179,7 @@ func pgDateRangeConditions(params QueryParams, argIdx int) (conditions []string,
 }
 
 func (r *PostgreSQLReader) findByResponseID(ctx context.Context, responseID string) (*LogEntry, error) {
-	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, cache_type, status_code, request_id, auth_key_id,
+	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, cache_type, status_code, request_id, auth_key_id, auth_method,
 		client_ip, method, path, stream, error_type, data
 		FROM audit_logs
 		WHERE data->'response_body'->>'id' = $1
@@ -198,7 +198,7 @@ func (r *PostgreSQLReader) findByResponseID(ctx context.Context, responseID stri
 }
 
 func (r *PostgreSQLReader) findByPreviousResponseID(ctx context.Context, previousResponseID string) (*LogEntry, error) {
-	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, cache_type, status_code, request_id, auth_key_id,
+	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, cache_type, status_code, request_id, auth_key_id, auth_method,
 		client_ip, method, path, stream, error_type, data
 		FROM audit_logs
 		WHERE data->'request_body'->>'previous_response_id' = $1
@@ -224,9 +224,10 @@ func scanPostgreSQLLogEntry(rows interface {
 	var executionPlanVersionID *string
 	var cacheType *string
 	var authKeyID *string
+	var authMethod *string
 
 	if err := rows.Scan(&e.ID, &e.Timestamp, &e.DurationNs, &e.Model, &e.ResolvedModel, &e.Provider, &e.AliasUsed, &executionPlanVersionID, &cacheType, &e.StatusCode,
-		&e.RequestID, &authKeyID, &e.ClientIP, &e.Method, &e.Path, &e.Stream, &e.ErrorType, &dataJSON); err != nil {
+		&e.RequestID, &authKeyID, &authMethod, &e.ClientIP, &e.Method, &e.Path, &e.Stream, &e.ErrorType, &dataJSON); err != nil {
 		return nil, fmt.Errorf("failed to scan audit log row: %w", err)
 	}
 	if executionPlanVersionID != nil {
@@ -234,6 +235,9 @@ func scanPostgreSQLLogEntry(rows interface {
 	}
 	if authKeyID != nil {
 		e.AuthKeyID = *authKeyID
+	}
+	if authMethod != nil {
+		e.AuthMethod = *authMethod
 	}
 	if cacheType != nil {
 		e.CacheType = normalizeCacheType(*cacheType)

--- a/internal/auditlog/reader_sqlite.go
+++ b/internal/auditlog/reader_sqlite.go
@@ -78,7 +78,7 @@ func (r *SQLiteReader) GetLogs(ctx context.Context, params LogQueryParams) (*Log
 		return nil, fmt.Errorf("failed to count audit log entries: %w", err)
 	}
 
-	dataQuery := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, cache_type, status_code, request_id, auth_key_id,
+	dataQuery := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, cache_type, status_code, request_id, auth_key_id, auth_method,
 		client_ip, method, path, stream, error_type, data
 		FROM audit_logs` + where + ` ORDER BY timestamp DESC LIMIT ? OFFSET ?`
 	dataArgs := append(append([]any(nil), args...), limit, offset)
@@ -99,9 +99,10 @@ func (r *SQLiteReader) GetLogs(ctx context.Context, params LogQueryParams) (*Log
 		var executionPlanVersionID sql.NullString
 		var cacheType sql.NullString
 		var authKeyID sql.NullString
+		var authMethod sql.NullString
 
 		if err := rows.Scan(&e.ID, &ts, &e.DurationNs, &e.Model, &e.ResolvedModel, &e.Provider, &aliasUsedInt, &executionPlanVersionID, &cacheType, &e.StatusCode,
-			&e.RequestID, &authKeyID, &e.ClientIP, &e.Method, &e.Path, &streamInt, &e.ErrorType, &dataJSON); err != nil {
+			&e.RequestID, &authKeyID, &authMethod, &e.ClientIP, &e.Method, &e.Path, &streamInt, &e.ErrorType, &dataJSON); err != nil {
 			return nil, fmt.Errorf("failed to scan audit log row: %w", err)
 		}
 
@@ -113,6 +114,9 @@ func (r *SQLiteReader) GetLogs(ctx context.Context, params LogQueryParams) (*Log
 		}
 		if authKeyID.Valid {
 			e.AuthKeyID = authKeyID.String
+		}
+		if authMethod.Valid {
+			e.AuthMethod = authMethod.String
 		}
 		if cacheType.Valid {
 			e.CacheType = normalizeCacheType(cacheType.String)
@@ -144,7 +148,7 @@ func (r *SQLiteReader) GetLogs(ctx context.Context, params LogQueryParams) (*Log
 
 // GetLogByID returns a single audit log entry by ID.
 func (r *SQLiteReader) GetLogByID(ctx context.Context, id string) (*LogEntry, error) {
-	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, cache_type, status_code, request_id, auth_key_id,
+	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, cache_type, status_code, request_id, auth_key_id, auth_method,
 		client_ip, method, path, stream, error_type, data
 		FROM audit_logs WHERE id = ? LIMIT 1`
 
@@ -276,7 +280,7 @@ func parseSQLTimestamp(ts string, entryID string) time.Time {
 }
 
 func (r *SQLiteReader) findByResponseID(ctx context.Context, responseID string) (*LogEntry, error) {
-	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, cache_type, status_code, request_id, auth_key_id,
+	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, cache_type, status_code, request_id, auth_key_id, auth_method,
 		client_ip, method, path, stream, error_type, data
 		FROM audit_logs
 		WHERE json_extract(data, '$.response_body.id') = ?
@@ -295,7 +299,7 @@ func (r *SQLiteReader) findByResponseID(ctx context.Context, responseID string) 
 }
 
 func (r *SQLiteReader) findByPreviousResponseID(ctx context.Context, previousResponseID string) (*LogEntry, error) {
-	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, cache_type, status_code, request_id, auth_key_id,
+	query := `SELECT id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, cache_type, status_code, request_id, auth_key_id, auth_method,
 		client_ip, method, path, stream, error_type, data
 		FROM audit_logs
 		WHERE json_extract(data, '$.request_body.previous_response_id') = ?
@@ -322,9 +326,10 @@ func scanSQLiteLogEntry(rows *sql.Rows) (*LogEntry, error) {
 	var executionPlanVersionID sql.NullString
 	var cacheType sql.NullString
 	var authKeyID sql.NullString
+	var authMethod sql.NullString
 
 	if err := rows.Scan(&e.ID, &ts, &e.DurationNs, &e.Model, &e.ResolvedModel, &e.Provider, &aliasUsedInt, &executionPlanVersionID, &cacheType, &e.StatusCode,
-		&e.RequestID, &authKeyID, &e.ClientIP, &e.Method, &e.Path, &streamInt, &e.ErrorType, &dataJSON); err != nil {
+		&e.RequestID, &authKeyID, &authMethod, &e.ClientIP, &e.Method, &e.Path, &streamInt, &e.ErrorType, &dataJSON); err != nil {
 		return nil, fmt.Errorf("failed to scan audit log row: %w", err)
 	}
 
@@ -336,6 +341,9 @@ func scanSQLiteLogEntry(rows *sql.Rows) (*LogEntry, error) {
 	}
 	if authKeyID.Valid {
 		e.AuthKeyID = authKeyID.String
+	}
+	if authMethod.Valid {
+		e.AuthMethod = authMethod.String
 	}
 	if cacheType.Valid {
 		e.CacheType = normalizeCacheType(cacheType.String)

--- a/internal/auditlog/store_postgresql.go
+++ b/internal/auditlog/store_postgresql.go
@@ -87,7 +87,6 @@ func NewPostgreSQLStore(pool *pgxpool.Pool, retentionDays int) (*PostgreSQLStore
 		"ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS auth_key_id TEXT",
 		"ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS auth_method TEXT",
 		"ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS user_path TEXT",
-		"ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS auth_method TEXT",
 	}
 	for _, migration := range migrations {
 		if _, err := pool.Exec(ctx, migration); err != nil {

--- a/internal/auditlog/store_postgresql.go
+++ b/internal/auditlog/store_postgresql.go
@@ -14,14 +14,14 @@ import (
 )
 
 const (
-	auditLogInsertColumnCount     = 18
+	auditLogInsertColumnCount     = 19
 	postgresMaxBindParameters     = 65535
 	auditLogInsertMaxRowsPerQuery = postgresMaxBindParameters / auditLogInsertColumnCount
 )
 
 const auditLogInsertPrefix = `
 		INSERT INTO audit_logs (id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, cache_type, status_code,
-			request_id, auth_key_id, client_ip, method, path, stream, error_type, data)
+			request_id, auth_key_id, auth_method, client_ip, method, path, stream, error_type, data)
 		VALUES `
 
 const auditLogInsertSuffix = `
@@ -65,6 +65,7 @@ func NewPostgreSQLStore(pool *pgxpool.Pool, retentionDays int) (*PostgreSQLStore
 			status_code INTEGER DEFAULT 0,
 			request_id TEXT,
 			auth_key_id TEXT,
+			auth_method TEXT,
 			client_ip TEXT,
 			method TEXT,
 			path TEXT,
@@ -83,6 +84,7 @@ func NewPostgreSQLStore(pool *pgxpool.Pool, retentionDays int) (*PostgreSQLStore
 		"ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS execution_plan_version_id TEXT",
 		"ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS cache_type TEXT",
 		"ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS auth_key_id TEXT",
+		"ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS auth_method TEXT",
 	}
 	for _, migration := range migrations {
 		if _, err := pool.Exec(ctx, migration); err != nil {
@@ -222,6 +224,7 @@ func buildAuditLogInsert(entries []*LogEntry) (string, []any) {
 			entry.StatusCode,
 			entry.RequestID,
 			entry.AuthKeyID,
+			entry.AuthMethod,
 			entry.ClientIP,
 			entry.Method,
 			entry.Path,

--- a/internal/auditlog/store_postgresql_test.go
+++ b/internal/auditlog/store_postgresql_test.go
@@ -51,12 +51,12 @@ func TestBuildAuditLogInsert(t *testing.T) {
 	})
 
 	normalized := strings.Join(strings.Fields(query), " ")
-	wantQuery := "INSERT INTO audit_logs (id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, cache_type, status_code, request_id, auth_key_id, client_ip, method, path, stream, error_type, data) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18), ($19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36) ON CONFLICT (id) DO NOTHING"
+	wantQuery := "INSERT INTO audit_logs (id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, cache_type, status_code, request_id, auth_key_id, auth_method, client_ip, method, path, stream, error_type, data) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19), ($20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38) ON CONFLICT (id) DO NOTHING"
 	if normalized != wantQuery {
 		t.Fatalf("query = %q, want %q", normalized, wantQuery)
 	}
 
-	if got, want := len(args), 36; got != want {
+	if got, want := len(args), 38; got != want {
 		t.Fatalf("len(args) = %d, want %d", got, want)
 	}
 	if got := args[0]; got != "log-1" {
@@ -68,24 +68,24 @@ func TestBuildAuditLogInsert(t *testing.T) {
 	if got, ok := args[11].(string); !ok || got != "auth-key-1" {
 		t.Fatalf("args[11] = (%T) %v, want (string) auth-key-1", args[11], args[11])
 	}
-	if got := args[18]; got != "log-2" {
-		t.Fatalf("args[18] = %v, want log-2", got)
+	if got := string(args[18].([]byte)); got != `{"user_agent":"test-agent"}` {
+		t.Fatalf("args[18] = %q, want %q", got, `{"user_agent":"test-agent"}`)
 	}
-	if got, ok := args[29].(string); !ok || got != "" {
-		t.Fatalf("args[29] = (%T) %v, want (string) \"\"", args[29], args[29])
+	if got := args[19]; got != "log-2" {
+		t.Fatalf("args[19] = %v, want log-2", got)
 	}
-	if got := string(args[17].([]byte)); got != `{"user_agent":"test-agent"}` {
-		t.Fatalf("args[17] = %q, want %q", got, `{"user_agent":"test-agent"}`)
+	if got, ok := args[30].(string); !ok || got != "" {
+		t.Fatalf("args[30] = (%T) %v, want (string) \"\"", args[30], args[30])
 	}
-	if got := args[26]; got != nil {
-		t.Fatalf("args[26] = %v, want nil cache type", got)
+	if got := args[27]; got != nil {
+		t.Fatalf("args[27] = %v, want nil cache type", got)
 	}
-	dataJSON, ok := args[35].([]byte)
+	dataJSON, ok := args[37].([]byte)
 	if !ok {
-		t.Fatalf("args[35] has type %T, want []byte", args[35])
+		t.Fatalf("args[37] has type %T, want []byte", args[37])
 	}
 	if dataJSON != nil {
-		t.Fatalf("args[35] = %v, want nil data", dataJSON)
+		t.Fatalf("args[37] = %v, want nil data", dataJSON)
 	}
 }
 

--- a/internal/auditlog/store_sqlite.go
+++ b/internal/auditlog/store_sqlite.go
@@ -11,12 +11,12 @@ import (
 )
 
 // SQLite has a default limit of 999 bindable parameters per query (SQLITE_MAX_VARIABLE_NUMBER).
-// With 18 columns per log entry, we can safely insert up to 55 entries per batch (55 * 18 = 990).
+// With 19 columns per log entry, we can safely insert up to 52 entries per batch (52 * 19 = 988).
 // We chunk larger batches to avoid hitting this limit.
 const (
 	maxSQLiteParams    = 999
-	columnsPerEntry    = 18
-	maxEntriesPerBatch = maxSQLiteParams / columnsPerEntry // 55 entries
+	columnsPerEntry    = 19
+	maxEntriesPerBatch = maxSQLiteParams / columnsPerEntry // 52 entries
 )
 
 // SQLiteStore implements LogStore for SQLite databases.
@@ -50,6 +50,7 @@ func NewSQLiteStore(db *sql.DB, retentionDays int) (*SQLiteStore, error) {
 			status_code INTEGER DEFAULT 0,
 			request_id TEXT,
 			auth_key_id TEXT,
+			auth_method TEXT,
 			client_ip TEXT,
 			method TEXT,
 			path TEXT,
@@ -68,6 +69,7 @@ func NewSQLiteStore(db *sql.DB, retentionDays int) (*SQLiteStore, error) {
 		"ALTER TABLE audit_logs ADD COLUMN execution_plan_version_id TEXT",
 		"ALTER TABLE audit_logs ADD COLUMN cache_type TEXT",
 		"ALTER TABLE audit_logs ADD COLUMN auth_key_id TEXT",
+		"ALTER TABLE audit_logs ADD COLUMN auth_method TEXT",
 	}
 	for _, migration := range migrations {
 		if _, err := db.Exec(migration); err != nil {
@@ -129,7 +131,7 @@ func (s *SQLiteStore) WriteBatch(ctx context.Context, entries []*LogEntry) error
 		values := make([]any, 0, len(chunk)*columnsPerEntry)
 
 		for j, e := range chunk {
-			placeholders[j] = "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+			placeholders[j] = "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 
 			dataJSON := marshalLogData(e.Data, e.ID)
 
@@ -166,6 +168,7 @@ func (s *SQLiteStore) WriteBatch(ctx context.Context, entries []*LogEntry) error
 				e.StatusCode,
 				e.RequestID,
 				e.AuthKeyID,
+				e.AuthMethod,
 				e.ClientIP,
 				e.Method,
 				e.Path,
@@ -176,7 +179,7 @@ func (s *SQLiteStore) WriteBatch(ctx context.Context, entries []*LogEntry) error
 		}
 
 		query := `INSERT OR IGNORE INTO audit_logs (id, timestamp, duration_ns, model, resolved_model, provider, alias_used, execution_plan_version_id, cache_type, status_code,
-			request_id, auth_key_id, client_ip, method, path, stream, error_type, data) VALUES ` +
+			request_id, auth_key_id, auth_method, client_ip, method, path, stream, error_type, data) VALUES ` +
 			strings.Join(placeholders, ",")
 
 		_, err := s.db.ExecContext(ctx, query, values...)

--- a/internal/auditlog/store_sqlite.go
+++ b/internal/auditlog/store_sqlite.go
@@ -72,7 +72,6 @@ func NewSQLiteStore(db *sql.DB, retentionDays int) (*SQLiteStore, error) {
 		"ALTER TABLE audit_logs ADD COLUMN auth_key_id TEXT",
 		"ALTER TABLE audit_logs ADD COLUMN auth_method TEXT",
 		"ALTER TABLE audit_logs ADD COLUMN user_path TEXT",
-		"ALTER TABLE audit_logs ADD COLUMN auth_method TEXT",
 	}
 	for _, migration := range migrations {
 		if _, err := db.Exec(migration); err != nil {

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -44,9 +44,11 @@ func AuthMiddlewareWithAuthenticator(masterKey string, authenticator BearerToken
 				if strings.HasSuffix(skipPath, "/*") {
 					prefix := strings.TrimSuffix(skipPath, "*")
 					if strings.HasPrefix(requestPath, prefix) {
+						auditlog.EnrichEntryWithAuthMethod(c, auditlog.AuthMethodNoKey)
 						return next(c)
 					}
 				} else if requestPath == skipPath {
+					auditlog.EnrichEntryWithAuthMethod(c, auditlog.AuthMethodNoKey)
 					return next(c)
 				}
 			}

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -33,6 +33,7 @@ func AuthMiddlewareWithAuthenticator(masterKey string, authenticator BearerToken
 		return func(c *echo.Context) error {
 			// If no auth mechanism is configured, allow all requests.
 			if masterKey == "" && (authenticator == nil || !authenticator.Enabled()) {
+				auditlog.EnrichEntryWithAuthMethod(c, auditlog.AuthMethodNoKey)
 				return next(c)
 			}
 
@@ -66,6 +67,7 @@ func AuthMiddlewareWithAuthenticator(masterKey string, authenticator BearerToken
 
 			token := strings.TrimPrefix(authHeader, prefix)
 			if masterKey != "" && subtle.ConstantTimeCompare([]byte(token), []byte(masterKey)) == 1 {
+				auditlog.EnrichEntryWithAuthMethod(c, auditlog.AuthMethodMasterKey)
 				return next(c)
 			}
 
@@ -75,6 +77,7 @@ func AuthMiddlewareWithAuthenticator(masterKey string, authenticator BearerToken
 					ctx := core.WithAuthKeyID(c.Request().Context(), authKeyID)
 					c.SetRequest(c.Request().WithContext(ctx))
 					auditlog.EnrichEntryWithAuthKeyID(c, authKeyID)
+					auditlog.EnrichEntryWithAuthMethod(c, auditlog.AuthMethodAPIKey)
 					return next(c)
 				}
 

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -72,12 +72,12 @@ func AuthMiddlewareWithAuthenticator(masterKey string, authenticator BearerToken
 			}
 
 			if authenticator != nil && authenticator.Enabled() {
+				auditlog.EnrichEntryWithAuthMethod(c, auditlog.AuthMethodAPIKey)
 				authKeyID, err := authenticator.Authenticate(c.Request().Context(), token)
 				if err == nil {
 					ctx := core.WithAuthKeyID(c.Request().Context(), authKeyID)
 					c.SetRequest(c.Request().WithContext(ctx))
 					auditlog.EnrichEntryWithAuthKeyID(c, authKeyID)
-					auditlog.EnrichEntryWithAuthMethod(c, auditlog.AuthMethodAPIKey)
 					return next(c)
 				}
 

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -365,6 +365,31 @@ func TestAuthMiddleware_WildcardSkipPaths(t *testing.T) {
 	}
 }
 
+func TestAuthMiddleware_SkipPathEnrichesNoKeyAuditMethod(t *testing.T) {
+	e := echo.New()
+	handler := AuthMiddlewareWithAuthenticator("secret-key", nil, []string{"/health"})(func(c *echo.Context) error {
+		entryVal := c.Get(string(auditlog.LogEntryKey))
+		entry, ok := entryVal.(*auditlog.LogEntry)
+		if !ok || entry == nil {
+			t.Fatal("audit log entry missing from context")
+		}
+		if entry.AuthMethod != auditlog.AuthMethodNoKey {
+			t.Fatalf("audit entry auth method = %q, want %q", entry.AuthMethod, auditlog.AuthMethodNoKey)
+		}
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(auditlog.LogEntryKey), &auditlog.LogEntry{Data: &auditlog.LogData{}})
+
+	err := handler(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "ok", rec.Body.String())
+}
+
 func TestAuthMiddleware_ConstantTimeComparison(t *testing.T) {
 	t.Run("constant-time comparison prevents timing attacks", func(t *testing.T) {
 		// Test that the constant-time comparison works correctly for various inputs

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -189,6 +189,9 @@ func TestAuthMiddlewareWithAuthenticator_ManagedKeyEnrichesContextAndAudit(t *te
 		if entry.AuthKeyID != "key-123" {
 			t.Fatalf("audit entry auth key id = %q, want key-123", entry.AuthKeyID)
 		}
+		if entry.AuthMethod != auditlog.AuthMethodAPIKey {
+			t.Fatalf("audit entry auth method = %q, want %q", entry.AuthMethod, auditlog.AuthMethodAPIKey)
+		}
 		return c.String(http.StatusOK, "ok")
 	}
 
@@ -235,6 +238,7 @@ func TestAuthMiddlewareWithAuthenticator_ManagedKeyFailureUsesGenericClientMessa
 	require.True(t, ok)
 	require.NotNil(t, entry)
 	require.NotNil(t, entry.Data)
+	assert.Equal(t, auditlog.AuthMethodAPIKey, entry.AuthMethod)
 	assert.Equal(t, string(core.ErrorTypeAuthentication), entry.ErrorType)
 	assert.Equal(t, "authentication unavailable", entry.Data.ErrorMessage)
 }


### PR DESCRIPTION
## Summary
- add a managed API Keys page to the admin dashboard for listing, issuing, and deactivating keys
- treat date-only key expirations as valid through the selected UTC day and render expiration dates without timezone drift in the table
- surface auth method data in audit traces and execution-plan charts, while keeping the merged audit-log schema compatible with both `auth_method` and `user_path`

## Testing
- `go test ./internal/auditlog ./internal/server ./internal/admin`
- `node --test internal/admin/dashboard/static/js/modules/auth-keys.test.js internal/admin/dashboard/static/js/modules/timestamp-format.test.js internal/admin/dashboard/static/js/modules/dashboard-layout.test.js internal/admin/dashboard/static/js/modules/execution-plans.test.js internal/admin/dashboard/static/js/modules/execution-plans-layout.test.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API Keys page to create, view, copy, and deactivate keys with expirations, issued-key banner, copy feedback, badges, and empty-state messaging.
  * Execution pipeline chart now shows an "Auth" step with per-request auth success/error visuals.
  * Sidebar navigation link for API Keys.

* **Tests**
  * New and expanded tests covering API key workflows, copy fallbacks, auth-state rendering, and UTC date formatting for expirations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->