### PR TITLE
fix(bailian): preserve passthrough bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Example model identifiers are illustrative and subject to change; consult provid
 | OpenRouter    | `OPENROUTER_API_KEY`                                              | `google/gemini-2.5-flash`          |  ✅  |      ✅      |  ✅   |  ✅   |   ✅    |    ✅    |
 | Z.ai          | `ZAI_API_KEY` (`ZAI_BASE_URL` optional)                           | `glm-5.1`                          |  ✅  |      ✅      |  ✅   |  ❌   |   ❌    |    ✅    |
 | xAI (Grok)    | `XAI_API_KEY`                                                     | `grok-4`                           |  ✅  |      ✅      |  ✅   |  ✅   |   ✅    |    ❌    |
-| Alibaba Cloud Bailian | `BAILIAN_API_KEY` (`BAILIAN_BASE_URL` optional)       | `qwen3-max`                        |  ✅  |      ✅      |  ✅   |  ✅   |   ✅    |    ✅    |
+| Alibaba Cloud Model Studio (Bailian) | `BAILIAN_API_KEY` (`BAILIAN_BASE_URL` optional)       | `qwen3-max`                        |  ✅  |      ✅      |  ✅   |  ✅   |   ✅    |    ✅    |
 | MiniMax       | `MINIMAX_API_KEY` (`MINIMAX_BASE_URL` optional)                   | `MiniMax-M3`                       |  ✅  |      ✅      |  ✅   |  ❌   |   ❌    |    ✅    |
 | Xiaomi MiMo   | `XIAOMI_API_KEY` (`XIAOMI_BASE_URL` optional)                     | `mimo-v2.5-pro`                    |  ✅  |      ✅      |  ❌   |  ❌   |   ❌    |    ✅    |
 | Azure OpenAI  | `AZURE_API_KEY` + `AZURE_BASE_URL` (`AZURE_API_VERSION` optional) | `gpt-5`                            |  ✅  |      ✅      |  ✅   |  ✅   |   ✅    |    ✅    |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -104,7 +104,7 @@
                     "providers/anthropic",
                     "providers/gemini",
                     "providers/deepseek",
-"providers/bailian",
+                    "providers/bailian",
                     "providers/xiaomi",
                     "providers/vllm",
                     "providers/multiple-ollama",

--- a/docs/providers/bailian.mdx
+++ b/docs/providers/bailian.mdx
@@ -1,12 +1,18 @@
 ---
-title: "Alibaba Cloud Bailian"
-description: "Configure Alibaba Cloud Bailian (百炼 / DashScope) in GoModel, including the max_tokens compatibility shim for models like Qwen."
+title: "Alibaba Cloud Model Studio"
+description: "Configure Alibaba Cloud Model Studio, formerly Bailian (百炼) and also known through DashScope APIs, including the max_tokens compatibility shim for Qwen models."
 icon: "cloud"
 ---
 
-Bailian (百炼) is Alibaba Cloud's model-as-a-service platform for the Qwen
-family of models. GoModel routes to Bailian through its OpenAI-compatible
-endpoint (`/compatible-mode/v1`).
+Alibaba Cloud Model Studio is Alibaba Cloud's model-as-a-service platform for
+the Qwen family of models. The service has also been called Bailian (百炼) and
+DashScope in consoles, SDKs, and API documentation. GoModel routes to it through
+the OpenAI-compatible endpoint (`/compatible-mode/v1`).
+
+<Note>
+  GoModel keeps the provider ID, environment variables, and passthrough path as
+  `bailian`, `BAILIAN_*`, and `/p/bailian/...` for compatibility.
+</Note>
 
 Because Bailian deprecated `max_tokens` in April 2026 in favor of
 `max_completion_tokens`, GoModel automatically maps the standard
@@ -31,7 +37,7 @@ providers:
 
 ## Base URLs
 
-Bailian's OpenAI-compatible API is available in multiple regions. Set
+Model Studio's OpenAI-compatible API is available in multiple regions. Set
 `BAILIAN_BASE_URL` to switch:
 
 | Region | URL |
@@ -43,7 +49,7 @@ Bailian's OpenAI-compatible API is available in multiple regions. Set
 
 ## Model IDs
 
-Common Qwen model identifiers — check the [Bailian model
+Common Qwen model identifiers — check the [Model Studio model
 list](https://www.alibabacloud.com/help/zh/model-studio/model-list) for the
 current catalog:
 
@@ -60,12 +66,13 @@ current catalog:
 
 ## `max_tokens` compatibility
 
-Bailian deprecated `max_tokens` on 2026-04-20 (effective 2026-05-30).
-All Bailian models now require `max_completion_tokens` instead.
+Model Studio deprecated `max_tokens` on 2026-04-20 (effective 2026-05-30).
+Its compatible-mode models now require `max_completion_tokens` instead.
 
 GoModel transparently maps the standard `max_tokens` parameter to
-`max_completion_tokens` for every bailian model — send `max_tokens` as you
-normally would, and GoModel rewrites it before forwarding to Bailian.
+`max_completion_tokens` for every `bailian` provider request — send
+`max_tokens` as you normally would, and GoModel rewrites it before forwarding to
+Model Studio.
 
 ```bash
 # max_tokens=4096 is automatically sent as max_completion_tokens=4096
@@ -99,6 +106,7 @@ curl http://localhost:8080/v1/chat/completions \
 
 ## References
 
+- [Model Studio documentation](https://www.alibabacloud.com/help/en/model-studio/what-is-model-studio)
 - [Bailian documentation](https://www.alibabacloud.com/help/zh/model-studio/)
 - [OpenAI-compatible API reference](https://www.alibabacloud.com/help/zh/model-studio/compatibility-with-openai-responses-api)
 - [Qwen model list](https://www.alibabacloud.com/help/zh/model-studio/model-list)

--- a/docs/providers/overview.mdx
+++ b/docs/providers/overview.mdx
@@ -25,7 +25,7 @@ quirks.
 | Z.ai | `ZAI_API_KEY` (`ZAI_BASE_URL` optional) | — |
 | xAI (Grok) | `XAI_API_KEY` | — |
 | MiniMax | `MINIMAX_API_KEY` (`MINIMAX_BASE_URL` optional) | — |
-| Alibaba Cloud Bailian | `BAILIAN_API_KEY` (`BAILIAN_BASE_URL` optional) | [Alibaba Cloud Bailian](/providers/bailian) |
+| Alibaba Cloud Model Studio (Bailian) | `BAILIAN_API_KEY` (`BAILIAN_BASE_URL` optional) | [Alibaba Cloud Model Studio](/providers/bailian) |
 | Xiaomi MiMo | `XIAOMI_API_KEY` (`XIAOMI_BASE_URL` optional) | [Xiaomi MiMo](/providers/xiaomi) |
 | Azure OpenAI | `AZURE_API_KEY` + `AZURE_BASE_URL` (`AZURE_API_VERSION` optional) | [Azure OpenAI](/providers/azure) |
 | Amazon Bedrock | `BEDROCK_BASE_URL` (region or endpoint) + AWS credentials | [Amazon Bedrock](/providers/bedrock) |

--- a/internal/providers/bailian/bailian.go
+++ b/internal/providers/bailian/bailian.go
@@ -108,6 +108,9 @@ func (p *Provider) Embeddings(ctx context.Context, req *core.EmbeddingRequest) (
 // It also adapts max_tokens -> max_completion_tokens in the raw body,
 // mirroring the adaptation done in ChatCompletion/StreamChatCompletion.
 func (p *Provider) Passthrough(ctx context.Context, req *core.PassthroughRequest) (*core.PassthroughResponse, error) {
+	if req == nil {
+		return nil, core.NewInvalidRequestError("passthrough request is required", nil)
+	}
 	adapted, err := adaptPassthroughBody(req.Body)
 	if err != nil {
 		slog.Warn("bailian: passthrough body adaptation failed",

--- a/internal/providers/bailian/bailian.go
+++ b/internal/providers/bailian/bailian.go
@@ -110,14 +110,9 @@ func (p *Provider) Embeddings(ctx context.Context, req *core.EmbeddingRequest) (
 func (p *Provider) Passthrough(ctx context.Context, req *core.PassthroughRequest) (*core.PassthroughResponse, error) {
 	adapted, err := adaptPassthroughBody(req.Body)
 	if err != nil {
-		slog.Warn("bailian: passthrough body adaptation failed, forwarding original body",
+		slog.Warn("bailian: passthrough body adaptation failed",
 			"error", err)
-		// Read the original body back so we can still forward it
-		req.Body, err = rewindBody(req.Body, nil)
-		if err != nil {
-			return nil, err
-		}
-		return p.compatible.Passthrough(ctx, req)
+		return nil, err
 	}
 	if adapted != nil {
 		req.Body = adapted
@@ -236,9 +231,8 @@ func adaptBailianRequest(req *core.ChatRequest) *core.ChatRequest {
 
 // adaptPassthroughBody adapts max_tokens -> max_completion_tokens in a raw
 // passthrough request body. It reads the body, parses it as JSON, swaps the
-// field if needed, and returns a new io.ReadCloser with the adapted body.
-// If no adaptation is needed, it returns nil (the caller should rewind the
-// original body). If parsing fails, it returns the error.
+// field if needed, and returns a new io.ReadCloser with the adapted or original
+// body. If parsing fails, the original bytes are forwarded unchanged.
 func adaptPassthroughBody(body io.ReadCloser) (io.ReadCloser, error) {
 	if body == nil {
 		return nil, nil
@@ -257,7 +251,7 @@ func adaptPassthroughBody(body io.ReadCloser) (io.ReadCloser, error) {
 
 	// No max_tokens present — no adaptation needed, rewind original.
 	if _, hasMaxTokens := obj["max_tokens"]; !hasMaxTokens {
-		return nil, nil
+		return io.NopCloser(bytes.NewReader(raw)), nil
 	}
 
 	// Caller already set max_completion_tokens — just remove max_tokens.
@@ -278,25 +272,4 @@ func adaptPassthroughBody(body io.ReadCloser) (io.ReadCloser, error) {
 		return nil, err
 	}
 	return io.NopCloser(bytes.NewReader(adapted)), nil
-}
-
-// rewindBody reads an io.ReadCloser into memory and returns a new ReadCloser
-// over the same bytes, allowing the body to be read again.
-// If fallback is non-nil, it is used when the original body is nil or cannot be read.
-func rewindBody(body io.ReadCloser, fallback []byte) (io.ReadCloser, error) {
-	if body == nil {
-		if fallback != nil {
-			return io.NopCloser(bytes.NewReader(fallback)), nil
-		}
-		return nil, nil
-	}
-	raw, err := io.ReadAll(body)
-	body.Close()
-	if err != nil {
-		if fallback != nil {
-			return io.NopCloser(bytes.NewReader(fallback)), nil
-		}
-		return nil, err
-	}
-	return io.NopCloser(bytes.NewReader(raw)), nil
 }

--- a/internal/providers/bailian/bailian_test.go
+++ b/internal/providers/bailian/bailian_test.go
@@ -78,8 +78,8 @@ func TestChatCompletion_MaxTokensMapping(t *testing.T) {
 
 	maxTokens := 4096
 	_, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{
-		Model:    "qwen3-max",
-		Messages: []core.Message{{Role: "user", Content: "hi"}},
+		Model:     "qwen3-max",
+		Messages:  []core.Message{{Role: "user", Content: "hi"}},
 		MaxTokens: &maxTokens,
 	})
 	if err != nil {
@@ -162,8 +162,8 @@ func TestStreamChatCompletion_MaxTokensMapping(t *testing.T) {
 
 	maxTokens := 2048
 	_, err := provider.StreamChatCompletion(context.Background(), &core.ChatRequest{
-		Model:    "qwen3-flash",
-		Messages: []core.Message{{Role: "user", Content: "hi"}},
+		Model:     "qwen3-flash",
+		Messages:  []core.Message{{Role: "user", Content: "hi"}},
 		MaxTokens: &maxTokens,
 	})
 	if err != nil {
@@ -399,7 +399,6 @@ func TestAdaptBailianRequest_NoMaxTokens(t *testing.T) {
 		t.Fatal("should not set max_completion_tokens when request had none")
 	}
 
-
 }
 func TestNew_UsesRegistrationAndDefaultBaseURL(t *testing.T) {
 	provider := New(providers.ProviderConfig{
@@ -465,7 +464,6 @@ func TestAdaptBailianRequest_PreservesOtherFields(t *testing.T) {
 	}
 }
 
-
 func TestAdaptBailianRequest_RespectsExistingMaxCompletionTokens(t *testing.T) {
 	extra := core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
 		"max_completion_tokens": json.RawMessage(`200`),
@@ -519,7 +517,7 @@ func TestChatCompletion_UpstreamError(t *testing.T) {
 	provider.SetBaseURL(server.URL)
 
 	_, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{
-		Model: "qwen3-max",
+		Model:    "qwen3-max",
 		Messages: []core.Message{{Role: "user", Content: "hi"}},
 	})
 	if err == nil {
@@ -537,7 +535,7 @@ func TestChatCompletion_TransportFailure(t *testing.T) {
 	}, llmclient.Hooks{})
 
 	_, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{
-		Model: "qwen3-max",
+		Model:    "qwen3-max",
 		Messages: []core.Message{{Role: "user", Content: "hi"}},
 	})
 	if err == nil {
@@ -556,7 +554,7 @@ func TestStreamChatCompletion_UpstreamError(t *testing.T) {
 	provider.SetBaseURL(server.URL)
 
 	_, err := provider.StreamChatCompletion(context.Background(), &core.ChatRequest{
-		Model: "qwen3-max",
+		Model:    "qwen3-max",
 		Messages: []core.Message{{Role: "user", Content: "hi"}},
 	})
 	if err == nil {

--- a/internal/providers/bailian/bailian_test.go
+++ b/internal/providers/bailian/bailian_test.go
@@ -386,6 +386,28 @@ func TestPassthrough_Delegates(t *testing.T) {
 	}
 }
 
+func TestPassthrough_NilRequest(t *testing.T) {
+	provider := NewWithHTTPClient("key", nil, llmclient.Hooks{})
+
+	if _, err := provider.Passthrough(context.Background(), nil); err == nil {
+		t.Fatal("expected error for nil passthrough request")
+	}
+}
+
+func TestPassthrough_ReadError(t *testing.T) {
+	readErr := errors.New("read failed")
+	provider := NewWithHTTPClient("key", nil, llmclient.Hooks{})
+
+	_, err := provider.Passthrough(context.Background(), &core.PassthroughRequest{
+		Method:   http.MethodPost,
+		Endpoint: "/chat/completions",
+		Body:     errReadCloser{err: readErr},
+	})
+	if !errors.Is(err, readErr) {
+		t.Fatalf("Passthrough() error = %v, want %v", err, readErr)
+	}
+}
+
 func TestAdaptBailianRequest_Nil(t *testing.T) {
 	if r := adaptBailianRequest(nil); r != nil {
 		t.Fatal("expected nil")
@@ -828,6 +850,18 @@ type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 	return f(r)
+}
+
+type errReadCloser struct {
+	err error
+}
+
+func (r errReadCloser) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+func (r errReadCloser) Close() error {
+	return nil
 }
 
 func TestPassthrough_MaxTokensMapping(t *testing.T) {


### PR DESCRIPTION
## Summary
- Preserve Bailian passthrough request bodies when no max_tokens rewrite is needed
- Remove the now-unused rewind helper
- Update provider docs to lead with Alibaba Cloud Model Studio while keeping bailian compatibility names documented

## Tests
- go test -v ./internal/providers/bailian
- go test ./cmd/... ./internal/... ./config/...
- python3 -m json.tool docs/docs.json
- git diff --check
- pre-commit hook: make test-race, make lint, mint validate, hot-path performance guard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Alibaba Cloud provider branding and terminology to “Model Studio (Bailian)” across provider guides and overview tables
  * Refreshed the Bailian compatibility notes and updated provider references

* **Bug Fixes**
  * Improved Bailian passthrough handling to validate requests, properly surface body read/adaptation errors, and avoid silent fallback

* **Tests**
  * Added coverage for nil requests and request-body read failures
<!-- end of auto-generated comment: release notes by coderabbit.ai -->