### PR TITLE
refactor: deduplicate shared helpers and consolidate app startup wiring

### DIFF
--- a/internal/aliases/store.go
+++ b/internal/aliases/store.go
@@ -4,39 +4,23 @@ import (
 	"context"
 	"errors"
 	"strings"
+
+	"gomodel/internal/validation"
 )
 
 // ErrNotFound indicates a requested alias was not found.
 var ErrNotFound = errors.New("alias not found")
 
 // ValidationError indicates invalid alias input or invalid alias state.
-type ValidationError struct {
-	Message string
-	Err     error
-}
-
-func (e *ValidationError) Error() string {
-	if e == nil {
-		return ""
-	}
-	return e.Message
-}
-
-func (e *ValidationError) Unwrap() error {
-	if e == nil {
-		return nil
-	}
-	return e.Err
-}
+type ValidationError = validation.Error
 
 func newValidationError(message string, err error) error {
-	return &ValidationError{Message: message, Err: err}
+	return validation.NewError(message, err)
 }
 
 // IsValidationError reports whether err is a validation error.
 func IsValidationError(err error) bool {
-	_, ok := errors.AsType[*ValidationError](err)
-	return ok
+	return validation.IsError(err)
 }
 
 // Store defines persistence operations for aliases.

--- a/internal/anthropicapi/request.go
+++ b/internal/anthropicapi/request.go
@@ -247,7 +247,7 @@ func collapseParts(parts []core.ContentPart) core.MessageContent {
 // blocks is non-nil (possibly empty).
 func parseContent(raw json.RawMessage) (text string, blocks []ContentBlock, err error) {
 	trimmed := bytes.TrimSpace(raw)
-	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+	if core.IsJSONNull(trimmed) {
 		return "", nil, nil
 	}
 	switch trimmed[0] {
@@ -339,7 +339,7 @@ func imageURLFromSource(source *Source) (string, error) {
 // the form expected by core.FunctionCall.Arguments.
 func rawToArguments(raw json.RawMessage) string {
 	trimmed := bytes.TrimSpace(raw)
-	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+	if core.IsJSONNull(trimmed) {
 		return "{}"
 	}
 	var compact bytes.Buffer

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -113,8 +113,12 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 	// closers collects the Close functions of successfully initialized
 	// components; fail unwinds them in reverse order before returning an
 	// initialization error. Appending here is the single source of truth
-	// for the cleanup order on startup failure.
-	var closers []func() error
+	// for the cleanup order on startup failure. The live broker is created
+	// above, so it is the first entry.
+	closers := []func() error{func() error {
+		app.live.Close()
+		return nil
+	}}
 	fail := func(msg string, cause error) (*App, error) {
 		var closeErrs []error
 		for i := len(closers) - 1; i >= 0; i-- {
@@ -144,7 +148,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 
 	providerResult, err := providers.Init(ctx, cfg.AppConfig, cfg.Factory)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize providers: %w", err)
+		return fail("failed to initialize providers", err)
 	}
 	app.providers = providerResult
 	closers = append(closers, app.providers.Close)
@@ -661,7 +665,16 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// 2. Close providers (stops model refresh and provider-owned resources)
+	// 2. Release server-owned resources now that no requests are in flight
+	// (drains response cache writes, closes response/conversation stores).
+	if a.server != nil {
+		if err := a.server.Shutdown(ctx); err != nil {
+			slog.Error("server resources close error", "error", err)
+			errs = append(errs, fmt.Errorf("server resources close: %w", err))
+		}
+	}
+
+	// 3. Close providers (stops model refresh and provider-owned resources)
 	if a.providers != nil {
 		if err := a.providers.Close(); err != nil {
 			slog.Error("providers close error", "error", err)
@@ -669,7 +682,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// 3. Close aliases subsystem.
+	// 4. Close aliases subsystem.
 	if a.aliases != nil {
 		if err := a.aliases.Close(); err != nil {
 			slog.Error("aliases close error", "error", err)
@@ -677,7 +690,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// 4. Close workflows subsystem.
+	// 5. Close workflows subsystem.
 	if a.workflows != nil {
 		if err := a.workflows.Close(); err != nil {
 			slog.Error("workflows close error", "error", err)
@@ -685,7 +698,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// 5. Close model overrides subsystem.
+	// 6. Close model overrides subsystem.
 	if a.modelOverrides != nil {
 		if err := a.modelOverrides.Close(); err != nil {
 			slog.Error("model overrides close error", "error", err)
@@ -693,7 +706,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// 6. Close model pricing overrides subsystem.
+	// 7. Close model pricing overrides subsystem.
 	if a.pricingOverrides != nil {
 		if err := a.pricingOverrides.Close(); err != nil {
 			slog.Error("model pricing overrides close error", "error", err)
@@ -701,7 +714,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// 7. Close reusable guardrails subsystem.
+	// 8. Close reusable guardrails subsystem.
 	if a.guardrails != nil {
 		if err := a.guardrails.Close(); err != nil {
 			slog.Error("guardrails close error", "error", err)
@@ -709,7 +722,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// 8. Close managed auth keys subsystem.
+	// 9. Close managed auth keys subsystem.
 	if a.authKeys != nil {
 		if err := a.authKeys.Close(); err != nil {
 			slog.Error("auth keys close error", "error", err)
@@ -717,7 +730,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// 9. Close file mapping store.
+	// 10. Close file mapping store.
 	if a.fileStore != nil {
 		if err := a.fileStore.Close(); err != nil {
 			slog.Error("file mapping store close error", "error", err)
@@ -725,7 +738,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// 10. Close batch store (flushes pending entries)
+	// 11. Close batch store (flushes pending entries)
 	if a.batch != nil {
 		if err := a.batch.Close(); err != nil {
 			slog.Error("batch store close error", "error", err)
@@ -733,7 +746,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// 11. Close budget subsystem.
+	// 12. Close budget subsystem.
 	if a.budgets != nil {
 		if err := a.budgets.Close(); err != nil {
 			slog.Error("budgets close error", "error", err)
@@ -741,7 +754,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// 12. Close usage tracking (flushes pending entries)
+	// 13. Close usage tracking (flushes pending entries)
 	if a.usage != nil {
 		if err := a.usage.Close(); err != nil {
 			slog.Error("usage logger close error", "error", err)
@@ -749,7 +762,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// 13. Close audit logging (flushes pending logs)
+	// 14. Close audit logging (flushes pending logs)
 	if a.audit != nil {
 		if err := a.audit.Close(); err != nil {
 			slog.Error("audit logger close error", "error", err)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -110,22 +110,53 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		Heartbeat:   time.Duration(appCfg.Admin.LiveLogsHeartbeatSeconds) * time.Second,
 	})
 
+	// closers collects the Close functions of successfully initialized
+	// components; fail unwinds them in reverse order before returning an
+	// initialization error. Appending here is the single source of truth
+	// for the cleanup order on startup failure.
+	var closers []func() error
+	fail := func(msg string, cause error) (*App, error) {
+		var closeErrs []error
+		for i := len(closers) - 1; i >= 0; i-- {
+			closeErrs = append(closeErrs, closers[i]())
+		}
+		closeErr := errors.Join(closeErrs...)
+		switch {
+		case cause != nil && closeErr != nil:
+			return nil, fmt.Errorf("%s: %w (also: close error: %v)", msg, cause, closeErr)
+		case cause != nil:
+			return nil, fmt.Errorf("%s: %w", msg, cause)
+		case closeErr != nil:
+			return nil, fmt.Errorf("%s (also: close error: %v)", msg, closeErr)
+		default:
+			return nil, errors.New(msg)
+		}
+	}
+
+	// sharedStorage is the first non-nil storage backend among initialized
+	// components; later stores reuse it instead of opening their own.
+	var sharedStorage storage.Storage
+	claimSharedStorage := func(s storage.Storage) {
+		if sharedStorage == nil {
+			sharedStorage = s
+		}
+	}
+
 	providerResult, err := providers.Init(ctx, cfg.AppConfig, cfg.Factory)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize providers: %w", err)
 	}
 	app.providers = providerResult
+	closers = append(closers, app.providers.Close)
 
 	// Initialize audit logging
 	auditResult, err := auditlog.New(ctx, appCfg)
 	if err != nil {
-		closeErr := app.providers.Close()
-		if closeErr != nil {
-			return nil, fmt.Errorf("failed to initialize audit logging: %w (also: providers close error: %v)", err, closeErr)
-		}
-		return nil, fmt.Errorf("failed to initialize audit logging: %w", err)
+		return fail("failed to initialize audit logging", err)
 	}
 	app.audit = auditResult
+	closers = append(closers, app.audit.Close)
+	claimSharedStorage(auditResult.Storage)
 
 	// Initialize usage tracking
 	// Use shared storage if both audit logging and usage tracking use the same backend
@@ -138,139 +169,107 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		usageResult, err = usage.New(ctx, appCfg)
 	}
 	if err != nil {
-		closeErr := errors.Join(app.audit.Close(), app.providers.Close())
-		if closeErr != nil {
-			return nil, fmt.Errorf("failed to initialize usage tracking: %w (also: close error: %v)", err, closeErr)
-		}
-		return nil, fmt.Errorf("failed to initialize usage tracking: %w", err)
+		return fail("failed to initialize usage tracking", err)
 	}
 	if usageResult == nil || usageResult.Logger == nil {
-		var usageCloseErr error
 		if usageResult != nil {
-			usageCloseErr = usageResult.Close()
+			closers = append(closers, usageResult.Close)
 		}
-		closeErr := errors.Join(usageCloseErr, app.audit.Close(), app.providers.Close())
-		if closeErr != nil {
-			return nil, fmt.Errorf("usage tracking initialization returned nil result (also: close error: %v)", closeErr)
-		}
-		return nil, fmt.Errorf("usage tracking initialization returned nil result")
+		return fail("usage tracking initialization returned nil result", nil)
 	}
 	app.usage = usageResult
+	closers = append(closers, app.usage.Close)
+	claimSharedStorage(usageResult.Storage)
 
 	var budgetResult *budget.Result
 	if appCfg.Budgets.Enabled {
-		sharedBudgetStorage := firstSharedStorage(auditResult.Storage, usageResult.Storage)
-		if sharedBudgetStorage != nil {
-			budgetResult, err = budget.NewWithSharedStorage(ctx, appCfg, sharedBudgetStorage)
+		if sharedStorage != nil {
+			budgetResult, err = budget.NewWithSharedStorage(ctx, appCfg, sharedStorage)
 		} else {
 			budgetResult, err = budget.New(ctx, appCfg)
 		}
 		if err != nil {
-			closeErr := errors.Join(app.usage.Close(), app.audit.Close(), app.providers.Close())
-			if closeErr != nil {
-				return nil, fmt.Errorf("failed to initialize budgets: %w (also: close error: %v)", err, closeErr)
-			}
-			return nil, fmt.Errorf("failed to initialize budgets: %w", err)
+			return fail("failed to initialize budgets", err)
 		}
 	} else {
 		budgetResult = &budget.Result{}
 		slog.Info("budgets disabled")
 	}
 	app.budgets = budgetResult
+	closers = append(closers, app.budgets.Close)
 
 	// Initialize batch lifecycle storage.
 	var batchResult *batch.Result
-	if auditResult.Storage != nil {
-		batchResult, err = batch.NewWithSharedStorage(ctx, auditResult.Storage)
-	} else if usageResult.Storage != nil {
-		batchResult, err = batch.NewWithSharedStorage(ctx, usageResult.Storage)
+	if sharedStorage != nil {
+		batchResult, err = batch.NewWithSharedStorage(ctx, sharedStorage)
 	} else {
 		batchResult, err = batch.New(ctx, appCfg)
 	}
 	if err != nil {
-		closeErr := errors.Join(app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
-		if closeErr != nil {
-			return nil, fmt.Errorf("failed to initialize batch storage: %w (also: close error: %v)", err, closeErr)
-		}
-		return nil, fmt.Errorf("failed to initialize batch storage: %w", err)
+		return fail("failed to initialize batch storage", err)
 	}
 	app.batch = batchResult
+	closers = append(closers, app.batch.Close)
+	claimSharedStorage(batchResult.Storage)
 
 	// Initialize file provider mapping storage for OpenAI-compatible Files/Batches workflows.
 	var fileStoreResult *filestore.Result
-	sharedFileStorage := firstSharedStorage(auditResult.Storage, usageResult.Storage, batchResult.Storage)
-	if sharedFileStorage != nil {
-		fileStoreResult, err = filestore.NewWithSharedStorage(ctx, sharedFileStorage)
+	if sharedStorage != nil {
+		fileStoreResult, err = filestore.NewWithSharedStorage(ctx, sharedStorage)
 	} else {
 		fileStoreResult, err = filestore.New(ctx, appCfg)
 	}
 	if err != nil {
-		closeErr := errors.Join(app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
-		if closeErr != nil {
-			return nil, fmt.Errorf("failed to initialize file mapping storage: %w (also: close error: %v)", err, closeErr)
-		}
-		return nil, fmt.Errorf("failed to initialize file mapping storage: %w", err)
+		return fail("failed to initialize file mapping storage", err)
 	}
 	app.fileStore = fileStoreResult
+	closers = append(closers, app.fileStore.Close)
+	claimSharedStorage(fileStoreResult.Storage)
 
 	// Initialize aliases using shared storage when already available.
 	var aliasResult *aliases.Result
-	if auditResult.Storage != nil {
-		aliasResult, err = aliases.NewWithSharedStorage(ctx, appCfg, auditResult.Storage, providerResult.Registry)
-	} else if usageResult.Storage != nil {
-		aliasResult, err = aliases.NewWithSharedStorage(ctx, appCfg, usageResult.Storage, providerResult.Registry)
-	} else if batchResult.Storage != nil {
-		aliasResult, err = aliases.NewWithSharedStorage(ctx, appCfg, batchResult.Storage, providerResult.Registry)
-	} else if fileStoreResult.Storage != nil {
-		aliasResult, err = aliases.NewWithSharedStorage(ctx, appCfg, fileStoreResult.Storage, providerResult.Registry)
+	if sharedStorage != nil {
+		aliasResult, err = aliases.NewWithSharedStorage(ctx, appCfg, sharedStorage, providerResult.Registry)
 	} else {
 		aliasResult, err = aliases.New(ctx, appCfg, providerResult.Registry)
 	}
 	if err != nil {
-		closeErr := errors.Join(app.fileStore.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
-		if closeErr != nil {
-			return nil, fmt.Errorf("failed to initialize aliases: %w (also: close error: %v)", err, closeErr)
-		}
-		return nil, fmt.Errorf("failed to initialize aliases: %w", err)
+		return fail("failed to initialize aliases", err)
 	}
 	app.aliases = aliasResult
+	closers = append(closers, app.aliases.Close)
+	claimSharedStorage(aliasResult.Storage)
 
 	var modelOverrideResult *modeloverrides.Result
 	if appCfg.Models.OverridesEnabled {
-		sharedModelOverrideStorage := firstSharedStorage(auditResult.Storage, usageResult.Storage, batchResult.Storage, fileStoreResult.Storage, aliasResult.Storage)
-		if sharedModelOverrideStorage != nil {
-			modelOverrideResult, err = modeloverrides.NewWithSharedStorage(ctx, appCfg, sharedModelOverrideStorage, providerResult.Registry)
+		if sharedStorage != nil {
+			modelOverrideResult, err = modeloverrides.NewWithSharedStorage(ctx, appCfg, sharedStorage, providerResult.Registry)
 		} else {
 			modelOverrideResult, err = modeloverrides.New(ctx, appCfg, providerResult.Registry)
 		}
 		if err != nil {
-			closeErr := errors.Join(app.aliases.Close(), app.fileStore.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
-			if closeErr != nil {
-				return nil, fmt.Errorf("failed to initialize model overrides: %w (also: close error: %v)", err, closeErr)
-			}
-			return nil, fmt.Errorf("failed to initialize model overrides: %w", err)
+			return fail("failed to initialize model overrides", err)
 		}
 	} else {
 		modelOverrideResult = &modeloverrides.Result{}
 		slog.Info("model overrides disabled")
 	}
 	app.modelOverrides = modelOverrideResult
+	closers = append(closers, app.modelOverrides.Close)
+	claimSharedStorage(modelOverrideResult.Storage)
 
 	var pricingOverrideResult *pricingoverrides.Result
-	sharedPricingOverrideStorage := firstSharedStorage(auditResult.Storage, usageResult.Storage, batchResult.Storage, fileStoreResult.Storage, aliasResult.Storage, modelOverrideResult.Storage)
-	if sharedPricingOverrideStorage != nil {
-		pricingOverrideResult, err = pricingoverrides.NewWithSharedStorage(ctx, appCfg, sharedPricingOverrideStorage, providerResult.Registry, providerResult.Registry)
+	if sharedStorage != nil {
+		pricingOverrideResult, err = pricingoverrides.NewWithSharedStorage(ctx, appCfg, sharedStorage, providerResult.Registry, providerResult.Registry)
 	} else {
 		pricingOverrideResult, err = pricingoverrides.New(ctx, appCfg, providerResult.Registry, providerResult.Registry)
 	}
 	if err != nil {
-		closeErr := errors.Join(app.modelOverrides.Close(), app.aliases.Close(), app.fileStore.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
-		if closeErr != nil {
-			return nil, fmt.Errorf("failed to initialize model pricing overrides: %w (also: close error: %v)", err, closeErr)
-		}
-		return nil, fmt.Errorf("failed to initialize model pricing overrides: %w", err)
+		return fail("failed to initialize model pricing overrides", err)
 	}
 	app.pricingOverrides = pricingOverrideResult
+	closers = append(closers, app.pricingOverrides.Close)
+	claimSharedStorage(pricingOverrideResult.Storage)
 	pricingResolver := usage.PricingResolver(providerResult.Registry)
 	if app.pricingOverrides != nil && app.pricingOverrides.Service != nil {
 		pricingResolver = app.pricingOverrides.Service
@@ -284,35 +283,24 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 
 	// Initialize reusable guardrail definitions using shared storage when already available.
 	var guardrailResult *guardrails.Result
-	sharedGuardrailStorage := firstSharedStorage(auditResult.Storage, usageResult.Storage, batchResult.Storage, fileStoreResult.Storage, aliasResult.Storage, modelOverrideResult.Storage, pricingOverrideResult.Storage)
-	if sharedGuardrailStorage != nil {
-		guardrailResult, err = guardrails.NewWithSharedStorage(ctx, sharedGuardrailStorage, refreshInterval, guardrailExecutor)
+	if sharedStorage != nil {
+		guardrailResult, err = guardrails.NewWithSharedStorage(ctx, sharedStorage, refreshInterval, guardrailExecutor)
 	} else {
 		guardrailResult, err = guardrails.New(ctx, appCfg, refreshInterval, guardrailExecutor)
 	}
 	if err != nil {
-		closeErr := errors.Join(app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.fileStore.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
-		if closeErr != nil {
-			return nil, fmt.Errorf("failed to initialize guardrails: %w (also: close error: %v)", err, closeErr)
-		}
-		return nil, fmt.Errorf("failed to initialize guardrails: %w", err)
+		return fail("failed to initialize guardrails", err)
 	}
 	app.guardrails = guardrailResult
+	closers = append(closers, app.guardrails.Close)
+	claimSharedStorage(guardrailResult.Storage)
 
 	seedGuardrails, err := configGuardrailDefinitions(appCfg.Guardrails)
 	if err != nil {
-		closeErr := errors.Join(app.guardrails.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.fileStore.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
-		if closeErr != nil {
-			return nil, fmt.Errorf("failed to prepare guardrail definitions: %w (also: close error: %v)", err, closeErr)
-		}
-		return nil, fmt.Errorf("failed to prepare guardrail definitions: %w", err)
+		return fail("failed to prepare guardrail definitions", err)
 	}
 	if err := guardrailResult.Service.UpsertDefinitions(ctx, seedGuardrails); err != nil {
-		closeErr := errors.Join(app.guardrails.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.fileStore.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
-		if closeErr != nil {
-			return nil, fmt.Errorf("failed to upsert guardrails: %w (also: close error: %v)", err, closeErr)
-		}
-		return nil, fmt.Errorf("failed to upsert guardrails: %w", err)
+		return fail("failed to upsert guardrails", err)
 	}
 
 	// Build runtime execution dependencies. Policy is passed explicitly into the
@@ -323,62 +311,37 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 	featureCaps := runtimeWorkflowFeatureCaps(appCfg)
 
 	var workflowResult *workflows.Result
-	sharedWorkflowStorage := firstSharedStorage(auditResult.Storage, usageResult.Storage, batchResult.Storage, fileStoreResult.Storage, aliasResult.Storage, modelOverrideResult.Storage, pricingOverrideResult.Storage, guardrailResult.Storage)
 	workflowCompiler := workflows.NewCompilerWithFeatureCaps(guardrailResult.Service, featureCaps)
-	if sharedWorkflowStorage != nil {
-		workflowResult, err = workflows.NewWithSharedStorage(ctx, sharedWorkflowStorage, workflowCompiler, refreshInterval)
+	if sharedStorage != nil {
+		workflowResult, err = workflows.NewWithSharedStorage(ctx, sharedStorage, workflowCompiler, refreshInterval)
 	} else {
 		workflowResult, err = workflows.New(ctx, appCfg, workflowCompiler, refreshInterval)
 	}
 	if err != nil {
-		closeErr := errors.Join(app.guardrails.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.fileStore.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
-		if closeErr != nil {
-			return nil, fmt.Errorf("failed to initialize workflows: %w (also: close error: %v)", err, closeErr)
-		}
-		return nil, fmt.Errorf("failed to initialize workflows: %w", err)
+		return fail("failed to initialize workflows", err)
 	}
+	closers = append(closers, workflowResult.Close)
+	claimSharedStorage(workflowResult.Storage)
 	defaultWorkflow := defaultWorkflowInput(appCfg, guardrailResult.Service.Names(), seedGuardrails)
 	if err := workflowResult.Service.EnsureDefaultGlobal(ctx, defaultWorkflow); err != nil {
-		closeErr := errors.Join(workflowResult.Close(), app.guardrails.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.fileStore.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
-		if closeErr != nil {
-			return nil, fmt.Errorf("failed to seed workflows: %w (also: close error: %v)", err, closeErr)
-		}
-		return nil, fmt.Errorf("failed to seed workflows: %w", err)
+		return fail("failed to seed workflows", err)
 	}
 	if err := workflowResult.Service.Refresh(ctx); err != nil {
-		closeErr := errors.Join(workflowResult.Close(), app.guardrails.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.fileStore.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
-		if closeErr != nil {
-			return nil, fmt.Errorf("failed to load workflows: %w (also: close error: %v)", err, closeErr)
-		}
-		return nil, fmt.Errorf("failed to load workflows: %w", err)
+		return fail("failed to load workflows", err)
 	}
 	app.workflows = workflowResult
 
 	var authKeyResult *authkeys.Result
-	sharedAuthKeyStorage := firstSharedStorage(
-		auditResult.Storage,
-		usageResult.Storage,
-		batchResult.Storage,
-		fileStoreResult.Storage,
-		aliasResult.Storage,
-		modelOverrideResult.Storage,
-		pricingOverrideResult.Storage,
-		guardrailResult.Storage,
-		workflowResult.Storage,
-	)
-	if sharedAuthKeyStorage != nil {
-		authKeyResult, err = authkeys.NewWithSharedStorage(ctx, sharedAuthKeyStorage)
+	if sharedStorage != nil {
+		authKeyResult, err = authkeys.NewWithSharedStorage(ctx, sharedStorage)
 	} else {
 		authKeyResult, err = authkeys.New(ctx, appCfg)
 	}
 	if err != nil {
-		closeErr := errors.Join(workflowResult.Close(), app.guardrails.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.fileStore.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
-		if closeErr != nil {
-			return nil, fmt.Errorf("failed to initialize auth keys: %w (also: close error: %v)", err, closeErr)
-		}
-		return nil, fmt.Errorf("failed to initialize auth keys: %w", err)
+		return fail("failed to initialize auth keys", err)
 	}
 	app.authKeys = authKeyResult
+	closers = append(closers, app.authKeys.Close)
 
 	// Log configuration status after auth has been initialized so the startup
 	// message reflects both bootstrap and managed auth modes.
@@ -508,46 +471,9 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 
 	rcm, err := responsecache.NewResponseCacheMiddleware(appCfg.Cache.Response, providerResult.CredentialResolvedProviders, usageResult.Logger, pricingResolver)
 	if err != nil {
-		var (
-			workflowsCloseErr        error
-			guardrailsCloseErr       error
-			authKeysCloseErr         error
-			aliasCloseErr            error
-			modelOverridesCloseErr   error
-			pricingOverridesCloseErr error
-			fileStoreCloseErr        error
-			batchCloseErr            error
-		)
-		if app.workflows != nil {
-			workflowsCloseErr = app.workflows.Close()
-		}
-		if app.guardrails != nil {
-			guardrailsCloseErr = app.guardrails.Close()
-		}
-		if app.authKeys != nil {
-			authKeysCloseErr = app.authKeys.Close()
-		}
-		if app.aliases != nil {
-			aliasCloseErr = app.aliases.Close()
-		}
-		if app.modelOverrides != nil {
-			modelOverridesCloseErr = app.modelOverrides.Close()
-		}
-		if app.pricingOverrides != nil {
-			pricingOverridesCloseErr = app.pricingOverrides.Close()
-		}
-		if app.fileStore != nil {
-			fileStoreCloseErr = app.fileStore.Close()
-		}
-		if app.batch != nil {
-			batchCloseErr = app.batch.Close()
-		}
-		closeErr := errors.Join(workflowsCloseErr, guardrailsCloseErr, authKeysCloseErr, aliasCloseErr, modelOverridesCloseErr, pricingOverridesCloseErr, fileStoreCloseErr, batchCloseErr, app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
-		if closeErr != nil {
-			return nil, fmt.Errorf("failed to initialize response cache: %w (also: close error: %v)", err, closeErr)
-		}
-		return nil, fmt.Errorf("failed to initialize response cache: %w", err)
+		return fail("failed to initialize response cache", err)
 	}
+	closers = append(closers, rcm.Close)
 	serverCfg.ResponseCacheMiddleware = rcm
 
 	internalGuardrailExecutor := server.NewInternalChatCompletionExecutor(provider, server.InternalChatCompletionExecutorConfig{
@@ -560,22 +486,11 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		PricingResolver:        pricingResolver,
 		ResponseCache:          rcm,
 	})
-	closeWiredRuntime := func() error {
-		return errors.Join(rcm.Close(), app.workflows.Close(), app.guardrails.Close(), app.authKeys.Close(), app.pricingOverrides.Close(), app.modelOverrides.Close(), app.aliases.Close(), app.fileStore.Close(), app.batch.Close(), app.budgets.Close(), app.usage.Close(), app.audit.Close(), app.providers.Close())
-	}
 	if err := guardrailResult.Service.SetExecutor(ctx, internalGuardrailExecutor); err != nil {
-		closeErr := closeWiredRuntime()
-		if closeErr != nil {
-			return nil, fmt.Errorf("failed to wire internal guardrail executor: %w (also: close error: %v)", err, closeErr)
-		}
-		return nil, fmt.Errorf("failed to wire internal guardrail executor: %w", err)
+		return fail("failed to wire internal guardrail executor", err)
 	}
 	if err := workflowResult.Service.Refresh(ctx); err != nil {
-		closeErr := closeWiredRuntime()
-		if closeErr != nil {
-			return nil, fmt.Errorf("failed to refresh workflows after wiring internal guardrail executor: %w (also: close error: %v)", err, closeErr)
-		}
-		return nil, fmt.Errorf("failed to refresh workflows after wiring internal guardrail executor: %w", err)
+		return fail("failed to refresh workflows after wiring internal guardrail executor", err)
 	}
 
 	if livePublishersEnabled {
@@ -1224,13 +1139,4 @@ func fallbackModeEnabled(mode config.FallbackMode) bool {
 	default:
 		return false
 	}
-}
-
-func firstSharedStorage(candidates ...storage.Storage) storage.Storage {
-	for _, candidate := range candidates {
-		if candidate != nil {
-			return candidate
-		}
-	}
-	return nil
 }

--- a/internal/auditlog/reader_helpers.go
+++ b/internal/auditlog/reader_helpers.go
@@ -1,32 +1,11 @@
 package auditlog
 
 import (
-	"strings"
+	"gomodel/internal/storage/sqlutil"
 )
 
-func buildWhereClause(conditions []string) string {
-	if len(conditions) == 0 {
-		return ""
-	}
-	return " WHERE " + strings.Join(conditions, " AND ")
-}
-
-func escapeLikeWildcards(s string) string {
-	s = strings.ReplaceAll(s, `\`, `\\`)
-	s = strings.ReplaceAll(s, `%`, `\%`)
-	s = strings.ReplaceAll(s, `_`, `\_`)
-	return s
-}
-
+// clampLimitOffset applies the audit log reader pagination policy:
+// limit defaults to 25 and is capped at 100; offset floors at 0.
 func clampLimitOffset(limit, offset int) (int, int) {
-	if limit <= 0 {
-		limit = 25
-	}
-	if limit > 100 {
-		limit = 100
-	}
-	if offset < 0 {
-		offset = 0
-	}
-	return limit, offset
+	return sqlutil.ClampLimitOffset(limit, offset, 25, 100)
 }

--- a/internal/auditlog/reader_postgresql.go
+++ b/internal/auditlog/reader_postgresql.go
@@ -1,6 +1,8 @@
 package auditlog
 
 import (
+	"gomodel/internal/storage/sqlutil"
+
 	"context"
 	"encoding/json"
 	"fmt"
@@ -34,12 +36,12 @@ func (r *PostgreSQLReader) GetLogs(ctx context.Context, params LogQueryParams) (
 
 	if params.RequestedModel != "" {
 		conditions = append(conditions, fmt.Sprintf("requested_model ILIKE $%d ESCAPE '\\'", argIdx))
-		args = append(args, "%"+escapeLikeWildcards(params.RequestedModel)+"%")
+		args = append(args, "%"+sqlutil.EscapeLikeWildcards(params.RequestedModel)+"%")
 		argIdx++
 	}
 	if params.Provider != "" {
 		conditions = append(conditions, fmt.Sprintf("(provider ILIKE $%d ESCAPE '\\' OR provider_name ILIKE $%d ESCAPE '\\')", argIdx, argIdx+1))
-		args = append(args, "%"+escapeLikeWildcards(params.Provider)+"%", "%"+escapeLikeWildcards(params.Provider)+"%")
+		args = append(args, "%"+sqlutil.EscapeLikeWildcards(params.Provider)+"%", "%"+sqlutil.EscapeLikeWildcards(params.Provider)+"%")
 		argIdx += 2
 	}
 	if params.Method != "" {
@@ -49,7 +51,7 @@ func (r *PostgreSQLReader) GetLogs(ctx context.Context, params LogQueryParams) (
 	}
 	if params.Path != "" {
 		conditions = append(conditions, fmt.Sprintf("path ILIKE $%d ESCAPE '\\'", argIdx))
-		args = append(args, "%"+escapeLikeWildcards(params.Path)+"%")
+		args = append(args, "%"+sqlutil.EscapeLikeWildcards(params.Path)+"%")
 		argIdx++
 	}
 	if userPath != "" {
@@ -63,7 +65,7 @@ func (r *PostgreSQLReader) GetLogs(ctx context.Context, params LogQueryParams) (
 	}
 	if params.ErrorType != "" {
 		conditions = append(conditions, fmt.Sprintf("error_type ILIKE $%d ESCAPE '\\'", argIdx))
-		args = append(args, "%"+escapeLikeWildcards(params.ErrorType)+"%")
+		args = append(args, "%"+sqlutil.EscapeLikeWildcards(params.ErrorType)+"%")
 		argIdx++
 	}
 	if params.StatusCode != nil {
@@ -77,13 +79,13 @@ func (r *PostgreSQLReader) GetLogs(ctx context.Context, params LogQueryParams) (
 		argIdx++
 	}
 	if params.Search != "" {
-		s := "%" + escapeLikeWildcards(params.Search) + "%"
+		s := "%" + sqlutil.EscapeLikeWildcards(params.Search) + "%"
 		conditions = append(conditions, fmt.Sprintf("(request_id ILIKE $%d ESCAPE '\\' OR auth_key_id ILIKE $%d ESCAPE '\\' OR requested_model ILIKE $%d ESCAPE '\\' OR provider ILIKE $%d ESCAPE '\\' OR provider_name ILIKE $%d ESCAPE '\\' OR method ILIKE $%d ESCAPE '\\' OR path ILIKE $%d ESCAPE '\\' OR user_path ILIKE $%d ESCAPE '\\' OR error_type ILIKE $%d ESCAPE '\\' OR data->>'error_message' ILIKE $%d ESCAPE '\\')", argIdx, argIdx, argIdx, argIdx, argIdx, argIdx, argIdx, argIdx, argIdx, argIdx))
 		args = append(args, s)
 		argIdx++
 	}
 
-	where := buildWhereClause(conditions)
+	where := sqlutil.BuildWhereClause(conditions)
 
 	var total int
 	countQuery := `SELECT COUNT(*) FROM audit_logs` + where

--- a/internal/auditlog/reader_sqlite.go
+++ b/internal/auditlog/reader_sqlite.go
@@ -1,6 +1,8 @@
 package auditlog
 
 import (
+	"gomodel/internal/storage/sqlutil"
+
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -37,11 +39,11 @@ func (r *SQLiteReader) GetLogs(ctx context.Context, params LogQueryParams) (*Log
 
 	if params.RequestedModel != "" {
 		conditions = append(conditions, "requested_model LIKE ? ESCAPE '\\'")
-		args = append(args, "%"+escapeLikeWildcards(params.RequestedModel)+"%")
+		args = append(args, "%"+sqlutil.EscapeLikeWildcards(params.RequestedModel)+"%")
 	}
 	if params.Provider != "" {
 		conditions = append(conditions, "(provider LIKE ? ESCAPE '\\' OR provider_name LIKE ? ESCAPE '\\')")
-		args = append(args, "%"+escapeLikeWildcards(params.Provider)+"%", "%"+escapeLikeWildcards(params.Provider)+"%")
+		args = append(args, "%"+sqlutil.EscapeLikeWildcards(params.Provider)+"%", "%"+sqlutil.EscapeLikeWildcards(params.Provider)+"%")
 	}
 	if params.Method != "" {
 		conditions = append(conditions, "method = ?")
@@ -49,7 +51,7 @@ func (r *SQLiteReader) GetLogs(ctx context.Context, params LogQueryParams) (*Log
 	}
 	if params.Path != "" {
 		conditions = append(conditions, "path LIKE ? ESCAPE '\\'")
-		args = append(args, "%"+escapeLikeWildcards(params.Path)+"%")
+		args = append(args, "%"+sqlutil.EscapeLikeWildcards(params.Path)+"%")
 	}
 	if userPath != "" {
 		conditions = append(conditions, auditUserPathSQLPredicate(userPath, "user_path = ?", "user_path LIKE ? ESCAPE '\\'"))
@@ -57,7 +59,7 @@ func (r *SQLiteReader) GetLogs(ctx context.Context, params LogQueryParams) (*Log
 	}
 	if params.ErrorType != "" {
 		conditions = append(conditions, "error_type LIKE ? ESCAPE '\\'")
-		args = append(args, "%"+escapeLikeWildcards(params.ErrorType)+"%")
+		args = append(args, "%"+sqlutil.EscapeLikeWildcards(params.ErrorType)+"%")
 	}
 	if params.StatusCode != nil {
 		conditions = append(conditions, "status_code = ?")
@@ -72,12 +74,12 @@ func (r *SQLiteReader) GetLogs(ctx context.Context, params LogQueryParams) (*Log
 		}
 	}
 	if params.Search != "" {
-		s := "%" + escapeLikeWildcards(params.Search) + "%"
+		s := "%" + sqlutil.EscapeLikeWildcards(params.Search) + "%"
 		conditions = append(conditions, `(request_id LIKE ? ESCAPE '\' OR auth_key_id LIKE ? ESCAPE '\' OR requested_model LIKE ? ESCAPE '\' OR provider LIKE ? ESCAPE '\' OR provider_name LIKE ? ESCAPE '\' OR method LIKE ? ESCAPE '\' OR path LIKE ? ESCAPE '\' OR user_path LIKE ? ESCAPE '\' OR error_type LIKE ? ESCAPE '\' OR json_extract(data, '$.error_message') LIKE ? ESCAPE '\')`)
 		args = append(args, s, s, s, s, s, s, s, s, s, s)
 	}
 
-	where := buildWhereClause(conditions)
+	where := sqlutil.BuildWhereClause(conditions)
 
 	// Count total
 	var total int

--- a/internal/auditlog/reader_sqlite.go
+++ b/internal/auditlog/reader_sqlite.go
@@ -285,18 +285,11 @@ func sqliteTimestampBoundary(t time.Time) string {
 }
 
 func parseSQLTimestamp(ts string, entryID string) time.Time {
-	if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
-		return t
+	t, ok := sqlutil.ParseSQLiteTimestamp(ts)
+	if !ok {
+		slog.Warn("failed to parse audit timestamp", "id", entryID, "raw_timestamp", ts)
 	}
-	if t, err := time.Parse("2006-01-02 15:04:05.999999999-07:00", ts); err == nil {
-		return t
-	}
-	if t, err := time.Parse("2006-01-02T15:04:05Z", ts); err == nil {
-		return t
-	}
-
-	slog.Warn("failed to parse audit timestamp", "id", entryID, "raw_timestamp", ts)
-	return time.Time{}
+	return t
 }
 
 func (r *SQLiteReader) findByResponseID(ctx context.Context, responseID string) (*LogEntry, error) {

--- a/internal/auditlog/user_path_filter.go
+++ b/internal/auditlog/user_path_filter.go
@@ -1,6 +1,8 @@
 package auditlog
 
 import (
+	"gomodel/internal/storage/sqlutil"
+
 	"fmt"
 	"regexp"
 
@@ -19,7 +21,7 @@ func auditUserPathSubtreePattern(userPath string) string {
 	if userPath == "/" {
 		return "/%"
 	}
-	return escapeLikeWildcards(userPath) + "/%"
+	return sqlutil.EscapeLikeWildcards(userPath) + "/%"
 }
 
 func auditUserPathSQLPredicate(userPath, exactExpr, subtreeExpr string) string {

--- a/internal/auditlog/user_path_filter_test.go
+++ b/internal/auditlog/user_path_filter_test.go
@@ -1,6 +1,10 @@
 package auditlog
 
-import "testing"
+import (
+	"testing"
+
+	"gomodel/internal/storage/sqlutil"
+)
 
 func TestAuditUserPathSubtreePattern(t *testing.T) {
 	tests := []struct {
@@ -67,8 +71,8 @@ func TestAuditUserPathSubtreeRegex(t *testing.T) {
 }
 
 func TestEscapeLikeWildcards(t *testing.T) {
-	if got := escapeLikeWildcards("/team%_a"); got != "/team\\%\\_a" {
-		t.Fatalf("escapeLikeWildcards(%q) = %q, want %q", "/team%_a", got, "/team\\%\\_a")
+	if got := sqlutil.EscapeLikeWildcards("/team%_a"); got != "/team\\%\\_a" {
+		t.Fatalf("sqlutil.EscapeLikeWildcards(%q) = %q, want %q", "/team%_a", got, "/team\\%\\_a")
 	}
 }
 

--- a/internal/authkeys/store.go
+++ b/internal/authkeys/store.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"gomodel/internal/core"
+	"gomodel/internal/validation"
 )
 
 var (
@@ -21,33 +22,15 @@ var (
 )
 
 // ValidationError indicates invalid auth key input or state.
-type ValidationError struct {
-	Message string
-	Err     error
-}
-
-func (e *ValidationError) Error() string {
-	if e == nil {
-		return ""
-	}
-	return e.Message
-}
-
-func (e *ValidationError) Unwrap() error {
-	if e == nil {
-		return nil
-	}
-	return e.Err
-}
+type ValidationError = validation.Error
 
 func newValidationError(message string, err error) error {
-	return &ValidationError{Message: message, Err: err}
+	return validation.NewError(message, err)
 }
 
 // IsValidationError reports whether err is a validation error.
 func IsValidationError(err error) bool {
-	_, ok := errors.AsType[*ValidationError](err)
-	return ok
+	return validation.IsError(err)
 }
 
 // Store defines persistence operations for managed auth keys.

--- a/internal/authkeys/store_postgresql.go
+++ b/internal/authkeys/store_postgresql.go
@@ -1,10 +1,11 @@
 package authkeys
 
 import (
+	"gomodel/internal/storage/sqlutil"
+
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -84,7 +85,7 @@ func (s *PostgreSQLStore) Create(ctx context.Context, key AuthKey) error {
 	_, err := s.pool.Exec(ctx, `
 		INSERT INTO auth_keys (id, name, description, user_path, redacted_value, secret_hash, enabled, expires_at, deactivated_at, created_at, updated_at)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-	`, key.ID, key.Name, key.Description, pgNullableString(key.UserPath), key.RedactedValue, key.SecretHash, key.Enabled, pgUnixOrNil(key.ExpiresAt), pgUnixOrNil(key.DeactivatedAt), key.CreatedAt.Unix(), key.UpdatedAt.Unix())
+	`, key.ID, key.Name, key.Description, sqlutil.NullableString(key.UserPath), key.RedactedValue, key.SecretHash, key.Enabled, sqlutil.UnixOrNil(key.ExpiresAt), sqlutil.UnixOrNil(key.DeactivatedAt), key.CreatedAt.Unix(), key.UpdatedAt.Unix())
 	if err != nil {
 		return fmt.Errorf("create auth key: %w", err)
 	}
@@ -137,40 +138,10 @@ func scanPostgreSQLAuthKey(scanner authKeyScanner) (AuthKey, error) {
 		}
 		return AuthKey{}, err
 	}
-	key.UserPath = derefTrimmedString(userPath)
-	key.ExpiresAt = int64PtrToTime(expiresAt)
-	key.DeactivatedAt = int64PtrToTime(deactivatedAt)
+	key.UserPath = sqlutil.DerefTrimmed(userPath)
+	key.ExpiresAt = sqlutil.TimeFromUnixPtr(expiresAt)
+	key.DeactivatedAt = sqlutil.TimeFromUnixPtr(deactivatedAt)
 	key.CreatedAt = time.Unix(createdAt, 0).UTC()
 	key.UpdatedAt = time.Unix(updatedAt, 0).UTC()
 	return key, nil
-}
-
-func pgUnixOrNil(value *time.Time) any {
-	if value == nil {
-		return nil
-	}
-	return value.UTC().Unix()
-}
-
-func int64PtrToTime(value *int64) *time.Time {
-	if value == nil {
-		return nil
-	}
-	t := time.Unix(*value, 0).UTC()
-	return &t
-}
-
-func pgNullableString(value string) any {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return nil
-	}
-	return value
-}
-
-func derefTrimmedString(value *string) string {
-	if value == nil {
-		return ""
-	}
-	return strings.TrimSpace(*value)
 }

--- a/internal/authkeys/store_sqlite.go
+++ b/internal/authkeys/store_sqlite.go
@@ -1,6 +1,8 @@
 package authkeys
 
 import (
+	"gomodel/internal/storage/sqlutil"
+
 	"context"
 	"database/sql"
 	"errors"
@@ -80,7 +82,7 @@ func (s *SQLiteStore) Create(ctx context.Context, key AuthKey) error {
 	_, err := s.db.ExecContext(ctx, `
 		INSERT INTO auth_keys (id, name, description, user_path, redacted_value, secret_hash, enabled, expires_at, deactivated_at, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`, key.ID, key.Name, key.Description, nullableString(key.UserPath), key.RedactedValue, key.SecretHash, boolToSQLite(key.Enabled), unixOrNil(key.ExpiresAt), unixOrNil(key.DeactivatedAt), key.CreatedAt.Unix(), key.UpdatedAt.Unix())
+	`, key.ID, key.Name, key.Description, sqlutil.NullableString(key.UserPath), key.RedactedValue, key.SecretHash, boolToSQLite(key.Enabled), sqlutil.UnixOrNil(key.ExpiresAt), sqlutil.UnixOrNil(key.DeactivatedAt), key.CreatedAt.Unix(), key.UpdatedAt.Unix())
 	if err != nil {
 		return fmt.Errorf("create auth key: %w", err)
 	}
@@ -138,10 +140,10 @@ func scanSQLiteAuthKey(scanner authKeyScanner) (AuthKey, error) {
 		}
 		return AuthKey{}, err
 	}
-	key.UserPath = nullableStringValue(userPath)
+	key.UserPath = sqlutil.StringFromNullable(userPath)
 	key.Enabled = enabled != 0
-	key.ExpiresAt = unixPtr(expiresAt)
-	key.DeactivatedAt = unixPtr(deactivatedAt)
+	key.ExpiresAt = sqlutil.TimeFromUnix(expiresAt)
+	key.DeactivatedAt = sqlutil.TimeFromUnix(deactivatedAt)
 	key.CreatedAt = time.Unix(createdAt, 0).UTC()
 	key.UpdatedAt = time.Unix(updatedAt, 0).UTC()
 	return key, nil
@@ -160,34 +162,4 @@ func boolToSQLite(v bool) int {
 		return 1
 	}
 	return 0
-}
-
-func unixOrNil(value *time.Time) any {
-	if value == nil {
-		return nil
-	}
-	return value.UTC().Unix()
-}
-
-func unixPtr(value sql.NullInt64) *time.Time {
-	if !value.Valid {
-		return nil
-	}
-	t := time.Unix(value.Int64, 0).UTC()
-	return &t
-}
-
-func nullableString(value string) any {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return nil
-	}
-	return value
-}
-
-func nullableStringValue(value sql.NullString) string {
-	if !value.Valid {
-		return ""
-	}
-	return strings.TrimSpace(value.String)
 }

--- a/internal/budget/store_postgresql.go
+++ b/internal/budget/store_postgresql.go
@@ -1,6 +1,8 @@
 package budget
 
 import (
+	"gomodel/internal/storage/sqlutil"
+
 	"context"
 	"fmt"
 	"strconv"
@@ -279,7 +281,7 @@ func upsertPostgreSQLBudgets(ctx context.Context, tx pgx.Tx, budgets []Budget) e
 			budget.PeriodSeconds,
 			budget.Amount,
 			budget.Source,
-			unixOrNil(budget.LastResetAt),
+			sqlutil.UnixOrNil(budget.LastResetAt),
 			budget.CreatedAt.Unix(),
 			budget.UpdatedAt.Unix(),
 			SourceManual,

--- a/internal/budget/store_sqlite.go
+++ b/internal/budget/store_sqlite.go
@@ -1,6 +1,8 @@
 package budget
 
 import (
+	"gomodel/internal/storage/sqlutil"
+
 	"context"
 	"database/sql"
 	"fmt"
@@ -130,7 +132,7 @@ func (s *SQLiteStore) UpsertBudgets(ctx context.Context, budgets []Budget) error
 			budget.PeriodSeconds,
 			budget.Amount,
 			budget.Source,
-			unixOrNil(budget.LastResetAt),
+			sqlutil.UnixOrNil(budget.LastResetAt),
 			budget.CreatedAt.Unix(),
 			budget.UpdatedAt.Unix(),
 			SourceManual,
@@ -345,7 +347,7 @@ func upsertSQLiteBudgets(ctx context.Context, tx *sql.Tx, budgets []Budget) erro
 			budget.PeriodSeconds,
 			budget.Amount,
 			budget.Source,
-			unixOrNil(budget.LastResetAt),
+			sqlutil.UnixOrNil(budget.LastResetAt),
 			budget.CreatedAt.Unix(),
 			budget.UpdatedAt.Unix(),
 			SourceManual,
@@ -377,7 +379,7 @@ func scanSQLiteBudget(scanner interface{ Scan(dest ...any) error }) (Budget, err
 	); err != nil {
 		return Budget{}, fmt.Errorf("scan budget: %w", err)
 	}
-	budget.LastResetAt = unixPtr(lastResetAt)
+	budget.LastResetAt = sqlutil.TimeFromUnix(lastResetAt)
 	budget.CreatedAt = time.Unix(createdAt, 0).UTC()
 	budget.UpdatedAt = time.Unix(updatedAt, 0).UTC()
 	return budget, nil
@@ -393,19 +395,4 @@ func isSQLiteDuplicateColumnError(err error) bool {
 	}
 	message := strings.ToLower(err.Error())
 	return strings.Contains(message, "duplicate column") || strings.Contains(message, "already exists")
-}
-
-func unixOrNil(value *time.Time) any {
-	if value == nil {
-		return nil
-	}
-	return value.UTC().Unix()
-}
-
-func unixPtr(value sql.NullInt64) *time.Time {
-	if !value.Valid {
-		return nil
-	}
-	t := time.Unix(value.Int64, 0).UTC()
-	return &t
 }

--- a/internal/core/chat_content.go
+++ b/internal/core/chat_content.go
@@ -82,7 +82,7 @@ func (p ContentPart) MarshalJSON() ([]byte, error) {
 
 func (c *ImageURLContent) UnmarshalJSON(data []byte) error {
 	trimmed := bytes.TrimSpace(data)
-	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+	if IsJSONNull(trimmed) {
 		return fmt.Errorf("image_url part is missing image_url.url")
 	}
 
@@ -145,7 +145,7 @@ func (c ImageURLContent) MarshalJSON() ([]byte, error) {
 
 func (a *InputAudioContent) UnmarshalJSON(data []byte) error {
 	trimmed := bytes.TrimSpace(data)
-	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+	if IsJSONNull(trimmed) {
 		return fmt.Errorf("input_audio part is missing data or format")
 	}
 	if trimmed[0] != '{' {
@@ -193,7 +193,7 @@ func (a InputAudioContent) MarshalJSON() ([]byte, error) {
 // Chat content accepts plain strings, null, or arrays of supported content parts.
 func UnmarshalMessageContent(data []byte) (any, error) {
 	trimmed := bytes.TrimSpace(data)
-	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+	if IsJSONNull(trimmed) {
 		return nil, nil
 	}
 
@@ -467,7 +467,7 @@ func normalizeContentPartMap(partMap map[string]any) (ContentPart, error) {
 
 func unmarshalImageURLContent(data []byte) (*ImageURLContent, error) {
 	trimmed := bytes.TrimSpace(data)
-	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+	if IsJSONNull(trimmed) {
 		return nil, fmt.Errorf("image_url part is missing image_url.url")
 	}
 
@@ -497,7 +497,7 @@ func unmarshalImageURLContent(data []byte) (*ImageURLContent, error) {
 
 func unmarshalInputAudioContent(data []byte) (*InputAudioContent, error) {
 	trimmed := bytes.TrimSpace(data)
-	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+	if IsJSONNull(trimmed) {
 		return nil, fmt.Errorf("input_audio part is missing data or format")
 	}
 

--- a/internal/core/json_fields.go
+++ b/internal/core/json_fields.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"slices"
 	"sort"
 
 	"github.com/tidwall/gjson"
@@ -233,7 +234,7 @@ func extractUnknownJSONFields(data []byte, knownFields ...string) (UnknownJSONFi
 	buf.WriteByte('{')
 	wrote := false
 	root.ForEach(func(key, value gjson.Result) bool {
-		if containsJSONField(knownFields, key.String()) {
+		if slices.Contains(knownFields, key.String()) {
 			return true
 		}
 		if wrote {
@@ -251,15 +252,6 @@ func extractUnknownJSONFields(data []byte, knownFields ...string) (UnknownJSONFi
 
 	buf.WriteByte('}')
 	return UnknownJSONFields{raw: buf.Bytes()}, nil
-}
-
-func containsJSONField(knownFields []string, field string) bool {
-	for _, known := range knownFields {
-		if field == known {
-			return true
-		}
-	}
-	return false
 }
 
 func marshalWithUnknownJSONFields(base any, extraFields UnknownJSONFields) ([]byte, error) {

--- a/internal/core/json_fields.go
+++ b/internal/core/json_fields.go
@@ -19,6 +19,11 @@ type UnknownJSONFields struct {
 }
 
 // CloneRawJSON returns a detached copy of a raw JSON value.
+// IsJSONNull reports whether trimmed JSON data is empty or the null literal.
+func IsJSONNull(trimmed []byte) bool {
+	return len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null"))
+}
+
 func CloneRawJSON(raw json.RawMessage) json.RawMessage {
 	if len(raw) == 0 {
 		return nil

--- a/internal/core/responses_json.go
+++ b/internal/core/responses_json.go
@@ -6,6 +6,40 @@ import (
 	"fmt"
 )
 
+// responsesUtilityRequestFields lists the JSON fields recognized on responses
+// utility requests; any other field is preserved as an unknown extra field.
+var responsesUtilityRequestFields = []string{
+	"model",
+	"provider",
+	"input",
+	"instructions",
+	"tools",
+	"tool_choice",
+	"parallel_tool_calls",
+	"temperature",
+	"top_p",
+	"top_logprobs",
+	"max_output_tokens",
+	"metadata",
+	"reasoning",
+	"text",
+	"include",
+	"truncation",
+	"store",
+	"previous_response_id",
+	"conversation",
+	"prompt",
+	"prompt_cache_retention",
+	"context_management",
+	"user",
+	"service_tier",
+	"safety_identifier",
+}
+
+// responsesRequestFields additionally recognizes the streaming controls that
+// only apply to full responses requests.
+var responsesRequestFields = append([]string{"stream", "stream_options"}, responsesUtilityRequestFields...)
+
 // UnmarshalJSON preserves dynamic input payloads while supporting Swagger-only schema fields.
 // Array inputs are deserialized as []ResponsesInputElement for type-safe downstream handling.
 func (r *ResponsesRequest) UnmarshalJSON(data []byte) error {
@@ -42,35 +76,7 @@ func (r *ResponsesRequest) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	extraFields, err := extractUnknownJSONFields(data,
-		"model",
-		"provider",
-		"input",
-		"instructions",
-		"tools",
-		"tool_choice",
-		"parallel_tool_calls",
-		"temperature",
-		"top_p",
-		"top_logprobs",
-		"max_output_tokens",
-		"stream",
-		"stream_options",
-		"metadata",
-		"reasoning",
-		"text",
-		"include",
-		"truncation",
-		"store",
-		"previous_response_id",
-		"conversation",
-		"prompt",
-		"prompt_cache_retention",
-		"context_management",
-		"user",
-		"service_tier",
-		"safety_identifier",
-	)
+	extraFields, err := extractUnknownJSONFields(data, responsesRequestFields...)
 	if err != nil {
 		return err
 	}
@@ -306,33 +312,7 @@ func decodeResponseUtilityRequestJSON(data []byte) (responseUtilityRequestJSON, 
 		return responseUtilityRequestJSON{}, err
 	}
 
-	extraFields, err := extractUnknownJSONFields(data,
-		"model",
-		"provider",
-		"input",
-		"instructions",
-		"tools",
-		"tool_choice",
-		"parallel_tool_calls",
-		"temperature",
-		"top_p",
-		"top_logprobs",
-		"max_output_tokens",
-		"metadata",
-		"reasoning",
-		"text",
-		"include",
-		"truncation",
-		"store",
-		"previous_response_id",
-		"conversation",
-		"prompt",
-		"prompt_cache_retention",
-		"context_management",
-		"user",
-		"service_tier",
-		"safety_identifier",
-	)
+	extraFields, err := extractUnknownJSONFields(data, responsesUtilityRequestFields...)
 	if err != nil {
 		return responseUtilityRequestJSON{}, err
 	}

--- a/internal/core/responses_json.go
+++ b/internal/core/responses_json.go
@@ -119,7 +119,7 @@ func (r *ResponsesRequest) UnmarshalJSON(data []byte) error {
 
 func decodeResponsesInput(raw json.RawMessage) (any, error) {
 	trimmed := bytes.TrimSpace(raw)
-	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+	if IsJSONNull(trimmed) {
 		return nil, nil
 	}
 	if trimmed[0] == '[' {
@@ -141,7 +141,7 @@ func decodeResponsesInput(raw json.RawMessage) (any, error) {
 // ID or an object with an id field.
 func (c *ResponsesConversationRef) UnmarshalJSON(data []byte) error {
 	trimmed := bytes.TrimSpace(data)
-	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+	if IsJSONNull(trimmed) {
 		*c = ResponsesConversationRef{}
 		return nil
 	}
@@ -586,7 +586,7 @@ func cloneRawMessage(data []byte) json.RawMessage {
 // JSON strings are unwrapped; objects/arrays are returned as-is.
 func stringifyRawValue(raw json.RawMessage) string {
 	trimmed := bytes.TrimSpace(raw)
-	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+	if IsJSONNull(trimmed) {
 		return ""
 	}
 	if trimmed[0] == '"' {

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -46,6 +46,14 @@ func (r *ChatRequest) semanticSelector() (string, string) {
 	return r.Model, r.Provider
 }
 
+// EnsureModel sets *model to the requested model when a provider response
+// omits it, keeping responses OpenAI-compatible.
+func EnsureModel(model *string, requested string) {
+	if *model == "" {
+		*model = requested
+	}
+}
+
 // WithStreaming returns a shallow copy of the request with Stream set to true.
 // This avoids mutating the caller's request object.
 func (r *ChatRequest) WithStreaming() *ChatRequest {

--- a/internal/guardrails/store.go
+++ b/internal/guardrails/store.go
@@ -5,39 +5,23 @@ import (
 	"database/sql"
 	"errors"
 	"strings"
+
+	"gomodel/internal/validation"
 )
 
 // ErrNotFound indicates a requested guardrail was not found.
 var ErrNotFound = errors.New("guardrail not found")
 
 // ValidationError indicates invalid guardrail input or state.
-type ValidationError struct {
-	Message string
-	Err     error
-}
-
-func (e *ValidationError) Error() string {
-	if e == nil {
-		return ""
-	}
-	return e.Message
-}
-
-func (e *ValidationError) Unwrap() error {
-	if e == nil {
-		return nil
-	}
-	return e.Err
-}
+type ValidationError = validation.Error
 
 func newValidationError(message string, err error) error {
-	return &ValidationError{Message: message, Err: err}
+	return validation.NewError(message, err)
 }
 
 // IsValidationError reports whether err is a validation error.
 func IsValidationError(err error) bool {
-	_, ok := errors.AsType[*ValidationError](err)
-	return ok
+	return validation.IsError(err)
 }
 
 // Store defines persistence operations for reusable guardrail definitions.

--- a/internal/guardrails/store_mongodb.go
+++ b/internal/guardrails/store_mongodb.go
@@ -11,6 +11,8 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
+
+	"gomodel/internal/core"
 )
 
 type mongoDefinitionDocument struct {
@@ -205,7 +207,7 @@ func (s *MongoDBStore) Close() error {
 
 func mongoConfigFromRaw(raw json.RawMessage) (bson.M, error) {
 	trimmed := bytes.TrimSpace(raw)
-	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+	if core.IsJSONNull(trimmed) {
 		return bson.M{}, nil
 	}
 	var doc bson.M

--- a/internal/modelselectors/selectors.go
+++ b/internal/modelselectors/selectors.go
@@ -3,8 +3,9 @@
 package modelselectors
 
 import (
-	"errors"
 	"strings"
+
+	"gomodel/internal/validation"
 )
 
 // Catalog is the minimal configured-provider surface needed for selector validation.
@@ -30,34 +31,16 @@ const (
 )
 
 // ValidationError indicates invalid selector input or invalid selector state.
-type ValidationError struct {
-	Message string
-	Err     error
-}
-
-func (e *ValidationError) Error() string {
-	if e == nil {
-		return ""
-	}
-	return e.Message
-}
-
-func (e *ValidationError) Unwrap() error {
-	if e == nil {
-		return nil
-	}
-	return e.Err
-}
+type ValidationError = validation.Error
 
 // NewValidationError creates a selector validation error.
 func NewValidationError(message string, err error) error {
-	return &ValidationError{Message: message, Err: err}
+	return validation.NewError(message, err)
 }
 
 // IsValidationError reports whether err is a validation error.
 func IsValidationError(err error) bool {
-	var target *ValidationError
-	return errors.As(err, &target)
+	return validation.IsError(err)
 }
 
 // NormalizeInput validates and normalizes one user-supplied selector.

--- a/internal/providers/anthropic/anthropic.go
+++ b/internal/providers/anthropic/anthropic.go
@@ -23,7 +23,7 @@ import (
 var Registration = providers.Registration{
 	Type:                        "anthropic",
 	New:                         New,
-	PassthroughSemanticEnricher: passthroughSemanticEnricher{},
+	PassthroughSemanticEnricher: passthroughSemanticEnricher,
 	Discovery: providers.DiscoveryConfig{
 		DefaultBaseURL: defaultBaseURL,
 	},

--- a/internal/providers/anthropic/passthrough_semantics.go
+++ b/internal/providers/anthropic/passthrough_semantics.go
@@ -1,35 +1,8 @@
 package anthropic
 
-import (
-	"strings"
+import "gomodel/internal/providers"
 
-	"gomodel/internal/core"
-	"gomodel/internal/providers"
-)
-
-type passthroughSemanticEnricher struct{}
-
-func (passthroughSemanticEnricher) ProviderType() string {
-	return "anthropic"
-}
-
-func (passthroughSemanticEnricher) Enrich(_ *core.RequestSnapshot, _ *core.WhiteBoxPrompt, info *core.PassthroughRouteInfo) *core.PassthroughRouteInfo {
-	if info == nil {
-		return nil
-	}
-	enriched := *info
-	normalizedEndpoint := strings.TrimLeft(strings.TrimSpace(providers.PassthroughEndpointPath(&enriched)), "/")
-	switch "/" + normalizedEndpoint {
-	case "/messages":
-		enriched.SemanticOperation = "anthropic.messages"
-		enriched.AuditPath = "/v1/messages"
-	case "/messages/batches":
-		enriched.SemanticOperation = "anthropic.messages_batches"
-		enriched.AuditPath = "/v1/messages/batches"
-	default:
-		if strings.TrimSpace(enriched.AuditPath) == "" && normalizedEndpoint != "" {
-			enriched.AuditPath = "/p/anthropic/" + normalizedEndpoint
-		}
-	}
-	return &enriched
-}
+var passthroughSemanticEnricher = providers.NewSemanticEnricher("anthropic", map[string]providers.PassthroughEndpointSemantics{
+	"/messages":         {Operation: "anthropic.messages", AuditPath: "/v1/messages"},
+	"/messages/batches": {Operation: "anthropic.messages_batches", AuditPath: "/v1/messages/batches"},
+})

--- a/internal/providers/anthropic/passthrough_semantics_test.go
+++ b/internal/providers/anthropic/passthrough_semantics_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestPassthroughSemanticEnricher_Enrich(t *testing.T) {
-	enricher := passthroughSemanticEnricher{}
+	enricher := passthroughSemanticEnricher
 
 	tests := []struct {
 		name          string

--- a/internal/providers/anthropic/request_translation.go
+++ b/internal/providers/anthropic/request_translation.go
@@ -554,7 +554,7 @@ func anthropicCacheControlFromExtra(extraFields core.UnknownJSONFields) (json.Ra
 	}
 
 	trimmed := bytes.TrimSpace(raw)
-	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+	if core.IsJSONNull(trimmed) {
 		return nil, nil
 	}
 	if trimmed[0] != '{' {

--- a/internal/providers/azure/azure.go
+++ b/internal/providers/azure/azure.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 
 	"gomodel/internal/core"
@@ -114,18 +113,7 @@ func (p *Provider) GetBatch(ctx context.Context, id string) (*core.BatchResponse
 }
 
 func (p *Provider) ListBatches(ctx context.Context, limit int, after string) (*core.BatchListResponse, error) {
-	values := url.Values{}
-	if limit > 0 {
-		values.Set("limit", strconv.Itoa(limit))
-	}
-	if after != "" {
-		values.Set("after", after)
-	}
-
-	endpoint := "/openai/batches"
-	if encoded := values.Encode(); encoded != "" {
-		endpoint += "?" + encoded
-	}
+	endpoint := providers.PaginatedEndpoint("/openai/batches", limit, "after", after)
 
 	var resp core.BatchListResponse
 	if err := p.resourceProvider.Do(ctx, llmclient.Request{

--- a/internal/providers/deepseek/deepseek.go
+++ b/internal/providers/deepseek/deepseek.go
@@ -135,9 +135,7 @@ func (p *Provider) ChatCompletion(ctx context.Context, req *core.ChatRequest) (*
 	if err != nil {
 		return nil, err
 	}
-	if resp.Model == "" {
-		resp.Model = req.Model
-	}
+	core.EnsureModel(&resp.Model, req.Model)
 	return &resp, nil
 }
 

--- a/internal/providers/deepseek/deepseek.go
+++ b/internal/providers/deepseek/deepseek.go
@@ -19,7 +19,7 @@ const defaultBaseURL = "https://api.deepseek.com"
 var Registration = providers.Registration{
 	Type:                        "deepseek",
 	New:                         New,
-	PassthroughSemanticEnricher: passthroughSemanticEnricher{},
+	PassthroughSemanticEnricher: passthroughSemanticEnricher,
 	Discovery: providers.DiscoveryConfig{
 		DefaultBaseURL: defaultBaseURL,
 	},

--- a/internal/providers/deepseek/passthrough_semantics.go
+++ b/internal/providers/deepseek/passthrough_semantics.go
@@ -1,35 +1,8 @@
 package deepseek
 
-import (
-	"strings"
+import "gomodel/internal/providers"
 
-	"gomodel/internal/core"
-	"gomodel/internal/providers"
-)
-
-type passthroughSemanticEnricher struct{}
-
-func (passthroughSemanticEnricher) ProviderType() string {
-	return "deepseek"
-}
-
-func (passthroughSemanticEnricher) Enrich(_ *core.RequestSnapshot, _ *core.WhiteBoxPrompt, info *core.PassthroughRouteInfo) *core.PassthroughRouteInfo {
-	if info == nil {
-		return nil
-	}
-	enriched := *info
-	normalizedEndpoint := strings.TrimLeft(strings.TrimSpace(providers.PassthroughEndpointPath(&enriched)), "/")
-	switch "/" + normalizedEndpoint {
-	case "/chat/completions":
-		enriched.SemanticOperation = "deepseek.chat_completions"
-		enriched.AuditPath = "/v1/chat/completions"
-	case "/beta/completions":
-		enriched.SemanticOperation = "deepseek.fim_completions"
-		enriched.AuditPath = "/beta/completions"
-	default:
-		if strings.TrimSpace(enriched.AuditPath) == "" && normalizedEndpoint != "" {
-			enriched.AuditPath = "/p/deepseek/" + normalizedEndpoint
-		}
-	}
-	return &enriched
-}
+var passthroughSemanticEnricher = providers.NewSemanticEnricher("deepseek", map[string]providers.PassthroughEndpointSemantics{
+	"/chat/completions": {Operation: "deepseek.chat_completions", AuditPath: "/v1/chat/completions"},
+	"/beta/completions": {Operation: "deepseek.fim_completions", AuditPath: "/beta/completions"},
+})

--- a/internal/providers/deepseek/passthrough_semantics_test.go
+++ b/internal/providers/deepseek/passthrough_semantics_test.go
@@ -7,21 +7,21 @@ import (
 )
 
 func TestPassthroughSemanticEnricher_ProviderType(t *testing.T) {
-	e := passthroughSemanticEnricher{}
+	e := passthroughSemanticEnricher
 	if got := e.ProviderType(); got != "deepseek" {
 		t.Fatalf("ProviderType() = %q, want deepseek", got)
 	}
 }
 
 func TestPassthroughSemanticEnricher_NilInfo_ReturnsNil(t *testing.T) {
-	e := passthroughSemanticEnricher{}
+	e := passthroughSemanticEnricher
 	if got := e.Enrich(nil, nil, nil); got != nil {
 		t.Fatalf("Enrich(nil) = %v, want nil", got)
 	}
 }
 
 func TestPassthroughSemanticEnricher_Enrich(t *testing.T) {
-	e := passthroughSemanticEnricher{}
+	e := passthroughSemanticEnricher
 
 	tests := []struct {
 		name               string

--- a/internal/providers/endpoints.go
+++ b/internal/providers/endpoints.go
@@ -1,0 +1,24 @@
+package providers
+
+import (
+	"net/url"
+	"strconv"
+)
+
+// PaginatedEndpoint appends optional limit and pagination-cursor query
+// parameters to an endpoint path. The cursor parameter name varies by
+// provider (e.g. "after" for OpenAI-compatible APIs, "before_id" for
+// Anthropic).
+func PaginatedEndpoint(path string, limit int, cursorParam, cursor string) string {
+	values := url.Values{}
+	if limit > 0 {
+		values.Set("limit", strconv.Itoa(limit))
+	}
+	if cursor != "" {
+		values.Set(cursorParam, cursor)
+	}
+	if encoded := values.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+	return path
+}

--- a/internal/providers/gemini/gemini.go
+++ b/internal/providers/gemini/gemini.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"os"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -730,17 +729,7 @@ func (p *Provider) ListBatches(ctx context.Context, limit int, after string) (*c
 	if err := p.ready(); err != nil {
 		return nil, err
 	}
-	values := url.Values{}
-	if limit > 0 {
-		values.Set("limit", strconv.Itoa(limit))
-	}
-	if after != "" {
-		values.Set("after", after)
-	}
-	endpoint := "/batches"
-	if encoded := values.Encode(); encoded != "" {
-		endpoint += "?" + encoded
-	}
+	endpoint := providers.PaginatedEndpoint("/batches", limit, "after", after)
 
 	var resp core.BatchListResponse
 	err := p.client.Do(ctx, llmclient.Request{

--- a/internal/providers/gemini/gemini.go
+++ b/internal/providers/gemini/gemini.go
@@ -453,9 +453,7 @@ func (p *Provider) ChatCompletion(ctx context.Context, req *core.ChatRequest) (*
 	if err != nil {
 		return nil, err
 	}
-	if resp.Model == "" {
-		resp.Model = req.Model
-	}
+	core.EnsureModel(&resp.Model, req.Model)
 	if resp.Provider == "" {
 		resp.Provider = p.responseProviderName()
 	}
@@ -677,9 +675,7 @@ func (p *Provider) Embeddings(ctx context.Context, req *core.EmbeddingRequest) (
 	if err != nil {
 		return nil, err
 	}
-	if resp.Model == "" {
-		resp.Model = req.Model
-	}
+	core.EnsureModel(&resp.Model, req.Model)
 	if resp.Provider == "" {
 		resp.Provider = p.responseProviderName()
 	}

--- a/internal/providers/groq/groq.go
+++ b/internal/providers/groq/groq.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
 
 	"gomodel/internal/core"
 	"gomodel/internal/llmclient"
@@ -165,17 +164,7 @@ func (p *Provider) GetBatch(ctx context.Context, id string) (*core.BatchResponse
 
 // ListBatches lists native Groq batch jobs.
 func (p *Provider) ListBatches(ctx context.Context, limit int, after string) (*core.BatchListResponse, error) {
-	values := url.Values{}
-	if limit > 0 {
-		values.Set("limit", strconv.Itoa(limit))
-	}
-	if after != "" {
-		values.Set("after", after)
-	}
-	endpoint := "/batches"
-	if encoded := values.Encode(); encoded != "" {
-		endpoint += "?" + encoded
-	}
+	endpoint := providers.PaginatedEndpoint("/batches", limit, "after", after)
 
 	var resp core.BatchListResponse
 	err := p.client.Do(ctx, llmclient.Request{

--- a/internal/providers/groq/groq.go
+++ b/internal/providers/groq/groq.go
@@ -83,9 +83,7 @@ func (p *Provider) ChatCompletion(ctx context.Context, req *core.ChatRequest) (*
 	if err != nil {
 		return nil, err
 	}
-	if resp.Model == "" {
-		resp.Model = req.Model
-	}
+	core.EnsureModel(&resp.Model, req.Model)
 	return &resp, nil
 }
 
@@ -132,9 +130,7 @@ func (p *Provider) Embeddings(ctx context.Context, req *core.EmbeddingRequest) (
 	if err != nil {
 		return nil, err
 	}
-	if resp.Model == "" {
-		resp.Model = req.Model
-	}
+	core.EnsureModel(&resp.Model, req.Model)
 	return &resp, nil
 }
 

--- a/internal/providers/ollama/ollama.go
+++ b/internal/providers/ollama/ollama.go
@@ -119,9 +119,7 @@ func (p *Provider) ChatCompletion(ctx context.Context, req *core.ChatRequest) (*
 	if err != nil {
 		return nil, err
 	}
-	if resp.Model == "" {
-		resp.Model = req.Model
-	}
+	core.EnsureModel(&resp.Model, req.Model)
 	return &resp, nil
 }
 

--- a/internal/providers/ollama/ollama.go
+++ b/internal/providers/ollama/ollama.go
@@ -215,27 +215,33 @@ func (p *Provider) Embeddings(ctx context.Context, req *core.EmbeddingRequest) (
 	}, nil
 }
 
+// errBatchUnsupported is returned by every batch endpoint because Ollama has
+// no native discounted batch API.
+func errBatchUnsupported() error {
+	return core.NewInvalidRequestError("ollama does not support native discounted batch processing", nil)
+}
+
 // CreateBatch returns unsupported because Ollama has no native discounted batch API.
 func (p *Provider) CreateBatch(_ context.Context, _ *core.BatchRequest) (*core.BatchResponse, error) {
-	return nil, core.NewInvalidRequestError("ollama does not support native discounted batch processing", nil)
+	return nil, errBatchUnsupported()
 }
 
 // GetBatch returns unsupported because Ollama has no native discounted batch API.
 func (p *Provider) GetBatch(_ context.Context, _ string) (*core.BatchResponse, error) {
-	return nil, core.NewInvalidRequestError("ollama does not support native discounted batch processing", nil)
+	return nil, errBatchUnsupported()
 }
 
 // ListBatches returns unsupported because Ollama has no native discounted batch API.
 func (p *Provider) ListBatches(_ context.Context, _ int, _ string) (*core.BatchListResponse, error) {
-	return nil, core.NewInvalidRequestError("ollama does not support native discounted batch processing", nil)
+	return nil, errBatchUnsupported()
 }
 
 // CancelBatch returns unsupported because Ollama has no native discounted batch API.
 func (p *Provider) CancelBatch(_ context.Context, _ string) (*core.BatchResponse, error) {
-	return nil, core.NewInvalidRequestError("ollama does not support native discounted batch processing", nil)
+	return nil, errBatchUnsupported()
 }
 
 // GetBatchResults returns unsupported because Ollama has no native discounted batch API.
 func (p *Provider) GetBatchResults(_ context.Context, _ string) (*core.BatchResultsResponse, error) {
-	return nil, core.NewInvalidRequestError("ollama does not support native discounted batch processing", nil)
+	return nil, errBatchUnsupported()
 }

--- a/internal/providers/openai/compatible_provider.go
+++ b/internal/providers/openai/compatible_provider.go
@@ -105,9 +105,7 @@ func (p *CompatibleProvider) ChatCompletion(ctx context.Context, req *core.ChatR
 	if err != nil {
 		return nil, err
 	}
-	if resp.Model == "" {
-		resp.Model = req.Model
-	}
+	core.EnsureModel(&resp.Model, req.Model)
 	return &resp, nil
 }
 
@@ -167,9 +165,7 @@ func (p *CompatibleProvider) Responses(ctx context.Context, req *core.ResponsesR
 	if err != nil {
 		return nil, err
 	}
-	if resp.Model == "" {
-		resp.Model = req.Model
-	}
+	core.EnsureModel(&resp.Model, req.Model)
 	return &resp, nil
 }
 
@@ -340,9 +336,7 @@ func (p *CompatibleProvider) Embeddings(ctx context.Context, req *core.Embedding
 	if err != nil {
 		return nil, err
 	}
-	if resp.Model == "" {
-		resp.Model = req.Model
-	}
+	core.EnsureModel(&resp.Model, req.Model)
 	return &resp, nil
 }
 

--- a/internal/providers/openai/compatible_provider.go
+++ b/internal/providers/openai/compatible_provider.go
@@ -393,17 +393,7 @@ func (p *CompatibleProvider) GetBatch(ctx context.Context, id string) (*core.Bat
 }
 
 func (p *CompatibleProvider) ListBatches(ctx context.Context, limit int, after string) (*core.BatchListResponse, error) {
-	values := url.Values{}
-	if limit > 0 {
-		values.Set("limit", strconv.Itoa(limit))
-	}
-	if after != "" {
-		values.Set("after", after)
-	}
-	endpoint := "/batches"
-	if encoded := values.Encode(); encoded != "" {
-		endpoint += "?" + encoded
-	}
+	endpoint := providers.PaginatedEndpoint("/batches", limit, "after", after)
 
 	var resp core.BatchListResponse
 	err := p.Do(ctx, llmclient.Request{

--- a/internal/providers/openai/openai.go
+++ b/internal/providers/openai/openai.go
@@ -15,7 +15,7 @@ import (
 var Registration = providers.Registration{
 	Type:                        "openai",
 	New:                         New,
-	PassthroughSemanticEnricher: passthroughSemanticEnricher{},
+	PassthroughSemanticEnricher: passthroughSemanticEnricher,
 	Discovery: providers.DiscoveryConfig{
 		DefaultBaseURL: defaultBaseURL,
 	},

--- a/internal/providers/openai/passthrough_semantics.go
+++ b/internal/providers/openai/passthrough_semantics.go
@@ -1,38 +1,9 @@
 package openai
 
-import (
-	"strings"
+import "gomodel/internal/providers"
 
-	"gomodel/internal/core"
-	"gomodel/internal/providers"
-)
-
-type passthroughSemanticEnricher struct{}
-
-func (passthroughSemanticEnricher) ProviderType() string {
-	return "openai"
-}
-
-func (passthroughSemanticEnricher) Enrich(_ *core.RequestSnapshot, _ *core.WhiteBoxPrompt, info *core.PassthroughRouteInfo) *core.PassthroughRouteInfo {
-	if info == nil {
-		return nil
-	}
-	enriched := *info
-	normalizedEndpoint := strings.TrimLeft(strings.TrimSpace(providers.PassthroughEndpointPath(&enriched)), "/")
-	switch "/" + normalizedEndpoint {
-	case "/chat/completions":
-		enriched.SemanticOperation = "openai.chat_completions"
-		enriched.AuditPath = "/v1/chat/completions"
-	case "/responses":
-		enriched.SemanticOperation = "openai.responses"
-		enriched.AuditPath = "/v1/responses"
-	case "/embeddings":
-		enriched.SemanticOperation = "openai.embeddings"
-		enriched.AuditPath = "/v1/embeddings"
-	default:
-		if strings.TrimSpace(enriched.AuditPath) == "" && normalizedEndpoint != "" {
-			enriched.AuditPath = "/p/openai/" + normalizedEndpoint
-		}
-	}
-	return &enriched
-}
+var passthroughSemanticEnricher = providers.NewSemanticEnricher("openai", map[string]providers.PassthroughEndpointSemantics{
+	"/chat/completions": {Operation: "openai.chat_completions", AuditPath: "/v1/chat/completions"},
+	"/responses":        {Operation: "openai.responses", AuditPath: "/v1/responses"},
+	"/embeddings":       {Operation: "openai.embeddings", AuditPath: "/v1/embeddings"},
+})

--- a/internal/providers/openai/passthrough_semantics_test.go
+++ b/internal/providers/openai/passthrough_semantics_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestPassthroughSemanticEnricher_Enrich(t *testing.T) {
-	enricher := passthroughSemanticEnricher{}
+	enricher := passthroughSemanticEnricher
 
 	tests := []struct {
 		name          string

--- a/internal/providers/passthrough.go
+++ b/internal/providers/passthrough.go
@@ -53,3 +53,46 @@ func PassthroughEndpointPath(info *core.PassthroughRouteInfo) string {
 	}
 	return endpoint
 }
+
+// PassthroughEndpointSemantics names the semantic operation and audit path
+// for one provider passthrough endpoint.
+type PassthroughEndpointSemantics struct {
+	Operation string
+	AuditPath string
+}
+
+// SemanticEnricher implements core.PassthroughSemanticEnricher from a static
+// endpoint table. Endpoints missing from the table keep their audit path, or
+// fall back to the generic /p/{provider}/... form when none is set.
+type SemanticEnricher struct {
+	providerType string
+	endpoints    map[string]PassthroughEndpointSemantics
+}
+
+// NewSemanticEnricher builds a SemanticEnricher for a provider type from its
+// endpoint table; keys are normalized endpoint paths such as "/embeddings".
+func NewSemanticEnricher(providerType string, endpoints map[string]PassthroughEndpointSemantics) SemanticEnricher {
+	return SemanticEnricher{providerType: providerType, endpoints: endpoints}
+}
+
+// ProviderType returns the provider type this enricher serves.
+func (e SemanticEnricher) ProviderType() string {
+	return e.providerType
+}
+
+// Enrich annotates passthrough route info with the provider's semantic
+// operation and audit path for known endpoints.
+func (e SemanticEnricher) Enrich(_ *core.RequestSnapshot, _ *core.WhiteBoxPrompt, info *core.PassthroughRouteInfo) *core.PassthroughRouteInfo {
+	if info == nil {
+		return nil
+	}
+	enriched := *info
+	normalizedEndpoint := strings.TrimLeft(strings.TrimSpace(PassthroughEndpointPath(&enriched)), "/")
+	if semantics, ok := e.endpoints["/"+normalizedEndpoint]; ok {
+		enriched.SemanticOperation = semantics.Operation
+		enriched.AuditPath = semantics.AuditPath
+	} else if strings.TrimSpace(enriched.AuditPath) == "" && normalizedEndpoint != "" {
+		enriched.AuditPath = "/p/" + e.providerType + "/" + normalizedEndpoint
+	}
+	return &enriched
+}

--- a/internal/providers/vllm/passthrough_semantics.go
+++ b/internal/providers/vllm/passthrough_semantics.go
@@ -1,41 +1,10 @@
 package vllm
 
-import (
-	"strings"
+import "gomodel/internal/providers"
 
-	"gomodel/internal/core"
-	"gomodel/internal/providers"
-)
-
-type passthroughSemanticEnricher struct{}
-
-func (passthroughSemanticEnricher) ProviderType() string {
-	return "vllm"
-}
-
-func (passthroughSemanticEnricher) Enrich(_ *core.RequestSnapshot, _ *core.WhiteBoxPrompt, info *core.PassthroughRouteInfo) *core.PassthroughRouteInfo {
-	if info == nil {
-		return nil
-	}
-	enriched := *info
-	normalizedEndpoint := strings.TrimLeft(strings.TrimSpace(providers.PassthroughEndpointPath(&enriched)), "/")
-	switch "/" + normalizedEndpoint {
-	case "/chat/completions":
-		enriched.SemanticOperation = "vllm.chat_completions"
-		enriched.AuditPath = "/v1/chat/completions"
-	case "/responses":
-		enriched.SemanticOperation = "vllm.responses"
-		enriched.AuditPath = "/v1/responses"
-	case "/embeddings":
-		enriched.SemanticOperation = "vllm.embeddings"
-		enriched.AuditPath = "/v1/embeddings"
-	case "/completions":
-		enriched.SemanticOperation = "vllm.completions"
-		enriched.AuditPath = "/v1/completions"
-	default:
-		if strings.TrimSpace(enriched.AuditPath) == "" && normalizedEndpoint != "" {
-			enriched.AuditPath = "/p/vllm/" + normalizedEndpoint
-		}
-	}
-	return &enriched
-}
+var passthroughSemanticEnricher = providers.NewSemanticEnricher("vllm", map[string]providers.PassthroughEndpointSemantics{
+	"/chat/completions": {Operation: "vllm.chat_completions", AuditPath: "/v1/chat/completions"},
+	"/responses":        {Operation: "vllm.responses", AuditPath: "/v1/responses"},
+	"/embeddings":       {Operation: "vllm.embeddings", AuditPath: "/v1/embeddings"},
+	"/completions":      {Operation: "vllm.completions", AuditPath: "/v1/completions"},
+})

--- a/internal/providers/vllm/vllm.go
+++ b/internal/providers/vllm/vllm.go
@@ -19,7 +19,7 @@ const defaultBaseURL = "http://localhost:8000/v1"
 var Registration = providers.Registration{
 	Type:                        "vllm",
 	New:                         New,
-	PassthroughSemanticEnricher: passthroughSemanticEnricher{},
+	PassthroughSemanticEnricher: passthroughSemanticEnricher,
 	Discovery: providers.DiscoveryConfig{
 		DefaultBaseURL:  defaultBaseURL,
 		AllowAPIKeyless: true,

--- a/internal/providers/xai/xai.go
+++ b/internal/providers/xai/xai.go
@@ -179,9 +179,7 @@ func (p *Provider) ChatCompletion(ctx context.Context, req *core.ChatRequest) (*
 	if err != nil {
 		return nil, err
 	}
-	if resp.Model == "" {
-		resp.Model = req.Model
-	}
+	core.EnsureModel(&resp.Model, req.Model)
 	return &resp, nil
 }
 
@@ -219,9 +217,7 @@ func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*
 	if err != nil {
 		return nil, err
 	}
-	if resp.Model == "" {
-		resp.Model = req.Model
-	}
+	core.EnsureModel(&resp.Model, req.Model)
 	return &resp, nil
 }
 
@@ -254,9 +250,7 @@ func (p *Provider) Embeddings(ctx context.Context, req *core.EmbeddingRequest) (
 	if err != nil {
 		return nil, err
 	}
-	if resp.Model == "" {
-		resp.Model = req.Model
-	}
+	core.EnsureModel(&resp.Model, req.Model)
 	return &resp, nil
 }
 

--- a/internal/providers/xai/xai.go
+++ b/internal/providers/xai/xai.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 
 	"gomodel/internal/core"
@@ -285,17 +284,7 @@ func (p *Provider) GetBatch(ctx context.Context, id string) (*core.BatchResponse
 
 // ListBatches lists native xAI batch jobs.
 func (p *Provider) ListBatches(ctx context.Context, limit int, after string) (*core.BatchListResponse, error) {
-	values := url.Values{}
-	if limit > 0 {
-		values.Set("limit", strconv.Itoa(limit))
-	}
-	if after != "" {
-		values.Set("after", after)
-	}
-	endpoint := "/batches"
-	if encoded := values.Encode(); encoded != "" {
-		endpoint += "?" + encoded
-	}
+	endpoint := providers.PaginatedEndpoint("/batches", limit, "after", after)
 
 	var resp core.BatchListResponse
 	err := p.client.Do(ctx, llmclient.Request{

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -30,6 +30,7 @@ import (
 	batchstore "gomodel/internal/batch"
 	"gomodel/internal/core"
 	"gomodel/internal/filestore"
+	"gomodel/internal/gateway"
 	"gomodel/internal/guardrails"
 	"gomodel/internal/observability"
 	provideradapter "gomodel/internal/providers"
@@ -1043,7 +1044,7 @@ func (m *mockProvider) ListFiles(_ context.Context, providerType, purpose string
 				Bytes:     10,
 				CreatedAt: 1000,
 				Filename:  "a.jsonl",
-				Purpose:   firstNonEmpty(purpose, "batch"),
+				Purpose:   gateway.FirstNonEmpty(purpose, "batch"),
 				Provider:  providerType,
 			},
 		},
@@ -6508,7 +6509,7 @@ func TestMergeStoredBatchFromUpstreamPreservesGatewayMetadata(t *testing.T) {
 		},
 	}
 
-	mergeStoredBatchFromUpstream(stored, upstream)
+	gateway.MergeStoredBatchFromUpstream(stored, upstream)
 
 	if stored.Batch.Metadata["provider"] != "openai" {
 		t.Fatalf("provider metadata overwritten: %q", stored.Batch.Metadata["provider"])
@@ -6576,7 +6577,7 @@ func TestMergeStoredBatchFromUpstreamPreservesExistingValuesOnSparseUpstream(t *
 		},
 	}
 
-	mergeStoredBatchFromUpstream(stored, upstream)
+	gateway.MergeStoredBatchFromUpstream(stored, upstream)
 
 	if got := stored.Batch.Status; got != "in_progress" {
 		t.Fatalf("Status = %q, want in_progress", got)
@@ -7285,7 +7286,7 @@ func TestIsNativeBatchResultsPending(t *testing.T) {
 		batchGetResponse: &core.BatchResponse{ID: "provider-batch-1", Status: "in_progress"},
 	}
 	anthropicErr := core.NewProviderError("anthropic", http.StatusNotFound, "pending", nil)
-	pending, latest := isNativeBatchResultsPending(context.Background(), provider, "anthropic", "provider-batch-1", anthropicErr)
+	pending, latest := gateway.IsNativeBatchResultsPending(context.Background(), provider, "anthropic", "provider-batch-1", anthropicErr)
 	if !pending {
 		t.Fatal("expected anthropic 404 to be treated as pending")
 	}
@@ -7294,12 +7295,12 @@ func TestIsNativeBatchResultsPending(t *testing.T) {
 	}
 
 	openAIErr := core.NewProviderError("openai", http.StatusNotFound, "not found", nil)
-	if pending, _ := isNativeBatchResultsPending(context.Background(), provider, "openai", "provider-batch-1", openAIErr); pending {
+	if pending, _ := gateway.IsNativeBatchResultsPending(context.Background(), provider, "openai", "provider-batch-1", openAIErr); pending {
 		t.Fatal("expected openai 404 not to be treated as pending")
 	}
 
 	provider.batchGetResponse = &core.BatchResponse{ID: "provider-batch-1", Status: "expired"}
-	if pending, _ := isNativeBatchResultsPending(context.Background(), provider, "anthropic", "provider-batch-1", anthropicErr); pending {
+	if pending, _ := gateway.IsNativeBatchResultsPending(context.Background(), provider, "anthropic", "provider-batch-1", anthropicErr); pending {
 		t.Fatal("expected terminal anthropic batch not to be treated as pending")
 	}
 }

--- a/internal/server/native_batch_support.go
+++ b/internal/server/native_batch_support.go
@@ -7,38 +7,7 @@ import (
 	batchstore "gomodel/internal/batch"
 	"gomodel/internal/batchrewrite"
 	"gomodel/internal/core"
-	"gomodel/internal/gateway"
 )
-
-type batchExecutionSelection struct {
-	providerType string
-	selector     core.WorkflowSelector
-}
-
-func determineBatchExecutionSelection(
-	provider core.RoutableProvider,
-	resolver RequestModelResolver,
-	req *core.BatchRequest,
-) (batchExecutionSelection, error) {
-	return determineBatchExecutionSelectionWithAuthorizer(context.Background(), provider, resolver, nil, req)
-}
-
-func determineBatchExecutionSelectionWithAuthorizer(
-	ctx context.Context,
-	provider core.RoutableProvider,
-	resolver RequestModelResolver,
-	authorizer RequestModelAuthorizer,
-	req *core.BatchRequest,
-) (batchExecutionSelection, error) {
-	selection, err := gateway.DetermineBatchExecutionSelectionWithAuthorizer(ctx, provider, resolver, authorizer, req)
-	if err != nil {
-		return batchExecutionSelection{}, err
-	}
-	return batchExecutionSelection{
-		providerType: selection.ProviderType,
-		selector:     selection.Selector,
-	}, nil
-}
 
 func (h *Handler) cleanupPreparedBatchInputFile(ctx context.Context, providerType, fileID string) {
 	fileID = strings.TrimSpace(fileID)
@@ -50,18 +19,6 @@ func (h *Handler) cleanupPreparedBatchInputFile(ctx context.Context, providerTyp
 		return
 	}
 	batchrewrite.CleanupFile(ctx, files, providerType, fileID, "")
-}
-
-func (h *Handler) logBatchUsageFromBatchResults(stored *batchstore.StoredBatch, result *core.BatchResultsResponse, fallbackRequestID string) bool {
-	return gateway.LogBatchUsageFromBatchResults(stored, result, fallbackRequestID, h.usageLogger, h.pricingResolver)
-}
-
-func firstNonEmpty(values ...string) string {
-	return gateway.FirstNonEmpty(values...)
-}
-
-func mergeStoredBatchFromUpstream(stored *batchstore.StoredBatch, upstream *core.BatchResponse) {
-	gateway.MergeStoredBatchFromUpstream(stored, upstream)
 }
 
 func (h *Handler) cleanupStoredBatchRewrittenInputFile(ctx context.Context, stored *batchstore.StoredBatch) bool {
@@ -81,13 +38,4 @@ func (h *Handler) cleanupStoredBatchRewrittenInputFile(ctx context.Context, stor
 	}
 	stored.RewrittenInputFileID = ""
 	return true
-}
-
-func isNativeBatchResultsPending(
-	ctx context.Context,
-	nativeRouter core.NativeBatchRoutableProvider,
-	providerType, providerBatchID string,
-	err error,
-) (bool, *core.BatchResponse) {
-	return gateway.IsNativeBatchResultsPending(ctx, nativeRouter, providerType, providerBatchID, err)
 }

--- a/internal/server/native_batch_support_test.go
+++ b/internal/server/native_batch_support_test.go
@@ -5,6 +5,7 @@ import (
 
 	batchstore "gomodel/internal/batch"
 	"gomodel/internal/core"
+	"gomodel/internal/gateway"
 	"gomodel/internal/usage"
 )
 
@@ -46,7 +47,7 @@ func TestHandlerLogBatchUsageFromBatchResultsUsesStoredUserPath(t *testing.T) {
 		},
 	}
 
-	logged := handler.logBatchUsageFromBatchResults(stored, result, "")
+	logged := gateway.LogBatchUsageFromBatchResults(stored, result, "", handler.usageLogger, handler.pricingResolver)
 	if !logged {
 		t.Fatal("logBatchUsageFromBatchResults() = false, want true")
 	}

--- a/internal/server/native_response_service.go
+++ b/internal/server/native_response_service.go
@@ -12,6 +12,7 @@ import (
 
 	"gomodel/internal/auditlog"
 	"gomodel/internal/core"
+	"gomodel/internal/gateway"
 	"gomodel/internal/responsestore"
 )
 
@@ -110,7 +111,7 @@ func (s *nativeResponseService) CancelResponse(c *echo.Context) error {
 		providerType := storedProvider(stored)
 		providerRoute := storedProviderRoute(stored)
 		auditResponseEntry(c, providerType)
-		resp, err := s.cancelNativeResponse(ctx, providerRoute, firstNonEmpty(stored.ProviderResponseID, id))
+		resp, err := s.cancelNativeResponse(ctx, providerRoute, gateway.FirstNonEmpty(stored.ProviderResponseID, id))
 		if err != nil {
 			if isUnsupportedNativeResponseError(err) {
 				return handleError(c, unsupportedResponseOperation("native response cancellation is not available for this provider"))
@@ -157,7 +158,7 @@ func (s *nativeResponseService) DeleteResponse(c *echo.Context) error {
 		providerType := storedProvider(stored)
 		providerRoute := storedProviderRoute(stored)
 		auditResponseEntry(c, providerType)
-		deleteResp, deleteErr := s.deleteNativeResponse(ctx, providerRoute, firstNonEmpty(stored.ProviderResponseID, id))
+		deleteResp, deleteErr := s.deleteNativeResponse(ctx, providerRoute, gateway.FirstNonEmpty(stored.ProviderResponseID, id))
 		if deleteErr != nil && !isUnsupportedNativeResponseError(deleteErr) && !isNotFoundGatewayError(deleteErr) {
 			return handleError(c, deleteErr)
 		}

--- a/internal/server/workflow_policy_test.go
+++ b/internal/server/workflow_policy_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"gomodel/internal/core"
+	"gomodel/internal/gateway"
 )
 
 type requestWorkflowPolicyResolverFunc func(selector core.WorkflowSelector) (*core.ResolvedWorkflowPolicy, error)
@@ -73,15 +74,15 @@ func TestDetermineBatchExecutionSelection_UsesSingleResolutionPass(t *testing.T)
 		},
 	}
 
-	selection, err := determineBatchExecutionSelection(provider, resolver, req)
+	selection, err := gateway.DetermineBatchExecutionSelectionWithAuthorizer(context.Background(), provider, resolver, nil, req)
 	if err != nil {
-		t.Fatalf("determineBatchExecutionSelection() error = %v", err)
+		t.Fatalf("DetermineBatchExecutionSelectionWithAuthorizer() error = %v", err)
 	}
-	if selection.providerType != "openai" {
-		t.Fatalf("providerType = %q, want openai", selection.providerType)
+	if selection.ProviderType != "openai" {
+		t.Fatalf("providerType = %q, want openai", selection.ProviderType)
 	}
-	if selection.selector.Provider != "openai" || selection.selector.Model != "gpt-4o-mini" {
-		t.Fatalf("selector = %+v, want openai/gpt-4o-mini", selection.selector)
+	if selection.Selector.Provider != "openai" || selection.Selector.Model != "gpt-4o-mini" {
+		t.Fatalf("selector = %+v, want openai/gpt-4o-mini", selection.Selector)
 	}
 	if resolver.calls != len(req.Requests) {
 		t.Fatalf("resolver calls = %d, want %d", resolver.calls, len(req.Requests))

--- a/internal/storage/sqlutil/sqlutil.go
+++ b/internal/storage/sqlutil/sqlutil.go
@@ -1,8 +1,12 @@
-// Package sqlutil provides small SQL query-building helpers shared by the
-// SQL-backed readers (usage, audit log).
+// Package sqlutil provides small SQL query-building and value-conversion
+// helpers shared by the SQL-backed stores and readers.
 package sqlutil
 
-import "strings"
+import (
+	"database/sql"
+	"strings"
+	"time"
+)
 
 // EscapeLikeWildcards escapes SQL LIKE/ILIKE wildcard characters in user input
 // to prevent wildcard injection. Escapes \, %, and _.
@@ -35,4 +39,57 @@ func ClampLimitOffset(limit, offset, defaultLimit, maxLimit int) (int, int) {
 		offset = 0
 	}
 	return limit, offset
+}
+
+// UnixOrNil returns the UTC Unix timestamp for value, or nil when value is
+// nil, for binding optional timestamps to nullable integer columns.
+func UnixOrNil(value *time.Time) any {
+	if value == nil {
+		return nil
+	}
+	return value.UTC().Unix()
+}
+
+// TimeFromUnix converts a nullable Unix timestamp column to a *time.Time.
+func TimeFromUnix(value sql.NullInt64) *time.Time {
+	if !value.Valid {
+		return nil
+	}
+	t := time.Unix(value.Int64, 0).UTC()
+	return &t
+}
+
+// TimeFromUnixPtr converts an optional Unix timestamp to a *time.Time.
+func TimeFromUnixPtr(value *int64) *time.Time {
+	if value == nil {
+		return nil
+	}
+	t := time.Unix(*value, 0).UTC()
+	return &t
+}
+
+// NullableString returns the trimmed value, or nil when blank, for binding
+// optional strings to nullable text columns.
+func NullableString(value string) any {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+// StringFromNullable converts a nullable text column to a trimmed string.
+func StringFromNullable(value sql.NullString) string {
+	if !value.Valid {
+		return ""
+	}
+	return strings.TrimSpace(value.String)
+}
+
+// DerefTrimmed converts an optional text column to a trimmed string.
+func DerefTrimmed(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(*value)
 }

--- a/internal/storage/sqlutil/sqlutil.go
+++ b/internal/storage/sqlutil/sqlutil.go
@@ -41,6 +41,18 @@ func ClampLimitOffset(limit, offset, defaultLimit, maxLimit int) (int, int) {
 	return limit, offset
 }
 
+// ParseSQLiteTimestamp parses a SQLite text timestamp in the formats GoModel
+// writes (RFC3339Nano, SQLite datetime with offset, or bare UTC seconds).
+// Returns the zero time and false when no format matches.
+func ParseSQLiteTimestamp(ts string) (time.Time, bool) {
+	for _, layout := range []string{time.RFC3339Nano, "2006-01-02 15:04:05.999999999-07:00", "2006-01-02T15:04:05Z"} {
+		if t, err := time.Parse(layout, ts); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
 // UnixOrNil returns the UTC Unix timestamp for value, or nil when value is
 // nil, for binding optional timestamps to nullable integer columns.
 func UnixOrNil(value *time.Time) any {

--- a/internal/storage/sqlutil/sqlutil.go
+++ b/internal/storage/sqlutil/sqlutil.go
@@ -1,0 +1,38 @@
+// Package sqlutil provides small SQL query-building helpers shared by the
+// SQL-backed readers (usage, audit log).
+package sqlutil
+
+import "strings"
+
+// EscapeLikeWildcards escapes SQL LIKE/ILIKE wildcard characters in user input
+// to prevent wildcard injection. Escapes \, %, and _.
+func EscapeLikeWildcards(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `%`, `\%`)
+	s = strings.ReplaceAll(s, `_`, `\_`)
+	return s
+}
+
+// BuildWhereClause joins condition strings into a SQL WHERE clause.
+// Returns an empty string when conditions is empty.
+func BuildWhereClause(conditions []string) string {
+	if len(conditions) == 0 {
+		return ""
+	}
+	return " WHERE " + strings.Join(conditions, " AND ")
+}
+
+// ClampLimitOffset normalises pagination parameters: limit defaults to
+// defaultLimit when non-positive and is capped at maxLimit; offset floors at 0.
+func ClampLimitOffset(limit, offset, defaultLimit, maxLimit int) (int, int) {
+	if limit <= 0 {
+		limit = defaultLimit
+	}
+	if limit > maxLimit {
+		limit = maxLimit
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	return limit, offset
+}

--- a/internal/usage/reader_helpers.go
+++ b/internal/usage/reader_helpers.go
@@ -1,26 +1,8 @@
 package usage
 
 import (
-	"strings"
+	"gomodel/internal/storage/sqlutil"
 )
-
-// escapeLikeWildcards escapes SQL LIKE/ILIKE wildcard characters in user input
-// to prevent wildcard injection. Escapes \, %, and _.
-func escapeLikeWildcards(s string) string {
-	s = strings.ReplaceAll(s, `\`, `\\`)
-	s = strings.ReplaceAll(s, `%`, `\%`)
-	s = strings.ReplaceAll(s, `_`, `\_`)
-	return s
-}
-
-// buildWhereClause joins condition strings into a SQL WHERE clause.
-// Returns an empty string when conditions is empty.
-func buildWhereClause(conditions []string) string {
-	if len(conditions) == 0 {
-		return ""
-	}
-	return " WHERE " + strings.Join(conditions, " AND ")
-}
 
 // usageGroupedProviderNameSQL returns a SQL expression that collapses blank
 // provider_name values to the canonical provider before grouping.
@@ -34,18 +16,8 @@ func usageGroupedUserPathSQL(userPathColumn string) string {
 	return "COALESCE(NULLIF(TRIM(" + userPathColumn + "), ''), '/')"
 }
 
-// clampLimitOffset normalises pagination parameters:
-//   - limit defaults to 50 and is capped at 200
-//   - offset floors at 0
+// clampLimitOffset applies the usage reader pagination policy:
+// limit defaults to 50 and is capped at 200; offset floors at 0.
 func clampLimitOffset(limit, offset int) (int, int) {
-	if limit <= 0 {
-		limit = 50
-	}
-	if limit > 200 {
-		limit = 200
-	}
-	if offset < 0 {
-		offset = 0
-	}
-	return limit, offset
+	return sqlutil.ClampLimitOffset(limit, offset, 50, 200)
 }

--- a/internal/usage/reader_mongodb.go
+++ b/internal/usage/reader_mongodb.go
@@ -63,6 +63,26 @@ func (row mongoUsageLogRow) toUsageLogEntry() UsageLogEntry {
 }
 
 // NewMongoDBReader creates a new MongoDB usage reader.
+// mongoCostSum sums a nullable cost field, treating missing values as zero.
+func mongoCostSum(field string) bson.D {
+	return bson.D{{Key: "$sum", Value: bson.D{{Key: "$ifNull", Value: bson.A{field, 0}}}}}
+}
+
+// mongoCostPresenceCount counts documents where a nullable cost field is set,
+// so decoders can distinguish an all-null aggregate from a zero total.
+func mongoCostPresenceCount(field string) bson.D {
+	return bson.D{{Key: "$sum", Value: bson.D{{Key: "$cond", Value: bson.A{bson.D{{Key: "$gt", Value: bson.A{field, nil}}}, 1, 0}}}}}
+}
+
+// costPtr exposes an aggregated cost only when at least one document carried
+// that cost, mirroring the nullable columns of the SQL backends.
+func costPtr(present int, value float64) *float64 {
+	if present > 0 {
+		return &value
+	}
+	return nil
+}
+
 func NewMongoDBReader(database *mongo.Database) (*MongoDBReader, error) {
 	if database == nil {
 		return nil, fmt.Errorf("database is required")
@@ -87,12 +107,12 @@ func (r *MongoDBReader) GetSummary(ctx context.Context, params UsageQueryParams)
 		{Key: "total_input", Value: bson.D{{Key: "$sum", Value: "$input_tokens"}}},
 		{Key: "total_output", Value: bson.D{{Key: "$sum", Value: "$output_tokens"}}},
 		{Key: "total_tokens", Value: bson.D{{Key: "$sum", Value: "$total_tokens"}}},
-		{Key: "total_input_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$ifNull", Value: bson.A{"$input_cost", 0}}}}}},
-		{Key: "total_output_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$ifNull", Value: bson.A{"$output_cost", 0}}}}}},
-		{Key: "total_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$ifNull", Value: bson.A{"$total_cost", 0}}}}}},
-		{Key: "has_input_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$cond", Value: bson.A{bson.D{{Key: "$gt", Value: bson.A{"$input_cost", nil}}}, 1, 0}}}}}},
-		{Key: "has_output_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$cond", Value: bson.A{bson.D{{Key: "$gt", Value: bson.A{"$output_cost", nil}}}, 1, 0}}}}}},
-		{Key: "has_total_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$cond", Value: bson.A{bson.D{{Key: "$gt", Value: bson.A{"$total_cost", nil}}}, 1, 0}}}}}},
+		{Key: "total_input_cost", Value: mongoCostSum("$input_cost")},
+		{Key: "total_output_cost", Value: mongoCostSum("$output_cost")},
+		{Key: "total_cost", Value: mongoCostSum("$total_cost")},
+		{Key: "has_input_cost", Value: mongoCostPresenceCount("$input_cost")},
+		{Key: "has_output_cost", Value: mongoCostPresenceCount("$output_cost")},
+		{Key: "has_total_cost", Value: mongoCostPresenceCount("$total_cost")},
 	}}})
 
 	cursor, err := r.collection.Aggregate(ctx, pipeline)
@@ -122,15 +142,9 @@ func (r *MongoDBReader) GetSummary(ctx context.Context, params UsageQueryParams)
 		summary.TotalInput = result.TotalInput
 		summary.TotalOutput = result.TotalOutput
 		summary.TotalTokens = result.TotalTokens
-		if result.HasInputCost > 0 {
-			summary.TotalInputCost = &result.TotalInputCost
-		}
-		if result.HasOutputCost > 0 {
-			summary.TotalOutputCost = &result.TotalOutputCost
-		}
-		if result.HasTotalCost > 0 {
-			summary.TotalCost = &result.TotalCost
-		}
+		summary.TotalInputCost = costPtr(result.HasInputCost, result.TotalInputCost)
+		summary.TotalOutputCost = costPtr(result.HasOutputCost, result.TotalOutputCost)
+		summary.TotalCost = costPtr(result.HasTotalCost, result.TotalCost)
 	}
 
 	if err := cursor.Err(); err != nil {
@@ -160,12 +174,12 @@ func (r *MongoDBReader) GetUsageByModel(ctx context.Context, params UsageQueryPa
 		}},
 		{Key: "input_tokens", Value: bson.D{{Key: "$sum", Value: "$input_tokens"}}},
 		{Key: "output_tokens", Value: bson.D{{Key: "$sum", Value: "$output_tokens"}}},
-		{Key: "input_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$ifNull", Value: bson.A{"$input_cost", 0}}}}}},
-		{Key: "output_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$ifNull", Value: bson.A{"$output_cost", 0}}}}}},
-		{Key: "total_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$ifNull", Value: bson.A{"$total_cost", 0}}}}}},
-		{Key: "has_input_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$cond", Value: bson.A{bson.D{{Key: "$gt", Value: bson.A{"$input_cost", nil}}}, 1, 0}}}}}},
-		{Key: "has_output_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$cond", Value: bson.A{bson.D{{Key: "$gt", Value: bson.A{"$output_cost", nil}}}, 1, 0}}}}}},
-		{Key: "has_total_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$cond", Value: bson.A{bson.D{{Key: "$gt", Value: bson.A{"$total_cost", nil}}}, 1, 0}}}}}},
+		{Key: "input_cost", Value: mongoCostSum("$input_cost")},
+		{Key: "output_cost", Value: mongoCostSum("$output_cost")},
+		{Key: "total_cost", Value: mongoCostSum("$total_cost")},
+		{Key: "has_input_cost", Value: mongoCostPresenceCount("$input_cost")},
+		{Key: "has_output_cost", Value: mongoCostPresenceCount("$output_cost")},
+		{Key: "has_total_cost", Value: mongoCostPresenceCount("$total_cost")},
 	}}})
 
 	cursor, err := r.collection.Aggregate(ctx, pipeline)
@@ -201,15 +215,9 @@ func (r *MongoDBReader) GetUsageByModel(ctx context.Context, params UsageQueryPa
 			InputTokens:  row.InputTokens,
 			OutputTokens: row.OutputTokens,
 		}
-		if row.HasInputCost > 0 {
-			m.InputCost = &row.InputCost
-		}
-		if row.HasOutputCost > 0 {
-			m.OutputCost = &row.OutputCost
-		}
-		if row.HasTotalCost > 0 {
-			m.TotalCost = &row.TotalCost
-		}
+		m.InputCost = costPtr(row.HasInputCost, row.InputCost)
+		m.OutputCost = costPtr(row.HasOutputCost, row.OutputCost)
+		m.TotalCost = costPtr(row.HasTotalCost, row.TotalCost)
 		result = append(result, m)
 	}
 
@@ -253,12 +261,12 @@ func (r *MongoDBReader) GetUsageByUserPath(ctx context.Context, params UsageQuer
 		{Key: "input_tokens", Value: bson.D{{Key: "$sum", Value: "$input_tokens"}}},
 		{Key: "output_tokens", Value: bson.D{{Key: "$sum", Value: "$output_tokens"}}},
 		{Key: "total_tokens", Value: bson.D{{Key: "$sum", Value: "$total_tokens"}}},
-		{Key: "input_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$ifNull", Value: bson.A{"$input_cost", 0}}}}}},
-		{Key: "output_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$ifNull", Value: bson.A{"$output_cost", 0}}}}}},
-		{Key: "total_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$ifNull", Value: bson.A{"$total_cost", 0}}}}}},
-		{Key: "has_input_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$cond", Value: bson.A{bson.D{{Key: "$gt", Value: bson.A{"$input_cost", nil}}}, 1, 0}}}}}},
-		{Key: "has_output_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$cond", Value: bson.A{bson.D{{Key: "$gt", Value: bson.A{"$output_cost", nil}}}, 1, 0}}}}}},
-		{Key: "has_total_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$cond", Value: bson.A{bson.D{{Key: "$gt", Value: bson.A{"$total_cost", nil}}}, 1, 0}}}}}},
+		{Key: "input_cost", Value: mongoCostSum("$input_cost")},
+		{Key: "output_cost", Value: mongoCostSum("$output_cost")},
+		{Key: "total_cost", Value: mongoCostSum("$total_cost")},
+		{Key: "has_input_cost", Value: mongoCostPresenceCount("$input_cost")},
+		{Key: "has_output_cost", Value: mongoCostPresenceCount("$output_cost")},
+		{Key: "has_total_cost", Value: mongoCostPresenceCount("$total_cost")},
 	}}})
 
 	cursor, err := r.collection.Aggregate(ctx, pipeline)
@@ -293,15 +301,9 @@ func (r *MongoDBReader) GetUsageByUserPath(ctx context.Context, params UsageQuer
 		if u.UserPath == "" {
 			u.UserPath = "/"
 		}
-		if row.HasInputCost > 0 {
-			u.InputCost = &row.InputCost
-		}
-		if row.HasOutputCost > 0 {
-			u.OutputCost = &row.OutputCost
-		}
-		if row.HasTotalCost > 0 {
-			u.TotalCost = &row.TotalCost
-		}
+		u.InputCost = costPtr(row.HasInputCost, row.InputCost)
+		u.OutputCost = costPtr(row.HasOutputCost, row.OutputCost)
+		u.TotalCost = costPtr(row.HasTotalCost, row.TotalCost)
 		result = append(result, u)
 	}
 
@@ -490,12 +492,12 @@ func (r *MongoDBReader) GetDailyUsage(ctx context.Context, params UsageQueryPara
 			{Key: "input_tokens", Value: bson.D{{Key: "$sum", Value: "$input_tokens"}}},
 			{Key: "output_tokens", Value: bson.D{{Key: "$sum", Value: "$output_tokens"}}},
 			{Key: "total_tokens", Value: bson.D{{Key: "$sum", Value: "$total_tokens"}}},
-			{Key: "input_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$ifNull", Value: bson.A{"$input_cost", 0}}}}}},
-			{Key: "output_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$ifNull", Value: bson.A{"$output_cost", 0}}}}}},
-			{Key: "total_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$ifNull", Value: bson.A{"$total_cost", 0}}}}}},
-			{Key: "has_input_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$cond", Value: bson.A{bson.D{{Key: "$gt", Value: bson.A{"$input_cost", nil}}}, 1, 0}}}}}},
-			{Key: "has_output_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$cond", Value: bson.A{bson.D{{Key: "$gt", Value: bson.A{"$output_cost", nil}}}, 1, 0}}}}}},
-			{Key: "has_total_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$cond", Value: bson.A{bson.D{{Key: "$gt", Value: bson.A{"$total_cost", nil}}}, 1, 0}}}}}},
+			{Key: "input_cost", Value: mongoCostSum("$input_cost")},
+			{Key: "output_cost", Value: mongoCostSum("$output_cost")},
+			{Key: "total_cost", Value: mongoCostSum("$total_cost")},
+			{Key: "has_input_cost", Value: mongoCostPresenceCount("$input_cost")},
+			{Key: "has_output_cost", Value: mongoCostPresenceCount("$output_cost")},
+			{Key: "has_total_cost", Value: mongoCostPresenceCount("$total_cost")},
 		}}},
 		bson.D{{Key: "$sort", Value: bson.D{{Key: "_id", Value: 1}}}},
 	)
@@ -531,15 +533,9 @@ func (r *MongoDBReader) GetDailyUsage(ctx context.Context, params UsageQueryPara
 			OutputTokens: row.OutputTokens,
 			TotalTokens:  row.TotalTokens,
 		}
-		if row.HasInputCost > 0 {
-			d.InputCost = &row.InputCost
-		}
-		if row.HasOutputCost > 0 {
-			d.OutputCost = &row.OutputCost
-		}
-		if row.HasTotalCost > 0 {
-			d.TotalCost = &row.TotalCost
-		}
+		d.InputCost = costPtr(row.HasInputCost, row.InputCost)
+		d.OutputCost = costPtr(row.HasOutputCost, row.OutputCost)
+		d.TotalCost = costPtr(row.HasTotalCost, row.TotalCost)
 		result = append(result, d)
 	}
 
@@ -578,8 +574,8 @@ func (r *MongoDBReader) GetCacheOverview(ctx context.Context, params UsageQueryP
 				{Key: "total_input_tokens", Value: bson.D{{Key: "$sum", Value: "$input_tokens"}}},
 				{Key: "total_output_tokens", Value: bson.D{{Key: "$sum", Value: "$output_tokens"}}},
 				{Key: "total_tokens", Value: bson.D{{Key: "$sum", Value: "$total_tokens"}}},
-				{Key: "total_saved_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$ifNull", Value: bson.A{"$total_cost", 0}}}}}},
-				{Key: "has_saved_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$cond", Value: bson.A{bson.D{{Key: "$gt", Value: bson.A{"$total_cost", nil}}}, 1, 0}}}}}},
+				{Key: "total_saved_cost", Value: mongoCostSum("$total_cost")},
+				{Key: "has_saved_cost", Value: mongoCostPresenceCount("$total_cost")},
 			}}},
 		}},
 		{Key: "daily", Value: bson.A{
@@ -595,8 +591,8 @@ func (r *MongoDBReader) GetCacheOverview(ctx context.Context, params UsageQueryP
 				{Key: "input_tokens", Value: bson.D{{Key: "$sum", Value: "$input_tokens"}}},
 				{Key: "output_tokens", Value: bson.D{{Key: "$sum", Value: "$output_tokens"}}},
 				{Key: "total_tokens", Value: bson.D{{Key: "$sum", Value: "$total_tokens"}}},
-				{Key: "saved_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$ifNull", Value: bson.A{"$total_cost", 0}}}}}},
-				{Key: "has_saved_cost", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$cond", Value: bson.A{bson.D{{Key: "$gt", Value: bson.A{"$total_cost", nil}}}, 1, 0}}}}}},
+				{Key: "saved_cost", Value: mongoCostSum("$total_cost")},
+				{Key: "has_saved_cost", Value: mongoCostPresenceCount("$total_cost")},
 			}}},
 			bson.D{{Key: "$sort", Value: bson.D{{Key: "_id", Value: 1}}}},
 		}},
@@ -667,9 +663,7 @@ func (r *MongoDBReader) GetCacheOverview(ctx context.Context, params UsageQueryP
 			OutputTokens: row.OutputTokens,
 			TotalTokens:  row.TotalTokens,
 		}
-		if row.HasSavedCost > 0 {
-			entry.SavedCost = &row.SavedCost
-		}
+		entry.SavedCost = costPtr(row.HasSavedCost, row.SavedCost)
 		overview.Daily = append(overview.Daily, entry)
 	}
 

--- a/internal/usage/reader_postgresql.go
+++ b/internal/usage/reader_postgresql.go
@@ -1,6 +1,8 @@
 package usage
 
 import (
+	"gomodel/internal/storage/sqlutil"
+
 	"context"
 	"encoding/json"
 	"fmt"
@@ -34,7 +36,7 @@ func (r *PostgreSQLReader) GetSummary(ctx context.Context, params UsageQueryPara
 	if err != nil {
 		return nil, err
 	}
-	where := buildWhereClause(conditions)
+	where := sqlutil.BuildWhereClause(conditions)
 
 	costCols := `, SUM(input_cost), SUM(output_cost), SUM(total_cost)`
 	query := `SELECT COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)` + costCols + `
@@ -58,7 +60,7 @@ func (r *PostgreSQLReader) GetUsageByModel(ctx context.Context, params UsageQuer
 	if err != nil {
 		return nil, err
 	}
-	where := buildWhereClause(conditions)
+	where := sqlutil.BuildWhereClause(conditions)
 	providerNameExpr := usageGroupedProviderNameSQL("provider_name", "provider")
 
 	costCols := `, SUM(input_cost), SUM(output_cost), SUM(total_cost)`
@@ -94,7 +96,7 @@ func (r *PostgreSQLReader) GetUsageByUserPath(ctx context.Context, params UsageQ
 	if err != nil {
 		return nil, err
 	}
-	where := buildWhereClause(conditions)
+	where := sqlutil.BuildWhereClause(conditions)
 
 	costCols := `, SUM(input_cost), SUM(output_cost), SUM(total_cost)`
 	query := `SELECT ` + userPathExpr + ` AS user_path, COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)` + costCols + `
@@ -142,13 +144,13 @@ func (r *PostgreSQLReader) GetUsageLog(ctx context.Context, params UsageLogParam
 		argIdx += 2
 	}
 	if params.Search != "" {
-		s := "%" + escapeLikeWildcards(params.Search) + "%"
+		s := "%" + sqlutil.EscapeLikeWildcards(params.Search) + "%"
 		conditions = append(conditions, fmt.Sprintf("(model ILIKE $%d ESCAPE '\\' OR provider ILIKE $%d ESCAPE '\\' OR provider_name ILIKE $%d ESCAPE '\\' OR request_id ILIKE $%d ESCAPE '\\' OR provider_id ILIKE $%d ESCAPE '\\')", argIdx, argIdx, argIdx, argIdx, argIdx))
 		args = append(args, s)
 		argIdx++
 	}
 
-	where := buildWhereClause(conditions)
+	where := sqlutil.BuildWhereClause(conditions)
 
 	// Count total
 	var total int
@@ -302,7 +304,7 @@ func (r *PostgreSQLReader) GetDailyUsage(ctx context.Context, params UsageQueryP
 	if err != nil {
 		return nil, err
 	}
-	where := buildWhereClause(conditions)
+	where := sqlutil.BuildWhereClause(conditions)
 
 	costCols := `, SUM(input_cost), SUM(output_cost), SUM(total_cost)`
 	query := fmt.Sprintf(`SELECT %s as period, COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)`+costCols+`
@@ -338,7 +340,7 @@ func (r *PostgreSQLReader) GetCacheOverview(ctx context.Context, params UsageQue
 	if err != nil {
 		return nil, err
 	}
-	where := buildWhereClause(conditions)
+	where := sqlutil.BuildWhereClause(conditions)
 	queryArgs := append([]any{CacheTypeExact, CacheTypeSemantic}, args...)
 
 	summaryQuery := `SELECT COUNT(*),

--- a/internal/usage/reader_sqlite.go
+++ b/internal/usage/reader_sqlite.go
@@ -232,11 +232,7 @@ func scanSQLiteUsageLogEntries(rows *sql.Rows) ([]UsageLogEntry, error) {
 			&e.InputTokens, &e.OutputTokens, &e.TotalTokens, &e.InputCost, &e.OutputCost, &e.TotalCost, &e.CostSource, &rawDataJSON, &caveat); err != nil {
 			return nil, fmt.Errorf("failed to scan usage log row: %w", err)
 		}
-		if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
-			e.Timestamp = t
-		} else if t, err := time.Parse("2006-01-02 15:04:05.999999999-07:00", ts); err == nil {
-			e.Timestamp = t
-		} else if t, err := time.Parse("2006-01-02T15:04:05Z", ts); err == nil {
+		if t, ok := sqlutil.ParseSQLiteTimestamp(ts); ok {
 			e.Timestamp = t
 		} else {
 			slog.Warn("failed to parse timestamp", "request_id", e.RequestID, "raw_timestamp", ts)

--- a/internal/usage/reader_sqlite.go
+++ b/internal/usage/reader_sqlite.go
@@ -1,6 +1,8 @@
 package usage
 
 import (
+	"gomodel/internal/storage/sqlutil"
+
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -29,7 +31,7 @@ func (r *SQLiteReader) GetSummary(ctx context.Context, params UsageQueryParams) 
 	if err != nil {
 		return nil, err
 	}
-	where := buildWhereClause(conditions)
+	where := sqlutil.BuildWhereClause(conditions)
 
 	costCols := `, SUM(input_cost), SUM(output_cost), SUM(total_cost)`
 	query := `SELECT COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)` + costCols + `
@@ -53,7 +55,7 @@ func (r *SQLiteReader) GetUsageByModel(ctx context.Context, params UsageQueryPar
 	if err != nil {
 		return nil, err
 	}
-	where := buildWhereClause(conditions)
+	where := sqlutil.BuildWhereClause(conditions)
 	providerNameExpr := usageGroupedProviderNameSQL("provider_name", "provider")
 
 	costCols := `, SUM(input_cost), SUM(output_cost), SUM(total_cost)`
@@ -89,7 +91,7 @@ func (r *SQLiteReader) GetUsageByUserPath(ctx context.Context, params UsageQuery
 	if err != nil {
 		return nil, err
 	}
-	where := buildWhereClause(conditions)
+	where := sqlutil.BuildWhereClause(conditions)
 
 	costCols := `, SUM(input_cost), SUM(output_cost), SUM(total_cost)`
 	query := `SELECT ` + userPathExpr + ` AS user_path, COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)` + costCols + `
@@ -136,11 +138,11 @@ func (r *SQLiteReader) GetUsageLog(ctx context.Context, params UsageLogParams) (
 	}
 	if params.Search != "" {
 		conditions = append(conditions, "(model LIKE ? ESCAPE '\\' OR provider LIKE ? ESCAPE '\\' OR provider_name LIKE ? ESCAPE '\\' OR request_id LIKE ? ESCAPE '\\' OR provider_id LIKE ? ESCAPE '\\')")
-		s := "%" + escapeLikeWildcards(params.Search) + "%"
+		s := "%" + sqlutil.EscapeLikeWildcards(params.Search) + "%"
 		args = append(args, s, s, s, s, s)
 	}
 
-	where := buildWhereClause(conditions)
+	where := sqlutil.BuildWhereClause(conditions)
 
 	// Count total
 	var total int
@@ -329,7 +331,7 @@ func (r *SQLiteReader) GetDailyUsage(ctx context.Context, params UsageQueryParam
 	if err != nil {
 		return nil, err
 	}
-	where := buildWhereClause(conditions)
+	where := sqlutil.BuildWhereClause(conditions)
 
 	costCols := `, SUM(input_cost), SUM(output_cost), SUM(total_cost)`
 	query := `WITH usage_periods AS (
@@ -372,7 +374,7 @@ func (r *SQLiteReader) GetCacheOverview(ctx context.Context, params UsageQueryPa
 	if err != nil {
 		return nil, err
 	}
-	where := buildWhereClause(conditions)
+	where := sqlutil.BuildWhereClause(conditions)
 
 	summaryQuery := `SELECT COUNT(*),
 		COALESCE(SUM(CASE WHEN cache_type = '` + CacheTypeExact + `' THEN 1 ELSE 0 END), 0),
@@ -556,7 +558,7 @@ func (r *SQLiteReader) sqliteGroupingRange(ctx context.Context, params UsageQuer
 		conditions = append(conditions, "(user_path = ? OR user_path LIKE ? ESCAPE '\\')")
 		args = append(args, userPath, usageUserPathSubtreePattern(userPath))
 	}
-	query := `SELECT MIN(` + sqliteTimestampEpochExpr() + `), MAX(` + sqliteTimestampEpochExpr() + `) FROM usage` + buildWhereClause(conditions)
+	query := `SELECT MIN(` + sqliteTimestampEpochExpr() + `), MAX(` + sqliteTimestampEpochExpr() + `) FROM usage` + sqlutil.BuildWhereClause(conditions)
 	if err := r.db.QueryRowContext(ctx, query, args...).Scan(&minTS, &maxTS); err != nil {
 		return time.Time{}, time.Time{}, false, fmt.Errorf("failed to determine sqlite usage range: %w", err)
 	}

--- a/internal/usage/recalculate_pricing_postgresql.go
+++ b/internal/usage/recalculate_pricing_postgresql.go
@@ -1,6 +1,8 @@
 package usage
 
 import (
+	"gomodel/internal/storage/sqlutil"
+
 	"context"
 	"database/sql"
 	"fmt"
@@ -73,7 +75,7 @@ func postgresRecalculationEntries(ctx context.Context, tx pgx.Tx, params Recalcu
 
 	rows, err := tx.Query(ctx, `
 		SELECT id::text, model, provider, provider_name, endpoint, input_tokens, output_tokens, raw_data::text
-		FROM usage`+buildWhereClause(conditions)+`
+		FROM usage`+sqlutil.BuildWhereClause(conditions)+`
 		FOR UPDATE`, args...)
 	if err != nil {
 		return nil, fmt.Errorf("query postgres usage costs for recalculation: %w", err)

--- a/internal/usage/recalculate_pricing_sqlite.go
+++ b/internal/usage/recalculate_pricing_sqlite.go
@@ -1,6 +1,8 @@
 package usage
 
 import (
+	"gomodel/internal/storage/sqlutil"
+
 	"context"
 	"database/sql"
 	"fmt"
@@ -94,7 +96,7 @@ func (s *SQLiteStore) sqliteRecalculationEntries(ctx context.Context, tx *sql.Tx
 
 	rows, err := tx.QueryContext(ctx, `
 		SELECT id, model, provider, provider_name, endpoint, input_tokens, output_tokens, raw_data
-		FROM usage`+buildWhereClause(conditions)+`
+		FROM usage`+sqlutil.BuildWhereClause(conditions)+`
 		ORDER BY id
 		LIMIT ?`, args...)
 	if err != nil {

--- a/internal/usage/user_path_filter.go
+++ b/internal/usage/user_path_filter.go
@@ -1,6 +1,8 @@
 package usage
 
 import (
+	"gomodel/internal/storage/sqlutil"
+
 	"fmt"
 	"regexp"
 
@@ -19,7 +21,7 @@ func usageUserPathSubtreePattern(userPath string) string {
 	if userPath == "/" {
 		return "/%"
 	}
-	return escapeLikeWildcards(userPath) + "/%"
+	return sqlutil.EscapeLikeWildcards(userPath) + "/%"
 }
 
 func usageUserPathSubtreeRegex(userPath string) string {

--- a/internal/validation/error.go
+++ b/internal/validation/error.go
@@ -1,0 +1,37 @@
+// Package validation provides the shared validation error type used by
+// admin-managed resources (aliases, auth keys, guardrails, workflows,
+// model selectors and overrides).
+package validation
+
+import "errors"
+
+// Error indicates invalid user-supplied input or invalid resource state.
+type Error struct {
+	Message string
+	Err     error
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Message
+}
+
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// NewError creates a validation error.
+func NewError(message string, err error) error {
+	return &Error{Message: message, Err: err}
+}
+
+// IsError reports whether err is a validation error.
+func IsError(err error) bool {
+	_, ok := errors.AsType[*Error](err)
+	return ok
+}

--- a/internal/workflows/store.go
+++ b/internal/workflows/store.go
@@ -3,39 +3,23 @@ package workflows
 import (
 	"context"
 	"errors"
+
+	"gomodel/internal/validation"
 )
 
 // ErrNotFound indicates a requested workflow version was not found.
 var ErrNotFound = errors.New("workflow version not found")
 
 // ValidationError indicates invalid workflow input or state.
-type ValidationError struct {
-	Message string
-	Err     error
-}
-
-func (e *ValidationError) Error() string {
-	if e == nil {
-		return ""
-	}
-	return e.Message
-}
-
-func (e *ValidationError) Unwrap() error {
-	if e == nil {
-		return nil
-	}
-	return e.Err
-}
+type ValidationError = validation.Error
 
 func newValidationError(message string, err error) error {
-	return &ValidationError{Message: message, Err: err}
+	return validation.NewError(message, err)
 }
 
 // IsValidationError reports whether err is a validation error.
 func IsValidationError(err error) bool {
-	_, ok := errors.AsType[*ValidationError](err)
-	return ok
+	return validation.IsError(err)
 }
 
 // Store defines persistence operations for immutable workflow versions.


### PR DESCRIPTION
## Summary

Cleanup pass across the codebase: removes duplicated code and dead indirection in 14 focused commits, **−327 net lines** with no behavior changes. Full test suite (including `make test-race` and lint via pre-commit) passed on every commit.

### Cross-package deduplication
- `ValidationError` was defined identically in 5 packages (aliases, authkeys, guardrails, workflows, modelselectors) → single `internal/validation.Error` behind type aliases; every package's public API (`ValidationError`, `IsValidationError`) is unchanged
- New `internal/storage/sqlutil` package collects helpers that had drifted into copies: LIKE-wildcard escaping, WHERE-clause building, pagination clamping (parameterized — usage keeps 50/200, auditlog keeps 25/100), unix-timestamp/nullable-string column converters, and SQLite timestamp parsing

### App startup wiring (`internal/app/app.go`, −94 lines)
- `New()` repeated hand-maintained `errors.Join` close chains at 11 failure points, each re-listing every prior component — and the close order had already drifted between blocks. Replaced with a LIFO `closers` slice unwound by a single `fail()` helper, so shutdown order on startup failure has one source of truth
- The growing `firstSharedStorage(a, b, c, ...)` calls became a single running `sharedStorage` claimed after each component initializes

### Provider layer
- Passthrough semantic enrichers: four providers carried identical `Enrich()` mechanics → shared `providers.SemanticEnricher`; each provider now declares only its endpoint table
- `ListBatches` pagination query building deduplicated across 6 providers (`providers.PaginatedEndpoint`, cursor param name covers Anthropic's `before_id`)
- `core.EnsureModel` names the empty-model response fallback repeated at 12 sites; ollama's five unsupported-batch stubs share one error constructor

### Core / JSON / readers
- The 25-entry responses known-field list was inlined twice (drifting only by `stream`/`stream_options`) → defined once, with the full-request variant layered explicitly on top
- `core.IsJSONNull` replaces 12 copies of the trimmed-null check; `slices.Contains` replaces a hand-rolled search
- MongoDB usage reader: 41 replacements via `mongoCostSum` / `mongoCostPresenceCount` / `costPtr` helpers for the repeated cost-aggregation BSON and decode blocks
- `server/native_batch_support.go`: removed five pass-through wrappers around `gateway` functions (most were test-only); callers use `gateway` directly

## User-visible impact

None intended. Public APIs, error types, wire formats, and audit/usage semantics are unchanged. The only message-level change: a few startup *failure* error strings now use the uniform `failed to <step>: <err> (also: close error: <err>)` format.

## Notes for reviewers

- The `app.go` rewrite is the most behavior-sensitive commit (`73c1dc4`): cleanup-on-failure now always closes in exact reverse-init order, where the old hand-written chains had minor order inconsistencies between blocks (e.g. the response-cache failure path closed workflows before authKeys). Closing order among these independent stores is not semantically significant, which is why this is safe — but worth a look.
- Latest `main` (Go 1.26.4 bump, TTS audio-duration costing) is merged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated validation error handling across components.
  * Centralized SQL helpers for consistent query building, wildcard escaping, and timestamp handling.
  * Unified provider passthrough semantics and standardized pagination endpoint construction.
  * Standardized JSON-null handling and response model defaulting.

* **Bug Fixes**
  * More reliable startup/shutdown error handling and resource cleanup.
  * Safer, consistent filtering and pagination behavior in logs/usage queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->