### PR TITLE
fix(release): publish draft release without checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,4 +180,4 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit "$GITHUB_REF_NAME" --draft=false --verify-tag
+        run: gh release edit "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --draft=false --verify-tag


### PR DESCRIPTION
## Summary
- Pass `--repo "$GITHUB_REPOSITORY"` to `gh release edit` in the release publish job.
- Removes the publish step dependency on a checked-out `.git` directory.

## Context
The `v0.1.34` release run failed in `Publish GitHub release` with:

```text
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

Failed run: https://github.com/ENTERPILOT/GoModel/actions/runs/26556449768

## Verification
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow automation for better verification and publishing accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ENTERPILOT/GoModel/pull/359?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->