### PR TITLE
fix(dashboard): correct workflow charts and cache overview requests

### DIFF
--- a/internal/admin/dashboard/static/js/modules/request-cancellation.test.js
+++ b/internal/admin/dashboard/static/js/modules/request-cancellation.test.js
@@ -326,6 +326,23 @@ test('fetchUsage clears stale usage data and rerenders on real response failures
     assert.equal(renderChartCalls, 1);
 });
 
+test('fetchUsage skips cache overview requests on pages without cache analytics cards', async() => {
+    const queue = createPendingFetchQueue();
+    const app = loadDashboardApp({ fetch: queue.fetch });
+    app.page = 'workflows';
+    app.workflowRuntimeBooleanFlag = (name) => name === 'CACHE_ENABLED';
+    app.renderChart = () => {};
+
+    const request = app.fetchUsage();
+    assert.equal(queue.requests.length, 2);
+
+    queue.requests[0].resolve(jsonResponse({ total_requests: 7 }));
+    queue.requests[1].resolve(jsonResponse([{ date: '2026-03-29', input_tokens: 3, output_tokens: 4 }]));
+    await request;
+
+    assert.equal(queue.requests.length, 2);
+});
+
 test('fetchModels aborts stale in-flight requests before applying new data', async() => {
     const queue = createPendingFetchQueue();
     const app = loadDashboardApp({ fetch: queue.fetch });

--- a/internal/admin/dashboard/static/js/modules/usage.js
+++ b/internal/admin/dashboard/static/js/modules/usage.js
@@ -34,6 +34,10 @@
                     : false;
             },
 
+            cacheOverviewVisible() {
+                return this.page === 'overview' || this.page === 'usage';
+            },
+
             _usageQueryStr() {
                 if (this.customStartDate && this.customEndDate) {
                     return 'start_date=' + this._formatDate(this.customStartDate) +
@@ -43,6 +47,9 @@
             },
 
             async fetchCacheOverview() {
+                if (!this.cacheOverviewVisible()) {
+                    return;
+                }
                 if (!this.cacheAnalyticsEnabled()) {
                     this.cacheOverview = this.emptyCacheOverview();
                     if (this.page === 'overview') this.renderChart();
@@ -148,9 +155,9 @@
                     this.summary = summary;
                     this.daily = daily;
                     this.renderChart();
-                    if (this.cacheAnalyticsEnabled()) {
+                    if (this.cacheOverviewVisible() && this.cacheAnalyticsEnabled()) {
                         this.fetchCacheOverview();
-                    } else {
+                    } else if (this.cacheOverviewVisible()) {
                         this.cacheOverview = this.emptyCacheOverview();
                     }
                     if (this.page === 'usage') this.fetchUsagePage();

--- a/internal/admin/dashboard/static/js/modules/workflows-layout.test.js
+++ b/internal/admin/dashboard/static/js/modules/workflows-layout.test.js
@@ -78,11 +78,11 @@ test("async label stays inline on the right side of the branch", () => {
   );
   assert.match(
     template,
-    /<div class="workflow-conn workflow-conn-async" x-show="workflow\.showUsage && workflow\.showAudit"><\/div>\s*<div class="workflow-node workflow-node-feature workflow-node-async workflow-node-async-audit" x-show="workflow\.showAudit" :class="workflow\.auditNodeClass">/,
+    /<div class="workflow-conn workflow-conn-async" x-show="chart\.showUsage && chart\.showAudit"><\/div>\s*<div class="workflow-node workflow-node-feature workflow-node-async workflow-node-async-audit" x-show="chart\.showAudit" :class="chart\.auditNodeClass">/,
   );
   assert.match(
     template,
-    /<div class="workflow-node workflow-node-feature workflow-node-async workflow-node-async-usage" x-show="workflow\.showUsage" :class="workflow\.usageNodeClass">/,
+    /<div class="workflow-node workflow-node-feature workflow-node-async workflow-node-async-usage" x-show="chart\.showUsage" :class="chart\.usageNodeClass">/,
   );
 
   const asyncLabelRule = readCSSRule(css, ".workflow-async-label");
@@ -296,8 +296,9 @@ test("workflow editor renders a live preview card from the draft workflow state"
   );
   assert.match(
     chartTemplate,
-    /{{define "workflow-chart"}}[\s\S]*x-data="\{ workflow: {{\.}} \|\| \{\} \}"[\s\S]*x-effect="workflow = {{\.}} \|\| \{\}"[\s\S]*<span class="workflow-node-label">Auth<\/span>[\s\S]*x-text="workflow\.authNodeSublabel"[\s\S]*x-show="workflow\.showGuardrails"[\s\S]*x-show="workflow\.showCache"[\s\S]*x-text="workflow\.aiLabel"[\s\S]*x-show="workflow\.showFailover"[\s\S]*x-text="workflow\.failoverTargetLabel"/,
+    /{{define "workflow-chart"}}[\s\S]*x-data="\{ chart: {{\.}} \|\| \{\} \}"[\s\S]*x-effect="chart = {{\.}} \|\| \{\}"[\s\S]*<span class="workflow-node-label">Auth<\/span>[\s\S]*x-text="chart\.authNodeSublabel"[\s\S]*x-show="chart\.showGuardrails"[\s\S]*x-show="chart\.showCache"[\s\S]*x-text="chart\.aiLabel"[\s\S]*x-show="chart\.showFailover"[\s\S]*x-text="chart\.failoverTargetLabel"/,
   );
+  assert.doesNotMatch(chartTemplate, /x-data="\{ workflow:/);
 });
 
 test("audit log pipeline binds cache visibility and runtime highlight classes across the full path", () => {
@@ -306,27 +307,27 @@ test("audit log pipeline binds cache visibility and runtime highlight classes ac
 
   assert.match(
     template,
-    /{{template "workflow-chart" "workflowAuditChart\(entry\)"}}[\s\S]*<div class="workflow-conn" x-show="workflow\.showCache" :class="workflow\.cacheConnClass"><\/div>[\s\S]*<div class="workflow-node workflow-node-feature workflow-node-cache" x-show="workflow\.showCache" :class="workflow\.cacheNodeClass">[\s\S]*x-text="workflow\.cacheStatusLabel"[\s\S]*<div class="workflow-conn" x-show="workflow\.showFailover" :class="workflow\.failoverConnClass"><\/div>[\s\S]*<div class="workflow-node workflow-node-feature workflow-node-failover" x-show="workflow\.showFailover" :class="workflow\.failoverNodeClass">[\s\S]*x-text="workflow\.failoverStatusLabel"[\s\S]*x-text="workflow\.failoverTargetLabel"/,
+    /{{template "workflow-chart" "workflowAuditChart\(entry\)"}}[\s\S]*<div class="workflow-conn" x-show="chart\.showCache" :class="chart\.cacheConnClass"><\/div>[\s\S]*<div class="workflow-node workflow-node-feature workflow-node-cache" x-show="chart\.showCache" :class="chart\.cacheNodeClass">[\s\S]*x-text="chart\.cacheStatusLabel"[\s\S]*<div class="workflow-conn" x-show="chart\.showFailover" :class="chart\.failoverConnClass"><\/div>[\s\S]*<div class="workflow-node workflow-node-feature workflow-node-failover" x-show="chart\.showFailover" :class="chart\.failoverNodeClass">[\s\S]*x-text="chart\.failoverStatusLabel"[\s\S]*x-text="chart\.failoverTargetLabel"/,
   );
   assert.match(
     template,
-    /:class="workflow\.authNodeClass"[\s\S]*x-show="workflow\.showGuardrails"[\s\S]*x-show="workflow\.showUsage"[\s\S]*x-show="workflow\.showAudit"/,
+    /:class="chart\.authNodeClass"[\s\S]*x-show="chart\.showGuardrails"[\s\S]*x-show="chart\.showUsage"[\s\S]*x-show="chart\.showAudit"/,
   );
   assert.match(
     template,
-    /<div class="workflow-conn" :class="workflow\.aiConnClass"><\/div>[\s\S]*<div class="workflow-node workflow-node-ai" :class="workflow\.aiNodeClass">/,
+    /<div class="workflow-conn" :class="chart\.aiConnClass"><\/div>[\s\S]*<div class="workflow-node workflow-node-ai" :class="chart\.aiNodeClass">/,
   );
   assert.match(
     template,
-    /<div class="workflow-pipeline" x-data="\{ workflow: {{\.}} \|\| \{\} \}" x-effect="workflow = {{\.}} \|\| \{\}" :class="\{ 'workflow-pipeline-has-meta': workflow\.workflowID \}">[\s\S]*<button type="button"[\s\S]*class="workflow-pipeline-meta workflow-pipeline-meta-copy mono"[\s\S]*x-show="workflow\.workflowID"[\s\S]*x-data="workflowIDChip\(workflow\.workflowID\)"[\s\S]*x-effect="setWorkflowID\(workflow\.workflowID\)"[\s\S]*@click\.prevent="copyWorkflowID\(\)"[\s\S]*<span class="workflow-pipeline-meta-label">id:<\/span>[\s\S]*<span class="workflow-pipeline-meta-placeholder">\.\.\.<\/span>[\s\S]*x-text="workflowID"/,
+    /<div class="workflow-pipeline" x-data="\{ chart: {{\.}} \|\| \{\} \}" x-effect="chart = {{\.}} \|\| \{\}" :class="\{ 'workflow-pipeline-has-meta': chart\.workflowID \}">[\s\S]*<button type="button"[\s\S]*class="workflow-pipeline-meta workflow-pipeline-meta-copy mono"[\s\S]*x-show="chart\.workflowID"[\s\S]*x-data="workflowIDChip\(chart\.workflowID\)"[\s\S]*x-effect="setWorkflowID\(chart\.workflowID\)"[\s\S]*@click\.prevent="copyWorkflowID\(\)"[\s\S]*<span class="workflow-pipeline-meta-label">id:<\/span>[\s\S]*<span class="workflow-pipeline-meta-placeholder">\.\.\.<\/span>[\s\S]*x-text="workflowID"/,
   );
   assert.match(
     template,
-    /<div class="workflow-conn" :class="workflow\.responseConnClass"><\/div>[\s\S]*<div class="workflow-node workflow-node-endpoint" :class="workflow\.responseNodeClass">/,
+    /<div class="workflow-conn" :class="chart\.responseConnClass"><\/div>[\s\S]*<div class="workflow-node workflow-node-endpoint" :class="chart\.responseNodeClass">/,
   );
   assert.doesNotMatch(
     template,
-    /<div class="workflow-pipeline-meta" x-show="workflow\.workflowID">/,
+    /<div class="workflow-pipeline-meta" x-show="chart\.workflowID">/,
   );
 
   const successRule = readCSSRule(css, ".workflow-node-success");
@@ -442,7 +443,7 @@ test("workflow pipeline main row is flattened without workflow-left or workflow-
   assert.doesNotMatch(template, /class="workflow-step"/);
   assert.match(
     template,
-    /<div class="workflow-pipeline-row">[\s\S]*<div class="workflow-node workflow-node-endpoint">[\s\S]*<div class="workflow-conn"><\/div>[\s\S]*<div class="workflow-node workflow-node-feature workflow-node-auth"[\s\S]*<div class="workflow-conn" :class="workflow\.aiConnClass"><\/div>[\s\S]*<div class="workflow-node workflow-node-ai" :class="workflow\.aiNodeClass">[\s\S]*<div class="workflow-conn" :class="workflow\.responseConnClass"><\/div>[\s\S]*<div class="workflow-node workflow-node-endpoint" :class="workflow\.responseNodeClass">/,
+    /<div class="workflow-pipeline-row">[\s\S]*<div class="workflow-node workflow-node-endpoint">[\s\S]*<div class="workflow-conn"><\/div>[\s\S]*<div class="workflow-node workflow-node-feature workflow-node-auth"[\s\S]*<div class="workflow-conn" :class="chart\.aiConnClass"><\/div>[\s\S]*<div class="workflow-node workflow-node-ai" :class="chart\.aiNodeClass">[\s\S]*<div class="workflow-conn" :class="chart\.responseConnClass"><\/div>[\s\S]*<div class="workflow-node workflow-node-endpoint" :class="chart\.responseNodeClass">/,
   );
   assert.doesNotMatch(css, /\.workflow-left\s*,/);
   assert.doesNotMatch(css, /\.workflow-right\s*\{/);
@@ -477,7 +478,7 @@ test("guardrails node only renders a sublabel when step detail exists", () => {
 
   assert.match(
     template,
-    /<span class="workflow-node-label">Guardrails<\/span>\s*<span class="workflow-node-sub" x-show="workflow\.guardrailLabel" x-text="workflow\.guardrailLabel"><\/span>/,
+    /<span class="workflow-node-label">Guardrails<\/span>\s*<span class="workflow-node-sub" x-show="chart\.guardrailLabel" x-text="chart\.guardrailLabel"><\/span>/,
   );
 });
 

--- a/internal/admin/dashboard/static/js/modules/workflows.js
+++ b/internal/admin/dashboard/static/js/modules/workflows.js
@@ -752,25 +752,7 @@
 	                    }
 	                    this.workflowRuntimeConfig = next;
 	                    if (typeof this.fetchCacheOverview === 'function') {
-	                        if (this.workflowCacheVisible()) {
-	                            this.fetchCacheOverview();
-	                        } else {
-	                            this.cacheOverview = {
-	                                summary: {
-	                                    total_hits: 0,
-	                                    exact_hits: 0,
-	                                    semantic_hits: 0,
-	                                    total_input_tokens: 0,
-	                                    total_output_tokens: 0,
-	                                    total_tokens: 0,
-	                                    total_saved_cost: null
-	                                },
-	                                daily: []
-	                            };
-	                            if (typeof this.renderChart === 'function') {
-	                                this.renderChart();
-	                            }
-	                        }
+	                        this.fetchCacheOverview();
 	                    }
 	                } catch (e) {
 	                    console.error('Failed to fetch dashboard config:', e);

--- a/internal/admin/dashboard/static/js/modules/workflows.test.js
+++ b/internal/admin/dashboard/static/js/modules/workflows.test.js
@@ -1161,6 +1161,28 @@ test('fetchWorkflowRuntimeConfig loads FEATURE_FALLBACK_MODE from the admin conf
     );
 });
 
+test('fetchWorkflowRuntimeConfig delegates cache overview refresh after loading runtime config', async () => {
+    let cacheOverviewCalls = 0;
+    const module = createWorkflowsModule({
+        fetch() {
+            return Promise.resolve({
+                ok: true,
+                json: async () => ({
+                    CACHE_ENABLED: 'on'
+                })
+            });
+        }
+    });
+    module.handleFetchResponse = () => true;
+    module.headers = () => ({});
+    module.fetchCacheOverview = () => {
+        cacheOverviewCalls++;
+    };
+
+    await module.fetchWorkflowRuntimeConfig();
+    assert.equal(cacheOverviewCalls, 1);
+});
+
 test('fetchWorkflowRuntimeConfig aborts hung requests and clears the timeout', async () => {
     let timeoutCleared = false;
     class AbortControllerStub {

--- a/internal/admin/dashboard/templates/workflow-chart.html
+++ b/internal/admin/dashboard/templates/workflow-chart.html
@@ -1,10 +1,10 @@
 {{define "workflow-chart"}}
-<div class="workflow-pipeline" x-data="{ workflow: {{.}} || {} }" x-effect="workflow = {{.}} || {}" :class="{ 'workflow-pipeline-has-meta': workflow.workflowID }">
+<div class="workflow-pipeline" x-data="{ chart: {{.}} || {} }" x-effect="chart = {{.}} || {}" :class="{ 'workflow-pipeline-has-meta': chart.workflowID }">
     <button type="button"
         class="workflow-pipeline-meta workflow-pipeline-meta-copy mono"
-        x-show="workflow.workflowID"
-        x-data="workflowIDChip(workflow.workflowID)"
-        x-effect="setWorkflowID(workflow.workflowID)"
+        x-show="chart.workflowID"
+        x-data="workflowIDChip(chart.workflowID)"
+        x-effect="setWorkflowID(chart.workflowID)"
         :class="{ 'workflow-pipeline-meta-copied': copyState.copied, 'workflow-pipeline-meta-error': copyState.error }"
         :title="copyTitle()"
         :aria-label="copyAriaLabel()"
@@ -25,69 +25,69 @@
         </div>
 
         <div class="workflow-conn"></div>
-        <div class="workflow-node workflow-node-feature workflow-node-auth" :class="workflow.authNodeClass">
+        <div class="workflow-node workflow-node-feature workflow-node-auth" :class="chart.authNodeClass">
             <div class="workflow-node-icon">
                 <svg viewBox="0 0 24 24"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg>
             </div>
             <span class="workflow-node-label">Auth</span>
-            <span class="workflow-node-sub" x-show="workflow.authNodeSublabel" x-text="workflow.authNodeSublabel"></span>
+            <span class="workflow-node-sub" x-show="chart.authNodeSublabel" x-text="chart.authNodeSublabel"></span>
         </div>
 
-        <div class="workflow-conn" x-show="workflow.showGuardrails"></div>
-        <div class="workflow-node workflow-node-feature workflow-node-guardrails" x-show="workflow.showGuardrails">
+        <div class="workflow-conn" x-show="chart.showGuardrails"></div>
+        <div class="workflow-node workflow-node-feature workflow-node-guardrails" x-show="chart.showGuardrails">
             <div class="workflow-node-icon">
                 <svg viewBox="0 0 24 24"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
             </div>
             <span class="workflow-node-label">Guardrails</span>
-            <span class="workflow-node-sub" x-show="workflow.guardrailLabel" x-text="workflow.guardrailLabel"></span>
+            <span class="workflow-node-sub" x-show="chart.guardrailLabel" x-text="chart.guardrailLabel"></span>
         </div>
 
-        <div class="workflow-conn" x-show="workflow.showCache" :class="workflow.cacheConnClass"></div>
-        <div class="workflow-node workflow-node-feature workflow-node-cache" x-show="workflow.showCache" :class="workflow.cacheNodeClass">
+        <div class="workflow-conn" x-show="chart.showCache" :class="chart.cacheConnClass"></div>
+        <div class="workflow-node workflow-node-feature workflow-node-cache" x-show="chart.showCache" :class="chart.cacheNodeClass">
             <div class="workflow-node-icon">
                 <svg viewBox="0 0 24 24"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg>
             </div>
             <span class="workflow-node-label">Cache</span>
-            <span class="workflow-node-badge" x-show="workflow.cacheStatusLabel" x-text="workflow.cacheStatusLabel"></span>
+            <span class="workflow-node-badge" x-show="chart.cacheStatusLabel" x-text="chart.cacheStatusLabel"></span>
         </div>
 
-        <div class="workflow-conn" :class="workflow.aiConnClass"></div>
+        <div class="workflow-conn" :class="chart.aiConnClass"></div>
 
-        <div class="workflow-node workflow-node-ai" :class="workflow.aiNodeClass">
-            <span class="workflow-node-label" x-text="workflow.aiLabel"></span>
-            <span class="workflow-node-sub" x-show="workflow.aiSublabel" x-text="workflow.aiSublabel"></span>
+        <div class="workflow-node workflow-node-ai" :class="chart.aiNodeClass">
+            <span class="workflow-node-label" x-text="chart.aiLabel"></span>
+            <span class="workflow-node-sub" x-show="chart.aiSublabel" x-text="chart.aiSublabel"></span>
         </div>
 
-        <div class="workflow-conn" x-show="workflow.showFailover" :class="workflow.failoverConnClass"></div>
-        <div class="workflow-node workflow-node-feature workflow-node-failover" x-show="workflow.showFailover" :class="workflow.failoverNodeClass">
+        <div class="workflow-conn" x-show="chart.showFailover" :class="chart.failoverConnClass"></div>
+        <div class="workflow-node workflow-node-feature workflow-node-failover" x-show="chart.showFailover" :class="chart.failoverNodeClass">
             <div class="workflow-node-icon">
                 <svg viewBox="0 0 24 24"><path d="M17 3h4v4"/><path d="M7 21H3v-4"/><path d="M21 3l-7 7"/><path d="M3 21l7-7"/></svg>
             </div>
             <span class="workflow-node-label">Failover</span>
-            <span class="workflow-node-badge" x-show="workflow.failoverStatusLabel" x-text="workflow.failoverStatusLabel"></span>
-            <span class="workflow-node-sub" x-show="workflow.failoverTargetLabel" x-text="workflow.failoverTargetLabel"></span>
+            <span class="workflow-node-badge" x-show="chart.failoverStatusLabel" x-text="chart.failoverStatusLabel"></span>
+            <span class="workflow-node-sub" x-show="chart.failoverTargetLabel" x-text="chart.failoverTargetLabel"></span>
         </div>
 
-        <div class="workflow-conn" :class="workflow.responseConnClass"></div>
-        <div class="workflow-node workflow-node-endpoint" :class="workflow.responseNodeClass">
+        <div class="workflow-conn" :class="chart.responseConnClass"></div>
+        <div class="workflow-node workflow-node-endpoint" :class="chart.responseNodeClass">
             <div class="workflow-node-icon workflow-node-icon-endpoint">
                 <svg viewBox="0 0 24 24"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
             </div>
             <span class="workflow-node-label">Response</span>
-            <span class="workflow-node-sub" x-show="workflow.responseNodeSublabel" x-text="workflow.responseNodeSublabel"></span>
+            <span class="workflow-node-sub" x-show="chart.responseNodeSublabel" x-text="chart.responseNodeSublabel"></span>
         </div>
     </div>
 
-    <div class="workflow-async-section" x-show="workflow.showAsync">
+    <div class="workflow-async-section" x-show="chart.showAsync">
         <div class="workflow-async-row">
-            <div class="workflow-node workflow-node-feature workflow-node-async workflow-node-async-usage" x-show="workflow.showUsage" :class="workflow.usageNodeClass">
+            <div class="workflow-node workflow-node-feature workflow-node-async workflow-node-async-usage" x-show="chart.showUsage" :class="chart.usageNodeClass">
                 <div class="workflow-node-icon">
                     <svg viewBox="0 0 24 24"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
                 </div>
                 <span class="workflow-node-label">Usage</span>
             </div>
-            <div class="workflow-conn workflow-conn-async" x-show="workflow.showUsage && workflow.showAudit"></div>
-            <div class="workflow-node workflow-node-feature workflow-node-async workflow-node-async-audit" x-show="workflow.showAudit" :class="workflow.auditNodeClass">
+            <div class="workflow-conn workflow-conn-async" x-show="chart.showUsage && chart.showAudit"></div>
+            <div class="workflow-node workflow-node-feature workflow-node-async workflow-node-async-audit" x-show="chart.showAudit" :class="chart.auditNodeClass">
                 <div class="workflow-node-icon">
                     <svg viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
                 </div>


### PR DESCRIPTION
## Summary
- avoid Alpine state shadowing in the shared workflow chart so persisted workflow cards keep Cache and Guardrails nodes
- centralize cache overview visibility so non-analytics pages do not start unnecessary `/cache/overview` requests
- add regression coverage for workflow chart bindings and hidden cache overview requests

## Tests
- node --test internal/admin/dashboard/static/js/modules/*.test.js
- go test ./internal/admin/dashboard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Cache analytics requests are now made only on pages displaying cache analytics cards, reducing unnecessary network calls.

* **Refactor**
  * Simplified cache overview loading logic.
  * Updated workflow chart template data structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->