### PR TITLE
ci: add vuln scanning + module verify, and streamline the test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,6 +134,25 @@ jobs:
         # Thresholds are maintained in tests/perf/hotpath_test.go.
         run: make perf-check
 
+  vulncheck:
+    name: Vulnerability Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      # Scans the dependency graph against the Go vulnerability database,
+      # reporting only vulnerabilities reachable from our code.
+      - name: Run govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...
+
   docs-validate:
     name: Docs Validation
     runs-on: ubuntu-latest
@@ -165,6 +184,9 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
+
+      - name: Verify module integrity
+        run: go mod verify
 
       - name: Build
         run: go build -v ./cmd/gomodel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,9 +37,24 @@ jobs:
           # the schema fetch is reliable again; track in this PR/branch discussion.
           verify: false
 
-  test-unit:
-    name: Unit Tests
+  # Unit, E2E, integration, and contract suites share identical setup and
+  # differ only in the test command, so they run as one matrix.
+  go-tests:
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Unit Tests
+            cmd: make test-race
+            coverage: true
+          - name: E2E Tests
+            cmd: go test -v -tags=e2e -timeout=5m ./tests/e2e/...
+          - name: Integration Tests
+            cmd: go test -v -tags=integration -timeout=10m ./tests/integration/...
+          - name: Contract Replay Tests
+            cmd: go test -v -tags=contract -timeout=5m ./tests/contract/...
     steps:
       - uses: actions/checkout@v6
 
@@ -49,10 +64,11 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
-      - name: Run unit tests
-        run: make test-race
+      - name: Run tests
+        run: ${{ matrix.cmd }}
 
       - name: Upload coverage
+        if: matrix.coverage
         uses: codecov/codecov-action@v7
         with:
           files: ./coverage.out
@@ -72,51 +88,6 @@ jobs:
 
       - name: Run dashboard JavaScript tests
         run: make test-dashboard
-
-  test-e2e:
-    name: E2E Tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: true
-
-      - name: Run E2E tests
-        run: go test -v -tags=e2e -timeout=5m ./tests/e2e/...
-
-  integration:
-    name: Integration Tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: true
-
-      - name: Run integration tests
-        run: go test -v -tags=integration -timeout=10m ./tests/integration/...
-
-  test-contract:
-    name: Contract Replay Tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: true
-
-      - name: Run contract replay tests
-        run: go test -v -tags=contract -timeout=5m ./tests/contract/...
 
   performance:
     name: Performance Guard
@@ -172,10 +143,11 @@ jobs:
         run: npx mint validate
         working-directory: docs
 
+  # Compiling the binary doesn't depend on tests passing, so this runs in
+  # parallel with the test jobs rather than gating behind them.
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, test-unit, test-dashboard, test-e2e, integration, test-contract, performance]
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,6 +108,7 @@ jobs:
   vulncheck:
     name: Vulnerability Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -118,11 +119,15 @@ jobs:
           cache: true
 
       # Scans the dependency graph against the Go vulnerability database,
-      # reporting only vulnerabilities reachable from our code.
+      # reporting only vulnerabilities reachable from our code. The second run
+      # covers the swagger-tagged production build (swagger_enabled.go), which
+      # the default tag set excludes. The tests/* suites behind e2e/integration/
+      # contract tags are deliberately skipped — they aren't in the shipped binary.
       - name: Run govulncheck
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...
+          govulncheck -tags=swagger ./...
 
   docs-validate:
     name: Docs Validation

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,7 @@ jobs:
       # contract tags are deliberately skipped — they aren't in the shipped binary.
       - name: Run govulncheck
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
+          go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
           govulncheck ./...
           govulncheck -tags=swagger ./...
 


### PR DESCRIPTION
## Summary

Consolidated CI improvements to `test.yml` (originally split across #409 + #410, now combined here):

**Supply-chain controls**
- New `vulncheck` job runs `govulncheck ./...` plus a second `-tags=swagger` pass, so the swagger-tagged production build (`swagger_enabled.go`) — excluded by the default tag set — is also scanned. The `tests/*` suites behind `e2e`/`integration`/`contract` tags are intentionally not scanned; they aren't in the shipped binary.
- `timeout-minutes: 10` on the vulncheck job so a hung scan can't run to the 360-minute default.
- `go mod verify` step in the `build` job — verifies the restored module cache against `go.sum` before the build trusts it.

**Workflow simplification**
- The four Go test jobs (`Unit Tests`, `E2E Tests`, `Integration Tests`, `Contract Replay Tests`) collapse into a single `go-tests` matrix. Check names are preserved, so required-status-check rules keep matching.
- The `build` job is no longer gated behind the test jobs — compiling the binary doesn't depend on tests passing, so it runs in parallel and shortens the critical path.

## User-visible impact

None at runtime — CI-only. Faster feedback and a vulnerability gate on PRs.

## Notes

- `go mod verify` checks *cache ↔ go.sum*; the *go.sum ↔ upstream* trust is covered by `GOSUMDB` (on by default) + PR review of `go.sum` diffs.
- Action SHA-pinning + `persist-credentials: false` (flagged by zizmor/CodeRabbit) is a repo-wide pattern and will be addressed in a dedicated follow-up PR across all workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores

- **Chores**
  - Strengthened the continuous integration pipeline with automated module verification and vulnerability scanning to improve build integrity and security.
  - Consolidated Go unit, E2E, integration, and contract replay tests into a single matrix-driven job for simpler, more consistent test execution.
  - Adjusted CI job ordering and dependencies to align the build and test flow with the new structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->