### PR TITLE
feat(audit): show live request bodies after workflow resolution

### DIFF
--- a/internal/admin/dashboard/static/js/modules/live-logs.js
+++ b/internal/admin/dashboard/static/js/modules/live-logs.js
@@ -498,7 +498,7 @@
             },
 
             async fetchAuditEntryDetail(entry) {
-                if (!entry || entry._detail_loading || entry._detail_loaded || this.auditEntryHasDetailData(entry)) return;
+                if (!this.auditEntryShouldFetchDetail(entry)) return;
                 const id = String(entry.id || '').trim();
                 if (!id) return;
                 entry._detail_loading = true;
@@ -518,6 +518,24 @@
                 } finally {
                     this.clearAuditDetailLoading(detailEntry);
                 }
+            },
+
+            auditEntryShouldFetchDetail(entry) {
+                if (!entry || entry._detail_loading || entry._detail_loaded) return false;
+                if (this.auditEntryLiveDetailPending(entry)) return false;
+                if (this.auditEntryNeedsPersistedLiveDetail(entry)) return true;
+                return !this.auditEntryHasDetailData(entry);
+            },
+
+            auditEntryLiveDetailPending(entry) {
+                if (!entry || !entry._live) return false;
+                const state = String(entry._live_state || '').trim();
+                if (state === 'audit.failed') return true;
+                return !entry._audit_flushed && state !== 'audit.flushed' && state !== 'audit.detail';
+            },
+
+            auditEntryNeedsPersistedLiveDetail(entry) {
+                return !!(entry && entry._live && !entry._detail_loaded);
             },
 
             auditEntryHasDetailData(entry) {

--- a/internal/admin/dashboard/static/js/modules/live-logs.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/live-logs.test.cjs
@@ -657,6 +657,73 @@ test('audit detail fetch skips rows that already have captured detail data', asy
     assert.equal(requests, 0);
 });
 
+test('audit detail fetch waits for live audit rows to flush before loading persisted detail', async () => {
+    let requests = 0;
+    const app = createLiveLogsApp({
+        fetch() {
+            requests++;
+            return Promise.reject(new Error('fetch should not run before flush'));
+        }
+    });
+    const entry = {
+        id: 'audit-1',
+        request_id: 'req-1',
+        _live: true,
+        _live_state: 'audit.updated',
+        _live_pending: true,
+        _audit_flushed: false,
+        data: {
+            request_headers: { authorization: 'Bearer redacted' },
+            request_body: { model: 'gpt-test' }
+        }
+    };
+
+    await app.fetchAuditEntryDetail(entry);
+
+    assert.equal(requests, 0);
+});
+
+test('flushed live audit rows fetch persisted detail even with preview request data', async () => {
+    const requests = [];
+    const app = createLiveLogsApp({
+        fetch(url) {
+            requests.push(url);
+            return Promise.resolve({
+                json: async () => ({
+                    id: 'audit-1',
+                    request_id: 'req-1',
+                    data: {
+                        response_headers: { 'x-request-id': 'req-1' },
+                        response_body: { id: 'chatcmpl-test' }
+                    }
+                })
+            });
+        }
+    });
+    app.auditLog.entries = [{
+        id: 'audit-1',
+        request_id: 'req-1',
+        _live: true,
+        _live_state: 'audit.flushed',
+        _live_pending: false,
+        _audit_flushed: true,
+        data: {
+            request_headers: { authorization: 'Bearer redacted' },
+            request_body: { model: 'gpt-test' }
+        }
+    }];
+
+    await app.fetchAuditEntryDetail(app.auditLog.entries[0]);
+
+    assert.equal(requests.length, 1);
+    assert.match(requests[0], /log_id=audit-1/);
+    assert.equal(app.auditLog.entries[0]._detail_loaded, true);
+    assert.deepEqual(app.auditLog.entries[0].data.request_headers, { authorization: 'Bearer redacted' });
+    assert.deepEqual(app.auditLog.entries[0].data.request_body, { model: 'gpt-test' });
+    assert.deepEqual(app.auditLog.entries[0].data.response_headers, { 'x-request-id': 'req-1' });
+    assert.deepEqual(app.auditLog.entries[0].data.response_body, { id: 'chatcmpl-test' });
+});
+
 test('late queued events do not regress flushed live rows to pending', () => {
     const app = createLiveLogsApp();
 

--- a/internal/auditlog/entry_capture.go
+++ b/internal/auditlog/entry_capture.go
@@ -19,27 +19,42 @@ func PopulateRequestData(entry *LogEntry, req *http.Request, cfg Config) {
 		return
 	}
 
-	data := ensureLogData(entry)
-
 	if cfg.LogHeaders {
-		data.RequestHeaders = extractHeaders(req.Header)
+		PopulateRequestHeaders(entry, req.Header)
 	}
 
 	if !cfg.LogBodies {
 		return
 	}
 
-	snapshot := core.GetRequestSnapshot(req.Context())
-	if snapshot == nil {
+	populateRequestBodyFromSnapshot(entry, core.GetRequestSnapshot(req.Context()))
+}
+
+func populateRequestBodyFromSnapshot(entry *LogEntry, snapshot *core.RequestSnapshot) {
+	if entry == nil || snapshot == nil {
+		return
+	}
+	data := ensureLogData(entry)
+	if data.RequestBody != nil || data.RequestBodyTooBigToHandle {
 		return
 	}
 
-	switch body := snapshot.CapturedBody(); {
+	switch body := snapshot.CapturedBodyView(); {
 	case snapshot.BodyNotCaptured:
 		data.RequestBodyTooBigToHandle = true
 	case body != nil:
 		captureLoggedRequestBody(entry, body)
 	}
+}
+
+// PopulateRequestHeaders copies redacted request headers into the log entry.
+func PopulateRequestHeaders(entry *LogEntry, headers http.Header) {
+	if entry == nil || headers == nil {
+		return
+	}
+
+	data := ensureLogData(entry)
+	data.RequestHeaders = extractHeaders(headers)
 }
 
 // PopulateResponseHeaders copies response headers into the log entry when header logging is enabled.

--- a/internal/auditlog/middleware.go
+++ b/internal/auditlog/middleware.go
@@ -400,8 +400,30 @@ func EnrichEntry(c *echo.Context, model, provider string) {
 	publishLiveAuditUpdate(c, entry)
 }
 
+// EnrichEntryWithRequestedModel attaches early requested-model metadata to the
+// live audit entry before the final workflow policy has been resolved.
+func EnrichEntryWithRequestedModel(c *echo.Context, requestedModel string) {
+	entryVal := c.Get(string(LogEntryKey))
+	if entryVal == nil {
+		return
+	}
+
+	entry, ok := entryVal.(*LogEntry)
+	if !ok || entry == nil {
+		return
+	}
+
+	requestedModel = strings.TrimSpace(requestedModel)
+	if requestedModel == "" {
+		return
+	}
+
+	entry.RequestedModel = requestedModel
+	publishLiveAuditUpdate(c, entry)
+}
+
 // EnrichEntryWithWorkflow attaches workflow metadata to the live
-// audit entry. This is preferred over resolution-only enrichment once workflow
+// audit entry. This is preferred over requested-model-only enrichment once workflow
 // resolution has completed for the request.
 func EnrichEntryWithWorkflow(c *echo.Context, workflow *core.Workflow) {
 	entryVal := c.Get(string(LogEntryKey))

--- a/internal/auditlog/middleware.go
+++ b/internal/auditlog/middleware.go
@@ -80,6 +80,9 @@ func Middleware(logger LoggerInterface) echo.MiddlewareFunc {
 			if authHeader := req.Header.Get("Authorization"); authHeader != "" {
 				entry.Data.APIKeyHash = hashAPIKey(authHeader)
 			}
+			if cfg.LogHeaders {
+				PopulateRequestHeaders(entry, req.Header)
+			}
 
 			// Store entry in context for potential enrichment by handlers
 			c.Set(string(LogEntryKey), entry)
@@ -412,6 +415,7 @@ func EnrichEntryWithWorkflow(c *echo.Context, workflow *core.Workflow) {
 	}
 
 	enrichEntryWithWorkflow(entry, workflow)
+	populateLiveRequestDataAfterWorkflow(c, entry, workflow)
 	publishLiveAuditUpdate(c, entry)
 }
 
@@ -597,6 +601,21 @@ func publishLiveAuditUpdate(c *echo.Context, entry *LogEntry) {
 		return
 	}
 	publisher.PublishLiveEvent(LiveEventAuditUpdated, entry)
+}
+
+func populateLiveRequestDataAfterWorkflow(c *echo.Context, entry *LogEntry, workflow *core.Workflow) {
+	if c == nil || entry == nil || workflow == nil || !workflow.AuditEnabled() {
+		return
+	}
+	logger, ok := c.Get(string(LogEntryLivePublisherKey)).(LoggerInterface)
+	if !ok || logger == nil {
+		return
+	}
+	cfg := logger.Config()
+	if !cfg.Enabled || !cfg.LogBodies {
+		return
+	}
+	PopulateRequestData(entry, c.Request(), cfg)
 }
 
 func auditEnabledForContext(ctx context.Context) bool {

--- a/internal/auditlog/middleware.go
+++ b/internal/auditlog/middleware.go
@@ -426,6 +426,8 @@ func EnrichEntryWithRequestedModel(c *echo.Context, requestedModel string) {
 // audit entry. This is preferred over requested-model-only enrichment once workflow
 // resolution has completed for the request.
 func EnrichEntryWithWorkflow(c *echo.Context, workflow *core.Workflow) {
+	syncRequestWorkflow(c, workflow)
+
 	entryVal := c.Get(string(LogEntryKey))
 	if entryVal == nil {
 		return
@@ -439,6 +441,21 @@ func EnrichEntryWithWorkflow(c *echo.Context, workflow *core.Workflow) {
 	enrichEntryWithWorkflow(entry, workflow)
 	populateLiveRequestDataAfterWorkflow(c, entry, workflow)
 	publishLiveAuditUpdate(c, entry)
+}
+
+func syncRequestWorkflow(c *echo.Context, workflow *core.Workflow) {
+	if c == nil || workflow == nil {
+		return
+	}
+	req := c.Request()
+	if req == nil {
+		return
+	}
+	ctx := req.Context()
+	if core.GetWorkflow(ctx) == workflow {
+		return
+	}
+	c.SetRequest(req.WithContext(core.WithWorkflow(ctx, workflow)))
 }
 
 // EnrichLogEntryWithWorkflow attaches workflow metadata directly to

--- a/internal/auditlog/middleware_test.go
+++ b/internal/auditlog/middleware_test.go
@@ -179,8 +179,10 @@ func TestMiddlewareDoesNotPublishRequestBodyForAuditDisabledWorkflow(t *testing.
 				},
 			},
 		}
-		c.SetRequest(c.Request().WithContext(core.WithWorkflow(c.Request().Context(), workflow)))
 		EnrichEntryWithWorkflow(c, workflow)
+		if got := core.GetWorkflow(c.Request().Context()); got != workflow {
+			t.Fatal("request context workflow was not synchronized")
+		}
 		if len(logger.events) != 2 {
 			t.Fatalf("live events before handler completes = %d, want 2", len(logger.events))
 		}
@@ -190,8 +192,19 @@ func TestMiddlewareDoesNotPublishRequestBodyForAuditDisabledWorkflow(t *testing.
 	if err := handler(c); err != nil {
 		t.Fatalf("handler error: %v", err)
 	}
+	if len(logger.events) != 3 {
+		t.Fatalf("live events after handler completes = %d, want 3", len(logger.events))
+	}
 	if body := logger.events[1].requestBody; body != nil {
 		t.Fatalf("audit-disabled workflow request body = %#v, want nil", body)
+	}
+	if removed := logger.events[2]; removed.eventType != LiveEventAuditRemoved {
+		t.Fatalf("third event type = %q, want %q", removed.eventType, LiveEventAuditRemoved)
+	} else if removed.requestBody != nil {
+		t.Fatalf("audit removed request body = %#v, want nil", removed.requestBody)
+	}
+	if logger.writes != 0 {
+		t.Fatalf("audit writes = %d, want 0", logger.writes)
 	}
 }
 
@@ -204,9 +217,12 @@ type capturedLiveEvent struct {
 type captureLiveLogger struct {
 	cfg    Config
 	events []capturedLiveEvent
+	writes int
 }
 
-func (l *captureLiveLogger) Write(_ *LogEntry) {}
+func (l *captureLiveLogger) Write(_ *LogEntry) {
+	l.writes++
+}
 
 func (l *captureLiveLogger) Config() Config {
 	return l.cfg

--- a/internal/auditlog/middleware_test.go
+++ b/internal/auditlog/middleware_test.go
@@ -112,7 +112,14 @@ func TestMiddlewarePublishesWorkflowUpdateWithCapturedRequestBody(t *testing.T) 
 	c := e.NewContext(req, rec)
 
 	handler := Middleware(logger)(func(c *echo.Context) error {
-		EnrichEntryWithWorkflow(c, &core.Workflow{})
+		EnrichEntryWithWorkflow(c, &core.Workflow{
+			Policy: &core.ResolvedWorkflowPolicy{
+				VersionID: "audit-enabled",
+				Features: core.WorkflowFeatures{
+					Audit: true,
+				},
+			},
+		})
 		if len(logger.events) != 2 {
 			t.Fatalf("live events before handler completes = %d, want 2", len(logger.events))
 		}

--- a/internal/auditlog/middleware_test.go
+++ b/internal/auditlog/middleware_test.go
@@ -3,6 +3,7 @@ package auditlog
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/labstack/echo/v5"
@@ -39,4 +40,190 @@ func TestEnrichEntryWithWorkflow_PrefersProviderNameForResolvedModel(t *testing.
 	if got := entry.ResolvedModel; got != "openai_test/gpt-5-nano" {
 		t.Fatalf("ResolvedModel = %q, want %q", got, "openai_test/gpt-5-nano")
 	}
+}
+
+func TestMiddlewarePublishesStartedEventWithRedactedRequestHeaders(t *testing.T) {
+	logger := &captureLiveLogger{
+		cfg: Config{
+			Enabled:    true,
+			LogHeaders: true,
+		},
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("X-Request-ID", "req-started")
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("X-Test", "visible")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	handler := Middleware(logger)(func(c *echo.Context) error {
+		if len(logger.events) != 1 {
+			t.Fatalf("live events before handler = %d, want 1", len(logger.events))
+		}
+		return nil
+	})
+
+	if err := handler(c); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if len(logger.events) == 0 {
+		t.Fatal("no live events were published")
+	}
+
+	started := logger.events[0]
+	if started.eventType != LiveEventAuditStarted {
+		t.Fatalf("first event type = %q, want %q", started.eventType, LiveEventAuditStarted)
+	}
+	if got := started.requestHeaders["Authorization"]; got != "[REDACTED]" {
+		t.Fatalf("Authorization header = %q, want [REDACTED]", got)
+	}
+	if got := started.requestHeaders["X-Test"]; got != "visible" {
+		t.Fatalf("X-Test header = %q, want visible", got)
+	}
+}
+
+func TestMiddlewarePublishesWorkflowUpdateWithCapturedRequestBody(t *testing.T) {
+	logger := &captureLiveLogger{
+		cfg: Config{
+			Enabled:   true,
+			LogBodies: true,
+		},
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	trackedBody := &readCountCloser{reader: strings.NewReader(`{"model":"from-stream"}`)}
+	req.Body = trackedBody
+	req = req.WithContext(core.WithRequestSnapshot(req.Context(), core.NewRequestSnapshot(
+		http.MethodPost,
+		"/v1/chat/completions",
+		nil,
+		nil,
+		nil,
+		"application/json",
+		[]byte(`{"model":"from-snapshot"}`),
+		false,
+		"req-body",
+		nil,
+	)))
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	handler := Middleware(logger)(func(c *echo.Context) error {
+		EnrichEntryWithWorkflow(c, &core.Workflow{})
+		if len(logger.events) != 2 {
+			t.Fatalf("live events before handler completes = %d, want 2", len(logger.events))
+		}
+		return nil
+	})
+
+	if err := handler(c); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if trackedBody.readCalls != 0 {
+		t.Fatalf("request body was read %d times, want 0", trackedBody.readCalls)
+	}
+	updated := logger.events[1]
+	if updated.eventType != LiveEventAuditUpdated {
+		t.Fatalf("second event type = %q, want %q", updated.eventType, LiveEventAuditUpdated)
+	}
+	body, ok := updated.requestBody.(map[string]any)
+	if !ok {
+		t.Fatalf("request body = %T, want map[string]any", updated.requestBody)
+	}
+	if got := body["model"]; got != "from-snapshot" {
+		t.Fatalf("request body model = %#v, want from-snapshot", got)
+	}
+}
+
+func TestMiddlewareDoesNotPublishRequestBodyForAuditDisabledWorkflow(t *testing.T) {
+	logger := &captureLiveLogger{
+		cfg: Config{
+			Enabled:   true,
+			LogBodies: true,
+		},
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req = req.WithContext(core.WithRequestSnapshot(req.Context(), core.NewRequestSnapshot(
+		http.MethodPost,
+		"/v1/chat/completions",
+		nil,
+		nil,
+		nil,
+		"application/json",
+		[]byte(`{"model":"hidden"}`),
+		false,
+		"req-hidden",
+		nil,
+	)))
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	handler := Middleware(logger)(func(c *echo.Context) error {
+		workflow := &core.Workflow{
+			Policy: &core.ResolvedWorkflowPolicy{
+				VersionID: "audit-disabled",
+				Features: core.WorkflowFeatures{
+					Audit: false,
+				},
+			},
+		}
+		c.SetRequest(c.Request().WithContext(core.WithWorkflow(c.Request().Context(), workflow)))
+		EnrichEntryWithWorkflow(c, workflow)
+		if len(logger.events) != 2 {
+			t.Fatalf("live events before handler completes = %d, want 2", len(logger.events))
+		}
+		return nil
+	})
+
+	if err := handler(c); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if body := logger.events[1].requestBody; body != nil {
+		t.Fatalf("audit-disabled workflow request body = %#v, want nil", body)
+	}
+}
+
+type capturedLiveEvent struct {
+	eventType      string
+	requestHeaders map[string]string
+	requestBody    any
+}
+
+type captureLiveLogger struct {
+	cfg    Config
+	events []capturedLiveEvent
+}
+
+func (l *captureLiveLogger) Write(_ *LogEntry) {}
+
+func (l *captureLiveLogger) Config() Config {
+	return l.cfg
+}
+
+func (l *captureLiveLogger) Close() error {
+	return nil
+}
+
+func (l *captureLiveLogger) PublishLiveEvent(eventType string, entry *LogEntry) {
+	headers := map[string]string(nil)
+	if entry != nil && entry.Data != nil && entry.Data.RequestHeaders != nil {
+		headers = make(map[string]string, len(entry.Data.RequestHeaders))
+		for key, value := range entry.Data.RequestHeaders {
+			headers[key] = value
+		}
+	}
+	var requestBody any
+	if entry != nil && entry.Data != nil {
+		requestBody = entry.Data.RequestBody
+	}
+	l.events = append(l.events, capturedLiveEvent{
+		eventType:      eventType,
+		requestHeaders: headers,
+		requestBody:    requestBody,
+	})
 }

--- a/internal/live/broker.go
+++ b/internal/live/broker.go
@@ -423,7 +423,29 @@ func mergeEventData(base, patch json.RawMessage) json.RawMessage {
 		return append(json.RawMessage(nil), patch...)
 	}
 	for key, value := range patchObject {
-		baseObject[key] = value
+		baseObject[key] = mergeEventDataValue(baseObject[key], value)
+	}
+	merged, err := json.Marshal(baseObject)
+	if err != nil {
+		return append(json.RawMessage(nil), patch...)
+	}
+	return merged
+}
+
+func mergeEventDataValue(base, patch json.RawMessage) json.RawMessage {
+	if len(base) == 0 || len(patch) == 0 {
+		return append(json.RawMessage(nil), patch...)
+	}
+	var baseObject map[string]json.RawMessage
+	var patchObject map[string]json.RawMessage
+	if err := json.Unmarshal(base, &baseObject); err != nil || baseObject == nil {
+		return append(json.RawMessage(nil), patch...)
+	}
+	if err := json.Unmarshal(patch, &patchObject); err != nil || patchObject == nil {
+		return append(json.RawMessage(nil), patch...)
+	}
+	for key, value := range patchObject {
+		baseObject[key] = mergeEventDataValue(baseObject[key], value)
 	}
 	merged, err := json.Marshal(baseObject)
 	if err != nil {
@@ -533,6 +555,15 @@ func auditPreviewFromEntry(eventType string, entry *auditlog.LogEntry) auditPrev
 			WorkflowFeatures: entry.Data.WorkflowFeatures,
 			Failover:         entry.Data.Failover,
 		}
+		if auditPreviewIncludesLiveRequestMetadata(eventType) {
+			data.UserAgent = entry.Data.UserAgent
+			data.APIKeyHash = entry.Data.APIKeyHash
+			data.RequestHeaders = entry.Data.RequestHeaders
+		}
+		if auditPreviewIncludesLiveRequestBody(eventType) {
+			data.RequestBody = entry.Data.RequestBody
+			data.RequestBodyTooBigToHandle = entry.Data.RequestBodyTooBigToHandle
+		}
 		if auditPreviewIncludesCapturedData(eventType) {
 			data.UserAgent = entry.Data.UserAgent
 			data.APIKeyHash = entry.Data.APIKeyHash
@@ -552,6 +583,14 @@ func auditPreviewFromEntry(eventType string, entry *auditlog.LogEntry) auditPrev
 		}
 	}
 	return preview
+}
+
+func auditPreviewIncludesLiveRequestMetadata(eventType string) bool {
+	return eventType == EventAuditStarted || eventType == EventAuditUpdated
+}
+
+func auditPreviewIncludesLiveRequestBody(eventType string) bool {
+	return eventType == EventAuditUpdated
 }
 
 func auditPreviewIncludesCapturedData(eventType string) bool {

--- a/internal/live/broker_test.go
+++ b/internal/live/broker_test.go
@@ -438,7 +438,95 @@ func TestBrokerCloseStopsSubscribersAndRejectsNewSubscriptions(t *testing.T) {
 	b.Close()
 }
 
-func TestBrokerAuditUpdatedPreviewOmitsCapturedDetailData(t *testing.T) {
+func TestBrokerAuditStartedPreviewIncludesRequestHeadersOnly(t *testing.T) {
+	b := NewBroker(Config{Enabled: true})
+	b.PublishAuditEvent(EventAuditStarted, &auditlog.LogEntry{
+		ID:        "audit-1",
+		RequestID: "req-1",
+		Timestamp: time.Now(),
+		Data: &auditlog.LogData{
+			UserAgent:       "test-agent",
+			APIKeyHash:      "hash123",
+			RequestHeaders:  map[string]string{"Authorization": "[REDACTED]", "Content-Type": "application/json"},
+			ResponseHeaders: map[string]string{"X-Request-ID": "req-1"},
+			RequestBody:     map[string]any{"model": "gpt-test"},
+			ResponseBody:    map[string]any{"id": "chatcmpl-test"},
+		},
+	})
+
+	payload := eventPayload(t, b.events[0])
+	data, ok := payload["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("preview data = %T, want object", payload["data"])
+	}
+	headers, ok := data["request_headers"].(map[string]any)
+	if !ok {
+		t.Fatalf("request_headers = %T, want object", data["request_headers"])
+	}
+	if got := headers["Authorization"]; got != "[REDACTED]" {
+		t.Fatalf("request_headers[Authorization] = %v, want [REDACTED]", got)
+	}
+	if got := data["user_agent"]; got != "test-agent" {
+		t.Fatalf("user_agent = %v, want test-agent", got)
+	}
+	if got := data["api_key_hash"]; got != "hash123" {
+		t.Fatalf("api_key_hash = %v, want hash123", got)
+	}
+	if _, ok := data["request_body"]; ok {
+		t.Fatal("started preview data contains request body")
+	}
+	if _, ok := data["response_headers"]; ok {
+		t.Fatal("started preview data contains response headers")
+	}
+	if _, ok := data["response_body"]; ok {
+		t.Fatal("started preview data contains response body")
+	}
+}
+
+func TestBrokerAuditActiveSnapshotMergesNestedPreviewData(t *testing.T) {
+	b := NewBroker(Config{Enabled: true, BufferSize: 1, ReplayLimit: 1})
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+
+	b.PublishAuditEvent(EventAuditStarted, &auditlog.LogEntry{
+		ID:        "audit-1",
+		RequestID: "req-1",
+		Timestamp: now,
+		Data: &auditlog.LogData{
+			RequestHeaders: map[string]string{"Authorization": "[REDACTED]"},
+		},
+	})
+	b.PublishAuditEvent(EventAuditUpdated, &auditlog.LogEntry{
+		ID:        "audit-1",
+		RequestID: "req-1",
+		Timestamp: now.Add(time.Second),
+		Data: &auditlog.LogData{
+			WorkflowFeatures: &auditlog.WorkflowFeaturesSnapshot{Audit: true, Usage: true},
+		},
+	})
+
+	sub := b.Subscribe(0)
+	if sub == nil {
+		t.Fatal("Subscribe returned nil")
+	}
+	defer sub.Close()
+	if len(sub.Replay) != 1 {
+		t.Fatalf("replay len = %d, want 1", len(sub.Replay))
+	}
+
+	payload := eventPayload(t, sub.Replay[0])
+	data, ok := payload["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("preview data = %T, want object", payload["data"])
+	}
+	if headers, ok := data["request_headers"].(map[string]any); !ok || headers["Authorization"] != "[REDACTED]" {
+		t.Fatalf("request_headers = %#v, want redacted authorization", data["request_headers"])
+	}
+	if features, ok := data["workflow_features"].(map[string]any); !ok || features["audit"] != true || features["usage"] != true {
+		t.Fatalf("workflow_features = %#v, want audit and usage flags", data["workflow_features"])
+	}
+}
+
+func TestBrokerAuditUpdatedPreviewIncludesRequestBodyOnly(t *testing.T) {
 	b := NewBroker(Config{Enabled: true})
 	b.PublishAuditEvent(EventAuditUpdated, &auditlog.LogEntry{
 		ID:         "audit-1",
@@ -446,7 +534,10 @@ func TestBrokerAuditUpdatedPreviewOmitsCapturedDetailData(t *testing.T) {
 		Timestamp:  time.Now(),
 		StatusCode: 200,
 		Data: &auditlog.LogData{
-			RequestBody: map[string]any{"secret": "large body"},
+			RequestHeaders:  map[string]string{"Authorization": "[REDACTED]"},
+			RequestBody:     map[string]any{"model": "gpt-test"},
+			ResponseHeaders: map[string]string{"X-Request-ID": "req-1"},
+			ResponseBody:    map[string]any{"id": "chatcmpl-test"},
 		},
 	})
 	sub := b.Subscribe(0)
@@ -459,11 +550,18 @@ func TestBrokerAuditUpdatedPreviewOmitsCapturedDetailData(t *testing.T) {
 	if err := json.Unmarshal(b.events[0].Data, &payload); err != nil {
 		t.Fatalf("unmarshal preview: %v", err)
 	}
-	if _, ok := payload["data"]; ok {
-		t.Fatal("preview payload contains advanced data")
+	data, ok := payload["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("preview data = %T, want object", payload["data"])
 	}
-	if _, ok := payload["request_body"]; ok {
-		t.Fatal("preview payload contains request body")
+	if body, ok := data["request_body"].(map[string]any); !ok || body["model"] != "gpt-test" {
+		t.Fatalf("request_body = %#v, want model", data["request_body"])
+	}
+	if _, ok := data["response_headers"]; ok {
+		t.Fatal("updated preview data contains response headers")
+	}
+	if _, ok := data["response_body"]; ok {
+		t.Fatal("updated preview data contains response body")
 	}
 }
 
@@ -527,8 +625,7 @@ func TestBrokerAuditPreviewIncludesCompactWorkflowData(t *testing.T) {
 				Usage:    true,
 				Fallback: true,
 			},
-			Failover:    &auditlog.FailoverSnapshot{TargetModel: "fallback-model"},
-			RequestBody: map[string]any{"messages": []any{"sensitive"}},
+			Failover: &auditlog.FailoverSnapshot{TargetModel: "fallback-model"},
 		},
 	})
 
@@ -536,9 +633,6 @@ func TestBrokerAuditPreviewIncludesCompactWorkflowData(t *testing.T) {
 	data, ok := payload["data"].(map[string]any)
 	if !ok {
 		t.Fatalf("preview data = %T, want object", payload["data"])
-	}
-	if _, ok := data["request_body"]; ok {
-		t.Fatal("preview data contains request body")
 	}
 	features, ok := data["workflow_features"].(map[string]any)
 	if !ok {

--- a/internal/server/model_validation.go
+++ b/internal/server/model_validation.go
@@ -136,9 +136,9 @@ func storeWorkflow(c *echo.Context, workflow *core.Workflow) {
 	if c == nil || workflow == nil {
 		return
 	}
-	auditlog.EnrichEntryWithWorkflow(c, workflow)
 	ctx := core.WithWorkflow(c.Request().Context(), workflow)
 	c.SetRequest(c.Request().WithContext(ctx))
+	auditlog.EnrichEntryWithWorkflow(c, workflow)
 }
 
 func selectorHintsForValidation(c *echo.Context) (model, provider string, parsed bool, err error) {

--- a/internal/server/request_model_resolution.go
+++ b/internal/server/request_model_resolution.go
@@ -108,13 +108,13 @@ func enrichAuditEntryWithRequestedModel(c *echo.Context, requested core.Requeste
 	if requested.Model == "" {
 		return
 	}
-	workflow := &core.Workflow{}
 	if existing := core.GetWorkflow(c.Request().Context()); existing != nil {
 		cloned := *existing
-		workflow = &cloned
+		cloned.Resolution = &core.RequestModelResolution{
+			Requested: requested,
+		}
+		auditlog.EnrichEntryWithWorkflow(c, &cloned)
+		return
 	}
-	workflow.Resolution = &core.RequestModelResolution{
-		Requested: requested,
-	}
-	auditlog.EnrichEntryWithWorkflow(c, workflow)
+	auditlog.EnrichEntryWithRequestedModel(c, requested.RequestedQualifiedModel())
 }

--- a/internal/server/request_model_resolution.go
+++ b/internal/server/request_model_resolution.go
@@ -46,14 +46,14 @@ func storeRequestModelResolution(c *echo.Context, resolution *core.RequestModelR
 		cloned := *workflow
 		cloned.ProviderType = resolution.ProviderType
 		cloned.Resolution = resolution
-		auditlog.EnrichEntryWithWorkflow(c, &cloned)
 		ctx = core.WithWorkflow(ctx, &cloned)
+		c.SetRequest(c.Request().WithContext(ctx))
+		auditlog.EnrichEntryWithWorkflow(c, &cloned)
 	}
 	if env := core.GetWhiteBoxPrompt(ctx); env != nil {
 		env.RouteHints.Model = resolution.ResolvedSelector.Model
 		env.RouteHints.Provider = resolution.ResolvedSelector.Provider
 	}
-	c.SetRequest(c.Request().WithContext(ctx))
 }
 
 func ensureRequestModelResolution(c *echo.Context, provider core.RoutableProvider, resolver RequestModelResolver) (*core.RequestModelResolution, bool, error) {

--- a/internal/server/request_model_resolution_test.go
+++ b/internal/server/request_model_resolution_test.go
@@ -3,9 +3,14 @@ package server
 import (
 	"context"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/labstack/echo/v5"
+
+	"gomodel/internal/auditlog"
 	"gomodel/internal/core"
 )
 
@@ -168,4 +173,110 @@ func TestResolveRequestModel_CanonicalizesAliasOutputThroughProviderResolver(t *
 	if got := resolution.ProviderName; got != "openai_test" {
 		t.Fatalf("ProviderName = %q, want %q", got, "openai_test")
 	}
+}
+
+func TestEnrichAuditEntryWithRequestedModelDoesNotPublishBodyBeforePolicy(t *testing.T) {
+	logger := &requestModelLiveLogger{
+		cfg: auditlog.Config{
+			Enabled:   true,
+			LogBodies: true,
+		},
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req = req.WithContext(core.WithRequestSnapshot(req.Context(), core.NewRequestSnapshot(
+		http.MethodPost,
+		"/v1/chat/completions",
+		nil,
+		nil,
+		nil,
+		"application/json",
+		[]byte(`{"model":"hidden"}`),
+		false,
+		"req-hidden",
+		nil,
+	)))
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	handler := auditlog.Middleware(logger)(func(c *echo.Context) error {
+		enrichAuditEntryWithRequestedModel(c, core.NewRequestedModelSelector("gpt-test", ""))
+		if len(logger.events) != 2 {
+			t.Fatalf("live events before policy resolution = %d, want 2", len(logger.events))
+		}
+		updated := logger.events[1]
+		if updated.eventType != auditlog.LiveEventAuditUpdated {
+			t.Fatalf("second event type = %q, want %q", updated.eventType, auditlog.LiveEventAuditUpdated)
+		}
+		if updated.requestedModel != "gpt-test" {
+			t.Fatalf("requested model = %q, want gpt-test", updated.requestedModel)
+		}
+		if updated.requestBody != nil {
+			t.Fatalf("request body before policy resolution = %#v, want nil", updated.requestBody)
+		}
+
+		workflow := &core.Workflow{
+			Policy: &core.ResolvedWorkflowPolicy{
+				VersionID: "audit-disabled",
+				Features: core.WorkflowFeatures{
+					Audit: false,
+				},
+			},
+		}
+		c.SetRequest(c.Request().WithContext(core.WithWorkflow(c.Request().Context(), workflow)))
+		return nil
+	})
+
+	if err := handler(c); err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if len(logger.events) != 3 {
+		t.Fatalf("live events after audit removal = %d, want 3", len(logger.events))
+	}
+	removed := logger.events[2]
+	if removed.eventType != auditlog.LiveEventAuditRemoved {
+		t.Fatalf("third event type = %q, want %q", removed.eventType, auditlog.LiveEventAuditRemoved)
+	}
+	if removed.requestBody != nil {
+		t.Fatalf("removed event request body = %#v, want nil", removed.requestBody)
+	}
+	if logger.writes != 0 {
+		t.Fatalf("audit writes = %d, want 0", logger.writes)
+	}
+}
+
+type requestModelLiveEvent struct {
+	eventType      string
+	requestedModel string
+	requestBody    any
+}
+
+type requestModelLiveLogger struct {
+	cfg    auditlog.Config
+	events []requestModelLiveEvent
+	writes int
+}
+
+func (l *requestModelLiveLogger) Write(_ *auditlog.LogEntry) {
+	l.writes++
+}
+
+func (l *requestModelLiveLogger) Config() auditlog.Config {
+	return l.cfg
+}
+
+func (l *requestModelLiveLogger) Close() error {
+	return nil
+}
+
+func (l *requestModelLiveLogger) PublishLiveEvent(eventType string, entry *auditlog.LogEntry) {
+	event := requestModelLiveEvent{eventType: eventType}
+	if entry != nil {
+		event.requestedModel = entry.RequestedModel
+		if entry.Data != nil {
+			event.requestBody = entry.Data.RequestBody
+		}
+	}
+	l.events = append(l.events, event)
 }


### PR DESCRIPTION
## Summary
- publish redacted request headers in the initial live audit preview
- publish already-captured request bodies on the post-workflow audit update
- preserve nested live preview data across audit lifecycle updates

## Testing
- go test ./...
- node --test internal/admin/dashboard/static/js/modules/live-logs.test.cjs internal/admin/dashboard/static/js/modules/audit-list.test.cjs
- go test ./tests/perf -run '^$' -bench 'Benchmark.*Audit|Benchmark.*Hot' -benchtime=100ms\n- pre-commit hook: make test-race, go mod tidy, hot-path performance guard, make lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Request headers are now captured with Authorization redacted; request bodies are captured reliably when enabled.

* **New Features**
  * Live audit previews merge nested preview data and selectively include request metadata/body for started vs. updated events.
  * Middleware now publishes requested-model metadata earlier to support live updates.
  * UI defers detail fetches while live rows are pending.

* **Tests**
  * Added tests for header redaction, captured-body timing, preview merging, and live-row fetch behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ENTERPILOT/GoModel/pull/339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->