### PR TITLE
fix(responsecache): propagate write errors in writeCachedResponse

### DIFF
--- a/internal/responsecache/stream_cache.go
+++ b/internal/responsecache/stream_cache.go
@@ -142,14 +142,18 @@ func writeCachedResponse(c *echo.Context, path string, requestBody, cached []byt
 		c.Response().Header().Set("Connection", "keep-alive")
 		c.Response().Header().Set("X-Cache", cacheHeader)
 		c.Response().WriteHeader(http.StatusOK)
-		_, _ = c.Response().Write(cached)
+		if _, err := c.Response().Write(cached); err != nil {
+			return err
+		}
 		return nil
 	}
 
 	c.Response().Header().Set("Content-Type", "application/json")
 	c.Response().Header().Set("X-Cache", cacheHeader)
 	c.Response().WriteHeader(http.StatusOK)
-	_, _ = c.Response().Write(cached)
+	if _, err := c.Response().Write(cached); err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- `writeCachedResponse` discarded response write errors with `_, _ = c.Response().Write(cached)`
- If the client disconnects during cache replay (e.g., connection reset), the function returned `nil`, causing the semantic cache to report a successful hit while the client received nothing
- Propagated write errors so the caller can log the failure and the upstream handler can react appropriately

## Test plan
- [x] Existing tests pass (`go test ./internal/responsecache/...`)
- [x] Verified compilation with `go build ./internal/responsecache/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)