### PR TITLE
fix(audit): log cached streams and polish dashboard UI

### DIFF
--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -1324,7 +1324,7 @@ body {
 
 .filter-input {
   flex: 1;
-  max-width: 420px;
+  min-width: 400px;
   padding: 8px 12px;
   background: var(--bg-surface);
   border: 1px solid var(--border);
@@ -1336,10 +1336,6 @@ body {
 
 .filter-input:focus {
   border-color: var(--accent);
-}
-
-.models-filter-input {
-  max-width: 840px;
 }
 
 .table-wrapper {
@@ -2472,13 +2468,14 @@ td.col-price {
 
 .audit-request-response {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   gap: 12px;
+  overflow-x: auto;
 }
 
 .audit-entry-metadata {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 10px;
   margin-top: 12px;
   padding-top: 12px;
@@ -2505,6 +2502,7 @@ td.col-price {
   border: 1px solid var(--border);
   border-radius: 8px;
   background: var(--bg);
+  min-width: 0;
   padding: 12px;
 }
 
@@ -2527,30 +2525,76 @@ td.col-price {
   text-transform: uppercase;
   letter-spacing: 0.4px;
   color: var(--text-muted);
-  margin-bottom: 6px;
+}
+
+.audit-pane-block {
+  min-width: 0;
 }
 
 .audit-pane-block + .audit-pane-block {
   margin-top: 10px;
 }
 
+.audit-pane-block > h5 {
+  margin-bottom: 6px;
+}
+
+.audit-pane-block-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.audit-copy-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+  padding: 4px 8px;
+  background-color: var(--bg-surface);
+  border: 1px solid color-mix(in srgb, var(--border) 70%, var(--text) 30%);
+  border-radius: 6px;
+  color: var(--text);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 12px;
+  transition:
+    background-color 0.15s,
+    border-color 0.15s,
+    color 0.15s;
+}
+
+.audit-copy-btn:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--bg-surface) 80%, var(--text) 20%);
+  border-color: color-mix(in srgb, var(--border) 45%, var(--text) 55%);
+}
+
+.audit-copy-btn.copy-feedback-btn-copied {
+  background: color-mix(in srgb, var(--success) 18%, var(--bg-surface));
+}
+
 .audit-json {
   background: var(--bg-surface);
   border: 1px solid var(--border);
   border-radius: 6px;
+  box-sizing: border-box;
   font-family: "SF Mono", Menlo, Consolas, monospace;
   font-size: 12px;
   line-height: 1.45;
+  max-width: 100%;
   padding: 10px;
   max-height: 220px;
-  overflow: auto;
+  overflow-x: auto;
+  overflow-y: auto;
   white-space: pre;
   color: var(--text);
 }
 
 .audit-json-body {
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
+  white-space: pre;
+  overflow-wrap: normal;
 }
 
 .conversation-body-highlight {
@@ -3681,10 +3725,11 @@ body.conversation-drawer-open {
   }
   .audit-entry-metadata {
     flex-direction: column;
+    align-items: flex-start;
     gap: 8px;
   }
   .audit-request-response {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
   .conversation-drawer {
     width: 100%;
@@ -3914,6 +3959,7 @@ body.conversation-drawer-open {
   align-items: center;
   width: 100%;
   min-width: 0;
+  overflow-x: auto;
 }
 
 /* ─── Connectors ─── */

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -1324,7 +1324,7 @@ body {
 
 .filter-input {
   flex: 1;
-  min-width: 400px;
+  min-width: min(400px, 100%);
   padding: 8px 12px;
   background: var(--bg-surface);
   border: 1px solid var(--border);
@@ -1332,6 +1332,31 @@ body {
   color: var(--text);
   font-size: 13px;
   outline: none;
+}
+
+.filter-input-wrap {
+  position: relative;
+  display: flex;
+  flex: 1;
+  min-width: min(400px, 100%);
+  width: 100%;
+}
+
+.filter-input-wrap .filter-input {
+  min-width: 0;
+  width: 100%;
+  padding-left: 34px;
+}
+
+.filter-input-icon {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  width: 14px;
+  height: 14px;
+  color: var(--text-muted);
+  pointer-events: none;
+  transform: translateY(-50%);
 }
 
 .filter-input:focus {
@@ -2212,7 +2237,7 @@ td.col-price {
   margin-bottom: 16px;
 }
 
-.usage-log-toolbar .filter-input {
+.usage-log-toolbar .filter-input-wrap {
   flex: 1;
   max-width: none;
 }
@@ -2280,7 +2305,7 @@ td.col-price {
   min-width: 0;
 }
 
-.audit-filter-row-search .filter-input {
+.audit-filter-row-search .filter-input-wrap {
   grid-column: 1 / -1;
   max-width: none;
 }
@@ -3710,6 +3735,7 @@ body.conversation-drawer-open {
   .audit-filter-row {
     grid-template-columns: 1fr;
   }
+  .audit-filter-row .filter-input-wrap,
   .audit-filter-row .filter-input,
   .audit-filter-select,
   .audit-filter-row .pagination-btn {

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -604,6 +604,11 @@ function dashboard() {
       );
     },
 
+    runtimeRefreshSteps() {
+      const steps = this.runtimeRefreshReport && this.runtimeRefreshReport.steps;
+      return Array.isArray(steps) ? steps : [];
+    },
+
     runtimeRefreshStepLabel(step) {
       const name = String((step && step.name) || "").replace(/_/g, " ");
       const status = String((step && step.status) || "").trim();

--- a/internal/admin/dashboard/static/js/modules/audit-list.js
+++ b/internal/admin/dashboard/static/js/modules/audit-list.js
@@ -174,6 +174,7 @@
                 return {
                     title: 'Request',
                     entry,
+                    copyHeaders: data && data.request_headers,
                     copyBody: data && data.request_body,
                     showErrorMessage: false,
                     errorMessage: null,
@@ -194,6 +195,7 @@
                 return {
                     title: 'Response',
                     entry,
+                    copyHeaders: data && data.response_headers,
                     copyBody: data && data.response_body,
                     showErrorMessage: !!(data && data.error_message),
                     errorMessage: data && data.error_message,
@@ -213,25 +215,34 @@
                 const renderBody = typeof this.renderBodyWithConversationHighlights === 'function'
                     ? this.renderBodyWithConversationHighlights.bind(this)
                     : (_entry, body) => formatJSON(body);
+                const createCopyState = () => clipboard
+                    ? clipboard.createClipboardButtonState({
+                        logPrefix: 'Failed to copy audit payload:'
+                    })
+                    : {
+                        copied: false,
+                        error: false,
+                        copy() {
+                            return Promise.resolve();
+                        }
+                    };
+                const copyBodyState = createCopyState();
+                const copyHeadersState = createCopyState();
 
                 return {
                     pane,
                     formattedHeaders: pane && pane.showHeaders ? formatJSON(pane.headers) : '',
                     renderedBody: pane && pane.showBody ? renderBody(pane.entry, pane.body) : '',
-                    copyState: clipboard
-                        ? clipboard.createClipboardButtonState({
-                            logPrefix: 'Failed to copy audit payload:'
-                        })
-                        : {
-                            copied: false,
-                            error: false,
-                            copy() {
-                                return Promise.resolve();
-                            }
-                        },
+                    copyBodyState,
+                    copyHeadersState,
+                    copyState: copyBodyState,
 
                     copyBody() {
-                        return this.copyState.copy(this.pane.copyBody, formatJSON);
+                        return this.copyBodyState.copy(this.pane.copyBody, formatJSON);
+                    },
+
+                    copyHeaders() {
+                        return this.copyHeadersState.copy(this.pane.copyHeaders, formatJSON);
                     }
                 };
             }

--- a/internal/admin/dashboard/static/js/modules/audit-list.test.js
+++ b/internal/admin/dashboard/static/js/modules/audit-list.test.js
@@ -40,6 +40,7 @@ test('auditRequestPane returns the shared request-pane contract', () => {
 
     assert.equal(pane.title, 'Request');
     assert.equal(pane.entry, entry);
+    assert.equal(JSON.stringify(pane.copyHeaders), JSON.stringify(entry.data.request_headers));
     assert.equal(JSON.stringify(pane.copyBody), JSON.stringify(entry.data.request_body));
     assert.equal(pane.showErrorMessage, false);
     assert.equal(pane.errorMessage, null);
@@ -68,6 +69,7 @@ test('auditResponsePane returns the shared response-pane contract', () => {
 
     assert.equal(pane.title, 'Response');
     assert.equal(pane.entry, entry);
+    assert.equal(JSON.stringify(pane.copyHeaders), JSON.stringify(entry.data.response_headers));
     assert.equal(JSON.stringify(pane.copyBody), JSON.stringify(entry.data.response_body));
     assert.equal(pane.showErrorMessage, true);
     assert.equal(pane.errorMessage, 'provider timeout');
@@ -254,14 +256,47 @@ test('auditPaneState copies the formatted body and resets success feedback', asy
     await paneState.copyBody();
 
     assert.deepEqual(writes, ['{\n  "model": "gpt-5",\n  "stream": false\n}']);
-    assert.equal(paneState.copyState.copied, true);
-    assert.equal(paneState.copyState.error, false);
+    assert.equal(paneState.copyBodyState.copied, true);
+    assert.equal(paneState.copyBodyState.error, false);
 
     assert.equal(typeof resetCallback, 'function');
     resetCallback();
 
-    assert.equal(paneState.copyState.copied, false);
-    assert.equal(paneState.copyState.error, false);
+    assert.equal(paneState.copyBodyState.copied, false);
+    assert.equal(paneState.copyBodyState.error, false);
+});
+
+test('auditPaneState copies the formatted headers independently from body feedback', async () => {
+    const writes = [];
+    const module = createAuditListModule({
+        setTimeout() {
+            return 1;
+        },
+        clearTimeout() {},
+        window: {
+            navigator: {
+                clipboard: {
+                    writeText(value) {
+                        writes.push(value);
+                        return Promise.resolve();
+                    }
+                }
+            }
+        }
+    });
+
+    const paneState = module.auditPaneState({
+        copyHeaders: { 'x-request-id': 'req-123' },
+        copyBody: { id: 'body-1' }
+    });
+
+    await paneState.copyHeaders();
+
+    assert.deepEqual(writes, ['{\n  "x-request-id": "req-123"\n}']);
+    assert.equal(paneState.copyHeadersState.copied, true);
+    assert.equal(paneState.copyHeadersState.error, false);
+    assert.equal(paneState.copyBodyState.copied, false);
+    assert.equal(paneState.copyBodyState.error, false);
 });
 
 test('auditPaneState marks copy failures and clears the error after reset', async () => {
@@ -292,12 +327,12 @@ test('auditPaneState marks copy failures and clears the error after reset', asyn
 
     await paneState.copyBody();
 
-    assert.equal(paneState.copyState.copied, false);
-    assert.equal(paneState.copyState.error, true);
+    assert.equal(paneState.copyBodyState.copied, false);
+    assert.equal(paneState.copyBodyState.error, true);
 
     assert.equal(typeof resetCallback, 'function');
     resetCallback();
 
-    assert.equal(paneState.copyState.copied, false);
-    assert.equal(paneState.copyState.error, false);
+    assert.equal(paneState.copyBodyState.copied, false);
+    assert.equal(paneState.copyBodyState.error, false);
 });

--- a/internal/admin/dashboard/static/js/modules/charts.js
+++ b/internal/admin/dashboard/static/js/modules/charts.js
@@ -282,6 +282,18 @@
                 return this._usageRowsBySelectedValue(this.userPathUsage || []);
             },
 
+            userPathUsageChartVisible() {
+                const rows = Array.isArray(this.userPathUsage) ? this.userPathUsage : [];
+                if (rows.length === 0) {
+                    return false;
+                }
+                if (rows.length !== 1) {
+                    return true;
+                }
+                const onlyPath = String(rows[0] && rows[0].user_path || '').trim();
+                return onlyPath !== '' && onlyPath !== '/';
+            },
+
             _barData() {
                 return this._barDataFrom(this.modelUsage, (m) => typeof this.qualifiedModelDisplay === 'function'
                     ? this.qualifiedModelDisplay(m)
@@ -351,7 +363,7 @@
             renderUserPathChart(retries) {
                 if (retries === undefined) retries = 3;
                 this.$nextTick(() => {
-                    if (!this.userPathUsage || this.userPathUsage.length === 0 || this.page !== 'usage' || (this.userPathUsageView || 'chart') !== 'chart') {
+                    if (!this.userPathUsageChartVisible() || this.page !== 'usage' || (this.userPathUsageView || 'chart') !== 'chart') {
                         if (this.usageUserPathChart) {
                             this.usageUserPathChart.destroy();
                             this.usageUserPathChart = null;

--- a/internal/admin/dashboard/static/js/modules/charts.test.js
+++ b/internal/admin/dashboard/static/js/modules/charts.test.js
@@ -174,6 +174,32 @@ test('renderUserPathChart recreates the user path chart and uses usage mode valu
     assert.equal(JSON.stringify(module.usageUserPathChart.data.datasets[0].data), JSON.stringify([0.03]));
 });
 
+test('user path usage chart hides when the only path is root', () => {
+    FakeChart.instances = [];
+    const { module } = createChartsContext();
+    module.page = 'usage';
+    module.usageUserPathChart = null;
+    module.userPathUsage = [
+        { user_path: '/', input_tokens: 21, output_tokens: 34, total_tokens: 55, total_cost: 0.03 }
+    ];
+
+    assert.equal(module.userPathUsageChartVisible(), false);
+    module.renderUserPathChart();
+
+    assert.equal(FakeChart.instances.length, 0);
+    assert.equal(module.usageUserPathChart, null);
+
+    module.userPathUsage = [
+        { user_path: '/team/alpha', input_tokens: 21, output_tokens: 34, total_tokens: 55, total_cost: 0.03 }
+    ];
+
+    assert.equal(module.userPathUsageChartVisible(), true);
+    module.renderUserPathChart();
+
+    assert.equal(FakeChart.instances.length, 1);
+    assert.notEqual(module.usageUserPathChart, null);
+});
+
 test('usage chart table rows use the same selected metric ordering as charts', () => {
     const { module } = createChartsContext();
     module.usageMode = 'tokens';

--- a/internal/admin/dashboard/static/js/modules/dashboard-layout.test.js
+++ b/internal/admin/dashboard/static/js/modules/dashboard-layout.test.js
@@ -366,6 +366,7 @@ test('audit toolbar uses a full-width search row above the select row with a rig
         indexTemplate,
         /id="audit-filter-search"[^>]*placeholder="Search by request ID, model, provider, path, user path, or error\.\.\."/
     );
+    assert.match(indexTemplate, /class="audit-filter-row audit-filter-row-search"[\s\S]*data-lucide="search" class="filter-input-icon"[\s\S]*id="audit-filter-search"/);
     assert.match(indexTemplate, /id="audit-filter-status"[\s\S]*<option value="504">504<\/option>/);
     assert.doesNotMatch(indexTemplate, /id="audit-filter-model"/);
     assert.doesNotMatch(indexTemplate, /id="audit-filter-provider"/);
@@ -378,7 +379,7 @@ test('audit toolbar uses a full-width search row above the select row with a rig
     assert.match(clearRule, /background:\s*#fff/);
     assert.match(clearRule, /color:\s*#111110/);
 
-    const searchRule = readCSSRule(css, '.audit-filter-row-search .filter-input');
+    const searchRule = readCSSRule(css, '.audit-filter-row-search .filter-input-wrap');
     assert.match(searchRule, /grid-column:\s*1\s*\/\s*-1/);
 
     const selectRule = readCSSRule(css, '.usage-log-select');
@@ -466,6 +467,8 @@ test('model category tables lazy mount only the active table body', () => {
     assert.match(modelsBlock, /activeCategory === 'utility'[\s\S]*{{template "model-table-body" \.}}/);
     assert.match(modelsBlock, /class="loading-state" x-show="modelsLoading && !authError" role="status" aria-live="polite"/);
     assert.match(modelsBlock, /x-text="displayModels\.length > 0 \? 'Refreshing models\.\.\.' : 'Loading models\.\.\.'"/);
+    assert.match(modelsBlock, /class="filter-input-wrap"[\s\S]*data-lucide="search" class="filter-input-icon"[\s\S]*x-model="modelFilter"/);
+    assert.match(modelsBlock, /placeholder="Filter by provider, provider\/model, alias, or owner\.\.\." aria-label="Filter models by provider, provider\/model, alias, or owner" x-model="modelFilter" class="filter-input"/);
     assert.match(modelsBlock, /class="pagination-btn pagination-btn-primary pagination-btn-with-icon alias-create-btn"[\s\S]*@click="openAliasCreate\(\)"[\s\S]*data-lucide="plus" class="alias-create-icon"[\s\S]*<span>Create Alias<\/span>/);
     assert.match(modelsBlock, /class="pagination-btn pagination-btn-primary pagination-btn-with-icon alias-submit-btn"[\s\S]*:disabled="aliasSubmitting"[\s\S]*data-lucide="plus" class="form-action-icon" x-show="aliasFormMode !== 'edit'"[\s\S]*data-lucide="save" class="form-action-icon" x-show="aliasFormMode === 'edit'"[\s\S]*x-text="aliasSubmitting \? 'Saving\.\.\.' : \(aliasFormMode === 'edit' \? 'Save Alias' : 'Create Alias'\)"/);
     assert.match(modelsBlock, /class="pagination-btn pagination-btn-primary pagination-btn-with-icon model-access-submit-btn"[\s\S]*:disabled="modelOverrideSubmitting"[\s\S]*data-lucide="save" class="form-action-icon"[\s\S]*x-text="modelOverrideSubmitting \? 'Saving\.\.\.' : 'Save Access'"/);
@@ -474,6 +477,16 @@ test('model category tables lazy mount only the active table body', () => {
     const loadingRule = readCSSRule(css, '.loading-state');
     assert.match(loadingRule, /display:\s*flex/);
     assert.match(loadingRule, /min-height:\s*64px/);
+
+    const filterInputRule = readCSSRule(css, '.filter-input');
+    assert.match(filterInputRule, /min-width:\s*min\(400px,\s*100%\)/);
+
+    const filterInputWrapRule = readCSSRule(css, '.filter-input-wrap');
+    assert.match(filterInputWrapRule, /position:\s*relative/);
+    assert.match(filterInputWrapRule, /min-width:\s*min\(400px,\s*100%\)/);
+
+    const filterInputIconRule = readCSSRule(css, '.filter-input-icon');
+    assert.match(filterInputIconRule, /pointer-events:\s*none/);
 
     const spinnerRule = readCSSRule(css, '.loading-spinner');
     assert.match(spinnerRule, /animation:\s*loading-spin 0\.8s linear infinite/);
@@ -535,6 +548,8 @@ test('audit request and response sections reuse a shared audit pane template', (
         auditPaneTemplate,
         /{{define "audit-pane"}}[\s\S]*x-data="auditPaneState\({{\.\}}\)"[\s\S]*x-text="pane\.title"[\s\S]*x-show="pane\.showHeaders"[\s\S]*@click\.prevent="copyHeaders\(\)"[\s\S]*x-text="formattedHeaders"[\s\S]*x-show="pane\.showBody"[\s\S]*@click\.prevent="copyBody\(\)"[\s\S]*x-html="renderedBody"[\s\S]*x-text="pane\.emptyMessage"[\s\S]*x-text="pane\.tooLargeMessage"[\s\S]*{{end}}/
     );
+    assert.match(auditPaneTemplate, /aria-live="polite" aria-atomic="true" x-text="copyHeadersState\.error \? 'Copy failed' : \(copyHeadersState\.copied \? 'Copied' : 'Copy Headers'\)"/);
+    assert.match(auditPaneTemplate, /aria-live="polite" aria-atomic="true" x-text="copyBodyState\.error \? 'Copy failed' : \(copyBodyState\.copied \? 'Copied' : 'Copy Body'\)"/);
     assert.match(indexTemplate, /{{template "audit-pane" "auditRequestPane\(entry\)"}}/);
     assert.match(indexTemplate, /{{template "audit-pane" "auditResponsePane\(entry\)"}}/);
     assert.doesNotMatch(indexTemplate, /<section class="audit-pane">[\s\S]*<h4>Request<\/h4>/);

--- a/internal/admin/dashboard/static/js/modules/dashboard-layout.test.js
+++ b/internal/admin/dashboard/static/js/modules/dashboard-layout.test.js
@@ -394,9 +394,6 @@ test('audit toolbar uses a full-width search row above the select row with a rig
     const controlsRule = readCSSRule(css, '.audit-filter-row-controls .pagination-btn');
     assert.match(controlsRule, /grid-column:\s*11\s*\/\s*-1/);
     assert.match(controlsRule, /justify-self:\s*end/);
-
-    const modelsFilterRule = readCSSRule(css, '.models-filter-input');
-    assert.match(modelsFilterRule, /max-width:\s*840px/);
 });
 
 test('audit entry metadata is rendered as a labeled pill row at the bottom of the expanded entry', () => {
@@ -422,8 +419,23 @@ test('audit entry metadata is rendered as a labeled pill row at the bottom of th
     assert.match(auditEntry, /<span class="provider-badge mono" x-show="entry\.client_ip" x-text="'ip: ' \+ entry\.client_ip"><\/span>/);
     assert.match(auditEntry, /<span class="provider-badge mono" x-show="workflowFailoverTarget\(entry\)" x-text="'failover: ' \+ workflowFailoverTarget\(entry\)"><\/span>/);
 
+    const requestResponseRule = readCSSRule(css, '.audit-request-response');
+    assert.match(requestResponseRule, /grid-template-columns:\s*minmax\(0,\s*1fr\) minmax\(0,\s*1fr\)/);
+    assert.match(requestResponseRule, /overflow-x:\s*auto/);
+
+    const paneRule = readCSSRule(css, '.audit-pane');
+    assert.match(paneRule, /min-width:\s*0/);
+
+    const paneBlockRule = readCSSRule(css, '.audit-pane-block');
+    assert.match(paneBlockRule, /min-width:\s*0/);
+
+    const auditJSONRule = readCSSRule(css, '.audit-json');
+    assert.match(auditJSONRule, /max-width:\s*100%/);
+    assert.match(auditJSONRule, /overflow-x:\s*auto/);
+
     const metadataRule = readCSSRule(css, '.audit-entry-metadata');
     assert.match(metadataRule, /display:\s*flex/);
+    assert.match(metadataRule, /align-items:\s*center/);
     assert.match(metadataRule, /margin-top:\s*12px/);
     assert.match(metadataRule, /padding-top:\s*12px/);
     assert.match(metadataRule, /border-top:\s*1px solid var\(--border\)/);
@@ -510,7 +522,7 @@ test('usage charts can switch between chart and table views', () => {
     assert.match(indexTemplate, /<div class="bar-chart-wrap" x-show="modelUsageView === 'chart'">[\s\S]*<canvas id="usageBarChart"><\/canvas>/);
     assert.match(indexTemplate, /<template x-if="modelUsageView === 'table'">[\s\S]*modelUsageTableRows\(\)/);
     assert.match(indexTemplate, /class="chart-view-toggle"[\s\S]*@click="toggleUsageChartView\('userPath', 'chart'\)"[\s\S]*@click="toggleUsageChartView\('userPath', 'table'\)"/);
-    assert.match(indexTemplate, /<h3 x-text="usageMode === 'costs' \? 'Cost by User Path' : 'Usage by User Path'"><\/h3>/);
+    assert.match(indexTemplate, /<div class="model-chart-section" x-show="userPathUsageChartVisible\(\)">[\s\S]*<h3 x-text="usageMode === 'costs' \? 'Cost by User Path' : 'Usage by User Path'"><\/h3>/);
     assert.match(indexTemplate, /<div class="bar-chart-wrap" x-show="userPathUsageView === 'chart'">[\s\S]*<canvas id="usageUserPathChart"><\/canvas>/);
     assert.match(indexTemplate, /<template x-if="userPathUsageView === 'table'">[\s\S]*userPathUsageTableRows\(\)/);
 });
@@ -521,7 +533,7 @@ test('audit request and response sections reuse a shared audit pane template', (
 
     assert.match(
         auditPaneTemplate,
-        /{{define "audit-pane"}}[\s\S]*x-data="auditPaneState\({{\.\}}\)"[\s\S]*x-text="pane\.title"[\s\S]*type="button"[\s\S]*@click\.prevent="copyBody\(\)"[\s\S]*x-text="formattedHeaders"[\s\S]*x-html="renderedBody"[\s\S]*x-text="pane\.emptyMessage"[\s\S]*x-text="pane\.tooLargeMessage"[\s\S]*{{end}}/
+        /{{define "audit-pane"}}[\s\S]*x-data="auditPaneState\({{\.\}}\)"[\s\S]*x-text="pane\.title"[\s\S]*x-show="pane\.showHeaders"[\s\S]*@click\.prevent="copyHeaders\(\)"[\s\S]*x-text="formattedHeaders"[\s\S]*x-show="pane\.showBody"[\s\S]*@click\.prevent="copyBody\(\)"[\s\S]*x-html="renderedBody"[\s\S]*x-text="pane\.emptyMessage"[\s\S]*x-text="pane\.tooLargeMessage"[\s\S]*{{end}}/
     );
     assert.match(indexTemplate, /{{template "audit-pane" "auditRequestPane\(entry\)"}}/);
     assert.match(indexTemplate, /{{template "audit-pane" "auditResponsePane\(entry\)"}}/);

--- a/internal/admin/dashboard/static/js/modules/request-cancellation.test.js
+++ b/internal/admin/dashboard/static/js/modules/request-cancellation.test.js
@@ -211,7 +211,7 @@ test('runtimeRefreshSteps returns a safe array while the report is empty', () =>
 
     const steps = [{ name: 'providers', status: 'ok' }];
     app.runtimeRefreshReport = { steps };
-    assert.equal(app.runtimeRefreshSteps(), steps);
+    assert.strictEqual(app.runtimeRefreshSteps(), steps);
 });
 
 function loadDashboardApp(overrides = {}) {

--- a/internal/admin/dashboard/static/js/modules/request-cancellation.test.js
+++ b/internal/admin/dashboard/static/js/modules/request-cancellation.test.js
@@ -199,6 +199,21 @@ test('refreshRuntime leaves dashboard data untouched when the admin request fail
     assert.match(app.runtimeRefreshNotice, /Runtime refresh failed/);
 });
 
+test('runtimeRefreshSteps returns a safe array while the report is empty', () => {
+    const app = loadDashboardApp();
+
+    assert.equal(Array.isArray(app.runtimeRefreshSteps()), true);
+    assert.equal(app.runtimeRefreshSteps().length, 0);
+
+    app.runtimeRefreshReport = { steps: null };
+    assert.equal(Array.isArray(app.runtimeRefreshSteps()), true);
+    assert.equal(app.runtimeRefreshSteps().length, 0);
+
+    const steps = [{ name: 'providers', status: 'ok' }];
+    app.runtimeRefreshReport = { steps };
+    assert.equal(app.runtimeRefreshSteps(), steps);
+});
+
 function loadDashboardApp(overrides = {}) {
     const sources = [
         fs.readFileSync(path.join(__dirname, 'usage.js'), 'utf8'),

--- a/internal/admin/dashboard/static/js/modules/timezone-layout.test.js
+++ b/internal/admin/dashboard/static/js/modules/timezone-layout.test.js
@@ -52,7 +52,7 @@ test('dashboard templates expose a settings page and timezone context in activit
     assert.match(template, /class="alert alert-success settings-refresh-alert"[\s\S]*role="status"[\s\S]*aria-live="polite"[\s\S]*runtimeRefreshSucceeded\(\)/);
     assert.match(template, /class="alert alert-warning settings-refresh-alert"[\s\S]*role="alert"[\s\S]*aria-live="assertive"[\s\S]*runtimeRefreshError \|\| runtimeRefreshNotice/);
     assert.match(template, /class="runtime-refresh-steps"[\s\S]*role="status"[\s\S]*aria-live="polite"[\s\S]*runtimeRefreshStepLabel\(step\)/);
-    assert.match(template, /runtimeRefreshReport\.steps/);
+    assert.match(template, /x-for="step in runtimeRefreshSteps\(\)"/);
     assert.match(template, /{{template "helper-disclosure" "\{ heading: 'Timezone', open: false, copyId: 'timezone-help-copy'/);
     assert.match(template, /class="inline-help-toggle"/);
     assert.match(template, /class="inline-help-toggle-icon"/);

--- a/internal/admin/dashboard/static/js/modules/workflows.js
+++ b/internal/admin/dashboard/static/js/modules/workflows.js
@@ -1196,46 +1196,47 @@
                 };
             },
 
-	            workflowChartModel(source, runtime, options) {
-	                const config = options || {};
-	                const features = config.features && typeof config.features === 'object' && !Array.isArray(config.features)
+            workflowChartModel(source, runtime, options) {
+                const config = options || {};
+                const features = config.features && typeof config.features === 'object' && !Array.isArray(config.features)
                     ? this.workflowNormalizedFeatures(config.features)
                     : this.workflowSourceFeatures(source);
-	                const forceAudit = !!config.forceAudit;
-                    const highlightAsyncPresent = !!config.highlightAsyncPresent;
-	                const showGuardrails = !!features.guardrails;
-	                const showUsage = !!features.usage;
-	                const showAudit = forceAudit || !!features.audit;
-	                const showAsync = !!config.forceAsync || !!(showUsage || showAudit);
-                    const workflowID = this.workflowChartWorkflowID(source, config.entry);
-	                return {
-	                    showGuardrails,
-	                    guardrailLabel: showGuardrails ? this.workflowGuardrailLabel(source) : '',
-	                    showCache: !!config.forceCache || !!features.cache || this.workflowRuntimeHasCache(runtime),
+                const forceAudit = !!config.forceAudit;
+                const highlightAsyncPresent = !!config.highlightAsyncPresent;
+                const showGuardrails = !!features.guardrails;
+                const showUsage = !!features.usage;
+                const showAudit = forceAudit || !!features.audit;
+                const showAsync = !!config.forceAsync || !!(showUsage || showAudit);
+                const showFailover = !!features.fallback || this.workflowRuntimeUsedFailover(runtime);
+                const workflowID = this.workflowChartWorkflowID(source, config.entry);
+                return {
+                    showGuardrails,
+                    guardrailLabel: showGuardrails ? this.workflowGuardrailLabel(source) : '',
+                    showCache: !!config.forceCache || !!features.cache || this.workflowRuntimeHasCache(runtime),
                     cacheNodeClass: this.workflowCacheNodeClass(runtime),
                     cacheConnClass: this.workflowCacheConnClass(runtime),
                     cacheStatusLabel: this.workflowCacheStatusLabel(runtime),
-                    showFailover: !!features.fallback || this.workflowRuntimeUsedFailover(runtime),
-                    failoverNodeClass: this.workflowFailoverNodeClass(runtime),
-                    failoverConnClass: this.workflowFailoverConnClass(runtime),
-                    failoverStatusLabel: this.workflowFailoverStatusLabel(runtime),
-                    failoverTargetLabel: this.workflowFailoverTargetLabel(runtime),
+                    showFailover,
+                    failoverNodeClass: showFailover ? this.workflowFailoverNodeClass(runtime) : '',
+                    failoverConnClass: showFailover ? this.workflowFailoverConnClass(runtime) : '',
+                    failoverStatusLabel: showFailover ? this.workflowFailoverStatusLabel(runtime) : null,
+                    failoverTargetLabel: showFailover ? this.workflowFailoverTargetLabel(runtime) : null,
                     aiLabel: this.workflowAiLabel(source, runtime),
                     aiSublabel: this.workflowAiSublabel(source, runtime),
-	                    aiConnClass: this.workflowAiConnClass(runtime),
-	                    aiNodeClass: this.workflowAiNodeClass(runtime),
-	                    responseConnClass: this.workflowResponseConnClass(runtime),
-	                    responseNodeClass: this.workflowResponseNodeClass(runtime),
-				    authNodeClass: this.workflowAuthNodeClass(runtime),
-				    authNodeSublabel: this.workflowAuthNodeSublabel(runtime),
-                        usageNodeClass: this.workflowAsyncNodeClass(showUsage, highlightAsyncPresent),
-                        auditNodeClass: this.workflowAsyncNodeClass(showAudit, highlightAsyncPresent),
-	                    showAsync,
-	                    showUsage,
-	                    showAudit,
-                        workflowID
-	                };
-	            },
+                    aiConnClass: this.workflowAiConnClass(runtime),
+                    aiNodeClass: this.workflowAiNodeClass(runtime),
+                    responseConnClass: this.workflowResponseConnClass(runtime),
+                    responseNodeClass: this.workflowResponseNodeClass(runtime),
+                    authNodeClass: this.workflowAuthNodeClass(runtime),
+                    authNodeSublabel: this.workflowAuthNodeSublabel(runtime),
+                    usageNodeClass: this.workflowAsyncNodeClass(showUsage, highlightAsyncPresent),
+                    auditNodeClass: this.workflowAsyncNodeClass(showAudit, highlightAsyncPresent),
+                    showAsync,
+                    showUsage,
+                    showAudit,
+                    workflowID
+                };
+            },
 
             workflowChart(source) {
                 return this.workflowChartModel(source, null, { forceCache: false });
@@ -1300,10 +1301,12 @@
             },
 
             workflowFailoverNodeClass(runtime) {
+                if (runtime && runtime.cacheHit) return 'workflow-node-skipped';
                 return runtime && runtime.failoverTarget ? 'workflow-node-success' : '';
             },
 
             workflowFailoverConnClass(runtime) {
+                if (runtime && runtime.cacheHit) return 'workflow-conn-dim';
                 return runtime && runtime.failoverTarget ? 'workflow-conn-hit' : '';
             },
 

--- a/internal/admin/dashboard/static/js/modules/workflows.test.js
+++ b/internal/admin/dashboard/static/js/modules/workflows.test.js
@@ -429,8 +429,8 @@ test('workflowAuditChart returns the shared chart contract for audit runtime ent
             cacheConnClass: 'workflow-conn-hit',
             cacheStatusLabel: 'Hit (Semantic)',
             showFailover: true,
-            failoverNodeClass: '',
-            failoverConnClass: '',
+            failoverNodeClass: 'workflow-node-skipped',
+            failoverConnClass: 'workflow-conn-dim',
             failoverStatusLabel: null,
             failoverTargetLabel: null,
             aiLabel: 'openai',
@@ -1799,6 +1799,8 @@ test('audit runtime uses explicit cache-hit labels and highlights the uncached 2
     assert.equal(module.workflowCacheNodeClass(semanticHit), 'workflow-node-success');
     assert.equal(module.workflowCacheConnClass(semanticHit), 'workflow-conn-hit');
     assert.equal(module.workflowCacheStatusLabel(semanticHit), 'Hit (Semantic)');
+    assert.equal(module.workflowFailoverNodeClass(semanticHit), 'workflow-node-skipped');
+    assert.equal(module.workflowFailoverConnClass(semanticHit), 'workflow-conn-dim');
     assert.equal(module.workflowAiConnClass(semanticHit), 'workflow-conn-dim');
     assert.equal(module.workflowAiNodeClass(semanticHit), 'workflow-node-skipped');
     assert.equal(module.workflowResponseConnClass(semanticHit), 'workflow-conn-dim');

--- a/internal/admin/dashboard/templates/audit-pane.html
+++ b/internal/admin/dashboard/templates/audit-pane.html
@@ -2,28 +2,43 @@
 <section class="audit-pane" x-data="auditPaneState({{.}})">
     <div class="audit-pane-head">
         <h4 x-text="pane.title"></h4>
-        <button type="button" class="pagination-btn copy-feedback-btn"
-            :class="{ 'copy-feedback-btn-copied': copyState.copied }"
-            @click.prevent="copyBody()">
-            <template x-if="!copyState.copied">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-            </template>
-            <template x-if="copyState.copied">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 12l3 3 5-5"/></svg>
-            </template>
-            <span x-text="copyState.error ? 'Copy failed' : (copyState.copied ? 'Copied' : 'Copy Body')"></span>
-        </button>
     </div>
     <div class="audit-pane-block" x-show="pane.showErrorMessage">
         <h5>Error Message</h5>
         <pre class="audit-json" x-text="pane.errorMessage"></pre>
     </div>
     <div class="audit-pane-block" x-show="pane.showHeaders">
-        <h5>Headers</h5>
+        <div class="audit-pane-block-head">
+            <h5>Headers</h5>
+            <button type="button" class="copy-feedback-btn audit-copy-btn"
+                :class="{ 'copy-feedback-btn-copied': copyHeadersState.copied }"
+                @click.prevent="copyHeaders()">
+                <template x-if="!copyHeadersState.copied">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                </template>
+                <template x-if="copyHeadersState.copied">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 12l3 3 5-5"/></svg>
+                </template>
+                <span x-text="copyHeadersState.error ? 'Copy failed' : (copyHeadersState.copied ? 'Copied' : 'Copy Headers')"></span>
+            </button>
+        </div>
         <pre class="audit-json" x-text="formattedHeaders"></pre>
     </div>
     <div class="audit-pane-block" x-show="pane.showBody">
-        <h5>Body</h5>
+        <div class="audit-pane-block-head">
+            <h5>Body</h5>
+            <button type="button" class="copy-feedback-btn audit-copy-btn"
+                :class="{ 'copy-feedback-btn-copied': copyBodyState.copied }"
+                @click.prevent="copyBody()">
+                <template x-if="!copyBodyState.copied">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                </template>
+                <template x-if="copyBodyState.copied">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 12l3 3 5-5"/></svg>
+                </template>
+                <span x-text="copyBodyState.error ? 'Copy failed' : (copyBodyState.copied ? 'Copied' : 'Copy Body')"></span>
+            </button>
+        </div>
         <pre class="audit-json audit-json-body"
              x-html="renderedBody"
              @mousedown="startBodyInteraction($event)"

--- a/internal/admin/dashboard/templates/audit-pane.html
+++ b/internal/admin/dashboard/templates/audit-pane.html
@@ -19,7 +19,7 @@
                 <template x-if="copyHeadersState.copied">
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 12l3 3 5-5"/></svg>
                 </template>
-                <span x-text="copyHeadersState.error ? 'Copy failed' : (copyHeadersState.copied ? 'Copied' : 'Copy Headers')"></span>
+                <span aria-live="polite" aria-atomic="true" x-text="copyHeadersState.error ? 'Copy failed' : (copyHeadersState.copied ? 'Copied' : 'Copy Headers')"></span>
             </button>
         </div>
         <pre class="audit-json" x-text="formattedHeaders"></pre>
@@ -36,7 +36,7 @@
                 <template x-if="copyBodyState.copied">
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 12l3 3 5-5"/></svg>
                 </template>
-                <span x-text="copyBodyState.error ? 'Copy failed' : (copyBodyState.copied ? 'Copied' : 'Copy Body')"></span>
+                <span aria-live="polite" aria-atomic="true" x-text="copyBodyState.error ? 'Copy failed' : (copyBodyState.copied ? 'Copied' : 'Copy Body')"></span>
             </button>
         </div>
         <pre class="audit-json audit-json-body"

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -294,7 +294,7 @@
     </div>
 
     <!-- Usage by User Path Chart -->
-    <div class="model-chart-section" x-show="userPathUsage.length > 0">
+    <div class="model-chart-section" x-show="userPathUsageChartVisible()">
         <div class="model-chart-header">
             <h3 x-text="usageMode === 'costs' ? 'Cost by User Path' : 'Usage by User Path'"></h3>
             <div class="chart-view-toggle" role="group" aria-label="User path usage view">
@@ -478,7 +478,7 @@
                 role="status"
                 aria-live="polite"
                 x-show="runtimeRefreshReport && runtimeRefreshReport.steps && runtimeRefreshReport.steps.length > 0">
-                <template x-for="step in runtimeRefreshReport.steps" :key="step.name">
+                <template x-for="step in runtimeRefreshSteps()" :key="step.name">
                     <li :class="'runtime-refresh-step is-' + step.status" x-text="runtimeRefreshStepLabel(step)"></li>
                 </template>
             </ul>
@@ -872,7 +872,7 @@
     <!-- Filter -->
     <div class="table-toolbar" x-show="displayModels.length > 0 || modelFilter || aliasesAvailable">
         <div class="table-toolbar-main">
-            <input type="text" placeholder="Filter by provider, provider/model, alias, or owner..." x-model="modelFilter" class="filter-input models-filter-input">
+            <input type="text" placeholder="Filter by provider, provider/model, alias, or owner..." x-model="modelFilter" class="filter-input">
         </div>
         <div class="table-toolbar-actions">
             <button type="button" class="pagination-btn pagination-btn-primary pagination-btn-with-icon alias-create-btn" x-show="aliasesAvailable" @click="openAliasCreate()">

--- a/internal/admin/dashboard/templates/index.html
+++ b/internal/admin/dashboard/templates/index.html
@@ -345,7 +345,10 @@
     <div class="usage-log-section">
         <h3>Request Log</h3>
         <div class="usage-log-toolbar">
-            <input type="text" placeholder="Search by request ID, model, provider..." x-model="usageLogSearch" @input.debounce.300ms="fetchUsageLog(true)" class="filter-input">
+            <div class="filter-input-wrap">
+                <i data-lucide="search" class="filter-input-icon" aria-hidden="true"></i>
+                <input type="text" placeholder="Search by request ID, model, provider..." x-model="usageLogSearch" @input.debounce.300ms="fetchUsageLog(true)" class="filter-input">
+            </div>
             <select x-model="usageLogModel" @change="fetchUsageLog(true)" class="usage-log-select">
                 <option value="">All Models</option>
                 <template x-for="m in usageLogModelOptions()" :key="m">
@@ -358,7 +361,10 @@
                     <option :value="p" x-text="p"></option>
                 </template>
             </select>
-            <input type="text" placeholder="User path /team/alpha" aria-label="Filter by user path" x-model="usageLogUserPath" @input.debounce.300ms="fetchUsageLog(true)" class="filter-input">
+            <div class="filter-input-wrap">
+                <i data-lucide="search" class="filter-input-icon" aria-hidden="true"></i>
+                <input type="text" placeholder="User path /team/alpha" aria-label="Filter by user path" x-model="usageLogUserPath" @input.debounce.300ms="fetchUsageLog(true)" class="filter-input">
+            </div>
         </div>
         <div class="table-wrapper" x-show="usageLog.entries.length > 0">
             <table class="data-table usage-log-table">
@@ -628,7 +634,10 @@
 
             <div class="table-toolbar" x-show="guardrailsAvailable">
                 <div class="table-toolbar-main">
-                    <input type="text" id="guardrail-filter" class="filter-input" placeholder="Filter by name, type, user path, summary..." aria-label="Guardrail filter" x-model="guardrailFilter">
+                    <div class="filter-input-wrap">
+                        <i data-lucide="search" class="filter-input-icon" aria-hidden="true"></i>
+                        <input type="text" id="guardrail-filter" class="filter-input" placeholder="Filter by name, type, user path, summary..." aria-label="Guardrail filter" x-model="guardrailFilter">
+                    </div>
                 </div>
             </div>
 
@@ -872,7 +881,10 @@
     <!-- Filter -->
     <div class="table-toolbar" x-show="displayModels.length > 0 || modelFilter || aliasesAvailable">
         <div class="table-toolbar-main">
-            <input type="text" placeholder="Filter by provider, provider/model, alias, or owner..." x-model="modelFilter" class="filter-input">
+            <div class="filter-input-wrap">
+                <i data-lucide="search" class="filter-input-icon" aria-hidden="true"></i>
+                <input type="text" placeholder="Filter by provider, provider/model, alias, or owner..." aria-label="Filter models by provider, provider/model, alias, or owner" x-model="modelFilter" class="filter-input">
+            </div>
         </div>
         <div class="table-toolbar-actions">
             <button type="button" class="pagination-btn pagination-btn-primary pagination-btn-with-icon alias-create-btn" x-show="aliasesAvailable" @click="openAliasCreate()">
@@ -1178,7 +1190,10 @@
 
     <div class="table-toolbar" x-show="workflowsAvailable">
         <div class="table-toolbar-main">
-            <input type="text" placeholder="Filter by scope, name, hash, or guardrail..." x-model="workflowFilter" class="filter-input" aria-label="Filter workflows by scope, name, hash, or guardrail">
+            <div class="filter-input-wrap">
+                <i data-lucide="search" class="filter-input-icon" aria-hidden="true"></i>
+                <input type="text" placeholder="Filter by scope, name, hash, or guardrail..." x-model="workflowFilter" class="filter-input" aria-label="Filter workflows by scope, name, hash, or guardrail">
+            </div>
         </div>
         <div class="table-toolbar-actions">
             <span class="model-count" x-text="filteredWorkflows.length + ' active scopes'"></span>
@@ -1441,7 +1456,10 @@
     <div class="audit-log-section">
         <div class="audit-log-toolbar">
             <div class="audit-filter-row audit-filter-row-search">
-                <input id="audit-filter-search" type="text" placeholder="Search by request ID, model, provider, path, user path, or error..." aria-label="Search by request ID, model, provider, path, user path, or error" x-model="auditSearch" @input.debounce.300ms="fetchAuditLog(true)" class="filter-input">
+                <div class="filter-input-wrap">
+                    <i data-lucide="search" class="filter-input-icon" aria-hidden="true"></i>
+                    <input id="audit-filter-search" type="text" placeholder="Search by request ID, model, provider, path, user path, or error..." aria-label="Search by request ID, model, provider, path, user path, or error" x-model="auditSearch" @input.debounce.300ms="fetchAuditLog(true)" class="filter-input">
+                </div>
             </div>
             <div class="audit-filter-row audit-filter-row-controls">
                 <select id="audit-filter-method" aria-label="HTTP method filter" x-model="auditMethod" @change="fetchAuditLog(true)" class="usage-log-select audit-filter-select">

--- a/internal/auditlog/auditlog_test.go
+++ b/internal/auditlog/auditlog_test.go
@@ -931,6 +931,53 @@ data: [DONE]
 	}
 }
 
+func TestStreamLogObserverDefaultsMissingChatRoleToAssistant(t *testing.T) {
+	streamContent := `data: {"id":"chatcmpl-123","model":"claude-sonnet","choices":[{"delta":{"content":"Hello"}}]}
+
+data: {"id":"chatcmpl-123","model":"claude-sonnet","choices":[{"delta":{},"finish_reason":"stop"}]}
+
+data: [DONE]
+
+`
+	logger := &capturingLogger{cfg: Config{Enabled: true, LogBodies: true}}
+	entry := &LogEntry{
+		ID:        "test-entry",
+		Timestamp: time.Now(),
+		Data:      &LogData{},
+	}
+
+	observedStream := streaming.NewObservedSSEStream(
+		io.NopCloser(strings.NewReader(streamContent)),
+		NewStreamLogObserver(logger, entry, "/v1/chat/completions"),
+	)
+	_, err := io.Copy(io.Discard, observedStream)
+	if err != nil {
+		t.Fatalf("failed to read stream: %v", err)
+	}
+	if err := observedStream.Close(); err != nil {
+		t.Fatalf("failed to close stream: %v", err)
+	}
+
+	if len(logger.entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(logger.entries))
+	}
+	response, ok := logger.entries[0].Data.ResponseBody.(map[string]any)
+	if !ok {
+		t.Fatalf("response body type = %T, want map[string]any", logger.entries[0].Data.ResponseBody)
+	}
+	choices, ok := response["choices"].([]map[string]any)
+	if !ok || len(choices) != 1 {
+		t.Fatalf("choices = %#v, want one choice", response["choices"])
+	}
+	message, ok := choices[0]["message"].(map[string]any)
+	if !ok {
+		t.Fatalf("message = %#v, want map[string]any", choices[0]["message"])
+	}
+	if got := message["role"]; got != "assistant" {
+		t.Fatalf("message role = %#v, want assistant", got)
+	}
+}
+
 func TestNewStreamLogObserverNilInputs(t *testing.T) {
 	if observer := NewStreamLogObserver(nil, &LogEntry{}, "/v1/chat/completions"); observer != nil {
 		t.Error("expected nil observer with nil logger")

--- a/internal/auditlog/auditlog_test.go
+++ b/internal/auditlog/auditlog_test.go
@@ -1445,6 +1445,29 @@ func TestResponseBodyCapture_Write_SkipsWhenDisabled(t *testing.T) {
 	}
 }
 
+func TestHasResponseBodyCaptureHandlesWrappedAndCyclicWriters(t *testing.T) {
+	capture := &responseBodyCapture{
+		ResponseWriter: &discardWriter{},
+		body:           &bytes.Buffer{},
+	}
+	wrapped := &unwrapTestWriter{ResponseWriter: &discardWriter{}, next: capture}
+	if !hasResponseBodyCapture(wrapped) {
+		t.Fatal("expected wrapped responseBodyCapture to be detected")
+	}
+
+	self := &selfUnwrapTestWriter{ResponseWriter: &discardWriter{}}
+	if hasResponseBodyCapture(self) {
+		t.Fatal("expected self-unwrapping writer not to report responseBodyCapture")
+	}
+
+	first := &unwrapTestWriter{ResponseWriter: &discardWriter{}}
+	second := &unwrapTestWriter{ResponseWriter: &discardWriter{}, next: first}
+	first.next = second
+	if hasResponseBodyCapture(first) {
+		t.Fatal("expected cyclic wrapper chain not to report responseBodyCapture")
+	}
+}
+
 // trackingReadCloser wraps an io.Reader and tracks whether Close was called.
 type trackingReadCloser struct {
 	io.Reader
@@ -1474,6 +1497,23 @@ type discardWriter struct{}
 func (d *discardWriter) Header() http.Header         { return http.Header{} }
 func (d *discardWriter) Write(b []byte) (int, error) { return len(b), nil }
 func (d *discardWriter) WriteHeader(int)             {}
+
+type unwrapTestWriter struct {
+	http.ResponseWriter
+	next http.ResponseWriter
+}
+
+func (w *unwrapTestWriter) Unwrap() http.ResponseWriter {
+	return w.next
+}
+
+type selfUnwrapTestWriter struct {
+	http.ResponseWriter
+}
+
+func (w *selfUnwrapTestWriter) Unwrap() http.ResponseWriter {
+	return w
+}
 
 func TestLimitedReaderRequestBodyCapture(t *testing.T) {
 	t.Run("chunked request body under limit is captured", func(t *testing.T) {

--- a/internal/auditlog/stream_observer.go
+++ b/internal/auditlog/stream_observer.go
@@ -16,6 +16,8 @@ type responseWriterUnwrapper interface {
 	Unwrap() http.ResponseWriter
 }
 
+const maxResponseWriterUnwrapDepth = 10
+
 // StreamLogObserver reconstructs stream metadata and optional response bodies
 // from parsed SSE JSON payloads.
 type StreamLogObserver struct {
@@ -126,7 +128,7 @@ func (o *cachedStreamObserver) OnJSONEvent(event map[string]any) {
 func (o *cachedStreamObserver) OnStreamClose() {}
 
 func hasResponseBodyCapture(w http.ResponseWriter) bool {
-	for w != nil {
+	for depth := 0; w != nil && depth < maxResponseWriterUnwrapDepth; depth++ {
 		if _, ok := w.(*responseBodyCapture); ok {
 			return true
 		}
@@ -134,7 +136,11 @@ func hasResponseBodyCapture(w http.ResponseWriter) bool {
 		if !ok {
 			return false
 		}
-		w = unwrapper.Unwrap()
+		next := unwrapper.Unwrap()
+		if next == w {
+			return false
+		}
+		w = next
 	}
 	return false
 }

--- a/internal/auditlog/stream_observer.go
+++ b/internal/auditlog/stream_observer.go
@@ -1,9 +1,20 @@
 package auditlog
 
 import (
+	"bytes"
+	"io"
+	"net/http"
 	"strings"
 	"time"
+
+	"github.com/labstack/echo/v5"
+
+	"gomodel/internal/streaming"
 )
+
+type responseWriterUnwrapper interface {
+	Unwrap() http.ResponseWriter
+}
 
 // StreamLogObserver reconstructs stream metadata and optional response bodies
 // from parsed SSE JSON payloads.
@@ -42,11 +53,7 @@ func (o *StreamLogObserver) OnJSONEvent(event map[string]any) {
 	if !o.logBodies || o.builder == nil {
 		return
 	}
-	if o.builder.IsResponsesAPI {
-		o.parseResponsesAPIEvent(event)
-		return
-	}
-	o.parseChatCompletionEvent(event)
+	observeStreamJSONEvent(o.builder, event)
 }
 
 func (o *StreamLogObserver) OnStreamClose() {
@@ -73,43 +80,113 @@ func (o *StreamLogObserver) OnStreamClose() {
 	}
 }
 
-func (o *StreamLogObserver) parseChatCompletionEvent(event map[string]any) {
-	if o.builder == nil {
+// EnrichEntryWithCachedStreamResponse reconstructs the OpenAI-compatible
+// response body for a cached SSE replay when audit body capture is enabled.
+func EnrichEntryWithCachedStreamResponse(c *echo.Context, path string, body []byte) {
+	if c == nil || len(body) == 0 {
+		return
+	}
+	if !hasResponseBodyCapture(c.Response()) {
 		return
 	}
 
-	if o.builder.ID == "" {
+	entry := GetStreamEntryFromContext(c)
+	if entry == nil {
+		return
+	}
+
+	builder := &streamResponseBuilder{
+		IsResponsesAPI: strings.HasPrefix(path, "/v1/responses"),
+	}
+	observer := &cachedStreamObserver{builder: builder}
+	stream := streaming.NewObservedSSEStream(io.NopCloser(bytes.NewReader(body)), observer)
+	_, _ = io.Copy(io.Discard, stream)
+	_ = stream.Close()
+
+	data := ensureLogData(entry)
+	if builder.IsResponsesAPI {
+		data.ResponseBody = builder.buildResponsesAPIResponse()
+	} else {
+		data.ResponseBody = builder.buildChatCompletionResponse()
+	}
+	data.ResponseBodyTooBigToHandle = builder.truncated
+}
+
+type cachedStreamObserver struct {
+	builder *streamResponseBuilder
+}
+
+func (o *cachedStreamObserver) OnJSONEvent(event map[string]any) {
+	if o == nil || o.builder == nil {
+		return
+	}
+	observeStreamJSONEvent(o.builder, event)
+}
+
+func (o *cachedStreamObserver) OnStreamClose() {}
+
+func hasResponseBodyCapture(w http.ResponseWriter) bool {
+	for w != nil {
+		if _, ok := w.(*responseBodyCapture); ok {
+			return true
+		}
+		unwrapper, ok := w.(responseWriterUnwrapper)
+		if !ok {
+			return false
+		}
+		w = unwrapper.Unwrap()
+	}
+	return false
+}
+
+func observeStreamJSONEvent(builder *streamResponseBuilder, event map[string]any) {
+	if builder == nil {
+		return
+	}
+	if builder.IsResponsesAPI {
+		parseResponsesAPIEvent(builder, event)
+		return
+	}
+	parseChatCompletionEvent(builder, event)
+}
+
+func parseChatCompletionEvent(builder *streamResponseBuilder, event map[string]any) {
+	if builder == nil {
+		return
+	}
+
+	if builder.ID == "" {
 		if id, ok := event["id"].(string); ok {
-			o.builder.ID = id
+			builder.ID = id
 		}
 		if model, ok := event["model"].(string); ok {
-			o.builder.Model = model
+			builder.Model = model
 		}
 		if created, ok := event["created"].(float64); ok {
-			o.builder.Created = int64(created)
+			builder.Created = int64(created)
 		}
 	}
 
 	if choices, ok := event["choices"].([]any); ok && len(choices) > 0 {
 		if choice, ok := choices[0].(map[string]any); ok {
 			if fr, ok := choice["finish_reason"].(string); ok && fr != "" {
-				o.builder.FinishReason = fr
+				builder.FinishReason = fr
 			}
 
 			if delta, ok := choice["delta"].(map[string]any); ok {
 				if role, ok := delta["role"].(string); ok {
-					o.builder.Role = role
+					builder.Role = role
 				}
 				if content, ok := delta["content"].(string); ok && content != "" {
-					o.appendContent(content)
+					appendStreamContent(builder, content)
 				}
 			}
 		}
 	}
 }
 
-func (o *StreamLogObserver) parseResponsesAPIEvent(event map[string]any) {
-	if o.builder == nil {
+func parseResponsesAPIEvent(builder *streamResponseBuilder, event map[string]any) {
+	if builder == nil {
 		return
 	}
 
@@ -118,35 +195,35 @@ func (o *StreamLogObserver) parseResponsesAPIEvent(event map[string]any) {
 	case "response.created", "response.completed", "response.done":
 		if resp, ok := event["response"].(map[string]any); ok {
 			if id, ok := resp["id"].(string); ok {
-				o.builder.ResponseID = id
+				builder.ResponseID = id
 			}
 			if status, ok := resp["status"].(string); ok {
-				o.builder.Status = status
+				builder.Status = status
 			}
 			if model, ok := resp["model"].(string); ok {
-				o.builder.Model = model
+				builder.Model = model
 			}
 			if createdAt, ok := resp["created_at"].(float64); ok {
-				o.builder.CreatedAt = int64(createdAt)
+				builder.CreatedAt = int64(createdAt)
 			}
 		}
 	case "response.output_text.delta":
 		if delta, ok := event["delta"].(string); ok && delta != "" {
-			o.appendContent(delta)
+			appendStreamContent(builder, delta)
 		}
 	}
 }
 
-func (o *StreamLogObserver) appendContent(content string) {
-	if o.builder == nil || o.builder.truncated || o.builder.contentLen >= MaxContentCapture {
+func appendStreamContent(builder *streamResponseBuilder, content string) {
+	if builder == nil || builder.truncated || builder.contentLen >= MaxContentCapture {
 		return
 	}
 
-	remaining := MaxContentCapture - o.builder.contentLen
+	remaining := MaxContentCapture - builder.contentLen
 	if len(content) > remaining {
 		content = content[:remaining]
-		o.builder.truncated = true
+		builder.truncated = true
 	}
-	o.builder.Content.WriteString(content)
-	o.builder.contentLen += len(content)
+	builder.Content.WriteString(content)
+	builder.contentLen += len(content)
 }

--- a/internal/auditlog/stream_wrapper.go
+++ b/internal/auditlog/stream_wrapper.go
@@ -30,6 +30,11 @@ type streamResponseBuilder struct {
 
 // buildChatCompletionResponse constructs a ChatCompletion response from accumulated data
 func (b *streamResponseBuilder) buildChatCompletionResponse() map[string]any {
+	role := strings.TrimSpace(b.Role)
+	if role == "" {
+		role = "assistant"
+	}
+
 	return map[string]any{
 		"id":      b.ID,
 		"object":  "chat.completion",
@@ -39,7 +44,7 @@ func (b *streamResponseBuilder) buildChatCompletionResponse() map[string]any {
 			{
 				"index": 0,
 				"message": map[string]any{
-					"role":    b.Role,
+					"role":    role,
 					"content": b.Content.String(),
 				},
 				"finish_reason": b.FinishReason,

--- a/internal/providers/anthropic/anthropic.go
+++ b/internal/providers/anthropic/anthropic.go
@@ -737,14 +737,24 @@ func (sc *streamConverter) formatChatChunk(delta map[string]any, finishReason an
 func (sc *streamConverter) convertEvent(event *anthropicStreamEvent) string {
 	switch event.Type {
 	case "message_start":
+		role := ""
 		if event.Message != nil {
 			sc.msgID = event.Message.ID
 			if mergeAnthropicUsage(&sc.usage, &event.Message.Usage) {
 				sc.hasUsage = true
 			}
+			role = strings.TrimSpace(event.Message.Role)
 		}
 		if mergeAnthropicUsage(&sc.usage, event.Usage) {
 			sc.hasUsage = true
+		}
+		if event.Message != nil {
+			if role == "" {
+				role = "assistant"
+			}
+			return sc.formatChatChunk(map[string]any{
+				"role": role,
+			}, nil, nil)
 		}
 		return ""
 

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -421,6 +421,9 @@ data: {"type":"message_stop"}
 				if !strings.Contains(responseStr, "data:") {
 					t.Error("response should contain SSE data")
 				}
+				if !strings.Contains(responseStr, `"role":"assistant"`) {
+					t.Error("response should include assistant role delta")
+				}
 				if !strings.Contains(responseStr, "[DONE]") {
 					t.Error("response should end with [DONE]")
 				}
@@ -789,6 +792,7 @@ data: {"type":"message_stop"}
 		t.Fatal("expected at least one SSE event")
 	}
 
+	foundTerminalChunk := false
 	for _, event := range events {
 		if event.Done {
 			continue
@@ -802,18 +806,23 @@ data: {"type":"message_stop"}
 		if !ok {
 			continue
 		}
-		if choice["finish_reason"] != "tool_use" {
-			t.Fatalf("finish_reason = %#v, want %q", choice["finish_reason"], "tool_use")
-		}
 
 		delta, _ := choice["delta"].(map[string]any)
 		if _, ok := delta["tool_calls"]; ok {
 			t.Fatalf("did not expect tool_calls in malformed stream fallback, got %#v", delta["tool_calls"])
 		}
-		return
+		if choice["finish_reason"] == nil {
+			continue
+		}
+		foundTerminalChunk = true
+		if choice["finish_reason"] != "tool_use" {
+			t.Fatalf("finish_reason = %#v, want %q", choice["finish_reason"], "tool_use")
+		}
 	}
 
-	t.Fatal("expected a chat completion chunk")
+	if !foundTerminalChunk {
+		t.Fatal("expected a terminal chat completion chunk")
+	}
 }
 
 func TestStreamChatCompletion_MalformedEventReturnsError(t *testing.T) {

--- a/internal/responsecache/handle_request_test.go
+++ b/internal/responsecache/handle_request_test.go
@@ -37,6 +37,25 @@ func (l *recordingUsageLogger) Close() error {
 	return nil
 }
 
+type recordingAuditLogger struct {
+	config  auditlog.Config
+	entries []*auditlog.LogEntry
+}
+
+func (l *recordingAuditLogger) Write(entry *auditlog.LogEntry) {
+	if entry != nil {
+		l.entries = append(l.entries, entry)
+	}
+}
+
+func (l *recordingAuditLogger) Config() auditlog.Config {
+	return l.config
+}
+
+func (l *recordingAuditLogger) Close() error {
+	return nil
+}
+
 func TestHandleRequest_SemanticMissPopulatesExactCache(t *testing.T) {
 	store := cache.NewMapStore()
 	defer store.Close()
@@ -676,6 +695,106 @@ func TestHandleRequest_StreamingExactHitWritesSyntheticUsageEntry(t *testing.T) 
 	}
 	if entry.ProviderID != "chatcmpl-cache-hit" {
 		t.Fatalf("ProviderID = %q, want chatcmpl-cache-hit", entry.ProviderID)
+	}
+}
+
+func TestHandleRequest_StreamingExactHitAuditLogsCachedResponseBody(t *testing.T) {
+	store := cache.NewMapStore()
+	defer store.Close()
+
+	m := &ResponseCacheMiddleware{
+		simple: newSimpleCacheMiddleware(store, time.Hour, nil),
+	}
+	logger := &recordingAuditLogger{
+		config: auditlog.Config{
+			Enabled:    true,
+			LogBodies:  true,
+			LogHeaders: true,
+		},
+	}
+
+	body := []byte(`{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"cache-stream-audit-hit"}]}`)
+	rawStream := []byte(
+		"data: {\"id\":\"chatcmpl-cache-audit\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"Hello\"},\"finish_reason\":null}]}\n\n" +
+			"data: {\"id\":\"chatcmpl-cache-audit\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" cached audit\"},\"finish_reason\":\"stop\"}]}\n\n" +
+			"data: [DONE]\n\n",
+	)
+	e := echo.New()
+
+	run := func() *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Request-ID", "req-cache-audit")
+		plan := &core.Workflow{
+			Mode:         core.ExecutionModeTranslated,
+			ProviderType: "openai",
+			Resolution: &core.RequestModelResolution{
+				ResolvedSelector: core.ModelSelector{Provider: "openai", Model: "gpt-4"},
+			},
+		}
+		req = req.WithContext(core.WithWorkflow(req.Context(), plan))
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		handler := auditlog.Middleware(logger)(func(c *echo.Context) error {
+			return m.HandleRequest(c, body, func() error {
+				auditlog.MarkEntryAsStreaming(c, true)
+				auditlog.EnrichEntryWithStream(c, true)
+				c.Response().Header().Set("Content-Type", "text/event-stream")
+				c.Response().WriteHeader(http.StatusOK)
+				_, _ = c.Response().Write(rawStream)
+				return nil
+			})
+		})
+		if err := handler(c); err != nil {
+			t.Fatalf("handler: %v", err)
+		}
+		return rec
+	}
+
+	rec1 := run()
+	if got := rec1.Header().Get("X-Cache"); got != "" {
+		t.Fatalf("first request should miss exact cache, got X-Cache=%q", got)
+	}
+	m.simple.wg.Wait()
+	if len(logger.entries) != 0 {
+		t.Fatalf("streaming miss test path should be handled by stream observer, got %d middleware entries", len(logger.entries))
+	}
+
+	rec2 := run()
+	if got := rec2.Header().Get("X-Cache"); got != "HIT (exact)" {
+		t.Fatalf("second request should be exact hit, got X-Cache=%q", got)
+	}
+	if len(logger.entries) != 1 {
+		t.Fatalf("expected 1 audit log entry for cached stream hit, got %d", len(logger.entries))
+	}
+	entry := logger.entries[0]
+	if !entry.Stream {
+		t.Fatal("expected cached stream hit audit entry to be marked as streaming")
+	}
+	if entry.CacheType != auditlog.CacheTypeExact {
+		t.Fatalf("CacheType = %q, want %q", entry.CacheType, auditlog.CacheTypeExact)
+	}
+	if entry.Data == nil || entry.Data.ResponseBody == nil {
+		t.Fatalf("expected cached stream hit response body to be logged, got %#v", entry.Data)
+	}
+	response, ok := entry.Data.ResponseBody.(map[string]any)
+	if !ok {
+		t.Fatalf("response body type = %T, want map[string]any", entry.Data.ResponseBody)
+	}
+	choices, ok := response["choices"].([]map[string]any)
+	if !ok || len(choices) != 1 {
+		t.Fatalf("choices = %#v, want one choice", response["choices"])
+	}
+	message, ok := choices[0]["message"].(map[string]any)
+	if !ok {
+		t.Fatalf("message = %#v, want map[string]any", choices[0]["message"])
+	}
+	if got := message["content"]; got != "Hello cached audit" {
+		t.Fatalf("logged response content = %#v, want %q", got, "Hello cached audit")
+	}
+	if got := entry.Data.ResponseHeaders["X-Cache"]; got != "HIT (exact)" {
+		t.Fatalf("logged X-Cache header = %q, want HIT (exact)", got)
 	}
 }
 

--- a/internal/responsecache/stream_cache.go
+++ b/internal/responsecache/stream_cache.go
@@ -136,6 +136,7 @@ func writeCachedResponse(c *echo.Context, path string, requestBody, cached []byt
 	cacheHeader := cacheHeaderValue(cacheType)
 	if isStreamingRequest(path, requestBody) {
 		auditlog.EnrichEntryWithStream(c, true)
+		auditlog.EnrichEntryWithCachedStreamResponse(c, path, cached)
 		c.Response().Header().Set("Content-Type", "text/event-stream")
 		c.Response().Header().Set("Cache-Control", "no-cache")
 		c.Response().Header().Set("Connection", "keep-alive")

--- a/tests/contract/testdata/golden/anthropic/messages_stream.golden.json
+++ b/tests/contract/testdata/golden/anthropic/messages_stream.golden.json
@@ -4,6 +4,22 @@
       "choices": [
         {
           "delta": {
+            "role": "assistant"
+          },
+          "finish_reason": null,
+          "index": 0
+        }
+      ],
+      "created": 0,
+      "id": "msg_\u003cgenerated\u003e",
+      "model": "claude-sonnet-4-20250514",
+      "object": "chat.completion.chunk",
+      "provider": "anthropic"
+    },
+    {
+      "choices": [
+        {
+          "delta": {
             "content": "Hello World"
           },
           "finish_reason": null,


### PR DESCRIPTION
Generally it improves UI and the HTTP timeout visibility #237 

## Summary
- Log cached streaming responses into audit entries and reconstruct cached SSE response bodies for audit capture.
- Preserve Anthropic assistant roles in streaming chunks and audit stream reconstruction.
- Polish audit, workflow, usage, and settings dashboard behavior for copy buttons, scrolling, cache-hit paths, root-only user-path charts, and runtime refresh state.

## Tests
- node --test internal/admin/dashboard/static/js/modules/*.test.js
- go test ./internal/... ./cmd/...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate copy buttons for audit request/response headers and bodies
  * Improved streaming response handling with automatic role assignment

* **Bug Fixes**
  * Fixed missing role defaulting to "assistant" in streaming responses
  * Enhanced audit logging for cached streaming responses

* **Improvements**
  * Refined audit pane layout with better scrolling and alignment
  * Optimized user path chart visibility logic
  * Better mobile responsiveness for audit details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->