### PR TITLE
feat(dashboard): show gateway and provider cache on Usage page

### DIFF
--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -2439,9 +2439,38 @@ textarea:focus {
   min-width: 0;
 }
 
+.usage-filter-row-options {
+  grid-template-columns: 1fr;
+}
+
+.usage-log-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text);
+  cursor: pointer;
+  user-select: none;
+}
+
+.usage-log-checkbox input {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+}
+
 .usage-ts {
   white-space: nowrap;
   font-size: 12px;
+}
+
+.usage-log-row-cached td {
+  opacity: 0.75;
+  font-style: italic;
+}
+
+.usage-log-row-cached .usage-log-cache-cell {
+  font-weight: 700;
 }
 
 /* Audit Log Section */
@@ -3156,6 +3185,16 @@ body.conversation-drawer-open {
   height: 14px;
   margin-left: 4px;
   color: var(--success);
+  cursor: help;
+  vertical-align: -2px;
+  stroke-width: 2;
+}
+
+.cache-savings-icon {
+  width: 14px;
+  height: 14px;
+  margin-left: 4px;
+  color: var(--accent);
   cursor: help;
   vertical-align: -2px;
   stroke-width: 2;

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -614,7 +614,7 @@ body.dashboard-modal-open {
   flex: 1 1 0;
   min-width: 0;
   width: 100%;
-  max-width: 1200px;
+  max-width: 1400px;
   margin: 0 auto;
   padding: 32px;
   transition: width 0.2s;
@@ -1485,6 +1485,7 @@ td.col-price {
   font-family: "SF Mono", Menlo, Consolas, monospace;
   font-size: 13px;
   color: var(--text-muted);
+  white-space: nowrap;
 }
 
 .provider-badge {

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -162,6 +162,7 @@ function dashboard() {
     usageLogModel: "",
     usageLogProvider: "",
     usageLogUserPath: "",
+    usageLogHideCached: false,
     usageBarChart: null,
     usageUserPathChart: null,
 

--- a/internal/admin/dashboard/static/js/modules/dashboard-layout.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/dashboard-layout.test.cjs
@@ -83,7 +83,7 @@ test("sidebar and main content share the flex layout without manual content offs
   const contentRule = readCSSRule(css, ".content");
   assert.match(contentRule, /flex:\s*1 1 0/);
   assert.match(contentRule, /width:\s*100%/);
-  assert.match(contentRule, /max-width:\s*1200px/);
+  assert.match(contentRule, /max-width:\s*1400px/);
   assert.match(contentRule, /margin:\s*0 auto/);
   assert.doesNotMatch(contentRule, /margin-left:\s*max\(/);
 

--- a/internal/admin/dashboard/static/js/modules/live-logs.js
+++ b/internal/admin/dashboard/static/js/modules/live-logs.js
@@ -287,6 +287,9 @@
                 this.applyLiveUsageToAudit(incoming);
                 const currentEntries = (this.usageLog && Array.isArray(this.usageLog.entries)) ? this.usageLog.entries : [];
                 const index = currentEntries.findIndex((entry) => String(entry.id || '').trim() === id);
+                if (this.usageLogHideCached && this.liveUsageEntryCached(incoming) && index < 0) {
+                    return;
+                }
                 if (index >= 0) {
                     const previous = currentEntries[index] || {};
                     const liveState = this.liveUsageStateAfter(previous._live_state, incoming._live_state);

--- a/internal/admin/dashboard/static/js/modules/live-logs.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/live-logs.test.cjs
@@ -562,6 +562,46 @@ test('failed live events clear pending state', () => {
     assert.equal(app.auditLog.entries[0]._usage_live_pending, false);
 });
 
+test('cached live usage events are suppressed when hide-cached toggle is on', () => {
+    const app = createLiveLogsApp();
+    app.usageLogHideCached = true;
+
+    app.applyLiveLogEvent({
+        seq: 10,
+        type: 'usage.completed',
+        data: {
+            id: 'usage-cache',
+            request_id: 'req-cache',
+            cache_type: 'exact',
+            model: 'gpt-test',
+            provider: 'openai',
+            input_tokens: 10,
+            output_tokens: 4,
+            total_tokens: 14
+        }
+    });
+
+    assert.equal(app.usageLog.entries.length, 0);
+    assert.equal(app.usageLog.total, 0);
+
+    app.applyLiveLogEvent({
+        seq: 11,
+        type: 'usage.completed',
+        data: {
+            id: 'usage-fresh',
+            request_id: 'req-fresh',
+            model: 'gpt-test',
+            provider: 'openai',
+            input_tokens: 10,
+            output_tokens: 4,
+            total_tokens: 14
+        }
+    });
+
+    assert.equal(app.usageLog.entries.length, 1);
+    assert.equal(app.usageLog.entries[0].id, 'usage-fresh');
+});
+
 test('live reset asks normal REST endpoints to resync source of truth', () => {
     const app = createLiveLogsApp();
 

--- a/internal/admin/dashboard/static/js/modules/usage.js
+++ b/internal/admin/dashboard/static/js/modules/usage.js
@@ -383,6 +383,35 @@
                 return base ? prefix + '\n' + base : prefix;
             },
 
+            providerCacheRatio(entry) {
+                const ratio = Number(entry && entry.cached_input_ratio);
+                if (!Number.isFinite(ratio) || ratio <= 0) return 0;
+                return Math.min(1, ratio);
+            },
+
+            hasProviderCache(entry) {
+                return Number(entry && entry.cached_input_tokens || 0) > 0;
+            },
+
+            providerCacheLabel(entry) {
+                if (!this.hasProviderCache(entry)) return '';
+                const pct = this.providerCacheRatio(entry) * 100;
+                return pct.toFixed(1) + '%';
+            },
+
+            providerCacheTitle(entry) {
+                if (!this.hasProviderCache(entry)) return '';
+                const cached = Number(entry.cached_input_tokens || 0);
+                const uncached = Number(entry.uncached_input_tokens || 0);
+                const write = Number(entry.cache_write_input_tokens || 0);
+                const total = cached + uncached + write;
+                const parts = [this.formatNumber(cached) + ' cached / ' + this.formatNumber(total) + ' input tokens'];
+                if (write > 0) {
+                    parts.push(this.formatNumber(write) + ' cache write');
+                }
+                return parts.join('\n');
+            },
+
             usesOpenRouterCreditPricing(entry) {
                 return costSource(entry) === 'openrouter_credits';
             },

--- a/internal/admin/dashboard/static/js/modules/usage.js
+++ b/internal/admin/dashboard/static/js/modules/usage.js
@@ -282,6 +282,7 @@
                     if (resetOffset) this.usageLog.offset = 0;
                     let qs = this._usageQueryStr();
                     qs += '&limit=' + this.usageLog.limit + '&offset=' + this.usageLog.offset;
+                    qs += '&cache_mode=' + (this.usageLogHideCached ? 'uncached' : 'all');
                     if (this.usageLogSearch) qs += '&search=' + encodeURIComponent(this.usageLogSearch);
                     if (this.usageLogModel) qs += '&model=' + encodeURIComponent(this.usageLogModel);
                     if (this.usageLogProvider) qs += '&provider=' + encodeURIComponent(this.usageLogProvider);
@@ -357,6 +358,29 @@
                     }
                 });
                 return [...set].sort();
+            },
+
+            usageEntryCacheType(entry) {
+                return String((entry && entry.cache_type) || '').trim().toLowerCase();
+            },
+
+            usageEntryCached(entry) {
+                const type = this.usageEntryCacheType(entry);
+                return type === 'exact' || type === 'semantic';
+            },
+
+            usageEntryCacheLabel(entry) {
+                const type = this.usageEntryCacheType(entry);
+                if (type === 'exact') return 'Exact';
+                if (type === 'semantic') return 'Semantic';
+                return '-';
+            },
+
+            cachedCostTitle(entry, baseTitle) {
+                const base = baseTitle ? String(baseTitle) : '';
+                if (!this.usageEntryCached(entry)) return base;
+                const prefix = 'Saved by cache — not charged';
+                return base ? prefix + '\n' + base : prefix;
             },
 
             usesOpenRouterCreditPricing(entry) {

--- a/internal/admin/dashboard/static/js/modules/usage.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/usage.test.cjs
@@ -42,6 +42,40 @@ test('usesResponseCostPricing detects provider-reported costs', () => {
     assert.equal(module.usesResponseCostPricing({}), false);
 });
 
+test('usageEntryCached detects exact and semantic cache types and ignores others', () => {
+    const module = createUsageModule();
+
+    assert.equal(module.usageEntryCached({ cache_type: 'exact' }), true);
+    assert.equal(module.usageEntryCached({ cache_type: ' Semantic ' }), true);
+    assert.equal(module.usageEntryCached({ cache_type: '' }), false);
+    assert.equal(module.usageEntryCached({}), false);
+    assert.equal(module.usageEntryCached({ cache_type: 'other' }), false);
+});
+
+test('usageEntryCacheLabel returns capitalized cache type or dash', () => {
+    const module = createUsageModule();
+
+    assert.equal(module.usageEntryCacheLabel({ cache_type: 'exact' }), 'Exact');
+    assert.equal(module.usageEntryCacheLabel({ cache_type: 'SEMANTIC' }), 'Semantic');
+    assert.equal(module.usageEntryCacheLabel({}), '-');
+    assert.equal(module.usageEntryCacheLabel({ cache_type: 'other' }), '-');
+});
+
+test('cachedCostTitle prepends savings note for cached entries and passes through otherwise', () => {
+    const module = createUsageModule();
+
+    assert.equal(
+        module.cachedCostTitle({ cache_type: 'exact' }, '12 tokens'),
+        'Saved by cache — not charged\n12 tokens'
+    );
+    assert.equal(
+        module.cachedCostTitle({ cache_type: 'semantic' }, ''),
+        'Saved by cache — not charged'
+    );
+    assert.equal(module.cachedCostTitle({}, '12 tokens'), '12 tokens');
+    assert.equal(module.cachedCostTitle({}, ''), '');
+});
+
 test('costSourceTooltip explains provider-reported costs', () => {
     const module = createUsageModule();
 
@@ -54,4 +88,60 @@ test('costSourceTooltip explains provider-reported costs', () => {
         'Costs from xAI usage.cost_in_usd_ticks.'
     );
     assert.equal(module.costSourceTooltip({ cost_source: 'model_pricing' }), '');
+});
+
+function createUsageLogApp(overrides = {}) {
+    const fetchCalls = [];
+    const fetch = async (url, options) => {
+        fetchCalls.push({ url, options });
+        return {
+            async json() {
+                return { entries: [], total: 0, limit: 50, offset: 0 };
+            }
+        };
+    };
+    const factory = loadUsageModuleFactory({ fetch });
+    const app = {
+        days: '30',
+        interval: 'daily',
+        customStartDate: null,
+        customEndDate: null,
+        usageLog: { entries: [], total: 0, limit: 50, offset: 0 },
+        usageLogSearch: '',
+        usageLogModel: '',
+        usageLogProvider: '',
+        usageLogUserPath: '',
+        usageLogHideCached: false,
+        _formatDate(date) {
+            return date.toISOString().slice(0, 10);
+        },
+        requestOptions() {
+            return { headers: {} };
+        },
+        handleFetchResponse() {
+            return true;
+        },
+        ...overrides,
+        ...factory()
+    };
+    return { app, fetchCalls };
+}
+
+test('fetchUsageLog includes cache_mode=all by default so cached records are returned', async () => {
+    const { app, fetchCalls } = createUsageLogApp();
+
+    await app.fetchUsageLog(true);
+
+    assert.equal(fetchCalls.length, 1);
+    assert.match(fetchCalls[0].url, /cache_mode=all/);
+    assert.doesNotMatch(fetchCalls[0].url, /cache_mode=uncached/);
+});
+
+test('fetchUsageLog switches to cache_mode=uncached when hide-cached toggle is on', async () => {
+    const { app, fetchCalls } = createUsageLogApp({ usageLogHideCached: true });
+
+    await app.fetchUsageLog(true);
+
+    assert.equal(fetchCalls.length, 1);
+    assert.match(fetchCalls[0].url, /cache_mode=uncached/);
 });

--- a/internal/admin/dashboard/static/js/modules/usage.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/usage.test.cjs
@@ -61,6 +61,37 @@ test('usageEntryCacheLabel returns capitalized cache type or dash', () => {
     assert.equal(module.usageEntryCacheLabel({ cache_type: 'other' }), '-');
 });
 
+test('hasProviderCache detects positive cached_input_tokens', () => {
+    const module = createUsageModule();
+
+    assert.equal(module.hasProviderCache({ cached_input_tokens: 100 }), true);
+    assert.equal(module.hasProviderCache({ cached_input_tokens: 0 }), false);
+    assert.equal(module.hasProviderCache({}), false);
+    assert.equal(module.hasProviderCache(null), false);
+});
+
+test('providerCacheLabel renders percentage with one decimal', () => {
+    const module = createUsageModule();
+
+    assert.equal(module.providerCacheLabel({ cached_input_tokens: 50, cached_input_ratio: 0.25 }), '25.0%');
+    assert.equal(module.providerCacheLabel({ cached_input_tokens: 1, cached_input_ratio: 0.1234 }), '12.3%');
+    assert.equal(module.providerCacheLabel({}), '');
+});
+
+test('providerCacheTitle reports cached and total input tokens, with cache write when present', () => {
+    const module = Object.assign({ formatNumber: (n) => String(n) }, createUsageModule());
+
+    assert.equal(
+        module.providerCacheTitle({ cached_input_tokens: 90, uncached_input_tokens: 50, cache_write_input_tokens: 0 }),
+        '90 cached / 140 input tokens'
+    );
+    assert.equal(
+        module.providerCacheTitle({ cached_input_tokens: 90, uncached_input_tokens: 50, cache_write_input_tokens: 30 }),
+        '90 cached / 170 input tokens\n30 cache write'
+    );
+    assert.equal(module.providerCacheTitle({}), '');
+});
+
 test('cachedCostTitle prepends savings note for cached entries and passes through otherwise', () => {
     const module = createUsageModule();
 

--- a/internal/admin/dashboard/templates/page-usage.html
+++ b/internal/admin/dashboard/templates/page-usage.html
@@ -153,6 +153,12 @@
                     <input type="text" placeholder="User path /team/alpha" aria-label="Filter by user path" x-model="usageLogUserPath" @input.debounce.300ms="fetchUsageLog(true)" class="filter-input">
                 </div>
             </div>
+            <div class="usage-filter-row usage-filter-row-options">
+                <label class="usage-log-checkbox">
+                    <input type="checkbox" x-model="usageLogHideCached" @change="fetchUsageLog(true)">
+                    <span>Hide cached requests</span>
+                </label>
+            </div>
         </div>
         <div class="table-wrapper" x-show="usageLog.entries.length > 0">
             <table class="data-table usage-log-table">
@@ -162,6 +168,7 @@
                         <th>Model</th>
                         <th>Provider</th>
                         <th>User Path</th>
+                        <th>Cache</th>
                         <th class="col-price" x-text="usageMode === 'costs' ? 'Input Cost' : 'Input'"></th>
                         <th class="col-price" x-text="usageMode === 'costs' ? 'Output Cost' : 'Output'"></th>
                         <th class="col-price" x-text="usageMode === 'costs' ? 'Total Cost' : 'Total'"></th>
@@ -170,29 +177,32 @@
                 </thead>
                 <tbody>
                     <template x-for="entry in usageLog.entries" :key="entry.id">
-                        <tr>
+                        <tr :class="{'usage-log-row-cached': usageEntryCached(entry)}">
                             <td class="mono usage-ts" x-text="formatTimestamp(entry.timestamp)" :title="timestampTitle(entry.timestamp)"></td>
                             <td class="mono font-size-md" x-text="entry.model"></td>
                             <td>
                                 <span class="provider-badge" x-text="providerDisplayValue(entry) || '-'"></span>
                             </td>
                             <td class="mono font-size-md" x-text="entry.user_path || '-'"></td>
+                            <td class="usage-log-cache-cell" x-text="usageEntryCacheLabel(entry)"></td>
                             <td class="col-price"
                                 x-text="usageMode === 'costs' ? formatCost(entry.input_cost) : formatNumber(entry.input_tokens)"
                                 :title="usageMode === 'costs' ? formatNumber(entry.input_tokens) + ' tokens' : ''"></td>
                             <td class="col-price"
                                 x-text="usageMode === 'costs' ? formatCost(entry.output_cost) : formatNumber(entry.output_tokens)"
                                 :title="usageMode === 'costs' ? formatNumber(entry.output_tokens) + ' tokens' : ''"></td>
-                            <td class="col-price">
+                            <td class="col-price" :title="usageMode === 'costs' ? cachedCostTitle(entry, '') : ''">
                                 <span x-text="usageMode === 'costs' ? formatCost(entry.total_cost) : formatNumber(entry.total_tokens)"
-                                      :title="usageMode === 'costs' ? formatNumber(entry.total_tokens) + ' tokens\n' + formatCostTooltip(entry) : ''"></span>
+                                      :title="usageMode === 'costs' ? cachedCostTitle(entry, formatNumber(entry.total_tokens) + ' tokens\n' + formatCostTooltip(entry)) : ''"></span>
                                 <i data-lucide="circle-dollar-sign" class="cost-source-icon" x-show="usageMode === 'costs' && usesResponseCostPricing(entry)" :title="costSourceTooltip(entry)" aria-hidden="true"></i>
+                                <i data-lucide="database-zap" class="cache-savings-icon" x-show="usageMode === 'costs' && usageEntryCached(entry)" aria-hidden="true"></i>
                                 <span class="caveat-icon" x-show="usageMode === 'costs' && entry.costs_calculation_caveat" :title="entry.costs_calculation_caveat">&#9888;</span>
                             </td>
                             <td class="col-price" x-show="usageMode === 'tokens'"
-                                :title="formatCostTooltip(entry)">
+                                :title="cachedCostTitle(entry, formatCostTooltip(entry))">
                                 <span x-text="formatCost(entry.total_cost)"></span>
                                 <i data-lucide="circle-dollar-sign" class="cost-source-icon" x-show="usesResponseCostPricing(entry)" :title="costSourceTooltip(entry)" aria-hidden="true"></i>
+                                <i data-lucide="database-zap" class="cache-savings-icon" x-show="usageEntryCached(entry)" aria-hidden="true"></i>
                                 <span class="caveat-icon" x-show="entry.costs_calculation_caveat" :title="entry.costs_calculation_caveat">&#9888;</span>
                             </td>
                         </tr>

--- a/internal/admin/dashboard/templates/page-usage.html
+++ b/internal/admin/dashboard/templates/page-usage.html
@@ -165,10 +165,11 @@
                 <thead>
                     <tr>
                         <th>Timestamp</th>
-                        <th>Model</th>
                         <th>Provider</th>
+                        <th>Model</th>
                         <th>User Path</th>
                         <th>Cache</th>
+                        <th title="Share of input tokens served from the provider's prompt cache">Provider Cache</th>
                         <th class="col-price" x-text="usageMode === 'costs' ? 'Input Cost' : 'Input'"></th>
                         <th class="col-price" x-text="usageMode === 'costs' ? 'Output Cost' : 'Output'"></th>
                         <th class="col-price" x-text="usageMode === 'costs' ? 'Total Cost' : 'Total'"></th>
@@ -179,12 +180,16 @@
                     <template x-for="entry in usageLog.entries" :key="entry.id">
                         <tr :class="{'usage-log-row-cached': usageEntryCached(entry)}">
                             <td class="mono usage-ts" x-text="formatTimestamp(entry.timestamp)" :title="timestampTitle(entry.timestamp)"></td>
-                            <td class="mono font-size-md" x-text="entry.model"></td>
                             <td>
                                 <span class="provider-badge" x-text="providerDisplayValue(entry) || '-'"></span>
                             </td>
+                            <td class="mono font-size-md" x-text="entry.model"></td>
                             <td class="mono font-size-md" x-text="entry.user_path || '-'"></td>
                             <td class="usage-log-cache-cell" x-text="usageEntryCacheLabel(entry)"></td>
+                            <td class="usage-log-provider-cache-cell" :title="providerCacheTitle(entry)">
+                                <span class="audit-prompt-cache-pill mono" x-show="hasProviderCache(entry)" x-text="providerCacheLabel(entry)"></span>
+                                <span x-show="!hasProviderCache(entry)">-</span>
+                            </td>
                             <td class="col-price"
                                 x-text="usageMode === 'costs' ? formatCost(entry.input_cost) : formatNumber(entry.input_tokens)"
                                 :title="usageMode === 'costs' ? formatNumber(entry.input_tokens) + ' tokens' : ''"></td>

--- a/internal/admin/handler_usage.go
+++ b/internal/admin/handler_usage.go
@@ -215,6 +215,9 @@ func (h *Handler) UsageLog(c *echo.Context) error {
 	if result.Entries == nil {
 		result.Entries = []usage.UsageLogEntry{}
 	}
+	for i := range result.Entries {
+		usage.EnrichUsageLogEntry(&result.Entries[i])
+	}
 
 	return c.JSON(http.StatusOK, result)
 }

--- a/internal/live/broker.go
+++ b/internal/live/broker.go
@@ -441,22 +441,15 @@ func (b *Broker) PublishAuditEvent(eventType string, entry *auditlog.LogEntry) {
 	b.publish(eventType, entry.RequestID, entry.Timestamp, payload)
 }
 
-// PublishUsageEvent publishes a compact usage log event.
+// PublishUsageEvent publishes a compact usage log event. Cached usage entries
+// are broadcast like any other so the dashboard can choose to surface or hide
+// them via the "Hide cached requests" toggle on the Usage page.
 func (b *Broker) PublishUsageEvent(eventType string, entry *usage.UsageEntry) {
-	if entry == nil || cachedUsageEntry(entry) {
+	if entry == nil {
 		return
 	}
 	payload := usagePreviewFromEntry(entry)
 	b.publish(eventType, entry.RequestID, entry.Timestamp, payload)
-}
-
-func cachedUsageEntry(entry *usage.UsageEntry) bool {
-	switch strings.ToLower(strings.TrimSpace(entry.CacheType)) {
-	case usage.CacheTypeExact, usage.CacheTypeSemantic:
-		return true
-	default:
-		return false
-	}
 }
 
 type auditPreview struct {

--- a/internal/live/broker.go
+++ b/internal/live/broker.go
@@ -580,7 +580,7 @@ func auditEventTerminal(eventType string) bool {
 }
 
 func usagePreviewFromEntry(entry *usage.UsageEntry) usage.UsageLogEntry {
-	return usage.UsageLogEntry{
+	preview := usage.UsageLogEntry{
 		ID:                     entry.ID,
 		RequestID:              entry.RequestID,
 		ProviderID:             entry.ProviderID,
@@ -601,6 +601,8 @@ func usagePreviewFromEntry(entry *usage.UsageEntry) usage.UsageLogEntry {
 		RawData:                copyRawData(entry.RawData),
 		CostsCalculationCaveat: entry.CostsCalculationCaveat,
 	}
+	usage.EnrichUsageLogEntry(&preview)
+	return preview
 }
 
 func copyRawData(src map[string]any) map[string]any {

--- a/internal/live/broker_test.go
+++ b/internal/live/broker_test.go
@@ -48,7 +48,7 @@ func TestBrokerPublishesAndReplaysBySequence(t *testing.T) {
 	}
 }
 
-func TestBrokerSkipsCachedUsageEvents(t *testing.T) {
+func TestBrokerBroadcastsCachedUsageEvents(t *testing.T) {
 	b := NewBroker(Config{Enabled: true})
 	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
 
@@ -58,15 +58,15 @@ func TestBrokerSkipsCachedUsageEvents(t *testing.T) {
 		Timestamp: now,
 		CacheType: " EXACT ",
 	})
-	b.PublishUsageEvent(EventUsageFlushed, &usage.UsageEntry{
+	b.PublishUsageEvent(EventUsageCompleted, &usage.UsageEntry{
 		ID:        "usage-semantic",
 		RequestID: "req-semantic",
 		Timestamp: now.Add(time.Second),
 		CacheType: usage.CacheTypeSemantic,
 	})
 
-	if got := b.LatestSeq(); got != 0 {
-		t.Fatalf("latest seq = %d, want 0", got)
+	if got := b.LatestSeq(); got != 2 {
+		t.Fatalf("latest seq = %d, want 2", got)
 	}
 
 	sub := b.Subscribe(0)
@@ -74,8 +74,13 @@ func TestBrokerSkipsCachedUsageEvents(t *testing.T) {
 		t.Fatal("Subscribe returned nil")
 	}
 	defer sub.Close()
-	if len(sub.Replay) != 0 {
-		t.Fatalf("replay len = %d, want 0", len(sub.Replay))
+	if len(sub.Replay) != 2 {
+		t.Fatalf("replay len = %d, want 2", len(sub.Replay))
+	}
+	for i, event := range sub.Replay {
+		if event.Type != EventUsageCompleted {
+			t.Fatalf("replay[%d] type = %q, want %q", i, event.Type, EventUsageCompleted)
+		}
 	}
 }
 

--- a/internal/usage/enrich_test.go
+++ b/internal/usage/enrich_test.go
@@ -117,6 +117,25 @@ func TestEnrichUsageLogEntry_BedrockCacheWriteOnly(t *testing.T) {
 	}
 }
 
+func TestEnrichUsageLogEntry_CoalescesCacheWriteFieldsByMax(t *testing.T) {
+	// If a provider's raw_data ever carries both Anthropic-style
+	// cache_creation_input_tokens and Bedrock-style cache_write_input_tokens,
+	// EntryInputSegments must pick the larger value so the displayed
+	// provider-cache totals are not undercounted.
+	entry := UsageLogEntry{
+		Provider:    "bedrock",
+		InputTokens: 40,
+		RawData: map[string]any{
+			"cache_creation_input_tokens": 30,
+			"cache_write_input_tokens":    60,
+		},
+	}
+	EnrichUsageLogEntry(&entry)
+	if entry.CacheWriteInputTokens != 60 {
+		t.Fatalf("CacheWriteInputTokens = %d, want 60", entry.CacheWriteInputTokens)
+	}
+}
+
 func TestEnrichUsageLogEntry_NilSafe(t *testing.T) {
 	EnrichUsageLogEntry(nil)
 }

--- a/internal/usage/enrich_test.go
+++ b/internal/usage/enrich_test.go
@@ -1,0 +1,76 @@
+package usage
+
+import (
+	"math"
+	"testing"
+)
+
+func TestEnrichUsageLogEntry_OpenAICachedTokens(t *testing.T) {
+	entry := UsageLogEntry{
+		Provider:    "openai",
+		InputTokens: 120,
+		RawData: map[string]any{
+			"prompt_cached_tokens": 80,
+		},
+	}
+	EnrichUsageLogEntry(&entry)
+	if entry.UncachedInputTokens != 40 {
+		t.Fatalf("UncachedInputTokens = %d, want 40", entry.UncachedInputTokens)
+	}
+	if entry.CachedInputTokens != 80 {
+		t.Fatalf("CachedInputTokens = %d, want 80", entry.CachedInputTokens)
+	}
+	if entry.CacheWriteInputTokens != 0 {
+		t.Fatalf("CacheWriteInputTokens = %d, want 0", entry.CacheWriteInputTokens)
+	}
+	want := 80.0 / 120.0
+	if math.Abs(entry.CachedInputRatio-want) > 1e-9 {
+		t.Fatalf("CachedInputRatio = %f, want %f", entry.CachedInputRatio, want)
+	}
+}
+
+func TestEnrichUsageLogEntry_AnthropicSplitAccounting(t *testing.T) {
+	entry := UsageLogEntry{
+		Provider:    "anthropic",
+		InputTokens: 50,
+		RawData: map[string]any{
+			"cache_read_input_tokens":     90,
+			"cache_creation_input_tokens": 30,
+		},
+	}
+	EnrichUsageLogEntry(&entry)
+	if entry.UncachedInputTokens != 50 {
+		t.Fatalf("UncachedInputTokens = %d, want 50", entry.UncachedInputTokens)
+	}
+	if entry.CachedInputTokens != 90 {
+		t.Fatalf("CachedInputTokens = %d, want 90", entry.CachedInputTokens)
+	}
+	if entry.CacheWriteInputTokens != 30 {
+		t.Fatalf("CacheWriteInputTokens = %d, want 30", entry.CacheWriteInputTokens)
+	}
+	want := 90.0 / 170.0
+	if math.Abs(entry.CachedInputRatio-want) > 1e-9 {
+		t.Fatalf("CachedInputRatio = %f, want %f", entry.CachedInputRatio, want)
+	}
+}
+
+func TestEnrichUsageLogEntry_NoCacheData(t *testing.T) {
+	entry := UsageLogEntry{
+		Provider:    "openai",
+		InputTokens: 100,
+	}
+	EnrichUsageLogEntry(&entry)
+	if entry.UncachedInputTokens != 100 {
+		t.Fatalf("UncachedInputTokens = %d, want 100", entry.UncachedInputTokens)
+	}
+	if entry.CachedInputTokens != 0 {
+		t.Fatalf("CachedInputTokens = %d, want 0", entry.CachedInputTokens)
+	}
+	if entry.CachedInputRatio != 0 {
+		t.Fatalf("CachedInputRatio = %f, want 0", entry.CachedInputRatio)
+	}
+}
+
+func TestEnrichUsageLogEntry_NilSafe(t *testing.T) {
+	EnrichUsageLogEntry(nil)
+}

--- a/internal/usage/enrich_test.go
+++ b/internal/usage/enrich_test.go
@@ -71,6 +71,52 @@ func TestEnrichUsageLogEntry_NoCacheData(t *testing.T) {
 	}
 }
 
+func TestEnrichUsageLogEntry_BedrockCacheWriteField(t *testing.T) {
+	entry := UsageLogEntry{
+		Provider:    "bedrock",
+		InputTokens: 40,
+		RawData: map[string]any{
+			"cache_read_input_tokens":  120,
+			"cache_write_input_tokens": 60,
+		},
+	}
+	EnrichUsageLogEntry(&entry)
+	if entry.UncachedInputTokens != 40 {
+		t.Fatalf("UncachedInputTokens = %d, want 40", entry.UncachedInputTokens)
+	}
+	if entry.CachedInputTokens != 120 {
+		t.Fatalf("CachedInputTokens = %d, want 120", entry.CachedInputTokens)
+	}
+	if entry.CacheWriteInputTokens != 60 {
+		t.Fatalf("CacheWriteInputTokens = %d, want 60", entry.CacheWriteInputTokens)
+	}
+	want := 120.0 / 220.0
+	if math.Abs(entry.CachedInputRatio-want) > 1e-9 {
+		t.Fatalf("CachedInputRatio = %f, want %f", entry.CachedInputRatio, want)
+	}
+}
+
+func TestEnrichUsageLogEntry_BedrockCacheWriteOnly(t *testing.T) {
+	// First request that writes to the cache reports only cache_write_input_tokens.
+	entry := UsageLogEntry{
+		Provider:    "bedrock",
+		InputTokens: 100,
+		RawData: map[string]any{
+			"cache_write_input_tokens": 80,
+		},
+	}
+	EnrichUsageLogEntry(&entry)
+	if entry.UncachedInputTokens != 100 {
+		t.Fatalf("UncachedInputTokens = %d, want 100", entry.UncachedInputTokens)
+	}
+	if entry.CachedInputTokens != 0 {
+		t.Fatalf("CachedInputTokens = %d, want 0", entry.CachedInputTokens)
+	}
+	if entry.CacheWriteInputTokens != 80 {
+		t.Fatalf("CacheWriteInputTokens = %d, want 80", entry.CacheWriteInputTokens)
+	}
+}
+
 func TestEnrichUsageLogEntry_NilSafe(t *testing.T) {
 	EnrichUsageLogEntry(nil)
 }

--- a/internal/usage/reader.go
+++ b/internal/usage/reader.go
@@ -75,6 +75,10 @@ type UsageLogParams struct {
 }
 
 // UsageLogEntry represents a single usage record in the request log.
+//
+// The cached_input_tokens, uncached_input_tokens, cache_write_input_tokens,
+// and cached_input_ratio fields are derived from RawData at read time by
+// EnrichUsageLogEntry; storage layers never populate them.
 type UsageLogEntry struct {
 	ID                     string         `json:"id"`
 	RequestID              string         `json:"request_id"`
@@ -89,12 +93,35 @@ type UsageLogEntry struct {
 	InputTokens            int            `json:"input_tokens"`
 	OutputTokens           int            `json:"output_tokens"`
 	TotalTokens            int            `json:"total_tokens"`
+	UncachedInputTokens    int64          `json:"uncached_input_tokens,omitempty"`
+	CachedInputTokens      int64          `json:"cached_input_tokens,omitempty"`
+	CacheWriteInputTokens  int64          `json:"cache_write_input_tokens,omitempty"`
+	CachedInputRatio       float64        `json:"cached_input_ratio,omitempty"`
 	InputCost              *float64       `json:"input_cost"`
 	OutputCost             *float64       `json:"output_cost"`
 	TotalCost              *float64       `json:"total_cost"`
 	CostSource             string         `json:"cost_source,omitempty"`
 	RawData                map[string]any `json:"raw_data,omitempty"`
 	CostsCalculationCaveat string         `json:"costs_calculation_caveat,omitempty"`
+}
+
+// EnrichUsageLogEntry populates the derived provider-cache fields on entry
+// (uncached/cached/write split and the cached ratio) from RawData. Safe to
+// call on entries whose RawData does not contain provider cache fields.
+func EnrichUsageLogEntry(entry *UsageLogEntry) {
+	if entry == nil {
+		return
+	}
+	uncached, cached, cacheWrite := EntryInputSegments(*entry)
+	entry.UncachedInputTokens = uncached
+	entry.CachedInputTokens = cached
+	entry.CacheWriteInputTokens = cacheWrite
+	total := uncached + cached + cacheWrite
+	if total > 0 && cached > 0 {
+		entry.CachedInputRatio = float64(cached) / float64(total)
+	} else {
+		entry.CachedInputRatio = 0
+	}
 }
 
 // UsageLogResult holds a paginated list of usage log entries.

--- a/internal/usage/request_summary.go
+++ b/internal/usage/request_summary.go
@@ -54,15 +54,20 @@ func SummarizeRequestUsage(entries []UsageLogEntry) *RequestUsageSummary {
 
 // EntryInputSegments splits one usage log entry's input tokens into the
 // provider-uncached prompt, the provider-cached read, and the provider cache
-// write portions. Provider-specific quirks (e.g. Anthropic reporting cached
-// reads/writes as separate counts on top of input_tokens) are handled here so
-// callers — request summaries, the admin usage log, and the live SSE preview —
-// stay in sync.
+// write portions. Provider-specific quirks are handled here so callers —
+// request summaries, the admin usage log, and the live SSE preview — stay in
+// sync. The various provider field names are coalesced via max:
+//   - cached reads: cache_read_input_tokens (Anthropic, Bedrock),
+//     prompt_cached_tokens (OpenAI, DeepSeek), cached_tokens (Gemini)
+//   - cache writes: cache_creation_input_tokens (Anthropic),
+//     cache_write_input_tokens (Bedrock Converse)
 func EntryInputSegments(entry UsageLogEntry) (uncachedInput, cachedInput, cacheWriteInput int64) {
 	cacheReadTopLevel := int64(extractInt(entry.RawData, "cache_read_input_tokens"))
 	cacheReadNormalized := int64(extractInt(entry.RawData, "prompt_cached_tokens"))
 	cacheReadGeneric := int64(extractInt(entry.RawData, "cached_tokens"))
-	cacheWriteInput = int64(extractInt(entry.RawData, "cache_creation_input_tokens"))
+	cacheWriteCreation := int64(extractInt(entry.RawData, "cache_creation_input_tokens"))
+	cacheWriteGeneric := int64(extractInt(entry.RawData, "cache_write_input_tokens"))
+	cacheWriteInput = maxInt64(cacheWriteCreation, cacheWriteGeneric)
 
 	cachedInput = maxInt64(cacheReadTopLevel, cacheReadNormalized, cacheReadGeneric)
 	baseInput := int64(entry.InputTokens)

--- a/internal/usage/request_summary.go
+++ b/internal/usage/request_summary.go
@@ -32,7 +32,7 @@ func SummarizeRequestUsage(entries []UsageLogEntry) *RequestUsageSummary {
 
 	summary := &RequestUsageSummary{}
 	for _, entry := range entries {
-		uncachedInput, cachedInput, cacheWriteInput := requestInputSegments(entry)
+		uncachedInput, cachedInput, cacheWriteInput := EntryInputSegments(entry)
 		totalInput := uncachedInput + cachedInput + cacheWriteInput
 
 		summary.Entries++
@@ -52,7 +52,13 @@ func SummarizeRequestUsage(entries []UsageLogEntry) *RequestUsageSummary {
 	return summary
 }
 
-func requestInputSegments(entry UsageLogEntry) (uncachedInput, cachedInput, cacheWriteInput int64) {
+// EntryInputSegments splits one usage log entry's input tokens into the
+// provider-uncached prompt, the provider-cached read, and the provider cache
+// write portions. Provider-specific quirks (e.g. Anthropic reporting cached
+// reads/writes as separate counts on top of input_tokens) are handled here so
+// callers — request summaries, the admin usage log, and the live SSE preview —
+// stay in sync.
+func EntryInputSegments(entry UsageLogEntry) (uncachedInput, cachedInput, cacheWriteInput int64) {
 	cacheReadTopLevel := int64(extractInt(entry.RawData, "cache_read_input_tokens"))
 	cacheReadNormalized := int64(extractInt(entry.RawData, "prompt_cached_tokens"))
 	cacheReadGeneric := int64(extractInt(entry.RawData, "cached_tokens"))
@@ -61,7 +67,7 @@ func requestInputSegments(entry UsageLogEntry) (uncachedInput, cachedInput, cach
 	cachedInput = maxInt64(cacheReadTopLevel, cacheReadNormalized, cacheReadGeneric)
 	baseInput := int64(entry.InputTokens)
 
-	if requestUsesSplitPromptCacheAccounting(entry, cacheReadTopLevel, cacheWriteInput) {
+	if entryUsesSplitPromptCacheAccounting(entry, cacheReadTopLevel, cacheWriteInput) {
 		return baseInput, cachedInput, cacheWriteInput
 	}
 
@@ -72,7 +78,7 @@ func requestInputSegments(entry UsageLogEntry) (uncachedInput, cachedInput, cach
 	return uncachedInput, cachedInput, cacheWriteInput
 }
 
-func requestUsesSplitPromptCacheAccounting(entry UsageLogEntry, cacheReadInput, cacheWriteInput int64) bool {
+func entryUsesSplitPromptCacheAccounting(entry UsageLogEntry, cacheReadInput, cacheWriteInput int64) bool {
 	if cacheReadInput > 0 || cacheWriteInput > 0 {
 		return true
 	}


### PR DESCRIPTION
## Summary

- **Gateway response cache**: cached usage entries are now visible by default on the Usage page, with an opt-in "Hide cached requests" checkbox that filters both the paginated log and the live SSE stream (broker now broadcasts cached events so the client can decide). Cached rows render italic and dimmed, with a Cache column (Exact/Semantic) and a database-zap icon on the cost cell whose ancestor tooltip reads "Saved by cache — not charged".
- **Provider prompt cache**: new Provider Cache column shows the percentage of input tokens served from the upstream provider's prompt cache (OpenAI prefix cache, Anthropic ephemeral cache, DeepSeek context cache, Gemini cache). Column order swapped to Provider | Model. Cost cells use `white-space: nowrap` so trailing icons stay inline.
- **Refactor**: extracted `usage.EntryInputSegments` so `SummarizeRequestUsage`, the admin usage log handler, and the live SSE preview share one provider-cache segmenter — handles Anthropic's split accounting where `input_tokens` is the uncached portion and `cache_read/creation_input_tokens` are reported alongside.
- **Layout**: widened `.content` from 1200px to 1400px.

Derived fields (`uncached_input_tokens`, `cached_input_tokens`, `cache_write_input_tokens`, `cached_input_ratio`) are JSON-only on `UsageLogEntry`, populated by `EnrichUsageLogEntry` at the admin/SSE boundary so storage layers stay untouched.

## Test plan

- [x] `go test ./...` (full Go suite)
- [x] `node --test internal/admin/dashboard/static/js/modules/*.test.cjs` (292 tests)
- [x] Live verification: paired large-prompt requests to gpt-4o-mini, claude-sonnet-4-5, deepseek-v4-flash → Provider Cache column rendered 96.2%, 99.5%, and 99.2% with correct tooltips on the dashboard.
- [ ] Flip "Hide cached requests" — paginated log and live SSE updates respect the toggle in both directions.
- [ ] Verify Cache column shows "Exact"/"Semantic" in bold for cached rows; cached cost cell shows database-zap icon and the ancestor tooltip "Saved by cache — not charged".
- [ ] Resize browser past 1400px to confirm content width is comfortable and tables breathe; verify mobile (\<768px) still goes 100% width.

> Note: the native passthrough route `/p/{provider}/...` does not record usage entries today, so passthrough traffic won't appear in the Provider Cache column. Worth filing as a separate task if we want passthrough usage tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Hide cached requests" toggle in the Usage Log filter
  * Usage log shows cache and provider-cache indicators and icons

* **Improvements**
  * Wider dashboard content area for improved visibility
  * Price cells no longer wrap; usage rows show cached vs uncached token and cost details with updated tooltips
  * Live usage previews include cached entries when applicable

* **Tests**
  * Expanded unit tests covering cache handling and usage summaries

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ENTERPILOT/GoModel/pull/336?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->