### PR TITLE
fix(core): remove custom JSON field scanner

### DIFF
--- a/internal/core/json_fields.go
+++ b/internal/core/json_fields.go
@@ -6,7 +6,8 @@ import (
 	"fmt"
 	"math"
 	"sort"
-	"strconv"
+
+	"github.com/tidwall/gjson"
 )
 
 // UnknownJSONFields stores unknown JSON object members as a single raw object.
@@ -31,6 +32,10 @@ func CloneUnknownJSONFields(fields UnknownJSONFields) UnknownJSONFields {
 
 // UnknownJSONFieldsFromMap converts a raw field map into a compact JSON object.
 func UnknownJSONFieldsFromMap(fields map[string]json.RawMessage) UnknownJSONFields {
+	return unknownJSONFieldsFromMap(fields, true)
+}
+
+func unknownJSONFieldsFromMap(fields map[string]json.RawMessage, cloneValues bool) UnknownJSONFields {
 	if len(fields) == 0 {
 		return UnknownJSONFields{}
 	}
@@ -53,7 +58,10 @@ func UnknownJSONFieldsFromMap(fields map[string]json.RawMessage) UnknownJSONFiel
 		}
 		buf.Write(keyBody)
 		buf.WriteByte(':')
-		rawValue := CloneRawJSON(fields[key])
+		rawValue := fields[key]
+		if cloneValues {
+			rawValue = CloneRawJSON(rawValue)
+		}
 		if len(rawValue) == 0 {
 			buf.WriteString("null")
 			continue
@@ -83,7 +91,11 @@ func (fields UnknownJSONFields) Lookup(key string) json.RawMessage {
 	}
 
 	for dec.More() {
-		fieldName, ok := readJSONObjectKey(dec)
+		keyToken, err := dec.Token()
+		if err != nil {
+			return nil
+		}
+		fieldName, ok := keyToken.(string)
 		if !ok {
 			return nil
 		}
@@ -107,7 +119,50 @@ func (fields UnknownJSONFields) IsEmpty() bool {
 }
 
 func extractUnknownJSONFields(data []byte, knownFields ...string) (UnknownJSONFields, error) {
-	return extractUnknownJSONFieldsObjectByScan(data, knownFields...)
+	data = bytes.TrimSpace(data)
+	if len(data) == 0 || data[0] != '{' {
+		return UnknownJSONFields{}, fmt.Errorf("expected JSON object")
+	}
+	if !gjson.ValidBytes(data) {
+		return UnknownJSONFields{}, fmt.Errorf("invalid JSON object")
+	}
+
+	root := gjson.ParseBytes(data)
+	if !root.IsObject() {
+		return UnknownJSONFields{}, fmt.Errorf("expected JSON object")
+	}
+
+	buf := bytes.NewBuffer(make([]byte, 0, len(data)))
+	buf.WriteByte('{')
+	wrote := false
+	root.ForEach(func(key, value gjson.Result) bool {
+		if containsJSONField(knownFields, key.String()) {
+			return true
+		}
+		if wrote {
+			buf.WriteByte(',')
+		}
+		buf.WriteString(key.Raw)
+		buf.WriteByte(':')
+		buf.WriteString(value.Raw)
+		wrote = true
+		return true
+	})
+	if !wrote {
+		return UnknownJSONFields{}, nil
+	}
+
+	buf.WriteByte('}')
+	return UnknownJSONFields{raw: buf.Bytes()}, nil
+}
+
+func containsJSONField(knownFields []string, field string) bool {
+	for _, known := range knownFields {
+		if field == known {
+			return true
+		}
+	}
+	return false
 }
 
 func marshalWithUnknownJSONFields(base any, extraFields UnknownJSONFields) ([]byte, error) {
@@ -161,258 +216,4 @@ func mergedJSONObjectCap(baseLen, extraLen int) (int, error) {
 		return 0, fmt.Errorf("combined JSON object too large")
 	}
 	return baseLen + extraLen - 1, nil
-}
-
-func readJSONObjectKey(dec *json.Decoder) (string, bool) {
-	keyToken, err := dec.Token()
-	if err != nil {
-		return "", false
-	}
-	key, ok := keyToken.(string)
-	return key, ok
-}
-
-func extractUnknownJSONFieldsObjectByScan(data []byte, knownFields ...string) (UnknownJSONFields, error) {
-	data = bytes.TrimSpace(data)
-	if len(data) == 0 || data[0] != '{' {
-		return UnknownJSONFields{}, fmt.Errorf("expected JSON object")
-	}
-
-	known := make(map[string]struct{}, len(knownFields))
-	for _, field := range knownFields {
-		known[field] = struct{}{}
-	}
-
-	buf := bytes.NewBuffer(make([]byte, 0, len(data)))
-	buf.WriteByte('{')
-	wrote := false
-
-	i := skipJSONWhitespace(data, 1)
-	for i < len(data) {
-		if data[i] == '}' {
-			break
-		}
-
-		keyStart := i
-		keyEnd, err := scanJSONString(data, keyStart)
-		if err != nil {
-			return UnknownJSONFields{}, err
-		}
-		key, err := decodeJSONString(data[keyStart:keyEnd])
-		if err != nil {
-			return UnknownJSONFields{}, err
-		}
-
-		i = skipJSONWhitespace(data, keyEnd)
-		if i >= len(data) || data[i] != ':' {
-			return UnknownJSONFields{}, fmt.Errorf("expected ':' after object key")
-		}
-		i = skipJSONWhitespace(data, i+1)
-
-		valueStart := i
-		valueEnd, err := scanJSONValue(data, valueStart)
-		if err != nil {
-			return UnknownJSONFields{}, err
-		}
-
-		if _, isKnown := known[key]; !isKnown {
-			if wrote {
-				buf.WriteByte(',')
-			}
-			buf.Write(data[keyStart:keyEnd])
-			buf.WriteByte(':')
-			buf.Write(data[valueStart:valueEnd])
-			wrote = true
-		}
-
-		i = skipJSONWhitespace(data, valueEnd)
-		if i >= len(data) {
-			return UnknownJSONFields{}, fmt.Errorf("unterminated JSON object")
-		}
-		switch data[i] {
-		case ',':
-			i = skipJSONWhitespace(data, i+1)
-			if i >= len(data) {
-				return UnknownJSONFields{}, fmt.Errorf("unterminated JSON object")
-			}
-			if data[i] == '}' {
-				return UnknownJSONFields{}, fmt.Errorf("unexpected trailing comma in JSON object")
-			}
-		case '}':
-			// The next loop iteration will terminate cleanly on the closing brace.
-		default:
-			return UnknownJSONFields{}, fmt.Errorf("expected ',' or '}' after object value")
-		}
-	}
-
-	if !wrote {
-		return UnknownJSONFields{}, nil
-	}
-	buf.WriteByte('}')
-	return UnknownJSONFields{raw: buf.Bytes()}, nil
-}
-
-func scanJSONValue(data []byte, start int) (int, error) {
-	if start >= len(data) {
-		return 0, fmt.Errorf("expected JSON value")
-	}
-	switch data[start] {
-	case '"':
-		return scanJSONString(data, start)
-	case '{':
-		return scanJSONObject(data, start)
-	case '[':
-		return scanJSONArray(data, start)
-	default:
-		i := start
-		for i < len(data) {
-			switch data[i] {
-			case ',', '}', ']':
-				goto validateLiteral
-			case ' ', '\n', '\r', '\t':
-				goto validateLiteral
-			}
-			i++
-		}
-	validateLiteral:
-		if i == start {
-			return 0, fmt.Errorf("expected JSON literal")
-		}
-		if err := validateJSONLiteral(data[start:i]); err != nil {
-			return 0, err
-		}
-		return i, nil
-	}
-}
-
-func scanJSONObject(data []byte, start int) (int, error) {
-	i := start + 1
-	for i < len(data) {
-		i = skipJSONWhitespace(data, i)
-		if i >= len(data) {
-			break
-		}
-		if data[i] == '}' {
-			return i + 1, nil
-		}
-		keyEnd, err := scanJSONString(data, i)
-		if err != nil {
-			return 0, err
-		}
-		i = skipJSONWhitespace(data, keyEnd)
-		if i >= len(data) || data[i] != ':' {
-			return 0, fmt.Errorf("expected ':' after object key")
-		}
-		i = skipJSONWhitespace(data, i+1)
-		valueEnd, err := scanJSONValue(data, i)
-		if err != nil {
-			return 0, err
-		}
-		i = skipJSONWhitespace(data, valueEnd)
-		if i >= len(data) {
-			return 0, fmt.Errorf("unterminated JSON object")
-		}
-		switch data[i] {
-		case ',':
-			i = skipJSONWhitespace(data, i+1)
-			if i >= len(data) {
-				return 0, fmt.Errorf("unterminated JSON object")
-			}
-			if data[i] == '}' {
-				return 0, fmt.Errorf("unexpected trailing comma in JSON object")
-			}
-		case '}':
-			return i + 1, nil
-		default:
-			return 0, fmt.Errorf("expected ',' or '}' after object value")
-		}
-	}
-	return 0, fmt.Errorf("unterminated JSON object")
-}
-
-func scanJSONArray(data []byte, start int) (int, error) {
-	i := start + 1
-	for i < len(data) {
-		i = skipJSONWhitespace(data, i)
-		if i >= len(data) {
-			break
-		}
-		if data[i] == ']' {
-			return i + 1, nil
-		}
-		valueEnd, err := scanJSONValue(data, i)
-		if err != nil {
-			return 0, err
-		}
-		i = skipJSONWhitespace(data, valueEnd)
-		if i >= len(data) {
-			return 0, fmt.Errorf("unterminated JSON array")
-		}
-		switch data[i] {
-		case ',':
-			i = skipJSONWhitespace(data, i+1)
-			if i >= len(data) {
-				return 0, fmt.Errorf("unterminated JSON array")
-			}
-			if data[i] == ']' {
-				return 0, fmt.Errorf("unexpected trailing comma in JSON array")
-			}
-		case ']':
-			return i + 1, nil
-		default:
-			return 0, fmt.Errorf("expected ',' or ']' after array element")
-		}
-	}
-	return 0, fmt.Errorf("unterminated JSON array")
-}
-
-func validateJSONLiteral(raw []byte) error {
-	var value any
-	if err := json.Unmarshal(raw, &value); err != nil {
-		return fmt.Errorf("invalid JSON literal: %w", err)
-	}
-	switch value.(type) {
-	case nil, bool, float64:
-		return nil
-	default:
-		return fmt.Errorf("invalid JSON literal")
-	}
-}
-
-func scanJSONString(data []byte, start int) (int, error) {
-	if start >= len(data) || data[start] != '"' {
-		return 0, fmt.Errorf("expected JSON string")
-	}
-	for i := start + 1; i < len(data); i++ {
-		switch data[i] {
-		case '\\':
-			i++
-		case '"':
-			return i + 1, nil
-		}
-	}
-	return 0, fmt.Errorf("unterminated JSON string")
-}
-
-func decodeJSONString(raw []byte) (string, error) {
-	if len(raw) < 2 {
-		return "", fmt.Errorf("invalid JSON string")
-	}
-	if bytes.IndexByte(raw, '\\') == -1 {
-		return string(raw[1 : len(raw)-1]), nil
-	}
-	return strconv.Unquote(string(raw))
-}
-
-func skipJSONWhitespace(data []byte, start int) int {
-	i := start
-	for i < len(data) {
-		switch data[i] {
-		case ' ', '\n', '\r', '\t':
-			i++
-		default:
-			return i
-		}
-	}
-	return i
 }

--- a/internal/core/json_fields_test.go
+++ b/internal/core/json_fields_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestExtractUnknownJSONFieldsObjectByScan_PreservesNestedValues(t *testing.T) {
+func TestExtractUnknownJSONFields_PreservesNestedValues(t *testing.T) {
 	data := []byte(`{
 		"known":"value",
 		"x_object":{"nested":[1,{"ok":true}],"text":"hello"},
@@ -15,9 +15,9 @@ func TestExtractUnknownJSONFieldsObjectByScan_PreservesNestedValues(t *testing.T
 		"x_bool":true
 	}`)
 
-	fields, err := extractUnknownJSONFieldsObjectByScan(data, "known")
+	fields, err := extractUnknownJSONFields(data, "known")
 	if err != nil {
-		t.Fatalf("extractUnknownJSONFieldsObjectByScan() error = %v", err)
+		t.Fatalf("extractUnknownJSONFields() error = %v", err)
 	}
 
 	if fields.IsEmpty() {
@@ -36,16 +36,16 @@ func TestExtractUnknownJSONFieldsObjectByScan_PreservesNestedValues(t *testing.T
 	}
 }
 
-func TestExtractUnknownJSONFieldsObjectByScan_HandlesEscapedStrings(t *testing.T) {
+func TestExtractUnknownJSONFields_HandlesEscapedStrings(t *testing.T) {
 	data := []byte(`{
 		"model":"gpt-5-mini",
 		"x_text":"quote: \"ok\" and slash \\\\",
 		"x_json":"{\"embedded\":true}"
 	}`)
 
-	fields, err := extractUnknownJSONFieldsObjectByScan(data, "model")
+	fields, err := extractUnknownJSONFields(data, "model")
 	if err != nil {
-		t.Fatalf("extractUnknownJSONFieldsObjectByScan() error = %v", err)
+		t.Fatalf("extractUnknownJSONFields() error = %v", err)
 	}
 
 	if got := fields.Lookup("x_text"); !bytes.Equal(got, []byte(`"quote: \"ok\" and slash \\\\"`)) {
@@ -53,6 +53,21 @@ func TestExtractUnknownJSONFieldsObjectByScan_HandlesEscapedStrings(t *testing.T
 	}
 	if got := fields.Lookup("x_json"); !bytes.Equal(got, []byte(`"{\"embedded\":true}"`)) {
 		t.Fatalf("x_json = %s", got)
+	}
+}
+
+func TestExtractUnknownJSONFields_PreservesDuplicateUnknownKeys(t *testing.T) {
+	data := []byte(`{"known":"value","x_meta":1,"x_meta":2}`)
+
+	fields, err := extractUnknownJSONFields(data, "known")
+	if err != nil {
+		t.Fatalf("extractUnknownJSONFields() error = %v", err)
+	}
+	if got := string(fields.raw); got != `{"x_meta":1,"x_meta":2}` {
+		t.Fatalf("raw = %s, want duplicate keys preserved", got)
+	}
+	if got := fields.Lookup("x_meta"); !bytes.Equal(got, []byte("1")) {
+		t.Fatalf("Lookup(x_meta) = %s, want first duplicate value", got)
 	}
 }
 
@@ -70,7 +85,7 @@ func TestUnknownJSONFieldsFromMap_EmptyRawValueEncodesAsNull(t *testing.T) {
 	}
 }
 
-func TestExtractUnknownJSONFieldsObjectByScan_RejectsInvalidJSONSyntax(t *testing.T) {
+func TestExtractUnknownJSONFields_RejectsInvalidJSONSyntax(t *testing.T) {
 	tests := []struct {
 		name string
 		body string
@@ -79,12 +94,13 @@ func TestExtractUnknownJSONFieldsObjectByScan_RejectsInvalidJSONSyntax(t *testin
 		{name: "missing object comma", body: `{"known":"value" "x":1}`},
 		{name: "trailing object comma", body: `{"known":"value","x":1,}`},
 		{name: "trailing array comma", body: `{"known":"value","x":[1,]}`},
+		{name: "trailing top-level data", body: `{"known":"value","x":1}{"extra":true}`},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if _, err := extractUnknownJSONFieldsObjectByScan([]byte(tt.body), "known"); err == nil {
-				t.Fatalf("extractUnknownJSONFieldsObjectByScan(%q) error = nil, want syntax error", tt.body)
+			if _, err := extractUnknownJSONFields([]byte(tt.body), "known"); err == nil {
+				t.Fatalf("extractUnknownJSONFields(%q) error = nil, want syntax error", tt.body)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- replace the custom byte-by-byte JSON scanner used for unknown field preservation
- preserve unknown top-level JSON members via raw `gjson` iteration and remove redundant scanner helpers
- add regression coverage for invalid JSON and duplicate unknown keys

## Testing
- go test ./internal/core/...
- go test ./tests/perf -run TestHotPathPerfGuard
- go test ./...  # existing unrelated failure in internal/usage: TestSQLiteStoreCleanup_KeepsNewerLegacyOffsetRows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON validation to properly reject malformed input with explicit error messages.
  * Enhanced handling of duplicate unknown fields in JSON objects, ensuring they are correctly preserved and accessible.

* **Tests**
  * Updated test coverage for JSON field extraction with additional validation for edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->