### PR TITLE
feat(pricing): add admin-managed model pricing overrides

### DIFF
--- a/cmd/gomodel/docs/docs.go
+++ b/cmd/gomodel/docs/docs.go
@@ -3792,6 +3792,9 @@ const docTemplate = `{
         },
         "admin.upsertModelPricingOverrideRequest": {
             "type": "object",
+            "required": [
+                "pricing"
+            ],
             "properties": {
                 "pricing": {
                     "$ref": "#/definitions/pricingoverrides.Pricing"
@@ -5421,10 +5424,6 @@ const docTemplate = `{
         "pricingoverrides.ScopeKind": {
             "type": "string",
             "enum": [
-                "global",
-                "model",
-                "provider",
-                "provider_model",
                 "global",
                 "model",
                 "provider",

--- a/cmd/gomodel/docs/docs.go
+++ b/cmd/gomodel/docs/docs.go
@@ -758,6 +758,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/core.GatewayError"
                         }
                     },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
@@ -806,6 +812,12 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
                         "schema": {
                             "$ref": "#/definitions/core.GatewayError"
                         }

--- a/cmd/gomodel/docs/docs.go
+++ b/cmd/gomodel/docs/docs.go
@@ -665,7 +665,7 @@ const docTemplate = `{
         },
         "/admin/api/v1/model-overrides": {
             "get": {
-                "description": "Lists persisted model access overrides by global, provider-wide, model-wide, or exact selector.",
+                "description": "Lists persisted model access overrides by global, provider-wide, model-wide, or exact selector.\nSelectors support global \"/\", provider-wide \"provider/\", model-wide \"model\", and exact \"provider/model\" scopes.",
                 "produces": [
                     "application/json"
                 ],
@@ -737,7 +737,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/modeloverrides.Override"
+                            "$ref": "#/definitions/modeloverrides.View"
                         }
                     },
                     "400": {

--- a/cmd/gomodel/docs/docs.go
+++ b/cmd/gomodel/docs/docs.go
@@ -663,6 +663,329 @@ const docTemplate = `{
                 ]
             }
         },
+        "/admin/api/v1/model-overrides": {
+            "get": {
+                "description": "Lists persisted model access overrides by global, provider-wide, model-wide, or exact selector.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "List model access overrides",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/modeloverrides.View"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/admin/api/v1/model-overrides/{selector}": {
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Create or update one model access override",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "URL-encoded model selector such as /, openai/, gpt-4o-mini, or openai/gpt-4o-mini",
+                        "name": "selector",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Allowed user paths",
+                        "name": "override",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/admin.upsertModelOverrideRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/modeloverrides.Override"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ]
+            },
+            "delete": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Delete one model access override",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "URL-encoded model selector",
+                        "name": "selector",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/admin/api/v1/model-pricing-overrides": {
+            "get": {
+                "description": "Lists persisted USD pricing overrides. Selectors support global \"/\", provider-wide \"provider/\", model-wide \"model\", and exact \"provider/model\" scopes.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "List model pricing overrides",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/pricingoverrides.View"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/admin/api/v1/model-pricing-overrides/{selector}": {
+            "put": {
+                "description": "Stores USD-only pricing for one selector. More precise selectors override broader selectors at runtime.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Create or update one model pricing override",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "URL-encoded pricing selector such as /, openai/, gpt-4o-mini, or openai/gpt-4o-mini",
+                        "name": "selector",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Pricing override",
+                        "name": "override",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/admin.upsertModelPricingOverrideRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/pricingoverrides.View"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ]
+            },
+            "delete": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Delete one model pricing override",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "URL-encoded pricing selector",
+                        "name": "selector",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ]
+            }
+        },
         "/admin/api/v1/models": {
             "get": {
                 "produces": [
@@ -3456,6 +3779,25 @@ const docTemplate = `{
                 }
             }
         },
+        "admin.upsertModelOverrideRequest": {
+            "type": "object",
+            "properties": {
+                "user_paths": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "admin.upsertModelPricingOverrideRequest": {
+            "type": "object",
+            "properties": {
+                "pricing": {
+                    "$ref": "#/definitions/pricingoverrides.Pricing"
+                }
+            }
+        },
         "auditlog.ConversationResult": {
             "type": "object",
             "properties": {
@@ -4354,6 +4696,12 @@ const docTemplate = `{
                 "pricing": {
                     "$ref": "#/definitions/core.ModelPricing"
                 },
+                "pricing_sources": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "rankings": {
                     "type": "object",
                     "additionalProperties": {
@@ -4440,6 +4788,9 @@ const docTemplate = `{
                     "type": "number"
                 },
                 "up_to_mtok": {
+                    "type": "number"
+                },
+                "up_to_tokens": {
                     "type": "number"
                 }
             }
@@ -4944,6 +5295,171 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "modeloverrides.ScopeKind": {
+            "type": "string",
+            "enum": [
+                "global",
+                "model",
+                "provider",
+                "provider_model"
+            ],
+            "x-enum-varnames": [
+                "ScopeGlobal",
+                "ScopeModel",
+                "ScopeProvider",
+                "ScopeProviderModel"
+            ]
+        },
+        "modeloverrides.View": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "provider_name": {
+                    "type": "string"
+                },
+                "scope_kind": {
+                    "$ref": "#/definitions/modeloverrides.ScopeKind"
+                },
+                "selector": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "user_paths": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "pricingoverrides.Pricing": {
+            "type": "object",
+            "properties": {
+                "audio_input_per_mtok": {
+                    "type": "number"
+                },
+                "audio_output_per_mtok": {
+                    "type": "number"
+                },
+                "batch_input_per_mtok": {
+                    "type": "number"
+                },
+                "batch_output_per_mtok": {
+                    "type": "number"
+                },
+                "cache_write_per_mtok": {
+                    "type": "number"
+                },
+                "cached_input_per_mtok": {
+                    "type": "number"
+                },
+                "input_per_image": {
+                    "type": "number"
+                },
+                "input_per_mtok": {
+                    "type": "number"
+                },
+                "output_per_mtok": {
+                    "type": "number"
+                },
+                "per_character_input": {
+                    "type": "number"
+                },
+                "per_image": {
+                    "type": "number"
+                },
+                "per_page": {
+                    "type": "number"
+                },
+                "per_request": {
+                    "type": "number"
+                },
+                "per_second_input": {
+                    "type": "number"
+                },
+                "per_second_output": {
+                    "type": "number"
+                },
+                "reasoning_output_per_mtok": {
+                    "type": "number"
+                },
+                "tiers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/pricingoverrides.PricingTier"
+                    }
+                }
+            }
+        },
+        "pricingoverrides.PricingTier": {
+            "type": "object",
+            "properties": {
+                "input_per_mtok": {
+                    "type": "number"
+                },
+                "output_per_mtok": {
+                    "type": "number"
+                },
+                "up_to_mtok": {
+                    "type": "number"
+                },
+                "up_to_tokens": {
+                    "type": "number"
+                }
+            }
+        },
+        "pricingoverrides.ScopeKind": {
+            "type": "string",
+            "enum": [
+                "global",
+                "model",
+                "provider",
+                "provider_model",
+                "global",
+                "model",
+                "provider",
+                "provider_model"
+            ],
+            "x-enum-varnames": [
+                "ScopeGlobal",
+                "ScopeModel",
+                "ScopeProvider",
+                "ScopeProviderModel"
+            ]
+        },
+        "pricingoverrides.View": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "pricing": {
+                    "$ref": "#/definitions/pricingoverrides.Pricing"
+                },
+                "provider_name": {
+                    "type": "string"
+                },
+                "scope_kind": {
+                    "$ref": "#/definitions/pricingoverrides.ScopeKind"
+                },
+                "selector": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -935,6 +935,16 @@
               }
             }
           },
+          "502": {
+            "description": "Bad Gateway",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
           "503": {
             "description": "Service Unavailable",
             "content": {
@@ -994,6 +1004,16 @@
           },
           "404": {
             "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Bad Gateway",
             "content": {
               "application/json": {
                 "schema": {
@@ -6369,7 +6389,8 @@
             "type": "number"
           },
           "up_to_tokens": {
-            "type": "number"
+            "type": "integer",
+            "minimum": 0
           }
         }
       },
@@ -7010,7 +7031,8 @@
               "$ref": "#/components/schemas/pricingoverrides.PricingTier"
             }
           }
-        }
+        },
+        "minProperties": 1
       },
       "pricingoverrides.PricingTier": {
         "type": "object",
@@ -7025,7 +7047,8 @@
             "type": "number"
           },
           "up_to_tokens": {
-            "type": "number"
+            "type": "integer",
+            "minimum": 0
           }
         }
       },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -831,7 +831,9 @@
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/modeloverrides.View"
-                  }
+                  },
+                  "maxItems": 10000,
+                  "description": "Bounded by maxItems=10000."
                 }
               }
             }
@@ -1034,7 +1036,9 @@
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/pricingoverrides.View"
-                  }
+                  },
+                  "maxItems": 10000,
+                  "description": "Bounded by maxItems=10000."
                 }
               }
             }
@@ -5361,6 +5365,9 @@
       },
       "admin.upsertModelPricingOverrideRequest": {
         "type": "object",
+        "required": [
+          "pricing"
+        ],
         "properties": {
           "pricing": {
             "$ref": "#/components/schemas/pricingoverrides.Pricing"
@@ -7023,10 +7030,6 @@
       "pricingoverrides.ScopeKind": {
         "type": "string",
         "enum": [
-          "global",
-          "model",
-          "provider",
-          "provider_model",
           "global",
           "model",
           "provider",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -815,6 +815,413 @@
         ]
       }
     },
+    "/admin/api/v1/model-overrides": {
+      "get": {
+        "description": "Lists persisted model access overrides by global, provider-wide, model-wide, or exact selector.",
+        "tags": [
+          "admin"
+        ],
+        "summary": "List model access overrides",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/modeloverrides.View"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ]
+      }
+    },
+    "/admin/api/v1/model-overrides/{selector}": {
+      "put": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Create or update one model access override",
+        "parameters": [
+          {
+            "description": "URL-encoded model selector such as /, openai/, gpt-4o-mini, or openai/gpt-4o-mini",
+            "name": "selector",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/admin.upsertModelOverrideRequest"
+              }
+            }
+          },
+          "description": "Allowed user paths",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/modeloverrides.Override"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Delete one model access override",
+        "parameters": [
+          {
+            "description": "URL-encoded model selector",
+            "name": "selector",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ]
+      }
+    },
+    "/admin/api/v1/model-pricing-overrides": {
+      "get": {
+        "description": "Lists persisted USD pricing overrides. Selectors support global \"/\", provider-wide \"provider/\", model-wide \"model\", and exact \"provider/model\" scopes.",
+        "tags": [
+          "admin"
+        ],
+        "summary": "List model pricing overrides",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/pricingoverrides.View"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ]
+      }
+    },
+    "/admin/api/v1/model-pricing-overrides/{selector}": {
+      "put": {
+        "description": "Stores USD-only pricing for one selector. More precise selectors override broader selectors at runtime.",
+        "tags": [
+          "admin"
+        ],
+        "summary": "Create or update one model pricing override",
+        "parameters": [
+          {
+            "description": "URL-encoded pricing selector such as /, openai/, gpt-4o-mini, or openai/gpt-4o-mini",
+            "name": "selector",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/admin.upsertModelPricingOverrideRequest"
+              }
+            }
+          },
+          "description": "Pricing override",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/pricingoverrides.View"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Delete one model pricing override",
+        "parameters": [
+          {
+            "description": "URL-encoded pricing selector",
+            "name": "selector",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ]
+      }
+    },
     "/admin/api/v1/models": {
       "get": {
         "tags": [
@@ -4941,6 +5348,25 @@
           }
         }
       },
+      "admin.upsertModelOverrideRequest": {
+        "type": "object",
+        "properties": {
+          "user_paths": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "admin.upsertModelPricingOverrideRequest": {
+        "type": "object",
+        "properties": {
+          "pricing": {
+            "$ref": "#/components/schemas/pricingoverrides.Pricing"
+          }
+        }
+      },
       "auditlog.ConversationResult": {
         "type": "object",
         "properties": {
@@ -5839,6 +6265,12 @@
           "pricing": {
             "$ref": "#/components/schemas/core.ModelPricing"
           },
+          "pricing_sources": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
           "rankings": {
             "type": "object",
             "additionalProperties": {
@@ -5925,6 +6357,9 @@
             "type": "number"
           },
           "up_to_mtok": {
+            "type": "number"
+          },
+          "up_to_tokens": {
             "type": "number"
           }
         }
@@ -6462,6 +6897,171 @@
             "items": {
               "type": "string"
             }
+          }
+        }
+      },
+      "modeloverrides.ScopeKind": {
+        "type": "string",
+        "enum": [
+          "global",
+          "model",
+          "provider",
+          "provider_model"
+        ],
+        "x-enum-varnames": [
+          "ScopeGlobal",
+          "ScopeModel",
+          "ScopeProvider",
+          "ScopeProviderModel"
+        ]
+      },
+      "modeloverrides.View": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "provider_name": {
+            "type": "string"
+          },
+          "scope_kind": {
+            "$ref": "#/components/schemas/modeloverrides.ScopeKind"
+          },
+          "selector": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "user_paths": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "pricingoverrides.Pricing": {
+        "type": "object",
+        "properties": {
+          "audio_input_per_mtok": {
+            "type": "number"
+          },
+          "audio_output_per_mtok": {
+            "type": "number"
+          },
+          "batch_input_per_mtok": {
+            "type": "number"
+          },
+          "batch_output_per_mtok": {
+            "type": "number"
+          },
+          "cache_write_per_mtok": {
+            "type": "number"
+          },
+          "cached_input_per_mtok": {
+            "type": "number"
+          },
+          "input_per_image": {
+            "type": "number"
+          },
+          "input_per_mtok": {
+            "type": "number"
+          },
+          "output_per_mtok": {
+            "type": "number"
+          },
+          "per_character_input": {
+            "type": "number"
+          },
+          "per_image": {
+            "type": "number"
+          },
+          "per_page": {
+            "type": "number"
+          },
+          "per_request": {
+            "type": "number"
+          },
+          "per_second_input": {
+            "type": "number"
+          },
+          "per_second_output": {
+            "type": "number"
+          },
+          "reasoning_output_per_mtok": {
+            "type": "number"
+          },
+          "tiers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/pricingoverrides.PricingTier"
+            }
+          }
+        }
+      },
+      "pricingoverrides.PricingTier": {
+        "type": "object",
+        "properties": {
+          "input_per_mtok": {
+            "type": "number"
+          },
+          "output_per_mtok": {
+            "type": "number"
+          },
+          "up_to_mtok": {
+            "type": "number"
+          },
+          "up_to_tokens": {
+            "type": "number"
+          }
+        }
+      },
+      "pricingoverrides.ScopeKind": {
+        "type": "string",
+        "enum": [
+          "global",
+          "model",
+          "provider",
+          "provider_model",
+          "global",
+          "model",
+          "provider",
+          "provider_model"
+        ],
+        "x-enum-varnames": [
+          "ScopeGlobal",
+          "ScopeModel",
+          "ScopeProvider",
+          "ScopeProviderModel"
+        ]
+      },
+      "pricingoverrides.View": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "pricing": {
+            "$ref": "#/components/schemas/pricingoverrides.Pricing"
+          },
+          "provider_name": {
+            "type": "string"
+          },
+          "scope_kind": {
+            "$ref": "#/components/schemas/pricingoverrides.ScopeKind"
+          },
+          "selector": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
           }
         }
       },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -6390,7 +6390,7 @@
           },
           "up_to_tokens": {
             "type": "integer",
-            "minimum": 0
+            "minimum": 1
           }
         }
       },
@@ -7048,7 +7048,7 @@
           },
           "up_to_tokens": {
             "type": "integer",
-            "minimum": 0
+            "minimum": 1
           }
         }
       },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -817,7 +817,7 @@
     },
     "/admin/api/v1/model-overrides": {
       "get": {
-        "description": "Lists persisted model access overrides by global, provider-wide, model-wide, or exact selector.",
+        "description": "Lists persisted model access overrides by global, provider-wide, model-wide, or exact selector.\nSelectors support global \"/\", provider-wide \"provider/\", model-wide \"model\", and exact \"provider/model\" scopes.",
         "tags": [
           "admin"
         ],
@@ -900,7 +900,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/modeloverrides.Override"
+                  "$ref": "#/components/schemas/modeloverrides.View"
                 }
               }
             }
@@ -5358,8 +5358,10 @@
           "user_paths": {
             "type": "array",
             "items": {
-              "type": "string"
-            }
+              "type": "string",
+              "maxLength": 1024
+            },
+            "maxItems": 100
           }
         }
       },
@@ -6916,10 +6918,10 @@
           "provider_model"
         ],
         "x-enum-varnames": [
-          "ScopeGlobal",
-          "ScopeModel",
-          "ScopeProvider",
-          "ScopeProviderModel"
+          "ModelScopeGlobal",
+          "ModelScopeModel",
+          "ModelScopeProvider",
+          "ModelScopeProviderModel"
         ]
       },
       "modeloverrides.View": {
@@ -7036,10 +7038,10 @@
           "provider_model"
         ],
         "x-enum-varnames": [
-          "ScopeGlobal",
-          "ScopeModel",
-          "ScopeProvider",
-          "ScopeProviderModel"
+          "PricingScopeGlobal",
+          "PricingScopeModel",
+          "PricingScopeProvider",
+          "PricingScopeProviderModel"
         ]
       },
       "pricingoverrides.View": {

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -1715,12 +1715,89 @@ td.col-price {
   font-size: 13px;
 }
 
+.pricing-override-rows {
+  display: grid;
+  gap: 12px;
+}
+
+.pricing-override-row {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(130px, 180px) 32px;
+  gap: 12px;
+  align-items: end;
+}
+
+.pricing-override-remove-row {
+  margin-bottom: 1px;
+}
+
+.pricing-override-row-actions {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.pricing-override-tier-note {
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.pricing-preview {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.pricing-preview-header,
+.pricing-preview-row {
+  display: grid;
+  grid-template-columns: minmax(150px, 1fr) minmax(90px, auto) minmax(130px, 0.8fr);
+  gap: 12px;
+  align-items: center;
+  padding: 10px 12px;
+}
+
+.pricing-preview-header {
+  background: var(--bg);
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.pricing-preview-row {
+  border-top: 1px solid var(--border);
+  font-size: 13px;
+}
+
+.pricing-preview-row-empty {
+  grid-template-columns: 1fr;
+  color: var(--text-muted);
+}
+
 .alias-actions-cell {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
   align-items: center;
   justify-content: flex-end;
+}
+
+.model-list-actions {
+  flex-wrap: nowrap;
+  white-space: nowrap;
+}
+
+.model-list-actions .table-icon-btn {
+  flex: 0 0 32px;
+}
+
+.model-list-actions .model-access-state-badge,
+.model-list-actions .alias-toggle {
+  flex: 0 0 auto;
 }
 
 .alias-toggle {
@@ -2308,6 +2385,7 @@ textarea:focus {
   grid-column: 1 / -1;
 }
 
+.form-select,
 .usage-log-select {
   appearance: none;
   -webkit-appearance: none;
@@ -2331,13 +2409,20 @@ textarea:focus {
   min-width: 140px;
 }
 
+.form-select:disabled,
 .usage-log-select:disabled {
   cursor: default;
   opacity: 0.65;
 }
 
+.form-select:focus,
 .usage-log-select:focus {
   border-color: var(--accent);
+}
+
+.form-select {
+  width: 100%;
+  min-width: 0;
 }
 
 .usage-filter-row-controls .usage-log-select {
@@ -4301,6 +4386,14 @@ body.conversation-drawer-open {
   .model-editor {
     padding: 16px;
   }
+  .pricing-override-row,
+  .pricing-preview-header,
+  .pricing-preview-row {
+    grid-template-columns: 1fr;
+  }
+  .pricing-override-remove-row {
+    margin-bottom: 0;
+  }
   .alias-actions-cell,
   .editor-header,
   .model-name-primary,
@@ -4315,6 +4408,18 @@ body.conversation-drawer-open {
   .alias-actions-cell .table-icon-btn,
   .editor-header .table-icon-btn {
     width: 36px;
+  }
+  .model-list-actions {
+    flex-direction: row;
+    align-items: center;
+    flex-wrap: nowrap;
+  }
+  .model-list-actions .table-action-btn {
+    width: auto;
+  }
+  .model-list-actions .table-icon-btn {
+    width: 32px;
+    flex-basis: 32px;
   }
   .model-editor .editor-header {
     flex-direction: row;

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -402,7 +402,9 @@ function dashboard() {
       return (
         this.authDialogOpen ||
         (this.page === "models" &&
-          (this.aliasFormOpen || this.modelOverrideFormOpen)) ||
+          (this.aliasFormOpen ||
+            this.modelOverrideFormOpen ||
+            this.modelPricingOverrideFormOpen)) ||
         (this.page === "workflows" && this.workflowFormOpen) ||
         (this.page === "guardrails" && this.guardrailFormOpen) ||
         (this.page === "auth-keys" && this.authKeyFormOpen) ||
@@ -586,6 +588,9 @@ function dashboard() {
       }
       if (typeof this.fetchModelOverrides === "function") {
         requests.push(this.fetchModelOverrides());
+      }
+      if (typeof this.fetchModelPricingOverrides === "function") {
+        requests.push(this.fetchModelPricingOverrides());
       }
       if (typeof this.fetchWorkflowsPage === "function") {
         requests.push(this.fetchWorkflowsPage());
@@ -1066,6 +1071,12 @@ function dashboard() {
         ? dashboardAliasesModule
         : null,
       "dashboardAliasesModule",
+    ),
+    resolveModuleFactory(
+      typeof dashboardModelPricingOverridesModule === "function"
+        ? dashboardModelPricingOverridesModule
+        : null,
+      "dashboardModelPricingOverridesModule",
     ),
     resolveModuleFactory(
       typeof dashboardAuthKeysModule === "function"

--- a/internal/admin/dashboard/static/js/modules/dashboard-layout.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/dashboard-layout.test.cjs
@@ -1118,6 +1118,51 @@ test("alias rows use a shared icon-only edit action", () => {
   assert.match(editIconTemplate, /{{define "edit-icon"}}/);
 });
 
+test("pricing action buttons use inline dollar icons that survive table remounts", () => {
+  const pageModelsTemplate = readFixture("../../../templates/page-models.html");
+  const modelTableTemplate = readFixture(
+    "../../../templates/model-table-body.html",
+  );
+  const dollarIconTemplate = readFixture("../../../templates/dollar-icon.html");
+
+  assert.match(dollarIconTemplate, /{{define "dollar-icon"}}/);
+  assert.match(dollarIconTemplate, /<circle cx="12" cy="12" r="10"><\/circle>/);
+  assert.match(pageModelsTemplate, /modelPricingButtonLabel\('global model pricing'[\s\S]*{{template "dollar-icon"}}/);
+  assert.match(modelTableTemplate, /modelPricingButtonLabel\('provider pricing for ' \+ group\.display_name[\s\S]*{{template "dollar-icon"}}/);
+  assert.match(modelTableTemplate, /modelPricingButtonLabel\('model pricing for ' \+ row\.display_name[\s\S]*{{template "dollar-icon"}}/);
+  assert.doesNotMatch(pageModelsTemplate, /data-lucide="circle-dollar-sign"/);
+  assert.doesNotMatch(modelTableTemplate, /data-lucide="circle-dollar-sign"/);
+});
+
+test("pricing override dropdowns use the shared form select style", () => {
+  const indexTemplate = readDashboardTemplateSource();
+  const css = readFixture("../../css/dashboard.css");
+
+  assert.match(
+    indexTemplate,
+    /<select id="model-pricing-override-scope" class="form-select"[\s\S]*x-model="modelPricingOverrideFormScope"/,
+  );
+  assert.match(
+    indexTemplate,
+    /<select class="form-select" x-model="row\.field" data-modal-autofocus>/,
+  );
+  assert.match(
+    indexTemplate,
+    /<div class="pricing-preview-header">[\s\S]*<span>Price Type<\/span>[\s\S]*<span>USD<\/span>[\s\S]*<span>Source<\/span>/,
+  );
+
+  assert.match(css, /\.form-select,\s*\.usage-log-select\s*\{/);
+
+  const sharedSelectRule = readCSSRule(css, ".usage-log-select");
+  assert.match(sharedSelectRule, /appearance:\s*none/);
+  assert.match(sharedSelectRule, /padding:\s*8px 34px 8px 12px/);
+  assert.match(sharedSelectRule, /background-image:[\s\S]*currentcolor/);
+
+  const formSelectRule = readCSSRule(css, ".form-select");
+  assert.match(formSelectRule, /width:\s*100%/);
+  assert.match(formSelectRule, /min-width:\s*0/);
+});
+
 test("mobile modal editor headers keep the close action beside the title", () => {
   const indexTemplate = readDashboardTemplateSource();
   const css = readFixture("../../css/dashboard.css");

--- a/internal/admin/dashboard/static/js/modules/dashboard-layout.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/dashboard-layout.test.cjs
@@ -1144,7 +1144,11 @@ test("pricing override dropdowns use the shared form select style", () => {
   );
   assert.match(
     indexTemplate,
-    /<select class="form-select" x-model="row\.field" data-modal-autofocus>/,
+    /<label class="form-field-label" :for="'pricing-type-' \+ row\.id">Price Type<\/label>\s*<select :id="'pricing-type-' \+ row\.id" class="form-select" x-model="row\.field" data-modal-autofocus>/,
+  );
+  assert.match(
+    indexTemplate,
+    /<label class="form-field-label" :for="'pricing-value-' \+ row\.id">USD Value<\/label>\s*<input :id="'pricing-value-' \+ row\.id" type="number" step="any" min="0" inputmode="decimal" x-model="row\.value">/,
   );
   assert.match(
     indexTemplate,

--- a/internal/admin/dashboard/static/js/modules/model-pricing-overrides.js
+++ b/internal/admin/dashboard/static/js/modules/model-pricing-overrides.js
@@ -1,0 +1,577 @@
+(function(global) {
+    const PRICE_FIELDS = [
+        { value: 'input_per_mtok', label: 'Input $/MTok', group: 'Tokens' },
+        { value: 'output_per_mtok', label: 'Output $/MTok', group: 'Tokens' },
+        { value: 'cached_input_per_mtok', label: 'Cached input $/MTok', group: 'Tokens' },
+        { value: 'cache_write_per_mtok', label: 'Cache write $/MTok', group: 'Tokens' },
+        { value: 'reasoning_output_per_mtok', label: 'Reasoning output $/MTok', group: 'Tokens' },
+        { value: 'batch_input_per_mtok', label: 'Batch input $/MTok', group: 'Batch' },
+        { value: 'batch_output_per_mtok', label: 'Batch output $/MTok', group: 'Batch' },
+        { value: 'audio_input_per_mtok', label: 'Audio input $/MTok', group: 'Audio' },
+        { value: 'audio_output_per_mtok', label: 'Audio output $/MTok', group: 'Audio' },
+        { value: 'per_image', label: '$/Image', group: 'Image' },
+        { value: 'input_per_image', label: 'Input $/Image', group: 'Image' },
+        { value: 'per_second_input', label: 'Input $/Second', group: 'Audio/Video' },
+        { value: 'per_second_output', label: 'Output $/Second', group: 'Video' },
+        { value: 'per_character_input', label: '$/Character', group: 'Audio' },
+        { value: 'per_page', label: '$/Page', group: 'Utility' },
+        { value: 'per_request', label: '$/Request', group: 'Utility' }
+    ];
+
+    function dashboardModelPricingOverridesModule() {
+        return {
+            modelPricingOverridesAvailable: true,
+            modelPricingOverrideViews: [],
+            modelPricingOverrideError: '',
+            modelPricingOverrideNotice: '',
+            modelPricingOverrideFormOpen: false,
+            modelPricingOverrideSubmitting: false,
+            modelPricingOverrideFormHasExistingOverride: false,
+            modelPricingOverrideFormDisplayName: '',
+            modelPricingOverrideFormScope: '',
+            modelPricingOverrideFormScopeOptions: [],
+            modelPricingOverrideFormRow: null,
+            modelPricingOverrideFormBasePricing: null,
+            modelPricingOverrideFormBasePricingSources: null,
+            modelPricingOverrideFormPreservedTiers: [],
+            modelPricingOverrideRows: [],
+            modelPricingOverrideForm: {
+                selector: ''
+            },
+
+            pricingFieldOptions() {
+                return PRICE_FIELDS;
+            },
+
+            pricingFieldLabel(field) {
+                const option = PRICE_FIELDS.find((item) => item.value === field);
+                return option ? option.label : String(field || '').replace(/_/g, ' ');
+            },
+
+            async fetchModelPricingOverrides() {
+                this.modelPricingOverrideError = '';
+                try {
+                    const request = typeof this.adminRequestOptions === 'function'
+                        ? this.adminRequestOptions()
+                        : this.requestOptions();
+                    const res = await fetch('/admin/api/v1/model-pricing-overrides', request);
+                    if (res.status === 503) {
+                        this.modelPricingOverridesAvailable = false;
+                        this.modelPricingOverrideViews = [];
+                        if (typeof this.syncDisplayModels === 'function') {
+                            this.syncDisplayModels();
+                        }
+                        return;
+                    }
+                    const handled = this.handleFetchResponse(res, 'model pricing overrides', request);
+                    if (typeof this.isStaleAuthFetchResult === 'function' && this.isStaleAuthFetchResult(handled)) {
+                        return;
+                    }
+                    this.modelPricingOverridesAvailable = true;
+                    if (!handled) {
+                        this.modelPricingOverrideViews = [];
+                        if (typeof this.syncDisplayModels === 'function') {
+                            this.syncDisplayModels();
+                        }
+                        return;
+                    }
+                    const payload = await res.json();
+                    this.modelPricingOverrideViews = Array.isArray(payload) ? payload : [];
+                    if (typeof this.syncDisplayModels === 'function') {
+                        this.syncDisplayModels();
+                    }
+                } catch (e) {
+                    console.error('Failed to fetch model pricing overrides:', e);
+                    this.modelPricingOverrideViews = [];
+                    this.modelPricingOverrideError = 'Unable to load model pricing overrides.';
+                    if (typeof this.syncDisplayModels === 'function') {
+                        this.syncDisplayModels();
+                    }
+                }
+            },
+
+            modelPricingOverrideMap() {
+                const out = new Map();
+                for (const override of this.modelPricingOverrideViews) {
+                    const selector = String(override && override.selector || '').trim();
+                    if (selector) {
+                        out.set(selector, override);
+                    }
+                }
+                return out;
+            },
+
+            globalPricingOverrideSelector() {
+                return '/';
+            },
+
+            providerPricingOverrideSelector(providerName) {
+                const name = String(providerName || '').trim();
+                return name ? name + '/' : '';
+            },
+
+            modelPricingModelID(row) {
+                return String(row && row.model && row.model.id || '').trim();
+            },
+
+            modelPricingExactSelector(row) {
+                const providerName = String(row && row.provider_name || '').trim();
+                const modelID = this.modelPricingModelID(row);
+                if (providerName && modelID) {
+                    return providerName + '/' + modelID;
+                }
+                return modelID;
+            },
+
+            modelPricingModelWideSelector(row) {
+                return this.modelPricingModelID(row);
+            },
+
+            findModelPricingOverrideView(selector) {
+                const normalized = String(selector || '').trim();
+                if (!normalized) {
+                    return null;
+                }
+                return this.modelPricingOverrideMap().get(normalized) || null;
+            },
+
+            hasGlobalPricingOverride() {
+                return Boolean(this.findModelPricingOverrideView(this.globalPricingOverrideSelector()));
+            },
+
+            hasProviderPricingOverride(group) {
+                return Boolean(this.findModelPricingOverrideView(this.providerPricingOverrideSelector(group && group.provider_name)));
+            },
+
+            hasModelPricingOverride(row) {
+                return Boolean(this.findModelPricingOverrideView(this.modelPricingExactSelector(row)));
+            },
+
+            modelPricingButtonClass(hasOverride) {
+                return hasOverride ? 'table-action-btn-active' : '';
+            },
+
+            modelPricingButtonLabel(subject, hasOverride) {
+                const base = 'Edit ' + String(subject || 'model pricing');
+                return hasOverride ? base + ' (override exists)' : base;
+            },
+
+            matchingModelPricingOverride(row, ignoredSelector) {
+                const overrides = this.modelPricingOverrideMap();
+                const exact = this.modelPricingExactSelector(row);
+                const modelWide = this.modelPricingModelWideSelector(row);
+                const providerWide = this.providerPricingOverrideSelector(row && row.provider_name);
+                const globalSelector = this.globalPricingOverrideSelector();
+                const ignored = String(ignoredSelector || '').trim();
+                for (const selector of [exact, modelWide, providerWide, globalSelector]) {
+                    if (!selector || selector === ignored) {
+                        continue;
+                    }
+                    const override = overrides.get(selector);
+                    if (override) {
+                        return override;
+                    }
+                }
+                return null;
+            },
+
+            clonePricing(pricing) {
+                return pricing && typeof pricing === 'object'
+                    ? JSON.parse(JSON.stringify(pricing))
+                    : {};
+            },
+
+            mergePricing(base, override) {
+                const out = this.clonePricing(base);
+                const patch = override && override.pricing ? override.pricing : override;
+                if (!patch || typeof patch !== 'object') {
+                    return out;
+                }
+                for (const option of PRICE_FIELDS) {
+                    if (patch[option.value] !== null && patch[option.value] !== undefined) {
+                        out[option.value] = Number(patch[option.value]);
+                    }
+                }
+                if (Array.isArray(patch.tiers) && patch.tiers.length > 0) {
+                    out.tiers = this.clonePricing(patch.tiers);
+                }
+                return out;
+            },
+
+            pricingSourcesFromMetadata(metadata) {
+                const pricing = metadata && metadata.pricing ? metadata.pricing : {};
+                const rawSources = metadata && metadata.pricing_sources && typeof metadata.pricing_sources === 'object'
+                    ? metadata.pricing_sources
+                    : {};
+                const sources = {};
+                for (const option of PRICE_FIELDS) {
+                    if (pricing[option.value] !== null && pricing[option.value] !== undefined) {
+                        sources[option.value] = this.modelPricingSourceLabel(rawSources[option.value] || 'model_registry');
+                    }
+                }
+                return sources;
+            },
+
+            modelPricingSourceLabel(source) {
+                switch (String(source || '').trim()) {
+                case 'config_yaml':
+                    return 'config.yaml';
+                case 'model_registry':
+                    return 'Model registry';
+                default:
+                    return source ? String(source) : 'Unknown';
+                }
+            },
+
+            modelPricingOverrideSourceLabel(override) {
+                const selector = String(override && override.selector || '').trim();
+                return selector ? 'Dashboard/API override (' + selector + ')' : 'Dashboard/API override';
+            },
+
+            modelRowPricingState(row, ignoredSelector) {
+                const metadata = row && row.model && row.model.metadata ? row.model.metadata : null;
+                const pricing = this.clonePricing(metadata && metadata.pricing);
+                const sources = this.pricingSourcesFromMetadata(metadata);
+                const override = this.matchingModelPricingOverride(row, ignoredSelector);
+                const patch = override && override.pricing ? override.pricing : null;
+                if (patch) {
+                    const overrideSource = this.modelPricingOverrideSourceLabel(override);
+                    for (const option of PRICE_FIELDS) {
+                        if (patch[option.value] !== null && patch[option.value] !== undefined) {
+                            pricing[option.value] = Number(patch[option.value]);
+                            sources[option.value] = overrideSource;
+                        }
+                    }
+                    if (Array.isArray(patch.tiers) && patch.tiers.length > 0) {
+                        pricing.tiers = this.clonePricing(patch.tiers);
+                        sources.tiers = overrideSource;
+                    }
+                }
+                return { pricing, sources };
+            },
+
+            modelRowPricing(row) {
+                return this.modelRowPricingState(row).pricing;
+            },
+
+            modelRowPricingIgnoring(row, ignoredSelector) {
+                return this.modelRowPricingState(row, ignoredSelector).pricing;
+            },
+
+            openGlobalPricingOverrideEdit() {
+                this.openModelPricingOverrideForm({
+                    displayName: 'All providers and models',
+                    selector: this.globalPricingOverrideSelector(),
+                    scope: 'global',
+                    scopeOptions: [{ value: 'global', label: 'All providers and models', selector: this.globalPricingOverrideSelector() }],
+                    row: null
+                });
+            },
+
+            openProviderPricingOverrideEdit(group) {
+                const selector = this.providerPricingOverrideSelector(group && group.provider_name);
+                if (!selector) {
+                    return;
+                }
+                this.openModelPricingOverrideForm({
+                    displayName: 'All models in ' + (group.display_name || group.provider_name || selector),
+                    selector,
+                    scope: 'provider',
+                    scopeOptions: [{ value: 'provider', label: 'Provider', selector }],
+                    row: null
+                });
+            },
+
+            openModelPricingOverrideEdit(row) {
+                if (!row || row.is_alias) {
+                    return;
+                }
+                const exact = this.modelPricingExactSelector(row);
+                const modelWide = this.modelPricingModelWideSelector(row);
+                const scopeOptions = [{ value: 'exact', label: 'This provider and model', selector: exact }];
+                if (modelWide && modelWide !== exact) {
+                    scopeOptions.push({ value: 'model', label: 'This model across providers', selector: modelWide });
+                }
+                this.openModelPricingOverrideForm({
+                    displayName: row.display_name || exact,
+                    selector: exact,
+                    scope: 'exact',
+                    scopeOptions,
+                    row
+                });
+            },
+
+            openModelPricingOverrideForm(options) {
+                const opts = options || {};
+                this.modelPricingOverrideFormOpen = true;
+                this.modelPricingOverrideError = '';
+                this.modelPricingOverrideNotice = '';
+                this.modelPricingOverrideFormDisplayName = opts.displayName || opts.selector || 'Pricing';
+                this.modelPricingOverrideFormScope = opts.scope || '';
+                this.modelPricingOverrideFormScopeOptions = Array.isArray(opts.scopeOptions) ? opts.scopeOptions : [];
+                this.modelPricingOverrideFormRow = opts.row || null;
+                this.modelPricingOverrideForm = { selector: opts.selector || '' };
+                this.loadModelPricingOverrideFormSelector(opts.selector || '');
+                if (typeof this.focusEditorField === 'function') {
+                    this.focusEditorField('modelPricingOverrideEditor');
+                }
+            },
+
+            loadModelPricingOverrideFormSelector(selector) {
+                selector = String(selector || '').trim();
+                const override = this.findModelPricingOverrideView(selector);
+                this.modelPricingOverrideFormHasExistingOverride = Boolean(override);
+                this.modelPricingOverrideRows = this.pricingRowsFromOverride(override);
+                this.modelPricingOverrideFormPreservedTiers = override && override.pricing && Array.isArray(override.pricing.tiers)
+                    ? this.clonePricing(override.pricing.tiers)
+                    : [];
+                if (this.modelPricingOverrideRows.length === 0 && this.modelPricingOverrideFormPreservedTiers.length === 0) {
+                    this.addModelPricingOverrideRow();
+                }
+                const row = this.modelPricingOverrideFormRow;
+                const state = row ? this.modelRowPricingState(row, selector) : { pricing: {}, sources: {} };
+                this.modelPricingOverrideFormBasePricing = state.pricing;
+                this.modelPricingOverrideFormBasePricingSources = state.sources;
+            },
+
+            setModelPricingOverrideScope(scope) {
+                this.modelPricingOverrideFormScope = scope;
+                const option = this.modelPricingOverrideFormScopeOptions.find((item) => item.value === scope);
+                if (!option) {
+                    return;
+                }
+                this.modelPricingOverrideForm.selector = option.selector;
+                this.loadModelPricingOverrideFormSelector(option.selector);
+            },
+
+            pricingRowsFromOverride(override) {
+                const pricing = override && override.pricing ? override.pricing : {};
+                const rows = [];
+                for (const option of PRICE_FIELDS) {
+                    if (pricing[option.value] !== null && pricing[option.value] !== undefined) {
+                        rows.push({
+                            id: this.nextModelPricingOverrideRowID(),
+                            field: option.value,
+                            value: String(pricing[option.value])
+                        });
+                    }
+                }
+                return rows;
+            },
+
+            nextModelPricingOverrideRowID() {
+                this._modelPricingOverrideRowID = (this._modelPricingOverrideRowID || 0) + 1;
+                return 'pricing-row-' + this._modelPricingOverrideRowID;
+            },
+
+            selectedPricingFields(exceptID) {
+                const fields = new Set();
+                for (const row of this.modelPricingOverrideRows) {
+                    if (exceptID && row.id === exceptID) {
+                        continue;
+                    }
+                    const field = String(row.field || '').trim();
+                    if (field) {
+                        fields.add(field);
+                    }
+                }
+                return fields;
+            },
+
+            availablePricingFieldOptions(row) {
+                const selected = this.selectedPricingFields(row && row.id);
+                return PRICE_FIELDS.filter((option) => option.value === (row && row.field) || !selected.has(option.value));
+            },
+
+            addModelPricingOverrideRow() {
+                const selected = this.selectedPricingFields();
+                const option = PRICE_FIELDS.find((item) => !selected.has(item.value)) || PRICE_FIELDS[0];
+                if (!option) {
+                    return;
+                }
+                this.modelPricingOverrideRows.push({
+                    id: this.nextModelPricingOverrideRowID(),
+                    field: option.value,
+                    value: ''
+                });
+            },
+
+            removeModelPricingOverrideRow(row) {
+                this.modelPricingOverrideRows = this.modelPricingOverrideRows.filter((item) => item.id !== row.id);
+                if (this.modelPricingOverrideRows.length === 0 && this.modelPricingOverrideFormPreservedTiers.length === 0) {
+                    this.addModelPricingOverrideRow();
+                }
+            },
+
+            modelPricingOverridePayload() {
+                const pricing = {};
+                const seen = new Set();
+                for (const row of this.modelPricingOverrideRows) {
+                    const field = String(row.field || '').trim();
+                    if (!field) {
+                        return { error: 'Choose a price type for every row.' };
+                    }
+                    if (seen.has(field)) {
+                        return { error: 'Each price type can only be used once.' };
+                    }
+                    seen.add(field);
+                    const raw = String(row.value || '').trim();
+                    if (raw === '') {
+                        return { error: 'Enter a value for ' + this.pricingFieldLabel(field) + '.' };
+                    }
+                    const value = Number(raw);
+                    if (!Number.isFinite(value) || value < 0) {
+                        return { error: 'Pricing values must be numbers greater than or equal to 0.' };
+                    }
+                    pricing[field] = value;
+                }
+                if (this.modelPricingOverrideFormPreservedTiers.length > 0) {
+                    pricing.tiers = this.clonePricing(this.modelPricingOverrideFormPreservedTiers);
+                }
+                if (Object.keys(pricing).length === 0) {
+                    return { error: 'Add at least one pricing field before saving.' };
+                }
+                return { pricing };
+            },
+
+            modelPricingOverrideDraftPricing() {
+                const payload = this.modelPricingOverridePayload();
+                return payload && payload.pricing ? payload.pricing : {};
+            },
+
+            modelPricingEffectivePreviewRows() {
+                const base = this.modelPricingOverrideFormBasePricing || {};
+                const baseSources = this.modelPricingOverrideFormBasePricingSources || {};
+                const draft = this.modelPricingOverrideDraftPricing();
+                const effective = this.mergePricing(base, draft);
+                return PRICE_FIELDS.map((option) => {
+                    const hasDraft = draft[option.value] !== null && draft[option.value] !== undefined;
+                    const hasBase = base[option.value] !== null && base[option.value] !== undefined;
+                    return {
+                        field: option.value,
+                        label: option.label,
+                        value: effective[option.value],
+                        source: hasDraft ? 'Form/API value' : (hasBase ? (baseSources[option.value] || 'Model registry') : 'Unset')
+                    };
+                }).filter((row) => row.source !== 'Unset' || row.value !== undefined);
+            },
+
+            closeModelPricingOverrideForm() {
+                this.modelPricingOverrideFormOpen = false;
+                this.modelPricingOverrideSubmitting = false;
+                this.modelPricingOverrideError = '';
+                this.modelPricingOverrideFormHasExistingOverride = false;
+                this.modelPricingOverrideFormDisplayName = '';
+                this.modelPricingOverrideFormScope = '';
+                this.modelPricingOverrideFormScopeOptions = [];
+                this.modelPricingOverrideFormRow = null;
+                this.modelPricingOverrideFormBasePricing = null;
+                this.modelPricingOverrideFormBasePricingSources = null;
+                this.modelPricingOverrideFormPreservedTiers = [];
+                this.modelPricingOverrideRows = [];
+                this.modelPricingOverrideForm = { selector: '' };
+            },
+
+            async submitModelPricingOverrideForm() {
+                const selector = String(this.modelPricingOverrideForm.selector || '').trim();
+                if (!selector) {
+                    this.modelPricingOverrideError = 'Model pricing selector is required.';
+                    return;
+                }
+                const payload = this.modelPricingOverridePayload();
+                if (payload.error) {
+                    this.modelPricingOverrideError = payload.error;
+                    return;
+                }
+
+                this.modelPricingOverrideSubmitting = true;
+                this.modelPricingOverrideError = '';
+                this.modelPricingOverrideNotice = '';
+                try {
+                    const request = typeof this.adminRequestOptions === 'function'
+                        ? this.adminRequestOptions({ method: 'PUT', body: JSON.stringify(payload) })
+                        : this.requestOptions({ method: 'PUT', body: JSON.stringify(payload) });
+                    const res = await fetch('/admin/api/v1/model-pricing-overrides/' + encodeURIComponent(selector), request);
+                    if (res.status === 503) {
+                        this.modelPricingOverridesAvailable = false;
+                        this.modelPricingOverrideError = 'Model pricing overrides feature is unavailable.';
+                        return;
+                    }
+                    const handled = this.handleFetchResponse(res, 'model pricing override', request);
+                    if (typeof this.isStaleAuthFetchResult === 'function' && this.isStaleAuthFetchResult(handled)) {
+                        return;
+                    }
+                    if (!handled) {
+                        this.modelPricingOverrideError = res.status === 401
+                            ? 'Authentication required.'
+                            : await this.aliasResponseMessage(res, 'Failed to save model pricing.');
+                        return;
+                    }
+                    this.modelPricingOverridesAvailable = true;
+                    await this.fetchModelPricingOverrides();
+                    if (typeof this.syncDisplayModels === 'function') {
+                        this.syncDisplayModels();
+                    }
+                    this.closeModelPricingOverrideForm();
+                    this.modelPricingOverrideNotice = 'Model pricing saved.';
+                } catch (e) {
+                    console.error('Failed to save model pricing override:', e);
+                    this.modelPricingOverrideError = 'Failed to save model pricing.';
+                } finally {
+                    this.modelPricingOverrideSubmitting = false;
+                }
+            },
+
+            async deleteModelPricingOverride() {
+                const selector = String(this.modelPricingOverrideForm.selector || '').trim();
+                if (!selector || !this.modelPricingOverrideFormHasExistingOverride) {
+                    return;
+                }
+                if (!window.confirm('Remove the model pricing override for "' + selector + '"?')) {
+                    return;
+                }
+
+                this.modelPricingOverrideSubmitting = true;
+                this.modelPricingOverrideError = '';
+                this.modelPricingOverrideNotice = '';
+                try {
+                    const request = typeof this.adminRequestOptions === 'function'
+                        ? this.adminRequestOptions({ method: 'DELETE' })
+                        : this.requestOptions({ method: 'DELETE' });
+                    const res = await fetch('/admin/api/v1/model-pricing-overrides/' + encodeURIComponent(selector), request);
+                    if (res.status === 503) {
+                        this.modelPricingOverridesAvailable = false;
+                        this.modelPricingOverrideError = 'Model pricing overrides feature is unavailable.';
+                        return;
+                    }
+                    if (res.status !== 404) {
+                        const handled = this.handleFetchResponse(res, 'model pricing override', request);
+                        if (typeof this.isStaleAuthFetchResult === 'function' && this.isStaleAuthFetchResult(handled)) {
+                            return;
+                        }
+                        if (!handled) {
+                            this.modelPricingOverrideError = res.status === 401
+                                ? 'Authentication required.'
+                                : await this.aliasResponseMessage(res, 'Failed to remove model pricing override.');
+                            return;
+                        }
+                    }
+                    this.modelPricingOverridesAvailable = true;
+                    await this.fetchModelPricingOverrides();
+                    if (typeof this.syncDisplayModels === 'function') {
+                        this.syncDisplayModels();
+                    }
+                    this.closeModelPricingOverrideForm();
+                    this.modelPricingOverrideNotice = 'Model pricing override removed.';
+                } catch (e) {
+                    console.error('Failed to delete model pricing override:', e);
+                    this.modelPricingOverrideError = 'Failed to remove model pricing override.';
+                } finally {
+                    this.modelPricingOverrideSubmitting = false;
+                }
+            }
+        };
+    }
+
+    global.dashboardModelPricingOverridesModule = dashboardModelPricingOverridesModule;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/internal/admin/dashboard/static/js/modules/model-pricing-overrides.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/model-pricing-overrides.test.cjs
@@ -1,0 +1,124 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function loadModelPricingOverridesModuleFactory(overrides = {}) {
+    const source = fs.readFileSync(path.join(__dirname, 'model-pricing-overrides.js'), 'utf8');
+    const window = {
+        ...(overrides.window || {})
+    };
+    const context = {
+        console,
+        ...overrides.context,
+        window
+    };
+    vm.createContext(context);
+    vm.runInContext(source, context);
+    return context.window.dashboardModelPricingOverridesModule;
+}
+
+function createModule(overrides) {
+    const factory = loadModelPricingOverridesModuleFactory(overrides);
+    return factory();
+}
+
+test('modelRowPricing applies exact override over inherited/base pricing', () => {
+    const module = createModule();
+    const row = {
+        provider_name: 'openai-main',
+        model: {
+            id: 'gpt-4o',
+            metadata: {
+                pricing: {
+                    input_per_mtok: 1,
+                    output_per_mtok: 2
+                }
+            }
+        }
+    };
+    module.modelPricingOverrideViews = [
+        { selector: '/', pricing: { input_per_mtok: 10 } },
+        { selector: 'openai-main/', pricing: { input_per_mtok: 20 } },
+        { selector: 'gpt-4o', pricing: { input_per_mtok: 30 } },
+        { selector: 'openai-main/gpt-4o', pricing: { input_per_mtok: 40 } }
+    ];
+
+    const pricing = module.modelRowPricing(row);
+
+    assert.equal(pricing.input_per_mtok, 40);
+    assert.equal(pricing.output_per_mtok, 2);
+});
+
+test('effective preview reports per-field pricing sources', () => {
+    const module = createModule();
+    const row = {
+        provider_name: 'openai-main',
+        model: {
+            id: 'gpt-4o',
+            metadata: {
+                pricing: {
+                    input_per_mtok: 1,
+                    output_per_mtok: 2,
+                    cached_input_per_mtok: 0.5
+                },
+                pricing_sources: {
+                    input_per_mtok: 'config_yaml',
+                    output_per_mtok: 'model_registry'
+                }
+            }
+        }
+    };
+    module.modelPricingOverrideViews = [
+        { selector: 'openai-main/', pricing: { output_per_mtok: 20 } }
+    ];
+
+    const state = module.modelRowPricingState(row, 'openai-main/gpt-4o');
+    assert.equal(state.pricing.output_per_mtok, 20);
+    assert.equal(state.sources.input_per_mtok, 'config.yaml');
+    assert.equal(state.sources.output_per_mtok, 'Dashboard/API override (openai-main/)');
+    assert.equal(state.sources.cached_input_per_mtok, 'Model registry');
+
+    module.modelPricingOverrideFormBasePricing = state.pricing;
+    module.modelPricingOverrideFormBasePricingSources = state.sources;
+    module.modelPricingOverrideRows = [
+        { id: 'draft', field: 'input_per_mtok', value: '10' }
+    ];
+
+    const rows = module.modelPricingEffectivePreviewRows();
+    assert.equal(rows.find((item) => item.field === 'input_per_mtok').source, 'Form/API value');
+    assert.equal(rows.find((item) => item.field === 'output_per_mtok').source, 'Dashboard/API override (openai-main/)');
+    assert.equal(rows.find((item) => item.field === 'cached_input_per_mtok').source, 'Model registry');
+});
+
+test('payload validates duplicate and negative pricing rows', () => {
+    const module = createModule();
+    module.modelPricingOverrideRows = [
+        { id: '1', field: 'input_per_mtok', value: '1' },
+        { id: '2', field: 'input_per_mtok', value: '2' }
+    ];
+
+    assert.match(module.modelPricingOverridePayload().error, /only be used once/);
+
+    module.modelPricingOverrideRows = [
+        { id: '1', field: 'input_per_mtok', value: '-1' }
+    ];
+    assert.match(module.modelPricingOverridePayload().error, /greater than or equal to 0/);
+});
+
+test('payload preserves tiered pricing when scalar rows are absent', () => {
+    const module = createModule();
+    module.modelPricingOverrideRows = [];
+    module.modelPricingOverrideFormPreservedTiers = [
+        { up_to_mtok: 1, input_per_mtok: 0.5 }
+    ];
+
+    assert.equal(JSON.stringify(module.modelPricingOverridePayload()), JSON.stringify({
+        pricing: {
+            tiers: [
+                { up_to_mtok: 1, input_per_mtok: 0.5 }
+            ]
+        }
+    }));
+});

--- a/internal/admin/dashboard/templates/dollar-icon.html
+++ b/internal/admin/dashboard/templates/dollar-icon.html
@@ -1,0 +1,7 @@
+{{define "dollar-icon"}}
+<svg class="table-icon-svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="10"></circle>
+    <path d="M16 8h-6a2 2 0 1 0 0 4h4a2 2 0 1 1 0 4H8"></path>
+    <path d="M12 18V6"></path>
+</svg>
+{{end}}

--- a/internal/admin/dashboard/templates/layout.html
+++ b/internal/admin/dashboard/templates/layout.html
@@ -141,6 +141,7 @@
     <script src="{{assetURL "js/modules/usage.js"}}"></script>
     <script src="{{assetURL "js/modules/audit-list.js"}}"></script>
     <script src="{{assetURL "js/modules/aliases.js"}}"></script>
+    <script src="{{assetURL "js/modules/model-pricing-overrides.js"}}"></script>
     <script src="{{assetURL "js/modules/workflows.js"}}"></script>
     <script src="{{assetURL "js/modules/auth-keys.js"}}"></script>
     <script src="{{assetURL "js/modules/guardrails.js"}}"></script>

--- a/internal/admin/dashboard/templates/model-table-body.html
+++ b/internal/admin/dashboard/templates/model-table-body.html
@@ -12,8 +12,16 @@
                         </div>
                         <div class="provider-group-summary" x-show="group.access_summary" x-text="group.access_summary"></div>
                     </div>
-                    <div class="alias-actions-cell">
+                    <div class="alias-actions-cell model-list-actions">
                         <span class="model-access-state-badge" :class="modelAccessStateClass(group.access)" x-text="modelAccessStateText(group.access)"></span>
+                        <button type="button" class="table-action-btn table-icon-btn"
+                            x-show="modelPricingOverridesAvailable && group.provider_name"
+                            :class="modelPricingButtonClass(hasProviderPricingOverride(group))"
+                            :aria-label="modelPricingButtonLabel('provider pricing for ' + group.display_name, hasProviderPricingOverride(group))"
+                            :title="modelPricingButtonLabel('provider pricing for ' + group.display_name, hasProviderPricingOverride(group))"
+                            @click="openProviderPricingOverrideEdit(group)">
+                            {{template "dollar-icon"}}
+                        </button>
                         <button type="button" class="table-action-btn table-icon-btn"
                             x-show="modelOverridesAvailable && group.access.selector"
                             :class="modelOverrideEditButtonClass(hasAccessOverride(group.access))"
@@ -43,19 +51,19 @@
                     </div>
                 </td>
                 <td x-show="activeCategory === 'all' || activeCategory === 'text_generation'" x-text="(row.model.metadata?.modes ?? []).join(', ') || '-'"></td>
-                <td class="col-price" x-show="activeCategory === 'all' || activeCategory === 'text_generation' || activeCategory === 'embedding'" x-text="formatPrice(row.model.metadata?.pricing?.input_per_mtok)"></td>
-                <td class="col-price" x-show="activeCategory === 'all' || activeCategory === 'text_generation'" x-text="formatPrice(row.model.metadata?.pricing?.output_per_mtok)"></td>
-                <td class="col-price" x-show="activeCategory === 'text_generation'" x-text="formatPrice(row.model.metadata?.pricing?.cached_input_per_mtok)"></td>
-                <td class="col-price" x-show="activeCategory === 'image'" x-text="formatPriceFine(row.model.metadata?.pricing?.per_image)"></td>
-                <td class="col-price" x-show="activeCategory === 'audio'" x-text="formatPriceFine(row.model.metadata?.pricing?.per_second_input)"></td>
-                <td class="col-price" x-show="activeCategory === 'audio'" x-text="formatPriceFine(row.model.metadata?.pricing?.per_character_input)"></td>
-                <td class="col-price" x-show="activeCategory === 'video'" x-text="formatPriceFine(row.model.metadata?.pricing?.per_second_input)"></td>
-                <td class="col-price" x-show="activeCategory === 'video'" x-text="formatPriceFine(row.model.metadata?.pricing?.per_second_output)"></td>
-                <td class="col-price" x-show="activeCategory === 'utility'" x-text="formatPriceFine(row.model.metadata?.pricing?.per_page)"></td>
-                <td class="col-price" x-show="activeCategory === 'utility'" x-text="formatPriceFine(row.model.metadata?.pricing?.per_request)"></td>
+                <td class="col-price" x-show="activeCategory === 'all' || activeCategory === 'text_generation' || activeCategory === 'embedding'" x-text="formatPrice(modelRowPricing(row)?.input_per_mtok)"></td>
+                <td class="col-price" x-show="activeCategory === 'all' || activeCategory === 'text_generation'" x-text="formatPrice(modelRowPricing(row)?.output_per_mtok)"></td>
+                <td class="col-price" x-show="activeCategory === 'text_generation'" x-text="formatPrice(modelRowPricing(row)?.cached_input_per_mtok)"></td>
+                <td class="col-price" x-show="activeCategory === 'image'" x-text="formatPriceFine(modelRowPricing(row)?.per_image)"></td>
+                <td class="col-price" x-show="activeCategory === 'audio'" x-text="formatPriceFine(modelRowPricing(row)?.per_second_input)"></td>
+                <td class="col-price" x-show="activeCategory === 'audio'" x-text="formatPriceFine(modelRowPricing(row)?.per_character_input)"></td>
+                <td class="col-price" x-show="activeCategory === 'video'" x-text="formatPriceFine(modelRowPricing(row)?.per_second_input)"></td>
+                <td class="col-price" x-show="activeCategory === 'video'" x-text="formatPriceFine(modelRowPricing(row)?.per_second_output)"></td>
+                <td class="col-price" x-show="activeCategory === 'utility'" x-text="formatPriceFine(modelRowPricing(row)?.per_page)"></td>
+                <td class="col-price" x-show="activeCategory === 'utility'" x-text="formatPriceFine(modelRowPricing(row)?.per_request)"></td>
                 <td class="model-row-actions">
                     <template x-if="row.is_alias">
-                        <div class="alias-actions-cell">
+                        <div class="alias-actions-cell model-list-actions">
                             <button type="button" class="alias-toggle" :class="{ enabled: row.alias.enabled !== false }" :disabled="aliasTogglingName === row.alias.name" @click="toggleAliasEnabled(row.alias)">
                                 <span class="alias-toggle-track"><span class="alias-toggle-thumb"></span></span>
                                 <span x-text="aliasTogglingName === row.alias.name ? 'Updating...' : (row.alias.enabled !== false ? 'Active' : 'Disabled')"></span>
@@ -76,8 +84,16 @@
                         </div>
                     </template>
                     <template x-if="!row.is_alias">
-                        <div class="alias-actions-cell">
+                        <div class="alias-actions-cell model-list-actions">
                             <span class="model-access-state-badge" :class="modelAccessStateClass(row.access)" x-text="modelAccessStateText(row.access)"></span>
+                            <button type="button" class="table-action-btn table-icon-btn"
+                                x-show="modelPricingOverridesAvailable"
+                                :class="modelPricingButtonClass(hasModelPricingOverride(row))"
+                                :aria-label="modelPricingButtonLabel('model pricing for ' + row.display_name, hasModelPricingOverride(row))"
+                                :title="modelPricingButtonLabel('model pricing for ' + row.display_name, hasModelPricingOverride(row))"
+                                @click="openModelPricingOverrideEdit(row)">
+                                {{template "dollar-icon"}}
+                            </button>
                             <button type="button" class="table-action-btn table-icon-btn"
                                 x-show="modelOverridesAvailable"
                                 :class="modelOverrideEditButtonClass(hasAccessOverride(row.access))"

--- a/internal/admin/dashboard/templates/page-budgets.html
+++ b/internal/admin/dashboard/templates/page-budgets.html
@@ -97,7 +97,7 @@
                     <div class="form-field">
                         <label class="form-field-label" for="budget-period">Period</label>
                         <select id="budget-period"
-                                class="usage-log-select settings-select"
+                                class="form-select settings-select"
                                 x-model="budgetForm.period"
                                 :disabled="budgetEditing"
                                 @change="syncBudgetPeriodSeconds()">

--- a/internal/admin/dashboard/templates/page-guardrails.html
+++ b/internal/admin/dashboard/templates/page-guardrails.html
@@ -76,7 +76,7 @@
 
                     <div class="form-field">
                         <label class="form-field-label" for="guardrail-type">Type</label>
-                        <select id="guardrail-type" class="usage-log-select settings-select" x-ref="guardrailTypeSelect" x-model="guardrailForm.type" x-effect="guardrailTypes.length; guardrailForm.type; $nextTick(() => syncGuardrailTypeSelectValue())" :disabled="guardrailFormMode === 'edit'" @change="onGuardrailTypeChange()">
+                        <select id="guardrail-type" class="form-select settings-select" x-ref="guardrailTypeSelect" x-model="guardrailForm.type" x-effect="guardrailTypes.length; guardrailForm.type; $nextTick(() => syncGuardrailTypeSelectValue())" :disabled="guardrailFormMode === 'edit'" @change="onGuardrailTypeChange()">
                             <template x-for="typeDef in guardrailTypes" :key="typeDef.type">
                                 <option :value="typeDef.type" x-text="typeDef.label"></option>
                             </template>
@@ -113,7 +113,7 @@
                                         <p :id="copyId" class="inline-help-copy" x-show="open && text" x-transition.opacity.duration.200ms x-text="text"></p>
                                     </div>
                                     <template x-if="field.input === 'select'">
-                                        <select class="usage-log-select settings-select" :id="'guardrail-field-' + field.key" :value="guardrailFieldValue(field)" :aria-describedby="field.help ? 'guardrail-field-help-' + field.key : null" @change="setGuardrailFieldValue(field, $event.target.value)">
+                                        <select class="form-select settings-select" :id="'guardrail-field-' + field.key" :value="guardrailFieldValue(field)" :aria-describedby="field.help ? 'guardrail-field-help-' + field.key : null" @change="setGuardrailFieldValue(field, $event.target.value)">
                                             <template x-for="option in field.options" :key="option.value">
                                                 <option :value="option.value" x-text="option.label"></option>
                                             </template>

--- a/internal/admin/dashboard/templates/page-models.html
+++ b/internal/admin/dashboard/templates/page-models.html
@@ -18,6 +18,8 @@
     <div class="alert alert-success" x-show="aliasNotice" x-text="aliasNotice"></div>
     <div class="alert alert-warning" x-show="modelOverrideError && !authError && !modelOverrideFormOpen" x-text="modelOverrideError"></div>
     <div class="alert alert-success" x-show="modelOverrideNotice && !modelOverrideError" x-text="modelOverrideNotice"></div>
+    <div class="alert alert-warning" x-show="modelPricingOverrideError && !authError && !modelPricingOverrideFormOpen" x-text="modelPricingOverrideError"></div>
+    <div class="alert alert-success" x-show="modelPricingOverrideNotice && !modelPricingOverrideError" x-text="modelPricingOverrideNotice"></div>
 
     <!-- Category Tabs -->
     <div class="category-tabs" x-show="categories.length > 0">
@@ -177,6 +179,116 @@
         </div>
     </div>
 
+    <div class="editor-modal-backdrop"
+         x-cloak
+         x-show="modelPricingOverrideFormOpen"
+         x-transition.opacity.duration.160ms
+         aria-hidden="true"></div>
+    <div class="editor-modal-shell"
+         x-cloak
+         x-show="modelPricingOverrideFormOpen"
+         x-transition.opacity.duration.160ms
+         @click="closeModelPricingOverrideForm()"
+         @keydown.escape.window="modelPricingOverrideFormOpen && !authDialogOpen && closeModelPricingOverrideForm()">
+        <div class="model-editor model-pricing-editor" x-show="modelPricingOverrideFormOpen" x-ref="modelPricingOverrideEditor" role="dialog" aria-modal="true" aria-label="Model pricing editor" @click.stop>
+            <form class="form" @submit.prevent="submitModelPricingOverrideForm()">
+                <div class="editor-header">
+                    <div>
+                        <p class="form-kicker">Pricing override</p>
+                        <h3 x-text="modelPricingOverrideFormDisplayName || modelPricingOverrideForm.selector || 'Pricing'"></h3>
+                    </div>
+                    <button type="button" class="dialog-close-btn" aria-label="Close model pricing editor" @click="closeModelPricingOverrideForm()">
+                        {{template "x-icon"}}
+                    </button>
+                </div>
+
+                <div class="form-grid">
+                    <div class="form-field">
+                        <label class="form-field-label" for="model-pricing-override-selector">Selector</label>
+                        <input id="model-pricing-override-selector" type="text" class="mono" x-model="modelPricingOverrideForm.selector" disabled>
+                    </div>
+
+                    <div class="form-field" x-show="modelPricingOverrideFormScopeOptions.length > 1">
+                        <label class="form-field-label" for="model-pricing-override-scope">Scope</label>
+                        <select id="model-pricing-override-scope" class="form-select" x-model="modelPricingOverrideFormScope" @change="setModelPricingOverrideScope(modelPricingOverrideFormScope)">
+                            <template x-for="option in modelPricingOverrideFormScopeOptions" :key="option.value">
+                                <option :value="option.value" x-text="option.label"></option>
+                            </template>
+                        </select>
+                    </div>
+                </div>
+
+                <p class="form-hint">
+                    Currency is USD. Saved fields override model registry and config.yaml pricing for this selector; unset fields continue to inherit.
+                </p>
+
+                <div class="pricing-override-rows">
+                    <template x-for="row in modelPricingOverrideRows" :key="row.id">
+                        <div class="pricing-override-row">
+                            <div class="form-field pricing-override-type-field">
+                                <label class="form-field-label">Price Type</label>
+                                <select class="form-select" x-model="row.field" data-modal-autofocus>
+                                    <template x-for="option in availablePricingFieldOptions(row)" :key="option.value">
+                                        <option :value="option.value" x-text="option.group + ' - ' + option.label"></option>
+                                    </template>
+                                </select>
+                            </div>
+                            <div class="form-field pricing-override-value-field">
+                                <label class="form-field-label">USD Value</label>
+                                <input type="number" step="any" min="0" inputmode="decimal" x-model="row.value">
+                            </div>
+                            <button type="button"
+                                    class="table-action-btn table-action-btn-danger table-icon-btn pricing-override-remove-row"
+                                    :aria-label="'Remove ' + pricingFieldLabel(row.field)"
+                                    :title="'Remove ' + pricingFieldLabel(row.field)"
+                                    @click="removeModelPricingOverrideRow(row)">
+                                {{template "x-icon"}}
+                            </button>
+                        </div>
+                    </template>
+                </div>
+
+                <div class="pricing-override-row-actions">
+                    <button type="button" class="pagination-btn pagination-btn-with-icon" @click="addModelPricingOverrideRow()">
+                        <i data-lucide="plus" class="form-action-icon" aria-hidden="true"></i>
+                        <span>Add Price</span>
+                    </button>
+                </div>
+
+                <div class="pricing-override-tier-note" x-show="modelPricingOverrideFormPreservedTiers.length > 0">
+                    Tiered pricing exists for this override and will be preserved. Tier editing can be added without a database migration.
+                </div>
+
+                <div class="pricing-preview">
+                    <div class="pricing-preview-header">
+                        <span>Price Type</span>
+                        <span>USD</span>
+                        <span>Source</span>
+                    </div>
+                    <div class="pricing-preview-row pricing-preview-row-empty" x-show="modelPricingEffectivePreviewRows().length === 0">No pricing fields set.</div>
+                    <template x-for="row in modelPricingEffectivePreviewRows()" :key="row.field">
+                        <div class="pricing-preview-row">
+                            <span x-text="row.label"></span>
+                            <span class="mono" x-text="row.value === null || row.value === undefined ? '-' : formatPriceFine(Number(row.value))"></span>
+                            <span x-text="row.source"></span>
+                        </div>
+                    </template>
+                </div>
+
+                <p class="form-error" x-show="modelPricingOverrideError" x-text="modelPricingOverrideError" role="alert" aria-live="assertive"></p>
+
+                <div class="form-actions">
+                    <button type="button" class="pagination-btn" @click="closeModelPricingOverrideForm()">Cancel</button>
+                    <button type="button" class="pagination-btn pagination-btn-danger-outline" x-show="modelPricingOverrideFormHasExistingOverride" :disabled="modelPricingOverrideSubmitting" @click="deleteModelPricingOverride()">Remove Override</button>
+                    <button type="submit" class="pagination-btn pagination-btn-primary pagination-btn-with-icon model-pricing-submit-btn" :disabled="modelPricingOverrideSubmitting">
+                        <i data-lucide="save" class="form-action-icon" aria-hidden="true"></i>
+                        <span x-text="modelPricingOverrideSubmitting ? 'Saving...' : 'Save Pricing'"></span>
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+
     <!-- Models Table: All / Text Generation -->
     <template x-if="(displayModels.length > 0 || modelFilter) && (activeCategory === 'all' || activeCategory === 'text_generation')">
     <div class="table-wrapper">
@@ -188,16 +300,7 @@
                     <th class="col-price">Input<br>$/MTok</th>
                     <th class="col-price">Output<br>$/MTok</th>
                     <th class="col-price" x-show="activeCategory === 'text_generation'">Cached $/MTok</th>
-                    <th class="model-actions-header">
-                        <button type="button" class="table-action-btn table-icon-btn"
-                            x-show="modelOverridesAvailable"
-                            :class="modelOverrideEditButtonClass(hasGlobalModelOverride())"
-                            :aria-label="modelOverrideEditButtonLabel('global model access', hasGlobalModelOverride())"
-                            :title="modelOverrideEditButtonLabel('global model access', hasGlobalModelOverride())"
-                            @click="openGlobalModelOverrideEdit()">
-                            {{template "edit-icon"}}
-                        </button>
-                    </th>
+                    <th class="model-actions-header">{{template "model-global-action-buttons" .}}</th>
                 </tr>
             </thead>
             {{template "model-table-body" .}}
@@ -213,16 +316,7 @@
                 <tr>
                     <th>Model</th>
                     <th class="col-price">Input<br>$/MTok</th>
-                    <th class="model-actions-header">
-                        <button type="button" class="table-action-btn table-icon-btn"
-                            x-show="modelOverridesAvailable"
-                            :class="modelOverrideEditButtonClass(hasGlobalModelOverride())"
-                            :aria-label="modelOverrideEditButtonLabel('global model access', hasGlobalModelOverride())"
-                            :title="modelOverrideEditButtonLabel('global model access', hasGlobalModelOverride())"
-                            @click="openGlobalModelOverrideEdit()">
-                            {{template "edit-icon"}}
-                        </button>
-                    </th>
+                    <th class="model-actions-header">{{template "model-global-action-buttons" .}}</th>
                 </tr>
             </thead>
             {{template "model-table-body" .}}
@@ -238,16 +332,7 @@
                 <tr>
                     <th>Model</th>
                     <th class="col-price">$/Image</th>
-                    <th class="model-actions-header">
-                        <button type="button" class="table-action-btn table-icon-btn"
-                            x-show="modelOverridesAvailable"
-                            :class="modelOverrideEditButtonClass(hasGlobalModelOverride())"
-                            :aria-label="modelOverrideEditButtonLabel('global model access', hasGlobalModelOverride())"
-                            :title="modelOverrideEditButtonLabel('global model access', hasGlobalModelOverride())"
-                            @click="openGlobalModelOverrideEdit()">
-                            {{template "edit-icon"}}
-                        </button>
-                    </th>
+                    <th class="model-actions-header">{{template "model-global-action-buttons" .}}</th>
                 </tr>
             </thead>
             {{template "model-table-body" .}}
@@ -264,16 +349,7 @@
                     <th>Model</th>
                     <th class="col-price">$/Second</th>
                     <th class="col-price">$/Character</th>
-                    <th class="model-actions-header">
-                        <button type="button" class="table-action-btn table-icon-btn"
-                            x-show="modelOverridesAvailable"
-                            :class="modelOverrideEditButtonClass(hasGlobalModelOverride())"
-                            :aria-label="modelOverrideEditButtonLabel('global model access', hasGlobalModelOverride())"
-                            :title="modelOverrideEditButtonLabel('global model access', hasGlobalModelOverride())"
-                            @click="openGlobalModelOverrideEdit()">
-                            {{template "edit-icon"}}
-                        </button>
-                    </th>
+                    <th class="model-actions-header">{{template "model-global-action-buttons" .}}</th>
                 </tr>
             </thead>
             {{template "model-table-body" .}}
@@ -290,16 +366,7 @@
                     <th>Model</th>
                     <th class="col-price">$/Second (In)</th>
                     <th class="col-price">$/Second (Out)</th>
-                    <th class="model-actions-header">
-                        <button type="button" class="table-action-btn table-icon-btn"
-                            x-show="modelOverridesAvailable"
-                            :class="modelOverrideEditButtonClass(hasGlobalModelOverride())"
-                            :aria-label="modelOverrideEditButtonLabel('global model access', hasGlobalModelOverride())"
-                            :title="modelOverrideEditButtonLabel('global model access', hasGlobalModelOverride())"
-                            @click="openGlobalModelOverrideEdit()">
-                            {{template "edit-icon"}}
-                        </button>
-                    </th>
+                    <th class="model-actions-header">{{template "model-global-action-buttons" .}}</th>
                 </tr>
             </thead>
             {{template "model-table-body" .}}
@@ -316,16 +383,7 @@
                     <th>Model</th>
                     <th class="col-price">$/Page</th>
                     <th class="col-price">$/Request</th>
-                    <th class="model-actions-header">
-                        <button type="button" class="table-action-btn table-icon-btn"
-                            x-show="modelOverridesAvailable"
-                            :class="modelOverrideEditButtonClass(hasGlobalModelOverride())"
-                            :aria-label="modelOverrideEditButtonLabel('global model access', hasGlobalModelOverride())"
-                            :title="modelOverrideEditButtonLabel('global model access', hasGlobalModelOverride())"
-                            @click="openGlobalModelOverrideEdit()">
-                            {{template "edit-icon"}}
-                        </button>
-                    </th>
+                    <th class="model-actions-header">{{template "model-global-action-buttons" .}}</th>
                 </tr>
             </thead>
             {{template "model-table-body" .}}
@@ -338,4 +396,25 @@
     <p class="empty-state" x-show="displayModels.length > 0 && filteredDisplayModels.length === 0 && modelFilter">No models match your filter.</p>
 </div>
 </template>
+{{end}}
+
+{{define "model-global-action-buttons"}}
+<div class="alias-actions-cell model-list-actions">
+    <button type="button" class="table-action-btn table-icon-btn"
+        x-show="modelPricingOverridesAvailable"
+        :class="modelPricingButtonClass(hasGlobalPricingOverride())"
+        :aria-label="modelPricingButtonLabel('global model pricing', hasGlobalPricingOverride())"
+        :title="modelPricingButtonLabel('global model pricing', hasGlobalPricingOverride())"
+        @click="openGlobalPricingOverrideEdit()">
+        {{template "dollar-icon"}}
+    </button>
+    <button type="button" class="table-action-btn table-icon-btn"
+        x-show="modelOverridesAvailable"
+        :class="modelOverrideEditButtonClass(hasGlobalModelOverride())"
+        :aria-label="modelOverrideEditButtonLabel('global model access', hasGlobalModelOverride())"
+        :title="modelOverrideEditButtonLabel('global model access', hasGlobalModelOverride())"
+        @click="openGlobalModelOverrideEdit()">
+        {{template "edit-icon"}}
+    </button>
+</div>
 {{end}}

--- a/internal/admin/dashboard/templates/page-models.html
+++ b/internal/admin/dashboard/templates/page-models.html
@@ -226,16 +226,16 @@
                     <template x-for="row in modelPricingOverrideRows" :key="row.id">
                         <div class="pricing-override-row">
                             <div class="form-field pricing-override-type-field">
-                                <label class="form-field-label">Price Type</label>
-                                <select class="form-select" x-model="row.field" data-modal-autofocus>
+                                <label class="form-field-label" :for="'pricing-type-' + row.id">Price Type</label>
+                                <select :id="'pricing-type-' + row.id" class="form-select" x-model="row.field" data-modal-autofocus>
                                     <template x-for="option in availablePricingFieldOptions(row)" :key="option.value">
                                         <option :value="option.value" x-text="option.group + ' - ' + option.label"></option>
                                     </template>
                                 </select>
                             </div>
                             <div class="form-field pricing-override-value-field">
-                                <label class="form-field-label">USD Value</label>
-                                <input type="number" step="any" min="0" inputmode="decimal" x-model="row.value">
+                                <label class="form-field-label" :for="'pricing-value-' + row.id">USD Value</label>
+                                <input :id="'pricing-value-' + row.id" type="number" step="any" min="0" inputmode="decimal" x-model="row.value">
                             </div>
                             <button type="button"
                                     class="table-action-btn table-action-btn-danger table-icon-btn pricing-override-remove-row"

--- a/internal/admin/dashboard/templates/page-settings.html
+++ b/internal/admin/dashboard/templates/page-settings.html
@@ -24,7 +24,7 @@
         <div class="settings-form-grid">
             <div class="form-field">
                 <label class="form-field-label" for="timezone-override-select">Timezone Override</label>
-                <select id="timezone-override-select" class="usage-log-select settings-select" x-ref="timezoneOverrideSelect" x-model="timezoneOverride" x-effect="timezoneOptions.length; timezoneOverride; $nextTick(() => syncTimezoneOverrideSelectValue())" aria-describedby="timezone-help-copy" @focus="ensureTimezoneOptions()" @change="saveTimezoneOverride()">
+                <select id="timezone-override-select" class="form-select settings-select" x-ref="timezoneOverrideSelect" x-model="timezoneOverride" x-effect="timezoneOptions.length; timezoneOverride; $nextTick(() => syncTimezoneOverrideSelectValue())" aria-describedby="timezone-help-copy" @focus="ensureTimezoneOptions()" @change="saveTimezoneOverride()">
                     <option value="" :selected="!timezoneOverride" x-text="'Automatic (' + detectedTimeZoneLabel() + ')'"></option>
                     <template x-for="timeZone in timezoneOptions" :key="timeZone.value">
                         <option :value="timeZone.value" :selected="timeZone.value === timezoneOverride" x-text="timeZone.label"></option>
@@ -72,7 +72,7 @@
                     <div class="budget-settings-period">Weekly</div>
                     <div class="form-field">
                         <label class="form-field-label" for="budget-weekly-day">Day of Week</label>
-                        <select id="budget-weekly-day" class="usage-log-select settings-select" x-model.number="budgetSettings.weekly_reset_weekday">
+                        <select id="budget-weekly-day" class="form-select settings-select" x-model.number="budgetSettings.weekly_reset_weekday">
                             <template x-for="day in budgetWeekdays()" :key="day.value">
                                 <option :value="day.value" x-text="day.label"></option>
                             </template>

--- a/internal/admin/dashboard/templates/page-workflows.html
+++ b/internal/admin/dashboard/templates/page-workflows.html
@@ -67,7 +67,7 @@
                 <div class="form-grid">
                     <div class="form-field">
                         <label class="form-field-label" for="workflow-scope-provider">Provider Name</label>
-                        <select id="workflow-scope-provider" class="usage-log-select workflow-input" x-model="workflowForm.scope_provider" @change="setWorkflowProvider(workflowForm.scope_provider)" data-modal-autofocus>
+                        <select id="workflow-scope-provider" class="form-select workflow-input" x-model="workflowForm.scope_provider" @change="setWorkflowProvider(workflowForm.scope_provider)" data-modal-autofocus>
                             <option value="">All providers and models</option>
                             <template x-for="providerName in workflowProviderOptions()" :key="providerName">
                                 <option :value="providerName" x-text="providerName"></option>
@@ -77,7 +77,7 @@
 
                     <div class="form-field" x-show="workflowForm.scope_provider">
                         <label class="form-field-label" for="workflow-scope-model">Model</label>
-                        <select id="workflow-scope-model" class="usage-log-select workflow-input" x-model="workflowForm.scope_model">
+                        <select id="workflow-scope-model" class="form-select workflow-input" x-model="workflowForm.scope_model">
                             <option value="">All models for provider</option>
                             <template x-for="modelID in workflowModelOptions(workflowForm.scope_provider)" :key="workflowForm.scope_provider + '-' + modelID">
                                 <option :value="modelID" x-text="modelID"></option>

--- a/internal/admin/errors.go
+++ b/internal/admin/errors.go
@@ -15,6 +15,7 @@ import (
 	"gomodel/internal/core"
 	"gomodel/internal/guardrails"
 	"gomodel/internal/modeloverrides"
+	"gomodel/internal/pricingoverrides"
 	"gomodel/internal/workflows"
 )
 
@@ -59,6 +60,16 @@ func modelOverrideWriteError(err error) error {
 		return core.NewInvalidRequestError(err.Error(), err)
 	}
 	return core.NewProviderError("model_overrides", http.StatusBadGateway, err.Error(), err)
+}
+
+func pricingOverrideWriteError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if pricingoverrides.IsValidationError(err) {
+		return core.NewInvalidRequestError(err.Error(), err)
+	}
+	return core.NewProviderError("model_pricing_overrides", http.StatusBadGateway, err.Error(), err)
 }
 
 func deactivateByID(
@@ -136,6 +147,25 @@ func decodeModelOverridePathSelector(raw string) (string, error) {
 	selector = strings.TrimSpace(selector)
 	if selector == "" {
 		return "", core.NewInvalidRequestError("model override selector is required", nil)
+	}
+	return selector, nil
+}
+
+// modelPricingOverrideSelectorMaxLen caps decoded selectors to a sane size; provider
+// IDs and model IDs are short identifiers, never essays.
+const modelPricingOverrideSelectorMaxLen = 256
+
+func decodeModelPricingOverridePathSelector(raw string) (string, error) {
+	selector, err := url.PathUnescape(strings.TrimSpace(raw))
+	if err != nil {
+		return "", core.NewInvalidRequestError("invalid model pricing override selector", err)
+	}
+	selector = strings.TrimSpace(selector)
+	if selector == "" {
+		return "", core.NewInvalidRequestError("model pricing override selector is required", nil)
+	}
+	if len(selector) > modelPricingOverrideSelectorMaxLen {
+		return "", core.NewInvalidRequestError("model pricing override selector is too long", nil)
 	}
 	return selector, nil
 }

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -20,6 +20,7 @@ import (
 	"gomodel/internal/core"
 	"gomodel/internal/guardrails"
 	"gomodel/internal/modeloverrides"
+	"gomodel/internal/pricingoverrides"
 	"gomodel/internal/providers"
 	"gomodel/internal/usage"
 	"gomodel/internal/workflows"
@@ -31,9 +32,11 @@ type Handler struct {
 	usageRecalculator   usage.PricingRecalculator
 	auditReader         auditlog.Reader
 	registry            *providers.ModelRegistry
+	pricingResolver     usage.PricingResolver
 	authKeys            *authkeys.Service
 	aliases             *aliases.Service
 	modelOverrides      *modeloverrides.Service
+	pricingOverrides    *pricingoverrides.Service
 	workflows           *workflows.Service
 	budgets             *budget.Service
 	guardrails          guardrails.Catalog
@@ -159,6 +162,13 @@ func WithUsagePricingRecalculator(recalculator usage.PricingRecalculator) Option
 	}
 }
 
+// WithPricingResolver sets the resolver used for usage pricing recalculation.
+func WithPricingResolver(resolver usage.PricingResolver) Option {
+	return func(h *Handler) {
+		h.pricingResolver = resolver
+	}
+}
+
 // WithAliases enables alias administration endpoints.
 func WithAliases(service *aliases.Service) Option {
 	return func(h *Handler) {
@@ -177,6 +187,13 @@ func WithAuthKeys(service *authkeys.Service) Option {
 func WithModelOverrides(service *modeloverrides.Service) Option {
 	return func(h *Handler) {
 		h.modelOverrides = service
+	}
+}
+
+// WithPricingOverrides enables model pricing override administration endpoints.
+func WithPricingOverrides(service *pricingoverrides.Service) Option {
+	return func(h *Handler) {
+		h.pricingOverrides = service
 	}
 }
 
@@ -234,9 +251,10 @@ func WithConfiguredProviders(configs []providers.SanitizedProviderConfig) Option
 // usageReader may be nil if usage tracking is not available.
 func NewHandler(reader usage.UsageReader, registry *providers.ModelRegistry, options ...Option) *Handler {
 	h := &Handler{
-		usageReader:   reader,
-		registry:      registry,
-		runtimeConfig: DashboardConfigResponse{},
+		usageReader:     reader,
+		registry:        registry,
+		pricingResolver: registry,
+		runtimeConfig:   DashboardConfigResponse{},
 	}
 
 	for _, opt := range options {

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -251,10 +251,12 @@ func WithConfiguredProviders(configs []providers.SanitizedProviderConfig) Option
 // usageReader may be nil if usage tracking is not available.
 func NewHandler(reader usage.UsageReader, registry *providers.ModelRegistry, options ...Option) *Handler {
 	h := &Handler{
-		usageReader:     reader,
-		registry:        registry,
-		pricingResolver: registry,
-		runtimeConfig:   DashboardConfigResponse{},
+		usageReader:   reader,
+		registry:      registry,
+		runtimeConfig: DashboardConfigResponse{},
+	}
+	if registry != nil {
+		h.pricingResolver = registry
 	}
 
 	for _, opt := range options {

--- a/internal/admin/handler_model_overrides.go
+++ b/internal/admin/handler_model_overrides.go
@@ -51,6 +51,7 @@ func (h *Handler) ListModelOverrides(c *echo.Context) error {
 // @Failure      400       {object}  core.GatewayError
 // @Failure      401       {object}  core.GatewayError
 // @Failure      500       {object}  core.GatewayError
+// @Failure      502       {object}  core.GatewayError
 // @Failure      503       {object}  core.GatewayError
 // @Router       /admin/api/v1/model-overrides/{selector} [put]
 //
@@ -99,6 +100,7 @@ func (h *Handler) UpsertModelOverride(c *echo.Context) error {
 // @Failure      400       {object}  core.GatewayError
 // @Failure      401       {object}  core.GatewayError
 // @Failure      404       {object}  core.GatewayError
+// @Failure      502       {object}  core.GatewayError
 // @Failure      503       {object}  core.GatewayError
 // @Router       /admin/api/v1/model-overrides/{selector} [delete]
 func (h *Handler) DeleteModelOverride(c *echo.Context) error {

--- a/internal/admin/handler_model_overrides.go
+++ b/internal/admin/handler_model_overrides.go
@@ -19,6 +19,7 @@ type upsertModelOverrideRequest struct {
 //
 // @Summary      List model access overrides
 // @Description  Lists persisted model access overrides by global, provider-wide, model-wide, or exact selector.
+// @Description  Selectors support global "/", provider-wide "provider/", model-wide "model", and exact "provider/model" scopes.
 // @Tags         admin
 // @Produce      json
 // @Security     BearerAuth
@@ -46,7 +47,7 @@ func (h *Handler) ListModelOverrides(c *echo.Context) error {
 // @Security     BearerAuth
 // @Param        selector  path      string                      true  "URL-encoded model selector such as /, openai/, gpt-4o-mini, or openai/gpt-4o-mini"
 // @Param        override  body      upsertModelOverrideRequest  true  "Allowed user paths"
-// @Success      200       {object}  modeloverrides.Override
+// @Success      200       {object}  modeloverrides.View
 // @Failure      400       {object}  core.GatewayError
 // @Failure      401       {object}  core.GatewayError
 // @Failure      500       {object}  core.GatewayError
@@ -81,7 +82,10 @@ func (h *Handler) UpsertModelOverride(c *echo.Context) error {
 		slog.Error("model override service returned no override after upsert", "selector", selector)
 		return handleError(c, core.NewProviderError("model_overrides", http.StatusInternalServerError, "model override update failed unexpectedly", nil))
 	}
-	return c.JSON(http.StatusOK, override)
+	return c.JSON(http.StatusOK, modeloverrides.View{
+		Override:  *override,
+		ScopeKind: override.ScopeKind(),
+	})
 }
 
 // DeleteModelOverride handles DELETE /admin/api/v1/model-overrides/{selector}.

--- a/internal/admin/handler_model_overrides.go
+++ b/internal/admin/handler_model_overrides.go
@@ -15,6 +15,17 @@ type upsertModelOverrideRequest struct {
 	UserPaths []string `json:"user_paths,omitempty"`
 }
 
+// ListModelOverrides handles GET /admin/api/v1/model-overrides.
+//
+// @Summary      List model access overrides
+// @Description  Lists persisted model access overrides by global, provider-wide, model-wide, or exact selector.
+// @Tags         admin
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200  {array}   modeloverrides.View
+// @Failure      401  {object}  core.GatewayError
+// @Failure      503  {object}  core.GatewayError
+// @Router       /admin/api/v1/model-overrides [get]
 func (h *Handler) ListModelOverrides(c *echo.Context) error {
 	if h.modelOverrides == nil {
 		return handleError(c, featureUnavailableError("model overrides feature is unavailable"))
@@ -27,6 +38,22 @@ func (h *Handler) ListModelOverrides(c *echo.Context) error {
 }
 
 // UpsertModelOverride handles PUT /admin/api/v1/model-overrides/{selector}.
+//
+// @Summary      Create or update one model access override
+// @Tags         admin
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        selector  path      string                      true  "URL-encoded model selector such as /, openai/, gpt-4o-mini, or openai/gpt-4o-mini"
+// @Param        override  body      upsertModelOverrideRequest  true  "Allowed user paths"
+// @Success      200       {object}  modeloverrides.Override
+// @Failure      400       {object}  core.GatewayError
+// @Failure      401       {object}  core.GatewayError
+// @Failure      500       {object}  core.GatewayError
+// @Failure      503       {object}  core.GatewayError
+// @Router       /admin/api/v1/model-overrides/{selector} [put]
+//
+//nolint:dupl // structurally similar to UpsertModelPricingOverride but operates on different types and stores.
 func (h *Handler) UpsertModelOverride(c *echo.Context) error {
 	if h.modelOverrides == nil {
 		return handleError(c, featureUnavailableError("model overrides feature is unavailable"))
@@ -58,6 +85,18 @@ func (h *Handler) UpsertModelOverride(c *echo.Context) error {
 }
 
 // DeleteModelOverride handles DELETE /admin/api/v1/model-overrides/{selector}.
+//
+// @Summary      Delete one model access override
+// @Tags         admin
+// @Produce      json
+// @Security     BearerAuth
+// @Param        selector  path  string  true  "URL-encoded model selector"
+// @Success      204       "No Content"
+// @Failure      400       {object}  core.GatewayError
+// @Failure      401       {object}  core.GatewayError
+// @Failure      404       {object}  core.GatewayError
+// @Failure      503       {object}  core.GatewayError
+// @Router       /admin/api/v1/model-overrides/{selector} [delete]
 func (h *Handler) DeleteModelOverride(c *echo.Context) error {
 	var unavailableErr error
 	var deleteFunc func(context.Context, string) error

--- a/internal/admin/handler_model_overrides_test.go
+++ b/internal/admin/handler_model_overrides_test.go
@@ -13,6 +13,7 @@ import (
 
 	"gomodel/internal/core"
 	"gomodel/internal/modeloverrides"
+	"gomodel/internal/modelselectors"
 	"gomodel/internal/providers"
 )
 
@@ -290,12 +291,15 @@ func TestUpsertAndDeleteModelOverride(t *testing.T) {
 		t.Fatalf("put status = %d, want 200", putRec.Code)
 	}
 
-	var body modeloverrides.Override
+	var body modeloverrides.View
 	if err := json.Unmarshal(putRec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("decode upsert response: %v", err)
 	}
 	if body.Selector != "openai/gpt-4o" {
 		t.Fatalf("body.Selector = %q, want openai/gpt-4o", body.Selector)
+	}
+	if body.ScopeKind != modelselectors.ScopeProviderModel {
+		t.Fatalf("body.ScopeKind = %q, want %q", body.ScopeKind, modelselectors.ScopeProviderModel)
 	}
 	if len(body.UserPaths) != 1 || body.UserPaths[0] != "/team/alpha" {
 		t.Fatalf("body.UserPaths = %#v, want [/team/alpha]", body.UserPaths)

--- a/internal/admin/handler_model_pricing_overrides.go
+++ b/internal/admin/handler_model_pricing_overrides.go
@@ -12,7 +12,7 @@ import (
 )
 
 type upsertModelPricingOverrideRequest struct {
-	Pricing pricingoverrides.Pricing `json:"pricing"`
+	Pricing pricingoverrides.Pricing `json:"pricing" binding:"required"`
 }
 
 // ListModelPricingOverrides handles GET /admin/api/v1/model-pricing-overrides.

--- a/internal/admin/handler_model_pricing_overrides.go
+++ b/internal/admin/handler_model_pricing_overrides.go
@@ -1,0 +1,119 @@
+package admin
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+
+	"github.com/labstack/echo/v5"
+
+	"gomodel/internal/core"
+	"gomodel/internal/pricingoverrides"
+)
+
+type upsertModelPricingOverrideRequest struct {
+	Pricing pricingoverrides.Pricing `json:"pricing"`
+}
+
+// ListModelPricingOverrides handles GET /admin/api/v1/model-pricing-overrides.
+//
+// @Summary      List model pricing overrides
+// @Description  Lists persisted USD pricing overrides. Selectors support global "/", provider-wide "provider/", model-wide "model", and exact "provider/model" scopes.
+// @Tags         admin
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200  {array}   pricingoverrides.View
+// @Failure      401  {object}  core.GatewayError
+// @Failure      503  {object}  core.GatewayError
+// @Router       /admin/api/v1/model-pricing-overrides [get]
+func (h *Handler) ListModelPricingOverrides(c *echo.Context) error {
+	if h.pricingOverrides == nil {
+		return handleError(c, featureUnavailableError("model pricing overrides feature is unavailable"))
+	}
+	views := h.pricingOverrides.ListViews()
+	if views == nil {
+		views = []pricingoverrides.View{}
+	}
+	return c.JSON(http.StatusOK, views)
+}
+
+// UpsertModelPricingOverride handles PUT /admin/api/v1/model-pricing-overrides/{selector}.
+//
+// @Summary      Create or update one model pricing override
+// @Description  Stores USD-only pricing for one selector. More precise selectors override broader selectors at runtime.
+// @Tags         admin
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        selector  path      string                              true  "URL-encoded pricing selector such as /, openai/, gpt-4o-mini, or openai/gpt-4o-mini"
+// @Param        override  body      upsertModelPricingOverrideRequest  true  "Pricing override"
+// @Success      200       {object}  pricingoverrides.View
+// @Failure      400       {object}  core.GatewayError
+// @Failure      401       {object}  core.GatewayError
+// @Failure      500       {object}  core.GatewayError
+// @Failure      503       {object}  core.GatewayError
+// @Router       /admin/api/v1/model-pricing-overrides/{selector} [put]
+//
+//nolint:dupl // structurally similar to UpsertModelOverride but operates on different types and stores.
+func (h *Handler) UpsertModelPricingOverride(c *echo.Context) error {
+	if h.pricingOverrides == nil {
+		return handleError(c, featureUnavailableError("model pricing overrides feature is unavailable"))
+	}
+
+	selector, err := decodeModelPricingOverridePathSelector(c.Param("selector"))
+	if err != nil {
+		return handleError(c, err)
+	}
+
+	var req upsertModelPricingOverrideRequest
+	if err := c.Bind(&req); err != nil {
+		return handleError(c, core.NewInvalidRequestError("invalid request body: "+err.Error(), err))
+	}
+
+	if err := h.pricingOverrides.Upsert(c.Request().Context(), pricingoverrides.Override{
+		Selector: selector,
+		Pricing:  req.Pricing,
+	}); err != nil {
+		return handleError(c, pricingOverrideWriteError(err))
+	}
+
+	view, ok := h.pricingOverrides.GetView(selector)
+	if !ok || view == nil {
+		slog.Error("model pricing override service returned no override after upsert", "selector", selector)
+		return handleError(c, core.NewProviderError("model_pricing_overrides", http.StatusInternalServerError, "model pricing override update failed unexpectedly", nil))
+	}
+	return c.JSON(http.StatusOK, view)
+}
+
+// DeleteModelPricingOverride handles DELETE /admin/api/v1/model-pricing-overrides/{selector}.
+//
+// @Summary      Delete one model pricing override
+// @Tags         admin
+// @Produce      json
+// @Security     BearerAuth
+// @Param        selector  path  string  true  "URL-encoded pricing selector"
+// @Success      204       "No Content"
+// @Failure      400       {object}  core.GatewayError
+// @Failure      401       {object}  core.GatewayError
+// @Failure      404       {object}  core.GatewayError
+// @Failure      503       {object}  core.GatewayError
+// @Router       /admin/api/v1/model-pricing-overrides/{selector} [delete]
+func (h *Handler) DeleteModelPricingOverride(c *echo.Context) error {
+	var unavailableErr error
+	var deleteFunc func(context.Context, string) error
+	if h.pricingOverrides == nil {
+		unavailableErr = featureUnavailableError("model pricing overrides feature is unavailable")
+	} else {
+		deleteFunc = h.pricingOverrides.Delete
+	}
+	return deleteByName(
+		c,
+		unavailableErr,
+		"selector",
+		decodeModelPricingOverridePathSelector,
+		deleteFunc,
+		pricingoverrides.ErrNotFound,
+		"model pricing override not found: ",
+		pricingOverrideWriteError,
+	)
+}

--- a/internal/admin/handler_model_pricing_overrides_test.go
+++ b/internal/admin/handler_model_pricing_overrides_test.go
@@ -1,0 +1,134 @@
+package admin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+
+	"gomodel/internal/pricingoverrides"
+)
+
+type modelPricingOverrideTestStore struct {
+	items map[string]pricingoverrides.Override
+}
+
+func newModelPricingOverrideTestStore(items ...pricingoverrides.Override) *modelPricingOverrideTestStore {
+	store := &modelPricingOverrideTestStore{items: make(map[string]pricingoverrides.Override, len(items))}
+	for _, item := range items {
+		store.items[item.Selector] = item
+	}
+	return store
+}
+
+func (s *modelPricingOverrideTestStore) List(_ context.Context) ([]pricingoverrides.Override, error) {
+	result := make([]pricingoverrides.Override, 0, len(s.items))
+	for _, item := range s.items {
+		result = append(result, item)
+	}
+	return result, nil
+}
+
+func (s *modelPricingOverrideTestStore) Upsert(_ context.Context, override pricingoverrides.Override) error {
+	s.items[override.Selector] = override
+	return nil
+}
+
+func (s *modelPricingOverrideTestStore) Delete(_ context.Context, selector string) error {
+	if _, ok := s.items[selector]; !ok {
+		return pricingoverrides.ErrNotFound
+	}
+	delete(s.items, selector)
+	return nil
+}
+
+func (s *modelPricingOverrideTestStore) Close() error { return nil }
+
+func newModelPricingOverrideService(t *testing.T, store pricingoverrides.Store) *pricingoverrides.Service {
+	t.Helper()
+	service, err := pricingoverrides.NewService(store, newModelOverrideRegistry(t), nil)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+	return service
+}
+
+func TestModelPricingOverrideLifecycle(t *testing.T) {
+	service := newModelPricingOverrideService(t, newModelPricingOverrideTestStore())
+	h := NewHandler(nil, nil, WithPricingOverrides(service))
+	e := echo.New()
+
+	putReq := httptest.NewRequest(http.MethodPut, "/admin/api/v1/model-pricing-overrides/openai%2Fgpt-4o", bytes.NewBufferString(`{"pricing":{"input_per_mtok":1.25}}`))
+	putReq.Header.Set("Content-Type", "application/json")
+	putRec := httptest.NewRecorder()
+	putCtx := e.NewContext(putReq, putRec)
+	putCtx.SetPathValues(echo.PathValues{{Name: "selector", Value: "openai/gpt-4o"}})
+
+	if err := h.UpsertModelPricingOverride(putCtx); err != nil {
+		t.Fatalf("UpsertModelPricingOverride() error = %v", err)
+	}
+	if putRec.Code != http.StatusOK {
+		t.Fatalf("put status = %d, want 200 body=%s", putRec.Code, putRec.Body.String())
+	}
+
+	var body pricingoverrides.View
+	if err := json.Unmarshal(putRec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode upsert response: %v", err)
+	}
+	if body.Selector != "openai/gpt-4o" || body.ProviderName != "openai" || body.Model != "gpt-4o" {
+		t.Fatalf("body selector parts = (%q, %q, %q), want openai/gpt-4o parts", body.Selector, body.ProviderName, body.Model)
+	}
+	if body.ScopeKind != pricingoverrides.ScopeProviderModel {
+		t.Fatalf("ScopeKind = %q, want %q", body.ScopeKind, pricingoverrides.ScopeProviderModel)
+	}
+	if body.Pricing.InputPerMtok == nil || *body.Pricing.InputPerMtok != 1.25 {
+		t.Fatalf("InputPerMtok = %#v, want 1.25", body.Pricing.InputPerMtok)
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/admin/api/v1/model-pricing-overrides", nil)
+	listRec := httptest.NewRecorder()
+	listCtx := e.NewContext(listReq, listRec)
+	if err := h.ListModelPricingOverrides(listCtx); err != nil {
+		t.Fatalf("ListModelPricingOverrides() error = %v", err)
+	}
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("list status = %d, want 200", listRec.Code)
+	}
+
+	deleteReq := httptest.NewRequest(http.MethodDelete, "/admin/api/v1/model-pricing-overrides/openai%2Fgpt-4o", nil)
+	deleteRec := httptest.NewRecorder()
+	deleteCtx := e.NewContext(deleteReq, deleteRec)
+	deleteCtx.SetPathValues(echo.PathValues{{Name: "selector", Value: "openai/gpt-4o"}})
+	if err := h.DeleteModelPricingOverride(deleteCtx); err != nil {
+		t.Fatalf("DeleteModelPricingOverride() error = %v", err)
+	}
+	if deleteRec.Code != http.StatusNoContent {
+		t.Fatalf("delete status = %d, want 204", deleteRec.Code)
+	}
+}
+
+func TestUpsertModelPricingOverrideReturnsBadRequestForValidationErrors(t *testing.T) {
+	service := newModelPricingOverrideService(t, newModelPricingOverrideTestStore())
+	h := NewHandler(nil, nil, WithPricingOverrides(service))
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodPut, "/admin/api/v1/model-pricing-overrides/openai%2Fgpt-4o", bytes.NewBufferString(`{"pricing":{}}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPathValues(echo.PathValues{{Name: "selector", Value: "openai/gpt-4o"}})
+
+	if err := h.UpsertModelPricingOverride(c); err != nil {
+		t.Fatalf("UpsertModelPricingOverride() error = %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}

--- a/internal/admin/handler_model_pricing_overrides_test.go
+++ b/internal/admin/handler_model_pricing_overrides_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/labstack/echo/v5"
@@ -49,9 +50,20 @@ func (s *modelPricingOverrideTestStore) Delete(_ context.Context, selector strin
 
 func (s *modelPricingOverrideTestStore) Close() error { return nil }
 
-func newModelPricingOverrideService(t *testing.T, store pricingoverrides.Store) *pricingoverrides.Service {
+type modelPricingOverrideTestCatalog struct {
+	providerNames []string
+}
+
+func (c modelPricingOverrideTestCatalog) ProviderNames() []string {
+	return append([]string(nil), c.providerNames...)
+}
+
+func newModelPricingOverrideService(t *testing.T, store pricingoverrides.Store, providerNames ...string) *pricingoverrides.Service {
 	t.Helper()
-	service, err := pricingoverrides.NewService(store, newModelOverrideRegistry(t), nil)
+	if len(providerNames) == 0 {
+		providerNames = []string{"openai"}
+	}
+	service, err := pricingoverrides.NewService(store, modelPricingOverrideTestCatalog{providerNames: providerNames}, nil)
 	if err != nil {
 		t.Fatalf("NewService() error = %v", err)
 	}
@@ -62,69 +74,106 @@ func newModelPricingOverrideService(t *testing.T, store pricingoverrides.Store) 
 }
 
 func TestModelPricingOverrideLifecycle(t *testing.T) {
-	service := newModelPricingOverrideService(t, newModelPricingOverrideTestStore())
-	h := NewHandler(nil, nil, WithPricingOverrides(service))
-	e := echo.New()
-
-	putReq := httptest.NewRequest(http.MethodPut, "/admin/api/v1/model-pricing-overrides/openai%2Fgpt-4o", bytes.NewBufferString(`{"pricing":{"input_per_mtok":1.25}}`))
-	putReq.Header.Set("Content-Type", "application/json")
-	putRec := httptest.NewRecorder()
-	putCtx := e.NewContext(putReq, putRec)
-	putCtx.SetPathValues(echo.PathValues{{Name: "selector", Value: "openai/gpt-4o"}})
-
-	if err := h.UpsertModelPricingOverride(putCtx); err != nil {
-		t.Fatalf("UpsertModelPricingOverride() error = %v", err)
-	}
-	if putRec.Code != http.StatusOK {
-		t.Fatalf("put status = %d, want 200 body=%s", putRec.Code, putRec.Body.String())
-	}
-
-	var body pricingoverrides.View
-	if err := json.Unmarshal(putRec.Body.Bytes(), &body); err != nil {
-		t.Fatalf("decode upsert response: %v", err)
-	}
-	if body.Selector != "openai/gpt-4o" || body.ProviderName != "openai" || body.Model != "gpt-4o" {
-		t.Fatalf("body selector parts = (%q, %q, %q), want openai/gpt-4o parts", body.Selector, body.ProviderName, body.Model)
-	}
-	if body.ScopeKind != modelselectors.ScopeProviderModel {
-		t.Fatalf("ScopeKind = %q, want %q", body.ScopeKind, modelselectors.ScopeProviderModel)
-	}
-	if body.Pricing.InputPerMtok == nil || *body.Pricing.InputPerMtok != 1.25 {
-		t.Fatalf("InputPerMtok = %#v, want 1.25", body.Pricing.InputPerMtok)
-	}
-
-	listReq := httptest.NewRequest(http.MethodGet, "/admin/api/v1/model-pricing-overrides", nil)
-	listRec := httptest.NewRecorder()
-	listCtx := e.NewContext(listReq, listRec)
-	if err := h.ListModelPricingOverrides(listCtx); err != nil {
-		t.Fatalf("ListModelPricingOverrides() error = %v", err)
-	}
-	if listRec.Code != http.StatusOK {
-		t.Fatalf("list status = %d, want 200", listRec.Code)
-	}
-	var listBody []pricingoverrides.View
-	if err := json.Unmarshal(listRec.Body.Bytes(), &listBody); err != nil {
-		t.Fatalf("decode list response: %v", err)
-	}
-	if len(listBody) != 1 {
-		t.Fatalf("list length = %d, want 1: %+v", len(listBody), listBody)
-	}
-	if listBody[0].Selector != "openai/gpt-4o" || listBody[0].ProviderName != "openai" || listBody[0].Model != "gpt-4o" {
-		t.Fatalf("list[0] selector parts = (%q, %q, %q), want openai/gpt-4o parts", listBody[0].Selector, listBody[0].ProviderName, listBody[0].Model)
-	}
-	if listBody[0].Pricing.InputPerMtok == nil || *listBody[0].Pricing.InputPerMtok != 1.25 {
-		t.Fatalf("list[0].InputPerMtok = %#v, want 1.25", listBody[0].Pricing.InputPerMtok)
+	tests := []struct {
+		name         string
+		providers    []string
+		selector     string
+		encodedPath  string
+		price        float64
+		wantProvider string
+		wantModel    string
+		wantScope    modelselectors.ScopeKind
+	}{
+		{
+			name:         "simple provider model selector",
+			providers:    []string{"openai"},
+			selector:     "openai/gpt-4o",
+			encodedPath:  "openai%2Fgpt-4o",
+			price:        1.25,
+			wantProvider: "openai",
+			wantModel:    "gpt-4o",
+			wantScope:    modelselectors.ScopeProviderModel,
+		},
+		{
+			name:         "provider model selector with slash-shaped model id",
+			providers:    []string{"openrouter"},
+			selector:     "openrouter/meta-llama/llama-3.1-8b-instruct",
+			encodedPath:  "openrouter%2Fmeta-llama%2Fllama-3.1-8b-instruct",
+			price:        0.18,
+			wantProvider: "openrouter",
+			wantModel:    "meta-llama/llama-3.1-8b-instruct",
+			wantScope:    modelselectors.ScopeProviderModel,
+		},
 	}
 
-	deleteReq := httptest.NewRequest(http.MethodDelete, "/admin/api/v1/model-pricing-overrides/openai%2Fgpt-4o", nil)
-	deleteRec := httptest.NewRecorder()
-	deleteCtx := e.NewContext(deleteReq, deleteRec)
-	deleteCtx.SetPathValues(echo.PathValues{{Name: "selector", Value: "openai/gpt-4o"}})
-	if err := h.DeleteModelPricingOverride(deleteCtx); err != nil {
-		t.Fatalf("DeleteModelPricingOverride() error = %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := newModelPricingOverrideService(t, newModelPricingOverrideTestStore(), tt.providers...)
+			h := NewHandler(nil, nil, WithPricingOverrides(service))
+			e := echo.New()
+
+			bodyJSON := `{"pricing":{"input_per_mtok":` + strconv.FormatFloat(tt.price, 'f', -1, 64) + `}}`
+			putReq := httptest.NewRequest(http.MethodPut, "/admin/api/v1/model-pricing-overrides/"+tt.encodedPath, bytes.NewBufferString(bodyJSON))
+			putReq.Header.Set("Content-Type", "application/json")
+			putRec := httptest.NewRecorder()
+			putCtx := e.NewContext(putReq, putRec)
+			putCtx.SetPathValues(echo.PathValues{{Name: "selector", Value: tt.selector}})
+
+			if err := h.UpsertModelPricingOverride(putCtx); err != nil {
+				t.Fatalf("UpsertModelPricingOverride() error = %v", err)
+			}
+			if putRec.Code != http.StatusOK {
+				t.Fatalf("put status = %d, want 200 body=%s", putRec.Code, putRec.Body.String())
+			}
+
+			var body pricingoverrides.View
+			if err := json.Unmarshal(putRec.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode upsert response: %v", err)
+			}
+			assertPricingOverrideView(t, body, tt.selector, tt.wantProvider, tt.wantModel, tt.wantScope, tt.price)
+
+			listReq := httptest.NewRequest(http.MethodGet, "/admin/api/v1/model-pricing-overrides", nil)
+			listRec := httptest.NewRecorder()
+			listCtx := e.NewContext(listReq, listRec)
+			if err := h.ListModelPricingOverrides(listCtx); err != nil {
+				t.Fatalf("ListModelPricingOverrides() error = %v", err)
+			}
+			if listRec.Code != http.StatusOK {
+				t.Fatalf("list status = %d, want 200", listRec.Code)
+			}
+			var listBody []pricingoverrides.View
+			if err := json.Unmarshal(listRec.Body.Bytes(), &listBody); err != nil {
+				t.Fatalf("decode list response: %v", err)
+			}
+			if len(listBody) != 1 {
+				t.Fatalf("list length = %d, want 1: %+v", len(listBody), listBody)
+			}
+			assertPricingOverrideView(t, listBody[0], tt.selector, tt.wantProvider, tt.wantModel, tt.wantScope, tt.price)
+
+			deleteReq := httptest.NewRequest(http.MethodDelete, "/admin/api/v1/model-pricing-overrides/"+tt.encodedPath, nil)
+			deleteRec := httptest.NewRecorder()
+			deleteCtx := e.NewContext(deleteReq, deleteRec)
+			deleteCtx.SetPathValues(echo.PathValues{{Name: "selector", Value: tt.selector}})
+			if err := h.DeleteModelPricingOverride(deleteCtx); err != nil {
+				t.Fatalf("DeleteModelPricingOverride() error = %v", err)
+			}
+			if deleteRec.Code != http.StatusNoContent {
+				t.Fatalf("delete status = %d, want 204", deleteRec.Code)
+			}
+		})
 	}
-	if deleteRec.Code != http.StatusNoContent {
-		t.Fatalf("delete status = %d, want 204", deleteRec.Code)
+}
+
+func assertPricingOverrideView(t *testing.T, view pricingoverrides.View, selector, provider, model string, scope modelselectors.ScopeKind, price float64) {
+	t.Helper()
+	if view.Selector != selector || view.ProviderName != provider || view.Model != model {
+		t.Fatalf("selector parts = (%q, %q, %q), want (%q, %q, %q)", view.Selector, view.ProviderName, view.Model, selector, provider, model)
+	}
+	if view.ScopeKind != scope {
+		t.Fatalf("ScopeKind = %q, want %q", view.ScopeKind, scope)
+	}
+	if view.Pricing.InputPerMtok == nil || *view.Pricing.InputPerMtok != price {
+		t.Fatalf("InputPerMtok = %#v, want %v", view.Pricing.InputPerMtok, price)
 	}
 }
 

--- a/internal/admin/handler_model_pricing_overrides_test.go
+++ b/internal/admin/handler_model_pricing_overrides_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/labstack/echo/v5"
 
+	"gomodel/internal/modelselectors"
 	"gomodel/internal/pricingoverrides"
 )
 
@@ -85,8 +86,8 @@ func TestModelPricingOverrideLifecycle(t *testing.T) {
 	if body.Selector != "openai/gpt-4o" || body.ProviderName != "openai" || body.Model != "gpt-4o" {
 		t.Fatalf("body selector parts = (%q, %q, %q), want openai/gpt-4o parts", body.Selector, body.ProviderName, body.Model)
 	}
-	if body.ScopeKind != pricingoverrides.ScopeProviderModel {
-		t.Fatalf("ScopeKind = %q, want %q", body.ScopeKind, pricingoverrides.ScopeProviderModel)
+	if body.ScopeKind != modelselectors.ScopeProviderModel {
+		t.Fatalf("ScopeKind = %q, want %q", body.ScopeKind, modelselectors.ScopeProviderModel)
 	}
 	if body.Pricing.InputPerMtok == nil || *body.Pricing.InputPerMtok != 1.25 {
 		t.Fatalf("InputPerMtok = %#v, want 1.25", body.Pricing.InputPerMtok)
@@ -100,6 +101,19 @@ func TestModelPricingOverrideLifecycle(t *testing.T) {
 	}
 	if listRec.Code != http.StatusOK {
 		t.Fatalf("list status = %d, want 200", listRec.Code)
+	}
+	var listBody []pricingoverrides.View
+	if err := json.Unmarshal(listRec.Body.Bytes(), &listBody); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(listBody) != 1 {
+		t.Fatalf("list length = %d, want 1: %+v", len(listBody), listBody)
+	}
+	if listBody[0].Selector != "openai/gpt-4o" || listBody[0].ProviderName != "openai" || listBody[0].Model != "gpt-4o" {
+		t.Fatalf("list[0] selector parts = (%q, %q, %q), want openai/gpt-4o parts", listBody[0].Selector, listBody[0].ProviderName, listBody[0].Model)
+	}
+	if listBody[0].Pricing.InputPerMtok == nil || *listBody[0].Pricing.InputPerMtok != 1.25 {
+		t.Fatalf("list[0].InputPerMtok = %#v, want 1.25", listBody[0].Pricing.InputPerMtok)
 	}
 
 	deleteReq := httptest.NewRequest(http.MethodDelete, "/admin/api/v1/model-pricing-overrides/openai%2Fgpt-4o", nil)

--- a/internal/admin/handler_model_pricing_overrides_test.go
+++ b/internal/admin/handler_model_pricing_overrides_test.go
@@ -111,17 +111,13 @@ func TestModelPricingOverrideLifecycle(t *testing.T) {
 			service := newModelPricingOverrideService(t, newModelPricingOverrideTestStore(), tt.providers...)
 			h := NewHandler(nil, nil, WithPricingOverrides(service))
 			e := echo.New()
+			h.RegisterRoutes(e.Group("/admin/api/v1"))
 
 			bodyJSON := `{"pricing":{"input_per_mtok":` + strconv.FormatFloat(tt.price, 'f', -1, 64) + `}}`
 			putReq := httptest.NewRequest(http.MethodPut, "/admin/api/v1/model-pricing-overrides/"+tt.encodedPath, bytes.NewBufferString(bodyJSON))
 			putReq.Header.Set("Content-Type", "application/json")
 			putRec := httptest.NewRecorder()
-			putCtx := e.NewContext(putReq, putRec)
-			putCtx.SetPathValues(echo.PathValues{{Name: "selector", Value: tt.selector}})
-
-			if err := h.UpsertModelPricingOverride(putCtx); err != nil {
-				t.Fatalf("UpsertModelPricingOverride() error = %v", err)
-			}
+			e.ServeHTTP(putRec, putReq)
 			if putRec.Code != http.StatusOK {
 				t.Fatalf("put status = %d, want 200 body=%s", putRec.Code, putRec.Body.String())
 			}
@@ -134,10 +130,7 @@ func TestModelPricingOverrideLifecycle(t *testing.T) {
 
 			listReq := httptest.NewRequest(http.MethodGet, "/admin/api/v1/model-pricing-overrides", nil)
 			listRec := httptest.NewRecorder()
-			listCtx := e.NewContext(listReq, listRec)
-			if err := h.ListModelPricingOverrides(listCtx); err != nil {
-				t.Fatalf("ListModelPricingOverrides() error = %v", err)
-			}
+			e.ServeHTTP(listRec, listReq)
 			if listRec.Code != http.StatusOK {
 				t.Fatalf("list status = %d, want 200", listRec.Code)
 			}
@@ -152,11 +145,7 @@ func TestModelPricingOverrideLifecycle(t *testing.T) {
 
 			deleteReq := httptest.NewRequest(http.MethodDelete, "/admin/api/v1/model-pricing-overrides/"+tt.encodedPath, nil)
 			deleteRec := httptest.NewRecorder()
-			deleteCtx := e.NewContext(deleteReq, deleteRec)
-			deleteCtx.SetPathValues(echo.PathValues{{Name: "selector", Value: tt.selector}})
-			if err := h.DeleteModelPricingOverride(deleteCtx); err != nil {
-				t.Fatalf("DeleteModelPricingOverride() error = %v", err)
-			}
+			e.ServeHTTP(deleteRec, deleteReq)
 			if deleteRec.Code != http.StatusNoContent {
 				t.Fatalf("delete status = %d, want 204", deleteRec.Code)
 			}

--- a/internal/admin/handler_pricing_test.go
+++ b/internal/admin/handler_pricing_test.go
@@ -35,6 +35,13 @@ func (m *mockPricingRecalculator) RecalculatePricing(_ context.Context, params u
 	return m.result, nil
 }
 
+func TestNewHandlerDoesNotWrapNilRegistryAsPricingResolver(t *testing.T) {
+	h := NewHandler(nil, nil)
+	if h.pricingResolver != nil {
+		t.Fatal("pricingResolver is non-nil for nil registry")
+	}
+}
+
 func TestRecalculateUsagePricingResolvesAliasAndFilters(t *testing.T) {
 	catalog := newAliasTestCatalog()
 	catalog.add("openai/gpt-4o", "openai")

--- a/internal/admin/handler_usage.go
+++ b/internal/admin/handler_usage.go
@@ -257,7 +257,7 @@ func (h *Handler) RecalculateUsagePricing(c *echo.Context) error {
 	h.pricingMu.Lock()
 	defer h.pricingMu.Unlock()
 
-	result, err := h.usageRecalculator.RecalculatePricing(c.Request().Context(), params, h.registry)
+	result, err := h.usageRecalculator.RecalculatePricing(c.Request().Context(), params, h.pricingResolver)
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return handleError(c, err)

--- a/internal/admin/handler_usage.go
+++ b/internal/admin/handler_usage.go
@@ -237,7 +237,7 @@ func (h *Handler) RecalculateUsagePricing(c *echo.Context) error {
 	if h.usageRecalculator == nil {
 		return handleError(c, featureUnavailableError("usage pricing recalculation is unavailable"))
 	}
-	if h.registry == nil {
+	if h.pricingResolver == nil {
 		return handleError(c, featureUnavailableError("model pricing metadata is unavailable"))
 	}
 

--- a/internal/admin/routes.go
+++ b/internal/admin/routes.go
@@ -47,6 +47,10 @@ func (h *Handler) RegisterRoutes(g RouteRegistrar) {
 	g.PUT("/model-overrides/:selector", h.UpsertModelOverride)
 	g.DELETE("/model-overrides/:selector", h.DeleteModelOverride)
 
+	g.GET("/model-pricing-overrides", h.ListModelPricingOverrides)
+	g.PUT("/model-pricing-overrides/:selector", h.UpsertModelPricingOverride)
+	g.DELETE("/model-pricing-overrides/:selector", h.DeleteModelPricingOverride)
+
 	g.GET("/auth-keys", h.ListAuthKeys)
 	g.POST("/auth-keys", h.CreateAuthKey)
 	g.POST("/auth-keys/:id/deactivate", h.DeactivateAuthKey)

--- a/internal/admin/routes_test.go
+++ b/internal/admin/routes_test.go
@@ -62,6 +62,10 @@ func TestRegisterRoutes_RegistersExpectedPaths(t *testing.T) {
 		"PUT /admin/api/v1/model-overrides/:selector",
 		"DELETE /admin/api/v1/model-overrides/:selector",
 
+		"GET /admin/api/v1/model-pricing-overrides",
+		"PUT /admin/api/v1/model-pricing-overrides/:selector",
+		"DELETE /admin/api/v1/model-pricing-overrides/:selector",
+
 		"GET /admin/api/v1/auth-keys",
 		"POST /admin/api/v1/auth-keys",
 		"POST /admin/api/v1/auth-keys/:id/deactivate",

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -26,6 +26,7 @@ import (
 	"gomodel/internal/fallback"
 	"gomodel/internal/guardrails"
 	"gomodel/internal/modeloverrides"
+	"gomodel/internal/pricingoverrides"
 	"gomodel/internal/providers"
 	"gomodel/internal/responsecache"
 	"gomodel/internal/server"
@@ -37,18 +38,19 @@ import (
 // App represents the main application with all its dependencies.
 // It provides centralized lifecycle management for all components.
 type App struct {
-	config         *config.Config
-	providers      *providers.InitResult
-	audit          *auditlog.Result
-	usage          *usage.Result
-	budgets        *budget.Result
-	batch          *batch.Result
-	aliases        *aliases.Result
-	modelOverrides *modeloverrides.Result
-	authKeys       *authkeys.Result
-	guardrails     *guardrails.Result
-	workflows      *workflows.Result
-	server         *server.Server
+	config           *config.Config
+	providers        *providers.InitResult
+	audit            *auditlog.Result
+	usage            *usage.Result
+	budgets          *budget.Result
+	batch            *batch.Result
+	aliases          *aliases.Result
+	modelOverrides   *modeloverrides.Result
+	pricingOverrides *pricingoverrides.Result
+	authKeys         *authkeys.Result
+	guardrails       *guardrails.Result
+	workflows        *workflows.Result
+	server           *server.Server
 
 	shutdownMu  sync.Mutex
 	shutdown    bool
@@ -225,6 +227,26 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 	}
 	app.modelOverrides = modelOverrideResult
 
+	var pricingOverrideResult *pricingoverrides.Result
+	sharedPricingOverrideStorage := firstSharedStorage(auditResult.Storage, usageResult.Storage, batchResult.Storage, aliasResult.Storage, modelOverrideResult.Storage)
+	if sharedPricingOverrideStorage != nil {
+		pricingOverrideResult, err = pricingoverrides.NewWithSharedStorage(ctx, appCfg, sharedPricingOverrideStorage, providerResult.Registry, providerResult.Registry)
+	} else {
+		pricingOverrideResult, err = pricingoverrides.New(ctx, appCfg, providerResult.Registry, providerResult.Registry)
+	}
+	if err != nil {
+		closeErr := errors.Join(app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		if closeErr != nil {
+			return nil, fmt.Errorf("failed to initialize model pricing overrides: %w (also: close error: %v)", err, closeErr)
+		}
+		return nil, fmt.Errorf("failed to initialize model pricing overrides: %w", err)
+	}
+	app.pricingOverrides = pricingOverrideResult
+	pricingResolver := usage.PricingResolver(providerResult.Registry)
+	if app.pricingOverrides != nil && app.pricingOverrides.Service != nil {
+		pricingResolver = app.pricingOverrides.Service
+	}
+
 	refreshInterval := workflowRefreshInterval(appCfg)
 	var guardrailExecutor guardrails.ChatCompletionExecutor = app.providers.Router
 	if app.aliases != nil && app.aliases.Service != nil {
@@ -233,14 +255,14 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 
 	// Initialize reusable guardrail definitions using shared storage when already available.
 	var guardrailResult *guardrails.Result
-	sharedGuardrailStorage := firstSharedStorage(auditResult.Storage, usageResult.Storage, batchResult.Storage, aliasResult.Storage, modelOverrideResult.Storage)
+	sharedGuardrailStorage := firstSharedStorage(auditResult.Storage, usageResult.Storage, batchResult.Storage, aliasResult.Storage, modelOverrideResult.Storage, pricingOverrideResult.Storage)
 	if sharedGuardrailStorage != nil {
 		guardrailResult, err = guardrails.NewWithSharedStorage(ctx, sharedGuardrailStorage, refreshInterval, guardrailExecutor)
 	} else {
 		guardrailResult, err = guardrails.New(ctx, appCfg, refreshInterval, guardrailExecutor)
 	}
 	if err != nil {
-		closeErr := errors.Join(app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		closeErr := errors.Join(app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
 		if closeErr != nil {
 			return nil, fmt.Errorf("failed to initialize guardrails: %w (also: close error: %v)", err, closeErr)
 		}
@@ -250,14 +272,14 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 
 	seedGuardrails, err := configGuardrailDefinitions(appCfg.Guardrails)
 	if err != nil {
-		closeErr := errors.Join(app.guardrails.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		closeErr := errors.Join(app.guardrails.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
 		if closeErr != nil {
 			return nil, fmt.Errorf("failed to prepare guardrail definitions: %w (also: close error: %v)", err, closeErr)
 		}
 		return nil, fmt.Errorf("failed to prepare guardrail definitions: %w", err)
 	}
 	if err := guardrailResult.Service.UpsertDefinitions(ctx, seedGuardrails); err != nil {
-		closeErr := errors.Join(app.guardrails.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		closeErr := errors.Join(app.guardrails.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
 		if closeErr != nil {
 			return nil, fmt.Errorf("failed to upsert guardrails: %w (also: close error: %v)", err, closeErr)
 		}
@@ -272,7 +294,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 	featureCaps := runtimeWorkflowFeatureCaps(appCfg)
 
 	var workflowResult *workflows.Result
-	sharedWorkflowStorage := firstSharedStorage(auditResult.Storage, usageResult.Storage, batchResult.Storage, aliasResult.Storage, modelOverrideResult.Storage, guardrailResult.Storage)
+	sharedWorkflowStorage := firstSharedStorage(auditResult.Storage, usageResult.Storage, batchResult.Storage, aliasResult.Storage, modelOverrideResult.Storage, pricingOverrideResult.Storage, guardrailResult.Storage)
 	workflowCompiler := workflows.NewCompilerWithFeatureCaps(guardrailResult.Service, featureCaps)
 	if sharedWorkflowStorage != nil {
 		workflowResult, err = workflows.NewWithSharedStorage(ctx, sharedWorkflowStorage, workflowCompiler, refreshInterval)
@@ -280,7 +302,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		workflowResult, err = workflows.New(ctx, appCfg, workflowCompiler, refreshInterval)
 	}
 	if err != nil {
-		closeErr := errors.Join(app.guardrails.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		closeErr := errors.Join(app.guardrails.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
 		if closeErr != nil {
 			return nil, fmt.Errorf("failed to initialize workflows: %w (also: close error: %v)", err, closeErr)
 		}
@@ -288,14 +310,14 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 	}
 	defaultWorkflow := defaultWorkflowInput(appCfg, guardrailResult.Service.Names(), seedGuardrails)
 	if err := workflowResult.Service.EnsureDefaultGlobal(ctx, defaultWorkflow); err != nil {
-		closeErr := errors.Join(workflowResult.Close(), app.guardrails.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		closeErr := errors.Join(workflowResult.Close(), app.guardrails.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
 		if closeErr != nil {
 			return nil, fmt.Errorf("failed to seed workflows: %w (also: close error: %v)", err, closeErr)
 		}
 		return nil, fmt.Errorf("failed to seed workflows: %w", err)
 	}
 	if err := workflowResult.Service.Refresh(ctx); err != nil {
-		closeErr := errors.Join(workflowResult.Close(), app.guardrails.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		closeErr := errors.Join(workflowResult.Close(), app.guardrails.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
 		if closeErr != nil {
 			return nil, fmt.Errorf("failed to load workflows: %w (also: close error: %v)", err, closeErr)
 		}
@@ -310,6 +332,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		batchResult.Storage,
 		aliasResult.Storage,
 		modelOverrideResult.Storage,
+		pricingOverrideResult.Storage,
 		guardrailResult.Storage,
 		workflowResult.Storage,
 	)
@@ -319,7 +342,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		authKeyResult, err = authkeys.New(ctx, appCfg)
 	}
 	if err != nil {
-		closeErr := errors.Join(workflowResult.Close(), app.guardrails.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		closeErr := errors.Join(workflowResult.Close(), app.guardrails.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
 		if closeErr != nil {
 			return nil, fmt.Errorf("failed to initialize auth keys: %w (also: close error: %v)", err, closeErr)
 		}
@@ -373,7 +396,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		AuditLogger:                     auditResult.Logger,
 		UsageLogger:                     usageResult.Logger,
 		BudgetChecker:                   budgetResult.Service,
-		PricingResolver:                 providerResult.Registry,
+		PricingResolver:                 pricingResolver,
 		ModelResolver:                   app.aliases.Service,
 		ModelAuthorizer:                 app.modelOverrides.Service,
 		FallbackResolver:                fallback.NewResolver(appCfg.Fallback, providerResult.Registry),
@@ -407,6 +430,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 			authKeyResult.Service,
 			app.aliases.Service,
 			app.modelOverrides.Service,
+			app.pricingOverrides.Service,
 			workflowResult.Service,
 			app.guardrails.Service,
 			budgetResult.Service,
@@ -444,15 +468,16 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		slog.Info("provider passthrough disabled")
 	}
 
-	rcm, err := responsecache.NewResponseCacheMiddleware(appCfg.Cache.Response, providerResult.CredentialResolvedProviders, usageResult.Logger, providerResult.Registry)
+	rcm, err := responsecache.NewResponseCacheMiddleware(appCfg.Cache.Response, providerResult.CredentialResolvedProviders, usageResult.Logger, pricingResolver)
 	if err != nil {
 		var (
-			workflowsCloseErr      error
-			guardrailsCloseErr     error
-			authKeysCloseErr       error
-			aliasCloseErr          error
-			modelOverridesCloseErr error
-			batchCloseErr          error
+			workflowsCloseErr        error
+			guardrailsCloseErr       error
+			authKeysCloseErr         error
+			aliasCloseErr            error
+			modelOverridesCloseErr   error
+			pricingOverridesCloseErr error
+			batchCloseErr            error
 		)
 		if app.workflows != nil {
 			workflowsCloseErr = app.workflows.Close()
@@ -469,10 +494,13 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		if app.modelOverrides != nil {
 			modelOverridesCloseErr = app.modelOverrides.Close()
 		}
+		if app.pricingOverrides != nil {
+			pricingOverridesCloseErr = app.pricingOverrides.Close()
+		}
 		if app.batch != nil {
 			batchCloseErr = app.batch.Close()
 		}
-		closeErr := errors.Join(workflowsCloseErr, guardrailsCloseErr, authKeysCloseErr, aliasCloseErr, modelOverridesCloseErr, batchCloseErr, app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		closeErr := errors.Join(workflowsCloseErr, guardrailsCloseErr, authKeysCloseErr, aliasCloseErr, modelOverridesCloseErr, pricingOverridesCloseErr, batchCloseErr, app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
 		if closeErr != nil {
 			return nil, fmt.Errorf("failed to initialize response cache: %w (also: close error: %v)", err, closeErr)
 		}
@@ -487,18 +515,18 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		FallbackResolver:       serverCfg.FallbackResolver,
 		AuditLogger:            auditResult.Logger,
 		UsageLogger:            usageResult.Logger,
-		PricingResolver:        providerResult.Registry,
+		PricingResolver:        pricingResolver,
 		ResponseCache:          rcm,
 	})
 	if err := guardrailResult.Service.SetExecutor(ctx, internalGuardrailExecutor); err != nil {
-		closeErr := errors.Join(rcm.Close(), app.workflows.Close(), app.guardrails.Close(), app.authKeys.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		closeErr := errors.Join(rcm.Close(), app.workflows.Close(), app.guardrails.Close(), app.authKeys.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
 		if closeErr != nil {
 			return nil, fmt.Errorf("failed to wire internal guardrail executor: %w (also: close error: %v)", err, closeErr)
 		}
 		return nil, fmt.Errorf("failed to wire internal guardrail executor: %w", err)
 	}
 	if err := workflowResult.Service.Refresh(ctx); err != nil {
-		closeErr := errors.Join(rcm.Close(), app.workflows.Close(), app.guardrails.Close(), app.authKeys.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		closeErr := errors.Join(rcm.Close(), app.workflows.Close(), app.guardrails.Close(), app.authKeys.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
 		if closeErr != nil {
 			return nil, fmt.Errorf("failed to refresh workflows after wiring internal guardrail executor: %w (also: close error: %v)", err, closeErr)
 		}
@@ -679,7 +707,15 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// 6. Close reusable guardrails subsystem.
+	// 6. Close model pricing overrides subsystem.
+	if a.pricingOverrides != nil {
+		if err := a.pricingOverrides.Close(); err != nil {
+			slog.Error("model pricing overrides close error", "error", err)
+			errs = append(errs, fmt.Errorf("model pricing overrides close: %w", err))
+		}
+	}
+
+	// 7. Close reusable guardrails subsystem.
 	if a.guardrails != nil {
 		if err := a.guardrails.Close(); err != nil {
 			slog.Error("guardrails close error", "error", err)
@@ -687,7 +723,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// 7. Close managed auth keys subsystem.
+	// 8. Close managed auth keys subsystem.
 	if a.authKeys != nil {
 		if err := a.authKeys.Close(); err != nil {
 			slog.Error("auth keys close error", "error", err)
@@ -695,7 +731,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// 8. Close batch store (flushes pending entries)
+	// 9. Close batch store (flushes pending entries)
 	if a.batch != nil {
 		if err := a.batch.Close(); err != nil {
 			slog.Error("batch store close error", "error", err)
@@ -703,7 +739,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// 9. Close budget subsystem.
+	// 10. Close budget subsystem.
 	if a.budgets != nil {
 		if err := a.budgets.Close(); err != nil {
 			slog.Error("budgets close error", "error", err)
@@ -797,6 +833,7 @@ func initAdmin(
 	authKeyService *authkeys.Service,
 	aliasService *aliases.Service,
 	modelOverrideService *modeloverrides.Service,
+	pricingOverrideService *pricingoverrides.Service,
 	workflowService *workflows.Service,
 	guardrailService *guardrails.Service,
 	budgetService *budget.Service,
@@ -849,10 +886,12 @@ func initAdmin(
 		registry,
 		admin.WithConfiguredProviders(configuredProviders),
 		admin.WithUsagePricingRecalculator(pricingRecalculator),
+		admin.WithPricingResolver(pricingOverrideService),
 		admin.WithAuditReader(auditReader),
 		admin.WithAuthKeys(authKeyService),
 		admin.WithAliases(aliasService),
 		admin.WithModelOverrides(modelOverrideService),
+		admin.WithPricingOverrides(pricingOverrideService),
 		admin.WithWorkflows(workflowService),
 		admin.WithGuardrailService(guardrailService),
 		admin.WithBudgets(budgetService),

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -165,6 +165,7 @@ type ModelMetadata struct {
 	Capabilities    map[string]bool         `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
 	Rankings        map[string]ModelRanking `json:"rankings,omitempty" yaml:"rankings,omitempty"`
 	Pricing         *ModelPricing           `json:"pricing,omitempty" yaml:"pricing,omitempty"`
+	PricingSources  map[string]string       `json:"pricing_sources,omitempty" yaml:"-"`
 }
 
 // ModelRanking holds one benchmark or leaderboard entry for a model.
@@ -256,6 +257,47 @@ type ModelPricing struct {
 	PerRequest             *float64           `json:"per_request,omitempty" yaml:"per_request,omitempty"`
 	PerPage                *float64           `json:"per_page,omitempty" yaml:"per_page,omitempty"`
 	Tiers                  []ModelPricingTier `json:"tiers,omitempty" yaml:"tiers,omitempty"`
+}
+
+const (
+	ModelPricingSourceModelRegistry = "model_registry"
+	ModelPricingSourceConfigYAML    = "config_yaml"
+)
+
+// FieldSources returns a field-name keyed source map for non-empty pricing fields.
+func (p *ModelPricing) FieldSources(source string) map[string]string {
+	if p == nil || source == "" {
+		return nil
+	}
+	out := make(map[string]string)
+	add := func(name string, value *float64) {
+		if value != nil {
+			out[name] = source
+		}
+	}
+	add("input_per_mtok", p.InputPerMtok)
+	add("output_per_mtok", p.OutputPerMtok)
+	add("cached_input_per_mtok", p.CachedInputPerMtok)
+	add("cache_write_per_mtok", p.CacheWritePerMtok)
+	add("reasoning_output_per_mtok", p.ReasoningOutputPerMtok)
+	add("batch_input_per_mtok", p.BatchInputPerMtok)
+	add("batch_output_per_mtok", p.BatchOutputPerMtok)
+	add("audio_input_per_mtok", p.AudioInputPerMtok)
+	add("audio_output_per_mtok", p.AudioOutputPerMtok)
+	add("per_image", p.PerImage)
+	add("input_per_image", p.InputPerImage)
+	add("per_second_input", p.PerSecondInput)
+	add("per_second_output", p.PerSecondOutput)
+	add("per_character_input", p.PerCharacterInput)
+	add("per_request", p.PerRequest)
+	add("per_page", p.PerPage)
+	if len(p.Tiers) > 0 {
+		out["tiers"] = source
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // ModelPricingTier represents a volume-based pricing tier.
@@ -375,6 +417,14 @@ func (m *ModelMetadata) Clone() *ModelMetadata {
 	out.ContextWindow = cloneIntPtr(m.ContextWindow)
 	out.MaxOutputTokens = cloneIntPtr(m.MaxOutputTokens)
 	out.Pricing = m.Pricing.Clone()
+	if len(m.PricingSources) > 0 {
+		out.PricingSources = make(map[string]string, len(m.PricingSources))
+		for k, v := range m.PricingSources {
+			out.PricingSources[k] = v
+		}
+	} else {
+		out.PricingSources = nil
+	}
 	return &out
 }
 

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -260,11 +260,15 @@ type ModelPricing struct {
 }
 
 const (
+	// ModelPricingSourceModelRegistry identifies pricing data from the model registry.
 	ModelPricingSourceModelRegistry = "model_registry"
-	ModelPricingSourceConfigYAML    = "config_yaml"
+	// ModelPricingSourceConfigYAML identifies pricing data from config.yaml.
+	ModelPricingSourceConfigYAML = "config_yaml"
 )
 
-// FieldSources returns a field-name keyed source map for non-empty pricing fields.
+// FieldSources returns non-empty pricing field names mapped to source.
+// Callers should pass a non-empty source string. Tiered pricing is reported as
+// the coarse "tiers" key rather than per-tier entries.
 func (p *ModelPricing) FieldSources(source string) map[string]string {
 	if p == nil || source == "" {
 		return nil

--- a/internal/gateway/inference_execute.go
+++ b/internal/gateway/inference_execute.go
@@ -350,7 +350,8 @@ func requestModel[Req any](req Req, model func(Req) string) string {
 }
 
 func usagePricingModel(workflow *core.Workflow, requestedModel, failoverModel, responseModel string) string {
-	if failoverModel = strings.TrimSpace(failoverModel); failoverModel != "" {
+	failoverModel = strings.TrimSpace(failoverModel)
+	if failoverModel != "" {
 		return failoverModel
 	}
 	if model := ResolvedModelFromWorkflow(workflow, requestedModel); model != "" {

--- a/internal/gateway/inference_execute.go
+++ b/internal/gateway/inference_execute.go
@@ -106,7 +106,8 @@ func (o *InferenceOrchestrator) ExecuteEmbeddings(ctx context.Context, workflow 
 	if err != nil {
 		return nil, err
 	}
-	o.logUsage(ctx, workflow, resp.Model, providerType, providerName, func(pricing *core.ModelPricing) *usage.UsageEntry {
+	pricingModel := usagePricingModel(workflow, req.Model, "", resp.Model)
+	o.logUsage(ctx, workflow, pricingModel, providerType, providerName, func(pricing *core.ModelPricing) *usage.UsageEntry {
 		return usage.ExtractFromEmbeddingResponse(resp, requestID, providerType, endpoint, pricing)
 	})
 	return &EmbeddingResult{

--- a/internal/gateway/inference_execute.go
+++ b/internal/gateway/inference_execute.go
@@ -350,6 +350,7 @@ func requestModel[Req any](req Req, model func(Req) string) string {
 }
 
 func usagePricingModel(workflow *core.Workflow, requestedModel, failoverModel, responseModel string) string {
+	requestedModel = strings.TrimSpace(requestedModel)
 	failoverModel = strings.TrimSpace(failoverModel)
 	if failoverModel != "" {
 		return failoverModel

--- a/internal/gateway/inference_execute.go
+++ b/internal/gateway/inference_execute.go
@@ -260,6 +260,7 @@ func (o *InferenceOrchestrator) streamResponses(
 type translatedExecutionSpec[Req any, Resp any, Result any] struct {
 	execute func(*InferenceOrchestrator, context.Context, *core.Workflow, Req) (Resp, string, string, string, bool, error)
 	model   func(Resp) string
+	request func(Req) string
 	usage   func(Resp, string, string, string, *core.ModelPricing) *usage.UsageEntry
 	build   func(Resp, ExecutionMeta) Result
 }
@@ -267,6 +268,7 @@ type translatedExecutionSpec[Req any, Resp any, Result any] struct {
 var chatExecutionSpec = translatedExecutionSpec[*core.ChatRequest, *core.ChatResponse, *ChatCompletionResult]{
 	execute: executeChatCompletionRequest,
 	model:   chatResponseModel,
+	request: chatRequestModel,
 	usage: func(resp *core.ChatResponse, requestID, providerType, endpoint string, pricing *core.ModelPricing) *usage.UsageEntry {
 		return usage.ExtractFromChatResponse(resp, requestID, providerType, endpoint, pricing)
 	},
@@ -278,6 +280,7 @@ var chatExecutionSpec = translatedExecutionSpec[*core.ChatRequest, *core.ChatRes
 var responsesExecutionSpec = translatedExecutionSpec[*core.ResponsesRequest, *core.ResponsesResponse, *ResponsesResult]{
 	execute: executeResponsesRequest,
 	model:   responsesResponseModel,
+	request: responsesRequestModel,
 	usage: func(resp *core.ResponsesResponse, requestID, providerType, endpoint string, pricing *core.ModelPricing) *usage.UsageEntry {
 		return usage.ExtractFromResponsesResponse(resp, requestID, providerType, endpoint, pricing)
 	},
@@ -298,6 +301,7 @@ func executeTranslatedResult[Req any, Resp any, Result any](
 		func() (Resp, string, string, string, bool, error) {
 			return spec.execute(o, ctx, workflow, req)
 		},
+		requestModel(req, spec.request),
 		spec.model,
 		func(resp Resp, providerType string, pricing *core.ModelPricing) *usage.UsageEntry {
 			return spec.usage(resp, requestID, providerType, endpoint, pricing)
@@ -315,6 +319,7 @@ func executeWithUsage[Resp any](
 	ctx context.Context,
 	workflow *core.Workflow,
 	execute func() (Resp, string, string, string, bool, error),
+	requestedModel string,
 	modelFromResponse func(Resp) string,
 	entry func(Resp, string, *core.ModelPricing) *usage.UsageEntry,
 ) (Resp, ExecutionMeta, error) {
@@ -324,7 +329,8 @@ func executeWithUsage[Resp any](
 		return zero, ExecutionMeta{}, err
 	}
 	model := modelFromResponse(resp)
-	o.logUsage(ctx, workflow, model, providerType, providerName, func(pricing *core.ModelPricing) *usage.UsageEntry {
+	pricingModel := usagePricingModel(workflow, requestedModel, failoverModel, model)
+	o.logUsage(ctx, workflow, pricingModel, providerType, providerName, func(pricing *core.ModelPricing) *usage.UsageEntry {
 		return entry(resp, providerType, pricing)
 	})
 	return resp, ExecutionMeta{
@@ -334,6 +340,23 @@ func executeWithUsage[Resp any](
 		FailoverModel: failoverModel,
 		UsedFallback:  usedFallback,
 	}, nil
+}
+
+func requestModel[Req any](req Req, model func(Req) string) string {
+	if model == nil {
+		return ""
+	}
+	return strings.TrimSpace(model(req))
+}
+
+func usagePricingModel(workflow *core.Workflow, requestedModel, failoverModel, responseModel string) string {
+	if failoverModel = strings.TrimSpace(failoverModel); failoverModel != "" {
+		return failoverModel
+	}
+	if model := ResolvedModelFromWorkflow(workflow, requestedModel); model != "" {
+		return model
+	}
+	return strings.TrimSpace(responseModel)
 }
 
 func executeTranslatedProviderRequest[Req any, Resp any](
@@ -467,6 +490,13 @@ func chatResponseModel(resp *core.ChatResponse) string {
 	return resp.Model
 }
 
+func chatRequestModel(req *core.ChatRequest) string {
+	if req == nil {
+		return ""
+	}
+	return req.Model
+}
+
 func chatResponseProvider(resp *core.ChatResponse) string {
 	if resp == nil {
 		return ""
@@ -479,6 +509,13 @@ func responsesResponseModel(resp *core.ResponsesResponse) string {
 		return ""
 	}
 	return resp.Model
+}
+
+func responsesRequestModel(req *core.ResponsesRequest) string {
+	if req == nil {
+		return ""
+	}
+	return req.Model
 }
 
 func responsesResponseProvider(resp *core.ResponsesResponse) string {

--- a/internal/gateway/inference_orchestrator_test.go
+++ b/internal/gateway/inference_orchestrator_test.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"io"
+	"math"
 	"testing"
 
 	"gomodel/internal/core"
@@ -21,6 +22,18 @@ func (l *usageCaptureLogger) Write(entry *usage.UsageEntry) {
 func (l *usageCaptureLogger) Config() usage.Config { return l.config }
 func (l *usageCaptureLogger) Close() error         { return nil }
 
+type pricingCaptureResolver struct {
+	model    string
+	provider string
+	pricing  *core.ModelPricing
+}
+
+func (r *pricingCaptureResolver) ResolvePricing(model, provider string) *core.ModelPricing {
+	r.model = model
+	r.provider = provider
+	return r.pricing
+}
+
 func TestInferenceOrchestratorLogUsageAssignsUserPathAndProviderName(t *testing.T) {
 	logger := &usageCaptureLogger{config: usage.Config{Enabled: true}}
 	orchestrator := NewInferenceOrchestrator(InferenceConfig{UsageLogger: logger})
@@ -38,6 +51,71 @@ func TestInferenceOrchestratorLogUsageAssignsUserPathAndProviderName(t *testing.
 	}
 	if got := logger.entries[0].ProviderName; got != "primary-openai" {
 		t.Fatalf("ProviderName = %q, want primary-openai", got)
+	}
+}
+
+func TestExecuteChatCompletionPricesRequestedModelWhenResponseModelIsVersioned(t *testing.T) {
+	zero := 0.0
+	perRequest := 0.033333
+	logger := &usageCaptureLogger{config: usage.Config{Enabled: true}}
+	pricing := &pricingCaptureResolver{pricing: &core.ModelPricing{
+		InputPerMtok:  &zero,
+		OutputPerMtok: &zero,
+		PerRequest:    &perRequest,
+	}}
+	provider := &providerTypeResolverStub{
+		chatResponse: &core.ChatResponse{
+			ID:       "chatcmpl-test",
+			Model:    "gpt-4o-mini-2024-07-18",
+			Provider: "openai",
+			Usage: core.Usage{
+				PromptTokens:     12,
+				CompletionTokens: 1,
+				TotalTokens:      13,
+			},
+		},
+	}
+	orchestrator := NewInferenceOrchestrator(InferenceConfig{
+		Provider:        provider,
+		UsageLogger:     logger,
+		PricingResolver: pricing,
+	})
+	workflow := &core.Workflow{
+		ProviderType: "openai",
+		Resolution: &core.RequestModelResolution{
+			Requested:        core.NewRequestedModelSelector("openai/gpt-4o-mini", ""),
+			ResolvedSelector: core.ModelSelector{Provider: "openai", Model: "gpt-4o-mini"},
+			ProviderType:     "openai",
+			ProviderName:     "openai",
+		},
+	}
+
+	_, err := orchestrator.ExecuteChatCompletion(
+		context.Background(),
+		workflow,
+		&core.ChatRequest{Model: "openai/gpt-4o-mini"},
+		"req-usage-pricing",
+		"/v1/chat/completions",
+	)
+	if err != nil {
+		t.Fatalf("ExecuteChatCompletion() error = %v", err)
+	}
+
+	if pricing.model != "gpt-4o-mini" {
+		t.Fatalf("pricing model = %q, want gpt-4o-mini", pricing.model)
+	}
+	if pricing.provider != "openai" {
+		t.Fatalf("pricing provider = %q, want openai", pricing.provider)
+	}
+	if len(logger.entries) != 1 {
+		t.Fatalf("len(entries) = %d, want 1", len(logger.entries))
+	}
+	entry := logger.entries[0]
+	if entry.Model != "gpt-4o-mini-2024-07-18" {
+		t.Fatalf("usage model = %q, want provider response model", entry.Model)
+	}
+	if entry.TotalCost == nil || math.Abs(*entry.TotalCost-perRequest) > 0.0000001 {
+		t.Fatalf("total cost = %v, want %f", entry.TotalCost, perRequest)
 	}
 }
 
@@ -127,10 +205,11 @@ func TestQualifyModelWithProviderKeepsAlreadyQualifiedModelIDs(t *testing.T) {
 
 type providerTypeResolverStub struct {
 	providerTypes map[string]string
+	chatResponse  *core.ChatResponse
 }
 
 func (p *providerTypeResolverStub) ChatCompletion(context.Context, *core.ChatRequest) (*core.ChatResponse, error) {
-	return nil, nil
+	return p.chatResponse, nil
 }
 
 func (p *providerTypeResolverStub) StreamChatCompletion(context.Context, *core.ChatRequest) (io.ReadCloser, error) {

--- a/internal/gateway/usage.go
+++ b/internal/gateway/usage.go
@@ -29,13 +29,20 @@ func (o *InferenceOrchestrator) logUsage(
 	}
 	var pricing *core.ModelPricing
 	if o.pricingResolver != nil {
-		pricing = o.pricingResolver.ResolvePricing(model, providerType)
+		pricing = o.pricingResolver.ResolvePricing(model, effectivePricingProvider(providerType, providerName))
 	}
 	if entry := extractFn(pricing); entry != nil {
 		entry.ProviderName = strings.TrimSpace(providerName)
 		entry.UserPath = core.UserPathFromContext(ctx)
 		o.usageLogger.Write(entry)
 	}
+}
+
+func effectivePricingProvider(providerType, providerName string) string {
+	if name := strings.TrimSpace(providerName); name != "" {
+		return name
+	}
+	return strings.TrimSpace(providerType)
 }
 
 // ShouldEnforceReturningUsageData reports whether streams should request usage chunks.

--- a/internal/modeldata/merge.go
+++ b/internal/modeldata/merge.go
@@ -74,7 +74,23 @@ func MergeMetadata(base, override *core.ModelMetadata) *core.ModelMetadata {
 	}
 	if override.Pricing != nil {
 		merged.Pricing = override.Pricing.Clone()
+		if len(override.PricingSources) > 0 {
+			merged.PricingSources = clonePricingSources(override.PricingSources)
+		} else {
+			merged.PricingSources = nil
+		}
 	}
 
 	return merged
+}
+
+func clonePricingSources(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }

--- a/internal/modeldata/merger.go
+++ b/internal/modeldata/merger.go
@@ -214,6 +214,7 @@ func buildMetadata(model *ModelEntry, pm *ProviderModelEntry) *core.ModelMetadat
 		meta.Capabilities = model.Capabilities
 		meta.Rankings = buildRankings(model.Rankings)
 		meta.Pricing = model.Pricing
+		meta.PricingSources = model.Pricing.FieldSources(core.ModelPricingSourceModelRegistry)
 	}
 
 	// Apply provider_model overrides (non-nil fields win)
@@ -226,6 +227,7 @@ func buildMetadata(model *ModelEntry, pm *ProviderModelEntry) *core.ModelMetadat
 		}
 		if pm.Pricing != nil {
 			meta.Pricing = pm.Pricing
+			meta.PricingSources = pm.Pricing.FieldSources(core.ModelPricingSourceModelRegistry)
 		}
 		if pm.Capabilities != nil {
 			meta.Capabilities = pm.Capabilities

--- a/internal/modeldata/merger_test.go
+++ b/internal/modeldata/merger_test.go
@@ -154,6 +154,9 @@ func TestResolve_ProviderModelOverride(t *testing.T) {
 	if got := meta.PricingSources["input_per_mtok"]; got != core.ModelPricingSourceModelRegistry {
 		t.Errorf("PricingSources[input_per_mtok] = %q, want %q", got, core.ModelPricingSourceModelRegistry)
 	}
+	if got := meta.PricingSources["output_per_mtok"]; got != core.ModelPricingSourceModelRegistry {
+		t.Errorf("PricingSources[output_per_mtok] = %q, want %q", got, core.ModelPricingSourceModelRegistry)
+	}
 	// DisplayName from base model
 	if meta.DisplayName != "GPT-4o" {
 		t.Errorf("DisplayName = %s, want GPT-4o (base)", meta.DisplayName)

--- a/internal/modeldata/merger_test.go
+++ b/internal/modeldata/merger_test.go
@@ -93,6 +93,12 @@ func TestResolve_DirectModelMatch(t *testing.T) {
 	if *meta.Pricing.OutputPerMtok != 10.00 {
 		t.Errorf("OutputPerMtok = %f, want 10.00", *meta.Pricing.OutputPerMtok)
 	}
+	if got := meta.PricingSources["input_per_mtok"]; got != core.ModelPricingSourceModelRegistry {
+		t.Errorf("PricingSources[input_per_mtok] = %q, want %q", got, core.ModelPricingSourceModelRegistry)
+	}
+	if got := meta.PricingSources["output_per_mtok"]; got != core.ModelPricingSourceModelRegistry {
+		t.Errorf("PricingSources[output_per_mtok] = %q, want %q", got, core.ModelPricingSourceModelRegistry)
+	}
 }
 
 func TestResolve_ProviderModelOverride(t *testing.T) {
@@ -144,6 +150,9 @@ func TestResolve_ProviderModelOverride(t *testing.T) {
 	}
 	if *meta.Pricing.OutputPerMtok != 15.00 {
 		t.Errorf("OutputPerMtok = %f, want 15.00 (override)", *meta.Pricing.OutputPerMtok)
+	}
+	if got := meta.PricingSources["input_per_mtok"]; got != core.ModelPricingSourceModelRegistry {
+		t.Errorf("PricingSources[input_per_mtok] = %q, want %q", got, core.ModelPricingSourceModelRegistry)
 	}
 	// DisplayName from base model
 	if meta.DisplayName != "GPT-4o" {

--- a/internal/modeloverrides/service.go
+++ b/internal/modeloverrides/service.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"gomodel/internal/core"
+	"gomodel/internal/modelselectors"
 )
 
 type compiledOverride struct {
@@ -136,7 +137,7 @@ func (s *Service) buildSnapshot(overrides []Override) (snapshot, error) {
 			next.global = compiled
 			next.hasGlobal = true
 		case ScopeProviderModel:
-			next.exact[exactMatchKey(normalized.ProviderName, normalized.Model)] = compiled
+			next.exact[modelselectors.ExactMatchKey(normalized.ProviderName, normalized.Model)] = compiled
 		case ScopeProvider:
 			next.providerWide[normalized.ProviderName] = compiled
 		default:
@@ -420,7 +421,7 @@ func (snap snapshot) effectiveState(selector core.ModelSelector) EffectiveState 
 }
 
 func (snap snapshot) matchingOverride(providerName, model string) (compiledOverride, bool) {
-	if key := exactMatchKey(providerName, model); key != "" {
+	if key := modelselectors.ExactMatchKey(providerName, model); key != "" {
 		if exact, ok := snap.exact[key]; ok {
 			return exact, true
 		}

--- a/internal/modeloverrides/service.go
+++ b/internal/modeloverrides/service.go
@@ -133,12 +133,12 @@ func (s *Service) buildSnapshot(overrides []Override) (snapshot, error) {
 
 		compiled := compiledOverride{override: normalized}
 		switch normalized.ScopeKind() {
-		case ScopeGlobal:
+		case modelselectors.ScopeGlobal:
 			next.global = compiled
 			next.hasGlobal = true
-		case ScopeProviderModel:
+		case modelselectors.ScopeProviderModel:
 			next.exact[modelselectors.ExactMatchKey(normalized.ProviderName, normalized.Model)] = compiled
-		case ScopeProvider:
+		case modelselectors.ScopeProvider:
 			next.providerWide[normalized.ProviderName] = compiled
 		default:
 			next.modelWide[normalized.Model] = compiled

--- a/internal/modeloverrides/service_test.go
+++ b/internal/modeloverrides/service_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"gomodel/internal/core"
+	"gomodel/internal/modelselectors"
 )
 
 type testStore struct {
@@ -263,6 +264,81 @@ func TestService_MostSpecificOverrideWins(t *testing.T) {
 			if len(state.UserPaths) != 1 || state.UserPaths[0] != tt.wantPath {
 				t.Fatalf("EffectiveState().UserPaths = %#v, want [%s]", state.UserPaths, tt.wantPath)
 			}
+		})
+	}
+}
+
+func TestServiceBuildSnapshotIndexesAllScopeKinds(t *testing.T) {
+	service, err := NewService(newTestStore(), testCatalog{providerNames: []string{"openai"}}, true)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		override Override
+		assert   func(t *testing.T, snap snapshot)
+	}{
+		{
+			name:     "exact provider model",
+			override: Override{Selector: "openai/gpt-4o", UserPaths: []string{"/"}},
+			assert: func(t *testing.T, snap snapshot) {
+				t.Helper()
+				key := modelselectors.ExactMatchKey("openai", "gpt-4o")
+				if got, ok := snap.exact[key]; !ok || got.override.Selector != "openai/gpt-4o" {
+					t.Fatalf("exact[%q] = %+v, %v; want openai/gpt-4o", key, got, ok)
+				}
+			},
+		},
+		{
+			name:     "model wide",
+			override: Override{Selector: "gpt-4o", UserPaths: []string{"/"}},
+			assert: func(t *testing.T, snap snapshot) {
+				t.Helper()
+				if got, ok := snap.modelWide["gpt-4o"]; !ok || got.override.Selector != "gpt-4o" {
+					t.Fatalf("modelWide[gpt-4o] = %+v, %v; want gpt-4o", got, ok)
+				}
+			},
+		},
+		{
+			name:     "provider wide",
+			override: Override{Selector: "openai/", UserPaths: []string{"/"}},
+			assert: func(t *testing.T, snap snapshot) {
+				t.Helper()
+				if got, ok := snap.providerWide["openai"]; !ok || got.override.Selector != "openai/" {
+					t.Fatalf("providerWide[openai] = %+v, %v; want openai/", got, ok)
+				}
+			},
+		},
+		{
+			name:     "global",
+			override: Override{Selector: "/", UserPaths: []string{"/"}},
+			assert: func(t *testing.T, snap snapshot) {
+				t.Helper()
+				if !snap.hasGlobal || snap.global.override.Selector != "/" {
+					t.Fatalf("global = %+v hasGlobal=%v; want /", snap.global, snap.hasGlobal)
+				}
+			},
+		},
+		{
+			name:     "slash-shaped raw model id",
+			override: Override{Selector: "vendor/model-with-slash", Model: "vendor/model-with-slash", UserPaths: []string{"/"}},
+			assert: func(t *testing.T, snap snapshot) {
+				t.Helper()
+				if got, ok := snap.modelWide["vendor/model-with-slash"]; !ok || got.override.Model != "vendor/model-with-slash" {
+					t.Fatalf("modelWide[vendor/model-with-slash] = %+v, %v; want raw model id", got, ok)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			snap, err := service.buildSnapshot([]Override{tt.override})
+			if err != nil {
+				t.Fatalf("buildSnapshot() error = %v", err)
+			}
+			tt.assert(t, snap)
 		})
 	}
 }

--- a/internal/modeloverrides/types.go
+++ b/internal/modeloverrides/types.go
@@ -31,13 +31,6 @@ type Override struct {
 // ScopeKind identifies how broadly an override applies.
 type ScopeKind = modelselectors.ScopeKind
 
-const (
-	ScopeGlobal        = modelselectors.ScopeGlobal
-	ScopeModel         = modelselectors.ScopeModel
-	ScopeProvider      = modelselectors.ScopeProvider
-	ScopeProviderModel = modelselectors.ScopeProviderModel
-)
-
 // ScopeKind reports the normalized selector scope for one override.
 func (o Override) ScopeKind() ScopeKind {
 	return modelselectors.ScopeKindFor(o.Selector, o.ProviderName, o.Model)

--- a/internal/modeloverrides/types.go
+++ b/internal/modeloverrides/types.go
@@ -29,18 +29,18 @@ type Override struct {
 }
 
 // ScopeKind identifies how broadly an override applies.
-type ScopeKind string
+type ScopeKind = modelselectors.ScopeKind
 
 const (
-	ScopeGlobal        ScopeKind = ScopeKind(modelselectors.ScopeGlobal)
-	ScopeModel         ScopeKind = ScopeKind(modelselectors.ScopeModel)
-	ScopeProvider      ScopeKind = ScopeKind(modelselectors.ScopeProvider)
-	ScopeProviderModel ScopeKind = ScopeKind(modelselectors.ScopeProviderModel)
+	ScopeGlobal        = modelselectors.ScopeGlobal
+	ScopeModel         = modelselectors.ScopeModel
+	ScopeProvider      = modelselectors.ScopeProvider
+	ScopeProviderModel = modelselectors.ScopeProviderModel
 )
 
 // ScopeKind reports the normalized selector scope for one override.
 func (o Override) ScopeKind() ScopeKind {
-	return ScopeKind(modelselectors.ScopeKindFor(o.Selector, o.ProviderName, o.Model))
+	return modelselectors.ScopeKindFor(o.Selector, o.ProviderName, o.Model)
 }
 
 // View is the admin-facing representation of one persisted override.

--- a/internal/modeloverrides/types.go
+++ b/internal/modeloverrides/types.go
@@ -2,10 +2,10 @@ package modeloverrides
 
 import (
 	"sort"
-	"strings"
 	"time"
 
 	"gomodel/internal/core"
+	"gomodel/internal/modelselectors"
 )
 
 // Override stores one persisted access-policy override for a model selector.
@@ -32,24 +32,15 @@ type Override struct {
 type ScopeKind string
 
 const (
-	ScopeGlobal        ScopeKind = "global"
-	ScopeModel         ScopeKind = "model"
-	ScopeProvider      ScopeKind = "provider"
-	ScopeProviderModel ScopeKind = "provider_model"
+	ScopeGlobal        ScopeKind = ScopeKind(modelselectors.ScopeGlobal)
+	ScopeModel         ScopeKind = ScopeKind(modelselectors.ScopeModel)
+	ScopeProvider      ScopeKind = ScopeKind(modelselectors.ScopeProvider)
+	ScopeProviderModel ScopeKind = ScopeKind(modelselectors.ScopeProviderModel)
 )
 
 // ScopeKind reports the normalized selector scope for one override.
 func (o Override) ScopeKind() ScopeKind {
-	switch {
-	case isGlobalSelector(o.Selector):
-		return ScopeGlobal
-	case strings.TrimSpace(o.ProviderName) != "" && strings.TrimSpace(o.Model) != "":
-		return ScopeProviderModel
-	case strings.TrimSpace(o.ProviderName) != "":
-		return ScopeProvider
-	default:
-		return ScopeModel
-	}
+	return ScopeKind(modelselectors.ScopeKindFor(o.Selector, o.ProviderName, o.Model))
 }
 
 // View is the admin-facing representation of one persisted override.
@@ -74,14 +65,14 @@ type Catalog interface {
 }
 
 func normalizeOverrideInput(catalog Catalog, override Override) (Override, error) {
-	selector, providerName, model, err := normalizeSelectorInput(selectorProviderNames(catalog), override.Selector)
+	parts, err := modelselectors.NormalizeInput(catalog, override.Selector)
 	if err != nil {
 		return Override{}, err
 	}
 
-	override.Selector = selector
-	override.ProviderName = providerName
-	override.Model = model
+	override.Selector = parts.Selector
+	override.ProviderName = parts.ProviderName
+	override.Model = parts.Model
 
 	paths, err := normalizeUserPaths(override.UserPaths)
 	if err != nil {
@@ -95,28 +86,13 @@ func normalizeOverrideInput(catalog Catalog, override Override) (Override, error
 }
 
 func normalizeStoredOverride(override Override) (Override, error) {
-	override.Selector = strings.TrimSpace(override.Selector)
-	override.ProviderName = strings.TrimSpace(override.ProviderName)
-	override.Model = strings.TrimSpace(override.Model)
-	globalSelector := isGlobalSelector(override.Selector)
-
-	if override.Selector == "" {
-		override.Selector = selectorString(override.ProviderName, override.Model)
+	parts, err := modelselectors.NormalizeStored(override.Selector, override.ProviderName, override.Model)
+	if err != nil {
+		return Override{}, err
 	}
-	if override.Selector == "" {
-		return Override{}, newValidationError("selector is required", nil)
-	}
-	if override.ProviderName == "" && override.Model == "" && !globalSelector {
-		providerName, model := parseStoredSelectorParts(override.Selector)
-		override.ProviderName = providerName
-		override.Model = model
-	}
-	if override.ProviderName == "" && override.Model == "" && !isGlobalSelector(override.Selector) {
-		return Override{}, newValidationError("selector is required", nil)
-	}
-	if normalized := selectorString(override.ProviderName, override.Model); normalized != "" {
-		override.Selector = normalized
-	}
+	override.Selector = parts.Selector
+	override.ProviderName = parts.ProviderName
+	override.Model = parts.Model
 
 	paths, err := normalizeUserPaths(override.UserPaths)
 	if err != nil {
@@ -130,50 +106,15 @@ func normalizeStoredOverride(override Override) (Override, error) {
 }
 
 func normalizeSelectorInput(providerNames []string, raw string) (selector, providerName, model string, err error) {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return "", "", "", newValidationError("selector is required", nil)
+	parts, err := modelselectors.NormalizeInputWithProviderNames(providerNames, raw)
+	if err != nil {
+		return "", "", "", err
 	}
-	if isGlobalSelector(raw) {
-		return "/", "", "", nil
-	}
-
-	providerNameSet := make(map[string]struct{}, len(providerNames))
-	for _, name := range providerNames {
-		name = strings.TrimSpace(name)
-		if name == "" {
-			continue
-		}
-		providerNameSet[name] = struct{}{}
-	}
-
-	if prefix, rest, ok := splitFirst(raw); ok {
-		if _, exists := providerNameSet[prefix]; exists {
-			providerName = prefix
-			model = rest
-		} else {
-			model = raw
-		}
-	} else {
-		model = raw
-	}
-
-	if providerName == "" && model == "" {
-		return "", "", "", newValidationError("selector is required", nil)
-	}
-	if providerName != "" {
-		if _, exists := providerNameSet[providerName]; !exists {
-			return "", "", "", newValidationError("unknown provider_name: "+providerName, nil)
-		}
-	}
-	return selectorString(providerName, model), providerName, model, nil
+	return parts.Selector, parts.ProviderName, parts.Model, nil
 }
 
 func selectorProviderNames(catalog Catalog) []string {
-	if catalog == nil {
-		return nil
-	}
-	return append([]string(nil), catalog.ProviderNames()...)
+	return modelselectors.ProviderNames(catalog)
 }
 
 func normalizeUserPaths(paths []string) ([]string, error) {
@@ -205,59 +146,5 @@ func normalizeUserPaths(paths []string) ([]string, error) {
 }
 
 func selectorString(providerName, model string) string {
-	providerName = strings.TrimSpace(providerName)
-	model = strings.TrimSpace(model)
-	switch {
-	case providerName != "" && model != "":
-		return providerName + "/" + model
-	case providerName != "":
-		return providerName + "/"
-	case model != "":
-		return model
-	default:
-		return ""
-	}
-}
-
-func isGlobalSelector(selector string) bool {
-	return strings.TrimSpace(selector) == "/"
-}
-
-func exactMatchKey(providerName, model string) string {
-	providerName = strings.TrimSpace(providerName)
-	model = strings.TrimSpace(model)
-	if providerName == "" || model == "" {
-		return ""
-	}
-	return providerName + "/" + model
-}
-
-func splitFirst(value string) (prefix, rest string, ok bool) {
-	parts := strings.SplitN(strings.TrimSpace(value), "/", 2)
-	if len(parts) != 2 {
-		return "", "", false
-	}
-	prefix = strings.TrimSpace(parts[0])
-	rest = strings.TrimSpace(parts[1])
-	if prefix == "" {
-		return "", "", false
-	}
-	return prefix, rest, true
-}
-
-func parseStoredSelectorParts(selector string) (providerName, model string) {
-	selector = strings.TrimSpace(selector)
-	if selector == "" {
-		return "", ""
-	}
-	if isGlobalSelector(selector) {
-		return "", ""
-	}
-	if strings.HasSuffix(selector, "/") {
-		return strings.TrimSpace(strings.TrimSuffix(selector, "/")), ""
-	}
-	if providerName, model, ok := splitFirst(selector); ok {
-		return providerName, model
-	}
-	return "", selector
+	return modelselectors.String(providerName, model)
 }

--- a/internal/modelselectors/selectors.go
+++ b/internal/modelselectors/selectors.go
@@ -127,7 +127,7 @@ func NormalizeStored(selector, providerName, model string) (Selector, error) {
 	if providerName == "" && model == "" && !globalSelector {
 		providerName, model = ParseStoredParts(selector)
 	}
-	if providerName == "" && model == "" && !IsGlobal(selector) {
+	if providerName == "" && model == "" && !globalSelector {
 		return Selector{}, NewValidationError("selector is required", nil)
 	}
 	if normalized := String(providerName, model); normalized != "" {

--- a/internal/modelselectors/selectors.go
+++ b/internal/modelselectors/selectors.go
@@ -1,0 +1,220 @@
+// Package modelselectors normalizes provider/model selector strings shared by
+// model-level admin features.
+package modelselectors
+
+import (
+	"errors"
+	"strings"
+)
+
+// Catalog is the minimal configured-provider surface needed for selector validation.
+type Catalog interface {
+	ProviderNames() []string
+}
+
+// Selector is the normalized form of a model selector.
+type Selector struct {
+	Selector     string
+	ProviderName string
+	Model        string
+}
+
+// ScopeKind identifies how broadly a selector applies.
+type ScopeKind string
+
+const (
+	ScopeGlobal        ScopeKind = "global"
+	ScopeModel         ScopeKind = "model"
+	ScopeProvider      ScopeKind = "provider"
+	ScopeProviderModel ScopeKind = "provider_model"
+)
+
+// ValidationError indicates invalid selector input or invalid selector state.
+type ValidationError struct {
+	Message string
+	Err     error
+}
+
+func (e *ValidationError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Message
+}
+
+func (e *ValidationError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// NewValidationError creates a selector validation error.
+func NewValidationError(message string, err error) error {
+	return &ValidationError{Message: message, Err: err}
+}
+
+// IsValidationError reports whether err is a validation error.
+func IsValidationError(err error) bool {
+	var target *ValidationError
+	return errors.As(err, &target)
+}
+
+// NormalizeInput validates and normalizes one user-supplied selector.
+func NormalizeInput(catalog Catalog, raw string) (Selector, error) {
+	return NormalizeInputWithProviderNames(ProviderNames(catalog), raw)
+}
+
+// NormalizeInputWithProviderNames validates and normalizes one user-supplied selector.
+func NormalizeInputWithProviderNames(providerNames []string, raw string) (Selector, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return Selector{}, NewValidationError("selector is required", nil)
+	}
+	if IsGlobal(raw) {
+		return Selector{Selector: "/"}, nil
+	}
+
+	providerNameSet := make(map[string]struct{}, len(providerNames))
+	for _, name := range providerNames {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		providerNameSet[name] = struct{}{}
+	}
+
+	var providerName, model string
+	if prefix, rest, ok := splitFirst(raw); ok {
+		if _, exists := providerNameSet[prefix]; exists {
+			providerName = prefix
+			model = rest
+		} else {
+			model = raw
+		}
+	} else {
+		model = raw
+	}
+
+	if providerName == "" && model == "" {
+		return Selector{}, NewValidationError("selector is required", nil)
+	}
+	if providerName != "" {
+		if _, exists := providerNameSet[providerName]; !exists {
+			return Selector{}, NewValidationError("unknown provider_name: "+providerName, nil)
+		}
+	}
+	return Selector{
+		Selector:     String(providerName, model),
+		ProviderName: providerName,
+		Model:        model,
+	}, nil
+}
+
+// NormalizeStored normalizes selector columns loaded from storage.
+func NormalizeStored(selector, providerName, model string) (Selector, error) {
+	selector = strings.TrimSpace(selector)
+	providerName = strings.TrimSpace(providerName)
+	model = strings.TrimSpace(model)
+	globalSelector := IsGlobal(selector)
+
+	if selector == "" {
+		selector = String(providerName, model)
+	}
+	if selector == "" {
+		return Selector{}, NewValidationError("selector is required", nil)
+	}
+	if providerName == "" && model == "" && !globalSelector {
+		providerName, model = ParseStoredParts(selector)
+	}
+	if providerName == "" && model == "" && !IsGlobal(selector) {
+		return Selector{}, NewValidationError("selector is required", nil)
+	}
+	if normalized := String(providerName, model); normalized != "" {
+		selector = normalized
+	}
+	return Selector{
+		Selector:     selector,
+		ProviderName: providerName,
+		Model:        model,
+	}, nil
+}
+
+// ProviderNames returns a copy of configured provider names from catalog.
+func ProviderNames(catalog Catalog) []string {
+	if catalog == nil {
+		return nil
+	}
+	return append([]string(nil), catalog.ProviderNames()...)
+}
+
+// ScopeKindFor reports the normalized selector scope.
+func ScopeKindFor(selector, providerName, model string) ScopeKind {
+	switch {
+	case IsGlobal(selector):
+		return ScopeGlobal
+	case strings.TrimSpace(providerName) != "" && strings.TrimSpace(model) != "":
+		return ScopeProviderModel
+	case strings.TrimSpace(providerName) != "":
+		return ScopeProvider
+	default:
+		return ScopeModel
+	}
+}
+
+// String returns the canonical selector string for normalized parts.
+func String(providerName, model string) string {
+	providerName = strings.TrimSpace(providerName)
+	model = strings.TrimSpace(model)
+	switch {
+	case providerName != "" && model != "":
+		return providerName + "/" + model
+	case providerName != "":
+		return providerName + "/"
+	case model != "":
+		return model
+	default:
+		return ""
+	}
+}
+
+// IsGlobal reports whether raw selects every provider and model.
+func IsGlobal(raw string) bool {
+	return strings.TrimSpace(raw) == "/"
+}
+
+// ExactMatchKey returns the lookup key used to index exact provider+model overrides.
+// Returns "" when either side is missing — exact matching only applies to fully-qualified pairs.
+func ExactMatchKey(providerName, model string) string {
+	providerName = strings.TrimSpace(providerName)
+	model = strings.TrimSpace(model)
+	if providerName == "" || model == "" {
+		return ""
+	}
+	return providerName + "/" + model
+}
+
+// ParseStoredParts splits a stored selector without a configured-provider catalog.
+func ParseStoredParts(selector string) (providerName, model string) {
+	selector = strings.TrimSpace(selector)
+	if IsGlobal(selector) {
+		return "", ""
+	}
+	if prefix, rest, ok := splitFirst(selector); ok && rest == "" {
+		return prefix, ""
+	}
+	if providerName, model, ok := splitFirst(selector); ok {
+		return providerName, model
+	}
+	return "", selector
+}
+
+func splitFirst(value string) (prefix, rest string, ok bool) {
+	prefix, rest, ok = strings.Cut(value, "/")
+	if !ok {
+		return "", "", false
+	}
+	prefix = strings.TrimSpace(prefix)
+	rest = strings.TrimSpace(rest)
+	return prefix, rest, true
+}

--- a/internal/modelselectors/selectors.go
+++ b/internal/modelselectors/selectors.go
@@ -195,6 +195,9 @@ func ExactMatchKey(providerName, model string) string {
 }
 
 // ParseStoredParts splits a stored selector without a configured-provider catalog.
+// This is a best-effort fallback for old rows. Stores should persist
+// provider_name and model columns because slash-shaped model IDs cannot be
+// distinguished from provider/model selectors without a provider catalog.
 func ParseStoredParts(selector string) (providerName, model string) {
 	selector = strings.TrimSpace(selector)
 	if IsGlobal(selector) {

--- a/internal/modelselectors/selectors.go
+++ b/internal/modelselectors/selectors.go
@@ -203,9 +203,6 @@ func ParseStoredParts(selector string) (providerName, model string) {
 	if IsGlobal(selector) {
 		return "", ""
 	}
-	if prefix, rest, ok := splitFirst(selector); ok && rest == "" {
-		return prefix, ""
-	}
 	if providerName, model, ok := splitFirst(selector); ok {
 		return providerName, model
 	}

--- a/internal/modelselectors/selectors_test.go
+++ b/internal/modelselectors/selectors_test.go
@@ -1,0 +1,319 @@
+package modelselectors
+
+import "testing"
+
+type selectorTestCatalog struct{ names []string }
+
+func (c selectorTestCatalog) ProviderNames() []string { return c.names }
+
+type selectorCase struct {
+	name         string
+	providers    []string
+	raw          string
+	want         Selector
+	wantScope    ScopeKind
+	wantExactKey string
+	wantErr      bool
+}
+
+func TestNormalizeInputWithProviderNames(t *testing.T) {
+	tests := []selectorCase{
+		{name: "empty input", providers: []string{"prov"}, raw: " ", wantErr: true},
+		{name: "global", providers: []string{"prov"}, raw: " / ", want: Selector{Selector: "/"}, wantScope: ScopeGlobal},
+		{name: "provider only", providers: []string{"prov"}, raw: " prov/ ", want: Selector{Selector: "prov/", ProviderName: "prov"}, wantScope: ScopeProvider},
+		{name: "model only", providers: []string{"prov"}, raw: " model ", want: Selector{Selector: "model", Model: "model"}, wantScope: ScopeModel},
+		{
+			name:         "provider model",
+			providers:    []string{"prov"},
+			raw:          " prov/model ",
+			want:         Selector{Selector: "prov/model", ProviderName: "prov", Model: "model"},
+			wantScope:    ScopeProviderModel,
+			wantExactKey: "prov/model",
+		},
+		{
+			name:      "slash-shaped model without provider catalog",
+			raw:       "org/model",
+			want:      Selector{Selector: "org/model", Model: "org/model"},
+			wantScope: ScopeModel,
+		},
+		{
+			name:      "slash-shaped model with unknown provider",
+			providers: []string{"prov"},
+			raw:       "unknown/model",
+			want:      Selector{Selector: "unknown/model", Model: "unknown/model"},
+			wantScope: ScopeModel,
+		},
+		{
+			name:         "trimmed provider names",
+			providers:    []string{" prov "},
+			raw:          "prov/model",
+			want:         Selector{Selector: "prov/model", ProviderName: "prov", Model: "model"},
+			wantScope:    ScopeProviderModel,
+			wantExactKey: "prov/model",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeInputWithProviderNames(tt.providers, tt.raw)
+			assertNormalizeResult(t, got, err, tt)
+		})
+	}
+}
+
+func TestNormalizeInputUsesCatalogProviderNames(t *testing.T) {
+	tests := []struct {
+		name    string
+		catalog Catalog
+		input   selectorCase
+	}{
+		{
+			name:    "nil catalog treats slash input as model id",
+			catalog: nil,
+			input: selectorCase{
+				raw:       "org/model",
+				want:      Selector{Selector: "org/model", Model: "org/model"},
+				wantScope: ScopeModel,
+			},
+		},
+		{
+			name:    "catalog provider creates exact selector",
+			catalog: selectorTestCatalog{names: []string{"prov"}},
+			input: selectorCase{
+				raw:          "prov/model",
+				want:         Selector{Selector: "prov/model", ProviderName: "prov", Model: "model"},
+				wantScope:    ScopeProviderModel,
+				wantExactKey: "prov/model",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeInput(tt.catalog, tt.input.raw)
+			assertNormalizeResult(t, got, err, tt.input)
+		})
+	}
+}
+
+func TestProviderNames(t *testing.T) {
+	if got := ProviderNames(nil); got != nil {
+		t.Fatalf("ProviderNames(nil) = %#v, want nil", got)
+	}
+
+	names := []string{"prov"}
+	got := ProviderNames(selectorTestCatalog{names: names})
+	if len(got) != 1 || got[0] != "prov" {
+		t.Fatalf("ProviderNames() = %#v, want [prov]", got)
+	}
+	got[0] = "changed"
+	if names[0] != "prov" {
+		t.Fatalf("ProviderNames() did not return a copy; original names = %#v", names)
+	}
+}
+
+func TestNormalizeStored(t *testing.T) {
+	tests := []struct {
+		name         string
+		selector     string
+		providerName string
+		model        string
+		input        selectorCase
+	}{
+		{name: "empty stored parts", input: selectorCase{wantErr: true}},
+		{name: "global stored selector", selector: " / ", input: selectorCase{want: Selector{Selector: "/"}, wantScope: ScopeGlobal}},
+		{
+			name:         "provider column without selector",
+			providerName: " prov ",
+			input:        selectorCase{want: Selector{Selector: "prov/", ProviderName: "prov"}, wantScope: ScopeProvider},
+		},
+		{
+			name:  "model column without selector",
+			model: " model ",
+			input: selectorCase{want: Selector{Selector: "model", Model: "model"}, wantScope: ScopeModel},
+		},
+		{
+			name:         "columns override stale selector",
+			selector:     "old",
+			providerName: "prov",
+			model:        "model",
+			input: selectorCase{
+				want:         Selector{Selector: "prov/model", ProviderName: "prov", Model: "model"},
+				wantScope:    ScopeProviderModel,
+				wantExactKey: "prov/model",
+			},
+		},
+		{
+			name:     "legacy provider model selector",
+			selector: "prov/model",
+			input: selectorCase{
+				want:         Selector{Selector: "prov/model", ProviderName: "prov", Model: "model"},
+				wantScope:    ScopeProviderModel,
+				wantExactKey: "prov/model",
+			},
+		},
+		{name: "legacy provider selector", selector: "prov/", input: selectorCase{want: Selector{Selector: "prov/", ProviderName: "prov"}, wantScope: ScopeProvider}},
+		{name: "legacy model selector", selector: "model", input: selectorCase{want: Selector{Selector: "model", Model: "model"}, wantScope: ScopeModel}},
+		{
+			name:     "legacy slash-shaped model is best-effort provider model",
+			selector: "org/model",
+			input: selectorCase{
+				want:         Selector{Selector: "org/model", ProviderName: "org", Model: "model"},
+				wantScope:    ScopeProviderModel,
+				wantExactKey: "org/model",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeStored(tt.selector, tt.providerName, tt.model)
+			assertNormalizeResult(t, got, err, tt.input)
+		})
+	}
+}
+
+func TestParseStoredParts(t *testing.T) {
+	tests := []struct {
+		name         string
+		selector     string
+		wantProvider string
+		wantModel    string
+	}{
+		{name: "empty"},
+		{name: "global", selector: "/"},
+		{name: "provider only", selector: "prov/", wantProvider: "prov"},
+		{name: "provider model", selector: "prov/model", wantProvider: "prov", wantModel: "model"},
+		{name: "model only", selector: "model", wantModel: "model"},
+		{name: "trims parts", selector: " prov / model ", wantProvider: "prov", wantModel: "model"},
+		{name: "slash-shaped model legacy fallback", selector: "org/model/variant", wantProvider: "org", wantModel: "model/variant"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			providerName, model := ParseStoredParts(tt.selector)
+			if providerName != tt.wantProvider || model != tt.wantModel {
+				t.Fatalf("ParseStoredParts() = (%q, %q), want (%q, %q)", providerName, model, tt.wantProvider, tt.wantModel)
+			}
+		})
+	}
+}
+
+func TestSelectorHelpers(t *testing.T) {
+	t.Run("String", func(t *testing.T) {
+		tests := []struct{ name, providerName, model, want string }{
+			{name: "empty"},
+			{name: "provider", providerName: " prov ", want: "prov/"},
+			{name: "model", model: " model ", want: "model"},
+			{name: "provider model", providerName: " prov ", model: " model ", want: "prov/model"},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				if got := String(tt.providerName, tt.model); got != tt.want {
+					t.Fatalf("String() = %q, want %q", got, tt.want)
+				}
+			})
+		}
+	})
+
+	t.Run("IsGlobal", func(t *testing.T) {
+		tests := []struct {
+			raw  string
+			want bool
+		}{{raw: "/", want: true}, {raw: " / ", want: true}, {raw: ""}, {raw: "prov/"}}
+		for _, tt := range tests {
+			if got := IsGlobal(tt.raw); got != tt.want {
+				t.Fatalf("IsGlobal(%q) = %v, want %v", tt.raw, got, tt.want)
+			}
+		}
+	})
+
+	t.Run("ScopeKindFor", func(t *testing.T) {
+		tests := []struct {
+			name         string
+			selector     string
+			providerName string
+			model        string
+			want         ScopeKind
+		}{
+			{name: "global", selector: "/", want: ScopeGlobal},
+			{name: "provider model", providerName: "prov", model: "model", want: ScopeProviderModel},
+			{name: "provider", providerName: "prov", want: ScopeProvider},
+			{name: "model", model: "model", want: ScopeModel},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				if got := ScopeKindFor(tt.selector, tt.providerName, tt.model); got != tt.want {
+					t.Fatalf("ScopeKindFor() = %q, want %q", got, tt.want)
+				}
+			})
+		}
+	})
+
+	t.Run("ExactMatchKey", func(t *testing.T) {
+		tests := []struct{ name, providerName, model, want string }{
+			{name: "empty"},
+			{name: "provider only", providerName: "prov"},
+			{name: "model only", model: "model"},
+			{name: "provider model", providerName: " prov ", model: " model ", want: "prov/model"},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				if got := ExactMatchKey(tt.providerName, tt.model); got != tt.want {
+					t.Fatalf("ExactMatchKey() = %q, want %q", got, tt.want)
+				}
+			})
+		}
+	})
+
+	t.Run("splitFirst", func(t *testing.T) {
+		tests := []struct {
+			name       string
+			value      string
+			wantPrefix string
+			wantRest   string
+			wantOK     bool
+		}{
+			{name: "no slash", value: "model"},
+			{name: "provider only", value: " prov / ", wantPrefix: "prov", wantOK: true},
+			{name: "provider model", value: " prov / model ", wantPrefix: "prov", wantRest: "model", wantOK: true},
+			{name: "first slash only", value: "org/model/variant", wantPrefix: "org", wantRest: "model/variant", wantOK: true},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				prefix, rest, ok := splitFirst(tt.value)
+				if prefix != tt.wantPrefix || rest != tt.wantRest || ok != tt.wantOK {
+					t.Fatalf("splitFirst() = (%q, %q, %v), want (%q, %q, %v)", prefix, rest, ok, tt.wantPrefix, tt.wantRest, tt.wantOK)
+				}
+			})
+		}
+	})
+}
+
+func assertNormalizeResult(t *testing.T, got Selector, err error, tt selectorCase) {
+	t.Helper()
+	if tt.wantErr {
+		if err == nil {
+			t.Fatal("normalize error = nil, want error")
+		}
+		if !IsValidationError(err) {
+			t.Fatalf("normalize error = %T %v, want validation error", err, err)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("normalize error = %v", err)
+	}
+	if got != tt.want {
+		t.Fatalf("selector = %+v, want %+v", got, tt.want)
+	}
+	if got.Selector != String(got.ProviderName, got.Model) && !IsGlobal(got.Selector) {
+		t.Fatalf("selector string = %q, want canonical %q", got.Selector, String(got.ProviderName, got.Model))
+	}
+	if scope := ScopeKindFor(got.Selector, got.ProviderName, got.Model); scope != tt.wantScope {
+		t.Fatalf("scope = %q, want %q", scope, tt.wantScope)
+	}
+	if key := ExactMatchKey(got.ProviderName, got.Model); key != tt.wantExactKey {
+		t.Fatalf("exact key = %q, want %q", key, tt.wantExactKey)
+	}
+}

--- a/internal/pricingoverrides/factory.go
+++ b/internal/pricingoverrides/factory.go
@@ -1,0 +1,120 @@
+package pricingoverrides
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+
+	"gomodel/config"
+	"gomodel/internal/storage"
+	"gomodel/internal/usage"
+)
+
+// Result holds the initialized pricing override service and any owned resources.
+type Result struct {
+	Service *Service
+	Store   Store
+	Storage storage.Storage
+
+	stopRefresh func()
+	closeOnce   sync.Once
+	closeErr    error
+}
+
+// Close releases resources held by the pricing override subsystem.
+func (r *Result) Close() error {
+	if r == nil {
+		return nil
+	}
+	r.closeOnce.Do(func() {
+		if r.stopRefresh != nil {
+			r.stopRefresh()
+			r.stopRefresh = nil
+		}
+
+		var errs []error
+		if r.Store != nil {
+			if err := r.Store.Close(); err != nil {
+				errs = append(errs, fmt.Errorf("store close: %w", err))
+			}
+		}
+		if r.Storage != nil {
+			if err := r.Storage.Close(); err != nil {
+				errs = append(errs, fmt.Errorf("storage close: %w", err))
+			}
+		}
+		if len(errs) > 0 {
+			r.closeErr = fmt.Errorf("close errors: %w", errors.Join(errs...))
+		}
+	})
+	return r.closeErr
+}
+
+// New creates a pricing override subsystem with its own storage connection.
+func New(ctx context.Context, cfg *config.Config, catalog Catalog, base usage.PricingResolver) (*Result, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config is required")
+	}
+	storeConn, err := storage.New(ctx, cfg.Storage.BackendConfig())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create storage: %w", err)
+	}
+	result, err := newResult(ctx, cfg, storeConn, catalog, base)
+	if err != nil {
+		_ = storeConn.Close()
+		return nil, err
+	}
+	result.Storage = storeConn
+	return result, nil
+}
+
+// NewWithSharedStorage creates a pricing override subsystem using an existing storage connection.
+func NewWithSharedStorage(ctx context.Context, cfg *config.Config, shared storage.Storage, catalog Catalog, base usage.PricingResolver) (*Result, error) {
+	if shared == nil {
+		return nil, fmt.Errorf("shared storage is required")
+	}
+	if cfg == nil {
+		return nil, fmt.Errorf("config is required")
+	}
+	return newResult(ctx, cfg, shared, catalog, base)
+}
+
+func newResult(ctx context.Context, cfg *config.Config, storeConn storage.Storage, catalog Catalog, base usage.PricingResolver) (*Result, error) {
+	store, err := createStore(ctx, storeConn)
+	if err != nil {
+		return nil, err
+	}
+	service, err := NewService(store, catalog, base)
+	if err != nil {
+		return nil, err
+	}
+	if err := service.Refresh(ctx); err != nil {
+		return nil, err
+	}
+
+	refreshInterval := time.Minute
+	if cfg.Workflows.RefreshInterval > 0 {
+		refreshInterval = cfg.Workflows.RefreshInterval
+	}
+
+	return &Result{
+		Service:     service,
+		Store:       store,
+		stopRefresh: service.StartBackgroundRefresh(refreshInterval),
+	}, nil
+}
+
+func createStore(ctx context.Context, store storage.Storage) (Store, error) {
+	return storage.ResolveBackend[Store](
+		store,
+		func(db *sql.DB) (Store, error) { return NewSQLiteStore(db) },
+		func(pool *pgxpool.Pool) (Store, error) { return NewPostgreSQLStore(ctx, pool) },
+		func(db *mongo.Database) (Store, error) { return NewMongoDBStore(db) },
+	)
+}

--- a/internal/pricingoverrides/pricing.go
+++ b/internal/pricingoverrides/pricing.go
@@ -1,0 +1,146 @@
+package pricingoverrides
+
+import (
+	"gomodel/internal/core"
+)
+
+func clonePricing(p Pricing) Pricing {
+	out := p
+	out.InputPerMtok = cloneFloatPtr(p.InputPerMtok)
+	out.OutputPerMtok = cloneFloatPtr(p.OutputPerMtok)
+	out.CachedInputPerMtok = cloneFloatPtr(p.CachedInputPerMtok)
+	out.CacheWritePerMtok = cloneFloatPtr(p.CacheWritePerMtok)
+	out.ReasoningOutputPerMtok = cloneFloatPtr(p.ReasoningOutputPerMtok)
+	out.BatchInputPerMtok = cloneFloatPtr(p.BatchInputPerMtok)
+	out.BatchOutputPerMtok = cloneFloatPtr(p.BatchOutputPerMtok)
+	out.AudioInputPerMtok = cloneFloatPtr(p.AudioInputPerMtok)
+	out.AudioOutputPerMtok = cloneFloatPtr(p.AudioOutputPerMtok)
+	out.PerImage = cloneFloatPtr(p.PerImage)
+	out.InputPerImage = cloneFloatPtr(p.InputPerImage)
+	out.PerSecondInput = cloneFloatPtr(p.PerSecondInput)
+	out.PerSecondOutput = cloneFloatPtr(p.PerSecondOutput)
+	out.PerCharacterInput = cloneFloatPtr(p.PerCharacterInput)
+	out.PerRequest = cloneFloatPtr(p.PerRequest)
+	out.PerPage = cloneFloatPtr(p.PerPage)
+	if len(p.Tiers) > 0 {
+		out.Tiers = make([]PricingTier, len(p.Tiers))
+		for i, tier := range p.Tiers {
+			out.Tiers[i] = PricingTier{
+				UpToTokens:    cloneFloatPtr(tier.UpToTokens),
+				UpToMtok:      cloneFloatPtr(tier.UpToMtok),
+				InputPerMtok:  cloneFloatPtr(tier.InputPerMtok),
+				OutputPerMtok: cloneFloatPtr(tier.OutputPerMtok),
+			}
+		}
+	} else {
+		out.Tiers = nil
+	}
+	return out
+}
+
+func pricingEmpty(p Pricing) bool {
+	if p.InputPerMtok != nil ||
+		p.OutputPerMtok != nil ||
+		p.CachedInputPerMtok != nil ||
+		p.CacheWritePerMtok != nil ||
+		p.ReasoningOutputPerMtok != nil ||
+		p.BatchInputPerMtok != nil ||
+		p.BatchOutputPerMtok != nil ||
+		p.AudioInputPerMtok != nil ||
+		p.AudioOutputPerMtok != nil ||
+		p.PerImage != nil ||
+		p.InputPerImage != nil ||
+		p.PerSecondInput != nil ||
+		p.PerSecondOutput != nil ||
+		p.PerCharacterInput != nil ||
+		p.PerRequest != nil ||
+		p.PerPage != nil {
+		return false
+	}
+	return len(p.Tiers) == 0
+}
+
+func overrideClone(override Override) Override {
+	override.Pricing = clonePricing(override.Pricing)
+	return override
+}
+
+func cloneFloatPtr(v *float64) *float64 {
+	if v == nil {
+		return nil
+	}
+	out := *v
+	return &out
+}
+
+func pricingToCore(p Pricing) *core.ModelPricing {
+	out := &core.ModelPricing{
+		Currency:               CurrencyUSD,
+		InputPerMtok:           cloneFloatPtr(p.InputPerMtok),
+		OutputPerMtok:          cloneFloatPtr(p.OutputPerMtok),
+		CachedInputPerMtok:     cloneFloatPtr(p.CachedInputPerMtok),
+		CacheWritePerMtok:      cloneFloatPtr(p.CacheWritePerMtok),
+		ReasoningOutputPerMtok: cloneFloatPtr(p.ReasoningOutputPerMtok),
+		BatchInputPerMtok:      cloneFloatPtr(p.BatchInputPerMtok),
+		BatchOutputPerMtok:     cloneFloatPtr(p.BatchOutputPerMtok),
+		AudioInputPerMtok:      cloneFloatPtr(p.AudioInputPerMtok),
+		AudioOutputPerMtok:     cloneFloatPtr(p.AudioOutputPerMtok),
+		PerImage:               cloneFloatPtr(p.PerImage),
+		InputPerImage:          cloneFloatPtr(p.InputPerImage),
+		PerSecondInput:         cloneFloatPtr(p.PerSecondInput),
+		PerSecondOutput:        cloneFloatPtr(p.PerSecondOutput),
+		PerCharacterInput:      cloneFloatPtr(p.PerCharacterInput),
+		PerRequest:             cloneFloatPtr(p.PerRequest),
+		PerPage:                cloneFloatPtr(p.PerPage),
+	}
+	if len(p.Tiers) > 0 {
+		out.Tiers = make([]core.ModelPricingTier, len(p.Tiers))
+		for i, tier := range p.Tiers {
+			out.Tiers[i] = core.ModelPricingTier{
+				UpToTokens:    cloneFloatPtr(tier.UpToTokens),
+				UpToMtok:      cloneFloatPtr(tier.UpToMtok),
+				InputPerMtok:  cloneFloatPtr(tier.InputPerMtok),
+				OutputPerMtok: cloneFloatPtr(tier.OutputPerMtok),
+			}
+		}
+	}
+	return out
+}
+
+func mergePricing(base *core.ModelPricing, override Pricing) *core.ModelPricing {
+	var out *core.ModelPricing
+	if base != nil {
+		out = base.Clone()
+	} else {
+		out = &core.ModelPricing{}
+	}
+	out.Currency = CurrencyUSD
+
+	overlay := pricingToCore(override)
+	applyFloatOverride(&out.InputPerMtok, overlay.InputPerMtok)
+	applyFloatOverride(&out.OutputPerMtok, overlay.OutputPerMtok)
+	applyFloatOverride(&out.CachedInputPerMtok, overlay.CachedInputPerMtok)
+	applyFloatOverride(&out.CacheWritePerMtok, overlay.CacheWritePerMtok)
+	applyFloatOverride(&out.ReasoningOutputPerMtok, overlay.ReasoningOutputPerMtok)
+	applyFloatOverride(&out.BatchInputPerMtok, overlay.BatchInputPerMtok)
+	applyFloatOverride(&out.BatchOutputPerMtok, overlay.BatchOutputPerMtok)
+	applyFloatOverride(&out.AudioInputPerMtok, overlay.AudioInputPerMtok)
+	applyFloatOverride(&out.AudioOutputPerMtok, overlay.AudioOutputPerMtok)
+	applyFloatOverride(&out.PerImage, overlay.PerImage)
+	applyFloatOverride(&out.InputPerImage, overlay.InputPerImage)
+	applyFloatOverride(&out.PerSecondInput, overlay.PerSecondInput)
+	applyFloatOverride(&out.PerSecondOutput, overlay.PerSecondOutput)
+	applyFloatOverride(&out.PerCharacterInput, overlay.PerCharacterInput)
+	applyFloatOverride(&out.PerRequest, overlay.PerRequest)
+	applyFloatOverride(&out.PerPage, overlay.PerPage)
+	if len(overlay.Tiers) > 0 {
+		out.Tiers = overlay.Tiers
+	}
+	return out
+}
+
+func applyFloatOverride(target **float64, value *float64) {
+	if value != nil {
+		*target = cloneFloatPtr(value)
+	}
+}

--- a/internal/pricingoverrides/resolver.go
+++ b/internal/pricingoverrides/resolver.go
@@ -11,13 +11,14 @@ func (s *Service) ResolvePricing(model, providerName string) *core.ModelPricing 
 	if s == nil {
 		return nil
 	}
+	providerName = strings.TrimSpace(providerName)
+	model = modelIDFromSelector(model, providerName)
+
 	var basePricing *core.ModelPricing
 	if s.base != nil {
 		basePricing = s.base.ResolvePricing(model, providerName)
 	}
 
-	providerName = strings.TrimSpace(providerName)
-	model = modelIDFromSelector(model, providerName)
 	if rule, ok := s.snapshot().matchingOverride(providerName, model); ok {
 		return mergePricing(basePricing, rule.override.Pricing)
 	}

--- a/internal/pricingoverrides/resolver.go
+++ b/internal/pricingoverrides/resolver.go
@@ -8,12 +8,12 @@ import (
 
 // ResolvePricing resolves base pricing and applies the most specific DB override.
 func (s *Service) ResolvePricing(model, providerName string) *core.ModelPricing {
-	var basePricing *core.ModelPricing
-	if s != nil && s.base != nil {
-		basePricing = s.base.ResolvePricing(model, providerName)
-	}
 	if s == nil {
-		return cloneBasePricing(basePricing)
+		return nil
+	}
+	var basePricing *core.ModelPricing
+	if s.base != nil {
+		basePricing = s.base.ResolvePricing(model, providerName)
 	}
 
 	providerName = strings.TrimSpace(providerName)

--- a/internal/pricingoverrides/resolver.go
+++ b/internal/pricingoverrides/resolver.go
@@ -41,11 +41,5 @@ func modelIDFromSelector(model, providerName string) string {
 	if providerName != "" && strings.HasPrefix(model, providerName+"/") {
 		return strings.TrimSpace(strings.TrimPrefix(model, providerName+"/"))
 	}
-	if providerName == "" {
-		return model
-	}
-	if _, rest, ok := strings.Cut(model, "/"); ok && rest != "" {
-		return strings.TrimSpace(rest)
-	}
 	return model
 }

--- a/internal/pricingoverrides/resolver.go
+++ b/internal/pricingoverrides/resolver.go
@@ -1,0 +1,51 @@
+package pricingoverrides
+
+import (
+	"strings"
+
+	"gomodel/internal/core"
+)
+
+// ResolvePricing resolves base pricing and applies the most specific DB override.
+func (s *Service) ResolvePricing(model, providerName string) *core.ModelPricing {
+	var basePricing *core.ModelPricing
+	if s != nil && s.base != nil {
+		basePricing = s.base.ResolvePricing(model, providerName)
+	}
+	if s == nil {
+		return cloneBasePricing(basePricing)
+	}
+
+	providerName = strings.TrimSpace(providerName)
+	model = modelIDFromSelector(model, providerName)
+	if rule, ok := s.snapshot().matchingOverride(providerName, model); ok {
+		return mergePricing(basePricing, rule.override.Pricing)
+	}
+	return cloneBasePricing(basePricing)
+}
+
+func cloneBasePricing(base *core.ModelPricing) *core.ModelPricing {
+	if base == nil {
+		return nil
+	}
+	cloned := base.Clone()
+	if cloned != nil && strings.TrimSpace(cloned.Currency) == "" {
+		cloned.Currency = CurrencyUSD
+	}
+	return cloned
+}
+
+func modelIDFromSelector(model, providerName string) string {
+	model = strings.TrimSpace(model)
+	providerName = strings.TrimSpace(providerName)
+	if providerName != "" && strings.HasPrefix(model, providerName+"/") {
+		return strings.TrimSpace(strings.TrimPrefix(model, providerName+"/"))
+	}
+	if providerName == "" {
+		return model
+	}
+	if _, rest, ok := strings.Cut(model, "/"); ok && rest != "" {
+		return strings.TrimSpace(rest)
+	}
+	return model
+}

--- a/internal/pricingoverrides/service.go
+++ b/internal/pricingoverrides/service.go
@@ -21,6 +21,8 @@ type Service struct {
 	refreshMu sync.Mutex
 }
 
+const refreshTimeout = 30 * time.Second
+
 // NewService creates a pricing override service backed by storage.
 func NewService(store Store, catalog Catalog, base usage.PricingResolver) (*Service, error) {
 	if store == nil {
@@ -194,10 +196,9 @@ func (s *Service) Delete(ctx context.Context, selector string) error {
 }
 
 // StartBackgroundRefresh periodically reloads pricing overrides from storage until stopped.
+// Each s.Refresh call is capped by refreshTimeout, and shorter intervals are clamped to refreshTimeout.
 func (s *Service) StartBackgroundRefresh(interval time.Duration) func() {
-	if interval <= 0 {
-		interval = time.Minute
-	}
+	interval = normalizedRefreshInterval(interval)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
@@ -212,7 +213,7 @@ func (s *Service) StartBackgroundRefresh(interval time.Duration) func() {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				refreshCtx, refreshCancel := context.WithTimeout(ctx, 30*time.Second)
+				refreshCtx, refreshCancel := context.WithTimeout(ctx, refreshTimeout)
 				if err := s.Refresh(refreshCtx); err != nil {
 					slog.Error("failed to refresh model pricing overrides", "error", err)
 				}
@@ -227,6 +228,16 @@ func (s *Service) StartBackgroundRefresh(interval time.Duration) func() {
 			<-done
 		})
 	}
+}
+
+func normalizedRefreshInterval(interval time.Duration) time.Duration {
+	if interval <= 0 {
+		return time.Minute
+	}
+	if interval < refreshTimeout {
+		return refreshTimeout
+	}
+	return interval
 }
 
 func rollbackContext() (context.Context, context.CancelFunc) {

--- a/internal/pricingoverrides/service.go
+++ b/internal/pricingoverrides/service.go
@@ -1,0 +1,234 @@
+package pricingoverrides
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"gomodel/internal/modelselectors"
+	"gomodel/internal/usage"
+)
+
+// Service keeps pricing overrides cached in memory and resolves effective pricing.
+type Service struct {
+	store     Store
+	catalog   Catalog
+	base      usage.PricingResolver
+	current   atomic.Value
+	refreshMu sync.Mutex
+}
+
+// NewService creates a pricing override service backed by storage.
+func NewService(store Store, catalog Catalog, base usage.PricingResolver) (*Service, error) {
+	if store == nil {
+		return nil, fmt.Errorf("store is required")
+	}
+	if catalog == nil {
+		return nil, fmt.Errorf("catalog is required")
+	}
+
+	service := &Service{
+		store:   store,
+		catalog: catalog,
+		base:    base,
+	}
+	service.current.Store(emptySnapshot())
+	return service, nil
+}
+
+// Refresh reloads overrides from storage and atomically swaps the snapshot.
+func (s *Service) Refresh(ctx context.Context) error {
+	s.refreshMu.Lock()
+	defer s.refreshMu.Unlock()
+	return s.refreshLocked(ctx)
+}
+
+func (s *Service) refreshLocked(ctx context.Context) error {
+	overrides, err := s.store.List(ctx)
+	if err != nil {
+		return fmt.Errorf("list model pricing overrides: %w", err)
+	}
+	next, err := s.buildSnapshot(overrides)
+	if err != nil {
+		return err
+	}
+	s.current.Store(next)
+	return nil
+}
+
+func (s *Service) snapshot() snapshot {
+	if s == nil {
+		return emptySnapshot()
+	}
+	return s.current.Load().(snapshot)
+}
+
+// List returns all cached overrides sorted by selector.
+func (s *Service) List() []Override {
+	snap := s.snapshot()
+	result := make([]Override, 0, len(snap.order))
+	for _, selector := range snap.order {
+		result = append(result, overrideClone(snap.bySelector[selector]))
+	}
+	return result
+}
+
+// ListViews returns all cached overrides with scope metadata.
+func (s *Service) ListViews() []View {
+	overrides := s.List()
+	result := make([]View, 0, len(overrides))
+	for _, override := range overrides {
+		result = append(result, viewForOverride(override))
+	}
+	return result
+}
+
+// GetView returns one cached override with scope metadata by normalized selector.
+func (s *Service) GetView(selector string) (*View, bool) {
+	override, ok := s.Get(selector)
+	if !ok || override == nil {
+		return nil, false
+	}
+	view := viewForOverride(*override)
+	return &view, true
+}
+
+func viewForOverride(override Override) View {
+	return View{
+		Override:  override,
+		ScopeKind: override.ScopeKind(),
+	}
+}
+
+// Get returns one cached override by normalized selector.
+func (s *Service) Get(selector string) (*Override, bool) {
+	parts, err := modelselectors.NormalizeInput(s.catalog, selector)
+	if err != nil {
+		return nil, false
+	}
+	override, ok := s.snapshot().bySelector[parts.Selector]
+	if !ok {
+		return nil, false
+	}
+	override = overrideClone(override)
+	return &override, true
+}
+
+// Upsert validates and stores one override, then refreshes the in-memory snapshot.
+func (s *Service) Upsert(ctx context.Context, override Override) error {
+	if s == nil {
+		return fmt.Errorf("model pricing override service is required")
+	}
+
+	normalized, err := normalizeOverrideInput(s.catalog, override)
+	if err != nil {
+		return err
+	}
+
+	s.refreshMu.Lock()
+	defer s.refreshMu.Unlock()
+
+	current := s.snapshot()
+	if _, err := s.buildSnapshot(upsertOverride(snapshotOverrides(current), normalized)); err != nil {
+		return fmt.Errorf("validate model pricing overrides: %w", err)
+	}
+	previous, existed := current.bySelector[normalized.Selector]
+	if err := s.store.Upsert(ctx, normalized); err != nil {
+		return fmt.Errorf("upsert model pricing override: %w", err)
+	}
+	if err := s.refreshLocked(ctx); err != nil {
+		rollbackCtx, cancel := rollbackContext()
+		defer cancel()
+
+		var rollbackErr error
+		if existed {
+			rollbackErr = s.store.Upsert(rollbackCtx, previous)
+		} else {
+			rollbackErr = s.store.Delete(rollbackCtx, normalized.Selector)
+		}
+		if rollbackErr != nil {
+			return fmt.Errorf("refresh model pricing overrides: %w (rollback failed: %v)", err, rollbackErr)
+		}
+		return fmt.Errorf("refresh model pricing overrides: %w", err)
+	}
+	return nil
+}
+
+// Delete removes one override and refreshes the in-memory snapshot.
+func (s *Service) Delete(ctx context.Context, selector string) error {
+	if s == nil {
+		return fmt.Errorf("model pricing override service is required")
+	}
+
+	parts, err := modelselectors.NormalizeInput(s.catalog, selector)
+	if err != nil {
+		return err
+	}
+
+	s.refreshMu.Lock()
+	defer s.refreshMu.Unlock()
+
+	current := s.snapshot()
+	if _, err := s.buildSnapshot(deleteOverride(snapshotOverrides(current), parts.Selector)); err != nil {
+		return fmt.Errorf("validate model pricing overrides: %w", err)
+	}
+	previous, existed := current.bySelector[parts.Selector]
+	if err := s.store.Delete(ctx, parts.Selector); err != nil {
+		return fmt.Errorf("delete model pricing override: %w", err)
+	}
+	if err := s.refreshLocked(ctx); err != nil {
+		if !existed {
+			return fmt.Errorf("refresh model pricing overrides: %w", err)
+		}
+		rollbackCtx, cancel := rollbackContext()
+		defer cancel()
+		if rollbackErr := s.store.Upsert(rollbackCtx, previous); rollbackErr != nil {
+			return fmt.Errorf("refresh model pricing overrides: %w (rollback failed: %v)", err, rollbackErr)
+		}
+		return fmt.Errorf("refresh model pricing overrides: %w", err)
+	}
+	return nil
+}
+
+// StartBackgroundRefresh periodically reloads pricing overrides from storage until stopped.
+func (s *Service) StartBackgroundRefresh(interval time.Duration) func() {
+	if interval <= 0 {
+		interval = time.Minute
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	var once sync.Once
+
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				refreshCtx, refreshCancel := context.WithTimeout(ctx, 30*time.Second)
+				if err := s.Refresh(refreshCtx); err != nil {
+					slog.Error("failed to refresh model pricing overrides", "error", err)
+				}
+				refreshCancel()
+			}
+		}
+	}()
+
+	return func() {
+		once.Do(func() {
+			cancel()
+			<-done
+		})
+	}
+}
+
+func rollbackContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), 30*time.Second)
+}

--- a/internal/pricingoverrides/service.go
+++ b/internal/pricingoverrides/service.go
@@ -182,6 +182,8 @@ func (s *Service) Delete(ctx context.Context, selector string) error {
 		return fmt.Errorf("delete model pricing override: %w", err)
 	}
 	if err := s.refreshLocked(ctx); err != nil {
+		// If the selector was absent from the snapshot, there is no known previous
+		// value to restore, so we intentionally skip rollback.
 		if !existed {
 			return fmt.Errorf("refresh model pricing overrides: %w", err)
 		}
@@ -240,8 +242,10 @@ func normalizedRefreshInterval(interval time.Duration) time.Duration {
 	return interval
 }
 
+// rollbackContext deliberately uses context.Background with context.WithTimeout
+// so cleanup can continue briefly even when the caller's request context is canceled.
 func rollbackContext() (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.Background(), 30*time.Second)
+	return context.WithTimeout(context.Background(), refreshTimeout)
 }
 
 func (s *Service) reconcileSnapshotAfterRollbackFailureLocked(operation string, refreshErr, rollbackErr error) error {

--- a/internal/pricingoverrides/service.go
+++ b/internal/pricingoverrides/service.go
@@ -150,7 +150,7 @@ func (s *Service) Upsert(ctx context.Context, override Override) error {
 			rollbackErr = s.store.Delete(rollbackCtx, normalized.Selector)
 		}
 		if rollbackErr != nil {
-			return fmt.Errorf("refresh model pricing overrides: %w (rollback failed: %v)", err, rollbackErr)
+			return s.reconcileSnapshotAfterRollbackFailureLocked("upsert", err, rollbackErr)
 		}
 		return fmt.Errorf("refresh model pricing overrides: %w", err)
 	}
@@ -186,7 +186,7 @@ func (s *Service) Delete(ctx context.Context, selector string) error {
 		rollbackCtx, cancel := rollbackContext()
 		defer cancel()
 		if rollbackErr := s.store.Upsert(rollbackCtx, previous); rollbackErr != nil {
-			return fmt.Errorf("refresh model pricing overrides: %w (rollback failed: %v)", err, rollbackErr)
+			return s.reconcileSnapshotAfterRollbackFailureLocked("delete", err, rollbackErr)
 		}
 		return fmt.Errorf("refresh model pricing overrides: %w", err)
 	}
@@ -231,4 +231,28 @@ func (s *Service) StartBackgroundRefresh(interval time.Duration) func() {
 
 func rollbackContext() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), 30*time.Second)
+}
+
+func (s *Service) reconcileSnapshotAfterRollbackFailureLocked(operation string, refreshErr, rollbackErr error) error {
+	reconcileCtx, cancel := rollbackContext()
+	defer cancel()
+
+	if reconcileErr := s.refreshLocked(reconcileCtx); reconcileErr != nil {
+		slog.Warn(
+			"model pricing override snapshot may be stale after failed rollback",
+			"operation", operation,
+			"refresh_error", refreshErr,
+			"rollback_error", rollbackErr,
+			"reconcile_error", reconcileErr,
+		)
+		return fmt.Errorf("refresh model pricing overrides: %w (rollback failed: %v; snapshot refresh failed: %v)", refreshErr, rollbackErr, reconcileErr)
+	}
+
+	slog.Warn(
+		"model pricing override rollback failed; refreshed snapshot from persisted state",
+		"operation", operation,
+		"refresh_error", refreshErr,
+		"rollback_error", rollbackErr,
+	)
+	return fmt.Errorf("refresh model pricing overrides: %w (rollback failed: %v)", refreshErr, rollbackErr)
 }

--- a/internal/pricingoverrides/service_test.go
+++ b/internal/pricingoverrides/service_test.go
@@ -3,7 +3,9 @@ package pricingoverrides
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	"gomodel/internal/core"
 )
@@ -332,5 +334,46 @@ func TestServiceReconcilesSnapshotWhenDeleteRollbackFails(t *testing.T) {
 
 	if _, ok := service.Get("openai/gpt-4o"); ok {
 		t.Fatal("Get() found deleted override after rollback failure, want reconciled persisted state")
+	}
+}
+
+func TestServiceBuildSnapshotRejectsDuplicateNormalizedSelectors(t *testing.T) {
+	service, err := NewService(newTestStore(), testCatalog{providerNames: []string{"openai"}}, nil)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	_, err = service.buildSnapshot([]Override{
+		{Selector: "openai/gpt-4o", ProviderName: "openai", Model: "gpt-4o", Pricing: Pricing{InputPerMtok: ptr(1)}},
+		{Selector: " openai/gpt-4o ", ProviderName: "openai", Model: "gpt-4o", Pricing: Pricing{InputPerMtok: ptr(2)}},
+	})
+	if err == nil {
+		t.Fatal("buildSnapshot() error = nil, want duplicate selector error")
+	}
+	if !strings.Contains(err.Error(), `duplicate model pricing override selector "openai/gpt-4o"`) ||
+		!strings.Contains(err.Error(), `stored selector " openai/gpt-4o "`) {
+		t.Fatalf("buildSnapshot() error = %v, want normalized and original selector details", err)
+	}
+}
+
+func TestNormalizedRefreshIntervalClampsBelowRefreshTimeout(t *testing.T) {
+	tests := []struct {
+		name     string
+		interval time.Duration
+		want     time.Duration
+	}{
+		{name: "default", interval: 0, want: time.Minute},
+		{name: "negative default", interval: -time.Second, want: time.Minute},
+		{name: "below timeout", interval: time.Second, want: refreshTimeout},
+		{name: "at timeout", interval: refreshTimeout, want: refreshTimeout},
+		{name: "above timeout", interval: time.Minute, want: time.Minute},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizedRefreshInterval(tt.interval); got != tt.want {
+				t.Fatalf("normalizedRefreshInterval(%s) = %s, want %s", tt.interval, got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/pricingoverrides/service_test.go
+++ b/internal/pricingoverrides/service_test.go
@@ -2,13 +2,17 @@ package pricingoverrides
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"gomodel/internal/core"
 )
 
 type testStore struct {
-	items map[string]Override
+	items     map[string]Override
+	listErrs  []error
+	upsertErr error
+	deleteErr error
 }
 
 func newTestStore(items ...Override) *testStore {
@@ -20,6 +24,13 @@ func newTestStore(items ...Override) *testStore {
 }
 
 func (s *testStore) List(_ context.Context) ([]Override, error) {
+	if len(s.listErrs) > 0 {
+		err := s.listErrs[0]
+		s.listErrs = s.listErrs[1:]
+		if err != nil {
+			return nil, err
+		}
+	}
 	result := make([]Override, 0, len(s.items))
 	for _, item := range s.items {
 		result = append(result, item)
@@ -28,11 +39,17 @@ func (s *testStore) List(_ context.Context) ([]Override, error) {
 }
 
 func (s *testStore) Upsert(_ context.Context, override Override) error {
+	if s.upsertErr != nil {
+		return s.upsertErr
+	}
 	s.items[override.Selector] = override
 	return nil
 }
 
 func (s *testStore) Delete(_ context.Context, selector string) error {
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
 	if _, ok := s.items[selector]; !ok {
 		return ErrNotFound
 	}
@@ -225,6 +242,12 @@ func TestServiceRejectsInvalidTieredPricing(t *testing.T) {
 			}},
 		},
 		{
+			name: "both threshold units",
+			pricing: Pricing{Tiers: []PricingTier{
+				{UpToTokens: ptr(1000), UpToMtok: ptr(1), InputPerMtok: ptr(1)},
+			}},
+		},
+		{
 			name: "negative tier rate",
 			pricing: Pricing{Tiers: []PricingTier{
 				{UpToTokens: ptr(1000), InputPerMtok: ptr(-1)},
@@ -259,5 +282,55 @@ func TestServiceAcceptsIncreasingTieredPricing(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("Upsert(valid tiers) error = %v", err)
+	}
+}
+
+func TestServiceReconcilesSnapshotWhenUpsertRollbackFails(t *testing.T) {
+	store := newTestStore()
+	service, err := NewService(store, testCatalog{providerNames: []string{"openai"}}, nil)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	store.listErrs = []error{errors.New("list failed"), nil}
+	store.deleteErr = errors.New("rollback delete failed")
+	err = service.Upsert(context.Background(), Override{
+		Selector: "openai/gpt-4o",
+		Pricing:  Pricing{InputPerMtok: ptr(9)},
+	})
+	if err == nil {
+		t.Fatal("Upsert() error = nil, want refresh/rollback error")
+	}
+
+	pricing := service.ResolvePricing("gpt-4o", "openai")
+	if pricing == nil || pricing.InputPerMtok == nil || *pricing.InputPerMtok != 9 {
+		t.Fatalf("ResolvePricing() = %+v, want reconciled persisted override", pricing)
+	}
+}
+
+func TestServiceReconcilesSnapshotWhenDeleteRollbackFails(t *testing.T) {
+	store := newTestStore(Override{
+		Selector:     "openai/gpt-4o",
+		ProviderName: "openai",
+		Model:        "gpt-4o",
+		Pricing:      Pricing{InputPerMtok: ptr(9)},
+	})
+	service, err := NewService(store, testCatalog{providerNames: []string{"openai"}}, nil)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	store.listErrs = []error{errors.New("list failed"), nil}
+	store.upsertErr = errors.New("rollback upsert failed")
+	err = service.Delete(context.Background(), "openai/gpt-4o")
+	if err == nil {
+		t.Fatal("Delete() error = nil, want refresh/rollback error")
+	}
+
+	if _, ok := service.Get("openai/gpt-4o"); ok {
+		t.Fatal("Get() found deleted override after rollback failure, want reconciled persisted state")
 	}
 }

--- a/internal/pricingoverrides/service_test.go
+++ b/internal/pricingoverrides/service_test.go
@@ -122,6 +122,56 @@ func TestServiceResolvePricingModelWideBeatsProviderWide(t *testing.T) {
 	}
 }
 
+func TestServiceResolvePricingPreservesSlashShapedModelIDs(t *testing.T) {
+	service, err := NewService(
+		newTestStore(
+			Override{Selector: "openrouter/", Pricing: Pricing{InputPerMtok: ptr(20)}},
+			Override{Selector: "anthropic/claude-sonnet", Pricing: Pricing{InputPerMtok: ptr(30)}},
+			Override{Selector: "openrouter/anthropic/claude-sonnet", Pricing: Pricing{InputPerMtok: ptr(40)}},
+		),
+		testCatalog{providerNames: []string{"openrouter"}},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	pricing := service.ResolvePricing("anthropic/claude-sonnet", "openrouter")
+	if pricing == nil || pricing.InputPerMtok == nil || *pricing.InputPerMtok != 40 {
+		t.Fatalf("ResolvePricing(slash-shaped exact) = %+v, want exact input rate 40", pricing)
+	}
+
+	pricing = service.ResolvePricing("openrouter/anthropic/claude-sonnet", "openrouter")
+	if pricing == nil || pricing.InputPerMtok == nil || *pricing.InputPerMtok != 40 {
+		t.Fatalf("ResolvePricing(redundant provider prefix) = %+v, want exact input rate 40", pricing)
+	}
+}
+
+func TestServiceResolvePricingSlashShapedModelWideBeatsProviderWide(t *testing.T) {
+	service, err := NewService(
+		newTestStore(
+			Override{Selector: "openrouter/", Pricing: Pricing{InputPerMtok: ptr(20)}},
+			Override{Selector: "anthropic/claude-sonnet", Model: "anthropic/claude-sonnet", Pricing: Pricing{InputPerMtok: ptr(30)}},
+		),
+		testCatalog{providerNames: []string{"openrouter"}},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	pricing := service.ResolvePricing("anthropic/claude-sonnet", "openrouter")
+	if pricing == nil || pricing.InputPerMtok == nil || *pricing.InputPerMtok != 30 {
+		t.Fatalf("ResolvePricing(slash-shaped model-wide) = %+v, want model-wide input rate 30", pricing)
+	}
+}
+
 func TestServiceRejectsEmptyAndNegativePricing(t *testing.T) {
 	service, err := NewService(newTestStore(), testCatalog{providerNames: []string{"openai"}}, nil)
 	if err != nil {

--- a/internal/pricingoverrides/service_test.go
+++ b/internal/pricingoverrides/service_test.go
@@ -3,7 +3,6 @@ package pricingoverrides
 import (
 	"context"
 	"errors"
-	"strings"
 	"testing"
 	"time"
 
@@ -350,9 +349,14 @@ func TestServiceBuildSnapshotRejectsDuplicateNormalizedSelectors(t *testing.T) {
 	if err == nil {
 		t.Fatal("buildSnapshot() error = nil, want duplicate selector error")
 	}
-	if !strings.Contains(err.Error(), `duplicate model pricing override selector "openai/gpt-4o"`) ||
-		!strings.Contains(err.Error(), `stored selector " openai/gpt-4o "`) {
-		t.Fatalf("buildSnapshot() error = %v, want normalized and original selector details", err)
+	var duplicateErr *DuplicateSelectorError
+	if !errors.As(err, &duplicateErr) {
+		t.Fatalf("buildSnapshot() error = %T %v, want *DuplicateSelectorError", err, err)
+	}
+	if duplicateErr.Normalized != "openai/gpt-4o" ||
+		duplicateErr.Original != " openai/gpt-4o " ||
+		duplicateErr.Existing != "openai/gpt-4o" {
+		t.Fatalf("DuplicateSelectorError = %+v, want normalized/original/existing selector details", duplicateErr)
 	}
 }
 

--- a/internal/pricingoverrides/service_test.go
+++ b/internal/pricingoverrides/service_test.go
@@ -1,0 +1,213 @@
+package pricingoverrides
+
+import (
+	"context"
+	"testing"
+
+	"gomodel/internal/core"
+)
+
+type testStore struct {
+	items map[string]Override
+}
+
+func newTestStore(items ...Override) *testStore {
+	store := &testStore{items: make(map[string]Override, len(items))}
+	for _, item := range items {
+		store.items[item.Selector] = item
+	}
+	return store
+}
+
+func (s *testStore) List(_ context.Context) ([]Override, error) {
+	result := make([]Override, 0, len(s.items))
+	for _, item := range s.items {
+		result = append(result, item)
+	}
+	return result, nil
+}
+
+func (s *testStore) Upsert(_ context.Context, override Override) error {
+	s.items[override.Selector] = override
+	return nil
+}
+
+func (s *testStore) Delete(_ context.Context, selector string) error {
+	if _, ok := s.items[selector]; !ok {
+		return ErrNotFound
+	}
+	delete(s.items, selector)
+	return nil
+}
+
+func (s *testStore) Close() error { return nil }
+
+type testCatalog struct {
+	providerNames []string
+}
+
+func (c testCatalog) ProviderNames() []string {
+	return append([]string(nil), c.providerNames...)
+}
+
+type staticPricingResolver struct {
+	pricing *core.ModelPricing
+}
+
+func (r staticPricingResolver) ResolvePricing(_, _ string) *core.ModelPricing {
+	return r.pricing
+}
+
+func ptr(v float64) *float64 {
+	return &v
+}
+
+func TestServiceResolvePricingAppliesMostSpecificOverride(t *testing.T) {
+	baseInput := 1.0
+	baseOutput := 2.0
+	service, err := NewService(
+		newTestStore(
+			Override{Selector: "/", Pricing: Pricing{InputPerMtok: ptr(10)}},
+			Override{Selector: "openai/", Pricing: Pricing{InputPerMtok: ptr(20)}},
+			Override{Selector: "gpt-4o", Pricing: Pricing{InputPerMtok: ptr(30)}},
+			Override{Selector: "openai/gpt-4o", Pricing: Pricing{InputPerMtok: ptr(40)}},
+		),
+		testCatalog{providerNames: []string{"openai"}},
+		staticPricingResolver{pricing: &core.ModelPricing{
+			InputPerMtok:  &baseInput,
+			OutputPerMtok: &baseOutput,
+		}},
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	pricing := service.ResolvePricing("gpt-4o", "openai")
+	if pricing == nil {
+		t.Fatal("ResolvePricing() = nil")
+	}
+	if pricing.InputPerMtok == nil || *pricing.InputPerMtok != 40 {
+		t.Fatalf("InputPerMtok = %#v, want 40", pricing.InputPerMtok)
+	}
+	if pricing.OutputPerMtok == nil || *pricing.OutputPerMtok != baseOutput {
+		t.Fatalf("OutputPerMtok = %#v, want base %v", pricing.OutputPerMtok, baseOutput)
+	}
+	if pricing.Currency != CurrencyUSD {
+		t.Fatalf("Currency = %q, want %q", pricing.Currency, CurrencyUSD)
+	}
+}
+
+func TestServiceResolvePricingModelWideBeatsProviderWide(t *testing.T) {
+	service, err := NewService(
+		newTestStore(
+			Override{Selector: "openai/", Pricing: Pricing{InputPerMtok: ptr(20)}},
+			Override{Selector: "gpt-4o", Pricing: Pricing{InputPerMtok: ptr(30)}},
+		),
+		testCatalog{providerNames: []string{"openai"}},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	pricing := service.ResolvePricing("gpt-4o", "openai")
+	if pricing == nil || pricing.InputPerMtok == nil || *pricing.InputPerMtok != 30 {
+		t.Fatalf("ResolvePricing() = %+v, want model-wide input rate 30", pricing)
+	}
+}
+
+func TestServiceRejectsEmptyAndNegativePricing(t *testing.T) {
+	service, err := NewService(newTestStore(), testCatalog{providerNames: []string{"openai"}}, nil)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	if err := service.Upsert(context.Background(), Override{Selector: "openai/gpt-4o"}); !IsValidationError(err) {
+		t.Fatalf("Upsert(empty) error = %v, want validation", err)
+	}
+	if err := service.Upsert(context.Background(), Override{
+		Selector: "openai/gpt-4o",
+		Pricing:  Pricing{InputPerMtok: ptr(-1)},
+	}); !IsValidationError(err) {
+		t.Fatalf("Upsert(negative) error = %v, want validation", err)
+	}
+}
+
+func TestServiceRejectsInvalidTieredPricing(t *testing.T) {
+	service, err := NewService(newTestStore(), testCatalog{providerNames: []string{"openai"}}, nil)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	cases := []struct {
+		name    string
+		pricing Pricing
+	}{
+		{
+			name: "missing threshold",
+			pricing: Pricing{Tiers: []PricingTier{
+				{InputPerMtok: ptr(1)},
+			}},
+		},
+		{
+			name: "missing rate",
+			pricing: Pricing{Tiers: []PricingTier{
+				{UpToTokens: ptr(1000)},
+			}},
+		},
+		{
+			name: "non-increasing thresholds",
+			pricing: Pricing{Tiers: []PricingTier{
+				{UpToTokens: ptr(1000), InputPerMtok: ptr(1)},
+				{UpToTokens: ptr(500), InputPerMtok: ptr(2)},
+			}},
+		},
+		{
+			name: "zero threshold",
+			pricing: Pricing{Tiers: []PricingTier{
+				{UpToMtok: ptr(0), InputPerMtok: ptr(1)},
+			}},
+		},
+		{
+			name: "negative tier rate",
+			pricing: Pricing{Tiers: []PricingTier{
+				{UpToTokens: ptr(1000), InputPerMtok: ptr(-1)},
+			}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := service.Upsert(context.Background(), Override{
+				Selector: "openai/gpt-4o",
+				Pricing:  tc.pricing,
+			})
+			if !IsValidationError(err) {
+				t.Fatalf("Upsert(%s) error = %v, want validation", tc.name, err)
+			}
+		})
+	}
+}
+
+func TestServiceAcceptsIncreasingTieredPricing(t *testing.T) {
+	service, err := NewService(newTestStore(), testCatalog{providerNames: []string{"openai"}}, nil)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+
+	err = service.Upsert(context.Background(), Override{
+		Selector: "openai/gpt-4o",
+		Pricing: Pricing{Tiers: []PricingTier{
+			{UpToTokens: ptr(200_000), InputPerMtok: ptr(1)},
+			{UpToMtok: ptr(1), InputPerMtok: ptr(0.5)},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Upsert(valid tiers) error = %v", err)
+	}
+}

--- a/internal/pricingoverrides/snapshot.go
+++ b/internal/pricingoverrides/snapshot.go
@@ -46,12 +46,12 @@ func (s *Service) buildSnapshot(overrides []Override) (snapshot, error) {
 
 		compiled := compiledOverride{override: normalized}
 		switch normalized.ScopeKind() {
-		case ScopeGlobal:
+		case modelselectors.ScopeGlobal:
 			next.global = compiled
 			next.hasGlobal = true
-		case ScopeProviderModel:
+		case modelselectors.ScopeProviderModel:
 			next.exact[modelselectors.ExactMatchKey(normalized.ProviderName, normalized.Model)] = compiled
-		case ScopeProvider:
+		case modelselectors.ScopeProvider:
 			next.providerWide[normalized.ProviderName] = compiled
 		default:
 			next.modelWide[normalized.Model] = compiled

--- a/internal/pricingoverrides/snapshot.go
+++ b/internal/pricingoverrides/snapshot.go
@@ -7,6 +7,20 @@ import (
 	"gomodel/internal/modelselectors"
 )
 
+// DuplicateSelectorError reports two stored rows that normalize to one selector.
+type DuplicateSelectorError struct {
+	Normalized string
+	Original   string
+	Existing   string
+}
+
+func (e *DuplicateSelectorError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("duplicate model pricing override selector %q from stored selector %q collides with stored selector %q", e.Normalized, e.Original, e.Existing)
+}
+
 type compiledOverride struct {
 	override Override
 }
@@ -43,7 +57,11 @@ func (s *Service) buildSnapshot(overrides []Override) (snapshot, error) {
 			return snapshot{}, fmt.Errorf("load model pricing override %q: %w", override.Selector, err)
 		}
 		if original, exists := originalSelectors[normalized.Selector]; exists {
-			return snapshot{}, fmt.Errorf("duplicate model pricing override selector %q from stored selector %q collides with stored selector %q", normalized.Selector, override.Selector, original)
+			return snapshot{}, &DuplicateSelectorError{
+				Normalized: normalized.Selector,
+				Original:   override.Selector,
+				Existing:   original,
+			}
 		}
 		originalSelectors[normalized.Selector] = override.Selector
 		next.order = append(next.order, normalized.Selector)
@@ -58,8 +76,10 @@ func (s *Service) buildSnapshot(overrides []Override) (snapshot, error) {
 			next.exact[modelselectors.ExactMatchKey(normalized.ProviderName, normalized.Model)] = compiled
 		case modelselectors.ScopeProvider:
 			next.providerWide[normalized.ProviderName] = compiled
-		default:
+		case modelselectors.ScopeModel:
 			next.modelWide[normalized.Model] = compiled
+		default:
+			return snapshot{}, fmt.Errorf("unknown model pricing override scope %q for selector %q", normalized.ScopeKind(), normalized.Selector)
 		}
 	}
 	sort.Strings(next.order)

--- a/internal/pricingoverrides/snapshot.go
+++ b/internal/pricingoverrides/snapshot.go
@@ -1,0 +1,113 @@
+package pricingoverrides
+
+import (
+	"fmt"
+	"sort"
+
+	"gomodel/internal/modelselectors"
+)
+
+type compiledOverride struct {
+	override Override
+}
+
+type snapshot struct {
+	order        []string
+	bySelector   map[string]Override
+	global       compiledOverride
+	hasGlobal    bool
+	modelWide    map[string]compiledOverride
+	providerWide map[string]compiledOverride
+	exact        map[string]compiledOverride
+}
+
+func emptySnapshot() snapshot {
+	return snapshot{
+		order:        []string{},
+		bySelector:   map[string]Override{},
+		modelWide:    map[string]compiledOverride{},
+		providerWide: map[string]compiledOverride{},
+		exact:        map[string]compiledOverride{},
+	}
+}
+
+func (s *Service) buildSnapshot(overrides []Override) (snapshot, error) {
+	next := emptySnapshot()
+	next.order = make([]string, 0, len(overrides))
+	next.bySelector = make(map[string]Override, len(overrides))
+
+	for _, override := range overrides {
+		normalized, err := normalizeStoredOverride(override)
+		if err != nil {
+			return snapshot{}, fmt.Errorf("load model pricing override %q: %w", override.Selector, err)
+		}
+		next.order = append(next.order, normalized.Selector)
+		next.bySelector[normalized.Selector] = normalized
+
+		compiled := compiledOverride{override: normalized}
+		switch normalized.ScopeKind() {
+		case ScopeGlobal:
+			next.global = compiled
+			next.hasGlobal = true
+		case ScopeProviderModel:
+			next.exact[modelselectors.ExactMatchKey(normalized.ProviderName, normalized.Model)] = compiled
+		case ScopeProvider:
+			next.providerWide[normalized.ProviderName] = compiled
+		default:
+			next.modelWide[normalized.Model] = compiled
+		}
+	}
+	sort.Strings(next.order)
+	return next, nil
+}
+
+func (snap snapshot) matchingOverride(providerName, model string) (compiledOverride, bool) {
+	if key := modelselectors.ExactMatchKey(providerName, model); key != "" {
+		if exact, ok := snap.exact[key]; ok {
+			return exact, true
+		}
+	}
+	if model != "" {
+		if modelWide, ok := snap.modelWide[model]; ok {
+			return modelWide, true
+		}
+	}
+	if providerName != "" {
+		if providerWide, ok := snap.providerWide[providerName]; ok {
+			return providerWide, true
+		}
+	}
+	if snap.hasGlobal {
+		return snap.global, true
+	}
+	return compiledOverride{}, false
+}
+
+func snapshotOverrides(snap snapshot) []Override {
+	result := make([]Override, 0, len(snap.order))
+	for _, selector := range snap.order {
+		result = append(result, overrideClone(snap.bySelector[selector]))
+	}
+	return result
+}
+
+func upsertOverride(overrides []Override, next Override) []Override {
+	for i := range overrides {
+		if overrides[i].Selector == next.Selector {
+			overrides[i] = overrideClone(next)
+			return overrides
+		}
+	}
+	return append(overrides, overrideClone(next))
+}
+
+func deleteOverride(overrides []Override, selector string) []Override {
+	result := make([]Override, 0, len(overrides))
+	for _, override := range overrides {
+		if override.Selector == selector {
+			continue
+		}
+		result = append(result, overrideClone(override))
+	}
+	return result
+}

--- a/internal/pricingoverrides/snapshot.go
+++ b/internal/pricingoverrides/snapshot.go
@@ -35,12 +35,17 @@ func (s *Service) buildSnapshot(overrides []Override) (snapshot, error) {
 	next := emptySnapshot()
 	next.order = make([]string, 0, len(overrides))
 	next.bySelector = make(map[string]Override, len(overrides))
+	originalSelectors := make(map[string]string, len(overrides))
 
 	for _, override := range overrides {
 		normalized, err := normalizeStoredOverride(override)
 		if err != nil {
 			return snapshot{}, fmt.Errorf("load model pricing override %q: %w", override.Selector, err)
 		}
+		if original, exists := originalSelectors[normalized.Selector]; exists {
+			return snapshot{}, fmt.Errorf("duplicate model pricing override selector %q from stored selector %q collides with stored selector %q", normalized.Selector, override.Selector, original)
+		}
+		originalSelectors[normalized.Selector] = override.Selector
 		next.order = append(next.order, normalized.Selector)
 		next.bySelector[normalized.Selector] = normalized
 

--- a/internal/pricingoverrides/store.go
+++ b/internal/pricingoverrides/store.go
@@ -1,4 +1,4 @@
-package modeloverrides
+package pricingoverrides
 
 import (
 	"context"
@@ -10,8 +10,8 @@ import (
 	"gomodel/internal/modelselectors"
 )
 
-// ErrNotFound indicates a requested override was not found.
-var ErrNotFound = errors.New("model override not found")
+// ErrNotFound indicates a requested pricing override was not found.
+var ErrNotFound = errors.New("model pricing override not found")
 
 // ValidationError indicates invalid override input or invalid override state.
 type ValidationError = modelselectors.ValidationError
@@ -25,7 +25,7 @@ func IsValidationError(err error) bool {
 	return modelselectors.IsValidationError(err)
 }
 
-// Store defines persistence operations for model overrides.
+// Store defines persistence operations for pricing overrides.
 type Store interface {
 	List(ctx context.Context) ([]Override, error)
 	Upsert(ctx context.Context, override Override) error
@@ -46,7 +46,7 @@ func collectOverrides(next func() (Override, bool, error), rowsErr func() error)
 		result = append(result, override)
 	}
 	if err := rowsErr(); err != nil {
-		return nil, fmt.Errorf("iterate model overrides: %w", err)
+		return nil, fmt.Errorf("iterate model pricing overrides: %w", err)
 	}
 	return result, nil
 }
@@ -57,9 +57,9 @@ func prepareOverrideUpsert(override Override) (Override, string, error) {
 		return Override{}, "", err
 	}
 
-	pathsJSON, err := json.Marshal(override.UserPaths)
+	pricingJSON, err := json.Marshal(override.Pricing)
 	if err != nil {
-		return Override{}, "", fmt.Errorf("encode user_paths: %w", err)
+		return Override{}, "", fmt.Errorf("encode pricing: %w", err)
 	}
 
 	now := time.Now().UTC()
@@ -67,5 +67,5 @@ func prepareOverrideUpsert(override Override) (Override, string, error) {
 		override.CreatedAt = now
 	}
 	override.UpdatedAt = now
-	return override, string(pathsJSON), nil
+	return override, string(pricingJSON), nil
 }

--- a/internal/pricingoverrides/store_mongodb.go
+++ b/internal/pricingoverrides/store_mongodb.go
@@ -1,0 +1,127 @@
+package pricingoverrides
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+type mongoOverrideDocument struct {
+	ID           string    `bson:"_id"`
+	ProviderName string    `bson:"provider_name,omitempty"`
+	Model        string    `bson:"model,omitempty"`
+	Pricing      Pricing   `bson:"pricing"`
+	CreatedAt    time.Time `bson:"created_at"`
+	UpdatedAt    time.Time `bson:"updated_at"`
+}
+
+type mongoOverrideIDFilter struct {
+	ID string `bson:"_id"`
+}
+
+// MongoDBStore stores model pricing overrides in MongoDB.
+type MongoDBStore struct {
+	collection *mongo.Collection
+}
+
+// NewMongoDBStore creates collection indexes if needed.
+func NewMongoDBStore(database *mongo.Database) (*MongoDBStore, error) {
+	if database == nil {
+		return nil, fmt.Errorf("database is required")
+	}
+	coll := database.Collection("model_pricing_overrides")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	indexes := []mongo.IndexModel{
+		{Keys: bson.D{{Key: "provider_name", Value: 1}}},
+		{Keys: bson.D{{Key: "model", Value: 1}}},
+		{Keys: bson.D{{Key: "updated_at", Value: -1}}},
+	}
+	if _, err := coll.Indexes().CreateMany(ctx, indexes); err != nil {
+		return nil, fmt.Errorf("create model_pricing_overrides indexes: %w", err)
+	}
+	return &MongoDBStore{collection: coll}, nil
+}
+
+func (s *MongoDBStore) List(ctx context.Context) ([]Override, error) {
+	cursor, err := s.collection.Find(ctx, bson.M{}, options.Find().SetSort(bson.D{{Key: "_id", Value: 1}}))
+	if err != nil {
+		return nil, fmt.Errorf("list model pricing overrides: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	result := make([]Override, 0)
+	for cursor.Next(ctx) {
+		var doc mongoOverrideDocument
+		if err := cursor.Decode(&doc); err != nil {
+			return nil, fmt.Errorf("decode model pricing override: %w", err)
+		}
+		result = append(result, overrideFromMongo(doc))
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, fmt.Errorf("iterate model pricing overrides: %w", err)
+	}
+	return result, nil
+}
+
+func (s *MongoDBStore) Upsert(ctx context.Context, override Override) error {
+	override, err := normalizeStoredOverride(override)
+	if err != nil {
+		return err
+	}
+
+	now := time.Now().UTC()
+	if override.CreatedAt.IsZero() {
+		override.CreatedAt = now
+	}
+	override.UpdatedAt = now
+
+	update := bson.M{
+		"$set": bson.M{
+			"provider_name": override.ProviderName,
+			"model":         override.Model,
+			"pricing":       override.Pricing,
+			"updated_at":    override.UpdatedAt,
+		},
+		"$setOnInsert": bson.M{
+			"created_at": override.CreatedAt,
+		},
+	}
+	_, err = s.collection.UpdateOne(ctx, mongoOverrideIDFilter{ID: override.Selector}, update, options.UpdateOne().SetUpsert(true))
+	if err != nil {
+		return fmt.Errorf("upsert model pricing override: %w", err)
+	}
+	return nil
+}
+
+func (s *MongoDBStore) Delete(ctx context.Context, selector string) error {
+	result, err := s.collection.DeleteOne(ctx, mongoOverrideIDFilter{ID: strings.TrimSpace(selector)})
+	if err != nil {
+		return fmt.Errorf("delete model pricing override: %w", err)
+	}
+	if result.DeletedCount == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *MongoDBStore) Close() error {
+	return nil
+}
+
+func overrideFromMongo(doc mongoOverrideDocument) Override {
+	return Override{
+		Selector:     doc.ID,
+		ProviderName: doc.ProviderName,
+		Model:        doc.Model,
+		Pricing:      clonePricing(doc.Pricing),
+		CreatedAt:    doc.CreatedAt.UTC(),
+		UpdatedAt:    doc.UpdatedAt.UTC(),
+	}
+}

--- a/internal/pricingoverrides/store_postgresql.go
+++ b/internal/pricingoverrides/store_postgresql.go
@@ -1,0 +1,137 @@
+package pricingoverrides
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// PostgreSQLStore stores model pricing overrides in PostgreSQL.
+type PostgreSQLStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgreSQLStore creates the model_pricing_overrides table and indexes if needed.
+func NewPostgreSQLStore(ctx context.Context, pool *pgxpool.Pool) (*PostgreSQLStore, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("context is required")
+	}
+	if pool == nil {
+		return nil, fmt.Errorf("connection pool is required")
+	}
+
+	_, err := pool.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS model_pricing_overrides (
+			selector TEXT PRIMARY KEY,
+			provider_name TEXT NOT NULL DEFAULT '',
+			model TEXT NOT NULL DEFAULT '',
+			pricing JSONB NOT NULL DEFAULT '{}'::jsonb,
+			created_at BIGINT NOT NULL,
+			updated_at BIGINT NOT NULL
+		)
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create model_pricing_overrides table: %w", err)
+	}
+	if _, err := pool.Exec(ctx, `CREATE INDEX IF NOT EXISTS idx_model_pricing_overrides_provider_name ON model_pricing_overrides(provider_name)`); err != nil {
+		return nil, fmt.Errorf("failed to create model_pricing_overrides provider_name index: %w", err)
+	}
+	if _, err := pool.Exec(ctx, `CREATE INDEX IF NOT EXISTS idx_model_pricing_overrides_model ON model_pricing_overrides(model)`); err != nil {
+		return nil, fmt.Errorf("failed to create model_pricing_overrides model index: %w", err)
+	}
+	if _, err := pool.Exec(ctx, `CREATE INDEX IF NOT EXISTS idx_model_pricing_overrides_updated_at ON model_pricing_overrides(updated_at DESC)`); err != nil {
+		return nil, fmt.Errorf("failed to create model_pricing_overrides updated_at index: %w", err)
+	}
+	return &PostgreSQLStore{pool: pool}, nil
+}
+
+func (s *PostgreSQLStore) List(ctx context.Context) ([]Override, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT selector, provider_name, model, pricing, created_at, updated_at
+		FROM model_pricing_overrides
+		ORDER BY selector ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list model pricing overrides: %w", err)
+	}
+	defer rows.Close()
+	return collectOverrides(func() (Override, bool, error) {
+		if !rows.Next() {
+			return Override{}, false, nil
+		}
+		override, err := scanPostgreSQLOverride(rows)
+		return override, true, err
+	}, rows.Err)
+}
+
+func (s *PostgreSQLStore) Upsert(ctx context.Context, override Override) error {
+	override, pricingJSON, err := prepareOverrideUpsert(override)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.pool.Exec(ctx, `
+		INSERT INTO model_pricing_overrides (
+			selector, provider_name, model, pricing, created_at, updated_at
+		)
+		VALUES ($1, $2, $3, $4::jsonb, $5, $6)
+		ON CONFLICT(selector) DO UPDATE SET
+			provider_name = excluded.provider_name,
+			model = excluded.model,
+			pricing = excluded.pricing,
+			updated_at = excluded.updated_at
+	`,
+		override.Selector,
+		override.ProviderName,
+		override.Model,
+		pricingJSON,
+		override.CreatedAt.Unix(),
+		override.UpdatedAt.Unix(),
+	)
+	if err != nil {
+		return fmt.Errorf("upsert model pricing override: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgreSQLStore) Delete(ctx context.Context, selector string) error {
+	cmd, err := s.pool.Exec(ctx, `DELETE FROM model_pricing_overrides WHERE selector = $1`, strings.TrimSpace(selector))
+	if err != nil {
+		return fmt.Errorf("delete model pricing override: %w", err)
+	}
+	if cmd.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *PostgreSQLStore) Close() error {
+	return nil
+}
+
+func scanPostgreSQLOverride(scanner interface{ Scan(dest ...any) error }) (Override, error) {
+	var override Override
+	var pricing []byte
+	var createdAt int64
+	var updatedAt int64
+	if err := scanner.Scan(
+		&override.Selector,
+		&override.ProviderName,
+		&override.Model,
+		&pricing,
+		&createdAt,
+		&updatedAt,
+	); err != nil {
+		return Override{}, fmt.Errorf("scan model pricing override: %w", err)
+	}
+	if err := json.Unmarshal(pricing, &override.Pricing); err != nil {
+		return Override{}, fmt.Errorf("decode pricing: %w", err)
+	}
+	override.CreatedAt = time.Unix(createdAt, 0).UTC()
+	override.UpdatedAt = time.Unix(updatedAt, 0).UTC()
+	return override, nil
+}

--- a/internal/pricingoverrides/store_sqlite.go
+++ b/internal/pricingoverrides/store_sqlite.go
@@ -1,0 +1,137 @@
+package pricingoverrides
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// SQLiteStore stores model pricing overrides in SQLite.
+type SQLiteStore struct {
+	db *sql.DB
+}
+
+// NewSQLiteStore creates the model_pricing_overrides table and indexes if needed.
+func NewSQLiteStore(db *sql.DB) (*SQLiteStore, error) {
+	if db == nil {
+		return nil, fmt.Errorf("database connection is required")
+	}
+
+	_, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS model_pricing_overrides (
+			selector TEXT PRIMARY KEY,
+			provider_name TEXT NOT NULL DEFAULT '',
+			model TEXT NOT NULL DEFAULT '',
+			pricing TEXT NOT NULL DEFAULT '{}',
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		)
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create model_pricing_overrides table: %w", err)
+	}
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_model_pricing_overrides_provider_name ON model_pricing_overrides(provider_name)`); err != nil {
+		return nil, fmt.Errorf("failed to create model_pricing_overrides provider_name index: %w", err)
+	}
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_model_pricing_overrides_model ON model_pricing_overrides(model)`); err != nil {
+		return nil, fmt.Errorf("failed to create model_pricing_overrides model index: %w", err)
+	}
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_model_pricing_overrides_updated_at ON model_pricing_overrides(updated_at DESC)`); err != nil {
+		return nil, fmt.Errorf("failed to create model_pricing_overrides updated_at index: %w", err)
+	}
+	return &SQLiteStore{db: db}, nil
+}
+
+func (s *SQLiteStore) List(ctx context.Context) ([]Override, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT selector, provider_name, model, pricing, created_at, updated_at
+		FROM model_pricing_overrides
+		ORDER BY selector ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list model pricing overrides: %w", err)
+	}
+	defer rows.Close()
+	return collectOverrides(func() (Override, bool, error) {
+		if !rows.Next() {
+			return Override{}, false, nil
+		}
+		override, err := scanSQLiteOverride(rows)
+		return override, true, err
+	}, rows.Err)
+}
+
+func (s *SQLiteStore) Upsert(ctx context.Context, override Override) error {
+	override, pricingJSON, err := prepareOverrideUpsert(override)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO model_pricing_overrides (
+			selector, provider_name, model, pricing, created_at, updated_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(selector) DO UPDATE SET
+			provider_name = excluded.provider_name,
+			model = excluded.model,
+			pricing = excluded.pricing,
+			updated_at = excluded.updated_at
+	`,
+		override.Selector,
+		override.ProviderName,
+		override.Model,
+		pricingJSON,
+		override.CreatedAt.Unix(),
+		override.UpdatedAt.Unix(),
+	)
+	if err != nil {
+		return fmt.Errorf("upsert model pricing override: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) Delete(ctx context.Context, selector string) error {
+	result, err := s.db.ExecContext(ctx, `DELETE FROM model_pricing_overrides WHERE selector = ?`, strings.TrimSpace(selector))
+	if err != nil {
+		return fmt.Errorf("delete model pricing override: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read delete rows affected: %w", err)
+	}
+	if affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *SQLiteStore) Close() error {
+	return nil
+}
+
+func scanSQLiteOverride(scanner interface{ Scan(dest ...any) error }) (Override, error) {
+	var override Override
+	var pricing string
+	var createdAt int64
+	var updatedAt int64
+	if err := scanner.Scan(
+		&override.Selector,
+		&override.ProviderName,
+		&override.Model,
+		&pricing,
+		&createdAt,
+		&updatedAt,
+	); err != nil {
+		return Override{}, fmt.Errorf("scan model pricing override: %w", err)
+	}
+	if err := json.Unmarshal([]byte(pricing), &override.Pricing); err != nil {
+		return Override{}, fmt.Errorf("decode pricing: %w", err)
+	}
+	override.CreatedAt = time.Unix(createdAt, 0).UTC()
+	override.UpdatedAt = time.Unix(updatedAt, 0).UTC()
+	return override, nil
+}

--- a/internal/pricingoverrides/store_sqlite_test.go
+++ b/internal/pricingoverrides/store_sqlite_test.go
@@ -1,0 +1,52 @@
+package pricingoverrides
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestSQLiteStoreStoresPricingWithoutCurrency(t *testing.T) {
+	t.Parallel()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	defer db.Close()
+
+	store, err := NewSQLiteStore(db)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore() error = %v", err)
+	}
+
+	if err := store.Upsert(context.Background(), Override{
+		Selector: "openai/gpt-4o",
+		Pricing:  Pricing{InputPerMtok: ptr(1.25)},
+	}); err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+
+	var rawPricing string
+	if err := db.QueryRow(`SELECT pricing FROM model_pricing_overrides WHERE selector = 'openai/gpt-4o'`).Scan(&rawPricing); err != nil {
+		t.Fatalf("read pricing JSON: %v", err)
+	}
+	if strings.Contains(rawPricing, "currency") {
+		t.Fatalf("pricing JSON = %s, did not expect currency field", rawPricing)
+	}
+
+	overrides, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(overrides) != 1 {
+		t.Fatalf("len(overrides) = %d, want 1", len(overrides))
+	}
+	if overrides[0].ProviderName != "openai" || overrides[0].Model != "gpt-4o" {
+		t.Fatalf("stored parts = (%q, %q), want (openai, gpt-4o)", overrides[0].ProviderName, overrides[0].Model)
+	}
+}

--- a/internal/pricingoverrides/types.go
+++ b/internal/pricingoverrides/types.go
@@ -51,13 +51,6 @@ type Override struct {
 // ScopeKind identifies how broadly an override applies.
 type ScopeKind = modelselectors.ScopeKind
 
-const (
-	ScopeGlobal        = modelselectors.ScopeGlobal
-	ScopeModel         = modelselectors.ScopeModel
-	ScopeProvider      = modelselectors.ScopeProvider
-	ScopeProviderModel = modelselectors.ScopeProviderModel
-)
-
 // ScopeKind reports the normalized selector scope for one override.
 func (o Override) ScopeKind() ScopeKind {
 	return modelselectors.ScopeKindFor(o.Selector, o.ProviderName, o.Model)

--- a/internal/pricingoverrides/types.go
+++ b/internal/pricingoverrides/types.go
@@ -1,0 +1,107 @@
+package pricingoverrides
+
+import (
+	"time"
+
+	"gomodel/internal/modelselectors"
+)
+
+const CurrencyUSD = "USD"
+
+// Pricing stores operator-supplied pricing fields. Currency is intentionally
+// omitted from persistence and API payloads; UI-managed pricing is USD-only.
+type Pricing struct {
+	InputPerMtok           *float64      `json:"input_per_mtok,omitempty" bson:"input_per_mtok,omitempty"`
+	OutputPerMtok          *float64      `json:"output_per_mtok,omitempty" bson:"output_per_mtok,omitempty"`
+	CachedInputPerMtok     *float64      `json:"cached_input_per_mtok,omitempty" bson:"cached_input_per_mtok,omitempty"`
+	CacheWritePerMtok      *float64      `json:"cache_write_per_mtok,omitempty" bson:"cache_write_per_mtok,omitempty"`
+	ReasoningOutputPerMtok *float64      `json:"reasoning_output_per_mtok,omitempty" bson:"reasoning_output_per_mtok,omitempty"`
+	BatchInputPerMtok      *float64      `json:"batch_input_per_mtok,omitempty" bson:"batch_input_per_mtok,omitempty"`
+	BatchOutputPerMtok     *float64      `json:"batch_output_per_mtok,omitempty" bson:"batch_output_per_mtok,omitempty"`
+	AudioInputPerMtok      *float64      `json:"audio_input_per_mtok,omitempty" bson:"audio_input_per_mtok,omitempty"`
+	AudioOutputPerMtok     *float64      `json:"audio_output_per_mtok,omitempty" bson:"audio_output_per_mtok,omitempty"`
+	PerImage               *float64      `json:"per_image,omitempty" bson:"per_image,omitempty"`
+	InputPerImage          *float64      `json:"input_per_image,omitempty" bson:"input_per_image,omitempty"`
+	PerSecondInput         *float64      `json:"per_second_input,omitempty" bson:"per_second_input,omitempty"`
+	PerSecondOutput        *float64      `json:"per_second_output,omitempty" bson:"per_second_output,omitempty"`
+	PerCharacterInput      *float64      `json:"per_character_input,omitempty" bson:"per_character_input,omitempty"`
+	PerRequest             *float64      `json:"per_request,omitempty" bson:"per_request,omitempty"`
+	PerPage                *float64      `json:"per_page,omitempty" bson:"per_page,omitempty"`
+	Tiers                  []PricingTier `json:"tiers,omitempty" bson:"tiers,omitempty"`
+}
+
+// PricingTier stores future tiered pricing without changing the DB schema.
+type PricingTier struct {
+	UpToTokens    *float64 `json:"up_to_tokens,omitempty" bson:"up_to_tokens,omitempty"`
+	UpToMtok      *float64 `json:"up_to_mtok,omitempty" bson:"up_to_mtok,omitempty"`
+	InputPerMtok  *float64 `json:"input_per_mtok,omitempty" bson:"input_per_mtok,omitempty"`
+	OutputPerMtok *float64 `json:"output_per_mtok,omitempty" bson:"output_per_mtok,omitempty"`
+}
+
+// Override stores one persisted pricing override for a model selector.
+type Override struct {
+	Selector     string    `json:"selector" bson:"_id"`
+	ProviderName string    `json:"provider_name,omitempty" bson:"provider_name,omitempty"`
+	Model        string    `json:"model,omitempty" bson:"model,omitempty"`
+	Pricing      Pricing   `json:"pricing" bson:"pricing"`
+	CreatedAt    time.Time `json:"created_at" bson:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at" bson:"updated_at"`
+}
+
+// ScopeKind identifies how broadly an override applies.
+type ScopeKind = modelselectors.ScopeKind
+
+const (
+	ScopeGlobal        = modelselectors.ScopeGlobal
+	ScopeModel         = modelselectors.ScopeModel
+	ScopeProvider      = modelselectors.ScopeProvider
+	ScopeProviderModel = modelselectors.ScopeProviderModel
+)
+
+// ScopeKind reports the normalized selector scope for one override.
+func (o Override) ScopeKind() ScopeKind {
+	return modelselectors.ScopeKindFor(o.Selector, o.ProviderName, o.Model)
+}
+
+// View is the admin-facing representation of one persisted pricing override.
+type View struct {
+	Override
+	ScopeKind ScopeKind `json:"scope_kind"`
+}
+
+// Catalog is the minimal configured-provider surface needed for selector validation.
+type Catalog = modelselectors.Catalog
+
+func normalizeOverrideInput(catalog Catalog, override Override) (Override, error) {
+	parts, err := modelselectors.NormalizeInput(catalog, override.Selector)
+	if err != nil {
+		return Override{}, err
+	}
+	override.Selector = parts.Selector
+	override.ProviderName = parts.ProviderName
+	override.Model = parts.Model
+	return normalizeOverridePricing(override)
+}
+
+func normalizeStoredOverride(override Override) (Override, error) {
+	parts, err := modelselectors.NormalizeStored(override.Selector, override.ProviderName, override.Model)
+	if err != nil {
+		return Override{}, err
+	}
+	override.Selector = parts.Selector
+	override.ProviderName = parts.ProviderName
+	override.Model = parts.Model
+	return normalizeOverridePricing(override)
+}
+
+func normalizeOverridePricing(override Override) (Override, error) {
+	pricing := clonePricing(override.Pricing)
+	if pricingEmpty(pricing) {
+		return Override{}, newValidationError("pricing is required", nil)
+	}
+	if err := validatePricing(pricing); err != nil {
+		return Override{}, err
+	}
+	override.Pricing = pricing
+	return override, nil
+}

--- a/internal/pricingoverrides/validation.go
+++ b/internal/pricingoverrides/validation.go
@@ -1,0 +1,75 @@
+package pricingoverrides
+
+type pricingField struct {
+	name  string
+	value *float64
+}
+
+func validatePricing(p Pricing) error {
+	for _, field := range pricingScalarFields(p) {
+		if field.value != nil && *field.value < 0 {
+			return newValidationError("pricing."+field.name+" must be greater than or equal to 0", nil)
+		}
+	}
+	for i, tier := range p.Tiers {
+		if tier.UpToTokens != nil && *tier.UpToTokens <= 0 {
+			return newValidationError("pricing.tiers up_to_tokens must be greater than 0", nil)
+		}
+		if tier.UpToMtok != nil && *tier.UpToMtok <= 0 {
+			return newValidationError("pricing.tiers up_to_mtok must be greater than 0", nil)
+		}
+		if tier.UpToTokens == nil && tier.UpToMtok == nil {
+			return newValidationError("pricing.tiers threshold is required", nil)
+		}
+		if tier.InputPerMtok == nil && tier.OutputPerMtok == nil {
+			return newValidationError("pricing.tiers rate is required", nil)
+		}
+		for _, field := range pricingTierFields(tier) {
+			if field.value != nil && *field.value < 0 {
+				return newValidationError("pricing.tiers "+field.name+" must be greater than or equal to 0", nil)
+			}
+		}
+		if i > 0 && tierLimit(tier) <= tierLimit(p.Tiers[i-1]) {
+			return newValidationError("pricing.tiers thresholds must be increasing", nil)
+		}
+	}
+	return nil
+}
+
+func pricingScalarFields(p Pricing) []pricingField {
+	return []pricingField{
+		{"input_per_mtok", p.InputPerMtok},
+		{"output_per_mtok", p.OutputPerMtok},
+		{"cached_input_per_mtok", p.CachedInputPerMtok},
+		{"cache_write_per_mtok", p.CacheWritePerMtok},
+		{"reasoning_output_per_mtok", p.ReasoningOutputPerMtok},
+		{"batch_input_per_mtok", p.BatchInputPerMtok},
+		{"batch_output_per_mtok", p.BatchOutputPerMtok},
+		{"audio_input_per_mtok", p.AudioInputPerMtok},
+		{"audio_output_per_mtok", p.AudioOutputPerMtok},
+		{"per_image", p.PerImage},
+		{"input_per_image", p.InputPerImage},
+		{"per_second_input", p.PerSecondInput},
+		{"per_second_output", p.PerSecondOutput},
+		{"per_character_input", p.PerCharacterInput},
+		{"per_request", p.PerRequest},
+		{"per_page", p.PerPage},
+	}
+}
+
+func pricingTierFields(t PricingTier) []pricingField {
+	return []pricingField{
+		{"input_per_mtok", t.InputPerMtok},
+		{"output_per_mtok", t.OutputPerMtok},
+	}
+}
+
+func tierLimit(t PricingTier) float64 {
+	if t.UpToTokens != nil {
+		return *t.UpToTokens
+	}
+	if t.UpToMtok != nil {
+		return *t.UpToMtok * 1_000_000
+	}
+	return 0
+}

--- a/internal/pricingoverrides/validation.go
+++ b/internal/pricingoverrides/validation.go
@@ -12,6 +12,9 @@ func validatePricing(p Pricing) error {
 		}
 	}
 	for i, tier := range p.Tiers {
+		if tier.UpToTokens != nil && tier.UpToMtok != nil {
+			return newValidationError("pricing.tiers must set only one threshold: up_to_tokens or up_to_mtok", nil)
+		}
 		if tier.UpToTokens != nil && *tier.UpToTokens <= 0 {
 			return newValidationError("pricing.tiers up_to_tokens must be greater than 0", nil)
 		}

--- a/internal/providers/registry_metadata.go
+++ b/internal/providers/registry_metadata.go
@@ -318,9 +318,12 @@ func applyConfigMetadataOverrides(
 			if !ok {
 				continue
 			}
+			basePricing := metadataPricing(current.Model.Metadata)
+			basePricingSources := metadataPricingSources(current.Model.Metadata)
 			merged := modeldata.MergeMetadata(current.Model.Metadata, override)
 			if override.Pricing != nil {
-				merged.PricingSources = override.Pricing.FieldSources(core.ModelPricingSourceConfigYAML)
+				merged.Pricing = mergeConfigPricing(basePricing, override.Pricing)
+				merged.PricingSources = mergePricingSources(basePricingSources, override.Pricing.FieldSources(core.ModelPricingSourceConfigYAML))
 			}
 			// Skip no-op merges so concurrent readers holding the current
 			// pointer keep a stable view when the override adds no new info.

--- a/internal/providers/registry_metadata.go
+++ b/internal/providers/registry_metadata.go
@@ -319,6 +319,9 @@ func applyConfigMetadataOverrides(
 				continue
 			}
 			merged := modeldata.MergeMetadata(current.Model.Metadata, override)
+			if override.Pricing != nil {
+				merged.PricingSources = override.Pricing.FieldSources(core.ModelPricingSourceConfigYAML)
+			}
 			// Skip no-op merges so concurrent readers holding the current
 			// pointer keep a stable view when the override adds no new info.
 			if reflect.DeepEqual(current.Model.Metadata, merged) {

--- a/internal/providers/registry_metadata_override_test.go
+++ b/internal/providers/registry_metadata_override_test.go
@@ -185,6 +185,59 @@ func TestResolvePricingPrefersProviderSpecificMetadata(t *testing.T) {
 	}
 }
 
+func TestApplyConfigMetadataOverrides_MergesPricingSourcesPerField(t *testing.T) {
+	baseInput := 1.0
+	baseOutput := 2.0
+	configInput := 3.0
+	existing := &ModelInfo{
+		Model: core.Model{
+			ID: "priced-model",
+			Metadata: &core.ModelMetadata{
+				Pricing: &core.ModelPricing{
+					Currency:      "USD",
+					InputPerMtok:  &baseInput,
+					OutputPerMtok: &baseOutput,
+				},
+				PricingSources: map[string]string{
+					"input_per_mtok":  core.ModelPricingSourceModelRegistry,
+					"output_per_mtok": core.ModelPricingSourceModelRegistry,
+				},
+			},
+		},
+		ProviderName: "openai-main",
+		ProviderType: "openai",
+	}
+	modelsByProvider := map[string]map[string]*ModelInfo{
+		"openai-main": {"priced-model": existing},
+	}
+	overrides := map[string]map[string]*core.ModelMetadata{
+		"openai-main": {
+			"priced-model": {
+				Pricing: &core.ModelPricing{InputPerMtok: &configInput},
+			},
+		},
+	}
+
+	applied := applyConfigMetadataOverrides(overrides, modelsByProvider, nil)
+	if applied != 1 {
+		t.Fatalf("applied = %d, want 1", applied)
+	}
+
+	metadata := existing.Model.Metadata
+	if metadata.Pricing == nil || metadata.Pricing.InputPerMtok == nil || *metadata.Pricing.InputPerMtok != configInput {
+		t.Fatalf("InputPerMtok = %#v, want config override %v", metadata.Pricing, configInput)
+	}
+	if metadata.Pricing.OutputPerMtok == nil || *metadata.Pricing.OutputPerMtok != baseOutput {
+		t.Fatalf("OutputPerMtok = %#v, want registry value %v", metadata.Pricing.OutputPerMtok, baseOutput)
+	}
+	if got := metadata.PricingSources["input_per_mtok"]; got != core.ModelPricingSourceConfigYAML {
+		t.Errorf("PricingSources[input_per_mtok] = %q, want %q", got, core.ModelPricingSourceConfigYAML)
+	}
+	if got := metadata.PricingSources["output_per_mtok"]; got != core.ModelPricingSourceModelRegistry {
+		t.Errorf("PricingSources[output_per_mtok] = %q, want %q", got, core.ModelPricingSourceModelRegistry)
+	}
+}
+
 // TestApplyConfigMetadataOverrides_NoOpPreservesPointerIdentity verifies that
 // an override whose fields already match the current metadata does not
 // replace the ModelInfo pointer — a concurrent reader that captured the

--- a/internal/providers/registry_metadata_override_test.go
+++ b/internal/providers/registry_metadata_override_test.go
@@ -74,6 +74,9 @@ func TestInitialize_AppliesConfigMetadataOverrides(t *testing.T) {
 	if got := overridden.Model.Metadata.PricingSources["input_per_mtok"]; got != core.ModelPricingSourceConfigYAML {
 		t.Errorf("PricingSources[input_per_mtok] = %q, want %q", got, core.ModelPricingSourceConfigYAML)
 	}
+	if got := overridden.Model.Metadata.PricingSources["output_per_mtok"]; got != core.ModelPricingSourceConfigYAML {
+		t.Errorf("PricingSources[output_per_mtok] = %q, want %q", got, core.ModelPricingSourceConfigYAML)
+	}
 
 	untouched := registry.GetModel("nippur/Gemma4-31B")
 	if untouched == nil {

--- a/internal/providers/registry_metadata_override_test.go
+++ b/internal/providers/registry_metadata_override_test.go
@@ -10,6 +10,8 @@ import (
 
 func ctxWindow(v int) *int { return &v }
 
+func price(v float64) *float64 { return &v }
+
 // TestInitialize_AppliesConfigMetadataOverrides verifies that operator-supplied
 // metadata from config.yaml takes precedence over (and merges onto) the remote
 // model registry during provider initialization. Exercises the config-driven
@@ -44,6 +46,11 @@ func TestInitialize_AppliesConfigMetadataOverrides(t *testing.T) {
 			DisplayName:   "GLM 4.7 Flash (local)",
 			ContextWindow: ctxWindow(131072),
 			Capabilities:  map[string]bool{"tools": true},
+			Pricing: &core.ModelPricing{
+				Currency:      "USD",
+				InputPerMtok:  price(0),
+				OutputPerMtok: price(0),
+			},
 		},
 	})
 
@@ -63,6 +70,9 @@ func TestInitialize_AppliesConfigMetadataOverrides(t *testing.T) {
 	}
 	if !overridden.Model.Metadata.Capabilities["tools"] {
 		t.Errorf("Capabilities[tools] = false, want true")
+	}
+	if got := overridden.Model.Metadata.PricingSources["input_per_mtok"]; got != core.ModelPricingSourceConfigYAML {
+		t.Errorf("PricingSources[input_per_mtok] = %q, want %q", got, core.ModelPricingSourceConfigYAML)
 	}
 
 	untouched := registry.GetModel("nippur/Gemma4-31B")

--- a/internal/providers/registry_pricing_merge.go
+++ b/internal/providers/registry_pricing_merge.go
@@ -1,0 +1,81 @@
+package providers
+
+import "gomodel/internal/core"
+
+func metadataPricing(metadata *core.ModelMetadata) *core.ModelPricing {
+	if metadata == nil {
+		return nil
+	}
+	return metadata.Pricing
+}
+
+func metadataPricingSources(metadata *core.ModelMetadata) map[string]string {
+	if metadata == nil {
+		return nil
+	}
+	return metadata.PricingSources
+}
+
+func mergePricingSources(base, override map[string]string) map[string]string {
+	if len(base) == 0 && len(override) == 0 {
+		return nil
+	}
+	merged := make(map[string]string, len(base)+len(override))
+	for key, source := range base {
+		if source != "" {
+			merged[key] = source
+		}
+	}
+	for key, source := range override {
+		if source != "" {
+			merged[key] = source
+		}
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+	return merged
+}
+
+func mergeConfigPricing(base, override *core.ModelPricing) *core.ModelPricing {
+	if override == nil {
+		return base.Clone()
+	}
+	var merged *core.ModelPricing
+	if base != nil {
+		merged = base.Clone()
+	} else {
+		merged = &core.ModelPricing{}
+	}
+	if override.Currency != "" {
+		merged.Currency = override.Currency
+	}
+	applyPricingOverride(&merged.InputPerMtok, override.InputPerMtok)
+	applyPricingOverride(&merged.OutputPerMtok, override.OutputPerMtok)
+	applyPricingOverride(&merged.CachedInputPerMtok, override.CachedInputPerMtok)
+	applyPricingOverride(&merged.CacheWritePerMtok, override.CacheWritePerMtok)
+	applyPricingOverride(&merged.ReasoningOutputPerMtok, override.ReasoningOutputPerMtok)
+	applyPricingOverride(&merged.BatchInputPerMtok, override.BatchInputPerMtok)
+	applyPricingOverride(&merged.BatchOutputPerMtok, override.BatchOutputPerMtok)
+	applyPricingOverride(&merged.AudioInputPerMtok, override.AudioInputPerMtok)
+	applyPricingOverride(&merged.AudioOutputPerMtok, override.AudioOutputPerMtok)
+	applyPricingOverride(&merged.PerImage, override.PerImage)
+	applyPricingOverride(&merged.InputPerImage, override.InputPerImage)
+	applyPricingOverride(&merged.PerSecondInput, override.PerSecondInput)
+	applyPricingOverride(&merged.PerSecondOutput, override.PerSecondOutput)
+	applyPricingOverride(&merged.PerCharacterInput, override.PerCharacterInput)
+	applyPricingOverride(&merged.PerRequest, override.PerRequest)
+	applyPricingOverride(&merged.PerPage, override.PerPage)
+	if len(override.Tiers) > 0 {
+		merged.Tiers = override.Clone().Tiers
+	}
+	return merged
+}
+
+func applyPricingOverride(target **float64, value *float64) {
+	if value == nil {
+		return
+	}
+	copied := *value
+	*target = &copied
+}

--- a/internal/responsecache/usage_hit.go
+++ b/internal/responsecache/usage_hit.go
@@ -49,7 +49,7 @@ func newUsageHitRecorder(logger usage.LoggerInterface, pricingResolver usage.Pri
 
 		var pricing *core.ModelPricing
 		if pricingResolver != nil {
-			pricing = pricingResolver.ResolvePricing(model, provider)
+			pricing = pricingResolver.ResolvePricing(model, cacheHitPricingProvider(provider, providerName))
 		}
 
 		entry := usage.ExtractFromCachedResponseBody(body, requestID, model, provider, endpoint, cacheType, pricing)
@@ -60,4 +60,11 @@ func newUsageHitRecorder(logger usage.LoggerInterface, pricingResolver usage.Pri
 		entry.UserPath = core.UserPathFromContext(ctx)
 		logger.Write(entry)
 	}
+}
+
+func cacheHitPricingProvider(provider, providerName string) string {
+	if name := strings.TrimSpace(providerName); name != "" {
+		return name
+	}
+	return strings.TrimSpace(provider)
 }

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -3349,7 +3349,7 @@ func TestEmbeddings_WithUsageTracking(t *testing.T) {
 			Data: []core.EmbeddingData{
 				{Object: "embedding", Embedding: json.RawMessage(`[0.1,0.2,0.3]`), Index: 0},
 			},
-			Model: "text-embedding-3-small",
+			Model: "provider-canonical-embedding",
 			Usage: core.EmbeddingUsage{PromptTokens: 10, TotalTokens: 10},
 		},
 	}
@@ -3395,6 +3395,9 @@ func TestEmbeddings_WithUsageTracking(t *testing.T) {
 	}
 	if capturedEntry.RequestID != "test-req-embed-usage" {
 		t.Errorf("RequestID = %q, want %q", capturedEntry.RequestID, "test-req-embed-usage")
+	}
+	if resolver.model != "text-embedding-3-small" {
+		t.Errorf("pricing resolver model = %q, want requested model", resolver.model)
 	}
 	if capturedEntry.InputCost == nil || *capturedEntry.InputCost == 0 {
 		t.Error("expected non-zero InputCost from pricing resolver")
@@ -4961,10 +4964,14 @@ func (c *collectingUsageLogger) Config() usage.Config { return c.config }
 func (c *collectingUsageLogger) Close() error         { return nil }
 
 type mockPricingResolver struct {
-	pricing *core.ModelPricing
+	pricing  *core.ModelPricing
+	model    string
+	provider string
 }
 
-func (m *mockPricingResolver) ResolvePricing(_, _ string) *core.ModelPricing {
+func (m *mockPricingResolver) ResolvePricing(model, provider string) *core.ModelPricing {
+	m.model = model
+	m.provider = provider
 	return m.pricing
 }
 

--- a/internal/usage/stream_observer.go
+++ b/internal/usage/stream_observer.go
@@ -136,7 +136,7 @@ func (o *StreamUsageObserver) extractUsageFromEvent(chunk map[string]any) *Usage
 
 	var pricingArgs []*core.ModelPricing
 	if o.pricingResolver != nil {
-		if p := o.pricingResolver.ResolvePricing(model, o.provider); p != nil {
+		if p := o.pricingResolver.ResolvePricing(o.pricingModel(model), o.pricingProvider()); p != nil {
 			pricingArgs = append(pricingArgs, p)
 		}
 	}
@@ -153,6 +153,26 @@ func (o *StreamUsageObserver) extractUsageFromEvent(chunk map[string]any) *Usage
 		entry.UserPath = o.userPath
 	}
 	return entry
+}
+
+func (o *StreamUsageObserver) pricingModel(responseModel string) string {
+	if o == nil {
+		return strings.TrimSpace(responseModel)
+	}
+	if model := strings.TrimSpace(o.model); model != "" {
+		return model
+	}
+	return strings.TrimSpace(responseModel)
+}
+
+func (o *StreamUsageObserver) pricingProvider() string {
+	if o == nil {
+		return ""
+	}
+	if providerName := strings.TrimSpace(o.providerName); providerName != "" {
+		return providerName
+	}
+	return strings.TrimSpace(o.provider)
 }
 
 func copyExtendedUsageFields(rawData map[string]any, usageMap map[string]any) {

--- a/internal/usage/stream_observer_test.go
+++ b/internal/usage/stream_observer_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"testing"
 
+	"gomodel/internal/core"
 	"gomodel/internal/streaming"
 )
 
@@ -37,6 +38,18 @@ func (l *trackingLogger) getEntries() []*UsageEntry {
 	result := make([]*UsageEntry, len(l.entries))
 	copy(result, l.entries)
 	return result
+}
+
+type streamPricingCaptureResolver struct {
+	model    string
+	provider string
+	pricing  *core.ModelPricing
+}
+
+func (r *streamPricingCaptureResolver) ResolvePricing(model, provider string) *core.ModelPricing {
+	r.model = model
+	r.provider = provider
+	return r.pricing
 }
 
 func TestStreamUsageObserverChatCompletionStream(t *testing.T) {
@@ -83,6 +96,47 @@ data: [DONE]
 	}
 	if entry.Model != "gpt-4" {
 		t.Errorf("Model = %s, want gpt-4", entry.Model)
+	}
+}
+
+func TestStreamUsageObserverPricesRequestedModelWhenEventModelIsVersioned(t *testing.T) {
+	zero := 0.0
+	perRequest := 0.033333
+	resolver := &streamPricingCaptureResolver{pricing: &core.ModelPricing{
+		InputPerMtok:  &zero,
+		OutputPerMtok: &zero,
+		PerRequest:    &perRequest,
+	}}
+	logger := &trackingLogger{enabled: true}
+	observer := NewStreamUsageObserver(logger, "gpt-4o-mini", "openai", "req-stream", "/v1/chat/completions", resolver)
+	observer.SetProviderName("openai")
+	observer.OnJSONEvent(map[string]any{
+		"id":    "chatcmpl-stream",
+		"model": "gpt-4o-mini-2024-07-18",
+		"usage": map[string]any{
+			"prompt_tokens":     float64(12),
+			"completion_tokens": float64(1),
+			"total_tokens":      float64(13),
+		},
+	})
+	observer.OnStreamClose()
+
+	if resolver.model != "gpt-4o-mini" {
+		t.Fatalf("pricing model = %q, want gpt-4o-mini", resolver.model)
+	}
+	if resolver.provider != "openai" {
+		t.Fatalf("pricing provider = %q, want openai", resolver.provider)
+	}
+	entries := logger.getEntries()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	entry := entries[0]
+	if entry.Model != "gpt-4o-mini-2024-07-18" {
+		t.Fatalf("usage model = %q, want provider event model", entry.Model)
+	}
+	if entry.TotalCost == nil || math.Abs(*entry.TotalCost-perRequest) > 0.0000001 {
+		t.Fatalf("total cost = %v, want %f", entry.TotalCost, perRequest)
 	}
 }
 

--- a/tools/openapi-postprocess.mjs
+++ b/tools/openapi-postprocess.mjs
@@ -158,12 +158,25 @@ function applyStringArrayPropertyBounds(schemaName, propertyName, maxItems, item
   property.items.maxLength = itemMaxLength;
 }
 
+function applyPricingSchemaConstraints() {
+  schema("pricingoverrides.Pricing").minProperties = 1;
+  for (const name of ["core.ModelPricingTier", "pricingoverrides.PricingTier"]) {
+    const upToTokens = schema(name).properties?.up_to_tokens;
+    if (!upToTokens) {
+      throw new Error(`missing up_to_tokens property on schema: ${name}`);
+    }
+    upToTokens.type = "integer";
+    upToTokens.minimum = 0;
+  }
+}
+
 spec.servers = parseServers(process.env.DOCS_API_SERVERS);
 ensureResponsesInputElementSchema();
 ensureBearerAuthSecurityScheme();
 ensureRequiredProperty("admin.recalculatePricingRequest", "confirmation");
 ensureRequiredProperty("admin.upsertModelPricingOverrideRequest", "pricing");
 applyStringArrayPropertyBounds("admin.upsertModelOverrideRequest", "user_paths", 100, 1024);
+applyPricingSchemaConstraints();
 
 // Bound the registry-backed admin model listing so OpenAPI consumers (and
 // security scanners like CKV_OPENAPI_21) see an explicit upper limit. The

--- a/tools/openapi-postprocess.mjs
+++ b/tools/openapi-postprocess.mjs
@@ -147,11 +147,23 @@ function applyStringEnum(schemaName, values, varnames) {
   }
 }
 
+function applyStringArrayPropertyBounds(schemaName, propertyName, maxItems, itemMaxLength) {
+  const target = schema(schemaName);
+  const property = target.properties?.[propertyName];
+  if (!property || property.type !== "array") {
+    throw new Error(`expected array property ${propertyName} on schema: ${schemaName}`);
+  }
+  property.maxItems = maxItems;
+  property.items = property.items || {};
+  property.items.maxLength = itemMaxLength;
+}
+
 spec.servers = parseServers(process.env.DOCS_API_SERVERS);
 ensureResponsesInputElementSchema();
 ensureBearerAuthSecurityScheme();
 ensureRequiredProperty("admin.recalculatePricingRequest", "confirmation");
 ensureRequiredProperty("admin.upsertModelPricingOverrideRequest", "pricing");
+applyStringArrayPropertyBounds("admin.upsertModelOverrideRequest", "user_paths", 100, 1024);
 
 // Bound the registry-backed admin model listing so OpenAPI consumers (and
 // security scanners like CKV_OPENAPI_21) see an explicit upper limit. The
@@ -161,13 +173,16 @@ applyArrayMaxItems("/admin/api/v1/models", "get", "200", 10000);
 applyArrayMaxItems("/admin/api/v1/model-overrides", "get", "200", 10000);
 applyArrayMaxItems("/admin/api/v1/model-pricing-overrides", "get", "200", 10000);
 
-for (const name of ["modeloverrides.ScopeKind", "pricingoverrides.ScopeKind"]) {
-  applyStringEnum(
-    name,
-    ["global", "model", "provider", "provider_model"],
-    ["ScopeGlobal", "ScopeModel", "ScopeProvider", "ScopeProviderModel"],
-  );
-}
+applyStringEnum(
+  "modeloverrides.ScopeKind",
+  ["global", "model", "provider", "provider_model"],
+  ["ModelScopeGlobal", "ModelScopeModel", "ModelScopeProvider", "ModelScopeProviderModel"],
+);
+applyStringEnum(
+  "pricingoverrides.ScopeKind",
+  ["global", "model", "provider", "provider_model"],
+  ["PricingScopeGlobal", "PricingScopeModel", "PricingScopeProvider", "PricingScopeProviderModel"],
+);
 
 for (const name of [
   "core.ResponsesRequest",

--- a/tools/openapi-postprocess.mjs
+++ b/tools/openapi-postprocess.mjs
@@ -166,7 +166,7 @@ function applyPricingSchemaConstraints() {
       throw new Error(`missing up_to_tokens property on schema: ${name}`);
     }
     upToTokens.type = "integer";
-    upToTokens.minimum = 0;
+    upToTokens.minimum = 1;
   }
 }
 

--- a/tools/openapi-postprocess.mjs
+++ b/tools/openapi-postprocess.mjs
@@ -138,16 +138,36 @@ function applyArrayMaxItems(operationPath, method, statusCode, maxItems) {
   }
 }
 
+function applyStringEnum(schemaName, values, varnames) {
+  const target = schema(schemaName);
+  target.type = "string";
+  target.enum = values;
+  if (varnames) {
+    target["x-enum-varnames"] = varnames;
+  }
+}
+
 spec.servers = parseServers(process.env.DOCS_API_SERVERS);
 ensureResponsesInputElementSchema();
 ensureBearerAuthSecurityScheme();
 ensureRequiredProperty("admin.recalculatePricingRequest", "confirmation");
+ensureRequiredProperty("admin.upsertModelPricingOverrideRequest", "pricing");
 
 // Bound the registry-backed admin model listing so OpenAPI consumers (and
 // security scanners like CKV_OPENAPI_21) see an explicit upper limit. The
 // runtime registry is bounded by configured providers and the backing
 // model list; 10000 leaves substantial headroom for that worst case.
 applyArrayMaxItems("/admin/api/v1/models", "get", "200", 10000);
+applyArrayMaxItems("/admin/api/v1/model-overrides", "get", "200", 10000);
+applyArrayMaxItems("/admin/api/v1/model-pricing-overrides", "get", "200", 10000);
+
+for (const name of ["modeloverrides.ScopeKind", "pricingoverrides.ScopeKind"]) {
+  applyStringEnum(
+    name,
+    ["global", "model", "provider", "provider_model"],
+    ["ScopeGlobal", "ScopeModel", "ScopeProvider", "ScopeProviderModel"],
+  );
+}
 
 for (const name of [
   "core.ResponsesRequest",


### PR DESCRIPTION
## Summary
- add admin-managed model pricing override storage/API/UI with exact, model-wide, provider-wide, and global scope priority
- apply DB pricing overrides to usage cost calculation and show effective pricing previews in the dashboard
- expose per-field pricing sources, update Swagger/OpenAPI, and preserve slash-shaped model IDs such as OpenRouter models

## Tests
- go test ./...
- node --test internal/admin/dashboard/static/js/modules/*.test.cjs
- git diff --check
- pre-commit hook: make test-race, make lint, go mod tidy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin API + dashboard UI to list/create/update/delete selector-scoped model pricing overrides with modal editor, live pricing preview, tiered pricing, and pricing action buttons.

* **Behavior Changes**
  * Pricing resolution now prefers the requested model/provider, records per-field pricing sources, and supports per-tier token caps.

* **Documentation**
  * OpenAPI spec and admin docs updated with new pricing-override endpoints and schemas.

* **Tests**
  * Expanded coverage for lifecycle, validation, storage backends, resolution precedence, and UI rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->