### PR TITLE
fix(gemini): send tool schemas as JSON schema

### DIFF
--- a/internal/providers/gemini/native.go
+++ b/internal/providers/gemini/native.go
@@ -76,9 +76,10 @@ type geminiTool struct {
 }
 
 type geminiFunctionDeclaration struct {
-	Name        string          `json:"name,omitempty"`
-	Description string          `json:"description,omitempty"`
-	Parameters  json.RawMessage `json:"parameters,omitempty"`
+	Name                 string          `json:"name,omitempty"`
+	Description          string          `json:"description,omitempty"`
+	Parameters           json.RawMessage `json:"parameters,omitempty"`
+	ParametersJSONSchema json.RawMessage `json:"parametersJsonSchema,omitempty"`
 }
 
 type geminiToolConfig struct {
@@ -358,24 +359,77 @@ func geminiToolsFromOpenAI(tools []map[string]any) ([]geminiTool, error) {
 			continue
 		}
 		description, _ := fn["description"].(string)
-		var parameters json.RawMessage
+		var parametersJSONSchema json.RawMessage
 		if raw, ok := fn["parameters"]; ok {
-			encoded, err := json.Marshal(raw)
+			encoded, err := geminiParametersJSONSchema(raw)
 			if err != nil {
-				return nil, core.NewInvalidRequestError("failed to marshal Gemini tool parameters", err)
+				return nil, err
 			}
-			parameters = encoded
+			parametersJSONSchema = encoded
 		}
 		declarations = append(declarations, geminiFunctionDeclaration{
-			Name:        name,
-			Description: description,
-			Parameters:  parameters,
+			Name:                 name,
+			Description:          description,
+			ParametersJSONSchema: parametersJSONSchema,
 		})
 	}
 	if len(declarations) == 0 {
 		return nil, nil
 	}
 	return []geminiTool{{FunctionDeclarations: declarations}}, nil
+}
+
+func geminiParametersJSONSchema(raw any) (json.RawMessage, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return nil, core.NewInvalidRequestError("failed to marshal Gemini tool parameters", err)
+	}
+	if bytes.Equal(encoded, []byte("null")) {
+		return nil, nil
+	}
+	stripped, err := validateGeminiParametersJSONSchema(encoded)
+	if err != nil {
+		return nil, err
+	}
+	return stripped, nil
+}
+
+func validateGeminiParametersJSONSchema(encoded json.RawMessage) (json.RawMessage, error) {
+	var schema map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &schema); err != nil {
+		return nil, core.NewInvalidRequestError("tool.function.parameters must be an object", nil)
+	}
+	if schema == nil {
+		return nil, core.NewInvalidRequestError("tool.function.parameters must be an object", nil)
+	}
+	addedType := false
+	if rawType, ok := schema["type"]; ok {
+		if bytes.Equal(rawType, []byte("null")) {
+			return nil, core.NewInvalidRequestError("tool.function.parameters must define an object schema", nil)
+		}
+		var schemaType string
+		if err := json.Unmarshal(rawType, &schemaType); err != nil {
+			return nil, core.NewInvalidRequestError("tool.function.parameters must define an object schema", nil)
+		}
+		if schemaType == "" || schemaType != "object" {
+			return nil, core.NewInvalidRequestError("tool.function.parameters must define an object schema", nil)
+		}
+	} else {
+		schema["type"] = json.RawMessage(`"object"`)
+		addedType = true
+	}
+	if _, ok := schema["$schema"]; !ok && !addedType {
+		return encoded, nil
+	}
+	delete(schema, "$schema")
+	stripped, err := json.Marshal(schema)
+	if err != nil {
+		return nil, core.NewInvalidRequestError("failed to marshal Gemini tool parameters", err)
+	}
+	return stripped, nil
 }
 
 func geminiToolConfigFromOpenAI(choice any) *geminiToolConfig {

--- a/internal/providers/gemini/native_schema_test.go
+++ b/internal/providers/gemini/native_schema_test.go
@@ -1,0 +1,157 @@
+package gemini
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestGeminiToolsFromOpenAIUsesParametersJSONSchema(t *testing.T) {
+	parameters := map[string]any{
+		"$schema":              "https://json-schema.org/draft/2020-12/schema",
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"city": map[string]any{"type": "string"},
+			"labels": map[string]any{
+				"type": "object",
+				"additionalProperties": map[string]any{
+					"type": "string",
+				},
+			},
+		},
+		"required": []any{"city"},
+	}
+
+	tools, err := geminiToolsFromOpenAI([]map[string]any{{
+		"type": "function",
+		"function": map[string]any{
+			"name":        "lookup_weather",
+			"description": "Look up weather",
+			"parameters":  parameters,
+		},
+	}})
+	if err != nil {
+		t.Fatalf("geminiToolsFromOpenAI() error = %v", err)
+	}
+	if len(tools) != 1 || len(tools[0].FunctionDeclarations) != 1 {
+		t.Fatalf("tools = %#v, want one function declaration", tools)
+	}
+
+	declaration := tools[0].FunctionDeclarations[0]
+	if len(declaration.Parameters) != 0 {
+		t.Fatalf("parameters = %s, want omitted when parametersJsonSchema is used", declaration.Parameters)
+	}
+	if len(declaration.ParametersJSONSchema) == 0 {
+		t.Fatal("parametersJsonSchema is empty")
+	}
+	if _, ok := parameters["$schema"]; !ok {
+		t.Fatal("input parameters were mutated")
+	}
+
+	var schema map[string]any
+	if err := json.Unmarshal(declaration.ParametersJSONSchema, &schema); err != nil {
+		t.Fatalf("failed to unmarshal parametersJsonSchema: %v", err)
+	}
+	if _, ok := schema["$schema"]; ok {
+		t.Fatalf("parametersJsonSchema = %s, want $schema stripped", declaration.ParametersJSONSchema)
+	}
+	if got := schema["additionalProperties"]; got != false {
+		t.Fatalf("additionalProperties = %#v, want false", got)
+	}
+
+	properties := schema["properties"].(map[string]any)
+	labels := properties["labels"].(map[string]any)
+	additionalProperties := labels["additionalProperties"].(map[string]any)
+	if got := additionalProperties["type"]; got != "string" {
+		t.Fatalf("nested additionalProperties.type = %#v, want string", got)
+	}
+}
+
+func TestGeminiToolsFromOpenAINormalizesMissingObjectType(t *testing.T) {
+	tools, err := geminiToolsFromOpenAI([]map[string]any{{
+		"type": "function",
+		"function": map[string]any{
+			"name": "lookup_weather",
+			"parameters": map[string]any{
+				"properties": map[string]any{
+					"city": map[string]any{"type": "string"},
+				},
+				"required": []any{"city"},
+			},
+		},
+	}})
+	if err != nil {
+		t.Fatalf("geminiToolsFromOpenAI() error = %v", err)
+	}
+
+	var schema map[string]any
+	if err := json.Unmarshal(tools[0].FunctionDeclarations[0].ParametersJSONSchema, &schema); err != nil {
+		t.Fatalf("failed to unmarshal parametersJsonSchema: %v", err)
+	}
+	if got := schema["type"]; got != "object" {
+		t.Fatalf("type = %#v, want object", got)
+	}
+}
+
+func TestGeminiToolsFromOpenAIRejectsInvalidParameterSchemas(t *testing.T) {
+	tests := []struct {
+		name       string
+		parameters any
+		wantError  string
+	}{
+		{
+			name:       "array parameters",
+			parameters: []any{"invalid"},
+			wantError:  "tool.function.parameters must be an object",
+		},
+		{
+			name:       "string parameters",
+			parameters: "invalid",
+			wantError:  "tool.function.parameters must be an object",
+		},
+		{
+			name:       "boolean parameters",
+			parameters: true,
+			wantError:  "tool.function.parameters must be an object",
+		},
+		{
+			name:       "non object schema type",
+			parameters: map[string]any{"type": "array"},
+			wantError:  "tool.function.parameters must define an object schema",
+		},
+		{
+			name:       "null schema type",
+			parameters: map[string]any{"type": nil},
+			wantError:  "tool.function.parameters must define an object schema",
+		},
+		{
+			name:       "empty schema type",
+			parameters: map[string]any{"type": ""},
+			wantError:  "tool.function.parameters must define an object schema",
+		},
+		{
+			name:       "ambiguous schema type",
+			parameters: map[string]any{"type": []any{"object", "null"}},
+			wantError:  "tool.function.parameters must define an object schema",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := geminiToolsFromOpenAI([]map[string]any{{
+				"type": "function",
+				"function": map[string]any{
+					"name":       "lookup_weather",
+					"parameters": tt.parameters,
+				},
+			}})
+			if err == nil {
+				t.Fatal("geminiToolsFromOpenAI() error = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("error = %q, want to contain %q", err.Error(), tt.wantError)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Send Gemini native tool schemas via `parametersJsonSchema` instead of the stricter `parameters` field.
- Strip the root JSON Schema `$schema` dialect marker while preserving `additionalProperties` constraints.
- Add focused coverage for n8n-style tool schemas with root and nested `additionalProperties`.

## Verification
- `go test ./...`
- Commit hooks passed: `make test-race`, `go mod tidy`, hot-path performance guard, `make lint`
- Live Gemini native verification with `PORT=19080 make run` and curl calls against `/v1/chat/completions`:
  - simple `gemini/gemini-2.5-flash` chat returned HTTP 200
  - tool schema with root `$schema` and `additionalProperties: false` returned HTTP 200 and a tool call
  - tool schema with nested `additionalProperties: {"type":"string"}` returned HTTP 200 and a tool call


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Gemini provider now transmits tool/function parameter schemas in the standardized JSON Schema field, normalizes missing types to object, strips top-level metadata, preserves nested constraints, and avoids mutating input schemas.

* **Tests**
  * Added tests covering schema conversion, normalization of absent/null inputs, preservation of nested rules, stripping of top-level metadata, and rejection of invalid parameter schemas with clear errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ENTERPILOT/GoModel/pull/340?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->