### PR TITLE
fix(passthrough): preserve original provider name in route resolution

### DIFF
--- a/internal/core/passthrough.go
+++ b/internal/core/passthrough.go
@@ -8,10 +8,11 @@ import (
 
 // PassthroughRequest is the transport-oriented request for opaque provider-native forwarding.
 type PassthroughRequest struct {
-	Method   string
-	Endpoint string
-	Body     io.ReadCloser
-	Headers  http.Header
+	Method       string
+	Endpoint     string
+	Body         io.ReadCloser
+	Headers      http.Header
+	ProviderName string // optional: concrete configured provider instance name for name-based routing
 }
 
 // PassthroughResponse is the raw upstream response for opaque forwarding.

--- a/internal/core/semantic.go
+++ b/internal/core/semantic.go
@@ -36,7 +36,8 @@ type RouteHints struct {
 // WhiteBoxPrompt or Workflow, it should be treated as immutable by later
 // request stages.
 type PassthroughRouteInfo struct {
-	Provider           string
+	Provider           string // resolved provider type (e.g. "anthropic")
+	ProviderName       string // original configured provider instance name (e.g. "teste")
 	RawEndpoint        string
 	NormalizedEndpoint string
 	SemanticOperation  string

--- a/internal/providers/router.go
+++ b/internal/providers/router.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"sort"
 	"strings"
@@ -766,10 +767,29 @@ func (r *Router) NativeResponseProviderTypes() []string {
 }
 
 // Passthrough routes an opaque provider-native request by provider type.
+// If req.ProviderName is set, routing prefers the named provider instance over
+// the first registered provider of the given type.
 func (r *Router) Passthrough(ctx context.Context, providerType string, req *core.PassthroughRequest) (*core.PassthroughResponse, error) {
-	pp, err := r.resolvePassthroughProvider(providerType)
-	if err != nil {
-		return nil, err
+	var pp core.PassthroughProvider
+	if req != nil && strings.TrimSpace(req.ProviderName) != "" {
+		slog.DebugContext(ctx, "passthrough routing by name", "providerName", req.ProviderName, "providerType", providerType)
+		if p := r.providerByNameRegistry(strings.TrimSpace(req.ProviderName)); p != nil {
+			if named, ok := p.(core.PassthroughProvider); ok {
+				pp = named
+				slog.DebugContext(ctx, "passthrough routed by name", "providerName", req.ProviderName)
+			} else {
+				slog.DebugContext(ctx, "passthrough provider found by name but does not implement PassthroughProvider", "providerName", req.ProviderName)
+			}
+		} else {
+			slog.DebugContext(ctx, "passthrough provider not found by name, falling back to type", "providerName", req.ProviderName, "providerType", providerType)
+		}
+	}
+	if pp == nil {
+		var err error
+		pp, err = r.resolvePassthroughProvider(providerType)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return pp.Passthrough(ctx, req)
 }

--- a/internal/server/passthrough_execution_helpers.go
+++ b/internal/server/passthrough_execution_helpers.go
@@ -8,24 +8,31 @@ import (
 	"gomodel/internal/core"
 )
 
-func passthroughExecutionTarget(c *echo.Context, provider core.RoutableProvider, allowPassthroughV1Alias bool) (string, string, *core.PassthroughRouteInfo, error) {
+func passthroughExecutionTarget(c *echo.Context, provider core.RoutableProvider, allowPassthroughV1Alias bool) (string, string, string, *core.PassthroughRouteInfo, error) {
 	if c == nil {
-		return "", "", nil, core.NewInvalidRequestError("invalid provider passthrough path", nil)
+		return "", "", "", nil, core.NewInvalidRequestError("invalid provider passthrough path", nil)
 	}
 
 	info := passthroughRouteInfo(c)
 	if info == nil {
-		return "", "", nil, core.NewInvalidRequestError("invalid provider passthrough path", nil)
+		return "", "", "", nil, core.NewInvalidRequestError("invalid provider passthrough path", nil)
 	}
 
-	providerType := strings.TrimSpace(resolvePassthroughProvider(provider, info.Provider).ProviderType)
+	resolved := resolvePassthroughProvider(provider, info.Provider)
+	providerType := strings.TrimSpace(resolved.ProviderType)
+	// Prefer the provider name cached by the semantic enrichment middleware,
+	// which preserves the original route name before it is overwritten with the type.
+	providerName := strings.TrimSpace(info.ProviderName)
+	if providerName == "" {
+		providerName = strings.TrimSpace(resolved.ProviderName)
+	}
 	if providerType == "" {
 		if workflow := core.GetWorkflow(c.Request().Context()); workflow != nil {
 			providerType = strings.TrimSpace(workflow.ProviderType)
 		}
 	}
 	if providerType == "" {
-		return "", "", nil, core.NewInvalidRequestError("invalid provider passthrough path", nil)
+		return "", "", "", nil, core.NewInvalidRequestError("invalid provider passthrough path", nil)
 	}
 
 	endpoint := strings.TrimSpace(info.NormalizedEndpoint)
@@ -33,17 +40,17 @@ func passthroughExecutionTarget(c *echo.Context, provider core.RoutableProvider,
 		var err error
 		endpoint, err = normalizePassthroughEndpoint(info.RawEndpoint, allowPassthroughV1Alias)
 		if err != nil {
-			return "", "", nil, err
+			return "", "", "", nil, err
 		}
 		info.NormalizedEndpoint = endpoint
 	}
 	if endpoint == "" {
-		return "", "", nil, core.NewInvalidRequestError("provider passthrough endpoint is required", nil)
+		return "", "", "", nil, core.NewInvalidRequestError("provider passthrough endpoint is required", nil)
 	}
 	if rawQuery := strings.TrimSpace(c.Request().URL.RawQuery); rawQuery != "" {
 		endpoint += "?" + rawQuery
 	}
 
 	info.Provider = providerType
-	return providerType, endpoint, info, nil
+	return providerType, providerName, endpoint, info, nil
 }

--- a/internal/server/passthrough_execution_helpers_test.go
+++ b/internal/server/passthrough_execution_helpers_test.go
@@ -26,7 +26,7 @@ func TestPassthroughExecutionTarget_PrefersWorkflow(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
-	providerType, endpoint, info, err := passthroughExecutionTarget(c, nil, false)
+	providerType, _, endpoint, info, err := passthroughExecutionTarget(c, nil, false)
 	if err != nil {
 		t.Fatalf("passthroughExecutionTarget() error = %v", err)
 	}
@@ -50,7 +50,7 @@ func TestPassthroughExecutionTarget_NormalizesFallbackFromPath(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
-	providerType, endpoint, info, err := passthroughExecutionTarget(c, nil, true)
+	providerType, _, endpoint, info, err := passthroughExecutionTarget(c, nil, true)
 	if err != nil {
 		t.Fatalf("passthroughExecutionTarget() error = %v", err)
 	}
@@ -83,12 +83,15 @@ func TestPassthroughExecutionTarget_ResolvesConfiguredProviderNameToType(t *test
 		},
 	}
 
-	providerType, endpoint, info, err := passthroughExecutionTarget(c, provider, true)
+	providerType, providerName, endpoint, info, err := passthroughExecutionTarget(c, provider, true)
 	if err != nil {
 		t.Fatalf("passthroughExecutionTarget() error = %v", err)
 	}
 	if providerType != "openai" {
 		t.Fatalf("providerType = %q, want openai", providerType)
+	}
+	if providerName != "openai_test" {
+		t.Fatalf("providerName = %q, want openai_test", providerName)
 	}
 	if endpoint != "responses?trace=1" {
 		t.Fatalf("endpoint = %q, want responses?trace=1", endpoint)

--- a/internal/server/passthrough_provider_resolution.go
+++ b/internal/server/passthrough_provider_resolution.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"log/slog"
 	"strings"
 
 	"gomodel/internal/core"
@@ -20,21 +21,29 @@ func resolvePassthroughProvider(provider core.RoutableProvider, routeProvider st
 
 	if provider != nil {
 		if named, ok := provider.(core.ProviderNameTypeResolver); ok {
-			if providerType := strings.TrimSpace(named.GetProviderTypeForName(routeProvider)); providerType != "" {
+			providerType := strings.TrimSpace(named.GetProviderTypeForName(routeProvider))
+			slog.Debug("passthrough provider resolution", "routeProvider", routeProvider, "resolvedType", providerType, "hasNameTypeResolver", true)
+			if providerType != "" {
 				return passthroughProviderResolution{
 					RouteProvider: routeProvider,
 					ProviderType:  providerType,
 					ProviderName:  routeProvider,
 				}
 			}
+		} else {
+			slog.Debug("passthrough provider resolution", "routeProvider", routeProvider, "hasNameTypeResolver", false)
 		}
+	} else {
+		slog.Debug("passthrough provider resolution", "routeProvider", routeProvider, "provider", "nil")
 	}
 
-	return passthroughProviderResolution{
+	result := passthroughProviderResolution{
 		RouteProvider: routeProvider,
 		ProviderType:  routeProvider,
 		ProviderName:  workflowProviderNameForType(provider, routeProvider),
 	}
+	slog.Debug("passthrough provider resolution fallback", "routeProvider", routeProvider, "providerType", result.ProviderType, "providerName", result.ProviderName)
+	return result
 }
 
 // passthroughAccessSelector derives an authorization selector from provider,

--- a/internal/server/passthrough_semantic_enrichment.go
+++ b/internal/server/passthrough_semantic_enrichment.go
@@ -41,6 +41,7 @@ func PassthroughSemanticEnrichment(provider core.RoutableProvider, enrichers []c
 			}
 			info.NormalizedEndpoint = normalized
 			if resolved := resolvePassthroughProvider(provider, info.Provider); resolved.ProviderType != "" {
+				info.ProviderName = resolved.ProviderName
 				info.Provider = resolved.ProviderType
 			}
 

--- a/internal/server/passthrough_service.go
+++ b/internal/server/passthrough_service.go
@@ -25,7 +25,7 @@ func (s *passthroughService) ProviderPassthrough(c *echo.Context) error {
 		return handleError(c, core.NewInvalidRequestError("provider passthrough is not supported by the current provider router", nil))
 	}
 
-	providerType, endpoint, info, err := passthroughExecutionTarget(c, s.provider, s.normalizePassthroughV1Prefix)
+	providerType, providerName, endpoint, info, err := passthroughExecutionTarget(c, s.provider, s.normalizePassthroughV1Prefix)
 	if err != nil {
 		return handleError(c, err)
 	}
@@ -46,10 +46,11 @@ func (s *passthroughService) ProviderPassthrough(c *echo.Context) error {
 	ctx, _ := requestContextWithRequestID(c.Request())
 	c.SetRequest(c.Request().WithContext(ctx))
 	resp, err := passthroughProvider.Passthrough(ctx, providerType, &core.PassthroughRequest{
-		Method:   c.Request().Method,
-		Endpoint: endpoint,
-		Body:     c.Request().Body,
-		Headers:  buildPassthroughHeaders(ctx, c.Request().Header),
+		Method:       c.Request().Method,
+		Endpoint:     endpoint,
+		Body:         c.Request().Body,
+		Headers:      buildPassthroughHeaders(ctx, c.Request().Header),
+		ProviderName: providerName,
 	})
 	if err != nil {
 		return handleError(c, err)


### PR DESCRIPTION
  The semantic enrichment middleware was overwriting info.Provider with the
  resolved type (e.g. 'anthropic') before caching, causing passthroughExecutionTarget
  to route by type instead of the original configured name (e.g. 'teste').

  Added info.ProviderName field to preserve the original route name through the
  resolution pipeline. The execution target now prefers the cached provider name
  when available, ensuring requests route to the correct configured instance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for name-based provider routing, allowing you to specify a particular configured provider instance by name for pass-through requests instead of relying solely on provider type-based resolution.

* **Improvements**
  * Enhanced debug logging for provider resolution to aid in troubleshooting routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->