### PR TITLE
feat(deepseek): add Passthrough support and PassthroughSemanticEnricher

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Example model identifiers are illustrative and subject to change; consult provid
 | Anthropic     | `ANTHROPIC_API_KEY`                                               | `claude-sonnet-4-20250514`         |  ✅  |      ✅      |  ❌   |  ❌   |   ✅    |    ✅    |
 | Google Gemini | `GEMINI_API_KEY`                                                   | `gemini-2.5-flash`                 |  ✅  |      ✅      |  ✅   |  ✅   |   ✅    |    ❌    |
 | Vertex AI     | `VERTEX_PROJECT` + `VERTEX_LOCATION`                               | `google/gemini-2.5-flash`          |  ✅  |      ✅      |  ✅   |  ❌   |   ❌    |    ❌    |
-| DeepSeek      | `DEEPSEEK_API_KEY`                                                | `deepseek-v4-pro`                  |  ✅  |      ✅      |  ❌   |  ❌   |   ❌    |    ❌    |
+| DeepSeek      | `DEEPSEEK_API_KEY`                                                | `deepseek-v4-pro`                  |  ✅  |      ✅      |  ❌   |  ❌   |   ❌    |    ✅    |
 | Groq          | `GROQ_API_KEY`                                                    | `llama-3.3-70b-versatile`          |  ✅  |      ✅      |  ✅   |  ✅   |   ✅    |    ❌    |
 | OpenRouter    | `OPENROUTER_API_KEY`                                              | `google/gemini-2.5-flash`          |  ✅  |      ✅      |  ✅   |  ✅   |   ✅    |    ✅    |
 | Z.ai          | `ZAI_API_KEY` (`ZAI_BASE_URL` optional)                           | `glm-5.1`                          |  ✅  |      ✅      |  ✅   |  ❌   |   ❌    |    ✅    |
@@ -263,7 +263,7 @@ Key settings:
 | `GOMODEL_MASTER_KEY`            | (none)                                 | API key for authentication                                                       |
 | `ENABLE_PASSTHROUGH_ROUTES`     | `true`                                 | Enable provider-native passthrough routes under `/p/{provider}/...`              |
 | `ALLOW_PASSTHROUGH_V1_ALIAS`    | `true`                                 | Allow `/p/{provider}/v1/...` aliases while keeping `/p/{provider}/...` canonical |
-| `ENABLED_PASSTHROUGH_PROVIDERS` | `openai,anthropic,openrouter,zai,vllm` | Comma-separated list of enabled passthrough providers                            |
+| `ENABLED_PASSTHROUGH_PROVIDERS` | `openai,anthropic,openrouter,zai,vllm,deepseek` | Comma-separated list of enabled passthrough providers                            |
 | `GEMINI_API_MODE`               | `native`                               | Gemini AI Studio upstream mode: `native` or `openai_compatible`                 |
 | `VERTEX_API_MODE`               | `native`                               | Vertex AI Gemini upstream mode: `native` or `openai_compatible`                 |
 | `USE_GOOGLE_GEMINI_NATIVE_API`  | `true`                                 | Legacy global Gemini mode toggle used when per-provider `*_API_MODE` is unset   |

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -12,7 +12,7 @@ server:
   pprof_enabled: false # expose /debug/pprof/* for local profiling only
   enable_passthrough_routes: true # expose /p/{provider}/{endpoint} passthrough routes
   allow_passthrough_v1_alias: true # allow /p/{provider}/v1/... while keeping /p/{provider}/... canonical
-  enabled_passthrough_providers: ["openai", "anthropic", "openrouter", "zai", "vllm"] # providers enabled on /p/{provider}/...
+  enabled_passthrough_providers: ["openai", "anthropic", "openrouter", "zai", "vllm", "deepseek"] # providers enabled on /p/{provider}/...
 
 models:
   enabled_by_default: true # env: MODELS_ENABLED_BY_DEFAULT; when false, models stay unavailable until an override allows one or more user paths

--- a/config/config.go
+++ b/config/config.go
@@ -519,6 +519,7 @@ func buildDefaultConfig() *Config {
 				"openrouter",
 				"zai",
 				"vllm",
+				"deepseek",
 			},
 		},
 		Models: ModelsConfig{

--- a/config/config.go
+++ b/config/config.go
@@ -408,7 +408,7 @@ type ServerConfig struct {
 	AllowPassthroughV1Alias bool `yaml:"allow_passthrough_v1_alias" env:"ALLOW_PASSTHROUGH_V1_ALIAS"`
 	// EnabledPassthroughProviders lists the provider types enabled on
 	// /p/{provider}/... passthrough routes. Default:
-	// ["openai", "anthropic", "openrouter", "zai", "vllm"].
+	// ["openai", "anthropic", "openrouter", "zai", "vllm", "deepseek"].
 	EnabledPassthroughProviders []string `yaml:"enabled_passthrough_providers" env:"ENABLED_PASSTHROUGH_PROVIDERS"`
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -113,7 +113,7 @@ func TestBuildDefaultConfig(t *testing.T) {
 	if !cfg.Server.AllowPassthroughV1Alias {
 		t.Error("expected Server.AllowPassthroughV1Alias=true")
 	}
-	if got, want := cfg.Server.EnabledPassthroughProviders, []string{"openai", "anthropic", "openrouter", "zai", "vllm"}; !reflect.DeepEqual(got, want) {
+	if got, want := cfg.Server.EnabledPassthroughProviders, []string{"openai", "anthropic", "openrouter", "zai", "vllm", "deepseek"}; !reflect.DeepEqual(got, want) {
 		t.Errorf("expected Server.EnabledPassthroughProviders=%v, got %v", want, got)
 	}
 	if cfg.Models.ConfiguredProviderModelsMode != ConfiguredProviderModelsModeFallback {
@@ -1102,7 +1102,7 @@ func TestLoad_ConfigExample_UsesNestedModelCacheSettings(t *testing.T) {
 			t.Fatalf("expected Cache.Model.Redis to be nil in example config, got %+v", result.Config.Cache.Model.Redis)
 		}
 		gotProviders := result.Config.Server.EnabledPassthroughProviders
-		wantProviders := []string{"openai", "anthropic", "openrouter", "zai", "vllm"}
+		wantProviders := []string{"openai", "anthropic", "openrouter", "zai", "vllm", "deepseek"}
 		if !reflect.DeepEqual(gotProviders, wantProviders) {
 			t.Fatalf("Server.EnabledPassthroughProviders = %v, want %v", gotProviders, wantProviders)
 		}

--- a/docs/features/passthrough-api.mdx
+++ b/docs/features/passthrough-api.mdx
@@ -145,7 +145,7 @@ Passthrough routes are enabled by default:
 ```env
 ENABLE_PASSTHROUGH_ROUTES=true
 ALLOW_PASSTHROUGH_V1_ALIAS=true
-ENABLED_PASSTHROUGH_PROVIDERS=openai,anthropic,openrouter,zai,vllm
+ENABLED_PASSTHROUGH_PROVIDERS=openai,anthropic,openrouter,zai,vllm,deepseek
 ```
 
 Set `ENABLED_PASSTHROUGH_PROVIDERS` to the provider types you want to expose.

--- a/docs/features/passthrough-api.mdx
+++ b/docs/features/passthrough-api.mdx
@@ -130,7 +130,7 @@ from passthrough requests before forwarding them upstream.
 
 Passthrough is intentionally narrow while the API is in beta.
 
-- `openai`, `anthropic`, `openrouter`, `zai`, and `vllm` are enabled by
+- `openai`, `anthropic`, `openrouter`, `zai`, `vllm`, and `deepseek` are enabled by
   default.
 - GoModel does not translate passthrough request bodies or response bodies.
 - Provider-native error bodies and status codes are proxied instead of converted

--- a/internal/providers/deepseek/deepseek.go
+++ b/internal/providers/deepseek/deepseek.go
@@ -91,6 +91,10 @@ func adaptChatRequest(req *core.ChatRequest) (any, error) {
 
 	effort, _ := json.Marshal(normalizeReasoningEffort(req.Reasoning.Effort))
 	raw["reasoning_effort"] = effort
+	// Delete the full reasoning object: DeepSeek accepts reasoning_effort as a
+	// top-level string only. Other reasoning fields (e.g. budget_tokens) are not
+	// forwarded because DeepSeek has no equivalent. Update this if DeepSeek
+	// expands its reasoning API surface.
 	delete(raw, "reasoning")
 	return raw, nil
 }

--- a/internal/providers/deepseek/deepseek.go
+++ b/internal/providers/deepseek/deepseek.go
@@ -168,11 +168,17 @@ func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error)
 
 // Responses sends a Responses API request to DeepSeek using chat-completions translation.
 func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
+	if req == nil {
+		return nil, core.NewInvalidRequestError("responses request is required", nil)
+	}
 	return providers.ResponsesViaChat(ctx, p, req)
 }
 
 // StreamResponses streams a Responses API request to DeepSeek using chat-completions translation.
 func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
+	if req == nil {
+		return nil, core.NewInvalidRequestError("responses request is required", nil)
+	}
 	return providers.StreamResponsesViaChat(ctx, p, req, "deepseek")
 }
 

--- a/internal/providers/deepseek/deepseek.go
+++ b/internal/providers/deepseek/deepseek.go
@@ -17,8 +17,9 @@ const defaultBaseURL = "https://api.deepseek.com"
 
 // Registration provides factory registration for the DeepSeek provider.
 var Registration = providers.Registration{
-	Type: "deepseek",
-	New:  New,
+	Type:                        "deepseek",
+	New:                         New,
+	PassthroughSemanticEnricher: passthroughSemanticEnricher{},
 	Discovery: providers.DiscoveryConfig{
 		DefaultBaseURL: defaultBaseURL,
 	},

--- a/internal/providers/deepseek/deepseek.go
+++ b/internal/providers/deepseek/deepseek.go
@@ -190,3 +190,26 @@ func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesReque
 func (p *Provider) Embeddings(_ context.Context, _ *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
 	return nil, core.NewInvalidRequestError("deepseek does not support embeddings", nil)
 }
+
+// Passthrough forwards a raw request to DeepSeek without any transformation,
+// enabling direct access to provider-native endpoints such as /beta/completions
+// (FIM) that GOModel does not expose as first-class typed operations.
+func (p *Provider) Passthrough(ctx context.Context, req *core.PassthroughRequest) (*core.PassthroughResponse, error) {
+	if req == nil {
+		return nil, core.NewInvalidRequestError("passthrough request is required", nil)
+	}
+	resp, err := p.client.DoPassthrough(ctx, llmclient.Request{
+		Method:        req.Method,
+		Endpoint:      providers.PassthroughEndpoint(req.Endpoint),
+		RawBodyReader: req.Body,
+		Headers:       req.Headers,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &core.PassthroughResponse{
+		StatusCode: resp.StatusCode,
+		Headers:    providers.CloneHTTPHeaders(resp.Header),
+		Body:       resp.Body,
+	}, nil
+}

--- a/internal/providers/deepseek/deepseek_test.go
+++ b/internal/providers/deepseek/deepseek_test.go
@@ -227,6 +227,112 @@ func TestProvider_DoesNotExposeOptionalNativeInterfaces(t *testing.T) {
 	}
 }
 
+func TestPassthrough_ForwardsRequestWithBearerAuth(t *testing.T) {
+	var gotPath, gotAuth, gotMethod string
+	var gotBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotMethod = r.Method
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"fim_completion","choices":[{"text":"world"}]}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("deepseek-key", server.URL, server.Client(), llmclient.Hooks{})
+
+	body := strings.NewReader(`{"model":"deepseek-v4-pro","prompt":"hello "}`)
+	resp, err := provider.Passthrough(context.Background(), &core.PassthroughRequest{
+		Method:   http.MethodPost,
+		Endpoint: "/beta/completions",
+		Body:     io.NopCloser(body),
+	})
+	if err != nil {
+		t.Fatalf("Passthrough() error = %v", err)
+	}
+	defer resp.Body.Close()
+	if gotPath != "/beta/completions" {
+		t.Fatalf("path = %q, want /beta/completions", gotPath)
+	}
+	if gotAuth != "Bearer deepseek-key" {
+		t.Fatalf("authorization = %q, want Bearer deepseek-key", gotAuth)
+	}
+	if gotMethod != http.MethodPost {
+		t.Fatalf("method = %q, want POST", gotMethod)
+	}
+	if !strings.Contains(string(gotBody), "deepseek-v4-pro") {
+		t.Fatalf("body = %q, want body containing deepseek-v4-pro", gotBody)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestPassthrough_NilRequest_ReturnsError(t *testing.T) {
+	provider := NewWithHTTPClient("deepseek-key", "", nil, llmclient.Hooks{})
+	_, err := provider.Passthrough(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil passthrough request, got nil")
+	}
+}
+
+func TestPassthrough_ForwardsRequestHeaders(t *testing.T) {
+	var gotContentType string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("deepseek-key", server.URL, server.Client(), llmclient.Hooks{})
+
+	resp, err := provider.Passthrough(context.Background(), &core.PassthroughRequest{
+		Method:   http.MethodPost,
+		Endpoint: "/beta/completions",
+		Body:     io.NopCloser(strings.NewReader(`{}`)),
+		Headers:  http.Header{"Content-Type": []string{"application/json"}},
+	})
+	if err != nil {
+		t.Fatalf("Passthrough() error = %v", err)
+	}
+	defer resp.Body.Close()
+	if gotContentType != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json", gotContentType)
+	}
+}
+
+func TestPassthrough_PreservesNon2xxStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"code":"rate_limit_exceeded"}}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("deepseek-key", server.URL, server.Client(), llmclient.Hooks{})
+
+	resp, err := provider.Passthrough(context.Background(), &core.PassthroughRequest{
+		Method:   http.MethodPost,
+		Endpoint: "/beta/completions",
+		Body:     io.NopCloser(strings.NewReader(`{}`)),
+	})
+	if err != nil {
+		t.Fatalf("Passthrough() error = %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429", resp.StatusCode)
+	}
+}
+
+func TestProvider_ImplementsPassthroughProvider(t *testing.T) {
+	provider := NewWithHTTPClient("deepseek-key", "", nil, llmclient.Hooks{})
+	var _ core.PassthroughProvider = provider
+}
+
 func TestResponses_NilRequest_ReturnsError(t *testing.T) {
 	provider := NewWithHTTPClient("deepseek-key", "", nil, llmclient.Hooks{})
 	_, err := provider.Responses(context.Background(), nil)

--- a/internal/providers/deepseek/deepseek_test.go
+++ b/internal/providers/deepseek/deepseek_test.go
@@ -227,6 +227,22 @@ func TestProvider_DoesNotExposeOptionalNativeInterfaces(t *testing.T) {
 	}
 }
 
+func TestResponses_NilRequest_ReturnsError(t *testing.T) {
+	provider := NewWithHTTPClient("deepseek-key", "", nil, llmclient.Hooks{})
+	_, err := provider.Responses(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil Responses request, got nil")
+	}
+}
+
+func TestStreamResponses_NilRequest_ReturnsError(t *testing.T) {
+	provider := NewWithHTTPClient("deepseek-key", "", nil, llmclient.Hooks{})
+	_, err := provider.StreamResponses(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil StreamResponses request, got nil")
+	}
+}
+
 func TestEmbeddings_ReturnsUnsupported(t *testing.T) {
 	provider := NewWithHTTPClient("deepseek-key", "", nil, llmclient.Hooks{})
 

--- a/internal/providers/deepseek/deepseek_test.go
+++ b/internal/providers/deepseek/deepseek_test.go
@@ -328,6 +328,61 @@ func TestPassthrough_PreservesNon2xxStatus(t *testing.T) {
 	}
 }
 
+func TestPassthrough_ForwardsQueryString(t *testing.T) {
+	var gotPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.RequestURI()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("deepseek-key", server.URL, server.Client(), llmclient.Hooks{})
+
+	resp, err := provider.Passthrough(context.Background(), &core.PassthroughRequest{
+		Method:   http.MethodGet,
+		Endpoint: "/beta/completions?stream=true",
+		Body:     io.NopCloser(strings.NewReader(``)),
+	})
+	if err != nil {
+		t.Fatalf("Passthrough() error = %v", err)
+	}
+	defer resp.Body.Close()
+	if gotPath != "/beta/completions?stream=true" {
+		t.Fatalf("path = %q, want /beta/completions?stream=true", gotPath)
+	}
+}
+
+func TestPassthrough_PreservesResponseBody(t *testing.T) {
+	const upstreamBody = `{"error":{"message":"rate_limit_exceeded","type":"rate_limit_error"}}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(upstreamBody))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("deepseek-key", server.URL, server.Client(), llmclient.Hooks{})
+
+	resp, err := provider.Passthrough(context.Background(), &core.PassthroughRequest{
+		Method:   http.MethodPost,
+		Endpoint: "/beta/completions",
+		Body:     io.NopCloser(strings.NewReader(`{}`)),
+	})
+	if err != nil {
+		t.Fatalf("Passthrough() error = %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if string(body) != upstreamBody {
+		t.Fatalf("response body = %q, want %q", string(body), upstreamBody)
+	}
+}
+
 func TestProvider_ImplementsPassthroughProvider(t *testing.T) {
 	provider := NewWithHTTPClient("deepseek-key", "", nil, llmclient.Hooks{})
 	var _ core.PassthroughProvider = provider

--- a/internal/providers/deepseek/passthrough_semantics.go
+++ b/internal/providers/deepseek/passthrough_semantics.go
@@ -1,0 +1,35 @@
+package deepseek
+
+import (
+	"strings"
+
+	"gomodel/internal/core"
+	"gomodel/internal/providers"
+)
+
+type passthroughSemanticEnricher struct{}
+
+func (passthroughSemanticEnricher) ProviderType() string {
+	return "deepseek"
+}
+
+func (passthroughSemanticEnricher) Enrich(_ *core.RequestSnapshot, _ *core.WhiteBoxPrompt, info *core.PassthroughRouteInfo) *core.PassthroughRouteInfo {
+	if info == nil {
+		return nil
+	}
+	enriched := *info
+	normalizedEndpoint := strings.TrimLeft(strings.TrimSpace(providers.PassthroughEndpointPath(&enriched)), "/")
+	switch "/" + normalizedEndpoint {
+	case "/chat/completions":
+		enriched.SemanticOperation = "deepseek.chat_completions"
+		enriched.AuditPath = "/v1/chat/completions"
+	case "/beta/completions":
+		enriched.SemanticOperation = "deepseek.fim_completions"
+		enriched.AuditPath = "/beta/completions"
+	default:
+		if strings.TrimSpace(enriched.AuditPath) == "" && normalizedEndpoint != "" {
+			enriched.AuditPath = "/p/deepseek/" + normalizedEndpoint
+		}
+	}
+	return &enriched
+}

--- a/internal/providers/deepseek/passthrough_semantics_test.go
+++ b/internal/providers/deepseek/passthrough_semantics_test.go
@@ -1,0 +1,77 @@
+package deepseek
+
+import (
+	"testing"
+
+	"gomodel/internal/core"
+)
+
+func TestPassthroughSemanticEnricher_ProviderType(t *testing.T) {
+	e := passthroughSemanticEnricher{}
+	if got := e.ProviderType(); got != "deepseek" {
+		t.Fatalf("ProviderType() = %q, want deepseek", got)
+	}
+}
+
+func TestPassthroughSemanticEnricher_NilInfo_ReturnsNil(t *testing.T) {
+	e := passthroughSemanticEnricher{}
+	if got := e.Enrich(nil, nil, nil); got != nil {
+		t.Fatalf("Enrich(nil) = %v, want nil", got)
+	}
+}
+
+func TestPassthroughSemanticEnricher_Enrich(t *testing.T) {
+	e := passthroughSemanticEnricher{}
+
+	tests := []struct {
+		name               string
+		rawEndpoint        string
+		normalizedEndpoint string
+		wantSemanticOp     string
+		wantAuditPath      string
+	}{
+		{
+			name:           "chat completions",
+			rawEndpoint:    "/chat/completions",
+			wantSemanticOp: "deepseek.chat_completions",
+			wantAuditPath:  "/v1/chat/completions",
+		},
+		{
+			name:           "FIM completions",
+			rawEndpoint:    "/beta/completions",
+			wantSemanticOp: "deepseek.fim_completions",
+			wantAuditPath:  "/beta/completions",
+		},
+		{
+			name:          "unknown endpoint gets prefixed audit path",
+			rawEndpoint:   "/v1/models",
+			wantAuditPath: "/p/deepseek/v1/models",
+		},
+		{
+			name:               "NormalizedEndpoint takes precedence over RawEndpoint",
+			rawEndpoint:        "/ignored",
+			normalizedEndpoint: "/chat/completions",
+			wantSemanticOp:     "deepseek.chat_completions",
+			wantAuditPath:      "/v1/chat/completions",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			info := &core.PassthroughRouteInfo{
+				RawEndpoint:        tc.rawEndpoint,
+				NormalizedEndpoint: tc.normalizedEndpoint,
+			}
+			got := e.Enrich(nil, nil, info)
+			if got == nil {
+				t.Fatal("Enrich() returned nil, want enriched info")
+			}
+			if tc.wantSemanticOp != "" && got.SemanticOperation != tc.wantSemanticOp {
+				t.Errorf("SemanticOperation = %q, want %q", got.SemanticOperation, tc.wantSemanticOp)
+			}
+			if got.AuditPath != tc.wantAuditPath {
+				t.Errorf("AuditPath = %q, want %q", got.AuditPath, tc.wantAuditPath)
+			}
+		})
+	}
+}

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -6701,7 +6701,7 @@ func TestProviderPassthrough_RejectsUnsupportedProvider(t *testing.T) {
 	if !strings.Contains(rec.Body.String(), `provider passthrough for \"groq\" is not enabled`) {
 		t.Fatalf("unexpected error body: %s", rec.Body.String())
 	}
-	if !strings.Contains(rec.Body.String(), "anthropic, openai, openrouter, vllm, zai") {
+	if !strings.Contains(rec.Body.String(), "anthropic, deepseek, openai, openrouter, vllm, zai") {
 		t.Fatalf("unexpected error body: %s", rec.Body.String())
 	}
 }

--- a/internal/server/passthrough_support.go
+++ b/internal/server/passthrough_support.go
@@ -16,7 +16,7 @@ import (
 	"gomodel/internal/usage"
 )
 
-var defaultEnabledPassthroughProviders = []string{"openai", "anthropic", "openrouter", "zai", "vllm"}
+var defaultEnabledPassthroughProviders = []string{"openai", "anthropic", "openrouter", "zai", "vllm", "deepseek"}
 
 func (h *Handler) setEnabledPassthroughProviders(providerTypes []string) {
 	h.enabledPassthroughProviders = normalizeEnabledPassthroughProviders(providerTypes)


### PR DESCRIPTION
## Summary

- Implement `Passthrough()` on the DeepSeek provider, enabling `/p/deepseek/...` routes including FIM at `/beta/completions`
- Add `PassthroughSemanticEnricher` for audit-path tagging (`deepseek.chat_completions`, `deepseek.fim_completions`), registered in `Registration`
- Add `deepseek` to the default `EnabledPassthroughProviders` list across all five locations: `config.go`, `passthrough_support.go`, `config.example.yaml`, `README.md`, `docs/features/passthrough-api.mdx`
- Fix: add nil guards to `Responses()` and `StreamResponses()` for consistency with `CompatibleProvider`
- Docs: document intentional reasoning field deletion in `adaptChatRequest`

## Why

DeepSeek was the only provider with first-class chat support but no passthrough. This blocked access to DeepSeek-native endpoints (notably `/beta/completions` for fill-in-the-middle/FIM) without direct API calls. With this PR, `/p/deepseek/<any-endpoint>` works out of the box.

## Test Plan

- [ ] `go test ./internal/providers/deepseek/... -race` — passthrough auth, header forwarding, 4xx status preservation, nil request, interface compliance, enricher (all cases including `NormalizedEndpoint` precedence)
- [ ] `go test ./config/... -race` — default provider list assertions updated
- [ ] `go test ./internal/server/... -race` — `TestProviderPassthrough_RejectsUnsupportedProvider` updated for new default list
- [ ] `go test ./internal/providers/... -race` — all 16 provider packages pass
- [ ] `go test $(go list ./... | grep -v tests/perf) -race` — full suite green (perf tests are pre-existing failures unrelated to this change)

## Notes

- `tests/perf` failures (`TestHotPathPerfGuard`) are pre-existing on `main` and unrelated to this change (confirmed by running against unmodified code)
- DeepSeek has no native embeddings, files, or batches API — those remain correctly stubbed/absent
- Unknown `reasoning_effort` values continue to pass through (existing intentional behavior, covered by `TestNormalizeReasoningEffort`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DeepSeek passthrough support added, enabling direct forwarding of passthrough requests to DeepSeek.

* **Documentation**
  * Docs and config examples updated to list DeepSeek among enabled passthrough providers by default.

* **Bug Fixes / Behavior**
  * Server default passthrough provider defaults were adjusted (affects whether DeepSeek is enabled without config).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ENTERPILOT/GoModel/pull/314)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->