### PR TITLE
feat(dashboard): show version on settings page

### DIFF
--- a/internal/admin/dashboard/dashboard.go
+++ b/internal/admin/dashboard/dashboard.go
@@ -115,8 +115,8 @@ func assetURL(basePath, assetPath string, versions map[string]string) string {
 		return config.JoinBasePath(basePath, "/admin/static/")
 	}
 	urlPath := config.JoinBasePath(basePath, "/admin/static/"+normalizedPath)
-	if version := versions[normalizedPath]; version != "" {
-		return urlPath + "?v=" + version
+	if v := versions[normalizedPath]; v != "" {
+		return urlPath + "?v=" + v
 	}
 	return urlPath
 }

--- a/internal/admin/dashboard/dashboard.go
+++ b/internal/admin/dashboard/dashboard.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"gomodel/config"
+	"gomodel/internal/version"
 
 	"github.com/labstack/echo/v5"
 )
@@ -66,12 +67,13 @@ func NewWithBasePath(basePath string) (*Handler, error) {
 
 type templateData struct {
 	BasePath string
+	Version  string
 }
 
 // Index serves GET /admin/dashboard — the main dashboard page.
 func (h *Handler) Index(c *echo.Context) error {
 	var buf bytes.Buffer
-	if err := h.indexTmpl.ExecuteTemplate(&buf, "layout", templateData{BasePath: h.basePath}); err != nil {
+	if err := h.indexTmpl.ExecuteTemplate(&buf, "layout", templateData{BasePath: h.basePath, Version: version.Info()}); err != nil {
 		slog.Error("failed to render admin dashboard", "path", c.Request().URL.Path, "error", err)
 		return err
 	}

--- a/internal/admin/dashboard/dashboard_test.go
+++ b/internal/admin/dashboard/dashboard_test.go
@@ -63,6 +63,12 @@ func TestIndex_ReturnsHTML(t *testing.T) {
 	if !regexp.MustCompile(`/admin/static/css/dashboard\.css\?v=[0-9a-f]+`).MatchString(rec.Body.String()) {
 		t.Errorf("expected versioned dashboard CSS link in page HTML")
 	}
+	if !strings.Contains(body, "settings-version-footer") {
+		t.Errorf("expected settings-version-footer element in page HTML")
+	}
+	if !strings.Contains(body, "gomodel ") {
+		t.Errorf("expected gomodel version string in page HTML")
+	}
 }
 
 func TestIndex_UsesBasePathForGeneratedURLs(t *testing.T) {

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -3414,6 +3414,13 @@ body.conversation-drawer-open {
   border-top: 1px solid var(--border);
 }
 
+.settings-version-footer {
+  margin-top: 24px;
+  color: var(--text-muted);
+  font-size: 12px;
+  text-align: right;
+}
+
 .settings-refresh-section h3 {
   font-size: 18px;
 }

--- a/internal/admin/dashboard/templates/page-settings.html
+++ b/internal/admin/dashboard/templates/page-settings.html
@@ -245,6 +245,8 @@
             </ul>
         </div>
     </div>
+
+    <p class="settings-version-footer mono">{{.Version}}</p>
 </div>
 </template>
 {{end}}


### PR DESCRIPTION
## Summary
- Render the same string `gomodel --version` prints (via `version.Info()`) in a small muted, right-aligned, monospaced footer at the bottom of the Dashboard → Settings panel.
- Wires `Version` into `templateData` so it's sourced from the existing `internal/version` package — picked up automatically from build-time `-ldflags` in release builds, no hardcoding.
- Reuses the existing `.mono` utility class; only ~5 lines of new CSS and a single `<p>` in the template.

## Test plan
- [x] `go test ./internal/admin/dashboard/...` (added two assertions: `settings-version-footer` element and `gomodel ` prefix appear in rendered HTML)
- [ ] Visit Dashboard → Settings and confirm version appears at the bottom in dev (`gomodel dev (commit: none, built: unknown, go1.x)`)
- [ ] Confirm a release build shows the injected version/commit/date

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Application version is now shown in the admin dashboard settings footer, giving users quick visibility of the running version.

* **Style**
  * Added footer styling for the settings page to align and visually mute the version display for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->