### PR TITLE
chore(release): speed up releases and update roadmap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,9 +142,8 @@ jobs:
           docker buildx imagetools create "${tags[@]}" "${IMAGE}@${DIGEST}"
 
   goreleaser:
-    name: Publish GitHub release
+    name: Build draft GitHub release
     runs-on: ubuntu-latest
-    needs: docker-promote
     permissions:
       contents: write
     steps:
@@ -164,6 +163,21 @@ jobs:
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release --clean
+          args: release --clean --draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  github-release:
+    name: Publish GitHub release
+    runs-on: ubuntu-latest
+    needs:
+      - docker-promote
+      - goreleaser
+    permissions:
+      contents: write
+    steps:
+      - name: Publish drafted release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "$GITHUB_REF_NAME" --draft=false --verify-tag

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,6 +37,9 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
+release:
+  replace_existing_draft: true
+
 snapshot:
   version_template: "{{ .Tag }}-next"
 

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,8 @@ swagger:
 		--output cmd/gomodel/docs \
 		--outputTypes go \
 		--parseDependency
+	@command -v node >/dev/null 2>&1 || { echo "node is required to build docs; install from https://nodejs.org" >&2; exit 1; }
+	node tools/swagger-postprocess.mjs cmd/gomodel/docs/docs.go
 	$(MAKE) docs-openapi
 
 docs-openapi:

--- a/README.md
+++ b/README.md
@@ -208,6 +208,13 @@ docker run --rm -p 8080:8080 --env-file .env gomodel
 | `/v1/batches/{id}/cancel`   | POST   | Cancel a pending batch                                                                                       |
 | `/v1/batches/{id}/results`  | GET    | Retrieve native batch results when available                                                                 |
 
+### Anthropic-Compatible API
+
+| Endpoint                    | Method | Description                                                                                                  |
+| --------------------------- | ------ | ------------------------------------------------------------------------------------------------------------ |
+| `/v1/messages`              | POST   | Anthropic Messages API through translated model routing (streaming supported)                                 |
+| `/v1/messages/count_tokens` | POST   | Heuristic Anthropic Messages input token estimate                                                            |
+
 ### Provider Passthrough
 
 | Endpoint            | Method                                       | Description                                        |
@@ -318,13 +325,15 @@ See [DEVELOPMENT.md](docs/DEVELOPMENT.md) for testing, linting, and pre-commit s
 
 - [ ] Intelligent routing
 - [ ] Broader provider support: Cohere, Command A, and Operational
-- [ ] Budget management with limits per `user_path` and/or API key
-- [ ] Editable model pricing for accurate cost tracking and budgeting
-- [ ] Full support for the OpenAI `/responses` and `/conversations` lifecycle
-- [ ] Prompt cache visibility showing how much of each prompt was cached by the provider
+- [x] Budget management with limits per `user_path` and/or API key
+- [x] Editable model pricing for accurate cost tracking and budgeting
+- [x] Full support for the OpenAI `/responses` lifecycle
+- [x] Anthropic-compatible `/messages` ingress and `/messages/count_tokens`
+- [ ] Full support for the OpenAI `/conversations` lifecycle
+- [x] Prompt cache visibility showing how much of each prompt was cached by the provider
 - [ ] Guardrails hardening: better UI, simpler architecture, easier custom guardrails, and response-side guardrails before output reaches the client
 - [ ] Passthrough for all providers, beyond the current OpenAI and Anthropic beta
-- [ ] Fix failover charts in the dashboard
+- [x] Fix failover charts in the dashboard
 
 ### Should Have
 

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ docker run --rm -p 8080:8080 --env-file .env gomodel
 | `/admin/usage/models`               | GET    | Usage breakdown by model                   |
 | `/admin/usage/user-paths`           | GET    | Usage breakdown by user path               |
 | `/admin/usage/log`                  | GET    | Paginated usage log entries                |
+| `/admin/audit/detail`               | GET    | Detailed audit entry information           |
 | `/admin/audit/log`                  | GET    | Paginated audit log entries                |
 | `/admin/audit/conversation`         | GET    | Conversation thread around one audit entry |
 | `/admin/providers/status`           | GET    | Provider availability status               |

--- a/cmd/gomodel/docs/docs.go
+++ b/cmd/gomodel/docs/docs.go
@@ -4055,10 +4055,17 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "content": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/anthropicapi.ContentBlock"
+                            }
+                        }
+                    ]
                 },
                 "role": {
                     "type": "string"
@@ -4093,10 +4100,17 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "system": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/anthropicapi.ContentBlock"
+                            }
+                        }
+                    ]
                 },
                 "temperature": {
                     "type": "number"
@@ -4168,10 +4182,8 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "input": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
+                    "type": "object",
+                    "additionalProperties": true
                 },
                 "name": {
                     "type": "string"
@@ -4205,10 +4217,8 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "input_schema": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
+                    "type": "object",
+                    "additionalProperties": true
                 },
                 "name": {
                     "type": "string"
@@ -6249,6 +6259,53 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "user_path": {
+                    "type": "string"
+                }
+            }
+        },
+        "anthropicapi.ContentBlock": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/anthropicapi.ContentBlock"
+                            }
+                        }
+                    ]
+                },
+                "id": {
+                    "type": "string"
+                },
+                "input": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "is_error": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "text": {
+                    "type": "string"
+                },
+                "thinking": {
+                    "type": "string"
+                },
+                "tool_use_id": {
+                    "type": "string"
+                },
+                "type": {
                     "type": "string"
                 }
             }

--- a/cmd/gomodel/docs/docs.go
+++ b/cmd/gomodel/docs/docs.go
@@ -6293,8 +6293,15 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "source": {
-                    "type": "object",
-                    "additionalProperties": true
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    ]
                 },
                 "text": {
                     "type": "string"

--- a/cmd/gomodel/docs/docs.go
+++ b/cmd/gomodel/docs/docs.go
@@ -67,6 +67,64 @@ const docTemplate = `{
                 ]
             }
         },
+        "/admin/audit/detail": {
+            "get": {
+                "description": "Returns one audit log entry enriched with usage summary when available.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Get audit log entry detail",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Audit log entry ID",
+                        "name": "log_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.auditLogEntryResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ]
+            }
+        },
         "/admin/audit/log": {
             "get": {
                 "produces": [
@@ -2867,6 +2925,120 @@ const docTemplate = `{
                 ]
             }
         },
+        "/v1/messages": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json",
+                    "text/event-stream"
+                ],
+                "tags": [
+                    "messages"
+                ],
+                "summary": "Create a message (Anthropic Messages API)",
+                "parameters": [
+                    {
+                        "description": "Anthropic Messages request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/anthropicapi.MessagesRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "JSON response or SSE stream when stream=true",
+                        "schema": {
+                            "$ref": "#/definitions/anthropicapi.MessagesResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/anthropicapi.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/anthropicapi.ErrorResponse"
+                        }
+                    },
+                    "429": {
+                        "description": "Too Many Requests",
+                        "schema": {
+                            "$ref": "#/definitions/anthropicapi.ErrorResponse"
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "schema": {
+                            "$ref": "#/definitions/anthropicapi.ErrorResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/v1/messages/count_tokens": {
+            "post": {
+                "description": "Returns a provider-agnostic heuristic estimate of the input token count.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "messages"
+                ],
+                "summary": "Count message tokens (Anthropic Messages API)",
+                "parameters": [
+                    {
+                        "description": "Anthropic Messages request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/anthropicapi.MessagesRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/anthropicapi.CountTokensResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/anthropicapi.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/anthropicapi.ErrorResponse"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ]
+            }
+        },
         "/v1/models": {
             "get": {
                 "produces": [
@@ -3449,6 +3621,9 @@ const docTemplate = `{
                 "CACHE_ENABLED": {
                     "type": "string"
                 },
+                "DASHBOARD_LIVE_LOGS_ENABLED": {
+                    "type": "string"
+                },
                 "FEATURE_FALLBACK_MODE": {
                     "type": "string"
                 },
@@ -3843,6 +4018,234 @@ const docTemplate = `{
                 },
                 "selector": {
                     "type": "string"
+                }
+            }
+        },
+        "anthropicapi.CountTokensResponse": {
+            "type": "object",
+            "properties": {
+                "input_tokens": {
+                    "type": "integer"
+                }
+            }
+        },
+        "anthropicapi.ErrorObject": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "anthropicapi.ErrorResponse": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "$ref": "#/definitions/anthropicapi.ErrorObject"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "anthropicapi.Message": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "role": {
+                    "type": "string"
+                }
+            }
+        },
+        "anthropicapi.MessagesRequest": {
+            "type": "object",
+            "properties": {
+                "max_tokens": {
+                    "type": "integer"
+                },
+                "messages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/anthropicapi.Message"
+                    }
+                },
+                "metadata": {
+                    "$ref": "#/definitions/anthropicapi.Metadata"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "stop_sequences": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "stream": {
+                    "type": "boolean"
+                },
+                "system": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "temperature": {
+                    "type": "number"
+                },
+                "thinking": {
+                    "$ref": "#/definitions/anthropicapi.Thinking"
+                },
+                "tool_choice": {
+                    "$ref": "#/definitions/anthropicapi.ToolChoice"
+                },
+                "tools": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/anthropicapi.Tool"
+                    }
+                },
+                "top_k": {
+                    "type": "integer"
+                },
+                "top_p": {
+                    "type": "number"
+                }
+            }
+        },
+        "anthropicapi.MessagesResponse": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/anthropicapi.ResponseContentBlock"
+                    }
+                },
+                "id": {
+                    "type": "string"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "stop_reason": {
+                    "type": "string"
+                },
+                "stop_sequence": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "usage": {
+                    "$ref": "#/definitions/anthropicapi.Usage"
+                }
+            }
+        },
+        "anthropicapi.Metadata": {
+            "type": "object",
+            "properties": {
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "anthropicapi.ResponseContentBlock": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "input": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "text": {
+                    "type": "string"
+                },
+                "thinking": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "anthropicapi.Thinking": {
+            "type": "object",
+            "properties": {
+                "budget_tokens": {
+                    "type": "integer"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "anthropicapi.Tool": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "input_schema": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "anthropicapi.ToolChoice": {
+            "type": "object",
+            "properties": {
+                "disable_parallel_tool_use": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "anthropicapi.Usage": {
+            "type": "object",
+            "properties": {
+                "cache_creation_input_tokens": {
+                    "type": "integer"
+                },
+                "cache_read_input_tokens": {
+                    "type": "integer"
+                },
+                "input_tokens": {
+                    "type": "integer"
+                },
+                "output_tokens": {
+                    "type": "integer"
                 }
             }
         },
@@ -5706,6 +6109,15 @@ const docTemplate = `{
                 "cache_type": {
                     "type": "string"
                 },
+                "cache_write_input_tokens": {
+                    "type": "integer"
+                },
+                "cached_input_ratio": {
+                    "type": "number"
+                },
+                "cached_input_tokens": {
+                    "type": "integer"
+                },
                 "cost_source": {
                     "type": "string"
                 },
@@ -5756,6 +6168,9 @@ const docTemplate = `{
                     "type": "number"
                 },
                 "total_tokens": {
+                    "type": "integer"
+                },
+                "uncached_input_tokens": {
                     "type": "integer"
                 },
                 "user_path": {
@@ -5855,7 +6270,7 @@ var SwaggerInfo = &swag.Spec{
 	BasePath:         "/",
 	Schemes:          []string{"http"},
 	Title:            "GoModel API",
-	Description:      "High-performance AI gateway routing requests to multiple LLM providers (OpenAI, Anthropic, Gemini, Groq, OpenRouter, DeepSeek, Z.ai, xAI, MiniMax, Oracle, Ollama). Drop-in OpenAI-compatible API.",
+	Description:      "AI gateway routing requests to multiple LLM providers (OpenAI, Anthropic, Gemini, Groq, OpenRouter, DeepSeek, Z.ai, xAI, MiniMax, Oracle, Ollama). Drop-in OpenAI-compatible API.",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,
 	LeftDelim:        "{{",

--- a/docs/about/roadmap.mdx
+++ b/docs/about/roadmap.mdx
@@ -8,12 +8,15 @@ icon: "list-todo"
 
 - [ ] Intelligent routing
 - [ ] Broader provider support: Cohere, Command A, and Operational
-- [ ] Budget management with limits per `user_path` and/or API key
-- [ ] Editable model pricing for accurate cost tracking and budgeting
-- [ ] Full support for the OpenAI `/responses` and `/conversations` lifecycle
-- [ ] Prompt cache visibility showing how much of each prompt was cached by the provider
+- [x] Budget management with limits per `user_path` and/or API key
+- [x] Editable model pricing for accurate cost tracking and budgeting
+- [x] Full support for the OpenAI `/responses` lifecycle
+- [x] Anthropic-compatible `/messages` ingress and `/messages/count_tokens`
+- [ ] Full support for the OpenAI `/conversations` lifecycle
+- [x] Prompt cache visibility showing how much of each prompt was cached by the provider
 - [ ] Guardrails hardening: better UI, simpler architecture, easier custom guardrails, and response-side guardrails before output reaches the client
 - [ ] Passthrough for all providers, beyond the current OpenAI and Anthropic beta
+- [x] Fix failover charts in the dashboard
 
 ### Should Have
 

--- a/docs/advanced/guardrails.mdx
+++ b/docs/advanced/guardrails.mdx
@@ -12,6 +12,7 @@ Guardrails work across all text-based endpoints:
 
 - `/v1/chat/completions`
 - `/v1/responses`
+- `/v1/messages`
 
 <Note>
   Guardrails for images, TTS, STT, and video models are planned as a separate
@@ -53,7 +54,7 @@ flowchart LR
 3. Modified messages are **applied back** to the original request
 4. The request continues to the LLM provider
 
-Guardrails never see the raw API request types — they operate on a normalized message list. This means the same guardrail works identically for `/chat/completions` and `/responses`.
+Guardrails never see the raw API request types — they operate on a normalized message list. This means the same guardrail works identically for `/chat/completions`, `/responses`, and `/messages`.
 
 ## Execution Order
 
@@ -341,10 +342,11 @@ Guardrails operate on a normalized message format internally. The adaptation bet
 | --------------------- | ------------------------ | -------------------- |
 | `/v1/chat/completions`| `messages` with `role: "system"` | `messages` array     |
 | `/v1/responses`       | `instructions` field     | `input` field        |
+| `/v1/messages`        | `system` field           | `messages` array     |
 
 <Tip>
   You don't need to think about which endpoint your users call. A single
-  guardrail rule works identically for both.
+  guardrail rule works identically for all supported text endpoints.
 </Tip>
 
 ## Errors and Rejection

--- a/docs/features/cache.mdx
+++ b/docs/features/cache.mdx
@@ -10,6 +10,7 @@ GoModel ships with two response-cache layers for non-streaming requests on:
 
 - `/v1/chat/completions`
 - `/v1/responses`
+- `/v1/messages`
 - `/v1/embeddings`
 
 Exact-match cache returns byte-identical responses with:

--- a/docs/features/failover.mdx
+++ b/docs/features/failover.mdx
@@ -67,5 +67,5 @@ Failover is attempted only after the primary request returns:
 - `429`
 - model unavailable, unsupported, or not found style errors
 
-It currently applies to translated `/v1/chat/completions` and `/v1/responses`
-requests, not `/v1/embeddings`.
+It currently applies to translated `/v1/chat/completions`, `/v1/responses`,
+and `/v1/messages` requests, not `/v1/embeddings`.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -8307,8 +8307,15 @@
             "type": "string"
           },
           "source": {
-            "type": "object",
-            "additionalProperties": true
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object",
+                "additionalProperties": true
+              }
+            ]
           },
           "text": {
             "type": "string"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "description": "High-performance AI gateway routing requests to multiple LLM providers (OpenAI, Anthropic, Gemini, Groq, OpenRouter, DeepSeek, Z.ai, xAI, MiniMax, Oracle, Ollama). Drop-in OpenAI-compatible API.",
+    "description": "AI gateway routing requests to multiple LLM providers (OpenAI, Anthropic, Gemini, Groq, OpenRouter, DeepSeek, Z.ai, xAI, MiniMax, Oracle, Ollama). Drop-in OpenAI-compatible API.",
     "title": "GoModel API",
     "contact": {},
     "version": "1.0"
@@ -72,6 +72,88 @@
         "x-mint": {
           "metadata": {
             "sidebarTitle": "/admin/audit/conversation"
+          }
+        }
+      }
+    },
+    "/admin/audit/detail": {
+      "get": {
+        "description": "Returns one audit log entry enriched with usage summary when available.",
+        "tags": [
+          "admin"
+        ],
+        "summary": "Get audit log entry detail",
+        "parameters": [
+          {
+            "description": "Audit log entry ID",
+            "name": "log_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/admin.auditLogEntryResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/audit/detail"
           }
         }
       }
@@ -4436,6 +4518,158 @@
         }
       }
     },
+    "/v1/messages": {
+      "post": {
+        "tags": [
+          "messages"
+        ],
+        "summary": "Create a message (Anthropic Messages API)",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/anthropicapi.MessagesRequest"
+        },
+        "responses": {
+          "200": {
+            "description": "JSON response or SSE stream when stream=true",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/anthropicapi.MessagesResponse"
+                }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/anthropicapi.MessagesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/anthropicapi.ErrorResponse"
+                }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/anthropicapi.ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/anthropicapi.ErrorResponse"
+                }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/anthropicapi.ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/anthropicapi.ErrorResponse"
+                }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/anthropicapi.ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Bad Gateway",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/anthropicapi.ErrorResponse"
+                }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/anthropicapi.ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/v1/messages"
+          }
+        }
+      }
+    },
+    "/v1/messages/count_tokens": {
+      "post": {
+        "description": "Returns a provider-agnostic heuristic estimate of the input token count.",
+        "tags": [
+          "messages"
+        ],
+        "summary": "Count message tokens (Anthropic Messages API)",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/anthropicapi.MessagesRequest"
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/anthropicapi.CountTokensResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/anthropicapi.ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/anthropicapi.ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/v1/messages/count_tokens"
+          }
+        }
+      }
+    },
     "/v1/models": {
       "get": {
         "tags": [
@@ -5254,6 +5488,19 @@
     }
   ],
   "components": {
+    "requestBodies": {
+      "anthropicapi.MessagesRequest": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/anthropicapi.MessagesRequest"
+            }
+          }
+        },
+        "description": "Anthropic Messages request",
+        "required": true
+      }
+    },
     "securitySchemes": {
       "BearerAuth": {
         "type": "http",
@@ -5269,6 +5516,9 @@
             "type": "string"
           },
           "CACHE_ENABLED": {
+            "type": "string"
+          },
+          "DASHBOARD_LIVE_LOGS_ENABLED": {
             "type": "string"
           },
           "FEATURE_FALLBACK_MODE": {
@@ -5704,6 +5954,234 @@
           "pricing",
           "selector"
         ]
+      },
+      "anthropicapi.CountTokensResponse": {
+        "type": "object",
+        "properties": {
+          "input_tokens": {
+            "type": "integer"
+          }
+        }
+      },
+      "anthropicapi.ErrorObject": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "anthropicapi.ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/anthropicapi.ErrorObject"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "anthropicapi.Message": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "role": {
+            "type": "string"
+          }
+        }
+      },
+      "anthropicapi.MessagesRequest": {
+        "type": "object",
+        "properties": {
+          "max_tokens": {
+            "type": "integer"
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/anthropicapi.Message"
+            }
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/anthropicapi.Metadata"
+          },
+          "model": {
+            "type": "string"
+          },
+          "stop_sequences": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "stream": {
+            "type": "boolean"
+          },
+          "system": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "temperature": {
+            "type": "number"
+          },
+          "thinking": {
+            "$ref": "#/components/schemas/anthropicapi.Thinking"
+          },
+          "tool_choice": {
+            "$ref": "#/components/schemas/anthropicapi.ToolChoice"
+          },
+          "tools": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/anthropicapi.Tool"
+            }
+          },
+          "top_k": {
+            "type": "integer"
+          },
+          "top_p": {
+            "type": "number"
+          }
+        }
+      },
+      "anthropicapi.MessagesResponse": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/anthropicapi.ResponseContentBlock"
+            }
+          },
+          "id": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string"
+          },
+          "stop_reason": {
+            "type": "string"
+          },
+          "stop_sequence": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/anthropicapi.Usage"
+          }
+        }
+      },
+      "anthropicapi.Metadata": {
+        "type": "object",
+        "properties": {
+          "user_id": {
+            "type": "string"
+          }
+        }
+      },
+      "anthropicapi.ResponseContentBlock": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "input": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "thinking": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "anthropicapi.Thinking": {
+        "type": "object",
+        "properties": {
+          "budget_tokens": {
+            "type": "integer"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "anthropicapi.Tool": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "input_schema": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "anthropicapi.ToolChoice": {
+        "type": "object",
+        "properties": {
+          "disable_parallel_tool_use": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "anthropicapi.Usage": {
+        "type": "object",
+        "properties": {
+          "cache_creation_input_tokens": {
+            "type": "integer"
+          },
+          "cache_read_input_tokens": {
+            "type": "integer"
+          },
+          "input_tokens": {
+            "type": "integer"
+          },
+          "output_tokens": {
+            "type": "integer"
+          }
+        }
       },
       "auditlog.ConversationResult": {
         "type": "object",
@@ -7601,6 +8079,15 @@
           "cache_type": {
             "type": "string"
           },
+          "cache_write_input_tokens": {
+            "type": "integer"
+          },
+          "cached_input_ratio": {
+            "type": "number"
+          },
+          "cached_input_tokens": {
+            "type": "integer"
+          },
           "cost_source": {
             "type": "string"
           },
@@ -7651,6 +8138,9 @@
             "type": "number"
           },
           "total_tokens": {
+            "type": "integer"
+          },
+          "uncached_input_tokens": {
             "type": "integer"
           },
           "user_path": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4538,7 +4538,7 @@
               },
               "text/event-stream": {
                 "schema": {
-                  "$ref": "#/components/schemas/anthropicapi.MessagesResponse"
+                  "$ref": "#/components/schemas/anthropicapi.SSEEventFrame"
                 }
               }
             }
@@ -8330,6 +8330,184 @@
             "type": "string"
           }
         }
+      },
+      "anthropicapi.SSEMessageStartEvent": {
+        "type": "object",
+        "required": [
+          "message",
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "message_start"
+            ]
+          },
+          "message": {
+            "$ref": "#/components/schemas/anthropicapi.MessagesResponse"
+          }
+        }
+      },
+      "anthropicapi.SSEContentBlockStartEvent": {
+        "type": "object",
+        "required": [
+          "content_block",
+          "index",
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "content_block_start"
+            ]
+          },
+          "index": {
+            "type": "integer"
+          },
+          "content_block": {
+            "$ref": "#/components/schemas/anthropicapi.ResponseContentBlock"
+          }
+        }
+      },
+      "anthropicapi.SSEContentBlockDeltaEvent": {
+        "type": "object",
+        "required": [
+          "delta",
+          "index",
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "content_block_delta"
+            ]
+          },
+          "index": {
+            "type": "integer"
+          },
+          "delta": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "anthropicapi.SSEContentBlockStopEvent": {
+        "type": "object",
+        "required": [
+          "index",
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "content_block_stop"
+            ]
+          },
+          "index": {
+            "type": "integer"
+          }
+        }
+      },
+      "anthropicapi.SSEMessageDeltaEvent": {
+        "type": "object",
+        "required": [
+          "delta",
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "message_delta"
+            ]
+          },
+          "delta": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "usage": {
+            "$ref": "#/components/schemas/anthropicapi.Usage"
+          }
+        }
+      },
+      "anthropicapi.SSEMessageStopEvent": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "message_stop"
+            ]
+          }
+        }
+      },
+      "anthropicapi.SSEPingEvent": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "ping"
+            ]
+          }
+        }
+      },
+      "anthropicapi.SSEErrorEvent": {
+        "type": "object",
+        "required": [
+          "error",
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "error"
+            ]
+          },
+          "error": {
+            "$ref": "#/components/schemas/anthropicapi.ErrorObject"
+          }
+        }
+      },
+      "anthropicapi.SSEEventFrame": {
+        "description": "One server-sent event frame emitted by streaming /v1/messages. On the wire each frame is sent as event: <name> and data: <JSON payload>.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/anthropicapi.SSEMessageStartEvent"
+          },
+          {
+            "$ref": "#/components/schemas/anthropicapi.SSEContentBlockStartEvent"
+          },
+          {
+            "$ref": "#/components/schemas/anthropicapi.SSEContentBlockDeltaEvent"
+          },
+          {
+            "$ref": "#/components/schemas/anthropicapi.SSEContentBlockStopEvent"
+          },
+          {
+            "$ref": "#/components/schemas/anthropicapi.SSEMessageDeltaEvent"
+          },
+          {
+            "$ref": "#/components/schemas/anthropicapi.SSEMessageStopEvent"
+          },
+          {
+            "$ref": "#/components/schemas/anthropicapi.SSEPingEvent"
+          },
+          {
+            "$ref": "#/components/schemas/anthropicapi.SSEErrorEvent"
+          }
+        ]
       }
     }
   }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -8480,9 +8480,22 @@
           }
         }
       },
+      "anthropicapi.SSEUnknownEvent": {
+        "description": "Fallback for future Anthropic streaming event payloads.",
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      },
       "anthropicapi.SSEEventFrame": {
-        "description": "One server-sent event frame emitted by streaming /v1/messages. On the wire each frame is sent as event: <name> and data: <JSON payload>.",
-        "oneOf": [
+        "description": "One server-sent event frame emitted by streaming /v1/messages. On the wire each frame is sent as event: <name> and data: <JSON payload>. Unknown event payloads are accepted for forward compatibility.",
+        "anyOf": [
           {
             "$ref": "#/components/schemas/anthropicapi.SSEMessageStartEvent"
           },
@@ -8506,6 +8519,9 @@
           },
           {
             "$ref": "#/components/schemas/anthropicapi.SSEErrorEvent"
+          },
+          {
+            "$ref": "#/components/schemas/anthropicapi.SSEUnknownEvent"
           }
         ]
       }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5989,10 +5989,17 @@
         "type": "object",
         "properties": {
           "content": {
-            "type": "array",
-            "items": {
-              "type": "integer"
-            }
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/anthropicapi.ContentBlock"
+                }
+              }
+            ]
           },
           "role": {
             "type": "string"
@@ -6027,10 +6034,17 @@
             "type": "boolean"
           },
           "system": {
-            "type": "array",
-            "items": {
-              "type": "integer"
-            }
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/anthropicapi.ContentBlock"
+                }
+              }
+            ]
           },
           "temperature": {
             "type": "number"
@@ -6102,10 +6116,8 @@
             "type": "string"
           },
           "input": {
-            "type": "array",
-            "items": {
-              "type": "integer"
-            }
+            "type": "object",
+            "additionalProperties": true
           },
           "name": {
             "type": "string"
@@ -6139,10 +6151,8 @@
             "type": "string"
           },
           "input_schema": {
-            "type": "array",
-            "items": {
-              "type": "integer"
-            }
+            "type": "object",
+            "additionalProperties": true
           },
           "name": {
             "type": "string"
@@ -8263,6 +8273,53 @@
           },
           "type": {
             "description": "\"message\", \"function_call\", \"function_call_output\"",
+            "type": "string"
+          }
+        }
+      },
+      "anthropicapi.ContentBlock": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/anthropicapi.ContentBlock"
+                }
+              }
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "input": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "is_error": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "source": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "text": {
+            "type": "string"
+          },
+          "thinking": {
+            "type": "string"
+          },
+          "tool_use_id": {
+            "type": "string"
+          },
+          "type": {
             "type": "string"
           }
         }

--- a/tools/openapi-postprocess.mjs
+++ b/tools/openapi-postprocess.mjs
@@ -246,9 +246,18 @@ function ensureAnthropicSSEEventSchemas() {
       error: { $ref: "#/components/schemas/anthropicapi.ErrorObject" },
     },
   };
+  schemas["anthropicapi.SSEUnknownEvent"] = {
+    description: "Fallback for future Anthropic streaming event payloads.",
+    type: "object",
+    required: ["type"],
+    properties: {
+      type: { type: "string" },
+    },
+    additionalProperties: true,
+  };
   schemas["anthropicapi.SSEEventFrame"] = {
-    description: "One server-sent event frame emitted by streaming /v1/messages. On the wire each frame is sent as event: <name> and data: <JSON payload>.",
-    oneOf: [
+    description: "One server-sent event frame emitted by streaming /v1/messages. On the wire each frame is sent as event: <name> and data: <JSON payload>. Unknown event payloads are accepted for forward compatibility.",
+    anyOf: [
       { $ref: "#/components/schemas/anthropicapi.SSEMessageStartEvent" },
       { $ref: "#/components/schemas/anthropicapi.SSEContentBlockStartEvent" },
       { $ref: "#/components/schemas/anthropicapi.SSEContentBlockDeltaEvent" },
@@ -257,6 +266,7 @@ function ensureAnthropicSSEEventSchemas() {
       { $ref: "#/components/schemas/anthropicapi.SSEMessageStopEvent" },
       { $ref: "#/components/schemas/anthropicapi.SSEPingEvent" },
       { $ref: "#/components/schemas/anthropicapi.SSEErrorEvent" },
+      { $ref: "#/components/schemas/anthropicapi.SSEUnknownEvent" },
     ],
   };
 }

--- a/tools/openapi-postprocess.mjs
+++ b/tools/openapi-postprocess.mjs
@@ -169,6 +169,109 @@ function applyAnthropicMessageSchemas() {
   schema("anthropicapi.Tool").properties.input_schema = freeFormObjectSchema();
 }
 
+function constStringSchema(value) {
+  return {
+    type: "string",
+    enum: [value],
+  };
+}
+
+function ensureAnthropicSSEEventSchemas() {
+  const schemas = spec.components?.schemas;
+  if (!schemas) {
+    throw new Error("missing OpenAPI components.schemas");
+  }
+  schemas["anthropicapi.SSEMessageStartEvent"] = {
+    type: "object",
+    required: ["message", "type"],
+    properties: {
+      type: constStringSchema("message_start"),
+      message: { $ref: "#/components/schemas/anthropicapi.MessagesResponse" },
+    },
+  };
+  schemas["anthropicapi.SSEContentBlockStartEvent"] = {
+    type: "object",
+    required: ["content_block", "index", "type"],
+    properties: {
+      type: constStringSchema("content_block_start"),
+      index: { type: "integer" },
+      content_block: { $ref: "#/components/schemas/anthropicapi.ResponseContentBlock" },
+    },
+  };
+  schemas["anthropicapi.SSEContentBlockDeltaEvent"] = {
+    type: "object",
+    required: ["delta", "index", "type"],
+    properties: {
+      type: constStringSchema("content_block_delta"),
+      index: { type: "integer" },
+      delta: freeFormObjectSchema(),
+    },
+  };
+  schemas["anthropicapi.SSEContentBlockStopEvent"] = {
+    type: "object",
+    required: ["index", "type"],
+    properties: {
+      type: constStringSchema("content_block_stop"),
+      index: { type: "integer" },
+    },
+  };
+  schemas["anthropicapi.SSEMessageDeltaEvent"] = {
+    type: "object",
+    required: ["delta", "type"],
+    properties: {
+      type: constStringSchema("message_delta"),
+      delta: freeFormObjectSchema(),
+      usage: { $ref: "#/components/schemas/anthropicapi.Usage" },
+    },
+  };
+  schemas["anthropicapi.SSEMessageStopEvent"] = {
+    type: "object",
+    required: ["type"],
+    properties: {
+      type: constStringSchema("message_stop"),
+    },
+  };
+  schemas["anthropicapi.SSEPingEvent"] = {
+    type: "object",
+    required: ["type"],
+    properties: {
+      type: constStringSchema("ping"),
+    },
+  };
+  schemas["anthropicapi.SSEErrorEvent"] = {
+    type: "object",
+    required: ["error", "type"],
+    properties: {
+      type: constStringSchema("error"),
+      error: { $ref: "#/components/schemas/anthropicapi.ErrorObject" },
+    },
+  };
+  schemas["anthropicapi.SSEEventFrame"] = {
+    description: "One server-sent event frame emitted by streaming /v1/messages. On the wire each frame is sent as event: <name> and data: <JSON payload>.",
+    oneOf: [
+      { $ref: "#/components/schemas/anthropicapi.SSEMessageStartEvent" },
+      { $ref: "#/components/schemas/anthropicapi.SSEContentBlockStartEvent" },
+      { $ref: "#/components/schemas/anthropicapi.SSEContentBlockDeltaEvent" },
+      { $ref: "#/components/schemas/anthropicapi.SSEContentBlockStopEvent" },
+      { $ref: "#/components/schemas/anthropicapi.SSEMessageDeltaEvent" },
+      { $ref: "#/components/schemas/anthropicapi.SSEMessageStopEvent" },
+      { $ref: "#/components/schemas/anthropicapi.SSEPingEvent" },
+      { $ref: "#/components/schemas/anthropicapi.SSEErrorEvent" },
+    ],
+  };
+}
+
+function applyAnthropicMessagesStreamSchema() {
+  ensureAnthropicSSEEventSchemas();
+  const streamResponse = spec.paths?.["/v1/messages"]?.post?.responses?.["200"]?.content?.["text/event-stream"];
+  if (!streamResponse) {
+    throw new Error("missing OpenAPI text/event-stream response: POST /v1/messages 200");
+  }
+  streamResponse.schema = {
+    $ref: "#/components/schemas/anthropicapi.SSEEventFrame",
+  };
+}
+
 function ensureBearerAuthSecurityScheme() {
   const securitySchemes = spec.components?.securitySchemes;
   if (!securitySchemes?.BearerAuth) {
@@ -281,6 +384,7 @@ function applyBudgetKeySchemaConstraints() {
 spec.servers = parseServers(process.env.DOCS_API_SERVERS);
 ensureResponsesInputElementSchema();
 applyAnthropicMessageSchemas();
+applyAnthropicMessagesStreamSchema();
 ensureBearerAuthSecurityScheme();
 ensureRequiredProperty("admin.recalculatePricingRequest", "confirmation");
 ensureRequiredProperty("admin.upsertBudgetRequest", "amount");

--- a/tools/openapi-postprocess.mjs
+++ b/tools/openapi-postprocess.mjs
@@ -130,6 +130,15 @@ function freeFormObjectSchema() {
   };
 }
 
+function stringOrFreeFormObjectSchema() {
+  return {
+    oneOf: [
+      { type: "string" },
+      freeFormObjectSchema(),
+    ],
+  };
+}
+
 function ensureAnthropicContentBlockSchema() {
   const schemas = spec.components?.schemas;
   if (!schemas) {
@@ -143,7 +152,7 @@ function ensureAnthropicContentBlockSchema() {
       input: freeFormObjectSchema(),
       is_error: { type: "boolean" },
       name: { type: "string" },
-      source: freeFormObjectSchema(),
+      source: stringOrFreeFormObjectSchema(),
       text: { type: "string" },
       thinking: { type: "string" },
       tool_use_id: { type: "string" },

--- a/tools/openapi-postprocess.mjs
+++ b/tools/openapi-postprocess.mjs
@@ -111,6 +111,55 @@ function ensureResponsesInputElementSchema() {
   };
 }
 
+function anthropicContentSchema() {
+  return {
+    oneOf: [
+      { type: "string" },
+      {
+        type: "array",
+        items: { $ref: "#/components/schemas/anthropicapi.ContentBlock" },
+      },
+    ],
+  };
+}
+
+function freeFormObjectSchema() {
+  return {
+    type: "object",
+    additionalProperties: true,
+  };
+}
+
+function ensureAnthropicContentBlockSchema() {
+  const schemas = spec.components?.schemas;
+  if (!schemas) {
+    throw new Error("missing OpenAPI components.schemas");
+  }
+  schemas["anthropicapi.ContentBlock"] = {
+    type: "object",
+    properties: {
+      content: anthropicContentSchema(),
+      id: { type: "string" },
+      input: freeFormObjectSchema(),
+      is_error: { type: "boolean" },
+      name: { type: "string" },
+      source: freeFormObjectSchema(),
+      text: { type: "string" },
+      thinking: { type: "string" },
+      tool_use_id: { type: "string" },
+      type: { type: "string" },
+    },
+  };
+}
+
+function applyAnthropicMessageSchemas() {
+  ensureAnthropicContentBlockSchema();
+  schema("anthropicapi.Message").properties.content = anthropicContentSchema();
+  schema("anthropicapi.MessagesRequest").properties.system = anthropicContentSchema();
+  schema("anthropicapi.ResponseContentBlock").properties.input = freeFormObjectSchema();
+  schema("anthropicapi.Tool").properties.input_schema = freeFormObjectSchema();
+}
+
 function ensureBearerAuthSecurityScheme() {
   const securitySchemes = spec.components?.securitySchemes;
   if (!securitySchemes?.BearerAuth) {
@@ -222,6 +271,7 @@ function applyBudgetKeySchemaConstraints() {
 
 spec.servers = parseServers(process.env.DOCS_API_SERVERS);
 ensureResponsesInputElementSchema();
+applyAnthropicMessageSchemas();
 ensureBearerAuthSecurityScheme();
 ensureRequiredProperty("admin.recalculatePricingRequest", "confirmation");
 ensureRequiredProperty("admin.upsertBudgetRequest", "amount");

--- a/tools/swagger-postprocess.mjs
+++ b/tools/swagger-postprocess.mjs
@@ -52,6 +52,15 @@ function freeFormObjectSchema() {
   };
 }
 
+function stringOrFreeFormObjectSchema() {
+  return {
+    oneOf: [
+      { type: "string" },
+      freeFormObjectSchema(),
+    ],
+  };
+}
+
 function ensureAnthropicContentBlockSchema() {
   if (!spec.definitions) {
     throw new Error("missing Swagger definitions");
@@ -64,7 +73,7 @@ function ensureAnthropicContentBlockSchema() {
       input: freeFormObjectSchema(),
       is_error: { type: "boolean" },
       name: { type: "string" },
-      source: freeFormObjectSchema(),
+      source: stringOrFreeFormObjectSchema(),
       text: { type: "string" },
       thinking: { type: "string" },
       tool_use_id: { type: "string" },

--- a/tools/swagger-postprocess.mjs
+++ b/tools/swagger-postprocess.mjs
@@ -1,0 +1,92 @@
+import fs from "node:fs";
+
+const file = process.argv[2] || "cmd/gomodel/docs/docs.go";
+const source = fs.readFileSync(file, "utf8");
+const marker = "const docTemplate = `";
+const start = source.indexOf(marker);
+if (start < 0) {
+  throw new Error("missing docTemplate start");
+}
+const templateStart = start + marker.length;
+const end = source.indexOf("`\n\n// SwaggerInfo", templateStart);
+if (end < 0) {
+  throw new Error("missing docTemplate end");
+}
+
+const schemesMarker = "__GOMODEL_SWAGGER_SCHEMES__";
+const template = source.slice(templateStart, end);
+const rawBacktickJoin = "` + \"`\" + `";
+const parseableTemplate = template.replace(
+  new RegExp(rawBacktickJoin.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g"),
+  "`",
+).replace(
+  "{{ marshal .Schemes }}",
+  `["${schemesMarker}"]`,
+);
+const spec = JSON.parse(parseableTemplate);
+
+function schema(name) {
+  const result = spec.definitions?.[name];
+  if (!result) {
+    throw new Error(`missing Swagger definition: ${name}`);
+  }
+  return result;
+}
+
+function anthropicContentSchema() {
+  return {
+    oneOf: [
+      { type: "string" },
+      {
+        type: "array",
+        items: { $ref: "#/definitions/anthropicapi.ContentBlock" },
+      },
+    ],
+  };
+}
+
+function freeFormObjectSchema() {
+  return {
+    type: "object",
+    additionalProperties: true,
+  };
+}
+
+function ensureAnthropicContentBlockSchema() {
+  if (!spec.definitions) {
+    throw new Error("missing Swagger definitions");
+  }
+  spec.definitions["anthropicapi.ContentBlock"] = {
+    type: "object",
+    properties: {
+      content: anthropicContentSchema(),
+      id: { type: "string" },
+      input: freeFormObjectSchema(),
+      is_error: { type: "boolean" },
+      name: { type: "string" },
+      source: freeFormObjectSchema(),
+      text: { type: "string" },
+      thinking: { type: "string" },
+      tool_use_id: { type: "string" },
+      type: { type: "string" },
+    },
+  };
+}
+
+function applyAnthropicMessageSchemas() {
+  ensureAnthropicContentBlockSchema();
+  schema("anthropicapi.Message").properties.content = anthropicContentSchema();
+  schema("anthropicapi.MessagesRequest").properties.system = anthropicContentSchema();
+  schema("anthropicapi.ResponseContentBlock").properties.input = freeFormObjectSchema();
+  schema("anthropicapi.Tool").properties.input_schema = freeFormObjectSchema();
+}
+
+applyAnthropicMessageSchemas();
+
+let rendered = JSON.stringify(spec, null, 4);
+rendered = rendered.replace(
+  `"schemes": [\n        "${schemesMarker}"\n    ]`,
+  `"schemes": {{ marshal .Schemes }}`,
+).replace(/`/g, rawBacktickJoin);
+
+fs.writeFileSync(file, `${source.slice(0, templateStart)}${rendered}${source.slice(end)}`);


### PR DESCRIPTION
## Summary
- Run GoReleaser as a draft release in parallel with Docker builds, then publish only after Docker tag promotion succeeds.
- Mark completed 0.2.0 roadmap items in README and docs, including /messages support.
- Add /v1/messages and /v1/messages/count_tokens to README, docs, and generated OpenAPI output.

## Verification
- make swagger
- YAML parse check
- jq empty docs/openapi.json
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml
- go run github.com/goreleaser/goreleaser/v2@latest check
- go test -tags=swagger ./cmd/gomodel
- git diff --check
- pre-commit hooks during commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Anthropic-compatible /v1/messages and /v1/messages/count_tokens endpoints
  * Added admin GET /admin/audit/detail endpoint
  * Extended usage logs with cache-related token metrics

* **Documentation**
  * Updated API docs, OpenAPI/Swagger output, guardrails, caching, and failover docs to include Anthropic endpoints
  * Updated roadmap progress for 0.2.0

* **Chores**
  * Release workflow now builds draft releases and adds a separate publish step

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ENTERPILOT/GoModel/pull/346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->