### PR TITLE
fix(passthrough): track usage for non-streaming responses and extract…

### DIFF
--- a/internal/server/passthrough_support.go
+++ b/internal/server/passthrough_support.go
@@ -311,12 +311,55 @@ func (s *passthroughService) proxyPassthroughResponse(c *echo.Context, providerT
 		return nil
 	}
 
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return handleError(c, core.NewProviderError(providerType, http.StatusBadGateway, "failed to read provider passthrough response body", err))
+	}
+
+	workflow := core.GetWorkflow(c.Request().Context())
+	if s.usageLogger != nil && s.usageLogger.Config().Enabled && (workflow == nil || workflow.UsageEnabled()) {
+		model := ""
+		if info != nil {
+			model = strings.TrimSpace(info.Model)
+		}
+		model = resolvedModelFromWorkflow(workflow, model)
+		requestID := requestIDFromContextOrHeader(c.Request())
+		usagePath := strings.TrimSpace(c.Request().URL.Path)
+		s.logPassthroughNonStreamUsage(body, model, providerType, providerName, requestID, usagePath, c.Request().Context())
+	}
+
 	c.Response().WriteHeader(resp.StatusCode)
-	if _, err := io.Copy(c.Response(), resp.Body); err != nil {
+	if _, err := c.Response().Write(body); err != nil {
 		return err
 	}
 	if f, ok := c.Response().(http.Flusher); ok {
 		f.Flush()
 	}
 	return nil
+}
+
+func (s *passthroughService) logPassthroughNonStreamUsage(body []byte, model, providerType, providerName, requestID, endpoint string, ctx context.Context) {
+	if len(body) == 0 {
+		return
+	}
+
+	auditPath := passthroughStreamAuditPath(endpoint, providerType, endpoint)
+	var pricingArgs []*core.ModelPricing
+	if s.pricingResolver != nil {
+		pricingProvider := strings.TrimSpace(providerName)
+		if pricingProvider == "" {
+			pricingProvider = strings.TrimSpace(providerType)
+		}
+		if p := s.pricingResolver.ResolvePricing(model, pricingProvider); p != nil {
+			pricingArgs = append(pricingArgs, p)
+		}
+	}
+
+	entry := usage.ExtractFromCachedResponseBody(body, requestID, model, providerType, auditPath, "", pricingArgs...)
+	if entry == nil {
+		return
+	}
+	entry.ProviderName = strings.TrimSpace(providerName)
+	entry.UserPath = core.UserPathFromContext(ctx)
+	s.usageLogger.Write(entry)
 }

--- a/internal/server/request_selector_peek.go
+++ b/internal/server/request_selector_peek.go
@@ -26,7 +26,10 @@ func seedRequestBodySelectorHints(req *http.Request, bodyMode core.BodyMode, env
 	}
 
 	hints := peekRequestBodySelectorHints(req, requestSelectorPeekLimit)
-	if !hints.parsed || !hints.complete {
+	if !hints.parsed && !hints.complete {
+		if bodyMode == core.BodyModeOpaque && hints.model != "" {
+			core.ApplyBodySelectorHints(env, hints.model, hints.provider, hints.stream)
+		}
 		return
 	}
 	core.ApplyBodySelectorHints(env, hints.model, hints.provider, hints.stream)


### PR DESCRIPTION
… model from opaque bodies

Non-streaming passthrough responses were not logging usage data because the response body was copied directly to the client without parsing. Additionally, when the request body was not fully captured (chunked transfer), the model field was not extracted for opaque passthrough routes because the peek logic required both model and provider to apply selector hints.

- Read non-streaming response body and extract usage via ExtractFromCachedResponseBody before forwarding to the client
- Apply body selector hints for BodyModeOpaque when only model is found, ensuring passthrough routes populate PassthroughRouteInfo.Model even without a provider field in the request body

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved usage tracking and logging for non-streaming provider responses, including accurate model/provider resolution and pricing calculation.
  * Enhanced request body parsing with more robust selector hint application for increased reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ENTERPILOT/GoModel/pull/332)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->