### PR TITLE
fix(auditlog): preserve auth metadata for streamed entries

### DIFF
--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -2535,6 +2535,7 @@ body.conversation-drawer-open {
    ═══════════════════════════════════════════════════════════════ */
 
 .exec-pipeline {
+    position: relative;
     display: flex;
     flex-direction: column;
     gap: 0;
@@ -2543,6 +2544,35 @@ body.conversation-drawer-open {
     border-radius: var(--radius);
     border: 1px solid var(--border);
     background: var(--bg);
+}
+
+.exec-pipeline-has-meta {
+    padding-top: 42px;
+}
+
+.exec-pipeline-meta {
+    position: absolute;
+    top: 12px;
+    right: 14px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    max-width: calc(100% - 28px);
+}
+
+.exec-pipeline-meta-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 3px 8px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: color-mix(in srgb, var(--bg-surface) 86%, transparent);
+    color: var(--text-muted);
+    font-size: 10px;
+    line-height: 1.2;
+    white-space: nowrap;
 }
 
 /* ─── Main pipeline row ─── */

--- a/internal/admin/dashboard/static/js/modules/execution-plans-layout.test.js
+++ b/internal/admin/dashboard/static/js/modules/execution-plans-layout.test.js
@@ -239,7 +239,7 @@ test('workflow editor renders a live preview card from the draft workflow state'
     );
 });
 
-test('audit log pipeline always renders cache and binds runtime highlight classes across the full path', () => {
+test('audit log pipeline binds cache visibility and runtime highlight classes across the full path', () => {
     const template = readExecutionPlanTemplateSource();
     const css = readFixture('../../css/dashboard.css');
 
@@ -250,6 +250,10 @@ test('audit log pipeline always renders cache and binds runtime highlight classe
     assert.match(
         template,
         /:class="{{\.}}\.authNodeClass"[\s\S]*x-show="{{\.}}\.showGuardrails"[\s\S]*x-show="{{\.}}\.showUsage"[\s\S]*x-show="{{\.}}\.showAudit"/
+    );
+    assert.match(
+        template,
+        /<div class="exec-pipeline" :class="\{ 'exec-pipeline-has-meta': {{\.}}\.workflowID \}">[\s\S]*<div class="exec-pipeline-meta" x-show="{{\.}}\.workflowID">[\s\S]*x-text="'id: ' \+ {{\.}}\.workflowID"/
     );
     assert.match(
         template,
@@ -271,6 +275,14 @@ test('audit log pipeline always renders cache and binds runtime highlight classe
     const semanticCacheRule = readCSSRule(css, '.ep-node-cache-semantic');
     assert.match(semanticCacheRule, /border-color:\s*color-mix\(in srgb, var\(--success\) 52%, var\(--border\)\)/);
     assert.match(semanticCacheRule, /background:\s*color-mix\(in srgb, var\(--success\) 9%, var\(--bg-surface\)\)/);
+
+    const pipelineRule = readCSSRule(css, '.exec-pipeline');
+    assert.match(pipelineRule, /position:\s*relative/);
+
+    const metaRule = readCSSRule(css, '.exec-pipeline-meta');
+    assert.match(metaRule, /position:\s*absolute/);
+    assert.match(metaRule, /top:\s*12px/);
+    assert.match(metaRule, /right:\s*14px/);
 
     const authSuccessRule = readCSSRule(css, '.ep-node-auth-success');
     assert.match(authSuccessRule, /border-color:\s*color-mix\(in srgb, var\(--success\) 52%, var\(--border\)\)/);

--- a/internal/admin/dashboard/static/js/modules/execution-plans.js
+++ b/internal/admin/dashboard/static/js/modules/execution-plans.js
@@ -399,6 +399,14 @@
 	                };
 	            },
 
+            executionPlanEntryFeatures(entry) {
+                const raw = entry && entry.data && entry.data.execution_features;
+                if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+                    return null;
+                }
+                return this.executionPlanNormalizedFeatures(raw);
+            },
+
             executionPlanSourceGuardrails(source) {
                 const raw = Array.isArray(source && source.plan_payload && source.plan_payload.guardrails)
                     ? source.plan_payload.guardrails
@@ -1058,22 +1066,35 @@
                 return provider || 'AI';
             },
 
-            epAiSublabel(source, runtime) {
-                if (runtime && runtime.model) return runtime.model;
-                return source && source.scope && source.scope.scope_model || null;
+	            epAiSublabel(source, runtime) {
+	                if (runtime && runtime.model) return runtime.model;
+	                return source && source.scope && source.scope.scope_model || null;
+	            },
+
+            executionPlanChartWorkflowID(source, entry) {
+                const sourceID = String(source && source.id || '').trim();
+                if (sourceID) {
+                    return sourceID;
+                }
+                const entryID = String(entry && entry.execution_plan_version_id || '').trim();
+                return entryID || null;
             },
 
 	            executionPlanChartModel(source, runtime, options) {
 	                const config = options || {};
+	                const features = config.features && typeof config.features === 'object' && !Array.isArray(config.features)
+                    ? this.executionPlanNormalizedFeatures(config.features)
+                    : this.executionPlanSourceFeatures(source);
 	                const forceAudit = !!config.forceAudit;
-	                const showGuardrails = this.epHasGuardrails(source);
-	                const showUsage = this.epHasUsage(source);
-	                const showAudit = this.executionPlanAuditVisible() && (forceAudit || this.epHasAudit(source));
-	                const showAsync = !!(showUsage || showAudit);
+	                const showGuardrails = !!features.guardrails;
+	                const showUsage = !!features.usage;
+	                const showAudit = forceAudit || !!features.audit;
+	                const showAsync = !!config.forceAsync || !!(showUsage || showAudit);
+                    const workflowID = this.executionPlanChartWorkflowID(source, config.entry);
 	                return {
 	                    showGuardrails,
 	                    guardrailLabel: showGuardrails ? this.epGuardrailLabel(source) : '',
-	                    showCache: !!config.forceCache || this.epShowCacheStep(source, runtime),
+	                    showCache: !!config.forceCache || !!features.cache || this.epRuntimeHasCache(runtime),
                     cacheNodeClass: this.epCacheNodeClass(runtime),
                     cacheConnClass: this.epCacheConnClass(runtime),
                     cacheStatusLabel: this.epCacheStatusLabel(runtime),
@@ -1087,7 +1108,8 @@
 				    authNodeSublabel: this.epAuthNodeSublabel(runtime),
 	                    showAsync,
 	                    showUsage,
-	                    showAudit
+	                    showAudit,
+                        workflowID
 	                };
 	            },
 
@@ -1098,8 +1120,10 @@
             executionPlanAuditChart(entry) {
                 const source = this.auditEntryExecutionPlan(entry);
                 const runtime = this.epRuntimeFromEntry(entry);
+                const features = this.executionPlanEntryFeatures(entry) || this.executionPlanSourceFeatures(source);
                 return this.executionPlanChartModel(source, runtime, {
-                    forceCache: true,
+                    entry,
+                    features,
                     forceAudit: true,
                     forceAsync: true
                 });

--- a/internal/admin/dashboard/static/js/modules/execution-plans.js
+++ b/internal/admin/dashboard/static/js/modules/execution-plans.js
@@ -1,4 +1,6 @@
 (function(global) {
+    const DRAFT_WORKFLOW_PREVIEW_ID = 'draft-workflow-preview';
+
     function dashboardExecutionPlansModule() {
         return {
             executionPlans: [],
@@ -359,7 +361,7 @@
                 const scopeDisplay = this.executionPlanScopeDisplay(scope);
 
                 return {
-                    id: 'draft-workflow-preview',
+                    id: DRAFT_WORKFLOW_PREVIEW_ID,
                     scope_type: scopeType,
                     scope_display: scopeDisplay,
                     scope: {
@@ -1073,11 +1075,14 @@
 
             executionPlanChartWorkflowID(source, entry) {
                 const sourceID = String(source && source.id || '').trim();
-                if (sourceID) {
+                if (sourceID && sourceID !== DRAFT_WORKFLOW_PREVIEW_ID) {
                     return sourceID;
                 }
                 const entryID = String(entry && entry.execution_plan_version_id || '').trim();
-                return entryID || null;
+                if (entryID && entryID !== DRAFT_WORKFLOW_PREVIEW_ID) {
+                    return entryID;
+                }
+                return null;
             },
 
 	            executionPlanChartModel(source, runtime, options) {

--- a/internal/admin/dashboard/static/js/modules/execution-plans.test.js
+++ b/internal/admin/dashboard/static/js/modules/execution-plans.test.js
@@ -169,6 +169,7 @@ test('executionPlanWorkflowChart returns the shared chart contract for workflow 
 
     assert.equal(
         JSON.stringify(module.executionPlanWorkflowChart({
+            id: 'workflow-openai-gpt-5-v7',
             scope: {
                 scope_provider: 'openai',
                 scope_model: 'gpt-5'
@@ -204,7 +205,8 @@ test('executionPlanWorkflowChart returns the shared chart contract for workflow 
             authNodeSublabel: null,
             showAsync: true,
             showUsage: false,
-            showAudit: true
+            showAudit: true,
+            workflowID: 'workflow-openai-gpt-5-v7'
         })
     );
 });
@@ -256,7 +258,8 @@ test('executionPlanWorkflowChart masks globally disabled workflow features from 
             authNodeSublabel: null,
             showAsync: false,
             showUsage: false,
-            showAudit: false
+            showAudit: false,
+            workflowID: null
         })
     );
 });
@@ -310,7 +313,8 @@ test('executionPlanAuditChart returns the shared chart contract for audit runtim
             authNodeSublabel: null,
             showAsync: true,
             showUsage: true,
-            showAudit: true
+            showAudit: true,
+            workflowID: 'historical-v1'
         })
     );
 });
@@ -343,7 +347,71 @@ test('executionPlanAuditChart forces audit nodes even when the workflow version 
             authNodeSublabel: null,
             showAsync: true,
             showUsage: false,
-            showAudit: true
+            showAudit: true,
+            workflowID: 'missing-plan'
+        })
+    );
+});
+
+test('executionPlanAuditChart prefers request-time execution features over current workflow state', () => {
+    const module = createExecutionPlansModule();
+    module.executionPlanVersionsByID = {
+        'historical-v2': {
+            id: 'historical-v2',
+            scope: {
+                scope_provider: 'openai',
+                scope_model: 'gpt-5'
+            },
+            plan_payload: {
+                features: {
+                    cache: true,
+                    audit: true,
+                    usage: true,
+                    guardrails: true,
+                    fallback: true
+                },
+                guardrails: [
+                    { ref: 'policy-system', step: 10 }
+                ]
+            }
+        }
+    };
+
+    assert.equal(
+        JSON.stringify(module.executionPlanAuditChart({
+            execution_plan_version_id: 'historical-v2',
+            provider: 'openai',
+            model: 'gpt-5',
+            status_code: 200,
+            data: {
+                execution_features: {
+                    cache: false,
+                    audit: true,
+                    usage: false,
+                    guardrails: false,
+                    fallback: true
+                }
+            }
+        })),
+        JSON.stringify({
+            showGuardrails: false,
+            guardrailLabel: '',
+            showCache: false,
+            cacheNodeClass: '',
+            cacheConnClass: '',
+            cacheStatusLabel: null,
+            aiLabel: 'openai',
+            aiSublabel: 'gpt-5',
+            aiConnClass: '',
+            aiNodeClass: 'ep-node-ai-success',
+            responseConnClass: '',
+            responseNodeClass: 'ep-node-endpoint-success',
+            authNodeClass: '',
+            authNodeSublabel: null,
+            showAsync: true,
+            showUsage: false,
+            showAudit: true,
+            workflowID: 'historical-v2'
         })
     );
 });

--- a/internal/admin/dashboard/static/js/modules/execution-plans.test.js
+++ b/internal/admin/dashboard/static/js/modules/execution-plans.test.js
@@ -264,6 +264,25 @@ test('executionPlanWorkflowChart masks globally disabled workflow features from 
     );
 });
 
+test('executionPlanChartWorkflowID ignores the draft workflow preview sentinel and falls back to stored entry ids', () => {
+    const module = createExecutionPlansModule();
+
+    assert.equal(
+        module.executionPlanChartWorkflowID(
+            { id: 'draft-workflow-preview' },
+            { execution_plan_version_id: 'historical-v1' }
+        ),
+        'historical-v1'
+    );
+    assert.equal(
+        module.executionPlanChartWorkflowID(
+            { id: 'draft-workflow-preview' },
+            { execution_plan_version_id: 'draft-workflow-preview' }
+        ),
+        null
+    );
+});
+
 test('executionPlanAuditChart returns the shared chart contract for audit runtime entries', () => {
     const module = createExecutionPlansModule();
     module.executionPlanVersionsByID = {

--- a/internal/admin/dashboard/templates/execution-plan-chart.html
+++ b/internal/admin/dashboard/templates/execution-plan-chart.html
@@ -1,5 +1,8 @@
 {{define "execution-plan-chart"}}
-<div class="exec-pipeline">
+<div class="exec-pipeline" :class="{ 'exec-pipeline-has-meta': {{.}}.workflowID }">
+    <div class="exec-pipeline-meta" x-show="{{.}}.workflowID">
+        <span class="exec-pipeline-meta-chip mono" x-show="{{.}}.workflowID" x-text="'id: ' + {{.}}.workflowID"></span>
+    </div>
     <div class="exec-pipeline-row">
         <div class="ep-left">
             <div class="ep-node ep-node-endpoint">

--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -56,15 +56,15 @@ type LogEntry struct {
 	StatusCode             int    `json:"status_code" bson:"status_code"`
 
 	// Extracted fields for efficient filtering (indexed in relational DBs)
-	RequestID string `json:"request_id,omitempty" bson:"request_id,omitempty"`
+	RequestID  string `json:"request_id,omitempty" bson:"request_id,omitempty"`
 	AuthKeyID  string `json:"auth_key_id,omitempty" bson:"auth_key_id,omitempty"`
 	AuthMethod string `json:"auth_method,omitempty" bson:"auth_method,omitempty"`
-	ClientIP  string `json:"client_ip,omitempty" bson:"client_ip,omitempty"`
-	Method    string `json:"method,omitempty" bson:"method,omitempty"`
-	Path      string `json:"path,omitempty" bson:"path,omitempty"`
-	UserPath  string `json:"user_path,omitempty" bson:"user_path,omitempty"`
-	Stream    bool   `json:"stream,omitempty" bson:"stream,omitempty"`
-	ErrorType string `json:"error_type,omitempty" bson:"error_type,omitempty"`
+	ClientIP   string `json:"client_ip,omitempty" bson:"client_ip,omitempty"`
+	Method     string `json:"method,omitempty" bson:"method,omitempty"`
+	Path       string `json:"path,omitempty" bson:"path,omitempty"`
+	UserPath   string `json:"user_path,omitempty" bson:"user_path,omitempty"`
+	Stream     bool   `json:"stream,omitempty" bson:"stream,omitempty"`
+	ErrorType  string `json:"error_type,omitempty" bson:"error_type,omitempty"`
 
 	// Data contains flexible request/response information as JSON
 	Data *LogData `json:"data,omitempty" bson:"data,omitempty"`
@@ -77,6 +77,11 @@ type LogData struct {
 	// Identity
 	UserAgent  string `json:"user_agent,omitempty" bson:"user_agent,omitempty"`
 	APIKeyHash string `json:"api_key_hash,omitempty" bson:"api_key_hash,omitempty"`
+
+	// ExecutionFeatures captures the request-time effective workflow features
+	// after runtime caps were applied. This keeps audit views historically accurate
+	// even if the active process config changes later.
+	ExecutionFeatures *ExecutionFeaturesSnapshot `json:"execution_features,omitempty" bson:"execution_features,omitempty"`
 
 	// Request parameters
 	Temperature *float64 `json:"temperature,omitempty" bson:"temperature,omitempty"`
@@ -99,6 +104,17 @@ type LogData struct {
 	// Body capture status flags (set when body exceeds 1MB limit)
 	RequestBodyTooBigToHandle  bool `json:"request_body_too_big_to_handle,omitempty" bson:"request_body_too_big_to_handle,omitempty"`
 	ResponseBodyTooBigToHandle bool `json:"response_body_too_big_to_handle,omitempty" bson:"response_body_too_big_to_handle,omitempty"`
+}
+
+// ExecutionFeaturesSnapshot stores the effective workflow feature state that
+// applied to one request. Fields intentionally do not use omitempty so "false"
+// remains explicit once the snapshot exists.
+type ExecutionFeaturesSnapshot struct {
+	Cache      bool `json:"cache" bson:"cache"`
+	Audit      bool `json:"audit" bson:"audit"`
+	Usage      bool `json:"usage" bson:"usage"`
+	Guardrails bool `json:"guardrails" bson:"guardrails"`
+	Fallback   bool `json:"fallback" bson:"fallback"`
 }
 
 // marshalLogData marshals the Data field to JSON for SQL storage.

--- a/internal/auditlog/auditlog_test.go
+++ b/internal/auditlog/auditlog_test.go
@@ -960,6 +960,13 @@ func TestCreateStreamEntry(t *testing.T) {
 		Stream:                 false,
 		Data: &LogData{
 			UserAgent: "test",
+			ExecutionFeatures: &ExecutionFeaturesSnapshot{
+				Cache:      false,
+				Audit:      true,
+				Usage:      true,
+				Guardrails: false,
+				Fallback:   true,
+			},
 			RequestHeaders: map[string]string{
 				"Content-Type": "application/json",
 			},
@@ -1030,6 +1037,60 @@ func TestCreateStreamEntry(t *testing.T) {
 	baseEntry.Data.RequestHeaders["New"] = "value"
 	if streamEntry.Data.RequestHeaders["New"] == "value" {
 		t.Error("Headers should be a copy, not same reference")
+	}
+	if streamEntry.Data.ExecutionFeatures == nil {
+		t.Fatal("ExecutionFeatures is nil")
+	}
+	if streamEntry.Data.ExecutionFeatures == baseEntry.Data.ExecutionFeatures {
+		t.Fatal("ExecutionFeatures should be copied, not shared")
+	}
+	if streamEntry.Data.ExecutionFeatures.Cache != baseEntry.Data.ExecutionFeatures.Cache {
+		t.Error("ExecutionFeatures.Cache mismatch")
+	}
+}
+
+func TestEnrichEntryWithExecutionPlanStoresExecutionFeatures(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	entry := &LogEntry{ID: "plan-audit-entry"}
+	c.Set(string(LogEntryKey), entry)
+
+	EnrichEntryWithExecutionPlan(c, &core.ExecutionPlan{
+		Policy: &core.ResolvedExecutionPolicy{
+			VersionID: "workflow-v3",
+			Features: core.ExecutionFeatures{
+				Cache:      false,
+				Audit:      true,
+				Usage:      false,
+				Guardrails: true,
+				Fallback:   false,
+			},
+		},
+	})
+
+	if entry.ExecutionPlanVersionID != "workflow-v3" {
+		t.Fatalf("ExecutionPlanVersionID = %q, want workflow-v3", entry.ExecutionPlanVersionID)
+	}
+	if entry.Data == nil || entry.Data.ExecutionFeatures == nil {
+		t.Fatal("expected execution feature snapshot to be stored in audit data")
+	}
+	if entry.Data.ExecutionFeatures.Cache {
+		t.Fatal("ExecutionFeatures.Cache = true, want false")
+	}
+	if !entry.Data.ExecutionFeatures.Audit {
+		t.Fatal("ExecutionFeatures.Audit = false, want true")
+	}
+	if entry.Data.ExecutionFeatures.Usage {
+		t.Fatal("ExecutionFeatures.Usage = true, want false")
+	}
+	if !entry.Data.ExecutionFeatures.Guardrails {
+		t.Fatal("ExecutionFeatures.Guardrails = false, want true")
+	}
+	if entry.Data.ExecutionFeatures.Fallback {
+		t.Fatal("ExecutionFeatures.Fallback = true, want false")
 	}
 }
 

--- a/internal/auditlog/auditlog_test.go
+++ b/internal/auditlog/auditlog_test.go
@@ -951,9 +951,12 @@ func TestCreateStreamEntry(t *testing.T) {
 		CacheType:              CacheTypeSemantic,
 		StatusCode:             200,
 		RequestID:              "req-123",
+		AuthKeyID:              "auth-key-123",
+		AuthMethod:             AuthMethodAPIKey,
 		ClientIP:               "127.0.0.1",
 		Method:                 "POST",
 		Path:                   "/v1/chat/completions",
+		UserPath:               "/team/alpha",
 		Stream:                 false,
 		Data: &LogData{
 			UserAgent: "test",
@@ -994,6 +997,12 @@ func TestCreateStreamEntry(t *testing.T) {
 	if streamEntry.RequestID != baseEntry.RequestID {
 		t.Error("RequestID not copied")
 	}
+	if streamEntry.AuthKeyID != baseEntry.AuthKeyID {
+		t.Error("AuthKeyID not copied")
+	}
+	if streamEntry.AuthMethod != baseEntry.AuthMethod {
+		t.Error("AuthMethod not copied")
+	}
 	if streamEntry.ClientIP != baseEntry.ClientIP {
 		t.Error("ClientIP not copied")
 	}
@@ -1002,6 +1011,9 @@ func TestCreateStreamEntry(t *testing.T) {
 	}
 	if streamEntry.Path != baseEntry.Path {
 		t.Error("Path not copied")
+	}
+	if streamEntry.UserPath != baseEntry.UserPath {
+		t.Error("UserPath not copied")
 	}
 
 	// Verify Data fields are copied

--- a/internal/auditlog/auditlog_test.go
+++ b/internal/auditlog/auditlog_test.go
@@ -1047,6 +1047,18 @@ func TestCreateStreamEntry(t *testing.T) {
 	if streamEntry.Data.ExecutionFeatures.Cache != baseEntry.Data.ExecutionFeatures.Cache {
 		t.Error("ExecutionFeatures.Cache mismatch")
 	}
+	if streamEntry.Data.ExecutionFeatures.Audit != baseEntry.Data.ExecutionFeatures.Audit {
+		t.Error("ExecutionFeatures.Audit mismatch")
+	}
+	if streamEntry.Data.ExecutionFeatures.Usage != baseEntry.Data.ExecutionFeatures.Usage {
+		t.Error("ExecutionFeatures.Usage mismatch")
+	}
+	if streamEntry.Data.ExecutionFeatures.Guardrails != baseEntry.Data.ExecutionFeatures.Guardrails {
+		t.Error("ExecutionFeatures.Guardrails mismatch")
+	}
+	if streamEntry.Data.ExecutionFeatures.Fallback != baseEntry.Data.ExecutionFeatures.Fallback {
+		t.Error("ExecutionFeatures.Fallback mismatch")
+	}
 }
 
 func TestEnrichEntryWithExecutionPlanStoresExecutionFeatures(t *testing.T) {

--- a/internal/auditlog/middleware.go
+++ b/internal/auditlog/middleware.go
@@ -211,6 +211,15 @@ func enrichEntryWithExecutionPlan(entry *LogEntry, plan *core.ExecutionPlan) {
 	if versionID := strings.TrimSpace(plan.ExecutionPlanVersionID()); versionID != "" {
 		entry.ExecutionPlanVersionID = versionID
 	}
+	if plan.Policy != nil {
+		ensureLogData(entry).ExecutionFeatures = &ExecutionFeaturesSnapshot{
+			Cache:      plan.Policy.Features.Cache,
+			Audit:      plan.Policy.Features.Audit,
+			Usage:      plan.Policy.Features.Usage,
+			Guardrails: plan.Policy.Features.Guardrails,
+			Fallback:   plan.Policy.Features.Fallback,
+		}
+	}
 }
 
 func captureLoggedRequestBody(entry *LogEntry, bodyBytes []byte) {

--- a/internal/auditlog/stream_wrapper.go
+++ b/internal/auditlog/stream_wrapper.go
@@ -112,6 +112,10 @@ func CreateStreamEntry(baseEntry *LogEntry) *LogEntry {
 			ResponseHeaders: copyMap(baseEntry.Data.ResponseHeaders),
 			RequestBody:     baseEntry.Data.RequestBody,
 		}
+		if baseEntry.Data.ExecutionFeatures != nil {
+			snapshot := *baseEntry.Data.ExecutionFeatures
+			entryCopy.Data.ExecutionFeatures = &snapshot
+		}
 	}
 
 	return entryCopy

--- a/internal/auditlog/stream_wrapper.go
+++ b/internal/auditlog/stream_wrapper.go
@@ -92,12 +92,14 @@ func CreateStreamEntry(baseEntry *LogEntry) *LogEntry {
 		CacheType:              baseEntry.CacheType,
 		StatusCode:             baseEntry.StatusCode,
 		// Copy extracted fields
-		RequestID: baseEntry.RequestID,
-		AuthKeyID: baseEntry.AuthKeyID,
-		ClientIP:  baseEntry.ClientIP,
-		Method:    baseEntry.Method,
-		Path:      baseEntry.Path,
-		Stream:    true, // Mark as streaming
+		RequestID:  baseEntry.RequestID,
+		AuthKeyID:  baseEntry.AuthKeyID,
+		AuthMethod: baseEntry.AuthMethod,
+		ClientIP:   baseEntry.ClientIP,
+		Method:     baseEntry.Method,
+		Path:       baseEntry.Path,
+		UserPath:   baseEntry.UserPath,
+		Stream:     true, // Mark as streaming
 	}
 
 	if baseEntry.Data != nil {


### PR DESCRIPTION
## Summary
- preserve auth method and user path when cloning streamed audit log entries
- keep streamed auth metadata aligned with non-streamed audit entries
- add regression coverage for stream entry cloning

## Testing
- go test ./internal/auditlog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Execution pipeline cards show workflow ID chips in the top-right corner.
  * Audit logs now capture and persist execution feature snapshots (cache, audit, usage, guardrails, fallback).

* **Tests**
  * Added and updated tests to cover workflow ID behavior, meta chip rendering, and execution feature snapshot handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->