### PR TITLE
fix(providers): keep unavailable providers registered at startup

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -221,7 +221,7 @@ The env var override walk skips maps. `RETRY_MAX_RETRIES` changes the global def
 Setting `CIRCUIT_BREAKER_TIMEOUT=60s` in the environment overrides whatever `timeout` is written in `config.yaml`, regardless of order or file contents.
 
 **Ollama is always active.**
-Ollama requires no API key. Even with no YAML and no `OLLAMA_BASE_URL` set, an Ollama provider is registered pointing at `http://localhost:11434/v1`. If you do not want Ollama, make sure no Ollama instance is reachable at that address (the gateway's availability check will remove it from routing if it cannot be reached).
+Ollama requires no API key. Even with no YAML and no `OLLAMA_BASE_URL` set, an Ollama provider is registered pointing at `http://localhost:11434/v1`. If it is unreachable at startup, the gateway still starts and keeps retrying model discovery on the configured refresh interval.
 
 **Azure requires both key and base URL.**
 `AZURE_API_KEY` alone is not enough for auto-discovery. Set `AZURE_BASE_URL` to the Azure deployment endpoint as well, otherwise the provider is ignored.

--- a/internal/core/interfaces.go
+++ b/internal/core/interfaces.go
@@ -123,11 +123,12 @@ type ProviderNameTypeResolver interface {
 	GetProviderTypeForName(providerName string) string
 }
 
-// AvailabilityChecker is an optional interface for providers that need
-// to verify service availability before registration.
+// AvailabilityChecker is an optional interface for providers that can report
+// backend reachability during startup diagnostics.
 type AvailabilityChecker interface {
 	// CheckAvailability verifies the provider's backend service is reachable.
-	// Returns nil if available, error otherwise.
+	// Returns nil if available, error otherwise. Initialization logs failures but
+	// keeps the provider registered so later refreshes can retry discovery.
 	CheckAvailability(ctx context.Context) error
 }
 

--- a/internal/providers/init.go
+++ b/internal/providers/init.go
@@ -72,6 +72,9 @@ func Init(ctx context.Context, result *config.LoadResult, factory *ProviderFacto
 	if factory == nil {
 		return nil, fmt.Errorf("factory is required")
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
 	providerMap, credentialResolved := resolveProviders(result.RawProviders, result.Config.Resilience, factory.discoveryConfigsSnapshot())
 
@@ -217,11 +220,7 @@ func initializeProviders(ctx context.Context, providerMap map[string]ProviderCon
 		// Availability checks are diagnostics only. Providers stay registered so
 		// async initialization and periodic refresh can discover them later.
 		if checker, ok := p.(core.AvailabilityChecker); ok {
-			probeParent := ctx
-			if probeParent == nil {
-				probeParent = context.Background()
-			}
-			probeCtx, cancel := context.WithTimeout(probeParent, 5*time.Second)
+			probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			if err := checker.CheckAvailability(probeCtx); err != nil {
 				slog.Warn("provider unavailable at startup; keeping registered for refresh",
 					"name", name,

--- a/internal/providers/init.go
+++ b/internal/providers/init.go
@@ -83,7 +83,7 @@ func Init(ctx context.Context, result *config.LoadResult, factory *ProviderFacto
 	registry := NewModelRegistry()
 	registry.SetCache(modelCache)
 
-	count, err := initializeProviders(providerMap, factory, registry)
+	count, err := initializeProviders(ctx, providerMap, factory, registry)
 	if err != nil {
 		modelCache.Close()
 		return nil, err
@@ -194,7 +194,7 @@ func initCache(cfg *config.Config) (modelcache.Cache, error) {
 
 // initializeProviders instantiates and registers all resolved providers.
 // Returns the count of successfully registered providers.
-func initializeProviders(providerMap map[string]ProviderConfig, factory *ProviderFactory, registry *ModelRegistry) (int, error) {
+func initializeProviders(ctx context.Context, providerMap map[string]ProviderConfig, factory *ProviderFactory, registry *ModelRegistry) (int, error) {
 	// Sort provider names for deterministic initialization order
 	names := make([]string, 0, len(providerMap))
 	for name := range providerMap {
@@ -217,8 +217,12 @@ func initializeProviders(providerMap map[string]ProviderConfig, factory *Provide
 		// Availability checks are diagnostics only. Providers stay registered so
 		// async initialization and periodic refresh can discover them later.
 		if checker, ok := p.(core.AvailabilityChecker); ok {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			if err := checker.CheckAvailability(ctx); err != nil {
+			probeParent := ctx
+			if probeParent == nil {
+				probeParent = context.Background()
+			}
+			probeCtx, cancel := context.WithTimeout(probeParent, 5*time.Second)
+			if err := checker.CheckAvailability(probeCtx); err != nil {
 				slog.Warn("provider unavailable at startup; keeping registered for refresh",
 					"name", name,
 					"type", pCfg.Type,

--- a/internal/providers/init.go
+++ b/internal/providers/init.go
@@ -193,7 +193,7 @@ func initCache(cfg *config.Config) (modelcache.Cache, error) {
 }
 
 // initializeProviders instantiates and registers all resolved providers.
-// Returns the count of successfully initialized providers.
+// Returns the count of successfully registered providers.
 func initializeProviders(providerMap map[string]ProviderConfig, factory *ProviderFactory, registry *ModelRegistry) (int, error) {
 	// Sort provider names for deterministic initialization order
 	names := make([]string, 0, len(providerMap))
@@ -214,23 +214,22 @@ func initializeProviders(providerMap map[string]ProviderConfig, factory *Provide
 			continue
 		}
 
-		// Check availability for providers that support it
+		// Availability checks are diagnostics only. Providers stay registered so
+		// async initialization and periodic refresh can discover them later.
 		if checker, ok := p.(core.AvailabilityChecker); ok {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			if err := checker.CheckAvailability(ctx); err != nil {
-				slog.Warn("provider not available, skipping",
+				slog.Warn("provider unavailable at startup; keeping registered for refresh",
 					"name", name,
 					"type", pCfg.Type,
 					"reason", err.Error())
-				cancel()
-				continue
 			}
 			cancel()
 		}
 
 		registry.RegisterProviderWithNameAndType(p, name, pCfg.Type)
 		count++
-		slog.Info("provider initialized", "name", name, "type", pCfg.Type)
+		slog.Info("provider registered", "name", name, "type", pCfg.Type)
 	}
 
 	return count, nil

--- a/internal/providers/init.go
+++ b/internal/providers/init.go
@@ -90,7 +90,7 @@ func Init(ctx context.Context, result *config.LoadResult, factory *ProviderFacto
 	}
 	if count == 0 {
 		modelCache.Close()
-		return nil, fmt.Errorf("no providers were successfully initialized")
+		return nil, fmt.Errorf("no providers were successfully registered")
 	}
 
 	slog.Info("starting non-blocking model registry initialization...")

--- a/internal/providers/init_test.go
+++ b/internal/providers/init_test.go
@@ -5,9 +5,14 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"gomodel/config"
 	"gomodel/internal/cache/modelcache"
@@ -166,6 +171,105 @@ func TestInit_AllowsStartupWhenProviderIsUnavailable(t *testing.T) {
 	}
 	if got := result.Registry.ProviderByType("test"); got != provider {
 		t.Fatal("ProviderByType(test) = nil or wrong provider, want registered unavailable provider")
+	}
+}
+
+func TestInit_NormalizesNilContext(t *testing.T) {
+	nilInitContext := func() context.Context {
+		return nil
+	}
+
+	cacheDir, err := os.MkdirTemp("", "gomodel-init-nil-context-*")
+	if err != nil {
+		t.Fatalf("os.MkdirTemp() error = %v, want nil", err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(cacheDir)
+	})
+
+	modelListFetched := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case modelListFetched <- struct{}{}:
+		default:
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"version":1,"updated_at":"2026-04-10T00:00:00Z","providers":{},"models":{},"provider_models":{}}`)
+	}))
+	defer server.Close()
+
+	provider := &initTestProvider{
+		modelsResponse: &core.ModelsResponse{
+			Object: "list",
+			Data: []core.Model{
+				{ID: "test-model", Object: "model", OwnedBy: "test"},
+			},
+		},
+	}
+
+	factory := NewProviderFactory()
+	factory.Add(Registration{
+		Type: "test",
+		New: func(ProviderConfig, ProviderOptions) core.Provider {
+			return provider
+		},
+	})
+
+	result, err := Init(nilInitContext(), &config.LoadResult{
+		Config: &config.Config{
+			Cache: config.CacheConfig{
+				Model: config.ModelCacheConfig{
+					RefreshInterval: 1,
+					ModelList: config.ModelListConfig{
+						URL: server.URL,
+					},
+					Local: &config.LocalCacheConfig{
+						CacheDir: cacheDir,
+					},
+				},
+			},
+		},
+		RawProviders: map[string]config.RawProviderConfig{
+			"test": {
+				Type:   "test",
+				APIKey: "sk-test",
+			},
+		},
+	}, factory)
+	if err != nil {
+		t.Fatalf("Init() error = %v, want nil", err)
+	}
+	defer func() {
+		_ = result.Close()
+	}()
+
+	select {
+	case <-modelListFetched:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected Init(nil, ...) to fetch the model list without a nil-context panic")
+	}
+
+	cacheFile := filepath.Join(cacheDir, "models.json")
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if result.Registry.IsInitialized() {
+			if _, err := os.Stat(cacheFile); err == nil {
+				if _, err := os.Stat(cacheFile + ".tmp"); os.IsNotExist(err) {
+					return
+				}
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if !result.Registry.IsInitialized() {
+		t.Fatal("expected Init(nil, ...) to complete background registry initialization")
+	}
+	if _, err := os.Stat(cacheFile); err != nil {
+		t.Fatalf("expected Init(nil, ...) to persist the cache file, stat error = %v", err)
+	}
+	if _, err := os.Stat(cacheFile + ".tmp"); !os.IsNotExist(err) {
+		t.Fatalf("expected no in-progress cache temp file, stat error = %v", err)
 	}
 }
 

--- a/internal/providers/init_test.go
+++ b/internal/providers/init_test.go
@@ -3,11 +3,14 @@ package providers
 import (
 	"context"
 	"errors"
+	"io"
 	"sync"
 	"sync/atomic"
 	"testing"
 
+	"gomodel/config"
 	"gomodel/internal/cache/modelcache"
+	"gomodel/internal/core"
 )
 
 type mockInitCache struct {
@@ -70,5 +73,137 @@ func TestInitResultClose_NilReceiver(t *testing.T) {
 	var result *InitResult
 	if err := result.Close(); err != nil {
 		t.Fatalf("Close() error = %v, want nil", err)
+	}
+}
+
+type initTestProvider struct {
+	availabilityErr error
+	listModelsErr   error
+	modelsResponse  *core.ModelsResponse
+}
+
+func (p *initTestProvider) CheckAvailability(context.Context) error {
+	return p.availabilityErr
+}
+
+func (p *initTestProvider) ChatCompletion(context.Context, *core.ChatRequest) (*core.ChatResponse, error) {
+	return &core.ChatResponse{}, nil
+}
+
+func (p *initTestProvider) StreamChatCompletion(context.Context, *core.ChatRequest) (io.ReadCloser, error) {
+	return io.NopCloser(nil), nil
+}
+
+func (p *initTestProvider) ListModels(context.Context) (*core.ModelsResponse, error) {
+	if p.listModelsErr != nil {
+		return nil, p.listModelsErr
+	}
+	if p.modelsResponse != nil {
+		return p.modelsResponse, nil
+	}
+	return &core.ModelsResponse{Object: "list"}, nil
+}
+
+func (p *initTestProvider) Responses(context.Context, *core.ResponsesRequest) (*core.ResponsesResponse, error) {
+	return &core.ResponsesResponse{}, nil
+}
+
+func (p *initTestProvider) StreamResponses(context.Context, *core.ResponsesRequest) (io.ReadCloser, error) {
+	return io.NopCloser(nil), nil
+}
+
+func (p *initTestProvider) Embeddings(context.Context, *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	return &core.EmbeddingResponse{}, nil
+}
+
+func TestInit_AllowsStartupWhenProviderIsUnavailable(t *testing.T) {
+	provider := &initTestProvider{
+		availabilityErr: errors.New("startup unavailable"),
+		listModelsErr:   errors.New("models unavailable"),
+	}
+
+	factory := NewProviderFactory()
+	factory.Add(Registration{
+		Type: "test",
+		New: func(ProviderConfig, ProviderOptions) core.Provider {
+			return provider
+		},
+	})
+
+	result, err := Init(context.Background(), &config.LoadResult{
+		Config: &config.Config{
+			Cache: config.CacheConfig{
+				Model: config.ModelCacheConfig{
+					RefreshInterval: 1,
+					Local: &config.LocalCacheConfig{
+						CacheDir: t.TempDir(),
+					},
+				},
+			},
+		},
+		RawProviders: map[string]config.RawProviderConfig{
+			"test": {
+				Type:   "test",
+				APIKey: "sk-test",
+			},
+		},
+	}, factory)
+	if err != nil {
+		t.Fatalf("Init() error = %v, want nil", err)
+	}
+	t.Cleanup(func() {
+		_ = result.Close()
+	})
+
+	if got := result.Registry.ProviderCount(); got != 1 {
+		t.Fatalf("ProviderCount() = %d, want 1", got)
+	}
+	if got := result.Registry.ProviderByType("test"); got != provider {
+		t.Fatal("ProviderByType(test) = nil or wrong provider, want registered unavailable provider")
+	}
+}
+
+func TestInitializeProviders_UnavailableProviderCanRefreshLater(t *testing.T) {
+	provider := &initTestProvider{
+		availabilityErr: errors.New("startup unavailable"),
+		listModelsErr:   errors.New("models unavailable"),
+	}
+
+	factory := NewProviderFactory()
+	factory.Add(Registration{
+		Type: "test",
+		New: func(ProviderConfig, ProviderOptions) core.Provider {
+			return provider
+		},
+	})
+
+	registry := NewModelRegistry()
+	count, err := initializeProviders(map[string]ProviderConfig{
+		"test": {Type: "test", APIKey: "sk-test"},
+	}, factory, registry)
+	if err != nil {
+		t.Fatalf("initializeProviders() error = %v, want nil", err)
+	}
+	if count != 1 {
+		t.Fatalf("initializeProviders() count = %d, want 1", count)
+	}
+
+	if err := registry.Refresh(context.Background()); err == nil {
+		t.Fatal("Refresh() error = nil, want startup failure while provider models are unavailable")
+	}
+
+	provider.listModelsErr = nil
+	provider.modelsResponse = &core.ModelsResponse{
+		Object: "list",
+		Data: []core.Model{
+			{ID: "later-model", Object: "model", OwnedBy: "test"},
+		},
+	}
+
+	if err := registry.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() after recovery error = %v, want nil", err)
+	}
+	if !registry.Supports("later-model") {
+		t.Fatal("expected later-model to be discoverable after refresh")
 	}
 }

--- a/internal/providers/init_test.go
+++ b/internal/providers/init_test.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -77,12 +78,16 @@ func TestInitResultClose_NilReceiver(t *testing.T) {
 }
 
 type initTestProvider struct {
-	availabilityErr error
-	listModelsErr   error
-	modelsResponse  *core.ModelsResponse
+	availabilityErr   error
+	checkAvailability func(context.Context) error
+	listModelsErr     error
+	modelsResponse    *core.ModelsResponse
 }
 
-func (p *initTestProvider) CheckAvailability(context.Context) error {
+func (p *initTestProvider) CheckAvailability(ctx context.Context) error {
+	if p.checkAvailability != nil {
+		return p.checkAvailability(ctx)
+	}
 	return p.availabilityErr
 }
 
@@ -91,7 +96,7 @@ func (p *initTestProvider) ChatCompletion(context.Context, *core.ChatRequest) (*
 }
 
 func (p *initTestProvider) StreamChatCompletion(context.Context, *core.ChatRequest) (io.ReadCloser, error) {
-	return io.NopCloser(nil), nil
+	return io.NopCloser(bytes.NewReader(nil)), nil
 }
 
 func (p *initTestProvider) ListModels(context.Context) (*core.ModelsResponse, error) {
@@ -109,7 +114,7 @@ func (p *initTestProvider) Responses(context.Context, *core.ResponsesRequest) (*
 }
 
 func (p *initTestProvider) StreamResponses(context.Context, *core.ResponsesRequest) (io.ReadCloser, error) {
-	return io.NopCloser(nil), nil
+	return io.NopCloser(bytes.NewReader(nil)), nil
 }
 
 func (p *initTestProvider) Embeddings(context.Context, *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
@@ -117,6 +122,7 @@ func (p *initTestProvider) Embeddings(context.Context, *core.EmbeddingRequest) (
 }
 
 func TestInit_AllowsStartupWhenProviderIsUnavailable(t *testing.T) {
+	ctx := t.Context()
 	provider := &initTestProvider{
 		availabilityErr: errors.New("startup unavailable"),
 		listModelsErr:   errors.New("models unavailable"),
@@ -130,7 +136,7 @@ func TestInit_AllowsStartupWhenProviderIsUnavailable(t *testing.T) {
 		},
 	})
 
-	result, err := Init(context.Background(), &config.LoadResult{
+	result, err := Init(ctx, &config.LoadResult{
 		Config: &config.Config{
 			Cache: config.CacheConfig{
 				Model: config.ModelCacheConfig{
@@ -164,6 +170,7 @@ func TestInit_AllowsStartupWhenProviderIsUnavailable(t *testing.T) {
 }
 
 func TestInitializeProviders_UnavailableProviderCanRefreshLater(t *testing.T) {
+	ctx := t.Context()
 	provider := &initTestProvider{
 		availabilityErr: errors.New("startup unavailable"),
 		listModelsErr:   errors.New("models unavailable"),
@@ -178,7 +185,7 @@ func TestInitializeProviders_UnavailableProviderCanRefreshLater(t *testing.T) {
 	})
 
 	registry := NewModelRegistry()
-	count, err := initializeProviders(map[string]ProviderConfig{
+	count, err := initializeProviders(ctx, map[string]ProviderConfig{
 		"test": {Type: "test", APIKey: "sk-test"},
 	}, factory, registry)
 	if err != nil {
@@ -188,7 +195,7 @@ func TestInitializeProviders_UnavailableProviderCanRefreshLater(t *testing.T) {
 		t.Fatalf("initializeProviders() count = %d, want 1", count)
 	}
 
-	if err := registry.Refresh(context.Background()); err == nil {
+	if err := registry.Refresh(ctx); err == nil {
 		t.Fatal("Refresh() error = nil, want startup failure while provider models are unavailable")
 	}
 
@@ -200,10 +207,45 @@ func TestInitializeProviders_UnavailableProviderCanRefreshLater(t *testing.T) {
 		},
 	}
 
-	if err := registry.Refresh(context.Background()); err != nil {
+	if err := registry.Refresh(ctx); err != nil {
 		t.Fatalf("Refresh() after recovery error = %v, want nil", err)
 	}
 	if !registry.Supports("later-model") {
 		t.Fatal("expected later-model to be discoverable after refresh")
+	}
+}
+
+func TestInitializeProviders_AvailabilityCheckUsesCallerContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	var checkErr error
+	provider := &initTestProvider{
+		checkAvailability: func(ctx context.Context) error {
+			checkErr = ctx.Err()
+			return ctx.Err()
+		},
+	}
+
+	factory := NewProviderFactory()
+	factory.Add(Registration{
+		Type: "test",
+		New: func(ProviderConfig, ProviderOptions) core.Provider {
+			return provider
+		},
+	})
+
+	registry := NewModelRegistry()
+	count, err := initializeProviders(ctx, map[string]ProviderConfig{
+		"test": {Type: "test", APIKey: "sk-test"},
+	}, factory, registry)
+	if err != nil {
+		t.Fatalf("initializeProviders() error = %v, want nil", err)
+	}
+	if count != 1 {
+		t.Fatalf("initializeProviders() count = %d, want 1", count)
+	}
+	if !errors.Is(checkErr, context.Canceled) {
+		t.Fatalf("CheckAvailability() context error = %v, want %v", checkErr, context.Canceled)
 	}
 }


### PR DESCRIPTION
## Summary
- keep providers registered even when the startup availability probe fails
- allow async initialization and periodic refresh to discover models after the backend becomes reachable
- add regression coverage for startup and later refresh recovery, and update the startup behavior note in the docs

## Testing
- go test ./internal/providers
- repo pre-commit checks run during git commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Providers stay registered at startup even if backends are temporarily unreachable; the system keeps retrying model discovery on the configured refresh interval and reports availability as diagnostic-only.

* **Documentation**
  * Clarified startup behavior in Getting Started: gateway still starts when backends are unreachable and will continue retry attempts.

* **Tests**
  * Added tests ensuring resilient startup registration, retry behavior, and correct handling of caller-provided initialization contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->