### PR TITLE
fix(cache): route go-redis internal logs through slog

### DIFF
--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -29,6 +29,7 @@ type RedisStore struct {
 
 // NewRedisStore creates a Redis-based key-value store.
 func NewRedisStore(cfg RedisStoreConfig) (*RedisStore, error) {
+	installRedisLogger()
 	opts, err := redis.ParseURL(cfg.URL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid redis URL: %w", err)

--- a/internal/cache/redis_logger.go
+++ b/internal/cache/redis_logger.go
@@ -1,0 +1,28 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// installRedisLogger routes go-redis's package-level internal logger through
+// slog, so its connection-pool and pubsub diagnostics honor the application's
+// configured log format and level instead of writing raw lines straight to
+// stderr. go-redis exposes only one process-global logger, so this is set once.
+var installRedisLogger = sync.OnceFunc(func() {
+	redis.SetLogger(slogRedisLogger{})
+})
+
+// slogRedisLogger adapts go-redis's internal.Logging interface to slog. go-redis
+// uses this logger for non-fatal operational diagnostics, so messages are
+// emitted at warn level; the higher-level operation that triggered them is
+// logged separately by the caller.
+type slogRedisLogger struct{}
+
+func (slogRedisLogger) Printf(ctx context.Context, format string, v ...any) {
+	slog.WarnContext(ctx, fmt.Sprintf(format, v...))
+}

--- a/internal/cache/redis_logger_test.go
+++ b/internal/cache/redis_logger_test.go
@@ -1,0 +1,32 @@
+package cache
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+)
+
+func TestSlogRedisLogger_Printf_RoutesThroughSlogAtWarn(t *testing.T) {
+	var buf bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	slogRedisLogger{}.Printf(context.Background(), "connection pool: failed after %d attempts", 5)
+
+	var entry struct {
+		Level   string `json:"level"`
+		Message string `json:"msg"`
+	}
+	if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &entry); err != nil {
+		t.Fatalf("failed to decode log entry %q: %v", buf.String(), err)
+	}
+	if entry.Level != "WARN" {
+		t.Errorf("level = %q, want WARN", entry.Level)
+	}
+	if want := "connection pool: failed after 5 attempts"; entry.Message != want {
+		t.Errorf("msg = %q, want %q", entry.Message, want)
+	}
+}


### PR DESCRIPTION
## Summary

go-redis keeps its own **package-level internal logger** for connection-pool and pubsub diagnostics. By default that logger is a stdlib `log.Logger` writing raw lines straight to stderr, bypassing slog entirely:

```
redis: 2026/06/13 07:05:47 pool.go:715: redis: connection pool: failed to dial after 5 attempts: dial tcp [::1]:6379: connect: connection refused
```

These lines ignored the configured `LOG_FORMAT`/`LOG_LEVEL` and broke structured-log output (e.g. when shipping JSON logs to a collector).

## Fix

Install a small slog adapter via `redis.SetLogger` once at store creation (`internal/cache/NewRedisStore` — the single redis client construction site, covering both the response cache and the model cache). go-redis's internal diagnostics are now emitted as structured **warn-level** records consistent with the rest of the application.

The same message now renders as:

```
WRN redis: connection pool: failed to dial after 5 attempts: dial tcp [::1]:6379: connect: connection refused
```

(or a JSON record under `LOG_FORMAT=json`), and respects `LOG_LEVEL`.

## Notes

- **Level choice:** warn — these are recoverable operational diagnostics; the higher-level operation that triggered them is already logged separately by the caller.
- go-redis exposes only a process-global logger, so the adapter is installed once via `sync.OnceFunc`.

## Testing

- Unit test asserts the adapter routes through slog at warn level with the formatted message.
- Verified at runtime against a dead Redis port: the connection-pool dial-failure line is emitted as a structured slog record instead of a raw stderr line.
- `go build ./...` and the cache test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced Redis cache logging to integrate with the application's standard logging system for consistent message formatting and level management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->