### PR TITLE
chore: shorten /admin API prefix and polish docs/OpenAPI surface

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -146,7 +146,7 @@
 # =============================================================================
 
 # Enable/disable admin REST API endpoints (default: true)
-# When enabled, provides /admin/api/v1/* REST endpoints
+# When enabled, provides /admin/* REST endpoints
 # ADMIN_ENDPOINTS_ENABLED=true
 
 # Enable/disable admin dashboard UI (default: true)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ all: build
 VERSION ?= $(shell git describe --tags --always --dirty)
 COMMIT ?= $(shell git rev-parse --short HEAD)
 DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-DOCS_API_SERVERS ?= https://gomodel.example.com,http://localhost:8080
+DOCS_API_SERVERS ?= http://localhost:8080
 LOG_LEVEL ?= debug
 SWAGGER_ENABLED ?= true
 

--- a/README.md
+++ b/README.md
@@ -216,23 +216,29 @@ docker run --rm -p 8080:8080 --env-file .env gomodel
 | Endpoint                                   | Method | Description                                |
 | ------------------------------------------ | ------ | ------------------------------------------ |
 | `/admin/dashboard`                         | GET    | Admin dashboard UI                         |
-| `/admin/api/v1/dashboard/config`           | GET    | Dashboard configuration                    |
-| `/admin/api/v1/cache/overview`             | GET    | Cache statistics overview                  |
-| `/admin/api/v1/usage/summary`              | GET    | Aggregate token usage statistics           |
-| `/admin/api/v1/usage/daily`                | GET    | Per-period token usage breakdown           |
-| `/admin/api/v1/usage/models`               | GET    | Usage breakdown by model                   |
-| `/admin/api/v1/usage/user-paths`           | GET    | Usage breakdown by user path               |
-| `/admin/api/v1/usage/log`                  | GET    | Paginated usage log entries                |
-| `/admin/api/v1/audit/log`                  | GET    | Paginated audit log entries                |
-| `/admin/api/v1/audit/conversation`         | GET    | Conversation thread around one audit entry |
-| `/admin/api/v1/providers/status`           | GET    | Provider availability status               |
-| `/admin/api/v1/runtime/refresh`            | POST   | Refresh runtime configuration              |
-| `/admin/api/v1/models`                     | GET    | List models with provider type             |
-| `/admin/api/v1/models/categories`          | GET    | List model categories                      |
-| `/admin/api/v1/model-overrides`            | GET    | List model overrides                       |
-| `/admin/api/v1/model-overrides`            | PUT    | Create/update model override               |
-| `/admin/api/v1/model-overrides`            | DELETE | Remove model override                      |
-| `/admin/api/v1/auth-keys`                  | GET    | List authentication keys                   |
+| `/admin/runtime/config`                    | GET    | Admin runtime configuration                |
+| `/admin/cache/overview`             | GET    | Cache statistics overview                  |
+| `/admin/usage/summary`              | GET    | Aggregate token usage statistics           |
+| `/admin/usage/daily`                | GET    | Per-period token usage breakdown           |
+| `/admin/usage/models`               | GET    | Usage breakdown by model                   |
+| `/admin/usage/user-paths`           | GET    | Usage breakdown by user path               |
+| `/admin/usage/log`                  | GET    | Paginated usage log entries                |
+| `/admin/audit/log`                  | GET    | Paginated audit log entries                |
+| `/admin/audit/conversation`         | GET    | Conversation thread around one audit entry |
+| `/admin/providers/status`           | GET    | Provider availability status               |
+| `/admin/runtime/refresh`            | POST   | Refresh runtime configuration              |
+| `/admin/models`                     | GET    | List models with provider type             |
+| `/admin/models/categories`          | GET    | List model categories                      |
+| `/admin/model-overrides`            | GET    | List model overrides                       |
+| `/admin/model-overrides`            | PUT    | Create/update model override               |
+| `/admin/model-overrides`            | DELETE | Remove model override                      |
+| `/admin/auth-keys`                  | GET    | List authentication keys                   |
+
+> **Legacy alias:** Until **2026-08-09**, all admin endpoints are also
+> reachable under `/admin/api/v1/*`. Legacy responses include
+> `Deprecation: true` and `Sunset: Sun, 09 Aug 2026 00:00:00 GMT` headers.
+> The endpoint formerly at `/admin/api/v1/dashboard/config` moved to
+> `/admin/runtime/config` on the new prefix.
 
 ### Operations Endpoints
 

--- a/cmd/gomodel/docs/docs.go
+++ b/cmd/gomodel/docs/docs.go
@@ -16,7 +16,7 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
-        "/admin/api/v1/audit/conversation": {
+        "/admin/audit/conversation": {
             "get": {
                 "produces": [
                     "application/json"
@@ -67,7 +67,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/admin/api/v1/audit/log": {
+        "/admin/audit/log": {
             "get": {
                 "produces": [
                     "application/json"
@@ -189,7 +189,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/admin/api/v1/budgets": {
+        "/admin/budgets": {
             "get": {
                 "produces": [
                     "application/json"
@@ -333,7 +333,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/admin/api/v1/budgets/reset": {
+        "/admin/budgets/reset": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -389,7 +389,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/admin/api/v1/budgets/reset-one": {
+        "/admin/budgets/reset-one": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -445,7 +445,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/admin/api/v1/budgets/settings": {
+        "/admin/budgets/settings": {
             "get": {
                 "produces": [
                     "application/json"
@@ -535,7 +535,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/admin/api/v1/cache/overview": {
+        "/admin/cache/overview": {
             "get": {
                 "produces": [
                     "application/json"
@@ -615,37 +615,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/admin/api/v1/dashboard/config": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "admin"
-                ],
-                "summary": "Get dashboard runtime configuration",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/admin.DashboardConfigResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/core.GatewayError"
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ]
-            }
-        },
-        "/admin/api/v1/model-overrides": {
+        "/admin/model-overrides": {
             "get": {
                 "description": "Lists persisted model access overrides by global, provider-wide, model-wide, or exact selector.\nSelectors support global \"/\", provider-wide \"provider/\", model-wide \"model\", and exact \"provider/model\" scopes.",
                 "produces": [
@@ -814,7 +784,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/admin/api/v1/model-pricing-overrides": {
+        "/admin/model-pricing-overrides": {
             "get": {
                 "description": "Lists persisted USD pricing overrides. Selectors support global \"/\", provider-wide \"provider/\", model-wide \"model\", and exact \"provider/model\" scopes.",
                 "produces": [
@@ -984,7 +954,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/admin/api/v1/models": {
+        "/admin/models": {
             "get": {
                 "produces": [
                     "application/json"
@@ -1031,7 +1001,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/admin/api/v1/models/categories": {
+        "/admin/models/categories": {
             "get": {
                 "produces": [
                     "application/json"
@@ -1064,7 +1034,37 @@ const docTemplate = `{
                 ]
             }
         },
-        "/admin/api/v1/usage/daily": {
+        "/admin/runtime/config": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Get admin runtime configuration",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.DashboardConfigResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/admin/usage/daily": {
             "get": {
                 "produces": [
                     "application/json"
@@ -1141,7 +1141,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/admin/api/v1/usage/log": {
+        "/admin/usage/log": {
             "get": {
                 "produces": [
                     "application/json"
@@ -1239,7 +1239,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/admin/api/v1/usage/models": {
+        "/admin/usage/models": {
             "get": {
                 "produces": [
                     "application/json"
@@ -1310,7 +1310,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/admin/api/v1/usage/recalculate-pricing": {
+        "/admin/usage/recalculate-pricing": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -1372,7 +1372,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/admin/api/v1/usage/summary": {
+        "/admin/usage/summary": {
             "get": {
                 "produces": [
                     "application/json"
@@ -1440,7 +1440,7 @@ const docTemplate = `{
                 ]
             }
         },
-        "/admin/api/v1/usage/user-paths": {
+        "/admin/usage/user-paths": {
             "get": {
                 "produces": [
                     "application/json"

--- a/config/config_helpers_test.go
+++ b/config/config_helpers_test.go
@@ -192,9 +192,9 @@ func TestJoinBasePath(t *testing.T) {
 		urlPath  string
 		expected string
 	}{
-		{name: "root leaves absolute path unchanged", basePath: "/", urlPath: "/admin/api/v1", expected: "/admin/api/v1"},
-		{name: "root adds leading slash", basePath: "/", urlPath: "admin/api/v1", expected: "/admin/api/v1"},
-		{name: "prefixes normalized base path", basePath: "g/", urlPath: "/admin/api/v1", expected: "/g/admin/api/v1"},
+		{name: "root leaves absolute path unchanged", basePath: "/", urlPath: "/admin", expected: "/admin"},
+		{name: "root adds leading slash", basePath: "/", urlPath: "admin", expected: "/admin"},
+		{name: "prefixes normalized base path", basePath: "g/", urlPath: "/admin", expected: "/g/admin"},
 		{name: "empty app path resolves to base path", basePath: "/g", urlPath: "", expected: "/g"},
 		{name: "root app path resolves to base path", basePath: "/g", urlPath: "/", expected: "/g"},
 	}

--- a/docs/advanced/admin-endpoints.mdx
+++ b/docs/advanced/admin-endpoints.mdx
@@ -10,7 +10,7 @@ GoModel ships with admin endpoints **enabled by default**. The goal is simple: y
 
 The admin layer is split into two independently controllable pieces:
 
-1. **Admin REST API** (`/admin/api/v1/*`) — machine-readable JSON endpoints for usage data, budgets, and model inventory. Protected by `GOMODEL_MASTER_KEY` like all other API routes.
+1. **Admin REST API** (`/admin/*`) — machine-readable JSON endpoints for usage data, budgets, and model inventory. Protected by `GOMODEL_MASTER_KEY` like all other API routes.
 2. **Admin Dashboard UI** (`/admin/dashboard`) — a lightweight, embedded HTML dashboard that visualizes the same data. No external dependencies, no JavaScript frameworks to install — it's compiled into the binary.
 
 Both are on by default because observability shouldn't be opt-in. If you don't need them, turn them off with a single environment variable.
@@ -38,11 +38,11 @@ admin:
 
 ## Authentication
 
-The admin REST API endpoints (`/admin/api/v1/*`) are protected by the same `GOMODEL_MASTER_KEY` authentication as the main API routes. Include the key as a Bearer token:
+The admin REST API endpoints (`/admin/*`) are protected by the same `GOMODEL_MASTER_KEY` authentication as the main API routes. Include the key as a Bearer token:
 
 ```bash
 curl -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
-  http://localhost:8080/admin/api/v1/usage/summary
+  http://localhost:8080/admin/usage/summary
 ```
 
 The dashboard UI pages (`/admin/dashboard`) and static assets (`/admin/static/*`) **skip authentication** so the dashboard is accessible without configuring API keys in the browser.
@@ -55,9 +55,18 @@ The dashboard UI pages (`/admin/dashboard`) and static assets (`/admin/static/*`
 
 ## REST API Endpoints
 
-All admin API endpoints are mounted under `/admin/api/v1`.
+All admin API endpoints are mounted under `/admin`.
 
-### GET /admin/api/v1/usage/summary
+<Note>
+  **Legacy path alias** — until **2026-08-09**, the same endpoints are also
+  reachable under `/admin/api/v1/*`. Responses on the legacy path carry
+  `Deprecation: true`, `Sunset: Sun, 09 Aug 2026 00:00:00 GMT`, and a `Link`
+  header pointing to the new path. To migrate, replace `/admin/api/v1/` with
+  `/admin/` in your scripts. One endpoint also moved within `/admin`:
+  `/admin/api/v1/dashboard/config` → `/admin/runtime/config`.
+</Note>
+
+### GET /admin/usage/summary
 
 Returns aggregate token usage statistics over a configurable time window.
 
@@ -84,7 +93,7 @@ Use `start_date`/`end_date` for explicit ranges or `days` as a shorthand. When b
 
 If usage tracking is disabled, returns zeroed values.
 
-### GET /admin/api/v1/usage/daily
+### GET /admin/usage/daily
 
 Returns per-period token usage breakdown over a configurable time window, grouped by the specified interval.
 
@@ -124,18 +133,18 @@ Returns an empty array if usage tracking is disabled or no data exists for the p
 
 ### Budget endpoints
 
-Budgets are managed under `/admin/api/v1/budgets`. These endpoints are
+Budgets are managed under `/admin/budgets`. These endpoints are
 available when budget management is enabled.
 
 | Method   | Path                                  | Description                          |
 | -------- | ------------------------------------- | ------------------------------------ |
-| `GET`    | `/admin/api/v1/budgets`               | List budgets with current status     |
-| `PUT`    | `/admin/api/v1/budgets/{user_path}/{period}` | Create or update one budget          |
-| `DELETE` | `/admin/api/v1/budgets/{user_path}/{period}` | Delete one budget                    |
-| `GET`    | `/admin/api/v1/budgets/settings`      | Read budget reset settings           |
-| `PUT`    | `/admin/api/v1/budgets/settings`      | Update budget reset settings         |
-| `POST`   | `/admin/api/v1/budgets/reset-one`     | Reset one budget period              |
-| `POST`   | `/admin/api/v1/budgets/reset`         | Reset all budget periods             |
+| `GET`    | `/admin/budgets`               | List budgets with current status     |
+| `PUT`    | `/admin/budgets/{user_path}/{period}` | Create or update one budget          |
+| `DELETE` | `/admin/budgets/{user_path}/{period}` | Delete one budget                    |
+| `GET`    | `/admin/budgets/settings`      | Read budget reset settings           |
+| `PUT`    | `/admin/budgets/settings`      | Update budget reset settings         |
+| `POST`   | `/admin/budgets/reset-one`     | Reset one budget period              |
+| `POST`   | `/admin/budgets/reset`         | Reset all budget periods             |
 
 `PUT`, `DELETE`, and `reset-one` identify one budget by the composite
 `(user_path, period)` key, or `(user_path, period_seconds)` for custom periods.
@@ -145,7 +154,7 @@ the request shape.
 
 See [Budgets](/features/budgets) for request examples and enforcement behavior.
 
-### GET /admin/api/v1/models
+### GET /admin/models
 
 Returns all registered models with both provider type and configured provider name.
 

--- a/docs/advanced/workflows.mdx
+++ b/docs/advanced/workflows.mdx
@@ -96,7 +96,7 @@ Even though both have provider type `openai`, they are different workflow scopes
 Create a workflow scoped to one configured provider name, one model, and one user-path subtree:
 
 ```bash
-curl -X POST http://localhost:8080/admin/api/v1/workflows \
+curl -X POST http://localhost:8080/admin/workflows \
   -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
   -H "Content-Type: application/json" \
   -d '{

--- a/docs/dev/2026-03-16_ARCHITECTURE_SNAPSHOT.md
+++ b/docs/dev/2026-03-16_ARCHITECTURE_SNAPSHOT.md
@@ -144,7 +144,7 @@ Echo + Handler"]
     Server --> HTTP["HTTP surface
 - /v1/*
 - /p/*
-- /admin/api/v1/*
+- /admin/*
 - /admin/dashboard
 - /metrics
 - /health
@@ -467,7 +467,7 @@ File request path:
 ## 6. Side Paths Outside The Main Ingress Pipeline
 
 - `GET /v1/models`: `Handler.ListModels` calls `providers.Router.ListModels()` and then merges alias-exposed models from `aliases.Service`.
-- `/admin/api/v1/*`: reads usage and audit storage, model registry, and alias service through `admin.Handler`.
+- `/admin/*`: reads usage and audit storage, model registry, and alias service through `admin.Handler`.
 - `/admin/dashboard`: dashboard UI handler over the same underlying readers.
 - `/metrics`: Prometheus endpoint when enabled.
 - `/health`: simple health check.

--- a/docs/features/budgets.mdx
+++ b/docs/features/budgets.mdx
@@ -182,13 +182,13 @@ Budget management is also available through the admin API:
 
 ```bash
 curl -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
-  http://localhost:8080/admin/api/v1/budgets
+  http://localhost:8080/admin/budgets
 ```
 
 Create or update a budget:
 
 ```bash
-curl -X PUT http://localhost:8080/admin/api/v1/budgets/%2Fteam%2Falpha/daily \
+curl -X PUT http://localhost:8080/admin/budgets/%2Fteam%2Falpha/daily \
   -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -199,7 +199,7 @@ curl -X PUT http://localhost:8080/admin/api/v1/budgets/%2Fteam%2Falpha/daily \
 Delete a budget:
 
 ```bash
-curl -X DELETE http://localhost:8080/admin/api/v1/budgets/%2Fteam%2Falpha/daily \
+curl -X DELETE http://localhost:8080/admin/budgets/%2Fteam%2Falpha/daily \
   -H "Authorization: Bearer $GOMODEL_MASTER_KEY"
 ```
 

--- a/docs/features/cache.mdx
+++ b/docs/features/cache.mdx
@@ -114,7 +114,7 @@ When response caching and usage tracking are enabled, the admin API exposes a
 cached-only overview at:
 
 ```text
-/admin/api/v1/cache/overview
+/admin/cache/overview
 ```
 
 Cached usage entries are also visible in the regular usage log and summary

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -93,7 +93,7 @@ Open this URL in your browser:
 
 <Tip>
   Dashboard UI is enabled by default (`ADMIN_UI_ENABLED=true`). Admin API
-  endpoints are at `/admin/api/v1/*` and use the same bearer auth as the main
+  endpoints are at `/admin/*` and use the same bearer auth as the main
   API.
 </Tip>
 

--- a/docs/guides/deepseek.mdx
+++ b/docs/guides/deepseek.mdx
@@ -1,5 +1,5 @@
 ---
-title: "GoModel & DeepSeek"
+title: "DeepSeek"
 description: "Configure DeepSeek V4 in GoModel and understand how reasoning effort is mapped to DeepSeek's reasoning_effort field."
 icon: "brain"
 ---

--- a/docs/guides/gemini.mdx
+++ b/docs/guides/gemini.mdx
@@ -1,5 +1,5 @@
 ---
-title: "GoModel & Google Gemini"
+title: "Google Gemini"
 description: "Configure Google Gemini in GoModel, choose native or OpenAI-compatible routing, and understand image_url behavior."
 icon: "sparkles"
 ---

--- a/docs/guides/multiple-ollama.mdx
+++ b/docs/guides/multiple-ollama.mdx
@@ -1,5 +1,5 @@
 ---
-title: "GoModel & Ollama"
+title: "Ollama"
 description: "Use one GoModel instance with multiple Ollama providers through suffixed environment variables and provider-qualified model IDs."
 icon: "network"
 ---

--- a/docs/guides/oracle.mdx
+++ b/docs/guides/oracle.mdx
@@ -1,5 +1,5 @@
 ---
-title: "GoModel & Oracle"
+title: "Oracle"
 description: "Configure Oracle's OpenAI-compatible Generative AI endpoint in GoModel, including the required OCI policy and configured model lists."
 icon: "cloud"
 ---

--- a/docs/guides/vllm.mdx
+++ b/docs/guides/vllm.mdx
@@ -1,5 +1,5 @@
 ---
-title: "GoModel & vLLM"
+title: "vLLM"
 description: "Route OpenAI-compatible GoModel requests to one or more vLLM servers, including slash-shaped Hugging Face model IDs."
 icon: "server"
 ---

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -68,7 +68,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/audit/conversation"
+          }
+        }
       }
     },
     "/admin/audit/log": {
@@ -227,7 +232,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/audit/log"
+          }
+        }
       }
     },
     "/admin/budgets": {
@@ -272,7 +282,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/budgets"
+          }
+        }
       },
       "put": {
         "tags": [
@@ -336,7 +351,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/budgets"
+          }
+        }
       },
       "delete": {
         "tags": [
@@ -400,7 +420,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/budgets"
+          }
+        }
       }
     },
     "/admin/budgets/reset": {
@@ -466,7 +491,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/budgets/reset"
+          }
+        }
       }
     },
     "/admin/budgets/reset-one": {
@@ -532,7 +562,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/budgets/reset-one"
+          }
+        }
       }
     },
     "/admin/budgets/settings": {
@@ -577,7 +612,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/budgets/settings"
+          }
+        }
       },
       "put": {
         "tags": [
@@ -641,7 +681,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/budgets/settings"
+          }
+        }
       }
     },
     "/admin/cache/overview": {
@@ -746,7 +791,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/cache/overview"
+          }
+        }
       }
     },
     "/admin/model-overrides": {
@@ -797,7 +847,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/model-overrides"
+          }
+        }
       },
       "put": {
         "tags": [
@@ -881,7 +936,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/model-overrides"
+          }
+        }
       },
       "delete": {
         "tags": [
@@ -958,7 +1018,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/model-overrides"
+          }
+        }
       }
     },
     "/admin/model-pricing-overrides": {
@@ -1009,7 +1074,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/model-pricing-overrides"
+          }
+        }
       },
       "put": {
         "description": "Stores USD-only pricing for one selector. More precise selectors override broader selectors at runtime.",
@@ -1094,7 +1164,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/model-pricing-overrides"
+          }
+        }
       },
       "delete": {
         "tags": [
@@ -1171,7 +1246,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/model-pricing-overrides"
+          }
+        }
       }
     },
     "/admin/models": {
@@ -1231,7 +1311,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/models"
+          }
+        }
       }
     },
     "/admin/models/categories": {
@@ -1269,7 +1354,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/models/categories"
+          }
+        }
       }
     },
     "/admin/runtime/config": {
@@ -1304,7 +1394,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/runtime/config"
+          }
+        }
       }
     },
     "/admin/usage/daily": {
@@ -1402,7 +1497,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/usage/daily"
+          }
+        }
       }
     },
     "/admin/usage/log": {
@@ -1529,7 +1629,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/usage/log"
+          }
+        }
       }
     },
     "/admin/usage/models": {
@@ -1619,7 +1724,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/usage/models"
+          }
+        }
       }
     },
     "/admin/usage/recalculate-pricing": {
@@ -1695,7 +1805,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/usage/recalculate-pricing"
+          }
+        }
       }
     },
     "/admin/usage/summary": {
@@ -1782,7 +1897,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/usage/summary"
+          }
+        }
       }
     },
     "/admin/usage/user-paths": {
@@ -1872,7 +1992,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/usage/user-paths"
+          }
+        }
       }
     },
     "/health": {
@@ -1894,6 +2019,11 @@
                 }
               }
             }
+          }
+        },
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/health"
           }
         }
       }
@@ -2080,7 +2210,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/p/{provider}/{endpoint}"
+          }
+        }
       },
       "put": {
         "description": "Runtime-configurable passthrough endpoint under /p/{provider}/{endpoint}; enabled by default via server.enable_passthrough_routes. The endpoint path is opaque and may proxy JSON, binary, or SSE responses with upstream status codes preserved. For multi-segment provider endpoints, clients that rely on OpenAPI-generated path handling should URL-encode embedded slashes in the endpoint parameter. A leading v1/ segment is normalized away by default so /p/{provider}/v1/... and /p/{provider}/... map to the same upstream path relative to the provider base URL.",
@@ -2263,7 +2398,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/p/{provider}/{endpoint}"
+          }
+        }
       },
       "post": {
         "description": "Runtime-configurable passthrough endpoint under /p/{provider}/{endpoint}; enabled by default via server.enable_passthrough_routes. The endpoint path is opaque and may proxy JSON, binary, or SSE responses with upstream status codes preserved. For multi-segment provider endpoints, clients that rely on OpenAPI-generated path handling should URL-encode embedded slashes in the endpoint parameter. A leading v1/ segment is normalized away by default so /p/{provider}/v1/... and /p/{provider}/... map to the same upstream path relative to the provider base URL.",
@@ -2446,7 +2586,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/p/{provider}/{endpoint}"
+          }
+        }
       },
       "delete": {
         "description": "Runtime-configurable passthrough endpoint under /p/{provider}/{endpoint}; enabled by default via server.enable_passthrough_routes. The endpoint path is opaque and may proxy JSON, binary, or SSE responses with upstream status codes preserved. For multi-segment provider endpoints, clients that rely on OpenAPI-generated path handling should URL-encode embedded slashes in the endpoint parameter. A leading v1/ segment is normalized away by default so /p/{provider}/v1/... and /p/{provider}/... map to the same upstream path relative to the provider base URL.",
@@ -2629,7 +2774,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/p/{provider}/{endpoint}"
+          }
+        }
       },
       "options": {
         "description": "Runtime-configurable passthrough endpoint under /p/{provider}/{endpoint}; enabled by default via server.enable_passthrough_routes. The endpoint path is opaque and may proxy JSON, binary, or SSE responses with upstream status codes preserved. For multi-segment provider endpoints, clients that rely on OpenAPI-generated path handling should URL-encode embedded slashes in the endpoint parameter. A leading v1/ segment is normalized away by default so /p/{provider}/v1/... and /p/{provider}/... map to the same upstream path relative to the provider base URL.",
@@ -2812,7 +2962,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/p/{provider}/{endpoint}"
+          }
+        }
       },
       "head": {
         "description": "Runtime-configurable passthrough endpoint under /p/{provider}/{endpoint}; enabled by default via server.enable_passthrough_routes. The endpoint path is opaque and may proxy JSON, binary, or SSE responses with upstream status codes preserved. For multi-segment provider endpoints, clients that rely on OpenAPI-generated path handling should URL-encode embedded slashes in the endpoint parameter. A leading v1/ segment is normalized away by default so /p/{provider}/v1/... and /p/{provider}/... map to the same upstream path relative to the provider base URL.",
@@ -2995,7 +3150,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/p/{provider}/{endpoint}"
+          }
+        }
       },
       "patch": {
         "description": "Runtime-configurable passthrough endpoint under /p/{provider}/{endpoint}; enabled by default via server.enable_passthrough_routes. The endpoint path is opaque and may proxy JSON, binary, or SSE responses with upstream status codes preserved. For multi-segment provider endpoints, clients that rely on OpenAPI-generated path handling should URL-encode embedded slashes in the endpoint parameter. A leading v1/ segment is normalized away by default so /p/{provider}/v1/... and /p/{provider}/... map to the same upstream path relative to the provider base URL.",
@@ -3178,7 +3338,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/p/{provider}/{endpoint}"
+          }
+        }
       }
     },
     "/v1/batches": {
@@ -3261,7 +3426,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/v1/batches"
+          }
+        }
       },
       "post": {
         "tags": [
@@ -3325,7 +3495,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/v1/batches"
+          }
+        }
       }
     },
     "/v1/batches/{id}": {
@@ -3411,7 +3586,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/v1/batches/{id}"
+          }
+        }
       }
     },
     "/v1/batches/{id}/cancel": {
@@ -3497,7 +3677,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/v1/batches/{id}/cancel"
+          }
+        }
       }
     },
     "/v1/batches/{id}/results": {
@@ -3593,7 +3778,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/v1/batches/{id}/results"
+          }
+        }
       }
     },
     "/v1/chat/completions": {
@@ -3694,7 +3884,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/v1/chat/completions"
+          }
+        }
       }
     },
     "/v1/embeddings": {
@@ -3770,7 +3965,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/v1/embeddings"
+          }
+        }
       }
     },
     "/v1/files": {
@@ -3869,7 +4069,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/v1/files"
+          }
+        }
       },
       "post": {
         "tags": [
@@ -3957,7 +4162,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/v1/files"
+          }
+        }
       }
     },
     "/v1/files/{id}": {
@@ -4041,7 +4251,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/v1/files/{id}"
+          }
+        }
       },
       "delete": {
         "tags": [
@@ -4123,7 +4338,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/v1/files/{id}"
+          }
+        }
       }
     },
     "/v1/files/{id}/content": {
@@ -4208,7 +4428,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/v1/files/{id}/content"
+          }
+        }
       }
     },
     "/v1/models": {
@@ -4253,7 +4478,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/v1/models"
+          }
+        }
       }
     },
     "/v1/responses": {
@@ -4354,7 +4584,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/v1/responses"
+          }
+        }
       }
     },
     "/v1/responses/compact": {
@@ -4430,7 +4665,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/v1/responses/compact"
+          }
+        }
       }
     },
     "/v1/responses/input_tokens": {
@@ -4506,7 +4746,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/v1/responses/input_tokens"
+          }
+        }
       }
     },
     "/v1/responses/{id}": {
@@ -4640,7 +4885,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/v1/responses/{id}"
+          }
+        }
       },
       "delete": {
         "tags": [
@@ -4732,7 +4982,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/v1/responses/{id}"
+          }
+        }
       }
     },
     "/v1/responses/{id}/cancel": {
@@ -4826,7 +5081,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/v1/responses/{id}/cancel"
+          }
+        }
       }
     },
     "/v1/responses/{id}/input_items": {
@@ -4972,7 +5232,12 @@
           {
             "BearerAuth": []
           }
-        ]
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/v1/responses/{id}/input_items"
+          }
+        }
       }
     }
   },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7,7 +7,7 @@
     "version": "1.0"
   },
   "paths": {
-    "/admin/api/v1/audit/conversation": {
+    "/admin/audit/conversation": {
       "get": {
         "tags": [
           "admin"
@@ -71,7 +71,7 @@
         ]
       }
     },
-    "/admin/api/v1/audit/log": {
+    "/admin/audit/log": {
       "get": {
         "tags": [
           "admin"
@@ -230,7 +230,7 @@
         ]
       }
     },
-    "/admin/api/v1/budgets": {
+    "/admin/budgets": {
       "get": {
         "tags": [
           "admin"
@@ -403,7 +403,7 @@
         ]
       }
     },
-    "/admin/api/v1/budgets/reset": {
+    "/admin/budgets/reset": {
       "post": {
         "tags": [
           "admin"
@@ -469,7 +469,7 @@
         ]
       }
     },
-    "/admin/api/v1/budgets/reset-one": {
+    "/admin/budgets/reset-one": {
       "post": {
         "tags": [
           "admin"
@@ -535,7 +535,7 @@
         ]
       }
     },
-    "/admin/api/v1/budgets/settings": {
+    "/admin/budgets/settings": {
       "get": {
         "tags": [
           "admin"
@@ -644,7 +644,7 @@
         ]
       }
     },
-    "/admin/api/v1/cache/overview": {
+    "/admin/cache/overview": {
       "get": {
         "tags": [
           "admin"
@@ -749,42 +749,7 @@
         ]
       }
     },
-    "/admin/api/v1/dashboard/config": {
-      "get": {
-        "tags": [
-          "admin"
-        ],
-        "summary": "Get dashboard runtime configuration",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/admin.DashboardConfigResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/core.GatewayError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ]
-      }
-    },
-    "/admin/api/v1/model-overrides": {
+    "/admin/model-overrides": {
       "get": {
         "description": "Lists persisted model access overrides by global, provider-wide, model-wide, or exact selector.\nSelectors support global \"/\", provider-wide \"provider/\", model-wide \"model\", and exact \"provider/model\" scopes.",
         "tags": [
@@ -996,7 +961,7 @@
         ]
       }
     },
-    "/admin/api/v1/model-pricing-overrides": {
+    "/admin/model-pricing-overrides": {
       "get": {
         "description": "Lists persisted USD pricing overrides. Selectors support global \"/\", provider-wide \"provider/\", model-wide \"model\", and exact \"provider/model\" scopes.",
         "tags": [
@@ -1209,7 +1174,7 @@
         ]
       }
     },
-    "/admin/api/v1/models": {
+    "/admin/models": {
       "get": {
         "tags": [
           "admin"
@@ -1269,7 +1234,7 @@
         ]
       }
     },
-    "/admin/api/v1/models/categories": {
+    "/admin/models/categories": {
       "get": {
         "tags": [
           "admin"
@@ -1307,7 +1272,42 @@
         ]
       }
     },
-    "/admin/api/v1/usage/daily": {
+    "/admin/runtime/config": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Get admin runtime configuration",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/admin.DashboardConfigResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ]
+      }
+    },
+    "/admin/usage/daily": {
       "get": {
         "tags": [
           "admin"
@@ -1405,7 +1405,7 @@
         ]
       }
     },
-    "/admin/api/v1/usage/log": {
+    "/admin/usage/log": {
       "get": {
         "tags": [
           "admin"
@@ -1532,7 +1532,7 @@
         ]
       }
     },
-    "/admin/api/v1/usage/models": {
+    "/admin/usage/models": {
       "get": {
         "tags": [
           "admin"
@@ -1622,7 +1622,7 @@
         ]
       }
     },
-    "/admin/api/v1/usage/recalculate-pricing": {
+    "/admin/usage/recalculate-pricing": {
       "post": {
         "tags": [
           "admin"
@@ -1698,7 +1698,7 @@
         ]
       }
     },
-    "/admin/api/v1/usage/summary": {
+    "/admin/usage/summary": {
       "get": {
         "tags": [
           "admin"
@@ -1785,7 +1785,7 @@
         ]
       }
     },
-    "/admin/api/v1/usage/user-paths": {
+    "/admin/usage/user-paths": {
       "get": {
         "tags": [
           "admin"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5243,12 +5243,14 @@
   },
   "servers": [
     {
-      "url": "https://gomodel.example.com",
-      "description": "GoModel HTTPS deployment"
-    },
-    {
-      "url": "http://localhost:8080",
-      "description": "Local GoModel"
+      "url": "{base_url}",
+      "description": "Edit the base URL to point at your GoModel deployment.",
+      "variables": {
+        "base_url": {
+          "default": "http://localhost:8080",
+          "description": "Your GoModel deployment URL"
+        }
+      }
     }
   ],
   "components": {

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -632,7 +632,7 @@ function dashboard() {
         const request = this.requestOptions({
           method: "POST",
         });
-        const res = await fetch("/admin/api/v1/runtime/refresh", request);
+        const res = await fetch("/admin/runtime/refresh", request);
         const handled = this.handleFetchResponse(
           res,
           "runtime refresh",
@@ -802,7 +802,7 @@ function dashboard() {
 
       this.modelsLoading = true;
       try {
-        let url = "/admin/api/v1/models";
+        let url = "/admin/models";
         if (this.activeCategory && this.activeCategory !== "all") {
           url += "?category=" + encodeURIComponent(this.activeCategory);
         }
@@ -853,7 +853,7 @@ function dashboard() {
     async fetchCategories() {
       const request = this.requestOptions();
       try {
-        const res = await fetch("/admin/api/v1/models/categories", request);
+        const res = await fetch("/admin/models/categories", request);
         const handled = this.handleFetchResponse(res, "categories", request);
         if (this.isStaleAuthFetchResult(handled)) {
           return;

--- a/internal/admin/dashboard/static/js/modules/aliases.js
+++ b/internal/admin/dashboard/static/js/modules/aliases.js
@@ -157,7 +157,7 @@
                 this.aliasError = '';
                 try {
                     const request = this.adminRequestOptions();
-                    const res = await fetch('/admin/api/v1/aliases', request);
+                    const res = await fetch('/admin/aliases', request);
                     if (res.status === 503) {
                         this.aliasesAvailable = false;
                         this.aliases = [];
@@ -191,7 +191,7 @@
                 this.modelOverrideError = '';
                 try {
                     const request = this.adminRequestOptions();
-                    const res = await fetch('/admin/api/v1/model-overrides', request);
+                    const res = await fetch('/admin/model-overrides', request);
                     if (res.status === 503) {
                         this.modelOverridesAvailable = false;
                         this.modelOverrideViews = [];
@@ -712,7 +712,7 @@
                         method: 'PUT',
                         body: JSON.stringify(payload)
                     });
-                    const res = await fetch('/admin/api/v1/aliases', request);
+                    const res = await fetch('/admin/aliases', request);
                     if (res.status === 503) {
                         this.aliasesAvailable = false;
                         this.aliasError = 'Aliases feature is unavailable.';
@@ -914,7 +914,7 @@
                         method: 'PUT',
                         body: JSON.stringify(payload)
                     });
-                    const saveRes = await fetch('/admin/api/v1/aliases', saveRequest);
+                    const saveRes = await fetch('/admin/aliases', saveRequest);
 
                     if (saveRes.status === 503) {
                         this.aliasesAvailable = false;
@@ -937,7 +937,7 @@
                             method: 'DELETE',
                             body: JSON.stringify({ name: originalName })
                         });
-                        const deleteRes = await fetch('/admin/api/v1/aliases', deleteRequest);
+                        const deleteRes = await fetch('/admin/aliases', deleteRequest);
                         if (deleteRes.status !== 404) {
                             const deleteHandled = this.handleFetchResponse(deleteRes, 'previous alias', deleteRequest);
                             if (typeof this.isStaleAuthFetchResult === 'function' && this.isStaleAuthFetchResult(deleteHandled)) {
@@ -980,7 +980,7 @@
                         method: 'DELETE',
                         body: JSON.stringify({ name: alias.name })
                     });
-                    const res = await fetch('/admin/api/v1/aliases', request);
+                    const res = await fetch('/admin/aliases', request);
                     if (res.status === 503) {
                         this.aliasesAvailable = false;
                         this.aliasError = 'Aliases feature is unavailable.';
@@ -1036,7 +1036,7 @@
                         method: 'PUT',
                         body: JSON.stringify(payload)
                     });
-                    const res = await fetch('/admin/api/v1/model-overrides', request);
+                    const res = await fetch('/admin/model-overrides', request);
                     if (res.status === 503) {
                         this.modelOverridesAvailable = false;
                         this.modelOverrideError = 'Model overrides feature is unavailable.';
@@ -1083,7 +1083,7 @@
                         method: 'DELETE',
                         body: JSON.stringify({ selector })
                     });
-                    const res = await fetch('/admin/api/v1/model-overrides', request);
+                    const res = await fetch('/admin/model-overrides', request);
                     if (res.status === 503) {
                         this.modelOverridesAvailable = false;
                         this.modelOverrideError = 'Model overrides feature is unavailable.';

--- a/internal/admin/dashboard/static/js/modules/aliases.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/aliases.test.cjs
@@ -116,8 +116,8 @@ test('model override mutations send selector in JSON body', async() => {
     await module.deleteModelOverride();
 
     assert.equal(requests.length, 2);
-    assert.equal(requests[0].url, '/admin/api/v1/model-overrides');
-    assert.equal(requests[1].url, '/admin/api/v1/model-overrides');
+    assert.equal(requests[0].url, '/admin/model-overrides');
+    assert.equal(requests[1].url, '/admin/model-overrides');
     assert.deepEqual(JSON.parse(requests[0].request.body), {
         selector: 'openrouter/meta-llama/llama-3.1-8b-instruct',
         user_paths: ['/team/alpha']
@@ -179,9 +179,9 @@ test('alias mutations send alias name in JSON body', async() => {
 
     assert.equal(requests.length, 3);
     assert.deepEqual(requests.map((request) => request.url), [
-        '/admin/api/v1/aliases',
-        '/admin/api/v1/aliases',
-        '/admin/api/v1/aliases'
+        '/admin/aliases',
+        '/admin/aliases',
+        '/admin/aliases'
     ]);
     assert.deepEqual(requests.map((request) => request.request.method), ['PUT', 'PUT', 'DELETE']);
     assert.deepEqual(JSON.parse(requests[0].request.body), {

--- a/internal/admin/dashboard/static/js/modules/audit-list.js
+++ b/internal/admin/dashboard/static/js/modules/audit-list.js
@@ -143,7 +143,7 @@
                     if (this.auditStream) qs += '&stream=' + encodeURIComponent(this.auditStream);
 
                     const request = typeof this.requestOptions === 'function' ? this.requestOptions() : { headers: this.headers() };
-                    const res = await fetch('/admin/api/v1/audit/log?' + qs, request);
+                    const res = await fetch('/admin/audit/log?' + qs, request);
                     const handled = this.handleFetchResponse(res, 'audit log', request);
                     if (typeof this.isStaleAuthFetchResult === 'function' && this.isStaleAuthFetchResult(handled)) {
                         return;

--- a/internal/admin/dashboard/static/js/modules/auth-keys.js
+++ b/internal/admin/dashboard/static/js/modules/auth-keys.js
@@ -91,7 +91,7 @@
                 this.authKeyError = '';
                 try {
                     const request = typeof this.requestOptions === 'function' ? this.requestOptions() : { headers: this.headers() };
-                    const res = await fetch('/admin/api/v1/auth-keys', request);
+                    const res = await fetch('/admin/auth-keys', request);
                     if (res.status === 503) {
                         this.authKeysAvailable = false;
                         this.authKeys = [];
@@ -212,7 +212,7 @@
                             headers: this.headers(),
                             body: JSON.stringify(payload)
                         };
-                    const res = await fetch('/admin/api/v1/auth-keys', request);
+                    const res = await fetch('/admin/auth-keys', request);
                     if (res.status === 503) {
                         this.authKeysAvailable = false;
                         this.authKeyError = 'Auth keys feature is unavailable.';
@@ -277,7 +277,7 @@
                             method: 'POST',
                             headers: this.headers()
                         };
-                    const res = await fetch('/admin/api/v1/auth-keys/' + encodeURIComponent(key.id) + '/deactivate', request);
+                    const res = await fetch('/admin/auth-keys/' + encodeURIComponent(key.id) + '/deactivate', request);
                     if (res.status === 503) {
                         this.authKeysAvailable = false;
                         this.authKeyError = 'Auth keys feature is unavailable.';

--- a/internal/admin/dashboard/static/js/modules/auth-keys.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/auth-keys.test.cjs
@@ -74,7 +74,7 @@ test('submitAuthKeyForm serializes date-only expirations to the end of the selec
     await module.submitAuthKeyForm();
 
     assert.equal(requests.length, 1);
-    assert.equal(requests[0].url, '/admin/api/v1/auth-keys');
+    assert.equal(requests[0].url, '/admin/auth-keys');
     assert.equal(
         JSON.parse(requests[0].options.body).expires_at,
         '2026-04-01T23:59:59Z'

--- a/internal/admin/dashboard/static/js/modules/budgets.js
+++ b/internal/admin/dashboard/static/js/modules/budgets.js
@@ -251,7 +251,7 @@
                 this.budgetError = '';
                 try {
                     const request = typeof this.requestOptions === 'function' ? this.requestOptions() : { headers: this.headers() };
-                    const res = await fetch('/admin/api/v1/budgets', request);
+                    const res = await fetch('/admin/budgets', request);
                     if (res.status === 503) {
                         this.budgetsAvailable = false;
                         this.budgets = [];
@@ -454,7 +454,7 @@
                                 amount: payload.amount
                             })
                         };
-                    const res = await fetch('/admin/api/v1/budgets', request);
+                    const res = await fetch('/admin/budgets', request);
                     if (res.status === 503) {
                         this.budgetsAvailable = false;
                         this.budgetFormError = 'Budget management is unavailable.';
@@ -511,7 +511,7 @@
                                 period_seconds: item.period_seconds
                             })
                         };
-                    const res = await fetch('/admin/api/v1/budgets/reset-one', request);
+                    const res = await fetch('/admin/budgets/reset-one', request);
                     if (res.status === 503) {
                         this.budgetsAvailable = false;
                         this.budgetError = 'Budget management is unavailable.';
@@ -571,7 +571,7 @@
                                 }
                             })
                         };
-                    const res = await fetch('/admin/api/v1/budgets', request);
+                    const res = await fetch('/admin/budgets', request);
                     if (res.status === 503) {
                         this.budgetsAvailable = false;
                         this.budgetError = 'Budget management is unavailable.';
@@ -791,7 +791,7 @@
                 this.budgetSettingsError = '';
                 try {
                     const request = this.requestOptions();
-                    const res = await fetch('/admin/api/v1/budgets/settings', request);
+                    const res = await fetch('/admin/budgets/settings', request);
                     const handled = this.handleFetchResponse(res, 'budget settings', request);
                     if (typeof this.isStaleAuthFetchResult === 'function' && this.isStaleAuthFetchResult(handled)) {
                         return;
@@ -821,7 +821,7 @@
                         method: 'PUT',
                         body: JSON.stringify(this.budgetSettingsPayload())
                     });
-                    const res = await fetch('/admin/api/v1/budgets/settings', request);
+                    const res = await fetch('/admin/budgets/settings', request);
                     const handled = this.handleFetchResponse(res, 'budget settings', request);
                     if (typeof this.isStaleAuthFetchResult === 'function' && this.isStaleAuthFetchResult(handled)) {
                         return;
@@ -905,7 +905,7 @@
                         method: 'POST',
                         body: JSON.stringify({ confirmation: 'reset' })
                     });
-                    const res = await fetch('/admin/api/v1/budgets/reset', request);
+                    const res = await fetch('/admin/budgets/reset', request);
                     const handled = this.handleFetchResponse(res, 'budget reset', request);
                     if (typeof this.isStaleAuthFetchResult === 'function' && this.isStaleAuthFetchResult(handled)) {
                         return;

--- a/internal/admin/dashboard/static/js/modules/budgets.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/budgets.test.cjs
@@ -120,7 +120,7 @@ test('fetchBudgets reads budget rows from the list envelope', async () => {
     let renderIconsCalls = 0;
     const module = createBudgetsModule({
         fetch(url) {
-            assert.equal(url, '/admin/api/v1/budgets');
+            assert.equal(url, '/admin/budgets');
             return Promise.resolve({
                 status: 200,
                 ok: true,
@@ -209,7 +209,7 @@ test('confirmBudgetOverride saves the pending create after confirmation', async 
     await module.confirmBudgetOverride();
 
     assert.equal(requests.length, 2);
-    assert.equal(requests[0].url, '/admin/api/v1/budgets');
+    assert.equal(requests[0].url, '/admin/budgets');
     assert.equal(requests[0].request.method, 'PUT');
     assert.equal(requests[0].request.body, JSON.stringify({
         user_path: '/team',
@@ -218,7 +218,7 @@ test('confirmBudgetOverride saves the pending create after confirmation', async 
         },
         amount: 12.5
     }));
-    assert.equal(requests[1].url, '/admin/api/v1/budgets');
+    assert.equal(requests[1].url, '/admin/budgets');
     assert.equal(module.budgetOverrideDialogOpen, false);
     assert.equal(module.budgetFormOpen, false);
     assert.equal(module.budgetNotice, 'Budget saved.');
@@ -342,7 +342,7 @@ test('deleteBudget sends the selected budget key in the body and refreshes from 
     await module.deleteBudget({ user_path: '/team', period_seconds: 86400, period_label: 'daily' });
 
     assert.equal(requests.length, 1);
-    assert.equal(requests[0].url, '/admin/api/v1/budgets');
+    assert.equal(requests[0].url, '/admin/budgets');
     assert.equal(requests[0].request.method, 'DELETE');
     assert.equal(requests[0].request.body, JSON.stringify({
         user_path: '/team',
@@ -383,7 +383,7 @@ test('resetBudgets posts after confirmation and refreshes the budget page', asyn
     });
     module.fetch = (url, request) => {
         requests.push({ url, request });
-        assert.equal(url, '/admin/api/v1/budgets/reset');
+        assert.equal(url, '/admin/budgets/reset');
         assert.equal(request.method, 'POST');
         return Promise.resolve({ status: 200, ok: true });
     };

--- a/internal/admin/dashboard/static/js/modules/contribution-calendar.js
+++ b/internal/admin/dashboard/static/js/modules/contribution-calendar.js
@@ -25,7 +25,7 @@
                     if (controller) {
                         options.signal = controller.signal;
                     }
-                    const res = await fetch('/admin/api/v1/usage/daily?days=365&interval=daily', options);
+                    const res = await fetch('/admin/usage/daily?days=365&interval=daily', options);
                     if (!isCurrentRequest()) {
                         return;
                     }

--- a/internal/admin/dashboard/static/js/modules/conversation-drawer.js
+++ b/internal/admin/dashboard/static/js/modules/conversation-drawer.js
@@ -109,7 +109,7 @@
                 try {
                     const qs = 'log_id=' + encodeURIComponent(logID) + '&limit=120';
                     const request = typeof this.requestOptions === 'function' ? this.requestOptions() : { headers: this.headers() };
-                    const res = await fetch('/admin/api/v1/audit/conversation?' + qs, request);
+                    const res = await fetch('/admin/audit/conversation?' + qs, request);
 
                     if (requestToken !== this.conversationRequestToken) return;
 

--- a/internal/admin/dashboard/static/js/modules/dashboard-paths.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/dashboard-paths.test.cjs
@@ -85,40 +85,40 @@ test("dashboardUnprefixedPath strips only the configured base path boundary", ()
 test("layout gomodelPath prefixes root-relative dashboard URLs idempotently", () => {
   const { window } = loadLayoutBootstrap();
 
-  assert.equal(window.gomodelPath("/admin/api/v1/models"), "/g/admin/api/v1/models");
-  assert.equal(window.gomodelPath("/g/admin/api/v1/models"), "/g/admin/api/v1/models");
-  assert.equal(window.gomodelPath("https://example.com/admin/api/v1/models"), "https://example.com/admin/api/v1/models");
+  assert.equal(window.gomodelPath("/admin/models"), "/g/admin/models");
+  assert.equal(window.gomodelPath("/g/admin/models"), "/g/admin/models");
+  assert.equal(window.gomodelPath("https://example.com/admin/models"), "https://example.com/admin/models");
 });
 
 test("layout fetch wrapper prefixes string, URL, and Request inputs", async() => {
   const { fetchCalls, window } = loadLayoutBootstrap();
 
-  await window.fetch("/admin/api/v1/models", { headers: { Accept: "application/json" } });
-  assert.equal(fetchCalls[0].input, "/g/admin/api/v1/models");
+  await window.fetch("/admin/models", { headers: { Accept: "application/json" } });
+  assert.equal(fetchCalls[0].input, "/g/admin/models");
   assert.equal(fetchCalls[0].init.headers.Accept, "application/json");
 
-  await window.fetch(new URL("http://localhost/admin/api/v1/models?limit=1"));
-  assert.equal(fetchCalls[1].input.toString(), "http://localhost/g/admin/api/v1/models?limit=1");
+  await window.fetch(new URL("http://localhost/admin/models?limit=1"));
+  assert.equal(fetchCalls[1].input.toString(), "http://localhost/g/admin/models?limit=1");
 
-  const crossOriginURL = new URL("http://other-origin.example.com/admin/api/v1/models?limit=1");
+  const crossOriginURL = new URL("http://other-origin.example.com/admin/models?limit=1");
   await window.fetch(crossOriginURL);
   assert.equal(fetchCalls[2].input.toString(), crossOriginURL.toString());
 
-  await window.fetch(new URL("http://localhost/g/admin/api/v1/models?limit=1"));
-  assert.equal(fetchCalls[3].input.toString(), "http://localhost/g/admin/api/v1/models?limit=1");
+  await window.fetch(new URL("http://localhost/g/admin/models?limit=1"));
+  assert.equal(fetchCalls[3].input.toString(), "http://localhost/g/admin/models?limit=1");
 
-  const request = new Request("http://localhost/admin/api/v1/models?limit=1", {
+  const request = new Request("http://localhost/admin/models?limit=1", {
     headers: { Authorization: "Bearer test" },
   });
   await window.fetch(request);
   assert.ok(fetchCalls[4].input instanceof Request);
-  assert.equal(fetchCalls[4].input.url, "http://localhost/g/admin/api/v1/models?limit=1");
+  assert.equal(fetchCalls[4].input.url, "http://localhost/g/admin/models?limit=1");
   assert.equal(fetchCalls[4].input.headers.get("authorization"), "Bearer test");
 });
 
 test("layout fetch wrapper leaves cross-origin Request inputs unchanged", async() => {
   const { fetchCalls, window } = loadLayoutBootstrap();
-  const request = new Request("http://api.example.com/admin/api/v1/models");
+  const request = new Request("http://api.example.com/admin/models");
 
   await window.fetch(request);
 

--- a/internal/admin/dashboard/static/js/modules/guardrails.js
+++ b/internal/admin/dashboard/static/js/modules/guardrails.js
@@ -281,7 +281,7 @@
                 this.guardrailTypesLoading = true;
                 try {
                     const request = typeof this.requestOptions === 'function' ? this.requestOptions() : { headers: this.headers() };
-                    const res = await fetch('/admin/api/v1/guardrails/types', request);
+                    const res = await fetch('/admin/guardrails/types', request);
                     if (res.status === 503) {
                         this.guardrailsAvailable = false;
                         this.guardrailTypes = [];
@@ -318,7 +318,7 @@
                 this.guardrailError = '';
                 try {
                     const request = typeof this.requestOptions === 'function' ? this.requestOptions() : { headers: this.headers() };
-                    const res = await fetch('/admin/api/v1/guardrails', request);
+                    const res = await fetch('/admin/guardrails', request);
                     if (res.status === 503) {
                         this.guardrailsAvailable = false;
                         this.guardrails = [];
@@ -386,7 +386,7 @@
                             headers: this.headers(),
                             body: JSON.stringify(payload)
                         };
-                    const res = await fetch('/admin/api/v1/guardrails', request);
+                    const res = await fetch('/admin/guardrails', request);
                     if (res.status === 503) {
                         this.guardrailsAvailable = false;
                         this.guardrailError = 'Guardrails feature is unavailable.';
@@ -455,7 +455,7 @@
                             headers: this.headers(),
                             body: JSON.stringify({ name })
                         };
-                    const res = await fetch('/admin/api/v1/guardrails', request);
+                    const res = await fetch('/admin/guardrails', request);
                     if (res.status === 503) {
                         this.guardrailsAvailable = false;
                         this.guardrailError = 'Guardrails feature is unavailable.';

--- a/internal/admin/dashboard/static/js/modules/guardrails.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/guardrails.test.cjs
@@ -306,8 +306,8 @@ test('guardrail mutations send guardrail name in JSON body', async () => {
 
     assert.equal(requests.length, 2);
     assert.deepEqual(requests.map((request) => request.url), [
-        '/admin/api/v1/guardrails',
-        '/admin/api/v1/guardrails'
+        '/admin/guardrails',
+        '/admin/guardrails'
     ]);
     assert.deepEqual(requests.map((request) => request.request.method), ['PUT', 'DELETE']);
     assert.deepEqual(JSON.parse(requests[0].request.body), {

--- a/internal/admin/dashboard/static/js/modules/model-pricing-overrides.js
+++ b/internal/admin/dashboard/static/js/modules/model-pricing-overrides.js
@@ -54,7 +54,7 @@
                     const request = typeof this.adminRequestOptions === 'function'
                         ? this.adminRequestOptions()
                         : this.requestOptions();
-                    const res = await fetch('/admin/api/v1/model-pricing-overrides', request);
+                    const res = await fetch('/admin/model-pricing-overrides', request);
                     if (res.status === 503) {
                         this.modelPricingOverridesAvailable = false;
                         this.modelPricingOverrideViews = [];
@@ -492,7 +492,7 @@
                     const request = typeof this.adminRequestOptions === 'function'
                         ? this.adminRequestOptions({ method: 'PUT', body: JSON.stringify(requestPayload) })
                         : this.requestOptions({ method: 'PUT', body: JSON.stringify(requestPayload) });
-                    const res = await fetch('/admin/api/v1/model-pricing-overrides', request);
+                    const res = await fetch('/admin/model-pricing-overrides', request);
                     if (res.status === 503) {
                         this.modelPricingOverridesAvailable = false;
                         this.modelPricingOverrideError = 'Model pricing overrides feature is unavailable.';
@@ -539,7 +539,7 @@
                     const request = typeof this.adminRequestOptions === 'function'
                         ? this.adminRequestOptions({ method: 'DELETE', body: JSON.stringify({ selector }) })
                         : this.requestOptions({ method: 'DELETE', body: JSON.stringify({ selector }) });
-                    const res = await fetch('/admin/api/v1/model-pricing-overrides', request);
+                    const res = await fetch('/admin/model-pricing-overrides', request);
                     if (res.status === 503) {
                         this.modelPricingOverridesAvailable = false;
                         this.modelPricingOverrideError = 'Model pricing overrides feature is unavailable.';

--- a/internal/admin/dashboard/static/js/modules/model-pricing-overrides.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/model-pricing-overrides.test.cjs
@@ -170,8 +170,8 @@ test('model pricing override mutations send selector in JSON body', async() => {
     await module.deleteModelPricingOverride();
 
     assert.equal(requests.length, 2);
-    assert.equal(requests[0].url, '/admin/api/v1/model-pricing-overrides');
-    assert.equal(requests[1].url, '/admin/api/v1/model-pricing-overrides');
+    assert.equal(requests[0].url, '/admin/model-pricing-overrides');
+    assert.equal(requests[1].url, '/admin/model-pricing-overrides');
     assert.deepEqual(JSON.parse(requests[0].request.body), {
         selector: 'openrouter/meta-llama/llama-3.1-8b-instruct',
         pricing: {

--- a/internal/admin/dashboard/static/js/modules/pricing.js
+++ b/internal/admin/dashboard/static/js/modules/pricing.js
@@ -103,7 +103,7 @@
                         method: 'POST',
                         body: JSON.stringify(this.pricingRecalculatePayload('recalculate'))
                     });
-                    const res = await fetch('/admin/api/v1/usage/recalculate-pricing', request);
+                    const res = await fetch('/admin/usage/recalculate-pricing', request);
                     const handled = this.handleFetchResponse(res, 'pricing recalculation', request);
                     if (typeof this.isStaleAuthFetchResult === 'function' && this.isStaleAuthFetchResult(handled)) {
                         return;

--- a/internal/admin/dashboard/static/js/modules/pricing.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/pricing.test.cjs
@@ -84,7 +84,7 @@ test('recalculatePricing posts after typed confirmation', async () => {
     await module.recalculatePricing();
 
     assert.equal(requests.length, 1);
-    assert.equal(requests[0].url, '/admin/api/v1/usage/recalculate-pricing');
+    assert.equal(requests[0].url, '/admin/usage/recalculate-pricing');
     assert.equal(requests[0].request.method, 'POST');
     assert.equal(requests[0].request.body, JSON.stringify({
         days: 30,

--- a/internal/admin/dashboard/static/js/modules/providers.js
+++ b/internal/admin/dashboard/static/js/modules/providers.js
@@ -71,7 +71,7 @@
                     if (controller) {
                         options.signal = controller.signal;
                     }
-                    const res = await fetch('/admin/api/v1/providers/status', options);
+                    const res = await fetch('/admin/providers/status', options);
                     if (options.signal && options.signal.aborted) {
                         return;
                     }

--- a/internal/admin/dashboard/static/js/modules/request-cancellation.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/request-cancellation.test.cjs
@@ -118,7 +118,7 @@ test('refreshRuntime posts to admin endpoint and refreshes dashboard data', asyn
     const refresh = app.refreshRuntime();
     assert.equal(app.runtimeRefreshLoading, true);
     assert.equal(queue.requests.length, 1);
-    assert.equal(queue.requests[0].url, '/admin/api/v1/runtime/refresh');
+    assert.equal(queue.requests[0].url, '/admin/runtime/refresh');
     assert.equal(queue.requests[0].options.method, 'POST');
 
     queue.requests[0].resolve(jsonResponse({
@@ -180,7 +180,7 @@ test('refreshRuntime leaves dashboard data untouched when the admin request fail
     const refresh = app.refreshRuntime();
     assert.equal(app.runtimeRefreshLoading, true);
     assert.equal(queue.requests.length, 1);
-    assert.equal(queue.requests[0].url, '/admin/api/v1/runtime/refresh');
+    assert.equal(queue.requests[0].url, '/admin/runtime/refresh');
     assert.equal(queue.requests[0].options.method, 'POST');
 
     queue.requests[0].resolve({

--- a/internal/admin/dashboard/static/js/modules/usage.js
+++ b/internal/admin/dashboard/static/js/modules/usage.js
@@ -85,7 +85,7 @@
                     }
                     queryStr += '&interval=' + this.interval;
 
-                    const res = await fetch('/admin/api/v1/cache/overview?' + queryStr, options);
+                    const res = await fetch('/admin/cache/overview?' + queryStr, options);
                     const handled = this.handleFetchResponse(res, 'cache overview', options);
                     if (typeof this.isStaleAuthFetchResult === 'function' && this.isStaleAuthFetchResult(handled)) {
                         return;
@@ -139,8 +139,8 @@
                     queryStr += '&interval=' + this.interval;
 
                     const [summaryRes, dailyRes] = await Promise.all([
-                        fetch('/admin/api/v1/usage/summary?' + queryStr, options),
-                        fetch('/admin/api/v1/usage/daily?' + queryStr, options)
+                        fetch('/admin/usage/summary?' + queryStr, options),
+                        fetch('/admin/usage/daily?' + queryStr, options)
                     ]);
 
                     const summaryHandled = this.handleFetchResponse(summaryRes, 'usage summary', options);
@@ -205,7 +205,7 @@
                     if (controller) {
                         options.signal = controller.signal;
                     }
-                    const res = await fetch('/admin/api/v1/usage/models?' + this._usageQueryStr(), options);
+                    const res = await fetch('/admin/usage/models?' + this._usageQueryStr(), options);
                     const handled = this.handleFetchResponse(res, 'usage models', options);
                     if (typeof this.isStaleAuthFetchResult === 'function' && this.isStaleAuthFetchResult(handled)) {
                         return;
@@ -242,7 +242,7 @@
                     if (controller) {
                         options.signal = controller.signal;
                     }
-                    const res = await fetch('/admin/api/v1/usage/user-paths?' + this._usageQueryStr(), options);
+                    const res = await fetch('/admin/usage/user-paths?' + this._usageQueryStr(), options);
                     const handled = this.handleFetchResponse(res, 'usage user paths', options);
                     if (typeof this.isStaleAuthFetchResult === 'function' && this.isStaleAuthFetchResult(handled)) {
                         return;
@@ -287,7 +287,7 @@
                     if (this.usageLogProvider) qs += '&provider=' + encodeURIComponent(this.usageLogProvider);
                     if (this.usageLogUserPath) qs += '&user_path=' + encodeURIComponent(this.usageLogUserPath);
 
-                    const res = await fetch('/admin/api/v1/usage/log?' + qs, options);
+                    const res = await fetch('/admin/usage/log?' + qs, options);
                     const handled = this.handleFetchResponse(res, 'usage log', options);
                     if (typeof this.isStaleAuthFetchResult === 'function' && this.isStaleAuthFetchResult(handled)) {
                         return;

--- a/internal/admin/dashboard/static/js/modules/workflows.js
+++ b/internal/admin/dashboard/static/js/modules/workflows.js
@@ -757,7 +757,7 @@
                     if (controller) {
                         request.signal = controller.signal;
                     }
-                    const res = await fetch('/admin/api/v1/dashboard/config', request);
+                    const res = await fetch('/admin/runtime/config', request);
                     const handled = this.handleFetchResponse(res, 'dashboard config', request);
                     if (typeof this.isStaleAuthFetchResult === 'function' && this.isStaleAuthFetchResult(handled)) {
                         return;
@@ -863,7 +863,7 @@
                     if (controller) {
                         request.signal = controller.signal;
                     }
-                    const res = await fetch('/admin/api/v1/workflows', request);
+                    const res = await fetch('/admin/workflows', request);
                     if (res.status === 503) {
                         this.workflowsAvailable = false;
                         this.workflows = [];
@@ -898,7 +898,7 @@
             async fetchWorkflowGuardrails() {
                 try {
                     const request = typeof this.requestOptions === 'function' ? this.requestOptions() : { headers: this.headers() };
-                    const res = await fetch('/admin/api/v1/workflows/guardrails', request);
+                    const res = await fetch('/admin/workflows/guardrails', request);
                     const handled = this.handleFetchResponse(res, 'workflow guardrails', request);
                     if (typeof this.isStaleAuthFetchResult === 'function' && this.isStaleAuthFetchResult(handled)) {
                         return;
@@ -1004,7 +1004,7 @@
 	                        if (controller) {
 	                            options.signal = controller.signal;
 	                        }
-	                        const res = await fetch('/admin/api/v1/workflows/' + encodeURIComponent(normalizedID), options);
+	                        const res = await fetch('/admin/workflows/' + encodeURIComponent(normalizedID), options);
 	                        if (res.status === 404) {
 	                            this.cacheMissingWorkflowVersion(normalizedID);
 	                            return null;
@@ -1097,7 +1097,7 @@
                             headers: this.headers(),
                             body: JSON.stringify(payload)
                         };
-                    const res = await fetch('/admin/api/v1/workflows', request);
+                    const res = await fetch('/admin/workflows', request);
 
                     if (res.status === 401) {
                         this.handleFetchResponse(res, 'create workflow', request);
@@ -1553,7 +1553,7 @@
                             method: 'POST',
                             headers: this.headers()
                         };
-                    const res = await fetch('/admin/api/v1/workflows/' + encodeURIComponent(workflowID) + '/deactivate', request);
+                    const res = await fetch('/admin/workflows/' + encodeURIComponent(workflowID) + '/deactivate', request);
 
                     if (res.status === 401) {
                         this.handleFetchResponse(res, 'deactivate workflow', request);

--- a/internal/admin/dashboard/static/js/modules/workflows.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/workflows.test.cjs
@@ -1194,7 +1194,7 @@ test('workflowSourceFeatures masks raw workflow features by global runtime confi
 test('fetchWorkflowRuntimeConfig loads FEATURE_FALLBACK_MODE from the admin config endpoint', async () => {
     const module = createWorkflowsModule({
         fetch(url, options) {
-            assert.equal(url, '/admin/api/v1/dashboard/config');
+            assert.equal(url, '/admin/runtime/config');
             assert.equal(options.headers.authorization, 'Bearer token');
             return Promise.resolve({
                 ok: true,
@@ -2241,8 +2241,8 @@ test('fetchWorkflowVersion loads a historical workflow version once and caches m
     assert.equal(missing, null);
     assert.equal(missingAgain, null);
     assert.deepEqual(fetchCalls, [
-        '/admin/api/v1/workflows/historical-v2',
-        '/admin/api/v1/workflows/missing-workflow'
+        '/admin/workflows/historical-v2',
+        '/admin/workflows/missing-workflow'
     ]);
 });
 

--- a/internal/admin/handler_aliases.go
+++ b/internal/admin/handler_aliases.go
@@ -34,7 +34,7 @@ func (h *Handler) ListAliases(c *echo.Context) error {
 	return c.JSON(http.StatusOK, views)
 }
 
-// UpsertAlias handles PUT /admin/api/v1/aliases
+// UpsertAlias handles PUT /admin/aliases
 func (h *Handler) UpsertAlias(c *echo.Context) error {
 	if h.aliases == nil {
 		return handleError(c, featureUnavailableError("aliases feature is unavailable"))
@@ -74,7 +74,7 @@ func (h *Handler) UpsertAlias(c *echo.Context) error {
 	return c.JSON(http.StatusOK, alias)
 }
 
-// DeleteAlias handles DELETE /admin/api/v1/aliases
+// DeleteAlias handles DELETE /admin/aliases
 func (h *Handler) DeleteAlias(c *echo.Context) error {
 	if h.aliases == nil {
 		return handleError(c, featureUnavailableError("aliases feature is unavailable"))

--- a/internal/admin/handler_aliases_test.go
+++ b/internal/admin/handler_aliases_test.go
@@ -139,7 +139,7 @@ func newAliasHandlerWithStore(t *testing.T, store aliases.Store) *Handler {
 
 func TestListAliases(t *testing.T) {
 	h := newAliasHandler(t, aliases.Alias{Name: "smart", TargetModel: "gpt-4o", Enabled: true})
-	c, rec := newHandlerContext("/admin/api/v1/aliases")
+	c, rec := newHandlerContext("/admin/aliases")
 
 	if err := h.ListAliases(c); err != nil {
 		t.Fatalf("ListAliases() error = %v", err)
@@ -179,16 +179,16 @@ func TestAliasesEndpointsReturn503WhenServiceUnavailable(t *testing.T) {
 		}
 	}
 
-	listCtx, listRec := newHandlerContext("/admin/api/v1/aliases")
+	listCtx, listRec := newHandlerContext("/admin/aliases")
 	assertUnavailable("ListAliases", h.ListAliases(listCtx), listRec)
 
-	putReq := httptest.NewRequest(http.MethodPut, "/admin/api/v1/aliases", bytes.NewBufferString(`{"name":"smart","target_model":"gpt-4o"}`))
+	putReq := httptest.NewRequest(http.MethodPut, "/admin/aliases", bytes.NewBufferString(`{"name":"smart","target_model":"gpt-4o"}`))
 	putReq.Header.Set("Content-Type", "application/json")
 	putRec := httptest.NewRecorder()
 	putCtx := e.NewContext(putReq, putRec)
 	assertUnavailable("UpsertAlias", h.UpsertAlias(putCtx), putRec)
 
-	deleteReq := httptest.NewRequest(http.MethodDelete, "/admin/api/v1/aliases", bytes.NewBufferString(`{"name":"smart"}`))
+	deleteReq := httptest.NewRequest(http.MethodDelete, "/admin/aliases", bytes.NewBufferString(`{"name":"smart"}`))
 	deleteReq.Header.Set("Content-Type", "application/json")
 	deleteRec := httptest.NewRecorder()
 	deleteCtx := e.NewContext(deleteReq, deleteRec)
@@ -199,7 +199,7 @@ func TestUpsertAliasAndDeleteAlias(t *testing.T) {
 	h := newAliasHandler(t)
 	e := echo.New()
 
-	putReq := httptest.NewRequest(http.MethodPut, "/admin/api/v1/aliases", bytes.NewBufferString(`{"name":"smart","target_model":"gpt-4o","description":"primary"}`))
+	putReq := httptest.NewRequest(http.MethodPut, "/admin/aliases", bytes.NewBufferString(`{"name":"smart","target_model":"gpt-4o","description":"primary"}`))
 	putReq.Header.Set("Content-Type", "application/json")
 	putRec := httptest.NewRecorder()
 	putCtx := e.NewContext(putReq, putRec)
@@ -211,7 +211,7 @@ func TestUpsertAliasAndDeleteAlias(t *testing.T) {
 		t.Fatalf("put status = %d, want 200", putRec.Code)
 	}
 
-	deleteReq := httptest.NewRequest(http.MethodDelete, "/admin/api/v1/aliases", bytes.NewBufferString(`{"name":"smart"}`))
+	deleteReq := httptest.NewRequest(http.MethodDelete, "/admin/aliases", bytes.NewBufferString(`{"name":"smart"}`))
 	deleteReq.Header.Set("Content-Type", "application/json")
 	deleteRec := httptest.NewRecorder()
 	deleteCtx := e.NewContext(deleteReq, deleteRec)
@@ -228,7 +228,7 @@ func TestUpsertAliasAcceptsQualifiedAliasName(t *testing.T) {
 	h := newAliasHandler(t)
 	e := echo.New()
 
-	req := httptest.NewRequest(http.MethodPut, "/admin/api/v1/aliases", bytes.NewBufferString(`{"name":"openai/smart","target_model":"gpt-4o"}`))
+	req := httptest.NewRequest(http.MethodPut, "/admin/aliases", bytes.NewBufferString(`{"name":"openai/smart","target_model":"gpt-4o"}`))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
@@ -258,7 +258,7 @@ func TestUpsertAliasPreservesEnabledWhenOmitted(t *testing.T) {
 	})
 	e := echo.New()
 
-	req := httptest.NewRequest(http.MethodPut, "/admin/api/v1/aliases", bytes.NewBufferString(`{"name":"smart","target_model":"gpt-4o","description":"after"}`))
+	req := httptest.NewRequest(http.MethodPut, "/admin/aliases", bytes.NewBufferString(`{"name":"smart","target_model":"gpt-4o","description":"after"}`))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
@@ -288,7 +288,7 @@ func TestUpsertAliasReturns500OnStoreFailure(t *testing.T) {
 	})
 	e := echo.New()
 
-	req := httptest.NewRequest(http.MethodPut, "/admin/api/v1/aliases", bytes.NewBufferString(`{"name":"smart","target_model":"gpt-4o"}`))
+	req := httptest.NewRequest(http.MethodPut, "/admin/aliases", bytes.NewBufferString(`{"name":"smart","target_model":"gpt-4o"}`))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
@@ -308,7 +308,7 @@ func TestUpsertAliasReturns400OnValidationError(t *testing.T) {
 	h := newAliasHandler(t)
 	e := echo.New()
 
-	req := httptest.NewRequest(http.MethodPut, "/admin/api/v1/aliases", bytes.NewBufferString(`{"name":"smart","description":"missing target"}`))
+	req := httptest.NewRequest(http.MethodPut, "/admin/aliases", bytes.NewBufferString(`{"name":"smart","description":"missing target"}`))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
@@ -330,7 +330,7 @@ func TestDeleteAliasReturns500OnStoreFailure(t *testing.T) {
 	})
 	e := echo.New()
 
-	req := httptest.NewRequest(http.MethodDelete, "/admin/api/v1/aliases", bytes.NewBufferString(`{"name":"smart"}`))
+	req := httptest.NewRequest(http.MethodDelete, "/admin/aliases", bytes.NewBufferString(`{"name":"smart"}`))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)

--- a/internal/admin/handler_audit.go
+++ b/internal/admin/handler_audit.go
@@ -18,7 +18,7 @@ import (
 // matches the value documented in the @Param limit annotation below.
 const maxAuditLogLimit = 100
 
-// AuditLog handles GET /admin/api/v1/audit/log
+// AuditLog handles GET /admin/audit/log
 //
 // @Summary      Get paginated audit log entries
 // @Tags         admin
@@ -41,7 +41,7 @@ const maxAuditLogLimit = 100
 // @Success      200  {object}  auditLogListResponse
 // @Failure      400  {object}  core.GatewayError
 // @Failure      401  {object}  core.GatewayError
-// @Router       /admin/api/v1/audit/log [get]
+// @Router       /admin/audit/log [get]
 func (h *Handler) AuditLog(c *echo.Context) error {
 	// Validate request shape before the disabled-reader fast path so callers
 	// always get a 400 for malformed inputs, regardless of whether audit
@@ -173,7 +173,7 @@ func (h *Handler) auditLogResponse(ctx context.Context, result *auditlog.LogList
 	return response, nil
 }
 
-// AuditConversation handles GET /admin/api/v1/audit/conversation
+// AuditConversation handles GET /admin/audit/conversation
 //
 // @Summary      Get conversation thread around an audit log entry
 // @Tags         admin
@@ -184,7 +184,7 @@ func (h *Handler) auditLogResponse(ctx context.Context, result *auditlog.LogList
 // @Success      200  {object}  auditlog.ConversationResult
 // @Failure      400  {object}  core.GatewayError
 // @Failure      401  {object}  core.GatewayError
-// @Router       /admin/api/v1/audit/conversation [get]
+// @Router       /admin/audit/conversation [get]
 func (h *Handler) AuditConversation(c *echo.Context) error {
 	// Validate request shape before the disabled-reader fast path so callers
 	// always get a 400 for missing/invalid params, regardless of whether

--- a/internal/admin/handler_authkeys.go
+++ b/internal/admin/handler_authkeys.go
@@ -31,7 +31,7 @@ func (h *Handler) ListAuthKeys(c *echo.Context) error {
 	return c.JSON(http.StatusOK, views)
 }
 
-// CreateAuthKey handles POST /admin/api/v1/auth-keys
+// CreateAuthKey handles POST /admin/auth-keys
 func (h *Handler) CreateAuthKey(c *echo.Context) error {
 	if h.authKeys == nil {
 		return handleError(c, featureUnavailableError("auth keys feature is unavailable"))
@@ -68,7 +68,7 @@ func (h *Handler) CreateAuthKey(c *echo.Context) error {
 	return c.JSON(http.StatusCreated, issued)
 }
 
-// DeactivateAuthKey handles POST /admin/api/v1/auth-keys/:id/deactivate
+// DeactivateAuthKey handles POST /admin/auth-keys/:id/deactivate
 func (h *Handler) DeactivateAuthKey(c *echo.Context) error {
 	var unavailableErr error
 	var deactivate func(context.Context, string) error

--- a/internal/admin/handler_authkeys_test.go
+++ b/internal/admin/handler_authkeys_test.go
@@ -72,7 +72,7 @@ func TestAuthKeyEndpointsReturn503WhenServiceUnavailable(t *testing.T) {
 	h := NewHandler(nil, nil)
 	e := echo.New()
 
-	listCtx, listRec := newHandlerContext("/admin/api/v1/auth-keys")
+	listCtx, listRec := newHandlerContext("/admin/auth-keys")
 	if err := h.ListAuthKeys(listCtx); err != nil {
 		t.Fatalf("ListAuthKeys() error = %v", err)
 	}
@@ -80,7 +80,7 @@ func TestAuthKeyEndpointsReturn503WhenServiceUnavailable(t *testing.T) {
 		t.Fatalf("ListAuthKeys() status = %d, want 503", listRec.Code)
 	}
 
-	createReq := httptest.NewRequest(http.MethodPost, "/admin/api/v1/auth-keys", bytes.NewBufferString(`{"name":"primary"}`))
+	createReq := httptest.NewRequest(http.MethodPost, "/admin/auth-keys", bytes.NewBufferString(`{"name":"primary"}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	createRec := httptest.NewRecorder()
 	createCtx := e.NewContext(createReq, createRec)
@@ -91,7 +91,7 @@ func TestAuthKeyEndpointsReturn503WhenServiceUnavailable(t *testing.T) {
 		t.Fatalf("CreateAuthKey() status = %d, want 503", createRec.Code)
 	}
 
-	deactivateReq := httptest.NewRequest(http.MethodPost, "/admin/api/v1/auth-keys/test-key/deactivate", nil)
+	deactivateReq := httptest.NewRequest(http.MethodPost, "/admin/auth-keys/test-key/deactivate", nil)
 	deactivateRec := httptest.NewRecorder()
 	deactivateCtx := e.NewContext(deactivateReq, deactivateRec)
 	deactivateCtx.SetPathValues(echo.PathValues{{Name: "id", Value: "test-key"}})
@@ -107,7 +107,7 @@ func TestCreateListAndDeactivateAuthKey(t *testing.T) {
 	h := newAuthKeyHandler(t, newAuthKeyTestStore())
 	e := echo.New()
 
-	createReq := httptest.NewRequest(http.MethodPost, "/admin/api/v1/auth-keys", bytes.NewBufferString(`{"name":"primary","description":"prod key","user_path":" team//alpha/service/ "}`))
+	createReq := httptest.NewRequest(http.MethodPost, "/admin/auth-keys", bytes.NewBufferString(`{"name":"primary","description":"prod key","user_path":" team//alpha/service/ "}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	createRec := httptest.NewRecorder()
 	createCtx := e.NewContext(createReq, createRec)
@@ -130,7 +130,7 @@ func TestCreateListAndDeactivateAuthKey(t *testing.T) {
 		t.Fatalf("issued.UserPath = %q, want /team/alpha/service", issued.UserPath)
 	}
 
-	listCtx, listRec := newHandlerContext("/admin/api/v1/auth-keys")
+	listCtx, listRec := newHandlerContext("/admin/auth-keys")
 	if err := h.ListAuthKeys(listCtx); err != nil {
 		t.Fatalf("ListAuthKeys() error = %v", err)
 	}
@@ -149,7 +149,7 @@ func TestCreateListAndDeactivateAuthKey(t *testing.T) {
 		t.Fatalf("views[0].UserPath = %q, want /team/alpha/service", views[0].UserPath)
 	}
 
-	deactivateReq := httptest.NewRequest(http.MethodPost, "/admin/api/v1/auth-keys/"+issued.ID+"/deactivate", nil)
+	deactivateReq := httptest.NewRequest(http.MethodPost, "/admin/auth-keys/"+issued.ID+"/deactivate", nil)
 	deactivateRec := httptest.NewRecorder()
 	deactivateCtx := e.NewContext(deactivateReq, deactivateRec)
 	deactivateCtx.SetPathValues(echo.PathValues{{Name: "id", Value: issued.ID}})
@@ -161,7 +161,7 @@ func TestCreateListAndDeactivateAuthKey(t *testing.T) {
 		t.Fatalf("DeactivateAuthKey() status = %d, want 204", deactivateRec.Code)
 	}
 
-	listCtx, listRec = newHandlerContext("/admin/api/v1/auth-keys")
+	listCtx, listRec = newHandlerContext("/admin/auth-keys")
 	if err := h.ListAuthKeys(listCtx); err != nil {
 		t.Fatalf("ListAuthKeys() error after deactivate = %v", err)
 	}
@@ -177,7 +177,7 @@ func TestCreateAuthKeyRejectsInvalidUserPath(t *testing.T) {
 	h := newAuthKeyHandler(t, newAuthKeyTestStore())
 	e := echo.New()
 
-	createReq := httptest.NewRequest(http.MethodPost, "/admin/api/v1/auth-keys", bytes.NewBufferString(`{"name":"primary","user_path":"/team/../alpha"}`))
+	createReq := httptest.NewRequest(http.MethodPost, "/admin/auth-keys", bytes.NewBufferString(`{"name":"primary","user_path":"/team/../alpha"}`))
 	createReq.Header.Set("Content-Type", "application/json")
 	createRec := httptest.NewRecorder()
 	createCtx := e.NewContext(createReq, createRec)

--- a/internal/admin/handler_budgets.go
+++ b/internal/admin/handler_budgets.go
@@ -13,7 +13,7 @@ import (
 	"gomodel/internal/core"
 )
 
-// ListBudgets handles GET /admin/api/v1/budgets.
+// ListBudgets handles GET /admin/budgets.
 //
 // @Summary      List budgets with current status
 // @Tags         admin
@@ -22,7 +22,7 @@ import (
 // @Success      200  {object}  budgetListResponse
 // @Failure      401  {object}  core.GatewayError
 // @Failure      503  {object}  core.GatewayError
-// @Router       /admin/api/v1/budgets [get]
+// @Router       /admin/budgets [get]
 func (h *Handler) ListBudgets(c *echo.Context) error {
 	if h.budgets == nil {
 		return handleError(c, featureUnavailableError("budgets feature is unavailable"))
@@ -38,7 +38,7 @@ func (h *Handler) ListBudgets(c *echo.Context) error {
 	})
 }
 
-// UpsertBudget handles PUT /admin/api/v1/budgets.
+// UpsertBudget handles PUT /admin/budgets.
 // @Summary      Create or update one budget
 // @Tags         admin
 // @Accept       json
@@ -49,7 +49,7 @@ func (h *Handler) ListBudgets(c *echo.Context) error {
 // @Failure      400        {object}  core.GatewayError
 // @Failure      401        {object}  core.GatewayError
 // @Failure      503        {object}  core.GatewayError
-// @Router       /admin/api/v1/budgets [put]
+// @Router       /admin/budgets [put]
 func (h *Handler) UpsertBudget(c *echo.Context) error {
 	if h.budgets == nil {
 		return handleError(c, featureUnavailableError("budgets feature is unavailable"))
@@ -77,7 +77,7 @@ func (h *Handler) UpsertBudget(c *echo.Context) error {
 	return h.ListBudgets(c)
 }
 
-// DeleteBudget handles DELETE /admin/api/v1/budgets.
+// DeleteBudget handles DELETE /admin/budgets.
 // @Summary      Delete one budget
 // @Tags         admin
 // @Accept       json
@@ -88,7 +88,7 @@ func (h *Handler) UpsertBudget(c *echo.Context) error {
 // @Failure      400        {object}  core.GatewayError
 // @Failure      401        {object}  core.GatewayError
 // @Failure      503        {object}  core.GatewayError
-// @Router       /admin/api/v1/budgets [delete]
+// @Router       /admin/budgets [delete]
 func (h *Handler) DeleteBudget(c *echo.Context) error {
 	if h.budgets == nil {
 		return handleError(c, featureUnavailableError("budgets feature is unavailable"))
@@ -107,7 +107,7 @@ func (h *Handler) DeleteBudget(c *echo.Context) error {
 	return h.ListBudgets(c)
 }
 
-// BudgetSettings handles GET /admin/api/v1/budgets/settings.
+// BudgetSettings handles GET /admin/budgets/settings.
 // @Summary      Get budget reset settings
 // @Tags         admin
 // @Produce      json
@@ -115,7 +115,7 @@ func (h *Handler) DeleteBudget(c *echo.Context) error {
 // @Success      200  {object}  budget.Settings
 // @Failure      401  {object}  core.GatewayError
 // @Failure      503  {object}  core.GatewayError
-// @Router       /admin/api/v1/budgets/settings [get]
+// @Router       /admin/budgets/settings [get]
 func (h *Handler) BudgetSettings(c *echo.Context) error {
 	if h.budgets == nil {
 		return handleError(c, featureUnavailableError("budgets feature is unavailable"))
@@ -123,7 +123,7 @@ func (h *Handler) BudgetSettings(c *echo.Context) error {
 	return c.JSON(http.StatusOK, h.budgets.Settings())
 }
 
-// UpdateBudgetSettings handles PUT /admin/api/v1/budgets/settings.
+// UpdateBudgetSettings handles PUT /admin/budgets/settings.
 // @Summary      Update budget reset settings
 // @Tags         admin
 // @Accept       json
@@ -134,7 +134,7 @@ func (h *Handler) BudgetSettings(c *echo.Context) error {
 // @Failure      400       {object}  core.GatewayError
 // @Failure      401       {object}  core.GatewayError
 // @Failure      503       {object}  core.GatewayError
-// @Router       /admin/api/v1/budgets/settings [put]
+// @Router       /admin/budgets/settings [put]
 func (h *Handler) UpdateBudgetSettings(c *echo.Context) error {
 	if h.budgets == nil {
 		return handleError(c, featureUnavailableError("budgets feature is unavailable"))
@@ -154,7 +154,7 @@ func (h *Handler) UpdateBudgetSettings(c *echo.Context) error {
 	return c.JSON(http.StatusOK, saved)
 }
 
-// ResetBudget handles POST /admin/api/v1/budgets/reset-one.
+// ResetBudget handles POST /admin/budgets/reset-one.
 // @Summary      Reset one budget period
 // @Tags         admin
 // @Accept       json
@@ -165,7 +165,7 @@ func (h *Handler) UpdateBudgetSettings(c *echo.Context) error {
 // @Failure      400     {object}  core.GatewayError
 // @Failure      401     {object}  core.GatewayError
 // @Failure      503     {object}  core.GatewayError
-// @Router       /admin/api/v1/budgets/reset-one [post]
+// @Router       /admin/budgets/reset-one [post]
 func (h *Handler) ResetBudget(c *echo.Context) error {
 	if h.budgets == nil {
 		return handleError(c, featureUnavailableError("budgets feature is unavailable"))
@@ -188,7 +188,7 @@ func (h *Handler) ResetBudget(c *echo.Context) error {
 	return h.ListBudgets(c)
 }
 
-// ResetBudgets handles POST /admin/api/v1/budgets/reset.
+// ResetBudgets handles POST /admin/budgets/reset.
 // @Summary      Reset all budget periods
 // @Tags         admin
 // @Accept       json
@@ -199,7 +199,7 @@ func (h *Handler) ResetBudget(c *echo.Context) error {
 // @Failure      400           {object}  core.GatewayError
 // @Failure      401           {object}  core.GatewayError
 // @Failure      503           {object}  core.GatewayError
-// @Router       /admin/api/v1/budgets/reset [post]
+// @Router       /admin/budgets/reset [post]
 func (h *Handler) ResetBudgets(c *echo.Context) error {
 	if h.budgets == nil {
 		return handleError(c, featureUnavailableError("budgets feature is unavailable"))

--- a/internal/admin/handler_budgets_test.go
+++ b/internal/admin/handler_budgets_test.go
@@ -135,7 +135,7 @@ func TestBudgetEndpointsListStatuses(t *testing.T) {
 	}
 	h := newBudgetHandler(t, store)
 	e := echo.New()
-	req := httptest.NewRequest(http.MethodGet, "/admin/api/v1/budgets", nil)
+	req := httptest.NewRequest(http.MethodGet, "/admin/budgets", nil)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
@@ -164,7 +164,7 @@ func TestBudgetEndpointsUpsertAndResetOneBudget(t *testing.T) {
 
 	upsertReq := httptest.NewRequest(
 		http.MethodPut,
-		"/admin/api/v1/budgets",
+		"/admin/budgets",
 		strings.NewReader(`{"user_path":"/team/beta","budget_key":{"period":"weekly"},"amount":12.5}`),
 	)
 	upsertReq.Header.Set("Content-Type", "application/json")
@@ -182,7 +182,7 @@ func TestBudgetEndpointsUpsertAndResetOneBudget(t *testing.T) {
 
 	resetReq := httptest.NewRequest(
 		http.MethodPost,
-		"/admin/api/v1/budgets/reset-one",
+		"/admin/budgets/reset-one",
 		strings.NewReader(`{"user_path":"/team/beta","period_seconds":604800}`),
 	)
 	resetReq.Header.Set("Content-Type", "application/json")
@@ -209,7 +209,7 @@ func TestBudgetEndpointsUpsertMarksConfigBudgetManual(t *testing.T) {
 	e := echo.New()
 	req := httptest.NewRequest(
 		http.MethodPut,
-		"/admin/api/v1/budgets",
+		"/admin/budgets",
 		strings.NewReader(`{"user_path":"/team","budget_key":{"period":"daily"},"amount":12.5}`),
 	)
 	req.Header.Set("Content-Type", "application/json")
@@ -236,7 +236,7 @@ func TestBudgetEndpointsUpsertAcceptsNumericPeriodString(t *testing.T) {
 	e := echo.New()
 	req := httptest.NewRequest(
 		http.MethodPut,
-		"/admin/api/v1/budgets",
+		"/admin/budgets",
 		strings.NewReader(`{"user_path":"/team","budget_key":{"period":"604800"},"amount":12.5}`),
 	)
 	req.Header.Set("Content-Type", "application/json")
@@ -287,7 +287,7 @@ func TestBudgetEndpointsRejectInvalidBudgetKey(t *testing.T) {
 			store := &adminBudgetStore{}
 			h := newBudgetHandler(t, store)
 			e := echo.New()
-			req := httptest.NewRequest(http.MethodPut, "/admin/api/v1/budgets", strings.NewReader(tt.body))
+			req := httptest.NewRequest(http.MethodPut, "/admin/budgets", strings.NewReader(tt.body))
 			req.Header.Set("Content-Type", "application/json")
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)
@@ -313,7 +313,7 @@ func TestBudgetEndpointsDeleteBudget(t *testing.T) {
 	e := echo.New()
 	req := httptest.NewRequest(
 		http.MethodDelete,
-		"/admin/api/v1/budgets",
+		"/admin/budgets",
 		strings.NewReader(`{"user_path":"/team/beta","budget_key":{"period_seconds":604800}}`),
 	)
 	req.Header.Set("Content-Type", "application/json")
@@ -343,7 +343,7 @@ func TestBudgetEndpointsMissingMutationsReturnNotFound(t *testing.T) {
 				store.deleteErr = budget.ErrNotFound
 			},
 			run: func(h *Handler, e *echo.Echo) *httptest.ResponseRecorder {
-				req := httptest.NewRequest(http.MethodDelete, "/admin/api/v1/budgets", strings.NewReader(`{"user_path":"/team","budget_key":{"period_seconds":86400}}`))
+				req := httptest.NewRequest(http.MethodDelete, "/admin/budgets", strings.NewReader(`{"user_path":"/team","budget_key":{"period_seconds":86400}}`))
 				req.Header.Set("Content-Type", "application/json")
 				rec := httptest.NewRecorder()
 				c := e.NewContext(req, rec)
@@ -361,7 +361,7 @@ func TestBudgetEndpointsMissingMutationsReturnNotFound(t *testing.T) {
 			run: func(h *Handler, e *echo.Echo) *httptest.ResponseRecorder {
 				req := httptest.NewRequest(
 					http.MethodPost,
-					"/admin/api/v1/budgets/reset-one",
+					"/admin/budgets/reset-one",
 					strings.NewReader(`{"user_path":"/team","period_seconds":86400}`),
 				)
 				req.Header.Set("Content-Type", "application/json")
@@ -399,7 +399,7 @@ func TestBudgetSettingsEndpoints(t *testing.T) {
 	h := newBudgetHandler(t, store)
 	e := echo.New()
 
-	getReq := httptest.NewRequest(http.MethodGet, "/admin/api/v1/budgets/settings", nil)
+	getReq := httptest.NewRequest(http.MethodGet, "/admin/budgets/settings", nil)
 	getRec := httptest.NewRecorder()
 	getCtx := e.NewContext(getReq, getRec)
 	if err := h.BudgetSettings(getCtx); err != nil {
@@ -418,7 +418,7 @@ func TestBudgetSettingsEndpoints(t *testing.T) {
 
 	updateReq := httptest.NewRequest(
 		http.MethodPut,
-		"/admin/api/v1/budgets/settings",
+		"/admin/budgets/settings",
 		strings.NewReader(`{"daily_reset_hour":6,"daily_reset_minute":30,"weekly_reset_weekday":2,"weekly_reset_hour":9,"weekly_reset_minute":15,"monthly_reset_day":31,"monthly_reset_hour":2,"monthly_reset_minute":45}`),
 	)
 	updateReq.Header.Set("Content-Type", "application/json")
@@ -436,7 +436,7 @@ func TestBudgetSettingsEndpoints(t *testing.T) {
 
 	partialReq := httptest.NewRequest(
 		http.MethodPut,
-		"/admin/api/v1/budgets/settings",
+		"/admin/budgets/settings",
 		strings.NewReader(`{"daily_reset_hour":8}`),
 	)
 	partialReq.Header.Set("Content-Type", "application/json")
@@ -454,7 +454,7 @@ func TestBudgetSettingsEndpoints(t *testing.T) {
 
 	invalidReq := httptest.NewRequest(
 		http.MethodPut,
-		"/admin/api/v1/budgets/settings",
+		"/admin/budgets/settings",
 		strings.NewReader(`{"daily_reset_hour":24,"daily_reset_minute":0,"weekly_reset_weekday":1,"weekly_reset_hour":0,"weekly_reset_minute":0,"monthly_reset_day":1,"monthly_reset_hour":0,"monthly_reset_minute":0}`),
 	)
 	invalidReq.Header.Set("Content-Type", "application/json")
@@ -469,7 +469,7 @@ func TestBudgetSettingsEndpoints(t *testing.T) {
 
 	malformedReq := httptest.NewRequest(
 		http.MethodPut,
-		"/admin/api/v1/budgets/settings",
+		"/admin/budgets/settings",
 		strings.NewReader(`{"daily_reset_hour":`),
 	)
 	malformedReq.Header.Set("Content-Type", "application/json")
@@ -492,7 +492,7 @@ func TestResetBudgetsEndpoint(t *testing.T) {
 	h := newBudgetHandler(t, store)
 	e := echo.New()
 
-	badReq := httptest.NewRequest(http.MethodPost, "/admin/api/v1/budgets/reset", strings.NewReader(`{"confirm":"no"}`))
+	badReq := httptest.NewRequest(http.MethodPost, "/admin/budgets/reset", strings.NewReader(`{"confirm":"no"}`))
 	badReq.Header.Set("Content-Type", "application/json")
 	badRec := httptest.NewRecorder()
 	badCtx := e.NewContext(badReq, badRec)
@@ -506,7 +506,7 @@ func TestResetBudgetsEndpoint(t *testing.T) {
 		t.Fatalf("resetAllAt = %s, want zero", store.resetAllAt)
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/budgets/reset", strings.NewReader(`{"confirm":"reset"}`))
+	req := httptest.NewRequest(http.MethodPost, "/admin/budgets/reset", strings.NewReader(`{"confirm":"reset"}`))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)

--- a/internal/admin/handler_guardrails.go
+++ b/internal/admin/handler_guardrails.go
@@ -31,7 +31,7 @@ func (h *Handler) ListGuardrailTypes(c *echo.Context) error {
 	return c.JSON(http.StatusOK, h.guardrailDefs.TypeDefinitions())
 }
 
-// ListGuardrails handles GET /admin/api/v1/guardrails
+// ListGuardrails handles GET /admin/guardrails
 func (h *Handler) ListGuardrails(c *echo.Context) error {
 	if h.guardrailDefs == nil {
 		return handleError(c, featureUnavailableError("guardrails feature is unavailable"))
@@ -43,7 +43,7 @@ func (h *Handler) ListGuardrails(c *echo.Context) error {
 	return c.JSON(http.StatusOK, views)
 }
 
-// UpsertGuardrail handles PUT /admin/api/v1/guardrails
+// UpsertGuardrail handles PUT /admin/guardrails
 func (h *Handler) UpsertGuardrail(c *echo.Context) error {
 	if h.guardrailDefs == nil {
 		return handleError(c, featureUnavailableError("guardrails feature is unavailable"))
@@ -86,7 +86,7 @@ func (h *Handler) UpsertGuardrail(c *echo.Context) error {
 	return c.JSON(http.StatusOK, guardrails.ViewFromDefinition(*definition))
 }
 
-// DeleteGuardrail handles DELETE /admin/api/v1/guardrails
+// DeleteGuardrail handles DELETE /admin/guardrails
 func (h *Handler) DeleteGuardrail(c *echo.Context) error {
 	if h.guardrailDefs == nil {
 		return handleError(c, featureUnavailableError("guardrails feature is unavailable"))

--- a/internal/admin/handler_guardrails_test.go
+++ b/internal/admin/handler_guardrails_test.go
@@ -104,7 +104,7 @@ func TestListGuardrails(t *testing.T) {
 		}),
 	})
 
-	c, rec := newHandlerContext("/admin/api/v1/guardrails")
+	c, rec := newHandlerContext("/admin/guardrails")
 	if err := h.ListGuardrails(c); err != nil {
 		t.Fatalf("ListGuardrails() error = %v", err)
 	}
@@ -126,7 +126,7 @@ func TestListGuardrails(t *testing.T) {
 
 func TestListGuardrailTypes(t *testing.T) {
 	h := newGuardrailHandler(t)
-	c, rec := newHandlerContext("/admin/api/v1/guardrails/types")
+	c, rec := newHandlerContext("/admin/guardrails/types")
 
 	if err := h.ListGuardrailTypes(c); err != nil {
 		t.Fatalf("ListGuardrailTypes() error = %v", err)
@@ -182,7 +182,7 @@ func TestUpsertGuardrail(t *testing.T) {
 	h := newGuardrailHandler(t)
 	e := echo.New()
 
-	req := httptest.NewRequest(http.MethodPut, "/admin/api/v1/guardrails", bytes.NewBufferString(`{
+	req := httptest.NewRequest(http.MethodPut, "/admin/guardrails", bytes.NewBufferString(`{
 		"name":"policy-system",
 		"type":"system_prompt",
 		"description":"Default policy",
@@ -216,7 +216,7 @@ func TestUpsertGuardrailLLMBasedAltering(t *testing.T) {
 	h := newGuardrailHandler(t)
 	e := echo.New()
 
-	req := httptest.NewRequest(http.MethodPut, "/admin/api/v1/guardrails", bytes.NewBufferString(`{
+	req := httptest.NewRequest(http.MethodPut, "/admin/guardrails", bytes.NewBufferString(`{
 		"name":"privacy",
 		"type":"llm_based_altering",
 		"description":"Rewrite user PII",
@@ -257,7 +257,7 @@ func TestUpsertGuardrailLLMBasedAlteringNormalizesProviderHintIntoModel(t *testi
 	h := newGuardrailHandler(t)
 	e := echo.New()
 
-	req := httptest.NewRequest(http.MethodPut, "/admin/api/v1/guardrails", bytes.NewBufferString(`{
+	req := httptest.NewRequest(http.MethodPut, "/admin/guardrails", bytes.NewBufferString(`{
 		"name":"privacy",
 		"type":"llm_based_altering",
 		"description":"Rewrite user PII",
@@ -295,7 +295,7 @@ func TestUpsertGuardrailRejectsSlashInName(t *testing.T) {
 	h := newGuardrailHandler(t)
 	e := echo.New()
 
-	req := httptest.NewRequest(http.MethodPut, "/admin/api/v1/guardrails", bytes.NewBufferString(`{
+	req := httptest.NewRequest(http.MethodPut, "/admin/guardrails", bytes.NewBufferString(`{
 		"name":"privacy/redactor",
 		"type":"llm_based_altering",
 		"config":{"model":"gpt-4o-mini","roles":["user"]}
@@ -363,7 +363,7 @@ func TestDeleteGuardrailRejectsActiveWorkflowReference(t *testing.T) {
 
 	h := NewHandler(nil, nil, WithGuardrailService(guardrailService), WithWorkflows(planService))
 	e := echo.New()
-	req := httptest.NewRequest(http.MethodDelete, "/admin/api/v1/guardrails", bytes.NewBufferString(`{"name":"policy-system"}`))
+	req := httptest.NewRequest(http.MethodDelete, "/admin/guardrails", bytes.NewBufferString(`{"name":"policy-system"}`))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
@@ -418,7 +418,7 @@ func TestDeleteGuardrailIgnoresDisabledWorkflowGuardrailRefs(t *testing.T) {
 
 	h := NewHandler(nil, nil, WithGuardrailService(guardrailService), WithWorkflows(planService))
 	e := echo.New()
-	req := httptest.NewRequest(http.MethodDelete, "/admin/api/v1/guardrails", bytes.NewBufferString(`{"name":"policy-system"}`))
+	req := httptest.NewRequest(http.MethodDelete, "/admin/guardrails", bytes.NewBufferString(`{"name":"policy-system"}`))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)

--- a/internal/admin/handler_model_overrides.go
+++ b/internal/admin/handler_model_overrides.go
@@ -20,7 +20,7 @@ type deleteModelOverrideRequest struct {
 	Selector string `json:"selector"`
 }
 
-// ListModelOverrides handles GET /admin/api/v1/model-overrides.
+// ListModelOverrides handles GET /admin/model-overrides.
 //
 // @Summary      List model access overrides
 // @Description  Lists persisted model access overrides by global, provider-wide, model-wide, or exact selector.
@@ -31,7 +31,7 @@ type deleteModelOverrideRequest struct {
 // @Success      200  {array}   modeloverrides.View
 // @Failure      401  {object}  core.GatewayError
 // @Failure      503  {object}  core.GatewayError
-// @Router       /admin/api/v1/model-overrides [get]
+// @Router       /admin/model-overrides [get]
 func (h *Handler) ListModelOverrides(c *echo.Context) error {
 	if h.modelOverrides == nil {
 		return handleError(c, featureUnavailableError("model overrides feature is unavailable"))
@@ -43,7 +43,7 @@ func (h *Handler) ListModelOverrides(c *echo.Context) error {
 	return c.JSON(http.StatusOK, views)
 }
 
-// UpsertModelOverride handles PUT /admin/api/v1/model-overrides.
+// UpsertModelOverride handles PUT /admin/model-overrides.
 //
 // @Summary      Create or update one model access override
 // @Tags         admin
@@ -57,7 +57,7 @@ func (h *Handler) ListModelOverrides(c *echo.Context) error {
 // @Failure      500       {object}  core.GatewayError
 // @Failure      502       {object}  core.GatewayError
 // @Failure      503       {object}  core.GatewayError
-// @Router       /admin/api/v1/model-overrides [put]
+// @Router       /admin/model-overrides [put]
 //
 //nolint:dupl // structurally similar to UpsertModelPricingOverride but operates on different types and stores.
 func (h *Handler) UpsertModelOverride(c *echo.Context) error {
@@ -92,7 +92,7 @@ func (h *Handler) UpsertModelOverride(c *echo.Context) error {
 	})
 }
 
-// DeleteModelOverride handles DELETE /admin/api/v1/model-overrides.
+// DeleteModelOverride handles DELETE /admin/model-overrides.
 //
 // @Summary      Delete one model access override
 // @Tags         admin
@@ -106,7 +106,7 @@ func (h *Handler) UpsertModelOverride(c *echo.Context) error {
 // @Failure      404       {object}  core.GatewayError
 // @Failure      502       {object}  core.GatewayError
 // @Failure      503       {object}  core.GatewayError
-// @Router       /admin/api/v1/model-overrides [delete]
+// @Router       /admin/model-overrides [delete]
 //
 //nolint:dupl // structurally similar to DeleteModelPricingOverride but operates on different types and stores.
 func (h *Handler) DeleteModelOverride(c *echo.Context) error {

--- a/internal/admin/handler_model_overrides_test.go
+++ b/internal/admin/handler_model_overrides_test.go
@@ -110,7 +110,7 @@ func TestListModels_IncludesModelAccessState(t *testing.T) {
 	}), false)
 
 	h := NewHandler(nil, registry, WithModelOverrides(service))
-	c, rec := newHandlerContext("/admin/api/v1/models")
+	c, rec := newHandlerContext("/admin/models")
 
 	if err := h.ListModels(c); err != nil {
 		t.Fatalf("ListModels() error = %v", err)
@@ -156,7 +156,7 @@ func TestListModels_AppliesProviderWideOverrideToConcreteModels(t *testing.T) {
 	}), true)
 
 	h := NewHandler(nil, registry, WithModelOverrides(service))
-	c, rec := newHandlerContext("/admin/api/v1/models")
+	c, rec := newHandlerContext("/admin/models")
 
 	if err := h.ListModels(c); err != nil {
 		t.Fatalf("ListModels() error = %v", err)
@@ -199,7 +199,7 @@ func TestListModels_AppliesGlobalOverrideToConcreteModels(t *testing.T) {
 	}), true)
 
 	h := NewHandler(nil, registry, WithModelOverrides(service))
-	c, rec := newHandlerContext("/admin/api/v1/models")
+	c, rec := newHandlerContext("/admin/models")
 
 	if err := h.ListModels(c); err != nil {
 		t.Fatalf("ListModels() error = %v", err)
@@ -256,16 +256,16 @@ func TestModelOverrideEndpointsReturn503WhenServiceUnavailable(t *testing.T) {
 		}
 	}
 
-	listCtx, listRec := newHandlerContext("/admin/api/v1/model-overrides")
+	listCtx, listRec := newHandlerContext("/admin/model-overrides")
 	assertUnavailable("ListModelOverrides", h.ListModelOverrides(listCtx), listRec)
 
-	putReq := httptest.NewRequest(http.MethodPut, "/admin/api/v1/model-overrides", bytes.NewBufferString(`{"selector":"openai/gpt-4o","user_paths":["/"]}`))
+	putReq := httptest.NewRequest(http.MethodPut, "/admin/model-overrides", bytes.NewBufferString(`{"selector":"openai/gpt-4o","user_paths":["/"]}`))
 	putReq.Header.Set("Content-Type", "application/json")
 	putRec := httptest.NewRecorder()
 	putCtx := e.NewContext(putReq, putRec)
 	assertUnavailable("UpsertModelOverride", h.UpsertModelOverride(putCtx), putRec)
 
-	deleteReq := httptest.NewRequest(http.MethodDelete, "/admin/api/v1/model-overrides", bytes.NewBufferString(`{"selector":"openai/gpt-4o"}`))
+	deleteReq := httptest.NewRequest(http.MethodDelete, "/admin/model-overrides", bytes.NewBufferString(`{"selector":"openai/gpt-4o"}`))
 	deleteReq.Header.Set("Content-Type", "application/json")
 	deleteRec := httptest.NewRecorder()
 	deleteCtx := e.NewContext(deleteReq, deleteRec)
@@ -278,7 +278,7 @@ func TestUpsertAndDeleteModelOverride(t *testing.T) {
 	e := echo.New()
 
 	selector := "openai/meta-llama/llama-3.1-8b-instruct"
-	putReq := httptest.NewRequest(http.MethodPut, "/admin/api/v1/model-overrides", bytes.NewBufferString(`{"selector":"`+selector+`","user_paths":["team/alpha"]}`))
+	putReq := httptest.NewRequest(http.MethodPut, "/admin/model-overrides", bytes.NewBufferString(`{"selector":"`+selector+`","user_paths":["team/alpha"]}`))
 	putReq.Header.Set("Content-Type", "application/json")
 	putRec := httptest.NewRecorder()
 	putCtx := e.NewContext(putReq, putRec)
@@ -304,7 +304,7 @@ func TestUpsertAndDeleteModelOverride(t *testing.T) {
 		t.Fatalf("body.UserPaths = %#v, want [/team/alpha]", body.UserPaths)
 	}
 
-	deleteReq := httptest.NewRequest(http.MethodDelete, "/admin/api/v1/model-overrides", bytes.NewBufferString(`{"selector":"`+selector+`"}`))
+	deleteReq := httptest.NewRequest(http.MethodDelete, "/admin/model-overrides", bytes.NewBufferString(`{"selector":"`+selector+`"}`))
 	deleteReq.Header.Set("Content-Type", "application/json")
 	deleteRec := httptest.NewRecorder()
 	deleteCtx := e.NewContext(deleteReq, deleteRec)
@@ -322,7 +322,7 @@ func TestUpsertAndDeleteProviderWideModelOverride(t *testing.T) {
 	h := NewHandler(nil, nil, WithModelOverrides(service))
 	e := echo.New()
 
-	putReq := httptest.NewRequest(http.MethodPut, "/admin/api/v1/model-overrides", bytes.NewBufferString(`{"selector":"openai/","user_paths":["/non-existing"]}`))
+	putReq := httptest.NewRequest(http.MethodPut, "/admin/model-overrides", bytes.NewBufferString(`{"selector":"openai/","user_paths":["/non-existing"]}`))
 	putReq.Header.Set("Content-Type", "application/json")
 	putRec := httptest.NewRecorder()
 	putCtx := e.NewContext(putReq, putRec)
@@ -345,7 +345,7 @@ func TestUpsertAndDeleteProviderWideModelOverride(t *testing.T) {
 		t.Fatalf("body.UserPaths = %#v, want [/non-existing]", body.UserPaths)
 	}
 
-	deleteReq := httptest.NewRequest(http.MethodDelete, "/admin/api/v1/model-overrides", bytes.NewBufferString(`{"selector":"openai/"}`))
+	deleteReq := httptest.NewRequest(http.MethodDelete, "/admin/model-overrides", bytes.NewBufferString(`{"selector":"openai/"}`))
 	deleteReq.Header.Set("Content-Type", "application/json")
 	deleteRec := httptest.NewRecorder()
 	deleteCtx := e.NewContext(deleteReq, deleteRec)
@@ -363,7 +363,7 @@ func TestUpsertAndDeleteGlobalModelOverride(t *testing.T) {
 	h := NewHandler(nil, nil, WithModelOverrides(service))
 	e := echo.New()
 
-	putReq := httptest.NewRequest(http.MethodPut, "/admin/api/v1/model-overrides", bytes.NewBufferString(`{"selector":"/","user_paths":["/"]}`))
+	putReq := httptest.NewRequest(http.MethodPut, "/admin/model-overrides", bytes.NewBufferString(`{"selector":"/","user_paths":["/"]}`))
 	putReq.Header.Set("Content-Type", "application/json")
 	putRec := httptest.NewRecorder()
 	putCtx := e.NewContext(putReq, putRec)
@@ -386,7 +386,7 @@ func TestUpsertAndDeleteGlobalModelOverride(t *testing.T) {
 		t.Fatalf("body.UserPaths = %#v, want [/]", body.UserPaths)
 	}
 
-	deleteReq := httptest.NewRequest(http.MethodDelete, "/admin/api/v1/model-overrides", bytes.NewBufferString(`{"selector":"/"}`))
+	deleteReq := httptest.NewRequest(http.MethodDelete, "/admin/model-overrides", bytes.NewBufferString(`{"selector":"/"}`))
 	deleteReq.Header.Set("Content-Type", "application/json")
 	deleteRec := httptest.NewRecorder()
 	deleteCtx := e.NewContext(deleteReq, deleteRec)
@@ -404,7 +404,7 @@ func TestUpsertModelOverrideReturnsBadRequestForValidationErrors(t *testing.T) {
 	h := NewHandler(nil, nil, WithModelOverrides(service))
 	e := echo.New()
 
-	req := httptest.NewRequest(http.MethodPut, "/admin/api/v1/model-overrides", bytes.NewBufferString(`{"selector":"openai/gpt-4o","user_paths":[]}`))
+	req := httptest.NewRequest(http.MethodPut, "/admin/model-overrides", bytes.NewBufferString(`{"selector":"openai/gpt-4o","user_paths":[]}`))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
@@ -424,7 +424,7 @@ func TestModelOverrideWriteErrorsBubbleProviderErrors(t *testing.T) {
 	h := NewHandler(nil, nil, WithModelOverrides(service))
 	e := echo.New()
 
-	req := httptest.NewRequest(http.MethodPut, "/admin/api/v1/model-overrides", bytes.NewBufferString(`{"selector":"openai/gpt-4o","user_paths":["/"]}`))
+	req := httptest.NewRequest(http.MethodPut, "/admin/model-overrides", bytes.NewBufferString(`{"selector":"openai/gpt-4o","user_paths":["/"]}`))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
@@ -455,7 +455,7 @@ func TestDeleteModelOverrideWriteErrorsBubbleProviderErrors(t *testing.T) {
 	h := NewHandler(nil, nil, WithModelOverrides(service))
 	e := echo.New()
 
-	req := httptest.NewRequest(http.MethodDelete, "/admin/api/v1/model-overrides", bytes.NewBufferString(`{"selector":"openai/gpt-4o"}`))
+	req := httptest.NewRequest(http.MethodDelete, "/admin/model-overrides", bytes.NewBufferString(`{"selector":"openai/gpt-4o"}`))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)

--- a/internal/admin/handler_model_pricing_overrides.go
+++ b/internal/admin/handler_model_pricing_overrides.go
@@ -20,7 +20,7 @@ type deleteModelPricingOverrideRequest struct {
 	Selector string `json:"selector"`
 }
 
-// ListModelPricingOverrides handles GET /admin/api/v1/model-pricing-overrides.
+// ListModelPricingOverrides handles GET /admin/model-pricing-overrides.
 //
 // @Summary      List model pricing overrides
 // @Description  Lists persisted USD pricing overrides. Selectors support global "/", provider-wide "provider/", model-wide "model", and exact "provider/model" scopes.
@@ -30,7 +30,7 @@ type deleteModelPricingOverrideRequest struct {
 // @Success      200  {array}   pricingoverrides.View
 // @Failure      401  {object}  core.GatewayError
 // @Failure      503  {object}  core.GatewayError
-// @Router       /admin/api/v1/model-pricing-overrides [get]
+// @Router       /admin/model-pricing-overrides [get]
 func (h *Handler) ListModelPricingOverrides(c *echo.Context) error {
 	if h.pricingOverrides == nil {
 		return handleError(c, featureUnavailableError("model pricing overrides feature is unavailable"))
@@ -42,7 +42,7 @@ func (h *Handler) ListModelPricingOverrides(c *echo.Context) error {
 	return c.JSON(http.StatusOK, views)
 }
 
-// UpsertModelPricingOverride handles PUT /admin/api/v1/model-pricing-overrides.
+// UpsertModelPricingOverride handles PUT /admin/model-pricing-overrides.
 //
 // @Summary      Create or update one model pricing override
 // @Description  Stores USD-only pricing for one selector. More precise selectors override broader selectors at runtime.
@@ -57,7 +57,7 @@ func (h *Handler) ListModelPricingOverrides(c *echo.Context) error {
 // @Failure      500       {object}  core.GatewayError
 // @Failure      502       {object}  core.GatewayError
 // @Failure      503       {object}  core.GatewayError
-// @Router       /admin/api/v1/model-pricing-overrides [put]
+// @Router       /admin/model-pricing-overrides [put]
 //
 //nolint:dupl // structurally similar to UpsertModelOverride but operates on different types and stores.
 func (h *Handler) UpsertModelPricingOverride(c *echo.Context) error {
@@ -89,7 +89,7 @@ func (h *Handler) UpsertModelPricingOverride(c *echo.Context) error {
 	return c.JSON(http.StatusOK, view)
 }
 
-// DeleteModelPricingOverride handles DELETE /admin/api/v1/model-pricing-overrides.
+// DeleteModelPricingOverride handles DELETE /admin/model-pricing-overrides.
 //
 // @Summary      Delete one model pricing override
 // @Tags         admin
@@ -103,7 +103,7 @@ func (h *Handler) UpsertModelPricingOverride(c *echo.Context) error {
 // @Failure      404       {object}  core.GatewayError
 // @Failure      502       {object}  core.GatewayError
 // @Failure      503       {object}  core.GatewayError
-// @Router       /admin/api/v1/model-pricing-overrides [delete]
+// @Router       /admin/model-pricing-overrides [delete]
 //
 //nolint:dupl // structurally similar to DeleteModelOverride but operates on different types and stores.
 func (h *Handler) DeleteModelPricingOverride(c *echo.Context) error {

--- a/internal/admin/handler_model_pricing_overrides_test.go
+++ b/internal/admin/handler_model_pricing_overrides_test.go
@@ -108,10 +108,10 @@ func TestModelPricingOverrideLifecycle(t *testing.T) {
 			service := newModelPricingOverrideService(t, newModelPricingOverrideTestStore(), tt.providers...)
 			h := NewHandler(nil, nil, WithPricingOverrides(service))
 			e := echo.New()
-			h.RegisterRoutes(e.Group("/admin/api/v1"))
+			h.RegisterRoutes(e.Group("/admin"))
 
 			bodyJSON := `{"selector":"` + tt.selector + `","pricing":{"input_per_mtok":` + strconv.FormatFloat(tt.price, 'f', -1, 64) + `}}`
-			putReq := httptest.NewRequest(http.MethodPut, "/admin/api/v1/model-pricing-overrides", bytes.NewBufferString(bodyJSON))
+			putReq := httptest.NewRequest(http.MethodPut, "/admin/model-pricing-overrides", bytes.NewBufferString(bodyJSON))
 			putReq.Header.Set("Content-Type", "application/json")
 			putRec := httptest.NewRecorder()
 			e.ServeHTTP(putRec, putReq)
@@ -125,7 +125,7 @@ func TestModelPricingOverrideLifecycle(t *testing.T) {
 			}
 			assertPricingOverrideView(t, body, tt.selector, tt.wantProvider, tt.wantModel, tt.wantScope, tt.price)
 
-			listReq := httptest.NewRequest(http.MethodGet, "/admin/api/v1/model-pricing-overrides", nil)
+			listReq := httptest.NewRequest(http.MethodGet, "/admin/model-pricing-overrides", nil)
 			listRec := httptest.NewRecorder()
 			e.ServeHTTP(listRec, listReq)
 			if listRec.Code != http.StatusOK {
@@ -140,7 +140,7 @@ func TestModelPricingOverrideLifecycle(t *testing.T) {
 			}
 			assertPricingOverrideView(t, listBody[0], tt.selector, tt.wantProvider, tt.wantModel, tt.wantScope, tt.price)
 
-			deleteReq := httptest.NewRequest(http.MethodDelete, "/admin/api/v1/model-pricing-overrides", bytes.NewBufferString(`{"selector":"`+tt.selector+`"}`))
+			deleteReq := httptest.NewRequest(http.MethodDelete, "/admin/model-pricing-overrides", bytes.NewBufferString(`{"selector":"`+tt.selector+`"}`))
 			deleteReq.Header.Set("Content-Type", "application/json")
 			deleteRec := httptest.NewRecorder()
 			e.ServeHTTP(deleteRec, deleteReq)
@@ -169,7 +169,7 @@ func TestUpsertModelPricingOverrideReturnsBadRequestForValidationErrors(t *testi
 	h := NewHandler(nil, nil, WithPricingOverrides(service))
 	e := echo.New()
 
-	req := httptest.NewRequest(http.MethodPut, "/admin/api/v1/model-pricing-overrides", bytes.NewBufferString(`{"selector":"openai/gpt-4o","pricing":{}}`))
+	req := httptest.NewRequest(http.MethodPut, "/admin/model-pricing-overrides", bytes.NewBufferString(`{"selector":"openai/gpt-4o","pricing":{}}`))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)

--- a/internal/admin/handler_models.go
+++ b/internal/admin/handler_models.go
@@ -25,7 +25,7 @@ type modelInventoryResponse struct {
 	Access modelAccessResponse `json:"access"`
 }
 
-// ListModels handles GET /admin/api/v1/models
+// ListModels handles GET /admin/models
 // Supports optional ?category= query param for filtering by model category.
 //
 // @Summary      List all registered models with provider info and access state
@@ -36,7 +36,7 @@ type modelInventoryResponse struct {
 // @Success      200  {array}  modelInventoryResponse
 // @Failure      400  {object}  core.GatewayError
 // @Failure      401  {object}  core.GatewayError
-// @Router       /admin/api/v1/models [get]
+// @Router       /admin/models [get]
 func (h *Handler) ListModels(c *echo.Context) error {
 	if h.registry == nil {
 		return c.JSON(http.StatusOK, []modelInventoryResponse{})
@@ -110,7 +110,7 @@ func isValidCategory(cat core.ModelCategory) bool {
 	return slices.Contains(core.AllCategories(), cat)
 }
 
-// ListCategories handles GET /admin/api/v1/models/categories
+// ListCategories handles GET /admin/models/categories
 //
 // @Summary      List model categories with counts
 // @Tags         admin
@@ -118,7 +118,7 @@ func isValidCategory(cat core.ModelCategory) bool {
 // @Security     BearerAuth
 // @Success      200  {array}   providers.CategoryCount
 // @Failure      401  {object}  core.GatewayError
-// @Router       /admin/api/v1/models/categories [get]
+// @Router       /admin/models/categories [get]
 func (h *Handler) ListCategories(c *echo.Context) error {
 	if h.registry == nil {
 		return c.JSON(http.StatusOK, []providers.CategoryCount{})
@@ -127,15 +127,15 @@ func (h *Handler) ListCategories(c *echo.Context) error {
 	return c.JSON(http.StatusOK, h.registry.GetCategoryCounts())
 }
 
-// DashboardConfig handles GET /admin/api/v1/dashboard/config
+// DashboardConfig handles GET /admin/runtime/config
 //
-// @Summary      Get dashboard runtime configuration
+// @Summary      Get admin runtime configuration
 // @Tags         admin
 // @Produce      json
 // @Security     BearerAuth
 // @Success      200  {object}  DashboardConfigResponse
 // @Failure      401  {object}  core.GatewayError
-// @Router       /admin/api/v1/dashboard/config [get]
+// @Router       /admin/runtime/config [get]
 func (h *Handler) DashboardConfig(c *echo.Context) error {
 	return c.JSON(http.StatusOK, cloneDashboardRuntimeConfig(h.runtimeConfig))
 }

--- a/internal/admin/handler_pricing_test.go
+++ b/internal/admin/handler_pricing_test.go
@@ -79,7 +79,7 @@ func TestRecalculateUsagePricingResolvesAliasAndFilters(t *testing.T) {
 		"confirmation":"recalculate"
 	}`)
 	e := echo.New()
-	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", body)
+	req := httptest.NewRequest(http.MethodPost, "/admin/usage/recalculate-pricing", body)
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	req.Header.Set(dashboardTimeZoneHeader, "Europe/Warsaw")
 	rec := httptest.NewRecorder()
@@ -130,7 +130,7 @@ func TestRecalculateUsagePricingRequiresConfirmation(t *testing.T) {
 	h := NewHandler(nil, providers.NewModelRegistry(), WithUsagePricingRecalculator(recalculator))
 
 	e := echo.New()
-	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", bytes.NewBufferString(`{"confirmation":"nope"}`))
+	req := httptest.NewRequest(http.MethodPost, "/admin/usage/recalculate-pricing", bytes.NewBufferString(`{"confirmation":"nope"}`))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
@@ -175,7 +175,7 @@ func TestRecalculateUsagePricingAcceptsConfirmAlias(t *testing.T) {
 			h := NewHandler(nil, providers.NewModelRegistry(), WithUsagePricingRecalculator(recalculator))
 
 			e := echo.New()
-			req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", bytes.NewBufferString(test.body))
+			req := httptest.NewRequest(http.MethodPost, "/admin/usage/recalculate-pricing", bytes.NewBufferString(test.body))
 			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)
@@ -221,7 +221,7 @@ func TestRecalculateUsagePricingFeatureUnavailable(t *testing.T) {
 			h := test.handler(recalculator)
 
 			e := echo.New()
-			req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", bytes.NewBufferString(`{"confirmation":"recalculate"}`))
+			req := httptest.NewRequest(http.MethodPost, "/admin/usage/recalculate-pricing", bytes.NewBufferString(`{"confirmation":"recalculate"}`))
 			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)
@@ -247,7 +247,7 @@ func TestRecalculateUsagePricingInvalidSelector(t *testing.T) {
 	h := NewHandler(nil, providers.NewModelRegistry(), WithUsagePricingRecalculator(recalculator))
 
 	e := echo.New()
-	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", bytes.NewBufferString(`{"confirmation":"recalculate","selector":"invalid"}`))
+	req := httptest.NewRequest(http.MethodPost, "/admin/usage/recalculate-pricing", bytes.NewBufferString(`{"confirmation":"recalculate","selector":"invalid"}`))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
@@ -300,7 +300,7 @@ func TestRecalculateUsagePricingRejectsInvalidDateAndUserPath(t *testing.T) {
 			h := NewHandler(nil, providers.NewModelRegistry(), WithUsagePricingRecalculator(recalculator))
 
 			e := echo.New()
-			req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", bytes.NewBufferString(test.body))
+			req := httptest.NewRequest(http.MethodPost, "/admin/usage/recalculate-pricing", bytes.NewBufferString(test.body))
 			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)
@@ -336,7 +336,7 @@ func TestRecalculateUsagePricingDefaultsDateRange(t *testing.T) {
 	h := NewHandler(nil, providers.NewModelRegistry(), WithUsagePricingRecalculator(recalculator))
 
 	e := echo.New()
-	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", bytes.NewBufferString(`{"confirmation":"recalculate"}`))
+	req := httptest.NewRequest(http.MethodPost, "/admin/usage/recalculate-pricing", bytes.NewBufferString(`{"confirmation":"recalculate"}`))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
@@ -374,7 +374,7 @@ func TestRecalculateUsagePricingClampsRequestedDays(t *testing.T) {
 	h := NewHandler(nil, providers.NewModelRegistry(), WithUsagePricingRecalculator(recalculator))
 
 	e := echo.New()
-	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", bytes.NewBufferString(`{"confirmation":"recalculate","days":9999}`))
+	req := httptest.NewRequest(http.MethodPost, "/admin/usage/recalculate-pricing", bytes.NewBufferString(`{"confirmation":"recalculate","days":9999}`))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
@@ -402,7 +402,7 @@ func TestRecalculateUsagePricingReturnsInternalErrorOnRecalculatorFailure(t *tes
 	h := NewHandler(nil, providers.NewModelRegistry(), WithUsagePricingRecalculator(recalculator))
 
 	e := echo.New()
-	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", bytes.NewBufferString(`{"confirmation":"recalculate"}`))
+	req := httptest.NewRequest(http.MethodPost, "/admin/usage/recalculate-pricing", bytes.NewBufferString(`{"confirmation":"recalculate"}`))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
@@ -454,7 +454,7 @@ func TestRecalculateUsagePricingPreservesExpectedRecalculatorErrors(t *testing.T
 			h := NewHandler(nil, providers.NewModelRegistry(), WithUsagePricingRecalculator(recalculator))
 
 			e := echo.New()
-			req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", bytes.NewBufferString(`{"confirmation":"recalculate"}`))
+			req := httptest.NewRequest(http.MethodPost, "/admin/usage/recalculate-pricing", bytes.NewBufferString(`{"confirmation":"recalculate"}`))
 			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)

--- a/internal/admin/handler_providers.go
+++ b/internal/admin/handler_providers.go
@@ -16,7 +16,7 @@ func (h *Handler) ProviderStatus(c *echo.Context) error {
 	return c.JSON(http.StatusOK, h.buildProviderStatusResponse())
 }
 
-// RefreshRuntime handles POST /admin/api/v1/runtime/refresh
+// RefreshRuntime handles POST /admin/runtime/refresh
 func (h *Handler) RefreshRuntime(c *echo.Context) error {
 	if h.runtimeRefresher == nil {
 		return handleError(c, featureUnavailableError("runtime refresh is unavailable"))

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -181,7 +181,7 @@ func newHandlerContext(path string) (*echo.Context, *httptest.ResponseRecorder) 
 
 func TestUsageSummary_NilReader(t *testing.T) {
 	h := NewHandler(nil, nil)
-	c, rec := newHandlerContext("/admin/api/v1/usage/summary")
+	c, rec := newHandlerContext("/admin/usage/summary")
 
 	if err := h.UsageSummary(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -208,7 +208,7 @@ func TestUsageSummary_Success(t *testing.T) {
 		},
 	}
 	h := NewHandler(reader, nil)
-	c, rec := newHandlerContext("/admin/api/v1/usage/summary?days=30")
+	c, rec := newHandlerContext("/admin/usage/summary?days=30")
 
 	if err := h.UsageSummary(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -233,7 +233,7 @@ func TestUsageSummary_GatewayError(t *testing.T) {
 		summaryErr: core.NewProviderError("test", http.StatusBadGateway, "upstream failed", nil),
 	}
 	h := NewHandler(reader, nil)
-	c, rec := newHandlerContext("/admin/api/v1/usage/summary")
+	c, rec := newHandlerContext("/admin/usage/summary")
 
 	if err := h.UsageSummary(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -252,7 +252,7 @@ func TestUsageSummary_GenericError(t *testing.T) {
 		summaryErr: errors.New("database connection lost"),
 	}
 	h := NewHandler(reader, nil)
-	c, rec := newHandlerContext("/admin/api/v1/usage/summary")
+	c, rec := newHandlerContext("/admin/usage/summary")
 
 	if err := h.UsageSummary(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -290,7 +290,7 @@ func TestUsageSummary_WithPersistedCosts(t *testing.T) {
 	}
 
 	h := NewHandler(reader, nil)
-	c, rec := newHandlerContext("/admin/api/v1/usage/summary?days=30")
+	c, rec := newHandlerContext("/admin/usage/summary?days=30")
 
 	if err := h.UsageSummary(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -326,7 +326,7 @@ func TestUsageSummary_NilCosts(t *testing.T) {
 	}
 
 	h := NewHandler(reader, nil)
-	c, rec := newHandlerContext("/admin/api/v1/usage/summary?days=30")
+	c, rec := newHandlerContext("/admin/usage/summary?days=30")
 
 	if err := h.UsageSummary(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -353,7 +353,7 @@ func TestUsageSummary_NilCosts(t *testing.T) {
 
 func TestDailyUsage_NilReader(t *testing.T) {
 	h := NewHandler(nil, nil)
-	c, rec := newHandlerContext("/admin/api/v1/usage/daily")
+	c, rec := newHandlerContext("/admin/usage/daily")
 
 	if err := h.DailyUsage(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -375,7 +375,7 @@ func TestDailyUsage_Success(t *testing.T) {
 		},
 	}
 	h := NewHandler(reader, nil)
-	c, rec := newHandlerContext("/admin/api/v1/usage/daily?days=7")
+	c, rec := newHandlerContext("/admin/usage/daily?days=7")
 
 	if err := h.DailyUsage(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -397,7 +397,7 @@ func TestDailyUsage_NilResult(t *testing.T) {
 		daily: nil, // reader returns nil slice
 	}
 	h := NewHandler(reader, nil)
-	c, rec := newHandlerContext("/admin/api/v1/usage/daily")
+	c, rec := newHandlerContext("/admin/usage/daily")
 
 	if err := h.DailyUsage(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -416,7 +416,7 @@ func TestDailyUsage_Error(t *testing.T) {
 		dailyErr: core.NewRateLimitError("test", "too many requests"),
 	}
 	h := NewHandler(reader, nil)
-	c, rec := newHandlerContext("/admin/api/v1/usage/daily")
+	c, rec := newHandlerContext("/admin/usage/daily")
 
 	if err := h.DailyUsage(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -434,7 +434,7 @@ func TestDailyUsage_Error(t *testing.T) {
 
 func TestUsageByModel_NilReader(t *testing.T) {
 	h := NewHandler(nil, nil)
-	c, rec := newHandlerContext("/admin/api/v1/usage/models")
+	c, rec := newHandlerContext("/admin/usage/models")
 
 	if err := h.UsageByModel(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -455,7 +455,7 @@ func TestUsageByModel_Success(t *testing.T) {
 		},
 	}
 	h := NewHandler(reader, nil)
-	c, rec := newHandlerContext("/admin/api/v1/usage/models?days=30")
+	c, rec := newHandlerContext("/admin/usage/models?days=30")
 
 	if err := h.UsageByModel(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -485,7 +485,7 @@ func TestUsageByModel_PreservesProviderName(t *testing.T) {
 		},
 	}
 	h := NewHandler(reader, nil)
-	c, rec := newHandlerContext("/admin/api/v1/usage/models?days=30")
+	c, rec := newHandlerContext("/admin/usage/models?days=30")
 
 	if err := h.UsageByModel(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -514,7 +514,7 @@ func TestUsageByModel_Error(t *testing.T) {
 		modelUsageErr: errors.New("db failure"),
 	}
 	h := NewHandler(reader, nil)
-	c, rec := newHandlerContext("/admin/api/v1/usage/models")
+	c, rec := newHandlerContext("/admin/usage/models")
 
 	if err := h.UsageByModel(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -528,7 +528,7 @@ func TestUsageByModel_Error(t *testing.T) {
 
 func TestUsageByUserPath_NilReader(t *testing.T) {
 	h := NewHandler(nil, nil)
-	c, rec := newHandlerContext("/admin/api/v1/usage/user-paths")
+	c, rec := newHandlerContext("/admin/usage/user-paths")
 
 	if err := h.UsageByUserPath(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -549,7 +549,7 @@ func TestUsageByUserPath_Success(t *testing.T) {
 		},
 	}
 	h := NewHandler(reader, nil)
-	c, rec := newHandlerContext("/admin/api/v1/usage/user-paths?days=30")
+	c, rec := newHandlerContext("/admin/usage/user-paths?days=30")
 
 	if err := h.UsageByUserPath(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -580,7 +580,7 @@ func TestUsageByUserPath_Error(t *testing.T) {
 		userPathUsageErr: errors.New("db failure"),
 	}
 	h := NewHandler(reader, nil)
-	c, rec := newHandlerContext("/admin/api/v1/usage/user-paths")
+	c, rec := newHandlerContext("/admin/usage/user-paths")
 
 	if err := h.UsageByUserPath(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -594,7 +594,7 @@ func TestUsageByUserPath_Error(t *testing.T) {
 
 func TestUsageLog_NilReader(t *testing.T) {
 	h := NewHandler(nil, nil)
-	c, rec := newHandlerContext("/admin/api/v1/usage/log")
+	c, rec := newHandlerContext("/admin/usage/log")
 
 	if err := h.UsageLog(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -626,7 +626,7 @@ func TestUsageLog_Success(t *testing.T) {
 		},
 	}
 	h := NewHandler(reader, nil)
-	c, rec := newHandlerContext("/admin/api/v1/usage/log?days=30&limit=50&offset=0")
+	c, rec := newHandlerContext("/admin/usage/log?days=30&limit=50&offset=0")
 
 	if err := h.UsageLog(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -680,7 +680,7 @@ func TestUsageLog_PreservesProviderName(t *testing.T) {
 		},
 	}
 	h := NewHandler(reader, nil)
-	c, rec := newHandlerContext("/admin/api/v1/usage/log?days=30")
+	c, rec := newHandlerContext("/admin/usage/log?days=30")
 
 	if err := h.UsageLog(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -709,7 +709,7 @@ func TestUsageLog_Error(t *testing.T) {
 		usageLogErr: core.NewProviderError("test", http.StatusBadGateway, "upstream failed", nil),
 	}
 	h := NewHandler(reader, nil)
-	c, rec := newHandlerContext("/admin/api/v1/usage/log")
+	c, rec := newHandlerContext("/admin/usage/log")
 
 	if err := h.UsageLog(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -729,7 +729,7 @@ func TestUsageLog_WithFilters(t *testing.T) {
 		},
 	}
 	h := NewHandler(reader, nil)
-	c, rec := newHandlerContext("/admin/api/v1/usage/log?model=gpt-4&provider=openai&user_path=/team&search=test&limit=10&offset=5")
+	c, rec := newHandlerContext("/admin/usage/log?model=gpt-4&provider=openai&user_path=/team&search=test&limit=10&offset=5")
 
 	if err := h.UsageLog(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -746,7 +746,7 @@ func TestUsageLog_WithFilters(t *testing.T) {
 
 func TestAuditLog_NilReader(t *testing.T) {
 	h := NewHandler(nil, nil)
-	c, rec := newHandlerContext("/admin/api/v1/audit/log")
+	c, rec := newHandlerContext("/admin/audit/log")
 
 	if err := h.AuditLog(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -796,7 +796,7 @@ func TestAuditLog_Success(t *testing.T) {
 	}
 
 	h := NewHandler(nil, nil, WithAuditReader(reader))
-	c, rec := newHandlerContext("/admin/api/v1/audit/log?days=7")
+	c, rec := newHandlerContext("/admin/audit/log?days=7")
 
 	if err := h.AuditLog(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -846,7 +846,7 @@ func TestAuditLog_EmitsRequestedModel(t *testing.T) {
 	}
 
 	h := NewHandler(nil, nil, WithAuditReader(reader))
-	c, rec := newHandlerContext("/admin/api/v1/audit/log?search=req-1")
+	c, rec := newHandlerContext("/admin/audit/log?search=req-1")
 
 	if err := h.AuditLog(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -909,7 +909,7 @@ func TestAuditLog_EnrichesEntriesWithUsageSummary(t *testing.T) {
 	}
 
 	h := NewHandler(usageReader, nil, WithAuditReader(auditReader))
-	c, rec := newHandlerContext("/admin/api/v1/audit/log?days=7")
+	c, rec := newHandlerContext("/admin/audit/log?days=7")
 
 	if err := h.AuditLog(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -962,7 +962,7 @@ func TestAuditLog_PreservesProviderName(t *testing.T) {
 		},
 	}
 	h := NewHandler(nil, nil, WithAuditReader(reader))
-	c, rec := newHandlerContext("/admin/api/v1/audit/log?days=7")
+	c, rec := newHandlerContext("/admin/audit/log?days=7")
 
 	if err := h.AuditLog(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -997,7 +997,7 @@ func TestAuditLog_WithFilters(t *testing.T) {
 	}
 
 	h := NewHandler(nil, nil, WithAuditReader(reader))
-	c, rec := newHandlerContext("/admin/api/v1/audit/log?model=gpt-4&provider=openai&method=post&path=/v1/chat/completions&user_path=/team&error_type=provider_error&status_code=502&stream=true&search=timeout&limit=10&offset=5")
+	c, rec := newHandlerContext("/admin/audit/log?model=gpt-4&provider=openai&method=post&path=/v1/chat/completions&user_path=/team&error_type=provider_error&status_code=502&stream=true&search=timeout&limit=10&offset=5")
 
 	if err := h.AuditLog(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1043,7 +1043,7 @@ func TestAuditLog_InvalidStatusCode(t *testing.T) {
 		logResult: &auditlog.LogListResult{Entries: []auditlog.LogEntry{}},
 	}
 	h := NewHandler(nil, nil, WithAuditReader(reader))
-	c, rec := newHandlerContext("/admin/api/v1/audit/log?status_code=foo")
+	c, rec := newHandlerContext("/admin/audit/log?status_code=foo")
 
 	if err := h.AuditLog(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1061,7 +1061,7 @@ func TestAuditLog_InvalidStream(t *testing.T) {
 		logResult: &auditlog.LogListResult{Entries: []auditlog.LogEntry{}},
 	}
 	h := NewHandler(nil, nil, WithAuditReader(reader))
-	c, rec := newHandlerContext("/admin/api/v1/audit/log?stream=maybe")
+	c, rec := newHandlerContext("/admin/audit/log?stream=maybe")
 
 	if err := h.AuditLog(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1082,7 +1082,7 @@ func TestAuditLog_InvalidLimit(t *testing.T) {
 				logResult: &auditlog.LogListResult{Entries: []auditlog.LogEntry{}},
 			}
 			h := NewHandler(nil, nil, WithAuditReader(reader))
-			c, rec := newHandlerContext("/admin/api/v1/audit/log?limit=" + q)
+			c, rec := newHandlerContext("/admin/audit/log?limit=" + q)
 
 			if err := h.AuditLog(c); err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -1105,7 +1105,7 @@ func TestAuditLog_InvalidOffset(t *testing.T) {
 				logResult: &auditlog.LogListResult{Entries: []auditlog.LogEntry{}},
 			}
 			h := NewHandler(nil, nil, WithAuditReader(reader))
-			c, rec := newHandlerContext("/admin/api/v1/audit/log?offset=" + q)
+			c, rec := newHandlerContext("/admin/audit/log?offset=" + q)
 
 			if err := h.AuditLog(c); err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -1125,7 +1125,7 @@ func TestAuditLog_Error(t *testing.T) {
 		logErr: core.NewProviderError("test", http.StatusBadGateway, "upstream failed", nil),
 	}
 	h := NewHandler(nil, nil, WithAuditReader(reader))
-	c, rec := newHandlerContext("/admin/api/v1/audit/log")
+	c, rec := newHandlerContext("/admin/audit/log")
 
 	if err := h.AuditLog(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1137,7 +1137,7 @@ func TestAuditLog_Error(t *testing.T) {
 
 func TestAuditConversation_NilReader(t *testing.T) {
 	h := NewHandler(nil, nil)
-	c, rec := newHandlerContext("/admin/api/v1/audit/conversation?log_id=log-1")
+	c, rec := newHandlerContext("/admin/audit/conversation?log_id=log-1")
 
 	if err := h.AuditConversation(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1170,7 +1170,7 @@ func TestAuditConversation_Success(t *testing.T) {
 		},
 	}
 	h := NewHandler(nil, nil, WithAuditReader(reader))
-	c, rec := newHandlerContext("/admin/api/v1/audit/conversation?log_id=log-2&limit=80")
+	c, rec := newHandlerContext("/admin/audit/conversation?log_id=log-2&limit=80")
 
 	if err := h.AuditConversation(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1195,7 +1195,7 @@ func TestAuditConversation_PreservesProviderName(t *testing.T) {
 		},
 	}
 	h := NewHandler(nil, nil, WithAuditReader(reader))
-	c, rec := newHandlerContext("/admin/api/v1/audit/conversation?log_id=log-2")
+	c, rec := newHandlerContext("/admin/audit/conversation?log_id=log-2")
 
 	if err := h.AuditConversation(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1222,7 +1222,7 @@ func TestAuditConversation_PreservesProviderName(t *testing.T) {
 func TestAuditConversation_MissingLogID(t *testing.T) {
 	reader := &mockAuditReader{}
 	h := NewHandler(nil, nil, WithAuditReader(reader))
-	c, rec := newHandlerContext("/admin/api/v1/audit/conversation")
+	c, rec := newHandlerContext("/admin/audit/conversation")
 
 	if err := h.AuditConversation(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1235,7 +1235,7 @@ func TestAuditConversation_MissingLogID(t *testing.T) {
 func TestAuditConversation_InvalidLimit(t *testing.T) {
 	reader := &mockAuditReader{}
 	h := NewHandler(nil, nil, WithAuditReader(reader))
-	c, rec := newHandlerContext("/admin/api/v1/audit/conversation?log_id=log-1&limit=bad")
+	c, rec := newHandlerContext("/admin/audit/conversation?log_id=log-1&limit=bad")
 
 	if err := h.AuditConversation(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1250,7 +1250,7 @@ func TestAuditConversation_Error(t *testing.T) {
 		conversationErr: core.NewProviderError("test", http.StatusBadGateway, "upstream failed", nil),
 	}
 	h := NewHandler(nil, nil, WithAuditReader(reader))
-	c, rec := newHandlerContext("/admin/api/v1/audit/conversation?log_id=log-1")
+	c, rec := newHandlerContext("/admin/audit/conversation?log_id=log-1")
 
 	if err := h.AuditConversation(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1270,7 +1270,7 @@ func TestAuditConversation_Error(t *testing.T) {
 
 func TestAuditLog_NilReaderStillValidatesParams(t *testing.T) {
 	h := NewHandler(nil, nil) // no audit reader configured
-	c, rec := newHandlerContext("/admin/api/v1/audit/log?status_code=not-an-int")
+	c, rec := newHandlerContext("/admin/audit/log?status_code=not-an-int")
 
 	if err := h.AuditLog(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1285,7 +1285,7 @@ func TestAuditLog_NilReaderStillValidatesParams(t *testing.T) {
 
 func TestAuditConversation_NilReaderStillValidatesParams(t *testing.T) {
 	h := NewHandler(nil, nil)                                       // no audit reader configured
-	c, rec := newHandlerContext("/admin/api/v1/audit/conversation") // missing required log_id
+	c, rec := newHandlerContext("/admin/audit/conversation") // missing required log_id
 
 	if err := h.AuditConversation(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1300,7 +1300,7 @@ func TestAuditConversation_NilReaderStillValidatesParams(t *testing.T) {
 
 func TestUsageLog_NilReaderStillValidatesParams(t *testing.T) {
 	h := NewHandler(nil, nil) // no usage reader configured
-	c, rec := newHandlerContext("/admin/api/v1/usage/log?start_date=not-a-date")
+	c, rec := newHandlerContext("/admin/usage/log?start_date=not-a-date")
 
 	if err := h.UsageLog(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1317,7 +1317,7 @@ func TestUsageLog_NilReaderStillValidatesParams(t *testing.T) {
 
 func TestListModels_NilRegistry(t *testing.T) {
 	h := NewHandler(nil, nil)
-	c, rec := newHandlerContext("/admin/api/v1/models")
+	c, rec := newHandlerContext("/admin/models")
 
 	if err := h.ListModels(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1347,7 +1347,7 @@ func TestListModels_WithModels(t *testing.T) {
 	}
 
 	h := NewHandler(nil, registry)
-	c, rec := newHandlerContext("/admin/api/v1/models")
+	c, rec := newHandlerContext("/admin/models")
 
 	if err := h.ListModels(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1380,7 +1380,7 @@ func TestListModels_EmptyRegistry(t *testing.T) {
 	registry := providers.NewModelRegistry()
 
 	h := NewHandler(nil, registry)
-	c, rec := newHandlerContext("/admin/api/v1/models")
+	c, rec := newHandlerContext("/admin/models")
 
 	if err := h.ListModels(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1433,7 +1433,7 @@ func TestListModels_WithCategoryFilter(t *testing.T) {
 	h := NewHandler(nil, registry)
 
 	t.Run("FilterTextGeneration", func(t *testing.T) {
-		c, rec := newHandlerContext("/admin/api/v1/models?category=text_generation")
+		c, rec := newHandlerContext("/admin/models?category=text_generation")
 		if err := h.ListModels(c); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1453,7 +1453,7 @@ func TestListModels_WithCategoryFilter(t *testing.T) {
 	})
 
 	t.Run("FilterAll", func(t *testing.T) {
-		c, rec := newHandlerContext("/admin/api/v1/models?category=all")
+		c, rec := newHandlerContext("/admin/models?category=all")
 		if err := h.ListModels(c); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1467,7 +1467,7 @@ func TestListModels_WithCategoryFilter(t *testing.T) {
 	})
 
 	t.Run("NoFilter", func(t *testing.T) {
-		c, rec := newHandlerContext("/admin/api/v1/models")
+		c, rec := newHandlerContext("/admin/models")
 		if err := h.ListModels(c); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1497,7 +1497,7 @@ func TestListModels_InvalidCategory(t *testing.T) {
 	}
 
 	h := NewHandler(nil, registry)
-	c, rec := newHandlerContext("/admin/api/v1/models?category=bogus_category")
+	c, rec := newHandlerContext("/admin/models?category=bogus_category")
 
 	if err := h.ListModels(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1539,7 +1539,7 @@ func TestListModels_IncludesSelectorAndProviderName(t *testing.T) {
 	}
 
 	h := NewHandler(nil, registry)
-	c, rec := newHandlerContext("/admin/api/v1/models")
+	c, rec := newHandlerContext("/admin/models")
 
 	if err := h.ListModels(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1574,7 +1574,7 @@ func TestListModels_IncludesSelectorAndProviderName(t *testing.T) {
 
 func TestListCategories_NilRegistry(t *testing.T) {
 	h := NewHandler(nil, nil)
-	c, rec := newHandlerContext("/admin/api/v1/models/categories")
+	c, rec := newHandlerContext("/admin/models/categories")
 
 	if err := h.ListCategories(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1610,7 +1610,7 @@ func TestListCategories_WithModels(t *testing.T) {
 	}
 
 	h := NewHandler(nil, registry)
-	c, rec := newHandlerContext("/admin/api/v1/models/categories")
+	c, rec := newHandlerContext("/admin/models/categories")
 
 	if err := h.ListCategories(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1697,7 +1697,7 @@ func TestProviderStatus_DistinguishesProvidersWithSameTypeByName(t *testing.T) {
 			},
 		},
 	}))
-	c, rec := newHandlerContext("/admin/api/v1/providers/status")
+	c, rec := newHandlerContext("/admin/providers/status")
 
 	if err := h.ProviderStatus(c); err != nil {
 		t.Fatalf("ProviderStatus() error = %v", err)
@@ -1950,7 +1950,7 @@ func TestDashboardConfig_ReturnsAllowlistedRuntimeFlags(t *testing.T) {
 		SemanticCacheEnabled: "off",
 		PricingRecalculation: "on",
 	}))
-	c, rec := newHandlerContext("/admin/api/v1/dashboard/config")
+	c, rec := newHandlerContext("/admin/runtime/config")
 
 	if err := h.DashboardConfig(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -2011,7 +2011,7 @@ func TestRefreshRuntime_ReturnsReport(t *testing.T) {
 		},
 	}
 	h := NewHandler(nil, nil, WithRuntimeRefresher(refresher))
-	c, rec := newHandlerContext("/admin/api/v1/runtime/refresh")
+	c, rec := newHandlerContext("/admin/runtime/refresh")
 	c.Request().Method = http.MethodPost
 
 	if err := h.RefreshRuntime(c); err != nil {
@@ -2041,7 +2041,7 @@ func TestRefreshRuntime_ReturnsReport(t *testing.T) {
 
 func TestRefreshRuntime_FeatureUnavailableWhenNotConfigured(t *testing.T) {
 	h := NewHandler(nil, nil)
-	c, rec := newHandlerContext("/admin/api/v1/runtime/refresh")
+	c, rec := newHandlerContext("/admin/runtime/refresh")
 	c.Request().Method = http.MethodPost
 
 	if err := h.RefreshRuntime(c); err != nil {
@@ -2084,7 +2084,7 @@ func TestRefreshRuntime_PreservesGatewayError(t *testing.T) {
 			WithCode("request_canceled"),
 	}
 	h := NewHandler(nil, nil, WithRuntimeRefresher(refresher))
-	c, rec := newHandlerContext("/admin/api/v1/runtime/refresh")
+	c, rec := newHandlerContext("/admin/runtime/refresh")
 	c.Request().Method = http.MethodPost
 
 	if err := h.RefreshRuntime(c); err != nil {
@@ -2125,7 +2125,7 @@ func TestCacheOverview_FeatureUnavailableWhenCacheDisabled(t *testing.T) {
 	h := NewHandler(&mockUsageReader{}, nil, WithDashboardRuntimeConfig(DashboardConfigResponse{
 		CacheEnabled: "off",
 	}))
-	c, rec := newHandlerContext("/admin/api/v1/cache/overview")
+	c, rec := newHandlerContext("/admin/cache/overview")
 
 	if err := h.CacheOverview(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -2154,7 +2154,7 @@ func TestCacheOverview_ReturnsPayloadWhenEnabled(t *testing.T) {
 	h := NewHandler(reader, nil, WithDashboardRuntimeConfig(DashboardConfigResponse{
 		CacheEnabled: "on",
 	}))
-	c, rec := newHandlerContext("/admin/api/v1/cache/overview?days=30&user_path=/team")
+	c, rec := newHandlerContext("/admin/cache/overview?days=30&user_path=/team")
 
 	if err := h.CacheOverview(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -2186,7 +2186,7 @@ func TestCacheOverview_ReturnsErrorWhenReaderFails(t *testing.T) {
 	h := NewHandler(reader, nil, WithDashboardRuntimeConfig(DashboardConfigResponse{
 		CacheEnabled: "on",
 	}))
-	c, rec := newHandlerContext("/admin/api/v1/cache/overview?days=30")
+	c, rec := newHandlerContext("/admin/cache/overview?days=30")
 
 	if err := h.CacheOverview(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -2227,7 +2227,7 @@ func TestCacheOverview_ReturnsClientClosedWhenRequestIsCanceled(t *testing.T) {
 	h := NewHandler(reader, nil, WithDashboardRuntimeConfig(DashboardConfigResponse{
 		CacheEnabled: "on",
 	}))
-	c, rec := newHandlerContext("/admin/api/v1/cache/overview?days=30")
+	c, rec := newHandlerContext("/admin/cache/overview?days=30")
 
 	if err := h.CacheOverview(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -2263,7 +2263,7 @@ func TestCacheOverview_ReturnsGatewayTimeoutWhenRequestDeadlineExceeded(t *testi
 	h := NewHandler(reader, nil, WithDashboardRuntimeConfig(DashboardConfigResponse{
 		CacheEnabled: "on",
 	}))
-	c, rec := newHandlerContext("/admin/api/v1/cache/overview?days=30")
+	c, rec := newHandlerContext("/admin/cache/overview?days=30")
 
 	if err := h.CacheOverview(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -2377,7 +2377,7 @@ func TestHandleError_DoesNotLogCanceledRequestsAtDefaultLevel(t *testing.T) {
 	})
 
 	e := echo.New()
-	req := httptest.NewRequest(http.MethodGet, "/admin/api/v1/cache/overview", nil)
+	req := httptest.NewRequest(http.MethodGet, "/admin/cache/overview", nil)
 	req = req.WithContext(core.WithRequestID(req.Context(), "admin-canceled-req-789"))
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
@@ -2403,7 +2403,7 @@ func TestHandleError_LogsClientErrorsAtWarnLevel(t *testing.T) {
 	})
 
 	e := echo.New()
-	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/workflows", nil)
+	req := httptest.NewRequest(http.MethodPost, "/admin/workflows", nil)
 	req = req.WithContext(core.WithRequestID(req.Context(), "admin-warn-req-123"))
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
@@ -2423,7 +2423,7 @@ func TestHandleError_LogsClientErrorsAtWarnLevel(t *testing.T) {
 	if !strings.Contains(logOutput, `"msg":"admin request failed"`) {
 		t.Fatalf("expected admin request failed log, got %q", logOutput)
 	}
-	if !strings.Contains(logOutput, `"path":"/admin/api/v1/workflows"`) {
+	if !strings.Contains(logOutput, `"path":"/admin/workflows"`) {
 		t.Fatalf("expected admin path in log, got %q", logOutput)
 	}
 	if !strings.Contains(logOutput, `"request_id":"admin-warn-req-123"`) {
@@ -2440,7 +2440,7 @@ func TestHandleError_LogsServerErrorsAtErrorLevel(t *testing.T) {
 	})
 
 	e := echo.New()
-	req := httptest.NewRequest(http.MethodPut, "/admin/api/v1/guardrails", nil)
+	req := httptest.NewRequest(http.MethodPut, "/admin/guardrails", nil)
 	req = req.WithContext(core.WithRequestID(req.Context(), "admin-error-req-456"))
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)

--- a/internal/admin/handler_usage.go
+++ b/internal/admin/handler_usage.go
@@ -18,7 +18,7 @@ import (
 // matches the value documented in the @Param limit annotation below.
 const maxUsageLogLimit = 200
 
-// UsageSummary handles GET /admin/api/v1/usage/summary
+// UsageSummary handles GET /admin/usage/summary
 //
 // @Summary      Get usage summary
 // @Tags         admin
@@ -32,7 +32,7 @@ const maxUsageLogLimit = 200
 // @Success      200  {object}  usage.UsageSummary
 // @Failure      400  {object}  core.GatewayError
 // @Failure      401  {object}  core.GatewayError
-// @Router       /admin/api/v1/usage/summary [get]
+// @Router       /admin/usage/summary [get]
 func (h *Handler) UsageSummary(c *echo.Context) error {
 	// Validate request shape before the disabled-reader fast path so callers
 	// always get a 400 for malformed inputs, regardless of wiring.
@@ -82,7 +82,7 @@ func usageSliceResponse[T any](
 	return c.JSON(http.StatusOK, values)
 }
 
-// DailyUsage handles GET /admin/api/v1/usage/daily
+// DailyUsage handles GET /admin/usage/daily
 //
 // @Summary      Get usage breakdown by period
 // @Tags         admin
@@ -97,14 +97,14 @@ func usageSliceResponse[T any](
 // @Success      200  {array}   usage.DailyUsage
 // @Failure      400  {object}  core.GatewayError
 // @Failure      401  {object}  core.GatewayError
-// @Router       /admin/api/v1/usage/daily [get]
+// @Router       /admin/usage/daily [get]
 func (h *Handler) DailyUsage(c *echo.Context) error {
 	return usageSliceResponse(c, h.usageReader, func(ctx context.Context, params usage.UsageQueryParams) ([]usage.DailyUsage, error) {
 		return h.usageReader.GetDailyUsage(ctx, params)
 	})
 }
 
-// UsageByModel handles GET /admin/api/v1/usage/models
+// UsageByModel handles GET /admin/usage/models
 //
 // @Summary      Get usage breakdown by model
 // @Tags         admin
@@ -118,14 +118,14 @@ func (h *Handler) DailyUsage(c *echo.Context) error {
 // @Success      200  {array}   usage.ModelUsage
 // @Failure      400  {object}  core.GatewayError
 // @Failure      401  {object}  core.GatewayError
-// @Router       /admin/api/v1/usage/models [get]
+// @Router       /admin/usage/models [get]
 func (h *Handler) UsageByModel(c *echo.Context) error {
 	return usageSliceResponse(c, h.usageReader, func(ctx context.Context, params usage.UsageQueryParams) ([]usage.ModelUsage, error) {
 		return h.usageReader.GetUsageByModel(ctx, params)
 	})
 }
 
-// UsageByUserPath handles GET /admin/api/v1/usage/user-paths
+// UsageByUserPath handles GET /admin/usage/user-paths
 //
 // @Summary      Get usage breakdown by user path
 // @Tags         admin
@@ -139,14 +139,14 @@ func (h *Handler) UsageByModel(c *echo.Context) error {
 // @Success      200  {array}   usage.UserPathUsage
 // @Failure      400  {object}  core.GatewayError
 // @Failure      401  {object}  core.GatewayError
-// @Router       /admin/api/v1/usage/user-paths [get]
+// @Router       /admin/usage/user-paths [get]
 func (h *Handler) UsageByUserPath(c *echo.Context) error {
 	return usageSliceResponse(c, h.usageReader, func(ctx context.Context, params usage.UsageQueryParams) ([]usage.UserPathUsage, error) {
 		return h.usageReader.GetUsageByUserPath(ctx, params)
 	})
 }
 
-// UsageLog handles GET /admin/api/v1/usage/log
+// UsageLog handles GET /admin/usage/log
 //
 // @Summary      Get paginated usage log entries
 // @Tags         admin
@@ -165,7 +165,7 @@ func (h *Handler) UsageByUserPath(c *echo.Context) error {
 // @Success      200  {object}  usage.UsageLogResult
 // @Failure      400  {object}  core.GatewayError
 // @Failure      401  {object}  core.GatewayError
-// @Router       /admin/api/v1/usage/log [get]
+// @Router       /admin/usage/log [get]
 func (h *Handler) UsageLog(c *echo.Context) error {
 	// Validate request shape before the disabled-reader fast path so callers
 	// always get a 400 for malformed inputs, regardless of wiring.
@@ -219,7 +219,7 @@ func (h *Handler) UsageLog(c *echo.Context) error {
 	return c.JSON(http.StatusOK, result)
 }
 
-// RecalculateUsagePricing handles POST /admin/api/v1/usage/recalculate-pricing.
+// RecalculateUsagePricing handles POST /admin/usage/recalculate-pricing.
 //
 // @Summary      Recalculate stored usage costs from current model pricing metadata
 // @Tags         admin
@@ -232,7 +232,7 @@ func (h *Handler) UsageLog(c *echo.Context) error {
 // @Failure      401      {object}  core.GatewayError
 // @Failure      500      {object}  core.GatewayError
 // @Failure      503      {object}  core.GatewayError
-// @Router       /admin/api/v1/usage/recalculate-pricing [post]
+// @Router       /admin/usage/recalculate-pricing [post]
 func (h *Handler) RecalculateUsagePricing(c *echo.Context) error {
 	if h.usageRecalculator == nil {
 		return handleError(c, featureUnavailableError("usage pricing recalculation is unavailable"))
@@ -270,7 +270,7 @@ func (h *Handler) RecalculateUsagePricing(c *echo.Context) error {
 	return c.JSON(http.StatusOK, result)
 }
 
-// CacheOverview handles GET /admin/api/v1/cache/overview
+// CacheOverview handles GET /admin/cache/overview
 //
 // @Summary      Get cached-only usage overview
 // @Tags         admin
@@ -286,7 +286,7 @@ func (h *Handler) RecalculateUsagePricing(c *echo.Context) error {
 // @Failure      400  {object}  core.GatewayError
 // @Failure      401  {object}  core.GatewayError
 // @Failure      503  {object}  core.GatewayError
-// @Router       /admin/api/v1/cache/overview [get]
+// @Router       /admin/cache/overview [get]
 func (h *Handler) CacheOverview(c *echo.Context) error {
 	// Feature-gate check stays first: this endpoint is conceptually unavailable
 	// when cache analytics is off, and the response shape (503) communicates

--- a/internal/admin/handler_workflows.go
+++ b/internal/admin/handler_workflows.go
@@ -39,7 +39,7 @@ func (h *Handler) ListWorkflows(c *echo.Context) error {
 	return c.JSON(http.StatusOK, views)
 }
 
-// GetWorkflow handles GET /admin/api/v1/workflows/:id
+// GetWorkflow handles GET /admin/workflows/:id
 func (h *Handler) GetWorkflow(c *echo.Context) error {
 	if h.workflows == nil {
 		return handleError(c, featureUnavailableError("workflows feature is unavailable"))
@@ -61,7 +61,7 @@ func (h *Handler) GetWorkflow(c *echo.Context) error {
 	return c.JSON(http.StatusOK, view)
 }
 
-// ListWorkflowGuardrails handles GET /admin/api/v1/workflows/guardrails
+// ListWorkflowGuardrails handles GET /admin/workflows/guardrails
 func (h *Handler) ListWorkflowGuardrails(c *echo.Context) error {
 	if h.guardrails == nil {
 		return c.JSON(http.StatusOK, []string{})
@@ -70,7 +70,7 @@ func (h *Handler) ListWorkflowGuardrails(c *echo.Context) error {
 	return c.JSON(http.StatusOK, h.guardrails.Names())
 }
 
-// CreateWorkflow handles POST /admin/api/v1/workflows
+// CreateWorkflow handles POST /admin/workflows
 func (h *Handler) CreateWorkflow(c *echo.Context) error {
 	if h.workflows == nil {
 		return handleError(c, featureUnavailableError("workflows feature is unavailable"))
@@ -123,7 +123,7 @@ func (h *Handler) CreateWorkflow(c *echo.Context) error {
 	return c.JSON(http.StatusCreated, version)
 }
 
-// DeactivateWorkflow handles POST /admin/api/v1/workflows/:id/deactivate
+// DeactivateWorkflow handles POST /admin/workflows/:id/deactivate
 func (h *Handler) DeactivateWorkflow(c *echo.Context) error {
 	if h.workflows == nil {
 		return handleError(c, featureUnavailableError("workflows feature is unavailable"))

--- a/internal/admin/handler_workflows_test.go
+++ b/internal/admin/handler_workflows_test.go
@@ -225,7 +225,7 @@ func TestListWorkflows(t *testing.T) {
 	}
 
 	h := newWorkflowHandler(t, store, nil)
-	c, rec := newHandlerContext("/admin/api/v1/workflows")
+	c, rec := newHandlerContext("/admin/workflows")
 
 	if err := h.ListWorkflows(c); err != nil {
 		t.Fatalf("ListWorkflows() error = %v", err)
@@ -262,7 +262,7 @@ func TestWorkflowsEndpointsReturn503WhenServiceUnavailable(t *testing.T) {
 	h := NewHandler(nil, nil)
 	e := echo.New()
 
-	listCtx, listRec := newHandlerContext("/admin/api/v1/workflows")
+	listCtx, listRec := newHandlerContext("/admin/workflows")
 	if err := h.ListWorkflows(listCtx); err != nil {
 		t.Fatalf("ListWorkflows() error = %v", err)
 	}
@@ -283,7 +283,7 @@ func TestWorkflowsEndpointsReturn503WhenServiceUnavailable(t *testing.T) {
 		t.Fatalf("list error code = %v, want feature_unavailable", listEnvelope.Error.Code)
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/workflows", bytes.NewBufferString(`{}`))
+	req := httptest.NewRequest(http.MethodPost, "/admin/workflows", bytes.NewBufferString(`{}`))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
@@ -307,10 +307,10 @@ func TestWorkflowsEndpointsReturn503WhenServiceUnavailable(t *testing.T) {
 		t.Fatalf("create error code = %v, want feature_unavailable", createEnvelope.Error.Code)
 	}
 
-	req = httptest.NewRequest(http.MethodPost, "/admin/api/v1/workflows/test-workflow/deactivate", nil)
+	req = httptest.NewRequest(http.MethodPost, "/admin/workflows/test-workflow/deactivate", nil)
 	rec = httptest.NewRecorder()
 	c = e.NewContext(req, rec)
-	c.SetPath("/admin/api/v1/workflows/:id/deactivate")
+	c.SetPath("/admin/workflows/:id/deactivate")
 	c.SetPathValues(echo.PathValues{{Name: "id", Value: "test-workflow"}})
 	if err := h.DeactivateWorkflow(c); err != nil {
 		t.Fatalf("DeactivateWorkflow() error = %v", err)
@@ -332,8 +332,8 @@ func TestWorkflowsEndpointsReturn503WhenServiceUnavailable(t *testing.T) {
 		t.Fatalf("deactivate error code = %v, want feature_unavailable", deactivateEnvelope.Error.Code)
 	}
 
-	getCtx, getRec := newHandlerContext("/admin/api/v1/workflows/test-workflow")
-	getCtx.SetPath("/admin/api/v1/workflows/:id")
+	getCtx, getRec := newHandlerContext("/admin/workflows/test-workflow")
+	getCtx.SetPath("/admin/workflows/:id")
 	getCtx.SetPathValues(echo.PathValues{{Name: "id", Value: "test-workflow"}})
 	if err := h.GetWorkflow(getCtx); err != nil {
 		t.Fatalf("GetWorkflow() error = %v", err)
@@ -402,8 +402,8 @@ func TestGetWorkflow(t *testing.T) {
 
 	registry := newWorkflowRegistry(t)
 	h := newWorkflowHandler(t, store, registry)
-	c, rec := newHandlerContext("/admin/api/v1/workflows/provider-workflow-v1")
-	c.SetPath("/admin/api/v1/workflows/:id")
+	c, rec := newHandlerContext("/admin/workflows/provider-workflow-v1")
+	c.SetPath("/admin/workflows/:id")
 	c.SetPathValues(echo.PathValues{{Name: "id", Value: "provider-workflow-v1"}})
 
 	if err := h.GetWorkflow(c); err != nil {
@@ -472,7 +472,7 @@ func TestCreateWorkflow_NormalizesScopeUserPath(t *testing.T) {
 	h := newWorkflowHandler(t, store, nil)
 	e := echo.New()
 
-	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/workflows", bytes.NewBufferString(`{
+	req := httptest.NewRequest(http.MethodPost, "/admin/workflows", bytes.NewBufferString(`{
 		"scope_provider_name":"openai",
 		"scope_model":"gpt-5",
 		"scope_user_path":" team//alpha/user/ ",
@@ -505,7 +505,7 @@ func TestCreateWorkflow_NormalizesScopeUserPath(t *testing.T) {
 func TestListWorkflowGuardrails(t *testing.T) {
 	registry := newWorkflowRegistry(t)
 	h := NewHandler(nil, nil, WithGuardrailsRegistry(registry))
-	c, rec := newHandlerContext("/admin/api/v1/workflows/guardrails")
+	c, rec := newHandlerContext("/admin/workflows/guardrails")
 
 	if err := h.ListWorkflowGuardrails(c); err != nil {
 		t.Fatalf("ListWorkflowGuardrails() error = %v", err)
@@ -545,7 +545,7 @@ func TestCreateWorkflow(t *testing.T) {
 	h := newWorkflowHandler(t, store, nil)
 	e := echo.New()
 
-	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/workflows", bytes.NewBufferString(`{
+	req := httptest.NewRequest(http.MethodPost, "/admin/workflows", bytes.NewBufferString(`{
 		"scope_provider":"openai",
 		"scope_model":"gpt-5",
 		"name":"openai gpt-5",
@@ -652,7 +652,7 @@ func TestCreateWorkflow_StoresCanonicalScopeModel(t *testing.T) {
 			h := newWorkflowHandler(t, store, nil)
 			e := echo.New()
 
-			req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/workflows", bytes.NewBufferString(tt.body))
+			req := httptest.NewRequest(http.MethodPost, "/admin/workflows", bytes.NewBufferString(tt.body))
 			req.Header.Set("Content-Type", "application/json")
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)
@@ -713,7 +713,7 @@ func TestCreateWorkflow_LegacyProviderTypeResolvesToConfiguredProviderName(t *te
 	h := newWorkflowHandlerWithModelRegistry(t, store, modelRegistry, nil)
 	e := echo.New()
 
-	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/workflows", bytes.NewBufferString(`{
+	req := httptest.NewRequest(http.MethodPost, "/admin/workflows", bytes.NewBufferString(`{
 		"scope_provider":"openai",
 		"scope_model":"gpt-5",
 		"name":"legacy provider type scope",
@@ -765,7 +765,7 @@ func TestCreateWorkflow_AllowsEmptyName(t *testing.T) {
 	h := newWorkflowHandler(t, store, nil)
 	e := echo.New()
 
-	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/workflows", bytes.NewBufferString(`{
+	req := httptest.NewRequest(http.MethodPost, "/admin/workflows", bytes.NewBufferString(`{
 		"scope_provider":"openai",
 		"scope_model":"gpt-5",
 		"description":"provider-model workflow",
@@ -817,7 +817,7 @@ func TestCreateWorkflowRejectsUnknownGuardrail(t *testing.T) {
 	h := newWorkflowHandler(t, store, registry)
 	e := echo.New()
 
-	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/workflows", bytes.NewBufferString(`{
+	req := httptest.NewRequest(http.MethodPost, "/admin/workflows", bytes.NewBufferString(`{
 		"name":"guardrail workflow",
 		"workflow_payload":{
 			"schema_version":1,
@@ -873,7 +873,7 @@ func TestCreateWorkflowReturnsValidationErrors(t *testing.T) {
 	h := newWorkflowHandler(t, store, nil)
 	e := echo.New()
 
-	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/workflows", bytes.NewBufferString(`{
+	req := httptest.NewRequest(http.MethodPost, "/admin/workflows", bytes.NewBufferString(`{
 		"scope_model":"gpt-5",
 		"name":"invalid scope",
 		"workflow_payload":{
@@ -963,7 +963,7 @@ func TestCreateWorkflowRejectsUnknownProviderOrModelScope(t *testing.T) {
 			h := newWorkflowHandler(t, store, nil)
 			e := echo.New()
 
-			req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/workflows", bytes.NewBufferString(tt.body))
+			req := httptest.NewRequest(http.MethodPost, "/admin/workflows", bytes.NewBufferString(tt.body))
 			req.Header.Set("Content-Type", "application/json")
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)
@@ -1013,7 +1013,7 @@ func TestCreateWorkflow_UsesScopeUserPathInValidationErrors(t *testing.T) {
 	h := newWorkflowHandler(t, store, nil)
 	e := echo.New()
 
-	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/workflows", bytes.NewBufferString(`{
+	req := httptest.NewRequest(http.MethodPost, "/admin/workflows", bytes.NewBufferString(`{
 		"scope_user_path":"/team/../alpha",
 		"name":"invalid path",
 		"workflow_payload":{
@@ -1075,7 +1075,7 @@ func TestWorkflowViewReflectsFeatureCaps(t *testing.T) {
 	}
 
 	h := NewHandler(nil, nil, WithWorkflows(service))
-	c, rec := newHandlerContext("/admin/api/v1/workflows")
+	c, rec := newHandlerContext("/admin/workflows")
 
 	if err := h.ListWorkflows(c); err != nil {
 		t.Fatalf("ListWorkflows() error = %v", err)
@@ -1134,10 +1134,10 @@ func TestDeactivateWorkflow(t *testing.T) {
 	h := newWorkflowHandler(t, store, nil)
 	e := echo.New()
 
-	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/workflows/provider-workflow/deactivate", nil)
+	req := httptest.NewRequest(http.MethodPost, "/admin/workflows/provider-workflow/deactivate", nil)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
-	c.SetPath("/admin/api/v1/workflows/:id/deactivate")
+	c.SetPath("/admin/workflows/:id/deactivate")
 	c.SetPathValues(echo.PathValues{{Name: "id", Value: "provider-workflow"}})
 
 	if err := h.DeactivateWorkflow(c); err != nil {
@@ -1181,10 +1181,10 @@ func TestDeactivateWorkflowRejectsGlobalWorkflow(t *testing.T) {
 	h := newWorkflowHandler(t, store, nil)
 	e := echo.New()
 
-	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/workflows/global-workflow/deactivate", nil)
+	req := httptest.NewRequest(http.MethodPost, "/admin/workflows/global-workflow/deactivate", nil)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
-	c.SetPath("/admin/api/v1/workflows/:id/deactivate")
+	c.SetPath("/admin/workflows/:id/deactivate")
 	c.SetPathValues(echo.PathValues{{Name: "id", Value: "global-workflow"}})
 
 	if err := h.DeactivateWorkflow(c); err != nil {

--- a/internal/admin/routes.go
+++ b/internal/admin/routes.go
@@ -14,9 +14,9 @@ type RouteRegistrar interface {
 }
 
 // RegisterRoutes mounts the admin REST API on the given route group.
-// Callers typically pass an *echo.Group rooted at /admin/api/v1.
+// Callers typically pass an *echo.Group rooted at /admin.
 func (h *Handler) RegisterRoutes(g RouteRegistrar) {
-	g.GET("/dashboard/config", h.DashboardConfig)
+	g.GET("/runtime/config", h.DashboardConfig)
 	g.GET("/cache/overview", h.CacheOverview)
 
 	g.GET("/usage/summary", h.UsageSummary)

--- a/internal/admin/routes_test.go
+++ b/internal/admin/routes_test.go
@@ -18,7 +18,7 @@ import (
 func TestRegisterRoutes_RegistersExpectedPaths(t *testing.T) {
 	h := &Handler{}
 	e := echo.New()
-	g := e.Group("/admin/api/v1")
+	g := e.Group("/admin")
 
 	// RegisterRoutes must not panic with a zero-value handler — every endpoint
 	// reads its own dependencies inside the handler body, so route mounting
@@ -31,59 +31,59 @@ func TestRegisterRoutes_RegistersExpectedPaths(t *testing.T) {
 	h.RegisterRoutes(g)
 
 	want := []string{
-		"GET /admin/api/v1/dashboard/config",
-		"GET /admin/api/v1/cache/overview",
+		"GET /admin/runtime/config",
+		"GET /admin/cache/overview",
 
-		"GET /admin/api/v1/usage/summary",
-		"GET /admin/api/v1/usage/daily",
-		"GET /admin/api/v1/usage/models",
-		"GET /admin/api/v1/usage/user-paths",
-		"GET /admin/api/v1/usage/log",
-		"POST /admin/api/v1/usage/recalculate-pricing",
+		"GET /admin/usage/summary",
+		"GET /admin/usage/daily",
+		"GET /admin/usage/models",
+		"GET /admin/usage/user-paths",
+		"GET /admin/usage/log",
+		"POST /admin/usage/recalculate-pricing",
 
-		"GET /admin/api/v1/audit/log",
-		"GET /admin/api/v1/audit/conversation",
+		"GET /admin/audit/log",
+		"GET /admin/audit/conversation",
 
-		"GET /admin/api/v1/providers/status",
-		"POST /admin/api/v1/runtime/refresh",
+		"GET /admin/providers/status",
+		"POST /admin/runtime/refresh",
 
-		"GET /admin/api/v1/budgets",
-		"PUT /admin/api/v1/budgets",
-		"DELETE /admin/api/v1/budgets",
-		"GET /admin/api/v1/budgets/settings",
-		"PUT /admin/api/v1/budgets/settings",
-		"POST /admin/api/v1/budgets/reset-one",
-		"POST /admin/api/v1/budgets/reset",
+		"GET /admin/budgets",
+		"PUT /admin/budgets",
+		"DELETE /admin/budgets",
+		"GET /admin/budgets/settings",
+		"PUT /admin/budgets/settings",
+		"POST /admin/budgets/reset-one",
+		"POST /admin/budgets/reset",
 
-		"GET /admin/api/v1/models",
-		"GET /admin/api/v1/models/categories",
+		"GET /admin/models",
+		"GET /admin/models/categories",
 
-		"GET /admin/api/v1/model-overrides",
-		"PUT /admin/api/v1/model-overrides",
-		"DELETE /admin/api/v1/model-overrides",
+		"GET /admin/model-overrides",
+		"PUT /admin/model-overrides",
+		"DELETE /admin/model-overrides",
 
-		"GET /admin/api/v1/model-pricing-overrides",
-		"PUT /admin/api/v1/model-pricing-overrides",
-		"DELETE /admin/api/v1/model-pricing-overrides",
+		"GET /admin/model-pricing-overrides",
+		"PUT /admin/model-pricing-overrides",
+		"DELETE /admin/model-pricing-overrides",
 
-		"GET /admin/api/v1/auth-keys",
-		"POST /admin/api/v1/auth-keys",
-		"POST /admin/api/v1/auth-keys/:id/deactivate",
+		"GET /admin/auth-keys",
+		"POST /admin/auth-keys",
+		"POST /admin/auth-keys/:id/deactivate",
 
-		"GET /admin/api/v1/aliases",
-		"PUT /admin/api/v1/aliases",
-		"DELETE /admin/api/v1/aliases",
+		"GET /admin/aliases",
+		"PUT /admin/aliases",
+		"DELETE /admin/aliases",
 
-		"GET /admin/api/v1/guardrails/types",
-		"GET /admin/api/v1/guardrails",
-		"PUT /admin/api/v1/guardrails",
-		"DELETE /admin/api/v1/guardrails",
+		"GET /admin/guardrails/types",
+		"GET /admin/guardrails",
+		"PUT /admin/guardrails",
+		"DELETE /admin/guardrails",
 
-		"GET /admin/api/v1/workflows",
-		"GET /admin/api/v1/workflows/guardrails",
-		"GET /admin/api/v1/workflows/:id",
-		"POST /admin/api/v1/workflows",
-		"POST /admin/api/v1/workflows/:id/deactivate",
+		"GET /admin/workflows",
+		"GET /admin/workflows/guardrails",
+		"GET /admin/workflows/:id",
+		"POST /admin/workflows",
+		"POST /admin/workflows/:id/deactivate",
 	}
 
 	registered := make(map[string]struct{})

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -445,7 +445,10 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		} else {
 			serverCfg.AdminEndpointsEnabled = true
 			serverCfg.AdminHandler = adminHandler
-			slog.Info("admin API enabled", "api", config.JoinBasePath(appCfg.Server.BasePath, "/admin/api/v1"))
+			slog.Info("admin API enabled",
+				"api", config.JoinBasePath(appCfg.Server.BasePath, "/admin"),
+				"legacy_alias", config.JoinBasePath(appCfg.Server.BasePath, "/admin/api/v1"),
+				"legacy_sunset", "2026-08-09")
 			if adminCfg.UIEnabled {
 				serverCfg.AdminUIEnabled = true
 				serverCfg.DashboardHandler = dashHandler

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -383,8 +383,8 @@ func TestAuthMiddleware_WildcardSkipPaths(t *testing.T) {
 			wantSkip: true,
 		},
 		{
-			name:     "no match /admin/api/v1/models",
-			path:     "/admin/api/v1/models",
+			name:     "no match /admin/models",
+			path:     "/admin/models",
 			wantSkip: false,
 		},
 		{

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -170,7 +170,7 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 	// When no bootstrap master key is configured, keep admin APIs reachable so
 	// the dashboard can recover managed-key access instead of locking itself out.
 	if cfg != nil && cfg.MasterKey == "" && cfg.AdminEndpointsEnabled && cfg.AdminHandler != nil {
-		authSkipPaths = append(authSkipPaths, "/admin/api/v1/*")
+		authSkipPaths = append(authSkipPaths, "/admin/*")
 	}
 	if cfg != nil && cfg.SwaggerEnabled && SwaggerAvailable() {
 		authSkipPaths = append(authSkipPaths, "/swagger/*")
@@ -315,7 +315,16 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 
 	// Admin API routes (behind ADMIN_ENDPOINTS_ENABLED flag)
 	if cfg != nil && cfg.AdminEndpointsEnabled && cfg.AdminHandler != nil {
-		cfg.AdminHandler.RegisterRoutes(e.Group("/admin/api/v1"))
+		cfg.AdminHandler.RegisterRoutes(e.Group("/admin"))
+
+		// Legacy alias under /admin/api/v1/* — accepted until adminLegacySunset
+		// to give operators a window to migrate. Responses carry Deprecation,
+		// Sunset, and Link headers per RFC 8594 / draft-ietf-httpapi-deprecation-header.
+		legacy := e.Group("/admin/api/v1", adminLegacyDeprecationMiddleware)
+		cfg.AdminHandler.RegisterRoutes(legacy)
+		// DashboardConfig moved within /admin from /dashboard/config to
+		// /runtime/config; preserve the historical legacy path explicitly.
+		legacy.GET("/dashboard/config", cfg.AdminHandler.DashboardConfig)
 	}
 
 	// Admin dashboard UI routes (behind ADMIN_UI_ENABLED flag)
@@ -334,6 +343,22 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 		handler:                 handler,
 		responseCacheMiddleware: rcm,
 		responseStore:           handler.currentResponseStore(),
+	}
+}
+
+// adminLegacySunset is the sunset date advertised on responses served from the
+// deprecated /admin/api/v1/* alias. Format follows RFC 7231 HTTP-date.
+const adminLegacySunset = "Sun, 09 Aug 2026 00:00:00 GMT"
+
+// adminLegacyDeprecationMiddleware tags responses on the legacy /admin/api/v1/*
+// alias with deprecation signals so clients can detect the move to /admin/*.
+func adminLegacyDeprecationMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c *echo.Context) error {
+		h := c.Response().Header()
+		h.Set("Deprecation", "true")
+		h.Set("Sunset", adminLegacySunset)
+		h.Set("Link", `</admin/>; rel="successor-version"`)
+		return next(c)
 	}
 }
 

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -604,7 +604,7 @@ func TestAdminEndpoints_Enabled(t *testing.T) {
 		AdminHandler:          adminHandler,
 	})
 
-	for _, path := range []string{"/admin/api/v1/models", "/admin/api/v1/providers/status", "/admin/api/v1/audit/log", "/admin/api/v1/audit/conversation?log_id=abc"} {
+	for _, path := range []string{"/admin/models", "/admin/providers/status", "/admin/audit/log", "/admin/audit/conversation?log_id=abc"} {
 		req := httptest.NewRequest(http.MethodGet, path, nil)
 		rec := httptest.NewRecorder()
 		srv.ServeHTTP(rec, req)
@@ -627,16 +627,16 @@ func TestAdminWorkflowEndpoints_AreRegistered(t *testing.T) {
 		method string
 		path   string
 	}{
-		{method: http.MethodGet, path: "/admin/api/v1/dashboard/config"},
-		{method: http.MethodGet, path: "/admin/api/v1/providers/status"},
-		{method: http.MethodPost, path: "/admin/api/v1/runtime/refresh"},
-		{method: http.MethodGet, path: "/admin/api/v1/auth-keys"},
-		{method: http.MethodPost, path: "/admin/api/v1/auth-keys"},
-		{method: http.MethodPost, path: "/admin/api/v1/auth-keys/test-key/deactivate"},
-		{method: http.MethodGet, path: "/admin/api/v1/workflows"},
-		{method: http.MethodGet, path: "/admin/api/v1/workflows/guardrails"},
-		{method: http.MethodPost, path: "/admin/api/v1/workflows"},
-		{method: http.MethodPost, path: "/admin/api/v1/workflows/test-workflow/deactivate"},
+		{method: http.MethodGet, path: "/admin/runtime/config"},
+		{method: http.MethodGet, path: "/admin/providers/status"},
+		{method: http.MethodPost, path: "/admin/runtime/refresh"},
+		{method: http.MethodGet, path: "/admin/auth-keys"},
+		{method: http.MethodPost, path: "/admin/auth-keys"},
+		{method: http.MethodPost, path: "/admin/auth-keys/test-key/deactivate"},
+		{method: http.MethodGet, path: "/admin/workflows"},
+		{method: http.MethodGet, path: "/admin/workflows/guardrails"},
+		{method: http.MethodPost, path: "/admin/workflows"},
+		{method: http.MethodPost, path: "/admin/workflows/test-workflow/deactivate"},
 	} {
 		req := httptest.NewRequest(tc.method, tc.path, nil)
 		rec := httptest.NewRecorder()
@@ -658,7 +658,7 @@ func TestAdminDashboardConfigEndpoint_ReturnsHandlerResponse(t *testing.T) {
 		AdminHandler:          adminHandler,
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/admin/api/v1/dashboard/config", nil)
+	req := httptest.NewRequest(http.MethodGet, "/admin/runtime/config", nil)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -670,13 +670,65 @@ func TestAdminDashboardConfigEndpoint_ReturnsHandlerResponse(t *testing.T) {
 	}
 }
 
+func TestAdminLegacyAlias_Deprecation(t *testing.T) {
+	mock := &mockProvider{}
+	adminHandler := admin.NewHandler(nil, nil, admin.WithDashboardRuntimeConfig(admin.DashboardConfigResponse{
+		FeatureFallbackMode: "manual",
+	}))
+	srv := New(mock, &Config{
+		AdminEndpointsEnabled: true,
+		AdminHandler:          adminHandler,
+	})
+
+	cases := []struct {
+		name           string
+		path           string
+		wantDeprecated bool
+	}{
+		{name: "legacy alias serves request", path: "/admin/api/v1/models", wantDeprecated: true},
+		{name: "legacy dashboard/config alias preserved", path: "/admin/api/v1/dashboard/config", wantDeprecated: true},
+		{name: "new path has no deprecation header", path: "/admin/models", wantDeprecated: false},
+		{name: "new runtime/config path has no deprecation header", path: "/admin/runtime/config", wantDeprecated: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			rec := httptest.NewRecorder()
+			srv.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("%s returned %d, want 200; body=%s", tc.path, rec.Code, rec.Body.String())
+			}
+			gotDeprecation := rec.Header().Get("Deprecation")
+			gotSunset := rec.Header().Get("Sunset")
+			gotLink := rec.Header().Get("Link")
+			if tc.wantDeprecated {
+				if gotDeprecation != "true" {
+					t.Errorf("Deprecation header = %q, want %q", gotDeprecation, "true")
+				}
+				if gotSunset == "" {
+					t.Error("Sunset header missing on legacy path")
+				}
+				if !strings.Contains(gotLink, `rel="successor-version"`) {
+					t.Errorf("Link header = %q, want rel=successor-version", gotLink)
+				}
+			} else {
+				if gotDeprecation != "" || gotSunset != "" || gotLink != "" {
+					t.Errorf("non-legacy path leaked deprecation headers: dep=%q sunset=%q link=%q", gotDeprecation, gotSunset, gotLink)
+				}
+			}
+		})
+	}
+}
+
 func TestAdminEndpoints_Disabled(t *testing.T) {
 	mock := &mockProvider{}
 	srv := New(mock, &Config{
 		AdminEndpointsEnabled: false,
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/admin/api/v1/models", nil)
+	req := httptest.NewRequest(http.MethodGet, "/admin/models", nil)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -758,7 +810,7 @@ func TestAdminAPI_RequiresAuth(t *testing.T) {
 	})
 
 	// Admin API should require auth
-	req := httptest.NewRequest(http.MethodGet, "/admin/api/v1/models", nil)
+	req := httptest.NewRequest(http.MethodGet, "/admin/models", nil)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
@@ -776,7 +828,7 @@ func TestAdminAPI_SkipsAuthWithoutMasterKey(t *testing.T) {
 		AdminHandler:          adminHandler,
 	})
 
-	adminReq := httptest.NewRequest(http.MethodGet, "/admin/api/v1/models", nil)
+	adminReq := httptest.NewRequest(http.MethodGet, "/admin/models", nil)
 	adminRec := httptest.NewRecorder()
 	srv.ServeHTTP(adminRec, adminReq)
 
@@ -813,7 +865,7 @@ func TestAdminPricingRecalculationSkipsAuthWithoutMasterKey(t *testing.T) {
 				AdminHandler:          adminHandler,
 			})
 
-			req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", strings.NewReader(`{"confirmation":"recalculate"}`))
+			req := httptest.NewRequest(http.MethodPost, "/admin/usage/recalculate-pricing", strings.NewReader(`{"confirmation":"recalculate"}`))
 			req.Header.Set("Content-Type", "application/json")
 			rec := httptest.NewRecorder()
 			srv.ServeHTTP(rec, req)
@@ -838,7 +890,7 @@ func TestAdminPricingRecalculationRequiresAuthWithMasterKey(t *testing.T) {
 		AdminHandler:          adminHandler,
 	})
 
-	req := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", strings.NewReader(`{"confirmation":"recalculate"}`))
+	req := httptest.NewRequest(http.MethodPost, "/admin/usage/recalculate-pricing", strings.NewReader(`{"confirmation":"recalculate"}`))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -850,7 +902,7 @@ func TestAdminPricingRecalculationRequiresAuthWithMasterKey(t *testing.T) {
 		t.Fatalf("recalculator calls after unauthorized request = %d, want 0", recalculator.calls)
 	}
 
-	authReq := httptest.NewRequest(http.MethodPost, "/admin/api/v1/usage/recalculate-pricing", strings.NewReader(`{"confirmation":"recalculate"}`))
+	authReq := httptest.NewRequest(http.MethodPost, "/admin/usage/recalculate-pricing", strings.NewReader(`{"confirmation":"recalculate"}`))
 	authReq.Header.Set("Content-Type", "application/json")
 	authReq.Header.Set("Authorization", "Bearer test-secret-key")
 	authRec := httptest.NewRecorder()

--- a/tests/e2e/admin_test.go
+++ b/tests/e2e/admin_test.go
@@ -39,11 +39,11 @@ func TestAdminAPI_EndpointsEnabled_E2E(t *testing.T) {
 	defer ts.Close()
 
 	endpoints := []string{
-		"/admin/api/v1/usage/summary",
-		"/admin/api/v1/usage/daily",
-		"/admin/api/v1/audit/log",
-		"/admin/api/v1/audit/conversation?log_id=test",
-		"/admin/api/v1/models",
+		"/admin/usage/summary",
+		"/admin/usage/daily",
+		"/admin/audit/log",
+		"/admin/audit/conversation?log_id=test",
+		"/admin/models",
 	}
 
 	for _, ep := range endpoints {
@@ -68,11 +68,11 @@ func TestAdminAPI_EndpointsDisabled_E2E(t *testing.T) {
 	defer ts.Close()
 
 	endpoints := []string{
-		"/admin/api/v1/usage/summary",
-		"/admin/api/v1/usage/daily",
-		"/admin/api/v1/audit/log",
-		"/admin/api/v1/audit/conversation?log_id=test",
-		"/admin/api/v1/models",
+		"/admin/usage/summary",
+		"/admin/usage/daily",
+		"/admin/audit/log",
+		"/admin/audit/conversation?log_id=test",
+		"/admin/models",
 	}
 
 	for _, ep := range endpoints {
@@ -91,7 +91,7 @@ func TestAdminAPI_RequiresAuth_E2E(t *testing.T) {
 	defer ts.Close()
 
 	t.Run("without auth returns 401", func(t *testing.T) {
-		resp, err := http.Get(ts.URL + "/admin/api/v1/models")
+		resp, err := http.Get(ts.URL + "/admin/models")
 		require.NoError(t, err)
 		defer closeBody(resp)
 
@@ -99,7 +99,7 @@ func TestAdminAPI_RequiresAuth_E2E(t *testing.T) {
 	})
 
 	t.Run("with valid auth returns 200", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/models", nil)
+		req, err := http.NewRequest(http.MethodGet, ts.URL+"/admin/models", nil)
 		require.NoError(t, err)
 		req.Header.Set("Authorization", "Bearer "+testMasterKey)
 
@@ -120,7 +120,7 @@ func TestAdminAPI_PricingRecalculationNoMasterKey_E2E(t *testing.T) {
 	})
 	defer ts.Close()
 
-	req, err := http.NewRequest(http.MethodPost, ts.URL+"/admin/api/v1/usage/recalculate-pricing", strings.NewReader(`{
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/admin/usage/recalculate-pricing", strings.NewReader(`{
 		"confirmation": "recalculate",
 		"user_path": "/team/recalc"
 	}`))
@@ -186,7 +186,7 @@ func TestAdminDashboard_SkipsAuth_E2E(t *testing.T) {
 	})
 
 	t.Run("API is protected (401 without auth)", func(t *testing.T) {
-		resp, err := http.Get(ts.URL + "/admin/api/v1/models")
+		resp, err := http.Get(ts.URL + "/admin/models")
 		require.NoError(t, err)
 		defer closeBody(resp)
 
@@ -198,7 +198,7 @@ func TestAdminAPI_ModelsEndpoint_E2E(t *testing.T) {
 	ts := setupAdminServer(t, "", true, false)
 	defer ts.Close()
 
-	resp, err := http.Get(ts.URL + "/admin/api/v1/models")
+	resp, err := http.Get(ts.URL + "/admin/models")
 	require.NoError(t, err)
 	defer closeBody(resp)
 
@@ -255,7 +255,7 @@ func TestAdminAPI_UsageEndpoints_E2E(t *testing.T) {
 	usageFixture.flush(t)
 
 	t.Run("summary includes persisted usage", func(t *testing.T) {
-		resp, err := http.Get(ts.URL + "/admin/api/v1/usage/summary")
+		resp, err := http.Get(ts.URL + "/admin/usage/summary")
 		require.NoError(t, err)
 		defer closeBody(resp)
 
@@ -270,7 +270,7 @@ func TestAdminAPI_UsageEndpoints_E2E(t *testing.T) {
 	})
 
 	t.Run("daily includes persisted usage", func(t *testing.T) {
-		resp, err := http.Get(ts.URL + "/admin/api/v1/usage/daily?days=7")
+		resp, err := http.Get(ts.URL + "/admin/usage/daily?days=7")
 		require.NoError(t, err)
 		defer closeBody(resp)
 
@@ -298,7 +298,7 @@ func TestAdminAPI_UsageEndpoints_E2E(t *testing.T) {
 	})
 
 	t.Run("query params accepted", func(t *testing.T) {
-		resp, err := http.Get(ts.URL + "/admin/api/v1/usage/daily?days=7&interval=weekly")
+		resp, err := http.Get(ts.URL + "/admin/usage/daily?days=7&interval=weekly")
 		require.NoError(t, err)
 		defer closeBody(resp)
 

--- a/tests/e2e/budget_test.go
+++ b/tests/e2e/budget_test.go
@@ -87,7 +87,7 @@ func TestBudgetAdminEndpointsSQLite_E2E(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	putResp := sendBudgetJSONRequest(t, http.MethodPut, ts.URL+"/admin/api/v1/budgets", map[string]any{
+	putResp := sendBudgetJSONRequest(t, http.MethodPut, ts.URL+"/admin/budgets", map[string]any{
 		"user_path":  "/team/admin",
 		"budget_key": map[string]any{"period": "daily"},
 		"amount":     12.5,
@@ -95,7 +95,7 @@ func TestBudgetAdminEndpointsSQLite_E2E(t *testing.T) {
 	require.Equal(t, http.StatusOK, putResp.StatusCode)
 	closeBody(putResp)
 
-	listResp := sendBudgetJSONRequest(t, http.MethodGet, ts.URL+"/admin/api/v1/budgets", nil)
+	listResp := sendBudgetJSONRequest(t, http.MethodGet, ts.URL+"/admin/budgets", nil)
 	require.Equal(t, http.StatusOK, listResp.StatusCode)
 	var listBody struct {
 		Budgets []struct {
@@ -111,7 +111,7 @@ func TestBudgetAdminEndpointsSQLite_E2E(t *testing.T) {
 	require.Equal(t, budget.PeriodDailySeconds, listBody.Budgets[0].PeriodSeconds)
 	require.Equal(t, 12.5, listBody.Budgets[0].Amount)
 
-	resetResp := sendBudgetJSONRequest(t, http.MethodPost, ts.URL+"/admin/api/v1/budgets/reset-one", map[string]any{
+	resetResp := sendBudgetJSONRequest(t, http.MethodPost, ts.URL+"/admin/budgets/reset-one", map[string]any{
 		"user_path":      "/team/admin",
 		"period_seconds": budget.PeriodDailySeconds,
 	})
@@ -123,7 +123,7 @@ func TestBudgetAdminEndpointsSQLite_E2E(t *testing.T) {
 	require.Len(t, statuses, 1)
 	require.NotNil(t, statuses[0].Budget.LastResetAt)
 
-	deleteResp := sendBudgetJSONRequest(t, http.MethodDelete, ts.URL+"/admin/api/v1/budgets", map[string]any{
+	deleteResp := sendBudgetJSONRequest(t, http.MethodDelete, ts.URL+"/admin/budgets", map[string]any{
 		"user_path":  "/team/admin",
 		"budget_key": map[string]any{"period": "daily"},
 	})

--- a/tests/e2e/manage-release-e2e-stack.sh
+++ b/tests/e2e/manage-release-e2e-stack.sh
@@ -320,7 +320,7 @@ start_stack() {
     REDIS_KEY_MODELS="gomodel:release-e2e:models" \
     REDIS_KEY_RESPONSES="gomodel:release-e2e:response:"
 
-  curl -fsS "http://localhost:18084/admin/api/v1/dashboard/config" \
+  curl -fsS "http://localhost:18084/admin/runtime/config" \
     -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
     | jq -e '.CACHE_ENABLED == "on" and .REDIS_URL == "on"' >/dev/null
 

--- a/tests/e2e/release-e2e-scenarios.md
+++ b/tests/e2e/release-e2e-scenarios.md
@@ -76,7 +76,7 @@ wait_release_usage_entry() {
   local output_file="$4"
 
   for _ in $(seq 1 15); do
-    curl -fsS "$base_url/admin/api/v1/usage/log?search=$request_id&limit=5" > "$output_file"
+    curl -fsS "$base_url/admin/usage/log?search=$request_id&limit=5" > "$output_file"
     if jq -e --arg request_id "$request_id" --arg user_path "$user_path" '
       any(.entries[]?; .request_id == $request_id and .user_path == $user_path and (.total_cost // 0) > 0 and (.total_tokens // 0) > 0)
     ' "$output_file" >/dev/null; then
@@ -106,7 +106,7 @@ run_release_budget_enforcement() {
   local headers_file="$QA_RUN_DIR/$artifact_prefix.headers"
   local body_file="$QA_RUN_DIR/$artifact_prefix.body"
 
-  curl -fsS -X PUT "$base_url/admin/api/v1/budgets" \
+  curl -fsS -X PUT "$base_url/admin/budgets" \
     -H 'Content-Type: application/json' \
     -d "{\"user_path\":\"$budget_path\",\"budget_key\":{\"period\":\"daily\"},\"amount\":$QA_BUDGET_AMOUNT}" \
     > "$budget_json_file"
@@ -123,7 +123,7 @@ run_release_budget_enforcement() {
 
   wait_release_usage_entry "$base_url" "$req1" "$leaf_path" "$usage_json_file"
 
-  curl -fsS "$base_url/admin/api/v1/budgets" > "$budget_json_file"
+  curl -fsS "$base_url/admin/budgets" > "$budget_json_file"
   jq -e --arg user_path "$budget_path" '
     any(.budgets[]?; .user_path == $user_path and .spent > 0 and .has_usage == true and .remaining < 0 and .usage_ratio > 1)
   ' "$budget_json_file" >/dev/null
@@ -138,7 +138,7 @@ run_release_budget_enforcement() {
   jq -e '.error.type == "rate_limit_error" and .error.code == "budget_exceeded" and (.error.message | test("budget exceeded"))' "$body_file" >/dev/null
 
   for _ in $(seq 1 10); do
-    curl -fsS "$base_url/admin/api/v1/audit/log?search=$req2&limit=5" > "$audit_json_file"
+    curl -fsS "$base_url/admin/audit/log?search=$req2&limit=5" > "$audit_json_file"
     if jq -e --arg request_id "$req2" --arg user_path "$leaf_path" '
       any(.entries[]?; .request_id == $request_id and .user_path == $user_path and .status_code == 429 and .error_type == "rate_limit_error")
     ' "$audit_json_file" >/dev/null; then
@@ -150,7 +150,7 @@ run_release_budget_enforcement() {
     any(.entries[]?; .request_id == $request_id and .user_path == $user_path and .status_code == 429 and .error_type == "rate_limit_error")
   ' "$audit_json_file" >/dev/null
 
-  curl -fsS -X POST "$base_url/admin/api/v1/budgets/reset-one" \
+  curl -fsS -X POST "$base_url/admin/budgets/reset-one" \
     -H 'Content-Type: application/json' \
     -d "{\"user_path\":\"$budget_path\",\"period\":\"daily\"}" \
     > "$budget_json_file"
@@ -158,7 +158,7 @@ run_release_budget_enforcement() {
     any(.budgets[]?; .user_path == $user_path and .last_reset_at != null and .spent == 0 and .has_usage == false)
   ' "$budget_json_file" >/dev/null
 
-  curl -fsS -X DELETE "$base_url/admin/api/v1/budgets" \
+  curl -fsS -X DELETE "$base_url/admin/budgets" \
     -H 'Content-Type: application/json' \
     -d "{\"user_path\":\"$budget_path\",\"budget_key\":{\"period\":\"daily\"}}" \
     > "$budget_json_file"
@@ -261,18 +261,18 @@ curl -fsS "$BASE_URL/v1/models" \
 
 ### S04 Admin model inventory
 
-Checks `/admin/api/v1/models`.
+Checks `/admin/models`.
 
 ```bash
-curl -fsS "$BASE_URL/admin/api/v1/models" | jq -e '.[0:5]'
+curl -fsS "$BASE_URL/admin/models" | jq -e '.[0:5]'
 ```
 
 ### S05 Admin model categories
 
-Checks `/admin/api/v1/models/categories`.
+Checks `/admin/models/categories`.
 
 ```bash
-curl -fsS "$BASE_URL/admin/api/v1/models/categories" | jq -e '.'
+curl -fsS "$BASE_URL/admin/models/categories" | jq -e '.'
 ```
 
 ### S06 Usage summary endpoint
@@ -280,7 +280,7 @@ curl -fsS "$BASE_URL/admin/api/v1/models/categories" | jq -e '.'
 Reads aggregate usage summary.
 
 ```bash
-curl -fsS "$BASE_URL/admin/api/v1/usage/summary" | jq -e '.'
+curl -fsS "$BASE_URL/admin/usage/summary" | jq -e '.'
 ```
 
 ### S07 Usage daily endpoint
@@ -288,7 +288,7 @@ curl -fsS "$BASE_URL/admin/api/v1/usage/summary" | jq -e '.'
 Reads daily usage rollup.
 
 ```bash
-curl -fsS "$BASE_URL/admin/api/v1/usage/daily?days=7" | jq -e '.'
+curl -fsS "$BASE_URL/admin/usage/daily?days=7" | jq -e '.'
 ```
 
 ### S08 Usage by model endpoint
@@ -296,7 +296,7 @@ curl -fsS "$BASE_URL/admin/api/v1/usage/daily?days=7" | jq -e '.'
 Reads per-model usage totals.
 
 ```bash
-curl -fsS "$BASE_URL/admin/api/v1/usage/models?limit=10" | jq -e '.'
+curl -fsS "$BASE_URL/admin/usage/models?limit=10" | jq -e '.'
 ```
 
 ### S09 Filtered usage log
@@ -304,7 +304,7 @@ curl -fsS "$BASE_URL/admin/api/v1/usage/models?limit=10" | jq -e '.'
 Reads recent usage entries for a specific model.
 
 ```bash
-curl -fsS "$BASE_URL/admin/api/v1/usage/log?model=gpt-4.1-nano-2025-04-14&limit=5" \
+curl -fsS "$BASE_URL/admin/usage/log?model=gpt-4.1-nano-2025-04-14&limit=5" \
   | jq -e '.'
 ```
 
@@ -313,7 +313,7 @@ curl -fsS "$BASE_URL/admin/api/v1/usage/log?model=gpt-4.1-nano-2025-04-14&limit=
 Reads recent audit entries.
 
 ```bash
-curl -fsS "$BASE_URL/admin/api/v1/audit/log?limit=5" \
+curl -fsS "$BASE_URL/admin/audit/log?limit=5" \
   | jq -e '{total,entries:(.entries|map({id,request_id,model,provider,path,status_code,stream,error_type}))}'
 ```
 
@@ -322,8 +322,8 @@ curl -fsS "$BASE_URL/admin/api/v1/audit/log?limit=5" \
 Reads a conversation thread anchored to the newest audit entry.
 
 ```bash
-AUDIT_ID=$(curl -fsS "$BASE_URL/admin/api/v1/audit/log?limit=1" | jq -er '.entries[0].id')
-curl -fsS "$BASE_URL/admin/api/v1/audit/conversation?log_id=$AUDIT_ID&limit=5" \
+AUDIT_ID=$(curl -fsS "$BASE_URL/admin/audit/log?limit=1" | jq -er '.entries[0].id')
+curl -fsS "$BASE_URL/admin/audit/conversation?log_id=$AUDIT_ID&limit=5" \
   | jq -e '{anchor_id,entry_count:(.entries|length),entries:(.entries|map({id,request_id,path,status_code}))}'
 ```
 
@@ -332,7 +332,7 @@ curl -fsS "$BASE_URL/admin/api/v1/audit/conversation?log_id=$AUDIT_ID&limit=5" \
 Reads current aliases.
 
 ```bash
-curl -fsS "$BASE_URL/admin/api/v1/aliases" | jq -e '.'
+curl -fsS "$BASE_URL/admin/aliases" | jq -e '.'
 ```
 
 ## 2. Alias administration
@@ -342,7 +342,7 @@ curl -fsS "$BASE_URL/admin/api/v1/aliases" | jq -e '.'
 Creates an alias pointing to the newest cheap OpenAI model.
 
 ```bash
-curl -fsS -X PUT "$BASE_URL/admin/api/v1/aliases" \
+curl -fsS -X PUT "$BASE_URL/admin/aliases" \
   -H 'Content-Type: application/json' \
   -d "{\"name\":\"$QA_OPENAI_ALIAS\",\"target_model\":\"gpt-4.1-nano\",\"target_provider\":\"openai\",\"description\":\"QA alias for release e2e\"}" \
   | jq -e '.'
@@ -353,7 +353,7 @@ curl -fsS -X PUT "$BASE_URL/admin/api/v1/aliases" \
 Creates an alias pointing to `claude-sonnet-4-6`.
 
 ```bash
-curl -fsS -X PUT "$BASE_URL/admin/api/v1/aliases" \
+curl -fsS -X PUT "$BASE_URL/admin/aliases" \
   -H 'Content-Type: application/json' \
   -d "{\"name\":\"$QA_ANTHROPIC_ALIAS\",\"target_model\":\"claude-sonnet-4-6\",\"target_provider\":\"anthropic\",\"description\":\"QA alias for anthropic reasoning\"}" \
   | jq -e '.'
@@ -830,8 +830,8 @@ curl -fsS "$PG_BASE_URL/v1/chat/completions" \
   -d '{"model":"gpt-4.1-nano","messages":[{"role":"user","content":"Reply with exactly QA_POSTGRES_OK"}],"max_tokens":20}' \
   | jq -e '{model,provider,answer:.choices[0].message.content}' && echo
 sleep 6
-curl -fsS "$PG_BASE_URL/admin/api/v1/usage/summary" | jq -e '.' && echo
-curl -fsS "$PG_BASE_URL/admin/api/v1/audit/log?limit=3" \
+curl -fsS "$PG_BASE_URL/admin/usage/summary" | jq -e '.' && echo
+curl -fsS "$PG_BASE_URL/admin/audit/log?limit=3" \
   | jq -e '{total,entries:(.entries|map({request_id,path,model,provider,status_code}))}'
 ```
 
@@ -846,9 +846,9 @@ curl -fsS "$MONGO_BASE_URL/v1/chat/completions" \
   -d '{"model":"gpt-4.1-nano","messages":[{"role":"user","content":"Reply with exactly QA_MONGO_OK"}],"max_tokens":20}' \
   | jq -e '{model,provider,answer:.choices[0].message.content}' && echo
 sleep 6
-curl -fsS "$MONGO_BASE_URL/admin/api/v1/usage/log?limit=3" \
+curl -fsS "$MONGO_BASE_URL/admin/usage/log?limit=3" \
   | jq -e '{total,entries:(.entries|map({request_id,model,provider,endpoint,total_tokens}))}' && echo
-curl -fsS "$MONGO_BASE_URL/admin/api/v1/audit/log?limit=3" \
+curl -fsS "$MONGO_BASE_URL/admin/audit/log?limit=3" \
   | jq -e '{total,entries:(.entries|map({request_id,path,model,provider,status_code}))}'
 ```
 
@@ -880,9 +880,9 @@ Reads admin evidence after the guardrail requests flush.
 
 ```bash
 sleep 6
-curl -fsS "$GR_BASE_URL/admin/api/v1/audit/log?limit=3" \
+curl -fsS "$GR_BASE_URL/admin/audit/log?limit=3" \
   | jq -e '{total,entries:(.entries|map({request_id,path,model,provider,status_code,stream}))}' && echo
-curl -fsS "$GR_BASE_URL/admin/api/v1/usage/summary" | jq -e '.'
+curl -fsS "$GR_BASE_URL/admin/usage/summary" | jq -e '.'
 ```
 
 ## 10. Alias cleanup
@@ -892,7 +892,7 @@ curl -fsS "$GR_BASE_URL/admin/api/v1/usage/summary" | jq -e '.'
 Removes the per-run OpenAI alias.
 
 ```bash
-curl -fsS -X DELETE -i "$BASE_URL/admin/api/v1/aliases" \
+curl -fsS -X DELETE -i "$BASE_URL/admin/aliases" \
   -H 'Content-Type: application/json' \
   -d "{\"name\":\"$QA_OPENAI_ALIAS\"}"
 ```
@@ -902,7 +902,7 @@ curl -fsS -X DELETE -i "$BASE_URL/admin/api/v1/aliases" \
 Removes the per-run Anthropic alias.
 
 ```bash
-curl -fsS -X DELETE -i "$BASE_URL/admin/api/v1/aliases" \
+curl -fsS -X DELETE -i "$BASE_URL/admin/aliases" \
   -H 'Content-Type: application/json' \
   -d "{\"name\":\"$QA_ANTHROPIC_ALIAS\"}"
 ```
@@ -927,7 +927,7 @@ grep -Eiq '^HTTP/.* 400 ' "$HEADERS_FILE"
 jq -e '.error.type == "invalid_request_error"' "$BODY_FILE" >/dev/null
 sleep 6
 AUDIT_JSON_FILE="$QA_RUN_DIR/s61.audit.json"
-curl -fsS "$BASE_URL/admin/api/v1/audit/log?search=$REQUEST_ID&limit=5" > "$AUDIT_JSON_FILE"
+curl -fsS "$BASE_URL/admin/audit/log?search=$REQUEST_ID&limit=5" > "$AUDIT_JSON_FILE"
 jq --arg request_id "$REQUEST_ID" '{total:(.entries|map(select(.request_id==$request_id))|length),entries:(.entries|map(select(.request_id==$request_id))|map({request_id,path,requested_model,resolved_model,provider,status_code,error_type}))}' "$AUDIT_JSON_FILE"
 jq -e --arg request_id "$REQUEST_ID" '
     any(.entries[]?;
@@ -958,7 +958,7 @@ grep -Eiq '^HTTP/.* 400 ' "$HEADERS_FILE"
 jq -e '.error.type == "invalid_request_error"' "$BODY_FILE" >/dev/null
 sleep 6
 AUDIT_JSON_FILE="$QA_RUN_DIR/s62.audit.json"
-curl -fsS "$BASE_URL/admin/api/v1/audit/log?search=$REQUEST_ID&limit=5" > "$AUDIT_JSON_FILE"
+curl -fsS "$BASE_URL/admin/audit/log?search=$REQUEST_ID&limit=5" > "$AUDIT_JSON_FILE"
 jq --arg request_id "$REQUEST_ID" '{total:(.entries|map(select(.request_id==$request_id))|length),entries:(.entries|map(select(.request_id==$request_id))|map({request_id,path,requested_model,provider,status_code,error_type}))}' "$AUDIT_JSON_FILE"
 jq -e --arg request_id "$REQUEST_ID" '
     any(.entries[]?;
@@ -980,7 +980,7 @@ Reads the allowlisted runtime flags for the dedicated auth-enabled release gatew
 
 ```bash
 CONFIG_JSON_FILE="$QA_RUN_DIR/s63.dashboard-config.json"
-curl -fsS "$AUTH_BASE_URL/admin/api/v1/dashboard/config" \
+curl -fsS "$AUTH_BASE_URL/admin/runtime/config" \
   -H "$ADMIN_AUTH_HEADER" \
   > "$CONFIG_JSON_FILE"
 jq '.' "$CONFIG_JSON_FILE"
@@ -999,7 +999,7 @@ jq -e '
 Creates one managed API key scoped to a release-specific user path and stores the one-time secret under `QA_RUN_DIR`.
 
 ```bash
-curl -fsS -X POST "$AUTH_BASE_URL/admin/api/v1/auth-keys" \
+curl -fsS -X POST "$AUTH_BASE_URL/admin/auth-keys" \
   -H "$ADMIN_AUTH_HEADER" \
   -H 'Content-Type: application/json' \
   -d "{\"name\":\"$QA_AUTH_KEY_NAME\",\"description\":\"Release e2e managed key\",\"user_path\":\"$QA_USER_PATH\"}" \
@@ -1027,7 +1027,7 @@ Checks that the newly issued managed API key is visible and active.
 
 ```bash
 AUTH_KEYS_JSON_FILE="$QA_RUN_DIR/s65.auth-keys.json"
-curl -fsS "$AUTH_BASE_URL/admin/api/v1/auth-keys" \
+curl -fsS "$AUTH_BASE_URL/admin/auth-keys" \
   -H "$ADMIN_AUTH_HEADER" \
   > "$AUTH_KEYS_JSON_FILE"
 jq -e --arg name "$QA_AUTH_KEY_NAME" --arg user_path "$QA_USER_PATH" '
@@ -1041,7 +1041,7 @@ jq -e --arg name "$QA_AUTH_KEY_NAME" --arg user_path "$QA_USER_PATH" '
 Creates a scoped workflow for `openai/gpt-4.1-nano` that disables cache for the managed-key user path.
 
 ```bash
-curl -fsS -X POST "$AUTH_BASE_URL/admin/api/v1/workflows" \
+curl -fsS -X POST "$AUTH_BASE_URL/admin/workflows" \
   -H "$ADMIN_AUTH_HEADER" \
   -H 'Content-Type: application/json' \
   -d "{\"scope_provider\":\"openai\",\"scope_model\":\"gpt-4.1-nano\",\"scope_user_path\":\"$QA_USER_PATH\",\"name\":\"$QA_WORKFLOW_NAME\",\"description\":\"Disable cache for managed-key release e2e scope\",\"workflow_payload\":{\"schema_version\":1,\"features\":{\"cache\":false,\"audit\":true,\"usage\":true,\"guardrails\":false,\"fallback\":false},\"guardrails\":[]}}" \
@@ -1067,7 +1067,7 @@ Reads the created workflow back and confirms the normalized scope and effective 
 require_release_artifact "$QA_WORKFLOW_ID_FILE"
 WORKFLOW_ID=$(<"$QA_WORKFLOW_ID_FILE")
 WORKFLOW_DETAIL_FILE="$QA_RUN_DIR/s67.workflow-detail.json"
-curl -fsS "$AUTH_BASE_URL/admin/api/v1/workflows/$WORKFLOW_ID" \
+curl -fsS "$AUTH_BASE_URL/admin/workflows/$WORKFLOW_ID" \
   -H "$ADMIN_AUTH_HEADER" \
   > "$WORKFLOW_DETAIL_FILE"
 jq '{id,name,scope,workflow_payload,effective_features}' "$WORKFLOW_DETAIL_FILE"
@@ -1140,7 +1140,7 @@ if ! AUTH_KEY_ID=$(jq -er '.id' "$QA_AUTH_KEY_JSON"); then
 fi
 WORKFLOW_ID=$(<"$QA_WORKFLOW_ID_FILE")
 AUDIT_JSON_FILE="$QA_RUN_DIR/s70.audit.json"
-curl -fsS "$AUTH_BASE_URL/admin/api/v1/audit/log?search=$QA_AUTH_REQ2&limit=5" \
+curl -fsS "$AUTH_BASE_URL/admin/audit/log?search=$QA_AUTH_REQ2&limit=5" \
   -H "$ADMIN_AUTH_HEADER" \
   > "$AUDIT_JSON_FILE"
 jq --arg request_id "$QA_AUTH_REQ2" '{total:(.entries|map(select(.request_id==$request_id))|length),entries:(.entries|map(select(.request_id==$request_id))|map({request_id,status_code,auth_method,auth_key_id,user_path,workflow_version_id,cache_type,answer:.data.response_body.choices[0].message.content}))}' "$AUDIT_JSON_FILE"
@@ -1210,7 +1210,7 @@ Checks cache analytics after the exact-cache hit using the same tracked user pat
 ```bash
 sleep 6
 CACHE_OVERVIEW_JSON_FILE="$QA_RUN_DIR/s73.cache-overview.json"
-curl -fsS "$AUTH_BASE_URL/admin/api/v1/cache/overview?days=1&user_path=$QA_CACHE_USER_PATH" \
+curl -fsS "$AUTH_BASE_URL/admin/cache/overview?days=1&user_path=$QA_CACHE_USER_PATH" \
   -H "$ADMIN_AUTH_HEADER" \
   > "$CACHE_OVERVIEW_JSON_FILE"
 jq '.' "$CACHE_OVERVIEW_JSON_FILE"
@@ -1223,7 +1223,7 @@ Reads cached-only usage entries for the same exact-hit request path.
 
 ```bash
 CACHED_USAGE_JSON_FILE="$QA_RUN_DIR/s74.cached-usage.json"
-curl -fsS "$AUTH_BASE_URL/admin/api/v1/usage/log?days=1&user_path=$QA_CACHE_USER_PATH&cache_mode=cached&limit=5" \
+curl -fsS "$AUTH_BASE_URL/admin/usage/log?days=1&user_path=$QA_CACHE_USER_PATH&cache_mode=cached&limit=5" \
   -H "$ADMIN_AUTH_HEADER" \
   > "$CACHED_USAGE_JSON_FILE"
 jq '{total,entries:(.entries|map({request_id,cache_type,model,provider,endpoint,user_path,total_tokens}))}' "$CACHED_USAGE_JSON_FILE"
@@ -1240,7 +1240,7 @@ Verifies user-path validation for managed API key creation.
 ```bash
 HEADERS_FILE=$(mktemp "$QA_RUN_DIR/s75.headers.XXXXXX")
 BODY_FILE=$(mktemp "$QA_RUN_DIR/s75.body.XXXXXX")
-curl -sS -D "$HEADERS_FILE" -o "$BODY_FILE" -X POST "$AUTH_BASE_URL/admin/api/v1/auth-keys" \
+curl -sS -D "$HEADERS_FILE" -o "$BODY_FILE" -X POST "$AUTH_BASE_URL/admin/auth-keys" \
   -H "$ADMIN_AUTH_HEADER" \
   -H 'Content-Type: application/json' \
   -d '{"name":"qa-invalid-user-path","user_path":"/team/../alpha"}'
@@ -1257,7 +1257,7 @@ Verifies user-path validation for workflow creation.
 ```bash
 HEADERS_FILE=$(mktemp "$QA_RUN_DIR/s76.headers.XXXXXX")
 BODY_FILE=$(mktemp "$QA_RUN_DIR/s76.body.XXXXXX")
-curl -sS -D "$HEADERS_FILE" -o "$BODY_FILE" -X POST "$AUTH_BASE_URL/admin/api/v1/workflows" \
+curl -sS -D "$HEADERS_FILE" -o "$BODY_FILE" -X POST "$AUTH_BASE_URL/admin/workflows" \
   -H "$ADMIN_AUTH_HEADER" \
   -H 'Content-Type: application/json' \
   -d '{"scope_provider":"openai","scope_model":"gpt-4.1-nano","scope_user_path":"/team/../alpha","name":"qa-invalid-workflow-path","workflow_payload":{"schema_version":1,"features":{"cache":true,"audit":true,"usage":true,"guardrails":false},"guardrails":[]}}'
@@ -1275,7 +1275,7 @@ Deactivates the managed key created for the auth-enabled release run.
 
 ```bash
 AUTH_KEYS_JSON_FILE="$QA_RUN_DIR/s77.auth-keys.json"
-curl -fsS "$AUTH_BASE_URL/admin/api/v1/auth-keys" \
+curl -fsS "$AUTH_BASE_URL/admin/auth-keys" \
   -H "$ADMIN_AUTH_HEADER" \
   > "$AUTH_KEYS_JSON_FILE"
 if ! AUTH_KEY_ID=$(jq -er --arg name "$QA_AUTH_KEY_NAME" '.[] | select(.name == $name) | .id' "$AUTH_KEYS_JSON_FILE"); then
@@ -1283,7 +1283,7 @@ if ! AUTH_KEY_ID=$(jq -er --arg name "$QA_AUTH_KEY_NAME" '.[] | select(.name == 
   exit 1
 fi
 HEADERS_FILE=$(mktemp "$QA_RUN_DIR/s77.headers.XXXXXX")
-curl -sS -D "$HEADERS_FILE" -o /dev/null -X POST "$AUTH_BASE_URL/admin/api/v1/auth-keys/$AUTH_KEY_ID/deactivate" \
+curl -sS -D "$HEADERS_FILE" -o /dev/null -X POST "$AUTH_BASE_URL/admin/auth-keys/$AUTH_KEY_ID/deactivate" \
   -H "$ADMIN_AUTH_HEADER"
 sed -n '1,20p' "$HEADERS_FILE"
 grep -Eiq '^HTTP/.* 204 ' "$HEADERS_FILE"
@@ -1317,7 +1317,7 @@ Deactivates the workflow created for the scoped managed-key release run.
 require_release_artifact "$QA_WORKFLOW_ID_FILE"
 WORKFLOW_ID=$(<"$QA_WORKFLOW_ID_FILE")
 HEADERS_FILE=$(mktemp "$QA_RUN_DIR/s79.headers.XXXXXX")
-curl -sS -D "$HEADERS_FILE" -o /dev/null -X POST "$AUTH_BASE_URL/admin/api/v1/workflows/$WORKFLOW_ID/deactivate" \
+curl -sS -D "$HEADERS_FILE" -o /dev/null -X POST "$AUTH_BASE_URL/admin/workflows/$WORKFLOW_ID/deactivate" \
   -H "$ADMIN_AUTH_HEADER"
 sed -n '1,20p' "$HEADERS_FILE"
 grep -Eiq '^HTTP/.* 204 ' "$HEADERS_FILE"
@@ -1458,7 +1458,7 @@ BUDGET_PATH="/team/budget/admin/$QA_SUFFIX"
 HEADERS_FILE=$(mktemp "$QA_RUN_DIR/s86.headers.XXXXXX")
 BODY_FILE=$(mktemp "$QA_RUN_DIR/s86.body.XXXXXX")
 
-curl -sS -D "$HEADERS_FILE" -o "$BODY_FILE" -X PUT "$BASE_URL/admin/api/v1/budgets/settings" \
+curl -sS -D "$HEADERS_FILE" -o "$BODY_FILE" -X PUT "$BASE_URL/admin/budgets/settings" \
   -H 'Content-Type: application/json' \
   -d '{"daily_reset_hour":24}'
 sed -n '1,20p' "$HEADERS_FILE"
@@ -1466,12 +1466,12 @@ jq . "$BODY_FILE"
 grep -Eiq '^HTTP/.* 400 ' "$HEADERS_FILE"
 jq -e '.error.type == "invalid_request_error" and (.error.message | test("daily_reset_hour"))' "$BODY_FILE" >/dev/null
 
-curl -fsS -X PUT "$BASE_URL/admin/api/v1/budgets/settings" \
+curl -fsS -X PUT "$BASE_URL/admin/budgets/settings" \
   -H 'Content-Type: application/json' \
   -d '{"daily_reset_hour":1,"daily_reset_minute":15,"weekly_reset_weekday":2,"monthly_reset_day":2}' \
   | jq -e '.daily_reset_hour == 1 and .daily_reset_minute == 15 and .weekly_reset_weekday == 2 and .monthly_reset_day == 2'
 
-curl -sS -D "$HEADERS_FILE" -o "$BODY_FILE" -X PUT "$BASE_URL/admin/api/v1/budgets" \
+curl -sS -D "$HEADERS_FILE" -o "$BODY_FILE" -X PUT "$BASE_URL/admin/budgets" \
   -H 'Content-Type: application/json' \
   -d "{\"user_path\":\"$BUDGET_PATH\",\"budget_key\":{\"period\":\"daily\"},\"amount\":-1}"
 sed -n '1,20p' "$HEADERS_FILE"
@@ -1479,19 +1479,19 @@ jq . "$BODY_FILE"
 grep -Eiq '^HTTP/.* 400 ' "$HEADERS_FILE"
 jq -e '.error.type == "invalid_request_error" and (.error.message | test("amount"))' "$BODY_FILE" >/dev/null
 
-curl -fsS -X PUT "$BASE_URL/admin/api/v1/budgets" \
+curl -fsS -X PUT "$BASE_URL/admin/budgets" \
   -H 'Content-Type: application/json' \
   -d "{\"user_path\":\"$BUDGET_PATH\",\"budget_key\":{\"period\":\"weekly\"},\"amount\":12.5}" \
   | jq -e --arg user_path "$BUDGET_PATH" '
       any(.budgets[]?; .user_path == $user_path and .period_seconds == 604800 and .amount == 12.5 and .source == "manual")
     ' >/dev/null
 
-curl -fsS -X DELETE "$BASE_URL/admin/api/v1/budgets" \
+curl -fsS -X DELETE "$BASE_URL/admin/budgets" \
   -H 'Content-Type: application/json' \
   -d "{\"user_path\":\"$BUDGET_PATH\",\"budget_key\":{\"period\":\"weekly\"}}" \
   | jq -e --arg user_path "$BUDGET_PATH" 'all(.budgets[]?; .user_path != $user_path)' >/dev/null
 
-curl -fsS -X PUT "$BASE_URL/admin/api/v1/budgets/settings" \
+curl -fsS -X PUT "$BASE_URL/admin/budgets/settings" \
   -H 'Content-Type: application/json' \
   -d '{"daily_reset_hour":0,"daily_reset_minute":0,"weekly_reset_weekday":1,"weekly_reset_hour":0,"weekly_reset_minute":0,"monthly_reset_day":1,"monthly_reset_hour":0,"monthly_reset_minute":0}' \
   >/dev/null
@@ -1540,7 +1540,7 @@ run_release_budget_enforcement \
 Runs the pricing recalculation action on the main SQLite-backed gateway. The release stack starts this gateway with `GOMODEL_MASTER_KEY` unset, so the request intentionally sends no `Authorization` header.
 
 ```bash
-curl -fsS -X POST "$BASE_URL/admin/api/v1/usage/recalculate-pricing" \
+curl -fsS -X POST "$BASE_URL/admin/usage/recalculate-pricing" \
   -H 'Content-Type: application/json' \
   -d '{"confirmation":"recalculate"}' \
   | jq -e '.status == "ok" and (.matched | type == "number") and (.recalculated | type == "number")'

--- a/tests/integration/admin_test.go
+++ b/tests/integration/admin_test.go
@@ -41,7 +41,7 @@ func TestAdminUsageSummary_PostgreSQL(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	// Query admin API
-	resp, err := http.Get(fixture.ServerURL + "/admin/api/v1/usage/summary?days=30")
+	resp, err := http.Get(fixture.ServerURL + "/admin/usage/summary?days=30")
 	require.NoError(t, err)
 	defer closeBody(resp)
 
@@ -84,7 +84,7 @@ func TestAdminDailyUsage_PostgreSQL(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	// Query admin API
-	resp, err := http.Get(fixture.ServerURL + "/admin/api/v1/usage/daily?days=30")
+	resp, err := http.Get(fixture.ServerURL + "/admin/usage/daily?days=30")
 	require.NoError(t, err)
 	defer closeBody(resp)
 
@@ -139,7 +139,7 @@ func TestAdminUsageSummary_MongoDB(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	// Query admin API
-	resp, err := http.Get(fixture.ServerURL + "/admin/api/v1/usage/summary?days=30")
+	resp, err := http.Get(fixture.ServerURL + "/admin/usage/summary?days=30")
 	require.NoError(t, err)
 	defer closeBody(resp)
 
@@ -177,7 +177,7 @@ func TestAdminDailyUsage_WithInterval_PostgreSQL(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	// Query with weekly interval
-	resp, err := http.Get(fixture.ServerURL + "/admin/api/v1/usage/daily?interval=weekly")
+	resp, err := http.Get(fixture.ServerURL + "/admin/usage/daily?interval=weekly")
 	require.NoError(t, err)
 	defer closeBody(resp)
 
@@ -213,7 +213,7 @@ func TestAdminPricingRecalculationNoMasterKey_PostgreSQL(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	req, err := http.NewRequest(http.MethodPost, fixture.ServerURL+"/admin/api/v1/usage/recalculate-pricing", bytes.NewBufferString(`{"confirmation":"recalculate"}`))
+	req, err := http.NewRequest(http.MethodPost, fixture.ServerURL+"/admin/usage/recalculate-pricing", bytes.NewBufferString(`{"confirmation":"recalculate"}`))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err = http.DefaultClient.Do(req)
@@ -240,7 +240,7 @@ func TestAdminModels_PostgreSQL(t *testing.T) {
 	})
 
 	// Query admin models endpoint
-	resp, err := http.Get(fixture.ServerURL + "/admin/api/v1/models")
+	resp, err := http.Get(fixture.ServerURL + "/admin/models")
 	require.NoError(t, err)
 	defer closeBody(resp)
 

--- a/tests/integration/workflows_guardrails_test.go
+++ b/tests/integration/workflows_guardrails_test.go
@@ -255,7 +255,7 @@ func TestGuardrailWorkflow_RewritesUpstreamRequestAndPreservesAuditUsage_Postgre
 func createManagedAuthKey(t *testing.T, serverURL, masterKey string, payload map[string]any) authkeys.IssuedKey {
 	t.Helper()
 
-	resp := adminJSONRequest(t, http.MethodPost, serverURL+"/admin/api/v1/auth-keys", masterKey, payload)
+	resp := adminJSONRequest(t, http.MethodPost, serverURL+"/admin/auth-keys", masterKey, payload)
 	defer closeBody(resp)
 	require.Equal(t, http.StatusCreated, resp.StatusCode)
 
@@ -271,7 +271,7 @@ func createManagedAuthKey(t *testing.T, serverURL, masterKey string, payload map
 func createWorkflow(t *testing.T, serverURL, masterKey string, payload map[string]any) workflows.Version {
 	t.Helper()
 
-	resp := adminJSONRequest(t, http.MethodPost, serverURL+"/admin/api/v1/workflows", masterKey, payload)
+	resp := adminJSONRequest(t, http.MethodPost, serverURL+"/admin/workflows", masterKey, payload)
 	defer closeBody(resp)
 	require.Equal(t, http.StatusCreated, resp.StatusCode)
 
@@ -291,7 +291,7 @@ func upsertGuardrail(t *testing.T, serverURL, masterKey, name string, payload ma
 	}
 	body["name"] = name
 
-	resp := adminJSONRequest(t, http.MethodPut, serverURL+"/admin/api/v1/guardrails", masterKey, body)
+	resp := adminJSONRequest(t, http.MethodPut, serverURL+"/admin/guardrails", masterKey, body)
 	defer closeBody(resp)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 

--- a/tools/openapi-postprocess.mjs
+++ b/tools/openapi-postprocess.mjs
@@ -198,9 +198,9 @@ applyPricingSchemaConstraints();
 // security scanners like CKV_OPENAPI_21) see an explicit upper limit. The
 // runtime registry is bounded by configured providers and the backing
 // model list; 10000 leaves substantial headroom for that worst case.
-applyArrayMaxItems("/admin/api/v1/models", "get", "200", 10000);
-applyArrayMaxItems("/admin/api/v1/model-overrides", "get", "200", 10000);
-applyArrayMaxItems("/admin/api/v1/model-pricing-overrides", "get", "200", 10000);
+applyArrayMaxItems("/admin/models", "get", "200", 10000);
+applyArrayMaxItems("/admin/model-overrides", "get", "200", 10000);
+applyArrayMaxItems("/admin/model-pricing-overrides", "get", "200", 10000);
 
 applyStringEnum(
   "modeloverrides.ScopeKind",

--- a/tools/openapi-postprocess.mjs
+++ b/tools/openapi-postprocess.mjs
@@ -158,6 +158,34 @@ function applyStringArrayPropertyBounds(schemaName, propertyName, maxItems, item
   property.items.maxLength = itemMaxLength;
 }
 
+// applyPathSidebarTitles sets the API Reference sidebar entry of every
+// operation to its path so endpoints are listed by URL rather than by
+// natural-language summary. Mintlify renders the HTTP method as a colored
+// pill from the spec, so the title itself omits the method to avoid
+// duplicating it.
+function applyPathSidebarTitles() {
+  const httpMethods = new Set([
+    "get",
+    "post",
+    "put",
+    "patch",
+    "delete",
+    "head",
+    "options",
+    "trace",
+  ]);
+  for (const [path, pathItem] of Object.entries(spec.paths || {})) {
+    if (!pathItem || typeof pathItem !== "object") continue;
+    for (const [method, operation] of Object.entries(pathItem)) {
+      if (!httpMethods.has(method)) continue;
+      if (!operation || typeof operation !== "object") continue;
+      operation["x-mint"] ??= {};
+      operation["x-mint"].metadata ??= {};
+      operation["x-mint"].metadata.sidebarTitle = path;
+    }
+  }
+}
+
 function applyPricingSchemaConstraints() {
   schema("pricingoverrides.Pricing").minProperties = 1;
   for (const name of ["core.ModelPricingTier", "pricingoverrides.PricingTier"]) {
@@ -193,6 +221,7 @@ ensureRequiredProperty("admin.deleteModelPricingOverrideRequest", "selector");
 applyBudgetKeySchemaConstraints();
 applyStringArrayPropertyBounds("admin.upsertModelOverrideRequest", "user_paths", 100, 1024);
 applyPricingSchemaConstraints();
+applyPathSidebarTitles();
 
 // Bound the registry-backed admin model listing so OpenAPI consumers (and
 // security scanners like CKV_OPENAPI_21) see an explicit upper limit. The

--- a/tools/openapi-postprocess.mjs
+++ b/tools/openapi-postprocess.mjs
@@ -3,6 +3,12 @@ import fs from "node:fs";
 const file = process.argv[2] || "docs/openapi.json";
 const spec = JSON.parse(fs.readFileSync(file, "utf8"));
 
+// parseServers emits a single templated OpenAPI 3 server entry whose URL is a
+// free-text variable. Mintlify renders this variable as an editable input at
+// the top of every API Reference page, so visitors can point the docs at
+// their own GoModel deployment without leaving the page. The first URL in
+// DOCS_API_SERVERS is used as the default; any additional URLs become
+// description hints so common deployments stay discoverable.
 function parseServers(value) {
   const urls = (value || "")
     .split(",")
@@ -11,14 +17,22 @@ function parseServers(value) {
   if (urls.length === 0) {
     throw new Error("DOCS_API_SERVERS must include at least one URL");
   }
-  return urls.map((url) => ({
-    url,
-    description: isLocalServer(url) ? "Local GoModel" : "GoModel HTTPS deployment",
-  }));
-}
-
-function isLocalServer(url) {
-  return /(^https?:\/\/)?(localhost|127\.0\.0\.1)(:|\/|$)/.test(url);
+  const [defaultURL, ...alternatives] = urls;
+  const description = alternatives.length === 0
+    ? "Your GoModel deployment URL"
+    : `Your GoModel deployment URL (e.g. ${alternatives.join(", ")})`;
+  return [
+    {
+      url: "{base_url}",
+      description: "Edit the base URL to point at your GoModel deployment.",
+      variables: {
+        base_url: {
+          default: defaultURL,
+          description,
+        },
+      },
+    },
+  ];
 }
 
 function clone(value) {


### PR DESCRIPTION
## Summary

- **`refactor(admin)`** — Shortens the admin REST API prefix from `/admin/api/v1/*` to `/admin/*`. The `/api/v1` segment was redundant — the whole service is an API, and the admin contract has its own lifecycle independent of the OpenAPI-locked `/v1/*`. One conflicting endpoint (`/admin/api/v1/dashboard/config`) moved to `/admin/runtime/config` to avoid colliding with the `/admin/dashboard/*` UI catch-all. Legacy `/admin/api/v1/*` paths keep working until **2026-08-09** with `Deprecation`, `Sunset`, and `Link` headers per RFC 8594 — no flag-day cutover for operators.
- **`docs(openapi)`** — API Reference sidebar now lists endpoints by path (e.g. `/admin/budgets`) rather than by natural-language summary. Mintlify still renders the colored method pill from the spec, so `GET`/`PUT`/`DELETE` on the same path share text but visually differ by pill color.
- **`docs(openapi)`** — Base URL banner at the top of every API Reference page is now an editable `{base_url}` input (OpenAPI 3 server variable). Self-hosters can type their own deployment URL without leaving the page; default is `http://localhost:8080`.
- **`docs(providers)`** — Drops the redundant "GoModel & " prefix from Providers tab page titles.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` clean (full suite)
- [x] `make test-dashboard` clean (258 JS tests)
- [x] New `TestAdminLegacyAlias_Deprecation` verifies legacy paths respond with `Deprecation`/`Sunset`/`Link` headers and that new paths don't leak them
- [x] `make swagger` regenerates `cmd/gomodel/docs/docs.go` and `docs/openapi.json` cleanly
- [x] `mint validate` passes
- [ ] Reviewer: spot-check the API Reference rendering after Mintlify deploys this branch — sidebar paths, method pills, and the editable `{base_url}` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin API endpoints reorganized to shorter paths (e.g., `/admin/usage/summary`, `/admin/budgets`, `/admin/models`)

* **Deprecations**
  * Previous `/admin/api/v1/*` endpoint paths remain functional but deprecated; will be removed August 9, 2026

* **Updates**
  * Dashboard static assets under `/admin/static/*` skip authentication
  * Updated documentation and examples to reflect new endpoint paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->