### PR TITLE
chore(swagger): reduce dependencies

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -44,10 +44,9 @@ Use `make swagger` to regenerate the checked-in Swagger docs package and
 `docs/openapi.json`.
 
 GoModel intentionally uses `github.com/swaggo/swag/v2/cmd/swag`. The Swagger UI
-is served through Echo v5 and `github.com/swaggo/echo-swagger`'s
-`WrapHandlerV3`, which reads registered specs through `github.com/swaggo/swag/v2`.
-Using the v1 `swag` generator will produce a docs package that does not match
-the Swagger build.
+is served through Echo v5 using the static assets from `github.com/swaggo/files/v2`
+and registered specs from `github.com/swaggo/swag/v2`. Using the v1 `swag`
+generator will produce a docs package that does not match the Swagger build.
 
 ## Release Hygiene
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/redis/go-redis/v9 v9.19.0
 	github.com/stretchr/testify v1.11.1
-	github.com/swaggo/echo-swagger v1.5.0
+	github.com/swaggo/files/v2 v2.0.2
 	github.com/swaggo/swag/v2 v2.0.0-rc5
 	github.com/tidwall/gjson v1.18.0
 	go.mongodb.org/mongo-driver/v2 v2.6.0
@@ -22,6 +22,7 @@ require (
 	golang.org/x/term v0.42.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.50.0
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -58,8 +59,6 @@ require (
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sv-tools/openapi v0.4.0 // indirect
-	github.com/swaggo/files/v2 v2.0.2 // indirect
-	github.com/swaggo/swag v1.16.6 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/urfave/cli/v2 v2.27.5 // indirect
@@ -72,7 +71,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
-	golang.org/x/mod v0.33.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
@@ -81,5 +79,4 @@ require (
 	modernc.org/libc v1.72.0 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -110,12 +110,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/sv-tools/openapi v0.4.0 h1:UhD9DVnGox1hfTePNclpUzUFgos57FvzT2jmcAuTOJ4=
 github.com/sv-tools/openapi v0.4.0/go.mod h1:kD/dG+KP0+Fom1r6nvcj/ORtLus8d8enXT6dyRZDirE=
-github.com/swaggo/echo-swagger v1.5.0 h1:nkHxOaBy0SkbJMtMeXZC64KHSa0mJdZFQhVqwEcMres=
-github.com/swaggo/echo-swagger v1.5.0/go.mod h1:TzO363X1ZG/MSbjrG2IX6m65Yd3/zpqh5KM6lPctAhk=
 github.com/swaggo/files/v2 v2.0.2 h1:Bq4tgS/yxLB/3nwOMcul5oLEUKa877Ykgz3CJMVbQKU=
 github.com/swaggo/files/v2 v2.0.2/go.mod h1:TVqetIzZsO9OhHX1Am9sRf9LdrFZqoK49N37KON/jr0=
-github.com/swaggo/swag v1.16.6 h1:qBNcx53ZaX+M5dxVyTrgQ0PJ/ACK+NzhwcbieTt+9yI=
-github.com/swaggo/swag v1.16.6/go.mod h1:ngP2etMK5a0P3QBizic5MEwpRmluJZPHjXcMoj4Xesg=
 github.com/swaggo/swag/v2 v2.0.0-rc5 h1:fK7d6ET9rrEsdB8IyuwXREWMcyQN3N7gawGFbbrjgHk=
 github.com/swaggo/swag/v2 v2.0.0-rc5/go.mod h1:kCL8Fu4Zl8d5tB2Bgj96b8wRowwrwk175bZHXfuGVFI=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=

--- a/internal/server/swagger_enabled.go
+++ b/internal/server/swagger_enabled.go
@@ -3,8 +3,17 @@
 package server
 
 import (
+	"errors"
+	"io/fs"
+	"mime"
+	"net/http"
+	"path"
+	"strings"
+
 	"github.com/labstack/echo/v5"
-	echoswagger "github.com/swaggo/echo-swagger"
+	swaggerFiles "github.com/swaggo/files/v2"
+	"github.com/swaggo/swag/v2"
+	"sigs.k8s.io/yaml"
 )
 
 // SwaggerAvailable reports whether this binary was built with Swagger UI support.
@@ -14,6 +23,154 @@ func SwaggerAvailable() bool {
 
 func registerSwagger(e *echo.Echo, cfg *Config) {
 	if cfg != nil && cfg.SwaggerEnabled {
-		e.GET("/swagger/*", echoswagger.WrapHandlerV3)
+		e.GET("/swagger/*", serveSwagger)
 	}
 }
+
+func serveSwagger(c *echo.Context) error {
+	if c.Request().Method != http.MethodGet {
+		return echo.NewHTTPError(http.StatusMethodNotAllowed, http.StatusText(http.StatusMethodNotAllowed))
+	}
+
+	resourcePath, ok := swaggerResourcePath(c.Request().URL.Path)
+	if !ok {
+		return echo.NewHTTPError(http.StatusNotFound, http.StatusText(http.StatusNotFound))
+	}
+	if resourcePath == "" {
+		return c.Redirect(http.StatusMovedPermanently, "index.html")
+	}
+
+	switch resourcePath {
+	case "index.html":
+		return c.HTMLBlob(http.StatusOK, []byte(swaggerIndexHTML))
+	case "doc.json":
+		doc, err := swag.ReadDoc(swag.Name)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		}
+		return c.JSONBlob(http.StatusOK, []byte(doc))
+	case "doc.yaml":
+		doc, err := swag.ReadDoc(swag.Name)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		}
+		yamlDoc, err := yaml.JSONToYAML([]byte(doc))
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		}
+		return c.Blob(http.StatusOK, "text/plain; charset=utf-8", yamlDoc)
+	default:
+		return serveSwaggerAsset(c, resourcePath)
+	}
+}
+
+func swaggerResourcePath(requestPath string) (string, bool) {
+	resourcePath, ok := strings.CutPrefix(requestPath, "/swagger/")
+	if !ok {
+		return "", false
+	}
+	for _, part := range strings.Split(resourcePath, "/") {
+		if part == ".." {
+			return "", false
+		}
+	}
+	if resourcePath == "" {
+		return "", true
+	}
+	return path.Clean(resourcePath), true
+}
+
+func serveSwaggerAsset(c *echo.Context, resourcePath string) error {
+	file, err := swaggerFiles.FS.Open(resourcePath)
+	if errors.Is(err, fs.ErrNotExist) {
+		return echo.NewHTTPError(http.StatusNotFound, http.StatusText(http.StatusNotFound))
+	}
+	if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, err.Error())
+	}
+	defer file.Close()
+
+	stat, err := file.Stat()
+	if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, err.Error())
+	}
+	if stat.IsDir() {
+		return echo.NewHTTPError(http.StatusNotFound, http.StatusText(http.StatusNotFound))
+	}
+
+	return c.Stream(http.StatusOK, swaggerContentType(resourcePath), file)
+}
+
+func swaggerContentType(resourcePath string) string {
+	switch path.Ext(resourcePath) {
+	case ".html":
+		return "text/html; charset=utf-8"
+	case ".css":
+		return "text/css; charset=utf-8"
+	case ".js":
+		return "application/javascript"
+	case ".json", ".map":
+		return "application/json; charset=utf-8"
+	case ".png":
+		return "image/png"
+	default:
+		if contentType := mime.TypeByExtension(path.Ext(resourcePath)); contentType != "" {
+			return contentType
+		}
+		return "application/octet-stream"
+	}
+}
+
+const swaggerIndexHTML = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Swagger UI</title>
+  <link rel="stylesheet" href="./swagger-ui.css">
+  <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32">
+  <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16">
+  <style>
+    html {
+      box-sizing: border-box;
+      overflow-y: scroll;
+    }
+    *, *:before, *:after {
+      box-sizing: inherit;
+    }
+    body {
+      margin: 0;
+      background: #fafafa;
+    }
+  </style>
+</head>
+<body>
+  <div id="swagger-ui"></div>
+  <script src="./swagger-ui-bundle.js"></script>
+  <script src="./swagger-ui-standalone-preset.js"></script>
+  <script>
+    window.onload = function() {
+      window.ui = SwaggerUIBundle({
+        urls: [
+          { name: "doc.json", url: "doc.json" },
+          { name: "doc.yaml", url: "doc.yaml" }
+        ],
+        dom_id: "#swagger-ui",
+        deepLinking: true,
+        docExpansion: "list",
+        persistAuthorization: false,
+        syntaxHighlight: true,
+        validatorUrl: null,
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIStandalonePreset
+        ],
+        plugins: [
+          SwaggerUIBundle.plugins.DownloadUrl
+        ],
+        layout: "StandaloneLayout"
+      })
+    }
+  </script>
+</body>
+</html>
+`

--- a/internal/server/swagger_enabled_test.go
+++ b/internal/server/swagger_enabled_test.go
@@ -53,3 +53,53 @@ func TestSwaggerDocJson_ReturnsExpectedContent(t *testing.T) {
 		t.Errorf("expected doc.json to contain swagger spec, got: %s", body[:min(300, len(body))])
 	}
 }
+
+func TestSwaggerDocYaml_ReturnsExpectedContent(t *testing.T) {
+	mock := &mockProvider{}
+	srv := New(mock, &Config{SwaggerEnabled: true})
+
+	req := httptest.NewRequest(http.MethodGet, "/swagger/doc.yaml", nil)
+	rec := httptest.NewRecorder()
+
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	contentType := rec.Header().Get("Content-Type")
+	if !strings.Contains(contentType, "text/plain") {
+		t.Errorf("expected text/plain Content-Type, got %s", contentType)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "GoModel API") {
+		t.Errorf("expected doc.yaml to contain GoModel API title, got: %s", body[:min(300, len(body))])
+	}
+	if !strings.Contains(body, "swagger:") {
+		t.Errorf("expected doc.yaml to contain swagger spec, got: %s", body[:min(300, len(body))])
+	}
+}
+
+func TestSwaggerStaticAsset_ReturnsContent(t *testing.T) {
+	mock := &mockProvider{}
+	srv := New(mock, &Config{SwaggerEnabled: true})
+
+	req := httptest.NewRequest(http.MethodGet, "/swagger/swagger-ui.css", nil)
+	rec := httptest.NewRecorder()
+
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	contentType := rec.Header().Get("Content-Type")
+	if !strings.Contains(contentType, "text/css") {
+		t.Errorf("expected text/css Content-Type, got %s", contentType)
+	}
+
+	if !strings.Contains(rec.Body.String(), "swagger-ui") {
+		t.Errorf("expected swagger UI CSS content, got: %s", rec.Body.String()[:min(200, len(rec.Body.String()))])
+	}
+}


### PR DESCRIPTION
## Summary
- Serve Swagger UI directly from `swaggo/files/v2` assets and `swaggo/swag/v2` specs
- Remove the `echo-swagger` and `swaggo` v1 dependency path
- Add coverage for `doc.yaml` and static Swagger UI assets

## Tests
- `go test ./...`
- commit hooks: `make test-race`, `go mod tidy`, hot-path performance guard, `make lint`
- `mint validate` skipped because local Node is 25.9.0 and Mintlify requires an LTS Node version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated development guide for API specification tooling configuration.

* **Refactor**
  * Refactored API documentation serving mechanism.
  * Updated core project dependencies.

* **Tests**
  * Added test coverage for API documentation endpoints (YAML format and static assets).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->