### PR TITLE
docs(roadmap): update roadmap and cache docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ See [DEVELOPMENT.md](DEVELOPMENT.md) for testing, linting, and pre-commit setup.
 ### Must Have
 
 - [ ] Intelligent routing
-- [ ] Broader provider support: Oracle model configuration via environment variables, plus [Cohere, Command A, Operational, and DeepSeek V3](https://linear.app/gomodel/issue/GOM-121/add-providers-cohere-command-operational-deepseek-v3-operational)
+- [ ] Broader provider support: Oracle model configuration via environment variables, plus Cohere, Command A, Operational, and DeepSeek V3
 - [ ] Budget management with limits per `user_path` and/or API key
 - [ ] Editable model pricing for accurate cost tracking and budgeting
 - [ ] Full support for the OpenAI `/responses` and `/conversations` lifecycle

--- a/README.md
+++ b/README.md
@@ -231,35 +231,25 @@ See [DEVELOPMENT.md](DEVELOPMENT.md) for testing, linting, and pre-commit setup.
 
 # Roadmap
 
-## Shipped
+## 0.2.0
 
-| Area                          | Status | Notes                                                                                                                                                                        |
-| ----------------------------- | :----: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| OpenAI-compatible API surface |   ✅   | `/v1/chat/completions`, `/v1/responses`, `/v1/embeddings`, `/v1/files*`, `/v1/batches*`, and `/v1/models` are implemented.                                                   |
-| Provider passthrough          |   ✅   | Provider-native passthrough routes are available under `/p/{provider}/...`.                                                                                                  |
-| Observability                 |   ✅   | Prometheus metrics, audit logging, usage tracking, request IDs, and trace-header capture are implemented.                                                                    |
-| Administrative endpoints      |   ✅   | Admin API and dashboard ship with usage, audit, and model views.                                                                                                             |
-| Guardrails                    |   ✅   | The guardrails pipeline is implemented and can be enabled from config.                                                                                                       |
-| Guardrail types               |   ✅   | `system_prompt` and `llm_based_altering` guardrails are supported.                                                                                                           |
-| Semantic response cache       |   ✅   | Exact-match Redis plus optional semantic layer (API embeddings, `qdrant` / `pgvector` / `pinecone` / `weaviate`) — see [ADR-0006](docs/adr/0006-semantic-response-cache.md). |
+Most user-facing work is listed first.
 
-## In Progress
+### Must Have
 
-| Area                       | Status | Notes                                                                                       |
-| -------------------------- | :----: | ------------------------------------------------------------------------------------------- |
-| Billing management         |   🚧   | Usage and pricing primitives exist, but billing workflows are not complete.                 |
-| Budget management          |   🚧   | Gateway-level budget enforcement and policy controls are not implemented yet.               |
-| Guardrails depth           |   🚧   | Text guardrails ship today; non-text guardrail types are still to come.                     |
-| Observability integrations |   🚧   | Native Prometheus support exists; OpenTelemetry and DataDog integrations are still pending. |
+- [ ] Intelligent routing
+- [ ] Broader provider support: Oracle model configuration via environment variables, plus [Cohere, Command A, Operational, and DeepSeek V3](https://linear.app/gomodel/issue/GOM-121/add-providers-cohere-command-operational-deepseek-v3-operational)
+- [ ] Budget management with limits per `user_path` and/or API key
+- [ ] Editable model pricing for accurate cost tracking and budgeting
+- [ ] Full support for the OpenAI `/responses` and `/conversations` lifecycle
+- [ ] Prompt cache visibility showing how much of each prompt was cached by the provider
+- [ ] Guardrails hardening: better UI, simpler architecture, easier custom guardrails, and response-side guardrails before output reaches the client
+- [ ] Passthrough for all providers, beyond the current OpenAI and Anthropic beta
+- [ ] Fix failover charts in the dashboard
 
-## Planned
+### Should Have
 
-| Area              | Status | Notes                                                                   |
-| ----------------- | :----: | ----------------------------------------------------------------------- |
-| Many keys support |   🚧   | The gateway still uses one configured credential/base URL per provider. |
-| SSO / OIDC        |   🚧   | No SSO implementation is present yet.                                   |
-
-✅ Shipped 🚧 Planned or in progress
+- [ ] Cluster mode
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -229,11 +229,7 @@ See [DEVELOPMENT.md](DEVELOPMENT.md) for testing, linting, and pre-commit setup.
 
 ---
 
-# Roadmap
-
-## 0.2.0
-
-Most user-facing work is listed first.
+# Roadmap to 0.2.0
 
 ### Must Have
 

--- a/docs/about/roadmap.mdx
+++ b/docs/about/roadmap.mdx
@@ -11,7 +11,7 @@ Most user-facing work is listed first.
 ### Must Have
 
 - [ ] Intelligent routing
-- [ ] Broader provider support: Oracle model configuration via environment variables, plus [Cohere, Command A, Operational, and DeepSeek V3](https://linear.app/gomodel/issue/GOM-121/add-providers-cohere-command-operational-deepseek-v3-operational)
+- [ ] Broader provider support: Oracle model configuration via environment variables, plus Cohere, Command A, Operational, and DeepSeek V3
 - [ ] Budget management with limits per `user_path` and/or API key
 - [ ] Editable model pricing for accurate cost tracking and budgeting
 - [ ] Full support for the OpenAI `/responses` and `/conversations` lifecycle

--- a/docs/about/roadmap.mdx
+++ b/docs/about/roadmap.mdx
@@ -4,7 +4,7 @@ description: "Condensed GoModel roadmap for version 0.2.0, ordered by user impac
 icon: "list-todo"
 ---
 
-## 0.2.0
+## Roadmap to 0.2.0
 
 Most user-facing work is listed first.
 

--- a/docs/about/roadmap.mdx
+++ b/docs/about/roadmap.mdx
@@ -1,0 +1,25 @@
+---
+title: "Roadmap"
+description: "Condensed GoModel roadmap for version 0.2.0, ordered by user impact."
+icon: "list-todo"
+---
+
+## 0.2.0
+
+Most user-facing work is listed first.
+
+### Must Have
+
+- [ ] Intelligent routing
+- [ ] Broader provider support: Oracle model configuration via environment variables, plus [Cohere, Command A, Operational, and DeepSeek V3](https://linear.app/gomodel/issue/GOM-121/add-providers-cohere-command-operational-deepseek-v3-operational)
+- [ ] Budget management with limits per `user_path` and/or API key
+- [ ] Editable model pricing for accurate cost tracking and budgeting
+- [ ] Full support for the OpenAI `/responses` and `/conversations` lifecycle
+- [ ] Prompt cache visibility showing how much of each prompt was cached by the provider
+- [ ] Guardrails hardening: better UI, simpler architecture, easier custom guardrails, and response-side guardrails before output reaches the client
+- [ ] Passthrough for all providers, beyond the current OpenAI and Anthropic beta
+- [ ] Fix failover charts in the dashboard
+
+### Should Have
+
+- [ ] Cluster mode

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -59,6 +59,7 @@
                             "about/who-we-are",
                             "about/values",
                             "about/technical-philosophy",
+                            "about/roadmap",
                             "about/license",
                             "about/benchmarks"
                         ]

--- a/docs/features/cache.mdx
+++ b/docs/features/cache.mdx
@@ -1,25 +1,29 @@
 ---
 title: "Cache"
-description: "How GoModel response caching works, how to enable it, and what is included in the exact-cache key."
+description: "How GoModel response caching works, how to enable exact and semantic cache layers, and what is included in the exact-cache key."
 icon: "database"
 ---
 
 ## Overview
 
-GoModel ships with an exact-match response cache for non-streaming requests on:
+GoModel ships with two response-cache layers for non-streaming requests on:
 
 - `/v1/chat/completions`
 - `/v1/responses`
 - `/v1/embeddings`
 
-When a response is served from the exact cache, GoModel returns:
+Exact-match cache returns byte-identical responses with:
 
 ```http
 X-Cache: HIT (exact)
 ```
 
-Semantic caching is planned separately. The exact layer is the cache behavior
-available today.
+Semantic cache uses embeddings plus vector search so meaning-equivalent prompts
+can reuse a stored response:
+
+```http
+X-Cache: HIT (semantic)
+```
 
 ## Enable the exact cache
 
@@ -40,6 +44,38 @@ You can also configure it with environment variables:
 - `REDIS_KEY_RESPONSES`
 - `REDIS_TTL_RESPONSES`
 
+## Enable semantic caching
+
+Add a `semantic` block with an embedder provider and a vector store:
+
+```yaml
+cache:
+  response:
+    semantic:
+      enabled: true
+      embedder:
+        provider: openai
+      vector_store:
+        type: qdrant
+        qdrant:
+          url: http://localhost:6333
+          collection: gomodel_semantic
+```
+
+Supported vector stores:
+
+- `qdrant`
+- `pgvector`
+- `pinecone`
+- `weaviate`
+
+Both cache layers run after workflow and guardrail patching, so they operate on
+the final request sent upstream. Use `Cache-Control: no-cache` or
+`Cache-Control: no-store` to bypass caching per request.
+
+For the full semantic-cache design and storage options, see
+[ADR-0006](/adr/0006-semantic-response-cache).
+
 ## What the exact cache keys on
 
 The exact cache hashes:
@@ -52,21 +88,9 @@ The exact cache hashes:
 This means guardrails and workflows affect cache keys when they change the
 resolved workflow or the final body sent through execution.
 
-You can bypass caching per request with:
-
-```http
-Cache-Control: no-cache
-```
-
-or:
-
-```http
-Cache-Control: no-store
-```
-
 ## `user_path` behavior
 
-`user_path` is not added to the exact-cache key by itself.
+For the exact cache, `user_path` is not added to the cache key by itself.
 
 That is intentional. If two requests end up with the same path, resolved
 workflow, and final request body, they can share the same exact-cache


### PR DESCRIPTION
## Summary
- replace the README roadmap tables with a condensed 0.2.0 checklist
- add a Roadmap page to the Mintlify docs and link it in navigation
- update cache docs to describe semantic caching as available today

## Testing
- pre-commit hooks on staged files
- git diff --cached --check