### PR TITLE
fix(base-path): consolidate prefix handling

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -871,6 +871,25 @@ func NormalizeBasePath(value string) string {
 	return normalized
 }
 
+// JoinBasePath prefixes urlPath with the normalized public mount path.
+func JoinBasePath(basePath, urlPath string) string {
+	basePath = NormalizeBasePath(basePath)
+	trimmedPath := strings.TrimSpace(urlPath)
+	if trimmedPath == "" || trimmedPath == "/" {
+		if basePath == "/" {
+			return "/"
+		}
+		return basePath
+	}
+	if !strings.HasPrefix(trimmedPath, "/") {
+		trimmedPath = "/" + trimmedPath
+	}
+	if basePath == "/" {
+		return trimmedPath
+	}
+	return basePath + trimmedPath
+}
+
 // MetricsConfig holds observability configuration for Prometheus metrics
 type MetricsConfig struct {
 	// Enabled controls whether Prometheus metrics are collected and exposed

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -185,6 +185,29 @@ func TestNormalizeBasePath(t *testing.T) {
 	}
 }
 
+func TestJoinBasePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		basePath string
+		urlPath  string
+		expected string
+	}{
+		{name: "root leaves absolute path unchanged", basePath: "/", urlPath: "/admin/api/v1", expected: "/admin/api/v1"},
+		{name: "root adds leading slash", basePath: "/", urlPath: "admin/api/v1", expected: "/admin/api/v1"},
+		{name: "prefixes normalized base path", basePath: "g/", urlPath: "/admin/api/v1", expected: "/g/admin/api/v1"},
+		{name: "empty app path resolves to base path", basePath: "/g", urlPath: "", expected: "/g"},
+		{name: "root app path resolves to base path", basePath: "/g", urlPath: "/", expected: "/g"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := JoinBasePath(tt.basePath, tt.urlPath); got != tt.expected {
+				t.Errorf("JoinBasePath(%q, %q) = %q, want %q", tt.basePath, tt.urlPath, got, tt.expected)
+			}
+		})
+	}
+}
+
 // TestApplyEnvOverrides tests the applyEnvOverrides function
 func TestApplyEnvOverrides(t *testing.T) {
 	tests := []struct {

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -93,6 +93,53 @@ Create the image reference
 {{- end }}
 
 {{/*
+Normalize the public base path used by the application.
+*/}}
+{{- define "gomodel.basePath" -}}
+{{- $basePath := trim (default "/" .Values.server.basePath) -}}
+{{- if or (eq $basePath "") (eq $basePath "/") -}}
+/
+{{- else -}}
+{{- if not (hasPrefix "/" $basePath) -}}
+{{- $basePath = printf "/%s" $basePath -}}
+{{- end -}}
+{{- $basePath = clean $basePath -}}
+{{- if or (eq $basePath ".") (eq $basePath "/") -}}
+/
+{{- else -}}
+{{- $basePath -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Prefix an application path with server.basePath unless it is already prefixed.
+*/}}
+{{- define "gomodel.pathWithBasePath" -}}
+{{- $root := .root -}}
+{{- $path := trim (default "/" .path) -}}
+{{- if or (eq $path "") (eq $path "/") -}}
+{{- $path = "/" -}}
+{{- else if not (hasPrefix "/" $path) -}}
+{{- $path = printf "/%s" $path -}}
+{{- end -}}
+{{- $basePath := include "gomodel.basePath" $root -}}
+{{- if eq $path "/" -}}
+{{- if eq $basePath "/" -}}
+{{- $path -}}
+{{- else -}}
+{{- $basePath -}}
+{{- end -}}
+{{- else if eq $basePath "/" -}}
+{{- $path -}}
+{{- else if or (eq $path $basePath) (hasPrefix (printf "%s/" $basePath) $path) -}}
+{{- $path -}}
+{{- else -}}
+{{- printf "%s%s" $basePath $path -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Generate provider API key entries for the Secret stringData.
 */}}
 {{- define "gomodel.providerSecretData" -}}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -117,10 +117,18 @@ spec:
           volumeMounts:
             - name: cache
               mountPath: /cache
+          {{- $livenessProbe := deepCopy .Values.livenessProbe }}
+          {{- if and $livenessProbe.httpGet $livenessProbe.httpGet.path }}
+          {{- $_ := set $livenessProbe.httpGet "path" (include "gomodel.pathWithBasePath" (dict "root" . "path" $livenessProbe.httpGet.path)) }}
+          {{- end }}
           livenessProbe:
-            {{- toYaml .Values.livenessProbe | nindent 12 }}
+            {{- toYaml $livenessProbe | nindent 12 }}
+          {{- $readinessProbe := deepCopy .Values.readinessProbe }}
+          {{- if and $readinessProbe.httpGet $readinessProbe.httpGet.path }}
+          {{- $_ := set $readinessProbe.httpGet "path" (include "gomodel.pathWithBasePath" (dict "root" . "path" $readinessProbe.httpGet.path)) }}
+          {{- end }}
           readinessProbe:
-            {{- toYaml .Values.readinessProbe | nindent 12 }}
+            {{- toYaml $readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/helm/templates/servicemonitor.yaml
+++ b/helm/templates/servicemonitor.yaml
@@ -14,6 +14,6 @@ spec:
       {{- include "gomodel.selectorLabels" . | nindent 6 }}
   endpoints:
     - port: http
-      path: {{ .Values.metrics.endpoint }}
+      path: {{ include "gomodel.pathWithBasePath" (dict "root" . "path" .Values.metrics.endpoint) | quote }}
       interval: {{ .Values.metrics.serviceMonitor.interval }}
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -147,7 +147,7 @@ metrics:
   serviceMonitor:
     # -- Create a ServiceMonitor for Prometheus Operator
     enabled: false
-    # If server.basePath is not "/", include the same prefix in metrics.endpoint.
+    # ServiceMonitor path is automatically prefixed with server.basePath.
     # -- Scrape interval
     interval: "15s"
     # -- Additional labels for the ServiceMonitor
@@ -233,7 +233,7 @@ podDisruptionBudget:
   # maxUnavailable: 1
 
 # Liveness probe configuration
-# If server.basePath is not "/", include the same prefix in the probe path.
+# httpGet.path is automatically prefixed with server.basePath.
 livenessProbe:
   httpGet:
     path: /health
@@ -244,7 +244,7 @@ livenessProbe:
   failureThreshold: 3
 
 # Readiness probe configuration
-# If server.basePath is not "/", include the same prefix in the probe path.
+# httpGet.path is automatically prefixed with server.basePath.
 readinessProbe:
   httpGet:
     path: /health

--- a/internal/admin/dashboard/dashboard.go
+++ b/internal/admin/dashboard/dashboard.go
@@ -10,8 +10,9 @@ import (
 	"io/fs"
 	"log/slog"
 	"net/http"
-	"path"
 	"strings"
+
+	"gomodel/config"
 
 	"github.com/labstack/echo/v5"
 )
@@ -33,7 +34,7 @@ func New() (*Handler, error) {
 
 // NewWithBasePath creates a dashboard handler for an app mounted under basePath.
 func NewWithBasePath(basePath string) (*Handler, error) {
-	basePath = normalizeBasePath(basePath)
+	basePath = config.NormalizeBasePath(basePath)
 	assetVersions, err := buildAssetVersions("css/dashboard.css")
 	if err != nil {
 		return nil, err
@@ -44,7 +45,7 @@ func NewWithBasePath(basePath string) (*Handler, error) {
 			return assetURL(basePath, path, assetVersions)
 		},
 		"appURL": func(path string) string {
-			return appURL(basePath, path)
+			return config.JoinBasePath(basePath, path)
 		},
 	}).ParseFS(content, "templates/*.html")
 	if err != nil {
@@ -109,44 +110,11 @@ func buildAssetVersions(paths ...string) (map[string]string, error) {
 func assetURL(basePath, assetPath string, versions map[string]string) string {
 	normalizedPath := strings.TrimLeft(strings.TrimSpace(assetPath), "/")
 	if normalizedPath == "" {
-		return appURL(basePath, "/admin/static/")
+		return config.JoinBasePath(basePath, "/admin/static/")
 	}
-	urlPath := appURL(basePath, "/admin/static/"+normalizedPath)
+	urlPath := config.JoinBasePath(basePath, "/admin/static/"+normalizedPath)
 	if version := versions[normalizedPath]; version != "" {
 		return urlPath + "?v=" + version
 	}
 	return urlPath
-}
-
-func appURL(basePath, urlPath string) string {
-	basePath = normalizeBasePath(basePath)
-	trimmedPath := strings.TrimSpace(urlPath)
-	if trimmedPath == "" || trimmedPath == "/" {
-		if basePath == "/" {
-			return "/"
-		}
-		return basePath
-	}
-	if !strings.HasPrefix(trimmedPath, "/") {
-		trimmedPath = "/" + trimmedPath
-	}
-	if basePath == "/" {
-		return trimmedPath
-	}
-	return basePath + trimmedPath
-}
-
-func normalizeBasePath(value string) string {
-	trimmed := strings.TrimSpace(value)
-	if trimmed == "" || trimmed == "/" {
-		return "/"
-	}
-	if !strings.HasPrefix(trimmed, "/") {
-		trimmed = "/" + trimmed
-	}
-	normalized := path.Clean(trimmed)
-	if normalized == "." || normalized == "/" {
-		return "/"
-	}
-	return normalized
 }

--- a/internal/admin/dashboard/static/js/modules/dashboard-paths.test.js
+++ b/internal/admin/dashboard/static/js/modules/dashboard-paths.test.js
@@ -1,0 +1,148 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+function loadDashboardGlobals(windowOverrides = {}) {
+  const source = fs.readFileSync(path.join(__dirname, "../dashboard.js"), "utf8");
+  const window = {
+    GOMODEL_BASE_PATH: "/g",
+    ...windowOverrides,
+  };
+  const context = {
+    console,
+    window,
+  };
+
+  vm.createContext(context);
+  vm.runInContext(source, context);
+  return context;
+}
+
+function loadLayoutBootstrap(basePath = "/g") {
+  const layout = fs.readFileSync(
+    path.join(__dirname, "../../../templates/layout.html"),
+    "utf8",
+  );
+  const match = layout.match(/<script>\s*([\s\S]*?)\s*<\/script>/i);
+  assert.ok(match, "expected inline dashboard bootstrap script");
+
+  const fetchCalls = [];
+  const historyCalls = [];
+  const window = {
+    location: {
+      href: "http://localhost/g/admin/dashboard",
+      origin: "http://localhost",
+    },
+    fetch(input, init) {
+      fetchCalls.push({ input, init });
+      return Promise.resolve({ input, init });
+    },
+    history: {
+      pushState(state, title, url) {
+        historyCalls.push({ method: "pushState", state, title, url });
+      },
+      replaceState(state, title, url) {
+        historyCalls.push({ method: "replaceState", state, title, url });
+      },
+    },
+  };
+  const context = {
+    console,
+    Request,
+    URL,
+    window,
+  };
+  const script = match[1].replace(
+    'const basePath = "{{.BasePath}}";',
+    `const basePath = "${basePath}";`,
+  );
+
+  vm.createContext(context);
+  vm.runInContext(script, context);
+  return { fetchCalls, historyCalls, window };
+}
+
+test("dashboardPath delegates to the layout path prefix helper", () => {
+  const context = loadDashboardGlobals({
+    gomodelPath(pathValue) {
+      return `/g${pathValue}`;
+    },
+  });
+
+  assert.equal(context.dashboardPath("/admin/dashboard/usage"), "/g/admin/dashboard/usage");
+});
+
+test("dashboardUnprefixedPath strips only the configured base path boundary", () => {
+  const context = loadDashboardGlobals();
+
+  assert.equal(context.dashboardUnprefixedPath("/g/admin/dashboard"), "/admin/dashboard");
+  assert.equal(context.dashboardUnprefixedPath("/g"), "/");
+  assert.equal(context.dashboardUnprefixedPath("/gopher/admin/dashboard"), "/gopher/admin/dashboard");
+});
+
+test("layout gomodelPath prefixes root-relative dashboard URLs idempotently", () => {
+  const { window } = loadLayoutBootstrap();
+
+  assert.equal(window.gomodelPath("/admin/api/v1/models"), "/g/admin/api/v1/models");
+  assert.equal(window.gomodelPath("/g/admin/api/v1/models"), "/g/admin/api/v1/models");
+  assert.equal(window.gomodelPath("https://example.com/admin/api/v1/models"), "https://example.com/admin/api/v1/models");
+});
+
+test("layout fetch wrapper prefixes string, URL, and Request inputs", async() => {
+  const { fetchCalls, window } = loadLayoutBootstrap();
+
+  await window.fetch("/admin/api/v1/models", { headers: { Accept: "application/json" } });
+  assert.equal(fetchCalls[0].input, "/g/admin/api/v1/models");
+  assert.equal(fetchCalls[0].init.headers.Accept, "application/json");
+
+  await window.fetch(new URL("http://localhost/admin/api/v1/models?limit=1"));
+  assert.equal(fetchCalls[1].input.toString(), "http://localhost/g/admin/api/v1/models?limit=1");
+
+  const crossOriginURL = new URL("http://other-origin.example.com/admin/api/v1/models?limit=1");
+  await window.fetch(crossOriginURL);
+  assert.equal(fetchCalls[2].input.toString(), crossOriginURL.toString());
+
+  await window.fetch(new URL("http://localhost/g/admin/api/v1/models?limit=1"));
+  assert.equal(fetchCalls[3].input.toString(), "http://localhost/g/admin/api/v1/models?limit=1");
+
+  const request = new Request("http://localhost/admin/api/v1/models?limit=1", {
+    headers: { Authorization: "Bearer test" },
+  });
+  await window.fetch(request);
+  assert.ok(fetchCalls[4].input instanceof Request);
+  assert.equal(fetchCalls[4].input.url, "http://localhost/g/admin/api/v1/models?limit=1");
+  assert.equal(fetchCalls[4].input.headers.get("authorization"), "Bearer test");
+});
+
+test("layout fetch wrapper leaves cross-origin Request inputs unchanged", async() => {
+  const { fetchCalls, window } = loadLayoutBootstrap();
+  const request = new Request("http://api.example.com/admin/api/v1/models");
+
+  await window.fetch(request);
+
+  assert.strictEqual(fetchCalls[0].input, request);
+});
+
+test("layout history wrapper prefixes dashboard navigation URLs", () => {
+  const { historyCalls, window } = loadLayoutBootstrap();
+
+  window.history.pushState(null, "", "/admin/dashboard/usage");
+  window.history.replaceState(null, "", "/g/admin/dashboard/models");
+
+  assert.deepEqual(historyCalls, [
+    {
+      method: "pushState",
+      state: null,
+      title: "",
+      url: "/g/admin/dashboard/usage",
+    },
+    {
+      method: "replaceState",
+      state: null,
+      title: "",
+      url: "/g/admin/dashboard/models",
+    },
+  ]);
+});

--- a/internal/admin/dashboard/static/js/modules/usage.js
+++ b/internal/admin/dashboard/static/js/modules/usage.js
@@ -1,16 +1,13 @@
 (function(global) {
-function dashboardUsageModule() {
-    function dashboardModulePath(path) {
-        if (typeof dashboardPath === 'function') {
-            return dashboardPath(path);
+    function dashboardUsageModule() {
+        function dashboardModulePath(path) {
+            if (typeof window !== 'undefined' && typeof window.gomodelPath === 'function') {
+                return window.gomodelPath(path);
+            }
+            return path;
         }
-        if (typeof window !== 'undefined' && typeof window.gomodelPath === 'function') {
-            return window.gomodelPath(path);
-        }
-        return path;
-    }
 
-    return {
+        return {
             emptyUsageSummary() {
                 return {
                     total_requests: 0,

--- a/internal/admin/dashboard/templates/layout.html
+++ b/internal/admin/dashboard/templates/layout.html
@@ -24,14 +24,52 @@
                 }
                 return basePath + urlPath;
             };
+            function sameOriginURLWithBasePath(rawURL) {
+                if (typeof URL !== "function") {
+                    return rawURL;
+                }
+                const url = new URL(rawURL, window.location.href);
+                if (url.origin !== window.location.origin) {
+                    return rawURL;
+                }
+                const nextPath = window.gomodelPath(url.pathname);
+                if (nextPath === url.pathname) {
+                    return rawURL;
+                }
+                url.pathname = nextPath;
+                return url.toString();
+            }
             if (basePath !== "/" && typeof window.fetch === "function") {
                 const rawFetch = window.fetch.bind(window);
                 window.fetch = function (input, init) {
                     if (typeof input === "string") {
                         return rawFetch(window.gomodelPath(input), init);
                     }
+                    if (typeof URL === "function" && input instanceof URL) {
+                        return rawFetch(new URL(sameOriginURLWithBasePath(input.toString())), init);
+                    }
+                    if (typeof Request === "function" && input instanceof Request) {
+                        const nextURL = sameOriginURLWithBasePath(input.url);
+                        if (nextURL !== input.url) {
+                            return rawFetch(new Request(nextURL, input), init);
+                        }
+                    }
                     return rawFetch(input, init);
                 };
+            }
+            if (basePath !== "/" && window.history) {
+                ["pushState", "replaceState"].forEach(function (method) {
+                    if (typeof window.history[method] !== "function") {
+                        return;
+                    }
+                    const rawHistoryMethod = window.history[method].bind(window.history);
+                    window.history[method] = function (state, title, url) {
+                        if (typeof url === "string") {
+                            return rawHistoryMethod(state, title, window.gomodelPath(url));
+                        }
+                        return rawHistoryMethod(state, title, url);
+                    };
+                });
             }
         })();
     </script>

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -381,11 +381,11 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		} else {
 			serverCfg.AdminEndpointsEnabled = true
 			serverCfg.AdminHandler = adminHandler
-			slog.Info("admin API enabled", "api", appPath(appCfg.Server.BasePath, "/admin/api/v1"))
+			slog.Info("admin API enabled", "api", config.JoinBasePath(appCfg.Server.BasePath, "/admin/api/v1"))
 			if adminCfg.UIEnabled {
 				serverCfg.AdminUIEnabled = true
 				serverCfg.DashboardHandler = dashHandler
-				slog.Info("admin UI enabled", "url", fmt.Sprintf("http://localhost:%s%s", appCfg.Server.Port, appPath(appCfg.Server.BasePath, "/admin/dashboard")))
+				slog.Info("admin UI enabled", "url", fmt.Sprintf("http://localhost:%s%s", appCfg.Server.Port, config.JoinBasePath(appCfg.Server.BasePath, "/admin/dashboard")))
 			}
 		}
 	} else {
@@ -393,13 +393,13 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 	}
 
 	if appCfg.Server.SwaggerEnabled {
-		slog.Info("swagger UI enabled", "path", appPath(appCfg.Server.BasePath, "/swagger/index.html"))
+		slog.Info("swagger UI enabled", "path", config.JoinBasePath(appCfg.Server.BasePath, "/swagger/index.html"))
 	}
 	if appCfg.Server.PprofEnabled {
-		slog.Info("pprof enabled", "path", appPath(appCfg.Server.BasePath, "/debug/pprof/"))
+		slog.Info("pprof enabled", "path", config.JoinBasePath(appCfg.Server.BasePath, "/debug/pprof/"))
 	}
 	if appCfg.Server.EnablePassthroughRoutes {
-		slog.Info("provider passthrough enabled", "path", appPath(appCfg.Server.BasePath, "/p/{provider}/{endpoint}"))
+		slog.Info("provider passthrough enabled", "path", config.JoinBasePath(appCfg.Server.BasePath, "/p/{provider}/{endpoint}"))
 	} else {
 		slog.Info("provider passthrough disabled")
 	}
@@ -809,24 +809,6 @@ func initAdmin(
 	}
 
 	return adminHandler, dashHandler, nil
-}
-
-func appPath(basePath, urlPath string) string {
-	basePath = config.NormalizeBasePath(basePath)
-	trimmedPath := strings.TrimSpace(urlPath)
-	if trimmedPath == "" || trimmedPath == "/" {
-		if basePath == "/" {
-			return "/"
-		}
-		return basePath
-	}
-	if !strings.HasPrefix(trimmedPath, "/") {
-		trimmedPath = "/" + trimmedPath
-	}
-	if basePath == "/" {
-		return trimmedPath
-	}
-	return basePath + trimmedPath
 }
 
 func configGuardrailDefinitions(cfg config.GuardrailsConfig) ([]guardrails.Definition, error) {

--- a/internal/server/base_path.go
+++ b/internal/server/base_path.go
@@ -2,36 +2,22 @@ package server
 
 import (
 	"net/http"
-	"path"
 	"strings"
+
+	"gomodel/config"
 
 	"github.com/labstack/echo/v5"
 )
-
-func normalizeBasePath(value string) string {
-	trimmed := strings.TrimSpace(value)
-	if trimmed == "" || trimmed == "/" {
-		return "/"
-	}
-	if !strings.HasPrefix(trimmed, "/") {
-		trimmed = "/" + trimmed
-	}
-	normalized := path.Clean(trimmed)
-	if normalized == "." || normalized == "/" {
-		return "/"
-	}
-	return normalized
-}
 
 func configuredBasePath(cfg *Config) string {
 	if cfg == nil {
 		return "/"
 	}
-	return normalizeBasePath(cfg.BasePath)
+	return config.NormalizeBasePath(cfg.BasePath)
 }
 
 func stripBasePathMiddleware(basePath string) echo.MiddlewareFunc {
-	basePath = normalizeBasePath(basePath)
+	basePath = config.NormalizeBasePath(basePath)
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c *echo.Context) error {
 			if basePath == "/" {
@@ -60,7 +46,7 @@ func stripBasePathMiddleware(basePath string) echo.MiddlewareFunc {
 }
 
 func stripBasePath(requestPath, basePath string) (string, bool) {
-	basePath = normalizeBasePath(basePath)
+	basePath = config.NormalizeBasePath(basePath)
 	if basePath == "/" {
 		if requestPath == "" {
 			return "/", true


### PR DESCRIPTION
## Summary
- consolidate base path normalization and joining into shared config helpers
- make dashboard fetch/history prefixing cover Request, URL, pushState, and replaceState
- auto-prefix Helm probes and ServiceMonitor paths from server.basePath
- add direct dashboard path-prefix tests and fix usage module indentation

## Validation
- go test ./cmd/... ./internal/... ./config/...
- node --test internal/admin/dashboard/static/js/modules/*.test.js
- helm lint ./helm --set providers.openai.apiKey=test --set server.basePath=/g --set metrics.serviceMonitor.enabled=true
- helm template --dependency-update gomodel ./helm --set providers.openai.apiKey=test --set server.basePath=/g --set metrics.serviceMonitor.enabled=true

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consistently applies a configured base path to health probes, metrics endpoint, service monitor, static assets, startup URLs, and admin/dashboard routes.

* **Tests**
  * Added server-side unit tests for base-path joining.
  * Added client-side tests for path prefixing, fetch/request rewriting, and history URL rewriting.

* **Refactor**
  * Centralized base-path normalization and joining into a shared utility for consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->