### PR TITLE
refactor(workflows): prefer user paths and provider names

### DIFF
--- a/docs/advanced/admin-endpoints.mdx
+++ b/docs/advanced/admin-endpoints.mdx
@@ -123,7 +123,7 @@ Returns an empty array if usage tracking is disabled or no data exists for the p
 
 ### GET /admin/api/v1/models
 
-Returns all registered models with their provider type.
+Returns all registered models with both provider type and configured provider name.
 
 **Response:**
 
@@ -136,7 +136,9 @@ Returns all registered models with their provider type.
       "created": 1715367049,
       "owned_by": "system"
     },
-    "provider_type": "openai"
+    "provider_type": "openai",
+    "provider_name": "openai_primary",
+    "selector": "openai_primary/gpt-4o"
   },
   {
     "model": {
@@ -145,12 +147,14 @@ Returns all registered models with their provider type.
       "created": 1727568000,
       "owned_by": "system"
     },
-    "provider_type": "anthropic"
+    "provider_type": "anthropic",
+    "provider_name": "anthropic_main",
+    "selector": "anthropic_main/claude-sonnet-4-5-20250929"
   }
 ]
 ```
 
-This differs from the standard `/v1/models` endpoint: the admin version includes `provider_type` for each model, making it useful for understanding which provider serves which model.
+This differs from the standard `/v1/models` endpoint: the admin version includes both `provider_type` and `provider_name` for each model, making it useful for understanding both the provider family and the concrete configured provider instance that serves the model.
 
 ## Admin Dashboard
 

--- a/docs/advanced/workflows.mdx
+++ b/docs/advanced/workflows.mdx
@@ -1,0 +1,124 @@
+---
+title: "Workflows"
+description: "How workflow matching works, including user_path-first precedence and provider-name scoping."
+---
+
+## Overview
+
+Workflows are immutable execution-policy versions stored in the gateway and matched per request.
+
+They currently control gateway-owned behavior such as:
+
+- cache
+- audit logging
+- usage tracking
+- guardrails
+- translated-route fallback
+
+Each request matches exactly one active workflow.
+
+## Scope Fields
+
+Workflow scope is defined by these fields:
+
+- `scope_provider_name`
+- `scope_model`
+- `scope_user_path`
+
+`scope_provider_name` is the configured provider instance name, not the provider type.
+
+Examples:
+
+- provider type: `openai`
+- provider name: `openai_primary`
+
+If you have multiple configured providers of the same type, workflows can target them independently by provider name.
+
+## Matching Precedence
+
+Workflow matching is user-path first.
+
+For a request with `user_path=/team/team1/user`, the gateway checks path-scoped candidates from deepest to root first:
+
+1. `provider_name + model + /team/team1/user`
+2. `provider_name + /team/team1/user`
+3. `/team/team1/user`
+4. `provider_name + model + /team/team1`
+5. `provider_name + /team/team1`
+6. `/team/team1`
+7. `provider_name + model + /team`
+8. `provider_name + /team`
+9. `/team`
+10. `provider_name + model + /`
+11. `provider_name + /`
+12. `/`
+13. `provider_name + model`
+14. `provider_name`
+15. `global`
+
+In practice:
+
+- a deeper `user_path` workflow beats a broader provider-only or provider+model workflow
+- within the same path depth, provider+model is more specific than provider-only
+- if no path-scoped workflow matches, the gateway falls back to provider+model, then provider, then global
+
+## Examples
+
+### Path Inheritance
+
+If you have:
+
+- workflow A: `scope_user_path=/team`
+- workflow B: `scope_user_path=/team/team1`
+
+and the API key uses `user_path=/team/team1/user`, workflow B wins.
+
+If workflow B does not exist, workflow A wins.
+
+### Provider-Name Scoping
+
+If you have two OpenAI providers:
+
+- `openai_primary`
+- `openai_backup`
+
+you can create separate workflows for:
+
+- `scope_provider_name=openai_primary`
+- `scope_provider_name=openai_backup`
+
+Even though both have provider type `openai`, they are different workflow scopes.
+
+## API Example
+
+Create a workflow scoped to one configured provider name, one model, and one user-path subtree:
+
+```bash
+curl -X POST http://localhost:8080/admin/api/v1/execution-plans \
+  -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "scope_provider_name": "openai_primary",
+    "scope_model": "gpt-5",
+    "scope_user_path": "/team/alpha",
+    "name": "team-alpha-openai-primary",
+    "description": "Disable cache for this tenant on the primary OpenAI provider",
+    "plan_payload": {
+      "schema_version": 1,
+      "features": {
+        "cache": false,
+        "audit": true,
+        "usage": true,
+        "guardrails": false,
+        "fallback": true
+      },
+      "guardrails": []
+    }
+  }'
+```
+
+## Notes
+
+- `scope_model` requires `scope_provider_name`
+- `scope_user_path` is normalized to canonical slash form
+- managed API keys can override the request `X-GoModel-User-Path`; workflow matching uses the effective request user path

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -32,7 +32,7 @@
             },
             {
                 "group": "Advanced",
-                "pages": ["advanced/configuration", "advanced/config-yaml", "advanced/guardrails", "advanced/admin-endpoints"]
+                "pages": ["advanced/configuration", "advanced/config-yaml", "advanced/guardrails", "advanced/workflows", "advanced/admin-endpoints"]
             },
             {
                 "group": "About",

--- a/internal/admin/dashboard/static/js/modules/execution-plans.js
+++ b/internal/admin/dashboard/static/js/modules/execution-plans.js
@@ -220,7 +220,7 @@
                         plan.description,
                         plan.scope_display,
                         plan.scope_type,
-                        plan.scope && plan.scope.scope_provider,
+                        this.executionPlanScopeProviderValue(plan && plan.scope),
                         plan.scope && plan.scope.scope_model,
                         plan.scope && plan.scope.scope_user_path,
                         plan.plan_hash,
@@ -232,6 +232,18 @@
                 });
             },
 
+            executionPlanScopeProviderValue(scope) {
+                return String(
+                    scope && (scope.scope_provider_name || scope.scope_provider) || ''
+                ).trim();
+            },
+
+            executionPlanModelProviderValue(model) {
+                return String(
+                    model && (model.provider_name || model.provider_type) || ''
+                ).trim();
+            },
+
             executionPlanProviderOptions() {
                 const options = new Set();
                 const preservedProvider = String(this.executionPlanHydratedScope && this.executionPlanHydratedScope.scope_provider || '').trim();
@@ -240,16 +252,16 @@
                 }
                 const models = Array.isArray(this.models) ? this.models : [];
                 models.forEach((model) => {
-                    const providerType = String(model && model.provider_type || '').trim();
-                    if (providerType) {
-                        options.add(providerType);
+                    const providerName = this.executionPlanModelProviderValue(model);
+                    if (providerName) {
+                        options.add(providerName);
                     }
                 });
                 return [...options].sort();
             },
 
-            executionPlanModelOptions(providerType) {
-                const wantedProvider = String(providerType || '').trim();
+            executionPlanModelOptions(providerName) {
+                const wantedProvider = String(providerName || '').trim();
                 const options = new Set();
                 const preservedProvider = String(this.executionPlanHydratedScope && this.executionPlanHydratedScope.scope_provider || '').trim();
                 const preservedModel = String(this.executionPlanHydratedScope && this.executionPlanHydratedScope.scope_model || '').trim();
@@ -258,7 +270,7 @@
                 }
                 const models = Array.isArray(this.models) ? this.models : [];
                 models.forEach((model) => {
-                    if (wantedProvider && String(model && model.provider_type || '').trim() !== wantedProvider) {
+                    if (wantedProvider && this.executionPlanModelProviderValue(model) !== wantedProvider) {
                         return;
                     }
                     const modelID = String(model && model.model && model.model.id || '').trim();
@@ -271,11 +283,11 @@
 
             planScopeTypeLabel(plan) {
                 const scopeType = String(plan && plan.scope_type || '').trim();
-                if (scopeType === 'provider_model') return 'Provider + Model';
-                if (scopeType === 'provider_model_path') return 'Provider + Model + Path';
-                if (scopeType === 'provider_path') return 'Provider + Path';
+                if (scopeType === 'provider_model') return 'Provider Name + Model';
+                if (scopeType === 'provider_model_path') return 'Provider Name + Model + Path';
+                if (scopeType === 'provider_path') return 'Provider Name + Path';
                 if (scopeType === 'path') return 'Path';
-                if (scopeType === 'provider') return 'Provider';
+                if (scopeType === 'provider') return 'Provider Name';
                 return 'Global';
             },
 
@@ -337,7 +349,7 @@
 
             executionPlanScopeMatches(plan, scope) {
                 const normalized = scope || { scope_provider: '', scope_model: '', scope_user_path: '' };
-                const provider = String(plan && plan.scope && plan.scope.scope_provider || '').trim();
+                const provider = this.executionPlanScopeProviderValue(plan && plan.scope);
                 const model = provider ? String(plan && plan.scope && plan.scope.scope_model || '').trim() : '';
                 const userPath = this.normalizeExecutionPlanScopeUserPath(plan && plan.scope && plan.scope.scope_user_path);
                 return provider === String(normalized.scope_provider || '').trim()
@@ -385,7 +397,7 @@
                     scope_type: scopeType,
                     scope_display: scopeDisplay,
                     scope: {
-                        scope_provider: scope.scope_provider,
+                        scope_provider_name: scope.scope_provider,
                         scope_model: scope.scope_model,
                         ...(scope.scope_user_path ? { scope_user_path: scope.scope_user_path } : {})
                     },
@@ -504,14 +516,14 @@
 
                 this.executionPlanFormHydrated = true;
                 this.executionPlanHydratedScope = {
-                    scope_provider: String(plan.scope && plan.scope.scope_provider || '').trim(),
+                    scope_provider: this.executionPlanScopeProviderValue(plan.scope),
                     scope_model: String(plan.scope && plan.scope.scope_model || '').trim(),
                     scope_user_path: String(plan.scope && plan.scope.scope_user_path || '').trim()
                 };
                 const features = this.executionPlanSourceFeatures(plan);
                 const guardrails = this.executionPlanSourceGuardrails(plan);
                 this.executionPlanForm = {
-                    scope_provider: String(plan.scope && plan.scope.scope_provider || ''),
+                    scope_provider: this.executionPlanScopeProviderValue(plan.scope),
                     scope_model: String(plan.scope && plan.scope.scope_model || ''),
                     scope_user_path: String(plan.scope && plan.scope.scope_user_path || ''),
                     name: String(plan.name || ''),
@@ -656,7 +668,7 @@
                     : [];
 
                 const payload = {
-                    scope_provider: provider,
+                    scope_provider_name: provider,
                     scope_model: model,
                     ...(userPath ? { scope_user_path: userPath } : {}),
                     name: String(form.name || '').trim(),
@@ -742,21 +754,23 @@
             validateExecutionPlanRequest(payload) {
                 const preservedProvider = String(this.executionPlanHydratedScope && this.executionPlanHydratedScope.scope_provider || '').trim();
                 const preservedModel = String(this.executionPlanHydratedScope && this.executionPlanHydratedScope.scope_model || '').trim();
+                const providerName = String(payload && (payload.scope_provider_name || payload.scope_provider) || '').trim();
+                const scopeModel = String(payload && payload.scope_model || '').trim();
 
-                if (payload.scope_provider) {
+                if (providerName) {
                     const providers = this.executionPlanProviderOptions();
-                    if (!providers.includes(payload.scope_provider) && payload.scope_provider !== preservedProvider) {
-                        return 'Choose a registered provider.';
+                    if (!providers.includes(providerName) && providerName !== preservedProvider) {
+                        return 'Choose a registered provider name.';
                     }
                 }
-                if (payload.scope_model && !payload.scope_provider) {
-                    return 'Model selection requires a provider.';
+                if (scopeModel && !providerName) {
+                    return 'Model selection requires a provider name.';
                 }
-                if (payload.scope_model) {
-                    const models = this.executionPlanModelOptions(payload.scope_provider);
-                    const isPreservedModel = payload.scope_provider === preservedProvider && payload.scope_model === preservedModel;
-                    if (!models.includes(payload.scope_model) && !isPreservedModel) {
-                        return 'Choose a registered model for the selected provider.';
+                if (scopeModel) {
+                    const models = this.executionPlanModelOptions(providerName);
+                    const isPreservedModel = providerName === preservedProvider && scopeModel === preservedModel;
+                    if (!models.includes(scopeModel) && !isPreservedModel) {
+                        return 'Choose a registered model for the selected provider name.';
                     }
                 }
                 const userPathError = this.executionPlanScopeUserPathValidationError(payload.scope_user_path);
@@ -1084,7 +1098,7 @@
 
             epAiLabel(source, runtime) {
                 if (runtime && runtime.provider) return runtime.provider;
-                const provider = source && source.scope && source.scope.scope_provider;
+                const provider = this.executionPlanScopeProviderValue(source && source.scope);
                 return provider || 'AI';
             },
 

--- a/internal/admin/dashboard/static/js/modules/execution-plans.test.js
+++ b/internal/admin/dashboard/static/js/modules/execution-plans.test.js
@@ -48,7 +48,7 @@ function createTimerHarness() {
     };
 }
 
-test('executionPlanProviderOptions returns unique sorted provider types', () => {
+test('executionPlanProviderOptions returns unique sorted provider names', () => {
     const module = createExecutionPlansModule();
     module.models = [
         { provider_type: 'anthropic', model: { id: 'claude-3-7' } },
@@ -95,7 +95,7 @@ test('executionPlanPreview mirrors the draft workflow card state from the editor
             scope_type: 'provider_model',
             scope_display: 'openai/gpt-5',
             scope: {
-                scope_provider: 'openai',
+                scope_provider_name: 'openai',
                 scope_model: 'gpt-5'
             },
             name: 'Draft workflow',
@@ -142,7 +142,7 @@ test('executionPlanPreview renders path-scoped draft labels using canonical scop
             scope_type: 'provider_model_path',
             scope_display: 'openai/gpt-5 @ /team/alpha',
             scope: {
-                scope_provider: 'openai',
+                scope_provider_name: 'openai',
                 scope_model: 'gpt-5',
                 scope_user_path: '/team/alpha'
             },
@@ -642,7 +642,7 @@ test('buildExecutionPlanRequest emits provider-model payload and strips guardrai
     assert.equal(
         JSON.stringify(module.buildExecutionPlanRequest()),
         JSON.stringify({
-            scope_provider: 'openai',
+            scope_provider_name: 'openai',
             scope_model: 'gpt-5',
             scope_user_path: '/team/alpha',
             name: 'OpenAI GPT-5',
@@ -807,7 +807,7 @@ test('editing a cloned workflow preserves retired provider and model options', (
     invalidPayload.scope_model = 'different-retired-model';
     assert.equal(
         module.validateExecutionPlanRequest(invalidPayload),
-        'Choose a registered model for the selected provider.'
+        'Choose a registered model for the selected provider name.'
     );
 });
 
@@ -1215,7 +1215,7 @@ test('buildExecutionPlanRequest clamps globally disabled workflow features off e
     assert.equal(
         JSON.stringify(module.buildExecutionPlanRequest()),
         JSON.stringify({
-            scope_provider: 'openai',
+            scope_provider_name: 'openai',
             scope_model: 'gpt-5',
             name: 'OpenAI GPT-5',
             description: 'Globally disabled features should be forced off',
@@ -1401,7 +1401,7 @@ test('validateExecutionPlanRequest rejects unregistered provider-model selection
                 guardrails: []
             }
         }),
-        'Choose a registered provider.'
+        'Choose a registered provider name.'
     );
 
     assert.equal(
@@ -1414,7 +1414,7 @@ test('validateExecutionPlanRequest rejects unregistered provider-model selection
                 guardrails: []
             }
         }),
-        'Choose a registered model for the selected provider.'
+        'Choose a registered model for the selected provider name.'
     );
 });
 

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -1072,7 +1072,7 @@
     <div class="page-header">
         <div>
             <h2>Workflows</h2>
-            <p class="execution-plan-page-note">Active workflows are matched with most-specific-wins precedence: provider + model, then provider, then global.</p>
+            <p class="execution-plan-page-note">Active workflows are matched path-first: deepest user path wins first, then provider name and model specificity, then broader matches, then global.</p>
         </div>
         <div class="page-header-controls">
             <button type="button" class="pagination-btn pagination-btn-primary" x-show="executionPlansAvailable" @click="openExecutionPlanCreate()">New Workflow</button>
@@ -1111,11 +1111,11 @@
 
                 <div class="alias-form-grid">
                     <label class="alias-form-field">
-                        <span>Provider</span>
+                        <span>Provider Name</span>
                         <select class="usage-log-select execution-plan-input" x-model="executionPlanForm.scope_provider" @change="setExecutionPlanProvider(executionPlanForm.scope_provider)">
                             <option value="">All providers and models</option>
-                            <template x-for="providerType in executionPlanProviderOptions()" :key="providerType">
-                                <option :value="providerType" x-text="providerType"></option>
+                            <template x-for="providerName in executionPlanProviderOptions()" :key="providerName">
+                                <option :value="providerName" x-text="providerName"></option>
                             </template>
                         </select>
                     </label>
@@ -1141,8 +1141,8 @@
                     </label>
                 </div>
 
-                <p class="alias-form-hint">Leave provider empty to target all providers and models. Select a provider without a model to target all models for that provider.</p>
-                <p class="alias-form-hint">Add a path to scope the workflow to that subtree. Leading slashes are optional and will be normalized; you can enter &quot;team/alpha&quot; or &quot;/team/alpha&quot;. Matching falls back from the deepest path toward the root.</p>
+                <p class="alias-form-hint">Leave provider name empty to target all providers and models. Select a provider name without a model to target all models for that configured provider.</p>
+                <p class="alias-form-hint">Add a path to scope the workflow to that subtree. Leading slashes are optional and will be normalized; you can enter &quot;team/alpha&quot; or &quot;/team/alpha&quot;. Matching checks the deepest user path first, then falls back toward the root.</p>
                 <p class="alias-form-hint">If you leave the name empty, the workflow will display as the matched provider/model scope or “All models”.</p>
 
                 <label class="alias-form-field">

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -735,12 +735,13 @@ type upsertGuardrailRequest struct {
 }
 
 type createExecutionPlanRequest struct {
-	ScopeProvider string                 `json:"scope_provider,omitempty"`
-	ScopeModel    string                 `json:"scope_model,omitempty"`
-	ScopeUserPath string                 `json:"scope_user_path,omitempty"`
-	Name          string                 `json:"name"`
-	Description   string                 `json:"description,omitempty"`
-	Payload       executionplans.Payload `json:"plan_payload"`
+	ScopeProviderName   string                 `json:"scope_provider_name,omitempty"`
+	LegacyScopeProvider string                 `json:"scope_provider,omitempty"`
+	ScopeModel          string                 `json:"scope_model,omitempty"`
+	ScopeUserPath       string                 `json:"scope_user_path,omitempty"`
+	Name                string                 `json:"name"`
+	Description         string                 `json:"description,omitempty"`
+	Payload             executionplans.Payload `json:"plan_payload"`
 }
 
 type createAuthKeyRequest struct {
@@ -1128,13 +1129,17 @@ func (h *Handler) CreateExecutionPlan(c *echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return handleError(c, core.NewInvalidRequestError("invalid request body: "+err.Error(), err))
 	}
+	scopeProviderName := strings.TrimSpace(req.ScopeProviderName)
+	if scopeProviderName == "" {
+		scopeProviderName = strings.TrimSpace(req.LegacyScopeProvider)
+	}
 
 	scopeUserPath, err := normalizeUserPathQueryParam("scope_user_path", req.ScopeUserPath)
 	if err != nil {
 		return handleError(c, err)
 	}
 
-	if err := h.validateExecutionPlanScope(req.ScopeProvider, req.ScopeModel); err != nil {
+	if err := h.validateExecutionPlanScope(scopeProviderName, req.ScopeModel); err != nil {
 		return handleError(c, err)
 	}
 
@@ -1147,7 +1152,7 @@ func (h *Handler) CreateExecutionPlan(c *echo.Context) error {
 
 	version, err := h.plans.Create(c.Request().Context(), executionplans.CreateInput{
 		Scope: executionplans.Scope{
-			Provider: req.ScopeProvider,
+			Provider: scopeProviderName,
 			Model:    req.ScopeModel,
 			UserPath: scopeUserPath,
 		},
@@ -1254,32 +1259,32 @@ func (h *Handler) validateExecutionPlanGuardrails(payload executionplans.Payload
 	return nil
 }
 
-func (h *Handler) validateExecutionPlanScope(scopeProvider, scopeModel string) error {
-	scopeProvider = strings.TrimSpace(scopeProvider)
+func (h *Handler) validateExecutionPlanScope(scopeProviderName, scopeModel string) error {
+	scopeProviderName = strings.TrimSpace(scopeProviderName)
 	scopeModel = strings.TrimSpace(scopeModel)
 
-	if scopeProvider == "" {
+	if scopeProviderName == "" {
 		if scopeModel != "" {
-			return core.NewInvalidRequestError("scope_model requires scope_provider", nil)
+			return core.NewInvalidRequestError("scope_model requires scope_provider_name", nil)
 		}
 		return nil
 	}
 	if h.registry == nil {
-		return core.NewInvalidRequestError("provider registry is unavailable for workflow scope validation", nil)
+		return core.NewInvalidRequestError("provider registry is unavailable for workflow provider-name validation", nil)
 	}
-	if !slices.Contains(h.registry.ProviderTypes(), scopeProvider) {
-		return core.NewInvalidRequestError("unknown provider type: "+scopeProvider, nil)
+	if !slices.Contains(h.registry.ProviderNames(), scopeProviderName) {
+		return core.NewInvalidRequestError("unknown provider name: "+scopeProviderName, nil)
 	}
 	if scopeModel == "" {
 		return nil
 	}
 
 	for _, model := range h.registry.ListModelsWithProvider() {
-		if model.ProviderType == scopeProvider && model.Model.ID == scopeModel {
+		if model.ProviderName == scopeProviderName && model.Model.ID == scopeModel {
 			return nil
 		}
 	}
-	return core.NewInvalidRequestError("unknown model for provider "+scopeProvider+": "+scopeModel, nil)
+	return core.NewInvalidRequestError("unknown model for provider name "+scopeProviderName+": "+scopeModel, nil)
 }
 
 func decodeAliasPathName(raw string) (string, error) {

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -1133,13 +1133,14 @@ func (h *Handler) CreateExecutionPlan(c *echo.Context) error {
 	if scopeProviderName == "" {
 		scopeProviderName = strings.TrimSpace(req.LegacyScopeProvider)
 	}
+	scopeModel := strings.TrimSpace(req.ScopeModel)
 
 	scopeUserPath, err := normalizeUserPathQueryParam("scope_user_path", req.ScopeUserPath)
 	if err != nil {
 		return handleError(c, err)
 	}
 
-	scopeProviderName, err = h.validateExecutionPlanScope(scopeProviderName, req.ScopeModel)
+	scopeProviderName, err = h.validateExecutionPlanScope(scopeProviderName, scopeModel)
 	if err != nil {
 		return handleError(c, err)
 	}
@@ -1154,7 +1155,7 @@ func (h *Handler) CreateExecutionPlan(c *echo.Context) error {
 	version, err := h.plans.Create(c.Request().Context(), executionplans.CreateInput{
 		Scope: executionplans.Scope{
 			Provider: scopeProviderName,
-			Model:    req.ScopeModel,
+			Model:    scopeModel,
 			UserPath: scopeUserPath,
 		},
 		Activate:    true,

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -1139,7 +1139,8 @@ func (h *Handler) CreateExecutionPlan(c *echo.Context) error {
 		return handleError(c, err)
 	}
 
-	if err := h.validateExecutionPlanScope(scopeProviderName, req.ScopeModel); err != nil {
+	scopeProviderName, err = h.validateExecutionPlanScope(scopeProviderName, req.ScopeModel)
+	if err != nil {
 		return handleError(c, err)
 	}
 
@@ -1259,32 +1260,37 @@ func (h *Handler) validateExecutionPlanGuardrails(payload executionplans.Payload
 	return nil
 }
 
-func (h *Handler) validateExecutionPlanScope(scopeProviderName, scopeModel string) error {
+func (h *Handler) validateExecutionPlanScope(scopeProviderName, scopeModel string) (string, error) {
 	scopeProviderName = strings.TrimSpace(scopeProviderName)
 	scopeModel = strings.TrimSpace(scopeModel)
 
 	if scopeProviderName == "" {
 		if scopeModel != "" {
-			return core.NewInvalidRequestError("scope_model requires scope_provider_name", nil)
+			return "", core.NewInvalidRequestError("scope_model requires scope_provider_name", nil)
 		}
-		return nil
+		return "", nil
 	}
 	if h.registry == nil {
-		return core.NewInvalidRequestError("provider registry is unavailable for workflow provider-name validation", nil)
+		return "", core.NewInvalidRequestError("provider registry is unavailable for workflow provider-name validation", nil)
 	}
 	if !slices.Contains(h.registry.ProviderNames(), scopeProviderName) {
-		return core.NewInvalidRequestError("unknown provider name: "+scopeProviderName, nil)
+		if resolvedProviderName := strings.TrimSpace(h.registry.GetProviderNameForType(scopeProviderName)); resolvedProviderName != "" {
+			scopeProviderName = resolvedProviderName
+		}
+	}
+	if !slices.Contains(h.registry.ProviderNames(), scopeProviderName) {
+		return "", core.NewInvalidRequestError("unknown provider name: "+scopeProviderName, nil)
 	}
 	if scopeModel == "" {
-		return nil
+		return scopeProviderName, nil
 	}
 
 	for _, model := range h.registry.ListModelsWithProvider() {
 		if model.ProviderName == scopeProviderName && model.Model.ID == scopeModel {
-			return nil
+			return scopeProviderName, nil
 		}
 	}
-	return core.NewInvalidRequestError("unknown model for provider name "+scopeProviderName+": "+scopeModel, nil)
+	return "", core.NewInvalidRequestError("unknown model for provider name "+scopeProviderName+": "+scopeModel, nil)
 }
 
 func decodeAliasPathName(raw string) (string, error) {

--- a/internal/admin/handler_executionplans_test.go
+++ b/internal/admin/handler_executionplans_test.go
@@ -456,7 +456,7 @@ func TestCreateExecutionPlan_NormalizesScopeUserPath(t *testing.T) {
 	e := echo.New()
 
 	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/execution-plans", bytes.NewBufferString(`{
-		"scope_provider":"openai",
+		"scope_provider_name":"openai",
 		"scope_model":"gpt-5",
 		"scope_user_path":" team//alpha/user/ ",
 		"name":"Scoped workflow",
@@ -770,7 +770,7 @@ func TestCreateExecutionPlanRejectsUnknownProviderOrModelScope(t *testing.T) {
 					"guardrails":[]
 				}
 			}`,
-			wantMessage: "unknown provider type: anthropic",
+			wantMessage: "unknown provider name: anthropic",
 		},
 		{
 			name: "unknown model for provider",
@@ -784,7 +784,7 @@ func TestCreateExecutionPlanRejectsUnknownProviderOrModelScope(t *testing.T) {
 					"guardrails":[]
 				}
 			}`,
-			wantMessage: "unknown model for provider openai: gpt-4o-mini",
+			wantMessage: "unknown model for provider name openai: gpt-4o-mini",
 		},
 	}
 

--- a/internal/admin/handler_executionplans_test.go
+++ b/internal/admin/handler_executionplans_test.go
@@ -573,6 +573,94 @@ func TestCreateExecutionPlan(t *testing.T) {
 	}
 }
 
+func TestCreateExecutionPlan_StoresCanonicalScopeModel(t *testing.T) {
+	tests := []struct {
+		name         string
+		body         string
+		wantModel    string
+		wantScopeKey string
+	}{
+		{
+			name: "trimmed model",
+			body: `{
+				"scope_provider_name":"openai",
+				"scope_model":"  gpt-5  ",
+				"name":"trimmed model",
+				"plan_payload":{
+					"schema_version":1,
+					"features":{"cache":true,"audit":true,"usage":true,"guardrails":false},
+					"guardrails":[]
+				}
+			}`,
+			wantModel:    "gpt-5",
+			wantScopeKey: "provider_model:openai:gpt-5",
+		},
+		{
+			name: "whitespace only model keeps provider-only scope",
+			body: `{
+				"scope_provider_name":"openai",
+				"scope_model":"   ",
+				"name":"provider only",
+				"plan_payload":{
+					"schema_version":1,
+					"features":{"cache":true,"audit":true,"usage":true,"guardrails":false},
+					"guardrails":[]
+				}
+			}`,
+			wantModel:    "",
+			wantScopeKey: "provider:openai",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &executionPlanTestStore{
+				versions: []executionplans.Version{
+					{
+						ID:       "global-plan",
+						Scope:    executionplans.Scope{},
+						ScopeKey: "global",
+						Version:  1,
+						Active:   true,
+						Name:     "global",
+						Payload: executionplans.Payload{
+							SchemaVersion: 1,
+							Features:      executionplans.FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
+						},
+						PlanHash: "hash-global",
+					},
+				},
+			}
+
+			h := newExecutionPlanHandler(t, store, nil)
+			e := echo.New()
+
+			req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/execution-plans", bytes.NewBufferString(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			if err := h.CreateExecutionPlan(c); err != nil {
+				t.Fatalf("CreateExecutionPlan() error = %v", err)
+			}
+			if rec.Code != http.StatusCreated {
+				t.Fatalf("status = %d, want 201", rec.Code)
+			}
+
+			var body executionplans.Version
+			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+				t.Fatalf("unmarshal response: %v", err)
+			}
+			if body.Scope.Model != tt.wantModel {
+				t.Fatalf("Scope.Model = %q, want %q", body.Scope.Model, tt.wantModel)
+			}
+			if body.ScopeKey != tt.wantScopeKey {
+				t.Fatalf("ScopeKey = %q, want %q", body.ScopeKey, tt.wantScopeKey)
+			}
+		})
+	}
+}
+
 func TestCreateExecutionPlan_LegacyProviderTypeResolvesToConfiguredProviderName(t *testing.T) {
 	store := &executionPlanTestStore{
 		versions: []executionplans.Version{

--- a/internal/admin/handler_executionplans_test.go
+++ b/internal/admin/handler_executionplans_test.go
@@ -573,6 +573,71 @@ func TestCreateExecutionPlan(t *testing.T) {
 	}
 }
 
+func TestCreateExecutionPlan_LegacyProviderTypeResolvesToConfiguredProviderName(t *testing.T) {
+	store := &executionPlanTestStore{
+		versions: []executionplans.Version{
+			{
+				ID:       "global-plan",
+				Scope:    executionplans.Scope{},
+				ScopeKey: "global",
+				Version:  1,
+				Active:   true,
+				Name:     "global",
+				Payload: executionplans.Payload{
+					SchemaVersion: 1,
+					Features:      executionplans.FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
+				},
+				PlanHash: "hash-global",
+			},
+		},
+	}
+
+	modelRegistry := providers.NewModelRegistry()
+	modelRegistry.RegisterProviderWithNameAndType(&handlerMockProvider{
+		models: &core.ModelsResponse{
+			Object: "list",
+			Data: []core.Model{
+				{ID: "gpt-5", Object: "model", OwnedBy: "openai"},
+			},
+		},
+	}, "primary-openai", "openai")
+	if err := modelRegistry.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	h := newExecutionPlanHandlerWithModelRegistry(t, store, modelRegistry, nil)
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/execution-plans", bytes.NewBufferString(`{
+		"scope_provider":"openai",
+		"scope_model":"gpt-5",
+		"name":"legacy provider type scope",
+		"plan_payload":{
+			"schema_version":1,
+			"features":{"cache":true,"audit":true,"usage":true,"guardrails":false},
+			"guardrails":[]
+		}
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.CreateExecutionPlan(c); err != nil {
+		t.Fatalf("CreateExecutionPlan() error = %v", err)
+	}
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201", rec.Code)
+	}
+
+	var body executionplans.Version
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if body.Scope.Provider != "primary-openai" || body.Scope.Model != "gpt-5" {
+		t.Fatalf("scope = %#v, want primary-openai/gpt-5", body.Scope)
+	}
+}
+
 func TestCreateExecutionPlan_AllowsEmptyName(t *testing.T) {
 	store := &executionPlanTestStore{
 		versions: []executionplans.Version{

--- a/internal/core/execution_plan.go
+++ b/internal/core/execution_plan.go
@@ -70,6 +70,7 @@ func CapabilitiesForEndpoint(desc EndpointDescriptor) CapabilitySet {
 // ExecutionPlanSelector contains the request facts used to match one persisted
 // execution-plan version.
 type ExecutionPlanSelector struct {
+	// Provider is the configured provider instance name used for workflow matching.
 	Provider string
 	Model    string
 	UserPath string
@@ -125,8 +126,9 @@ func DefaultExecutionFeatures() ExecutionFeatures {
 // ResolvedExecutionPolicy is the request-scoped runtime projection of one
 // matched persisted execution-plan version.
 type ResolvedExecutionPolicy struct {
-	VersionID      string
-	Version        int
+	VersionID string
+	Version   int
+	// ScopeProvider is the configured provider instance name stored on the matched workflow.
 	ScopeProvider  string
 	ScopeModel     string
 	ScopeUserPath  string

--- a/internal/core/interfaces.go
+++ b/internal/core/interfaces.go
@@ -109,6 +109,13 @@ type ProviderNameResolver interface {
 	GetProviderName(model string) string
 }
 
+// ProviderTypeNameResolver is an optional interface for components that can map
+// a provider type such as "openai" to the concrete configured provider
+// instance name used for routing, such as "openai_primary".
+type ProviderTypeNameResolver interface {
+	GetProviderNameForType(providerType string) string
+}
+
 // AvailabilityChecker is an optional interface for providers that need
 // to verify service availability before registration.
 type AvailabilityChecker interface {

--- a/internal/executionplans/service.go
+++ b/internal/executionplans/service.go
@@ -434,36 +434,32 @@ func (s *Service) matchCompiled(selector core.ExecutionPlanSelector) (*CompiledP
 	current := s.snapshot()
 	ancestors := core.UserPathAncestors(selector.UserPath)
 
-	if selector.Provider != "" && selector.Model != "" && len(ancestors) > 0 {
-		if models := current.providerModelPaths[selector.Provider]; models != nil {
-			if paths := models[selector.Model]; paths != nil {
-				for _, userPath := range ancestors {
+	if len(ancestors) > 0 {
+		for _, userPath := range ancestors {
+			if selector.Provider != "" && selector.Model != "" {
+				if models := current.providerModelPaths[selector.Provider]; models != nil {
+					if paths := models[selector.Model]; paths != nil {
+						if compiled := paths[userPath]; compiled != nil {
+							return compiled, nil
+						}
+					}
+				}
+			}
+			if selector.Provider != "" {
+				if paths := current.providerPaths[selector.Provider]; paths != nil {
 					if compiled := paths[userPath]; compiled != nil {
 						return compiled, nil
 					}
 				}
+			}
+			if compiled := current.paths[userPath]; compiled != nil {
+				return compiled, nil
 			}
 		}
 	}
 	if selector.Provider != "" && selector.Model != "" {
 		if models := current.providerModels[selector.Provider]; models != nil {
 			if compiled := models[selector.Model]; compiled != nil {
-				return compiled, nil
-			}
-		}
-	}
-	if selector.Provider != "" && len(ancestors) > 0 {
-		if paths := current.providerPaths[selector.Provider]; paths != nil {
-			for _, userPath := range ancestors {
-				if compiled := paths[userPath]; compiled != nil {
-					return compiled, nil
-				}
-			}
-		}
-	}
-	if len(ancestors) > 0 {
-		for _, userPath := range ancestors {
-			if compiled := current.paths[userPath]; compiled != nil {
 				return compiled, nil
 			}
 		}
@@ -624,13 +620,13 @@ func viewScopeSpecificity(scopeType string) int {
 	switch strings.TrimSpace(scopeType) {
 	case "global":
 		return 0
-	case "path":
-		return 2
 	case "provider":
 		return 1
-	case "provider_path":
-		return 3
 	case "provider_model":
+		return 2
+	case "path":
+		return 3
+	case "provider_path":
 		return 4
 	default:
 		return 5

--- a/internal/executionplans/service_test.go
+++ b/internal/executionplans/service_test.go
@@ -384,6 +384,7 @@ func TestServiceMatch_MostSpecificWins(t *testing.T) {
 	}
 
 	assertMatch("provider+model+path", core.NewExecutionPlanSelector("openai", "gpt-5", "/team/a/user"), "provider-model-path")
+	assertMatch("path beats provider+model", core.NewExecutionPlanSelector("openai", "gpt-5", "/team/user"), "path-team")
 	assertMatch("provider+model", core.NewExecutionPlanSelector("openai", "gpt-5"), "provider-model")
 	assertMatch("path", core.NewExecutionPlanSelector("anthropic", "claude-sonnet-4", "/team/a/user"), "path-team")
 	assertMatch("provider", core.NewExecutionPlanSelector("openai", "gpt-4o"), "provider")
@@ -956,11 +957,8 @@ func TestServiceListViews_AnnotatesCompileFailuresPerRow(t *testing.T) {
 }
 
 func TestViewScopeSpecificity_PathExceedsProvider(t *testing.T) {
-	if got, want := viewScopeSpecificity("path"), 2; got != want {
-		t.Fatalf("viewScopeSpecificity(path) = %d, want %d", got, want)
-	}
-	if got, want := viewScopeSpecificity("provider"), 1; got != want {
-		t.Fatalf("viewScopeSpecificity(provider) = %d, want %d", got, want)
+	if got, provider := viewScopeSpecificity("path"), viewScopeSpecificity("provider"); got <= provider {
+		t.Fatalf("viewScopeSpecificity(path) = %d, want > provider specificity %d", got, provider)
 	}
 }
 

--- a/internal/executionplans/types.go
+++ b/internal/executionplans/types.go
@@ -14,10 +14,44 @@ import (
 const currentSchemaVersion = 1
 
 // Scope identifies the request selector a persisted execution plan applies to.
+// Provider stores the configured provider instance name, not the provider type.
 type Scope struct {
-	Provider string `json:"scope_provider,omitempty" bson:"scope_provider,omitempty"`
+	Provider string `json:"-" bson:"scope_provider,omitempty"`
 	Model    string `json:"scope_model,omitempty" bson:"scope_model,omitempty"`
 	UserPath string `json:"scope_user_path,omitempty" bson:"scope_user_path,omitempty"`
+}
+
+type scopeJSON struct {
+	ProviderName   string `json:"scope_provider_name,omitempty"`
+	LegacyProvider string `json:"scope_provider,omitempty"`
+	Model          string `json:"scope_model,omitempty"`
+	UserPath       string `json:"scope_user_path,omitempty"`
+}
+
+func (s Scope) MarshalJSON() ([]byte, error) {
+	return json.Marshal(scopeJSON{
+		ProviderName: strings.TrimSpace(s.Provider),
+		Model:        strings.TrimSpace(s.Model),
+		UserPath:     strings.TrimSpace(s.UserPath),
+	})
+}
+
+func (s *Scope) UnmarshalJSON(data []byte) error {
+	if s == nil {
+		return nil
+	}
+	var raw scopeJSON
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	providerName := strings.TrimSpace(raw.ProviderName)
+	if providerName == "" {
+		providerName = strings.TrimSpace(raw.LegacyProvider)
+	}
+	s.Provider = providerName
+	s.Model = strings.TrimSpace(raw.Model)
+	s.UserPath = strings.TrimSpace(raw.UserPath)
+	return nil
 }
 
 // Payload is the immutable persisted execution-plan JSON document.
@@ -100,7 +134,7 @@ func normalizeScope(scope Scope) (Scope, string, error) {
 	}
 	scope.UserPath = userPath
 	if scope.Provider == "" && scope.Model != "" {
-		return Scope{}, "", newValidationError("scope_model requires scope_provider", nil)
+		return Scope{}, "", newValidationError("scope_model requires scope_provider_name", nil)
 	}
 	if strings.Contains(scope.Provider, ":") || strings.Contains(scope.Model, ":") || strings.Contains(scope.UserPath, ":") {
 		return Scope{}, "", newValidationError("scope fields cannot contain ':'", nil)

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -660,6 +660,26 @@ func (r *ModelRegistry) GetProviderName(model string) string {
 	return ""
 }
 
+// GetProviderNameForType returns the first registered configured provider name
+// for the given provider type. This follows the same first-registered behavior
+// used when provider-typed routes resolve a concrete provider instance.
+func (r *ModelRegistry) GetProviderNameForType(providerType string) string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	providerType = strings.TrimSpace(providerType)
+	if providerType == "" {
+		return ""
+	}
+	for _, provider := range r.providers {
+		if strings.TrimSpace(r.providerTypes[provider]) != providerType {
+			continue
+		}
+		return strings.TrimSpace(r.providerNames[provider])
+	}
+	return ""
+}
+
 // ProviderByType returns the first registered provider for the given provider type.
 // This lookup is independent of discovered models so provider-typed routes keep
 // working even when a provider currently exposes zero models.

--- a/internal/providers/router.go
+++ b/internal/providers/router.go
@@ -534,6 +534,15 @@ func (r *Router) GetProviderName(model string) string {
 	return ""
 }
 
+// GetProviderNameForType returns the concrete configured provider instance name
+// chosen for a provider-typed route.
+func (r *Router) GetProviderNameForType(providerType string) string {
+	if named, ok := r.lookup.(core.ProviderTypeNameResolver); ok {
+		return strings.TrimSpace(named.GetProviderNameForType(providerType))
+	}
+	return ""
+}
+
 func (r *Router) providerByType(providerType string) core.Provider {
 	models := r.lookup.ListModels()
 	for _, model := range models {

--- a/internal/server/execution_plan_helpers.go
+++ b/internal/server/execution_plan_helpers.go
@@ -139,7 +139,7 @@ func translatedExecutionPlan(
 	selector := core.ExecutionPlanSelector{}
 	if resolution != nil {
 		selector = core.NewExecutionPlanSelector(
-			plan.ProviderType,
+			resolvedWorkflowProviderName(resolution),
 			resolution.ResolvedSelector.Model,
 			core.UserPathFromContext(ctx),
 		)

--- a/internal/server/execution_plan_helpers_test.go
+++ b/internal/server/execution_plan_helpers_test.go
@@ -58,6 +58,6 @@ func TestEnsureTranslatedRequestPlan_CompletesPartialPlanFromDecodedSelector(t *
 		}
 	}
 	assert.Equal(t, "gpt-4o-mini", entry.RequestedModel)
-	assert.Equal(t, "gpt-4o-mini", entry.ResolvedModel)
+	assert.Equal(t, "mock/gpt-4o-mini", entry.ResolvedModel)
 	assert.Equal(t, "mock", entry.Provider)
 }

--- a/internal/server/execution_plan_helpers_test.go
+++ b/internal/server/execution_plan_helpers_test.go
@@ -58,6 +58,6 @@ func TestEnsureTranslatedRequestPlan_CompletesPartialPlanFromDecodedSelector(t *
 		}
 	}
 	assert.Equal(t, "gpt-4o-mini", entry.RequestedModel)
-	assert.Equal(t, "mock/gpt-4o-mini", entry.ResolvedModel)
+	assert.Equal(t, "gpt-4o-mini", entry.ResolvedModel)
 	assert.Equal(t, "mock", entry.Provider)
 }

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -395,6 +395,9 @@ func (m *mockProvider) GetProviderType(model string) string {
 		if providerType, ok := m.providerTypes[model]; ok {
 			return providerType
 		}
+		if providerType, ok := inferQualifiedProviderValue(m.providerTypes, model); ok {
+			return providerType
+		}
 	}
 	if m.Supports(model) {
 		return "mock"
@@ -417,8 +420,59 @@ func (m *mockProvider) GetProviderName(model string) string {
 		if providerName, ok := m.providerNames[model]; ok {
 			return providerName
 		}
+		if providerName, ok := inferQualifiedProviderValue(m.providerNames, model); ok {
+			return providerName
+		}
+	}
+	if providerType := m.GetProviderType(model); providerType != "" {
+		return providerType
+	}
+	if m.Supports(model) {
+		return "mock"
 	}
 	return ""
+}
+
+func (m *mockProvider) GetProviderNameForType(providerType string) string {
+	providerType = strings.TrimSpace(providerType)
+	if providerType == "" {
+		return ""
+	}
+	if len(m.providerNames) == 0 {
+		return providerType
+	}
+	for qualifiedModel, providerName := range m.providerNames {
+		if providerName == "" {
+			continue
+		}
+		if strings.TrimSpace(m.providerTypes[qualifiedModel]) == providerType {
+			return providerName
+		}
+	}
+	return providerType
+}
+
+func inferQualifiedProviderValue(values map[string]string, model string) (string, bool) {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return "", false
+	}
+
+	match := ""
+	for qualifiedModel, value := range values {
+		selector, err := core.ParseModelSelector(qualifiedModel, "")
+		if err != nil || selector.Provider == "" || selector.Model != model || strings.TrimSpace(value) == "" {
+			continue
+		}
+		if match != "" && match != value {
+			return "", false
+		}
+		match = value
+	}
+	if match == "" {
+		return "", false
+	}
+	return match, true
 }
 
 func (m *mockProvider) NativeFileProviderTypes() []string {

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -424,12 +424,6 @@ func (m *mockProvider) GetProviderName(model string) string {
 			return providerName
 		}
 	}
-	if providerType := m.GetProviderType(model); providerType != "" {
-		return providerType
-	}
-	if m.Supports(model) {
-		return "mock"
-	}
 	return ""
 }
 
@@ -439,17 +433,14 @@ func (m *mockProvider) GetProviderNameForType(providerType string) string {
 		return ""
 	}
 	if len(m.providerNames) == 0 {
-		return providerType
+		return ""
 	}
 	for qualifiedModel, providerName := range m.providerNames {
-		if providerName == "" {
-			continue
-		}
 		if strings.TrimSpace(m.providerTypes[qualifiedModel]) == providerType {
 			return providerName
 		}
 	}
-	return providerType
+	return ""
 }
 
 func inferQualifiedProviderValue(values map[string]string, model string) (string, bool) {

--- a/internal/server/model_validation.go
+++ b/internal/server/model_validation.go
@@ -95,7 +95,12 @@ func deriveExecutionPlanWithPolicy(
 		plan.Mode = core.ExecutionModePassthrough
 		plan.ProviderType = providerType
 		plan.Passthrough = passthrough
-		if err := applyExecutionPolicy(c.Request().Context(), plan, policyResolver, core.NewExecutionPlanSelector(providerType, passthrough.Model, userPath)); err != nil {
+		if err := applyExecutionPolicy(
+			c.Request().Context(),
+			plan,
+			policyResolver,
+			core.NewExecutionPlanSelector(workflowProviderNameForType(provider, providerType), passthrough.Model, userPath),
+		); err != nil {
 			return nil, err
 		}
 		return plan, nil

--- a/internal/server/model_validation_test.go
+++ b/internal/server/model_validation_test.go
@@ -285,7 +285,10 @@ func TestModelValidation_StoresExecutionPlan(t *testing.T) {
 }
 
 func TestModelValidation_StoresMatchedExecutionPolicy(t *testing.T) {
-	provider := &mockProvider{supportedModels: []string{"gpt-4o-mini"}}
+	provider := &mockProvider{
+		supportedModels: []string{"gpt-4o-mini"},
+		providerNames:   map[string]string{"gpt-4o-mini": "mock"},
+	}
 
 	e := echo.New()
 	var capturedPlan *core.ExecutionPlan
@@ -335,7 +338,10 @@ func TestModelValidation_StoresMatchedExecutionPolicy(t *testing.T) {
 }
 
 func TestModelValidation_PassesUserPathToExecutionPolicyResolver(t *testing.T) {
-	provider := &mockProvider{supportedModels: []string{"gpt-4o-mini"}}
+	provider := &mockProvider{
+		supportedModels: []string{"gpt-4o-mini"},
+		providerNames:   map[string]string{"gpt-4o-mini": "mock"},
+	}
 
 	e := echo.New()
 	var capturedSelector core.ExecutionPlanSelector

--- a/internal/server/native_batch_support.go
+++ b/internal/server/native_batch_support.go
@@ -46,7 +46,7 @@ func determineBatchExecutionSelection(provider core.RoutableProvider, resolver R
 		}
 		return batchExecutionSelection{
 			providerType: providerType,
-			selector:     core.NewExecutionPlanSelector(providerType, ""),
+			selector:     core.NewExecutionPlanSelector(workflowProviderNameForType(provider, providerType), ""),
 		}, nil
 	}
 
@@ -56,6 +56,7 @@ func determineBatchExecutionSelection(provider core.RoutableProvider, resolver R
 
 	var (
 		providerType   string
+		providerName   string
 		commonModel    string
 		hasCommonModel = true
 	)
@@ -81,6 +82,12 @@ func determineBatchExecutionSelection(provider core.RoutableProvider, resolver R
 		} else if providerType != itemProvider {
 			return batchExecutionSelection{}, core.NewInvalidRequestError("native batch supports a single provider per batch; split mixed-provider requests", nil)
 		}
+		itemProviderName := resolvedProviderName(provider, resolvedSelector, resolvedSelector.Provider)
+		if providerName == "" {
+			providerName = itemProviderName
+		} else if itemProviderName != "" && providerName != itemProviderName {
+			return batchExecutionSelection{}, core.NewInvalidRequestError("native batch supports a single configured provider per batch; split mixed-provider requests", nil)
+		}
 
 		if !hasCommonModel {
 			continue
@@ -102,12 +109,15 @@ func determineBatchExecutionSelection(provider core.RoutableProvider, resolver R
 	if providerType == "" {
 		return batchExecutionSelection{}, core.NewInvalidRequestError("unable to resolve provider for batch", nil)
 	}
+	if providerName == "" {
+		providerName = workflowProviderNameForType(provider, providerType)
+	}
 	if !hasCommonModel {
 		commonModel = ""
 	}
 	return batchExecutionSelection{
 		providerType: providerType,
-		selector:     core.NewExecutionPlanSelector(providerType, commonModel),
+		selector:     core.NewExecutionPlanSelector(providerName, commonModel),
 	}, nil
 }
 

--- a/internal/server/request_model_resolution.go
+++ b/internal/server/request_model_resolution.go
@@ -34,6 +34,27 @@ func resolvedProviderName(provider core.RoutableProvider, selector core.ModelSel
 	return fallback
 }
 
+func resolvedWorkflowProviderName(resolution *core.RequestModelResolution) string {
+	if resolution == nil {
+		return ""
+	}
+	if providerName := strings.TrimSpace(resolution.ProviderName); providerName != "" {
+		return providerName
+	}
+	return strings.TrimSpace(resolution.ResolvedSelector.Provider)
+}
+
+func workflowProviderNameForType(provider core.RoutableProvider, providerType string) string {
+	providerType = strings.TrimSpace(providerType)
+	if providerType == "" || provider == nil {
+		return ""
+	}
+	if named, ok := provider.(core.ProviderTypeNameResolver); ok {
+		return strings.TrimSpace(named.GetProviderNameForType(providerType))
+	}
+	return ""
+}
+
 func resolveRequestModel(provider core.RoutableProvider, resolver RequestModelResolver, requested core.RequestedModelSelector) (*core.RequestModelResolution, error) {
 	requested = core.NewRequestedModelSelector(requested.Model, requested.ProviderHint)
 


### PR DESCRIPTION
## Summary
- make workflow matching user-path first, so deeper path scopes win before provider-only or provider+model fallbacks
- switch workflow scoping from provider type to configured provider name across matching, admin validation, and request-time workflow resolution
- update admin/dashboard flows and Mintlify docs to use `scope_provider_name`, while keeping legacy reads for compatibility

## Testing
- go test ./internal/executionplans ./internal/admin ./internal/server ./internal/providers
- go test ./internal/admin/dashboard
- node --test internal/admin/dashboard/static/js/modules/execution-plans.test.js internal/admin/dashboard/static/js/modules/execution-plans-layout.test.js
- pre-commit hooks during `git commit` passed, including go unit tests, go mod tidy, perf guard, lint, and frontend build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed Workflows docs covering scope fields, user-path-first matching, provider-name scoping, examples, and API creation samples.

* **Documentation**
  * Admin models endpoint docs updated to show both provider family and configured provider instance; navigation updated to include Workflows.

* **Improvements**
  * Matching logic changed to prefer deeper user paths first.
  * Admin UI copy now shows “Provider Name.”
  * Added graceful handling of legacy request field names during migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->