### PR TITLE
fix(usage): cost text-to-speech by output audio duration

### DIFF
--- a/internal/llmclient/client.go
+++ b/internal/llmclient/client.go
@@ -168,8 +168,11 @@ type Request struct {
 // Response represents an HTTP response
 type Response struct {
 	StatusCode int
-	Header     http.Header
-	Body       []byte
+	// ContentType is the upstream response Content-Type header, preserved so
+	// callers can describe the bytes actually returned (e.g. audio formats).
+	// Only this header is surfaced; the full upstream header set is not exposed.
+	ContentType string
+	Body        []byte
 }
 
 type requestScope struct {
@@ -616,9 +619,9 @@ func (c *Client) doRequest(ctx context.Context, req Request) (*Response, error) 
 	}
 
 	return &Response{
-		StatusCode: resp.StatusCode,
-		Header:     resp.Header,
-		Body:       body,
+		StatusCode:  resp.StatusCode,
+		ContentType: resp.Header.Get("Content-Type"),
+		Body:        body,
 	}, nil
 }
 

--- a/internal/llmclient/client.go
+++ b/internal/llmclient/client.go
@@ -168,6 +168,7 @@ type Request struct {
 // Response represents an HTTP response
 type Response struct {
 	StatusCode int
+	Header     http.Header
 	Body       []byte
 }
 
@@ -616,6 +617,7 @@ func (c *Client) doRequest(ctx context.Context, req Request) (*Response, error) 
 
 	return &Response{
 		StatusCode: resp.StatusCode,
+		Header:     resp.Header,
 		Body:       body,
 	}, nil
 }

--- a/internal/providers/openai/audio.go
+++ b/internal/providers/openai/audio.go
@@ -13,8 +13,10 @@ import (
 )
 
 // CreateSpeech implements OpenAI text-to-speech (POST /audio/speech). The upstream
-// returns binary audio, so the response is read raw and tagged with the content
-// type implied by the requested response_format.
+// returns binary audio; the response is read raw and tagged with the upstream
+// Content-Type so it describes the bytes actually returned (see
+// speechResponseContentType), which usage relies on to price output-duration
+// models.
 func (p *CompatibleProvider) CreateSpeech(ctx context.Context, req *core.AudioSpeechRequest) (*core.AudioResponse, error) {
 	if req == nil {
 		return nil, core.NewInvalidRequestError("audio speech request is required", nil)
@@ -35,9 +37,22 @@ func (p *CompatibleProvider) CreateSpeech(ctx context.Context, req *core.AudioSp
 		return nil, err
 	}
 	return &core.AudioResponse{
-		ContentType: core.SpeechResponseContentType(req.ResponseFormat),
+		ContentType: speechResponseContentType(raw, req.ResponseFormat),
 		Data:        raw.Body,
 	}, nil
+}
+
+// speechResponseContentType returns the authoritative media type of synthesized
+// speech. The upstream response Content-Type describes the bytes actually
+// returned, so it wins; it falls back to the type implied by the requested
+// response_format when the upstream omits the header.
+func speechResponseContentType(raw *llmclient.Response, format string) string {
+	if raw != nil {
+		if ct := strings.TrimSpace(raw.Header.Get("Content-Type")); ct != "" {
+			return ct
+		}
+	}
+	return core.SpeechResponseContentType(format)
 }
 
 // CreateTranscription implements OpenAI speech-to-text (POST /audio/transcriptions).

--- a/internal/providers/openai/audio.go
+++ b/internal/providers/openai/audio.go
@@ -48,7 +48,7 @@ func (p *CompatibleProvider) CreateSpeech(ctx context.Context, req *core.AudioSp
 // response_format when the upstream omits the header.
 func speechResponseContentType(raw *llmclient.Response, format string) string {
 	if raw != nil {
-		if ct := strings.TrimSpace(raw.Header.Get("Content-Type")); ct != "" {
+		if ct := strings.TrimSpace(raw.ContentType); ct != "" {
 			return ct
 		}
 	}

--- a/internal/providers/openai/audio_test.go
+++ b/internal/providers/openai/audio_test.go
@@ -1,0 +1,64 @@
+package openai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"gomodel/internal/core"
+	"gomodel/internal/llmclient"
+)
+
+func newSpeechTestProvider(t *testing.T, handler http.HandlerFunc) *CompatibleProvider {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	return NewCompatibleProviderWithHTTPClient(
+		"test-key",
+		server.Client(),
+		llmclient.Hooks{},
+		CompatibleProviderConfig{ProviderName: "openai", BaseURL: server.URL},
+	)
+}
+
+// TestCreateSpeech_PreservesUpstreamContentType ensures the response is tagged
+// with the upstream Content-Type — the authoritative description of the bytes
+// usage prices output-duration models from — rather than re-deriving it from the
+// requested response_format.
+func TestCreateSpeech_PreservesUpstreamContentType(t *testing.T) {
+	tests := []struct {
+		name           string
+		responseFormat string
+		upstreamType   string // "" => upstream sends no Content-Type
+		wantType       string
+	}{
+		{"upstream wav honored", "wav", "audio/wav", "audio/wav"},
+		// The provider transcoded to mp3 even though wav was requested: the
+		// upstream type must win so billing sees the real format.
+		{"upstream overrides request", "wav", "audio/mpeg", "audio/mpeg"},
+		{"fallback to request format", "pcm", "", "audio/pcm"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := newSpeechTestProvider(t, func(w http.ResponseWriter, _ *http.Request) {
+				if tt.upstreamType != "" {
+					w.Header().Set("Content-Type", tt.upstreamType)
+				} else {
+					w.Header()["Content-Type"] = nil // suppress net/http content sniffing
+				}
+				_, _ = w.Write([]byte("audio-bytes"))
+			})
+
+			resp, err := provider.CreateSpeech(context.Background(), &core.AudioSpeechRequest{
+				Model: "gpt-4o-mini-tts", Input: "hello", Voice: "alloy", ResponseFormat: tt.responseFormat,
+			})
+			if err != nil {
+				t.Fatalf("CreateSpeech() error = %v", err)
+			}
+			if resp.ContentType != tt.wantType {
+				t.Errorf("ContentType = %q, want %q", resp.ContentType, tt.wantType)
+			}
+		})
+	}
+}

--- a/internal/server/audio_service.go
+++ b/internal/server/audio_service.go
@@ -78,9 +78,25 @@ func (s *audioService) CreateSpeech(c *echo.Context) error {
 		return s.respondAudio(c, resp) // emits the 502 guard; no usage for a failed call
 	}
 	s.logUsage(ctx, route, func(pricing *core.ModelPricing) *usage.UsageEntry {
-		return usage.ExtractFromSpeechRequest(req.Input, route.requestID, route.model, route.providerType, pricing)
+		return usage.ExtractFromSpeechRequest(req.Input, resp.Data, speechResponseFormat(req, resp), route.requestID, route.model, route.providerType, pricing)
 	})
 	return s.respondAudio(c, resp)
+}
+
+// speechResponseFormat resolves the codec of the synthesized audio so usage can
+// price models billed by output duration. The request response_format is
+// authoritative (OpenAI accepts mp3/opus/aac/flac/wav/pcm); when omitted it
+// falls back to the response Content-Type and finally OpenAI's mp3 default.
+func speechResponseFormat(req *core.AudioSpeechRequest, resp *core.AudioResponse) string {
+	if f := strings.TrimSpace(req.ResponseFormat); f != "" {
+		return f
+	}
+	if resp != nil {
+		if ct := strings.TrimSpace(resp.ContentType); ct != "" {
+			return ct
+		}
+	}
+	return "mp3"
 }
 
 // CreateTranscription handles POST /v1/audio/transcriptions.

--- a/internal/server/audio_service.go
+++ b/internal/server/audio_service.go
@@ -84,17 +84,18 @@ func (s *audioService) CreateSpeech(c *echo.Context) error {
 }
 
 // speechResponseFormat resolves the codec of the synthesized audio so usage can
-// price models billed by output duration. The request response_format is
-// authoritative (OpenAI accepts mp3/opus/aac/flac/wav/pcm); when omitted it
-// falls back to the response Content-Type and finally OpenAI's mp3 default.
+// price models billed by output duration. The response Content-Type describes
+// the bytes actually returned, so it is authoritative when it names an audio
+// media type; this avoids charging a per-second rate against bytes whose real
+// format differs from the requested one (e.g. response_format=pcm but the
+// provider returns mp3). It falls back to the requested response_format and
+// finally OpenAI's mp3 default.
 func speechResponseFormat(req *core.AudioSpeechRequest, resp *core.AudioResponse) string {
+	if resp != nil && auditlog.IsAudioContentType(resp.ContentType) {
+		return resp.ContentType
+	}
 	if f := strings.TrimSpace(req.ResponseFormat); f != "" {
 		return f
-	}
-	if resp != nil {
-		if ct := strings.TrimSpace(resp.ContentType); ct != "" {
-			return ct
-		}
 	}
 	return "mp3"
 }

--- a/internal/server/audio_service_test.go
+++ b/internal/server/audio_service_test.go
@@ -374,6 +374,10 @@ func TestAudioSpeech_CostsOutputAudioDuration(t *testing.T) {
 	}{
 		{"explicit wav", "wav", "audio/wav", wav, 2, 0.0005, false},
 		{"content-type fallback wav", "", "audio/wav", wav, 2, 0.0005, false},
+		// The client requested a measurable format (pcm) but the provider
+		// actually returned mp3; the response Content-Type must win so the
+		// non-PCM bytes are caveated, not charged as len/48000 of fake PCM.
+		{"content-type overrides requested format", "pcm", "audio/mpeg", mp3, 0, 0, true},
 		{"default mp3 unmeasured", "", "", mp3, 0, 0, true},
 	}
 	for _, tt := range tests {

--- a/internal/server/audio_service_test.go
+++ b/internal/server/audio_service_test.go
@@ -353,41 +353,72 @@ func TestAudioSpeech_LogsUsage(t *testing.T) {
 }
 
 // TestAudioSpeech_CostsOutputAudioDuration verifies the full wire path for
-// output-duration-priced TTS models (e.g. gpt-4o-mini-tts): the synthesized WAV
-// is measured and priced via PerSecondOutput rather than logged as a zero cost.
+// output-duration-priced TTS models (e.g. gpt-4o-mini-tts), including how the
+// billing format is resolved: the response Content-Type is authoritative, the
+// requested response_format is the fallback, and mp3 is the final default.
 func TestAudioSpeech_CostsOutputAudioDuration(t *testing.T) {
-	var captured *usage.UsageEntry
-	logger := &capturingUsageLogger{config: usage.Config{Enabled: true}, captured: &captured}
 	// 2-second 24 kHz mono 16-bit WAV: byteRate 48000, dataLen 96000.
 	wav := wavBytes(24000, 1, 16, 2.0)
-	mock := &audioMockProvider{
-		mockProvider: &mockProvider{supportedModels: []string{"gpt-4o-mini-tts"}},
-		speechResp:   &core.AudioResponse{ContentType: "audio/wav", Data: wav},
-	}
-	resolver := &mockPricingResolver{pricing: &core.ModelPricing{PerSecondOutput: floatPtr(0.00025)}}
-	svc := &audioService{provider: mock, usageLogger: logger, pricingResolver: resolver}
+	mp3 := []byte("\xff\xfbnot-a-wav-body")
+	// gpt-4o-mini-tts-style pricing: tiny text input plus per-second audio output.
+	pricing := &core.ModelPricing{InputPerMtok: floatPtr(0.6), PerSecondOutput: floatPtr(0.00025)}
 
-	body := `{"model":"gpt-4o-mini-tts","input":"hello","voice":"alloy","response_format":"wav"}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/audio/speech", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	rec := httptest.NewRecorder()
-	c := echo.New().NewContext(req, rec)
-	c.Set(string(auditlog.LogEntryKey), &auditlog.LogEntry{})
+	tests := []struct {
+		name           string
+		responseFormat string // omitted from the request body when empty
+		contentType    string
+		data           []byte
+		wantSeconds    float64 // 0 => no measured duration expected
+		wantCost       float64
+		wantCaveat     bool
+	}{
+		{"explicit wav", "wav", "audio/wav", wav, 2, 0.0005, false},
+		{"content-type fallback wav", "", "audio/wav", wav, 2, 0.0005, false},
+		{"default mp3 unmeasured", "", "", mp3, 0, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var captured *usage.UsageEntry
+			logger := &capturingUsageLogger{config: usage.Config{Enabled: true}, captured: &captured}
+			mock := &audioMockProvider{
+				mockProvider: &mockProvider{supportedModels: []string{"gpt-4o-mini-tts"}},
+				speechResp:   &core.AudioResponse{ContentType: tt.contentType, Data: tt.data},
+			}
+			svc := &audioService{provider: mock, usageLogger: logger, pricingResolver: &mockPricingResolver{pricing: pricing}}
 
-	if err := svc.CreateSpeech(c); err != nil {
-		t.Fatalf("CreateSpeech returned error: %v", err)
-	}
-	if captured == nil {
-		t.Fatal("expected a usage entry to be written")
-	}
-	if got := captured.RawData["audio_output_seconds"]; got != float64(2) {
-		t.Errorf("audio_output_seconds = %v, want 2", got)
-	}
-	if captured.TotalCost == nil || *captured.TotalCost != 0.0005 {
-		t.Fatalf("total_cost = %v, want 0.0005", captured.TotalCost)
-	}
-	if captured.CostsCalculationCaveat != "" {
-		t.Errorf("measured wav should carry no caveat, got %q", captured.CostsCalculationCaveat)
+			body := `{"model":"gpt-4o-mini-tts","input":"hello","voice":"alloy"`
+			if tt.responseFormat != "" {
+				body += `,"response_format":"` + tt.responseFormat + `"`
+			}
+			body += `}`
+			req := httptest.NewRequest(http.MethodPost, "/v1/audio/speech", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			c := echo.New().NewContext(req, httptest.NewRecorder())
+			c.Set(string(auditlog.LogEntryKey), &auditlog.LogEntry{})
+
+			if err := svc.CreateSpeech(c); err != nil {
+				t.Fatalf("CreateSpeech returned error: %v", err)
+			}
+			if captured == nil {
+				t.Fatal("expected a usage entry to be written")
+			}
+
+			got, hasSeconds := captured.RawData["audio_output_seconds"]
+			if tt.wantSeconds > 0 {
+				if !hasSeconds || got != tt.wantSeconds {
+					t.Errorf("audio_output_seconds = %v (present=%v), want %v", got, hasSeconds, tt.wantSeconds)
+				}
+			} else if hasSeconds {
+				t.Errorf("audio_output_seconds = %v, want none", got)
+			}
+
+			if captured.TotalCost == nil || *captured.TotalCost != tt.wantCost {
+				t.Fatalf("total_cost = %v, want %v", captured.TotalCost, tt.wantCost)
+			}
+			if hasCaveat := captured.CostsCalculationCaveat != ""; hasCaveat != tt.wantCaveat {
+				t.Errorf("caveat = %q, want present=%v", captured.CostsCalculationCaveat, tt.wantCaveat)
+			}
+		})
 	}
 }
 

--- a/internal/server/audio_service_test.go
+++ b/internal/server/audio_service_test.go
@@ -352,6 +352,70 @@ func TestAudioSpeech_LogsUsage(t *testing.T) {
 	}
 }
 
+// TestAudioSpeech_CostsOutputAudioDuration verifies the full wire path for
+// output-duration-priced TTS models (e.g. gpt-4o-mini-tts): the synthesized WAV
+// is measured and priced via PerSecondOutput rather than logged as a zero cost.
+func TestAudioSpeech_CostsOutputAudioDuration(t *testing.T) {
+	var captured *usage.UsageEntry
+	logger := &capturingUsageLogger{config: usage.Config{Enabled: true}, captured: &captured}
+	// 2-second 24 kHz mono 16-bit WAV: byteRate 48000, dataLen 96000.
+	wav := wavBytes(24000, 1, 16, 2.0)
+	mock := &audioMockProvider{
+		mockProvider: &mockProvider{supportedModels: []string{"gpt-4o-mini-tts"}},
+		speechResp:   &core.AudioResponse{ContentType: "audio/wav", Data: wav},
+	}
+	resolver := &mockPricingResolver{pricing: &core.ModelPricing{PerSecondOutput: floatPtr(0.00025)}}
+	svc := &audioService{provider: mock, usageLogger: logger, pricingResolver: resolver}
+
+	body := `{"model":"gpt-4o-mini-tts","input":"hello","voice":"alloy","response_format":"wav"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/speech", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := echo.New().NewContext(req, rec)
+	c.Set(string(auditlog.LogEntryKey), &auditlog.LogEntry{})
+
+	if err := svc.CreateSpeech(c); err != nil {
+		t.Fatalf("CreateSpeech returned error: %v", err)
+	}
+	if captured == nil {
+		t.Fatal("expected a usage entry to be written")
+	}
+	if got := captured.RawData["audio_output_seconds"]; got != float64(2) {
+		t.Errorf("audio_output_seconds = %v, want 2", got)
+	}
+	if captured.TotalCost == nil || *captured.TotalCost != 0.0005 {
+		t.Fatalf("total_cost = %v, want 0.0005", captured.TotalCost)
+	}
+	if captured.CostsCalculationCaveat != "" {
+		t.Errorf("measured wav should carry no caveat, got %q", captured.CostsCalculationCaveat)
+	}
+}
+
+func floatPtr(v float64) *float64 { return &v }
+
+// wavBytes builds a minimal canonical PCM WAV of the requested duration.
+func wavBytes(sampleRate, channels, bitsPerSample int, seconds float64) []byte {
+	byteRate := sampleRate * channels * bitsPerSample / 8
+	dataLen := int(float64(byteRate) * seconds)
+	le := func(v uint32) []byte { return []byte{byte(v), byte(v >> 8), byte(v >> 16), byte(v >> 24)} }
+	le16 := func(v uint16) []byte { return []byte{byte(v), byte(v >> 8)} }
+	out := []byte("RIFF")
+	out = append(out, le(uint32(36+dataLen))...)
+	out = append(out, "WAVE"...)
+	out = append(out, "fmt "...)
+	out = append(out, le(16)...)
+	out = append(out, le16(1)...)
+	out = append(out, le16(uint16(channels))...)
+	out = append(out, le(uint32(sampleRate))...)
+	out = append(out, le(uint32(byteRate))...)
+	out = append(out, le16(uint16(channels*bitsPerSample/8))...)
+	out = append(out, le16(uint16(bitsPerSample))...)
+	out = append(out, "data"...)
+	out = append(out, le(uint32(dataLen))...)
+	out = append(out, make([]byte, dataLen)...)
+	return out
+}
+
 // TestAudioTranscription_LogsUsage verifies a speech-to-text call records a usage
 // entry even when the provider response carries no usage object (e.g. whisper).
 func TestAudioTranscription_LogsUsage(t *testing.T) {

--- a/internal/usage/audio.go
+++ b/internal/usage/audio.go
@@ -52,10 +52,14 @@ func ExtractFromSpeechRequest(input string, output []byte, format, requestID, mo
 	if chars := len([]rune(input)); chars > 0 {
 		raw[rawKeyInputCharacters] = chars
 	}
+	// Record the output codec whenever it is known, even for an empty body, so a
+	// compressed (unmeasurable) format still surfaces a cost caveat in cost.go
+	// rather than a silent zero. Record the measured duration only when the
+	// gateway can compute it from the returned audio (uncompressed wav/pcm).
+	if codec := normalizeAudioFormat(format); codec != "" {
+		raw[rawKeyAudioOutputFormat] = codec
+	}
 	if len(output) > 0 {
-		if codec := normalizeAudioFormat(format); codec != "" {
-			raw[rawKeyAudioOutputFormat] = codec
-		}
 		if seconds, ok := measureSpeechDurationSeconds(output, format); ok {
 			raw[rawKeyAudioOutputSeconds] = seconds
 		}

--- a/internal/usage/audio.go
+++ b/internal/usage/audio.go
@@ -19,15 +19,26 @@ const (
 	// cost.go prices them via PerCharacterInput / PerSecondInput respectively.
 	rawKeyInputCharacters = "input_characters"
 	rawKeyAudioSeconds    = "audio_seconds"
+
+	// rawKeyAudioOutputSeconds carries the synthesized speech duration the gateway
+	// measures from the returned audio, priced via PerSecondOutput. rawKeyAudioOutputFormat
+	// records the output codec so cost.go can flag a duration it could not measure
+	// (compressed mp3/opus/aac/flac) rather than reporting a silent zero.
+	rawKeyAudioOutputSeconds = "audio_output_seconds"
+	rawKeyAudioOutputFormat  = "audio_output_format"
 )
 
 // ExtractFromSpeechRequest builds a usage entry for a text-to-speech request.
 // Speech responses are binary audio with no provider-reported usage, so the
-// billable unit is the input character count, recorded in RawData so the
-// interaction stays observable and per-character pricing can apply. model is the
-// resolved route model (not the raw user input) so the row groups and prices
-// consistently with the pricing lookup, mirroring the transcription extractor.
-func ExtractFromSpeechRequest(input, requestID, model, provider string, pricing ...*core.ModelPricing) *UsageEntry {
+// billable units are derived locally: the input character count (per-character
+// models such as tts-1) and the synthesized audio duration (per-second-output
+// models such as gpt-4o-mini-tts), both recorded in RawData so the interaction
+// stays observable and pricing can apply. output is the returned audio and
+// format its response_format/MIME type; duration is measured for uncompressed
+// formats only (see measureSpeechDurationSeconds). model is the resolved route
+// model (not the raw user input) so the row groups and prices consistently with
+// the pricing lookup, mirroring the transcription extractor.
+func ExtractFromSpeechRequest(input string, output []byte, format, requestID, model, provider string, pricing ...*core.ModelPricing) *UsageEntry {
 	entry := &UsageEntry{
 		ID:        uuid.New().String(),
 		RequestID: requestID,
@@ -36,8 +47,21 @@ func ExtractFromSpeechRequest(input, requestID, model, provider string, pricing 
 		Provider:  provider,
 		Endpoint:  endpointAudioSpeech,
 	}
+
+	raw := map[string]any{}
 	if chars := len([]rune(input)); chars > 0 {
-		entry.RawData = map[string]any{rawKeyInputCharacters: chars}
+		raw[rawKeyInputCharacters] = chars
+	}
+	if len(output) > 0 {
+		if codec := normalizeAudioFormat(format); codec != "" {
+			raw[rawKeyAudioOutputFormat] = codec
+		}
+		if seconds, ok := measureSpeechDurationSeconds(output, format); ok {
+			raw[rawKeyAudioOutputSeconds] = seconds
+		}
+	}
+	if len(raw) > 0 {
+		entry.RawData = raw
 	}
 
 	applyUsageCosts(entry, provider, endpointAudioSpeech, pricing...)

--- a/internal/usage/audio_duration.go
+++ b/internal/usage/audio_duration.go
@@ -90,9 +90,10 @@ func wavDurationSeconds(data []byte) (float64, bool) {
 		if haveFmt && haveData {
 			break
 		}
-		if size <= 0 {
-			break // malformed/streaming size: stop walking instead of spinning
-		}
+		// Advance past this chunk: an 8-byte header plus its word-aligned body.
+		// pos always grows by at least the header, so the walk terminates; a
+		// zero-length non-data chunk (valid) simply advances to the next header.
+		// size is read from a uint32, so it is never negative.
 		pos = body + size
 		if size%2 == 1 {
 			pos++ // chunks are word-aligned

--- a/internal/usage/audio_duration.go
+++ b/internal/usage/audio_duration.go
@@ -1,0 +1,106 @@
+package usage
+
+import (
+	"encoding/binary"
+	"strings"
+)
+
+// pcmBytesPerSecond is the byte rate of OpenAI's headerless PCM speech output:
+// signed 16-bit, little-endian, mono, 24 kHz (24000 samples * 2 bytes).
+const pcmBytesPerSecond = 24000 * 2
+
+// measureSpeechDurationSeconds returns the playback duration, in seconds, of
+// synthesized speech the gateway can compute without decoding a compressed
+// codec. It parses self-describing WAV (RIFF/WAVE) containers and the fixed-rate
+// PCM stream OpenAI emits for response_format=pcm. Compressed formats (mp3,
+// opus, aac, flac) return ok=false so the caller can flag the cost as partial
+// rather than reporting a silent zero.
+func measureSpeechDurationSeconds(data []byte, format string) (float64, bool) {
+	if seconds, ok := wavDurationSeconds(data); ok {
+		return seconds, true
+	}
+	if normalizeAudioFormat(format) == "pcm" && len(data) > 0 {
+		return float64(len(data)) / pcmBytesPerSecond, true
+	}
+	return 0, false
+}
+
+// normalizeAudioFormat reduces a response_format token or audio MIME type to a
+// bare lowercase codec name (e.g. "audio/wav" -> "wav", "audio/mpeg" -> "mp3").
+func normalizeAudioFormat(format string) string {
+	f := strings.ToLower(strings.TrimSpace(format))
+	if f == "" {
+		return ""
+	}
+	// Strip MIME parameters, e.g. "audio/webm; codecs=opus".
+	f = strings.TrimSpace(strings.Split(f, ";")[0])
+	switch f {
+	case "audio/wav", "audio/x-wav", "audio/wave":
+		return "wav"
+	case "audio/mpeg", "audio/mp3":
+		return "mp3"
+	case "audio/opus", "audio/ogg":
+		return "opus"
+	case "audio/aac":
+		return "aac"
+	case "audio/flac", "audio/x-flac":
+		return "flac"
+	case "audio/pcm", "audio/l16", "audio/basic":
+		return "pcm"
+	}
+	return strings.TrimPrefix(f, "audio/")
+}
+
+// wavDurationSeconds parses a canonical RIFF/WAVE container and derives its
+// duration from the format byte rate and the data chunk size. It tolerates
+// extra chunks (LIST/fact/etc.) and a data chunk whose declared size is missing
+// or overruns the buffer (some streamed encoders write 0 or 0xFFFFFFFF), falling
+// back to the trailing byte count in that case.
+func wavDurationSeconds(data []byte) (float64, bool) {
+	if len(data) < 12 || string(data[0:4]) != "RIFF" || string(data[8:12]) != "WAVE" {
+		return 0, false
+	}
+
+	var byteRate uint32
+	var dataSize int
+	var haveFmt, haveData bool
+
+	pos := 12
+	for pos+8 <= len(data) {
+		id := string(data[pos : pos+4])
+		size := int(binary.LittleEndian.Uint32(data[pos+4 : pos+8]))
+		body := pos + 8
+
+		switch id {
+		case "fmt ":
+			// byte rate lives at offset 8 within the fmt chunk body.
+			if body+12 <= len(data) {
+				byteRate = binary.LittleEndian.Uint32(data[body+8 : body+12])
+				haveFmt = true
+			}
+		case "data":
+			remaining := len(data) - body
+			if size <= 0 || size > remaining {
+				size = remaining
+			}
+			dataSize = size
+			haveData = true
+		}
+
+		if haveFmt && haveData {
+			break
+		}
+		if size <= 0 {
+			break // malformed/streaming size: stop walking instead of spinning
+		}
+		pos = body + size
+		if size%2 == 1 {
+			pos++ // chunks are word-aligned
+		}
+	}
+
+	if !haveFmt || !haveData || byteRate == 0 || dataSize <= 0 {
+		return 0, false
+	}
+	return float64(dataSize) / float64(byteRate), true
+}

--- a/internal/usage/audio_duration_test.go
+++ b/internal/usage/audio_duration_test.go
@@ -83,6 +83,22 @@ func TestWavDurationSeconds_FallsBackToTrailingBytes(t *testing.T) {
 	}
 }
 
+func TestWavDurationSeconds_SkipsZeroLengthChunk(t *testing.T) {
+	// A valid zero-length non-data chunk (e.g. "fact") before "data" must not
+	// stop the walk; the duration is still derived from the following data chunk.
+	wav := buildWAV(t, 24000, 1, 16, 1.0)
+	idx := bytes.Index(wav, []byte("data"))
+	if idx < 0 {
+		t.Fatal("no data chunk")
+	}
+	withEmptyChunk := append(append(append([]byte{}, wav[:idx]...), []byte("fact\x00\x00\x00\x00")...), wav[idx:]...)
+
+	got, ok := wavDurationSeconds(withEmptyChunk)
+	if !ok || !nearlyEqual(got, 1.0) {
+		t.Errorf("got (%v, %v), want (1, true)", got, ok)
+	}
+}
+
 func TestNormalizeAudioFormat(t *testing.T) {
 	cases := map[string]string{
 		"wav":                     "wav",

--- a/internal/usage/audio_duration_test.go
+++ b/internal/usage/audio_duration_test.go
@@ -1,0 +1,111 @@
+package usage
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// buildWAV produces a canonical PCM WAV of the given duration so duration and
+// cost tests can assert exact, dependency-free measurements.
+func buildWAV(t *testing.T, sampleRate, channels, bitsPerSample int, seconds float64) []byte {
+	t.Helper()
+	byteRate := sampleRate * channels * bitsPerSample / 8
+	dataLen := int(float64(byteRate) * seconds)
+
+	var buf bytes.Buffer
+	write := func(v any) {
+		if err := binary.Write(&buf, binary.LittleEndian, v); err != nil {
+			t.Fatalf("write wav: %v", err)
+		}
+	}
+	buf.WriteString("RIFF")
+	write(uint32(36 + dataLen))
+	buf.WriteString("WAVE")
+	buf.WriteString("fmt ")
+	write(uint32(16))
+	write(uint16(1)) // PCM
+	write(uint16(channels))
+	write(uint32(sampleRate))
+	write(uint32(byteRate))
+	write(uint16(channels * bitsPerSample / 8))
+	write(uint16(bitsPerSample))
+	buf.WriteString("data")
+	write(uint32(dataLen))
+	buf.Write(make([]byte, dataLen))
+	return buf.Bytes()
+}
+
+func TestMeasureSpeechDurationSeconds(t *testing.T) {
+	tests := []struct {
+		name   string
+		data   []byte
+		format string
+		want   float64
+		wantOK bool
+	}{
+		{"wav 1s 24kHz mono", buildWAV(t, 24000, 1, 16, 1.0), "wav", 1.0, true},
+		{"wav 2.5s 48kHz stereo", buildWAV(t, 48000, 2, 16, 2.5), "wav", 2.5, true},
+		{"wav detected despite mp3 format hint", buildWAV(t, 24000, 1, 16, 0.5), "mp3", 0.5, true},
+		{"pcm half second", make([]byte, pcmBytesPerSecond/2), "pcm", 0.5, true},
+		{"pcm via mime", make([]byte, pcmBytesPerSecond), "audio/pcm", 1.0, true},
+		{"mp3 unmeasured", []byte("\xff\xfbnot really mp3"), "mp3", 0, false},
+		{"opus unmeasured", []byte("OggS....."), "opus", 0, false},
+		{"empty", nil, "wav", 0, false},
+		{"truncated riff", []byte("RIFF"), "wav", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := measureSpeechDurationSeconds(tt.data, tt.format)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && !nearlyEqual(got, tt.want) {
+				t.Errorf("seconds = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWavDurationSeconds_FallsBackToTrailingBytes(t *testing.T) {
+	// Some streamed encoders write an unknown (0xFFFFFFFF) data chunk size; the
+	// parser must fall back to the actual trailing byte count.
+	wav := buildWAV(t, 24000, 1, 16, 1.0)
+	idx := bytes.Index(wav, []byte("data"))
+	if idx < 0 {
+		t.Fatal("no data chunk")
+	}
+	binary.LittleEndian.PutUint32(wav[idx+4:idx+8], 0xFFFFFFFF)
+
+	got, ok := wavDurationSeconds(wav)
+	if !ok || !nearlyEqual(got, 1.0) {
+		t.Errorf("got (%v, %v), want (1, true)", got, ok)
+	}
+}
+
+func TestNormalizeAudioFormat(t *testing.T) {
+	cases := map[string]string{
+		"wav":                     "wav",
+		"WAV":                     "wav",
+		"audio/wav":               "wav",
+		"audio/mpeg":              "mp3",
+		"mp3":                     "mp3",
+		"audio/webm; codecs=opus": "webm",
+		"pcm":                     "pcm",
+		"audio/l16":               "pcm",
+		"":                        "",
+	}
+	for in, want := range cases {
+		if got := normalizeAudioFormat(in); got != want {
+			t.Errorf("normalizeAudioFormat(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func nearlyEqual(a, b float64) bool {
+	diff := a - b
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff < 1e-9
+}

--- a/internal/usage/audio_test.go
+++ b/internal/usage/audio_test.go
@@ -1,6 +1,7 @@
 package usage
 
 import (
+	"strings"
 	"testing"
 
 	"gomodel/internal/core"
@@ -9,7 +10,7 @@ import (
 func floatPtr(v float64) *float64 { return &v }
 
 func TestExtractFromSpeechRequest(t *testing.T) {
-	entry := ExtractFromSpeechRequest("hello", "req-1", "gpt-4o-mini-tts", "openai")
+	entry := ExtractFromSpeechRequest("hello", nil, "", "req-1", "gpt-4o-mini-tts", "openai")
 	if entry == nil {
 		t.Fatal("expected a usage entry")
 	}
@@ -25,7 +26,7 @@ func TestExtractFromSpeechRequest(t *testing.T) {
 }
 
 func TestExtractFromSpeechRequest_EmptyInput(t *testing.T) {
-	entry := ExtractFromSpeechRequest("", "req", "tts-1", "openai")
+	entry := ExtractFromSpeechRequest("", nil, "", "req", "tts-1", "openai")
 	if entry == nil {
 		t.Fatal("empty input should still yield an entry")
 	}
@@ -36,17 +37,53 @@ func TestExtractFromSpeechRequest_EmptyInput(t *testing.T) {
 
 func TestExtractFromSpeechRequest_PerCharacterPricing(t *testing.T) {
 	// "hello" = 5 characters at $0.00001/char => $0.00005.
-	entry := ExtractFromSpeechRequest("hello", "req", "tts-1", "openai", &core.ModelPricing{PerCharacterInput: floatPtr(0.00001)})
+	entry := ExtractFromSpeechRequest("hello", nil, "", "req", "tts-1", "openai", &core.ModelPricing{PerCharacterInput: floatPtr(0.00001)})
 	assertCostPtrNear(t, "input cost", entry.InputCost, 0.00005)
 	assertCostPtrNear(t, "total cost", entry.TotalCost, 0.00005)
 }
 
-func TestExtractFromSpeechRequest_NoPerCharacterRateStaysUnpriced(t *testing.T) {
-	// gpt-4o-mini-tts is priced by output audio duration, which the gateway does
-	// not measure; with only an output-side audio rate, character usage is unpriced.
-	entry := ExtractFromSpeechRequest("hello", "req", "gpt-4o-mini-tts", "openai", &core.ModelPricing{PerSecondOutput: floatPtr(0.00025)})
-	if entry.TotalCost != nil {
-		t.Errorf("want nil cost when only output audio duration is priced, got %v", *entry.TotalCost)
+func TestExtractFromSpeechRequest_WavOutputPerSecondOutput(t *testing.T) {
+	// A 1-second 24 kHz mono 16-bit WAV at $0.00025/sec => $0.00025 output cost.
+	wav := buildWAV(t, 24000, 1, 16, 1.0)
+	entry := ExtractFromSpeechRequest("hello", wav, "wav", "req", "gpt-4o-mini-tts", "openai",
+		&core.ModelPricing{InputPerMtok: floatPtr(0.6), PerSecondOutput: floatPtr(0.00025)})
+
+	if got := entry.RawData[rawKeyAudioOutputSeconds]; got != float64(1) {
+		t.Errorf("audio_output_seconds = %v, want 1", got)
+	}
+	assertCostPtrNear(t, "output cost", entry.OutputCost, 0.00025)
+	assertCostPtrNear(t, "total cost", entry.TotalCost, 0.00025)
+	if entry.CostsCalculationCaveat != "" {
+		t.Errorf("measured wav should carry no caveat, got %q", entry.CostsCalculationCaveat)
+	}
+}
+
+func TestExtractFromSpeechRequest_PcmOutputPerSecondOutput(t *testing.T) {
+	// Headerless PCM is 48000 bytes/sec; 24000 bytes => 0.5s at $0.00025/sec.
+	pcm := make([]byte, 24000)
+	entry := ExtractFromSpeechRequest("hi", pcm, "pcm", "req", "gpt-4o-mini-tts", "openai",
+		&core.ModelPricing{PerSecondOutput: floatPtr(0.00025)})
+
+	if got := entry.RawData[rawKeyAudioOutputSeconds]; got != 0.5 {
+		t.Errorf("audio_output_seconds = %v, want 0.5", got)
+	}
+	assertCostPtrNear(t, "output cost", entry.OutputCost, 0.000125)
+}
+
+func TestExtractFromSpeechRequest_CompressedOutputCaveat(t *testing.T) {
+	// mp3 output cannot be measured without decoding; the per-second-output model
+	// must surface a caveat rather than a silent zero.
+	entry := ExtractFromSpeechRequest("hello", []byte("\xff\xfbmp3 frames"), "mp3", "req", "gpt-4o-mini-tts", "openai",
+		&core.ModelPricing{InputPerMtok: floatPtr(0.6), PerSecondOutput: floatPtr(0.00025)})
+
+	if _, ok := entry.RawData[rawKeyAudioOutputSeconds]; ok {
+		t.Error("mp3 output should not record a measured duration")
+	}
+	if entry.RawData[rawKeyAudioOutputFormat] != "mp3" {
+		t.Errorf("audio_output_format = %v, want mp3", entry.RawData[rawKeyAudioOutputFormat])
+	}
+	if !strings.Contains(entry.CostsCalculationCaveat, "mp3") {
+		t.Errorf("want caveat mentioning mp3, got %q", entry.CostsCalculationCaveat)
 	}
 }
 

--- a/internal/usage/cost.go
+++ b/internal/usage/cost.go
@@ -192,13 +192,33 @@ func CalculateGranularCost(inputTokens, outputTokens int, rawData map[string]any
 	}
 
 	// Price non-token audio units the providers report outside the usage tokens:
-	// per-character input for text-to-speech and per-second input audio duration
-	// for transcription. Both quantities live in RawData (see usage/audio.go).
-	if audioCost, ok := applyAudioUnitCosts(rawData, pricing); ok {
-		inputCost += audioCost
-		hasInput = true
+	// per-character input for text-to-speech, per-second input audio duration for
+	// transcription, and per-second output audio duration for text-to-speech.
+	// All quantities live in RawData (see usage/audio.go).
+	if inAudio, outAudio, ok := applyAudioUnitCosts(rawData, pricing); ok {
+		if inAudio > 0 {
+			inputCost += inAudio
+			hasInput = true
+		}
+		if outAudio > 0 {
+			outputCost += outAudio
+			hasOutput = true
+		}
 		mappedKeys[rawKeyInputCharacters] = true
 		mappedKeys[rawKeyAudioSeconds] = true
+		mappedKeys[rawKeyAudioOutputSeconds] = true
+	}
+
+	// Flag speech priced by output audio duration whose codec the gateway could
+	// not measure (compressed mp3/opus/aac/flac), so the cost reads as visibly
+	// partial instead of a silent zero. Transcription rows never set the output
+	// format key, so per-second-output transcription models are unaffected.
+	if pricing.PerSecondOutput != nil {
+		if _, measured := extractFloat(rawData, rawKeyAudioOutputSeconds); !measured {
+			if format, ok := rawData[rawKeyAudioOutputFormat].(string); ok && format != "" {
+				caveats = append(caveats, "audio output duration unmeasured for format: "+format)
+			}
+		}
 	}
 
 	// Check for unmapped token fields in RawData
@@ -246,26 +266,32 @@ func CalculateGranularCost(inputTokens, outputTokens int, rawData map[string]any
 
 // applyAudioUnitCosts prices the non-token audio units carried in RawData:
 // PerCharacterInput against input characters (text-to-speech) and PerSecondInput
-// against input audio seconds (transcription). Both are input-side costs. It
-// returns the summed cost and whether any rate applied. Models priced by output
-// audio duration (e.g. gpt-4o-mini-tts) are not handled here because the gateway
-// proxies opaque audio bytes and does not measure their duration.
-func applyAudioUnitCosts(rawData map[string]any, pricing *core.ModelPricing) (float64, bool) {
-	var cost float64
-	var applied bool
+// against input audio seconds (transcription) on the input side, and
+// PerSecondOutput against synthesized audio seconds (text-to-speech) on the
+// output side. It returns the input and output costs and whether any rate
+// applied. Output duration is present only when the gateway could measure the
+// returned audio (uncompressed wav/pcm); compressed formats are flagged with a
+// caveat by the caller instead.
+func applyAudioUnitCosts(rawData map[string]any, pricing *core.ModelPricing) (inputCost, outputCost float64, applied bool) {
 	if pricing.PerCharacterInput != nil {
 		if chars := extractInt(rawData, rawKeyInputCharacters); chars > 0 {
-			cost += float64(chars) * *pricing.PerCharacterInput
+			inputCost += float64(chars) * *pricing.PerCharacterInput
 			applied = true
 		}
 	}
 	if pricing.PerSecondInput != nil {
 		if seconds, ok := extractFloat(rawData, rawKeyAudioSeconds); ok && seconds > 0 {
-			cost += seconds * *pricing.PerSecondInput
+			inputCost += seconds * *pricing.PerSecondInput
 			applied = true
 		}
 	}
-	return cost, applied
+	if pricing.PerSecondOutput != nil {
+		if seconds, ok := extractFloat(rawData, rawKeyAudioOutputSeconds); ok && seconds > 0 {
+			outputCost += seconds * *pricing.PerSecondOutput
+			applied = true
+		}
+	}
+	return inputCost, outputCost, applied
 }
 
 func pricingForTokenCount(pricing *core.ModelPricing, inputTokens int) *core.ModelPricing {

--- a/tests/contract/openai_audio_test.go
+++ b/tests/contract/openai_audio_test.go
@@ -29,14 +29,19 @@ func openAIAudioProvider(t *testing.T, routes map[string]replayRoute) core.Audio
 }
 
 func TestOpenAIReplayCreateSpeech(t *testing.T) {
+	// The response is tagged with the upstream Content-Type, which describes the
+	// bytes actually returned (usage prices output-duration models from it). The
+	// requested response_format does not override it — the last case returns mp3
+	// for a wav request to prove the upstream type wins.
 	testCases := []struct {
 		name           string
 		responseFormat string
-		wantType       string
+		upstreamType   string
 	}{
-		{name: "default", responseFormat: "", wantType: "audio/mpeg"},
-		{name: "wav", responseFormat: "wav", wantType: "audio/wav"},
-		{name: "opus", responseFormat: "opus", wantType: "audio/ogg"},
+		{name: "mp3 default", responseFormat: "", upstreamType: "audio/mpeg"},
+		{name: "wav", responseFormat: "wav", upstreamType: "audio/wav"},
+		{name: "opus", responseFormat: "opus", upstreamType: "audio/opus"},
+		{name: "upstream overrides requested format", responseFormat: "wav", upstreamType: "audio/mpeg"},
 	}
 
 	for _, tc := range testCases {
@@ -45,7 +50,7 @@ func TestOpenAIReplayCreateSpeech(t *testing.T) {
 			audio := openAIAudioProvider(t, map[string]replayRoute{
 				replayKey(http.MethodPost, "/audio/speech"): {
 					statusCode:  http.StatusOK,
-					contentType: "audio/mpeg",
+					contentType: tc.upstreamType,
 					body:        audioBytes,
 				},
 			})
@@ -58,8 +63,7 @@ func TestOpenAIReplayCreateSpeech(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.NotNil(t, resp)
-			// Content type is derived from the requested format, not the upstream header.
-			require.Equal(t, tc.wantType, resp.ContentType)
+			require.Equal(t, tc.upstreamType, resp.ContentType)
 			require.Equal(t, audioBytes, resp.Data)
 		})
 	}


### PR DESCRIPTION
## Summary

Text-to-speech models priced by **output audio duration** — `gpt-4o-mini-tts` and the rest of the gpt-4o TTS family — were logged with a **silent `total_cost` of 0** and no caveat. Their registry pricing carries `per_second_output` (e.g. `$0.00025/s` = $0.015/min) but **no** `per_character_input`, and the cost path only applied `PerCharacterInput` / `PerSecondInput`. Legacy per-character models (`tts-1`) and all STT models were already costed correctly.

This was found during release smoke testing: `gpt-4o-mini-tts` recorded `input_characters` but `total_cost=0`, while `tts-1` (per-character) and `whisper-1`/`gpt-4o-transcribe` (per-second / per-token) priced fine.

## Fix

The gateway already has the synthesized audio bytes at usage time, so it can measure the duration that `per_second_output` needs:

- **WAV** (`response_format=wav`): parsed from the self-describing RIFF/WAVE header (byte rate × data-chunk size), tolerant of extra chunks and unknown/streamed data sizes.
- **PCM** (`response_format=pcm`): OpenAI's headerless 16-bit / 24 kHz / mono stream → `len/48000` bytes-per-second.
- **Compressed** (mp3 — the API default — opus, aac, flac): cannot be measured without a decoder, so they now surface `costs_calculation_caveat: "audio output duration unmeasured for format: <fmt>"` instead of a silent `$0`.

`PerSecondOutput` is applied on the **output** side; the new `audio_output_seconds` / `audio_output_format` keys live in `raw_data`. **Transcription is untouched** — STT rows set `audio_seconds` (input) and never the new output keys, so per-second-output STT models like `whisper-1` are unaffected.

## User-visible impact

- TTS usage rows for output-duration-priced models now report real cost for uncompressed output and an explicit caveat (not a silent `$0`) for compressed output.
- New `raw_data` fields on `/v1/audio/speech` usage entries: `audio_output_seconds` (when measured) and `audio_output_format`.
- No public API change; no config change.

## Testing

- New unit tests: WAV/PCM/compressed duration measurement, unknown-data-size fallback, format normalization, and cost paths (WAV output → `PerSecondOutput`, PCM output, mp3 → caveat).
- New end-to-end service test: a WAV-returning `gpt-4o-mini-tts` is priced via `PerSecondOutput` through the full `CreateSpeech` path.
- `go test ./...` green; `make lint`, `make test-race`, and the hot-path perf guard pass.
- **Live verified** against the release e2e stack on SQLite, PostgreSQL, and MongoDB:
  - WAV → `audio_output_seconds` measured, `total_cost = secs × $0.00025` (e.g. 5s → `$0.00125`) on all three backends.
  - MP3 → `total_cost=0` **with** caveat `audio output duration unmeasured for format: mp3`.
  - PCM → measured via fixed rate.

## Follow-up (not in this PR)

Measuring duration for compressed formats (mp3/opus/aac/flac) would need a decoder/parser; left as a caveat for now. The text-token input cost for these models (`input_per_mtok`) is also not applied since the gateway records characters, not tokens — negligible next to the audio-output cost, and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Usage billing for text‑to‑speech now derives from synthesized audio output (measured duration and normalized format) when available.

* **Improvements**
  * Improved audio format normalization and duration estimation; billing records output-audio-seconds and adds caveats when duration is unmeasurable.
  * Pricing now separates input vs. output audio costs; gateway respects upstream Content-Type for returned audio.

* **Tests**
  * Added tests for WAV/PCM duration measurement, format normalization, output-duration pricing, and upstream Content-Type handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->