### PR TITLE
refactor(router): inline 3 core resolver methods into ModelLookup

### DIFF
--- a/internal/core/interfaces.go
+++ b/internal/core/interfaces.go
@@ -194,4 +194,19 @@ type ModelLookup interface {
 
 	// ModelCount returns the number of registered models
 	ModelCount() int
+
+	// GetProviderName maps a model selector back to the concrete configured
+	// provider instance name. Implementations that have no such mapping return
+	// an empty string. Same shape as the optional ProviderNameResolver
+	// interface used elsewhere for provider-side type assertions.
+	GetProviderName(model string) string
+
+	// GetProviderNameForType maps a provider type such as "openai" to the
+	// concrete configured instance name chosen for routing, e.g.
+	// "openai-primary". Returns empty when no mapping exists.
+	GetProviderNameForType(providerType string) string
+
+	// GetProviderTypeForName maps a concrete configured instance name back to
+	// its provider type. Returns empty when no mapping exists.
+	GetProviderTypeForName(providerName string) string
 }

--- a/internal/providers/router.go
+++ b/internal/providers/router.go
@@ -112,12 +112,7 @@ func (r *Router) resolveUnqualifiedSelector(selector core.ModelSelector) (core.M
 	if selector.Provider != "" || strings.TrimSpace(selector.Model) == "" {
 		return core.ModelSelector{}, false
 	}
-
-	named, ok := r.lookup.(core.ProviderNameResolver)
-	if !ok {
-		return core.ModelSelector{}, false
-	}
-	providerName := strings.TrimSpace(named.GetProviderName(selector.Model))
+	providerName := strings.TrimSpace(r.lookup.GetProviderName(selector.Model))
 	if providerName == "" {
 		return core.ModelSelector{}, false
 	}
@@ -613,19 +608,13 @@ func (r *Router) GetProviderName(model string) string {
 	if selector.Provider != "" {
 		return selector.Provider
 	}
-	if named, ok := r.lookup.(core.ProviderNameResolver); ok {
-		return named.GetProviderName(selector.QualifiedModel())
-	}
-	return ""
+	return r.lookup.GetProviderName(selector.QualifiedModel())
 }
 
 // GetProviderNameForType returns the concrete configured provider instance name
 // chosen for a provider-typed route.
 func (r *Router) GetProviderNameForType(providerType string) string {
-	if named, ok := r.lookup.(core.ProviderTypeNameResolver); ok {
-		return strings.TrimSpace(named.GetProviderNameForType(providerType))
-	}
-	return ""
+	return strings.TrimSpace(r.lookup.GetProviderNameForType(providerType))
 }
 
 // GetProviderTypeForName returns the provider type for a concrete configured
@@ -635,20 +624,7 @@ func (r *Router) GetProviderTypeForName(providerName string) string {
 	if providerName == "" {
 		return ""
 	}
-	if typed, ok := r.lookup.(core.ProviderNameTypeResolver); ok {
-		return strings.TrimSpace(typed.GetProviderTypeForName(providerName))
-	}
-	if models, ok := r.lookup.(modelWithProviderLister); ok {
-		for _, entry := range models.ListModelsWithProvider() {
-			if strings.TrimSpace(entry.ProviderName) != providerName {
-				continue
-			}
-			if providerType := strings.TrimSpace(entry.ProviderType); providerType != "" {
-				return providerType
-			}
-		}
-	}
-	return ""
+	return strings.TrimSpace(r.lookup.GetProviderTypeForName(providerName))
 }
 
 func (r *Router) providerByType(providerType string) core.Provider {

--- a/internal/providers/router_test.go
+++ b/internal/providers/router_test.go
@@ -104,6 +104,13 @@ func (m *mockModelLookup) ModelCount() int {
 	return len(m.models)
 }
 
+// The mock keeps no provider-name <-> type mapping, so the three resolver
+// methods always return empty. Tests that need provider-name routing use the
+// real ModelRegistry via newTestRegistryWithModels instead of this mock.
+func (m *mockModelLookup) GetProviderName(_ string) string             { return "" }
+func (m *mockModelLookup) GetProviderNameForType(_ string) string      { return "" }
+func (m *mockModelLookup) GetProviderTypeForName(_ string) string      { return "" }
+
 // mockProvider is a simple mock implementation of core.Provider for testing
 type mockProvider struct {
 	name              string


### PR DESCRIPTION
## Summary

Router.go ran three runtime type-assertions on `r.lookup` against the optional interfaces `core.ProviderNameResolver`, `core.ProviderTypeNameResolver`, and `core.ProviderNameTypeResolver`. `*ModelRegistry` already implements all three; the assertions existed because the test `mockModelLookup` deliberately omitted them to keep its surface small.

That made the optional-protocol pattern act as feature detection rather than real interface segregation: every production call site assumed the assertion would succeed. This PR widens `core.ModelLookup` with the three methods and drops the indirection — `r.lookup.GetProviderName(...)` instead of the `if ok` ceremony — and the mock gains three trivial stub methods returning empty string, matching how its missing data was already surfaced.

## What does NOT change

The three `core.*Resolver` interface types stay defined. They are still used in 5 other places for **provider-side** type assertions on `core.Provider` (in `internal/server/`, `internal/aliases/`, `internal/gateway/`). Only the lookup-side assertions are removed.

## One side-effect cleanup

`Router.GetProviderTypeForName` had a `modelWithProviderLister` iteration fallback for the case where the lookup didn't implement `core.ProviderNameTypeResolver`. With the direct method always available, that fallback became unreachable and is removed. Behavior is strictly more complete than the fallback: `*ModelRegistry.GetProviderTypeForName` consults the `providerNames`/`providerTypes` maps directly, which include registered providers with zero discovered models that the model-iteration fallback would have missed.

## Risk

- **API surface widening**: `core.ModelLookup` gains 3 methods. Inside this repo it's a non-event — only impl is `*ModelRegistry` (already has them) and the test mock (now has stubs). Anyone outside the repo who implemented `core.ModelLookup` for their own purposes would need to add the 3 methods.
- **Mock stubs return ""**: `mockModelLookup` returns empty string from all three new methods, matching the prior degraded behavior (the type-assertion path used to fail for the mock and fall through to the same `""` outcome).
- **No semantic loss**: All 25 tests using the mock pass under `-race`, plus the full `./...` suite (56 packages).

## Test plan

- [x] `make test-race`, `make lint`, `go mod tidy` — all green via pre-commit hooks.
- [x] Full `go test ./...` clean across 56 packages.
- [x] `*ModelRegistry` satisfies the widened interface (compile-time assertion at `registry_test.go:1865` still holds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal provider lookup mechanisms to streamline routing efficiency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ENTERPILOT/GoModel/pull/327)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->