### PR TITLE
refactor(providers): centralize auth headers, batch-id fallback, and capability resolution

### DIFF
--- a/internal/providers/auth_headers.go
+++ b/internal/providers/auth_headers.go
@@ -1,0 +1,51 @@
+package providers
+
+import (
+	"net/http"
+
+	"gomodel/internal/core"
+)
+
+// AuthHeaderConfig describes how a provider populates outbound request headers.
+// It captures the few axes along which OpenAI-compatible providers differ so the
+// shared logic (empty-key handling, request-ID forwarding, validation) lives in
+// one place and each provider declares only its variations as data.
+type AuthHeaderConfig struct {
+	// AuthHeader carries the credential. Defaults to "Authorization".
+	AuthHeader string
+	// AuthScheme prefixes the credential, e.g. "Bearer ". Empty for raw values.
+	AuthScheme string
+	// RequestIDHeader, when non-empty, forwards the context request ID under
+	// this header name. When empty, no request ID is forwarded.
+	RequestIDHeader string
+	// ValidateRequestID, when set, gates request-ID forwarding (e.g. ASCII and
+	// length checks required by some upstreams).
+	ValidateRequestID func(string) bool
+	// OptionalAPIKey skips the auth header entirely when the API key is empty,
+	// for providers that allow unauthenticated access (e.g. local Ollama/vLLM).
+	OptionalAPIKey bool
+}
+
+// SetAuthHeaders applies cfg to req for the given API key. It is safe to use
+// directly as an llmclient header hook or as CompatibleProviderConfig.SetHeaders.
+func SetAuthHeaders(req *http.Request, apiKey string, cfg AuthHeaderConfig) {
+	if apiKey != "" || !cfg.OptionalAPIKey {
+		header := cfg.AuthHeader
+		if header == "" {
+			header = "Authorization"
+		}
+		req.Header.Set(header, cfg.AuthScheme+apiKey)
+	}
+
+	if cfg.RequestIDHeader == "" {
+		return
+	}
+	requestID := core.GetRequestID(req.Context())
+	if requestID == "" {
+		return
+	}
+	if cfg.ValidateRequestID != nil && !cfg.ValidateRequestID(requestID) {
+		return
+	}
+	req.Header.Set(cfg.RequestIDHeader, requestID)
+}

--- a/internal/providers/auth_headers_test.go
+++ b/internal/providers/auth_headers_test.go
@@ -1,0 +1,109 @@
+package providers
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"gomodel/internal/core"
+)
+
+func TestSetAuthHeaders(t *testing.T) {
+	const longID = "this-request-id-is-rejected" // gated by the validator below
+
+	tests := []struct {
+		name      string
+		apiKey    string
+		requestID string
+		cfg       AuthHeaderConfig
+		wantAuth  string // value of the auth header; "" means header must be absent
+		authKey   string // header name to read the credential from
+		wantReqID string // expected request-id header value; "" means absent
+		reqIDKey  string
+	}{
+		{
+			name:     "default authorization header",
+			apiKey:   "secret",
+			cfg:      AuthHeaderConfig{AuthScheme: "Bearer "},
+			wantAuth: "Bearer secret",
+			authKey:  "Authorization",
+		},
+		{
+			name:     "custom auth header without scheme",
+			apiKey:   "secret",
+			cfg:      AuthHeaderConfig{AuthHeader: "api-key"},
+			wantAuth: "secret",
+			authKey:  "api-key",
+		},
+		{
+			name:      "forwards request id",
+			apiKey:    "secret",
+			requestID: "req-123",
+			cfg:       AuthHeaderConfig{AuthScheme: "Bearer ", RequestIDHeader: "X-Request-ID"},
+			wantAuth:  "Bearer secret",
+			authKey:   "Authorization",
+			wantReqID: "req-123",
+			reqIDKey:  "X-Request-ID",
+		},
+		{
+			name:      "no request id header when not configured",
+			apiKey:    "secret",
+			requestID: "req-123",
+			cfg:       AuthHeaderConfig{AuthScheme: "Bearer "},
+			wantAuth:  "Bearer secret",
+			authKey:   "Authorization",
+			reqIDKey:  "X-Request-ID",
+		},
+		{
+			name:      "validator rejects request id",
+			apiKey:    "secret",
+			requestID: longID,
+			cfg: AuthHeaderConfig{
+				AuthScheme:        "Bearer ",
+				RequestIDHeader:   "X-Request-ID",
+				ValidateRequestID: func(string) bool { return false },
+			},
+			wantAuth: "Bearer secret",
+			authKey:  "Authorization",
+			reqIDKey: "X-Request-ID",
+		},
+		{
+			name:     "optional api key skips auth header when empty",
+			apiKey:   "",
+			cfg:      AuthHeaderConfig{AuthScheme: "Bearer ", OptionalAPIKey: true},
+			authKey:  "Authorization",
+			wantAuth: "",
+		},
+		{
+			name:     "required api key still sets header when empty",
+			apiKey:   "",
+			cfg:      AuthHeaderConfig{AuthScheme: "Bearer "},
+			authKey:  "Authorization",
+			wantAuth: "Bearer ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.requestID != "" {
+				ctx = core.WithRequestID(ctx, tt.requestID)
+			}
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.com", nil)
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+
+			SetAuthHeaders(req, tt.apiKey, tt.cfg)
+
+			if got := req.Header.Get(tt.authKey); got != tt.wantAuth {
+				t.Errorf("auth header %q = %q, want %q", tt.authKey, got, tt.wantAuth)
+			}
+			if tt.reqIDKey != "" {
+				if got := req.Header.Get(tt.reqIDKey); got != tt.wantReqID {
+					t.Errorf("request id header %q = %q, want %q", tt.reqIDKey, got, tt.wantReqID)
+				}
+			}
+		})
+	}
+}

--- a/internal/providers/azure/azure.go
+++ b/internal/providers/azure/azure.go
@@ -97,9 +97,7 @@ func (p *Provider) CreateBatch(ctx context.Context, req *core.BatchRequest) (*co
 	}, &resp); err != nil {
 		return nil, err
 	}
-	if resp.ProviderBatchID == "" {
-		resp.ProviderBatchID = resp.ID
-	}
+	providers.EnsureProviderBatchID(&resp)
 	return &resp, nil
 }
 
@@ -111,9 +109,7 @@ func (p *Provider) GetBatch(ctx context.Context, id string) (*core.BatchResponse
 	}, &resp); err != nil {
 		return nil, err
 	}
-	if resp.ProviderBatchID == "" {
-		resp.ProviderBatchID = resp.ID
-	}
+	providers.EnsureProviderBatchID(&resp)
 	return &resp, nil
 }
 
@@ -138,11 +134,7 @@ func (p *Provider) ListBatches(ctx context.Context, limit int, after string) (*c
 	}, &resp); err != nil {
 		return nil, err
 	}
-	for i := range resp.Data {
-		if resp.Data[i].ProviderBatchID == "" {
-			resp.Data[i].ProviderBatchID = resp.Data[i].ID
-		}
-	}
+	providers.EnsureProviderBatchIDs(&resp)
 	return &resp, nil
 }
 
@@ -154,9 +146,7 @@ func (p *Provider) CancelBatch(ctx context.Context, id string) (*core.BatchRespo
 	}, &resp); err != nil {
 		return nil, err
 	}
-	if resp.ProviderBatchID == "" {
-		resp.ProviderBatchID = resp.ID
-	}
+	providers.EnsureProviderBatchID(&resp)
 	return &resp, nil
 }
 
@@ -183,10 +173,11 @@ func (p *Provider) mutateRequest(req *llmclient.Request) {
 }
 
 func setHeaders(req *http.Request, apiKey string) {
-	req.Header.Set("api-key", apiKey)
-	if requestID := core.GetRequestID(req.Context()); requestID != "" && isValidClientRequestID(requestID) {
-		req.Header.Set("X-Client-Request-Id", requestID)
-	}
+	providers.SetAuthHeaders(req, apiKey, providers.AuthHeaderConfig{
+		AuthHeader:        "api-key",
+		RequestIDHeader:   "X-Client-Request-Id",
+		ValidateRequestID: isValidClientRequestID,
+	})
 }
 
 func isValidClientRequestID(id string) bool {

--- a/internal/providers/batch_identity.go
+++ b/internal/providers/batch_identity.go
@@ -1,0 +1,23 @@
+package providers
+
+import "gomodel/internal/core"
+
+// EnsureProviderBatchID defaults the provider-facing batch ID to the response ID
+// when an OpenAI-compatible upstream does not return a distinct one. No-op for a
+// nil response or one that already carries a provider batch ID.
+func EnsureProviderBatchID(resp *core.BatchResponse) {
+	if resp != nil && resp.ProviderBatchID == "" {
+		resp.ProviderBatchID = resp.ID
+	}
+}
+
+// EnsureProviderBatchIDs applies EnsureProviderBatchID to every batch in a list
+// response.
+func EnsureProviderBatchIDs(resp *core.BatchListResponse) {
+	if resp == nil {
+		return
+	}
+	for i := range resp.Data {
+		EnsureProviderBatchID(&resp.Data[i])
+	}
+}

--- a/internal/providers/batch_identity_test.go
+++ b/internal/providers/batch_identity_test.go
@@ -1,0 +1,48 @@
+package providers
+
+import (
+	"testing"
+
+	"gomodel/internal/core"
+)
+
+func TestEnsureProviderBatchID(t *testing.T) {
+	t.Run("defaults to id when empty", func(t *testing.T) {
+		resp := &core.BatchResponse{ID: "batch_1"}
+		EnsureProviderBatchID(resp)
+		if resp.ProviderBatchID != "batch_1" {
+			t.Errorf("ProviderBatchID = %q, want %q", resp.ProviderBatchID, "batch_1")
+		}
+	})
+
+	t.Run("preserves existing provider id", func(t *testing.T) {
+		resp := &core.BatchResponse{ID: "batch_1", ProviderBatchID: "upstream_9"}
+		EnsureProviderBatchID(resp)
+		if resp.ProviderBatchID != "upstream_9" {
+			t.Errorf("ProviderBatchID = %q, want %q", resp.ProviderBatchID, "upstream_9")
+		}
+	})
+
+	t.Run("nil is a no-op", func(t *testing.T) {
+		EnsureProviderBatchID(nil) // must not panic
+	})
+}
+
+func TestEnsureProviderBatchIDs(t *testing.T) {
+	resp := &core.BatchListResponse{
+		Data: []core.BatchResponse{
+			{ID: "batch_1"},
+			{ID: "batch_2", ProviderBatchID: "upstream_2"},
+		},
+	}
+	EnsureProviderBatchIDs(resp)
+
+	if resp.Data[0].ProviderBatchID != "batch_1" {
+		t.Errorf("Data[0].ProviderBatchID = %q, want %q", resp.Data[0].ProviderBatchID, "batch_1")
+	}
+	if resp.Data[1].ProviderBatchID != "upstream_2" {
+		t.Errorf("Data[1].ProviderBatchID = %q, want %q", resp.Data[1].ProviderBatchID, "upstream_2")
+	}
+
+	EnsureProviderBatchIDs(nil) // must not panic
+}

--- a/internal/providers/deepseek/deepseek.go
+++ b/internal/providers/deepseek/deepseek.go
@@ -66,10 +66,10 @@ func (p *Provider) SetBaseURL(url string) {
 }
 
 func (p *Provider) setHeaders(req *http.Request) {
-	req.Header.Set("Authorization", "Bearer "+p.apiKey)
-	if requestID := core.GetRequestID(req.Context()); requestID != "" {
-		req.Header.Set("X-Request-Id", requestID)
-	}
+	providers.SetAuthHeaders(req, p.apiKey, providers.AuthHeaderConfig{
+		AuthScheme:      "Bearer ",
+		RequestIDHeader: "X-Request-Id",
+	})
 }
 
 // adaptChatRequest rewrites GoModel's common reasoning shape into DeepSeek's

--- a/internal/providers/gemini/gemini.go
+++ b/internal/providers/gemini/gemini.go
@@ -708,9 +708,7 @@ func (p *Provider) CreateBatch(ctx context.Context, req *core.BatchRequest) (*co
 	if err != nil {
 		return nil, err
 	}
-	if resp.ProviderBatchID == "" {
-		resp.ProviderBatchID = resp.ID
-	}
+	providers.EnsureProviderBatchID(&resp)
 	return &resp, nil
 }
 
@@ -727,9 +725,7 @@ func (p *Provider) GetBatch(ctx context.Context, id string) (*core.BatchResponse
 	if err != nil {
 		return nil, err
 	}
-	if resp.ProviderBatchID == "" {
-		resp.ProviderBatchID = resp.ID
-	}
+	providers.EnsureProviderBatchID(&resp)
 	return &resp, nil
 }
 
@@ -758,11 +754,7 @@ func (p *Provider) ListBatches(ctx context.Context, limit int, after string) (*c
 	if err != nil {
 		return nil, err
 	}
-	for i := range resp.Data {
-		if resp.Data[i].ProviderBatchID == "" {
-			resp.Data[i].ProviderBatchID = resp.Data[i].ID
-		}
-	}
+	providers.EnsureProviderBatchIDs(&resp)
 	return &resp, nil
 }
 
@@ -779,9 +771,7 @@ func (p *Provider) CancelBatch(ctx context.Context, id string) (*core.BatchRespo
 	if err != nil {
 		return nil, err
 	}
-	if resp.ProviderBatchID == "" {
-		resp.ProviderBatchID = resp.ID
-	}
+	providers.EnsureProviderBatchID(&resp)
 	return &resp, nil
 }
 

--- a/internal/providers/groq/groq.go
+++ b/internal/providers/groq/groq.go
@@ -66,12 +66,10 @@ func (p *Provider) SetBaseURL(url string) {
 
 // setHeaders sets the required headers for Groq API requests
 func (p *Provider) setHeaders(req *http.Request) {
-	req.Header.Set("Authorization", "Bearer "+p.apiKey)
-
-	// Forward request ID if present in context
-	if requestID := core.GetRequestID(req.Context()); requestID != "" {
-		req.Header.Set("X-Request-ID", requestID)
-	}
+	providers.SetAuthHeaders(req, p.apiKey, providers.AuthHeaderConfig{
+		AuthScheme:      "Bearer ",
+		RequestIDHeader: "X-Request-ID",
+	})
 }
 
 // ChatCompletion sends a chat completion request to Groq
@@ -151,9 +149,7 @@ func (p *Provider) CreateBatch(ctx context.Context, req *core.BatchRequest) (*co
 	if err != nil {
 		return nil, err
 	}
-	if resp.ProviderBatchID == "" {
-		resp.ProviderBatchID = resp.ID
-	}
+	providers.EnsureProviderBatchID(&resp)
 	return &resp, nil
 }
 
@@ -167,9 +163,7 @@ func (p *Provider) GetBatch(ctx context.Context, id string) (*core.BatchResponse
 	if err != nil {
 		return nil, err
 	}
-	if resp.ProviderBatchID == "" {
-		resp.ProviderBatchID = resp.ID
-	}
+	providers.EnsureProviderBatchID(&resp)
 	return &resp, nil
 }
 
@@ -195,11 +189,7 @@ func (p *Provider) ListBatches(ctx context.Context, limit int, after string) (*c
 	if err != nil {
 		return nil, err
 	}
-	for i := range resp.Data {
-		if resp.Data[i].ProviderBatchID == "" {
-			resp.Data[i].ProviderBatchID = resp.Data[i].ID
-		}
-	}
+	providers.EnsureProviderBatchIDs(&resp)
 	return &resp, nil
 }
 
@@ -213,9 +203,7 @@ func (p *Provider) CancelBatch(ctx context.Context, id string) (*core.BatchRespo
 	if err != nil {
 		return nil, err
 	}
-	if resp.ProviderBatchID == "" {
-		resp.ProviderBatchID = resp.ID
-	}
+	providers.EnsureProviderBatchID(&resp)
 	return &resp, nil
 }
 

--- a/internal/providers/minimax/minimax.go
+++ b/internal/providers/minimax/minimax.go
@@ -63,7 +63,7 @@ func (p *Provider) SetBaseURL(url string) {
 }
 
 func setHeaders(req *http.Request, apiKey string) {
-	req.Header.Set("Authorization", "Bearer "+apiKey)
+	providers.SetAuthHeaders(req, apiKey, providers.AuthHeaderConfig{AuthScheme: "Bearer "})
 }
 
 // clampTemperature returns the request with temperature clamped to (0.0, 1.0].

--- a/internal/providers/ollama/ollama.go
+++ b/internal/providers/ollama/ollama.go
@@ -100,15 +100,12 @@ func (p *Provider) CheckAvailability(ctx context.Context) error {
 
 // setHeaders sets the required headers for Ollama API requests
 func (p *Provider) setHeaders(req *http.Request) {
-	// Ollama doesn't require authentication, but accepts Bearer token if provided
-	if p.apiKey != "" {
-		req.Header.Set("Authorization", "Bearer "+p.apiKey)
-	}
-
-	// Forward request ID if present in context
-	if requestID := core.GetRequestID(req.Context()); requestID != "" {
-		req.Header.Set("X-Request-ID", requestID)
-	}
+	// Ollama doesn't require authentication, but accepts a Bearer token if provided.
+	providers.SetAuthHeaders(req, p.apiKey, providers.AuthHeaderConfig{
+		AuthScheme:      "Bearer ",
+		RequestIDHeader: "X-Request-ID",
+		OptionalAPIKey:  true,
+	})
 }
 
 // ChatCompletion sends a chat completion request to Ollama

--- a/internal/providers/openai/compatible_provider.go
+++ b/internal/providers/openai/compatible_provider.go
@@ -360,9 +360,7 @@ func (p *CompatibleProvider) CreateBatch(ctx context.Context, req *core.BatchReq
 	if err != nil {
 		return nil, err
 	}
-	if resp.ProviderBatchID == "" {
-		resp.ProviderBatchID = resp.ID
-	}
+	providers.EnsureProviderBatchID(&resp)
 	return &resp, nil
 }
 
@@ -375,9 +373,7 @@ func (p *CompatibleProvider) GetBatch(ctx context.Context, id string) (*core.Bat
 	if err != nil {
 		return nil, err
 	}
-	if resp.ProviderBatchID == "" {
-		resp.ProviderBatchID = resp.ID
-	}
+	providers.EnsureProviderBatchID(&resp)
 	return &resp, nil
 }
 
@@ -402,11 +398,7 @@ func (p *CompatibleProvider) ListBatches(ctx context.Context, limit int, after s
 	if err != nil {
 		return nil, err
 	}
-	for i := range resp.Data {
-		if resp.Data[i].ProviderBatchID == "" {
-			resp.Data[i].ProviderBatchID = resp.Data[i].ID
-		}
-	}
+	providers.EnsureProviderBatchIDs(&resp)
 	return &resp, nil
 }
 
@@ -419,9 +411,7 @@ func (p *CompatibleProvider) CancelBatch(ctx context.Context, id string) (*core.
 	if err != nil {
 		return nil, err
 	}
-	if resp.ProviderBatchID == "" {
-		resp.ProviderBatchID = resp.ID
-	}
+	providers.EnsureProviderBatchID(&resp)
 	return &resp, nil
 }
 

--- a/internal/providers/openai/openai.go
+++ b/internal/providers/openai/openai.go
@@ -54,15 +54,15 @@ func NewWithHTTPClient(apiKey string, httpClient *http.Client, hooks llmclient.H
 	}
 }
 
-// setHeaders sets the required headers for OpenAI API requests
+// setHeaders sets the required headers for OpenAI API requests.
+// OpenAI requires the request ID to be ASCII-only and at most 512 bytes,
+// otherwise it returns 400, so forwarding is gated by isValidClientRequestID.
 func setHeaders(req *http.Request, apiKey string) {
-	req.Header.Set("Authorization", "Bearer "+apiKey)
-
-	// Forward request ID if present in context using OpenAI's X-Client-Request-Id header.
-	// OpenAI requires ASCII-only characters and max 512 bytes, otherwise returns 400.
-	if requestID := core.GetRequestID(req.Context()); requestID != "" && isValidClientRequestID(requestID) {
-		req.Header.Set("X-Client-Request-Id", requestID)
-	}
+	providers.SetAuthHeaders(req, apiKey, providers.AuthHeaderConfig{
+		AuthScheme:        "Bearer ",
+		RequestIDHeader:   "X-Client-Request-Id",
+		ValidateRequestID: isValidClientRequestID,
+	})
 }
 
 // isValidClientRequestID checks if the request ID is valid for OpenAI's X-Client-Request-Id header.

--- a/internal/providers/openrouter/openrouter.go
+++ b/internal/providers/openrouter/openrouter.go
@@ -76,10 +76,11 @@ func (p *Provider) mutateRequest(req *llmclient.Request) {
 }
 
 func setHeaders(req *http.Request, apiKey string) {
-	req.Header.Set("Authorization", "Bearer "+apiKey)
-	if requestID := core.GetRequestID(req.Context()); requestID != "" && isValidClientRequestID(requestID) {
-		req.Header.Set("X-Client-Request-Id", requestID)
-	}
+	providers.SetAuthHeaders(req, apiKey, providers.AuthHeaderConfig{
+		AuthScheme:        "Bearer ",
+		RequestIDHeader:   "X-Client-Request-Id",
+		ValidateRequestID: isValidClientRequestID,
+	})
 }
 
 func envOrDefault(key, fallback string) string {

--- a/internal/providers/oracle/oracle.go
+++ b/internal/providers/oracle/oracle.go
@@ -75,5 +75,5 @@ func (p *Provider) Embeddings(_ context.Context, _ *core.EmbeddingRequest) (*cor
 }
 
 func setHeaders(req *http.Request, apiKey string) {
-	req.Header.Set("Authorization", "Bearer "+apiKey)
+	providers.SetAuthHeaders(req, apiKey, providers.AuthHeaderConfig{AuthScheme: "Bearer "})
 }

--- a/internal/providers/router.go
+++ b/internal/providers/router.go
@@ -385,52 +385,49 @@ func (r *Router) ensureProviderInventoryReady() error {
 	return nil
 }
 
+// assertProviderCapability narrows a resolved provider to capability T. It
+// propagates any resolution error unchanged and, when the provider does not
+// implement T, returns the error built by unsupported.
+func assertProviderCapability[T any](provider core.Provider, err error, unsupported func() error) (T, error) {
+	var capability T
+	if err != nil {
+		return capability, err
+	}
+	capability, ok := provider.(T)
+	if !ok {
+		return capability, unsupported()
+	}
+	return capability, nil
+}
+
 func (r *Router) resolveNativeBatchProvider(providerType string) (core.NativeBatchProvider, error) {
 	provider, err := r.resolveProviderType(providerType)
-	if err != nil {
-		return nil, err
-	}
-	bp, ok := provider.(core.NativeBatchProvider)
-	if !ok {
-		return nil, core.NewInvalidRequestError(fmt.Sprintf("%s does not support native batch processing", providerType), nil)
-	}
-	return bp, nil
+	return assertProviderCapability[core.NativeBatchProvider](provider, err, func() error {
+		return core.NewInvalidRequestError(fmt.Sprintf("%s does not support native batch processing", providerType), nil)
+	})
 }
 
 func (r *Router) resolveNativeFileProvider(providerType string) (core.NativeFileProvider, error) {
 	provider, err := r.resolveProviderType(providerType)
-	if err != nil {
-		return nil, err
-	}
-	fp, ok := provider.(core.NativeFileProvider)
-	if !ok {
-		return nil, core.NewInvalidRequestError(fmt.Sprintf("%s does not support native file operations", providerType), nil)
-	}
-	return fp, nil
+	return assertProviderCapability[core.NativeFileProvider](provider, err, func() error {
+		return core.NewInvalidRequestError(fmt.Sprintf("%s does not support native file operations", providerType), nil)
+	})
 }
 
 func (r *Router) resolveNativeResponseLifecycleProvider(providerType string) (core.NativeResponseLifecycleProvider, string, error) {
 	provider, resolvedProviderType, err := r.resolveProviderSelector(providerType)
-	if err != nil {
-		return nil, "", err
-	}
-	rp, ok := provider.(core.NativeResponseLifecycleProvider)
-	if !ok {
-		return nil, "", unsupportedNativeResponseOperation(fmt.Sprintf("%s does not support native response lifecycle operations", providerType))
-	}
-	return rp, resolvedProviderType, nil
+	rp, err := assertProviderCapability[core.NativeResponseLifecycleProvider](provider, err, func() error {
+		return unsupportedNativeResponseOperation(fmt.Sprintf("%s does not support native response lifecycle operations", providerType))
+	})
+	return rp, resolvedProviderType, err
 }
 
 func (r *Router) resolveNativeResponseUtilityProvider(providerType string) (core.NativeResponseUtilityProvider, string, error) {
 	provider, resolvedProviderType, err := r.resolveProviderSelector(providerType)
-	if err != nil {
-		return nil, "", err
-	}
-	rp, ok := provider.(core.NativeResponseUtilityProvider)
-	if !ok {
-		return nil, "", unsupportedNativeResponseOperation(fmt.Sprintf("%s does not support native response utility operations", providerType))
-	}
-	return rp, resolvedProviderType, nil
+	rp, err := assertProviderCapability[core.NativeResponseUtilityProvider](provider, err, func() error {
+		return unsupportedNativeResponseOperation(fmt.Sprintf("%s does not support native response utility operations", providerType))
+	})
+	return rp, resolvedProviderType, err
 }
 
 func unsupportedNativeResponseOperation(message string) *core.GatewayError {
@@ -439,14 +436,9 @@ func unsupportedNativeResponseOperation(message string) *core.GatewayError {
 
 func (r *Router) resolvePassthroughProvider(providerType string) (core.PassthroughProvider, error) {
 	provider, err := r.resolveProviderType(providerType)
-	if err != nil {
-		return nil, err
-	}
-	pp, ok := provider.(core.PassthroughProvider)
-	if !ok {
-		return nil, core.NewInvalidRequestError(fmt.Sprintf("%s does not support provider passthrough", providerType), nil)
-	}
-	return pp, nil
+	return assertProviderCapability[core.PassthroughProvider](provider, err, func() error {
+		return core.NewInvalidRequestError(fmt.Sprintf("%s does not support provider passthrough", providerType), nil)
+	})
 }
 
 func routeResolvedModelCall[Req any, Resp any](

--- a/internal/providers/vllm/vllm.go
+++ b/internal/providers/vllm/vllm.go
@@ -79,12 +79,11 @@ func (p *Provider) SetBaseURL(url string) {
 }
 
 func setHeaders(req *http.Request, apiKey string) {
-	if apiKey != "" {
-		req.Header.Set("Authorization", "Bearer "+apiKey)
-	}
-	if requestID := core.GetRequestID(req.Context()); requestID != "" {
-		req.Header.Set("X-Request-Id", requestID)
-	}
+	providers.SetAuthHeaders(req, apiKey, providers.AuthHeaderConfig{
+		AuthScheme:      "Bearer ",
+		RequestIDHeader: "X-Request-Id",
+		OptionalAPIKey:  true,
+	})
 }
 
 // ChatCompletion sends a chat completion request to vLLM.

--- a/internal/providers/xai/xai.go
+++ b/internal/providers/xai/xai.go
@@ -71,12 +71,10 @@ func (p *Provider) SetBaseURL(url string) {
 
 // setHeaders sets the required headers for xAI API requests
 func (p *Provider) setHeaders(req *http.Request) {
-	req.Header.Set("Authorization", "Bearer "+p.apiKey)
-
-	// Forward request ID if present in context
-	if requestID := core.GetRequestID(req.Context()); requestID != "" {
-		req.Header.Set("X-Request-ID", requestID)
-	}
+	providers.SetAuthHeaders(req, p.apiKey, providers.AuthHeaderConfig{
+		AuthScheme:      "Bearer ",
+		RequestIDHeader: "X-Request-ID",
+	})
 }
 
 type grokConversationAnchor struct {
@@ -273,9 +271,7 @@ func (p *Provider) CreateBatch(ctx context.Context, req *core.BatchRequest) (*co
 	if err != nil {
 		return nil, err
 	}
-	if resp.ProviderBatchID == "" {
-		resp.ProviderBatchID = resp.ID
-	}
+	providers.EnsureProviderBatchID(&resp)
 	return &resp, nil
 }
 
@@ -289,9 +285,7 @@ func (p *Provider) GetBatch(ctx context.Context, id string) (*core.BatchResponse
 	if err != nil {
 		return nil, err
 	}
-	if resp.ProviderBatchID == "" {
-		resp.ProviderBatchID = resp.ID
-	}
+	providers.EnsureProviderBatchID(&resp)
 	return &resp, nil
 }
 
@@ -317,11 +311,7 @@ func (p *Provider) ListBatches(ctx context.Context, limit int, after string) (*c
 	if err != nil {
 		return nil, err
 	}
-	for i := range resp.Data {
-		if resp.Data[i].ProviderBatchID == "" {
-			resp.Data[i].ProviderBatchID = resp.Data[i].ID
-		}
-	}
+	providers.EnsureProviderBatchIDs(&resp)
 	return &resp, nil
 }
 
@@ -335,9 +325,7 @@ func (p *Provider) CancelBatch(ctx context.Context, id string) (*core.BatchRespo
 	if err != nil {
 		return nil, err
 	}
-	if resp.ProviderBatchID == "" {
-		resp.ProviderBatchID = resp.ID
-	}
+	providers.EnsureProviderBatchID(&resp)
 	return &resp, nil
 }
 

--- a/internal/providers/zai/zai.go
+++ b/internal/providers/zai/zai.go
@@ -59,7 +59,7 @@ func (p *Provider) SetBaseURL(url string) {
 }
 
 func setHeaders(req *http.Request, apiKey string) {
-	req.Header.Set("Authorization", "Bearer "+apiKey)
+	providers.SetAuthHeaders(req, apiKey, providers.AuthHeaderConfig{AuthScheme: "Bearer "})
 }
 
 // ChatCompletion sends a chat completion request to Z.ai.


### PR DESCRIPTION
## What

Removes duplicated provider boilerplate. **No user-visible behavior change** — pure internal refactor.

### Changes

1. **`providers.SetAuthHeaders`** (`auth_headers.go`) — the 11 OpenAI-compatible providers (openai, azure, deepseek, groq, minimax, ollama, openrouter, oracle, vllm, xai, zai) each reimplemented Bearer-token + request-ID header logic with small variations. They now call one helper and declare only their differences as data: auth header name (`api-key` vs `Authorization`), scheme, request-ID header name, optional ASCII/length validator, and optional-key behavior.

2. **`providers.EnsureProviderBatchID` / `EnsureProviderBatchIDs`** (`batch_identity.go`) — replace ~20 copies of the `if resp.ProviderBatchID == "" { resp.ProviderBatchID = resp.ID }` fallback across openai-compat, azure, gemini, groq, and xai.

3. **`assertProviderCapability[T]`** (`router.go`) — the five `resolve*Provider` methods (batch, file, response lifecycle, response utility, passthrough) shared the same resolve → type-assert → typed-error shape. They now route through one generic helper, keeping their exact signatures and error messages.

### Deliberate non-changes
- Anthropic's *unconditional* `mapped.ProviderBatchID = mapped.ID` is left alone (different semantics).
- Each provider's exact header quirks (header names, validation) are preserved.

### Design note
Helpers live in the `providers` package, not `core` — keeping `core` a behavior-free leaf and provider normalization policy isolated in the provider layer (per CLAUDE.md).

## Testing
- Added table-driven tests for both helpers (`auth_headers_test.go`, `batch_identity_test.go`).
- `go build ./...`, `go vet`, `golangci-lint`, and `make test-race` all pass.
- Net: **+167 / -158** across 18 files (4 new, including tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized authentication header handling across multiple AI provider integrations for improved consistency.
  * Centralized batch ID assignment logic to reduce code duplication across providers.
  * Streamlined provider capability validation through shared utility functions.

* **Tests**
  * Added comprehensive unit tests for new authentication and batch ID handling utilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ENTERPILOT/GoModel/pull/361?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->