### PR TITLE
fix(anthropic): map claude-fable-5 reasoning to adaptive thinking

### DIFF
--- a/docs/providers/anthropic.mdx
+++ b/docs/providers/anthropic.mdx
@@ -33,20 +33,24 @@ providers:
 
 ## Reasoning effort mapping
 
-GoModel accepts OpenAI-shaped `"reasoning": {"effort": "..."}` and translates it
-to Claude's native controls. The five accepted levels are `low`, `medium`,
-`high`, `xhigh`, and `max`; any other value is downgraded to `low` and logged.
-The translation depends on whether the model supports **adaptive thinking**.
+GoModel accepts the OpenAI-shaped `"reasoning": {"effort": "..."}` object as
+well as the Chat Completions string form `"reasoning_effort": "..."` (the
+object wins when both are present) and translates them to Claude's native
+controls. The five accepted levels are `low`, `medium`, `high`, `xhigh`, and
+`max`; any other value is downgraded to `low` and logged. The translation
+depends on whether the model supports **adaptive thinking**.
 
 | Model generation | Thinking config | Effort destination |
 | ---------------- | --------------- | ------------------ |
-| Adaptive — `claude-opus-4-8`, `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6` (and dated snapshots of each) | `thinking: {type: "adaptive"}` | `output_config.effort` (passed through) |
+| Adaptive — `claude-fable-5`, `claude-opus-4-8`, `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6` (and dated snapshots of each) | `thinking: {type: "adaptive"}` | `output_config.effort` (passed through) |
 | Legacy (everything else, e.g. `claude-opus-4-5`, `claude-3-5-sonnet`) | `thinking: {type: "enabled", budget_tokens: N}` | mapped to a token budget |
 
 <Note>
-  Adaptive routing is an explicit allowlist, not a version comparison. New model
-  IDs are treated as legacy until added to the list, so they keep working
-  (via `budget_tokens`) rather than silently sending an unsupported config.
+  Adaptive routing is an explicit allowlist, not a version comparison. New
+  model IDs are treated as legacy until added to the list. For pre-4.7 models
+  the legacy fallback keeps working via `budget_tokens`; models from Opus 4.7
+  onward reject `budget_tokens` outright, so a new adaptive-only model ID
+  fails with an upstream 400 until it is added to the allowlist.
 </Note>
 
 For legacy models the effort string maps to a thinking budget; `max_tokens` is
@@ -71,11 +75,12 @@ so on legacy models they are capped at the `high` budget rather than inflating
 </Note>
 
 <Note>
-  Effort levels are model-gated upstream: `xhigh` is only available on Opus 4.8
-  and Opus 4.7, and `max` on Opus 4.8/4.7/4.6 and Sonnet 4.6. GoModel forwards
-  the level you send; Anthropic rejects it with a 400 if the target model does
-  not support it. Manual `budget_tokens` thinking is rejected on Opus 4.7/4.8,
-  which is why GoModel uses adaptive thinking for those models.
+  Effort levels are model-gated upstream: `xhigh` is only available on Fable 5
+  and Opus 4.8/4.7, and `max` on Fable 5, Opus 4.8/4.7/4.6, and Sonnet 4.6.
+  GoModel forwards the level you send; Anthropic rejects it with a 400 if the
+  target model does not support it. Manual `budget_tokens` thinking is rejected
+  on Fable 5 and Opus 4.7/4.8, which is why GoModel uses adaptive thinking for
+  those models.
 </Note>
 
 When extended thinking is engaged, Anthropic requires `temperature = 1`. GoModel

--- a/docs/providers/anthropic.mdx
+++ b/docs/providers/anthropic.mdx
@@ -34,10 +34,12 @@ providers:
 ## Reasoning effort mapping
 
 GoModel accepts the OpenAI-shaped `"reasoning": {"effort": "..."}` object as
-well as the Chat Completions string form `"reasoning_effort": "..."` (the
-object wins when both are present) and translates them to Claude's native
-controls. The five accepted levels are `low`, `medium`, `high`, `xhigh`, and
-`max`; any other value is downgraded to `low` and logged. The translation
+well as the Chat Completions string form `"reasoning_effort": "..."` (a
+non-empty `reasoning.effort` wins when both are present; an empty object falls
+back to the string form) and translates them to Claude's native controls. The
+five accepted levels are `low`, `medium`, `high`, `xhigh`, and `max`; values
+are matched case-insensitively and any other value is downgraded to `low` and
+logged. The translation
 depends on whether the model supports **adaptive thinking**.
 
 | Model generation | Thinking config | Effort destination |

--- a/internal/providers/anthropic/anthropic.go
+++ b/internal/providers/anthropic/anthropic.go
@@ -189,6 +189,7 @@ func (p *Provider) Passthrough(ctx context.Context, req *core.PassthroughRequest
 }
 
 var adaptiveThinkingPrefixes = []string{
+	"claude-fable-5",
 	"claude-opus-4-8",
 	"claude-opus-4-7",
 	"claude-opus-4-6",

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -1477,6 +1477,42 @@ func TestConvertToAnthropicRequest_TypedTopPWinsOverExtraFields(t *testing.T) {
 	}
 }
 
+func TestConvertToAnthropicRequest_ReasoningEffortFromExtraFields(t *testing.T) {
+	result, err := convertToAnthropicRequest(&core.ChatRequest{
+		Model:    "claude-fable-5",
+		Messages: []core.Message{{Role: "user", Content: "hi"}},
+		ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+			"reasoning_effort": json.RawMessage(`"high"`),
+		}),
+	})
+	if err != nil {
+		t.Fatalf("convertToAnthropicRequest() error = %v", err)
+	}
+	if result.Thinking == nil || result.Thinking.Type != "adaptive" {
+		t.Fatalf("Thinking = %#v, want adaptive", result.Thinking)
+	}
+	if result.OutputConfig == nil || result.OutputConfig.Effort != "high" {
+		t.Fatalf("OutputConfig = %#v, want effort high", result.OutputConfig)
+	}
+}
+
+func TestConvertToAnthropicRequest_ReasoningObjectWinsOverReasoningEffort(t *testing.T) {
+	result, err := convertToAnthropicRequest(&core.ChatRequest{
+		Model:     "claude-fable-5",
+		Messages:  []core.Message{{Role: "user", Content: "hi"}},
+		Reasoning: &core.Reasoning{Effort: "low"},
+		ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+			"reasoning_effort": json.RawMessage(`"max"`),
+		}),
+	})
+	if err != nil {
+		t.Fatalf("convertToAnthropicRequest() error = %v", err)
+	}
+	if result.OutputConfig == nil || result.OutputConfig.Effort != "low" {
+		t.Fatalf("OutputConfig = %#v, want object-form effort low", result.OutputConfig)
+	}
+}
+
 func TestConvertToAnthropicRequest_InvalidToolArguments(t *testing.T) {
 	_, err := convertToAnthropicRequest(&core.ChatRequest{
 		Model: "claude-sonnet-4-5-20250929",
@@ -3793,6 +3829,16 @@ func TestConvertToAnthropicRequest_ReasoningEffort(t *testing.T) {
 			expectNilTemp:     true,
 		},
 		{
+			name:              "fable 5 - adaptive thinking with high effort",
+			model:             "claude-fable-5",
+			reasoning:         &core.Reasoning{Effort: "high"},
+			maxTokens:         new(4096),
+			expectedThinkType: "adaptive",
+			expectedEffort:    "high",
+			expectedMaxTokens: 4096,
+			expectNilTemp:     true,
+		},
+		{
 			name:              "opus 4.8 - adaptive thinking with xhigh effort",
 			model:             "claude-opus-4-8",
 			reasoning:         &core.Reasoning{Effort: "xhigh"},
@@ -4012,6 +4058,16 @@ func TestConvertResponsesRequestToAnthropic_ReasoningEffort(t *testing.T) {
 			expectNilTemp:     true,
 		},
 		{
+			name:              "fable 5 - adaptive thinking with high effort",
+			model:             "claude-fable-5",
+			reasoning:         &core.Reasoning{Effort: "high"},
+			maxOutputTokens:   new(4096),
+			expectedThinkType: "adaptive",
+			expectedEffort:    "high",
+			expectedMaxTokens: 4096,
+			expectNilTemp:     true,
+		},
+		{
 			name:              "opus 4.8 - adaptive thinking with xhigh effort",
 			model:             "claude-opus-4-8",
 			reasoning:         &core.Reasoning{Effort: "xhigh"},
@@ -4126,6 +4182,8 @@ func TestIsAdaptiveThinkingModel(t *testing.T) {
 		model    string
 		expected bool
 	}{
+		{"claude-fable-5", true},
+		{"claude-fable-5-20260601", true},
 		{"claude-opus-4-8", true},
 		{"claude-opus-4-8-20260301", true},
 		{"claude-opus-4-7", true},

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -1513,6 +1513,68 @@ func TestConvertToAnthropicRequest_ReasoningObjectWinsOverReasoningEffort(t *tes
 	}
 }
 
+func TestConvertToAnthropicRequest_EmptyReasoningObjectFallsBackToReasoningEffort(t *testing.T) {
+	result, err := convertToAnthropicRequest(&core.ChatRequest{
+		Model:     "claude-fable-5",
+		Messages:  []core.Message{{Role: "user", Content: "hi"}},
+		Reasoning: &core.Reasoning{},
+		ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+			"reasoning_effort": json.RawMessage(`"high"`),
+		}),
+	})
+	if err != nil {
+		t.Fatalf("convertToAnthropicRequest() error = %v", err)
+	}
+	if result.OutputConfig == nil || result.OutputConfig.Effort != "high" {
+		t.Fatalf("OutputConfig = %#v, want string-form effort high", result.OutputConfig)
+	}
+}
+
+func TestResolveAnthropicReasoningEffort_NormalizesSpelling(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *core.ChatRequest
+		want string
+	}{
+		{
+			name: "object form uppercase with whitespace",
+			req:  &core.ChatRequest{Reasoning: &core.Reasoning{Effort: " HIGH "}},
+			want: "high",
+		},
+		{
+			name: "string form mixed case",
+			req: &core.ChatRequest{ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+				"reasoning_effort": json.RawMessage(`" Max "`),
+			})},
+			want: "max",
+		},
+		{
+			name: "whitespace-only object effort falls back to string form",
+			req: &core.ChatRequest{
+				Reasoning: &core.Reasoning{Effort: "  "},
+				ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+					"reasoning_effort": json.RawMessage(`"medium"`),
+				}),
+			},
+			want: "medium",
+		},
+		{
+			name: "whitespace-only string form resolves to empty",
+			req: &core.ChatRequest{ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+				"reasoning_effort": json.RawMessage(`"  "`),
+			})},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveAnthropicReasoningEffort(tt.req); got != tt.want {
+				t.Fatalf("resolveAnthropicReasoningEffort() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestConvertToAnthropicRequest_InvalidToolArguments(t *testing.T) {
 	_, err := convertToAnthropicRequest(&core.ChatRequest{
 		Model: "claude-sonnet-4-5-20250929",

--- a/internal/providers/anthropic/request_translation.go
+++ b/internal/providers/anthropic/request_translation.go
@@ -565,11 +565,15 @@ func anthropicCacheControlFromExtra(extraFields core.UnknownJSONFields) (json.Ra
 
 // resolveAnthropicReasoningEffort returns the requested reasoning effort,
 // accepting both the OpenAI Responses-style reasoning object and the Chat
-// Completions reasoning_effort string carried in extra fields. The object
-// form wins when both are present.
+// Completions reasoning_effort string carried in extra fields. A non-empty
+// object effort wins when both are present; an empty object expresses no
+// effort intent, so the string form still applies. Values are trimmed and
+// lowercased so spellings like "High" map to the intended level.
 func resolveAnthropicReasoningEffort(req *core.ChatRequest) string {
-	if req.Reasoning != nil && req.Reasoning.Effort != "" {
-		return req.Reasoning.Effort
+	if req.Reasoning != nil {
+		if effort := normalizeEffortInput(req.Reasoning.Effort); effort != "" {
+			return effort
+		}
 	}
 
 	raw := bytes.TrimSpace(req.ExtraFields.Lookup("reasoning_effort"))
@@ -580,7 +584,13 @@ func resolveAnthropicReasoningEffort(req *core.ChatRequest) string {
 	if err := json.Unmarshal(raw, &effort); err != nil {
 		return ""
 	}
-	return effort
+	return normalizeEffortInput(effort)
+}
+
+// normalizeEffortInput canonicalizes a user-supplied effort spelling so the
+// exact-match effort mapping does not downgrade values like " HIGH " to "low".
+func normalizeEffortInput(effort string) string {
+	return strings.ToLower(strings.TrimSpace(effort))
 }
 
 func resolveAnthropicTopP(req *core.ChatRequest) *float64 {

--- a/internal/providers/anthropic/request_translation.go
+++ b/internal/providers/anthropic/request_translation.go
@@ -307,8 +307,8 @@ func convertToAnthropicRequest(req *core.ChatRequest) (*anthropicRequest, error)
 		anthropicReq.MaxTokens = resolveDefaultMaxTokens()
 	}
 
-	if req.Reasoning != nil && req.Reasoning.Effort != "" {
-		applyReasoning(anthropicReq, req.Model, req.Reasoning.Effort)
+	if effort := resolveAnthropicReasoningEffort(req); effort != "" {
+		applyReasoning(anthropicReq, req.Model, effort)
 	}
 
 	tools, err := convertOpenAIToolsToAnthropic(req.Tools)
@@ -561,6 +561,26 @@ func anthropicCacheControlFromExtra(extraFields core.UnknownJSONFields) (json.Ra
 		return nil, core.NewInvalidRequestError("anthropic cache_control must be an object", nil)
 	}
 	return core.CloneRawJSON(trimmed), nil
+}
+
+// resolveAnthropicReasoningEffort returns the requested reasoning effort,
+// accepting both the OpenAI Responses-style reasoning object and the Chat
+// Completions reasoning_effort string carried in extra fields. The object
+// form wins when both are present.
+func resolveAnthropicReasoningEffort(req *core.ChatRequest) string {
+	if req.Reasoning != nil && req.Reasoning.Effort != "" {
+		return req.Reasoning.Effort
+	}
+
+	raw := bytes.TrimSpace(req.ExtraFields.Lookup("reasoning_effort"))
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return ""
+	}
+	var effort string
+	if err := json.Unmarshal(raw, &effort); err != nil {
+		return ""
+	}
+	return effort
 }
 
 func resolveAnthropicTopP(req *core.ChatRequest) *float64 {


### PR DESCRIPTION
## Problem

`claude-fable-5` was missing from the Anthropic provider's adaptive-thinking allowlist, so any request with `reasoning: {effort: ...}` was translated to the legacy `thinking: {type: "enabled", budget_tokens: N}` config — which Fable 5 (like Opus 4.7/4.8) rejects:

> `"thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.`

Separately, the standard OpenAI Chat Completions param `reasoning_effort` (string form) was silently dropped for Anthropic targets: only the object form `reasoning: {effort}` was read, so OpenAI SDK users got no thinking and no warning.

## Changes

- Add `claude-fable-5` to `adaptiveThinkingPrefixes` — reasoning now maps to `thinking: {type: "adaptive"}` + `output_config.effort`.
- New `resolveAnthropicReasoningEffort()` accepts `reasoning_effort` from extra fields as a fallback (object form wins when both are present), mirroring the existing `top_p`-from-extras pattern. Deliberately scoped to the Anthropic translation: OpenAI-compatible upstreams already receive `reasoning_effort` verbatim via extra-field passthrough, so a global ingress rewrite would have regressed that.
- Docs (`docs/providers/anthropic.mdx`): Fable 5 added to the adaptive table, both reasoning spellings documented, and the allowlist note corrected — models from Opus 4.7 onward reject `budget_tokens`, so new adaptive-only model IDs fail with an upstream 400 until allowlisted (the old text claimed the legacy fallback "keeps working").

## User-visible impact

- `claude-fable-5` + `reasoning.effort` requests succeed instead of returning a 400.
- `reasoning_effort` (OpenAI standard spelling) now engages thinking on all Anthropic models instead of being ignored.

## Testing

- New table cases for `claude-fable-5` in `TestIsAdaptiveThinkingModel` and both reasoning-translation tables (chat + responses).
- New tests: `reasoning_effort` from extra fields, and object-form precedence over the string form.
- Verified live against a running instance with Anthropic upstream: previously-400 request now succeeds; differential test (`temperature: 0.7` + `reasoning_effort`) confirms the thinking path engages (temperature stripped with warning instead of an upstream 400).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Claude Fable 5 to the list of models supported by adaptive thinking.

* **Documentation**
  * Clarified reasoning effort precedence: a non-empty structured reasoning setting takes priority, empty structures fall back to the string form; values are case-insensitive and invalid levels are downgraded to low (and logged).
  * Explained adaptive vs legacy behavior, model allowlist rules, legacy budget_tokens fallback limits, and updated availability statements for xhigh/max.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->