### PR TITLE
fix(providers): mark allowlist mode as authoritative inventory in runtime status

### DIFF
--- a/internal/admin/handler_providers_test.go
+++ b/internal/admin/handler_providers_test.go
@@ -1,0 +1,36 @@
+package admin
+
+import (
+	"testing"
+	"time"
+
+	"gomodel/internal/providers"
+)
+
+// TestClassifyProviderStatus_HealthyForAllowlistInventory locks in the
+// admin-endpoint behavior fixed alongside the registry change that makes
+// allowlist mode set LastModelFetchSuccessAt. Before the fix, an allowlist
+// provider serving real traffic appeared as status=degraded / label=Starting
+// because the classifier treated LastModelFetchSuccessAt==nil as "still
+// loading cached models". Now the classifier correctly reports healthy.
+func TestClassifyProviderStatus_HealthyForAllowlistInventory(t *testing.T) {
+	now := time.Now().UTC()
+	cfg := providers.SanitizedProviderConfig{Name: "bedrock", Type: "bedrock"}
+	runtime := providers.ProviderRuntimeSnapshot{
+		Name:                    "bedrock",
+		Type:                    "bedrock",
+		Registered:              true,
+		RegistryInitialized:     true,
+		DiscoveredModelCount:    1,
+		LastModelFetchAt:        &now,
+		LastModelFetchSuccessAt: &now,
+	}
+
+	status, label, _, _ := classifyProviderStatus(cfg, runtime)
+	if status != "healthy" {
+		t.Fatalf("status = %q, want healthy", status)
+	}
+	if label != "Healthy" {
+		t.Fatalf("label = %q, want Healthy", label)
+	}
+}

--- a/internal/providers/registry_init.go
+++ b/internal/providers/registry_init.go
@@ -184,7 +184,17 @@ func (r *ModelRegistry) fetchAllProviderModels(
 			lastModelFetchAt:    fetchAt,
 			lastModelFetchError: configuredUpstreamError,
 		}
-		if configuredReason == configuredProviderModelsNotApplied {
+		// Mark the inventory as authoritatively populated when this fetch is the
+		// last word on the provider's model list. That covers two cases:
+		//  - upstream succeeded (no allowlist, or allowlist overlaid on a real
+		//    response) — reason is configuredProviderModelsNotApplied
+		//  - allowlist mode intentionally skipped upstream and produced the
+		//    inventory from configuration — reason is configuredProviderModelsAllowlist
+		// Fallback cases (configured*UpstreamError, *Nil, *Empty) keep
+		// lastModelFetchSuccessAt unset so health surfaces "live refresh failed,
+		// serving configured fallback".
+		if configuredReason == configuredProviderModelsNotApplied ||
+			configuredReason == configuredProviderModelsAllowlist {
 			runtimeUpdate.lastModelFetchSuccessAt = fetchAt
 		}
 		out.runtimeUpdates[providerName] = runtimeUpdate

--- a/internal/providers/registry_test.go
+++ b/internal/providers/registry_test.go
@@ -257,8 +257,14 @@ func TestModelRegistry(t *testing.T) {
 		if len(snapshots) != 1 {
 			t.Fatalf("expected 1 provider runtime snapshot, got %d", len(snapshots))
 		}
-		if snapshots[0].LastModelFetchSuccessAt != nil {
-			t.Fatalf("LastModelFetchSuccessAt = %v, want nil when allowlist skips upstream ListModels", snapshots[0].LastModelFetchSuccessAt)
+		if snapshots[0].LastModelFetchSuccessAt == nil {
+			t.Fatal("LastModelFetchSuccessAt = nil, want set when allowlist mode authoritatively populates inventory")
+		}
+		if snapshots[0].DiscoveredModelCount == 0 {
+			t.Fatalf("DiscoveredModelCount = 0, want allowlist models counted")
+		}
+		if snapshots[0].UsingCachedModels {
+			t.Fatal("UsingCachedModels = true, want false when inventory came from allowlist (not stale cache)")
 		}
 		missing := registry.GetModel("missing-configured")
 		if missing == nil {
@@ -1348,9 +1354,9 @@ func (c *countingRegistryMockProvider) ListModels(ctx context.Context) (*core.Mo
 // TestApplyProviderRuntimeUpdates_ClearsStaleErrorOnSuccessfulRefresh locks the
 // behavior that a successful refresh (non-zero fetchAt + empty fetch error)
 // clears any error left over from a previous failed refresh, regardless of
-// whether the success bumps lastModelFetchSuccessAt. The allowlist case is
-// the original motivator: SuccessAt stays nil because upstream is never
-// called, but a stale error must not survive into runtime status.
+// whether the success bumps lastModelFetchSuccessAt. This protects against any
+// future fetch path that produces a refresh result without touching SuccessAt —
+// a stale error must not survive into runtime status.
 func TestApplyProviderRuntimeUpdates_ClearsStaleErrorOnSuccessfulRefresh(t *testing.T) {
 	registry := NewModelRegistry()
 


### PR DESCRIPTION
## Summary

When `CONFIGURED_PROVIDER_MODELS_MODE=allowlist` applies a configured model list and intentionally skips the upstream `/models` call, the registry left `lastModelFetchSuccessAt` unset. The admin status classifier interprets that combination (Registered + DiscoveredModelCount > 0 + no fetch error + no success timestamp) as "still serving cached inventory while live refresh finishes" and reports `status: degraded, label: Starting`. The result: a fully functional allowlist-mode provider — serving real traffic against AWS Bedrock during smoke-testing of #324 — appears unhealthy on dashboards and to any health-keyed monitoring.

This PR sets `lastModelFetchSuccessAt` for the allowlist-applied case too, because in that mode the allowlist **is** the authoritative inventory: there is no pending refresh to wait for. Upstream-failure fallbacks (`configured_models_upstream_error`/`nil`/`empty`) still leave SuccessAt unset, so health correctly surfaces "live refresh failed, serving configured fallback" for that distinct scenario.

## Why this surfaces now

Smoke-testing the provider-naming PR (#324) with `BEDROCK_MODELS=us.amazon.nova-lite-v1:0` and `CONFIGURED_PROVIDER_MODELS_MODE=allowlist`:

- `/v1/models` correctly returned `bedrock/us.amazon.nova-lite-v1:0` and `bedrock-us/us.amazon.nova-lite-v1:0`.
- Both providers served real Nova Lite chat completions through AWS.
- `/admin/providers/status` reported `status: degraded, label: Starting` for both.

The 0-model count was a separate misread on my part (jq lookup against the wrong field), but the `degraded` status was real and reproducible.

## Why the existing test asserted the buggy behavior

`TestModelRegistry/ConfiguredModelsAllowlistModeSkipsUpstreamAndUsesConfiguredModels` (registry_test.go:212) had an explicit `LastModelFetchSuccessAt != nil → fail` assertion. That assertion was codifying the original design choice ("SuccessAt strictly means upstream succeeded") rather than catching a regression. Updated to reflect the corrected semantics: when allowlist mode authoritatively populates the inventory, that *is* a successful fetch.

## Test plan

- [x] Updated `TestModelRegistry/ConfiguredModelsAllowlistModeSkipsUpstreamAndUsesConfiguredModels` now asserts:
  - `LastModelFetchSuccessAt != nil`
  - `DiscoveredModelCount > 0`
  - `UsingCachedModels == false`
- [x] New `TestClassifyProviderStatus_HealthyForAllowlistInventory` in `internal/admin/` pins the end-to-end classifier outcome: an allowlist provider with one model and a SuccessAt timestamp is `healthy`, not `degraded`.
- [x] Existing fallback-mode tests (`ConfiguredModelsFallback*`) still pass — they assert `SuccessAt == nil` because that case represents a real upstream failure, which this PR does not change.
- [x] `make test-race`, `make lint`, `go mod tidy`, `mint validate` — all green via pre-commit hooks.
- [x] Full `./internal/providers/` and `./internal/admin/` test suites pass under `-race`.

## Compat

No API changes. The `lastModelFetchSuccessAt` field on `ProviderRuntimeSnapshot` was already present; only its population condition expands. Operators using `CONFIGURED_PROVIDER_MODELS_MODE=allowlist` will see their dashboards and `/admin/providers/status` responses flip from `degraded`/`Starting` to `healthy`/`Healthy` once this lands. Operators in the default `fallback` mode see no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed provider inventory fetch success tracking to properly mark allowlist mode inventories as successfully populated when configured models are applied.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ENTERPILOT/GoModel/pull/326)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->