### PR TITLE
refactor(providers): export HasResolvedProviderValue and drop duplicate copies

### DIFF
--- a/internal/providers/config.go
+++ b/internal/providers/config.go
@@ -580,8 +580,8 @@ func isVertexProviderConfig(p config.RawProviderConfig) bool {
 }
 
 func validVertexProviderConfig(p config.RawProviderConfig) bool {
-	if !hasResolvedProviderValue(p.BaseURL) &&
-		(!hasResolvedProviderValue(p.VertexProject) || !hasResolvedProviderValue(p.VertexLocation)) {
+	if !HasResolvedProviderValue(p.BaseURL) &&
+		(!HasResolvedProviderValue(p.VertexProject) || !HasResolvedProviderValue(p.VertexLocation)) {
 		return false
 	}
 	authType := strings.ToLower(strings.TrimSpace(p.AuthType))
@@ -589,15 +589,21 @@ func validVertexProviderConfig(p config.RawProviderConfig) bool {
 	case "", "gcp_adc", "adc", "google_adc":
 		return true
 	case "gcp_service_account", "service_account":
-		return hasResolvedProviderValue(p.ServiceAccountFile) ||
-			hasResolvedProviderValue(p.ServiceAccountJSON) ||
-			hasResolvedProviderValue(p.ServiceAccountJSONBase64)
+		return HasResolvedProviderValue(p.ServiceAccountFile) ||
+			HasResolvedProviderValue(p.ServiceAccountJSON) ||
+			HasResolvedProviderValue(p.ServiceAccountJSONBase64)
 	default:
 		return false
 	}
 }
 
-func hasResolvedProviderValue(value string) bool {
+// HasResolvedProviderValue reports whether a provider-config field carries a
+// usable string value. It returns false for empty/whitespace input and false
+// when the value still contains a literal `${` substring — that signals an
+// unresolved YAML environment-variable placeholder such as `${OPENAI_API_KEY}`
+// which the env-substitution pass failed to fill in. Provider builders use
+// this to drop providers whose credentials never resolved.
+func HasResolvedProviderValue(value string) bool {
 	value = strings.TrimSpace(value)
 	return value != "" && !strings.Contains(value, "${")
 }

--- a/internal/providers/gemini/gemini.go
+++ b/internal/providers/gemini/gemini.go
@@ -172,8 +172,8 @@ func (p *Provider) validateConfig(providerCfg providers.ProviderConfig) {
 		p.configErr = fmt.Errorf("vertex Gemini requires gcp_adc or gcp_service_account auth")
 		return
 	}
-	if p.backend == geminiBackendVertex && !hasResolvedProviderValue(providerCfg.BaseURL) &&
-		(!hasResolvedProviderValue(providerCfg.VertexProject) || !hasResolvedProviderValue(providerCfg.VertexLocation)) {
+	if p.backend == geminiBackendVertex && !providers.HasResolvedProviderValue(providerCfg.BaseURL) &&
+		(!providers.HasResolvedProviderValue(providerCfg.VertexProject) || !providers.HasResolvedProviderValue(providerCfg.VertexLocation)) {
 		p.configErr = fmt.Errorf("vertex Gemini requires base_url or vertex_project and vertex_location")
 		return
 	}
@@ -261,11 +261,6 @@ func normalizeGeminiBackend(cfg providers.ProviderConfig) string {
 		return geminiBackendVertex
 	}
 	return geminiBackendAIStudio
-}
-
-func hasResolvedProviderValue(value string) bool {
-	value = strings.TrimSpace(value)
-	return value != "" && !strings.Contains(value, "${")
 }
 
 func normalizeGeminiAuthType(backend string, cfg providers.ProviderConfig) string {

--- a/internal/providers/vertex/vertex.go
+++ b/internal/providers/vertex/vertex.go
@@ -75,8 +75,8 @@ func newProvider(providerCfg providers.ProviderConfig, opts providers.ProviderOp
 }
 
 func (p *Provider) validateConfig(providerCfg providers.ProviderConfig) {
-	if !hasResolvedProviderValue(providerCfg.BaseURL) &&
-		(!hasResolvedProviderValue(providerCfg.VertexProject) || !hasResolvedProviderValue(providerCfg.VertexLocation)) {
+	if !providers.HasResolvedProviderValue(providerCfg.BaseURL) &&
+		(!providers.HasResolvedProviderValue(providerCfg.VertexProject) || !providers.HasResolvedProviderValue(providerCfg.VertexLocation)) {
 		p.configErr = fmt.Errorf("vertex AI requires base_url or vertex_project and vertex_location")
 		return
 	}
@@ -104,11 +104,6 @@ func validAuthType(authType string) bool {
 	default:
 		return false
 	}
-}
-
-func hasResolvedProviderValue(value string) bool {
-	value = strings.TrimSpace(value)
-	return value != "" && !strings.Contains(value, "${")
 }
 
 func normalizeAuthType(providerCfg providers.ProviderConfig) string {


### PR DESCRIPTION
## Summary

The unresolved-`${VAR}` placeholder check was defined three times byte-for-byte (MD5-verified):

- `internal/providers/config.go` — used in `buildProviderConfig` validation
- `internal/providers/vertex/vertex.go` — used in `validateConfig`
- `internal/providers/gemini/gemini.go` — same shape

The function isn't GCP-specific. It just looks for a literal `${` substring that would indicate the YAML env-substitution pass left a placeholder unresolved (e.g. `${OPENAI_API_KEY}` when the env var wasn't set).

This PR exports the parent-package copy as `HasResolvedProviderValue`, deletes the two duplicates in `vertex/` and `gemini/`, and rewrites the 6 child-package call sites to use `providers.HasResolvedProviderValue`. Both child packages already import `gomodel/internal/providers`, so no new dependencies.

Added a doc comment to the now-exported function explaining the `${VAR}`-placeholder semantics so future readers don't have to infer them from the implementation.

## Risk

- **Function gains export visibility**: `HasResolvedProviderValue` is now public on the `providers` package. Anyone outside this repo who needs the same check could call it. No downside — the function is small, well-defined, and the semantics are stable.
- **Call sites in `vertex.go` and `gemini.go` are 1 token longer** (`providers.HasResolvedProviderValue` vs `hasResolvedProviderValue`). Trivial.
- **No behavior change**. The deleted definitions were byte-identical to the kept one.

## Out of scope

The name `HasResolvedProviderValue` carries the "Provider" qualifier purely for continuity with the existing usage. If a future caller outside provider config wants this check, a follow-up cosmetic rename (`HasResolvedConfigValue` or similar) is fine — not chasing it here.

## Test plan

- [x] Full `go test ./...` clean across the module.
- [x] `go test -race` clean on `./internal/providers/...`.
- [x] Pre-commit hooks: `make test-race`, `make lint`, `go mod tidy` all green.

Net diff: **-4 lines** (16 inserted, including the new 6-line doc comment; 20 removed across 3 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated provider configuration validation logic by centralizing a shared validation helper function across internal modules, reducing code duplication.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ENTERPILOT/GoModel/pull/329)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->