### PR TITLE
test(usage): table-driven transcription no-usage cases

### DIFF
--- a/internal/usage/audio_test.go
+++ b/internal/usage/audio_test.go
@@ -97,18 +97,24 @@ func TestExtractFromTranscriptionResponse_PerSecondCost(t *testing.T) {
 
 func TestExtractFromTranscriptionResponse_NoUsage(t *testing.T) {
 	// Whisper / text responses carry no usage; the interaction is still recorded.
-	for _, body := range [][]byte{
-		[]byte(`{"text":"hi"}`),
-		[]byte("plain transcript text"),
-		nil,
-	} {
-		entry := ExtractFromTranscriptionResponse(body, "req", "whisper-1", "openai")
-		if entry == nil {
-			t.Fatalf("expected an entry for body %q", body)
-		}
-		if entry.TotalTokens != 0 || entry.RawData != nil {
-			t.Errorf("expected zero-usage entry for body %q, got %+v", body, entry)
-		}
+	tests := []struct {
+		name string
+		body []byte
+	}{
+		{"json without usage", []byte(`{"text":"hi"}`)},
+		{"plain text", []byte("plain transcript text")},
+		{"nil body", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry := ExtractFromTranscriptionResponse(tt.body, "req", "whisper-1", "openai")
+			if entry == nil {
+				t.Fatal("expected an entry")
+			}
+			if entry.TotalTokens != 0 || entry.RawData != nil {
+				t.Errorf("expected zero-usage entry, got %+v", entry)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Follow-up to #372 (merged). Addresses the one remaining post-merge review comment from CodeRabbit — a 🔵 trivial nitpick to make `TestExtractFromTranscriptionResponse_NoUsage` table-driven.

## Change
Converts the inline `for range [][]byte{...}` loop into a named-subtest table, matching CLAUDE.md's "prefer table-driven tests" guidance. Each scenario (`json without usage`, `plain text`, `nil body`) now runs as its own subtest, so failures point at the specific case.

**Test-only — no behavior change.** All usage tests pass; `go vet`, `make test-race`, `make lint` green via pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test structure for usage data extraction validation, refactoring test cases into a table-driven format for better organization and comprehensive coverage of edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->