### PR TITLE
fix(core): normalize provider error payloads

### DIFF
--- a/internal/core/errors.go
+++ b/internal/core/errors.go
@@ -280,16 +280,19 @@ func providerErrorMetadataRaw(raw json.RawMessage) string {
 	return jsonString(metadata["raw"])
 }
 
+// shouldPreferProviderRaw handles OpenRouter wrapper errors: OpenRouter can
+// return a generic "Provider returned ..." message while placing the useful
+// upstream provider detail in metadata.raw. Use a tolerant prefix match so
+// small wording or punctuation changes still surface the actionable message.
 func shouldPreferProviderRaw(message, raw string) bool {
 	if strings.TrimSpace(raw) == "" {
 		return false
 	}
-	switch strings.ToLower(strings.TrimSpace(message)) {
-	case "", "provider returned error":
+	normalizedMessage := strings.ToLower(strings.TrimSpace(message))
+	if normalizedMessage == "" || strings.HasPrefix(normalizedMessage, "provider returned") {
 		return true
-	default:
-		return false
 	}
+	return false
 }
 
 func jsonString(raw json.RawMessage) string {

--- a/internal/core/errors.go
+++ b/internal/core/errors.go
@@ -2,9 +2,11 @@
 package core
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 )
 
 // ErrorType represents the type of error that occurred
@@ -174,19 +176,10 @@ func NewNotFoundError(message string) *GatewayError {
 
 // ParseProviderError parses an error response from a provider and returns an appropriate GatewayError
 func ParseProviderError(provider string, statusCode int, body []byte, originalErr error) *GatewayError {
-	// Try to parse the error response as JSON
-	var errorResponse struct {
-		Error struct {
-			Message string `json:"message"`
-			Type    string `json:"type"`
-			Code    string `json:"code"`
-			Param   string `json:"param"`
-		} `json:"error"`
-	}
-
 	message := string(body)
-	if err := json.Unmarshal(body, &errorResponse); err == nil && errorResponse.Error.Message != "" {
-		message = errorResponse.Error.Message
+	errorResponse := parseProviderErrorBody(body)
+	if errorResponse.Message != "" {
+		message = errorResponse.Message
 	}
 
 	// Determine error type based on status code
@@ -233,12 +226,98 @@ func ParseProviderError(provider string, statusCode int, body []byte, originalEr
 		gatewayErr = NewProviderError(provider, http.StatusBadGateway, message, originalErr)
 	}
 
-	if errorResponse.Error.Param != "" {
-		gatewayErr = gatewayErr.WithParam(errorResponse.Error.Param)
+	if errorResponse.Param != "" {
+		gatewayErr = gatewayErr.WithParam(errorResponse.Param)
 	}
-	if errorResponse.Error.Code != "" {
-		gatewayErr = gatewayErr.WithCode(errorResponse.Error.Code)
+	if errorResponse.Code != "" {
+		gatewayErr = gatewayErr.WithCode(errorResponse.Code)
 	}
 
 	return gatewayErr
+}
+
+type providerErrorDetails struct {
+	Message string
+	Param   string
+	Code    string
+}
+
+func parseProviderErrorBody(body []byte) providerErrorDetails {
+	var payload struct {
+		Error json.RawMessage `json:"error"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil || len(payload.Error) == 0 {
+		return providerErrorDetails{}
+	}
+
+	if message := jsonString(payload.Error); message != "" {
+		return providerErrorDetails{Message: message}
+	}
+
+	var errorFields map[string]json.RawMessage
+	if err := json.Unmarshal(payload.Error, &errorFields); err != nil {
+		return providerErrorDetails{}
+	}
+
+	details := providerErrorDetails{
+		Message: jsonString(errorFields["message"]),
+		Param:   jsonString(errorFields["param"]),
+		Code:    jsonScalarString(errorFields["code"]),
+	}
+
+	if raw := providerErrorMetadataRaw(errorFields["metadata"]); shouldPreferProviderRaw(details.Message, raw) {
+		details.Message = raw
+	}
+
+	return details
+}
+
+func providerErrorMetadataRaw(raw json.RawMessage) string {
+	var metadata map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &metadata); err != nil {
+		return ""
+	}
+	return jsonString(metadata["raw"])
+}
+
+func shouldPreferProviderRaw(message, raw string) bool {
+	if strings.TrimSpace(raw) == "" {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(message)) {
+	case "", "provider returned error":
+		return true
+	default:
+		return false
+	}
+}
+
+func jsonString(raw json.RawMessage) string {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return ""
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return ""
+	}
+	return value
+}
+
+func jsonScalarString(raw json.RawMessage) string {
+	if value := jsonString(raw); value != "" {
+		return value
+	}
+
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return ""
+	}
+	var number json.Number
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&number); err != nil {
+		return ""
+	}
+	return number.String()
 }

--- a/internal/core/errors_test.go
+++ b/internal/core/errors_test.go
@@ -384,19 +384,72 @@ func TestParseProviderError(t *testing.T) {
 	}
 }
 
-func TestParseProviderError_OpenRouterNumericCodeUsesMetadataRaw(t *testing.T) {
-	body := []byte(`{"error":{"message":"Provider returned error","code":429,"metadata":{"raw":"deepseek/deepseek-v4-pro is temporarily rate-limited upstream. Please retry shortly.","provider_name":"Together","is_byok":false,"retry_after_seconds":1}},"user_id":"user_34xtJN3FV8S4Jdq3UNuWa0n9RAh"}`)
-
-	err := ParseProviderError("openrouter", http.StatusTooManyRequests, body, nil)
-
-	if err.Type != ErrorTypeRateLimit {
-		t.Fatalf("Type = %v, want %v", err.Type, ErrorTypeRateLimit)
+func TestParseProviderError_OpenRouter_TableDriven(t *testing.T) {
+	tests := []struct {
+		name        string
+		body        []byte
+		wantType    ErrorType
+		wantMessage string
+		wantCode    *string
+	}{
+		{
+			name:        "numeric code without metadata raw preserves message",
+			body:        []byte(`{"error":{"message":"Provider returned error","code":429,"metadata":{"provider_name":"Together","is_byok":false,"retry_after_seconds":1}},"user_id":"user_test_123"}`),
+			wantType:    ErrorTypeRateLimit,
+			wantMessage: "Provider returned error",
+			wantCode:    stringPointer("429"),
+		},
+		{
+			name:        "metadata raw with non generic message preserves original message",
+			body:        []byte(`{"error":{"message":"The selected provider rejected the request","code":"rate_limit_exceeded","metadata":{"raw":"deepseek/deepseek-v4-pro is temporarily rate-limited upstream. Please retry shortly.","provider_name":"Together"}},"user_id":"user_test_123"}`),
+			wantType:    ErrorTypeRateLimit,
+			wantMessage: "The selected provider rejected the request",
+			wantCode:    stringPointer("rate_limit_exceeded"),
+		},
+		{
+			name:        "empty message with metadata raw uses raw and numeric code",
+			body:        []byte(`{"error":{"message":"","code":429,"metadata":{"raw":"deepseek/deepseek-v4-pro is temporarily rate-limited upstream. Please retry shortly.","provider_name":"Together","is_byok":false,"retry_after_seconds":1}},"user_id":"user_test_123"}`),
+			wantType:    ErrorTypeRateLimit,
+			wantMessage: "deepseek/deepseek-v4-pro is temporarily rate-limited upstream. Please retry shortly.",
+			wantCode:    stringPointer("429"),
+		},
+		{
+			name:        "provider returned prefix with metadata raw uses raw",
+			body:        []byte(`{"error":{"message":"Provider returned an error: upstream rejected the request","code":429,"metadata":{"raw":"deepseek/deepseek-v4-pro is temporarily rate-limited upstream. Please retry shortly.","provider_name":"Together"}},"user_id":"user_test_123"}`),
+			wantType:    ErrorTypeRateLimit,
+			wantMessage: "deepseek/deepseek-v4-pro is temporarily rate-limited upstream. Please retry shortly.",
+			wantCode:    stringPointer("429"),
+		},
+		{
+			name:        "malformed metadata falls back to parsed message and numeric code",
+			body:        []byte(`{"error":{"message":"Provider returned error","code":429,"metadata":"not an object"},"user_id":"user_test_123"}`),
+			wantType:    ErrorTypeRateLimit,
+			wantMessage: "Provider returned error",
+			wantCode:    stringPointer("429"),
+		},
+		{
+			name:        "missing metadata and object code falls back without code",
+			body:        []byte(`{"error":{"message":"Provider returned error","code":{"status":429}},"user_id":"user_test_123"}`),
+			wantType:    ErrorTypeRateLimit,
+			wantMessage: "Provider returned error",
+			wantCode:    nil,
+		},
 	}
-	if err.Message != "deepseek/deepseek-v4-pro is temporarily rate-limited upstream. Please retry shortly." {
-		t.Fatalf("Message = %q", err.Message)
-	}
-	if err.Code == nil || *err.Code != "429" {
-		t.Fatalf("Code = %v, want 429", err.Code)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ParseProviderError("openrouter", http.StatusTooManyRequests, tt.body, nil)
+
+			if err.Type != tt.wantType {
+				t.Fatalf("Type = %v, want %v", err.Type, tt.wantType)
+			}
+			if err.Message != tt.wantMessage {
+				t.Fatalf("Message = %q, want %q", err.Message, tt.wantMessage)
+			}
+			if !equalStringPointers(err.Code, tt.wantCode) {
+				t.Fatalf("Code = %v, want %v", err.Code, tt.wantCode)
+			}
+		})
 	}
 }
 
@@ -409,6 +462,10 @@ func equalStringPointers(a, b *string) bool {
 	default:
 		return *a == *b
 	}
+}
+
+func stringPointer(value string) *string {
+	return &value
 }
 
 func TestGatewayError_AsError(t *testing.T) {

--- a/internal/core/errors_test.go
+++ b/internal/core/errors_test.go
@@ -384,6 +384,22 @@ func TestParseProviderError(t *testing.T) {
 	}
 }
 
+func TestParseProviderError_OpenRouterNumericCodeUsesMetadataRaw(t *testing.T) {
+	body := []byte(`{"error":{"message":"Provider returned error","code":429,"metadata":{"raw":"deepseek/deepseek-v4-pro is temporarily rate-limited upstream. Please retry shortly.","provider_name":"Together","is_byok":false,"retry_after_seconds":1}},"user_id":"user_34xtJN3FV8S4Jdq3UNuWa0n9RAh"}`)
+
+	err := ParseProviderError("openrouter", http.StatusTooManyRequests, body, nil)
+
+	if err.Type != ErrorTypeRateLimit {
+		t.Fatalf("Type = %v, want %v", err.Type, ErrorTypeRateLimit)
+	}
+	if err.Message != "deepseek/deepseek-v4-pro is temporarily rate-limited upstream. Please retry shortly." {
+		t.Fatalf("Message = %q", err.Message)
+	}
+	if err.Code == nil || *err.Code != "429" {
+		t.Fatalf("Code = %v, want 429", err.Code)
+	}
+}
+
 func equalStringPointers(a, b *string) bool {
 	switch {
 	case a == nil && b == nil:


### PR DESCRIPTION
## Summary
- tolerate provider error objects with numeric `error.code` values
- prefer OpenRouter `metadata.raw` when the upstream message is the generic `Provider returned error`
- add a regression test for OpenRouter rate-limit payloads

## Tests
- `go test ./internal/core`
- `go test ./internal/llmclient ./internal/server`
- `go test ./...`
- pre-commit: `make test-race`, `make lint`, hot-path performance guard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust extraction of provider error messages and codes across varied response shapes
  * Improved detection and reporting of rate-limit errors with clearer, user-facing messages
  * Safer fallback behavior when provider error payloads are incomplete or malformed

* **Tests**
  * Added comprehensive tests covering varied provider error formats and message/code propagation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->