### PR TITLE
feat(server): add Anthropic Messages API ingress endpoint

### DIFF
--- a/docs/adr/0007-anthropic-messages-ingress.md
+++ b/docs/adr/0007-anthropic-messages-ingress.md
@@ -116,8 +116,14 @@ end to end, including request-validation and upstream errors.
   benefits are not preserved when translating through `core.ChatRequest`.
 - **Extended-thinking signatures and `thinking` blocks on input messages** — dropped; the
   canonical chat type has no first-class field for them.
-- **Server/built-in tools** (web search, code execution, etc.) — only custom tools
-  (`name` + `input_schema`) translate; server tools are not supported.
+- **Server/built-in tools** (web search, code execution, etc.) — a `tools[]` entry
+  with a versioned `type` (e.g. `web_search_20250305`) is **rejected with a clear
+  `400`** rather than mistranslated into a phantom custom function the gateway cannot
+  execute. Only custom tools (`type` absent or `"custom"`) translate.
+- **`top_k`** — dropped. It is not a valid OpenAI Chat Completions parameter, and the
+  OpenAI-family providers forward request fields verbatim and reject unknown ones with
+  a `400`; carrying it would make any `top_k` request fail when routed to those
+  providers. `temperature` and `top_p` are portable and are carried.
 - **`document` and other non-text/image content blocks** — these carry caller payload
   with no canonical chat equivalent, so they are rejected with a clear `400` error
   rather than silently dropped (which would make the model answer as if the attachment

--- a/docs/adr/0007-anthropic-messages-ingress.md
+++ b/docs/adr/0007-anthropic-messages-ingress.md
@@ -80,7 +80,7 @@ by the **actual** provider that served the request, so they work without changes
 
 For streaming, the observer ordering is the key decision:
 
-```
+```text
 provider chat SSE
   → ObservedSSEStream(audit + usage observers)   # observers see canonical OpenAI chat chunks
     → anthropicapi.StreamConverter               # outermost: chat SSE → Anthropic SSE

--- a/docs/adr/0007-anthropic-messages-ingress.md
+++ b/docs/adr/0007-anthropic-messages-ingress.md
@@ -1,0 +1,172 @@
+# ADR-0007: Anthropic Messages API Ingress
+
+## Status
+
+Accepted
+
+## Context
+
+GoModel exposes an OpenAI-compatible public API (`/v1/chat/completions`, `/v1/responses`,
+`/v1/embeddings`). A growing number of clients and SDKs speak the **Anthropic Messages API**
+dialect (`POST /v1/messages`) instead. Today those clients can only reach GoModel through the
+opaque passthrough route `/p/anthropic/v1/messages`, which:
+
+- forwards bytes verbatim to the Anthropic upstream only — it cannot route to OpenAI, Gemini,
+  Bedrock, or any other provider;
+- bypasses managed features: model aliases, workflow policy, budgets, failover, and the
+  exact/semantic response cache.
+
+We want a **managed** `/v1/messages` endpoint that accepts the Anthropic request dialect but
+can route to **any** configured provider, with the same cost tracking and audit logging as the
+OpenAI-compatible routes.
+
+The existing `/v1/responses` endpoint already solved the structurally identical problem — a
+non-chat-completions dialect that is translated into the canonical chat type and run through the
+shared pipeline. ADR-0002 (ingress frame and semantic envelope) established that dialect
+translation belongs at the ingress boundary.
+
+## Decision
+
+### Translate at the ingress boundary; keep the gateway canonical
+
+`POST /v1/messages` is implemented as a thin ingress dialect. The Anthropic request is
+translated **once, centrally** into the canonical `core.ChatRequest`, then run through the
+**unchanged** chat-completions pipeline (workflow resolution, model authorization, budgets,
+failover, response cache, provider dispatch). The provider's `core.ChatResponse` (or its
+OpenAI-style SSE stream) is translated back into the Anthropic Messages shape just before the
+response is written to the client.
+
+```mermaid
+flowchart TD
+  Req([POST /v1/messages])
+  Req --> decode[anthropicapi.ToChatRequest]
+  decode --> chat[*core.ChatRequest]
+  chat --> pipeline[chat-completions pipeline:\nworkflow, budgets, cache, failover]
+  pipeline --> provider[any provider .ChatCompletion / .StreamChatCompletion]
+  provider --> resp[*core.ChatResponse / OpenAI chat SSE]
+  resp --> encode[anthropicapi.FromChatResponse /\nanthropicapi.StreamConverter]
+  encode --> Out([Anthropic MessagesResponse / Anthropic SSE])
+```
+
+Because every provider already implements `ChatCompletion`/`StreamChatCompletion`, the endpoint
+works for **all providers** with no provider-specific code. There are **no changes** to
+`internal/gateway`, `internal/providers`, `internal/usage`, or `internal/auditlog`.
+
+### Package layout
+
+A new, isolated package `internal/anthropicapi` owns the dialect and depends only on
+`internal/core`. It deliberately does **not** depend on the `anthropic` *provider* package:
+provider egress (talking to the Anthropic upstream) and ingress dialect translation (accepting
+the Anthropic wire format from clients) are different concerns and translate in opposite
+directions.
+
+| File | Responsibility |
+| ---- | -------------- |
+| `types.go`    | Anthropic Messages wire DTOs (request, response, content blocks, SSE events, error) |
+| `request.go`  | `DecodeMessagesRequest`, `ToChatRequest`, `EstimateInputTokens` |
+| `response.go` | `FromChatResponse` |
+| `stream.go`   | `StreamConverter` — wraps an OpenAI-style chat SSE stream, emits Anthropic SSE events |
+| `errors.go`   | `ErrorFromGateway` — `core.GatewayError` → Anthropic error envelope |
+
+The HTTP glue lives in `internal/server/messages_handler.go`; `POST /v1/messages` and
+`POST /v1/messages/count_tokens` are registered in `http.go` and classified in
+`core/endpoints.go` (Dialect `anthropic`, Operation `chat_completions`).
+
+### Cost tracking and audit logging come for free
+
+Audit logging is an HTTP middleware that wraps every route, so `/v1/messages` is audited
+automatically. Usage and cost are extracted from the canonical `core.ChatResponse` and priced
+by the **actual** provider that served the request, so they work without changes.
+
+For streaming, the observer ordering is the key decision:
+
+```
+provider chat SSE
+  → ObservedSSEStream(audit + usage observers)   # observers see canonical OpenAI chat chunks
+    → anthropicapi.StreamConverter               # outermost: chat SSE → Anthropic SSE
+      → HTTP response
+```
+
+The audit and usage observers wrap the **inner** canonical stream — the format they already
+parse — and the Anthropic converter is the **outermost** layer applied last. This is the
+opposite ordering from `/v1/responses` (which wraps the converter first and required the audit
+observer to learn a Responses-specific code path); the inner-observer ordering means audit and
+usage need no Anthropic-specific knowledge. `stream_options.include_usage` is set on the
+translated request so the provider emits the final usage chunk.
+
+### count_tokens is a heuristic estimate
+
+`POST /v1/messages/count_tokens` returns `{"input_tokens": N}` using a provider-agnostic
+character-based heuristic (`≈ characters / 4`) over all request text. No upstream provider has
+a portable cross-provider token-counting endpoint, and adding one would require a new provider
+interface method. The heuristic keeps the endpoint dependency-free, deterministic, and
+universal. It is an **approximation**, not a tokenizer-exact count — see Consequences.
+
+### Errors
+
+All `/v1/messages` and `/v1/messages/count_tokens` failures are returned in the Anthropic error
+envelope (`{"type": "error", "error": {"type": ..., "message": ...}}`), with `core.ErrorType`
+mapped to the nearest Anthropic error type. This keeps the endpoint faithfully Anthropic-compatible
+end to end, including request-validation and upstream errors.
+
+### What is explicitly not implemented (v1)
+
+- **`/v1/messages/batches`** (Messages Batches API) — deferred; batches has its own pipeline.
+- **`cache_control` breakpoints** — dropped during the canonical hop; prompt-caching cost
+  benefits are not preserved when translating through `core.ChatRequest`.
+- **Extended-thinking signatures and `thinking` blocks on input messages** — dropped; the
+  canonical chat type has no first-class field for them.
+- **Server/built-in tools** (web search, code execution, etc.) — only custom tools
+  (`name` + `input_schema`) translate; server tools are not supported.
+- **`document` and other non-text/image content blocks** — these carry caller payload
+  with no canonical chat equivalent, so they are rejected with a clear `400` error
+  rather than silently dropped (which would make the model answer as if the attachment
+  were never sent). `thinking`/`redacted_thinking` blocks are the exception: they are
+  assistant-side artifacts and are dropped silently.
+
+## Consequences
+
+### Positive
+
+- One managed Anthropic-dialect endpoint that routes to **every** configured provider.
+- Model aliases, workflow policy, budgets, failover, and the response cache apply unchanged.
+- Cost tracking and audit logging work with **zero** changes to `usage`/`auditlog`.
+- No changes to `gateway` or `providers`; ~5 small files plus thin HTTP glue.
+- Translation is centralized and dialect-isolated; a future dialect (e.g. Gemini-native
+  ingress) can follow the same shape.
+
+### Negative / Mitigations
+
+- **Lossy round-trip to the Anthropic provider.** A `/v1/messages` request routed *to* the
+  Anthropic provider is translated Anthropic → `core.ChatRequest` → Anthropic; provider-only
+  features (`cache_control`, thinking signatures, server tools) do not survive the canonical
+  hop. Mitigation: clients needing byte-exact Anthropic fidelity (including prompt-cache
+  breakpoints) can still use the `/p/anthropic/v1/messages` passthrough. A future optimization
+  could add an Anthropic → Anthropic fast path that skips the canonical hop.
+- **count_tokens is an estimate**, typically within ~10–25% of a tokenizer-exact count, and is
+  not model-specific. Mitigation: documented clearly; adequate for budgeting/UX sizing, not for
+  hard context-limit decisions.
+- **`stop_reason` fidelity for stop sequences.** `stop_sequences` are honored end to end (the
+  OpenAI `stop` field is mapped to Anthropic `stop_sequences`), but the canonical chat type has
+  no distinct "stop sequence" finish reason, so a stop-sequence-triggered completion is reported
+  as `stop_reason: "end_turn"` rather than `"stop_sequence"`. The output is truncated correctly;
+  only the reason label differs.
+- Anthropic-specific request features routed to non-Anthropic providers degrade gracefully
+  (dropped or approximated), consistent with Postel's law.
+- Streaming audit reconstructs the response body in OpenAI chat shape (the observer sees the
+  canonical inner stream), while non-streaming stores the Anthropic body. This streaming /
+  non-streaming asymmetry already exists for `/v1/responses` and is accepted.
+
+## Alternatives Considered
+
+- **Per-provider `Messages()` interface method** (mirroring `Responses()`) — rejected: it would
+  require touching every provider and a new `core.Provider` method, for no behavioral gain over
+  central translation. The Responses API needed per-provider hooks for native Responses
+  endpoints; the Messages dialect has no such requirement.
+- **Reusing the `anthropic` provider's wire types** (`anthropicRequest`, etc.) — rejected: they
+  are unexported and coupled to upstream egress. Ingress translation is a distinct layer; a
+  small amount of DTO duplication is cleaner than a cross-layer dependency.
+- **Anthropic → Anthropic passthrough fast path in v1** — deferred: correct, but adds a second
+  code path; the lossy round-trip is an acceptable, documented v1 tradeoff.
+- **Provider-backed count_tokens** (call Anthropic's native count endpoint) — rejected for v1:
+  only one provider has such an endpoint, so it cannot be universal without a new interface.

--- a/docs/advanced/anthropic-messages-api.mdx
+++ b/docs/advanced/anthropic-messages-api.mdx
@@ -65,8 +65,11 @@ features that have no canonical equivalent are not preserved end to end:
 - **`cache_control` breakpoints** are dropped — prompt-caching cost benefits are not
   carried through the canonical hop.
 - **Extended-thinking signatures** and `thinking` blocks on input messages are dropped.
-- **Server/built-in tools** (web search, code execution, …) are not supported; only
-  custom tools (`name` + `input_schema`) translate.
+- **Server/built-in tools** (web search, code execution, …) are rejected with a clear
+  `400`; only custom tools (`type` absent or `"custom"`) translate.
+- **`top_k`** is dropped — it has no portable OpenAI-compatible equivalent, and
+  OpenAI-family providers reject unknown request fields. `temperature` and `top_p`
+  are forwarded.
 - **`document` and other non-text/image content blocks** are rejected with a clear
   `400` error rather than silently dropped.
 - **`stop_sequences`** are honored, but a stop-sequence-triggered completion reports

--- a/docs/advanced/anthropic-messages-api.mdx
+++ b/docs/advanced/anthropic-messages-api.mdx
@@ -1,0 +1,83 @@
+---
+title: "Anthropic Messages API"
+description: "Accept Anthropic-style /v1/messages requests and route them to any provider."
+icon: "message-square-code"
+tag: "Beta"
+---
+
+## Overview
+
+GoModel accepts the **Anthropic Messages API** request dialect at `POST /v1/messages`,
+in addition to its OpenAI-compatible API. Clients and SDKs that speak the Anthropic
+format can point at GoModel unchanged.
+
+The request is translated to GoModel's canonical chat type at ingress and runs through
+the same pipeline as `/v1/chat/completions` — so model aliases, workflow policy,
+budgets, failover, the response cache, usage/cost tracking, and audit logging all
+apply. Because every provider implements chat completion, an Anthropic-format request
+can be routed to **any** configured provider (OpenAI, Gemini, Bedrock, and others),
+not only Anthropic.
+
+This differs from the [passthrough API](/features/passthrough-api): `/p/anthropic/v1/messages`
+forwards bytes verbatim to the Anthropic upstream only, while the managed `/v1/messages`
+endpoint routes anywhere and is fully managed.
+
+## Supported endpoints
+
+| Endpoint | Behavior |
+| --- | --- |
+| `POST /v1/messages` | Creates a message through translated model routing. Supports streaming (`stream: true`) with Anthropic-format SSE events. |
+| `POST /v1/messages/count_tokens` | Returns a heuristic input token estimate. |
+
+## Example
+
+```bash
+curl https://your-gateway/v1/messages \
+  -H "Authorization: Bearer $GOMODEL_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "claude-sonnet-4-6",
+    "max_tokens": 256,
+    "system": "Be concise.",
+    "messages": [{"role": "user", "content": "Hello"}]
+  }'
+```
+
+The response uses the Anthropic Messages shape (`type: "message"`, `content` blocks,
+`stop_reason`, `usage`). Errors use the Anthropic error envelope
+(`{"type": "error", "error": {...}}`). `max_tokens` is required, as in the Anthropic API.
+
+Streaming responses emit the Anthropic SSE event sequence (`message_start`,
+`content_block_start`/`content_block_delta`/`content_block_stop`, `message_delta`,
+`message_stop`).
+
+## Cost tracking and audit logs
+
+`/v1/messages` requests are tracked and audited exactly like the OpenAI-compatible
+routes. Cost is computed from the actual provider that served the request, and usage
+is recorded under the `/v1/messages` endpoint so it can be filtered in the dashboard.
+
+## Limitations
+
+`/v1/messages` translates through GoModel's canonical chat type. Anthropic-specific
+features that have no canonical equivalent are not preserved end to end:
+
+- **`cache_control` breakpoints** are dropped — prompt-caching cost benefits are not
+  carried through the canonical hop.
+- **Extended-thinking signatures** and `thinking` blocks on input messages are dropped.
+- **Server/built-in tools** (web search, code execution, …) are not supported; only
+  custom tools (`name` + `input_schema`) translate.
+- **`document` and other non-text/image content blocks** are rejected with a clear
+  `400` error rather than silently dropped.
+- **`stop_sequences`** are honored, but a stop-sequence-triggered completion reports
+  `stop_reason: "end_turn"` instead of `"stop_sequence"` (the output is still truncated
+  correctly).
+- **`count_tokens`** returns a provider-agnostic heuristic estimate (≈ characters / 4),
+  not a tokenizer-exact count. Use it for budgeting and UX sizing, not hard
+  context-limit decisions.
+
+For byte-exact Anthropic fidelity (including prompt-cache breakpoints), use the
+`/p/anthropic/v1/messages` passthrough route instead.
+
+See [ADR-0007](https://github.com/ENTERPILOT/GoModel/blob/main/docs/adr/0007-anthropic-messages-ingress.md)
+for the design rationale and tradeoffs.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -61,6 +61,7 @@
                             "advanced/config-yaml",
                             "advanced/resilience",
                             "advanced/responses-api",
+                            "advanced/anthropic-messages-api",
                             "advanced/guardrails",
                             "advanced/workflows",
                             "advanced/admin-endpoints"

--- a/internal/anthropicapi/errors.go
+++ b/internal/anthropicapi/errors.go
@@ -1,0 +1,51 @@
+package anthropicapi
+
+import (
+	"net/http"
+
+	"gomodel/internal/core"
+)
+
+// ErrorFromGateway converts a gateway error into an HTTP status code and the
+// Anthropic error envelope. A nil error is reported as a generic api_error.
+func ErrorFromGateway(err *core.GatewayError) (int, ErrorResponse) {
+	if err == nil {
+		return http.StatusInternalServerError, newErrorResponse("api_error", "an unexpected error occurred")
+	}
+	return err.HTTPStatusCode(), newErrorResponse(anthropicErrorType(err), err.Message)
+}
+
+func newErrorResponse(errType, message string) ErrorResponse {
+	return ErrorResponse{
+		Type:  "error",
+		Error: ErrorObject{Type: errType, Message: message},
+	}
+}
+
+// anthropicErrorType maps a core error type onto the nearest Anthropic error
+// type. The status code is preserved separately by the caller.
+func anthropicErrorType(err *core.GatewayError) string {
+	switch err.Type {
+	case core.ErrorTypeInvalidRequest:
+		if err.StatusCode == http.StatusRequestEntityTooLarge {
+			return "request_too_large"
+		}
+		return "invalid_request_error"
+	case core.ErrorTypeAuthentication:
+		if err.StatusCode == http.StatusForbidden {
+			return "permission_error"
+		}
+		return "authentication_error"
+	case core.ErrorTypeNotFound:
+		return "not_found_error"
+	case core.ErrorTypeRateLimit:
+		return "rate_limit_error"
+	case core.ErrorTypeProvider:
+		if err.StatusCode == http.StatusServiceUnavailable {
+			return "overloaded_error"
+		}
+		return "api_error"
+	default:
+		return "api_error"
+	}
+}

--- a/internal/anthropicapi/errors_test.go
+++ b/internal/anthropicapi/errors_test.go
@@ -1,0 +1,81 @@
+package anthropicapi
+
+import (
+	"net/http"
+	"testing"
+
+	"gomodel/internal/core"
+)
+
+func TestErrorFromGateway(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        *core.GatewayError
+		wantStatus int
+		wantType   string
+	}{
+		{
+			name:       "invalid request",
+			err:        core.NewInvalidRequestError("bad", nil),
+			wantStatus: http.StatusBadRequest,
+			wantType:   "invalid_request_error",
+		},
+		{
+			name:       "authentication",
+			err:        core.NewAuthenticationError("p", "no key"),
+			wantStatus: http.StatusUnauthorized,
+			wantType:   "authentication_error",
+		},
+		{
+			name:       "not found",
+			err:        core.NewNotFoundError("missing model"),
+			wantStatus: http.StatusNotFound,
+			wantType:   "not_found_error",
+		},
+		{
+			name:       "rate limit",
+			err:        core.NewRateLimitError("p", "slow down"),
+			wantStatus: http.StatusTooManyRequests,
+			wantType:   "rate_limit_error",
+		},
+		{
+			name:       "provider error",
+			err:        core.NewProviderError("p", http.StatusBadGateway, "upstream down", nil),
+			wantStatus: http.StatusBadGateway,
+			wantType:   "api_error",
+		},
+		{
+			name:       "provider overloaded",
+			err:        core.NewProviderError("p", http.StatusServiceUnavailable, "overloaded", nil),
+			wantStatus: http.StatusServiceUnavailable,
+			wantType:   "overloaded_error",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			status, body := ErrorFromGateway(tc.err)
+			if status != tc.wantStatus {
+				t.Errorf("status = %d, want %d", status, tc.wantStatus)
+			}
+			if body.Type != "error" {
+				t.Errorf("envelope type = %q, want error", body.Type)
+			}
+			if body.Error.Type != tc.wantType {
+				t.Errorf("error type = %q, want %q", body.Error.Type, tc.wantType)
+			}
+			if body.Error.Message != tc.err.Message {
+				t.Errorf("message = %q, want %q", body.Error.Message, tc.err.Message)
+			}
+		})
+	}
+}
+
+func TestErrorFromGatewayNil(t *testing.T) {
+	status, body := ErrorFromGateway(nil)
+	if status != http.StatusInternalServerError {
+		t.Errorf("status = %d", status)
+	}
+	if body.Error.Type != "api_error" {
+		t.Errorf("error type = %q", body.Error.Type)
+	}
+}

--- a/internal/anthropicapi/errors_test.go
+++ b/internal/anthropicapi/errors_test.go
@@ -21,10 +21,22 @@ func TestErrorFromGateway(t *testing.T) {
 			wantType:   "invalid_request_error",
 		},
 		{
+			name:       "request too large",
+			err:        core.NewInvalidRequestErrorWithStatus(http.StatusRequestEntityTooLarge, "payload too large", nil),
+			wantStatus: http.StatusRequestEntityTooLarge,
+			wantType:   "request_too_large",
+		},
+		{
 			name:       "authentication",
 			err:        core.NewAuthenticationError("p", "no key"),
 			wantStatus: http.StatusUnauthorized,
 			wantType:   "authentication_error",
+		},
+		{
+			name:       "forbidden maps to permission error",
+			err:        core.ParseProviderError("p", http.StatusForbidden, []byte("forbidden"), nil),
+			wantStatus: http.StatusForbidden,
+			wantType:   "permission_error",
 		},
 		{
 			name:       "not found",

--- a/internal/anthropicapi/request.go
+++ b/internal/anthropicapi/request.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 
 	"gomodel/internal/core"
@@ -20,9 +21,11 @@ func DecodeMessagesRequest(body []byte) (*MessagesRequest, error) {
 	if err := dec.Decode(&req); err != nil {
 		return nil, err
 	}
-	// Reject trailing bytes after the JSON object so a malformed body cannot
-	// look valid while audit/cache inputs disagree with the parsed request.
-	if dec.More() {
+	// Require the body to hold exactly one JSON value: decoding again must
+	// reach EOF. This rejects any trailing bytes (a second object, stray
+	// brackets, garbage) so a malformed body cannot look valid while
+	// audit/cache inputs disagree with the parsed request.
+	if err := dec.Decode(new(json.RawMessage)); err != io.EOF {
 		return nil, fmt.Errorf("request body must contain a single JSON object")
 	}
 	return &req, nil

--- a/internal/anthropicapi/request.go
+++ b/internal/anthropicapi/request.go
@@ -1,0 +1,427 @@
+package anthropicapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"gomodel/internal/core"
+)
+
+// DecodeMessagesRequest parses an Anthropic Messages API request body.
+func DecodeMessagesRequest(body []byte) (*MessagesRequest, error) {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return nil, fmt.Errorf("request body is empty")
+	}
+	var req MessagesRequest
+	dec := json.NewDecoder(bytes.NewReader(trimmed))
+	if err := dec.Decode(&req); err != nil {
+		return nil, err
+	}
+	return &req, nil
+}
+
+// ToChatRequest translates an Anthropic Messages request into the canonical
+// chat request. The translation is provider-agnostic: the resulting request
+// runs through the standard chat-completions pipeline.
+func ToChatRequest(req *MessagesRequest) (*core.ChatRequest, error) {
+	if req == nil {
+		return nil, core.NewInvalidRequestError("messages request is required", nil)
+	}
+	if strings.TrimSpace(req.Model) == "" {
+		return nil, core.NewInvalidRequestError("model is required", nil).WithParam("model")
+	}
+	if req.MaxTokens <= 0 {
+		return nil, core.NewInvalidRequestError("max_tokens must be a positive integer", nil).WithParam("max_tokens")
+	}
+	if len(req.Messages) == 0 {
+		return nil, core.NewInvalidRequestError("messages must not be empty", nil).WithParam("messages")
+	}
+
+	messages, err := convertMessages(req)
+	if err != nil {
+		return nil, err
+	}
+
+	maxTokens := req.MaxTokens
+	chat := &core.ChatRequest{
+		Model:       req.Model,
+		Messages:    messages,
+		MaxTokens:   &maxTokens,
+		Temperature: req.Temperature,
+		Stream:      req.Stream,
+		Reasoning:   thinkingToReasoning(req.Thinking),
+	}
+	if req.Stream {
+		chat.StreamOptions = &core.StreamOptions{IncludeUsage: true}
+	}
+
+	tools, err := convertTools(req.Tools)
+	if err != nil {
+		return nil, err
+	}
+	chat.Tools = tools
+	toolChoice, parallel := convertToolChoice(req.ToolChoice)
+	chat.ToolChoice = toolChoice
+	chat.ParallelToolCalls = parallel
+
+	if extra := buildExtraFields(req); !extra.IsEmpty() {
+		chat.ExtraFields = extra
+	}
+	return chat, nil
+}
+
+// convertMessages flattens the Anthropic system prompt and messages into the
+// canonical message list. A single Anthropic message may expand into multiple
+// canonical messages: tool_result blocks become standalone role:"tool" messages.
+func convertMessages(req *MessagesRequest) ([]core.Message, error) {
+	out := make([]core.Message, 0, len(req.Messages)+1)
+
+	if system := systemText(req.System); system != "" {
+		out = append(out, core.Message{Role: "system", Content: system})
+	}
+
+	for i, msg := range req.Messages {
+		text, blocks, err := parseContent(msg.Content)
+		if err != nil {
+			return nil, core.NewInvalidRequestError(fmt.Sprintf("messages[%d].content: %v", i, err), err)
+		}
+		if blocks == nil {
+			out = append(out, core.Message{Role: normalizeRole(msg.Role), Content: text})
+			continue
+		}
+		converted, err := convertBlockMessage(msg.Role, blocks)
+		if err != nil {
+			return nil, core.NewInvalidRequestError(fmt.Sprintf("messages[%d]: %v", i, err), err)
+		}
+		out = append(out, converted...)
+	}
+	return out, nil
+}
+
+// convertBlockMessage converts one Anthropic block-content message. tool_result
+// blocks are emitted as separate role:"tool" messages (OpenAI representation);
+// text/image blocks and tool_use blocks collapse into a single user/assistant
+// message.
+func convertBlockMessage(role string, blocks []ContentBlock) ([]core.Message, error) {
+	var (
+		toolMessages []core.Message
+		parts        []core.ContentPart
+		toolCalls    []core.ToolCall
+	)
+	for _, block := range blocks {
+		switch block.Type {
+		case "text":
+			if block.Text != "" {
+				parts = append(parts, core.ContentPart{Type: "text", Text: block.Text})
+			}
+		case "image":
+			url, err := imageURLFromSource(block.Source)
+			if err != nil {
+				return nil, err
+			}
+			parts = append(parts, core.ContentPart{
+				Type:     "image_url",
+				ImageURL: &core.ImageURLContent{URL: url},
+			})
+		case "tool_use":
+			if strings.TrimSpace(block.Name) == "" {
+				return nil, fmt.Errorf("tool_use block is missing name")
+			}
+			toolCalls = append(toolCalls, core.ToolCall{
+				ID:       block.ID,
+				Type:     "function",
+				Function: core.FunctionCall{Name: block.Name, Arguments: rawToArguments(block.Input)},
+			})
+		case "tool_result":
+			id := strings.TrimSpace(block.ToolUseID)
+			if id == "" {
+				return nil, fmt.Errorf("tool_result block is missing tool_use_id")
+			}
+			toolMessages = append(toolMessages, core.Message{
+				Role:       "tool",
+				ToolCallID: id,
+				Content:    toolResultText(block.Content),
+			})
+		case "thinking", "redacted_thinking":
+			// Extended-thinking history has no canonical chat equivalent; drop
+			// it. It is an assistant-side artifact, so dropping it does not lose
+			// caller intent.
+		default:
+			// Block types that carry caller payload (e.g. document) have no
+			// canonical chat equivalent. Reject them rather than silently
+			// dropping the data, which would make the model answer as if the
+			// attachment were never sent.
+			return nil, fmt.Errorf("unsupported content block type %q; use the /p/anthropic passthrough for provider-native features", block.Type)
+		}
+	}
+
+	messages := toolMessages
+	if content := collapseParts(parts); content != nil || len(toolCalls) > 0 {
+		messages = append(messages, core.Message{
+			Role:      normalizeRole(role),
+			Content:   content,
+			ToolCalls: toolCalls,
+		})
+	}
+	return messages, nil
+}
+
+// collapseParts reduces content parts to a plain string when they are all text,
+// and otherwise returns the typed part slice. It returns nil when there is no
+// content at all.
+func collapseParts(parts []core.ContentPart) core.MessageContent {
+	if len(parts) == 0 {
+		return nil
+	}
+	onlyText := true
+	for _, part := range parts {
+		if part.Type != "text" {
+			onlyText = false
+			break
+		}
+	}
+	if onlyText {
+		texts := make([]string, 0, len(parts))
+		for _, part := range parts {
+			texts = append(texts, part.Text)
+		}
+		return strings.Join(texts, "\n")
+	}
+	return parts
+}
+
+func normalizeRole(role string) string {
+	if role == "assistant" {
+		return "assistant"
+	}
+	return "user"
+}
+
+// parseContent decodes a polymorphic Anthropic content value. When the value is
+// a string, blocks is nil and text holds the string. When it is an array,
+// blocks is non-nil (possibly empty).
+func parseContent(raw json.RawMessage) (text string, blocks []ContentBlock, err error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return "", nil, nil
+	}
+	switch trimmed[0] {
+	case '"':
+		if err := json.Unmarshal(trimmed, &text); err != nil {
+			return "", nil, err
+		}
+		return text, nil, nil
+	case '[':
+		decoded := []ContentBlock{}
+		if err := json.Unmarshal(trimmed, &decoded); err != nil {
+			return "", nil, err
+		}
+		return "", decoded, nil
+	default:
+		return "", nil, fmt.Errorf("must be a string or an array of content blocks")
+	}
+}
+
+// systemText flattens the Anthropic system field (string or text-block array)
+// into a single string.
+func systemText(raw json.RawMessage) string {
+	text, blocks, err := parseContent(raw)
+	if err != nil {
+		return ""
+	}
+	if blocks == nil {
+		return strings.TrimSpace(text)
+	}
+	parts := make([]string, 0, len(blocks))
+	for _, block := range blocks {
+		if block.Type == "text" && block.Text != "" {
+			parts = append(parts, block.Text)
+		}
+	}
+	return strings.TrimSpace(strings.Join(parts, "\n\n"))
+}
+
+// toolResultText extracts the text payload of a tool_result block content,
+// which itself may be a string or an array of (text) blocks.
+func toolResultText(raw json.RawMessage) string {
+	text, blocks, err := parseContent(raw)
+	if err != nil {
+		return ""
+	}
+	if blocks == nil {
+		return text
+	}
+	parts := make([]string, 0, len(blocks))
+	for _, block := range blocks {
+		if block.Type == "text" && block.Text != "" {
+			parts = append(parts, block.Text)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func imageURLFromSource(source *Source) (string, error) {
+	if source == nil {
+		return "", fmt.Errorf("image block is missing source")
+	}
+	switch source.Type {
+	case "base64":
+		if source.MediaType == "" || source.Data == "" {
+			return "", fmt.Errorf("base64 image source requires media_type and data")
+		}
+		return "data:" + source.MediaType + ";base64," + source.Data, nil
+	case "url":
+		if source.URL == "" {
+			return "", fmt.Errorf("url image source requires url")
+		}
+		return source.URL, nil
+	default:
+		return "", fmt.Errorf("unsupported image source type %q", source.Type)
+	}
+}
+
+// rawToArguments renders a tool_use input object as a compact JSON string,
+// the form expected by core.FunctionCall.Arguments.
+func rawToArguments(raw json.RawMessage) string {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return "{}"
+	}
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, trimmed); err != nil {
+		return "{}"
+	}
+	return compact.String()
+}
+
+func convertTools(tools []Tool) ([]map[string]any, error) {
+	if len(tools) == 0 {
+		return nil, nil
+	}
+	out := make([]map[string]any, 0, len(tools))
+	for i, tool := range tools {
+		if strings.TrimSpace(tool.Name) == "" {
+			return nil, core.NewInvalidRequestError(fmt.Sprintf("tools[%d].name is required", i), nil)
+		}
+		function := map[string]any{"name": tool.Name}
+		if tool.Description != "" {
+			function["description"] = tool.Description
+		}
+		if len(bytes.TrimSpace(tool.InputSchema)) > 0 {
+			var schema any
+			if err := json.Unmarshal(tool.InputSchema, &schema); err != nil {
+				return nil, core.NewInvalidRequestError(fmt.Sprintf("tools[%d].input_schema: %v", i, err), err)
+			}
+			function["parameters"] = schema
+		}
+		out = append(out, map[string]any{"type": "function", "function": function})
+	}
+	return out, nil
+}
+
+// convertToolChoice maps an Anthropic tool_choice to its OpenAI equivalent and
+// the parallel_tool_calls flag.
+func convertToolChoice(choice *ToolChoice) (any, *bool) {
+	if choice == nil {
+		return nil, nil
+	}
+	var parallel *bool
+	if choice.DisableParallelToolUse != nil && *choice.DisableParallelToolUse {
+		disabled := false
+		parallel = &disabled
+	}
+	switch choice.Type {
+	case "auto":
+		return "auto", parallel
+	case "any":
+		return "required", parallel
+	case "none":
+		return "none", parallel
+	case "tool":
+		if strings.TrimSpace(choice.Name) != "" {
+			return map[string]any{
+				"type":     "function",
+				"function": map[string]any{"name": choice.Name},
+			}, parallel
+		}
+		return "auto", parallel
+	default:
+		return nil, parallel
+	}
+}
+
+// thinkingToReasoning maps Anthropic extended-thinking config onto the canonical
+// reasoning effort. Budget thresholds mirror the anthropic provider's
+// effort-to-budget mapping.
+func thinkingToReasoning(thinking *Thinking) *core.Reasoning {
+	if thinking == nil || thinking.Type == "" || thinking.Type == "disabled" {
+		return nil
+	}
+	effort := "low"
+	switch {
+	case thinking.Type == "adaptive":
+		effort = "medium"
+	case thinking.BudgetTokens >= 20000:
+		effort = "high"
+	case thinking.BudgetTokens >= 10000:
+		effort = "medium"
+	}
+	return &core.Reasoning{Effort: effort}
+}
+
+// buildExtraFields carries Anthropic request fields that have no first-class
+// canonical field through as OpenAI-compatible extra fields.
+func buildExtraFields(req *MessagesRequest) core.UnknownJSONFields {
+	fields := map[string]json.RawMessage{}
+	add := func(key string, value any) {
+		if raw, err := json.Marshal(value); err == nil {
+			fields[key] = raw
+		}
+	}
+	if len(req.StopSequences) > 0 {
+		add("stop", req.StopSequences)
+	}
+	if req.TopP != nil {
+		add("top_p", *req.TopP)
+	}
+	if req.TopK != nil {
+		add("top_k", *req.TopK)
+	}
+	if req.Metadata != nil && strings.TrimSpace(req.Metadata.UserID) != "" {
+		add("user", req.Metadata.UserID)
+	}
+	return core.UnknownJSONFieldsFromMap(fields)
+}
+
+// EstimateInputTokens returns a provider-agnostic heuristic estimate of the
+// input token count for a Messages request (roughly characters / 4). It is an
+// approximation, not a tokenizer-exact count.
+func EstimateInputTokens(req *MessagesRequest) int {
+	if req == nil {
+		return 0
+	}
+	chars := len(systemText(req.System))
+	for _, msg := range req.Messages {
+		text, blocks, err := parseContent(msg.Content)
+		if err != nil {
+			continue
+		}
+		chars += len(text)
+		for _, block := range blocks {
+			chars += len(block.Text) + len(block.Thinking)
+			chars += len(bytes.TrimSpace(block.Input))
+			chars += len(toolResultText(block.Content))
+		}
+	}
+	for _, tool := range req.Tools {
+		chars += len(tool.Name) + len(tool.Description) + len(bytes.TrimSpace(tool.InputSchema))
+	}
+	tokens := (chars + 3) / 4
+	if tokens == 0 && chars > 0 {
+		return 1
+	}
+	return tokens
+}

--- a/internal/anthropicapi/request.go
+++ b/internal/anthropicapi/request.go
@@ -20,6 +20,11 @@ func DecodeMessagesRequest(body []byte) (*MessagesRequest, error) {
 	if err := dec.Decode(&req); err != nil {
 		return nil, err
 	}
+	// Reject trailing bytes after the JSON object so a malformed body cannot
+	// look valid while audit/cache inputs disagree with the parsed request.
+	if dec.More() {
+		return nil, fmt.Errorf("request body must contain a single JSON object")
+	}
 	return &req, nil
 }
 
@@ -79,17 +84,25 @@ func ToChatRequest(req *MessagesRequest) (*core.ChatRequest, error) {
 func convertMessages(req *MessagesRequest) ([]core.Message, error) {
 	out := make([]core.Message, 0, len(req.Messages)+1)
 
-	if system := systemText(req.System); system != "" {
+	system, err := systemText(req.System)
+	if err != nil {
+		return nil, core.NewInvalidRequestError(err.Error(), err)
+	}
+	if system != "" {
 		out = append(out, core.Message{Role: "system", Content: system})
 	}
 
 	for i, msg := range req.Messages {
+		if msg.Role != "user" && msg.Role != "assistant" {
+			return nil, core.NewInvalidRequestError(
+				fmt.Sprintf("messages[%d].role must be \"user\" or \"assistant\"", i), nil)
+		}
 		text, blocks, err := parseContent(msg.Content)
 		if err != nil {
 			return nil, core.NewInvalidRequestError(fmt.Sprintf("messages[%d].content: %v", i, err), err)
 		}
 		if blocks == nil {
-			out = append(out, core.Message{Role: normalizeRole(msg.Role), Content: text})
+			out = append(out, core.Message{Role: msg.Role, Content: text})
 			continue
 		}
 		converted, err := convertBlockMessage(msg.Role, blocks)
@@ -140,10 +153,14 @@ func convertBlockMessage(role string, blocks []ContentBlock) ([]core.Message, er
 			if id == "" {
 				return nil, fmt.Errorf("tool_result block is missing tool_use_id")
 			}
+			content, err := toolResultText(block.Content)
+			if err != nil {
+				return nil, err
+			}
 			toolMessages = append(toolMessages, core.Message{
 				Role:       "tool",
 				ToolCallID: id,
-				Content:    toolResultText(block.Content),
+				Content:    content,
 			})
 		case "thinking", "redacted_thinking":
 			// Extended-thinking history has no canonical chat equivalent; drop
@@ -154,14 +171,14 @@ func convertBlockMessage(role string, blocks []ContentBlock) ([]core.Message, er
 			// canonical chat equivalent. Reject them rather than silently
 			// dropping the data, which would make the model answer as if the
 			// attachment were never sent.
-			return nil, fmt.Errorf("unsupported content block type %q; use the /p/anthropic passthrough for provider-native features", block.Type)
+			return nil, fmt.Errorf("unsupported content block type %q; use the /p/anthropic/v1/messages passthrough for provider-native features", block.Type)
 		}
 	}
 
 	messages := toolMessages
 	if content := collapseParts(parts); content != nil || len(toolCalls) > 0 {
 		messages = append(messages, core.Message{
-			Role:      normalizeRole(role),
+			Role:      role,
 			Content:   content,
 			ToolCalls: toolCalls,
 		})
@@ -193,13 +210,6 @@ func collapseParts(parts []core.ContentPart) core.MessageContent {
 	return parts
 }
 
-func normalizeRole(role string) string {
-	if role == "assistant" {
-		return "assistant"
-	}
-	return "user"
-}
-
 // parseContent decodes a polymorphic Anthropic content value. When the value is
 // a string, blocks is nil and text holds the string. When it is an array,
 // blocks is non-nil (possibly empty).
@@ -226,41 +236,51 @@ func parseContent(raw json.RawMessage) (text string, blocks []ContentBlock, err 
 }
 
 // systemText flattens the Anthropic system field (string or text-block array)
-// into a single string.
-func systemText(raw json.RawMessage) string {
+// into a single string. A present but malformed system value is an error
+// rather than silently dropped: the model must not run without the caller's
+// instructions.
+func systemText(raw json.RawMessage) (string, error) {
 	text, blocks, err := parseContent(raw)
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("system: %v", err)
 	}
 	if blocks == nil {
-		return strings.TrimSpace(text)
+		return strings.TrimSpace(text), nil
 	}
 	parts := make([]string, 0, len(blocks))
 	for _, block := range blocks {
-		if block.Type == "text" && block.Text != "" {
+		if block.Type != "text" {
+			return "", fmt.Errorf("system block type %q is not supported; only text is allowed", block.Type)
+		}
+		if block.Text != "" {
 			parts = append(parts, block.Text)
 		}
 	}
-	return strings.TrimSpace(strings.Join(parts, "\n\n"))
+	return strings.TrimSpace(strings.Join(parts, "\n\n")), nil
 }
 
 // toolResultText extracts the text payload of a tool_result block content,
-// which itself may be a string or an array of (text) blocks.
-func toolResultText(raw json.RawMessage) string {
+// which itself may be a string or an array of text blocks. A present but
+// malformed or non-text tool_result content is an error rather than silently
+// dropped: the downstream provider must not receive an empty tool response.
+func toolResultText(raw json.RawMessage) (string, error) {
 	text, blocks, err := parseContent(raw)
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("tool_result content: %v", err)
 	}
 	if blocks == nil {
-		return text
+		return text, nil
 	}
 	parts := make([]string, 0, len(blocks))
 	for _, block := range blocks {
-		if block.Type == "text" && block.Text != "" {
+		if block.Type != "text" {
+			return "", fmt.Errorf("tool_result content block type %q is not supported; only text is allowed", block.Type)
+		}
+		if block.Text != "" {
 			parts = append(parts, block.Text)
 		}
 	}
-	return strings.Join(parts, "\n")
+	return strings.Join(parts, "\n"), nil
 }
 
 func imageURLFromSource(source *Source) (string, error) {
@@ -308,7 +328,7 @@ func convertTools(tools []Tool) ([]map[string]any, error) {
 		// canonical chat equivalent; reject them rather than mistranslating
 		// them into a phantom custom function the gateway cannot execute.
 		if t := strings.TrimSpace(tool.Type); t != "" && t != "custom" {
-			return nil, core.NewInvalidRequestError(fmt.Sprintf("tools[%d]: server tool type %q is not supported; use the /p/anthropic passthrough for provider-native tools", i, tool.Type), nil)
+			return nil, core.NewInvalidRequestError(fmt.Sprintf("tools[%d]: server tool type %q is not supported; use the /p/anthropic/v1/messages passthrough for provider-native tools", i, tool.Type), nil)
 		}
 		if strings.TrimSpace(tool.Name) == "" {
 			return nil, core.NewInvalidRequestError(fmt.Sprintf("tools[%d].name is required", i), nil)
@@ -413,7 +433,10 @@ func EstimateInputTokens(req *MessagesRequest) int {
 	if req == nil {
 		return 0
 	}
-	chars := len(systemText(req.System))
+	// Errors are ignored here: count_tokens is a best-effort heuristic and
+	// must not fail on malformed sub-fields that ToChatRequest would reject.
+	system, _ := systemText(req.System)
+	chars := len(system)
 	for _, msg := range req.Messages {
 		text, blocks, err := parseContent(msg.Content)
 		if err != nil {
@@ -423,7 +446,8 @@ func EstimateInputTokens(req *MessagesRequest) int {
 		for _, block := range blocks {
 			chars += len(block.Text) + len(block.Thinking)
 			chars += len(bytes.TrimSpace(block.Input))
-			chars += len(toolResultText(block.Content))
+			result, _ := toolResultText(block.Content)
+			chars += len(result)
 		}
 	}
 	for _, tool := range req.Tools {

--- a/internal/anthropicapi/request.go
+++ b/internal/anthropicapi/request.go
@@ -303,6 +303,13 @@ func convertTools(tools []Tool) ([]map[string]any, error) {
 	}
 	out := make([]map[string]any, 0, len(tools))
 	for i, tool := range tools {
+		// A non-empty type other than "custom" marks an Anthropic server/
+		// built-in tool (web search, code execution, …). These have no
+		// canonical chat equivalent; reject them rather than mistranslating
+		// them into a phantom custom function the gateway cannot execute.
+		if t := strings.TrimSpace(tool.Type); t != "" && t != "custom" {
+			return nil, core.NewInvalidRequestError(fmt.Sprintf("tools[%d]: server tool type %q is not supported; use the /p/anthropic passthrough for provider-native tools", i, tool.Type), nil)
+		}
 		if strings.TrimSpace(tool.Name) == "" {
 			return nil, core.NewInvalidRequestError(fmt.Sprintf("tools[%d].name is required", i), nil)
 		}
@@ -372,8 +379,14 @@ func thinkingToReasoning(thinking *Thinking) *core.Reasoning {
 	return &core.Reasoning{Effort: effort}
 }
 
-// buildExtraFields carries Anthropic request fields that have no first-class
-// canonical field through as OpenAI-compatible extra fields.
+// buildExtraFields carries Anthropic request fields that have a portable
+// OpenAI-compatible equivalent through as extra fields.
+//
+// top_k is deliberately not carried: it is not a valid OpenAI Chat Completions
+// parameter, and the OpenAI-family providers forward request fields verbatim
+// and reject unknown ones with a 400. Carrying it would make any request with
+// top_k fail when routed to those providers, so it is dropped (see ADR-0007).
+// stop, top_p, and user are all portable across OpenAI-compatible providers.
 func buildExtraFields(req *MessagesRequest) core.UnknownJSONFields {
 	fields := map[string]json.RawMessage{}
 	add := func(key string, value any) {
@@ -386,9 +399,6 @@ func buildExtraFields(req *MessagesRequest) core.UnknownJSONFields {
 	}
 	if req.TopP != nil {
 		add("top_p", *req.TopP)
-	}
-	if req.TopK != nil {
-		add("top_k", *req.TopK)
 	}
 	if req.Metadata != nil && strings.TrimSpace(req.Metadata.UserID) != "" {
 		add("user", req.Metadata.UserID)

--- a/internal/anthropicapi/request_test.go
+++ b/internal/anthropicapi/request_test.go
@@ -26,6 +26,8 @@ func TestDecodeMessagesRequest(t *testing.T) {
 		{name: "valid", body: `{"model":"m","max_tokens":10,"messages":[]}`},
 		{name: "empty", body: "  ", wantErr: true},
 		{name: "malformed", body: `{"model":`, wantErr: true},
+		{name: "trailing object", body: `{"model":"m","max_tokens":10,"messages":[]}{"x":1}`, wantErr: true},
+		{name: "trailing garbage", body: `{"model":"m","max_tokens":10,"messages":[]} oops`, wantErr: true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -45,6 +47,31 @@ func TestToChatRequestValidation(t *testing.T) {
 		{name: "missing model", body: `{"max_tokens":10,"messages":[{"role":"user","content":"hi"}]}`},
 		{name: "zero max_tokens", body: `{"model":"m","max_tokens":0,"messages":[{"role":"user","content":"hi"}]}`},
 		{name: "empty messages", body: `{"model":"m","max_tokens":10,"messages":[]}`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ToChatRequest(mustDecode(t, tc.body))
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if _, ok := err.(*core.GatewayError); !ok {
+				t.Fatalf("expected *core.GatewayError, got %T", err)
+			}
+		})
+	}
+}
+
+func TestToChatRequestRejectsInvalidShapes(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "unsupported role", body: `{"model":"m","max_tokens":10,"messages":[{"role":"system","content":"hi"}]}`},
+		{name: "typo role", body: `{"model":"m","max_tokens":10,"messages":[{"role":"assisstant","content":"hi"}]}`},
+		{name: "malformed system", body: `{"model":"m","max_tokens":10,"system":42,"messages":[{"role":"user","content":"hi"}]}`},
+		{name: "non-text system block", body: `{"model":"m","max_tokens":10,"system":[{"type":"image"}],"messages":[{"role":"user","content":"hi"}]}`},
+		{name: "malformed tool_result content", body: `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":42}]}]}`},
+		{name: "non-text tool_result block", body: `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"image"}]}]}]}`},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/anthropicapi/request_test.go
+++ b/internal/anthropicapi/request_test.go
@@ -28,6 +28,7 @@ func TestDecodeMessagesRequest(t *testing.T) {
 		{name: "malformed", body: `{"model":`, wantErr: true},
 		{name: "trailing object", body: `{"model":"m","max_tokens":10,"messages":[]}{"x":1}`, wantErr: true},
 		{name: "trailing garbage", body: `{"model":"m","max_tokens":10,"messages":[]} oops`, wantErr: true},
+		{name: "trailing brace", body: `{"model":"m","max_tokens":10,"messages":[]}}`, wantErr: true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -79,8 +80,9 @@ func TestToChatRequestRejectsInvalidShapes(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected error")
 			}
-			if _, ok := err.(*core.GatewayError); !ok {
-				t.Fatalf("expected *core.GatewayError, got %T", err)
+			gatewayErr, ok := err.(*core.GatewayError)
+			if !ok || gatewayErr.Type != core.ErrorTypeInvalidRequest {
+				t.Fatalf("expected invalid_request_error, got %T: %v", err, err)
 			}
 		})
 	}

--- a/internal/anthropicapi/request_test.go
+++ b/internal/anthropicapi/request_test.go
@@ -154,10 +154,11 @@ func TestToChatRequestToolUseAndResult(t *testing.T) {
 }
 
 func TestToChatRequestTools(t *testing.T) {
+	// An explicit type of "custom" is accepted alongside the typeless form.
 	chat, err := ToChatRequest(mustDecode(t, `{
 		"model":"m","max_tokens":10,
 		"messages":[{"role":"user","content":"hi"}],
-		"tools":[{"name":"get_weather","description":"weather","input_schema":{"type":"object","properties":{}}}],
+		"tools":[{"type":"custom","name":"get_weather","description":"weather","input_schema":{"type":"object","properties":{}}}],
 		"tool_choice":{"type":"tool","name":"get_weather"}
 	}`))
 	if err != nil {
@@ -176,6 +177,21 @@ func TestToChatRequestTools(t *testing.T) {
 	choice, ok := chat.ToolChoice.(map[string]any)
 	if !ok || choice["type"] != "function" {
 		t.Fatalf("tool_choice = %#v", chat.ToolChoice)
+	}
+}
+
+func TestToChatRequestRejectsServerTool(t *testing.T) {
+	_, err := ToChatRequest(mustDecode(t, `{
+		"model":"m","max_tokens":10,
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[{"type":"web_search_20250305","name":"web_search"}]
+	}`))
+	if err == nil {
+		t.Fatal("expected error for Anthropic server tool")
+	}
+	gatewayErr, ok := err.(*core.GatewayError)
+	if !ok || gatewayErr.Type != core.ErrorTypeInvalidRequest {
+		t.Fatalf("err = %#v, want invalid_request_error", err)
 	}
 }
 
@@ -259,13 +275,17 @@ func TestToChatRequestExtraFields(t *testing.T) {
 	for key, want := range map[string]string{
 		"stop":  `["STOP"]`,
 		"top_p": `0.9`,
-		"top_k": `40`,
 		"user":  `"u-123"`,
 	} {
 		raw := chat.ExtraFields.Lookup(key)
 		if string(raw) != want {
 			t.Errorf("ExtraFields[%q] = %s, want %s", key, raw, want)
 		}
+	}
+	// top_k has no portable OpenAI-compatible equivalent and OpenAI-family
+	// providers reject unknown request fields; it must be dropped, not carried.
+	if raw := chat.ExtraFields.Lookup("top_k"); len(raw) > 0 {
+		t.Errorf("ExtraFields[top_k] = %s, want dropped", raw)
 	}
 }
 

--- a/internal/anthropicapi/request_test.go
+++ b/internal/anthropicapi/request_test.go
@@ -1,0 +1,336 @@
+package anthropicapi
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"gomodel/internal/core"
+)
+
+func mustDecode(t *testing.T, body string) *MessagesRequest {
+	t.Helper()
+	req, err := DecodeMessagesRequest([]byte(body))
+	if err != nil {
+		t.Fatalf("DecodeMessagesRequest: %v", err)
+	}
+	return req
+}
+
+func TestDecodeMessagesRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr bool
+	}{
+		{name: "valid", body: `{"model":"m","max_tokens":10,"messages":[]}`},
+		{name: "empty", body: "  ", wantErr: true},
+		{name: "malformed", body: `{"model":`, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := DecodeMessagesRequest([]byte(tc.body))
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("err=%v, wantErr=%v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestToChatRequestValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "missing model", body: `{"max_tokens":10,"messages":[{"role":"user","content":"hi"}]}`},
+		{name: "zero max_tokens", body: `{"model":"m","max_tokens":0,"messages":[{"role":"user","content":"hi"}]}`},
+		{name: "empty messages", body: `{"model":"m","max_tokens":10,"messages":[]}`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ToChatRequest(mustDecode(t, tc.body))
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if _, ok := err.(*core.GatewayError); !ok {
+				t.Fatalf("expected *core.GatewayError, got %T", err)
+			}
+		})
+	}
+}
+
+func TestToChatRequestBasic(t *testing.T) {
+	chat, err := ToChatRequest(mustDecode(t, `{
+		"model":"claude-test","max_tokens":256,"temperature":0.5,"stream":true,
+		"system":"be brief",
+		"messages":[{"role":"user","content":"hello"}]
+	}`))
+	if err != nil {
+		t.Fatalf("ToChatRequest: %v", err)
+	}
+	if chat.Model != "claude-test" {
+		t.Errorf("Model = %q", chat.Model)
+	}
+	if chat.MaxTokens == nil || *chat.MaxTokens != 256 {
+		t.Errorf("MaxTokens = %v", chat.MaxTokens)
+	}
+	if chat.Temperature == nil || *chat.Temperature != 0.5 {
+		t.Errorf("Temperature = %v", chat.Temperature)
+	}
+	if !chat.Stream || chat.StreamOptions == nil || !chat.StreamOptions.IncludeUsage {
+		t.Errorf("stream options not set: stream=%v opts=%v", chat.Stream, chat.StreamOptions)
+	}
+	if len(chat.Messages) != 2 {
+		t.Fatalf("messages = %d, want 2 (system + user)", len(chat.Messages))
+	}
+	if chat.Messages[0].Role != "system" || chat.Messages[0].Content != "be brief" {
+		t.Errorf("system message = %+v", chat.Messages[0])
+	}
+	if chat.Messages[1].Role != "user" || chat.Messages[1].Content != "hello" {
+		t.Errorf("user message = %+v", chat.Messages[1])
+	}
+}
+
+func TestToChatRequestImageBlock(t *testing.T) {
+	chat, err := ToChatRequest(mustDecode(t, `{
+		"model":"m","max_tokens":10,
+		"messages":[{"role":"user","content":[
+			{"type":"text","text":"look"},
+			{"type":"image","source":{"type":"base64","media_type":"image/png","data":"AAAA"}}
+		]}]
+	}`))
+	if err != nil {
+		t.Fatalf("ToChatRequest: %v", err)
+	}
+	parts, ok := chat.Messages[0].Content.([]core.ContentPart)
+	if !ok {
+		t.Fatalf("content type = %T, want []core.ContentPart", chat.Messages[0].Content)
+	}
+	if len(parts) != 2 || parts[1].Type != "image_url" {
+		t.Fatalf("parts = %+v", parts)
+	}
+	if got := parts[1].ImageURL.URL; got != "data:image/png;base64,AAAA" {
+		t.Errorf("image URL = %q", got)
+	}
+}
+
+func TestToChatRequestToolUseAndResult(t *testing.T) {
+	chat, err := ToChatRequest(mustDecode(t, `{
+		"model":"m","max_tokens":10,
+		"messages":[
+			{"role":"assistant","content":[
+				{"type":"text","text":"calling"},
+				{"type":"tool_use","id":"tu_1","name":"get_weather","input":{"city":"paris"}}
+			]},
+			{"role":"user","content":[
+				{"type":"tool_result","tool_use_id":"tu_1","content":"sunny"},
+				{"type":"text","text":"thanks"}
+			]}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("ToChatRequest: %v", err)
+	}
+	if len(chat.Messages) != 3 {
+		t.Fatalf("messages = %d, want 3 (assistant, tool, user)", len(chat.Messages))
+	}
+	assistant := chat.Messages[0]
+	if assistant.Role != "assistant" || len(assistant.ToolCalls) != 1 {
+		t.Fatalf("assistant = %+v", assistant)
+	}
+	if assistant.ToolCalls[0].ID != "tu_1" || assistant.ToolCalls[0].Function.Name != "get_weather" {
+		t.Errorf("tool call = %+v", assistant.ToolCalls[0])
+	}
+	if assistant.ToolCalls[0].Function.Arguments != `{"city":"paris"}` {
+		t.Errorf("arguments = %q", assistant.ToolCalls[0].Function.Arguments)
+	}
+	tool := chat.Messages[1]
+	if tool.Role != "tool" || tool.ToolCallID != "tu_1" || tool.Content != "sunny" {
+		t.Errorf("tool message = %+v", tool)
+	}
+	if chat.Messages[2].Role != "user" || chat.Messages[2].Content != "thanks" {
+		t.Errorf("user message = %+v", chat.Messages[2])
+	}
+}
+
+func TestToChatRequestTools(t *testing.T) {
+	chat, err := ToChatRequest(mustDecode(t, `{
+		"model":"m","max_tokens":10,
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[{"name":"get_weather","description":"weather","input_schema":{"type":"object","properties":{}}}],
+		"tool_choice":{"type":"tool","name":"get_weather"}
+	}`))
+	if err != nil {
+		t.Fatalf("ToChatRequest: %v", err)
+	}
+	if len(chat.Tools) != 1 {
+		t.Fatalf("tools = %d", len(chat.Tools))
+	}
+	if chat.Tools[0]["type"] != "function" {
+		t.Errorf("tool type = %v", chat.Tools[0]["type"])
+	}
+	fn, _ := chat.Tools[0]["function"].(map[string]any)
+	if fn["name"] != "get_weather" || fn["parameters"] == nil {
+		t.Errorf("function = %+v", fn)
+	}
+	choice, ok := chat.ToolChoice.(map[string]any)
+	if !ok || choice["type"] != "function" {
+		t.Fatalf("tool_choice = %#v", chat.ToolChoice)
+	}
+}
+
+func TestToChatRequestToolChoiceMapping(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  any
+	}{
+		{name: "auto", input: `{"type":"auto"}`, want: "auto"},
+		{name: "any", input: `{"type":"any"}`, want: "required"},
+		{name: "none", input: `{"type":"none"}`, want: "none"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			chat, err := ToChatRequest(mustDecode(t, `{
+				"model":"m","max_tokens":10,
+				"messages":[{"role":"user","content":"hi"}],
+				"tool_choice":`+tc.input+`}`))
+			if err != nil {
+				t.Fatalf("ToChatRequest: %v", err)
+			}
+			if chat.ToolChoice != tc.want {
+				t.Errorf("ToolChoice = %#v, want %#v", chat.ToolChoice, tc.want)
+			}
+		})
+	}
+}
+
+func TestToChatRequestDisableParallelToolUse(t *testing.T) {
+	chat, err := ToChatRequest(mustDecode(t, `{
+		"model":"m","max_tokens":10,
+		"messages":[{"role":"user","content":"hi"}],
+		"tool_choice":{"type":"auto","disable_parallel_tool_use":true}
+	}`))
+	if err != nil {
+		t.Fatalf("ToChatRequest: %v", err)
+	}
+	if chat.ParallelToolCalls == nil || *chat.ParallelToolCalls {
+		t.Errorf("ParallelToolCalls = %v, want false", chat.ParallelToolCalls)
+	}
+}
+
+func TestToChatRequestThinking(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		effort string
+	}{
+		{name: "low budget", input: `{"type":"enabled","budget_tokens":5000}`, effort: "low"},
+		{name: "medium budget", input: `{"type":"enabled","budget_tokens":12000}`, effort: "medium"},
+		{name: "high budget", input: `{"type":"enabled","budget_tokens":24000}`, effort: "high"},
+		{name: "adaptive", input: `{"type":"adaptive"}`, effort: "medium"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			chat, err := ToChatRequest(mustDecode(t, `{
+				"model":"m","max_tokens":30000,
+				"messages":[{"role":"user","content":"hi"}],
+				"thinking":`+tc.input+`}`))
+			if err != nil {
+				t.Fatalf("ToChatRequest: %v", err)
+			}
+			if chat.Reasoning == nil || chat.Reasoning.Effort != tc.effort {
+				t.Errorf("Reasoning = %+v, want effort %q", chat.Reasoning, tc.effort)
+			}
+		})
+	}
+}
+
+func TestToChatRequestExtraFields(t *testing.T) {
+	chat, err := ToChatRequest(mustDecode(t, `{
+		"model":"m","max_tokens":10,
+		"messages":[{"role":"user","content":"hi"}],
+		"stop_sequences":["STOP"],"top_p":0.9,"top_k":40,
+		"metadata":{"user_id":"u-123"}
+	}`))
+	if err != nil {
+		t.Fatalf("ToChatRequest: %v", err)
+	}
+	for key, want := range map[string]string{
+		"stop":  `["STOP"]`,
+		"top_p": `0.9`,
+		"top_k": `40`,
+		"user":  `"u-123"`,
+	} {
+		raw := chat.ExtraFields.Lookup(key)
+		if string(raw) != want {
+			t.Errorf("ExtraFields[%q] = %s, want %s", key, raw, want)
+		}
+	}
+}
+
+func TestToChatRequestRejectsUnsupportedContentBlock(t *testing.T) {
+	_, err := ToChatRequest(mustDecode(t, `{
+		"model":"m","max_tokens":10,
+		"messages":[{"role":"user","content":[
+			{"type":"text","text":"summarize"},
+			{"type":"document","source":{"type":"base64","media_type":"application/pdf","data":"eA=="}}
+		]}]
+	}`))
+	if err == nil {
+		t.Fatal("expected error for unsupported document content block")
+	}
+	gatewayErr, ok := err.(*core.GatewayError)
+	if !ok || gatewayErr.Type != core.ErrorTypeInvalidRequest {
+		t.Fatalf("expected invalid_request_error, got %T: %v", err, err)
+	}
+	if !strings.Contains(gatewayErr.Message, "document") {
+		t.Errorf("error message should name the block type: %q", gatewayErr.Message)
+	}
+}
+
+func TestToChatRequestDropsThinkingBlocks(t *testing.T) {
+	// thinking blocks are assistant-side artifacts and are dropped, not rejected.
+	chat, err := ToChatRequest(mustDecode(t, `{
+		"model":"m","max_tokens":10,
+		"messages":[{"role":"assistant","content":[
+			{"type":"thinking","thinking":"hmm"},
+			{"type":"text","text":"answer"}
+		]}]
+	}`))
+	if err != nil {
+		t.Fatalf("ToChatRequest: %v", err)
+	}
+	if len(chat.Messages) != 1 || chat.Messages[0].Content != "answer" {
+		t.Fatalf("messages = %+v", chat.Messages)
+	}
+}
+
+func TestEstimateInputTokens(t *testing.T) {
+	req := mustDecode(t, `{
+		"model":"m","max_tokens":10,
+		"system":"you are helpful",
+		"messages":[{"role":"user","content":"count these characters please"}]
+	}`)
+	got := EstimateInputTokens(req)
+	if got <= 0 {
+		t.Fatalf("EstimateInputTokens = %d, want > 0", got)
+	}
+	if EstimateInputTokens(nil) != 0 {
+		t.Error("EstimateInputTokens(nil) should be 0")
+	}
+}
+
+func TestToChatRequestRoundTripsAsJSON(t *testing.T) {
+	// The translated request must marshal cleanly for the response cache key.
+	chat, err := ToChatRequest(mustDecode(t, `{
+		"model":"m","max_tokens":10,
+		"messages":[{"role":"user","content":"hi"}]
+	}`))
+	if err != nil {
+		t.Fatalf("ToChatRequest: %v", err)
+	}
+	if _, err := json.Marshal(chat); err != nil {
+		t.Fatalf("json.Marshal(chat): %v", err)
+	}
+}

--- a/internal/anthropicapi/response.go
+++ b/internal/anthropicapi/response.go
@@ -1,0 +1,140 @@
+package anthropicapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+
+	"gomodel/internal/core"
+)
+
+// FromChatResponse renders a canonical chat response in the Anthropic Messages
+// response shape.
+func FromChatResponse(resp *core.ChatResponse) *MessagesResponse {
+	out := &MessagesResponse{
+		Type:    "message",
+		Role:    "assistant",
+		Content: []ResponseContentBlock{},
+		Usage:   Usage{},
+	}
+	if resp == nil {
+		return out
+	}
+
+	out.ID = normalizeMessageID(resp.ID)
+	out.Model = resp.Model
+	out.Usage = usageFromCore(resp.Usage)
+
+	if len(resp.Choices) > 0 {
+		choice := resp.Choices[0]
+		if thinking := reasoningContent(choice.Message.ExtraFields); thinking != "" {
+			out.Content = append(out.Content, ResponseContentBlock{Type: "thinking", Thinking: thinking})
+		}
+		if text := core.ExtractTextContent(choice.Message.Content); text != "" {
+			out.Content = append(out.Content, ResponseContentBlock{Type: "text", Text: text})
+		}
+		for _, call := range choice.Message.ToolCalls {
+			out.Content = append(out.Content, ResponseContentBlock{
+				Type:  "tool_use",
+				ID:    call.ID,
+				Name:  call.Function.Name,
+				Input: argumentsToRaw(call.Function.Arguments),
+			})
+		}
+		out.StopReason = stopReasonFromFinish(choice.FinishReason, len(choice.Message.ToolCalls) > 0)
+	}
+	if out.StopReason == "" {
+		out.StopReason = "end_turn"
+	}
+	return out
+}
+
+func usageFromCore(usage core.Usage) Usage {
+	out := Usage{
+		InputTokens:  usage.PromptTokens,
+		OutputTokens: usage.CompletionTokens,
+	}
+	out.CacheCreationInputTokens = intFromRaw(usage.RawUsage["cache_creation_input_tokens"])
+	out.CacheReadInputTokens = intFromRaw(usage.RawUsage["cache_read_input_tokens"])
+	return out
+}
+
+// normalizeMessageID ensures the response carries an Anthropic-style msg_ id.
+func normalizeMessageID(id string) string {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return ""
+	}
+	if strings.HasPrefix(id, "msg_") {
+		return id
+	}
+	return "msg_" + id
+}
+
+// reasoningContent extracts the reasoning_content surfaced by providers (e.g.
+// the anthropic provider) in a response message's extra fields.
+func reasoningContent(fields core.UnknownJSONFields) string {
+	raw := fields.Lookup("reasoning_content")
+	if len(raw) == 0 {
+		return ""
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err != nil {
+		return ""
+	}
+	return text
+}
+
+// argumentsToRaw renders a tool-call arguments string as a JSON object value.
+func argumentsToRaw(arguments string) json.RawMessage {
+	trimmed := strings.TrimSpace(arguments)
+	if trimmed == "" {
+		return json.RawMessage("{}")
+	}
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, []byte(trimmed)); err != nil {
+		return json.RawMessage("{}")
+	}
+	return json.RawMessage(compact.Bytes())
+}
+
+// stopReasonFromFinish maps an OpenAI finish_reason to an Anthropic stop_reason.
+func stopReasonFromFinish(finish string, hasToolCalls bool) string {
+	switch finish {
+	case "stop":
+		return "end_turn"
+	case "length":
+		return "max_tokens"
+	case "tool_calls":
+		return "tool_use"
+	case "content_filter":
+		return "end_turn"
+	case "":
+		if hasToolCalls {
+			return "tool_use"
+		}
+		return ""
+	default:
+		return finish
+	}
+}
+
+// intFromRaw coerces a value decoded from a raw usage map into an int.
+func intFromRaw(value any) int {
+	switch v := value.(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	case json.Number:
+		n, err := v.Int64()
+		if err != nil {
+			return 0
+		}
+		return int(n)
+	default:
+		return 0
+	}
+}

--- a/internal/anthropicapi/response_test.go
+++ b/internal/anthropicapi/response_test.go
@@ -1,0 +1,142 @@
+package anthropicapi
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gomodel/internal/core"
+)
+
+func TestFromChatResponseText(t *testing.T) {
+	resp := FromChatResponse(&core.ChatResponse{
+		ID:    "abc123",
+		Model: "claude-test",
+		Choices: []core.Choice{{
+			Message:      core.ResponseMessage{Role: "assistant", Content: "hello there"},
+			FinishReason: "stop",
+		}},
+		Usage: core.Usage{PromptTokens: 12, CompletionTokens: 7},
+	})
+	if resp.ID != "msg_abc123" {
+		t.Errorf("ID = %q, want msg_abc123", resp.ID)
+	}
+	if resp.Type != "message" || resp.Role != "assistant" {
+		t.Errorf("envelope = %+v", resp)
+	}
+	if len(resp.Content) != 1 || resp.Content[0].Type != "text" || resp.Content[0].Text != "hello there" {
+		t.Fatalf("content = %+v", resp.Content)
+	}
+	if resp.StopReason != "end_turn" {
+		t.Errorf("StopReason = %q, want end_turn", resp.StopReason)
+	}
+	if resp.Usage.InputTokens != 12 || resp.Usage.OutputTokens != 7 {
+		t.Errorf("usage = %+v", resp.Usage)
+	}
+}
+
+func TestFromChatResponseToolCalls(t *testing.T) {
+	resp := FromChatResponse(&core.ChatResponse{
+		ID:    "msg_x",
+		Model: "m",
+		Choices: []core.Choice{{
+			Message: core.ResponseMessage{
+				Role: "assistant",
+				ToolCalls: []core.ToolCall{{
+					ID:       "tu_1",
+					Type:     "function",
+					Function: core.FunctionCall{Name: "get_weather", Arguments: `{"city":"paris"}`},
+				}},
+			},
+			FinishReason: "tool_calls",
+		}},
+	})
+	if len(resp.Content) != 1 || resp.Content[0].Type != "tool_use" {
+		t.Fatalf("content = %+v", resp.Content)
+	}
+	block := resp.Content[0]
+	if block.ID != "tu_1" || block.Name != "get_weather" {
+		t.Errorf("tool_use block = %+v", block)
+	}
+	if string(block.Input) != `{"city":"paris"}` {
+		t.Errorf("input = %s", block.Input)
+	}
+	if resp.StopReason != "tool_use" {
+		t.Errorf("StopReason = %q, want tool_use", resp.StopReason)
+	}
+}
+
+func TestFromChatResponseThinking(t *testing.T) {
+	thinking, _ := json.Marshal("let me think")
+	resp := FromChatResponse(&core.ChatResponse{
+		ID:    "msg_x",
+		Model: "m",
+		Choices: []core.Choice{{
+			Message: core.ResponseMessage{
+				Role:    "assistant",
+				Content: "answer",
+				ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+					"reasoning_content": thinking,
+				}),
+			},
+			FinishReason: "stop",
+		}},
+	})
+	if len(resp.Content) != 2 {
+		t.Fatalf("content = %+v, want thinking + text", resp.Content)
+	}
+	if resp.Content[0].Type != "thinking" || resp.Content[0].Thinking != "let me think" {
+		t.Errorf("thinking block = %+v", resp.Content[0])
+	}
+	if resp.Content[1].Type != "text" {
+		t.Errorf("text block = %+v", resp.Content[1])
+	}
+}
+
+func TestFromChatResponseStopReasons(t *testing.T) {
+	tests := []struct {
+		finish string
+		want   string
+	}{
+		{finish: "stop", want: "end_turn"},
+		{finish: "length", want: "max_tokens"},
+		{finish: "tool_calls", want: "tool_use"},
+		{finish: "content_filter", want: "end_turn"},
+		{finish: "", want: "end_turn"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.finish, func(t *testing.T) {
+			resp := FromChatResponse(&core.ChatResponse{
+				Choices: []core.Choice{{
+					Message:      core.ResponseMessage{Content: "x"},
+					FinishReason: tc.finish,
+				}},
+			})
+			if resp.StopReason != tc.want {
+				t.Errorf("StopReason = %q, want %q", resp.StopReason, tc.want)
+			}
+		})
+	}
+}
+
+func TestFromChatResponseCacheUsage(t *testing.T) {
+	resp := FromChatResponse(&core.ChatResponse{
+		Usage: core.Usage{
+			PromptTokens:     100,
+			CompletionTokens: 20,
+			RawUsage: map[string]any{
+				"cache_creation_input_tokens": float64(30),
+				"cache_read_input_tokens":     float64(40),
+			},
+		},
+	})
+	if resp.Usage.CacheCreationInputTokens != 30 || resp.Usage.CacheReadInputTokens != 40 {
+		t.Errorf("cache usage = %+v", resp.Usage)
+	}
+}
+
+func TestFromChatResponseNil(t *testing.T) {
+	resp := FromChatResponse(nil)
+	if resp == nil || resp.Type != "message" || resp.Content == nil {
+		t.Fatalf("FromChatResponse(nil) = %+v", resp)
+	}
+}

--- a/internal/anthropicapi/stream.go
+++ b/internal/anthropicapi/stream.go
@@ -1,0 +1,319 @@
+package anthropicapi
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+
+	"gomodel/internal/streaming"
+)
+
+// chatChunk is the subset of an OpenAI chat.completion.chunk consumed by the
+// stream converter.
+type chatChunk struct {
+	ID      string `json:"id"`
+	Model   string `json:"model"`
+	Choices []struct {
+		Delta struct {
+			Content          string              `json:"content"`
+			ReasoningContent string              `json:"reasoning_content"`
+			ToolCalls        []chatToolCallDelta `json:"tool_calls"`
+		} `json:"delta"`
+		FinishReason string `json:"finish_reason"`
+	} `json:"choices"`
+	Usage *chatUsage `json:"usage"`
+}
+
+type chatToolCallDelta struct {
+	Index    int    `json:"index"`
+	ID       string `json:"id"`
+	Function struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"function"`
+}
+
+type chatUsage struct {
+	PromptTokens             int `json:"prompt_tokens"`
+	CompletionTokens         int `json:"completion_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+	PromptTokensDetails      *struct {
+		CachedTokens int `json:"cached_tokens"`
+	} `json:"prompt_tokens_details"`
+}
+
+func (u chatUsage) cacheRead() int {
+	if u.CacheReadInputTokens > 0 {
+		return u.CacheReadInputTokens
+	}
+	if u.PromptTokensDetails != nil {
+		return u.PromptTokensDetails.CachedTokens
+	}
+	return 0
+}
+
+// NewStreamConverter wraps an OpenAI-style chat completion SSE stream and emits
+// the equivalent Anthropic Messages SSE event sequence. The returned reader
+// owns body and closes it on Close.
+func NewStreamConverter(body io.ReadCloser, model string) io.ReadCloser {
+	return &streamConverter{
+		reader:    bufio.NewReader(body),
+		body:      body,
+		model:     model,
+		buffer:    streaming.NewStreamBuffer(1024),
+		toolBlock: make(map[int]int),
+	}
+}
+
+// streamConverter is an io.ReadCloser that converts a chat SSE stream into an
+// Anthropic Messages SSE stream. It is single-reader and must not be shared.
+type streamConverter struct {
+	reader *bufio.Reader
+	body   io.ReadCloser
+	buffer streaming.StreamBuffer
+	model  string
+
+	started    bool
+	blockOpen  bool
+	blockType  string
+	curIndex   int
+	nextIndex  int
+	toolBlock  map[int]int
+	stopReason string
+	usage      chatUsage
+	finalized  bool
+	closed     bool
+}
+
+func (sc *streamConverter) Read(p []byte) (int, error) {
+	if sc.buffer.Len() > 0 {
+		return sc.buffer.Read(p), nil
+	}
+	// End-of-stream is signalled by io.EOF only. Ownership of the underlying
+	// stream stays with Close so observers (audit, usage) still fire on
+	// OnStreamClose; Read must never mark the converter closed.
+	if sc.finalized || sc.closed {
+		return 0, io.EOF
+	}
+
+	for {
+		line, err := sc.reader.ReadBytes('\n')
+		if len(bytes.TrimSpace(line)) > 0 {
+			if done := sc.consumeLine(line); done {
+				sc.finalize()
+			}
+		}
+		if err != nil {
+			if err == io.EOF {
+				sc.finalize()
+				if sc.buffer.Len() > 0 {
+					return sc.buffer.Read(p), nil
+				}
+				return 0, io.EOF
+			}
+			return 0, err
+		}
+		if sc.buffer.Len() > 0 {
+			return sc.buffer.Read(p), nil
+		}
+		if sc.finalized {
+			return 0, io.EOF
+		}
+	}
+}
+
+func (sc *streamConverter) Close() error {
+	if sc.closed {
+		return nil
+	}
+	sc.closed = true
+	sc.buffer.Release()
+	return sc.body.Close()
+}
+
+// consumeLine parses a single SSE line. It returns true when the stream's
+// terminal [DONE] sentinel is seen.
+func (sc *streamConverter) consumeLine(line []byte) (done bool) {
+	line = bytes.TrimSpace(line)
+	if !bytes.HasPrefix(line, []byte("data:")) {
+		return false
+	}
+	payload := bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
+	if bytes.Equal(payload, []byte("[DONE]")) {
+		return true
+	}
+	var chunk chatChunk
+	if err := json.Unmarshal(payload, &chunk); err != nil {
+		return false
+	}
+	sc.handleChunk(&chunk)
+	return false
+}
+
+func (sc *streamConverter) handleChunk(chunk *chatChunk) {
+	sc.ensureStarted(chunk.ID, chunk.Model)
+	if chunk.Usage != nil {
+		sc.usage = *chunk.Usage
+	}
+	for _, choice := range chunk.Choices {
+		if choice.Delta.ReasoningContent != "" {
+			sc.ensureBlock("thinking")
+			sc.emit("content_block_delta", map[string]any{
+				"type":  "content_block_delta",
+				"index": sc.curIndex,
+				"delta": map[string]any{"type": "thinking_delta", "thinking": choice.Delta.ReasoningContent},
+			})
+		}
+		if choice.Delta.Content != "" {
+			sc.ensureBlock("text")
+			sc.emit("content_block_delta", map[string]any{
+				"type":  "content_block_delta",
+				"index": sc.curIndex,
+				"delta": map[string]any{"type": "text_delta", "text": choice.Delta.Content},
+			})
+		}
+		for _, call := range choice.Delta.ToolCalls {
+			sc.handleToolCall(call)
+		}
+		if choice.FinishReason != "" {
+			sc.stopReason = stopReasonFromFinish(choice.FinishReason, len(sc.toolBlock) > 0)
+		}
+	}
+}
+
+func (sc *streamConverter) handleToolCall(call chatToolCallDelta) {
+	index, seen := sc.toolBlock[call.Index]
+	if !seen {
+		sc.closeBlock()
+		sc.openBlock("tool_use", map[string]any{
+			"type":  "tool_use",
+			"id":    call.ID,
+			"name":  call.Function.Name,
+			"input": map[string]any{},
+		})
+		sc.toolBlock[call.Index] = sc.curIndex
+		index = sc.curIndex
+	}
+	if call.Function.Arguments == "" {
+		return
+	}
+	sc.emit("content_block_delta", map[string]any{
+		"type":  "content_block_delta",
+		"index": index,
+		"delta": map[string]any{"type": "input_json_delta", "partial_json": call.Function.Arguments},
+	})
+}
+
+// ensureBlock opens a text or thinking content block, closing any block of a
+// different type that is currently open.
+func (sc *streamConverter) ensureBlock(blockType string) {
+	if sc.blockOpen && sc.blockType == blockType {
+		return
+	}
+	sc.closeBlock()
+	contentBlock := map[string]any{"type": blockType}
+	if blockType == "thinking" {
+		contentBlock["thinking"] = ""
+	} else {
+		contentBlock["text"] = ""
+	}
+	sc.openBlock(blockType, contentBlock)
+}
+
+func (sc *streamConverter) openBlock(blockType string, contentBlock map[string]any) {
+	sc.curIndex = sc.nextIndex
+	sc.nextIndex++
+	sc.blockOpen = true
+	sc.blockType = blockType
+	sc.emit("content_block_start", map[string]any{
+		"type":          "content_block_start",
+		"index":         sc.curIndex,
+		"content_block": contentBlock,
+	})
+}
+
+func (sc *streamConverter) closeBlock() {
+	if !sc.blockOpen {
+		return
+	}
+	sc.blockOpen = false
+	sc.emit("content_block_stop", map[string]any{
+		"type":  "content_block_stop",
+		"index": sc.curIndex,
+	})
+}
+
+func (sc *streamConverter) ensureStarted(id, model string) {
+	if sc.started {
+		return
+	}
+	sc.started = true
+	msgID := normalizeMessageID(id)
+	if msgID == "" {
+		msgID = "msg_stream"
+	}
+	if model == "" {
+		model = sc.model
+	}
+	sc.emit("message_start", map[string]any{
+		"type": "message_start",
+		"message": map[string]any{
+			"id":            msgID,
+			"type":          "message",
+			"role":          "assistant",
+			"model":         model,
+			"content":       []any{},
+			"stop_reason":   nil,
+			"stop_sequence": nil,
+			"usage":         map[string]any{"input_tokens": 0, "output_tokens": 0},
+		},
+	})
+}
+
+// finalize emits the closing message_delta and message_stop events exactly once.
+func (sc *streamConverter) finalize() {
+	if sc.finalized {
+		return
+	}
+	sc.finalized = true
+	sc.ensureStarted("", "")
+	sc.closeBlock()
+
+	stopReason := sc.stopReason
+	if stopReason == "" {
+		stopReason = "end_turn"
+	}
+	sc.emit("message_delta", map[string]any{
+		"type":  "message_delta",
+		"delta": map[string]any{"stop_reason": stopReason, "stop_sequence": nil},
+		"usage": sc.usagePayload(),
+	})
+	sc.emit("message_stop", map[string]any{"type": "message_stop"})
+}
+
+func (sc *streamConverter) usagePayload() map[string]any {
+	payload := map[string]any{"output_tokens": sc.usage.CompletionTokens}
+	if sc.usage.PromptTokens > 0 {
+		payload["input_tokens"] = sc.usage.PromptTokens
+	}
+	if read := sc.usage.cacheRead(); read > 0 {
+		payload["cache_read_input_tokens"] = read
+	}
+	if sc.usage.CacheCreationInputTokens > 0 {
+		payload["cache_creation_input_tokens"] = sc.usage.CacheCreationInputTokens
+	}
+	return payload
+}
+
+// emit appends a complete Anthropic SSE event to the output buffer.
+func (sc *streamConverter) emit(eventType string, payload map[string]any) {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+	sc.buffer.AppendString("event: " + eventType + "\ndata: ")
+	sc.buffer.AppendBytes(data)
+	sc.buffer.AppendString("\n\n")
+}

--- a/internal/anthropicapi/stream_test.go
+++ b/internal/anthropicapi/stream_test.go
@@ -1,0 +1,166 @@
+package anthropicapi
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+)
+
+// drainConverter runs the SSE converter over chatStream and returns the parsed
+// sequence of emitted Anthropic events (the decoded data: payloads).
+func drainConverter(t *testing.T, chatStream string) []map[string]any {
+	t.Helper()
+	conv := NewStreamConverter(io.NopCloser(strings.NewReader(chatStream)), "fallback-model")
+	defer conv.Close() //nolint:errcheck
+
+	out, err := io.ReadAll(conv)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+
+	var events []map[string]any
+	for _, block := range strings.Split(string(out), "\n\n") {
+		for _, line := range strings.Split(block, "\n") {
+			data, ok := strings.CutPrefix(line, "data: ")
+			if !ok {
+				continue
+			}
+			var payload map[string]any
+			if err := json.Unmarshal([]byte(data), &payload); err != nil {
+				t.Fatalf("unmarshal event %q: %v", data, err)
+			}
+			events = append(events, payload)
+		}
+	}
+	return events
+}
+
+func eventTypes(events []map[string]any) []string {
+	types := make([]string, len(events))
+	for i, e := range events {
+		types[i], _ = e["type"].(string)
+	}
+	return types
+}
+
+func TestStreamConverterText(t *testing.T) {
+	chatStream := strings.Join([]string{
+		`data: {"id":"chatcmpl-1","model":"gpt","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		`data: {"choices":[{"index":0,"delta":{"content":"Hel"},"finish_reason":null}]}`,
+		`data: {"choices":[{"index":0,"delta":{"content":"lo"},"finish_reason":null}]}`,
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		`data: {"choices":[],"usage":{"prompt_tokens":5,"completion_tokens":2}}`,
+		`data: [DONE]`,
+		"",
+	}, "\n\n")
+
+	events := drainConverter(t, chatStream)
+	want := []string{
+		"message_start", "content_block_start",
+		"content_block_delta", "content_block_delta",
+		"content_block_stop", "message_delta", "message_stop",
+	}
+	got := eventTypes(events)
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("event sequence = %v, want %v", got, want)
+	}
+
+	start := events[0]["message"].(map[string]any)
+	if start["id"] != "msg_chatcmpl-1" || start["model"] != "gpt" {
+		t.Errorf("message_start = %+v", start)
+	}
+
+	// content_block_delta payloads carry the text deltas.
+	d0 := events[2]["delta"].(map[string]any)
+	d1 := events[3]["delta"].(map[string]any)
+	if d0["type"] != "text_delta" || d0["text"] != "Hel" || d1["text"] != "lo" {
+		t.Errorf("text deltas = %v / %v", d0, d1)
+	}
+
+	delta := events[5]
+	if delta["delta"].(map[string]any)["stop_reason"] != "end_turn" {
+		t.Errorf("message_delta stop_reason = %+v", delta["delta"])
+	}
+	usage := delta["usage"].(map[string]any)
+	if usage["input_tokens"] != float64(5) || usage["output_tokens"] != float64(2) {
+		t.Errorf("message_delta usage = %+v", usage)
+	}
+}
+
+func TestStreamConverterToolCall(t *testing.T) {
+	chatStream := strings.Join([]string{
+		`data: {"id":"chatcmpl-2","model":"gpt","choices":[{"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"get_weather","arguments":""}}]},"finish_reason":null}]}`,
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"city\":"}}]},"finish_reason":null}]}`,
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"paris\"}"}}]},"finish_reason":null}]}`,
+		`data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":8,"completion_tokens":4}}`,
+		`data: [DONE]`,
+		"",
+	}, "\n\n")
+
+	events := drainConverter(t, chatStream)
+	want := []string{
+		"message_start", "content_block_start",
+		"content_block_delta", "content_block_delta",
+		"content_block_stop", "message_delta", "message_stop",
+	}
+	got := eventTypes(events)
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("event sequence = %v, want %v", got, want)
+	}
+
+	block := events[1]["content_block"].(map[string]any)
+	if block["type"] != "tool_use" || block["id"] != "call_1" || block["name"] != "get_weather" {
+		t.Errorf("tool_use content_block = %+v", block)
+	}
+
+	args := events[2]["delta"].(map[string]any)
+	if args["type"] != "input_json_delta" || args["partial_json"] != `{"city":` {
+		t.Errorf("input_json_delta = %+v", args)
+	}
+
+	if events[5]["delta"].(map[string]any)["stop_reason"] != "tool_use" {
+		t.Errorf("message_delta = %+v", events[5]["delta"])
+	}
+}
+
+// closeTracker records whether Close was called on the underlying stream.
+type closeTracker struct {
+	io.Reader
+	closed bool
+}
+
+func (c *closeTracker) Close() error {
+	c.closed = true
+	return nil
+}
+
+// TestStreamConverterCloseClosesUnderlying guards a regression where Read
+// marked the converter closed on EOF, making the deferred Close a no-op that
+// skipped the underlying stream — which suppressed audit/usage OnStreamClose
+// and leaked the provider connection.
+func TestStreamConverterCloseClosesUnderlying(t *testing.T) {
+	body := &closeTracker{Reader: strings.NewReader("data: [DONE]\n\n")}
+	conv := NewStreamConverter(body, "m")
+
+	if _, err := io.ReadAll(conv); err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if err := conv.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !body.closed {
+		t.Fatal("Close did not propagate to the underlying stream")
+	}
+}
+
+func TestStreamConverterEmptyStream(t *testing.T) {
+	// Even with no chunks the converter must emit a well-formed envelope.
+	events := drainConverter(t, "data: [DONE]\n\n")
+	got := eventTypes(events)
+	want := []string{"message_start", "message_delta", "message_stop"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("event sequence = %v, want %v", got, want)
+	}
+}

--- a/internal/anthropicapi/types.go
+++ b/internal/anthropicapi/types.go
@@ -64,8 +64,11 @@ type Source struct {
 	URL       string `json:"url,omitempty"`
 }
 
-// Tool is an Anthropic custom tool definition.
+// Tool is an Anthropic tool definition. A custom tool has no Type (or Type
+// "custom"); a server/built-in tool (web search, code execution, …) carries a
+// versioned Type and is rejected during translation — see convertTools.
 type Tool struct {
+	Type        string          `json:"type,omitempty"`
 	Name        string          `json:"name"`
 	Description string          `json:"description,omitempty"`
 	InputSchema json.RawMessage `json:"input_schema,omitempty"`

--- a/internal/anthropicapi/types.go
+++ b/internal/anthropicapi/types.go
@@ -1,0 +1,132 @@
+// Package anthropicapi translates the Anthropic Messages API dialect to and from
+// GoModel's canonical chat types. It is an ingress concern: it accepts the
+// Anthropic wire format from clients and renders responses back in that format,
+// independent of which provider ultimately serves the request.
+package anthropicapi
+
+import "encoding/json"
+
+// MessagesRequest is the Anthropic Messages API request body.
+// System and message content fields are polymorphic on the wire (string or
+// array), so they are kept raw and decoded in request.go.
+type MessagesRequest struct {
+	Model         string          `json:"model"`
+	Messages      []Message       `json:"messages"`
+	MaxTokens     int             `json:"max_tokens"`
+	System        json.RawMessage `json:"system,omitempty"`
+	Metadata      *Metadata       `json:"metadata,omitempty"`
+	StopSequences []string        `json:"stop_sequences,omitempty"`
+	Stream        bool            `json:"stream,omitempty"`
+	Temperature   *float64        `json:"temperature,omitempty"`
+	TopP          *float64        `json:"top_p,omitempty"`
+	TopK          *int            `json:"top_k,omitempty"`
+	Tools         []Tool          `json:"tools,omitempty"`
+	ToolChoice    *ToolChoice     `json:"tool_choice,omitempty"`
+	Thinking      *Thinking       `json:"thinking,omitempty"`
+}
+
+// Metadata carries the optional Anthropic request metadata object.
+type Metadata struct {
+	UserID string `json:"user_id,omitempty"`
+}
+
+// Message is a single Anthropic conversation message. Content is a string or an
+// array of ContentBlock values.
+type Message struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"`
+}
+
+// ContentBlock is one element of an Anthropic message content array. The struct
+// is a union; only the fields relevant to Type are populated.
+type ContentBlock struct {
+	Type string `json:"type"`
+	// text / thinking
+	Text     string `json:"text,omitempty"`
+	Thinking string `json:"thinking,omitempty"`
+	// image
+	Source *Source `json:"source,omitempty"`
+	// tool_use
+	ID    string          `json:"id,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
+	// tool_result
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	Content   json.RawMessage `json:"content,omitempty"`
+	IsError   bool            `json:"is_error,omitempty"`
+}
+
+// Source describes an Anthropic image source (base64 inline data or a URL).
+type Source struct {
+	Type      string `json:"type"`
+	MediaType string `json:"media_type,omitempty"`
+	Data      string `json:"data,omitempty"`
+	URL       string `json:"url,omitempty"`
+}
+
+// Tool is an Anthropic custom tool definition.
+type Tool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	InputSchema json.RawMessage `json:"input_schema,omitempty"`
+}
+
+// ToolChoice constrains how the model selects tools.
+type ToolChoice struct {
+	Type                   string `json:"type"`
+	Name                   string `json:"name,omitempty"`
+	DisableParallelToolUse *bool  `json:"disable_parallel_tool_use,omitempty"`
+}
+
+// Thinking is the Anthropic extended-thinking configuration.
+type Thinking struct {
+	Type         string `json:"type"`
+	BudgetTokens int    `json:"budget_tokens,omitempty"`
+}
+
+// MessagesResponse is the Anthropic Messages API response body.
+type MessagesResponse struct {
+	ID           string                 `json:"id"`
+	Type         string                 `json:"type"`
+	Role         string                 `json:"role"`
+	Model        string                 `json:"model"`
+	Content      []ResponseContentBlock `json:"content"`
+	StopReason   string                 `json:"stop_reason"`
+	StopSequence *string                `json:"stop_sequence"`
+	Usage        Usage                  `json:"usage"`
+}
+
+// ResponseContentBlock is one element of an Anthropic response content array.
+type ResponseContentBlock struct {
+	Type     string          `json:"type"`
+	Text     string          `json:"text,omitempty"`
+	Thinking string          `json:"thinking,omitempty"`
+	ID       string          `json:"id,omitempty"`
+	Name     string          `json:"name,omitempty"`
+	Input    json.RawMessage `json:"input,omitempty"`
+}
+
+// Usage reports Anthropic-style token usage.
+type Usage struct {
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens,omitempty"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty"`
+}
+
+// CountTokensResponse is the Anthropic /v1/messages/count_tokens response body.
+type CountTokensResponse struct {
+	InputTokens int `json:"input_tokens"`
+}
+
+// ErrorResponse is the Anthropic error envelope.
+type ErrorResponse struct {
+	Type  string      `json:"type"`
+	Error ErrorObject `json:"error"`
+}
+
+// ErrorObject is the inner error detail of an Anthropic error envelope.
+type ErrorObject struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}

--- a/internal/core/endpoints.go
+++ b/internal/core/endpoints.go
@@ -75,6 +75,16 @@ func describeEndpointPath(path string) EndpointDescriptor {
 			Dialect:          "openai_compat",
 			Operation:        OperationEmbeddings,
 		}
+	case path == "/v1/messages" || path == "/v1/messages/count_tokens":
+		// Anthropic Messages dialect. It is translated to the canonical chat
+		// type at ingress and runs through the chat-completions pipeline, so it
+		// is classified as a chat-completions operation (see ADR-0007).
+		return EndpointDescriptor{
+			ModelInteraction: true,
+			IngressManaged:   true,
+			Dialect:          "anthropic",
+			Operation:        OperationChatCompletions,
+		}
 	case path == "/v1/batches" || strings.HasPrefix(path, "/v1/batches/"):
 		return EndpointDescriptor{
 			ModelInteraction: true,

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -1306,6 +1307,37 @@ func TestConvertToAnthropicRequest(t *testing.T) {
 				t.Fatalf("convertToAnthropicRequest() error = %v", err)
 			}
 			tt.checkFn(t, result)
+		})
+	}
+}
+
+func TestConvertToAnthropicRequest_MapsStopSequences(t *testing.T) {
+	tests := []struct {
+		name string
+		stop string
+		want []string
+	}{
+		{name: "array", stop: `["FOO","BAR"]`, want: []string{"FOO", "BAR"}},
+		{name: "single string", stop: `"END"`, want: []string{"END"}},
+		{name: "empty entries dropped", stop: `["",""]`, want: nil},
+		{name: "null", stop: `null`, want: nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &core.ChatRequest{
+				Model:    "claude-sonnet-4-5-20250929",
+				Messages: []core.Message{{Role: "user", Content: "hi"}},
+				ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+					"stop": json.RawMessage(tt.stop),
+				}),
+			}
+			result, err := convertToAnthropicRequest(req)
+			if err != nil {
+				t.Fatalf("convertToAnthropicRequest() error = %v", err)
+			}
+			if !slices.Equal(result.StopSequences, tt.want) {
+				t.Errorf("StopSequences = %v, want %v", result.StopSequences, tt.want)
+			}
 		})
 	}
 }

--- a/internal/providers/anthropic/request_translation.go
+++ b/internal/providers/anthropic/request_translation.go
@@ -285,10 +285,11 @@ func convertToAnthropicRequest(req *core.ChatRequest) (*anthropicRequest, error)
 	}
 
 	anthropicReq := &anthropicRequest{
-		Model:       req.Model,
-		Messages:    make([]anthropicMessage, 0, len(req.Messages)),
-		Temperature: req.Temperature,
-		Stream:      req.Stream,
+		Model:         req.Model,
+		Messages:      make([]anthropicMessage, 0, len(req.Messages)),
+		Temperature:   req.Temperature,
+		Stream:        req.Stream,
+		StopSequences: stopSequencesFromExtra(req.ExtraFields),
 	}
 
 	if req.MaxTokens != nil {
@@ -526,6 +527,42 @@ func anthropicCacheControlFromExtra(extraFields core.UnknownJSONFields) (json.Ra
 		return nil, core.NewInvalidRequestError("anthropic cache_control must be an object", nil)
 	}
 	return core.CloneRawJSON(trimmed), nil
+}
+
+// stopSequencesFromExtra maps the OpenAI-compatible stop field (a string or an
+// array of strings, carried in the request's extra fields) to Anthropic's
+// stop_sequences. Empty or malformed values yield no sequences.
+func stopSequencesFromExtra(extraFields core.UnknownJSONFields) []string {
+	raw := bytes.TrimSpace(extraFields.Lookup("stop"))
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return nil
+	}
+
+	switch raw[0] {
+	case '"':
+		var single string
+		if err := json.Unmarshal(raw, &single); err != nil || single == "" {
+			return nil
+		}
+		return []string{single}
+	case '[':
+		var list []string
+		if err := json.Unmarshal(raw, &list); err != nil {
+			return nil
+		}
+		sequences := make([]string, 0, len(list))
+		for _, item := range list {
+			if item != "" {
+				sequences = append(sequences, item)
+			}
+		}
+		if len(sequences) == 0 {
+			return nil
+		}
+		return sequences
+	default:
+		return nil
+	}
 }
 
 func convertMessageContentToAnthropic(content any) (any, error) {

--- a/internal/providers/anthropic/types.go
+++ b/internal/providers/anthropic/types.go
@@ -17,16 +17,17 @@ type anthropicOutputConfig struct {
 
 // anthropicRequest represents the Anthropic API request format
 type anthropicRequest struct {
-	Model        string                 `json:"model"`
-	Messages     []anthropicMessage     `json:"messages"`
-	Tools        []anthropicTool        `json:"tools,omitempty"`
-	ToolChoice   *anthropicToolChoice   `json:"tool_choice,omitempty"`
-	MaxTokens    int                    `json:"max_tokens"`
-	Temperature  *float64               `json:"temperature,omitempty"`
-	System       any                    `json:"system,omitempty"`
-	Stream       bool                   `json:"stream,omitempty"`
-	Thinking     *anthropicThinking     `json:"thinking,omitempty"`
-	OutputConfig *anthropicOutputConfig `json:"output_config,omitempty"`
+	Model         string                 `json:"model"`
+	Messages      []anthropicMessage     `json:"messages"`
+	Tools         []anthropicTool        `json:"tools,omitempty"`
+	ToolChoice    *anthropicToolChoice   `json:"tool_choice,omitempty"`
+	MaxTokens     int                    `json:"max_tokens"`
+	Temperature   *float64               `json:"temperature,omitempty"`
+	System        any                    `json:"system,omitempty"`
+	Stream        bool                   `json:"stream,omitempty"`
+	StopSequences []string               `json:"stop_sequences,omitempty"`
+	Thinking      *anthropicThinking     `json:"thinking,omitempty"`
+	OutputConfig  *anthropicOutputConfig `json:"output_config,omitempty"`
 }
 
 type anthropicTool struct {

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -59,14 +59,14 @@ func AuthMiddlewareWithAuthenticator(masterKey string, authenticator BearerToken
 			authHeader := c.Request().Header.Get("Authorization")
 			if authHeader == "" {
 				authErr := authenticationError(c, "missing authorization header")
-				return c.JSON(authErr.HTTPStatusCode(), authErr.ToJSON())
+				return writeGatewayError(c, authErr)
 			}
 
 			// Extract Bearer token
 			const prefix = "Bearer "
 			if !strings.HasPrefix(authHeader, prefix) {
 				authErr := authenticationError(c, "invalid authorization header format, expected 'Bearer <token>'")
-				return c.JSON(authErr.HTTPStatusCode(), authErr.ToJSON())
+				return writeGatewayError(c, authErr)
 			}
 
 			token := strings.TrimPrefix(authHeader, prefix)
@@ -95,11 +95,11 @@ func AuthMiddlewareWithAuthenticator(masterKey string, authenticator BearerToken
 				}
 
 				authErr := authenticationErrorWithAudit(c, authFailureMessage(err), "authentication failed")
-				return c.JSON(authErr.HTTPStatusCode(), authErr.ToJSON())
+				return writeGatewayError(c, authErr)
 			}
 
 			authErr := authenticationError(c, "invalid master key")
-			return c.JSON(authErr.HTTPStatusCode(), authErr.ToJSON())
+			return writeGatewayError(c, authErr)
 		}
 	}
 }

--- a/internal/server/error_support.go
+++ b/internal/server/error_support.go
@@ -7,23 +7,42 @@ import (
 
 	"github.com/labstack/echo/v5"
 
+	"gomodel/internal/anthropicapi"
 	"gomodel/internal/auditlog"
 	"gomodel/internal/core"
 )
 
-// handleError converts gateway errors to appropriate HTTP responses.
+// handleError converts gateway errors to an HTTP response, rendered in the wire
+// dialect of the request path (Anthropic envelope for /v1/messages, otherwise
+// the OpenAI-compatible envelope).
 func handleError(c *echo.Context, err error) error {
-	if gatewayErr, ok := errors.AsType[*core.GatewayError](err); ok {
-		logHandledError(c, gatewayErr)
-		auditlog.EnrichEntryWithError(c, string(gatewayErr.Type), gatewayErr.Message, gatewayErrorCode(gatewayErr))
-		applyErrorResponseHeaders(c, err)
-		return c.JSON(gatewayErr.HTTPStatusCode(), gatewayErr.ToJSON())
+	gatewayErr, ok := errors.AsType[*core.GatewayError](err)
+	if !ok {
+		gatewayErr = core.NewProviderError("", http.StatusInternalServerError, "an unexpected error occurred", err)
 	}
-
-	gatewayErr := core.NewProviderError("", http.StatusInternalServerError, "an unexpected error occurred", err)
 	logHandledError(c, gatewayErr)
 	auditlog.EnrichEntryWithError(c, string(gatewayErr.Type), gatewayErr.Message, gatewayErrorCode(gatewayErr))
+	applyErrorResponseHeaders(c, err)
+	return writeGatewayError(c, gatewayErr)
+}
+
+// writeGatewayError renders a gateway error in the request's wire dialect
+// without logging or audit enrichment, for callers that already recorded it.
+func writeGatewayError(c *echo.Context, gatewayErr *core.GatewayError) error {
+	if requestDialect(c) == "anthropic" {
+		status, body := anthropicapi.ErrorFromGateway(gatewayErr)
+		return c.JSON(status, body)
+	}
 	return c.JSON(gatewayErr.HTTPStatusCode(), gatewayErr.ToJSON())
+}
+
+// requestDialect reports the ingress wire dialect classified for the request
+// path (e.g. "anthropic", "openai_compat"), or "" when unclassified.
+func requestDialect(c *echo.Context) string {
+	if c == nil || c.Request() == nil {
+		return ""
+	}
+	return core.DescribeEndpointPath(c.Request().URL.Path).Dialect
 }
 
 type responseHeaderError interface {

--- a/internal/server/error_support_test.go
+++ b/internal/server/error_support_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -14,6 +15,54 @@ import (
 	"gomodel/internal/auditlog"
 	"gomodel/internal/core"
 )
+
+func TestHandleError_RendersDialectSpecificEnvelope(t *testing.T) {
+	tests := []struct {
+		name          string
+		path          string
+		wantAnthropic bool
+	}{
+		{name: "anthropic dialect", path: "/v1/messages", wantAnthropic: true},
+		{name: "anthropic count_tokens", path: "/v1/messages/count_tokens", wantAnthropic: true},
+		{name: "openai dialect", path: "/v1/chat/completions", wantAnthropic: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, tc.path, nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			_ = handleError(c, core.NewInvalidRequestError("bad input", nil))
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", rec.Code)
+			}
+			var body map[string]any
+			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			// Anthropic envelope: {"type":"error","error":{...}}.
+			// OpenAI envelope:    {"error":{...}} with no top-level "type".
+			if tc.wantAnthropic {
+				if body["type"] != "error" {
+					t.Errorf("expected Anthropic envelope, got %v", body)
+				}
+				errObj, _ := body["error"].(map[string]any)
+				if errObj["type"] != "invalid_request_error" {
+					t.Errorf("error.type = %v", errObj["type"])
+				}
+			} else {
+				if _, hasType := body["type"]; hasType {
+					t.Errorf("expected OpenAI envelope without top-level type, got %v", body)
+				}
+				if _, hasErr := body["error"]; !hasErr {
+					t.Errorf("expected OpenAI error envelope, got %v", body)
+				}
+			}
+		})
+	}
+}
 
 func TestHandleError_LogsClientErrorsAtWarnLevel(t *testing.T) {
 	var buf bytes.Buffer

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -301,6 +301,8 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 	}
 	e.GET("/v1/models", handler.ListModels)
 	e.POST("/v1/chat/completions", handler.ChatCompletion)
+	e.POST("/v1/messages", handler.Messages)
+	e.POST("/v1/messages/count_tokens", handler.CountMessageTokens)
 	e.POST("/v1/responses/input_tokens", handler.ResponseInputTokens)
 	e.POST("/v1/responses/compact", handler.CompactResponse)
 	e.GET("/v1/responses/:id/input_items", handler.ListResponseInputItems)

--- a/internal/server/messages_handler.go
+++ b/internal/server/messages_handler.go
@@ -1,0 +1,153 @@
+package server
+
+import (
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v5"
+
+	"gomodel/internal/anthropicapi"
+	"gomodel/internal/auditlog"
+	"gomodel/internal/core"
+)
+
+// Messages handles POST /v1/messages.
+//
+// It accepts the Anthropic Messages API request dialect, translates it to the
+// canonical chat request, and runs it through the standard chat-completions
+// pipeline so it routes to any configured provider with full workflow, budget,
+// failover, cache, usage, and audit support. See ADR-0007.
+//
+// @Summary      Create a message (Anthropic Messages API)
+// @Tags         messages
+// @Accept       json
+// @Produce      json
+// @Produce      text/event-stream
+// @Security     BearerAuth
+// @Param        request  body      anthropicapi.MessagesRequest  true  "Anthropic Messages request"
+// @Success      200      {object}  anthropicapi.MessagesResponse  "JSON response or SSE stream when stream=true"
+// @Failure      400      {object}  anthropicapi.ErrorResponse
+// @Failure      401      {object}  anthropicapi.ErrorResponse
+// @Failure      429      {object}  anthropicapi.ErrorResponse
+// @Failure      502      {object}  anthropicapi.ErrorResponse
+// @Router       /v1/messages [post]
+func (h *Handler) Messages(c *echo.Context) error {
+	return h.translatedInference().Messages(c)
+}
+
+// CountMessageTokens handles POST /v1/messages/count_tokens.
+//
+// @Summary      Count message tokens (Anthropic Messages API)
+// @Description  Returns a provider-agnostic heuristic estimate of the input token count.
+// @Tags         messages
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        request  body      anthropicapi.MessagesRequest  true  "Anthropic Messages request"
+// @Success      200      {object}  anthropicapi.CountTokensResponse
+// @Failure      400      {object}  anthropicapi.ErrorResponse
+// @Failure      401      {object}  anthropicapi.ErrorResponse
+// @Router       /v1/messages/count_tokens [post]
+func (h *Handler) CountMessageTokens(c *echo.Context) error {
+	return h.translatedInference().CountMessageTokens(c)
+}
+
+// Messages translates an Anthropic Messages request and dispatches it through
+// the shared chat-completions pipeline (workflow resolution, response cache).
+func (s *translatedInferenceService) Messages(c *echo.Context) error {
+	req, err := decodeMessagesChatRequest(c)
+	if err != nil {
+		return handleError(c, err)
+	}
+
+	ctx, prepared, workflow, err := prepareChatCompletionRequest(s, c.Request().Context(), req, translatedRequestMeta(c))
+	if err != nil {
+		return handleError(c, err)
+	}
+	attachPreparedWorkflow(c, ctx, workflow)
+
+	return handleWithCache(s, c, prepared, workflow, s.dispatchMessages)
+}
+
+// CountMessageTokens returns a heuristic input token estimate for a Messages
+// request. It performs no provider call (see ADR-0007).
+func (s *translatedInferenceService) CountMessageTokens(c *echo.Context) error {
+	body, err := requestBodyBytes(c)
+	if err != nil {
+		return handleError(c, core.NewInvalidRequestError("invalid request body: "+err.Error(), err))
+	}
+	req, err := anthropicapi.DecodeMessagesRequest(body)
+	if err != nil {
+		return handleError(c, core.NewInvalidRequestError("invalid request body: "+err.Error(), err))
+	}
+	if strings.TrimSpace(req.Model) == "" {
+		return handleError(c, core.NewInvalidRequestError("model is required", nil).WithParam("model"))
+	}
+	return c.JSON(http.StatusOK, anthropicapi.CountTokensResponse{
+		InputTokens: anthropicapi.EstimateInputTokens(req),
+	})
+}
+
+func (s *translatedInferenceService) dispatchMessages(c *echo.Context, req *core.ChatRequest, workflow *core.Workflow) error {
+	ctx := c.Request().Context()
+	requestID := requestIDFromContextOrHeader(c.Request())
+
+	if err := enforceBudget(c, s.budgetChecker); err != nil {
+		return handleError(c, err)
+	}
+
+	if req.Stream {
+		result, err := s.inference().StreamChatCompletion(ctx, workflow, req)
+		if err != nil {
+			return handleStreamingDispatchError(c, err)
+		}
+		if result.Meta.UsedFallback {
+			markRequestFallbackUsed(c)
+		}
+		model := result.Meta.Model
+		return s.handleStreamingReadCloser(
+			c,
+			workflow,
+			model,
+			result.Meta.ProviderType,
+			result.Meta.ProviderName,
+			result.Meta.FailoverModel,
+			result.Stream,
+			func(stream io.ReadCloser) io.ReadCloser {
+				return anthropicapi.NewStreamConverter(stream, model)
+			},
+		)
+	}
+
+	result, err := s.inference().ExecuteChatCompletion(ctx, workflow, req, requestID, "/v1/messages")
+	if err != nil {
+		return handleError(c, err)
+	}
+	if result.Meta.UsedFallback {
+		markRequestFallbackUsed(c)
+		auditlog.EnrichEntryWithFailover(c, result.Meta.FailoverModel)
+	}
+	auditlog.EnrichEntryWithResolvedRoute(
+		c,
+		qualifyExecutedModel(workflow, result.Response.Model, result.Meta.ProviderName),
+		result.Meta.ProviderType,
+		result.Meta.ProviderName,
+	)
+
+	return c.JSON(http.StatusOK, anthropicapi.FromChatResponse(result.Response))
+}
+
+// decodeMessagesChatRequest reads the request body, decodes the Anthropic
+// Messages request, and translates it to the canonical chat request.
+func decodeMessagesChatRequest(c *echo.Context) (*core.ChatRequest, error) {
+	body, err := requestBodyBytes(c)
+	if err != nil {
+		return nil, core.NewInvalidRequestError("invalid request body: "+err.Error(), err)
+	}
+	req, err := anthropicapi.DecodeMessagesRequest(body)
+	if err != nil {
+		return nil, core.NewInvalidRequestError("invalid request body: "+err.Error(), err)
+	}
+	return anthropicapi.ToChatRequest(req)
+}

--- a/internal/server/messages_handler_test.go
+++ b/internal/server/messages_handler_test.go
@@ -1,0 +1,183 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+
+	"gomodel/internal/core"
+)
+
+func TestMessages_NonStreaming(t *testing.T) {
+	provider := &capturingProvider{
+		mockProvider: mockProvider{
+			supportedModels: []string{"claude-test"},
+			response: &core.ChatResponse{
+				ID:     "resp-1",
+				Object: "chat.completion",
+				Model:  "claude-test",
+				Choices: []core.Choice{{
+					Index:        0,
+					Message:      core.ResponseMessage{Role: "assistant", Content: "Hello back"},
+					FinishReason: "stop",
+				}},
+				Usage: core.Usage{PromptTokens: 9, CompletionTokens: 3, TotalTokens: 12},
+			},
+		},
+	}
+
+	e := echo.New()
+	handler := NewHandler(provider, nil, nil, nil)
+
+	reqBody := `{"model":"claude-test","max_tokens":64,"system":"be brief","messages":[{"role":"user","content":"Hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	if err := handler.Messages(e.NewContext(req, rec)); err != nil {
+		t.Fatalf("Messages: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp["type"] != "message" || resp["role"] != "assistant" {
+		t.Errorf("envelope = %+v", resp)
+	}
+	content, _ := resp["content"].([]any)
+	if len(content) != 1 {
+		t.Fatalf("content = %+v", resp["content"])
+	}
+	block, _ := content[0].(map[string]any)
+	if block["type"] != "text" || block["text"] != "Hello back" {
+		t.Errorf("content block = %+v", block)
+	}
+	if resp["stop_reason"] != "end_turn" {
+		t.Errorf("stop_reason = %v", resp["stop_reason"])
+	}
+
+	// The Anthropic request must have been translated to the canonical chat type.
+	if provider.capturedChatReq == nil {
+		t.Fatal("provider did not receive a chat request")
+	}
+	msgs := provider.capturedChatReq.Messages
+	if len(msgs) != 2 || msgs[0].Role != "system" || msgs[1].Role != "user" {
+		t.Fatalf("translated messages = %+v", msgs)
+	}
+}
+
+func TestMessages_Streaming(t *testing.T) {
+	chatSSE := strings.Join([]string{
+		`data: {"id":"resp-2","model":"claude-test","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		`data: {"choices":[{"index":0,"delta":{"content":"Hi!"},"finish_reason":null}]}`,
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"completion_tokens":1}}`,
+		`data: [DONE]`,
+		"",
+	}, "\n\n")
+
+	provider := &capturingProvider{
+		mockProvider: mockProvider{
+			supportedModels: []string{"claude-test"},
+			streamData:      chatSSE,
+		},
+	}
+
+	e := echo.New()
+	handler := NewHandler(provider, nil, nil, nil)
+
+	reqBody := `{"model":"claude-test","max_tokens":64,"stream":true,"messages":[{"role":"user","content":"Hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	if err := handler.Messages(e.NewContext(req, rec)); err != nil {
+		t.Fatalf("Messages: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		"event: message_start",
+		"event: content_block_start",
+		`"text_delta"`,
+		"event: message_delta",
+		"event: message_stop",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("stream missing %q\n%s", want, body)
+		}
+	}
+	// include_usage must be set so the converter sees the final usage chunk.
+	if provider.capturedChatReq == nil || provider.capturedChatReq.StreamOptions == nil ||
+		!provider.capturedChatReq.StreamOptions.IncludeUsage {
+		t.Error("translated stream request did not request usage")
+	}
+}
+
+func TestMessages_InvalidRequestReturnsAnthropicError(t *testing.T) {
+	provider := &mockProvider{supportedModels: []string{"claude-test"}}
+	e := echo.New()
+	handler := NewHandler(provider, nil, nil, nil)
+
+	// max_tokens is required by the Anthropic dialect.
+	reqBody := `{"model":"claude-test","messages":[{"role":"user","content":"Hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	if err := handler.Messages(e.NewContext(req, rec)); err != nil {
+		t.Fatalf("Messages: %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp["type"] != "error" {
+		t.Fatalf("response is not an Anthropic error envelope: %+v", resp)
+	}
+	errObj, _ := resp["error"].(map[string]any)
+	if errObj["type"] != "invalid_request_error" {
+		t.Errorf("error type = %v, want invalid_request_error", errObj["type"])
+	}
+}
+
+func TestCountMessageTokens(t *testing.T) {
+	provider := &mockProvider{supportedModels: []string{"claude-test"}}
+	e := echo.New()
+	handler := NewHandler(provider, nil, nil, nil)
+
+	reqBody := `{"model":"claude-test","max_tokens":64,"messages":[{"role":"user","content":"count these tokens please"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	if err := handler.CountMessageTokens(e.NewContext(req, rec)); err != nil {
+		t.Fatalf("CountMessageTokens: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	tokens, ok := resp["input_tokens"].(float64)
+	if !ok || tokens <= 0 {
+		t.Errorf("input_tokens = %v, want > 0", resp["input_tokens"])
+	}
+}

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -108,6 +108,7 @@ func (s *translatedInferenceService) dispatchChatCompletion(c *echo.Context, req
 			result.Meta.ProviderName,
 			result.Meta.FailoverModel,
 			result.Stream,
+			nil,
 		)
 	}
 
@@ -251,6 +252,7 @@ func (s *translatedInferenceService) dispatchResponses(c *echo.Context, req *cor
 			result.Meta.ProviderName,
 			result.Meta.FailoverModel,
 			result.Stream,
+			nil,
 		)
 	}
 
@@ -435,12 +437,18 @@ func cacheWorkflowResolutionHints(c *echo.Context, workflow *core.Workflow) {
 	}
 }
 
+// handleStreamingReadCloser flushes a provider SSE stream to the client while
+// fanning audit and usage observers off the canonical (OpenAI-shaped) stream.
+// outerWrap, when non-nil, wraps the observed stream as the outermost layer —
+// used by the Anthropic /v1/messages dialect to re-encode the SSE events after
+// the observers have already seen the canonical form.
 func (s *translatedInferenceService) handleStreamingReadCloser(
 	c *echo.Context,
 	workflow *core.Workflow,
 	model, provider, providerName string,
 	failoverModel string,
 	stream io.ReadCloser,
+	outerWrap func(io.ReadCloser) io.ReadCloser,
 ) error {
 	auditlog.MarkEntryAsStreaming(c, true)
 	auditlog.EnrichEntryWithStream(c, true)
@@ -471,6 +479,9 @@ func (s *translatedInferenceService) handleStreamingReadCloser(
 		}
 	}
 	wrappedStream := streaming.NewObservedSSEStream(stream, observers...)
+	if outerWrap != nil {
+		wrappedStream = outerWrap(wrappedStream)
+	}
 
 	defer func() {
 		_ = wrappedStream.Close() //nolint:errcheck
@@ -501,7 +512,7 @@ func (s *translatedInferenceService) handleStreamingResponse(
 	if err != nil {
 		return handleStreamingDispatchError(c, err)
 	}
-	return s.handleStreamingReadCloser(c, workflow, model, provider, providerName, "", stream)
+	return s.handleStreamingReadCloser(c, workflow, model, provider, providerName, "", stream, nil)
 }
 
 // handleStreamingDispatchError records audit context for a streaming request


### PR DESCRIPTION
## Summary

Adds a managed `POST /v1/messages` endpoint (plus `POST /v1/messages/count_tokens`) that accepts the **Anthropic Messages API** request dialect and routes it to **any** configured provider — not just Anthropic.

The Anthropic request is translated once at the ingress boundary into the canonical `core.ChatRequest`, then runs through the **unchanged** chat-completions pipeline. Model aliases, workflow policy, budgets, failover, the response cache, usage/cost tracking, and audit logging all apply — with **zero changes** to `gateway`, `providers`, `usage`, or `auditlog`.

This mirrors the existing `/v1/responses` ingress dialect. See [ADR-0007](docs/adr/0007-anthropic-messages-ingress.md) for the full rationale and tradeoffs.

## User-visible impact

- Clients and SDKs that speak the Anthropic Messages format can point at GoModel unchanged.
- Anthropic-format requests can be routed to OpenAI, Gemini, Bedrock, Groq, and any other configured provider.
- Responses use the Anthropic Messages shape (`type: "message"`, `content` blocks, `stop_reason`, `usage`); errors use the Anthropic error envelope (`{"type":"error","error":{...}}`).
- Streaming emits the Anthropic SSE sequence (`message_start` / `content_block_*` / `message_delta` / `message_stop`).
- The OpenAI-compatible API is unchanged — `/v1/chat/completions` still returns the OpenAI shape.

## What's included

- New isolated `internal/anthropicapi` package: wire DTOs, request/response translation, OpenAI→Anthropic SSE stream conversion, error-envelope mapping.
- Thin HTTP glue in `internal/server/messages_handler.go`; routes registered in `http.go`, classified in `core/endpoints.go` (dialect `anthropic`).
- `count_tokens` returns a provider-agnostic heuristic input-token estimate.
- `handleError` is now dialect-aware (`writeGatewayError`) so middleware errors (auth, workflow resolution) also render the Anthropic envelope.

## Provider-specific behavior

- Maps OpenAI `stop` → Anthropic `stop_sequences` in the **anthropic provider** request translation. This also fixes a pre-existing gap where `stop` was dropped for `/v1/chat/completions` routed to Anthropic.
- A `/v1/messages` request routed *to* the Anthropic provider is lossy (`cache_control`, thinking signatures, server tools do not survive the canonical hop) — clients needing byte-exact fidelity should use the `/p/anthropic/v1/messages` passthrough.

## Bugs found during live testing (and fixed)

Tested extensively with curl against real provider keys (Anthropic, OpenAI, Groq, Gemini): non-streaming, streaming, function calling (incl. multi-turn `tool_result`), multimodal images, extended thinking, `count_tokens`, error cases, response cache, cost tracking, audit logs.

1. **Middleware errors rendered the OpenAI envelope on `/v1/messages`** — auth/bad-model errors bypass the handler. Fixed via dialect-aware `handleError`; let us delete the duplicate error helpers.
2. **`stop_sequences` silently dropped** when routed to the Anthropic provider — the provider never read `stop`. Fixed (see above).
3. **Unsupported content blocks (`document`/PDF) silently dropped** — the model answered as if no attachment was sent. Now returns a clear `400`.
4. **Streaming converter never closed the underlying stream** — `Read()` set `closed=true` on EOF, so `Close()` skipped `body.Close()` → no audit log, no usage/cost record, leaked provider connection. Fixed so `Close` always propagates.

## Testing

- `go build ./...` ✓ · full `go test ./...` ✓ · `golangci-lint` 0 issues · `gofmt` clean · `make test-race` ✓ (pre-commit).
- Regression tests added: stream-close propagation, dialect-aware error rendering, unsupported-block rejection, thinking-block drop, `stop_sequences` mapping.
- Verified via direct DB inspection: streaming `/v1/messages` records usage rows (with cost) and `stream=1` audit rows; cache hits recorded at `0.000000` with `cache_type=exact`.

## Docs

- New ADR-0007 and a docs page (`docs/advanced/anthropic-messages-api.mdx`) with nav entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Anthropic Messages API endpoints: POST /v1/messages (Anthropic-shaped requests routed into the platform chat pipeline) and POST /v1/messages/count_tokens (provider-agnostic token estimate).
  * Anthropic-style SSE streaming output and dialect-specific error envelopes.

* **Documentation**
  * Added ADR and advanced guide detailing behavior, streaming event sequence, cost/audit attribution, known limitations, and a byte-exact passthrough option.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ENTERPILOT/GoModel/pull/343?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->