### PR TITLE
fix(admin): allow pricing recalculation without master key

### DIFF
--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -102,20 +102,6 @@ func AuthMiddlewareWithAuthenticator(masterKey string, authenticator BearerToken
 	}
 }
 
-// RequireConfiguredAuthMiddleware enforces authentication even on routes that
-// are otherwise covered by a global auth skip path.
-func RequireConfiguredAuthMiddleware(masterKey string, authenticator BearerTokenAuthenticator) echo.MiddlewareFunc {
-	return func(next echo.HandlerFunc) echo.HandlerFunc {
-		return func(c *echo.Context) error {
-			if masterKey == "" && (authenticator == nil || !authenticator.Enabled()) {
-				authErr := authenticationError(c, "authentication is required for this operation")
-				return c.JSON(authErr.HTTPStatusCode(), authErr.ToJSON())
-			}
-			return AuthMiddlewareWithAuthenticator(masterKey, authenticator, nil)(next)(c)
-		}
-	}
-}
-
 func authFailureMessage(err error) string {
 	if err == nil {
 		return "invalid API key"

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -323,7 +323,7 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 		adminAPI.GET("/usage/models", cfg.AdminHandler.UsageByModel)
 		adminAPI.GET("/usage/user-paths", cfg.AdminHandler.UsageByUserPath)
 		adminAPI.GET("/usage/log", cfg.AdminHandler.UsageLog)
-		adminAPI.POST("/usage/recalculate-pricing", cfg.AdminHandler.RecalculateUsagePricing, RequireConfiguredAuthMiddleware(cfg.MasterKey, cfg.Authenticator))
+		adminAPI.POST("/usage/recalculate-pricing", cfg.AdminHandler.RecalculateUsagePricing)
 		adminAPI.GET("/audit/log", cfg.AdminHandler.AuditLog)
 		adminAPI.GET("/audit/conversation", cfg.AdminHandler.AuditConversation)
 		adminAPI.GET("/providers/status", cfg.AdminHandler.ProviderStatus)

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -13,6 +13,8 @@ import (
 	"gomodel/internal/admin"
 	"gomodel/internal/admin/dashboard"
 	"gomodel/internal/core"
+	"gomodel/internal/providers"
+	"gomodel/internal/usage"
 
 	_ "gomodel/cmd/gomodel/docs"
 
@@ -585,6 +587,15 @@ func newDashboardHandler(t *testing.T) *dashboard.Handler {
 	return h
 }
 
+type pricingRecalculatorStub struct {
+	calls int
+}
+
+func (s *pricingRecalculatorStub) RecalculatePricing(context.Context, usage.RecalculatePricingParams, usage.PricingResolver) (usage.RecalculatePricingResult, error) {
+	s.calls++
+	return usage.RecalculatePricingResult{Status: "ok", Matched: 1, Recalculated: 1, WithPricing: 1}, nil
+}
+
 func TestAdminEndpoints_Enabled(t *testing.T) {
 	mock := &mockProvider{}
 	adminHandler := admin.NewHandler(nil, nil)
@@ -782,24 +793,47 @@ func TestAdminAPI_SkipsAuthWithoutMasterKey(t *testing.T) {
 	}
 }
 
-func TestAdminPricingRecalculationRequiresAuthWithoutMasterKey(t *testing.T) {
-	mock := &mockProvider{}
-	adminHandler := admin.NewHandler(nil, nil)
-	unsafeSrv := New(mock, &Config{
-		AdminEndpointsEnabled: true,
-		AdminHandler:          adminHandler,
-	})
-	unsafeReq := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", strings.NewReader(`{"confirmation":"recalculate"}`))
-	unsafeReq.Header.Set("Content-Type", "application/json")
-	unsafeRec := httptest.NewRecorder()
-	unsafeSrv.ServeHTTP(unsafeRec, unsafeReq)
-
-	if unsafeRec.Code != http.StatusUnauthorized {
-		t.Fatalf("expected pricing recalculation 401 when no auth is configured, got %d body=%s", unsafeRec.Code, unsafeRec.Body.String())
+func TestAdminPricingRecalculationSkipsAuthWithoutMasterKey(t *testing.T) {
+	tests := []struct {
+		name          string
+		authenticator BearerTokenAuthenticator
+	}{
+		{name: "no auth configured"},
+		{name: "managed keys enabled", authenticator: mockAuthenticator{enabled: true, tokenToID: map[string]string{"managed-token": "key-123"}}},
 	}
 
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockProvider{}
+			recalculator := &pricingRecalculatorStub{}
+			adminHandler := admin.NewHandler(nil, providers.NewModelRegistry(), admin.WithUsagePricingRecalculator(recalculator))
+			srv := New(mock, &Config{
+				Authenticator:         tt.authenticator,
+				AdminEndpointsEnabled: true,
+				AdminHandler:          adminHandler,
+			})
+
+			req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", strings.NewReader(`{"confirmation":"recalculate"}`))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			srv.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected pricing recalculation 200 without auth when master key is unset, got %d body=%s", rec.Code, rec.Body.String())
+			}
+			if recalculator.calls != 1 {
+				t.Fatalf("recalculator calls = %d, want 1", recalculator.calls)
+			}
+		})
+	}
+}
+
+func TestAdminPricingRecalculationRequiresAuthWithMasterKey(t *testing.T) {
+	mock := &mockProvider{}
+	recalculator := &pricingRecalculatorStub{}
+	adminHandler := admin.NewHandler(nil, providers.NewModelRegistry(), admin.WithUsagePricingRecalculator(recalculator))
 	srv := New(mock, &Config{
-		Authenticator:         mockAuthenticator{enabled: true, tokenToID: map[string]string{"managed-token": "key-123"}},
+		MasterKey:             "test-secret-key",
 		AdminEndpointsEnabled: true,
 		AdminHandler:          adminHandler,
 	})
@@ -810,17 +844,23 @@ func TestAdminPricingRecalculationRequiresAuthWithoutMasterKey(t *testing.T) {
 	srv.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusUnauthorized {
-		t.Fatalf("expected pricing recalculation 401 without auth, got %d body=%s", rec.Code, rec.Body.String())
+		t.Fatalf("expected pricing recalculation 401 without auth when master key is set, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if recalculator.calls != 0 {
+		t.Fatalf("recalculator calls after unauthorized request = %d, want 0", recalculator.calls)
 	}
 
 	authReq := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", strings.NewReader(`{"confirmation":"recalculate"}`))
 	authReq.Header.Set("Content-Type", "application/json")
-	authReq.Header.Set("Authorization", "Bearer managed-token")
+	authReq.Header.Set("Authorization", "Bearer test-secret-key")
 	authRec := httptest.NewRecorder()
 	srv.ServeHTTP(authRec, authReq)
 
-	if authRec.Code == http.StatusUnauthorized {
-		t.Fatalf("expected authorized pricing recalculation request to reach handler, got 401 body=%s", authRec.Body.String())
+	if authRec.Code != http.StatusOK {
+		t.Fatalf("expected authorized pricing recalculation 200, got %d body=%s", authRec.Code, authRec.Body.String())
+	}
+	if recalculator.calls != 1 {
+		t.Fatalf("recalculator calls after authorized request = %d, want 1", recalculator.calls)
 	}
 }
 

--- a/tests/e2e/admin_test.go
+++ b/tests/e2e/admin_test.go
@@ -3,18 +3,36 @@
 package e2e
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"gomodel/internal/admin"
 	"gomodel/internal/providers"
 	"gomodel/internal/usage"
 )
+
+type e2ePricingRecalculator struct {
+	calls  int
+	params usage.RecalculatePricingParams
+	result usage.RecalculatePricingResult
+}
+
+func (r *e2ePricingRecalculator) RecalculatePricing(_ context.Context, params usage.RecalculatePricingParams, _ usage.PricingResolver) (usage.RecalculatePricingResult, error) {
+	r.calls++
+	r.params = params
+	if r.result.Status == "" {
+		r.result.Status = "ok"
+	}
+	return r.result, nil
+}
 
 func TestAdminAPI_EndpointsEnabled_E2E(t *testing.T) {
 	ts := setupAdminServer(t, "", true, false)
@@ -91,6 +109,35 @@ func TestAdminAPI_RequiresAuth_E2E(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})
+}
+
+func TestAdminAPI_PricingRecalculationNoMasterKey_E2E(t *testing.T) {
+	recalculator := &e2ePricingRecalculator{
+		result: usage.RecalculatePricingResult{Status: "ok", Matched: 1, Recalculated: 1, WithPricing: 1},
+	}
+	ts := setupE2EAdminServer(t, e2eServerOptions{
+		adminOptions: []admin.Option{admin.WithUsagePricingRecalculator(recalculator)},
+	})
+	defer ts.Close()
+
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/admin/api/v1/usage/recalculate-pricing", strings.NewReader(`{
+		"confirmation": "recalculate",
+		"user_path": "/team/recalc"
+	}`))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer closeBody(resp)
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 1, recalculator.calls)
+	assert.Equal(t, "/team/recalc", recalculator.params.UserPath)
+
+	var result usage.RecalculatePricingResult
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+	assert.Equal(t, int64(1), result.Recalculated)
 }
 
 func TestAdminDashboard_Enabled_E2E(t *testing.T) {

--- a/tests/e2e/release-e2e-scenarios.md
+++ b/tests/e2e/release-e2e-scenarios.md
@@ -35,6 +35,7 @@ Stateful note:
 - `S64`-`S79` mutate managed keys, workflows, and auth artifacts
 - `S80`-`S85` mutate response snapshots and response-cache artifacts
 - `S86`-`S89` mutate budget settings and budgets
+- `S90` mutates stored usage pricing fields on the no-master-key gateway
 - For stateful partial reruns, prefer a contiguous range that includes the
   prerequisite setup scenarios, or rerun with the same `--qa-suffix` and
   `--keep-artifacts`
@@ -1525,4 +1526,17 @@ run_release_budget_enforcement \
   "$QA_BUDGET_MONGO_PATH" \
   "s89-mongo-budget" \
   "QA_BUDGET_MONGO_OK_$QA_BUDGET_SUFFIX"
+```
+
+## 16. No-master-key admin mutations
+
+### S90 Usage pricing recalculation without master key
+
+Runs the pricing recalculation action on the main SQLite-backed gateway. The release stack starts this gateway with `GOMODEL_MASTER_KEY` unset, so the request intentionally sends no `Authorization` header.
+
+```bash
+curl -fsS -X POST "$BASE_URL/admin/api/v1/usage/recalculate-pricing" \
+  -H 'Content-Type: application/json' \
+  -d '{"confirmation":"recalculate"}' \
+  | jq -e '.status == "ok" and (.matched | type == "number") and (.recalculated | type == "number")'
 ```

--- a/tests/integration/admin_test.go
+++ b/tests/integration/admin_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -190,6 +191,42 @@ func TestAdminDailyUsage_WithInterval_PostgreSQL(t *testing.T) {
 
 	// Should return valid JSON array (may be empty or have entries)
 	assert.True(t, json.Valid(body), "response should be valid JSON")
+
+	fixture.FlushAndClose(t)
+}
+
+func TestAdminPricingRecalculationNoMasterKey_PostgreSQL(t *testing.T) {
+	fixture := SetupTestServer(t, TestServerConfig{
+		DBType:                           "postgresql",
+		UsageEnabled:                     true,
+		UsagePricingRecalculationEnabled: true,
+		AdminEndpointsEnabled:            true,
+		OnlyModelInteractions:            false,
+	})
+
+	dbassert.ClearUsage(t, fixture.PgPool)
+
+	payload := newChatRequest("gpt-4", "Hello!")
+	resp := sendChatRequest(t, fixture.ServerURL, payload)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	closeBody(resp)
+
+	time.Sleep(2 * time.Second)
+
+	req, err := http.NewRequest(http.MethodPost, fixture.ServerURL+"/admin/api/v1/usage/recalculate-pricing", bytes.NewBufferString(`{"confirmation":"recalculate"}`))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer closeBody(resp)
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result usage.RecalculatePricingResult
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+	assert.Equal(t, "ok", result.Status)
+	assert.GreaterOrEqual(t, result.Matched, int64(1))
+	assert.GreaterOrEqual(t, result.Recalculated, int64(1))
 
 	fixture.FlushAndClose(t)
 }

--- a/tests/integration/setup_test.go
+++ b/tests/integration/setup_test.go
@@ -37,6 +37,9 @@ type TestServerConfig struct {
 	// UsageEnabled enables usage tracking
 	UsageEnabled bool
 
+	// UsagePricingRecalculationEnabled enables admin usage pricing recalculation.
+	UsagePricingRecalculationEnabled bool
+
 	// BudgetsEnabled enables budget enforcement.
 	BudgetsEnabled bool
 
@@ -296,11 +299,12 @@ func buildAppConfig(t *testing.T, cfg TestServerConfig, mockLLMURL string, port 
 			OnlyModelInteractions: cfg.OnlyModelInteractions,
 		},
 		Usage: config.UsageConfig{
-			Enabled:                   cfg.UsageEnabled,
-			EnforceReturningUsageData: true,
-			BufferSize:                100,
-			FlushInterval:             1,
-			RetentionDays:             0,
+			Enabled:                     cfg.UsageEnabled,
+			EnforceReturningUsageData:   true,
+			PricingRecalculationEnabled: cfg.UsagePricingRecalculationEnabled,
+			BufferSize:                  100,
+			FlushInterval:               1,
+			RetentionDays:               0,
 		},
 		Budgets: config.BudgetsConfig{
 			Enabled:   cfg.BudgetsEnabled,


### PR DESCRIPTION
## Summary
- make usage pricing recalculation follow the same admin API auth policy as other admin endpoints
- remove the route-only auth override that blocked recalculation in no-master-key unsafe mode
- add component, e2e, integration, and release-e2e coverage for no-master-key recalculation

## Verification
- curl sweep against isolated binary with GOMODEL_MASTER_KEY unset before and after the fix
- go test ./cmd/... ./internal/... ./config/... -count=1
- go test -tags=e2e ./tests/e2e/... -count=1
- go test -tags=integration ./tests/integration/... -count=1
- tests/e2e/run-release-e2e.sh --list
- pre-commit hook: make test-race, go mod tidy, hot-path performance guard, make lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The admin usage pricing recalculation endpoint no longer requires authentication when the master key is unset, allowing automatic price adjustments to be processed without authorization headers.

* **Tests**
  * Added end-to-end and integration tests to validate pricing recalculation functionality and verify correct authentication behavior across different configuration states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->