### PR TITLE
fix(dashboard): trim trailing zeros in cost display

### DIFF
--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -933,7 +933,8 @@ function dashboard() {
 
     formatCost(v) {
       if (v == null || v === undefined) return "N/A";
-      return "$" + v.toFixed(4);
+      if (v > 0 && v < 0.0001) return "<$0.0001";
+      return "$" + v.toFixed(4).replace(/(\.\d{2}\d*?)0+$/, "$1");
     },
 
     formatCostTooltip(entry) {

--- a/internal/admin/dashboard/static/js/modules/budgets.js
+++ b/internal/admin/dashboard/static/js/modules/budgets.js
@@ -380,7 +380,7 @@
                 if (typeof this.formatCost === 'function') {
                     return this.formatCost(amount);
                 }
-                return '$' + amount.toFixed(4);
+                return '$' + amount.toFixed(4).replace(/(\.\d{2}\d*?)0+$/, '$1');
             },
 
             budgetOverrideDialogMessage() {

--- a/internal/admin/dashboard/static/js/modules/budgets.js
+++ b/internal/admin/dashboard/static/js/modules/budgets.js
@@ -380,6 +380,9 @@
                 if (typeof this.formatCost === 'function') {
                     return this.formatCost(amount);
                 }
+                if (amount > 0 && amount < 0.0001) {
+                    return '<$0.0001';
+                }
                 return '$' + amount.toFixed(4).replace(/(\.\d{2}\d*?)0+$/, '$1');
             },
 

--- a/internal/admin/dashboard/static/js/modules/budgets.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/budgets.test.cjs
@@ -175,7 +175,7 @@ test('submitBudgetForm asks for confirmation before a create overrides an existi
         source: 'manual'
     }));
     assert.match(module.budgetOverrideDialogMessage(), /A budget for "\/team Daily" already exists/);
-    assert.match(module.budgetOverrideDialogMessage(), /override the current \$10\.0000 limit with \$12\.5000/);
+    assert.match(module.budgetOverrideDialogMessage(), /override the current \$10\.00 limit with \$12\.50/);
 });
 
 test('confirmBudgetOverride saves the pending create after confirmation', async () => {


### PR DESCRIPTION
## Summary
- `formatCost` now strips trailing zeros while keeping at least 2 decimals, so budget limits and usage costs render as `$0.12` / `$1.00` instead of `$0.1200` / `$1.0000`.
- Non-zero costs below the 4-decimal display precision now render as `<$0.0001` instead of being misleadingly rounded to `$0.00`. True `$0` still renders as `$0.00`.
- Aligned the defensive fallback in `budgets.js` (`budgetAmountLabel`) and updated the affected test expectation.

User-visible impact: every place that calls `formatCost` — Usage page columns and tooltips, Budgets page (limits, remaining/over labels, progress bar text), Overview total cost card.

## Test plan
- [x] `node --test internal/admin/dashboard/static/js/modules/*.test.cjs` — 258/258 pass
- [ ] Manual: open the Budgets page and confirm whole-dollar limits show as `$1.00` (not `$1.0000`) and fractional limits drop trailing zeros.
- [ ] Manual: open the Usage page in cost mode and confirm rows with sub-`$0.0001` totals show `<$0.0001`, and rows with truly zero cost still show `$0.00`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cost and budget amount formatting by trimming unnecessary trailing zeros for cleaner display.
  * Very small positive amounts (< $0.0001) now show as "<$0.0001" for clarity.

* **Tests**
  * Updated confirmation message tests to match the new currency precision formatting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ENTERPILOT/GoModel/pull/313)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->