### PR TITLE
feat(providers): add MiniMax provider support

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -269,6 +269,10 @@
 # ZAI_API_KEY=...
 # ZAI_BASE_URL=https://api.z.ai/api/paas/v4
 
+# MiniMax (default base URL: https://api.minimax.io/v1)
+# MINIMAX_API_KEY=...
+# MINIMAX_BASE_URL=https://api.minimax.io/v1
+
 # Azure OpenAI
 # AZURE_API_KEY=...
 # AZURE_BASE_URL=https://your-resource.openai.azure.com/openai/deployments/your-deployment

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Guidance for AI models (like Claude) working with this codebase.
 
 ## Project Overview
 
-**GoModel** is a high-performance AI gateway in Go that routes requests to multiple AI model providers (OpenAI, Anthropic, Gemini, Groq, OpenRouter, Z.ai, xAI, Azure OpenAI, Oracle, Ollama). LiteLLM killer.
+**GoModel** is a high-performance AI gateway in Go that routes requests to multiple AI model providers (OpenAI, Anthropic, Gemini, Groq, OpenRouter, Z.ai, xAI, MiniMax, Azure OpenAI, Oracle, Ollama). LiteLLM killer.
 
 **Go:** 1.26.2
 **Repo:** https://github.com/ENTERPILOT/GoModel
@@ -115,5 +115,5 @@ Full reference: `.env.template` and `config/config.yaml`
 - **Resilience:** Configured via `config/config.yaml` - global `resilience.retry.*` and `resilience.circuit_breaker.*` defaults with optional per-provider overrides under `providers.<name>.resilience.retry.*` and `providers.<name>.resilience.circuit_breaker.*`. Retry defaults: `max_retries` (3), `initial_backoff` (1s), `max_backoff` (30s), `backoff_factor` (2.0), `jitter_factor` (0.1). Circuit breaker defaults: `failure_threshold` (5), `success_threshold` (2), `timeout` (30s)
 - **Metrics:** `METRICS_ENABLED` (false), `METRICS_ENDPOINT` (/metrics)
 - **Guardrails:** Configured via `config/config.yaml` only (except `GUARDRAILS_ENABLED` env var)
-- **Providers:** `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `XAI_API_KEY`, `GROQ_API_KEY`, `OPENROUTER_API_KEY`, `ZAI_API_KEY`, `ZAI_BASE_URL` (optional Z.ai endpoint override), `AZURE_API_KEY`, `AZURE_BASE_URL` (Azure OpenAI deployment base URL), `AZURE_API_VERSION` (optional Azure API version), `ORACLE_API_KEY` (Oracle API key), `ORACLE_BASE_URL` (Oracle OpenAI-compatible base URL), `ORACLE_MODELS` (comma-separated Oracle fallback model inventory), `OLLAMA_BASE_URL`, `VLLM_BASE_URL`, `VLLM_API_KEY` (optional upstream vLLM bearer token)
+- **Providers:** `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `XAI_API_KEY`, `GROQ_API_KEY`, `OPENROUTER_API_KEY`, `ZAI_API_KEY`, `ZAI_BASE_URL` (optional Z.ai endpoint override), `MINIMAX_API_KEY`, `MINIMAX_BASE_URL` (optional MiniMax endpoint override), `AZURE_API_KEY`, `AZURE_BASE_URL` (Azure OpenAI deployment base URL), `AZURE_API_VERSION` (optional Azure API version), `ORACLE_API_KEY` (Oracle API key), `ORACLE_BASE_URL` (Oracle OpenAI-compatible base URL), `ORACLE_MODELS` (comma-separated Oracle fallback model inventory), `OLLAMA_BASE_URL`, `VLLM_BASE_URL`, `VLLM_API_KEY` (optional upstream vLLM bearer token)
 - **Provider model metadata:** `providers.<name>.models` accepts either model IDs (strings) or `{id, metadata}` objects. When `metadata` is supplied (`display_name`, `context_window`, `max_output_tokens`, `modes`, `capabilities`, `pricing`, …) it is merged onto the remote ai-model-list entry during enrichment, with operator values winning per-field. Primary use case: advertising context windows, capabilities, and pricing for local models (Ollama) and other custom endpoints whose IDs are not in the upstream registry.

--- a/cmd/gomodel/main.go
+++ b/cmd/gomodel/main.go
@@ -21,6 +21,7 @@ import (
 	"gomodel/internal/providers/azure"
 	"gomodel/internal/providers/gemini"
 	"gomodel/internal/providers/groq"
+	"gomodel/internal/providers/minimax"
 	"gomodel/internal/providers/ollama"
 	"gomodel/internal/providers/openai"
 	"gomodel/internal/providers/openrouter"
@@ -73,7 +74,7 @@ func startApplication(application lifecycleApp, addr string) error {
 
 // @title          GoModel API
 // @version        1.0
-// @description    High-performance AI gateway routing requests to multiple LLM providers (OpenAI, Anthropic, Gemini, Groq, OpenRouter, Z.ai, xAI, Oracle, Ollama). Drop-in OpenAI-compatible API.
+// @description    High-performance AI gateway routing requests to multiple LLM providers (OpenAI, Anthropic, Gemini, Groq, OpenRouter, Z.ai, xAI, MiniMax, Oracle, Ollama). Drop-in OpenAI-compatible API.
 // @BasePath       /
 // @schemes        http
 // @securityDefinitions.apikey BearerAuth
@@ -120,6 +121,7 @@ func main() {
 	factory.Add(anthropic.Registration)
 	factory.Add(gemini.Registration)
 	factory.Add(groq.Registration)
+	factory.Add(minimax.Registration)
 	factory.Add(ollama.Registration)
 	factory.Add(vllm.Registration)
 	factory.Add(xai.Registration)

--- a/internal/providers/minimax/minimax.go
+++ b/internal/providers/minimax/minimax.go
@@ -1,0 +1,114 @@
+// Package minimax provides MiniMax API integration for the LLM gateway.
+package minimax
+
+import (
+	"context"
+	"io"
+	"net/http"
+
+	"gomodel/internal/core"
+	"gomodel/internal/llmclient"
+	"gomodel/internal/providers"
+	"gomodel/internal/providers/openai"
+)
+
+const defaultBaseURL = "https://api.minimax.io/v1"
+
+// defaultTemperature is the fallback temperature for MiniMax.
+// MiniMax requires temperature to be in (0.0, 1.0] — zero is not allowed.
+const defaultTemperature = 1.0
+
+// Registration provides factory registration for the MiniMax provider.
+var Registration = providers.Registration{
+	Type: "minimax",
+	New:  New,
+	Discovery: providers.DiscoveryConfig{
+		DefaultBaseURL: defaultBaseURL,
+	},
+}
+
+// Provider implements the core.Provider interface for MiniMax.
+type Provider struct {
+	compatible *openai.CompatibleProvider
+}
+
+// New creates a new MiniMax provider.
+func New(cfg providers.ProviderConfig, opts providers.ProviderOptions) core.Provider {
+	baseURL := providers.ResolveBaseURL(cfg.BaseURL, defaultBaseURL)
+	return &Provider{
+		compatible: openai.NewCompatibleProvider(cfg.APIKey, opts, openai.CompatibleProviderConfig{
+			ProviderName: "minimax",
+			BaseURL:      baseURL,
+			SetHeaders:   setHeaders,
+		}),
+	}
+}
+
+// NewWithHTTPClient creates a new MiniMax provider with a custom HTTP client.
+// If httpClient is nil, http.DefaultClient is used.
+func NewWithHTTPClient(apiKey string, baseURL string, httpClient *http.Client, hooks llmclient.Hooks) *Provider {
+	resolvedBaseURL := providers.ResolveBaseURL(baseURL, defaultBaseURL)
+	return &Provider{
+		compatible: openai.NewCompatibleProviderWithHTTPClient(apiKey, httpClient, hooks, openai.CompatibleProviderConfig{
+			ProviderName: "minimax",
+			BaseURL:      resolvedBaseURL,
+			SetHeaders:   setHeaders,
+		}),
+	}
+}
+
+// SetBaseURL allows configuring a custom base URL for the provider.
+func (p *Provider) SetBaseURL(url string) {
+	p.compatible.SetBaseURL(url)
+}
+
+func setHeaders(req *http.Request, apiKey string) {
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+}
+
+// clampTemperature returns the request with temperature clamped to (0.0, 1.0].
+// MiniMax rejects temperature=0; if zero or negative, defaultTemperature is used.
+func clampTemperature(req *core.ChatRequest) *core.ChatRequest {
+	if req == nil || req.Temperature == nil || *req.Temperature > 0 {
+		return req
+	}
+	t := defaultTemperature
+	cloned := *req
+	cloned.Temperature = &t
+	return &cloned
+}
+
+// ChatCompletion sends a chat completion request to MiniMax.
+func (p *Provider) ChatCompletion(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+	return p.compatible.ChatCompletion(ctx, clampTemperature(req))
+}
+
+// StreamChatCompletion returns a raw response body for streaming.
+func (p *Provider) StreamChatCompletion(ctx context.Context, req *core.ChatRequest) (io.ReadCloser, error) {
+	return p.compatible.StreamChatCompletion(ctx, clampTemperature(req))
+}
+
+// ListModels retrieves the list of available models from MiniMax.
+func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error) {
+	return p.compatible.ListModels(ctx)
+}
+
+// Responses sends a Responses API request to MiniMax using chat-completions translation.
+func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
+	return providers.ResponsesViaChat(ctx, p, req)
+}
+
+// StreamResponses streams a Responses API request to MiniMax using chat-completions translation.
+func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
+	return providers.StreamResponsesViaChat(ctx, p, req, "minimax")
+}
+
+// Embeddings sends an embeddings request to MiniMax.
+func (p *Provider) Embeddings(ctx context.Context, req *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	return p.compatible.Embeddings(ctx, req)
+}
+
+// Passthrough routes an opaque provider-native request to MiniMax.
+func (p *Provider) Passthrough(ctx context.Context, req *core.PassthroughRequest) (*core.PassthroughResponse, error) {
+	return p.compatible.Passthrough(ctx, req)
+}

--- a/internal/providers/minimax/minimax_test.go
+++ b/internal/providers/minimax/minimax_test.go
@@ -1,0 +1,155 @@
+package minimax
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"gomodel/internal/core"
+	"gomodel/internal/llmclient"
+)
+
+func TestChatCompletion_UsesBearerAuthAndChatEndpoint(t *testing.T) {
+	var gotPath string
+	var gotAuth string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-minimax",
+			"created":1677652288,
+			"model":"MiniMax-M2.7",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}]
+		}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("minimax-key", server.URL, server.Client(), llmclient.Hooks{})
+
+	resp, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{
+		Model: "MiniMax-M2.7",
+		Messages: []core.Message{
+			{Role: "user", Content: "hi"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ChatCompletion() error = %v", err)
+	}
+	if resp.Model != "MiniMax-M2.7" {
+		t.Fatalf("resp.Model = %q, want MiniMax-M2.7", resp.Model)
+	}
+	if gotPath != "/chat/completions" {
+		t.Fatalf("path = %q, want /chat/completions", gotPath)
+	}
+	if gotAuth != "Bearer minimax-key" {
+		t.Fatalf("authorization = %q, want Bearer minimax-key", gotAuth)
+	}
+}
+
+func TestChatCompletion_ClampsZeroTemperature(t *testing.T) {
+	var gotBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read error", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-minimax",
+			"created":1677652288,
+			"model":"MiniMax-M2.7",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]
+		}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("minimax-key", server.URL, server.Client(), llmclient.Hooks{})
+
+	temp := 0.0
+	_, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{
+		Model:       "MiniMax-M2.7",
+		Messages:    []core.Message{{Role: "user", Content: "hi"}},
+		Temperature: &temp,
+	})
+	if err != nil {
+		t.Fatalf("ChatCompletion() error = %v", err)
+	}
+
+	// Verify the body sent to the server does not contain temperature=0
+	bodyStr := string(gotBody)
+	if strings.Contains(bodyStr, `"temperature":0`) {
+		t.Fatalf("request body should not contain temperature=0, got: %s", bodyStr)
+	}
+	if !strings.Contains(bodyStr, `"temperature":1`) {
+		t.Fatalf("request body should contain temperature=1, got: %s", bodyStr)
+	}
+}
+
+func TestProvider_DefaultBaseURL(t *testing.T) {
+	provider := NewWithHTTPClient("key", "", nil, llmclient.Hooks{})
+	if provider == nil {
+		t.Fatal("expected non-nil provider")
+	}
+}
+
+func TestProvider_DoesNotExposeOptionalOpenAICompatibleInterfaces(t *testing.T) {
+	provider := NewWithHTTPClient("minimax-key", "", nil, llmclient.Hooks{})
+
+	if _, ok := any(provider).(core.NativeBatchProvider); ok {
+		t.Fatal("minimax provider should not implement native batch provider")
+	}
+	if _, ok := any(provider).(core.NativeFileProvider); ok {
+		t.Fatal("minimax provider should not implement native file provider")
+	}
+}
+
+func TestClampTemperature_NilRequest(t *testing.T) {
+	result := clampTemperature(nil)
+	if result != nil {
+		t.Fatal("expected nil for nil input")
+	}
+}
+
+func TestClampTemperature_NilTemperature(t *testing.T) {
+	req := &core.ChatRequest{Model: "MiniMax-M2.7"}
+	result := clampTemperature(req)
+	if result.Temperature != nil {
+		t.Fatal("expected nil temperature to remain nil")
+	}
+}
+
+func TestClampTemperature_ZeroTemperature(t *testing.T) {
+	temp := 0.0
+	req := &core.ChatRequest{Model: "MiniMax-M2.7", Temperature: &temp}
+	result := clampTemperature(req)
+	if result.Temperature == nil {
+		t.Fatal("expected non-nil temperature after clamping")
+	}
+	if *result.Temperature != defaultTemperature {
+		t.Fatalf("expected temperature=%v after clamping zero, got %v", defaultTemperature, *result.Temperature)
+	}
+	// Original request should not be mutated
+	if *req.Temperature != 0.0 {
+		t.Fatal("original request should not be mutated")
+	}
+}
+
+func TestClampTemperature_PositiveTemperature(t *testing.T) {
+	temp := 0.7
+	req := &core.ChatRequest{Model: "MiniMax-M2.7", Temperature: &temp}
+	result := clampTemperature(req)
+	if result != req {
+		t.Fatal("expected same pointer for valid temperature")
+	}
+	if *result.Temperature != 0.7 {
+		t.Fatalf("expected temperature=0.7, got %v", *result.Temperature)
+	}
+}


### PR DESCRIPTION
## Summary

- Add MiniMax chat model provider using the OpenAI-compatible API (`https://api.minimax.io/v1`)
- Implement temperature clamping: MiniMax requires temperature in `(0.0, 1.0]` — zero values are automatically remapped to the default `1.0`
- Add `MINIMAX_API_KEY` and `MINIMAX_BASE_URL` environment variable support
- Add unit tests covering auth headers, chat endpoint routing, temperature clamping, and interface assertions
- Register MiniMax provider in `main.go` and document in `CLAUDE.md` and `.env.template`

## Supported Models

| Model ID | Description |
|----------|-------------|
| `MiniMax-M2.7` | Peak Performance. Ultimate Value. Master the Complex |
| `MiniMax-M2.7-highspeed` | Same performance, faster and more agile |

## API Reference

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api

## Configuration

```env
MINIMAX_API_KEY=your-api-key
# Optional, defaults to https://api.minimax.io/v1
MINIMAX_BASE_URL=https://api.minimax.io/v1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added MiniMax as a newly supported AI model provider with OpenAI-compatible API integration.

* **Documentation**
  * Updated configuration guides to document MiniMax provider setup and required environment variables (`MINIMAX_API_KEY` and `MINIMAX_BASE_URL`).

* **Chores**
  * Added environment variable templates for MiniMax configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->