### PR TITLE
fix: extract system messages from messages array in Anthropic API

### DIFF
--- a/internal/anthropicapi/request.go
+++ b/internal/anthropicapi/request.go
@@ -84,18 +84,47 @@ func ToChatRequest(req *MessagesRequest) (*core.ChatRequest, error) {
 // convertMessages flattens the Anthropic system prompt and messages into the
 // canonical message list. A single Anthropic message may expand into multiple
 // canonical messages: tool_result blocks become standalone role:"tool" messages.
+// Messages with role "system" in the messages array are extracted and prepended
+// to the system prompt, as the Anthropic Messages API requires system content
+// to be in the top-level system field, not in messages.
 func convertMessages(req *MessagesRequest) ([]core.Message, error) {
 	out := make([]core.Message, 0, len(req.Messages)+1)
 
+	// Collect system messages from the messages array
+	var systemMessages []string
+	filteredMessages := make([]Message, 0, len(req.Messages))
+	for _, msg := range req.Messages {
+		if msg.Role == "system" {
+			// Extract system content from message
+			text, err := systemText(msg.Content)
+			if err != nil {
+				return nil, core.NewInvalidRequestError("system message content: "+err.Error(), err)
+			}
+			if text != "" {
+				systemMessages = append(systemMessages, text)
+			}
+		} else {
+			filteredMessages = append(filteredMessages, msg)
+		}
+	}
+
+	// Build the system prompt by combining existing system field and system messages
 	system, err := systemText(req.System)
 	if err != nil {
 		return nil, core.NewInvalidRequestError(err.Error(), err)
+	}
+	if len(systemMessages) > 0 {
+		if system != "" {
+			system = strings.TrimSpace(system + "\n\n" + strings.Join(systemMessages, "\n\n"))
+		} else {
+			system = strings.TrimSpace(strings.Join(systemMessages, "\n\n"))
+		}
 	}
 	if system != "" {
 		out = append(out, core.Message{Role: "system", Content: system})
 	}
 
-	for i, msg := range req.Messages {
+	for i, msg := range filteredMessages {
 		if msg.Role != "user" && msg.Role != "assistant" {
 			return nil, core.NewInvalidRequestError(
 				fmt.Sprintf("messages[%d].role must be \"user\" or \"assistant\"", i), nil)

--- a/internal/anthropicapi/request_test.go
+++ b/internal/anthropicapi/request_test.go
@@ -67,7 +67,6 @@ func TestToChatRequestRejectsInvalidShapes(t *testing.T) {
 		name string
 		body string
 	}{
-		{name: "unsupported role", body: `{"model":"m","max_tokens":10,"messages":[{"role":"system","content":"hi"}]}`},
 		{name: "typo role", body: `{"model":"m","max_tokens":10,"messages":[{"role":"assisstant","content":"hi"}]}`},
 		{name: "malformed system", body: `{"model":"m","max_tokens":10,"system":42,"messages":[{"role":"user","content":"hi"}]}`},
 		{name: "non-text system block", body: `{"model":"m","max_tokens":10,"system":[{"type":"image"}],"messages":[{"role":"user","content":"hi"}]}`},
@@ -114,6 +113,71 @@ func TestToChatRequestBasic(t *testing.T) {
 	}
 	if chat.Messages[0].Role != "system" || chat.Messages[0].Content != "be brief" {
 		t.Errorf("system message = %+v", chat.Messages[0])
+	}
+	if chat.Messages[1].Role != "user" || chat.Messages[1].Content != "hello" {
+		t.Errorf("user message = %+v", chat.Messages[1])
+	}
+}
+
+func TestToChatRequestSystemMessageInMessages(t *testing.T) {
+	// System messages in the messages array should be extracted and prepended to the system prompt
+	chat, err := ToChatRequest(mustDecode(t, `{
+		"model":"m","max_tokens":10,
+		"messages":[
+			{"role":"system","content":"system prompt"},
+			{"role":"user","content":"hello"}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("ToChatRequest: %v", err)
+	}
+	if len(chat.Messages) != 2 {
+		t.Fatalf("messages = %d, want 2 (system + user)", len(chat.Messages))
+	}
+	if chat.Messages[0].Role != "system" {
+		t.Errorf("first message role = %q, want system", chat.Messages[0].Role)
+	}
+	systemContent, ok := chat.Messages[0].Content.(string)
+	if !ok {
+		t.Fatalf("system content is not a string: %T", chat.Messages[0].Content)
+	}
+	if systemContent != "system prompt" {
+		t.Errorf("system content = %q, want system prompt", systemContent)
+	}
+	if chat.Messages[1].Role != "user" || chat.Messages[1].Content != "hello" {
+		t.Errorf("user message = %+v", chat.Messages[1])
+	}
+}
+
+func TestToChatRequestSystemMessageCombined(t *testing.T) {
+	// System messages in messages array should be combined with top-level system field
+	chat, err := ToChatRequest(mustDecode(t, `{
+		"model":"m","max_tokens":10,
+		"system":"top-level system",
+		"messages":[
+			{"role":"system","content":"message system"},
+			{"role":"user","content":"hello"}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("ToChatRequest: %v", err)
+	}
+	if len(chat.Messages) != 2 {
+		t.Fatalf("messages = %d, want 2 (system + user)", len(chat.Messages))
+	}
+	// System messages should be combined with top-level system
+	if chat.Messages[0].Role != "system" {
+		t.Errorf("first message role = %q, want system", chat.Messages[0].Role)
+	}
+	systemContent, ok := chat.Messages[0].Content.(string)
+	if !ok {
+		t.Fatalf("system content is not a string: %T", chat.Messages[0].Content)
+	}
+	if !strings.Contains(systemContent, "top-level system") {
+		t.Errorf("system message should contain top-level system, got: %s", systemContent)
+	}
+	if !strings.Contains(systemContent, "message system") {
+		t.Errorf("system message should contain message system, got: %s", systemContent)
 	}
 	if chat.Messages[1].Role != "user" || chat.Messages[1].Content != "hello" {
 		t.Errorf("user message = %+v", chat.Messages[1])


### PR DESCRIPTION
The Anthropic Messages API (/v1/messages) only accepts "user" or "assistant" roles in the messages array. System prompts must be passed in the top-level "system" field.

Previously, messages with role "system" in the messages array were rejected with error: "messages[N].role must be \"user\" or \"assistant\""

This issue only occurred when using Claude Opus 4.8 model, as other models did not exhibit this behavior

This change extracts messages with role "system" from the messages array and prepends them to the system prompt, allowing clients to send system content in either format.

Fixes compatibility with Claude Code and other clients that include system messages in the messages array.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System messages can now be included within the messages array and will be automatically combined with any top-level system instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->