### PR TITLE
fix(audit): improve failover and timeout visibility

### DIFF
--- a/internal/admin/dashboard/static/js/modules/dashboard-layout.test.js
+++ b/internal/admin/dashboard/static/js/modules/dashboard-layout.test.js
@@ -366,6 +366,7 @@ test('audit toolbar uses a full-width search row above the select row with a rig
         indexTemplate,
         /id="audit-filter-search"[^>]*placeholder="Search by request ID, model, provider, path, user path, or error\.\.\."/
     );
+    assert.match(indexTemplate, /id="audit-filter-status"[\s\S]*<option value="504">504<\/option>/);
     assert.doesNotMatch(indexTemplate, /id="audit-filter-model"/);
     assert.doesNotMatch(indexTemplate, /id="audit-filter-provider"/);
     assert.doesNotMatch(indexTemplate, /id="audit-filter-path"/);
@@ -419,6 +420,7 @@ test('audit entry metadata is rendered as a labeled pill row at the bottom of th
     assert.match(auditEntry, /<span class="provider-badge mono" x-text="entry\.requested_model \|\| entry\.model \|\| '-'"><\/span>/);
     assert.match(auditEntry, /<span class="provider-badge mono" x-text="'request_id: ' \+ \(entry\.request_id \|\| '-'\)"><\/span>/);
     assert.match(auditEntry, /<span class="provider-badge mono" x-show="entry\.client_ip" x-text="'ip: ' \+ entry\.client_ip"><\/span>/);
+    assert.match(auditEntry, /<span class="provider-badge mono" x-show="workflowFailoverTarget\(entry\)" x-text="'failover: ' \+ workflowFailoverTarget\(entry\)"><\/span>/);
 
     const metadataRule = readCSSRule(css, '.audit-entry-metadata');
     assert.match(metadataRule, /display:\s*flex/);

--- a/internal/admin/dashboard/static/js/modules/workflows-layout.test.js
+++ b/internal/admin/dashboard/static/js/modules/workflows-layout.test.js
@@ -218,7 +218,7 @@ test('workflow editor renders a live preview card from the draft workflow state'
     );
     assert.match(
         chartTemplate,
-        /{{define "workflow-chart"}}[\s\S]*x-data="\{ workflow: {{\.}} \|\| \{\} \}"[\s\S]*x-effect="workflow = {{\.}} \|\| \{\}"[\s\S]*<span class="workflow-node-label">Auth<\/span>[\s\S]*x-text="workflow\.authNodeSublabel"[\s\S]*x-show="workflow\.showGuardrails"[\s\S]*x-show="workflow\.showCache"[\s\S]*x-text="workflow\.aiLabel"/
+        /{{define "workflow-chart"}}[\s\S]*x-data="\{ workflow: {{\.}} \|\| \{\} \}"[\s\S]*x-effect="workflow = {{\.}} \|\| \{\}"[\s\S]*<span class="workflow-node-label">Auth<\/span>[\s\S]*x-text="workflow\.authNodeSublabel"[\s\S]*x-show="workflow\.showGuardrails"[\s\S]*x-show="workflow\.showCache"[\s\S]*x-text="workflow\.aiLabel"[\s\S]*x-show="workflow\.showFailover"[\s\S]*x-text="workflow\.failoverTargetLabel"/
     );
 });
 
@@ -228,7 +228,7 @@ test('audit log pipeline binds cache visibility and runtime highlight classes ac
 
     assert.match(
         template,
-        /{{template "workflow-chart" "workflowAuditChart\(entry\)"}}[\s\S]*<div class="workflow-conn" x-show="workflow\.showCache" :class="workflow\.cacheConnClass"><\/div>[\s\S]*<div class="workflow-node workflow-node-feature workflow-node-cache" x-show="workflow\.showCache" :class="workflow\.cacheNodeClass">[\s\S]*x-text="workflow\.cacheStatusLabel"/
+        /{{template "workflow-chart" "workflowAuditChart\(entry\)"}}[\s\S]*<div class="workflow-conn" x-show="workflow\.showCache" :class="workflow\.cacheConnClass"><\/div>[\s\S]*<div class="workflow-node workflow-node-feature workflow-node-cache" x-show="workflow\.showCache" :class="workflow\.cacheNodeClass">[\s\S]*x-text="workflow\.cacheStatusLabel"[\s\S]*<div class="workflow-conn" x-show="workflow\.showFailover" :class="workflow\.failoverConnClass"><\/div>[\s\S]*<div class="workflow-node workflow-node-feature workflow-node-failover" x-show="workflow\.showFailover" :class="workflow\.failoverNodeClass">[\s\S]*x-text="workflow\.failoverStatusLabel"[\s\S]*x-text="workflow\.failoverTargetLabel"/
     );
     assert.match(
         template,

--- a/internal/admin/dashboard/static/js/modules/workflows.js
+++ b/internal/admin/dashboard/static/js/modules/workflows.js
@@ -441,6 +441,27 @@
                 return this.workflowNormalizedFeatures(raw);
             },
 
+            workflowEntryFailover(entry) {
+                const raw = entry && entry.data && entry.data.failover;
+                if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+                    return null;
+                }
+
+                const targetModel = String(raw.target_model || raw.targetModel || '').trim() || null;
+                if (!targetModel) {
+                    return null;
+                }
+
+                return {
+                    targetModel
+                };
+            },
+
+            workflowFailoverTarget(entry) {
+                const failover = this.workflowEntryFailover(entry);
+                return failover && failover.targetModel ? failover.targetModel : null;
+            },
+
             workflowSourceGuardrails(source) {
                 const raw = Array.isArray(source && source.workflow_payload && source.workflow_payload.guardrails)
                     ? source.workflow_payload.guardrails
@@ -1194,6 +1215,11 @@
                     cacheNodeClass: this.workflowCacheNodeClass(runtime),
                     cacheConnClass: this.workflowCacheConnClass(runtime),
                     cacheStatusLabel: this.workflowCacheStatusLabel(runtime),
+                    showFailover: !!features.fallback || this.workflowRuntimeUsedFailover(runtime),
+                    failoverNodeClass: this.workflowFailoverNodeClass(runtime),
+                    failoverConnClass: this.workflowFailoverConnClass(runtime),
+                    failoverStatusLabel: this.workflowFailoverStatusLabel(runtime),
+                    failoverTargetLabel: this.workflowFailoverTargetLabel(runtime),
                     aiLabel: this.workflowAiLabel(source, runtime),
                     aiSublabel: this.workflowAiSublabel(source, runtime),
 	                    aiConnClass: this.workflowAiConnClass(runtime),
@@ -1217,8 +1243,17 @@
 
             workflowAuditChart(entry) {
                 const source = this.auditEntryWorkflow(entry);
-                const runtime = this.workflowRuntimeFromEntry(entry);
-                const features = this.workflowEntryFeatures(entry) || this.workflowSourceFeatures(source);
+                const runtime = this.workflowRuntimeFromEntry(entry, source);
+                const features = this.workflowEntryFeatures(entry)
+                    || (source
+                        ? this.workflowSourceFeatures(source)
+                        : {
+                            cache: false,
+                            audit: false,
+                            usage: false,
+                            guardrails: false,
+                            fallback: false
+                        });
                 return this.workflowChartModel(source, runtime, {
                     entry,
                     features,
@@ -1231,6 +1266,7 @@
             // runtime shape: {
             //   cacheHit: bool,
             //   cacheType: 'exact'|'semantic'|null,
+            //   failoverTarget: string|null,
             //   provider,
             //   model,
             //   statusCode: number|null,
@@ -1239,6 +1275,10 @@
             // }
             workflowRuntimeHasCache(runtime) {
                 return !!(runtime && runtime.cacheHit);
+            },
+
+            workflowRuntimeUsedFailover(runtime) {
+                return !!(runtime && runtime.failoverTarget);
             },
 
             workflowShowCacheStep(source, runtime) {
@@ -1257,6 +1297,22 @@
                 if (!runtime || !runtime.cacheHit) return null;
                 if (runtime.cacheType === 'semantic') return 'Hit (Semantic)';
                 return 'Hit (Exact)';
+            },
+
+            workflowFailoverNodeClass(runtime) {
+                return runtime && runtime.failoverTarget ? 'workflow-node-success' : '';
+            },
+
+            workflowFailoverConnClass(runtime) {
+                return runtime && runtime.failoverTarget ? 'workflow-conn-hit' : '';
+            },
+
+            workflowFailoverStatusLabel(runtime) {
+                return runtime && runtime.failoverTarget ? 'Redirected' : null;
+            },
+
+            workflowFailoverTargetLabel(runtime) {
+                return runtime && runtime.failoverTarget ? runtime.failoverTarget : null;
             },
 
             workflowAiConnClass(runtime) {
@@ -1298,7 +1354,52 @@
                 return visible && highlightPresent ? 'workflow-node-success' : '';
             },
 
-            workflowRuntimeFromEntry(entry) {
+            workflowQualifiedSelectorParts(selector) {
+                const raw = String(selector || '').trim();
+                if (!raw) return null;
+                const slashIndex = raw.indexOf('/');
+                if (slashIndex <= 0 || slashIndex >= raw.length - 1) {
+                    return null;
+                }
+                return {
+                    provider: raw.slice(0, slashIndex),
+                    model: raw.slice(slashIndex + 1)
+                };
+            },
+
+            workflowPrimaryRouteFromEntry(entry, source) {
+                const requestedModel = String(entry && (entry.requested_model || entry.model) || '').trim();
+                const failover = this.workflowEntryFailover(entry);
+                if (!(failover && failover.targetModel)) {
+                    return {
+                        provider: String(entry && entry.provider || '').trim() || null,
+                        model: requestedModel || null
+                    };
+                }
+
+                const qualifiedRequested = this.workflowQualifiedSelectorParts(requestedModel);
+                if (qualifiedRequested) {
+                    return qualifiedRequested;
+                }
+
+                const scopeProvider = this.workflowScopeProviderValue(source && source.scope);
+                const scopeModel = scopeProvider
+                    ? String(source && source.scope && source.scope.scope_model || '').trim()
+                    : '';
+                if (scopeProvider || scopeModel) {
+                    return {
+                        provider: scopeProvider || null,
+                        model: scopeModel || requestedModel || null
+                    };
+                }
+
+                return {
+                    provider: null,
+                    model: requestedModel || null
+                };
+            },
+
+            workflowRuntimeFromEntry(entry, source) {
                 if (!entry) return null;
                 const normalizedCacheType = (() => {
                     const value = String(entry.cache_type || '').trim().toLowerCase();
@@ -1313,18 +1414,21 @@
                     return Number.isFinite(value) ? value : null;
                 })();
                 const cacheHit = normalizedCacheType
-                    ? true
-                    : (entry.cache_hit !== undefined && entry.cache_hit !== null)
-                        ? !!entry.cache_hit
-                        : false;
+                        ? true
+                        : (entry.cache_hit !== undefined && entry.cache_hit !== null)
+                            ? !!entry.cache_hit
+                            : false;
+                const failover = this.workflowEntryFailover(entry);
+                const primaryRoute = this.workflowPrimaryRouteFromEntry(entry, source);
                 const responseSuccess = Number.isFinite(statusCode) && statusCode >= 200 && statusCode < 300;
                 const authError = String(entry.error_type || '').trim().toLowerCase() === 'authentication_error';
                 const authMethod = String(entry.auth_method || '').trim().toLowerCase() || null;
                 return {
                     cacheHit,
                     cacheType: normalizedCacheType || null,
-                    provider: entry.provider || null,
-                    model: entry.requested_model || entry.model || null,
+                    failoverTarget: failover && failover.targetModel ? failover.targetModel : null,
+                    provider: primaryRoute.provider,
+                    model: primaryRoute.model,
                     statusCode,
                     responseSuccess,
                     aiSuccess: responseSuccess && !cacheHit,

--- a/internal/admin/dashboard/static/js/modules/workflows.test.js
+++ b/internal/admin/dashboard/static/js/modules/workflows.test.js
@@ -219,6 +219,11 @@ test('workflowChart returns the shared chart contract for workflow sources', () 
             cacheNodeClass: '',
             cacheConnClass: '',
             cacheStatusLabel: null,
+            showFailover: true,
+            failoverNodeClass: '',
+            failoverConnClass: '',
+            failoverStatusLabel: null,
+            failoverTargetLabel: null,
             aiLabel: 'openai',
             aiSublabel: 'gpt-5',
             aiConnClass: '',
@@ -274,6 +279,11 @@ test('workflowChart masks globally disabled workflow features from persisted wor
             cacheNodeClass: '',
             cacheConnClass: '',
             cacheStatusLabel: null,
+            showFailover: true,
+            failoverNodeClass: '',
+            failoverConnClass: '',
+            failoverStatusLabel: null,
+            failoverTargetLabel: null,
             aiLabel: 'openai',
             aiSublabel: 'gpt-5',
             aiConnClass: '',
@@ -418,6 +428,11 @@ test('workflowAuditChart returns the shared chart contract for audit runtime ent
             cacheNodeClass: 'workflow-node-success',
             cacheConnClass: 'workflow-conn-hit',
             cacheStatusLabel: 'Hit (Semantic)',
+            showFailover: true,
+            failoverNodeClass: '',
+            failoverConnClass: '',
+            failoverStatusLabel: null,
+            failoverTargetLabel: null,
             aiLabel: 'openai',
             aiSublabel: 'gpt-5',
             aiConnClass: 'workflow-conn-dim',
@@ -454,6 +469,11 @@ test('workflowAuditChart forces audit nodes even when the workflow version canno
             cacheNodeClass: 'workflow-node-success',
             cacheConnClass: 'workflow-conn-hit',
             cacheStatusLabel: 'Hit (Exact)',
+            showFailover: false,
+            failoverNodeClass: '',
+            failoverConnClass: '',
+            failoverStatusLabel: null,
+            failoverTargetLabel: null,
             aiLabel: 'openai',
             aiSublabel: 'gpt-5',
             aiConnClass: 'workflow-conn-dim',
@@ -519,6 +539,11 @@ test('workflowAuditChart prefers request-time workflow features over current wor
             cacheNodeClass: '',
             cacheConnClass: '',
             cacheStatusLabel: null,
+            showFailover: true,
+            failoverNodeClass: '',
+            failoverConnClass: '',
+            failoverStatusLabel: null,
+            failoverTargetLabel: null,
             aiLabel: 'openai',
             aiSublabel: 'gpt-5',
             aiConnClass: '',
@@ -533,6 +558,118 @@ test('workflowAuditChart prefers request-time workflow features over current wor
             showUsage: false,
             showAudit: true,
             workflowID: 'historical-v2'
+        })
+    );
+});
+
+test('workflowAuditChart highlights configured failover redirects and exposes the selected target', () => {
+    const module = createWorkflowsModule();
+    module.workflowVersionsByID = {
+        'historical-v3': {
+            id: 'historical-v3',
+            scope: {
+                scope_provider: 'openai',
+                scope_model: 'gpt-5'
+            },
+            workflow_payload: {
+                features: {
+                    cache: false,
+                    audit: true,
+                    usage: true,
+                    guardrails: false,
+                    fallback: true
+                },
+                guardrails: []
+            }
+        }
+    };
+
+    assert.equal(
+        JSON.stringify(module.workflowAuditChart({
+            workflow_version_id: 'historical-v3',
+            provider: 'azure',
+            requested_model: 'gpt-5',
+            status_code: 200,
+            data: {
+                workflow_features: {
+                    cache: false,
+                    audit: true,
+                    usage: true,
+                    guardrails: false,
+                    fallback: true
+                },
+                failover: {
+                    target_model: 'azure/gpt-4o'
+                }
+            }
+        })),
+        JSON.stringify({
+            showGuardrails: false,
+            guardrailLabel: '',
+            showCache: false,
+            cacheNodeClass: '',
+            cacheConnClass: '',
+            cacheStatusLabel: null,
+            showFailover: true,
+            failoverNodeClass: 'workflow-node-success',
+            failoverConnClass: 'workflow-conn-hit',
+            failoverStatusLabel: 'Redirected',
+            failoverTargetLabel: 'azure/gpt-4o',
+            aiLabel: 'openai',
+            aiSublabel: 'gpt-5',
+            aiConnClass: '',
+            aiNodeClass: 'workflow-node-success',
+            responseConnClass: '',
+            responseNodeClass: 'workflow-node-success',
+            authNodeClass: '',
+            authNodeSublabel: null,
+            usageNodeClass: 'workflow-node-success',
+            auditNodeClass: 'workflow-node-success',
+            showAsync: true,
+            showUsage: true,
+            showAudit: true,
+            workflowID: 'historical-v3'
+        })
+    );
+    assert.equal(module.workflowFailoverTarget({
+        data: {
+            failover: {
+                target_model: 'azure/gpt-4o'
+            }
+        }
+    }), 'azure/gpt-4o');
+});
+
+test('workflowRuntimeFromEntry preserves the primary route for cross-provider failover entries', () => {
+    const module = createWorkflowsModule();
+
+    assert.equal(
+        JSON.stringify(module.workflowRuntimeFromEntry({
+            provider: 'azure',
+            requested_model: 'gpt-5',
+            status_code: 200,
+            data: {
+                failover: {
+                    target_model: 'azure/gpt-4o'
+                }
+            }
+        }, {
+            scope: {
+                scope_provider: 'openai',
+                scope_model: 'gpt-5'
+            }
+        })),
+        JSON.stringify({
+            cacheHit: false,
+            cacheType: null,
+            failoverTarget: 'azure/gpt-4o',
+            provider: 'openai',
+            model: 'gpt-5',
+            statusCode: 200,
+            responseSuccess: true,
+            aiSuccess: true,
+            authError: false,
+            authMethod: null
         })
     );
 });
@@ -1608,6 +1745,7 @@ test('workflowRuntimeFromEntry derives cache hit state from cache_type without r
         JSON.stringify({
             cacheHit: true,
             cacheType: 'semantic',
+            failoverTarget: null,
             provider: 'openai',
             model: 'gpt-5',
             statusCode: null,
@@ -1623,6 +1761,7 @@ test('workflowRuntimeFromEntry derives cache hit state from cache_type without r
         JSON.stringify({
             cacheHit: true,
             cacheType: 'exact',
+            failoverTarget: null,
             provider: null,
             model: null,
             statusCode: null,
@@ -1638,6 +1777,7 @@ test('workflowRuntimeFromEntry derives cache hit state from cache_type without r
         JSON.stringify({
             cacheHit: false,
             cacheType: null,
+            failoverTarget: null,
             provider: null,
             model: null,
             statusCode: null,
@@ -1690,6 +1830,7 @@ test('workflowRuntimeFromEntry treats any uncached 2xx status as a successful AI
         JSON.stringify({
             cacheHit: false,
             cacheType: null,
+            failoverTarget: null,
             provider: 'openai',
             model: 'gpt-5',
             statusCode: 204,

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -1464,6 +1464,7 @@
                     <option value="500">500</option>
                     <option value="502">502</option>
                     <option value="503">503</option>
+                    <option value="504">504</option>
                 </select>
                 <select id="audit-filter-stream" aria-label="Streaming mode filter" x-model="auditStream" @change="fetchAuditLog(true)" class="usage-log-select audit-filter-select">
                     <option value="">All Modes</option>
@@ -1524,6 +1525,7 @@
                                     <span class="provider-badge mono" x-show="entry.auth_key_id" x-text="'auth_key_id: ' + entry.auth_key_id"></span>
                                     <span class="provider-badge audit-alias-badge" x-show="entry.alias_used">alias</span>
                                     <span class="provider-badge mono" x-show="entry.alias_used && entry.resolved_model" x-text="'resolved: ' + qualifiedResolvedModelDisplay(entry)"></span>
+                                    <span class="provider-badge mono" x-show="workflowFailoverTarget(entry)" x-text="'failover: ' + workflowFailoverTarget(entry)"></span>
                                     <span class="provider-badge" x-show="entry.stream">stream</span>
                                     <span class="provider-badge" x-show="entry.error_type" x-text="entry.error_type"></span>
                                 </div>

--- a/internal/admin/dashboard/templates/workflow-chart.html
+++ b/internal/admin/dashboard/templates/workflow-chart.html
@@ -58,6 +58,16 @@
             <span class="workflow-node-sub" x-show="workflow.aiSublabel" x-text="workflow.aiSublabel"></span>
         </div>
 
+        <div class="workflow-conn" x-show="workflow.showFailover" :class="workflow.failoverConnClass"></div>
+        <div class="workflow-node workflow-node-feature workflow-node-failover" x-show="workflow.showFailover" :class="workflow.failoverNodeClass">
+            <div class="workflow-node-icon">
+                <svg viewBox="0 0 24 24"><path d="M17 3h4v4"/><path d="M7 21H3v-4"/><path d="M21 3l-7 7"/><path d="M3 21l7-7"/></svg>
+            </div>
+            <span class="workflow-node-label">Failover</span>
+            <span class="workflow-node-badge" x-show="workflow.failoverStatusLabel" x-text="workflow.failoverStatusLabel"></span>
+            <span class="workflow-node-sub" x-show="workflow.failoverTargetLabel" x-text="workflow.failoverTargetLabel"></span>
+        </div>
+
         <div class="workflow-conn" :class="workflow.responseConnClass"></div>
         <div class="workflow-node workflow-node-endpoint" :class="workflow.responseNodeClass">
             <div class="workflow-node-icon workflow-node-icon-endpoint">

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -624,7 +624,7 @@ func (h *Handler) CacheOverview(c *echo.Context) error {
 // @Param        error_type   query     string  false  "Filter by error type"
 // @Param        status_code  query     int     false  "Filter by status code"
 // @Param        stream       query     bool    false  "Filter by stream mode (true/false)"
-// @Param        search       query     string  false  "Search across request_id/requested_model/provider/method/path/error_type"
+// @Param        search       query     string  false  "Search across request_id/requested_model/provider/method/path/error_type/error_message"
 // @Param        limit        query     int     false  "Page size (default 25, max 100)"
 // @Param        offset       query     int     false  "Offset for pagination"
 // @Success      200  {object}  auditlog.LogListResult

--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -84,6 +84,10 @@ type LogData struct {
 	// even if the active process config changes later.
 	WorkflowFeatures *WorkflowFeaturesSnapshot `json:"workflow_features,omitempty" bson:"workflow_features,omitempty"`
 
+	// Failover captures runtime redirect details when translated execution
+	// moved from the primary selector to a configured failover target.
+	Failover *FailoverSnapshot `json:"failover,omitempty" bson:"failover,omitempty"`
+
 	// Request parameters
 	Temperature *float64 `json:"temperature,omitempty" bson:"temperature,omitempty"`
 	MaxTokens   *int     `json:"max_tokens,omitempty" bson:"max_tokens,omitempty"`
@@ -116,6 +120,13 @@ type WorkflowFeaturesSnapshot struct {
 	Usage      bool `json:"usage" bson:"usage"`
 	Guardrails bool `json:"guardrails" bson:"guardrails"`
 	Fallback   bool `json:"fallback" bson:"fallback"`
+}
+
+// FailoverSnapshot stores the runtime failover selection used for one request.
+// The target model is the configured failover selector, not the model echoed by
+// the provider response body.
+type FailoverSnapshot struct {
+	TargetModel string `json:"target_model,omitempty" bson:"target_model,omitempty"`
 }
 
 // marshalLogData marshals the Data field to JSON for SQL storage.

--- a/internal/auditlog/auditlog_test.go
+++ b/internal/auditlog/auditlog_test.go
@@ -135,6 +135,9 @@ func TestLogEntryJSON(t *testing.T) {
 		Stream:         false,
 		Data: &LogData{
 			UserAgent: "test-agent",
+			Failover: &FailoverSnapshot{
+				TargetModel: "azure/gpt-4o",
+			},
 		},
 	}
 
@@ -174,6 +177,12 @@ func TestLogEntryJSON(t *testing.T) {
 	}
 	if decoded.RequestID != entry.RequestID {
 		t.Errorf("RequestID mismatch: expected %q, got %q", entry.RequestID, decoded.RequestID)
+	}
+	if decoded.Data == nil || decoded.Data.Failover == nil {
+		t.Fatal("expected Failover snapshot to survive JSON round-trip")
+	}
+	if decoded.Data.Failover.TargetModel != "azure/gpt-4o" {
+		t.Errorf("Failover.TargetModel mismatch: got %q, want %q", decoded.Data.Failover.TargetModel, "azure/gpt-4o")
 	}
 }
 
@@ -968,6 +977,9 @@ func TestCreateStreamEntry(t *testing.T) {
 				Guardrails: false,
 				Fallback:   true,
 			},
+			Failover: &FailoverSnapshot{
+				TargetModel: "azure/gpt-4o",
+			},
 			RequestHeaders: map[string]string{
 				"Content-Type": "application/json",
 			},
@@ -1013,6 +1025,12 @@ func TestCreateStreamEntry(t *testing.T) {
 	}
 	if streamEntry.AuthMethod != baseEntry.AuthMethod {
 		t.Error("AuthMethod not copied")
+	}
+	if streamEntry.Data == nil || streamEntry.Data.Failover == nil {
+		t.Fatal("Failover snapshot not copied")
+	}
+	if streamEntry.Data.Failover.TargetModel != "azure/gpt-4o" {
+		t.Errorf("Failover.TargetModel = %q, want %q", streamEntry.Data.Failover.TargetModel, "azure/gpt-4o")
 	}
 	if streamEntry.ClientIP != baseEntry.ClientIP {
 		t.Error("ClientIP not copied")

--- a/internal/auditlog/middleware.go
+++ b/internal/auditlog/middleware.go
@@ -434,6 +434,29 @@ func EnrichLogEntryWithResolvedRoute(entry *LogEntry, resolvedModel, providerTyp
 	enrichEntryWithResolvedRoute(entry, resolvedModel, providerType, providerName)
 }
 
+// EnrichEntryWithFailover records the configured failover selector used for the
+// live request when translated execution redirected away from the primary
+// selector.
+func EnrichEntryWithFailover(c *echo.Context, targetModel string) {
+	entryVal := c.Get(string(LogEntryKey))
+	if entryVal == nil {
+		return
+	}
+
+	entry, ok := entryVal.(*LogEntry)
+	if !ok || entry == nil {
+		return
+	}
+
+	enrichEntryWithFailover(entry, targetModel)
+}
+
+// EnrichLogEntryWithFailover attaches failover redirect metadata directly to an
+// existing audit log entry.
+func EnrichLogEntryWithFailover(entry *LogEntry, targetModel string) {
+	enrichEntryWithFailover(entry, targetModel)
+}
+
 func enrichEntryWithResolvedRoute(entry *LogEntry, resolvedModel, providerType, providerName string) {
 	if entry == nil {
 		return
@@ -446,6 +469,21 @@ func enrichEntryWithResolvedRoute(entry *LogEntry, resolvedModel, providerType, 
 	}
 	if providerName = strings.TrimSpace(providerName); providerName != "" {
 		entry.ProviderName = providerName
+	}
+}
+
+func enrichEntryWithFailover(entry *LogEntry, targetModel string) {
+	if entry == nil {
+		return
+	}
+
+	targetModel = strings.TrimSpace(targetModel)
+	if targetModel == "" {
+		return
+	}
+
+	ensureLogData(entry).Failover = &FailoverSnapshot{
+		TargetModel: targetModel,
 	}
 }
 

--- a/internal/auditlog/reader_postgresql.go
+++ b/internal/auditlog/reader_postgresql.go
@@ -78,7 +78,7 @@ func (r *PostgreSQLReader) GetLogs(ctx context.Context, params LogQueryParams) (
 	}
 	if params.Search != "" {
 		s := "%" + escapeLikeWildcards(params.Search) + "%"
-		conditions = append(conditions, fmt.Sprintf("(request_id ILIKE $%d ESCAPE '\\' OR auth_key_id ILIKE $%d ESCAPE '\\' OR requested_model ILIKE $%d ESCAPE '\\' OR provider ILIKE $%d ESCAPE '\\' OR provider_name ILIKE $%d ESCAPE '\\' OR method ILIKE $%d ESCAPE '\\' OR path ILIKE $%d ESCAPE '\\' OR user_path ILIKE $%d ESCAPE '\\' OR error_type ILIKE $%d ESCAPE '\\')", argIdx, argIdx, argIdx, argIdx, argIdx, argIdx, argIdx, argIdx, argIdx))
+		conditions = append(conditions, fmt.Sprintf("(request_id ILIKE $%d ESCAPE '\\' OR auth_key_id ILIKE $%d ESCAPE '\\' OR requested_model ILIKE $%d ESCAPE '\\' OR provider ILIKE $%d ESCAPE '\\' OR provider_name ILIKE $%d ESCAPE '\\' OR method ILIKE $%d ESCAPE '\\' OR path ILIKE $%d ESCAPE '\\' OR user_path ILIKE $%d ESCAPE '\\' OR error_type ILIKE $%d ESCAPE '\\' OR data->>'error_message' ILIKE $%d ESCAPE '\\')", argIdx, argIdx, argIdx, argIdx, argIdx, argIdx, argIdx, argIdx, argIdx, argIdx))
 		args = append(args, s)
 		argIdx++
 	}

--- a/internal/auditlog/reader_sqlite.go
+++ b/internal/auditlog/reader_sqlite.go
@@ -73,8 +73,8 @@ func (r *SQLiteReader) GetLogs(ctx context.Context, params LogQueryParams) (*Log
 	}
 	if params.Search != "" {
 		s := "%" + escapeLikeWildcards(params.Search) + "%"
-		conditions = append(conditions, `(request_id LIKE ? ESCAPE '\' OR auth_key_id LIKE ? ESCAPE '\' OR requested_model LIKE ? ESCAPE '\' OR provider LIKE ? ESCAPE '\' OR provider_name LIKE ? ESCAPE '\' OR method LIKE ? ESCAPE '\' OR path LIKE ? ESCAPE '\' OR user_path LIKE ? ESCAPE '\' OR error_type LIKE ? ESCAPE '\')`)
-		args = append(args, s, s, s, s, s, s, s, s, s)
+		conditions = append(conditions, `(request_id LIKE ? ESCAPE '\' OR auth_key_id LIKE ? ESCAPE '\' OR requested_model LIKE ? ESCAPE '\' OR provider LIKE ? ESCAPE '\' OR provider_name LIKE ? ESCAPE '\' OR method LIKE ? ESCAPE '\' OR path LIKE ? ESCAPE '\' OR user_path LIKE ? ESCAPE '\' OR error_type LIKE ? ESCAPE '\' OR json_extract(data, '$.error_message') LIKE ? ESCAPE '\')`)
+		args = append(args, s, s, s, s, s, s, s, s, s, s)
 	}
 
 	where := buildWhereClause(conditions)

--- a/internal/auditlog/reader_sqlite_boundary_test.go
+++ b/internal/auditlog/reader_sqlite_boundary_test.go
@@ -128,3 +128,62 @@ func TestSQLiteReaderGetLogs_SearchMatchesUserPath(t *testing.T) {
 		t.Fatalf("expected matching entry %q, got %q", "team-match", result.Entries[0].ID)
 	}
 }
+
+func TestSQLiteReaderGetLogs_SearchMatchesErrorMessage(t *testing.T) {
+	db := createTestDB(t)
+	defer db.Close()
+
+	store, err := NewSQLiteStore(db, 0)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := store.WriteBatch(ctx, []*LogEntry{
+		{
+			ID:             "timeout-match",
+			Timestamp:      time.Date(2026, 1, 16, 12, 0, 0, 0, time.UTC),
+			RequestedModel: "gpt-5",
+			Provider:       "openai",
+			ErrorType:      "provider_error",
+			Data: &LogData{
+				ErrorMessage: `failed to send request: Post "https://api.openai.com/v1/chat/completions": http2: timeout awaiting response headers`,
+			},
+		},
+		{
+			ID:             "other-error",
+			Timestamp:      time.Date(2026, 1, 16, 11, 0, 0, 0, time.UTC),
+			RequestedModel: "gpt-5",
+			Provider:       "openai",
+			ErrorType:      "provider_error",
+			Data: &LogData{
+				ErrorMessage: "upstream refused connection",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("failed to seed audit logs: %v", err)
+	}
+
+	reader, err := NewSQLiteReader(db)
+	if err != nil {
+		t.Fatalf("failed to create sqlite reader: %v", err)
+	}
+
+	result, err := reader.GetLogs(ctx, LogQueryParams{
+		Search: "timeout awaiting response headers",
+		Limit:  10,
+	})
+	if err != nil {
+		t.Fatalf("GetLogs returned error: %v", err)
+	}
+
+	if result.Total != 1 {
+		t.Fatalf("expected 1 log in search result, got %d", result.Total)
+	}
+	if len(result.Entries) != 1 {
+		t.Fatalf("expected 1 returned entry, got %d", len(result.Entries))
+	}
+	if result.Entries[0].ID != "timeout-match" {
+		t.Fatalf("expected matching entry %q, got %q", "timeout-match", result.Entries[0].ID)
+	}
+}

--- a/internal/auditlog/stream_wrapper.go
+++ b/internal/auditlog/stream_wrapper.go
@@ -117,6 +117,10 @@ func CreateStreamEntry(baseEntry *LogEntry) *LogEntry {
 			snapshot := *baseEntry.Data.WorkflowFeatures
 			entryCopy.Data.WorkflowFeatures = &snapshot
 		}
+		if baseEntry.Data.Failover != nil {
+			snapshot := *baseEntry.Data.Failover
+			entryCopy.Data.Failover = &snapshot
+		}
 	}
 
 	return entryCopy

--- a/internal/llmclient/client.go
+++ b/internal/llmclient/client.go
@@ -9,10 +9,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
 	"math/rand"
+	"net"
 	"net/http"
 	"strings"
 	"sync"
@@ -538,7 +540,7 @@ func (c *Client) doHTTPRequest(ctx context.Context, req Request) (*http.Response
 
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
-		return nil, core.NewProviderError(c.config.ProviderName, http.StatusBadGateway, "failed to send request: "+err.Error(), err)
+		return nil, core.NewProviderError(c.config.ProviderName, providerErrorStatusCode(err), "failed to send request: "+err.Error(), err)
 	}
 	return resp, nil
 }
@@ -557,7 +559,7 @@ func (c *Client) doRequest(ctx context.Context, req Request) (*Response, error) 
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, core.NewProviderError(c.config.ProviderName, http.StatusBadGateway, "failed to read response: "+err.Error(), err)
+		return nil, core.NewProviderError(c.config.ProviderName, providerErrorStatusCode(err), "failed to read response: "+err.Error(), err)
 	}
 
 	return &Response{
@@ -662,6 +664,31 @@ func (c *Client) isRetryable(statusCode int) bool {
 		statusCode == http.StatusServiceUnavailable ||
 		statusCode == http.StatusBadGateway ||
 		statusCode == http.StatusGatewayTimeout
+}
+
+func providerErrorStatusCode(err error) int {
+	if isTimeoutError(err) {
+		return http.StatusGatewayTimeout
+	}
+	return http.StatusBadGateway
+}
+
+func isTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "client.timeout exceeded") ||
+		strings.Contains(message, "timeout awaiting response headers")
 }
 
 // circuitBreaker implements a circuit breaker pattern with half-open state protection

--- a/internal/llmclient/client_test.go
+++ b/internal/llmclient/client_test.go
@@ -1210,6 +1210,76 @@ func TestClient_ContextCancellation(t *testing.T) {
 	}
 }
 
+func TestClient_Do_HTTPTimeoutReturnsGatewayTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	cfg := DefaultConfig("test", server.URL)
+	cfg.Retry.MaxRetries = 0
+	client := NewWithHTTPClient(&http.Client{Timeout: 50 * time.Millisecond}, cfg, nil)
+
+	err := client.Do(context.Background(), Request{
+		Method:   http.MethodGet,
+		Endpoint: "/test",
+	}, nil)
+
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+
+	gatewayErr, ok := err.(*core.GatewayError)
+	if !ok {
+		t.Fatalf("expected GatewayError, got %T", err)
+	}
+	if gatewayErr.StatusCode != http.StatusGatewayTimeout {
+		t.Fatalf("StatusCode = %d, want %d", gatewayErr.StatusCode, http.StatusGatewayTimeout)
+	}
+	if !strings.Contains(gatewayErr.Message, "failed to send request") {
+		t.Fatalf("Message = %q, want send-request timeout context", gatewayErr.Message)
+	}
+}
+
+func TestClient_Do_BodyReadTimeoutReturnsGatewayTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"partial":"`))
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		time.Sleep(200 * time.Millisecond)
+		_, _ = w.Write([]byte(`done"}`))
+	}))
+	defer server.Close()
+
+	cfg := DefaultConfig("test", server.URL)
+	cfg.Retry.MaxRetries = 0
+	client := NewWithHTTPClient(&http.Client{Timeout: 50 * time.Millisecond}, cfg, nil)
+
+	err := client.Do(context.Background(), Request{
+		Method:   http.MethodGet,
+		Endpoint: "/test",
+	}, nil)
+
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+
+	gatewayErr, ok := err.(*core.GatewayError)
+	if !ok {
+		t.Fatalf("expected GatewayError, got %T", err)
+	}
+	if gatewayErr.StatusCode != http.StatusGatewayTimeout {
+		t.Fatalf("StatusCode = %d, want %d", gatewayErr.StatusCode, http.StatusGatewayTimeout)
+	}
+	if !strings.Contains(gatewayErr.Message, "failed to read response") {
+		t.Fatalf("Message = %q, want read-response timeout context", gatewayErr.Message)
+	}
+}
+
 func TestDefaultConfig(t *testing.T) {
 	config := DefaultConfig("test-provider", "https://api.test.com")
 

--- a/internal/server/fallback_test.go
+++ b/internal/server/fallback_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/labstack/echo/v5"
 
+	"gomodel/internal/auditlog"
 	"gomodel/internal/core"
 )
 
@@ -142,6 +143,8 @@ func TestChatCompletion_FallsBackToAlternateModel(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
+	entry := &auditlog.LogEntry{Data: &auditlog.LogData{}}
+	c.Set(string(auditlog.LogEntryKey), entry)
 
 	if err := handler.ChatCompletion(c); err != nil {
 		t.Fatalf("handler.ChatCompletion() error = %v", err)
@@ -160,6 +163,12 @@ func TestChatCompletion_FallsBackToAlternateModel(t *testing.T) {
 	}
 	if !core.GetFallbackUsed(c.Request().Context()) {
 		t.Fatal("expected request context to be marked as fallback-used")
+	}
+	if entry.Data == nil || entry.Data.Failover == nil {
+		t.Fatal("expected audit entry to capture failover details")
+	}
+	if got := entry.Data.Failover.TargetModel; got != "azure/gpt-4o" {
+		t.Fatalf("failover target = %q, want %q", got, "azure/gpt-4o")
 	}
 }
 
@@ -380,6 +389,8 @@ func TestResponses_FallsBackToAlternateModel(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
+	entry := &auditlog.LogEntry{Data: &auditlog.LogData{}}
+	c.Set(string(auditlog.LogEntryKey), entry)
 
 	if err := handler.Responses(c); err != nil {
 		t.Fatalf("handler.Responses() error = %v", err)
@@ -405,6 +416,12 @@ func TestResponses_FallsBackToAlternateModel(t *testing.T) {
 	}
 	if !core.GetFallbackUsed(c.Request().Context()) {
 		t.Fatal("expected request context to be marked as fallback-used")
+	}
+	if entry.Data == nil || entry.Data.Failover == nil {
+		t.Fatal("expected audit entry to capture streaming failover details")
+	}
+	if got := entry.Data.Failover.TargetModel; got != "azure/gpt-4o" {
+		t.Fatalf("streaming failover target = %q, want %q", got, "azure/gpt-4o")
 	}
 }
 

--- a/internal/server/internal_chat_completion_executor.go
+++ b/internal/server/internal_chat_completion_executor.go
@@ -87,8 +87,9 @@ func (e *InternalChatCompletionExecutor) ChatCompletion(ctx context.Context, req
 	var cacheType string
 	var providerType string
 	var providerName string
+	var failoverModel string
 	defer func() {
-		e.finishAuditEntry(ctx, entry, start, workflow, req, resp, err, cacheType, providerType, providerName)
+		e.finishAuditEntry(ctx, entry, start, workflow, req, resp, err, cacheType, providerType, providerName, failoverModel)
 	}()
 
 	resolution, err := resolveRequestModelWithAuthorizer(ctx, e.provider, e.modelResolver, e.modelAuthorizer, requested)
@@ -108,7 +109,7 @@ func (e *InternalChatCompletionExecutor) ChatCompletion(ctx context.Context, req
 
 	ctx = e.service.withCacheRequestContext(ctx, workflow)
 	execReq := cloneChatRequestForSelector(req, resolution.ResolvedSelector)
-	resp, providerType, providerName, _, cacheType, err = e.executeChatCompletion(ctx, workflow, execReq)
+	resp, providerType, providerName, failoverModel, _, cacheType, err = e.executeChatCompletion(ctx, workflow, execReq)
 	if err != nil {
 		return nil, err
 	}
@@ -125,30 +126,31 @@ func (e *InternalChatCompletionExecutor) executeChatCompletion(
 	ctx context.Context,
 	workflow *core.Workflow,
 	req *core.ChatRequest,
-) (*core.ChatResponse, string, string, bool, string, error) {
+) (*core.ChatResponse, string, string, string, bool, string, error) {
 	if e.service.responseCache == nil || (workflow != nil && !workflow.CacheEnabled()) {
-		resp, providerType, providerName, usedFallback, err := e.service.executeChatCompletion(ctx, workflow, req)
-		return resp, providerType, providerName, usedFallback, "", err
+		resp, providerType, providerName, failoverModel, usedFallback, err := e.service.executeChatCompletion(ctx, workflow, req)
+		return resp, providerType, providerName, failoverModel, usedFallback, "", err
 	}
 
 	body, err := marshalRequestBody(req)
 	if err != nil {
-		resp, providerType, providerName, usedFallback, execErr := e.service.executeChatCompletion(ctx, workflow, req)
+		resp, providerType, providerName, failoverModel, usedFallback, execErr := e.service.executeChatCompletion(ctx, workflow, req)
 		if execErr != nil {
-			return nil, "", "", false, "", execErr
+			return nil, "", "", "", false, "", execErr
 		}
-		return resp, providerType, providerName, usedFallback, "", nil
+		return resp, providerType, providerName, failoverModel, usedFallback, "", nil
 	}
 
 	var (
-		resp         *core.ChatResponse
-		providerType string
-		providerName string
-		usedFallback bool
+		resp          *core.ChatResponse
+		providerType  string
+		providerName  string
+		failoverModel string
+		usedFallback  bool
 	)
 	result, err := e.service.responseCache.HandleInternalRequest(ctx, http.MethodPost, "/v1/chat/completions", body, func(c *echo.Context) error {
 		var execErr error
-		resp, providerType, providerName, usedFallback, execErr = e.service.executeChatCompletion(c.Request().Context(), workflow, req)
+		resp, providerType, providerName, failoverModel, usedFallback, execErr = e.service.executeChatCompletion(c.Request().Context(), workflow, req)
 		if execErr != nil {
 			return execErr
 		}
@@ -158,16 +160,16 @@ func (e *InternalChatCompletionExecutor) executeChatCompletion(
 		return c.JSON(http.StatusOK, resp)
 	})
 	if err != nil {
-		return nil, "", "", false, "", err
+		return nil, "", "", "", false, "", err
 	}
 	if result != nil && result.CacheType != "" {
 		var cached core.ChatResponse
 		if err := json.Unmarshal(result.Body, &cached); err != nil {
-			return nil, "", "", false, "", err
+			return nil, "", "", "", false, "", err
 		}
-		return &cached, workflow.ProviderType, providerNameFromWorkflow(workflow), false, result.CacheType, nil
+		return &cached, workflow.ProviderType, providerNameFromWorkflow(workflow), "", false, result.CacheType, nil
 	}
-	return resp, providerType, providerName, usedFallback, "", nil
+	return resp, providerType, providerName, failoverModel, usedFallback, "", nil
 }
 
 func (e *InternalChatCompletionExecutor) newAuditEntry(
@@ -210,6 +212,7 @@ func (e *InternalChatCompletionExecutor) finishAuditEntry(
 	cacheType string,
 	providerType string,
 	providerName string,
+	failoverModel string,
 ) {
 	if entry == nil || e.logger == nil || !e.logger.Config().Enabled {
 		return
@@ -217,6 +220,7 @@ func (e *InternalChatCompletionExecutor) finishAuditEntry(
 
 	entry.DurationNs = time.Since(start).Nanoseconds()
 	auditlog.EnrichLogEntryWithWorkflow(entry, workflow)
+	auditlog.EnrichLogEntryWithFailover(entry, failoverModel)
 	auditlog.EnrichLogEntryWithResolvedRoute(entry, qualifyExecutedModel(workflow, chatResponseModel(resp), providerName), providerType, providerName)
 	auditlog.EnrichLogEntryWithRequestContext(entry, ctx)
 	if workflow != nil && !workflow.AuditEnabled() {

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -89,22 +89,23 @@ func (s *translatedInferenceService) dispatchChatCompletion(c *echo.Context, req
 				return err
 			}
 		}
-		stream, resolvedProviderType, resolvedProviderName, resolvedUsageModel, usedFallback, err := s.streamChatCompletion(ctx, workflow, streamReq, providerType, providerName, usageModel)
+		stream, resolvedProviderType, resolvedProviderName, resolvedUsageModel, failoverModel, usedFallback, err := s.streamChatCompletion(ctx, workflow, streamReq, providerType, providerName, usageModel)
 		if err != nil {
 			return handleError(c, err)
 		}
 		if usedFallback {
 			markRequestFallbackUsed(c)
 		}
-		return s.handleStreamingReadCloser(c, workflow, resolvedUsageModel, resolvedProviderType, resolvedProviderName, stream)
+		return s.handleStreamingReadCloser(c, workflow, resolvedUsageModel, resolvedProviderType, resolvedProviderName, failoverModel, stream)
 	}
 
-	resp, providerType, providerName, usedFallback, err := s.executeChatCompletion(ctx, workflow, req)
+	resp, providerType, providerName, failoverModel, usedFallback, err := s.executeChatCompletion(ctx, workflow, req)
 	if err != nil {
 		return handleError(c, err)
 	}
 	if usedFallback {
 		markRequestFallbackUsed(c)
+		auditlog.EnrichEntryWithFailover(c, failoverModel)
 	}
 	auditlog.EnrichEntryWithResolvedRoute(c, qualifyExecutedModel(workflow, resp.Model, providerName), providerType, providerName)
 
@@ -205,22 +206,23 @@ func (s *translatedInferenceService) dispatchResponses(c *echo.Context, req *cor
 		if (workflow == nil || workflow.UsageEnabled()) && s.shouldEnforceReturningUsageData() {
 			ctx = core.WithEnforceReturningUsageData(ctx, true)
 		}
-		stream, resolvedProviderType, resolvedProviderName, resolvedUsageModel, usedFallback, err := s.streamResponses(ctx, workflow, req, providerType, providerName, usageModel)
+		stream, resolvedProviderType, resolvedProviderName, resolvedUsageModel, failoverModel, usedFallback, err := s.streamResponses(ctx, workflow, req, providerType, providerName, usageModel)
 		if err != nil {
 			return handleError(c, err)
 		}
 		if usedFallback {
 			markRequestFallbackUsed(c)
 		}
-		return s.handleStreamingReadCloser(c, workflow, resolvedUsageModel, resolvedProviderType, resolvedProviderName, stream)
+		return s.handleStreamingReadCloser(c, workflow, resolvedUsageModel, resolvedProviderType, resolvedProviderName, failoverModel, stream)
 	}
 
-	resp, providerType, providerName, usedFallback, err := s.executeResponses(ctx, workflow, req)
+	resp, providerType, providerName, failoverModel, usedFallback, err := s.executeResponses(ctx, workflow, req)
 	if err != nil {
 		return handleError(c, err)
 	}
 	if usedFallback {
 		markRequestFallbackUsed(c)
+		auditlog.EnrichEntryWithFailover(c, failoverModel)
 	}
 	auditlog.EnrichEntryWithResolvedRoute(c, qualifyExecutedModel(workflow, resp.Model, providerName), providerType, providerName)
 
@@ -355,10 +357,12 @@ func (s *translatedInferenceService) handleStreamingReadCloser(
 	c *echo.Context,
 	workflow *core.Workflow,
 	model, provider, providerName string,
+	failoverModel string,
 	stream io.ReadCloser,
 ) error {
 	auditlog.MarkEntryAsStreaming(c, true)
 	auditlog.EnrichEntryWithStream(c, true)
+	auditlog.EnrichEntryWithFailover(c, failoverModel)
 	auditlog.EnrichEntryWithResolvedRoute(c, qualifyExecutedModel(workflow, model, providerName), provider, providerName)
 
 	entry := auditlog.GetStreamEntryFromContext(c)
@@ -415,7 +419,7 @@ func (s *translatedInferenceService) handleStreamingResponse(
 	if err != nil {
 		return handleError(c, err)
 	}
-	return s.handleStreamingReadCloser(c, workflow, model, provider, providerName, stream)
+	return s.handleStreamingReadCloser(c, workflow, model, provider, providerName, "", stream)
 }
 
 //nolint:dupl // typed wrapper over the shared translated fallback executor
@@ -423,7 +427,7 @@ func (s *translatedInferenceService) executeChatCompletion(
 	ctx context.Context,
 	workflow *core.Workflow,
 	req *core.ChatRequest,
-) (*core.ChatResponse, string, string, bool, error) {
+) (*core.ChatResponse, string, string, string, bool, error) {
 	return executeTranslatedWithFallback(ctx, s, workflow, req, req.Model, req.Provider, cloneChatRequestForSelector,
 		func(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, string, error) {
 			resp, err := s.provider.ChatCompletion(ctx, req)
@@ -440,13 +444,13 @@ func (s *translatedInferenceService) streamChatCompletion(
 	workflow *core.Workflow,
 	req *core.ChatRequest,
 	providerType, providerName, usageModel string,
-) (io.ReadCloser, string, string, string, bool, error) {
+) (io.ReadCloser, string, string, string, string, bool, error) {
 	stream, err := s.provider.StreamChatCompletion(ctx, req)
 	if err == nil {
-		return stream, providerType, providerName, usageModel, false, nil
+		return stream, providerType, providerName, usageModel, "", false, nil
 	}
 
-	stream, resolvedProviderType, resolvedProviderName, resolvedUsageModel, err := tryFallbackStream(ctx, s, workflow, req.Model, req.Provider, err,
+	stream, resolvedProviderType, resolvedProviderName, resolvedUsageModel, failoverModel, err := tryFallbackStream(ctx, s, workflow, req.Model, req.Provider, err,
 		func(selector core.ModelSelector, providerType, providerName string) (io.ReadCloser, string, string, error) {
 			stream, err := s.provider.StreamChatCompletion(ctx, cloneChatRequestForSelector(req, selector))
 			if err != nil {
@@ -456,9 +460,9 @@ func (s *translatedInferenceService) streamChatCompletion(
 		},
 	)
 	if err != nil {
-		return nil, "", "", "", false, err
+		return nil, "", "", "", "", false, err
 	}
-	return stream, resolvedProviderType, resolvedProviderName, resolvedUsageModel, true, nil
+	return stream, resolvedProviderType, resolvedProviderName, resolvedUsageModel, failoverModel, true, nil
 }
 
 //nolint:dupl // typed wrapper over the shared translated fallback executor
@@ -466,7 +470,7 @@ func (s *translatedInferenceService) executeResponses(
 	ctx context.Context,
 	workflow *core.Workflow,
 	req *core.ResponsesRequest,
-) (*core.ResponsesResponse, string, string, bool, error) {
+) (*core.ResponsesResponse, string, string, string, bool, error) {
 	return executeTranslatedWithFallback(ctx, s, workflow, req, req.Model, req.Provider, cloneResponsesRequestForSelector,
 		func(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, string, error) {
 			resp, err := s.provider.Responses(ctx, req)
@@ -483,13 +487,13 @@ func (s *translatedInferenceService) streamResponses(
 	workflow *core.Workflow,
 	req *core.ResponsesRequest,
 	providerType, providerName, usageModel string,
-) (io.ReadCloser, string, string, string, bool, error) {
+) (io.ReadCloser, string, string, string, string, bool, error) {
 	stream, err := s.provider.StreamResponses(ctx, req)
 	if err == nil {
-		return stream, providerType, providerName, usageModel, false, nil
+		return stream, providerType, providerName, usageModel, "", false, nil
 	}
 
-	stream, resolvedProviderType, resolvedProviderName, resolvedUsageModel, err := tryFallbackStream(ctx, s, workflow, req.Model, req.Provider, err,
+	stream, resolvedProviderType, resolvedProviderName, resolvedUsageModel, failoverModel, err := tryFallbackStream(ctx, s, workflow, req.Model, req.Provider, err,
 		func(selector core.ModelSelector, providerType, providerName string) (io.ReadCloser, string, string, error) {
 			stream, err := s.provider.StreamResponses(ctx, cloneResponsesRequestForSelector(req, selector))
 			if err != nil {
@@ -499,9 +503,9 @@ func (s *translatedInferenceService) streamResponses(
 		},
 	)
 	if err != nil {
-		return nil, "", "", "", false, err
+		return nil, "", "", "", "", false, err
 	}
-	return stream, resolvedProviderType, resolvedProviderName, resolvedUsageModel, true, nil
+	return stream, resolvedProviderType, resolvedProviderName, resolvedUsageModel, failoverModel, true, nil
 }
 
 func (s *translatedInferenceService) executeEmbeddings(
@@ -758,12 +762,12 @@ func tryFallbackResponse[T any](
 	model, provider string,
 	primaryErr error,
 	call func(selector core.ModelSelector, providerType, providerName string) (T, string, error),
-) (T, string, string, bool, error) {
+) (T, string, string, string, bool, error) {
 	var zero T
 
 	fallbacks := s.fallbackSelectors(workflow)
 	if len(fallbacks) == 0 || !shouldAttemptFallback(primaryErr) {
-		return zero, "", "", false, primaryErr
+		return zero, "", "", "", false, primaryErr
 	}
 
 	requestID := strings.TrimSpace(core.GetRequestID(ctx))
@@ -792,12 +796,12 @@ func tryFallbackResponse[T any](
 				"to", qualified,
 				"provider_type", resolvedProviderType,
 			)
-			return resp, resolvedProviderType, providerName, true, nil
+			return resp, resolvedProviderType, providerName, qualified, true, nil
 		}
 		lastErr = err
 	}
 
-	return zero, "", "", false, lastErr
+	return zero, "", "", "", false, lastErr
 }
 
 func executeWithFallbackResponse[T any](
@@ -807,10 +811,10 @@ func executeWithFallbackResponse[T any](
 	model, provider string,
 	primary func() (T, string, string, error),
 	fallback func(selector core.ModelSelector, providerType, providerName string) (T, string, error),
-) (T, string, string, bool, error) {
+) (T, string, string, string, bool, error) {
 	resp, resolvedProviderType, resolvedProviderName, err := primary()
 	if err == nil {
-		return resp, resolvedProviderType, resolvedProviderName, false, nil
+		return resp, resolvedProviderType, resolvedProviderName, "", false, nil
 	}
 	return tryFallbackResponse(ctx, s, workflow, model, provider, err, fallback)
 }
@@ -823,7 +827,7 @@ func executeTranslatedWithFallback[Req any, Resp any](
 	model, provider string,
 	cloneForSelector func(Req, core.ModelSelector) Req,
 	call func(context.Context, Req) (Resp, string, error),
-) (Resp, string, string, bool, error) {
+) (Resp, string, string, string, bool, error) {
 	return executeWithFallbackResponse(ctx, s, workflow, model, provider,
 		func() (Resp, string, string, error) {
 			resp, responseProvider, err := call(ctx, req)
@@ -851,10 +855,10 @@ func tryFallbackStream(
 	model, provider string,
 	primaryErr error,
 	call func(selector core.ModelSelector, providerType, providerName string) (io.ReadCloser, string, string, error),
-) (io.ReadCloser, string, string, string, error) {
+) (io.ReadCloser, string, string, string, string, error) {
 	fallbacks := s.fallbackSelectors(workflow)
 	if len(fallbacks) == 0 || !shouldAttemptFallback(primaryErr) {
-		return nil, "", "", "", primaryErr
+		return nil, "", "", "", "", primaryErr
 	}
 
 	requestID := strings.TrimSpace(core.GetRequestID(ctx))
@@ -883,12 +887,12 @@ func tryFallbackStream(
 				"to", qualified,
 				"provider_type", resolvedProviderType,
 			)
-			return stream, resolvedProviderType, providerName, usageModel, nil
+			return stream, resolvedProviderType, providerName, usageModel, qualified, nil
 		}
 		lastErr = err
 	}
 
-	return nil, "", "", "", lastErr
+	return nil, "", "", "", "", lastErr
 }
 
 func shouldAttemptFallback(err error) bool {


### PR DESCRIPTION
## Summary
- persist failover target details in audit logs and surface failover in workflow charts
- record timeout/provider errors with the correct HTTP status code and make them searchable/filterable in audit logs
- preserve the primary route in failover audit charts so cross-provider fallbacks do not render impossible provider/model combinations

## Testing
- go test ./internal/llmclient ./internal/auditlog ./internal/server ./internal/admin
- node --test internal/admin/dashboard/static/js/modules/workflows.test.js internal/admin/dashboard/static/js/modules/workflows-layout.test.js internal/admin/dashboard/static/js/modules/dashboard-layout.test.js internal/admin/dashboard/static/js/modules/dashboard-display.test.js internal/admin/dashboard/static/js/modules/audit-list.test.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added failover routing support for workflows with configurable fallback targets
  * Extended audit log search functionality to include error messages
  * Added failover metadata display in audit logs and workflow visualization

* **Bug Fixes**
  * Improved timeout error handling with proper gateway timeout status codes

* **Documentation**
  * Added 504 (Gateway Timeout) status code option to audit filter

<!-- end of auto-generated comment: release notes by coderabbit.ai -->