### PR TITLE
fix(streaming): normalize non-SSE upstream chat completions

### DIFF
--- a/internal/providers/chat_stream_normalize.go
+++ b/internal/providers/chat_stream_normalize.go
@@ -99,12 +99,12 @@ func bufferedCompletionToSSE(body []byte) []byte {
 		}
 	}
 
-	out := make([]byte, 0, len(payload)+len("data: \n\n")+len(chatDonePayload))
-	out = append(out, "data: "...)
-	out = append(out, payload...)
-	out = append(out, '\n', '\n')
-	out = append(out, chatDonePayload...)
-	return out
+	var out bytes.Buffer
+	out.WriteString("data: ")
+	out.Write(payload)
+	out.WriteString("\n\n")
+	out.Write(chatDonePayload)
+	return out.Bytes()
 }
 
 // bufferedReadCloser pairs a buffered reader with the underlying stream's Close.

--- a/internal/providers/chat_stream_normalize.go
+++ b/internal/providers/chat_stream_normalize.go
@@ -1,0 +1,103 @@
+package providers
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+)
+
+// chatDonePayload terminates a chat completions SSE stream.
+var chatDonePayload = []byte("data: [DONE]\n\n")
+
+// peekForNonSSE inspects up to this many leading bytes to classify the upstream
+// response. SSE payloads begin with a field name (data:, event:, id:, retry:) or
+// a ':' comment; a buffered JSON completion begins with '{'. 512 bytes comfortably
+// clears any leading whitespace or comment lines without buffering real streams.
+const peekForNonSSE = 512
+
+// EnsureChatCompletionSSE normalizes a chat completions stream so the client
+// always receives well-formed Server-Sent Events terminated by data: [DONE].
+//
+// Some OpenAI-compatible upstreams ignore stream:true and reply with a single
+// buffered application/json completion (no data: framing, no [DONE]). Forwarding
+// that verbatim under a text/event-stream content type leaves SSE clients waiting
+// forever for an end-of-stream marker that never arrives. When the upstream body
+// is detected as a buffered JSON object it is re-emitted as one SSE chunk plus a
+// terminal [DONE]; genuine SSE streams pass through untouched with no buffering.
+func EnsureChatCompletionSSE(stream io.ReadCloser) io.ReadCloser {
+	if stream == nil {
+		return nil
+	}
+
+	reader := bufio.NewReaderSize(stream, peekForNonSSE)
+	prefix, _ := reader.Peek(peekForNonSSE)
+	if firstNonSpace(prefix) != '{' {
+		// Genuine SSE (or empty): stream through unchanged.
+		return &bufferedReadCloser{Reader: reader, closer: stream}
+	}
+
+	body, err := io.ReadAll(reader)
+	_ = stream.Close() //nolint:errcheck
+	if err != nil {
+		return io.NopCloser(bytes.NewReader(chatDonePayload))
+	}
+	return io.NopCloser(bytes.NewReader(bufferedCompletionToSSE(body)))
+}
+
+// firstNonSpace returns the first non-whitespace byte of data, or 0 if none.
+func firstNonSpace(data []byte) byte {
+	for _, b := range data {
+		switch b {
+		case ' ', '\t', '\r', '\n':
+			continue
+		default:
+			return b
+		}
+	}
+	return 0
+}
+
+// bufferedCompletionToSSE wraps a buffered chat completion JSON object as a
+// single SSE chunk followed by the terminal [DONE] marker. The object field is
+// rewritten to chat.completion.chunk and each choice's message is moved to delta
+// so OpenAI SSE clients parse it as a streaming chunk. If the body does not parse
+// as a JSON object it is forwarded as-is so no data is lost, still followed by
+// [DONE] so the client stops waiting.
+func bufferedCompletionToSSE(body []byte) []byte {
+	payload := body
+	var obj map[string]any
+	if err := json.Unmarshal(body, &obj); err == nil {
+		obj["object"] = "chat.completion.chunk"
+		if choices, ok := obj["choices"].([]any); ok {
+			for _, c := range choices {
+				choice, ok := c.(map[string]any)
+				if !ok {
+					continue
+				}
+				if msg, ok := choice["message"]; ok {
+					choice["delta"] = msg
+					delete(choice, "message")
+				}
+			}
+		}
+		if encoded, err := json.Marshal(obj); err == nil {
+			payload = encoded
+		}
+	}
+
+	out := make([]byte, 0, len(payload)+len("data: \n\n")+len(chatDonePayload))
+	out = append(out, "data: "...)
+	out = append(out, payload...)
+	out = append(out, '\n', '\n')
+	out = append(out, chatDonePayload...)
+	return out
+}
+
+// bufferedReadCloser pairs a buffered reader with the underlying stream's Close.
+type bufferedReadCloser struct {
+	*bufio.Reader
+	closer io.Closer
+}
+
+func (b *bufferedReadCloser) Close() error { return b.closer.Close() }

--- a/internal/providers/chat_stream_normalize.go
+++ b/internal/providers/chat_stream_normalize.go
@@ -36,16 +36,13 @@ func EnsureChatCompletionSSE(stream io.ReadCloser) io.ReadCloser {
 		return &bufferedReadCloser{Reader: reader, closer: stream}
 	}
 
-	body, err := io.ReadAll(reader)
+	// The '{' that classified this body is already buffered, so io.ReadAll
+	// always returns at least that byte; a mid-read failure still yields the
+	// partial bytes. Either way bufferedCompletionToSSE forwards what arrived
+	// (raw when the JSON is truncated) and appends [DONE], so generated content
+	// is never dropped and the client always receives a terminator.
+	body, _ := io.ReadAll(reader)
 	_ = stream.Close() //nolint:errcheck
-	if err != nil && len(body) == 0 {
-		// The body looked like JSON but nothing arrived before the failure;
-		// still terminate so the client stops waiting instead of hanging.
-		return io.NopCloser(bytes.NewReader(chatDonePayload))
-	}
-	// A partial read (err != nil with body != "") still forwards what arrived so
-	// generated content is never silently dropped; bufferedCompletionToSSE
-	// forwards the raw bytes when they no longer parse as a complete object.
 	return io.NopCloser(bytes.NewReader(bufferedCompletionToSSE(body)))
 }
 

--- a/internal/providers/chat_stream_normalize.go
+++ b/internal/providers/chat_stream_normalize.go
@@ -31,24 +31,37 @@ func EnsureChatCompletionSSE(stream io.ReadCloser) io.ReadCloser {
 	}
 
 	reader := bufio.NewReaderSize(stream, peekForNonSSE)
-	prefix, _ := reader.Peek(peekForNonSSE)
-	if firstNonSpace(prefix) != '{' {
-		// Genuine SSE (or empty): stream through unchanged.
+	if firstNonSpaceByte(reader, peekForNonSSE) != '{' {
+		// Genuine SSE (or empty): stream through unchanged, no buffering.
 		return &bufferedReadCloser{Reader: reader, closer: stream}
 	}
 
 	body, err := io.ReadAll(reader)
 	_ = stream.Close() //nolint:errcheck
-	if err != nil {
+	if err != nil && len(body) == 0 {
+		// The body looked like JSON but nothing arrived before the failure;
+		// still terminate so the client stops waiting instead of hanging.
 		return io.NopCloser(bytes.NewReader(chatDonePayload))
 	}
+	// A partial read (err != nil with body != "") still forwards what arrived so
+	// generated content is never silently dropped; bufferedCompletionToSSE
+	// forwards the raw bytes when they no longer parse as a complete object.
 	return io.NopCloser(bytes.NewReader(bufferedCompletionToSSE(body)))
 }
 
-// firstNonSpace returns the first non-whitespace byte of data, or 0 if none.
-func firstNonSpace(data []byte) byte {
-	for _, b := range data {
-		switch b {
+// firstNonSpaceByte reports the first non-whitespace byte buffered by reader,
+// peeking one byte further at a time so a genuine SSE stream is classified from
+// its first token without blocking until a full buffer fills. It never consumes
+// input, so a passed-through stream is forwarded byte-for-byte. Returns 0 when
+// the stream ends, errors, or yields only whitespace within max bytes.
+func firstNonSpaceByte(r *bufio.Reader, max int) byte {
+	for i := 1; i <= max; i++ {
+		prefix, err := r.Peek(i)
+		if len(prefix) < i {
+			_ = err // EOF or error before any non-space byte was found
+			return 0
+		}
+		switch b := prefix[i-1]; b {
 		case ' ', '\t', '\r', '\n':
 			continue
 		default:

--- a/internal/providers/chat_stream_normalize_test.go
+++ b/internal/providers/chat_stream_normalize_test.go
@@ -1,0 +1,70 @@
+package providers
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestEnsureChatCompletionSSE_ConvertsBufferedJSON(t *testing.T) {
+	// Upstream ignored stream:true and returned a buffered, non-SSE completion.
+	body := `{"id":"x","object":"chat.completion","choices":[{"finish_reason":"stop","message":{"role":"assistant","content":"Hi there"}}]}`
+	stream := io.NopCloser(strings.NewReader(body))
+
+	got, err := io.ReadAll(EnsureChatCompletionSSE(stream))
+	if err != nil {
+		t.Fatalf("read stream: %v", err)
+	}
+
+	out := string(got)
+	if !strings.HasPrefix(out, "data: {") {
+		t.Fatalf("expected SSE data framing, got %q", out)
+	}
+	if !strings.HasSuffix(out, "data: [DONE]\n\n") {
+		t.Fatalf("expected terminal done marker, got %q", out)
+	}
+	if !strings.Contains(out, `"object":"chat.completion.chunk"`) {
+		t.Fatalf("expected object rewritten to chunk, got %q", out)
+	}
+	if !strings.Contains(out, `"delta":`) || strings.Contains(out, `"message":`) {
+		t.Fatalf("expected message rewritten to delta, got %q", out)
+	}
+}
+
+func TestEnsureChatCompletionSSE_PassesThroughRealSSE(t *testing.T) {
+	chunks := [][]byte{
+		[]byte("data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n"),
+		[]byte("data: {\"choices\":[{\"delta\":{\"content\":\" there\"}}]}\n\n"),
+		[]byte("data: [DONE]\n\n"),
+	}
+	original := strings.Join([]string{string(chunks[0]), string(chunks[1]), string(chunks[2])}, "")
+	stream := &chunkedReadCloser{chunks: chunks}
+
+	got, err := io.ReadAll(EnsureChatCompletionSSE(stream))
+	if err != nil {
+		t.Fatalf("read stream: %v", err)
+	}
+	if string(got) != original {
+		t.Fatalf("expected genuine SSE passed through unchanged.\n got: %q\nwant: %q", string(got), original)
+	}
+}
+
+func TestEnsureChatCompletionSSE_PassesThroughSSEWithLeadingComment(t *testing.T) {
+	// Providers like OpenRouter emit a leading ": ... PROCESSING" comment line.
+	body := ": OPENROUTER PROCESSING\n\ndata: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\ndata: [DONE]\n\n"
+	stream := io.NopCloser(strings.NewReader(body))
+
+	got, err := io.ReadAll(EnsureChatCompletionSSE(stream))
+	if err != nil {
+		t.Fatalf("read stream: %v", err)
+	}
+	if string(got) != body {
+		t.Fatalf("expected comment-prefixed SSE unchanged, got %q", string(got))
+	}
+}
+
+func TestEnsureChatCompletionSSE_NilStream(t *testing.T) {
+	if EnsureChatCompletionSSE(nil) != nil {
+		t.Fatal("expected nil for nil stream")
+	}
+}

--- a/internal/providers/chat_stream_normalize_test.go
+++ b/internal/providers/chat_stream_normalize_test.go
@@ -6,6 +6,28 @@ import (
 	"testing"
 )
 
+// errAfterReadCloser yields its data once, then fails — simulating a connection
+// that drops mid-body after some bytes have arrived.
+type errAfterReadCloser struct {
+	data []byte
+	err  error
+	done bool
+}
+
+func (r *errAfterReadCloser) Read(p []byte) (int, error) {
+	if r.done {
+		return 0, r.err
+	}
+	n := copy(p, r.data)
+	r.data = r.data[n:]
+	if len(r.data) == 0 {
+		r.done = true
+	}
+	return n, nil
+}
+
+func (r *errAfterReadCloser) Close() error { return nil }
+
 func TestEnsureChatCompletionSSE_ConvertsBufferedJSON(t *testing.T) {
 	// Upstream ignored stream:true and returned a buffered, non-SSE completion.
 	body := `{"id":"x","object":"chat.completion","choices":[{"finish_reason":"stop","message":{"role":"assistant","content":"Hi there"}}]}`
@@ -60,6 +82,25 @@ func TestEnsureChatCompletionSSE_PassesThroughSSEWithLeadingComment(t *testing.T
 	}
 	if string(got) != body {
 		t.Fatalf("expected comment-prefixed SSE unchanged, got %q", string(got))
+	}
+}
+
+func TestEnsureChatCompletionSSE_PreservesPartialBodyOnReadError(t *testing.T) {
+	// Upstream began a buffered JSON body, then the connection dropped mid-read.
+	// The partial content must still reach the client, followed by [DONE].
+	partial := `{"id":"x","choices":[{"message":{"content":"Hel`
+	stream := &errAfterReadCloser{data: []byte(partial), err: io.ErrUnexpectedEOF}
+
+	got, err := io.ReadAll(EnsureChatCompletionSSE(stream))
+	if err != nil {
+		t.Fatalf("read stream: %v", err)
+	}
+	out := string(got)
+	if !strings.Contains(out, "Hel") {
+		t.Fatalf("expected partial content preserved, got %q", out)
+	}
+	if !strings.HasSuffix(out, "data: [DONE]\n\n") {
+		t.Fatalf("expected terminal done marker, got %q", out)
 	}
 }
 

--- a/internal/providers/deepseek/deepseek.go
+++ b/internal/providers/deepseek/deepseek.go
@@ -149,11 +149,15 @@ func (p *Provider) StreamChatCompletion(ctx context.Context, req *core.ChatReque
 	if err != nil {
 		return nil, err
 	}
-	return p.client.DoStream(ctx, llmclient.Request{
+	stream, err := p.client.DoStream(ctx, llmclient.Request{
 		Method:   http.MethodPost,
 		Endpoint: "/chat/completions",
 		Body:     body,
 	})
+	if err != nil {
+		return nil, err
+	}
+	return providers.EnsureChatCompletionSSE(stream), nil
 }
 
 // ListModels retrieves the list of available models from DeepSeek.

--- a/internal/providers/openai/compatible_provider.go
+++ b/internal/providers/openai/compatible_provider.go
@@ -125,11 +125,15 @@ func (p *CompatibleProvider) StreamChatCompletion(ctx context.Context, req *core
 	if err != nil {
 		return nil, err
 	}
-	return p.client.DoStream(ctx, p.prepareRequest(llmclient.Request{
+	stream, err := p.client.DoStream(ctx, p.prepareRequest(llmclient.Request{
 		Method:   http.MethodPost,
 		Endpoint: "/chat/completions",
 		Body:     body,
 	}))
+	if err != nil {
+		return nil, err
+	}
+	return providers.EnsureChatCompletionSSE(stream), nil
 }
 
 func (p *CompatibleProvider) ListModels(ctx context.Context) (*core.ModelsResponse, error) {

--- a/internal/providers/xai/xai.go
+++ b/internal/providers/xai/xai.go
@@ -184,6 +184,9 @@ func (p *Provider) ChatCompletion(ctx context.Context, req *core.ChatRequest) (*
 
 // StreamChatCompletion returns a raw response body for streaming (caller must close)
 func (p *Provider) StreamChatCompletion(ctx context.Context, req *core.ChatRequest) (io.ReadCloser, error) {
+	if req == nil {
+		return nil, core.NewInvalidRequestError("chat request is required", nil)
+	}
 	stream, err := p.client.DoStream(ctx, llmclient.Request{
 		Method:   http.MethodPost,
 		Endpoint: "/chat/completions",

--- a/internal/providers/xai/xai.go
+++ b/internal/providers/xai/xai.go
@@ -184,12 +184,16 @@ func (p *Provider) ChatCompletion(ctx context.Context, req *core.ChatRequest) (*
 
 // StreamChatCompletion returns a raw response body for streaming (caller must close)
 func (p *Provider) StreamChatCompletion(ctx context.Context, req *core.ChatRequest) (io.ReadCloser, error) {
-	return p.client.DoStream(ctx, llmclient.Request{
+	stream, err := p.client.DoStream(ctx, llmclient.Request{
 		Method:   http.MethodPost,
 		Endpoint: "/chat/completions",
 		Body:     req.WithStreaming(),
 		Headers:  xGrokConversationHeaders(ctx, req),
 	})
+	if err != nil {
+		return nil, err
+	}
+	return providers.EnsureChatCompletionSSE(stream), nil
 }
 
 // ListModels retrieves the list of available models from xAI


### PR DESCRIPTION
## Summary

Fixes #411 — streaming chat completions where the connection appears to hang after the model has clearly finished, leaving the client "waiting for the model to continue outputting."

**Root cause:** Some OpenAI-compatible upstreams ignore `stream:true` and reply with a single buffered `application/json` completion (no `data:` framing, no `[DONE]`). The gateway forwarded that body verbatim under a `text/event-stream` content type, so SSE clients waited forever for an end-of-stream marker that never arrived.

Reproduced with `bailian/deepseek-v3.2` (a dedicated Aliyun MaaS deepseek deployment that silently drops streaming):

```
HTTP/1.1 200 OK
Content-Type: text/event-stream                          ← gateway claims SSE
{"choices":[{"finish_reason":"stop","message":{...}}]}   ← but buffered JSON, no data:/[DONE]
```

Other models (`qwen-flash`, `glm-5.1`, `deepseek-v4-*`, OpenAI, Anthropic, Groq) stream normally — so this is a general robustness gap for any upstream that drops streaming, not a single-provider issue.

## Not a version regression

The faulty path predates the versions named in the issue: `CompatibleProvider.StreamChatCompletion` (raw `DoStream` passthrough) is byte-identical at `v0.1.40` and today, and the unconditional `text/event-stream` header has existed since the first commit. The `v0.1.40..v0.1.42` diff touches only embeddings, health/readiness, dashboard, and storage — nothing in the chat-streaming path. The hang is triggered by the upstream model/endpoint behavior, not a gateway code change. This PR hardens the long-standing edge case.

## Fix

New shared wrapper `EnsureChatCompletionSSE`, applied in `CompatibleProvider.StreamChatCompletion` so every OpenAI-compatible provider (bailian, groq, oracle, vllm, xiaomi, deepseek, openai) benefits. Following Postel's Law:

- **Genuine SSE** (starts with `data:`, `:`, `event:`, …) passes through untouched, no buffering.
- A **buffered JSON completion** (starts with `{`) is re-emitted as one SSE chunk (`object` → `chat.completion.chunk`, each choice's `message` → `delta`) followed by a terminal `data: [DONE]`.

## Testing

- New table-driven tests for `EnsureChatCompletionSSE` (buffered-JSON conversion, genuine-SSE passthrough, leading-comment passthrough, nil).
- Manually verified with curl: `deepseek-v3.2` now emits a proper chunk **and** `[DONE]`; previously-working providers still stream multi-chunk unchanged.
- `make test-race` and `make lint` pass (pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chat completion streaming is now normalized to standard Server-Sent Events across providers, with consistent `data:` frames and a proper `[DONE]` terminator.
  * Improved behavior for non-SSE JSON responses and for upstream disconnects mid-stream, so already-received content is still delivered and the stream ends cleanly.
  * Added request validation in the XAI provider to return a clear error when the request is missing.
* **Tests**
  * Expanded coverage for SSE pass-through (including comment-prefixed payloads), JSON-to-SSE conversion, and mid-body read error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->