### PR TITLE
build(go): upgrade to go 1.26.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.26.2
+          go-version: 1.26.3
           cache: true
 
       - name: Run GoReleaser

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.26.2"
+  GO_VERSION: "1.26.3"
 
 # Restrict token permissions to minimum required
 permissions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage — run on the build host's native arch for speed, cross-compile for target
-FROM --platform=$BUILDPLATFORM golang:1.26.2-alpine3.23 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.3-alpine3.23 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ provider `vertex_us`. Vertex requires `VERTEX_PROJECT` and `VERTEX_LOCATION`;
 
 ### Running from Source
 
-**Prerequisites:** Go 1.26.2+
+**Prerequisites:** Go 1.26.3+
 
 1. Create a `.env` file:
 

--- a/docs/2026-03-23_benchmark_scripts/README.md
+++ b/docs/2026-03-23_benchmark_scripts/README.md
@@ -28,7 +28,7 @@ gateway in the middle.
 
 ## Prerequisites
 
-- Go 1.26.2+
+- Go 1.26.3+
 - Python 3.10+
 - `hey`
 - `litellm`

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -207,9 +207,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.3"
 
       # Unit + E2E (no external dependencies)
       - run: make test-all

--- a/docs/about/benchmarks.mdx
+++ b/docs/about/benchmarks.mdx
@@ -77,7 +77,7 @@ All the tooling used in the published benchmark is available in this repository.
 
 ### Prerequisites
 
-- Go 1.26.2+
+- Go 1.26.3+
 - Python 3.10+ with `matplotlib` and `numpy`
 - `jq`, `curl`
 - A Groq API key (or any OpenAI-compatible provider — adjust the script)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gomodel
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/andybalholm/brotli v1.2.1


### PR DESCRIPTION
## Summary
- Upgrade project Go version pins from 1.26.2 to 1.26.3.
- Update Docker builder image, GitHub Actions setup-go versions, and docs prerequisites to match.

## Validation
- go mod tidy
- go test ./...
- commit hook: make test-race, dashboard JavaScript unit tests, perf guard, make lint, mint validate

## Notes
- Docker build was intentionally not run yet; it remains a later follow-up check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain to version 1.26.3 across CI/CD workflows, Docker build configurations, module definitions, and related documentation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ENTERPILOT/GoModel/pull/315)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->