### PR TITLE
fix(review): address dashboard and docs follow-ups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,8 @@ swagger:
 	$(MAKE) docs-openapi
 
 docs-openapi:
+	@command -v node >/dev/null 2>&1 || { echo "node is required to build docs; install from https://nodejs.org" >&2; exit 1; }
+	@command -v npx >/dev/null 2>&1 || { echo "npx is required; install npm (includes npx)" >&2; exit 1; }
 	@tmp_dir=$$(mktemp -d); \
 	trap 'rm -rf "$$tmp_dir"' EXIT; \
 	go run github.com/swaggo/swag/cmd/swag init --quiet --generalInfo main.go \

--- a/docs/about/benchmarks.mdx
+++ b/docs/about/benchmarks.mdx
@@ -63,10 +63,10 @@ This docs page keeps only the primary comparison matrix from the blog post.
 
 Some useful reads from that March 5, 2026 run:
 
-- GoModel posted lower p95 latency at every tested concurrency level.
-- GoModel reached higher throughput across the benchmark matrix.
-- GoModel stayed near `45-46 MB` RSS, while LiteLLM stayed near `320-321 MB`.
-- GoModel also used less CPU in these runs.
+- Lower p95 latency at every tested concurrency level.
+- Higher throughput across the benchmark matrix.
+- `45-46 MB` RSS, while LiteLLM stayed near `320-321 MB`.
+- Less CPU in these runs.
 
 At the highest tested concurrency, GoModel reached `52.75 req/s` versus
 LiteLLM at `35.81 req/s`.

--- a/docs/about/values.mdx
+++ b/docs/about/values.mdx
@@ -15,14 +15,14 @@ icon: "heart"
 
 We are here to outdo LiteLLM, and quality is how we get there.
 
-We do not believe an AI gateway has to be written in Python. We chose Go
-because runtime behavior, deployment shape, and long-term maintainability matter.
+An AI gateway does not have to be written in Python. Go was chosen because
+runtime behavior, deployment shape, and long-term maintainability matter.
 
 The jar is a useful reminder: if you fill it with sand first, the larger stones
 will not fit later. In GoModel, the big stones are experience, programming language and architecture.
 The sand is the smaller work: features, functions, tests, and fixes.
 
-We try to put the big stones in first.
+Big stones come first.
 
 <Note>
   We still respect LiteLLM and people behind it. They got there first, helped a

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -451,6 +451,13 @@ body {
   color: #fff;
 }
 
+.theme-btn:focus-visible,
+.theme-toggle-mobile:focus-visible,
+.sidebar-toggle:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 36%, transparent);
+  outline-offset: 2px;
+}
+
 /* Theme toggle — single button for mobile */
 .theme-toggle-mobile {
   display: none;
@@ -488,6 +495,9 @@ body {
   top: 0;
   width: 6px;
   height: 100vh;
+  padding: 0;
+  background: transparent;
+  border: none;
   cursor: w-resize;
   z-index: 11;
   transition: background 0.15s;

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -510,7 +510,17 @@ function dashboard() {
         this.runtimeRefreshReport =
           payload && typeof payload === "object" ? payload : null;
         this.runtimeRefreshNotice = this.runtimeRefreshSummary();
-        await this.refreshDashboardDataAfterRuntimeRefresh();
+
+        try {
+          await this.refreshDashboardDataAfterRuntimeRefresh();
+        } catch (e) {
+          console.error(
+            "Failed to reload dashboard data after runtime refresh:",
+            e,
+          );
+          this.runtimeRefreshError =
+            "Runtime refreshed, but dashboard data could not be reloaded.";
+        }
       } catch (e) {
         console.error("Failed to refresh runtime:", e);
         this.runtimeRefreshNotice = "Runtime refresh failed.";

--- a/internal/admin/dashboard/static/js/modules/dashboard-layout.test.js
+++ b/internal/admin/dashboard/static/js/modules/dashboard-layout.test.js
@@ -35,7 +35,7 @@ test('sidebar and main content share the flex layout without manual content offs
     const css = readFixture('../../css/dashboard.css');
 
     assert.match(readFixture('../../../templates/layout.html'), /{{template "sidebar" \.}}/);
-    assert.match(template, /<aside class="sidebar"[\s\S]*<div class="sidebar-toggle"[\s\S]*<main class="content"/);
+    assert.match(template, /<aside class="sidebar"[\s\S]*<button type="button"[\s\S]*class="sidebar-toggle"[\s\S]*<main class="content"/);
     assert.doesNotMatch(template, /content-collapsed/);
     assert.match(
         template,
@@ -65,6 +65,18 @@ test('sidebar and main content share the flex layout without manual content offs
 
     const collapsedSidebarRule = readCSSRule(css, '.sidebar.sidebar-collapsed');
     assert.match(collapsedSidebarRule, /flex-basis:\s*60px/);
+});
+
+test('sidebar theme controls and collapse handle stay keyboard accessible', () => {
+    const template = readDashboardShellTemplate();
+
+    assert.match(template, /class="theme-btn"[\s\S]*@click="setTheme\('light'\)"[\s\S]*title="Light theme"[\s\S]*aria-label="Light theme"/);
+    assert.match(template, /class="theme-btn"[\s\S]*@click="setTheme\('system'\)"[\s\S]*title="System theme"[\s\S]*aria-label="System theme"/);
+    assert.match(template, /class="theme-btn"[\s\S]*@click="setTheme\('dark'\)"[\s\S]*title="Dark theme"[\s\S]*aria-label="Dark theme"/);
+    assert.match(template, /class="theme-toggle-mobile"[\s\S]*@click="toggleTheme\(\)"[\s\S]*:title="theme === 'light' \? 'Light theme' : theme === 'dark' \? 'Dark theme' : 'System theme'"[\s\S]*:aria-label="theme === 'light' \? 'Light theme' : theme === 'dark' \? 'Dark theme' : 'System theme'"/);
+    assert.match(template, /<button type="button"[\s\S]*class="sidebar-toggle"[\s\S]*@click="toggleSidebar\(\)"[\s\S]*:aria-label="sidebarCollapsed \? 'Expand sidebar' : 'Collapse sidebar'"[\s\S]*:aria-expanded="sidebarCollapsed \? 'false' : 'true'"/);
+    assert.doesNotMatch(template, /tabindex="-1"/);
+    assert.doesNotMatch(template, /@mousedown="toggleSidebar\(\)"/);
 });
 
 test('mono utility only sets the font family and font-size-md carries the 13px size', () => {
@@ -443,6 +455,7 @@ test('model category tables lazy mount only the active table body', () => {
     assert.match(modelsBlock, /class="pagination-btn pagination-btn-primary pagination-btn-with-icon alias-create-btn"[\s\S]*@click="openAliasCreate\(\)"[\s\S]*data-lucide="plus" class="alias-create-icon"[\s\S]*<span>Create Alias<\/span>/);
     assert.match(modelsBlock, /class="pagination-btn pagination-btn-primary pagination-btn-with-icon alias-submit-btn"[\s\S]*:disabled="aliasSubmitting"[\s\S]*data-lucide="plus" class="form-action-icon" x-show="aliasFormMode !== 'edit'"[\s\S]*data-lucide="save" class="form-action-icon" x-show="aliasFormMode === 'edit'"[\s\S]*x-text="aliasSubmitting \? 'Saving\.\.\.' : \(aliasFormMode === 'edit' \? 'Save Alias' : 'Create Alias'\)"/);
     assert.match(modelsBlock, /class="pagination-btn pagination-btn-primary pagination-btn-with-icon model-access-submit-btn"[\s\S]*:disabled="modelOverrideSubmitting"[\s\S]*data-lucide="save" class="form-action-icon"[\s\S]*x-text="modelOverrideSubmitting \? 'Saving\.\.\.' : 'Save Access'"/);
+    assert.match(modelsBlock, /The selector uses <code>\/<\/code> for all providers and models, <code>\{provider_name\}\/<\/code> for one provider, or <code>\{provider_name\}\/\{model\}<\/code> for one model\.[\s\S]*managed API key <code>user_path<\/code> when present, otherwise the <code>X-GoModel-User-Path<\/code> request header\./);
 
     const loadingRule = readCSSRule(css, '.loading-state');
     assert.match(loadingRule, /display:\s*flex/);

--- a/internal/admin/dashboard/static/js/modules/request-cancellation.test.js
+++ b/internal/admin/dashboard/static/js/modules/request-cancellation.test.js
@@ -136,6 +136,38 @@ test('refreshRuntime posts to admin endpoint and refreshes dashboard data', asyn
     assert.equal(app.runtimeRefreshStepLabel(app.runtimeRefreshReport.steps[0]), 'providers: ok - refreshed');
 });
 
+test('refreshRuntime keeps the successful report when dashboard data reload fails', async() => {
+    const queue = createPendingFetchQueue();
+    const app = loadDashboardApp({
+        fetch: queue.fetch,
+        console: { error() {}, log() {} }
+    });
+    let dashboardRefreshes = 0;
+    app.dashboardDataFetches = () => {
+        dashboardRefreshes++;
+        return [Promise.reject(new Error('reload failed'))];
+    };
+
+    const refresh = app.refreshRuntime();
+    assert.equal(app.runtimeRefreshLoading, true);
+    assert.equal(queue.requests.length, 1);
+
+    queue.requests[0].resolve(jsonResponse({
+        status: 'ok',
+        model_count: 4,
+        provider_count: 2,
+        steps: [{ name: 'providers', status: 'ok', message: 'refreshed' }]
+    }));
+    await refresh;
+
+    assert.equal(app.runtimeRefreshLoading, false);
+    assert.equal(dashboardRefreshes, 1);
+    assert.equal(app.runtimeRefreshSucceeded(), true);
+    assert.equal(app.runtimeRefreshNotice, 'Runtime refreshed. 4 models across 2 providers.');
+    assert.equal(app.runtimeRefreshError, 'Runtime refreshed, but dashboard data could not be reloaded.');
+    assert.equal(app.runtimeRefreshStepLabel(app.runtimeRefreshReport.steps[0]), 'providers: ok - refreshed');
+});
+
 test('refreshRuntime leaves dashboard data untouched when the admin request fails', async() => {
     const queue = createPendingFetchQueue();
     const app = loadDashboardApp({ fetch: queue.fetch });

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -965,7 +965,7 @@
             </label>
 
             <p class="alias-form-hint">
-                The selector uses <code>/</code> for all providers and models, <code>{provider_name}/</code> for one provider, or <code>{provider_name}/{model}</code> for one model. <code>user_paths</code> is matched against the effective managed API key <code>user_path</code>.
+                The selector uses <code>/</code> for all providers and models, <code>{provider_name}/</code> for one provider, or <code>{provider_name}/{model}</code> for one model. <code>user_paths</code> is matched against the effective request <code>user_path</code>: the managed API key <code>user_path</code> when present, otherwise the <code>X-GoModel-User-Path</code> request header.
             </p>
             <p class="alias-form-hint" x-text="'Default enabled: ' + (modelOverrideFormDefaultEnabled ? 'yes' : 'no') + ' · Effective now: ' + (modelOverrideFormEffectiveEnabled ? 'yes' : 'no')"></p>
 

--- a/internal/admin/dashboard/templates/sidebar.html
+++ b/internal/admin/dashboard/templates/sidebar.html
@@ -47,17 +47,20 @@
     </nav>
     <div class="sidebar-footer">
         <div class="theme-toggle">
-            <button class="theme-btn" :class="{ active: theme === 'light' }" @click="setTheme('light')" title="Light" tabindex="-1">
+            <button class="theme-btn" :class="{ active: theme === 'light' }" @click="setTheme('light')" title="Light theme" aria-label="Light theme">
                 <i data-lucide="sun" class="theme-icon" aria-hidden="true"></i>
             </button>
-            <button class="theme-btn" :class="{ active: theme === 'system' }" @click="setTheme('system')" title="System" tabindex="-1">
+            <button class="theme-btn" :class="{ active: theme === 'system' }" @click="setTheme('system')" title="System theme" aria-label="System theme">
                 <i data-lucide="monitor" class="theme-icon" aria-hidden="true"></i>
             </button>
-            <button class="theme-btn" :class="{ active: theme === 'dark' }" @click="setTheme('dark')" title="Dark" tabindex="-1">
+            <button class="theme-btn" :class="{ active: theme === 'dark' }" @click="setTheme('dark')" title="Dark theme" aria-label="Dark theme">
                 <i data-lucide="moon" class="theme-icon" aria-hidden="true"></i>
             </button>
         </div>
-        <button class="theme-toggle-mobile" @click="toggleTheme()" :title="theme === 'light' ? 'Light' : theme === 'dark' ? 'Dark' : 'System'" tabindex="-1">
+        <button class="theme-toggle-mobile"
+                @click="toggleTheme()"
+                :title="theme === 'light' ? 'Light theme' : theme === 'dark' ? 'Dark theme' : 'System theme'"
+                :aria-label="theme === 'light' ? 'Light theme' : theme === 'dark' ? 'Dark theme' : 'System theme'">
             <template x-if="theme === 'light'">
                 <i data-lucide="sun" class="theme-icon" aria-hidden="true"></i>
             </template>
@@ -79,8 +82,11 @@
         </div>
     </div>
 </aside>
-<div class="sidebar-toggle"
-     @mousedown="toggleSidebar()"
-     :class="{ collapsed: sidebarCollapsed }"
-     :title="sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'"></div>
+<button type="button"
+        class="sidebar-toggle"
+        @click="toggleSidebar()"
+        :class="{ collapsed: sidebarCollapsed }"
+        :title="sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'"
+        :aria-label="sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'"
+        :aria-expanded="sidebarCollapsed ? 'false' : 'true'"></button>
 {{end}}


### PR DESCRIPTION
## Summary
- clarify model access override help text and tighten docs copy on benchmarks and values
- keep runtime refresh success state even when the follow-up dashboard reload fails
- make sidebar theme controls and collapse handle keyboard accessible
- fail fast in `docs-openapi` when `node` or `npx` is missing

## Verification
- pre-commit hooks passed
- `dashboard JavaScript unit tests`
- `make test-race`
- `hot-path performance guard (alloc/byte thresholds)`
- `make lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined benchmark and values documentation wording.

* **Accessibility**
  * Added focus outline styling for interactive controls.
  * Improved keyboard navigation and ARIA labels for theme and sidebar controls.

* **Bug Fixes**
  * Better error handling when dashboard data fails to reload after runtime refresh.

* **Chores**
  * Added Node.js tooling validation to build process.
  * Extended test coverage for accessibility and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->