### PR TITLE
ci: simplify test workflow — matrix go tests, un-gate build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,9 +37,24 @@ jobs:
           # the schema fetch is reliable again; track in this PR/branch discussion.
           verify: false
 
-  test-unit:
-    name: Unit Tests
+  # Unit, E2E, integration, and contract suites share identical setup and
+  # differ only in the test command, so they run as one matrix.
+  go-tests:
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Unit Tests
+            cmd: make test-race
+            coverage: true
+          - name: E2E Tests
+            cmd: go test -v -tags=e2e -timeout=5m ./tests/e2e/...
+          - name: Integration Tests
+            cmd: go test -v -tags=integration -timeout=10m ./tests/integration/...
+          - name: Contract Replay Tests
+            cmd: go test -v -tags=contract -timeout=5m ./tests/contract/...
     steps:
       - uses: actions/checkout@v6
 
@@ -49,10 +64,11 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
-      - name: Run unit tests
-        run: make test-race
+      - name: Run tests
+        run: ${{ matrix.cmd }}
 
       - name: Upload coverage
+        if: matrix.coverage
         uses: codecov/codecov-action@v7
         with:
           files: ./coverage.out
@@ -72,51 +88,6 @@ jobs:
 
       - name: Run dashboard JavaScript tests
         run: make test-dashboard
-
-  test-e2e:
-    name: E2E Tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: true
-
-      - name: Run E2E tests
-        run: go test -v -tags=e2e -timeout=5m ./tests/e2e/...
-
-  integration:
-    name: Integration Tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: true
-
-      - name: Run integration tests
-        run: go test -v -tags=integration -timeout=10m ./tests/integration/...
-
-  test-contract:
-    name: Contract Replay Tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: true
-
-      - name: Run contract replay tests
-        run: go test -v -tags=contract -timeout=5m ./tests/contract/...
 
   performance:
     name: Performance Guard
@@ -172,10 +143,11 @@ jobs:
         run: npx mint validate
         working-directory: docs
 
+  # Compiling the binary doesn't depend on tests passing, so this runs in
+  # parallel with the test jobs rather than gating behind them.
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, test-unit, test-dashboard, test-e2e, integration, test-contract, performance]
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Stacked on #409 (base branch `ci/supply-chain-vulncheck`). Review/merge that first; this PR's diff then collapses to just the workflow simplification once rebased onto `main`.

## Summary

Two no-coverage-change simplifications to `test.yml`:

1. **Collapse the four Go test jobs into one matrix.** `Unit Tests`, `E2E Tests`, `Integration Tests`, and `Contract Replay Tests` shared identical checkout + `setup-go` + cache boilerplate and differed only in the test command. They're now a single `go-tests` matrix job. Net: **−50 / +22 lines**, same parallelism, same suites.
2. **Un-gate the `build` job.** It previously declared `needs: [lint, test-unit, …, performance]`, which serialized a fresh-runner recompile to *after* the slowest test finished. Compiling `./cmd/gomodel` doesn't depend on tests passing, so it now runs in parallel — shortening the critical path.

## Compatibility

- Matrix `name: ${{ matrix.name }}` renders to the **exact same check names** (`Unit Tests`, `E2E Tests`, `Integration Tests`, `Contract Replay Tests`), so required-status-check rules in branch protection keep matching with no reconfiguration.
- Codecov upload now runs only on the `Unit Tests` matrix row (`if: matrix.coverage`), same as before.

## User-visible impact

None at runtime — CI-only. Faster feedback (build no longer waits on tests) and less workflow boilerplate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated Go test execution (unit, E2E, integration, contract replay) into a single matrix job, eliminating duplicate test job configurations.
  * Build job now runs in parallel with test jobs instead of sequentially, improving CI/CD pipeline efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->