### PR TITLE
fix(dashboard): sync live usage audit status

### DIFF
--- a/internal/admin/dashboard/static/js/modules/live-logs.js
+++ b/internal/admin/dashboard/static/js/modules/live-logs.js
@@ -186,7 +186,7 @@
                         return merged;
                     }
                     if (!this.auditLiveInsertAllowed()) return;
-                    this.auditLog.entries = [patch, ...currentEntries].slice(0, this.auditLog.limit || 25);
+                    this.auditLog.entries = [this.mergeLiveAuditUsagePatch(patch), ...currentEntries].slice(0, this.auditLog.limit || 25);
                     this.auditLog.total = Number(this.auditLog.total || 0) + 1;
                     return this.auditLog.entries[0];
                 }
@@ -206,7 +206,7 @@
                     return merged;
                 }
                 if (!this.auditLiveInsertAllowed()) return;
-                this.auditLog.entries = [patch, ...currentEntries].slice(0, this.auditLog.limit || 25);
+                this.auditLog.entries = [this.mergeLiveAuditUsagePatch(patch), ...currentEntries].slice(0, this.auditLog.limit || 25);
                 this.auditLog.total = Number(this.auditLog.total || 0) + 1;
                 const inserted = this.auditLog.entries[0];
                 this.fetchExpandedAuditDetailIfReady(inserted);
@@ -222,7 +222,20 @@
                     !Array.isArray(previous.data) && !Array.isArray(patch.data)) {
                     merged.data = { ...previous.data, ...patch.data };
                 }
-                return merged;
+                return this.mergeLiveAuditUsagePatch(merged);
+            },
+
+            mergeLiveAuditUsagePatch(entry) {
+                const usageEntry = this.liveUsageEntryForAudit(entry);
+                return usageEntry ? this.auditEntryWithLiveUsage(entry, usageEntry) : entry;
+            },
+
+            liveUsageEntryForAudit(entry) {
+                const requestID = String(entry && entry.request_id || '').trim();
+                if (!requestID || !this.usageLog || !Array.isArray(this.usageLog.entries)) return null;
+                return this.usageLog.entries.find((usageEntry) => {
+                    return String(usageEntry && usageEntry.request_id || '').trim() === requestID;
+                }) || null;
             },
 
             fetchExpandedAuditDetailIfReady(entry) {
@@ -284,37 +297,38 @@
                 incoming = { ...incoming, _live_state: eventType || incoming._live_state || 'usage.completed' };
                 const id = String(incoming.id || '').trim();
                 if (!id) return;
-                this.applyLiveUsageToAudit(incoming);
                 const currentEntries = (this.usageLog && Array.isArray(this.usageLog.entries)) ? this.usageLog.entries : [];
                 const index = currentEntries.findIndex((entry) => String(entry.id || '').trim() === id);
-                if (this.usageLogHideCached && this.liveUsageEntryCached(incoming) && index < 0) {
-                    return;
-                }
                 if (index >= 0) {
                     const previous = currentEntries[index] || {};
                     const liveState = this.liveUsageStateAfter(previous._live_state, incoming._live_state);
                     const usageFlushed = this.liveUsageEventFlushed(previous) || this.liveUsageEventFlushed({ ...incoming, _live_state: liveState });
-                    currentEntries.splice(index, 1, {
+                    const merged = {
                         ...previous,
                         ...incoming,
                         _live: true,
                         _live_state: liveState || 'usage.completed',
                         _live_pending: !usageFlushed,
                         _usage_flushed: usageFlushed
-                    });
+                    };
+                    currentEntries.splice(index, 1, merged);
                     this.usageLog.entries = [...currentEntries];
+                    this.applyLiveUsageToAudit(merged);
                     return;
                 }
-                if (!this.usageLiveInsertAllowed()) return;
                 const liveState = this.liveUsageStateAfter('', incoming._live_state);
                 const usageFlushed = this.liveUsageEventFlushed({ ...incoming, _live_state: liveState });
-                this.usageLog.entries = [{
+                const liveEntry = {
                     ...incoming,
                     _live: true,
                     _live_state: liveState || 'usage.completed',
                     _live_pending: !usageFlushed,
                     _usage_flushed: usageFlushed
-                }, ...currentEntries].slice(0, this.usageLog.limit || 50);
+                };
+                this.applyLiveUsageToAudit(liveEntry);
+                if (this.usageLogHideCached && this.liveUsageEntryCached(liveEntry)) return;
+                if (!this.usageLiveInsertAllowed()) return;
+                this.usageLog.entries = [liveEntry, ...currentEntries].slice(0, this.usageLog.limit || 50);
                 this.usageLog.total = Number(this.usageLog.total || 0) + 1;
             },
 
@@ -347,36 +361,68 @@
             },
 
             applyLiveUsageToAudit(usageEntry) {
-                if (this.liveUsageEntryCached(usageEntry)) return;
                 const requestID = String(usageEntry && usageEntry.request_id || '').trim();
                 if (!requestID || !this.auditLog || !Array.isArray(this.auditLog.entries)) return;
                 const index = this.auditLog.entries.findIndex((entry) => String(entry.request_id || '').trim() === requestID);
                 if (index < 0) return;
                 const entry = this.auditLog.entries[index];
+                this.auditLog.entries.splice(index, 1, this.auditEntryWithLiveUsage(entry, usageEntry));
+                this.auditLog.entries = [...this.auditLog.entries];
+            },
+
+            auditEntryWithLiveUsage(entry, usageEntry) {
                 const usageLiveState = this.liveUsageStateAfter(entry._usage_live_state, usageEntry._live_state || 'usage.completed');
                 const usageFlushed = this.liveUsageEventFlushed({
                     _live_state: usageLiveState,
                     _usage_flushed: entry._usage_flushed || usageEntry._usage_flushed
                 });
-                const usage = {
-                    entries: 1,
-                    input_tokens: Number(usageEntry.input_tokens || 0),
-                    uncached_input_tokens: Number(usageEntry.input_tokens || 0),
-                    cached_input_tokens: 0,
-                    cache_write_input_tokens: 0,
-                    output_tokens: Number(usageEntry.output_tokens || 0),
-                    total_tokens: Number(usageEntry.total_tokens || 0),
-                    cached_input_ratio: 0,
-                    estimated_cached_characters: 0
-                };
-                this.auditLog.entries.splice(index, 1, {
+                return {
                     ...entry,
-                    usage,
+                    usage: this.liveUsageSummary(usageEntry, entry.usage),
                     _usage_live_state: usageLiveState || 'usage.completed',
                     _usage_live_pending: !usageFlushed,
                     _usage_flushed: usageFlushed
-                });
-                this.auditLog.entries = [...this.auditLog.entries];
+                };
+            },
+
+            liveUsageSummary(usageEntry, previousUsage) {
+                const previous = previousUsage && typeof previousUsage === 'object' && !Array.isArray(previousUsage) ? previousUsage : {};
+                const inputTokens = this.liveNumber(usageEntry.input_tokens, this.liveNumber(previous.input_tokens, 0));
+                const outputTokens = this.liveNumber(usageEntry.output_tokens, this.liveNumber(previous.output_tokens, 0));
+                let uncachedInputTokens = this.liveNumber(usageEntry.uncached_input_tokens, this.liveNumber(previous.uncached_input_tokens, 0));
+                const cachedInputTokens = this.liveNumber(usageEntry.cached_input_tokens, this.liveNumber(previous.cached_input_tokens, 0));
+                const cacheWriteInputTokens = this.liveNumber(usageEntry.cache_write_input_tokens, this.liveNumber(previous.cache_write_input_tokens, 0));
+                if (inputTokens > 0 && uncachedInputTokens + cachedInputTokens + cacheWriteInputTokens === 0) {
+                    uncachedInputTokens = inputTokens;
+                }
+                const normalizedInputTokens = inputTokens || uncachedInputTokens + cachedInputTokens + cacheWriteInputTokens;
+                const totalTokens = this.liveNumber(
+                    usageEntry.total_tokens,
+                    this.liveNumber(previous.total_tokens, normalizedInputTokens + outputTokens)
+                );
+                const cachedInputRatio = this.liveNumber(
+                    usageEntry.cached_input_ratio,
+                    this.liveNumber(previous.cached_input_ratio, normalizedInputTokens > 0 ? cachedInputTokens / normalizedInputTokens : 0)
+                );
+                return {
+                    entries: Math.max(1, this.liveNumber(usageEntry.entries, this.liveNumber(previous.entries, 1))),
+                    input_tokens: normalizedInputTokens,
+                    uncached_input_tokens: uncachedInputTokens,
+                    cached_input_tokens: cachedInputTokens,
+                    cache_write_input_tokens: cacheWriteInputTokens,
+                    output_tokens: outputTokens,
+                    total_tokens: totalTokens,
+                    cached_input_ratio: cachedInputRatio,
+                    estimated_cached_characters: this.liveNumber(
+                        usageEntry.estimated_cached_characters,
+                        this.liveNumber(previous.estimated_cached_characters, cachedInputTokens * 4)
+                    )
+                };
+            },
+
+            liveNumber(value, fallback) {
+                const number = Number(value);
+                return Number.isFinite(number) ? number : fallback;
             },
 
             async fetchAuditEntryDetail(entry) {

--- a/internal/admin/dashboard/static/js/modules/live-logs.js
+++ b/internal/admin/dashboard/static/js/modules/live-logs.js
@@ -228,7 +228,10 @@
 
             mergeLiveAuditUsagePatch(entry) {
                 const usageEntry = this.liveUsageEntryForAudit(entry);
-                return usageEntry ? this.auditEntryWithLiveUsage(entry, usageEntry) : entry;
+                if (!usageEntry) return entry;
+                const merged = this.auditEntryWithLiveUsage(entry, usageEntry);
+                this.removeSkippedLiveUsage(usageEntry);
+                return merged;
             },
 
             liveUsageEntryForAudit(entry) {
@@ -306,19 +309,22 @@
                 if (index >= 0) {
                     const previous = currentEntries[index] || {};
                     const merged = this.mergeLiveUsagePatch(previous, incoming);
+                    this.applyLiveUsageToAudit(merged);
+                    if (this.liveUsageShouldSkip(merged)) {
+                        currentEntries.splice(index, 1);
+                        this.usageLog.entries = [...currentEntries];
+                        this.usageLog.total = Math.max(0, Number(this.usageLog.total || 0) - 1);
+                        this.storeSkippedLiveUsage(merged);
+                        return;
+                    }
                     currentEntries.splice(index, 1, merged);
                     this.usageLog.entries = [...currentEntries];
                     this.removeSkippedLiveUsage(merged);
-                    this.applyLiveUsageToAudit(merged);
                     return;
                 }
-                const liveEntry = this.mergeLiveUsagePatch(this.skippedLiveUsageForEntry(incoming), incoming);
+                const liveEntry = this.mergeLiveUsagePatch(this.liveUsageSeedForEntry(incoming), incoming);
                 this.applyLiveUsageToAudit(liveEntry);
-                if (this.usageLogHideCached && this.liveUsageEntryCached(liveEntry)) {
-                    this.storeSkippedLiveUsage(liveEntry);
-                    return;
-                }
-                if (!this.usageLiveInsertAllowed()) {
+                if (this.liveUsageShouldSkip(liveEntry)) {
                     this.storeSkippedLiveUsage(liveEntry);
                     return;
                 }
@@ -341,9 +347,43 @@
                 };
             },
 
+            liveUsageShouldSkip(entry) {
+                return !!(this.usageLogHideCached && this.liveUsageEntryCached(entry)) || !this.usageLiveInsertAllowed();
+            },
+
+            liveUsageSeedForEntry(entry) {
+                return this.skippedLiveUsageForEntry(entry) || this.auditLiveUsageForEntry(entry);
+            },
+
             skippedLiveUsageForEntry(entry) {
                 const requestID = String(entry && entry.request_id || '').trim();
                 return requestID && this.skippedLiveUsageByRequestId ? this.skippedLiveUsageByRequestId[requestID] : null;
+            },
+
+            auditLiveUsageForEntry(entry) {
+                const requestID = String(entry && entry.request_id || '').trim();
+                if (!requestID || !this.auditLog || !Array.isArray(this.auditLog.entries)) return null;
+                const auditEntry = this.auditLog.entries.find((candidate) => String(candidate && candidate.request_id || '').trim() === requestID);
+                const usage = auditEntry && auditEntry.usage && typeof auditEntry.usage === 'object' && !Array.isArray(auditEntry.usage)
+                    ? auditEntry.usage
+                    : null;
+                if (!usage) return null;
+                return {
+                    id: entry && entry.id,
+                    request_id: requestID,
+                    entries: usage.entries,
+                    input_tokens: usage.input_tokens,
+                    uncached_input_tokens: usage.uncached_input_tokens,
+                    cached_input_tokens: usage.cached_input_tokens,
+                    cache_write_input_tokens: usage.cache_write_input_tokens,
+                    output_tokens: usage.output_tokens,
+                    total_tokens: usage.total_tokens,
+                    cached_input_ratio: usage.cached_input_ratio,
+                    estimated_cached_characters: usage.estimated_cached_characters,
+                    _live_state: auditEntry._usage_live_state,
+                    _live_pending: auditEntry._usage_live_pending,
+                    _usage_flushed: auditEntry._usage_flushed
+                };
             },
 
             storeSkippedLiveUsage(entry) {

--- a/internal/admin/dashboard/static/js/modules/live-logs.js
+++ b/internal/admin/dashboard/static/js/modules/live-logs.js
@@ -12,6 +12,7 @@
             liveLogsReconnectAttempts: 0,
             liveLogsReconnectTimer: null,
             liveLogsController: null,
+            skippedLiveUsageByRequestId: null,
 
             liveLogsEnabled() {
                 return typeof this.workflowRuntimeBooleanFlag === 'function'
@@ -232,10 +233,13 @@
 
             liveUsageEntryForAudit(entry) {
                 const requestID = String(entry && entry.request_id || '').trim();
-                if (!requestID || !this.usageLog || !Array.isArray(this.usageLog.entries)) return null;
-                return this.usageLog.entries.find((usageEntry) => {
+                if (!requestID) return null;
+                const entries = this.usageLog && Array.isArray(this.usageLog.entries) ? this.usageLog.entries : [];
+                const visible = entries.find((usageEntry) => {
                     return String(usageEntry && usageEntry.request_id || '').trim() === requestID;
-                }) || null;
+                });
+                if (visible) return visible;
+                return this.skippedLiveUsageByRequestId && this.skippedLiveUsageByRequestId[requestID] || null;
             },
 
             fetchExpandedAuditDetailIfReady(entry) {
@@ -301,35 +305,61 @@
                 const index = currentEntries.findIndex((entry) => String(entry.id || '').trim() === id);
                 if (index >= 0) {
                     const previous = currentEntries[index] || {};
-                    const liveState = this.liveUsageStateAfter(previous._live_state, incoming._live_state);
-                    const usageFlushed = this.liveUsageEventFlushed(previous) || this.liveUsageEventFlushed({ ...incoming, _live_state: liveState });
-                    const merged = {
-                        ...previous,
-                        ...incoming,
-                        _live: true,
-                        _live_state: liveState || 'usage.completed',
-                        _live_pending: !usageFlushed,
-                        _usage_flushed: usageFlushed
-                    };
+                    const merged = this.mergeLiveUsagePatch(previous, incoming);
                     currentEntries.splice(index, 1, merged);
                     this.usageLog.entries = [...currentEntries];
+                    this.removeSkippedLiveUsage(merged);
                     this.applyLiveUsageToAudit(merged);
                     return;
                 }
-                const liveState = this.liveUsageStateAfter('', incoming._live_state);
-                const usageFlushed = this.liveUsageEventFlushed({ ...incoming, _live_state: liveState });
-                const liveEntry = {
+                const liveEntry = this.mergeLiveUsagePatch(this.skippedLiveUsageForEntry(incoming), incoming);
+                this.applyLiveUsageToAudit(liveEntry);
+                if (this.usageLogHideCached && this.liveUsageEntryCached(liveEntry)) {
+                    this.storeSkippedLiveUsage(liveEntry);
+                    return;
+                }
+                if (!this.usageLiveInsertAllowed()) {
+                    this.storeSkippedLiveUsage(liveEntry);
+                    return;
+                }
+                this.removeSkippedLiveUsage(liveEntry);
+                this.usageLog.entries = [liveEntry, ...currentEntries].slice(0, this.usageLog.limit || 50);
+                this.usageLog.total = Number(this.usageLog.total || 0) + 1;
+            },
+
+            mergeLiveUsagePatch(previous, incoming) {
+                previous = previous && typeof previous === 'object' ? previous : {};
+                const liveState = this.liveUsageStateAfter(previous._live_state, incoming && incoming._live_state);
+                const usageFlushed = this.liveUsageEventFlushed(previous) || this.liveUsageEventFlushed({ ...incoming, _live_state: liveState });
+                return {
+                    ...previous,
                     ...incoming,
                     _live: true,
                     _live_state: liveState || 'usage.completed',
                     _live_pending: !usageFlushed,
                     _usage_flushed: usageFlushed
                 };
-                this.applyLiveUsageToAudit(liveEntry);
-                if (this.usageLogHideCached && this.liveUsageEntryCached(liveEntry)) return;
-                if (!this.usageLiveInsertAllowed()) return;
-                this.usageLog.entries = [liveEntry, ...currentEntries].slice(0, this.usageLog.limit || 50);
-                this.usageLog.total = Number(this.usageLog.total || 0) + 1;
+            },
+
+            skippedLiveUsageForEntry(entry) {
+                const requestID = String(entry && entry.request_id || '').trim();
+                return requestID && this.skippedLiveUsageByRequestId ? this.skippedLiveUsageByRequestId[requestID] : null;
+            },
+
+            storeSkippedLiveUsage(entry) {
+                const requestID = String(entry && entry.request_id || '').trim();
+                if (!requestID) return;
+                if (!this.skippedLiveUsageByRequestId || typeof this.skippedLiveUsageByRequestId !== 'object' || Array.isArray(this.skippedLiveUsageByRequestId)) {
+                    this.skippedLiveUsageByRequestId = {};
+                }
+                this.skippedLiveUsageByRequestId[requestID] = entry;
+            },
+
+            removeSkippedLiveUsage(entry) {
+                const requestID = String(entry && entry.request_id || '').trim();
+                if (requestID && this.skippedLiveUsageByRequestId) {
+                    delete this.skippedLiveUsageByRequestId[requestID];
+                }
             },
 
             liveUsageEntryCached(entry) {
@@ -395,10 +425,12 @@
                 if (inputTokens > 0 && uncachedInputTokens + cachedInputTokens + cacheWriteInputTokens === 0) {
                     uncachedInputTokens = inputTokens;
                 }
-                const normalizedInputTokens = inputTokens || uncachedInputTokens + cachedInputTokens + cacheWriteInputTokens;
-                const totalTokens = this.liveNumber(
+                const segmentedInputTokens = uncachedInputTokens + cachedInputTokens + cacheWriteInputTokens;
+                const normalizedInputTokens = segmentedInputTokens || inputTokens;
+                const computedTotalTokens = normalizedInputTokens + outputTokens;
+                const totalTokens = computedTotalTokens || this.liveNumber(
                     usageEntry.total_tokens,
-                    this.liveNumber(previous.total_tokens, normalizedInputTokens + outputTokens)
+                    this.liveNumber(previous.total_tokens, 0)
                 );
                 const cachedInputRatio = this.liveNumber(
                     usageEntry.cached_input_ratio,

--- a/internal/admin/dashboard/static/js/modules/live-logs.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/live-logs.test.cjs
@@ -402,6 +402,103 @@ test('cached live usage attaches when the audit preview arrives later', () => {
     assert.equal(app.auditLog.entries[0]._usage_live_pending, true);
 });
 
+test('hidden cached live usage attaches to later audit previews', () => {
+    const app = createLiveLogsApp();
+    app.usageLogHideCached = true;
+
+    app.applyLiveLogEvent({
+        seq: 11,
+        type: 'usage.completed',
+        data: {
+            id: 'usage-cache',
+            request_id: 'req-cache',
+            cache_type: 'exact',
+            model: 'gpt-test',
+            provider: 'openai',
+            input_tokens: 10,
+            output_tokens: 4,
+            total_tokens: 14
+        }
+    });
+
+    assert.equal(app.usageLog.entries.length, 0);
+
+    app.applyLiveLogEvent({
+        seq: 12,
+        type: 'audit.completed',
+        data: {
+            id: 'audit-cache',
+            request_id: 'req-cache',
+            cache_type: 'exact',
+            status_code: 200
+        }
+    });
+
+    assert.equal(app.auditLog.entries[0].usage.total_tokens, 14);
+    assert.equal(app.auditLog.entries[0]._usage_live_state, 'usage.completed');
+    assert.equal(app.auditLog.entries[0]._usage_live_pending, true);
+
+    app.applyLiveLogEvent({
+        seq: 13,
+        type: 'usage.flushed',
+        data: {
+            id: 'usage-cache',
+            request_id: 'req-cache',
+            cache_type: 'exact'
+        }
+    });
+
+    assert.equal(app.usageLog.entries.length, 0);
+    assert.equal(app.auditLog.entries[0].usage.total_tokens, 14);
+    assert.equal(app.auditLog.entries[0]._usage_flushed, true);
+    assert.equal(app.auditLog.entries[0]._usage_live_pending, false);
+
+    app.usageLogHideCached = false;
+    app.applyLiveLogEvent({
+        seq: 14,
+        type: 'usage.flushed',
+        data: {
+            id: 'usage-cache',
+            request_id: 'req-cache',
+            cache_type: 'exact'
+        }
+    });
+
+    assert.equal(app.usageLog.entries.length, 1);
+    assert.equal(app.usageLog.entries[0].total_tokens, 14);
+    assert.equal(app.skippedLiveUsageByRequestId['req-cache'], undefined);
+});
+
+test('live usage audit summary uses normalized split prompt-cache tokens', () => {
+    const app = createLiveLogsApp();
+    app.auditLog.entries = [{ id: 'audit-cache', request_id: 'req-cache' }];
+
+    app.applyLiveLogEvent({
+        seq: 15,
+        type: 'usage.completed',
+        data: {
+            id: 'usage-cache',
+            request_id: 'req-cache',
+            input_tokens: 100,
+            uncached_input_tokens: 100,
+            cached_input_tokens: 50,
+            cache_write_input_tokens: 25,
+            output_tokens: 20,
+            total_tokens: 120
+        }
+    });
+
+    const summary = app.auditLog.entries[0].usage;
+    assert.equal(summary.input_tokens, 175);
+    assert.equal(summary.uncached_input_tokens, 100);
+    assert.equal(summary.cached_input_tokens, 50);
+    assert.equal(summary.cache_write_input_tokens, 25);
+    assert.equal(summary.output_tokens, 20);
+    assert.equal(summary.total_tokens, 195);
+    assert.equal(summary.cached_input_ratio, 50 / 175);
+    assert.equal(summary.estimated_cached_characters, 200);
+});
+
 test('audit detail merge preserves existing live lifecycle state', () => {
     const app = createLiveLogsApp();
     app.auditLog.entries = [{

--- a/internal/admin/dashboard/static/js/modules/live-logs.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/live-logs.test.cjs
@@ -437,6 +437,7 @@ test('hidden cached live usage attaches to later audit previews', () => {
     assert.equal(app.auditLog.entries[0].usage.total_tokens, 14);
     assert.equal(app.auditLog.entries[0]._usage_live_state, 'usage.completed');
     assert.equal(app.auditLog.entries[0]._usage_live_pending, true);
+    assert.equal(app.skippedLiveUsageByRequestId['req-cache'], undefined);
 
     app.applyLiveLogEvent({
         seq: 13,
@@ -469,12 +470,51 @@ test('hidden cached live usage attaches to later audit previews', () => {
     assert.equal(app.skippedLiveUsageByRequestId['req-cache'], undefined);
 });
 
-test('live usage audit summary uses normalized split prompt-cache tokens', () => {
+test('cached updates to visible live usage rows move to skipped when cached rows are hidden', () => {
     const app = createLiveLogsApp();
     app.auditLog.entries = [{ id: 'audit-cache', request_id: 'req-cache' }];
 
     app.applyLiveLogEvent({
         seq: 15,
+        type: 'usage.completed',
+        data: {
+            id: 'usage-cache',
+            request_id: 'req-cache',
+            model: 'gpt-test',
+            provider: 'openai',
+            input_tokens: 10,
+            output_tokens: 4,
+            total_tokens: 14
+        }
+    });
+
+    assert.equal(app.usageLog.entries.length, 1);
+    assert.equal(app.usageLog.total, 1);
+
+    app.usageLogHideCached = true;
+    app.applyLiveLogEvent({
+        seq: 16,
+        type: 'usage.flushed',
+        data: {
+            id: 'usage-cache',
+            request_id: 'req-cache',
+            cache_type: 'exact'
+        }
+    });
+
+    assert.equal(app.usageLog.entries.length, 0);
+    assert.equal(app.usageLog.total, 0);
+    assert.equal(app.auditLog.entries[0]._usage_flushed, true);
+    assert.equal(app.auditLog.entries[0].usage.total_tokens, 14);
+    assert.equal(app.skippedLiveUsageByRequestId['req-cache'].total_tokens, 14);
+});
+
+test('live usage audit summary uses normalized split prompt-cache tokens', () => {
+    const app = createLiveLogsApp();
+    app.auditLog.entries = [{ id: 'audit-cache', request_id: 'req-cache' }];
+
+    app.applyLiveLogEvent({
+        seq: 17,
         type: 'usage.completed',
         data: {
             id: 'usage-cache',

--- a/internal/admin/dashboard/static/js/modules/live-logs.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/live-logs.test.cjs
@@ -314,17 +314,28 @@ test('cached live usage events stay visible in default usage preview', () => {
     assert.equal(app.usageLog.total, 1);
     assert.equal(app.usageLog.entries[0].id, 'usage-cache');
     assert.equal(app.usageLog.entries[0]._live_pending, true);
-    assert.equal(app.auditLog.entries[0].usage, undefined);
-    assert.equal(app.auditLog.entries[0]._usage_live_pending, undefined);
-    assert.equal(app.auditLog.entries[0]._usage_live_state, undefined);
+    assert.equal(app.auditLog.entries[0].usage.total_tokens, 14);
+    assert.equal(app.auditLog.entries[0]._usage_live_pending, true);
+    assert.equal(app.auditLog.entries[0]._usage_live_state, 'usage.completed');
 });
 
 test('cached live usage flushed events keep and settle existing previews', () => {
     const app = createLiveLogsApp();
+    app.auditLog.entries = [{
+        id: 'audit-cache',
+        request_id: 'req-cache',
+        cache_type: 'exact',
+        usage: { entries: 1, input_tokens: 10, uncached_input_tokens: 10, output_tokens: 4, total_tokens: 14 },
+        _usage_live_state: 'usage.completed',
+        _usage_live_pending: true
+    }];
     app.usageLog.entries = [{
         id: 'usage-cache',
         request_id: 'req-cache',
         cache_type: 'exact',
+        input_tokens: 10,
+        output_tokens: 4,
+        total_tokens: 14,
         _live: true,
         _live_pending: true
     }];
@@ -345,6 +356,50 @@ test('cached live usage flushed events keep and settle existing previews', () =>
     assert.equal(app.usageLog.entries[0]._live_state, 'usage.flushed');
     assert.equal(app.usageLog.entries[0]._live_pending, false);
     assert.equal(app.usageLog.entries[0]._usage_flushed, true);
+    assert.equal(app.auditLog.entries[0]._usage_flushed, true);
+    assert.equal(app.auditLog.entries[0]._usage_live_pending, false);
+    assert.equal(app.auditLog.entries[0].usage.total_tokens, 14);
+});
+
+test('cached live usage attaches when the audit preview arrives later', () => {
+    const app = createLiveLogsApp();
+
+    app.applyLiveLogEvent({
+        seq: 9,
+        type: 'usage.completed',
+        data: {
+            id: 'usage-cache',
+            request_id: 'req-cache',
+            cache_type: 'exact',
+            model: 'gpt-test',
+            provider: 'openai',
+            input_tokens: 10,
+            output_tokens: 4,
+            total_tokens: 14
+        }
+    });
+    app.applyLiveLogEvent({
+        seq: 10,
+        type: 'audit.completed',
+        data: {
+            id: 'audit-cache',
+            request_id: 'req-cache',
+            cache_type: 'exact',
+            status_code: 200,
+            data: {
+                workflow_features: {
+                    cache: true,
+                    audit: true,
+                    usage: true
+                }
+            }
+        }
+    });
+
+    assert.equal(app.auditLog.entries.length, 1);
+    assert.equal(app.auditLog.entries[0].usage.total_tokens, 14);
+    assert.equal(app.auditLog.entries[0]._usage_live_state, 'usage.completed');
+    assert.equal(app.auditLog.entries[0]._usage_live_pending, true);
 });
 
 test('audit detail merge preserves existing live lifecycle state', () => {

--- a/internal/admin/dashboard/static/js/modules/workflows.js
+++ b/internal/admin/dashboard/static/js/modules/workflows.js
@@ -1225,6 +1225,8 @@
                 const showFailover = !!features.fallback || this.workflowRuntimeUsedFailover(runtime);
                 const workflowID = this.workflowChartWorkflowID(source, config.entry);
                 const liveStep = this.workflowLiveCurrentStep(config.entry, runtime, features);
+                const usagePending = this.workflowLiveUsagePending(config.entry);
+                const auditPending = this.workflowLiveAuditPending(config.entry, runtime);
                 const auditFlushed = this.workflowAuditFlushed(config.entry, highlightAsyncPresent);
                 const usageFlushed = this.workflowUsageFlushed(config.entry, highlightAsyncPresent);
                 return {
@@ -1251,8 +1253,8 @@
                     responseNodeSublabel: this.workflowResponseNodeSublabel(runtime),
                     authNodeClass: this.workflowAuthNodeClass(runtime, liveStep === 'auth'),
                     authNodeSublabel: this.workflowAuthNodeSublabel(runtime),
-                    usageNodeClass: this.workflowAsyncNodeClass(showUsage, usageFlushed, liveStep === 'usage'),
-                    auditNodeClass: this.workflowAsyncNodeClass(showAudit, auditFlushed, liveStep === 'audit'),
+                    usageNodeClass: this.workflowAsyncNodeClass(showUsage, usageFlushed, usagePending),
+                    auditNodeClass: this.workflowAsyncNodeClass(showAudit, auditFlushed, auditPending),
                     showAsync,
                     showUsage,
                     showAudit,
@@ -1304,14 +1306,22 @@
                 return hasUsage && !entry._live_pending;
             },
 
+            workflowLiveUsagePending(entry) {
+                return !!(entry && entry._live && entry._usage_live_pending && !entry._usage_flushed);
+            },
+
+            workflowLiveAuditPending(entry, runtime) {
+                if (!entry || !entry._live || this.workflowAuditFlushed(entry, false)) return false;
+                const state = String(entry._live_state || '').trim();
+                return state === 'audit.completed' || !!(runtime && Number.isFinite(runtime.statusCode));
+            },
+
             workflowLiveCurrentStep(entry, runtime, features) {
                 if (!entry || !entry._live) return '';
-                if (entry._usage_live_pending && !entry._usage_flushed) return 'usage';
+                if (this.workflowLiveUsagePending(entry)) return 'usage';
+                if (this.workflowLiveAuditPending(entry, runtime)) return 'audit';
                 if (this.workflowAuditFlushed(entry, false) && !entry._live_pending) return '';
 
-                const state = String(entry._live_state || '').trim();
-                if (state === 'audit.completed') return 'audit';
-                if (runtime && Number.isFinite(runtime.statusCode)) return 'audit';
                 if (runtime && runtime.cacheHit) return 'cache';
                 if (runtime && (runtime.provider || runtime.model)) return 'ai';
                 if (features && features.budget && (entry.workflow_version_id || entry.requested_model)) return 'budget';

--- a/internal/admin/dashboard/static/js/modules/workflows.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/workflows.test.cjs
@@ -755,6 +755,9 @@ test('workflowAuditChart marks live current steps blue and waits for async flush
         _live: true,
         _live_state: 'audit.completed',
         _live_pending: true,
+        _usage_live_state: 'usage.completed',
+        _usage_live_pending: true,
+        _usage_flushed: false,
         data: {
             workflow_features: {
                 audit: true,
@@ -764,7 +767,7 @@ test('workflowAuditChart marks live current steps blue and waits for async flush
     });
     assert.equal(auditQueued.responseNodeClass, 'workflow-node-success');
     assert.equal(auditQueued.auditNodeClass, 'workflow-node-current');
-    assert.equal(auditQueued.usageNodeClass, '');
+    assert.equal(auditQueued.usageNodeClass, 'workflow-node-current');
 
     const auditFlushedUsageQueuedEntry = {
         id: 'audit-live-1',


### PR DESCRIPTION
## Summary
- mark Usage and Audit Logs independently as pending in live workflow previews
- enrich audit live rows from cached usage events before and after audit previews arrive
- add dashboard JS tests for cached usage/audit pending and flushed states

## Tests
- node --test internal/admin/dashboard/static/js/modules/live-logs.test.cjs
- node --test internal/admin/dashboard/static/js/modules/workflows.test.cjs
- node --test internal/admin/dashboard/static/js/modules/*.test.cjs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audit rows now attach live usage details (token counts, normalized summaries, estimated cached characters) and live-state flags even when usage events were previously hidden or cached.

* **Improvements**
  * Formalized handling of hidden/cached usage so previews still enrich audits; skipped cached usage is tracked to preserve enrichment.
  * Workflow dashboard distinguishes pending/completed states separately for usage and audit.

* **Tests**
  * Expanded tests for cached-preview behavior, enrichment timing, pending/flushed state transitions, and normalized usage summaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ENTERPILOT/GoModel/pull/338?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->