### PR TITLE
fix(providers): propagate quota project to Vertex via X-Goog-User-Project

### DIFF
--- a/internal/providers/gemini/gemini.go
+++ b/internal/providers/gemini/gemini.go
@@ -190,7 +190,7 @@ func (p *Provider) authHTTPClient(providerCfg providers.ProviderConfig, base *ht
 	if p.configErr != nil || p.authType == geminiAuthTypeAPIKey {
 		return base
 	}
-	source, err := googleauth.TokenSource(context.Background(), googleauth.Config{
+	creds, err := googleauth.FindCredentials(context.Background(), googleauth.Config{
 		AuthType:                 p.authType,
 		ServiceAccountFile:       providerCfg.ServiceAccountFile,
 		ServiceAccountJSON:       providerCfg.ServiceAccountJSON,
@@ -204,7 +204,11 @@ func (p *Provider) authHTTPClient(providerCfg providers.ProviderConfig, base *ht
 	if base == nil {
 		base = httpclient.NewDefaultHTTPClient()
 	}
-	return googleauth.HTTPClient(base, source)
+	quotaProject := creds.QuotaProjectID
+	if strings.TrimSpace(quotaProject) == "" {
+		quotaProject = strings.TrimSpace(providerCfg.VertexProject)
+	}
+	return googleauth.HTTPClient(base, creds.TokenSource, quotaProject)
 }
 
 func (p *Provider) ready() error {

--- a/internal/providers/gemini/gemini_test.go
+++ b/internal/providers/gemini/gemini_test.go
@@ -751,7 +751,7 @@ func newVertexTestProvider(server *httptest.Server, native bool) *Provider {
 	tokenClient := googleauth.HTTPClient(server.Client(), oauth2.StaticTokenSource(&oauth2.Token{
 		AccessToken: "vertex-token",
 		TokenType:   "Bearer",
-	}))
+	}), "")
 	p := &Provider{
 		backend:      geminiBackendVertex,
 		authType:     geminiAuthTypeGCPADC,

--- a/internal/providers/googleauth/googleauth.go
+++ b/internal/providers/googleauth/googleauth.go
@@ -3,6 +3,7 @@ package googleauth
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -14,12 +15,28 @@ import (
 
 const DefaultScope = "https://www.googleapis.com/auth/cloud-platform"
 
+// QuotaProjectHeader is the HTTP header Google APIs read to determine which
+// project to bill and count quota against. Required for ADC user credentials
+// against APIs like aiplatform.googleapis.com; harmless (and routinely set)
+// for service-account credentials.
+const QuotaProjectHeader = "X-Goog-User-Project"
+
 type Config struct {
 	AuthType                 string
 	ServiceAccountFile       string
 	ServiceAccountJSON       string
 	ServiceAccountJSONBase64 string
 	Scope                    string
+}
+
+// Credentials bundles the OAuth2 token source with the project ID resolved
+// from the credentials material. For ADC user credentials this is the
+// `quota_project_id` written by `gcloud auth application-default
+// set-quota-project`; for service accounts it is the SA JSON `project_id`.
+// QuotaProjectID may be empty when neither source supplies one.
+type Credentials struct {
+	TokenSource    oauth2.TokenSource
+	QuotaProjectID string
 }
 
 func NormalizeAuthType(authType string, hasServiceAccount bool) string {
@@ -42,7 +59,13 @@ func HasServiceAccount(cfg Config) bool {
 		strings.TrimSpace(cfg.ServiceAccountFile) != ""
 }
 
-func TokenSource(ctx context.Context, cfg Config) (oauth2.TokenSource, error) {
+// FindCredentials resolves a TokenSource and QuotaProjectID from either a
+// service-account credential (file, raw JSON, or base64 JSON) or Application
+// Default Credentials. The returned QuotaProjectID flows from ADC
+// `quota_project_id` or SA `project_id` and is intended to be sent as the
+// X-Goog-User-Project header on outbound API calls; callers may override it
+// when their resource-owning project differs from the auth project.
+func FindCredentials(ctx context.Context, cfg Config) (*Credentials, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -54,23 +77,60 @@ func TokenSource(ctx context.Context, cfg Config) (oauth2.TokenSource, error) {
 	authType := NormalizeAuthType(cfg.AuthType, HasServiceAccount(cfg))
 	switch authType {
 	case "gcp_service_account":
-		credentials, err := serviceAccountJSON(cfg)
+		credBytes, err := serviceAccountJSON(cfg)
 		if err != nil {
 			return nil, err
 		}
-		jwtCfg, err := google.JWTConfigFromJSON(credentials, scope)
+		creds, err := google.CredentialsFromJSONWithType(ctx, credBytes, google.ServiceAccount, scope)
 		if err != nil {
 			return nil, fmt.Errorf("parse service account credentials: %w", err)
 		}
-		return jwtCfg.TokenSource(ctx), nil
+		return &Credentials{TokenSource: creds.TokenSource, QuotaProjectID: resolveQuotaProject(creds)}, nil
 	case "gcp_adc":
-		source, err := google.DefaultTokenSource(ctx, scope)
+		creds, err := google.FindDefaultCredentials(ctx, scope)
 		if err != nil {
 			return nil, fmt.Errorf("load application default credentials: %w", err)
 		}
-		return source, nil
+		return &Credentials{TokenSource: creds.TokenSource, QuotaProjectID: resolveQuotaProject(creds)}, nil
 	}
 	return nil, fmt.Errorf("unsupported Google auth type %q", authType)
+}
+
+// resolveQuotaProject returns the project that should be sent as
+// X-Goog-User-Project. For service-account credentials this is the `project_id`
+// already surfaced on *google.Credentials. For authorized-user ADC the public
+// Credentials struct leaves ProjectID empty, so we parse `quota_project_id`
+// from the raw JSON ourselves — that field is what `gcloud auth
+// application-default set-quota-project` writes and is required for ADC
+// access to APIs like aiplatform.googleapis.com.
+func resolveQuotaProject(creds *google.Credentials) string {
+	if creds == nil {
+		return ""
+	}
+	if project := strings.TrimSpace(creds.ProjectID); project != "" {
+		return project
+	}
+	if len(creds.JSON) == 0 {
+		return ""
+	}
+	var raw struct {
+		QuotaProjectID string `json:"quota_project_id"`
+	}
+	if err := json.Unmarshal(creds.JSON, &raw); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(raw.QuotaProjectID)
+}
+
+// TokenSource returns just the OAuth2 token source for the given config. It is
+// a thin wrapper around FindCredentials kept for callers that do not need the
+// resolved quota project.
+func TokenSource(ctx context.Context, cfg Config) (oauth2.TokenSource, error) {
+	creds, err := FindCredentials(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return creds.TokenSource, nil
 }
 
 func serviceAccountJSON(cfg Config) ([]byte, error) {
@@ -132,7 +192,12 @@ func paddedBase64(value string) string {
 	}
 }
 
-func HTTPClient(base *http.Client, source oauth2.TokenSource) *http.Client {
+// HTTPClient returns an *http.Client that injects bearer tokens from source on
+// every request and, when quotaProject is non-empty, also sets the
+// X-Goog-User-Project header. The latter is required for ADC user-credential
+// flows against APIs like aiplatform.googleapis.com that demand an explicit
+// billing project; pass an empty string to skip.
+func HTTPClient(base *http.Client, source oauth2.TokenSource, quotaProject string) *http.Client {
 	if base == nil {
 		base = http.DefaultClient
 	}
@@ -140,10 +205,31 @@ func HTTPClient(base *http.Client, source oauth2.TokenSource) *http.Client {
 	if transport == nil {
 		transport = http.DefaultTransport
 	}
-	clone := *base
-	clone.Transport = &oauth2.Transport{
+	var rt http.RoundTripper = &oauth2.Transport{
 		Source: oauth2.ReuseTokenSource(nil, source),
 		Base:   transport,
 	}
+	if project := strings.TrimSpace(quotaProject); project != "" {
+		rt = &quotaProjectTransport{base: rt, project: project}
+	}
+	clone := *base
+	clone.Transport = rt
 	return &clone
+}
+
+// quotaProjectTransport sets the X-Goog-User-Project header on outbound
+// requests before delegating. The request is cloned so the caller's struct is
+// not mutated.
+type quotaProjectTransport struct {
+	base    http.RoundTripper
+	project string
+}
+
+func (t *quotaProjectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	if clone.Header == nil {
+		clone.Header = make(http.Header)
+	}
+	clone.Header.Set(QuotaProjectHeader, t.project)
+	return t.base.RoundTrip(clone)
 }

--- a/internal/providers/googleauth/googleauth_test.go
+++ b/internal/providers/googleauth/googleauth_test.go
@@ -15,6 +15,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"golang.org/x/oauth2"
 )
 
 func TestServiceAccountJSONDecodesURLSafeBase64(t *testing.T) {
@@ -121,7 +123,7 @@ func TestTokenSourceAndHTTPClientAuthSelection(t *testing.T) {
 			}))
 			defer upstream.Close()
 
-			client := HTTPClient(upstream.Client(), source)
+			client := HTTPClient(upstream.Client(), source, "")
 			resp, err := client.Get(upstream.URL)
 			if err != nil {
 				t.Fatalf("HTTPClient request error = %v", err)
@@ -143,6 +145,11 @@ func TestTokenSourceAndHTTPClientAuthSelection(t *testing.T) {
 
 func adcCredentialsFile(t *testing.T, tokenURL string) string {
 	t.Helper()
+	return adcCredentialsFileWithQuotaProject(t, tokenURL, "")
+}
+
+func adcCredentialsFileWithQuotaProject(t *testing.T, tokenURL, quotaProject string) string {
+	t.Helper()
 	path := filepath.Join(t.TempDir(), "adc.json")
 	contents := map[string]string{
 		"type":          "authorized_user",
@@ -150,6 +157,9 @@ func adcCredentialsFile(t *testing.T, tokenURL string) string {
 		"client_secret": "adc-client-secret",
 		"refresh_token": "adc-refresh-token",
 		"token_uri":     tokenURL,
+	}
+	if quotaProject != "" {
+		contents["quota_project_id"] = quotaProject
 	}
 	encoded, err := json.Marshal(contents)
 	if err != nil {
@@ -159,6 +169,118 @@ func adcCredentialsFile(t *testing.T, tokenURL string) string {
 		t.Fatalf("failed to write ADC credentials: %v", err)
 	}
 	return path
+}
+
+func TestFindCredentialsReadsADCQuotaProject(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "adc-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer tokenServer.Close()
+
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", adcCredentialsFileWithQuotaProject(t, tokenServer.URL, "billing-target"))
+
+	creds, err := FindCredentials(context.Background(), Config{})
+	if err != nil {
+		t.Fatalf("FindCredentials() error = %v", err)
+	}
+	if creds.QuotaProjectID != "billing-target" {
+		t.Fatalf("QuotaProjectID = %q, want billing-target", creds.QuotaProjectID)
+	}
+}
+
+func TestFindCredentialsReadsServiceAccountProject(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "sa-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer tokenServer.Close()
+
+	saJSON := serviceAccountCredentialsWithProject(t, tokenServer.URL, "sa-home-project")
+	creds, err := FindCredentials(context.Background(), Config{ServiceAccountJSON: saJSON})
+	if err != nil {
+		t.Fatalf("FindCredentials() error = %v", err)
+	}
+	if creds.QuotaProjectID != "sa-home-project" {
+		t.Fatalf("QuotaProjectID = %q, want sa-home-project", creds.QuotaProjectID)
+	}
+}
+
+func TestHTTPClientSetsQuotaProjectHeader(t *testing.T) {
+	var gotHeader string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get(QuotaProjectHeader)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	source := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token", TokenType: "Bearer"})
+	client := HTTPClient(upstream.Client(), source, "billing-target")
+	resp, err := client.Get(upstream.URL)
+	if err != nil {
+		t.Fatalf("HTTPClient request error = %v", err)
+	}
+	_ = resp.Body.Close()
+	if gotHeader != "billing-target" {
+		t.Fatalf("%s header = %q, want billing-target", QuotaProjectHeader, gotHeader)
+	}
+}
+
+func TestHTTPClientOmitsQuotaProjectHeaderWhenEmpty(t *testing.T) {
+	var hasHeader bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, hasHeader = r.Header[QuotaProjectHeader]
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	source := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token", TokenType: "Bearer"})
+	client := HTTPClient(upstream.Client(), source, "")
+	resp, err := client.Get(upstream.URL)
+	if err != nil {
+		t.Fatalf("HTTPClient request error = %v", err)
+	}
+	_ = resp.Body.Close()
+	if hasHeader {
+		t.Fatalf("upstream saw %s header; expected it to be omitted", QuotaProjectHeader)
+	}
+}
+
+func serviceAccountCredentialsWithProject(t *testing.T, tokenURL, projectID string) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate test RSA key: %v", err)
+	}
+	keyBytes, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("failed to marshal test RSA key: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: keyBytes,
+	})
+	contents := map[string]string{
+		"type":           "service_account",
+		"client_email":   "service@example.com",
+		"private_key_id": "test-key-id",
+		"private_key":    string(keyPEM),
+		"token_uri":      tokenURL,
+		"project_id":     projectID,
+	}
+	encoded, err := json.Marshal(contents)
+	if err != nil {
+		t.Fatalf("failed to marshal service account credentials: %v", err)
+	}
+	return string(encoded)
 }
 
 func serviceAccountCredentials(t *testing.T, tokenURL string) string {

--- a/internal/providers/vertex/vertex.go
+++ b/internal/providers/vertex/vertex.go
@@ -124,7 +124,7 @@ func (p *Provider) authHTTPClient(providerCfg providers.ProviderConfig, base *ht
 	}
 	authCfg := buildGoogleAuthConfig(providerCfg)
 	authCfg.AuthType = p.authType
-	source, err := googleauth.TokenSource(context.Background(), authCfg)
+	creds, err := googleauth.FindCredentials(context.Background(), authCfg)
 	if err != nil {
 		p.configErr = err
 		return base
@@ -132,7 +132,11 @@ func (p *Provider) authHTTPClient(providerCfg providers.ProviderConfig, base *ht
 	if base == nil {
 		base = httpclient.NewDefaultHTTPClient()
 	}
-	return googleauth.HTTPClient(base, source)
+	quotaProject := creds.QuotaProjectID
+	if strings.TrimSpace(quotaProject) == "" {
+		quotaProject = strings.TrimSpace(providerCfg.VertexProject)
+	}
+	return googleauth.HTTPClient(base, creds.TokenSource, quotaProject)
 }
 
 func buildGoogleAuthConfig(providerCfg providers.ProviderConfig) googleauth.Config {

--- a/internal/providers/vertex/vertex_test.go
+++ b/internal/providers/vertex/vertex_test.go
@@ -354,10 +354,15 @@ func authedTestClient(base *http.Client) *http.Client {
 	return googleauth.HTTPClient(base, oauth2.StaticTokenSource(&oauth2.Token{
 		AccessToken: "vertex-token",
 		TokenType:   "Bearer",
-	}))
+	}), "")
 }
 
 func vertexADCCredentialsFile(t *testing.T, tokenURL string) string {
+	t.Helper()
+	return vertexADCCredentialsFileWithQuotaProject(t, tokenURL, "")
+}
+
+func vertexADCCredentialsFileWithQuotaProject(t *testing.T, tokenURL, quotaProject string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "adc.json")
 	contents := map[string]string{
@@ -367,6 +372,9 @@ func vertexADCCredentialsFile(t *testing.T, tokenURL string) string {
 		"refresh_token": "adc-refresh-token",
 		"token_uri":     tokenURL,
 	}
+	if quotaProject != "" {
+		contents["quota_project_id"] = quotaProject
+	}
 	encoded, err := json.Marshal(contents)
 	if err != nil {
 		t.Fatalf("failed to marshal ADC credentials: %v", err)
@@ -375,6 +383,69 @@ func vertexADCCredentialsFile(t *testing.T, tokenURL string) string {
 		t.Fatalf("failed to write ADC credentials: %v", err)
 	}
 	return path
+}
+
+func TestNewSetsQuotaProjectHeaderOnVertexRequests(t *testing.T) {
+	tests := []struct {
+		name      string
+		configure func(t *testing.T, cfg *providers.ProviderConfig, tokenURL string)
+		wantProj  string
+	}{
+		{
+			name: "ADC quota project wins over VERTEX_PROJECT",
+			configure: func(t *testing.T, cfg *providers.ProviderConfig, tokenURL string) {
+				t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", vertexADCCredentialsFileWithQuotaProject(t, tokenURL, "billing-project"))
+				cfg.AuthType = "gcp_adc"
+			},
+			wantProj: "billing-project",
+		},
+		{
+			name: "ADC without quota project falls back to VERTEX_PROJECT",
+			configure: func(t *testing.T, cfg *providers.ProviderConfig, tokenURL string) {
+				t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", vertexADCCredentialsFile(t, tokenURL))
+				cfg.AuthType = "gcp_adc"
+			},
+			wantProj: "prod-ai",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"access_token": "token",
+					"token_type":   "Bearer",
+					"expires_in":   3600,
+				})
+			}))
+			defer tokenServer.Close()
+
+			var gotProj string
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotProj = r.Header.Get("X-Goog-User-Project")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"responseId":"r","candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}]}`))
+			}))
+			defer upstream.Close()
+
+			cfg := testConfig()
+			cfg.APIMode = "native"
+			cfg.BaseURL = upstream.URL + "/v1/projects/prod-ai/locations/us-central1/publishers/google"
+			tt.configure(t, &cfg, tokenServer.URL)
+
+			provider := New(cfg, providers.ProviderOptions{})
+			if _, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{
+				Model:    "google/gemini-2.5-flash",
+				Messages: []core.Message{{Role: "user", Content: "hi"}},
+			}); err != nil {
+				t.Fatalf("ChatCompletion() error = %v", err)
+			}
+			if gotProj != tt.wantProj {
+				t.Fatalf("X-Goog-User-Project = %q, want %q", gotProj, tt.wantProj)
+			}
+		})
+	}
 }
 
 func vertexServiceAccountCredentialsFile(t *testing.T, tokenURL string) string {


### PR DESCRIPTION
## Summary

- Switch `internal/providers/googleauth` from `google.DefaultTokenSource` / `google.JWTConfigFromJSON` to `google.FindDefaultCredentials` / `google.CredentialsFromJSONWithType`, and expose a new `Credentials` wrapper that carries the resolved quota project alongside the token source.
- Parse `quota_project_id` from the raw ADC JSON ourselves — `*google.Credentials.ProjectID` only surfaces SA `project_id`, the authorized-user ADC quota override never propagates through the public struct.
- Add a `quotaProject` parameter to `googleauth.HTTPClient`. When non-empty, a small `RoundTripper` wrapper sets `X-Goog-User-Project` on every outbound request (above the existing OAuth2 token transport).
- Vertex and Gemini-on-Vertex providers prefer the credential-supplied quota project, then fall back to `VERTEX_PROJECT`. Single-project deployments work out-of-the-box without `gcloud auth application-default set-quota-project`.
- `TokenSource()` is kept as a thin wrapper around `FindCredentials` for callers that only need the token source.

## Why

Surfaced during live testing of #324. With ADC user credentials (the common `gcloud auth application-default login` flow) GoModel was sending requests to `aiplatform.googleapis.com` without an `X-Goog-User-Project` header. Google's Vertex API responds:

```
authentication_error: Your application is authenticating by using local
Application Default Credentials. The aiplatform.googleapis.com API requires
a quota project, which is not set by default.
```

This blocked every ADC-based Vertex deployment, regardless of whether the operator had run `gcloud auth application-default set-quota-project`. Even when set, the quota project lived in `application_default_credentials.json` and was never read.

## Test plan

- [x] `make test-race`, `make lint`, `go mod tidy`, `mint validate` — all green via pre-commit hooks.
- [x] New `googleauth` tests:
  - `TestFindCredentialsReadsADCQuotaProject` — ADC user JSON with `quota_project_id` round-trips through `FindCredentials`.
  - `TestFindCredentialsReadsServiceAccountProject` — SA JSON with `project_id` round-trips through `FindCredentials`.
  - `TestHTTPClientSetsQuotaProjectHeader` — upstream receives `X-Goog-User-Project: <project>` when set.
  - `TestHTTPClientOmitsQuotaProjectHeaderWhenEmpty` — header is omitted entirely when not set.
- [x] New `vertex` integration test `TestNewSetsQuotaProjectHeaderOnVertexRequests` with a live `httptest` upstream:
  - ADC `quota_project_id=billing-project` + `VERTEX_PROJECT=prod-ai` → upstream sees `X-Goog-User-Project: billing-project` (credential wins).
  - ADC without `quota_project_id` + `VERTEX_PROJECT=prod-ai` → upstream sees `X-Goog-User-Project: prod-ai` (fallback).
- [x] Existing `googleauth`, `vertex`, and `gemini` tests updated for the new `HTTPClient` signature; all pass under `-race`.

## Compat

No behavior change for service-account auth, AI Studio Gemini, or any non-Google provider. ADC users who already had a quota project set in their `application_default_credentials.json` will start seeing it propagated automatically; users without one fall back to `VERTEX_PROJECT`, which has always been required for the Vertex provider anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic quota project identification and header injection for Google API requests, enabling improved billing and resource attribution tracking.

* **Improvements**
  * Enhanced credential resolution for Google Cloud authentication providers, including quota project extraction from service accounts and application default credentials.

* **Tests**
  * Expanded test coverage for quota project credential loading and header injection validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ENTERPILOT/GoModel/pull/325)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->