### PR TITLE
fix(responsestore): use read lock for MemoryStore.Get on the happy path

### DIFF
--- a/internal/responsestore/store_memory.go
+++ b/internal/responsestore/store_memory.go
@@ -104,19 +104,22 @@ func (s *MemoryStore) Create(_ context.Context, response *StoredResponse) error 
 // Get retrieves one response snapshot by id.
 func (s *MemoryStore) Get(_ context.Context, id string) (*StoredResponse, error) {
 	now := time.Now().UTC()
-	s.mu.Lock()
-	s.cleanupExpiredLocked(now)
+	s.mu.RLock()
 	response, ok := s.items[id]
 	if !ok {
-		s.mu.Unlock()
+		s.mu.RUnlock()
 		return nil, ErrNotFound
 	}
 	if responseExpired(response, now) {
+		s.mu.RUnlock()
+		// Upgrade to write lock to remove expired entry and run cleanup.
+		s.mu.Lock()
 		delete(s.items, id)
+		s.cleanupExpiredLocked(now)
 		s.mu.Unlock()
 		return nil, ErrNotFound
 	}
-	s.mu.Unlock()
+	s.mu.RUnlock()
 	return cloneResponse(response)
 }
 


### PR DESCRIPTION
## Summary
- `MemoryStore.Get()` was acquiring an exclusive write lock (`sync.Mutex.Lock()`) for every read operation, serializing all concurrent lookups
- The write lock was only needed for expired-entry cleanup and deletion, which are rare compared to normal reads
- Restructured `Get` to acquire `RLock` for the common case (entry found, not expired) and only upgrade to a write lock when an expired entry needs to be removed

## Test plan
- [x] Existing tests pass (`go test ./internal/responsestore/...`)
- [x] Verified compilation with `go build ./internal/responsestore/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced memory store concurrency handling for improved performance under concurrent access patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->