### PR TITLE
fix(server): flush non-SSE passthrough responses after copy

### DIFF
--- a/internal/server/passthrough_support.go
+++ b/internal/server/passthrough_support.go
@@ -305,5 +305,8 @@ func (s *passthroughService) proxyPassthroughResponse(c *echo.Context, providerT
 	if _, err := io.Copy(c.Response(), resp.Body); err != nil {
 		return err
 	}
+	if f, ok := c.Response().(http.Flusher); ok {
+		f.Flush()
+	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- `proxyPassthroughResponse` correctly flushes SSE streams after each chunk but does not flush the response writer for non-SSE responses
- When middleware (e.g., response capture) wraps the ResponseWriter with buffering, the final data may be held in the buffer and never delivered to the client
- Added an explicit `Flush` after `io.Copy` for non-SSE passthrough responses, matching the pattern already used for the SSE path

## Test plan
- [x] Existing tests pass (`go test ./internal/server/...`)
- [x] Verified compilation with `go build ./internal/server/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)