### PR TITLE
feat(admin): refine dashboard model and overview UI

### DIFF
--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -1289,6 +1289,12 @@ body.dashboard-modal-open {
   padding: 20px;
 }
 
+@media (min-width: 720px) {
+  .card-wide {
+    grid-column: span 2;
+  }
+}
+
 .card-label {
   font-size: 12px;
   font-weight: 600;
@@ -1302,6 +1308,36 @@ body.dashboard-modal-open {
   font-size: 28px;
   font-weight: 700;
   letter-spacing: -0.5px;
+}
+
+.cache-token-value {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  line-height: 1;
+}
+
+.cache-token-part {
+  align-items: center;
+  display: inline-flex;
+}
+
+.cache-token-operator {
+  color: var(--text-muted);
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: 0;
+  line-height: 1;
+}
+
+.cache-token-marker {
+  color: var(--text-muted);
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0;
+  margin-left: 2px;
+  text-transform: uppercase;
 }
 
 /* Chart */
@@ -1481,6 +1517,10 @@ input:is([type="text"], [type="date"], [type="number"]):focus {
   text-align: right;
 }
 
+.data-table th.col-price {
+  text-align: right;
+}
+
 td.col-price {
   font-family: "SF Mono", Menlo, Consolas, monospace;
   font-size: 13px;
@@ -1509,6 +1549,38 @@ td.col-price {
   color: var(--text-muted);
   padding: 48px 0;
   font-size: 14px;
+}
+
+.empty-state-icon {
+  display: block;
+  width: auto;
+  height: auto;
+  max-height: 160px;
+  margin: 0 auto;
+  color: var(--text-muted);
+}
+
+.empty-state-icon text {
+  font-family: inherit;
+  font-weight: 600;
+  fill: var(--text-muted);
+}
+
+/* Empty-state illustration (with baked-in label) centered over the blank usage chart, filling its height. */
+.chart-empty-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.chart-empty-overlay .empty-state-icon {
+  width: auto;
+  height: auto;
+  max-height: 195px;
+  max-width: 90%;
 }
 
 .loading-state {
@@ -2036,14 +2108,6 @@ textarea:focus {
 
 .data-table tr.alias-row.is-disabled:hover td {
   background: var(--bg-surface-hover);
-  opacity: 0.72;
-}
-
-.data-table tr.masked-model-row td {
-  opacity: 0.58;
-}
-
-.data-table tr.masked-model-row:hover td {
   opacity: 0.72;
 }
 

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -944,9 +944,11 @@ function dashboard() {
     },
 
     formatCost(v) {
-      if (v == null || v === undefined) return "---";
-      if (v > 0 && v < 0.0001) return "<$0.0001";
-      return "$" + v.toFixed(4).replace(/(\.\d{2}\d*?)0+$/, "$1");
+      if (v == null) return "---";
+      const cost = Number(v);
+      if (!Number.isFinite(cost)) return "---";
+      if (cost > 0 && cost < 0.0001) return "<$0.0001";
+      return "$" + cost.toFixed(4).replace(/(\.\d{2}\d*?)0+$/, "$1");
     },
 
     formatCostTooltip(entry) {

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -944,7 +944,7 @@ function dashboard() {
     },
 
     formatCost(v) {
-      if (v == null || v === undefined) return "N/A";
+      if (v == null || v === undefined) return "---";
       if (v > 0 && v < 0.0001) return "<$0.0001";
       return "$" + v.toFixed(4).replace(/(\.\d{2}\d*?)0+$/, "$1");
     },

--- a/internal/admin/dashboard/static/js/modules/budgets.js
+++ b/internal/admin/dashboard/static/js/modules/budgets.js
@@ -373,6 +373,9 @@
             },
 
             budgetAmountLabel(value) {
+                if (value == null) {
+                    return '---';
+                }
                 const amount = Number(value);
                 if (!Number.isFinite(amount)) {
                     return '---';

--- a/internal/admin/dashboard/static/js/modules/budgets.js
+++ b/internal/admin/dashboard/static/js/modules/budgets.js
@@ -375,7 +375,7 @@
             budgetAmountLabel(value) {
                 const amount = Number(value);
                 if (!Number.isFinite(amount)) {
-                    return 'N/A';
+                    return '---';
                 }
                 if (typeof this.formatCost === 'function') {
                     return this.formatCost(amount);

--- a/internal/admin/dashboard/static/js/modules/budgets.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/budgets.test.cjs
@@ -100,6 +100,13 @@ test('budgetFormPayload normalizes user path and standard periods', () => {
     }));
 });
 
+test('budgetAmountLabel uses data placeholder for invalid amounts', () => {
+    const module = createBudgetsModule();
+
+    assert.equal(module.budgetAmountLabel(undefined), '---');
+    assert.equal(module.budgetAmountLabel('abc'), '---');
+});
+
 test('setBudgetFormUserPath keeps the form input controlled with a leading slash', () => {
     const module = createBudgetsModule();
 

--- a/internal/admin/dashboard/static/js/modules/budgets.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/budgets.test.cjs
@@ -103,6 +103,7 @@ test('budgetFormPayload normalizes user path and standard periods', () => {
 test('budgetAmountLabel uses data placeholder for invalid amounts', () => {
     const module = createBudgetsModule();
 
+    assert.equal(module.budgetAmountLabel(null), '---');
     assert.equal(module.budgetAmountLabel(undefined), '---');
     assert.equal(module.budgetAmountLabel('abc'), '---');
 });

--- a/internal/admin/dashboard/static/js/modules/dashboard-display.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/dashboard-display.test.cjs
@@ -93,6 +93,13 @@ test('qualifiedModelDisplay does not duplicate an existing exact provider prefix
     );
 });
 
+test('formatCost uses data placeholder for missing values', () => {
+    const app = loadDashboardApp();
+
+    assert.equal(app.formatCost(null), '---');
+    assert.equal(app.formatCost(undefined), '---');
+});
+
 test('system theme media changes rerender all dashboard charts', () => {
     let mediaChangeHandler = null;
     const app = loadDashboardApp({

--- a/internal/admin/dashboard/static/js/modules/dashboard-display.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/dashboard-display.test.cjs
@@ -98,6 +98,9 @@ test('formatCost uses data placeholder for missing values', () => {
 
     assert.equal(app.formatCost(null), '---');
     assert.equal(app.formatCost(undefined), '---');
+    assert.equal(app.formatCost(NaN), '---');
+    assert.equal(app.formatCost(Infinity), '---');
+    assert.equal(app.formatCost('0.25'), '$0.25');
 });
 
 test('system theme media changes rerender all dashboard charts', () => {

--- a/internal/admin/dashboard/static/js/modules/dashboard-layout.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/dashboard-layout.test.cjs
@@ -245,12 +245,22 @@ test("overview page shows provider status summary and per-provider cards keyed b
   );
   assert.match(
     indexTemplate,
-    /Local Cache Output Tokens[\s\S]*class="card provider-status-flag"[\s\S]*<!-- Usage Chart -->/,
+    /class="card card-wide"[\s\S]*<div class="card-label">Tokens<\/div>[\s\S]*class="cache-token-part" title="Input tokens"[\s\S]*summary\.total_input_tokens[\s\S]*class="cache-token-marker">i<\/span>[\s\S]*class="cache-token-part" title="Output tokens"[\s\S]*summary\.total_output_tokens[\s\S]*class="cache-token-marker">o<\/span>[\s\S]*summaryTotalTokens\(\)[\s\S]*<div class="card-label">Total Requests<\/div>/,
   );
+  assert.doesNotMatch(indexTemplate, /<div class="card-label">Input Tokens<\/div>/);
+  assert.doesNotMatch(indexTemplate, /<div class="card-label">Output Tokens<\/div>/);
+  assert.doesNotMatch(indexTemplate, /<div class="card-label">Total Tokens<\/div>/);
+  assert.match(
+    indexTemplate,
+    /class="card card-wide" x-show="cacheAnalyticsEnabled\(\)"[\s\S]*<div class="card-label">Local Cache<\/div>[\s\S]*class="cache-token-part" title="Input tokens"[\s\S]*class="cache-token-marker">i<\/span>[\s\S]*class="cache-token-part" title="Output tokens"[\s\S]*class="cache-token-marker">o<\/span>[\s\S]*cacheOverviewTotalTokens\(\)[\s\S]*class="card provider-status-flag"[\s\S]*<!-- Usage Chart -->/,
+  );
+  assert.doesNotMatch(indexTemplate, /Local Cache Input Tokens/);
+  assert.doesNotMatch(indexTemplate, /Local Cache Output Tokens/);
   assert.match(
     indexTemplate,
     /<div class="card-label">Provider Status<\/div>[\s\S]*class="card-value provider-status-value"[\s\S]*providerStatusRatioText\(\)/,
   );
+  assert.match(css, /\.card-wide\s*\{\s*grid-column:\s*span 2;/);
   assert.match(
     indexTemplate,
     /class="provider-status-card-link"[\s\S]*x-show="providerStatusHasIssues\(\)"[\s\S]*@click="scrollToProviderStatusSection\(\)"/,
@@ -1053,6 +1063,18 @@ test("model category tables lazy mount only the active table body", () => {
   );
   assert.match(
     modelsBlock,
+    /<th class="col-price">Input \/ Output \(\$\/MTok\)<\/th>/,
+  );
+  assert.doesNotMatch(
+    modelsBlock,
+    /<th class="col-price">Output<br>\$\/MTok<\/th>/,
+  );
+  assert.match(
+    modelsBlock,
+    /activeCategory === 'embedding'[\s\S]*<th class="col-price">Input<br>\$\/MTok<\/th>/,
+  );
+  assert.match(
+    modelsBlock,
     /class="loading-state" x-show="modelsLoading && !authError" role="status" aria-live="polite"/,
   );
   assert.match(
@@ -1069,11 +1091,15 @@ test("model category tables lazy mount only the active table body", () => {
   );
   assert.match(
     modelsBlock,
-    /class="pagination-btn pagination-btn-primary pagination-btn-with-icon alias-create-btn"[\s\S]*@click="openVirtualModelCreate\(\)"[\s\S]*data-lucide="plus" class="alias-create-icon"[\s\S]*<span>Create(?:&nbsp;| )Alias<\/span>/,
+    /class="pagination-btn pagination-btn-primary pagination-btn-with-icon alias-create-btn"[\s\S]*aria-label="New virtual model alias"[\s\S]*title="Alias"[\s\S]*@click="openVirtualModelCreate\(\)"[\s\S]*data-lucide="plus" class="alias-create-icon"[\s\S]*<span>New(?:&nbsp;| )virtual(?:&nbsp;| )model<\/span>/,
   );
   assert.match(
     modelsBlock,
     /class="pagination-btn pagination-btn-primary pagination-btn-with-icon virtual-model-submit-btn"[\s\S]*:disabled="vmSubmitting \|\| vmDeleting"[\s\S]*data-lucide="plus" class="form-action-icon" x-show="vmFormMode !== 'edit'"[\s\S]*data-lucide="save" class="form-action-icon" x-show="vmFormMode === 'edit'"[\s\S]*x-text="vmSubmitting \? 'Saving\.\.\.' : \(vmFormMode === 'edit' \? 'Save' : 'Create'\)"/,
+  );
+  assert.doesNotMatch(
+    modelsBlock,
+    /class="form-kicker" x-text="vmFormMode === 'edit' \? 'Edit virtual model' : 'New virtual model'"/,
   );
   assert.match(
     modelsBlock,
@@ -1102,10 +1128,14 @@ test("model category tables lazy mount only the active table body", () => {
 
   const spinnerRule = readCSSRule(css, ".loading-spinner");
   assert.match(spinnerRule, /animation:\s*loading-spin 0\.8s linear infinite/);
+
+  const priceColumnRule = readCSSRule(css, ".data-table th.col-price");
+  assert.match(priceColumnRule, /text-align:\s*right/);
 });
 
 test("alias rows use a shared icon-only edit action", () => {
   const indexTemplate = readDashboardTemplateSource();
+  const css = readFixture("../../css/dashboard.css");
   const modelTableTemplate = readFixture(
     "../../../templates/model-table-body.html",
   );
@@ -1113,8 +1143,25 @@ test("alias rows use a shared icon-only edit action", () => {
 
   assert.match(
     modelTableTemplate,
-    /class="table-action-btn table-icon-btn"[\s\S]*:aria-label="'Edit alias ' \+ row\.alias\.name"[\s\S]*@click="openVirtualModelEditAlias\(row\.alias\)"[\s\S]*{{template "edit-icon"}}/,
+    /class="table-action-btn table-action-btn-danger table-icon-btn"[\s\S]*x-show="virtualModelsAvailable && aliasRowCanRemove\(row\)"[\s\S]*@click="removeAliasRow\(row\)"[\s\S]*{{template "trash-icon"}}[\s\S]*class="table-action-btn table-icon-btn"[\s\S]*:aria-label="'Edit alias ' \+ row\.alias\.name"[\s\S]*@click="openVirtualModelEditAlias\(row\.alias\)"[\s\S]*{{template "edit-icon"}}/,
   );
+  assert.match(
+    modelTableTemplate,
+    /x-show="activeCategory === 'all' \|\| activeCategory === 'text_generation'" x-text="formatPrice\(modelRowPricing\(row\)\?\.input_per_mtok\) \+ ' \/ ' \+ formatPrice\(modelRowPricing\(row\)\?\.output_per_mtok\)"/,
+  );
+  assert.match(
+    modelTableTemplate,
+    /x-show="activeCategory === 'embedding'" x-text="formatPrice\(modelRowPricing\(row\)\?\.input_per_mtok\)"/,
+  );
+  assert.match(
+    modelTableTemplate,
+    /Redirects to <span class="mono font-size-md" x-text="aliasTargetLabel\(row\.masking_alias\)"><\/span>/,
+  );
+  assert.match(
+    modelTableTemplate,
+    /x-show="modelPricingOverridesAvailable"[\s\S]*@click="openModelPricingOverrideEdit\(row\)"[\s\S]*{{template "dollar-icon"}}[\s\S]*class="table-action-btn table-action-btn-danger table-icon-btn"[\s\S]*x-show="virtualModelsAvailable && rowRedirectCanRemove\(row\)"[\s\S]*@click="removeRedirectRow\(row\)"[\s\S]*{{template "trash-icon"}}/,
+  );
+  assert.doesNotMatch(css, /\.data-table tr\.masked-model-row td/);
   assert.match(indexTemplate, /{{template "model-table-body" \.}}/);
   assert.match(
     indexTemplate,

--- a/internal/admin/dashboard/static/js/modules/providers.js
+++ b/internal/admin/dashboard/static/js/modules/providers.js
@@ -33,7 +33,12 @@
                 try {
                     const storage = browserStorage();
                     if (storage) {
-                        storage.setItem(PROVIDER_STATUS_DETAILS_STORAGE_KEY, 'false');
+                        const stored = storage.getItem(PROVIDER_STATUS_DETAILS_STORAGE_KEY);
+                        if (stored === 'true' || stored === 'false') {
+                            this.providerStatusDetailsExpanded = stored === 'true';
+                        } else {
+                            storage.setItem(PROVIDER_STATUS_DETAILS_STORAGE_KEY, 'false');
+                        }
                     }
                 } catch (_) {
                     // Ignore storage failures; details still start collapsed.

--- a/internal/admin/dashboard/static/js/modules/providers.js
+++ b/internal/admin/dashboard/static/js/modules/providers.js
@@ -1,5 +1,6 @@
 (function(global) {
     const PROVIDER_STATUS_DETAILS_STORAGE_KEY = 'gomodel_provider_status_details_expanded';
+    const PROVIDER_STATUS_POLL_MS = 3000;
 
     function browserStorage() {
         try {
@@ -12,6 +13,7 @@
     function dashboardProvidersModule() {
         return {
             providerStatusDetailsExpanded: false,
+            providerStatusPollTimer: null,
 
             emptyProviderStatus() {
                 return {
@@ -27,16 +29,14 @@
             },
 
             initProviderStatusPreferences() {
-                const storage = browserStorage();
-                if (!storage) {
-                    this.providerStatusDetailsExpanded = false;
-                    return;
-                }
-
+                this.providerStatusDetailsExpanded = false;
                 try {
-                    this.providerStatusDetailsExpanded = storage.getItem(PROVIDER_STATUS_DETAILS_STORAGE_KEY) === 'true';
+                    const storage = browserStorage();
+                    if (storage) {
+                        storage.setItem(PROVIDER_STATUS_DETAILS_STORAGE_KEY, 'false');
+                    }
                 } catch (_) {
-                    this.providerStatusDetailsExpanded = false;
+                    // Ignore storage failures; details still start collapsed.
                 }
             },
 
@@ -58,7 +58,46 @@
             },
 
             providerStatusDetailsToggleLabel() {
-                return this.providerStatusDetailsExpanded ? 'Hide Details' : 'Show Details';
+                return this.providerStatusDetailsExpanded ? 'Show Details' : 'Hide Details';
+            },
+
+            providerStatusNeedsPolling() {
+                const providers = this.providerStatus && Array.isArray(this.providerStatus.providers)
+                    ? this.providerStatus.providers
+                    : [];
+                return providers.some((provider) => {
+                    const label = String(provider && provider.status_label || '').trim().toLowerCase();
+                    return label === 'starting';
+                });
+            },
+
+            clearProviderStatusRefresh() {
+                if (!this.providerStatusPollTimer) {
+                    return;
+                }
+                const clearTimer = global.clearTimeout || (typeof clearTimeout === 'function' ? clearTimeout : null);
+                if (typeof clearTimer === 'function') {
+                    clearTimer(this.providerStatusPollTimer);
+                }
+                this.providerStatusPollTimer = null;
+            },
+
+            scheduleProviderStatusRefresh() {
+                this.clearProviderStatusRefresh();
+                if (!this.providerStatusNeedsPolling()) {
+                    return;
+                }
+                const setTimer = global.setTimeout || (typeof setTimeout === 'function' ? setTimeout : null);
+                if (typeof setTimer !== 'function') {
+                    return;
+                }
+                this.providerStatusPollTimer = setTimer(() => {
+                    this.providerStatusPollTimer = null;
+                    if (typeof this.fetchProviderStatus === 'function') {
+                        return this.fetchProviderStatus();
+                    }
+                    return null;
+                }, PROVIDER_STATUS_POLL_MS);
             },
 
             async fetchProviderStatus() {
@@ -81,6 +120,7 @@
                     }
                     if (!handled) {
                         this.providerStatus = this.emptyProviderStatus();
+                        this.clearProviderStatusRefresh();
                         return;
                     }
                     const payload = await res.json();
@@ -96,12 +136,14 @@
                     if (!Array.isArray(this.providerStatus.providers)) {
                         this.providerStatus.providers = [];
                     }
+                    this.scheduleProviderStatusRefresh();
                 } catch (e) {
                     if (typeof this._isAbortError === 'function' && this._isAbortError(e)) {
                         return;
                     }
                     console.error('Failed to fetch provider status:', e);
                     this.providerStatus = this.emptyProviderStatus();
+                    this.clearProviderStatusRefresh();
                 } finally {
                     if (typeof this._clearAbortableRequest === 'function') {
                         this._clearAbortableRequest('_providerStatusFetchController', controller);

--- a/internal/admin/dashboard/static/js/modules/providers.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/providers.test.cjs
@@ -78,7 +78,7 @@ test('provider helper methods format configured models and resilience summaries'
 
 test('provider detail toggle starts collapsed, persists toggles, and last check formatting uses time-only text', () => {
     const storage = {
-        values: new Map([['gomodel_provider_status_details_expanded', 'true']]),
+        values: new Map(),
         getItem(key) {
             return this.values.has(key) ? this.values.get(key) : null;
         },
@@ -98,6 +98,14 @@ test('provider detail toggle starts collapsed, persists toggles, and last check 
     module.toggleProviderStatusDetails();
     assert.equal(module.providerStatusDetailsExpanded, true);
     assert.equal(module.providerStatusDetailsToggleLabel(), 'Show Details');
+    assert.equal(storage.getItem('gomodel_provider_status_details_expanded'), 'true');
+
+    const reloadedModule = createProvidersModule({
+        window: { localStorage: storage }
+    });
+    reloadedModule.initProviderStatusPreferences();
+    assert.equal(reloadedModule.providerStatusDetailsExpanded, true);
+    assert.equal(reloadedModule.providerStatusDetailsToggleLabel(), 'Show Details');
     assert.equal(storage.getItem('gomodel_provider_status_details_expanded'), 'true');
 
     module.formatTimestamp = (value) => value === '2026-04-10T12:00:00Z'

--- a/internal/admin/dashboard/static/js/modules/providers.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/providers.test.cjs
@@ -76,7 +76,7 @@ test('provider helper methods format configured models and resilience summaries'
     assert.equal(module.providerTypeLabel({ name: 'azure-east', config: { type: 'azure' } }), 'azure');
 });
 
-test('provider detail toggle persists in browser storage and last check formatting uses time-only text', () => {
+test('provider detail toggle starts collapsed, persists toggles, and last check formatting uses time-only text', () => {
     const storage = {
         values: new Map([['gomodel_provider_status_details_expanded', 'true']]),
         getItem(key) {
@@ -91,12 +91,14 @@ test('provider detail toggle persists in browser storage and last check formatti
     });
 
     module.initProviderStatusPreferences();
-    assert.equal(module.providerStatusDetailsExpanded, true);
+    assert.equal(module.providerStatusDetailsExpanded, false);
     assert.equal(module.providerStatusDetailsToggleLabel(), 'Hide Details');
+    assert.equal(storage.getItem('gomodel_provider_status_details_expanded'), 'false');
 
     module.toggleProviderStatusDetails();
-    assert.equal(module.providerStatusDetailsExpanded, false);
-    assert.equal(storage.getItem('gomodel_provider_status_details_expanded'), 'false');
+    assert.equal(module.providerStatusDetailsExpanded, true);
+    assert.equal(module.providerStatusDetailsToggleLabel(), 'Show Details');
+    assert.equal(storage.getItem('gomodel_provider_status_details_expanded'), 'true');
 
     module.formatTimestamp = (value) => value === '2026-04-10T12:00:00Z'
         ? '2026-04-10 14:00:00'
@@ -110,6 +112,57 @@ test('provider detail toggle persists in browser storage and last check formatti
 
     assert.equal(module.providerLastCheckedTime(provider), '14:00:00');
     assert.equal(module.providerLastCheckedTitle(provider), '2026-04-10 14:00:00');
+});
+
+test('provider status polling refreshes while any provider is starting', async() => {
+    const timers = [];
+    const cleared = [];
+    const responses = [
+        {
+            summary: { total: 1, healthy: 0, degraded: 1, unhealthy: 0, overall_status: 'degraded' },
+            providers: [{ name: 'openai', status_label: 'Starting' }]
+        },
+        {
+            summary: { total: 1, healthy: 1, degraded: 0, unhealthy: 0, overall_status: 'healthy' },
+            providers: [{ name: 'openai', status_label: 'Healthy' }]
+        }
+    ];
+    let fetches = 0;
+    const module = createProvidersModule({
+        window: {
+            setTimeout(callback, ms) {
+                const timer = { callback, ms };
+                timers.push(timer);
+                return timer;
+            },
+            clearTimeout(timer) {
+                cleared.push(timer);
+            }
+        },
+        fetch: async() => ({
+            ok: true,
+            status: 200,
+            json: async() => responses[Math.min(fetches++, responses.length - 1)]
+        })
+    });
+
+    module._startAbortableRequest = () => null;
+    module._clearAbortableRequest = () => {};
+    module.requestOptions = () => ({ headers: {} });
+    module.handleFetchResponse = () => true;
+    module.isStaleAuthFetchResult = () => false;
+
+    await module.fetchProviderStatus();
+
+    assert.equal(module.providerStatusNeedsPolling(), true);
+    assert.equal(timers.length, 1);
+    assert.equal(timers[0].ms, 3000);
+
+    await timers[0].callback();
+
+    assert.equal(fetches, 2);
+    assert.equal(module.providerStatusNeedsPolling(), false);
+    assert.equal(module.providerStatusPollTimer, null);
 });
 
 test('fetchProviderStatus ignores responses whose request signal was aborted', async() => {

--- a/internal/admin/dashboard/static/js/modules/usage.js
+++ b/internal/admin/dashboard/static/js/modules/usage.js
@@ -39,6 +39,26 @@
                 };
             },
 
+            summaryTotalTokens() {
+                const summary = this.summary || {};
+                if (summary.total_tokens !== null && summary.total_tokens !== undefined) {
+                    const total = Number(summary.total_tokens);
+                    if (Number.isFinite(total)) {
+                        return total;
+                    }
+                }
+                const input = Number(summary.total_input_tokens || 0);
+                const output = Number(summary.total_output_tokens || 0);
+                return (Number.isFinite(input) ? input : 0) + (Number.isFinite(output) ? output : 0);
+            },
+
+            cacheOverviewTotalTokens() {
+                const summary = this.cacheOverview && this.cacheOverview.summary ? this.cacheOverview.summary : {};
+                const input = Number(summary.total_input_tokens || 0);
+                const output = Number(summary.total_output_tokens || 0);
+                return (Number.isFinite(input) ? input : 0) + (Number.isFinite(output) ? output : 0);
+            },
+
             cacheAnalyticsEnabled() {
                 return typeof this.workflowRuntimeBooleanFlag === 'function'
                     ? this.workflowRuntimeBooleanFlag('CACHE_ENABLED', false)

--- a/internal/admin/dashboard/static/js/modules/usage.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/usage.test.cjs
@@ -61,6 +61,46 @@ test('usageEntryCacheLabel returns capitalized cache type or dash', () => {
     assert.equal(module.usageEntryCacheLabel({ cache_type: 'other' }), '-');
 });
 
+test('summaryTotalTokens uses total tokens and falls back to input plus output', () => {
+    const module = createUsageModule();
+
+    module.summary = {
+        total_input_tokens: 120,
+        total_output_tokens: 30,
+        total_tokens: 155
+    };
+    assert.equal(module.summaryTotalTokens(), 155);
+
+    module.summary = {
+        total_input_tokens: '120',
+        total_output_tokens: 30,
+        total_tokens: null
+    };
+    assert.equal(module.summaryTotalTokens(), 150);
+
+    module.summary = null;
+    assert.equal(module.summaryTotalTokens(), 0);
+});
+
+test('cacheOverviewTotalTokens sums local cache input and output tokens', () => {
+    const module = createUsageModule();
+
+    module.cacheOverview = {
+        summary: {
+            total_input_tokens: '120',
+            total_output_tokens: 30
+        }
+    };
+
+    assert.equal(module.cacheOverviewTotalTokens(), 150);
+
+    module.cacheOverview = { summary: { total_input_tokens: null, total_output_tokens: 'bad' } };
+    assert.equal(module.cacheOverviewTotalTokens(), 0);
+
+    module.cacheOverview = null;
+    assert.equal(module.cacheOverviewTotalTokens(), 0);
+});
+
 test('hasProviderCache detects positive cached_input_tokens', () => {
     const module = createUsageModule();
 

--- a/internal/admin/dashboard/static/js/modules/virtual-models.js
+++ b/internal/admin/dashboard/static/js/modules/virtual-models.js
@@ -66,11 +66,7 @@
                 }
 
                 for (const row of rows) {
-                    const sourceKeys = [
-                        String(row.display_name || '').trim().toLowerCase(),
-                        String(row.selector || '').trim().toLowerCase()
-                    ].filter(Boolean);
-                    for (const key of sourceKeys) {
+                    for (const key of this.modelKeys(row)) {
                         const redirect = redirectsBySource.get(key);
                         if (!redirect) continue;
                         row.masking_alias = redirect;
@@ -1154,11 +1150,7 @@
                 if (!normalizedName) {
                     return false;
                 }
-                return this.models.some((model) => {
-                    const qualified = this.normalizedAliasName(this.qualifiedModelName(model));
-                    const selector = this.normalizedAliasName(model && model.selector);
-                    return qualified === normalizedName || (selector && selector === normalizedName);
-                });
+                return this.models.some((model) => this.modelKeys(model).has(normalizedName));
             },
 
             // submitVirtualModelForm saves the unified editor: a filled Target model

--- a/internal/admin/dashboard/static/js/modules/virtual-models.js
+++ b/internal/admin/dashboard/static/js/modules/virtual-models.js
@@ -11,6 +11,7 @@
             aliasError: '',
             aliasNotice: '',
             rowTogglingKey: '',
+            rowDeletingKey: '',
 
             // Unified editor (replaces the old alias modal and access-override modal).
             vmFormOpen: false,
@@ -55,26 +56,26 @@
                     return rows;
                 }
 
-                const maskingAliases = new Map();
+                const redirectsBySource = new Map();
                 for (const alias of this.aliases) {
                     const aliasName = String(alias && alias.name || '').trim().toLowerCase();
                     if (!aliasName || alias.enabled === false || !alias.valid) {
                         continue;
                     }
-                    maskingAliases.set(aliasName, alias);
+                    redirectsBySource.set(aliasName, alias);
                 }
 
                 for (const row of rows) {
-                    for (const key of this.modelIdentifierKeys(
-                        row.model && row.model.id,
-                        row.provider_type,
-                        row.provider_name,
-                        row.display_name
-                    )) {
-                        if (maskingAliases.has(key)) {
-                            row.masking_alias = maskingAliases.get(key);
-                            break;
-                        }
+                    const sourceKeys = [
+                        String(row.display_name || '').trim().toLowerCase(),
+                        String(row.selector || '').trim().toLowerCase()
+                    ].filter(Boolean);
+                    for (const key of sourceKeys) {
+                        const redirect = redirectsBySource.get(key);
+                        if (!redirect) continue;
+                        row.masking_alias = redirect;
+                        row.has_virtual_model = true;
+                        break;
                     }
                     // A real model row carries a virtual model when an access policy
                     // override exists for its selector.
@@ -84,6 +85,9 @@
                 }
 
                 for (const alias of this.aliases) {
+                    if (alias && alias.enabled !== false && alias.valid && this.hasConcreteSourceModel(alias.name)) {
+                        continue;
+                    }
                     const targetModel = this.findConcreteModelForAlias(alias);
                     if (!targetModel && this.activeCategory && this.activeCategory !== 'all') {
                         continue;
@@ -100,8 +104,9 @@
                         is_alias: true,
                         alias,
                         access: null,
-                        kind_badge: 'Alias',
+                        kind_badge: 'Virtual Model',
                         masking_alias: null,
+                        source_model_exists: this.hasConcreteSourceModel(alias.name),
                         has_virtual_model: true,
                         alias_state_class: this.aliasStateClass(alias),
                         alias_state_text: this.aliasStateText(alias)
@@ -505,12 +510,23 @@
 
             // rowVirtualBadge returns the small badge label shown on a real model row
             // that carries a virtual model (empty for plain rows and alias rows, which
-            // already show their own Alias badge).
+            // already show their own Virtual Model badge).
             rowVirtualBadge(row) {
                 if (!row || row.is_alias || !row.has_virtual_model) {
                     return '';
                 }
+                if (row.masking_alias) {
+                    return 'Redirect';
+                }
                 return 'Override';
+            },
+
+            aliasRowCanRemove(row) {
+                return Boolean(row && row.is_alias && row.alias && row.alias.name && !row.source_model_exists);
+            },
+
+            rowRedirectCanRemove(row) {
+                return Boolean(row && !row.is_alias && row.masking_alias && row.masking_alias.name);
             },
 
             rowAnchorID(row) {
@@ -955,6 +971,73 @@
                 }
             },
 
+            async removeAliasRow(row) {
+                if (!this.aliasRowCanRemove(row) || this.rowDeletingKey === row.key) {
+                    return;
+                }
+                const source = String(row.alias.name || '').trim();
+                if (!source) {
+                    return;
+                }
+                await this.removeVirtualModelSource(source, row.key, 'Remove the virtual model alias "' + source + '"?');
+            },
+
+            async removeRedirectRow(row) {
+                if (!this.rowRedirectCanRemove(row) || this.rowDeletingKey === row.key) {
+                    return;
+                }
+                const source = String(row.masking_alias.name || '').trim();
+                if (!source) {
+                    return;
+                }
+                await this.removeVirtualModelSource(source, row.key, 'Remove the redirect for "' + source + '"?');
+            },
+
+            async removeVirtualModelSource(source, rowKey, confirmMessage) {
+                if (!this.confirmAction(confirmMessage)) {
+                    return;
+                }
+
+                this.rowDeletingKey = rowKey;
+                this.aliasError = '';
+                this.aliasNotice = '';
+
+                try {
+                    const request = this.adminRequestOptions({
+                        method: 'DELETE',
+                        body: JSON.stringify({ source })
+                    });
+                    const res = await fetch('/admin/virtual-models', request);
+                    if (res.status === 503) {
+                        this.setVirtualModelsAvailable(false);
+                        this.aliasError = 'Virtual models feature is unavailable.';
+                        return;
+                    }
+                    if (res.status !== 404) {
+                        const handled = this.handleFetchResponse(res, 'virtual model', request);
+                        if (typeof this.isStaleAuthFetchResult === 'function' && this.isStaleAuthFetchResult(handled)) {
+                            return;
+                        }
+                        if (!handled) {
+                            this.aliasError = res.status === 401
+                                ? 'Authentication required.'
+                                : await this.aliasResponseMessage(res, 'Failed to remove virtual model.');
+                            return;
+                        }
+                    }
+                    this.setVirtualModelsAvailable(true);
+
+                    await Promise.all([this.fetchModels(), this.fetchVirtualModels()]);
+                    this.syncDisplayModels();
+                    this.aliasNotice = 'Virtual model removed.';
+                } catch (e) {
+                    console.error('Failed to delete virtual model:', e);
+                    this.aliasError = 'Failed to remove virtual model.';
+                } finally {
+                    this.rowDeletingKey = '';
+                }
+            },
+
             modelKeys(model) {
                 return this.modelIdentifierKeys(
                     model && model.model ? model.model.id : '',
@@ -1064,6 +1147,18 @@
                     }
                 }
                 return null;
+            },
+
+            hasConcreteSourceModel(name) {
+                const normalizedName = this.normalizedAliasName(name);
+                if (!normalizedName) {
+                    return false;
+                }
+                return this.models.some((model) => {
+                    const qualified = this.normalizedAliasName(this.qualifiedModelName(model));
+                    const selector = this.normalizedAliasName(model && model.selector);
+                    return qualified === normalizedName || (selector && selector === normalizedName);
+                });
             },
 
             // submitVirtualModelForm saves the unified editor: a filled Target model

--- a/internal/admin/dashboard/static/js/modules/virtual-models.js
+++ b/internal/admin/dashboard/static/js/modules/virtual-models.js
@@ -518,7 +518,7 @@
             },
 
             aliasRowCanRemove(row) {
-                return Boolean(row && row.is_alias && row.alias && row.alias.name && !row.source_model_exists);
+                return Boolean(row && row.is_alias && row.alias && row.alias.name);
             },
 
             rowRedirectCanRemove(row) {
@@ -968,7 +968,7 @@
             },
 
             async removeAliasRow(row) {
-                if (!this.aliasRowCanRemove(row) || this.rowDeletingKey === row.key) {
+                if (!this.aliasRowCanRemove(row) || this.rowDeletingKey) {
                     return;
                 }
                 const source = String(row.alias.name || '').trim();
@@ -979,7 +979,7 @@
             },
 
             async removeRedirectRow(row) {
-                if (!this.rowRedirectCanRemove(row) || this.rowDeletingKey === row.key) {
+                if (!this.rowRedirectCanRemove(row) || this.rowDeletingKey) {
                     return;
                 }
                 const source = String(row.masking_alias.name || '').trim();
@@ -990,6 +990,9 @@
             },
 
             async removeVirtualModelSource(source, rowKey, confirmMessage) {
+                if (this.rowDeletingKey) {
+                    return;
+                }
                 if (!this.confirmAction(confirmMessage)) {
                     return;
                 }

--- a/internal/admin/dashboard/static/js/modules/virtual-models.js
+++ b/internal/admin/dashboard/static/js/modules/virtual-models.js
@@ -1182,7 +1182,7 @@
                     const existingPolicy = existingAlias ? null : this.findModelOverrideView(source);
                     if (existingAlias || existingPolicy) {
                         const overwriteMessage = existingAlias
-                            ? 'An alias named "' + existingAlias.name + '" already exists. Saving will update that virtual model. Continue?'
+                            ? 'A virtual model named "' + existingAlias.name + '" already exists. Saving will update that virtual model. Continue?'
                             : 'An access policy for "' + source + '" already exists. Saving will update that virtual model. Continue?';
                         if (!this.confirmAction(overwriteMessage)) {
                             this.vmFormError = 'Choose a different source or edit the existing virtual model.';

--- a/internal/admin/dashboard/static/js/modules/virtual-models.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/virtual-models.test.cjs
@@ -421,6 +421,44 @@ test('submitVirtualModelForm sends a redirect payload when target_model is fille
     });
 });
 
+test('submitVirtualModelForm names existing aliases as virtual models in overwrite confirmation', async() => {
+    const requests = [];
+    const confirms = [];
+    const module = createAliasesModule({
+        context: {
+            fetch: async(url, request) => {
+                requests.push({ url, request });
+                return { ok: true, status: 200, json: async() => ({}) };
+            }
+        },
+        window: {
+            confirm(message) {
+                confirms.push(message);
+                return false;
+            }
+        }
+    });
+    stubRequests(module);
+    module.aliases = [{ name: 'smart', enabled: true, valid: true }];
+    module.models = [];
+    module.vmFormMode = 'create';
+    module.vmForm = {
+        source: 'smart',
+        target_model: 'openai/gpt-4o',
+        user_paths: '',
+        description: '',
+        enabled: true
+    };
+
+    await module.submitVirtualModelForm();
+
+    assert.deepEqual(confirms, [
+        'A virtual model named "smart" already exists. Saving will update that virtual model. Continue?'
+    ]);
+    assert.equal(requests.length, 0);
+    assert.equal(module.vmFormError, 'Choose a different source or edit the existing virtual model.');
+});
+
 test('submitVirtualModelForm sends a policy payload when target_model is empty', async() => {
     const requests = [];
     const module = createAliasesModule({

--- a/internal/admin/dashboard/static/js/modules/virtual-models.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/virtual-models.test.cjs
@@ -568,7 +568,7 @@ test('buildDisplayModels combines source-backed redirects with the concrete mode
             valid: true
         },
         {
-            name: 'openai/gpt-4o',
+            name: 'gpt-4o',
             target_provider: 'openai',
             target_model: 'gpt-4o',
             enabled: true,
@@ -587,20 +587,22 @@ test('buildDisplayModels combines source-backed redirects with the concrete mode
     module.syncDisplayModels();
 
     const aliasOnly = module.displayModels.find((row) => row.key === 'alias:smart');
-    const modelBackedAliasRow = module.displayModels.find((row) => row.key === 'alias:openai/gpt-4o');
+    const modelBackedAliasRow = module.displayModels.find((row) => row.key === 'alias:gpt-4o');
     const modelBacked = module.displayModels.find((row) => row.key === 'model:openai/gpt-4o');
     const nestedTargetAlias = module.displayModels.find((row) => row.key === 'alias:anthropic/claude-fable-5');
+    const nestedTargetModel = module.displayModels.find((row) => row.key === 'model:openrouter/anthropic/claude-fable-5');
 
     assert.equal(aliasOnly.kind_badge, 'Virtual Model');
     assert.equal(aliasOnly.source_model_exists, false);
     assert.equal(module.aliasRowCanRemove(aliasOnly), true);
     assert.equal(modelBackedAliasRow, undefined);
-    assert.equal(modelBacked.masking_alias.name, 'openai/gpt-4o');
+    assert.equal(modelBacked.masking_alias.name, 'gpt-4o');
     assert.equal(module.rowVirtualBadge(modelBacked), 'Redirect');
     assert.equal(module.rowRedirectCanRemove(modelBacked), true);
-    assert.equal(nestedTargetAlias.secondary_name, 'openrouter/anthropic/claude-fable-5');
-    assert.equal(nestedTargetAlias.source_model_exists, false);
-    assert.equal(module.aliasRowCanRemove(nestedTargetAlias), true);
+    assert.equal(nestedTargetAlias, undefined);
+    assert.equal(nestedTargetModel.masking_alias.name, 'anthropic/claude-fable-5');
+    assert.equal(module.rowVirtualBadge(nestedTargetModel), 'Redirect');
+    assert.equal(module.rowRedirectCanRemove(nestedTargetModel), true);
 });
 
 test('removeAliasRow confirms and deletes an alias-only virtual model', async() => {

--- a/internal/admin/dashboard/static/js/modules/virtual-models.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/virtual-models.test.cjs
@@ -509,6 +509,11 @@ test('displayRowClass renders real models carrying a virtual model as alias-like
     const aliasRow = { is_alias: true, alias: { enabled: true, valid: true } };
     assert.equal(module.displayRowClass(aliasRow), 'alias-row is-valid');
     assert.equal(module.rowVirtualBadge(aliasRow), '');
+    assert.equal(module.aliasRowCanRemove({
+        is_alias: true,
+        source_model_exists: true,
+        alias: { name: 'openai/gpt-4o' }
+    }), true);
 });
 
 test('buildDisplayModels flags model rows with a policy override as carrying a virtual model', () => {
@@ -683,6 +688,45 @@ test('removeRedirectRow confirms and deletes a source-backed redirect', async() 
     assert.deepEqual(JSON.parse(requests[0].request.body), { source: 'openai/gpt-4o' });
     assert.deepEqual(fetched, ['models', 'virtual', 'sync']);
     assert.equal(module.aliasNotice, 'Virtual model removed.');
+    assert.equal(module.rowDeletingKey, '');
+});
+
+test('row virtual model deletes are serialized while a delete is in flight', async() => {
+    const requests = [];
+    let finishFirstDelete;
+    const module = createAliasesModule({
+        context: {
+            fetch: async(url, request) => {
+                requests.push({ url, request });
+                await new Promise((resolve) => { finishFirstDelete = resolve; });
+                return { ok: true, status: 200, json: async() => ({}) };
+            }
+        },
+        window: { confirm: () => true }
+    });
+    stubRequests(module);
+    module.fetchModels = async() => {};
+    module.fetchVirtualModels = async() => {};
+    module.syncDisplayModels = () => {};
+
+    const firstDelete = module.removeAliasRow({
+        key: 'alias:first',
+        is_alias: true,
+        alias: { name: 'first' }
+    });
+    await Promise.resolve();
+
+    await module.removeAliasRow({
+        key: 'alias:second',
+        is_alias: true,
+        alias: { name: 'second' }
+    });
+
+    assert.equal(requests.length, 1);
+    assert.deepEqual(JSON.parse(requests[0].request.body), { source: 'first' });
+
+    finishFirstDelete();
+    await firstDelete;
     assert.equal(module.rowDeletingKey, '');
 });
 

--- a/internal/admin/dashboard/static/js/modules/virtual-models.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/virtual-models.test.cjs
@@ -492,6 +492,16 @@ test('displayRowClass renders real models carrying a virtual model as alias-like
     assert.equal(module.displayRowClass(overrideRow), 'alias-row is-valid');
     assert.equal(module.rowVirtualBadge(overrideRow), 'Override');
 
+    const redirectRow = {
+        is_alias: false,
+        has_virtual_model: true,
+        masking_alias: { name: 'openai/gpt-4o' },
+        access: { effective_enabled: true }
+    };
+    assert.equal(module.displayRowClass(redirectRow), 'alias-row is-valid masked-model-row');
+    assert.equal(module.rowVirtualBadge(redirectRow), 'Redirect');
+    assert.equal(module.rowRedirectCanRemove(redirectRow), true);
+
     const plainRow = { is_alias: false, has_virtual_model: false, access: { effective_enabled: true } };
     assert.equal(module.displayRowClass(plainRow), '');
     assert.equal(module.rowVirtualBadge(plainRow), '');
@@ -531,6 +541,147 @@ test('buildDisplayModels flags model rows with a policy override as carrying a v
 
     assert.equal(withOverride.has_virtual_model, true);
     assert.equal(without.has_virtual_model, false);
+});
+
+test('buildDisplayModels combines source-backed redirects with the concrete model row', () => {
+    const module = createAliasesModule();
+    module.models = [
+        {
+            provider_name: 'openai',
+            provider_type: 'openai',
+            selector: 'openai/gpt-4o',
+            model: { id: 'gpt-4o', object: 'model' }
+        },
+        {
+            provider_name: 'openrouter',
+            provider_type: 'openrouter',
+            selector: 'openrouter/anthropic/claude-fable-5',
+            model: { id: 'anthropic/claude-fable-5', object: 'model' }
+        }
+    ];
+    module.aliases = [
+        {
+            name: 'smart',
+            target_provider: 'openai',
+            target_model: 'gpt-4o',
+            enabled: true,
+            valid: true
+        },
+        {
+            name: 'openai/gpt-4o',
+            target_provider: 'openai',
+            target_model: 'gpt-4o',
+            enabled: true,
+            valid: true
+        },
+        {
+            name: 'anthropic/claude-fable-5',
+            target_provider: 'openrouter',
+            target_model: 'anthropic/claude-fable-5',
+            resolved_model: 'openrouter/anthropic/claude-fable-5',
+            enabled: true,
+            valid: true
+        }
+    ];
+    module.virtualModelsAvailable = true;
+    module.syncDisplayModels();
+
+    const aliasOnly = module.displayModels.find((row) => row.key === 'alias:smart');
+    const modelBackedAliasRow = module.displayModels.find((row) => row.key === 'alias:openai/gpt-4o');
+    const modelBacked = module.displayModels.find((row) => row.key === 'model:openai/gpt-4o');
+    const nestedTargetAlias = module.displayModels.find((row) => row.key === 'alias:anthropic/claude-fable-5');
+
+    assert.equal(aliasOnly.kind_badge, 'Virtual Model');
+    assert.equal(aliasOnly.source_model_exists, false);
+    assert.equal(module.aliasRowCanRemove(aliasOnly), true);
+    assert.equal(modelBackedAliasRow, undefined);
+    assert.equal(modelBacked.masking_alias.name, 'openai/gpt-4o');
+    assert.equal(module.rowVirtualBadge(modelBacked), 'Redirect');
+    assert.equal(module.rowRedirectCanRemove(modelBacked), true);
+    assert.equal(nestedTargetAlias.secondary_name, 'openrouter/anthropic/claude-fable-5');
+    assert.equal(nestedTargetAlias.source_model_exists, false);
+    assert.equal(module.aliasRowCanRemove(nestedTargetAlias), true);
+});
+
+test('removeAliasRow confirms and deletes an alias-only virtual model', async() => {
+    const requests = [];
+    const confirms = [];
+    const fetched = [];
+    const module = createAliasesModule({
+        context: {
+            fetch: async(url, request) => {
+                requests.push({ url, request });
+                return { ok: true, status: 200, json: async() => ({}) };
+            }
+        },
+        window: {
+            confirm(message) {
+                confirms.push(message);
+                return true;
+            }
+        }
+    });
+    stubRequests(module);
+    module.models = [];
+    module.fetchModels = async() => { fetched.push('models'); };
+    module.fetchVirtualModels = async() => { fetched.push('virtual'); };
+    module.syncDisplayModels = () => { fetched.push('sync'); };
+
+    await module.removeAliasRow({
+        key: 'alias:smart',
+        is_alias: true,
+        source_model_exists: false,
+        alias: { name: 'smart' }
+    });
+
+    assert.deepEqual(confirms, ['Remove the virtual model alias "smart"?']);
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0].url, '/admin/virtual-models');
+    assert.equal(requests[0].request.method, 'DELETE');
+    assert.deepEqual(JSON.parse(requests[0].request.body), { source: 'smart' });
+    assert.deepEqual(fetched, ['models', 'virtual', 'sync']);
+    assert.equal(module.aliasNotice, 'Virtual model removed.');
+    assert.equal(module.rowDeletingKey, '');
+});
+
+test('removeRedirectRow confirms and deletes a source-backed redirect', async() => {
+    const requests = [];
+    const confirms = [];
+    const fetched = [];
+    const module = createAliasesModule({
+        context: {
+            fetch: async(url, request) => {
+                requests.push({ url, request });
+                return { ok: true, status: 200, json: async() => ({}) };
+            }
+        },
+        window: {
+            confirm(message) {
+                confirms.push(message);
+                return true;
+            }
+        }
+    });
+    stubRequests(module);
+    module.fetchModels = async() => { fetched.push('models'); };
+    module.fetchVirtualModels = async() => { fetched.push('virtual'); };
+    module.syncDisplayModels = () => { fetched.push('sync'); };
+
+    await module.removeRedirectRow({
+        key: 'model:openai/gpt-4o',
+        is_alias: false,
+        display_name: 'openai/gpt-4o',
+        masking_alias: { name: 'openai/gpt-4o' }
+    });
+
+    assert.deepEqual(confirms, ['Remove the redirect for "openai/gpt-4o"?']);
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0].url, '/admin/virtual-models');
+    assert.equal(requests[0].request.method, 'DELETE');
+    assert.deepEqual(JSON.parse(requests[0].request.body), { source: 'openai/gpt-4o' });
+    assert.deepEqual(fetched, ['models', 'virtual', 'sync']);
+    assert.equal(module.aliasNotice, 'Virtual model removed.');
+    assert.equal(module.rowDeletingKey, '');
 });
 
 test('filteredDisplayModelGroups groups rows by provider_name and applies provider-wide overrides', () => {

--- a/internal/admin/dashboard/templates/model-table-body.html
+++ b/internal/admin/dashboard/templates/model-table-body.html
@@ -72,7 +72,7 @@
                                 x-show="virtualModelsAvailable && aliasRowCanRemove(row)"
                                 :aria-label="rowDeletingKey === row.key ? 'Removing alias ' + row.alias.name : 'Remove alias ' + row.alias.name"
                                 :title="rowDeletingKey === row.key ? 'Removing alias ' + row.alias.name : 'Remove alias ' + row.alias.name"
-                                :disabled="rowDeletingKey === row.key"
+                                :disabled="Boolean(rowDeletingKey)"
                                 @click="removeAliasRow(row)">
                                 {{template "trash-icon"}}
                             </button>
@@ -100,7 +100,7 @@
                                 x-show="virtualModelsAvailable && rowRedirectCanRemove(row)"
                                 :aria-label="rowDeletingKey === row.key ? 'Removing redirect for ' + row.display_name : 'Remove redirect for ' + row.display_name"
                                 :title="rowDeletingKey === row.key ? 'Removing redirect for ' + row.display_name : 'Remove redirect for ' + row.display_name"
-                                :disabled="rowDeletingKey === row.key"
+                                :disabled="Boolean(rowDeletingKey)"
                                 @click="removeRedirectRow(row)">
                                 {{template "trash-icon"}}
                             </button>

--- a/internal/admin/dashboard/templates/model-table-body.html
+++ b/internal/admin/dashboard/templates/model-table-body.html
@@ -2,7 +2,7 @@
 <template x-for="group in filteredDisplayModelGroups" :key="group.key">
     <tbody>
         <tr class="provider-group-row">
-            <td :colspan="activeCategory === 'embedding' || activeCategory === 'image' ? 3 : (activeCategory === 'all' || activeCategory === 'text_generation' ? 6 : 4)">
+            <td :colspan="activeCategory === 'embedding' || activeCategory === 'image' ? 3 : (activeCategory === 'text_generation' ? 5 : (activeCategory === 'all' ? 4 : 4))">
                 <div class="provider-group-header">
                     <div class="provider-group-meta">
                         <div class="provider-group-title">
@@ -49,13 +49,13 @@
                             Targets <span class="mono font-size-md" x-text="row.secondary_name"></span>
                         </div>
                         <div class="model-name-secondary" x-show="!row.is_alias && row.masking_alias">
-                            Masked by alias to <span class="mono font-size-md" x-text="aliasTargetLabel(row.masking_alias)"></span>
+                            Redirects to <span class="mono font-size-md" x-text="aliasTargetLabel(row.masking_alias)"></span>
                         </div>
                     </div>
                 </td>
                 <td x-show="activeCategory === 'all' || activeCategory === 'text_generation'" x-text="(row.model.metadata?.modes ?? []).join(', ') || '-'"></td>
-                <td class="col-price" x-show="activeCategory === 'all' || activeCategory === 'text_generation' || activeCategory === 'embedding'" x-text="formatPrice(modelRowPricing(row)?.input_per_mtok)"></td>
-                <td class="col-price" x-show="activeCategory === 'all' || activeCategory === 'text_generation'" x-text="formatPrice(modelRowPricing(row)?.output_per_mtok)"></td>
+                <td class="col-price" x-show="activeCategory === 'all' || activeCategory === 'text_generation'" x-text="formatPrice(modelRowPricing(row)?.input_per_mtok) + ' / ' + formatPrice(modelRowPricing(row)?.output_per_mtok)"></td>
+                <td class="col-price" x-show="activeCategory === 'embedding'" x-text="formatPrice(modelRowPricing(row)?.input_per_mtok)"></td>
                 <td class="col-price" x-show="activeCategory === 'text_generation'" x-text="formatPrice(modelRowPricing(row)?.cached_input_per_mtok)"></td>
                 <td class="col-price" x-show="activeCategory === 'image'" x-text="formatPriceFine(modelRowPricing(row)?.per_image)"></td>
                 <td class="col-price" x-show="activeCategory === 'audio'" x-text="formatPriceFine(modelRowPricing(row)?.per_second_input)"></td>
@@ -68,6 +68,14 @@
                     <template x-if="row.is_alias">
                         <div class="alias-actions-cell model-list-actions">
                             {{template "access-toggle" "row"}}
+                            <button type="button" class="table-action-btn table-action-btn-danger table-icon-btn"
+                                x-show="virtualModelsAvailable && aliasRowCanRemove(row)"
+                                :aria-label="rowDeletingKey === row.key ? 'Removing alias ' + row.alias.name : 'Remove alias ' + row.alias.name"
+                                :title="rowDeletingKey === row.key ? 'Removing alias ' + row.alias.name : 'Remove alias ' + row.alias.name"
+                                :disabled="rowDeletingKey === row.key"
+                                @click="removeAliasRow(row)">
+                                {{template "trash-icon"}}
+                            </button>
                             <button type="button" class="table-action-btn table-icon-btn"
                                 x-show="virtualModelsAvailable"
                                 :aria-label="'Edit alias ' + row.alias.name"
@@ -87,6 +95,14 @@
                                 :title="modelPricingButtonLabel('model pricing for ' + row.display_name, hasModelPricingOverride(row))"
                                 @click="openModelPricingOverrideEdit(row)">
                                 {{template "dollar-icon"}}
+                            </button>
+                            <button type="button" class="table-action-btn table-action-btn-danger table-icon-btn"
+                                x-show="virtualModelsAvailable && rowRedirectCanRemove(row)"
+                                :aria-label="rowDeletingKey === row.key ? 'Removing redirect for ' + row.display_name : 'Remove redirect for ' + row.display_name"
+                                :title="rowDeletingKey === row.key ? 'Removing redirect for ' + row.display_name : 'Remove redirect for ' + row.display_name"
+                                :disabled="rowDeletingKey === row.key"
+                                @click="removeRedirectRow(row)">
+                                {{template "trash-icon"}}
                             </button>
                             <button type="button" class="table-action-btn table-icon-btn"
                                 x-show="virtualModelsAvailable"

--- a/internal/admin/dashboard/templates/no-data-icon.html
+++ b/internal/admin/dashboard/templates/no-data-icon.html
@@ -1,0 +1,20 @@
+{{define "no-data-icon"}}
+<svg class="empty-state-icon" viewBox="0 0 220 262" fill="none" role="img" aria-label="No data" xmlns="http://www.w3.org/2000/svg">
+    <!-- GoModel hexagon mark: sharp mitered edges like the logotype -->
+    <path d="M110 20 L187.9 65 L187.9 155 L110 200 L32.1 155 L32.1 65 Z"
+          stroke="var(--accent)" stroke-width="5" stroke-linejoin="miter" opacity="0.5"></path>
+    <!-- faint chart gridlines -->
+    <path d="M60 123 H160" stroke="currentColor" stroke-width="2" stroke-dasharray="1.5 7" stroke-linecap="round" opacity="0.18"></path>
+    <path d="M60 93 H160"  stroke="currentColor" stroke-width="2" stroke-dasharray="1.5 7" stroke-linecap="round" opacity="0.18"></path>
+    <!-- empty chart baseline (the floor), level with the hexagon's lower shoulders -->
+    <path d="M50 155 H170" stroke="currentColor" stroke-width="5" stroke-linecap="round" opacity="0.6"></path>
+    <!-- ghosted placeholder bars, floating just above the floor -->
+    <rect x="57"  y="113" width="14" height="36" rx="4" stroke="currentColor" stroke-width="2.8" stroke-dasharray="5 4" opacity="0.55"></rect>
+    <rect x="80"  y="91"  width="14" height="58" rx="4" stroke="currentColor" stroke-width="2.8" stroke-dasharray="5 4" opacity="0.55"></rect>
+    <rect x="103" y="75"  width="14" height="74" rx="4" stroke="currentColor" stroke-width="2.8" stroke-dasharray="5 4" opacity="0.55"></rect>
+    <rect x="126" y="97"  width="14" height="52" rx="4" stroke="currentColor" stroke-width="2.8" stroke-dasharray="5 4" opacity="0.55"></rect>
+    <rect x="149" y="119" width="14" height="30" rx="4" stroke="currentColor" stroke-width="2.8" stroke-dasharray="5 4" opacity="0.55"></rect>
+    <!-- label -->
+    <text x="110" y="250" text-anchor="middle" fill="currentColor" font-size="40">No data</text>
+</svg>
+{{end}}

--- a/internal/admin/dashboard/templates/page-audit-logs.html
+++ b/internal/admin/dashboard/templates/page-audit-logs.html
@@ -113,7 +113,7 @@
             </template>
         </div>
 
-        <p class="empty-state" x-show="auditLog.entries.length === 0 && !loading && !authError">No audit log entries found.</p>
+        <div class="empty-state" x-show="auditLog.entries.length === 0 && !loading && !authError">{{template "no-data-icon"}}</div>
 
         {{template "pagination" "auditLog"}}
     </div>

--- a/internal/admin/dashboard/templates/page-models.html
+++ b/internal/admin/dashboard/templates/page-models.html
@@ -38,9 +38,9 @@
             </div>
         </div>
         <div class="table-toolbar-actions">
-            <button type="button" class="pagination-btn pagination-btn-primary pagination-btn-with-icon alias-create-btn" x-show="virtualModelsAvailable" @click="openVirtualModelCreate()">
+            <button type="button" class="pagination-btn pagination-btn-primary pagination-btn-with-icon alias-create-btn" x-show="virtualModelsAvailable" aria-label="New virtual model alias" title="Alias" @click="openVirtualModelCreate()">
                 <i data-lucide="plus" class="alias-create-icon" aria-hidden="true"></i>
-                <span>Create&nbsp;Alias</span>
+                <span>New&nbsp;virtual&nbsp;model</span>
             </button>
         </div>
     </div>
@@ -65,7 +65,6 @@
             <form class="form" @submit.prevent="submitVirtualModelForm()">
                 <div class="editor-header">
                     <div>
-                        <p class="form-kicker" x-text="vmFormMode === 'edit' ? 'Edit virtual model' : 'New virtual model'"></p>
                         <h3 x-text="vmFormDisplayName || vmForm.source || 'Virtual model'"></h3>
                     </div>
                     <button type="button" class="dialog-close-btn" aria-label="Close virtual model editor" @click="closeVirtualModelForm()">
@@ -256,8 +255,7 @@
                 <tr>
                     <th>Model</th>
                     <th>Modes</th>
-                    <th class="col-price">Input<br>$/MTok</th>
-                    <th class="col-price">Output<br>$/MTok</th>
+                    <th class="col-price">Input / Output ($/MTok)</th>
                     <th class="col-price" x-show="activeCategory === 'text_generation'">Cached $/MTok</th>
                     <th class="model-actions-header">{{template "model-global-action-buttons" .}}</th>
                 </tr>

--- a/internal/admin/dashboard/templates/page-overview.html
+++ b/internal/admin/dashboard/templates/page-overview.html
@@ -20,21 +20,23 @@
 
     <!-- Summary Cards -->
     <div class="cards">
+        <div class="card card-wide">
+            <div class="card-label">Tokens</div>
+            <div class="card-value cache-token-value">
+                <span class="cache-token-part" title="Input tokens">
+                    <span x-text="formatNumber(summary.total_input_tokens)">-</span><span class="cache-token-marker">i</span>
+                </span>
+                <span class="cache-token-operator">+</span>
+                <span class="cache-token-part" title="Output tokens">
+                    <span x-text="formatNumber(summary.total_output_tokens)">-</span><span class="cache-token-marker">o</span>
+                </span>
+                <span class="cache-token-operator">=</span>
+                <span x-text="formatNumber(summaryTotalTokens())" title="Total tokens">-</span>
+            </div>
+        </div>
         <div class="card">
             <div class="card-label">Total Requests</div>
             <div class="card-value" x-text="formatNumber(summary.total_requests)">-</div>
-        </div>
-        <div class="card">
-            <div class="card-label">Input Tokens</div>
-            <div class="card-value" x-text="formatNumber(summary.total_input_tokens)">-</div>
-        </div>
-        <div class="card">
-            <div class="card-label">Output Tokens</div>
-            <div class="card-value" x-text="formatNumber(summary.total_output_tokens)">-</div>
-        </div>
-        <div class="card">
-            <div class="card-label">Total Tokens</div>
-            <div class="card-value" x-text="formatNumber(summary.total_tokens)">-</div>
         </div>
         <div class="card">
             <div class="card-label">Estimated Cost</div>
@@ -44,13 +46,19 @@
             <div class="card-label">Cache Hits</div>
             <div class="card-value" x-text="formatNumber(cacheOverview.summary.total_hits)">-</div>
         </div>
-        <div class="card" x-show="cacheAnalyticsEnabled()">
-            <div class="card-label">Local Cache Input Tokens</div>
-            <div class="card-value" x-text="formatNumber(cacheOverview.summary.total_input_tokens)">-</div>
-        </div>
-        <div class="card" x-show="cacheAnalyticsEnabled()">
-            <div class="card-label">Local Cache Output Tokens</div>
-            <div class="card-value" x-text="formatNumber(cacheOverview.summary.total_output_tokens)">-</div>
+        <div class="card card-wide" x-show="cacheAnalyticsEnabled()">
+            <div class="card-label">Local Cache</div>
+            <div class="card-value cache-token-value">
+                <span class="cache-token-part" title="Input tokens">
+                    <span x-text="formatNumber(cacheOverview.summary.total_input_tokens)">-</span><span class="cache-token-marker">i</span>
+                </span>
+                <span class="cache-token-operator">+</span>
+                <span class="cache-token-part" title="Output tokens">
+                    <span x-text="formatNumber(cacheOverview.summary.total_output_tokens)">-</span><span class="cache-token-marker">o</span>
+                </span>
+                <span class="cache-token-operator">=</span>
+                <span x-text="formatNumber(cacheOverviewTotalTokens())" title="Total tokens">-</span>
+            </div>
         </div>
         <div class="card provider-status-flag" x-show="providerStatus.summary.total > 0" :class="providerStatusSummaryClass()">
             <div class="card-label">Provider Status</div>
@@ -71,8 +79,8 @@
         <h3 x-text="chartTitle()">Daily Token Usage</h3>
         <div class="chart-wrapper">
             <canvas id="usageChart"></canvas>
+            <div class="chart-empty-overlay" x-show="daily.length === 0 && !loading && !authError">{{template "no-data-icon"}}</div>
         </div>
-        <p class="empty-state" x-show="daily.length === 0 && !loading && !authError">No usage data yet.</p>
     </div>
 
     <!-- Contribution Calendar -->

--- a/internal/admin/dashboard/templates/page-usage.html
+++ b/internal/admin/dashboard/templates/page-usage.html
@@ -215,7 +215,7 @@
                 </tbody>
             </table>
         </div>
-        <p class="empty-state" x-show="usageLog.entries.length === 0 && !loading && !authError">No usage log entries found.</p>
+        <div class="empty-state" x-show="usageLog.entries.length === 0 && !loading && !authError">{{template "no-data-icon"}}</div>
         <!-- Pagination -->
         {{template "pagination" "usageLog"}}
     </div>

--- a/internal/admin/dashboard/templates/trash-icon.html
+++ b/internal/admin/dashboard/templates/trash-icon.html
@@ -1,0 +1,9 @@
+{{define "trash-icon"}}
+<svg class="table-icon-svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M3 6h18"></path>
+    <path d="M8 6V4h8v2"></path>
+    <path d="M19 6l-1 14H6L5 6"></path>
+    <path d="M10 11v6"></path>
+    <path d="M14 11v6"></path>
+</svg>
+{{end}}


### PR DESCRIPTION
## Summary
- combine overview token and local cache metrics into wider summary cards with clearer input/output indicators
- refine virtual model rows, redirect pills, removal actions, pricing columns, and modal labels on the models page
- add provider overview auto-refresh for starting providers, default-collapsed details, corrected toggle labels, and shared no-data/trash icons

## Tests
- node --test internal/admin/dashboard/static/js/modules/usage.test.cjs internal/admin/dashboard/static/js/modules/dashboard-display.test.cjs internal/admin/dashboard/static/js/modules/budgets.test.cjs internal/admin/dashboard/static/js/modules/dashboard-layout.test.cjs internal/admin/dashboard/static/js/modules/virtual-models.test.cjs internal/admin/dashboard/static/js/modules/providers.test.cjs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consolidated overview and Local Cache token metrics into wider Input/Output/Total cards.
  * Added shared “No data” empty-state illustration for charts, usage, and audit logs, including a centered chart overlay.
  * Improved virtual model management UI with alias/redirect-specific delete controls and updated labels.

* **Bug Fixes**
  * Standardized missing/invalid cost and budget displays to show `---`.
  * Refined dashboard table pricing alignment and empty/error presentation; updated token rendering styling.
  * Improved provider status auto-refresh and made the details panel default to collapsed with updated toggle text.

* **Tests**
  * Added/updated unit and UI tests for formatting, token totals, provider polling, and virtual model overwrite/redirect/delete flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->