### PR TITLE
chore(e2e): fix release validation checks

### DIFF
--- a/internal/admin/handler_executionplans_test.go
+++ b/internal/admin/handler_executionplans_test.go
@@ -413,6 +413,23 @@ func TestGetExecutionPlan(t *testing.T) {
 		t.Fatalf("status = %d, want 200", rec.Code)
 	}
 
+	var rawBody map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &rawBody); err != nil {
+		t.Fatalf("unmarshal raw response: %v", err)
+	}
+	var effectiveFeatures map[string]bool
+	if err := json.Unmarshal(rawBody["effective_features"], &effectiveFeatures); err != nil {
+		t.Fatalf("unmarshal effective_features: %v", err)
+	}
+	for _, key := range []string{"cache", "audit", "usage", "guardrails", "fallback"} {
+		if _, ok := effectiveFeatures[key]; !ok {
+			t.Fatalf("effective_features missing lower-case key %q: %s", key, rec.Body.String())
+		}
+	}
+	if _, ok := effectiveFeatures["Cache"]; ok {
+		t.Fatalf("effective_features leaked Go field key %q: %s", "Cache", rec.Body.String())
+	}
+
 	var body executionplans.View
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("unmarshal response: %v", err)

--- a/internal/core/execution_plan.go
+++ b/internal/core/execution_plan.go
@@ -93,11 +93,11 @@ func NewExecutionPlanSelector(provider, model string, userPath ...string) Execut
 // ExecutionFeatures stores resolved per-request feature flags sourced from the
 // matched persisted execution plan.
 type ExecutionFeatures struct {
-	Cache      bool
-	Audit      bool
-	Usage      bool
-	Guardrails bool
-	Fallback   bool
+	Cache      bool `json:"cache"`
+	Audit      bool `json:"audit"`
+	Usage      bool `json:"usage"`
+	Guardrails bool `json:"guardrails"`
+	Fallback   bool `json:"fallback"`
 }
 
 // ApplyUpperBound returns features with process-level caps applied.

--- a/tests/e2e/release-e2e-scenarios.md
+++ b/tests/e2e/release-e2e-scenarios.md
@@ -102,7 +102,7 @@ export QA_AUTH_REQ2="qa-auth-cacheoff-$QA_SUFFIX-2"
 export QA_CACHE_REQ1="qa-cache-exact-$QA_SUFFIX-1"
 export QA_CACHE_REQ2="qa-cache-exact-$QA_SUFFIX-2"
 export QA_DEACTIVATED_REQ="qa-auth-deactivated-$QA_SUFFIX"
-export QA_CACHE_REPLY="QA_CACHE_EXACT_OK_$QA_SUFFIX"
+export QA_CACHE_REPLY="QA_CACHE_EXACT_OK"
 
 cleanup_release_auth_artifacts() {
   rm -f "$QA_AUTH_KEY_JSON" "$QA_AUTH_KEY_VALUE_FILE" "$QA_WORKFLOW_JSON" "$QA_WORKFLOW_ID_FILE"

--- a/tests/e2e/run-release-e2e.sh
+++ b/tests/e2e/run-release-e2e.sh
@@ -128,7 +128,9 @@ run_with_timeout() {
   local watchdog=$!
 
   local status=0
-  if ! wait "$pid"; then
+  if wait "$pid"; then
+    status=0
+  else
     status=$?
   fi
 


### PR DESCRIPTION
## Summary
- preserve real release e2e scenario exit codes in the runner
- serialize execution-plan effective feature flags with lower-case JSON keys and cover it with an API test
- keep the exact-cache release scenario reply short so it fits its token budget while preserving per-run isolation via request IDs and user path

## Tests
- go test ./internal/core ./internal/executionplans ./internal/admin
- bash -n tests/e2e/run-release-e2e.sh
- tests/e2e/run-release-e2e.sh --list
- pre-commit hooks: go unit test, make lint, hot-path performance guard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized execution plan API response format to use lowercase field names for feature flags (`cache`, `audit`, `usage`, `guardrails`, `fallback`).

* **Tests**
  * Enhanced validation of feature flag response format in execution plan tests.
  * Improved test infrastructure reliability for script-based test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->