### PR TITLE
feat(admin): add runtime refresh button

### DIFF
--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -2920,6 +2920,12 @@ body.conversation-drawer-open {
     margin-bottom: 0;
 }
 
+.settings-refresh-loading {
+    justify-content: flex-start;
+    min-height: 52px;
+    margin-top: 14px;
+}
+
 .runtime-refresh-steps {
     display: grid;
     gap: 8px;
@@ -2933,9 +2939,12 @@ body.conversation-drawer-open {
     color: var(--success);
 }
 
-.runtime-refresh-step.is-partial,
-.runtime-refresh-step.is-failed {
+.runtime-refresh-step.is-partial {
     color: var(--warning);
+}
+
+.runtime-refresh-step.is-failed {
+    color: var(--danger);
 }
 
 .page-subtitle {

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -2877,6 +2877,51 @@ body.conversation-drawer-open {
     width: 100%;
 }
 
+.settings-refresh-section {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    margin-top: 24px;
+    padding-top: 22px;
+    border-top: 1px solid var(--border);
+}
+
+.settings-refresh-section h3 {
+    margin-bottom: 6px;
+    font-size: 18px;
+}
+
+.settings-refresh-section p {
+    max-width: 720px;
+    color: var(--text-muted);
+    font-size: 14px;
+    line-height: 1.55;
+}
+
+.settings-refresh-alert {
+    margin-top: 16px;
+    margin-bottom: 0;
+}
+
+.runtime-refresh-steps {
+    display: grid;
+    gap: 8px;
+    margin-top: 14px;
+    padding-left: 18px;
+    color: var(--text-muted);
+    font-size: 13px;
+}
+
+.runtime-refresh-step.is-ok {
+    color: var(--success);
+}
+
+.runtime-refresh-step.is-partial,
+.runtime-refresh-step.is-failed {
+    color: var(--warning);
+}
+
 .page-subtitle {
     margin-top: 6px;
     color: var(--text-muted);
@@ -3241,6 +3286,9 @@ body.conversation-drawer-open {
     }
     .settings-form-grid {
         grid-template-columns: 1fr;
+    }
+    .settings-refresh-section {
+        flex-direction: column;
     }
 
     /* Date picker mobile */

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -350,17 +350,19 @@ function dashboard() {
                     headers: this.headers()
                 });
                 if (!this.handleFetchResponse(res, 'runtime refresh')) {
-                    this.runtimeRefreshError = 'Runtime refresh failed.';
+                    this.runtimeRefreshNotice = 'Runtime refresh failed.';
+                    this.runtimeRefreshError = this.runtimeRefreshNotice;
                     return;
                 }
 
                 const payload = await res.json();
                 this.runtimeRefreshReport = payload && typeof payload === 'object' ? payload : null;
-                this.runtimeRefreshNotice = this.runtimeRefreshSummary(this.runtimeRefreshReport);
+                this.runtimeRefreshNotice = this.runtimeRefreshSummary();
                 await this.refreshDashboardDataAfterRuntimeRefresh();
             } catch (e) {
                 console.error('Failed to refresh runtime:', e);
-                this.runtimeRefreshError = 'Runtime refresh failed.';
+                this.runtimeRefreshNotice = 'Runtime refresh failed.';
+                this.runtimeRefreshError = this.runtimeRefreshNotice;
             } finally {
                 this.runtimeRefreshLoading = false;
             }
@@ -383,13 +385,19 @@ function dashboard() {
             await Promise.all(requests);
         },
 
-        runtimeRefreshSummary(report) {
+        runtimeRefreshStatus() {
+            const report = this.runtimeRefreshReport;
+            return String((report && report.status) || 'ok').toLowerCase();
+        },
+
+        runtimeRefreshSummary() {
+            const report = this.runtimeRefreshReport;
             if (!report || typeof report !== 'object') {
                 return 'Runtime refresh completed.';
             }
             const modelCount = Number(report.model_count || 0);
             const providerCount = Number(report.provider_count || 0);
-            const status = String(report.status || 'ok').toLowerCase();
+            const status = this.runtimeRefreshStatus();
             const prefix = status === 'ok'
                 ? 'Runtime refreshed.'
                 : status === 'partial'
@@ -400,11 +408,11 @@ function dashboard() {
         },
 
         runtimeRefreshSucceeded() {
-            return this.runtimeRefreshReport && String(this.runtimeRefreshReport.status || '').toLowerCase() === 'ok';
+            return Boolean(this.runtimeRefreshReport) && this.runtimeRefreshStatus() === 'ok';
         },
 
         runtimeRefreshWarnings() {
-            return this.runtimeRefreshReport && String(this.runtimeRefreshReport.status || '').toLowerCase() !== 'ok';
+            return Boolean(this.runtimeRefreshReport) && this.runtimeRefreshStatus() !== 'ok';
         },
 
         runtimeRefreshStepLabel(step) {

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -31,6 +31,10 @@ function dashboard() {
         theme: 'system',
         sidebarCollapsed: false,
         settingsSubpage: 'general',
+        runtimeRefreshLoading: false,
+        runtimeRefreshNotice: '',
+        runtimeRefreshError: '',
+        runtimeRefreshReport: null,
 
         // Date picker
         datePickerOpen: false,
@@ -300,10 +304,7 @@ function dashboard() {
             return Boolean(error) && (error.name === 'AbortError' || error.code === 20);
         },
 
-        async fetchAll() {
-            this.loading = true;
-            this.authError = false;
-            this.needsAuth = false;
+        dashboardDataFetches() {
             const requests = [this.fetchUsage(), this.fetchModels(), this.fetchCategories()];
             if (typeof this.fetchProviderStatus === 'function') {
                 requests.push(this.fetchProviderStatus());
@@ -320,8 +321,97 @@ function dashboard() {
             if (this.hasCalendarModule && typeof this.fetchCalendarData === 'function') {
                 requests.push(this.fetchCalendarData());
             }
+            return requests;
+        },
+
+        async fetchAll() {
+            this.loading = true;
+            this.authError = false;
+            this.needsAuth = false;
+            const requests = this.dashboardDataFetches();
             await Promise.all(requests);
             this.loading = false;
+        },
+
+        async refreshRuntime() {
+            if (this.runtimeRefreshLoading) {
+                return;
+            }
+            this.runtimeRefreshLoading = true;
+            this.runtimeRefreshNotice = '';
+            this.runtimeRefreshError = '';
+            this.runtimeRefreshReport = null;
+
+            try {
+                const res = await fetch('/admin/api/v1/runtime/refresh', {
+                    method: 'POST',
+                    headers: this.headers()
+                });
+                if (!this.handleFetchResponse(res, 'runtime refresh')) {
+                    this.runtimeRefreshError = 'Runtime refresh failed.';
+                    return;
+                }
+
+                const payload = await res.json();
+                this.runtimeRefreshReport = payload && typeof payload === 'object' ? payload : null;
+                this.runtimeRefreshNotice = this.runtimeRefreshSummary(this.runtimeRefreshReport);
+                await this.refreshDashboardDataAfterRuntimeRefresh();
+            } catch (e) {
+                console.error('Failed to refresh runtime:', e);
+                this.runtimeRefreshError = 'Runtime refresh failed.';
+            } finally {
+                this.runtimeRefreshLoading = false;
+            }
+        },
+
+        async refreshDashboardDataAfterRuntimeRefresh() {
+            const requests = this.dashboardDataFetches();
+            if (this.page === 'audit-logs' && typeof this.fetchAuditLog === 'function') {
+                requests.push(this.fetchAuditLog(true));
+            }
+            if (this.page === 'auth-keys' && typeof this.fetchAuthKeys === 'function') {
+                requests.push(this.fetchAuthKeys());
+            }
+            if (this.page === 'guardrails' && typeof this.fetchGuardrailsPage === 'function') {
+                requests.push(this.fetchGuardrailsPage());
+            }
+            if (this.page === 'usage' && typeof this.fetchUsagePage === 'function') {
+                requests.push(this.fetchUsagePage());
+            }
+            await Promise.all(requests);
+        },
+
+        runtimeRefreshSummary(report) {
+            if (!report || typeof report !== 'object') {
+                return 'Runtime refresh completed.';
+            }
+            const modelCount = Number(report.model_count || 0);
+            const providerCount = Number(report.provider_count || 0);
+            const status = String(report.status || 'ok').toLowerCase();
+            const prefix = status === 'ok'
+                ? 'Runtime refreshed.'
+                : status === 'partial'
+                    ? 'Runtime refresh completed with warnings.'
+                    : 'Runtime refresh failed.';
+            return prefix + ' ' + modelCount + ' model' + (modelCount === 1 ? '' : 's') +
+                ' across ' + providerCount + ' provider' + (providerCount === 1 ? '' : 's') + '.';
+        },
+
+        runtimeRefreshSucceeded() {
+            return this.runtimeRefreshReport && String(this.runtimeRefreshReport.status || '').toLowerCase() === 'ok';
+        },
+
+        runtimeRefreshWarnings() {
+            return this.runtimeRefreshReport && String(this.runtimeRefreshReport.status || '').toLowerCase() !== 'ok';
+        },
+
+        runtimeRefreshStepLabel(step) {
+            const name = String(step && step.name || '').replace(/_/g, ' ');
+            const status = String(step && step.status || '').trim();
+            const detail = String((step && (step.error || step.message)) || '').trim();
+            if (!name) return detail || status || '';
+            if (!detail) return name + ': ' + status;
+            return name + ': ' + status + ' - ' + detail;
         },
 
         handleFetchResponse(res, label) {

--- a/internal/admin/dashboard/static/js/modules/dashboard-layout.test.js
+++ b/internal/admin/dashboard/static/js/modules/dashboard-layout.test.js
@@ -142,7 +142,8 @@ test('dashboard pages reuse a shared auth banner template', () => {
     );
 
     const authBannerCalls = indexTemplate.match(/{{template "auth-banner" \.}}/g) || [];
-    assert.equal(authBannerCalls.length, 7);
+    assert.equal(authBannerCalls.length, 8);
+    assert.match(indexTemplate, /<template x-if="page==='settings'">\s*<div>[\s\S]*{{template "auth-banner" \.}}/);
     assert.match(indexTemplate, /<template x-if="page==='guardrails'">\s*<div>[\s\S]*{{template "auth-banner" \.}}/);
     assert.doesNotMatch(
         indexTemplate,
@@ -316,12 +317,12 @@ test('alias rows use a shared icon-only edit action', () => {
     const indexTemplate = readFixture('../../../templates/index.html');
     const modelTableTemplate = readFixture('../../../templates/model-table-body.html');
     const editIconTemplate = readFixture('../../../templates/edit-icon.html');
-    const templates = indexTemplate + '\n' + modelTableTemplate;
 
     assert.match(
-        templates,
+        modelTableTemplate,
         /class="table-action-btn table-icon-btn"[\s\S]*:aria-label="'Edit alias ' \+ row\.alias\.name"[\s\S]*@click="openAliasEdit\(row\.alias\)"[\s\S]*{{template "edit-icon"}}/
     );
+    assert.match(indexTemplate, /{{template "model-table-body" \.}}/);
     assert.match(indexTemplate, /x-show="modelOverrideFormOpen" x-ref="modelOverrideEditor"/);
     assert.doesNotMatch(indexTemplate, /Model overrides feature is unavailable\./);
     assert.doesNotMatch(indexTemplate, /!modelOverridesAvailable && !authError/);

--- a/internal/admin/dashboard/static/js/modules/dashboard-layout.test.js
+++ b/internal/admin/dashboard/static/js/modules/dashboard-layout.test.js
@@ -288,10 +288,12 @@ test('audit entry metadata is rendered as a labeled pill row at the bottom of th
 
 test('alias rows use a shared icon-only edit action', () => {
     const indexTemplate = readFixture('../../../templates/index.html');
+    const modelTableTemplate = readFixture('../../../templates/model-table-body.html');
     const editIconTemplate = readFixture('../../../templates/edit-icon.html');
+    const templates = indexTemplate + '\n' + modelTableTemplate;
 
     assert.match(
-        indexTemplate,
+        templates,
         /class="table-action-btn table-icon-btn"[\s\S]*:aria-label="'Edit alias ' \+ row\.alias\.name"[\s\S]*@click="openAliasEdit\(row\.alias\)"[\s\S]*{{template "edit-icon"}}/
     );
     assert.match(indexTemplate, /x-show="modelOverrideFormOpen" x-ref="modelOverrideEditor"/);

--- a/internal/admin/dashboard/static/js/modules/request-cancellation.test.js
+++ b/internal/admin/dashboard/static/js/modules/request-cancellation.test.js
@@ -136,6 +136,37 @@ test('refreshRuntime posts to admin endpoint and refreshes dashboard data', asyn
     assert.equal(app.runtimeRefreshStepLabel(app.runtimeRefreshReport.steps[0]), 'providers: ok - refreshed');
 });
 
+test('refreshRuntime leaves dashboard data untouched when the admin request fails', async() => {
+    const queue = createPendingFetchQueue();
+    const app = loadDashboardApp({ fetch: queue.fetch });
+    let dashboardRefreshes = 0;
+    app.dashboardDataFetches = () => {
+        dashboardRefreshes++;
+        return [Promise.resolve()];
+    };
+
+    const refresh = app.refreshRuntime();
+    assert.equal(app.runtimeRefreshLoading, true);
+    assert.equal(queue.requests.length, 1);
+    assert.equal(queue.requests[0].url, '/admin/api/v1/runtime/refresh');
+    assert.equal(queue.requests[0].options.method, 'POST');
+
+    queue.requests[0].resolve({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        json: async() => ({})
+    });
+    await refresh;
+
+    assert.equal(app.runtimeRefreshLoading, false);
+    assert.equal(dashboardRefreshes, 0);
+    assert.equal(app.runtimeRefreshSucceeded(), false);
+    assert.equal(app.authError, true);
+    assert.equal(app.needsAuth, true);
+    assert.match(app.runtimeRefreshNotice, /Runtime refresh failed/);
+});
+
 function loadDashboardApp(overrides = {}) {
     const sources = [
         fs.readFileSync(path.join(__dirname, 'usage.js'), 'utf8'),

--- a/internal/admin/dashboard/static/js/modules/request-cancellation.test.js
+++ b/internal/admin/dashboard/static/js/modules/request-cancellation.test.js
@@ -106,6 +106,36 @@ function jsonResponse(payload) {
     };
 }
 
+test('refreshRuntime posts to admin endpoint and refreshes dashboard data', async() => {
+    const queue = createPendingFetchQueue();
+    const app = loadDashboardApp({ fetch: queue.fetch });
+    let dashboardRefreshes = 0;
+    app.dashboardDataFetches = () => {
+        dashboardRefreshes++;
+        return [Promise.resolve()];
+    };
+
+    const refresh = app.refreshRuntime();
+    assert.equal(app.runtimeRefreshLoading, true);
+    assert.equal(queue.requests.length, 1);
+    assert.equal(queue.requests[0].url, '/admin/api/v1/runtime/refresh');
+    assert.equal(queue.requests[0].options.method, 'POST');
+
+    queue.requests[0].resolve(jsonResponse({
+        status: 'ok',
+        model_count: 4,
+        provider_count: 2,
+        steps: [{ name: 'providers', status: 'ok', message: 'refreshed' }]
+    }));
+    await refresh;
+
+    assert.equal(app.runtimeRefreshLoading, false);
+    assert.equal(dashboardRefreshes, 1);
+    assert.equal(app.runtimeRefreshSucceeded(), true);
+    assert.equal(app.runtimeRefreshNotice, 'Runtime refreshed. 4 models across 2 providers.');
+    assert.equal(app.runtimeRefreshStepLabel(app.runtimeRefreshReport.steps[0]), 'providers: ok - refreshed');
+});
+
 function loadDashboardApp(overrides = {}) {
     const sources = [
         fs.readFileSync(path.join(__dirname, 'usage.js'), 'utf8'),

--- a/internal/admin/dashboard/static/js/modules/timezone-layout.test.js
+++ b/internal/admin/dashboard/static/js/modules/timezone-layout.test.js
@@ -45,6 +45,8 @@ test('dashboard templates expose a settings page and timezone context in activit
     assert.match(template, /<h3>Runtime Refresh<\/h3>/);
     assert.match(template, /@click="refreshRuntime\(\)"/);
     assert.match(template, /x-text="runtimeRefreshLoading \? 'Refreshing\.\.\.' : 'Refresh Runtime'"/);
+    assert.match(template, /class="loading-state settings-refresh-loading"[\s\S]*x-show="runtimeRefreshLoading"[\s\S]*class="loading-spinner"[\s\S]*Generating runtime report\.\.\./);
+    assert.match(template, /role="status" aria-live="polite" aria-atomic="true"[\s\S]*runtimeRefreshSucceeded\(\)[\s\S]*runtimeRefreshWarnings\(\)[\s\S]*runtimeRefreshStepLabel\(step\)/);
     assert.match(template, /runtimeRefreshReport\.steps/);
     assert.match(template, /{{template "helper-disclosure" "\{ heading: 'Timezone', open: false, copyId: 'timezone-help-copy'/);
     assert.match(template, /class="inline-help-toggle"/);
@@ -108,6 +110,16 @@ test('dashboard templates expose a settings page and timezone context in activit
     const refreshRule = readCSSRule(css, '.settings-refresh-section');
     assert.match(refreshRule, /border-top:\s*1px solid var\(--border\)/);
     assert.match(refreshRule, /justify-content:\s*space-between/);
+
+    const refreshLoadingRule = readCSSRule(css, '.settings-refresh-loading');
+    assert.match(refreshLoadingRule, /justify-content:\s*flex-start/);
+    assert.match(refreshLoadingRule, /min-height:\s*52px/);
+
+    const refreshPartialRule = readCSSRule(css, '.runtime-refresh-step.is-partial');
+    assert.match(refreshPartialRule, /color:\s*var\(--warning\)/);
+
+    const refreshFailedRule = readCSSRule(css, '.runtime-refresh-step.is-failed');
+    assert.match(refreshFailedRule, /color:\s*var\(--danger\)/);
 });
 
 test('guardrails authoring moved to a top-level page while settings keeps the general switch', () => {

--- a/internal/admin/dashboard/static/js/modules/timezone-layout.test.js
+++ b/internal/admin/dashboard/static/js/modules/timezone-layout.test.js
@@ -42,6 +42,10 @@ test('dashboard templates expose a settings page and timezone context in activit
     assert.match(template, /:selected="!timezoneOverride"/);
     assert.match(template, /<option :value="timeZone\.value"/);
     assert.match(template, /:selected="timeZone\.value === timezoneOverride"/);
+    assert.match(template, /<h3>Runtime Refresh<\/h3>/);
+    assert.match(template, /@click="refreshRuntime\(\)"/);
+    assert.match(template, /x-text="runtimeRefreshLoading \? 'Refreshing\.\.\.' : 'Refresh Runtime'"/);
+    assert.match(template, /runtimeRefreshReport\.steps/);
     assert.match(template, /{{template "helper-disclosure" "\{ heading: 'Timezone', open: false, copyId: 'timezone-help-copy'/);
     assert.match(template, /class="inline-help-toggle"/);
     assert.match(template, /class="inline-help-toggle-icon"/);
@@ -100,6 +104,10 @@ test('dashboard templates expose a settings page and timezone context in activit
     assert.doesNotMatch(copyRule, /border:/);
     assert.doesNotMatch(copyRule, /background:/);
     assert.doesNotMatch(copyRule, /padding:/);
+
+    const refreshRule = readCSSRule(css, '.settings-refresh-section');
+    assert.match(refreshRule, /border-top:\s*1px solid var\(--border\)/);
+    assert.match(refreshRule, /justify-content:\s*space-between/);
 });
 
 test('guardrails authoring moved to a top-level page while settings keeps the general switch', () => {

--- a/internal/admin/dashboard/static/js/modules/timezone-layout.test.js
+++ b/internal/admin/dashboard/static/js/modules/timezone-layout.test.js
@@ -46,7 +46,9 @@ test('dashboard templates expose a settings page and timezone context in activit
     assert.match(template, /@click="refreshRuntime\(\)"/);
     assert.match(template, /x-text="runtimeRefreshLoading \? 'Refreshing\.\.\.' : 'Refresh Runtime'"/);
     assert.match(template, /class="loading-state settings-refresh-loading"[\s\S]*x-show="runtimeRefreshLoading"[\s\S]*class="loading-spinner"[\s\S]*Generating runtime report\.\.\./);
-    assert.match(template, /role="status" aria-live="polite" aria-atomic="true"[\s\S]*runtimeRefreshSucceeded\(\)[\s\S]*runtimeRefreshWarnings\(\)[\s\S]*runtimeRefreshStepLabel\(step\)/);
+    assert.match(template, /class="alert alert-success settings-refresh-alert"[\s\S]*role="status"[\s\S]*aria-live="polite"[\s\S]*runtimeRefreshSucceeded\(\)/);
+    assert.match(template, /class="alert alert-warning settings-refresh-alert"[\s\S]*role="alert"[\s\S]*aria-live="assertive"[\s\S]*runtimeRefreshError \|\| runtimeRefreshNotice/);
+    assert.match(template, /class="runtime-refresh-steps"[\s\S]*role="status"[\s\S]*aria-live="polite"[\s\S]*runtimeRefreshStepLabel\(step\)/);
     assert.match(template, /runtimeRefreshReport\.steps/);
     assert.match(template, /{{template "helper-disclosure" "\{ heading: 'Timezone', open: false, copyId: 'timezone-help-copy'/);
     assert.match(template, /class="inline-help-toggle"/);

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -331,6 +331,8 @@
         </div>
     </div>
 
+    {{template "auth-banner" .}}
+
     <div class="settings-subnav">
         <button type="button" class="settings-subnav-btn active" @click="navigateSettings('general')">General</button>
     </div>
@@ -367,18 +369,27 @@
                     x-text="runtimeRefreshLoading ? 'Refreshing...' : 'Refresh Runtime'"></button>
         </div>
 
-        <div class="alert alert-success settings-refresh-alert"
-             x-show="runtimeRefreshNotice && runtimeRefreshSucceeded()"
-             x-text="runtimeRefreshNotice"></div>
-        <div class="alert alert-warning settings-refresh-alert"
-             x-show="runtimeRefreshError || (runtimeRefreshNotice && runtimeRefreshWarnings())"
-             x-text="runtimeRefreshError || runtimeRefreshNotice"></div>
-        <ul class="runtime-refresh-steps"
-            x-show="runtimeRefreshReport && runtimeRefreshReport.steps && runtimeRefreshReport.steps.length > 0">
-            <template x-for="step in runtimeRefreshReport.steps" :key="step.name">
-                <li :class="'runtime-refresh-step is-' + step.status" x-text="runtimeRefreshStepLabel(step)"></li>
-            </template>
-        </ul>
+        <div class="loading-state settings-refresh-loading"
+             x-show="runtimeRefreshLoading"
+             role="status"
+             aria-live="polite">
+            <span class="loading-spinner" aria-hidden="true"></span>
+            <span>Generating runtime report...</span>
+        </div>
+        <div role="status" aria-live="polite" aria-atomic="true">
+            <div class="alert alert-success settings-refresh-alert"
+                 x-show="runtimeRefreshNotice && runtimeRefreshSucceeded()"
+                 x-text="runtimeRefreshNotice"></div>
+            <div class="alert alert-warning settings-refresh-alert"
+                 x-show="runtimeRefreshError || (runtimeRefreshNotice && runtimeRefreshWarnings())"
+                 x-text="runtimeRefreshError || runtimeRefreshNotice"></div>
+            <ul class="runtime-refresh-steps"
+                x-show="runtimeRefreshReport && runtimeRefreshReport.steps && runtimeRefreshReport.steps.length > 0">
+                <template x-for="step in runtimeRefreshReport.steps" :key="step.name">
+                    <li :class="'runtime-refresh-step is-' + step.status" x-text="runtimeRefreshStepLabel(step)"></li>
+                </template>
+            </ul>
+        </div>
     </div>
 </div>
 </template>

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -376,14 +376,22 @@
             <span class="loading-spinner" aria-hidden="true"></span>
             <span>Generating runtime report...</span>
         </div>
-        <div role="status" aria-live="polite" aria-atomic="true">
+        <div>
             <div class="alert alert-success settings-refresh-alert"
+                 role="status"
+                 aria-live="polite"
+                 aria-atomic="true"
                  x-show="runtimeRefreshNotice && runtimeRefreshSucceeded()"
                  x-text="runtimeRefreshNotice"></div>
             <div class="alert alert-warning settings-refresh-alert"
+                 role="alert"
+                 aria-live="assertive"
+                 aria-atomic="true"
                  x-show="runtimeRefreshError || (runtimeRefreshNotice && runtimeRefreshWarnings())"
                  x-text="runtimeRefreshError || runtimeRefreshNotice"></div>
             <ul class="runtime-refresh-steps"
+                role="status"
+                aria-live="polite"
                 x-show="runtimeRefreshReport && runtimeRefreshReport.steps && runtimeRefreshReport.steps.length > 0">
                 <template x-for="step in runtimeRefreshReport.steps" :key="step.name">
                     <li :class="'runtime-refresh-step is-' + step.status" x-text="runtimeRefreshStepLabel(step)"></li>

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -349,6 +349,31 @@
         <div class="alias-form-actions">
             <button type="button" class="pagination-btn" x-show="timezoneOverride" @click="clearTimezoneOverride()">Use Browser Timezone</button>
         </div>
+
+        <div class="settings-refresh-section">
+            <div>
+                <h3>Runtime Refresh</h3>
+                <p>Pull the latest model metadata, provider inventory, API keys, aliases, model access rules, guardrails, and workflows.</p>
+            </div>
+            <button type="button"
+                    class="pagination-btn pagination-btn-primary"
+                    :disabled="runtimeRefreshLoading"
+                    @click="refreshRuntime()"
+                    x-text="runtimeRefreshLoading ? 'Refreshing...' : 'Refresh Runtime'"></button>
+        </div>
+
+        <div class="alert alert-success settings-refresh-alert"
+             x-show="runtimeRefreshNotice && runtimeRefreshSucceeded()"
+             x-text="runtimeRefreshNotice"></div>
+        <div class="alert alert-warning settings-refresh-alert"
+             x-show="runtimeRefreshError || (runtimeRefreshNotice && runtimeRefreshWarnings())"
+             x-text="runtimeRefreshError || runtimeRefreshNotice"></div>
+        <ul class="runtime-refresh-steps"
+            x-show="runtimeRefreshReport && runtimeRefreshReport.steps && runtimeRefreshReport.steps.length > 0">
+            <template x-for="step in runtimeRefreshReport.steps" :key="step.name">
+                <li :class="'runtime-refresh-step is-' + step.status" x-text="runtimeRefreshStepLabel(step)"></li>
+            </template>
+        </ul>
     </div>
 </div>
 

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -882,6 +882,9 @@ func (h *Handler) RefreshRuntime(c *echo.Context) error {
 
 	report, err := h.runtimeRefresher.RefreshRuntime(c.Request().Context())
 	if err != nil {
+		if gatewayErr, ok := errors.AsType[*core.GatewayError](err); ok {
+			return handleError(c, gatewayErr)
+		}
 		return handleError(c, core.NewProviderError("runtime_refresh", http.StatusInternalServerError, "runtime refresh failed", err))
 	}
 	if report.Status == "" {

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -40,6 +40,7 @@ type Handler struct {
 	guardrails          guardrails.Catalog
 	guardrailDefs       *guardrails.Service
 	runtimeConfig       DashboardConfigResponse
+	runtimeRefresher    RuntimeRefresher
 	configuredProviders []providers.SanitizedProviderConfig
 
 	mutationMu sync.Mutex
@@ -91,6 +92,38 @@ type providerStatusItemResponse struct {
 type providerStatusResponse struct {
 	Summary   providerStatusSummaryResponse `json:"summary"`
 	Providers []providerStatusItemResponse  `json:"providers"`
+}
+
+const (
+	RuntimeRefreshStatusOK      = "ok"
+	RuntimeRefreshStatusPartial = "partial"
+	RuntimeRefreshStatusFailed  = "failed"
+	RuntimeRefreshStatusSkipped = "skipped"
+)
+
+// RuntimeRefreshStep describes the result of one manual runtime refresh step.
+type RuntimeRefreshStep struct {
+	Name       string `json:"name"`
+	Status     string `json:"status"`
+	Message    string `json:"message,omitempty"`
+	Error      string `json:"error,omitempty"`
+	DurationMS int64  `json:"duration_ms"`
+}
+
+// RuntimeRefreshReport is returned by the manual runtime refresh endpoint.
+type RuntimeRefreshReport struct {
+	Status        string               `json:"status"`
+	StartedAt     time.Time            `json:"started_at"`
+	FinishedAt    time.Time            `json:"finished_at"`
+	DurationMS    int64                `json:"duration_ms"`
+	ModelCount    int                  `json:"model_count"`
+	ProviderCount int                  `json:"provider_count"`
+	Steps         []RuntimeRefreshStep `json:"steps"`
+}
+
+// RuntimeRefresher refreshes application runtime snapshots on demand.
+type RuntimeRefresher interface {
+	RefreshRuntime(ctx context.Context) (RuntimeRefreshReport, error)
 }
 
 // WithAuditReader enables audit log read endpoints.
@@ -147,6 +180,13 @@ func WithGuardrailService(service *guardrails.Service) Option {
 func WithDashboardRuntimeConfig(values DashboardConfigResponse) Option {
 	return func(h *Handler) {
 		h.runtimeConfig = normalizeDashboardRuntimeConfig(values)
+	}
+}
+
+// WithRuntimeRefresher enables manual runtime refresh from the admin API.
+func WithRuntimeRefresher(refresher RuntimeRefresher) Option {
+	return func(h *Handler) {
+		h.runtimeRefresher = refresher
 	}
 }
 
@@ -832,6 +872,25 @@ func (h *Handler) DashboardConfig(c *echo.Context) error {
 // ProviderStatus handles GET /admin/api/v1/providers/status
 func (h *Handler) ProviderStatus(c *echo.Context) error {
 	return c.JSON(http.StatusOK, h.buildProviderStatusResponse())
+}
+
+// RefreshRuntime handles POST /admin/api/v1/runtime/refresh
+func (h *Handler) RefreshRuntime(c *echo.Context) error {
+	if h.runtimeRefresher == nil {
+		return handleError(c, featureUnavailableError("runtime refresh is unavailable"))
+	}
+
+	report, err := h.runtimeRefresher.RefreshRuntime(c.Request().Context())
+	if err != nil {
+		return handleError(c, core.NewProviderError("runtime_refresh", http.StatusInternalServerError, "runtime refresh failed", err))
+	}
+	if report.Status == "" {
+		report.Status = RuntimeRefreshStatusOK
+	}
+	if report.Steps == nil {
+		report.Steps = []RuntimeRefreshStep{}
+	}
+	return c.JSON(http.StatusOK, report)
 }
 
 func (h *Handler) buildProviderStatusResponse() providerStatusResponse {

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -1603,6 +1603,66 @@ func TestRefreshRuntime_FeatureUnavailableWhenNotConfigured(t *testing.T) {
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status = %d, want 503", rec.Code)
 	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	rawError, ok := body["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("error object missing or invalid: %#v", body["error"])
+	}
+	for _, key := range []string{"type", "message", "param", "code"} {
+		if _, ok := rawError[key]; !ok {
+			t.Fatalf("error.%s missing from response: %#v", key, rawError)
+		}
+	}
+	if rawError["type"] != string(core.ErrorTypeInvalidRequest) {
+		t.Fatalf("error.type = %#v, want %q", rawError["type"], core.ErrorTypeInvalidRequest)
+	}
+	if rawError["message"] != "runtime refresh is unavailable" {
+		t.Fatalf("error.message = %#v, want runtime refresh is unavailable", rawError["message"])
+	}
+	if rawError["param"] != nil {
+		t.Fatalf("error.param = %#v, want null", rawError["param"])
+	}
+	if rawError["code"] != "feature_unavailable" {
+		t.Fatalf("error.code = %#v, want feature_unavailable", rawError["code"])
+	}
+}
+
+func TestRefreshRuntime_PreservesGatewayError(t *testing.T) {
+	refresher := &mockRuntimeRefresher{
+		err: core.NewInvalidRequestErrorWithStatus(http.StatusRequestTimeout, "runtime refresh canceled before start", context.Canceled).
+			WithCode("request_canceled"),
+	}
+	h := NewHandler(nil, nil, WithRuntimeRefresher(refresher))
+	c, rec := newHandlerContext("/admin/api/v1/runtime/refresh")
+
+	if err := h.RefreshRuntime(c); err != nil {
+		t.Fatalf("RefreshRuntime() error = %v", err)
+	}
+	if rec.Code != http.StatusRequestTimeout {
+		t.Fatalf("status = %d, want 408", rec.Code)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	rawError, ok := body["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("error object missing or invalid: %#v", body["error"])
+	}
+	if rawError["type"] != string(core.ErrorTypeInvalidRequest) {
+		t.Fatalf("error.type = %#v, want %q", rawError["type"], core.ErrorTypeInvalidRequest)
+	}
+	if rawError["message"] != "runtime refresh canceled before start" {
+		t.Fatalf("error.message = %#v, want preserved message", rawError["message"])
+	}
+	if rawError["code"] != "request_canceled" {
+		t.Fatalf("error.code = %#v, want request_canceled", rawError["code"])
+	}
 }
 
 func TestCacheOverview_FeatureUnavailableWhenCacheDisabled(t *testing.T) {

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -1567,6 +1567,7 @@ func TestRefreshRuntime_ReturnsReport(t *testing.T) {
 	}
 	h := NewHandler(nil, nil, WithRuntimeRefresher(refresher))
 	c, rec := newHandlerContext("/admin/api/v1/runtime/refresh")
+	c.Request().Method = http.MethodPost
 
 	if err := h.RefreshRuntime(c); err != nil {
 		t.Fatalf("RefreshRuntime() error = %v", err)
@@ -1596,6 +1597,7 @@ func TestRefreshRuntime_ReturnsReport(t *testing.T) {
 func TestRefreshRuntime_FeatureUnavailableWhenNotConfigured(t *testing.T) {
 	h := NewHandler(nil, nil)
 	c, rec := newHandlerContext("/admin/api/v1/runtime/refresh")
+	c.Request().Method = http.MethodPost
 
 	if err := h.RefreshRuntime(c); err != nil {
 		t.Fatalf("RefreshRuntime() error = %v", err)
@@ -1638,6 +1640,7 @@ func TestRefreshRuntime_PreservesGatewayError(t *testing.T) {
 	}
 	h := NewHandler(nil, nil, WithRuntimeRefresher(refresher))
 	c, rec := newHandlerContext("/admin/api/v1/runtime/refresh")
+	c.Request().Method = http.MethodPost
 
 	if err := h.RefreshRuntime(c); err != nil {
 		t.Fatalf("RefreshRuntime() error = %v", err)
@@ -1654,11 +1657,19 @@ func TestRefreshRuntime_PreservesGatewayError(t *testing.T) {
 	if !ok {
 		t.Fatalf("error object missing or invalid: %#v", body["error"])
 	}
+	for _, key := range []string{"type", "message", "param", "code"} {
+		if _, ok := rawError[key]; !ok {
+			t.Fatalf("error.%s missing from response: %#v", key, rawError)
+		}
+	}
 	if rawError["type"] != string(core.ErrorTypeInvalidRequest) {
 		t.Fatalf("error.type = %#v, want %q", rawError["type"], core.ErrorTypeInvalidRequest)
 	}
 	if rawError["message"] != "runtime refresh canceled before start" {
 		t.Fatalf("error.message = %#v, want preserved message", rawError["message"])
+	}
+	if rawError["param"] != nil {
+		t.Fatalf("error.param = %#v, want null", rawError["param"])
 	}
 	if rawError["code"] != "request_canceled" {
 		t.Fatalf("error.code = %#v, want request_canceled", rawError["code"])

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -47,6 +47,17 @@ type mockAuditReader struct {
 	lastConversationLim int
 }
 
+type mockRuntimeRefresher struct {
+	report RuntimeRefreshReport
+	err    error
+	calls  int
+}
+
+func (m *mockRuntimeRefresher) RefreshRuntime(_ context.Context) (RuntimeRefreshReport, error) {
+	m.calls++
+	return m.report, m.err
+}
+
 func (m *mockUsageReader) GetSummary(_ context.Context, _ usage.UsageQueryParams) (*usage.UsageSummary, error) {
 	if m.summaryErr != nil {
 		return nil, m.summaryErr
@@ -1536,6 +1547,61 @@ func TestDashboardConfig_ReturnsAllowlistedRuntimeFlags(t *testing.T) {
 	}
 	if rec.Body.String() == "" || strings.Contains(rec.Body.String(), "UNRELATED_FLAG") {
 		t.Fatal("UNRELATED_FLAG should not be exposed")
+	}
+}
+
+func TestRefreshRuntime_ReturnsReport(t *testing.T) {
+	started := time.Date(2026, 4, 11, 12, 0, 0, 0, time.UTC)
+	refresher := &mockRuntimeRefresher{
+		report: RuntimeRefreshReport{
+			Status:        RuntimeRefreshStatusPartial,
+			StartedAt:     started,
+			FinishedAt:    started.Add(2 * time.Second),
+			DurationMS:    2000,
+			ModelCount:    7,
+			ProviderCount: 2,
+			Steps: []RuntimeRefreshStep{
+				{Name: "providers", Status: RuntimeRefreshStatusPartial, Error: "one provider failed"},
+			},
+		},
+	}
+	h := NewHandler(nil, nil, WithRuntimeRefresher(refresher))
+	c, rec := newHandlerContext("/admin/api/v1/runtime/refresh")
+
+	if err := h.RefreshRuntime(c); err != nil {
+		t.Fatalf("RefreshRuntime() error = %v", err)
+	}
+	if refresher.calls != 1 {
+		t.Fatalf("RefreshRuntime calls = %d, want 1", refresher.calls)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	var body RuntimeRefreshReport
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Status != RuntimeRefreshStatusPartial {
+		t.Fatalf("status = %q, want partial", body.Status)
+	}
+	if body.ModelCount != 7 || body.ProviderCount != 2 {
+		t.Fatalf("counts = %d/%d, want 7/2", body.ModelCount, body.ProviderCount)
+	}
+	if len(body.Steps) != 1 || body.Steps[0].Error != "one provider failed" {
+		t.Fatalf("steps = %+v, want provider warning", body.Steps)
+	}
+}
+
+func TestRefreshRuntime_FeatureUnavailableWhenNotConfigured(t *testing.T) {
+	h := NewHandler(nil, nil)
+	c, rec := newHandlerContext("/admin/api/v1/runtime/refresh")
+
+	if err := h.RefreshRuntime(c); err != nil {
+		t.Fatalf("RefreshRuntime() error = %v", err)
+	}
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
 	}
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -48,12 +48,13 @@ type App struct {
 	executionPlans *executionplans.Result
 	server         *server.Server
 
-	shutdownMu sync.Mutex
-	shutdown   bool
-	serverMu   sync.Mutex
-	serverStop context.CancelFunc
-	serverDone chan error
-	refreshMu  sync.Mutex
+	shutdownMu  sync.Mutex
+	shutdown    bool
+	serverMu    sync.Mutex
+	serverStop  context.CancelFunc
+	serverDone  chan error
+	refreshCh   chan struct{}
+	refreshOnce sync.Once
 }
 
 // Config holds the configuration options for creating an App.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -53,6 +53,7 @@ type App struct {
 	serverMu   sync.Mutex
 	serverStop context.CancelFunc
 	serverDone chan error
+	refreshMu  sync.Mutex
 }
 
 // Config holds the configuration options for creating an App.
@@ -368,6 +369,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 			app.modelOverrides.Service,
 			executionPlanResult.Service,
 			app.guardrails.Service,
+			app,
 			dashboardRuntimeConfig(appCfg, usageEnabledForDashboard),
 			adminCfg.UIEnabled,
 		)
@@ -746,6 +748,7 @@ func initAdmin(
 	modelOverrideService *modeloverrides.Service,
 	executionPlanService *executionplans.Service,
 	guardrailService *guardrails.Service,
+	runtimeRefresher admin.RuntimeRefresher,
 	runtimeConfig admin.DashboardConfigResponse,
 	uiEnabled bool,
 ) (*admin.Handler, *dashboard.Handler, error) {
@@ -788,6 +791,7 @@ func initAdmin(
 		admin.WithModelOverrides(modelOverrideService),
 		admin.WithExecutionPlans(executionPlanService),
 		admin.WithGuardrailService(guardrailService),
+		admin.WithRuntimeRefresher(runtimeRefresher),
 		admin.WithDashboardRuntimeConfig(runtimeConfig),
 	)
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -146,6 +147,32 @@ func TestRefreshRuntime_SkipsDisabledModelOverrides(t *testing.T) {
 	}
 	if step.Status != admin.RuntimeRefreshStatusSkipped {
 		t.Fatalf("model_overrides step status = %q, want skipped; step=%+v", step.Status, *step)
+	}
+}
+
+func TestRefreshRuntime_ReturnsGatewayErrorWhenContextCanceledBeforeAcquire(t *testing.T) {
+	app := &App{}
+	ch := app.runtimeRefreshSemaphore()
+	ch <- struct{}{}
+	defer func() { <-ch }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := app.RefreshRuntime(ctx)
+	if err == nil {
+		t.Fatal("RefreshRuntime() error = nil, want cancellation error")
+	}
+
+	var gatewayErr *core.GatewayError
+	if !errors.As(err, &gatewayErr) {
+		t.Fatalf("RefreshRuntime() error = %T, want *core.GatewayError", err)
+	}
+	if gatewayErr.HTTPStatusCode() != http.StatusRequestTimeout {
+		t.Fatalf("status = %d, want 408", gatewayErr.HTTPStatusCode())
+	}
+	if gatewayErr.Provider != "runtime_refresh" {
+		t.Fatalf("provider = %q, want runtime_refresh", gatewayErr.Provider)
 	}
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,12 +1,162 @@
 package app
 
 import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"gomodel/config"
 	"gomodel/internal/admin"
+	"gomodel/internal/core"
 	"gomodel/internal/guardrails"
+	"gomodel/internal/modeloverrides"
+	"gomodel/internal/providers"
 )
+
+type runtimeRefreshMockProvider struct {
+	models *core.ModelsResponse
+	err    error
+}
+
+func (m *runtimeRefreshMockProvider) ChatCompletion(_ context.Context, _ *core.ChatRequest) (*core.ChatResponse, error) {
+	return nil, nil
+}
+
+func (m *runtimeRefreshMockProvider) StreamChatCompletion(_ context.Context, _ *core.ChatRequest) (io.ReadCloser, error) {
+	return io.NopCloser(nil), nil
+}
+
+func (m *runtimeRefreshMockProvider) ListModels(_ context.Context) (*core.ModelsResponse, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.models, nil
+}
+
+func (m *runtimeRefreshMockProvider) Responses(_ context.Context, _ *core.ResponsesRequest) (*core.ResponsesResponse, error) {
+	return nil, nil
+}
+
+func (m *runtimeRefreshMockProvider) StreamResponses(_ context.Context, _ *core.ResponsesRequest) (io.ReadCloser, error) {
+	return io.NopCloser(nil), nil
+}
+
+func (m *runtimeRefreshMockProvider) Embeddings(_ context.Context, _ *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	return nil, core.NewInvalidRequestError("not supported", nil)
+}
+
+func TestRefreshRuntime_RefreshesModelListProvidersAndRegistryCache(t *testing.T) {
+	registry := providers.NewModelRegistry()
+	registry.RegisterProviderWithNameAndType(&runtimeRefreshMockProvider{
+		models: &core.ModelsResponse{
+			Object: "list",
+			Data: []core.Model{
+				{ID: "gpt-test", Object: "model", OwnedBy: "openai"},
+			},
+		},
+	}, "openai", "openai")
+
+	modelListServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"version": 1,
+			"updated_at": "2026-04-11T00:00:00Z",
+			"providers": {
+				"openai": {
+					"display_name": "OpenAI",
+					"api_type": "openai",
+					"supported_modes": ["chat"]
+				}
+			},
+			"models": {
+				"gpt-test": {
+					"display_name": "GPT Test",
+					"modes": ["chat"],
+					"context_window": 128000
+				}
+			},
+			"provider_models": {}
+		}`))
+	}))
+	defer modelListServer.Close()
+
+	app := &App{
+		config: &config.Config{
+			Cache: config.CacheConfig{
+				Model: config.ModelCacheConfig{
+					ModelList: config.ModelListConfig{URL: modelListServer.URL},
+				},
+			},
+		},
+		providers: &providers.InitResult{Registry: registry},
+	}
+
+	report, err := app.RefreshRuntime(context.Background())
+	if err != nil {
+		t.Fatalf("RefreshRuntime() error = %v", err)
+	}
+	if report.Status != admin.RuntimeRefreshStatusOK {
+		t.Fatalf("RefreshRuntime().Status = %q, want ok; steps=%+v", report.Status, report.Steps)
+	}
+	if report.ModelCount != 1 || report.ProviderCount != 1 {
+		t.Fatalf("RefreshRuntime() counts = %d/%d, want 1/1", report.ModelCount, report.ProviderCount)
+	}
+
+	info := registry.GetModel("openai/gpt-test")
+	if info == nil || info.Model.Metadata == nil {
+		t.Fatal("expected refreshed provider model metadata")
+	}
+	if info.Model.Metadata.DisplayName != "GPT Test" {
+		t.Fatalf("DisplayName = %q, want GPT Test", info.Model.Metadata.DisplayName)
+	}
+	if info.Model.Metadata.ContextWindow == nil || *info.Model.Metadata.ContextWindow != 128000 {
+		t.Fatalf("ContextWindow = %v, want 128000", info.Model.Metadata.ContextWindow)
+	}
+}
+
+func TestRefreshRuntime_SkipsDisabledModelOverrides(t *testing.T) {
+	registry := providers.NewModelRegistry()
+	registry.RegisterProviderWithNameAndType(&runtimeRefreshMockProvider{
+		models: &core.ModelsResponse{
+			Object: "list",
+			Data: []core.Model{
+				{ID: "gpt-test", Object: "model", OwnedBy: "openai"},
+			},
+		},
+	}, "openai", "openai")
+
+	app := &App{
+		config: &config.Config{},
+		providers: &providers.InitResult{
+			Registry: registry,
+		},
+		modelOverrides: &modeloverrides.Result{},
+	}
+
+	report, err := app.RefreshRuntime(context.Background())
+	if err != nil {
+		t.Fatalf("RefreshRuntime() error = %v", err)
+	}
+
+	step := runtimeRefreshStepByName(report.Steps, "model_overrides")
+	if step == nil {
+		t.Fatalf("model_overrides step missing: %+v", report.Steps)
+	}
+	if step.Status != admin.RuntimeRefreshStatusSkipped {
+		t.Fatalf("model_overrides step status = %q, want skipped; step=%+v", step.Status, *step)
+	}
+}
+
+func runtimeRefreshStepByName(steps []admin.RuntimeRefreshStep, name string) *admin.RuntimeRefreshStep {
+	for i := range steps {
+		if steps[i].Name == name {
+			return &steps[i]
+		}
+	}
+	return nil
+}
 
 func TestRuntimeExecutionFeatureCaps_EnableFallbackFromOverride(t *testing.T) {
 	cfg := &config.Config{

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -176,6 +176,33 @@ func TestRefreshRuntime_ReturnsGatewayErrorWhenContextCanceledBeforeAcquire(t *t
 	}
 }
 
+func TestRunRuntimeRefreshStepReturnsContextErrorWithoutAppendingStep(t *testing.T) {
+	app := &App{}
+	report := admin.RuntimeRefreshReport{}
+
+	err := app.runRuntimeRefreshStep(&report, "providers", func() runtimeRefreshStepResult {
+		return runtimeRefreshStepResult{err: context.Canceled}
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("runRuntimeRefreshStep() error = %v, want context canceled", err)
+	}
+	if len(report.Steps) != 0 {
+		t.Fatalf("steps = %+v, want none appended for context cancellation", report.Steps)
+	}
+}
+
+func TestProviderRefreshIssueCountIncludesAvailabilityErrors(t *testing.T) {
+	got := providerRefreshIssueCount([]providers.ProviderRuntimeSnapshot{
+		{Name: "healthy"},
+		{Name: "model-fetch", LastModelFetchError: " failed to fetch models "},
+		{Name: "availability", LastAvailabilityError: " provider unavailable "},
+		{Name: "both", LastModelFetchError: "fetch failed", LastAvailabilityError: "unavailable"},
+	})
+	if got != 3 {
+		t.Fatalf("providerRefreshIssueCount() = %d, want 3", got)
+	}
+}
+
 func runtimeRefreshStepByName(steps []admin.RuntimeRefreshStep, name string) *admin.RuntimeRefreshStep {
 	for i := range steps {
 		if steps[i].Name == name {

--- a/internal/app/runtime_refresh.go
+++ b/internal/app/runtime_refresh.go
@@ -2,11 +2,14 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
 	"gomodel/internal/admin"
+	"gomodel/internal/core"
 	"gomodel/internal/providers"
 )
 
@@ -28,8 +31,11 @@ func (a *App) RefreshRuntime(ctx context.Context) (admin.RuntimeRefreshReport, e
 		ctx = context.Background()
 	}
 
-	a.refreshMu.Lock()
-	defer a.refreshMu.Unlock()
+	release, err := a.acquireRuntimeRefresh(ctx)
+	if err != nil {
+		return admin.RuntimeRefreshReport{}, err
+	}
+	defer release()
 
 	startedAt := time.Now().UTC()
 	report := admin.RuntimeRefreshReport{
@@ -221,6 +227,38 @@ func pluralSuffix(count int) string {
 		return ""
 	}
 	return "s"
+}
+
+func (a *App) acquireRuntimeRefresh(ctx context.Context) (func(), error) {
+	if a == nil {
+		return nil, core.NewProviderError("runtime_refresh", http.StatusInternalServerError, "runtime refresh is unavailable", nil)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, runtimeRefreshAcquireError(err)
+	}
+	ch := a.runtimeRefreshSemaphore()
+	select {
+	case ch <- struct{}{}:
+		return func() { <-ch }, nil
+	case <-ctx.Done():
+		return nil, runtimeRefreshAcquireError(ctx.Err())
+	}
+}
+
+func (a *App) runtimeRefreshSemaphore() chan struct{} {
+	a.refreshOnce.Do(func() {
+		if a.refreshCh == nil {
+			a.refreshCh = make(chan struct{}, 1)
+		}
+	})
+	return a.refreshCh
+}
+
+func runtimeRefreshAcquireError(err error) *core.GatewayError {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return core.NewProviderError("runtime_refresh", http.StatusGatewayTimeout, "runtime refresh timed out before start", err)
+	}
+	return core.NewProviderError("runtime_refresh", http.StatusRequestTimeout, "runtime refresh canceled before start", err)
 }
 
 func (a *App) modelRegistry() *providers.ModelRegistry {

--- a/internal/app/runtime_refresh.go
+++ b/internal/app/runtime_refresh.go
@@ -47,7 +47,7 @@ func (a *App) RefreshRuntime(ctx context.Context) (admin.RuntimeRefreshReport, e
 	registry := a.modelRegistry()
 	modelListURL := a.modelListURL()
 
-	a.runRuntimeRefreshStep(&report, "model_list", func() runtimeRefreshStepResult {
+	if err := a.runRuntimeRefreshStep(&report, "model_list", func() runtimeRefreshStepResult {
 		if registry == nil {
 			return runtimeRefreshStepResult{err: fmt.Errorf("model registry is unavailable")}
 		}
@@ -68,9 +68,11 @@ func (a *App) RefreshRuntime(ctx context.Context) (admin.RuntimeRefreshReport, e
 		return runtimeRefreshStepResult{
 			message: fmt.Sprintf("downloaded %d model metadata entries", count),
 		}
-	})
+	}); err != nil {
+		return report, err
+	}
 
-	a.runRuntimeRefreshStep(&report, "providers", func() runtimeRefreshStepResult {
+	if err := a.runRuntimeRefreshStep(&report, "providers", func() runtimeRefreshStepResult {
 		if registry == nil {
 			return runtimeRefreshStepResult{err: fmt.Errorf("model registry is unavailable")}
 		}
@@ -99,9 +101,11 @@ func (a *App) RefreshRuntime(ctx context.Context) (admin.RuntimeRefreshReport, e
 				message: fmt.Sprintf("refreshed %d provider model%s", registry.ModelCount(), pluralSuffix(registry.ModelCount())),
 			}
 		}
-	})
+	}); err != nil {
+		return report, err
+	}
 
-	a.runRuntimeRefreshStep(&report, "model_registry_cache", func() runtimeRefreshStepResult {
+	if err := a.runRuntimeRefreshStep(&report, "model_registry_cache", func() runtimeRefreshStepResult {
 		if registry == nil {
 			return runtimeRefreshStepResult{err: fmt.Errorf("model registry is unavailable")}
 		}
@@ -115,13 +119,25 @@ func (a *App) RefreshRuntime(ctx context.Context) (admin.RuntimeRefreshReport, e
 			return runtimeRefreshStepResult{err: err}
 		}
 		return runtimeRefreshStepResult{message: "persisted refreshed model registry"}
-	})
+	}); err != nil {
+		return report, err
+	}
 
-	a.runRefreshableServiceStep(&report, "auth_keys", a.authKeyService(), ctx)
-	a.runRefreshableServiceStep(&report, "aliases", a.aliasService(), ctx)
-	a.runRefreshableServiceStep(&report, "model_overrides", a.modelOverrideService(), ctx)
-	a.runRefreshableServiceStep(&report, "guardrails", a.guardrailService(), ctx)
-	a.runRefreshableServiceStep(&report, "execution_plans", a.executionPlanService(), ctx)
+	if err := a.runRefreshableServiceStep(&report, "auth_keys", a.authKeyService(), ctx); err != nil {
+		return report, err
+	}
+	if err := a.runRefreshableServiceStep(&report, "aliases", a.aliasService(), ctx); err != nil {
+		return report, err
+	}
+	if err := a.runRefreshableServiceStep(&report, "model_overrides", a.modelOverrideService(), ctx); err != nil {
+		return report, err
+	}
+	if err := a.runRefreshableServiceStep(&report, "guardrails", a.guardrailService(), ctx); err != nil {
+		return report, err
+	}
+	if err := a.runRefreshableServiceStep(&report, "execution_plans", a.executionPlanService(), ctx); err != nil {
+		return report, err
+	}
 
 	if registry != nil {
 		report.ModelCount = registry.ModelCount()
@@ -131,8 +147,8 @@ func (a *App) RefreshRuntime(ctx context.Context) (admin.RuntimeRefreshReport, e
 	return report, nil
 }
 
-func (a *App) runRefreshableServiceStep(report *admin.RuntimeRefreshReport, name string, service refreshableService, ctx context.Context) {
-	a.runRuntimeRefreshStep(report, name, func() runtimeRefreshStepResult {
+func (a *App) runRefreshableServiceStep(report *admin.RuntimeRefreshReport, name string, service refreshableService, ctx context.Context) error {
+	return a.runRuntimeRefreshStep(report, name, func() runtimeRefreshStepResult {
 		if service == nil {
 			return runtimeRefreshStepResult{
 				status:  admin.RuntimeRefreshStatusSkipped,
@@ -146,9 +162,13 @@ func (a *App) runRefreshableServiceStep(report *admin.RuntimeRefreshReport, name
 	})
 }
 
-func (a *App) runRuntimeRefreshStep(report *admin.RuntimeRefreshReport, name string, fn func() runtimeRefreshStepResult) {
+func (a *App) runRuntimeRefreshStep(report *admin.RuntimeRefreshReport, name string, fn func() runtimeRefreshStepResult) error {
 	startedAt := time.Now()
 	result := fn()
+	if errors.Is(result.err, context.Canceled) || errors.Is(result.err, context.DeadlineExceeded) {
+		return result.err
+	}
+
 	status := strings.TrimSpace(result.status)
 	if status == "" {
 		if result.err != nil {
@@ -168,6 +188,7 @@ func (a *App) runRuntimeRefreshStep(report *admin.RuntimeRefreshReport, name str
 		step.Error = result.err.Error()
 	}
 	report.Steps = append(report.Steps, step)
+	return nil
 }
 
 func finalizeRuntimeRefreshReport(report *admin.RuntimeRefreshReport) {
@@ -215,7 +236,7 @@ func runtimeRefreshStepStatus(steps []admin.RuntimeRefreshStep, name string) str
 func providerRefreshIssueCount(snapshots []providers.ProviderRuntimeSnapshot) int {
 	var count int
 	for _, snapshot := range snapshots {
-		if strings.TrimSpace(snapshot.LastModelFetchError) != "" {
+		if strings.TrimSpace(snapshot.LastModelFetchError) != "" || strings.TrimSpace(snapshot.LastAvailabilityError) != "" {
 			count++
 		}
 	}

--- a/internal/app/runtime_refresh.go
+++ b/internal/app/runtime_refresh.go
@@ -1,0 +1,273 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"gomodel/internal/admin"
+	"gomodel/internal/providers"
+)
+
+type refreshableService interface {
+	Refresh(context.Context) error
+}
+
+type runtimeRefreshStepResult struct {
+	status  string
+	message string
+	err     error
+}
+
+// RefreshRuntime performs a manual runtime refresh for admin-triggered actions.
+// It refreshes provider/model metadata and DB-backed in-memory snapshots without
+// touching exact or semantic response caches.
+func (a *App) RefreshRuntime(ctx context.Context) (admin.RuntimeRefreshReport, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	a.refreshMu.Lock()
+	defer a.refreshMu.Unlock()
+
+	startedAt := time.Now().UTC()
+	report := admin.RuntimeRefreshReport{
+		Status:    admin.RuntimeRefreshStatusOK,
+		StartedAt: startedAt,
+		Steps:     []admin.RuntimeRefreshStep{},
+	}
+
+	registry := a.modelRegistry()
+	modelListURL := a.modelListURL()
+
+	a.runRuntimeRefreshStep(&report, "model_list", func() runtimeRefreshStepResult {
+		if registry == nil {
+			return runtimeRefreshStepResult{err: fmt.Errorf("model registry is unavailable")}
+		}
+		if modelListURL == "" {
+			return runtimeRefreshStepResult{
+				status:  admin.RuntimeRefreshStatusSkipped,
+				message: "model metadata URL is not configured",
+			}
+		}
+		count, err := registry.RefreshModelList(ctx, modelListURL)
+		if err != nil {
+			return runtimeRefreshStepResult{
+				status:  admin.RuntimeRefreshStatusFailed,
+				message: "kept previous model metadata",
+				err:     err,
+			}
+		}
+		return runtimeRefreshStepResult{
+			message: fmt.Sprintf("downloaded %d model metadata entries", count),
+		}
+	})
+
+	a.runRuntimeRefreshStep(&report, "providers", func() runtimeRefreshStepResult {
+		if registry == nil {
+			return runtimeRefreshStepResult{err: fmt.Errorf("model registry is unavailable")}
+		}
+		err := registry.Refresh(ctx)
+		issueCount := providerRefreshIssueCount(registry.ProviderRuntimeSnapshots())
+		switch {
+		case err != nil && registry.ModelCount() > 0:
+			return runtimeRefreshStepResult{
+				status:  admin.RuntimeRefreshStatusPartial,
+				message: "previous provider model inventory is still available",
+				err:     err,
+			}
+		case err != nil:
+			return runtimeRefreshStepResult{
+				status:  admin.RuntimeRefreshStatusFailed,
+				message: "no provider model inventory is available",
+				err:     err,
+			}
+		case issueCount > 0:
+			return runtimeRefreshStepResult{
+				status:  admin.RuntimeRefreshStatusPartial,
+				message: fmt.Sprintf("%d provider refresh issue%s", issueCount, pluralSuffix(issueCount)),
+			}
+		default:
+			return runtimeRefreshStepResult{
+				message: fmt.Sprintf("refreshed %d provider model%s", registry.ModelCount(), pluralSuffix(registry.ModelCount())),
+			}
+		}
+	})
+
+	a.runRuntimeRefreshStep(&report, "model_registry_cache", func() runtimeRefreshStepResult {
+		if registry == nil {
+			return runtimeRefreshStepResult{err: fmt.Errorf("model registry is unavailable")}
+		}
+		if registry.ModelCount() == 0 {
+			return runtimeRefreshStepResult{
+				status:  admin.RuntimeRefreshStatusSkipped,
+				message: "no provider models are available to persist",
+			}
+		}
+		if err := registry.SaveToCache(ctx); err != nil {
+			return runtimeRefreshStepResult{err: err}
+		}
+		return runtimeRefreshStepResult{message: "persisted refreshed model registry"}
+	})
+
+	a.runRefreshableServiceStep(&report, "auth_keys", a.authKeyService(), ctx)
+	a.runRefreshableServiceStep(&report, "aliases", a.aliasService(), ctx)
+	a.runRefreshableServiceStep(&report, "model_overrides", a.modelOverrideService(), ctx)
+	a.runRefreshableServiceStep(&report, "guardrails", a.guardrailService(), ctx)
+	a.runRefreshableServiceStep(&report, "execution_plans", a.executionPlanService(), ctx)
+
+	if registry != nil {
+		report.ModelCount = registry.ModelCount()
+		report.ProviderCount = registry.ProviderCount()
+	}
+	finalizeRuntimeRefreshReport(&report)
+	return report, nil
+}
+
+func (a *App) runRefreshableServiceStep(report *admin.RuntimeRefreshReport, name string, service refreshableService, ctx context.Context) {
+	a.runRuntimeRefreshStep(report, name, func() runtimeRefreshStepResult {
+		if service == nil {
+			return runtimeRefreshStepResult{
+				status:  admin.RuntimeRefreshStatusSkipped,
+				message: "service is not configured",
+			}
+		}
+		if err := service.Refresh(ctx); err != nil {
+			return runtimeRefreshStepResult{err: err}
+		}
+		return runtimeRefreshStepResult{message: "snapshot refreshed"}
+	})
+}
+
+func (a *App) runRuntimeRefreshStep(report *admin.RuntimeRefreshReport, name string, fn func() runtimeRefreshStepResult) {
+	startedAt := time.Now()
+	result := fn()
+	status := strings.TrimSpace(result.status)
+	if status == "" {
+		if result.err != nil {
+			status = admin.RuntimeRefreshStatusFailed
+		} else {
+			status = admin.RuntimeRefreshStatusOK
+		}
+	}
+
+	step := admin.RuntimeRefreshStep{
+		Name:       name,
+		Status:     status,
+		Message:    strings.TrimSpace(result.message),
+		DurationMS: time.Since(startedAt).Milliseconds(),
+	}
+	if result.err != nil {
+		step.Error = result.err.Error()
+	}
+	report.Steps = append(report.Steps, step)
+}
+
+func finalizeRuntimeRefreshReport(report *admin.RuntimeRefreshReport) {
+	report.FinishedAt = time.Now().UTC()
+	report.DurationMS = report.FinishedAt.Sub(report.StartedAt).Milliseconds()
+	report.Status = aggregateRuntimeRefreshStatus(report.Steps)
+	if report.ModelCount == 0 && runtimeRefreshStepStatus(report.Steps, "providers") == admin.RuntimeRefreshStatusFailed {
+		report.Status = admin.RuntimeRefreshStatusFailed
+	}
+}
+
+func aggregateRuntimeRefreshStatus(steps []admin.RuntimeRefreshStep) string {
+	hasIssue := false
+	hasSuccess := false
+	for _, step := range steps {
+		switch step.Status {
+		case admin.RuntimeRefreshStatusFailed:
+			hasIssue = true
+		case admin.RuntimeRefreshStatusPartial:
+			hasIssue = true
+			hasSuccess = true
+		case admin.RuntimeRefreshStatusOK:
+			hasSuccess = true
+		}
+	}
+	switch {
+	case !hasIssue:
+		return admin.RuntimeRefreshStatusOK
+	case hasSuccess:
+		return admin.RuntimeRefreshStatusPartial
+	default:
+		return admin.RuntimeRefreshStatusFailed
+	}
+}
+
+func runtimeRefreshStepStatus(steps []admin.RuntimeRefreshStep, name string) string {
+	for _, step := range steps {
+		if step.Name == name {
+			return step.Status
+		}
+	}
+	return ""
+}
+
+func providerRefreshIssueCount(snapshots []providers.ProviderRuntimeSnapshot) int {
+	var count int
+	for _, snapshot := range snapshots {
+		if strings.TrimSpace(snapshot.LastModelFetchError) != "" {
+			count++
+		}
+	}
+	return count
+}
+
+func pluralSuffix(count int) string {
+	if count == 1 {
+		return ""
+	}
+	return "s"
+}
+
+func (a *App) modelRegistry() *providers.ModelRegistry {
+	if a == nil || a.providers == nil {
+		return nil
+	}
+	return a.providers.Registry
+}
+
+func (a *App) modelListURL() string {
+	if a == nil || a.config == nil {
+		return ""
+	}
+	return strings.TrimSpace(a.config.Cache.Model.ModelList.URL)
+}
+
+func (a *App) authKeyService() refreshableService {
+	if a == nil || a.authKeys == nil || a.authKeys.Service == nil {
+		return nil
+	}
+	return a.authKeys.Service
+}
+
+func (a *App) aliasService() refreshableService {
+	if a == nil || a.aliases == nil || a.aliases.Service == nil {
+		return nil
+	}
+	return a.aliases.Service
+}
+
+func (a *App) modelOverrideService() refreshableService {
+	if a == nil || a.modelOverrides == nil || a.modelOverrides.Service == nil {
+		return nil
+	}
+	return a.modelOverrides.Service
+}
+
+func (a *App) guardrailService() refreshableService {
+	if a == nil || a.guardrails == nil || a.guardrails.Service == nil {
+		return nil
+	}
+	return a.guardrails.Service
+}
+
+func (a *App) executionPlanService() refreshableService {
+	if a == nil || a.executionPlans == nil || a.executionPlans.Service == nil {
+		return nil
+	}
+	return a.executionPlans.Service
+}

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"net/http"
 	"slices"
 	"sort"
 	"strings"
@@ -41,7 +42,8 @@ type ModelRegistry struct {
 	cache            modelcache.Cache     // cache backend (local or redis)
 	initialized      bool                 // true when at least one successful network fetch completed
 	initMu           sync.Mutex           // protects initialized flag
-	refreshMu        sync.Mutex           // serializes provider/model-list refresh cycles
+	refreshCh        chan struct{}        // serializes provider/model-list refresh cycles
+	refreshOnce      sync.Once            // initializes refreshCh for zero-value safety
 	modelList        *modeldata.ModelList // parsed model list (nil = not loaded)
 	modelListRaw     json.RawMessage      // raw bytes for cache persistence
 
@@ -74,6 +76,7 @@ func NewModelRegistry() *ModelRegistry {
 		providerTypes:    make(map[core.Provider]string),
 		providerNames:    make(map[core.Provider]string),
 		providerRuntime:  make(map[string]providerRuntimeState),
+		refreshCh:        make(chan struct{}, 1),
 	}
 }
 
@@ -131,8 +134,11 @@ func (r *ModelRegistry) RegisterProviderWithNameAndType(provider core.Provider, 
 // Initialize fetches models from all registered providers and populates the registry.
 // This should be called on application startup.
 func (r *ModelRegistry) Initialize(ctx context.Context) error {
-	r.refreshMu.Lock()
-	defer r.refreshMu.Unlock()
+	release, err := r.acquireRefresh(ctx)
+	if err != nil {
+		return err
+	}
+	defer release()
 	return r.initialize(ctx)
 }
 
@@ -323,6 +329,38 @@ func (r *ModelRegistry) applyProviderRuntimeUpdatesLocked(updates map[string]pro
 // This can be called periodically to keep the registry up to date.
 func (r *ModelRegistry) Refresh(ctx context.Context) error {
 	return r.Initialize(ctx)
+}
+
+func (r *ModelRegistry) acquireRefresh(ctx context.Context) (func(), error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, registryRefreshAcquireError(err)
+	}
+	ch := r.refreshSemaphore()
+	select {
+	case ch <- struct{}{}:
+		return func() { <-ch }, nil
+	case <-ctx.Done():
+		return nil, registryRefreshAcquireError(ctx.Err())
+	}
+}
+
+func (r *ModelRegistry) refreshSemaphore() chan struct{} {
+	r.refreshOnce.Do(func() {
+		if r.refreshCh == nil {
+			r.refreshCh = make(chan struct{}, 1)
+		}
+	})
+	return r.refreshCh
+}
+
+func registryRefreshAcquireError(err error) *core.GatewayError {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return core.NewProviderError("model_registry", http.StatusGatewayTimeout, "model registry refresh timed out before start", err)
+	}
+	return core.NewProviderError("model_registry", http.StatusRequestTimeout, "model registry refresh canceled before start", err)
 }
 
 // LoadFromCache loads the model list from the cache backend.
@@ -1366,8 +1404,11 @@ func (r *ModelRegistry) RefreshModelList(ctx context.Context, url string) (int, 
 		return 0, nil
 	}
 
-	r.refreshMu.Lock()
-	defer r.refreshMu.Unlock()
+	release, err := r.acquireRefresh(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer release()
 
 	models, _, err := r.refreshModelListLocked(ctx, url)
 	return models, err
@@ -1391,9 +1432,21 @@ func (r *ModelRegistry) refreshModelList(ctx context.Context, url string) {
 	fetchCtx, cancel := context.WithTimeout(ctx, 45*time.Second)
 	defer cancel()
 
-	r.refreshMu.Lock()
-	models, metadataStats, err := r.refreshModelListLocked(fetchCtx, url)
-	r.refreshMu.Unlock()
+	release, err := r.acquireRefresh(fetchCtx)
+	if err != nil {
+		if !isBenignBackgroundRefreshError(ctx, err) {
+			slog.Warn("failed to acquire model list refresh", "url", url, "error", err)
+		}
+		return
+	}
+	var (
+		models        int
+		metadataStats metadataEnrichmentStats
+	)
+	func() {
+		defer release()
+		models, metadataStats, err = r.refreshModelListLocked(fetchCtx, url)
+	}()
 	if err != nil {
 		if !isBenignBackgroundRefreshError(ctx, err) {
 			slog.Warn("failed to refresh model list", "url", url, "error", err)

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -41,6 +41,7 @@ type ModelRegistry struct {
 	cache            modelcache.Cache     // cache backend (local or redis)
 	initialized      bool                 // true when at least one successful network fetch completed
 	initMu           sync.Mutex           // protects initialized flag
+	refreshMu        sync.Mutex           // serializes provider/model-list refresh cycles
 	modelList        *modeldata.ModelList // parsed model list (nil = not loaded)
 	modelListRaw     json.RawMessage      // raw bytes for cache persistence
 
@@ -130,6 +131,12 @@ func (r *ModelRegistry) RegisterProviderWithNameAndType(provider core.Provider, 
 // Initialize fetches models from all registered providers and populates the registry.
 // This should be called on application startup.
 func (r *ModelRegistry) Initialize(ctx context.Context) error {
+	r.refreshMu.Lock()
+	defer r.refreshMu.Unlock()
+	return r.initialize(ctx)
+}
+
+func (r *ModelRegistry) initialize(ctx context.Context) error {
 	// Get a snapshot of providers with a read lock
 	r.mu.RLock()
 	providers := make([]core.Provider, len(r.providers))
@@ -1147,7 +1154,10 @@ func (r *ModelRegistry) EnrichModels() {
 func (r *ModelRegistry) enrichModels() metadataEnrichmentStats {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	return r.enrichModelsLocked()
+}
 
+func (r *ModelRegistry) enrichModelsLocked() metadataEnrichmentStats {
 	if r.modelList == nil || len(r.models) == 0 {
 		return metadataEnrichmentStats{}
 	}
@@ -1164,6 +1174,14 @@ func (r *ModelRegistry) enrichModels() metadataEnrichmentStats {
 	}
 	r.invalidateSortedCaches()
 	return stats
+}
+
+func (r *ModelRegistry) setModelListAndEnrich(list *modeldata.ModelList, raw json.RawMessage) metadataEnrichmentStats {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.modelList = list
+	r.modelListRaw = raw
+	return r.enrichModelsLocked()
 }
 
 // ResolveMetadata resolves metadata for a model directly via the stored model list,
@@ -1306,7 +1324,7 @@ func (r *ModelRegistry) StartBackgroundRefresh(interval time.Duration, modelList
 				return
 			case <-ticker.C:
 				refreshCtx, refreshCancel := context.WithTimeout(ctx, 30*time.Second)
-				err := r.Refresh(refreshCtx)
+				err := r.Initialize(refreshCtx)
 				refreshCancel()
 				if err != nil {
 					if !isBenignBackgroundRefreshError(ctx, err) {
@@ -1340,31 +1358,58 @@ func (r *ModelRegistry) StartBackgroundRefresh(interval time.Duration, modelList
 	}
 }
 
+// RefreshModelList fetches the external model metadata list and re-enriches all
+// currently registered models. It does not persist the model cache; callers that
+// want durable startup data should call SaveToCache after this succeeds.
+func (r *ModelRegistry) RefreshModelList(ctx context.Context, url string) (int, error) {
+	if strings.TrimSpace(url) == "" {
+		return 0, nil
+	}
+
+	r.refreshMu.Lock()
+	defer r.refreshMu.Unlock()
+
+	models, _, err := r.refreshModelListLocked(ctx, url)
+	return models, err
+}
+
+func (r *ModelRegistry) refreshModelListLocked(ctx context.Context, url string) (int, metadataEnrichmentStats, error) {
+	list, raw, err := modeldata.Fetch(ctx, url)
+	if err != nil {
+		return 0, metadataEnrichmentStats{}, err
+	}
+	if list == nil {
+		return 0, metadataEnrichmentStats{}, nil
+	}
+
+	metadataStats := r.setModelListAndEnrich(list, raw)
+	return len(list.Models), metadataStats, nil
+}
+
 // refreshModelList fetches the model list and re-enriches all models.
 func (r *ModelRegistry) refreshModelList(ctx context.Context, url string) {
 	fetchCtx, cancel := context.WithTimeout(ctx, 45*time.Second)
 	defer cancel()
 
-	list, raw, err := modeldata.Fetch(fetchCtx, url)
+	r.refreshMu.Lock()
+	models, metadataStats, err := r.refreshModelListLocked(fetchCtx, url)
+	r.refreshMu.Unlock()
 	if err != nil {
 		if !isBenignBackgroundRefreshError(ctx, err) {
 			slog.Warn("failed to refresh model list", "url", url, "error", err)
 		}
 		return
 	}
-	if list == nil {
+	if models == 0 {
 		return
 	}
-
-	r.SetModelList(list, raw)
-	metadataStats := r.enrichModels()
 
 	if err := r.SaveToCache(fetchCtx); err != nil {
 		if !isBenignBackgroundRefreshError(ctx, err) {
 			slog.Warn("failed to save cache after model list refresh", "error", err)
 		}
 	}
-	attrs := []any{"models", len(list.Models)}
+	attrs := []any{"models", models}
 	attrs = append(attrs, metadataStats.slogAttrs()...)
 	slog.Debug("model list refreshed", attrs...)
 }

--- a/internal/providers/registry_test.go
+++ b/internal/providers/registry_test.go
@@ -448,6 +448,58 @@ func TestModelRegistry(t *testing.T) {
 		}
 	})
 
+	t.Run("InitializeReturnsGatewayErrorWhenContextCanceledBeforeAcquire", func(t *testing.T) {
+		registry := NewModelRegistry()
+		ch := registry.refreshSemaphore()
+		ch <- struct{}{}
+		defer func() { <-ch }()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := registry.Initialize(ctx)
+		if err == nil {
+			t.Fatal("Initialize() error = nil, want cancellation error")
+		}
+
+		var gatewayErr *core.GatewayError
+		if !errors.As(err, &gatewayErr) {
+			t.Fatalf("Initialize() error = %T, want *core.GatewayError", err)
+		}
+		if gatewayErr.HTTPStatusCode() != http.StatusRequestTimeout {
+			t.Fatalf("status = %d, want 408", gatewayErr.HTTPStatusCode())
+		}
+		if gatewayErr.Provider != "model_registry" {
+			t.Fatalf("provider = %q, want model_registry", gatewayErr.Provider)
+		}
+	})
+
+	t.Run("RefreshModelListReturnsGatewayErrorWhenContextCanceledBeforeAcquire", func(t *testing.T) {
+		registry := NewModelRegistry()
+		ch := registry.refreshSemaphore()
+		ch <- struct{}{}
+		defer func() { <-ch }()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := registry.RefreshModelList(ctx, "https://example.test/models.min.json")
+		if err == nil {
+			t.Fatal("RefreshModelList() error = nil, want cancellation error")
+		}
+
+		var gatewayErr *core.GatewayError
+		if !errors.As(err, &gatewayErr) {
+			t.Fatalf("RefreshModelList() error = %T, want *core.GatewayError", err)
+		}
+		if gatewayErr.HTTPStatusCode() != http.StatusRequestTimeout {
+			t.Fatalf("status = %d, want 408", gatewayErr.HTTPStatusCode())
+		}
+		if gatewayErr.Provider != "model_registry" {
+			t.Fatalf("provider = %q, want model_registry", gatewayErr.Provider)
+		}
+	})
+
 	t.Run("DuplicateModels", func(t *testing.T) {
 		registry := NewModelRegistry()
 		mock1 := &registryMockProvider{

--- a/internal/providers/registry_test.go
+++ b/internal/providers/registry_test.go
@@ -384,6 +384,70 @@ func TestModelRegistry(t *testing.T) {
 		}
 	})
 
+	t.Run("RefreshModelListDownloadsAndEnrichesCurrentModels", func(t *testing.T) {
+		registry := NewModelRegistry()
+		mock := &registryMockProvider{
+			name: "openai-provider",
+			modelsResponse: &core.ModelsResponse{
+				Object: "list",
+				Data: []core.Model{
+					{
+						ID:      "gpt-test",
+						Object:  "model",
+						OwnedBy: "openai",
+					},
+				},
+			},
+		}
+		registry.RegisterProviderWithType(mock, "openai")
+		if err := registry.Initialize(context.Background()); err != nil {
+			t.Fatalf("Initialize() error = %v", err)
+		}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"version": 1,
+				"updated_at": "2026-04-11T00:00:00Z",
+				"providers": {
+					"openai": {
+						"display_name": "OpenAI",
+						"api_type": "openai",
+						"supported_modes": ["chat"]
+					}
+				},
+				"models": {
+					"gpt-test": {
+						"display_name": "GPT Test",
+						"modes": ["chat"],
+						"capabilities": {"tool_calling": true}
+					}
+				},
+				"provider_models": {}
+			}`))
+		}))
+		defer server.Close()
+
+		count, err := registry.RefreshModelList(context.Background(), server.URL)
+		if err != nil {
+			t.Fatalf("RefreshModelList() error = %v", err)
+		}
+		if count != 1 {
+			t.Fatalf("RefreshModelList() count = %d, want 1", count)
+		}
+
+		info := registry.GetModel("gpt-test")
+		if info == nil || info.Model.Metadata == nil {
+			t.Fatal("expected refreshed model metadata")
+		}
+		if info.Model.Metadata.DisplayName != "GPT Test" {
+			t.Fatalf("DisplayName = %q, want GPT Test", info.Model.Metadata.DisplayName)
+		}
+		if !info.Model.Metadata.Capabilities["tool_calling"] {
+			t.Fatal("expected tool_calling capability from refreshed model list")
+		}
+	})
+
 	t.Run("DuplicateModels", func(t *testing.T) {
 		registry := NewModelRegistry()
 		mock1 := &registryMockProvider{

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -308,6 +308,7 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 		adminAPI.GET("/audit/log", cfg.AdminHandler.AuditLog)
 		adminAPI.GET("/audit/conversation", cfg.AdminHandler.AuditConversation)
 		adminAPI.GET("/providers/status", cfg.AdminHandler.ProviderStatus)
+		adminAPI.POST("/runtime/refresh", cfg.AdminHandler.RefreshRuntime)
 		adminAPI.GET("/models", cfg.AdminHandler.ListModels)
 		adminAPI.GET("/models/categories", cfg.AdminHandler.ListCategories)
 		adminAPI.GET("/model-overrides", cfg.AdminHandler.ListModelOverrides)

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -470,8 +470,8 @@ func TestAdminExecutionPlanEndpoints_AreRegistered(t *testing.T) {
 		rec := httptest.NewRecorder()
 		srv.ServeHTTP(rec, req)
 
-		if rec.Code == http.StatusNotFound {
-			t.Fatalf("%s %s returned 404, want registered route", tc.method, tc.path)
+		if rec.Code == http.StatusNotFound || rec.Code == http.StatusMethodNotAllowed {
+			t.Fatalf("%s %s returned %d, want registered route and method", tc.method, tc.path, rec.Code)
 		}
 	}
 }

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -457,6 +457,7 @@ func TestAdminExecutionPlanEndpoints_AreRegistered(t *testing.T) {
 	}{
 		{method: http.MethodGet, path: "/admin/api/v1/dashboard/config"},
 		{method: http.MethodGet, path: "/admin/api/v1/providers/status"},
+		{method: http.MethodPost, path: "/admin/api/v1/runtime/refresh"},
 		{method: http.MethodGet, path: "/admin/api/v1/auth-keys"},
 		{method: http.MethodPost, path: "/admin/api/v1/auth-keys"},
 		{method: http.MethodPost, path: "/admin/api/v1/auth-keys/test-key/deactivate"},


### PR DESCRIPTION
## Summary
- add an admin runtime refresh endpoint and app orchestration for model metadata, provider inventory, and in-memory DB-backed snapshots
- add the Settings dashboard button and refresh result feedback
- serialize provider/model-list refreshes and cover disabled model overrides with regression tests

## Tests
- go test ./...
- node --test internal/admin/dashboard/static/js/modules/*.test.js
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings gains a "Runtime Refresh" section: a Refresh button, loading state, step-by-step status list, and success/warning notices showing model/provider counts.
  * Admin endpoint added to trigger runtime refresh from the UI.

* **Style**
  * Responsive styling and status-based colors for the runtime refresh block and step list; mobile stacks the layout.

* **Tests**
  * Added tests covering UI bindings, API success/failure, refresh orchestration, and model-list refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->