### PR TITLE
fix(docker): stamp release image metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,17 @@ jobs:
             type=semver,pattern={{major}}
             type=raw,value=latest
 
+      - name: Set build metadata
+        id: build_meta
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          {
+            echo "version=${version}"
+            echo "commit=${GITHUB_SHA}"
+            echo "date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@v7
         with:
@@ -72,5 +83,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.build_meta.outputs.version }}
+            COMMIT=${{ steps.build_meta.outputs.commit }}
+            DATE=${{ steps.build_meta.outputs.date }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,12 @@ RUN go mod download
 
 # Copy source and cross-compile for the target platform
 COPY . .
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build -ldflags="-s -w" -o /gomodel ./cmd/gomodel
+ARG VERSION=dev
+ARG COMMIT=none
+ARG DATE=unknown
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build \
+	-ldflags="-s -w -X gomodel/internal/version.Version=${VERSION} -X gomodel/internal/version.Commit=${COMMIT} -X gomodel/internal/version.Date=${DATE}" \
+	-o /gomodel ./cmd/gomodel
 
 # Create .cache and data directories for runtime (with placeholder for COPY)
 RUN mkdir -p /app/.cache /app/data && touch /app/.cache/.keep /app/data/.keep


### PR DESCRIPTION
## Summary
- pass VERSION, COMMIT, and DATE build args into Docker image builds
- derive release Docker metadata from the pushed tag, GitHub SHA, and UTC build time

## Verification
- go test ./cmd/gomodel ./internal/version
- docker build --build-arg VERSION=0.1.15 --build-arg COMMIT=824a135e93b650e87d24e7bae3045dc3abdfe39f --build-arg DATE=2026-04-11T13:46:26Z -t gomodel:metadata-test .
- docker run --rm gomodel:metadata-test -version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker images now include version, commit hash, and build date information in the compiled binary for improved traceability during deployment and debugging.
  * Build pipeline enhanced to automatically compute and include metadata with each image release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->