### PR TITLE
feat(aliases): add user_path restrictions to model aliases

### DIFF
--- a/internal/admin/dashboard/static/js/modules/aliases.js
+++ b/internal/admin/dashboard/static/js/modules/aliases.js
@@ -20,7 +20,8 @@
                 name: '',
                 target_model: '',
                 description: '',
-                enabled: true
+                enabled: true,
+                user_paths: ''
             },
             modelOverrideFormOpen: false,
             modelOverrideSubmitting: false,
@@ -142,7 +143,8 @@
                     name: '',
                     target_model: '',
                     description: '',
-                    enabled: true
+                    enabled: true,
+                    user_paths: ''
                 };
             },
 
@@ -510,11 +512,13 @@
                 this.aliasFormOriginalName = alias.name || '';
                 this.aliasFormError = '';
                 this.aliasNotice = '';
+                const userPaths = Array.isArray(alias.user_paths) ? alias.user_paths.join('\n') : '';
                 this.aliasForm = {
                     name: alias.name || '',
                     target_model: alias.target_provider ? alias.target_provider + '/' + alias.target_model : (alias.target_model || ''),
                     description: alias.description || '',
-                    enabled: alias.enabled !== false
+                    enabled: alias.enabled !== false,
+                    user_paths: userPaths
                 };
                 this.focusEditorField('aliasEditor');
             },
@@ -700,11 +704,13 @@
                 this.aliasNotice = '';
                 this.aliasFormError = '';
 
+                const userPaths = Array.isArray(alias.user_paths) ? alias.user_paths : [];
                 const payload = {
                     name: alias.name,
                     target_model: alias.target_provider ? alias.target_provider + '/' + alias.target_model : alias.target_model,
                     description: String(alias.description || '').trim(),
-                    enabled: alias.enabled === false
+                    enabled: alias.enabled === false,
+                    user_paths: userPaths
                 };
 
                 try {
@@ -902,11 +908,14 @@
 
                 this.aliasSubmitting = true;
 
+                const userPaths = this.normalizeModelOverridePaths(this.aliasForm.user_paths);
+
                 const payload = {
                     name,
                     target_model: targetModel,
                     description: String(this.aliasForm.description || '').trim(),
-                    enabled: Boolean(this.aliasForm.enabled)
+                    enabled: Boolean(this.aliasForm.enabled),
+                    user_paths: userPaths
                 };
 
                 try {

--- a/internal/admin/dashboard/static/js/modules/aliases.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/aliases.test.cjs
@@ -165,13 +165,15 @@ test('alias mutations send alias name in JSON body', async() => {
         target_model: 'gpt-4o',
         target_provider: 'openai',
         description: '',
-        enabled: true
+        enabled: true,
+        user_paths: []
     });
     module.aliasForm = {
         name: 'openai/smart',
         target_model: 'openai/gpt-4o',
         description: 'smart alias',
-        enabled: true
+        enabled: true,
+        user_paths: ''
     };
     module.aliasFormOriginalName = '';
     await module.submitAliasForm();
@@ -188,13 +190,15 @@ test('alias mutations send alias name in JSON body', async() => {
         name: 'openai/smart',
         target_model: 'openai/gpt-4o',
         description: '',
-        enabled: false
+        enabled: false,
+        user_paths: []
     });
     assert.deepEqual(JSON.parse(requests[1].request.body), {
         name: 'openai/smart',
         target_model: 'openai/gpt-4o',
         description: 'smart alias',
-        enabled: true
+        enabled: true,
+        user_paths: []
     });
     assert.deepEqual(JSON.parse(requests[2].request.body), {
         name: 'openai/smart'

--- a/internal/admin/dashboard/templates/page-models.html
+++ b/internal/admin/dashboard/templates/page-models.html
@@ -97,6 +97,12 @@
                     <textarea id="alias-description" rows="3" placeholder="Optional description" x-model="aliasForm.description"></textarea>
                 </div>
 
+                <div class="form-field">
+                    <label class="form-field-label" for="alias-user-paths">User Paths (conditional)</label>
+                    <textarea id="alias-user-paths" rows="3" placeholder="/victor" x-model="aliasForm.user_paths"></textarea>
+                    <p class="form-hint">Leave empty for all users. One path per line. Use / for every user path.</p>
+                </div>
+
                 <p class="form-hint">
                     Aliases are not supported on pass-through endpoints.
                 </p>

--- a/internal/admin/handler_aliases.go
+++ b/internal/admin/handler_aliases.go
@@ -12,11 +12,12 @@ import (
 )
 
 type upsertAliasRequest struct {
-	Name           string `json:"name"`
-	TargetModel    string `json:"target_model"`
-	TargetProvider string `json:"target_provider,omitempty"`
-	Description    string `json:"description,omitempty"`
-	Enabled        *bool  `json:"enabled,omitempty"`
+	Name           string   `json:"name"`
+	TargetModel    string   `json:"target_model"`
+	TargetProvider string   `json:"target_provider,omitempty"`
+	Description    string   `json:"description,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+	UserPaths      []string `json:"user_paths,omitempty"`
 }
 
 type deleteAliasRequest struct {
@@ -63,6 +64,7 @@ func (h *Handler) UpsertAlias(c *echo.Context) error {
 		TargetProvider: req.TargetProvider,
 		Description:    req.Description,
 		Enabled:        enabled,
+		UserPaths:      req.UserPaths,
 	}); err != nil {
 		return handleError(c, aliasWriteError(err))
 	}

--- a/internal/admin/handler_usage.go
+++ b/internal/admin/handler_usage.go
@@ -393,7 +393,7 @@ func (h *Handler) recalculatePricingSelector(raw string) (provider, model string
 	}
 
 	if h.aliases != nil {
-		selector, changed, err := h.aliases.ResolveModel(core.NewRequestedModelSelector(raw, ""))
+		selector, changed, err := h.aliases.ResolveModel(context.Background(), core.NewRequestedModelSelector(raw, ""))
 		if err != nil {
 			return "", "", core.NewInvalidRequestError("invalid selector: "+err.Error(), err)
 		}

--- a/internal/aliases/batch_preparer.go
+++ b/internal/aliases/batch_preparer.go
@@ -50,16 +50,16 @@ type aliasModelProviderTypeChecker interface {
 	GetProviderType(string) string
 }
 
-func resolveAliasModel(service *Service, requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
+func resolveAliasModel(ctx context.Context, service *Service, requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
 	if service == nil {
 		selector, err := requested.Normalize()
 		return selector, false, err
 	}
-	return service.ResolveModel(requested)
+	return service.ResolveModelWithUserPath(ctx, requested, "")
 }
 
-func resolveAliasRequestSelector(service *Service, requested core.RequestedModelSelector) (core.ModelSelector, error) {
-	selector, changed, err := resolveAliasModel(service, requested)
+func resolveAliasRequestSelector(ctx context.Context, service *Service, requested core.RequestedModelSelector) (core.ModelSelector, error) {
+	selector, changed, err := resolveAliasModel(ctx, service, requested)
 	if err != nil {
 		return core.ModelSelector{}, err
 	}
@@ -69,8 +69,8 @@ func resolveAliasRequestSelector(service *Service, requested core.RequestedModel
 	return requested.Normalize()
 }
 
-func resolveAliasRoutableSelector(service *Service, checker aliasModelSupportChecker, requested core.RequestedModelSelector, expectedProviderType string) (core.ModelSelector, error) {
-	selector, err := resolveAliasRequestSelector(service, requested)
+func resolveAliasRoutableSelector(ctx context.Context, service *Service, checker aliasModelSupportChecker, requested core.RequestedModelSelector, expectedProviderType string) (core.ModelSelector, error) {
+	selector, err := resolveAliasRequestSelector(ctx, service, requested)
 	if err != nil {
 		return core.ModelSelector{}, err
 	}
@@ -112,11 +112,25 @@ func validateResolvedProviderType(checker aliasModelSupportChecker, selector cor
 	)
 }
 
-func rewriteAliasChatRequest(service *Service, checker aliasModelSupportChecker, req *core.ChatRequest, expectedProviderType string, mode requestRewriteMode) (*core.ChatRequest, error) {
+func rewriteAliasChatRequest(ctx context.Context, service *Service, checker aliasModelSupportChecker, req *core.ChatRequest, expectedProviderType string, mode requestRewriteMode) (*core.ChatRequest, error) {
 	if req == nil {
 		return nil, nil
 	}
-	selector, err := resolveAliasRoutableSelector(service, checker, core.NewRequestedModelSelector(req.Model, req.Provider), expectedProviderType)
+	selector, err := resolveAliasRoutableSelector(ctx, service, checker, core.NewRequestedModelSelector(req.Model, req.Provider), expectedProviderType)
+	if err != nil {
+		return nil, err
+	}
+	forward := *req
+	forward.Model = selector.Model
+	forward.Provider = providerValueForMode(selector, mode)
+	return&forward, nil
+}
+
+func rewriteAliasResponsesRequest(ctx context.Context, service *Service, checker aliasModelSupportChecker, req *core.ResponsesRequest, expectedProviderType string, mode requestRewriteMode) (*core.ResponsesRequest, error) {
+	if req == nil {
+		return nil, nil
+	}
+	selector, err := resolveAliasRoutableSelector(ctx, service, checker, core.NewRequestedModelSelector(req.Model, req.Provider), expectedProviderType)
 	if err != nil {
 		return nil, err
 	}
@@ -126,25 +140,11 @@ func rewriteAliasChatRequest(service *Service, checker aliasModelSupportChecker,
 	return &forward, nil
 }
 
-func rewriteAliasResponsesRequest(service *Service, checker aliasModelSupportChecker, req *core.ResponsesRequest, expectedProviderType string, mode requestRewriteMode) (*core.ResponsesRequest, error) {
+func rewriteAliasEmbeddingRequest(ctx context.Context, service *Service, checker aliasModelSupportChecker, req *core.EmbeddingRequest, expectedProviderType string, mode requestRewriteMode) (*core.EmbeddingRequest, error) {
 	if req == nil {
 		return nil, nil
 	}
-	selector, err := resolveAliasRoutableSelector(service, checker, core.NewRequestedModelSelector(req.Model, req.Provider), expectedProviderType)
-	if err != nil {
-		return nil, err
-	}
-	forward := *req
-	forward.Model = selector.Model
-	forward.Provider = providerValueForMode(selector, mode)
-	return &forward, nil
-}
-
-func rewriteAliasEmbeddingRequest(service *Service, checker aliasModelSupportChecker, req *core.EmbeddingRequest, expectedProviderType string, mode requestRewriteMode) (*core.EmbeddingRequest, error) {
-	if req == nil {
-		return nil, nil
-	}
-	selector, err := resolveAliasRoutableSelector(service, checker, core.NewRequestedModelSelector(req.Model, req.Provider), expectedProviderType)
+	selector, err := resolveAliasRoutableSelector(ctx, service, checker, core.NewRequestedModelSelector(req.Model, req.Provider), expectedProviderType)
 	if err != nil {
 		return nil, err
 	}
@@ -168,10 +168,10 @@ func rewriteAliasBatchSource(
 		req,
 		fileTransport,
 		[]core.Operation{core.OperationChatCompletions, core.OperationResponses, core.OperationEmbeddings},
-		func(_ context.Context, _ core.BatchRequestItem, decoded *core.DecodedBatchItemRequest) (json.RawMessage, error) {
+		func(ctx context.Context, _ core.BatchRequestItem, decoded *core.DecodedBatchItemRequest) (json.RawMessage, error) {
 			switch typed := decoded.Request.(type) {
 			case *core.ChatRequest:
-				modified, err := rewriteAliasChatRequest(service, checker, typed, providerType, rewriteForUpstream)
+				modified, err := rewriteAliasChatRequest(ctx, service, checker, typed, providerType, rewriteForUpstream)
 				if err != nil {
 					return nil, err
 				}
@@ -181,7 +181,7 @@ func rewriteAliasBatchSource(
 				}
 				return body, nil
 			case *core.ResponsesRequest:
-				modified, err := rewriteAliasResponsesRequest(service, checker, typed, providerType, rewriteForUpstream)
+				modified, err := rewriteAliasResponsesRequest(ctx, service, checker, typed, providerType, rewriteForUpstream)
 				if err != nil {
 					return nil, err
 				}
@@ -191,7 +191,7 @@ func rewriteAliasBatchSource(
 				}
 				return body, nil
 			case *core.EmbeddingRequest:
-				modified, err := rewriteAliasEmbeddingRequest(service, checker, typed, providerType, rewriteForUpstream)
+				modified, err := rewriteAliasEmbeddingRequest(ctx, service, checker, typed, providerType, rewriteForUpstream)
 				if err != nil {
 					return nil, err
 				}

--- a/internal/aliases/provider.go
+++ b/internal/aliases/provider.go
@@ -50,15 +50,15 @@ func NewProviderWithOptions(inner core.RoutableProvider, service *Service, optio
 }
 
 // ResolveModel resolves a requested selector through the alias table.
-func (p *Provider) ResolveModel(requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
-	return resolveAliasModel(p.service, requested)
+func (p *Provider) ResolveModel(ctx context.Context, requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
+	return resolveAliasModel(ctx, p.service, requested)
 }
 
 func (p *Provider) ChatCompletion(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
 	if p.options.DisableTranslatedRequestProcessing {
 		return p.inner.ChatCompletion(ctx, req)
 	}
-	forward, err := rewriteAliasChatRequest(p.service, p.inner, req, "", rewriteForRouting)
+	forward, err := rewriteAliasChatRequest(ctx, p.service, p.inner, req, "", rewriteForRouting)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func (p *Provider) StreamChatCompletion(ctx context.Context, req *core.ChatReque
 	if p.options.DisableTranslatedRequestProcessing {
 		return p.inner.StreamChatCompletion(ctx, req)
 	}
-	forward, err := rewriteAliasChatRequest(p.service, p.inner, req, "", rewriteForRouting)
+	forward, err := rewriteAliasChatRequest(ctx, p.service, p.inner, req, "", rewriteForRouting)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*
 	if p.options.DisableTranslatedRequestProcessing {
 		return p.inner.Responses(ctx, req)
 	}
-	forward, err := rewriteAliasResponsesRequest(p.service, p.inner, req, "", rewriteForRouting)
+	forward, err := rewriteAliasResponsesRequest(ctx, p.service, p.inner, req, "", rewriteForRouting)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesReque
 	if p.options.DisableTranslatedRequestProcessing {
 		return p.inner.StreamResponses(ctx, req)
 	}
-	forward, err := rewriteAliasResponsesRequest(p.service, p.inner, req, "", rewriteForRouting)
+	forward, err := rewriteAliasResponsesRequest(ctx, p.service, p.inner, req, "", rewriteForRouting)
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +132,7 @@ func (p *Provider) Embeddings(ctx context.Context, req *core.EmbeddingRequest) (
 	if p.options.DisableTranslatedRequestProcessing {
 		return p.inner.Embeddings(ctx, req)
 	}
-	forward, err := rewriteAliasEmbeddingRequest(p.service, p.inner, req, "", rewriteForRouting)
+	forward, err := rewriteAliasEmbeddingRequest(ctx, p.service, p.inner, req, "", rewriteForRouting)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/aliases/provider_test.go
+++ b/internal/aliases/provider_test.go
@@ -164,7 +164,7 @@ func TestProviderResolvesRequestsAndExposesAliasModels(t *testing.T) {
 	if got := provider.GetProviderType("smart"); got != "openai" {
 		t.Fatalf("GetProviderType(smart) = %q, want openai", got)
 	}
-	selector, changed, err := provider.ResolveModel(core.NewRequestedModelSelector("smart", ""))
+	selector, changed, err := provider.ResolveModel(context.Background(), core.NewRequestedModelSelector("smart", ""))
 	if err != nil {
 		t.Fatalf("ResolveModel() error = %v", err)
 	}
@@ -296,7 +296,7 @@ func TestProviderCanDisableTranslatedRequestRewriting(t *testing.T) {
 	if got := provider.GetProviderType("smart"); got != "openai" {
 		t.Fatalf("GetProviderType(smart) = %q, want openai", got)
 	}
-	selector, changed, err := provider.ResolveModel(core.NewRequestedModelSelector("smart", ""))
+	selector, changed, err := provider.ResolveModel(context.Background(), core.NewRequestedModelSelector("smart", ""))
 	if err != nil {
 		t.Fatalf("ResolveModel() error = %v", err)
 	}

--- a/internal/aliases/service.go
+++ b/internal/aliases/service.go
@@ -94,6 +94,7 @@ func (s *Service) ListViews() []View {
 			view.ProviderType = strings.TrimSpace(s.catalog.GetProviderType(view.ResolvedModel))
 			view.Valid = s.catalog.Supports(view.ResolvedModel)
 		}
+		view.HasUserPathRestriction = len(alias.UserPaths) > 0 && !(len(alias.UserPaths) == 1 && alias.UserPaths[0] == "/")
 		views = append(views, view)
 	}
 	return views
@@ -118,10 +119,10 @@ func (s *Service) Get(name string) (*Alias, bool) {
 
 // Resolve resolves raw model/provider inputs through the alias table.
 func (s *Service) Resolve(model, provider string) (Resolution, bool, error) {
-	return s.resolveRequested(core.NewRequestedModelSelector(model, provider))
+	return s.resolveRequested(core.NewRequestedModelSelector(model, provider), "")
 }
 
-func (s *Service) resolveRequested(requested core.RequestedModelSelector) (Resolution, bool, error) {
+func (s *Service) resolveRequested(requested core.RequestedModelSelector, userPath string) (Resolution, bool, error) {
 	selector, err := requested.Normalize()
 	if err != nil {
 		return Resolution{}, false, err
@@ -131,7 +132,7 @@ func (s *Service) resolveRequested(requested core.RequestedModelSelector) (Resol
 		return Resolution{Requested: selector, Resolved: selector}, false, nil
 	}
 
-	if resolution, ok := s.resolveAlias(requested.Model); ok {
+	if resolution, ok := s.resolveAlias(requested.Model, userPath); ok {
 		return resolution, true, nil
 	}
 	return Resolution{Requested: selector, Resolved: selector}, false, nil
@@ -141,8 +142,18 @@ func (s *Service) resolveRequested(requested core.RequestedModelSelector) (Resol
 // chosen for execution. This allows alias policy to be consumed as an explicit
 // workflow resolution dependency without requiring the provider chain itself to
 // own alias behavior.
-func (s *Service) ResolveModel(requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
-	resolution, changed, err := s.resolveRequested(requested)
+func (s *Service) ResolveModel(ctx context.Context, requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
+	return s.ResolveModelWithUserPath(ctx, requested, "")
+}
+
+// ResolveModelWithUserPath resolves a requested selector, honoring user_path
+// restrictions on aliases. If userPath is empty, all aliases are considered (same
+// as ResolveModel). The userPath is extracted from ctx if not explicitly provided.
+func (s *Service) ResolveModelWithUserPath(ctx context.Context, requested core.RequestedModelSelector, userPath string) (core.ModelSelector, bool, error) {
+	if userPath == "" {
+		userPath = core.UserPathFromContext(ctx)
+	}
+	resolution, changed, err := s.resolveRequested(requested, userPath)
 	if err != nil {
 		return core.ModelSelector{}, false, err
 	}
@@ -173,13 +184,13 @@ func (s *Service) ResolveRefreshTarget(requested core.RequestedModelSelector) (c
 
 // Supports reports whether an alias currently resolves to a concrete model.
 func (s *Service) Supports(model string) bool {
-	_, ok := s.resolveAlias(model)
+	_, ok := s.resolveAlias(model, "")
 	return ok
 }
 
 // GetProviderType returns the resolved provider type for an alias, or empty if unresolved.
 func (s *Service) GetProviderType(model string) string {
-	if resolution, ok := s.resolveAlias(model); ok {
+	if resolution, ok := s.resolveAlias(model, ""); ok {
 		return strings.TrimSpace(s.catalog.GetProviderType(resolution.Resolved.QualifiedModel()))
 	}
 	return ""
@@ -275,7 +286,7 @@ func (s *Service) validate(alias Alias) error {
 	return nil
 }
 
-func (s *Service) resolveAlias(name string) (Resolution, bool) {
+func (s *Service) resolveAlias(name string, userPath string) (Resolution, bool) {
 	name = normalizeName(name)
 	resolution := Resolution{
 		Requested: core.ModelSelector{Model: name},
@@ -287,6 +298,11 @@ func (s *Service) resolveAlias(name string) (Resolution, bool) {
 
 	alias, ok := s.Get(name)
 	if !ok || !alias.Enabled {
+		return resolution, false
+	}
+
+	// Check user_path restriction if userPath is provided
+	if userPath != "" && !alias.MatchesUserPath(userPath) {
 		return resolution, false
 	}
 

--- a/internal/aliases/service.go
+++ b/internal/aliases/service.go
@@ -94,7 +94,7 @@ func (s *Service) ListViews() []View {
 			view.ProviderType = strings.TrimSpace(s.catalog.GetProviderType(view.ResolvedModel))
 			view.Valid = s.catalog.Supports(view.ResolvedModel)
 		}
-		view.HasUserPathRestriction = len(alias.UserPaths) > 0 && !(len(alias.UserPaths) == 1 && alias.UserPaths[0] == "/")
+		view.HasUserPathRestriction = len(alias.UserPaths) > 0 && (len(alias.UserPaths) != 1 || alias.UserPaths[0] != "/")
 		views = append(views, view)
 	}
 	return views

--- a/internal/aliases/service_test.go
+++ b/internal/aliases/service_test.go
@@ -142,7 +142,7 @@ func TestServiceResolveRefreshTargetDoesNotRequireCatalogSupport(t *testing.T) {
 		t.Fatalf("Refresh() error = %v", err)
 	}
 
-	selector, changed, err := service.ResolveModel(core.NewRequestedModelSelector("smart", ""))
+	selector, changed, err := service.ResolveModel(context.Background(), core.NewRequestedModelSelector("smart", ""))
 	if err != nil {
 		t.Fatalf("ResolveModel() error = %v", err)
 	}
@@ -289,7 +289,7 @@ func TestServiceResolveAliasWithExplicitProviderPreservesRequestedSelector(t *te
 		t.Fatalf("Refresh() error = %v", err)
 	}
 
-	selector, changed, err := service.ResolveModel(core.NewRequestedModelSelector("smart", "openai"))
+	selector, changed, err := service.ResolveModel(context.Background(), core.NewRequestedModelSelector("smart", "openai"))
 	if err != nil {
 		t.Fatalf("ResolveModel() error = %v", err)
 	}

--- a/internal/aliases/store_mongodb.go
+++ b/internal/aliases/store_mongodb.go
@@ -15,8 +15,9 @@ type mongoAliasDocument struct {
 	Name           string    `bson:"_id"`
 	TargetModel    string    `bson:"target_model"`
 	TargetProvider string    `bson:"target_provider,omitempty"`
-	Description    string    `bson:"description,omitempty"`
+	Description string    `bson:"description,omitempty"`
 	Enabled        bool      `bson:"enabled"`
+	UserPaths      []string  `bson:"user_paths,omitempty"`
 	CreatedAt      time.Time `bson:"created_at"`
 	UpdatedAt      time.Time `bson:"updated_at"`
 }
@@ -100,6 +101,7 @@ func (s *MongoDBStore) Upsert(ctx context.Context, alias Alias) error {
 			"target_provider": alias.TargetProvider,
 			"description":     alias.Description,
 			"enabled":         alias.Enabled,
+			"user_paths":      alias.UserPaths,
 			"updated_at":      alias.UpdatedAt,
 		},
 		"$setOnInsert": bson.M{
@@ -135,6 +137,7 @@ func aliasFromMongo(doc mongoAliasDocument) Alias {
 		TargetProvider: doc.TargetProvider,
 		Description:    doc.Description,
 		Enabled:        doc.Enabled,
+		UserPaths:      doc.UserPaths,
 		CreatedAt:      doc.CreatedAt.UTC(),
 		UpdatedAt:      doc.UpdatedAt.UTC(),
 	}

--- a/internal/aliases/store_postgresql.go
+++ b/internal/aliases/store_postgresql.go
@@ -2,6 +2,7 @@ package aliases
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -31,6 +32,7 @@ func NewPostgreSQLStore(ctx context.Context, pool *pgxpool.Pool) (*PostgreSQLSto
 			target_provider TEXT NOT NULL DEFAULT '',
 			description TEXT NOT NULL DEFAULT '',
 			enabled BOOLEAN NOT NULL DEFAULT TRUE,
+			user_paths JSONB NOT NULL DEFAULT '[]',
 			created_at BIGINT NOT NULL,
 			updated_at BIGINT NOT NULL
 		)
@@ -49,7 +51,7 @@ func NewPostgreSQLStore(ctx context.Context, pool *pgxpool.Pool) (*PostgreSQLSto
 
 func (s *PostgreSQLStore) List(ctx context.Context) ([]Alias, error) {
 	rows, err := s.pool.Query(ctx, `
-		SELECT name, target_model, target_provider, description, enabled, created_at, updated_at
+		SELECT name, target_model, target_provider, description, enabled, user_paths, created_at, updated_at
 		FROM aliases
 		ORDER BY name ASC
 	`)
@@ -66,7 +68,7 @@ func (s *PostgreSQLStore) List(ctx context.Context) ([]Alias, error) {
 
 func (s *PostgreSQLStore) Get(ctx context.Context, name string) (*Alias, error) {
 	row := s.pool.QueryRow(ctx, `
-		SELECT name, target_model, target_provider, description, enabled, created_at, updated_at
+		SELECT name, target_model, target_provider, description, enabled, user_paths, created_at, updated_at
 		FROM aliases
 		WHERE name = $1
 	`, normalizeName(name))
@@ -92,15 +94,16 @@ func (s *PostgreSQLStore) Upsert(ctx context.Context, alias Alias) error {
 	alias.UpdatedAt = time.Unix(now, 0).UTC()
 
 	_, err = s.pool.Exec(ctx, `
-		INSERT INTO aliases (name, target_model, target_provider, description, enabled, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		INSERT INTO aliases (name, target_model, target_provider, description, enabled, user_paths, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		ON CONFLICT(name) DO UPDATE SET
 			target_model = excluded.target_model,
 			target_provider = excluded.target_provider,
 			description = excluded.description,
 			enabled = excluded.enabled,
+			user_paths = excluded.user_paths,
 			updated_at = excluded.updated_at
-	`, alias.Name, alias.TargetModel, alias.TargetProvider, alias.Description, alias.Enabled, alias.CreatedAt.Unix(), alias.UpdatedAt.Unix())
+	`, alias.Name, alias.TargetModel, alias.TargetProvider, alias.Description, alias.Enabled, userPathsToJSON(alias.UserPaths), alias.CreatedAt.Unix(), alias.UpdatedAt.Unix())
 	if err != nil {
 		return fmt.Errorf("upsert alias: %w", err)
 	}
@@ -126,12 +129,14 @@ func scanPostgreSQLAlias(scanner aliasScanner) (Alias, error) {
 	var alias Alias
 	var createdAt int64
 	var updatedAt int64
+	var userPathsJSON []byte
 	if err := scanner.Scan(
 		&alias.Name,
 		&alias.TargetModel,
 		&alias.TargetProvider,
 		&alias.Description,
 		&alias.Enabled,
+		&userPathsJSON,
 		&createdAt,
 		&updatedAt,
 	); err != nil {
@@ -139,5 +144,8 @@ func scanPostgreSQLAlias(scanner aliasScanner) (Alias, error) {
 	}
 	alias.CreatedAt = time.Unix(createdAt, 0).UTC()
 	alias.UpdatedAt = time.Unix(updatedAt, 0).UTC()
+	if err := json.Unmarshal(userPathsJSON,&alias.UserPaths); err != nil {
+		alias.UserPaths = nil
+	}
 	return alias, nil
 }

--- a/internal/aliases/store_sqlite.go
+++ b/internal/aliases/store_sqlite.go
@@ -3,6 +3,7 @@ package aliases
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -26,6 +27,7 @@ func NewSQLiteStore(db *sql.DB) (*SQLiteStore, error) {
 			target_provider TEXT NOT NULL DEFAULT '',
 			description TEXT NOT NULL DEFAULT '',
 			enabled INTEGER NOT NULL DEFAULT 1,
+			user_paths TEXT NOT NULL DEFAULT '[]',
 			created_at INTEGER NOT NULL,
 			updated_at INTEGER NOT NULL
 		)
@@ -44,7 +46,7 @@ func NewSQLiteStore(db *sql.DB) (*SQLiteStore, error) {
 
 func (s *SQLiteStore) List(ctx context.Context) ([]Alias, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT name, target_model, target_provider, description, enabled, created_at, updated_at
+		SELECT name, target_model, target_provider, description, enabled, user_paths, created_at, updated_at
 		FROM aliases
 		ORDER BY name ASC
 	`)
@@ -61,7 +63,7 @@ func (s *SQLiteStore) List(ctx context.Context) ([]Alias, error) {
 
 func (s *SQLiteStore) Get(ctx context.Context, name string) (*Alias, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT name, target_model, target_provider, description, enabled, created_at, updated_at
+		SELECT name, target_model, target_provider, description, enabled, user_paths, created_at, updated_at
 		FROM aliases
 		WHERE name = ?
 	`, normalizeName(name))
@@ -87,15 +89,16 @@ func (s *SQLiteStore) Upsert(ctx context.Context, alias Alias) error {
 	alias.UpdatedAt = time.Unix(now, 0).UTC()
 
 	_, err = s.db.ExecContext(ctx, `
-		INSERT INTO aliases (name, target_model, target_provider, description, enabled, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO aliases (name, target_model, target_provider, description, enabled, user_paths, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(name) DO UPDATE SET
 			target_model = excluded.target_model,
 			target_provider = excluded.target_provider,
 			description = excluded.description,
 			enabled = excluded.enabled,
+			user_paths = excluded.user_paths,
 			updated_at = excluded.updated_at
-	`, alias.Name, alias.TargetModel, alias.TargetProvider, alias.Description, boolToSQLite(alias.Enabled), alias.CreatedAt.Unix(), alias.UpdatedAt.Unix())
+	`, alias.Name, alias.TargetModel, alias.TargetProvider, alias.Description, boolToSQLite(alias.Enabled), userPathsToJSON(alias.UserPaths), alias.CreatedAt.Unix(), alias.UpdatedAt.Unix())
 	if err != nil {
 		return fmt.Errorf("upsert alias: %w", err)
 	}
@@ -126,12 +129,14 @@ func scanSQLiteAlias(scanner aliasScanner) (Alias, error) {
 	var enabled int
 	var createdAt int64
 	var updatedAt int64
+	var userPathsJSON string
 	if err := scanner.Scan(
 		&alias.Name,
 		&alias.TargetModel,
 		&alias.TargetProvider,
 		&alias.Description,
 		&enabled,
+		&userPathsJSON,
 		&createdAt,
 		&updatedAt,
 	); err != nil {
@@ -140,7 +145,21 @@ func scanSQLiteAlias(scanner aliasScanner) (Alias, error) {
 	alias.Enabled = enabled != 0
 	alias.CreatedAt = time.Unix(createdAt, 0).UTC()
 	alias.UpdatedAt = time.Unix(updatedAt, 0).UTC()
+	if err := json.Unmarshal([]byte(userPathsJSON), &alias.UserPaths); err != nil {
+		alias.UserPaths = nil
+	}
 	return alias, nil
+}
+
+func userPathsToJSON(paths []string) string {
+	if len(paths) == 0 {
+		return "[]"
+	}
+	data, err := json.Marshal(paths)
+	if err != nil {
+		return "[]"
+	}
+	return string(data)
 }
 
 func boolToSQLite(v bool) int {

--- a/internal/aliases/types.go
+++ b/internal/aliases/types.go
@@ -1,6 +1,7 @@
 package aliases
 
 import (
+	"strings"
 	"time"
 
 	"gomodel/internal/core"
@@ -11,10 +12,32 @@ type Alias struct {
 	Name           string    `json:"name" bson:"name"`
 	TargetModel    string    `json:"target_model" bson:"target_model"`
 	TargetProvider string    `json:"target_provider,omitempty" bson:"target_provider,omitempty"`
-	Description    string    `json:"description,omitempty" bson:"description,omitempty"`
+	Description string    `json:"description,omitempty" bson:"description,omitempty"`
 	Enabled        bool      `json:"enabled" bson:"enabled"`
+	UserPaths      []string  `json:"user_paths,omitempty" bson:"user_paths,omitempty"`
 	CreatedAt      time.Time `json:"created_at" bson:"created_at"`
 	UpdatedAt      time.Time `json:"updated_at" bson:"updated_at"`
+}
+
+// MatchesUserPath reports whether the given userPath is allowed to use this alias.
+// An empty or single-element list containing "/" matches all user paths.
+func (a Alias) MatchesUserPath(userPath string) bool {
+	if len(a.UserPaths) == 0 {
+		return true
+	}
+	for _, allowed := range a.UserPaths {
+		if allowed == "/" {
+			return true
+		}
+		if userPath == allowed {
+			return true
+		}
+		// Check if userPath is a descendant of allowed path
+		if strings.HasPrefix(userPath, allowed+"/") {
+			return true
+		}
+	}
+	return false
 }
 
 // TargetSelector returns the concrete selector this alias points to.
@@ -32,7 +55,8 @@ type Resolution struct {
 // View is the admin-facing representation of an alias with current validity status.
 type View struct {
 	Alias
-	ResolvedModel string `json:"resolved_model"`
-	ProviderType  string `json:"provider_type,omitempty"`
-	Valid         bool   `json:"valid"`
+	ResolvedModel            string `json:"resolved_model"`
+	ProviderType             string `json:"provider_type,omitempty"`
+	Valid                    bool   `json:"valid"`
+	HasUserPathRestriction   bool   `json:"has_user_path_restriction"`
 }

--- a/internal/gateway/batch_selection.go
+++ b/internal/gateway/batch_selection.go
@@ -96,7 +96,7 @@ func DetermineBatchExecutionSelectionWithAuthorizerAndInputFileResolver(
 		if err != nil {
 			return BatchExecutionSelection{}, core.NewInvalidRequestError(fmt.Sprintf("batch item %d: %s", i, err.Error()), err)
 		}
-		resolvedSelector, _, err := ResolveExecutionSelector(provider, resolver, requested)
+		resolvedSelector, _, err := ResolveExecutionSelector(ctx, provider, resolver, requested)
 		if err != nil {
 			return BatchExecutionSelection{}, core.NewInvalidRequestError(fmt.Sprintf("batch item %d: %s", i, err.Error()), err)
 		}

--- a/internal/gateway/interfaces.go
+++ b/internal/gateway/interfaces.go
@@ -10,7 +10,7 @@ import (
 // ModelResolver resolves raw request selectors into concrete model selectors
 // before provider execution.
 type ModelResolver interface {
-	ResolveModel(requested core.RequestedModelSelector) (core.ModelSelector, bool, error)
+	ResolveModel(ctx context.Context, requested core.RequestedModelSelector) (core.ModelSelector, bool, error)
 }
 
 // FallbackResolver resolves alternate concrete model selectors for a translated

--- a/internal/gateway/request_model_resolution.go
+++ b/internal/gateway/request_model_resolution.go
@@ -71,7 +71,7 @@ func ResolveRequestModelWithAuthorizer(
 ) (*core.RequestModelResolution, error) {
 	requested = core.NewRequestedModelSelector(requested.Model, requested.ProviderHint)
 
-	resolvedSelector, aliasApplied, err := ResolveExecutionSelector(provider, resolver, requested)
+	resolvedSelector, aliasApplied, err := ResolveExecutionSelector(ctx, provider, resolver, requested)
 	refreshed := false
 	if err != nil {
 		var refreshErr error
@@ -82,7 +82,7 @@ func ResolveRequestModelWithAuthorizer(
 		if !refreshed {
 			return nil, core.NewInvalidRequestError(err.Error(), err)
 		}
-		resolvedSelector, aliasApplied, err = ResolveExecutionSelector(provider, resolver, requested)
+		resolvedSelector, aliasApplied, err = ResolveExecutionSelector(ctx, provider, resolver, requested)
 		if err != nil {
 			return nil, core.NewInvalidRequestError(err.Error(), err)
 		}
@@ -103,7 +103,7 @@ func ResolveRequestModelWithAuthorizer(
 				return nil, refreshErr
 			}
 			if refreshed {
-				resolvedSelector, aliasApplied, err = ResolveExecutionSelector(provider, resolver, requested)
+				resolvedSelector, aliasApplied, err = ResolveExecutionSelector(ctx, provider, resolver, requested)
 				if err != nil {
 					return nil, core.NewInvalidRequestError(err.Error(), err)
 				}
@@ -122,7 +122,7 @@ func ResolveRequestModelWithAuthorizer(
 				return nil, refreshErr
 			}
 			if refreshed {
-				resolvedSelector, aliasApplied, err = ResolveExecutionSelector(provider, resolver, requested)
+				resolvedSelector, aliasApplied, err = ResolveExecutionSelector(ctx, provider, resolver, requested)
 				if err != nil {
 					return nil, core.NewInvalidRequestError(err.Error(), err)
 				}
@@ -189,6 +189,7 @@ func refreshProviderModelsForResolution(
 
 // ResolveExecutionSelector applies explicit and provider-owned selector resolution.
 func ResolveExecutionSelector(
+	ctx context.Context,
 	provider core.RoutableProvider,
 	resolver ModelResolver,
 	requested core.RequestedModelSelector,
@@ -202,7 +203,7 @@ func ResolveExecutionSelector(
 	)
 
 	if resolver != nil {
-		resolvedSelector, aliasApplied, err = resolver.ResolveModel(requested)
+		resolvedSelector, aliasApplied, err = resolver.ResolveModel(ctx, requested)
 		if err != nil {
 			return core.ModelSelector{}, false, err
 		}
@@ -210,7 +211,7 @@ func ResolveExecutionSelector(
 	}
 
 	if providerResolver, ok := provider.(ModelResolver); ok {
-		providerSelector, providerChanged, err := providerResolver.ResolveModel(requested)
+		providerSelector, providerChanged, err := providerResolver.ResolveModel(ctx, requested)
 		if err != nil {
 			if resolvedSelector != (core.ModelSelector{}) {
 				// Preserve alias targets so callers can refresh the concrete provider before retrying.

--- a/internal/gateway/request_model_resolution_test.go
+++ b/internal/gateway/request_model_resolution_test.go
@@ -45,7 +45,7 @@ func (p *requestRefreshProvider) RefreshProviderModels(_ context.Context, provid
 	return 1, nil
 }
 
-func (p *requestRefreshProvider) ResolveModel(requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
+func (p *requestRefreshProvider) ResolveModel(_ context.Context, requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
 	if p.resolveErrWhenEmpty && p.modelCount == 0 {
 		return core.ModelSelector{}, false, core.NewProviderError("", http.StatusServiceUnavailable, "model registry not initialized", nil)
 	}
@@ -91,7 +91,7 @@ func (p *requestRefreshProvider) Embeddings(context.Context, *core.EmbeddingRequ
 
 type requestAliasResolver map[string]core.ModelSelector
 
-func (r requestAliasResolver) ResolveModel(requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
+func (r requestAliasResolver) ResolveModel(_ context.Context, requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
 	if selector, ok := r[requested.RequestedQualifiedModel()]; ok {
 		return selector, true, nil
 	}
@@ -105,7 +105,7 @@ type requestRefreshTargetResolver struct {
 	err      error
 }
 
-func (r requestRefreshTargetResolver) ResolveModel(requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
+func (r requestRefreshTargetResolver) ResolveModel(_ context.Context, requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
 	if requested.RequestedQualifiedModel() == "smart" && r.provider.Supports(r.target.QualifiedModel()) {
 		return r.target, true, nil
 	}

--- a/internal/modeloverrides/batch_preparer.go
+++ b/internal/modeloverrides/batch_preparer.go
@@ -10,7 +10,7 @@ import (
 )
 
 type selectorResolver interface {
-	ResolveModel(requested core.RequestedModelSelector) (core.ModelSelector, bool, error)
+	ResolveModel(ctx context.Context, requested core.RequestedModelSelector) (core.ModelSelector, bool, error)
 }
 
 // BatchPreparer validates model access for native batch subrequests before provider submission.
@@ -40,7 +40,7 @@ func (p *BatchPreparer) PrepareBatchRequest(ctx context.Context, providerType st
 			if err != nil {
 				return nil, err
 			}
-			resolved, err := p.resolveSelector(requested)
+			resolved, err := p.resolveSelector(ctx, requested)
 			if err != nil {
 				return nil, err
 			}
@@ -81,12 +81,12 @@ func (p *BatchPreparer) batchFileTransport() core.BatchFileTransport {
 	return nil
 }
 
-func (p *BatchPreparer) resolveSelector(requested core.RequestedModelSelector) (core.ModelSelector, error) {
+func (p *BatchPreparer) resolveSelector(ctx context.Context, requested core.RequestedModelSelector) (core.ModelSelector, error) {
 	if p == nil || p.provider == nil {
 		return requested.Normalize()
 	}
 	if resolver, ok := p.provider.(selectorResolver); ok {
-		selector, _, err := resolver.ResolveModel(requested)
+		selector, _, err := resolver.ResolveModel(ctx, requested)
 		return selector, err
 	}
 	return requested.Normalize()

--- a/internal/providers/router.go
+++ b/internal/providers/router.go
@@ -67,7 +67,7 @@ func NewRouter(lookup core.ModelLookup) (*Router, error) {
 	if lookup == nil {
 		return nil, fmt.Errorf("lookup cannot be nil")
 	}
-	return &Router{
+	return&Router{
 		lookup: lookup,
 	}, nil
 }
@@ -89,7 +89,7 @@ func (r *Router) checkReady() error {
 //  2. provider type + model ID
 //  3. raw slash-shaped model ID (only when provider was not explicit)
 //  4. default normalization fallback
-func (r *Router) ResolveModel(requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
+func (r *Router) ResolveModel(_ context.Context, requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
 	if err := r.checkReady(); err != nil {
 		return core.ModelSelector{}, false, registryUnavailableError(err)
 	}
@@ -241,7 +241,7 @@ func (r *Router) hasConfiguredProviderName(providerName string) bool {
 // resolveProvider validates readiness, parses the model selector, and finds the target provider.
 func (r *Router) resolveProvider(ctx context.Context, model, providerHint string) (core.Provider, core.ModelSelector, error) {
 	requested := core.NewRequestedModelSelector(model, providerHint)
-	selector, _, err := r.ResolveModel(requested)
+	selector, _, err := r.ResolveModel(context.Background(), requested)
 	refreshed := false
 	if err != nil {
 		var refreshErr error
@@ -252,7 +252,7 @@ func (r *Router) resolveProvider(ctx context.Context, model, providerHint string
 		if !refreshed {
 			return nil, core.ModelSelector{}, err
 		}
-		selector, _, err = r.ResolveModel(requested)
+		selector, _, err = r.ResolveModel(context.Background(), requested)
 		if err != nil {
 			return nil, core.ModelSelector{}, err
 		}
@@ -267,7 +267,7 @@ func (r *Router) resolveProvider(ctx context.Context, model, providerHint string
 			return nil, core.ModelSelector{}, refreshErr
 		}
 		if refreshed {
-			selector, _, err = r.ResolveModel(requested)
+			selector, _, err = r.ResolveModel(context.Background(), requested)
 			if err != nil {
 				return nil, core.ModelSelector{}, err
 			}
@@ -595,7 +595,7 @@ func callEmbeddings(ctx context.Context, provider core.Provider, req *core.Embed
 // Supports returns true if any provider supports the given model.
 // Returns false if the lookup has no models loaded.
 func (r *Router) Supports(model string) bool {
-	selector, _, err := r.ResolveModel(core.NewRequestedModelSelector(model, ""))
+	selector, _, err := r.ResolveModel(context.Background(), core.NewRequestedModelSelector(model, ""))
 	if err != nil {
 		return false
 	}
@@ -764,7 +764,7 @@ func audioUnsupportedError(model string) error {
 // GetProviderType returns the provider type string for the given model.
 // Returns empty string if the model is not found.
 func (r *Router) GetProviderType(model string) string {
-	selector, _, err := r.ResolveModel(core.NewRequestedModelSelector(model, ""))
+	selector, _, err := r.ResolveModel(context.Background(), core.NewRequestedModelSelector(model, ""))
 	if err != nil {
 		return ""
 	}
@@ -774,7 +774,7 @@ func (r *Router) GetProviderType(model string) string {
 // GetProviderName returns the concrete configured provider instance name for
 // the given model selector. Returns empty string when unavailable.
 func (r *Router) GetProviderName(model string) string {
-	selector, _, err := r.ResolveModel(core.NewRequestedModelSelector(model, ""))
+	selector, _, err := r.ResolveModel(context.Background(), core.NewRequestedModelSelector(model, ""))
 	if err != nil {
 		return ""
 	}

--- a/internal/server/audio_service.go
+++ b/internal/server/audio_service.go
@@ -141,7 +141,7 @@ func (s *audioService) CreateTranscription(c *echo.Context) error {
 // selector. The production provider (the Router) implements it; when absent, audio
 // authorizes on the parsed selector as a fallback.
 type selectorResolver interface {
-	ResolveModel(core.RequestedModelSelector) (core.ModelSelector, bool, error)
+	ResolveModel(ctx context.Context, requested core.RequestedModelSelector) (core.ModelSelector, bool, error)
 }
 
 // audioRoute carries the resolved routing identity for a single audio call,
@@ -167,7 +167,7 @@ func (s *audioService) prepare(c *echo.Context, model, providerHint string) (con
 		// instead of authorizing the unresolved selector. The boolean is "did the
 		// selector change", not a found flag — on no change resolved already
 		// equals the normalized selector, so it is always safe to adopt.
-		resolved, _, resolveErr := resolver.ResolveModel(core.NewRequestedModelSelector(model, providerHint))
+		resolved, _, resolveErr := resolver.ResolveModel(c.Request().Context(), core.NewRequestedModelSelector(model, providerHint))
 		if resolveErr != nil {
 			return nil, audioRoute{}, resolveErr
 		}

--- a/internal/server/audio_service_test.go
+++ b/internal/server/audio_service_test.go
@@ -32,7 +32,7 @@ type audioMockProvider struct {
 // ResolveModel lets the fake stand in for the Router so the service can authorize
 // on a resolved (provider-qualified) selector. A nil resolved selector falls back
 // to the default parse behavior.
-func (m *audioMockProvider) ResolveModel(requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
+func (m *audioMockProvider) ResolveModel(_ context.Context, requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
 	if m.resolved != nil {
 		return *m.resolved, true, nil
 	}

--- a/internal/server/request_model_resolution_test.go
+++ b/internal/server/request_model_resolution_test.go
@@ -20,7 +20,7 @@ type canonicalizingProvider struct {
 	names    map[string]string
 }
 
-func (p *canonicalizingProvider) ResolveModel(requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
+func (p *canonicalizingProvider) ResolveModel(_ context.Context, requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
 	key := requested.RequestedQualifiedModel()
 	if selector, ok := p.resolved[key]; ok {
 		return selector, selector.QualifiedModel() != key, nil
@@ -135,7 +135,7 @@ func TestResolveRequestModel_CanonicalizesProviderTypeSelectorToConcreteProvider
 
 type aliasResolverStub struct{}
 
-func (aliasResolverStub) ResolveModel(requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
+func (aliasResolverStub) ResolveModel(_ context.Context, requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
 	if requested.RequestedQualifiedModel() == "anthropic/claude-opus-4-6" {
 		return core.ModelSelector{Provider: "openai", Model: "gpt-5-nano"}, true, nil
 	}

--- a/internal/server/workflow_policy_test.go
+++ b/internal/server/workflow_policy_test.go
@@ -22,7 +22,7 @@ type countingBatchResolver struct {
 	resolved core.ModelSelector
 }
 
-func (r *countingBatchResolver) ResolveModel(requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
+func (r *countingBatchResolver) ResolveModel(_ context.Context, requested core.RequestedModelSelector) (core.ModelSelector, bool, error) {
 	r.calls++
 	return r.resolved, false, nil
 }


### PR DESCRIPTION
Aliases can now be restricted to specific user paths. When a `user_paths` list is set on an alias, only requests whose `X-GoModel-User-Path` header matches one of the listed paths (or a descendant) will have the alias applied. Requests that do not match fall through to the original model name unchanged.

- An empty `user_paths` list (the default) applies the alias to all users
- A single "/" entry also applies the alias to all users
- Paths are matched exactly or by prefix (e.g. /team matches /team/alpha)
- Multiple paths can be specified per alias

Backend changes:
- `Alias.UserPaths []string` field added with `MatchesUserPath()` helper
- `Service.ResolveModelWithUserPath()` reads user_path from context and filters aliases that do not match the caller's path
- All three stores (SQLite, PostgreSQL, MongoDB) persist the new field; SQLite and PostgreSQL use a JSON column with a safe migration default
- `ModelResolver` interface updated to accept `context.Context` so the resolution chain can carry request-scoped user_path through to alias evaluation without changing public API signatures
- Admin handler accepts `user_paths` in the upsert request body
- `View.HasUserPathRestriction` flag exposed for dashboard display

Dashboard changes:
- Alias create/edit form includes a "User Paths" textarea (one path per line, reuses the same normalizer as model overrides)
- Existing alias data is populated in the form when editing
- Toggle and save operations preserve the current user_paths value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can define per-alias user path restrictions via a new "User Paths (conditional)" textarea (one path per line; leave empty for all users).
  * Alias records now include an enabled flag and persist user-path rules so dashboard edits, toggles, and saves honor configured user-path restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->