### PR TITLE
fix(auditlog): reconstruct streamed tool calls

### DIFF
--- a/internal/auditlog/auditlog_test.go
+++ b/internal/auditlog/auditlog_test.go
@@ -1159,6 +1159,23 @@ func TestStreamResponseBuilderChatCapturesTrailingUsageChunk(t *testing.T) {
 	}
 }
 
+func TestAppendLimitedStreamTextMarksTruncatedWhenBudgetAlreadyFull(t *testing.T) {
+	builder := &streamResponseBuilder{contentLen: MaxContentCapture}
+	var dst strings.Builder
+
+	appendLimitedStreamText(builder, &dst, "x")
+
+	if !builder.truncated {
+		t.Fatal("truncated = false, want true when a non-empty chunk arrives after the capture budget is full")
+	}
+	if got := dst.String(); got != "" {
+		t.Fatalf("captured text = %q, want empty", got)
+	}
+	if got := builder.contentLen; got != MaxContentCapture {
+		t.Fatalf("contentLen = %d, want %d", got, MaxContentCapture)
+	}
+}
+
 func buildChatStreamResponseForTest(t *testing.T, events ...string) map[string]any {
 	t.Helper()
 

--- a/internal/auditlog/auditlog_test.go
+++ b/internal/auditlog/auditlog_test.go
@@ -1071,6 +1071,73 @@ func TestStreamResponseBuilderChatParallelToolCalls(t *testing.T) {
 	}
 }
 
+func TestStreamResponseBuilderChatSparseChoiceFallbackDoesNotCollide(t *testing.T) {
+	response := buildChatStreamResponseForTest(t,
+		`{"id":"chatcmpl-sparse-choice","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","content":"zero"},"finish_reason":"stop"},{"index":2,"delta":{"role":"assistant","content":"two"},"finish_reason":"stop"}]}`,
+		`{"id":"chatcmpl-sparse-choice","model":"gpt-4o-mini","choices":[{"delta":{"role":"assistant","content":"synthetic"},"finish_reason":"stop"}]}`,
+	)
+
+	choices := chatStreamChoicesForTest(t, response)
+	if len(choices) != 3 {
+		t.Fatalf("len(choices) = %d, want 3", len(choices))
+	}
+	for i, want := range []int{0, 2, 3} {
+		if got := choices[i]["index"]; got != want {
+			t.Fatalf("choices[%d].index = %#v, want %d", i, got, want)
+		}
+	}
+	if got := chatStreamMessageForTest(t, choices[1])["content"]; got != "two" {
+		t.Fatalf("choices[1].message.content = %#v, want two", got)
+	}
+	if got := chatStreamMessageForTest(t, choices[2])["content"]; got != "synthetic" {
+		t.Fatalf("choices[2].message.content = %#v, want synthetic", got)
+	}
+}
+
+func TestStreamResponseBuilderChatSparseToolCallFallbackDoesNotCollide(t *testing.T) {
+	response := buildChatStreamResponseForTest(t,
+		`{"id":"chatcmpl-sparse-tools","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_a","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Paris\"}"}},{"index":2,"id":"call_c","type":"function","function":{"name":"lookup_time","arguments":"{\"city\":\"Warsaw\"}"}}]},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-sparse-tools","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"tool_calls":[{"id":"call_synthetic","type":"function","function":{"name":"lookup_air","arguments":"{\"city\":\"Berlin\"}"}}]},"finish_reason":"tool_calls"}]}`,
+	)
+
+	message := chatStreamMessageForTest(t, firstChatStreamChoiceForTest(t, response))
+	toolCalls, ok := message["tool_calls"].([]map[string]any)
+	if !ok || len(toolCalls) != 3 {
+		t.Fatalf("tool_calls = %#v, want three tool calls", message["tool_calls"])
+	}
+	for i, want := range []string{"call_a", "call_c", "call_synthetic"} {
+		if got := toolCalls[i]["id"]; got != want {
+			t.Fatalf("tool_calls[%d].id = %#v, want %s", i, got, want)
+		}
+	}
+	if got := chatStreamFunctionForTest(t, toolCalls[1])["arguments"]; got != `{"city":"Warsaw"}` {
+		t.Fatalf("tool_calls[1].arguments = %#v, want Warsaw JSON", got)
+	}
+	if got := chatStreamFunctionForTest(t, toolCalls[2])["arguments"]; got != `{"city":"Berlin"}` {
+		t.Fatalf("tool_calls[2].arguments = %#v, want Berlin JSON", got)
+	}
+}
+
+func TestStreamResponseBuilderChatSkipsToolCallWithoutFunctionDelta(t *testing.T) {
+	response := buildChatStreamResponseForTest(t,
+		`{"id":"chatcmpl-orphan-tool","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_keep","type":"function"},{"index":1,"id":"call_drop","type":"function"}]},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-orphan-tool","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"get_weather","arguments":"{\"city\":\"Paris\"}"}}]},"finish_reason":"tool_calls"}]}`,
+	)
+
+	message := chatStreamMessageForTest(t, firstChatStreamChoiceForTest(t, response))
+	toolCall := firstChatStreamToolCallForTest(t, message)
+	if got := toolCall["id"]; got != "call_keep" {
+		t.Fatalf("tool_call.id = %#v, want call_keep", got)
+	}
+	function := chatStreamFunctionForTest(t, toolCall)
+	if got := function["name"]; got != "get_weather" {
+		t.Fatalf("function.name = %#v, want get_weather", got)
+	}
+	if got := function["arguments"]; got != `{"city":"Paris"}` {
+		t.Fatalf("function.arguments = %#v, want Paris JSON", got)
+	}
+}
+
 func TestStreamResponseBuilderChatCapturesTrailingUsageChunk(t *testing.T) {
 	response := buildChatStreamResponseForTest(t,
 		`{"id":"chatcmpl-usage","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"},"finish_reason":"stop"}]}`,
@@ -1106,11 +1173,21 @@ func buildChatStreamResponseForTest(t *testing.T, events ...string) map[string]a
 	return builder.buildChatCompletionResponse()
 }
 
-func firstChatStreamChoiceForTest(t *testing.T, response map[string]any) map[string]any {
+func chatStreamChoicesForTest(t *testing.T, response map[string]any) []map[string]any {
 	t.Helper()
 
 	choices, ok := response["choices"].([]map[string]any)
-	if !ok || len(choices) != 1 {
+	if !ok {
+		t.Fatalf("choices = %#v, want choice slice", response["choices"])
+	}
+	return choices
+}
+
+func firstChatStreamChoiceForTest(t *testing.T, response map[string]any) map[string]any {
+	t.Helper()
+
+	choices := chatStreamChoicesForTest(t, response)
+	if len(choices) != 1 {
 		t.Fatalf("choices = %#v, want one choice", response["choices"])
 	}
 	return choices[0]

--- a/internal/auditlog/auditlog_test.go
+++ b/internal/auditlog/auditlog_test.go
@@ -978,6 +978,174 @@ data: [DONE]
 	}
 }
 
+func TestStreamResponseBuilderChatTextOnly(t *testing.T) {
+	response := buildChatStreamResponseForTest(t,
+		`{"id":"chatcmpl-text","model":"gpt-4o-mini","created":123,"choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-text","model":"gpt-4o-mini","created":123,"choices":[{"index":0,"delta":{"content":" world"},"finish_reason":"stop"}]}`,
+	)
+
+	choice := firstChatStreamChoiceForTest(t, response)
+	message := chatStreamMessageForTest(t, choice)
+	if got := message["content"]; got != "Hello world" {
+		t.Fatalf("message.content = %#v, want Hello world", got)
+	}
+	if _, ok := message["tool_calls"]; ok {
+		t.Fatalf("message.tool_calls present for text-only stream: %#v", message["tool_calls"])
+	}
+	if got := choice["finish_reason"]; got != "stop" {
+		t.Fatalf("finish_reason = %#v, want stop", got)
+	}
+}
+
+func TestStreamResponseBuilderChatToolCallOnly(t *testing.T) {
+	response := buildChatStreamResponseForTest(t,
+		`{"id":"chatcmpl-tools","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"get_weather","arguments":""}}]},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-tools","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"city\""}}]},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-tools","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":":\"Paris\"}"}}]},"finish_reason":"tool_calls"}]}`,
+	)
+
+	choice := firstChatStreamChoiceForTest(t, response)
+	message := chatStreamMessageForTest(t, choice)
+	if got := message["content"]; got != nil {
+		t.Fatalf("message.content = %#v, want nil", got)
+	}
+	toolCall := firstChatStreamToolCallForTest(t, message)
+	if _, ok := toolCall["index"]; ok {
+		t.Fatalf("final message tool_call contains streaming index: %#v", toolCall)
+	}
+	if got := toolCall["id"]; got != "call_1" {
+		t.Fatalf("tool_call.id = %#v, want call_1", got)
+	}
+	function := chatStreamFunctionForTest(t, toolCall)
+	if got := function["name"]; got != "get_weather" {
+		t.Fatalf("function.name = %#v, want get_weather", got)
+	}
+	if got := function["arguments"]; got != `{"city":"Paris"}` {
+		t.Fatalf("function.arguments = %#v, want Paris JSON", got)
+	}
+	if got := choice["finish_reason"]; got != "tool_calls" {
+		t.Fatalf("finish_reason = %#v, want tool_calls", got)
+	}
+}
+
+func TestStreamResponseBuilderChatInterleavesTextAndToolCall(t *testing.T) {
+	response := buildChatStreamResponseForTest(t,
+		`{"id":"chatcmpl-mixed","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","content":"Checking weather.\n"},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-mixed","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\""}}]},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-mixed","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"content":"Calling tool.","tool_calls":[{"index":0,"function":{"arguments":"Paris\"}"}}]},"finish_reason":"tool_calls"}]}`,
+	)
+
+	choice := firstChatStreamChoiceForTest(t, response)
+	message := chatStreamMessageForTest(t, choice)
+	if got := message["content"]; got != "Checking weather.\nCalling tool." {
+		t.Fatalf("message.content = %#v, want interleaved text", got)
+	}
+	function := chatStreamFunctionForTest(t, firstChatStreamToolCallForTest(t, message))
+	if got := function["arguments"]; got != `{"city":"Paris"}` {
+		t.Fatalf("function.arguments = %#v, want Paris JSON", got)
+	}
+}
+
+func TestStreamResponseBuilderChatParallelToolCalls(t *testing.T) {
+	response := buildChatStreamResponseForTest(t,
+		`{"id":"chatcmpl-parallel","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":1,"id":"call_b","type":"function","function":{"name":"lookup_time","arguments":"{\"city\":\""}},{"index":0,"id":"call_a","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\""}}]},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-parallel","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Paris\"}"}},{"index":1,"function":{"arguments":"Warsaw\"}"}}]},"finish_reason":"tool_calls"}]}`,
+	)
+
+	message := chatStreamMessageForTest(t, firstChatStreamChoiceForTest(t, response))
+	toolCalls, ok := message["tool_calls"].([]map[string]any)
+	if !ok || len(toolCalls) != 2 {
+		t.Fatalf("tool_calls = %#v, want two tool calls", message["tool_calls"])
+	}
+	if got := toolCalls[0]["id"]; got != "call_a" {
+		t.Fatalf("tool_calls[0].id = %#v, want call_a", got)
+	}
+	if got := toolCalls[1]["id"]; got != "call_b" {
+		t.Fatalf("tool_calls[1].id = %#v, want call_b", got)
+	}
+	if got := chatStreamFunctionForTest(t, toolCalls[0])["arguments"]; got != `{"city":"Paris"}` {
+		t.Fatalf("tool_calls[0].arguments = %#v, want Paris JSON", got)
+	}
+	if got := chatStreamFunctionForTest(t, toolCalls[1])["arguments"]; got != `{"city":"Warsaw"}` {
+		t.Fatalf("tool_calls[1].arguments = %#v, want Warsaw JSON", got)
+	}
+}
+
+func TestStreamResponseBuilderChatCapturesTrailingUsageChunk(t *testing.T) {
+	response := buildChatStreamResponseForTest(t,
+		`{"id":"chatcmpl-usage","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"},"finish_reason":"stop"}]}`,
+		`{"id":"chatcmpl-usage","model":"gpt-4o-mini","choices":[],"usage":{"prompt_tokens":7,"completion_tokens":2,"total_tokens":9}}`,
+	)
+
+	usage, ok := response["usage"].(map[string]any)
+	if !ok {
+		t.Fatalf("usage = %#v, want object", response["usage"])
+	}
+	if got := usage["prompt_tokens"]; got != float64(7) {
+		t.Fatalf("usage.prompt_tokens = %#v, want 7", got)
+	}
+	if got := usage["completion_tokens"]; got != float64(2) {
+		t.Fatalf("usage.completion_tokens = %#v, want 2", got)
+	}
+	if got := usage["total_tokens"]; got != float64(9) {
+		t.Fatalf("usage.total_tokens = %#v, want 9", got)
+	}
+}
+
+func buildChatStreamResponseForTest(t *testing.T, events ...string) map[string]any {
+	t.Helper()
+
+	builder := &streamResponseBuilder{}
+	for _, raw := range events {
+		var event map[string]any
+		if err := json.Unmarshal([]byte(raw), &event); err != nil {
+			t.Fatalf("failed to unmarshal event %q: %v", raw, err)
+		}
+		parseChatCompletionEvent(builder, event)
+	}
+	return builder.buildChatCompletionResponse()
+}
+
+func firstChatStreamChoiceForTest(t *testing.T, response map[string]any) map[string]any {
+	t.Helper()
+
+	choices, ok := response["choices"].([]map[string]any)
+	if !ok || len(choices) != 1 {
+		t.Fatalf("choices = %#v, want one choice", response["choices"])
+	}
+	return choices[0]
+}
+
+func chatStreamMessageForTest(t *testing.T, choice map[string]any) map[string]any {
+	t.Helper()
+
+	message, ok := choice["message"].(map[string]any)
+	if !ok {
+		t.Fatalf("message = %#v, want object", choice["message"])
+	}
+	return message
+}
+
+func firstChatStreamToolCallForTest(t *testing.T, message map[string]any) map[string]any {
+	t.Helper()
+
+	toolCalls, ok := message["tool_calls"].([]map[string]any)
+	if !ok || len(toolCalls) != 1 {
+		t.Fatalf("tool_calls = %#v, want one tool call", message["tool_calls"])
+	}
+	return toolCalls[0]
+}
+
+func chatStreamFunctionForTest(t *testing.T, toolCall map[string]any) map[string]any {
+	t.Helper()
+
+	function, ok := toolCall["function"].(map[string]any)
+	if !ok {
+		t.Fatalf("tool_call.function = %#v, want object", toolCall["function"])
+	}
+	return function
+}
+
 func TestNewStreamLogObserverNilInputs(t *testing.T) {
 	if observer := NewStreamLogObserver(nil, &LogEntry{}, "/v1/chat/completions"); observer != nil {
 		t.Error("expected nil observer with nil logger")

--- a/internal/auditlog/stream_observer.go
+++ b/internal/auditlog/stream_observer.go
@@ -314,11 +314,15 @@ func appendStreamContent(builder *streamResponseBuilder, content string) {
 }
 
 func appendLimitedStreamText(builder *streamResponseBuilder, dst *strings.Builder, content string) {
-	if builder == nil || dst == nil || content == "" || builder.truncated || builder.contentLen >= MaxContentCapture {
+	if builder == nil || dst == nil || content == "" || builder.truncated {
 		return
 	}
 
 	remaining := MaxContentCapture - builder.contentLen
+	if remaining <= 0 {
+		builder.truncated = true
+		return
+	}
 	if len(content) > remaining {
 		content = content[:remaining]
 		builder.truncated = true

--- a/internal/auditlog/stream_observer.go
+++ b/internal/auditlog/stream_observer.go
@@ -209,6 +209,10 @@ func parseChatCompletionEvent(builder *streamResponseBuilder, event map[string]a
 }
 
 func defaultChatChoiceIndex(states map[int]*streamChatChoiceState) int {
+	return defaultStreamStateIndex(states)
+}
+
+func defaultStreamStateIndex[T any](states map[int]T) int {
 	if len(states) == 1 {
 		for index := range states {
 			return index
@@ -270,18 +274,7 @@ func appendChatToolCalls(builder *streamResponseBuilder, state *streamChatChoice
 }
 
 func defaultToolCallIndex(states map[int]*streamChatToolCallState) int {
-	if len(states) == 1 {
-		for index := range states {
-			return index
-		}
-	}
-	maxIndex := -1
-	for index := range states {
-		if index > maxIndex {
-			maxIndex = index
-		}
-	}
-	return maxIndex + 1
+	return defaultStreamStateIndex(states)
 }
 
 func parseResponsesAPIEvent(builder *streamResponseBuilder, event map[string]any) {
@@ -317,7 +310,7 @@ func appendStreamContent(builder *streamResponseBuilder, content string) {
 	if builder == nil {
 		return
 	}
-	appendLimitedStreamText(builder, &builder.Content, content)
+	appendLimitedStreamText(builder, &builder.OutputText, content)
 }
 
 func appendLimitedStreamText(builder *streamResponseBuilder, dst *strings.Builder, content string) {

--- a/internal/auditlog/stream_observer.go
+++ b/internal/auditlog/stream_observer.go
@@ -214,7 +214,13 @@ func defaultChatChoiceIndex(states map[int]*streamChatChoiceState) int {
 			return index
 		}
 	}
-	return len(states)
+	maxIndex := -1
+	for index := range states {
+		if index > maxIndex {
+			maxIndex = index
+		}
+	}
+	return maxIndex + 1
 }
 
 func appendChatContent(builder *streamResponseBuilder, state *streamChatChoiceState, content string) {
@@ -253,6 +259,7 @@ func appendChatToolCalls(builder *streamResponseBuilder, state *streamChatChoice
 		if !ok {
 			continue
 		}
+		toolState.hasFunction = true
 		if name, ok := function["name"].(string); ok && name != "" && toolState.Name == "" {
 			toolState.Name = name
 		}
@@ -268,7 +275,13 @@ func defaultToolCallIndex(states map[int]*streamChatToolCallState) int {
 			return index
 		}
 	}
-	return len(states)
+	maxIndex := -1
+	for index := range states {
+		if index > maxIndex {
+			maxIndex = index
+		}
+	}
+	return maxIndex + 1
 }
 
 func parseResponsesAPIEvent(builder *streamResponseBuilder, event map[string]any) {

--- a/internal/auditlog/stream_observer.go
+++ b/internal/auditlog/stream_observer.go
@@ -161,34 +161,114 @@ func parseChatCompletionEvent(builder *streamResponseBuilder, event map[string]a
 		return
 	}
 
-	if builder.ID == "" {
-		if id, ok := event["id"].(string); ok {
-			builder.ID = id
-		}
-		if model, ok := event["model"].(string); ok {
-			builder.Model = model
-		}
-		if created, ok := event["created"].(float64); ok {
-			builder.Created = int64(created)
-		}
+	if id, ok := event["id"].(string); ok && id != "" {
+		builder.ID = id
+	}
+	if model, ok := event["model"].(string); ok && model != "" {
+		builder.Model = model
+	}
+	if provider, ok := event["provider"].(string); ok && provider != "" {
+		builder.Provider = provider
+	}
+	if fingerprint, ok := event["system_fingerprint"].(string); ok && fingerprint != "" {
+		builder.SystemFingerprint = fingerprint
+	}
+	if created, ok := jsonNumberToInt64(event["created"]); ok {
+		builder.Created = created
+	}
+	if usage, ok := event["usage"].(map[string]any); ok {
+		builder.Usage = copyAnyMap(usage)
 	}
 
 	if choices, ok := event["choices"].([]any); ok && len(choices) > 0 {
-		if choice, ok := choices[0].(map[string]any); ok {
+		for _, choiceAny := range choices {
+			choice, ok := choiceAny.(map[string]any)
+			if !ok {
+				continue
+			}
+			index, ok := jsonNumberToInt(choice["index"])
+			if !ok {
+				index = defaultChatChoiceIndex(builder.Choices)
+			}
+			state := builder.chatChoice(index)
 			if fr, ok := choice["finish_reason"].(string); ok && fr != "" {
-				builder.FinishReason = fr
+				state.FinishReason = fr
 			}
 
 			if delta, ok := choice["delta"].(map[string]any); ok {
 				if role, ok := delta["role"].(string); ok {
-					builder.Role = role
+					state.Role = role
 				}
 				if content, ok := delta["content"].(string); ok && content != "" {
-					appendStreamContent(builder, content)
+					appendChatContent(builder, state, content)
 				}
+				appendChatToolCalls(builder, state, delta)
 			}
 		}
 	}
+}
+
+func defaultChatChoiceIndex(states map[int]*streamChatChoiceState) int {
+	if len(states) == 1 {
+		for index := range states {
+			return index
+		}
+	}
+	return len(states)
+}
+
+func appendChatContent(builder *streamResponseBuilder, state *streamChatChoiceState, content string) {
+	if state == nil {
+		return
+	}
+	appendLimitedStreamText(builder, &state.Content, content)
+}
+
+func appendChatToolCalls(builder *streamResponseBuilder, state *streamChatChoiceState, delta map[string]any) {
+	if state == nil || delta == nil {
+		return
+	}
+
+	toolCalls, ok := delta["tool_calls"].([]any)
+	if !ok {
+		return
+	}
+	for _, toolAny := range toolCalls {
+		toolMap, ok := toolAny.(map[string]any)
+		if !ok {
+			continue
+		}
+		toolIndex, ok := jsonNumberToInt(toolMap["index"])
+		if !ok {
+			toolIndex = defaultToolCallIndex(state.ToolCalls)
+		}
+		toolState := state.toolCall(toolIndex)
+		if id, ok := toolMap["id"].(string); ok && id != "" && toolState.ID == "" {
+			toolState.ID = id
+		}
+		if typ, ok := toolMap["type"].(string); ok && typ != "" && toolState.Type == "" {
+			toolState.Type = typ
+		}
+		function, ok := toolMap["function"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if name, ok := function["name"].(string); ok && name != "" && toolState.Name == "" {
+			toolState.Name = name
+		}
+		if arguments, ok := function["arguments"].(string); ok && arguments != "" {
+			appendLimitedStreamText(builder, &toolState.Arguments, arguments)
+		}
+	}
+}
+
+func defaultToolCallIndex(states map[int]*streamChatToolCallState) int {
+	if len(states) == 1 {
+		for index := range states {
+			return index
+		}
+	}
+	return len(states)
 }
 
 func parseResponsesAPIEvent(builder *streamResponseBuilder, event map[string]any) {
@@ -221,7 +301,14 @@ func parseResponsesAPIEvent(builder *streamResponseBuilder, event map[string]any
 }
 
 func appendStreamContent(builder *streamResponseBuilder, content string) {
-	if builder == nil || builder.truncated || builder.contentLen >= MaxContentCapture {
+	if builder == nil {
+		return
+	}
+	appendLimitedStreamText(builder, &builder.Content, content)
+}
+
+func appendLimitedStreamText(builder *streamResponseBuilder, dst *strings.Builder, content string) {
+	if builder == nil || dst == nil || content == "" || builder.truncated || builder.contentLen >= MaxContentCapture {
 		return
 	}
 
@@ -230,6 +317,6 @@ func appendStreamContent(builder *streamResponseBuilder, content string) {
 		content = content[:remaining]
 		builder.truncated = true
 	}
-	builder.Content.WriteString(content)
+	dst.WriteString(content)
 	builder.contentLen += len(content)
 }

--- a/internal/auditlog/stream_wrapper.go
+++ b/internal/auditlog/stream_wrapper.go
@@ -2,6 +2,7 @@ package auditlog
 
 import (
 	"maps"
+	"sort"
 	"strings"
 )
 
@@ -10,12 +11,14 @@ import (
 // streamResponseBuilder accumulates data from SSE events to reconstruct a response
 type streamResponseBuilder struct {
 	// ChatCompletion fields
-	ID           string
-	Model        string
-	Created      int64
-	Role         string
-	FinishReason string
-	Content      strings.Builder // accumulated delta content
+	ID                string
+	Model             string
+	Provider          string
+	SystemFingerprint string
+	Created           int64
+	Usage             map[string]any
+	Choices           map[int]*streamChatChoiceState
+	Content           strings.Builder // accumulated Responses API output text
 
 	// Responses API fields
 	IsResponsesAPI bool
@@ -28,29 +31,144 @@ type streamResponseBuilder struct {
 	truncated  bool
 }
 
+type streamChatToolCallState struct {
+	ID        string
+	Type      string
+	Name      string
+	Arguments strings.Builder
+}
+
+type streamChatChoiceState struct {
+	Role         string
+	Content      strings.Builder
+	FinishReason string
+	ToolCalls    map[int]*streamChatToolCallState
+}
+
 // buildChatCompletionResponse constructs a ChatCompletion response from accumulated data
 func (b *streamResponseBuilder) buildChatCompletionResponse() map[string]any {
-	role := strings.TrimSpace(b.Role)
-	if role == "" {
-		role = "assistant"
-	}
+	choices := b.buildChatChoices()
 
-	return map[string]any{
+	response := map[string]any{
 		"id":      b.ID,
 		"object":  "chat.completion",
 		"model":   b.Model,
 		"created": b.Created,
-		"choices": []map[string]any{
+		"choices": choices,
+	}
+	if b.Provider != "" {
+		response["provider"] = b.Provider
+	}
+	if b.SystemFingerprint != "" {
+		response["system_fingerprint"] = b.SystemFingerprint
+	}
+	if b.Usage != nil {
+		response["usage"] = b.Usage
+	}
+	return response
+}
+
+func (b *streamResponseBuilder) buildChatChoices() []map[string]any {
+	if len(b.Choices) == 0 {
+		return []map[string]any{
 			{
 				"index": 0,
 				"message": map[string]any{
-					"role":    role,
-					"content": b.Content.String(),
+					"role":    "assistant",
+					"content": "",
 				},
-				"finish_reason": b.FinishReason,
+				"finish_reason": "",
 			},
-		},
+		}
 	}
+
+	indexes := make([]int, 0, len(b.Choices))
+	for index := range b.Choices {
+		indexes = append(indexes, index)
+	}
+	sort.Ints(indexes)
+
+	choices := make([]map[string]any, 0, len(indexes))
+	for _, index := range indexes {
+		state := b.Choices[index]
+		message := map[string]any{
+			"role": nonEmptyString(state.Role, "assistant"),
+		}
+
+		content := state.Content.String()
+		toolCalls := buildStreamChatToolCalls(state.ToolCalls)
+		switch {
+		case content != "":
+			message["content"] = content
+		case len(toolCalls) > 0:
+			message["content"] = nil
+		default:
+			message["content"] = ""
+		}
+		if len(toolCalls) > 0 {
+			message["tool_calls"] = toolCalls
+		}
+
+		choices = append(choices, map[string]any{
+			"index":         index,
+			"message":       message,
+			"finish_reason": state.FinishReason,
+		})
+	}
+
+	return choices
+}
+
+func buildStreamChatToolCalls(states map[int]*streamChatToolCallState) []map[string]any {
+	if len(states) == 0 {
+		return nil
+	}
+
+	indexes := make([]int, 0, len(states))
+	for index := range states {
+		indexes = append(indexes, index)
+	}
+	sort.Ints(indexes)
+
+	toolCalls := make([]map[string]any, 0, len(indexes))
+	for _, index := range indexes {
+		state := states[index]
+		toolCalls = append(toolCalls, map[string]any{
+			"id":   state.ID,
+			"type": nonEmptyString(state.Type, "function"),
+			"function": map[string]any{
+				"name":      state.Name,
+				"arguments": state.Arguments.String(),
+			},
+		})
+	}
+	return toolCalls
+}
+
+func (b *streamResponseBuilder) chatChoice(index int) *streamChatChoiceState {
+	if b.Choices == nil {
+		b.Choices = make(map[int]*streamChatChoiceState)
+	}
+	state, ok := b.Choices[index]
+	if ok {
+		return state
+	}
+	state = &streamChatChoiceState{ToolCalls: make(map[int]*streamChatToolCallState)}
+	b.Choices[index] = state
+	return state
+}
+
+func (c *streamChatChoiceState) toolCall(index int) *streamChatToolCallState {
+	if c.ToolCalls == nil {
+		c.ToolCalls = make(map[int]*streamChatToolCallState)
+	}
+	state, ok := c.ToolCalls[index]
+	if ok {
+		return state
+	}
+	state = &streamChatToolCallState{}
+	c.ToolCalls[index] = state
+	return state
 }
 
 // buildResponsesAPIResponse constructs a Responses API response from accumulated data
@@ -139,6 +257,47 @@ func copyMap(m map[string]string) map[string]string {
 	result := make(map[string]string, len(m))
 	maps.Copy(result, m)
 	return result
+}
+
+func copyAnyMap(m map[string]any) map[string]any {
+	if m == nil {
+		return nil
+	}
+	return maps.Clone(m)
+}
+
+func jsonNumberToInt(value any) (int, bool) {
+	switch v := value.(type) {
+	case float64:
+		return int(v), true
+	case int:
+		return v, true
+	case int64:
+		return int(v), true
+	default:
+		return 0, false
+	}
+}
+
+func jsonNumberToInt64(value any) (int64, bool) {
+	switch v := value.(type) {
+	case float64:
+		return int64(v), true
+	case int:
+		return int64(v), true
+	case int64:
+		return v, true
+	default:
+		return 0, false
+	}
+}
+
+func nonEmptyString(value, fallback string) string {
+	value = strings.TrimSpace(value)
+	if value != "" {
+		return value
+	}
+	return strings.TrimSpace(fallback)
 }
 
 // GetStreamEntryFromContext retrieves the log entry from Echo context for streaming.

--- a/internal/auditlog/stream_wrapper.go
+++ b/internal/auditlog/stream_wrapper.go
@@ -98,6 +98,10 @@ func (b *streamResponseBuilder) buildChatChoices() []map[string]any {
 
 		content := state.Content.String()
 		toolCalls := buildStreamChatToolCalls(state.ToolCalls)
+		// OpenAI chat messages distinguish tool-only output from an explicitly
+		// empty message: no state.Content.String() plus state.ToolCalls renders
+		// message["content"] as nil; no text and no buildStreamChatToolCalls(...)
+		// result renders message["content"] as "".
 		switch {
 		case content != "":
 			message["content"] = content

--- a/internal/auditlog/stream_wrapper.go
+++ b/internal/auditlog/stream_wrapper.go
@@ -32,10 +32,11 @@ type streamResponseBuilder struct {
 }
 
 type streamChatToolCallState struct {
-	ID        string
-	Type      string
-	Name      string
-	Arguments strings.Builder
+	ID          string
+	Type        string
+	Name        string
+	Arguments   strings.Builder
+	hasFunction bool
 }
 
 type streamChatChoiceState struct {
@@ -133,6 +134,9 @@ func buildStreamChatToolCalls(states map[int]*streamChatToolCallState) []map[str
 	toolCalls := make([]map[string]any, 0, len(indexes))
 	for _, index := range indexes {
 		state := states[index]
+		if !state.hasFunction {
+			continue
+		}
 		toolCalls = append(toolCalls, map[string]any{
 			"id":   state.ID,
 			"type": nonEmptyString(state.Type, "function"),

--- a/internal/auditlog/stream_wrapper.go
+++ b/internal/auditlog/stream_wrapper.go
@@ -18,13 +18,13 @@ type streamResponseBuilder struct {
 	Created           int64
 	Usage             map[string]any
 	Choices           map[int]*streamChatChoiceState
-	Content           strings.Builder // accumulated Responses API output text
 
 	// Responses API fields
 	IsResponsesAPI bool
 	ResponseID     string
 	CreatedAt      int64
 	Status         string
+	OutputText     strings.Builder
 
 	// Tracking
 	contentLen int // track content length to enforce limit
@@ -190,7 +190,7 @@ func (b *streamResponseBuilder) buildResponsesAPIResponse() map[string]any {
 				"content": []map[string]any{
 					{
 						"type": "output_text",
-						"text": b.Content.String(),
+						"text": b.OutputText.String(),
 					},
 				},
 			},


### PR DESCRIPTION
## Summary
- reconstruct streamed chat audit responses per choice instead of content-only
- accumulate streamed `delta.tool_calls` id/type/name and concatenated arguments
- preserve provider metadata and trailing usage in captured streaming response bodies

## Verification
- `go test ./internal/auditlog ./internal/streaming ./internal/responsecache`
- `go test ./...`
- commit hook: `make test-race`, `go mod tidy`, hot-path performance guard, `make lint`
- live Bedrock repro with `amazon.nova-micro-v1:0`: audit row stored `tool_calls[0]` as `get_weather` with `{"city":"Paris"}`, `finish_reason=tool_calls`, and usage total tokens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for streamed chat responses: text-only, tool-call-only, interleaved text/tool streams, parallel tool-call aggregation, sparse-index fallbacks, skipping incomplete tool calls, trailing usage capture, and truncation behavior when budget is exhausted.

* **Improvements**
  * Streaming response builder now emits richer multi-choice chat outputs with preserved metadata, deterministic tool-call ordering, robust handling of streamed tool-call arguments, and improved output-text aggregation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ENTERPILOT/GoModel/pull/317)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->