### PR TITLE
feat(routing): add canonical model pools and admin controls

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -185,6 +185,72 @@ fallback:
     "claude-sonnet-4":
       mode: "off" # disable fallback just for this model
 
+routing:
+  # Canonical model pool routing.
+  #
+  # Use this section when you want clients to call a stable public model name
+  # (for example: "claude-sonnet-4-6") while the gateway maps that name to one
+  # or more exact provider/model candidates.
+  #
+  # Typical use cases:
+  # - multiple named accounts expose the same logical model with different IDs;
+  # - one provider/account should be primary and another should be a standby;
+  # - traffic should be distributed across equivalent candidates;
+  # - operators need manual enable/disable control per provider, canonical model,
+  #   or pool candidate through the admin API/dashboard.
+  defaults:
+    strategy: "priority_failover" # "priority_failover" = always prefer the lowest priority candidate; "weighted_round_robin" = distribute requests by weight
+    session_affinity: true # parsed sticky-routing setting for canonical pools; keep enabled if you want future/runtime affinity support to pin repeated requests to the same candidate
+    session_affinity_ttl: 30m # parsed TTL for session affinity bindings
+    failover:
+      enabled: true # when true, eligible errors can move the request to the next candidate in the same canonical pool
+      max_attempts: 3 # total attempts across pool candidates, including the first candidate
+      retry_on_statuses: [429, 500, 502, 503, 504] # provider statuses that qualify for retry/failover
+      retry_on_model_errors: true # also retry/fail over on model-unavailable / model-not-found / model-unsupported style errors
+
+  # model_pools map one public canonical model name to one or more exact provider
+  # candidates. The canonical key is what clients send in requests to the gateway.
+  #
+  # Example A: primary/backup routing.
+  # - Use strategy: "priority_failover"
+  # - Lower priority number wins during normal routing
+  # - Other candidates are used only when failover is triggered
+  #
+  # model_pools:
+  #   claude-sonnet-4-6:
+  #     candidates:
+  #       - provider: anthropic_primary
+  #         model: claude-sonnet-4-6
+  #         priority: 1
+  #       - provider: anthropic_backup
+  #         model: claude-sonnet-4-6-20250929
+  #         priority: 2
+  #
+  # Example B: weighted distribution across equivalent candidates.
+  # - Use strategy: "weighted_round_robin"
+  # - Higher weight receives more traffic
+  # - priority is still useful as a deterministic tie-breaker
+  #
+  # model_pools:
+  #   claude-opus-4-7:
+  #     candidates:
+  #       - provider: anthropic_primary
+  #         model: claude-opus-4-7
+  #         weight: 10
+  #         priority: 1
+  #       - provider: anthropic_backup
+  #         model: claude-opus-4-7
+  #         weight: 6
+  #         priority: 2
+  #
+  # Notes:
+  # - provider must match the named provider key under `providers:`.
+  # - model must be the exact provider-facing model ID.
+  # - canonical names are declared explicitly; the gateway does not infer that
+  #   dated and non-dated model IDs are equivalent.
+  # - if a canonical model has no pool entry, normal alias/provider resolution
+  #   continues to apply.
+
 providers:
   openai:
     type: openai

--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	Admin      AdminConfig      `yaml:"admin"`
 	Guardrails GuardrailsConfig `yaml:"guardrails"`
 	Fallback   FallbackConfig   `yaml:"fallback"`
+	Routing    RoutingConfig    `yaml:"routing"`
 	Workflows  WorkflowsConfig  `yaml:"workflows"`
 	Resilience ResilienceConfig `yaml:"resilience"`
 }
@@ -115,6 +116,19 @@ func buildDefaultConfig() *Config {
 		Fallback: FallbackConfig{
 			DefaultMode: FallbackModeManual,
 		},
+		Routing: RoutingConfig{
+			Defaults: RoutingDefaultsConfig{
+				Strategy:           RoutingStrategyPriorityFailover,
+				SessionAffinity:    true,
+				SessionAffinityTTL: 30 * time.Minute,
+				Failover: RoutingFailoverConfig{
+					Enabled:            true,
+					MaxAttempts:        3,
+					RetryOnStatuses:    []int{429, 500, 502, 503, 504},
+					RetryOnModelErrors: true,
+				},
+			},
+		},
 		Workflows: WorkflowsConfig{
 			RefreshInterval: time.Minute,
 		},
@@ -178,6 +192,9 @@ func Load() (*LoadResult, error) {
 	}
 
 	if err := loadFallbackConfig(&cfg.Fallback); err != nil {
+		return nil, err
+	}
+	if err := loadRoutingConfig(&cfg.Routing); err != nil {
 		return nil, err
 	}
 

--- a/config/config_example_test.go
+++ b/config/config_example_test.go
@@ -11,12 +11,14 @@ func TestLoad_FromEnvironment(t *testing.T) {
 		_ = os.Unsetenv("PORT")
 	}()
 
-	result, err := Load()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	withTempDir(t, func(string) {
+		result, err := Load()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 
-	if result.Config.Server.Port != "9090" {
-		t.Errorf("expected port 9090, got %s", result.Config.Server.Port)
-	}
+		if result.Config.Server.Port != "9090" {
+			t.Errorf("expected port 9090, got %s", result.Config.Server.Port)
+		}
+	})
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -133,6 +133,9 @@ func TestBuildDefaultConfig(t *testing.T) {
 	if cfg.Storage.Type != "sqlite" {
 		t.Errorf("expected Storage.Type=sqlite, got %s", cfg.Storage.Type)
 	}
+	if cfg.Routing.Defaults.Strategy != RoutingStrategyPriorityFailover {
+		t.Errorf("expected Routing.Defaults.Strategy=%q, got %q", RoutingStrategyPriorityFailover, cfg.Routing.Defaults.Strategy)
+	}
 	if cfg.Storage.SQLite.Path != "data/gomodel.db" {
 		t.Errorf("expected Storage.SQLite.Path=data/gomodel.db, got %s", cfg.Storage.SQLite.Path)
 	}
@@ -710,6 +713,81 @@ fallback:
 
 		if _, err := Load(); err == nil {
 			t.Fatal("expected Load() to fail for invalid fallback mode")
+		}
+	})
+}
+
+func TestLoad_RoutingConfigYAML(t *testing.T) {
+	clearAllConfigEnvVars(t)
+
+	withTempDir(t, func(dir string) {
+		yaml := `
+routing:
+  defaults:
+    strategy: weighted_round_robin
+    session_affinity: false
+    session_affinity_ttl: 45m
+    failover:
+      enabled: true
+      max_attempts: 5
+      retry_on_statuses: [429, 503]
+      retry_on_model_errors: false
+  model_pools:
+    claude-sonnet-4-6:
+      candidates:
+        - provider: anthropic_b
+          model: claude-sonnet-4-6
+          weight: 10
+          priority: 1
+        - provider: anthropic_a
+          model: claude-sonnet-4-6-20250929
+          weight: 8
+          priority: 2
+`
+		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(yaml), 0644); err != nil {
+			t.Fatalf("Failed to write config.yaml: %v", err)
+		}
+
+		result, err := Load()
+		if err != nil {
+			t.Fatalf("Load() failed: %v", err)
+		}
+		cfg := result.Config
+		if cfg.Routing.Defaults.Strategy != RoutingStrategyWeightedRoundRobin {
+			t.Fatalf("Routing.Defaults.Strategy = %q, want %q", cfg.Routing.Defaults.Strategy, RoutingStrategyWeightedRoundRobin)
+		}
+		if cfg.Routing.Defaults.SessionAffinity {
+			t.Fatal("expected SessionAffinity=false from YAML")
+		}
+		if cfg.Routing.Defaults.SessionAffinityTTL != 45*time.Minute {
+			t.Fatalf("SessionAffinityTTL = %s, want 45m", cfg.Routing.Defaults.SessionAffinityTTL)
+		}
+		pool := cfg.Routing.ModelPools["claude-sonnet-4-6"]
+		if len(pool.Candidates) != 2 {
+			t.Fatalf("len(pool.Candidates) = %d, want 2", len(pool.Candidates))
+		}
+	})
+}
+
+func TestLoad_InvalidRoutingStrategy(t *testing.T) {
+	clearAllConfigEnvVars(t)
+
+	withTempDir(t, func(dir string) {
+		yaml := `
+routing:
+  defaults:
+    strategy: invalid
+`
+		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(yaml), 0644); err != nil {
+			t.Fatalf("Failed to write config.yaml: %v", err)
+		}
+
+		_, err := Load()
+		if err == nil {
+			t.Fatal("expected Load() to fail for invalid routing strategy")
+		}
+		if !strings.Contains(err.Error(), "routing.defaults.strategy must be one of") {
+			t.Fatalf("Load() error = %v, want routing strategy validation error", err)
 		}
 	})
 }

--- a/config/routing.go
+++ b/config/routing.go
@@ -1,0 +1,152 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+type RoutingStrategy string
+
+const (
+	RoutingStrategyPriorityFailover   RoutingStrategy = "priority_failover"
+	RoutingStrategyWeightedRoundRobin RoutingStrategy = "weighted_round_robin"
+)
+
+func normalizeRoutingStrategy(strategy RoutingStrategy) RoutingStrategy {
+	return RoutingStrategy(strings.ToLower(strings.TrimSpace(string(strategy))))
+}
+
+func ResolveRoutingStrategy(strategy RoutingStrategy) RoutingStrategy {
+	strategy = normalizeRoutingStrategy(strategy)
+	if strategy == "" {
+		return RoutingStrategyPriorityFailover
+	}
+	return strategy
+}
+
+func (s RoutingStrategy) Valid() bool {
+	switch normalizeRoutingStrategy(s) {
+	case RoutingStrategyPriorityFailover, RoutingStrategyWeightedRoundRobin:
+		return true
+	default:
+		return false
+	}
+}
+
+// RoutingConfig holds canonical model pool routing configuration.
+type RoutingConfig struct {
+	Defaults   RoutingDefaultsConfig       `yaml:"defaults"`
+	ModelPools map[string]ModelPoolConfig `yaml:"model_pools"`
+}
+
+// RoutingDefaultsConfig holds default routing behavior for canonical pools.
+type RoutingDefaultsConfig struct {
+	Strategy          RoutingStrategy      `yaml:"strategy"`
+	SessionAffinity   bool                 `yaml:"session_affinity"`
+	SessionAffinityTTL time.Duration       `yaml:"session_affinity_ttl"`
+	Failover          RoutingFailoverConfig `yaml:"failover"`
+}
+
+// RoutingFailoverConfig controls fallback between candidates within the same pool.
+type RoutingFailoverConfig struct {
+	Enabled            bool  `yaml:"enabled"`
+	MaxAttempts        int   `yaml:"max_attempts"`
+	RetryOnStatuses    []int `yaml:"retry_on_statuses"`
+	RetryOnModelErrors bool  `yaml:"retry_on_model_errors"`
+}
+
+// ModelPoolConfig maps one public canonical model name to concrete provider candidates.
+type ModelPoolConfig struct {
+	Candidates []ModelPoolCandidateConfig `yaml:"candidates"`
+}
+
+// ModelPoolCandidateConfig defines one concrete provider/model candidate.
+type ModelPoolCandidateConfig struct {
+	Provider string `yaml:"provider"`
+	Model    string `yaml:"model"`
+	Priority int    `yaml:"priority"`
+	Weight   int    `yaml:"weight"`
+}
+
+func loadRoutingConfig(cfg *RoutingConfig) error {
+	if cfg == nil {
+		return nil
+	}
+
+	cfg.Defaults.Strategy = ResolveRoutingStrategy(cfg.Defaults.Strategy)
+	if !cfg.Defaults.Strategy.Valid() {
+		return fmt.Errorf("routing.defaults.strategy must be one of: priority_failover, weighted_round_robin")
+	}
+	if cfg.Defaults.SessionAffinityTTL <= 0 {
+		cfg.Defaults.SessionAffinityTTL = 30 * time.Minute
+	}
+	if cfg.Defaults.Failover.MaxAttempts <= 0 {
+		cfg.Defaults.Failover.MaxAttempts = 3
+	}
+	if len(cfg.Defaults.Failover.RetryOnStatuses) == 0 {
+		cfg.Defaults.Failover.RetryOnStatuses = []int{429, 500, 502, 503, 504}
+	}
+
+	if len(cfg.ModelPools) == 0 {
+		cfg.ModelPools = nil
+		return nil
+	}
+
+	normalized := make(map[string]ModelPoolConfig, len(cfg.ModelPools))
+	keys := make([]string, 0, len(cfg.ModelPools))
+	for key := range cfg.ModelPools {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		trimmedKey := strings.TrimSpace(key)
+		if trimmedKey == "" {
+			return fmt.Errorf("routing.model_pools: model key cannot be empty")
+		}
+		if _, exists := normalized[trimmedKey]; exists {
+			return fmt.Errorf("routing.model_pools: duplicate model key after trimming: %q", trimmedKey)
+		}
+		pool := cfg.ModelPools[key]
+		if len(pool.Candidates) == 0 {
+			return fmt.Errorf("routing.model_pools[%q]: at least one candidate is required", trimmedKey)
+		}
+
+		seenCandidates := make(map[string]struct{}, len(pool.Candidates))
+		normalizedCandidates := make([]ModelPoolCandidateConfig, 0, len(pool.Candidates))
+		for idx, candidate := range pool.Candidates {
+			candidate.Provider = strings.TrimSpace(candidate.Provider)
+			candidate.Model = strings.TrimSpace(candidate.Model)
+			if candidate.Provider == "" {
+				return fmt.Errorf("routing.model_pools[%q].candidates[%d].provider is required", trimmedKey, idx)
+			}
+			if candidate.Model == "" {
+				return fmt.Errorf("routing.model_pools[%q].candidates[%d].model is required", trimmedKey, idx)
+			}
+			candidateKey := candidate.Provider + "/" + candidate.Model
+			if _, exists := seenCandidates[candidateKey]; exists {
+				return fmt.Errorf("routing.model_pools[%q]: duplicate candidate %q", trimmedKey, candidateKey)
+			}
+			seenCandidates[candidateKey] = struct{}{}
+
+			switch cfg.Defaults.Strategy {
+			case RoutingStrategyPriorityFailover:
+				if candidate.Priority <= 0 {
+					return fmt.Errorf("routing.model_pools[%q].candidates[%d].priority must be > 0 for priority_failover", trimmedKey, idx)
+				}
+			case RoutingStrategyWeightedRoundRobin:
+				if candidate.Weight <= 0 {
+					return fmt.Errorf("routing.model_pools[%q].candidates[%d].weight must be > 0 for weighted_round_robin", trimmedKey, idx)
+				}
+			}
+
+			normalizedCandidates = append(normalizedCandidates, candidate)
+		}
+		normalized[trimmedKey] = ModelPoolConfig{Candidates: normalizedCandidates}
+	}
+
+	cfg.ModelPools = normalized
+	return nil
+}

--- a/docs/features/canonical-routing.mdx
+++ b/docs/features/canonical-routing.mdx
@@ -1,0 +1,333 @@
+---
+title: "Canonical Routing"
+description: "Route one public model name to multiple concrete provider candidates with priority failover, weighted distribution, session affinity, and admin controls."
+icon: "git-branch"
+keywords: ["routing", "failover", "session affinity", "canonical models", "model pools"]
+---
+
+## Overview
+
+GoModel can now expose one **stable public model name** while routing requests to
+one or more **exact provider/model candidates** behind the scenes.
+
+This is useful when:
+
+- multiple named provider accounts expose the same logical model under slightly different IDs;
+- one provider should be the normal primary and another should be a standby;
+- traffic should be distributed across equivalent backends;
+- operators need to disable a provider, a canonical model, or a single candidate without changing client requests.
+
+## What This Feature Adds
+
+Canonical routing introduces a new `routing` config block with:
+
+- per-pool routing strategies;
+- provider/model candidate lists;
+- intra-pool failover rules;
+- session affinity for repeated requests;
+- runtime-aware candidate filtering;
+- admin endpoints and dashboard controls for provider, canonical model, and candidate state.
+
+Clients keep sending the canonical model name. GoModel resolves it to the best
+currently eligible provider/model candidate.
+
+## Configuration
+
+### Top-level routing block
+
+```yaml
+routing:
+  defaults:
+    strategy: "priority_failover"
+    session_affinity: true
+    session_affinity_ttl: 30m
+    failover:
+      enabled: true
+      max_attempts: 3
+      retry_on_statuses: [429, 500, 502, 503, 504]
+      retry_on_model_errors: true
+```
+
+### Available defaults
+
+#### `routing.defaults.strategy`
+
+Controls how GoModel chooses the initial candidate inside each canonical pool.
+
+Supported values:
+
+- `priority_failover`
+- `weighted_round_robin`
+
+`priority_failover` always prefers the candidate with the lowest `priority`
+value. `weighted_round_robin` distributes requests by `weight`.
+
+#### `routing.defaults.session_affinity`
+
+When enabled, repeated requests for the same canonical model and the same
+request scope stay pinned to the same candidate while that candidate remains
+eligible.
+
+GoModel currently derives the affinity key from:
+
+1. `user_path`, when present;
+2. request ID as a fallback when no `user_path` is available.
+
+#### `routing.defaults.session_affinity_ttl`
+
+How long an affinity binding stays valid.
+
+If the pinned candidate becomes unavailable, unhealthy, or manually disabled,
+GoModel reselects a new candidate and refreshes the binding.
+
+#### `routing.defaults.failover.enabled`
+
+Enables failover to the next candidate in the same canonical pool.
+
+#### `routing.defaults.failover.max_attempts`
+
+Total number of attempts allowed within one canonical pool, including the first
+candidate.
+
+#### `routing.defaults.failover.retry_on_statuses`
+
+HTTP statuses that qualify for retry/failover inside the same pool.
+
+#### `routing.defaults.failover.retry_on_model_errors`
+
+Also fail over on model-unavailable, model-not-found, and model-unsupported
+style errors.
+
+## Model pools
+
+Canonical names are declared explicitly in `routing.model_pools`.
+
+```yaml
+routing:
+  defaults:
+    strategy: "priority_failover"
+    session_affinity: true
+    session_affinity_ttl: 30m
+    failover:
+      enabled: true
+      max_attempts: 3
+      retry_on_statuses: [429, 500, 502, 503, 504]
+      retry_on_model_errors: true
+
+  model_pools:
+    claude-sonnet-4-6:
+      candidates:
+        - provider: anthropic_primary
+          model: claude-sonnet-4-6
+          priority: 1
+        - provider: anthropic_backup
+          model: claude-sonnet-4-6-20250929
+          priority: 2
+```
+
+### Candidate fields
+
+Each candidate supports:
+
+- `provider`: configured provider instance name from `providers:`
+- `model`: exact provider-facing model ID
+- `priority`: required for `priority_failover`
+- `weight`: required for `weighted_round_robin`
+
+## Weighted distribution example
+
+```yaml
+routing:
+  defaults:
+    strategy: "weighted_round_robin"
+    session_affinity: true
+    session_affinity_ttl: 30m
+
+  model_pools:
+    claude-opus-4-7:
+      candidates:
+        - provider: anthropic_primary
+          model: claude-opus-4-7
+          weight: 10
+          priority: 1
+        - provider: anthropic_backup
+          model: claude-opus-4-7
+          weight: 6
+          priority: 2
+```
+
+Higher `weight` gets more traffic. `priority` still acts as a deterministic
+secondary ordering input.
+
+## Provider inventories and configured model lists
+
+Canonical routing works best when provider inventories are explicit and stable.
+
+`models.configured_provider_models_mode` still matters with canonical pools:
+
+- `fallback`: use configured provider model lists only when provider `/models` is unavailable or empty;
+- `allowlist`: expose only configured models and skip provider `/models` for providers that declare a list.
+
+This matters because pool candidates must reference exact provider model IDs
+that exist either in the live provider inventory or in `providers.<name>.models`.
+
+## Runtime eligibility rules
+
+GoModel now evaluates candidates using both **manual state** and **runtime
+health**.
+
+### Manual state
+
+A candidate may become ineligible because:
+
+- its provider was disabled manually;
+- the canonical model was disabled manually;
+- the candidate itself was disabled manually.
+
+### Runtime state
+
+GoModel classifies provider runtime as:
+
+- `healthy`
+- `degraded`
+- `unhealthy`
+
+Routing behavior:
+
+- `healthy`: eligible
+- `degraded`: still eligible, but marked degraded
+- `unhealthy`: removed from effective selection
+
+## `/v1/models` behavior
+
+`GET /v1/models` now reflects the same effective routing policy.
+
+For each canonical pool, GoModel exposes the model only when at least one
+candidate is effectively eligible.
+
+The model entry is derived from the **effective selected candidate**, not simply
+from the first configured candidate.
+
+## Admin API and dashboard
+
+This change adds operational state and routing visibility to the admin surface.
+
+### Admin endpoints
+
+- `GET /admin/routing-state`
+- `PUT /admin/routing-state`
+- `DELETE /admin/routing-state`
+- `GET /admin/routing/model-pools`
+
+### What the dashboard now shows
+
+For each candidate, the dashboard distinguishes:
+
+- **Config Primary**: the candidate preferred by pool configuration;
+- **Effective Candidate**: the candidate currently selected by the live routing decision.
+
+It also shows:
+
+- canonical model status;
+- candidate status;
+- runtime degradation;
+- blocked candidates and their reasons;
+- provider/canonical/candidate enable-disable controls.
+
+## Request observability
+
+Canonical routing now records structured routing metadata during request
+resolution and failover.
+
+Available fields include:
+
+- requested model
+- canonical model
+- routing strategy
+- config primary candidate
+- effective candidate
+- selected provider name
+- selected exact model
+- blocked candidates
+- failover usage
+- fallback target
+
+When a failover happens inside a canonical pool, GoModel updates the request
+resolution so downstream logging and diagnostics can tell which candidate was
+actually used.
+
+## Relationship to legacy fallback config
+
+The legacy `fallback` block still exists and remains useful for model-level
+fallback outside canonical pools.
+
+Canonical routing is different:
+
+- it is driven by explicit `routing.model_pools`;
+- it selects from candidates inside one canonical pool;
+- it applies pool-aware failover and session affinity;
+- it exposes pool state through the admin API and dashboard.
+
+## Recommended rollout
+
+1. Define named providers under `providers:`.
+2. Declare exact model IDs for each provider when needed.
+3. Create one canonical pool per public model name.
+4. Start with `priority_failover` for predictable behavior.
+5. Enable `session_affinity` if repeated scoped requests should stay pinned.
+6. Use the admin dashboard to verify effective candidates and blocked reasons.
+
+## Example complete config
+
+```yaml
+models:
+  configured_provider_models_mode: "allowlist"
+
+routing:
+  defaults:
+    strategy: "priority_failover"
+    session_affinity: true
+    session_affinity_ttl: 30m
+    failover:
+      enabled: true
+      max_attempts: 3
+      retry_on_statuses: [429, 500, 502, 503, 504]
+      retry_on_model_errors: true
+
+  model_pools:
+    claude-sonnet-4-6:
+      candidates:
+        - provider: anthropic_primary
+          model: claude-sonnet-4-6
+          priority: 1
+        - provider: anthropic_backup
+          model: claude-sonnet-4-6-20250929
+          priority: 2
+
+providers:
+  anthropic_primary:
+    type: anthropic
+    api_key: "${ANTHROPIC_PRIMARY_API_KEY}"
+    models:
+      - claude-sonnet-4-6
+
+  anthropic_backup:
+    type: anthropic
+    api_key: "${ANTHROPIC_BACKUP_API_KEY}"
+    models:
+      - claude-sonnet-4-6-20250929
+```
+
+## Summary
+
+This commit turns canonical model routing into a complete operator-facing
+feature with:
+
+- explicit canonical pools;
+- priority or weighted candidate selection;
+- session affinity;
+- runtime-aware routing eligibility;
+- intra-pool failover;
+- `/v1/models` alignment with effective routing;
+- admin/dashboard controls and visibility;
+- structured routing and failover metadata.

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -605,6 +605,12 @@ function dashboard() {
       if (typeof this.fetchModelOverrides === "function") {
         requests.push(this.fetchModelOverrides());
       }
+      if (typeof this.fetchRoutingState === "function") {
+        requests.push(this.fetchRoutingState());
+      }
+      if (typeof this.fetchRoutingPools === "function") {
+        requests.push(this.fetchRoutingPools());
+      }
       if (typeof this.fetchModelPricingOverrides === "function") {
         requests.push(this.fetchModelPricingOverrides());
       }

--- a/internal/admin/dashboard/static/js/modules/aliases.js
+++ b/internal/admin/dashboard/static/js/modules/aliases.js
@@ -5,6 +5,9 @@
             aliasesAvailable: true,
             modelOverridesAvailable: true,
             modelOverrideViews: [],
+            routingStateViews: [],
+            routingPools: [],
+            routingStateAvailable: true,
             displayModels: [],
             aliasLoading: false,
             aliasError: '',
@@ -36,6 +39,16 @@
             },
 
             buildDisplayModels() {
+                const routingCandidates = new Map();
+                for (const pool of this.routingPools || []) {
+                    const canonical = String(pool && pool.canonical_model || '').trim();
+                    const candidates = Array.isArray(pool && pool.candidates) ? pool.candidates : [];
+                    for (const candidate of candidates) {
+                        const key = String(candidate && candidate.provider_name || '').trim() + '/' + String(candidate && candidate.model || '').trim();
+                        if (!key || !canonical) continue;
+                        routingCandidates.set(key, { canonical_model: canonical, routing_state: candidate, pool });
+                    }
+                }
                 const rows = this.models.map((model) => ({
                     key: 'model:' + this.qualifiedModelName(model),
                     display_name: this.qualifiedModelName(model),
@@ -49,7 +62,20 @@
                     kind_badge: '',
                     masking_alias: null,
                     alias_state_class: '',
-                    alias_state_text: ''
+                    alias_state_text: '',
+                    canonical_model: (routingCandidates.get(this.qualifiedModelName(model)) || {}).canonical_model || '',
+                    routing_state: (routingCandidates.get(this.qualifiedModelName(model)) || {}).routing_state || null,
+                    routing_pool: (routingCandidates.get(this.qualifiedModelName(model)) || {}).pool || null,
+                    canonical_enabled: (routingCandidates.get(this.qualifiedModelName(model)) || {}).pool ? ((routingCandidates.get(this.qualifiedModelName(model)) || {}).pool.enabled !== false) : true,
+                    canonical_status: ((routingCandidates.get(this.qualifiedModelName(model)) || {}).pool || {}).status || '',
+                    canonical_reason: ((routingCandidates.get(this.qualifiedModelName(model)) || {}).pool || {}).status_reason || '',
+                    routing_strategy: ((routingCandidates.get(this.qualifiedModelName(model)) || {}).pool || {}).strategy || '',
+                    candidate_priority: (((routingCandidates.get(this.qualifiedModelName(model)) || {}).routing_state || {}).priority ?? null),
+                    candidate_weight: (((routingCandidates.get(this.qualifiedModelName(model)) || {}).routing_state || {}).weight ?? null),
+                    is_config_primary: Boolean(((routingCandidates.get(this.qualifiedModelName(model)) || {}).routing_state || {}).is_config_primary),
+                    is_effective_candidate: Boolean(((routingCandidates.get(this.qualifiedModelName(model)) || {}).routing_state || {}).is_effective_candidate),
+                    effective_candidate: (((routingCandidates.get(this.qualifiedModelName(model)) || {}).pool || {}).effective_candidate || ''),
+                    config_primary_candidate: (((routingCandidates.get(this.qualifiedModelName(model)) || {}).pool || {}).config_primary_candidate || '')
                 }));
 
                 if (!this.aliasesAvailable) {
@@ -187,6 +213,58 @@
                 }
             },
 
+            async fetchRoutingState() {
+                try {
+                    const request = this.adminRequestOptions();
+                    const res = await fetch('/admin/routing-state', request);
+                    if (res.status === 503) {
+                        this.routingStateAvailable = false;
+                        this.routingStateViews = [];
+                        this.routingPools = [];
+                        this.syncDisplayModels();
+                        return;
+                    }
+                    const handled = this.handleFetchResponse(res, 'routing state', request);
+                    if (typeof this.isStaleAuthFetchResult === 'function' && this.isStaleAuthFetchResult(handled)) {
+                        return;
+                    }
+                    if (!handled) {
+                        this.routingStateViews = [];
+                        this.routingPools = [];
+                        this.syncDisplayModels();
+                        return;
+                    }
+                    this.routingStateAvailable = true;
+                    const payload = await res.json();
+                    this.routingStateViews = Array.isArray(payload) ? payload : [];
+                } catch (e) {
+                    console.error('Failed to fetch routing state:', e);
+                    this.routingStateViews = [];
+                }
+            },
+
+            async fetchRoutingPools() {
+                try {
+                    const request = this.adminRequestOptions();
+                    const res = await fetch('/admin/routing/model-pools', request);
+                    const handled = this.handleFetchResponse(res, 'routing model pools', request);
+                    if (typeof this.isStaleAuthFetchResult === 'function' && this.isStaleAuthFetchResult(handled)) {
+                        return;
+                    }
+                    if (!handled) {
+                        this.routingPools = [];
+                        this.syncDisplayModels();
+                        return;
+                    }
+                    const payload = await res.json();
+                    this.routingPools = Array.isArray(payload) ? payload : [];
+                    this.syncDisplayModels();
+                } catch (e) {
+                    console.error('Failed to fetch routing pools:', e);
+                    this.routingPools = [];
+                }
+            },
+
             async fetchModelOverrides() {
                 this.modelOverrideError = '';
                 try {
@@ -263,9 +341,23 @@
                 return Array.from(groups.values())
                     .map((group) => {
                         const access = this.providerGroupAccess(group.provider_name, group.provider_type, overridesBySelector);
+                        const providerRoutingEnabled = this.providerRoutingEnabled(group.provider_name);
+                        const seenCanonicals = new Set();
+                        group.rows = group.rows.map((row) => {
+                            const canonical = String(row && row.canonical_model || '').trim();
+                            const showCanonicalControls = canonical && !seenCanonicals.has(canonical);
+                            if (canonical) {
+                                seenCanonicals.add(canonical);
+                            }
+                            return {
+                                ...row,
+                                show_canonical_controls: Boolean(showCanonicalControls)
+                            };
+                        });
                         return {
                             ...group,
                             access,
+                            provider_routing_enabled: providerRoutingEnabled,
                             access_summary: this.modelAccessSummary(access),
                             item_count_label: this.providerGroupItemCountLabel(group.rows)
                         };
@@ -381,6 +473,60 @@
                     user_paths: userPaths,
                     override
                 };
+            },
+
+            providerRoutingEnabled(providerName) {
+                const normalized = String(providerName || '').trim();
+                if (!normalized) return true;
+                for (const entry of this.routingStateViews || []) {
+                    if (String(entry && entry.kind || '').trim() === 'provider' && String(entry && entry.provider_name || '').trim() === normalized) {
+                        return entry.enabled !== false;
+                    }
+                }
+                return true;
+            },
+
+            async submitRoutingStateChange(payload) {
+                const request = this.adminRequestOptions({ method: 'PUT', body: JSON.stringify(payload) });
+                const res = await fetch('/admin/routing-state', request);
+                const handled = this.handleFetchResponse(res, 'routing state update', request);
+                if (typeof this.isStaleAuthFetchResult === 'function' && this.isStaleAuthFetchResult(handled)) {
+                    return false;
+                }
+                if (!handled) {
+                    return false;
+                }
+                await Promise.all([this.fetchRoutingState(), this.fetchRoutingPools()]);
+                return true;
+            },
+
+            async toggleProviderEnabled(group) {
+                if (!group || !group.provider_name) return;
+                await this.submitRoutingStateChange({
+                    kind: 'provider',
+                    provider_name: group.provider_name,
+                    enabled: !group.provider_routing_enabled
+                });
+            },
+
+            async togglePoolCandidateEnabled(row) {
+                if (!row || !row.provider_name || !row.model || !row.model.id) return;
+                const enabled = !(row.routing_state && row.routing_state.candidate_enabled === false);
+                await this.submitRoutingStateChange({
+                    kind: 'pool_candidate',
+                    provider_name: row.provider_name,
+                    model: row.model.id,
+                    enabled: !enabled
+                });
+            },
+
+            async toggleCanonicalModelEnabled(row) {
+                if (!row || !row.canonical_model) return;
+                await this.submitRoutingStateChange({
+                    kind: 'canonical_model',
+                    canonical_model: row.canonical_model,
+                    enabled: !(row.canonical_enabled === false)
+                });
             },
 
             providerGroupItemCountLabel(rows) {

--- a/internal/admin/dashboard/static/js/modules/aliases.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/aliases.test.cjs
@@ -201,6 +201,41 @@ test('alias mutations send alias name in JSON body', async() => {
     });
 });
 
+test('buildDisplayModels marks config primary and effective candidate from routing pools', () => {
+    const module = createAliasesModule();
+    module.models = [{
+        provider_name: 'anthropic_b',
+        provider_type: 'anthropic',
+        model: {
+            id: 'claude-sonnet-4-6',
+            object: 'model',
+            owned_by: 'anthropic',
+            metadata: { modes: ['chat'], categories: ['text_generation'] }
+        }
+    }];
+    module.routingPools = [{
+        canonical_model: 'claude-sonnet-4-6',
+        strategy: 'priority_failover',
+        effective_candidate: 'anthropic_b/claude-sonnet-4-6',
+        config_primary_candidate: 'anthropic_b/claude-sonnet-4-6',
+        candidates: [{
+            provider_name: 'anthropic_b',
+            model: 'claude-sonnet-4-6',
+            priority: 1,
+            is_config_primary: true,
+            is_effective_candidate: true
+        }]
+    }];
+    module.aliases = [];
+    module.aliasesAvailable = true;
+    module.syncDisplayModels();
+
+    assert.equal(module.displayModels.length, 1);
+    assert.equal(module.displayModels[0].is_config_primary, true);
+    assert.equal(module.displayModels[0].is_effective_candidate, true);
+    assert.equal(module.displayModels[0].effective_candidate, 'anthropic_b/claude-sonnet-4-6');
+});
+
 test('filteredDisplayModelGroups groups rows by provider_name and applies provider-wide overrides', () => {
     const module = createAliasesModule();
     module.models = [

--- a/internal/admin/dashboard/templates/model-table-body.html
+++ b/internal/admin/dashboard/templates/model-table-body.html
@@ -22,6 +22,10 @@
                             @click="openProviderPricingOverrideEdit(group)">
                             {{template "dollar-icon"}}
                         </button>
+                        <button type="button" class="alias-toggle" x-show="routingStateAvailable && group.provider_name" :class="{ enabled: group.provider_routing_enabled !== false }" @click="toggleProviderEnabled(group)">
+                            <span class="alias-toggle-track"><span class="alias-toggle-thumb"></span></span>
+                            <span x-text="group.provider_routing_enabled !== false ? 'Provider Active' : 'Provider Disabled'"></span>
+                        </button>
                         <button type="button" class="table-action-btn table-icon-btn"
                             x-show="modelOverridesAvailable && group.access.selector"
                             :class="modelOverrideEditButtonClass(hasAccessOverride(group.access))"
@@ -47,6 +51,14 @@
                         </div>
                         <div class="model-name-secondary" x-show="!row.is_alias && row.masking_alias">
                             Masked by alias to <span class="mono font-size-md" x-text="aliasTargetLabel(row.masking_alias)"></span>
+                        </div>
+                        <div class="model-name-secondary" x-show="!row.is_alias && row.canonical_model && row.show_canonical_controls">
+                            Canonical <span class="mono font-size-md" x-text="row.canonical_model"></span>
+                            <span x-show="row.routing_strategy" x-text="' · Strategy: ' + row.routing_strategy"></span>
+                            <span x-show="row.candidate_priority !== null" x-text="' · Priority: ' + row.candidate_priority"></span>
+                            <span x-show="row.candidate_weight !== null && row.candidate_weight !== 0" x-text="' · Weight: ' + row.candidate_weight"></span>
+                            <span x-show="row.is_config_primary" x-text="' · Config Primary'"></span>
+                            <span x-show="row.is_effective_candidate" x-text="' · Effective'"></span>
                         </div>
                     </div>
                 </td>
@@ -86,6 +98,18 @@
                     <template x-if="!row.is_alias">
                         <div class="alias-actions-cell model-list-actions">
                             <span class="model-access-state-badge" :class="modelAccessStateClass(row.access)" x-text="modelAccessStateText(row.access)"></span>
+                            <span class="model-access-state-badge" x-show="row.canonical_model && row.show_canonical_controls" :class="row.canonical_enabled === false ? 'is-disabled' : (row.canonical_status === 'degraded' ? 'is-restricted' : 'is-enabled')" x-text="row.canonical_enabled === false ? 'Canonical Disabled' : (row.canonical_status === 'degraded' ? 'Canonical Degraded' : 'Canonical Enabled')"></span>
+                            <span class="model-access-state-badge" x-show="row.routing_state" :class="row.routing_state && row.routing_state.status === 'disabled_manual' ? 'is-disabled' : (row.routing_state && row.routing_state.status === 'degraded_runtime' ? 'is-restricted' : 'is-enabled')" x-text="row.routing_state && row.routing_state.status === 'disabled_manual' ? 'Candidate Disabled' : (row.routing_state && row.routing_state.status === 'degraded_runtime' ? 'Candidate Degraded' : (row.routing_state ? 'Candidate Enabled' : ''))"></span>
+                            <span class="model-access-state-badge" x-show="row.is_effective_candidate" :class="'is-enabled'" x-text="'Effective Candidate'"></span>
+                            <span class="model-access-state-badge" x-show="row.is_config_primary && !row.is_effective_candidate" :class="'is-restricted'" x-text="'Config Primary'"></span>
+                            <button type="button" class="alias-toggle" x-show="routingStateAvailable && row.canonical_model && row.show_canonical_controls" :class="{ enabled: row.canonical_enabled !== false }" @click="toggleCanonicalModelEnabled(row)">
+                                <span class="alias-toggle-track"><span class="alias-toggle-thumb"></span></span>
+                                <span x-text="row.canonical_enabled === false ? 'Canonical Disabled' : 'Canonical Active'"></span>
+                            </button>
+                            <button type="button" class="alias-toggle" x-show="routingStateAvailable && row.routing_state" :class="{ enabled: !(row.routing_state && row.routing_state.candidate_enabled === false) }" @click="togglePoolCandidateEnabled(row)">
+                                <span class="alias-toggle-track"><span class="alias-toggle-thumb"></span></span>
+                                <span x-text="row.routing_state && row.routing_state.candidate_enabled === false ? 'Candidate Disabled' : 'Candidate Active'"></span>
+                            </button>
                             <button type="button" class="table-action-btn table-icon-btn"
                                 x-show="modelPricingOverridesAvailable"
                                 :class="modelPricingButtonClass(hasModelPricingOverride(row))"

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/labstack/echo/v5"
 
+	"gomodel/config"
 	"gomodel/internal/aliases"
 	"gomodel/internal/auditlog"
 	"gomodel/internal/authkeys"
@@ -23,6 +24,7 @@ import (
 	"gomodel/internal/modeloverrides"
 	"gomodel/internal/pricingoverrides"
 	"gomodel/internal/providers"
+	"gomodel/internal/routingstate"
 	"gomodel/internal/usage"
 	"gomodel/internal/workflows"
 )
@@ -38,6 +40,7 @@ type Handler struct {
 	aliases             *aliases.Service
 	modelOverrides      *modeloverrides.Service
 	pricingOverrides    *pricingoverrides.Service
+	routingState        *routingstate.Service
 	workflows           *workflows.Service
 	budgets             *budget.Service
 	guardrails          guardrails.Catalog
@@ -46,6 +49,7 @@ type Handler struct {
 	runtimeConfig       DashboardConfigResponse
 	runtimeRefresher    RuntimeRefresher
 	configuredProviders []providers.SanitizedProviderConfig
+	routingConfig       config.RoutingConfig
 
 	mutationMu sync.Mutex
 	pricingMu  sync.Mutex
@@ -201,6 +205,13 @@ func WithPricingOverrides(service *pricingoverrides.Service) Option {
 	}
 }
 
+// WithRoutingState enables routing state administration and status enrichment.
+func WithRoutingState(service *routingstate.Service) Option {
+	return func(h *Handler) {
+		h.routingState = service
+	}
+}
+
 // WithWorkflows enables workflow administration endpoints.
 func WithWorkflows(service *workflows.Service) Option {
 	return func(h *Handler) {
@@ -255,6 +266,13 @@ func WithRuntimeRefresher(refresher RuntimeRefresher) Option {
 func WithConfiguredProviders(configs []providers.SanitizedProviderConfig) Option {
 	return func(h *Handler) {
 		h.configuredProviders = cloneConfiguredProviders(configs)
+	}
+}
+
+// WithRoutingConfig enables canonical routing pool introspection in admin APIs.
+func WithRoutingConfig(cfg config.RoutingConfig) Option {
+	return func(h *Handler) {
+		h.routingConfig = cfg
 	}
 }
 

--- a/internal/admin/handler_providers.go
+++ b/internal/admin/handler_providers.go
@@ -10,6 +10,7 @@ import (
 
 	"gomodel/internal/core"
 	"gomodel/internal/providers"
+	"gomodel/internal/routingstate"
 )
 
 func (h *Handler) ProviderStatus(c *echo.Context) error {
@@ -49,7 +50,7 @@ func (h *Handler) buildProviderStatusResponse() providerStatusResponse {
 	}
 
 	for _, name := range names {
-		item := buildProviderStatusItem(name, configuredByName[name], runtimeByName[name])
+		item := buildProviderStatusItem(name, configuredByName[name], runtimeByName[name], h.routingState)
 		resp.Providers = append(resp.Providers, item)
 		resp.Summary.Total++
 		switch item.Status {
@@ -109,12 +110,18 @@ func (h *Handler) collectProviderStatusInputs() (
 // buildProviderStatusItem reconciles cfg/runtime gaps for a single provider
 // (either side may be zero-valued when only one source knows the name) and
 // produces the response row.
-func buildProviderStatusItem(name string, cfg providers.SanitizedProviderConfig, runtime providers.ProviderRuntimeSnapshot) providerStatusItemResponse {
+func buildProviderStatusItem(name string, cfg providers.SanitizedProviderConfig, runtime providers.ProviderRuntimeSnapshot, state *routingstate.Service) providerStatusItemResponse {
 	// Classify against the inputs as-given so the "Unknown" branch in
 	// classifyProviderStatus stays reachable for runtime-only providers.
 	// Synthesising cfg.Name first would always make the provider look
 	// configured to the classifier.
 	status, label, reason, lastError := classifyProviderStatus(cfg, runtime)
+	if state != nil && !state.ProviderEnabled(name) {
+		status = "degraded"
+		label = "Disabled"
+		reason = "provider disabled manually"
+		lastError = ""
+	}
 
 	// For the response row, fill in display fallbacks from the peer side.
 	if strings.TrimSpace(cfg.Name) == "" {

--- a/internal/admin/handler_routing_pools.go
+++ b/internal/admin/handler_routing_pools.go
@@ -1,0 +1,159 @@
+package admin
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v5"
+
+	"gomodel/internal/core"
+	"gomodel/internal/routing"
+)
+
+type routingPoolCandidateResponse struct {
+	ProviderName         string `json:"provider_name"`
+	ProviderType         string `json:"provider_type"`
+	Model                string `json:"model"`
+	Priority             int    `json:"priority"`
+	Weight               int    `json:"weight"`
+	ProviderEnabled      bool   `json:"provider_enabled"`
+	CandidateEnabled     bool   `json:"candidate_enabled"`
+	EffectiveEnabled     bool   `json:"effective_enabled"`
+	Status               string `json:"status"`
+	StatusReason         string `json:"status_reason,omitempty"`
+	ProviderRuntime      string `json:"provider_runtime_status,omitempty"`
+	ProviderLastError    string `json:"provider_last_error,omitempty"`
+	IsConfigPrimary      bool   `json:"is_config_primary"`
+	IsEffectiveCandidate bool   `json:"is_effective_candidate"`
+}
+
+type routingPoolResponse struct {
+	CanonicalModel         string                         `json:"canonical_model"`
+	Enabled                bool                           `json:"enabled"`
+	Strategy               string                         `json:"strategy"`
+	Status                 string                         `json:"status"`
+	StatusReason           string                         `json:"status_reason,omitempty"`
+	EffectiveCandidate     string                         `json:"effective_candidate,omitempty"`
+	EffectiveProviderName  string                         `json:"effective_provider_name,omitempty"`
+	ConfigPrimaryCandidate string                         `json:"config_primary_candidate,omitempty"`
+	ConfigPrimaryProvider  string                         `json:"config_primary_provider_name,omitempty"`
+	BlockedCandidates      []routingBlockedCandidate      `json:"blocked_candidates,omitempty"`
+	Candidates             []routingPoolCandidateResponse `json:"candidates"`
+}
+
+type routingBlockedCandidate struct {
+	Selector string `json:"selector"`
+	Status   string `json:"status"`
+	Reason   string `json:"reason,omitempty"`
+}
+
+func (h *Handler) ListRoutingModelPools(c *echo.Context) error {
+	pools := h.buildRoutingPoolResponses()
+	if pools == nil {
+		pools = []routingPoolResponse{}
+	}
+	return c.JSON(http.StatusOK, pools)
+}
+
+func (h *Handler) buildRoutingPoolResponses() []routingPoolResponse {
+	if len(h.routingConfig.ModelPools) == 0 {
+		return nil
+	}
+
+	runtimeByName := make(map[string]routing.CandidateRuntimeInfo)
+	if h.registry != nil {
+		for _, snapshot := range h.registry.ProviderRuntimeSnapshots() {
+			name := strings.TrimSpace(snapshot.Name)
+			if name == "" {
+				continue
+			}
+			lastError := strings.TrimSpace(snapshot.LastModelFetchError)
+			if lastError == "" {
+				lastError = strings.TrimSpace(snapshot.LastAvailabilityError)
+			}
+			runtimeByName[name] = routing.CandidateRuntimeInfo{
+				Status:    routing.ClassifyProviderRuntime(snapshot),
+				LastError: lastError,
+			}
+		}
+	}
+
+	responses := make([]routingPoolResponse, 0, len(h.routingConfig.ModelPools))
+	for canonical, poolCfg := range h.routingConfig.ModelPools {
+		canonicalName := strings.TrimSpace(canonical)
+		if canonicalName == "" {
+			continue
+		}
+
+		pool := routing.Pool{CanonicalModel: canonicalName, Candidates: make([]routing.Candidate, 0, len(poolCfg.Candidates))}
+		for _, candidate := range poolCfg.Candidates {
+			pool.Candidates = append(pool.Candidates, routing.Candidate{
+				Provider: strings.TrimSpace(candidate.Provider),
+				Model:    strings.TrimSpace(candidate.Model),
+				Priority: candidate.Priority,
+				Weight:   candidate.Weight,
+			})
+		}
+
+		evaluated := routing.EvaluatePool(h.routingConfig.Defaults.Strategy, pool, h.routingState, runtimeByName)
+		configPrimary, _ := evaluated.ConfigPrimaryCandidate()
+		effectiveCandidate := ""
+		effectiveProviderName := ""
+		if resolver := routing.NewResolver(h.routingConfig, h.routingState); resolver != nil {
+			resolver = resolver.WithRuntime(h.registry)
+			if resolution, matched, err := resolver.Resolve(core.NewRequestedModelSelector(canonicalName, "")); err == nil && matched && resolution != nil {
+				effectiveCandidate = resolution.Primary.QualifiedModel()
+				effectiveProviderName = resolution.Primary.Provider
+			}
+		}
+
+		candidates := make([]routingPoolCandidateResponse, 0, len(evaluated.Candidates))
+		for _, candidate := range evaluated.Candidates {
+			providerType := ""
+			if h.registry != nil {
+				providerType = strings.TrimSpace(h.registry.GetProviderTypeForName(candidate.Candidate.Provider))
+			}
+			qualified := candidate.Candidate.QualifiedModel()
+			candidates = append(candidates, routingPoolCandidateResponse{
+				ProviderName:         candidate.Candidate.Provider,
+				ProviderType:         providerType,
+				Model:                candidate.Candidate.Model,
+				Priority:             candidate.Candidate.Priority,
+				Weight:               candidate.Candidate.Weight,
+				ProviderEnabled:      candidate.ProviderEnabled,
+				CandidateEnabled:     candidate.CandidateEnabled,
+				EffectiveEnabled:     candidate.EffectiveEnabled,
+				Status:               candidate.Status,
+				StatusReason:         candidate.StatusReason,
+				ProviderRuntime:      candidate.RuntimeStatus,
+				ProviderLastError:    candidate.RuntimeLastError,
+				IsConfigPrimary:      qualified == configPrimary.QualifiedModel(),
+				IsEffectiveCandidate: qualified != "" && qualified == effectiveCandidate,
+			})
+		}
+
+		blocked := make([]routingBlockedCandidate, 0, len(evaluated.BlockedCandidates()))
+		for _, blockedCandidate := range evaluated.BlockedCandidates() {
+			blocked = append(blocked, routingBlockedCandidate{
+				Selector: blockedCandidate.Selector.QualifiedModel(),
+				Status:   blockedCandidate.Status,
+				Reason:   blockedCandidate.Reason,
+			})
+		}
+
+		responses = append(responses, routingPoolResponse{
+			CanonicalModel:         canonicalName,
+			Enabled:                evaluated.Enabled,
+			Strategy:               string(evaluated.Strategy),
+			Status:                 evaluated.Status,
+			StatusReason:           evaluated.StatusReason,
+			EffectiveCandidate:     effectiveCandidate,
+			EffectiveProviderName:  effectiveProviderName,
+			ConfigPrimaryCandidate: configPrimary.QualifiedModel(),
+			ConfigPrimaryProvider:  configPrimary.Provider,
+			BlockedCandidates:      blocked,
+			Candidates:             candidates,
+		})
+	}
+	return responses
+}

--- a/internal/admin/handler_routing_pools_test.go
+++ b/internal/admin/handler_routing_pools_test.go
@@ -1,0 +1,91 @@
+package admin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+
+	"gomodel/config"
+	"gomodel/internal/providers"
+	"gomodel/internal/routingstate"
+)
+
+func TestListRoutingModelPools_EmptyRegistry(t *testing.T) {
+	h := NewHandler(nil, nil)
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/admin/routing/model-pools", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	if err := h.ListRoutingModelPools(c); err != nil {
+		t.Fatalf("ListRoutingModelPools() error = %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestBuildRoutingPoolResponses_UsesRoutingConfigAndState(t *testing.T) {
+	registry := providers.NewModelRegistry()
+	service, err := routingstate.NewService(&routingStateMemoryStore{entries: map[string]routingstate.Entry{}})
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Upsert(context.Background(), routingstate.Entry{Kind: routingstate.KindProvider, ProviderName: "anthropic_a", Enabled: false}); err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+	if err := service.Upsert(context.Background(), routingstate.Entry{Kind: routingstate.KindCanonicalModel, CanonicalModel: "claude-sonnet-4-6", Enabled: false}); err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+	h := NewHandler(nil, registry,
+		WithRoutingState(service),
+		WithRoutingConfig(config.RoutingConfig{
+			Defaults: config.RoutingDefaultsConfig{Strategy: config.RoutingStrategyPriorityFailover},
+			ModelPools: map[string]config.ModelPoolConfig{
+				"claude-sonnet-4-6": {Candidates: []config.ModelPoolCandidateConfig{{Provider: "anthropic_a", Model: "claude-sonnet-4-6-20250929", Priority: 2, Weight: 8}, {Provider: "anthropic_b", Model: "claude-sonnet-4-6", Priority: 1, Weight: 10}}},
+			},
+		}),
+	)
+	responses := h.buildRoutingPoolResponses()
+	if len(responses) != 1 {
+		t.Fatalf("len(responses) = %d, want 1", len(responses))
+	}
+	if responses[0].Strategy != string(config.RoutingStrategyPriorityFailover) {
+		t.Fatalf("Strategy = %q, want %q", responses[0].Strategy, config.RoutingStrategyPriorityFailover)
+	}
+	if responses[0].Enabled {
+		t.Fatal("expected canonical model disabled")
+	}
+	if len(responses[0].Candidates) != 2 {
+		t.Fatalf("len(candidates) = %d, want 2", len(responses[0].Candidates))
+	}
+	if responses[0].Candidates[0].Priority != 2 || responses[0].Candidates[0].Weight != 8 {
+		t.Fatalf("first candidate priority/weight = %+v", responses[0].Candidates[0])
+	}
+	if responses[0].Candidates[0].Status != "disabled_manual" {
+		t.Fatalf("first candidate status = %q, want disabled_manual", responses[0].Candidates[0].Status)
+	}
+	if responses[0].Candidates[0].IsConfigPrimary {
+		t.Fatal("expected first candidate not to be config primary under priority_failover")
+	}
+	if !responses[0].Candidates[1].IsConfigPrimary {
+		t.Fatal("expected second candidate to be config primary under priority_failover")
+	}
+	if !responses[0].Candidates[1].CandidateEnabled {
+		t.Fatal("expected second candidate to remain directly enabled")
+	}
+	if responses[0].Candidates[1].Priority != 1 || responses[0].Candidates[1].Weight != 10 {
+		t.Fatalf("second candidate priority/weight = %+v", responses[0].Candidates[1])
+	}
+	if responses[0].EffectiveCandidate != "" {
+		t.Fatalf("EffectiveCandidate = %q, want empty when canonical model is disabled", responses[0].EffectiveCandidate)
+	}
+	if responses[0].ConfigPrimaryCandidate != "anthropic_b/claude-sonnet-4-6" {
+		t.Fatalf("ConfigPrimaryCandidate = %q, want anthropic_b/claude-sonnet-4-6", responses[0].ConfigPrimaryCandidate)
+	}
+	if len(responses[0].BlockedCandidates) == 0 {
+		t.Fatal("expected blocked candidates to be reported")
+	}
+}

--- a/internal/admin/handler_routing_state.go
+++ b/internal/admin/handler_routing_state.go
@@ -1,0 +1,104 @@
+package admin
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v5"
+
+	"gomodel/internal/core"
+	"gomodel/internal/routingstate"
+)
+
+type upsertRoutingStateRequest struct {
+	Kind           string `json:"kind"`
+	ProviderName   string `json:"provider_name,omitempty"`
+	CanonicalModel string `json:"canonical_model,omitempty"`
+	Model          string `json:"model,omitempty"`
+	Enabled        *bool  `json:"enabled,omitempty"`
+	Reason         string `json:"reason,omitempty"`
+}
+
+type deleteRoutingStateRequest struct {
+	Key string `json:"key"`
+}
+
+func (h *Handler) ListRoutingState(c *echo.Context) error {
+	if h.routingState == nil {
+		return handleError(c, featureUnavailableError("routing state feature is unavailable"))
+	}
+	views := h.routingState.List()
+	if views == nil {
+		views = []routingstate.Entry{}
+	}
+	return c.JSON(http.StatusOK, views)
+}
+
+func (h *Handler) UpsertRoutingState(c *echo.Context) error {
+	if h.routingState == nil {
+		return handleError(c, featureUnavailableError("routing state feature is unavailable"))
+	}
+	var req upsertRoutingStateRequest
+	if err := c.Bind(&req); err != nil {
+		return handleError(c, core.NewInvalidRequestError("invalid request body: "+err.Error(), err))
+	}
+	if req.Enabled == nil {
+		return handleError(c, core.NewInvalidRequestError("enabled is required", nil))
+	}
+	entry := routingstate.Entry{
+		Kind:           routingstate.Kind(strings.TrimSpace(req.Kind)),
+		ProviderName:   strings.TrimSpace(req.ProviderName),
+		CanonicalModel: strings.TrimSpace(req.CanonicalModel),
+		Model:          strings.TrimSpace(req.Model),
+		Enabled:        *req.Enabled,
+		Reason:         strings.TrimSpace(req.Reason),
+	}
+	if err := h.routingState.Upsert(c.Request().Context(), entry); err != nil {
+		if routingstate.IsValidationError(err) {
+			return handleError(c, core.NewInvalidRequestError(err.Error(), err))
+		}
+		return handleError(c, core.NewProviderError("routing_state", http.StatusBadGateway, "failed to update routing state", err))
+	}
+	entries := h.routingState.List()
+	for _, current := range entries {
+		if current.Kind == entry.Kind {
+			switch current.Kind {
+			case routingstate.KindProvider:
+				if current.ProviderName == entry.ProviderName {
+					return c.JSON(http.StatusOK, current)
+				}
+			case routingstate.KindCanonicalModel:
+				if current.CanonicalModel == entry.CanonicalModel {
+					return c.JSON(http.StatusOK, current)
+				}
+			case routingstate.KindPoolCandidate:
+				if current.ProviderName == entry.ProviderName && current.Model == entry.Model {
+					return c.JSON(http.StatusOK, current)
+				}
+			}
+		}
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+func (h *Handler) DeleteRoutingState(c *echo.Context) error {
+	if h.routingState == nil {
+		return handleError(c, featureUnavailableError("routing state feature is unavailable"))
+	}
+	var req deleteRoutingStateRequest
+	if err := c.Bind(&req); err != nil {
+		return handleError(c, core.NewInvalidRequestError("invalid request body: "+err.Error(), err))
+	}
+	key := strings.TrimSpace(req.Key)
+	if key == "" {
+		return handleError(c, core.NewInvalidRequestError("key is required", nil))
+	}
+	if err := h.routingState.Delete(c.Request().Context(), key); err != nil {
+		if errors.Is(err, routingstate.ErrNotFound) {
+			return handleError(c, core.NewNotFoundError("routing state not found: "+key))
+		}
+		return handleError(c, core.NewProviderError("routing_state", http.StatusBadGateway, "failed to delete routing state", err))
+	}
+	return c.NoContent(http.StatusNoContent)
+}

--- a/internal/admin/handler_routing_state_test.go
+++ b/internal/admin/handler_routing_state_test.go
@@ -1,0 +1,88 @@
+package admin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+
+	"gomodel/internal/routingstate"
+)
+
+func newRoutingStateHandler(t *testing.T) *Handler {
+	t.Helper()
+	service, err := routingstate.NewService(&routingStateMemoryStore{})
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	return NewHandler(nil, nil, WithRoutingState(service))
+}
+
+type routingStateMemoryStore struct{ entries map[string]routingstate.Entry }
+
+func (m *routingStateMemoryStore) List(context.Context) ([]routingstate.Entry, error) {
+	result := make([]routingstate.Entry, 0, len(m.entries))
+	for _, entry := range m.entries { result = append(result, entry) }
+	return result, nil
+}
+func (m *routingStateMemoryStore) Upsert(_ context.Context, entry routingstate.Entry) error { if m.entries == nil { m.entries = map[string]routingstate.Entry{} }; m.entries[entry.Key] = entry; return nil }
+func (m *routingStateMemoryStore) Delete(_ context.Context, key string) error { delete(m.entries, key); return nil }
+func (m *routingStateMemoryStore) Close() error { return nil }
+
+func TestListRoutingState_Empty(t *testing.T) {
+	h := newRoutingStateHandler(t)
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/admin/routing-state", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	if err := h.ListRoutingState(c); err != nil { t.Fatalf("ListRoutingState() error = %v", err) }
+	if rec.Code != http.StatusOK { t.Fatalf("status = %d, want 200", rec.Code) }
+	if rec.Body.String() != "[]\n" { t.Fatalf("body = %q, want []", rec.Body.String()) }
+}
+
+func TestUpsertRoutingState_Provider(t *testing.T) {
+	h := newRoutingStateHandler(t)
+	body, _ := json.Marshal(map[string]any{"kind": "provider", "provider_name": "anthropic_a", "enabled": false, "reason": "429"})
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPut, "/admin/routing-state", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	if err := h.UpsertRoutingState(c); err != nil { t.Fatalf("UpsertRoutingState() error = %v", err) }
+	if rec.Code != http.StatusOK { t.Fatalf("status = %d, want 200", rec.Code) }
+}
+
+func TestUpsertRoutingState_InvalidMissingEnabled(t *testing.T) {
+	h := newRoutingStateHandler(t)
+	body, _ := json.Marshal(map[string]any{"kind": "provider", "provider_name": "anthropic_a"})
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPut, "/admin/routing-state", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	_ = h.UpsertRoutingState(c)
+	if rec.Code != http.StatusBadRequest { t.Fatalf("status = %d, want 400", rec.Code) }
+}
+
+func TestDeleteRoutingState(t *testing.T) {
+	h := newRoutingStateHandler(t)
+	body, _ := json.Marshal(map[string]any{"kind": "provider", "provider_name": "anthropic_a", "enabled": false})
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPut, "/admin/routing-state", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	if err := h.UpsertRoutingState(c); err != nil { t.Fatalf("UpsertRoutingState() error = %v", err) }
+
+	deleteBody, _ := json.Marshal(map[string]any{"key": "anthropic_a"})
+	req = httptest.NewRequest(http.MethodDelete, "/admin/routing-state", bytes.NewReader(deleteBody))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec)
+	if err := h.DeleteRoutingState(c); err != nil { t.Fatalf("DeleteRoutingState() error = %v", err) }
+	if rec.Code != http.StatusNoContent { t.Fatalf("status = %d, want 204", rec.Code) }
+}

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -2028,7 +2028,7 @@ func TestBuildProviderStatusItem_ClassifyAndDisplayFallbacks(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			item := buildProviderStatusItem(tc.key, tc.cfg, tc.runtime)
+			item := buildProviderStatusItem(tc.key, tc.cfg, tc.runtime, nil)
 
 			if item.Name != tc.key {
 				t.Errorf("Name = %q, want %q", item.Name, tc.key)

--- a/internal/admin/routes.go
+++ b/internal/admin/routes.go
@@ -32,6 +32,10 @@ func (h *Handler) RegisterRoutes(g RouteRegistrar) {
 	g.GET("/audit/conversation", h.AuditConversation)
 
 	g.GET("/providers/status", h.ProviderStatus)
+	g.GET("/routing-state", h.ListRoutingState)
+	g.PUT("/routing-state", h.UpsertRoutingState)
+	g.DELETE("/routing-state", h.DeleteRoutingState)
+	g.GET("/routing/model-pools", h.ListRoutingModelPools)
 	g.POST("/runtime/refresh", h.RefreshRuntime)
 
 	g.GET("/budgets", h.ListBudgets)

--- a/internal/admin/routes_test.go
+++ b/internal/admin/routes_test.go
@@ -47,6 +47,10 @@ func TestRegisterRoutes_RegistersExpectedPaths(t *testing.T) {
 		"GET /admin/audit/conversation",
 
 		"GET /admin/providers/status",
+		"GET /admin/routing-state",
+		"PUT /admin/routing-state",
+		"DELETE /admin/routing-state",
+		"GET /admin/routing/model-pools",
 		"POST /admin/runtime/refresh",
 
 		"GET /admin/budgets",

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -31,6 +31,8 @@ import (
 	"gomodel/internal/pricingoverrides"
 	"gomodel/internal/providers"
 	"gomodel/internal/responsecache"
+	"gomodel/internal/routing"
+	"gomodel/internal/routingstate"
 	"gomodel/internal/server"
 	"gomodel/internal/storage"
 	"gomodel/internal/usage"
@@ -50,6 +52,7 @@ type App struct {
 	aliases          *aliases.Result
 	modelOverrides   *modeloverrides.Result
 	pricingOverrides *pricingoverrides.Result
+	routingState     *routingstate.Result
 	authKeys         *authkeys.Result
 	guardrails       *guardrails.Result
 	workflows        *workflows.Result
@@ -271,6 +274,22 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		return nil, fmt.Errorf("failed to initialize model pricing overrides: %w", err)
 	}
 	app.pricingOverrides = pricingOverrideResult
+
+	var routingStateResult *routingstate.Result
+	sharedRoutingStateStorage := firstSharedStorage(auditResult.Storage, usageResult.Storage, batchResult.Storage, fileStoreResult.Storage, aliasResult.Storage, modelOverrideResult.Storage, pricingOverrideResult.Storage)
+	if sharedRoutingStateStorage != nil {
+		routingStateResult, err = routingstate.NewWithSharedStorage(ctx, appCfg, sharedRoutingStateStorage)
+	} else {
+		routingStateResult, err = routingstate.New(ctx, appCfg)
+	}
+	if err != nil {
+		closeErr := errors.Join(app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.fileStore.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		if closeErr != nil {
+			return nil, fmt.Errorf("failed to initialize routing state: %w (also: close error: %v)", err, closeErr)
+		}
+		return nil, fmt.Errorf("failed to initialize routing state: %w", err)
+	}
+	app.routingState = routingStateResult
 	pricingResolver := usage.PricingResolver(providerResult.Registry)
 	if app.pricingOverrides != nil && app.pricingOverrides.Service != nil {
 		pricingResolver = app.pricingOverrides.Service
@@ -415,6 +434,12 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 			"recommendation", "rebuild with -tags=swagger")
 	}
 
+	routingResolver := routing.NewResolver(appCfg.Routing, app.routingState.Service).WithRuntime(providerResult.Registry)
+	routingFailoverPolicy := routing.NewFailoverPolicy(appCfg.Routing.Defaults.Failover)
+	composedModelResolver := routing.NewComposedResolver(app.aliases.Service, routingResolver)
+	canonicalExposedModels := routing.NewCanonicalExposedModelLister(appCfg.Routing, providerResult.Registry, app.routingState.Service, providerResult.Registry)
+	exposedModels := routing.NewCombinedExposedModelLister(canonicalExposedModels, app.aliases.Service)
+
 	serverCfg := &server.Config{
 		BasePath:                        appCfg.Server.BasePath,
 		MasterKey:                       appCfg.Server.MasterKey,
@@ -427,13 +452,13 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		UsageLogger:                     usageResult.Logger,
 		BudgetChecker:                   budgetResult.Service,
 		PricingResolver:                 pricingResolver,
-		ModelResolver:                   app.aliases.Service,
+		ModelResolver:                   composedModelResolver,
 		ModelAuthorizer:                 app.modelOverrides.Service,
 		FallbackResolver:                fallback.NewResolver(appCfg.Fallback, providerResult.Registry),
 		WorkflowPolicyResolver:          workflowResult.Service,
 		TranslatedRequestPatcher:        translatedRequestPatcher,
 		BatchRequestPreparer:            batchRequestPreparer,
-		ExposedModelLister:              app.aliases.Service,
+		ExposedModelLister:              exposedModels,
 		KeepOnlyAliasesAtModelsEndpoint: appCfg.Models.KeepOnlyAliasesAtModelsEndpoint,
 		PassthroughSemanticEnrichers:    cfg.Factory.PassthroughSemanticEnrichers(),
 		BatchStore:                      batchResult.Store,
@@ -444,6 +469,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		AllowPassthroughV1Alias:         &allowPassthroughV1Alias,
 		UserPathHeader:                  appCfg.Server.UserPathHeader,
 		SwaggerEnabled:                  swaggerEnabled,
+		FailoverPolicy:                  routingFailoverPolicy,
 	}
 
 	// Initialize admin API and dashboard (behind separate feature flags)
@@ -464,9 +490,11 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 			app.aliases.Service,
 			app.modelOverrides.Service,
 			app.pricingOverrides.Service,
+			app.routingState.Service,
 			workflowResult.Service,
 			app.guardrails.Service,
 			budgetResult.Service,
+			appCfg.Routing,
 			app,
 			dashboardRuntimeConfig(appCfg, usageEnabledForDashboard),
 			app.live,
@@ -542,7 +570,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		if app.batch != nil {
 			batchCloseErr = app.batch.Close()
 		}
-		closeErr := errors.Join(workflowsCloseErr, guardrailsCloseErr, authKeysCloseErr, aliasCloseErr, modelOverridesCloseErr, pricingOverridesCloseErr, fileStoreCloseErr, batchCloseErr, app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		closeErr := errors.Join(workflowsCloseErr, guardrailsCloseErr, authKeysCloseErr, aliasCloseErr, modelOverridesCloseErr, pricingOverridesCloseErr, app.routingState.Close(), fileStoreCloseErr, batchCloseErr, app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
 		if closeErr != nil {
 			return nil, fmt.Errorf("failed to initialize response cache: %w (also: close error: %v)", err, closeErr)
 		}
@@ -551,17 +579,18 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 	serverCfg.ResponseCacheMiddleware = rcm
 
 	internalGuardrailExecutor := server.NewInternalChatCompletionExecutor(provider, server.InternalChatCompletionExecutorConfig{
-		ModelResolver:          app.aliases.Service,
+		ModelResolver:          composedModelResolver,
 		ModelAuthorizer:        app.modelOverrides.Service,
 		WorkflowPolicyResolver: workflowResult.Service,
 		FallbackResolver:       serverCfg.FallbackResolver,
+		FailoverPolicy:         routingFailoverPolicy,
 		AuditLogger:            auditResult.Logger,
 		UsageLogger:            usageResult.Logger,
 		PricingResolver:        pricingResolver,
 		ResponseCache:          rcm,
 	})
 	closeWiredRuntime := func() error {
-		return errors.Join(rcm.Close(), app.workflows.Close(), app.guardrails.Close(), app.authKeys.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.fileStore.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
+		return errors.Join(rcm.Close(), app.workflows.Close(), app.guardrails.Close(), app.authKeys.Close(), app.routingState.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.fileStore.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
 	}
 	if err := guardrailResult.Service.SetExecutor(ctx, internalGuardrailExecutor); err != nil {
 		closeErr := closeWiredRuntime()
@@ -913,9 +942,11 @@ func initAdmin(
 	aliasService *aliases.Service,
 	modelOverrideService *modeloverrides.Service,
 	pricingOverrideService *pricingoverrides.Service,
+	routingStateService *routingstate.Service,
 	workflowService *workflows.Service,
 	guardrailService *guardrails.Service,
 	budgetService *budget.Service,
+	routingConfig config.RoutingConfig,
 	runtimeRefresher admin.RuntimeRefresher,
 	runtimeConfig admin.DashboardConfigResponse,
 	liveBroker *live.Broker,
@@ -965,6 +996,7 @@ func initAdmin(
 		reader,
 		registry,
 		admin.WithConfiguredProviders(configuredProviders),
+		admin.WithRoutingConfig(routingConfig),
 		admin.WithUsagePricingRecalculator(pricingRecalculator),
 		admin.WithPricingResolver(pricingOverrideService),
 		admin.WithAuditReader(auditReader),
@@ -972,6 +1004,7 @@ func initAdmin(
 		admin.WithAliases(aliasService),
 		admin.WithModelOverrides(modelOverrideService),
 		admin.WithPricingOverrides(pricingOverrideService),
+		admin.WithRoutingState(routingStateService),
 		admin.WithWorkflows(workflowService),
 		admin.WithGuardrailService(guardrailService),
 		admin.WithBudgets(budgetService),

--- a/internal/core/canonical_routing.go
+++ b/internal/core/canonical_routing.go
@@ -1,0 +1,27 @@
+package core
+
+// CanonicalRoutingResolution captures pool-based model routing metadata.
+type CanonicalRoutingResolution struct {
+	CanonicalModel       string
+	Primary              ModelSelector
+	Fallbacks            []ModelSelector
+	Strategy             string
+	ConfigPrimary        ModelSelector
+	EffectiveCandidate   ModelSelector
+	BlockedCandidates    []BlockedCandidate
+	SelectedProviderName string
+	SelectedExactModel   string
+	FailoverUsed         bool
+	FallbackTarget       string
+}
+
+type BlockedCandidate struct {
+	Selector ModelSelector
+	Reason   string
+	Status   string
+}
+
+// CanonicalRoutingResolver optionally exposes canonical pool resolution metadata.
+type CanonicalRoutingResolver interface {
+	Resolve(requested RequestedModelSelector) (*CanonicalRoutingResolution, bool, error)
+}

--- a/internal/core/request_model_resolution.go
+++ b/internal/core/request_model_resolution.go
@@ -3,11 +3,21 @@ package core
 // RequestModelResolution captures the requested model selector at ingress and
 // the concrete selector chosen for execution after alias resolution.
 type RequestModelResolution struct {
-	Requested        RequestedModelSelector
-	ResolvedSelector ModelSelector
-	ProviderType     string
-	ProviderName     string
-	AliasApplied     bool
+	Requested              RequestedModelSelector
+	ResolvedSelector       ModelSelector
+	ProviderType           string
+	ProviderName           string
+	AliasApplied           bool
+	CanonicalModel         string
+	CanonicalPoolFallbacks []ModelSelector
+	RoutingStrategy        string
+	ConfigPrimary          ModelSelector
+	EffectiveCandidate     ModelSelector
+	SelectedProviderName   string
+	SelectedExactModel     string
+	BlockedCandidates      []BlockedCandidate
+	FailoverUsed           bool
+	FallbackTarget         string
 }
 
 // RequestedQualifiedModel returns the canonical requested selector.

--- a/internal/fallback/resolver.go
+++ b/internal/fallback/resolver.go
@@ -73,6 +73,9 @@ func (r *Resolver) ResolveFallbacks(resolution *core.RequestModelResolution, op 
 	if r == nil || resolution == nil || r.registry == nil {
 		return nil
 	}
+	if len(resolution.CanonicalPoolFallbacks) > 0 {
+		return append([]core.ModelSelector(nil), resolution.CanonicalPoolFallbacks...)
+	}
 
 	requiredCategory := requiredCategoryForOperation(op)
 	if requiredCategory == core.CategoryEmbedding {

--- a/internal/fallback/resolver_test.go
+++ b/internal/fallback/resolver_test.go
@@ -90,6 +90,29 @@ func TestResolverAutoModeAppendsRankingCandidates(t *testing.T) {
 	}
 }
 
+func TestResolverPrefersCanonicalPoolFallbacksWhenPresent(t *testing.T) {
+	registry := newFakeRegistry(
+		modelInfo("claude-sonnet-4-6", "anthropic_b", "anthropic", 1287, "claude-sonnet-4-6"),
+		modelInfo("claude-sonnet-4-6-20250929", "anthropic_a", "anthropic", 1287, "claude-sonnet-4-6"),
+	)
+
+	resolver := NewResolver(config.FallbackConfig{DefaultMode: config.FallbackModeAuto}, registry)
+	got := resolver.ResolveFallbacks(&core.RequestModelResolution{
+		Requested:              core.NewRequestedModelSelector("claude-sonnet-4-6", ""),
+		ResolvedSelector:       core.ModelSelector{Model: "claude-sonnet-4-6", Provider: "anthropic_b"},
+		ProviderType:          "anthropic",
+		CanonicalModel:        "claude-sonnet-4-6",
+		CanonicalPoolFallbacks: []core.ModelSelector{{Provider: "anthropic_a", Model: "claude-sonnet-4-6-20250929"}},
+	}, core.OperationChatCompletions)
+
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	if got[0].QualifiedModel() != "anthropic_a/claude-sonnet-4-6-20250929" {
+		t.Fatalf("got[0] = %q, want anthropic_a/claude-sonnet-4-6-20250929", got[0].QualifiedModel())
+	}
+}
+
 func TestResolverBlankDefaultModeUsesManualFallback(t *testing.T) {
 	registry := newFakeRegistry(
 		modelInfo("gpt-4o", "openai", "openai", 1287, "gpt-4o"),

--- a/internal/gateway/fallback.go
+++ b/internal/gateway/fallback.go
@@ -13,7 +13,13 @@ import (
 
 // FallbackSelectors returns fallback selectors for a translated workflow.
 func (o *InferenceOrchestrator) FallbackSelectors(workflow *core.Workflow) []core.ModelSelector {
-	if o.fallbackResolver == nil || workflow == nil || workflow.Resolution == nil || !workflow.FallbackEnabled() {
+	if o.fallbackResolver == nil || workflow == nil || workflow.Resolution == nil {
+		return nil
+	}
+	if workflow.Resolution.CanonicalModel != "" && len(workflow.Resolution.CanonicalPoolFallbacks) > 0 {
+		return o.fallbackResolver.ResolveFallbacks(workflow.Resolution, workflow.Endpoint.Operation)
+	}
+	if !workflow.FallbackEnabled() {
 		return nil
 	}
 	return o.fallbackResolver.ResolveFallbacks(workflow.Resolution, workflow.Endpoint.Operation)
@@ -48,14 +54,23 @@ func tryFallbackResponse[T any](
 	var zero T
 
 	fallbacks := o.FallbackSelectors(workflow)
-	if len(fallbacks) == 0 || !ShouldAttemptFallback(primaryErr) {
+	shouldAttempt := ShouldAttemptFallback(primaryErr)
+	if workflow != nil && workflow.Resolution != nil && workflow.Resolution.CanonicalModel != "" {
+		shouldAttempt = o.failoverPolicy.ShouldAttempt(primaryErr)
+	}
+	if len(fallbacks) == 0 || !shouldAttempt {
 		return zero, "", "", "", false, primaryErr
 	}
 
 	requestID := strings.TrimSpace(core.GetRequestID(ctx))
 	primaryModel := currentSelectorForWorkflow(workflow, model, provider)
 	lastErr := primaryErr
+	canonicalPool := workflow != nil && workflow.Resolution != nil && workflow.Resolution.CanonicalModel != ""
+	attempts := 0
 	for _, selector := range fallbacks {
+		if canonicalPool && o.failoverPolicy.MaxAttempts > 0 && attempts >= o.failoverPolicy.MaxAttempts-1 {
+			break
+		}
 		if o.modelAuthorizer != nil && !o.modelAuthorizer.AllowsModel(ctx, selector) {
 			continue
 		}
@@ -70,6 +85,7 @@ func tryFallbackResponse[T any](
 			"error", lastErr,
 		)
 
+		attempts++
 		resp, resolvedProviderType, err := call(selector, providerType, providerName)
 		if err == nil {
 			slog.Info("fallback model attempt succeeded",
@@ -78,6 +94,7 @@ func tryFallbackResponse[T any](
 				"to", qualified,
 				"provider_type", resolvedProviderType,
 			)
+			markWorkflowFailover(workflow, selector, providerName, qualified)
 			return resp, resolvedProviderType, providerName, qualified, true, nil
 		}
 		lastErr = err
@@ -139,14 +156,23 @@ func tryFallbackStream(
 	call func(selector core.ModelSelector, providerType, providerName string) (io.ReadCloser, string, string, error),
 ) (io.ReadCloser, string, string, string, string, error) {
 	fallbacks := o.FallbackSelectors(workflow)
-	if len(fallbacks) == 0 || !ShouldAttemptFallback(primaryErr) {
+	shouldAttempt := ShouldAttemptFallback(primaryErr)
+	if workflow != nil && workflow.Resolution != nil && workflow.Resolution.CanonicalModel != "" {
+		shouldAttempt = o.failoverPolicy.ShouldAttempt(primaryErr)
+	}
+	if len(fallbacks) == 0 || !shouldAttempt {
 		return nil, "", "", "", "", primaryErr
 	}
 
 	requestID := strings.TrimSpace(core.GetRequestID(ctx))
 	primaryModel := currentSelectorForWorkflow(workflow, model, provider)
 	lastErr := primaryErr
+	canonicalPool := workflow != nil && workflow.Resolution != nil && workflow.Resolution.CanonicalModel != ""
+	attempts := 0
 	for _, selector := range fallbacks {
+		if canonicalPool && o.failoverPolicy.MaxAttempts > 0 && attempts >= o.failoverPolicy.MaxAttempts-1 {
+			break
+		}
 		if o.modelAuthorizer != nil && !o.modelAuthorizer.AllowsModel(ctx, selector) {
 			continue
 		}
@@ -161,6 +187,7 @@ func tryFallbackStream(
 			"error", lastErr,
 		)
 
+		attempts++
 		stream, resolvedProviderType, usageModel, err := call(selector, providerType, providerName)
 		if err == nil {
 			slog.Info("fallback stream attempt succeeded",
@@ -169,12 +196,24 @@ func tryFallbackStream(
 				"to", qualified,
 				"provider_type", resolvedProviderType,
 			)
+			markWorkflowFailover(workflow, selector, providerName, qualified)
 			return stream, resolvedProviderType, providerName, usageModel, qualified, nil
 		}
 		lastErr = err
 	}
 
 	return nil, "", "", "", "", lastErr
+}
+
+func markWorkflowFailover(workflow *core.Workflow, selector core.ModelSelector, providerName, qualified string) {
+	if workflow == nil || workflow.Resolution == nil {
+		return
+	}
+	workflow.Resolution.FailoverUsed = true
+	workflow.Resolution.FallbackTarget = strings.TrimSpace(qualified)
+	workflow.Resolution.EffectiveCandidate = selector
+	workflow.Resolution.SelectedProviderName = strings.TrimSpace(providerName)
+	workflow.Resolution.SelectedExactModel = selector.Model
 }
 
 // ShouldAttemptFallback reports whether err should trigger translated fallback.

--- a/internal/gateway/inference_orchestrator.go
+++ b/internal/gateway/inference_orchestrator.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"gomodel/internal/core"
+	"gomodel/internal/routing"
 	"gomodel/internal/usage"
 )
 
@@ -15,6 +16,7 @@ type InferenceConfig struct {
 	ModelAuthorizer          ModelAuthorizer
 	WorkflowPolicyResolver   WorkflowPolicyResolver
 	FallbackResolver         FallbackResolver
+	FailoverPolicy           routing.FailoverPolicy
 	TranslatedRequestPatcher TranslatedRequestPatcher
 	UsageLogger              usage.LoggerInterface
 	PricingResolver          usage.PricingResolver
@@ -29,6 +31,7 @@ type InferenceOrchestrator struct {
 	modelAuthorizer          ModelAuthorizer
 	workflowPolicyResolver   WorkflowPolicyResolver
 	fallbackResolver         FallbackResolver
+	failoverPolicy           routing.FailoverPolicy
 	translatedRequestPatcher TranslatedRequestPatcher
 	usageLogger              usage.LoggerInterface
 	pricingResolver          usage.PricingResolver
@@ -43,6 +46,7 @@ func NewInferenceOrchestrator(cfg InferenceConfig) *InferenceOrchestrator {
 		modelAuthorizer:          cfg.ModelAuthorizer,
 		workflowPolicyResolver:   cfg.WorkflowPolicyResolver,
 		fallbackResolver:         cfg.FallbackResolver,
+		failoverPolicy:           cfg.FailoverPolicy,
 		translatedRequestPatcher: cfg.TranslatedRequestPatcher,
 		usageLogger:              cfg.UsageLogger,
 		pricingResolver:          cfg.PricingResolver,

--- a/internal/gateway/request_model_resolution.go
+++ b/internal/gateway/request_model_resolution.go
@@ -63,12 +63,27 @@ func ResolveRequestModelWithAuthorizer(
 ) (*core.RequestModelResolution, error) {
 	requested = core.NewRequestedModelSelector(requested.Model, requested.ProviderHint)
 
-	resolvedSelector, aliasApplied, err := ResolveExecutionSelector(provider, resolver, requested)
+	resolvedSelector, aliasApplied, err := ResolveExecutionSelectorWithContext(ctx, provider, resolver, requested)
 	if err != nil {
 		return nil, core.NewInvalidRequestError(err.Error(), err)
 	}
 	if resolvedSelector == (core.ModelSelector{}) {
 		resolvedSelector, err = requested.Normalize()
+		if err != nil {
+			return nil, core.NewInvalidRequestError(err.Error(), err)
+		}
+	}
+
+	var canonicalResolution *core.CanonicalRoutingResolution
+	if canonicalResolver, ok := resolver.(interface {
+		ResolveWithContext(context.Context, core.RequestedModelSelector) (*core.CanonicalRoutingResolution, bool, error)
+	}); ok {
+		canonicalResolution, _, err = canonicalResolver.ResolveWithContext(ctx, requested)
+		if err != nil {
+			return nil, core.NewInvalidRequestError(err.Error(), err)
+		}
+	} else if canonicalResolver, ok := resolver.(core.CanonicalRoutingResolver); ok {
+		canonicalResolution, _, err = canonicalResolver.Resolve(requested)
 		if err != nil {
 			return nil, core.NewInvalidRequestError(err.Error(), err)
 		}
@@ -87,17 +102,37 @@ func ResolveRequestModelWithAuthorizer(
 		}
 	}
 
-	return &core.RequestModelResolution{
+	resolution := &core.RequestModelResolution{
 		Requested:        requested,
 		ResolvedSelector: resolvedSelector,
 		ProviderType:     strings.TrimSpace(provider.GetProviderType(resolvedModel)),
 		ProviderName:     ResolvedProviderName(provider, resolvedSelector, ""),
 		AliasApplied:     aliasApplied,
-	}, nil
+	}
+	if canonicalResolution != nil {
+		resolution.CanonicalModel = canonicalResolution.CanonicalModel
+		resolution.CanonicalPoolFallbacks = append([]core.ModelSelector(nil), canonicalResolution.Fallbacks...)
+		resolution.RoutingStrategy = string(canonicalResolution.Strategy)
+		resolution.ConfigPrimary = canonicalResolution.ConfigPrimary
+		resolution.EffectiveCandidate = canonicalResolution.EffectiveCandidate
+		resolution.SelectedProviderName = canonicalResolution.SelectedProviderName
+		resolution.SelectedExactModel = canonicalResolution.SelectedExactModel
+		resolution.BlockedCandidates = append([]core.BlockedCandidate(nil), canonicalResolution.BlockedCandidates...)
+	}
+	return resolution, nil
 }
 
 // ResolveExecutionSelector applies explicit and provider-owned selector resolution.
 func ResolveExecutionSelector(
+	provider core.RoutableProvider,
+	resolver ModelResolver,
+	requested core.RequestedModelSelector,
+) (core.ModelSelector, bool, error) {
+	return ResolveExecutionSelectorWithContext(context.Background(), provider, resolver, requested)
+}
+
+func ResolveExecutionSelectorWithContext(
+	ctx context.Context,
 	provider core.RoutableProvider,
 	resolver ModelResolver,
 	requested core.RequestedModelSelector,
@@ -111,7 +146,13 @@ func ResolveExecutionSelector(
 	)
 
 	if resolver != nil {
-		resolvedSelector, aliasApplied, err = resolver.ResolveModel(requested)
+		if contextual, ok := resolver.(interface {
+			ResolveModelWithContext(context.Context, core.RequestedModelSelector) (core.ModelSelector, bool, error)
+		}); ok {
+			resolvedSelector, aliasApplied, err = contextual.ResolveModelWithContext(ctx, requested)
+		} else {
+			resolvedSelector, aliasApplied, err = resolver.ResolveModel(requested)
+		}
 		if err != nil {
 			return core.ModelSelector{}, false, err
 		}

--- a/internal/providers/config_test.go
+++ b/internal/providers/config_test.go
@@ -63,6 +63,26 @@ var testDiscoveryConfigs = map[string]DiscoveryConfig{
 	},
 }
 
+func clearProviderConfigEnvVars(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"OPENAI_API_KEY", "OPENAI_BASE_URL", "OPENAI_MODELS",
+		"ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_MODELS",
+		"GEMINI_API_KEY", "GEMINI_BASE_URL", "GEMINI_MODELS",
+		"DEEPSEEK_API_KEY", "DEEPSEEK_BASE_URL", "DEEPSEEK_MODELS",
+		"XAI_API_KEY", "XAI_BASE_URL", "XAI_MODELS",
+		"GROQ_API_KEY", "GROQ_BASE_URL", "GROQ_MODELS",
+		"OPENROUTER_API_KEY", "OPENROUTER_BASE_URL", "OPENROUTER_MODELS",
+		"ZAI_API_KEY", "ZAI_BASE_URL", "ZAI_MODELS",
+		"AZURE_API_KEY", "AZURE_BASE_URL", "AZURE_API_VERSION", "AZURE_MODELS",
+		"ORACLE_API_KEY", "ORACLE_BASE_URL", "ORACLE_MODELS",
+		"VLLM_API_KEY", "VLLM_BASE_URL", "VLLM_MODELS",
+		"OLLAMA_API_KEY", "OLLAMA_BASE_URL", "OLLAMA_MODELS",
+	} {
+		t.Setenv(key, "")
+	}
+}
+
 // --- buildProviderConfig ---
 
 func TestBuildProviderConfig_InheritsGlobal(t *testing.T) {
@@ -1517,6 +1537,7 @@ func TestResolveProviders_SingleCustomNamedProviderDoesNotDuplicateTypeKey(t *te
 }
 
 func TestResolveProviders_NoProvidersNoEnvVars(t *testing.T) {
+	clearProviderConfigEnvVars(t)
 	got, filteredRaw := resolveProviders(map[string]config.RawProviderConfig{}, globalResilience, testDiscoveryConfigs)
 	if len(got) != 0 {
 		t.Errorf("expected empty result, got %d entries", len(got))

--- a/internal/routing/composed_resolver.go
+++ b/internal/routing/composed_resolver.go
@@ -1,0 +1,81 @@
+package routing
+
+import (
+	"context"
+
+	"gomodel/internal/core"
+)
+
+type AliasResolver interface {
+	ResolveModel(requested core.RequestedModelSelector) (core.ModelSelector, bool, error)
+}
+
+type ComposedResolver struct {
+	aliasResolver AliasResolver
+	poolResolver  *Resolver
+}
+
+func NewComposedResolver(aliasResolver AliasResolver, poolResolver *Resolver) *ComposedResolver {
+	if aliasResolver == nil && poolResolver == nil {
+		return nil
+	}
+	return &ComposedResolver{aliasResolver: aliasResolver, poolResolver: poolResolver}
+}
+
+func (r *ComposedResolver) ResolveModel(requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
+	return r.ResolveModelWithContext(context.Background(), requested)
+}
+
+func (r *ComposedResolver) ResolveModelWithContext(ctx context.Context, requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
+	requested = core.NewRequestedModelSelector(requested.Model, requested.ProviderHint)
+
+	aliasApplied := false
+	if r != nil && r.aliasResolver != nil {
+		selector, changed, err := r.aliasResolver.ResolveModel(requested)
+		if err != nil {
+			return core.ModelSelector{}, false, err
+		}
+		if selector != (core.ModelSelector{}) {
+			requested = core.NewRequestedModelSelector(selector.QualifiedModel(), "")
+			aliasApplied = changed
+		}
+	}
+
+	if r != nil && r.poolResolver != nil {
+		resolution, matched, err := r.poolResolver.ResolveWithContext(ctx, requested)
+		if err != nil {
+			return core.ModelSelector{}, false, err
+		}
+		if matched && resolution != nil {
+			return resolution.Primary, true, nil
+		}
+	}
+
+	if r != nil && r.aliasResolver != nil {
+		selector, err := requested.Normalize()
+		return selector, aliasApplied, err
+	}
+	selector, err := requested.Normalize()
+	return selector, false, err
+}
+
+func (r *ComposedResolver) Resolve(requested core.RequestedModelSelector) (*core.CanonicalRoutingResolution, bool, error) {
+	return r.ResolveWithContext(context.Background(), requested)
+}
+
+func (r *ComposedResolver) ResolveWithContext(ctx context.Context, requested core.RequestedModelSelector) (*core.CanonicalRoutingResolution, bool, error) {
+	requested = core.NewRequestedModelSelector(requested.Model, requested.ProviderHint)
+	if r == nil || r.poolResolver == nil {
+		return nil, false, nil
+	}
+	if r.aliasResolver != nil {
+		selector, _, err := r.aliasResolver.ResolveModel(requested)
+		if err != nil {
+			return nil, false, err
+		}
+		if selector != (core.ModelSelector{}) {
+			requested = core.NewRequestedModelSelector(selector.QualifiedModel(), "")
+		}
+	}
+	return r.poolResolver.ResolveWithContext(ctx, requested)
+}

--- a/internal/routing/exposed_models.go
+++ b/internal/routing/exposed_models.go
@@ -1,0 +1,116 @@
+package routing
+
+import (
+	"sort"
+	"strings"
+
+	"gomodel/config"
+	"gomodel/internal/core"
+)
+
+type Catalog interface {
+	LookupModel(model string) (*core.Model, bool)
+}
+
+type CanonicalExposedModelLister struct {
+	cfg      config.RoutingConfig
+	catalog  Catalog
+	state    StateChecker
+	runtime  RuntimeSnapshotProvider
+	resolver *Resolver
+}
+
+func NewCanonicalExposedModelLister(cfg config.RoutingConfig, catalog Catalog, state StateChecker, runtime RuntimeSnapshotProvider) *CanonicalExposedModelLister {
+	if len(cfg.ModelPools) == 0 || catalog == nil {
+		return nil
+	}
+	return &CanonicalExposedModelLister{cfg: cfg, catalog: catalog, state: state, runtime: runtime, resolver: NewResolver(cfg, state).WithRuntime(runtime)}
+}
+
+func (l *CanonicalExposedModelLister) ExposedModels() []core.Model {
+	return l.ExposedModelsFiltered(nil)
+}
+
+func (l *CanonicalExposedModelLister) ExposedModelsFiltered(allow func(core.ModelSelector) bool) []core.Model {
+	if l == nil || l.catalog == nil || len(l.cfg.ModelPools) == 0 {
+		return nil
+	}
+	models := make([]core.Model, 0, len(l.cfg.ModelPools))
+	for canonical := range l.cfg.ModelPools {
+		canonical = strings.TrimSpace(canonical)
+		if canonical == "" {
+			continue
+		}
+		if l.resolver == nil {
+			continue
+		}
+		resolution, matched, err := l.resolver.Resolve(core.NewRequestedModelSelector(canonical, ""))
+		if err != nil || !matched || resolution == nil {
+			continue
+		}
+		selector := resolution.Primary
+		if allow != nil && !allow(selector) {
+			continue
+		}
+		model, ok := l.catalog.LookupModel(selector.QualifiedModel())
+		if !ok || model == nil {
+			continue
+		}
+		clone := *model
+		clone.ID = canonical
+		models = append(models, clone)
+	}
+	sort.Slice(models, func(i, j int) bool { return models[i].ID < models[j].ID })
+	return models
+}
+
+type CombinedExposedModelLister struct {
+	listers []serverExposedModelLister
+}
+
+type serverExposedModelLister interface {
+	ExposedModels() []core.Model
+}
+
+type serverFilteredExposedModelLister interface {
+	ExposedModelsFiltered(allow func(core.ModelSelector) bool) []core.Model
+}
+
+func NewCombinedExposedModelLister(listers ...serverExposedModelLister) *CombinedExposedModelLister {
+	filtered := make([]serverExposedModelLister, 0, len(listers))
+	for _, lister := range listers {
+		if lister != nil {
+			filtered = append(filtered, lister)
+		}
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+	return &CombinedExposedModelLister{listers: filtered}
+}
+
+func (l *CombinedExposedModelLister) ExposedModels() []core.Model {
+	if l == nil {
+		return nil
+	}
+	var result []core.Model
+	for _, lister := range l.listers {
+		result = append(result, lister.ExposedModels()...)
+	}
+	return result
+}
+
+func (l *CombinedExposedModelLister) ExposedModelsFiltered(allow func(core.ModelSelector) bool) []core.Model {
+	if l == nil {
+		return nil
+	}
+	var result []core.Model
+	for _, lister := range l.listers {
+		if filtered, ok := lister.(serverFilteredExposedModelLister); ok {
+			result = append(result, filtered.ExposedModelsFiltered(allow)...)
+			continue
+		}
+		result = append(result, lister.ExposedModels()...)
+	}
+	return result
+}

--- a/internal/routing/exposed_models_test.go
+++ b/internal/routing/exposed_models_test.go
@@ -1,0 +1,98 @@
+package routing
+
+import (
+	"testing"
+	"time"
+
+	"gomodel/config"
+	"gomodel/internal/core"
+	"gomodel/internal/providers"
+)
+
+type testCatalog struct {
+	models map[string]core.Model
+}
+
+func (c testCatalog) LookupModel(model string) (*core.Model, bool) {
+	value, ok := c.models[model]
+	if !ok {
+		return nil, false
+	}
+	clone := value
+	return &clone, true
+}
+
+type staticRuntimeProvider struct {
+	snapshots []providers.ProviderRuntimeSnapshot
+}
+
+func (p staticRuntimeProvider) ProviderRuntimeSnapshots() []providers.ProviderRuntimeSnapshot {
+	return append([]providers.ProviderRuntimeSnapshot(nil), p.snapshots...)
+}
+
+func TestCanonicalExposedModelLister_UsesEffectiveResolverChoice(t *testing.T) {
+	now := time.Now().UTC()
+	lister := NewCanonicalExposedModelLister(
+		config.RoutingConfig{
+			Defaults: config.RoutingDefaultsConfig{Strategy: config.RoutingStrategyWeightedRoundRobin},
+			ModelPools: map[string]config.ModelPoolConfig{
+				"claude-opus-4-7": {
+					Candidates: []config.ModelPoolCandidateConfig{
+						{Provider: "anthropic_a", Model: "claude-opus-4-7", Weight: 1, Priority: 2},
+						{Provider: "anthropic_b", Model: "claude-opus-4-7", Weight: 10, Priority: 1},
+					},
+				},
+			},
+		},
+		testCatalog{models: map[string]core.Model{
+			"anthropic_a/claude-opus-4-7": {ID: "claude-opus-4-7", Object: "model", OwnedBy: "a"},
+			"anthropic_b/claude-opus-4-7": {ID: "claude-opus-4-7", Object: "model", OwnedBy: "b"},
+		}},
+		nil,
+		staticRuntimeProvider{snapshots: []providers.ProviderRuntimeSnapshot{
+			{Name: "anthropic_a", Registered: true, DiscoveredModelCount: 1, LastModelFetchSuccessAt: &now},
+			{Name: "anthropic_b", Registered: true, DiscoveredModelCount: 1, LastModelFetchSuccessAt: &now},
+		}},
+	)
+	models := lister.ExposedModels()
+	if len(models) != 1 {
+		t.Fatalf("len(models) = %d, want 1", len(models))
+	}
+	if got := models[0].OwnedBy; got != "b" {
+		t.Fatalf("models[0].OwnedBy = %q, want b", got)
+	}
+}
+
+func TestCanonicalExposedModelLister_SkipsUnhealthyCandidates(t *testing.T) {
+	now := time.Now().UTC()
+	lister := NewCanonicalExposedModelLister(
+		config.RoutingConfig{
+			Defaults: config.RoutingDefaultsConfig{Strategy: config.RoutingStrategyPriorityFailover},
+			ModelPools: map[string]config.ModelPoolConfig{
+				"claude-sonnet-4-6": {
+					Candidates: []config.ModelPoolCandidateConfig{
+						{Provider: "anthropic_a", Model: "claude-sonnet-4-6-20250929", Priority: 1},
+						{Provider: "anthropic_b", Model: "claude-sonnet-4-6", Priority: 2},
+					},
+				},
+			},
+		},
+		testCatalog{models: map[string]core.Model{
+			"anthropic_a/claude-sonnet-4-6-20250929": {ID: "claude-sonnet-4-6-20250929", Object: "model"},
+			"anthropic_b/claude-sonnet-4-6":          {ID: "claude-sonnet-4-6", Object: "model"},
+		}},
+		nil,
+		staticRuntimeProvider{snapshots: []providers.ProviderRuntimeSnapshot{
+			{Name: "anthropic_a", Registered: true, LastModelFetchError: "boom"},
+			{Name: "anthropic_b", Registered: true, DiscoveredModelCount: 1, LastModelFetchSuccessAt: &now},
+		}},
+	)
+
+	models := lister.ExposedModels()
+	if len(models) != 1 {
+		t.Fatalf("len(models) = %d, want 1", len(models))
+	}
+	if got := models[0].ID; got != "claude-sonnet-4-6" {
+		t.Fatalf("models[0].ID = %q, want claude-sonnet-4-6", got)
+	}
+}

--- a/internal/routing/failover_policy.go
+++ b/internal/routing/failover_policy.go
@@ -1,0 +1,62 @@
+package routing
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"gomodel/config"
+	"gomodel/internal/core"
+)
+
+type FailoverPolicy struct {
+	Enabled            bool
+	MaxAttempts        int
+	RetryOnStatuses    map[int]struct{}
+	RetryOnModelErrors bool
+}
+
+func NewFailoverPolicy(cfg config.RoutingFailoverConfig) FailoverPolicy {
+	statuses := make(map[int]struct{}, len(cfg.RetryOnStatuses))
+	for _, status := range cfg.RetryOnStatuses {
+		statuses[status] = struct{}{}
+	}
+	maxAttempts := cfg.MaxAttempts
+	if maxAttempts <= 0 {
+		maxAttempts = 3
+	}
+	return FailoverPolicy{
+		Enabled:            cfg.Enabled,
+		MaxAttempts:        maxAttempts,
+		RetryOnStatuses:    statuses,
+		RetryOnModelErrors: cfg.RetryOnModelErrors,
+	}
+}
+
+func (p FailoverPolicy) ShouldAttempt(err error) bool {
+	if !p.Enabled {
+		return false
+	}
+	if err == nil {
+		return false
+	}
+	var gatewayErr *core.GatewayError
+	if !errors.As(err, &gatewayErr) || gatewayErr == nil {
+		return false
+	}
+	status := gatewayErr.HTTPStatusCode()
+	if _, ok := p.RetryOnStatuses[status]; ok {
+		return true
+	}
+	if !p.RetryOnModelErrors {
+		return false
+	}
+	message := strings.ToLower(strings.TrimSpace(gatewayErr.Message))
+	if strings.Contains(message, "model") && (strings.Contains(message, "unavailable") || strings.Contains(message, "not found") || strings.Contains(message, "unsupported")) {
+		return true
+	}
+	if status >= http.StatusInternalServerError || status == http.StatusTooManyRequests {
+		return true
+	}
+	return false
+}

--- a/internal/routing/pool_evaluator.go
+++ b/internal/routing/pool_evaluator.go
@@ -1,0 +1,178 @@
+package routing
+
+import (
+	"strings"
+
+	"gomodel/config"
+	"gomodel/internal/core"
+)
+
+type CandidateRuntimeInfo struct {
+	Status    string
+	LastError string
+}
+
+type EvaluatedCandidate struct {
+	Candidate        Candidate
+	ProviderEnabled  bool
+	CandidateEnabled bool
+	EffectiveEnabled bool
+	Selectable       bool
+	Status           string
+	StatusReason     string
+	RuntimeStatus    string
+	RuntimeLastError string
+}
+
+type EvaluatedPool struct {
+	CanonicalModel string
+	Strategy       config.RoutingStrategy
+	Enabled        bool
+	Status         string
+	StatusReason   string
+	Candidates     []EvaluatedCandidate
+}
+
+func (p EvaluatedPool) ConfigPrimaryCandidate() (Candidate, bool) {
+	if len(p.Candidates) == 0 {
+		return Candidate{}, false
+	}
+	candidate := p.Candidates[0].Candidate
+	for _, current := range p.Candidates[1:] {
+		switch p.Strategy {
+		case config.RoutingStrategyWeightedRoundRobin:
+			if current.Candidate.Weight > candidate.Weight || (current.Candidate.Weight == candidate.Weight && current.Candidate.Priority < candidate.Priority) {
+				candidate = current.Candidate
+			}
+		default:
+			if current.Candidate.Priority < candidate.Priority || (current.Candidate.Priority == candidate.Priority && current.Candidate.QualifiedModel() < candidate.QualifiedModel()) {
+				candidate = current.Candidate
+			}
+		}
+	}
+	return candidate, true
+}
+
+func (p EvaluatedPool) BlockedCandidates() []core.BlockedCandidate {
+	blocked := make([]core.BlockedCandidate, 0)
+	for _, candidate := range p.Candidates {
+		if candidate.Selectable {
+			continue
+		}
+		blocked = append(blocked, core.BlockedCandidate{Selector: candidate.Candidate.Selector(), Reason: candidate.StatusReason, Status: candidate.Status})
+	}
+	return blocked
+}
+
+type detailedStateChecker interface {
+	StateChecker
+	ProviderEnabled(name string) bool
+	CandidateEnabled(selector core.ModelSelector) bool
+}
+
+func EvaluatePool(strategy config.RoutingStrategy, pool Pool, state StateChecker, runtimeByProvider map[string]CandidateRuntimeInfo) EvaluatedPool {
+	strategy = config.ResolveRoutingStrategy(strategy)
+	canonicalEnabled := true
+	if state != nil {
+		canonicalEnabled = state.CanonicalModelEnabled(pool.CanonicalModel)
+	}
+
+	result := EvaluatedPool{
+		CanonicalModel: pool.CanonicalModel,
+		Strategy:       strategy,
+		Enabled:        canonicalEnabled,
+		Candidates:     make([]EvaluatedCandidate, 0, len(pool.Candidates)),
+	}
+
+	selectableCount := 0
+	availableCount := 0
+	for _, candidate := range pool.Candidates {
+		providerEnabled := providerEnabled(state, candidate.Provider)
+		candidateEnabled := candidateEnabled(state, candidate.Selector())
+		effectiveEnabled := canonicalEnabled && providerEnabled && candidateEnabled
+		runtime := runtimeByProvider[strings.TrimSpace(candidate.Provider)]
+
+		status := "enabled"
+		reason := ""
+		switch {
+		case !candidateEnabled:
+			status = "disabled_manual"
+			reason = "candidate disabled manually"
+		case !providerEnabled:
+			status = "disabled_manual"
+			reason = "provider disabled manually"
+		case !canonicalEnabled:
+			status = "disabled_effective"
+			reason = "canonical model disabled manually"
+		case runtime.Status == "degraded" || runtime.Status == "unhealthy":
+			status = "degraded_runtime"
+			reason = "provider runtime degraded"
+		}
+
+		selectable := effectiveEnabled && runtime.Status != "unhealthy"
+		if selectable {
+			selectableCount++
+		}
+		if effectiveEnabled {
+			availableCount++
+		}
+
+		result.Candidates = append(result.Candidates, EvaluatedCandidate{
+			Candidate:        candidate,
+			ProviderEnabled:  providerEnabled,
+			CandidateEnabled: candidateEnabled,
+			EffectiveEnabled: effectiveEnabled,
+			Selectable:       selectable,
+			Status:           status,
+			StatusReason:     reason,
+			RuntimeStatus:    runtime.Status,
+			RuntimeLastError: runtime.LastError,
+		})
+	}
+
+	switch {
+	case !canonicalEnabled:
+		result.Status = "disabled_manual"
+		result.StatusReason = "canonical model disabled manually"
+	case selectableCount == 0:
+		result.Status = "degraded"
+		result.StatusReason = "no enabled candidates"
+	case availableCount < len(result.Candidates):
+		result.Status = "degraded"
+		result.StatusReason = "one or more candidates unavailable"
+	default:
+		result.Status = "enabled"
+	}
+
+	return result
+}
+
+func (p EvaluatedPool) SelectableCandidates() []Candidate {
+	candidates := make([]Candidate, 0, len(p.Candidates))
+	for _, candidate := range p.Candidates {
+		if candidate.Selectable {
+			candidates = append(candidates, candidate.Candidate)
+		}
+	}
+	return candidates
+}
+
+func providerEnabled(state StateChecker, provider string) bool {
+	if state == nil {
+		return true
+	}
+	if detailed, ok := state.(detailedStateChecker); ok {
+		return detailed.ProviderEnabled(provider)
+	}
+	return true
+}
+
+func candidateEnabled(state StateChecker, selector core.ModelSelector) bool {
+	if state == nil {
+		return true
+	}
+	if detailed, ok := state.(detailedStateChecker); ok {
+		return detailed.CandidateEnabled(selector)
+	}
+	return true
+}

--- a/internal/routing/resolver.go
+++ b/internal/routing/resolver.go
@@ -1,0 +1,164 @@
+package routing
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"gomodel/config"
+	"gomodel/internal/core"
+)
+
+type StateChecker interface {
+	CanonicalModelEnabled(name string) bool
+	FilterCandidates(canonical string, candidates []Candidate) []Candidate
+}
+
+type Resolver struct {
+	strategy config.RoutingStrategy
+	pools    map[string]Pool
+	state    StateChecker
+	runtime  RuntimeSnapshotProvider
+	affinity *affinityStore
+	mu       sync.Mutex
+	counters map[string]int
+}
+
+func NewResolver(cfg config.RoutingConfig, state ...StateChecker) *Resolver {
+	if len(cfg.ModelPools) == 0 {
+		return nil
+	}
+
+	pools := make(map[string]Pool, len(cfg.ModelPools))
+	for canonicalModel, poolCfg := range cfg.ModelPools {
+		candidates := make([]Candidate, 0, len(poolCfg.Candidates))
+		for _, candidate := range poolCfg.Candidates {
+			candidates = append(candidates, Candidate{
+				Provider: strings.TrimSpace(candidate.Provider),
+				Model:    strings.TrimSpace(candidate.Model),
+				Priority: candidate.Priority,
+				Weight:   candidate.Weight,
+			})
+		}
+		key := normalizePoolKey(canonicalModel)
+		pools[key] = Pool{CanonicalModel: key, Candidates: candidates}
+	}
+
+	var checker StateChecker
+	if len(state) > 0 {
+		checker = state[0]
+	}
+	return &Resolver{
+		strategy: config.ResolveRoutingStrategy(cfg.Defaults.Strategy),
+		pools:    pools,
+		state:    checker,
+		affinity: newAffinityStore(cfg.Defaults.SessionAffinity, cfg.Defaults.SessionAffinityTTL),
+		counters: make(map[string]int),
+	}
+}
+
+func (r *Resolver) WithRuntime(runtime RuntimeSnapshotProvider) *Resolver {
+	if r == nil {
+		return nil
+	}
+	r.runtime = runtime
+	return r
+}
+
+func (r *Resolver) HasPool(model string) bool {
+	if r == nil {
+		return false
+	}
+	_, ok := r.pools[normalizePoolKey(model)]
+	return ok
+}
+
+func (r *Resolver) Resolve(requested core.RequestedModelSelector) (*core.CanonicalRoutingResolution, bool, error) {
+	return r.ResolveWithContext(context.Background(), requested)
+}
+
+func (r *Resolver) ResolveWithContext(ctx context.Context, requested core.RequestedModelSelector) (*core.CanonicalRoutingResolution, bool, error) {
+	if r == nil {
+		return nil, false, nil
+	}
+	if strings.TrimSpace(requested.ProviderHint) != "" {
+		return nil, false, nil
+	}
+
+	pool, ok := r.pools[normalizePoolKey(requested.Model)]
+	if !ok {
+		return nil, false, nil
+	}
+	if len(pool.Candidates) == 0 {
+		return nil, false, fmt.Errorf("routing pool %q has no candidates", pool.CanonicalModel)
+	}
+
+	evaluated := EvaluatePool(r.strategy, pool, r.state, RuntimeInfoByProvider(r.runtime))
+	if !evaluated.Enabled {
+		return nil, false, fmt.Errorf("canonical model %q is disabled", pool.CanonicalModel)
+	}
+	configPrimary, _ := evaluated.ConfigPrimaryCandidate()
+	blockedCandidates := evaluated.BlockedCandidates()
+	pool.Candidates = evaluated.SelectableCandidates()
+	if len(pool.Candidates) == 0 {
+		return nil, false, fmt.Errorf("routing pool %q has no enabled candidates", pool.CanonicalModel)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if affinity := r.affinity; affinity != nil {
+		if pinned, ok := affinity.Get(ctx, pool.CanonicalModel); ok {
+			for idx, candidate := range pool.Candidates {
+				if candidate.QualifiedModel() != pinned.QualifiedModel() {
+					continue
+				}
+				fallbacks := make([]Candidate, 0, len(pool.Candidates)-1)
+				for i, fallback := range pool.Candidates {
+					if i == idx {
+						continue
+					}
+					fallbacks = append(fallbacks, fallback)
+				}
+				resolved := &core.CanonicalRoutingResolution{
+					CanonicalModel:       pool.CanonicalModel,
+					Primary:              candidate.Selector(),
+					Strategy:             string(r.strategy),
+					ConfigPrimary:        configPrimary.Selector(),
+					EffectiveCandidate:   candidate.Selector(),
+					SelectedExactModel:   candidate.Model,
+					SelectedProviderName: candidate.Provider,
+					BlockedCandidates:    append([]core.BlockedCandidate(nil), blockedCandidates...),
+					Fallbacks:            make([]core.ModelSelector, 0, len(fallbacks)),
+				}
+				for _, fallback := range fallbacks {
+					resolved.Fallbacks = append(resolved.Fallbacks, fallback.Selector())
+				}
+				return resolved, true, nil
+			}
+		}
+	}
+	primary, fallbacks, err := selectCandidates(r.strategy, pool, r.counters)
+	if err == nil && r.affinity != nil {
+		r.affinity.Put(ctx, pool.CanonicalModel, primary)
+	}
+	if err != nil {
+		return nil, false, err
+	}
+
+	resolved := &core.CanonicalRoutingResolution{
+		CanonicalModel:       pool.CanonicalModel,
+		Primary:              primary.Selector(),
+		Strategy:             string(r.strategy),
+		ConfigPrimary:        configPrimary.Selector(),
+		EffectiveCandidate:   primary.Selector(),
+		SelectedProviderName: primary.Provider,
+		SelectedExactModel:   primary.Model,
+		BlockedCandidates:    append([]core.BlockedCandidate(nil), blockedCandidates...),
+		Fallbacks:            make([]core.ModelSelector, 0, len(fallbacks)),
+	}
+	for _, candidate := range fallbacks {
+		resolved.Fallbacks = append(resolved.Fallbacks, candidate.Selector())
+	}
+	return resolved, true, nil
+}

--- a/internal/routing/resolver_test.go
+++ b/internal/routing/resolver_test.go
@@ -1,0 +1,325 @@
+package routing
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"gomodel/config"
+	"gomodel/internal/core"
+	"gomodel/internal/providers"
+)
+
+func TestNewResolverPriorityFailover(t *testing.T) {
+	resolver := NewResolver(config.RoutingConfig{
+		Defaults: config.RoutingDefaultsConfig{
+			Strategy:           config.RoutingStrategyPriorityFailover,
+			SessionAffinity:    true,
+			SessionAffinityTTL: 30 * time.Minute,
+		},
+		ModelPools: map[string]config.ModelPoolConfig{
+			"claude-sonnet-4-6": {
+				Candidates: []config.ModelPoolCandidateConfig{
+					{Provider: "anthropic_b", Model: "claude-sonnet-4-6", Priority: 1},
+					{Provider: "anthropic_a", Model: "claude-sonnet-4-6-20250929", Priority: 2},
+				},
+			},
+		},
+	})
+	if resolver == nil {
+		t.Fatal("NewResolver() = nil, want resolver")
+	}
+
+	resolution, matched, err := resolver.Resolve(core.NewRequestedModelSelector("claude-sonnet-4-6", ""))
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if !matched {
+		t.Fatal("matched = false, want true")
+	}
+	if got := resolution.Primary.QualifiedModel(); got != "anthropic_b/claude-sonnet-4-6" {
+		t.Fatalf("primary = %q, want anthropic_b/claude-sonnet-4-6", got)
+	}
+	if len(resolution.Fallbacks) != 1 || resolution.Fallbacks[0].QualifiedModel() != "anthropic_a/claude-sonnet-4-6-20250929" {
+		t.Fatalf("fallbacks = %v, want [anthropic_a/claude-sonnet-4-6-20250929]", resolution.Fallbacks)
+	}
+}
+
+func TestNewResolverWeightedRoundRobinDistributesPrimary(t *testing.T) {
+	resolver := NewResolver(config.RoutingConfig{
+		Defaults: config.RoutingDefaultsConfig{
+			Strategy: config.RoutingStrategyWeightedRoundRobin,
+		},
+		ModelPools: map[string]config.ModelPoolConfig{
+			"claude-opus-4-7": {
+				Candidates: []config.ModelPoolCandidateConfig{
+					{Provider: "anthropic_b", Model: "claude-opus-4-7", Weight: 10, Priority: 1},
+					{Provider: "anthropic_a", Model: "claude-opus-4-7", Weight: 8, Priority: 2},
+				},
+			},
+		},
+	})
+
+	seen := map[string]int{}
+	for i := 0; i < 4; i++ {
+		resolution, matched, err := resolver.Resolve(core.NewRequestedModelSelector("claude-opus-4-7", ""))
+		if err != nil {
+			t.Fatalf("Resolve() error = %v", err)
+		}
+		if !matched {
+			t.Fatal("matched = false, want true")
+		}
+		seen[resolution.Primary.QualifiedModel()]++
+	}
+	if len(seen) < 2 {
+		t.Fatalf("weighted selection saw %v, want at least 2 candidates chosen", seen)
+	}
+}
+
+func TestResolverReturnsErrorWhenCanonicalModelDisabled(t *testing.T) {
+	resolver := NewResolver(config.RoutingConfig{
+		Defaults: config.RoutingDefaultsConfig{Strategy: config.RoutingStrategyPriorityFailover},
+		ModelPools: map[string]config.ModelPoolConfig{
+			"claude-sonnet-4-6": {Candidates: []config.ModelPoolCandidateConfig{{Provider: "anthropic_b", Model: "claude-sonnet-4-6", Priority: 1}}},
+		},
+	}, disabledCanonicalStateChecker{})
+	_, matched, err := resolver.Resolve(core.NewRequestedModelSelector("claude-sonnet-4-6", ""))
+	if err == nil {
+		t.Fatal("expected error for disabled canonical model")
+	}
+	if matched {
+		t.Fatal("matched = true, want false on disabled canonical model")
+	}
+}
+
+func TestResolverSkipsUnhealthyPrimaryCandidate(t *testing.T) {
+	resolver := NewResolver(config.RoutingConfig{
+		Defaults: config.RoutingDefaultsConfig{Strategy: config.RoutingStrategyPriorityFailover},
+		ModelPools: map[string]config.ModelPoolConfig{
+			"claude-sonnet-4-6": {
+				Candidates: []config.ModelPoolCandidateConfig{
+					{Provider: "anthropic_a", Model: "claude-sonnet-4-6-20250929", Priority: 1},
+					{Provider: "anthropic_b", Model: "claude-sonnet-4-6", Priority: 2},
+				},
+			},
+		},
+	}).WithRuntime(staticRuntimeProvider{snapshots: []providers.ProviderRuntimeSnapshot{{Name: "anthropic_a", Registered: true, LastModelFetchError: "boom"}, {Name: "anthropic_b", Registered: true, DiscoveredModelCount: 1}}})
+	resolution, matched, err := resolver.Resolve(core.NewRequestedModelSelector("claude-sonnet-4-6", ""))
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if !matched {
+		t.Fatal("matched = false, want true")
+	}
+	if got := resolution.Primary.QualifiedModel(); got != "anthropic_b/claude-sonnet-4-6" {
+		t.Fatalf("primary = %q, want anthropic_b/claude-sonnet-4-6", got)
+	}
+}
+
+func TestResolverKeepsDegradedCandidateEligible(t *testing.T) {
+	resolver := NewResolver(config.RoutingConfig{
+		Defaults: config.RoutingDefaultsConfig{Strategy: config.RoutingStrategyPriorityFailover},
+		ModelPools: map[string]config.ModelPoolConfig{
+			"claude-sonnet-4-6": {
+				Candidates: []config.ModelPoolCandidateConfig{
+					{Provider: "anthropic_a", Model: "claude-sonnet-4-6-20250929", Priority: 1},
+					{Provider: "anthropic_b", Model: "claude-sonnet-4-6", Priority: 2},
+				},
+			},
+		},
+	}).WithRuntime(staticRuntimeProvider{snapshots: []providers.ProviderRuntimeSnapshot{{Name: "anthropic_a", Registered: true, DiscoveredModelCount: 1, LastModelFetchError: "temporary issue"}, {Name: "anthropic_b", Registered: true, DiscoveredModelCount: 1}}})
+	resolution, matched, err := resolver.Resolve(core.NewRequestedModelSelector("claude-sonnet-4-6", ""))
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if !matched {
+		t.Fatal("matched = false, want true")
+	}
+	if got := resolution.Primary.QualifiedModel(); got != "anthropic_a/claude-sonnet-4-6-20250929" {
+		t.Fatalf("primary = %q, want degraded candidate to remain eligible", got)
+	}
+}
+
+func TestResolverUsesSessionAffinityForSameUserPath(t *testing.T) {
+	resolver := NewResolver(config.RoutingConfig{
+		Defaults: config.RoutingDefaultsConfig{
+			Strategy:        config.RoutingStrategyWeightedRoundRobin,
+			SessionAffinity: true,
+		},
+		ModelPools: map[string]config.ModelPoolConfig{
+			"claude-opus-4-7": {
+				Candidates: []config.ModelPoolCandidateConfig{
+					{Provider: "anthropic_a", Model: "claude-opus-4-7", Weight: 10, Priority: 1},
+					{Provider: "anthropic_b", Model: "claude-opus-4-7", Weight: 10, Priority: 2},
+				},
+			},
+		},
+	})
+	ctx := core.WithRequestID(context.Background(), "req-1")
+	ctx = core.WithRequestSnapshot(ctx, (&core.RequestSnapshot{UserPath: "/team/a"}))
+	first, matched, err := resolver.ResolveWithContext(ctx, core.NewRequestedModelSelector("claude-opus-4-7", ""))
+	if err != nil {
+		t.Fatalf("first ResolveWithContext() error = %v", err)
+	}
+	if !matched {
+		t.Fatal("first matched = false, want true")
+	}
+	second, matched, err := resolver.ResolveWithContext(ctx, core.NewRequestedModelSelector("claude-opus-4-7", ""))
+	if err != nil {
+		t.Fatalf("second ResolveWithContext() error = %v", err)
+	}
+	if !matched {
+		t.Fatal("second matched = false, want true")
+	}
+	if first.Primary.QualifiedModel() != second.Primary.QualifiedModel() {
+		t.Fatalf("affinity primary mismatch: first=%q second=%q", first.Primary.QualifiedModel(), second.Primary.QualifiedModel())
+	}
+}
+
+func TestResolverRepinsWhenPinnedCandidateBecomesIneligible(t *testing.T) {
+	resolver := NewResolver(config.RoutingConfig{
+		Defaults: config.RoutingDefaultsConfig{
+			Strategy:        config.RoutingStrategyPriorityFailover,
+			SessionAffinity: true,
+		},
+		ModelPools: map[string]config.ModelPoolConfig{
+			"claude-sonnet-4-6": {
+				Candidates: []config.ModelPoolCandidateConfig{
+					{Provider: "anthropic_a", Model: "claude-sonnet-4-6-20250929", Priority: 1},
+					{Provider: "anthropic_b", Model: "claude-sonnet-4-6", Priority: 2},
+				},
+			},
+		},
+	})
+	ctx := core.WithRequestID(context.Background(), "req-1")
+	ctx = core.WithRequestSnapshot(ctx, (&core.RequestSnapshot{UserPath: "/team/a"}))
+	first, matched, err := resolver.ResolveWithContext(ctx, core.NewRequestedModelSelector("claude-sonnet-4-6", ""))
+	if err != nil {
+		t.Fatalf("first ResolveWithContext() error = %v", err)
+	}
+	if !matched {
+		t.Fatal("first matched = false, want true")
+	}
+	resolver.runtime = staticRuntimeProvider{snapshots: []providers.ProviderRuntimeSnapshot{{Name: "anthropic_a", Registered: true, LastModelFetchError: "boom"}, {Name: "anthropic_b", Registered: true, DiscoveredModelCount: 1}}}
+	second, matched, err := resolver.ResolveWithContext(ctx, core.NewRequestedModelSelector("claude-sonnet-4-6", ""))
+	if err != nil {
+		t.Fatalf("second ResolveWithContext() error = %v", err)
+	}
+	if !matched {
+		t.Fatal("second matched = false, want true")
+	}
+	if first.Primary.QualifiedModel() == second.Primary.QualifiedModel() {
+		t.Fatalf("expected repin after runtime failure, both resolutions used %q", second.Primary.QualifiedModel())
+	}
+}
+
+func TestResolverRepinsWhenPinnedCandidateIsManuallyDisabled(t *testing.T) {
+	state := &manualDisableStateChecker{}
+	resolver := NewResolver(config.RoutingConfig{
+		Defaults: config.RoutingDefaultsConfig{
+			Strategy:        config.RoutingStrategyPriorityFailover,
+			SessionAffinity: true,
+		},
+		ModelPools: map[string]config.ModelPoolConfig{
+			"claude-sonnet-4-6": {
+				Candidates: []config.ModelPoolCandidateConfig{
+					{Provider: "anthropic_a", Model: "claude-sonnet-4-6-20250929", Priority: 1},
+					{Provider: "anthropic_b", Model: "claude-sonnet-4-6", Priority: 2},
+				},
+			},
+		},
+	}, state)
+	ctx := core.WithRequestID(context.Background(), "req-1")
+	ctx = core.WithRequestSnapshot(ctx, (&core.RequestSnapshot{UserPath: "/team/a"}))
+	first, matched, err := resolver.ResolveWithContext(ctx, core.NewRequestedModelSelector("claude-sonnet-4-6", ""))
+	if err != nil {
+		t.Fatalf("first ResolveWithContext() error = %v", err)
+	}
+	if !matched {
+		t.Fatal("first matched = false, want true")
+	}
+	state.disabledProvider = "anthropic_a"
+	state.disabledModel = "claude-sonnet-4-6-20250929"
+	second, matched, err := resolver.ResolveWithContext(ctx, core.NewRequestedModelSelector("claude-sonnet-4-6", ""))
+	if err != nil {
+		t.Fatalf("second ResolveWithContext() error = %v", err)
+	}
+	if !matched {
+		t.Fatal("second matched = false, want true")
+	}
+	if first.Primary.QualifiedModel() == second.Primary.QualifiedModel() {
+		t.Fatalf("expected repin after manual disable, both resolutions used %q", second.Primary.QualifiedModel())
+	}
+}
+
+func TestComposedResolverAppliesAliasThenPool(t *testing.T) {
+	alias := aliasResolverStub{}
+	pool := NewResolver(config.RoutingConfig{
+		Defaults: config.RoutingDefaultsConfig{Strategy: config.RoutingStrategyPriorityFailover},
+		ModelPools: map[string]config.ModelPoolConfig{
+			"claude-sonnet-4-6": {
+				Candidates: []config.ModelPoolCandidateConfig{{Provider: "anthropic_b", Model: "claude-sonnet-4-6", Priority: 1}},
+			},
+		},
+	})
+	resolver := NewComposedResolver(alias, pool)
+
+	selector, changed, err := resolver.ResolveModel(core.NewRequestedModelSelector("friendly-sonnet", ""))
+	if err != nil {
+		t.Fatalf("ResolveModel() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true")
+	}
+	if got := selector.QualifiedModel(); got != "anthropic_b/claude-sonnet-4-6" {
+		t.Fatalf("selector = %q, want anthropic_b/claude-sonnet-4-6", got)
+	}
+}
+
+type disabledCanonicalStateChecker struct{}
+
+func (disabledCanonicalStateChecker) CanonicalModelEnabled(name string) bool {
+	return name != "claude-sonnet-4-6"
+}
+
+func (disabledCanonicalStateChecker) FilterCandidates(_ string, candidates []Candidate) []Candidate {
+	return candidates
+}
+
+type manualDisableStateChecker struct {
+	disabledProvider string
+	disabledModel    string
+}
+
+func (s *manualDisableStateChecker) CanonicalModelEnabled(string) bool {
+	return true
+}
+
+func (s *manualDisableStateChecker) FilterCandidates(_ string, candidates []Candidate) []Candidate {
+	filtered := make([]Candidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.Provider == s.disabledProvider && candidate.Model == s.disabledModel {
+			continue
+		}
+		filtered = append(filtered, candidate)
+	}
+	return filtered
+}
+
+func (s *manualDisableStateChecker) ProviderEnabled(string) bool {
+	return true
+}
+
+func (s *manualDisableStateChecker) CandidateEnabled(selector core.ModelSelector) bool {
+	return selector.Provider != s.disabledProvider || selector.Model != s.disabledModel
+}
+
+type aliasResolverStub struct{}
+
+func (aliasResolverStub) ResolveModel(requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
+	if requested.RequestedQualifiedModel() == "friendly-sonnet" {
+		return core.ModelSelector{Model: "claude-sonnet-4-6"}, true, nil
+	}
+	selector, err := requested.Normalize()
+	return selector, false, err
+}

--- a/internal/routing/runtime.go
+++ b/internal/routing/runtime.go
@@ -1,0 +1,51 @@
+package routing
+
+import (
+	"strings"
+
+	"gomodel/internal/providers"
+)
+
+func RuntimeInfoByProvider(source RuntimeSnapshotProvider) map[string]CandidateRuntimeInfo {
+	if source == nil {
+		return nil
+	}
+	infos := make(map[string]CandidateRuntimeInfo)
+	for _, snapshot := range source.ProviderRuntimeSnapshots() {
+		name := strings.TrimSpace(snapshot.Name)
+		if name == "" {
+			continue
+		}
+		lastError := strings.TrimSpace(snapshot.LastModelFetchError)
+		if lastError == "" {
+			lastError = strings.TrimSpace(snapshot.LastAvailabilityError)
+		}
+		infos[name] = CandidateRuntimeInfo{
+			Status:    ClassifyProviderRuntime(snapshot),
+			LastError: lastError,
+		}
+	}
+	return infos
+}
+
+func ClassifyProviderRuntime(snapshot providers.ProviderRuntimeSnapshot) string {
+	modelFetchError := strings.TrimSpace(snapshot.LastModelFetchError)
+	availabilityError := strings.TrimSpace(snapshot.LastAvailabilityError)
+	switch {
+	case snapshot.Registered && snapshot.DiscoveredModelCount > 0 && modelFetchError == "":
+		if snapshot.UsingCachedModels && snapshot.LastModelFetchSuccessAt == nil {
+			return "degraded"
+		}
+		return "healthy"
+	case modelFetchError != "" && snapshot.DiscoveredModelCount > 0:
+		return "degraded"
+	case modelFetchError != "":
+		return "unhealthy"
+	case availabilityError != "" && snapshot.DiscoveredModelCount == 0:
+		return "unhealthy"
+	case snapshot.DiscoveredModelCount > 0:
+		return "healthy"
+	default:
+		return "degraded"
+	}
+}

--- a/internal/routing/session_affinity.go
+++ b/internal/routing/session_affinity.go
@@ -1,0 +1,85 @@
+package routing
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"gomodel/internal/core"
+)
+
+type affinityStore struct {
+	mu      sync.Mutex
+	entries map[string]affinityEntry
+	now     func() time.Time
+	ttl     time.Duration
+	enabled bool
+}
+
+type affinityEntry struct {
+	selector  Candidate
+	expiresAt time.Time
+}
+
+func newAffinityStore(enabled bool, ttl time.Duration) *affinityStore {
+	if ttl <= 0 {
+		ttl = 30 * time.Minute
+	}
+	return &affinityStore{
+		entries: make(map[string]affinityEntry),
+		now:     time.Now,
+		ttl:     ttl,
+		enabled: enabled,
+	}
+}
+
+func affinityKey(ctx context.Context, canonicalModel string) string {
+	canonicalModel = strings.TrimSpace(canonicalModel)
+	if canonicalModel == "" {
+		return ""
+	}
+	userPath := strings.TrimSpace(core.UserPathFromContext(ctx))
+	if userPath != "" {
+		return canonicalModel + "|user_path|" + userPath
+	}
+	requestID := strings.TrimSpace(core.GetRequestID(ctx))
+	if requestID != "" {
+		return canonicalModel + "|request_id|" + requestID
+	}
+	return ""
+}
+
+func (s *affinityStore) Get(ctx context.Context, canonicalModel string) (Candidate, bool) {
+	if s == nil || !s.enabled {
+		return Candidate{}, false
+	}
+	key := affinityKey(ctx, canonicalModel)
+	if key == "" {
+		return Candidate{}, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, ok := s.entries[key]
+	if !ok {
+		return Candidate{}, false
+	}
+	if !entry.expiresAt.After(s.now()) {
+		delete(s.entries, key)
+		return Candidate{}, false
+	}
+	return entry.selector, true
+}
+
+func (s *affinityStore) Put(ctx context.Context, canonicalModel string, candidate Candidate) {
+	if s == nil || !s.enabled {
+		return
+	}
+	key := affinityKey(ctx, canonicalModel)
+	if key == "" {
+		return
+	}
+	s.mu.Lock()
+	s.entries[key] = affinityEntry{selector: candidate, expiresAt: s.now().Add(s.ttl)}
+	s.mu.Unlock()
+}

--- a/internal/routing/strategy.go
+++ b/internal/routing/strategy.go
@@ -1,0 +1,67 @@
+package routing
+
+import (
+	"fmt"
+	"sort"
+
+	"gomodel/config"
+)
+
+func selectCandidates(strategy config.RoutingStrategy, pool Pool, counters map[string]int) (Candidate, []Candidate, error) {
+	switch strategy {
+	case config.RoutingStrategyPriorityFailover:
+		ordered := append([]Candidate(nil), pool.Candidates...)
+		sort.SliceStable(ordered, func(i, j int) bool {
+			if ordered[i].Priority != ordered[j].Priority {
+				return ordered[i].Priority < ordered[j].Priority
+			}
+			return ordered[i].QualifiedModel() < ordered[j].QualifiedModel()
+		})
+		return ordered[0], ordered[1:], nil
+	case config.RoutingStrategyWeightedRoundRobin:
+		return selectWeightedRoundRobin(pool, counters)
+	default:
+		return Candidate{}, nil, fmt.Errorf("unsupported routing strategy: %s", strategy)
+	}
+}
+
+func selectWeightedRoundRobin(pool Pool, counters map[string]int) (Candidate, []Candidate, error) {
+	if len(pool.Candidates) == 0 {
+		return Candidate{}, nil, fmt.Errorf("pool %q has no candidates", pool.CanonicalModel)
+	}
+
+	ordered := append([]Candidate(nil), pool.Candidates...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		if ordered[i].Weight != ordered[j].Weight {
+			return ordered[i].Weight > ordered[j].Weight
+		}
+		if ordered[i].Priority != ordered[j].Priority {
+			return ordered[i].Priority < ordered[j].Priority
+		}
+		return ordered[i].QualifiedModel() < ordered[j].QualifiedModel()
+	})
+
+	bestIdx := 0
+	bestScore := 0
+	for i, candidate := range ordered {
+		key := pool.CanonicalModel + "|" + candidate.QualifiedModel()
+		score := candidate.Weight - counters[key]
+		if i == 0 || score > bestScore {
+			bestIdx = i
+			bestScore = score
+		}
+	}
+
+	primary := ordered[bestIdx]
+	primaryKey := pool.CanonicalModel + "|" + primary.QualifiedModel()
+	counters[primaryKey]++
+
+	fallbacks := make([]Candidate, 0, len(ordered)-1)
+	for i, candidate := range ordered {
+		if i == bestIdx {
+			continue
+		}
+		fallbacks = append(fallbacks, candidate)
+	}
+	return primary, fallbacks, nil
+}

--- a/internal/routing/types.go
+++ b/internal/routing/types.go
@@ -1,0 +1,41 @@
+package routing
+
+import (
+	"strings"
+
+	"gomodel/internal/core"
+	"gomodel/internal/providers"
+)
+
+type Registry interface {
+	GetModel(model string) any
+	GetProviderTypeForName(providerName string) string
+}
+
+type RuntimeSnapshotProvider interface {
+	ProviderRuntimeSnapshots() []providers.ProviderRuntimeSnapshot
+}
+
+type Candidate struct {
+	Provider string
+	Model    string
+	Priority int
+	Weight   int
+}
+
+func (c Candidate) Selector() core.ModelSelector {
+	return core.ModelSelector{Provider: c.Provider, Model: c.Model}
+}
+
+func (c Candidate) QualifiedModel() string {
+	return c.Selector().QualifiedModel()
+}
+
+type Pool struct {
+	CanonicalModel string
+	Candidates     []Candidate
+}
+
+func normalizePoolKey(model string) string {
+	return strings.TrimSpace(model)
+}

--- a/internal/routingstate/factory.go
+++ b/internal/routingstate/factory.go
@@ -1,0 +1,104 @@
+package routingstate
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+
+	"gomodel/config"
+	"gomodel/internal/storage"
+)
+
+type Result struct {
+	Service *Service
+	Store   Store
+	Storage storage.Storage
+
+	stopRefresh func()
+	closeOnce   sync.Once
+	closeErr    error
+}
+
+func (r *Result) Close() error {
+	if r == nil {
+		return nil
+	}
+	r.closeOnce.Do(func() {
+		if r.stopRefresh != nil {
+			r.stopRefresh()
+			r.stopRefresh = nil
+		}
+		var errs []error
+		if r.Store != nil {
+			if err := r.Store.Close(); err != nil {
+				errs = append(errs, fmt.Errorf("store close: %w", err))
+			}
+		}
+		if r.Storage != nil {
+			if err := r.Storage.Close(); err != nil {
+				errs = append(errs, fmt.Errorf("storage close: %w", err))
+			}
+		}
+		if len(errs) > 0 {
+			r.closeErr = fmt.Errorf("close errors: %w", errors.Join(errs...))
+		}
+	})
+	return r.closeErr
+}
+
+func New(ctx context.Context, cfg *config.Config) (*Result, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config is required")
+	}
+	storeConn, err := storage.New(ctx, cfg.Storage.BackendConfig())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create storage: %w", err)
+	}
+	result, err := newResult(ctx, cfg, storeConn)
+	if err != nil {
+		_ = storeConn.Close()
+		return nil, err
+	}
+	result.Storage = storeConn
+	return result, nil
+}
+
+func NewWithSharedStorage(ctx context.Context, cfg *config.Config, shared storage.Storage) (*Result, error) {
+	if shared == nil {
+		return nil, fmt.Errorf("shared storage is required")
+	}
+	if cfg == nil {
+		return nil, fmt.Errorf("config is required")
+	}
+	return newResult(ctx, cfg, shared)
+}
+
+func newResult(ctx context.Context, cfg *config.Config, storeConn storage.Storage) (*Result, error) {
+	store, err := storage.ResolveBackend[Store](
+		storeConn,
+		func(db *sql.DB) (Store, error) { return NewSQLiteStore(db) },
+		func(pool *pgxpool.Pool) (Store, error) { return NewPostgreSQLStore(ctx, pool) },
+		func(db *mongo.Database) (Store, error) { return NewMongoDBStore(db) },
+	)
+	if err != nil {
+		return nil, err
+	}
+	service, err := NewService(store)
+	if err != nil {
+		return nil, err
+	}
+	if err := service.Refresh(ctx); err != nil {
+		return nil, err
+	}
+	refreshInterval := time.Minute
+	if cfg.Workflows.RefreshInterval > 0 {
+		refreshInterval = cfg.Workflows.RefreshInterval
+	}
+	return &Result{Service: service, Store: store, stopRefresh: service.StartBackgroundRefresh(refreshInterval)}, nil
+}

--- a/internal/routingstate/service.go
+++ b/internal/routingstate/service.go
@@ -1,0 +1,191 @@
+package routingstate
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"gomodel/internal/core"
+	"gomodel/internal/routing"
+)
+
+type snapshot struct {
+	order           []string
+	byKey           map[string]Entry
+	providers       map[string]Entry
+	canonicalModels map[string]Entry
+	candidates      map[string]Entry
+}
+
+type Service struct {
+	store     Store
+	mu        sync.RWMutex
+	snapshot  snapshot
+}
+
+func NewService(store Store) (*Service, error) {
+	if store == nil {
+		return nil, fmt.Errorf("store is required")
+	}
+	return &Service{store: store, snapshot: snapshot{
+		order:           []string{},
+		byKey:           map[string]Entry{},
+		providers:       map[string]Entry{},
+		canonicalModels: map[string]Entry{},
+		candidates:      map[string]Entry{},
+	}}, nil
+}
+
+func (s *Service) Refresh(ctx context.Context) error {
+	entries, err := s.store.List(ctx)
+	if err != nil {
+		return fmt.Errorf("list routing state: %w", err)
+	}
+	next := snapshot{
+		order:           make([]string, 0, len(entries)),
+		byKey:           make(map[string]Entry, len(entries)),
+		providers:       make(map[string]Entry),
+		canonicalModels: make(map[string]Entry),
+		candidates:      make(map[string]Entry),
+	}
+	for _, entry := range entries {
+		normalized, err := normalizeEntry(entry)
+		if err != nil {
+			return fmt.Errorf("load routing state %q: %w", entry.Key, err)
+		}
+		next.order = append(next.order, normalized.Key)
+		next.byKey[normalized.Key] = normalized
+		switch normalized.Kind {
+		case KindProvider:
+			next.providers[normalized.ProviderName] = normalized
+		case KindCanonicalModel:
+			next.canonicalModels[normalized.CanonicalModel] = normalized
+		case KindPoolCandidate:
+			next.candidates[normalized.ProviderName+"/"+normalized.Model] = normalized
+		}
+	}
+	sort.Strings(next.order)
+
+	s.mu.Lock()
+	s.snapshot = next
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *Service) List() []Entry {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	result := make([]Entry, 0, len(s.snapshot.order))
+	for _, key := range s.snapshot.order {
+		result = append(result, s.snapshot.byKey[key])
+	}
+	return result
+}
+
+func (s *Service) Upsert(ctx context.Context, entry Entry) error {
+	normalized, err := normalizeEntry(entry)
+	if err != nil {
+		return err
+	}
+	if err := s.store.Upsert(ctx, normalized); err != nil {
+		return err
+	}
+	return s.Refresh(ctx)
+}
+
+func (s *Service) Delete(ctx context.Context, key string) error {
+	if err := s.store.Delete(ctx, strings.TrimSpace(key)); err != nil {
+		return err
+	}
+	return s.Refresh(ctx)
+}
+
+func (s *Service) Close() error {
+	if s == nil || s.store == nil {
+		return nil
+	}
+	return s.store.Close()
+}
+
+func (s *Service) StartBackgroundRefresh(interval time.Duration) func() {
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	stop := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				_ = s.Refresh(context.Background())
+			case <-stop:
+				return
+			}
+		}
+	}()
+	return func() { close(stop) }
+}
+
+func (s *Service) ProviderEnabled(name string) bool {
+	if s == nil {
+		return true
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	entry, ok := s.snapshot.providers[strings.TrimSpace(name)]
+	if !ok {
+		return true
+	}
+	return entry.Enabled
+}
+
+func (s *Service) CanonicalModelEnabled(name string) bool {
+	if s == nil {
+		return true
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	entry, ok := s.snapshot.canonicalModels[strings.TrimSpace(name)]
+	if !ok {
+		return true
+	}
+	return entry.Enabled
+}
+
+func (s *Service) CandidateEnabled(selector core.ModelSelector) bool {
+	if s == nil {
+		return true
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	entry, ok := s.snapshot.candidates[strings.TrimSpace(selector.Provider)+"/"+strings.TrimSpace(selector.Model)]
+	if !ok {
+		return true
+	}
+	return entry.Enabled
+}
+
+func (s *Service) FilterCandidates(canonical string, candidates []routing.Candidate) []routing.Candidate {
+	if s == nil {
+		return append([]routing.Candidate(nil), candidates...)
+	}
+	if !s.CanonicalModelEnabled(canonical) {
+		return nil
+	}
+	filtered := make([]routing.Candidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		selector := core.ModelSelector{Provider: candidate.Provider, Model: candidate.Model}
+		if !s.ProviderEnabled(candidate.Provider) {
+			continue
+		}
+		if !s.CandidateEnabled(selector) {
+			continue
+		}
+		filtered = append(filtered, candidate)
+	}
+	return filtered
+}

--- a/internal/routingstate/service_test.go
+++ b/internal/routingstate/service_test.go
@@ -1,0 +1,47 @@
+package routingstate
+
+import (
+	"context"
+	"testing"
+
+	"gomodel/internal/core"
+	"gomodel/internal/routing"
+)
+
+type memoryStore struct{ entries map[string]Entry }
+
+func (m *memoryStore) List(context.Context) ([]Entry, error) {
+	result := make([]Entry, 0, len(m.entries))
+	for _, entry := range m.entries {
+		result = append(result, entry)
+	}
+	return result, nil
+}
+func (m *memoryStore) Upsert(_ context.Context, entry Entry) error { if m.entries == nil { m.entries = map[string]Entry{} }; m.entries[entry.Key] = entry; return nil }
+func (m *memoryStore) Delete(_ context.Context, key string) error { delete(m.entries, key); return nil }
+func (m *memoryStore) Close() error { return nil }
+
+func TestServiceFilterCandidatesHonorsManualDisable(t *testing.T) {
+	store := &memoryStore{}
+	service, err := NewService(store)
+	if err != nil { t.Fatalf("NewService() error = %v", err) }
+	if err := service.Upsert(context.Background(), Entry{Kind: KindProvider, ProviderName: "anthropic_a", Enabled: false}); err != nil {
+		t.Fatalf("Upsert provider state error = %v", err)
+	}
+	if err := service.Upsert(context.Background(), Entry{Kind: KindPoolCandidate, ProviderName: "anthropic_b", Model: "claude-sonnet-4-6", Enabled: false}); err != nil {
+		t.Fatalf("Upsert candidate state error = %v", err)
+	}
+	candidates := []routing.Candidate{{Provider: "anthropic_a", Model: "claude-sonnet-4-6"}, {Provider: "anthropic_b", Model: "claude-sonnet-4-6"}, {Provider: "anthropic_c", Model: "claude-sonnet-4-6"}}
+	filtered := service.FilterCandidates("claude-sonnet-4-6", candidates)
+	if len(filtered) != 1 || filtered[0].Provider != "anthropic_c" {
+		t.Fatalf("filtered = %+v, want only anthropic_c", filtered)
+	}
+}
+
+func TestServiceCandidateEnabledDefaultsTrue(t *testing.T) {
+	service, err := NewService(&memoryStore{})
+	if err != nil { t.Fatalf("NewService() error = %v", err) }
+	if !service.CandidateEnabled(core.ModelSelector{Provider: "anthropic_b", Model: "claude-opus-4-7"}) {
+		t.Fatal("expected unspecified candidate to default to enabled")
+	}
+}

--- a/internal/routingstate/store.go
+++ b/internal/routingstate/store.go
@@ -1,0 +1,57 @@
+package routingstate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+var ErrNotFound = errors.New("routing state not found")
+
+type ValidationError struct {
+	message string
+	cause   error
+}
+
+func (e *ValidationError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.message
+}
+
+func (e *ValidationError) Unwrap() error { return e.cause }
+
+func newValidationError(message string, err error) error {
+	return &ValidationError{message: message, cause: err}
+}
+
+func IsValidationError(err error) bool {
+	var target *ValidationError
+	return errors.As(err, &target)
+}
+
+type Store interface {
+	List(ctx context.Context) ([]Entry, error)
+	Upsert(ctx context.Context, entry Entry) error
+	Delete(ctx context.Context, key string) error
+	Close() error
+}
+
+func collectEntries(next func() (Entry, bool, error), rowsErr func() error) ([]Entry, error) {
+	result := make([]Entry, 0)
+	for {
+		entry, ok, err := next()
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			break
+		}
+		result = append(result, entry)
+	}
+	if err := rowsErr(); err != nil {
+		return nil, fmt.Errorf("iterate routing state: %w", err)
+	}
+	return result, nil
+}

--- a/internal/routingstate/store_mongodb.go
+++ b/internal/routingstate/store_mongodb.go
@@ -1,0 +1,123 @@
+package routingstate
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+type mongoEntryDocument struct {
+	ID             string    `bson:"_id"`
+	Kind           string    `bson:"kind"`
+	ProviderName   string    `bson:"provider_name,omitempty"`
+	CanonicalModel string    `bson:"canonical_model,omitempty"`
+	Model          string    `bson:"model,omitempty"`
+	Enabled        bool      `bson:"enabled"`
+	Reason         string    `bson:"reason,omitempty"`
+	CreatedAt      time.Time `bson:"created_at"`
+	UpdatedAt      time.Time `bson:"updated_at"`
+}
+
+type mongoEntryIDFilter struct {
+	ID string `bson:"_id"`
+}
+
+type MongoDBStore struct {
+	collection *mongo.Collection
+}
+
+func NewMongoDBStore(database *mongo.Database) (*MongoDBStore, error) {
+	if database == nil {
+		return nil, fmt.Errorf("database is required")
+	}
+	coll := database.Collection("routing_state")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	indexes := []mongo.IndexModel{
+		{Keys: bson.D{{Key: "kind", Value: 1}}},
+		{Keys: bson.D{{Key: "provider_name", Value: 1}}},
+		{Keys: bson.D{{Key: "canonical_model", Value: 1}}},
+	}
+	if _, err := coll.Indexes().CreateMany(ctx, indexes); err != nil {
+		return nil, fmt.Errorf("create routing_state indexes: %w", err)
+	}
+	return &MongoDBStore{collection: coll}, nil
+}
+
+func (s *MongoDBStore) List(ctx context.Context) ([]Entry, error) {
+	cursor, err := s.collection.Find(ctx, bson.M{}, options.Find().SetSort(bson.D{{Key: "_id", Value: 1}}))
+	if err != nil {
+		return nil, fmt.Errorf("list routing state: %w", err)
+	}
+	defer cursor.Close(ctx)
+	result := make([]Entry, 0)
+	for cursor.Next(ctx) {
+		var doc mongoEntryDocument
+		if err := cursor.Decode(&doc); err != nil {
+			return nil, fmt.Errorf("decode routing state: %w", err)
+		}
+		result = append(result, entryFromMongo(doc))
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, fmt.Errorf("iterate routing state: %w", err)
+	}
+	return result, nil
+}
+
+func (s *MongoDBStore) Upsert(ctx context.Context, entry Entry) error {
+	entry, err := normalizeEntry(entry)
+	if err != nil {
+		return err
+	}
+	update := bson.M{
+		"$set": bson.M{
+			"kind":            string(entry.Kind),
+			"provider_name":   entry.ProviderName,
+			"canonical_model": entry.CanonicalModel,
+			"model":           entry.Model,
+			"enabled":         entry.Enabled,
+			"reason":          entry.Reason,
+			"updated_at":      entry.UpdatedAt,
+		},
+		"$setOnInsert": bson.M{
+			"created_at": entry.CreatedAt,
+		},
+	}
+	_, err = s.collection.UpdateOne(ctx, mongoEntryIDFilter{ID: entry.Key}, update, options.UpdateOne().SetUpsert(true))
+	if err != nil {
+		return fmt.Errorf("upsert routing state: %w", err)
+	}
+	return nil
+}
+
+func (s *MongoDBStore) Delete(ctx context.Context, key string) error {
+	result, err := s.collection.DeleteOne(ctx, mongoEntryIDFilter{ID: strings.TrimSpace(key)})
+	if err != nil {
+		return fmt.Errorf("delete routing state: %w", err)
+	}
+	if result.DeletedCount == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *MongoDBStore) Close() error { return nil }
+
+func entryFromMongo(doc mongoEntryDocument) Entry {
+	return Entry{
+		Key:            doc.ID,
+		Kind:           Kind(doc.Kind),
+		ProviderName:   doc.ProviderName,
+		CanonicalModel: doc.CanonicalModel,
+		Model:          doc.Model,
+		Enabled:        doc.Enabled,
+		Reason:         doc.Reason,
+		CreatedAt:      doc.CreatedAt.UTC(),
+		UpdatedAt:      doc.UpdatedAt.UTC(),
+	}
+}

--- a/internal/routingstate/store_postgresql.go
+++ b/internal/routingstate/store_postgresql.go
@@ -1,0 +1,121 @@
+package routingstate
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type PostgreSQLStore struct {
+	pool *pgxpool.Pool
+}
+
+func NewPostgreSQLStore(ctx context.Context, pool *pgxpool.Pool) (*PostgreSQLStore, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("context is required")
+	}
+	if pool == nil {
+		return nil, fmt.Errorf("connection pool is required")
+	}
+
+	_, err := pool.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS routing_state (
+			key TEXT PRIMARY KEY,
+			kind TEXT NOT NULL,
+			provider_name TEXT NOT NULL DEFAULT '',
+			canonical_model TEXT NOT NULL DEFAULT '',
+			model TEXT NOT NULL DEFAULT '',
+			enabled BOOLEAN NOT NULL,
+			reason TEXT NOT NULL DEFAULT '',
+			created_at BIGINT NOT NULL,
+			updated_at BIGINT NOT NULL
+		)
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create routing_state table: %w", err)
+	}
+	if _, err := pool.Exec(ctx, `CREATE INDEX IF NOT EXISTS idx_routing_state_kind ON routing_state(kind)`); err != nil {
+		return nil, fmt.Errorf("failed to create routing_state kind index: %w", err)
+	}
+	if _, err := pool.Exec(ctx, `CREATE INDEX IF NOT EXISTS idx_routing_state_provider_name ON routing_state(provider_name)`); err != nil {
+		return nil, fmt.Errorf("failed to create routing_state provider_name index: %w", err)
+	}
+	if _, err := pool.Exec(ctx, `CREATE INDEX IF NOT EXISTS idx_routing_state_canonical_model ON routing_state(canonical_model)`); err != nil {
+		return nil, fmt.Errorf("failed to create routing_state canonical_model index: %w", err)
+	}
+	return &PostgreSQLStore{pool: pool}, nil
+}
+
+func (s *PostgreSQLStore) List(ctx context.Context) ([]Entry, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT key, kind, provider_name, canonical_model, model, enabled, reason, created_at, updated_at
+		FROM routing_state
+		ORDER BY key ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list routing state: %w", err)
+	}
+	defer rows.Close()
+	return collectEntries(func() (Entry, bool, error) {
+		if !rows.Next() {
+			return Entry{}, false, nil
+		}
+		entry, err := scanPostgreSQLEntry(rows)
+		return entry, true, err
+	}, rows.Err)
+}
+
+func (s *PostgreSQLStore) Upsert(ctx context.Context, entry Entry) error {
+	entry, err := normalizeEntry(entry)
+	if err != nil {
+		return err
+	}
+	_, err = s.pool.Exec(ctx, `
+		INSERT INTO routing_state (key, kind, provider_name, canonical_model, model, enabled, reason, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		ON CONFLICT(key) DO UPDATE SET
+			kind = excluded.kind,
+			provider_name = excluded.provider_name,
+			canonical_model = excluded.canonical_model,
+			model = excluded.model,
+			enabled = excluded.enabled,
+			reason = excluded.reason,
+			updated_at = excluded.updated_at
+	`, entry.Key, string(entry.Kind), entry.ProviderName, entry.CanonicalModel, entry.Model, entry.Enabled, entry.Reason, entry.CreatedAt.Unix(), entry.UpdatedAt.Unix())
+	if err != nil {
+		return fmt.Errorf("upsert routing state: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgreSQLStore) Delete(ctx context.Context, key string) error {
+	cmd, err := s.pool.Exec(ctx, `DELETE FROM routing_state WHERE key = $1`, strings.TrimSpace(key))
+	if err != nil {
+		return fmt.Errorf("delete routing state: %w", err)
+	}
+	if cmd.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *PostgreSQLStore) Close() error { return nil }
+
+func scanPostgreSQLEntry(scanner interface{ Scan(dest ...any) error }) (Entry, error) {
+	var entry Entry
+	var createdAt int64
+	var updatedAt int64
+	if err := scanner.Scan(&entry.Key, &entry.Kind, &entry.ProviderName, &entry.CanonicalModel, &entry.Model, &entry.Enabled, &entry.Reason, &createdAt, &updatedAt); err != nil {
+		if err == pgx.ErrNoRows {
+			return Entry{}, ErrNotFound
+		}
+		return Entry{}, fmt.Errorf("scan routing state: %w", err)
+	}
+	entry.CreatedAt = time.Unix(createdAt, 0).UTC()
+	entry.UpdatedAt = time.Unix(updatedAt, 0).UTC()
+	return entry, nil
+}

--- a/internal/routingstate/store_sqlite.go
+++ b/internal/routingstate/store_sqlite.go
@@ -1,0 +1,146 @@
+package routingstate
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type SQLiteStore struct {
+	db *sql.DB
+}
+
+func NewSQLiteStore(db *sql.DB) (*SQLiteStore, error) {
+	if db == nil {
+		return nil, fmt.Errorf("database connection is required")
+	}
+
+	_, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS routing_state (
+			key TEXT PRIMARY KEY,
+			kind TEXT NOT NULL,
+			provider_name TEXT NOT NULL DEFAULT '',
+			canonical_model TEXT NOT NULL DEFAULT '',
+			model TEXT NOT NULL DEFAULT '',
+			enabled INTEGER NOT NULL,
+			reason TEXT NOT NULL DEFAULT '',
+			created_at INTEGER NOT NULL,
+			updated_at INTEGER NOT NULL
+		)
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create routing_state table: %w", err)
+	}
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_routing_state_kind ON routing_state(kind)`); err != nil {
+		return nil, fmt.Errorf("failed to create routing_state kind index: %w", err)
+	}
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_routing_state_provider_name ON routing_state(provider_name)`); err != nil {
+		return nil, fmt.Errorf("failed to create routing_state provider_name index: %w", err)
+	}
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_routing_state_canonical_model ON routing_state(canonical_model)`); err != nil {
+		return nil, fmt.Errorf("failed to create routing_state canonical_model index: %w", err)
+	}
+	return &SQLiteStore{db: db}, nil
+}
+
+func (s *SQLiteStore) List(ctx context.Context) ([]Entry, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT key, kind, provider_name, canonical_model, model, enabled, reason, created_at, updated_at
+		FROM routing_state
+		ORDER BY key ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list routing state: %w", err)
+	}
+	defer rows.Close()
+	return collectEntries(func() (Entry, bool, error) {
+		if !rows.Next() {
+			return Entry{}, false, nil
+		}
+		entry, err := scanSQLiteEntry(rows)
+		return entry, true, err
+	}, rows.Err)
+}
+
+func (s *SQLiteStore) Upsert(ctx context.Context, entry Entry) error {
+	entry, err := normalizeEntry(entry)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO routing_state (key, kind, provider_name, canonical_model, model, enabled, reason, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(key) DO UPDATE SET
+			kind = excluded.kind,
+			provider_name = excluded.provider_name,
+			canonical_model = excluded.canonical_model,
+			model = excluded.model,
+			enabled = excluded.enabled,
+			reason = excluded.reason,
+			updated_at = excluded.updated_at
+	`,
+		entry.Key,
+		string(entry.Kind),
+		entry.ProviderName,
+		entry.CanonicalModel,
+		entry.Model,
+		boolToInt(entry.Enabled),
+		entry.Reason,
+		entry.CreatedAt.Unix(),
+		entry.UpdatedAt.Unix(),
+	)
+	if err != nil {
+		return fmt.Errorf("upsert routing state: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) Delete(ctx context.Context, key string) error {
+	result, err := s.db.ExecContext(ctx, `DELETE FROM routing_state WHERE key = ?`, strings.TrimSpace(key))
+	if err != nil {
+		return fmt.Errorf("delete routing state: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read delete rows affected: %w", err)
+	}
+	if affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *SQLiteStore) Close() error { return nil }
+
+func scanSQLiteEntry(scanner interface{ Scan(dest ...any) error }) (Entry, error) {
+	var entry Entry
+	var enabled int
+	var createdAt int64
+	var updatedAt int64
+	if err := scanner.Scan(
+		&entry.Key,
+		&entry.Kind,
+		&entry.ProviderName,
+		&entry.CanonicalModel,
+		&entry.Model,
+		&enabled,
+		&entry.Reason,
+		&createdAt,
+		&updatedAt,
+	); err != nil {
+		return Entry{}, fmt.Errorf("scan routing state: %w", err)
+	}
+	entry.Enabled = enabled != 0
+	entry.CreatedAt = time.Unix(createdAt, 0).UTC()
+	entry.UpdatedAt = time.Unix(updatedAt, 0).UTC()
+	return entry, nil
+}
+
+func boolToInt(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}

--- a/internal/routingstate/types.go
+++ b/internal/routingstate/types.go
@@ -1,0 +1,75 @@
+package routingstate
+
+import (
+	"strings"
+	"time"
+)
+
+type Kind string
+
+const (
+	KindProvider       Kind = "provider"
+	KindCanonicalModel Kind = "canonical_model"
+	KindPoolCandidate  Kind = "pool_candidate"
+)
+
+type Entry struct {
+	Key            string    `json:"key" bson:"key"`
+	Kind           Kind      `json:"kind" bson:"kind"`
+	ProviderName   string    `json:"provider_name,omitempty" bson:"provider_name,omitempty"`
+	CanonicalModel string    `json:"canonical_model,omitempty" bson:"canonical_model,omitempty"`
+	Model          string    `json:"model,omitempty" bson:"model,omitempty"`
+	Enabled        bool      `json:"enabled" bson:"enabled"`
+	Reason         string    `json:"reason,omitempty" bson:"reason,omitempty"`
+	CreatedAt      time.Time `json:"created_at" bson:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at" bson:"updated_at"`
+}
+
+type View = Entry
+
+func normalizeKind(kind Kind) Kind {
+	return Kind(strings.ToLower(strings.TrimSpace(string(kind))))
+}
+
+func normalizeEntry(entry Entry) (Entry, error) {
+	entry.Kind = normalizeKind(entry.Kind)
+	entry.Key = strings.TrimSpace(entry.Key)
+	entry.ProviderName = strings.TrimSpace(entry.ProviderName)
+	entry.CanonicalModel = strings.TrimSpace(entry.CanonicalModel)
+	entry.Model = strings.TrimSpace(entry.Model)
+	entry.Reason = strings.TrimSpace(entry.Reason)
+
+	switch entry.Kind {
+	case KindProvider:
+		if entry.ProviderName == "" {
+			entry.ProviderName = entry.Key
+		}
+		if entry.ProviderName == "" {
+			return Entry{}, newValidationError("provider_name is required", nil)
+		}
+		entry.Key = entry.ProviderName
+	case KindCanonicalModel:
+		if entry.CanonicalModel == "" {
+			entry.CanonicalModel = entry.Key
+		}
+		if entry.CanonicalModel == "" {
+			return Entry{}, newValidationError("canonical_model is required", nil)
+		}
+		entry.Key = entry.CanonicalModel
+	case KindPoolCandidate:
+		if entry.ProviderName == "" || entry.Model == "" {
+			return Entry{}, newValidationError("provider_name and model are required for pool_candidate", nil)
+		}
+		if entry.Key == "" {
+			entry.Key = entry.ProviderName + "/" + entry.Model
+		}
+	default:
+		return Entry{}, newValidationError("kind must be one of: provider, canonical_model, pool_candidate", nil)
+	}
+
+	if entry.CreatedAt.IsZero() {
+		entry.CreatedAt = time.Now().UTC()
+	}
+	entry.UpdatedAt = time.Now().UTC()
+	return entry, nil
+}

--- a/internal/server/fallback_test.go
+++ b/internal/server/fallback_test.go
@@ -170,6 +170,16 @@ func TestChatCompletion_FallsBackToAlternateModel(t *testing.T) {
 	if got := entry.Data.Failover.TargetModel; got != "azure/gpt-4o" {
 		t.Fatalf("failover target = %q, want %q", got, "azure/gpt-4o")
 	}
+	workflow := core.GetWorkflow(c.Request().Context())
+	if workflow == nil || workflow.Resolution == nil {
+		t.Fatal("expected workflow resolution to be available")
+	}
+	if !workflow.Resolution.FailoverUsed {
+		t.Fatal("expected resolution to record failover usage")
+	}
+	if got := workflow.Resolution.FallbackTarget; got != "azure/gpt-4o" {
+		t.Fatalf("resolution fallback target = %q, want %q", got, "azure/gpt-4o")
+	}
 }
 
 func TestChatCompletion_DoesNotFallbackOnNonAvailabilityError(t *testing.T) {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -14,6 +14,7 @@ import (
 	"gomodel/internal/filestore"
 	"gomodel/internal/responsecache"
 	"gomodel/internal/responsestore"
+	"gomodel/internal/routing"
 	"gomodel/internal/usage"
 )
 
@@ -41,6 +42,7 @@ type Handler struct {
 	enabledPassthroughProviders     map[string]struct{}
 	responseCache                   *responsecache.ResponseCacheMiddleware
 	guardrailsHash                  string
+	failoverPolicy                  routing.FailoverPolicy
 
 	translatedSvc     *translatedInferenceService // snapshot of handler fields at first use; server.New sets cache/hash before traffic
 	translatedSvcOnce sync.Once
@@ -167,6 +169,7 @@ func (h *Handler) translatedInference() *translatedInferenceService {
 			pricingResolver:          h.pricingResolver,
 			responseCache:            h.responseCache,
 			guardrailsHash:           h.guardrailsHash,
+			failoverPolicy:           h.failoverPolicy,
 			responseStore:            h.currentResponseStore(),
 		}
 		s.initHandlers()

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -26,6 +26,7 @@ import (
 	"gomodel/internal/filestore"
 	"gomodel/internal/responsecache"
 	"gomodel/internal/responsestore"
+	"gomodel/internal/routing"
 	"gomodel/internal/usage"
 )
 
@@ -82,6 +83,7 @@ type Config struct {
 	SwaggerEnabled                  bool                                   // Whether to expose the Swagger UI at /swagger/index.html
 	ResponseCacheMiddleware         *responsecache.ResponseCacheMiddleware // Optional: response cache middleware for cacheable endpoints
 	GuardrailsHash                  string                                 // Optional: SHA-256 hash of active guardrail rules; stored in context post-patch for semantic cache
+	FailoverPolicy                  routing.FailoverPolicy                 // Optional: operational failover policy for canonical model pools
 	IPExtractor                     echo.IPExtractor                       // Optional: trusted client IP extraction strategy for proxied deployments
 }
 
@@ -134,6 +136,7 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 		handler.keepOnlyAliasesAtModelsEndpoint = cfg.KeepOnlyAliasesAtModelsEndpoint
 		handler.responseCache = cfg.ResponseCacheMiddleware
 		handler.guardrailsHash = cfg.GuardrailsHash
+		handler.failoverPolicy = cfg.FailoverPolicy
 	}
 	if cfg != nil && cfg.EnabledPassthroughProviders != nil {
 		handler.setEnabledPassthroughProviders(cfg.EnabledPassthroughProviders)

--- a/internal/server/internal_chat_completion_executor.go
+++ b/internal/server/internal_chat_completion_executor.go
@@ -16,6 +16,7 @@ import (
 	"gomodel/internal/core"
 	"gomodel/internal/gateway"
 	"gomodel/internal/responsecache"
+	"gomodel/internal/routing"
 	"gomodel/internal/usage"
 )
 
@@ -26,6 +27,7 @@ type InternalChatCompletionExecutorConfig struct {
 	ModelAuthorizer        RequestModelAuthorizer
 	WorkflowPolicyResolver RequestWorkflowPolicyResolver
 	FallbackResolver       RequestFallbackResolver
+	FailoverPolicy         routing.FailoverPolicy
 	AuditLogger            auditlog.LoggerInterface
 	UsageLogger            usage.LoggerInterface
 	PricingResolver        usage.PricingResolver
@@ -60,6 +62,7 @@ func NewInternalChatCompletionExecutor(provider core.RoutableProvider, cfg Inter
 			ModelAuthorizer:          cfg.ModelAuthorizer,
 			WorkflowPolicyResolver:   cfg.WorkflowPolicyResolver,
 			FallbackResolver:         cfg.FallbackResolver,
+			FailoverPolicy:           cfg.FailoverPolicy,
 			UsageLogger:              cfg.UsageLogger,
 			PricingResolver:          cfg.PricingResolver,
 			TranslatedRequestPatcher: nil,

--- a/internal/server/request_model_resolution_test.go
+++ b/internal/server/request_model_resolution_test.go
@@ -10,8 +10,10 @@ import (
 
 	"github.com/labstack/echo/v5"
 
+	"gomodel/config"
 	"gomodel/internal/auditlog"
 	"gomodel/internal/core"
+	"gomodel/internal/routing"
 )
 
 type canonicalizingProvider struct {
@@ -141,6 +143,46 @@ func (aliasResolverStub) ResolveModel(requested core.RequestedModelSelector) (co
 	}
 	selector, err := requested.Normalize()
 	return selector, false, err
+}
+
+func TestResolveRequestModel_CanonicalPoolResolutionCarriesFallbackMetadata(t *testing.T) {
+	provider := &canonicalizingProvider{
+		resolved: map[string]core.ModelSelector{
+			"anthropic_b/claude-sonnet-4-6": {Provider: "anthropic_b", Model: "claude-sonnet-4-6"},
+		},
+		types: map[string]string{
+			"anthropic_b/claude-sonnet-4-6": "anthropic",
+		},
+		names: map[string]string{
+			"anthropic_b/claude-sonnet-4-6": "anthropic_b",
+		},
+	}
+
+	resolver := routing.NewComposedResolver(nil, routing.NewResolver(config.RoutingConfig{
+		Defaults: config.RoutingDefaultsConfig{Strategy: config.RoutingStrategyPriorityFailover},
+		ModelPools: map[string]config.ModelPoolConfig{
+			"claude-sonnet-4-6": {
+				Candidates: []config.ModelPoolCandidateConfig{
+					{Provider: "anthropic_b", Model: "claude-sonnet-4-6", Priority: 1},
+					{Provider: "anthropic_a", Model: "claude-sonnet-4-6-20250929", Priority: 2},
+				},
+			},
+		},
+	}))
+
+	resolution, err := resolveRequestModel(provider, resolver, core.NewRequestedModelSelector("claude-sonnet-4-6", ""))
+	if err != nil {
+		t.Fatalf("resolveRequestModel() error = %v", err)
+	}
+	if got := resolution.CanonicalModel; got != "claude-sonnet-4-6" {
+		t.Fatalf("CanonicalModel = %q, want claude-sonnet-4-6", got)
+	}
+	if got := resolution.RoutingStrategy; got != string(config.RoutingStrategyPriorityFailover) {
+		t.Fatalf("RoutingStrategy = %q, want %q", got, config.RoutingStrategyPriorityFailover)
+	}
+	if len(resolution.CanonicalPoolFallbacks) != 1 || resolution.CanonicalPoolFallbacks[0].QualifiedModel() != "anthropic_a/claude-sonnet-4-6-20250929" {
+		t.Fatalf("CanonicalPoolFallbacks = %v, want [anthropic_a/claude-sonnet-4-6-20250929]", resolution.CanonicalPoolFallbacks)
+	}
 }
 
 func TestResolveRequestModel_CanonicalizesAliasOutputThroughProviderResolver(t *testing.T) {

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -18,6 +18,7 @@ import (
 	"gomodel/internal/gateway"
 	"gomodel/internal/observability"
 	"gomodel/internal/responsecache"
+	"gomodel/internal/routing"
 	"gomodel/internal/responsestore"
 	"gomodel/internal/streaming"
 	"gomodel/internal/usage"
@@ -38,6 +39,7 @@ type translatedInferenceService struct {
 	pricingResolver          usage.PricingResolver
 	responseCache            *responsecache.ResponseCacheMiddleware
 	guardrailsHash           string
+	failoverPolicy           routing.FailoverPolicy
 	responseStore            responsestore.Store
 	responseStoreMu          sync.RWMutex
 
@@ -64,6 +66,7 @@ func (s *translatedInferenceService) newInferenceOrchestrator() *gateway.Inferen
 		ModelAuthorizer:          s.modelAuthorizer,
 		WorkflowPolicyResolver:   s.workflowPolicyResolver,
 		FallbackResolver:         s.fallbackResolver,
+		FailoverPolicy:           s.failoverPolicy,
 		TranslatedRequestPatcher: s.translatedRequestPatcher,
 		UsageLogger:              s.usageLogger,
 		PricingResolver:          s.pricingResolver,


### PR DESCRIPTION
## Summary
- add canonical model pool routing so one public model name can resolve to multiple exact provider/model candidates
- add pool-aware failover, session affinity, runtime-aware candidate eligibility, and persisted routing state
- add admin/dashboard controls and visibility for provider, canonical model, and candidate state
- align `/v1/models`, request resolution, and failover metadata with the same effective routing decision
- document the feature and new user-facing configuration in `docs/features/canonical-routing.mdx`

## What changed

### 1. Canonical routing configuration
This PR introduces a new `routing` config block with:
- `routing.defaults.strategy`
- `routing.defaults.session_affinity`
- `routing.defaults.session_affinity_ttl`
- `routing.defaults.failover.enabled`
- `routing.defaults.failover.max_attempts`
- `routing.defaults.failover.retry_on_statuses`
- `routing.defaults.failover.retry_on_model_errors`
- `routing.model_pools`

It also adds validation and defaults in `config/routing.go` and expands `config/config.example.yaml` so operators have a concrete example to follow.

### 2. Canonical model pool resolver
This PR adds a dedicated routing layer in `internal/routing/` that:
- resolves canonical model names to exact provider/model candidates
- supports `priority_failover` and `weighted_round_robin`
- applies session affinity before strategy selection
- repins automatically when the pinned candidate becomes ineligible
- filters candidates using both manual routing state and runtime health

Key files:
- `internal/routing/resolver.go`
- `internal/routing/pool_evaluator.go`
- `internal/routing/session_affinity.go`
- `internal/routing/exposed_models.go`
- `internal/routing/failover_policy.go`

### 3. Persisted routing state
This PR adds `internal/routingstate/` for persisted operational routing state, including:
- provider enable/disable
- canonical model enable/disable
- pool candidate enable/disable

That state is then consumed by runtime routing, admin APIs, and dashboard views.

Key files:
- `internal/routingstate/service.go`
- `internal/routingstate/store_sqlite.go`
- `internal/routingstate/store_postgresql.go`
- `internal/routingstate/store_mongodb.go`

### 4. Runtime-aware eligibility and failover
Candidate eligibility is now shared across resolver, `/v1/models`, and admin status.

Behavior implemented here:
- `healthy` candidates remain eligible
- `degraded` candidates remain eligible but are marked degraded
- `unhealthy` candidates are removed from effective selection
- canonical pool failover respects pool-scoped failover policy and max attempts

### 5. `/v1/models` alignment
`GET /v1/models` now reflects the same effective routing policy used for real request execution.

Instead of exposing a canonical model based on the first configured candidate, the response is derived from the effective candidate selected by the routing layer.

### 6. Admin API and dashboard
This PR adds new admin routing endpoints and dashboard behavior for operators.

Admin endpoints:
- `GET /admin/routing-state`
- `PUT /admin/routing-state`
- `DELETE /admin/routing-state`
- `GET /admin/routing/model-pools`

Dashboard updates include:
- provider/canonical/candidate toggles
- candidate runtime status badges
- `Config Primary` vs `Effective Candidate`
- blocked candidate visibility and pool status context

Key files:
- `internal/admin/handler_routing_state.go`
- `internal/admin/handler_routing_pools.go`
- `internal/admin/dashboard/static/js/modules/aliases.js`
- `internal/admin/dashboard/templates/model-table-body.html`

### 7. Structured routing metadata
This PR extends routing/failover observability by carrying structured routing metadata through request resolution and fallback execution.

Examples of metadata now propagated on request resolution:
- canonical model
- routing strategy
- config primary candidate
- effective candidate
- selected provider name
- selected exact model
- blocked candidates
- failover used
- fallback target

Key files:
- `internal/core/canonical_routing.go`
- `internal/core/request_model_resolution.go`
- `internal/gateway/request_model_resolution.go`
- `internal/gateway/fallback.go`

## Developer notes
- The canonical routing feature is centered around `internal/routing/` and is wired into the app in `internal/app/app.go`.
- `internal/routing/exposed_models.go` now uses the same routing decision surface as real request execution, so `/v1/models` and translated request routing stay consistent.
- Session affinity currently prefers `user_path` as the affinity key and falls back to request ID when no scoped user path is available.
- Failover metadata is updated in the workflow resolution when an actual fallback candidate succeeds.
- The dashboard consumes pool-level and candidate-level routing state through the admin API rather than recomputing it client-side.

## Documentation
User-facing documentation for this feature lives at:
- `docs/features/canonical-routing.mdx`

That doc explains:
- the new `routing` config block
- supported strategies
- session affinity behavior
- failover behavior
- runtime eligibility rules
- `/v1/models` behavior
- admin/dashboard controls
- how `configured_provider_models_mode` still interacts with canonical pools

## Test plan
- [x] `go test ./internal/routing ./internal/routingstate ./internal/gateway ./internal/server ./internal/admin ./internal/admin/dashboard ./internal/app`
- [x] `node --test internal/admin/dashboard/static/js/modules/aliases.test.cjs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Canonical model pool routing with priority-failover and weighted round-robin strategies.
  * Session affinity (configurable enable/TTL) and configurable failover/retry policies.
  * Admin REST APIs and dashboard controls to view/manage routing state and model pools.
  * Exposed-model listing reflects canonical/effective candidate selection and eligibility.

* **Documentation**
  * Added comprehensive canonical routing guide, examples, rollout checklist, and observability notes.

* **Tests**
  * Added unit/integration tests covering routing config, resolver, pool evaluation, failover, admin handlers, and exposure listers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ENTERPILOT/GoModel/pull/352?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->