### PR TITLE
feat(vllm): add provider support

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -21,8 +21,8 @@
 # Allow optional /p/{provider}/v1/... passthrough aliases while keeping /p/{provider}/... canonical (default: true)
 # ALLOW_PASSTHROUGH_V1_ALIAS=true
 
-# Comma-separated list of provider types enabled for /p/{provider}/... passthrough (default: openai,anthropic,openrouter,zai)
-# ENABLED_PASSTHROUGH_PROVIDERS=openai,anthropic,openrouter,zai
+# Comma-separated list of provider types enabled for /p/{provider}/... passthrough (default: openai,anthropic,openrouter,zai,vllm)
+# ENABLED_PASSTHROUGH_PROVIDERS=openai,anthropic,openrouter,zai,vllm
 
 # HTTP Client Configuration (for upstream API requests)
 # Values in seconds (or Go duration format like "10m", "1h30m")
@@ -282,3 +282,9 @@
 # OLLAMA_API_KEY=...
 # Set base URL to enable (default: http://localhost:11434/v1)
 # OLLAMA_BASE_URL=http://localhost:11434/v1
+
+# vLLM (OpenAI-compatible server)
+# VLLM_API_KEY is optional; set it only if vllm serve was started with --api-key.
+# VLLM_API_KEY=token-abc123
+# Set base URL to enable (default: http://localhost:8000/v1)
+# VLLM_BASE_URL=http://localhost:8000/v1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ Full reference: `.env.template` and `config/config.yaml`
   - `BODY_SIZE_LIMIT` ("10M")
   - `ENABLE_PASSTHROUGH_ROUTES` (true: Enable provider-native passthrough routes under /p/{provider}/...)
   - `ALLOW_PASSTHROUGH_V1_ALIAS` (true: Allow /p/{provider}/v1/... aliases while keeping /p/{provider}/... canonical)
-  - `ENABLED_PASSTHROUGH_PROVIDERS` (openai,anthropic,openrouter,zai: Comma-separated list of enabled passthrough providers)
+  - `ENABLED_PASSTHROUGH_PROVIDERS` (openai,anthropic,openrouter,zai,vllm: Comma-separated list of enabled passthrough providers)
 - **Storage:** `STORAGE_TYPE` (sqlite), `SQLITE_PATH` (data/gomodel.db), `POSTGRES_URL`, `MONGODB_URL`
 - **Models:** `MODELS_ENABLED_BY_DEFAULT` (true), `MODEL_OVERRIDES_ENABLED` (false), `KEEP_ONLY_ALIASES_AT_MODELS_ENDPOINT` (false); persisted overrides restrict/allow selectors with `user_paths`. When alias-only models listing is enabled, `GET /v1/models` returns only model aliases, not full concrete model specs, to operators.
 - **Audit logging:** `LOGGING_ENABLED` (false), `LOGGING_LOG_BODIES` (false), `LOGGING_LOG_HEADERS` (false), `LOGGING_RETENTION_DAYS` (30)
@@ -115,4 +115,4 @@ Full reference: `.env.template` and `config/config.yaml`
 - **Resilience:** Configured via `config/config.yaml` - global `resilience.retry.*` and `resilience.circuit_breaker.*` defaults with optional per-provider overrides under `providers.<name>.resilience.retry.*` and `providers.<name>.resilience.circuit_breaker.*`. Retry defaults: `max_retries` (3), `initial_backoff` (1s), `max_backoff` (30s), `backoff_factor` (2.0), `jitter_factor` (0.1). Circuit breaker defaults: `failure_threshold` (5), `success_threshold` (2), `timeout` (30s)
 - **Metrics:** `METRICS_ENABLED` (false), `METRICS_ENDPOINT` (/metrics)
 - **Guardrails:** Configured via `config/config.yaml` only (except `GUARDRAILS_ENABLED` env var)
-- **Providers:** `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `XAI_API_KEY`, `GROQ_API_KEY`, `OPENROUTER_API_KEY`, `ZAI_API_KEY`, `ZAI_BASE_URL` (optional Z.ai endpoint override), `AZURE_API_KEY`, `AZURE_BASE_URL` (Azure OpenAI deployment base URL), `AZURE_API_VERSION` (optional Azure API version), `ORACLE_API_KEY` (Oracle API key), `ORACLE_BASE_URL` (Oracle OpenAI-compatible base URL), `ORACLE_MODELS` (comma-separated Oracle fallback model inventory), `OLLAMA_BASE_URL`
+- **Providers:** `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `XAI_API_KEY`, `GROQ_API_KEY`, `OPENROUTER_API_KEY`, `ZAI_API_KEY`, `ZAI_BASE_URL` (optional Z.ai endpoint override), `AZURE_API_KEY`, `AZURE_BASE_URL` (Azure OpenAI deployment base URL), `AZURE_API_VERSION` (optional Azure API version), `ORACLE_API_KEY` (Oracle API key), `ORACLE_BASE_URL` (Oracle OpenAI-compatible base URL), `ORACLE_MODELS` (comma-separated Oracle fallback model inventory), `OLLAMA_BASE_URL`, `VLLM_BASE_URL`, `VLLM_API_KEY` (optional upstream vLLM bearer token)

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -201,6 +201,8 @@ Provider credentials:
 | `ORACLE_BASE_URL`     | Oracle OpenAI-compatible base URL                                                     |
 | `ORACLE_MODELS`       | Oracle fallback model inventory (comma-separated, used when `/models` is unavailable) |
 | `OLLAMA_BASE_URL`     | Ollama (default: `http://localhost:11434/v1`)                                         |
+| `VLLM_BASE_URL`       | vLLM OpenAI-compatible server (default: `http://localhost:8000/v1`)                   |
+| `VLLM_API_KEY`        | vLLM bearer token, only when upstream vLLM was started with `--api-key`               |
 
 See `.env.template` for the full list of all configurable environment variables.
 
@@ -235,6 +237,12 @@ When the `openrouter` provider is used, the gateway adds `HTTP-Referer` and `X-O
 
 **Z.ai Coding Plan uses a different endpoint.**
 `ZAI_API_KEY` uses `https://api.z.ai/api/paas/v4` by default. For GLM Coding Plan, set `ZAI_BASE_URL=https://api.z.ai/api/coding/paas/v4`.
+
+**vLLM uses its `/models` endpoint.**
+Set `VLLM_BASE_URL` to register a keyless vLLM server. Set `VLLM_API_KEY` only
+when upstream vLLM requires bearer authentication. GoModel uses the model IDs
+returned by vLLM, including slash-shaped Hugging Face IDs such as
+`meta-llama/Llama-3.1-8B-Instruct`.
 
 **Partial YAML fields leave the rest at defaults.**
 YAML is unmarshalled onto the struct that was already populated by built-in defaults. Only fields that appear in the file are written. Omitting `max_backoff` from `resilience.retry` leaves it at `30s`; you do not need to repeat defaults you are happy with.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ docker run --rm -p 8080:8080 \
   -e ORACLE_BASE_URL="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com/20231130/actions/v1" \
   -e ORACLE_MODELS="openai.gpt-oss-120b,xai.grok-3" \
   -e OLLAMA_BASE_URL="http://host.docker.internal:11434/v1" \
+  -e VLLM_BASE_URL="http://host.docker.internal:8000/v1" \
   enterpilot/gomodel
 ```
 
@@ -78,12 +79,15 @@ Example model identifiers are illustrative and subject to change; consult provid
 | Azure OpenAI  | `AZURE_API_KEY` + `AZURE_BASE_URL` (`AZURE_API_VERSION` optional) | `gpt-4o`                   |  ✅  |      ✅      |  ✅   |  ✅   |   ✅    |    ✅    |
 | Oracle        | `ORACLE_API_KEY` + `ORACLE_BASE_URL`                              | `openai.gpt-oss-120b`      |  ✅  |      ✅      |  ❌   |  ❌   |   ❌    |    ❌    |
 | Ollama        | `OLLAMA_BASE_URL`                                                 | `llama3.2`                 |  ✅  |      ✅      |  ✅   |  ❌   |   ❌    |    ❌    |
+| vLLM          | `VLLM_BASE_URL` (`VLLM_API_KEY` optional)                         | `meta-llama/Llama-3.1-8B-Instruct` | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ |
 
 ✅ Supported ❌ Unsupported
 
 For Z.ai's GLM Coding Plan, set `ZAI_BASE_URL=https://api.z.ai/api/coding/paas/v4`.
 For Oracle, set `ORACLE_MODELS=openai.gpt-oss-120b,xai.grok-3` when the
 upstream `/models` endpoint is unavailable.
+For vLLM, set `VLLM_API_KEY` only if the upstream server was started with
+`--api-key`.
 
 ---
 
@@ -186,7 +190,7 @@ Key settings:
 | `GOMODEL_MASTER_KEY`            | (none)                            | API key for authentication                                                       |
 | `ENABLE_PASSTHROUGH_ROUTES`     | `true`                            | Enable provider-native passthrough routes under `/p/{provider}/...`              |
 | `ALLOW_PASSTHROUGH_V1_ALIAS`    | `true`                            | Allow `/p/{provider}/v1/...` aliases while keeping `/p/{provider}/...` canonical |
-| `ENABLED_PASSTHROUGH_PROVIDERS` | `openai,anthropic,openrouter,zai` | Comma-separated list of enabled passthrough providers                            |
+| `ENABLED_PASSTHROUGH_PROVIDERS` | `openai,anthropic,openrouter,zai,vllm` | Comma-separated list of enabled passthrough providers                            |
 | `STORAGE_TYPE`                  | `sqlite`                          | Storage backend (`sqlite`, `postgresql`, `mongodb`)                              |
 | `METRICS_ENABLED`               | `false`                           | Enable Prometheus metrics                                                        |
 | `LOGGING_ENABLED`               | `false`                           | Enable audit logging                                                             |

--- a/cmd/gomodel/main.go
+++ b/cmd/gomodel/main.go
@@ -25,6 +25,7 @@ import (
 	"gomodel/internal/providers/openai"
 	"gomodel/internal/providers/openrouter"
 	"gomodel/internal/providers/oracle"
+	"gomodel/internal/providers/vllm"
 	"gomodel/internal/providers/xai"
 	"gomodel/internal/providers/zai"
 	"gomodel/internal/version"
@@ -120,6 +121,7 @@ func main() {
 	factory.Add(gemini.Registration)
 	factory.Add(groq.Registration)
 	factory.Add(ollama.Registration)
+	factory.Add(vllm.Registration)
 	factory.Add(xai.Registration)
 	factory.Add(zai.Registration)
 

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -10,7 +10,7 @@ server:
   pprof_enabled: false # expose /debug/pprof/* for local profiling only
   enable_passthrough_routes: true # expose /p/{provider}/{endpoint} passthrough routes
   allow_passthrough_v1_alias: true # allow /p/{provider}/v1/... while keeping /p/{provider}/... canonical
-  enabled_passthrough_providers: ["openai", "anthropic"] # providers enabled on /p/{provider}/...
+  enabled_passthrough_providers: ["openai", "anthropic", "openrouter", "zai", "vllm"] # providers enabled on /p/{provider}/...
 
 models:
   enabled_by_default: true # env: MODELS_ENABLED_BY_DEFAULT; when false, models stay unavailable until an override allows one or more user paths
@@ -200,6 +200,12 @@ providers:
   ollama:
     type: ollama
     base_url: "http://localhost:11434/v1"
+
+  vllm:
+    type: vllm
+    base_url: "http://localhost:8000/v1"
+    # Optional: set this only when vllm serve was started with --api-key.
+    # api_key: "token-abc123"
 
   # Custom OpenAI-compatible provider
   # my-provider:

--- a/config/config.go
+++ b/config/config.go
@@ -809,7 +809,8 @@ type ServerConfig struct {
 	// while keeping /p/{provider}/... as the canonical form. Default: true.
 	AllowPassthroughV1Alias bool `yaml:"allow_passthrough_v1_alias" env:"ALLOW_PASSTHROUGH_V1_ALIAS"`
 	// EnabledPassthroughProviders lists the provider types enabled on
-	// /p/{provider}/... passthrough routes. Default: ["openai", "anthropic"].
+	// /p/{provider}/... passthrough routes. Default:
+	// ["openai", "anthropic", "openrouter", "zai", "vllm"].
 	EnabledPassthroughProviders []string `yaml:"enabled_passthrough_providers" env:"ENABLED_PASSTHROUGH_PROVIDERS"`
 }
 
@@ -880,6 +881,9 @@ func buildDefaultConfig() *Config {
 			EnabledPassthroughProviders: []string{
 				"openai",
 				"anthropic",
+				"openrouter",
+				"zai",
+				"vllm",
 			},
 		},
 		Models: ModelsConfig{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -23,6 +24,7 @@ func clearProviderEnvVars(t *testing.T) {
 		"ZAI_API_KEY", "ZAI_BASE_URL",
 		"AZURE_API_KEY", "AZURE_BASE_URL", "AZURE_API_VERSION",
 		"ORACLE_API_KEY", "ORACLE_BASE_URL",
+		"VLLM_API_KEY", "VLLM_BASE_URL", "VLLM_MODELS",
 		"OLLAMA_API_KEY", "OLLAMA_BASE_URL",
 	} {
 		t.Setenv(key, "")
@@ -95,7 +97,7 @@ func TestBuildDefaultConfig(t *testing.T) {
 	if !cfg.Server.AllowPassthroughV1Alias {
 		t.Error("expected Server.AllowPassthroughV1Alias=true")
 	}
-	if got, want := cfg.Server.EnabledPassthroughProviders, []string{"openai", "anthropic"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+	if got, want := cfg.Server.EnabledPassthroughProviders, []string{"openai", "anthropic", "openrouter", "zai", "vllm"}; !reflect.DeepEqual(got, want) {
 		t.Errorf("expected Server.EnabledPassthroughProviders=%v, got %v", want, got)
 	}
 	if cfg.Cache.Model.Local != nil {
@@ -761,8 +763,8 @@ func TestLoad_ConfigExample_UsesNestedModelCacheSettings(t *testing.T) {
 			t.Fatalf("expected Cache.Model.Redis to be nil in example config, got %+v", result.Config.Cache.Model.Redis)
 		}
 		gotProviders := result.Config.Server.EnabledPassthroughProviders
-		wantProviders := []string{"openai", "anthropic"}
-		if len(gotProviders) != len(wantProviders) || gotProviders[0] != wantProviders[0] || gotProviders[1] != wantProviders[1] {
+		wantProviders := []string{"openai", "anthropic", "openrouter", "zai", "vllm"}
+		if !reflect.DeepEqual(gotProviders, wantProviders) {
 			t.Fatalf("Server.EnabledPassthroughProviders = %v, want %v", gotProviders, wantProviders)
 		}
 	})

--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -144,7 +144,7 @@ Set these to automatically register providers. No YAML configuration required.
 | `VLLM_BASE_URL`      | vLLM (no API key needed unless upstream requires) |
 
 Most providers can use a custom base URL via `<PROVIDER>_BASE_URL` (for example `OPENAI_BASE_URL`). OpenRouter defaults to `https://openrouter.ai/api/v1` and can be overridden with `OPENROUTER_BASE_URL`. Z.ai defaults to `https://api.z.ai/api/paas/v4`; set `ZAI_BASE_URL=https://api.z.ai/api/coding/paas/v4` for the GLM Coding Plan endpoint. vLLM defaults to `http://localhost:8000/v1` when `VLLM_API_KEY` is set, but keyless deployments should set `VLLM_BASE_URL` explicitly to register the provider. Azure uses `AZURE_BASE_URL` for its deployment base URL and accepts an optional `AZURE_API_VERSION` override; otherwise it defaults to `2024-10-21`. Oracle requires `ORACLE_BASE_URL` because its OpenAI-compatible endpoint is region-specific.
-When using Oracle, set `ORACLE_MODELS` to a comma-separated list such as `openai.gpt-oss-120b,xai.grok-3` if the upstream endpoint does not expose a usable `/models` response. YAML `models:` remains available for custom provider names and multi-provider Oracle setups.
+When using Oracle, set `ORACLE_MODELS` to a comma-separated list such as `openai.gpt-oss-120b,xai.grok-3` if the upstream endpoint does not expose a usable `/models` response. YAML `models:` remains available for custom provider names and larger Oracle provider blocks.
 
 For OpenRouter, GoModel also sends default attribution headers unless the request already sets them. Override those defaults with `OPENROUTER_SITE_URL` and `OPENROUTER_APP_NAME`.
 
@@ -353,16 +353,36 @@ providers:
 
 ### vLLM
 
-vLLM uses its OpenAI-compatible `/v1` API. Set `VLLM_BASE_URL` to register a
-keyless vLLM server:
+vLLM uses its OpenAI-compatible `/v1` API. In Docker, set `VLLM_BASE_URL` to
+register a keyless vLLM server:
 
 ```bash
-export VLLM_BASE_URL="http://localhost:8000/v1"
+docker run --rm -p 8080:8080 \
+  -e GOMODEL_MASTER_KEY="change-me" \
+  -e VLLM_BASE_URL="http://host.docker.internal:8000/v1" \
+  enterpilot/gomodel
 ```
 
 If the upstream server was started with `vllm serve ... --api-key token-abc123`,
 also set:
 
 ```bash
-export VLLM_API_KEY="token-abc123"
+docker run --rm -p 8080:8080 \
+  -e GOMODEL_MASTER_KEY="change-me" \
+  -e VLLM_BASE_URL="http://host.docker.internal:8000/v1" \
+  -e VLLM_API_KEY="token-abc123" \
+  enterpilot/gomodel
 ```
+
+You can also register more than one vLLM instance without YAML:
+
+```bash
+docker run --rm -p 8080:8080 \
+  -e GOMODEL_MASTER_KEY="change-me" \
+  -e VLLM_BASE_URL="http://host.docker.internal:8000/v1" \
+  -e VLLM_TEST_BASE_URL="http://host.docker.internal:8000/v1" \
+  enterpilot/gomodel
+```
+
+This registers providers `vllm` and `vllm-test`. Use YAML only when the
+generated provider names are not enough or you need a larger structured block.

--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -141,8 +141,9 @@ Set these to automatically register providers. No YAML configuration required.
 | `AZURE_API_KEY`      | Azure OpenAI (`AZURE_BASE_URL` also required)     |
 | `ORACLE_API_KEY`     | Oracle (`ORACLE_BASE_URL` also required)          |
 | `OLLAMA_BASE_URL`    | Ollama (no API key needed)                        |
+| `VLLM_BASE_URL`      | vLLM (no API key needed unless upstream requires) |
 
-Most providers can use a custom base URL via `<PROVIDER>_BASE_URL` (for example `OPENAI_BASE_URL`). OpenRouter defaults to `https://openrouter.ai/api/v1` and can be overridden with `OPENROUTER_BASE_URL`. Z.ai defaults to `https://api.z.ai/api/paas/v4`; set `ZAI_BASE_URL=https://api.z.ai/api/coding/paas/v4` for the GLM Coding Plan endpoint. Azure uses `AZURE_BASE_URL` for its deployment base URL and accepts an optional `AZURE_API_VERSION` override; otherwise it defaults to `2024-10-21`. Oracle requires `ORACLE_BASE_URL` because its OpenAI-compatible endpoint is region-specific.
+Most providers can use a custom base URL via `<PROVIDER>_BASE_URL` (for example `OPENAI_BASE_URL`). OpenRouter defaults to `https://openrouter.ai/api/v1` and can be overridden with `OPENROUTER_BASE_URL`. Z.ai defaults to `https://api.z.ai/api/paas/v4`; set `ZAI_BASE_URL=https://api.z.ai/api/coding/paas/v4` for the GLM Coding Plan endpoint. vLLM defaults to `http://localhost:8000/v1` when `VLLM_API_KEY` is set, but keyless deployments should set `VLLM_BASE_URL` explicitly to register the provider. Azure uses `AZURE_BASE_URL` for its deployment base URL and accepts an optional `AZURE_API_VERSION` override; otherwise it defaults to `2024-10-21`. Oracle requires `ORACLE_BASE_URL` because its OpenAI-compatible endpoint is region-specific.
 When using Oracle, set `ORACLE_MODELS` to a comma-separated list such as `openai.gpt-oss-120b,xai.grok-3` if the upstream endpoint does not expose a usable `/models` response. YAML `models:` remains available for custom provider names and multi-provider Oracle setups.
 
 For OpenRouter, GoModel also sends default attribution headers unless the request already sets them. Override those defaults with `OPENROUTER_SITE_URL` and `OPENROUTER_APP_NAME`.
@@ -252,6 +253,8 @@ export ORACLE_API_KEY="..."          # Registers "oracle" provider when paired w
 export ORACLE_BASE_URL="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com/20231130/actions/v1"
 export ORACLE_MODELS="openai.gpt-oss-120b,xai.grok-3" # Optional fallback inventory for Oracle
 export OLLAMA_BASE_URL="http://localhost:11434/v1" # Registers "ollama" provider
+export VLLM_BASE_URL="http://localhost:8000/v1" # Registers keyless "vllm" provider
+# Optional: export VLLM_API_KEY="token-abc123"
 ```
 
 GoModel also works with additional OpenAI-compatible providers out of the box
@@ -284,6 +287,13 @@ providers:
     models:
       - openai.gpt-oss-120b
       - xai.grok-3
+
+  # Add a vLLM OpenAI-compatible server
+  vllm:
+    type: vllm
+    base_url: "http://localhost:8000/v1"
+    # api_key is optional; set it only when vllm serve uses --api-key.
+    # api_key: "token-abc123"
 
   # Restrict to specific models
   gemini:
@@ -320,4 +330,20 @@ providers:
   ollama:
     type: ollama
     base_url: "http://localhost:11434/v1"
+```
+
+### vLLM
+
+vLLM uses its OpenAI-compatible `/v1` API. Set `VLLM_BASE_URL` to register a
+keyless vLLM server:
+
+```bash
+export VLLM_BASE_URL="http://localhost:8000/v1"
+```
+
+If the upstream server was started with `vllm serve ... --api-key token-abc123`,
+also set:
+
+```bash
+export VLLM_API_KEY="token-abc123"
 ```

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -75,6 +75,7 @@
                 "pages": [
                     "guides/openclaw",
                     "guides/oracle",
+                    "guides/vllm",
                     "guides/multiple-ollama",
                     "guides/claude-code",
                     "guides/codex",

--- a/docs/features/passthrough-api.mdx
+++ b/docs/features/passthrough-api.mdx
@@ -130,7 +130,8 @@ from passthrough requests before forwarding them upstream.
 
 Passthrough is intentionally narrow while the API is in beta.
 
-- `openai`, `anthropic`, `openrouter`, and `zai` are enabled by default.
+- `openai`, `anthropic`, `openrouter`, `zai`, and `vllm` are enabled by
+  default.
 - GoModel does not translate passthrough request bodies or response bodies.
 - Provider-native error bodies and status codes are proxied instead of converted
   into OpenAI-compatible responses.
@@ -144,7 +145,7 @@ Passthrough routes are enabled by default:
 ```env
 ENABLE_PASSTHROUGH_ROUTES=true
 ALLOW_PASSTHROUGH_V1_ALIAS=true
-ENABLED_PASSTHROUGH_PROVIDERS=openai,anthropic,openrouter,zai
+ENABLED_PASSTHROUGH_PROVIDERS=openai,anthropic,openrouter,zai,vllm
 ```
 
 Set `ENABLED_PASSTHROUGH_PROVIDERS` to the provider types you want to expose.

--- a/docs/guides/multiple-ollama.mdx
+++ b/docs/guides/multiple-ollama.mdx
@@ -1,46 +1,31 @@
 ---
 title: "GoModel & Ollama"
-description: "Use one GoModel instance with multiple Ollama providers by mounting a YAML config and selecting provider-qualified model IDs."
+description: "Use one GoModel instance with multiple Ollama providers through suffixed environment variables and provider-qualified model IDs."
 icon: "network"
 ---
 
-GoModel can register multiple Ollama providers when each one has its own key in
-the top-level `providers:` map.
+GoModel can register multiple Ollama providers through suffixed environment
+variables.
 
 Flow:
 
 `Client -> GoModel -> ollama-a / ollama-b`
 
-## 1. Create a host-side `config.yml`
-
-```yaml
-providers:
-  ollama-a:
-    type: ollama
-    base_url: "http://host.docker.internal:11434/v1"
-
-  ollama-b:
-    type: ollama
-    base_url: "http://host.docker.internal:11435/v1"
-```
-
-Use different ports or hostnames for each Ollama instance.
-
-## 2. Run GoModel and mount the config
+## 1. Run GoModel with multiple Ollama base URLs
 
 ```bash
 docker run --rm --name gomodel \
   -p 8080:8080 \
   -e GOMODEL_MASTER_KEY="change-me" \
-  -v "$PWD/config.yml:/app/config/config.yaml:ro" \
+  -e OLLAMA_A_BASE_URL="http://host.docker.internal:11434/v1" \
+  -e OLLAMA_B_BASE_URL="http://host.docker.internal:11435/v1" \
   enterpilot/gomodel:latest
 ```
 
-<Note>
-  The file can be named `config.yml` on the host. The important part is the
-  bind mount target: GoModel reads `/app/config/config.yaml` inside the
-  container.
-</Note>
+`OLLAMA_A_BASE_URL` registers provider `ollama-a`. `OLLAMA_B_BASE_URL`
+registers provider `ollama-b`.
+
+Use different ports or hostnames for each Ollama instance.
 
 <Tip>
   On Linux, you may need to add
@@ -48,7 +33,12 @@ docker run --rm --name gomodel \
   Ollama running on the host.
 </Tip>
 
-## 3. Verify the model registry
+<Note>
+  Use YAML only when generated provider names such as `ollama-a` and
+  `ollama-b` are not enough or you need a larger structured provider block.
+</Note>
+
+## 2. Verify the model registry
 
 ```bash
 curl -s http://localhost:8080/v1/models \
@@ -60,7 +50,7 @@ Expected model IDs will be provider-qualified, for example:
 - `ollama-a/llama3.2`
 - `ollama-b/llama3.2`
 
-## 4. Route to a specific Ollama backend
+## 3. Route to a specific Ollama backend
 
 ```bash
 curl -s http://localhost:8080/v1/chat/completions \
@@ -77,10 +67,22 @@ expose it, GoModel will route the request to one provider based on provider
 registration order. To choose a specific Ollama backend, use the qualified form
 such as `ollama-a/llama3.2` or `ollama-b/llama3.2`.
 
-## Validated on April 6, 2026
+## 4. When YAML still makes sense
 
-This guide was validated with:
+Use `config.yaml` when you need custom provider names, per-provider resilience
+overrides, or a larger structured config:
 
-- `enterpilot/gomodel:latest`
-- a bind-mounted host `config.yml`
-- two Ollama-compatible upstream endpoints exposed as separate provider names
+```yaml
+providers:
+  local-fast:
+    type: ollama
+    base_url: "http://ollama-fast:11434/v1"
+
+  local-large:
+    type: ollama
+    base_url: "http://ollama-large:11434/v1"
+```
+
+This pattern relies on the same suffixed env auto-discovery used across GoModel
+providers: `OLLAMA_A_BASE_URL` registers `ollama-a`, and `OLLAMA_B_BASE_URL`
+registers `ollama-b`.

--- a/docs/guides/oracle.mdx
+++ b/docs/guides/oracle.mdx
@@ -52,8 +52,21 @@ export ORACLE_MODELS="openai.gpt-oss-120b,xai.grok-3"
 entry and uses the list as the fallback inventory when Oracle's `/models`
 endpoint is unavailable.
 
-Use a YAML provider block when you want a custom provider name, multiple Oracle
-providers, or prefer to keep the model list in `config.yaml`:
+For multiple Oracle providers without YAML, use suffixed env vars such as
+`ORACLE_US_BASE_URL`, `ORACLE_US_API_KEY`, and `ORACLE_US_MODELS`. For
+example:
+
+```bash
+export ORACLE_US_BASE_URL="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com/20231130/actions/v1"
+export ORACLE_US_API_KEY="..."
+export ORACLE_US_MODELS="openai.gpt-oss-120b"
+```
+
+This registers provider `oracle-us`.
+
+Use a YAML provider block when you want a custom provider name that does not
+fit the generated suffix pattern, per-provider resilience settings, or prefer
+to keep the model list in `config.yaml`:
 
 ```yaml
 providers:

--- a/docs/guides/vllm.mdx
+++ b/docs/guides/vllm.mdx
@@ -30,32 +30,50 @@ vllm serve meta-llama/Llama-3.1-8B-Instruct --api-key token-abc123
 
 ## 1. Configure GoModel
 
-For a single keyless vLLM server, env-only configuration is enough:
+For a single keyless vLLM server, Docker env vars are enough:
 
 ```bash
-export VLLM_BASE_URL="http://localhost:8000/v1"
+docker run --rm -p 8080:8080 \
+  -e GOMODEL_MASTER_KEY="change-me" \
+  -e VLLM_BASE_URL="http://host.docker.internal:8000/v1" \
+  enterpilot/gomodel
 ```
 
 Set `VLLM_API_KEY` only when the upstream vLLM server was started with
 `--api-key`:
 
 ```bash
-export VLLM_API_KEY="token-abc123"
+docker run --rm -p 8080:8080 \
+  -e GOMODEL_MASTER_KEY="change-me" \
+  -e VLLM_BASE_URL="http://host.docker.internal:8000/v1" \
+  -e VLLM_API_KEY="token-abc123" \
+  enterpilot/gomodel
 ```
 
-Use YAML when you want multiple vLLM backends or custom provider names:
+Use suffixed env vars when you want more than one vLLM instance without YAML:
 
-```yaml
-providers:
-  qwen-vllm:
-    type: vllm
-    base_url: "http://qwen-vllm:8000/v1"
-
-  llama-vllm:
-    type: vllm
-    base_url: "http://llama-vllm:8000/v1"
-    api_key: "${VLLM_API_KEY}"
+```bash
+docker run --rm -p 8080:8080 \
+  -e GOMODEL_MASTER_KEY="change-me" \
+  -e VLLM_BASE_URL="http://host.docker.internal:8000/v1" \
+  -e VLLM_TEST_BASE_URL="http://host.docker.internal:8000/v1" \
+  enterpilot/gomodel
 ```
+
+`VLLM_BASE_URL` registers provider `vllm`. `VLLM_TEST_BASE_URL` registers
+provider `vllm-test`. The suffix is normalized to lowercase and underscores
+become hyphens.
+
+Use YAML only when generated names such as `vllm-test` are not enough or you
+need larger structured provider blocks.
+
+<Note>
+  These examples assume GoModel runs in Docker and your vLLM server is reachable
+  from the host at `localhost:8000`, so GoModel uses
+  `host.docker.internal:8000` to reach it. If both services run in the same
+  Docker network, replace `host.docker.internal` with the vLLM service name.
+  If GoModel runs directly on the host, use `http://localhost:8000/v1`.
+</Note>
 
 ## 2. Verify the model registry
 
@@ -65,15 +83,15 @@ curl -s http://localhost:8080/v1/models \
 ```
 
 GoModel uses the model IDs returned by vLLM's `/models` endpoint. Hugging Face
-model IDs can contain slashes. With a provider named `llama-vllm`, a vLLM model
+model IDs can contain slashes. With a provider named `vllm-test`, a vLLM model
 such as `meta-llama/Llama-3.1-8B-Instruct` is exposed through GoModel as:
 
 ```text
-llama-vllm/meta-llama/Llama-3.1-8B-Instruct
+vllm-test/meta-llama/Llama-3.1-8B-Instruct
 ```
 
 GoModel splits provider-qualified selectors on the first slash only, so
-`llama-vllm` is the provider and `meta-llama/Llama-3.1-8B-Instruct` remains the
+`vllm-test` is the provider and `meta-llama/Llama-3.1-8B-Instruct` remains the
 upstream model ID.
 
 ## 3. Send a chat request
@@ -83,7 +101,7 @@ curl -s http://localhost:8080/v1/chat/completions \
   -H "Authorization: Bearer change-me" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "llama-vllm/meta-llama/Llama-3.1-8B-Instruct",
+    "model": "vllm-test/meta-llama/Llama-3.1-8B-Instruct",
     "messages": [{"role": "user", "content": "Reply with exactly ok."}]
   }'
 ```
@@ -105,6 +123,13 @@ curl -s http://localhost:8080/p/vllm/tokenize \
 
 GoModel handles gateway authentication, strips client auth headers before
 forwarding, and applies `VLLM_API_KEY` to upstream requests when configured.
+
+<Note>
+  Passthrough routes are provider-type scoped at `/p/vllm/...`. When you need
+  to target one named vLLM instance in a multi-provider setup, use translated
+  `/v1/...` requests with provider-qualified model IDs such as
+  `vllm-test/meta-llama/Llama-3.1-8B-Instruct`.
+</Note>
 
 ## Current support
 

--- a/docs/guides/vllm.mdx
+++ b/docs/guides/vllm.mdx
@@ -1,0 +1,124 @@
+---
+title: "GoModel & vLLM"
+description: "Route OpenAI-compatible GoModel requests to one or more vLLM servers, including slash-shaped Hugging Face model IDs."
+icon: "server"
+---
+
+GoModel can use vLLM through vLLM's OpenAI-compatible HTTP server.
+
+Flow:
+
+`Client -> GoModel -> vLLM`
+
+## Before you start
+
+- Start vLLM with its OpenAI-compatible server.
+- Note the vLLM base URL, including `/v1`.
+- Decide whether vLLM should require an upstream API key.
+
+For a local vLLM server:
+
+```bash
+vllm serve meta-llama/Llama-3.1-8B-Instruct
+```
+
+If you want vLLM itself to require bearer auth:
+
+```bash
+vllm serve meta-llama/Llama-3.1-8B-Instruct --api-key token-abc123
+```
+
+## 1. Configure GoModel
+
+For a single keyless vLLM server, env-only configuration is enough:
+
+```bash
+export VLLM_BASE_URL="http://localhost:8000/v1"
+```
+
+Set `VLLM_API_KEY` only when the upstream vLLM server was started with
+`--api-key`:
+
+```bash
+export VLLM_API_KEY="token-abc123"
+```
+
+Use YAML when you want multiple vLLM backends or custom provider names:
+
+```yaml
+providers:
+  qwen-vllm:
+    type: vllm
+    base_url: "http://qwen-vllm:8000/v1"
+
+  llama-vllm:
+    type: vllm
+    base_url: "http://llama-vllm:8000/v1"
+    api_key: "${VLLM_API_KEY}"
+```
+
+## 2. Verify the model registry
+
+```bash
+curl -s http://localhost:8080/v1/models \
+  -H "Authorization: Bearer change-me"
+```
+
+GoModel uses the model IDs returned by vLLM's `/models` endpoint. Hugging Face
+model IDs can contain slashes. With a provider named `llama-vllm`, a vLLM model
+such as `meta-llama/Llama-3.1-8B-Instruct` is exposed through GoModel as:
+
+```text
+llama-vllm/meta-llama/Llama-3.1-8B-Instruct
+```
+
+GoModel splits provider-qualified selectors on the first slash only, so
+`llama-vllm` is the provider and `meta-llama/Llama-3.1-8B-Instruct` remains the
+upstream model ID.
+
+## 3. Send a chat request
+
+```bash
+curl -s http://localhost:8080/v1/chat/completions \
+  -H "Authorization: Bearer change-me" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "llama-vllm/meta-llama/Llama-3.1-8B-Instruct",
+    "messages": [{"role": "user", "content": "Reply with exactly ok."}]
+  }'
+```
+
+## 4. Use vLLM passthrough
+
+vLLM passthrough is enabled by default. Use it for vLLM-specific endpoints such
+as `/tokenize`, `/detokenize`, `/pooling`, and `/rerank`:
+
+```bash
+curl -s http://localhost:8080/p/vllm/tokenize \
+  -H "Authorization: Bearer change-me" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "meta-llama/Llama-3.1-8B-Instruct",
+    "prompt": "Hello"
+  }'
+```
+
+GoModel handles gateway authentication, strips client auth headers before
+forwarding, and applies `VLLM_API_KEY` to upstream requests when configured.
+
+## Current support
+
+Integrated:
+
+- chat completions
+- streaming chat completions
+- Responses API
+- streaming Responses API
+- embeddings
+- provider-native passthrough
+
+Not exposed as first-class GoModel capabilities yet:
+
+- native vLLM batch APIs
+- OpenAI-compatible files lifecycle
+- Responses lifecycle utility endpoints

--- a/helm/README.md
+++ b/helm/README.md
@@ -63,6 +63,8 @@ helm install gomodel ./helm \
 | `providers.zai.baseUrl`          | Optional Z.ai base URL mapped to `ZAI_BASE_URL`; use Coding Plan endpoint when needed          | `""`                   |
 | `providers.oracle.enabled`       | Enable Oracle                                                                                  | `false`                |
 | `providers.oracle.baseUrl`       | Oracle OpenAI-compatible base URL mapped to `ORACLE_BASE_URL`; required when Oracle is enabled | `""`                   |
+| `providers.vllm.enabled`         | Enable vLLM                                                                                    | `false`                |
+| `providers.vllm.baseUrl`         | vLLM OpenAI-compatible base URL mapped to `VLLM_BASE_URL`; required when vLLM is enabled       | `""`                   |
 | `cache.type`                     | Cache type (local/redis)                                                                       | `"redis"`              |
 | `redis.enabled`                  | Deploy Redis subchart                                                                          | `true`                 |
 | `metrics.enabled`                | Enable Prometheus metrics                                                                      | `true`                 |
@@ -88,10 +90,15 @@ stringData:
   GEMINI_API_KEY: "..."
   ZAI_API_KEY: "..."
   ORACLE_API_KEY: "..."
+  VLLM_API_KEY: "..."
 ```
 
 Oracle also requires a base URL in values. The chart maps `providers.oracle.baseUrl`
 to the container env var `ORACLE_BASE_URL`.
+
+vLLM does not require an API key unless the upstream server was started with
+`--api-key`. The chart maps `providers.vllm.baseUrl` to the container env var
+`VLLM_BASE_URL`.
 
 Then reference it (use `enabled=true` when using existingSecret since apiKey isn't set directly):
 
@@ -108,6 +115,14 @@ helm install gomodel ./helm \
   --set providers.existingSecret="llm-api-keys" \
   --set providers.oracle.enabled=true \
   --set providers.oracle.baseUrl="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com/20231130/actions/v1"
+```
+
+Example keyless vLLM setup:
+
+```bash
+helm install gomodel ./helm \
+  --set providers.vllm.enabled=true \
+  --set providers.vllm.baseUrl="http://vllm.default.svc.cluster.local:8000/v1"
 ```
 
 ### Ingress Example

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -112,12 +112,15 @@ Generate provider environment variables for the Deployment.
 {{- if kindIs "map" $config }}
 {{- $hasAPIKey := and (hasKey $config "apiKey") $config.apiKey }}
 {{- $enabledWithExistingSecret := and $.Values.providers.existingSecret (hasKey $config "enabled") $config.enabled }}
+{{- $enabledWithBaseURL := and (hasKey $config "enabled") $config.enabled $config.baseUrl }}
 {{- if or $hasAPIKey $enabledWithExistingSecret }}
 - name: {{ upper $name }}_API_KEY
   valueFrom:
     secretKeyRef:
       name: {{ $secretName }}
       key: {{ upper $name }}_API_KEY
+{{- end }}
+{{- if or (or $hasAPIKey $enabledWithExistingSecret) $enabledWithBaseURL }}
 {{- if $config.baseUrl }}
 - name: {{ upper $name }}_BASE_URL
   value: {{ $config.baseUrl | quote }}

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -82,6 +82,33 @@
           }
         }
       }
+    },
+    {
+      "if": {
+        "properties": {
+          "providers": {
+            "properties": {
+              "vllm": {
+                "properties": { "enabled": { "const": true } }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "providers": {
+            "properties": {
+              "vllm": {
+                "properties": {
+                  "baseUrl": { "minLength": 1 }
+                },
+                "required": ["baseUrl"]
+              }
+            }
+          }
+        }
+      }
     }
   ],
   "anyOf": [
@@ -171,6 +198,20 @@
           }
         }
       }
+    },
+    {
+      "properties": {
+        "providers": {
+          "properties": {
+            "vllm": {
+              "properties": {
+                "enabled": { "const": true },
+                "baseUrl": { "minLength": 1 }
+              }
+            }
+          }
+        }
+      }
     }
   ],
   "properties": {
@@ -242,6 +283,14 @@
           }
         },
         "oracle": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "apiKey": { "type": "string" },
+            "baseUrl": { "type": "string" }
+          }
+        },
+        "vllm": {
           "type": "object",
           "properties": {
             "enabled": { "type": "boolean" },

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -38,7 +38,7 @@ auth:
 # LLM Provider configuration
 providers:
   # -- Use an existing secret for all provider API keys
-  # Secret should contain keys: OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, GROQ_API_KEY, XAI_API_KEY, ZAI_API_KEY, ORACLE_API_KEY
+  # Secret should contain keys: OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, GROQ_API_KEY, XAI_API_KEY, ZAI_API_KEY, ORACLE_API_KEY, VLLM_API_KEY
   existingSecret: ""
 
   openai:
@@ -95,6 +95,14 @@ providers:
     # -- Oracle API key (ignored if providers.existingSecret is set)
     apiKey: ""
     # -- Required: Oracle OpenAI-compatible base URL
+    baseUrl: ""
+
+  vllm:
+    # -- Enable vLLM provider (API key optional; baseUrl required when enabled)
+    enabled: false
+    # -- Optional vLLM API key, matching vllm serve --api-key when configured
+    apiKey: ""
+    # -- vLLM OpenAI-compatible base URL
     baseUrl: ""
 
 # Cache configuration

--- a/internal/providers/config.go
+++ b/internal/providers/config.go
@@ -44,7 +44,10 @@ func applyProviderEnvVars(raw map[string]config.RawProviderConfig, discovery map
 
 		apiKey := os.Getenv(envNames.APIKey)
 		explicitBaseURL := normalizeResolvedBaseURL(os.Getenv(envNames.BaseURL))
-		models := parseCSVEnvList(os.Getenv(envNames.Models))
+		var models []string
+		if spec.SupportsModelsEnv {
+			models = parseCSVEnvList(os.Getenv(envNames.Models))
+		}
 		apiVersion := ""
 		if spec.SupportsAPIVersion {
 			apiVersion = os.Getenv(envNames.APIVersion)

--- a/internal/providers/config_test.go
+++ b/internal/providers/config_test.go
@@ -354,6 +354,35 @@ func TestApplyProviderEnvVars_DiscoversFromBaseURL(t *testing.T) {
 	}
 }
 
+func TestApplyProviderEnvVars_DiscoversMultipleSuffixedOllamaProvidersFromBaseURLs(t *testing.T) {
+	t.Setenv("OLLAMA_A_BASE_URL", "http://localhost:11434/v1")
+	t.Setenv("OLLAMA_B_BASE_URL", "http://localhost:11435/v1")
+
+	got := applyProviderEnvVars(map[string]config.RawProviderConfig{}, testDiscoveryConfigs)
+
+	providerA, exists := got["ollama-a"]
+	if !exists {
+		t.Fatal("expected ollama-a to be discovered from OLLAMA_A_BASE_URL")
+	}
+	if providerA.Type != "ollama" {
+		t.Fatalf("ollama-a Type = %q, want ollama", providerA.Type)
+	}
+	if providerA.BaseURL != "http://localhost:11434/v1" {
+		t.Fatalf("ollama-a BaseURL = %q, want http://localhost:11434/v1", providerA.BaseURL)
+	}
+
+	providerB, exists := got["ollama-b"]
+	if !exists {
+		t.Fatal("expected ollama-b to be discovered from OLLAMA_B_BASE_URL")
+	}
+	if providerB.Type != "ollama" {
+		t.Fatalf("ollama-b Type = %q, want ollama", providerB.Type)
+	}
+	if providerB.BaseURL != "http://localhost:11435/v1" {
+		t.Fatalf("ollama-b BaseURL = %q, want http://localhost:11435/v1", providerB.BaseURL)
+	}
+}
+
 func TestApplyProviderEnvVars_DiscoversOpenRouterFromAPIKey(t *testing.T) {
 	t.Setenv("OPENROUTER_API_KEY", "sk-openrouter")
 
@@ -433,6 +462,35 @@ func TestApplyProviderEnvVars_DiscoversVLLMFromBaseURLWithoutAPIKey(t *testing.T
 	}
 	if p.BaseURL != "http://localhost:8000/v1" {
 		t.Errorf("BaseURL = %q, want http://localhost:8000/v1", p.BaseURL)
+	}
+}
+
+func TestApplyProviderEnvVars_DiscoversUnsuffixedAndSuffixedVLLMProvidersFromBaseURLs(t *testing.T) {
+	t.Setenv("VLLM_BASE_URL", "http://localhost:8000/v1")
+	t.Setenv("VLLM_TEST_BASE_URL", "http://localhost:8000/v1")
+
+	got := applyProviderEnvVars(map[string]config.RawProviderConfig{}, testDiscoveryConfigs)
+
+	primary, exists := got["vllm"]
+	if !exists {
+		t.Fatal("expected vllm to be discovered from VLLM_BASE_URL")
+	}
+	if primary.Type != "vllm" {
+		t.Fatalf("vllm Type = %q, want vllm", primary.Type)
+	}
+	if primary.BaseURL != "http://localhost:8000/v1" {
+		t.Fatalf("vllm BaseURL = %q, want http://localhost:8000/v1", primary.BaseURL)
+	}
+
+	suffixed, exists := got["vllm-test"]
+	if !exists {
+		t.Fatal("expected vllm-test to be discovered from VLLM_TEST_BASE_URL")
+	}
+	if suffixed.Type != "vllm" {
+		t.Fatalf("vllm-test Type = %q, want vllm", suffixed.Type)
+	}
+	if suffixed.BaseURL != "http://localhost:8000/v1" {
+		t.Fatalf("vllm-test BaseURL = %q, want http://localhost:8000/v1", suffixed.BaseURL)
 	}
 }
 

--- a/internal/providers/config_test.go
+++ b/internal/providers/config_test.go
@@ -39,12 +39,17 @@ var testDiscoveryConfigs = map[string]DiscoveryConfig{
 	"zai": {
 		DefaultBaseURL: "https://api.z.ai/api/paas/v4",
 	},
+	"vllm": {
+		DefaultBaseURL:  "http://localhost:8000/v1",
+		AllowAPIKeyless: true,
+	},
 	"azure": {
 		RequireBaseURL:     true,
 		SupportsAPIVersion: true,
 	},
 	"oracle": {
-		RequireBaseURL: true,
+		RequireBaseURL:    true,
+		SupportsModelsEnv: true,
 	},
 	"ollama": {
 		DefaultBaseURL:  "http://localhost:11434/v1",
@@ -276,6 +281,15 @@ func TestFilterEmptyProviders_OllamaAlwaysKept(t *testing.T) {
 	}
 }
 
+func TestFilterEmptyProviders_VLLMAllowsKeylessConfig(t *testing.T) {
+	got := filterEmptyProviders(map[string]config.RawProviderConfig{
+		"vllm": {Type: "vllm", BaseURL: "http://localhost:8000/v1"},
+	}, testDiscoveryConfigs)
+	if _, exists := got["vllm"]; !exists {
+		t.Fatal("expected vllm to be kept without an API key")
+	}
+}
+
 func TestFilterEmptyProviders_EmptyMap(t *testing.T) {
 	got := filterEmptyProviders(map[string]config.RawProviderConfig{}, testDiscoveryConfigs)
 	if len(got) != 0 {
@@ -399,6 +413,53 @@ func TestApplyProviderEnvVars_DiscoversZAIWithExplicitBaseURL(t *testing.T) {
 	}
 	if p.BaseURL != explicitBaseURL {
 		t.Errorf("BaseURL = %q, want %q", p.BaseURL, explicitBaseURL)
+	}
+}
+
+func TestApplyProviderEnvVars_DiscoversVLLMFromBaseURLWithoutAPIKey(t *testing.T) {
+	t.Setenv("VLLM_BASE_URL", "http://localhost:8000/v1")
+
+	got := applyProviderEnvVars(map[string]config.RawProviderConfig{}, testDiscoveryConfigs)
+
+	p, exists := got["vllm"]
+	if !exists {
+		t.Fatal("expected vllm to be discovered from base URL env var")
+	}
+	if p.APIKey != "" {
+		t.Errorf("APIKey = %q, want empty", p.APIKey)
+	}
+	if p.Type != "vllm" {
+		t.Errorf("Type = %q, want vllm", p.Type)
+	}
+	if p.BaseURL != "http://localhost:8000/v1" {
+		t.Errorf("BaseURL = %q, want http://localhost:8000/v1", p.BaseURL)
+	}
+}
+
+func TestApplyProviderEnvVars_DiscoversVLLMFromAPIKeyWithDefaultBaseURL(t *testing.T) {
+	t.Setenv("VLLM_API_KEY", "vllm-key")
+
+	got := applyProviderEnvVars(map[string]config.RawProviderConfig{}, testDiscoveryConfigs)
+
+	p, exists := got["vllm"]
+	if !exists {
+		t.Fatal("expected vllm to be discovered from API key env var")
+	}
+	if p.APIKey != "vllm-key" {
+		t.Errorf("APIKey = %q, want vllm-key", p.APIKey)
+	}
+	if p.BaseURL != testDiscoveryConfigs["vllm"].DefaultBaseURL {
+		t.Errorf("BaseURL = %q, want %q", p.BaseURL, testDiscoveryConfigs["vllm"].DefaultBaseURL)
+	}
+}
+
+func TestApplyProviderEnvVars_IgnoresVLLMModelsEnv(t *testing.T) {
+	t.Setenv("VLLM_MODELS", "meta-llama/Llama-3.1-8B-Instruct")
+
+	got := applyProviderEnvVars(map[string]config.RawProviderConfig{}, testDiscoveryConfigs)
+
+	if _, exists := got["vllm"]; exists {
+		t.Fatal("expected VLLM_MODELS not to discover vllm provider")
 	}
 }
 

--- a/internal/providers/factory.go
+++ b/internal/providers/factory.go
@@ -28,6 +28,7 @@ type DiscoveryConfig struct {
 	RequireBaseURL     bool
 	AllowAPIKeyless    bool
 	SupportsAPIVersion bool
+	SupportsModelsEnv  bool
 }
 
 // Registration contains metadata for registering a provider with the factory.

--- a/internal/providers/oracle/oracle.go
+++ b/internal/providers/oracle/oracle.go
@@ -19,7 +19,8 @@ var Registration = providers.Registration{
 	Type: "oracle",
 	New:  New,
 	Discovery: providers.DiscoveryConfig{
-		RequireBaseURL: true,
+		RequireBaseURL:    true,
+		SupportsModelsEnv: true,
 	},
 }
 

--- a/internal/providers/vllm/passthrough_semantics.go
+++ b/internal/providers/vllm/passthrough_semantics.go
@@ -1,0 +1,41 @@
+package vllm
+
+import (
+	"strings"
+
+	"gomodel/internal/core"
+	"gomodel/internal/providers"
+)
+
+type passthroughSemanticEnricher struct{}
+
+func (passthroughSemanticEnricher) ProviderType() string {
+	return "vllm"
+}
+
+func (passthroughSemanticEnricher) Enrich(_ *core.RequestSnapshot, _ *core.WhiteBoxPrompt, info *core.PassthroughRouteInfo) *core.PassthroughRouteInfo {
+	if info == nil {
+		return nil
+	}
+	enriched := *info
+	normalizedEndpoint := strings.TrimLeft(strings.TrimSpace(providers.PassthroughEndpointPath(&enriched)), "/")
+	switch "/" + normalizedEndpoint {
+	case "/chat/completions":
+		enriched.SemanticOperation = "vllm.chat_completions"
+		enriched.AuditPath = "/v1/chat/completions"
+	case "/responses":
+		enriched.SemanticOperation = "vllm.responses"
+		enriched.AuditPath = "/v1/responses"
+	case "/embeddings":
+		enriched.SemanticOperation = "vllm.embeddings"
+		enriched.AuditPath = "/v1/embeddings"
+	case "/completions":
+		enriched.SemanticOperation = "vllm.completions"
+		enriched.AuditPath = "/v1/completions"
+	default:
+		if strings.TrimSpace(enriched.AuditPath) == "" && normalizedEndpoint != "" {
+			enriched.AuditPath = "/p/vllm/" + normalizedEndpoint
+		}
+	}
+	return &enriched
+}

--- a/internal/providers/vllm/vllm.go
+++ b/internal/providers/vllm/vllm.go
@@ -1,0 +1,105 @@
+// Package vllm provides vLLM OpenAI-compatible API integration for the LLM gateway.
+package vllm
+
+import (
+	"context"
+	"io"
+	"net/http"
+
+	"gomodel/internal/core"
+	"gomodel/internal/llmclient"
+	"gomodel/internal/providers"
+	"gomodel/internal/providers/openai"
+)
+
+const defaultBaseURL = "http://localhost:8000/v1"
+
+// Registration provides factory registration for the vLLM provider.
+var Registration = providers.Registration{
+	Type:                        "vllm",
+	New:                         New,
+	PassthroughSemanticEnricher: passthroughSemanticEnricher{},
+	Discovery: providers.DiscoveryConfig{
+		DefaultBaseURL:  defaultBaseURL,
+		AllowAPIKeyless: true,
+	},
+}
+
+// Provider implements the core.Provider interface for vLLM.
+type Provider struct {
+	compatible *openai.CompatibleProvider
+}
+
+// New creates a new vLLM provider.
+func New(cfg providers.ProviderConfig, opts providers.ProviderOptions) core.Provider {
+	baseURL := providers.ResolveBaseURL(cfg.BaseURL, defaultBaseURL)
+	return &Provider{
+		compatible: openai.NewCompatibleProvider(cfg.APIKey, opts, openai.CompatibleProviderConfig{
+			ProviderName: "vllm",
+			BaseURL:      baseURL,
+			SetHeaders:   setHeaders,
+		}),
+	}
+}
+
+// NewWithHTTPClient creates a new vLLM provider with a custom HTTP client.
+// If httpClient is nil, http.DefaultClient is used.
+func NewWithHTTPClient(apiKey string, baseURL string, httpClient *http.Client, hooks llmclient.Hooks) *Provider {
+	resolvedBaseURL := providers.ResolveBaseURL(baseURL, defaultBaseURL)
+	return &Provider{
+		compatible: openai.NewCompatibleProviderWithHTTPClient(apiKey, httpClient, hooks, openai.CompatibleProviderConfig{
+			ProviderName: "vllm",
+			BaseURL:      resolvedBaseURL,
+			SetHeaders:   setHeaders,
+		}),
+	}
+}
+
+// SetBaseURL allows configuring a custom base URL for the provider.
+func (p *Provider) SetBaseURL(url string) {
+	p.compatible.SetBaseURL(url)
+}
+
+func setHeaders(req *http.Request, apiKey string) {
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	if requestID := core.GetRequestID(req.Context()); requestID != "" {
+		req.Header.Set("X-Request-Id", requestID)
+	}
+}
+
+// ChatCompletion sends a chat completion request to vLLM.
+func (p *Provider) ChatCompletion(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+	return p.compatible.ChatCompletion(ctx, req)
+}
+
+// StreamChatCompletion returns a raw response body for streaming.
+func (p *Provider) StreamChatCompletion(ctx context.Context, req *core.ChatRequest) (io.ReadCloser, error) {
+	return p.compatible.StreamChatCompletion(ctx, req)
+}
+
+// ListModels retrieves the list of available models from vLLM.
+func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error) {
+	return p.compatible.ListModels(ctx)
+}
+
+// Responses sends a Responses API request to vLLM.
+func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
+	return p.compatible.Responses(ctx, req)
+}
+
+// StreamResponses streams a Responses API request to vLLM.
+func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
+	return p.compatible.StreamResponses(ctx, req)
+}
+
+// Embeddings sends an embeddings request to vLLM.
+func (p *Provider) Embeddings(ctx context.Context, req *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	return p.compatible.Embeddings(ctx, req)
+}
+
+// Passthrough routes an opaque provider-native request to vLLM.
+func (p *Provider) Passthrough(ctx context.Context, req *core.PassthroughRequest) (*core.PassthroughResponse, error) {
+	return p.compatible.Passthrough(ctx, req)
+}

--- a/internal/providers/vllm/vllm.go
+++ b/internal/providers/vllm/vllm.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"strings"
 
 	"gomodel/internal/core"
 	"gomodel/internal/llmclient"
@@ -28,16 +29,27 @@ var Registration = providers.Registration{
 // Provider implements the core.Provider interface for vLLM.
 type Provider struct {
 	compatible *openai.CompatibleProvider
+	rootClient *llmclient.Client
 }
 
 // New creates a new vLLM provider.
 func New(cfg providers.ProviderConfig, opts providers.ProviderOptions) core.Provider {
 	baseURL := providers.ResolveBaseURL(cfg.BaseURL, defaultBaseURL)
+	rootBaseURL := passthroughBaseURL(baseURL)
 	return &Provider{
 		compatible: openai.NewCompatibleProvider(cfg.APIKey, opts, openai.CompatibleProviderConfig{
 			ProviderName: "vllm",
 			BaseURL:      baseURL,
 			SetHeaders:   setHeaders,
+		}),
+		rootClient: llmclient.New(llmclient.Config{
+			ProviderName:   "vllm",
+			BaseURL:        rootBaseURL,
+			Retry:          opts.Resilience.Retry,
+			Hooks:          opts.Hooks,
+			CircuitBreaker: opts.Resilience.CircuitBreaker,
+		}, func(req *http.Request) {
+			setHeaders(req, cfg.APIKey)
 		}),
 	}
 }
@@ -46,11 +58,16 @@ func New(cfg providers.ProviderConfig, opts providers.ProviderOptions) core.Prov
 // If httpClient is nil, http.DefaultClient is used.
 func NewWithHTTPClient(apiKey string, baseURL string, httpClient *http.Client, hooks llmclient.Hooks) *Provider {
 	resolvedBaseURL := providers.ResolveBaseURL(baseURL, defaultBaseURL)
+	rootClientCfg := llmclient.DefaultConfig("vllm", passthroughBaseURL(resolvedBaseURL))
+	rootClientCfg.Hooks = hooks
 	return &Provider{
 		compatible: openai.NewCompatibleProviderWithHTTPClient(apiKey, httpClient, hooks, openai.CompatibleProviderConfig{
 			ProviderName: "vllm",
 			BaseURL:      resolvedBaseURL,
 			SetHeaders:   setHeaders,
+		}),
+		rootClient: llmclient.NewWithHTTPClient(httpClient, rootClientCfg, func(req *http.Request) {
+			setHeaders(req, apiKey)
 		}),
 	}
 }
@@ -58,6 +75,7 @@ func NewWithHTTPClient(apiKey string, baseURL string, httpClient *http.Client, h
 // SetBaseURL allows configuring a custom base URL for the provider.
 func (p *Provider) SetBaseURL(url string) {
 	p.compatible.SetBaseURL(url)
+	p.rootClient.SetBaseURL(passthroughBaseURL(url))
 }
 
 func setHeaders(req *http.Request, apiKey string) {
@@ -101,5 +119,58 @@ func (p *Provider) Embeddings(ctx context.Context, req *core.EmbeddingRequest) (
 
 // Passthrough routes an opaque provider-native request to vLLM.
 func (p *Provider) Passthrough(ctx context.Context, req *core.PassthroughRequest) (*core.PassthroughResponse, error) {
+	if req == nil {
+		return nil, core.NewInvalidRequestError("passthrough request is required", nil)
+	}
+	endpoint := providers.PassthroughEndpoint(req.Endpoint)
+	if !usesV1PassthroughBase(endpoint) {
+		resp, err := p.rootClient.DoPassthrough(ctx, llmclient.Request{
+			Method:        req.Method,
+			Endpoint:      endpoint,
+			RawBodyReader: req.Body,
+			Headers:       req.Headers,
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &core.PassthroughResponse{
+			StatusCode: resp.StatusCode,
+			Headers:    providers.CloneHTTPHeaders(resp.Header),
+			Body:       resp.Body,
+		}, nil
+	}
 	return p.compatible.Passthrough(ctx, req)
+}
+
+func passthroughBaseURL(baseURL string) string {
+	trimmed := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if strings.HasSuffix(trimmed, "/v1") {
+		return strings.TrimSuffix(trimmed, "/v1")
+	}
+	return trimmed
+}
+
+func usesV1PassthroughBase(endpoint string) bool {
+	endpoint = providers.PassthroughEndpoint(endpoint)
+	if strings.HasPrefix(endpoint, "/v1/") {
+		return false
+	}
+
+	v1Prefixes := []string{
+		"/models",
+		"/chat/completions",
+		"/responses",
+		"/completions",
+		"/embeddings",
+		"/messages",
+		"/audio",
+		"/files",
+		"/batches",
+	}
+	for _, prefix := range v1Prefixes {
+		if endpoint == prefix || strings.HasPrefix(endpoint, prefix+"/") {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/providers/vllm/vllm_test.go
+++ b/internal/providers/vllm/vllm_test.go
@@ -1,0 +1,147 @@
+package vllm
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"gomodel/internal/core"
+	"gomodel/internal/llmclient"
+)
+
+func TestChatCompletion_UsesOptionalBearerAuthAndChatEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		apiKey   string
+		wantAuth string
+	}{
+		{name: "with api key", apiKey: "vllm-key", wantAuth: "Bearer vllm-key"},
+		{name: "without api key"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPath string
+			var gotAuth string
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				gotAuth = r.Header.Get("Authorization")
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{
+					"id":"chatcmpl-vllm",
+					"created":1677652288,
+					"model":"meta-llama/Llama-3.1-8B-Instruct",
+					"choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}]
+				}`))
+			}))
+			defer server.Close()
+
+			provider := NewWithHTTPClient(tt.apiKey, server.URL, server.Client(), llmclient.Hooks{})
+
+			resp, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{
+				Model: "meta-llama/Llama-3.1-8B-Instruct",
+				Messages: []core.Message{
+					{Role: "user", Content: "hi"},
+				},
+			})
+			if err != nil {
+				t.Fatalf("ChatCompletion() error = %v", err)
+			}
+			if resp.Model != "meta-llama/Llama-3.1-8B-Instruct" {
+				t.Fatalf("resp.Model = %q, want meta-llama/Llama-3.1-8B-Instruct", resp.Model)
+			}
+			if gotPath != "/chat/completions" {
+				t.Fatalf("path = %q, want /chat/completions", gotPath)
+			}
+			if gotAuth != tt.wantAuth {
+				t.Fatalf("authorization = %q, want %q", gotAuth, tt.wantAuth)
+			}
+		})
+	}
+}
+
+func TestEmbeddings_DelegatesToCompatibleProvider(t *testing.T) {
+	var gotPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"object":"list",
+			"model":"BAAI/bge-small-en-v1.5",
+			"data":[{"object":"embedding","embedding":[0.1,0.2],"index":0}],
+			"usage":{"prompt_tokens":3,"total_tokens":3}
+		}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("", server.URL, server.Client(), llmclient.Hooks{})
+
+	resp, err := provider.Embeddings(context.Background(), &core.EmbeddingRequest{
+		Model: "BAAI/bge-small-en-v1.5",
+		Input: "hello",
+	})
+	if err != nil {
+		t.Fatalf("Embeddings() error = %v", err)
+	}
+	if resp.Model != "BAAI/bge-small-en-v1.5" {
+		t.Fatalf("resp.Model = %q, want BAAI/bge-small-en-v1.5", resp.Model)
+	}
+	if gotPath != "/embeddings" {
+		t.Fatalf("path = %q, want /embeddings", gotPath)
+	}
+}
+
+func TestProvider_ExposesPassthroughButNotOptionalNativeInterfaces(t *testing.T) {
+	provider := NewWithHTTPClient("", "", nil, llmclient.Hooks{})
+
+	if _, ok := any(provider).(core.PassthroughProvider); !ok {
+		t.Fatal("vllm provider should implement passthrough provider")
+	}
+	if _, ok := any(provider).(core.NativeBatchProvider); ok {
+		t.Fatal("vllm provider should not implement native batch provider")
+	}
+	if _, ok := any(provider).(core.NativeFileProvider); ok {
+		t.Fatal("vllm provider should not implement native file provider")
+	}
+	if _, ok := any(provider).(core.NativeResponseLifecycleProvider); ok {
+		t.Fatal("vllm provider should not implement native response lifecycle provider")
+	}
+}
+
+func TestPassthrough_ForwardsProviderNativeEndpoint(t *testing.T) {
+	var gotPath string
+	var gotAuth string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tokens":[1,2,3]}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("vllm-key", server.URL, server.Client(), llmclient.Hooks{})
+
+	resp, err := provider.Passthrough(context.Background(), &core.PassthroughRequest{
+		Method:   http.MethodPost,
+		Endpoint: "tokenize",
+		Body:     io.NopCloser(strings.NewReader("{}")),
+		Headers:  http.Header{"Content-Type": []string{"application/json"}},
+	})
+	if err != nil {
+		t.Fatalf("Passthrough() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if gotPath != "/tokenize" {
+		t.Fatalf("path = %q, want /tokenize", gotPath)
+	}
+	if gotAuth != "Bearer vllm-key" {
+		t.Fatalf("authorization = %q, want Bearer vllm-key", gotAuth)
+	}
+}

--- a/internal/providers/vllm/vllm_test.go
+++ b/internal/providers/vllm/vllm_test.go
@@ -145,3 +145,67 @@ func TestPassthrough_ForwardsProviderNativeEndpoint(t *testing.T) {
 		t.Fatalf("authorization = %q, want Bearer vllm-key", gotAuth)
 	}
 }
+
+func TestPassthrough_UsesRootForNativeEndpointsWhenBaseURLIncludesV1(t *testing.T) {
+	var gotPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tokens":[1,2,3]}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("", server.URL+"/v1", server.Client(), llmclient.Hooks{})
+
+	resp, err := provider.Passthrough(context.Background(), &core.PassthroughRequest{
+		Method:   http.MethodPost,
+		Endpoint: "tokenize",
+		Body:     io.NopCloser(strings.NewReader("{}")),
+		Headers:  http.Header{"Content-Type": []string{"application/json"}},
+	})
+	if err != nil {
+		t.Fatalf("Passthrough() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if gotPath != "/tokenize" {
+		t.Fatalf("path = %q, want /tokenize", gotPath)
+	}
+}
+
+func TestPassthrough_UsesV1ForOpenAICompatibleEndpointsWhenBaseURLIncludesV1(t *testing.T) {
+	var gotPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-vllm",
+			"created":1677652288,
+			"model":"Qwen/Qwen2.5-0.5B-Instruct",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]
+		}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("", server.URL+"/v1", server.Client(), llmclient.Hooks{})
+
+	resp, err := provider.Passthrough(context.Background(), &core.PassthroughRequest{
+		Method:   http.MethodPost,
+		Endpoint: "chat/completions",
+		Body: io.NopCloser(strings.NewReader(`{
+			"model":"Qwen/Qwen2.5-0.5B-Instruct",
+			"messages":[{"role":"user","content":"hi"}]
+		}`)),
+		Headers: http.Header{"Content-Type": []string{"application/json"}},
+	})
+	if err != nil {
+		t.Fatalf("Passthrough() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if gotPath != "/v1/chat/completions" {
+		t.Fatalf("path = %q, want /v1/chat/completions", gotPath)
+	}
+}

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -6694,7 +6694,7 @@ func TestProviderPassthrough_RejectsUnsupportedProvider(t *testing.T) {
 	if !strings.Contains(rec.Body.String(), `provider passthrough for \"groq\" is not enabled`) {
 		t.Fatalf("unexpected error body: %s", rec.Body.String())
 	}
-	if !strings.Contains(rec.Body.String(), "anthropic, openai, openrouter, zai") {
+	if !strings.Contains(rec.Body.String(), "anthropic, openai, openrouter, vllm, zai") {
 		t.Fatalf("unexpected error body: %s", rec.Body.String())
 	}
 }

--- a/internal/server/passthrough_support.go
+++ b/internal/server/passthrough_support.go
@@ -16,7 +16,7 @@ import (
 	"gomodel/internal/usage"
 )
 
-var defaultEnabledPassthroughProviders = []string{"openai", "anthropic", "openrouter", "zai"}
+var defaultEnabledPassthroughProviders = []string{"openai", "anthropic", "openrouter", "zai", "vllm"}
 
 func (h *Handler) setEnabledPassthroughProviders(providerTypes []string) {
 	h.enabledPassthroughProviders = normalizeEnabledPassthroughProviders(providerTypes)


### PR DESCRIPTION
## Summary
- add first-class vLLM provider backed by its OpenAI-compatible API
- support optional API key, keyless local/self-hosted vLLM, /models discovery, embeddings, responses, streaming, and passthrough
- enable /p/vllm/... passthrough by default and document configuration across README, docs, examples, and Helm

## Verification
- go test ./...
- git diff --check
- helm template with keyless vLLM provider enabled
