### PR TITLE
fix(server): prevent empty replies on long chat responses

### DIFF
--- a/internal/server/error_support.go
+++ b/internal/server/error_support.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"errors"
+	"log/slog"
 	"net/http"
 
 	"github.com/labstack/echo/v5"
@@ -13,11 +14,51 @@ import (
 // handleError converts gateway errors to appropriate HTTP responses.
 func handleError(c *echo.Context, err error) error {
 	if gatewayErr, ok := errors.AsType[*core.GatewayError](err); ok {
+		logHandledError(c, gatewayErr)
 		auditlog.EnrichEntryWithError(c, string(gatewayErr.Type), gatewayErr.Message)
 		return c.JSON(gatewayErr.HTTPStatusCode(), gatewayErr.ToJSON())
 	}
 
 	gatewayErr := core.NewProviderError("", http.StatusInternalServerError, "an unexpected error occurred", err)
+	logHandledError(c, gatewayErr)
 	auditlog.EnrichEntryWithError(c, string(gatewayErr.Type), gatewayErr.Message)
 	return c.JSON(gatewayErr.HTTPStatusCode(), gatewayErr.ToJSON())
+}
+
+func logHandledError(c *echo.Context, gatewayErr *core.GatewayError) {
+	if gatewayErr == nil {
+		return
+	}
+
+	attrs := []any{
+		"type", gatewayErr.Type,
+		"status", gatewayErr.HTTPStatusCode(),
+		"message", gatewayErr.Message,
+	}
+	if gatewayErr.Provider != "" {
+		attrs = append(attrs, "provider", gatewayErr.Provider)
+	}
+	if gatewayErr.Param != nil {
+		attrs = append(attrs, "param", *gatewayErr.Param)
+	}
+	if gatewayErr.Code != nil {
+		attrs = append(attrs, "code", *gatewayErr.Code)
+	}
+	if gatewayErr.Err != nil {
+		attrs = append(attrs, "error", gatewayErr.Err)
+	}
+	if c != nil && c.Request() != nil {
+		req := c.Request()
+		attrs = append(attrs,
+			"method", req.Method,
+			"path", req.URL.Path,
+			"request_id", requestIDFromContextOrHeader(req),
+		)
+	}
+
+	if gatewayErr.HTTPStatusCode() >= http.StatusInternalServerError {
+		slog.Error("request failed", attrs...)
+		return
+	}
+	slog.Warn("request failed", attrs...)
 }

--- a/internal/server/error_support_test.go
+++ b/internal/server/error_support_test.go
@@ -1,0 +1,90 @@
+package server
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+
+	"gomodel/internal/core"
+)
+
+func TestHandleError_LogsClientErrorsAtWarnLevel(t *testing.T) {
+	var buf bytes.Buffer
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() {
+		slog.SetDefault(original)
+	})
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req = req.WithContext(core.WithRequestID(req.Context(), "warn-req-123"))
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := handleError(c, core.NewInvalidRequestError("unsupported model: nope", nil)); err != nil {
+		t.Fatalf("handleError() error = %v", err)
+	}
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+
+	logOutput := buf.String()
+	if !strings.Contains(logOutput, `"level":"WARN"`) {
+		t.Fatalf("expected WARN log, got %q", logOutput)
+	}
+	if !strings.Contains(logOutput, `"msg":"request failed"`) {
+		t.Fatalf("expected request failed log, got %q", logOutput)
+	}
+	if !strings.Contains(logOutput, `"request_id":"warn-req-123"`) {
+		t.Fatalf("expected request_id in log, got %q", logOutput)
+	}
+	if !strings.Contains(logOutput, `"message":"unsupported model: nope"`) {
+		t.Fatalf("expected error message in log, got %q", logOutput)
+	}
+}
+
+func TestHandleError_LogsServerErrorsAtErrorLevel(t *testing.T) {
+	var buf bytes.Buffer
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() {
+		slog.SetDefault(original)
+	})
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req = req.WithContext(core.WithRequestID(req.Context(), "error-req-456"))
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	upstreamErr := errors.New("upstream timed out")
+	if err := handleError(c, core.NewProviderError("openai", http.StatusGatewayTimeout, "provider timeout", upstreamErr)); err != nil {
+		t.Fatalf("handleError() error = %v", err)
+	}
+
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusGatewayTimeout)
+	}
+
+	logOutput := buf.String()
+	if !strings.Contains(logOutput, `"level":"ERROR"`) {
+		t.Fatalf("expected ERROR log, got %q", logOutput)
+	}
+	if !strings.Contains(logOutput, `"provider":"openai"`) {
+		t.Fatalf("expected provider in log, got %q", logOutput)
+	}
+	if !strings.Contains(logOutput, `"request_id":"error-req-456"`) {
+		t.Fatalf("expected request_id in log, got %q", logOutput)
+	}
+	if !strings.Contains(logOutput, `"message":"provider timeout"`) {
+		t.Fatalf("expected error message in log, got %q", logOutput)
+	}
+}

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -7,6 +7,7 @@ import (
 	httppprof "net/http/pprof"
 	"path"
 	"strings"
+	"time"
 
 	"gomodel/config"
 
@@ -31,6 +32,11 @@ type Server struct {
 	handler                 *Handler
 	responseCacheMiddleware *responsecache.ResponseCacheMiddleware
 }
+
+const (
+	inboundServerReadTimeout       = 30 * time.Second
+	inboundServerReadHeaderTimeout = 10 * time.Second
+)
 
 // Config holds server configuration options
 type Config struct {
@@ -330,11 +336,7 @@ func passthroughV1PrefixNormalizationEnabled(cfg *Config) bool {
 
 // Start starts the HTTP server on the given address and exits when ctx is canceled.
 func (s *Server) Start(ctx context.Context, addr string) error {
-	sc := echo.StartConfig{
-		Address:    addr,
-		HideBanner: true,
-	}
-	return sc.Start(ctx, s.echo)
+	return newGatewayStartConfig(addr, 0).Start(ctx, s.echo)
 }
 
 // Shutdown releases server resources. The HTTP server itself is stopped by
@@ -350,6 +352,30 @@ func (s *Server) Shutdown(_ context.Context) error {
 // ServeHTTP implements the http.Handler interface, allowing Server to be used with httptest
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.echo.ServeHTTP(w, r)
+}
+
+func newGatewayStartConfig(addr string, writeTimeout time.Duration) echo.StartConfig {
+	return echo.StartConfig{
+		Address:    addr,
+		HideBanner: true,
+		BeforeServeFunc: func(server *http.Server) error {
+			return configureGatewayHTTPServer(server, writeTimeout)
+		},
+	}
+}
+
+func configureGatewayHTTPServer(server *http.Server, writeTimeout time.Duration) error {
+	if server == nil {
+		return nil
+	}
+
+	// Long-running model inference and SSE streams regularly exceed Echo's
+	// default 30s write deadline, which causes clients to see "empty reply from
+	// server" even after the provider has produced a valid response.
+	server.ReadTimeout = inboundServerReadTimeout
+	server.ReadHeaderTimeout = inboundServerReadHeaderTimeout
+	server.WriteTimeout = writeTimeout
+	return nil
 }
 
 func parseBodySizeLimitBytes(limit string) int64 {

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	httppprof "net/http/pprof"
@@ -36,6 +37,7 @@ type Server struct {
 const (
 	inboundServerReadTimeout       = 30 * time.Second
 	inboundServerReadHeaderTimeout = 10 * time.Second
+	inboundServerWriteTimeout      = 30 * time.Second
 )
 
 // Config holds server configuration options
@@ -207,6 +209,7 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 			return next(c)
 		}
 	})
+	e.Use(modelInteractionWriteDeadlineMiddleware())
 
 	// Ingress capture (before auth/audit/model validation so they can consume shared raw request state)
 	e.Use(RequestSnapshotCapture())
@@ -336,7 +339,7 @@ func passthroughV1PrefixNormalizationEnabled(cfg *Config) bool {
 
 // Start starts the HTTP server on the given address and exits when ctx is canceled.
 func (s *Server) Start(ctx context.Context, addr string) error {
-	return newGatewayStartConfig(addr, 0).Start(ctx, s.echo)
+	return newGatewayStartConfig(addr).Start(ctx, s.echo)
 }
 
 // Shutdown releases server resources. The HTTP server itself is stopped by
@@ -354,28 +357,45 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.echo.ServeHTTP(w, r)
 }
 
-func newGatewayStartConfig(addr string, writeTimeout time.Duration) echo.StartConfig {
+func newGatewayStartConfig(addr string) echo.StartConfig {
 	return echo.StartConfig{
 		Address:    addr,
 		HideBanner: true,
 		BeforeServeFunc: func(server *http.Server) error {
-			return configureGatewayHTTPServer(server, writeTimeout)
+			return configureGatewayHTTPServer(server)
 		},
 	}
 }
 
-func configureGatewayHTTPServer(server *http.Server, writeTimeout time.Duration) error {
+func configureGatewayHTTPServer(server *http.Server) error {
 	if server == nil {
 		return nil
 	}
 
-	// Long-running model inference and SSE streams regularly exceed Echo's
-	// default 30s write deadline, which causes clients to see "empty reply from
-	// server" even after the provider has produced a valid response.
+	// Keep an explicit server-wide write timeout for ordinary routes. Long-lived
+	// model interaction routes clear it per request before provider work begins.
 	server.ReadTimeout = inboundServerReadTimeout
 	server.ReadHeaderTimeout = inboundServerReadHeaderTimeout
-	server.WriteTimeout = writeTimeout
+	server.WriteTimeout = inboundServerWriteTimeout
 	return nil
+}
+
+func modelInteractionWriteDeadlineMiddleware() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c *echo.Context) error {
+			if !core.IsModelInteractionPath(c.Request().URL.Path) {
+				return next(c)
+			}
+			if err := http.NewResponseController(c.Response()).SetWriteDeadline(time.Time{}); err != nil && !errors.Is(err, http.ErrNotSupported) {
+				slog.Warn("failed to clear write deadline for model interaction",
+					"path", c.Request().URL.Path,
+					"request_id", requestIDFromContextOrHeader(c.Request()),
+					"error", err,
+				)
+			}
+			return next(c)
+		}
+	}
 }
 
 func parseBodySizeLimitBytes(limit string) int64 {

--- a/internal/server/http_start_test.go
+++ b/internal/server/http_start_test.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestConfigureGatewayHTTPServer_DisablesWriteTimeoutForInference(t *testing.T) {
+	server := &http.Server{
+		ReadTimeout:  time.Second,
+		WriteTimeout: 30 * time.Second,
+	}
+
+	if err := configureGatewayHTTPServer(server, 0); err != nil {
+		t.Fatalf("configureGatewayHTTPServer() error = %v", err)
+	}
+
+	if got := server.ReadTimeout; got != inboundServerReadTimeout {
+		t.Fatalf("ReadTimeout = %v, want %v", got, inboundServerReadTimeout)
+	}
+	if got := server.ReadHeaderTimeout; got != inboundServerReadHeaderTimeout {
+		t.Fatalf("ReadHeaderTimeout = %v, want %v", got, inboundServerReadHeaderTimeout)
+	}
+	if got := server.WriteTimeout; got != 0 {
+		t.Fatalf("WriteTimeout = %v, want 0", got)
+	}
+}
+
+func TestNewGatewayStartConfig_AppliesTimeoutOverrides(t *testing.T) {
+	cfg := newGatewayStartConfig(":0", 0)
+	if cfg.BeforeServeFunc == nil {
+		t.Fatal("BeforeServeFunc = nil, want configured server overrides")
+	}
+
+	server := &http.Server{}
+	if err := cfg.BeforeServeFunc(server); err != nil {
+		t.Fatalf("BeforeServeFunc() error = %v", err)
+	}
+
+	if got := server.ReadTimeout; got != inboundServerReadTimeout {
+		t.Fatalf("ReadTimeout = %v, want %v", got, inboundServerReadTimeout)
+	}
+	if got := server.ReadHeaderTimeout; got != inboundServerReadHeaderTimeout {
+		t.Fatalf("ReadHeaderTimeout = %v, want %v", got, inboundServerReadHeaderTimeout)
+	}
+	if got := server.WriteTimeout; got != 0 {
+		t.Fatalf("WriteTimeout = %v, want 0", got)
+	}
+}

--- a/internal/server/http_start_test.go
+++ b/internal/server/http_start_test.go
@@ -2,17 +2,20 @@ package server
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/labstack/echo/v5"
 )
 
-func TestConfigureGatewayHTTPServer_DisablesWriteTimeoutForInference(t *testing.T) {
+func TestConfigureGatewayHTTPServer_PreservesServerWriteTimeoutDefault(t *testing.T) {
 	server := &http.Server{
 		ReadTimeout:  time.Second,
 		WriteTimeout: 30 * time.Second,
 	}
 
-	if err := configureGatewayHTTPServer(server, 0); err != nil {
+	if err := configureGatewayHTTPServer(server); err != nil {
 		t.Fatalf("configureGatewayHTTPServer() error = %v", err)
 	}
 
@@ -22,13 +25,13 @@ func TestConfigureGatewayHTTPServer_DisablesWriteTimeoutForInference(t *testing.
 	if got := server.ReadHeaderTimeout; got != inboundServerReadHeaderTimeout {
 		t.Fatalf("ReadHeaderTimeout = %v, want %v", got, inboundServerReadHeaderTimeout)
 	}
-	if got := server.WriteTimeout; got != 0 {
-		t.Fatalf("WriteTimeout = %v, want 0", got)
+	if got := server.WriteTimeout; got != inboundServerWriteTimeout {
+		t.Fatalf("WriteTimeout = %v, want %v", got, inboundServerWriteTimeout)
 	}
 }
 
 func TestNewGatewayStartConfig_AppliesTimeoutOverrides(t *testing.T) {
-	cfg := newGatewayStartConfig(":0", 0)
+	cfg := newGatewayStartConfig(":0")
 	if cfg.BeforeServeFunc == nil {
 		t.Fatal("BeforeServeFunc = nil, want configured server overrides")
 	}
@@ -44,7 +47,56 @@ func TestNewGatewayStartConfig_AppliesTimeoutOverrides(t *testing.T) {
 	if got := server.ReadHeaderTimeout; got != inboundServerReadHeaderTimeout {
 		t.Fatalf("ReadHeaderTimeout = %v, want %v", got, inboundServerReadHeaderTimeout)
 	}
-	if got := server.WriteTimeout; got != 0 {
-		t.Fatalf("WriteTimeout = %v, want 0", got)
+	if got := server.WriteTimeout; got != inboundServerWriteTimeout {
+		t.Fatalf("WriteTimeout = %v, want %v", got, inboundServerWriteTimeout)
 	}
+}
+
+func TestModelInteractionWriteDeadlineMiddleware_ClearsDeadlineForModelRoutes(t *testing.T) {
+	e := echo.New()
+	writer := &deadlineTrackingWriter{ResponseRecorder: httptest.NewRecorder()}
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	c := e.NewContext(req, writer)
+
+	handler := modelInteractionWriteDeadlineMiddleware()(func(c *echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	if err := handler(c); err != nil {
+		t.Fatalf("handler() error = %v", err)
+	}
+	if len(writer.deadlines) != 1 {
+		t.Fatalf("deadline calls = %d, want 1", len(writer.deadlines))
+	}
+	if !writer.deadlines[0].IsZero() {
+		t.Fatalf("deadline = %v, want zero time", writer.deadlines[0])
+	}
+}
+
+func TestModelInteractionWriteDeadlineMiddleware_LeavesNonModelRoutesUntouched(t *testing.T) {
+	e := echo.New()
+	writer := &deadlineTrackingWriter{ResponseRecorder: httptest.NewRecorder()}
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	c := e.NewContext(req, writer)
+
+	handler := modelInteractionWriteDeadlineMiddleware()(func(c *echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	if err := handler(c); err != nil {
+		t.Fatalf("handler() error = %v", err)
+	}
+	if len(writer.deadlines) != 0 {
+		t.Fatalf("deadline calls = %d, want 0", len(writer.deadlines))
+	}
+}
+
+type deadlineTrackingWriter struct {
+	*httptest.ResponseRecorder
+	deadlines []time.Time
+}
+
+func (w *deadlineTrackingWriter) SetWriteDeadline(deadline time.Time) error {
+	w.deadlines = append(w.deadlines, deadline)
+	return nil
 }


### PR DESCRIPTION
## Summary
- disable Echo's default 30s inbound write timeout for gateway responses so long chat completions and SSE streams are not cut off mid-response
- log handled gateway failures at WARN/ERROR with request metadata so client-visible failures are also visible in server logs
- add regression coverage for the server timeout override and error logging behavior

## Verification
- go test ./internal/server
- curl http://localhost:8080/v1/chat/completions with model `gpt-5-nano` now returns `200 OK` JSON instead of `curl: (52) Empty reply from server`
- invalid requests now return JSON errors and emit WARN logs with the request id

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling with structured logs that include request context and appropriate severity (warnings for client errors, errors for server/provider issues).

* **New Features**
  * Server now enforces explicit inbound read/header/write timeouts and clears write deadlines for model-interaction requests to improve reliability.

* **Tests**
  * Added unit tests covering error logging, timeout application, and write-deadline behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->