### PR TITLE
fix(responsecache): split stream cache entries and validate SSE

### DIFF
--- a/internal/responsecache/handle_request_test.go
+++ b/internal/responsecache/handle_request_test.go
@@ -331,7 +331,7 @@ func TestHandleRequest_CacheControlNoCacheBypassesAllLayers(t *testing.T) {
 	}
 }
 
-func TestHandleRequest_StreamingMissPopulatesExactCacheAcrossModes(t *testing.T) {
+func TestHandleRequest_StreamingMissPopulatesExactStreamingCacheOnly(t *testing.T) {
 	store := cache.NewMapStore()
 	defer store.Close()
 
@@ -341,6 +341,11 @@ func TestHandleRequest_StreamingMissPopulatesExactCacheAcrossModes(t *testing.T)
 
 	streamBody := []byte(`{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"cache-streaming-cross-mode"}]}`)
 	jsonBody := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"cache-streaming-cross-mode"}]}`)
+	rawStream := []byte(
+		"data: {\"id\":\"chatcmpl-stream-cache\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4\",\"provider\":\"openai\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"Hello\"},\"finish_reason\":null}]}\n\n" +
+			"data: {\"id\":\"chatcmpl-stream-cache\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4\",\"provider\":\"openai\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" world\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":2,\"total_tokens\":13}}\n\n" +
+			"data: [DONE]\n\n",
+	)
 	e := echo.New()
 	handlerCalls := 0
 
@@ -360,12 +365,13 @@ func TestHandleRequest_StreamingMissPopulatesExactCacheAcrossModes(t *testing.T)
 		c.SetRequest(req.WithContext(core.WithExecutionPlan(req.Context(), plan)))
 		if err := m.HandleRequest(c, body, func() error {
 			handlerCalls++
-			c.Response().Header().Set("Content-Type", "text/event-stream")
-			c.Response().WriteHeader(http.StatusOK)
-			_, _ = c.Response().Write([]byte("data: {\"id\":\"chatcmpl-stream-cache\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4\",\"provider\":\"openai\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"Hello\"},\"finish_reason\":null}]}\n\n"))
-			_, _ = c.Response().Write([]byte("data: {\"id\":\"chatcmpl-stream-cache\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4\",\"provider\":\"openai\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" world\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":2,\"total_tokens\":13}}\n\n"))
-			_, _ = c.Response().Write([]byte("data: [DONE]\n\n"))
-			return nil
+			if isStreamingRequest(c.Request().URL.Path, body) {
+				c.Response().Header().Set("Content-Type", "text/event-stream")
+				c.Response().WriteHeader(http.StatusOK)
+				_, _ = c.Response().Write(rawStream)
+				return nil
+			}
+			return c.JSON(http.StatusOK, map[string]string{"mode": "json"})
 		}); err != nil {
 			t.Fatalf("HandleRequest: %v", err)
 		}
@@ -382,35 +388,179 @@ func TestHandleRequest_StreamingMissPopulatesExactCacheAcrossModes(t *testing.T)
 	if handlerCalls != 1 {
 		t.Fatalf("expected 1 handler invocation after streaming miss, got %d", handlerCalls)
 	}
+	if !bytes.Equal(rec1.Body.Bytes(), rawStream) {
+		t.Fatalf("streaming miss body = %q, want original SSE payload", rec1.Body.String())
+	}
 
 	m.simple.wg.Wait()
 
 	rec2 := run(jsonBody)
-	if got := rec2.Header().Get("X-Cache"); got != "HIT (exact)" {
-		t.Fatalf("non-streaming follow-up should hit exact cache, got X-Cache=%q", got)
+	if got := rec2.Header().Get("X-Cache"); got != "" {
+		t.Fatalf("non-streaming follow-up should miss exact cache because stream mode is keyed separately, got X-Cache=%q", got)
 	}
 	if got := rec2.Header().Get("Content-Type"); got != "application/json" {
-		t.Fatalf("non-streaming hit Content-Type = %q, want application/json", got)
+		t.Fatalf("non-streaming miss Content-Type = %q, want application/json", got)
 	}
-	if !bytes.Contains(rec2.Body.Bytes(), []byte(`"content":"Hello world"`)) {
-		t.Fatalf("non-streaming cache hit body = %q, want reconstructed JSON response", rec2.Body.String())
+	if !bytes.Contains(rec2.Body.Bytes(), []byte(`"mode":"json"`)) {
+		t.Fatalf("non-streaming miss body = %q, want JSON response", rec2.Body.String())
 	}
-	if handlerCalls != 1 {
-		t.Fatalf("non-streaming exact hit should not call handler again, got %d calls", handlerCalls)
+	if handlerCalls != 2 {
+		t.Fatalf("non-streaming miss should call handler again, got %d calls", handlerCalls)
 	}
+
+	m.simple.wg.Wait()
 
 	rec3 := run(streamBody)
 	if got := rec3.Header().Get("X-Cache"); got != "HIT (exact)" {
-		t.Fatalf("streaming follow-up should hit exact cache, got X-Cache=%q", got)
+		t.Fatalf("streaming follow-up should hit its own exact cache entry, got X-Cache=%q", got)
 	}
 	if got := rec3.Header().Get("Content-Type"); got != "text/event-stream" {
 		t.Fatalf("streaming hit Content-Type = %q, want text/event-stream", got)
 	}
-	if !bytes.Contains(rec3.Body.Bytes(), []byte("Hello world")) || !bytes.Contains(rec3.Body.Bytes(), []byte("[DONE]")) {
-		t.Fatalf("streaming cache hit body = %q, want synthesized SSE with content and [DONE]", rec3.Body.String())
+	if !bytes.Equal(rec3.Body.Bytes(), rawStream) {
+		t.Fatalf("streaming cache hit body = %q, want verbatim SSE replay", rec3.Body.String())
 	}
-	if handlerCalls != 1 {
+	if handlerCalls != 2 {
 		t.Fatalf("streaming exact hit should not call handler again, got %d calls", handlerCalls)
+	}
+
+	rec4 := run(jsonBody)
+	if got := rec4.Header().Get("X-Cache"); got != "HIT (exact)" {
+		t.Fatalf("non-streaming follow-up should hit its own exact cache entry, got X-Cache=%q", got)
+	}
+	if got := rec4.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("non-streaming hit Content-Type = %q, want application/json", got)
+	}
+	if !bytes.Contains(rec4.Body.Bytes(), []byte(`"mode":"json"`)) {
+		t.Fatalf("non-streaming cache hit body = %q, want cached JSON response", rec4.Body.String())
+	}
+	if handlerCalls != 2 {
+		t.Fatalf("non-streaming exact hit should not call handler again, got %d calls", handlerCalls)
+	}
+}
+
+func TestHandleRequest_StreamingExactHitWritesSyntheticUsageEntry(t *testing.T) {
+	store := cache.NewMapStore()
+	defer store.Close()
+
+	logger := &recordingUsageLogger{}
+	m := &ResponseCacheMiddleware{
+		simple: newSimpleCacheMiddleware(store, time.Hour, newUsageHitRecorder(logger, nil)),
+	}
+
+	body := []byte(`{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"cache-stream-usage-hit"}]}`)
+	rawStream := []byte(
+		"data: {\"id\":\"chatcmpl-cache-hit\",\"object\":\"chat.completion.chunk\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"},\"finish_reason\":null}]}\n\n" +
+			"data: {\"id\":\"chatcmpl-cache-hit\",\"object\":\"chat.completion.chunk\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":5,\"total_tokens\":16}}\n\n" +
+			"data: [DONE]\n\n",
+	)
+	e := echo.New()
+
+	run := func() *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		plan := &core.ExecutionPlan{
+			Mode:         core.ExecutionModeTranslated,
+			ProviderType: "openai",
+			Resolution: &core.RequestModelResolution{
+				ResolvedSelector: core.ModelSelector{Provider: "openai", Model: "gpt-4"},
+			},
+		}
+		c.SetRequest(req.WithContext(core.WithExecutionPlan(req.Context(), plan)))
+		if err := m.HandleRequest(c, body, func() error {
+			c.Response().Header().Set("Content-Type", "text/event-stream")
+			c.Response().WriteHeader(http.StatusOK)
+			_, _ = c.Response().Write(rawStream)
+			return nil
+		}); err != nil {
+			t.Fatalf("HandleRequest: %v", err)
+		}
+		return rec
+	}
+
+	rec1 := run()
+	if got := rec1.Header().Get("X-Cache"); got != "" {
+		t.Fatalf("first request should miss exact cache, got X-Cache=%q", got)
+	}
+
+	m.simple.wg.Wait()
+
+	rec2 := run()
+	if got := rec2.Header().Get("X-Cache"); got != "HIT (exact)" {
+		t.Fatalf("second request should be exact hit, got X-Cache=%q", got)
+	}
+	if len(logger.entries) != 1 {
+		t.Fatalf("expected 1 synthetic usage entry, got %d", len(logger.entries))
+	}
+	entry := logger.entries[0]
+	if entry.CacheType != usage.CacheTypeExact {
+		t.Fatalf("CacheType = %q, want %q", entry.CacheType, usage.CacheTypeExact)
+	}
+	if entry.InputTokens != 11 || entry.OutputTokens != 5 || entry.TotalTokens != 16 {
+		t.Fatalf("unexpected tokens: %+v", entry)
+	}
+	if entry.ProviderID != "chatcmpl-cache-hit" {
+		t.Fatalf("ProviderID = %q, want chatcmpl-cache-hit", entry.ProviderID)
+	}
+}
+
+func TestHandleRequest_InvalidStreamingBodySkipsExactCacheWrite(t *testing.T) {
+	store := cache.NewMapStore()
+	defer store.Close()
+
+	m := &ResponseCacheMiddleware{
+		simple: newSimpleCacheMiddleware(store, time.Hour, nil),
+	}
+
+	body := []byte(`{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"invalid-stream-cache"}]}`)
+	invalidStream := []byte(
+		"data: {\"id\":\"chatcmpl-invalid\",\"object\":\"chat.completion.chunk\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"partial\"},\"finish_reason\":null}]}\n\n",
+	)
+	e := echo.New()
+	handlerCalls := 0
+
+	run := func() *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		plan := &core.ExecutionPlan{
+			Mode:         core.ExecutionModeTranslated,
+			ProviderType: "openai",
+			Resolution: &core.RequestModelResolution{
+				ResolvedSelector: core.ModelSelector{Provider: "openai", Model: "gpt-4"},
+			},
+		}
+		c.SetRequest(req.WithContext(core.WithExecutionPlan(req.Context(), plan)))
+		if err := m.HandleRequest(c, body, func() error {
+			handlerCalls++
+			c.Response().Header().Set("Content-Type", "text/event-stream")
+			c.Response().WriteHeader(http.StatusOK)
+			_, _ = c.Response().Write(invalidStream)
+			return nil
+		}); err != nil {
+			t.Fatalf("HandleRequest: %v", err)
+		}
+		return rec
+	}
+
+	rec1 := run()
+	if got := rec1.Header().Get("X-Cache"); got != "" {
+		t.Fatalf("first request should miss cache, got X-Cache=%q", got)
+	}
+
+	m.simple.wg.Wait()
+
+	rec2 := run()
+	if got := rec2.Header().Get("X-Cache"); got != "" {
+		t.Fatalf("invalid streaming body should not be cached, got X-Cache=%q", got)
+	}
+	if handlerCalls != 2 {
+		t.Fatalf("expected invalid stream to bypass cache on follow-up, got %d calls", handlerCalls)
 	}
 }
 

--- a/internal/responsecache/middleware_test.go
+++ b/internal/responsecache/middleware_test.go
@@ -219,7 +219,26 @@ func TestHashRequest_StreamIncludeUsageChangesKey(t *testing.T) {
 	}
 }
 
-func TestSimpleCacheMiddleware_SharesCacheAcrossStreamingAndNonStreaming(t *testing.T) {
+func TestHashRequest_StreamModeChangesKey(t *testing.T) {
+	base := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}`)
+	streaming := []byte(`{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"hi"}]}`)
+	plan := &core.ExecutionPlan{
+		Mode:         core.ExecutionModeTranslated,
+		ProviderType: "openai",
+		Resolution: &core.RequestModelResolution{
+			ResolvedSelector: core.ModelSelector{Provider: "openai", Model: "gpt-4"},
+		},
+	}
+
+	first := hashRequest("/v1/chat/completions", base, plan)
+	second := hashRequest("/v1/chat/completions", streaming, plan)
+
+	if first == second {
+		t.Fatal("stream mode should affect the exact cache key")
+	}
+}
+
+func TestSimpleCacheMiddleware_SeparatesStreamingAndNonStreamingEntries(t *testing.T) {
 	store := cache.NewMapStore()
 	defer store.Close()
 	mw := NewResponseCacheMiddlewareWithStore(store, time.Hour)
@@ -227,30 +246,27 @@ func TestSimpleCacheMiddleware_SharesCacheAcrossStreamingAndNonStreaming(t *test
 	installResolvedExecutionPlan(e, "openai", "gpt-4")
 	e.Use(mw.Middleware())
 	callCount := 0
+	rawStream := []byte(
+		"data: {\"id\":\"chatcmpl-stream\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"streamed\"},\"finish_reason\":null}]}\n\n" +
+			"data: {\"id\":\"chatcmpl-stream\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":9,\"completion_tokens\":1,\"total_tokens\":10}}\n\n" +
+			"data: [DONE]\n\n",
+	)
 	e.POST("/v1/chat/completions", func(c *echo.Context) error {
 		callCount++
-		return c.JSON(http.StatusOK, &core.ChatResponse{
-			ID:       "chatcmpl-shared-cache",
-			Object:   "chat.completion",
-			Model:    "gpt-4",
-			Provider: "openai",
-			Created:  1234567890,
-			Choices: []core.Choice{
-				{
-					Index: 0,
-					Message: core.ResponseMessage{
-						Role:    "assistant",
-						Content: "shared cached response",
-					},
-					FinishReason: "stop",
-				},
-			},
-			Usage: core.Usage{
-				PromptTokens:     9,
-				CompletionTokens: 3,
-				TotalTokens:      12,
-			},
-		})
+		body, cacheable, err := requestBodyForCache(c.Request())
+		if err != nil {
+			t.Fatalf("requestBodyForCache: %v", err)
+		}
+		if !cacheable {
+			t.Fatal("expected request to be cacheable")
+		}
+		if isStreamingRequest(c.Request().URL.Path, body) {
+			c.Response().Header().Set("Content-Type", "text/event-stream")
+			c.Response().WriteHeader(http.StatusOK)
+			_, _ = c.Response().Write(rawStream)
+			return nil
+		}
+		return c.JSON(http.StatusOK, map[string]string{"result": "json cached response"})
 	})
 
 	nonStreamingBody := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}`)
@@ -270,17 +286,53 @@ func TestSimpleCacheMiddleware_SharesCacheAcrossStreamingAndNonStreaming(t *test
 	req2.Header.Set("Content-Type", "application/json")
 	rec2 := httptest.NewRecorder()
 	e.ServeHTTP(rec2, req2)
-	if got := rec2.Header().Get("X-Cache"); got != "HIT (exact)" {
-		t.Fatalf("streaming request should reuse cached full response, got X-Cache=%q", got)
+	if got := rec2.Header().Get("X-Cache"); got != "" {
+		t.Fatalf("streaming request should miss exact cache because stream mode is keyed separately, got X-Cache=%q", got)
 	}
 	if got := rec2.Header().Get("Content-Type"); got != "text/event-stream" {
+		t.Fatalf("streaming miss Content-Type = %q, want text/event-stream", got)
+	}
+	if !bytes.Equal(rec2.Body.Bytes(), rawStream) {
+		t.Fatalf("streaming miss body = %q, want original SSE payload", rec2.Body.String())
+	}
+	if callCount != 2 {
+		t.Fatalf("expected separate stream miss to call handler again, got %d calls", callCount)
+	}
+
+	mw.simple.wg.Wait()
+
+	req3 := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(streamingBody))
+	req3.Header.Set("Content-Type", "application/json")
+	rec3 := httptest.NewRecorder()
+	e.ServeHTTP(rec3, req3)
+	if got := rec3.Header().Get("X-Cache"); got != "HIT (exact)" {
+		t.Fatalf("streaming follow-up should hit its own exact cache entry, got X-Cache=%q", got)
+	}
+	if got := rec3.Header().Get("Content-Type"); got != "text/event-stream" {
 		t.Fatalf("streaming cache hit Content-Type = %q, want text/event-stream", got)
 	}
-	if !bytes.Contains(rec2.Body.Bytes(), []byte("shared cached response")) || !bytes.Contains(rec2.Body.Bytes(), []byte("[DONE]")) {
-		t.Fatalf("streaming cache hit body = %q, want synthesized SSE", rec2.Body.String())
+	if !bytes.Equal(rec3.Body.Bytes(), rawStream) {
+		t.Fatalf("streaming cache hit body = %q, want verbatim SSE replay", rec3.Body.String())
 	}
-	if callCount != 1 {
-		t.Fatalf("expected streaming replay to avoid second handler call, got %d calls", callCount)
+	if callCount != 2 {
+		t.Fatalf("expected streaming replay to avoid a third handler call, got %d calls", callCount)
+	}
+
+	req4 := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(nonStreamingBody))
+	req4.Header.Set("Content-Type", "application/json")
+	rec4 := httptest.NewRecorder()
+	e.ServeHTTP(rec4, req4)
+	if got := rec4.Header().Get("X-Cache"); got != "HIT (exact)" {
+		t.Fatalf("non-streaming follow-up should hit its own exact cache entry, got X-Cache=%q", got)
+	}
+	if got := rec4.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("non-streaming cache hit Content-Type = %q, want application/json", got)
+	}
+	if !bytes.Contains(rec4.Body.Bytes(), []byte("json cached response")) {
+		t.Fatalf("non-streaming cache hit body = %q, want cached JSON response", rec4.Body.String())
+	}
+	if callCount != 2 {
+		t.Fatalf("non-streaming exact hit should not call handler again, got %d calls", callCount)
 	}
 }
 

--- a/internal/responsecache/responsecache.go
+++ b/internal/responsecache/responsecache.go
@@ -94,8 +94,8 @@ func (m *ResponseCacheMiddleware) Middleware() echo.MiddlewareFunc {
 // HandleRequest runs the full dual-layer cache check (exact then semantic) for a
 // translated inference request that has already been guardrail-patched.
 // body is the final patched request bytes; next is the real LLM call.
-// Streaming misses are reconstructed into full JSON before storage; streaming
-// hits replay that stored JSON as synthetic SSE.
+// Streaming and non-streaming requests are cached independently. Streaming
+// misses persist raw SSE bytes and replay them verbatim on cache hits.
 func (m *ResponseCacheMiddleware) HandleRequest(c *echo.Context, body []byte, next func() error) error {
 	if m == nil {
 		return next()

--- a/internal/responsecache/semantic.go
+++ b/internal/responsecache/semantic.go
@@ -133,9 +133,9 @@ func (m *semanticCacheMiddleware) Handle(c *echo.Context, body []byte, next func
 	if core.GetFallbackUsed(c.Request().Context()) {
 		return nil
 	}
-	data, ok := capture.cachedBody(path, streamResponseDefaultsFromContext(c.Request().Context()), c.Response().Header().Get("Content-Type"))
+	data, ok := capture.cachedBody(c.Response().Header().Get("Content-Type"))
 	if !ok {
-		slog.Warn("semantic cache: failed to reconstruct cacheable response body", "path", path)
+		slog.Warn("semantic cache: failed to capture cacheable response body", "path", path)
 		return nil
 	}
 	ttl := time.Duration(m.cfg.TTL) * time.Second
@@ -351,6 +351,7 @@ func computeParamsHash(body []byte, endpointPath string, plan *core.ExecutionPla
 		MaxTokens      *int                `json:"max_tokens"`
 		Tools          []map[string]any    `json:"tools"`
 		ResponseFormat any                 `json:"response_format"`
+		Stream         bool                `json:"stream,omitempty"`
 		StreamOptions  *core.StreamOptions `json:"stream_options"`
 	}
 	_ = json.Unmarshal(body, &req)
@@ -396,7 +397,12 @@ func computeParamsHash(body []byte, endpointPath string, plan *core.ExecutionPla
 	}
 	h.Write([]byte{0})
 
-	if streamOptions := normalizeStreamOptionsForCache(req.StreamOptions); streamOptions != nil {
+	if req.Stream {
+		h.Write([]byte("1"))
+	}
+	h.Write([]byte{0})
+
+	if streamOptions := normalizeStreamOptionsForCache(req.StreamOptions); req.Stream && streamOptions != nil {
 		soJSON, _ := json.Marshal(streamOptions)
 		h.Write(soJSON)
 	}

--- a/internal/responsecache/semantic_test.go
+++ b/internal/responsecache/semantic_test.go
@@ -226,6 +226,25 @@ func TestComputeParamsHash_StreamIncludeUsageChangesHash(t *testing.T) {
 	}
 }
 
+func TestComputeParamsHash_StreamModeChangesHash(t *testing.T) {
+	base := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"same prompt"}]}`)
+	streaming := []byte(`{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"same prompt"}]}`)
+	plan := &core.ExecutionPlan{
+		Mode:         core.ExecutionModeTranslated,
+		ProviderType: "openai",
+		Resolution: &core.RequestModelResolution{
+			ResolvedSelector: core.ModelSelector{Provider: "openai", Model: "gpt-4"},
+		},
+	}
+
+	first := computeParamsHash(base, "/v1/chat/completions", plan, "", "")
+	second := computeParamsHash(streaming, "/v1/chat/completions", plan, "", "")
+
+	if first == second {
+		t.Fatal("stream mode should affect semantic params_hash")
+	}
+}
+
 func TestSemanticCacheMiddleware_GuardrailsHashIsolation(t *testing.T) {
 	m, store, emb := newTestSemanticMiddleware(0.90, 10, false)
 	emb.vector = []float32{1, 0, 0}
@@ -303,10 +322,15 @@ func TestSemanticCacheMiddleware_ExcludeSystemPrompt(t *testing.T) {
 	}
 }
 
-func TestSemanticCacheMiddleware_StreamingMissPopulatesSemanticCacheAcrossModes(t *testing.T) {
+func TestSemanticCacheMiddleware_StreamingMissPopulatesStreamingSemanticCacheOnly(t *testing.T) {
 	m, store, _ := newTestSemanticMiddleware(0.90, 10, false)
 	streamBody := []byte(`{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"semantic-stream-cache"}]}`)
 	jsonBody := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"semantic-stream-cache"}]}`)
+	rawStream := []byte(
+		"data: {\"id\":\"chatcmpl-semantic-stream\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4\",\"provider\":\"openai\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"Semantic\"},\"finish_reason\":null}]}\n\n" +
+			"data: {\"id\":\"chatcmpl-semantic-stream\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4\",\"provider\":\"openai\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" cache\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":7,\"completion_tokens\":2,\"total_tokens\":9}}\n\n" +
+			"data: [DONE]\n\n",
+	)
 	e := echo.New()
 	handlerCalls := 0
 
@@ -318,12 +342,13 @@ func TestSemanticCacheMiddleware_StreamingMissPopulatesSemanticCacheAcrossModes(
 		c := e.NewContext(req, rec)
 		if err := m.Handle(c, body, func() error {
 			handlerCalls++
-			c.Response().Header().Set("Content-Type", "text/event-stream")
-			c.Response().WriteHeader(http.StatusOK)
-			_, _ = c.Response().Write([]byte("data: {\"id\":\"chatcmpl-semantic-stream\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4\",\"provider\":\"openai\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"Semantic\"},\"finish_reason\":null}]}\n\n"))
-			_, _ = c.Response().Write([]byte("data: {\"id\":\"chatcmpl-semantic-stream\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4\",\"provider\":\"openai\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" cache\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":7,\"completion_tokens\":2,\"total_tokens\":9}}\n\n"))
-			_, _ = c.Response().Write([]byte("data: [DONE]\n\n"))
-			return nil
+			if isStreamingRequest(c.Request().URL.Path, body) {
+				c.Response().Header().Set("Content-Type", "text/event-stream")
+				c.Response().WriteHeader(http.StatusOK)
+				_, _ = c.Response().Write(rawStream)
+				return nil
+			}
+			return c.JSON(http.StatusOK, map[string]string{"mode": "json"})
 		}); err != nil {
 			t.Fatalf("Handle error: %v", err)
 		}
@@ -342,31 +367,99 @@ func TestSemanticCacheMiddleware_StreamingMissPopulatesSemanticCacheAcrossModes(
 	}
 
 	rec2 := run(jsonBody)
-	if got := rec2.Header().Get("X-Cache"); got != "HIT (semantic)" {
-		t.Fatalf("non-streaming follow-up should hit semantic cache, got X-Cache=%q", got)
+	if got := rec2.Header().Get("X-Cache"); got != "" {
+		t.Fatalf("non-streaming follow-up should miss semantic cache because stream mode is keyed separately, got X-Cache=%q", got)
 	}
 	if got := rec2.Header().Get("Content-Type"); got != "application/json" {
-		t.Fatalf("non-streaming semantic hit Content-Type = %q, want application/json", got)
+		t.Fatalf("non-streaming miss Content-Type = %q, want application/json", got)
 	}
-	if !bytes.Contains(rec2.Body.Bytes(), []byte(`"content":"Semantic cache"`)) {
-		t.Fatalf("semantic cache hit body = %q, want reconstructed JSON response", rec2.Body.String())
+	if !bytes.Contains(rec2.Body.Bytes(), []byte(`"mode":"json"`)) {
+		t.Fatalf("non-streaming miss body = %q, want JSON response", rec2.Body.String())
 	}
-	if handlerCalls != 1 {
-		t.Fatalf("semantic hit should not call handler again, got %d calls", handlerCalls)
+	if handlerCalls != 2 {
+		t.Fatalf("non-streaming miss should call handler again, got %d calls", handlerCalls)
+	}
+
+	m.wg.Wait()
+
+	if store.Len() != 2 {
+		t.Fatalf("expected separate semantic entries for stream and non-stream requests, got %d entries", store.Len())
 	}
 
 	rec3 := run(streamBody)
 	if got := rec3.Header().Get("X-Cache"); got != "HIT (semantic)" {
-		t.Fatalf("streaming follow-up should hit semantic cache, got X-Cache=%q", got)
+		t.Fatalf("streaming follow-up should hit its own semantic cache entry, got X-Cache=%q", got)
 	}
 	if got := rec3.Header().Get("Content-Type"); got != "text/event-stream" {
 		t.Fatalf("streaming semantic hit Content-Type = %q, want text/event-stream", got)
 	}
-	if !bytes.Contains(rec3.Body.Bytes(), []byte("Semantic cache")) || !bytes.Contains(rec3.Body.Bytes(), []byte("[DONE]")) {
-		t.Fatalf("streaming semantic hit body = %q, want synthesized SSE", rec3.Body.String())
+	if !bytes.Equal(rec3.Body.Bytes(), rawStream) {
+		t.Fatalf("streaming semantic hit body = %q, want verbatim SSE replay", rec3.Body.String())
 	}
-	if handlerCalls != 1 {
+	if handlerCalls != 2 {
 		t.Fatalf("streaming semantic hit should not call handler again, got %d calls", handlerCalls)
+	}
+
+	rec4 := run(jsonBody)
+	if got := rec4.Header().Get("X-Cache"); got != "HIT (semantic)" {
+		t.Fatalf("non-streaming follow-up should hit its own semantic cache entry, got X-Cache=%q", got)
+	}
+	if got := rec4.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("non-streaming semantic hit Content-Type = %q, want application/json", got)
+	}
+	if !bytes.Contains(rec4.Body.Bytes(), []byte(`"mode":"json"`)) {
+		t.Fatalf("non-streaming semantic hit body = %q, want cached JSON response", rec4.Body.String())
+	}
+	if handlerCalls != 2 {
+		t.Fatalf("non-streaming semantic hit should not call handler again, got %d calls", handlerCalls)
+	}
+}
+
+func TestSemanticCacheMiddleware_InvalidStreamingBodySkipsSemanticCacheWrite(t *testing.T) {
+	m, store, _ := newTestSemanticMiddleware(0.90, 10, false)
+	body := []byte(`{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"semantic-invalid-stream"}]}`)
+	invalidStream := []byte(
+		": keep-alive\n\n" +
+			"data: {\"id\":\"chatcmpl-semantic-invalid\",\"object\":\"chat.completion.chunk\",\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"partial\"},\"finish_reason\":null}]}\n\n",
+	)
+	e := echo.New()
+	handlerCalls := 0
+
+	run := func() *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		if err := m.Handle(c, body, func() error {
+			handlerCalls++
+			c.Response().Header().Set("Content-Type", "text/event-stream")
+			c.Response().WriteHeader(http.StatusOK)
+			_, _ = c.Response().Write(invalidStream)
+			return nil
+		}); err != nil {
+			t.Fatalf("Handle error: %v", err)
+		}
+		return rec
+	}
+
+	rec1 := run()
+	if got := rec1.Header().Get("X-Cache"); got != "" {
+		t.Fatalf("first request should miss cache, got X-Cache=%q", got)
+	}
+
+	m.wg.Wait()
+
+	if store.Len() != 0 {
+		t.Fatalf("invalid streaming body should not populate semantic cache, got %d entries", store.Len())
+	}
+
+	rec2 := run()
+	if got := rec2.Header().Get("X-Cache"); got != "" {
+		t.Fatalf("invalid streaming body should not be cached, got X-Cache=%q", got)
+	}
+	if handlerCalls != 2 {
+		t.Fatalf("expected invalid stream to bypass semantic cache on follow-up, got %d calls", handlerCalls)
 	}
 }
 

--- a/internal/responsecache/simple.go
+++ b/internal/responsecache/simple.go
@@ -146,9 +146,9 @@ func (m *simpleCacheMiddleware) StoreAfter(c *echo.Context, body []byte, next fu
 		if core.GetFallbackUsed(c.Request().Context()) {
 			return nil
 		}
-		data, ok := capture.cachedBody(path, streamResponseDefaultsFromContext(c.Request().Context()), c.Response().Header().Get("Content-Type"))
+		data, ok := capture.cachedBody(c.Response().Header().Get("Content-Type"))
 		if !ok {
-			slog.Warn("response cache: failed to reconstruct cacheable response body", "path", path)
+			slog.Warn("response cache: failed to capture cacheable response body", "path", path)
 			return nil
 		}
 		m.enqueueWrite(cacheWriteJob{key: key, data: data})
@@ -294,14 +294,17 @@ type responseCapture struct {
 	status int
 }
 
-func (r *responseCapture) cachedBody(path string, defaults streamResponseDefaults, contentType string) ([]byte, bool) {
+func (r *responseCapture) cachedBody(contentType string) ([]byte, bool) {
 	if r == nil || r.body == nil || r.body.Len() == 0 {
 		return nil, false
 	}
 
 	raw := bytes.Clone(r.body.Bytes())
 	if isEventStreamContentType(contentType) {
-		return reconstructStreamingResponse(path, raw, defaults)
+		if !validateCacheableSSE(raw) {
+			return nil, false
+		}
+		return raw, true
 	}
 	if !json.Valid(raw) {
 		return nil, false

--- a/internal/responsecache/sse_validation.go
+++ b/internal/responsecache/sse_validation.go
@@ -26,6 +26,9 @@ func validateCacheableSSE(raw []byte) bool {
 		raw = raw[idx+sepLen:]
 
 		payload, hasData := sseEventPayload(event)
+		if sawDone {
+			return false
+		}
 		if !hasData {
 			continue
 		}
@@ -36,12 +39,7 @@ func validateCacheableSSE(raw []byte) bool {
 			sawDone = true
 			continue
 		}
-		if sawDone {
-			return false
-		}
-
-		var decoded map[string]any
-		if err := json.Unmarshal(payload, &decoded); err != nil {
+		if !json.Valid(payload) {
 			return false
 		}
 		sawJSONPayload = true

--- a/internal/responsecache/sse_validation.go
+++ b/internal/responsecache/sse_validation.go
@@ -1,0 +1,67 @@
+package responsecache
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// validateCacheableSSE reports whether raw is a complete, cache-safe SSE body.
+// Cacheable streams must be fully framed, contain at least one JSON data payload,
+// and terminate with a final [DONE] event.
+func validateCacheableSSE(raw []byte) bool {
+	if len(raw) == 0 {
+		return false
+	}
+
+	sawJSONPayload := false
+	sawDone := false
+
+	for len(raw) > 0 {
+		idx, sepLen := nextCacheEventBoundary(raw)
+		if idx == -1 {
+			return false
+		}
+
+		event := raw[:idx]
+		raw = raw[idx+sepLen:]
+
+		payload, hasData := sseEventPayload(event)
+		if !hasData {
+			continue
+		}
+		if len(bytes.TrimSpace(payload)) == 0 {
+			continue
+		}
+		if bytes.Equal(payload, cacheDonePayload) {
+			sawDone = true
+			continue
+		}
+		if sawDone {
+			return false
+		}
+
+		var decoded map[string]any
+		if err := json.Unmarshal(payload, &decoded); err != nil {
+			return false
+		}
+		sawJSONPayload = true
+	}
+
+	return sawJSONPayload && sawDone
+}
+
+func sseEventPayload(event []byte) ([]byte, bool) {
+	lines := bytes.Split(event, []byte("\n"))
+	payloadLines := make([][]byte, 0, len(lines))
+	for _, line := range lines {
+		data, ok := parseCacheDataLine(line)
+		if !ok {
+			continue
+		}
+		payloadLines = append(payloadLines, data)
+	}
+	if len(payloadLines) == 0 {
+		return nil, false
+	}
+	return bytes.Join(payloadLines, []byte("\n")), true
+}

--- a/internal/responsecache/sse_validation.go
+++ b/internal/responsecache/sse_validation.go
@@ -17,13 +17,14 @@ func validateCacheableSSE(raw []byte) bool {
 	sawDone := false
 
 	for len(raw) > 0 {
+		remaining := raw
 		idx, sepLen := nextCacheEventBoundary(raw)
-		if idx == -1 {
-			return false
+		event := remaining
+		raw = nil
+		if idx != -1 {
+			event = remaining[:idx]
+			raw = remaining[idx+sepLen:]
 		}
-
-		event := raw[:idx]
-		raw = raw[idx+sepLen:]
 
 		payload, hasData := sseEventPayload(event)
 		if sawDone {

--- a/internal/responsecache/sse_validation_test.go
+++ b/internal/responsecache/sse_validation_test.go
@@ -11,6 +11,11 @@ func TestValidateCacheableSSE(t *testing.T) {
 		want bool
 	}{
 		{
+			name: "rejects empty input",
+			raw:  []byte(""),
+			want: false,
+		},
+		{
 			name: "valid chat stream",
 			raw: []byte(
 				"data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n" +
@@ -49,6 +54,15 @@ func TestValidateCacheableSSE(t *testing.T) {
 				"data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\"}}\n\n" +
 					"data: [DONE]\n\n" +
 					"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\"}}\n\n",
+			),
+			want: false,
+		},
+		{
+			name: "rejects keepalive after done",
+			raw: []byte(
+				"data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\"}}\n\n" +
+					"data: [DONE]\n\n" +
+					": keep-alive\n\n",
 			),
 			want: false,
 		},

--- a/internal/responsecache/sse_validation_test.go
+++ b/internal/responsecache/sse_validation_test.go
@@ -1,0 +1,75 @@
+package responsecache
+
+import "testing"
+
+func TestValidateCacheableSSE(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  []byte
+		want bool
+	}{
+		{
+			name: "valid chat stream",
+			raw: []byte(
+				"data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n" +
+					"data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n" +
+					"data: [DONE]\n\n",
+			),
+			want: true,
+		},
+		{
+			name: "rejects truncated stream without done",
+			raw: []byte(
+				"data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n",
+			),
+			want: false,
+		},
+		{
+			name: "rejects malformed json payload",
+			raw: []byte(
+				"data: {\"id\":\"chatcmpl-1\"\n\n" +
+					"data: [DONE]\n\n",
+			),
+			want: false,
+		},
+		{
+			name: "rejects comment only stream",
+			raw: []byte(
+				": keep-alive\n\n" +
+					": still-alive\n\n" +
+					"data: [DONE]\n\n",
+			),
+			want: false,
+		},
+		{
+			name: "rejects payload after done",
+			raw: []byte(
+				"data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\"}}\n\n" +
+					"data: [DONE]\n\n" +
+					"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\"}}\n\n",
+			),
+			want: false,
+		},
+		{
+			name: "rejects trailing partial event",
+			raw: []byte(
+				"data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n" +
+					"data: [DONE]\n\n" +
+					": trailing keepalive",
+			),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := validateCacheableSSE(tt.raw); got != tt.want {
+				t.Fatalf("validateCacheableSSE() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/responsecache/sse_validation_test.go
+++ b/internal/responsecache/sse_validation_test.go
@@ -25,6 +25,15 @@ func TestValidateCacheableSSE(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "accepts eof terminated done marker",
+			raw: []byte(
+				"data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n" +
+					"data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n" +
+					"data: [DONE]\n",
+			),
+			want: true,
+		},
+		{
 			name: "rejects truncated stream without done",
 			raw: []byte(
 				"data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n",

--- a/internal/responsecache/stream_cache.go
+++ b/internal/responsecache/stream_cache.go
@@ -2,9 +2,7 @@ package responsecache
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"sort"
 	"strings"
@@ -126,25 +124,6 @@ func cacheKeyRequestBody(path string, body []byte) []byte {
 	}
 }
 
-func streamResponseDefaultsFromContext(ctx context.Context) streamResponseDefaults {
-	var defaults streamResponseDefaults
-
-	plan := core.GetExecutionPlan(ctx)
-	if plan == nil {
-		return defaults
-	}
-
-	defaults.Provider = strings.TrimSpace(plan.ProviderType)
-	if plan.Resolution != nil {
-		if defaults.Provider == "" {
-			defaults.Provider = strings.TrimSpace(plan.Resolution.ResolvedSelector.Provider)
-		}
-		defaults.Model = strings.TrimSpace(plan.Resolution.ResolvedSelector.Model)
-	}
-
-	return defaults
-}
-
 func isEventStreamContentType(contentType string) bool {
 	if contentType == "" {
 		return false
@@ -170,17 +149,6 @@ func writeCachedResponse(c *echo.Context, path string, requestBody, cached []byt
 	c.Response().WriteHeader(http.StatusOK)
 	_, _ = c.Response().Write(cached)
 	return nil
-}
-
-func renderCachedStream(path string, requestBody, cached []byte) ([]byte, error) {
-	switch path {
-	case "/v1/chat/completions":
-		return renderCachedChatStream(requestBody, cached)
-	case "/v1/responses":
-		return renderCachedResponsesStream(requestBody, cached)
-	default:
-		return nil, errors.New("cached streaming replay is not supported for this path")
-	}
 }
 
 func renderCachedChatStream(requestBody, cached []byte) ([]byte, error) {

--- a/internal/responsecache/stream_cache.go
+++ b/internal/responsecache/stream_cache.go
@@ -96,8 +96,11 @@ func cacheKeyRequestBody(path string, body []byte) []byte {
 		if err != nil || req == nil {
 			return body
 		}
-		req.Stream = false
-		req.StreamOptions = normalizeStreamOptionsForCache(req.StreamOptions)
+		if req.Stream {
+			req.StreamOptions = normalizeStreamOptionsForCache(req.StreamOptions)
+		} else {
+			req.StreamOptions = nil
+		}
 		normalized, err := json.Marshal(req)
 		if err != nil {
 			return body
@@ -108,8 +111,11 @@ func cacheKeyRequestBody(path string, body []byte) []byte {
 		if err != nil || req == nil {
 			return body
 		}
-		req.Stream = false
-		req.StreamOptions = normalizeStreamOptionsForCache(req.StreamOptions)
+		if req.Stream {
+			req.StreamOptions = normalizeStreamOptionsForCache(req.StreamOptions)
+		} else {
+			req.StreamOptions = nil
+		}
 		normalized, err := json.Marshal(req)
 		if err != nil {
 			return body
@@ -149,17 +155,13 @@ func isEventStreamContentType(contentType string) bool {
 
 func writeCachedResponse(c *echo.Context, path string, requestBody, cached []byte, cacheType string) error {
 	if isStreamingRequest(path, requestBody) {
-		streamBody, err := renderCachedStream(path, requestBody, cached)
-		if err != nil {
-			return err
-		}
 		auditlog.EnrichEntryWithStream(c, true)
 		c.Response().Header().Set("Content-Type", "text/event-stream")
 		c.Response().Header().Set("Cache-Control", "no-cache")
 		c.Response().Header().Set("Connection", "keep-alive")
 		c.Response().Header().Set("X-Cache", "HIT ("+cacheType+")")
 		c.Response().WriteHeader(http.StatusOK)
-		_, _ = c.Response().Write(streamBody)
+		_, _ = c.Response().Write(cached)
 		return nil
 	}
 

--- a/internal/usage/extractor.go
+++ b/internal/usage/extractor.go
@@ -1,7 +1,9 @@
 package usage
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
 	"maps"
 	"path"
 	"strings"
@@ -10,6 +12,7 @@ import (
 	"github.com/google/uuid"
 
 	"gomodel/internal/core"
+	"gomodel/internal/streaming"
 )
 
 // buildRawUsageFromDetails merges typed token detail fields into a RawUsage map.
@@ -266,6 +269,9 @@ func ExtractFromCachedResponseBody(
 			entry = ExtractFromEmbeddingResponse(&resp, requestID, provider, endpoint, pricing...)
 		}
 	}
+	if entry == nil {
+		entry = extractFromCachedSSEBody(body, requestID, model, provider, endpoint, pricing...)
+	}
 
 	if entry == nil {
 		entry = &UsageEntry{
@@ -295,6 +301,40 @@ func ExtractFromCachedResponseBody(
 		entry.Endpoint = endpoint
 	}
 	return entry
+}
+
+type staticPricingResolver struct {
+	pricing *core.ModelPricing
+}
+
+func (r staticPricingResolver) ResolvePricing(_, _ string) *core.ModelPricing {
+	return r.pricing
+}
+
+func extractFromCachedSSEBody(
+	body []byte,
+	requestID, model, provider, endpoint string,
+	pricing ...*core.ModelPricing,
+) *UsageEntry {
+	if len(bytes.TrimSpace(body)) == 0 || !bytes.Contains(body, []byte("data:")) {
+		return nil
+	}
+
+	observer := &StreamUsageObserver{
+		model:     strings.TrimSpace(model),
+		provider:  strings.TrimSpace(provider),
+		requestID: strings.TrimSpace(requestID),
+		endpoint:  endpoint,
+	}
+	if len(pricing) > 0 && pricing[0] != nil {
+		observer.pricingResolver = staticPricingResolver{pricing: pricing[0]}
+	}
+
+	stream := streaming.NewObservedSSEStream(io.NopCloser(bytes.NewReader(body)), observer)
+	_, _ = io.Copy(io.Discard, stream)
+	_ = stream.Close()
+
+	return observer.cachedEntry
 }
 
 func normalizeCachedResponseEndpoint(endpoint string) string {

--- a/internal/usage/extractor_test.go
+++ b/internal/usage/extractor_test.go
@@ -570,6 +570,46 @@ func TestExtractFromCachedResponseBody(t *testing.T) {
 		}
 	})
 
+	t.Run("parses cached chat SSE bodies", func(t *testing.T) {
+		body := []byte(
+			"data: {\"id\":\"chatcmpl-cache-sse\",\"object\":\"chat.completion.chunk\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hi\"},\"finish_reason\":null}]}\n\n" +
+				"data: {\"id\":\"chatcmpl-cache-sse\",\"object\":\"chat.completion.chunk\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":9,\"completion_tokens\":4,\"total_tokens\":13}}\n\n" +
+				"data: [DONE]\n\n",
+		)
+
+		entry := ExtractFromCachedResponseBody(body, "req-cache-sse", "gpt-4o", "openai", "/v1/chat/completions", CacheTypeExact)
+		if entry == nil {
+			t.Fatal("expected non-nil entry")
+		}
+		if entry.ProviderID != "chatcmpl-cache-sse" {
+			t.Fatalf("ProviderID = %q, want chatcmpl-cache-sse", entry.ProviderID)
+		}
+		if entry.InputTokens != 9 || entry.OutputTokens != 4 || entry.TotalTokens != 13 {
+			t.Fatalf("unexpected token counts: %+v", entry)
+		}
+	})
+
+	t.Run("parses cached responses SSE bodies", func(t *testing.T) {
+		body := []byte(
+			"event: response.created\n" +
+				"data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-cache-sse\",\"object\":\"response\",\"status\":\"in_progress\",\"model\":\"gpt-5\",\"output\":[]}}\n\n" +
+				"event: response.completed\n" +
+				"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-cache-sse\",\"object\":\"response\",\"status\":\"completed\",\"model\":\"gpt-5\",\"output\":[],\"usage\":{\"input_tokens\":15,\"output_tokens\":8,\"total_tokens\":23}}}\n\n" +
+				"data: [DONE]\n\n",
+		)
+
+		entry := ExtractFromCachedResponseBody(body, "req-resp-sse", "gpt-5", "openai", "/v1/responses", CacheTypeExact)
+		if entry == nil {
+			t.Fatal("expected non-nil entry")
+		}
+		if entry.ProviderID != "resp-cache-sse" {
+			t.Fatalf("ProviderID = %q, want resp-cache-sse", entry.ProviderID)
+		}
+		if entry.InputTokens != 15 || entry.OutputTokens != 8 || entry.TotalTokens != 23 {
+			t.Fatalf("unexpected token counts: %+v", entry)
+		}
+	})
+
 	t.Run("defaults unknown cache type to exact", func(t *testing.T) {
 		resp := &core.ChatResponse{
 			ID:    "chatcmpl-cache",


### PR DESCRIPTION
## Summary
- treat `stream=true` and `stream=false` as separate exact and semantic cache entries
- persist valid raw SSE for streaming cache hits and replay it verbatim
- validate SSE before caching so partial, malformed, or keepalive-only streams cannot poison cache
- keep cache-hit usage accounting working by extracting usage from cached SSE bodies

## Testing
- `go test ./internal/responsecache ./internal/usage ./internal/server`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming responses are cached separately from non-streaming responses; streaming cache stores and replays raw SSE bytes.
  * Usage extraction now supports cached streaming responses to produce usage entries.

* **Bug Fixes**
  * Streaming vs non-streaming cache keying corrected so hits/misses behave independently and replay is byte-exact.
  * Invalid streaming payloads are rejected from cache population.

* **Tests**
  * Added and updated tests validating streaming validation, caching separation, and usage extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->