### PR TITLE
fix(batches): resolve providers for input file batches

### DIFF
--- a/internal/aliases/provider.go
+++ b/internal/aliases/provider.go
@@ -178,6 +178,15 @@ func (p *Provider) NativeFileProviderTypes() []string {
 	return nil
 }
 
+// NativeBatchProviderTypes delegates provider capability inventory to the inner
+// provider when available.
+func (p *Provider) NativeBatchProviderTypes() []string {
+	if typed, ok := p.inner.(core.NativeBatchProviderTypeLister); ok {
+		return typed.NativeBatchProviderTypes()
+	}
+	return nil
+}
+
 // NativeResponseProviderTypes delegates provider capability inventory to the
 // inner provider when available.
 func (p *Provider) NativeResponseProviderTypes() []string {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -24,6 +24,7 @@ import (
 	"gomodel/internal/budget"
 	"gomodel/internal/core"
 	"gomodel/internal/fallback"
+	"gomodel/internal/filestore"
 	"gomodel/internal/guardrails"
 	"gomodel/internal/modeloverrides"
 	"gomodel/internal/pricingoverrides"
@@ -44,6 +45,7 @@ type App struct {
 	usage            *usage.Result
 	budgets          *budget.Result
 	batch            *batch.Result
+	fileStore        *filestore.Result
 	aliases          *aliases.Result
 	modelOverrides   *modeloverrides.Result
 	pricingOverrides *pricingoverrides.Result
@@ -186,6 +188,23 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 	}
 	app.batch = batchResult
 
+	// Initialize file provider mapping storage for OpenAI-compatible Files/Batches workflows.
+	var fileStoreResult *filestore.Result
+	sharedFileStorage := firstSharedStorage(auditResult.Storage, usageResult.Storage, batchResult.Storage)
+	if sharedFileStorage != nil {
+		fileStoreResult, err = filestore.NewWithSharedStorage(ctx, sharedFileStorage)
+	} else {
+		fileStoreResult, err = filestore.New(ctx, appCfg)
+	}
+	if err != nil {
+		closeErr := errors.Join(app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		if closeErr != nil {
+			return nil, fmt.Errorf("failed to initialize file mapping storage: %w (also: close error: %v)", err, closeErr)
+		}
+		return nil, fmt.Errorf("failed to initialize file mapping storage: %w", err)
+	}
+	app.fileStore = fileStoreResult
+
 	// Initialize aliases using shared storage when already available.
 	var aliasResult *aliases.Result
 	if auditResult.Storage != nil {
@@ -194,11 +213,13 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		aliasResult, err = aliases.NewWithSharedStorage(ctx, appCfg, usageResult.Storage, providerResult.Registry)
 	} else if batchResult.Storage != nil {
 		aliasResult, err = aliases.NewWithSharedStorage(ctx, appCfg, batchResult.Storage, providerResult.Registry)
+	} else if fileStoreResult.Storage != nil {
+		aliasResult, err = aliases.NewWithSharedStorage(ctx, appCfg, fileStoreResult.Storage, providerResult.Registry)
 	} else {
 		aliasResult, err = aliases.New(ctx, appCfg, providerResult.Registry)
 	}
 	if err != nil {
-		closeErr := errors.Join(app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		closeErr := errors.Join(app.fileStore.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
 		if closeErr != nil {
 			return nil, fmt.Errorf("failed to initialize aliases: %w (also: close error: %v)", err, closeErr)
 		}
@@ -208,14 +229,14 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 
 	var modelOverrideResult *modeloverrides.Result
 	if appCfg.Models.OverridesEnabled {
-		sharedModelOverrideStorage := firstSharedStorage(auditResult.Storage, usageResult.Storage, batchResult.Storage, aliasResult.Storage)
+		sharedModelOverrideStorage := firstSharedStorage(auditResult.Storage, usageResult.Storage, batchResult.Storage, fileStoreResult.Storage, aliasResult.Storage)
 		if sharedModelOverrideStorage != nil {
 			modelOverrideResult, err = modeloverrides.NewWithSharedStorage(ctx, appCfg, sharedModelOverrideStorage, providerResult.Registry)
 		} else {
 			modelOverrideResult, err = modeloverrides.New(ctx, appCfg, providerResult.Registry)
 		}
 		if err != nil {
-			closeErr := errors.Join(app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+			closeErr := errors.Join(app.aliases.Close(), app.fileStore.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
 			if closeErr != nil {
 				return nil, fmt.Errorf("failed to initialize model overrides: %w (also: close error: %v)", err, closeErr)
 			}
@@ -228,14 +249,14 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 	app.modelOverrides = modelOverrideResult
 
 	var pricingOverrideResult *pricingoverrides.Result
-	sharedPricingOverrideStorage := firstSharedStorage(auditResult.Storage, usageResult.Storage, batchResult.Storage, aliasResult.Storage, modelOverrideResult.Storage)
+	sharedPricingOverrideStorage := firstSharedStorage(auditResult.Storage, usageResult.Storage, batchResult.Storage, fileStoreResult.Storage, aliasResult.Storage, modelOverrideResult.Storage)
 	if sharedPricingOverrideStorage != nil {
 		pricingOverrideResult, err = pricingoverrides.NewWithSharedStorage(ctx, appCfg, sharedPricingOverrideStorage, providerResult.Registry, providerResult.Registry)
 	} else {
 		pricingOverrideResult, err = pricingoverrides.New(ctx, appCfg, providerResult.Registry, providerResult.Registry)
 	}
 	if err != nil {
-		closeErr := errors.Join(app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		closeErr := errors.Join(app.modelOverrides.Close(), app.aliases.Close(), app.fileStore.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
 		if closeErr != nil {
 			return nil, fmt.Errorf("failed to initialize model pricing overrides: %w (also: close error: %v)", err, closeErr)
 		}
@@ -255,14 +276,14 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 
 	// Initialize reusable guardrail definitions using shared storage when already available.
 	var guardrailResult *guardrails.Result
-	sharedGuardrailStorage := firstSharedStorage(auditResult.Storage, usageResult.Storage, batchResult.Storage, aliasResult.Storage, modelOverrideResult.Storage, pricingOverrideResult.Storage)
+	sharedGuardrailStorage := firstSharedStorage(auditResult.Storage, usageResult.Storage, batchResult.Storage, fileStoreResult.Storage, aliasResult.Storage, modelOverrideResult.Storage, pricingOverrideResult.Storage)
 	if sharedGuardrailStorage != nil {
 		guardrailResult, err = guardrails.NewWithSharedStorage(ctx, sharedGuardrailStorage, refreshInterval, guardrailExecutor)
 	} else {
 		guardrailResult, err = guardrails.New(ctx, appCfg, refreshInterval, guardrailExecutor)
 	}
 	if err != nil {
-		closeErr := errors.Join(app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		closeErr := errors.Join(app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.fileStore.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
 		if closeErr != nil {
 			return nil, fmt.Errorf("failed to initialize guardrails: %w (also: close error: %v)", err, closeErr)
 		}
@@ -272,14 +293,14 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 
 	seedGuardrails, err := configGuardrailDefinitions(appCfg.Guardrails)
 	if err != nil {
-		closeErr := errors.Join(app.guardrails.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		closeErr := errors.Join(app.guardrails.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.fileStore.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
 		if closeErr != nil {
 			return nil, fmt.Errorf("failed to prepare guardrail definitions: %w (also: close error: %v)", err, closeErr)
 		}
 		return nil, fmt.Errorf("failed to prepare guardrail definitions: %w", err)
 	}
 	if err := guardrailResult.Service.UpsertDefinitions(ctx, seedGuardrails); err != nil {
-		closeErr := errors.Join(app.guardrails.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		closeErr := errors.Join(app.guardrails.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.fileStore.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
 		if closeErr != nil {
 			return nil, fmt.Errorf("failed to upsert guardrails: %w (also: close error: %v)", err, closeErr)
 		}
@@ -294,7 +315,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 	featureCaps := runtimeWorkflowFeatureCaps(appCfg)
 
 	var workflowResult *workflows.Result
-	sharedWorkflowStorage := firstSharedStorage(auditResult.Storage, usageResult.Storage, batchResult.Storage, aliasResult.Storage, modelOverrideResult.Storage, pricingOverrideResult.Storage, guardrailResult.Storage)
+	sharedWorkflowStorage := firstSharedStorage(auditResult.Storage, usageResult.Storage, batchResult.Storage, fileStoreResult.Storage, aliasResult.Storage, modelOverrideResult.Storage, pricingOverrideResult.Storage, guardrailResult.Storage)
 	workflowCompiler := workflows.NewCompilerWithFeatureCaps(guardrailResult.Service, featureCaps)
 	if sharedWorkflowStorage != nil {
 		workflowResult, err = workflows.NewWithSharedStorage(ctx, sharedWorkflowStorage, workflowCompiler, refreshInterval)
@@ -302,7 +323,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		workflowResult, err = workflows.New(ctx, appCfg, workflowCompiler, refreshInterval)
 	}
 	if err != nil {
-		closeErr := errors.Join(app.guardrails.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		closeErr := errors.Join(app.guardrails.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.fileStore.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
 		if closeErr != nil {
 			return nil, fmt.Errorf("failed to initialize workflows: %w (also: close error: %v)", err, closeErr)
 		}
@@ -310,14 +331,14 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 	}
 	defaultWorkflow := defaultWorkflowInput(appCfg, guardrailResult.Service.Names(), seedGuardrails)
 	if err := workflowResult.Service.EnsureDefaultGlobal(ctx, defaultWorkflow); err != nil {
-		closeErr := errors.Join(workflowResult.Close(), app.guardrails.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		closeErr := errors.Join(workflowResult.Close(), app.guardrails.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.fileStore.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
 		if closeErr != nil {
 			return nil, fmt.Errorf("failed to seed workflows: %w (also: close error: %v)", err, closeErr)
 		}
 		return nil, fmt.Errorf("failed to seed workflows: %w", err)
 	}
 	if err := workflowResult.Service.Refresh(ctx); err != nil {
-		closeErr := errors.Join(workflowResult.Close(), app.guardrails.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		closeErr := errors.Join(workflowResult.Close(), app.guardrails.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.fileStore.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
 		if closeErr != nil {
 			return nil, fmt.Errorf("failed to load workflows: %w (also: close error: %v)", err, closeErr)
 		}
@@ -330,6 +351,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		auditResult.Storage,
 		usageResult.Storage,
 		batchResult.Storage,
+		fileStoreResult.Storage,
 		aliasResult.Storage,
 		modelOverrideResult.Storage,
 		pricingOverrideResult.Storage,
@@ -342,7 +364,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		authKeyResult, err = authkeys.New(ctx, appCfg)
 	}
 	if err != nil {
-		closeErr := errors.Join(workflowResult.Close(), app.guardrails.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		closeErr := errors.Join(workflowResult.Close(), app.guardrails.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.fileStore.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
 		if closeErr != nil {
 			return nil, fmt.Errorf("failed to initialize auth keys: %w (also: close error: %v)", err, closeErr)
 		}
@@ -407,6 +429,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		KeepOnlyAliasesAtModelsEndpoint: appCfg.Models.KeepOnlyAliasesAtModelsEndpoint,
 		PassthroughSemanticEnrichers:    cfg.Factory.PassthroughSemanticEnrichers(),
 		BatchStore:                      batchResult.Store,
+		FileStore:                       fileStoreResult.Store,
 		LogOnlyModelInteractions:        appCfg.Logging.OnlyModelInteractions,
 		DisablePassthroughRoutes:        !appCfg.Server.EnablePassthroughRoutes,
 		EnabledPassthroughProviders:     appCfg.Server.EnabledPassthroughProviders,
@@ -480,6 +503,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 			aliasCloseErr            error
 			modelOverridesCloseErr   error
 			pricingOverridesCloseErr error
+			fileStoreCloseErr        error
 			batchCloseErr            error
 		)
 		if app.workflows != nil {
@@ -500,10 +524,13 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		if app.pricingOverrides != nil {
 			pricingOverridesCloseErr = app.pricingOverrides.Close()
 		}
+		if app.fileStore != nil {
+			fileStoreCloseErr = app.fileStore.Close()
+		}
 		if app.batch != nil {
 			batchCloseErr = app.batch.Close()
 		}
-		closeErr := errors.Join(workflowsCloseErr, guardrailsCloseErr, authKeysCloseErr, aliasCloseErr, modelOverridesCloseErr, pricingOverridesCloseErr, batchCloseErr, app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		closeErr := errors.Join(workflowsCloseErr, guardrailsCloseErr, authKeysCloseErr, aliasCloseErr, modelOverridesCloseErr, pricingOverridesCloseErr, fileStoreCloseErr, batchCloseErr, app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
 		if closeErr != nil {
 			return nil, fmt.Errorf("failed to initialize response cache: %w (also: close error: %v)", err, closeErr)
 		}
@@ -521,15 +548,18 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		PricingResolver:        pricingResolver,
 		ResponseCache:          rcm,
 	})
+	closeWiredRuntime := func() error {
+		return errors.Join(rcm.Close(), app.workflows.Close(), app.guardrails.Close(), app.authKeys.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.fileStore.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+	}
 	if err := guardrailResult.Service.SetExecutor(ctx, internalGuardrailExecutor); err != nil {
-		closeErr := errors.Join(rcm.Close(), app.workflows.Close(), app.guardrails.Close(), app.authKeys.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		closeErr := closeWiredRuntime()
 		if closeErr != nil {
 			return nil, fmt.Errorf("failed to wire internal guardrail executor: %w (also: close error: %v)", err, closeErr)
 		}
 		return nil, fmt.Errorf("failed to wire internal guardrail executor: %w", err)
 	}
 	if err := workflowResult.Service.Refresh(ctx); err != nil {
-		closeErr := errors.Join(rcm.Close(), app.workflows.Close(), app.guardrails.Close(), app.authKeys.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		closeErr := closeWiredRuntime()
 		if closeErr != nil {
 			return nil, fmt.Errorf("failed to refresh workflows after wiring internal guardrail executor: %w (also: close error: %v)", err, closeErr)
 		}
@@ -734,7 +764,15 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// 9. Close batch store (flushes pending entries)
+	// 9. Close file mapping store.
+	if a.fileStore != nil {
+		if err := a.fileStore.Close(); err != nil {
+			slog.Error("file mapping store close error", "error", err)
+			errs = append(errs, fmt.Errorf("file store close: %w", err))
+		}
+	}
+
+	// 10. Close batch store (flushes pending entries)
 	if a.batch != nil {
 		if err := a.batch.Close(); err != nil {
 			slog.Error("batch store close error", "error", err)
@@ -742,7 +780,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// 10. Close budget subsystem.
+	// 11. Close budget subsystem.
 	if a.budgets != nil {
 		if err := a.budgets.Close(); err != nil {
 			slog.Error("budgets close error", "error", err)
@@ -750,7 +788,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// 10. Close usage tracking (flushes pending entries)
+	// 12. Close usage tracking (flushes pending entries)
 	if a.usage != nil {
 		if err := a.usage.Close(); err != nil {
 			slog.Error("usage logger close error", "error", err)
@@ -758,7 +796,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// 11. Close audit logging (flushes pending logs)
+	// 13. Close audit logging (flushes pending logs)
 	if a.audit != nil {
 		if err := a.audit.Close(); err != nil {
 			slog.Error("audit logger close error", "error", err)

--- a/internal/core/interfaces.go
+++ b/internal/core/interfaces.go
@@ -60,6 +60,12 @@ type NativeBatchRoutableProvider interface {
 	GetBatchResults(ctx context.Context, providerType, id string) (*BatchResultsResponse, error)
 }
 
+// NativeBatchProviderTypeLister exposes registered provider types that support
+// native batch operations.
+type NativeBatchProviderTypeLister interface {
+	NativeBatchProviderTypes() []string
+}
+
 // NativeBatchHintRoutableProvider is an optional routing extension for
 // providers that can consume persisted per-item endpoint hints.
 type NativeBatchHintRoutableProvider interface {

--- a/internal/filestore/factory.go
+++ b/internal/filestore/factory.go
@@ -1,0 +1,80 @@
+package filestore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+
+	"gomodel/config"
+	"gomodel/internal/storage"
+)
+
+// Result holds the initialized file store and optional owned storage.
+type Result struct {
+	Store   Store
+	Storage storage.Storage
+}
+
+// Close releases resources held by the file store.
+func (r *Result) Close() error {
+	if r == nil {
+		return nil
+	}
+	var errs []error
+	if r.Store != nil {
+		if err := r.Store.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("store close: %w", err))
+		}
+	}
+	if r.Storage != nil {
+		if err := r.Storage.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("storage close: %w", err))
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("close errors: %w", errors.Join(errs...))
+	}
+	return nil
+}
+
+// New creates a file store from app configuration.
+func New(ctx context.Context, cfg *config.Config) (*Result, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config is required")
+	}
+	store, err := storage.New(ctx, cfg.Storage.BackendConfig())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create storage: %w", err)
+	}
+	fileStore, err := createStore(ctx, store)
+	if err != nil {
+		_ = store.Close()
+		return nil, err
+	}
+	return &Result{Store: fileStore, Storage: store}, nil
+}
+
+// NewWithSharedStorage creates a file store using a shared storage connection.
+func NewWithSharedStorage(ctx context.Context, shared storage.Storage) (*Result, error) {
+	if shared == nil {
+		return nil, fmt.Errorf("shared storage is required")
+	}
+	fileStore, err := createStore(ctx, shared)
+	if err != nil {
+		return nil, err
+	}
+	return &Result{Store: fileStore}, nil
+}
+
+func createStore(ctx context.Context, store storage.Storage) (Store, error) {
+	return storage.ResolveBackend[Store](
+		store,
+		func(db *sql.DB) (Store, error) { return NewSQLiteStore(db) },
+		func(pool *pgxpool.Pool) (Store, error) { return NewPostgreSQLStore(ctx, pool) },
+		func(db *mongo.Database) (Store, error) { return NewMongoDBStore(db) },
+	)
+}

--- a/internal/filestore/store.go
+++ b/internal/filestore/store.go
@@ -1,0 +1,75 @@
+// Package filestore persists provider ownership for uploaded files.
+package filestore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrNotFound indicates a requested file mapping was not found.
+var ErrNotFound = errors.New("file mapping not found")
+
+// StoredFile maps an OpenAI-compatible file ID to the provider that owns it.
+type StoredFile struct {
+	ID           string `json:"id" bson:"_id"`
+	ProviderType string `json:"provider_type" bson:"provider_type"`
+	Purpose      string `json:"purpose,omitempty" bson:"purpose,omitempty"`
+	Filename     string `json:"filename,omitempty" bson:"filename,omitempty"`
+	Bytes        int64  `json:"bytes,omitempty" bson:"bytes,omitempty"`
+	CreatedAt    int64  `json:"created_at,omitempty" bson:"created_at,omitempty"`
+	UserPath     string `json:"user_path,omitempty" bson:"user_path,omitempty"`
+}
+
+// Store defines persistence operations for file provider mappings.
+type Store interface {
+	Upsert(ctx context.Context, file *StoredFile) error
+	Get(ctx context.Context, id string) (*StoredFile, error)
+	Delete(ctx context.Context, id string) error
+	Close() error
+}
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanStoredFile(row rowScanner, notFound error) (*StoredFile, error) {
+	file := &StoredFile{}
+	err := row.Scan(&file.ID, &file.ProviderType, &file.Purpose, &file.Filename, &file.Bytes, &file.CreatedAt, &file.UserPath)
+	if err != nil {
+		if errors.Is(err, notFound) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("query file mapping: %w", err)
+	}
+	return cloneStoredFile(file)
+}
+
+func normalizeStoredFile(file *StoredFile) (*StoredFile, error) {
+	if file == nil {
+		return nil, fmt.Errorf("file mapping is nil")
+	}
+	normalized := *file
+	normalized.ID = strings.TrimSpace(normalized.ID)
+	normalized.ProviderType = strings.TrimSpace(normalized.ProviderType)
+	normalized.Purpose = strings.TrimSpace(normalized.Purpose)
+	normalized.Filename = strings.TrimSpace(normalized.Filename)
+	normalized.UserPath = strings.TrimSpace(normalized.UserPath)
+	if normalized.ID == "" {
+		return nil, fmt.Errorf("file id is required")
+	}
+	if normalized.ProviderType == "" {
+		return nil, fmt.Errorf("provider type is required")
+	}
+	return &normalized, nil
+}
+
+func cloneStoredFile(file *StoredFile) (*StoredFile, error) {
+	normalized, err := normalizeStoredFile(file)
+	if err != nil {
+		return nil, err
+	}
+	cloned := *normalized
+	return &cloned, nil
+}

--- a/internal/filestore/store_memory.go
+++ b/internal/filestore/store_memory.go
@@ -24,6 +24,9 @@ func (s *MemoryStore) Upsert(_ context.Context, file *StoredFile) error {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if existing, ok := s.items[cloned.ID]; ok {
+		cloned.CreatedAt = existing.CreatedAt
+	}
 	s.items[cloned.ID] = cloned
 	return nil
 }

--- a/internal/filestore/store_memory.go
+++ b/internal/filestore/store_memory.go
@@ -1,0 +1,56 @@
+package filestore
+
+import (
+	"context"
+	"sync"
+)
+
+// MemoryStore keeps file provider mappings in process memory.
+type MemoryStore struct {
+	mu    sync.RWMutex
+	items map[string]*StoredFile
+}
+
+// NewMemoryStore creates an empty in-memory file store.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{items: make(map[string]*StoredFile)}
+}
+
+// Upsert creates or replaces a file mapping.
+func (s *MemoryStore) Upsert(_ context.Context, file *StoredFile) error {
+	cloned, err := cloneStoredFile(file)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.items[cloned.ID] = cloned
+	return nil
+}
+
+// Get retrieves one file mapping by id.
+func (s *MemoryStore) Get(_ context.Context, id string) (*StoredFile, error) {
+	s.mu.RLock()
+	file, ok := s.items[id]
+	s.mu.RUnlock()
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return cloneStoredFile(file)
+}
+
+// Delete removes one file mapping by id.
+func (s *MemoryStore) Delete(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.items[id]; !ok {
+		return ErrNotFound
+	}
+	delete(s.items, id)
+	return nil
+}
+
+// Close releases resources.
+func (s *MemoryStore) Close() error {
+	return nil
+}

--- a/internal/filestore/store_mongodb.go
+++ b/internal/filestore/store_mongodb.go
@@ -1,0 +1,109 @@
+package filestore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+type mongoFileDocument struct {
+	ID           string `bson:"_id"`
+	ProviderType string `bson:"provider_type"`
+	Purpose      string `bson:"purpose,omitempty"`
+	Filename     string `bson:"filename,omitempty"`
+	Bytes        int64  `bson:"bytes,omitempty"`
+	CreatedAt    int64  `bson:"created_at,omitempty"`
+	UpdatedAt    int64  `bson:"updated_at"`
+	UserPath     string `bson:"user_path,omitempty"`
+}
+
+// MongoDBStore stores file provider mappings in MongoDB.
+type MongoDBStore struct {
+	collection *mongo.Collection
+}
+
+// NewMongoDBStore creates collection indexes if needed.
+func NewMongoDBStore(database *mongo.Database) (*MongoDBStore, error) {
+	if database == nil {
+		return nil, fmt.Errorf("database is required")
+	}
+	coll := database.Collection("file_mappings")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	indexes := []mongo.IndexModel{
+		{Keys: bson.D{{Key: "provider_type", Value: 1}}},
+		{Keys: bson.D{{Key: "created_at", Value: -1}}},
+	}
+	if _, err := coll.Indexes().CreateMany(ctx, indexes); err != nil {
+		return nil, fmt.Errorf("create file_mappings indexes: %w", err)
+	}
+	return &MongoDBStore{collection: coll}, nil
+}
+
+// Upsert creates or replaces a file mapping.
+func (s *MongoDBStore) Upsert(ctx context.Context, file *StoredFile) error {
+	normalized, err := normalizeStoredFile(file)
+	if err != nil {
+		return err
+	}
+	opts := options.UpdateOne().SetUpsert(true)
+	update := bson.M{
+		"$set": bson.M{
+			"provider_type": normalized.ProviderType,
+			"purpose":       normalized.Purpose,
+			"filename":      normalized.Filename,
+			"bytes":         normalized.Bytes,
+			"created_at":    normalized.CreatedAt,
+			"updated_at":    time.Now().Unix(),
+			"user_path":     normalized.UserPath,
+		},
+		"$setOnInsert": bson.M{"_id": normalized.ID},
+	}
+	if _, err := s.collection.UpdateOne(ctx, bson.M{"_id": normalized.ID}, update, opts); err != nil {
+		return fmt.Errorf("upsert file mapping: %w", err)
+	}
+	return nil
+}
+
+// Get retrieves one file mapping by id.
+func (s *MongoDBStore) Get(ctx context.Context, id string) (*StoredFile, error) {
+	var doc mongoFileDocument
+	err := s.collection.FindOne(ctx, bson.M{"_id": id}).Decode(&doc)
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("query file mapping: %w", err)
+	}
+	return cloneStoredFile(&StoredFile{
+		ID:           doc.ID,
+		ProviderType: doc.ProviderType,
+		Purpose:      doc.Purpose,
+		Filename:     doc.Filename,
+		Bytes:        doc.Bytes,
+		CreatedAt:    doc.CreatedAt,
+		UserPath:     doc.UserPath,
+	})
+}
+
+// Delete removes one file mapping by id.
+func (s *MongoDBStore) Delete(ctx context.Context, id string) error {
+	result, err := s.collection.DeleteOne(ctx, bson.M{"_id": id})
+	if err != nil {
+		return fmt.Errorf("delete file mapping: %w", err)
+	}
+	if result.DeletedCount == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// Close is a no-op; Mongo client lifecycle is managed by storage layer.
+func (s *MongoDBStore) Close() error {
+	return nil
+}

--- a/internal/filestore/store_mongodb.go
+++ b/internal/filestore/store_mongodb.go
@@ -58,11 +58,10 @@ func (s *MongoDBStore) Upsert(ctx context.Context, file *StoredFile) error {
 			"purpose":       normalized.Purpose,
 			"filename":      normalized.Filename,
 			"bytes":         normalized.Bytes,
-			"created_at":    normalized.CreatedAt,
 			"updated_at":    time.Now().Unix(),
 			"user_path":     normalized.UserPath,
 		},
-		"$setOnInsert": bson.M{"_id": normalized.ID},
+		"$setOnInsert": bson.M{"_id": normalized.ID, "created_at": normalized.CreatedAt},
 	}
 	if _, err := s.collection.UpdateOne(ctx, bson.M{"_id": normalized.ID}, update, opts); err != nil {
 		return fmt.Errorf("upsert file mapping: %w", err)

--- a/internal/filestore/store_postgresql.go
+++ b/internal/filestore/store_postgresql.go
@@ -1,0 +1,97 @@
+package filestore
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// PostgreSQLStore stores file provider mappings in PostgreSQL.
+type PostgreSQLStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgreSQLStore creates the file_mappings table and indexes if needed.
+func NewPostgreSQLStore(ctx context.Context, pool *pgxpool.Pool) (*PostgreSQLStore, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("context is required")
+	}
+	if pool == nil {
+		return nil, fmt.Errorf("connection pool is required")
+	}
+	_, err := pool.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS file_mappings (
+			id TEXT PRIMARY KEY,
+			provider_type TEXT NOT NULL,
+			purpose TEXT NOT NULL DEFAULT '',
+			filename TEXT NOT NULL DEFAULT '',
+			bytes BIGINT NOT NULL DEFAULT 0,
+			created_at BIGINT NOT NULL DEFAULT 0,
+			updated_at BIGINT NOT NULL,
+			user_path TEXT NOT NULL DEFAULT ''
+		)
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create file_mappings table: %w", err)
+	}
+	if _, err := pool.Exec(ctx, "CREATE INDEX IF NOT EXISTS idx_file_mappings_provider_type ON file_mappings(provider_type)"); err != nil {
+		return nil, fmt.Errorf("failed to create file_mappings provider index: %w", err)
+	}
+	if _, err := pool.Exec(ctx, "CREATE INDEX IF NOT EXISTS idx_file_mappings_created_at ON file_mappings(created_at DESC)"); err != nil {
+		return nil, fmt.Errorf("failed to create file_mappings created_at index: %w", err)
+	}
+	return &PostgreSQLStore{pool: pool}, nil
+}
+
+// Upsert creates or replaces a file mapping.
+func (s *PostgreSQLStore) Upsert(ctx context.Context, file *StoredFile) error {
+	normalized, err := normalizeStoredFile(file)
+	if err != nil {
+		return err
+	}
+	_, err = s.pool.Exec(ctx, `
+		INSERT INTO file_mappings (id, provider_type, purpose, filename, bytes, created_at, updated_at, user_path)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		ON CONFLICT(id) DO UPDATE SET
+			provider_type = excluded.provider_type,
+			purpose = excluded.purpose,
+			filename = excluded.filename,
+			bytes = excluded.bytes,
+			created_at = excluded.created_at,
+			updated_at = excluded.updated_at,
+			user_path = excluded.user_path
+	`, normalized.ID, normalized.ProviderType, normalized.Purpose, normalized.Filename, normalized.Bytes, normalized.CreatedAt, time.Now().Unix(), normalized.UserPath)
+	if err != nil {
+		return fmt.Errorf("upsert file mapping: %w", err)
+	}
+	return nil
+}
+
+// Get retrieves one file mapping by id.
+func (s *PostgreSQLStore) Get(ctx context.Context, id string) (*StoredFile, error) {
+	return scanStoredFile(s.pool.QueryRow(ctx, `
+		SELECT id, provider_type, purpose, filename, bytes, created_at, user_path
+		FROM file_mappings
+		WHERE id = $1
+	`, id), pgx.ErrNoRows)
+}
+
+// Delete removes one file mapping by id.
+func (s *PostgreSQLStore) Delete(ctx context.Context, id string) error {
+	cmd, err := s.pool.Exec(ctx, "DELETE FROM file_mappings WHERE id = $1", id)
+	if err != nil {
+		return fmt.Errorf("delete file mapping: %w", err)
+	}
+	if cmd.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// Close is a no-op; pool lifecycle is managed by storage layer.
+func (s *PostgreSQLStore) Close() error {
+	return nil
+}

--- a/internal/filestore/store_postgresql.go
+++ b/internal/filestore/store_postgresql.go
@@ -60,7 +60,6 @@ func (s *PostgreSQLStore) Upsert(ctx context.Context, file *StoredFile) error {
 			purpose = excluded.purpose,
 			filename = excluded.filename,
 			bytes = excluded.bytes,
-			created_at = excluded.created_at,
 			updated_at = excluded.updated_at,
 			user_path = excluded.user_path
 	`, normalized.ID, normalized.ProviderType, normalized.Purpose, normalized.Filename, normalized.Bytes, normalized.CreatedAt, time.Now().Unix(), normalized.UserPath)

--- a/internal/filestore/store_sqlite.go
+++ b/internal/filestore/store_sqlite.go
@@ -55,7 +55,6 @@ func (s *SQLiteStore) Upsert(ctx context.Context, file *StoredFile) error {
 			purpose = excluded.purpose,
 			filename = excluded.filename,
 			bytes = excluded.bytes,
-			created_at = excluded.created_at,
 			updated_at = excluded.updated_at,
 			user_path = excluded.user_path
 	`, normalized.ID, normalized.ProviderType, normalized.Purpose, normalized.Filename, normalized.Bytes, normalized.CreatedAt, time.Now().Unix(), normalized.UserPath)

--- a/internal/filestore/store_sqlite.go
+++ b/internal/filestore/store_sqlite.go
@@ -1,0 +1,96 @@
+package filestore
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// SQLiteStore stores file provider mappings in SQLite.
+type SQLiteStore struct {
+	db *sql.DB
+}
+
+// NewSQLiteStore creates the file_mappings table and indexes if needed.
+func NewSQLiteStore(db *sql.DB) (*SQLiteStore, error) {
+	if db == nil {
+		return nil, fmt.Errorf("database connection is required")
+	}
+	_, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS file_mappings (
+			id TEXT PRIMARY KEY,
+			provider_type TEXT NOT NULL,
+			purpose TEXT NOT NULL DEFAULT '',
+			filename TEXT NOT NULL DEFAULT '',
+			bytes INTEGER NOT NULL DEFAULT 0,
+			created_at INTEGER NOT NULL DEFAULT 0,
+			updated_at INTEGER NOT NULL,
+			user_path TEXT NOT NULL DEFAULT ''
+		)
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create file_mappings table: %w", err)
+	}
+	if _, err := db.Exec("CREATE INDEX IF NOT EXISTS idx_file_mappings_provider_type ON file_mappings(provider_type)"); err != nil {
+		return nil, fmt.Errorf("failed to create file_mappings provider index: %w", err)
+	}
+	if _, err := db.Exec("CREATE INDEX IF NOT EXISTS idx_file_mappings_created_at ON file_mappings(created_at DESC)"); err != nil {
+		return nil, fmt.Errorf("failed to create file_mappings created_at index: %w", err)
+	}
+	return &SQLiteStore{db: db}, nil
+}
+
+// Upsert creates or replaces a file mapping.
+func (s *SQLiteStore) Upsert(ctx context.Context, file *StoredFile) error {
+	normalized, err := normalizeStoredFile(file)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO file_mappings (id, provider_type, purpose, filename, bytes, created_at, updated_at, user_path)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			provider_type = excluded.provider_type,
+			purpose = excluded.purpose,
+			filename = excluded.filename,
+			bytes = excluded.bytes,
+			created_at = excluded.created_at,
+			updated_at = excluded.updated_at,
+			user_path = excluded.user_path
+	`, normalized.ID, normalized.ProviderType, normalized.Purpose, normalized.Filename, normalized.Bytes, normalized.CreatedAt, time.Now().Unix(), normalized.UserPath)
+	if err != nil {
+		return fmt.Errorf("upsert file mapping: %w", err)
+	}
+	return nil
+}
+
+// Get retrieves one file mapping by id.
+func (s *SQLiteStore) Get(ctx context.Context, id string) (*StoredFile, error) {
+	return scanStoredFile(s.db.QueryRowContext(ctx, `
+		SELECT id, provider_type, purpose, filename, bytes, created_at, user_path
+		FROM file_mappings
+		WHERE id = ?
+	`, id), sql.ErrNoRows)
+}
+
+// Delete removes one file mapping by id.
+func (s *SQLiteStore) Delete(ctx context.Context, id string) error {
+	result, err := s.db.ExecContext(ctx, "DELETE FROM file_mappings WHERE id = ?", id)
+	if err != nil {
+		return fmt.Errorf("delete file mapping: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read delete rows affected: %w", err)
+	}
+	if affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// Close is a no-op; DB lifecycle is managed by storage layer.
+func (s *SQLiteStore) Close() error {
+	return nil
+}

--- a/internal/filestore/store_test.go
+++ b/internal/filestore/store_test.go
@@ -3,8 +3,12 @@ package filestore
 import (
 	"context"
 	"database/sql"
+	"os"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	_ "modernc.org/sqlite"
 )
 
@@ -28,15 +32,35 @@ func TestStoreUpsertPreservesCreatedAt(t *testing.T) {
 				_ = db.Close()
 			}
 		},
+		"postgres": func(t *testing.T) (Store, func()) {
+			dsn := os.Getenv("TEST_DATABASE_DSN")
+			if dsn == "" {
+				t.Skip("TEST_DATABASE_DSN is not set")
+			}
+			pool, err := pgxpool.New(ctx, dsn)
+			if err != nil {
+				t.Fatalf("pgxpool.New() error = %v", err)
+			}
+			store, err := NewPostgreSQLStore(ctx, pool)
+			if err != nil {
+				pool.Close()
+				t.Fatalf("NewPostgreSQLStore() error = %v", err)
+			}
+			return store, pool.Close
+		},
 	}
 
 	for name, newStore := range stores {
 		t.Run(name, func(t *testing.T) {
 			store, cleanup := newStore(t)
 			defer cleanup()
+			fileID := "file_" + strings.ReplaceAll(t.Name(), "/", "_") + "_" + time.Now().Format("20060102150405.000000000")
+			defer func() {
+				_ = store.Delete(ctx, fileID)
+			}()
 
 			if err := store.Upsert(ctx, &StoredFile{
-				ID:           "file_1",
+				ID:           fileID,
 				ProviderType: "openai",
 				Purpose:      "batch",
 				Filename:     "original.jsonl",
@@ -47,7 +71,7 @@ func TestStoreUpsertPreservesCreatedAt(t *testing.T) {
 				t.Fatalf("initial Upsert() error = %v", err)
 			}
 			if err := store.Upsert(ctx, &StoredFile{
-				ID:           "file_1",
+				ID:           fileID,
 				ProviderType: "anthropic",
 				Purpose:      "fine-tune",
 				Filename:     "updated.jsonl",
@@ -58,7 +82,7 @@ func TestStoreUpsertPreservesCreatedAt(t *testing.T) {
 				t.Fatalf("second Upsert() error = %v", err)
 			}
 
-			stored, err := store.Get(ctx, "file_1")
+			stored, err := store.Get(ctx, fileID)
 			if err != nil {
 				t.Fatalf("Get() error = %v", err)
 			}

--- a/internal/filestore/store_test.go
+++ b/internal/filestore/store_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 	_ "modernc.org/sqlite"
 )
 
@@ -47,6 +49,26 @@ func TestStoreUpsertPreservesCreatedAt(t *testing.T) {
 				t.Fatalf("NewPostgreSQLStore() error = %v", err)
 			}
 			return store, pool.Close
+		},
+		"mongo": func(t *testing.T) (Store, func()) {
+			dsn := os.Getenv("MONGO_TEST_DSN")
+			if dsn == "" {
+				t.Skip("MONGO_TEST_DSN is not set")
+			}
+			client, err := mongo.Connect(options.Client().ApplyURI(dsn))
+			if err != nil {
+				t.Fatalf("mongo.Connect() error = %v", err)
+			}
+			db := client.Database("gomodel_filestore_test_" + strings.ReplaceAll(t.Name(), "/", "_") + "_" + time.Now().Format("20060102150405_000000000"))
+			store, err := NewMongoDBStore(db)
+			if err != nil {
+				_ = client.Disconnect(ctx)
+				t.Fatalf("NewMongoDBStore() error = %v", err)
+			}
+			return store, func() {
+				_ = db.Drop(ctx)
+				_ = client.Disconnect(ctx)
+			}
 		},
 	}
 

--- a/internal/filestore/store_test.go
+++ b/internal/filestore/store_test.go
@@ -1,0 +1,76 @@
+package filestore
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestStoreUpsertPreservesCreatedAt(t *testing.T) {
+	ctx := context.Background()
+	stores := map[string]func(t *testing.T) (Store, func()){
+		"memory": func(t *testing.T) (Store, func()) {
+			return NewMemoryStore(), func() {}
+		},
+		"sqlite": func(t *testing.T) (Store, func()) {
+			db, err := sql.Open("sqlite", ":memory:")
+			if err != nil {
+				t.Fatalf("sql.Open() error = %v", err)
+			}
+			store, err := NewSQLiteStore(db)
+			if err != nil {
+				_ = db.Close()
+				t.Fatalf("NewSQLiteStore() error = %v", err)
+			}
+			return store, func() {
+				_ = db.Close()
+			}
+		},
+	}
+
+	for name, newStore := range stores {
+		t.Run(name, func(t *testing.T) {
+			store, cleanup := newStore(t)
+			defer cleanup()
+
+			if err := store.Upsert(ctx, &StoredFile{
+				ID:           "file_1",
+				ProviderType: "openai",
+				Purpose:      "batch",
+				Filename:     "original.jsonl",
+				Bytes:        10,
+				CreatedAt:    111,
+				UserPath:     "/v1/files",
+			}); err != nil {
+				t.Fatalf("initial Upsert() error = %v", err)
+			}
+			if err := store.Upsert(ctx, &StoredFile{
+				ID:           "file_1",
+				ProviderType: "anthropic",
+				Purpose:      "fine-tune",
+				Filename:     "updated.jsonl",
+				Bytes:        20,
+				CreatedAt:    222,
+				UserPath:     "/v1/files?provider=anthropic",
+			}); err != nil {
+				t.Fatalf("second Upsert() error = %v", err)
+			}
+
+			stored, err := store.Get(ctx, "file_1")
+			if err != nil {
+				t.Fatalf("Get() error = %v", err)
+			}
+			if stored.CreatedAt != 111 {
+				t.Fatalf("CreatedAt = %d, want 111", stored.CreatedAt)
+			}
+			if stored.ProviderType != "anthropic" {
+				t.Fatalf("ProviderType = %q, want anthropic", stored.ProviderType)
+			}
+			if stored.Filename != "updated.jsonl" {
+				t.Fatalf("Filename = %q, want updated.jsonl", stored.Filename)
+			}
+		})
+	}
+}

--- a/internal/gateway/batch_orchestrator.go
+++ b/internal/gateway/batch_orchestrator.go
@@ -21,6 +21,7 @@ type BatchConfig struct {
 	Provider                             core.RoutableProvider
 	ModelResolver                        ModelResolver
 	ModelAuthorizer                      ModelAuthorizer
+	InputFileProviderResolver            BatchInputFileProviderResolver
 	WorkflowPolicyResolver               WorkflowPolicyResolver
 	BatchRequestPreparer                 BatchRequestPreparer
 	BatchStore                           batchstore.Store
@@ -36,6 +37,7 @@ type BatchOrchestrator struct {
 	provider                             core.RoutableProvider
 	modelResolver                        ModelResolver
 	modelAuthorizer                      ModelAuthorizer
+	inputFileProviderResolver            BatchInputFileProviderResolver
 	workflowPolicyResolver               WorkflowPolicyResolver
 	batchRequestPreparer                 BatchRequestPreparer
 	batchStore                           batchstore.Store
@@ -52,6 +54,7 @@ func NewBatchOrchestrator(cfg BatchConfig) *BatchOrchestrator {
 		provider:                             cfg.Provider,
 		modelResolver:                        cfg.ModelResolver,
 		modelAuthorizer:                      cfg.ModelAuthorizer,
+		inputFileProviderResolver:            cfg.InputFileProviderResolver,
 		workflowPolicyResolver:               cfg.WorkflowPolicyResolver,
 		batchRequestPreparer:                 cfg.BatchRequestPreparer,
 		batchStore:                           cfg.BatchStore,
@@ -109,7 +112,7 @@ func (o *BatchOrchestrator) Create(ctx context.Context, req *core.BatchRequest, 
 		return nil, core.NewInvalidRequestError("batch routing is not supported by the current provider router", nil)
 	}
 
-	selection, err := DetermineBatchExecutionSelectionWithAuthorizer(ctx, o.provider, o.modelResolver, o.modelAuthorizer, req)
+	selection, err := DetermineBatchExecutionSelectionWithAuthorizerAndInputFileResolver(ctx, o.provider, o.modelResolver, o.modelAuthorizer, o.inputFileProviderResolver, req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gateway/batch_selection.go
+++ b/internal/gateway/batch_selection.go
@@ -14,6 +14,12 @@ type BatchExecutionSelection struct {
 	Selector     core.WorkflowSelector
 }
 
+// BatchInputFileProviderResolver resolves provider ownership for an uploaded
+// batch input file.
+type BatchInputFileProviderResolver interface {
+	ResolveBatchInputFileProvider(ctx context.Context, fileID string) (providerType string, ok bool, err error)
+}
+
 // DetermineBatchExecutionSelection resolves a native batch to one provider.
 func DetermineBatchExecutionSelection(
 	provider core.RoutableProvider,
@@ -31,6 +37,20 @@ func DetermineBatchExecutionSelectionWithAuthorizer(
 	authorizer ModelAuthorizer,
 	req *core.BatchRequest,
 ) (BatchExecutionSelection, error) {
+	return DetermineBatchExecutionSelectionWithAuthorizerAndInputFileResolver(ctx, provider, resolver, authorizer, nil, req)
+}
+
+// DetermineBatchExecutionSelectionWithAuthorizerAndInputFileResolver resolves
+// and authorizes native batch items, using file ownership metadata for
+// file-backed batches when no explicit provider hint is supplied.
+func DetermineBatchExecutionSelectionWithAuthorizerAndInputFileResolver(
+	ctx context.Context,
+	provider core.RoutableProvider,
+	resolver ModelResolver,
+	authorizer ModelAuthorizer,
+	inputFileProviderResolver BatchInputFileProviderResolver,
+	req *core.BatchRequest,
+) (BatchExecutionSelection, error) {
 	if req == nil {
 		return BatchExecutionSelection{}, core.NewInvalidRequestError("batch request is required", nil)
 	}
@@ -39,12 +59,21 @@ func DetermineBatchExecutionSelectionWithAuthorizer(
 	}
 
 	if strings.TrimSpace(req.InputFileID) != "" {
-		if req.Metadata == nil {
-			return BatchExecutionSelection{}, core.NewInvalidRequestError("metadata.provider is required for input_file_id batches", nil)
+		providerType := ""
+		if req.Metadata != nil {
+			providerType = strings.TrimSpace(req.Metadata["provider"])
 		}
-		providerType := strings.TrimSpace(req.Metadata["provider"])
+		if providerType == "" && inputFileProviderResolver != nil {
+			resolved, ok, err := inputFileProviderResolver.ResolveBatchInputFileProvider(ctx, req.InputFileID)
+			if err != nil {
+				return BatchExecutionSelection{}, err
+			}
+			if ok {
+				providerType = strings.TrimSpace(resolved)
+			}
+		}
 		if providerType == "" {
-			return BatchExecutionSelection{}, core.NewInvalidRequestError("metadata.provider is required for input_file_id batches", nil)
+			return BatchExecutionSelection{}, core.NewInvalidRequestError("unable to resolve provider for input_file_id batch", nil)
 		}
 		return BatchExecutionSelection{
 			ProviderType: providerType,

--- a/internal/guardrails/provider.go
+++ b/internal/guardrails/provider.go
@@ -70,6 +70,15 @@ func (g *GuardedProvider) NativeFileProviderTypes() []string {
 	return nil
 }
 
+// NativeBatchProviderTypes delegates provider capability inventory to the inner
+// provider when available.
+func (g *GuardedProvider) NativeBatchProviderTypes() []string {
+	if typed, ok := g.inner.(core.NativeBatchProviderTypeLister); ok {
+		return typed.NativeBatchProviderTypes()
+	}
+	return nil
+}
+
 // NativeResponseProviderTypes delegates provider capability inventory to the
 // inner provider when available.
 func (g *GuardedProvider) NativeResponseProviderTypes() []string {
@@ -192,7 +201,6 @@ func (g *GuardedProvider) passthroughRouter() (core.RoutablePassthrough, error) 
 	}
 	return pp, nil
 }
-
 
 // CreateBatch delegates native batch creation and optionally applies guardrails to inline items.
 func (g *GuardedProvider) CreateBatch(ctx context.Context, providerType string, req *core.BatchRequest) (*core.BatchResponse, error) {
@@ -425,8 +433,6 @@ func (g *GuardedProvider) PrepareBatchRequest(ctx context.Context, providerType 
 	}
 	return processGuardedBatchRequest(ctx, providerType, req, g.pipeline, g.batchFileTransport())
 }
-
-
 
 func cloneToolCalls(toolCalls []core.ToolCall) []core.ToolCall {
 	if len(toolCalls) == 0 {

--- a/internal/providers/router.go
+++ b/internal/providers/router.go
@@ -748,6 +748,24 @@ func (r *Router) NativeFileProviderTypes() []string {
 	return result
 }
 
+// NativeBatchProviderTypes returns the registered provider types that support
+// native batch operations.
+func (r *Router) NativeBatchProviderTypes() []string {
+	providerTypes := r.providerTypes()
+	result := make([]string, 0, len(providerTypes))
+	for _, providerType := range providerTypes {
+		provider := r.providerByTypeRegistry(providerType)
+		if provider == nil {
+			continue
+		}
+		if _, ok := provider.(core.NativeBatchProvider); !ok {
+			continue
+		}
+		result = append(result, providerType)
+	}
+	return result
+}
+
 // NativeResponseProviderTypes returns the registered provider types that
 // support native Responses lifecycle operations.
 func (r *Router) NativeResponseProviderTypes() []string {

--- a/internal/server/batch_input_file_resolver.go
+++ b/internal/server/batch_input_file_resolver.go
@@ -1,0 +1,134 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sort"
+	"strings"
+
+	"gomodel/internal/core"
+	"gomodel/internal/filestore"
+	"gomodel/internal/gateway"
+)
+
+type batchInputFileProviderResolver struct {
+	provider  core.RoutableProvider
+	fileStore filestore.Store
+}
+
+func newBatchInputFileProviderResolver(provider core.RoutableProvider, fileStore filestore.Store) gateway.BatchInputFileProviderResolver {
+	if provider == nil && fileStore == nil {
+		return nil
+	}
+	return &batchInputFileProviderResolver{
+		provider:  provider,
+		fileStore: fileStore,
+	}
+}
+
+func (r *batchInputFileProviderResolver) ResolveBatchInputFileProvider(ctx context.Context, fileID string) (string, bool, error) {
+	fileID = strings.TrimSpace(fileID)
+	if fileID == "" {
+		return "", false, nil
+	}
+	if r.fileStore != nil {
+		stored, err := r.fileStore.Get(ctx, fileID)
+		switch {
+		case err == nil && stored != nil && strings.TrimSpace(stored.ProviderType) != "":
+			return strings.TrimSpace(stored.ProviderType), true, nil
+		case err == nil:
+			return "", false, nil
+		case errors.Is(err, filestore.ErrNotFound):
+		default:
+			return "", false, core.NewProviderError("file_store", http.StatusInternalServerError, "failed to look up input file provider", err)
+		}
+	}
+	return r.resolveProviderByFallback(ctx, fileID)
+}
+
+func (r *batchInputFileProviderResolver) resolveProviderByFallback(ctx context.Context, fileID string) (string, bool, error) {
+	candidates := nativeBatchFileProviderCandidates(r.provider)
+	if len(candidates) == 0 {
+		return "", false, nil
+	}
+	if len(candidates) == 1 {
+		return candidates[0], true, nil
+	}
+
+	nativeFiles, ok := r.provider.(core.NativeFileRoutableProvider)
+	if !ok {
+		return "", false, nil
+	}
+
+	var matches []string
+	var firstErr error
+	for _, candidate := range candidates {
+		if _, err := nativeFiles.GetFile(ctx, candidate, fileID); err == nil {
+			matches = append(matches, candidate)
+			continue
+		} else if isNotFoundGatewayError(err) || isUnsupportedNativeFilesError(err) {
+			continue
+		} else if firstErr == nil {
+			firstErr = err
+		}
+	}
+	switch len(matches) {
+	case 0:
+		if firstErr != nil {
+			return "", false, firstErr
+		}
+		return "", false, nil
+	case 1:
+		return matches[0], true, nil
+	default:
+		return "", false, core.NewInvalidRequestError("input_file_id is ambiguous across providers; pass metadata.provider", nil)
+	}
+}
+
+func nativeBatchFileProviderCandidates(provider core.RoutableProvider) []string {
+	fileTypes, ok := provider.(core.NativeFileProviderTypeLister)
+	if !ok {
+		return nil
+	}
+	candidates := normalizeProviderTypeList(fileTypes.NativeFileProviderTypes())
+	if len(candidates) == 0 {
+		return nil
+	}
+	batchTypes, ok := provider.(core.NativeBatchProviderTypeLister)
+	if !ok {
+		return candidates
+	}
+	batchSet := make(map[string]struct{}, len(batchTypes.NativeBatchProviderTypes()))
+	for _, providerType := range batchTypes.NativeBatchProviderTypes() {
+		providerType = strings.TrimSpace(providerType)
+		if providerType != "" {
+			batchSet[providerType] = struct{}{}
+		}
+	}
+	filtered := candidates[:0]
+	for _, candidate := range candidates {
+		if _, ok := batchSet[candidate]; ok {
+			filtered = append(filtered, candidate)
+		}
+	}
+	return filtered
+}
+
+func normalizeProviderTypeList(providerTypes []string) []string {
+	seen := make(map[string]struct{}, len(providerTypes))
+	out := make([]string, 0, len(providerTypes))
+	for _, providerType := range providerTypes {
+		providerType = strings.TrimSpace(providerType)
+		if providerType == "" {
+			continue
+		}
+		if _, ok := seen[providerType]; ok {
+			continue
+		}
+		seen[providerType] = struct{}{}
+		out = append(out, providerType)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/server/batch_input_file_resolver.go
+++ b/internal/server/batch_input_file_resolver.go
@@ -38,7 +38,7 @@ func (r *batchInputFileProviderResolver) ResolveBatchInputFileProvider(ctx conte
 		case err == nil && stored != nil && strings.TrimSpace(stored.ProviderType) != "":
 			return strings.TrimSpace(stored.ProviderType), true, nil
 		case err == nil:
-			return "", false, nil
+			// Legacy rows without provider_type fall through to provider probing.
 		case errors.Is(err, filestore.ErrNotFound):
 		default:
 			return "", false, core.NewProviderError("file_store", http.StatusInternalServerError, "failed to look up input file provider", err)
@@ -53,6 +53,7 @@ func (r *batchInputFileProviderResolver) resolveProviderByFallback(ctx context.C
 		return "", false, nil
 	}
 	if len(candidates) == 1 {
+		// Single-provider batches skip the extra GetFile preflight; upstream batch creation still validates the file ID.
 		return candidates[0], true, nil
 	}
 
@@ -106,6 +107,7 @@ func nativeBatchFileProviderCandidates(provider core.RoutableProvider) []string 
 			batchSet[providerType] = struct{}{}
 		}
 	}
+	// Reusing candidates for filtered is safe because append writes only batchSet matches up to the current index while for _, candidate := range candidates reads ahead.
 	filtered := candidates[:0]
 	for _, candidate := range candidates {
 		if _, ok := batchSet[candidate]; ok {

--- a/internal/server/batch_input_file_resolver.go
+++ b/internal/server/batch_input_file_resolver.go
@@ -48,6 +48,9 @@ func (r *batchInputFileProviderResolver) ResolveBatchInputFileProvider(ctx conte
 	providerType, ok, fallbackErr := r.resolveProviderByFallback(ctx, fileID)
 	if fallbackErr != nil {
 		if lookupErr != nil {
+			if isClientGatewayError(fallbackErr) {
+				return "", false, fallbackErr
+			}
 			return "", false, core.NewProviderError("file_store", http.StatusBadGateway, "failed to resolve input file provider", errors.Join(lookupErr, fallbackErr))
 		}
 		return "", false, fallbackErr
@@ -59,6 +62,15 @@ func (r *batchInputFileProviderResolver) ResolveBatchInputFileProvider(ctx conte
 		return "", false, core.NewProviderError("file_store", http.StatusInternalServerError, "failed to look up input file provider and fallback provider probing did not resolve the file", lookupErr)
 	}
 	return "", false, nil
+}
+
+func isClientGatewayError(err error) bool {
+	var gatewayErr *core.GatewayError
+	if !errors.As(err, &gatewayErr) {
+		return false
+	}
+	status := gatewayErr.HTTPStatusCode()
+	return status >= http.StatusBadRequest && status < http.StatusInternalServerError
 }
 
 func (r *batchInputFileProviderResolver) resolveProviderByFallback(ctx context.Context, fileID string) (string, bool, error) {

--- a/internal/server/batch_input_file_resolver.go
+++ b/internal/server/batch_input_file_resolver.go
@@ -53,7 +53,8 @@ func (r *batchInputFileProviderResolver) resolveProviderByFallback(ctx context.C
 		return "", false, nil
 	}
 	if len(candidates) == 1 {
-		// Single-provider batches skip the extra GetFile preflight; upstream batch creation still validates the file ID.
+		// Single-provider batches skip the extra GetFile preflight; upstream
+		// batch creation still validates the file ID.
 		return candidates[0], true, nil
 	}
 
@@ -100,14 +101,17 @@ func nativeBatchFileProviderCandidates(provider core.RoutableProvider) []string 
 	if !ok {
 		return candidates
 	}
-	batchSet := make(map[string]struct{}, len(batchTypes.NativeBatchProviderTypes()))
-	for _, providerType := range batchTypes.NativeBatchProviderTypes() {
+	batchProviderTypes := batchTypes.NativeBatchProviderTypes()
+	batchSet := make(map[string]struct{}, len(batchProviderTypes))
+	for _, providerType := range batchProviderTypes {
 		providerType = strings.TrimSpace(providerType)
 		if providerType != "" {
 			batchSet[providerType] = struct{}{}
 		}
 	}
-	// Reusing candidates for filtered is safe because append writes only batchSet matches up to the current index while for _, candidate := range candidates reads ahead.
+	// Reusing candidates for filtered is safe because append writes only
+	// batchSet matches up to the current index while
+	// for _, candidate := range candidates reads ahead.
 	filtered := candidates[:0]
 	for _, candidate := range candidates {
 		if _, ok := batchSet[candidate]; ok {

--- a/internal/server/batch_input_file_resolver.go
+++ b/internal/server/batch_input_file_resolver.go
@@ -32,6 +32,7 @@ func (r *batchInputFileProviderResolver) ResolveBatchInputFileProvider(ctx conte
 	if fileID == "" {
 		return "", false, nil
 	}
+	var lookupErr error
 	if r.fileStore != nil {
 		stored, err := r.fileStore.Get(ctx, fileID)
 		switch {
@@ -41,10 +42,23 @@ func (r *batchInputFileProviderResolver) ResolveBatchInputFileProvider(ctx conte
 			// Legacy rows without provider_type fall through to provider probing.
 		case errors.Is(err, filestore.ErrNotFound):
 		default:
-			return "", false, core.NewProviderError("file_store", http.StatusInternalServerError, "failed to look up input file provider", err)
+			lookupErr = err
 		}
 	}
-	return r.resolveProviderByFallback(ctx, fileID)
+	providerType, ok, fallbackErr := r.resolveProviderByFallback(ctx, fileID)
+	if fallbackErr != nil {
+		if lookupErr != nil {
+			return "", false, core.NewProviderError("file_store", http.StatusBadGateway, "failed to resolve input file provider", errors.Join(lookupErr, fallbackErr))
+		}
+		return "", false, fallbackErr
+	}
+	if ok {
+		return providerType, true, nil
+	}
+	if lookupErr != nil {
+		return "", false, core.NewProviderError("file_store", http.StatusInternalServerError, "failed to look up input file provider and fallback provider probing did not resolve the file", lookupErr)
+	}
+	return "", false, nil
 }
 
 func (r *batchInputFileProviderResolver) resolveProviderByFallback(ctx context.Context, fileID string) (string, bool, error) {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -10,6 +10,7 @@ import (
 	"gomodel/internal/auditlog"
 	batchstore "gomodel/internal/batch"
 	"gomodel/internal/core"
+	"gomodel/internal/filestore"
 	"gomodel/internal/responsecache"
 	"gomodel/internal/responsestore"
 	"gomodel/internal/usage"
@@ -31,6 +32,7 @@ type Handler struct {
 	budgetChecker                   BudgetChecker
 	pricingResolver                 usage.PricingResolver
 	batchStore                      batchstore.Store
+	fileStore                       filestore.Store
 	responseStore                   responsestore.Store
 	responseStoreMu                 sync.RWMutex
 	normalizePassthroughV1Prefix    bool
@@ -92,6 +94,7 @@ func newHandlerWithAuthorizer(
 		usageLogger:              usageLogger,
 		pricingResolver:          pricingResolver,
 		batchStore:               batchstore.NewMemoryStore(),
+		fileStore:                filestore.NewMemoryStore(),
 		responseStore: responsestore.NewMemoryStore(
 			responsestore.WithTTL(responsestore.DefaultMemoryStoreTTL),
 			responsestore.WithMaxEntries(responsestore.DefaultMemoryStoreMaxEntries),
@@ -108,6 +111,15 @@ func (h *Handler) SetBatchStore(store batchstore.Store) {
 		return
 	}
 	h.batchStore = store
+}
+
+// SetFileStore replaces the file provider mapping store.
+// nil is ignored to keep an always-available fallback memory store.
+func (h *Handler) SetFileStore(store filestore.Store) {
+	if store == nil {
+		return
+	}
+	h.fileStore = store
 }
 
 // SetResponseStore replaces the response snapshot store used by lifecycle endpoints.
@@ -157,6 +169,7 @@ func (h *Handler) nativeBatch() *nativeBatchService {
 		provider:                             h.provider,
 		modelResolver:                        h.modelResolver,
 		modelAuthorizer:                      h.modelAuthorizer,
+		inputFileProviderResolver:            newBatchInputFileProviderResolver(h.provider, h.fileStore),
 		workflowPolicyResolver:               h.workflowPolicyResolver,
 		batchRequestPreparer:                 h.batchRequestPreparer,
 		batchStore:                           h.batchStore,
@@ -169,7 +182,7 @@ func (h *Handler) nativeBatch() *nativeBatchService {
 }
 
 func (h *Handler) nativeFiles() *nativeFileService {
-	return &nativeFileService{provider: h.provider}
+	return &nativeFileService{provider: h.provider, fileStore: h.fileStore}
 }
 
 func (h *Handler) nativeResponses() *nativeResponseService {

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -3964,6 +3964,29 @@ func TestBatches_FileStoreLookupErrorFallsBackToProvider(t *testing.T) {
 	require.Equal(t, "file_source", mock.capturedBatchReq.InputFileID)
 }
 
+func TestBatches_FileStoreLookupErrorPreservesClientFallbackError(t *testing.T) {
+	mock := &mockProvider{
+		supportedModels: []string{"gpt-4o-mini", "claude-3-haiku"},
+		providerTypes: map[string]string{
+			"gpt-4o-mini":    "openai",
+			"claude-3-haiku": "anthropic",
+		},
+		fileErrByProvider: map[string]error{
+			"anthropic": core.NewNotFoundError("file not found"),
+			"openai":    core.NewInvalidRequestError("provider rejected file id", nil),
+		},
+	}
+
+	e := echo.New()
+	handler := NewHandler(mock, nil, nil, nil)
+	handler.SetFileStore(failingFileStore{err: errors.New("file store unavailable")})
+
+	batchRec := createInputFileBatchForTest(t, e, handler, "file_source", "")
+	require.Equal(t, http.StatusBadRequest, batchRec.Code)
+	require.Contains(t, batchRec.Body.String(), "provider rejected file id")
+	require.Nil(t, mock.capturedBatchReq)
+}
+
 func TestBatches_CleansUpPreparedInputFileOnCreateFailure(t *testing.T) {
 	mock := &mockProvider{
 		batchErr: errors.New("provider boom"),

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -349,6 +349,33 @@ func (emptyProviderFileStore) Close() error {
 	return nil
 }
 
+type failingFileStore struct {
+	err error
+}
+
+func (s failingFileStore) storeErr() error {
+	if s.err != nil {
+		return s.err
+	}
+	return errors.New("file store failed")
+}
+
+func (s failingFileStore) Upsert(context.Context, *filestore.StoredFile) error {
+	return s.storeErr()
+}
+
+func (s failingFileStore) Get(context.Context, string) (*filestore.StoredFile, error) {
+	return nil, s.storeErr()
+}
+
+func (s failingFileStore) Delete(context.Context, string) error {
+	return s.storeErr()
+}
+
+func (s failingFileStore) Close() error {
+	return nil
+}
+
 // mockProvider implements core.RoutableProvider for testing
 type mockProvider struct {
 	err               error
@@ -3896,6 +3923,47 @@ func TestBatches_LegacyFallbackUsesFileProvider(t *testing.T) {
 	require.Equal(t, "file_source", mock.capturedBatchReq.InputFileID)
 }
 
+func TestBatches_FileStoreLookupErrorFallsBackToProvider(t *testing.T) {
+	mock := &mockProvider{
+		supportedModels: []string{"gpt-4o-mini", "claude-3-haiku"},
+		providerTypes: map[string]string{
+			"gpt-4o-mini":    "openai",
+			"claude-3-haiku": "anthropic",
+		},
+		fileErrByProvider: map[string]error{
+			"openai": core.NewNotFoundError("file not found"),
+		},
+		fileGetByProvider: map[string]*core.FileObject{
+			"anthropic": {
+				ID:        "file_source",
+				Object:    "file",
+				Bytes:     32,
+				CreatedAt: 1000,
+				Filename:  "requests.jsonl",
+				Purpose:   "batch",
+				Provider:  "anthropic",
+			},
+		},
+		batchCreateResponse: &core.BatchResponse{
+			ID:          "provider-batch-1",
+			Object:      "batch",
+			Status:      "validating",
+			CreatedAt:   1234567890,
+			InputFileID: "file_source",
+		},
+	}
+
+	e := echo.New()
+	handler := NewHandler(mock, nil, nil, nil)
+	handler.SetFileStore(failingFileStore{err: errors.New("file store unavailable")})
+
+	batchRec := createInputFileBatchForTest(t, e, handler, "file_source", "")
+	require.Equal(t, http.StatusOK, batchRec.Code)
+	require.Equal(t, "anthropic", mock.capturedBatchProvider)
+	require.NotNil(t, mock.capturedBatchReq)
+	require.Equal(t, "file_source", mock.capturedBatchReq.InputFileID)
+}
+
 func TestBatches_CleansUpPreparedInputFileOnCreateFailure(t *testing.T) {
 	mock := &mockProvider{
 		batchErr: errors.New("provider boom"),
@@ -6022,6 +6090,46 @@ func TestGetFileWithoutProviderSkipsProviderErrors(t *testing.T) {
 	}
 	if entry.Provider != "openai" {
 		t.Fatalf("audit entry provider = %q, want openai", entry.Provider)
+	}
+}
+
+func TestGetFile_FileStoreLookupErrorFallsBackToProvider(t *testing.T) {
+	mock := &mockProvider{
+		supportedModels: []string{"gpt-4o-mini"},
+		providerTypes: map[string]string{
+			"gpt-4o-mini": "openai",
+		},
+		fileGetByProvider: map[string]*core.FileObject{
+			"openai": {
+				ID:        "file_ok_1",
+				Object:    "file",
+				Bytes:     10,
+				CreatedAt: 1000,
+				Filename:  "a.jsonl",
+				Purpose:   "batch",
+				Provider:  "openai",
+			},
+		},
+	}
+
+	e := echo.New()
+	handler := NewHandler(mock, nil, nil, nil)
+	handler.SetFileStore(failingFileStore{err: errors.New("file store unavailable")})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/files/file_ok_1", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/v1/files/:id")
+	setPathParam(c, "id", "file_ok_1")
+
+	if err := handler.GetFile(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "\"provider\":\"openai\"") {
+		t.Fatalf("unexpected response body: %s", rec.Body.String())
 	}
 }
 

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -331,6 +331,24 @@ func (s *failingBatchStore) Close() error {
 	return nil
 }
 
+type emptyProviderFileStore struct{}
+
+func (emptyProviderFileStore) Upsert(context.Context, *filestore.StoredFile) error {
+	return nil
+}
+
+func (emptyProviderFileStore) Get(_ context.Context, id string) (*filestore.StoredFile, error) {
+	return &filestore.StoredFile{ID: id}, nil
+}
+
+func (emptyProviderFileStore) Delete(context.Context, string) error {
+	return nil
+}
+
+func (emptyProviderFileStore) Close() error {
+	return nil
+}
+
 // mockProvider implements core.RoutableProvider for testing
 type mockProvider struct {
 	err               error
@@ -3702,6 +3720,55 @@ func TestBatches_UsesExplicitBatchRequestPreparer(t *testing.T) {
 	}, stored.RequestEndpointByCustomID)
 }
 
+func uploadBatchInputFileForTest(t *testing.T, e *echo.Echo, handler *Handler, providerType string) {
+	t.Helper()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	require.NoError(t, writer.WriteField("purpose", "batch"))
+	if providerType != "" {
+		require.NoError(t, writer.WriteField("provider", providerType))
+	}
+	part, err := writer.CreateFormFile("file", "requests.jsonl")
+	require.NoError(t, err)
+	_, err = part.Write([]byte("{\"custom_id\":\"1\"}\n"))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	uploadReq := httptest.NewRequest(http.MethodPost, "/v1/files", &body)
+	uploadReq.Header.Set("Content-Type", writer.FormDataContentType())
+	uploadFrame := core.NewRequestSnapshot(http.MethodPost, "/v1/files", nil, nil, nil, writer.FormDataContentType(), nil, false, "", nil)
+	uploadReq = withRequestSnapshotAndPrompt(uploadReq, uploadFrame)
+	uploadRec := httptest.NewRecorder()
+	uploadCtx := e.NewContext(uploadReq, uploadRec)
+
+	require.NoError(t, handler.CreateFile(uploadCtx))
+	require.Equal(t, http.StatusOK, uploadRec.Code)
+}
+
+func createInputFileBatchForTest(t *testing.T, e *echo.Echo, handler *Handler, inputFileID, metadataProvider string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	payload := map[string]any{
+		"input_file_id":     inputFileID,
+		"endpoint":          "/v1/chat/completions",
+		"completion_window": "24h",
+	}
+	if metadataProvider != "" {
+		payload["metadata"] = map[string]string{"provider": metadataProvider}
+	}
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	batchReq := httptest.NewRequest(http.MethodPost, "/v1/batches", bytes.NewReader(body))
+	batchReq.Header.Set("Content-Type", "application/json")
+	batchRec := httptest.NewRecorder()
+	batchCtx := e.NewContext(batchReq, batchRec)
+
+	require.NoError(t, handler.Batches(batchCtx))
+	return batchRec
+}
+
 func TestBatches_InputFileUsesStoredFileProviderWithoutMetadata(t *testing.T) {
 	mock := &mockProvider{
 		supportedModels: []string{"gpt-4o-mini", "claude-3-haiku"},
@@ -3732,42 +3799,99 @@ func TestBatches_InputFileUsesStoredFileProviderWithoutMetadata(t *testing.T) {
 	handler := NewHandler(mock, nil, nil, nil)
 	handler.SetFileStore(fileStore)
 
-	var body bytes.Buffer
-	writer := multipart.NewWriter(&body)
-	require.NoError(t, writer.WriteField("purpose", "batch"))
-	require.NoError(t, writer.WriteField("provider", "openai"))
-	part, err := writer.CreateFormFile("file", "requests.jsonl")
-	require.NoError(t, err)
-	_, err = part.Write([]byte("{\"custom_id\":\"1\"}\n"))
-	require.NoError(t, err)
-	require.NoError(t, writer.Close())
-
-	uploadReq := httptest.NewRequest(http.MethodPost, "/v1/files", &body)
-	uploadReq.Header.Set("Content-Type", writer.FormDataContentType())
-	uploadFrame := core.NewRequestSnapshot(http.MethodPost, "/v1/files", nil, nil, nil, writer.FormDataContentType(), nil, false, "", nil)
-	uploadReq = withRequestSnapshotAndPrompt(uploadReq, uploadFrame)
-	uploadRec := httptest.NewRecorder()
-	uploadCtx := e.NewContext(uploadReq, uploadRec)
-
-	require.NoError(t, handler.CreateFile(uploadCtx))
-	require.Equal(t, http.StatusOK, uploadRec.Code)
+	uploadBatchInputFileForTest(t, e, handler, "openai")
 
 	stored, err := fileStore.Get(context.Background(), "file_source")
 	require.NoError(t, err)
 	require.Equal(t, "openai", stored.ProviderType)
 
-	batchReq := httptest.NewRequest(http.MethodPost, "/v1/batches", strings.NewReader(`{
-	  "input_file_id":"file_source",
-	  "endpoint":"/v1/chat/completions",
-	  "completion_window":"24h"
-	}`))
-	batchReq.Header.Set("Content-Type", "application/json")
-	batchRec := httptest.NewRecorder()
-	batchCtx := e.NewContext(batchReq, batchRec)
-
-	require.NoError(t, handler.Batches(batchCtx))
+	batchRec := createInputFileBatchForTest(t, e, handler, "file_source", "")
 	require.Equal(t, http.StatusOK, batchRec.Code)
 	require.Equal(t, "openai", mock.capturedBatchProvider)
+	require.NotNil(t, mock.capturedBatchReq)
+	require.Equal(t, "file_source", mock.capturedBatchReq.InputFileID)
+}
+
+func TestBatches_InputFileUsesMetadataProviderOverride(t *testing.T) {
+	mock := &mockProvider{
+		supportedModels: []string{"gpt-4o-mini", "claude-3-haiku"},
+		providerTypes: map[string]string{
+			"gpt-4o-mini":    "openai",
+			"claude-3-haiku": "anthropic",
+		},
+		fileCreateResponse: &core.FileObject{
+			ID:        "file_source",
+			Object:    "file",
+			Bytes:     32,
+			CreatedAt: 1000,
+			Filename:  "requests.jsonl",
+			Purpose:   "batch",
+			Provider:  "openai",
+		},
+		batchCreateResponse: &core.BatchResponse{
+			ID:          "provider-batch-1",
+			Object:      "batch",
+			Status:      "validating",
+			CreatedAt:   1234567890,
+			InputFileID: "file_source",
+		},
+	}
+
+	e := echo.New()
+	fileStore := filestore.NewMemoryStore()
+	handler := NewHandler(mock, nil, nil, nil)
+	handler.SetFileStore(fileStore)
+
+	uploadBatchInputFileForTest(t, e, handler, "openai")
+
+	stored, err := fileStore.Get(context.Background(), "file_source")
+	require.NoError(t, err)
+	require.Equal(t, "openai", stored.ProviderType)
+
+	batchRec := createInputFileBatchForTest(t, e, handler, "file_source", "anthropic")
+	require.Equal(t, http.StatusOK, batchRec.Code)
+	require.Equal(t, "anthropic", mock.capturedBatchProvider)
+	require.NotNil(t, mock.capturedBatchReq)
+	require.Equal(t, "file_source", mock.capturedBatchReq.InputFileID)
+}
+
+func TestBatches_LegacyFallbackUsesFileProvider(t *testing.T) {
+	mock := &mockProvider{
+		supportedModels: []string{"gpt-4o-mini", "claude-3-haiku"},
+		providerTypes: map[string]string{
+			"gpt-4o-mini":    "openai",
+			"claude-3-haiku": "anthropic",
+		},
+		fileErrByProvider: map[string]error{
+			"openai": core.NewNotFoundError("file not found"),
+		},
+		fileGetByProvider: map[string]*core.FileObject{
+			"anthropic": {
+				ID:        "file_source",
+				Object:    "file",
+				Bytes:     32,
+				CreatedAt: 1000,
+				Filename:  "requests.jsonl",
+				Purpose:   "batch",
+				Provider:  "anthropic",
+			},
+		},
+		batchCreateResponse: &core.BatchResponse{
+			ID:          "provider-batch-1",
+			Object:      "batch",
+			Status:      "validating",
+			CreatedAt:   1234567890,
+			InputFileID: "file_source",
+		},
+	}
+
+	e := echo.New()
+	handler := NewHandler(mock, nil, nil, nil)
+	handler.SetFileStore(emptyProviderFileStore{})
+
+	batchRec := createInputFileBatchForTest(t, e, handler, "file_source", "")
+	require.Equal(t, http.StatusOK, batchRec.Code)
+	require.Equal(t, "anthropic", mock.capturedBatchProvider)
 	require.NotNil(t, mock.capturedBatchReq)
 	require.Equal(t, "file_source", mock.capturedBatchReq.InputFileID)
 }

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -27,6 +27,7 @@ import (
 	"gomodel/internal/auditlog"
 	batchstore "gomodel/internal/batch"
 	"gomodel/internal/core"
+	"gomodel/internal/filestore"
 	"gomodel/internal/guardrails"
 	"gomodel/internal/observability"
 	provideradapter "gomodel/internal/providers"
@@ -587,6 +588,10 @@ func (m *mockProvider) NativeFileProviderTypes() []string {
 	}
 	sort.Strings(result)
 	return result
+}
+
+func (m *mockProvider) NativeBatchProviderTypes() []string {
+	return m.NativeFileProviderTypes()
 }
 
 func (m *mockProvider) NativeResponseProviderTypes() []string {
@@ -3695,6 +3700,76 @@ func TestBatches_UsesExplicitBatchRequestPreparer(t *testing.T) {
 		"prepared-1": "/v1/responses",
 		"provider-1": "/v1/chat/completions",
 	}, stored.RequestEndpointByCustomID)
+}
+
+func TestBatches_InputFileUsesStoredFileProviderWithoutMetadata(t *testing.T) {
+	mock := &mockProvider{
+		supportedModels: []string{"gpt-4o-mini", "claude-3-haiku"},
+		providerTypes: map[string]string{
+			"gpt-4o-mini":    "openai",
+			"claude-3-haiku": "anthropic",
+		},
+		fileCreateResponse: &core.FileObject{
+			ID:        "file_source",
+			Object:    "file",
+			Bytes:     32,
+			CreatedAt: 1000,
+			Filename:  "requests.jsonl",
+			Purpose:   "batch",
+			Provider:  "openai",
+		},
+		batchCreateResponse: &core.BatchResponse{
+			ID:          "provider-batch-1",
+			Object:      "batch",
+			Status:      "validating",
+			CreatedAt:   1234567890,
+			InputFileID: "file_source",
+		},
+	}
+
+	e := echo.New()
+	fileStore := filestore.NewMemoryStore()
+	handler := NewHandler(mock, nil, nil, nil)
+	handler.SetFileStore(fileStore)
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	require.NoError(t, writer.WriteField("purpose", "batch"))
+	require.NoError(t, writer.WriteField("provider", "openai"))
+	part, err := writer.CreateFormFile("file", "requests.jsonl")
+	require.NoError(t, err)
+	_, err = part.Write([]byte("{\"custom_id\":\"1\"}\n"))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	uploadReq := httptest.NewRequest(http.MethodPost, "/v1/files", &body)
+	uploadReq.Header.Set("Content-Type", writer.FormDataContentType())
+	uploadFrame := core.NewRequestSnapshot(http.MethodPost, "/v1/files", nil, nil, nil, writer.FormDataContentType(), nil, false, "", nil)
+	uploadReq = withRequestSnapshotAndPrompt(uploadReq, uploadFrame)
+	uploadRec := httptest.NewRecorder()
+	uploadCtx := e.NewContext(uploadReq, uploadRec)
+
+	require.NoError(t, handler.CreateFile(uploadCtx))
+	require.Equal(t, http.StatusOK, uploadRec.Code)
+
+	stored, err := fileStore.Get(context.Background(), "file_source")
+	require.NoError(t, err)
+	require.Equal(t, "openai", stored.ProviderType)
+
+	batchReq := httptest.NewRequest(http.MethodPost, "/v1/batches", strings.NewReader(`{
+	  "input_file_id":"file_source",
+	  "endpoint":"/v1/chat/completions",
+	  "completion_window":"24h"
+	}`))
+	batchReq.Header.Set("Content-Type", "application/json")
+	batchRec := httptest.NewRecorder()
+	batchCtx := e.NewContext(batchReq, batchRec)
+
+	require.NoError(t, handler.Batches(batchCtx))
+	require.Equal(t, http.StatusOK, batchRec.Code)
+	require.Equal(t, "openai", mock.capturedBatchProvider)
+	require.NotNil(t, mock.capturedBatchReq)
+	require.Equal(t, "file_source", mock.capturedBatchReq.InputFileID)
 }
 
 func TestBatches_CleansUpPreparedInputFileOnCreateFailure(t *testing.T) {

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -22,6 +22,7 @@ import (
 	"gomodel/internal/auditlog"
 	batchstore "gomodel/internal/batch"
 	"gomodel/internal/core"
+	"gomodel/internal/filestore"
 	"gomodel/internal/responsecache"
 	"gomodel/internal/responsestore"
 	"gomodel/internal/usage"
@@ -64,6 +65,7 @@ type Config struct {
 	KeepOnlyAliasesAtModelsEndpoint bool                                   // Whether GET /v1/models should hide concrete provider models
 	PassthroughSemanticEnrichers    []core.PassthroughSemanticEnricher     // Optional: provider-owned passthrough semantic enrichers before workflow resolution
 	BatchStore                      batchstore.Store                       // Optional: Batch lifecycle persistence store
+	FileStore                       filestore.Store                        // Optional: File provider mapping persistence store
 	ResponseStore                   responsestore.Store                    // Optional: Responses lifecycle persistence store
 	LogOnlyModelInteractions        bool                                   // Only log AI model endpoints (default: true)
 	DisablePassthroughRoutes        bool                                   // Disable /p/{provider}/{endpoint} route registration
@@ -137,6 +139,9 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 	}
 	if cfg != nil && cfg.BatchStore != nil {
 		handler.SetBatchStore(cfg.BatchStore)
+	}
+	if cfg != nil && cfg.FileStore != nil {
+		handler.SetFileStore(cfg.FileStore)
 	}
 	if cfg != nil && cfg.ResponseStore != nil {
 		handler.SetResponseStore(cfg.ResponseStore)

--- a/internal/server/native_batch_service.go
+++ b/internal/server/native_batch_service.go
@@ -20,6 +20,7 @@ type nativeBatchService struct {
 	provider                             core.RoutableProvider
 	modelResolver                        RequestModelResolver
 	modelAuthorizer                      RequestModelAuthorizer
+	inputFileProviderResolver            gateway.BatchInputFileProviderResolver
 	workflowPolicyResolver               RequestWorkflowPolicyResolver
 	batchRequestPreparer                 BatchRequestPreparer
 	batchStore                           batchstore.Store
@@ -40,6 +41,7 @@ func (s *nativeBatchService) batch() *gateway.BatchOrchestrator {
 		Provider:                             s.provider,
 		ModelResolver:                        s.modelResolver,
 		ModelAuthorizer:                      s.modelAuthorizer,
+		InputFileProviderResolver:            s.inputFileProviderResolver,
 		WorkflowPolicyResolver:               s.workflowPolicyResolver,
 		BatchRequestPreparer:                 s.batchRequestPreparer,
 		BatchStore:                           s.batchStore,

--- a/internal/server/native_file_service.go
+++ b/internal/server/native_file_service.go
@@ -10,12 +10,14 @@ import (
 
 	"gomodel/internal/auditlog"
 	"gomodel/internal/core"
+	"gomodel/internal/filestore"
 )
 
 // nativeFileService owns native file orchestration so HTTP handlers can remain
 // thin transport adapters.
 type nativeFileService struct {
-	provider core.RoutableProvider
+	provider  core.RoutableProvider
+	fileStore filestore.Store
 }
 
 func (s *nativeFileService) router() (core.NativeFileRoutableProvider, error) {
@@ -38,6 +40,7 @@ func (s *nativeFileService) fileByID(
 	c *echo.Context,
 	callFn func(core.NativeFileRoutableProvider, string, string) (any, error),
 	respondFn func(*echo.Context, any) error,
+	onSuccess func(context.Context, string, string) error,
 ) error {
 	nativeRouter, err := s.router()
 	if err != nil {
@@ -60,7 +63,31 @@ func (s *nativeFileService) fileByID(
 		if err != nil {
 			return handleError(c, err)
 		}
+		if onSuccess != nil {
+			if err := onSuccess(c.Request().Context(), providerType, id); err != nil {
+				return handleError(c, err)
+			}
+		}
 		return respondFn(c, result)
+	}
+
+	if providerType, ok, err := s.storedProviderForFile(c.Request().Context(), id); err != nil {
+		return handleError(c, err)
+	} else if ok {
+		result, err := callFn(nativeRouter, providerType, id)
+		if err == nil {
+			auditlog.EnrichEntry(c, "file", providerType)
+			if onSuccess != nil {
+				if err := onSuccess(c.Request().Context(), providerType, id); err != nil {
+					return handleError(c, err)
+				}
+			}
+			return respondFn(c, result)
+		}
+		if !isNotFoundGatewayError(err) && !isUnsupportedNativeFilesError(err) {
+			return handleError(c, err)
+		}
+		_ = s.deleteStoredFileMapping(c.Request().Context(), id)
 	}
 
 	providers, err := s.providerTypes()
@@ -74,6 +101,11 @@ func (s *nativeFileService) fileByID(
 		result, err := callFn(nativeRouter, candidate, id)
 		if err == nil {
 			auditlog.EnrichEntry(c, "file", candidate)
+			if onSuccess != nil {
+				if err := onSuccess(c.Request().Context(), candidate, id); err != nil {
+					return handleError(c, err)
+				}
+			}
 			return respondFn(c, result)
 		}
 		if isNotFoundGatewayError(err) || isUnsupportedNativeFilesError(err) {
@@ -146,6 +178,9 @@ func (s *nativeFileService) CreateFile(c *echo.Context) error {
 	if err != nil {
 		return handleError(c, err)
 	}
+	if err := s.recordStoredFile(ctx, resp, providerType); err != nil {
+		return handleError(c, err)
+	}
 	return c.JSON(http.StatusOK, resp)
 }
 
@@ -209,6 +244,7 @@ func (s *nativeFileService) GetFile(c *echo.Context) error {
 		func(c *echo.Context, result any) error {
 			return c.JSON(http.StatusOK, result)
 		},
+		nil,
 	)
 }
 
@@ -219,6 +255,9 @@ func (s *nativeFileService) DeleteFile(c *echo.Context) error {
 		},
 		func(c *echo.Context, result any) error {
 			return c.JSON(http.StatusOK, result)
+		},
+		func(ctx context.Context, _, id string) error {
+			return s.deleteStoredFileMapping(ctx, id)
 		},
 	)
 }
@@ -239,7 +278,60 @@ func (s *nativeFileService) GetFileContent(c *echo.Context) error {
 			}
 			return c.Blob(http.StatusOK, contentType, resp.Data)
 		},
+		nil,
 	)
+}
+
+func (s *nativeFileService) recordStoredFile(ctx context.Context, resp *core.FileObject, providerType string) error {
+	if s.fileStore == nil || resp == nil {
+		return nil
+	}
+	if strings.TrimSpace(resp.ID) == "" {
+		return nil
+	}
+	createdAt := resp.CreatedAt
+	if createdAt <= 0 {
+		createdAt = 0
+	}
+	if err := s.fileStore.Upsert(ctx, &filestore.StoredFile{
+		ID:           resp.ID,
+		ProviderType: providerType,
+		Purpose:      resp.Purpose,
+		Filename:     resp.Filename,
+		Bytes:        resp.Bytes,
+		CreatedAt:    createdAt,
+		UserPath:     core.UserPathFromContext(ctx),
+	}); err != nil {
+		return core.NewProviderError("file_store", http.StatusInternalServerError, "failed to persist file provider mapping", err)
+	}
+	return nil
+}
+
+func (s *nativeFileService) storedProviderForFile(ctx context.Context, id string) (string, bool, error) {
+	if s.fileStore == nil {
+		return "", false, nil
+	}
+	stored, err := s.fileStore.Get(ctx, id)
+	switch {
+	case err == nil && stored != nil && strings.TrimSpace(stored.ProviderType) != "":
+		return strings.TrimSpace(stored.ProviderType), true, nil
+	case err == nil:
+		return "", false, nil
+	case errors.Is(err, filestore.ErrNotFound):
+		return "", false, nil
+	default:
+		return "", false, core.NewProviderError("file_store", http.StatusInternalServerError, "failed to look up file provider mapping", err)
+	}
+}
+
+func (s *nativeFileService) deleteStoredFileMapping(ctx context.Context, id string) error {
+	if s.fileStore == nil {
+		return nil
+	}
+	if err := s.fileStore.Delete(ctx, id); err != nil && !errors.Is(err, filestore.ErrNotFound) {
+		return core.NewProviderError("file_store", http.StatusInternalServerError, "failed to delete file provider mapping", err)
+	}
+	return nil
 }
 
 func isNotFoundGatewayError(err error) bool {

--- a/internal/server/native_file_service.go
+++ b/internal/server/native_file_service.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -87,7 +88,9 @@ func (s *nativeFileService) fileByID(
 		if !isNotFoundGatewayError(err) && !isUnsupportedNativeFilesError(err) {
 			return handleError(c, err)
 		}
-		_ = s.deleteStoredFileMapping(c.Request().Context(), id)
+		if err := s.deleteStoredFileMapping(c.Request().Context(), id); err != nil {
+			slog.Warn("failed to delete stale file provider mapping", "file_id", id, "provider", providerType, "error", err)
+		}
 	}
 
 	providers, err := s.providerTypes()
@@ -179,7 +182,11 @@ func (s *nativeFileService) CreateFile(c *echo.Context) error {
 		return handleError(c, err)
 	}
 	if err := s.recordStoredFile(ctx, resp, providerType); err != nil {
-		return handleError(c, err)
+		fileID := ""
+		if resp != nil {
+			fileID = resp.ID
+		}
+		slog.Warn("failed to persist file provider mapping", "file_id", fileID, "provider", providerType, "error", err)
 	}
 	return c.JSON(http.StatusOK, resp)
 }
@@ -256,8 +263,11 @@ func (s *nativeFileService) DeleteFile(c *echo.Context) error {
 		func(c *echo.Context, result any) error {
 			return c.JSON(http.StatusOK, result)
 		},
-		func(ctx context.Context, _, id string) error {
-			return s.deleteStoredFileMapping(ctx, id)
+		func(ctx context.Context, providerType, id string) error {
+			if err := s.deleteStoredFileMapping(ctx, id); err != nil {
+				slog.Warn("failed to delete file provider mapping", "file_id", id, "provider", providerType, "error", err)
+			}
+			return nil
 		},
 	)
 }

--- a/internal/server/native_file_service.go
+++ b/internal/server/native_file_service.go
@@ -322,16 +322,16 @@ func (s *nativeFileService) storedProviderForFile(ctx context.Context, id string
 		return "", false, nil
 	}
 	stored, err := s.fileStore.Get(ctx, id)
-	switch {
-	case err == nil && stored != nil && strings.TrimSpace(stored.ProviderType) != "":
-		return strings.TrimSpace(stored.ProviderType), true, nil
-	case err == nil:
+	if err != nil {
+		if !errors.Is(err, filestore.ErrNotFound) {
+			slog.Warn("failed to look up file provider mapping", "file_id", id, "error", err)
+		}
 		return "", false, nil
-	case errors.Is(err, filestore.ErrNotFound):
-		return "", false, nil
-	default:
-		return "", false, core.NewProviderError("file_store", http.StatusInternalServerError, "failed to look up file provider mapping", err)
 	}
+	if stored != nil && strings.TrimSpace(stored.ProviderType) != "" {
+		return strings.TrimSpace(stored.ProviderType), true, nil
+	}
+	return "", false, nil
 }
 
 func (s *nativeFileService) deleteStoredFileMapping(ctx context.Context, id string) error {


### PR DESCRIPTION
## Summary
- Persist provider ownership for uploaded files in the configured storage backend.
- Use the stored owner when creating native batches from input_file_id without metadata.provider.
- Keep explicit metadata.provider overrides and add fallback provider discovery for older uploaded files.

## Tests
- go test ./...
- pre-commit hook: make test-race, performance guard, make lint
- live validation: a batch request without metadata.provider no longer fails gateway validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable filestore for persisting file→provider mappings with multiple backends (in-memory, SQLite, PostgreSQL, MongoDB).
  * Batch creation can resolve provider from stored files or by probing native providers; metadata provider overrides.
  * Discovery of native-batch-capable provider types.

* **Behavior**
  * Native file operations record and reuse provider ownership per file ID; stale mappings are cleaned when appropriate.
  * Batch routing now considers input-file provider resolution.

* **Tests**
  * Added tests for Upsert behavior and batch provider resolution using stored files.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ENTERPILOT/GoModel/pull/318)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->