### PR TITLE
fix: resolve gateway issues found by end-to-end testing

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -192,6 +192,7 @@
 
 # MongoDB Configuration (recommended for high-volume logging)
 # MONGODB_URL=mongodb://localhost:27017/gomodel
+# MONGODB_DATABASE overrides the database named in MONGODB_URL (default: gomodel)
 # MONGODB_DATABASE=gomodel
 
 # =============================================================================

--- a/config/config.go
+++ b/config/config.go
@@ -82,9 +82,6 @@ func buildDefaultConfig() *Config {
 			PostgreSQL: PostgreSQLStorageConfig{
 				MaxConns: 10,
 			},
-			MongoDB: MongoDBStorageConfig{
-				Database: "gomodel",
-			},
 		},
 		Logging: LogConfig{
 			LogBodies:             true,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -139,8 +139,8 @@ func TestBuildDefaultConfig(t *testing.T) {
 	if cfg.Storage.PostgreSQL.MaxConns != 10 {
 		t.Errorf("expected Storage.PostgreSQL.MaxConns=10, got %d", cfg.Storage.PostgreSQL.MaxConns)
 	}
-	if cfg.Storage.MongoDB.Database != "gomodel" {
-		t.Errorf("expected Storage.MongoDB.Database=gomodel, got %s", cfg.Storage.MongoDB.Database)
+	if cfg.Storage.MongoDB.Database != "" {
+		t.Errorf("expected Storage.MongoDB.Database to default empty (resolved by storage layer), got %s", cfg.Storage.MongoDB.Database)
 	}
 	if !cfg.Logging.LogBodies {
 		t.Error("expected Logging.LogBodies=true")

--- a/config/storage.go
+++ b/config/storage.go
@@ -33,9 +33,10 @@ type PostgreSQLStorageConfig struct {
 
 // MongoDBStorageConfig holds MongoDB-specific storage configuration
 type MongoDBStorageConfig struct {
-	// URL is the connection string (e.g., mongodb://localhost:27017)
+	// URL is the connection string; a database named in its path is honored
+	// (e.g., mongodb://localhost:27017/gomodel)
 	URL string `yaml:"url" env:"MONGODB_URL"`
-	// Database is the database name (default: gomodel)
+	// Database overrides the database named in the URL (default: gomodel)
 	Database string `yaml:"database" env:"MONGODB_DATABASE"`
 }
 
@@ -60,9 +61,6 @@ func (c StorageConfig) BackendConfig() storage.Config {
 	}
 	if cfg.SQLite.Path == "" {
 		cfg.SQLite.Path = storage.DefaultSQLitePath
-	}
-	if cfg.MongoDB.Database == "" {
-		cfg.MongoDB.Database = "gomodel"
 	}
 	return cfg
 }

--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -83,8 +83,8 @@ Storage is shared by audit logging, usage tracking, and future features like IAM
 | `SQLITE_PATH`        | SQLite database file path                     | `data/gomodel.db` |
 | `POSTGRES_URL`       | PostgreSQL connection string                  | _(empty)_         |
 | `POSTGRES_MAX_CONNS` | PostgreSQL connection pool size               | `10`              |
-| `MONGODB_URL`        | MongoDB connection string                     | _(empty)_         |
-| `MONGODB_DATABASE`   | MongoDB database name                         | `gomodel`         |
+| `MONGODB_URL`        | MongoDB connection string; a database named in its path is used | _(empty)_ |
+| `MONGODB_DATABASE`   | MongoDB database name; overrides the URL path | `gomodel`         |
 
 #### Audit Logging
 

--- a/internal/aliases/batch_preparer.go
+++ b/internal/aliases/batch_preparer.go
@@ -80,7 +80,7 @@ func resolveAliasRoutableSelector(service *Service, checker aliasModelSupportChe
 		return core.ModelSelector{}, core.NewInvalidRequestError("model is required", nil)
 	}
 	if checker == nil || !checker.Supports(resolvedModel) {
-		return core.ModelSelector{}, core.NewInvalidRequestError("unsupported model: "+resolvedModel, nil)
+		return core.ModelSelector{}, core.NewModelNotFoundError(resolvedModel)
 	}
 	if err := validateResolvedProviderType(checker, selector, expectedProviderType); err != nil {
 		return core.ModelSelector{}, err

--- a/internal/conversationstore/store.go
+++ b/internal/conversationstore/store.go
@@ -32,6 +32,10 @@ type Store interface {
 	Create(ctx context.Context, conversation *StoredConversation) error
 	Get(ctx context.Context, id string) (*StoredConversation, error)
 	Update(ctx context.Context, conversation *StoredConversation) error
+	// AppendItems atomically appends items to an existing conversation, so two
+	// concurrently completing turns cannot overwrite each other's exchange the
+	// way a Get-then-Update would.
+	AppendItems(ctx context.Context, id string, items []json.RawMessage) error
 	Delete(ctx context.Context, id string) error
 	Close() error
 }

--- a/internal/conversationstore/store_memory.go
+++ b/internal/conversationstore/store_memory.go
@@ -2,10 +2,13 @@ package conversationstore
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"sync"
 	"time"
+
+	"gomodel/internal/core"
 )
 
 const (
@@ -156,6 +159,29 @@ func (s *MemoryStore) Update(_ context.Context, conversation *StoredConversation
 	}
 	s.items[c.Conversation.ID] = c
 	s.enforceMaxEntriesLocked()
+	return nil
+}
+
+// AppendItems atomically appends items to an existing conversation snapshot.
+func (s *MemoryStore) AppendItems(_ context.Context, id string, items []json.RawMessage) error {
+	if len(items) == 0 {
+		return nil
+	}
+	now := time.Now().UTC()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cleanupExpiredLocked(now)
+	conversation, exists := s.items[id]
+	if !exists {
+		return ErrNotFound
+	}
+	if conversationExpired(conversation, now) {
+		delete(s.items, id)
+		return ErrNotFound
+	}
+	for _, item := range items {
+		conversation.Items = append(conversation.Items, core.CloneRawJSON(item))
+	}
 	return nil
 }
 

--- a/internal/conversationstore/store_memory_test.go
+++ b/internal/conversationstore/store_memory_test.go
@@ -225,4 +225,19 @@ func TestMemoryStoreAppendItems_ConcurrentAppendsAllSurvive(t *testing.T) {
 	if len(got.Items) != writers {
 		t.Fatalf("Items = %d, want %d (no lost appends)", len(got.Items), writers)
 	}
+	seen := make(map[int]int, writers)
+	for _, raw := range got.Items {
+		var item struct {
+			Writer int `json:"writer"`
+		}
+		if err := json.Unmarshal(raw, &item); err != nil {
+			t.Fatalf("unmarshal appended item: %v", err)
+		}
+		seen[item.Writer]++
+	}
+	for i := range writers {
+		if seen[i] != 1 {
+			t.Fatalf("writer %d count = %d, want exactly once (no lost or duplicated appends)", i, seen[i])
+		}
+	}
 }

--- a/internal/conversationstore/store_memory_test.go
+++ b/internal/conversationstore/store_memory_test.go
@@ -2,7 +2,10 @@ package conversationstore
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -162,5 +165,64 @@ func TestMemoryStoreGetReturnsIsolatedCopy(t *testing.T) {
 	}
 	if _, mutated := second.Conversation.Metadata["mutated"]; mutated {
 		t.Fatal("stored conversation mutated through returned copy")
+	}
+}
+
+func TestMemoryStoreAppendItems(t *testing.T) {
+	store := NewMemoryStore()
+	conv := &StoredConversation{
+		Conversation: &core.Conversation{ID: "conv_append", Object: "conversation"},
+		Items:        []json.RawMessage{json.RawMessage(`{"n":0}`)},
+	}
+	if err := store.Create(context.Background(), conv); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	if err := store.AppendItems(context.Background(), "conv_append", []json.RawMessage{json.RawMessage(`{"n":1}`)}); err != nil {
+		t.Fatalf("AppendItems() error = %v", err)
+	}
+	if err := store.AppendItems(context.Background(), "conv_append", nil); err != nil {
+		t.Fatalf("AppendItems(empty) error = %v", err)
+	}
+	if err := store.AppendItems(context.Background(), "missing", []json.RawMessage{json.RawMessage(`{}`)}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("AppendItems(missing) error = %v, want ErrNotFound", err)
+	}
+
+	got, err := store.Get(context.Background(), "conv_append")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if len(got.Items) != 2 || string(got.Items[1]) != `{"n":1}` {
+		t.Fatalf("Items = %v, want initial item plus appended item", got.Items)
+	}
+}
+
+func TestMemoryStoreAppendItems_ConcurrentAppendsAllSurvive(t *testing.T) {
+	store := NewMemoryStore()
+	conv := &StoredConversation{Conversation: &core.Conversation{ID: "conv_race", Object: "conversation"}}
+	if err := store.Create(context.Background(), conv); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	const writers = 20
+	var wg sync.WaitGroup
+	for i := range writers {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			item := json.RawMessage(fmt.Sprintf(`{"writer":%d}`, n))
+			if err := store.AppendItems(context.Background(), "conv_race", []json.RawMessage{item}); err != nil {
+				t.Errorf("AppendItems() error = %v", err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	got, err := store.Get(context.Background(), "conv_race")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if len(got.Items) != writers {
+		t.Fatalf("Items = %d, want %d (no lost appends)", len(got.Items), writers)
 	}
 }

--- a/internal/core/errors.go
+++ b/internal/core/errors.go
@@ -174,6 +174,13 @@ func NewNotFoundError(message string) *GatewayError {
 	}
 }
 
+// NewModelNotFoundError reports a model the gateway cannot route. It mirrors
+// OpenAI's contract for unknown models — HTTP 404 with code "model_not_found" —
+// so clients that key on the status or code behave the same as against OpenAI.
+func NewModelNotFoundError(model string) *GatewayError {
+	return NewNotFoundError("unsupported model: " + model).WithCode("model_not_found")
+}
+
 // ParseProviderError parses an error response from a provider and returns an appropriate GatewayError
 func ParseProviderError(provider string, statusCode int, body []byte, originalErr error) *GatewayError {
 	message := string(body)

--- a/internal/gateway/batch_selection.go
+++ b/internal/gateway/batch_selection.go
@@ -105,7 +105,7 @@ func DetermineBatchExecutionSelectionWithAuthorizerAndInputFileResolver(
 			return BatchExecutionSelection{}, core.NewInvalidRequestError(fmt.Sprintf("batch item %d: model is required", i), nil)
 		}
 		if !provider.Supports(model) {
-			return BatchExecutionSelection{}, core.NewInvalidRequestError("unsupported model: "+model, nil)
+			return BatchExecutionSelection{}, core.NewModelNotFoundError(model)
 		}
 		if authorizer != nil {
 			if err := authorizer.ValidateModelAccess(ctx, resolvedSelector); err != nil {

--- a/internal/gateway/request_model_resolution.go
+++ b/internal/gateway/request_model_resolution.go
@@ -131,7 +131,7 @@ func ResolveRequestModelWithAuthorizer(
 		}
 	}
 	if !provider.Supports(resolvedModel) {
-		return nil, core.NewInvalidRequestError("unsupported model: "+resolvedModel, nil)
+		return nil, core.NewModelNotFoundError(resolvedModel)
 	}
 	if authorizer != nil {
 		if err := authorizer.ValidateModelAccess(ctx, resolvedSelector); err != nil {

--- a/internal/modeloverrides/batch_preparer.go
+++ b/internal/modeloverrides/batch_preparer.go
@@ -45,7 +45,7 @@ func (p *BatchPreparer) PrepareBatchRequest(ctx context.Context, providerType st
 				return nil, err
 			}
 			if p.provider != nil && !p.provider.Supports(resolved.QualifiedModel()) {
-				return nil, core.NewInvalidRequestError("unsupported model: "+resolved.QualifiedModel(), nil)
+				return nil, core.NewModelNotFoundError(resolved.QualifiedModel())
 			}
 			if providerType != "" && p.provider != nil {
 				actualProviderType := strings.TrimSpace(p.provider.GetProviderType(resolved.QualifiedModel()))

--- a/internal/providers/groq/groq.go
+++ b/internal/providers/groq/groq.go
@@ -5,11 +5,11 @@ import (
 	"context"
 	"io"
 	"net/http"
-	"net/url"
 
 	"gomodel/internal/core"
 	"gomodel/internal/llmclient"
 	"gomodel/internal/providers"
+	"gomodel/internal/providers/openai"
 )
 
 // Registration provides factory registration for the Groq provider.
@@ -25,87 +25,63 @@ const (
 	defaultBaseURL = "https://api.groq.com/openai/v1"
 )
 
-// Provider implements the core.Provider interface for Groq
+// Provider implements the core.Provider interface for Groq. Groq's API is
+// OpenAI-compatible, so all transport goes through the shared compatible
+// provider; only the Responses API differs (translated via chat) because the
+// gateway does not use Groq's native /responses endpoints.
 type Provider struct {
-	client *llmclient.Client
-	apiKey string
+	compat *openai.CompatibleProvider
 }
 
 // New creates a new Groq provider.
 func New(providerCfg providers.ProviderConfig, opts providers.ProviderOptions) core.Provider {
-	p := &Provider{apiKey: providerCfg.APIKey}
-	clientCfg := llmclient.Config{
-		ProviderName:   "groq",
-		BaseURL:        providers.ResolveBaseURL(providerCfg.BaseURL, defaultBaseURL),
-		Retry:          opts.Resilience.Retry,
-		Hooks:          opts.Hooks,
-		CircuitBreaker: opts.Resilience.CircuitBreaker,
+	return &Provider{
+		compat: openai.NewCompatibleProvider(providerCfg.APIKey, opts, openai.CompatibleProviderConfig{
+			ProviderName: "groq",
+			BaseURL:      providers.ResolveBaseURL(providerCfg.BaseURL, defaultBaseURL),
+			SetHeaders:   setHeaders,
+		}),
 	}
-	p.client = llmclient.New(clientCfg, p.setHeaders)
-	return p
 }
 
 // NewWithHTTPClient creates a new Groq provider with a custom HTTP client.
 // If httpClient is nil, http.DefaultClient is used.
 func NewWithHTTPClient(apiKey string, httpClient *http.Client, hooks llmclient.Hooks) *Provider {
-	if httpClient == nil {
-		httpClient = http.DefaultClient
+	return &Provider{
+		compat: openai.NewCompatibleProviderWithHTTPClient(apiKey, httpClient, hooks, openai.CompatibleProviderConfig{
+			ProviderName: "groq",
+			BaseURL:      defaultBaseURL,
+			SetHeaders:   setHeaders,
+		}),
 	}
-	p := &Provider{apiKey: apiKey}
-	cfg := llmclient.DefaultConfig("groq", defaultBaseURL)
-	cfg.Hooks = hooks
-	p.client = llmclient.NewWithHTTPClient(httpClient, cfg, p.setHeaders)
-	return p
-}
-
-// SetBaseURL allows configuring a custom base URL for the provider
-func (p *Provider) SetBaseURL(url string) {
-	p.client.SetBaseURL(url)
 }
 
 // setHeaders sets the required headers for Groq API requests
-func (p *Provider) setHeaders(req *http.Request) {
-	providers.SetAuthHeaders(req, p.apiKey, providers.AuthHeaderConfig{
+func setHeaders(req *http.Request, apiKey string) {
+	providers.SetAuthHeaders(req, apiKey, providers.AuthHeaderConfig{
 		AuthScheme:      "Bearer ",
 		RequestIDHeader: "X-Request-ID",
 	})
 }
 
+// SetBaseURL allows configuring a custom base URL for the provider
+func (p *Provider) SetBaseURL(url string) {
+	p.compat.SetBaseURL(url)
+}
+
 // ChatCompletion sends a chat completion request to Groq
 func (p *Provider) ChatCompletion(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
-	var resp core.ChatResponse
-	err := p.client.Do(ctx, llmclient.Request{
-		Method:   http.MethodPost,
-		Endpoint: "/chat/completions",
-		Body:     req,
-	}, &resp)
-	if err != nil {
-		return nil, err
-	}
-	core.EnsureModel(&resp.Model, req.Model)
-	return &resp, nil
+	return p.compat.ChatCompletion(ctx, req)
 }
 
 // StreamChatCompletion returns a raw response body for streaming (caller must close)
 func (p *Provider) StreamChatCompletion(ctx context.Context, req *core.ChatRequest) (io.ReadCloser, error) {
-	return p.client.DoStream(ctx, llmclient.Request{
-		Method:   http.MethodPost,
-		Endpoint: "/chat/completions",
-		Body:     req.WithStreaming(),
-	})
+	return p.compat.StreamChatCompletion(ctx, req)
 }
 
 // ListModels retrieves the list of available models from Groq
 func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error) {
-	var resp core.ModelsResponse
-	err := p.client.Do(ctx, llmclient.Request{
-		Method:   http.MethodGet,
-		Endpoint: "/models",
-	}, &resp)
-	if err != nil {
-		return nil, err
-	}
-	return &resp, nil
+	return p.compat.ListModels(ctx)
 }
 
 // Responses sends a Responses API request to Groq (converted to chat format)
@@ -120,121 +96,66 @@ func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesReque
 
 // Embeddings sends an embeddings request to Groq
 func (p *Provider) Embeddings(ctx context.Context, req *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
-	var resp core.EmbeddingResponse
-	err := p.client.Do(ctx, llmclient.Request{
-		Method:   http.MethodPost,
-		Endpoint: "/embeddings",
-		Body:     req,
-	}, &resp)
-	if err != nil {
-		return nil, err
-	}
-	core.EnsureModel(&resp.Model, req.Model)
-	return &resp, nil
+	return p.compat.Embeddings(ctx, req)
+}
+
+// CreateSpeech synthesizes speech through Groq's OpenAI-compatible /audio/speech API.
+func (p *Provider) CreateSpeech(ctx context.Context, req *core.AudioSpeechRequest) (*core.AudioResponse, error) {
+	return p.compat.CreateSpeech(ctx, req)
+}
+
+// CreateTranscription transcribes audio through Groq's OpenAI-compatible
+// /audio/transcriptions API (whisper models).
+func (p *Provider) CreateTranscription(ctx context.Context, req *core.AudioTranscriptionRequest) (*core.AudioResponse, error) {
+	return p.compat.CreateTranscription(ctx, req)
 }
 
 // CreateBatch creates a native Groq batch job.
 func (p *Provider) CreateBatch(ctx context.Context, req *core.BatchRequest) (*core.BatchResponse, error) {
-	var resp core.BatchResponse
-	err := p.client.Do(ctx, llmclient.Request{
-		Method:   http.MethodPost,
-		Endpoint: "/batches",
-		Body:     req,
-	}, &resp)
-	if err != nil {
-		return nil, err
-	}
-	providers.EnsureProviderBatchID(&resp)
-	return &resp, nil
+	return p.compat.CreateBatch(ctx, req)
 }
 
 // GetBatch retrieves a native Groq batch job.
 func (p *Provider) GetBatch(ctx context.Context, id string) (*core.BatchResponse, error) {
-	var resp core.BatchResponse
-	err := p.client.Do(ctx, llmclient.Request{
-		Method:   http.MethodGet,
-		Endpoint: "/batches/" + url.PathEscape(id),
-	}, &resp)
-	if err != nil {
-		return nil, err
-	}
-	providers.EnsureProviderBatchID(&resp)
-	return &resp, nil
+	return p.compat.GetBatch(ctx, id)
 }
 
 // ListBatches lists native Groq batch jobs.
 func (p *Provider) ListBatches(ctx context.Context, limit int, after string) (*core.BatchListResponse, error) {
-	endpoint := providers.PaginatedEndpoint("/batches", limit, "after", after)
-
-	var resp core.BatchListResponse
-	err := p.client.Do(ctx, llmclient.Request{
-		Method:   http.MethodGet,
-		Endpoint: endpoint,
-	}, &resp)
-	if err != nil {
-		return nil, err
-	}
-	providers.EnsureProviderBatchIDs(&resp)
-	return &resp, nil
+	return p.compat.ListBatches(ctx, limit, after)
 }
 
 // CancelBatch cancels a native Groq batch job.
 func (p *Provider) CancelBatch(ctx context.Context, id string) (*core.BatchResponse, error) {
-	var resp core.BatchResponse
-	err := p.client.Do(ctx, llmclient.Request{
-		Method:   http.MethodPost,
-		Endpoint: "/batches/" + url.PathEscape(id) + "/cancel",
-	}, &resp)
-	if err != nil {
-		return nil, err
-	}
-	providers.EnsureProviderBatchID(&resp)
-	return &resp, nil
+	return p.compat.CancelBatch(ctx, id)
 }
 
 // GetBatchResults fetches Groq batch results via the output file API.
 func (p *Provider) GetBatchResults(ctx context.Context, id string) (*core.BatchResultsResponse, error) {
-	return providers.FetchBatchResultsFromOutputFile(ctx, p.client, "groq", id)
+	return p.compat.GetBatchResults(ctx, id)
 }
 
 // CreateFile uploads a file through Groq's OpenAI-compatible /files API.
 func (p *Provider) CreateFile(ctx context.Context, req *core.FileCreateRequest) (*core.FileObject, error) {
-	resp, err := providers.CreateOpenAICompatibleFile(ctx, p.client, req)
-	if err != nil {
-		return nil, err
-	}
-	resp.Provider = "groq"
-	return resp, nil
+	return p.compat.CreateFile(ctx, req)
 }
 
 // ListFiles lists files through Groq's OpenAI-compatible /files API.
 func (p *Provider) ListFiles(ctx context.Context, purpose string, limit int, after string) (*core.FileListResponse, error) {
-	resp, err := providers.ListOpenAICompatibleFiles(ctx, p.client, purpose, limit, after)
-	if err != nil {
-		return nil, err
-	}
-	for i := range resp.Data {
-		resp.Data[i].Provider = "groq"
-	}
-	return resp, nil
+	return p.compat.ListFiles(ctx, purpose, limit, after)
 }
 
 // GetFile retrieves one file object through Groq's OpenAI-compatible /files API.
 func (p *Provider) GetFile(ctx context.Context, id string) (*core.FileObject, error) {
-	resp, err := providers.GetOpenAICompatibleFile(ctx, p.client, id)
-	if err != nil {
-		return nil, err
-	}
-	resp.Provider = "groq"
-	return resp, nil
+	return p.compat.GetFile(ctx, id)
 }
 
 // DeleteFile deletes a file object through Groq's OpenAI-compatible /files API.
 func (p *Provider) DeleteFile(ctx context.Context, id string) (*core.FileDeleteResponse, error) {
-	return providers.DeleteOpenAICompatibleFile(ctx, p.client, id)
+	return p.compat.DeleteFile(ctx, id)
 }
 
 // GetFileContent fetches raw file bytes through Groq's /files/{id}/content API.
 func (p *Provider) GetFileContent(ctx context.Context, id string) (*core.FileContentResponse, error) {
-	return providers.GetOpenAICompatibleFileContent(ctx, p.client, id)
+	return p.compat.GetFileContent(ctx, id)
 }

--- a/internal/providers/groq/groq_test.go
+++ b/internal/providers/groq/groq_test.go
@@ -15,15 +15,11 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	apiKey := "test-api-key"
 	// Use NewWithHTTPClient to get concrete type for internal testing
-	provider := NewWithHTTPClient(apiKey, nil, llmclient.Hooks{})
+	provider := NewWithHTTPClient("test-api-key", nil, llmclient.Hooks{})
 
-	if provider.apiKey != apiKey {
-		t.Errorf("apiKey = %q, want %q", provider.apiKey, apiKey)
-	}
-	if provider.client == nil {
-		t.Error("client should not be nil")
+	if provider.compat == nil {
+		t.Error("compat provider should not be nil")
 	}
 }
 
@@ -794,16 +790,10 @@ data: [DONE]
 }
 
 func TestNewWithHTTPClient(t *testing.T) {
-	customClient := &http.Client{}
-	apiKey := "test-api-key"
+	provider := NewWithHTTPClient("test-api-key", &http.Client{}, llmclient.Hooks{})
 
-	provider := NewWithHTTPClient(apiKey, customClient, llmclient.Hooks{})
-
-	if provider.apiKey != apiKey {
-		t.Errorf("apiKey = %q, want %q", provider.apiKey, apiKey)
-	}
-	if provider.client == nil {
-		t.Error("client should not be nil")
+	if provider.compat == nil {
+		t.Error("compat provider should not be nil")
 	}
 }
 

--- a/internal/providers/groq/groq_test.go
+++ b/internal/providers/groq/groq_test.go
@@ -817,3 +817,107 @@ func TestSetBaseURL(t *testing.T) {
 		t.Errorf("SetBaseURL should allow using custom URL: %v", err)
 	}
 }
+
+func TestCreateSpeech(t *testing.T) {
+	audio := []byte("fake-mp3-bytes")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/audio/speech" {
+			t.Errorf("path = %q, want /audio/speech", r.URL.Path)
+		}
+		if auth := r.Header.Get("Authorization"); !strings.HasPrefix(auth, "Bearer ") {
+			t.Error("Authorization header should start with 'Bearer '")
+		}
+		var req core.AudioSpeechRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req.Model != "playai-tts" || req.Voice != "Fritz-PlayAI" {
+			t.Errorf("forwarded request = %+v, want model/voice preserved", req)
+		}
+		w.Header().Set("Content-Type", "audio/mpeg")
+		_, _ = w.Write(audio)
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("test-api-key", server.Client(), llmclient.Hooks{})
+	provider.SetBaseURL(server.URL)
+
+	resp, err := provider.CreateSpeech(context.Background(), &core.AudioSpeechRequest{
+		Model: "playai-tts",
+		Input: "Hello from Groq.",
+		Voice: "Fritz-PlayAI",
+	})
+	if err != nil {
+		t.Fatalf("CreateSpeech() error = %v", err)
+	}
+	if resp.ContentType != "audio/mpeg" {
+		t.Errorf("ContentType = %q, want audio/mpeg", resp.ContentType)
+	}
+	if string(resp.Data) != string(audio) {
+		t.Errorf("Data = %q, want %q", resp.Data, audio)
+	}
+}
+
+func TestCreateTranscription(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/audio/transcriptions" {
+			t.Errorf("path = %q, want /audio/transcriptions", r.URL.Path)
+		}
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Fatalf("parse multipart: %v", err)
+		}
+		if got := r.FormValue("model"); got != "whisper-large-v3" {
+			t.Errorf("model field = %q, want whisper-large-v3", got)
+		}
+		file, _, err := r.FormFile("file")
+		if err != nil {
+			t.Fatalf("file part: %v", err)
+		}
+		defer func() { _ = file.Close() }()
+		data, _ := io.ReadAll(file)
+		if string(data) != "fake-wav-bytes" {
+			t.Errorf("file content = %q, want fake-wav-bytes", data)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"text":"hello from groq"}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("test-api-key", server.Client(), llmclient.Hooks{})
+	provider.SetBaseURL(server.URL)
+
+	resp, err := provider.CreateTranscription(context.Background(), &core.AudioTranscriptionRequest{
+		Model:    "whisper-large-v3",
+		Filename: "speech.wav",
+		File:     []byte("fake-wav-bytes"),
+	})
+	if err != nil {
+		t.Fatalf("CreateTranscription() error = %v", err)
+	}
+	if !strings.Contains(string(resp.Data), "hello from groq") {
+		t.Errorf("Data = %s, want transcription text", resp.Data)
+	}
+}
+
+func TestCreateTranscription_UpstreamError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"invalid audio"}}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("test-api-key", server.Client(), llmclient.Hooks{})
+	provider.SetBaseURL(server.URL)
+
+	_, err := provider.CreateTranscription(context.Background(), &core.AudioTranscriptionRequest{
+		Model:    "whisper-large-v3",
+		Filename: "speech.wav",
+		File:     []byte("bad"),
+	})
+	if err == nil {
+		t.Fatal("CreateTranscription() error = nil, want upstream error")
+	}
+	if !strings.Contains(err.Error(), "invalid audio") {
+		t.Errorf("error = %v, want upstream message propagated", err)
+	}
+}

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -318,7 +318,9 @@ func (r *ModelRegistry) ListModels() []core.Model {
 }
 
 // ListPublicModels returns all provider-backed models as public selectors in
-// providerName/modelID form, sorted by public model ID.
+// providerName/modelID form, sorted by public model ID. Models the owning
+// provider cannot actually serve (audio-only models on providers without audio
+// support) are not advertised.
 func (r *ModelRegistry) ListPublicModels() []core.Model {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -331,6 +333,9 @@ func (r *ModelRegistry) ListPublicModels() []core.Model {
 	result := make([]core.Model, 0, total)
 	for providerName, models := range r.modelsByProvider {
 		for modelID, info := range models {
+			if !providerCanServeModel(info) {
+				continue
+			}
 			model := info.Model
 			model.ID = qualifyPublicModelID(providerName, modelID)
 			model.OwnedBy = providerName
@@ -339,6 +344,33 @@ func (r *ModelRegistry) ListPublicModels() []core.Model {
 	}
 	sort.Slice(result, func(i, j int) bool { return result[i].ID < result[j].ID })
 	return result
+}
+
+// providerCanServeModel reports whether the owning provider implements the
+// capabilities a model needs. Upstream inventories and the metadata registry
+// can list audio-only models (TTS/STT) for providers whose gateway adapter has
+// no audio support; advertising those invites calls that can only fail with
+// "does not support audio operations". Models without mode metadata are kept —
+// missing data must not hide a model.
+func providerCanServeModel(info *ModelInfo) bool {
+	if !isAudioOnlyModel(info.Model) {
+		return true
+	}
+	_, ok := info.Provider.(core.AudioProvider)
+	return ok
+}
+
+// isAudioOnlyModel reports whether every declared mode is an audio operation.
+func isAudioOnlyModel(model core.Model) bool {
+	if model.Metadata == nil || len(model.Metadata.Modes) == 0 {
+		return false
+	}
+	for _, mode := range model.Metadata.Modes {
+		if mode != "audio_speech" && mode != "audio_transcription" {
+			return false
+		}
+	}
+	return true
 }
 
 // ModelCount returns the number of registered models

--- a/internal/providers/registry_test.go
+++ b/internal/providers/registry_test.go
@@ -1961,3 +1961,61 @@ func TestGetCategoryCounts(t *testing.T) {
 
 // Verify ModelRegistry implements core.ModelLookup interface
 var _ core.ModelLookup = (*ModelRegistry)(nil)
+
+// audioRegistryMockProvider extends the mock with audio support so capability
+// filtering can distinguish it from audio-less providers.
+type audioRegistryMockProvider struct {
+	registryMockProvider
+}
+
+func (m *audioRegistryMockProvider) CreateSpeech(_ context.Context, _ *core.AudioSpeechRequest) (*core.AudioResponse, error) {
+	return &core.AudioResponse{}, nil
+}
+
+func (m *audioRegistryMockProvider) CreateTranscription(_ context.Context, _ *core.AudioTranscriptionRequest) (*core.AudioResponse, error) {
+	return &core.AudioResponse{}, nil
+}
+
+func TestListPublicModels_HidesAudioOnlyModelsFromProvidersWithoutAudioSupport(t *testing.T) {
+	inventory := func() *core.ModelsResponse {
+		return &core.ModelsResponse{
+			Object: "list",
+			Data: []core.Model{
+				{ID: "tts-model", Object: "model", Metadata: &core.ModelMetadata{Modes: []string{"audio_speech"}}},
+				{ID: "stt-model", Object: "model", Metadata: &core.ModelMetadata{Modes: []string{"audio_transcription"}}},
+				{ID: "chat-model", Object: "model", Metadata: &core.ModelMetadata{Modes: []string{"chat"}}},
+				{ID: "bare-model", Object: "model"},
+			},
+		}
+	}
+
+	registry := NewModelRegistry()
+	noAudio := &registryMockProvider{modelsResponse: inventory()}
+	withAudio := &audioRegistryMockProvider{registryMockProvider{modelsResponse: inventory()}}
+	registry.RegisterProviderWithNameAndType(noAudio, "gemini", "gemini")
+	registry.RegisterProviderWithNameAndType(withAudio, "openai", "openai")
+	if err := registry.Initialize(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := make(map[string]bool)
+	for _, model := range registry.ListPublicModels() {
+		got[model.ID] = true
+	}
+
+	wantListed := []string{
+		"gemini/chat-model", "gemini/bare-model", // no mode data or non-audio: kept
+		"openai/chat-model", "openai/bare-model",
+		"openai/tts-model", "openai/stt-model", // provider supports audio: kept
+	}
+	for _, id := range wantListed {
+		if !got[id] {
+			t.Errorf("expected %q to be listed", id)
+		}
+	}
+	for _, id := range []string{"gemini/tts-model", "gemini/stt-model"} {
+		if got[id] {
+			t.Errorf("expected audio-only %q to be hidden (provider has no audio support)", id)
+		}
+	}
+}

--- a/internal/server/conversation_responses.go
+++ b/internal/server/conversation_responses.go
@@ -1,0 +1,201 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"gomodel/internal/conversationstore"
+	"gomodel/internal/core"
+)
+
+// Gateway-managed conversations live in the local conversation store; upstream
+// providers have never seen their IDs. A /v1/responses call that references one
+// is therefore resolved locally: the stored history is prepended to the request
+// input, the conversation field is stripped before dispatch, and the new
+// exchange (user input + model output) is appended to the store afterwards.
+// This works uniformly for native Responses providers and chat-translated ones.
+
+// conversationTurnKey carries the in-flight conversation turn through the
+// prepared request context so dispatch can persist the exchange on completion.
+type conversationTurnKey struct{}
+
+// conversationTurn tracks one /v1/responses call bound to a gateway-managed
+// conversation: where to append and the request's own (pre-merge) input that
+// becomes the user side of the turn.
+type conversationTurn struct {
+	store conversationstore.Store
+	id    string
+	input any
+}
+
+func conversationTurnFromContext(ctx context.Context) *conversationTurn {
+	turn, _ := ctx.Value(conversationTurnKey{}).(*conversationTurn)
+	return turn
+}
+
+// applyResponsesConversation resolves a gateway-managed conversation reference
+// on a prepared request. Requests without one pass through untouched. A
+// missing conversation fails with the same 404 contract OpenAI uses.
+func (s *translatedInferenceService) applyResponsesConversation(ctx context.Context, req *core.ResponsesRequest) (context.Context, *core.ResponsesRequest, error) {
+	if req == nil || req.Conversation == nil {
+		return ctx, req, nil
+	}
+	store := s.currentConversationStore()
+	if store == nil {
+		// No local store configured: keep the historical pass-through behavior.
+		return ctx, req, nil
+	}
+	if req.PreviousResponseID != "" {
+		return ctx, req, core.NewInvalidRequestError("previous_response_id cannot be used together with conversation", nil)
+	}
+	id := req.Conversation.ID
+	if id == "" {
+		return ctx, req, core.NewInvalidRequestError("conversation id is required", nil)
+	}
+
+	stored, err := store.Get(ctx, id)
+	if err != nil {
+		if errors.Is(err, conversationstore.ErrNotFound) {
+			return ctx, req, core.NewNotFoundError(fmt.Sprintf("Conversation with id '%s' not found.", id))
+		}
+		return ctx, req, core.NewProviderError("conversation_store", 500, "failed to load conversation", err)
+	}
+
+	merged, err := mergeConversationInput(stored.Items, req.Input)
+	if err != nil {
+		return ctx, req, err
+	}
+
+	patched := *req
+	patched.Input = merged
+	patched.Conversation = nil
+
+	turn := &conversationTurn{store: store, id: id, input: req.Input}
+	return context.WithValue(ctx, conversationTurnKey{}, turn), &patched, nil
+}
+
+// mergeConversationInput prepends stored history items to the request input,
+// producing the []any union shape every downstream path already accepts.
+// Stored item IDs are gateway-generated and stripped so upstream providers do
+// not treat them as item references.
+func mergeConversationInput(history []json.RawMessage, input any) ([]any, error) {
+	merged := make([]any, 0, len(history)+1)
+	for _, raw := range history {
+		var item map[string]any
+		if err := json.Unmarshal(raw, &item); err != nil {
+			return nil, core.NewProviderError("conversation_store", 500, "stored conversation item is not valid JSON", err)
+		}
+		delete(item, "id")
+		merged = append(merged, item)
+	}
+
+	switch in := input.(type) {
+	case nil:
+		return merged, nil
+	case string:
+		return append(merged, map[string]any{
+			"type": "message",
+			"role": "user",
+			"content": []map[string]any{
+				{"type": "input_text", "text": in},
+			},
+		}), nil
+	case []core.ResponsesInputElement:
+		for _, item := range in {
+			merged = append(merged, item)
+		}
+		return merged, nil
+	case []map[string]any:
+		for _, item := range in {
+			merged = append(merged, item)
+		}
+		return merged, nil
+	case []any:
+		return append(merged, in...), nil
+	default:
+		return nil, core.NewInvalidRequestError("input must be a string or an array of input items", nil)
+	}
+}
+
+// appendExchange records the completed turn: the request input normalized as
+// stored input items, followed by the response output. Failures only log —
+// the client already has its response, so the turn must not fail after the fact.
+func (t *conversationTurn) appendExchange(ctx context.Context, responseID string, output []json.RawMessage) {
+	items := normalizedResponseInputItems(responseID, &core.ResponsesRequest{Input: t.input})
+	items = append(items, output...)
+	if len(items) == 0 {
+		return
+	}
+
+	stored, err := t.store.Get(ctx, t.id)
+	if err != nil {
+		slog.Warn("conversation append failed: load", "conversation_id", t.id, "error", err)
+		return
+	}
+	stored.Items = append(stored.Items, items...)
+	if err := t.store.Update(ctx, stored); err != nil {
+		slog.Warn("conversation append failed: update", "conversation_id", t.id, "error", err)
+	}
+}
+
+// appendResponse records a completed non-streaming response on the turn.
+func (t *conversationTurn) appendResponse(ctx context.Context, resp *core.ResponsesResponse) {
+	if t == nil || resp == nil {
+		return
+	}
+	output := make([]json.RawMessage, 0, len(resp.Output))
+	for _, item := range resp.Output {
+		raw, err := json.Marshal(item)
+		if err != nil {
+			slog.Warn("conversation append failed: marshal output", "conversation_id", t.id, "error", err)
+			return
+		}
+		output = append(output, raw)
+	}
+	t.appendExchange(ctx, resp.ID, output)
+}
+
+// streamObserver returns a streaming.Observer that captures the final
+// response.completed event and appends the exchange when the stream closes.
+// The context is detached from the request so the append survives the client
+// connection ending right after the final event.
+func (t *conversationTurn) streamObserver(ctx context.Context) *conversationStreamObserver {
+	return &conversationStreamObserver{turn: t, ctx: context.WithoutCancel(ctx)}
+}
+
+type conversationStreamObserver struct {
+	turn     *conversationTurn
+	ctx      context.Context
+	response map[string]any
+}
+
+func (o *conversationStreamObserver) OnJSONEvent(payload map[string]any) {
+	eventType, _ := payload["type"].(string)
+	if eventType != "response.completed" && eventType != "response.done" {
+		return
+	}
+	if response, ok := payload["response"].(map[string]any); ok {
+		o.response = response
+	}
+}
+
+func (o *conversationStreamObserver) OnStreamClose() {
+	if o.response == nil {
+		return
+	}
+	responseID, _ := o.response["id"].(string)
+	outputItems, _ := o.response["output"].([]any)
+	output := make([]json.RawMessage, 0, len(outputItems))
+	for _, item := range outputItems {
+		raw, err := json.Marshal(item)
+		if err != nil {
+			slog.Warn("conversation append failed: marshal streamed output", "conversation_id", o.turn.id, "error", err)
+			return
+		}
+		output = append(output, raw)
+	}
+	o.turn.appendExchange(o.ctx, responseID, output)
+}

--- a/internal/server/conversation_responses.go
+++ b/internal/server/conversation_responses.go
@@ -82,7 +82,7 @@ func (s *translatedInferenceService) applyResponsesConversation(ctx context.Cont
 // Stored item IDs are gateway-generated and stripped so upstream providers do
 // not treat them as item references.
 func mergeConversationInput(history []json.RawMessage, input any) ([]any, error) {
-	merged := make([]any, 0, len(history)+1)
+	merged := make([]any, 0, len(history))
 	for _, raw := range history {
 		var item map[string]any
 		if err := json.Unmarshal(raw, &item); err != nil {
@@ -129,21 +129,14 @@ func (t *conversationTurn) appendExchange(ctx context.Context, responseID string
 	if len(items) == 0 {
 		return
 	}
-
-	stored, err := t.store.Get(ctx, t.id)
-	if err != nil {
-		slog.Warn("conversation append failed: load", "conversation_id", t.id, "error", err)
-		return
-	}
-	stored.Items = append(stored.Items, items...)
-	if err := t.store.Update(ctx, stored); err != nil {
-		slog.Warn("conversation append failed: update", "conversation_id", t.id, "error", err)
+	if err := t.store.AppendItems(ctx, t.id, items); err != nil {
+		slog.Warn("conversation append failed", "conversation_id", t.id, "error", err)
 	}
 }
 
 // appendResponse records a completed non-streaming response on the turn.
 func (t *conversationTurn) appendResponse(ctx context.Context, resp *core.ResponsesResponse) {
-	if t == nil || resp == nil {
+	if resp == nil {
 		return
 	}
 	output := make([]json.RawMessage, 0, len(resp.Output))

--- a/internal/server/conversation_responses_test.go
+++ b/internal/server/conversation_responses_test.go
@@ -1,0 +1,184 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"gomodel/internal/core"
+)
+
+func conversationTestProvider(t *testing.T) *capturingProvider {
+	t.Helper()
+	return &capturingProvider{mockProvider: mockProvider{
+		supportedModels: []string{"gpt-5-mini"},
+		providerTypes:   map[string]string{"gpt-5-mini": "mock"},
+		responsesResponse: &core.ResponsesResponse{
+			ID:     "resp_conv_1",
+			Object: "response",
+			Model:  "gpt-5-mini",
+			Status: "completed",
+			Output: []core.ResponsesOutputItem{
+				{
+					ID:   "msg_out_1",
+					Type: "message",
+					Role: "assistant",
+					Content: []core.ResponsesContentItem{
+						{Type: "output_text", Text: "the word is zebra"},
+					},
+				},
+			},
+		},
+	}}
+}
+
+func createTestConversation(t *testing.T, srv http.Handler, body string) string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/v1/conversations", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("create conversation status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	var conv core.Conversation
+	if err := json.Unmarshal(rec.Body.Bytes(), &conv); err != nil {
+		t.Fatalf("decode conversation: %v", err)
+	}
+	return conv.ID
+}
+
+func postResponses(t *testing.T, srv http.Handler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestResponsesWithConversation_ResolvesLocallyAndAppendsTurn(t *testing.T) {
+	provider := conversationTestProvider(t)
+	srv := New(provider, nil)
+
+	convID := createTestConversation(t, srv,
+		`{"items":[{"type":"message","role":"user","content":[{"type":"input_text","text":"remember: zebra"}]}]}`)
+
+	rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"what is the word?","conversation":"`+convID+`"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("responses status = %d (%s)", rec.Code, rec.Body.String())
+	}
+
+	forwarded := provider.capturedResponsesReq
+	if forwarded == nil {
+		t.Fatal("provider did not receive a responses request")
+	}
+	if forwarded.Conversation != nil {
+		t.Fatalf("conversation field must be stripped before dispatch, got %+v", forwarded.Conversation)
+	}
+	input, ok := forwarded.Input.([]any)
+	if !ok || len(input) != 2 {
+		t.Fatalf("forwarded input = %#v, want history + user message (2 items)", forwarded.Input)
+	}
+	history, ok := input[0].(map[string]any)
+	if !ok || history["role"] != "user" {
+		t.Fatalf("first forwarded item = %#v, want stored history item", input[0])
+	}
+	if _, hasID := history["id"]; hasID {
+		t.Fatalf("stored item id must be stripped before dispatch, got %#v", history)
+	}
+
+	// Second turn: the conversation now holds initial item + turn input + output.
+	rec = postResponses(t, srv, `{"model":"gpt-5-mini","input":"and again?","conversation":"`+convID+`"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second responses status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	input, ok = provider.capturedResponsesReq.Input.([]any)
+	if !ok || len(input) != 4 {
+		t.Fatalf("second turn forwarded %d items, want 4 (3 history + 1 new input): %#v", len(input), provider.capturedResponsesReq.Input)
+	}
+	assistant, ok := input[2].(map[string]any)
+	if !ok || assistant["role"] != "assistant" {
+		t.Fatalf("third forwarded item = %#v, want appended assistant output", input[2])
+	}
+}
+
+func TestResponsesWithConversation_UnknownIDReturns404(t *testing.T) {
+	provider := conversationTestProvider(t)
+	srv := New(provider, nil)
+
+	rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"hello","conversation":"conv_missing"}`)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d (%s), want 404", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "Conversation with id 'conv_missing' not found") {
+		t.Fatalf("body = %s, want conversation not found message", rec.Body.String())
+	}
+	if provider.capturedResponsesReq != nil {
+		t.Fatal("provider must not be called for an unknown conversation")
+	}
+}
+
+func TestResponsesWithConversation_RejectsPreviousResponseID(t *testing.T) {
+	provider := conversationTestProvider(t)
+	srv := New(provider, nil)
+	convID := createTestConversation(t, srv, `{}`)
+
+	rec := postResponses(t, srv,
+		`{"model":"gpt-5-mini","input":"hello","conversation":"`+convID+`","previous_response_id":"resp_1"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d (%s), want 400", rec.Code, rec.Body.String())
+	}
+}
+
+func TestResponsesWithConversation_ObjectRefAndStringInputShapes(t *testing.T) {
+	provider := conversationTestProvider(t)
+	srv := New(provider, nil)
+	convID := createTestConversation(t, srv, `{}`)
+
+	rec := postResponses(t, srv,
+		`{"model":"gpt-5-mini","input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}],"conversation":{"id":"`+convID+`"}}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	input, ok := provider.capturedResponsesReq.Input.([]any)
+	if !ok || len(input) != 1 {
+		t.Fatalf("forwarded input = %#v, want the single request item (empty history)", provider.capturedResponsesReq.Input)
+	}
+}
+
+func TestResponsesWithConversation_StreamingAppendsTurn(t *testing.T) {
+	streamData := strings.Join([]string{
+		`data: {"type":"response.created","response":{"id":"resp_s1"}}`,
+		"",
+		`data: {"type":"response.completed","response":{"id":"resp_s1","output":[{"id":"msg_s1","type":"message","role":"assistant","content":[{"type":"output_text","text":"streamed answer"}]}],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+	provider := conversationTestProvider(t)
+	provider.streamData = streamData
+	srv := New(provider, nil)
+	convID := createTestConversation(t, srv, `{}`)
+
+	rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"start","conversation":"`+convID+`","stream":true}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("stream status = %d (%s)", rec.Code, rec.Body.String())
+	}
+
+	// The streamed exchange (input + completed output) must now be history.
+	rec = postResponses(t, srv, `{"model":"gpt-5-mini","input":"next","conversation":"`+convID+`"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("follow-up status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	input, ok := provider.capturedResponsesReq.Input.([]any)
+	if !ok || len(input) != 3 {
+		t.Fatalf("follow-up forwarded %d items, want 3 (streamed input + output + new input): %#v", len(input), provider.capturedResponsesReq.Input)
+	}
+	assistant, ok := input[1].(map[string]any)
+	if !ok || assistant["role"] != "assistant" {
+		t.Fatalf("second item = %#v, want streamed assistant output", input[1])
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -35,12 +35,13 @@ type Handler struct {
 	batchStore                      batchstore.Store
 	fileStore                       filestore.Store
 	responseStore                   responsestore.Store
-	responseStoreMu                 sync.RWMutex
-	conversationStore               conversationstore.Store
-	normalizePassthroughV1Prefix    bool
-	enabledPassthroughProviders     map[string]struct{}
-	responseCache                   *responsecache.ResponseCacheMiddleware
-	guardrailsHash                  string
+	// storesMu guards responseStore, conversationStore, and translatedSvc wiring.
+	storesMu                     sync.RWMutex
+	conversationStore            conversationstore.Store
+	normalizePassthroughV1Prefix bool
+	enabledPassthroughProviders  map[string]struct{}
+	responseCache                *responsecache.ResponseCacheMiddleware
+	guardrailsHash               string
 
 	translatedSvc     *translatedInferenceService // snapshot of handler fields at first use; server.New sets cache/hash before traffic
 	translatedSvcOnce sync.Once
@@ -134,8 +135,8 @@ func (h *Handler) SetResponseStore(store responsestore.Store) {
 	if store == nil {
 		return
 	}
-	h.responseStoreMu.Lock()
-	defer h.responseStoreMu.Unlock()
+	h.storesMu.Lock()
+	defer h.storesMu.Unlock()
 	h.responseStore = store
 	if h.translatedSvc != nil {
 		h.translatedSvc.setResponseStore(store)
@@ -149,6 +150,8 @@ func (h *Handler) SetConversationStore(store conversationstore.Store) {
 	if store == nil {
 		return
 	}
+	h.storesMu.Lock()
+	defer h.storesMu.Unlock()
 	h.conversationStore = store
 	if h.translatedSvc != nil {
 		h.translatedSvc.setConversationStore(store)
@@ -171,16 +174,16 @@ func (h *Handler) translatedInference() *translatedInferenceService {
 			responseCache:            h.responseCache,
 			guardrailsHash:           h.guardrailsHash,
 			responseStore:            h.currentResponseStore(),
-			conversationStore:        h.conversationStore,
 		}
 		s.initHandlers()
-		h.responseStoreMu.Lock()
+		h.storesMu.Lock()
 		s.setResponseStore(h.responseStore)
+		s.setConversationStore(h.conversationStore)
 		h.translatedSvc = s
-		h.responseStoreMu.Unlock()
+		h.storesMu.Unlock()
 	})
-	h.responseStoreMu.RLock()
-	defer h.responseStoreMu.RUnlock()
+	h.storesMu.RLock()
+	defer h.storesMu.RUnlock()
 	return h.translatedSvc
 }
 
@@ -235,12 +238,14 @@ func (h *Handler) nativeResponses() *nativeResponseService {
 }
 
 func (h *Handler) conversations() *conversationService {
+	h.storesMu.RLock()
+	defer h.storesMu.RUnlock()
 	return &conversationService{conversationStore: h.conversationStore}
 }
 
 func (h *Handler) currentResponseStore() responsestore.Store {
-	h.responseStoreMu.RLock()
-	defer h.responseStoreMu.RUnlock()
+	h.storesMu.RLock()
+	defer h.storesMu.RUnlock()
 	return h.responseStore
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -143,13 +143,16 @@ func (h *Handler) SetResponseStore(store responsestore.Store) {
 }
 
 // SetConversationStore replaces the conversation store used by the
-// Conversations lifecycle endpoints.
+// Conversations lifecycle endpoints and by /v1/responses conversation turns.
 // nil is ignored to keep an always-available fallback memory store.
 func (h *Handler) SetConversationStore(store conversationstore.Store) {
 	if store == nil {
 		return
 	}
 	h.conversationStore = store
+	if h.translatedSvc != nil {
+		h.translatedSvc.setConversationStore(store)
+	}
 }
 
 func (h *Handler) translatedInference() *translatedInferenceService {
@@ -168,6 +171,7 @@ func (h *Handler) translatedInference() *translatedInferenceService {
 			responseCache:            h.responseCache,
 			guardrailsHash:           h.guardrailsHash,
 			responseStore:            h.currentResponseStore(),
+			conversationStore:        h.conversationStore,
 		}
 		s.initHandlers()
 		h.responseStoreMu.Lock()

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -4369,7 +4369,7 @@ func TestBatches_InputFileRejectsUnsupportedExplicitProviderSelector(t *testing.
 
 	err = handler.Batches(c)
 	require.NoError(t, err)
-	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, http.StatusNotFound, rec.Code)
 	require.Contains(t, rec.Body.String(), "unsupported model: openai/smart")
 	require.Nil(t, mock.capturedBatchReq)
 	require.Empty(t, mock.capturedFileCreateReqs)
@@ -4469,7 +4469,7 @@ func TestBatches_InputFileRejectsDisabledAlias(t *testing.T) {
 
 	err = handler.Batches(c)
 	require.NoError(t, err)
-	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, http.StatusNotFound, rec.Code)
 	require.Contains(t, rec.Body.String(), "unsupported model: smart")
 	require.Nil(t, inner.capturedBatchReq)
 	require.Empty(t, inner.capturedFileCreateReqs)

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -4371,6 +4371,7 @@ func TestBatches_InputFileRejectsUnsupportedExplicitProviderSelector(t *testing.
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNotFound, rec.Code)
 	require.Contains(t, rec.Body.String(), "unsupported model: openai/smart")
+	require.Contains(t, rec.Body.String(), `"code":"model_not_found"`)
 	require.Nil(t, mock.capturedBatchReq)
 	require.Empty(t, mock.capturedFileCreateReqs)
 }
@@ -4471,6 +4472,7 @@ func TestBatches_InputFileRejectsDisabledAlias(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNotFound, rec.Code)
 	require.Contains(t, rec.Body.String(), "unsupported model: smart")
+	require.Contains(t, rec.Body.String(), `"code":"model_not_found"`)
 	require.Nil(t, inner.capturedBatchReq)
 	require.Empty(t, inner.capturedFileCreateReqs)
 }

--- a/internal/server/model_validation_test.go
+++ b/internal/server/model_validation_test.go
@@ -144,12 +144,12 @@ func TestModelValidation(t *testing.T) {
 			handlerCalled:  false,
 		},
 		{
-			name:           "unsupported model returns 400",
+			name:           "unsupported model returns 404 model_not_found",
 			method:         http.MethodPost,
 			path:           "/v1/chat/completions",
 			body:           `{"model":"unsupported-model","messages":[{"role":"user","content":"hi"}]}`,
-			expectedStatus: http.StatusBadRequest,
-			expectedBody:   "unsupported model",
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   "model_not_found",
 			handlerCalled:  false,
 		},
 		{
@@ -758,12 +758,12 @@ func TestModelValidation_EnrichesAuditEntryWithRequestedModelOnResolutionError(t
 	require.NoError(t, err)
 
 	assert.False(t, handlerCalled)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
 	assert.Contains(t, rec.Body.String(), "unsupported model: smart")
 	assert.Equal(t, "smart", entry.RequestedModel)
 	assert.Equal(t, "", entry.ResolvedModel)
 	assert.Equal(t, "", entry.Provider)
-	assert.Equal(t, "invalid_request_error", entry.ErrorType)
+	assert.Equal(t, "not_found_error", entry.ErrorType)
 }
 
 func TestModelValidation_DefersOversizedLiveBodyResolutionToHandler(t *testing.T) {

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -294,7 +294,9 @@ func (s *translatedInferenceService) dispatchResponses(c *echo.Context, req *cor
 	if err := s.storeResponseSnapshot(ctx, workflow, req, result.Response, result.Meta.ProviderType, result.Meta.ProviderName, requestID); err != nil {
 		s.recordResponseSnapshotStoreFailure(workflow, result.Response, result.Meta.ProviderType, result.Meta.ProviderName, requestID, err)
 	}
-	conversationTurnFromContext(ctx).appendResponse(ctx, result.Response)
+	if turn := conversationTurnFromContext(ctx); turn != nil {
+		turn.appendResponse(ctx, result.Response)
+	}
 
 	return c.JSON(http.StatusOK, result.Response)
 }

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/labstack/echo/v5"
 
 	"gomodel/internal/auditlog"
+	"gomodel/internal/conversationstore"
 	"gomodel/internal/core"
 	"gomodel/internal/gateway"
 	"gomodel/internal/observability"
@@ -40,6 +41,8 @@ type translatedInferenceService struct {
 	guardrailsHash           string
 	responseStore            responsestore.Store
 	responseStoreMu          sync.RWMutex
+	conversationStore        conversationstore.Store
+	conversationStoreMu      sync.RWMutex
 
 	orchestrator *gateway.InferenceOrchestrator
 
@@ -176,7 +179,14 @@ func prepareResponsesRequest(
 	meta gateway.RequestMeta,
 ) (context.Context, *core.ResponsesRequest, *core.Workflow, error) {
 	prepared, err := s.inference().PrepareResponsesRequest(ctx, req, meta)
-	return unpackPrepared(ctx, prepared, err, responsesPreparedFields)
+	ctx, preparedReq, workflow, err := unpackPrepared(ctx, prepared, err, responsesPreparedFields)
+	if err != nil {
+		return ctx, preparedReq, workflow, err
+	}
+	// Resolve gateway-managed conversations before caching and dispatch so the
+	// cache key reflects the merged history and providers never see local IDs.
+	ctx, preparedReq, err = s.applyResponsesConversation(ctx, preparedReq)
+	return ctx, preparedReq, workflow, err
 }
 
 func unpackPrepared[Prepared any, Req any](
@@ -214,6 +224,12 @@ func handleWithCache[R any](
 	workflow *core.Workflow,
 	dispatch func(*echo.Context, R, *core.Workflow) error,
 ) error {
+	// Conversation turns are stateful: the same input means something different
+	// as the conversation grows, and a cache hit would skip the history append.
+	if conversationTurnFromContext(c.Request().Context()) != nil {
+		return dispatch(c, req, workflow)
+	}
+
 	if s.responseCache != nil && (workflow == nil || workflow.CacheEnabled()) {
 		body, marshalErr := marshalRequestBody(req)
 		if marshalErr != nil {
@@ -244,6 +260,10 @@ func (s *translatedInferenceService) dispatchResponses(c *echo.Context, req *cor
 		if result.Meta.UsedFallback {
 			markRequestFallbackUsed(c)
 		}
+		stream := result.Stream
+		if turn := conversationTurnFromContext(ctx); turn != nil {
+			stream = streaming.NewObservedSSEStream(stream, turn.streamObserver(ctx))
+		}
 		return s.handleStreamingReadCloser(
 			c,
 			workflow,
@@ -251,7 +271,7 @@ func (s *translatedInferenceService) dispatchResponses(c *echo.Context, req *cor
 			result.Meta.ProviderType,
 			result.Meta.ProviderName,
 			result.Meta.FailoverModel,
-			result.Stream,
+			stream,
 			nil,
 		)
 	}
@@ -274,6 +294,7 @@ func (s *translatedInferenceService) dispatchResponses(c *echo.Context, req *cor
 	if err := s.storeResponseSnapshot(ctx, workflow, req, result.Response, result.Meta.ProviderType, result.Meta.ProviderName, requestID); err != nil {
 		s.recordResponseSnapshotStoreFailure(workflow, result.Response, result.Meta.ProviderType, result.Meta.ProviderName, requestID, err)
 	}
+	conversationTurnFromContext(ctx).appendResponse(ctx, result.Response)
 
 	return c.JSON(http.StatusOK, result.Response)
 }
@@ -317,6 +338,18 @@ func (s *translatedInferenceService) setResponseStore(store responsestore.Store)
 	s.responseStoreMu.Lock()
 	defer s.responseStoreMu.Unlock()
 	s.responseStore = store
+}
+
+func (s *translatedInferenceService) currentConversationStore() conversationstore.Store {
+	s.conversationStoreMu.RLock()
+	defer s.conversationStoreMu.RUnlock()
+	return s.conversationStore
+}
+
+func (s *translatedInferenceService) setConversationStore(store conversationstore.Store) {
+	s.conversationStoreMu.Lock()
+	defer s.conversationStoreMu.Unlock()
+	s.conversationStore = store
 }
 
 func (s *translatedInferenceService) recordResponseSnapshotStoreFailure(workflow *core.Workflow, resp *core.ResponsesResponse, providerType, providerName, requestID string, err error) {

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -295,7 +295,9 @@ func (s *translatedInferenceService) dispatchResponses(c *echo.Context, req *cor
 		s.recordResponseSnapshotStoreFailure(workflow, result.Response, result.Meta.ProviderType, result.Meta.ProviderName, requestID, err)
 	}
 	if turn := conversationTurnFromContext(ctx); turn != nil {
-		turn.appendResponse(ctx, result.Response)
+		// Detach cancellation so a client disconnect after provider success
+		// cannot lose the completed turn, mirroring the streaming observer.
+		turn.appendResponse(context.WithoutCancel(ctx), result.Response)
 	}
 
 	return c.JSON(http.StatusOK, result.Response)

--- a/internal/storage/mongodb.go
+++ b/internal/storage/mongodb.go
@@ -66,14 +66,19 @@ func resolveMongoDatabase(cfg MongoDBConfig) string {
 }
 
 // databaseNameFromURI extracts the database name (the path component) from a
-// MongoDB connection string. Returns "" when the URI is unparseable or names
-// no database.
+// MongoDB connection string. Returns "" when the URI is unparseable, names no
+// database, or the path is not a single segment — MongoDB database names
+// cannot contain '/', so a multi-segment path would fail at connect time.
 func databaseNameFromURI(uri string) string {
 	u, err := url.Parse(uri)
 	if err != nil {
 		return ""
 	}
-	return strings.TrimPrefix(u.Path, "/")
+	name := strings.Trim(u.Path, "/")
+	if strings.Contains(name, "/") {
+		return ""
+	}
+	return name
 }
 
 func (s *mongoStorage) Close() error {

--- a/internal/storage/mongodb.go
+++ b/internal/storage/mongodb.go
@@ -3,10 +3,16 @@ package storage
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strings"
 
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
+
+// DefaultMongoDatabase is the database used when neither the explicit Database
+// config nor the connection string names one.
+const DefaultMongoDatabase = "gomodel"
 
 // mongoStorage implements Storage for MongoDB
 type mongoStorage struct {
@@ -20,11 +26,7 @@ func NewMongoDB(ctx context.Context, cfg MongoDBConfig) (MongoDBStorage, error) 
 		return nil, fmt.Errorf("MongoDB URL is required")
 	}
 
-	// Set default database name
-	dbName := cfg.Database
-	if dbName == "" {
-		dbName = "gomodel"
-	}
+	dbName := resolveMongoDatabase(cfg)
 
 	// Create client options
 	clientOpts := options.Client().ApplyURI(cfg.URL)
@@ -48,6 +50,30 @@ func NewMongoDB(ctx context.Context, cfg MongoDBConfig) (MongoDBStorage, error) 
 		client:   client,
 		database: database,
 	}, nil
+}
+
+// resolveMongoDatabase picks the database name for a connection: the explicit
+// Database config wins, then the database named in the connection string path
+// (the standard "mongodb://host/dbname" form), then DefaultMongoDatabase.
+func resolveMongoDatabase(cfg MongoDBConfig) string {
+	if cfg.Database != "" {
+		return cfg.Database
+	}
+	if name := databaseNameFromURI(cfg.URL); name != "" {
+		return name
+	}
+	return DefaultMongoDatabase
+}
+
+// databaseNameFromURI extracts the database name (the path component) from a
+// MongoDB connection string. Returns "" when the URI is unparseable or names
+// no database.
+func databaseNameFromURI(uri string) string {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimPrefix(u.Path, "/")
 }
 
 func (s *mongoStorage) Close() error {

--- a/internal/storage/mongodb_test.go
+++ b/internal/storage/mongodb_test.go
@@ -1,0 +1,60 @@
+package storage
+
+import "testing"
+
+func TestResolveMongoDatabase(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  MongoDBConfig
+		want string
+	}{
+		{
+			name: "explicit database wins over URL path",
+			cfg:  MongoDBConfig{URL: "mongodb://localhost:27017/from_url", Database: "explicit"},
+			want: "explicit",
+		},
+		{
+			name: "database from URL path",
+			cfg:  MongoDBConfig{URL: "mongodb://localhost:27017/from_url"},
+			want: "from_url",
+		},
+		{
+			name: "URL path with query options",
+			cfg:  MongoDBConfig{URL: "mongodb://localhost:27017/mydb?retryWrites=true&w=majority"},
+			want: "mydb",
+		},
+		{
+			name: "srv scheme",
+			cfg:  MongoDBConfig{URL: "mongodb+srv://user:pass@cluster.example.com/appdb"},
+			want: "appdb",
+		},
+		{
+			name: "multi-host URL",
+			cfg:  MongoDBConfig{URL: "mongodb://h1:27017,h2:27017/replicadb"},
+			want: "replicadb",
+		},
+		{
+			name: "no database in URL falls back to default",
+			cfg:  MongoDBConfig{URL: "mongodb://localhost:27017"},
+			want: DefaultMongoDatabase,
+		},
+		{
+			name: "trailing slash only falls back to default",
+			cfg:  MongoDBConfig{URL: "mongodb://localhost:27017/"},
+			want: DefaultMongoDatabase,
+		},
+		{
+			name: "unparseable URL falls back to default",
+			cfg:  MongoDBConfig{URL: "mongodb://[::1"},
+			want: DefaultMongoDatabase,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveMongoDatabase(tt.cfg); got != tt.want {
+				t.Errorf("resolveMongoDatabase(%+v) = %q, want %q", tt.cfg, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/storage/mongodb_test.go
+++ b/internal/storage/mongodb_test.go
@@ -44,6 +44,16 @@ func TestResolveMongoDatabase(t *testing.T) {
 			want: DefaultMongoDatabase,
 		},
 		{
+			name: "database with trailing slash is trimmed",
+			cfg:  MongoDBConfig{URL: "mongodb://localhost:27017/mydb/"},
+			want: "mydb",
+		},
+		{
+			name: "multi-segment path falls back to default",
+			cfg:  MongoDBConfig{URL: "mongodb://localhost:27017/a/b"},
+			want: DefaultMongoDatabase,
+		},
+		{
 			name: "unparseable URL falls back to default",
 			cfg:  MongoDBConfig{URL: "mongodb://[::1"},
 			want: DefaultMongoDatabase,

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -126,19 +126,3 @@ func New(ctx context.Context, cfg Config) (Storage, error) {
 		return nil, fmt.Errorf("unknown storage type: %s (valid: sqlite, postgresql, mongodb)", cfg.Type)
 	}
 }
-
-// DefaultConfig returns a Config with sensible defaults
-func DefaultConfig() Config {
-	return Config{
-		Type: TypeSQLite,
-		SQLite: SQLiteConfig{
-			Path: DefaultSQLitePath,
-		},
-		PostgreSQL: PostgreSQLConfig{
-			MaxConns: 10,
-		},
-		MongoDB: MongoDBConfig{
-			Database: "gomodel",
-		},
-	}
-}

--- a/internal/usage/audio.go
+++ b/internal/usage/audio.go
@@ -23,7 +23,7 @@ const (
 	// rawKeyAudioOutputSeconds carries the synthesized speech duration the gateway
 	// measures from the returned audio, priced via PerSecondOutput. rawKeyAudioOutputFormat
 	// records the output codec so cost.go can flag a duration it could not measure
-	// (compressed mp3/opus/aac/flac) rather than reporting a silent zero.
+	// (opus/aac/flac) rather than reporting a silent zero.
 	rawKeyAudioOutputSeconds = "audio_output_seconds"
 	rawKeyAudioOutputFormat  = "audio_output_format"
 )
@@ -34,8 +34,8 @@ const (
 // models such as tts-1) and the synthesized audio duration (per-second-output
 // models such as gpt-4o-mini-tts), both recorded in RawData so the interaction
 // stays observable and pricing can apply. output is the returned audio and
-// format its response_format/MIME type; duration is measured for uncompressed
-// formats only (see measureSpeechDurationSeconds). model is the resolved route
+// format its response_format/MIME type; duration is measured for wav/pcm/mp3
+// (see measureSpeechDurationSeconds). model is the resolved route
 // model (not the raw user input) so the row groups and prices consistently with
 // the pricing lookup, mirroring the transcription extractor.
 func ExtractFromSpeechRequest(input string, output []byte, format, requestID, model, provider string, pricing ...*core.ModelPricing) *UsageEntry {
@@ -52,10 +52,10 @@ func ExtractFromSpeechRequest(input string, output []byte, format, requestID, mo
 	if chars := len([]rune(input)); chars > 0 {
 		raw[rawKeyInputCharacters] = chars
 	}
-	// Record the output codec whenever it is known, even for an empty body, so a
-	// compressed (unmeasurable) format still surfaces a cost caveat in cost.go
-	// rather than a silent zero. Record the measured duration only when the
-	// gateway can compute it from the returned audio (uncompressed wav/pcm).
+	// Record the output codec whenever it is known, even for an empty body, so an
+	// unmeasurable format still surfaces a cost caveat in cost.go rather than a
+	// silent zero. Record the measured duration only when the gateway can compute
+	// it from the returned audio (wav/pcm/mp3).
 	if codec := normalizeAudioFormat(format); codec != "" {
 		raw[rawKeyAudioOutputFormat] = codec
 	}

--- a/internal/usage/audio_duration.go
+++ b/internal/usage/audio_duration.go
@@ -92,6 +92,9 @@ func mp3DurationSeconds(data []byte) (float64, bool) {
 			pos++ // still hunting for the first sync word
 			continue
 		}
+		if pos+frameSize > len(data) {
+			break // truncated frame: do not bill audio that is not there
+		}
 		seconds += frameSeconds
 		frames++
 		pos += frameSize

--- a/internal/usage/audio_duration.go
+++ b/internal/usage/audio_duration.go
@@ -10,17 +10,24 @@ import (
 const pcmBytesPerSecond = 24000 * 2
 
 // measureSpeechDurationSeconds returns the playback duration, in seconds, of
-// synthesized speech the gateway can compute without decoding a compressed
-// codec. It parses self-describing WAV (RIFF/WAVE) containers and the fixed-rate
-// PCM stream OpenAI emits for response_format=pcm. Compressed formats (mp3,
-// opus, aac, flac) return ok=false so the caller can flag the cost as partial
-// rather than reporting a silent zero.
+// synthesized speech the gateway can compute without decoding audio. It parses
+// self-describing WAV (RIFF/WAVE) containers, the fixed-rate PCM stream OpenAI
+// emits for response_format=pcm, and MPEG (mp3) streams via their frame
+// headers — mp3 matters because it is OpenAI's default speech format, so
+// per-second-output models would otherwise always cost zero. Other compressed
+// formats (opus, aac, flac) return ok=false so the caller can flag the cost as
+// partial rather than reporting a silent zero.
 func measureSpeechDurationSeconds(data []byte, format string) (float64, bool) {
 	if seconds, ok := wavDurationSeconds(data); ok {
 		return seconds, true
 	}
-	if normalizeAudioFormat(format) == "pcm" && len(data) > 0 {
-		return float64(len(data)) / pcmBytesPerSecond, true
+	switch normalizeAudioFormat(format) {
+	case "pcm":
+		if len(data) > 0 {
+			return float64(len(data)) / pcmBytesPerSecond, true
+		}
+	case "mp3":
+		return mp3DurationSeconds(data)
 	}
 	return 0, false
 }
@@ -49,6 +56,94 @@ func normalizeAudioFormat(format string) string {
 		return "pcm"
 	}
 	return strings.TrimPrefix(f, "audio/")
+}
+
+// mp3SamplesPerFrame and mp3BitrateKbps index Layer III frame parameters by
+// MPEG version group: 0 = MPEG-1, 1 = MPEG-2/2.5 (half sample rate).
+var (
+	mp3SamplesPerFrame = [2]int{1152, 576}
+	mp3BitrateKbps     = [2][15]int{
+		{0, 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320},
+		{0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160},
+	}
+	mp3SampleRates = map[byte][3]int{
+		3: {44100, 48000, 32000}, // MPEG-1
+		2: {22050, 24000, 16000}, // MPEG-2
+		0: {11025, 12000, 8000},  // MPEG-2.5
+	}
+)
+
+// mp3DurationSeconds derives the playback duration of an MPEG Layer III (mp3)
+// stream by walking its frame headers and summing samples-per-frame over the
+// sample rate — exact for both CBR and VBR without decoding any audio. It
+// skips a leading ID3v2 tag, resyncs across stray bytes, and stops at trailing
+// non-frame data (e.g. an ID3v1 tag). Returns ok=false when no frame is found.
+func mp3DurationSeconds(data []byte) (float64, bool) {
+	pos := skipID3v2(data)
+
+	var seconds float64
+	frames := 0
+	for pos+4 <= len(data) {
+		frameSize, frameSeconds, ok := parseMP3FrameHeader(data[pos:])
+		if !ok {
+			if frames > 0 {
+				break // trailing tag or junk after the audio stream
+			}
+			pos++ // still hunting for the first sync word
+			continue
+		}
+		seconds += frameSeconds
+		frames++
+		pos += frameSize
+	}
+	return seconds, frames > 0
+}
+
+// parseMP3FrameHeader validates the 4-byte MPEG header at the start of buf and
+// returns the frame's byte length and playback duration. ok=false for anything
+// that is not a Layer III frame with a defined bitrate and sample rate.
+func parseMP3FrameHeader(buf []byte) (frameSize int, seconds float64, ok bool) {
+	if len(buf) < 4 || buf[0] != 0xFF || buf[1]&0xE0 != 0xE0 {
+		return 0, 0, false
+	}
+	version := (buf[1] >> 3) & 0x3 // 3=MPEG-1, 2=MPEG-2, 0=MPEG-2.5, 1=reserved
+	layer := (buf[1] >> 1) & 0x3   // 1=Layer III
+	bitrateIdx := (buf[2] >> 4) & 0xF
+	sampleRateIdx := (buf[2] >> 2) & 0x3
+	padding := int((buf[2] >> 1) & 0x1)
+
+	rates, versionOK := mp3SampleRates[version]
+	if !versionOK || layer != 1 || bitrateIdx == 0 || bitrateIdx == 0xF || sampleRateIdx == 3 {
+		return 0, 0, false // reserved fields, or "free" bitrate we cannot size
+	}
+
+	group := 0 // MPEG-1
+	if version != 3 {
+		group = 1 // MPEG-2/2.5
+	}
+	bitrate := mp3BitrateKbps[group][bitrateIdx] * 1000
+	sampleRate := rates[sampleRateIdx]
+	samples := mp3SamplesPerFrame[group]
+
+	frameSize = samples/8*bitrate/sampleRate + padding
+	if frameSize <= 4 {
+		return 0, 0, false
+	}
+	return frameSize, float64(samples) / float64(sampleRate), true
+}
+
+// skipID3v2 returns the offset past a leading ID3v2 tag, whose size is encoded
+// as a 28-bit sync-safe integer, or 0 when no tag is present.
+func skipID3v2(data []byte) int {
+	if len(data) < 10 || string(data[0:3]) != "ID3" {
+		return 0
+	}
+	size := int(data[6]&0x7F)<<21 | int(data[7]&0x7F)<<14 | int(data[8]&0x7F)<<7 | int(data[9]&0x7F)
+	end := 10 + size
+	if end > len(data) {
+		return len(data)
+	}
+	return end
 }
 
 // wavDurationSeconds parses a canonical RIFF/WAVE container and derives its

--- a/internal/usage/audio_duration_test.go
+++ b/internal/usage/audio_duration_test.go
@@ -68,6 +68,8 @@ func TestMP3DurationSeconds(t *testing.T) {
 		{"leading ID3v2 tag skipped", append(id3, buildMP3(10)...), 10 * mp3FrameSeconds, true},
 		{"trailing ID3v1 tag ignored", append(buildMP3(10), id3v1...), 10 * mp3FrameSeconds, true},
 		{"junk before first sync", append([]byte("junk"), buildMP3(5)...), 5 * mp3FrameSeconds, true},
+		{"truncated final frame not counted", append(buildMP3(10), buildMP3(1)[:50]...), 10 * mp3FrameSeconds, true},
+		{"single truncated frame unmeasurable", buildMP3(1)[:50], 0, false},
 		{"no frames", []byte("definitely not audio"), 0, false},
 		{"empty", nil, 0, false},
 		{"ID3 tag only", id3, 0, false},

--- a/internal/usage/audio_duration_test.go
+++ b/internal/usage/audio_duration_test.go
@@ -36,6 +36,65 @@ func buildWAV(t *testing.T, sampleRate, channels, bitsPerSample int, seconds flo
 	return buf.Bytes()
 }
 
+// buildMP3 produces a CBR MPEG-2 Layer III stream (24 kHz, 64 kbps — the shape
+// OpenAI speech emits) of the given frame count. Each frame is 192 bytes and
+// plays 576/24000 s, so duration assertions are exact.
+func buildMP3(frames int) []byte {
+	const frameSize = 192 // 576/8 * 64000 / 24000
+	data := make([]byte, 0, frames*frameSize)
+	for range frames {
+		frame := make([]byte, frameSize)
+		// sync + MPEG-2 + Layer III, 64 kbps @ 24 kHz, no padding, mono.
+		frame[0], frame[1], frame[2], frame[3] = 0xFF, 0xF3, 0x84, 0xC0
+		data = append(data, frame...)
+	}
+	return data
+}
+
+const mp3FrameSeconds = 576.0 / 24000
+
+func TestMP3DurationSeconds(t *testing.T) {
+	id3 := append([]byte{'I', 'D', '3', 4, 0, 0, 0, 0, 0, 10}, make([]byte, 10)...) // 10-byte body
+	id3v1 := append([]byte("TAG"), make([]byte, 125)...)
+
+	tests := []struct {
+		name   string
+		data   []byte
+		want   float64
+		wantOK bool
+	}{
+		{"50 frames", buildMP3(50), 50 * mp3FrameSeconds, true},
+		{"single frame", buildMP3(1), mp3FrameSeconds, true},
+		{"leading ID3v2 tag skipped", append(id3, buildMP3(10)...), 10 * mp3FrameSeconds, true},
+		{"trailing ID3v1 tag ignored", append(buildMP3(10), id3v1...), 10 * mp3FrameSeconds, true},
+		{"junk before first sync", append([]byte("junk"), buildMP3(5)...), 5 * mp3FrameSeconds, true},
+		{"no frames", []byte("definitely not audio"), 0, false},
+		{"empty", nil, 0, false},
+		{"ID3 tag only", id3, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := mp3DurationSeconds(tt.data)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && !nearlyEqual(got, tt.want) {
+				t.Errorf("seconds = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseMP3FrameHeader_MPEG1(t *testing.T) {
+	// MPEG-1 Layer III, 128 kbps @ 44.1 kHz: 1152 samples, floor(144*128000/44100)
+	// = 417 bytes per frame.
+	buf := []byte{0xFF, 0xFB, 0x90, 0xC0}
+	size, seconds, ok := parseMP3FrameHeader(buf)
+	if !ok || size != 417 || !nearlyEqual(seconds, 1152.0/44100) {
+		t.Errorf("got (%d, %v, %v), want (417, %v, true)", size, seconds, ok, 1152.0/44100)
+	}
+}
+
 func TestMeasureSpeechDurationSeconds(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -49,7 +108,9 @@ func TestMeasureSpeechDurationSeconds(t *testing.T) {
 		{"wav detected despite mp3 format hint", buildWAV(t, 24000, 1, 16, 0.5), "mp3", 0.5, true},
 		{"pcm half second", make([]byte, pcmBytesPerSecond/2), "pcm", 0.5, true},
 		{"pcm via mime", make([]byte, pcmBytesPerSecond), "audio/pcm", 1.0, true},
-		{"mp3 unmeasured", []byte("\xff\xfbnot really mp3"), "mp3", 0, false},
+		{"mp3 measured via frame walk", buildMP3(25), "mp3", 25 * mp3FrameSeconds, true},
+		{"mp3 via mime type", buildMP3(25), "audio/mpeg", 25 * mp3FrameSeconds, true},
+		{"mp3 with no valid frames", []byte("\xff\xfbnot really mp3"), "mp3", 0, false},
 		{"opus unmeasured", []byte("OggS....."), "opus", 0, false},
 		{"empty", nil, "wav", 0, false},
 		{"truncated riff", []byte("RIFF"), "wav", 0, false},

--- a/internal/usage/cost.go
+++ b/internal/usage/cost.go
@@ -210,7 +210,7 @@ func CalculateGranularCost(inputTokens, outputTokens int, rawData map[string]any
 	}
 
 	// Flag speech priced by output audio duration whose codec the gateway could
-	// not measure (compressed mp3/opus/aac/flac), so the cost reads as visibly
+	// not measure (opus/aac/flac), so the cost reads as visibly
 	// partial instead of a silent zero. Transcription rows never set the output
 	// format key, so per-second-output transcription models are unaffected.
 	if pricing.PerSecondOutput != nil {
@@ -270,7 +270,7 @@ func CalculateGranularCost(inputTokens, outputTokens int, rawData map[string]any
 // PerSecondOutput against synthesized audio seconds (text-to-speech) on the
 // output side. It returns the input and output costs and whether any rate
 // applied. Output duration is present only when the gateway could measure the
-// returned audio (uncompressed wav/pcm); compressed formats are flagged with a
+// returned audio (wav/pcm/mp3); other compressed formats are flagged with a
 // caveat by the caller instead.
 func applyAudioUnitCosts(rawData map[string]any, pricing *core.ModelPricing) (inputCost, outputCost float64, applied bool) {
 	if pricing.PerCharacterInput != nil {

--- a/tests/e2e/auditlog_test.go
+++ b/tests/e2e/auditlog_test.go
@@ -613,17 +613,17 @@ func TestAuditLogErrorCapture(t *testing.T) {
 		resp, err := http.Post(serverURL+"/v1/chat/completions", "application/json", bytes.NewReader(body))
 		require.NoError(t, err)
 		defer closeBody(resp)
-		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 
 		// Wait for log entry
 		entries := store.WaitForAPIEntries(1, 2*time.Second)
 		require.Len(t, entries, 1)
 
 		entry := entries[0]
-		assert.Equal(t, http.StatusBadRequest, entry.StatusCode)
+		assert.Equal(t, http.StatusNotFound, entry.StatusCode)
 		assert.Equal(t, "/v1/chat/completions", entry.Path)
 		assert.Equal(t, "unsupported-model-xyz", entry.RequestedModel)
-		assert.Equal(t, "invalid_request_error", entry.ErrorType)
+		assert.Equal(t, "not_found_error", entry.ErrorType)
 		assert.Equal(t, "", entry.Provider)
 	})
 

--- a/tests/e2e/chat_test.go
+++ b/tests/e2e/chat_test.go
@@ -398,7 +398,7 @@ func TestChatCompletionErrors(t *testing.T) {
 		})
 		defer closeBody(resp)
 
-		requireErrorResponse(t, resp, http.StatusBadRequest, core.ErrorTypeInvalidRequest, "unsupported model")
+		requireErrorResponse(t, resp, http.StatusNotFound, core.ErrorTypeNotFound, "unsupported model")
 	})
 }
 

--- a/tests/e2e/responses_test.go
+++ b/tests/e2e/responses_test.go
@@ -324,7 +324,7 @@ func TestResponsesErrors(t *testing.T) {
 		resp := sendResponsesRequest(t, payload)
 		defer closeBody(resp)
 
-		requireErrorResponse(t, resp, http.StatusBadRequest, core.ErrorTypeInvalidRequest, "unsupported model")
+		requireErrorResponse(t, resp, http.StatusNotFound, core.ErrorTypeNotFound, "unsupported model")
 	})
 }
 


### PR DESCRIPTION
## Summary

A ~130-test end-to-end pass over the gateway (all providers, streaming + non-streaming, audio, all three storage backends, with DB-level verification) surfaced five bugs. This PR fixes all of them; each fix was re-verified live against real providers.

### 1. Conversations now work with `/v1/responses`
`POST /v1/conversations` stores conversations locally, but `/v1/responses` forwarded the `conversation` field verbatim upstream — so every gateway-created conversation ID 404ed at the provider. The gateway now resolves conversations locally: stored history is prepended to the input at prepare time, the field is stripped before dispatch, and the completed exchange is appended back to the store (streamed turns included, via a stream observer on `response.completed`).

**User-visible impact:** conversations become usable at all — including with chat-translated providers (Anthropic, Groq, …) and even across providers within one conversation. Unknown IDs return OpenAI's 404 contract; `conversation` + `previous_response_id` together is rejected like OpenAI does; conversation turns bypass the exact response cache (a hit would serve a stale turn and skip the history append).

### 2. mp3 TTS output is now costed
Duration-priced TTS models (`gpt-4o-mini-tts`) are billed from measured output duration, but only WAV/PCM were measurable — and mp3 is OpenAI's **default** speech format, so the default path always recorded $0 cost. Added an MPEG Layer III frame-header walk (no decoding, exact for CBR and VBR, skips ID3 tags). Verified: gateway-measured 5.208s matches ffprobe exactly.

### 3. `MONGODB_URL` database path is honored
`mongodb://host:27017/mydb` silently wrote to the hardcoded `gomodel` database — even though `.env.template` shows the path form. Resolution now lives in one place in the storage layer: explicit `MONGODB_DATABASE` > URL path > `gomodel`. Removed the duplicated defaulting and unused `storage.DefaultConfig`.

### 4. Unknown models return 404 `model_not_found`
Previously 400 `invalid_request_error`; OpenAI returns 404 with code `model_not_found`, and clients key on that. Four duplicated error constructions collapsed into `core.NewModelNotFoundError`. Fallback detection (substring `not_found`/`unsupported`) is unaffected.

### 5. Audio capability mismatch (Groq / Gemini)
Only the OpenAI provider implemented `AudioProvider`, yet `/v1/models` advertised `groq/whisper-large-v3` and Gemini TTS models — calling them could only fail with 400.
- **Groq** now serves audio: its provider was ~200 lines hand-duplicating `openai.CompatibleProvider`; it is now a thin delegating wrapper (same capability surface plus the two audio methods). Groq whisper transcription verified live.
- **Listing honesty:** `ListPublicModels` skips audio-only models (modes exclusively `audio_speech`/`audio_transcription`) when the owning provider has no audio support. Models without mode metadata stay listed — missing data must not hide a model.

## Provider-specific behavior
- Conversation history is converted through the existing input-union shapes, so it works with native Responses providers and chat-translated ones alike; stored item IDs are stripped before dispatch so upstreams don't treat them as item references.
- Groq keeps Responses-via-chat translation; its router capability surface is unchanged apart from audio.

## Test plan
- [x] New unit tests: Mongo DB-name resolution (8 cases), mp3 duration (10 cases incl. ID3/junk/MPEG-1), conversation turns (5 tests: merge/strip/append, 404, previous_response_id rejection, ref shapes, streaming append), audio capability filter
- [x] Updated tests encoding the old 400-on-unknown-model contract to the new 404
- [x] Full suite: 53 packages pass (`go test ./...`), pre-commit `make test-race` passed
- [x] Live verification against real providers: multi-turn + cross-provider + streaming conversations, Groq whisper STT, TTS cost row in usage DB matching ffprobe duration, Mongo URL-path database, 404 error shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversation support for /v1/responses to merge history and append turns
  * MongoDB: MONGODB_DATABASE option to override DB from connection URL
  * Improved audio duration measurement with MP3 support for usage reporting

* **Bug Fixes**
  * Unsupported/unknown models now return 404 with code model_not_found
  * Audio-only models hidden for providers without audio support
  * MongoDB DB resolution now honors explicit setting and URL parsing

* **Documentation**
  * Clarified MongoDB configuration and DATABASE precedence in docs and template
<!-- end of auto-generated comment: release notes by coderabbit.ai -->