### PR TITLE
feat(dashboard): add token cache meter and overview refinements

### DIFF
--- a/cmd/gomodel/docs/docs.go
+++ b/cmd/gomodel/docs/docs.go
@@ -6915,6 +6915,12 @@ const docTemplate = `{
         "usage.UsageSummary": {
             "type": "object",
             "properties": {
+                "cache_write_input_tokens": {
+                    "type": "integer"
+                },
+                "cached_input_tokens": {
+                    "type": "integer"
+                },
                 "total_cost": {
                     "type": "number"
                 },
@@ -6934,6 +6940,9 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "total_tokens": {
+                    "type": "integer"
+                },
+                "uncached_input_tokens": {
                     "type": "integer"
                 }
             }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -9051,6 +9051,12 @@
       "usage.UsageSummary": {
         "type": "object",
         "properties": {
+          "cache_write_input_tokens": {
+            "type": "integer"
+          },
+          "cached_input_tokens": {
+            "type": "integer"
+          },
           "total_cost": {
             "type": "number"
           },
@@ -9070,6 +9076,9 @@
             "type": "integer"
           },
           "total_tokens": {
+            "type": "integer"
+          },
+          "uncached_input_tokens": {
             "type": "integer"
           }
         }

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -18,6 +18,15 @@
   --danger: #ef4444;
   --prompt-cache-color: #40a811;
   --prompt-cache-color-bg: color-mix(in srgb, var(--prompt-cache-color) 14%, var(--bg-surface));
+  /* Cache meter segments. Declared once as semantic aliases: --accent/--info
+     are re-themed per mode, and var() resolves lazily per element, so these
+     stay theme-correct without duplicating across the light/dark blocks. */
+  --cache-meter-uncached: var(--accent);
+  /* Two distinct greens: a deep emerald (darkened --success) for local hits,
+     lime --prompt-cache-color for provider prompt-cache reads. --success is the
+     same in both themes, so the mix stays theme-consistent. */
+  --cache-meter-local: color-mix(in srgb, var(--success) 58%, #000);
+  --cache-meter-prompt: var(--prompt-cache-color);
   --sidebar-width: 240px;
   --radius: 8px;
   --chart-grid: #2a2826;
@@ -1149,6 +1158,12 @@ body.dashboard-modal-open {
   letter-spacing: -0.02em;
 }
 
+/* Provider docs help icon — reuses the standard help-toggle badge as a link. */
+.provider-doc-help {
+  align-self: center;
+  text-decoration: none;
+}
+
 .provider-status-name-type {
   font-size: 11px;
   font-weight: 700;
@@ -1341,6 +1356,114 @@ body.dashboard-modal-open {
 }
 
 /* Chart */
+.cache-meter {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 24px;
+  margin-bottom: 28px;
+}
+
+.cache-meter-header {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 4px 12px;
+  margin-bottom: 16px;
+}
+
+.cache-meter-header h3 {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.cache-meter-subtitle {
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.cache-meter-bar {
+  display: flex;
+  width: 100%;
+  height: 28px;
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--bg-surface-hover);
+}
+
+.cache-meter-segment {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  min-width: 3px;
+  overflow: hidden;
+  transition: width 0.3s ease;
+}
+
+.cache-meter-segment-label {
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+  /* Keeps white legible on the lighter brown slice in dark mode. */
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
+}
+
+.cache-meter-segment + .cache-meter-segment {
+  box-shadow: -1px 0 0 var(--bg-surface);
+}
+
+.cache-meter-bar.is-empty {
+  height: auto;
+  min-height: 28px;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 12px;
+  background: var(--bg-surface-hover);
+}
+
+.cache-meter-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 24px;
+  margin-top: 16px;
+}
+
+.cache-meter-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.cache-meter-swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.cache-meter-legend-label {
+  color: var(--text);
+}
+
+.cache-meter-legend-pct {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.cache-meter-legend-tokens {
+  color: var(--text-muted);
+}
+
+.cache-meter-empty {
+  font-size: 13px;
+  color: var(--text-muted);
+  text-align: center;
+}
+
 .chart-container {
   background: var(--bg-surface);
   border: 1px solid var(--border);
@@ -1352,6 +1475,20 @@ body.dashboard-modal-open {
   font-size: 16px;
   font-weight: 600;
   margin-bottom: 16px;
+}
+
+/* Chart header: title on the left, interval picker on the right. */
+.chart-container-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.chart-container-header h3 {
+  margin-bottom: 0;
 }
 
 .chart-wrapper {

--- a/internal/admin/dashboard/static/js/modules/providers.js
+++ b/internal/admin/dashboard/static/js/modules/providers.js
@@ -2,6 +2,25 @@
     const PROVIDER_STATUS_DETAILS_STORAGE_KEY = 'gomodel_provider_status_details_expanded';
     const PROVIDER_STATUS_POLL_MS = 3000;
 
+    // Provider types that have a dedicated docs page at
+    // gomodel.enterpilot.io/docs/providers/. Keyed by provider type; the value
+    // is the docs slug (identical to the type except opencode_go → opencode-go).
+    // Types absent here get no help icon — that is the "doc exists" gate.
+    const PROVIDER_DOCS_BASE_URL = 'https://gomodel.enterpilot.io/docs/providers/';
+    const PROVIDER_DOC_SLUGS = {
+        anthropic: 'anthropic',
+        azure: 'azure',
+        bailian: 'bailian',
+        bedrock: 'bedrock',
+        deepseek: 'deepseek',
+        gemini: 'gemini',
+        opencode_go: 'opencode-go',
+        oracle: 'oracle',
+        vertex: 'vertex',
+        vllm: 'vllm',
+        xiaomi: 'xiaomi'
+    };
+
     function browserStorage() {
         try {
             return global.localStorage || null;
@@ -247,6 +266,18 @@
                     return '';
                 }
                 return type;
+            },
+
+            // Docs URL for a provider's type, or '' when no provider-specific
+            // page exists (the help icon is shown only when this is non-empty).
+            // Uses the raw type so it still resolves when the (type) label is
+            // hidden because the provider name equals its type.
+            providerDocUrl(provider) {
+                const type = String(
+                    (provider && (provider.type || (provider.config && provider.config.type))) || ''
+                ).trim().toLowerCase();
+                const slug = type ? PROVIDER_DOC_SLUGS[type] : '';
+                return slug ? PROVIDER_DOCS_BASE_URL + slug : '';
             },
 
             providerRetrySummary(provider) {

--- a/internal/admin/dashboard/static/js/modules/providers.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/providers.test.cjs
@@ -76,6 +76,23 @@ test('provider helper methods format configured models and resilience summaries'
     assert.equal(module.providerTypeLabel({ name: 'azure-east', config: { type: 'azure' } }), 'azure');
 });
 
+test('providerDocUrl links provider types with docs and stays empty otherwise', () => {
+    const module = createProvidersModule();
+
+    // Types with a dedicated docs page.
+    assert.equal(module.providerDocUrl({ type: 'anthropic' }), 'https://gomodel.enterpilot.io/docs/providers/anthropic');
+    assert.equal(module.providerDocUrl({ config: { type: 'bedrock' } }), 'https://gomodel.enterpilot.io/docs/providers/bedrock');
+    // Type slug differs from the docs slug.
+    assert.equal(module.providerDocUrl({ type: 'opencode_go' }), 'https://gomodel.enterpilot.io/docs/providers/opencode-go');
+    // Resolves even when the (type) label is hidden because name === type.
+    assert.equal(module.providerDocUrl({ name: 'gemini', type: 'GEMINI' }), 'https://gomodel.enterpilot.io/docs/providers/gemini');
+    // Types without a provider-specific doc → no link (no icon).
+    assert.equal(module.providerDocUrl({ type: 'openai' }), '');
+    assert.equal(module.providerDocUrl({ type: 'ollama' }), '');
+    assert.equal(module.providerDocUrl({ name: 'mystery' }), '');
+    assert.equal(module.providerDocUrl(null), '');
+});
+
 test('provider detail toggle starts collapsed, persists toggles, and last check formatting uses time-only text', () => {
     const storage = {
         values: new Map(),

--- a/internal/admin/dashboard/static/js/modules/usage.js
+++ b/internal/admin/dashboard/static/js/modules/usage.js
@@ -330,6 +330,12 @@
                         return;
                     }
                     console.error('Failed to fetch usage:', e);
+                    // Match the handled-failure branch: a fetch()/json() rejection
+                    // must not leave the previous period's data rendered.
+                    this.summary = this.emptyUsageSummary();
+                    this.daily = [];
+                    this.cacheOverview = this.emptyCacheOverview();
+                    this.renderChart();
                 } finally {
                     if (typeof this._clearAbortableRequest === 'function') {
                         this._clearAbortableRequest('_usageFetchController', controller);

--- a/internal/admin/dashboard/static/js/modules/usage.js
+++ b/internal/admin/dashboard/static/js/modules/usage.js
@@ -18,6 +18,9 @@
                     total_input_tokens: 0,
                     total_output_tokens: 0,
                     total_tokens: 0,
+                    uncached_input_tokens: 0,
+                    cached_input_tokens: 0,
+                    cache_write_input_tokens: 0,
                     total_input_cost: null,
                     total_output_cost: null,
                     total_cost: null
@@ -52,6 +55,29 @@
                 return (Number.isFinite(input) ? input : 0) + (Number.isFinite(output) ? output : 0);
             },
 
+            // Local response-cache hits over the period. The summary endpoint
+            // counts provider (uncached-mode) requests only, so hits live in the
+            // cache overview. Zero when cache analytics is off (overview unfetched).
+            summaryCacheHits() {
+                if (!this.cacheAnalyticsEnabled()) return 0;
+                const cacheSummary = this.cacheOverview && this.cacheOverview.summary ? this.cacheOverview.summary : {};
+                const hits = Number(cacheSummary.total_hits || 0);
+                return Number.isFinite(hits) && hits > 0 ? hits : 0;
+            },
+
+            // Total requests including local cache hits (provider requests + hits).
+            summaryTotalRequests() {
+                const requests = Number((this.summary && this.summary.total_requests) || 0);
+                return (Number.isFinite(requests) ? requests : 0) + this.summaryCacheHits();
+            },
+
+            summaryTotalRequestsTitle() {
+                const hits = this.summaryCacheHits();
+                if (hits <= 0) return '';
+                const provider = this.summaryTotalRequests() - hits;
+                return this.formatNumber(provider) + ' to providers + ' + this.formatNumber(hits) + ' from cache';
+            },
+
             cacheOverviewTotalTokens() {
                 const summary = this.cacheOverview && this.cacheOverview.summary ? this.cacheOverview.summary : {};
                 const input = Number(summary.total_input_tokens || 0);
@@ -63,6 +89,104 @@
                 return typeof this.workflowRuntimeBooleanFlag === 'function'
                     ? this.workflowRuntimeBooleanFlag('CACHE_ENABLED', false)
                     : false;
+            },
+
+            // --- Cache meter (overview) ---
+            // Splits the selected period's input tokens into three buckets that
+            // sum to 100%: not-cached, locally-cached (GoModel response cache),
+            // and prompt-cached (provider cache reads). The provider split comes
+            // from /admin/usage/summary (uncached/cached/cache-write over provider
+            // rows); the local slice from /admin/cache/overview. Both already
+            // refresh with the period, so the meter follows the picker for free.
+            cacheMeterRawSegments() {
+                const positive = (value) => {
+                    const n = Number(value || 0);
+                    return Number.isFinite(n) && n > 0 ? n : 0;
+                };
+                const summary = this.summary || {};
+                const uncached = positive(summary.uncached_input_tokens);
+                const promptCached = positive(summary.cached_input_tokens);
+                const cacheWrite = positive(summary.cache_write_input_tokens);
+                const cacheSummary = this.cacheOverview && this.cacheOverview.summary ? this.cacheOverview.summary : {};
+                const locallyCached = this.cacheAnalyticsEnabled() ? positive(cacheSummary.total_input_tokens) : 0;
+                return [
+                    {
+                        key: 'uncached',
+                        label: 'Regular',
+                        tokens: uncached + cacheWrite,
+                        colorVar: '--cache-meter-uncached',
+                        note: cacheWrite > 0 ? 'Includes ' + this.formatNumber(cacheWrite) + ' cache-write tokens' : ''
+                    },
+                    {
+                        key: 'local',
+                        label: 'Locally cached',
+                        tokens: locallyCached,
+                        colorVar: '--cache-meter-local',
+                        note: 'Served from GoModel response cache'
+                    },
+                    {
+                        key: 'prompt',
+                        label: 'Prompt cached',
+                        tokens: promptCached,
+                        colorVar: '--cache-meter-prompt',
+                        note: 'Provider prompt-cache reads'
+                    }
+                ];
+            },
+
+            cacheMeterTotal() {
+                return this.cacheMeterRawSegments().reduce((sum, seg) => sum + seg.tokens, 0);
+            },
+
+            cacheMeterVisible() {
+                return this.cacheMeterTotal() > 0;
+            },
+
+            // The three fixed categories with integer percentages. Largest-
+            // remainder rounding keeps the percents summing to exactly 100 when
+            // there is data; with no usage every category is 0% so the meter can
+            // still render as an empty key. Used by the legend (all three shown)
+            // and, filtered to non-zero, by the bar segments.
+            cacheMeterCategories() {
+                const categories = this.cacheMeterRawSegments();
+                const total = categories.reduce((sum, seg) => sum + seg.tokens, 0);
+                if (total <= 0) {
+                    return categories.map((seg) => Object.assign({}, seg, { pct: 0 }));
+                }
+                const withPct = categories.map((seg) => {
+                    const exact = (seg.tokens / total) * 100;
+                    const floor = Math.floor(exact);
+                    return Object.assign({}, seg, { pct: floor, remainder: exact - floor });
+                });
+                let leftover = 100 - withPct.reduce((sum, seg) => sum + seg.pct, 0);
+                withPct
+                    .map((seg, index) => ({ index, remainder: seg.remainder, tokens: seg.tokens }))
+                    .filter((entry) => entry.tokens > 0)
+                    .sort((a, b) => b.remainder - a.remainder)
+                    .forEach((entry) => {
+                        if (leftover > 0) {
+                            withPct[entry.index].pct += 1;
+                            leftover -= 1;
+                        }
+                    });
+                return withPct;
+            },
+
+            // Non-zero categories only, so the bar never renders zero-width
+            // slivers. Empty when there is no usage.
+            cacheMeterSegments() {
+                return this.cacheMeterCategories().filter((seg) => seg.tokens > 0);
+            },
+
+            cacheMeterSegmentTitle(segment) {
+                const parts = [segment.label + ': ' + this.formatNumber(segment.tokens) + ' input tokens (' + segment.pct + '%)'];
+                if (segment.note) parts.push(segment.note);
+                return parts.join('\n');
+            },
+
+            cacheMeterAriaLabel() {
+                const parts = this.cacheMeterSegments().map((seg) => seg.label + ' ' + seg.pct + '%');
+                return 'Cache breakdown of input tokens — ' + (parts.length ? parts.join(', ') : 'no data');
             },
 
             cacheOverviewVisible() {

--- a/internal/admin/dashboard/static/js/modules/usage.js
+++ b/internal/admin/dashboard/static/js/modules/usage.js
@@ -313,11 +313,15 @@
                     }
                     this.summary = summary;
                     this.daily = daily;
+                    // Clear the previous period's cache overview before the first
+                    // render so the cache meter and Total Requests don't briefly
+                    // mix it with the new summary while it reloads.
+                    if (this.cacheOverviewVisible()) {
+                        this.cacheOverview = this.emptyCacheOverview();
+                    }
                     this.renderChart();
                     if (this.cacheOverviewVisible() && this.cacheAnalyticsEnabled()) {
                         this.fetchCacheOverview();
-                    } else if (this.cacheOverviewVisible()) {
-                        this.cacheOverview = this.emptyCacheOverview();
                     }
                     if (this.page === 'usage') this.fetchUsagePage();
                     if (this.page === 'audit-logs') this.fetchAuditLog(true);

--- a/internal/admin/dashboard/static/js/modules/usage.js
+++ b/internal/admin/dashboard/static/js/modules/usage.js
@@ -294,8 +294,12 @@
                         return;
                     }
                     if (!summaryHandled || !dailyHandled) {
+                        // Reset cache overview too: Total Requests and the cache
+                        // meter derive from it, so leaving it stale would show the
+                        // previous period's cache hits next to the empty summary.
                         this.summary = this.emptyUsageSummary();
                         this.daily = [];
+                        this.cacheOverview = this.emptyCacheOverview();
                         this.renderChart();
                         return;
                     }

--- a/internal/admin/dashboard/static/js/modules/usage.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/usage.test.cjs
@@ -227,6 +227,36 @@ test('fetchUsage clears stale cache overview when the summary refresh fails', as
     assert.equal(app.cacheOverview.daily.length, 0);
 });
 
+test('fetchUsage clears the previous cache overview before reloading on a range switch', async () => {
+    let cacheFetches = 0;
+    const factory = loadUsageModuleFactory({
+        fetch: async () => ({ async json() { return {}; } })
+    });
+    const app = Object.assign(
+        {
+            days: '7',
+            interval: 'daily',
+            page: 'overview',
+            customStartDate: null,
+            customEndDate: null,
+            requestOptions() { return { headers: {} }; },
+            handleFetchResponse() { return true; }, // success
+            renderChart() {}
+        },
+        factory()
+    );
+    app.cacheAnalyticsEnabled = () => true;
+    app.fetchCacheOverview = () => { cacheFetches++; }; // stub: does not repopulate
+    // Previous period's cache overview still in place.
+    app.cacheOverview = { summary: { total_hits: 42, total_input_tokens: 1000 }, daily: [{}] };
+
+    await app.fetchUsage();
+
+    // Cleared synchronously before the async reload, so the meter can't show the old period.
+    assert.equal(app.cacheOverview.summary.total_hits, 0);
+    assert.equal(cacheFetches, 1);
+});
+
 test('fetchUsageLog includes cache_mode=all by default so cached records are returned', async () => {
     const { app, fetchCalls } = createUsageLogApp();
 

--- a/internal/admin/dashboard/static/js/modules/usage.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/usage.test.cjs
@@ -227,6 +227,33 @@ test('fetchUsage clears stale cache overview when the summary refresh fails', as
     assert.equal(app.cacheOverview.daily.length, 0);
 });
 
+test('fetchUsage clears stale data when the request throws (network error)', async () => {
+    const factory = loadUsageModuleFactory({
+        fetch: async () => { throw new Error('network down'); }
+    });
+    const app = Object.assign(
+        {
+            days: '30',
+            interval: 'daily',
+            page: 'overview',
+            customStartDate: null,
+            customEndDate: null,
+            requestOptions() { return { headers: {} }; },
+            handleFetchResponse() { return true; },
+            renderChart() {}
+        },
+        factory()
+    );
+    app.summary = { total_requests: 999, total_input_tokens: 5000 };
+    app.cacheOverview = { summary: { total_hits: 42, total_input_tokens: 1000 }, daily: [{}] };
+
+    await app.fetchUsage();
+
+    assert.equal(app.summary.total_requests, 0);
+    assert.equal(app.cacheOverview.summary.total_hits, 0);
+    assert.equal(app.cacheOverview.daily.length, 0);
+});
+
 test('fetchUsage clears the previous cache overview before reloading on a range switch', async () => {
     let cacheFetches = 0;
     const factory = loadUsageModuleFactory({

--- a/internal/admin/dashboard/static/js/modules/usage.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/usage.test.cjs
@@ -198,6 +198,35 @@ function createUsageLogApp(overrides = {}) {
     return { app, fetchCalls };
 }
 
+test('fetchUsage clears stale cache overview when the summary refresh fails', async () => {
+    const factory = loadUsageModuleFactory({
+        fetch: async () => ({ async json() { return {}; } })
+    });
+    const app = Object.assign(
+        {
+            days: '30',
+            interval: 'daily',
+            page: 'overview',
+            customStartDate: null,
+            customEndDate: null,
+            requestOptions() { return { headers: {} }; },
+            handleFetchResponse() { return false; }, // simulate a failed refresh
+            renderChart() {}
+        },
+        factory()
+    );
+    // Data left over from a previous, successful period.
+    app.summary = { total_requests: 999, total_input_tokens: 5000 };
+    app.cacheOverview = { summary: { total_hits: 42, total_input_tokens: 1000 }, daily: [{}] };
+
+    await app.fetchUsage();
+
+    assert.equal(app.summary.total_requests, 0);
+    assert.equal(app.cacheOverview.summary.total_hits, 0);
+    assert.equal(app.cacheOverview.summary.total_input_tokens, 0);
+    assert.equal(app.cacheOverview.daily.length, 0);
+});
+
 test('fetchUsageLog includes cache_mode=all by default so cached records are returned', async () => {
     const { app, fetchCalls } = createUsageLogApp();
 

--- a/internal/admin/dashboard/static/js/modules/usage.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/usage.test.cjs
@@ -216,3 +216,134 @@ test('fetchUsageLog switches to cache_mode=uncached when hide-cached toggle is o
     assert.equal(fetchCalls.length, 1);
     assert.match(fetchCalls[0].url, /cache_mode=uncached/);
 });
+
+function createCacheMeterModule({ summary = {}, cacheOverview = null, cacheEnabled = false } = {}) {
+    const module = createUsageModule();
+    module.formatNumber = (n) => String(n);
+    module.workflowRuntimeBooleanFlag = (flag, def) => (flag === 'CACHE_ENABLED' ? cacheEnabled : def);
+    module.summary = { ...module.emptyUsageSummary(), ...summary };
+    module.cacheOverview = cacheOverview || module.emptyCacheOverview();
+    return module;
+}
+
+test('cacheMeterSegments splits input tokens token-weighted and percents sum to 100', () => {
+    const module = createCacheMeterModule({
+        summary: { uncached_input_tokens: 600, cached_input_tokens: 300, cache_write_input_tokens: 0 },
+        cacheOverview: { summary: { total_input_tokens: 100 }, daily: [] },
+        cacheEnabled: true
+    });
+
+    const segments = module.cacheMeterSegments();
+    const byKey = Object.fromEntries(segments.map((s) => [s.key, s]));
+
+    assert.equal(module.cacheMeterTotal(), 1000);
+    assert.equal(module.cacheMeterVisible(), true);
+    assert.equal(byKey.uncached.pct, 60);
+    assert.equal(byKey.local.pct, 10);
+    assert.equal(byKey.prompt.pct, 30);
+    assert.equal(byKey.uncached.tokens, 600);
+    assert.equal(byKey.local.tokens, 100);
+    assert.equal(byKey.prompt.tokens, 300);
+    assert.equal(segments.reduce((sum, s) => sum + s.pct, 0), 100);
+});
+
+test('cacheMeterVisible is false and segments empty when there is no usage', () => {
+    const module = createCacheMeterModule();
+
+    assert.equal(module.cacheMeterTotal(), 0);
+    assert.equal(module.cacheMeterVisible(), false);
+    assert.equal(module.cacheMeterSegments().length, 0);
+});
+
+test('cacheMeterSegments folds cache-write tokens into the not-cached slice', () => {
+    const module = createCacheMeterModule({
+        summary: { uncached_input_tokens: 50, cached_input_tokens: 0, cache_write_input_tokens: 50 }
+    });
+
+    const segments = module.cacheMeterSegments();
+
+    assert.equal(segments.length, 1);
+    assert.equal(segments[0].key, 'uncached');
+    assert.equal(segments[0].tokens, 100);
+    assert.equal(segments[0].pct, 100);
+    assert.match(module.cacheMeterSegmentTitle(segments[0]), /cache-write/);
+});
+
+test('cacheMeterSegments omits the local slice when cache analytics are disabled', () => {
+    const module = createCacheMeterModule({
+        summary: { uncached_input_tokens: 70, cached_input_tokens: 30 },
+        cacheOverview: { summary: { total_input_tokens: 999 }, daily: [] },
+        cacheEnabled: false
+    });
+
+    const keys = module.cacheMeterSegments().map((s) => s.key);
+
+    assert.equal(keys.join(','), 'uncached,prompt');
+    assert.equal(module.cacheMeterTotal(), 100);
+});
+
+test('cacheMeterSegments uses largest-remainder rounding so thirds still total 100', () => {
+    const module = createCacheMeterModule({
+        summary: { uncached_input_tokens: 1, cached_input_tokens: 1 },
+        cacheOverview: { summary: { total_input_tokens: 1 }, daily: [] },
+        cacheEnabled: true
+    });
+
+    const segments = module.cacheMeterSegments();
+
+    assert.equal(segments.length, 3);
+    assert.equal(segments.reduce((sum, s) => sum + s.pct, 0), 100);
+});
+
+test('cacheMeterCategories always returns all three categories at 0% when empty', () => {
+    const module = createCacheMeterModule();
+
+    const categories = module.cacheMeterCategories();
+
+    assert.equal(categories.length, 3);
+    assert.equal(categories.map((c) => c.key).join(','), 'uncached,local,prompt');
+    assert.equal(categories.every((c) => c.pct === 0), true);
+    // The bar stays empty while the legend key still renders all three.
+    assert.equal(module.cacheMeterSegments().length, 0);
+    assert.equal(module.cacheMeterVisible(), false);
+});
+
+test('summaryTotalRequests adds local cache hits when analytics enabled', () => {
+    const module = createCacheMeterModule({
+        summary: { total_requests: 40 },
+        cacheOverview: { summary: { total_hits: 10, total_input_tokens: 0 }, daily: [] },
+        cacheEnabled: true
+    });
+
+    assert.equal(module.summaryTotalRequests(), 50);
+    assert.equal(module.summaryCacheHits(), 10);
+    assert.match(module.summaryTotalRequestsTitle(), /40 to providers \+ 10 from cache/);
+});
+
+test('summaryTotalRequests excludes cache hits when analytics disabled', () => {
+    const module = createCacheMeterModule({
+        summary: { total_requests: 40 },
+        cacheOverview: { summary: { total_hits: 10 }, daily: [] },
+        cacheEnabled: false
+    });
+
+    assert.equal(module.summaryTotalRequests(), 40);
+    assert.equal(module.summaryCacheHits(), 0);
+    assert.equal(module.summaryTotalRequestsTitle(), '');
+});
+
+test('cacheMeterCategories keeps zero categories alongside non-zero ones', () => {
+    const module = createCacheMeterModule({
+        summary: { uncached_input_tokens: 70, cached_input_tokens: 30 },
+        cacheEnabled: true
+    });
+
+    const byKey = Object.fromEntries(module.cacheMeterCategories().map((c) => [c.key, c]));
+
+    assert.equal(byKey.uncached.pct, 70);
+    assert.equal(byKey.prompt.pct, 30);
+    assert.equal(byKey.local.pct, 0);
+    assert.equal(module.cacheMeterCategories().reduce((sum, c) => sum + c.pct, 0), 100);
+    // The zero local slice is in the legend but not in the rendered bar.
+    assert.equal(module.cacheMeterSegments().length, 2);
+});

--- a/internal/admin/dashboard/templates/page-overview.html
+++ b/internal/admin/dashboard/templates/page-overview.html
@@ -32,13 +32,13 @@
             <div class="card-label">Total Requests</div>
             <div class="card-value" x-text="formatNumber(summaryTotalRequests())" :title="summaryTotalRequestsTitle()">-</div>
         </div>
-        <div class="card">
-            <div class="card-label">Estimated Cost</div>
-            <div class="card-value" x-text="formatCost(summary.total_cost)">-</div>
-        </div>
         <div class="card" x-show="cacheAnalyticsEnabled()">
             <div class="card-label">Cache Hits</div>
             <div class="card-value" x-text="formatNumber(cacheOverview.summary.total_hits)">-</div>
+        </div>
+        <div class="card">
+            <div class="card-label">Estimated Cost</div>
+            <div class="card-value" x-text="formatCost(summary.total_cost)">-</div>
         </div>
         <div class="card card-wide" x-show="cacheAnalyticsEnabled()">
             <div class="card-label">Local Cache</div>

--- a/internal/admin/dashboard/templates/page-overview.html
+++ b/internal/admin/dashboard/templates/page-overview.html
@@ -5,12 +5,6 @@
     <div class="page-header">
         <h2>Usage Overview</h2>
         <div class="page-header-controls">
-            <div class="interval-picker">
-                <button type="button" class="interval-btn" :class="{active: interval==='daily'}" @click="setInterval('daily')">Daily</button>
-                <button type="button" class="interval-btn" :class="{active: interval==='weekly'}" @click="setInterval('weekly')">Weekly</button>
-                <button type="button" class="interval-btn" :class="{active: interval==='monthly'}" @click="setInterval('monthly')">Monthly</button>
-                <button type="button" class="interval-btn" :class="{active: interval==='yearly'}" @click="setInterval('yearly')">Yearly</button>
-            </div>
             {{template "date-picker" .}}
         </div>
     </div>
@@ -36,7 +30,7 @@
         </div>
         <div class="card">
             <div class="card-label">Total Requests</div>
-            <div class="card-value" x-text="formatNumber(summary.total_requests)">-</div>
+            <div class="card-value" x-text="formatNumber(summaryTotalRequests())" :title="summaryTotalRequestsTitle()">-</div>
         </div>
         <div class="card">
             <div class="card-label">Estimated Cost</div>
@@ -74,9 +68,45 @@
         </div>
     </div>
 
+    <!-- Cache Meter -->
+    <div class="cache-meter">
+        <div class="cache-meter-header">
+            <h3>Tokens</h3>
+            <span class="cache-meter-subtitle">Share of input tokens over the selected period</span>
+        </div>
+        <div class="cache-meter-bar" :class="{ 'is-empty': !cacheMeterVisible() }" role="img" :aria-label="cacheMeterAriaLabel()">
+            <template x-for="seg in cacheMeterSegments()" :key="seg.key">
+                <div class="cache-meter-segment"
+                     :style="'width: ' + seg.pct + '%; background: var(' + seg.colorVar + ')'"
+                     :title="cacheMeterSegmentTitle(seg)">
+                    <span class="cache-meter-segment-label" x-show="seg.pct >= 8" x-text="seg.pct + '%'"></span>
+                </div>
+            </template>
+            <span class="cache-meter-empty" x-show="!cacheMeterVisible()">No usage in the selected period yet</span>
+        </div>
+        <div class="cache-meter-legend">
+            <template x-for="seg in cacheMeterCategories()" :key="seg.key">
+                <div class="cache-meter-legend-item" :title="cacheMeterSegmentTitle(seg)">
+                    <span class="cache-meter-swatch" :style="'background: var(' + seg.colorVar + ')'"></span>
+                    <span class="cache-meter-legend-label" x-text="seg.label">-</span>
+                    <span class="cache-meter-legend-pct mono" x-text="seg.pct + '%'">-</span>
+                    <span class="cache-meter-legend-tokens mono" x-text="formatNumber(seg.tokens)">-</span>
+                </div>
+            </template>
+        </div>
+    </div>
+
     <!-- Usage Chart -->
     <div class="chart-container">
-        <h3 x-text="chartTitle()">Daily Token Usage</h3>
+        <div class="chart-container-header">
+            <h3 x-text="chartTitle()">Daily Token Usage</h3>
+            <div class="interval-picker">
+                <button type="button" class="interval-btn" :class="{active: interval==='daily'}" @click="setInterval('daily')">Daily</button>
+                <button type="button" class="interval-btn" :class="{active: interval==='weekly'}" @click="setInterval('weekly')">Weekly</button>
+                <button type="button" class="interval-btn" :class="{active: interval==='monthly'}" @click="setInterval('monthly')">Monthly</button>
+                <button type="button" class="interval-btn" :class="{active: interval==='yearly'}" @click="setInterval('yearly')">Yearly</button>
+            </div>
+        </div>
         <div class="chart-wrapper">
             <canvas id="usageChart"></canvas>
             <div class="chart-empty-overlay" x-show="daily.length === 0 && !loading && !authError">{{template "no-data-icon"}}</div>
@@ -167,6 +197,15 @@
                             <h4 class="provider-status-name">
                                 <span x-text="provider.name"></span>
                                 <span class="provider-status-name-type" x-show="providerTypeLabel(provider)" x-text="'(' + providerTypeLabel(provider) + ')'"></span>
+                                <a class="inline-help-toggle provider-doc-help"
+                                   x-show="providerDocUrl(provider)"
+                                   :href="providerDocUrl(provider)"
+                                   target="_blank"
+                                   rel="noopener noreferrer"
+                                   :aria-label="'View ' + (providerTypeLabel(provider) || provider.name) + ' provider docs'"
+                                   :title="'View ' + (providerTypeLabel(provider) || provider.name) + ' provider docs'">
+                                    <span class="inline-help-toggle-icon" aria-hidden="true">?</span>
+                                </a>
                             </h4>
                         </div>
                         <span class="provider-status-pill" :class="providerStatusBadgeClass(provider.status)" x-text="provider.status_label"></span>

--- a/internal/admin/dashboard/templates/page-overview.html
+++ b/internal/admin/dashboard/templates/page-overview.html
@@ -100,11 +100,11 @@
     <div class="chart-container">
         <div class="chart-container-header">
             <h3 x-text="chartTitle()">Daily Token Usage</h3>
-            <div class="interval-picker">
-                <button type="button" class="interval-btn" :class="{active: interval==='daily'}" @click="setInterval('daily')">Daily</button>
-                <button type="button" class="interval-btn" :class="{active: interval==='weekly'}" @click="setInterval('weekly')">Weekly</button>
-                <button type="button" class="interval-btn" :class="{active: interval==='monthly'}" @click="setInterval('monthly')">Monthly</button>
-                <button type="button" class="interval-btn" :class="{active: interval==='yearly'}" @click="setInterval('yearly')">Yearly</button>
+            <div class="interval-picker" role="group" aria-label="Usage chart interval">
+                <button type="button" class="interval-btn" :class="{active: interval==='daily'}" :aria-pressed="interval==='daily'" @click="setInterval('daily')">Daily</button>
+                <button type="button" class="interval-btn" :class="{active: interval==='weekly'}" :aria-pressed="interval==='weekly'" @click="setInterval('weekly')">Weekly</button>
+                <button type="button" class="interval-btn" :class="{active: interval==='monthly'}" :aria-pressed="interval==='monthly'" @click="setInterval('monthly')">Monthly</button>
+                <button type="button" class="interval-btn" :class="{active: interval==='yearly'}" :aria-pressed="interval==='yearly'" @click="setInterval('yearly')">Yearly</button>
             </div>
         </div>
         <div class="chart-wrapper">

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -228,6 +228,64 @@ func TestUsageSummary_Success(t *testing.T) {
 	}
 }
 
+func TestUsageSummary_IncludesCacheSplitFields(t *testing.T) {
+	reader := &mockUsageReader{
+		summary: &usage.UsageSummary{
+			TotalRequests:         10,
+			TotalInput:            1000,
+			UncachedInputTokens:   600,
+			CachedInputTokens:     350,
+			CacheWriteInputTokens: 50,
+		},
+	}
+	h := NewHandler(reader, nil)
+	c, rec := newHandlerContext("/admin/usage/summary?days=30")
+
+	if err := h.UsageSummary(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+
+	body := rec.Body.String()
+	for _, key := range []string{"uncached_input_tokens", "cached_input_tokens", "cache_write_input_tokens"} {
+		if !containsString(body, key) {
+			t.Errorf("expected %q in response body, got: %s", key, body)
+		}
+	}
+
+	var summary usage.UsageSummary
+	if err := json.Unmarshal(rec.Body.Bytes(), &summary); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if summary.UncachedInputTokens != 600 {
+		t.Errorf("expected 600 uncached input tokens, got %d", summary.UncachedInputTokens)
+	}
+	if summary.CachedInputTokens != 350 {
+		t.Errorf("expected 350 cached input tokens, got %d", summary.CachedInputTokens)
+	}
+	if summary.CacheWriteInputTokens != 50 {
+		t.Errorf("expected 50 cache-write input tokens, got %d", summary.CacheWriteInputTokens)
+	}
+}
+
+func TestUsageSummary_NilReaderZeroesCacheSplit(t *testing.T) {
+	h := NewHandler(nil, nil)
+	c, rec := newHandlerContext("/admin/usage/summary?days=30")
+
+	if err := h.UsageSummary(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var summary usage.UsageSummary
+	if err := json.Unmarshal(rec.Body.Bytes(), &summary); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if summary.UncachedInputTokens != 0 || summary.CachedInputTokens != 0 || summary.CacheWriteInputTokens != 0 {
+		t.Errorf("expected zero cache split for nil reader, got %+v", summary)
+	}
+}
+
 func TestUsageSummary_GatewayError(t *testing.T) {
 	reader := &mockUsageReader{
 		summaryErr: core.NewProviderError("test", http.StatusBadGateway, "upstream failed", nil),

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -277,6 +277,16 @@ func TestUsageSummary_NilReaderZeroesCacheSplit(t *testing.T) {
 	if err := h.UsageSummary(c); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+
+	// Assert the keys are present (not just absent-as-zero) so a dropped field
+	// can't masquerade as a zero value after unmarshalling.
+	body := rec.Body.String()
+	for _, key := range []string{"uncached_input_tokens", "cached_input_tokens", "cache_write_input_tokens"} {
+		if !containsString(body, key) {
+			t.Errorf("expected %q in nil-reader response body, got: %s", key, body)
+		}
+	}
+
 	var summary usage.UsageSummary
 	if err := json.Unmarshal(rec.Body.Bytes(), &summary); err != nil {
 		t.Fatalf("failed to unmarshal: %v", err)

--- a/internal/usage/reader.go
+++ b/internal/usage/reader.go
@@ -2,8 +2,12 @@ package usage
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
 	"strings"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // UsageQueryParams specifies the query parameters for usage data retrieval.
@@ -17,14 +21,75 @@ type UsageQueryParams struct {
 }
 
 // UsageSummary holds aggregated usage statistics over a time period.
+//
+// The *_input_tokens split fields (uncached/cached/cache-write) are the
+// provider prompt-cache breakdown of the input, summed per row via
+// addInputSegments which reuses EntryInputSegments. Their sum is the
+// provider-side "input parts" total; for additive-accounting providers
+// (Anthropic) it exceeds TotalInput, which only sums the input_tokens column.
+// Storage layers populate them by streaming rows; they are zero when the
+// reader is disabled.
 type UsageSummary struct {
-	TotalRequests   int      `json:"total_requests"`
-	TotalInput      int64    `json:"total_input_tokens"`
-	TotalOutput     int64    `json:"total_output_tokens"`
-	TotalTokens     int64    `json:"total_tokens"`
-	TotalInputCost  *float64 `json:"total_input_cost"`
-	TotalOutputCost *float64 `json:"total_output_cost"`
-	TotalCost       *float64 `json:"total_cost"`
+	TotalRequests         int      `json:"total_requests"`
+	TotalInput            int64    `json:"total_input_tokens"`
+	TotalOutput           int64    `json:"total_output_tokens"`
+	TotalTokens           int64    `json:"total_tokens"`
+	UncachedInputTokens   int64    `json:"uncached_input_tokens"`
+	CachedInputTokens     int64    `json:"cached_input_tokens"`
+	CacheWriteInputTokens int64    `json:"cache_write_input_tokens"`
+	TotalInputCost        *float64 `json:"total_input_cost"`
+	TotalOutputCost       *float64 `json:"total_output_cost"`
+	TotalCost             *float64 `json:"total_cost"`
+}
+
+// addInputSegments folds one usage row's provider-cache split into the summary
+// totals, reusing EntryInputSegments so every storage backend shares the single
+// source of truth for the provider-specific quirks (field-name coalescing and
+// the Anthropic additive-vs-subset accounting). Callers stream only the minimal
+// columns; cache_type is irrelevant because the summary covers provider
+// (uncached-mode) rows.
+func (s *UsageSummary) addInputSegments(inputTokens int, provider string, rawData map[string]any) {
+	uncached, cached, cacheWrite := EntryInputSegments(UsageLogEntry{
+		InputTokens: inputTokens,
+		Provider:    provider,
+		RawData:     rawData,
+	})
+	s.UncachedInputTokens += uncached
+	s.CachedInputTokens += cached
+	s.CacheWriteInputTokens += cacheWrite
+}
+
+// inputSegmentRows is the minimal row cursor shared by the SQL backends when
+// folding the provider prompt-cache split; both pgx.Rows and *sql.Rows satisfy it.
+type inputSegmentRows interface {
+	Next() bool
+	Scan(dest ...any) error
+	Err() error
+}
+
+// foldInputSegments scans (input_tokens, provider, raw_data) rows and folds each
+// into the summary via addInputSegments, so the SQLite and PostgreSQL readers
+// share one row-handling path (only the query/driver differs between them).
+func foldInputSegments(rows inputSegmentRows, summary *UsageSummary) error {
+	for rows.Next() {
+		var inputTokens int
+		var provider string
+		var rawDataJSON *string
+		if err := rows.Scan(&inputTokens, &provider, &rawDataJSON); err != nil {
+			return fmt.Errorf("failed to scan usage input segment row: %w", err)
+		}
+		var rawData map[string]any
+		if rawDataJSON != nil && *rawDataJSON != "" {
+			if err := json.Unmarshal([]byte(*rawDataJSON), &rawData); err != nil {
+				slog.Warn("failed to unmarshal raw_data JSON", "error", err)
+			}
+		}
+		summary.addInputSegments(inputTokens, provider, rawData)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("error iterating usage input segment rows: %w", err)
+	}
+	return nil
 }
 
 // ModelUsage holds per-model token usage aggregates.

--- a/internal/usage/reader_fold_test.go
+++ b/internal/usage/reader_fold_test.go
@@ -1,0 +1,96 @@
+package usage
+
+import (
+	"errors"
+	"testing"
+)
+
+// fakeInputSegmentRows is an in-memory inputSegmentRows for exercising
+// foldInputSegments without a database.
+type fakeInputSegmentRows struct {
+	rows      []fakeSegmentRow
+	pos       int
+	scanErrAt int // 1-based row index where Scan should fail (0 = never)
+	scanErr   error
+	iterErr   error
+}
+
+type fakeSegmentRow struct {
+	input    int
+	provider string
+	raw      *string
+}
+
+func segRaw(s string) *string { return &s }
+
+func (f *fakeInputSegmentRows) Next() bool {
+	f.pos++
+	return f.pos <= len(f.rows)
+}
+
+func (f *fakeInputSegmentRows) Scan(dest ...any) error {
+	if f.scanErrAt == f.pos && f.scanErr != nil {
+		return f.scanErr
+	}
+	r := f.rows[f.pos-1]
+	if p, ok := dest[0].(*int); ok {
+		*p = r.input
+	}
+	if p, ok := dest[1].(*string); ok {
+		*p = r.provider
+	}
+	if p, ok := dest[2].(**string); ok {
+		*p = r.raw
+	}
+	return nil
+}
+
+func (f *fakeInputSegmentRows) Err() error { return f.iterErr }
+
+func TestFoldInputSegments_FoldsAndToleratesMalformedRawData(t *testing.T) {
+	rows := &fakeInputSegmentRows{rows: []fakeSegmentRow{
+		{input: 120, provider: "openai", raw: segRaw(`{"prompt_cached_tokens":80}`)},                                       // subset → uncached 40, cached 80
+		{input: 50, provider: "anthropic", raw: segRaw(`{"cache_read_input_tokens":90,"cache_creation_input_tokens":30}`)}, // split → uncached 50, cached 90, write 30
+		{input: 70, provider: "openai", raw: segRaw(`{bad json`)},                                                          // malformed → degrades to no cache → uncached 70
+		{input: 10, provider: "openai", raw: nil},                                                                          // nil raw → uncached 10
+	}}
+
+	summary := &UsageSummary{}
+	if err := foldInputSegments(rows, summary); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if summary.UncachedInputTokens != 40+50+70+10 {
+		t.Fatalf("UncachedInputTokens = %d, want %d", summary.UncachedInputTokens, 40+50+70+10)
+	}
+	if summary.CachedInputTokens != 80+90 {
+		t.Fatalf("CachedInputTokens = %d, want %d", summary.CachedInputTokens, 80+90)
+	}
+	if summary.CacheWriteInputTokens != 30 {
+		t.Fatalf("CacheWriteInputTokens = %d, want 30", summary.CacheWriteInputTokens)
+	}
+}
+
+func TestFoldInputSegments_ScanErrorPropagates(t *testing.T) {
+	wantErr := errors.New("scan boom")
+	rows := &fakeInputSegmentRows{
+		rows:      []fakeSegmentRow{{input: 10, provider: "openai"}},
+		scanErrAt: 1,
+		scanErr:   wantErr,
+	}
+	err := foldInputSegments(rows, &UsageSummary{})
+	if err == nil || !errors.Is(err, wantErr) {
+		t.Fatalf("expected wrapped scan error, got %v", err)
+	}
+}
+
+func TestFoldInputSegments_IterationErrorPropagates(t *testing.T) {
+	wantErr := errors.New("iter boom")
+	rows := &fakeInputSegmentRows{
+		rows:    []fakeSegmentRow{{input: 10, provider: "openai", raw: segRaw(`{}`)}},
+		iterErr: wantErr,
+	}
+	err := foldInputSegments(rows, &UsageSummary{})
+	if err == nil || !errors.Is(err, wantErr) {
+		t.Fatalf("expected wrapped iteration error, got %v", err)
+	}
+}

--- a/internal/usage/reader_mongodb.go
+++ b/internal/usage/reader_mongodb.go
@@ -151,7 +151,45 @@ func (r *MongoDBReader) GetSummary(ctx context.Context, params UsageQueryParams)
 		return nil, fmt.Errorf("error iterating usage summary cursor: %w", err)
 	}
 
+	if err := r.accumulateInputSegments(ctx, matchFilters, summary); err != nil {
+		return nil, err
+	}
+
 	return summary, nil
+}
+
+// accumulateInputSegments streams the matched documents and folds each row's
+// provider prompt-cache split into the summary, reusing EntryInputSegments. The
+// $group aggregate above cannot return per-document raw_data, so this is a
+// second pass over the same filter projecting only the needed fields. This is
+// the dashboard summary path, not a request hot path.
+func (r *MongoDBReader) accumulateInputSegments(ctx context.Context, matchFilters bson.D, summary *UsageSummary) error {
+	projection := bson.D{
+		{Key: "input_tokens", Value: 1},
+		{Key: "provider", Value: 1},
+		{Key: "raw_data", Value: 1},
+	}
+	cursor, err := r.collection.Find(ctx, matchFilters, options.Find().SetProjection(projection))
+	if err != nil {
+		return fmt.Errorf("failed to query usage input segments: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	for cursor.Next(ctx) {
+		var row struct {
+			InputTokens int            `bson:"input_tokens"`
+			Provider    string         `bson:"provider"`
+			RawData     map[string]any `bson:"raw_data"`
+		}
+		if err := cursor.Decode(&row); err != nil {
+			return fmt.Errorf("failed to decode usage input segment row: %w", err)
+		}
+		summary.addInputSegments(row.InputTokens, row.Provider, row.RawData)
+	}
+	if err := cursor.Err(); err != nil {
+		return fmt.Errorf("error iterating usage input segment cursor: %w", err)
+	}
+	return nil
 }
 
 // GetUsageByModel returns token and cost totals grouped by model and provider.

--- a/internal/usage/reader_postgresql.go
+++ b/internal/usage/reader_postgresql.go
@@ -52,7 +52,25 @@ func (r *PostgreSQLReader) GetSummary(ctx context.Context, params UsageQueryPara
 		return nil, fmt.Errorf("failed to query usage summary: %w", err)
 	}
 
+	if err := r.accumulateInputSegments(ctx, where, args, summary); err != nil {
+		return nil, err
+	}
+
 	return summary, nil
+}
+
+// accumulateInputSegments streams the matched rows and folds each row's
+// provider prompt-cache split into the summary. It runs a second pass (the
+// aggregate above cannot also return per-row raw_data) over the same filter,
+// selecting only the columns EntryInputSegments needs. This is the dashboard
+// summary path, not a request hot path.
+func (r *PostgreSQLReader) accumulateInputSegments(ctx context.Context, where string, args []any, summary *UsageSummary) error {
+	rows, err := r.pool.Query(ctx, `SELECT input_tokens, provider, raw_data FROM "usage"`+where, args...)
+	if err != nil {
+		return fmt.Errorf("failed to query usage input segments: %w", err)
+	}
+	defer rows.Close()
+	return foldInputSegments(rows, summary)
 }
 
 // GetUsageByModel returns token and cost totals grouped by model and provider.

--- a/internal/usage/reader_sqlite.go
+++ b/internal/usage/reader_sqlite.go
@@ -47,7 +47,25 @@ func (r *SQLiteReader) GetSummary(ctx context.Context, params UsageQueryParams) 
 		return nil, fmt.Errorf("failed to query usage summary: %w", err)
 	}
 
+	if err := r.accumulateInputSegments(ctx, where, args, summary); err != nil {
+		return nil, err
+	}
+
 	return summary, nil
+}
+
+// accumulateInputSegments streams the matched rows and folds each row's
+// provider prompt-cache split into the summary. It runs a second pass (the
+// aggregate above cannot also return per-row raw_data) over the same filter,
+// selecting only the columns EntryInputSegments needs. This is the dashboard
+// summary path, not a request hot path.
+func (r *SQLiteReader) accumulateInputSegments(ctx context.Context, where string, args []any, summary *UsageSummary) error {
+	rows, err := r.db.QueryContext(ctx, `SELECT input_tokens, provider, raw_data FROM usage`+where, args...)
+	if err != nil {
+		return fmt.Errorf("failed to query usage input segments: %w", err)
+	}
+	defer rows.Close()
+	return foldInputSegments(rows, summary)
 }
 
 // GetUsageByModel returns token and cost totals grouped by model and provider.

--- a/internal/usage/reader_sqlite_cache_split_test.go
+++ b/internal/usage/reader_sqlite_cache_split_test.go
@@ -1,0 +1,128 @@
+package usage
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// TestSQLiteReaderSummary_AggregatesProviderCacheSplit verifies that GetSummary's
+// uncached/cached/cache-write fields equal the sum of per-row EntryInputSegments
+// over a mixed-provider fixture, and that local-cache rows (cache_type set) are
+// excluded by the default uncached cache mode. The fixture deliberately puts each
+// row's cache-read in a different raw_data field so the aggregate cannot be faked
+// by summing each field separately and taking the max of the sums.
+func TestSQLiteReaderSummary_AggregatesProviderCacheSplit(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open sqlite database: %v", err)
+	}
+	defer db.Close()
+
+	store, err := NewSQLiteStore(db, 0)
+	if err != nil {
+		t.Fatalf("failed to create sqlite store: %v", err)
+	}
+
+	ts := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+
+	// Provider (uncached-mode) rows — these feed both GetSummary and the oracle.
+	providerEntries := []*UsageEntry{
+		{
+			ID: "openai-subset", RequestID: "r1", ProviderID: "p1", Timestamp: ts,
+			Model: "gpt-5", Provider: "openai", Endpoint: "/v1/chat/completions",
+			InputTokens: 120, OutputTokens: 30, TotalTokens: 150,
+			RawData: map[string]any{"prompt_cached_tokens": 80},
+		},
+		{
+			ID: "anthropic-split", RequestID: "r2", ProviderID: "p2", Timestamp: ts,
+			Model: "claude-sonnet-4-6", Provider: "anthropic", Endpoint: "/v1/messages",
+			InputTokens: 50, OutputTokens: 20, TotalTokens: 70,
+			RawData: map[string]any{"cache_read_input_tokens": 90, "cache_creation_input_tokens": 30},
+		},
+		{
+			ID: "anthropic-nofields", RequestID: "r3", ProviderID: "p3", Timestamp: ts,
+			Model: "claude-sonnet-4-6", Provider: "anthropic", Endpoint: "/v1/messages",
+			InputTokens: 50, OutputTokens: 20, TotalTokens: 70,
+		},
+		{
+			ID: "gemini-subset", RequestID: "r4", ProviderID: "p4", Timestamp: ts,
+			Model: "gemini-2.5-pro", Provider: "gemini", Endpoint: "/v1/chat/completions",
+			InputTokens: 200, OutputTokens: 40, TotalTokens: 240,
+			RawData: map[string]any{"cached_tokens": 120},
+		},
+		{
+			ID: "groq-generic", RequestID: "r5", ProviderID: "p5", Timestamp: ts,
+			Model: "llama-3.3", Provider: "groq", Endpoint: "/v1/chat/completions",
+			InputTokens: 100, OutputTokens: 10, TotalTokens: 110,
+			RawData: map[string]any{"cached_tokens": 10},
+		},
+	}
+
+	// Local-cache hit — seeded but must be excluded from the uncached-mode summary.
+	localHit := &UsageEntry{
+		ID: "local-hit", RequestID: "r6", ProviderID: "p6", Timestamp: ts,
+		Model: "gpt-5", Provider: "openai", Endpoint: "/v1/chat/completions",
+		CacheType: CacheTypeExact, InputTokens: 999, OutputTokens: 999, TotalTokens: 1998,
+		RawData: map[string]any{"prompt_cached_tokens": 500},
+	}
+
+	ctx := context.Background()
+	if err := store.WriteBatch(ctx, append(append([]*UsageEntry{}, providerEntries...), localHit)); err != nil {
+		t.Fatalf("failed to seed usage entries: %v", err)
+	}
+
+	reader, err := NewSQLiteReader(db)
+	if err != nil {
+		t.Fatalf("failed to create sqlite reader: %v", err)
+	}
+
+	summary, err := reader.GetSummary(ctx, UsageQueryParams{
+		StartDate: time.Date(2026, 6, 16, 0, 0, 0, 0, time.UTC),
+		EndDate:   time.Date(2026, 6, 16, 0, 0, 0, 0, time.UTC),
+		TimeZone:  "UTC",
+	})
+	if err != nil {
+		t.Fatalf("GetSummary returned error: %v", err)
+	}
+
+	// Local-cache row excluded by the default uncached mode.
+	if summary.TotalRequests != len(providerEntries) {
+		t.Fatalf("TotalRequests = %d, want %d (local-cache row must be excluded)", summary.TotalRequests, len(providerEntries))
+	}
+
+	// Oracle: sum EntryInputSegments over the same provider rows independently.
+	var wantUncached, wantCached, wantWrite int64
+	for _, e := range providerEntries {
+		u, c, w := EntryInputSegments(UsageLogEntry{InputTokens: e.InputTokens, Provider: e.Provider, RawData: e.RawData})
+		wantUncached += u
+		wantCached += c
+		wantWrite += w
+	}
+
+	if summary.UncachedInputTokens != wantUncached {
+		t.Fatalf("UncachedInputTokens = %d, want %d", summary.UncachedInputTokens, wantUncached)
+	}
+	if summary.CachedInputTokens != wantCached {
+		t.Fatalf("CachedInputTokens = %d, want %d", summary.CachedInputTokens, wantCached)
+	}
+	if summary.CacheWriteInputTokens != wantWrite {
+		t.Fatalf("CacheWriteInputTokens = %d, want %d", summary.CacheWriteInputTokens, wantWrite)
+	}
+
+	// Explicit magic numbers guard against a regression that still happens to be
+	// self-consistent with a broken oracle. cached = 80+90+0+120+10 = 300 can only
+	// be reached by per-row max-coalescing, not max(sum-per-field).
+	if summary.CachedInputTokens != 300 {
+		t.Fatalf("CachedInputTokens = %d, want 300", summary.CachedInputTokens)
+	}
+	if summary.CacheWriteInputTokens != 30 {
+		t.Fatalf("CacheWriteInputTokens = %d, want 30", summary.CacheWriteInputTokens)
+	}
+	if summary.UncachedInputTokens != 310 {
+		t.Fatalf("UncachedInputTokens = %d, want 310", summary.UncachedInputTokens)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a **cache meter** to the dashboard overview plus several overview refinements. The meter answers *"what share of what we send is actually cached?"* — something the existing absolute Cache Hits / Local Cache cards didn't show.

## What's included

- **Tokens cache meter** — a 100%-stacked, input-token bar split into **regular (uncached) / locally cached / prompt cached**, with on-bar percentages, a legend key, and an empty state. Colors are on-palette (GoModel brown / emerald `--success` / lime `--prompt-cache-color`) and theme-correct.
- **Provider prompt-cache split in `UsageSummary`** — new additive fields `uncached_input_tokens` / `cached_input_tokens` / `cache_write_input_tokens`, aggregated per row via a **shared Go fold that reuses `EntryInputSegments`** across the SQLite/PostgreSQL/MongoDB readers (the provider quirks — field-name coalescing, Anthropic additive-vs-subset accounting — stay in one place rather than being re-encoded in SQL).
- **Total Requests now includes local cache hits** (with a `provider + cache` breakdown tooltip), computed on the frontend so the uncached-mode summary the meter relies on stays clean.
- **Per-provider docs link** — provider cards show the standard `?` help icon linking to `…/docs/providers/<slug>`, but only for provider types that have a docs page (allowlist derived from `docs/providers/*.mdx`; handles `opencode_go` → `opencode-go`).
- **Moved the Daily/Weekly/Monthly/Yearly switch onto the usage chart header** (it only affects that chart's grouping).
- **Reordered overview cards** so **Cache Hits** sits before **Estimated Cost**.
- Regenerated the API reference for the new `UsageSummary` fields.

## Provider-specific behavior

The prompt-cache split is normalized across providers via the existing `EntryInputSegments`: Anthropic reports cache reads/writes as additive to `input_tokens`, while OpenAI/Gemini/etc. report them as a subset — the aggregate reconciles both so the meter is accurate per provider.

## Testing

- `go build ./...`, `go vet`, gofmt clean; all Go tests pass — including a SQLite cross-check that the aggregated split equals `Σ EntryInputSegments` over a mixed-provider fixture (and catches the invalid sum-per-field shortcut), plus handler tests for the new JSON fields.
- All dashboard JS module tests pass (added coverage for the meter math, empty state, percentages summing to 100, Total-Requests-with-hits, and the provider docs link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cache-aware usage breakdown fields (uncached, cached, and cache-write input tokens) to the usage API schema.
  * Added a Cache Meter to the Usage Overview (token-segment visualization, legend with percentages/tokens, and empty state).
  * Added provider documentation help (“?” links) where provider-specific docs are available.
* **Bug Fixes**
  * Prevented stale cache hits and cache-meter data after failed refreshes or period/range changes.
* **Documentation**
  * Updated Swagger/OpenAPI to expose the new cache-split fields.
* **Tests**
  * Expanded API/UI/reader tests for cache splitting, meter calculations/rounding, provider doc URL logic, and failure-state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->