### PR TITLE
fix(dashboard): persist API key across browser sessions

### DIFF
--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -2,6 +2,7 @@
 
 function dashboard() {
   const STALE_AUTH_RESPONSE = "STALE_AUTH";
+  const API_KEY_STORAGE_KEY = "gomodel_api_key";
 
   function resolveModuleFactory(factory, windowName) {
     if (typeof factory === "function") {
@@ -221,8 +222,9 @@ function dashboard() {
       if (typeof this.initProviderStatusPreferences === "function") {
         this.initProviderStatusPreferences();
       }
-      // Older dashboard versions persisted this secret. Keep it memory-only.
-      localStorage.removeItem("gomodel_api_key");
+      this.apiKey = this.normalizeApiKey(
+        localStorage.getItem(API_KEY_STORAGE_KEY) || "",
+      );
       this.theme = localStorage.getItem("gomodel_theme") || "system";
       this.sidebarCollapsed =
         localStorage.getItem("gomodel_sidebar_collapsed") === "true";
@@ -336,8 +338,7 @@ function dashboard() {
 
     saveApiKey() {
       this.apiKey = this.normalizeApiKey(this.apiKey);
-      // Do not persist auth secrets in browser storage.
-      localStorage.removeItem("gomodel_api_key");
+      localStorage.setItem(API_KEY_STORAGE_KEY, this.apiKey);
     },
 
     requestOptions(options) {

--- a/internal/admin/dashboard/static/js/modules/dashboard-display.test.js
+++ b/internal/admin/dashboard/static/js/modules/dashboard-display.test.js
@@ -205,7 +205,7 @@ test('stale unauthorized category responses preserve existing categories', async
     assert.equal(app.authDialogOpen, false);
 });
 
-test('init clears legacy stored API key instead of restoring it', () => {
+test('init restores a persisted API key from browser storage', () => {
     const storage = createLocalStorage({
         gomodel_api_key: 'existing-token',
         gomodel_theme: 'dark'
@@ -222,12 +222,12 @@ test('init clears legacy stored API key instead of restoring it', () => {
 
     app.init();
 
-    assert.equal(app.apiKey, '');
-    assert.equal(storage.getItem('gomodel_api_key'), null);
+    assert.equal(app.apiKey, 'existing-token');
+    assert.equal(storage.getItem('gomodel_api_key'), 'existing-token');
     assert.equal(app.theme, 'dark');
 });
 
-test('submitApiKey trims bearer input and keeps the key in memory before refreshing dashboard data', () => {
+test('submitApiKey trims bearer input, persists it, and refreshes dashboard data', () => {
     const storage = createLocalStorage();
     const app = loadDashboardApp({
         window: { localStorage: storage }
@@ -243,7 +243,7 @@ test('submitApiKey trims bearer input and keeps the key in memory before refresh
 
     assert.equal(app.apiKey, 'secret-token');
     assert.equal(app.authRequestGeneration, 1);
-    assert.equal(storage.getItem('gomodel_api_key'), null);
+    assert.equal(storage.getItem('gomodel_api_key'), 'secret-token');
     assert.equal(app.authDialogOpen, false);
     assert.equal(fetches, 1);
 });


### PR DESCRIPTION
## Summary
- restore browser-side persistence for the dashboard API key
- load the stored key on dashboard init and persist the normalized value on submit
- update dashboard display tests to cover the restored behavior

## Testing
- node --test internal/admin/dashboard/static/js/modules/dashboard-display.test.js internal/admin/dashboard/static/js/modules/dashboard-layout.test.js internal/admin/dashboard/static/js/modules/request-cancellation.test.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API key is now persisted in browser storage and automatically restored on dashboard initialization.

* **Tests**
  * Updated authentication tests to reflect new API key persistence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->