### PR TITLE
fix(responsecache): avoid memory leak in MapVecStore.DeleteExpired

### DIFF
--- a/internal/responsecache/vecstore_map.go
+++ b/internal/responsecache/vecstore_map.go
@@ -85,7 +85,7 @@ func (s *MapVecStore) DeleteExpired(_ context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	now := time.Now().Unix()
-	filtered := s.entries[:0]
+	filtered := make([]mapVecEntry, 0, len(s.entries))
 	for _, e := range s.entries {
 		if e.expiresAt <= 0 || e.expiresAt >= now {
 			filtered = append(filtered, e)


### PR DESCRIPTION
## Summary
- `MapVecStore.DeleteExpired` used in-place slice filtering (`s.entries[:0]`) which reuses the backing array
- Expired entries' `response` bytes and `vec` slices remain referenced in the backing array beyond the slice length, preventing GC from reclaiming potentially large cached response bodies
- Allocate a new slice so expired entries' memory can be properly collected by the GC

## Test plan
- [x] Existing tests pass (`go test ./internal/responsecache/...`)
- [x] Verified compilation with `go build ./internal/responsecache/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)