### PR TITLE
fix(providers): support OpenRouter virtual model IDs

### DIFF
--- a/internal/pricingoverrides/resolver.go
+++ b/internal/pricingoverrides/resolver.go
@@ -12,11 +12,15 @@ func (s *Service) ResolvePricing(model, providerName string) *core.ModelPricing 
 		return nil
 	}
 	providerName = strings.TrimSpace(providerName)
-	model = modelIDFromSelector(model, providerName)
+	rawModel := strings.TrimSpace(model)
+	model = modelIDFromSelector(rawModel, providerName)
 
 	var basePricing *core.ModelPricing
 	if s.base != nil {
 		basePricing = s.base.ResolvePricing(model, providerName)
+		if basePricing == nil && rawModel != "" && rawModel != model {
+			basePricing = s.base.ResolvePricing(rawModel, providerName)
+		}
 	}
 
 	if rule, ok := s.snapshot().matchingOverride(providerName, model); ok {

--- a/internal/pricingoverrides/service_test.go
+++ b/internal/pricingoverrides/service_test.go
@@ -76,6 +76,12 @@ func (r staticPricingResolver) ResolvePricing(_, _ string) *core.ModelPricing {
 	return r.pricing
 }
 
+type selectivePricingResolver map[string]*core.ModelPricing
+
+func (r selectivePricingResolver) ResolvePricing(model, provider string) *core.ModelPricing {
+	return r[provider+"/"+model]
+}
+
 func ptr(v float64) *float64 {
 	return &v
 }
@@ -165,6 +171,28 @@ func TestServiceResolvePricingPreservesSlashShapedModelIDs(t *testing.T) {
 	pricing = service.ResolvePricing("openrouter/anthropic/claude-sonnet", "openrouter")
 	if pricing == nil || pricing.InputPerMtok == nil || *pricing.InputPerMtok != 40 {
 		t.Fatalf("ResolvePricing(redundant provider prefix) = %+v, want exact input rate 40", pricing)
+	}
+}
+
+func TestServiceResolvePricingFallsBackToRawProviderOwnedModelForBasePricing(t *testing.T) {
+	baseInput := 1.0
+	service, err := NewService(
+		newTestStore(),
+		testCatalog{providerNames: []string{"openrouter"}},
+		selectivePricingResolver{
+			"openrouter/openrouter/free": {InputPerMtok: &baseInput},
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	pricing := service.ResolvePricing("openrouter/free", "openrouter")
+	if pricing == nil || pricing.InputPerMtok == nil || *pricing.InputPerMtok != baseInput {
+		t.Fatalf("ResolvePricing(raw provider-owned base) = %+v, want base input rate %v", pricing, baseInput)
 	}
 }
 

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -191,9 +191,6 @@ func (r *ModelRegistry) RegisterProviderWithNameAndType(provider core.Provider, 
 	r.providerRuntime[providerName] = state
 }
 
-
-
-
 // GetProvider returns the provider for the given model, or nil if not found
 func (r *ModelRegistry) GetProvider(model string) core.Provider {
 	r.mu.RLock()
@@ -202,7 +199,7 @@ func (r *ModelRegistry) GetProvider(model string) core.Provider {
 	providerName, modelID := splitModelSelector(model)
 	if providerName != "" {
 		if providerModels, ok := r.modelsByProvider[providerName]; ok {
-			if info, exists := providerModels[modelID]; exists {
+			if info, exists := providerModelInfo(providerModels, modelID, model); exists {
 				return info.Provider
 			}
 		}
@@ -227,7 +224,7 @@ func (r *ModelRegistry) GetModel(model string) *ModelInfo {
 	providerName, modelID := splitModelSelector(model)
 	if providerName != "" {
 		if providerModels, ok := r.modelsByProvider[providerName]; ok {
-			if info, exists := providerModels[modelID]; exists {
+			if info, exists := providerModelInfo(providerModels, modelID, model); exists {
 				return info
 			}
 		}
@@ -252,7 +249,7 @@ func (r *ModelRegistry) LookupModel(model string) (*core.Model, bool) {
 	providerName, modelID := splitModelSelector(model)
 	if providerName != "" {
 		if providerModels, ok := r.modelsByProvider[providerName]; ok {
-			if info, exists := providerModels[modelID]; exists {
+			if info, exists := providerModelInfo(providerModels, modelID, model); exists {
 				cloned := info.Model
 				return &cloned, true
 			}
@@ -278,7 +275,7 @@ func (r *ModelRegistry) Supports(model string) bool {
 	providerName, modelID := splitModelSelector(model)
 	if providerName != "" {
 		if providerModels, ok := r.modelsByProvider[providerName]; ok {
-			if _, exists := providerModels[modelID]; exists {
+			if _, exists := providerModelInfo(providerModels, modelID, model); exists {
 				return true
 			}
 		}
@@ -360,7 +357,7 @@ func (r *ModelRegistry) GetProviderType(model string) string {
 	providerName, modelID := splitModelSelector(model)
 	if providerName != "" {
 		if providerModels, ok := r.modelsByProvider[providerName]; ok {
-			if info, exists := providerModels[modelID]; exists {
+			if info, exists := providerModelInfo(providerModels, modelID, model); exists {
 				return info.ProviderType
 			}
 		}
@@ -385,7 +382,7 @@ func (r *ModelRegistry) GetProviderName(model string) string {
 	providerName, modelID := splitModelSelector(model)
 	if providerName != "" {
 		if providerModels, ok := r.modelsByProvider[providerName]; ok {
-			if info, exists := providerModels[modelID]; exists {
+			if info, exists := providerModelInfo(providerModels, modelID, model); exists {
 				return strings.TrimSpace(info.ProviderName)
 			}
 		}
@@ -530,6 +527,20 @@ func splitModelSelector(model string) (providerName, modelID string) {
 		return "", model
 	}
 	return providerName, modelID
+}
+
+func providerModelInfo(providerModels map[string]*ModelInfo, modelID, rawModel string) (*ModelInfo, bool) {
+	modelID = strings.TrimSpace(modelID)
+	rawModel = strings.TrimSpace(rawModel)
+	if info, exists := providerModels[modelID]; exists {
+		return info, true
+	}
+	if rawModel != "" && rawModel != modelID {
+		if info, exists := providerModels[rawModel]; exists {
+			return info, true
+		}
+	}
+	return nil, false
 }
 
 func qualifyPublicModelID(providerName, modelID string) string {

--- a/internal/providers/registry_metadata.go
+++ b/internal/providers/registry_metadata.go
@@ -150,7 +150,7 @@ func metadataFromProviderModel(providerModels map[string]*ModelInfo, model strin
 	candidates := append([]string{model}, alternates...)
 	for _, candidate := range candidates {
 		info := providerModels[strings.TrimSpace(candidate)]
-		if info == nil {
+		if info == nil || info.Model.Metadata == nil {
 			continue
 		}
 		return info.Model.Metadata

--- a/internal/providers/registry_metadata.go
+++ b/internal/providers/registry_metadata.go
@@ -126,7 +126,7 @@ func (r *ModelRegistry) getProviderModelMetadata(providerSelector, model string)
 	defer r.mu.RUnlock()
 
 	if modelProviderName != "" {
-		if meta := metadataFromProviderModel(r.modelsByProvider[modelProviderName], modelID); meta != nil {
+		if meta := metadataFromProviderModel(r.modelsByProvider[modelProviderName], modelID, model); meta != nil {
 			return meta
 		}
 		if r.hasConfiguredProviderNameLocked(modelProviderName) {
@@ -143,15 +143,19 @@ func (r *ModelRegistry) getProviderModelMetadata(providerSelector, model string)
 	return nil
 }
 
-func metadataFromProviderModel(providerModels map[string]*ModelInfo, model string) *core.ModelMetadata {
+func metadataFromProviderModel(providerModels map[string]*ModelInfo, model string, alternates ...string) *core.ModelMetadata {
 	if len(providerModels) == 0 {
 		return nil
 	}
-	info := providerModels[strings.TrimSpace(model)]
-	if info == nil {
-		return nil
+	candidates := append([]string{model}, alternates...)
+	for _, candidate := range candidates {
+		info := providerModels[strings.TrimSpace(candidate)]
+		if info == nil {
+			continue
+		}
+		return info.Model.Metadata
 	}
-	return info.Model.Metadata
+	return nil
 }
 
 func (r *ModelRegistry) metadataProviderType(providerSelector string) string {
@@ -174,6 +178,13 @@ func (r *ModelRegistry) metadataModelID(model string) string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	if r.hasConfiguredProviderNameLocked(providerName) {
+		providerModels := r.modelsByProvider[providerName]
+		if _, ok := providerModels[modelID]; ok {
+			return modelID
+		}
+		if _, ok := providerModels[model]; ok {
+			return model
+		}
 		return modelID
 	}
 	return model

--- a/internal/providers/registry_metadata_override_test.go
+++ b/internal/providers/registry_metadata_override_test.go
@@ -205,6 +205,7 @@ func TestResolvePricingPrefersProviderOwnedRawSlashMetadata(t *testing.T) {
 		modelsResponse: &core.ModelsResponse{
 			Object: "list",
 			Data: []core.Model{
+				{ID: "free", Object: "model", OwnedBy: "openrouter"},
 				{ID: "openrouter/free", Object: "model", OwnedBy: "openrouter"},
 			},
 		},

--- a/internal/providers/registry_metadata_override_test.go
+++ b/internal/providers/registry_metadata_override_test.go
@@ -188,6 +188,56 @@ func TestResolvePricingPrefersProviderSpecificMetadata(t *testing.T) {
 	}
 }
 
+func TestResolvePricingPrefersProviderOwnedRawSlashMetadata(t *testing.T) {
+	registry := NewModelRegistry()
+
+	other := &registryMockProvider{
+		name: "provider-other",
+		modelsResponse: &core.ModelsResponse{
+			Object: "list",
+			Data: []core.Model{
+				{ID: "openrouter/free", Object: "model", OwnedBy: "other"},
+			},
+		},
+	}
+	openRouter := &registryMockProvider{
+		name: "provider-openrouter",
+		modelsResponse: &core.ModelsResponse{
+			Object: "list",
+			Data: []core.Model{
+				{ID: "openrouter/free", Object: "model", OwnedBy: "openrouter"},
+			},
+		},
+	}
+	registry.RegisterProviderWithNameAndType(other, "other", "other")
+	registry.RegisterProviderWithNameAndType(openRouter, "openrouter", "openrouter")
+
+	raw := []byte(`{"version":1,"updated_at":"2025-01-01T00:00:00Z","providers":{},"models":{},"provider_models":{}}`)
+	list, err := modeldata.Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	registry.SetModelList(list, raw)
+
+	otherRate := 1.0
+	openRouterRate := 2.0
+	registry.SetProviderMetadataOverrides("other", map[string]*core.ModelMetadata{
+		"openrouter/free": {Pricing: &core.ModelPricing{InputPerMtok: &otherRate}},
+	})
+	registry.SetProviderMetadataOverrides("openrouter", map[string]*core.ModelMetadata{
+		"openrouter/free": {Pricing: &core.ModelPricing{InputPerMtok: &openRouterRate}},
+	})
+
+	if err := registry.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	pricing := registry.ResolvePricing("openrouter/free", "openrouter")
+	if pricing == nil || pricing.InputPerMtok == nil || *pricing.InputPerMtok != openRouterRate {
+		t.Fatalf("ResolvePricing(openrouter/free, openrouter) = %+v, want openrouter pricing", pricing)
+	}
+}
+
 func TestApplyConfigMetadataOverrides_MergesPricingSourcesPerField(t *testing.T) {
 	baseInput := 1.0
 	baseOutput := 2.0

--- a/internal/providers/registry_test.go
+++ b/internal/providers/registry_test.go
@@ -361,6 +361,41 @@ func TestModelRegistry(t *testing.T) {
 		}
 	})
 
+	t.Run("ProviderOwnedRawSlashModel", func(t *testing.T) {
+		registry := NewModelRegistry()
+		openRouter := &registryMockProvider{
+			name: "openrouter",
+			modelsResponse: &core.ModelsResponse{
+				Object: "list",
+				Data: []core.Model{
+					{ID: "openrouter/free", Object: "model", OwnedBy: "openrouter"},
+				},
+			},
+		}
+		registry.RegisterProviderWithNameAndType(openRouter, "openrouter", "openrouter")
+		_ = registry.Initialize(context.Background())
+
+		if !registry.Supports("openrouter/free") {
+			t.Fatal("expected provider-owned raw slash model to be supported")
+		}
+		if provider := registry.GetProvider("openrouter/free"); provider != openRouter {
+			t.Fatal("expected raw slash model to resolve to openrouter provider")
+		}
+		model, ok := registry.LookupModel("openrouter/free")
+		if !ok || model == nil {
+			t.Fatal("expected raw slash model lookup to succeed")
+		}
+		if model.ID != "openrouter/free" {
+			t.Fatalf("model.ID = %q, want openrouter/free", model.ID)
+		}
+		if got := registry.GetProviderType("openrouter/free"); got != "openrouter" {
+			t.Fatalf("GetProviderType() = %q, want openrouter", got)
+		}
+		if got := registry.GetProviderName("openrouter/free"); got != "openrouter" {
+			t.Fatalf("GetProviderName() = %q, want openrouter", got)
+		}
+	})
+
 	t.Run("GetModel", func(t *testing.T) {
 		registry := NewModelRegistry()
 		expectedModel := core.Model{

--- a/internal/providers/router.go
+++ b/internal/providers/router.go
@@ -153,6 +153,10 @@ func (r *Router) resolveQualifiedSelector(requested core.RequestedModelSelector,
 		return core.ModelSelector{Provider: entry.ProviderName, Model: entry.Model.ID}, true
 	}
 
+	if concrete, ok := resolveProviderOwnedRawSelector(entries, providerSegment, requested.Model); ok {
+		return concrete, true
+	}
+
 	if requested.ExplicitProvider {
 		return core.ModelSelector{}, false
 	}
@@ -168,6 +172,36 @@ func (r *Router) resolveQualifiedSelector(requested core.RequestedModelSelector,
 		return core.ModelSelector{}, false
 	}
 	for _, entry := range entries {
+		if strings.TrimSpace(entry.Model.ID) != rawModelID {
+			continue
+		}
+		return core.ModelSelector{Provider: entry.ProviderName, Model: entry.Model.ID}, true
+	}
+
+	return core.ModelSelector{}, false
+}
+
+func resolveProviderOwnedRawSelector(entries []ModelWithProvider, providerSegment, rawModelID string) (core.ModelSelector, bool) {
+	providerSegment = strings.TrimSpace(providerSegment)
+	rawModelID = strings.TrimSpace(rawModelID)
+	if providerSegment == "" || rawModelID == "" {
+		return core.ModelSelector{}, false
+	}
+
+	for _, entry := range entries {
+		if strings.TrimSpace(entry.ProviderName) != providerSegment {
+			continue
+		}
+		if strings.TrimSpace(entry.Model.ID) != rawModelID {
+			continue
+		}
+		return core.ModelSelector{Provider: entry.ProviderName, Model: entry.Model.ID}, true
+	}
+
+	for _, entry := range entries {
+		if strings.TrimSpace(entry.ProviderType) != providerSegment {
+			continue
+		}
 		if strings.TrimSpace(entry.Model.ID) != rawModelID {
 			continue
 		}

--- a/internal/providers/router_test.go
+++ b/internal/providers/router_test.go
@@ -107,9 +107,9 @@ func (m *mockModelLookup) ModelCount() int {
 // The mock keeps no provider-name <-> type mapping, so the three resolver
 // methods always return empty. Tests that need provider-name routing use the
 // real ModelRegistry via newTestRegistryWithModels instead of this mock.
-func (m *mockModelLookup) GetProviderName(_ string) string             { return "" }
-func (m *mockModelLookup) GetProviderNameForType(_ string) string      { return "" }
-func (m *mockModelLookup) GetProviderTypeForName(_ string) string      { return "" }
+func (m *mockModelLookup) GetProviderName(_ string) string        { return "" }
+func (m *mockModelLookup) GetProviderNameForType(_ string) string { return "" }
+func (m *mockModelLookup) GetProviderTypeForName(_ string) string { return "" }
 
 // mockProvider is a simple mock implementation of core.Provider for testing
 type mockProvider struct {
@@ -641,6 +641,71 @@ func TestRouterChatCompletion_ProviderQualifiedRawSlashModelStillWorks(t *testin
 	}
 	if openRouter.lastChatReq.Provider != "" {
 		t.Fatalf("expected provider field to be stripped upstream, got %q", openRouter.lastChatReq.Provider)
+	}
+}
+
+func TestRouterChatCompletion_ProviderOwnedRawSlashModelStillWorks(t *testing.T) {
+	openRouterResp := &core.ChatResponse{ID: "openrouter", Model: "openrouter/free"}
+	openRouter := &mockProvider{name: "openrouter", chatResponse: openRouterResp}
+
+	registry := newTestRegistryWithModels(registryModelEntry{
+		provider:     openRouter,
+		providerName: "openrouter",
+		providerType: "openrouter",
+		modelID:      "openrouter/free",
+	})
+
+	router, _ := NewRouter(registry)
+
+	resp, err := router.ChatCompletion(context.Background(), &core.ChatRequest{Model: "openrouter/free"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.ID != "openrouter" {
+		t.Fatalf("expected openrouter response, got %q", resp.ID)
+	}
+	if openRouter.lastChatReq == nil || openRouter.lastChatReq.Model != "openrouter/free" {
+		t.Fatalf("expected openrouter provider to receive raw slash model, got %#v", openRouter.lastChatReq)
+	}
+	if openRouter.lastChatReq.Provider != "" {
+		t.Fatalf("expected provider field to be stripped upstream, got %q", openRouter.lastChatReq.Provider)
+	}
+	if got := router.GetProviderType("openrouter/free"); got != "openrouter" {
+		t.Fatalf("GetProviderType() = %q, want openrouter", got)
+	}
+	if got := router.GetProviderName("openrouter/free"); got != "openrouter" {
+		t.Fatalf("GetProviderName() = %q, want openrouter", got)
+	}
+}
+
+func TestRouterChatCompletion_ProviderTypeOwnedRawSlashModelStillWorks(t *testing.T) {
+	openRouterResp := &core.ChatResponse{ID: "openrouter", Model: "openrouter/auto"}
+	openRouter := &mockProvider{name: "openrouter-main", chatResponse: openRouterResp}
+
+	registry := newTestRegistryWithModels(registryModelEntry{
+		provider:     openRouter,
+		providerName: "openrouter-main",
+		providerType: "openrouter",
+		modelID:      "openrouter/auto",
+	})
+
+	router, _ := NewRouter(registry)
+
+	resp, err := router.ChatCompletion(context.Background(), &core.ChatRequest{Model: "openrouter/auto"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.ID != "openrouter" {
+		t.Fatalf("expected openrouter response, got %q", resp.ID)
+	}
+	if openRouter.lastChatReq == nil || openRouter.lastChatReq.Model != "openrouter/auto" {
+		t.Fatalf("expected openrouter provider to receive raw slash model, got %#v", openRouter.lastChatReq)
+	}
+	if openRouter.lastChatReq.Provider != "" {
+		t.Fatalf("expected provider field to be stripped upstream, got %q", openRouter.lastChatReq.Provider)
+	}
+	if got := router.GetProviderName("openrouter/auto"); got != "openrouter-main" {
+		t.Fatalf("GetProviderName() = %q, want openrouter-main", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Support provider-owned raw slash model IDs such as `openrouter/free` and `openrouter/auto`.
- Keep exact provider/model selector precedence before falling back to raw provider-owned IDs.
- Add router and registry coverage for OpenRouter virtual model selectors.

## Tests
- `go test ./...`
- pre-commit hook: `make test-race`, `go mod tidy`, dashboard JS check, hot-path performance guard, `make lint`

Fixes #342


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resolution for models containing raw slashes (e.g., provider/model) across lookup, routing, pricing and metadata so the correct provider/type/name and pricing are selected.
* **Tests**
  * Added tests validating routing, model lookup, metadata selection, and pricing behavior for provider-owned raw-slash model identifiers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ENTERPILOT/GoModel/pull/344?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->