### PR TITLE
feat(auth): add API key path scoping and workflow auth node styling

### DIFF
--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -2828,6 +2828,24 @@ body.conversation-drawer-open {
 
 /* ─── Auth node ─── */
 
+.ep-node-auth {
+    border-color: color-mix(in srgb, var(--accent) 46%, var(--border));
+    background: color-mix(in srgb, var(--accent) 8%, var(--bg-surface));
+}
+
+.ep-node-auth .ep-node-icon {
+    background: color-mix(in srgb, var(--accent) 16%, var(--bg));
+    color: var(--accent);
+}
+
+.ep-node-auth .ep-node-label {
+    color: var(--accent);
+}
+
+.ep-node-auth .ep-node-sub {
+    color: color-mix(in srgb, var(--accent) 70%, var(--text-muted));
+}
+
 .ep-node-auth-success {
     border-color: color-mix(in srgb, var(--success) 52%, var(--border));
     background: color-mix(in srgb, var(--success) 9%, var(--bg-surface));

--- a/internal/admin/dashboard/static/js/modules/auth-keys.js
+++ b/internal/admin/dashboard/static/js/modules/auth-keys.js
@@ -16,11 +16,58 @@
             authKeyForm: {
                 name: '',
                 description: '',
+                user_path: '',
                 expires_at: ''
             },
 
             defaultAuthKeyForm() {
-                return { name: '', description: '', expires_at: '' };
+                return { name: '', description: '', user_path: '', expires_at: '' };
+            },
+
+            authKeyUserPathValidationError(value) {
+                const trimmed = String(value || '').trim();
+                if (!trimmed) {
+                    return '';
+                }
+                const raw = trimmed.startsWith('/') ? trimmed : '/' + trimmed;
+                const segments = raw.split('/');
+                for (const part of segments) {
+                    const segment = String(part || '').trim();
+                    if (!segment) {
+                        continue;
+                    }
+                    if (segment === '.' || segment === '..') {
+                        return 'User path cannot contain "." or ".." segments.';
+                    }
+                    if (segment.includes(':')) {
+                        return 'User path cannot contain ":" segments.';
+                    }
+                }
+                return '';
+            },
+
+            normalizeAuthKeyUserPath(value) {
+                if (this.authKeyUserPathValidationError(value)) {
+                    return '';
+                }
+                const trimmed = String(value || '').trim();
+                if (!trimmed) {
+                    return '';
+                }
+                const raw = trimmed.startsWith('/') ? trimmed : '/' + trimmed;
+                const segments = raw.split('/');
+                const canonical = [];
+                for (const part of segments) {
+                    const segment = String(part || '').trim();
+                    if (!segment) {
+                        continue;
+                    }
+                    canonical.push(segment);
+                }
+                if (!canonical.length) {
+                    return '/';
+                }
+                return '/' + canonical.join('/');
             },
 
             async fetchAuthKeys() {
@@ -182,14 +229,21 @@
                     this.authKeyError = 'Name is required.';
                     return;
                 }
+                const userPathError = this.authKeyUserPathValidationError(this.authKeyForm.user_path);
+                if (userPathError) {
+                    this.authKeyError = userPathError;
+                    return;
+                }
 
                 this.authKeyError = '';
                 this.authKeyNotice = '';
                 this.authKeyFormSubmitting = true;
+                const userPath = this.normalizeAuthKeyUserPath(this.authKeyForm.user_path);
 
                 const payload = {
                     name,
-                    description: String(this.authKeyForm.description || '').trim() || undefined
+                    description: String(this.authKeyForm.description || '').trim() || undefined,
+                    user_path: userPath || undefined
                 };
                 if (this.authKeyForm.expires_at) {
                     payload.expires_at = this.authKeyForm.expires_at + 'T23:59:59Z';

--- a/internal/admin/dashboard/static/js/modules/auth-keys.test.js
+++ b/internal/admin/dashboard/static/js/modules/auth-keys.test.js
@@ -65,6 +65,7 @@ test('submitAuthKeyForm serializes date-only expirations to the end of the selec
     module.authKeyForm = {
         name: 'ci-deploy',
         description: '',
+        user_path: '',
         expires_at: '2026-04-01'
     };
 
@@ -76,6 +77,66 @@ test('submitAuthKeyForm serializes date-only expirations to the end of the selec
         JSON.parse(requests[0].options.body).expires_at,
         '2026-04-01T23:59:59Z'
     );
+});
+
+test('submitAuthKeyForm normalizes user paths before sending them', async () => {
+    const requests = [];
+    const module = createAuthKeysModule({
+        fetch: async (url, options) => {
+            requests.push({ url, options });
+            return {
+                status: 201,
+                async json() {
+                    return { value: 'sk_gom_test' };
+                }
+            };
+        }
+    });
+
+    module.headers = () => ({ 'Content-Type': 'application/json' });
+    module.fetchAuthKeys = async () => {};
+    module.authKeyForm = {
+        name: 'ci-deploy',
+        description: '',
+        user_path: ' team//alpha/service/ ',
+        expires_at: ''
+    };
+
+    await module.submitAuthKeyForm();
+
+    assert.equal(requests.length, 1);
+    assert.equal(
+        JSON.parse(requests[0].options.body).user_path,
+        '/team/alpha/service'
+    );
+});
+
+test('submitAuthKeyForm rejects invalid user paths before sending the request', async () => {
+    let called = false;
+    const module = createAuthKeysModule({
+        fetch: async () => {
+            called = true;
+            return {
+                status: 201,
+                async json() {
+                    return { value: 'sk_gom_test' };
+                }
+            };
+        }
+    });
+
+    module.headers = () => ({ 'Content-Type': 'application/json' });
+    module.authKeyForm = {
+        name: 'ci-deploy',
+        description: '',
+        user_path: '/team/../alpha',
+        expires_at: ''
+    };
+
+    await module.submitAuthKeyForm();
+
+    assert.equal(called, false);
+    assert.equal(module.authKeyError, 'User path cannot contain "." or ".." segments.');
 });
 
 test('copyAuthKeyValue uses navigator.clipboard when available and resets feedback', async () => {
@@ -277,6 +338,7 @@ test('submitAuthKeyForm reopens the editor if issuance finishes after a manual c
     module.authKeyForm = {
         name: 'ci-deploy',
         description: '',
+        user_path: '',
         expires_at: ''
     };
 

--- a/internal/admin/dashboard/static/js/modules/dashboard-layout.test.js
+++ b/internal/admin/dashboard/static/js/modules/dashboard-layout.test.js
@@ -94,6 +94,9 @@ test('auth key expirations render as a UTC date with the full UTC timestamp in t
 
     assert.match(indexTemplate, /x-text="key\.expires_at \? formatDateUTC\(key\.expires_at\) : '\\u2014'"/);
     assert.match(indexTemplate, /:title="key\.expires_at \? formatTimestampUTC\(key\.expires_at\) : ''"/);
+    assert.match(indexTemplate, /x-model="authKeyForm\.user_path"[^>]*aria-label="API key user path"/);
+    assert.match(indexTemplate, /x-text="key\.user_path \|\| '\\u2014'"/);
+    assert.match(indexTemplate, /X-GoModel-User-Path/);
     assert.match(indexTemplate, /:disabled="authKeyFormSubmitting"/);
     assert.match(indexTemplate, /@click="if \(!authKeyFormSubmitting\) openAuthKeyForm\(\)"/);
     assert.match(indexTemplate, /x-show="authKeys\.length === 0 && !authKeysLoading && !authError && !authKeyError && authKeysAvailable"/);

--- a/internal/admin/dashboard/static/js/modules/execution-plans-layout.test.js
+++ b/internal/admin/dashboard/static/js/modules/execution-plans-layout.test.js
@@ -72,6 +72,8 @@ test('workflow nodes use endpoint and feature color groups consistently', () => 
     assert.match(endpointRule, /background:\s*var\(--bg-surface\)/);
 
     const featureSelectors = [
+        '.ep-node-cache',
+        '.ep-node-auth',
         '.ep-node-guardrails',
         '.ep-node-async-audit',
         '.ep-node-async-usage'
@@ -83,6 +85,8 @@ test('workflow nodes use endpoint and feature color groups consistently', () => 
     }
 
     const featureIconSelectors = [
+        '.ep-node-cache .ep-node-icon',
+        '.ep-node-auth .ep-node-icon',
         '.ep-node-guardrails .ep-node-icon',
         '.ep-node-async-audit .ep-node-icon',
         '.ep-node-async-usage .ep-node-icon'
@@ -94,6 +98,8 @@ test('workflow nodes use endpoint and feature color groups consistently', () => 
     }
 
     const featureLabelSelectors = [
+        '.ep-node-cache .ep-node-label',
+        '.ep-node-auth .ep-node-label',
         '.ep-node-guardrails .ep-node-label',
         '.ep-node-async-audit .ep-node-label',
         '.ep-node-async-usage .ep-node-label'
@@ -102,6 +108,18 @@ test('workflow nodes use endpoint and feature color groups consistently', () => 
         const rule = readCSSRule(css, selector);
         assert.match(rule, /color:\s*var\(--accent\)/);
     }
+
+    const authSubRule = readCSSRule(css, '.ep-node-auth .ep-node-sub');
+    assert.match(authSubRule, /color:\s*color-mix\(in srgb, var\(--accent\) 70%, var\(--text-muted\)\)/);
+});
+
+test('auth node uses the cache iconography in execution plan charts', () => {
+    const chartTemplate = readFixture('../../../templates/execution-plan-chart.html');
+
+    assert.match(
+        chartTemplate,
+        /<div class="ep-node ep-node-auth"[\s\S]*?<svg viewBox="0 0 24 24"><ellipse cx="12" cy="5" rx="9" ry="3"\/><path d="M21 12c0 1\.66-4 3-9 3s-9-1\.34-9-3"\/><path d="M3 5v14c0 1\.66 4 3 9 3s9-1\.34 9-3V5"\/><\/svg>[\s\S]*?<span class="ep-node-label">Auth<\/span>/
+    );
 });
 
 test('execution plan authoring inputs expose stable accessible names', () => {

--- a/internal/admin/dashboard/templates/execution-plan-chart.html
+++ b/internal/admin/dashboard/templates/execution-plan-chart.html
@@ -13,7 +13,7 @@
                 <div class="ep-conn"></div>
                 <div class="ep-node ep-node-auth" :class="{{.}}.authNodeClass">
                     <div class="ep-node-icon">
-                        <svg viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+                        <svg viewBox="0 0 24 24"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg>
                     </div>
                     <span class="ep-node-label">Auth</span>
                     <span class="ep-node-sub" x-show="{{.}}.authNodeSublabel" x-text="{{.}}.authNodeSublabel"></span>

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -310,6 +310,14 @@
                         placeholder="What is this key used for?"
                         x-model="authKeyForm.description"></textarea>
                 </label>
+                <label class="alias-form-field">
+                    <span>User Path (optional)</span>
+                    <input type="text" class="filter-input" placeholder="team/alpha or /team/alpha"
+                        x-model="authKeyForm.user_path" aria-label="API key user path">
+                </label>
+                <p class="alias-form-hint">
+                    When set, this key overrides <code>X-GoModel-User-Path</code> for audit logging and downstream request context.
+                </p>
                 <p class="alias-form-error" x-show="authKeyError" x-text="authKeyError"></p>
                 <div class="alias-form-actions">
                     <button type="submit" class="pagination-btn pagination-btn-primary"
@@ -326,6 +334,7 @@
                 <tr>
                     <th>Name</th>
                     <th>Description</th>
+                    <th>User Path</th>
                     <th>Token</th>
                     <th>Status</th>
                     <th>Expires</th>
@@ -338,6 +347,7 @@
                     <tr>
                         <td x-text="key.name"></td>
                         <td class="auth-key-description" x-text="key.description || '\u2014'"></td>
+                        <td x-text="key.user_path || '\u2014'"></td>
                         <td><code class="auth-key-redacted" x-text="key.redacted_value"></code></td>
                         <td>
                             <span class="auth-key-status-badge"

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -648,6 +648,7 @@ type createExecutionPlanRequest struct {
 type createAuthKeyRequest struct {
 	Name        string     `json:"name"`
 	Description string     `json:"description,omitempty"`
+	UserPath    string     `json:"user_path,omitempty"`
 	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
 }
 
@@ -748,9 +749,15 @@ func (h *Handler) CreateAuthKey(c *echo.Context) error {
 		return handleError(c, core.NewInvalidRequestError("invalid request body: "+err.Error(), err))
 	}
 
+	userPath, err := normalizeUserPathQueryParam("user_path", req.UserPath)
+	if err != nil {
+		return handleError(c, err)
+	}
+
 	issued, err := h.authKeys.Create(c.Request().Context(), authkeys.CreateInput{
 		Name:        req.Name,
 		Description: req.Description,
+		UserPath:    userPath,
 		ExpiresAt:   req.ExpiresAt,
 	})
 	if err != nil {

--- a/internal/admin/handler_authkeys_test.go
+++ b/internal/admin/handler_authkeys_test.go
@@ -107,7 +107,7 @@ func TestCreateListAndDeactivateAuthKey(t *testing.T) {
 	h := newAuthKeyHandler(t, newAuthKeyTestStore())
 	e := echo.New()
 
-	createReq := httptest.NewRequest(http.MethodPost, "/admin/api/v1/auth-keys", bytes.NewBufferString(`{"name":"primary","description":"prod key"}`))
+	createReq := httptest.NewRequest(http.MethodPost, "/admin/api/v1/auth-keys", bytes.NewBufferString(`{"name":"primary","description":"prod key","user_path":" team//alpha/service/ "}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	createRec := httptest.NewRecorder()
 	createCtx := e.NewContext(createReq, createRec)
@@ -126,6 +126,9 @@ func TestCreateListAndDeactivateAuthKey(t *testing.T) {
 	if issued.Value == "" || issued.ID == "" {
 		t.Fatalf("issued response = %#v, want id and value", issued)
 	}
+	if issued.UserPath != "/team/alpha/service" {
+		t.Fatalf("issued.UserPath = %q, want /team/alpha/service", issued.UserPath)
+	}
 
 	listCtx, listRec := newHandlerContext("/admin/api/v1/auth-keys")
 	if err := h.ListAuthKeys(listCtx); err != nil {
@@ -141,6 +144,9 @@ func TestCreateListAndDeactivateAuthKey(t *testing.T) {
 	}
 	if len(views) != 1 || !views[0].Active {
 		t.Fatalf("list response = %#v, want one active key", views)
+	}
+	if views[0].UserPath != "/team/alpha/service" {
+		t.Fatalf("views[0].UserPath = %q, want /team/alpha/service", views[0].UserPath)
 	}
 
 	deactivateReq := httptest.NewRequest(http.MethodPost, "/admin/api/v1/auth-keys/"+issued.ID+"/deactivate", nil)
@@ -164,5 +170,22 @@ func TestCreateListAndDeactivateAuthKey(t *testing.T) {
 	}
 	if len(views) != 1 || views[0].Active {
 		t.Fatalf("list response after deactivate = %#v, want one inactive key", views)
+	}
+}
+
+func TestCreateAuthKeyRejectsInvalidUserPath(t *testing.T) {
+	h := newAuthKeyHandler(t, newAuthKeyTestStore())
+	e := echo.New()
+
+	createReq := httptest.NewRequest(http.MethodPost, "/admin/api/v1/auth-keys", bytes.NewBufferString(`{"name":"primary","user_path":"/team/../alpha"}`))
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	createCtx := e.NewContext(createReq, createRec)
+
+	if err := h.CreateAuthKey(createCtx); err != nil {
+		t.Fatalf("CreateAuthKey() error = %v", err)
+	}
+	if createRec.Code != http.StatusBadRequest {
+		t.Fatalf("CreateAuthKey() status = %d, want 400", createRec.Code)
 	}
 }

--- a/internal/auditlog/auditlog_test.go
+++ b/internal/auditlog/auditlog_test.go
@@ -699,6 +699,34 @@ func TestMiddleware_StoresAuthKeyIDFromContext(t *testing.T) {
 	}
 }
 
+func TestMiddleware_StoresEffectiveUserPathFromContext(t *testing.T) {
+	logger := &capturingLogger{cfg: Config{Enabled: true}}
+	middleware := Middleware(logger)
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-4o-mini"}`))
+	req.Header.Set("Content-Type", "application/json")
+	ctx := core.WithRequestSnapshot(req.Context(), &core.RequestSnapshot{UserPath: "/team/from-header"})
+	ctx = core.WithEffectiveUserPath(ctx, "/team/from-auth-key")
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	handler := middleware(func(c *echo.Context) error {
+		return c.NoContent(http.StatusOK)
+	})
+
+	if err := handler(c); err != nil {
+		t.Fatalf("handler() error = %v", err)
+	}
+	if len(logger.entries) != 1 {
+		t.Fatalf("logger.entries len = %d, want 1", len(logger.entries))
+	}
+	if got := logger.entries[0].UserPath; got != "/team/from-auth-key" {
+		t.Fatalf("UserPath = %q, want /team/from-auth-key", got)
+	}
+}
+
 func TestMiddleware_DefaultsMissingUserPathToRoot(t *testing.T) {
 	logger := &capturingLogger{cfg: Config{Enabled: true}}
 	middleware := Middleware(logger)

--- a/internal/auditlog/middleware.go
+++ b/internal/auditlog/middleware.go
@@ -176,6 +176,9 @@ func applyAuthentication(entry *LogEntry, ctx context.Context) {
 	if authKeyID := strings.TrimSpace(core.GetAuthKeyID(ctx)); authKeyID != "" {
 		entry.AuthKeyID = authKeyID
 	}
+	if userPath := strings.TrimSpace(core.UserPathFromContext(ctx)); userPath != "" {
+		entry.UserPath = userPath
+	}
 }
 
 func enrichEntryWithExecutionPlan(entry *LogEntry, plan *core.ExecutionPlan) {
@@ -424,6 +427,25 @@ func EnrichEntryWithAuthKeyID(c *echo.Context, authKeyID string) {
 		return
 	}
 	entry.AuthKeyID = authKeyID
+}
+
+// EnrichEntryWithUserPath attaches the effective user path to the live audit entry.
+func EnrichEntryWithUserPath(c *echo.Context, userPath string) {
+	entryVal := c.Get(string(LogEntryKey))
+	if entryVal == nil {
+		return
+	}
+
+	entry, ok := entryVal.(*LogEntry)
+	if !ok || entry == nil {
+		return
+	}
+
+	userPath = strings.TrimSpace(userPath)
+	if userPath == "" {
+		return
+	}
+	entry.UserPath = userPath
 }
 
 func auditEnabledForContext(ctx context.Context) bool {

--- a/internal/authkeys/service.go
+++ b/internal/authkeys/service.go
@@ -25,6 +25,12 @@ type snapshot struct {
 	activeByHash map[string]AuthKey
 }
 
+// AuthenticationResult describes one successful managed auth key lookup.
+type AuthenticationResult struct {
+	ID       string
+	UserPath string
+}
+
 // Service keeps managed auth keys cached in memory for request authentication.
 type Service struct {
 	store Store
@@ -167,6 +173,7 @@ func (s *Service) Create(ctx context.Context, input CreateInput) (*IssuedKey, er
 		ID:            uuid.NewString(),
 		Name:          normalized.Name,
 		Description:   normalized.Description,
+		UserPath:      normalized.UserPath,
 		RedactedValue: redactedValue,
 		SecretHash:    secretHash,
 		Enabled:       true,
@@ -211,15 +218,15 @@ func (s *Service) Deactivate(ctx context.Context, id string) error {
 }
 
 // Authenticate validates a presented bearer token against the in-memory snapshot
-// and returns the internal auth key id on success.
-func (s *Service) Authenticate(_ context.Context, token string) (string, error) {
+// and returns the matched auth key metadata on success.
+func (s *Service) Authenticate(_ context.Context, token string) (AuthenticationResult, error) {
 	if s == nil {
-		return "", ErrInvalidToken
+		return AuthenticationResult{}, ErrInvalidToken
 	}
 
 	secret, err := parseTokenSecret(token)
 	if err != nil {
-		return "", err
+		return AuthenticationResult{}, err
 	}
 	secretHash := hashSecret(secret)
 	now := time.Now().UTC()
@@ -233,7 +240,7 @@ func (s *Service) Authenticate(_ context.Context, token string) (string, error) 
 	key, exists := s.snapshot.bySecretHash[secretHash]
 	s.mu.RUnlock()
 	if !exists {
-		return "", ErrInvalidToken
+		return AuthenticationResult{}, ErrInvalidToken
 	}
 	return authenticateKey(key, now)
 }
@@ -272,17 +279,20 @@ func (s *Service) StartBackgroundRefresh(interval time.Duration) func() {
 	}
 }
 
-func authenticateKey(key AuthKey, now time.Time) (string, error) {
+func authenticateKey(key AuthKey, now time.Time) (AuthenticationResult, error) {
 	if !key.Enabled || key.DeactivatedAt != nil {
-		return "", ErrInactive
+		return AuthenticationResult{}, ErrInactive
 	}
 	if key.ExpiresAt != nil && !key.ExpiresAt.After(now) {
-		return "", ErrExpired
+		return AuthenticationResult{}, ErrExpired
 	}
 	if strings.TrimSpace(key.ID) == "" {
-		return "", ErrInvalidToken
+		return AuthenticationResult{}, ErrInvalidToken
 	}
-	return key.ID, nil
+	return AuthenticationResult{
+		ID:       key.ID,
+		UserPath: strings.TrimSpace(key.UserPath),
+	}, nil
 }
 
 func (s *Service) refreshBestEffort(ctx context.Context, operation string) {

--- a/internal/authkeys/service_test.go
+++ b/internal/authkeys/service_test.go
@@ -88,8 +88,8 @@ func TestServiceCreateAuthenticateAndDeactivate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Authenticate() error = %v", err)
 	}
-	if authKeyID != issued.ID {
-		t.Fatalf("Authenticate() id = %q, want %q", authKeyID, issued.ID)
+	if authKeyID.ID != issued.ID {
+		t.Fatalf("Authenticate() id = %q, want %q", authKeyID.ID, issued.ID)
 	}
 
 	if err := service.Deactivate(context.Background(), issued.ID); err != nil {
@@ -177,8 +177,8 @@ func TestServiceWriteOperationsIgnoreRefreshReconciliationFailures(t *testing.T)
 		if issued == nil {
 			t.Fatal("Create() = nil, want issued key")
 		}
-		if got, err := service.Authenticate(context.Background(), issued.Value); err != nil || got != issued.ID {
-			t.Fatalf("Authenticate() = (%q, %v), want (%q, nil)", got, err, issued.ID)
+		if got, err := service.Authenticate(context.Background(), issued.Value); err != nil || got.ID != issued.ID {
+			t.Fatalf("Authenticate() = (%q, %v), want (%q, nil)", got.ID, err, issued.ID)
 		}
 	})
 
@@ -209,4 +209,48 @@ func TestServiceWriteOperationsIgnoreRefreshReconciliationFailures(t *testing.T)
 			t.Fatalf("Authenticate() error = %v, want %v", err, ErrInactive)
 		}
 	})
+}
+
+func TestServiceCreateNormalizesUserPathAndReturnsItOnAuthenticate(t *testing.T) {
+	service, err := NewService(newTestStore())
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	issued, err := service.Create(context.Background(), CreateInput{
+		Name:     "scoped",
+		UserPath: " team//alpha/service/ ",
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if issued.UserPath != "/team/alpha/service" {
+		t.Fatalf("issued.UserPath = %q, want /team/alpha/service", issued.UserPath)
+	}
+
+	authenticated, err := service.Authenticate(context.Background(), issued.Value)
+	if err != nil {
+		t.Fatalf("Authenticate() error = %v", err)
+	}
+	if authenticated.UserPath != "/team/alpha/service" {
+		t.Fatalf("Authenticate().UserPath = %q, want /team/alpha/service", authenticated.UserPath)
+	}
+}
+
+func TestServiceCreateRejectsInvalidUserPath(t *testing.T) {
+	service, err := NewService(newTestStore())
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	_, err = service.Create(context.Background(), CreateInput{
+		Name:     "invalid",
+		UserPath: "/team/../alpha",
+	})
+	if err == nil {
+		t.Fatal("Create() error = nil, want validation error")
+	}
+	if !IsValidationError(err) {
+		t.Fatalf("Create() error = %T, want validation error", err)
+	}
 }

--- a/internal/authkeys/store.go
+++ b/internal/authkeys/store.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"strings"
 	"time"
+
+	"gomodel/internal/core"
 )
 
 var (
@@ -72,6 +74,11 @@ func normalizeCreateInput(input CreateInput) (CreateInput, error) {
 	if input.Name == "" {
 		return CreateInput{}, newValidationError("name is required", nil)
 	}
+	userPath, err := core.NormalizeUserPath(input.UserPath)
+	if err != nil {
+		return CreateInput{}, newValidationError("invalid user_path", err)
+	}
+	input.UserPath = userPath
 	if input.ExpiresAt != nil {
 		expiresAt := input.ExpiresAt.UTC()
 		now := time.Now().UTC()

--- a/internal/authkeys/store_mongodb.go
+++ b/internal/authkeys/store_mongodb.go
@@ -14,6 +14,7 @@ type mongoAuthKeyDocument struct {
 	ID            string     `bson:"_id"`
 	Name          string     `bson:"name"`
 	Description   string     `bson:"description,omitempty"`
+	UserPath      string     `bson:"user_path,omitempty"`
 	RedactedValue string     `bson:"redacted_value"`
 	SecretHash    string     `bson:"secret_hash"`
 	Enabled       bool       `bson:"enabled"`
@@ -78,6 +79,7 @@ func (s *MongoDBStore) Create(ctx context.Context, key AuthKey) error {
 		ID:            key.ID,
 		Name:          key.Name,
 		Description:   key.Description,
+		UserPath:      key.UserPath,
 		RedactedValue: key.RedactedValue,
 		SecretHash:    key.SecretHash,
 		Enabled:       key.Enabled,
@@ -122,6 +124,7 @@ func authKeyFromMongo(doc mongoAuthKeyDocument) AuthKey {
 		ID:            doc.ID,
 		Name:          doc.Name,
 		Description:   doc.Description,
+		UserPath:      doc.UserPath,
 		RedactedValue: doc.RedactedValue,
 		SecretHash:    doc.SecretHash,
 		Enabled:       doc.Enabled,

--- a/internal/authkeys/store_postgresql.go
+++ b/internal/authkeys/store_postgresql.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -29,6 +30,7 @@ func NewPostgreSQLStore(ctx context.Context, pool *pgxpool.Pool) (*PostgreSQLSto
 			id TEXT PRIMARY KEY,
 			name TEXT NOT NULL,
 			description TEXT NOT NULL DEFAULT '',
+			user_path TEXT,
 			redacted_value TEXT NOT NULL,
 			secret_hash TEXT NOT NULL UNIQUE,
 			enabled BOOLEAN NOT NULL DEFAULT TRUE,
@@ -40,6 +42,9 @@ func NewPostgreSQLStore(ctx context.Context, pool *pgxpool.Pool) (*PostgreSQLSto
 	`)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create auth_keys table: %w", err)
+	}
+	if _, err := pool.Exec(ctx, `ALTER TABLE auth_keys ADD COLUMN IF NOT EXISTS user_path TEXT`); err != nil {
+		return nil, fmt.Errorf("failed to initialize auth_keys table: %w", err)
 	}
 	for _, index := range []string{
 		`CREATE INDEX IF NOT EXISTS idx_auth_keys_enabled ON auth_keys(enabled)`,
@@ -54,7 +59,7 @@ func NewPostgreSQLStore(ctx context.Context, pool *pgxpool.Pool) (*PostgreSQLSto
 
 func (s *PostgreSQLStore) List(ctx context.Context) ([]AuthKey, error) {
 	rows, err := s.pool.Query(ctx, `
-		SELECT id, name, description, redacted_value, secret_hash, enabled, expires_at, deactivated_at, created_at, updated_at
+		SELECT id, name, description, user_path, redacted_value, secret_hash, enabled, expires_at, deactivated_at, created_at, updated_at
 		FROM auth_keys
 		ORDER BY created_at DESC, id ASC
 	`)
@@ -71,9 +76,9 @@ func (s *PostgreSQLStore) List(ctx context.Context) ([]AuthKey, error) {
 
 func (s *PostgreSQLStore) Create(ctx context.Context, key AuthKey) error {
 	_, err := s.pool.Exec(ctx, `
-		INSERT INTO auth_keys (id, name, description, redacted_value, secret_hash, enabled, expires_at, deactivated_at, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-	`, key.ID, key.Name, key.Description, key.RedactedValue, key.SecretHash, key.Enabled, pgUnixOrNil(key.ExpiresAt), pgUnixOrNil(key.DeactivatedAt), key.CreatedAt.Unix(), key.UpdatedAt.Unix())
+		INSERT INTO auth_keys (id, name, description, user_path, redacted_value, secret_hash, enabled, expires_at, deactivated_at, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+	`, key.ID, key.Name, key.Description, pgNullableString(key.UserPath), key.RedactedValue, key.SecretHash, key.Enabled, pgUnixOrNil(key.ExpiresAt), pgUnixOrNil(key.DeactivatedAt), key.CreatedAt.Unix(), key.UpdatedAt.Unix())
 	if err != nil {
 		return fmt.Errorf("create auth key: %w", err)
 	}
@@ -103,6 +108,7 @@ func (s *PostgreSQLStore) Close() error {
 
 func scanPostgreSQLAuthKey(scanner authKeyScanner) (AuthKey, error) {
 	var key AuthKey
+	var userPath *string
 	var expiresAt *int64
 	var deactivatedAt *int64
 	var createdAt int64
@@ -111,6 +117,7 @@ func scanPostgreSQLAuthKey(scanner authKeyScanner) (AuthKey, error) {
 		&key.ID,
 		&key.Name,
 		&key.Description,
+		&userPath,
 		&key.RedactedValue,
 		&key.SecretHash,
 		&key.Enabled,
@@ -124,6 +131,7 @@ func scanPostgreSQLAuthKey(scanner authKeyScanner) (AuthKey, error) {
 		}
 		return AuthKey{}, err
 	}
+	key.UserPath = derefTrimmedString(userPath)
 	key.ExpiresAt = int64PtrToTime(expiresAt)
 	key.DeactivatedAt = int64PtrToTime(deactivatedAt)
 	key.CreatedAt = time.Unix(createdAt, 0).UTC()
@@ -144,4 +152,19 @@ func int64PtrToTime(value *int64) *time.Time {
 	}
 	t := time.Unix(*value, 0).UTC()
 	return &t
+}
+
+func pgNullableString(value string) any {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+func derefTrimmedString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(*value)
 }

--- a/internal/authkeys/store_postgresql.go
+++ b/internal/authkeys/store_postgresql.go
@@ -43,8 +43,14 @@ func NewPostgreSQLStore(ctx context.Context, pool *pgxpool.Pool) (*PostgreSQLSto
 	if err != nil {
 		return nil, fmt.Errorf("failed to create auth_keys table: %w", err)
 	}
-	if _, err := pool.Exec(ctx, `ALTER TABLE auth_keys ADD COLUMN IF NOT EXISTS user_path TEXT`); err != nil {
-		return nil, fmt.Errorf("failed to initialize auth_keys table: %w", err)
+
+	migrations := []string{
+		`ALTER TABLE auth_keys ADD COLUMN IF NOT EXISTS user_path TEXT`,
+	}
+	for _, migration := range migrations {
+		if _, err := pool.Exec(ctx, migration); err != nil {
+			return nil, fmt.Errorf("failed to run migration %q: %w", migration, err)
+		}
 	}
 	for _, index := range []string{
 		`CREATE INDEX IF NOT EXISTS idx_auth_keys_enabled ON auth_keys(enabled)`,

--- a/internal/authkeys/store_sqlite.go
+++ b/internal/authkeys/store_sqlite.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -24,6 +25,7 @@ func NewSQLiteStore(db *sql.DB) (*SQLiteStore, error) {
 			id TEXT PRIMARY KEY,
 			name TEXT NOT NULL,
 			description TEXT NOT NULL DEFAULT '',
+			user_path TEXT,
 			redacted_value TEXT NOT NULL,
 			secret_hash TEXT NOT NULL UNIQUE,
 			enabled INTEGER NOT NULL DEFAULT 1,
@@ -35,6 +37,9 @@ func NewSQLiteStore(db *sql.DB) (*SQLiteStore, error) {
 	`)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create auth_keys table: %w", err)
+	}
+	if _, err := db.Exec(`ALTER TABLE auth_keys ADD COLUMN user_path TEXT`); err != nil && !isSQLiteDuplicateColumnError(err) {
+		return nil, fmt.Errorf("failed to initialize auth_keys table: %w", err)
 	}
 	for _, index := range []string{
 		`CREATE INDEX IF NOT EXISTS idx_auth_keys_enabled ON auth_keys(enabled)`,
@@ -50,7 +55,7 @@ func NewSQLiteStore(db *sql.DB) (*SQLiteStore, error) {
 
 func (s *SQLiteStore) List(ctx context.Context) ([]AuthKey, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, name, description, redacted_value, secret_hash, enabled, expires_at, deactivated_at, created_at, updated_at
+		SELECT id, name, description, user_path, redacted_value, secret_hash, enabled, expires_at, deactivated_at, created_at, updated_at
 		FROM auth_keys
 		ORDER BY created_at DESC, id ASC
 	`)
@@ -67,9 +72,9 @@ func (s *SQLiteStore) List(ctx context.Context) ([]AuthKey, error) {
 
 func (s *SQLiteStore) Create(ctx context.Context, key AuthKey) error {
 	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO auth_keys (id, name, description, redacted_value, secret_hash, enabled, expires_at, deactivated_at, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`, key.ID, key.Name, key.Description, key.RedactedValue, key.SecretHash, boolToSQLite(key.Enabled), unixOrNil(key.ExpiresAt), unixOrNil(key.DeactivatedAt), key.CreatedAt.Unix(), key.UpdatedAt.Unix())
+		INSERT INTO auth_keys (id, name, description, user_path, redacted_value, secret_hash, enabled, expires_at, deactivated_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, key.ID, key.Name, key.Description, nullableString(key.UserPath), key.RedactedValue, key.SecretHash, boolToSQLite(key.Enabled), unixOrNil(key.ExpiresAt), unixOrNil(key.DeactivatedAt), key.CreatedAt.Unix(), key.UpdatedAt.Unix())
 	if err != nil {
 		return fmt.Errorf("create auth key: %w", err)
 	}
@@ -103,6 +108,7 @@ func (s *SQLiteStore) Close() error {
 
 func scanSQLiteAuthKey(scanner authKeyScanner) (AuthKey, error) {
 	var key AuthKey
+	var userPath sql.NullString
 	var enabled int
 	var expiresAt sql.NullInt64
 	var deactivatedAt sql.NullInt64
@@ -112,6 +118,7 @@ func scanSQLiteAuthKey(scanner authKeyScanner) (AuthKey, error) {
 		&key.ID,
 		&key.Name,
 		&key.Description,
+		&userPath,
 		&key.RedactedValue,
 		&key.SecretHash,
 		&enabled,
@@ -125,12 +132,21 @@ func scanSQLiteAuthKey(scanner authKeyScanner) (AuthKey, error) {
 		}
 		return AuthKey{}, err
 	}
+	key.UserPath = nullableStringValue(userPath)
 	key.Enabled = enabled != 0
 	key.ExpiresAt = unixPtr(expiresAt)
 	key.DeactivatedAt = unixPtr(deactivatedAt)
 	key.CreatedAt = time.Unix(createdAt, 0).UTC()
 	key.UpdatedAt = time.Unix(updatedAt, 0).UTC()
 	return key, nil
+}
+
+func isSQLiteDuplicateColumnError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "duplicate column") || strings.Contains(message, "already exists")
 }
 
 func boolToSQLite(v bool) int {
@@ -153,4 +169,19 @@ func unixPtr(value sql.NullInt64) *time.Time {
 	}
 	t := time.Unix(value.Int64, 0).UTC()
 	return &t
+}
+
+func nullableString(value string) any {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+func nullableStringValue(value sql.NullString) string {
+	if !value.Valid {
+		return ""
+	}
+	return strings.TrimSpace(value.String)
 }

--- a/internal/authkeys/store_sqlite.go
+++ b/internal/authkeys/store_sqlite.go
@@ -38,8 +38,14 @@ func NewSQLiteStore(db *sql.DB) (*SQLiteStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create auth_keys table: %w", err)
 	}
-	if _, err := db.Exec(`ALTER TABLE auth_keys ADD COLUMN user_path TEXT`); err != nil && !isSQLiteDuplicateColumnError(err) {
-		return nil, fmt.Errorf("failed to initialize auth_keys table: %w", err)
+
+	migrations := []string{
+		`ALTER TABLE auth_keys ADD COLUMN user_path TEXT`,
+	}
+	for _, migration := range migrations {
+		if _, err := db.Exec(migration); err != nil && !isSQLiteDuplicateColumnError(err) {
+			return nil, fmt.Errorf("failed to run migration %q: %w", migration, err)
+		}
 	}
 	for _, index := range []string{
 		`CREATE INDEX IF NOT EXISTS idx_auth_keys_enabled ON auth_keys(enabled)`,

--- a/internal/authkeys/types.go
+++ b/internal/authkeys/types.go
@@ -13,6 +13,7 @@ type AuthKey struct {
 	ID            string     `json:"id" bson:"_id"`
 	Name          string     `json:"name" bson:"name"`
 	Description   string     `json:"description,omitempty" bson:"description,omitempty"`
+	UserPath      string     `json:"user_path,omitempty" bson:"user_path,omitempty"`
 	RedactedValue string     `json:"redacted_value" bson:"redacted_value"`
 	SecretHash    string     `json:"-" bson:"secret_hash"`
 	Enabled       bool       `json:"enabled" bson:"enabled"`
@@ -38,6 +39,7 @@ type IssuedKey struct {
 type CreateInput struct {
 	Name        string
 	Description string
+	UserPath    string
 	ExpiresAt   *time.Time
 }
 

--- a/internal/core/context.go
+++ b/internal/core/context.go
@@ -16,6 +16,9 @@ const (
 	executionPlanKey contextKey = "execution-plan"
 	// authKeyIDKey stores the internal managed auth key id for the request.
 	authKeyIDKey contextKey = "auth-key-id"
+	// effectiveUserPathKey stores a request-scoped user path override applied
+	// after ingress capture, for example from a managed auth key.
+	effectiveUserPathKey contextKey = "effective-user-path"
 	// batchPreparationMetadataKey stores request-scoped batch preprocessing metadata.
 	batchPreparationMetadataKey contextKey = "batch-preparation-metadata"
 
@@ -106,6 +109,21 @@ func GetAuthKeyID(ctx context.Context) string {
 	if v := ctx.Value(authKeyIDKey); v != nil {
 		if id, ok := v.(string); ok {
 			return id
+		}
+	}
+	return ""
+}
+
+// WithEffectiveUserPath returns a new context with an effective user path override attached.
+func WithEffectiveUserPath(ctx context.Context, userPath string) context.Context {
+	return context.WithValue(ctx, effectiveUserPathKey, userPath)
+}
+
+// GetEffectiveUserPath retrieves the effective user path override from context.
+func GetEffectiveUserPath(ctx context.Context) string {
+	if v := ctx.Value(effectiveUserPathKey); v != nil {
+		if userPath, ok := v.(string); ok {
+			return userPath
 		}
 	}
 	return ""

--- a/internal/core/request_snapshot.go
+++ b/internal/core/request_snapshot.go
@@ -79,6 +79,28 @@ func firstUserPath(values []string) string {
 	return strings.TrimSpace(values[0])
 }
 
+// WithUserPath returns a shallow-cloned snapshot with UserPath and the captured
+// X-GoModel-User-Path header rewritten to the provided canonical value.
+func (s *RequestSnapshot) WithUserPath(userPath string) *RequestSnapshot {
+	if s == nil {
+		return nil
+	}
+	cloned := *s
+	cloned.UserPath = strings.TrimSpace(userPath)
+	cloned.headers = cloneMultiMap(s.headers)
+	if cloned.UserPath == "" {
+		if cloned.headers != nil {
+			delete(cloned.headers, UserPathHeader)
+		}
+		return &cloned
+	}
+	if cloned.headers == nil {
+		cloned.headers = make(map[string][]string, 1)
+	}
+	cloned.headers[UserPathHeader] = []string{cloned.UserPath}
+	return &cloned
+}
+
 // CapturedBody returns a defensive copy of the captured request body bytes.
 func (s *RequestSnapshot) CapturedBody() []byte {
 	if s == nil {

--- a/internal/core/request_snapshot_test.go
+++ b/internal/core/request_snapshot_test.go
@@ -122,3 +122,33 @@ func BenchmarkNewRequestSnapshotWithOwnedBody(b *testing.B) {
 		_ = NewRequestSnapshotWithOwnedBody("POST", "/v1/chat/completions", nil, nil, nil, "application/json", body, false, "req-123", nil)
 	}
 }
+
+func TestRequestSnapshotWithUserPath_RewritesCapturedHeader(t *testing.T) {
+	snapshot := NewRequestSnapshot(
+		"POST",
+		"/v1/chat/completions",
+		nil,
+		nil,
+		map[string][]string{UserPathHeader: {"/team/from-header"}},
+		"application/json",
+		nil,
+		false,
+		"req-123",
+		nil,
+		"/team/from-header",
+	)
+
+	updated := snapshot.WithUserPath("/team/from-auth-key")
+	if updated == nil {
+		t.Fatal("WithUserPath() = nil, want snapshot")
+	}
+	if got := updated.UserPath; got != "/team/from-auth-key" {
+		t.Fatalf("updated.UserPath = %q, want /team/from-auth-key", got)
+	}
+	if got := updated.GetHeaders()[UserPathHeader][0]; got != "/team/from-auth-key" {
+		t.Fatalf("updated header = %q, want /team/from-auth-key", got)
+	}
+	if got := snapshot.UserPath; got != "/team/from-header" {
+		t.Fatalf("original snapshot UserPath = %q, want /team/from-header", got)
+	}
+}

--- a/internal/core/user_path.go
+++ b/internal/core/user_path.go
@@ -67,6 +67,9 @@ func UserPathAncestors(path string) []string {
 
 // UserPathFromContext returns the canonical request user path when available.
 func UserPathFromContext(ctx context.Context) string {
+	if userPath := GetEffectiveUserPath(ctx); userPath != "" {
+		return userPath
+	}
 	if snapshot := GetRequestSnapshot(ctx); snapshot != nil {
 		return snapshot.UserPath
 	}

--- a/internal/core/user_path_test.go
+++ b/internal/core/user_path_test.go
@@ -1,6 +1,9 @@
 package core
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestNormalizeUserPath(t *testing.T) {
 	t.Parallel()
@@ -38,6 +41,15 @@ func TestNormalizeUserPath(t *testing.T) {
 				t.Fatalf("NormalizeUserPath() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestUserPathFromContext_PrefersEffectiveOverride(t *testing.T) {
+	ctx := WithRequestSnapshot(context.Background(), &RequestSnapshot{UserPath: "/team/from-header"})
+	ctx = WithEffectiveUserPath(ctx, "/team/from-auth-key")
+
+	if got := UserPathFromContext(ctx); got != "/team/from-auth-key" {
+		t.Fatalf("UserPathFromContext() = %q, want /team/from-auth-key", got)
 	}
 }
 

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -9,14 +9,15 @@ import (
 	"github.com/labstack/echo/v5"
 
 	"gomodel/internal/auditlog"
+	"gomodel/internal/authkeys"
 	"gomodel/internal/core"
 )
 
 // BearerTokenAuthenticator authenticates managed bearer tokens and returns
-// their internal auth key id on success.
+// their internal auth key metadata on success.
 type BearerTokenAuthenticator interface {
 	Enabled() bool
-	Authenticate(ctx context.Context, token string) (string, error)
+	Authenticate(ctx context.Context, token string) (authkeys.AuthenticationResult, error)
 }
 
 // AuthMiddleware creates an Echo middleware that validates the master key
@@ -75,11 +76,19 @@ func AuthMiddlewareWithAuthenticator(masterKey string, authenticator BearerToken
 
 			if authenticator != nil && authenticator.Enabled() {
 				auditlog.EnrichEntryWithAuthMethod(c, auditlog.AuthMethodAPIKey)
-				authKeyID, err := authenticator.Authenticate(c.Request().Context(), token)
+				authResult, err := authenticator.Authenticate(c.Request().Context(), token)
 				if err == nil {
-					ctx := core.WithAuthKeyID(c.Request().Context(), authKeyID)
+					ctx := core.WithAuthKeyID(c.Request().Context(), authResult.ID)
+					if userPath := strings.TrimSpace(authResult.UserPath); userPath != "" {
+						ctx = core.WithEffectiveUserPath(ctx, userPath)
+						if snapshot := core.GetRequestSnapshot(ctx); snapshot != nil {
+							ctx = core.WithRequestSnapshot(ctx, snapshot.WithUserPath(userPath))
+						}
+						c.Request().Header.Set(core.UserPathHeader, userPath)
+						auditlog.EnrichEntryWithUserPath(c, userPath)
+					}
 					c.SetRequest(c.Request().WithContext(ctx))
-					auditlog.EnrichEntryWithAuthKeyID(c, authKeyID)
+					auditlog.EnrichEntryWithAuthKeyID(c, authResult.ID)
 					return next(c)
 				}
 

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -13,12 +13,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"gomodel/internal/auditlog"
+	"gomodel/internal/authkeys"
 	"gomodel/internal/core"
 )
 
 type mockAuthenticator struct {
 	enabled   bool
 	tokenToID map[string]string
+	tokenPath map[string]string
 	err       error
 }
 
@@ -26,15 +28,18 @@ func (m mockAuthenticator) Enabled() bool {
 	return m.enabled
 }
 
-func (m mockAuthenticator) Authenticate(_ context.Context, token string) (string, error) {
+func (m mockAuthenticator) Authenticate(_ context.Context, token string) (authkeys.AuthenticationResult, error) {
 	if m.err != nil {
-		return "", m.err
+		return authkeys.AuthenticationResult{}, m.err
 	}
 	id, ok := m.tokenToID[token]
 	if !ok {
-		return "", assert.AnError
+		return authkeys.AuthenticationResult{}, assert.AnError
 	}
-	return id, nil
+	return authkeys.AuthenticationResult{
+		ID:       id,
+		UserPath: m.tokenPath[token],
+	}, nil
 }
 
 func TestAuthMiddleware(t *testing.T) {
@@ -210,6 +215,52 @@ func TestAuthMiddlewareWithAuthenticator_ManagedKeyEnrichesContextAndAudit(t *te
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "ok", rec.Body.String())
+}
+
+func TestAuthMiddlewareWithAuthenticator_ManagedKeyUserPathOverridesHeader(t *testing.T) {
+	e := echo.New()
+	testHandler := func(c *echo.Context) error {
+		if got := core.UserPathFromContext(c.Request().Context()); got != "/team/auth-key" {
+			t.Fatalf("effective user path = %q, want /team/auth-key", got)
+		}
+		snapshot := core.GetRequestSnapshot(c.Request().Context())
+		if snapshot == nil {
+			t.Fatal("request snapshot missing from context")
+		}
+		if got := snapshot.UserPath; got != "/team/auth-key" {
+			t.Fatalf("snapshot.UserPath = %q, want /team/auth-key", got)
+		}
+		if got := c.Request().Header.Get(core.UserPathHeader); got != "/team/auth-key" {
+			t.Fatalf("%s = %q, want /team/auth-key", core.UserPathHeader, got)
+		}
+		entryVal := c.Get(string(auditlog.LogEntryKey))
+		entry, ok := entryVal.(*auditlog.LogEntry)
+		if !ok || entry == nil {
+			t.Fatal("audit log entry missing from context")
+		}
+		if got := entry.UserPath; got != "/team/auth-key" {
+			t.Fatalf("audit entry user path = %q, want /team/auth-key", got)
+		}
+		return c.String(http.StatusOK, "ok")
+	}
+
+	handler := RequestSnapshotCapture()(AuthMiddlewareWithAuthenticator("", mockAuthenticator{
+		enabled:   true,
+		tokenToID: map[string]string{"sk_gom_token": "key-123"},
+		tokenPath: map[string]string{"sk_gom_token": "/team/auth-key"},
+	}, nil)(testHandler))
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-5-mini"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(core.UserPathHeader, "/team/from-header")
+	req.Header.Set("Authorization", "Bearer sk_gom_token")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(auditlog.LogEntryKey), &auditlog.LogEntry{Data: &auditlog.LogData{}})
+
+	err := handler(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
 func TestAuthMiddlewareWithAuthenticator_ManagedKeyFailureUsesGenericClientMessage(t *testing.T) {

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -217,15 +217,15 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 		e.Use(auditlog.Middleware(cfg.AuditLogger))
 	}
 
-	// Request planning resolves the request-scoped execution plan before auth and
-	// handler execution. This keeps rejected model requests loggable and lets
-	// downstream stages consume a shared policy decision.
-	e.Use(ExecutionPlanningWithResolverAndPolicy(provider, modelResolver, executionPolicyResolver))
-
 	// Authentication (skips public paths)
 	if cfg != nil && (cfg.MasterKey != "" || cfg.Authenticator != nil) {
 		e.Use(AuthMiddlewareWithAuthenticator(cfg.MasterKey, cfg.Authenticator, authSkipPaths))
 	}
+
+	// Request planning resolves the request-scoped execution plan after auth so
+	// managed auth key user-path overrides are visible to policy resolution while
+	// still keeping planning failures loggable through the audit middleware.
+	e.Use(ExecutionPlanningWithResolverAndPolicy(provider, modelResolver, executionPolicyResolver))
 
 	// Public routes
 	e.GET("/health", handler.Health)

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -269,6 +269,57 @@ func TestServerWithMasterKeyAndMetrics(t *testing.T) {
 	})
 }
 
+func TestServer_ManagedAuthKeyUserPathOverridesHeaderBeforeExecutionPlanning(t *testing.T) {
+	mock := &mockProvider{
+		supportedModels: []string{"gpt-5-mini"},
+		providerTypes:   map[string]string{"gpt-5-mini": "openai"},
+		response: &core.ChatResponse{
+			ID:       "chatcmpl-test",
+			Object:   "chat.completion",
+			Model:    "gpt-5-mini",
+			Provider: "openai",
+			Choices: []core.Choice{
+				{
+					Index:        0,
+					FinishReason: "stop",
+					Message: core.ResponseMessage{
+						Role:    "assistant",
+						Content: "ok",
+					},
+				},
+			},
+		},
+	}
+
+	var capturedSelector core.ExecutionPlanSelector
+	srv := New(mock, &Config{
+		Authenticator: mockAuthenticator{
+			enabled:   true,
+			tokenToID: map[string]string{"managed-token": "key-123"},
+			tokenPath: map[string]string{"managed-token": "/team/from-key"},
+		},
+		ExecutionPolicyResolver: requestExecutionPolicyResolverFunc(func(selector core.ExecutionPlanSelector) (*core.ResolvedExecutionPolicy, error) {
+			capturedSelector = selector
+			return nil, nil
+		}),
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-5-mini","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer managed-token")
+	req.Header.Set(core.UserPathHeader, "/team/from-header")
+	rec := httptest.NewRecorder()
+
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if capturedSelector.UserPath != "/team/from-key" {
+		t.Fatalf("selector.UserPath = %q, want /team/from-key", capturedSelector.UserPath)
+	}
+}
+
 func newDashboardHandler(t *testing.T) *dashboard.Handler {
 	t.Helper()
 	h, err := dashboard.New()


### PR DESCRIPTION
## Summary
- add optional user-path scoping to managed API keys across storage, admin API, auth middleware, and dashboard UI
- apply managed-key user-path overrides before execution planning so scoped policies resolve correctly
- style the workflow/execution-plan Auth node like Cache by default and cover it with layout tests

## Testing
- go test ./internal/server ./internal/authkeys ./internal/auditlog ./internal/core ./internal/admin ./internal/app
- node --test internal/admin/dashboard/static/js/modules/auth-keys.test.js internal/admin/dashboard/static/js/modules/dashboard-layout.test.js internal/admin/dashboard/static/js/modules/execution-plans-layout.test.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional "User Path" field to API key creation; displays in the API keys table and can override the X-GoModel-User-Path header for request context and audit logging.
  * Authenticated API keys can supply an effective User Path used during request handling and execution planning.

* **Bug Fixes / Validation**
  * User Path input is validated and normalized to prevent path-traversal and collapse redundant slashes.

* **Style**
  * Improved Auth node styling and updated Auth node icon in execution-plan visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->