### PR TITLE
fix(providers): refresh unavailable providers on request

### DIFF
--- a/internal/aliases/service.go
+++ b/internal/aliases/service.go
@@ -149,6 +149,28 @@ func (s *Service) ResolveModel(requested core.RequestedModelSelector) (core.Mode
 	return resolution.Resolved, changed, nil
 }
 
+// ResolveRefreshTarget returns an alias target without consulting the current
+// catalog so callers can refresh an unavailable target provider before normal
+// alias resolution is retried.
+func (s *Service) ResolveRefreshTarget(requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
+	if s == nil || requested.ExplicitProvider {
+		return core.ModelSelector{}, false, nil
+	}
+	name := normalizeName(requested.Model)
+	if name == "" {
+		return core.ModelSelector{}, false, nil
+	}
+	alias, ok := s.Get(name)
+	if !ok || !alias.Enabled {
+		return core.ModelSelector{}, false, nil
+	}
+	target, err := alias.TargetSelector()
+	if err != nil {
+		return core.ModelSelector{}, false, err
+	}
+	return target, true, nil
+}
+
 // Supports reports whether an alias currently resolves to a concrete model.
 func (s *Service) Supports(model string) bool {
 	_, ok := s.resolveAlias(model)

--- a/internal/aliases/service_test.go
+++ b/internal/aliases/service_test.go
@@ -128,6 +128,43 @@ func TestServiceResolveAndExposeModels(t *testing.T) {
 	}
 }
 
+func TestServiceResolveRefreshTargetDoesNotRequireCatalogSupport(t *testing.T) {
+	service, err := NewService(newMemoryStore(Alias{
+		Name:           "smart",
+		TargetModel:    "qwen3:8b",
+		TargetProvider: "ollama",
+		Enabled:        true,
+	}), newTestCatalog())
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+
+	selector, changed, err := service.ResolveModel(core.NewRequestedModelSelector("smart", ""))
+	if err != nil {
+		t.Fatalf("ResolveModel() error = %v", err)
+	}
+	if changed {
+		t.Fatal("ResolveModel() changed = true, want false while target is absent from catalog")
+	}
+	if got := selector.QualifiedModel(); got != "smart" {
+		t.Fatalf("ResolveModel() selector = %q, want smart", got)
+	}
+
+	target, ok, err := service.ResolveRefreshTarget(core.NewRequestedModelSelector("smart", ""))
+	if err != nil {
+		t.Fatalf("ResolveRefreshTarget() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("ResolveRefreshTarget() ok = false, want true")
+	}
+	if got := target.QualifiedModel(); got != "ollama/qwen3:8b" {
+		t.Fatalf("ResolveRefreshTarget() = %q, want ollama/qwen3:8b", got)
+	}
+}
+
 func TestServiceUpsertRejectsAliasChainAndAllowsMasking(t *testing.T) {
 	catalog := newTestCatalog()
 	catalog.add("gpt-4o", "openai", core.Model{ID: "gpt-4o", Object: "model"})

--- a/internal/gateway/request_model_resolution.go
+++ b/internal/gateway/request_model_resolution.go
@@ -163,7 +163,11 @@ func refreshProviderModelsForResolution(
 	providerSelector := strings.TrimSpace(resolvedSelector.Provider)
 	if providerSelector == "" {
 		if targetResolver, ok := resolver.(modelRefreshTargetResolver); ok {
-			if selector, ok, err := targetResolver.ResolveRefreshTarget(requested); err == nil && ok {
+			selector, ok, err := targetResolver.ResolveRefreshTarget(requested)
+			if err != nil {
+				return false, err
+			}
+			if ok {
 				providerSelector = strings.TrimSpace(selector.Provider)
 			}
 		}

--- a/internal/gateway/request_model_resolution.go
+++ b/internal/gateway/request_model_resolution.go
@@ -15,6 +15,10 @@ type providerModelRefresher interface {
 	RefreshProviderModels(ctx context.Context, providerSelector string) (int, error)
 }
 
+type modelRefreshTargetResolver interface {
+	ResolveRefreshTarget(requested core.RequestedModelSelector) (core.ModelSelector, bool, error)
+}
+
 // ResolvedProviderName returns the configured provider instance name for a selector.
 func ResolvedProviderName(provider core.RoutableProvider, selector core.ModelSelector, fallback string) string {
 	fallback = strings.TrimSpace(fallback)
@@ -71,7 +75,7 @@ func ResolveRequestModelWithAuthorizer(
 	refreshed := false
 	if err != nil {
 		var refreshErr error
-		refreshed, refreshErr = refreshProviderModelsForResolution(ctx, provider, requested, resolvedSelector)
+		refreshed, refreshErr = refreshProviderModelsForResolution(ctx, provider, resolver, requested, resolvedSelector)
 		if refreshErr != nil {
 			return nil, refreshErr
 		}
@@ -94,7 +98,7 @@ func ResolveRequestModelWithAuthorizer(
 	if counted, ok := provider.(modelCountProvider); ok && counted.ModelCount() == 0 {
 		if !refreshed {
 			var refreshErr error
-			refreshed, refreshErr = refreshProviderModelsForResolution(ctx, provider, requested, resolvedSelector)
+			refreshed, refreshErr = refreshProviderModelsForResolution(ctx, provider, resolver, requested, resolvedSelector)
 			if refreshErr != nil {
 				return nil, refreshErr
 			}
@@ -113,7 +117,7 @@ func ResolveRequestModelWithAuthorizer(
 	if !provider.Supports(resolvedModel) {
 		if !refreshed {
 			var refreshErr error
-			refreshed, refreshErr = refreshProviderModelsForResolution(ctx, provider, requested, resolvedSelector)
+			refreshed, refreshErr = refreshProviderModelsForResolution(ctx, provider, resolver, requested, resolvedSelector)
 			if refreshErr != nil {
 				return nil, refreshErr
 			}
@@ -147,6 +151,7 @@ func ResolveRequestModelWithAuthorizer(
 func refreshProviderModelsForResolution(
 	ctx context.Context,
 	provider core.RoutableProvider,
+	resolver ModelResolver,
 	requested core.RequestedModelSelector,
 	resolvedSelector core.ModelSelector,
 ) (bool, error) {
@@ -156,6 +161,13 @@ func refreshProviderModelsForResolution(
 	}
 
 	providerSelector := strings.TrimSpace(resolvedSelector.Provider)
+	if providerSelector == "" {
+		if targetResolver, ok := resolver.(modelRefreshTargetResolver); ok {
+			if selector, ok, err := targetResolver.ResolveRefreshTarget(requested); err == nil && ok {
+				providerSelector = strings.TrimSpace(selector.Provider)
+			}
+		}
+	}
 	if providerSelector == "" {
 		selector, err := requested.Normalize()
 		if err != nil {
@@ -194,12 +206,15 @@ func ResolveExecutionSelector(
 	}
 
 	if providerResolver, ok := provider.(ModelResolver); ok {
-		var providerChanged bool
-		resolvedSelector, providerChanged, err = providerResolver.ResolveModel(requested)
+		providerSelector, providerChanged, err := providerResolver.ResolveModel(requested)
 		if err != nil {
+			if resolvedSelector != (core.ModelSelector{}) {
+				// Preserve alias targets so callers can refresh the concrete provider before retrying.
+				return resolvedSelector, aliasApplied, err
+			}
 			return core.ModelSelector{}, false, err
 		}
-		return resolvedSelector, aliasApplied || providerChanged, nil
+		return providerSelector, aliasApplied || providerChanged, nil
 	}
 
 	if resolvedSelector != (core.ModelSelector{}) {

--- a/internal/gateway/request_model_resolution.go
+++ b/internal/gateway/request_model_resolution.go
@@ -11,6 +11,10 @@ type modelCountProvider interface {
 	ModelCount() int
 }
 
+type providerModelRefresher interface {
+	RefreshProviderModels(ctx context.Context, providerSelector string) (int, error)
+}
+
 // ResolvedProviderName returns the configured provider instance name for a selector.
 func ResolvedProviderName(provider core.RoutableProvider, selector core.ModelSelector, fallback string) string {
 	fallback = strings.TrimSpace(fallback)
@@ -64,8 +68,20 @@ func ResolveRequestModelWithAuthorizer(
 	requested = core.NewRequestedModelSelector(requested.Model, requested.ProviderHint)
 
 	resolvedSelector, aliasApplied, err := ResolveExecutionSelector(provider, resolver, requested)
+	refreshed := false
 	if err != nil {
-		return nil, core.NewInvalidRequestError(err.Error(), err)
+		var refreshErr error
+		refreshed, refreshErr = refreshProviderModelsForResolution(ctx, provider, requested, resolvedSelector)
+		if refreshErr != nil {
+			return nil, refreshErr
+		}
+		if !refreshed {
+			return nil, core.NewInvalidRequestError(err.Error(), err)
+		}
+		resolvedSelector, aliasApplied, err = ResolveExecutionSelector(provider, resolver, requested)
+		if err != nil {
+			return nil, core.NewInvalidRequestError(err.Error(), err)
+		}
 	}
 	if resolvedSelector == (core.ModelSelector{}) {
 		resolvedSelector, err = requested.Normalize()
@@ -76,7 +92,39 @@ func ResolveRequestModelWithAuthorizer(
 
 	resolvedModel := resolvedSelector.QualifiedModel()
 	if counted, ok := provider.(modelCountProvider); ok && counted.ModelCount() == 0 {
+		if !refreshed {
+			var refreshErr error
+			refreshed, refreshErr = refreshProviderModelsForResolution(ctx, provider, requested, resolvedSelector)
+			if refreshErr != nil {
+				return nil, refreshErr
+			}
+			if refreshed {
+				resolvedSelector, aliasApplied, err = ResolveExecutionSelector(provider, resolver, requested)
+				if err != nil {
+					return nil, core.NewInvalidRequestError(err.Error(), err)
+				}
+				resolvedModel = resolvedSelector.QualifiedModel()
+			}
+		}
+	}
+	if counted, ok := provider.(modelCountProvider); ok && counted.ModelCount() == 0 {
 		return nil, core.NewProviderError("", 0, "model registry not initialized", nil)
+	}
+	if !provider.Supports(resolvedModel) {
+		if !refreshed {
+			var refreshErr error
+			refreshed, refreshErr = refreshProviderModelsForResolution(ctx, provider, requested, resolvedSelector)
+			if refreshErr != nil {
+				return nil, refreshErr
+			}
+			if refreshed {
+				resolvedSelector, aliasApplied, err = ResolveExecutionSelector(provider, resolver, requested)
+				if err != nil {
+					return nil, core.NewInvalidRequestError(err.Error(), err)
+				}
+				resolvedModel = resolvedSelector.QualifiedModel()
+			}
+		}
 	}
 	if !provider.Supports(resolvedModel) {
 		return nil, core.NewInvalidRequestError("unsupported model: "+resolvedModel, nil)
@@ -94,6 +142,33 @@ func ResolveRequestModelWithAuthorizer(
 		ProviderName:     ResolvedProviderName(provider, resolvedSelector, ""),
 		AliasApplied:     aliasApplied,
 	}, nil
+}
+
+func refreshProviderModelsForResolution(
+	ctx context.Context,
+	provider core.RoutableProvider,
+	requested core.RequestedModelSelector,
+	resolvedSelector core.ModelSelector,
+) (bool, error) {
+	refresher, ok := provider.(providerModelRefresher)
+	if !ok {
+		return false, nil
+	}
+
+	providerSelector := strings.TrimSpace(resolvedSelector.Provider)
+	if providerSelector == "" {
+		selector, err := requested.Normalize()
+		if err != nil {
+			return false, nil
+		}
+		providerSelector = strings.TrimSpace(selector.Provider)
+	}
+	if providerSelector == "" {
+		return false, nil
+	}
+
+	_, err := refresher.RefreshProviderModels(ctx, providerSelector)
+	return true, err
 }
 
 // ResolveExecutionSelector applies explicit and provider-owned selector resolution.

--- a/internal/gateway/request_model_resolution_test.go
+++ b/internal/gateway/request_model_resolution_test.go
@@ -102,6 +102,7 @@ func (r requestAliasResolver) ResolveModel(requested core.RequestedModelSelector
 type requestRefreshTargetResolver struct {
 	provider *requestRefreshProvider
 	target   core.ModelSelector
+	err      error
 }
 
 func (r requestRefreshTargetResolver) ResolveModel(requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
@@ -115,6 +116,9 @@ func (r requestRefreshTargetResolver) ResolveModel(requested core.RequestedModel
 func (r requestRefreshTargetResolver) ResolveRefreshTarget(requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
 	if requested.RequestedQualifiedModel() != "smart" {
 		return core.ModelSelector{}, false, nil
+	}
+	if r.err != nil {
+		return core.ModelSelector{}, false, r.err
 	}
 	return r.target, true, nil
 }
@@ -189,6 +193,33 @@ func TestResolveRequestModelRefreshesAliasTargetBeforeCatalogSupportsIt(t *testi
 	}
 	if !resolution.AliasApplied {
 		t.Fatal("AliasApplied = false, want true")
+	}
+}
+
+func TestResolveRequestModelReturnsRefreshTargetError(t *testing.T) {
+	provider := newRequestRefreshProvider(1)
+	targetErr := errors.New("invalid alias target")
+	resolver := requestRefreshTargetResolver{
+		provider: provider,
+		target:   core.ModelSelector{Provider: "ollama", Model: "qwen3:8b"},
+		err:      targetErr,
+	}
+
+	_, err := ResolveRequestModelWithAuthorizer(
+		context.Background(),
+		provider,
+		resolver,
+		nil,
+		core.NewRequestedModelSelector("smart", ""),
+	)
+	if err == nil {
+		t.Fatal("ResolveRequestModelWithAuthorizer() error = nil, want refresh target error")
+	}
+	if !errors.Is(err, targetErr) {
+		t.Fatalf("ResolveRequestModelWithAuthorizer() error = %v, want %v", err, targetErr)
+	}
+	if provider.refreshCalls != 0 {
+		t.Fatalf("refresh calls = %d, want 0 after refresh target error", provider.refreshCalls)
 	}
 }
 

--- a/internal/gateway/request_model_resolution_test.go
+++ b/internal/gateway/request_model_resolution_test.go
@@ -11,11 +11,12 @@ import (
 )
 
 type requestRefreshProvider struct {
-	supported    map[string]bool
-	providerType map[string]string
-	modelCount   int
-	refreshErr   error
-	refreshCalls int
+	supported           map[string]bool
+	providerType        map[string]string
+	modelCount          int
+	refreshErr          error
+	resolveErrWhenEmpty bool
+	refreshCalls        int
 }
 
 func newRequestRefreshProvider(modelCount int) *requestRefreshProvider {
@@ -45,6 +46,9 @@ func (p *requestRefreshProvider) RefreshProviderModels(_ context.Context, provid
 }
 
 func (p *requestRefreshProvider) ResolveModel(requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
+	if p.resolveErrWhenEmpty && p.modelCount == 0 {
+		return core.ModelSelector{}, false, core.NewProviderError("", http.StatusServiceUnavailable, "model registry not initialized", nil)
+	}
 	selector, err := requested.Normalize()
 	return selector, false, err
 }
@@ -83,6 +87,36 @@ func (p *requestRefreshProvider) StreamResponses(context.Context, *core.Response
 
 func (p *requestRefreshProvider) Embeddings(context.Context, *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
 	return nil, nil
+}
+
+type requestAliasResolver map[string]core.ModelSelector
+
+func (r requestAliasResolver) ResolveModel(requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
+	if selector, ok := r[requested.RequestedQualifiedModel()]; ok {
+		return selector, true, nil
+	}
+	selector, err := requested.Normalize()
+	return selector, false, err
+}
+
+type requestRefreshTargetResolver struct {
+	provider *requestRefreshProvider
+	target   core.ModelSelector
+}
+
+func (r requestRefreshTargetResolver) ResolveModel(requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
+	if requested.RequestedQualifiedModel() == "smart" && r.provider.Supports(r.target.QualifiedModel()) {
+		return r.target, true, nil
+	}
+	selector, err := requested.Normalize()
+	return selector, false, err
+}
+
+func (r requestRefreshTargetResolver) ResolveRefreshTarget(requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
+	if requested.RequestedQualifiedModel() != "smart" {
+		return core.ModelSelector{}, false, nil
+	}
+	return r.target, true, nil
 }
 
 func TestResolveRequestModelRefreshesBeforeUnsupportedModel(t *testing.T) {
@@ -127,6 +161,62 @@ func TestResolveRequestModelRefreshesBeforeEmptyRegistryFailure(t *testing.T) {
 	}
 	if got := resolution.ResolvedQualifiedModel(); got != "ollama/qwen3:8b" {
 		t.Fatalf("ResolvedQualifiedModel() = %q, want ollama/qwen3:8b", got)
+	}
+}
+
+func TestResolveRequestModelRefreshesAliasTargetBeforeCatalogSupportsIt(t *testing.T) {
+	provider := newRequestRefreshProvider(1)
+	resolver := requestRefreshTargetResolver{
+		provider: provider,
+		target:   core.ModelSelector{Provider: "ollama", Model: "qwen3:8b"},
+	}
+
+	resolution, err := ResolveRequestModelWithAuthorizer(
+		context.Background(),
+		provider,
+		resolver,
+		nil,
+		core.NewRequestedModelSelector("smart", ""),
+	)
+	if err != nil {
+		t.Fatalf("ResolveRequestModelWithAuthorizer() error = %v, want nil", err)
+	}
+	if provider.refreshCalls != 1 {
+		t.Fatalf("refresh calls = %d, want 1", provider.refreshCalls)
+	}
+	if got := resolution.ResolvedQualifiedModel(); got != "ollama/qwen3:8b" {
+		t.Fatalf("ResolvedQualifiedModel() = %q, want ollama/qwen3:8b", got)
+	}
+	if !resolution.AliasApplied {
+		t.Fatal("AliasApplied = false, want true")
+	}
+}
+
+func TestResolveRequestModelRefreshesAliasTargetAfterResolverFailure(t *testing.T) {
+	provider := newRequestRefreshProvider(0)
+	provider.resolveErrWhenEmpty = true
+	resolver := requestAliasResolver{
+		"smart": {Provider: "ollama", Model: "qwen3:8b"},
+	}
+
+	resolution, err := ResolveRequestModelWithAuthorizer(
+		context.Background(),
+		provider,
+		resolver,
+		nil,
+		core.NewRequestedModelSelector("smart", ""),
+	)
+	if err != nil {
+		t.Fatalf("ResolveRequestModelWithAuthorizer() error = %v, want nil", err)
+	}
+	if provider.refreshCalls != 1 {
+		t.Fatalf("refresh calls = %d, want 1", provider.refreshCalls)
+	}
+	if got := resolution.ResolvedQualifiedModel(); got != "ollama/qwen3:8b" {
+		t.Fatalf("ResolvedQualifiedModel() = %q, want ollama/qwen3:8b", got)
+	}
+	if !resolution.AliasApplied {
+		t.Fatal("AliasApplied = false, want true")
 	}
 }
 

--- a/internal/gateway/request_model_resolution_test.go
+++ b/internal/gateway/request_model_resolution_test.go
@@ -1,0 +1,157 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"gomodel/internal/core"
+)
+
+type requestRefreshProvider struct {
+	supported    map[string]bool
+	providerType map[string]string
+	modelCount   int
+	refreshErr   error
+	refreshCalls int
+}
+
+func newRequestRefreshProvider(modelCount int) *requestRefreshProvider {
+	return &requestRefreshProvider{
+		supported: map[string]bool{
+			"openai/gpt-4o": true,
+		},
+		providerType: map[string]string{
+			"openai/gpt-4o": "openai",
+		},
+		modelCount: modelCount,
+	}
+}
+
+func (p *requestRefreshProvider) RefreshProviderModels(_ context.Context, providerSelector string) (int, error) {
+	p.refreshCalls++
+	if p.refreshErr != nil {
+		return 0, p.refreshErr
+	}
+	if providerSelector != "ollama" {
+		return 0, nil
+	}
+	p.supported["ollama/qwen3:8b"] = true
+	p.providerType["ollama/qwen3:8b"] = "ollama"
+	p.modelCount = 1
+	return 1, nil
+}
+
+func (p *requestRefreshProvider) ResolveModel(requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
+	selector, err := requested.Normalize()
+	return selector, false, err
+}
+
+func (p *requestRefreshProvider) Supports(model string) bool {
+	return p.supported[model]
+}
+
+func (p *requestRefreshProvider) GetProviderType(model string) string {
+	return p.providerType[model]
+}
+
+func (p *requestRefreshProvider) ModelCount() int {
+	return p.modelCount
+}
+
+func (p *requestRefreshProvider) ChatCompletion(context.Context, *core.ChatRequest) (*core.ChatResponse, error) {
+	return nil, nil
+}
+
+func (p *requestRefreshProvider) StreamChatCompletion(context.Context, *core.ChatRequest) (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func (p *requestRefreshProvider) ListModels(context.Context) (*core.ModelsResponse, error) {
+	return nil, nil
+}
+
+func (p *requestRefreshProvider) Responses(context.Context, *core.ResponsesRequest) (*core.ResponsesResponse, error) {
+	return nil, nil
+}
+
+func (p *requestRefreshProvider) StreamResponses(context.Context, *core.ResponsesRequest) (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func (p *requestRefreshProvider) Embeddings(context.Context, *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	return nil, nil
+}
+
+func TestResolveRequestModelRefreshesBeforeUnsupportedModel(t *testing.T) {
+	provider := newRequestRefreshProvider(1)
+
+	resolution, err := ResolveRequestModelWithAuthorizer(
+		context.Background(),
+		provider,
+		nil,
+		nil,
+		core.NewRequestedModelSelector("ollama/qwen3:8b", ""),
+	)
+	if err != nil {
+		t.Fatalf("ResolveRequestModelWithAuthorizer() error = %v, want nil", err)
+	}
+	if provider.refreshCalls != 1 {
+		t.Fatalf("refresh calls = %d, want 1", provider.refreshCalls)
+	}
+	if got := resolution.ResolvedQualifiedModel(); got != "ollama/qwen3:8b" {
+		t.Fatalf("ResolvedQualifiedModel() = %q, want ollama/qwen3:8b", got)
+	}
+	if got := resolution.ProviderType; got != "ollama" {
+		t.Fatalf("ProviderType = %q, want ollama", got)
+	}
+}
+
+func TestResolveRequestModelRefreshesBeforeEmptyRegistryFailure(t *testing.T) {
+	provider := newRequestRefreshProvider(0)
+
+	resolution, err := ResolveRequestModelWithAuthorizer(
+		context.Background(),
+		provider,
+		nil,
+		nil,
+		core.NewRequestedModelSelector("ollama/qwen3:8b", ""),
+	)
+	if err != nil {
+		t.Fatalf("ResolveRequestModelWithAuthorizer() error = %v, want nil", err)
+	}
+	if provider.refreshCalls != 1 {
+		t.Fatalf("refresh calls = %d, want 1", provider.refreshCalls)
+	}
+	if got := resolution.ResolvedQualifiedModel(); got != "ollama/qwen3:8b" {
+		t.Fatalf("ResolvedQualifiedModel() = %q, want ollama/qwen3:8b", got)
+	}
+}
+
+func TestResolveRequestModelReturnsRefreshError(t *testing.T) {
+	provider := newRequestRefreshProvider(1)
+	provider.refreshErr = core.NewProviderError("ollama", http.StatusServiceUnavailable, "provider is unavailable", errors.New("connection refused"))
+
+	_, err := ResolveRequestModelWithAuthorizer(
+		context.Background(),
+		provider,
+		nil,
+		nil,
+		core.NewRequestedModelSelector("ollama/qwen3:8b", ""),
+	)
+	if err == nil {
+		t.Fatal("ResolveRequestModelWithAuthorizer() error = nil, want refresh error")
+	}
+	var gatewayErr *core.GatewayError
+	if !errors.As(err, &gatewayErr) {
+		t.Fatalf("error = %T, want GatewayError", err)
+	}
+	if gatewayErr.HTTPStatusCode() != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", gatewayErr.HTTPStatusCode(), http.StatusServiceUnavailable)
+	}
+	if gatewayErr.Type != core.ErrorTypeProvider {
+		t.Fatalf("error type = %q, want %q", gatewayErr.Type, core.ErrorTypeProvider)
+	}
+}

--- a/internal/providers/registry_init.go
+++ b/internal/providers/registry_init.go
@@ -197,6 +197,10 @@ func (r *ModelRegistry) fetchAllProviderModels(
 			configuredReason == configuredProviderModelsAllowlist {
 			runtimeUpdate.lastModelFetchSuccessAt = fetchAt
 		}
+		if configuredReason == configuredProviderModelsNotApplied {
+			runtimeUpdate.lastAvailabilityCheckAt = fetchAt
+			runtimeUpdate.lastAvailabilityOKAt = fetchAt
+		}
 		out.runtimeUpdates[providerName] = runtimeUpdate
 
 		if _, ok := out.modelsByProvider[providerName]; !ok {
@@ -239,15 +243,7 @@ func (r *ModelRegistry) applyFetchedInventory(
 	fetched fetchedInventory,
 	totalProviders int,
 ) {
-	r.mu.RLock()
-	list := r.modelList
-	r.mu.RUnlock()
-	configOverrides := r.snapshotConfigOverrides()
-	metadataStats := metadataEnrichmentStats{}
-	if list != nil {
-		metadataStats = enrichProviderModelMaps(list, providerTypes, fetched.modelsByProvider, nil)
-	}
-	metadataStats.Enriched += applyConfigMetadataOverrides(configOverrides, fetched.modelsByProvider, nil)
+	metadataStats := r.enrichFetchedProviderModelMaps(providerTypes, fetched.modelsByProvider)
 
 	r.mu.Lock()
 	r.models = fetched.models
@@ -267,6 +263,23 @@ func (r *ModelRegistry) applyFetchedInventory(
 	}
 	attrs = append(attrs, metadataStats.slogAttrs()...)
 	slog.Info("model registry initialized", attrs...)
+}
+
+func (r *ModelRegistry) enrichFetchedProviderModelMaps(
+	providerTypes map[core.Provider]string,
+	modelsByProvider map[string]map[string]*ModelInfo,
+) metadataEnrichmentStats {
+	r.mu.RLock()
+	list := r.modelList
+	r.mu.RUnlock()
+
+	configOverrides := r.snapshotConfigOverrides()
+	metadataStats := metadataEnrichmentStats{}
+	if list != nil {
+		metadataStats = enrichProviderModelMaps(list, providerTypes, modelsByProvider, nil)
+	}
+	metadataStats.Enriched += applyConfigMetadataOverrides(configOverrides, modelsByProvider, nil)
+	return metadataStats
 }
 
 func fetchProviderInventory(
@@ -332,6 +345,14 @@ func (r *ModelRegistry) applyProviderRuntimeUpdatesLocked(updates map[string]pro
 		}
 		if !update.lastModelFetchSuccessAt.IsZero() {
 			current.lastModelFetchSuccessAt = update.lastModelFetchSuccessAt
+		}
+		if !update.lastAvailabilityCheckAt.IsZero() {
+			current.lastAvailabilityCheckAt = update.lastAvailabilityCheckAt
+			current.lastAvailabilityError = strings.TrimSpace(update.lastAvailabilityError)
+		}
+		if !update.lastAvailabilityOKAt.IsZero() {
+			current.lastAvailabilityOKAt = update.lastAvailabilityOKAt
+			current.lastAvailabilityError = ""
 		}
 		r.providerRuntime[providerName] = current
 	}

--- a/internal/providers/registry_provider_refresh.go
+++ b/internal/providers/registry_provider_refresh.go
@@ -69,10 +69,11 @@ func (r *ModelRegistry) RefreshProviderModels(ctx context.Context, providerSelec
 	)
 
 	if fetched.totalModels == 0 {
-		r.applyProviderRuntimeUpdates(fetched.runtimeUpdates)
 		if fetched.failedProviders == len(providers) {
+			r.applyProviderRuntimeUpdates(fetched.runtimeUpdates)
 			return 0, core.NewProviderError(providerSelector, http.StatusServiceUnavailable, "failed to refresh provider models", fetchedProviderRefreshError(fetched))
 		}
+		r.applyFetchedProviderInventory(providerTypes, fetched)
 		return 0, core.NewProviderError(providerSelector, http.StatusServiceUnavailable, "provider returned no models", nil)
 	}
 

--- a/internal/providers/registry_provider_refresh.go
+++ b/internal/providers/registry_provider_refresh.go
@@ -1,0 +1,205 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"gomodel/internal/core"
+)
+
+type providerRefreshTarget struct {
+	provider     core.Provider
+	providerName string
+	providerType string
+}
+
+// RefreshProviderModels refreshes model inventory for a configured provider
+// name, or all providers matching a provider type. It is intended for
+// request-time recovery when startup discovery failed before a provider was
+// reachable.
+func (r *ModelRegistry) RefreshProviderModels(ctx context.Context, providerSelector string) (int, error) {
+	providerSelector = strings.TrimSpace(providerSelector)
+	if providerSelector == "" {
+		return 0, core.NewInvalidRequestError("provider selector is required", nil)
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	release, err := r.acquireRefresh(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer release()
+
+	targets := r.providerRefreshTargets(providerSelector)
+	if len(targets) == 0 {
+		return 0, core.NewInvalidRequestError(fmt.Sprintf("no provider found for provider: %s", providerSelector), nil)
+	}
+
+	targets, err = r.availableProviderRefreshTargets(ctx, providerSelector, targets)
+	if err != nil {
+		return 0, err
+	}
+	if len(targets) == 0 {
+		return 0, core.NewProviderError(providerSelector, http.StatusServiceUnavailable, "provider is unavailable", nil)
+	}
+
+	configuredProviderModels, configuredProviderModelsMode := r.snapshotConfiguredProviderModels()
+	providers := make([]core.Provider, 0, len(targets))
+	providerTypes := make(map[core.Provider]string, len(targets))
+	providerNames := make(map[core.Provider]string, len(targets))
+	for _, target := range targets {
+		providers = append(providers, target.provider)
+		providerTypes[target.provider] = target.providerType
+		providerNames[target.provider] = target.providerName
+	}
+
+	fetched := r.fetchAllProviderModels(
+		ctx,
+		providers,
+		providerTypes,
+		providerNames,
+		configuredProviderModels,
+		configuredProviderModelsMode,
+	)
+
+	if fetched.totalModels == 0 {
+		r.applyProviderRuntimeUpdates(fetched.runtimeUpdates)
+		if fetched.failedProviders == len(providers) {
+			return 0, core.NewProviderError(providerSelector, http.StatusServiceUnavailable, "failed to refresh provider models", fetchedProviderRefreshError(fetched))
+		}
+		return 0, core.NewProviderError(providerSelector, http.StatusServiceUnavailable, "provider returned no models", nil)
+	}
+
+	r.applyFetchedProviderInventory(providerTypes, fetched)
+	return fetched.totalModels, nil
+}
+
+func (r *ModelRegistry) providerRefreshTargets(providerSelector string) []providerRefreshTarget {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	providerSelector = strings.TrimSpace(providerSelector)
+	if providerSelector == "" {
+		return nil
+	}
+
+	for _, provider := range r.providers {
+		providerName := strings.TrimSpace(r.providerNames[provider])
+		if providerName != providerSelector {
+			continue
+		}
+		return []providerRefreshTarget{{
+			provider:     provider,
+			providerName: providerName,
+			providerType: strings.TrimSpace(r.providerTypes[provider]),
+		}}
+	}
+
+	targets := make([]providerRefreshTarget, 0)
+	for _, provider := range r.providers {
+		providerType := strings.TrimSpace(r.providerTypes[provider])
+		if providerType != providerSelector {
+			continue
+		}
+		providerName := strings.TrimSpace(r.providerNames[provider])
+		if providerName == "" {
+			continue
+		}
+		targets = append(targets, providerRefreshTarget{
+			provider:     provider,
+			providerName: providerName,
+			providerType: providerType,
+		})
+	}
+	return targets
+}
+
+func (r *ModelRegistry) availableProviderRefreshTargets(ctx context.Context, providerSelector string, targets []providerRefreshTarget) ([]providerRefreshTarget, error) {
+	available := make([]providerRefreshTarget, 0, len(targets))
+	var availabilityErrs []error
+
+	for _, target := range targets {
+		checker, ok := target.provider.(core.AvailabilityChecker)
+		if !ok {
+			available = append(available, target)
+			continue
+		}
+		err := checker.CheckAvailability(ctx)
+		r.RecordAvailabilityCheck(target.providerName, err)
+		if err != nil {
+			availabilityErrs = append(availabilityErrs, fmt.Errorf("%s: %w", target.providerName, err))
+			slog.Warn("provider unavailable during request-time refresh",
+				"provider", target.providerName,
+				"type", target.providerType,
+				"error", err,
+			)
+			continue
+		}
+		available = append(available, target)
+	}
+
+	if len(available) > 0 || len(availabilityErrs) == 0 {
+		return available, nil
+	}
+
+	err := errors.Join(availabilityErrs...)
+	return nil, core.NewProviderError(providerSelector, http.StatusServiceUnavailable, "provider is unavailable", err)
+}
+
+func fetchedProviderRefreshError(fetched fetchedInventory) error {
+	if len(fetched.runtimeUpdates) == 0 {
+		return nil
+	}
+	errs := make([]error, 0, len(fetched.runtimeUpdates))
+	for providerName, state := range fetched.runtimeUpdates {
+		errMessage := strings.TrimSpace(state.lastModelFetchError)
+		if errMessage == "" {
+			continue
+		}
+		errs = append(errs, fmt.Errorf("%s: %s", providerName, errMessage))
+	}
+	return errors.Join(errs...)
+}
+
+func (r *ModelRegistry) applyFetchedProviderInventory(providerTypes map[core.Provider]string, fetched fetchedInventory) {
+	metadataStats := r.enrichFetchedProviderModelMaps(providerTypes, fetched.modelsByProvider)
+
+	r.mu.Lock()
+	for providerName, providerModels := range fetched.modelsByProvider {
+		r.modelsByProvider[providerName] = providerModels
+	}
+	r.applyProviderRuntimeUpdatesLocked(fetched.runtimeUpdates)
+	r.models = rebuildGlobalModelMap(r.modelsByProvider, r.providerOrderNamesLocked())
+	r.invalidateSortedCaches()
+	r.mu.Unlock()
+
+	r.initMu.Lock()
+	r.initialized = true
+	r.initMu.Unlock()
+
+	attrs := []any{
+		"total_models", fetched.totalModels,
+		"providers", len(fetched.modelsByProvider),
+		"failed_providers", fetched.failedProviders,
+	}
+	attrs = append(attrs, metadataStats.slogAttrs()...)
+	slog.Info("provider models refreshed", attrs...)
+}
+
+func (r *ModelRegistry) providerOrderNamesLocked() []string {
+	names := make([]string, 0, len(r.providers))
+	for _, provider := range r.providers {
+		providerName := strings.TrimSpace(r.providerNames[provider])
+		if providerName == "" {
+			continue
+		}
+		names = append(names, providerName)
+	}
+	return names
+}

--- a/internal/providers/registry_test.go
+++ b/internal/providers/registry_test.go
@@ -239,6 +239,39 @@ func TestModelRegistry(t *testing.T) {
 		}
 	})
 
+	t.Run("TargetedRefreshWithEmptyInventoryClearsStaleProviderModels", func(t *testing.T) {
+		registry := NewModelRegistry()
+		mock := &registryMockProvider{
+			name: "ollama",
+			modelsResponse: &core.ModelsResponse{
+				Object: "list",
+				Data: []core.Model{
+					{ID: "qwen3:8b", Object: "model", OwnedBy: "ollama"},
+				},
+			},
+		}
+		registry.RegisterProviderWithNameAndType(mock, "ollama", "ollama")
+
+		if err := registry.Initialize(context.Background()); err != nil {
+			t.Fatalf("Initialize() error = %v, want nil", err)
+		}
+		if !registry.Supports("ollama/qwen3:8b") {
+			t.Fatal("expected ollama/qwen3:8b to be supported before empty refresh")
+		}
+
+		mock.modelsResponse = &core.ModelsResponse{Object: "list", Data: []core.Model{}}
+		_, err := registry.RefreshProviderModels(context.Background(), "ollama")
+		if err == nil || !strings.Contains(err.Error(), "provider returned no models") {
+			t.Fatalf("RefreshProviderModels() error = %v, want provider returned no models", err)
+		}
+		if registry.Supports("ollama/qwen3:8b") {
+			t.Fatal("expected stale ollama/qwen3:8b to be removed after empty refresh")
+		}
+		if registry.ModelCount() != 0 {
+			t.Fatalf("ModelCount() = %d, want 0", registry.ModelCount())
+		}
+	})
+
 	t.Run("ConfiguredModelsAllowlistModeSkipsUpstreamAndUsesConfiguredModels", func(t *testing.T) {
 		registry := NewModelRegistry()
 		registry.SetConfiguredProviderModelsMode(config.ConfiguredProviderModelsModeAllowlist)

--- a/internal/providers/registry_test.go
+++ b/internal/providers/registry_test.go
@@ -209,6 +209,36 @@ func TestModelRegistry(t *testing.T) {
 		}
 	})
 
+	t.Run("SuccessfulLiveModelFetchClearsAvailabilityError", func(t *testing.T) {
+		registry := NewModelRegistry()
+		mock := &registryMockProvider{
+			name: "ollama",
+			modelsResponse: &core.ModelsResponse{
+				Object: "list",
+				Data: []core.Model{
+					{ID: "qwen3:8b", Object: "model", OwnedBy: "ollama"},
+				},
+			},
+		}
+		registry.RegisterProviderWithNameAndType(mock, "ollama", "ollama")
+		registry.RecordAvailabilityCheck("ollama", errors.New("connection refused"))
+
+		if err := registry.Initialize(context.Background()); err != nil {
+			t.Fatalf("Initialize() error = %v, want nil", err)
+		}
+
+		snapshots := registry.ProviderRuntimeSnapshots()
+		if len(snapshots) != 1 {
+			t.Fatalf("snapshots = %d, want 1", len(snapshots))
+		}
+		if snapshots[0].LastAvailabilityError != "" {
+			t.Fatalf("LastAvailabilityError = %q, want empty after live model fetch", snapshots[0].LastAvailabilityError)
+		}
+		if snapshots[0].LastAvailabilityOKAt == nil {
+			t.Fatal("LastAvailabilityOKAt = nil, want timestamp after live model fetch")
+		}
+	})
+
 	t.Run("ConfiguredModelsAllowlistModeSkipsUpstreamAndUsesConfiguredModels", func(t *testing.T) {
 		registry := NewModelRegistry()
 		registry.SetConfiguredProviderModelsMode(config.ConfiguredProviderModelsModeAllowlist)

--- a/internal/providers/router.go
+++ b/internal/providers/router.go
@@ -52,6 +52,10 @@ type modelWithProviderLister interface {
 	ListModelsWithProvider() []ModelWithProvider
 }
 
+type providerModelRefresher interface {
+	RefreshProviderModels(ctx context.Context, providerSelector string) (int, error)
+}
+
 func registryUnavailableError(err error) error {
 	return core.NewProviderError("", http.StatusServiceUnavailable, err.Error(), err)
 }
@@ -235,17 +239,96 @@ func (r *Router) hasConfiguredProviderName(providerName string) bool {
 }
 
 // resolveProvider validates readiness, parses the model selector, and finds the target provider.
-func (r *Router) resolveProvider(model, providerHint string) (core.Provider, core.ModelSelector, error) {
-	selector, _, err := r.ResolveModel(core.NewRequestedModelSelector(model, providerHint))
+func (r *Router) resolveProvider(ctx context.Context, model, providerHint string) (core.Provider, core.ModelSelector, error) {
+	requested := core.NewRequestedModelSelector(model, providerHint)
+	selector, _, err := r.ResolveModel(requested)
+	refreshed := false
 	if err != nil {
-		return nil, core.ModelSelector{}, err
+		var refreshErr error
+		refreshed, refreshErr = r.refreshProviderModelsForRequest(ctx, requested)
+		if refreshErr != nil {
+			return nil, core.ModelSelector{}, refreshErr
+		}
+		if !refreshed {
+			return nil, core.ModelSelector{}, err
+		}
+		selector, _, err = r.ResolveModel(requested)
+		if err != nil {
+			return nil, core.ModelSelector{}, err
+		}
 	}
+
 	lookupModel := selector.QualifiedModel()
 	p := r.lookup.GetProvider(lookupModel)
+	if p == nil && !refreshed {
+		var refreshErr error
+		refreshed, refreshErr = r.refreshProviderModelsForRequest(ctx, requested)
+		if refreshErr != nil {
+			return nil, core.ModelSelector{}, refreshErr
+		}
+		if refreshed {
+			selector, _, err = r.ResolveModel(requested)
+			if err != nil {
+				return nil, core.ModelSelector{}, err
+			}
+			lookupModel = selector.QualifiedModel()
+			p = r.lookup.GetProvider(lookupModel)
+		}
+	}
 	if p == nil {
 		return nil, core.ModelSelector{}, core.NewNotFoundError("model not found: " + lookupModel)
 	}
 	return p, selector, nil
+}
+
+func (r *Router) refreshProviderModelsForRequest(ctx context.Context, requested core.RequestedModelSelector) (bool, error) {
+	refresher, ok := r.lookup.(providerModelRefresher)
+	if !ok {
+		return false, nil
+	}
+
+	selector, err := requested.Normalize()
+	if err != nil {
+		return false, nil
+	}
+	providerSelector := strings.TrimSpace(selector.Provider)
+	if providerSelector == "" {
+		return false, nil
+	}
+	if !r.hasRegisteredProviderSelector(providerSelector) {
+		return false, nil
+	}
+
+	_, err = refresher.RefreshProviderModels(ctx, providerSelector)
+	return true, err
+}
+
+// RefreshProviderModels refreshes a configured provider's model inventory when
+// the backing lookup supports request-time provider refreshes.
+func (r *Router) RefreshProviderModels(ctx context.Context, providerSelector string) (int, error) {
+	providerSelector = strings.TrimSpace(providerSelector)
+	if !r.hasRegisteredProviderSelector(providerSelector) {
+		return 0, nil
+	}
+	refresher, ok := r.lookup.(providerModelRefresher)
+	if !ok {
+		return 0, nil
+	}
+	return refresher.RefreshProviderModels(ctx, providerSelector)
+}
+
+func (r *Router) hasRegisteredProviderSelector(providerSelector string) bool {
+	providerSelector = strings.TrimSpace(providerSelector)
+	if providerSelector == "" {
+		return false
+	}
+	if r.hasConfiguredProviderName(providerSelector) {
+		return true
+	}
+	if strings.TrimSpace(r.lookup.GetProviderNameForType(providerSelector)) != "" {
+		return true
+	}
+	return r.providerByTypeRegistry(providerSelector) != nil
 }
 
 func (r *Router) resolveProviderType(providerType string) (core.Provider, error) {
@@ -374,7 +457,7 @@ func routeResolvedModelCall[Req any, Resp any](
 	buildForward func(core.ModelSelector) Req,
 	call func(context.Context, core.Provider, Req) (Resp, error),
 ) (Resp, string, error) {
-	p, selector, err := r.resolveProvider(model, providerHint)
+	p, selector, err := r.resolveProvider(ctx, model, providerHint)
 	if err != nil {
 		var zero Resp
 		return zero, "", err

--- a/internal/providers/router_test.go
+++ b/internal/providers/router_test.go
@@ -197,6 +197,28 @@ func (m *mockProvider) Passthrough(_ context.Context, req *core.PassthroughReque
 	}, nil
 }
 
+type lazyRefreshProvider struct {
+	mockProvider
+	modelsResponse    *core.ModelsResponse
+	listModelsErr     error
+	availabilityErr   error
+	listModelsCalls   int
+	availabilityCalls int
+}
+
+func (p *lazyRefreshProvider) ListModels(context.Context) (*core.ModelsResponse, error) {
+	p.listModelsCalls++
+	if p.listModelsErr != nil {
+		return nil, p.listModelsErr
+	}
+	return p.modelsResponse, nil
+}
+
+func (p *lazyRefreshProvider) CheckAvailability(context.Context) error {
+	p.availabilityCalls++
+	return p.availabilityErr
+}
+
 type mockBatchProvider struct {
 	mockProvider
 	listBatchesResp    *core.BatchListResponse
@@ -556,6 +578,137 @@ func TestRouterChatCompletion_PrefixedModelSelector(t *testing.T) {
 	}
 	if west.lastChatReq == nil || west.lastChatReq.Model != "gpt-4o" {
 		t.Fatalf("expected upstream model to be unqualified gpt-4o, got %#v", west.lastChatReq)
+	}
+}
+
+func TestRouterChatCompletion_RefreshesProviderModelsForQualifiedRequest(t *testing.T) {
+	provider := &lazyRefreshProvider{
+		mockProvider: mockProvider{
+			name:         "ollama",
+			chatResponse: &core.ChatResponse{ID: "chatcmpl-later", Model: "later-model"},
+		},
+		modelsResponse: &core.ModelsResponse{
+			Object: "list",
+			Data: []core.Model{
+				{ID: "later-model", Object: "model", OwnedBy: "ollama"},
+			},
+		},
+	}
+	registry := NewModelRegistry()
+	registry.RegisterProviderWithNameAndType(provider, "ollama", "ollama")
+
+	router, err := NewRouter(registry)
+	if err != nil {
+		t.Fatalf("NewRouter() error = %v", err)
+	}
+
+	resp, err := router.ChatCompletion(context.Background(), &core.ChatRequest{Model: "ollama/later-model"})
+	if err != nil {
+		t.Fatalf("ChatCompletion() error = %v, want nil", err)
+	}
+	if resp.ID != "chatcmpl-later" {
+		t.Fatalf("response ID = %q, want chatcmpl-later", resp.ID)
+	}
+	if provider.availabilityCalls != 1 {
+		t.Fatalf("availability calls = %d, want 1", provider.availabilityCalls)
+	}
+	if provider.listModelsCalls != 1 {
+		t.Fatalf("ListModels calls = %d, want 1", provider.listModelsCalls)
+	}
+	if provider.lastChatReq == nil || provider.lastChatReq.Model != "later-model" {
+		t.Fatalf("expected upstream model later-model, got %#v", provider.lastChatReq)
+	}
+	if !registry.Supports("ollama/later-model") {
+		t.Fatal("expected request-time refresh to register ollama/later-model")
+	}
+}
+
+func TestRouterChatCompletion_RefreshesMissingProviderWithoutDroppingExistingModels(t *testing.T) {
+	openAI := &mockProvider{
+		name:         "openai",
+		chatResponse: &core.ChatResponse{ID: "openai", Model: "gpt-4o"},
+	}
+	ollama := &lazyRefreshProvider{
+		mockProvider: mockProvider{
+			name:         "ollama",
+			chatResponse: &core.ChatResponse{ID: "ollama", Model: "local-model"},
+		},
+		modelsResponse: &core.ModelsResponse{
+			Object: "list",
+			Data: []core.Model{
+				{ID: "local-model", Object: "model", OwnedBy: "ollama"},
+			},
+		},
+	}
+	registry := newTestRegistryWithModels(registryModelEntry{
+		provider:     openAI,
+		providerName: "openai",
+		providerType: "openai",
+		modelID:      "gpt-4o",
+	})
+	registry.RegisterProviderWithNameAndType(ollama, "ollama", "ollama")
+
+	router, err := NewRouter(registry)
+	if err != nil {
+		t.Fatalf("NewRouter() error = %v", err)
+	}
+
+	resp, err := router.ChatCompletion(context.Background(), &core.ChatRequest{Model: "ollama/local-model"})
+	if err != nil {
+		t.Fatalf("ChatCompletion() error = %v, want nil", err)
+	}
+	if resp.ID != "ollama" {
+		t.Fatalf("response ID = %q, want ollama", resp.ID)
+	}
+	if !registry.Supports("openai/gpt-4o") {
+		t.Fatal("expected existing openai model to remain after targeted refresh")
+	}
+	if !registry.Supports("ollama/local-model") {
+		t.Fatal("expected targeted refresh to add ollama/local-model")
+	}
+}
+
+func TestRouterChatCompletion_RequestTimeRefreshUnavailableProvider(t *testing.T) {
+	provider := &lazyRefreshProvider{
+		mockProvider: mockProvider{
+			name:         "ollama",
+			chatResponse: &core.ChatResponse{ID: "should-not-run"},
+		},
+		availabilityErr: errors.New("connection refused"),
+		modelsResponse: &core.ModelsResponse{
+			Object: "list",
+			Data: []core.Model{
+				{ID: "later-model", Object: "model", OwnedBy: "ollama"},
+			},
+		},
+	}
+	registry := NewModelRegistry()
+	registry.RegisterProviderWithNameAndType(provider, "ollama", "ollama")
+
+	router, err := NewRouter(registry)
+	if err != nil {
+		t.Fatalf("NewRouter() error = %v", err)
+	}
+
+	_, err = router.ChatCompletion(context.Background(), &core.ChatRequest{Model: "ollama/later-model"})
+	if err == nil {
+		t.Fatal("ChatCompletion() error = nil, want provider unavailable")
+	}
+	var gatewayErr *core.GatewayError
+	if !errors.As(err, &gatewayErr) {
+		t.Fatalf("error = %T, want GatewayError", err)
+	}
+	if gatewayErr.HTTPStatusCode() != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", gatewayErr.HTTPStatusCode(), http.StatusServiceUnavailable)
+	}
+	if provider.availabilityCalls != 1 {
+		t.Fatalf("availability calls = %d, want 1", provider.availabilityCalls)
+	}
+	if provider.listModelsCalls != 0 {
+		t.Fatalf("ListModels calls = %d, want 0 when availability fails", provider.listModelsCalls)
+	}
+	if provider.lastChatReq != nil {
+		t.Fatalf("provider call should not be attempted, got %#v", provider.lastChatReq)
 	}
 }
 


### PR DESCRIPTION
## Summary
- refresh a provider's model inventory on provider-qualified requests when startup discovery left it unavailable
- let preflight model resolution trigger the same provider refresh before returning unsupported model
- clear stale availability errors after successful live model discovery so dashboard status can recover

## Tests
- go test ./internal/...
- commit hooks: go import/fmt, make test-race, go mod tidy, hot-path performance guard, make lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request-time provider model refresh when resolution fails, registry is empty, or an alias target may become available; router exposes targeted refresh and registry refresh API; alias service can resolve refresh targets without catalog support.

* **Bug Fixes**
  * Improved handling of provider availability timestamps and clearing stale availability errors; clearer error paths for refresh vs. unsupported/missing models.

* **Tests**
  * Added tests for refresh-before-resolution, empty-registry behavior, alias-target refresh flows, and refresh error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ENTERPILOT/GoModel/pull/357?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->