### PR TITLE
feat(admin): recalculate usage pricing

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -215,6 +215,10 @@
 # When enabled, token usage is tracked separately from audit logs
 # USAGE_ENABLED=true
 
+# Enable/disable the admin usage pricing recalculation action (default: true)
+# Requires USAGE_ENABLED=true and supported storage; false always hides/blocks it
+# USAGE_PRICING_RECALCULATION_ENABLED=true
+
 # Enforce returning usage data in streaming responses (default: true)
 # When true, stream_options: {"include_usage": true} is automatically added
 # to streaming requests for OpenAI-compatible providers

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -83,6 +83,7 @@ logging:
 
 usage:
   enabled: true
+  pricing_recalculation_enabled: true
   enforce_returning_usage_data: true
   buffer_size: 1000
   flush_interval: 5

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -82,6 +82,9 @@ logging:
   only_model_interactions: true
 
 usage:
+  # Usage actions require USAGE_ENABLED=true (or usage.enabled: true) and a supported
+  # storage backend; pricing recalculation appears only when both usage tracking and
+  # pricing_recalculation_enabled are enabled.
   enabled: true
   pricing_recalculation_enabled: true
   enforce_returning_usage_data: true

--- a/config/config.go
+++ b/config/config.go
@@ -365,6 +365,11 @@ type UsageConfig struct {
 	// Default: true
 	EnforceReturningUsageData bool `yaml:"enforce_returning_usage_data" env:"ENFORCE_RETURNING_USAGE_DATA"`
 
+	// PricingRecalculationEnabled controls whether the admin pricing recalculation action is available.
+	// Storage and pricing metadata support are still required; false always disables the feature.
+	// Default: true
+	PricingRecalculationEnabled bool `yaml:"pricing_recalculation_enabled" env:"USAGE_PRICING_RECALCULATION_ENABLED"`
+
 	// BufferSize is the number of usage entries to buffer before flushing
 	// Default: 1000
 	BufferSize int `yaml:"buffer_size" env:"USAGE_BUFFER_SIZE"`
@@ -1036,11 +1041,12 @@ func buildDefaultConfig() *Config {
 			OnlyModelInteractions: true,
 		},
 		Usage: UsageConfig{
-			Enabled:                   true,
-			EnforceReturningUsageData: true,
-			BufferSize:                1000,
-			FlushInterval:             5,
-			RetentionDays:             90,
+			Enabled:                     true,
+			EnforceReturningUsageData:   true,
+			PricingRecalculationEnabled: true,
+			BufferSize:                  1000,
+			FlushInterval:               5,
+			RetentionDays:               90,
 		},
 		Budgets: BudgetsConfig{
 			Enabled: true,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -55,6 +55,7 @@ func clearAllConfigEnvVars(t *testing.T) {
 		"LOGGING_ONLY_MODEL_INTERACTIONS", "LOGGING_BUFFER_SIZE",
 		"LOGGING_FLUSH_INTERVAL", "LOGGING_RETENTION_DAYS",
 		"USAGE_ENABLED", "ENFORCE_RETURNING_USAGE_DATA",
+		"USAGE_PRICING_RECALCULATION_ENABLED",
 		"USAGE_BUFFER_SIZE", "USAGE_FLUSH_INTERVAL", "USAGE_RETENTION_DAYS",
 		"BUDGETS_ENABLED",
 		"GUARDRAILS_ENABLED", "ENABLE_GUARDRAILS_FOR_BATCH_PROCESSING",
@@ -162,6 +163,9 @@ func TestBuildDefaultConfig(t *testing.T) {
 	}
 	if !cfg.Usage.EnforceReturningUsageData {
 		t.Error("expected Usage.EnforceReturningUsageData=true")
+	}
+	if !cfg.Usage.PricingRecalculationEnabled {
+		t.Error("expected Usage.PricingRecalculationEnabled=true")
 	}
 	if cfg.Usage.BufferSize != 1000 {
 		t.Errorf("expected Usage.BufferSize=1000, got %d", cfg.Usage.BufferSize)
@@ -420,6 +424,28 @@ func TestLoadBudgetsEnabledDisablesBudgetsWhenUsageTrackingDisabledWithoutSeedBu
 		}
 		if result.Config.Budgets.Enabled {
 			t.Fatal("expected budgets to be disabled when usage tracking is disabled")
+		}
+	})
+}
+
+func TestLoadUsagePricingRecalculationFromYAML(t *testing.T) {
+	clearAllConfigEnvVars(t)
+
+	withTempDir(t, func(dir string) {
+		yaml := `
+usage:
+  pricing_recalculation_enabled: false
+`
+		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(yaml), 0644); err != nil {
+			t.Fatalf("Failed to write config.yaml: %v", err)
+		}
+
+		result, err := Load()
+		if err != nil {
+			t.Fatalf("Load() failed: %v", err)
+		}
+		if result.Config.Usage.PricingRecalculationEnabled {
+			t.Fatal("expected usage pricing recalculation to be disabled from YAML")
 		}
 	})
 }
@@ -1122,6 +1148,7 @@ func TestLoad_EnvOverridesDefaults(t *testing.T) {
 		t.Setenv("MODELS_ENABLED_BY_DEFAULT", "false")
 		t.Setenv("KEEP_ONLY_ALIASES_AT_MODELS_ENDPOINT", "true")
 		t.Setenv("CONFIGURED_PROVIDER_MODELS_MODE", "allowlist")
+		t.Setenv("USAGE_PRICING_RECALCULATION_ENABLED", "false")
 		t.Setenv("STORAGE_TYPE", "postgresql")
 		t.Setenv("POSTGRES_URL", "postgres://localhost/test")
 		t.Setenv("POSTGRES_MAX_CONNS", "20")
@@ -1146,6 +1173,9 @@ func TestLoad_EnvOverridesDefaults(t *testing.T) {
 		}
 		if cfg.Models.ConfiguredProviderModelsMode != ConfiguredProviderModelsModeAllowlist {
 			t.Errorf("expected configured provider models mode allowlist from env, got %q", cfg.Models.ConfiguredProviderModelsMode)
+		}
+		if cfg.Usage.PricingRecalculationEnabled {
+			t.Error("expected usage pricing recalculation to be disabled from env")
 		}
 		if cfg.Storage.Type != "postgresql" {
 			t.Errorf("expected storage type postgresql, got %s", cfg.Storage.Type)

--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -108,6 +108,7 @@ Storage is shared by audit logging, usage tracking, and future features like IAM
 | Variable                       | Description                                    | Default |
 | ------------------------------ | ---------------------------------------------- | ------- |
 | `USAGE_ENABLED`                | Enable token usage tracking                    | `true`  |
+| `USAGE_PRICING_RECALCULATION_ENABLED` | Enable the admin usage pricing recalculation action when supported | `true` |
 | `ENFORCE_RETURNING_USAGE_DATA` | Auto-add `include_usage` to streaming requests | `true`  |
 | `USAGE_BUFFER_SIZE`            | In-memory buffer before flush                  | `1000`  |
 | `USAGE_FLUSH_INTERVAL`         | Flush interval in seconds                      | `5`     |

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -3852,9 +3852,21 @@ body.conversation-drawer-open {
 
 .pricing-recalculate-grid {
   display: grid;
-  grid-template-columns: minmax(220px, 320px) minmax(220px, 1fr) minmax(260px, 1fr);
+  grid-template-columns: minmax(220px, 320px) minmax(260px, 360px);
   align-items: end;
+  justify-content: start;
   gap: 12px;
+  width: 100%;
+}
+
+.pricing-recalculate-date-field {
+  grid-column: 1 / -1;
+  max-width: 320px;
+  width: 100%;
+}
+
+.pricing-recalculate-filter-field {
+  max-width: 360px;
   width: 100%;
 }
 

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -3846,6 +3846,37 @@ body.conversation-drawer-open {
   max-width: 460px;
 }
 
+.pricing-recalculate-section {
+  width: 100%;
+}
+
+.pricing-recalculate-grid {
+  display: grid;
+  grid-template-columns: minmax(220px, 320px) minmax(220px, 1fr) minmax(260px, 1fr);
+  align-items: end;
+  gap: 12px;
+  width: 100%;
+}
+
+.pricing-recalculate-date-field .date-picker,
+.pricing-recalculate-date-field .date-picker-trigger {
+  width: 100%;
+}
+
+.pricing-recalculate-date-field .date-picker-trigger {
+  justify-content: space-between;
+}
+
+.pricing-recalculate-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.pricing-recalculate-dialog {
+  max-width: 480px;
+}
+
 .budget-override-dialog-backdrop {
   z-index: 100;
 }
@@ -4328,6 +4359,15 @@ body.conversation-drawer-open {
     width: 100%;
   }
   .budget-settings-actions .pagination-btn {
+    width: 100%;
+  }
+  .pricing-recalculate-grid {
+    grid-template-columns: 1fr;
+  }
+  .pricing-recalculate-actions {
+    width: 100%;
+  }
+  .pricing-recalculate-actions .pagination-btn {
     width: 100%;
   }
 

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -3867,11 +3867,13 @@ body.conversation-drawer-open {
   justify-content: space-between;
 }
 
-.pricing-recalculate-date-field .date-picker-dropdown {
-  top: auto;
-  bottom: calc(100% + 6px);
-  right: auto;
-  left: 0;
+@media (min-width: 769px) {
+  .pricing-recalculate-date-field .date-picker-dropdown {
+    top: auto;
+    bottom: calc(100% + 6px);
+    right: auto;
+    left: 0;
+  }
 }
 
 .pricing-recalculate-actions {

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -3867,6 +3867,13 @@ body.conversation-drawer-open {
   justify-content: space-between;
 }
 
+.pricing-recalculate-date-field .date-picker-dropdown {
+  top: auto;
+  bottom: calc(100% + 6px);
+  right: auto;
+  left: 0;
+}
+
 .pricing-recalculate-actions {
   display: flex;
   flex-wrap: wrap;

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -70,6 +70,22 @@ function dashboard() {
     needsAuth: false,
     apiKey: "",
     authDialogOpen: false,
+    typedConfirmationDialog: {
+      open: false,
+      title: "",
+      titleId: "typedConfirmationDialogTitle",
+      inputId: "typed-confirmation-input",
+      message: "",
+      requiredText: "",
+      value: "",
+      confirmLabel: "Confirm",
+      icon: "alert-triangle",
+      dialogClass: "",
+      loadingKey: "",
+      errorKey: "",
+      onConfirm: null,
+      onClose: null,
+    },
     authRequestGeneration: 0,
     theme: "system",
     sidebarCollapsed: false,
@@ -391,8 +407,96 @@ function dashboard() {
         (this.page === "guardrails" && this.guardrailFormOpen) ||
         (this.page === "auth-keys" && this.authKeyFormOpen) ||
         (this.page === "budgets" && this.budgetFormOpen) ||
-        this.budgetResetDialogOpen
+        this.budgetResetDialogOpen ||
+        this.pricingRecalculateDialogOpen ||
+        (this.typedConfirmationDialog && this.typedConfirmationDialog.open)
       );
+    },
+
+    openTypedConfirmationDialog(options) {
+      const next = {
+        open: true,
+        title: "",
+        titleId: "typedConfirmationDialogTitle",
+        inputId: "typed-confirmation-input",
+        message: "",
+        requiredText: "",
+        value: "",
+        confirmLabel: "Confirm",
+        icon: "alert-triangle",
+        dialogClass: "",
+        loadingKey: "",
+        errorKey: "",
+        onConfirm: null,
+        onClose: null,
+        ...(options || {}),
+      };
+      this.typedConfirmationDialog = next;
+      setTimeout(() => {
+        const input = document.getElementById(next.inputId);
+        if (input && typeof input.focus === "function") {
+          input.focus();
+        }
+        if (typeof this.renderIconsAfterUpdate === "function") {
+          this.renderIconsAfterUpdate();
+        }
+      }, 0);
+    },
+
+    closeTypedConfirmationDialog() {
+      const current = this.typedConfirmationDialog || {};
+      if (typeof current.onClose === "function") {
+        current.onClose.call(this);
+      }
+      this.typedConfirmationDialog = {
+        open: false,
+        title: "",
+        titleId: "typedConfirmationDialogTitle",
+        inputId: "typed-confirmation-input",
+        message: "",
+        requiredText: "",
+        value: "",
+        confirmLabel: "Confirm",
+        icon: "alert-triangle",
+        dialogClass: "",
+        loadingKey: "",
+        errorKey: "",
+        onConfirm: null,
+        onClose: null,
+      };
+    },
+
+    typedConfirmationReady() {
+      const dialog = this.typedConfirmationDialog || {};
+      return (
+        String(dialog.value || "").trim().toLowerCase() ===
+        String(dialog.requiredText || "").trim().toLowerCase()
+      );
+    },
+
+    typedConfirmationLoading() {
+      const dialog = this.typedConfirmationDialog || {};
+      const key = String(dialog.loadingKey || "").trim();
+      return key ? !!this[key] : false;
+    },
+
+    typedConfirmationInputLabel() {
+      const dialog = this.typedConfirmationDialog || {};
+      return "Type " + String(dialog.requiredText || "").trim() + " to confirm";
+    },
+
+    async submitTypedConfirmationDialog() {
+      const dialog = this.typedConfirmationDialog || {};
+      if (!this.typedConfirmationReady()) {
+        const errorKey = String(dialog.errorKey || "").trim();
+        if (errorKey) {
+          this[errorKey] = this.typedConfirmationInputLabel() + ".";
+        }
+        return;
+      }
+      if (typeof dialog.onConfirm === "function") {
+        await dialog.onConfirm.call(this);
+      }
     },
 
     submitApiKey() {
@@ -969,6 +1073,12 @@ function dashboard() {
         ? dashboardBudgetsModule
         : null,
       "dashboardBudgetsModule",
+    ),
+    resolveModuleFactory(
+      typeof dashboardPricingModule === "function"
+        ? dashboardPricingModule
+        : null,
+      "dashboardPricingModule",
     ),
     resolveModuleFactory(
       typeof dashboardWorkflowsModule === "function"

--- a/internal/admin/dashboard/static/js/modules/budgets.js
+++ b/internal/admin/dashboard/static/js/modules/budgets.js
@@ -826,15 +826,45 @@
                 this.budgetResetConfirmation = '';
                 this.budgetSettingsError = '';
                 this.budgetResetDialogOpen = true;
-                setTimeout(() => {
-                    const input = document.getElementById('budget-reset-confirmation');
-                    if (input && typeof input.focus === 'function') {
-                        input.focus();
-                    }
-                }, 0);
+                if (typeof this.openTypedConfirmationDialog === 'function') {
+                    this.openTypedConfirmationDialog({
+                        title: 'Reset Budgets',
+                        titleId: 'budgetResetDialogTitle',
+                        inputId: 'budget-reset-confirmation',
+                        requiredText: 'reset',
+                        confirmLabel: 'Reset All Budgets',
+                        icon: 'rotate-ccw',
+                        dialogClass: 'budget-reset-dialog',
+                        loadingKey: 'budgetResetLoading',
+                        errorKey: 'budgetSettingsError',
+                        onConfirm: () => this.resetBudgets(),
+                        onClose: () => {
+                            this.budgetResetDialogOpen = false;
+                            this.budgetResetConfirmation = '';
+                        }
+                    });
+                } else {
+                    setTimeout(() => {
+                        const input = document.getElementById('budget-reset-confirmation');
+                        if (input && typeof input.focus === 'function') {
+                            input.focus();
+                        }
+                    }, 0);
+                }
+            },
+
+            budgetResetConfirmationValue() {
+                if (this.typedConfirmationDialog && this.typedConfirmationDialog.open) {
+                    return this.typedConfirmationDialog.value;
+                }
+                return this.budgetResetConfirmation;
             },
 
             closeBudgetResetDialog() {
+                if (this.typedConfirmationDialog && this.typedConfirmationDialog.open && typeof this.closeTypedConfirmationDialog === 'function') {
+                    this.closeTypedConfirmationDialog();
+                    return;
+                }
                 this.budgetResetDialogOpen = false;
                 this.budgetResetConfirmation = '';
             },
@@ -843,7 +873,9 @@
                 if (this.budgetResetLoading) {
                     return;
                 }
-                if (String(this.budgetResetConfirmation || '').trim().toLowerCase() !== 'reset') {
+                const confirmation = this.budgetResetConfirmationValue();
+                this.budgetResetConfirmation = confirmation;
+                if (String(confirmation || '').trim().toLowerCase() !== 'reset') {
                     this.budgetSettingsError = 'Type reset to confirm.';
                     return;
                 }

--- a/internal/admin/dashboard/static/js/modules/pricing.js
+++ b/internal/admin/dashboard/static/js/modules/pricing.js
@@ -8,6 +8,12 @@
             pricingRecalculateLoading: false,
             pricingRecalculateDialogOpen: false,
 
+            pricingRecalculationEnabled() {
+                return typeof this.workflowRuntimeBooleanFlag === 'function'
+                    ? this.workflowRuntimeBooleanFlag('USAGE_PRICING_RECALCULATION_ENABLED', false)
+                    : false;
+            },
+
             pricingRecalculateDatePayload() {
                 if (this.selectedPreset) {
                     return { days: parseInt(this.selectedPreset, 10) || 30 };
@@ -31,6 +37,10 @@
             },
 
             openPricingRecalculateDialog() {
+                if (!this.pricingRecalculationEnabled()) {
+                    this.pricingRecalculateError = 'Usage pricing recalculation is unavailable.';
+                    return;
+                }
                 if (this.pricingRecalculateLoading) {
                     return;
                 }
@@ -72,6 +82,10 @@
             },
 
             async recalculatePricing() {
+                if (!this.pricingRecalculationEnabled()) {
+                    this.pricingRecalculateError = 'Usage pricing recalculation is unavailable.';
+                    return;
+                }
                 if (this.pricingRecalculateLoading) {
                     return;
                 }

--- a/internal/admin/dashboard/static/js/modules/pricing.js
+++ b/internal/admin/dashboard/static/js/modules/pricing.js
@@ -1,0 +1,144 @@
+(function(global) {
+    function dashboardPricingModule() {
+        return {
+            pricingRecalculateUserPath: '',
+            pricingRecalculateSelector: '',
+            pricingRecalculateNotice: '',
+            pricingRecalculateError: '',
+            pricingRecalculateLoading: false,
+            pricingRecalculateDialogOpen: false,
+
+            pricingRecalculateDatePayload() {
+                if (this.selectedPreset) {
+                    return { days: parseInt(this.selectedPreset, 10) || 30 };
+                }
+                const start = this.customStartDate ? this._formatDate(this.customStartDate) : '';
+                const endDate = this.customEndDate || (typeof this.todayDate === 'function' ? this.todayDate() : null);
+                const end = endDate ? this._formatDate(endDate) : '';
+                return {
+                    start_date: start,
+                    end_date: end
+                };
+            },
+
+            pricingRecalculatePayload(confirmation) {
+                return {
+                    ...this.pricingRecalculateDatePayload(),
+                    user_path: String(this.pricingRecalculateUserPath || '').trim(),
+                    selector: String(this.pricingRecalculateSelector || '').trim(),
+                    confirmation
+                };
+            },
+
+            openPricingRecalculateDialog() {
+                if (this.pricingRecalculateLoading) {
+                    return;
+                }
+                this.pricingRecalculateError = '';
+                this.pricingRecalculateDialogOpen = true;
+                if (typeof this.openTypedConfirmationDialog === 'function') {
+                    this.openTypedConfirmationDialog({
+                        title: 'Recalculate Pricing',
+                        titleId: 'pricingRecalculateDialogTitle',
+                        inputId: 'pricing-recalculate-confirmation',
+                        requiredText: 'recalculate',
+                        confirmLabel: 'Recalculate Pricing',
+                        icon: 'calculator',
+                        dialogClass: 'pricing-recalculate-dialog',
+                        loadingKey: 'pricingRecalculateLoading',
+                        errorKey: 'pricingRecalculateError',
+                        message: 'Stored usage cost fields matching the selected filters will be overwritten.',
+                        onConfirm: () => this.recalculatePricing(),
+                        onClose: () => {
+                            this.pricingRecalculateDialogOpen = false;
+                        }
+                    });
+                }
+            },
+
+            closePricingRecalculateDialog() {
+                if (this.typedConfirmationDialog && this.typedConfirmationDialog.open && typeof this.closeTypedConfirmationDialog === 'function') {
+                    this.closeTypedConfirmationDialog();
+                    return;
+                }
+                this.pricingRecalculateDialogOpen = false;
+            },
+
+            pricingRecalculateConfirmationValue() {
+                if (this.typedConfirmationDialog && this.typedConfirmationDialog.open) {
+                    return this.typedConfirmationDialog.value;
+                }
+                return '';
+            },
+
+            async recalculatePricing() {
+                if (this.pricingRecalculateLoading) {
+                    return;
+                }
+                const confirmation = this.pricingRecalculateConfirmationValue();
+                if (String(confirmation || '').trim().toLowerCase() !== 'recalculate') {
+                    this.pricingRecalculateError = 'Type recalculate to confirm.';
+                    return;
+                }
+
+                this.pricingRecalculateLoading = true;
+                this.pricingRecalculateNotice = '';
+                this.pricingRecalculateError = '';
+                try {
+                    const request = this.requestOptions({
+                        method: 'POST',
+                        body: JSON.stringify(this.pricingRecalculatePayload('recalculate'))
+                    });
+                    const res = await fetch('/admin/api/v1/usage/recalculate-pricing', request);
+                    const handled = this.handleFetchResponse(res, 'pricing recalculation', request);
+                    if (typeof this.isStaleAuthFetchResult === 'function' && this.isStaleAuthFetchResult(handled)) {
+                        return;
+                    }
+                    if (!handled) {
+                        this.pricingRecalculateError = 'Unable to recalculate pricing.';
+                        return;
+                    }
+
+                    const result = await res.json();
+                    this.closePricingRecalculateDialog();
+                    this.pricingRecalculateNotice = this.pricingRecalculateSummary(result);
+                    await this.refreshAfterPricingRecalculate();
+                } catch (e) {
+                    console.error('Failed to recalculate pricing:', e);
+                    this.pricingRecalculateError = 'Unable to recalculate pricing.';
+                } finally {
+                    this.pricingRecalculateLoading = false;
+                }
+            },
+
+            pricingRecalculateSummary(result) {
+                const matched = Number(result && result.matched || 0);
+                const recalculated = Number(result && result.recalculated || 0);
+                const withoutPricing = Number(result && result.without_pricing || 0);
+                let message = 'Pricing recalculated for ' + recalculated + ' of ' + matched + ' usage record' + (matched === 1 ? '' : 's') + '.';
+                if (withoutPricing > 0) {
+                    message += ' ' + withoutPricing + ' usage record' + (withoutPricing === 1 ? ' still lacks' : 's still lack') + ' pricing metadata.';
+                }
+                return message;
+            },
+
+            async refreshAfterPricingRecalculate() {
+                const requests = [];
+                if (typeof this.fetchUsage === 'function') {
+                    requests.push(this.fetchUsage());
+                }
+                if (this.page === 'usage' && typeof this.fetchUsagePage === 'function') {
+                    requests.push(this.fetchUsagePage());
+                }
+                if (this.page === 'budgets' && typeof this.fetchBudgets === 'function') {
+                    requests.push(this.fetchBudgets());
+                }
+                if (requests.length > 0) {
+                    await Promise.all(requests);
+                }
+            }
+        };
+    }
+
+    global.dashboardPricingModule = dashboardPricingModule;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/internal/admin/dashboard/static/js/modules/pricing.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/pricing.test.cjs
@@ -1,0 +1,96 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function loadPricingModuleFactory(overrides = {}) {
+    const source = fs.readFileSync(path.join(__dirname, 'pricing.js'), 'utf8');
+    const window = {
+        ...(overrides.window || {})
+    };
+    const context = {
+        console,
+        setTimeout,
+        clearTimeout,
+        ...overrides,
+        window
+    };
+    vm.createContext(context);
+    vm.runInContext(source, context);
+    return context.window.dashboardPricingModule;
+}
+
+function createPricingModule(overrides) {
+    const factory = loadPricingModuleFactory(overrides);
+    return factory();
+}
+
+test('pricingRecalculatePayload uses preset days and filter fields', () => {
+    const module = createPricingModule();
+    module.selectedPreset = '14';
+    module.pricingRecalculateUserPath = ' /team/alpha ';
+    module.pricingRecalculateSelector = ' openai/gpt-4o ';
+
+    assert.equal(JSON.stringify(module.pricingRecalculatePayload('recalculate')), JSON.stringify({
+        days: 14,
+        user_path: '/team/alpha',
+        selector: 'openai/gpt-4o',
+        confirmation: 'recalculate'
+    }));
+});
+
+test('pricingRecalculatePayload uses custom date range', () => {
+    const module = createPricingModule();
+    module.selectedPreset = null;
+    module.customStartDate = new Date(Date.UTC(2026, 3, 1));
+    module.customEndDate = new Date(Date.UTC(2026, 3, 2));
+    module._formatDate = (date) => date.toISOString().slice(0, 10);
+
+    const payload = module.pricingRecalculatePayload('recalculate');
+
+    assert.equal(payload.start_date, '2026-04-01');
+    assert.equal(payload.end_date, '2026-04-02');
+});
+
+test('recalculatePricing posts after typed confirmation', async () => {
+    const requests = [];
+    const module = createPricingModule({
+        fetch(url, request) {
+            requests.push({ url, request });
+            return Promise.resolve({
+                ok: true,
+                status: 200,
+                json: async () => ({
+                    matched: 3,
+                    recalculated: 3,
+                    with_pricing: 2,
+                    without_pricing: 1
+                })
+            });
+        }
+    });
+
+    module.selectedPreset = '30';
+    module.typedConfirmationDialog = { open: true, value: 'recalculate' };
+    module.requestOptions = (options) => options || {};
+    module.handleFetchResponse = () => true;
+    module.closePricingRecalculateDialog = () => {
+        module.pricingRecalculateDialogOpen = false;
+    };
+    module.refreshAfterPricingRecalculate = async () => {};
+
+    await module.recalculatePricing();
+
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0].url, '/admin/api/v1/usage/recalculate-pricing');
+    assert.equal(requests[0].request.method, 'POST');
+    assert.equal(requests[0].request.body, JSON.stringify({
+        days: 30,
+        user_path: '',
+        selector: '',
+        confirmation: 'recalculate'
+    }));
+    assert.match(module.pricingRecalculateNotice, /Pricing recalculated for 3 of 3 usage records\./);
+    assert.match(module.pricingRecalculateNotice, /1 usage record still lacks pricing metadata\./);
+});

--- a/internal/admin/dashboard/static/js/modules/pricing.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/pricing.test.cjs
@@ -73,6 +73,7 @@ test('recalculatePricing posts after typed confirmation', async () => {
 
     module.selectedPreset = '30';
     module.typedConfirmationDialog = { open: true, value: 'recalculate' };
+    module.workflowRuntimeBooleanFlag = () => true;
     module.requestOptions = (options) => options || {};
     module.handleFetchResponse = () => true;
     module.closePricingRecalculateDialog = () => {
@@ -93,4 +94,22 @@ test('recalculatePricing posts after typed confirmation', async () => {
     }));
     assert.match(module.pricingRecalculateNotice, /Pricing recalculated for 3 of 3 usage records\./);
     assert.match(module.pricingRecalculateNotice, /1 usage record still lacks pricing metadata\./);
+});
+
+test('recalculatePricing does not post when feature flag is disabled', async () => {
+    let calls = 0;
+    const module = createPricingModule({
+        fetch() {
+            calls++;
+            return Promise.resolve({ ok: true });
+        }
+    });
+
+    module.workflowRuntimeBooleanFlag = () => false;
+    module.typedConfirmationDialog = { open: true, value: 'recalculate' };
+
+    await module.recalculatePricing();
+
+    assert.equal(calls, 0);
+    assert.equal(module.pricingRecalculateError, 'Usage pricing recalculation is unavailable.');
 });

--- a/internal/admin/dashboard/static/js/modules/workflows.js
+++ b/internal/admin/dashboard/static/js/modules/workflows.js
@@ -88,7 +88,8 @@
 	                    'GUARDRAILS_ENABLED',
 	                    'CACHE_ENABLED',
 	                    'REDIS_URL',
-	                    'SEMANTIC_CACHE_ENABLED'
+	                    'SEMANTIC_CACHE_ENABLED',
+	                    'USAGE_PRICING_RECALCULATION_ENABLED'
 	                ];
 	            },
 

--- a/internal/admin/dashboard/static/js/modules/workflows.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/workflows.test.cjs
@@ -1206,6 +1206,7 @@ test('fetchWorkflowRuntimeConfig loads FEATURE_FALLBACK_MODE from the admin conf
                     GUARDRAILS_ENABLED: 'on',
                     REDIS_URL: 'on',
                     SEMANTIC_CACHE_ENABLED: 'off',
+                    USAGE_PRICING_RECALCULATION_ENABLED: 'on',
                     UNRELATED_FLAG: 'ignored'
                 })
             });
@@ -1225,7 +1226,8 @@ test('fetchWorkflowRuntimeConfig loads FEATURE_FALLBACK_MODE from the admin conf
             BUDGETS_ENABLED: 'on',
             GUARDRAILS_ENABLED: 'on',
             REDIS_URL: 'on',
-            SEMANTIC_CACHE_ENABLED: 'off'
+            SEMANTIC_CACHE_ENABLED: 'off',
+            USAGE_PRICING_RECALCULATION_ENABLED: 'on'
         })
     );
 });

--- a/internal/admin/dashboard/templates/layout.html
+++ b/internal/admin/dashboard/templates/layout.html
@@ -129,6 +129,7 @@
                 </form>
             </section>
         </div>
+        {{template "typed-confirmation-dialog" .}}
     </div>
     <script src="https://cdn.jsdelivr.net/npm/lucide@0.577.0/dist/umd/lucide.min.js" integrity="sha384-orgVf2eX2+m1zKAOIi09hD0W6GtVhoOUmqDK+sysYB2JTZ4vS86j4jm+X7a4Nnei" crossorigin="anonymous"></script>
     <script src="{{assetURL "js/modules/conversation-helpers.js"}}"></script>
@@ -144,6 +145,7 @@
     <script src="{{assetURL "js/modules/auth-keys.js"}}"></script>
     <script src="{{assetURL "js/modules/guardrails.js"}}"></script>
     <script src="{{assetURL "js/modules/budgets.js"}}"></script>
+    <script src="{{assetURL "js/modules/pricing.js"}}"></script>
     <script src="{{assetURL "js/modules/conversation-drawer.js"}}"></script>
     <script src="{{assetURL "js/modules/contribution-calendar.js"}}"></script>
     <script src="{{assetURL "js/modules/charts.js"}}"></script>

--- a/internal/admin/dashboard/templates/page-settings.html
+++ b/internal/admin/dashboard/templates/page-settings.html
@@ -144,7 +144,7 @@
                  x-text="budgetSettingsError"></div>
         </div>
 
-        <div class="settings-refresh-section pricing-recalculate-section">
+        <div class="settings-refresh-section pricing-recalculate-section" x-show="pricingRecalculationEnabled()" x-cloak>
             <div class="inline-help-section" x-data="{ open: false, copyId: 'pricing-recalculate-help-copy', showLabel: 'Show pricing recalculation help', hideLabel: 'Hide pricing recalculation help', text: 'Recalculate stored usage costs from the current model pricing metadata. Filters are applied to the selected date range, user path subtree, and provider/model selector or alias.' }">
                 <div class="inline-help-title-row">
                     <h3>Usage Pricing Recalculation</h3>
@@ -179,7 +179,7 @@
             <div class="settings-refresh-actions pricing-recalculate-actions">
                 <button type="button"
                         class="pagination-btn pagination-btn-danger pagination-btn-with-icon"
-                        :disabled="pricingRecalculateLoading"
+                        :disabled="pricingRecalculateLoading || !pricingRecalculationEnabled()"
                         :aria-busy="pricingRecalculateLoading ? 'true' : 'false'"
                         aria-describedby="pricing-recalculate-help-copy"
                         @click="openPricingRecalculateDialog()">
@@ -188,7 +188,7 @@
                 </button>
             </div>
         </div>
-        <div>
+        <div x-show="pricingRecalculationEnabled()" x-cloak>
             <div class="alert alert-success settings-refresh-alert"
                  role="status"
                  aria-live="polite"

--- a/internal/admin/dashboard/templates/page-settings.html
+++ b/internal/admin/dashboard/templates/page-settings.html
@@ -160,7 +160,7 @@
                     </div>
                 </div>
                 <div class="form-field">
-                    <label class="form-field-label" for="pricing-recalculate-user-path">User Path</label>
+                    <label class="form-field-label" for="pricing-recalculate-user-path">User Path (optional)</label>
                     <input id="pricing-recalculate-user-path"
                            class="form-input"
                            type="text"
@@ -168,7 +168,7 @@
                            x-model="pricingRecalculateUserPath">
                 </div>
                 <div class="form-field">
-                    <label class="form-field-label" for="pricing-recalculate-selector">Provider/Model or Alias</label>
+                    <label class="form-field-label" for="pricing-recalculate-selector">Provider/Model or Alias (optional)</label>
                     <input id="pricing-recalculate-selector"
                            class="form-input"
                            type="text"

--- a/internal/admin/dashboard/templates/page-settings.html
+++ b/internal/admin/dashboard/templates/page-settings.html
@@ -144,6 +144,63 @@
                  x-text="budgetSettingsError"></div>
         </div>
 
+        <div class="settings-refresh-section pricing-recalculate-section">
+            <div class="inline-help-section" x-data="{ open: false, copyId: 'pricing-recalculate-help-copy', showLabel: 'Show pricing recalculation help', hideLabel: 'Hide pricing recalculation help', text: 'Recalculate stored usage costs from the current model pricing metadata. Filters are applied to the selected date range, user path subtree, and provider/model selector or alias.' }">
+                <div class="inline-help-title-row">
+                    <h3>Usage Pricing Recalculation</h3>
+                    {{template "inline-help-toggle" .}}
+                </div>
+                <p :id="copyId" class="inline-help-copy" x-show="open" x-transition.opacity.duration.200ms x-text="text"></p>
+            </div>
+            <div class="pricing-recalculate-grid">
+                <div class="form-field pricing-recalculate-date-field">
+                    <label class="form-field-label" id="pricing-recalculate-date-label">Date Range</label>
+                    <div aria-labelledby="pricing-recalculate-date-label">
+                        {{template "date-picker" .}}
+                    </div>
+                </div>
+                <div class="form-field">
+                    <label class="form-field-label" for="pricing-recalculate-user-path">User Path</label>
+                    <input id="pricing-recalculate-user-path"
+                           class="form-input"
+                           type="text"
+                           placeholder="/team/alpha"
+                           x-model="pricingRecalculateUserPath">
+                </div>
+                <div class="form-field">
+                    <label class="form-field-label" for="pricing-recalculate-selector">Provider/Model or Alias</label>
+                    <input id="pricing-recalculate-selector"
+                           class="form-input"
+                           type="text"
+                           placeholder="openai/gpt-4o or smart"
+                           x-model="pricingRecalculateSelector">
+                </div>
+            </div>
+            <div class="settings-refresh-actions pricing-recalculate-actions">
+                <button type="button"
+                        class="pagination-btn pagination-btn-danger pagination-btn-with-icon"
+                        :disabled="pricingRecalculateLoading"
+                        :aria-busy="pricingRecalculateLoading ? 'true' : 'false'"
+                        aria-describedby="pricing-recalculate-help-copy"
+                        @click="openPricingRecalculateDialog()">
+                    <i data-lucide="calculator" class="form-action-icon" aria-hidden="true"></i>
+                    <span>Recalculate Pricing</span>
+                </button>
+            </div>
+        </div>
+        <div>
+            <div class="alert alert-success settings-refresh-alert"
+                 role="status"
+                 aria-live="polite"
+                 x-show="pricingRecalculateNotice"
+                 x-text="pricingRecalculateNotice"></div>
+            <div class="alert alert-warning settings-refresh-alert"
+                 role="alert"
+                 aria-live="assertive"
+                 x-show="pricingRecalculateError"
+                 x-text="pricingRecalculateError"></div>
+        </div>
+
         <div class="settings-refresh-section">
             <div class="inline-help-section" x-data="{ open: false, copyId: 'runtime-refresh-help-copy', showLabel: 'Show runtime refresh help', hideLabel: 'Hide runtime refresh help', text: 'Pull the latest model metadata, provider inventory, API keys, aliases, model access rules, guardrails, and workflows.' }">
                 <div class="inline-help-title-row">
@@ -187,49 +244,6 @@
                 </template>
             </ul>
         </div>
-    </div>
-    <div class="auth-dialog-backdrop"
-         x-cloak
-         x-show="budgetResetDialogOpen"
-         x-transition.opacity.duration.160ms
-         aria-hidden="true"></div>
-    <div class="auth-dialog-shell"
-         x-cloak
-         x-show="budgetResetDialogOpen"
-         x-transition.opacity.duration.160ms
-         @click="closeBudgetResetDialog()"
-         @keydown.escape.window="!authDialogOpen && budgetResetDialogOpen && closeBudgetResetDialog()">
-        <section class="auth-dialog budget-reset-dialog"
-                 role="dialog"
-                 aria-modal="true"
-                 aria-labelledby="budgetResetDialogTitle"
-                 @click.stop>
-            <div class="auth-dialog-header">
-                <h2 id="budgetResetDialogTitle">Reset Budgets</h2>
-                <button type="button" class="auth-dialog-close dialog-close-btn" aria-label="Close budget reset dialog" @click="closeBudgetResetDialog()">
-                    {{template "x-icon"}}
-                </button>
-            </div>
-            <form class="auth-dialog-form" @submit.prevent="resetBudgets()">
-                <div class="form-field">
-                    <label class="form-field-label" for="budget-reset-confirmation">Type reset to confirm</label>
-                    <input id="budget-reset-confirmation"
-                           class="form-input"
-                           type="text"
-                           autocomplete="off"
-                           x-model="budgetResetConfirmation">
-                </div>
-                <div class="auth-dialog-actions">
-                    <button type="button" class="pagination-btn" @click="closeBudgetResetDialog()">Cancel</button>
-                    <button type="submit"
-                            class="pagination-btn pagination-btn-danger pagination-btn-with-icon"
-                            :disabled="budgetResetLoading || String(budgetResetConfirmation || '').trim().toLowerCase() !== 'reset'">
-                        <i data-lucide="rotate-ccw" class="form-action-icon" aria-hidden="true"></i>
-                        <span>Reset All Budgets</span>
-                    </button>
-                </div>
-            </form>
-        </section>
     </div>
 </div>
 </template>

--- a/internal/admin/dashboard/templates/page-settings.html
+++ b/internal/admin/dashboard/templates/page-settings.html
@@ -159,7 +159,7 @@
                         {{template "date-picker" .}}
                     </div>
                 </div>
-                <div class="form-field">
+                <div class="form-field pricing-recalculate-filter-field">
                     <label class="form-field-label" for="pricing-recalculate-user-path">User Path (optional)</label>
                     <input id="pricing-recalculate-user-path"
                            class="form-input"
@@ -167,7 +167,7 @@
                            placeholder="/team/alpha"
                            x-model="pricingRecalculateUserPath">
                 </div>
-                <div class="form-field">
+                <div class="form-field pricing-recalculate-filter-field pricing-recalculate-selector-field">
                     <label class="form-field-label" for="pricing-recalculate-selector">Provider/Model or Alias (optional)</label>
                     <input id="pricing-recalculate-selector"
                            class="form-input"

--- a/internal/admin/dashboard/templates/typed-confirmation-dialog.html
+++ b/internal/admin/dashboard/templates/typed-confirmation-dialog.html
@@ -1,0 +1,47 @@
+{{define "typed-confirmation-dialog"}}
+<div class="auth-dialog-backdrop"
+     x-cloak
+     x-show="typedConfirmationDialog.open"
+     x-transition.opacity.duration.160ms
+     aria-hidden="true"></div>
+<div class="auth-dialog-shell"
+     x-cloak
+     x-show="typedConfirmationDialog.open"
+     x-transition.opacity.duration.160ms
+     @click="closeTypedConfirmationDialog()"
+     @keydown.escape.window="!authDialogOpen && typedConfirmationDialog.open && closeTypedConfirmationDialog()">
+    <section class="auth-dialog"
+             :class="typedConfirmationDialog.dialogClass"
+             role="dialog"
+             aria-modal="true"
+             :aria-labelledby="typedConfirmationDialog.titleId"
+             @click.stop>
+        <div class="auth-dialog-header">
+            <h2 :id="typedConfirmationDialog.titleId" x-text="typedConfirmationDialog.title"></h2>
+            <button type="button" class="auth-dialog-close dialog-close-btn" aria-label="Close confirmation dialog" @click="closeTypedConfirmationDialog()">
+                {{template "x-icon"}}
+            </button>
+        </div>
+        <form class="auth-dialog-form" @submit.prevent="submitTypedConfirmationDialog()">
+            <p class="auth-dialog-hint" x-show="typedConfirmationDialog.message" x-text="typedConfirmationDialog.message"></p>
+            <div class="form-field">
+                <label class="form-field-label" :for="typedConfirmationDialog.inputId" x-text="typedConfirmationInputLabel()"></label>
+                <input :id="typedConfirmationDialog.inputId"
+                       class="form-input"
+                       type="text"
+                       autocomplete="off"
+                       x-model="typedConfirmationDialog.value">
+            </div>
+            <div class="auth-dialog-actions">
+                <button type="button" class="pagination-btn" @click="closeTypedConfirmationDialog()">Cancel</button>
+                <button type="submit"
+                        class="pagination-btn pagination-btn-danger pagination-btn-with-icon"
+                        :disabled="typedConfirmationLoading() || !typedConfirmationReady()">
+                    <i :data-lucide="typedConfirmationDialog.icon" class="form-action-icon" aria-hidden="true"></i>
+                    <span x-text="typedConfirmationDialog.confirmLabel"></span>
+                </button>
+            </div>
+        </form>
+    </section>
+</div>
+{{end}}

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -294,6 +294,8 @@ var validIntervals = map[string]bool{
 const (
 	dashboardTimeZoneHeader = "X-GoModel-Timezone"
 	defaultDashboardTZ      = "UTC"
+	defaultDateRangeDays    = 30
+	maxDateRangeDays        = 365
 )
 
 var timeNow = time.Now
@@ -341,10 +343,10 @@ func parseDateRangeParams(c *echo.Context) (usage.UsageQueryParams, error) {
 	now := timeNow().In(location)
 	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, location)
 
-	days := 30
+	days := defaultDateRangeDays
 	if d := c.QueryParam("days"); d != "" {
 		if parsed, err := strconv.Atoi(d); err == nil && parsed > 0 {
-			days = parsed
+			days = min(parsed, maxDateRangeDays)
 		}
 	}
 
@@ -388,12 +390,17 @@ func buildDateRange(startStr, endStr string, days int, location *time.Location, 
 		return start, end, nil
 	}
 
-	if days <= 0 {
-		days = 30
-	}
+	days = normalizeDateRangeDays(days)
 	end = today
 	start = today.AddDate(0, 0, -(days - 1))
 	return start, end, nil
+}
+
+func normalizeDateRangeDays(days int) int {
+	if days <= 0 {
+		return defaultDateRangeDays
+	}
+	return min(days, maxDateRangeDays)
 }
 
 func dashboardTimeZone(c *echo.Context) (string, *time.Location) {
@@ -1617,7 +1624,7 @@ func recalculatePricingDateParams(c *echo.Context, req recalculatePricingRequest
 	now := timeNow().In(location)
 	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, location)
 
-	start, end, err := buildDateRange(strings.TrimSpace(req.StartDate), strings.TrimSpace(req.EndDate), req.Days, location, today)
+	start, end, err := buildDateRange(strings.TrimSpace(req.StartDate), strings.TrimSpace(req.EndDate), normalizeDateRangeDays(req.Days), location, today)
 	if err != nil {
 		return params, err
 	}

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -730,6 +730,12 @@ func (h *Handler) RecalculateUsagePricing(c *echo.Context) error {
 
 	result, err := h.usageRecalculator.RecalculatePricing(c.Request().Context(), params, h.registry)
 	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return handleError(c, err)
+		}
+		if gatewayErr, ok := errors.AsType[*core.GatewayError](err); ok {
+			return handleError(c, gatewayErr)
+		}
 		return handleError(c, core.NewProviderError("usage", http.StatusInternalServerError, "failed to recalculate usage pricing", err))
 	}
 	return c.JSON(http.StatusOK, result)

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -33,6 +33,7 @@ import (
 // Handler serves admin API endpoints.
 type Handler struct {
 	usageReader         usage.UsageReader
+	usageRecalculator   usage.PricingRecalculator
 	auditReader         auditlog.Reader
 	registry            *providers.ModelRegistry
 	authKeys            *authkeys.Service
@@ -150,6 +151,13 @@ type RuntimeRefresher interface {
 func WithAuditReader(reader auditlog.Reader) Option {
 	return func(h *Handler) {
 		h.auditReader = reader
+	}
+}
+
+// WithUsagePricingRecalculator enables persisted usage pricing recalculation.
+func WithUsagePricingRecalculator(recalculator usage.PricingRecalculator) Option {
+	return func(h *Handler) {
+		h.usageRecalculator = recalculator
 	}
 }
 
@@ -655,6 +663,50 @@ func (h *Handler) UsageLog(c *echo.Context) error {
 		result.Entries = []usage.UsageLogEntry{}
 	}
 
+	return c.JSON(http.StatusOK, result)
+}
+
+// RecalculateUsagePricing handles POST /admin/api/v1/usage/recalculate-pricing.
+//
+// @Summary      Recalculate stored usage costs from current model pricing metadata
+// @Tags         admin
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        request  body      recalculatePricingRequest       true  "Recalculation filters and confirmation"
+// @Success      200      {object}  usage.RecalculatePricingResult
+// @Failure      400      {object}  core.GatewayError
+// @Failure      401      {object}  core.GatewayError
+// @Failure      503      {object}  core.GatewayError
+// @Router       /admin/api/v1/usage/recalculate-pricing [post]
+func (h *Handler) RecalculateUsagePricing(c *echo.Context) error {
+	if h.usageRecalculator == nil {
+		return handleError(c, featureUnavailableError("usage pricing recalculation is unavailable"))
+	}
+	if h.registry == nil {
+		return handleError(c, featureUnavailableError("model pricing metadata is unavailable"))
+	}
+
+	var req recalculatePricingRequest
+	if err := c.Bind(&req); err != nil {
+		return handleError(c, core.NewInvalidRequestError("invalid request body: "+err.Error(), err))
+	}
+	if strings.TrimSpace(strings.ToLower(req.confirmationValue())) != "recalculate" {
+		return handleError(c, core.NewInvalidRequestError("confirmation must be recalculate", nil))
+	}
+
+	params, err := h.recalculatePricingParams(c, req)
+	if err != nil {
+		return handleError(c, err)
+	}
+
+	h.mutationMu.Lock()
+	defer h.mutationMu.Unlock()
+
+	result, err := h.usageRecalculator.RecalculatePricing(c.Request().Context(), params, h.registry)
+	if err != nil {
+		return handleError(c, core.NewProviderError("usage", http.StatusInternalServerError, "failed to recalculate usage pricing", err))
+	}
 	return c.JSON(http.StatusOK, result)
 }
 
@@ -1456,6 +1508,23 @@ type updateBudgetSettingsRequest struct {
 	MonthlyResetMinute *int `json:"monthly_reset_minute"`
 }
 
+type recalculatePricingRequest struct {
+	Days         int    `json:"days,omitempty"`
+	StartDate    string `json:"start_date,omitempty"`
+	EndDate      string `json:"end_date,omitempty"`
+	UserPath     string `json:"user_path,omitempty"`
+	Selector     string `json:"selector,omitempty"`
+	Confirmation string `json:"confirmation"`
+	Confirm      string `json:"confirm,omitempty"`
+}
+
+func (r recalculatePricingRequest) confirmationValue() string {
+	if strings.TrimSpace(r.Confirmation) != "" {
+		return r.Confirmation
+	}
+	return r.Confirm
+}
+
 func (r updateBudgetSettingsRequest) apply(settings budget.Settings) budget.Settings {
 	if r.DailyResetHour != nil {
 		settings.DailyResetHour = *r.DailyResetHour
@@ -1498,6 +1567,103 @@ func (r resetBudgetsRequest) confirmationValue() string {
 
 type resetBudgetsResponse struct {
 	Status string `json:"status"`
+}
+
+func (h *Handler) recalculatePricingParams(c *echo.Context, req recalculatePricingRequest) (usage.RecalculatePricingParams, error) {
+	baseParams, err := recalculatePricingDateParams(c, req)
+	if err != nil {
+		return usage.RecalculatePricingParams{}, err
+	}
+
+	userPath, err := normalizeUserPathQueryParam("user_path", req.UserPath)
+	if err != nil {
+		return usage.RecalculatePricingParams{}, err
+	}
+	baseParams.UserPath = userPath
+	baseParams.CacheMode = usage.CacheModeAll
+
+	provider, model, err := h.recalculatePricingSelector(req.Selector)
+	if err != nil {
+		return usage.RecalculatePricingParams{}, err
+	}
+
+	return usage.RecalculatePricingParams{
+		UsageQueryParams: baseParams,
+		Provider:         provider,
+		Model:            model,
+	}, nil
+}
+
+func recalculatePricingDateParams(c *echo.Context, req recalculatePricingRequest) (usage.UsageQueryParams, error) {
+	var params usage.UsageQueryParams
+
+	timeZone, location := dashboardTimeZone(c)
+	params.TimeZone = timeZone
+
+	now := timeNow().In(location)
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, location)
+
+	startStr := strings.TrimSpace(req.StartDate)
+	endStr := strings.TrimSpace(req.EndDate)
+
+	var startParsed, endParsed bool
+	if startStr != "" {
+		t, err := time.ParseInLocation("2006-01-02", startStr, location)
+		if err != nil {
+			return params, core.NewInvalidRequestError("invalid start_date format, expected YYYY-MM-DD", nil)
+		}
+		params.StartDate = t
+		startParsed = true
+	}
+	if endStr != "" {
+		t, err := time.ParseInLocation("2006-01-02", endStr, location)
+		if err != nil {
+			return params, core.NewInvalidRequestError("invalid end_date format, expected YYYY-MM-DD", nil)
+		}
+		params.EndDate = t
+		endParsed = true
+	}
+
+	if startParsed || endParsed {
+		if !startParsed {
+			params.StartDate = params.EndDate.AddDate(0, 0, -29)
+		}
+		if !endParsed {
+			params.EndDate = today
+		}
+		return params, nil
+	}
+
+	days := req.Days
+	if days <= 0 {
+		days = 30
+	}
+	params.EndDate = today
+	params.StartDate = today.AddDate(0, 0, -(days - 1))
+	return params, nil
+}
+
+func (h *Handler) recalculatePricingSelector(raw string) (provider, model string, err error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", "", nil
+	}
+
+	if h.aliases != nil {
+		selector, changed, err := h.aliases.ResolveModel(core.NewRequestedModelSelector(raw, ""))
+		if err != nil {
+			return "", "", core.NewInvalidRequestError("invalid selector: "+err.Error(), err)
+		}
+		if changed {
+			return selector.Provider, selector.Model, nil
+		}
+	}
+
+	selector, err := core.ParseModelSelector(raw, "")
+	if err != nil {
+		return "", "", core.NewInvalidRequestError("invalid selector: "+err.Error(), err)
+	}
+	return selector.Provider, selector.Model, nil
 }
 
 func budgetStatusResponses(statuses []budget.CheckResult, now time.Time) []budgetStatusResponse {

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -48,6 +48,7 @@ type Handler struct {
 	configuredProviders []providers.SanitizedProviderConfig
 
 	mutationMu sync.Mutex
+	pricingMu  sync.Mutex
 }
 
 // Option configures the admin API handler.
@@ -724,8 +725,8 @@ func (h *Handler) RecalculateUsagePricing(c *echo.Context) error {
 		return handleError(c, err)
 	}
 
-	h.mutationMu.Lock()
-	defer h.mutationMu.Unlock()
+	h.pricingMu.Lock()
+	defer h.pricingMu.Unlock()
 
 	result, err := h.usageRecalculator.RecalculatePricing(c.Request().Context(), params, h.registry)
 	if err != nil {

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -62,6 +62,7 @@ const (
 	DashboardConfigCacheEnabled         = "CACHE_ENABLED"
 	DashboardConfigRedisURL             = "REDIS_URL"
 	DashboardConfigSemanticCacheEnabled = "SEMANTIC_CACHE_ENABLED"
+	DashboardConfigPricingRecalculation = "USAGE_PRICING_RECALCULATION_ENABLED"
 )
 
 // statusClientClosedRequest is the de facto status used by proxies for client-aborted requests.
@@ -77,6 +78,7 @@ type DashboardConfigResponse struct {
 	CacheEnabled         string `json:"CACHE_ENABLED,omitempty"`
 	RedisURL             string `json:"REDIS_URL,omitempty"`
 	SemanticCacheEnabled string `json:"SEMANTIC_CACHE_ENABLED,omitempty"`
+	PricingRecalculation string `json:"USAGE_PRICING_RECALCULATION_ENABLED,omitempty"`
 }
 
 type providerStatusSummaryResponse struct {
@@ -260,6 +262,7 @@ func normalizeDashboardRuntimeConfig(values DashboardConfigResponse) DashboardCo
 		CacheEnabled:         strings.TrimSpace(values.CacheEnabled),
 		RedisURL:             strings.TrimSpace(values.RedisURL),
 		SemanticCacheEnabled: strings.TrimSpace(values.SemanticCacheEnabled),
+		PricingRecalculation: strings.TrimSpace(values.PricingRecalculation),
 	}
 }
 
@@ -338,49 +341,59 @@ func parseDateRangeParams(c *echo.Context) (usage.UsageQueryParams, error) {
 	now := timeNow().In(location)
 	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, location)
 
-	startStr := c.QueryParam("start_date")
-	endStr := c.QueryParam("end_date")
-
-	var startParsed, endParsed bool
-
-	if startStr != "" {
-		t, err := time.ParseInLocation("2006-01-02", startStr, location)
-		if err != nil {
-			return params, core.NewInvalidRequestError("invalid start_date format, expected YYYY-MM-DD", nil)
-		}
-		params.StartDate = t
-		startParsed = true
-	}
-
-	if endStr != "" {
-		t, err := time.ParseInLocation("2006-01-02", endStr, location)
-		if err != nil {
-			return params, core.NewInvalidRequestError("invalid end_date format, expected YYYY-MM-DD", nil)
-		}
-		params.EndDate = t
-		endParsed = true
-	}
-
-	if startParsed || endParsed {
-		if !startParsed {
-			params.StartDate = params.EndDate.AddDate(0, 0, -29)
-		}
-		if !endParsed {
-			params.EndDate = today
-		}
-		return params, nil
-	}
-
 	days := 30
 	if d := c.QueryParam("days"); d != "" {
 		if parsed, err := strconv.Atoi(d); err == nil && parsed > 0 {
 			days = parsed
 		}
 	}
-	params.EndDate = today
-	params.StartDate = today.AddDate(0, 0, -(days - 1))
 
+	start, end, err := buildDateRange(strings.TrimSpace(c.QueryParam("start_date")), strings.TrimSpace(c.QueryParam("end_date")), days, location, today)
+	if err != nil {
+		return params, err
+	}
+	params.StartDate = start
+	params.EndDate = end
 	return params, nil
+}
+
+func buildDateRange(startStr, endStr string, days int, location *time.Location, today time.Time) (time.Time, time.Time, error) {
+	var start, end time.Time
+	var startParsed, endParsed bool
+
+	if startStr != "" {
+		t, err := time.ParseInLocation("2006-01-02", startStr, location)
+		if err != nil {
+			return time.Time{}, time.Time{}, core.NewInvalidRequestError("invalid start_date format, expected YYYY-MM-DD", nil)
+		}
+		start = t
+		startParsed = true
+	}
+	if endStr != "" {
+		t, err := time.ParseInLocation("2006-01-02", endStr, location)
+		if err != nil {
+			return time.Time{}, time.Time{}, core.NewInvalidRequestError("invalid end_date format, expected YYYY-MM-DD", nil)
+		}
+		end = t
+		endParsed = true
+	}
+
+	if startParsed || endParsed {
+		if !startParsed {
+			start = end.AddDate(0, 0, -29)
+		}
+		if !endParsed {
+			end = today
+		}
+		return start, end, nil
+	}
+
+	if days <= 0 {
+		days = 30
+	}
+	end = today
+	start = today.AddDate(0, 0, -(days - 1))
+	return start, end, nil
 }
 
 func dashboardTimeZone(c *echo.Context) (string, *time.Location) {
@@ -1603,43 +1616,12 @@ func recalculatePricingDateParams(c *echo.Context, req recalculatePricingRequest
 	now := timeNow().In(location)
 	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, location)
 
-	startStr := strings.TrimSpace(req.StartDate)
-	endStr := strings.TrimSpace(req.EndDate)
-
-	var startParsed, endParsed bool
-	if startStr != "" {
-		t, err := time.ParseInLocation("2006-01-02", startStr, location)
-		if err != nil {
-			return params, core.NewInvalidRequestError("invalid start_date format, expected YYYY-MM-DD", nil)
-		}
-		params.StartDate = t
-		startParsed = true
+	start, end, err := buildDateRange(strings.TrimSpace(req.StartDate), strings.TrimSpace(req.EndDate), req.Days, location, today)
+	if err != nil {
+		return params, err
 	}
-	if endStr != "" {
-		t, err := time.ParseInLocation("2006-01-02", endStr, location)
-		if err != nil {
-			return params, core.NewInvalidRequestError("invalid end_date format, expected YYYY-MM-DD", nil)
-		}
-		params.EndDate = t
-		endParsed = true
-	}
-
-	if startParsed || endParsed {
-		if !startParsed {
-			params.StartDate = params.EndDate.AddDate(0, 0, -29)
-		}
-		if !endParsed {
-			params.EndDate = today
-		}
-		return params, nil
-	}
-
-	days := req.Days
-	if days <= 0 {
-		days = 30
-	}
-	params.EndDate = today
-	params.StartDate = today.AddDate(0, 0, -(days - 1))
+	params.StartDate = start
+	params.EndDate = end
 	return params, nil
 }
 

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -387,12 +387,15 @@ func buildDateRange(startStr, endStr string, days int, location *time.Location, 
 		if !endParsed {
 			end = today
 		}
-		return start, end, nil
+	} else {
+		days = normalizeDateRangeDays(days)
+		end = today
+		start = today.AddDate(0, 0, -(days - 1))
 	}
 
-	days = normalizeDateRangeDays(days)
-	end = today
-	start = today.AddDate(0, 0, -(days - 1))
+	if start.After(end) {
+		return time.Time{}, time.Time{}, core.NewInvalidRequestError("start_date must be on or before end_date", nil)
+	}
 	return start, end, nil
 }
 

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -690,6 +690,7 @@ func (h *Handler) UsageLog(c *echo.Context) error {
 // @Success      200      {object}  usage.RecalculatePricingResult
 // @Failure      400      {object}  core.GatewayError
 // @Failure      401      {object}  core.GatewayError
+// @Failure      500      {object}  core.GatewayError
 // @Failure      503      {object}  core.GatewayError
 // @Router       /admin/api/v1/usage/recalculate-pricing [post]
 func (h *Handler) RecalculateUsagePricing(c *echo.Context) error {
@@ -1644,6 +1645,9 @@ func (h *Handler) recalculatePricingSelector(raw string) (provider, model string
 	selector, err := core.ParseModelSelector(raw, "")
 	if err != nil {
 		return "", "", core.NewInvalidRequestError("invalid selector: "+err.Error(), err)
+	}
+	if selector.Provider == "" {
+		return "", "", core.NewInvalidRequestError("invalid selector: provider/model or alias is required", nil)
 	}
 	return selector.Provider, selector.Model, nil
 }

--- a/internal/admin/handler_pricing_test.go
+++ b/internal/admin/handler_pricing_test.go
@@ -1,0 +1,137 @@
+package admin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v5"
+
+	"gomodel/internal/aliases"
+	"gomodel/internal/providers"
+	"gomodel/internal/usage"
+)
+
+type mockPricingRecalculator struct {
+	calls  int
+	params usage.RecalculatePricingParams
+	result usage.RecalculatePricingResult
+	err    error
+}
+
+func (m *mockPricingRecalculator) RecalculatePricing(_ context.Context, params usage.RecalculatePricingParams, _ usage.PricingResolver) (usage.RecalculatePricingResult, error) {
+	m.calls++
+	m.params = params
+	if m.err != nil {
+		return usage.RecalculatePricingResult{}, m.err
+	}
+	return m.result, nil
+}
+
+func TestRecalculateUsagePricingResolvesAliasAndFilters(t *testing.T) {
+	catalog := newAliasTestCatalog()
+	catalog.add("openai/gpt-4o", "openai")
+	service, err := aliases.NewService(newAliasTestStore(aliases.Alias{
+		Name:           "smart",
+		TargetModel:    "gpt-4o",
+		TargetProvider: "openai",
+		Enabled:        true,
+	}), catalog)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	recalculator := &mockPricingRecalculator{
+		result: usage.RecalculatePricingResult{
+			Status:       "ok",
+			Matched:      2,
+			Recalculated: 2,
+			WithPricing:  2,
+		},
+	}
+	h := NewHandler(nil, providers.NewModelRegistry(),
+		WithAliases(service),
+		WithUsagePricingRecalculator(recalculator),
+	)
+
+	body := bytes.NewBufferString(`{
+		"start_date":"2026-04-01",
+		"end_date":"2026-04-02",
+		"user_path":"team/alpha",
+		"selector":"smart",
+		"confirmation":"recalculate"
+	}`)
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", body)
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	req.Header.Set(dashboardTimeZoneHeader, "Europe/Warsaw")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.RecalculateUsagePricing(c); err != nil {
+		t.Fatalf("RecalculateUsagePricing() error = %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if recalculator.calls != 1 {
+		t.Fatalf("recalculator calls = %d, want 1", recalculator.calls)
+	}
+
+	params := recalculator.params
+	if params.Provider != "openai" || params.Model != "gpt-4o" {
+		t.Fatalf("selector params = %q/%q, want openai/gpt-4o", params.Provider, params.Model)
+	}
+	if params.UserPath != "/team/alpha" {
+		t.Fatalf("UserPath = %q, want /team/alpha", params.UserPath)
+	}
+	if params.CacheMode != usage.CacheModeAll {
+		t.Fatalf("CacheMode = %q, want %q", params.CacheMode, usage.CacheModeAll)
+	}
+
+	location, err := time.LoadLocation("Europe/Warsaw")
+	if err != nil {
+		t.Fatalf("LoadLocation() error = %v", err)
+	}
+	wantStart := time.Date(2026, 4, 1, 0, 0, 0, 0, location)
+	wantEnd := time.Date(2026, 4, 2, 0, 0, 0, 0, location)
+	if !params.StartDate.Equal(wantStart) || !params.EndDate.Equal(wantEnd) {
+		t.Fatalf("date range = %s to %s, want %s to %s", params.StartDate, params.EndDate, wantStart, wantEnd)
+	}
+
+	var result usage.RecalculatePricingResult
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if result.Recalculated != 2 || result.WithPricing != 2 {
+		t.Fatalf("result = %+v, want recalculated=2 with_pricing=2", result)
+	}
+}
+
+func TestRecalculateUsagePricingRequiresConfirmation(t *testing.T) {
+	recalculator := &mockPricingRecalculator{}
+	h := NewHandler(nil, providers.NewModelRegistry(), WithUsagePricingRecalculator(recalculator))
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", bytes.NewBufferString(`{"confirmation":"nope"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.RecalculateUsagePricing(c); err != nil {
+		t.Fatalf("RecalculateUsagePricing() returned handler error: %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if recalculator.calls != 0 {
+		t.Fatalf("recalculator calls = %d, want 0", recalculator.calls)
+	}
+}

--- a/internal/admin/handler_pricing_test.go
+++ b/internal/admin/handler_pricing_test.go
@@ -138,6 +138,79 @@ func TestRecalculateUsagePricingRequiresConfirmation(t *testing.T) {
 	}
 }
 
+func TestRecalculateUsagePricingFeatureUnavailable(t *testing.T) {
+	tests := []struct {
+		name      string
+		handler   func(*mockPricingRecalculator) *Handler
+		wantError string
+	}{
+		{
+			name: "missing recalculator",
+			handler: func(*mockPricingRecalculator) *Handler {
+				return NewHandler(nil, providers.NewModelRegistry())
+			},
+			wantError: "usage pricing recalculation is unavailable",
+		},
+		{
+			name: "missing model registry",
+			handler: func(recalculator *mockPricingRecalculator) *Handler {
+				return NewHandler(nil, nil, WithUsagePricingRecalculator(recalculator))
+			},
+			wantError: "model pricing metadata is unavailable",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			recalculator := &mockPricingRecalculator{}
+			h := test.handler(recalculator)
+
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", bytes.NewBufferString(`{"confirmation":"recalculate"}`))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			if err := h.RecalculateUsagePricing(c); err != nil {
+				t.Fatalf("RecalculateUsagePricing() returned handler error: %v", err)
+			}
+			if rec.Code != http.StatusServiceUnavailable {
+				t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusServiceUnavailable, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), test.wantError) {
+				t.Fatalf("response body = %s, want %q", rec.Body.String(), test.wantError)
+			}
+			if recalculator.calls != 0 {
+				t.Fatalf("recalculator calls = %d, want 0", recalculator.calls)
+			}
+		})
+	}
+}
+
+func TestRecalculateUsagePricingInvalidSelector(t *testing.T) {
+	recalculator := &mockPricingRecalculator{}
+	h := NewHandler(nil, providers.NewModelRegistry(), WithUsagePricingRecalculator(recalculator))
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", bytes.NewBufferString(`{"confirmation":"recalculate","selector":"invalid"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.RecalculateUsagePricing(c); err != nil {
+		t.Fatalf("RecalculateUsagePricing() returned handler error: %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "invalid selector") {
+		t.Fatalf("response body = %s, want invalid selector message", rec.Body.String())
+	}
+	if recalculator.calls != 0 {
+		t.Fatalf("recalculator calls = %d, want 0", recalculator.calls)
+	}
+}
+
 func TestRecalculateUsagePricingReturnsInternalErrorOnRecalculatorFailure(t *testing.T) {
 	recalculator := &mockPricingRecalculator{err: errors.New("storage write failed")}
 	h := NewHandler(nil, providers.NewModelRegistry(), WithUsagePricingRecalculator(recalculator))

--- a/internal/admin/handler_pricing_test.go
+++ b/internal/admin/handler_pricing_test.go
@@ -211,6 +211,94 @@ func TestRecalculateUsagePricingInvalidSelector(t *testing.T) {
 	}
 }
 
+func TestRecalculateUsagePricingRejectsInvalidDateAndUserPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		wantError string
+	}{
+		{
+			name:      "invalid start date",
+			body:      `{"confirmation":"recalculate","start_date":"2026/04/01"}`,
+			wantError: "invalid start_date format, expected YYYY-MM-DD",
+		},
+		{
+			name:      "invalid end date",
+			body:      `{"confirmation":"recalculate","end_date":"tomorrow"}`,
+			wantError: "invalid end_date format, expected YYYY-MM-DD",
+		},
+		{
+			name:      "invalid user path",
+			body:      `{"confirmation":"recalculate","user_path":"/team/../alpha"}`,
+			wantError: "invalid user_path: user path cannot contain '.' or '..' segments",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			recalculator := &mockPricingRecalculator{}
+			h := NewHandler(nil, providers.NewModelRegistry(), WithUsagePricingRecalculator(recalculator))
+
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", bytes.NewBufferString(test.body))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			if err := h.RecalculateUsagePricing(c); err != nil {
+				t.Fatalf("RecalculateUsagePricing() returned handler error: %v", err)
+			}
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), test.wantError) {
+				t.Fatalf("response body = %s, want %q", rec.Body.String(), test.wantError)
+			}
+			if recalculator.calls != 0 {
+				t.Fatalf("recalculator calls = %d, want 0", recalculator.calls)
+			}
+		})
+	}
+}
+
+func TestRecalculateUsagePricingClampsRequestedDays(t *testing.T) {
+	originalTimeNow := timeNow
+	timeNow = func() time.Time {
+		return time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	}
+	defer func() {
+		timeNow = originalTimeNow
+	}()
+
+	recalculator := &mockPricingRecalculator{
+		result: usage.RecalculatePricingResult{Status: "ok"},
+	}
+	h := NewHandler(nil, providers.NewModelRegistry(), WithUsagePricingRecalculator(recalculator))
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", bytes.NewBufferString(`{"confirmation":"recalculate","days":9999}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.RecalculateUsagePricing(c); err != nil {
+		t.Fatalf("RecalculateUsagePricing() returned handler error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if recalculator.calls != 1 {
+		t.Fatalf("recalculator calls = %d, want 1", recalculator.calls)
+	}
+
+	expectedEnd := time.Date(2026, 4, 28, 0, 0, 0, 0, time.UTC)
+	expectedStart := expectedEnd.AddDate(0, 0, -(maxDateRangeDays - 1))
+	if !recalculator.params.EndDate.Equal(expectedEnd) || !recalculator.params.StartDate.Equal(expectedStart) {
+		t.Fatalf("date range = %s to %s, want %s to %s",
+			recalculator.params.StartDate, recalculator.params.EndDate, expectedStart, expectedEnd)
+	}
+}
+
 func TestRecalculateUsagePricingReturnsInternalErrorOnRecalculatorFailure(t *testing.T) {
 	recalculator := &mockPricingRecalculator{err: errors.New("storage write failed")}
 	h := NewHandler(nil, providers.NewModelRegistry(), WithUsagePricingRecalculator(recalculator))

--- a/internal/admin/handler_pricing_test.go
+++ b/internal/admin/handler_pricing_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -133,5 +135,29 @@ func TestRecalculateUsagePricingRequiresConfirmation(t *testing.T) {
 	}
 	if recalculator.calls != 0 {
 		t.Fatalf("recalculator calls = %d, want 0", recalculator.calls)
+	}
+}
+
+func TestRecalculateUsagePricingReturnsInternalErrorOnRecalculatorFailure(t *testing.T) {
+	recalculator := &mockPricingRecalculator{err: errors.New("storage write failed")}
+	h := NewHandler(nil, providers.NewModelRegistry(), WithUsagePricingRecalculator(recalculator))
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", bytes.NewBufferString(`{"confirmation":"recalculate"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.RecalculateUsagePricing(c); err != nil {
+		t.Fatalf("RecalculateUsagePricing() returned handler error: %v", err)
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusInternalServerError, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "failed to recalculate usage pricing") {
+		t.Fatalf("response body = %s, want recalculation failure message", rec.Body.String())
+	}
+	if recalculator.calls != 1 {
+		t.Fatalf("recalculator calls = %d, want 1", recalculator.calls)
 	}
 }

--- a/internal/admin/handler_pricing_test.go
+++ b/internal/admin/handler_pricing_test.go
@@ -228,6 +228,11 @@ func TestRecalculateUsagePricingRejectsInvalidDateAndUserPath(t *testing.T) {
 			wantError: "invalid end_date format, expected YYYY-MM-DD",
 		},
 		{
+			name:      "inverted date range",
+			body:      `{"confirmation":"recalculate","start_date":"2026-04-29","end_date":"2026-04-28"}`,
+			wantError: "start_date must be on or before end_date",
+		},
+		{
 			name:      "invalid user path",
 			body:      `{"confirmation":"recalculate","user_path":"/team/../alpha"}`,
 			wantError: "invalid user_path: user path cannot contain '.' or '..' segments",

--- a/internal/admin/handler_pricing_test.go
+++ b/internal/admin/handler_pricing_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/labstack/echo/v5"
 
 	"gomodel/internal/aliases"
+	"gomodel/internal/core"
 	"gomodel/internal/providers"
 	"gomodel/internal/usage"
 )
@@ -410,5 +411,59 @@ func TestRecalculateUsagePricingReturnsInternalErrorOnRecalculatorFailure(t *tes
 	}
 	if recalculator.calls != 1 {
 		t.Fatalf("recalculator calls = %d, want 1", recalculator.calls)
+	}
+}
+
+func TestRecalculateUsagePricingPreservesExpectedRecalculatorErrors(t *testing.T) {
+	tests := []struct {
+		name           string
+		err            error
+		wantStatus     int
+		wantBodyString string
+	}{
+		{
+			name:           "context canceled",
+			err:            context.Canceled,
+			wantStatus:     statusClientClosedRequest,
+			wantBodyString: "request_canceled",
+		},
+		{
+			name:           "context deadline exceeded",
+			err:            context.DeadlineExceeded,
+			wantStatus:     http.StatusGatewayTimeout,
+			wantBodyString: "request_timeout",
+		},
+		{
+			name:           "gateway error",
+			err:            core.NewRateLimitError("usage", "pricing recalculation is rate limited"),
+			wantStatus:     http.StatusTooManyRequests,
+			wantBodyString: "rate_limit_error",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			recalculator := &mockPricingRecalculator{err: test.err}
+			h := NewHandler(nil, providers.NewModelRegistry(), WithUsagePricingRecalculator(recalculator))
+
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", bytes.NewBufferString(`{"confirmation":"recalculate"}`))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			if err := h.RecalculateUsagePricing(c); err != nil {
+				t.Fatalf("RecalculateUsagePricing() returned handler error: %v", err)
+			}
+			if rec.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d body=%s", rec.Code, test.wantStatus, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), test.wantBodyString) {
+				t.Fatalf("response body = %s, want %q", rec.Body.String(), test.wantBodyString)
+			}
+			if recalculator.calls != 1 {
+				t.Fatalf("recalculator calls = %d, want 1", recalculator.calls)
+			}
+		})
 	}
 }

--- a/internal/admin/handler_pricing_test.go
+++ b/internal/admin/handler_pricing_test.go
@@ -138,6 +138,53 @@ func TestRecalculateUsagePricingRequiresConfirmation(t *testing.T) {
 	}
 }
 
+func TestRecalculateUsagePricingAcceptsConfirmAlias(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		wantCode  int
+		wantCalls int
+	}{
+		{
+			name:      "confirm alias accepted",
+			body:      `{"confirm":"recalculate"}`,
+			wantCode:  http.StatusOK,
+			wantCalls: 1,
+		},
+		{
+			name:      "confirm alias rejected",
+			body:      `{"confirm":"nope"}`,
+			wantCode:  http.StatusBadRequest,
+			wantCalls: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			recalculator := &mockPricingRecalculator{
+				result: usage.RecalculatePricingResult{Status: "ok"},
+			}
+			h := NewHandler(nil, providers.NewModelRegistry(), WithUsagePricingRecalculator(recalculator))
+
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", bytes.NewBufferString(test.body))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			if err := h.RecalculateUsagePricing(c); err != nil {
+				t.Fatalf("RecalculateUsagePricing() returned handler error: %v", err)
+			}
+			if rec.Code != test.wantCode {
+				t.Fatalf("status = %d, want %d body=%s", rec.Code, test.wantCode, rec.Body.String())
+			}
+			if recalculator.calls != test.wantCalls {
+				t.Fatalf("recalculator calls = %d, want %d", recalculator.calls, test.wantCalls)
+			}
+		})
+	}
+}
+
 func TestRecalculateUsagePricingFeatureUnavailable(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -263,6 +310,44 @@ func TestRecalculateUsagePricingRejectsInvalidDateAndUserPath(t *testing.T) {
 				t.Fatalf("recalculator calls = %d, want 0", recalculator.calls)
 			}
 		})
+	}
+}
+
+func TestRecalculateUsagePricingDefaultsDateRange(t *testing.T) {
+	originalTimeNow := timeNow
+	timeNow = func() time.Time {
+		return time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	}
+	defer func() {
+		timeNow = originalTimeNow
+	}()
+
+	recalculator := &mockPricingRecalculator{
+		result: usage.RecalculatePricingResult{Status: "ok"},
+	}
+	h := NewHandler(nil, providers.NewModelRegistry(), WithUsagePricingRecalculator(recalculator))
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", bytes.NewBufferString(`{"confirmation":"recalculate"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.RecalculateUsagePricing(c); err != nil {
+		t.Fatalf("RecalculateUsagePricing() returned handler error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if recalculator.calls != 1 {
+		t.Fatalf("recalculator calls = %d, want 1", recalculator.calls)
+	}
+
+	expectedEnd := time.Date(2026, 4, 28, 0, 0, 0, 0, time.UTC)
+	expectedStart := expectedEnd.AddDate(0, 0, -(defaultDateRangeDays - 1))
+	if !recalculator.params.EndDate.Equal(expectedEnd) || !recalculator.params.StartDate.Equal(expectedStart) {
+		t.Fatalf("date range = %s to %s, want %s to %s",
+			recalculator.params.StartDate, recalculator.params.EndDate, expectedStart, expectedEnd)
 	}
 }
 

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -2341,6 +2341,32 @@ func TestParseUsageParams_DaysExplicit(t *testing.T) {
 	}
 }
 
+func TestParseUsageParams_DaysClamped(t *testing.T) {
+	originalTimeNow := timeNow
+	timeNow = func() time.Time {
+		return time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	}
+	defer func() {
+		timeNow = originalTimeNow
+	}()
+
+	c := newContext("days=9999")
+	params, err := parseUsageParams(c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedEnd := time.Date(2026, 4, 28, 0, 0, 0, 0, time.UTC)
+	expectedStart := expectedEnd.AddDate(0, 0, -(maxDateRangeDays - 1))
+
+	if !params.StartDate.Equal(expectedStart) {
+		t.Errorf("expected start date %v, got %v", expectedStart, params.StartDate)
+	}
+	if !params.EndDate.Equal(expectedEnd) {
+		t.Errorf("expected end date %v, got %v", expectedEnd, params.EndDate)
+	}
+}
+
 func TestParseUsageParams_StartAndEndDate(t *testing.T) {
 	c := newContext("start_date=2026-01-01&end_date=2026-01-31")
 	params, err := parseUsageParams(c)

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -1718,6 +1718,7 @@ func TestDashboardConfig_ReturnsAllowlistedRuntimeFlags(t *testing.T) {
 		CacheEnabled:         "on",
 		RedisURL:             "on",
 		SemanticCacheEnabled: "off",
+		PricingRecalculation: "on",
 	}))
 	c, rec := newHandlerContext("/admin/api/v1/dashboard/config")
 
@@ -1755,6 +1756,9 @@ func TestDashboardConfig_ReturnsAllowlistedRuntimeFlags(t *testing.T) {
 	}
 	if got := body.SemanticCacheEnabled; got != "off" {
 		t.Fatalf("SEMANTIC_CACHE_ENABLED = %q, want off", got)
+	}
+	if got := body.PricingRecalculation; got != "on" {
+		t.Fatalf("USAGE_PRICING_RECALCULATION_ENABLED = %q, want on", got)
 	}
 	if rec.Body.String() == "" || strings.Contains(rec.Body.String(), "UNRELATED_FLAG") {
 		t.Fatal("UNRELATED_FLAG should not be exposed")

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -814,11 +814,16 @@ func initAdmin(
 
 	// Create usage reader (may be nil if no storage)
 	var reader usage.UsageReader
+	var pricingRecalculator usage.PricingRecalculator
 	if store != nil {
 		var err error
 		reader, err = usage.NewReader(store)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create usage reader: %w", err)
+		}
+		pricingRecalculator, err = usage.NewPricingRecalculator(store)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create usage pricing recalculator: %w", err)
 		}
 	}
 
@@ -837,6 +842,7 @@ func initAdmin(
 		reader,
 		registry,
 		admin.WithConfiguredProviders(configuredProviders),
+		admin.WithUsagePricingRecalculator(pricingRecalculator),
 		admin.WithAuditReader(auditReader),
 		admin.WithAuthKeys(authKeyService),
 		admin.WithAliases(aliasService),

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -823,9 +823,11 @@ func initAdmin(
 		}
 		pricingRecalculator, err = usage.NewPricingRecalculator(store)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create usage pricing recalculator: %w", err)
+			slog.Warn("usage pricing recalculation unavailable", "error", err)
+			pricingRecalculator = nil
 		}
 	}
+	runtimeConfig.PricingRecalculation = dashboardEnabledValue(pricingRecalculator != nil)
 
 	// Create audit reader (only from audit storage, because the usage-only storage
 	// schema may not include the audit_logs table/collection).

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -412,6 +412,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 			budgetResult.Service,
 			app,
 			dashboardRuntimeConfig(appCfg, usageEnabledForDashboard),
+			usagePricingRecalculationConfigured(appCfg),
 			appCfg.Server.BasePath,
 			adminCfg.UIEnabled,
 		)
@@ -801,6 +802,7 @@ func initAdmin(
 	budgetService *budget.Service,
 	runtimeRefresher admin.RuntimeRefresher,
 	runtimeConfig admin.DashboardConfigResponse,
+	usagePricingRecalculationEnabled bool,
 	basePath string,
 	uiEnabled bool,
 ) (*admin.Handler, *dashboard.Handler, error) {
@@ -821,13 +823,15 @@ func initAdmin(
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create usage reader: %w", err)
 		}
-		pricingRecalculator, err = usage.NewPricingRecalculator(store)
-		if err != nil {
-			slog.Warn("usage pricing recalculation unavailable", "error", err)
-			pricingRecalculator = nil
+		if usagePricingRecalculationEnabled {
+			pricingRecalculator, err = usage.NewPricingRecalculator(store)
+			if err != nil {
+				slog.Warn("usage pricing recalculation unavailable", "error", err)
+				pricingRecalculator = nil
+			}
 		}
 	}
-	runtimeConfig.PricingRecalculation = dashboardEnabledValue(pricingRecalculator != nil)
+	runtimeConfig.PricingRecalculation = dashboardEnabledValue(usagePricingRecalculationEnabled && pricingRecalculator != nil)
 
 	// Create audit reader (only from audit storage, because the usage-only storage
 	// schema may not include the audit_logs table/collection).
@@ -985,6 +989,10 @@ func dashboardRuntimeConfig(cfg *config.Config, usageEnabled bool) admin.Dashboa
 		RedisURL:             dashboardEnabledValue(simpleResponseCacheConfigured(cfg)),
 		SemanticCacheEnabled: dashboardEnabledValue(semanticResponseCacheConfigured(cfg)),
 	}
+}
+
+func usagePricingRecalculationConfigured(cfg *config.Config) bool {
+	return cfg != nil && cfg.Usage.Enabled && cfg.Usage.PricingRecalculationEnabled
 }
 
 func cacheAnalyticsConfigured(cfg *config.Config, usageEnabled bool) bool {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -509,3 +509,52 @@ func TestDashboardRuntimeConfig_HidesCacheAnalyticsWhenUsageDisabled(t *testing.
 		t.Fatalf("dashboardRuntimeConfig()[%q] = %q, want on", admin.DashboardConfigRedisURL, got)
 	}
 }
+
+func TestUsagePricingRecalculationConfigured(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *config.Config
+		want bool
+	}{
+		{
+			name: "enabled",
+			cfg: &config.Config{
+				Usage: config.UsageConfig{
+					Enabled:                     true,
+					PricingRecalculationEnabled: true,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "disabled by usage",
+			cfg: &config.Config{
+				Usage: config.UsageConfig{
+					Enabled:                     false,
+					PricingRecalculationEnabled: true,
+				},
+			},
+		},
+		{
+			name: "disabled by pricing switch",
+			cfg: &config.Config{
+				Usage: config.UsageConfig{
+					Enabled:                     true,
+					PricingRecalculationEnabled: false,
+				},
+			},
+		},
+		{
+			name: "nil config",
+			cfg:  nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := usagePricingRecalculationConfigured(test.cfg); got != test.want {
+				t.Fatalf("usagePricingRecalculationConfigured() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -1445,17 +1445,87 @@ func (r *ModelRegistry) GetModelMetadata(modelID string) *core.ModelMetadata {
 // and falling back to a reverse-index lookup via the model list.
 // Returns nil if no pricing is available.
 func (r *ModelRegistry) ResolvePricing(model, providerType string) *core.ModelPricing {
+	providerSelector := strings.TrimSpace(providerType)
+	if meta := r.getProviderModelMetadata(providerSelector, model); meta != nil && meta.Pricing != nil {
+		return meta.Pricing
+	}
+
 	meta := r.GetModelMetadata(model)
 	if meta != nil && meta.Pricing != nil {
 		return meta.Pricing
 	}
-	if providerType != "" {
-		meta = r.ResolveMetadata(providerType, model)
+	if providerSelector != "" {
+		meta = r.ResolveMetadata(r.metadataProviderType(providerSelector), r.metadataModelID(model))
 		if meta != nil && meta.Pricing != nil {
 			return meta.Pricing
 		}
 	}
 	return nil
+}
+
+func (r *ModelRegistry) getProviderModelMetadata(providerSelector, model string) *core.ModelMetadata {
+	providerSelector = strings.TrimSpace(providerSelector)
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return nil
+	}
+
+	modelProviderName, modelID := splitModelSelector(model)
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if modelProviderName != "" {
+		if meta := metadataFromProviderModel(r.modelsByProvider[modelProviderName], modelID); meta != nil {
+			return meta
+		}
+		if r.hasConfiguredProviderNameLocked(modelProviderName) {
+			return nil
+		}
+	}
+
+	if providerSelector == "" {
+		return nil
+	}
+	if meta := metadataFromProviderModel(r.modelsByProvider[providerSelector], model); meta != nil {
+		return meta
+	}
+	return nil
+}
+
+func metadataFromProviderModel(providerModels map[string]*ModelInfo, model string) *core.ModelMetadata {
+	if len(providerModels) == 0 {
+		return nil
+	}
+	info := providerModels[strings.TrimSpace(model)]
+	if info == nil {
+		return nil
+	}
+	return info.Model.Metadata
+}
+
+func (r *ModelRegistry) metadataProviderType(providerSelector string) string {
+	providerSelector = strings.TrimSpace(providerSelector)
+	if providerSelector == "" {
+		return ""
+	}
+	if providerType := r.GetProviderTypeForName(providerSelector); providerType != "" {
+		return providerType
+	}
+	return providerSelector
+}
+
+func (r *ModelRegistry) metadataModelID(model string) string {
+	model = strings.TrimSpace(model)
+	providerName, modelID := splitModelSelector(model)
+	if providerName == "" {
+		return model
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.hasConfiguredProviderNameLocked(providerName) {
+		return modelID
+	}
+	return model
 }
 
 // snapshotProviderTypes returns a copy of the providerTypes map for use outside the lock.

--- a/internal/providers/registry_metadata_override_test.go
+++ b/internal/providers/registry_metadata_override_test.go
@@ -125,6 +125,56 @@ func TestInitialize_OverrideMergesOnRemoteEnrichment(t *testing.T) {
 	}
 }
 
+func TestResolvePricingPrefersProviderSpecificMetadata(t *testing.T) {
+	registry := NewModelRegistry()
+
+	primary := &registryMockProvider{
+		name: "provider-primary",
+		modelsResponse: &core.ModelsResponse{
+			Object: "list",
+			Data: []core.Model{
+				{ID: "shared-model", Object: "model", OwnedBy: "openai"},
+			},
+		},
+	}
+	backup := &registryMockProvider{
+		name: "provider-backup",
+		modelsResponse: &core.ModelsResponse{
+			Object: "list",
+			Data: []core.Model{
+				{ID: "shared-model", Object: "model", OwnedBy: "openai"},
+			},
+		},
+	}
+	registry.RegisterProviderWithNameAndType(primary, "openai-primary", "openai")
+	registry.RegisterProviderWithNameAndType(backup, "openai-backup", "openai")
+
+	raw := []byte(`{"version":1,"updated_at":"2025-01-01T00:00:00Z","providers":{},"models":{},"provider_models":{}}`)
+	list, err := modeldata.Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	registry.SetModelList(list, raw)
+
+	primaryRate := 1.0
+	backupRate := 2.0
+	registry.SetProviderMetadataOverrides("openai-primary", map[string]*core.ModelMetadata{
+		"shared-model": {Pricing: &core.ModelPricing{InputPerMtok: &primaryRate}},
+	})
+	registry.SetProviderMetadataOverrides("openai-backup", map[string]*core.ModelMetadata{
+		"shared-model": {Pricing: &core.ModelPricing{InputPerMtok: &backupRate}},
+	})
+
+	if err := registry.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	pricing := registry.ResolvePricing("shared-model", "openai-backup")
+	if pricing == nil || pricing.InputPerMtok == nil || *pricing.InputPerMtok != backupRate {
+		t.Fatalf("ResolvePricing(shared-model, openai-backup) = %+v, want backup pricing", pricing)
+	}
+}
+
 // TestApplyConfigMetadataOverrides_NoOpPreservesPointerIdentity verifies that
 // an override whose fields already match the current metadata does not
 // replace the ModelInfo pointer — a concurrent reader that captured the

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -102,6 +102,20 @@ func AuthMiddlewareWithAuthenticator(masterKey string, authenticator BearerToken
 	}
 }
 
+// RequireConfiguredAuthMiddleware enforces authentication even on routes that
+// are otherwise covered by a global auth skip path.
+func RequireConfiguredAuthMiddleware(masterKey string, authenticator BearerTokenAuthenticator) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c *echo.Context) error {
+			if masterKey == "" && (authenticator == nil || !authenticator.Enabled()) {
+				authErr := authenticationError(c, "authentication is required for this operation")
+				return c.JSON(authErr.HTTPStatusCode(), authErr.ToJSON())
+			}
+			return AuthMiddlewareWithAuthenticator(masterKey, authenticator, nil)(next)(c)
+		}
+	}
+}
+
 func authFailureMessage(err error) string {
 	if err == nil {
 		return "invalid API key"

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -323,7 +323,7 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 		adminAPI.GET("/usage/models", cfg.AdminHandler.UsageByModel)
 		adminAPI.GET("/usage/user-paths", cfg.AdminHandler.UsageByUserPath)
 		adminAPI.GET("/usage/log", cfg.AdminHandler.UsageLog)
-		adminAPI.POST("/usage/recalculate-pricing", cfg.AdminHandler.RecalculateUsagePricing)
+		adminAPI.POST("/usage/recalculate-pricing", cfg.AdminHandler.RecalculateUsagePricing, RequireConfiguredAuthMiddleware(cfg.MasterKey, cfg.Authenticator))
 		adminAPI.GET("/audit/log", cfg.AdminHandler.AuditLog)
 		adminAPI.GET("/audit/conversation", cfg.AdminHandler.AuditConversation)
 		adminAPI.GET("/providers/status", cfg.AdminHandler.ProviderStatus)

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -323,6 +323,7 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 		adminAPI.GET("/usage/models", cfg.AdminHandler.UsageByModel)
 		adminAPI.GET("/usage/user-paths", cfg.AdminHandler.UsageByUserPath)
 		adminAPI.GET("/usage/log", cfg.AdminHandler.UsageLog)
+		adminAPI.POST("/usage/recalculate-pricing", cfg.AdminHandler.RecalculateUsagePricing)
 		adminAPI.GET("/audit/log", cfg.AdminHandler.AuditLog)
 		adminAPI.GET("/audit/conversation", cfg.AdminHandler.AuditConversation)
 		adminAPI.GET("/providers/status", cfg.AdminHandler.ProviderStatus)

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -782,6 +782,48 @@ func TestAdminAPI_SkipsAuthWithoutMasterKey(t *testing.T) {
 	}
 }
 
+func TestAdminPricingRecalculationRequiresAuthWithoutMasterKey(t *testing.T) {
+	mock := &mockProvider{}
+	adminHandler := admin.NewHandler(nil, nil)
+	unsafeSrv := New(mock, &Config{
+		AdminEndpointsEnabled: true,
+		AdminHandler:          adminHandler,
+	})
+	unsafeReq := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", strings.NewReader(`{"confirmation":"recalculate"}`))
+	unsafeReq.Header.Set("Content-Type", "application/json")
+	unsafeRec := httptest.NewRecorder()
+	unsafeSrv.ServeHTTP(unsafeRec, unsafeReq)
+
+	if unsafeRec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected pricing recalculation 401 when no auth is configured, got %d body=%s", unsafeRec.Code, unsafeRec.Body.String())
+	}
+
+	srv := New(mock, &Config{
+		Authenticator:         mockAuthenticator{enabled: true, tokenToID: map[string]string{"managed-token": "key-123"}},
+		AdminEndpointsEnabled: true,
+		AdminHandler:          adminHandler,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", strings.NewReader(`{"confirmation":"recalculate"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected pricing recalculation 401 without auth, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	authReq := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", strings.NewReader(`{"confirmation":"recalculate"}`))
+	authReq.Header.Set("Content-Type", "application/json")
+	authReq.Header.Set("Authorization", "Bearer managed-token")
+	authRec := httptest.NewRecorder()
+	srv.ServeHTTP(authRec, authReq)
+
+	if authRec.Code == http.StatusUnauthorized {
+		t.Fatalf("expected authorized pricing recalculation request to reach handler, got 401 body=%s", authRec.Body.String())
+	}
+}
+
 func TestAdminStaticAssets_SkipAuth(t *testing.T) {
 	mock := &mockProvider{}
 	dashHandler := newDashboardHandler(t)

--- a/internal/usage/cost.go
+++ b/internal/usage/cost.go
@@ -233,6 +233,8 @@ func extractInt(data map[string]any, key string) int {
 		return int(n)
 	case int:
 		return n
+	case int32:
+		return int(n)
 	case int64:
 		return int(n)
 	default:

--- a/internal/usage/factory.go
+++ b/internal/usage/factory.go
@@ -126,6 +126,36 @@ func NewReader(store storage.Storage) (UsageReader, error) {
 	)
 }
 
+// NewPricingRecalculator creates a PricingRecalculator from a storage backend.
+// Returns nil if storage is nil.
+func NewPricingRecalculator(store storage.Storage) (PricingRecalculator, error) {
+	if store == nil {
+		return nil, nil
+	}
+
+	return storage.ResolveBackend[PricingRecalculator](
+		store,
+		func(db *sql.DB) (PricingRecalculator, error) {
+			if db == nil {
+				return nil, fmt.Errorf("database connection is required")
+			}
+			return &SQLiteStore{db: db}, nil
+		},
+		func(pool *pgxpool.Pool) (PricingRecalculator, error) {
+			if pool == nil {
+				return nil, fmt.Errorf("connection pool is required")
+			}
+			return &PostgreSQLStore{pool: pool}, nil
+		},
+		func(db *mongo.Database) (PricingRecalculator, error) {
+			if db == nil {
+				return nil, fmt.Errorf("database is required")
+			}
+			return &MongoDBStore{collection: db.Collection("usage")}, nil
+		},
+	)
+}
+
 // createUsageStore creates the appropriate UsageStore for the given storage backend.
 func createUsageStore(store storage.Storage, retentionDays int) (UsageStore, error) {
 	return storage.ResolveBackend[UsageStore](

--- a/internal/usage/recalculate_pricing.go
+++ b/internal/usage/recalculate_pricing.go
@@ -36,6 +36,7 @@ type recalculationEntry struct {
 	ID           string
 	Model        string
 	Provider     string
+	ProviderName string
 	Endpoint     string
 	InputTokens  int
 	OutputTokens int
@@ -59,9 +60,10 @@ func normalizedRecalculatePricingParams(params RecalculatePricingParams) Recalcu
 }
 
 func recalculateEntryCosts(entry recalculationEntry, resolver PricingResolver) recalculationUpdate {
+	pricingProvider := effectiveRecalculationPricingProvider(entry.Provider, entry.ProviderName)
 	var pricing *core.ModelPricing
 	if resolver != nil {
-		pricing = resolver.ResolvePricing(entry.Model, entry.Provider)
+		pricing = resolver.ResolvePricing(entry.Model, pricingProvider)
 	}
 	effectivePricing := pricingForEndpoint(pricing, entry.Endpoint)
 	result := CalculateGranularCost(entry.InputTokens, entry.OutputTokens, entry.RawData, entry.Provider, effectivePricing)
@@ -73,6 +75,13 @@ func recalculateEntryCosts(entry recalculationEntry, resolver PricingResolver) r
 		Caveat:     result.Caveat,
 		HasPricing: effectivePricing != nil,
 	}
+}
+
+func effectiveRecalculationPricingProvider(provider, providerName string) string {
+	if name := strings.TrimSpace(providerName); name != "" {
+		return name
+	}
+	return strings.TrimSpace(provider)
 }
 
 func updateRecalculatePricingResult(result *RecalculatePricingResult, update recalculationUpdate) {

--- a/internal/usage/recalculate_pricing.go
+++ b/internal/usage/recalculate_pricing.go
@@ -1,0 +1,121 @@
+package usage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"gomodel/internal/core"
+)
+
+// RecalculatePricingParams identifies the stored usage rows whose costs should
+// be recalculated from the latest model pricing metadata.
+type RecalculatePricingParams struct {
+	UsageQueryParams
+	Model    string
+	Provider string
+}
+
+// RecalculatePricingResult summarizes a pricing recalculation run.
+type RecalculatePricingResult struct {
+	Status         string `json:"status"`
+	Matched        int64  `json:"matched"`
+	Recalculated   int64  `json:"recalculated"`
+	WithPricing    int64  `json:"with_pricing"`
+	WithoutPricing int64  `json:"without_pricing"`
+}
+
+// PricingRecalculator updates persisted usage cost fields from current pricing metadata.
+type PricingRecalculator interface {
+	RecalculatePricing(ctx context.Context, params RecalculatePricingParams, resolver PricingResolver) (RecalculatePricingResult, error)
+}
+
+type recalculationEntry struct {
+	ID           string
+	Model        string
+	Provider     string
+	Endpoint     string
+	InputTokens  int
+	OutputTokens int
+	RawData      map[string]any
+}
+
+type recalculationUpdate struct {
+	ID         string
+	InputCost  *float64
+	OutputCost *float64
+	TotalCost  *float64
+	Caveat     string
+	HasPricing bool
+}
+
+func normalizedRecalculatePricingParams(params RecalculatePricingParams) RecalculatePricingParams {
+	params.Model = strings.TrimSpace(params.Model)
+	params.Provider = strings.TrimSpace(params.Provider)
+	params.CacheMode = CacheModeAll
+	return params
+}
+
+func recalculateEntryCosts(entry recalculationEntry, resolver PricingResolver) recalculationUpdate {
+	var pricing *core.ModelPricing
+	if resolver != nil {
+		pricing = resolver.ResolvePricing(entry.Model, entry.Provider)
+	}
+	effectivePricing := pricingForEndpoint(pricing, entry.Endpoint)
+	result := CalculateGranularCost(entry.InputTokens, entry.OutputTokens, entry.RawData, entry.Provider, effectivePricing)
+	return recalculationUpdate{
+		ID:         entry.ID,
+		InputCost:  result.InputCost,
+		OutputCost: result.OutputCost,
+		TotalCost:  result.TotalCost,
+		Caveat:     result.Caveat,
+		HasPricing: effectivePricing != nil,
+	}
+}
+
+func updateRecalculatePricingResult(result *RecalculatePricingResult, update recalculationUpdate) {
+	result.Matched++
+	result.Recalculated++
+	if update.HasPricing {
+		result.WithPricing++
+	} else {
+		result.WithoutPricing++
+	}
+}
+
+func finalizeRecalculatePricingResult(result RecalculatePricingResult) RecalculatePricingResult {
+	if result.Status == "" {
+		result.Status = "ok"
+	}
+	return result
+}
+
+func rawDataFromJSON(raw, entryID string) map[string]any {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal([]byte(raw), &data); err != nil {
+		slog.Warn("failed to unmarshal usage raw_data for pricing recalculation", "id", entryID, "error", err)
+		return nil
+	}
+	return data
+}
+
+func nullableFloat(v *float64) any {
+	if v == nil {
+		return nil
+	}
+	return *v
+}
+
+func recalculatePricingUnavailable(resolver PricingResolver) error {
+	if resolver == nil {
+		return fmt.Errorf("pricing resolver is required")
+	}
+	return nil
+}

--- a/internal/usage/recalculate_pricing_mongodb.go
+++ b/internal/usage/recalculate_pricing_mongodb.go
@@ -2,9 +2,13 @@ package usage
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log/slog"
+	"strings"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
 // RecalculatePricing updates matching MongoDB usage documents with costs
@@ -30,15 +34,68 @@ func (s *MongoDBStore) RecalculatePricing(ctx context.Context, params Recalculat
 	_, err = session.WithTransaction(ctx, func(txCtx context.Context) (any, error) {
 		next, err := s.recalculatePricingInMongoTransaction(txCtx, filter, resolver)
 		if err != nil {
+			if isMongoTransactionCapabilityError(err) {
+				return nil, &mongoTransactionFallbackError{err: err}
+			}
 			return nil, err
 		}
 		result = next
 		return nil, nil
 	})
 	if err != nil {
+		if fallbackErr := mongoTransactionFallbackCause(err); fallbackErr != nil || isMongoTransactionCapabilityError(err) {
+			if fallbackErr == nil {
+				fallbackErr = err
+			}
+			slog.Warn("MongoDB transactions unavailable for pricing recalculation; falling back to non-transactional update", "error", fallbackErr)
+			result, err := s.recalculatePricingInMongoTransaction(ctx, filter, resolver)
+			if err != nil {
+				return RecalculatePricingResult{}, fmt.Errorf("recalculate mongodb usage costs without transaction: %w", errors.Join(fallbackErr, err))
+			}
+			return finalizeRecalculatePricingResult(result), nil
+		}
 		return RecalculatePricingResult{}, fmt.Errorf("mongodb pricing recalculation transaction: %w", err)
 	}
 	return finalizeRecalculatePricingResult(result), nil
+}
+
+type mongoTransactionFallbackError struct {
+	err error
+}
+
+func (e *mongoTransactionFallbackError) Error() string {
+	if e == nil || e.err == nil {
+		return ""
+	}
+	return e.err.Error()
+}
+
+func mongoTransactionFallbackCause(err error) error {
+	var fallbackErr *mongoTransactionFallbackError
+	if errors.As(err, &fallbackErr) {
+		return fallbackErr.err
+	}
+	return nil
+}
+
+func isMongoTransactionCapabilityError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var commandErr mongo.CommandError
+	if errors.As(err, &commandErr) && commandErr.HasErrorCode(20) {
+		return true
+	}
+	var labeled mongo.LabeledError
+	if errors.As(err, &labeled) && labeled.HasErrorLabel("TransientTransactionError") {
+		message := strings.ToLower(err.Error())
+		return strings.Contains(message, "transaction") &&
+			(strings.Contains(message, "not supported") ||
+				strings.Contains(message, "not allowed") ||
+				strings.Contains(message, "replica set"))
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "transaction numbers are only allowed on a replica set member or mongos")
 }
 
 func (s *MongoDBStore) recalculatePricingInMongoTransaction(ctx context.Context, filter bson.D, resolver PricingResolver) (RecalculatePricingResult, error) {

--- a/internal/usage/recalculate_pricing_mongodb.go
+++ b/internal/usage/recalculate_pricing_mongodb.go
@@ -20,6 +20,28 @@ func (s *MongoDBStore) RecalculatePricing(ctx context.Context, params Recalculat
 		return RecalculatePricingResult{}, err
 	}
 
+	session, err := s.collection.Database().Client().StartSession()
+	if err != nil {
+		return RecalculatePricingResult{}, fmt.Errorf("start mongodb pricing recalculation transaction: %w", err)
+	}
+	defer session.EndSession(ctx)
+
+	var result RecalculatePricingResult
+	_, err = session.WithTransaction(ctx, func(txCtx context.Context) (any, error) {
+		next, err := s.recalculatePricingInMongoTransaction(txCtx, filter, resolver)
+		if err != nil {
+			return nil, err
+		}
+		result = next
+		return nil, nil
+	})
+	if err != nil {
+		return RecalculatePricingResult{}, fmt.Errorf("mongodb pricing recalculation transaction: %w", err)
+	}
+	return finalizeRecalculatePricingResult(result), nil
+}
+
+func (s *MongoDBStore) recalculatePricingInMongoTransaction(ctx context.Context, filter bson.D, resolver PricingResolver) (RecalculatePricingResult, error) {
 	cursor, err := s.collection.Find(ctx, filter)
 	if err != nil {
 		return RecalculatePricingResult{}, fmt.Errorf("query mongodb usage costs for recalculation: %w", err)

--- a/internal/usage/recalculate_pricing_mongodb.go
+++ b/internal/usage/recalculate_pricing_mongodb.go
@@ -1,0 +1,107 @@
+package usage
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// RecalculatePricing updates matching MongoDB usage documents with costs
+// computed from the supplied pricing resolver.
+func (s *MongoDBStore) RecalculatePricing(ctx context.Context, params RecalculatePricingParams, resolver PricingResolver) (RecalculatePricingResult, error) {
+	if err := recalculatePricingUnavailable(resolver); err != nil {
+		return RecalculatePricingResult{}, err
+	}
+	params = normalizedRecalculatePricingParams(params)
+
+	filter, err := mongoRecalculationFilter(params)
+	if err != nil {
+		return RecalculatePricingResult{}, err
+	}
+
+	cursor, err := s.collection.Find(ctx, filter)
+	if err != nil {
+		return RecalculatePricingResult{}, fmt.Errorf("query mongodb usage costs for recalculation: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	result := RecalculatePricingResult{}
+	for cursor.Next(ctx) {
+		var row struct {
+			ID           string         `bson:"_id"`
+			Model        string         `bson:"model"`
+			Provider     string         `bson:"provider"`
+			Endpoint     string         `bson:"endpoint"`
+			InputTokens  int            `bson:"input_tokens"`
+			OutputTokens int            `bson:"output_tokens"`
+			RawData      map[string]any `bson:"raw_data"`
+		}
+		if err := cursor.Decode(&row); err != nil {
+			return RecalculatePricingResult{}, fmt.Errorf("scan mongodb usage cost row: %w", err)
+		}
+
+		update := recalculateEntryCosts(recalculationEntry{
+			ID:           row.ID,
+			Model:        row.Model,
+			Provider:     row.Provider,
+			Endpoint:     row.Endpoint,
+			InputTokens:  row.InputTokens,
+			OutputTokens: row.OutputTokens,
+			RawData:      row.RawData,
+		}, resolver)
+
+		if _, err := s.collection.UpdateByID(ctx, update.ID, mongoRecalculationUpdate(update)); err != nil {
+			return RecalculatePricingResult{}, fmt.Errorf("update mongodb usage cost %s: %w", update.ID, err)
+		}
+		updateRecalculatePricingResult(&result, update)
+	}
+	if err := cursor.Err(); err != nil {
+		return RecalculatePricingResult{}, fmt.Errorf("iterate mongodb usage costs for recalculation: %w", err)
+	}
+	return finalizeRecalculatePricingResult(result), nil
+}
+
+func mongoRecalculationFilter(params RecalculatePricingParams) (bson.D, error) {
+	filter, err := mongoUsageMatchFilters(params.UsageQueryParams)
+	if err != nil {
+		return nil, err
+	}
+	if params.Model != "" {
+		filter = append(filter, bson.E{Key: "model", Value: params.Model})
+	}
+	if params.Provider != "" {
+		filter = mongoAndFilters(filter, bson.D{{Key: "$or", Value: bson.A{
+			bson.D{{Key: "provider", Value: params.Provider}},
+			bson.D{{Key: "provider_name", Value: params.Provider}},
+		}}})
+	}
+	return filter, nil
+}
+
+func mongoRecalculationUpdate(update recalculationUpdate) bson.D {
+	set := bson.D{{Key: "costs_calculation_caveat", Value: update.Caveat}}
+	unset := bson.D{}
+
+	if update.InputCost != nil {
+		set = append(set, bson.E{Key: "input_cost", Value: *update.InputCost})
+	} else {
+		unset = append(unset, bson.E{Key: "input_cost", Value: ""})
+	}
+	if update.OutputCost != nil {
+		set = append(set, bson.E{Key: "output_cost", Value: *update.OutputCost})
+	} else {
+		unset = append(unset, bson.E{Key: "output_cost", Value: ""})
+	}
+	if update.TotalCost != nil {
+		set = append(set, bson.E{Key: "total_cost", Value: *update.TotalCost})
+	} else {
+		unset = append(unset, bson.E{Key: "total_cost", Value: ""})
+	}
+
+	result := bson.D{{Key: "$set", Value: set}}
+	if len(unset) > 0 {
+		result = append(result, bson.E{Key: "$unset", Value: unset})
+	}
+	return result
+}

--- a/internal/usage/recalculate_pricing_mongodb.go
+++ b/internal/usage/recalculate_pricing_mongodb.go
@@ -111,6 +111,7 @@ func (s *MongoDBStore) recalculatePricingInMongoTransaction(ctx context.Context,
 			ID           string         `bson:"_id"`
 			Model        string         `bson:"model"`
 			Provider     string         `bson:"provider"`
+			ProviderName string         `bson:"provider_name"`
 			Endpoint     string         `bson:"endpoint"`
 			InputTokens  int            `bson:"input_tokens"`
 			OutputTokens int            `bson:"output_tokens"`
@@ -124,6 +125,7 @@ func (s *MongoDBStore) recalculatePricingInMongoTransaction(ctx context.Context,
 			ID:           row.ID,
 			Model:        row.Model,
 			Provider:     row.Provider,
+			ProviderName: row.ProviderName,
 			Endpoint:     row.Endpoint,
 			InputTokens:  row.InputTokens,
 			OutputTokens: row.OutputTokens,

--- a/internal/usage/recalculate_pricing_mongodb.go
+++ b/internal/usage/recalculate_pricing_mongodb.go
@@ -11,6 +11,23 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
+type mongoPricingSession interface {
+	WithTransaction(context.Context, func(context.Context) (any, error)) (any, error)
+	EndSession(context.Context)
+}
+
+type mongoDriverPricingSession struct {
+	session *mongo.Session
+}
+
+func (s mongoDriverPricingSession) WithTransaction(ctx context.Context, fn func(context.Context) (any, error)) (any, error) {
+	return s.session.WithTransaction(ctx, fn)
+}
+
+func (s mongoDriverPricingSession) EndSession(ctx context.Context) {
+	s.session.EndSession(ctx)
+}
+
 // RecalculatePricing updates matching MongoDB usage documents with costs
 // computed from the supplied pricing resolver.
 func (s *MongoDBStore) RecalculatePricing(ctx context.Context, params RecalculatePricingParams, resolver PricingResolver) (RecalculatePricingResult, error) {
@@ -24,7 +41,7 @@ func (s *MongoDBStore) RecalculatePricing(ctx context.Context, params Recalculat
 		return RecalculatePricingResult{}, err
 	}
 
-	session, err := s.collection.Database().Client().StartSession()
+	session, err := s.startMongoPricingSession()
 	if err != nil {
 		return RecalculatePricingResult{}, fmt.Errorf("start mongodb pricing recalculation transaction: %w", err)
 	}
@@ -32,7 +49,7 @@ func (s *MongoDBStore) RecalculatePricing(ctx context.Context, params Recalculat
 
 	var result RecalculatePricingResult
 	_, err = session.WithTransaction(ctx, func(txCtx context.Context) (any, error) {
-		next, err := s.recalculatePricingInMongoTransaction(txCtx, filter, resolver)
+		next, err := s.recalculatePricingDocumentsInContext(txCtx, filter, resolver)
 		if err != nil {
 			if isMongoTransactionCapabilityError(err) {
 				return nil, &mongoTransactionFallbackError{err: err}
@@ -48,7 +65,7 @@ func (s *MongoDBStore) RecalculatePricing(ctx context.Context, params Recalculat
 				fallbackErr = err
 			}
 			slog.Warn("MongoDB transactions unavailable for pricing recalculation; falling back to non-transactional update", "error", fallbackErr)
-			result, err := s.recalculatePricingInMongoTransaction(ctx, filter, resolver)
+			result, err := s.recalculatePricingDocumentsInContext(ctx, filter, resolver)
 			if err != nil {
 				return RecalculatePricingResult{}, fmt.Errorf("recalculate mongodb usage costs without transaction: %w", errors.Join(fallbackErr, err))
 			}
@@ -57,6 +74,27 @@ func (s *MongoDBStore) RecalculatePricing(ctx context.Context, params Recalculat
 		return RecalculatePricingResult{}, fmt.Errorf("mongodb pricing recalculation transaction: %w", err)
 	}
 	return finalizeRecalculatePricingResult(result), nil
+}
+
+func (s *MongoDBStore) startMongoPricingSession() (mongoPricingSession, error) {
+	if s.startPricingSession != nil {
+		return s.startPricingSession()
+	}
+	if s.collection == nil {
+		return nil, fmt.Errorf("mongodb usage collection is not configured")
+	}
+	session, err := s.collection.Database().Client().StartSession()
+	if err != nil {
+		return nil, err
+	}
+	return mongoDriverPricingSession{session: session}, nil
+}
+
+func (s *MongoDBStore) recalculatePricingDocumentsInContext(ctx context.Context, filter bson.D, resolver PricingResolver) (RecalculatePricingResult, error) {
+	if s.recalculatePricingDocuments != nil {
+		return s.recalculatePricingDocuments(ctx, filter, resolver)
+	}
+	return s.recalculatePricingInMongoTransaction(ctx, filter, resolver)
 }
 
 type mongoTransactionFallbackError struct {

--- a/internal/usage/recalculate_pricing_mongodb_test.go
+++ b/internal/usage/recalculate_pricing_mongodb_test.go
@@ -1,0 +1,228 @@
+package usage
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+
+	"gomodel/internal/core"
+)
+
+type mongoPricingTestContextKey struct{}
+
+type mockMongoPricingSession struct {
+	invokeTransaction    bool
+	withTransactionError error
+	withTransactionCalls int
+	endSessionCalls      int
+}
+
+func (s *mockMongoPricingSession) WithTransaction(ctx context.Context, fn func(context.Context) (any, error)) (any, error) {
+	s.withTransactionCalls++
+	if s.invokeTransaction {
+		nextCtx := context.WithValue(ctx, mongoPricingTestContextKey{}, "transaction")
+		result, err := fn(nextCtx)
+		if err != nil {
+			return result, err
+		}
+	}
+	if s.withTransactionError != nil {
+		return nil, s.withTransactionError
+	}
+	return nil, nil
+}
+
+func (s *mockMongoPricingSession) EndSession(context.Context) {
+	s.endSessionCalls++
+}
+
+func TestMongoDBStoreRecalculatePricingTransactionFlow(t *testing.T) {
+	session := &mockMongoPricingSession{invokeTransaction: true}
+	recalculateCalls := 0
+	store := &MongoDBStore{
+		startPricingSession: func() (mongoPricingSession, error) {
+			return session, nil
+		},
+		recalculatePricingDocuments: func(ctx context.Context, filter bson.D, _ PricingResolver) (RecalculatePricingResult, error) {
+			recalculateCalls++
+			if got := ctx.Value(mongoPricingTestContextKey{}); got != "transaction" {
+				t.Fatalf("transaction context marker = %v, want transaction", got)
+			}
+			if !mongoFilterHasProviderSelector(filter, "primary-openai") {
+				t.Fatalf("filter = %#v, want provider/provider_name selector", filter)
+			}
+			return RecalculatePricingResult{Matched: 1, Recalculated: 1, WithPricing: 1}, nil
+		},
+	}
+
+	result, err := store.RecalculatePricing(context.Background(), RecalculatePricingParams{
+		Model:    " gpt-4o ",
+		Provider: " primary-openai ",
+	}, staticTestPricingResolver{})
+	if err != nil {
+		t.Fatalf("RecalculatePricing() error = %v", err)
+	}
+	if result.Status != "ok" || result.Matched != 1 || result.Recalculated != 1 || result.WithPricing != 1 {
+		t.Fatalf("result = %+v, want finalized successful result", result)
+	}
+	if session.withTransactionCalls != 1 || session.endSessionCalls != 1 {
+		t.Fatalf("session calls = transaction %d end %d, want 1/1", session.withTransactionCalls, session.endSessionCalls)
+	}
+	if recalculateCalls != 1 {
+		t.Fatalf("recalculate calls = %d, want 1", recalculateCalls)
+	}
+}
+
+func TestMongoDBStoreRecalculatePricingFallsBackWhenTransactionsUnavailable(t *testing.T) {
+	originalLogger := slog.Default()
+	var logs bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	defer slog.SetDefault(originalLogger)
+
+	session := &mockMongoPricingSession{
+		withTransactionError: errors.New("transaction numbers are only allowed on a replica set member or mongos"),
+	}
+	recalculateCalls := 0
+	store := &MongoDBStore{
+		startPricingSession: func() (mongoPricingSession, error) {
+			return session, nil
+		},
+		recalculatePricingDocuments: func(ctx context.Context, _ bson.D, _ PricingResolver) (RecalculatePricingResult, error) {
+			recalculateCalls++
+			if got := ctx.Value(mongoPricingTestContextKey{}); got != nil {
+				t.Fatalf("fallback context marker = %v, want nil", got)
+			}
+			return RecalculatePricingResult{Matched: 2, Recalculated: 2, WithPricing: 2}, nil
+		},
+	}
+
+	result, err := store.RecalculatePricing(context.Background(), RecalculatePricingParams{}, staticTestPricingResolver{})
+	if err != nil {
+		t.Fatalf("RecalculatePricing() error = %v", err)
+	}
+	if result.Status != "ok" || result.Matched != 2 || result.Recalculated != 2 || result.WithPricing != 2 {
+		t.Fatalf("result = %+v, want finalized fallback result", result)
+	}
+	if session.withTransactionCalls != 1 || session.endSessionCalls != 1 {
+		t.Fatalf("session calls = transaction %d end %d, want 1/1", session.withTransactionCalls, session.endSessionCalls)
+	}
+	if recalculateCalls != 1 {
+		t.Fatalf("recalculate calls = %d, want 1", recalculateCalls)
+	}
+	if !strings.Contains(logs.String(), "falling back to non-transactional update") {
+		t.Fatalf("logs = %q, want fallback warning", logs.String())
+	}
+}
+
+func TestMongoDBStoreRecalculatePricingFallsBackWhenTransactionBodyReportsCapabilityError(t *testing.T) {
+	session := &mockMongoPricingSession{invokeTransaction: true}
+	recalculateCalls := 0
+	store := &MongoDBStore{
+		startPricingSession: func() (mongoPricingSession, error) {
+			return session, nil
+		},
+		recalculatePricingDocuments: func(ctx context.Context, _ bson.D, _ PricingResolver) (RecalculatePricingResult, error) {
+			recalculateCalls++
+			switch recalculateCalls {
+			case 1:
+				if got := ctx.Value(mongoPricingTestContextKey{}); got != "transaction" {
+					t.Fatalf("transaction context marker = %v, want transaction", got)
+				}
+				return RecalculatePricingResult{}, errors.New("transaction numbers are only allowed on a replica set member or mongos")
+			case 2:
+				if got := ctx.Value(mongoPricingTestContextKey{}); got != nil {
+					t.Fatalf("fallback context marker = %v, want nil", got)
+				}
+				return RecalculatePricingResult{Matched: 1, Recalculated: 1, WithPricing: 1}, nil
+			default:
+				t.Fatalf("unexpected recalculate call %d", recalculateCalls)
+				return RecalculatePricingResult{}, nil
+			}
+		},
+	}
+
+	result, err := store.RecalculatePricing(context.Background(), RecalculatePricingParams{}, staticTestPricingResolver{})
+	if err != nil {
+		t.Fatalf("RecalculatePricing() error = %v", err)
+	}
+	if result.Status != "ok" || result.Matched != 1 || result.Recalculated != 1 || result.WithPricing != 1 {
+		t.Fatalf("result = %+v, want finalized fallback result", result)
+	}
+	if recalculateCalls != 2 {
+		t.Fatalf("recalculate calls = %d, want 2", recalculateCalls)
+	}
+}
+
+func TestMongoDBStoreRecalculatePricingUsesProviderNameForPricing(t *testing.T) {
+	inputRate := 2.0
+	resolver := &recordingPricingResolver{
+		pricing: &core.ModelPricing{InputPerMtok: &inputRate},
+	}
+	session := &mockMongoPricingSession{invokeTransaction: true}
+	var capturedFilter bson.D
+	store := &MongoDBStore{
+		startPricingSession: func() (mongoPricingSession, error) {
+			return session, nil
+		},
+		recalculatePricingDocuments: func(_ context.Context, filter bson.D, resolver PricingResolver) (RecalculatePricingResult, error) {
+			capturedFilter = filter
+			update := recalculateEntryCosts(recalculationEntry{
+				ID:           "usage-1",
+				Model:        "gpt-4o",
+				Provider:     "openai",
+				ProviderName: "primary-openai",
+				InputTokens:  1_000_000,
+			}, resolver)
+			result := RecalculatePricingResult{}
+			updateRecalculatePricingResult(&result, update)
+			return result, nil
+		},
+	}
+
+	result, err := store.RecalculatePricing(context.Background(), RecalculatePricingParams{
+		Model:    "gpt-4o",
+		Provider: " primary-openai ",
+	}, resolver)
+	if err != nil {
+		t.Fatalf("RecalculatePricing() error = %v", err)
+	}
+	if result.WithPricing != 1 {
+		t.Fatalf("result = %+v, want pricing match", result)
+	}
+	if resolver.provider != "primary-openai" {
+		t.Fatalf("ResolvePricing provider = %q, want primary-openai", resolver.provider)
+	}
+	if !mongoFilterHasProviderSelector(capturedFilter, "primary-openai") {
+		t.Fatalf("filter = %#v, want provider/provider_name selector", capturedFilter)
+	}
+}
+
+func mongoFilterHasProviderSelector(filter bson.D, selector string) bool {
+	var hasProvider, hasProviderName bool
+	var visit func(any)
+	visit = func(value any) {
+		switch typed := value.(type) {
+		case bson.D:
+			for _, elem := range typed {
+				if elem.Key == "provider" && elem.Value == selector {
+					hasProvider = true
+				}
+				if elem.Key == "provider_name" && elem.Value == selector {
+					hasProviderName = true
+				}
+				visit(elem.Value)
+			}
+		case bson.A:
+			for _, item := range typed {
+				visit(item)
+			}
+		}
+	}
+	visit(filter)
+	return hasProvider && hasProviderName
+}

--- a/internal/usage/recalculate_pricing_postgresql.go
+++ b/internal/usage/recalculate_pricing_postgresql.go
@@ -57,14 +57,14 @@ func (s *PostgreSQLStore) postgresRecalculationEntries(ctx context.Context, para
 	if err != nil {
 		return nil, err
 	}
-	if params.Model != "" {
-		conditions = append(conditions, fmt.Sprintf("model = $%d", nextIdx))
-		args = append(args, params.Model)
-		nextIdx++
-	}
 	if params.Provider != "" {
 		conditions = append(conditions, fmt.Sprintf("(provider = $%d OR provider_name = $%d)", nextIdx, nextIdx+1))
 		args = append(args, params.Provider, params.Provider)
+		nextIdx += 2
+	}
+	if params.Model != "" {
+		conditions = append(conditions, fmt.Sprintf("model = $%d", nextIdx))
+		args = append(args, params.Model)
 	}
 
 	rows, err := s.pool.Query(ctx, `

--- a/internal/usage/recalculate_pricing_postgresql.go
+++ b/internal/usage/recalculate_pricing_postgresql.go
@@ -1,0 +1,102 @@
+package usage
+
+import (
+	"context"
+	"fmt"
+)
+
+// RecalculatePricing updates matching PostgreSQL usage rows with costs computed
+// from the supplied pricing resolver.
+func (s *PostgreSQLStore) RecalculatePricing(ctx context.Context, params RecalculatePricingParams, resolver PricingResolver) (RecalculatePricingResult, error) {
+	if err := recalculatePricingUnavailable(resolver); err != nil {
+		return RecalculatePricingResult{}, err
+	}
+	params = normalizedRecalculatePricingParams(params)
+
+	entries, err := s.postgresRecalculationEntries(ctx, params)
+	if err != nil {
+		return RecalculatePricingResult{}, err
+	}
+	if len(entries) == 0 {
+		return finalizeRecalculatePricingResult(RecalculatePricingResult{}), nil
+	}
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return RecalculatePricingResult{}, fmt.Errorf("begin postgres pricing recalculation: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	result := RecalculatePricingResult{}
+	for _, entry := range entries {
+		update := recalculateEntryCosts(entry, resolver)
+		if _, err := tx.Exec(ctx, `
+			UPDATE usage
+			SET input_cost = $1, output_cost = $2, total_cost = $3, costs_calculation_caveat = $4
+			WHERE id = $5::uuid
+		`,
+			nullableFloat(update.InputCost),
+			nullableFloat(update.OutputCost),
+			nullableFloat(update.TotalCost),
+			update.Caveat,
+			update.ID,
+		); err != nil {
+			return RecalculatePricingResult{}, fmt.Errorf("update postgres usage cost %s: %w", update.ID, err)
+		}
+		updateRecalculatePricingResult(&result, update)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return RecalculatePricingResult{}, fmt.Errorf("commit postgres pricing recalculation: %w", err)
+	}
+	return finalizeRecalculatePricingResult(result), nil
+}
+
+func (s *PostgreSQLStore) postgresRecalculationEntries(ctx context.Context, params RecalculatePricingParams) ([]recalculationEntry, error) {
+	conditions, args, nextIdx, err := pgUsageConditions(params.UsageQueryParams, 1)
+	if err != nil {
+		return nil, err
+	}
+	if params.Model != "" {
+		conditions = append(conditions, fmt.Sprintf("model = $%d", nextIdx))
+		args = append(args, params.Model)
+		nextIdx++
+	}
+	if params.Provider != "" {
+		conditions = append(conditions, fmt.Sprintf("(provider = $%d OR provider_name = $%d)", nextIdx, nextIdx+1))
+		args = append(args, params.Provider, params.Provider)
+	}
+
+	rows, err := s.pool.Query(ctx, `
+		SELECT id::text, model, provider, endpoint, input_tokens, output_tokens, raw_data::text
+		FROM usage`+buildWhereClause(conditions), args...)
+	if err != nil {
+		return nil, fmt.Errorf("query postgres usage costs for recalculation: %w", err)
+	}
+	defer rows.Close()
+
+	entries := make([]recalculationEntry, 0)
+	for rows.Next() {
+		var entry recalculationEntry
+		var rawData *string
+		if err := rows.Scan(
+			&entry.ID,
+			&entry.Model,
+			&entry.Provider,
+			&entry.Endpoint,
+			&entry.InputTokens,
+			&entry.OutputTokens,
+			&rawData,
+		); err != nil {
+			return nil, fmt.Errorf("scan postgres usage cost row: %w", err)
+		}
+		if rawData != nil {
+			entry.RawData = rawDataFromJSON(*rawData, entry.ID)
+		}
+		entries = append(entries, entry)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate postgres usage costs for recalculation: %w", err)
+	}
+	return entries, nil
+}

--- a/internal/usage/recalculate_pricing_postgresql.go
+++ b/internal/usage/recalculate_pricing_postgresql.go
@@ -3,6 +3,8 @@ package usage
 import (
 	"context"
 	"fmt"
+
+	"github.com/jackc/pgx/v5"
 )
 
 // RecalculatePricing updates matching PostgreSQL usage rows with costs computed
@@ -13,19 +15,19 @@ func (s *PostgreSQLStore) RecalculatePricing(ctx context.Context, params Recalcu
 	}
 	params = normalizedRecalculatePricingParams(params)
 
-	entries, err := s.postgresRecalculationEntries(ctx, params)
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return RecalculatePricingResult{}, fmt.Errorf("begin postgres pricing recalculation: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	entries, err := postgresRecalculationEntries(ctx, tx, params)
 	if err != nil {
 		return RecalculatePricingResult{}, err
 	}
 	if len(entries) == 0 {
 		return finalizeRecalculatePricingResult(RecalculatePricingResult{}), nil
 	}
-
-	tx, err := s.pool.Begin(ctx)
-	if err != nil {
-		return RecalculatePricingResult{}, fmt.Errorf("begin postgres pricing recalculation: %w", err)
-	}
-	defer func() { _ = tx.Rollback(ctx) }()
 
 	result := RecalculatePricingResult{}
 	for _, entry := range entries {
@@ -52,7 +54,7 @@ func (s *PostgreSQLStore) RecalculatePricing(ctx context.Context, params Recalcu
 	return finalizeRecalculatePricingResult(result), nil
 }
 
-func (s *PostgreSQLStore) postgresRecalculationEntries(ctx context.Context, params RecalculatePricingParams) ([]recalculationEntry, error) {
+func postgresRecalculationEntries(ctx context.Context, tx pgx.Tx, params RecalculatePricingParams) ([]recalculationEntry, error) {
 	conditions, args, nextIdx, err := pgUsageConditions(params.UsageQueryParams, 1)
 	if err != nil {
 		return nil, err
@@ -67,9 +69,10 @@ func (s *PostgreSQLStore) postgresRecalculationEntries(ctx context.Context, para
 		args = append(args, params.Model)
 	}
 
-	rows, err := s.pool.Query(ctx, `
+	rows, err := tx.Query(ctx, `
 		SELECT id::text, model, provider, endpoint, input_tokens, output_tokens, raw_data::text
-		FROM usage`+buildWhereClause(conditions), args...)
+		FROM usage`+buildWhereClause(conditions)+`
+		FOR UPDATE`, args...)
 	if err != nil {
 		return nil, fmt.Errorf("query postgres usage costs for recalculation: %w", err)
 	}

--- a/internal/usage/recalculate_pricing_postgresql.go
+++ b/internal/usage/recalculate_pricing_postgresql.go
@@ -2,6 +2,7 @@ package usage
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
@@ -70,7 +71,7 @@ func postgresRecalculationEntries(ctx context.Context, tx pgx.Tx, params Recalcu
 	}
 
 	rows, err := tx.Query(ctx, `
-		SELECT id::text, model, provider, endpoint, input_tokens, output_tokens, raw_data::text
+		SELECT id::text, model, provider, provider_name, endpoint, input_tokens, output_tokens, raw_data::text
 		FROM usage`+buildWhereClause(conditions)+`
 		FOR UPDATE`, args...)
 	if err != nil {
@@ -81,17 +82,22 @@ func postgresRecalculationEntries(ctx context.Context, tx pgx.Tx, params Recalcu
 	entries := make([]recalculationEntry, 0)
 	for rows.Next() {
 		var entry recalculationEntry
+		var providerName sql.NullString
 		var rawData *string
 		if err := rows.Scan(
 			&entry.ID,
 			&entry.Model,
 			&entry.Provider,
+			&providerName,
 			&entry.Endpoint,
 			&entry.InputTokens,
 			&entry.OutputTokens,
 			&rawData,
 		); err != nil {
 			return nil, fmt.Errorf("scan postgres usage cost row: %w", err)
+		}
+		if providerName.Valid {
+			entry.ProviderName = providerName.String
 		}
 		if rawData != nil {
 			entry.RawData = rawDataFromJSON(*rawData, entry.ID)

--- a/internal/usage/recalculate_pricing_sqlite.go
+++ b/internal/usage/recalculate_pricing_sqlite.go
@@ -74,7 +74,7 @@ func (s *SQLiteStore) sqliteRecalculationEntries(ctx context.Context, params Rec
 	}
 
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, model, provider, endpoint, input_tokens, output_tokens, raw_data
+		SELECT id, model, provider, provider_name, endpoint, input_tokens, output_tokens, raw_data
 		FROM usage`+buildWhereClause(conditions), args...)
 	if err != nil {
 		return nil, fmt.Errorf("query sqlite usage costs for recalculation: %w", err)
@@ -84,17 +84,22 @@ func (s *SQLiteStore) sqliteRecalculationEntries(ctx context.Context, params Rec
 	entries := make([]recalculationEntry, 0)
 	for rows.Next() {
 		var entry recalculationEntry
+		var providerName sql.NullString
 		var rawData sql.NullString
 		if err := rows.Scan(
 			&entry.ID,
 			&entry.Model,
 			&entry.Provider,
+			&providerName,
 			&entry.Endpoint,
 			&entry.InputTokens,
 			&entry.OutputTokens,
 			&rawData,
 		); err != nil {
 			return nil, fmt.Errorf("scan sqlite usage cost row: %w", err)
+		}
+		if providerName.Valid {
+			entry.ProviderName = providerName.String
 		}
 		if rawData.Valid {
 			entry.RawData = rawDataFromJSON(rawData.String, entry.ID)

--- a/internal/usage/recalculate_pricing_sqlite.go
+++ b/internal/usage/recalculate_pricing_sqlite.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 )
 
+const defaultSQLiteRecalculationBatchSize = 500
+
 // RecalculatePricing updates matching SQLite usage rows with costs computed
 // from the supplied pricing resolver.
 func (s *SQLiteStore) RecalculatePricing(ctx context.Context, params RecalculatePricingParams, resolver PricingResolver) (RecalculatePricingResult, error) {
@@ -13,14 +15,6 @@ func (s *SQLiteStore) RecalculatePricing(ctx context.Context, params Recalculate
 		return RecalculatePricingResult{}, err
 	}
 	params = normalizedRecalculatePricingParams(params)
-
-	entries, err := s.sqliteRecalculationEntries(ctx, params)
-	if err != nil {
-		return RecalculatePricingResult{}, err
-	}
-	if len(entries) == 0 {
-		return finalizeRecalculatePricingResult(RecalculatePricingResult{}), nil
-	}
 
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -39,18 +33,30 @@ func (s *SQLiteStore) RecalculatePricing(ctx context.Context, params Recalculate
 	defer stmt.Close()
 
 	result := RecalculatePricingResult{}
-	for _, entry := range entries {
-		update := recalculateEntryCosts(entry, resolver)
-		if _, err := stmt.ExecContext(ctx,
-			nullableFloat(update.InputCost),
-			nullableFloat(update.OutputCost),
-			nullableFloat(update.TotalCost),
-			update.Caveat,
-			update.ID,
-		); err != nil {
-			return RecalculatePricingResult{}, fmt.Errorf("update sqlite usage cost %s: %w", update.ID, err)
+	lastID := ""
+	for {
+		entries, err := s.sqliteRecalculationEntries(ctx, tx, params, lastID, s.sqliteRecalculationBatchSize())
+		if err != nil {
+			return RecalculatePricingResult{}, err
 		}
-		updateRecalculatePricingResult(&result, update)
+		if len(entries) == 0 {
+			break
+		}
+
+		for _, entry := range entries {
+			update := recalculateEntryCosts(entry, resolver)
+			if _, err := stmt.ExecContext(ctx,
+				nullableFloat(update.InputCost),
+				nullableFloat(update.OutputCost),
+				nullableFloat(update.TotalCost),
+				update.Caveat,
+				update.ID,
+			); err != nil {
+				return RecalculatePricingResult{}, fmt.Errorf("update sqlite usage cost %s: %w", update.ID, err)
+			}
+			updateRecalculatePricingResult(&result, update)
+		}
+		lastID = entries[len(entries)-1].ID
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -59,10 +65,21 @@ func (s *SQLiteStore) RecalculatePricing(ctx context.Context, params Recalculate
 	return finalizeRecalculatePricingResult(result), nil
 }
 
-func (s *SQLiteStore) sqliteRecalculationEntries(ctx context.Context, params RecalculatePricingParams) ([]recalculationEntry, error) {
+func (s *SQLiteStore) sqliteRecalculationBatchSize() int {
+	if s.recalculationBatchSize > 0 {
+		return s.recalculationBatchSize
+	}
+	return defaultSQLiteRecalculationBatchSize
+}
+
+func (s *SQLiteStore) sqliteRecalculationEntries(ctx context.Context, tx *sql.Tx, params RecalculatePricingParams, lastID string, limit int) ([]recalculationEntry, error) {
 	conditions, args, err := sqliteUsageConditions(params.UsageQueryParams)
 	if err != nil {
 		return nil, err
+	}
+	if lastID != "" {
+		conditions = append(conditions, "id > ?")
+		args = append(args, lastID)
 	}
 	if params.Model != "" {
 		conditions = append(conditions, "model = ?")
@@ -72,10 +89,13 @@ func (s *SQLiteStore) sqliteRecalculationEntries(ctx context.Context, params Rec
 		conditions = append(conditions, "(provider = ? OR provider_name = ?)")
 		args = append(args, params.Provider, params.Provider)
 	}
+	args = append(args, limit)
 
-	rows, err := s.db.QueryContext(ctx, `
+	rows, err := tx.QueryContext(ctx, `
 		SELECT id, model, provider, provider_name, endpoint, input_tokens, output_tokens, raw_data
-		FROM usage`+buildWhereClause(conditions), args...)
+		FROM usage`+buildWhereClause(conditions)+`
+		ORDER BY id
+		LIMIT ?`, args...)
 	if err != nil {
 		return nil, fmt.Errorf("query sqlite usage costs for recalculation: %w", err)
 	}

--- a/internal/usage/recalculate_pricing_sqlite.go
+++ b/internal/usage/recalculate_pricing_sqlite.go
@@ -1,0 +1,108 @@
+package usage
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// RecalculatePricing updates matching SQLite usage rows with costs computed
+// from the supplied pricing resolver.
+func (s *SQLiteStore) RecalculatePricing(ctx context.Context, params RecalculatePricingParams, resolver PricingResolver) (RecalculatePricingResult, error) {
+	if err := recalculatePricingUnavailable(resolver); err != nil {
+		return RecalculatePricingResult{}, err
+	}
+	params = normalizedRecalculatePricingParams(params)
+
+	entries, err := s.sqliteRecalculationEntries(ctx, params)
+	if err != nil {
+		return RecalculatePricingResult{}, err
+	}
+	if len(entries) == 0 {
+		return finalizeRecalculatePricingResult(RecalculatePricingResult{}), nil
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return RecalculatePricingResult{}, fmt.Errorf("begin sqlite pricing recalculation: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	stmt, err := tx.PrepareContext(ctx, `
+		UPDATE usage
+		SET input_cost = ?, output_cost = ?, total_cost = ?, costs_calculation_caveat = ?
+		WHERE id = ?
+	`)
+	if err != nil {
+		return RecalculatePricingResult{}, fmt.Errorf("prepare sqlite pricing recalculation update: %w", err)
+	}
+	defer stmt.Close()
+
+	result := RecalculatePricingResult{}
+	for _, entry := range entries {
+		update := recalculateEntryCosts(entry, resolver)
+		if _, err := stmt.ExecContext(ctx,
+			nullableFloat(update.InputCost),
+			nullableFloat(update.OutputCost),
+			nullableFloat(update.TotalCost),
+			update.Caveat,
+			update.ID,
+		); err != nil {
+			return RecalculatePricingResult{}, fmt.Errorf("update sqlite usage cost %s: %w", update.ID, err)
+		}
+		updateRecalculatePricingResult(&result, update)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return RecalculatePricingResult{}, fmt.Errorf("commit sqlite pricing recalculation: %w", err)
+	}
+	return finalizeRecalculatePricingResult(result), nil
+}
+
+func (s *SQLiteStore) sqliteRecalculationEntries(ctx context.Context, params RecalculatePricingParams) ([]recalculationEntry, error) {
+	conditions, args, err := sqliteUsageConditions(params.UsageQueryParams)
+	if err != nil {
+		return nil, err
+	}
+	if params.Model != "" {
+		conditions = append(conditions, "model = ?")
+		args = append(args, params.Model)
+	}
+	if params.Provider != "" {
+		conditions = append(conditions, "(provider = ? OR provider_name = ?)")
+		args = append(args, params.Provider, params.Provider)
+	}
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, model, provider, endpoint, input_tokens, output_tokens, raw_data
+		FROM usage`+buildWhereClause(conditions), args...)
+	if err != nil {
+		return nil, fmt.Errorf("query sqlite usage costs for recalculation: %w", err)
+	}
+	defer rows.Close()
+
+	entries := make([]recalculationEntry, 0)
+	for rows.Next() {
+		var entry recalculationEntry
+		var rawData sql.NullString
+		if err := rows.Scan(
+			&entry.ID,
+			&entry.Model,
+			&entry.Provider,
+			&entry.Endpoint,
+			&entry.InputTokens,
+			&entry.OutputTokens,
+			&rawData,
+		); err != nil {
+			return nil, fmt.Errorf("scan sqlite usage cost row: %w", err)
+		}
+		if rawData.Valid {
+			entry.RawData = rawDataFromJSON(rawData.String, entry.ID)
+		}
+		entries = append(entries, entry)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate sqlite usage costs for recalculation: %w", err)
+	}
+	return entries, nil
+}

--- a/internal/usage/recalculate_pricing_sqlite_test.go
+++ b/internal/usage/recalculate_pricing_sqlite_test.go
@@ -1,0 +1,107 @@
+package usage
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	"gomodel/internal/core"
+)
+
+type staticTestPricingResolver map[string]*core.ModelPricing
+
+func (r staticTestPricingResolver) ResolvePricing(model, providerType string) *core.ModelPricing {
+	return r[providerType+"/"+model]
+}
+
+func TestSQLiteStoreRecalculatePricingUpdatesFilteredUsageCosts(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+
+	store, err := NewSQLiteStore(db, 0)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore() error = %v", err)
+	}
+
+	oldCost := 99.0
+	ctx := context.Background()
+	if err := store.WriteBatch(ctx, []*UsageEntry{
+		{
+			ID:           "usage-match",
+			RequestID:    "req-match",
+			ProviderID:   "provider-match",
+			Timestamp:    time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC),
+			Model:        "gpt-4o",
+			Provider:     "openai",
+			ProviderName: "primary-openai",
+			Endpoint:     "/v1/chat/completions",
+			UserPath:     "/team/alpha",
+			InputTokens:  1_000_000,
+			OutputTokens: 500_000,
+			TotalTokens:  1_500_000,
+			InputCost:    &oldCost,
+			OutputCost:   &oldCost,
+			TotalCost:    &oldCost,
+		},
+		{
+			ID:          "usage-other-model",
+			RequestID:   "req-other",
+			ProviderID:  "provider-other",
+			Timestamp:   time.Date(2026, 4, 12, 11, 0, 0, 0, time.UTC),
+			Model:       "gpt-4o-mini",
+			Provider:    "openai",
+			Endpoint:    "/v1/chat/completions",
+			UserPath:    "/team/alpha",
+			InputTokens: 1_000_000,
+			TotalTokens: 1_000_000,
+			TotalCost:   &oldCost,
+		},
+	}); err != nil {
+		t.Fatalf("WriteBatch() error = %v", err)
+	}
+
+	inputRate := 2.0
+	outputRate := 6.0
+	result, err := store.RecalculatePricing(ctx, RecalculatePricingParams{
+		UsageQueryParams: UsageQueryParams{
+			StartDate: time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC),
+			EndDate:   time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC),
+			UserPath:  "/team",
+		},
+		Provider: "primary-openai",
+		Model:    "gpt-4o",
+	}, staticTestPricingResolver{
+		"openai/gpt-4o": {
+			InputPerMtok:  &inputRate,
+			OutputPerMtok: &outputRate,
+		},
+	})
+	if err != nil {
+		t.Fatalf("RecalculatePricing() error = %v", err)
+	}
+	if result.Matched != 1 || result.Recalculated != 1 || result.WithPricing != 1 || result.WithoutPricing != 0 {
+		t.Fatalf("result = %+v, want one recalculated row with pricing", result)
+	}
+
+	var inputCost, outputCost, totalCost float64
+	if err := db.QueryRow(`SELECT input_cost, output_cost, total_cost FROM usage WHERE id = 'usage-match'`).Scan(&inputCost, &outputCost, &totalCost); err != nil {
+		t.Fatalf("query recalculated row: %v", err)
+	}
+	if inputCost != 2.0 || outputCost != 3.0 || totalCost != 5.0 {
+		t.Fatalf("costs = input %.4f output %.4f total %.4f, want 2/3/5", inputCost, outputCost, totalCost)
+	}
+
+	var otherTotal float64
+	if err := db.QueryRow(`SELECT total_cost FROM usage WHERE id = 'usage-other-model'`).Scan(&otherTotal); err != nil {
+		t.Fatalf("query untouched row: %v", err)
+	}
+	if otherTotal != oldCost {
+		t.Fatalf("other total cost = %.4f, want %.4f", otherTotal, oldCost)
+	}
+}

--- a/internal/usage/recalculate_pricing_sqlite_test.go
+++ b/internal/usage/recalculate_pricing_sqlite_test.go
@@ -105,3 +105,84 @@ func TestSQLiteStoreRecalculatePricingUpdatesFilteredUsageCosts(t *testing.T) {
 		t.Fatalf("other total cost = %.4f, want %.4f", otherTotal, oldCost)
 	}
 }
+
+func TestSQLiteStoreRecalculatePricingProcessesBatches(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+
+	store, err := NewSQLiteStore(db, 0)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore() error = %v", err)
+	}
+	store.recalculationBatchSize = 1
+
+	ctx := context.Background()
+	if err := store.WriteBatch(ctx, []*UsageEntry{
+		{
+			ID:          "usage-1",
+			RequestID:   "req-1",
+			ProviderID:  "provider-1",
+			Timestamp:   time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC),
+			Model:       "gpt-4o",
+			Provider:    "openai",
+			Endpoint:    "/v1/chat/completions",
+			InputTokens: 1_000_000,
+		},
+		{
+			ID:           "usage-2",
+			RequestID:    "req-2",
+			ProviderID:   "provider-2",
+			Timestamp:    time.Date(2026, 4, 12, 11, 0, 0, 0, time.UTC),
+			Model:        "gpt-4o",
+			Provider:     "openai",
+			ProviderName: "primary-openai",
+			Endpoint:     "/v1/chat/completions",
+			InputTokens:  2_000_000,
+		},
+	}); err != nil {
+		t.Fatalf("WriteBatch() error = %v", err)
+	}
+
+	inputRate := 2.0
+	result, err := store.RecalculatePricing(ctx, RecalculatePricingParams{
+		Model: "gpt-4o",
+	}, staticTestPricingResolver{
+		"openai/gpt-4o": {
+			InputPerMtok: &inputRate,
+		},
+		"primary-openai/gpt-4o": {
+			InputPerMtok: &inputRate,
+		},
+	})
+	if err != nil {
+		t.Fatalf("RecalculatePricing() error = %v", err)
+	}
+	if result.Matched != 2 || result.Recalculated != 2 || result.WithPricing != 2 {
+		t.Fatalf("result = %+v, want two recalculated rows with pricing", result)
+	}
+
+	rows, err := db.Query(`SELECT id, input_cost FROM usage ORDER BY id`)
+	if err != nil {
+		t.Fatalf("query recalculated rows: %v", err)
+	}
+	defer rows.Close()
+
+	got := map[string]float64{}
+	for rows.Next() {
+		var id string
+		var inputCost float64
+		if err := rows.Scan(&id, &inputCost); err != nil {
+			t.Fatalf("scan recalculated row: %v", err)
+		}
+		got[id] = inputCost
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate recalculated rows: %v", err)
+	}
+	if got["usage-1"] != 2.0 || got["usage-2"] != 4.0 {
+		t.Fatalf("input costs = %+v, want usage-1=2 usage-2=4", got)
+	}
+}

--- a/internal/usage/recalculate_pricing_sqlite_test.go
+++ b/internal/usage/recalculate_pricing_sqlite_test.go
@@ -77,7 +77,7 @@ func TestSQLiteStoreRecalculatePricingUpdatesFilteredUsageCosts(t *testing.T) {
 		Provider: "primary-openai",
 		Model:    "gpt-4o",
 	}, staticTestPricingResolver{
-		"openai/gpt-4o": {
+		"primary-openai/gpt-4o": {
 			InputPerMtok:  &inputRate,
 			OutputPerMtok: &outputRate,
 		},

--- a/internal/usage/recalculate_pricing_test.go
+++ b/internal/usage/recalculate_pricing_test.go
@@ -1,0 +1,48 @@
+package usage
+
+import (
+	"testing"
+
+	"gomodel/internal/core"
+)
+
+type recordingPricingResolver struct {
+	model    string
+	provider string
+	pricing  *core.ModelPricing
+}
+
+func (r *recordingPricingResolver) ResolvePricing(model, providerType string) *core.ModelPricing {
+	r.model = model
+	r.provider = providerType
+	return r.pricing
+}
+
+func TestRecalculateEntryCostsPrefersProviderNameForPricingLookup(t *testing.T) {
+	inputRate := 2.0
+	cachedRate := 0.5
+	resolver := &recordingPricingResolver{
+		pricing: &core.ModelPricing{
+			InputPerMtok:       &inputRate,
+			CachedInputPerMtok: &cachedRate,
+		},
+	}
+
+	update := recalculateEntryCosts(recalculationEntry{
+		ID:           "usage-1",
+		Model:        "gpt-4o",
+		Provider:     "openai",
+		ProviderName: "primary-openai",
+		InputTokens:  1_000_000,
+		RawData: map[string]any{
+			"cached_tokens": 500_000,
+		},
+	}, resolver)
+
+	if resolver.model != "gpt-4o" || resolver.provider != "primary-openai" {
+		t.Fatalf("ResolvePricing called with %q/%q, want gpt-4o/primary-openai", resolver.provider, resolver.model)
+	}
+	if update.InputCost == nil || *update.InputCost != 1.25 {
+		t.Fatalf("InputCost = %v, want 1.25", update.InputCost)
+	}
+}

--- a/internal/usage/store_mongodb.go
+++ b/internal/usage/store_mongodb.go
@@ -45,8 +45,10 @@ var usagePartialWriteFailures = promauto.NewCounter(
 
 // MongoDBStore implements UsageStore for MongoDB.
 type MongoDBStore struct {
-	collection    *mongo.Collection
-	retentionDays int
+	collection                  *mongo.Collection
+	retentionDays               int
+	startPricingSession         func() (mongoPricingSession, error)
+	recalculatePricingDocuments func(context.Context, bson.D, PricingResolver) (RecalculatePricingResult, error)
 }
 
 // NewMongoDBStore creates a new MongoDB usage store.

--- a/internal/usage/store_sqlite.go
+++ b/internal/usage/store_sqlite.go
@@ -21,10 +21,11 @@ const (
 
 // SQLiteStore implements UsageStore for SQLite databases.
 type SQLiteStore struct {
-	db            *sql.DB
-	retentionDays int
-	stopCleanup   chan struct{}
-	closeOnce     sync.Once
+	db                     *sql.DB
+	retentionDays          int
+	recalculationBatchSize int
+	stopCleanup            chan struct{}
+	closeOnce              sync.Once
 }
 
 // NewSQLiteStore creates a new SQLite usage store.
@@ -97,9 +98,10 @@ func NewSQLiteStore(db *sql.DB, retentionDays int) (*SQLiteStore, error) {
 	}
 
 	store := &SQLiteStore{
-		db:            db,
-		retentionDays: retentionDays,
-		stopCleanup:   make(chan struct{}),
+		db:                     db,
+		retentionDays:          retentionDays,
+		recalculationBatchSize: defaultSQLiteRecalculationBatchSize,
+		stopCleanup:            make(chan struct{}),
 	}
 
 	// Start background cleanup if retention is configured


### PR DESCRIPTION
## Summary
- add a Settings tool for recalculating stored usage pricing with date range, user path, and provider/model or alias filters
- add a confirmed admin API action backed by SQLite, PostgreSQL, and MongoDB recalculators
- extract the typed confirmation dialog and reuse it for budget reset and pricing recalculation

## Testing
- go test ./...
- node --test internal/admin/dashboard/static/js/modules/*.test.cjs
- pre-commit hooks: make test-race, go mod tidy, dashboard JavaScript unit tests, hot-path performance guard, make lint
- curl validation against a running local GoModel instance: created OpenRouter usage rows, zeroed test rows, confirmed recalculation restored costs, checked invalid confirmation/date/user_path handling, and verified alias selector recalculation

## Curl Verification Highlights
- `POST /admin/api/v1/usage/recalculate-pricing` with OpenRouter filter returned `matched: 2`, `recalculated: 2`, `with_pricing: 2`, `without_pricing: 0` after zeroing test rows
- final OpenRouter usage check showed 4 rows and 0 zero/null cost rows


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin dashboard: usage pricing recalculation UI (presets/custom range, user/provider/model filters), responsive layout, notices and summary
  * Reusable typed-confirmation modal for sensitive actions; budget reset migrated to it
  * Server-side persisted pricing recalculation with multi-backend support behind a runtime flag
  * Admin auth-gating middleware for protected endpoints

* **Bug Fixes**
  * Improved numeric type handling when processing cost data

* **Tests**
  * Extensive unit/integration tests for recalculation logic, payloads, responses, dialogs, feature-flag and auth behavior

* **Documentation**
  * Config and docs for the pricing recalculation feature flag
<!-- end of auto-generated comment: release notes by coderabbit.ai -->