### PR TITLE
fix(usage): track xAI response costs

### DIFF
--- a/internal/admin/dashboard/static/js/modules/usage.js
+++ b/internal/admin/dashboard/static/js/modules/usage.js
@@ -7,6 +7,10 @@
             return path;
         }
 
+        function costSource(entry) {
+            return String((entry && entry.cost_source) || '').trim();
+        }
+
         return {
             emptyUsageSummary() {
                 return {
@@ -356,14 +360,23 @@
             },
 
             usesOpenRouterCreditPricing(entry) {
-                return String((entry && entry.cost_source) || '').trim() === 'openrouter_credits';
+                return costSource(entry) === 'openrouter_credits';
+            },
+
+            usesResponseCostPricing(entry) {
+                const source = costSource(entry);
+                return source === 'openrouter_credits' || source === 'xai_cost_in_usd_ticks';
             },
 
             costSourceTooltip(entry) {
-                if (this.usesOpenRouterCreditPricing(entry)) {
+                switch (costSource(entry)) {
+                case 'openrouter_credits':
                     return 'Costs from OpenRouter USD-based credits.';
+                case 'xai_cost_in_usd_ticks':
+                    return 'Costs from xAI usage.cost_in_usd_ticks.';
+                default:
+                    return '';
                 }
-                return '';
             }
         };
     }

--- a/internal/admin/dashboard/static/js/modules/usage.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/usage.test.cjs
@@ -28,16 +28,30 @@ test('usesOpenRouterCreditPricing detects OpenRouter credit cost source', () => 
     const module = createUsageModule();
 
     assert.equal(module.usesOpenRouterCreditPricing({ cost_source: 'openrouter_credits' }), true);
+    assert.equal(module.usesOpenRouterCreditPricing({ cost_source: 'xai_cost_in_usd_ticks' }), false);
     assert.equal(module.usesOpenRouterCreditPricing({ cost_source: 'model_pricing' }), false);
     assert.equal(module.usesOpenRouterCreditPricing({}), false);
 });
 
-test('costSourceTooltip explains OpenRouter credit costs', () => {
+test('usesResponseCostPricing detects provider-reported costs', () => {
+    const module = createUsageModule();
+
+    assert.equal(module.usesResponseCostPricing({ cost_source: 'openrouter_credits' }), true);
+    assert.equal(module.usesResponseCostPricing({ cost_source: 'xai_cost_in_usd_ticks' }), true);
+    assert.equal(module.usesResponseCostPricing({ cost_source: 'model_pricing' }), false);
+    assert.equal(module.usesResponseCostPricing({}), false);
+});
+
+test('costSourceTooltip explains provider-reported costs', () => {
     const module = createUsageModule();
 
     assert.equal(
         module.costSourceTooltip({ cost_source: 'openrouter_credits' }),
         'Costs from OpenRouter USD-based credits.'
+    );
+    assert.equal(
+        module.costSourceTooltip({ cost_source: 'xai_cost_in_usd_ticks' }),
+        'Costs from xAI usage.cost_in_usd_ticks.'
     );
     assert.equal(module.costSourceTooltip({ cost_source: 'model_pricing' }), '');
 });

--- a/internal/admin/dashboard/templates/page-usage.html
+++ b/internal/admin/dashboard/templates/page-usage.html
@@ -186,13 +186,13 @@
                             <td class="col-price">
                                 <span x-text="usageMode === 'costs' ? formatCost(entry.total_cost) : formatNumber(entry.total_tokens)"
                                       :title="usageMode === 'costs' ? formatNumber(entry.total_tokens) + ' tokens\n' + formatCostTooltip(entry) : ''"></span>
-                                <i data-lucide="circle-dollar-sign" class="cost-source-icon" x-show="usageMode === 'costs' && usesOpenRouterCreditPricing(entry)" :title="costSourceTooltip(entry)" aria-hidden="true"></i>
+                                <i data-lucide="circle-dollar-sign" class="cost-source-icon" x-show="usageMode === 'costs' && usesResponseCostPricing(entry)" :title="costSourceTooltip(entry)" aria-hidden="true"></i>
                                 <span class="caveat-icon" x-show="usageMode === 'costs' && entry.costs_calculation_caveat" :title="entry.costs_calculation_caveat">&#9888;</span>
                             </td>
                             <td class="col-price" x-show="usageMode === 'tokens'"
                                 :title="formatCostTooltip(entry)">
                                 <span x-text="formatCost(entry.total_cost)"></span>
-                                <i data-lucide="circle-dollar-sign" class="cost-source-icon" x-show="usesOpenRouterCreditPricing(entry)" :title="costSourceTooltip(entry)" aria-hidden="true"></i>
+                                <i data-lucide="circle-dollar-sign" class="cost-source-icon" x-show="usesResponseCostPricing(entry)" :title="costSourceTooltip(entry)" aria-hidden="true"></i>
                                 <span class="caveat-icon" x-show="entry.costs_calculation_caveat" :title="entry.costs_calculation_caveat">&#9888;</span>
                             </td>
                         </tr>

--- a/internal/gateway/batch_usage_test.go
+++ b/internal/gateway/batch_usage_test.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"math"
 	"testing"
 
 	batchstore "gomodel/internal/batch"
@@ -83,5 +84,67 @@ func TestLogBatchUsageFromBatchResultsOnlySetsObservedCostComponents(t *testing.
 	}
 	if got.TotalCost == nil || *got.TotalCost != inputRate {
 		t.Fatalf("TotalCost = %#v, want %.2f", got.TotalCost, inputRate)
+	}
+}
+
+func TestLogBatchUsageFromBatchResultsUsesXAITicks(t *testing.T) {
+	outputRate := 999.0
+	logger := &batchUsageCaptureLogger{config: usage.Config{Enabled: true}}
+	stored := &batchstore.StoredBatch{
+		Batch: &core.BatchResponse{
+			ID:       "batch_xai_ticks",
+			Provider: "xai",
+		},
+		RequestID: "req-batch-xai-ticks",
+	}
+	result := &core.BatchResultsResponse{
+		Object:  "list",
+		BatchID: "batch_xai_ticks",
+		Data: []core.BatchResultItem{
+			{
+				Index:      0,
+				StatusCode: 200,
+				Model:      "grok-4.3",
+				Provider:   "xai",
+				Response: map[string]any{
+					"id":    "resp-xai-batch",
+					"model": "grok-4.3",
+					"usage": map[string]any{
+						"input_tokens":      float64(199),
+						"output_tokens":     float64(1),
+						"total_tokens":      float64(200),
+						"cost_in_usd_ticks": float64(158_500),
+						"num_sources_used":  float64(2),
+					},
+				},
+			},
+		},
+	}
+
+	logged := LogBatchUsageFromBatchResults(
+		stored,
+		result,
+		"",
+		logger,
+		staticBatchPricingResolver{pricing: &core.ModelPricing{OutputPerMtok: &outputRate}},
+	)
+	if !logged {
+		t.Fatal("LogBatchUsageFromBatchResults() = false, want true")
+	}
+	if len(logger.entries) != 1 {
+		t.Fatalf("logged entries = %d, want 1", len(logger.entries))
+	}
+	entry := logger.entries[0]
+	if entry.CostSource != usage.CostSourceXAITicks {
+		t.Fatalf("CostSource = %q, want %q", entry.CostSource, usage.CostSourceXAITicks)
+	}
+	if entry.TotalCost == nil || math.Abs(*entry.TotalCost-0.00001585) > 1e-12 {
+		t.Fatalf("TotalCost = %#v, want 0.00001585", entry.TotalCost)
+	}
+	if entry.InputCost != nil || entry.OutputCost != nil {
+		t.Fatalf("InputCost/OutputCost = %#v/%#v, want nil response split", entry.InputCost, entry.OutputCost)
+	}
+	if stored.Batch.Usage.TotalCost == nil || math.Abs(*stored.Batch.Usage.TotalCost-0.00001585) > 1e-12 {
+		t.Fatalf("stored TotalCost = %#v, want 0.00001585", stored.Batch.Usage.TotalCost)
 	}
 }

--- a/internal/usage/cost.go
+++ b/internal/usage/cost.go
@@ -18,6 +18,8 @@ const (
 	CostSourceXAITicks          = "xai_cost_in_usd_ticks"
 )
 
+// xAI reports usage.cost_in_usd_ticks as USD-denominated ticks, where 10^10
+// ticks equals 1 USD.
 const xaiUSDTicksPerUSD = 10_000_000_000
 
 // CostResult holds the result of a granular cost calculation.

--- a/internal/usage/cost.go
+++ b/internal/usage/cost.go
@@ -15,7 +15,10 @@ import (
 const (
 	CostSourceModelPricing      = "model_pricing"
 	CostSourceOpenRouterCredits = "openrouter_credits"
+	CostSourceXAITicks          = "xai_cost_in_usd_ticks"
 )
+
+const xaiUSDTicksPerUSD = 10_000_000_000
 
 // CostResult holds the result of a granular cost calculation.
 type CostResult struct {
@@ -267,6 +270,9 @@ func CalculateUsageCost(inputTokens, outputTokens int, rawData map[string]any, p
 	if result, ok := openRouterCreditCost(rawData, providerType); ok {
 		return result
 	}
+	if result, ok := xaiTicksCost(rawData, providerType); ok {
+		return result
+	}
 	return CalculateGranularCost(inputTokens, outputTokens, rawData, providerType, pricing)
 }
 
@@ -294,6 +300,26 @@ func openRouterCreditCost(rawData map[string]any, providerType string) (CostResu
 
 func isOpenRouterProvider(providerType string) bool {
 	return strings.EqualFold(strings.TrimSpace(providerType), "openrouter")
+}
+
+func xaiTicksCost(rawData map[string]any, providerType string) (CostResult, bool) {
+	if !isXAIProvider(providerType) {
+		return CostResult{}, false
+	}
+	ticks, ok := extractFloat(rawData, "cost_in_usd_ticks")
+	if !ok || !isFiniteCost(ticks) || ticks < 0 {
+		return CostResult{}, false
+	}
+
+	total := ticks / xaiUSDTicksPerUSD
+	return CostResult{
+		TotalCost: &total,
+		Source:    CostSourceXAITicks,
+	}, true
+}
+
+func isXAIProvider(providerType string) bool {
+	return strings.EqualFold(strings.TrimSpace(providerType), "xai")
 }
 
 func openRouterCreditCostSplit(rawData map[string]any, total float64) (float64, float64, bool) {

--- a/internal/usage/cost_test.go
+++ b/internal/usage/cost_test.go
@@ -497,6 +497,87 @@ func TestCalculateUsageCost_OpenRouterFallsBackToModelPricingWithoutCredits(t *t
 	}
 }
 
+func TestCalculateUsageCost_XAITicksOverrideStaticPricing(t *testing.T) {
+	pricing := &core.ModelPricing{
+		InputPerMtok:  new(100.0),
+		OutputPerMtok: new(100.0),
+	}
+	rawData := map[string]any{
+		"cost_in_usd_ticks": 37_756_000,
+	}
+
+	result := CalculateUsageCost(10, 4, rawData, "xai", pricing)
+
+	if result.InputCost != nil || result.OutputCost != nil {
+		t.Fatalf("InputCost/OutputCost = %v/%v, want nil when xAI supplies only total cost", result.InputCost, result.OutputCost)
+	}
+	assertCostNear(t, "TotalCost", result.TotalCost, 0.0037756)
+	if result.Source != CostSourceXAITicks {
+		t.Fatalf("Source = %q, want %q", result.Source, CostSourceXAITicks)
+	}
+}
+
+func TestCalculateUsageCost_XAITicksAcceptsZeroCost(t *testing.T) {
+	pricing := &core.ModelPricing{
+		InputPerMtok:  new(1.0),
+		OutputPerMtok: new(2.0),
+	}
+
+	result := CalculateUsageCost(1_000_000, 500_000, map[string]any{"cost_in_usd_ticks": 0}, "xai", pricing)
+
+	assertCostNear(t, "TotalCost", result.TotalCost, 0)
+	if result.InputCost != nil || result.OutputCost != nil {
+		t.Fatalf("InputCost/OutputCost = %v/%v, want nil when xAI supplies only total cost", result.InputCost, result.OutputCost)
+	}
+	if result.Source != CostSourceXAITicks {
+		t.Fatalf("Source = %q, want %q", result.Source, CostSourceXAITicks)
+	}
+}
+
+func TestCalculateUsageCost_XAITicksFallBackToModelPricingWhenInvalid(t *testing.T) {
+	pricing := &core.ModelPricing{
+		InputPerMtok:  new(1.0),
+		OutputPerMtok: new(2.0),
+	}
+	tests := []struct {
+		name  string
+		ticks any
+	}{
+		{name: "negative", ticks: -1},
+		{name: "nan", ticks: math.NaN()},
+		{name: "positive infinity", ticks: math.Inf(1)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := CalculateUsageCost(1_000_000, 500_000, map[string]any{"cost_in_usd_ticks": test.ticks}, "xai", pricing)
+
+			assertCostNear(t, "InputCost", result.InputCost, 1.0)
+			assertCostNear(t, "OutputCost", result.OutputCost, 1.0)
+			assertCostNear(t, "TotalCost", result.TotalCost, 2.0)
+			if result.Source != CostSourceModelPricing {
+				t.Fatalf("Source = %q, want %q", result.Source, CostSourceModelPricing)
+			}
+		})
+	}
+}
+
+func TestCalculateUsageCost_XAITicksIgnoredForOtherProviders(t *testing.T) {
+	pricing := &core.ModelPricing{
+		InputPerMtok:  new(1.0),
+		OutputPerMtok: new(2.0),
+	}
+
+	result := CalculateUsageCost(1_000_000, 500_000, map[string]any{"cost_in_usd_ticks": 37_756_000}, "openai", pricing)
+
+	assertCostNear(t, "InputCost", result.InputCost, 1.0)
+	assertCostNear(t, "OutputCost", result.OutputCost, 1.0)
+	assertCostNear(t, "TotalCost", result.TotalCost, 2.0)
+	if result.Source != CostSourceModelPricing {
+		t.Fatalf("Source = %q, want %q", result.Source, CostSourceModelPricing)
+	}
+}
+
 func TestCalculateGranularCost_InformationalFieldsNoCaveat(t *testing.T) {
 	pricing := &core.ModelPricing{
 		InputPerMtok:  new(2.50),

--- a/internal/usage/extractor_test.go
+++ b/internal/usage/extractor_test.go
@@ -467,6 +467,57 @@ func TestExtractFromChatResponse_OpenRouterCreditCostWithoutStaticPricing(t *tes
 	}
 }
 
+func TestExtractFromChatResponse_XAITicksWithoutStaticPricing(t *testing.T) {
+	resp := &core.ChatResponse{
+		ID:    "chatcmpl-xai",
+		Model: "grok-4.3",
+		Usage: core.Usage{
+			PromptTokens:     199,
+			CompletionTokens: 1,
+			TotalTokens:      200,
+			RawUsage: map[string]any{
+				"cost_in_usd_ticks": float64(158_500),
+			},
+		},
+	}
+
+	entry := ExtractFromChatResponse(resp, "req-xai", "xai", "/v1/chat/completions")
+	if entry == nil {
+		t.Fatal("expected non-nil entry")
+	}
+	if entry.InputCost != nil || entry.OutputCost != nil {
+		t.Fatalf("InputCost/OutputCost = %v/%v, want nil without response split", entry.InputCost, entry.OutputCost)
+	}
+	assertCostPtrNear(t, "TotalCost", entry.TotalCost, 0.00001585)
+	if entry.CostSource != CostSourceXAITicks {
+		t.Fatalf("CostSource = %q, want %q", entry.CostSource, CostSourceXAITicks)
+	}
+}
+
+func TestExtractFromResponsesResponse_XAITicksWithoutStaticPricing(t *testing.T) {
+	resp := &core.ResponsesResponse{
+		ID:    "resp-xai",
+		Model: "grok-4.3",
+		Usage: &core.ResponsesUsage{
+			InputTokens:  199,
+			OutputTokens: 1,
+			TotalTokens:  200,
+			RawUsage: map[string]any{
+				"cost_in_usd_ticks": float64(158_500),
+			},
+		},
+	}
+
+	entry := ExtractFromResponsesResponse(resp, "req-xai-response", "xai", "/v1/responses")
+	if entry == nil {
+		t.Fatal("expected non-nil entry")
+	}
+	assertCostPtrNear(t, "TotalCost", entry.TotalCost, 0.00001585)
+	if entry.CostSource != CostSourceXAITicks {
+		t.Fatalf("CostSource = %q, want %q", entry.CostSource, CostSourceXAITicks)
+	}
+}
+
 func TestExtractFromSSEUsage(t *testing.T) {
 	entry := ExtractFromSSEUsage(
 		"chatcmpl-789",
@@ -804,5 +855,15 @@ func TestExtractFromChatResponse_BatchPrefixOvermatchUsesStandardPricing(t *test
 	}
 	if math.Abs(*entry.TotalCost-8.0) > 1e-9 {
 		t.Errorf("TotalCost = %f, want 8.0", *entry.TotalCost)
+	}
+}
+
+func assertCostPtrNear(t *testing.T, name string, got *float64, want float64) {
+	t.Helper()
+	if got == nil {
+		t.Fatalf("%s is nil, want %f", name, want)
+	}
+	if math.Abs(*got-want) > 1e-9 {
+		t.Fatalf("%s = %f, want %f", name, *got, want)
 	}
 }

--- a/internal/usage/stream_observer.go
+++ b/internal/usage/stream_observer.go
@@ -161,7 +161,7 @@ func copyExtendedUsageFields(rawData map[string]any, usageMap map[string]any) {
 		case "prompt_tokens", "completion_tokens", "total_tokens", "input_tokens", "output_tokens",
 			"prompt_tokens_details", "completion_tokens_details", "input_tokens_details", "output_tokens_details":
 			continue
-		case "cost":
+		case "cost", "cost_in_usd_ticks":
 			if numericValue, ok := numericFloat(value); ok && numericValue >= 0 {
 				rawData[key] = numericValue
 			}

--- a/internal/usage/stream_observer_test.go
+++ b/internal/usage/stream_observer_test.go
@@ -2,6 +2,7 @@ package usage
 
 import (
 	"io"
+	"math"
 	"strings"
 	"sync"
 	"testing"
@@ -165,6 +166,43 @@ func TestStreamUsageObserverOpenRouterCreditCost(t *testing.T) {
 	}
 	if entry.CostSource != CostSourceOpenRouterCredits {
 		t.Fatalf("CostSource = %q, want %q", entry.CostSource, CostSourceOpenRouterCredits)
+	}
+}
+
+func TestStreamUsageObserverXAITickCost(t *testing.T) {
+	logger := &trackingLogger{enabled: true}
+	observer := NewStreamUsageObserver(logger, "grok-4.3", "xai", "req-xai", "/v1/chat/completions", nil)
+	observer.OnJSONEvent(map[string]any{
+		"id":    "chatcmpl-xai",
+		"model": "grok-4.3",
+		"usage": map[string]any{
+			"prompt_tokens":      float64(199),
+			"completion_tokens":  float64(1),
+			"total_tokens":       float64(200),
+			"cost_in_usd_ticks":  float64(158_500),
+			"num_sources_used":   float64(2),
+			"server_tool_calls":  float64(1),
+			"zero_value_ignored": float64(0),
+		},
+	})
+	observer.OnStreamClose()
+
+	entries := logger.getEntries()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	entry := entries[0]
+	if entry.RawData == nil || entry.RawData["cost_in_usd_ticks"] != 158_500.0 {
+		t.Fatalf("RawData[cost_in_usd_ticks] = %#v, want 158500", entry.RawData["cost_in_usd_ticks"])
+	}
+	if entry.TotalCost == nil || math.Abs(*entry.TotalCost-0.00001585) > 1e-12 {
+		t.Fatalf("TotalCost = %v, want 0.00001585", entry.TotalCost)
+	}
+	if entry.InputCost != nil || entry.OutputCost != nil {
+		t.Fatalf("InputCost/OutputCost = %v/%v, want nil without response split", entry.InputCost, entry.OutputCost)
+	}
+	if entry.CostSource != CostSourceXAITicks {
+		t.Fatalf("CostSource = %q, want %q", entry.CostSource, CostSourceXAITicks)
 	}
 }
 
@@ -411,7 +449,7 @@ func TestStreamUsageObserverResponsesAPIWithDetailedUsage(t *testing.T) {
 	if entry.RawData["completion_reasoning_tokens"] != 7 {
 		t.Fatalf("RawData[completion_reasoning_tokens] = %v, want 7", entry.RawData["completion_reasoning_tokens"])
 	}
-	if entry.RawData["cost_in_usd_ticks"] != 158500 {
+	if got, ok := numericFloat(entry.RawData["cost_in_usd_ticks"]); !ok || got != 158500 {
 		t.Fatalf("RawData[cost_in_usd_ticks] = %v, want 158500", entry.RawData["cost_in_usd_ticks"])
 	}
 }


### PR DESCRIPTION
## Summary
- use xAI usage.cost_in_usd_ticks as the exact USD total cost source
- preserve xAI cost ticks from streamed usage events
- show the green confirmed-cost icon for xAI response-derived costs

## Tests
- go test ./...
- node --test internal/admin/dashboard/static/js/modules/usage.test.cjs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for provider-reported xAI "ticks" (tick-based USD costs) in usage cost reporting.

* **Improvements**
  * Request Log now shows cost indicators when costs come from provider responses (not only model pricing).
  * Cost source tooltips updated to explain xAI tick-based costs.
  * Cost classification logic refined for more accurate cost attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->