### PR TITLE
fix(admin): treat canceled admin requests as client closed

### DIFF
--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -390,6 +390,12 @@ func handleError(c *echo.Context, err error) error {
 		logHandledAdminError(c, gatewayErr)
 		return c.JSON(gatewayErr.HTTPStatusCode(), gatewayErr.ToJSON())
 	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		gatewayErr := core.NewInvalidRequestErrorWithStatus(http.StatusGatewayTimeout, "request timed out", err).
+			WithCode("request_timeout")
+		logHandledAdminError(c, gatewayErr)
+		return c.JSON(gatewayErr.HTTPStatusCode(), gatewayErr.ToJSON())
+	}
 
 	fallback := &core.GatewayError{
 		Type:       "internal_error",

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -59,6 +59,9 @@ const (
 	DashboardConfigSemanticCacheEnabled = "SEMANTIC_CACHE_ENABLED"
 )
 
+// statusClientClosedRequest is the de facto status used by proxies for client-aborted requests.
+const statusClientClosedRequest = 499
+
 // DashboardConfigResponse is the allowlisted runtime config contract exposed to the dashboard UI.
 type DashboardConfigResponse struct {
 	FeatureFallbackMode  string `json:"FEATURE_FALLBACK_MODE,omitempty"`
@@ -381,6 +384,13 @@ func handleError(c *echo.Context, err error) error {
 		return c.JSON(gatewayErr.HTTPStatusCode(), gatewayErr.ToJSON())
 	}
 
+	if errors.Is(err, context.Canceled) {
+		gatewayErr := core.NewInvalidRequestErrorWithStatus(statusClientClosedRequest, "request canceled", err).
+			WithCode("request_canceled")
+		logHandledAdminError(c, gatewayErr)
+		return c.JSON(gatewayErr.HTTPStatusCode(), gatewayErr.ToJSON())
+	}
+
 	fallback := &core.GatewayError{
 		Type:       "internal_error",
 		Message:    "an unexpected error occurred",
@@ -424,7 +434,12 @@ func logHandledAdminError(c *echo.Context, gatewayErr *core.GatewayError) {
 		}
 	}
 
-	if gatewayErr.HTTPStatusCode() >= http.StatusInternalServerError {
+	status := gatewayErr.HTTPStatusCode()
+	if status == statusClientClosedRequest {
+		slog.Debug("admin request canceled", attrs...)
+		return
+	}
+	if status >= http.StatusInternalServerError {
 		slog.Error("admin request failed", attrs...)
 		return
 	}

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -1942,9 +1942,6 @@ func TestCacheOverview_ReturnsClientClosedWhenRequestIsCanceled(t *testing.T) {
 		CacheEnabled: "on",
 	}))
 	c, rec := newHandlerContext("/admin/api/v1/cache/overview?days=30")
-	ctx, cancel := context.WithCancel(c.Request().Context())
-	cancel()
-	c.SetRequest(c.Request().WithContext(ctx))
 
 	if err := h.CacheOverview(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1972,6 +1969,39 @@ func TestCacheOverview_ReturnsClientClosedWhenRequestIsCanceled(t *testing.T) {
 	}
 	if reader.lastCacheOverview.CacheMode != usage.CacheModeCached {
 		t.Fatalf("CacheMode = %q, want %q", reader.lastCacheOverview.CacheMode, usage.CacheModeCached)
+	}
+}
+
+func TestCacheOverview_ReturnsGatewayTimeoutWhenRequestDeadlineExceeded(t *testing.T) {
+	reader := &mockUsageReader{cacheErr: errors.Join(errors.New("failed to query cache overview summary"), context.DeadlineExceeded)}
+	h := NewHandler(reader, nil, WithDashboardRuntimeConfig(DashboardConfigResponse{
+		CacheEnabled: "on",
+	}))
+	c, rec := newHandlerContext("/admin/api/v1/cache/overview?days=30")
+
+	if err := h.CacheOverview(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Fatalf("expected %d, got %d", http.StatusGatewayTimeout, rec.Code)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	errorBody, ok := body["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected error payload, got %v", body)
+	}
+	if got, ok := errorBody["type"].(string); !ok || got != string(core.ErrorTypeInvalidRequest) {
+		t.Fatalf("error.type = %#v, want %q", errorBody["type"], core.ErrorTypeInvalidRequest)
+	}
+	if got, ok := errorBody["message"].(string); !ok || got != "request timed out" {
+		t.Fatalf("error.message = %#v, want request timed out", errorBody["message"])
+	}
+	if got, ok := errorBody["code"].(string); !ok || got != "request_timeout" {
+		t.Fatalf("error.code = %#v, want request_timeout", errorBody["code"])
 	}
 }
 

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -1936,6 +1936,45 @@ func TestCacheOverview_ReturnsErrorWhenReaderFails(t *testing.T) {
 	}
 }
 
+func TestCacheOverview_ReturnsClientClosedWhenRequestIsCanceled(t *testing.T) {
+	reader := &mockUsageReader{cacheErr: errors.Join(errors.New("failed to query cache overview summary"), context.Canceled)}
+	h := NewHandler(reader, nil, WithDashboardRuntimeConfig(DashboardConfigResponse{
+		CacheEnabled: "on",
+	}))
+	c, rec := newHandlerContext("/admin/api/v1/cache/overview?days=30")
+	ctx, cancel := context.WithCancel(c.Request().Context())
+	cancel()
+	c.SetRequest(c.Request().WithContext(ctx))
+
+	if err := h.CacheOverview(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != statusClientClosedRequest {
+		t.Fatalf("expected %d, got %d", statusClientClosedRequest, rec.Code)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	errorBody, ok := body["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected error payload, got %v", body)
+	}
+	if got, ok := errorBody["type"].(string); !ok || got != string(core.ErrorTypeInvalidRequest) {
+		t.Fatalf("error.type = %#v, want %q", errorBody["type"], core.ErrorTypeInvalidRequest)
+	}
+	if got, ok := errorBody["message"].(string); !ok || got != "request canceled" {
+		t.Fatalf("error.message = %#v, want request canceled", errorBody["message"])
+	}
+	if got, ok := errorBody["code"].(string); !ok || got != "request_canceled" {
+		t.Fatalf("error.code = %#v, want request_canceled", errorBody["code"])
+	}
+	if reader.lastCacheOverview.CacheMode != usage.CacheModeCached {
+		t.Fatalf("CacheMode = %q, want %q", reader.lastCacheOverview.CacheMode, usage.CacheModeCached)
+	}
+}
+
 // --- handleError tests ---
 
 func TestHandleError_GatewayErrors(t *testing.T) {
@@ -2010,6 +2049,32 @@ func TestHandleError_UnexpectedError(t *testing.T) {
 	}
 	if containsString(body, "something broke") {
 		t.Errorf("original error should be hidden, got: %s", body)
+	}
+}
+
+func TestHandleError_DoesNotLogCanceledRequestsAtDefaultLevel(t *testing.T) {
+	var buf bytes.Buffer
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() {
+		slog.SetDefault(original)
+	})
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/admin/api/v1/cache/overview", nil)
+	req = req.WithContext(core.WithRequestID(req.Context(), "admin-canceled-req-789"))
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := handleError(c, errors.Join(errors.New("failed to query cache overview summary"), context.Canceled)); err != nil {
+		t.Fatalf("handleError() error = %v", err)
+	}
+
+	if rec.Code != statusClientClosedRequest {
+		t.Fatalf("status = %d, want %d", rec.Code, statusClientClosedRequest)
+	}
+	if logOutput := buf.String(); logOutput != "" {
+		t.Fatalf("expected canceled request to be hidden at info level, got %q", logOutput)
 	}
 }
 


### PR DESCRIPTION
Summary:
- Map raw admin context cancellations to 499 request_canceled instead of 500 internal_error.
- Map raw admin deadline timeouts to 504 request_timeout instead of 500 internal_error.
- Log client-closed admin requests at debug level so normal stdout is not noisy.
- Add cache overview and logging coverage for canceled and timed-out admin requests.

Tests:
- go test ./internal/admin
- pre-commit hook: make test-race, make lint, go mod tidy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Canceled requests now return HTTP 499 with structured error details and reduced logging noise.
  * Request timeouts now return HTTP 504 with structured error details.

* **Tests**
  * Added tests covering canceled-request and timeout responses, and logging behavior for canceled requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->