### PR TITLE
feat(usage): track and cost STT/TTS interactions

### DIFF
--- a/internal/server/audio_service.go
+++ b/internal/server/audio_service.go
@@ -74,8 +74,11 @@ func (s *audioService) CreateSpeech(c *echo.Context) error {
 	if err != nil {
 		return handleError(c, err)
 	}
+	if resp == nil {
+		return s.respondAudio(c, resp) // emits the 502 guard; no usage for a failed call
+	}
 	s.logUsage(ctx, route, func(pricing *core.ModelPricing) *usage.UsageEntry {
-		return usage.ExtractFromSpeechRequest(req, route.requestID, route.providerType, pricing)
+		return usage.ExtractFromSpeechRequest(req.Input, route.requestID, route.model, route.providerType, pricing)
 	})
 	return s.respondAudio(c, resp)
 }
@@ -107,6 +110,9 @@ func (s *audioService) CreateTranscription(c *echo.Context) error {
 	resp, err := router.CreateTranscription(ctx, req)
 	if err != nil {
 		return handleError(c, err)
+	}
+	if resp == nil {
+		return s.respondAudio(c, resp) // emits the 502 guard before resp.Data is read
 	}
 	s.logUsage(ctx, route, func(pricing *core.ModelPricing) *usage.UsageEntry {
 		return usage.ExtractFromTranscriptionResponse(resp.Data, route.requestID, route.model, route.providerType, pricing)

--- a/internal/server/audio_service.go
+++ b/internal/server/audio_service.go
@@ -11,6 +11,7 @@ import (
 
 	"gomodel/internal/auditlog"
 	"gomodel/internal/core"
+	"gomodel/internal/usage"
 )
 
 // audioService adapts Echo requests to the model-routed audio provider for the
@@ -28,6 +29,11 @@ type audioService struct {
 	// base64 (playable) or as a lightweight placeholder.
 	logBodies      bool
 	logAudioBodies bool
+	// usageLogger and pricingResolver record per-call usage. Audio providers
+	// return opaque bytes, so usage is derived locally: input characters for
+	// speech, and the optional usage object parsed from a transcription response.
+	usageLogger     usage.LoggerInterface
+	pricingResolver usage.PricingResolver
 }
 
 func (s *audioService) router() (core.AudioProvider, error) {
@@ -60,7 +66,7 @@ func (s *audioService) CreateSpeech(c *echo.Context) error {
 		auditlog.EnrichEntryWithRequestBody(c, audioSpeechAuditInput(req))
 	}
 
-	ctx, err := s.prepare(c, req.Model, req.Provider)
+	ctx, route, err := s.prepare(c, req.Model, req.Provider)
 	if err != nil {
 		return handleError(c, err)
 	}
@@ -68,6 +74,9 @@ func (s *audioService) CreateSpeech(c *echo.Context) error {
 	if err != nil {
 		return handleError(c, err)
 	}
+	s.logUsage(ctx, route, func(pricing *core.ModelPricing) *usage.UsageEntry {
+		return usage.ExtractFromSpeechRequest(req, route.requestID, route.providerType, pricing)
+	})
 	return s.respondAudio(c, resp)
 }
 
@@ -91,7 +100,7 @@ func (s *audioService) CreateTranscription(c *echo.Context) error {
 			audioUploadContentType(req), req.File, s.logAudioBodies, audioTranscriptionAuditInput(req)))
 	}
 
-	ctx, err := s.prepare(c, req.Model, req.Provider)
+	ctx, route, err := s.prepare(c, req.Model, req.Provider)
 	if err != nil {
 		return handleError(c, err)
 	}
@@ -99,6 +108,9 @@ func (s *audioService) CreateTranscription(c *echo.Context) error {
 	if err != nil {
 		return handleError(c, err)
 	}
+	s.logUsage(ctx, route, func(pricing *core.ModelPricing) *usage.UsageEntry {
+		return usage.ExtractFromTranscriptionResponse(resp.Data, route.requestID, route.model, route.providerType, pricing)
+	})
 	return s.respondAudio(c, resp)
 }
 
@@ -109,14 +121,23 @@ type selectorResolver interface {
 	ResolveModel(core.RequestedModelSelector) (core.ModelSelector, bool, error)
 }
 
+// audioRoute carries the resolved routing identity for a single audio call,
+// used to label its usage entry the same way the inference orchestrator does.
+type audioRoute struct {
+	model        string
+	providerType string
+	providerName string
+	requestID    string
+}
+
 // prepare resolves and authorizes the model, enforces budget, and stamps the
-// request id, returning the context to dispatch with. Authorization runs on the
-// registry-resolved selector so model-override and user-path rules see the same
-// concrete provider name as the inference orchestrator.
-func (s *audioService) prepare(c *echo.Context, model, providerHint string) (context.Context, error) {
+// request id, returning the context to dispatch with and the resolved route.
+// Authorization runs on the registry-resolved selector so model-override and
+// user-path rules see the same concrete provider name as the inference orchestrator.
+func (s *audioService) prepare(c *echo.Context, model, providerHint string) (context.Context, audioRoute, error) {
 	selector, err := core.ParseModelSelector(model, providerHint)
 	if err != nil {
-		return nil, core.NewInvalidRequestError(err.Error(), err)
+		return nil, audioRoute{}, core.NewInvalidRequestError(err.Error(), err)
 	}
 	if resolver, ok := s.provider.(selectorResolver); ok {
 		// Surface resolution failures (registry not ready, malformed selector)
@@ -125,23 +146,66 @@ func (s *audioService) prepare(c *echo.Context, model, providerHint string) (con
 		// equals the normalized selector, so it is always safe to adopt.
 		resolved, _, resolveErr := resolver.ResolveModel(core.NewRequestedModelSelector(model, providerHint))
 		if resolveErr != nil {
-			return nil, resolveErr
+			return nil, audioRoute{}, resolveErr
 		}
 		selector = resolved
 	}
 	if s.modelAuthorizer != nil {
 		if err := s.modelAuthorizer.ValidateModelAccess(c.Request().Context(), selector); err != nil {
-			return nil, err
+			return nil, audioRoute{}, err
 		}
 	}
 	if err := enforceBudget(c, s.budgetChecker); err != nil {
-		return nil, err
+		return nil, audioRoute{}, err
 	}
 	auditlog.EnrichEntry(c, selector.Model, "")
 
-	ctx, _ := requestContextWithRequestID(c.Request())
+	ctx, requestID := requestContextWithRequestID(c.Request())
 	c.SetRequest(c.Request().WithContext(ctx))
-	return ctx, nil
+	return ctx, s.routeFor(selector, requestID), nil
+}
+
+// routeFor maps a resolved selector to its canonical provider type and concrete
+// instance name. The name falls back to the selector's provider when the router
+// exposes no name resolver.
+func (s *audioService) routeFor(selector core.ModelSelector, requestID string) audioRoute {
+	qualified := selector.QualifiedModel()
+	route := audioRoute{
+		model:        selector.Model,
+		providerType: s.provider.GetProviderType(qualified),
+		providerName: selector.Provider,
+		requestID:    requestID,
+	}
+	if resolver, ok := s.provider.(core.ProviderNameResolver); ok {
+		if name := resolver.GetProviderName(qualified); name != "" {
+			route.providerName = name
+		}
+	}
+	return route
+}
+
+// logUsage records one usage entry for an audio call when usage tracking is on.
+// It mirrors the inference orchestrator: resolve pricing, extract the entry, then
+// stamp the concrete provider name and user path before the non-blocking write.
+func (s *audioService) logUsage(ctx context.Context, route audioRoute, extract func(*core.ModelPricing) *usage.UsageEntry) {
+	if s.usageLogger == nil || !s.usageLogger.Config().Enabled {
+		return
+	}
+	var pricing *core.ModelPricing
+	if s.pricingResolver != nil {
+		pricingProvider := route.providerName
+		if pricingProvider == "" {
+			pricingProvider = route.providerType
+		}
+		pricing = s.pricingResolver.ResolvePricing(route.model, pricingProvider)
+	}
+	entry := extract(pricing)
+	if entry == nil {
+		return
+	}
+	entry.ProviderName = strings.TrimSpace(route.providerName)
+	entry.UserPath = core.UserPathFromContext(ctx)
+	s.usageLogger.Write(entry)
 }
 
 func transcriptionRequestFromForm(c *echo.Context) (*core.AudioTranscriptionRequest, error) {

--- a/internal/server/audio_service_test.go
+++ b/internal/server/audio_service_test.go
@@ -14,6 +14,7 @@ import (
 
 	"gomodel/internal/auditlog"
 	"gomodel/internal/core"
+	"gomodel/internal/usage"
 )
 
 // audioMockProvider extends mockProvider (a RoutableProvider) with audio support
@@ -320,6 +321,78 @@ func TestAudioTranscription_NoCaptureWhenBodiesDisabled(t *testing.T) {
 	}
 	if entry.Data != nil && entry.Data.RequestBody != nil {
 		t.Errorf("nothing should be captured when LogBodies is off, got %+v", entry.Data.RequestBody)
+	}
+}
+
+// TestAudioSpeech_LogsUsage verifies a text-to-speech call records a usage entry
+// keyed by the input character count when usage tracking is enabled.
+func TestAudioSpeech_LogsUsage(t *testing.T) {
+	var captured *usage.UsageEntry
+	logger := &capturingUsageLogger{config: usage.Config{Enabled: true}, captured: &captured}
+	svc := &audioService{provider: newSpeechMock(), usageLogger: logger}
+	c, rec, _ := newSpeechRequestWithAuditEntry()
+
+	if err := svc.CreateSpeech(c); err != nil {
+		t.Fatalf("CreateSpeech returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if captured == nil {
+		t.Fatal("expected a usage entry to be written")
+	}
+	if captured.Endpoint != "/v1/audio/speech" {
+		t.Errorf("endpoint = %q, want /v1/audio/speech", captured.Endpoint)
+	}
+	if captured.Model != "gpt-4o-mini-tts" {
+		t.Errorf("model = %q, want gpt-4o-mini-tts", captured.Model)
+	}
+	if got := captured.RawData["input_characters"]; got != len("hello") {
+		t.Errorf("input_characters = %v, want %d", got, len("hello"))
+	}
+}
+
+// TestAudioTranscription_LogsUsage verifies a speech-to-text call records a usage
+// entry even when the provider response carries no usage object (e.g. whisper).
+func TestAudioTranscription_LogsUsage(t *testing.T) {
+	var captured *usage.UsageEntry
+	logger := &capturingUsageLogger{config: usage.Config{Enabled: true}, captured: &captured}
+	svc := &audioService{provider: newTranscriptionMock(), usageLogger: logger}
+	c, rec, _ := newTranscriptionRequestWithAuditEntry("speech.mp3", []byte("audio-bytes"))
+
+	if err := svc.CreateTranscription(c); err != nil {
+		t.Fatalf("CreateTranscription returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if captured == nil {
+		t.Fatal("expected a usage entry to be written")
+	}
+	if captured.Endpoint != "/v1/audio/transcriptions" {
+		t.Errorf("endpoint = %q, want /v1/audio/transcriptions", captured.Endpoint)
+	}
+	if captured.Model != "gpt-4o-transcribe" {
+		t.Errorf("model = %q, want gpt-4o-transcribe", captured.Model)
+	}
+}
+
+// TestAudioSpeech_NoUsageWhenDisabled verifies nothing is written when usage
+// tracking is off.
+func TestAudioSpeech_NoUsageWhenDisabled(t *testing.T) {
+	var captured *usage.UsageEntry
+	logger := &capturingUsageLogger{config: usage.Config{Enabled: false}, captured: &captured}
+	svc := &audioService{provider: newSpeechMock(), usageLogger: logger}
+	c, rec, _ := newSpeechRequestWithAuditEntry()
+
+	if err := svc.CreateSpeech(c); err != nil {
+		t.Fatalf("CreateSpeech returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if captured != nil {
+		t.Errorf("no usage entry should be written when disabled, got %+v", captured)
 	}
 }
 

--- a/internal/server/audio_service_test.go
+++ b/internal/server/audio_service_test.go
@@ -566,6 +566,52 @@ func TestAudioSpeech_NilResponseReturns502(t *testing.T) {
 	}
 }
 
+// TestAudio_NilResponseSkipsUsage covers the nil-response guard: a (nil, nil)
+// provider result must return 502 without writing a usage row — and for
+// transcription, without dereferencing resp.Data (which would panic).
+func TestAudio_NilResponseSkipsUsage(t *testing.T) {
+	t.Run("speech", func(t *testing.T) {
+		var captured *usage.UsageEntry
+		logger := &capturingUsageLogger{config: usage.Config{Enabled: true}, captured: &captured}
+		svc := &audioService{
+			provider:    &audioMockProvider{mockProvider: &mockProvider{supportedModels: []string{"gpt-4o-mini-tts"}}, speechResp: nil},
+			usageLogger: logger,
+		}
+		c, rec, _ := newSpeechRequestWithAuditEntry()
+
+		if err := svc.CreateSpeech(c); err != nil {
+			t.Fatalf("CreateSpeech returned error: %v", err)
+		}
+		if rec.Code != http.StatusBadGateway {
+			t.Fatalf("status = %d, want 502", rec.Code)
+		}
+		if captured != nil {
+			t.Errorf("no usage should be written for a failed call, got %+v", captured)
+		}
+	})
+
+	t.Run("transcription", func(t *testing.T) {
+		var captured *usage.UsageEntry
+		logger := &capturingUsageLogger{config: usage.Config{Enabled: true}, captured: &captured}
+		svc := &audioService{
+			provider:    &audioMockProvider{mockProvider: &mockProvider{supportedModels: []string{"gpt-4o-transcribe"}}, transcriptionResp: nil},
+			usageLogger: logger,
+		}
+		c, rec, _ := newTranscriptionRequestWithAuditEntry("speech.mp3", []byte("audio-bytes"))
+
+		// Must not panic on resp.Data when resp is nil.
+		if err := svc.CreateTranscription(c); err != nil {
+			t.Fatalf("CreateTranscription returned error: %v", err)
+		}
+		if rec.Code != http.StatusBadGateway {
+			t.Fatalf("status = %d, want 502", rec.Code)
+		}
+		if captured != nil {
+			t.Errorf("no usage should be written for a failed call, got %+v", captured)
+		}
+	})
+}
+
 // TestAudioSpeech_EmptyContentTypeDefaults covers the respondAudio default: an
 // empty response content type falls back to application/octet-stream.
 func TestAudioSpeech_EmptyContentTypeDefaults(t *testing.T) {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -214,6 +214,8 @@ func (h *Handler) audio() *audioService {
 		budgetChecker:   h.budgetChecker,
 		logBodies:       logBodies,
 		logAudioBodies:  logAudioBodies,
+		usageLogger:     h.usageLogger,
+		pricingResolver: h.pricingResolver,
 	}
 }
 

--- a/internal/usage/audio.go
+++ b/internal/usage/audio.go
@@ -1,0 +1,93 @@
+package usage
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+
+	"gomodel/internal/core"
+)
+
+const (
+	endpointAudioSpeech         = "/v1/audio/speech"
+	endpointAudioTranscriptions = "/v1/audio/transcriptions"
+
+	// rawKeyInputCharacters and rawKeyAudioSeconds are the RawData keys that carry
+	// the non-token billable units audio providers do not report as tokens: input
+	// characters for text-to-speech and input audio duration for transcription.
+	// cost.go prices them via PerCharacterInput / PerSecondInput respectively.
+	rawKeyInputCharacters = "input_characters"
+	rawKeyAudioSeconds    = "audio_seconds"
+)
+
+// ExtractFromSpeechRequest builds a usage entry for a text-to-speech request.
+// Speech responses are binary audio with no provider-reported usage, so the
+// billable unit is the input character count, recorded in RawData so the
+// interaction stays observable and per-character pricing can apply.
+func ExtractFromSpeechRequest(req *core.AudioSpeechRequest, requestID, provider string, pricing ...*core.ModelPricing) *UsageEntry {
+	if req == nil {
+		return nil
+	}
+
+	entry := &UsageEntry{
+		ID:        uuid.New().String(),
+		RequestID: requestID,
+		Timestamp: time.Now().UTC(),
+		Model:     req.Model,
+		Provider:  provider,
+		Endpoint:  endpointAudioSpeech,
+	}
+	if chars := len([]rune(req.Input)); chars > 0 {
+		entry.RawData = map[string]any{rawKeyInputCharacters: chars}
+	}
+
+	applyUsageCosts(entry, provider, endpointAudioSpeech, pricing...)
+
+	return entry
+}
+
+// transcriptionUsage mirrors the optional usage object the gpt-4o transcription
+// models return. It is token-based or duration-based; whisper omits it entirely.
+type transcriptionUsage struct {
+	InputTokens  int     `json:"input_tokens"`
+	OutputTokens int     `json:"output_tokens"`
+	TotalTokens  int     `json:"total_tokens"`
+	Seconds      float64 `json:"seconds"`
+}
+
+// ExtractFromTranscriptionResponse builds a usage entry for a speech-to-text
+// request. The response body is proxied verbatim; when it is JSON it may carry a
+// usage object (token- or duration-based). The entry is always returned so the
+// interaction stays observable even when the provider reports no usage (whisper,
+// or non-JSON response formats such as text/srt/vtt).
+func ExtractFromTranscriptionResponse(body []byte, requestID, model, provider string, pricing ...*core.ModelPricing) *UsageEntry {
+	entry := &UsageEntry{
+		ID:        uuid.New().String(),
+		RequestID: requestID,
+		Timestamp: time.Now().UTC(),
+		Model:     model,
+		Provider:  provider,
+		Endpoint:  endpointAudioTranscriptions,
+	}
+
+	var parsed struct {
+		Usage *transcriptionUsage `json:"usage"`
+	}
+	if json.Unmarshal(body, &parsed) == nil && parsed.Usage != nil {
+		u := parsed.Usage
+		entry.InputTokens = u.InputTokens
+		entry.OutputTokens = u.OutputTokens
+		entry.TotalTokens = u.TotalTokens
+		if entry.TotalTokens == 0 {
+			entry.TotalTokens = u.InputTokens + u.OutputTokens
+		}
+		if u.Seconds > 0 {
+			entry.RawData = map[string]any{rawKeyAudioSeconds: u.Seconds}
+		}
+	}
+
+	applyUsageCosts(entry, provider, endpointAudioTranscriptions, pricing...)
+
+	return entry
+}

--- a/internal/usage/audio.go
+++ b/internal/usage/audio.go
@@ -24,21 +24,19 @@ const (
 // ExtractFromSpeechRequest builds a usage entry for a text-to-speech request.
 // Speech responses are binary audio with no provider-reported usage, so the
 // billable unit is the input character count, recorded in RawData so the
-// interaction stays observable and per-character pricing can apply.
-func ExtractFromSpeechRequest(req *core.AudioSpeechRequest, requestID, provider string, pricing ...*core.ModelPricing) *UsageEntry {
-	if req == nil {
-		return nil
-	}
-
+// interaction stays observable and per-character pricing can apply. model is the
+// resolved route model (not the raw user input) so the row groups and prices
+// consistently with the pricing lookup, mirroring the transcription extractor.
+func ExtractFromSpeechRequest(input, requestID, model, provider string, pricing ...*core.ModelPricing) *UsageEntry {
 	entry := &UsageEntry{
 		ID:        uuid.New().String(),
 		RequestID: requestID,
 		Timestamp: time.Now().UTC(),
-		Model:     req.Model,
+		Model:     model,
 		Provider:  provider,
 		Endpoint:  endpointAudioSpeech,
 	}
-	if chars := len([]rune(req.Input)); chars > 0 {
+	if chars := len([]rune(input)); chars > 0 {
 		entry.RawData = map[string]any{rawKeyInputCharacters: chars}
 	}
 

--- a/internal/usage/audio_test.go
+++ b/internal/usage/audio_test.go
@@ -9,9 +9,7 @@ import (
 func floatPtr(v float64) *float64 { return &v }
 
 func TestExtractFromSpeechRequest(t *testing.T) {
-	req := &core.AudioSpeechRequest{Model: "gpt-4o-mini-tts", Input: "hello", Voice: "alloy"}
-
-	entry := ExtractFromSpeechRequest(req, "req-1", "openai")
+	entry := ExtractFromSpeechRequest("hello", "req-1", "gpt-4o-mini-tts", "openai")
 	if entry == nil {
 		t.Fatal("expected a usage entry")
 	}
@@ -26,11 +24,8 @@ func TestExtractFromSpeechRequest(t *testing.T) {
 	}
 }
 
-func TestExtractFromSpeechRequest_NilAndEmptyInput(t *testing.T) {
-	if ExtractFromSpeechRequest(nil, "req", "openai") != nil {
-		t.Error("nil request should yield nil entry")
-	}
-	entry := ExtractFromSpeechRequest(&core.AudioSpeechRequest{Model: "tts"}, "req", "openai")
+func TestExtractFromSpeechRequest_EmptyInput(t *testing.T) {
+	entry := ExtractFromSpeechRequest("", "req", "tts-1", "openai")
 	if entry == nil {
 		t.Fatal("empty input should still yield an entry")
 	}
@@ -41,8 +36,7 @@ func TestExtractFromSpeechRequest_NilAndEmptyInput(t *testing.T) {
 
 func TestExtractFromSpeechRequest_PerCharacterPricing(t *testing.T) {
 	// "hello" = 5 characters at $0.00001/char => $0.00005.
-	req := &core.AudioSpeechRequest{Model: "tts-1", Input: "hello", Voice: "alloy"}
-	entry := ExtractFromSpeechRequest(req, "req", "openai", &core.ModelPricing{PerCharacterInput: floatPtr(0.00001)})
+	entry := ExtractFromSpeechRequest("hello", "req", "tts-1", "openai", &core.ModelPricing{PerCharacterInput: floatPtr(0.00001)})
 	assertCostPtrNear(t, "input cost", entry.InputCost, 0.00005)
 	assertCostPtrNear(t, "total cost", entry.TotalCost, 0.00005)
 }
@@ -50,8 +44,7 @@ func TestExtractFromSpeechRequest_PerCharacterPricing(t *testing.T) {
 func TestExtractFromSpeechRequest_NoPerCharacterRateStaysUnpriced(t *testing.T) {
 	// gpt-4o-mini-tts is priced by output audio duration, which the gateway does
 	// not measure; with only an output-side audio rate, character usage is unpriced.
-	req := &core.AudioSpeechRequest{Model: "gpt-4o-mini-tts", Input: "hello", Voice: "alloy"}
-	entry := ExtractFromSpeechRequest(req, "req", "openai", &core.ModelPricing{PerSecondOutput: floatPtr(0.00025)})
+	entry := ExtractFromSpeechRequest("hello", "req", "gpt-4o-mini-tts", "openai", &core.ModelPricing{PerSecondOutput: floatPtr(0.00025)})
 	if entry.TotalCost != nil {
 		t.Errorf("want nil cost when only output audio duration is priced, got %v", *entry.TotalCost)
 	}

--- a/internal/usage/audio_test.go
+++ b/internal/usage/audio_test.go
@@ -1,0 +1,128 @@
+package usage
+
+import (
+	"testing"
+
+	"gomodel/internal/core"
+)
+
+func floatPtr(v float64) *float64 { return &v }
+
+func TestExtractFromSpeechRequest(t *testing.T) {
+	req := &core.AudioSpeechRequest{Model: "gpt-4o-mini-tts", Input: "hello", Voice: "alloy"}
+
+	entry := ExtractFromSpeechRequest(req, "req-1", "openai")
+	if entry == nil {
+		t.Fatal("expected a usage entry")
+	}
+	if entry.Endpoint != endpointAudioSpeech {
+		t.Errorf("endpoint = %q, want %q", entry.Endpoint, endpointAudioSpeech)
+	}
+	if entry.Model != "gpt-4o-mini-tts" || entry.Provider != "openai" || entry.RequestID != "req-1" {
+		t.Errorf("identity mismatch: %+v", entry)
+	}
+	if got := entry.RawData["input_characters"]; got != 5 {
+		t.Errorf("input_characters = %v, want 5", got)
+	}
+}
+
+func TestExtractFromSpeechRequest_NilAndEmptyInput(t *testing.T) {
+	if ExtractFromSpeechRequest(nil, "req", "openai") != nil {
+		t.Error("nil request should yield nil entry")
+	}
+	entry := ExtractFromSpeechRequest(&core.AudioSpeechRequest{Model: "tts"}, "req", "openai")
+	if entry == nil {
+		t.Fatal("empty input should still yield an entry")
+	}
+	if entry.RawData != nil {
+		t.Errorf("empty input should record no characters, got %+v", entry.RawData)
+	}
+}
+
+func TestExtractFromSpeechRequest_PerCharacterPricing(t *testing.T) {
+	// "hello" = 5 characters at $0.00001/char => $0.00005.
+	req := &core.AudioSpeechRequest{Model: "tts-1", Input: "hello", Voice: "alloy"}
+	entry := ExtractFromSpeechRequest(req, "req", "openai", &core.ModelPricing{PerCharacterInput: floatPtr(0.00001)})
+	assertCostPtrNear(t, "input cost", entry.InputCost, 0.00005)
+	assertCostPtrNear(t, "total cost", entry.TotalCost, 0.00005)
+}
+
+func TestExtractFromSpeechRequest_NoPerCharacterRateStaysUnpriced(t *testing.T) {
+	// gpt-4o-mini-tts is priced by output audio duration, which the gateway does
+	// not measure; with only an output-side audio rate, character usage is unpriced.
+	req := &core.AudioSpeechRequest{Model: "gpt-4o-mini-tts", Input: "hello", Voice: "alloy"}
+	entry := ExtractFromSpeechRequest(req, "req", "openai", &core.ModelPricing{PerSecondOutput: floatPtr(0.00025)})
+	if entry.TotalCost != nil {
+		t.Errorf("want nil cost when only output audio duration is priced, got %v", *entry.TotalCost)
+	}
+}
+
+func TestExtractFromTranscriptionResponse_TokenUsage(t *testing.T) {
+	body := []byte(`{"text":"hi","usage":{"type":"tokens","input_tokens":14,"output_tokens":45,"total_tokens":59}}`)
+
+	entry := ExtractFromTranscriptionResponse(body, "req-2", "gpt-4o-transcribe", "openai")
+	if entry == nil {
+		t.Fatal("expected a usage entry")
+	}
+	if entry.Endpoint != endpointAudioTranscriptions {
+		t.Errorf("endpoint = %q, want %q", entry.Endpoint, endpointAudioTranscriptions)
+	}
+	if entry.InputTokens != 14 || entry.OutputTokens != 45 || entry.TotalTokens != 59 {
+		t.Errorf("token counts mismatch: %+v", entry)
+	}
+}
+
+func TestExtractFromTranscriptionResponse_TotalTokensDerived(t *testing.T) {
+	body := []byte(`{"usage":{"input_tokens":10,"output_tokens":20}}`)
+
+	entry := ExtractFromTranscriptionResponse(body, "req", "m", "openai")
+	if entry.TotalTokens != 30 {
+		t.Errorf("total_tokens = %d, want 30 (derived)", entry.TotalTokens)
+	}
+}
+
+func TestExtractFromTranscriptionResponse_DurationUsage(t *testing.T) {
+	body := []byte(`{"text":"hi","usage":{"type":"duration","seconds":9}}`)
+
+	entry := ExtractFromTranscriptionResponse(body, "req", "whisper-1", "openai")
+	if entry.TotalTokens != 0 {
+		t.Errorf("duration usage should report no tokens, got %d", entry.TotalTokens)
+	}
+	if got := entry.RawData["audio_seconds"]; got != float64(9) {
+		t.Errorf("audio_seconds = %v, want 9", got)
+	}
+}
+
+func TestExtractFromTranscriptionResponse_PerSecondCost(t *testing.T) {
+	// 9 seconds of input audio at $0.0001/sec => $0.0009 (whisper-style pricing).
+	body := []byte(`{"usage":{"type":"duration","seconds":9}}`)
+	pricing := &core.ModelPricing{PerSecondInput: floatPtr(0.0001)}
+
+	entry := ExtractFromTranscriptionResponse(body, "req", "whisper-1", "openai", pricing)
+	assertCostPtrNear(t, "input cost", entry.InputCost, 0.0009)
+}
+
+func TestExtractFromTranscriptionResponse_NoUsage(t *testing.T) {
+	// Whisper / text responses carry no usage; the interaction is still recorded.
+	for _, body := range [][]byte{
+		[]byte(`{"text":"hi"}`),
+		[]byte("plain transcript text"),
+		nil,
+	} {
+		entry := ExtractFromTranscriptionResponse(body, "req", "whisper-1", "openai")
+		if entry == nil {
+			t.Fatalf("expected an entry for body %q", body)
+		}
+		if entry.TotalTokens != 0 || entry.RawData != nil {
+			t.Errorf("expected zero-usage entry for body %q, got %+v", body, entry)
+		}
+	}
+}
+
+func TestExtractFromTranscriptionResponse_TokenCost(t *testing.T) {
+	body := []byte(`{"usage":{"input_tokens":1000000,"output_tokens":0,"total_tokens":1000000}}`)
+	pricing := &core.ModelPricing{InputPerMtok: floatPtr(2.5)}
+
+	entry := ExtractFromTranscriptionResponse(body, "req", "gpt-4o-transcribe", "openai", pricing)
+	assertCostPtrNear(t, "input cost", entry.InputCost, 2.5)
+}

--- a/internal/usage/cost.go
+++ b/internal/usage/cost.go
@@ -191,6 +191,16 @@ func CalculateGranularCost(inputTokens, outputTokens int, rawData map[string]any
 		}
 	}
 
+	// Price non-token audio units the providers report outside the usage tokens:
+	// per-character input for text-to-speech and per-second input audio duration
+	// for transcription. Both quantities live in RawData (see usage/audio.go).
+	if audioCost, ok := applyAudioUnitCosts(rawData, pricing); ok {
+		inputCost += audioCost
+		hasInput = true
+		mappedKeys[rawKeyInputCharacters] = true
+		mappedKeys[rawKeyAudioSeconds] = true
+	}
+
 	// Check for unmapped token fields in RawData
 	for key := range rawData {
 		if mappedKeys[key] {
@@ -232,6 +242,30 @@ func CalculateGranularCost(inputTokens, outputTokens int, rawData map[string]any
 	result.Caveat = strings.Join(caveats, "; ")
 
 	return result
+}
+
+// applyAudioUnitCosts prices the non-token audio units carried in RawData:
+// PerCharacterInput against input characters (text-to-speech) and PerSecondInput
+// against input audio seconds (transcription). Both are input-side costs. It
+// returns the summed cost and whether any rate applied. Models priced by output
+// audio duration (e.g. gpt-4o-mini-tts) are not handled here because the gateway
+// proxies opaque audio bytes and does not measure their duration.
+func applyAudioUnitCosts(rawData map[string]any, pricing *core.ModelPricing) (float64, bool) {
+	var cost float64
+	var applied bool
+	if pricing.PerCharacterInput != nil {
+		if chars := extractInt(rawData, rawKeyInputCharacters); chars > 0 {
+			cost += float64(chars) * *pricing.PerCharacterInput
+			applied = true
+		}
+	}
+	if pricing.PerSecondInput != nil {
+		if seconds, ok := extractFloat(rawData, rawKeyAudioSeconds); ok && seconds > 0 {
+			cost += seconds * *pricing.PerSecondInput
+			applied = true
+		}
+	}
+	return cost, applied
 }
 
 func pricingForTokenCount(pricing *core.ModelPricing, inputTokens int) *core.ModelPricing {


### PR DESCRIPTION
## What & why

Audio endpoints (`/v1/audio/speech` and `/v1/audio/transcriptions`) were not recorded in usage tracking. Chat, responses, embeddings, and batches all log usage; audio was the gap. This adds usage + cost tracking for both.

Audio providers return opaque bytes with no token usage, so usage is derived locally at the audio service layer — providers and the router are untouched; the audio service is the single integration point, mirroring how the inference orchestrator logs usage.

## How usage is captured

- **Speech (TTS):** record input character count in `raw_data.input_characters`.
- **Transcription (STT):** parse the optional `usage` object from the proxied response — token-based (`gpt-4o-transcribe`) or duration-based (`whisper`, recorded as `raw_data.audio_seconds`). An entry is **always** written so the interaction stays observable even when the provider reports no usage (whisper without usage, or `text`/`srt`/`vtt` response formats).

## Cost

Wires the non-token pricing units already present in registry pricing but previously unused by the cost calculator:

- `per_character_input` × input characters (TTS)
- `per_second_input` × input audio duration (STT)

alongside the existing token-based path.

| model | priced by | result |
|---|---|---|
| `tts-1` / `tts-1-hd` | per-character | real cost |
| `whisper-1` | per-second | real cost |
| `gpt-4o-transcribe` | tokens | real cost (existing path) |
| `gpt-4o-mini-tts` | output audio duration | **uncosted** (see below) |

### Known limitation

Models priced by **output** audio duration (e.g. `gpt-4o-mini-tts` via `per_second_output`) remain uncosted: the gateway proxies opaque audio bytes and does not measure their duration. Documented in `applyAudioUnitCosts`. The usage interaction is still logged (with `input_characters`), just with `$0` cost.

## Verification

Verified live against OpenAI:

| model | usage | cost |
|---|---|---|
| `tts-1` | 50 chars | \$0.00075 |
| `whisper-1` | 4 sec | \$0.0004 |
| `gpt-4o-transcribe` | 42 tok | \$0.000195 |
| `gpt-4o-mini-tts` | 11 chars | \$0.00 (known gap) |

## Tests

- New `internal/usage/audio_test.go`: speech/transcription extraction (token, duration, no-usage, per-character cost, per-second cost, no-rate cases).
- New cases in `internal/server/audio_service_test.go`: usage is logged for speech & transcription, and not logged when usage is disabled.
- `go build`, `go vet`, full `go test ./...`, and pre-commit `make test-race` / `make lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-call audio usage tracking: records input characters for text-to-speech and audio duration for speech-to-text, with optional pricing applied.

* **Behavior**
  * Provider identity is consistently associated with usage entries.
  * Service returns a 502 when an upstream audio provider returns an empty response; no usage is recorded in that case.
  * Usage tracking can be disabled to suppress logging.

* **Tests**
  * Added comprehensive tests for audio usage extraction, pricing, logging, and nil-response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->