### PR TITLE
fix(usage): price dated OpenRouter model IDs

### DIFF
--- a/internal/modeldata/merger.go
+++ b/internal/modeldata/merger.go
@@ -1,8 +1,16 @@
 package modeldata
 
 import (
+	"regexp"
+
 	"gomodel/internal/core"
 )
+
+var terminalReleaseDateSuffixPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`[-_.]\d{8}$`),
+	regexp.MustCompile(`[-_.]\d{4}-\d{2}-\d{2}$`),
+	regexp.MustCompile(`[-_.]\d{4}$`),
+}
 
 // Resolve performs the three-layer merge to produce ModelMetadata for a given
 // provider type and model ID. It looks up provider_models[providerType/modelID]
@@ -29,7 +37,35 @@ func resolveEntries(list *ModelList, providerType string, modelID string) (*Mode
 	if model, pm := resolveReverseProviderModelID(list, providerType, modelID); model != nil || pm != nil {
 		return model, pm
 	}
-	return resolveAlias(list, providerType, modelID)
+	if model, pm := resolveAlias(list, providerType, modelID); model != nil || pm != nil {
+		return model, pm
+	}
+	return resolveReleaseDateAlias(list, providerType, modelID)
+}
+
+func resolveReleaseDateAlias(list *ModelList, providerType string, modelID string) (*ModelEntry, *ProviderModelEntry) {
+	stableID, ok := stripTerminalReleaseDateSuffix(modelID)
+	if !ok {
+		return nil, nil
+	}
+	if model, pm := resolveDirect(list, providerType, stableID); model != nil || pm != nil {
+		return model, pm
+	}
+	if model, pm := resolveReverseProviderModelID(list, providerType, stableID); model != nil || pm != nil {
+		return model, pm
+	}
+	return resolveAlias(list, providerType, stableID)
+}
+
+func stripTerminalReleaseDateSuffix(modelID string) (string, bool) {
+	for _, pattern := range terminalReleaseDateSuffixPatterns {
+		loc := pattern.FindStringIndex(modelID)
+		if loc == nil || loc[0] == 0 {
+			continue
+		}
+		return modelID[:loc[0]], true
+	}
+	return "", false
 }
 
 func resolveDirect(list *ModelList, providerType string, modelID string) (*ModelEntry, *ProviderModelEntry) {

--- a/internal/modeldata/merger.go
+++ b/internal/modeldata/merger.go
@@ -6,6 +6,10 @@ import (
 	"gomodel/internal/core"
 )
 
+// terminalReleaseDateSuffixPatterns are intentionally broad because provider
+// response IDs use mixed release suffixes: YYYYMMDD, YYYY-MM-DD, and four-digit
+// tokens that may be either YYYY or MMDD. These are only used after exact,
+// reverse-provider-model, and explicit alias lookup all fail.
 var terminalReleaseDateSuffixPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`[-_.]\d{8}$`),
 	regexp.MustCompile(`[-_.]\d{4}-\d{2}-\d{2}$`),
@@ -58,6 +62,8 @@ func resolveReleaseDateAlias(list *ModelList, providerType string, modelID strin
 }
 
 func stripTerminalReleaseDateSuffix(modelID string) (string, bool) {
+	// Strip one terminal release segment only. Repeated stripping could turn
+	// legitimate model names with date-like components into unrelated base IDs.
 	for _, pattern := range terminalReleaseDateSuffixPatterns {
 		loc := pattern.FindStringIndex(modelID)
 		if loc == nil || loc[0] == 0 {

--- a/internal/modeldata/merger_test.go
+++ b/internal/modeldata/merger_test.go
@@ -456,18 +456,26 @@ func TestResolve_ReleaseDateSuffixFallback(t *testing.T) {
 	}
 	list.buildReverseIndex()
 
-	meta := Resolve(list, "openrouter", "z-ai/glm-5.1-20260406")
-	if meta == nil {
-		t.Fatal("expected metadata via release-date suffix fallback")
-	}
-	if meta.Pricing == nil || meta.Pricing.CachedInputPerMtok == nil {
-		t.Fatal("expected OpenRouter provider pricing via fallback")
-	}
-	if *meta.Pricing.InputPerMtok != 1.05 {
-		t.Errorf("InputPerMtok = %f, want 1.05", *meta.Pricing.InputPerMtok)
-	}
-	if *meta.Pricing.CachedInputPerMtok != 0.525 {
-		t.Errorf("CachedInputPerMtok = %f, want 0.525", *meta.Pricing.CachedInputPerMtok)
+	for _, modelID := range []string{
+		"z-ai/glm-5.1-20260406",
+		"z-ai/glm-5.1-2026-04-06",
+		"z-ai/glm-5.1-2026",
+	} {
+		t.Run(modelID, func(t *testing.T) {
+			meta := Resolve(list, "openrouter", modelID)
+			if meta == nil {
+				t.Fatal("expected metadata via release-date suffix fallback")
+			}
+			if meta.Pricing == nil || meta.Pricing.CachedInputPerMtok == nil {
+				t.Fatal("expected OpenRouter provider pricing via fallback")
+			}
+			if *meta.Pricing.InputPerMtok != 1.05 {
+				t.Errorf("InputPerMtok = %f, want 1.05", *meta.Pricing.InputPerMtok)
+			}
+			if *meta.Pricing.CachedInputPerMtok != 0.525 {
+				t.Errorf("CachedInputPerMtok = %f, want 0.525", *meta.Pricing.CachedInputPerMtok)
+			}
+		})
 	}
 }
 

--- a/internal/modeldata/merger_test.go
+++ b/internal/modeldata/merger_test.go
@@ -411,16 +411,102 @@ func TestResolve_ReverseIndexNotBuilt(t *testing.T) {
 		ProviderModels: map[string]ProviderModelEntry{
 			"openai/gpt-4o": {
 				ModelRef:      "gpt-4o",
-				CustomModelID: new("gpt-4o-2024-08-06"),
+				CustomModelID: new("gpt-4o-blue"),
 				Enabled:       true,
 			},
 		},
 		// providerModelByActualID is nil (buildReverseIndex not called)
 	}
 
-	meta := Resolve(list, "openai", "gpt-4o-2024-08-06")
+	meta := Resolve(list, "openai", "gpt-4o-blue")
 	if meta != nil {
 		t.Error("expected nil when reverse index is not built")
+	}
+}
+
+func TestResolve_ReleaseDateSuffixFallback(t *testing.T) {
+	list := &ModelList{
+		Models: map[string]ModelEntry{
+			"glm-5.1": {
+				DisplayName: "GLM 5.1",
+				Modes:       []string{"chat"},
+				Aliases: []string{
+					"z-ai/glm-5.1",
+					"openrouter/z-ai/glm-5.1",
+				},
+				Pricing: &core.ModelPricing{
+					Currency:      "USD",
+					InputPerMtok:  new(1.05),
+					OutputPerMtok: new(3.50),
+				},
+			},
+		},
+		ProviderModels: map[string]ProviderModelEntry{
+			"openrouter/glm-5.1": {
+				ModelRef: "glm-5.1",
+				Enabled:  true,
+				Pricing: &core.ModelPricing{
+					Currency:           "USD",
+					InputPerMtok:       new(1.05),
+					OutputPerMtok:      new(3.50),
+					CachedInputPerMtok: new(0.525),
+				},
+			},
+		},
+	}
+	list.buildReverseIndex()
+
+	meta := Resolve(list, "openrouter", "z-ai/glm-5.1-20260406")
+	if meta == nil {
+		t.Fatal("expected metadata via release-date suffix fallback")
+	}
+	if meta.Pricing == nil || meta.Pricing.CachedInputPerMtok == nil {
+		t.Fatal("expected OpenRouter provider pricing via fallback")
+	}
+	if *meta.Pricing.InputPerMtok != 1.05 {
+		t.Errorf("InputPerMtok = %f, want 1.05", *meta.Pricing.InputPerMtok)
+	}
+	if *meta.Pricing.CachedInputPerMtok != 0.525 {
+		t.Errorf("CachedInputPerMtok = %f, want 0.525", *meta.Pricing.CachedInputPerMtok)
+	}
+}
+
+func TestResolve_ReleaseDateSuffixFallbackExactMatchWins(t *testing.T) {
+	list := &ModelList{
+		Models: map[string]ModelEntry{
+			"glm-5.1": {
+				DisplayName: "GLM 5.1",
+				Modes:       []string{"chat"},
+			},
+		},
+		ProviderModels: map[string]ProviderModelEntry{
+			"openrouter/z-ai/glm-5.1-20260406": {
+				ModelRef: "glm-5.1",
+				Enabled:  true,
+				Pricing: &core.ModelPricing{
+					Currency:      "USD",
+					InputPerMtok:  new(2.00),
+					OutputPerMtok: new(4.00),
+				},
+			},
+			"openrouter/glm-5.1": {
+				ModelRef: "glm-5.1",
+				Enabled:  true,
+				Pricing: &core.ModelPricing{
+					Currency:      "USD",
+					InputPerMtok:  new(1.05),
+					OutputPerMtok: new(3.50),
+				},
+			},
+		},
+	}
+
+	meta := Resolve(list, "openrouter", "z-ai/glm-5.1-20260406")
+	if meta == nil || meta.Pricing == nil || meta.Pricing.InputPerMtok == nil {
+		t.Fatal("expected exact provider-model pricing")
+	}
+	if *meta.Pricing.InputPerMtok != 2.00 {
+		t.Errorf("InputPerMtok = %f, want exact dated provider price 2.00", *meta.Pricing.InputPerMtok)
 	}
 }
 

--- a/internal/usage/cost.go
+++ b/internal/usage/cost.go
@@ -41,16 +41,19 @@ type tokenCostMapping struct {
 	includedInBase bool
 }
 
+var openAICompatibleTokenCostMappings = []tokenCostMapping{
+	{rawDataKey: "cached_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, side: sideInput, unit: unitPerMtok, includedInBase: true},
+	{rawDataKey: "prompt_cached_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, side: sideInput, unit: unitPerMtok, includedInBase: true},
+	{rawDataKey: "reasoning_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, side: sideOutput, unit: unitPerMtok, includedInBase: true},
+	{rawDataKey: "completion_reasoning_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, side: sideOutput, unit: unitPerMtok, includedInBase: true},
+	{rawDataKey: "prompt_audio_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.AudioInputPerMtok }, side: sideInput, unit: unitPerMtok, includedInBase: true},
+	{rawDataKey: "completion_audio_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.AudioOutputPerMtok }, side: sideOutput, unit: unitPerMtok, includedInBase: true},
+}
+
 // providerMappings defines the per-provider RawData key to pricing field mappings.
 var providerMappings = map[string][]tokenCostMapping{
-	"openai": {
-		{rawDataKey: "cached_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, side: sideInput, unit: unitPerMtok, includedInBase: true},
-		{rawDataKey: "prompt_cached_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, side: sideInput, unit: unitPerMtok, includedInBase: true},
-		{rawDataKey: "reasoning_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, side: sideOutput, unit: unitPerMtok, includedInBase: true},
-		{rawDataKey: "completion_reasoning_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, side: sideOutput, unit: unitPerMtok, includedInBase: true},
-		{rawDataKey: "prompt_audio_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.AudioInputPerMtok }, side: sideInput, unit: unitPerMtok, includedInBase: true},
-		{rawDataKey: "completion_audio_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.AudioOutputPerMtok }, side: sideOutput, unit: unitPerMtok, includedInBase: true},
-	},
+	"openai":     openAICompatibleTokenCostMappings,
+	"openrouter": openAICompatibleTokenCostMappings,
 	"anthropic": {
 		{rawDataKey: "cache_read_input_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, side: sideInput, unit: unitPerMtok},
 		{rawDataKey: "cache_creation_input_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.CacheWritePerMtok }, side: sideInput, unit: unitPerMtok},

--- a/internal/usage/cost_test.go
+++ b/internal/usage/cost_test.go
@@ -352,6 +352,27 @@ func TestCalculateGranularCost_Groq_PromptCachedTokensAndReasoningBreakdown(t *t
 	}
 }
 
+func TestCalculateGranularCost_OpenRouter_PromptCachedTokensAndReasoningBreakdown(t *testing.T) {
+	pricing := &core.ModelPricing{
+		InputPerMtok:       new(1.05),
+		OutputPerMtok:      new(3.50),
+		CachedInputPerMtok: new(0.525),
+		// ReasoningOutputPerMtok intentionally nil: base output rate covers the model.
+	}
+	rawData := map[string]any{
+		"prompt_cached_tokens":        136_128,
+		"completion_reasoning_tokens": 59,
+	}
+	result := CalculateGranularCost(161_490, 3_001, rawData, "openrouter", pricing)
+
+	assertCostNear(t, "InputCost", result.InputCost, 0.0980973)
+	assertCostNear(t, "OutputCost", result.OutputCost, 0.0105035)
+	assertCostNear(t, "TotalCost", result.TotalCost, 0.1086008)
+	if result.Caveat != "" {
+		t.Fatalf("expected no caveat for openrouter token details, got %q", result.Caveat)
+	}
+}
+
 func TestCalculateGranularCost_InformationalFieldsNoCaveat(t *testing.T) {
 	pricing := &core.ModelPricing{
 		InputPerMtok:  new(2.50),


### PR DESCRIPTION
## Summary
- resolve pricing for response model IDs with terminal release-date suffixes after exact/reverse/alias lookup fails
- add OpenRouter to OpenAI-compatible token-detail cost handling so cached input discounts are applied
- cover GLM 5.1 dated OpenRouter response IDs with regression tests

Related model-list update: https://github.com/ENTERPILOT/ai-model-list/pull/98

## Validation
- go test ./...
- commit hooks: make test-race, hot-path performance guard, make lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenRouter as a supported provider in cost calculations.
  * Improved model resolution to recognize and strip terminal release-date suffixes (multiple formats) and apply alias fallback while preserving resolution precedence.

* **Tests**
  * Added tests covering release-date suffix resolution (including precedence and reverse-index absent cases) and OpenRouter cost calculations for cached and reasoning token scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->