### PR TITLE
docs(features): add failover page

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -38,7 +38,8 @@
                         "pages": [
                             "features/aliases",
                             "features/user-path",
-                            "features/cache"
+                            "features/cache",
+                            "features/failover"
                         ]
                     },
                     {

--- a/docs/features/failover.mdx
+++ b/docs/features/failover.mdx
@@ -22,7 +22,8 @@ fallback:
   manual_rules_path: "config/fallback.json"
 ```
 
-`config/fallback.json` is an ordered JSON map:
+`config/fallback.json` is a JSON object where each model entry contains an
+ordered candidate list (array); top-level keys are not ordered:
 
 ```json
 {
@@ -32,6 +33,8 @@ fallback:
   ]
 }
 ```
+
+The order-sensitive part is the array under each model entry.
 
 GoModel tries the listed candidates in order and stops on the first success.
 Use bare model names like `gpt-4o` or provider-qualified selectors like

--- a/docs/features/failover.mdx
+++ b/docs/features/failover.mdx
@@ -1,0 +1,68 @@
+---
+title: "Failover"
+description: "Configure GoModel failover with manual rules, understand experimental auto mode, and know when fallback attempts run."
+icon: "shuffle"
+keywords: ["failover", "fallback"]
+---
+
+## Overview
+
+GoModel exposes failover through the `fallback` config block.
+
+When a request fails, GoModel can retry it against alternate models. For
+predictable behavior, use manual mode.
+
+## Manual Mode
+
+Manual mode is the recommended mode today.
+
+```yaml
+fallback:
+  default_mode: "manual"
+  manual_rules_path: "config/fallback.json"
+```
+
+`config/fallback.json` is an ordered JSON map:
+
+```json
+{
+  "gpt-4o": [
+    "azure/gpt-4o",
+    "gemini/gemini-2.5-pro"
+  ]
+}
+```
+
+GoModel tries the listed candidates in order and stops on the first success.
+Use bare model names like `gpt-4o` or provider-qualified selectors like
+`azure/gpt-4o`.
+
+If needed, you can override the mode per model with `fallback.overrides`.
+
+## Auto Mode
+
+<Note>
+  `auto` mode is experimental right now.
+</Note>
+
+```yaml
+fallback:
+  default_mode: "auto"
+  manual_rules_path: "config/fallback.json"
+```
+
+Auto mode keeps any manual candidates first, then appends up to five extra
+candidates from the current model registry. It prefers models with the same
+request category, similar rankings, overlapping capabilities, and the same
+family when possible.
+
+## When It Runs
+
+Failover is attempted only after the primary request returns:
+
+- `5xx`
+- `429`
+- model unavailable, unsupported, or not found style errors
+
+It currently applies to translated `/v1/chat/completions` and `/v1/responses`
+requests, not `/v1/embeddings`.


### PR DESCRIPTION
## Summary
- add a new Features page for failover
- explain how to configure manual mode
- document that auto mode is experimental and summarize how it selects candidates
- add the page to the Mintlify Features navigation

## Validation
- `mint validate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added failover configuration documentation covering manual and auto failover modes with setup instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->