### PR TITLE
fix(embeddings): honor encoding_format + fail loudly on empty ollama embeddings

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -379,6 +379,17 @@
 # Set base URL to enable (default: http://localhost:8000/v1)
 # VLLM_BASE_URL=http://localhost:8000/v1
 
+# LM Studio (local, OpenAI-compatible server)
+# LM Studio speaks the OpenAI API (/v1/chat/completions, /v1/embeddings) and has
+# NO native Ollama API. Attach it to the openai type via a suffix so it gets a
+# descriptive name — here "openai-lmstudio". Do NOT use OLLAMA_BASE_URL for it:
+# that routes embeddings to Ollama's native /api/embed, which LM Studio doesn't
+# implement. The API key can be any non-empty value; LM Studio ignores it.
+# OPENAI_LMSTUDIO_BASE_URL=http://localhost:1234/v1
+# OPENAI_LMSTUDIO_API_KEY=lm-studio
+# Optional: pin the served models (LM Studio only exposes loaded ones).
+# OPENAI_LMSTUDIO_MODELS=text-embedding-nomic-embed-text-v1.5
+
 # Amazon Bedrock
 # Bedrock has no per-provider API key. Auth comes from the standard AWS
 # credential chain — env vars (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -267,6 +267,16 @@ providers:
   #   base_url: "https://api.example.com/v1"
   #   api_key: "..."
 
+  # Example: LM Studio. Despite being "Ollama-like", LM Studio speaks the
+  # OpenAI-compatible API (/v1/chat/completions, /v1/embeddings) and has NO
+  # native Ollama API. Configure it as "openai" (or "vllm"), NOT "ollama" —
+  # the ollama type sends embeddings to Ollama's native /api/embed, which LM
+  # Studio does not implement.
+  # lmstudio:
+  #   type: openai
+  #   base_url: "http://localhost:1234/v1"
+  #   api_key: "lm-studio"  # any non-empty value; LM Studio ignores it
+
   # Example: Groq (OpenAI-compatible)
   # groq:
   #   type: "openai"

--- a/internal/core/embeddings_encoding.go
+++ b/internal/core/embeddings_encoding.go
@@ -92,6 +92,11 @@ func base64ToFloatArray(raw json.RawMessage) (json.RawMessage, bool) {
 	if err := json.Unmarshal(raw, &encoded); err != nil {
 		return nil, false
 	}
+	// Reject oversized payloads before DecodeString allocates the decode buffer,
+	// not just after, so a pathological upstream can't force a large allocation.
+	if len(encoded) > base64.StdEncoding.EncodedLen(maxEmbeddingDims*4) {
+		return nil, false
+	}
 	buf, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil || len(buf) == 0 || len(buf)%4 != 0 || len(buf)/4 > maxEmbeddingDims {
 		return nil, false

--- a/internal/core/embeddings_encoding.go
+++ b/internal/core/embeddings_encoding.go
@@ -1,0 +1,96 @@
+package core
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"math"
+	"strings"
+)
+
+// NormalizeEmbeddingEncoding reconciles a response's embedding encoding with the
+// encoding_format the client requested, keeping responses OpenAI-compatible
+// regardless of provider quirks.
+//
+// The OpenAI Python and JS/LangChain SDKs request encoding_format="base64" by
+// default and decode it client-side. Some OpenAI-compatible servers (notably
+// LM Studio) ignore encoding_format and always return float arrays, which makes
+// those SDKs mis-decode the floats as packed bytes and produce corrupted,
+// wrong-dimension vectors. Following Postel's Law, GoModel accepts whatever the
+// upstream returns and re-encodes each vector into the format the caller asked
+// for: base64 (little-endian float32, matching OpenAI) or a float array.
+//
+// An empty or unrecognized format is treated as "float" (the OpenAI default
+// when the field is omitted). Vectors already in the requested form, and values
+// that don't parse as either shape, are left untouched.
+func NormalizeEmbeddingEncoding(resp *EmbeddingResponse, encodingFormat string) {
+	if resp == nil {
+		return
+	}
+	wantBase64 := strings.EqualFold(strings.TrimSpace(encodingFormat), "base64")
+	for i := range resp.Data {
+		raw := bytes.TrimSpace(resp.Data[i].Embedding)
+		if len(raw) == 0 {
+			continue
+		}
+		if wantBase64 {
+			if encoded, ok := floatArrayToBase64(raw); ok {
+				resp.Data[i].Embedding = encoded
+			}
+			continue
+		}
+		if decoded, ok := base64ToFloatArray(raw); ok {
+			resp.Data[i].Embedding = decoded
+		}
+	}
+}
+
+// floatArrayToBase64 converts a JSON float array into an OpenAI-style base64
+// string (little-endian float32). It returns ok=false when raw is not a JSON
+// array (e.g. already a base64 string), so the caller leaves it as-is.
+func floatArrayToBase64(raw json.RawMessage) (json.RawMessage, bool) {
+	if len(raw) == 0 || raw[0] != '[' {
+		return nil, false
+	}
+	var values []float64
+	if err := json.Unmarshal(raw, &values); err != nil {
+		return nil, false
+	}
+	buf := make([]byte, len(values)*4)
+	for i, v := range values {
+		binary.LittleEndian.PutUint32(buf[i*4:], math.Float32bits(float32(v)))
+	}
+	encoded, err := json.Marshal(base64.StdEncoding.EncodeToString(buf))
+	if err != nil {
+		return nil, false
+	}
+	return encoded, true
+}
+
+// base64ToFloatArray converts an OpenAI-style base64 string (little-endian
+// float32) into a JSON float array. It returns ok=false when raw is not a JSON
+// string or doesn't decode to whole float32 values, so the caller leaves it
+// as-is (e.g. it's already a float array).
+func base64ToFloatArray(raw json.RawMessage) (json.RawMessage, bool) {
+	if len(raw) == 0 || raw[0] != '"' {
+		return nil, false
+	}
+	var encoded string
+	if err := json.Unmarshal(raw, &encoded); err != nil {
+		return nil, false
+	}
+	buf, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil || len(buf) == 0 || len(buf)%4 != 0 {
+		return nil, false
+	}
+	values := make([]float64, len(buf)/4)
+	for i := range values {
+		values[i] = float64(math.Float32frombits(binary.LittleEndian.Uint32(buf[i*4:])))
+	}
+	decoded, err := json.Marshal(values)
+	if err != nil {
+		return nil, false
+	}
+	return decoded, true
+}

--- a/internal/core/embeddings_encoding.go
+++ b/internal/core/embeddings_encoding.go
@@ -9,6 +9,12 @@ import (
 	"strings"
 )
 
+// maxEmbeddingDims caps how large a single vector may be before encoding
+// conversion is skipped. It sits far above any real embedding model (the
+// largest in common use are a few thousand dimensions) and exists only to bound
+// allocations and prevent the *4 byte-size computation from overflowing.
+const maxEmbeddingDims = 1 << 20
+
 // NormalizeEmbeddingEncoding reconciles a response's embedding encoding with the
 // encoding_format the client requested, keeping responses OpenAI-compatible
 // regardless of provider quirks.
@@ -57,6 +63,12 @@ func floatArrayToBase64(raw json.RawMessage) (json.RawMessage, bool) {
 	if err := json.Unmarshal(raw, &values); err != nil {
 		return nil, false
 	}
+	// Guard the *4 buffer sizing against overflow / absurd payloads. Real
+	// embedding vectors are at most a few thousand dimensions; anything beyond
+	// the cap is left untouched rather than allocated.
+	if len(values) > maxEmbeddingDims {
+		return nil, false
+	}
 	buf := make([]byte, len(values)*4)
 	for i, v := range values {
 		binary.LittleEndian.PutUint32(buf[i*4:], math.Float32bits(float32(v)))
@@ -81,7 +93,7 @@ func base64ToFloatArray(raw json.RawMessage) (json.RawMessage, bool) {
 		return nil, false
 	}
 	buf, err := base64.StdEncoding.DecodeString(encoded)
-	if err != nil || len(buf) == 0 || len(buf)%4 != 0 {
+	if err != nil || len(buf) == 0 || len(buf)%4 != 0 || len(buf)/4 > maxEmbeddingDims {
 		return nil, false
 	}
 	values := make([]float64, len(buf)/4)

--- a/internal/core/embeddings_encoding_test.go
+++ b/internal/core/embeddings_encoding_test.go
@@ -1,0 +1,116 @@
+package core
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"math"
+	"testing"
+)
+
+func b64OfFloats(vals []float32) string {
+	buf := make([]byte, len(vals)*4)
+	for i, v := range vals {
+		binary.LittleEndian.PutUint32(buf[i*4:], math.Float32bits(v))
+	}
+	return base64.StdEncoding.EncodeToString(buf)
+}
+
+func TestNormalizeEmbeddingEncoding(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+		in     json.RawMessage
+		want   json.RawMessage
+	}{
+		{
+			name:   "float array to base64 when base64 requested",
+			format: "base64",
+			in:     json.RawMessage(`[1,2,3]`),
+			want:   json.RawMessage(`"` + b64OfFloats([]float32{1, 2, 3}) + `"`),
+		},
+		{
+			name:   "base64 to float array when float requested",
+			format: "float",
+			in:     json.RawMessage(`"` + b64OfFloats([]float32{1, 2, 3}) + `"`),
+			want:   json.RawMessage(`[1,2,3]`),
+		},
+		{
+			name:   "base64 to float array when format omitted (OpenAI default)",
+			format: "",
+			in:     json.RawMessage(`"` + b64OfFloats([]float32{0.5, -0.25}) + `"`),
+			want:   json.RawMessage(`[0.5,-0.25]`),
+		},
+		{
+			name:   "already base64 left unchanged when base64 requested",
+			format: "base64",
+			in:     json.RawMessage(`"` + b64OfFloats([]float32{1, 2}) + `"`),
+			want:   json.RawMessage(`"` + b64OfFloats([]float32{1, 2}) + `"`),
+		},
+		{
+			name:   "already float left unchanged when float requested",
+			format: "float",
+			in:     json.RawMessage(`[1,2,3]`),
+			want:   json.RawMessage(`[1,2,3]`),
+		},
+		{
+			name:   "case-insensitive format",
+			format: "BASE64",
+			in:     json.RawMessage(`[1]`),
+			want:   json.RawMessage(`"` + b64OfFloats([]float32{1}) + `"`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &EmbeddingResponse{Data: []EmbeddingData{{Embedding: tt.in}}}
+			NormalizeEmbeddingEncoding(resp, tt.format)
+			if got := string(resp.Data[0].Embedding); got != string(tt.want) {
+				t.Errorf("got %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNormalizeEmbeddingEncoding_RoundTrip guards that float->base64->float is
+// lossless at float32 precision — the property LangChain/OpenAI clients rely on.
+func TestNormalizeEmbeddingEncoding_RoundTrip(t *testing.T) {
+	orig := []float32{0.123, -0.987, 1.5, 0, 42.25}
+	floats := make([]any, len(orig))
+	for i, v := range orig {
+		floats[i] = v
+	}
+	rawFloats, _ := json.Marshal(floats)
+
+	resp := &EmbeddingResponse{Data: []EmbeddingData{{Embedding: rawFloats}}}
+	NormalizeEmbeddingEncoding(resp, "base64") // float -> base64
+	if resp.Data[0].Embedding[0] != '"' {
+		t.Fatalf("expected base64 string, got %s", resp.Data[0].Embedding)
+	}
+	NormalizeEmbeddingEncoding(resp, "float") // base64 -> float
+
+	var back []float32
+	if err := json.Unmarshal(resp.Data[0].Embedding, &back); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(back) != len(orig) {
+		t.Fatalf("len = %d, want %d", len(back), len(orig))
+	}
+	for i := range orig {
+		if back[i] != orig[i] {
+			t.Errorf("index %d: got %v, want %v", i, back[i], orig[i])
+		}
+	}
+}
+
+// TestNormalizeEmbeddingEncoding_Malformed ensures non-vector payloads are left
+// untouched rather than corrupted or panicking.
+func TestNormalizeEmbeddingEncoding_Malformed(t *testing.T) {
+	for _, in := range []string{`null`, `"not-base64!!!"`, `{}`, `[`, ``} {
+		resp := &EmbeddingResponse{Data: []EmbeddingData{{Embedding: json.RawMessage(in)}}}
+		NormalizeEmbeddingEncoding(resp, "base64")
+		if got := string(resp.Data[0].Embedding); got != in {
+			t.Errorf("input %q mutated to %q", in, got)
+		}
+	}
+}

--- a/internal/providers/ollama/ollama.go
+++ b/internal/providers/ollama/ollama.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"reflect"
 	"strings"
 	"time"
 
@@ -228,7 +229,9 @@ func (p *Provider) Embeddings(ctx context.Context, req *core.EmbeddingRequest) (
 // embeddingInputIsEmpty reports whether an embeddings request carries no input,
 // in which case zero returned vectors is a legitimate result rather than a sign
 // the upstream rejected the request. Input is decoded from JSON, so a batch is a
-// []any and a single value is a string; unknown shapes are treated as non-empty.
+// []any and a single value is a string; the reflection fallback also handles a
+// directly-constructed typed slice (e.g. []string{}) so those aren't misread as
+// the LM-Studio-as-ollama misconfiguration.
 func embeddingInputIsEmpty(input any) bool {
 	switch v := input.(type) {
 	case nil:
@@ -238,6 +241,9 @@ func embeddingInputIsEmpty(input any) bool {
 	case []any:
 		return len(v) == 0
 	default:
+		if rv := reflect.ValueOf(input); rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array {
+			return rv.Len() == 0
+		}
 		return false
 	}
 }

--- a/internal/providers/ollama/ollama.go
+++ b/internal/providers/ollama/ollama.go
@@ -226,18 +226,18 @@ func (p *Provider) Embeddings(ctx context.Context, req *core.EmbeddingRequest) (
 	}, nil
 }
 
-// embeddingInputIsEmpty reports whether an embeddings request carries no input,
-// in which case zero returned vectors is a legitimate result rather than a sign
-// the upstream rejected the request. Input is decoded from JSON, so a batch is a
-// []any and a single value is a string; the reflection fallback also handles a
-// directly-constructed typed slice (e.g. []string{}) so those aren't misread as
-// the LM-Studio-as-ollama misconfiguration.
+// embeddingInputIsEmpty reports whether an embeddings request carries an empty
+// batch — an empty array/slice — for which zero returned vectors is a legitimate
+// result. Input is decoded from JSON (so a batch is []any), but the reflection
+// fallback also covers a directly-constructed typed slice such as []string{}.
+//
+// Scalar ("") and nil inputs are deliberately NOT treated as empty batches: if
+// they come back with zero vectors it more likely means the upstream rejected
+// the request (e.g. an OpenAI-compatible server misconfigured as ollama
+// answering 200 with an error body), which must stay on the loud-error path
+// rather than silently returning an empty list.
 func embeddingInputIsEmpty(input any) bool {
 	switch v := input.(type) {
-	case nil:
-		return true
-	case string:
-		return strings.TrimSpace(v) == ""
 	case []any:
 		return len(v) == 0
 	default:

--- a/internal/providers/ollama/ollama.go
+++ b/internal/providers/ollama/ollama.go
@@ -184,6 +184,16 @@ func (p *Provider) Embeddings(ctx context.Context, req *core.EmbeddingRequest) (
 		return nil, err
 	}
 
+	// A successful embeddings call always returns at least one vector. An empty
+	// result means the upstream did not honor the native /api/embed contract —
+	// e.g. an OpenAI-compatible server (LM Studio, vLLM) that has no native
+	// Ollama API and answers 200 with an error body. Fail loudly instead of
+	// returning an empty, OpenAI-shaped list that silently breaks the caller.
+	if len(ollamaResp.Embeddings) == 0 {
+		return nil, core.NewProviderError("ollama", http.StatusBadGateway,
+			"ollama embeddings returned no vectors; if this endpoint is an OpenAI-compatible server (e.g. LM Studio), configure it as an \"openai\" or \"vllm\" provider instead of \"ollama\"", nil)
+	}
+
 	data := make([]core.EmbeddingData, len(ollamaResp.Embeddings))
 	for i, emb := range ollamaResp.Embeddings {
 		raw, err := json.Marshal(emb)

--- a/internal/providers/ollama/ollama.go
+++ b/internal/providers/ollama/ollama.go
@@ -184,12 +184,14 @@ func (p *Provider) Embeddings(ctx context.Context, req *core.EmbeddingRequest) (
 		return nil, err
 	}
 
-	// A successful embeddings call always returns at least one vector. An empty
-	// result means the upstream did not honor the native /api/embed contract —
-	// e.g. an OpenAI-compatible server (LM Studio, vLLM) that has no native
-	// Ollama API and answers 200 with an error body. Fail loudly instead of
-	// returning an empty, OpenAI-shaped list that silently breaks the caller.
-	if len(ollamaResp.Embeddings) == 0 {
+	// A request that carried input always yields at least one vector. Zero
+	// vectors for a non-empty request means the upstream did not honor the
+	// native /api/embed contract — e.g. an OpenAI-compatible server (LM Studio,
+	// vLLM) that has no native Ollama API and answers 200 with an error body.
+	// Fail loudly instead of returning an empty, OpenAI-shaped list that
+	// silently breaks the caller. An empty input batch legitimately returns no
+	// vectors, so leave that case to pass through as an empty response.
+	if len(ollamaResp.Embeddings) == 0 && !embeddingInputIsEmpty(req.Input) {
 		return nil, core.NewProviderError("ollama", http.StatusBadGateway,
 			"ollama embeddings returned no vectors; if this endpoint is an OpenAI-compatible server (e.g. LM Studio), configure it as an \"openai\" or \"vllm\" provider instead of \"ollama\"", nil)
 	}
@@ -221,6 +223,23 @@ func (p *Provider) Embeddings(ctx context.Context, req *core.EmbeddingRequest) (
 			TotalTokens:  ollamaResp.PromptEvalCount,
 		},
 	}, nil
+}
+
+// embeddingInputIsEmpty reports whether an embeddings request carries no input,
+// in which case zero returned vectors is a legitimate result rather than a sign
+// the upstream rejected the request. Input is decoded from JSON, so a batch is a
+// []any and a single value is a string; unknown shapes are treated as non-empty.
+func embeddingInputIsEmpty(input any) bool {
+	switch v := input.(type) {
+	case nil:
+		return true
+	case string:
+		return strings.TrimSpace(v) == ""
+	case []any:
+		return len(v) == 0
+	default:
+		return false
+	}
 }
 
 // errBatchUnsupported is returned by every batch endpoint because Ollama has

--- a/internal/providers/ollama/ollama_test.go
+++ b/internal/providers/ollama/ollama_test.go
@@ -913,9 +913,10 @@ func TestEmbeddings_NoVectorsErrors(t *testing.T) {
 	}
 }
 
-// TestEmbeddings_EmptyInputNoError ensures an empty input batch is not mistaken
-// for the LM-Studio-as-ollama misconfiguration: zero vectors for zero inputs is
-// a legitimate result, not a provider error.
+// TestEmbeddings_EmptyInputNoError ensures an empty input batch (an empty
+// array/slice, including a typed []string{}) is not mistaken for the
+// LM-Studio-as-ollama misconfiguration: zero vectors for an empty batch is a
+// legitimate result, not a provider error.
 func TestEmbeddings_EmptyInputNoError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -926,16 +927,28 @@ func TestEmbeddings_EmptyInputNoError(t *testing.T) {
 	provider := NewWithHTTPClient("", nil, llmclient.Hooks{})
 	provider.SetBaseURL(server.URL + "/v1")
 
-	for _, empty := range []any{[]any{}, []string{}, "", nil} {
+	for _, empty := range []any{[]any{}, []string{}} {
 		resp, err := provider.Embeddings(context.Background(), &core.EmbeddingRequest{
 			Model: "nomic-embed-text",
 			Input: empty,
 		})
 		if err != nil {
-			t.Fatalf("unexpected error for empty input %#v: %v", empty, err)
+			t.Fatalf("unexpected error for empty batch %#v: %v", empty, err)
 		}
 		if resp == nil || len(resp.Data) != 0 {
 			t.Fatalf("input %#v: expected empty data response, got %+v", empty, resp)
+		}
+	}
+
+	// Scalar/nil inputs are NOT empty batches: zero vectors must stay on the
+	// loud-error path so a misconfigured OpenAI-compatible endpoint returning a
+	// 200 error body for "" / null isn't silently swallowed as an empty list.
+	for _, scalar := range []any{"", nil} {
+		if _, err := provider.Embeddings(context.Background(), &core.EmbeddingRequest{
+			Model: "nomic-embed-text",
+			Input: scalar,
+		}); err == nil {
+			t.Fatalf("input %#v: expected provider error for zero vectors, got nil", scalar)
 		}
 	}
 }

--- a/internal/providers/ollama/ollama_test.go
+++ b/internal/providers/ollama/ollama_test.go
@@ -3,6 +3,7 @@ package ollama
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -894,6 +895,45 @@ func TestEmbeddings_NoVectorsErrors(t *testing.T) {
 		Input: "hello world",
 	})
 	if err == nil {
-		t.Fatalf("expected error for empty embeddings, got response with %d data entries", len(resp.Data))
+		t.Fatal("expected provider error for empty embeddings, got nil")
+	}
+	if resp != nil {
+		t.Fatalf("expected nil response on error, got %d data entries", len(resp.Data))
+	}
+
+	var gatewayErr *core.GatewayError
+	if !errors.As(err, &gatewayErr) {
+		t.Fatalf("expected *core.GatewayError, got %T", err)
+	}
+	if gatewayErr.HTTPStatusCode() != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d", gatewayErr.HTTPStatusCode(), http.StatusBadGateway)
+	}
+	if !strings.Contains(gatewayErr.Message, `"openai" or "vllm" provider`) {
+		t.Fatalf("unexpected error message: %q", gatewayErr.Message)
+	}
+}
+
+// TestEmbeddings_EmptyInputNoError ensures an empty input batch is not mistaken
+// for the LM-Studio-as-ollama misconfiguration: zero vectors for zero inputs is
+// a legitimate result, not a provider error.
+func TestEmbeddings_EmptyInputNoError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"model":"nomic-embed-text","embeddings":[],"prompt_eval_count":0}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("", nil, llmclient.Hooks{})
+	provider.SetBaseURL(server.URL + "/v1")
+
+	resp, err := provider.Embeddings(context.Background(), &core.EmbeddingRequest{
+		Model: "nomic-embed-text",
+		Input: []any{},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error for empty input: %v", err)
+	}
+	if resp == nil || len(resp.Data) != 0 {
+		t.Fatalf("expected empty data response, got %+v", resp)
 	}
 }

--- a/internal/providers/ollama/ollama_test.go
+++ b/internal/providers/ollama/ollama_test.go
@@ -926,14 +926,16 @@ func TestEmbeddings_EmptyInputNoError(t *testing.T) {
 	provider := NewWithHTTPClient("", nil, llmclient.Hooks{})
 	provider.SetBaseURL(server.URL + "/v1")
 
-	resp, err := provider.Embeddings(context.Background(), &core.EmbeddingRequest{
-		Model: "nomic-embed-text",
-		Input: []any{},
-	})
-	if err != nil {
-		t.Fatalf("unexpected error for empty input: %v", err)
-	}
-	if resp == nil || len(resp.Data) != 0 {
-		t.Fatalf("expected empty data response, got %+v", resp)
+	for _, empty := range []any{[]any{}, []string{}, "", nil} {
+		resp, err := provider.Embeddings(context.Background(), &core.EmbeddingRequest{
+			Model: "nomic-embed-text",
+			Input: empty,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error for empty input %#v: %v", empty, err)
+		}
+		if resp == nil || len(resp.Data) != 0 {
+			t.Fatalf("input %#v: expected empty data response, got %+v", empty, resp)
+		}
 	}
 }

--- a/internal/providers/ollama/ollama_test.go
+++ b/internal/providers/ollama/ollama_test.go
@@ -873,3 +873,27 @@ func TestEmbeddings_ModelFallback(t *testing.T) {
 		t.Errorf("Model = %q, want %q (should fall back to request model)", resp.Model, "nomic-embed-text")
 	}
 }
+
+// TestEmbeddings_NoVectorsErrors guards the common misconfiguration where an
+// OpenAI-compatible server (e.g. LM Studio) is registered as an "ollama"
+// provider. Such servers answer the native /api/embed path with a 200 and an
+// error body, which unmarshals into zero embeddings. The adapter must surface
+// an error instead of returning an empty, OpenAI-shaped list.
+func TestEmbeddings_NoVectorsErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"error":"Unexpected endpoint or method. (POST /api/embed)"}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("", nil, llmclient.Hooks{})
+	provider.SetBaseURL(server.URL + "/v1")
+
+	resp, err := provider.Embeddings(context.Background(), &core.EmbeddingRequest{
+		Model: "text-embedding-nomic-embed-text-v1.5",
+		Input: "hello world",
+	})
+	if err == nil {
+		t.Fatalf("expected error for empty embeddings, got response with %d data entries", len(resp.Data))
+	}
+}

--- a/internal/providers/router.go
+++ b/internal/providers/router.go
@@ -696,7 +696,7 @@ func (r *Router) StreamResponses(ctx context.Context, req *core.ResponsesRequest
 
 // Embeddings routes the embeddings request to the appropriate provider.
 func (r *Router) Embeddings(ctx context.Context, req *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
-	return routeStampedModelResponse(
+	resp, err := routeStampedModelResponse(
 		r,
 		ctx,
 		req.Model,
@@ -706,6 +706,14 @@ func (r *Router) Embeddings(ctx context.Context, req *core.EmbeddingRequest) (*c
 		},
 		callEmbeddings,
 	)
+	if err != nil {
+		return nil, err
+	}
+	// Some OpenAI-compatible servers ignore encoding_format and always return
+	// float arrays; re-encode to the format the client asked for so SDKs that
+	// default to base64 (OpenAI, LangChain) don't mis-decode the response.
+	core.NormalizeEmbeddingEncoding(resp, req.EncodingFormat)
+	return resp, nil
 }
 
 // CreateSpeech routes a text-to-speech request to the provider that owns the model.


### PR DESCRIPTION
## Summary

Two fixes that make `/v1/embeddings` robust against OpenAI-compatible local servers (LM Studio, Ollama, vLLM). Both were found while debugging a real report: `arabold/docs-mcp-server` → GoModel → LM Studio produced broken embeddings with no error.

## Fix 1 (primary): honor `encoding_format`

**Root cause, verified end-to-end with the actual LangChain client:**

- The OpenAI Python and JS/**LangChain** SDKs request `encoding_format: "base64"` **by default** and decode it client-side.
- **LM Studio ignores `encoding_format`** and always returns a float array.
- LangChain then mis-decodes the float array as packed bytes (`Buffer.from(arr, "base64")`), producing a corrupted vector with **1/4 the dimensions** (768 → 192). The downstream vector store breaks.
- This happens whether the client hits LM Studio **directly or through the gateway** — so it isn't introduced by GoModel, but the gateway is the only place that can repair it.

**Wire capture (real `@langchain/openai` `OpenAIEmbeddings`, the exact path `docs-mcp-server` uses):**

```
DIRECT to LM Studio : request encoding_format=base64 → response float array(768) → client decodes 192 ❌ CORRUPTED
VIA GoModel (after) : request encoding_format=base64 → response base64 string    → client decodes 768 ✅
```

The fix normalizes the embeddings response to the encoding the caller requested (Postel's Law): accept whatever the upstream returns, re-encode each vector as base64 (little-endian float32, matching OpenAI) or as a float array. Vectors already in the requested form, and payloads that parse as neither, are left untouched — so real OpenAI/base64 upstreams are a no-op.

- `internal/core/embeddings_encoding.go` — `NormalizeEmbeddingEncoding` + table-driven tests (round-trip fidelity, both directions, malformed-passthrough).
- `internal/providers/router.go` — apply it in `Router.Embeddings` using the client's requested `encoding_format`.

> Note: provider-prefix trimming in the response (`lmstudio/model` → `model`) was investigated as a suspect and **ruled out** — the LangChain client round-trips fine with a trimmed model name; it's shared with chat completions, which work.

## Fix 2 (secondary): fail loudly on empty ollama embeddings

When an OpenAI-compatible server is misconfigured as `type: ollama`, the adapter calls Ollama's native `/api/embed`, which LM Studio answers with HTTP 200 + an error body → zero embeddings → GoModel returned `200 {"data":[]}`, a silent failure with nothing in the logs. Now it returns a `502 provider_error` pointing the operator at the `openai`/`vllm` types.

- `internal/providers/ollama/ollama.go` + test.

## Docs

- `.env.template` and `config/config.example.yaml` — document configuring LM Studio as `openai`/`vllm` (it is OpenAI-compatible, **not** Ollama-compatible).

## User-visible impact

- OpenAI/LangChain embedding clients that default to base64 (e.g. `docs-mcp-server`) now get correct, full-dimension vectors through GoModel even when the upstream ignores `encoding_format`.
- Misconfigured ollama-typed embeddings fail with a clear, actionable error instead of silently returning empty results.
- No change for upstreams that already honor `encoding_format`, and no change to the chat path.

## Tests

- `internal/core`: `TestNormalizeEmbeddingEncoding`, `_RoundTrip`, `_Malformed`.
- `internal/providers/ollama`: `TestEmbeddings_NoVectorsErrors`.
- `make test-race` and `make lint` pass via pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added LM Studio provider support with OpenAI-compatible API integration
  * Added base64 encoding format support for embeddings (in addition to float arrays)

* **Bug Fixes**
  * Enhanced error detection for malformed embedding responses to provide clearer diagnostics

* **Documentation**
  * Added LM Studio configuration examples to setup guides
<!-- end of auto-generated comment: release notes by coderabbit.ai -->