### PR TITLE
fix(anthropicapi): report stop_reason "tool_use" for tool-call responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,19 +17,17 @@
 # Data (runtime-created by SQLite storage)
 /data/
 
-# Others
-/*.bck.yml
-/repomix-output.*
-/coverage.out
-
 # Helm chart dependencies
 **/charts/*.tgz
 
 # OpenCode config - ignore because it might contain private servers URLs
 /opencode.json
 
-# Claude Code local settings (user-specific)
-/.claude/settings.local.json
-
 # Local git worktrees
 /.worktrees/
+
+# Others
+/*.bck.yml
+/repomix-output.*
+/coverage.out
+/.claude/

--- a/internal/anthropicapi/response.go
+++ b/internal/anthropicapi/response.go
@@ -99,7 +99,16 @@ func argumentsToRaw(arguments string) json.RawMessage {
 }
 
 // stopReasonFromFinish maps an OpenAI finish_reason to an Anthropic stop_reason.
+//
+// A response carrying tool calls always reports "tool_use" regardless of the
+// upstream finish_reason: OpenAI-family providers report finish_reason "stop"
+// alongside tool calls when a tool is forced via tool_choice, and the Anthropic
+// Messages API contract guarantees "tool_use" whenever the content holds
+// tool_use blocks.
 func stopReasonFromFinish(finish string, hasToolCalls bool) string {
+	if hasToolCalls {
+		return "tool_use"
+	}
 	switch finish {
 	case "stop":
 		return "end_turn"
@@ -110,9 +119,6 @@ func stopReasonFromFinish(finish string, hasToolCalls bool) string {
 	case "content_filter":
 		return "end_turn"
 	case "":
-		if hasToolCalls {
-			return "tool_use"
-		}
 		return ""
 	default:
 		return finish

--- a/internal/anthropicapi/response_test.go
+++ b/internal/anthropicapi/response_test.go
@@ -94,20 +94,35 @@ func TestFromChatResponseThinking(t *testing.T) {
 
 func TestFromChatResponseStopReasons(t *testing.T) {
 	tests := []struct {
-		finish string
-		want   string
+		name      string
+		finish    string
+		toolCalls bool
+		want      string
 	}{
-		{finish: "stop", want: "end_turn"},
-		{finish: "length", want: "max_tokens"},
-		{finish: "tool_calls", want: "tool_use"},
-		{finish: "content_filter", want: "end_turn"},
-		{finish: "", want: "end_turn"},
+		{name: "stop", finish: "stop", want: "end_turn"},
+		{name: "length", finish: "length", want: "max_tokens"},
+		{name: "tool_calls", finish: "tool_calls", want: "tool_use"},
+		{name: "content_filter", finish: "content_filter", want: "end_turn"},
+		{name: "empty", finish: "", want: "end_turn"},
+		// A response carrying tool calls always reports "tool_use". OpenAI-family
+		// providers report finish_reason "stop" alongside tool calls when a tool
+		// is forced via tool_choice.
+		{name: "stop_with_tool_calls", finish: "stop", toolCalls: true, want: "tool_use"},
+		{name: "empty_with_tool_calls", finish: "", toolCalls: true, want: "tool_use"},
 	}
 	for _, tc := range tests {
-		t.Run(tc.finish, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
+			message := core.ResponseMessage{Content: "x"}
+			if tc.toolCalls {
+				message.ToolCalls = []core.ToolCall{{
+					ID:       "tu_1",
+					Type:     "function",
+					Function: core.FunctionCall{Name: "get_weather", Arguments: `{"city":"paris"}`},
+				}}
+			}
 			resp := FromChatResponse(&core.ChatResponse{
 				Choices: []core.Choice{{
-					Message:      core.ResponseMessage{Content: "x"},
+					Message:      message,
 					FinishReason: tc.finish,
 				}},
 			})

--- a/tests/e2e/release-e2e-findings.md
+++ b/tests/e2e/release-e2e-findings.md
@@ -12,8 +12,8 @@ virtual model IDs` #344).
    API ingress endpoints (`POST /v1/messages`, `POST /v1/messages/count_tokens`)
    and ran them.
 
-The runner only parsed 2-digit scenario IDs (`^### S[0-9][0-9] `). It was
-widened to `^### S[0-9][0-9]+ ` in `run-release-e2e.sh` so `S96`–`S109` (and
+The runner only parsed 2-digit scenario IDs (`/^### S[0-9][0-9] /`). It was
+widened to `/^### S[0-9][0-9]+ /` in `run-release-e2e.sh` so `S96`–`S109` (and
 any future 3-digit IDs) parse. No other runner behavior changed.
 
 ## Stack
@@ -88,7 +88,7 @@ When a tool is forced via `tool_choice`, OpenAI (`gpt-4.1-nano`) returns
 `finish_reason: "stop"` **with** a non-empty `tool_calls` list — confirmed with a
 direct `/v1/chat/completions` call:
 
-```
+```json
 { "finish_reason": "stop", "has_tool_calls": 1 }
 ```
 

--- a/tests/e2e/release-e2e-findings.md
+++ b/tests/e2e/release-e2e-findings.md
@@ -1,0 +1,161 @@
+# Release E2E Findings
+
+Run date: 2026-05-21
+Branch: `main` @ `72a0e68` (after pulling `feat(server): add Anthropic
+Messages API ingress endpoint` #343 and `fix(providers): support OpenRouter
+virtual model IDs` #344).
+
+## Scope
+
+1. Ran the full existing release E2E matrix (`S01`–`S95`).
+2. Added 14 new scenarios (`S96`–`S109`) covering the new Anthropic Messages
+   API ingress endpoints (`POST /v1/messages`, `POST /v1/messages/count_tokens`)
+   and ran them.
+
+The runner only parsed 2-digit scenario IDs (`^### S[0-9][0-9] `). It was
+widened to `^### S[0-9][0-9]+ ` in `run-release-e2e.sh` so `S96`–`S109` (and
+any future 3-digit IDs) parse. No other runner behavior changed.
+
+## Stack
+
+Dedicated release stack on ports 18080-18084 via
+`tests/e2e/manage-release-e2e-stack.sh start`, backed by Docker
+redis/postgres/mongodb. All 5 gateways reported `health=ok`.
+
+## Result summary
+
+| Suite | Scenarios | Passed | Failed |
+|-------|-----------|--------|--------|
+| Existing matrix `S01`-`S95` | 95 | 94 | 1 (`S91`, see below) |
+| New Messages API `S96`-`S109` | 14 | 13 | 1 (`S102`, real bug) |
+| **Total** | **109** | **107** | **2** |
+
+`S91` is a test-host flake (passes on a clean re-run). `S102` caught a real
+product bug, which has since been fixed in this branch — after the fix, the
+**full 109/109 matrix passes**.
+
+## S91 — flaky, not a product bug
+
+`S91 Live preview heartbeat from an idle subscriber` failed on the first run
+with `curl: (28) Operation timed out after 801269 milliseconds` even though the
+curl had `--max-time 20`. The host went to sleep mid-scenario, suspending the
+process for ~13 minutes; the SSE connection was dead on resume.
+
+Re-running `S91` under `caffeinate -i` passed in 21s. **No product issue** — a
+test-host environment artifact. Recommendation: run the release matrix under
+`caffeinate -i` to avoid idle-sleep flakes.
+
+## S102 — REAL BUG (FIXED): `stop_reason` wrong for tool-use responses on `/v1/messages`
+
+**Status: fixed in this branch.** `stopReasonFromFinish` now returns `"tool_use"`
+whenever the response carries tool calls, before the `finish_reason` switch.
+`TestFromChatResponseStopReasons` gained `stop_with_tool_calls` and
+`empty_with_tool_calls` cases. `S102` re-run against the rebuilt binary returns
+`stop_reason: "tool_use"` and passes. Details below.
+
+
+`S102 Forced tool use round-trip` failed. The response correctly contains a
+`tool_use` content block, but `stop_reason` is `"end_turn"` instead of
+`"tool_use"`:
+
+```json
+{
+  "type": "message",
+  "stop_reason": "end_turn",
+  "content": [
+    { "type": "tool_use", "id": "call_…", "name": "get_weather",
+      "input": { "city": "Paris" } }
+  ]
+}
+```
+
+### Root cause
+
+`internal/anthropicapi/response.go` → `stopReasonFromFinish(finish, hasToolCalls)`
+only consults `hasToolCalls` in the `case ""` branch:
+
+```go
+case "stop":
+    return "end_turn"
+...
+case "":
+    if hasToolCalls {
+        return "tool_use"
+    }
+```
+
+When a tool is forced via `tool_choice`, OpenAI (`gpt-4.1-nano`) returns
+`finish_reason: "stop"` **with** a non-empty `tool_calls` list — confirmed with a
+direct `/v1/chat/completions` call:
+
+```
+{ "finish_reason": "stop", "has_tool_calls": 1 }
+```
+
+`stopReasonFromFinish` then takes the `case "stop"` branch and returns
+`"end_turn"`, ignoring the tool calls.
+
+### Impact
+
+Anthropic's Messages API contract guarantees `stop_reason: "tool_use"` whenever
+the response contains `tool_use` blocks. Anthropic-compatible clients (including
+the Anthropic SDK tool-use loop) branch on `stop_reason == "tool_use"` to decide
+whether to execute a tool and continue the conversation. With `"end_turn"`, such
+a client treats the turn as finished and **never executes the tool** — agentic
+tool-use loops through `/v1/messages` break whenever the upstream provider
+reports `finish_reason: "stop"` alongside tool calls (the common case for
+OpenAI-family providers with a forced `tool_choice`).
+
+### Fix applied
+
+`stop_reason` is `"tool_use"` whenever the response carries tool calls,
+regardless of `finish_reason`. `stopReasonFromFinish` now checks `hasToolCalls`
+first:
+
+```go
+func stopReasonFromFinish(finish string, hasToolCalls bool) string {
+    if hasToolCalls {
+        return "tool_use"
+    }
+    switch finish { ... }
+}
+```
+
+### Test-coverage gap (closed)
+
+`internal/anthropicapi/response_test.go` `TestFromChatResponseStopReasons`
+previously exercised each `finish_reason` in isolation but never the
+combination `finish_reason: "stop"` **+** non-empty tool calls — the exact case
+that failed. Rows `stop_with_tool_calls` and `empty_with_tool_calls` were added.
+
+## New scenarios `S96`-`S109` (Messages API ingress)
+
+All pass except `S102`. Notable confirmations:
+
+- `S96` — native Anthropic model: correct envelope, `id` normalized to `msg_…`,
+  Anthropic-style `usage.input_tokens` / `output_tokens`.
+- `S97` — provider-agnostic translation: an OpenAI model served through
+  `/v1/messages` returns a valid Anthropic envelope (`id` becomes
+  `msg_chatcmpl-…`, `model` is the resolved `gpt-4.1-nano-2025-04-14`).
+- `S98` — streaming emits the Anthropic SSE event sequence
+  (`message_start` → `content_block_start` → `content_block_delta`/`text_delta`
+  → `message_delta` → `message_stop`).
+- `S99` — polymorphic `system` as a text-block array is honored.
+- `S100` — multi-turn conversation with a prior `assistant` turn.
+- `S101` — `/v1/messages/count_tokens` returns a positive heuristic estimate.
+- `S103` — multimodal image (`source.type: "url"`) input works.
+- `S104` — alias resolution applies to `/v1/messages`.
+- `S105`-`S108` — error paths return the Anthropic error envelope
+  (`{"type":"error","error":{"type":"invalid_request_error",…}}`) with HTTP 400:
+  missing `max_tokens`, empty `messages`, unknown model, and unsupported content
+  block type (`document`).
+- `S109` — `/v1/messages` requests are recorded in the audit log under the
+  `/v1/messages` path and are searchable by request ID.
+
+## Recommendations
+
+1. The `S102` `stop_reason` bug is fixed in this branch — ship the fix with the
+   `/v1/messages` feature, since it breaks tool-use loops for OpenAI-family
+   providers.
+2. Run the release matrix under `caffeinate -i` on laptops to avoid idle-sleep
+   flakes like the first `S91` run.

--- a/tests/e2e/release-e2e-scenarios.md
+++ b/tests/e2e/release-e2e-scenarios.md
@@ -1,6 +1,6 @@
 # Release E2E Curl Matrix
 
-This file contains 95 end-to-end curl scenarios for release validation.
+This file contains 109 end-to-end curl scenarios for release validation.
 These scenarios are prepared for execution across these local gateways:
 
 - `http://localhost:18080` - SQLite-backed main test gateway
@@ -36,6 +36,9 @@ Stateful note:
 - `S80`-`S85` mutate response snapshots and response-cache artifacts
 - `S86`-`S89` mutate budget settings and budgets
 - `S90` mutates stored usage pricing fields on the no-master-key gateway
+- `S96`-`S109` exercise the Anthropic Messages API ingress endpoint and are
+  self-contained (`S104` creates and deletes its own alias); they can be rerun
+  in any order
 - For stateful partial reruns, prefer a contiguous range that includes the
   prerequisite setup scenarios, or rerun with the same `--qa-suffix` and
   `--keep-artifacts`
@@ -1662,6 +1665,271 @@ jq -e --arg rid "$RID" '
       and .path == "/v1/chat/completions"
       and .stream == true
       and .error_type == "client_disconnected"
+    )
+  ' "$AUDIT_JSON_FILE" >/dev/null
+```
+
+## 18. Anthropic Messages API ingress
+
+These scenarios exercise the `/v1/messages` and `/v1/messages/count_tokens`
+endpoints added in the Anthropic Messages API ingress feature. The endpoint
+accepts the Anthropic Messages request dialect, translates it to the canonical
+chat request, routes it through the standard chat-completions pipeline (so it
+works with any configured provider), and renders responses back in the
+Anthropic Messages shape. The main SQLite-backed gateway is used because it
+runs in unsafe mode (no master key) with audit logging enabled.
+
+### S96 Non-streaming message on an Anthropic model
+
+Checks a basic Messages request served by the native Anthropic provider.
+
+```bash
+RESP_FILE="$QA_RUN_DIR/s96.messages.json"
+curl -fsS "$BASE_URL/v1/messages" \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"claude-sonnet-4-6","max_tokens":64,"system":"You are terse.","messages":[{"role":"user","content":"Reply with exactly QA_MESSAGES_ANTHROPIC_OK"}]}' \
+  > "$RESP_FILE"
+jq '{id,type,role,model,stop_reason,usage,content}' "$RESP_FILE"
+jq -e '
+    .type == "message"
+    and .role == "assistant"
+    and (.id | type == "string" and startswith("msg_"))
+    and (.content | length) >= 1
+    and (any(.content[]; .type == "text" and (.text | length) > 0))
+    and (.usage.input_tokens > 0)
+    and (.usage.output_tokens > 0)
+    and (.stop_reason | type == "string" and length > 0)
+  ' "$RESP_FILE" >/dev/null
+```
+
+### S97 Messages request translated to a non-Anthropic provider
+
+Checks that the Anthropic dialect is provider-agnostic: an OpenAI model served
+through `/v1/messages` still returns an Anthropic Messages envelope.
+
+```bash
+RESP_FILE="$QA_RUN_DIR/s97.messages.json"
+curl -fsS "$BASE_URL/v1/messages" \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"gpt-4.1-nano","max_tokens":32,"messages":[{"role":"user","content":"Reply with exactly QA_MESSAGES_OPENAI_OK"}]}' \
+  > "$RESP_FILE"
+jq '{id,type,role,model,stop_reason,usage,content}' "$RESP_FILE"
+jq -e '
+    .type == "message"
+    and .role == "assistant"
+    and (any(.content[]; .type == "text" and (.text | contains("QA_MESSAGES_OPENAI_OK"))))
+    and (.usage.output_tokens > 0)
+  ' "$RESP_FILE" >/dev/null
+```
+
+### S98 Streaming message SSE
+
+Checks SSE streaming with the Anthropic event sequence.
+
+```bash
+SSE_FILE="$QA_RUN_DIR/s98.messages.sse"
+curl -fsS --no-buffer "$BASE_URL/v1/messages" \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"gpt-4.1-nano","max_tokens":32,"stream":true,"messages":[{"role":"user","content":"Reply with exactly QA_MESSAGES_STREAM_OK"}]}' \
+  > "$SSE_FILE"
+sed -n '1,24p' "$SSE_FILE"
+for event in 'event: message_start' 'event: content_block_start' 'event: content_block_delta' 'event: message_delta' 'event: message_stop'; do
+  if ! grep -qF "$event" "$SSE_FILE"; then
+    echo "error: message stream is missing $event" >&2
+    exit 1
+  fi
+done
+grep -qF '"text_delta"' "$SSE_FILE" || { echo "error: message stream is missing a text_delta" >&2; exit 1; }
+```
+
+### S99 System prompt supplied as a text-block array
+
+Checks that the polymorphic `system` field is honored when sent as an array of
+text blocks rather than a string.
+
+```bash
+RESP_FILE="$QA_RUN_DIR/s99.messages.json"
+curl -fsS "$BASE_URL/v1/messages" \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"gpt-4.1-nano","max_tokens":32,"system":[{"type":"text","text":"Always reply with exactly QA_MESSAGES_SYSTEM_OK regardless of the user message."}],"messages":[{"role":"user","content":"Say something unrelated."}]}' \
+  > "$RESP_FILE"
+jq '{type,role,content}' "$RESP_FILE"
+jq -e 'any(.content[]; .type == "text" and (.text | contains("QA_MESSAGES_SYSTEM_OK")))' "$RESP_FILE" >/dev/null
+```
+
+### S100 Multi-turn conversation with an assistant turn
+
+Checks that a conversation containing a prior `assistant` message is translated
+and routed correctly.
+
+```bash
+RESP_FILE="$QA_RUN_DIR/s100.messages.json"
+curl -fsS "$BASE_URL/v1/messages" \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"gpt-4.1-nano","max_tokens":32,"messages":[{"role":"user","content":"Remember the code word is QA_MEMO_42."},{"role":"assistant","content":"Understood, I will remember it."},{"role":"user","content":"Reply with only the code word."}]}' \
+  > "$RESP_FILE"
+jq '{type,role,stop_reason,content}' "$RESP_FILE"
+jq -e 'any(.content[]; .type == "text" and (.text | contains("QA_MEMO_42")))' "$RESP_FILE" >/dev/null
+```
+
+### S101 Count message tokens
+
+Checks the `/v1/messages/count_tokens` heuristic estimate endpoint.
+
+```bash
+RESP_FILE="$QA_RUN_DIR/s101.count-tokens.json"
+curl -fsS "$BASE_URL/v1/messages/count_tokens" \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"claude-sonnet-4-6","max_tokens":64,"system":"You are a helpful assistant.","messages":[{"role":"user","content":"How many tokens are in this Anthropic Messages request body?"}]}' \
+  > "$RESP_FILE"
+jq '.' "$RESP_FILE"
+jq -e '(.input_tokens | type == "number") and .input_tokens > 0' "$RESP_FILE" >/dev/null
+```
+
+### S102 Forced tool use round-trip
+
+Checks tool translation: an Anthropic `tools` definition with a `tool_choice`
+that forces a specific tool yields an Anthropic `tool_use` content block.
+
+```bash
+RESP_FILE="$QA_RUN_DIR/s102.messages.json"
+curl -fsS "$BASE_URL/v1/messages" \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"gpt-4.1-nano","max_tokens":256,"tool_choice":{"type":"tool","name":"get_weather"},"tools":[{"name":"get_weather","description":"Get the current weather for a city","input_schema":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}],"messages":[{"role":"user","content":"What is the weather in Paris?"}]}' \
+  > "$RESP_FILE"
+jq '{type,stop_reason,content}' "$RESP_FILE"
+jq -e '
+    .stop_reason == "tool_use"
+    and any(.content[]; .type == "tool_use" and .name == "get_weather" and (.input | type == "object"))
+  ' "$RESP_FILE" >/dev/null
+```
+
+### S103 Multimodal image input
+
+Checks an Anthropic image content block with a URL source.
+
+```bash
+RESP_FILE="$QA_RUN_DIR/s103.messages.json"
+curl -fsS "$BASE_URL/v1/messages" \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"gpt-4o-mini","max_tokens":20,"messages":[{"role":"user","content":[{"type":"text","text":"Reply with one digit only: which digit is visible in the image?"},{"type":"image","source":{"type":"url","url":"https://dummyimage.com/64x64/000/fff.png&text=7"}}]}]}' \
+  > "$RESP_FILE"
+jq '{type,role,usage,content}' "$RESP_FILE"
+jq -e '.type == "message" and any(.content[]; .type == "text" and (.text | length) > 0)' "$RESP_FILE" >/dev/null
+```
+
+### S104 Message through an alias
+
+Checks that alias resolution applies to `/v1/messages` like the other inference
+endpoints.
+
+```bash
+MESSAGES_ALIAS="qa-messages-alias-$QA_SUFFIX"
+curl -fsS -X PUT "$BASE_URL/admin/aliases" \
+  -H 'Content-Type: application/json' \
+  -d "{\"name\":\"$MESSAGES_ALIAS\",\"target_model\":\"gpt-4.1-nano\",\"target_provider\":\"openai\",\"description\":\"QA messages alias\"}" \
+  >/dev/null
+RESP_FILE="$QA_RUN_DIR/s104.messages.json"
+curl -fsS "$BASE_URL/v1/messages" \
+  -H 'Content-Type: application/json' \
+  -d "{\"model\":\"$MESSAGES_ALIAS\",\"max_tokens\":32,\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly QA_MESSAGES_ALIAS_OK\"}]}" \
+  > "$RESP_FILE"
+jq '{type,role,model,content}' "$RESP_FILE"
+jq -e '.type == "message" and any(.content[]; .type == "text" and (.text | contains("QA_MESSAGES_ALIAS_OK")))' "$RESP_FILE" >/dev/null
+curl -fsS -X DELETE "$BASE_URL/admin/aliases" \
+  -H 'Content-Type: application/json' \
+  -d "{\"name\":\"$MESSAGES_ALIAS\"}" >/dev/null
+```
+
+### S105 Missing `max_tokens` is rejected with an Anthropic error envelope (negative)
+
+Checks that a request missing the required `max_tokens` field is rejected as a
+`400` rendered in the Anthropic error envelope (`type: "error"`).
+
+```bash
+HEADERS_FILE=$(mktemp "$QA_RUN_DIR/s105.headers.XXXXXX")
+BODY_FILE=$(mktemp "$QA_RUN_DIR/s105.body.XXXXXX")
+curl -sS -D "$HEADERS_FILE" -o "$BODY_FILE" "$BASE_URL/v1/messages" \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"gpt-4.1-nano","messages":[{"role":"user","content":"Hi"}]}'
+sed -n '1,20p' "$HEADERS_FILE"
+jq '.' "$BODY_FILE"
+grep -Eiq '^HTTP/.* 400 ' "$HEADERS_FILE"
+jq -e '.type == "error" and .error.type == "invalid_request_error" and (.error.message | test("max_tokens"))' "$BODY_FILE" >/dev/null
+```
+
+### S106 Empty messages array is rejected (negative)
+
+Checks that a request with an empty `messages` array is rejected.
+
+```bash
+HEADERS_FILE=$(mktemp "$QA_RUN_DIR/s106.headers.XXXXXX")
+BODY_FILE=$(mktemp "$QA_RUN_DIR/s106.body.XXXXXX")
+curl -sS -D "$HEADERS_FILE" -o "$BODY_FILE" "$BASE_URL/v1/messages" \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"gpt-4.1-nano","max_tokens":16,"messages":[]}'
+sed -n '1,20p' "$HEADERS_FILE"
+jq '.' "$BODY_FILE"
+grep -Eiq '^HTTP/.* 400 ' "$HEADERS_FILE"
+jq -e '.type == "error" and .error.type == "invalid_request_error" and (.error.message | test("messages"))' "$BODY_FILE" >/dev/null
+```
+
+### S107 Unknown model is rejected with an Anthropic error envelope (negative)
+
+Checks that an unresolvable model produces a `400` Anthropic error envelope.
+
+```bash
+HEADERS_FILE=$(mktemp "$QA_RUN_DIR/s107.headers.XXXXXX")
+BODY_FILE=$(mktemp "$QA_RUN_DIR/s107.body.XXXXXX")
+curl -sS -D "$HEADERS_FILE" -o "$BODY_FILE" "$BASE_URL/v1/messages" \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"does-not-exist-model","max_tokens":16,"messages":[{"role":"user","content":"Hi"}]}'
+sed -n '1,20p' "$HEADERS_FILE"
+jq '.' "$BODY_FILE"
+grep -Eiq '^HTTP/.* 400 ' "$HEADERS_FILE"
+jq -e '.type == "error" and .error.type == "invalid_request_error"' "$BODY_FILE" >/dev/null
+```
+
+### S108 Unsupported content block type is rejected (negative)
+
+Checks that a content block type without a canonical chat equivalent (e.g.
+`document`) is rejected rather than silently dropped.
+
+```bash
+HEADERS_FILE=$(mktemp "$QA_RUN_DIR/s108.headers.XXXXXX")
+BODY_FILE=$(mktemp "$QA_RUN_DIR/s108.body.XXXXXX")
+curl -sS -D "$HEADERS_FILE" -o "$BODY_FILE" "$BASE_URL/v1/messages" \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"gpt-4.1-nano","max_tokens":16,"messages":[{"role":"user","content":[{"type":"document","source":{"type":"url","url":"https://example.com/contract.pdf"}}]}]}'
+sed -n '1,20p' "$HEADERS_FILE"
+jq '.' "$BODY_FILE"
+grep -Eiq '^HTTP/.* 400 ' "$HEADERS_FILE"
+jq -e '.type == "error" and .error.type == "invalid_request_error" and (.error.message | test("document"))' "$BODY_FILE" >/dev/null
+```
+
+### S109 Messages request is visible in the audit log
+
+Checks that a `/v1/messages` request is recorded in the audit log under the
+`/v1/messages` path and is searchable by request ID.
+
+```bash
+REQUEST_ID="qa-messages-audit-$QA_SUFFIX"
+RESP_FILE="$QA_RUN_DIR/s109.messages.json"
+curl -fsS "$BASE_URL/v1/messages" \
+  -H 'Content-Type: application/json' \
+  -H "X-Request-ID: $REQUEST_ID" \
+  -d '{"model":"gpt-4.1-nano","max_tokens":24,"messages":[{"role":"user","content":"Reply with exactly QA_MESSAGES_AUDIT_OK"}]}' \
+  > "$RESP_FILE"
+jq -e 'any(.content[]; .type == "text" and (.text | contains("QA_MESSAGES_AUDIT_OK")))' "$RESP_FILE" >/dev/null
+sleep 6
+AUDIT_JSON_FILE="$QA_RUN_DIR/s109.audit.json"
+curl -fsS "$BASE_URL/admin/audit/log?search=$REQUEST_ID&limit=5" > "$AUDIT_JSON_FILE"
+jq --arg rid "$REQUEST_ID" '{entries:(.entries|map(select(.request_id==$rid))|map({request_id,path,requested_model,provider,status_code,error_type}))}' "$AUDIT_JSON_FILE"
+jq -e --arg rid "$REQUEST_ID" '
+    any(.entries[]?;
+      .request_id == $rid
+      and .path == "/v1/messages"
+      and .status_code == 200
     )
   ' "$AUDIT_JSON_FILE" >/dev/null
 ```

--- a/tests/e2e/run-release-e2e.sh
+++ b/tests/e2e/run-release-e2e.sh
@@ -247,7 +247,7 @@ awk -v parsed_dir="$PARSED_DIR" -v manifest="$MANIFEST" -v setup_manifest="$SETU
     if (!in_code && $0 ~ /^## /) {
       current_h2 = substr($0, 4)
     }
-    if (!in_code && $0 ~ /^### S[0-9][0-9] /) {
+    if (!in_code && $0 ~ /^### S[0-9][0-9]+ /) {
       current_id = $2
       current_title = substr($0, length(current_id) + 5)
       next


### PR DESCRIPTION
## Summary

`POST /v1/messages` (the Anthropic Messages API ingress endpoint) returned
`stop_reason: "end_turn"` for responses that contained a `tool_use` content
block. The Anthropic Messages API contract guarantees `stop_reason: "tool_use"`
whenever the content holds `tool_use` blocks — Anthropic SDK tool-use loops
branch on it to decide whether to execute a tool and continue. With
`"end_turn"`, such a client treats the turn as finished and **never executes
the tool**, breaking agentic tool-use flows through `/v1/messages`.

### Root cause

OpenAI-family providers report `finish_reason: "stop"` *alongside* tool calls
when a tool is forced via `tool_choice` (confirmed against `gpt-4.1-nano`).
`stopReasonFromFinish` only consulted `hasToolCalls` in the `finish_reason == ""`
branch, so the `"stop"` branch won and dropped the tool-use signal.

### Fix

`stopReasonFromFinish` now returns `"tool_use"` whenever the response carries
tool calls, before the `finish_reason` switch.

```
before:  { "stop_reason": "end_turn",  "content": [ { "type": "tool_use", ... } ] }
after:   { "stop_reason": "tool_use",  "content": [ { "type": "tool_use", ... } ] }
```

## User-visible impact

Tool-use loops through `/v1/messages` now work with OpenAI-family providers
(the common case: a forced `tool_choice`). Plain text responses are unaffected.

## Tests

- `internal/anthropicapi/response_test.go`: `TestFromChatResponseStopReasons`
  gains `stop_with_tool_calls` and `empty_with_tool_calls` cases — the
  `finish_reason: "stop"` + non-empty tool calls combination that the previous
  table never exercised.
- `tests/e2e/release-e2e-scenarios.md`: new **section 18** with 14 scenarios
  (`S96`-`S109`) covering the Anthropic Messages API ingress endpoints —
  non-streaming, cross-provider routing, streaming SSE, polymorphic `system`,
  multi-turn, `count_tokens`, forced tool use (the case that surfaced this bug),
  multimodal image, alias resolution, four error-envelope negatives, and
  audit-log visibility.
- `tests/e2e/run-release-e2e.sh`: scenario-ID regex widened to accept 3-digit
  IDs so `S96`+ parse.
- `tests/e2e/release-e2e-findings.md`: findings from the validation run.

### Validation

- `make test-race` and `make lint` pass (pre-commit).
- Full release E2E matrix: **109/109 scenarios pass** (94/95 existing + 14 new;
  the one existing miss, `S91`, is a known idle-sleep test-host flake that
  passes on a clean re-run).
- Verified live with `curl` against a real gateway — a forced-tool-use
  `/v1/messages` request returns `stop_reason: "tool_use"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected stop-reason reporting so tool-invocations are consistently reported as tool_use.

* **Tests**
  * Expanded and refined table-driven test coverage for stop-reason and tool-use scenarios; added many new end-to-end scenarios and improved harness parsing for multi-digit IDs.

* **Documentation**
  * Updated end-to-end scenario matrix and findings with new scenarios and run results.

* **Chores**
  * Streamlined project ignore rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ENTERPILOT/GoModel/pull/345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->