### PR TITLE
feat(audit): surface provider prompt caching usage

### DIFF
--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -15,6 +15,8 @@
   --success: #34d399;
   --warning: #f59e0b;
   --danger: #ef4444;
+  --prompt-cache-color: #40a811;
+  --prompt-cache-color-bg: color-mix(in srgb, var(--prompt-cache-color) 14%, var(--bg-surface));
   --sidebar-width: 240px;
   --radius: 8px;
   --chart-grid: #2a2826;
@@ -53,6 +55,8 @@
   --success: #34d399;
   --warning: #d97706;
   --danger: #dc2626;
+  --prompt-cache-color: #40a811;
+  --prompt-cache-color-bg: color-mix(in srgb, var(--prompt-cache-color) 9%, var(--bg-surface));
   --chart-grid: #e8e0d6;
   --chart-text: #7a7068;
   --chart-tooltip-bg: #ffffff;
@@ -90,6 +94,8 @@
     --success: #34d399;
     --warning: #d97706;
     --danger: #dc2626;
+    --prompt-cache-color: #40a811;
+    --prompt-cache-color-bg: color-mix(in srgb, var(--prompt-cache-color) 9%, var(--bg-surface));
     --chart-grid: #e8e0d6;
     --chart-text: #7a7068;
     --chart-tooltip-bg: #ffffff;
@@ -2623,6 +2629,33 @@ textarea:focus {
   justify-content: space-between;
   gap: 8px;
   margin-bottom: 6px;
+}
+
+.audit-pane-block-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.audit-prompt-cache-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 20px;
+  padding: 2px 8px;
+  border: 1px solid color-mix(in srgb, var(--prompt-cache-color) 45%, var(--border));
+  border-radius: 999px;
+  background: var(--prompt-cache-color-bg);
+  color: var(--prompt-cache-color);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: none;
+}
+
+.audit-prompt-cache-highlight {
+  color: var(--prompt-cache-color);
+  font-weight: 700;
 }
 
 .audit-copy-btn {

--- a/internal/admin/dashboard/static/js/modules/audit-list.js
+++ b/internal/admin/dashboard/static/js/modules/audit-list.js
@@ -306,6 +306,8 @@
                     headers: data && data.request_headers,
                     showBody: !!(data && data.request_body),
                     body: data && data.request_body,
+                    bodyCacheRatioLabel: this.auditCacheRatioPillLabel(entry),
+                    promptCacheHighlight: this.auditPromptCacheHighlight(entry),
                     showEmpty: !data || (!data.request_headers && !data.request_body),
                     emptyMessage: 'Request details were not captured.',
                     showTooLarge: !!(data && data.request_body_too_big_to_handle),
@@ -335,6 +337,68 @@
                 };
             },
 
+            auditUsage(entry) {
+                const usage = entry && entry.usage;
+                if (!usage || typeof usage !== 'object') return null;
+                return usage;
+            },
+
+            auditHasCachedTokens(entry) {
+                const usage = this.auditUsage(entry);
+                return Number(usage && usage.cached_input_tokens || 0) > 0;
+            },
+
+            auditCacheSharePercent(entry) {
+                const usage = this.auditUsage(entry);
+                const inputTokens = Number(usage && usage.input_tokens || 0);
+                const cachedTokens = Number(usage && usage.cached_input_tokens || 0);
+                if (!Number.isFinite(inputTokens) || inputTokens <= 0 || !Number.isFinite(cachedTokens) || cachedTokens <= 0) {
+                    return 0;
+                }
+                return Math.max(0, Math.min(100, (cachedTokens / inputTokens) * 100));
+            },
+
+            auditCacheRatioLabel(entry) {
+                const usage = this.auditUsage(entry);
+                if (!usage) return '';
+                const inputTokens = Number(usage.input_tokens || 0);
+                const cachedTokens = Number(usage.cached_input_tokens || 0);
+                if (inputTokens <= 0) {
+                    return this.formatNumber(cachedTokens) + ' cached';
+                }
+                return this.auditCacheSharePercent(entry).toFixed(1) + '% cached';
+            },
+
+            auditCacheRatioPillLabel(entry) {
+                if (!this.auditHasCachedTokens(entry)) return '';
+                return this.auditCacheRatioLabel(entry);
+            },
+
+            auditPromptCacheHighlight(entry) {
+                const usage = this.auditUsage(entry);
+                if (!usage || !entry || !entry.data || !entry.data.request_body) return null;
+
+                const estimatedChars = Number(usage.estimated_cached_characters || 0);
+                if (!Number.isFinite(estimatedChars) || estimatedChars <= 0) {
+                    return null;
+                }
+
+                const helper = global.DashboardConversationHelpers;
+                if (!helper || typeof helper.extractRequestPromptTextSegments !== 'function') {
+                    return null;
+                }
+
+                const segments = helper.extractRequestPromptTextSegments(entry.data.request_body);
+                if (!Array.isArray(segments) || segments.length === 0) {
+                    return null;
+                }
+
+                return {
+                    characters: estimatedChars,
+                    segments
+                };
+            },
+
             auditPaneState(pane) {
                 const formatJSON = this.formatJSON.bind(this);
                 const renderBody = typeof this.renderBodyWithConversationHighlights === 'function'
@@ -357,7 +421,7 @@
                 return {
                     pane,
                     formattedHeaders: pane && pane.showHeaders ? formatJSON(pane.headers) : '',
-                    renderedBody: pane && pane.showBody ? renderBody(pane.entry, pane.body) : '',
+                    renderedBody: pane && pane.showBody ? renderBody(pane.entry, pane.body, { promptCacheHighlight: pane.promptCacheHighlight }) : '',
                     copyBodyState,
                     copyHeadersState,
                     copyState: copyBodyState,

--- a/internal/admin/dashboard/static/js/modules/audit-list.test.js
+++ b/internal/admin/dashboard/static/js/modules/audit-list.test.js
@@ -26,6 +26,14 @@ function createAuditListModule(overrides) {
     return factory();
 }
 
+function loadConversationHelpers() {
+    const source = fs.readFileSync(path.join(__dirname, 'conversation-helpers.js'), 'utf8');
+    const context = { window: {} };
+    vm.createContext(context);
+    vm.runInContext(source, context);
+    return context.window.DashboardConversationHelpers;
+}
+
 test('auditRequestPane returns the shared request-pane contract', () => {
     const module = createAuditListModule();
     const entry = {
@@ -82,6 +90,84 @@ test('auditResponsePane returns the shared response-pane contract', () => {
     assert.equal(pane.showTooLarge, false);
     assert.equal(pane.tooLargeMessage, 'Response body was too large to capture.');
 });
+
+test('audit cache helpers summarize cached prompt usage and derive a preview from the request body', () => {
+    const module = createAuditListModule({
+        window: {
+            DashboardConversationHelpers: {
+                extractRequestPromptTextSegments(body) {
+                    return [body.instructions, body.messages[0].content];
+                }
+            }
+        }
+    });
+    module.formatNumber = (value) => String(value);
+
+    const entry = {
+        usage: {
+            input_tokens: 200,
+            cached_input_tokens: 150,
+            cache_write_input_tokens: 32,
+            estimated_cached_characters: 600
+        },
+        data: {
+            request_body: {
+                instructions: 'You are a meticulous assistant.',
+                messages: [{ role: 'user', content: 'Summarize the attached policy memo.' }]
+            }
+        }
+    };
+
+    assert.equal(module.auditHasCachedTokens(entry), true);
+    assert.equal(module.auditCacheSharePercent(entry), 75);
+    assert.equal(module.auditCacheRatioLabel(entry), '75.0% cached');
+    assert.equal(module.auditCacheRatioPillLabel(entry), '75.0% cached');
+    assert.equal(JSON.stringify(module.auditPromptCacheHighlight(entry)), JSON.stringify({
+        characters: 600,
+        segments: ['You are a meticulous assistant.', 'Summarize the attached policy memo.']
+    }));
+
+    const pane = module.auditRequestPane(entry);
+    assert.equal(pane.bodyCacheRatioLabel, '75.0% cached');
+    assert.equal(JSON.stringify(pane.promptCacheHighlight), JSON.stringify({
+        characters: 600,
+        segments: ['You are a meticulous assistant.', 'Summarize the attached policy memo.']
+    }));
+});
+
+test('conversation body rendering darkens the estimated cached prompt text in request JSON', () => {
+    const helpers = loadConversationHelpers();
+    const requestBody = {
+        model: 'anthropic/claude-sonnet-4-5',
+        messages: [{
+            role: 'user',
+            content: [
+                {
+                    type: 'text',
+                    text: 'Reusable prefix for Anthropic prompt caching.'
+                },
+                {
+                    type: 'text',
+                    text: 'Fresh question.'
+                }
+            ]
+        }]
+    };
+    const segments = helpers.extractRequestPromptTextSegments(requestBody);
+
+    const rendered = helpers.renderBodyWithConversationHighlights({ path: '/v1/chat/completions' }, requestBody, {
+        formatJSON: (value) => JSON.stringify(value, null, 2),
+        canShowConversation: () => false,
+        promptCacheHighlight: {
+            characters: 18,
+            segments
+        }
+    });
+
+    assert.match(rendered, /<span class="audit-prompt-cache-highlight">Reusable prefix fo<\/span>r Anthropic prompt caching\./);
+    assert.doesNotMatch(rendered, /Fresh question\.<\/span>/);
+});
+
 
 test('auditResponsePane surfaces error message from captured error body', () => {
     const module = createAuditListModule();
@@ -293,9 +379,14 @@ test('auditPaneState formats pane content once for template rendering', () => {
     const module = createAuditListModule();
     const entry = { id: 'audit-1' };
     let renderCalls = 0;
-    module.renderBodyWithConversationHighlights = (renderEntry, body) => {
+    const promptCacheHighlight = {
+        characters: 42,
+        segments: ['cached prompt']
+    };
+    module.renderBodyWithConversationHighlights = (renderEntry, body, options) => {
         renderCalls++;
         assert.equal(renderEntry, entry);
+        assert.equal(JSON.stringify(options), JSON.stringify({ promptCacheHighlight }));
         return 'rendered:' + body.id;
     };
 
@@ -304,7 +395,8 @@ test('auditPaneState formats pane content once for template rendering', () => {
         showHeaders: true,
         headers: { authorization: 'Bearer redacted' },
         showBody: true,
-        body: { id: 'body-1' }
+        body: { id: 'body-1' },
+        promptCacheHighlight
     });
 
     assert.equal(paneState.formattedHeaders, '{\n  "authorization": "Bearer redacted"\n}');

--- a/internal/admin/dashboard/static/js/modules/conversation-drawer.js
+++ b/internal/admin/dashboard/static/js/modules/conversation-drawer.js
@@ -44,14 +44,15 @@
                 this.openConversation(entry, null, false, el);
             },
 
-            renderBodyWithConversationHighlights(entry, value) {
+            renderBodyWithConversationHighlights(entry, value, options) {
                 const h = getHelpers();
                 if (typeof h.renderBodyWithConversationHighlights !== 'function') {
                     return this.formatJSON(value);
                 }
                 return h.renderBodyWithConversationHighlights(entry, value, {
                     formatJSON: (v) => this.formatJSON(v),
-                    canShowConversation: (e) => this.canShowConversation(e)
+                    canShowConversation: (e) => this.canShowConversation(e),
+                    promptCacheHighlight: options && options.promptCacheHighlight
                 });
             },
 

--- a/internal/admin/dashboard/static/js/modules/conversation-helpers.js
+++ b/internal/admin/dashboard/static/js/modules/conversation-helpers.js
@@ -28,6 +28,29 @@
         return String(content).trim();
     }
 
+    function extractTextSegments(content) {
+        if (content == null) return [];
+        if (typeof content === 'string') return content ? [content] : [];
+
+        if (Array.isArray(content)) {
+            return content.flatMap((part) => {
+                if (typeof part === 'string') return part ? [part] : [];
+                if (!part || typeof part !== 'object') return [];
+                if (typeof part.text === 'string') return part.text ? [part.text] : [];
+                if (typeof part.output_text === 'string') return part.output_text ? [part.output_text] : [];
+                return [];
+            });
+        }
+
+        if (typeof content === 'object') {
+            if (typeof content.text === 'string') return content.text ? [content.text] : [];
+            return [];
+        }
+
+        const text = String(content);
+        return text ? [text] : [];
+    }
+
     function extractResponsesInputMessages(input) {
         if (input == null) return [];
         if (typeof input === 'string') {
@@ -60,6 +83,41 @@
         }).filter(Boolean);
 
         return parts.join('\n').trim();
+    }
+
+    function extractRequestPromptTextSegments(body) {
+        if (!body || typeof body !== 'object') return [];
+
+        const segments = [];
+        segments.push(...extractTextSegments(body.instructions));
+
+        if (Array.isArray(body.messages)) {
+            body.messages.forEach((message) => {
+                if (!message || typeof message !== 'object') return;
+                segments.push(...extractTextSegments(message.content));
+            });
+        }
+
+        if (typeof body.input === 'string') {
+            segments.push(body.input);
+        } else if (Array.isArray(body.input)) {
+            body.input.forEach((item) => {
+                if (!item || typeof item !== 'object') return;
+                segments.push(...extractTextSegments(item.content));
+                if (typeof item.text === 'string') {
+                    segments.push(item.text);
+                }
+            });
+        } else if (body.input && typeof body.input === 'object') {
+            segments.push(...extractTextSegments(body.input.content));
+            if (typeof body.input.text === 'string') {
+                segments.push(body.input.text);
+            }
+        }
+
+        return segments
+            .map((segment) => String(segment || ''))
+            .filter((segment) => segment.length > 0);
     }
 
     function tryParseJSON(value) {
@@ -285,14 +343,91 @@
             .replaceAll("'", '&#39;');
     }
 
+    function jsonStringContent(value) {
+        try {
+            return JSON.stringify(String(value)).slice(1, -1);
+        } catch (_) {
+            return '';
+        }
+    }
+
+    function createPromptCacheHighlightState(highlight) {
+        if (!highlight || typeof highlight !== 'object') return null;
+        const characters = Number(highlight.characters || 0);
+        if (!Number.isFinite(characters) || characters <= 0) return null;
+        const segments = Array.isArray(highlight.segments)
+            ? highlight.segments.map((segment) => String(segment || '')).filter(Boolean)
+            : [];
+        if (segments.length === 0) return null;
+        return {
+            remaining: Math.floor(characters),
+            segments,
+            segmentIndex: 0
+        };
+    }
+
+    function renderLineWithPromptCacheHighlight(line, state) {
+        if (!state || state.remaining <= 0 || state.segmentIndex >= state.segments.length) {
+            return escapeHTML(line);
+        }
+
+        let rendered = '';
+        let cursor = 0;
+        let searchFrom = 0;
+
+        while (state.remaining > 0 && state.segmentIndex < state.segments.length) {
+            const segment = state.segments[state.segmentIndex];
+            const encodedSegment = jsonStringContent(segment);
+            if (!encodedSegment) {
+                state.segmentIndex++;
+                continue;
+            }
+
+            const idx = line.indexOf(encodedSegment, searchFrom);
+            if (idx < 0) {
+                break;
+            }
+
+            const highlightedChars = Math.min(state.remaining, segment.length);
+            const encodedHighlight = jsonStringContent(segment.slice(0, highlightedChars));
+            if (!encodedHighlight) {
+                state.segmentIndex++;
+                continue;
+            }
+
+            rendered += escapeHTML(line.slice(cursor, idx));
+            rendered += '<span class="audit-prompt-cache-highlight">' + escapeHTML(encodedHighlight) + '</span>';
+
+            cursor = idx + encodedHighlight.length;
+            searchFrom = idx + encodedSegment.length;
+            state.remaining -= highlightedChars;
+
+            if (highlightedChars >= segment.length) {
+                state.segmentIndex++;
+                continue;
+            }
+            break;
+        }
+
+        if (!rendered) {
+            return escapeHTML(line);
+        }
+        return rendered + escapeHTML(line.slice(cursor));
+    }
+
     function renderBodyWithConversationHighlights(entry, value, deps) {
         const formatJSON = deps && typeof deps.formatJSON === 'function' ? deps.formatJSON : (v) => String(v);
         const canShow = deps && typeof deps.canShowConversation === 'function' ? deps.canShowConversation : () => false;
+        const promptCacheState = createPromptCacheHighlightState(deps && deps.promptCacheHighlight);
 
         const raw = formatJSON(value);
-        const escaped = escapeHTML(raw);
-        if (!canShow(entry) || !raw || raw === 'Not captured') {
-            return escaped;
+        if (!raw || raw === 'Not captured') {
+            return escapeHTML(raw);
+        }
+
+        const showConversation = canShow(entry);
+        if (!showConversation) {
+            return raw.split('\n').map((line) => renderLineWithPromptCacheHighlight(line, promptCacheState)).join('\n');
         }
 
         const lines = raw.split('\n');
@@ -307,12 +442,12 @@
                 const valuePart = match[3] || '';
                 const end = findConversationSectionEnd(lines, i, valuePart);
                 const roleClass = conversationHighlightRoleClass(key);
-                const block = lines.slice(i, end + 1).map((l) => escapeHTML(l)).join('\n');
+                const block = lines.slice(i, end + 1).map((l) => renderLineWithPromptCacheHighlight(l, promptCacheState)).join('\n');
                 rendered.push('<span class="conversation-body-highlight ' + roleClass + '" data-conversation-trigger="1">' + block + '</span>');
                 i = end + 1;
                 continue;
             }
-            rendered.push(escapeHTML(line));
+            rendered.push(renderLineWithPromptCacheHighlight(line, promptCacheState));
             i++;
         }
 
@@ -321,6 +456,7 @@
 
     global.DashboardConversationHelpers = {
         extractText,
+        extractRequestPromptTextSegments,
         extractResponsesInputMessages,
         extractResponsesOutputText,
         extractConversationErrorMessage,

--- a/internal/admin/dashboard/static/js/modules/dashboard-layout.test.js
+++ b/internal/admin/dashboard/static/js/modules/dashboard-layout.test.js
@@ -746,6 +746,42 @@ test("audit entry metadata is rendered as a labeled pill row at the bottom of th
   assert.match(metadataContextRule, /flex-wrap:\s*wrap/);
 });
 
+test("audit entry details show prompt caching inside the request body pane", () => {
+  const indexTemplate = readDashboardTemplateSource();
+  const auditPaneTemplate = readFixture("../../../templates/audit-pane.html");
+  const css = readFixture("../../css/dashboard.css");
+  const detailsStart = indexTemplate.indexOf(
+    '<div class="audit-entry-details">',
+  );
+  const detailsEnd = indexTemplate.indexOf("</template>", detailsStart);
+
+  assert.notEqual(detailsStart, -1, "Expected audit entry details block");
+  assert.notEqual(detailsEnd, -1, "Expected lazy audit entry details wrapper");
+
+  const auditEntry = indexTemplate.slice(detailsStart, detailsEnd);
+  const requestResponseIndex = auditEntry.indexOf(
+    '<div class="audit-request-response">',
+  );
+  const metadataIndex = auditEntry.indexOf(
+    '<div class="audit-entry-metadata">',
+  );
+
+  assert.ok(requestResponseIndex < metadataIndex);
+  assert.doesNotMatch(auditEntry, /audit-cache-panel/);
+  assert.match(
+    auditPaneTemplate,
+    /<h5>Body<\/h5>[\s\S]*<span class="audit-prompt-cache-pill mono" x-show="pane\.bodyCacheRatioLabel" x-text="pane\.bodyCacheRatioLabel"><\/span>/,
+  );
+
+  const pillRule = readCSSRule(css, ".audit-prompt-cache-pill");
+  assert.match(pillRule, /color:\s*var\(--prompt-cache-color\)/);
+  assert.match(pillRule, /border-radius:\s*999px/);
+
+  const highlightRule = readCSSRule(css, ".audit-prompt-cache-highlight");
+  assert.match(highlightRule, /color:\s*var\(--prompt-cache-color\)/);
+  assert.match(highlightRule, /font-weight:\s*700/);
+});
+
 test("model category tables lazy mount only the active table body", () => {
   const indexTemplate = readDashboardTemplateSource();
   const css = readFixture("../../css/dashboard.css");

--- a/internal/admin/dashboard/templates/audit-pane.html
+++ b/internal/admin/dashboard/templates/audit-pane.html
@@ -26,7 +26,10 @@
     </div>
     <div class="audit-pane-block" x-show="pane.showBody">
         <div class="audit-pane-block-head">
-            <h5>Body</h5>
+            <div class="audit-pane-block-title">
+                <h5>Body</h5>
+                <span class="audit-prompt-cache-pill mono" x-show="pane.bodyCacheRatioLabel" x-text="pane.bodyCacheRatioLabel"></span>
+            </div>
             <button type="button" class="copy-feedback-btn audit-copy-btn"
                 :class="{ 'copy-feedback-btn-copied': copyBodyState.copied }"
                 @click.prevent="copyBody()">

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -94,6 +94,18 @@ type providerStatusResponse struct {
 	Providers []providerStatusItemResponse  `json:"providers"`
 }
 
+type auditLogEntryResponse struct {
+	auditlog.LogEntry
+	Usage *usage.RequestUsageSummary `json:"usage,omitempty"`
+}
+
+type auditLogListResponse struct {
+	Entries []auditLogEntryResponse `json:"entries"`
+	Total   int                     `json:"total"`
+	Limit   int                     `json:"limit"`
+	Offset  int                     `json:"offset"`
+}
+
 const (
 	RuntimeRefreshStatusOK      = "ok"
 	RuntimeRefreshStatusPartial = "partial"
@@ -679,14 +691,14 @@ func (h *Handler) CacheOverview(c *echo.Context) error {
 // @Param        search       query     string  false  "Search across request_id/requested_model/provider/method/path/error_type/error_message"
 // @Param        limit        query     int     false  "Page size (default 25, max 100)"
 // @Param        offset       query     int     false  "Offset for pagination"
-// @Success      200  {object}  auditlog.LogListResult
+// @Success      200  {object}  auditLogListResponse
 // @Failure      400  {object}  core.GatewayError
 // @Failure      401  {object}  core.GatewayError
 // @Router       /admin/api/v1/audit/log [get]
 func (h *Handler) AuditLog(c *echo.Context) error {
 	if h.auditReader == nil {
-		return c.JSON(http.StatusOK, auditlog.LogListResult{
-			Entries: []auditlog.LogEntry{},
+		return c.JSON(http.StatusOK, auditLogListResponse{
+			Entries: []auditLogEntryResponse{},
 		})
 	}
 
@@ -754,7 +766,52 @@ func (h *Handler) AuditLog(c *echo.Context) error {
 		result.Entries = []auditlog.LogEntry{}
 	}
 
-	return c.JSON(http.StatusOK, result)
+	response, err := h.auditLogResponse(c.Request().Context(), result)
+	if err != nil {
+		return handleError(c, err)
+	}
+	return c.JSON(http.StatusOK, response)
+}
+
+func (h *Handler) auditLogResponse(ctx context.Context, result *auditlog.LogListResult) (*auditLogListResponse, error) {
+	if result == nil {
+		return &auditLogListResponse{Entries: []auditLogEntryResponse{}}, nil
+	}
+
+	response := &auditLogListResponse{
+		Entries: make([]auditLogEntryResponse, len(result.Entries)),
+		Total:   result.Total,
+		Limit:   result.Limit,
+		Offset:  result.Offset,
+	}
+	for i := range result.Entries {
+		response.Entries[i].LogEntry = result.Entries[i]
+	}
+
+	if h.usageReader == nil || len(result.Entries) == 0 {
+		return response, nil
+	}
+
+	requestIDs := make([]string, 0, len(result.Entries))
+	for _, entry := range result.Entries {
+		requestIDs = append(requestIDs, entry.RequestID)
+	}
+
+	entriesByRequestID, err := h.usageReader.GetUsageByRequestIDs(ctx, requestIDs)
+	if err != nil {
+		slog.Warn("failed to enrich audit log entries with usage", "error", err, "request_count", len(requestIDs))
+		return response, nil
+	}
+
+	summaries := usage.SummarizeUsageByRequestID(entriesByRequestID)
+	for i := range response.Entries {
+		requestID := response.Entries[i].RequestID
+		if summary, ok := summaries[requestID]; ok {
+			response.Entries[i].Usage = summary
+		}
+	}
+
+	return response, nil
 }
 
 // AuditConversation handles GET /admin/api/v1/audit/conversation

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -28,14 +28,17 @@ type mockUsageReader struct {
 	modelUsage        []usage.ModelUsage
 	userPathUsage     []usage.UserPathUsage
 	usageLog          *usage.UsageLogResult
+	usageByRequestID  map[string][]usage.UsageLogEntry
 	cacheOverview     *usage.CacheOverview
 	lastUsageLog      usage.UsageLogParams
+	lastRequestIDs    []string
 	lastCacheOverview usage.UsageQueryParams
 	summaryErr        error
 	dailyErr          error
 	modelUsageErr     error
 	userPathUsageErr  error
 	usageLogErr       error
+	usageByRequestErr error
 	cacheErr          error
 }
 
@@ -96,6 +99,14 @@ func (m *mockUsageReader) GetUsageLog(_ context.Context, params usage.UsageLogPa
 		return nil, m.usageLogErr
 	}
 	return m.usageLog, nil
+}
+
+func (m *mockUsageReader) GetUsageByRequestIDs(_ context.Context, requestIDs []string) (map[string][]usage.UsageLogEntry, error) {
+	m.lastRequestIDs = append([]string(nil), requestIDs...)
+	if m.usageByRequestErr != nil {
+		return nil, m.usageByRequestErr
+	}
+	return m.usageByRequestID, nil
 }
 
 func (m *mockUsageReader) GetCacheOverview(_ context.Context, params usage.UsageQueryParams) (*usage.CacheOverview, error) {
@@ -809,6 +820,77 @@ func TestAuditLog_Success(t *testing.T) {
 	}
 	if result.Entries[0].Data == nil || result.Entries[0].Data.RequestBody == nil {
 		t.Errorf("expected request body data to be present")
+	}
+}
+
+func TestAuditLog_EnrichesEntriesWithUsageSummary(t *testing.T) {
+	now := time.Now().UTC()
+	usageReader := &mockUsageReader{
+		usageByRequestID: map[string][]usage.UsageLogEntry{
+			"req-1": {
+				{
+					RequestID:    "req-1",
+					Provider:     "openai",
+					InputTokens:  200,
+					OutputTokens: 40,
+					RawData: map[string]any{
+						"prompt_cached_tokens": 150,
+					},
+				},
+			},
+		},
+	}
+	auditReader := &mockAuditReader{
+		logResult: &auditlog.LogListResult{
+			Entries: []auditlog.LogEntry{
+				{
+					ID:             "log-1",
+					Timestamp:      now,
+					RequestedModel: "gpt-4o",
+					Provider:       "openai",
+					StatusCode:     200,
+					RequestID:      "req-1",
+					Method:         http.MethodPost,
+					Path:           "/v1/chat/completions",
+				},
+			},
+			Total:  1,
+			Limit:  25,
+			Offset: 0,
+		},
+	}
+
+	h := NewHandler(usageReader, nil, WithAuditReader(auditReader))
+	c, rec := newHandlerContext("/admin/api/v1/audit/log?days=7")
+
+	if err := h.AuditLog(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var result auditLogListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if len(result.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(result.Entries))
+	}
+	if len(usageReader.lastRequestIDs) != 1 || usageReader.lastRequestIDs[0] != "req-1" {
+		t.Fatalf("lastRequestIDs = %#v, want [req-1]", usageReader.lastRequestIDs)
+	}
+	if result.Entries[0].Usage == nil {
+		t.Fatal("expected usage summary to be attached")
+	}
+	if result.Entries[0].Usage.CachedInputTokens != 150 {
+		t.Fatalf("CachedInputTokens = %d, want 150", result.Entries[0].Usage.CachedInputTokens)
+	}
+	if result.Entries[0].Usage.InputTokens != 200 {
+		t.Fatalf("InputTokens = %d, want 200", result.Entries[0].Usage.InputTokens)
+	}
+	if result.Entries[0].Usage.TotalTokens != 240 {
+		t.Fatalf("TotalTokens = %d, want 240", result.Entries[0].Usage.TotalTokens)
 	}
 }
 

--- a/internal/core/usage_json.go
+++ b/internal/core/usage_json.go
@@ -1,0 +1,267 @@
+package core
+
+import (
+	"encoding/json"
+)
+
+var usageKnownFields = map[string]struct{}{
+	"prompt_tokens":             {},
+	"completion_tokens":         {},
+	"total_tokens":              {},
+	"prompt_tokens_details":     {},
+	"completion_tokens_details": {},
+	"raw_usage":                 {},
+}
+
+var responsesUsageKnownFields = map[string]struct{}{
+	"input_tokens":              {},
+	"output_tokens":             {},
+	"total_tokens":              {},
+	"input_tokens_details":      {},
+	"output_tokens_details":     {},
+	"prompt_tokens_details":     {},
+	"completion_tokens_details": {},
+	"raw_usage":                 {},
+}
+
+func (u *Usage) UnmarshalJSON(data []byte) error {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return err
+	}
+
+	var rawUsage map[string]any
+	for key, raw := range payload {
+		switch key {
+		case "prompt_tokens":
+			if err := json.Unmarshal(raw, &u.PromptTokens); err != nil {
+				return err
+			}
+		case "completion_tokens":
+			if err := json.Unmarshal(raw, &u.CompletionTokens); err != nil {
+				return err
+			}
+		case "total_tokens":
+			if err := json.Unmarshal(raw, &u.TotalTokens); err != nil {
+				return err
+			}
+		case "prompt_tokens_details":
+			if err := json.Unmarshal(raw, &u.PromptTokensDetails); err != nil {
+				return err
+			}
+		case "completion_tokens_details":
+			if err := json.Unmarshal(raw, &u.CompletionTokensDetails); err != nil {
+				return err
+			}
+		case "raw_usage":
+			if err := mergeRawUsageObject(&rawUsage, raw); err != nil {
+				return err
+			}
+		default:
+			if _, known := usageKnownFields[key]; known {
+				continue
+			}
+			if err := mergeRawUsageField(&rawUsage, key, raw); err != nil {
+				return err
+			}
+		}
+	}
+
+	u.RawUsage = rawUsage
+	return nil
+}
+
+func (u Usage) MarshalJSON() ([]byte, error) {
+	return marshalTokenUsageJSON(
+		u.RawUsage,
+		usageJSONPayload{
+			PromptTokens:            u.PromptTokens,
+			CompletionTokens:        u.CompletionTokens,
+			TotalTokens:             u.TotalTokens,
+			PromptTokensDetails:     u.PromptTokensDetails,
+			CompletionTokensDetails: u.CompletionTokensDetails,
+		},
+		func(payload map[string]any) {
+			payload["prompt_tokens"] = u.PromptTokens
+			payload["completion_tokens"] = u.CompletionTokens
+			payload["total_tokens"] = u.TotalTokens
+		},
+		u.PromptTokensDetails,
+		"prompt_tokens_details",
+		u.CompletionTokensDetails,
+		"completion_tokens_details",
+		usageKnownFields,
+	)
+}
+
+func (u *ResponsesUsage) UnmarshalJSON(data []byte) error {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return err
+	}
+
+	var rawUsage map[string]any
+	for key, raw := range payload {
+		switch key {
+		case "input_tokens":
+			if err := json.Unmarshal(raw, &u.InputTokens); err != nil {
+				return err
+			}
+		case "output_tokens":
+			if err := json.Unmarshal(raw, &u.OutputTokens); err != nil {
+				return err
+			}
+		case "total_tokens":
+			if err := json.Unmarshal(raw, &u.TotalTokens); err != nil {
+				return err
+			}
+		case "input_tokens_details", "prompt_tokens_details":
+			if err := json.Unmarshal(raw, &u.PromptTokensDetails); err != nil {
+				return err
+			}
+		case "output_tokens_details", "completion_tokens_details":
+			if err := json.Unmarshal(raw, &u.CompletionTokensDetails); err != nil {
+				return err
+			}
+		case "raw_usage":
+			if err := mergeRawUsageObject(&rawUsage, raw); err != nil {
+				return err
+			}
+		default:
+			if _, known := responsesUsageKnownFields[key]; known {
+				continue
+			}
+			if err := mergeRawUsageField(&rawUsage, key, raw); err != nil {
+				return err
+			}
+		}
+	}
+
+	u.RawUsage = rawUsage
+	return nil
+}
+
+func (u ResponsesUsage) MarshalJSON() ([]byte, error) {
+	return marshalTokenUsageJSON(
+		u.RawUsage,
+		responsesUsageJSONPayload{
+			InputTokens:             u.InputTokens,
+			OutputTokens:            u.OutputTokens,
+			TotalTokens:             u.TotalTokens,
+			PromptTokensDetails:     u.PromptTokensDetails,
+			CompletionTokensDetails: u.CompletionTokensDetails,
+		},
+		func(payload map[string]any) {
+			payload["input_tokens"] = u.InputTokens
+			payload["output_tokens"] = u.OutputTokens
+			payload["total_tokens"] = u.TotalTokens
+		},
+		u.PromptTokensDetails,
+		"input_tokens_details",
+		u.CompletionTokensDetails,
+		"output_tokens_details",
+		responsesUsageKnownFields,
+	)
+}
+
+type usageJSONPayload struct {
+	PromptTokens            int                      `json:"prompt_tokens"`
+	CompletionTokens        int                      `json:"completion_tokens"`
+	TotalTokens             int                      `json:"total_tokens"`
+	PromptTokensDetails     *PromptTokensDetails     `json:"prompt_tokens_details,omitempty"`
+	CompletionTokensDetails *CompletionTokensDetails `json:"completion_tokens_details,omitempty"`
+}
+
+type responsesUsageJSONPayload struct {
+	InputTokens             int                      `json:"input_tokens"`
+	OutputTokens            int                      `json:"output_tokens"`
+	TotalTokens             int                      `json:"total_tokens"`
+	PromptTokensDetails     *PromptTokensDetails     `json:"input_tokens_details,omitempty"`
+	CompletionTokensDetails *CompletionTokensDetails `json:"output_tokens_details,omitempty"`
+}
+
+func marshalUsagePayload(
+	rawUsage map[string]any,
+	populateCounts func(map[string]any),
+	promptDetails *PromptTokensDetails,
+	promptDetailsKey string,
+	completionDetails *CompletionTokensDetails,
+	completionDetailsKey string,
+	knownFields map[string]struct{},
+) ([]byte, error) {
+	payload := make(map[string]any, 3+2+len(rawUsage))
+	populateCounts(payload)
+	if promptDetails != nil {
+		payload[promptDetailsKey] = promptDetails
+	}
+	if completionDetails != nil {
+		payload[completionDetailsKey] = completionDetails
+	}
+	mergeUsagePayload(payload, rawUsage, knownFields)
+	return json.Marshal(payload)
+}
+
+func marshalTokenUsageJSON(
+	rawUsage map[string]any,
+	emptyPayload any,
+	populateCounts func(map[string]any),
+	promptDetails *PromptTokensDetails,
+	promptDetailsKey string,
+	completionDetails *CompletionTokensDetails,
+	completionDetailsKey string,
+	knownFields map[string]struct{},
+) ([]byte, error) {
+	if len(rawUsage) == 0 {
+		return json.Marshal(emptyPayload)
+	}
+	return marshalUsagePayload(
+		rawUsage,
+		populateCounts,
+		promptDetails,
+		promptDetailsKey,
+		completionDetails,
+		completionDetailsKey,
+		knownFields,
+	)
+}
+
+func mergeRawUsageField(dst *map[string]any, key string, raw json.RawMessage) error {
+	var decoded any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return err
+	}
+	if *dst == nil {
+		*dst = make(map[string]any)
+	}
+	(*dst)[key] = decoded
+	return nil
+}
+
+func mergeRawUsageObject(dst *map[string]any, raw json.RawMessage) error {
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return err
+	}
+	if len(decoded) == 0 {
+		return nil
+	}
+	if *dst == nil {
+		*dst = make(map[string]any, len(decoded))
+	}
+	for key, value := range decoded {
+		(*dst)[key] = value
+	}
+	return nil
+}
+
+func mergeUsagePayload(payload map[string]any, rawUsage map[string]any, knownFields map[string]struct{}) {
+	for key, value := range rawUsage {
+		if _, known := knownFields[key]; known {
+			continue
+		}
+		if _, exists := payload[key]; exists {
+			continue
+		}
+		payload[key] = value
+	}
+}

--- a/internal/core/usage_json_test.go
+++ b/internal/core/usage_json_test.go
@@ -1,0 +1,154 @@
+package core
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestUsageUnmarshalJSON_PreservesExtendedFields(t *testing.T) {
+	var usage Usage
+	if err := json.Unmarshal([]byte(`{
+		"prompt_tokens": 120,
+		"completion_tokens": 30,
+		"total_tokens": 150,
+		"prompt_tokens_details": {
+			"cached_tokens": 80
+		},
+		"completion_tokens_details": {
+			"reasoning_tokens": 12
+		},
+		"cost_in_usd_ticks": 969250,
+		"num_sources_used": 2
+	}`), &usage); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if usage.PromptTokens != 120 {
+		t.Fatalf("PromptTokens = %d, want 120", usage.PromptTokens)
+	}
+	if usage.PromptTokensDetails == nil || usage.PromptTokensDetails.CachedTokens != 80 {
+		t.Fatalf("PromptTokensDetails = %+v, want cached_tokens=80", usage.PromptTokensDetails)
+	}
+	if usage.CompletionTokensDetails == nil || usage.CompletionTokensDetails.ReasoningTokens != 12 {
+		t.Fatalf("CompletionTokensDetails = %+v, want reasoning_tokens=12", usage.CompletionTokensDetails)
+	}
+	if usage.RawUsage["cost_in_usd_ticks"] != float64(969250) {
+		t.Fatalf("RawUsage[cost_in_usd_ticks] = %#v, want 969250", usage.RawUsage["cost_in_usd_ticks"])
+	}
+	if usage.RawUsage["num_sources_used"] != float64(2) {
+		t.Fatalf("RawUsage[num_sources_used] = %#v, want 2", usage.RawUsage["num_sources_used"])
+	}
+}
+
+func TestUsageMarshalJSON_MergesRawUsageIntoTopLevelUsage(t *testing.T) {
+	body, err := json.Marshal(Usage{
+		PromptTokens:     200,
+		CompletionTokens: 40,
+		TotalTokens:      240,
+		PromptTokensDetails: &PromptTokensDetails{
+			CachedTokens: 140,
+		},
+		RawUsage: map[string]any{
+			"cache_read_input_tokens": 140,
+			"service_tier":            "priority",
+		},
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if payload["cache_read_input_tokens"] != float64(140) {
+		t.Fatalf("cache_read_input_tokens = %#v, want 140", payload["cache_read_input_tokens"])
+	}
+	if payload["service_tier"] != "priority" {
+		t.Fatalf("service_tier = %#v, want priority", payload["service_tier"])
+	}
+	if _, exists := payload["raw_usage"]; exists {
+		t.Fatalf("did not expect raw_usage field in marshaled usage payload: %s", string(body))
+	}
+}
+
+func TestResponsesUsageUnmarshalJSON_AcceptsResponsesDetailFieldNames(t *testing.T) {
+	var usage ResponsesUsage
+	if err := json.Unmarshal([]byte(`{
+		"input_tokens": 125,
+		"output_tokens": 48,
+		"total_tokens": 173,
+		"input_tokens_details": {
+			"cached_tokens": 98
+		},
+		"output_tokens_details": {
+			"reasoning_tokens": 7
+		},
+		"cost_in_usd_ticks": 158500
+	}`), &usage); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if usage.InputTokens != 125 {
+		t.Fatalf("InputTokens = %d, want 125", usage.InputTokens)
+	}
+	if usage.PromptTokensDetails == nil || usage.PromptTokensDetails.CachedTokens != 98 {
+		t.Fatalf("PromptTokensDetails = %+v, want cached_tokens=98", usage.PromptTokensDetails)
+	}
+	if usage.CompletionTokensDetails == nil || usage.CompletionTokensDetails.ReasoningTokens != 7 {
+		t.Fatalf("CompletionTokensDetails = %+v, want reasoning_tokens=7", usage.CompletionTokensDetails)
+	}
+	if usage.RawUsage["cost_in_usd_ticks"] != float64(158500) {
+		t.Fatalf("RawUsage[cost_in_usd_ticks] = %#v, want 158500", usage.RawUsage["cost_in_usd_ticks"])
+	}
+}
+
+func TestResponsesUsageMarshalJSON_UsesResponsesDetailFieldNames(t *testing.T) {
+	body, err := json.Marshal(ResponsesUsage{
+		InputTokens:  125,
+		OutputTokens: 48,
+		TotalTokens:  173,
+		PromptTokensDetails: &PromptTokensDetails{
+			CachedTokens: 98,
+		},
+		CompletionTokensDetails: &CompletionTokensDetails{
+			ReasoningTokens: 7,
+		},
+		RawUsage: map[string]any{
+			"cache_read_input_tokens": 98,
+		},
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if _, exists := payload["prompt_tokens_details"]; exists {
+		t.Fatalf("did not expect prompt_tokens_details in marshaled responses payload: %s", string(body))
+	}
+	if _, exists := payload["completion_tokens_details"]; exists {
+		t.Fatalf("did not expect completion_tokens_details in marshaled responses payload: %s", string(body))
+	}
+
+	inputDetails, ok := payload["input_tokens_details"].(map[string]any)
+	if !ok {
+		t.Fatalf("input_tokens_details = %#v, want object", payload["input_tokens_details"])
+	}
+	if inputDetails["cached_tokens"] != float64(98) {
+		t.Fatalf("input_tokens_details.cached_tokens = %#v, want 98", inputDetails["cached_tokens"])
+	}
+
+	outputDetails, ok := payload["output_tokens_details"].(map[string]any)
+	if !ok {
+		t.Fatalf("output_tokens_details = %#v, want object", payload["output_tokens_details"])
+	}
+	if outputDetails["reasoning_tokens"] != float64(7) {
+		t.Fatalf("output_tokens_details.reasoning_tokens = %#v, want 7", outputDetails["reasoning_tokens"])
+	}
+	if payload["cache_read_input_tokens"] != float64(98) {
+		t.Fatalf("cache_read_input_tokens = %#v, want 98", payload["cache_read_input_tokens"])
+	}
+}

--- a/internal/providers/anthropic/anthropic.go
+++ b/internal/providers/anthropic/anthropic.go
@@ -215,7 +215,7 @@ type anthropicRequest struct {
 	ToolChoice   *anthropicToolChoice   `json:"tool_choice,omitempty"`
 	MaxTokens    int                    `json:"max_tokens"`
 	Temperature  *float64               `json:"temperature,omitempty"`
-	System       string                 `json:"system,omitempty"`
+	System       any                    `json:"system,omitempty"`
 	Stream       bool                   `json:"stream,omitempty"`
 	Thinking     *anthropicThinking     `json:"thinking,omitempty"`
 	OutputConfig *anthropicOutputConfig `json:"output_config,omitempty"`
@@ -254,15 +254,16 @@ type anthropicMessage struct {
 }
 
 type anthropicContentBlock struct {
-	Type      string                  `json:"type"`
-	Text      string                  `json:"text,omitempty"`
-	ID        string                  `json:"id,omitempty"`
-	Name      string                  `json:"name,omitempty"`
-	Input     any                     `json:"input,omitempty"`
-	ToolUseID string                  `json:"tool_use_id,omitempty"`
-	Content   any                     `json:"content,omitempty"`
-	IsError   bool                    `json:"is_error,omitempty"`
-	Source    *anthropicContentSource `json:"source,omitempty"`
+	Type         string                  `json:"type"`
+	Text         string                  `json:"text,omitempty"`
+	ID           string                  `json:"id,omitempty"`
+	Name         string                  `json:"name,omitempty"`
+	Input        any                     `json:"input,omitempty"`
+	ToolUseID    string                  `json:"tool_use_id,omitempty"`
+	Content      any                     `json:"content,omitempty"`
+	IsError      bool                    `json:"is_error,omitempty"`
+	Source       *anthropicContentSource `json:"source,omitempty"`
+	CacheControl json.RawMessage         `json:"cache_control,omitempty"`
 }
 
 type anthropicContentSource struct {
@@ -591,11 +592,18 @@ func anthropicChatUsagePayload(usage *anthropicUsage) map[string]any {
 		return nil
 	}
 
-	return map[string]any{
+	payload := map[string]any{
 		"prompt_tokens":     usage.InputTokens,
 		"completion_tokens": usage.OutputTokens,
 		"total_tokens":      usage.InputTokens + usage.OutputTokens,
 	}
+	if usage.CacheReadInputTokens > 0 {
+		payload["cache_read_input_tokens"] = usage.CacheReadInputTokens
+	}
+	if usage.CacheCreationInputTokens > 0 {
+		payload["cache_creation_input_tokens"] = usage.CacheCreationInputTokens
+	}
+	return payload
 }
 
 func anthropicResponsesUsagePayload(usage *anthropicUsage) map[string]any {
@@ -603,11 +611,18 @@ func anthropicResponsesUsagePayload(usage *anthropicUsage) map[string]any {
 		return nil
 	}
 
-	return map[string]any{
+	payload := map[string]any{
 		"input_tokens":  usage.InputTokens,
 		"output_tokens": usage.OutputTokens,
 		"total_tokens":  usage.InputTokens + usage.OutputTokens,
 	}
+	if usage.CacheReadInputTokens > 0 {
+		payload["cache_read_input_tokens"] = usage.CacheReadInputTokens
+	}
+	if usage.CacheCreationInputTokens > 0 {
+		payload["cache_creation_input_tokens"] = usage.CacheCreationInputTokens
+	}
+	return payload
 }
 
 func (sc *streamConverter) Read(p []byte) (n int, err error) {

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -551,8 +551,8 @@ data: {"type":"message_stop"}
 	if !strings.Contains(responseStr, `"total_tokens":12`) {
 		t.Fatalf("expected total_tokens in streamed usage, got %q", responseStr)
 	}
-	if strings.Contains(responseStr, `"cache_read_input_tokens":6`) {
-		t.Fatalf("did not expect cache_read_input_tokens in normalized streamed usage, got %q", responseStr)
+	if !strings.Contains(responseStr, `"cache_read_input_tokens":6`) {
+		t.Fatalf("expected cache_read_input_tokens in streamed usage, got %q", responseStr)
 	}
 }
 
@@ -2542,8 +2542,8 @@ data: {"type":"message_stop"}
 	if !strings.Contains(responseStr, `"total_tokens":12`) {
 		t.Fatalf("expected total_tokens in response.completed usage, got %q", responseStr)
 	}
-	if strings.Contains(responseStr, `"cache_creation_input_tokens":4`) {
-		t.Fatalf("did not expect cache_creation_input_tokens in normalized response.completed usage, got %q", responseStr)
+	if !strings.Contains(responseStr, `"cache_creation_input_tokens":4`) {
+		t.Fatalf("expected cache_creation_input_tokens in response.completed usage, got %q", responseStr)
 	}
 }
 
@@ -3915,6 +3915,101 @@ func TestConvertToAnthropicRequest_MultimodalImageContent(t *testing.T) {
 	}
 	if blocks[1].Type != "image" || blocks[1].Source == nil || blocks[1].Source.MediaType != "image/png" || blocks[1].Source.Data != "ZmFrZQ==" {
 		t.Fatalf("unexpected second block: %+v", blocks[1])
+	}
+}
+
+func TestConvertToAnthropicRequest_PreservesCacheControlOnContentBlocks(t *testing.T) {
+	req := &core.ChatRequest{
+		Model: "claude-sonnet-4-5-20250929",
+		Messages: []core.Message{
+			{
+				Role: "user",
+				Content: []core.ContentPart{
+					{
+						Type: "text",
+						Text: "Reusable prefix.",
+						ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+							"cache_control": json.RawMessage(`{"type":"ephemeral"}`),
+						}),
+					},
+					{
+						Type: "image_url",
+						ImageURL: &core.ImageURLContent{
+							URL: "data:image/png;base64,ZmFrZQ==",
+						},
+						ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+							"cache_control": json.RawMessage(`{"type":"ephemeral"}`),
+						}),
+					},
+				},
+			},
+		},
+	}
+
+	result, err := convertToAnthropicRequest(req)
+	if err != nil {
+		t.Fatalf("convertToAnthropicRequest() error = %v", err)
+	}
+
+	blocks, ok := result.Messages[0].Content.([]anthropicContentBlock)
+	if !ok {
+		t.Fatalf("message content type = %T, want []anthropicContentBlock", result.Messages[0].Content)
+	}
+	if len(blocks) != 2 {
+		t.Fatalf("len(blocks) = %d, want 2", len(blocks))
+	}
+	for i, block := range blocks {
+		if string(block.CacheControl) != `{"type":"ephemeral"}` {
+			t.Fatalf("blocks[%d].CacheControl = %s, want ephemeral cache_control", i, block.CacheControl)
+		}
+	}
+
+	body, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if got := strings.Count(string(body), `"cache_control":{"type":"ephemeral"}`); got != 2 {
+		t.Fatalf("marshaled request has %d cache_control blocks, want 2: %s", got, body)
+	}
+}
+
+func TestConvertToAnthropicRequest_PreservesCacheControlOnSystemBlocks(t *testing.T) {
+	req := &core.ChatRequest{
+		Model: "claude-sonnet-4-5-20250929",
+		Messages: []core.Message{
+			{
+				Role: "system",
+				Content: []core.ContentPart{
+					{
+						Type: "text",
+						Text: "Reusable system prefix.",
+						ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+							"cache_control": json.RawMessage(`{"type":"ephemeral"}`),
+						}),
+					},
+				},
+			},
+			{Role: "user", Content: "hello"},
+		},
+	}
+
+	result, err := convertToAnthropicRequest(req)
+	if err != nil {
+		t.Fatalf("convertToAnthropicRequest() error = %v", err)
+	}
+
+	blocks, ok := result.System.([]anthropicContentBlock)
+	if !ok {
+		t.Fatalf("System type = %T, want []anthropicContentBlock", result.System)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("len(System blocks) = %d, want 1", len(blocks))
+	}
+	if blocks[0].Type != "text" || blocks[0].Text != "Reusable system prefix." {
+		t.Fatalf("unexpected system block: %+v", blocks[0])
+	}
+	if string(blocks[0].CacheControl) != `{"type":"ephemeral"}` {
+		t.Fatalf("System[0].CacheControl = %s, want ephemeral cache_control", blocks[0].CacheControl)
 	}
 }
 

--- a/internal/providers/anthropic/request_translation.go
+++ b/internal/providers/anthropic/request_translation.go
@@ -1,6 +1,7 @@
 package anthropic
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -290,11 +291,11 @@ func convertToAnthropicRequest(req *core.ChatRequest) (*anthropicRequest, error)
 
 	for _, msg := range req.Messages {
 		if msg.Role == "system" {
-			systemText, err := textOnlyAnthropicContent(msg.Content)
+			systemContent, err := buildAnthropicSystemContent(msg.Content)
 			if err != nil {
 				return nil, err
 			}
-			anthropicReq.System = appendAnthropicSystemText(anthropicReq.System, systemText)
+			anthropicReq.System = appendAnthropicSystemContent(anthropicReq.System, systemContent)
 			continue
 		}
 
@@ -385,21 +386,115 @@ func appendAnthropicSystemText(existing, next string) string {
 	return existing + "\n\n" + next
 }
 
-func textOnlyAnthropicContent(content any) (string, error) {
+func appendAnthropicSystemContent(existing, next any) any {
+	if isEmptyAnthropicSystemContent(next) {
+		return existing
+	}
+	if isEmptyAnthropicSystemContent(existing) {
+		return next
+	}
+
+	if existingText, ok := existing.(string); ok {
+		if nextText, ok := next.(string); ok {
+			return appendAnthropicSystemText(existingText, nextText)
+		}
+	}
+
+	blocks := make([]anthropicContentBlock, 0)
+	blocks = append(blocks, anthropicSystemBlocks(existing)...)
+	blocks = append(blocks, anthropicSystemBlocks(next)...)
+	if len(blocks) == 0 {
+		return nil
+	}
+	return blocks
+}
+
+func isEmptyAnthropicSystemContent(content any) bool {
+	switch c := content.(type) {
+	case nil:
+		return true
+	case string:
+		return c == ""
+	case []anthropicContentBlock:
+		return len(c) == 0
+	default:
+		return false
+	}
+}
+
+func anthropicSystemBlocks(content any) []anthropicContentBlock {
+	switch c := content.(type) {
+	case string:
+		if c == "" {
+			return nil
+		}
+		return []anthropicContentBlock{{Type: "text", Text: c}}
+	case []anthropicContentBlock:
+		return c
+	default:
+		return nil
+	}
+}
+
+func buildAnthropicSystemContent(content any) (any, error) {
 	if !core.HasStructuredContent(content) {
-		return core.ExtractTextContent(content), nil
+		text := core.ExtractTextContent(content)
+		if text == "" {
+			return nil, nil
+		}
+		return text, nil
 	}
 
 	parts, ok := core.NormalizeContentParts(content)
 	if !ok {
-		return "", core.NewInvalidRequestError("unsupported anthropic chat content format", nil)
+		return nil, core.NewInvalidRequestError("unsupported anthropic chat content format", nil)
 	}
+
+	blocks := make([]anthropicContentBlock, 0, len(parts))
+	hasCacheControl := false
 	for _, part := range parts {
 		if part.Type != "text" {
-			return "", core.NewInvalidRequestError("anthropic system messages only support text content", nil)
+			return nil, core.NewInvalidRequestError("anthropic system messages only support text content", nil)
 		}
+		if part.Text == "" {
+			continue
+		}
+		cacheControl, err := anthropicCacheControlFromExtra(part.ExtraFields)
+		if err != nil {
+			return nil, err
+		}
+		if len(cacheControl) > 0 {
+			hasCacheControl = true
+		}
+		blocks = append(blocks, anthropicContentBlock{
+			Type:         "text",
+			Text:         part.Text,
+			CacheControl: cacheControl,
+		})
 	}
-	return core.ExtractTextContent(parts), nil
+	if len(blocks) == 0 {
+		return nil, nil
+	}
+	if !hasCacheControl {
+		return core.ExtractTextContent(parts), nil
+	}
+	return blocks, nil
+}
+
+func anthropicCacheControlFromExtra(extraFields core.UnknownJSONFields) (json.RawMessage, error) {
+	raw := extraFields.Lookup("cache_control")
+	if len(raw) == 0 {
+		return nil, nil
+	}
+
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil, nil
+	}
+	if trimmed[0] != '{' {
+		return nil, core.NewInvalidRequestError("anthropic cache_control must be an object", nil)
+	}
+	return core.CloneRawJSON(trimmed), nil
 }
 
 func convertMessageContentToAnthropic(content any) (any, error) {
@@ -414,14 +509,19 @@ func convertMessageContentToAnthropic(content any) (any, error) {
 
 	blocks := make([]anthropicContentBlock, 0, len(parts))
 	for _, part := range parts {
+		cacheControl, err := anthropicCacheControlFromExtra(part.ExtraFields)
+		if err != nil {
+			return nil, err
+		}
 		switch part.Type {
 		case "text":
 			if part.Text == "" {
 				continue
 			}
 			blocks = append(blocks, anthropicContentBlock{
-				Type: "text",
-				Text: part.Text,
+				Type:         "text",
+				Text:         part.Text,
+				CacheControl: cacheControl,
 			})
 		case "image_url":
 			if part.ImageURL == nil || part.ImageURL.URL == "" {
@@ -432,8 +532,9 @@ func convertMessageContentToAnthropic(content any) (any, error) {
 				return nil, err
 			}
 			blocks = append(blocks, anthropicContentBlock{
-				Type:   "image",
-				Source: source,
+				Type:         "image",
+				Source:       source,
+				CacheControl: cacheControl,
 			})
 		case "input_audio":
 			return nil, core.NewInvalidRequestError("anthropic chat does not support input_audio content", nil)

--- a/internal/providers/xai/xai.go
+++ b/internal/providers/xai/xai.go
@@ -3,10 +3,14 @@ package xai
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"gomodel/internal/core"
 	"gomodel/internal/llmclient"
@@ -23,7 +27,8 @@ var Registration = providers.Registration{
 }
 
 const (
-	defaultBaseURL = "https://api.x.ai/v1"
+	defaultBaseURL   = "https://api.x.ai/v1"
+	grokConvIDHeader = "X-Grok-Conv-Id"
 )
 
 // Provider implements the core.Provider interface for xAI
@@ -74,6 +79,96 @@ func (p *Provider) setHeaders(req *http.Request) {
 	}
 }
 
+type grokConversationAnchor struct {
+	Model             string           `json:"model,omitempty"`
+	Messages          []core.Message   `json:"messages,omitempty"`
+	Tools             []map[string]any `json:"tools,omitempty"`
+	ToolChoice        any              `json:"tool_choice,omitempty"`
+	ParallelToolCalls *bool            `json:"parallel_tool_calls,omitempty"`
+	Reasoning         *core.Reasoning  `json:"reasoning,omitempty"`
+	RequestID         string           `json:"request_id,omitempty"`
+}
+
+func xGrokConversationHeaders(ctx context.Context, req *core.ChatRequest) http.Header {
+	convID := xGrokConversationID(ctx, req)
+	if convID == "" {
+		return nil
+	}
+	headers := make(http.Header, 1)
+	headers.Set(grokConvIDHeader, convID)
+	return headers
+}
+
+func xGrokConversationID(ctx context.Context, req *core.ChatRequest) string {
+	if convID := xGrokConversationIDFromSnapshot(ctx); convID != "" {
+		return convID
+	}
+	return generatedXGrokConversationID(ctx, req)
+}
+
+func xGrokConversationIDFromSnapshot(ctx context.Context) string {
+	snapshot := core.GetRequestSnapshot(ctx)
+	if snapshot == nil {
+		return ""
+	}
+	for key, values := range snapshot.GetHeaders() {
+		if !strings.EqualFold(key, grokConvIDHeader) {
+			continue
+		}
+		for _, value := range values {
+			if convID := cleanXGrokConversationID(value); convID != "" {
+				return convID
+			}
+		}
+	}
+	return ""
+}
+
+func generatedXGrokConversationID(ctx context.Context, req *core.ChatRequest) string {
+	anchor := grokConversationAnchor{
+		RequestID: strings.TrimSpace(core.GetRequestID(ctx)),
+	}
+	if req != nil {
+		anchor.Model = req.Model
+		anchor.Messages = xGrokAnchorMessages(req.Messages)
+		anchor.Tools = req.Tools
+		anchor.ToolChoice = req.ToolChoice
+		anchor.ParallelToolCalls = req.ParallelToolCalls
+		anchor.Reasoning = req.Reasoning
+		anchor.RequestID = ""
+	}
+	if anchor.Model == "" && len(anchor.Messages) == 0 && anchor.RequestID == "" {
+		return ""
+	}
+	body, err := json.Marshal(anchor)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(body)
+	return "gomodel-" + hex.EncodeToString(sum[:16])
+}
+
+func xGrokAnchorMessages(messages []core.Message) []core.Message {
+	if len(messages) == 0 {
+		return nil
+	}
+	limit := 2
+	if len(messages) < limit {
+		limit = len(messages)
+	}
+	anchor := make([]core.Message, limit)
+	copy(anchor, messages[:limit])
+	return anchor
+}
+
+func cleanXGrokConversationID(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" || strings.ContainsAny(value, "\r\n") {
+		return ""
+	}
+	return value
+}
+
 // ChatCompletion sends a chat completion request to xAI
 func (p *Provider) ChatCompletion(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
 	var resp core.ChatResponse
@@ -81,6 +176,7 @@ func (p *Provider) ChatCompletion(ctx context.Context, req *core.ChatRequest) (*
 		Method:   http.MethodPost,
 		Endpoint: "/chat/completions",
 		Body:     req,
+		Headers:  xGrokConversationHeaders(ctx, req),
 	}, &resp)
 	if err != nil {
 		return nil, err
@@ -97,6 +193,7 @@ func (p *Provider) StreamChatCompletion(ctx context.Context, req *core.ChatReque
 		Method:   http.MethodPost,
 		Endpoint: "/chat/completions",
 		Body:     req.WithStreaming(),
+		Headers:  xGrokConversationHeaders(ctx, req),
 	})
 }
 

--- a/internal/providers/xai/xai_test.go
+++ b/internal/providers/xai/xai_test.go
@@ -127,6 +127,153 @@ func TestNewWithHTTPClient(t *testing.T) {
 	}
 }
 
+func TestChatCompletion_ForwardsXGrokConvIDFromSnapshot(t *testing.T) {
+	var receivedConvID string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedConvID = r.Header.Get(grokConvIDHeader)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"id": "chatcmpl-123",
+			"object": "chat.completion",
+			"created": 1677652288,
+			"model": "grok-2",
+			"choices": [{
+				"index": 0,
+				"message": {"role": "assistant", "content": "Hello!"},
+				"finish_reason": "stop"
+			}],
+			"usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+		}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("test-api-key", server.Client(), llmclient.Hooks{})
+	provider.SetBaseURL(server.URL)
+
+	ctx := core.WithRequestSnapshot(context.Background(), core.NewRequestSnapshot(
+		http.MethodPost,
+		"/v1/chat/completions",
+		nil,
+		nil,
+		map[string][]string{"x-grok-conv-id": {"client-conv-123"}},
+		"application/json",
+		nil,
+		false,
+		"req-123",
+		nil,
+	))
+	_, err := provider.ChatCompletion(ctx, &core.ChatRequest{
+		Model: "grok-2",
+		Messages: []core.Message{
+			{Role: "user", Content: "Hello"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ChatCompletion() error = %v", err)
+	}
+	if receivedConvID != "client-conv-123" {
+		t.Fatalf("%s = %q, want client-conv-123", grokConvIDHeader, receivedConvID)
+	}
+}
+
+func TestChatCompletion_GeneratesStableXGrokConvIDWhenMissing(t *testing.T) {
+	var receivedConvIDs []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedConvIDs = append(receivedConvIDs, r.Header.Get(grokConvIDHeader))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"id": "chatcmpl-123",
+			"object": "chat.completion",
+			"created": 1677652288,
+			"model": "grok-2",
+			"choices": [{
+				"index": 0,
+				"message": {"role": "assistant", "content": "Hello!"},
+				"finish_reason": "stop"
+			}],
+			"usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+		}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("test-api-key", server.Client(), llmclient.Hooks{})
+	provider.SetBaseURL(server.URL)
+
+	initialMessages := []core.Message{
+		{Role: "system", Content: "Reply with the requested marker only."},
+		{Role: "user", Content: "Use this fixed reference text for the cache anchor."},
+	}
+	req1 := &core.ChatRequest{
+		Model:    "grok-2",
+		Messages: initialMessages,
+	}
+	req2 := &core.ChatRequest{
+		Model: "grok-2",
+		Messages: append(append([]core.Message{}, initialMessages...),
+			core.Message{Role: "assistant", Content: "marker one"},
+			core.Message{Role: "user", Content: "Now reply with marker two."},
+		),
+	}
+
+	if _, err := provider.ChatCompletion(context.Background(), req1); err != nil {
+		t.Fatalf("first ChatCompletion() error = %v", err)
+	}
+	if _, err := provider.ChatCompletion(context.Background(), req2); err != nil {
+		t.Fatalf("second ChatCompletion() error = %v", err)
+	}
+	if len(receivedConvIDs) != 2 {
+		t.Fatalf("received %d requests, want 2", len(receivedConvIDs))
+	}
+	if receivedConvIDs[0] == "" {
+		t.Fatal("first generated x-grok-conv-id is empty")
+	}
+	if !strings.HasPrefix(receivedConvIDs[0], "gomodel-") {
+		t.Fatalf("generated x-grok-conv-id = %q, want gomodel-*", receivedConvIDs[0])
+	}
+	if receivedConvIDs[1] != receivedConvIDs[0] {
+		t.Fatalf("generated x-grok-conv-id changed across appended conversation: %q then %q", receivedConvIDs[0], receivedConvIDs[1])
+	}
+}
+
+func TestStreamChatCompletion_ForwardsXGrokConvIDFromSnapshot(t *testing.T) {
+	var receivedConvID string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedConvID = r.Header.Get(grokConvIDHeader)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("test-api-key", server.Client(), llmclient.Hooks{})
+	provider.SetBaseURL(server.URL)
+
+	ctx := core.WithRequestSnapshot(context.Background(), core.NewRequestSnapshot(
+		http.MethodPost,
+		"/v1/chat/completions",
+		nil,
+		nil,
+		map[string][]string{"X-Grok-Conv-Id": {"stream-conv-123"}},
+		"application/json",
+		nil,
+		false,
+		"req-123",
+		nil,
+	))
+	body, err := provider.StreamChatCompletion(ctx, &core.ChatRequest{
+		Model: "grok-2",
+		Messages: []core.Message{
+			{Role: "user", Content: "Hello"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("StreamChatCompletion() error = %v", err)
+	}
+	defer func() { _ = body.Close() }()
+	if receivedConvID != "stream-conv-123" {
+		t.Fatalf("%s = %q, want stream-conv-123", grokConvIDHeader, receivedConvID)
+	}
+}
+
 func TestChatCompletion(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/usage/cost.go
+++ b/internal/usage/cost.go
@@ -57,7 +57,14 @@ var providerMappings = map[string][]tokenCostMapping{
 	},
 	"gemini": {
 		{rawDataKey: "cached_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, side: sideInput, unit: unitPerMtok, includedInBase: true},
+		{rawDataKey: "prompt_cached_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, side: sideInput, unit: unitPerMtok, includedInBase: true},
 		{rawDataKey: "thought_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, side: sideOutput, unit: unitPerMtok, includedInBase: true},
+	},
+	"groq": {
+		{rawDataKey: "cached_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, side: sideInput, unit: unitPerMtok, includedInBase: true},
+		{rawDataKey: "prompt_cached_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, side: sideInput, unit: unitPerMtok, includedInBase: true},
+		{rawDataKey: "reasoning_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, side: sideOutput, unit: unitPerMtok, includedInBase: true},
+		{rawDataKey: "completion_reasoning_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, side: sideOutput, unit: unitPerMtok, includedInBase: true},
 	},
 	"xai": {
 		{rawDataKey: "cached_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, side: sideInput, unit: unitPerMtok, includedInBase: true},
@@ -78,19 +85,6 @@ var informationalFields = map[string]struct{}{
 	"completion_accepted_prediction_tokens": {},
 	"completion_rejected_prediction_tokens": {},
 }
-
-// extendedFieldSet is derived from providerMappings and contains all RawData keys
-// that providers may report. Used by stream_wrapper.go to extract extended fields
-// from SSE usage data without maintaining a separate hard-coded list.
-var extendedFieldSet = func() map[string]struct{} {
-	set := make(map[string]struct{})
-	for _, mappings := range providerMappings {
-		for _, m := range mappings {
-			set[m.rawDataKey] = struct{}{}
-		}
-	}
-	return set
-}()
 
 // CalculateGranularCost computes input, output, and total costs from token counts,
 // raw provider-specific data, and pricing information. It accounts for cached tokens,

--- a/internal/usage/cost_test.go
+++ b/internal/usage/cost_test.go
@@ -112,6 +112,24 @@ func TestCalculateGranularCost_Gemini_ThoughtTokens(t *testing.T) {
 	assertCostNear(t, "OutputCost", result.OutputCost, 1.375)
 }
 
+func TestCalculateGranularCost_Gemini_PromptCachedTokens(t *testing.T) {
+	pricing := &core.ModelPricing{
+		InputPerMtok:       new(0.30),
+		OutputPerMtok:      new(2.5),
+		CachedInputPerMtok: new(0.03),
+	}
+	rawData := map[string]any{
+		"prompt_cached_tokens": 11_240,
+	}
+	result := CalculateGranularCost(11_653, 1, rawData, "gemini", pricing)
+
+	// Input: 11653 * 0.30/1M + 11240 * (0.03-0.30)/1M
+	assertCostNear(t, "InputCost", result.InputCost, 0.0004611)
+	if result.Caveat != "" {
+		t.Fatalf("expected no caveat for gemini prompt_cached_tokens, got %q", result.Caveat)
+	}
+}
+
 func TestCalculateGranularCost_XAI_ImageTokens(t *testing.T) {
 	pricing := &core.ModelPricing{
 		InputPerMtok:  new(2.0),
@@ -311,6 +329,27 @@ func TestCalculateGranularCost_XAI_ReasoningTokensAreAdditionalOutput(t *testing
 	// Output: 1 * 0.5/1M + 270 * 1.5/1M = 0.0000005 + 0.000405 = 0.0004055
 	assertCostNear(t, "OutputCost", result.OutputCost, 0.0004055)
 	assertCostNear(t, "TotalCost", result.TotalCost, 0.0004082)
+}
+
+func TestCalculateGranularCost_Groq_PromptCachedTokensAndReasoningBreakdown(t *testing.T) {
+	pricing := &core.ModelPricing{
+		InputPerMtok:       new(0.075),
+		OutputPerMtok:      new(0.30),
+		CachedInputPerMtok: new(0.0375),
+		// ReasoningOutputPerMtok intentionally nil: base output rate covers the model.
+	}
+	rawData := map[string]any{
+		"prompt_cached_tokens":        1280,
+		"completion_reasoning_tokens": 2,
+	}
+	result := CalculateGranularCost(1409, 4, rawData, "groq", pricing)
+
+	// Input: 1409 * 0.075/1M + 1280 * (0.0375-0.075)/1M
+	assertCostNear(t, "InputCost", result.InputCost, 0.000057675)
+	assertCostNear(t, "OutputCost", result.OutputCost, 0.0000012)
+	if result.Caveat != "" {
+		t.Fatalf("expected no caveat for groq prompt_cached_tokens/reasoning breakdown, got %q", result.Caveat)
+	}
 }
 
 func TestCalculateGranularCost_InformationalFieldsNoCaveat(t *testing.T) {

--- a/internal/usage/extractor.go
+++ b/internal/usage/extractor.go
@@ -54,6 +54,31 @@ func buildRawUsageFromDetails(ptd *core.PromptTokensDetails, ctd *core.Completio
 	return raw
 }
 
+func mergeRawUsageMaps(base map[string]any, overlays ...map[string]any) map[string]any {
+	var merged map[string]any
+	if len(base) > 0 {
+		merged = cloneRawData(base)
+	}
+	for _, overlay := range overlays {
+		if len(overlay) == 0 {
+			continue
+		}
+		if merged == nil {
+			merged = make(map[string]any, len(overlay))
+		}
+		for key, value := range overlay {
+			if _, exists := merged[key]; exists {
+				continue
+			}
+			merged[key] = value
+		}
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+	return merged
+}
+
 // ExtractFromChatResponse extracts usage data from a ChatResponse.
 // It normalizes the usage data into a UsageEntry and preserves raw extended data.
 // If pricing is provided, granular cost fields are calculated.
@@ -77,16 +102,10 @@ func ExtractFromChatResponse(resp *core.ChatResponse, requestID, provider, endpo
 		TotalTokens:  resp.Usage.TotalTokens,
 	}
 
-	// Preserve raw extended usage data if available (defensive copy to avoid races)
-	if len(resp.Usage.RawUsage) > 0 {
-		entry.RawData = cloneRawData(resp.Usage.RawUsage)
-	}
-
-	// Merge typed detail fields into RawData (non-streaming path).
-	// Only fill from details when RawUsage wasn't already set by the provider.
-	if entry.RawData == nil {
-		entry.RawData = buildRawUsageFromDetails(resp.Usage.PromptTokensDetails, resp.Usage.CompletionTokensDetails)
-	}
+	entry.RawData = mergeRawUsageMaps(
+		resp.Usage.RawUsage,
+		buildRawUsageFromDetails(resp.Usage.PromptTokensDetails, resp.Usage.CompletionTokensDetails),
+	)
 
 	// Calculate granular costs if pricing is provided
 	if len(pricing) > 0 && pricing[0] != nil {
@@ -138,15 +157,10 @@ func ExtractFromResponsesResponse(resp *core.ResponsesResponse, requestID, provi
 		entry.OutputTokens = resp.Usage.OutputTokens
 		entry.TotalTokens = resp.Usage.TotalTokens
 
-		// Preserve raw extended usage data if available (defensive copy to avoid races)
-		if len(resp.Usage.RawUsage) > 0 {
-			entry.RawData = cloneRawData(resp.Usage.RawUsage)
-		}
-
-		// Merge typed detail fields into RawData (non-streaming path).
-		if entry.RawData == nil {
-			entry.RawData = buildRawUsageFromDetails(resp.Usage.PromptTokensDetails, resp.Usage.CompletionTokensDetails)
-		}
+		entry.RawData = mergeRawUsageMaps(
+			resp.Usage.RawUsage,
+			buildRawUsageFromDetails(resp.Usage.PromptTokensDetails, resp.Usage.CompletionTokensDetails),
+		)
 	}
 
 	// Calculate granular costs if pricing is provided

--- a/internal/usage/extractor_test.go
+++ b/internal/usage/extractor_test.go
@@ -305,8 +305,8 @@ func TestExtractFromChatResponse_RawUsageTakesPrecedenceOverDetails(t *testing.T
 	if entry.RawData["cached_tokens"] != 99 {
 		t.Errorf("RawData[cached_tokens] = %v, want 99 (from RawUsage)", entry.RawData["cached_tokens"])
 	}
-	if _, exists := entry.RawData["prompt_cached_tokens"]; exists {
-		t.Error("details should not be merged when RawUsage is already set")
+	if entry.RawData["prompt_cached_tokens"] != 150 {
+		t.Errorf("RawData[prompt_cached_tokens] = %v, want 150 (from PromptTokensDetails)", entry.RawData["prompt_cached_tokens"])
 	}
 }
 

--- a/internal/usage/reader.go
+++ b/internal/usage/reader.go
@@ -104,6 +104,22 @@ type UsageLogResult struct {
 	Offset  int             `json:"offset"`
 }
 
+// RequestUsageSummary aggregates usage records that belong to one request ID.
+// InputTokens and TotalTokens are normalized prompt/total counts across providers:
+// cached prompt reads and cache writes are included even when the upstream provider
+// reports them outside the base input token count.
+type RequestUsageSummary struct {
+	Entries                   int     `json:"entries"`
+	InputTokens               int64   `json:"input_tokens"`
+	UncachedInputTokens       int64   `json:"uncached_input_tokens"`
+	CachedInputTokens         int64   `json:"cached_input_tokens"`
+	CacheWriteInputTokens     int64   `json:"cache_write_input_tokens"`
+	OutputTokens              int64   `json:"output_tokens"`
+	TotalTokens               int64   `json:"total_tokens"`
+	CachedInputRatio          float64 `json:"cached_input_ratio"`
+	EstimatedCachedCharacters int64   `json:"estimated_cached_characters"`
+}
+
 // CacheOverviewSummary holds cached-only aggregate statistics over a time period.
 type CacheOverviewSummary struct {
 	TotalHits      int      `json:"total_hits"`
@@ -152,6 +168,10 @@ type UsageReader interface {
 	// GetUsageLog returns a paginated list of individual usage entries with optional filtering.
 	GetUsageLog(ctx context.Context, params UsageLogParams) (*UsageLogResult, error)
 
+	// GetUsageByRequestIDs returns usage log entries grouped by request_id.
+	// Missing IDs are omitted from the returned map.
+	GetUsageByRequestIDs(ctx context.Context, requestIDs []string) (map[string][]UsageLogEntry, error)
+
 	// GetCacheOverview returns cached-only aggregates for the admin dashboard.
 	GetCacheOverview(ctx context.Context, params UsageQueryParams) (*CacheOverview, error)
 }
@@ -161,4 +181,24 @@ func displayUsageProviderName(providerName, provider string) string {
 		return trimmed
 	}
 	return strings.TrimSpace(provider)
+}
+
+func compactNonEmptyStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	compacted := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if _, exists := seen[trimmed]; exists {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		compacted = append(compacted, trimmed)
+	}
+	return compacted
 }

--- a/internal/usage/reader_mongodb.go
+++ b/internal/usage/reader_mongodb.go
@@ -8,6 +8,7 @@ import (
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // MongoDBReader implements UsageReader for MongoDB.
@@ -365,6 +366,74 @@ func (r *MongoDBReader) GetUsageLog(ctx context.Context, params UsageLogParams) 
 		Limit:   limit,
 		Offset:  offset,
 	}, nil
+}
+
+// GetUsageByRequestIDs returns usage entries grouped by request ID.
+func (r *MongoDBReader) GetUsageByRequestIDs(ctx context.Context, requestIDs []string) (map[string][]UsageLogEntry, error) {
+	requestIDs = compactNonEmptyStrings(requestIDs)
+	if len(requestIDs) == 0 {
+		return map[string][]UsageLogEntry{}, nil
+	}
+
+	cursor, err := r.collection.Find(ctx,
+		bson.D{{Key: "request_id", Value: bson.D{{Key: "$in", Value: requestIDs}}}},
+		options.Find().SetSort(bson.D{{Key: "timestamp", Value: -1}, {Key: "_id", Value: -1}}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query usage by request IDs: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	var rows []struct {
+		ID                     string         `bson:"_id"`
+		RequestID              string         `bson:"request_id"`
+		ProviderID             string         `bson:"provider_id"`
+		Timestamp              time.Time      `bson:"timestamp"`
+		Model                  string         `bson:"model"`
+		Provider               string         `bson:"provider"`
+		ProviderName           string         `bson:"provider_name"`
+		Endpoint               string         `bson:"endpoint"`
+		UserPath               string         `bson:"user_path"`
+		CacheType              string         `bson:"cache_type"`
+		InputTokens            int            `bson:"input_tokens"`
+		OutputTokens           int            `bson:"output_tokens"`
+		TotalTokens            int            `bson:"total_tokens"`
+		InputCost              *float64       `bson:"input_cost"`
+		OutputCost             *float64       `bson:"output_cost"`
+		TotalCost              *float64       `bson:"total_cost"`
+		RawData                map[string]any `bson:"raw_data"`
+		CostsCalculationCaveat string         `bson:"costs_calculation_caveat"`
+	}
+	if err := cursor.All(ctx, &rows); err != nil {
+		return nil, fmt.Errorf("failed to decode usage by request ID rows: %w", err)
+	}
+
+	grouped := make(map[string][]UsageLogEntry, len(requestIDs))
+	for _, row := range rows {
+		entry := UsageLogEntry{
+			ID:                     row.ID,
+			RequestID:              row.RequestID,
+			ProviderID:             row.ProviderID,
+			Timestamp:              row.Timestamp,
+			Model:                  row.Model,
+			Provider:               row.Provider,
+			ProviderName:           displayUsageProviderName(row.ProviderName, row.Provider),
+			Endpoint:               row.Endpoint,
+			UserPath:               row.UserPath,
+			CacheType:              normalizeCacheType(row.CacheType),
+			InputTokens:            row.InputTokens,
+			OutputTokens:           row.OutputTokens,
+			TotalTokens:            row.TotalTokens,
+			InputCost:              row.InputCost,
+			OutputCost:             row.OutputCost,
+			TotalCost:              row.TotalCost,
+			RawData:                row.RawData,
+			CostsCalculationCaveat: row.CostsCalculationCaveat,
+		}
+		grouped[entry.RequestID] = append(grouped[entry.RequestID], entry)
+	}
+
+	return grouped, nil
 }
 
 // mongoDateRangeFilter returns a bson.D timestamp filter for the given date range.

--- a/internal/usage/reader_postgresql.go
+++ b/internal/usage/reader_postgresql.go
@@ -15,6 +15,11 @@ type PostgreSQLReader struct {
 	pool *pgxpool.Pool
 }
 
+type pgxRows interface {
+	Next() bool
+	Scan(dest ...any) error
+}
+
 // NewPostgreSQLReader creates a new PostgreSQL usage reader.
 func NewPostgreSQLReader(pool *pgxpool.Pool) (*PostgreSQLReader, error) {
 	if pool == nil {
@@ -164,6 +169,63 @@ func (r *PostgreSQLReader) GetUsageLog(ctx context.Context, params UsageLogParam
 	}
 	defer rows.Close()
 
+	entries, err := scanPostgreSQLUsageLogEntries(rows)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating usage log rows: %w", err)
+	}
+
+	return &UsageLogResult{
+		Entries: entries,
+		Total:   total,
+		Limit:   limit,
+		Offset:  offset,
+	}, nil
+}
+
+// GetUsageByRequestIDs returns usage entries grouped by request ID.
+func (r *PostgreSQLReader) GetUsageByRequestIDs(ctx context.Context, requestIDs []string) (map[string][]UsageLogEntry, error) {
+	requestIDs = compactNonEmptyStrings(requestIDs)
+	if len(requestIDs) == 0 {
+		return map[string][]UsageLogEntry{}, nil
+	}
+
+	args := make([]any, 0, len(requestIDs))
+	placeholders := make([]string, 0, len(requestIDs))
+	for idx, requestID := range requestIDs {
+		args = append(args, requestID)
+		placeholders = append(placeholders, fmt.Sprintf("$%d", idx+1))
+	}
+
+	query := fmt.Sprintf(`SELECT id, request_id, provider_id, timestamp, model, provider, provider_name, endpoint, user_path, cache_type,
+		input_tokens, output_tokens, total_tokens, COALESCE(input_cost, 0), COALESCE(output_cost, 0), COALESCE(total_cost, 0), raw_data, COALESCE(costs_calculation_caveat, '')
+		FROM "usage" WHERE request_id IN (%s) ORDER BY timestamp DESC, id DESC`, strings.Join(placeholders, ", "))
+
+	rows, err := r.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query usage by request IDs: %w", err)
+	}
+	defer rows.Close()
+
+	entries, err := scanPostgreSQLUsageLogEntries(rows)
+	if err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating usage by request ID rows: %w", err)
+	}
+
+	grouped := make(map[string][]UsageLogEntry, len(requestIDs))
+	for _, entry := range entries {
+		grouped[entry.RequestID] = append(grouped[entry.RequestID], entry)
+	}
+	return grouped, nil
+}
+
+func scanPostgreSQLUsageLogEntries(rows pgxRows) ([]UsageLogEntry, error) {
 	entries := make([]UsageLogEntry, 0)
 	for rows.Next() {
 		var e UsageLogEntry
@@ -193,17 +255,7 @@ func (r *PostgreSQLReader) GetUsageLog(ctx context.Context, params UsageLogParam
 		}
 		entries = append(entries, e)
 	}
-
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("error iterating usage log rows: %w", err)
-	}
-
-	return &UsageLogResult{
-		Entries: entries,
-		Total:   total,
-		Limit:   limit,
-		Offset:  offset,
-	}, nil
+	return entries, nil
 }
 
 // pgDateRangeConditions returns WHERE conditions and args for a date range.

--- a/internal/usage/reader_sqlite.go
+++ b/internal/usage/reader_sqlite.go
@@ -161,6 +161,62 @@ func (r *SQLiteReader) GetUsageLog(ctx context.Context, params UsageLogParams) (
 	}
 	defer rows.Close()
 
+	entries, err := scanSQLiteUsageLogEntries(rows)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating usage log rows: %w", err)
+	}
+
+	return &UsageLogResult{
+		Entries: entries,
+		Total:   total,
+		Limit:   limit,
+		Offset:  offset,
+	}, nil
+}
+
+// GetUsageByRequestIDs returns usage entries grouped by request ID.
+func (r *SQLiteReader) GetUsageByRequestIDs(ctx context.Context, requestIDs []string) (map[string][]UsageLogEntry, error) {
+	requestIDs = compactNonEmptyStrings(requestIDs)
+	if len(requestIDs) == 0 {
+		return map[string][]UsageLogEntry{}, nil
+	}
+
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(requestIDs)), ",")
+	args := make([]any, 0, len(requestIDs))
+	for _, requestID := range requestIDs {
+		args = append(args, requestID)
+	}
+
+	query := `SELECT id, request_id, provider_id, timestamp, model, provider, provider_name, endpoint, user_path, cache_type,
+		input_tokens, output_tokens, total_tokens, COALESCE(input_cost, 0), COALESCE(output_cost, 0), COALESCE(total_cost, 0), raw_data, COALESCE(costs_calculation_caveat, '')
+		FROM usage WHERE request_id IN (` + placeholders + `) ORDER BY ` + sqliteTimestampEpochExpr() + ` DESC, id DESC`
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query usage by request IDs: %w", err)
+	}
+	defer rows.Close()
+
+	entries, err := scanSQLiteUsageLogEntries(rows)
+	if err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating usage by request ID rows: %w", err)
+	}
+
+	grouped := make(map[string][]UsageLogEntry, len(requestIDs))
+	for _, entry := range entries {
+		grouped[entry.RequestID] = append(grouped[entry.RequestID], entry)
+	}
+	return grouped, nil
+}
+
+func scanSQLiteUsageLogEntries(rows *sql.Rows) ([]UsageLogEntry, error) {
 	entries := make([]UsageLogEntry, 0)
 	for rows.Next() {
 		var e UsageLogEntry
@@ -204,17 +260,7 @@ func (r *SQLiteReader) GetUsageLog(ctx context.Context, params UsageLogParams) (
 		}
 		entries = append(entries, e)
 	}
-
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("error iterating usage log rows: %w", err)
-	}
-
-	return &UsageLogResult{
-		Entries: entries,
-		Total:   total,
-		Limit:   limit,
-		Offset:  offset,
-	}, nil
+	return entries, nil
 }
 
 func sqliteTimestampTextExpr() string {

--- a/internal/usage/request_summary.go
+++ b/internal/usage/request_summary.go
@@ -1,0 +1,90 @@
+package usage
+
+import "strings"
+
+const estimatedCharactersPerToken int64 = 4
+
+// SummarizeUsageByRequestID aggregates usage log entries for each request ID.
+func SummarizeUsageByRequestID(entriesByRequest map[string][]UsageLogEntry) map[string]*RequestUsageSummary {
+	if len(entriesByRequest) == 0 {
+		return nil
+	}
+
+	summaries := make(map[string]*RequestUsageSummary, len(entriesByRequest))
+	for requestID, entries := range entriesByRequest {
+		summary := SummarizeRequestUsage(entries)
+		if summary == nil {
+			continue
+		}
+		summaries[requestID] = summary
+	}
+	if len(summaries) == 0 {
+		return nil
+	}
+	return summaries
+}
+
+// SummarizeRequestUsage aggregates one request's usage entries into a normalized summary.
+func SummarizeRequestUsage(entries []UsageLogEntry) *RequestUsageSummary {
+	if len(entries) == 0 {
+		return nil
+	}
+
+	summary := &RequestUsageSummary{}
+	for _, entry := range entries {
+		uncachedInput, cachedInput, cacheWriteInput := requestInputSegments(entry)
+		totalInput := uncachedInput + cachedInput + cacheWriteInput
+
+		summary.Entries++
+		summary.InputTokens += totalInput
+		summary.UncachedInputTokens += uncachedInput
+		summary.CachedInputTokens += cachedInput
+		summary.CacheWriteInputTokens += cacheWriteInput
+		summary.OutputTokens += int64(entry.OutputTokens)
+	}
+
+	summary.TotalTokens = summary.InputTokens + summary.OutputTokens
+	if summary.InputTokens > 0 {
+		summary.CachedInputRatio = float64(summary.CachedInputTokens) / float64(summary.InputTokens)
+	}
+	summary.EstimatedCachedCharacters = summary.CachedInputTokens * estimatedCharactersPerToken
+
+	return summary
+}
+
+func requestInputSegments(entry UsageLogEntry) (uncachedInput, cachedInput, cacheWriteInput int64) {
+	cacheReadTopLevel := int64(extractInt(entry.RawData, "cache_read_input_tokens"))
+	cacheReadNormalized := int64(extractInt(entry.RawData, "prompt_cached_tokens"))
+	cacheReadGeneric := int64(extractInt(entry.RawData, "cached_tokens"))
+	cacheWriteInput = int64(extractInt(entry.RawData, "cache_creation_input_tokens"))
+
+	cachedInput = maxInt64(cacheReadTopLevel, cacheReadNormalized, cacheReadGeneric)
+	baseInput := int64(entry.InputTokens)
+
+	if requestUsesSplitCacheAccounting(entry, cacheReadTopLevel, cacheWriteInput) {
+		return baseInput, cachedInput, cacheWriteInput
+	}
+
+	if cachedInput > baseInput {
+		cachedInput = baseInput
+	}
+	uncachedInput = baseInput - cachedInput
+	return uncachedInput, cachedInput, cacheWriteInput
+}
+
+func requestUsesSplitCacheAccounting(entry UsageLogEntry, cacheReadInput, cacheWriteInput int64) bool {
+	if cacheReadInput > 0 || cacheWriteInput > 0 {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(entry.Provider), "anthropic")
+}
+
+func maxInt64(values ...int64) int64 {
+	var max int64
+	for _, value := range values {
+		if value > max {
+			max = value
+		}
+	}
+	return max
+}

--- a/internal/usage/request_summary.go
+++ b/internal/usage/request_summary.go
@@ -61,7 +61,7 @@ func requestInputSegments(entry UsageLogEntry) (uncachedInput, cachedInput, cach
 	cachedInput = maxInt64(cacheReadTopLevel, cacheReadNormalized, cacheReadGeneric)
 	baseInput := int64(entry.InputTokens)
 
-	if requestUsesSplitCacheAccounting(entry, cacheReadTopLevel, cacheWriteInput) {
+	if requestUsesSplitPromptCacheAccounting(entry, cacheReadTopLevel, cacheWriteInput) {
 		return baseInput, cachedInput, cacheWriteInput
 	}
 
@@ -72,10 +72,12 @@ func requestInputSegments(entry UsageLogEntry) (uncachedInput, cachedInput, cach
 	return uncachedInput, cachedInput, cacheWriteInput
 }
 
-func requestUsesSplitCacheAccounting(entry UsageLogEntry, cacheReadInput, cacheWriteInput int64) bool {
+func requestUsesSplitPromptCacheAccounting(entry UsageLogEntry, cacheReadInput, cacheWriteInput int64) bool {
 	if cacheReadInput > 0 || cacheWriteInput > 0 {
 		return true
 	}
+	// Anthropic reports input_tokens as uncached prompt input; prompt-cache
+	// reads and writes are separate fields when present.
 	return strings.EqualFold(strings.TrimSpace(entry.Provider), "anthropic")
 }
 

--- a/internal/usage/request_summary_test.go
+++ b/internal/usage/request_summary_test.go
@@ -1,0 +1,86 @@
+package usage
+
+import "testing"
+
+func TestSummarizeRequestUsage_OpenAICompatibleCachedTokens(t *testing.T) {
+	summary := SummarizeRequestUsage([]UsageLogEntry{
+		{
+			Provider:     "openai",
+			InputTokens:  120,
+			OutputTokens: 30,
+			RawData: map[string]any{
+				"prompt_cached_tokens": 80,
+			},
+		},
+	})
+	if summary == nil {
+		t.Fatal("expected non-nil summary")
+	}
+	if summary.InputTokens != 120 {
+		t.Fatalf("InputTokens = %d, want 120", summary.InputTokens)
+	}
+	if summary.UncachedInputTokens != 40 {
+		t.Fatalf("UncachedInputTokens = %d, want 40", summary.UncachedInputTokens)
+	}
+	if summary.CachedInputTokens != 80 {
+		t.Fatalf("CachedInputTokens = %d, want 80", summary.CachedInputTokens)
+	}
+	if summary.TotalTokens != 150 {
+		t.Fatalf("TotalTokens = %d, want 150", summary.TotalTokens)
+	}
+	if summary.EstimatedCachedCharacters != 320 {
+		t.Fatalf("EstimatedCachedCharacters = %d, want 320", summary.EstimatedCachedCharacters)
+	}
+}
+
+func TestSummarizeRequestUsage_AnthropicSplitCacheAccounting(t *testing.T) {
+	summary := SummarizeRequestUsage([]UsageLogEntry{
+		{
+			Provider:     "anthropic",
+			InputTokens:  50,
+			OutputTokens: 20,
+			RawData: map[string]any{
+				"cache_read_input_tokens":     90,
+				"cache_creation_input_tokens": 30,
+			},
+		},
+	})
+	if summary == nil {
+		t.Fatal("expected non-nil summary")
+	}
+	if summary.InputTokens != 170 {
+		t.Fatalf("InputTokens = %d, want 170", summary.InputTokens)
+	}
+	if summary.UncachedInputTokens != 50 {
+		t.Fatalf("UncachedInputTokens = %d, want 50", summary.UncachedInputTokens)
+	}
+	if summary.CachedInputTokens != 90 {
+		t.Fatalf("CachedInputTokens = %d, want 90", summary.CachedInputTokens)
+	}
+	if summary.CacheWriteInputTokens != 30 {
+		t.Fatalf("CacheWriteInputTokens = %d, want 30", summary.CacheWriteInputTokens)
+	}
+	if summary.TotalTokens != 190 {
+		t.Fatalf("TotalTokens = %d, want 190", summary.TotalTokens)
+	}
+}
+
+func TestSummarizeUsageByRequestID(t *testing.T) {
+	summaries := SummarizeUsageByRequestID(map[string][]UsageLogEntry{
+		"req-1": {
+			{Provider: "openai", InputTokens: 10, OutputTokens: 5},
+		},
+		"req-2": {
+			{Provider: "openai", InputTokens: 20, OutputTokens: 10},
+		},
+	})
+	if len(summaries) != 2 {
+		t.Fatalf("len(summaries) = %d, want 2", len(summaries))
+	}
+	if summaries["req-1"].TotalTokens != 15 {
+		t.Fatalf("summaries[req-1].TotalTokens = %d, want 15", summaries["req-1"].TotalTokens)
+	}
+	if summaries["req-2"].TotalTokens != 30 {
+		t.Fatalf("summaries[req-2].TotalTokens = %d, want 30", summaries["req-2"].TotalTokens)
+	}
+}

--- a/internal/usage/request_summary_test.go
+++ b/internal/usage/request_summary_test.go
@@ -65,6 +65,34 @@ func TestSummarizeRequestUsage_AnthropicSplitCacheAccounting(t *testing.T) {
 	}
 }
 
+func TestSummarizeRequestUsage_AnthropicSplitCacheAccountingWithoutCacheFields(t *testing.T) {
+	summary := SummarizeRequestUsage([]UsageLogEntry{
+		{
+			Provider:     "anthropic",
+			InputTokens:  50,
+			OutputTokens: 20,
+		},
+	})
+	if summary == nil {
+		t.Fatal("expected non-nil summary")
+	}
+	if summary.InputTokens != 50 {
+		t.Fatalf("InputTokens = %d, want 50", summary.InputTokens)
+	}
+	if summary.UncachedInputTokens != 50 {
+		t.Fatalf("UncachedInputTokens = %d, want 50", summary.UncachedInputTokens)
+	}
+	if summary.CachedInputTokens != 0 {
+		t.Fatalf("CachedInputTokens = %d, want 0", summary.CachedInputTokens)
+	}
+	if summary.CacheWriteInputTokens != 0 {
+		t.Fatalf("CacheWriteInputTokens = %d, want 0", summary.CacheWriteInputTokens)
+	}
+	if summary.TotalTokens != 70 {
+		t.Fatalf("TotalTokens = %d, want 70", summary.TotalTokens)
+	}
+}
+
 func TestSummarizeUsageByRequestID(t *testing.T) {
 	summaries := SummarizeUsageByRequestID(map[string][]UsageLogEntry{
 		"req-1": {

--- a/internal/usage/stream_observer.go
+++ b/internal/usage/stream_observer.go
@@ -121,26 +121,11 @@ func (o *StreamUsageObserver) extractUsageFromEvent(chunk map[string]any) *Usage
 		totalTokens = int(v)
 	}
 
-	for field := range extendedFieldSet {
-		if v, ok := usageMap[field].(float64); ok && v > 0 {
-			rawData[field] = int(v)
-		}
-	}
-
-	if details, ok := usageMap["prompt_tokens_details"].(map[string]any); ok {
-		for k, v := range details {
-			if fv, ok := v.(float64); ok && fv > 0 {
-				rawData["prompt_"+k] = int(fv)
-			}
-		}
-	}
-	if details, ok := usageMap["completion_tokens_details"].(map[string]any); ok {
-		for k, v := range details {
-			if fv, ok := v.(float64); ok && fv > 0 {
-				rawData["completion_"+k] = int(fv)
-			}
-		}
-	}
+	copyExtendedUsageFields(rawData, usageMap)
+	copyUsageDetailsFields(rawData, usageMap["prompt_tokens_details"], "prompt_")
+	copyUsageDetailsFields(rawData, usageMap["input_tokens_details"], "prompt_")
+	copyUsageDetailsFields(rawData, usageMap["completion_tokens_details"], "completion_")
+	copyUsageDetailsFields(rawData, usageMap["output_tokens_details"], "completion_")
 
 	if inputTokens == 0 && outputTokens == 0 && totalTokens == 0 {
 		return nil
@@ -168,4 +153,51 @@ func (o *StreamUsageObserver) extractUsageFromEvent(chunk map[string]any) *Usage
 		entry.UserPath = o.userPath
 	}
 	return entry
+}
+
+func copyExtendedUsageFields(rawData map[string]any, usageMap map[string]any) {
+	for key, value := range usageMap {
+		switch key {
+		case "prompt_tokens", "completion_tokens", "total_tokens", "input_tokens", "output_tokens",
+			"prompt_tokens_details", "completion_tokens_details", "input_tokens_details", "output_tokens_details":
+			continue
+		}
+		if numericValue, ok := numericUsageValue(value); ok && numericValue > 0 {
+			rawData[key] = numericValue
+		}
+	}
+}
+
+func copyUsageDetailsFields(rawData map[string]any, detailsValue any, prefix string) {
+	details, ok := detailsValue.(map[string]any)
+	if !ok {
+		return
+	}
+
+	for key, value := range details {
+		numericValue, ok := numericUsageValue(value)
+		if !ok || numericValue <= 0 {
+			continue
+		}
+
+		switch key {
+		case "cache_read_input_tokens", "cache_creation_input_tokens":
+			rawData[key] = numericValue
+		default:
+			rawData[prefix+key] = numericValue
+		}
+	}
+}
+
+func numericUsageValue(value any) (int, bool) {
+	switch typed := value.(type) {
+	case float64:
+		return int(typed), true
+	case int:
+		return typed, true
+	case int64:
+		return int(typed), true
+	default:
+		return 0, false
+	}
 }

--- a/internal/usage/stream_observer_test.go
+++ b/internal/usage/stream_observer_test.go
@@ -332,6 +332,80 @@ data: [DONE]
 	}
 }
 
+func TestStreamUsageObserverResponsesAPIWithDetailedUsage(t *testing.T) {
+	logger := &trackingLogger{enabled: true}
+	observer := NewStreamUsageObserver(logger, "gpt-5", "openai", "req-resp-detailed", "/v1/responses", nil)
+	observer.OnJSONEvent(map[string]any{
+		"type": "response.completed",
+		"response": map[string]any{
+			"id":    "resp-456",
+			"model": "gpt-5",
+			"usage": map[string]any{
+				"input_tokens":  float64(125),
+				"output_tokens": float64(48),
+				"total_tokens":  float64(173),
+				"input_tokens_details": map[string]any{
+					"cached_tokens": float64(98),
+				},
+				"output_tokens_details": map[string]any{
+					"reasoning_tokens": float64(7),
+				},
+				"cost_in_usd_ticks": float64(158500),
+			},
+		},
+	})
+	observer.OnStreamClose()
+
+	entries := logger.getEntries()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	entry := entries[0]
+	if entry.RawData == nil {
+		t.Fatal("expected RawData to be set")
+	}
+	if entry.RawData["prompt_cached_tokens"] != 98 {
+		t.Fatalf("RawData[prompt_cached_tokens] = %v, want 98", entry.RawData["prompt_cached_tokens"])
+	}
+	if entry.RawData["completion_reasoning_tokens"] != 7 {
+		t.Fatalf("RawData[completion_reasoning_tokens] = %v, want 7", entry.RawData["completion_reasoning_tokens"])
+	}
+	if entry.RawData["cost_in_usd_ticks"] != 158500 {
+		t.Fatalf("RawData[cost_in_usd_ticks] = %v, want 158500", entry.RawData["cost_in_usd_ticks"])
+	}
+}
+
+func TestStreamUsageObserverAnthropicCacheFields(t *testing.T) {
+	logger := &trackingLogger{enabled: true}
+	observer := NewStreamUsageObserver(logger, "claude-sonnet-4-5", "anthropic", "req-anthropic", "/v1/chat/completions", nil)
+	observer.OnJSONEvent(map[string]any{
+		"id": "msg-123",
+		"usage": map[string]any{
+			"prompt_tokens":               float64(10),
+			"completion_tokens":           float64(2),
+			"total_tokens":                float64(12),
+			"cache_read_input_tokens":     float64(6),
+			"cache_creation_input_tokens": float64(4),
+		},
+	})
+	observer.OnStreamClose()
+
+	entries := logger.getEntries()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	entry := entries[0]
+	if entry.RawData == nil {
+		t.Fatal("expected RawData to be set")
+	}
+	if entry.RawData["cache_read_input_tokens"] != 6 {
+		t.Fatalf("RawData[cache_read_input_tokens] = %v, want 6", entry.RawData["cache_read_input_tokens"])
+	}
+	if entry.RawData["cache_creation_input_tokens"] != 4 {
+		t.Fatalf("RawData[cache_creation_input_tokens] = %v, want 4", entry.RawData["cache_creation_input_tokens"])
+	}
+}
+
 func TestStreamUsageObserverLargeResponsesDone(t *testing.T) {
 	largeText := strings.Repeat("This is a long response from the model. ", 300)
 	streamData := `event: response.created

--- a/tests/contract/testdata/golden/groq/chat_completion.golden.json
+++ b/tests/contract/testdata/golden/groq/chat_completion.golden.json
@@ -17,8 +17,12 @@
   "provider": "",
   "system_fingerprint": "fp_c06d5113ec",
   "usage": {
+    "completion_time": 0.030590271,
     "completion_tokens": 4,
+    "prompt_time": 0.001689387,
     "prompt_tokens": 38,
+    "queue_time": 0.089910694,
+    "total_time": 0.032279658,
     "total_tokens": 42
   }
 }

--- a/tests/contract/testdata/golden/groq/chat_with_params.golden.json
+++ b/tests/contract/testdata/golden/groq/chat_with_params.golden.json
@@ -17,8 +17,12 @@
   "provider": "",
   "system_fingerprint": "fp_f8b414701e",
   "usage": {
+    "completion_time": 0.023626468,
     "completion_tokens": 12,
+    "prompt_time": 0.002208827,
     "prompt_tokens": 43,
+    "queue_time": 0.04773597,
+    "total_time": 0.025835295,
     "total_tokens": 55
   }
 }

--- a/tests/contract/testdata/golden/groq/chat_with_tools.golden.json
+++ b/tests/contract/testdata/golden/groq/chat_with_tools.golden.json
@@ -27,8 +27,12 @@
   "provider": "",
   "system_fingerprint": "fp_dae98b5ecb",
   "usage": {
+    "completion_time": 0.055257456,
     "completion_tokens": 14,
+    "prompt_time": 0.019662953,
     "prompt_tokens": 203,
+    "queue_time": 0.092826763,
+    "total_time": 0.074920409,
     "total_tokens": 217
   }
 }

--- a/tests/contract/testdata/golden/groq/responses.golden.json
+++ b/tests/contract/testdata/golden/groq/responses.golden.json
@@ -20,8 +20,12 @@
   "provider": "",
   "status": "completed",
   "usage": {
+    "completion_time": 0.030590271,
     "input_tokens": 38,
     "output_tokens": 4,
+    "prompt_time": 0.001689387,
+    "queue_time": 0.089910694,
+    "total_time": 0.032279658,
     "total_tokens": 42
   }
 }

--- a/tests/contract/testdata/golden/openai/responses.golden.json
+++ b/tests/contract/testdata/golden/openai/responses.golden.json
@@ -21,7 +21,19 @@
   "status": "completed",
   "usage": {
     "input_tokens": 17,
+    "input_tokens_details": {
+      "audio_tokens": 0,
+      "cached_tokens": 0,
+      "image_tokens": 0,
+      "text_tokens": 0
+    },
     "output_tokens": 5,
+    "output_tokens_details": {
+      "accepted_prediction_tokens": 0,
+      "audio_tokens": 0,
+      "reasoning_tokens": 0,
+      "rejected_prediction_tokens": 0
+    },
     "total_tokens": 22
   }
 }

--- a/tests/contract/testdata/golden/xai/chat_completion.golden.json
+++ b/tests/contract/testdata/golden/xai/chat_completion.golden.json
@@ -25,6 +25,8 @@
       "reasoning_tokens": 375,
       "rejected_prediction_tokens": 0
     },
+    "cost_in_usd_ticks": 2073250,
+    "num_sources_used": 0,
     "prompt_tokens": 10,
     "prompt_tokens_details": {
       "audio_tokens": 0,

--- a/tests/contract/testdata/golden/xai/chat_with_params.golden.json
+++ b/tests/contract/testdata/golden/xai/chat_with_params.golden.json
@@ -25,6 +25,8 @@
       "reasoning_tokens": 173,
       "rejected_prediction_tokens": 0
     },
+    "cost_in_usd_ticks": 943000,
+    "num_sources_used": 0,
     "prompt_tokens": 19,
     "prompt_tokens_details": {
       "audio_tokens": 0,

--- a/tests/contract/testdata/golden/xai/responses.golden.json
+++ b/tests/contract/testdata/golden/xai/responses.golden.json
@@ -31,8 +31,23 @@
   "provider": "",
   "status": "completed",
   "usage": {
+    "cost_in_usd_ticks": 1424250,
     "input_tokens": 17,
+    "input_tokens_details": {
+      "audio_tokens": 0,
+      "cached_tokens": 3,
+      "image_tokens": 0,
+      "text_tokens": 0
+    },
+    "num_server_side_tools_used": 0,
+    "num_sources_used": 0,
     "output_tokens": 276,
+    "output_tokens_details": {
+      "accepted_prediction_tokens": 0,
+      "audio_tokens": 0,
+      "reasoning_tokens": 272,
+      "rejected_prediction_tokens": 0
+    },
     "total_tokens": 293
   }
 }


### PR DESCRIPTION
## Summary
- capture and normalize provider prompt-cache usage details across chat, responses, and streaming usage extraction
- make prompt caching visible in Audit Logs with inline body highlighting and a cache-ratio pill next to the request body label
- fix Anthropic prompt caching by preserving `cache_control` during request translation
- add xAI `x-grok-conv-id` support by forwarding the client header when present and generating a stable fallback when absent
- apply cached-input pricing correctly for Gemini and Groq in addition to the existing OpenAI/xAI/Anthropic paths

## Validation
- `go test ./...`
- pre-commit hooks during commit: race tests, dashboard JS tests, perf hot-path guard, lint
- live provider probes through GoModel and direct provider APIs for Anthropic, xAI, Gemini, and Groq prompt caching behavior
