### PR TITLE
ci(docker): use zstd compression for release images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ steps.build_meta.outputs.image }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ steps.build_meta.outputs.image }},push-by-digest=true,name-canonical=true,push=true,compression=zstd,compression-level=3,force-compression=true
           build-args: |
             VERSION=${{ steps.build_meta.outputs.version }}
             COMMIT=${{ steps.build_meta.outputs.commit }}


### PR DESCRIPTION
## Summary
- Enable zstd compression for release Docker image exports
- Use compression level 3 and force recompression for release layers

## Validation
- pre-commit checks from `git commit` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker image layer compression in the release workflow to improve build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->