### PR TITLE
refactor: making things smaller - function extractions

### DIFF
--- a/internal/admin/handler_providers.go
+++ b/internal/admin/handler_providers.go
@@ -63,10 +63,6 @@ func (h *Handler) buildProviderStatusResponse() providerStatusResponse {
 	}
 
 	resp.Summary.OverallStatus = overallProviderStatus(resp.Summary)
-
-	if resp.Providers == nil {
-		resp.Providers = []providerStatusItemResponse{}
-	}
 	return resp
 }
 

--- a/internal/admin/handler_providers.go
+++ b/internal/admin/handler_providers.go
@@ -39,6 +39,45 @@ func (h *Handler) RefreshRuntime(c *echo.Context) error {
 }
 
 func (h *Handler) buildProviderStatusResponse() providerStatusResponse {
+	configuredByName, runtimeByName, names := h.collectProviderStatusInputs()
+
+	resp := providerStatusResponse{
+		Summary: providerStatusSummaryResponse{
+			OverallStatus: "degraded",
+		},
+		Providers: make([]providerStatusItemResponse, 0, len(names)),
+	}
+
+	for _, name := range names {
+		item := buildProviderStatusItem(name, configuredByName[name], runtimeByName[name])
+		resp.Providers = append(resp.Providers, item)
+		resp.Summary.Total++
+		switch item.Status {
+		case "healthy":
+			resp.Summary.Healthy++
+		case "unhealthy":
+			resp.Summary.Unhealthy++
+		default:
+			resp.Summary.Degraded++
+		}
+	}
+
+	resp.Summary.OverallStatus = overallProviderStatus(resp.Summary)
+
+	if resp.Providers == nil {
+		resp.Providers = []providerStatusItemResponse{}
+	}
+	return resp
+}
+
+// collectProviderStatusInputs merges the configured-provider snapshot with the
+// registry's runtime snapshots and returns lookups keyed by trimmed name plus
+// a deterministically sorted list of all known names.
+func (h *Handler) collectProviderStatusInputs() (
+	map[string]providers.SanitizedProviderConfig,
+	map[string]providers.ProviderRuntimeSnapshot,
+	[]string,
+) {
 	configured := cloneConfiguredProviders(h.configuredProviders)
 	configuredByName := make(map[string]providers.SanitizedProviderConfig, len(configured))
 	nameSet := make(map[string]struct{}, len(configured))
@@ -68,67 +107,50 @@ func (h *Handler) buildProviderStatusResponse() providerStatusResponse {
 		names = append(names, name)
 	}
 	sort.Strings(names)
+	return configuredByName, runtimeByName, names
+}
 
-	resp := providerStatusResponse{
-		Summary: providerStatusSummaryResponse{
-			OverallStatus: "degraded",
-		},
-		Providers: make([]providerStatusItemResponse, 0, len(names)),
+// buildProviderStatusItem reconciles cfg/runtime gaps for a single provider
+// (either side may be zero-valued when only one source knows the name) and
+// produces the response row.
+func buildProviderStatusItem(name string, cfg providers.SanitizedProviderConfig, runtime providers.ProviderRuntimeSnapshot) providerStatusItemResponse {
+	if strings.TrimSpace(cfg.Name) == "" {
+		cfg = providers.SanitizedProviderConfig{Name: name, Type: strings.TrimSpace(runtime.Type)}
+	}
+	if strings.TrimSpace(runtime.Name) == "" {
+		runtime = providers.ProviderRuntimeSnapshot{Name: name, Type: strings.TrimSpace(cfg.Type)}
+	}
+	if strings.TrimSpace(cfg.Type) == "" {
+		cfg.Type = strings.TrimSpace(runtime.Type)
+	}
+	if strings.TrimSpace(runtime.Type) == "" {
+		runtime.Type = strings.TrimSpace(cfg.Type)
 	}
 
-	for _, name := range names {
-		cfg, hasConfig := configuredByName[name]
-		runtime, hasRuntime := runtimeByName[name]
-		if !hasConfig {
-			cfg = providers.SanitizedProviderConfig{Name: name, Type: strings.TrimSpace(runtime.Type)}
-		}
-		if !hasRuntime {
-			runtime = providers.ProviderRuntimeSnapshot{Name: name, Type: strings.TrimSpace(cfg.Type)}
-		}
-		if strings.TrimSpace(cfg.Type) == "" {
-			cfg.Type = strings.TrimSpace(runtime.Type)
-		}
-		if strings.TrimSpace(runtime.Type) == "" {
-			runtime.Type = strings.TrimSpace(cfg.Type)
-		}
-
-		status, label, reason, lastError := classifyProviderStatus(cfg, runtime)
-		resp.Providers = append(resp.Providers, providerStatusItemResponse{
-			Name:         name,
-			Type:         strings.TrimSpace(cfg.Type),
-			Status:       status,
-			StatusLabel:  label,
-			StatusReason: reason,
-			LastError:    lastError,
-			Config:       cfg,
-			Runtime:      runtime,
-		})
-		resp.Summary.Total++
-		switch status {
-		case "healthy":
-			resp.Summary.Healthy++
-		case "unhealthy":
-			resp.Summary.Unhealthy++
-		default:
-			resp.Summary.Degraded++
-		}
+	status, label, reason, lastError := classifyProviderStatus(cfg, runtime)
+	return providerStatusItemResponse{
+		Name:         name,
+		Type:         strings.TrimSpace(cfg.Type),
+		Status:       status,
+		StatusLabel:  label,
+		StatusReason: reason,
+		LastError:    lastError,
+		Config:       cfg,
+		Runtime:      runtime,
 	}
+}
 
+func overallProviderStatus(summary providerStatusSummaryResponse) string {
 	switch {
-	case resp.Summary.Total == 0:
-		resp.Summary.OverallStatus = "degraded"
-	case resp.Summary.Healthy == resp.Summary.Total:
-		resp.Summary.OverallStatus = "healthy"
-	case resp.Summary.Unhealthy == resp.Summary.Total:
-		resp.Summary.OverallStatus = "unhealthy"
+	case summary.Total == 0:
+		return "degraded"
+	case summary.Healthy == summary.Total:
+		return "healthy"
+	case summary.Unhealthy == summary.Total:
+		return "unhealthy"
 	default:
-		resp.Summary.OverallStatus = "degraded"
+		return "degraded"
 	}
-
-	if resp.Providers == nil {
-		resp.Providers = []providerStatusItemResponse{}
-	}
-	return resp
 }
 
 func classifyProviderStatus(cfg providers.SanitizedProviderConfig, runtime providers.ProviderRuntimeSnapshot) (status, label, reason, lastError string) {

--- a/internal/admin/handler_providers.go
+++ b/internal/admin/handler_providers.go
@@ -110,6 +110,13 @@ func (h *Handler) collectProviderStatusInputs() (
 // (either side may be zero-valued when only one source knows the name) and
 // produces the response row.
 func buildProviderStatusItem(name string, cfg providers.SanitizedProviderConfig, runtime providers.ProviderRuntimeSnapshot) providerStatusItemResponse {
+	// Classify against the inputs as-given so the "Unknown" branch in
+	// classifyProviderStatus stays reachable for runtime-only providers.
+	// Synthesising cfg.Name first would always make the provider look
+	// configured to the classifier.
+	status, label, reason, lastError := classifyProviderStatus(cfg, runtime)
+
+	// For the response row, fill in display fallbacks from the peer side.
 	if strings.TrimSpace(cfg.Name) == "" {
 		cfg = providers.SanitizedProviderConfig{Name: name, Type: strings.TrimSpace(runtime.Type)}
 	}
@@ -123,7 +130,6 @@ func buildProviderStatusItem(name string, cfg providers.SanitizedProviderConfig,
 		runtime.Type = strings.TrimSpace(cfg.Type)
 	}
 
-	status, label, reason, lastError := classifyProviderStatus(cfg, runtime)
 	return providerStatusItemResponse{
 		Name:         name,
 		Type:         strings.TrimSpace(cfg.Type),

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -1807,6 +1807,137 @@ func TestClassifyProviderStatus_DerivesCachedModelInventory(t *testing.T) {
 	}
 }
 
+// TestBuildProviderStatusItem_ClassifyAndDisplayFallbacks covers the contract
+// of buildProviderStatusItem — that classifyProviderStatus runs against the
+// original inputs (so runtime-only providers reach the "Unknown" branch) and
+// that the response row's Config/Runtime then gets Name/Type synthesised from
+// whichever side has the value.
+func TestBuildProviderStatusItem_ClassifyAndDisplayFallbacks(t *testing.T) {
+	cases := []struct {
+		name        string
+		key         string
+		cfg         providers.SanitizedProviderConfig
+		runtime     providers.ProviderRuntimeSnapshot
+		wantStatus  string
+		wantLabel   string
+		wantCfgName string
+		wantCfgType string
+		wantRunName string
+		wantRunTyp  string
+	}{
+		{
+			// Runtime-only: registry knows the provider but no operator config.
+			// Must hit the "Unknown" branch — synthesising cfg.Name first
+			// would mislabel this as "Configured".
+			name:        "runtime_only_unknown",
+			key:         "shadow",
+			cfg:         providers.SanitizedProviderConfig{},
+			runtime:     providers.ProviderRuntimeSnapshot{Name: "shadow", Type: "openai", Registered: true},
+			wantStatus:  "degraded",
+			wantLabel:   "Unknown",
+			wantCfgName: "shadow",
+			wantCfgType: "openai",
+			wantRunName: "shadow",
+			wantRunTyp:  "openai",
+		},
+		{
+			// Config-only: operator wired the provider but the registry has
+			// not produced a runtime snapshot yet.
+			name:        "config_only_starting",
+			key:         "openai",
+			cfg:         providers.SanitizedProviderConfig{Name: "openai", Type: "openai"},
+			runtime:     providers.ProviderRuntimeSnapshot{},
+			wantStatus:  "degraded",
+			wantLabel:   "Starting",
+			wantCfgName: "openai",
+			wantCfgType: "openai",
+			wantRunName: "openai",
+			wantRunTyp:  "openai",
+		},
+		{
+			// Config + registered + zero models: existing "Configured" path,
+			// guarded by TestClassifyProviderStatus_RegisteredZeroModelProviderIsConfigured
+			// at the classifier level — re-asserted here through the wrapper.
+			name:        "configured_zero_models",
+			key:         "openai",
+			cfg:         providers.SanitizedProviderConfig{Name: "openai", Type: "openai"},
+			runtime:     providers.ProviderRuntimeSnapshot{Name: "openai", Type: "openai", Registered: true},
+			wantStatus:  "degraded",
+			wantLabel:   "Configured",
+			wantCfgName: "openai",
+			wantCfgType: "openai",
+			wantRunName: "openai",
+			wantRunTyp:  "openai",
+		},
+		{
+			// Healthy: discovery succeeded.
+			name: "healthy",
+			key:  "openai",
+			cfg:  providers.SanitizedProviderConfig{Name: "openai", Type: "openai"},
+			runtime: providers.ProviderRuntimeSnapshot{
+				Name:                    "openai",
+				Type:                    "openai",
+				Registered:              true,
+				DiscoveredModelCount:    7,
+				LastModelFetchSuccessAt: timePtr(time.Now()),
+			},
+			wantStatus:  "healthy",
+			wantLabel:   "Healthy",
+			wantCfgName: "openai",
+			wantCfgType: "openai",
+			wantRunName: "openai",
+			wantRunTyp:  "openai",
+		},
+		{
+			// Type only known to the runtime side: cfg.Type should be filled
+			// from runtime.Type so the response row carries a usable label.
+			name:        "type_filled_from_runtime",
+			key:         "custom",
+			cfg:         providers.SanitizedProviderConfig{Name: "custom"},
+			runtime:     providers.ProviderRuntimeSnapshot{Name: "custom", Type: "ollama", Registered: true},
+			wantStatus:  "degraded",
+			wantLabel:   "Configured",
+			wantCfgName: "custom",
+			wantCfgType: "ollama",
+			wantRunName: "custom",
+			wantRunTyp:  "ollama",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			item := buildProviderStatusItem(tc.key, tc.cfg, tc.runtime)
+
+			if item.Name != tc.key {
+				t.Errorf("Name = %q, want %q", item.Name, tc.key)
+			}
+			if item.Status != tc.wantStatus {
+				t.Errorf("Status = %q, want %q", item.Status, tc.wantStatus)
+			}
+			if item.StatusLabel != tc.wantLabel {
+				t.Errorf("StatusLabel = %q, want %q", item.StatusLabel, tc.wantLabel)
+			}
+			if item.Config.Name != tc.wantCfgName {
+				t.Errorf("Config.Name = %q, want %q", item.Config.Name, tc.wantCfgName)
+			}
+			if item.Config.Type != tc.wantCfgType {
+				t.Errorf("Config.Type = %q, want %q", item.Config.Type, tc.wantCfgType)
+			}
+			if item.Runtime.Name != tc.wantRunName {
+				t.Errorf("Runtime.Name = %q, want %q", item.Runtime.Name, tc.wantRunName)
+			}
+			if item.Runtime.Type != tc.wantRunTyp {
+				t.Errorf("Runtime.Type = %q, want %q", item.Runtime.Type, tc.wantRunTyp)
+			}
+			if item.Type != tc.wantCfgType {
+				t.Errorf("Type = %q, want %q", item.Type, tc.wantCfgType)
+			}
+		})
+	}
+}
+
+func timePtr(t time.Time) *time.Time { return &t }
+
 func TestDashboardConfig_ReturnsAllowlistedRuntimeFlags(t *testing.T) {
 	h := NewHandler(nil, nil, WithDashboardRuntimeConfig(DashboardConfigResponse{
 		FeatureFallbackMode:  "auto",

--- a/internal/llmclient/client.go
+++ b/internal/llmclient/client.go
@@ -224,6 +224,35 @@ func (c *Client) finishRequest(scope requestScope, statusCode int, err error) {
 	})
 }
 
+// completeScope is the standard terminal step for a request that has passed
+// beginRequest. It records the circuit-breaker outcome (using cbErr to decide
+// whether the failure was transport-level) and emits the metrics observation.
+// Use this whenever a code path returns from one of the public Do* methods.
+func (c *Client) completeScope(scope requestScope, statusCode int, err, cbErr error) {
+	c.recordCircuitBreakerCompletion(statusCode, cbErr)
+	c.finishRequest(scope, statusCode, err)
+}
+
+// failAfterRetries handles the "exhausted retries with no captured error"
+// fallback shared by the retrying entry points (DoRaw, DoPassthrough). The
+// returned error is also reported through the scope.
+func (c *Client) failAfterRetries(scope requestScope) error {
+	err := core.NewProviderError(c.config.ProviderName, http.StatusBadGateway, "request failed after retries", nil)
+	c.completeScope(scope, http.StatusBadGateway, err, err)
+	return err
+}
+
+// waitForRetryAttempt sleeps for the per-attempt backoff (a no-op for
+// attempt 0) and finalises the scope if the context cancels mid-wait. The
+// caller should return early when this returns a non-nil error.
+func (c *Client) waitForRetryAttempt(ctx context.Context, scope requestScope, attempt int) error {
+	if err := c.waitForRetry(ctx, attempt); err != nil {
+		c.finishRequest(scope, 0, err)
+		return err
+	}
+	return nil
+}
+
 func (c *Client) recordCircuitBreakerCompletion(statusCode int, err error) {
 	if c.circuitBreaker == nil {
 		return
@@ -327,8 +356,7 @@ func (c *Client) DoRaw(ctx context.Context, req Request) (*Response, error) {
 	}
 
 	for attempt := 0; attempt < maxAttempts; attempt++ {
-		if err := c.waitForRetry(ctx, attempt); err != nil {
-			c.finishRequest(scope, 0, err)
+		if err := c.waitForRetryAttempt(ctx, scope, attempt); err != nil {
 			return nil, err
 		}
 
@@ -340,8 +368,7 @@ func (c *Client) DoRaw(ctx context.Context, req Request) (*Response, error) {
 			// Client-side timeouts are already the caller's latency budget. Do
 			// not retry them, or the logical request can outlive HTTP_TIMEOUT.
 			if scope.halfOpenProbe || isClientTimeoutGatewayError(lastErr) {
-				c.recordCircuitBreakerCompletion(lastStatusCode, lastErr)
-				c.finishRequest(scope, lastStatusCode, lastErr)
+				c.completeScope(scope, lastStatusCode, lastErr, lastErr)
 				return nil, lastErr
 			}
 			continue
@@ -353,8 +380,7 @@ func (c *Client) DoRaw(ctx context.Context, req Request) (*Response, error) {
 			lastStatusCode = resp.StatusCode
 			lastErrFromTransport = false
 			if scope.halfOpenProbe {
-				c.recordCircuitBreakerCompletion(lastStatusCode, nil)
-				c.finishRequest(scope, lastStatusCode, lastErr)
+				c.completeScope(scope, lastStatusCode, lastErr, nil)
 				return nil, lastErr
 			}
 			continue
@@ -362,15 +388,13 @@ func (c *Client) DoRaw(ctx context.Context, req Request) (*Response, error) {
 
 		// Non-retryable error
 		if resp.StatusCode != http.StatusOK {
-			c.recordCircuitBreakerCompletion(resp.StatusCode, nil)
-			err := core.ParseProviderError(c.config.ProviderName, resp.StatusCode, resp.Body, nil)
-			c.finishRequest(scope, resp.StatusCode, err)
-			return nil, err
+			parsedErr := core.ParseProviderError(c.config.ProviderName, resp.StatusCode, resp.Body, nil)
+			c.completeScope(scope, resp.StatusCode, parsedErr, nil)
+			return nil, parsedErr
 		}
 
 		// Success
-		c.recordCircuitBreakerCompletion(resp.StatusCode, nil)
-		c.finishRequest(scope, resp.StatusCode, nil)
+		c.completeScope(scope, resp.StatusCode, nil, nil)
 		return resp, nil
 	}
 
@@ -380,14 +404,10 @@ func (c *Client) DoRaw(ctx context.Context, req Request) (*Response, error) {
 		if lastErrFromTransport {
 			circuitErr = lastErr
 		}
-		c.recordCircuitBreakerCompletion(lastStatusCode, circuitErr)
-		c.finishRequest(scope, lastStatusCode, lastErr)
+		c.completeScope(scope, lastStatusCode, lastErr, circuitErr)
 		return nil, lastErr
 	}
-	err = core.NewProviderError(c.config.ProviderName, http.StatusBadGateway, "request failed after retries", nil)
-	c.recordCircuitBreakerCompletion(http.StatusBadGateway, err)
-	c.finishRequest(scope, http.StatusBadGateway, err)
-	return nil, err
+	return nil, c.failAfterRetries(scope)
 }
 
 // DoStream executes a streaming request, returning a ReadCloser
@@ -401,8 +421,8 @@ func (c *Client) DoStream(ctx context.Context, req Request) (io.ReadCloser, erro
 
 	resp, err := c.doHTTPRequest(scope.ctx, req)
 	if err != nil {
-		c.recordCircuitBreakerCompletion(extractStatusCode(err), err)
-		c.finishRequest(scope, extractStatusCode(err), err)
+		statusCode := extractStatusCode(err)
+		c.completeScope(scope, statusCode, err, err)
 		return nil, err
 	}
 
@@ -413,14 +433,12 @@ func (c *Client) DoStream(ctx context.Context, req Request) (io.ReadCloser, erro
 		}
 		_ = resp.Body.Close()
 
-		c.recordCircuitBreakerCompletion(resp.StatusCode, nil)
 		providerErr := core.ParseProviderError(c.config.ProviderName, resp.StatusCode, respBody, nil)
-		c.finishRequest(scope, resp.StatusCode, providerErr)
+		c.completeScope(scope, resp.StatusCode, providerErr, nil)
 		return nil, providerErr
 	}
 
-	c.recordCircuitBreakerCompletion(resp.StatusCode, nil)
-	c.finishRequest(scope, resp.StatusCode, nil)
+	c.completeScope(scope, resp.StatusCode, nil, nil)
 	return resp.Body, nil
 }
 
@@ -469,8 +487,7 @@ func (c *Client) DoPassthrough(ctx context.Context, req Request) (*http.Response
 	}
 
 	for attempt := 0; attempt < maxAttempts; attempt++ {
-		if err := c.waitForRetry(ctx, attempt); err != nil {
-			c.finishRequest(scope, 0, err)
+		if err := c.waitForRetryAttempt(ctx, scope, attempt); err != nil {
 			return nil, err
 		}
 
@@ -478,8 +495,7 @@ func (c *Client) DoPassthrough(ctx context.Context, req Request) (*http.Response
 		if err != nil {
 			statusCode := extractStatusCode(err)
 			if scope.halfOpenProbe || isClientTimeoutGatewayError(err) || attempt == maxAttempts-1 {
-				c.recordCircuitBreakerCompletion(statusCode, err)
-				c.finishRequest(scope, statusCode, err)
+				c.completeScope(scope, statusCode, err, err)
 				return nil, err
 			}
 			continue
@@ -488,23 +504,18 @@ func (c *Client) DoPassthrough(ctx context.Context, req Request) (*http.Response
 		retryable := c.isRetryable(resp.StatusCode)
 		if retryable {
 			if scope.halfOpenProbe || attempt == maxAttempts-1 {
-				c.recordCircuitBreakerCompletion(resp.StatusCode, nil)
-				c.finishRequest(scope, resp.StatusCode, nil)
+				c.completeScope(scope, resp.StatusCode, nil, nil)
 				return resp, nil
 			}
 			_ = resp.Body.Close()
 			continue
 		}
 
-		c.recordCircuitBreakerCompletion(resp.StatusCode, nil)
-		c.finishRequest(scope, resp.StatusCode, nil)
+		c.completeScope(scope, resp.StatusCode, nil, nil)
 		return resp, nil
 	}
 
-	err = core.NewProviderError(c.config.ProviderName, http.StatusBadGateway, "request failed after retries", nil)
-	c.recordCircuitBreakerCompletion(http.StatusBadGateway, err)
-	c.finishRequest(scope, http.StatusBadGateway, err)
-	return nil, err
+	return nil, c.failAfterRetries(scope)
 }
 
 // extractModel attempts to extract the model name from a request body

--- a/internal/llmclient/client.go
+++ b/internal/llmclient/client.go
@@ -364,6 +364,13 @@ func (c *Client) DoRaw(ctx context.Context, req Request) (*Response, error) {
 		if err != nil {
 			lastErr = err
 			lastStatusCode = extractStatusCode(err)
+			// Caller-side build errors (validation, body conflicts, marshal
+			// failures) will repeat deterministically and never reached the
+			// upstream — short-circuit without retrying or charging the breaker.
+			if isLocalRequestBuildError(err) {
+				c.completeScope(scope, lastStatusCode, err, nil)
+				return nil, err
+			}
 			lastErrFromTransport = true
 			// Client-side timeouts are already the caller's latency budget. Do
 			// not retry them, or the logical request can outlive HTTP_TIMEOUT.
@@ -422,7 +429,13 @@ func (c *Client) DoStream(ctx context.Context, req Request) (io.ReadCloser, erro
 	resp, err := c.doHTTPRequest(scope.ctx, req)
 	if err != nil {
 		statusCode := extractStatusCode(err)
-		c.completeScope(scope, statusCode, err, err)
+		// Caller-side build errors must not charge the breaker: the upstream
+		// was never contacted.
+		var cbErr error
+		if !isLocalRequestBuildError(err) {
+			cbErr = err
+		}
+		c.completeScope(scope, statusCode, err, cbErr)
 		return nil, err
 	}
 
@@ -494,6 +507,11 @@ func (c *Client) DoPassthrough(ctx context.Context, req Request) (*http.Response
 		resp, err := c.doHTTPRequest(ctx, req)
 		if err != nil {
 			statusCode := extractStatusCode(err)
+			// Caller-side build errors will repeat and never hit the upstream.
+			if isLocalRequestBuildError(err) {
+				c.completeScope(scope, statusCode, err, nil)
+				return nil, err
+			}
 			if scope.halfOpenProbe || isClientTimeoutGatewayError(err) || attempt == maxAttempts-1 {
 				c.completeScope(scope, statusCode, err, err)
 				return nil, err
@@ -713,6 +731,28 @@ func isTimeoutError(err error) bool {
 	message := strings.ToLower(err.Error())
 	return strings.Contains(message, "client.timeout exceeded") ||
 		strings.Contains(message, "timeout awaiting response headers")
+}
+
+// isLocalRequestBuildError reports whether err originated from buildRequest
+// (e.g. an empty endpoint, an invalid HTTP method, mutually-exclusive bodies,
+// or a marshal failure). Such errors are caller-side: they will repeat
+// deterministically on retry and must not be charged to the circuit breaker
+// because the upstream provider was never contacted.
+//
+// buildRequest is the only producer of *core.GatewayError with type
+// ErrorTypeInvalidRequest along the doRequest/doHTTPRequest path — the other
+// transport-layer wrappers all use NewProviderError. ParseProviderError runs
+// only on a returned response body, so an InvalidRequest seen in the
+// transport-error branch can only have come from buildRequest.
+func isLocalRequestBuildError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var gatewayErr *core.GatewayError
+	if !errors.As(err, &gatewayErr) || gatewayErr == nil {
+		return false
+	}
+	return gatewayErr.Type == core.ErrorTypeInvalidRequest
 }
 
 func isClientTimeoutGatewayError(err error) bool {

--- a/internal/llmclient/client.go
+++ b/internal/llmclient/client.go
@@ -366,9 +366,11 @@ func (c *Client) DoRaw(ctx context.Context, req Request) (*Response, error) {
 			lastStatusCode = extractStatusCode(err)
 			// Caller-side build errors (validation, body conflicts, marshal
 			// failures) will repeat deterministically and never reached the
-			// upstream — short-circuit without retrying or charging the breaker.
+			// upstream — short-circuit without retrying and skip the breaker
+			// entirely (a 400 with cbErr=nil would otherwise be recorded as
+			// a success by recordCircuitBreakerCompletion).
 			if isLocalRequestBuildError(err) {
-				c.completeScope(scope, lastStatusCode, err, nil)
+				c.finishRequest(scope, lastStatusCode, err)
 				return nil, err
 			}
 			lastErrFromTransport = true
@@ -429,13 +431,13 @@ func (c *Client) DoStream(ctx context.Context, req Request) (io.ReadCloser, erro
 	resp, err := c.doHTTPRequest(scope.ctx, req)
 	if err != nil {
 		statusCode := extractStatusCode(err)
-		// Caller-side build errors must not charge the breaker: the upstream
-		// was never contacted.
-		var cbErr error
-		if !isLocalRequestBuildError(err) {
-			cbErr = err
+		// Caller-side build errors never reached the upstream — skip the
+		// breaker entirely so neither RecordFailure nor RecordSuccess fires.
+		if isLocalRequestBuildError(err) {
+			c.finishRequest(scope, statusCode, err)
+			return nil, err
 		}
-		c.completeScope(scope, statusCode, err, cbErr)
+		c.completeScope(scope, statusCode, err, err)
 		return nil, err
 	}
 
@@ -507,9 +509,11 @@ func (c *Client) DoPassthrough(ctx context.Context, req Request) (*http.Response
 		resp, err := c.doHTTPRequest(ctx, req)
 		if err != nil {
 			statusCode := extractStatusCode(err)
-			// Caller-side build errors will repeat and never hit the upstream.
+			// Caller-side build errors will repeat and never hit the upstream;
+			// skip the breaker entirely (cbErr=nil would otherwise record a
+			// spurious success for a 400-class status).
 			if isLocalRequestBuildError(err) {
-				c.completeScope(scope, statusCode, err, nil)
+				c.finishRequest(scope, statusCode, err)
 				return nil, err
 			}
 			if scope.halfOpenProbe || isClientTimeoutGatewayError(err) || attempt == maxAttempts-1 {

--- a/internal/llmclient/client_test.go
+++ b/internal/llmclient/client_test.go
@@ -718,10 +718,15 @@ func TestClient_DoStream_Error(t *testing.T) {
 // charging the circuit breaker — the upstream was never contacted, so the
 // retry would just repeat the validation failure and the breaker should not
 // blame the provider.
+//
+// The closed-state subtests verify that build errors don't trip a healthy
+// breaker. The half-open subtests verify that build errors don't advance the
+// breaker state machine in either direction (no failure recorded → no
+// transition back to open; no success counted → no progress toward closed).
 func TestClient_BuildErrorDoesNotRetryOrChargeBreaker(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
+	entries := []struct {
 		name string
 		call func(t *testing.T, client *Client) error
 	}{
@@ -748,43 +753,78 @@ func TestClient_BuildErrorDoesNotRetryOrChargeBreaker(t *testing.T) {
 		},
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			var attempts int32
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				atomic.AddInt32(&attempts, 1)
-			}))
-			defer server.Close()
+	states := []struct {
+		name      string
+		preSeed   func(cb *circuitBreaker)
+		wantState string
+	}{
+		{
+			name:      "closed",
+			preSeed:   func(*circuitBreaker) {},
+			wantState: "closed",
+		},
+		{
+			// Half-open with the probe slot available: the breaker grants the
+			// probe, so the build error fires through the normal request path.
+			// We then assert the breaker stayed half-open — the build error
+			// must not record a success (which would advance toward closed)
+			// nor a failure (which would reopen the breaker).
+			name: "half_open",
+			preSeed: func(cb *circuitBreaker) {
+				cb.mu.Lock()
+				defer cb.mu.Unlock()
+				cb.state = circuitHalfOpen
+				cb.failures = cb.failureThreshold
+				cb.successes = 0
+				cb.halfOpenAllowed = true
+				cb.lastFailure = time.Now().Add(-cb.timeout - time.Millisecond)
+			},
+			wantState: "half-open",
+		},
+	}
 
-			config := DefaultConfig("test", server.URL)
-			config.Retry.MaxRetries = 3
-			config.Retry.InitialBackoff = time.Millisecond
-			config.Retry.JitterFactor = 0
-			config.CircuitBreaker = goconfig.CircuitBreakerConfig{
-				FailureThreshold: 1,
-				SuccessThreshold: 2,
-				Timeout:          time.Second,
-			}
-			client := New(config, nil)
+	for _, st := range states {
+		st := st
+		for _, e := range entries {
+			e := e
+			t.Run(st.name+"/"+e.name, func(t *testing.T) {
+				var attempts int32
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					atomic.AddInt32(&attempts, 1)
+				}))
+				defer server.Close()
 
-			err := tc.call(t, client)
-			if err == nil {
-				t.Fatal("expected error, got nil")
-			}
-			var gwErr *core.GatewayError
-			if !errors.As(err, &gwErr) {
-				t.Fatalf("expected *core.GatewayError, got %T: %v", err, err)
-			}
-			if gwErr.Type != core.ErrorTypeInvalidRequest {
-				t.Errorf("error type = %s, want %s", gwErr.Type, core.ErrorTypeInvalidRequest)
-			}
-			if got := atomic.LoadInt32(&attempts); got != 0 {
-				t.Errorf("server received %d attempts; want 0 (build errors must not be retried)", got)
-			}
-			if state := client.circuitBreaker.State(); state != "closed" {
-				t.Errorf("breaker state = %q; want closed (build errors must not charge the breaker)", state)
-			}
-		})
+				config := DefaultConfig("test", server.URL)
+				config.Retry.MaxRetries = 3
+				config.Retry.InitialBackoff = time.Millisecond
+				config.Retry.JitterFactor = 0
+				config.CircuitBreaker = goconfig.CircuitBreakerConfig{
+					FailureThreshold: 1,
+					SuccessThreshold: 2,
+					Timeout:          time.Second,
+				}
+				client := New(config, nil)
+				st.preSeed(client.circuitBreaker)
+
+				err := e.call(t, client)
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				var gwErr *core.GatewayError
+				if !errors.As(err, &gwErr) {
+					t.Fatalf("expected *core.GatewayError, got %T: %v", err, err)
+				}
+				if gwErr.Type != core.ErrorTypeInvalidRequest {
+					t.Errorf("error type = %s, want %s", gwErr.Type, core.ErrorTypeInvalidRequest)
+				}
+				if got := atomic.LoadInt32(&attempts); got != 0 {
+					t.Errorf("server received %d attempts; want 0 (build errors must not be retried)", got)
+				}
+				if state := client.circuitBreaker.State(); state != st.wantState {
+					t.Errorf("breaker state = %q; want %q (build errors must not advance the breaker)", state, st.wantState)
+				}
+			})
+		}
 	}
 }
 

--- a/internal/llmclient/client_test.go
+++ b/internal/llmclient/client_test.go
@@ -712,6 +712,82 @@ func TestClient_DoStream_Error(t *testing.T) {
 	}
 }
 
+// TestClient_BuildErrorDoesNotRetryOrChargeBreaker verifies that caller-side
+// request-construction failures (an invalid HTTP method, in this case)
+// short-circuit out of every Do* entry point without retrying and without
+// charging the circuit breaker — the upstream was never contacted, so the
+// retry would just repeat the validation failure and the breaker should not
+// blame the provider.
+func TestClient_BuildErrorDoesNotRetryOrChargeBreaker(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		call func(t *testing.T, client *Client) error
+	}{
+		{
+			name: "DoRaw",
+			call: func(t *testing.T, client *Client) error {
+				_, err := client.DoRaw(context.Background(), Request{Method: "INVALID", Endpoint: "/test"})
+				return err
+			},
+		},
+		{
+			name: "DoStream",
+			call: func(t *testing.T, client *Client) error {
+				_, err := client.DoStream(context.Background(), Request{Method: "INVALID", Endpoint: "/test"})
+				return err
+			},
+		},
+		{
+			name: "DoPassthrough",
+			call: func(t *testing.T, client *Client) error {
+				_, err := client.DoPassthrough(context.Background(), Request{Method: "INVALID", Endpoint: "/test"})
+				return err
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var attempts int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				atomic.AddInt32(&attempts, 1)
+			}))
+			defer server.Close()
+
+			config := DefaultConfig("test", server.URL)
+			config.Retry.MaxRetries = 3
+			config.Retry.InitialBackoff = time.Millisecond
+			config.Retry.JitterFactor = 0
+			config.CircuitBreaker = goconfig.CircuitBreakerConfig{
+				FailureThreshold: 1,
+				SuccessThreshold: 2,
+				Timeout:          time.Second,
+			}
+			client := New(config, nil)
+
+			err := tc.call(t, client)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			var gwErr *core.GatewayError
+			if !errors.As(err, &gwErr) {
+				t.Fatalf("expected *core.GatewayError, got %T: %v", err, err)
+			}
+			if gwErr.Type != core.ErrorTypeInvalidRequest {
+				t.Errorf("error type = %s, want %s", gwErr.Type, core.ErrorTypeInvalidRequest)
+			}
+			if got := atomic.LoadInt32(&attempts); got != 0 {
+				t.Errorf("server received %d attempts; want 0 (build errors must not be retried)", got)
+			}
+			if state := client.circuitBreaker.State(); state != "closed" {
+				t.Errorf("breaker state = %q; want closed (build errors must not charge the breaker)", state)
+			}
+		})
+	}
+}
+
 // TestRequest_Validation tests validation of Request fields
 func TestRequest_Validation(t *testing.T) {
 	config := DefaultConfig("test", "http://localhost")

--- a/internal/providers/registry_init.go
+++ b/internal/providers/registry_init.go
@@ -31,28 +31,72 @@ func (r *ModelRegistry) Initialize(ctx context.Context) error {
 }
 
 func (r *ModelRegistry) initialize(ctx context.Context) error {
-	// Get a snapshot of providers with a read lock
+	providers, providerTypes, providerNames := r.snapshotProviders()
+	configuredProviderModels, configuredProviderModelsMode := r.snapshotConfiguredProviderModels()
+
+	fetched := r.fetchAllProviderModels(
+		ctx,
+		providers,
+		providerTypes,
+		providerNames,
+		configuredProviderModels,
+		configuredProviderModelsMode,
+	)
+
+	if fetched.totalModels == 0 {
+		r.applyProviderRuntimeUpdates(fetched.runtimeUpdates)
+		if fetched.failedProviders == len(providers) {
+			return fmt.Errorf("failed to fetch models from any provider")
+		}
+		return fmt.Errorf("no models available: providers returned empty model lists")
+	}
+
+	r.applyFetchedInventory(providerTypes, fetched, len(providers))
+	return nil
+}
+
+// snapshotProviders copies the registry's provider slice and type/name maps
+// under a read lock so the rest of initialize can run without contending with
+// readers.
+func (r *ModelRegistry) snapshotProviders() ([]core.Provider, map[core.Provider]string, map[core.Provider]string) {
 	r.mu.RLock()
+	defer r.mu.RUnlock()
 	providers := make([]core.Provider, len(r.providers))
 	copy(providers, r.providers)
-	r.mu.RUnlock()
-
-	// Build new model maps without holding the lock.
-	// This allows concurrent reads to continue using the existing map
-	// while we fetch models from providers (which may involve network calls).
-	newModels := make(map[string]*ModelInfo)
-	newModelsByProvider := make(map[string]map[string]*ModelInfo)
-	var totalModels int
-	var failedProviders int
-	runtimeUpdates := make(map[string]providerRuntimeState)
-
-	r.mu.RLock()
 	providerTypes := make(map[core.Provider]string, len(r.providerTypes))
 	providerNames := make(map[core.Provider]string, len(r.providerNames))
 	maps.Copy(providerTypes, r.providerTypes)
 	maps.Copy(providerNames, r.providerNames)
-	r.mu.RUnlock()
-	configuredProviderModels, configuredProviderModelsMode := r.snapshotConfiguredProviderModels()
+	return providers, providerTypes, providerNames
+}
+
+// fetchedInventory captures the result of one full provider fetch sweep.
+// Shared by initial population and full refresh.
+type fetchedInventory struct {
+	models           map[string]*ModelInfo
+	modelsByProvider map[string]map[string]*ModelInfo
+	runtimeUpdates   map[string]providerRuntimeState
+	totalModels      int
+	failedProviders  int
+}
+
+// fetchAllProviderModels runs ListModels (or applies a configured allowlist)
+// for every registered provider and aggregates the results. Network calls
+// happen outside any registry lock so live readers keep serving the previous
+// inventory.
+func (r *ModelRegistry) fetchAllProviderModels(
+	ctx context.Context,
+	providers []core.Provider,
+	providerTypes map[core.Provider]string,
+	providerNames map[core.Provider]string,
+	configuredProviderModels map[string][]string,
+	configuredProviderModelsMode config.ConfiguredProviderModelsMode,
+) fetchedInventory {
+	out := fetchedInventory{
+		models:           make(map[string]*ModelInfo),
+		modelsByProvider: make(map[string]map[string]*ModelInfo),
+		runtimeUpdates:   make(map[string]providerRuntimeState),
+	}
 
 	for _, provider := range providers {
 		providerName := providerNames[provider]
@@ -95,8 +139,8 @@ func (r *ModelRegistry) initialize(ctx context.Context) error {
 				"provider", providerName,
 				"error", err,
 			)
-			failedProviders++
-			runtimeUpdates[providerName] = providerRuntimeState{
+			out.failedProviders++
+			out.runtimeUpdates[providerName] = providerRuntimeState{
 				registered:          true,
 				lastModelFetchAt:    fetchAt,
 				lastModelFetchError: err.Error(),
@@ -110,8 +154,8 @@ func (r *ModelRegistry) initialize(ctx context.Context) error {
 				"provider", providerName,
 				"error", err,
 			)
-			failedProviders++
-			runtimeUpdates[providerName] = providerRuntimeState{
+			out.failedProviders++
+			out.runtimeUpdates[providerName] = providerRuntimeState{
 				registered:          true,
 				lastModelFetchAt:    fetchAt,
 				lastModelFetchError: err.Error(),
@@ -124,13 +168,13 @@ func (r *ModelRegistry) initialize(ctx context.Context) error {
 			slog.Warn("provider returned empty model list",
 				"provider", providerName,
 			)
-			runtimeUpdates[providerName] = providerRuntimeState{
+			out.runtimeUpdates[providerName] = providerRuntimeState{
 				registered:          true,
 				lastModelFetchAt:    fetchAt,
 				lastModelFetchError: err.Error(),
 			}
-			if _, ok := newModelsByProvider[providerName]; !ok {
-				newModelsByProvider[providerName] = make(map[string]*ModelInfo)
+			if _, ok := out.modelsByProvider[providerName]; !ok {
+				out.modelsByProvider[providerName] = make(map[string]*ModelInfo)
 			}
 			continue
 		}
@@ -143,10 +187,10 @@ func (r *ModelRegistry) initialize(ctx context.Context) error {
 		if configuredReason == configuredProviderModelsNotApplied {
 			runtimeUpdate.lastModelFetchSuccessAt = fetchAt
 		}
-		runtimeUpdates[providerName] = runtimeUpdate
+		out.runtimeUpdates[providerName] = runtimeUpdate
 
-		if _, ok := newModelsByProvider[providerName]; !ok {
-			newModelsByProvider[providerName] = make(map[string]*ModelInfo, len(resp.Data))
+		if _, ok := out.modelsByProvider[providerName]; !ok {
+			out.modelsByProvider[providerName] = make(map[string]*ModelInfo, len(resp.Data))
 		}
 
 		for _, model := range resp.Data {
@@ -156,11 +200,11 @@ func (r *ModelRegistry) initialize(ctx context.Context) error {
 				ProviderName: providerName,
 				ProviderType: providerTypes[provider],
 			}
-			newModelsByProvider[providerName][model.ID] = info
+			out.modelsByProvider[providerName][model.ID] = info
 
-			if _, exists := newModels[model.ID]; exists {
-				// Model already registered by another provider, skip
-				// First provider wins for unqualified lookups.
+			if _, exists := out.models[model.ID]; exists {
+				// First provider wins for unqualified lookups; later duplicates
+				// stay reachable via modelsByProvider but lose the bare-id slot.
 				slog.Debug("model already registered, skipping",
 					"model", model.ID,
 					"provider", providerName,
@@ -169,52 +213,50 @@ func (r *ModelRegistry) initialize(ctx context.Context) error {
 				continue
 			}
 
-			newModels[model.ID] = info
-			totalModels++
+			out.models[model.ID] = info
+			out.totalModels++
 		}
 	}
 
-	if totalModels == 0 {
-		r.applyProviderRuntimeUpdates(runtimeUpdates)
-		if failedProviders == len(providers) {
-			return fmt.Errorf("failed to fetch models from any provider")
-		}
-		return fmt.Errorf("no models available: providers returned empty model lists")
-	}
+	return out
+}
 
-	// Enrich models with metadata from the model list (if loaded)
+// applyFetchedInventory enriches the freshly fetched maps with metadata,
+// atomically swaps them onto the registry, marks initialized, and emits the
+// summary log line.
+func (r *ModelRegistry) applyFetchedInventory(
+	providerTypes map[core.Provider]string,
+	fetched fetchedInventory,
+	totalProviders int,
+) {
 	r.mu.RLock()
 	list := r.modelList
 	r.mu.RUnlock()
 	configOverrides := r.snapshotConfigOverrides()
 	metadataStats := metadataEnrichmentStats{}
 	if list != nil {
-		metadataStats = enrichProviderModelMaps(list, providerTypes, newModelsByProvider, nil)
+		metadataStats = enrichProviderModelMaps(list, providerTypes, fetched.modelsByProvider, nil)
 	}
-	metadataStats.Enriched += applyConfigMetadataOverrides(configOverrides, newModelsByProvider, nil)
+	metadataStats.Enriched += applyConfigMetadataOverrides(configOverrides, fetched.modelsByProvider, nil)
 
-	// Atomically swap the models map and invalidate sorted caches
 	r.mu.Lock()
-	r.models = newModels
-	r.modelsByProvider = newModelsByProvider
-	r.applyProviderRuntimeUpdatesLocked(runtimeUpdates)
+	r.models = fetched.models
+	r.modelsByProvider = fetched.modelsByProvider
+	r.applyProviderRuntimeUpdatesLocked(fetched.runtimeUpdates)
 	r.invalidateSortedCaches()
 	r.mu.Unlock()
 
-	// Mark as initialized
 	r.initMu.Lock()
 	r.initialized = true
 	r.initMu.Unlock()
 
 	attrs := []any{
-		"total_models", totalModels,
-		"providers", len(providers),
-		"failed_providers", failedProviders,
+		"total_models", fetched.totalModels,
+		"providers", totalProviders,
+		"failed_providers", fetched.failedProviders,
 	}
 	attrs = append(attrs, metadataStats.slogAttrs()...)
 	slog.Info("model registry initialized", attrs...)
-
-	return nil
 }
 
 func fetchProviderInventory(


### PR DESCRIPTION
## Summary

Three focused extractions identified during the tier 3 refactor pass. Each commit is independent, behaviour-preserving, and covered by existing tests.

- **`refactor(admin): extract provider-status helpers`** — `buildProviderStatusResponse` is now `collect inputs → build per-provider item → summarise`. The single 92-line function becomes three named steps.
- **`refactor(providers): split ModelRegistry.initialize into named phases`** — pull the per-provider fetch loop into `fetchAllProviderModels` and the enrich + atomic-swap + initialised work into `applyFetchedInventory`. Orchestrator drops to ~25 lines reading as snapshot → fetch → apply. Same locking, runtime updates, log lines and error paths.
- **`refactor(llmclient): collapse scope finalisation into helpers`** — three new helpers (`completeScope`, `failAfterRetries`, `waitForRetryAttempt`) replace 11 paired `recordCircuitBreakerCompletion`/`finishRequest` call sites in `DoRaw`/`DoStream`/`DoPassthrough`. Transport-vs-HTTP CB classification is now an explicit parameter at every site.

No public API change. Hot-path perf guard still passes.

## Test plan

- [x] `go test ./...` — green
- [x] `make lint` — 0 issues
- [x] `make test-race` (via pre-commit) — green
- [x] hot-path perf guard — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated request completion and retry handling for more consistent error reporting and circuit-breaker behavior.
  * Reworked provider status assembly and overall status calculation for clearer, deterministic responses.
  * Rebuilt model registry initialization into a staged pipeline to reduce lock contention and improve inventory application.
* **Tests**
  * Added tests ensuring invalid client request builds short-circuit without retries or circuit-breaker impact, and tests validating provider-status item classification and synthesis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->