### PR TITLE
feat(dashboard): add usage by user path chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,8 @@ swagger:
 	go run github.com/swaggo/swag/cmd/swag init --generalInfo main.go \
 		--dir cmd/gomodel,internal \
 		--output cmd/gomodel/docs \
-		--outputTypes go,json
+		--outputTypes go,json \
+		--parseDependency
 
 # Run linter
 lint:

--- a/cmd/gomodel/docs/docs.go
+++ b/cmd/gomodel/docs/docs.go
@@ -2104,9 +2104,9 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "SSE stream (text/event-stream) when stream=true",
+                        "description": "JSON response or SSE stream when stream=true",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/core.ResponsesResponse"
                         }
                     },
                     "400": {
@@ -2647,9 +2647,48 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "logprobs": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
+                    "type": "object",
+                    "properties": {
+                        "content": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "bytes": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "logprob": {
+                                        "type": "number"
+                                    },
+                                    "token": {
+                                        "type": "string"
+                                    },
+                                    "top_logprobs": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "bytes": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "integer"
+                                                    }
+                                                },
+                                                "logprob": {
+                                                    "type": "number"
+                                                },
+                                                "token": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 },
                 "message": {
@@ -2854,13 +2893,15 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "code": {
-                    "type": "string"
+                    "type": "string",
+                    "x-nullable": true
                 },
                 "message": {
                     "type": "string"
                 },
                 "param": {
-                    "type": "string"
+                    "type": "string",
+                    "x-nullable": true
                 },
                 "provider": {
                     "type": "string"
@@ -3180,10 +3221,7 @@ const docTemplate = `{
                     "description": "Providers can return structured annotation objects here (for example\ncitations from native tools), so keep the payload shape liberal.",
                     "type": "array",
                     "items": {
-                        "type": "array",
-                        "items": {
-                            "type": "integer"
-                        }
+                        "type": "object"
                     }
                 },
                 "image_url": {
@@ -3697,19 +3735,22 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "input_cost": {
-                    "type": "number"
+                    "type": "number",
+                    "x-nullable": true
                 },
                 "input_tokens": {
                     "type": "integer"
                 },
                 "output_cost": {
-                    "type": "number"
+                    "type": "number",
+                    "x-nullable": true
                 },
                 "output_tokens": {
                     "type": "integer"
                 },
                 "total_cost": {
-                    "type": "number"
+                    "type": "number",
+                    "x-nullable": true
                 },
                 "total_tokens": {
                     "type": "integer"

--- a/cmd/gomodel/docs/docs.go
+++ b/cmd/gomodel/docs/docs.go
@@ -96,13 +96,13 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Filter by model name",
-                        "name": "model",
+                        "description": "Filter by requested model selector",
+                        "name": "requested_model",
                         "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "Filter by provider",
+                        "description": "Filter by provider name or provider type",
                         "name": "provider",
                         "in": "query"
                     },
@@ -116,6 +116,12 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Filter by request path",
                         "name": "path",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by tracked user path subtree",
+                        "name": "user_path",
                         "in": "query"
                     },
                     {
@@ -138,7 +144,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Search across request_id/model/provider/method/path/error_type",
+                        "description": "Search across request_id/requested_model/provider/method/path/error_type",
                         "name": "search",
                         "in": "query"
                     },
@@ -182,7 +188,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/admin/api/v1/models": {
+        "/admin/api/v1/cache/overview": {
             "get": {
                 "produces": [
                     "application/json"
@@ -190,19 +196,66 @@ const docTemplate = `{
                 "tags": [
                     "admin"
                 ],
-                "summary": "List all registered models with provider info",
+                "summary": "Get cached-only usage overview",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Number of days (default 30)",
+                        "name": "days",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Start date (YYYY-MM-DD)",
+                        "name": "start_date",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End date (YYYY-MM-DD)",
+                        "name": "end_date",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Grouping interval: daily, weekly, monthly, yearly (default daily)",
+                        "name": "interval",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by tracked user path subtree",
+                        "name": "user_path",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cache mode filter: uncached, cached, all (cache overview always uses cached mode)",
+                        "name": "cache_mode",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/providers.ModelWithProvider"
-                            }
+                            "$ref": "#/definitions/usage.CacheOverview"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
                         "schema": {
                             "$ref": "#/definitions/core.GatewayError"
                         }
@@ -281,6 +334,18 @@ const docTemplate = `{
                         "description": "Grouping interval: daily, weekly, monthly, yearly (default daily)",
                         "name": "interval",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by tracked user path subtree",
+                        "name": "user_path",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cache mode filter: uncached, cached, all (default uncached)",
+                        "name": "cache_mode",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -349,8 +414,20 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Filter by provider",
+                        "description": "Filter by provider name or provider type",
                         "name": "provider",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by tracked user path subtree",
+                        "name": "user_path",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cache mode filter: uncached, cached, all (default uncached)",
+                        "name": "cache_mode",
                         "in": "query"
                     },
                     {
@@ -426,6 +503,18 @@ const docTemplate = `{
                         "description": "End date (YYYY-MM-DD)",
                         "name": "end_date",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by tracked user path subtree",
+                        "name": "user_path",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cache mode filter: uncached, cached, all (default uncached)",
+                        "name": "cache_mode",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -485,6 +574,18 @@ const docTemplate = `{
                         "description": "End date (YYYY-MM-DD)",
                         "name": "end_date",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by tracked user path subtree",
+                        "name": "user_path",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cache mode filter: uncached, cached, all (default uncached)",
+                        "name": "cache_mode",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -492,6 +593,77 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/usage.UsageSummary"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/admin/api/v1/usage/user-paths": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Get usage breakdown by user path",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Number of days (default 30)",
+                        "name": "days",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Start date (YYYY-MM-DD)",
+                        "name": "start_date",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End date (YYYY-MM-DD)",
+                        "name": "end_date",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by tracked user path subtree",
+                        "name": "user_path",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cache mode filter: uncached, cached, all (default uncached)",
+                        "name": "cache_mode",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/usage.UserPathUsage"
+                            }
                         }
                     },
                     "400": {
@@ -538,7 +710,7 @@ const docTemplate = `{
         },
         "/p/{provider}/{endpoint}": {
             "get": {
-                "description": "Runtime-configurable passthrough endpoint under /p/{provider}/{endpoint}; enabled by default via server.enable_passthrough_routes and restricted to providers listed in server.enabled_passthrough_providers. The endpoint path is opaque and may proxy JSON, binary, or SSE responses with upstream status codes preserved. For multi-segment provider endpoints, clients that rely on OpenAPI-generated path handling should URL-encode embedded slashes in the endpoint parameter. A leading v1/ segment is normalized away by default so /p/{provider}/v1/... and /p/{provider}/... map to the same upstream path relative to the provider base URL.",
+                "description": "Runtime-configurable passthrough endpoint under /p/{provider}/{endpoint}; enabled by default via server.enable_passthrough_routes. The endpoint path is opaque and may proxy JSON, binary, or SSE responses with upstream status codes preserved. For multi-segment provider endpoints, clients that rely on OpenAPI-generated path handling should URL-encode embedded slashes in the endpoint parameter. A leading v1/ segment is normalized away by default so /p/{provider}/v1/... and /p/{provider}/... map to the same upstream path relative to the provider base URL.",
                 "consumes": [
                     "application/json",
                     "multipart/form-data"
@@ -619,7 +791,7 @@ const docTemplate = `{
                 ]
             },
             "put": {
-                "description": "Runtime-configurable passthrough endpoint under /p/{provider}/{endpoint}; enabled by default via server.enable_passthrough_routes and restricted to providers listed in server.enabled_passthrough_providers. The endpoint path is opaque and may proxy JSON, binary, or SSE responses with upstream status codes preserved. For multi-segment provider endpoints, clients that rely on OpenAPI-generated path handling should URL-encode embedded slashes in the endpoint parameter. A leading v1/ segment is normalized away by default so /p/{provider}/v1/... and /p/{provider}/... map to the same upstream path relative to the provider base URL.",
+                "description": "Runtime-configurable passthrough endpoint under /p/{provider}/{endpoint}; enabled by default via server.enable_passthrough_routes. The endpoint path is opaque and may proxy JSON, binary, or SSE responses with upstream status codes preserved. For multi-segment provider endpoints, clients that rely on OpenAPI-generated path handling should URL-encode embedded slashes in the endpoint parameter. A leading v1/ segment is normalized away by default so /p/{provider}/v1/... and /p/{provider}/... map to the same upstream path relative to the provider base URL.",
                 "consumes": [
                     "application/json",
                     "multipart/form-data"
@@ -700,7 +872,7 @@ const docTemplate = `{
                 ]
             },
             "post": {
-                "description": "Runtime-configurable passthrough endpoint under /p/{provider}/{endpoint}; enabled by default via server.enable_passthrough_routes and restricted to providers listed in server.enabled_passthrough_providers. The endpoint path is opaque and may proxy JSON, binary, or SSE responses with upstream status codes preserved. For multi-segment provider endpoints, clients that rely on OpenAPI-generated path handling should URL-encode embedded slashes in the endpoint parameter. A leading v1/ segment is normalized away by default so /p/{provider}/v1/... and /p/{provider}/... map to the same upstream path relative to the provider base URL.",
+                "description": "Runtime-configurable passthrough endpoint under /p/{provider}/{endpoint}; enabled by default via server.enable_passthrough_routes. The endpoint path is opaque and may proxy JSON, binary, or SSE responses with upstream status codes preserved. For multi-segment provider endpoints, clients that rely on OpenAPI-generated path handling should URL-encode embedded slashes in the endpoint parameter. A leading v1/ segment is normalized away by default so /p/{provider}/v1/... and /p/{provider}/... map to the same upstream path relative to the provider base URL.",
                 "consumes": [
                     "application/json",
                     "multipart/form-data"
@@ -781,7 +953,7 @@ const docTemplate = `{
                 ]
             },
             "delete": {
-                "description": "Runtime-configurable passthrough endpoint under /p/{provider}/{endpoint}; enabled by default via server.enable_passthrough_routes and restricted to providers listed in server.enabled_passthrough_providers. The endpoint path is opaque and may proxy JSON, binary, or SSE responses with upstream status codes preserved. For multi-segment provider endpoints, clients that rely on OpenAPI-generated path handling should URL-encode embedded slashes in the endpoint parameter. A leading v1/ segment is normalized away by default so /p/{provider}/v1/... and /p/{provider}/... map to the same upstream path relative to the provider base URL.",
+                "description": "Runtime-configurable passthrough endpoint under /p/{provider}/{endpoint}; enabled by default via server.enable_passthrough_routes. The endpoint path is opaque and may proxy JSON, binary, or SSE responses with upstream status codes preserved. For multi-segment provider endpoints, clients that rely on OpenAPI-generated path handling should URL-encode embedded slashes in the endpoint parameter. A leading v1/ segment is normalized away by default so /p/{provider}/v1/... and /p/{provider}/... map to the same upstream path relative to the provider base URL.",
                 "consumes": [
                     "application/json",
                     "multipart/form-data"
@@ -862,7 +1034,7 @@ const docTemplate = `{
                 ]
             },
             "options": {
-                "description": "Runtime-configurable passthrough endpoint under /p/{provider}/{endpoint}; enabled by default via server.enable_passthrough_routes and restricted to providers listed in server.enabled_passthrough_providers. The endpoint path is opaque and may proxy JSON, binary, or SSE responses with upstream status codes preserved. For multi-segment provider endpoints, clients that rely on OpenAPI-generated path handling should URL-encode embedded slashes in the endpoint parameter. A leading v1/ segment is normalized away by default so /p/{provider}/v1/... and /p/{provider}/... map to the same upstream path relative to the provider base URL.",
+                "description": "Runtime-configurable passthrough endpoint under /p/{provider}/{endpoint}; enabled by default via server.enable_passthrough_routes. The endpoint path is opaque and may proxy JSON, binary, or SSE responses with upstream status codes preserved. For multi-segment provider endpoints, clients that rely on OpenAPI-generated path handling should URL-encode embedded slashes in the endpoint parameter. A leading v1/ segment is normalized away by default so /p/{provider}/v1/... and /p/{provider}/... map to the same upstream path relative to the provider base URL.",
                 "consumes": [
                     "application/json",
                     "multipart/form-data"
@@ -943,7 +1115,7 @@ const docTemplate = `{
                 ]
             },
             "head": {
-                "description": "Runtime-configurable passthrough endpoint under /p/{provider}/{endpoint}; enabled by default via server.enable_passthrough_routes and restricted to providers listed in server.enabled_passthrough_providers. The endpoint path is opaque and may proxy JSON, binary, or SSE responses with upstream status codes preserved. For multi-segment provider endpoints, clients that rely on OpenAPI-generated path handling should URL-encode embedded slashes in the endpoint parameter. A leading v1/ segment is normalized away by default so /p/{provider}/v1/... and /p/{provider}/... map to the same upstream path relative to the provider base URL.",
+                "description": "Runtime-configurable passthrough endpoint under /p/{provider}/{endpoint}; enabled by default via server.enable_passthrough_routes. The endpoint path is opaque and may proxy JSON, binary, or SSE responses with upstream status codes preserved. For multi-segment provider endpoints, clients that rely on OpenAPI-generated path handling should URL-encode embedded slashes in the endpoint parameter. A leading v1/ segment is normalized away by default so /p/{provider}/v1/... and /p/{provider}/... map to the same upstream path relative to the provider base URL.",
                 "consumes": [
                     "application/json",
                     "multipart/form-data"
@@ -1024,7 +1196,7 @@ const docTemplate = `{
                 ]
             },
             "patch": {
-                "description": "Runtime-configurable passthrough endpoint under /p/{provider}/{endpoint}; enabled by default via server.enable_passthrough_routes and restricted to providers listed in server.enabled_passthrough_providers. The endpoint path is opaque and may proxy JSON, binary, or SSE responses with upstream status codes preserved. For multi-segment provider endpoints, clients that rely on OpenAPI-generated path handling should URL-encode embedded slashes in the endpoint parameter. A leading v1/ segment is normalized away by default so /p/{provider}/v1/... and /p/{provider}/... map to the same upstream path relative to the provider base URL.",
+                "description": "Runtime-configurable passthrough endpoint under /p/{provider}/{endpoint}; enabled by default via server.enable_passthrough_routes. The endpoint path is opaque and may proxy JSON, binary, or SSE responses with upstream status codes preserved. For multi-segment provider endpoints, clients that rely on OpenAPI-generated path handling should URL-encode embedded slashes in the endpoint parameter. A leading v1/ segment is normalized away by default so /p/{provider}/v1/... and /p/{provider}/... map to the same upstream path relative to the provider base URL.",
                 "consumes": [
                     "application/json",
                     "multipart/form-data"
@@ -1912,7 +2084,8 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "produces": [
-                    "application/json"
+                    "application/json",
+                    "text/event-stream"
                 ],
                 "tags": [
                     "responses"
@@ -1931,9 +2104,9 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "SSE stream (text/event-stream) when stream=true",
                         "schema": {
-                            "$ref": "#/definitions/core.ResponsesResponse"
+                            "type": "string"
                         }
                     },
                     "400": {
@@ -1984,6 +2157,26 @@ const docTemplate = `{
                 }
             }
         },
+        "auditlog.ExecutionFeaturesSnapshot": {
+            "type": "object",
+            "properties": {
+                "audit": {
+                    "type": "boolean"
+                },
+                "cache": {
+                    "type": "boolean"
+                },
+                "fallback": {
+                    "type": "boolean"
+                },
+                "guardrails": {
+                    "type": "boolean"
+                },
+                "usage": {
+                    "type": "boolean"
+                }
+            }
+        },
         "auditlog.LogData": {
             "type": "object",
             "properties": {
@@ -1993,6 +2186,14 @@ const docTemplate = `{
                 "error_message": {
                     "description": "Error details (message can be long, so kept in JSON)",
                     "type": "string"
+                },
+                "execution_features": {
+                    "description": "ExecutionFeatures captures the request-time effective workflow features\nafter runtime caps were applied. This keeps audit views historically accurate\neven if the active process config changes later.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/auditlog.ExecutionFeaturesSnapshot"
+                        }
+                    ]
                 },
                 "max_tokens": {
                     "type": "integer"
@@ -2034,6 +2235,18 @@ const docTemplate = `{
         "auditlog.LogEntry": {
             "type": "object",
             "properties": {
+                "alias_used": {
+                    "type": "boolean"
+                },
+                "auth_key_id": {
+                    "type": "string"
+                },
+                "auth_method": {
+                    "type": "string"
+                },
+                "cache_type": {
+                    "type": "string"
+                },
                 "client_ip": {
                     "type": "string"
                 },
@@ -2052,6 +2265,9 @@ const docTemplate = `{
                 "error_type": {
                     "type": "string"
                 },
+                "execution_plan_version_id": {
+                    "type": "string"
+                },
                 "id": {
                     "description": "ID is a unique identifier for this log entry (UUID)",
                     "type": "string"
@@ -2059,18 +2275,25 @@ const docTemplate = `{
                 "method": {
                     "type": "string"
                 },
-                "model": {
-                    "description": "Core fields (indexed for queries)",
-                    "type": "string"
-                },
                 "path": {
                     "type": "string"
                 },
                 "provider": {
+                    "description": "canonical provider type used for routing and filters",
+                    "type": "string"
+                },
+                "provider_name": {
                     "type": "string"
                 },
                 "request_id": {
                     "description": "Extracted fields for efficient filtering (indexed in relational DBs)",
+                    "type": "string"
+                },
+                "requested_model": {
+                    "description": "Core fields (indexed for queries)",
+                    "type": "string"
+                },
+                "resolved_model": {
                     "type": "string"
                 },
                 "status_code": {
@@ -2081,6 +2304,9 @@ const docTemplate = `{
                 },
                 "timestamp": {
                     "description": "Timestamp is when the request started",
+                    "type": "string"
+                },
+                "user_path": {
                     "type": "string"
                 }
             }
@@ -2352,6 +2578,7 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "provider": {
+                    "description": "Gateway routing hint; stripped before upstream execution.",
                     "type": "string"
                 },
                 "reasoning": {
@@ -2402,6 +2629,9 @@ const docTemplate = `{
                 "provider": {
                     "type": "string"
                 },
+                "system_fingerprint": {
+                    "type": "string"
+                },
                 "usage": {
                     "$ref": "#/definitions/core.Usage"
                 }
@@ -2415,6 +2645,12 @@ const docTemplate = `{
                 },
                 "index": {
                     "type": "integer"
+                },
+                "logprobs": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
                 },
                 "message": {
                     "$ref": "#/definitions/core.ResponseMessage"
@@ -2483,6 +2719,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "provider": {
+                    "description": "Gateway routing hint; stripped before upstream execution.",
                     "type": "string"
                 }
             }
@@ -2616,7 +2853,13 @@ const docTemplate = `{
         "core.GatewayError": {
             "type": "object",
             "properties": {
+                "code": {
+                    "type": "string"
+                },
                 "message": {
+                    "type": "string"
+                },
+                "param": {
                     "type": "string"
                 },
                 "provider": {
@@ -2765,6 +3008,12 @@ const docTemplate = `{
                 "pricing": {
                     "$ref": "#/definitions/core.ModelPricing"
                 },
+                "rankings": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/core.ModelRanking"
+                    }
+                },
                 "tags": {
                     "type": "array",
                     "items": {
@@ -2849,6 +3098,20 @@ const docTemplate = `{
                 }
             }
         },
+        "core.ModelRanking": {
+            "type": "object",
+            "properties": {
+                "as_of": {
+                    "type": "string"
+                },
+                "elo": {
+                    "type": "number"
+                },
+                "rank": {
+                    "type": "integer"
+                }
+            }
+        },
         "core.ModelsResponse": {
             "type": "object",
             "properties": {
@@ -2914,9 +3177,13 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "annotations": {
+                    "description": "Providers can return structured annotation objects here (for example\ncitations from native tools), so keep the payload shape liberal.",
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
                     }
                 },
                 "image_url": {
@@ -3044,6 +3311,7 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "provider": {
+                    "description": "Gateway routing hint; stripped before upstream execution.",
                     "type": "string"
                 },
                 "reasoning": {
@@ -3192,14 +3460,72 @@ const docTemplate = `{
                 }
             }
         },
-        "providers.ModelWithProvider": {
+        "usage.CacheOverview": {
             "type": "object",
             "properties": {
-                "model": {
-                    "$ref": "#/definitions/core.Model"
+                "daily": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/usage.CacheOverviewDaily"
+                    }
                 },
-                "provider_type": {
+                "summary": {
+                    "$ref": "#/definitions/usage.CacheOverviewSummary"
+                }
+            }
+        },
+        "usage.CacheOverviewDaily": {
+            "type": "object",
+            "properties": {
+                "date": {
                     "type": "string"
+                },
+                "exact_hits": {
+                    "type": "integer"
+                },
+                "hits": {
+                    "type": "integer"
+                },
+                "input_tokens": {
+                    "type": "integer"
+                },
+                "output_tokens": {
+                    "type": "integer"
+                },
+                "saved_cost": {
+                    "type": "number"
+                },
+                "semantic_hits": {
+                    "type": "integer"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                }
+            }
+        },
+        "usage.CacheOverviewSummary": {
+            "type": "object",
+            "properties": {
+                "exact_hits": {
+                    "type": "integer"
+                },
+                "semantic_hits": {
+                    "type": "integer"
+                },
+                "total_hits": {
+                    "type": "integer"
+                },
+                "total_input_tokens": {
+                    "type": "integer"
+                },
+                "total_output_tokens": {
+                    "type": "integer"
+                },
+                "total_saved_cost": {
+                    "type": "number"
+                },
+                "total_tokens": {
+                    "type": "integer"
                 }
             }
         },
@@ -3209,14 +3535,23 @@ const docTemplate = `{
                 "date": {
                     "type": "string"
                 },
+                "input_cost": {
+                    "type": "number"
+                },
                 "input_tokens": {
                     "type": "integer"
+                },
+                "output_cost": {
+                    "type": "number"
                 },
                 "output_tokens": {
                     "type": "integer"
                 },
                 "requests": {
                     "type": "integer"
+                },
+                "total_cost": {
+                    "type": "number"
                 },
                 "total_tokens": {
                     "type": "integer"
@@ -3244,6 +3579,9 @@ const docTemplate = `{
                 "provider": {
                     "type": "string"
                 },
+                "provider_name": {
+                    "type": "string"
+                },
                 "total_cost": {
                     "type": "number"
                 }
@@ -3252,6 +3590,9 @@ const docTemplate = `{
         "usage.UsageLogEntry": {
             "type": "object",
             "properties": {
+                "cache_type": {
+                    "type": "string"
+                },
                 "costs_calculation_caveat": {
                     "type": "string"
                 },
@@ -3282,6 +3623,9 @@ const docTemplate = `{
                 "provider_id": {
                     "type": "string"
                 },
+                "provider_name": {
+                    "type": "string"
+                },
                 "raw_data": {
                     "type": "object",
                     "additionalProperties": {}
@@ -3297,6 +3641,9 @@ const docTemplate = `{
                 },
                 "total_tokens": {
                     "type": "integer"
+                },
+                "user_path": {
+                    "type": "string"
                 }
             }
         },
@@ -3345,6 +3692,32 @@ const docTemplate = `{
                     "type": "integer"
                 }
             }
+        },
+        "usage.UserPathUsage": {
+            "type": "object",
+            "properties": {
+                "input_cost": {
+                    "type": "number"
+                },
+                "input_tokens": {
+                    "type": "integer"
+                },
+                "output_cost": {
+                    "type": "number"
+                },
+                "output_tokens": {
+                    "type": "integer"
+                },
+                "total_cost": {
+                    "type": "number"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                },
+                "user_path": {
+                    "type": "string"
+                }
+            }
         }
     },
     "securityDefinitions": {
@@ -3363,7 +3736,7 @@ var SwaggerInfo = &swag.Spec{
 	BasePath:         "/",
 	Schemes:          []string{"http"},
 	Title:            "GOModel API",
-	Description:      "High-performance AI gateway routing requests to multiple LLM providers (OpenAI, Anthropic, Gemini, Groq, xAI, Ollama). Drop-in OpenAI-compatible API.",
+	Description:      "High-performance AI gateway routing requests to multiple LLM providers (OpenAI, Anthropic, Gemini, Groq, xAI, Oracle, Ollama). Drop-in OpenAI-compatible API.",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,
 	LeftDelim:        "{{",

--- a/cmd/gomodel/docs/swagger.json
+++ b/cmd/gomodel/docs/swagger.json
@@ -2100,9 +2100,9 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "SSE stream (text/event-stream) when stream=true",
+                        "description": "JSON response or SSE stream when stream=true",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/core.ResponsesResponse"
                         }
                     },
                     "400": {
@@ -2643,9 +2643,48 @@
                     "type": "integer"
                 },
                 "logprobs": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
+                    "type": "object",
+                    "properties": {
+                        "content": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "bytes": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "logprob": {
+                                        "type": "number"
+                                    },
+                                    "token": {
+                                        "type": "string"
+                                    },
+                                    "top_logprobs": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "bytes": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "integer"
+                                                    }
+                                                },
+                                                "logprob": {
+                                                    "type": "number"
+                                                },
+                                                "token": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 },
                 "message": {
@@ -2850,13 +2889,15 @@
             "type": "object",
             "properties": {
                 "code": {
-                    "type": "string"
+                    "type": "string",
+                    "x-nullable": true
                 },
                 "message": {
                     "type": "string"
                 },
                 "param": {
-                    "type": "string"
+                    "type": "string",
+                    "x-nullable": true
                 },
                 "provider": {
                     "type": "string"
@@ -3176,10 +3217,7 @@
                     "description": "Providers can return structured annotation objects here (for example\ncitations from native tools), so keep the payload shape liberal.",
                     "type": "array",
                     "items": {
-                        "type": "array",
-                        "items": {
-                            "type": "integer"
-                        }
+                        "type": "object"
                     }
                 },
                 "image_url": {
@@ -3693,19 +3731,22 @@
             "type": "object",
             "properties": {
                 "input_cost": {
-                    "type": "number"
+                    "type": "number",
+                    "x-nullable": true
                 },
                 "input_tokens": {
                     "type": "integer"
                 },
                 "output_cost": {
-                    "type": "number"
+                    "type": "number",
+                    "x-nullable": true
                 },
                 "output_tokens": {
                     "type": "integer"
                 },
                 "total_cost": {
-                    "type": "number"
+                    "type": "number",
+                    "x-nullable": true
                 },
                 "total_tokens": {
                     "type": "integer"

--- a/cmd/gomodel/docs/swagger.json
+++ b/cmd/gomodel/docs/swagger.json
@@ -4,7 +4,7 @@
     ],
     "swagger": "2.0",
     "info": {
-        "description": "High-performance AI gateway routing requests to multiple LLM providers (OpenAI, Anthropic, Gemini, Groq, xAI, Ollama). Drop-in OpenAI-compatible API.",
+        "description": "High-performance AI gateway routing requests to multiple LLM providers (OpenAI, Anthropic, Gemini, Groq, xAI, Oracle, Ollama). Drop-in OpenAI-compatible API.",
         "title": "GOModel API",
         "contact": {},
         "version": "1.0"
@@ -92,13 +92,13 @@
                     },
                     {
                         "type": "string",
-                        "description": "Filter by model name",
-                        "name": "model",
+                        "description": "Filter by requested model selector",
+                        "name": "requested_model",
                         "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "Filter by provider",
+                        "description": "Filter by provider name or provider type",
                         "name": "provider",
                         "in": "query"
                     },
@@ -112,6 +112,12 @@
                         "type": "string",
                         "description": "Filter by request path",
                         "name": "path",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by tracked user path subtree",
+                        "name": "user_path",
                         "in": "query"
                     },
                     {
@@ -134,7 +140,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "Search across request_id/model/provider/method/path/error_type",
+                        "description": "Search across request_id/requested_model/provider/method/path/error_type",
                         "name": "search",
                         "in": "query"
                     },
@@ -178,7 +184,7 @@
                 ]
             }
         },
-        "/admin/api/v1/models": {
+        "/admin/api/v1/cache/overview": {
             "get": {
                 "produces": [
                     "application/json"
@@ -186,19 +192,66 @@
                 "tags": [
                     "admin"
                 ],
-                "summary": "List all registered models with provider info",
+                "summary": "Get cached-only usage overview",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Number of days (default 30)",
+                        "name": "days",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Start date (YYYY-MM-DD)",
+                        "name": "start_date",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End date (YYYY-MM-DD)",
+                        "name": "end_date",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Grouping interval: daily, weekly, monthly, yearly (default daily)",
+                        "name": "interval",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by tracked user path subtree",
+                        "name": "user_path",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cache mode filter: uncached, cached, all (cache overview always uses cached mode)",
+                        "name": "cache_mode",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/providers.ModelWithProvider"
-                            }
+                            "$ref": "#/definitions/usage.CacheOverview"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
                         "schema": {
                             "$ref": "#/definitions/core.GatewayError"
                         }
@@ -277,6 +330,18 @@
                         "description": "Grouping interval: daily, weekly, monthly, yearly (default daily)",
                         "name": "interval",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by tracked user path subtree",
+                        "name": "user_path",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cache mode filter: uncached, cached, all (default uncached)",
+                        "name": "cache_mode",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -345,8 +410,20 @@
                     },
                     {
                         "type": "string",
-                        "description": "Filter by provider",
+                        "description": "Filter by provider name or provider type",
                         "name": "provider",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by tracked user path subtree",
+                        "name": "user_path",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cache mode filter: uncached, cached, all (default uncached)",
+                        "name": "cache_mode",
                         "in": "query"
                     },
                     {
@@ -422,6 +499,18 @@
                         "description": "End date (YYYY-MM-DD)",
                         "name": "end_date",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by tracked user path subtree",
+                        "name": "user_path",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cache mode filter: uncached, cached, all (default uncached)",
+                        "name": "cache_mode",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -481,6 +570,18 @@
                         "description": "End date (YYYY-MM-DD)",
                         "name": "end_date",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by tracked user path subtree",
+                        "name": "user_path",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cache mode filter: uncached, cached, all (default uncached)",
+                        "name": "cache_mode",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -488,6 +589,77 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/usage.UsageSummary"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/admin/api/v1/usage/user-paths": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Get usage breakdown by user path",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Number of days (default 30)",
+                        "name": "days",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Start date (YYYY-MM-DD)",
+                        "name": "start_date",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End date (YYYY-MM-DD)",
+                        "name": "end_date",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by tracked user path subtree",
+                        "name": "user_path",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Cache mode filter: uncached, cached, all (default uncached)",
+                        "name": "cache_mode",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/usage.UserPathUsage"
+                            }
                         }
                     },
                     "400": {
@@ -1908,7 +2080,8 @@
                     "application/json"
                 ],
                 "produces": [
-                    "application/json"
+                    "application/json",
+                    "text/event-stream"
                 ],
                 "tags": [
                     "responses"
@@ -1927,9 +2100,9 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "SSE stream (text/event-stream) when stream=true",
                         "schema": {
-                            "$ref": "#/definitions/core.ResponsesResponse"
+                            "type": "string"
                         }
                     },
                     "400": {
@@ -1980,6 +2153,26 @@
                 }
             }
         },
+        "auditlog.ExecutionFeaturesSnapshot": {
+            "type": "object",
+            "properties": {
+                "audit": {
+                    "type": "boolean"
+                },
+                "cache": {
+                    "type": "boolean"
+                },
+                "fallback": {
+                    "type": "boolean"
+                },
+                "guardrails": {
+                    "type": "boolean"
+                },
+                "usage": {
+                    "type": "boolean"
+                }
+            }
+        },
         "auditlog.LogData": {
             "type": "object",
             "properties": {
@@ -1989,6 +2182,14 @@
                 "error_message": {
                     "description": "Error details (message can be long, so kept in JSON)",
                     "type": "string"
+                },
+                "execution_features": {
+                    "description": "ExecutionFeatures captures the request-time effective workflow features\nafter runtime caps were applied. This keeps audit views historically accurate\neven if the active process config changes later.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/auditlog.ExecutionFeaturesSnapshot"
+                        }
+                    ]
                 },
                 "max_tokens": {
                     "type": "integer"
@@ -2030,6 +2231,18 @@
         "auditlog.LogEntry": {
             "type": "object",
             "properties": {
+                "alias_used": {
+                    "type": "boolean"
+                },
+                "auth_key_id": {
+                    "type": "string"
+                },
+                "auth_method": {
+                    "type": "string"
+                },
+                "cache_type": {
+                    "type": "string"
+                },
                 "client_ip": {
                     "type": "string"
                 },
@@ -2048,6 +2261,9 @@
                 "error_type": {
                     "type": "string"
                 },
+                "execution_plan_version_id": {
+                    "type": "string"
+                },
                 "id": {
                     "description": "ID is a unique identifier for this log entry (UUID)",
                     "type": "string"
@@ -2055,18 +2271,25 @@
                 "method": {
                     "type": "string"
                 },
-                "model": {
-                    "description": "Core fields (indexed for queries)",
-                    "type": "string"
-                },
                 "path": {
                     "type": "string"
                 },
                 "provider": {
+                    "description": "canonical provider type used for routing and filters",
+                    "type": "string"
+                },
+                "provider_name": {
                     "type": "string"
                 },
                 "request_id": {
                     "description": "Extracted fields for efficient filtering (indexed in relational DBs)",
+                    "type": "string"
+                },
+                "requested_model": {
+                    "description": "Core fields (indexed for queries)",
+                    "type": "string"
+                },
+                "resolved_model": {
                     "type": "string"
                 },
                 "status_code": {
@@ -2077,6 +2300,9 @@
                 },
                 "timestamp": {
                     "description": "Timestamp is when the request started",
+                    "type": "string"
+                },
+                "user_path": {
                     "type": "string"
                 }
             }
@@ -2348,6 +2574,7 @@
                     "type": "boolean"
                 },
                 "provider": {
+                    "description": "Gateway routing hint; stripped before upstream execution.",
                     "type": "string"
                 },
                 "reasoning": {
@@ -2398,6 +2625,9 @@
                 "provider": {
                     "type": "string"
                 },
+                "system_fingerprint": {
+                    "type": "string"
+                },
                 "usage": {
                     "$ref": "#/definitions/core.Usage"
                 }
@@ -2411,6 +2641,12 @@
                 },
                 "index": {
                     "type": "integer"
+                },
+                "logprobs": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
                 },
                 "message": {
                     "$ref": "#/definitions/core.ResponseMessage"
@@ -2479,6 +2715,7 @@
                     "type": "string"
                 },
                 "provider": {
+                    "description": "Gateway routing hint; stripped before upstream execution.",
                     "type": "string"
                 }
             }
@@ -2612,7 +2849,13 @@
         "core.GatewayError": {
             "type": "object",
             "properties": {
+                "code": {
+                    "type": "string"
+                },
                 "message": {
+                    "type": "string"
+                },
+                "param": {
                     "type": "string"
                 },
                 "provider": {
@@ -2761,6 +3004,12 @@
                 "pricing": {
                     "$ref": "#/definitions/core.ModelPricing"
                 },
+                "rankings": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/core.ModelRanking"
+                    }
+                },
                 "tags": {
                     "type": "array",
                     "items": {
@@ -2845,6 +3094,20 @@
                 }
             }
         },
+        "core.ModelRanking": {
+            "type": "object",
+            "properties": {
+                "as_of": {
+                    "type": "string"
+                },
+                "elo": {
+                    "type": "number"
+                },
+                "rank": {
+                    "type": "integer"
+                }
+            }
+        },
         "core.ModelsResponse": {
             "type": "object",
             "properties": {
@@ -2910,9 +3173,13 @@
             "type": "object",
             "properties": {
                 "annotations": {
+                    "description": "Providers can return structured annotation objects here (for example\ncitations from native tools), so keep the payload shape liberal.",
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
                     }
                 },
                 "image_url": {
@@ -3040,6 +3307,7 @@
                     "type": "boolean"
                 },
                 "provider": {
+                    "description": "Gateway routing hint; stripped before upstream execution.",
                     "type": "string"
                 },
                 "reasoning": {
@@ -3188,14 +3456,72 @@
                 }
             }
         },
-        "providers.ModelWithProvider": {
+        "usage.CacheOverview": {
             "type": "object",
             "properties": {
-                "model": {
-                    "$ref": "#/definitions/core.Model"
+                "daily": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/usage.CacheOverviewDaily"
+                    }
                 },
-                "provider_type": {
+                "summary": {
+                    "$ref": "#/definitions/usage.CacheOverviewSummary"
+                }
+            }
+        },
+        "usage.CacheOverviewDaily": {
+            "type": "object",
+            "properties": {
+                "date": {
                     "type": "string"
+                },
+                "exact_hits": {
+                    "type": "integer"
+                },
+                "hits": {
+                    "type": "integer"
+                },
+                "input_tokens": {
+                    "type": "integer"
+                },
+                "output_tokens": {
+                    "type": "integer"
+                },
+                "saved_cost": {
+                    "type": "number"
+                },
+                "semantic_hits": {
+                    "type": "integer"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                }
+            }
+        },
+        "usage.CacheOverviewSummary": {
+            "type": "object",
+            "properties": {
+                "exact_hits": {
+                    "type": "integer"
+                },
+                "semantic_hits": {
+                    "type": "integer"
+                },
+                "total_hits": {
+                    "type": "integer"
+                },
+                "total_input_tokens": {
+                    "type": "integer"
+                },
+                "total_output_tokens": {
+                    "type": "integer"
+                },
+                "total_saved_cost": {
+                    "type": "number"
+                },
+                "total_tokens": {
+                    "type": "integer"
                 }
             }
         },
@@ -3205,14 +3531,23 @@
                 "date": {
                     "type": "string"
                 },
+                "input_cost": {
+                    "type": "number"
+                },
                 "input_tokens": {
                     "type": "integer"
+                },
+                "output_cost": {
+                    "type": "number"
                 },
                 "output_tokens": {
                     "type": "integer"
                 },
                 "requests": {
                     "type": "integer"
+                },
+                "total_cost": {
+                    "type": "number"
                 },
                 "total_tokens": {
                     "type": "integer"
@@ -3240,6 +3575,9 @@
                 "provider": {
                     "type": "string"
                 },
+                "provider_name": {
+                    "type": "string"
+                },
                 "total_cost": {
                     "type": "number"
                 }
@@ -3248,6 +3586,9 @@
         "usage.UsageLogEntry": {
             "type": "object",
             "properties": {
+                "cache_type": {
+                    "type": "string"
+                },
                 "costs_calculation_caveat": {
                     "type": "string"
                 },
@@ -3278,6 +3619,9 @@
                 "provider_id": {
                     "type": "string"
                 },
+                "provider_name": {
+                    "type": "string"
+                },
                 "raw_data": {
                     "type": "object",
                     "additionalProperties": {}
@@ -3293,6 +3637,9 @@
                 },
                 "total_tokens": {
                     "type": "integer"
+                },
+                "user_path": {
+                    "type": "string"
                 }
             }
         },
@@ -3339,6 +3686,32 @@
                 },
                 "total_tokens": {
                     "type": "integer"
+                }
+            }
+        },
+        "usage.UserPathUsage": {
+            "type": "object",
+            "properties": {
+                "input_cost": {
+                    "type": "number"
+                },
+                "input_tokens": {
+                    "type": "integer"
+                },
+                "output_cost": {
+                    "type": "number"
+                },
+                "output_tokens": {
+                    "type": "integer"
+                },
+                "total_cost": {
+                    "type": "number"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                },
+                "user_path": {
+                    "type": "string"
                 }
             }
         }

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -1938,7 +1938,7 @@ td.col-price {
     width: 16px;
     height: 16px;
     fill: none;
-    stroke: currentColor;
+    stroke: currentcolor;
     stroke-width: 2;
     stroke-linecap: round;
     stroke-linejoin: round;

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -1052,7 +1052,7 @@ body {
 
 .chart-wrapper {
     position: relative;
-    height: 300px;
+    height: 210px;
 }
 
 /* Alert */

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -1891,13 +1891,72 @@ td.col-price {
 .model-chart-section h3 {
     font-size: 16px;
     font-weight: 600;
+    margin: 0;
+}
+
+.model-chart-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
     margin-bottom: 16px;
+}
+
+.chart-view-toggle {
+    display: inline-flex;
+    align-items: center;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 2px;
+}
+
+.chart-view-btn {
+    width: 30px;
+    height: 28px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: none;
+    border-radius: 4px;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: all 0.15s;
+}
+
+.chart-view-btn:hover {
+    color: var(--text);
+}
+
+.chart-view-btn.active {
+    background: var(--accent);
+    color: #fff;
+}
+
+.chart-view-btn svg {
+    width: 16px;
+    height: 16px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
 }
 
 .bar-chart-wrap {
     position: relative;
     width: 100%;
     height: 360px;
+}
+
+.usage-chart-table-wrapper {
+    margin-top: 0;
+}
+
+.usage-chart-data-table th,
+.usage-chart-data-table td {
+    white-space: nowrap;
 }
 
 /* Usage Log Section */

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -1952,6 +1952,12 @@ td.col-price {
 
 .usage-chart-table-wrapper {
     margin-top: 0;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+.usage-chart-data-table {
+    min-width: max-content;
 }
 
 .usage-chart-data-table th,

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -1947,7 +1947,7 @@ td.col-price {
 .bar-chart-wrap {
     position: relative;
     width: 100%;
-    height: 360px;
+    height: 180px;
 }
 
 .usage-chart-table-wrapper {

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -188,6 +188,8 @@ function dashboard() {
             window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
                 if (this.theme === 'system') {
                     this.renderChart();
+                    this.renderBarChart();
+                    this.renderUserPathChart();
                 }
             });
 

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -187,9 +187,7 @@ function dashboard() {
 
             window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
                 if (this.theme === 'system') {
-                    this.renderChart();
-                    this.renderBarChart();
-                    this.renderUserPathChart();
+                    this.rerenderCharts();
                 }
             });
 
@@ -228,9 +226,7 @@ function dashboard() {
             this.theme = t;
             localStorage.setItem('gomodel_theme', t);
             this.applyTheme();
-            this.renderChart();
-            this.renderBarChart();
-            this.renderUserPathChart();
+            this.rerenderCharts();
         },
 
         toggleTheme() {
@@ -259,6 +255,12 @@ function dashboard() {
                 tooltipBorder: this.cssVar('--chart-tooltip-border'),
                 tooltipText: this.cssVar('--chart-tooltip-text')
             };
+        },
+
+        rerenderCharts() {
+            this.renderChart();
+            this.renderBarChart();
+            this.renderUserPathChart();
         },
 
         saveApiKey() {

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -77,13 +77,17 @@ function dashboard() {
 
         // Usage page state
         usageMode: 'tokens',
+        modelUsageView: 'chart',
+        userPathUsageView: 'chart',
         modelUsage: [],
+        userPathUsage: [],
         usageLog: { entries: [], total: 0, limit: 50, offset: 0 },
         usageLogSearch: '',
         usageLogModel: '',
         usageLogProvider: '',
         usageLogUserPath: '',
         usageBarChart: null,
+        usageUserPathChart: null,
 
         // Audit page state
         auditLog: { entries: [], total: 0, limit: 25, offset: 0 },
@@ -220,6 +224,7 @@ function dashboard() {
             this.applyTheme();
             this.renderChart();
             this.renderBarChart();
+            this.renderUserPathChart();
         },
 
         toggleTheme() {

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -546,21 +546,19 @@ function dashboard() {
         },
 
         qualifiedModelDisplay(value) {
-            const model = String(value && value.model || '').trim();
+            return this.qualifiedModelValueDisplay(value, value && value.model);
+        },
+
+        qualifiedModelValueDisplay(value, modelValue) {
+            const model = String(modelValue || '').trim();
             if (!model) return '-';
-            if (model.includes('/')) return model;
             const provider = this.providerDisplayValue(value);
-            if (!provider) return model;
+            if (!provider || model === provider || model.startsWith(provider + '/')) return model;
             return provider + '/' + model;
         },
 
         qualifiedResolvedModelDisplay(value) {
-            const model = String(value && value.resolved_model || '').trim();
-            if (!model) return '-';
-            if (model.includes('/')) return model;
-            const provider = this.providerDisplayValue(value);
-            if (!provider) return model;
-            return provider + '/' + model;
+            return this.qualifiedModelValueDisplay(value, value && value.resolved_model);
         },
 
         formatNumber(n) {

--- a/internal/admin/dashboard/static/js/modules/charts.js
+++ b/internal/admin/dashboard/static/js/modules/charts.js
@@ -305,13 +305,13 @@
             toggleUsageChartView(target, view) {
                 if (target === 'model') {
                     this.modelUsageView = view;
-                    if (view === 'chart') this.renderBarChart();
+                    this.renderBarChart();
                     return;
                 }
 
                 if (target === 'userPath') {
                     this.userPathUsageView = view;
-                    if (view === 'chart') this.renderUserPathChart();
+                    this.renderUserPathChart();
                 }
             },
 

--- a/internal/admin/dashboard/static/js/modules/charts.js
+++ b/internal/admin/dashboard/static/js/modules/charts.js
@@ -234,36 +234,62 @@
                 ];
             },
 
-            _barData() {
-                const sorted = [...this.modelUsage].sort((a, b) => {
-                    if (this.usageMode === 'costs') {
-                        return ((b.total_cost || 0) - (a.total_cost || 0));
-                    }
-                    return ((b.input_tokens + b.output_tokens) - (a.input_tokens + a.output_tokens));
-                });
+            _usageAggregateValue(row) {
+                if (this.usageMode === 'costs') return row.total_cost || 0;
+                return this.usageRowTotalTokens(row);
+            },
+
+            usageRowTotalTokens(row) {
+                if (row && typeof row.total_tokens === 'number') return row.total_tokens;
+                return ((row && row.input_tokens) || 0) + ((row && row.output_tokens) || 0);
+            },
+
+            _barDataFrom(items, labelFor) {
+                const sorted = this._usageRowsBySelectedValue(items);
 
                 const top = sorted.slice(0, 10);
                 const rest = sorted.slice(10);
 
-                const labels = top.map((m) => typeof this.qualifiedModelDisplay === 'function'
-                    ? this.qualifiedModelDisplay(m)
-                    : m.model);
-                const values = top.map((m) => {
-                    if (this.usageMode === 'costs') return m.total_cost || 0;
-                    return m.input_tokens + m.output_tokens;
-                });
+                const labels = top.map(labelFor);
+                const values = top.map((row) => this._usageAggregateValue(row));
 
                 if (rest.length > 0) {
                     labels.push('Other');
                     let otherVal = 0;
-                    rest.forEach((m) => {
-                        if (this.usageMode === 'costs') otherVal += (m.total_cost || 0);
-                        else otherVal += m.input_tokens + m.output_tokens;
+                    rest.forEach((row) => {
+                        otherVal += this._usageAggregateValue(row);
                     });
                     values.push(otherVal);
                 }
 
                 return { labels, values };
+            },
+
+            _usageRowsBySelectedValue(items) {
+                return [...(items || [])].sort((a, b) => {
+                    if (this.usageMode === 'costs') {
+                        return ((b.total_cost || 0) - (a.total_cost || 0));
+                    }
+                    return this._usageAggregateValue(b) - this._usageAggregateValue(a);
+                });
+            },
+
+            modelUsageTableRows() {
+                return this._usageRowsBySelectedValue(this.modelUsage || []);
+            },
+
+            userPathUsageTableRows() {
+                return this._usageRowsBySelectedValue(this.userPathUsage || []);
+            },
+
+            _barData() {
+                return this._barDataFrom(this.modelUsage, (m) => typeof this.qualifiedModelDisplay === 'function'
+                    ? this.qualifiedModelDisplay(m)
+                    : m.model);
+            },
+
+            _userPathBarData() {
+                return this._barDataFrom(this.userPathUsage || [], (u) => u.user_path || '/');
             },
 
             barLegendItems() {
@@ -276,10 +302,23 @@
                 }));
             },
 
+            toggleUsageChartView(target, view) {
+                if (target === 'model') {
+                    this.modelUsageView = view;
+                    if (view === 'chart') this.renderBarChart();
+                    return;
+                }
+
+                if (target === 'userPath') {
+                    this.userPathUsageView = view;
+                    if (view === 'chart') this.renderUserPathChart();
+                }
+            },
+
             renderBarChart(retries) {
                 if (retries === undefined) retries = 3;
                 this.$nextTick(() => {
-                    if (this.modelUsage.length === 0 || this.page !== 'usage') {
+                    if (this.modelUsage.length === 0 || this.page !== 'usage' || (this.modelUsageView || 'chart') !== 'chart') {
                         if (this.usageBarChart) {
                             this.usageBarChart.destroy();
                             this.usageBarChart = null;
@@ -306,6 +345,39 @@
                     }
 
                     this.usageBarChart = new Chart(canvas, config);
+                });
+            },
+
+            renderUserPathChart(retries) {
+                if (retries === undefined) retries = 3;
+                this.$nextTick(() => {
+                    if (!this.userPathUsage || this.userPathUsage.length === 0 || this.page !== 'usage' || (this.userPathUsageView || 'chart') !== 'chart') {
+                        if (this.usageUserPathChart) {
+                            this.usageUserPathChart.destroy();
+                            this.usageUserPathChart = null;
+                        }
+                        return;
+                    }
+
+                    const canvas = document.getElementById('usageUserPathChart');
+                    if (!canvas || canvas.offsetWidth === 0) {
+                        if (retries > 0) {
+                            setTimeout(() => this.renderUserPathChart(retries - 1), 100);
+                        }
+                        return;
+                    }
+
+                    const colors = this.chartColors();
+                    const { labels, values } = this._userPathBarData();
+                    const palette = this._barColors();
+                    const config = this._barChartConfig(colors, labels, values, palette);
+
+                    if (this.usageUserPathChart) {
+                        this.usageUserPathChart.destroy();
+                        this.usageUserPathChart = null;
+                    }
+
+                    this.usageUserPathChart = new Chart(canvas, config);
                 });
             }
         };

--- a/internal/admin/dashboard/static/js/modules/charts.test.js
+++ b/internal/admin/dashboard/static/js/modules/charts.test.js
@@ -204,9 +204,13 @@ test('toggleUsageChartView switches table and chart modes and rerenders chart vi
     ];
 
     module.renderBarChart();
+    module.renderUserPathChart();
     const modelChart = module.usageBarChart;
+    const userPathChart = module.usageUserPathChart;
+    assert.notEqual(modelChart, null);
+    assert.notEqual(userPathChart, null);
+
     module.toggleUsageChartView('model', 'table');
-    module.renderBarChart();
 
     assert.equal(module.modelUsageView, 'table');
     assert.equal(modelChart.destroyCalls, 1);
@@ -216,7 +220,17 @@ test('toggleUsageChartView switches table and chart modes and rerenders chart vi
 
     assert.equal(module.modelUsageView, 'chart');
     assert.notEqual(module.usageBarChart, null);
+    assert.notStrictEqual(module.usageBarChart, modelChart);
 
     module.toggleUsageChartView('userPath', 'table');
+
     assert.equal(module.userPathUsageView, 'table');
+    assert.equal(userPathChart.destroyCalls, 1);
+    assert.equal(module.usageUserPathChart, null);
+
+    module.toggleUsageChartView('userPath', 'chart');
+
+    assert.equal(module.userPathUsageView, 'chart');
+    assert.notEqual(module.usageUserPathChart, null);
+    assert.notStrictEqual(module.usageUserPathChart, userPathChart);
 });

--- a/internal/admin/dashboard/static/js/modules/charts.test.js
+++ b/internal/admin/dashboard/static/js/modules/charts.test.js
@@ -143,3 +143,80 @@ test('renderBarChart prefers provider_name in model labels when available', () =
 
     assert.equal(JSON.stringify(module.usageBarChart.data.labels), JSON.stringify(['primary-openai/gpt-4o']));
 });
+
+test('renderUserPathChart recreates the user path chart and uses usage mode values', () => {
+    FakeChart.instances = [];
+    const { module } = createChartsContext();
+    module.page = 'usage';
+    module.usageMode = 'tokens';
+    module.userPathUsage = [
+        { user_path: '/team/alpha', input_tokens: 5, output_tokens: 7, total_tokens: 12, total_cost: 0.01 },
+        { user_path: '/team/beta', input_tokens: 11, output_tokens: 13, total_tokens: 24, total_cost: 0.02 }
+    ];
+
+    module.renderUserPathChart();
+
+    assert.equal(FakeChart.instances.length, 1);
+    const firstChart = module.usageUserPathChart;
+    assert.equal(JSON.stringify(firstChart.data.labels), JSON.stringify(['/team/beta', '/team/alpha']));
+    assert.equal(JSON.stringify(firstChart.data.datasets[0].data), JSON.stringify([24, 12]));
+
+    module.usageMode = 'costs';
+    module.userPathUsage = [
+        { user_path: '/team/alpha', input_tokens: 21, output_tokens: 34, total_tokens: 55, total_cost: 0.03 }
+    ];
+    module.renderUserPathChart();
+
+    assert.notStrictEqual(module.usageUserPathChart, firstChart);
+    assert.equal(FakeChart.instances.length, 2);
+    assert.equal(firstChart.destroyCalls, 1);
+    assert.equal(JSON.stringify(module.usageUserPathChart.data.labels), JSON.stringify(['/team/alpha']));
+    assert.equal(JSON.stringify(module.usageUserPathChart.data.datasets[0].data), JSON.stringify([0.03]));
+});
+
+test('usage chart table rows use the same selected metric ordering as charts', () => {
+    const { module } = createChartsContext();
+    module.usageMode = 'tokens';
+    module.modelUsage = [
+        { model: 'small', input_tokens: 1, output_tokens: 2, total_cost: 9 },
+        { model: 'large', input_tokens: 10, output_tokens: 20, total_cost: 1 }
+    ];
+
+    assert.equal(JSON.stringify(module.modelUsageTableRows().map((row) => row.model)), JSON.stringify(['large', 'small']));
+
+    module.usageMode = 'costs';
+
+    assert.equal(JSON.stringify(module.modelUsageTableRows().map((row) => row.model)), JSON.stringify(['small', 'large']));
+});
+
+test('toggleUsageChartView switches table and chart modes and rerenders chart views', () => {
+    FakeChart.instances = [];
+    const { module } = createChartsContext();
+    module.page = 'usage';
+    module.usageMode = 'tokens';
+    module.modelUsageView = 'chart';
+    module.userPathUsageView = 'chart';
+    module.modelUsage = [
+        { model: 'gpt-5', input_tokens: 10, output_tokens: 20, total_cost: 0.01 }
+    ];
+    module.userPathUsage = [
+        { user_path: '/team/alpha', input_tokens: 10, output_tokens: 20, total_tokens: 30, total_cost: 0.01 }
+    ];
+
+    module.renderBarChart();
+    const modelChart = module.usageBarChart;
+    module.toggleUsageChartView('model', 'table');
+    module.renderBarChart();
+
+    assert.equal(module.modelUsageView, 'table');
+    assert.equal(modelChart.destroyCalls, 1);
+    assert.equal(module.usageBarChart, null);
+
+    module.toggleUsageChartView('model', 'chart');
+
+    assert.equal(module.modelUsageView, 'chart');
+    assert.notEqual(module.usageBarChart, null);
+
+    module.toggleUsageChartView('userPath', 'table');
+    assert.equal(module.userPathUsageView, 'table');
+});

--- a/internal/admin/dashboard/static/js/modules/dashboard-display.test.js
+++ b/internal/admin/dashboard/static/js/modules/dashboard-display.test.js
@@ -4,7 +4,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const vm = require('node:vm');
 
-function loadDashboardApp() {
+function loadDashboardApp(overrides = {}) {
     const dashboardSource = fs.readFileSync(path.join(__dirname, '../dashboard.js'), 'utf8');
     const window = {
         localStorage: {
@@ -18,7 +18,8 @@ function loadDashboardApp() {
         matchMedia() {
             return { addEventListener() {} };
         },
-        addEventListener() {}
+        addEventListener() {},
+        ...(overrides.window || {})
     };
     const context = {
         console,
@@ -46,6 +47,8 @@ function loadDashboardApp() {
                 }
             };
         },
+        localStorage: window.localStorage,
+        ...overrides.context,
         window
     };
 
@@ -78,4 +81,55 @@ test('qualifiedModelDisplay does not duplicate an existing exact provider prefix
         app.qualifiedResolvedModelDisplay({ provider_name: 'primary-openai', resolved_model: 'gpt-5-nano' }),
         'primary-openai/gpt-5-nano'
     );
+});
+
+test('system theme media changes rerender all dashboard charts', () => {
+    let mediaChangeHandler = null;
+    const app = loadDashboardApp({
+        window: {
+            location: { pathname: '/admin/dashboard/overview' },
+            matchMedia() {
+                return {
+                    addEventListener(event, handler) {
+                        if (event === 'change') {
+                            mediaChangeHandler = handler;
+                        }
+                    }
+                };
+            }
+        }
+    });
+    let overviewCalls = 0;
+    let modelCalls = 0;
+    let userPathCalls = 0;
+
+    app.fetchAll = () => {};
+    app.renderChart = () => {
+        overviewCalls++;
+    };
+    app.renderBarChart = () => {
+        modelCalls++;
+    };
+    app.renderUserPathChart = () => {
+        userPathCalls++;
+    };
+
+    app.init();
+    assert.equal(typeof mediaChangeHandler, 'function');
+
+    overviewCalls = 0;
+    modelCalls = 0;
+    userPathCalls = 0;
+    mediaChangeHandler();
+
+    assert.equal(overviewCalls, 1);
+    assert.equal(modelCalls, 1);
+    assert.equal(userPathCalls, 1);
+
+    app.theme = 'dark';
+    mediaChangeHandler();
+
+    assert.equal(overviewCalls, 1);
+    assert.equal(modelCalls, 1);
+    assert.equal(userPathCalls, 1);
 });

--- a/internal/admin/dashboard/static/js/modules/dashboard-display.test.js
+++ b/internal/admin/dashboard/static/js/modules/dashboard-display.test.js
@@ -1,0 +1,81 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function loadDashboardApp() {
+    const dashboardSource = fs.readFileSync(path.join(__dirname, '../dashboard.js'), 'utf8');
+    const window = {
+        localStorage: {
+            getItem() {
+                return null;
+            },
+            setItem() {},
+            removeItem() {}
+        },
+        location: { pathname: '/admin/dashboard/usage' },
+        matchMedia() {
+            return { addEventListener() {} };
+        },
+        addEventListener() {}
+    };
+    const context = {
+        console,
+        Date,
+        Intl,
+        setTimeout,
+        clearTimeout,
+        requestAnimationFrame(callback) {
+            callback();
+        },
+        history: { pushState() {} },
+        document: {
+            documentElement: {
+                removeAttribute() {},
+                setAttribute() {}
+            },
+            getElementById() {
+                return null;
+            }
+        },
+        getComputedStyle() {
+            return {
+                getPropertyValue() {
+                    return '';
+                }
+            };
+        },
+        window
+    };
+
+    vm.createContext(context);
+    vm.runInContext(dashboardSource, context);
+    return context.dashboard();
+}
+
+test('qualifiedModelDisplay keeps provider identity for nested provider model IDs', () => {
+    const app = loadDashboardApp();
+
+    assert.equal(
+        app.qualifiedModelDisplay({ provider: 'openrouter', model: 'openai/gpt-5-nano' }),
+        'openrouter/openai/gpt-5-nano'
+    );
+    assert.equal(
+        app.qualifiedModelDisplay({ provider: 'openai', model: 'gpt-5-nano' }),
+        'openai/gpt-5-nano'
+    );
+});
+
+test('qualifiedModelDisplay does not duplicate an existing exact provider prefix', () => {
+    const app = loadDashboardApp();
+
+    assert.equal(
+        app.qualifiedModelDisplay({ provider: 'openai', model: 'openai/gpt-5-nano' }),
+        'openai/gpt-5-nano'
+    );
+    assert.equal(
+        app.qualifiedResolvedModelDisplay({ provider_name: 'primary-openai', resolved_model: 'gpt-5-nano' }),
+        'primary-openai/gpt-5-nano'
+    );
+});

--- a/internal/admin/dashboard/static/js/modules/dashboard-layout.test.js
+++ b/internal/admin/dashboard/static/js/modules/dashboard-layout.test.js
@@ -356,6 +356,7 @@ test('usage charts can switch between chart and table views', () => {
     assert.match(indexTemplate, /<div class="bar-chart-wrap" x-show="modelUsageView === 'chart'">[\s\S]*<canvas id="usageBarChart"><\/canvas>/);
     assert.match(indexTemplate, /<template x-if="modelUsageView === 'table'">[\s\S]*modelUsageTableRows\(\)/);
     assert.match(indexTemplate, /class="chart-view-toggle"[\s\S]*@click="toggleUsageChartView\('userPath', 'chart'\)"[\s\S]*@click="toggleUsageChartView\('userPath', 'table'\)"/);
+    assert.match(indexTemplate, /<h3 x-text="usageMode === 'costs' \? 'Cost by User Path' : 'Usage by User Path'"><\/h3>/);
     assert.match(indexTemplate, /<div class="bar-chart-wrap" x-show="userPathUsageView === 'chart'">[\s\S]*<canvas id="usageUserPathChart"><\/canvas>/);
     assert.match(indexTemplate, /<template x-if="userPathUsageView === 'table'">[\s\S]*userPathUsageTableRows\(\)/);
 });

--- a/internal/admin/dashboard/static/js/modules/dashboard-layout.test.js
+++ b/internal/admin/dashboard/static/js/modules/dashboard-layout.test.js
@@ -349,6 +349,17 @@ test('usage and audit pages reuse a shared pagination template', () => {
     );
 });
 
+test('usage charts can switch between chart and table views', () => {
+    const indexTemplate = readFixture('../../../templates/index.html');
+
+    assert.match(indexTemplate, /class="chart-view-toggle"[\s\S]*@click="toggleUsageChartView\('model', 'chart'\)"[\s\S]*@click="toggleUsageChartView\('model', 'table'\)"/);
+    assert.match(indexTemplate, /<div class="bar-chart-wrap" x-show="modelUsageView === 'chart'">[\s\S]*<canvas id="usageBarChart"><\/canvas>/);
+    assert.match(indexTemplate, /<template x-if="modelUsageView === 'table'">[\s\S]*modelUsageTableRows\(\)/);
+    assert.match(indexTemplate, /class="chart-view-toggle"[\s\S]*@click="toggleUsageChartView\('userPath', 'chart'\)"[\s\S]*@click="toggleUsageChartView\('userPath', 'table'\)"/);
+    assert.match(indexTemplate, /<div class="bar-chart-wrap" x-show="userPathUsageView === 'chart'">[\s\S]*<canvas id="usageUserPathChart"><\/canvas>/);
+    assert.match(indexTemplate, /<template x-if="userPathUsageView === 'table'">[\s\S]*userPathUsageTableRows\(\)/);
+});
+
 test('audit request and response sections reuse a shared audit pane template', () => {
     const indexTemplate = readFixture('../../../templates/index.html');
     const auditPaneTemplate = readFixture('../../../templates/audit-pane.html');

--- a/internal/admin/dashboard/static/js/modules/usage.js
+++ b/internal/admin/dashboard/static/js/modules/usage.js
@@ -144,12 +144,13 @@
             },
 
             async fetchUsagePage() {
-                const requests = [this.fetchModelUsage(), this.fetchUsageLog(true)];
+                const requests = [this.fetchModelUsage(), this.fetchUserPathUsage(), this.fetchUsageLog(true)];
                 if (this.cacheAnalyticsEnabled()) {
                     requests.push(this.fetchCacheOverview());
                 }
                 await Promise.all(requests);
                 this.renderBarChart();
+                this.renderUserPathChart();
             },
 
             async fetchModelUsage() {
@@ -181,6 +182,39 @@
                 } finally {
                     if (typeof this._clearAbortableRequest === 'function') {
                         this._clearAbortableRequest('_modelUsageFetchController', controller);
+                    }
+                }
+            },
+
+            async fetchUserPathUsage() {
+                const controller = typeof this._startAbortableRequest === 'function'
+                    ? this._startAbortableRequest('_userPathUsageFetchController')
+                    : null;
+                const options = { headers: this.headers() };
+                if (controller) {
+                    options.signal = controller.signal;
+                }
+
+                try {
+                    const res = await fetch('/admin/api/v1/usage/user-paths?' + this._usageQueryStr(), options);
+                    if (!this.handleFetchResponse(res, 'usage user paths')) {
+                        this.userPathUsage = [];
+                        return;
+                    }
+                    const payload = await res.json();
+                    if (controller && controller.signal.aborted) {
+                        return;
+                    }
+                    this.userPathUsage = Array.isArray(payload) ? payload : [];
+                } catch (e) {
+                    if (typeof this._isAbortError === 'function' && this._isAbortError(e)) {
+                        return;
+                    }
+                    console.error('Failed to fetch usage by user path:', e);
+                    this.userPathUsage = [];
+                } finally {
+                    if (typeof this._clearAbortableRequest === 'function') {
+                        this._clearAbortableRequest('_userPathUsageFetchController', controller);
                     }
                 }
             },
@@ -232,6 +266,7 @@
                 const url = mode === 'costs' ? '/admin/dashboard/usage/costs' : '/admin/dashboard/usage';
                 history.pushState(null, '', url);
                 this.renderBarChart();
+                this.renderUserPathChart();
             },
 
             usageLogNextPage() {

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -296,7 +296,7 @@
     <!-- Usage by User Path Chart -->
     <div class="model-chart-section" x-show="userPathUsage.length > 0">
         <div class="model-chart-header">
-            <h3>Usage by User Path</h3>
+            <h3 x-text="usageMode === 'costs' ? 'Cost by User Path' : 'Usage by User Path'"></h3>
             <div class="chart-view-toggle" role="group" aria-label="User path usage view">
                 <button type="button" class="chart-view-btn" :class="{active: userPathUsageView === 'chart'}" :aria-pressed="userPathUsageView === 'chart' ? 'true' : 'false'" aria-label="Show user path usage chart" title="Chart" @click="toggleUsageChartView('userPath', 'chart')">
                     <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 19V11M12 19V5M19 19v-8"/></svg>

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -245,10 +245,100 @@
 
     <!-- Usage by Model Chart -->
     <div class="model-chart-section" x-show="modelUsage.length > 0">
-        <h3 x-text="usageMode === 'tokens' ? 'Token Usage by Model' : 'Cost by Model'"></h3>
-        <div class="bar-chart-wrap">
+        <div class="model-chart-header">
+            <h3 x-text="usageMode === 'tokens' ? 'Token Usage by Model' : 'Cost by Model'"></h3>
+            <div class="chart-view-toggle" role="group" aria-label="Model usage view">
+                <button type="button" class="chart-view-btn" :class="{active: modelUsageView === 'chart'}" :aria-pressed="modelUsageView === 'chart' ? 'true' : 'false'" aria-label="Show model usage chart" title="Chart" @click="toggleUsageChartView('model', 'chart')">
+                    <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 19V11M12 19V5M19 19v-8"/></svg>
+                </button>
+                <button type="button" class="chart-view-btn" :class="{active: modelUsageView === 'table'}" :aria-pressed="modelUsageView === 'table' ? 'true' : 'false'" aria-label="Show model usage table" title="Table" @click="toggleUsageChartView('model', 'table')">
+                    <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 6h16M4 12h16M4 18h16M9 6v12M15 6v12"/></svg>
+                </button>
+            </div>
+        </div>
+        <div class="bar-chart-wrap" x-show="modelUsageView === 'chart'">
             <canvas id="usageBarChart"></canvas>
         </div>
+        <template x-if="modelUsageView === 'table'">
+            <div class="table-wrapper usage-chart-table-wrapper">
+                <table class="data-table usage-chart-data-table">
+                    <thead>
+                        <tr>
+                            <th>Model</th>
+                            <th>Provider</th>
+                            <th class="col-price">Input Tokens</th>
+                            <th class="col-price">Output Tokens</th>
+                            <th class="col-price">Total Tokens</th>
+                            <th class="col-price">Input Cost</th>
+                            <th class="col-price">Output Cost</th>
+                            <th class="col-price">Total Cost</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <template x-for="row in modelUsageTableRows()" :key="(row.provider_name || row.provider || '-') + '/' + row.model">
+                            <tr>
+                                <td class="mono font-size-md" x-text="row.model || '-'"></td>
+                                <td><span class="provider-badge" x-text="providerDisplayValue(row) || '-'"></span></td>
+                                <td class="col-price" x-text="formatNumber(row.input_tokens)"></td>
+                                <td class="col-price" x-text="formatNumber(row.output_tokens)"></td>
+                                <td class="col-price" x-text="formatNumber(usageRowTotalTokens(row))"></td>
+                                <td class="col-price" x-text="formatCost(row.input_cost)"></td>
+                                <td class="col-price" x-text="formatCost(row.output_cost)"></td>
+                                <td class="col-price" x-text="formatCost(row.total_cost)"></td>
+                            </tr>
+                        </template>
+                    </tbody>
+                </table>
+            </div>
+        </template>
+    </div>
+
+    <!-- Usage by User Path Chart -->
+    <div class="model-chart-section" x-show="userPathUsage.length > 0">
+        <div class="model-chart-header">
+            <h3>Usage by User Path</h3>
+            <div class="chart-view-toggle" role="group" aria-label="User path usage view">
+                <button type="button" class="chart-view-btn" :class="{active: userPathUsageView === 'chart'}" :aria-pressed="userPathUsageView === 'chart' ? 'true' : 'false'" aria-label="Show user path usage chart" title="Chart" @click="toggleUsageChartView('userPath', 'chart')">
+                    <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 19V11M12 19V5M19 19v-8"/></svg>
+                </button>
+                <button type="button" class="chart-view-btn" :class="{active: userPathUsageView === 'table'}" :aria-pressed="userPathUsageView === 'table' ? 'true' : 'false'" aria-label="Show user path usage table" title="Table" @click="toggleUsageChartView('userPath', 'table')">
+                    <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 6h16M4 12h16M4 18h16M9 6v12M15 6v12"/></svg>
+                </button>
+            </div>
+        </div>
+        <div class="bar-chart-wrap" x-show="userPathUsageView === 'chart'">
+            <canvas id="usageUserPathChart"></canvas>
+        </div>
+        <template x-if="userPathUsageView === 'table'">
+            <div class="table-wrapper usage-chart-table-wrapper">
+                <table class="data-table usage-chart-data-table">
+                    <thead>
+                        <tr>
+                            <th>User Path</th>
+                            <th class="col-price">Input Tokens</th>
+                            <th class="col-price">Output Tokens</th>
+                            <th class="col-price">Total Tokens</th>
+                            <th class="col-price">Input Cost</th>
+                            <th class="col-price">Output Cost</th>
+                            <th class="col-price">Total Cost</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <template x-for="row in userPathUsageTableRows()" :key="row.user_path || '/'">
+                            <tr>
+                                <td class="mono font-size-md" x-text="row.user_path || '/'"></td>
+                                <td class="col-price" x-text="formatNumber(row.input_tokens)"></td>
+                                <td class="col-price" x-text="formatNumber(row.output_tokens)"></td>
+                                <td class="col-price" x-text="formatNumber(usageRowTotalTokens(row))"></td>
+                                <td class="col-price" x-text="formatCost(row.input_cost)"></td>
+                                <td class="col-price" x-text="formatCost(row.output_cost)"></td>
+                                <td class="col-price" x-text="formatCost(row.total_cost)"></td>
+                            </tr>
+                        </template>
+                    </tbody>
+                </table>
+            </div>
+        </template>
     </div>
 
     <!-- Request Log Section -->

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -432,23 +432,30 @@ func (h *Handler) DailyUsage(c *echo.Context) error {
 // @Failure      401  {object}  core.GatewayError
 // @Router       /admin/api/v1/usage/models [get]
 func (h *Handler) UsageByModel(c *echo.Context) error {
-	if h.usageReader == nil {
-		return c.JSON(http.StatusOK, []usage.ModelUsage{})
-	}
+	return usageSliceResponse(c, h.usageReader, func(ctx context.Context, params usage.UsageQueryParams) ([]usage.ModelUsage, error) {
+		return h.usageReader.GetUsageByModel(ctx, params)
+	})
+}
 
-	params, err := parseUsageParams(c)
-	if err != nil {
-		return handleError(c, err)
-	}
-
-	values, err := h.usageReader.GetUsageByModel(c.Request().Context(), params)
-	if err != nil {
-		return handleError(c, err)
-	}
-	if values == nil {
-		values = []usage.ModelUsage{}
-	}
-	return c.JSON(http.StatusOK, values)
+// UsageByUserPath handles GET /admin/api/v1/usage/user-paths
+//
+// @Summary      Get usage breakdown by user path
+// @Tags         admin
+// @Produce      json
+// @Security     BearerAuth
+// @Param        days        query     int     false  "Number of days (default 30)"
+// @Param        start_date  query     string  false  "Start date (YYYY-MM-DD)"
+// @Param        end_date    query     string  false  "End date (YYYY-MM-DD)"
+// @Param        user_path   query     string  false  "Filter by tracked user path subtree"
+// @Param        cache_mode  query     string  false  "Cache mode filter: uncached, cached, all (default uncached)"
+// @Success      200  {array}   usage.UserPathUsage
+// @Failure      400  {object}  core.GatewayError
+// @Failure      401  {object}  core.GatewayError
+// @Router       /admin/api/v1/usage/user-paths [get]
+func (h *Handler) UsageByUserPath(c *echo.Context) error {
+	return usageSliceResponse(c, h.usageReader, func(ctx context.Context, params usage.UsageQueryParams) ([]usage.UserPathUsage, error) {
+		return h.usageReader.GetUsageByUserPath(ctx, params)
+	})
 }
 
 // UsageLog handles GET /admin/api/v1/usage/log

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -24,6 +24,7 @@ type mockUsageReader struct {
 	summary           *usage.UsageSummary
 	daily             []usage.DailyUsage
 	modelUsage        []usage.ModelUsage
+	userPathUsage     []usage.UserPathUsage
 	usageLog          *usage.UsageLogResult
 	cacheOverview     *usage.CacheOverview
 	lastUsageLog      usage.UsageLogParams
@@ -31,6 +32,7 @@ type mockUsageReader struct {
 	summaryErr        error
 	dailyErr          error
 	modelUsageErr     error
+	userPathUsageErr  error
 	usageLogErr       error
 	cacheErr          error
 }
@@ -66,6 +68,13 @@ func (m *mockUsageReader) GetUsageByModel(_ context.Context, _ usage.UsageQueryP
 		return nil, m.modelUsageErr
 	}
 	return m.modelUsage, nil
+}
+
+func (m *mockUsageReader) GetUsageByUserPath(_ context.Context, _ usage.UsageQueryParams) ([]usage.UserPathUsage, error) {
+	if m.userPathUsageErr != nil {
+		return nil, m.userPathUsageErr
+	}
+	return m.userPathUsage, nil
 }
 
 func (m *mockUsageReader) GetUsageLog(_ context.Context, params usage.UsageLogParams) (*usage.UsageLogResult, error) {
@@ -484,6 +493,72 @@ func TestUsageByModel_Error(t *testing.T) {
 	c, rec := newHandlerContext("/admin/api/v1/usage/models")
 
 	if err := h.UsageByModel(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", rec.Code)
+	}
+}
+
+// --- UsageByUserPath handler tests ---
+
+func TestUsageByUserPath_NilReader(t *testing.T) {
+	h := NewHandler(nil, nil)
+	c, rec := newHandlerContext("/admin/api/v1/usage/user-paths")
+
+	if err := h.UsageByUserPath(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	if rec.Body.String() != "[]\n" {
+		t.Errorf("expected empty JSON array, got: %q", rec.Body.String())
+	}
+}
+
+func TestUsageByUserPath_Success(t *testing.T) {
+	cost := 0.75
+	reader := &mockUsageReader{
+		userPathUsage: []usage.UserPathUsage{
+			{UserPath: "/team/alpha", InputTokens: 100, OutputTokens: 50, TotalTokens: 150, TotalCost: &cost},
+		},
+	}
+	h := NewHandler(reader, nil)
+	c, rec := newHandlerContext("/admin/api/v1/usage/user-paths?days=30")
+
+	if err := h.UsageByUserPath(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	var userPaths []usage.UserPathUsage
+	if err := json.Unmarshal(rec.Body.Bytes(), &userPaths); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if len(userPaths) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(userPaths))
+	}
+	if userPaths[0].UserPath != "/team/alpha" {
+		t.Errorf("expected user_path /team/alpha, got %s", userPaths[0].UserPath)
+	}
+	if userPaths[0].TotalTokens != 150 {
+		t.Errorf("expected total_tokens 150, got %d", userPaths[0].TotalTokens)
+	}
+	if userPaths[0].TotalCost == nil || *userPaths[0].TotalCost != 0.75 {
+		t.Errorf("expected total_cost 0.75, got %v", userPaths[0].TotalCost)
+	}
+}
+
+func TestUsageByUserPath_Error(t *testing.T) {
+	reader := &mockUsageReader{
+		userPathUsageErr: errors.New("db failure"),
+	}
+	h := NewHandler(reader, nil)
+	c, rec := newHandlerContext("/admin/api/v1/usage/user-paths")
+
+	if err := h.UsageByUserPath(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if rec.Code != http.StatusInternalServerError {

--- a/internal/core/errors.go
+++ b/internal/core/errors.go
@@ -29,8 +29,8 @@ type GatewayError struct {
 	Message    string    `json:"message"`
 	StatusCode int       `json:"status_code"`
 	Provider   string    `json:"provider,omitempty"`
-	Param      *string   `json:"param"`
-	Code       *string   `json:"code"`
+	Param      *string   `json:"param" extensions:"x-nullable"`
+	Code       *string   `json:"code" extensions:"x-nullable"`
 	// Original error for debugging (not exposed to clients)
 	Err error `json:"-"`
 }

--- a/internal/core/responses.go
+++ b/internal/core/responses.go
@@ -105,7 +105,7 @@ type ResponsesContentItem struct {
 	InputAudio *InputAudioContent `json:"input_audio,omitempty"`
 	// Providers can return structured annotation objects here (for example
 	// citations from native tools), so keep the payload shape liberal.
-	Annotations []json.RawMessage `json:"annotations,omitempty"`
+	Annotations []json.RawMessage `json:"annotations,omitempty" swaggertype:"array,object"`
 }
 
 // ResponsesUsage represents token usage for the Responses API.

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -100,7 +100,7 @@ type Choice struct {
 	Message      ResponseMessage `json:"message"`
 	FinishReason string          `json:"finish_reason"`
 	Index        int             `json:"index"`
-	Logprobs     json.RawMessage `json:"logprobs,omitempty"`
+	Logprobs     json.RawMessage `json:"logprobs,omitempty" swaggertype:"object"`
 }
 
 // ResponseMessage represents a single assistant message in a chat response.

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -377,8 +377,7 @@ func (h *Handler) GetFileContent(c *echo.Context) error {
 // @Produce      text/event-stream
 // @Security     BearerAuth
 // @Param        request  body      core.ResponsesRequest  true  "Responses API request"
-// @Success      200      {object}  core.ResponsesResponse
-// @Success      200      {string}  string  "SSE stream (text/event-stream) when stream=true"
+// @Success      200      {object}  core.ResponsesResponse  "JSON response or SSE stream when stream=true"
 // @Failure      400      {object}  core.GatewayError
 // @Failure      401      {object}  core.GatewayError
 // @Failure      429      {object}  core.GatewayError

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -304,6 +304,7 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 		adminAPI.GET("/usage/summary", cfg.AdminHandler.UsageSummary)
 		adminAPI.GET("/usage/daily", cfg.AdminHandler.DailyUsage)
 		adminAPI.GET("/usage/models", cfg.AdminHandler.UsageByModel)
+		adminAPI.GET("/usage/user-paths", cfg.AdminHandler.UsageByUserPath)
 		adminAPI.GET("/usage/log", cfg.AdminHandler.UsageLog)
 		adminAPI.GET("/audit/log", cfg.AdminHandler.AuditLog)
 		adminAPI.GET("/audit/conversation", cfg.AdminHandler.AuditConversation)

--- a/internal/usage/reader.go
+++ b/internal/usage/reader.go
@@ -45,9 +45,9 @@ type UserPathUsage struct {
 	InputTokens  int64    `json:"input_tokens"`
 	OutputTokens int64    `json:"output_tokens"`
 	TotalTokens  int64    `json:"total_tokens"`
-	InputCost    *float64 `json:"input_cost"`
-	OutputCost   *float64 `json:"output_cost"`
-	TotalCost    *float64 `json:"total_cost"`
+	InputCost    *float64 `json:"input_cost" extensions:"x-nullable"`
+	OutputCost   *float64 `json:"output_cost" extensions:"x-nullable"`
+	TotalCost    *float64 `json:"total_cost" extensions:"x-nullable"`
 }
 
 // DailyUsage holds usage statistics for a single period.

--- a/internal/usage/reader.go
+++ b/internal/usage/reader.go
@@ -39,6 +39,17 @@ type ModelUsage struct {
 	TotalCost    *float64 `json:"total_cost"`
 }
 
+// UserPathUsage holds per-user-path token usage aggregates.
+type UserPathUsage struct {
+	UserPath     string   `json:"user_path"`
+	InputTokens  int64    `json:"input_tokens"`
+	OutputTokens int64    `json:"output_tokens"`
+	TotalTokens  int64    `json:"total_tokens"`
+	InputCost    *float64 `json:"input_cost"`
+	OutputCost   *float64 `json:"output_cost"`
+	TotalCost    *float64 `json:"total_cost"`
+}
+
 // DailyUsage holds usage statistics for a single period.
 // Date holds the period label: YYYY-MM-DD for daily, YYYY-Www for weekly,
 // YYYY-MM for monthly, or YYYY for yearly intervals.
@@ -134,6 +145,9 @@ type UsageReader interface {
 
 	// GetUsageByModel returns per-model token usage aggregates for the given date range.
 	GetUsageByModel(ctx context.Context, params UsageQueryParams) ([]ModelUsage, error)
+
+	// GetUsageByUserPath returns per-user-path token usage aggregates for the given date range.
+	GetUsageByUserPath(ctx context.Context, params UsageQueryParams) ([]UserPathUsage, error)
 
 	// GetUsageLog returns a paginated list of individual usage entries with optional filtering.
 	GetUsageLog(ctx context.Context, params UsageLogParams) (*UsageLogResult, error)

--- a/internal/usage/reader_helpers.go
+++ b/internal/usage/reader_helpers.go
@@ -28,6 +28,12 @@ func usageGroupedProviderNameSQL(providerNameColumn, providerColumn string) stri
 	return "COALESCE(NULLIF(TRIM(" + providerNameColumn + "), ''), " + providerColumn + ")"
 }
 
+// usageGroupedUserPathSQL returns a SQL expression that collapses blank
+// user_path values to the tracked root path before grouping.
+func usageGroupedUserPathSQL(userPathColumn string) string {
+	return "COALESCE(NULLIF(TRIM(" + userPathColumn + "), ''), '/')"
+}
+
 // clampLimitOffset normalises pagination parameters:
 //   - limit defaults to 50 and is capped at 200
 //   - offset floors at 0

--- a/internal/usage/reader_mongodb.go
+++ b/internal/usage/reader_mongodb.go
@@ -160,7 +160,9 @@ func (r *MongoDBReader) GetUsageByModel(ctx context.Context, params UsageQueryPa
 // GetUsageByUserPath returns token and cost totals grouped by tracked user path.
 func (r *MongoDBReader) GetUsageByUserPath(ctx context.Context, params UsageQueryParams) ([]UserPathUsage, error) {
 	pipeline := bson.A{}
-	matchFilters, err := mongoUsageMatchFilters(params)
+	matchParams := params
+	matchParams.UserPath = ""
+	matchFilters, err := mongoUsageMatchFilters(matchParams)
 	if err != nil {
 		return nil, err
 	}
@@ -168,8 +170,23 @@ func (r *MongoDBReader) GetUsageByUserPath(ctx context.Context, params UsageQuer
 		pipeline = append(pipeline, bson.D{{Key: "$match", Value: matchFilters}})
 	}
 
+	const canonicalUserPathField = "_gomodel_user_path"
+	pipeline = append(pipeline, bson.D{{Key: "$addFields", Value: bson.D{
+		{Key: canonicalUserPathField, Value: mongoUsageGroupedUserPathExpr()},
+	}}})
+
+	userPath, err := normalizeUsageUserPathFilter(params.UserPath)
+	if err != nil {
+		return nil, err
+	}
+	if userPath != "" {
+		pipeline = append(pipeline, bson.D{{Key: "$match", Value: bson.D{{Key: canonicalUserPathField, Value: bson.D{
+			{Key: "$regex", Value: usageUserPathSubtreeRegex(userPath)},
+		}}}}})
+	}
+
 	pipeline = append(pipeline, bson.D{{Key: "$group", Value: bson.D{
-		{Key: "_id", Value: mongoUsageGroupedUserPathExpr()},
+		{Key: "_id", Value: "$" + canonicalUserPathField},
 		{Key: "input_tokens", Value: bson.D{{Key: "$sum", Value: "$input_tokens"}}},
 		{Key: "output_tokens", Value: bson.D{{Key: "$sum", Value: "$output_tokens"}}},
 		{Key: "total_tokens", Value: bson.D{{Key: "$sum", Value: "$total_tokens"}}},

--- a/internal/usage/reader_mongodb.go
+++ b/internal/usage/reader_mongodb.go
@@ -157,6 +157,73 @@ func (r *MongoDBReader) GetUsageByModel(ctx context.Context, params UsageQueryPa
 	return result, nil
 }
 
+// GetUsageByUserPath returns token and cost totals grouped by tracked user path.
+func (r *MongoDBReader) GetUsageByUserPath(ctx context.Context, params UsageQueryParams) ([]UserPathUsage, error) {
+	pipeline := bson.A{}
+	matchFilters, err := mongoUsageMatchFilters(params)
+	if err != nil {
+		return nil, err
+	}
+	if len(matchFilters) > 0 {
+		pipeline = append(pipeline, bson.D{{Key: "$match", Value: matchFilters}})
+	}
+
+	pipeline = append(pipeline, bson.D{{Key: "$group", Value: bson.D{
+		{Key: "_id", Value: mongoUsageGroupedUserPathExpr()},
+		{Key: "input_tokens", Value: bson.D{{Key: "$sum", Value: "$input_tokens"}}},
+		{Key: "output_tokens", Value: bson.D{{Key: "$sum", Value: "$output_tokens"}}},
+		{Key: "total_tokens", Value: bson.D{{Key: "$sum", Value: "$total_tokens"}}},
+		{Key: "input_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$ifNull", Value: bson.A{"$input_cost", 0}}}}}},
+		{Key: "output_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$ifNull", Value: bson.A{"$output_cost", 0}}}}}},
+		{Key: "total_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$ifNull", Value: bson.A{"$total_cost", 0}}}}}},
+		{Key: "has_costs", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$cond", Value: bson.A{bson.D{{Key: "$gt", Value: bson.A{"$total_cost", nil}}}, 1, 0}}}}}},
+	}}})
+
+	cursor, err := r.collection.Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil, fmt.Errorf("failed to aggregate usage by user path: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	result := make([]UserPathUsage, 0)
+	for cursor.Next(ctx) {
+		var row struct {
+			UserPath     string  `bson:"_id"`
+			InputTokens  int64   `bson:"input_tokens"`
+			OutputTokens int64   `bson:"output_tokens"`
+			TotalTokens  int64   `bson:"total_tokens"`
+			InputCost    float64 `bson:"input_cost"`
+			OutputCost   float64 `bson:"output_cost"`
+			TotalCost    float64 `bson:"total_cost"`
+			HasCosts     int     `bson:"has_costs"`
+		}
+		if err := cursor.Decode(&row); err != nil {
+			return nil, fmt.Errorf("failed to decode usage by user path row: %w", err)
+		}
+		u := UserPathUsage{
+			UserPath:     row.UserPath,
+			InputTokens:  row.InputTokens,
+			OutputTokens: row.OutputTokens,
+			TotalTokens:  row.TotalTokens,
+		}
+		if u.UserPath == "" {
+			u.UserPath = "/"
+		}
+		if row.HasCosts > 0 {
+			u.InputCost = &row.InputCost
+			u.OutputCost = &row.OutputCost
+			u.TotalCost = &row.TotalCost
+		}
+		result = append(result, u)
+	}
+
+	if err := cursor.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating usage by user path cursor: %w", err)
+	}
+
+	return result, nil
+}
+
 func mongoUsageGroupedProviderNameExpr() bson.D {
 	trimmedProviderName := bson.D{{Key: "$trim", Value: bson.D{
 		{Key: "input", Value: bson.D{{Key: "$ifNull", Value: bson.A{"$provider_name", ""}}}},
@@ -165,6 +232,17 @@ func mongoUsageGroupedProviderNameExpr() bson.D {
 		bson.D{{Key: "$ne", Value: bson.A{trimmedProviderName, ""}}},
 		trimmedProviderName,
 		bson.D{{Key: "$trim", Value: bson.D{{Key: "input", Value: "$provider"}}}},
+	}}}
+}
+
+func mongoUsageGroupedUserPathExpr() bson.D {
+	trimmedUserPath := bson.D{{Key: "$trim", Value: bson.D{
+		{Key: "input", Value: bson.D{{Key: "$ifNull", Value: bson.A{"$user_path", ""}}}},
+	}}}
+	return bson.D{{Key: "$cond", Value: bson.A{
+		bson.D{{Key: "$ne", Value: bson.A{trimmedUserPath, ""}}},
+		trimmedUserPath,
+		"/",
 	}}}
 }
 

--- a/internal/usage/reader_postgresql.go
+++ b/internal/usage/reader_postgresql.go
@@ -82,6 +82,41 @@ func (r *PostgreSQLReader) GetUsageByModel(ctx context.Context, params UsageQuer
 	return result, nil
 }
 
+// GetUsageByUserPath returns token and cost totals grouped by tracked user path.
+func (r *PostgreSQLReader) GetUsageByUserPath(ctx context.Context, params UsageQueryParams) ([]UserPathUsage, error) {
+	conditions, args, _, err := pgUsageConditions(params, 1)
+	if err != nil {
+		return nil, err
+	}
+	where := buildWhereClause(conditions)
+	userPathExpr := usageGroupedUserPathSQL("user_path")
+
+	costCols := `, SUM(input_cost), SUM(output_cost), SUM(total_cost)`
+	query := `SELECT ` + userPathExpr + ` AS user_path, COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)` + costCols + `
+			FROM "usage"` + where + ` GROUP BY ` + userPathExpr
+
+	rows, err := r.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query usage by user path: %w", err)
+	}
+	defer rows.Close()
+
+	result := make([]UserPathUsage, 0)
+	for rows.Next() {
+		var u UserPathUsage
+		if err := rows.Scan(&u.UserPath, &u.InputTokens, &u.OutputTokens, &u.TotalTokens, &u.InputCost, &u.OutputCost, &u.TotalCost); err != nil {
+			return nil, fmt.Errorf("failed to scan usage by user path row: %w", err)
+		}
+		result = append(result, u)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating usage by user path rows: %w", err)
+	}
+
+	return result, nil
+}
+
 // GetUsageLog returns a paginated list of individual usage log entries.
 func (r *PostgreSQLReader) GetUsageLog(ctx context.Context, params UsageLogParams) (*UsageLogResult, error) {
 	limit, offset := clampLimitOffset(params.Limit, params.Offset)

--- a/internal/usage/reader_postgresql.go
+++ b/internal/usage/reader_postgresql.go
@@ -84,12 +84,12 @@ func (r *PostgreSQLReader) GetUsageByModel(ctx context.Context, params UsageQuer
 
 // GetUsageByUserPath returns token and cost totals grouped by tracked user path.
 func (r *PostgreSQLReader) GetUsageByUserPath(ctx context.Context, params UsageQueryParams) ([]UserPathUsage, error) {
-	conditions, args, _, err := pgUsageConditions(params, 1)
+	userPathExpr := usageGroupedUserPathSQL("user_path")
+	conditions, args, _, err := pgUsageByUserPathConditions(params, userPathExpr, 1)
 	if err != nil {
 		return nil, err
 	}
 	where := buildWhereClause(conditions)
-	userPathExpr := usageGroupedUserPathSQL("user_path")
 
 	costCols := `, SUM(input_cost), SUM(output_cost), SUM(total_cost)`
 	query := `SELECT ` + userPathExpr + ` AS user_path, COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)` + costCols + `
@@ -359,6 +359,23 @@ func pgUsageConditions(params UsageQueryParams, argIdx int) (conditions []string
 	}
 	if userPath != "" {
 		conditions = append(conditions, fmt.Sprintf("(user_path = $%d OR user_path LIKE $%d ESCAPE '\\')", nextIdx, nextIdx+1))
+		args = append(args, userPath, usageUserPathSubtreePattern(userPath))
+		nextIdx += 2
+	}
+	if condition := pgCacheModeCondition(params.CacheMode); condition != "" {
+		conditions = append(conditions, condition)
+	}
+	return conditions, args, nextIdx, nil
+}
+
+func pgUsageByUserPathConditions(params UsageQueryParams, userPathExpr string, argIdx int) (conditions []string, args []any, nextIdx int, err error) {
+	conditions, args, nextIdx = pgDateRangeConditions(params, argIdx)
+	userPath, err := normalizeUsageUserPathFilter(params.UserPath)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	if userPath != "" {
+		conditions = append(conditions, fmt.Sprintf("(%s = $%d OR %s LIKE $%d ESCAPE '\\')", userPathExpr, nextIdx, userPathExpr, nextIdx+1))
 		args = append(args, userPath, usageUserPathSubtreePattern(userPath))
 		nextIdx += 2
 	}

--- a/internal/usage/reader_sqlite.go
+++ b/internal/usage/reader_sqlite.go
@@ -84,12 +84,12 @@ func (r *SQLiteReader) GetUsageByModel(ctx context.Context, params UsageQueryPar
 
 // GetUsageByUserPath returns token and cost totals grouped by tracked user path.
 func (r *SQLiteReader) GetUsageByUserPath(ctx context.Context, params UsageQueryParams) ([]UserPathUsage, error) {
-	conditions, args, err := sqliteUsageConditions(params)
+	userPathExpr := usageGroupedUserPathSQL("user_path")
+	conditions, args, err := sqliteUsageByUserPathConditions(params, userPathExpr)
 	if err != nil {
 		return nil, err
 	}
 	where := buildWhereClause(conditions)
-	userPathExpr := usageGroupedUserPathSQL("user_path")
 
 	costCols := `, SUM(input_cost), SUM(output_cost), SUM(total_cost)`
 	query := `SELECT ` + userPathExpr + ` AS user_path, COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)` + costCols + `
@@ -406,6 +406,22 @@ func sqliteUsageConditions(params UsageQueryParams) ([]string, []any, error) {
 	}
 	if userPath != "" {
 		conditions = append(conditions, "(user_path = ? OR user_path LIKE ? ESCAPE '\\')")
+		args = append(args, userPath, usageUserPathSubtreePattern(userPath))
+	}
+	if condition := sqliteCacheModeCondition(params.CacheMode); condition != "" {
+		conditions = append(conditions, condition)
+	}
+	return conditions, args, nil
+}
+
+func sqliteUsageByUserPathConditions(params UsageQueryParams, userPathExpr string) ([]string, []any, error) {
+	conditions, args := sqliteDateRangeConditions(params)
+	userPath, err := normalizeUsageUserPathFilter(params.UserPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	if userPath != "" {
+		conditions = append(conditions, "("+userPathExpr+" = ? OR "+userPathExpr+" LIKE ? ESCAPE '\\')")
 		args = append(args, userPath, usageUserPathSubtreePattern(userPath))
 	}
 	if condition := sqliteCacheModeCondition(params.CacheMode); condition != "" {

--- a/internal/usage/reader_sqlite.go
+++ b/internal/usage/reader_sqlite.go
@@ -82,6 +82,41 @@ func (r *SQLiteReader) GetUsageByModel(ctx context.Context, params UsageQueryPar
 	return result, nil
 }
 
+// GetUsageByUserPath returns token and cost totals grouped by tracked user path.
+func (r *SQLiteReader) GetUsageByUserPath(ctx context.Context, params UsageQueryParams) ([]UserPathUsage, error) {
+	conditions, args, err := sqliteUsageConditions(params)
+	if err != nil {
+		return nil, err
+	}
+	where := buildWhereClause(conditions)
+	userPathExpr := usageGroupedUserPathSQL("user_path")
+
+	costCols := `, SUM(input_cost), SUM(output_cost), SUM(total_cost)`
+	query := `SELECT ` + userPathExpr + ` AS user_path, COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)` + costCols + `
+			FROM usage` + where + ` GROUP BY ` + userPathExpr
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query usage by user path: %w", err)
+	}
+	defer rows.Close()
+
+	result := make([]UserPathUsage, 0)
+	for rows.Next() {
+		var u UserPathUsage
+		if err := rows.Scan(&u.UserPath, &u.InputTokens, &u.OutputTokens, &u.TotalTokens, &u.InputCost, &u.OutputCost, &u.TotalCost); err != nil {
+			return nil, fmt.Errorf("failed to scan usage by user path row: %w", err)
+		}
+		result = append(result, u)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating usage by user path rows: %w", err)
+	}
+
+	return result, nil
+}
+
 // GetUsageLog returns a paginated list of individual usage log entries.
 func (r *SQLiteReader) GetUsageLog(ctx context.Context, params UsageLogParams) (*UsageLogResult, error) {
 	limit, offset := clampLimitOffset(params.Limit, params.Offset)

--- a/internal/usage/reader_sqlite_boundary_test.go
+++ b/internal/usage/reader_sqlite_boundary_test.go
@@ -683,11 +683,17 @@ func TestSQLiteReaderGetUsageByUserPath_GroupsByTrackedPath(t *testing.T) {
 	for _, row := range rootFiltered {
 		rootFilteredByPath[row.UserPath] = row
 	}
+	if len(rootFilteredByPath) != len(byPath) {
+		t.Fatalf("expected root filter to include %d grouped usage rows, got %d: %#v", len(byPath), len(rootFilteredByPath), rootFiltered)
+	}
 	if rootFilteredByPath["/"].TotalTokens != 50 {
 		t.Fatalf("expected root filter to include blank root total tokens 50, got %d", rootFilteredByPath["/"].TotalTokens)
 	}
 	if rootFilteredByPath["/team/alpha"].TotalTokens != 70 {
 		t.Fatalf("expected root filter to include alpha total tokens 70, got %d", rootFilteredByPath["/team/alpha"].TotalTokens)
+	}
+	if rootFilteredByPath["/team/beta"].TotalTokens != 110 {
+		t.Fatalf("expected root filter to include beta total tokens 110, got %d", rootFilteredByPath["/team/beta"].TotalTokens)
 	}
 }
 

--- a/internal/usage/reader_sqlite_boundary_test.go
+++ b/internal/usage/reader_sqlite_boundary_test.go
@@ -674,6 +674,21 @@ func TestSQLiteReaderGetUsageByUserPath_GroupsByTrackedPath(t *testing.T) {
 	if _, ok := filteredByPath["/"]; ok {
 		t.Fatalf("expected root path to be excluded by /team subtree filter")
 	}
+
+	rootFiltered, err := reader.GetUsageByUserPath(ctx, UsageQueryParams{UserPath: "/"})
+	if err != nil {
+		t.Fatalf("root filtered GetUsageByUserPath returned error: %v", err)
+	}
+	rootFilteredByPath := make(map[string]UserPathUsage, len(rootFiltered))
+	for _, row := range rootFiltered {
+		rootFilteredByPath[row.UserPath] = row
+	}
+	if rootFilteredByPath["/"].TotalTokens != 50 {
+		t.Fatalf("expected root filter to include blank root total tokens 50, got %d", rootFilteredByPath["/"].TotalTokens)
+	}
+	if rootFilteredByPath["/team/alpha"].TotalTokens != 70 {
+		t.Fatalf("expected root filter to include alpha total tokens 70, got %d", rootFilteredByPath["/team/alpha"].TotalTokens)
+	}
 }
 
 func TestSQLiteStoreCleanup_KeepsNewerLegacyOffsetRows(t *testing.T) {
@@ -682,6 +697,7 @@ func TestSQLiteStoreCleanup_KeepsNewerLegacyOffsetRows(t *testing.T) {
 		t.Fatalf("failed to open sqlite database: %v", err)
 	}
 	defer db.Close()
+	db.SetMaxOpenConns(1)
 
 	store, err := NewSQLiteStore(db, 1)
 	if err != nil {

--- a/internal/usage/reader_sqlite_boundary_test.go
+++ b/internal/usage/reader_sqlite_boundary_test.go
@@ -559,6 +559,123 @@ func TestSQLiteReaderGetUsageByModel_CollapsesBlankProviderNameIntoProviderGroup
 	}
 }
 
+func TestSQLiteReaderGetUsageByUserPath_GroupsByTrackedPath(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open sqlite database: %v", err)
+	}
+	defer db.Close()
+
+	store, err := NewSQLiteStore(db, 0)
+	if err != nil {
+		t.Fatalf("failed to create sqlite store: %v", err)
+	}
+
+	ctx := context.Background()
+	err = store.WriteBatch(ctx, []*UsageEntry{
+		{
+			ID:           "usage-root-blank",
+			RequestID:    "req-root-blank",
+			ProviderID:   "provider-root-blank",
+			Timestamp:    time.Date(2026, 4, 7, 10, 0, 0, 0, time.UTC),
+			Model:        "gpt-5",
+			Provider:     "openai",
+			Endpoint:     "/v1/chat/completions",
+			UserPath:     "",
+			InputTokens:  10,
+			OutputTokens: 20,
+			TotalTokens:  30,
+		},
+		{
+			ID:           "usage-root-explicit",
+			RequestID:    "req-root-explicit",
+			ProviderID:   "provider-root-explicit",
+			Timestamp:    time.Date(2026, 4, 7, 10, 1, 0, 0, time.UTC),
+			Model:        "gpt-5",
+			Provider:     "openai",
+			Endpoint:     "/v1/chat/completions",
+			UserPath:     "/",
+			InputTokens:  5,
+			OutputTokens: 15,
+			TotalTokens:  20,
+		},
+		{
+			ID:           "usage-alpha",
+			RequestID:    "req-alpha",
+			ProviderID:   "provider-alpha",
+			Timestamp:    time.Date(2026, 4, 7, 10, 2, 0, 0, time.UTC),
+			Model:        "gpt-5",
+			Provider:     "openai",
+			Endpoint:     "/v1/chat/completions",
+			UserPath:     "/team/alpha",
+			InputTokens:  30,
+			OutputTokens: 40,
+			TotalTokens:  70,
+		},
+		{
+			ID:           "usage-beta",
+			RequestID:    "req-beta",
+			ProviderID:   "provider-beta",
+			Timestamp:    time.Date(2026, 4, 7, 10, 3, 0, 0, time.UTC),
+			Model:        "gpt-5",
+			Provider:     "openai",
+			Endpoint:     "/v1/chat/completions",
+			UserPath:     "/team/beta",
+			InputTokens:  50,
+			OutputTokens: 60,
+			TotalTokens:  110,
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to seed usage entries: %v", err)
+	}
+
+	reader, err := NewSQLiteReader(db)
+	if err != nil {
+		t.Fatalf("failed to create sqlite reader: %v", err)
+	}
+
+	got, err := reader.GetUsageByUserPath(ctx, UsageQueryParams{})
+	if err != nil {
+		t.Fatalf("GetUsageByUserPath returned error: %v", err)
+	}
+
+	byPath := make(map[string]UserPathUsage, len(got))
+	for _, row := range got {
+		byPath[row.UserPath] = row
+	}
+	if len(byPath) != 3 {
+		t.Fatalf("expected 3 grouped usage rows, got %d: %#v", len(byPath), got)
+	}
+	if byPath["/"].InputTokens != 15 {
+		t.Fatalf("expected root input tokens 15, got %d", byPath["/"].InputTokens)
+	}
+	if byPath["/"].TotalTokens != 50 {
+		t.Fatalf("expected root total tokens 50, got %d", byPath["/"].TotalTokens)
+	}
+	if byPath["/team/alpha"].TotalTokens != 70 {
+		t.Fatalf("expected alpha total tokens 70, got %d", byPath["/team/alpha"].TotalTokens)
+	}
+	if byPath["/team/beta"].OutputTokens != 60 {
+		t.Fatalf("expected beta output tokens 60, got %d", byPath["/team/beta"].OutputTokens)
+	}
+
+	filtered, err := reader.GetUsageByUserPath(ctx, UsageQueryParams{UserPath: "/team"})
+	if err != nil {
+		t.Fatalf("filtered GetUsageByUserPath returned error: %v", err)
+	}
+	filteredByPath := make(map[string]UserPathUsage, len(filtered))
+	for _, row := range filtered {
+		filteredByPath[row.UserPath] = row
+	}
+	if len(filteredByPath) != 2 {
+		t.Fatalf("expected 2 filtered grouped usage rows, got %d: %#v", len(filteredByPath), filtered)
+	}
+	if _, ok := filteredByPath["/"]; ok {
+		t.Fatalf("expected root path to be excluded by /team subtree filter")
+	}
+}
+
 func TestSQLiteStoreCleanup_KeepsNewerLegacyOffsetRows(t *testing.T) {
 	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {


### PR DESCRIPTION
## Summary
- add a Usage by User Path aggregate endpoint and reader implementations for SQLite, PostgreSQL, and MongoDB
- render Usage by User Path under the model usage chart with the existing tokens/costs mode
- add chart/table view toggles for both usage charts and tables with the full aggregate data
- regenerate admin Swagger docs and update the swagger target to parse dependencies

## Tests
- go test ./...
- node --test internal/admin/dashboard/static/js/modules/*.test.js
- make swagger

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Usage analytics by user path in admin dashboard with chart/table toggle and per-user-path tables
  * New admin cache overview endpoint and new endpoint returning per-user-path usage

* **API Changes**
  * Renamed audit log query param: model → requested_model
  * Added user_path and cache_mode query filters across admin usage/audit endpoints
  * Responses API documents SSE (text/event-stream) alongside JSON
  * Oracle added to provider list

* **Style**
  * Updated dashboard usage chart layout, controls, and sizing

* **Tests**
  * Added tests for usage/user-path charts, tables, and handlers

* **Chores**
  * Swagger generation now parses dependent types/packages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->