### PR TITLE
feat(dashboard): live token throughput chart, prompt cache gauge, and overview refinements

### DIFF
--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -18,15 +18,22 @@
   --danger: #ef4444;
   --prompt-cache-color: #40a811;
   --prompt-cache-color-bg: color-mix(in srgb, var(--prompt-cache-color) 14%, var(--bg-surface));
-  /* Cache meter segments. Declared once as semantic aliases: --accent/--info
-     are re-themed per mode, and var() resolves lazily per element, so these
-     stay theme-correct without duplicating across the light/dark blocks. */
-  --cache-meter-uncached: var(--accent);
-  /* Two distinct greens: a deep emerald (darkened --success) for local hits,
-     lime --prompt-cache-color for provider prompt-cache reads. --success is the
-     same in both themes, so the mix stays theme-consistent. */
-  --cache-meter-local: color-mix(in srgb, var(--success) 58%, #000);
-  --cache-meter-prompt: var(--prompt-cache-color);
+  /* Cache meter segments share the live token-throughput palette (defined
+     below) so the meter and the chart read consistently: Regular is the paid
+     brown (input); local and prompt caches are the translucent blues, cheaper
+     = more transparent. */
+  --cache-meter-uncached: var(--token-input);
+  --cache-meter-local: var(--token-local);
+  --cache-meter-prompt: var(--token-prompt);
+  /* Live token throughput series, coloured by cost. Input and output are the
+     paid tokens: solid, light browns (output a shade lighter so the pair reads
+     together). Cached tokens are cheap, so they read as translucent blue —
+     prompt-cache reads (almost free) are semi-transparent; local cache hits
+     (no provider cost) are the most transparent. */
+  --token-input: #c0824a;
+  --token-output: #ddb27a;
+  --token-prompt: color-mix(in srgb, var(--info) 60%, transparent);
+  --token-local: color-mix(in srgb, var(--info) 20%, transparent);
   --sidebar-width: 240px;
   --radius: 8px;
   --chart-grid: #2a2826;
@@ -1494,6 +1501,113 @@ body.dashboard-modal-open {
 .chart-wrapper {
   position: relative;
   height: 210px;
+}
+
+/* Prompt cache rate gauge (compact half-circle in a stat card). A 180° doughnut's
+   natural box is 2:1, so the container is 2:1 and Chart.js sizes the canvas to it
+   — the semicircle fills it exactly and stays round. */
+.prompt-cache-gauge {
+  position: relative;
+  width: 120px;
+  height: 60px;
+  margin: 8px auto 0;
+  overflow: hidden;
+}
+
+.prompt-cache-gauge canvas {
+  display: block;
+}
+
+.prompt-cache-gauge-value {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 4px;
+  text-align: center;
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--text);
+}
+
+/* Live token throughput chart */
+/* The generic .chart-container has no margin (siblings space it), but this card
+   is followed by the cache meter, which only spaces below itself — so give the
+   live card the same 28px rhythm as .cards/.cache-meter. */
+.live-tokens {
+  margin-bottom: 28px;
+}
+
+.live-tokens-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.live-tokens-subtitle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.live-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.live-dot.is-streaming {
+  background: var(--success);
+  box-shadow: 0 0 0 0 color-mix(in srgb, var(--success) 70%, transparent);
+  animation: live-dot-pulse 1.8s ease-out infinite;
+}
+
+@keyframes live-dot-pulse {
+  0% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--success) 55%, transparent);
+  }
+  70% {
+    box-shadow: 0 0 0 6px color-mix(in srgb, var(--success) 0%, transparent);
+  }
+  100% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--success) 0%, transparent);
+  }
+}
+
+.live-tokens-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 18px;
+  margin-bottom: 16px;
+}
+
+.live-tokens-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.live-tokens-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.live-tokens-legend-value {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.live-tokens-empty .live-tokens-empty-text {
+  font-size: 13px;
+  color: var(--text-muted);
 }
 
 /* Alert */

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -1566,6 +1566,12 @@ body.dashboard-modal-open {
   animation: live-dot-pulse 1.8s ease-out infinite;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .live-dot.is-streaming {
+    animation: none;
+  }
+}
+
 @keyframes live-dot-pulse {
   0% {
     box-shadow: 0 0 0 0 color-mix(in srgb, var(--success) 55%, transparent);

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -150,6 +150,7 @@ function dashboard() {
 
     // Chart
     chart: null,
+    promptCacheChart: null,
 
     // Usage page state
     usageMode: "tokens",
@@ -220,6 +221,12 @@ function dashboard() {
     _applyRoute(page, sub) {
       this.page = page;
 
+      // Live token throughput is overview-only; tear it down when navigating
+      // away so it stops consuming the SSE stream and frees its buffers.
+      if (page !== "overview" && typeof this.stopLiveTokens === "function") {
+        this.stopLiveTokens();
+      }
+
       if (page === "usage" && sub === "costs") this.usageMode = "costs";
       if (page === "usage" && sub !== "costs") this.usageMode = "tokens";
       if (page === "audit-logs") this.fetchAuditLog(true);
@@ -248,7 +255,10 @@ function dashboard() {
           this.fetchBudgetSettings();
         }
       }
-      if (page === "overview") this.renderChart();
+      if (page === "overview") {
+        this.renderChart();
+        if (typeof this.startLiveTokens === "function") this.startLiveTokens();
+      }
       if (page === "usage") this.fetchUsagePage();
       if (typeof this.renderIconsAfterUpdate === "function") {
         this.renderIconsAfterUpdate();
@@ -356,6 +366,10 @@ function dashboard() {
       this.renderChart();
       this.renderBarChart();
       this.renderUserPathChart();
+      if (typeof this.redrawLiveTokensChart === "function") {
+        // Force a rebuild so the bars pick up the new theme's colors.
+        this.redrawLiveTokensChart();
+      }
     },
 
     normalizeApiKey(value) {
@@ -1141,6 +1155,12 @@ function dashboard() {
         ? dashboardChartsModule
         : null,
       "dashboardChartsModule",
+    ),
+    resolveModuleFactory(
+      typeof dashboardLiveTokensModule === "function"
+        ? dashboardLiveTokensModule
+        : null,
+      "dashboardLiveTokensModule",
     ),
   ];
 

--- a/internal/admin/dashboard/static/js/modules/charts.js
+++ b/internal/admin/dashboard/static/js/modules/charts.js
@@ -1,54 +1,60 @@
 (function(global) {
     function dashboardChartsModule() {
         return {
-            _overviewChartConfig(colors, labels, inputData, outputData, cacheInputData, cacheOutputData) {
+            // --- Shared overview chart styling, so the line (Daily Token Usage)
+            // and bar (Live Token Throughput) charts read as one family. ---
+            _chartTickFont() {
+                return { size: 11, family: "'SF Mono', Menlo, Consolas, monospace" };
+            },
+
+            _chartTooltip(colors, callbacks) {
+                return {
+                    backgroundColor: colors.tooltipBg,
+                    borderColor: colors.tooltipBorder,
+                    borderWidth: 1,
+                    titleColor: colors.tooltipText,
+                    bodyColor: colors.tooltipText,
+                    callbacks: callbacks
+                };
+            },
+
+            // Y-axis ticks that abbreviate token counts (e.g. 1.2K, 3.4M).
+            _tokenAxisTicks(colors) {
+                return {
+                    color: colors.text,
+                    font: this._chartTickFont(),
+                    callback: (v) => this.formatTokensShort(v)
+                };
+            },
+
+            _overviewChartConfig(colors, labels, inputData, outputData, promptData, localData) {
                 const cacheEnabled = typeof this.cacheAnalyticsEnabled === 'function' && this.cacheAnalyticsEnabled();
+                const resolve = (expr) => (typeof this._resolveLiveTokenColor === 'function' ? this._resolveLiveTokenColor(expr) : expr);
+                const fade = (expr, pct) => resolve('color-mix(in srgb, ' + expr + ' ' + pct + '%, transparent)');
+                // Same palette as the live throughput chart: paid tokens (input,
+                // output) are solid browns; cached tokens are dashed blues, the
+                // free "Locally Cached" lighter than the almost-free "Prompt cached".
+                // Markerless lines (dots on hover only), matching the bar chart's
+                // clean look; values stay readable via the tooltip.
+                const line = (label, data, color, opts) => Object.assign({
+                    label: label,
+                    data: data,
+                    borderColor: color,
+                    backgroundColor: color,
+                    fill: false,
+                    tension: 0.3,
+                    borderWidth: 2,
+                    pointRadius: 0,
+                    pointHoverRadius: 4
+                }, opts || {});
                 const datasets = [
-                    {
-                        label: 'Input Tokens',
-                        data: inputData,
-                        borderColor: '#c2845a',
-                        backgroundColor: 'rgba(194, 132, 90, 0.1)',
-                        fill: true,
-                        tension: 0.3,
-                        pointRadius: 3,
-                        pointHoverRadius: 5
-                    },
-                    {
-                        label: 'Output Tokens',
-                        data: outputData,
-                        borderColor: '#7a9e7e',
-                        backgroundColor: 'rgba(122, 158, 126, 0.1)',
-                        fill: true,
-                        tension: 0.3,
-                        pointRadius: 3,
-                        pointHoverRadius: 5
-                    }
+                    line('Input Tokens', inputData, resolve('var(--token-input)'), { fill: true, backgroundColor: fade('var(--token-input)', 12) }),
+                    line('Output Tokens', outputData, resolve('var(--token-output)'), { fill: true, backgroundColor: fade('var(--token-output)', 12) }),
+                    line('Prompt (Input) Cached', promptData, resolve('var(--token-prompt)'), { borderDash: [6, 4] })
                 ];
                 if (cacheEnabled) {
                     datasets.push(
-                        {
-                            label: 'Local Cache Input Tokens',
-                            data: cacheInputData,
-                            borderColor: '#5f7dcf',
-                            backgroundColor: 'rgba(95, 125, 207, 0.08)',
-                            fill: false,
-                            tension: 0.3,
-                            pointRadius: 2,
-                            pointHoverRadius: 4,
-                            borderDash: [6, 4]
-                        },
-                        {
-                            label: 'Local Cache Output Tokens',
-                            data: cacheOutputData,
-                            borderColor: '#b0677b',
-                            backgroundColor: 'rgba(176, 103, 123, 0.08)',
-                            fill: false,
-                            tension: 0.3,
-                            pointRadius: 2,
-                            pointHoverRadius: 4,
-                            borderDash: [6, 4]
-                        }
+                        line('Locally Cached', localData, fade('var(--info)', 35), { borderDash: [2, 3] })
                     );
                 }
                 return {
@@ -66,36 +72,21 @@
                             legend: {
                                 labels: { color: colors.text, font: { size: 12 } }
                             },
-                            tooltip: {
-                                backgroundColor: colors.tooltipBg,
-                                borderColor: colors.tooltipBorder,
-                                borderWidth: 1,
-                                titleColor: colors.tooltipText,
-                                bodyColor: colors.tooltipText,
-                                callbacks: {
-                                    label: function(c) {
-                                        return c.dataset.label + ': ' + c.parsed.y.toLocaleString();
-                                    }
-                                }
-                            }
+                            tooltip: this._chartTooltip(colors, {
+                                label: (c) => c.dataset.label + ': ' + c.parsed.y.toLocaleString()
+                            })
                         },
                         scales: {
                             x: {
                                 grid: { color: colors.grid },
-                                ticks: { color: colors.text, font: { size: 11 }, maxTicksLimit: 10 }
+                                border: { display: false },
+                                ticks: { color: colors.text, font: this._chartTickFont(), maxRotation: 0, autoSkip: true, maxTicksLimit: 10 }
                             },
                             y: {
                                 beginAtZero: true,
                                 grid: { color: colors.grid },
-                                ticks: {
-                                    color: colors.text,
-                                    font: { size: 11 },
-                                    callback: function(value) {
-                                        if (value >= 1000000) return (value / 1000000).toFixed(1) + 'M';
-                                        if (value >= 1000) return (value / 1000).toFixed(1) + 'K';
-                                        return value;
-                                    }
-                                }
+                                border: { display: false },
+                                ticks: this._tokenAxisTicks(colors)
                             }
                         }
                     }
@@ -186,8 +177,101 @@
                 return result;
             },
 
+            // Prompt cache rate: share of the period's provider input tokens
+            // that were served from the prompt cache. Denominator is the input
+            // "parts" (uncached + prompt-cached + cache writes), matching the
+            // cache meter's provider split.
+            promptCacheRate() {
+                const summary = this.summary || {};
+                const uncached = Math.max(0, Number(summary.uncached_input_tokens) || 0);
+                const cached = Math.max(0, Number(summary.cached_input_tokens) || 0);
+                const cacheWrite = Math.max(0, Number(summary.cache_write_input_tokens) || 0);
+                const denom = uncached + cached + cacheWrite;
+                return denom > 0 ? (cached / denom) * 100 : 0;
+            },
+
+            promptCacheRateHasData() {
+                const summary = this.summary || {};
+                const denom = (Number(summary.uncached_input_tokens) || 0) +
+                    (Number(summary.cached_input_tokens) || 0) +
+                    (Number(summary.cache_write_input_tokens) || 0);
+                return denom > 0;
+            },
+
+            promptCacheRateText() {
+                if (!this.promptCacheRateHasData()) return '—';
+                return Math.round(this.promptCacheRate()) + '%';
+            },
+
+            _promptCacheGaugeConfig(pct, fillColor, trackColor) {
+                const value = Math.max(0, Math.min(100, pct));
+                return {
+                    type: 'doughnut',
+                    data: {
+                        datasets: [{
+                            data: [value, 100 - value],
+                            backgroundColor: [fillColor, trackColor],
+                            borderWidth: 0,
+                            spacing: 0
+                        }]
+                    },
+                    options: {
+                        // Half-circle gauge, filling clockwise from the left.
+                        rotation: -90,
+                        circumference: 180,
+                        cutout: '84%',
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        animation: { duration: 0 },
+                        layout: { padding: 1 },
+                        events: [],
+                        plugins: {
+                            legend: { display: false },
+                            tooltip: { enabled: false }
+                        }
+                    }
+                };
+            },
+
+            renderPromptCacheGauge(retries) {
+                if (retries === undefined) retries = 3;
+                this.$nextTick(() => {
+                    if (this.page !== 'overview') {
+                        if (this.promptCacheChart) {
+                            this.promptCacheChart.destroy();
+                            this.promptCacheChart = null;
+                        }
+                        return;
+                    }
+                    const canvas = document.getElementById('promptCacheGauge');
+                    if (!canvas) {
+                        return; // no gauge on this page — nothing to render
+                    }
+                    if (canvas.offsetWidth === 0) {
+                        if (retries > 0) {
+                            setTimeout(() => this.renderPromptCacheGauge(retries - 1), 100);
+                        }
+                        return;
+                    }
+                    const resolve = (expr) => (typeof this._resolveLiveTokenColor === 'function'
+                        ? this._resolveLiveTokenColor(expr)
+                        : expr);
+                    // Same colour as the "Prompt cached" series in the Tokens meter/chart.
+                    const fill = resolve('var(--token-prompt)');
+                    const track = resolve('var(--bg-surface-hover)');
+                    const config = this._promptCacheGaugeConfig(this.promptCacheRate(), fill, track);
+
+                    if (this.promptCacheChart) {
+                        this.promptCacheChart.destroy();
+                        this.promptCacheChart = null;
+                    }
+                    this.promptCacheChart = new Chart(canvas, config);
+                });
+            },
+
             renderChart(retries) {
                 if (retries === undefined) retries = 3;
+                this.renderPromptCacheGauge();
                 this.$nextTick(() => {
                     if (this.daily.length === 0 || this.page !== 'overview') {
                         if (this.chart) {
@@ -208,14 +292,31 @@
                     const colors = this.chartColors();
                     const filled = this.fillMissingDays(this.daily);
                     const labels = filled.map((d) => d.date);
-                    const inputData = filled.map((d) => d.input_tokens);
-                    const outputData = filled.map((d) => d.output_tokens);
+                    const num = (v) => Number(v) || 0;
+
+                    // Paid input = uncached + cache writes (prompt-cache reads are
+                    // their own series). Older rows lack the split, so fall back to
+                    // the full input column when no split is present.
+                    const inputPaid = filled.map((d) => {
+                        const split = num(d.uncached_input_tokens) + num(d.cache_write_input_tokens) + num(d.cached_input_tokens);
+                        return split > 0 ? num(d.uncached_input_tokens) + num(d.cache_write_input_tokens) : num(d.input_tokens);
+                    });
+                    const outputData = filled.map((d) => num(d.output_tokens));
+                    const promptData = filled.map((d) => num(d.cached_input_tokens));
+
                     const cacheByDate = {};
                     const cacheDaily = this.fillMissingDays(this.cacheOverview && Array.isArray(this.cacheOverview.daily) ? this.cacheOverview.daily : []);
                     cacheDaily.forEach((d) => { cacheByDate[d.date] = d; });
-                    const cacheInputData = labels.map((label) => (cacheByDate[label] && cacheByDate[label].input_tokens) || 0);
-                    const cacheOutputData = labels.map((label) => (cacheByDate[label] && cacheByDate[label].output_tokens) || 0);
-                    const config = this._overviewChartConfig(colors, labels, inputData, outputData, cacheInputData, cacheOutputData);
+                    // Local cache as a single series: input + output served from cache.
+                    const localData = labels.map((label) => {
+                        const c = cacheByDate[label];
+                        return c ? num(c.input_tokens) + num(c.output_tokens) : 0;
+                    });
+
+                    const config = this._overviewChartConfig(
+                        colors, labels,
+                        inputPaid, outputData, promptData, localData
+                    );
 
                     if (this.chart) {
                         this.chart.destroy();

--- a/internal/admin/dashboard/static/js/modules/charts.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/charts.test.cjs
@@ -50,8 +50,11 @@ function createChartsContext() {
     const module = createChartsModule({
         Chart: FakeChart,
         document: {
-            getElementById() {
-                return canvas;
+            getElementById(id) {
+                // The prompt-cache gauge is a separate widget refreshed alongside
+                // the overview chart; the chart tests don't exercise it, so give
+                // it no canvas and it no-ops.
+                return id === 'promptCacheGauge' ? null : canvas;
             }
         }
     });

--- a/internal/admin/dashboard/static/js/modules/live-logs.js
+++ b/internal/admin/dashboard/static/js/modules/live-logs.js
@@ -133,6 +133,9 @@
                 }
                 if (type.indexOf('usage.') === 0) {
                     this.mergeLiveUsageEntry(event.data || {}, type);
+                    if (typeof this.noteLiveTokenUsage === 'function') {
+                        this.noteLiveTokenUsage(type);
+                    }
                 }
             },
 

--- a/internal/admin/dashboard/static/js/modules/live-tokens.js
+++ b/internal/admin/dashboard/static/js/modules/live-tokens.js
@@ -1,0 +1,437 @@
+(function(global) {
+    // Live token throughput chart (overview page).
+    //
+    // A rolling, stacked bar chart of token volume bucketed by a selectable
+    // granularity (seconds/minutes/hours/days). The buckets come from the
+    // backend aggregation endpoint (GET /admin/usage/throughput) — the database
+    // is the single source of truth — so history is present on load and survives
+    // refreshes/restarts. The live usage SSE stream is used only as a signal to
+    // refetch (debounced) when new usage is persisted; a steady timer refetches
+    // to keep the window scrolling.
+    //
+    // Each bucket carries four stacked series, mirroring the overview Cache Meter:
+    //   - Input Tokens          (regular, non-cached prompt input + cache writes)
+    //   - Output Tokens         (generated tokens)
+    //   - Prompt (Input) Cached (provider prompt-cache reads)
+    //   - Locally Cached        (responses served from GoModel's local cache)
+    function dashboardLiveTokensModule() {
+        function liveTokensPath(path) {
+            if (typeof window !== 'undefined' && typeof window.gomodelPath === 'function') {
+                return window.gomodelPath(path);
+            }
+            return path;
+        }
+
+        // apiName: backend granularity; refreshMs: how often to refetch to scroll
+        // the window (matched to the bucket width, capped for coarse views).
+        const GRANULARITIES = {
+            seconds: { apiName: 'second', windowLabel: 'Last 60 seconds', refreshMs: 2000 },
+            minutes: { apiName: 'minute', windowLabel: 'Last 60 minutes', refreshMs: 5000 },
+            hours:   { apiName: 'hour', windowLabel: 'Last 24 hours', refreshMs: 20000 },
+            days:    { apiName: 'day', windowLabel: 'Last 30 days', refreshMs: 60000 }
+        };
+
+        const GRANULARITY_OPTIONS = [
+            { value: 'seconds', label: 'Seconds' },
+            { value: 'minutes', label: 'Minutes' },
+            { value: 'hours', label: 'Hours' },
+            { value: 'days', label: 'Days' }
+        ];
+
+        // Engine state lives in this closure, deliberately OUTSIDE Alpine's
+        // reactive proxy: a Chart.js instance is deeply self-referential, so
+        // operating on a reactive-wrapped chart recurses forever. This also
+        // cleanly separates the engine from the reactive view state below.
+        let chart = null;
+        let chartGran = null;
+        let scrollTimer = null;
+        let debounceTimer = null;
+        let inFlight = false;
+        let buckets = [];
+        // Bucket-start timestamps for the current chart, kept here (not on the
+        // Chart instance) so they're available to the very first synchronous draw
+        // inside `new Chart()` — otherwise the day-marks plugin misses them on
+        // creation and the separator only appears on the next redraw (e.g. hover).
+        let liveStamps = [];
+
+        function zeroMetrics() {
+            return { input: 0, output: 0, prompt: 0, local: 0 };
+        }
+
+        function pad2(n) {
+            return String(n).padStart(2, '0');
+        }
+
+        function num(value) {
+            const n = Number(value);
+            return Number.isFinite(n) && n > 0 ? n : 0;
+        }
+
+        // Bucket-start label, formatted per granularity in local time.
+        function formatBucketLabel(granularity, startMs) {
+            if (!Number.isFinite(startMs)) {
+                return '';
+            }
+            const d = new Date(startMs);
+            switch (granularity) {
+            case 'seconds':
+                return pad2(d.getHours()) + ':' + pad2(d.getMinutes()) + ':' + pad2(d.getSeconds());
+            case 'minutes':
+                return pad2(d.getHours()) + ':' + pad2(d.getMinutes());
+            case 'hours':
+                return pad2(d.getHours()) + ':00';
+            case 'days':
+            default:
+                return pad2(d.getMonth() + 1) + '-' + pad2(d.getDate());
+            }
+        }
+
+        return {
+            // Reactive view state (bound in the template).
+            liveTokensGranularity: 'minutes',
+            liveTokensSummary: zeroMetrics(),
+            liveTokensActive: false,
+
+            liveTokensGranularityOptions() {
+                return GRANULARITY_OPTIONS;
+            },
+
+            liveTokensWindowLabel() {
+                return (GRANULARITIES[this.liveTokensGranularity] || GRANULARITIES.minutes).windowLabel;
+            },
+
+            liveTokensHasData() {
+                const s = this.liveTokensSummary;
+                return (s.input + s.output + s.prompt + s.local) > 0;
+            },
+
+            liveTokensLegendValue(metric) {
+                return this.formatTokensShort(Math.max(0, Math.round(this.liveTokensSummary[metric] || 0)));
+            },
+
+            setLiveTokensGranularity(value) {
+                if (!GRANULARITIES[value] || value === this.liveTokensGranularity) {
+                    return;
+                }
+                this.liveTokensGranularity = value;
+                chartGran = null; // force a rebuild so the x-axis re-buckets
+                buckets = [];
+                this.renderLiveTokensChart();
+                this._restartLiveTokensScroll();
+                this.fetchLiveTokens();
+            },
+
+            startLiveTokens() {
+                this.liveTokensActive = true;
+                this.fetchLiveTokens();
+                this._restartLiveTokensScroll();
+            },
+
+            stopLiveTokens() {
+                this.liveTokensActive = false;
+                if (scrollTimer) {
+                    clearInterval(scrollTimer);
+                    scrollTimer = null;
+                }
+                if (debounceTimer) {
+                    clearTimeout(debounceTimer);
+                    debounceTimer = null;
+                }
+                if (chart) {
+                    chart.destroy();
+                    chart = null;
+                }
+                chartGran = null;
+                buckets = [];
+                this.liveTokensSummary = zeroMetrics();
+            },
+
+            // Force a fresh chart (e.g. on theme change, to re-resolve colors).
+            redrawLiveTokensChart() {
+                chartGran = null;
+                this.renderLiveTokensChart();
+            },
+
+            _restartLiveTokensScroll() {
+                if (scrollTimer) {
+                    clearInterval(scrollTimer);
+                    scrollTimer = null;
+                }
+                if (typeof setInterval !== 'function') {
+                    return;
+                }
+                const cfg = GRANULARITIES[this.liveTokensGranularity] || GRANULARITIES.minutes;
+                scrollTimer = setInterval(() => {
+                    if (!this.liveTokensActive || this.page !== 'overview') {
+                        return;
+                    }
+                    this.fetchLiveTokens();
+                }, cfg.refreshMs);
+            },
+
+            // Called from the live-logs SSE consumer. A `usage.flushed` event
+            // means a row was just persisted, so the aggregate has changed —
+            // refetch (debounced to coalesce bursts). Other usage events are the
+            // not-yet-persisted echoes the periodic scroll already covers.
+            noteLiveTokenUsage(eventType) {
+                if (!this.liveTokensActive || eventType !== 'usage.flushed') {
+                    return;
+                }
+                if (debounceTimer || typeof setTimeout !== 'function') {
+                    return;
+                }
+                debounceTimer = setTimeout(() => {
+                    debounceTimer = null;
+                    this.fetchLiveTokens();
+                }, 900);
+            },
+
+            async fetchLiveTokens() {
+                if (!this.liveTokensActive || this.page !== 'overview' || inFlight) {
+                    return;
+                }
+                if (typeof fetch !== 'function') {
+                    return;
+                }
+                inFlight = true;
+                try {
+                    const cfg = GRANULARITIES[this.liveTokensGranularity] || GRANULARITIES.minutes;
+                    const options = typeof this.requestOptions === 'function' ? this.requestOptions() : { headers: this.headers() };
+                    const res = await fetch(liveTokensPath('/admin/usage/throughput?granularity=' + cfg.apiName), options);
+                    const handled = this.handleFetchResponse(res, 'token throughput', options);
+                    if (typeof this.isStaleAuthFetchResult === 'function' && this.isStaleAuthFetchResult(handled)) {
+                        return;
+                    }
+                    if (!handled) {
+                        return;
+                    }
+                    const payload = await res.json();
+                    buckets = payload && Array.isArray(payload.buckets) ? payload.buckets : [];
+                    this.renderLiveTokensChart();
+                } catch (e) {
+                    if (typeof this._isAbortError === 'function' && this._isAbortError(e)) {
+                        return;
+                    }
+                    console.error('Failed to fetch token throughput:', e);
+                } finally {
+                    inFlight = false;
+                }
+            },
+
+            // Resolve a CSS color expression to a canvas-safe rgb() string by
+            // letting the browser compute it on a throwaway element (handles
+            // var()/color-mix(), which canvas fillStyle may not accept directly).
+            _resolveLiveTokenColor(expr) {
+                if (typeof document === 'undefined' || !document.body) {
+                    return expr;
+                }
+                const probe = document.createElement('span');
+                probe.style.display = 'none';
+                probe.style.color = expr;
+                document.body.appendChild(probe);
+                const resolved = getComputedStyle(probe).color;
+                document.body.removeChild(probe);
+                return resolved || expr;
+            },
+
+            liveTokensColors() {
+                return {
+                    input: this._resolveLiveTokenColor('var(--token-input)'),
+                    output: this._resolveLiveTokenColor('var(--token-output)'),
+                    prompt: this._resolveLiveTokenColor('var(--token-prompt)'),
+                    local: this._resolveLiveTokenColor('var(--token-local)')
+                };
+            },
+
+            _liveTokensChartConfig(colors, seriesColors, labels, cols) {
+                const formatValue = (v) => this.formatTokensShort(Math.max(0, Math.round(v)));
+                const granularity = this.liveTokensGranularity;
+                const bar = (label, data, color) => ({
+                    label: label,
+                    data: data,
+                    backgroundColor: color,
+                    borderWidth: 0,
+                    borderRadius: 0,
+                    categoryPercentage: 1.0, // touching bars: fill the category, no inter-bar gap
+                    barPercentage: 1.0,
+                    stack: 'tokens'
+                });
+                // Mark where the local calendar day changes between buckets with a
+                // dashed separator + date label. Chart.js has no built-in for this
+                // on a category axis (a time scale could, but needs a date-adapter
+                // lib we don't bundle), so we draw it directly. Skipped for the
+                // Days view, where every bar is already a separate day.
+                const dayMarks = {
+                    id: 'liveTokensDayMarks',
+                    afterDatasetsDraw: (chart) => {
+                        if (granularity === 'days') return;
+                        const stamps = liveStamps;
+                        const meta = chart.getDatasetMeta(0);
+                        const area = chart.chartArea;
+                        if (!meta || !meta.data || !area) return;
+                        const ctx = chart.ctx;
+                        ctx.save();
+                        ctx.font = "10px 'SF Mono', Menlo, Consolas, monospace";
+                        let prevKey = null;
+                        for (let i = 0; i < stamps.length && i < meta.data.length; i++) {
+                            const ms = stamps[i];
+                            if (!Number.isFinite(ms)) { prevKey = null; continue; }
+                            const d = new Date(ms);
+                            const key = d.getFullYear() + '-' + d.getMonth() + '-' + d.getDate();
+                            if (prevKey !== null && key !== prevKey && meta.data[i - 1]) {
+                                const x = Math.round((meta.data[i - 1].x + meta.data[i].x) / 2) + 0.5;
+                                ctx.globalAlpha = 0.4;
+                                ctx.strokeStyle = colors.text;
+                                ctx.setLineDash([3, 3]);
+                                ctx.lineWidth = 1;
+                                ctx.beginPath();
+                                ctx.moveTo(x, area.top);
+                                ctx.lineTo(x, area.bottom);
+                                ctx.stroke();
+                                ctx.setLineDash([]);
+                                ctx.globalAlpha = 0.85;
+                                ctx.fillStyle = colors.text;
+                                ctx.textAlign = 'left';
+                                ctx.textBaseline = 'bottom';
+                                ctx.fillText(d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }), x + 3, area.bottom - 2);
+                            }
+                            prevKey = key;
+                        }
+                        ctx.restore();
+                    }
+                };
+                return {
+                    type: 'bar',
+                    plugins: [dayMarks],
+                    data: {
+                        labels: labels,
+                        datasets: [
+                            bar('Input Tokens', cols.input, seriesColors.input),
+                            bar('Output Tokens', cols.output, seriesColors.output),
+                            bar('Prompt (Input) Cached', cols.prompt, seriesColors.prompt),
+                            bar('Locally Cached', cols.local, seriesColors.local)
+                        ]
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        animation: { duration: 0 },
+                        interaction: { mode: 'index', intersect: false },
+                        scales: {
+                            x: {
+                                stacked: true,
+                                grid: { color: colors.grid },
+                                border: { display: false },
+                                ticks: {
+                                    color: colors.text,
+                                    font: this._chartTickFont(),
+                                    maxRotation: 0,
+                                    autoSkip: true,
+                                    maxTicksLimit: 8
+                                }
+                            },
+                            y: {
+                                stacked: true,
+                                beginAtZero: true,
+                                grid: { color: colors.grid },
+                                border: { display: false },
+                                ticks: this._tokenAxisTicks(colors)
+                            }
+                        },
+                        plugins: {
+                            legend: { display: false },
+                            tooltip: this._chartTooltip(colors, {
+                                title: (items) => {
+                                    if (!items.length) {
+                                        return '';
+                                    }
+                                    const ms = liveStamps[items[0].dataIndex];
+                                    if (!ms) {
+                                        return items[0].label;
+                                    }
+                                    const date = new Date(ms);
+                                    // Day buckets start at local midnight, so the time is always
+                                    // 00:00:00 — show the date alone on the Days view.
+                                    return granularity === 'days' ? date.toLocaleDateString() : date.toLocaleString();
+                                },
+                                label: (c) => c.dataset.label + ': ' + formatValue(c.parsed.y),
+                                footer: (items) => {
+                                    let total = 0;
+                                    items.forEach((it) => { total += Number(it.parsed.y) || 0; });
+                                    return 'Total: ' + formatValue(total);
+                                }
+                            })
+                        }
+                    }
+                };
+            },
+
+            renderLiveTokensChart(retries) {
+                if (retries === undefined) {
+                    retries = 3;
+                }
+                this.$nextTick(() => {
+                    if (!this.liveTokensActive || this.page !== 'overview') {
+                        if (chart) {
+                            chart.destroy();
+                            chart = null;
+                            chartGran = null;
+                        }
+                        return;
+                    }
+
+                    const canvas = document.getElementById('liveTokensChart');
+                    if (!canvas || canvas.offsetWidth === 0) {
+                        if (retries > 0) {
+                            setTimeout(() => this.renderLiveTokensChart(retries - 1), 100);
+                        }
+                        return;
+                    }
+
+                    const labels = [];
+                    const stamps = [];
+                    const cols = { input: [], output: [], prompt: [], local: [] };
+                    const totals = zeroMetrics();
+                    for (const bucket of buckets) {
+                        const startMs = Date.parse(bucket && bucket.start);
+                        const input = num(bucket && bucket.input_tokens);
+                        const output = num(bucket && bucket.output_tokens);
+                        const prompt = num(bucket && bucket.prompt_cached_tokens);
+                        const local = num(bucket && bucket.locally_cached_tokens);
+                        labels.push(formatBucketLabel(this.liveTokensGranularity, startMs));
+                        stamps.push(Number.isFinite(startMs) ? startMs : null);
+                        cols.input.push(input);
+                        cols.output.push(output);
+                        cols.prompt.push(prompt);
+                        cols.local.push(local);
+                        totals.input += input;
+                        totals.output += output;
+                        totals.prompt += prompt;
+                        totals.local += local;
+                    }
+                    this.liveTokensSummary = totals;
+                    liveStamps = stamps;
+
+                    if (chart && chartGran === this.liveTokensGranularity) {
+                        chart.data.labels = labels;
+                        chart.data.datasets[0].data = cols.input;
+                        chart.data.datasets[1].data = cols.output;
+                        chart.data.datasets[2].data = cols.prompt;
+                        chart.data.datasets[3].data = cols.local;
+                        chart.update('none');
+                        return;
+                    }
+
+                    if (chart) {
+                        chart.destroy();
+                    }
+                    const config = this._liveTokensChartConfig(this.chartColors(), this.liveTokensColors(), labels, cols);
+                    chart = new Chart(canvas, config);
+                    chartGran = this.liveTokensGranularity;
+                });
+            }
+        };
+    }
+
+    global.dashboardLiveTokensModule = dashboardLiveTokensModule;
+})(window);

--- a/internal/admin/dashboard/static/js/modules/live-tokens.js
+++ b/internal/admin/dashboard/static/js/modules/live-tokens.js
@@ -109,6 +109,16 @@
                 return this.formatTokensShort(Math.max(0, Math.round(this.liveTokensSummary[metric] || 0)));
             },
 
+            // Text equivalent of the chart for screen readers (the canvas itself
+            // is opaque to assistive tech).
+            liveTokensChartAriaLabel() {
+                return 'Live token throughput, ' + this.liveTokensWindowLabel().toLowerCase() + '. ' +
+                    'Input ' + this.liveTokensLegendValue('input') + ', ' +
+                    'output ' + this.liveTokensLegendValue('output') + ', ' +
+                    'prompt cached ' + this.liveTokensLegendValue('prompt') + ', ' +
+                    'locally cached ' + this.liveTokensLegendValue('local') + ' tokens.';
+            },
+
             setLiveTokensGranularity(value) {
                 if (!GRANULARITIES[value] || value === this.liveTokensGranularity) {
                     return;
@@ -194,8 +204,9 @@
                     return;
                 }
                 inFlight = true;
+                const requested = this.liveTokensGranularity;
                 try {
-                    const cfg = GRANULARITIES[this.liveTokensGranularity] || GRANULARITIES.minutes;
+                    const cfg = GRANULARITIES[requested] || GRANULARITIES.minutes;
                     const options = typeof this.requestOptions === 'function' ? this.requestOptions() : { headers: this.headers() };
                     const res = await fetch(liveTokensPath('/admin/usage/throughput?granularity=' + cfg.apiName), options);
                     const handled = this.handleFetchResponse(res, 'token throughput', options);
@@ -206,6 +217,12 @@
                         return;
                     }
                     const payload = await res.json();
+                    // The granularity changed while this request was in flight, so
+                    // its buckets no longer match the selected window — discard them
+                    // (a fresh fetch is issued in finally).
+                    if (this.liveTokensGranularity !== requested) {
+                        return;
+                    }
                     buckets = payload && Array.isArray(payload.buckets) ? payload.buckets : [];
                     this.renderLiveTokensChart();
                 } catch (e) {
@@ -215,6 +232,11 @@
                     console.error('Failed to fetch token throughput:', e);
                 } finally {
                     inFlight = false;
+                    // A granularity change during the fetch was swallowed by the
+                    // in-flight guard; fetch the now-selected granularity.
+                    if (this.liveTokensActive && this.page === 'overview' && this.liveTokensGranularity !== requested) {
+                        this.fetchLiveTokens();
+                    }
                 }
             },
 

--- a/internal/admin/dashboard/static/js/modules/usage.js
+++ b/internal/admin/dashboard/static/js/modules/usage.js
@@ -118,18 +118,18 @@
                         note: cacheWrite > 0 ? 'Includes ' + this.formatNumber(cacheWrite) + ' cache-write tokens' : ''
                     },
                     {
-                        key: 'local',
-                        label: 'Locally cached',
-                        tokens: locallyCached,
-                        colorVar: '--cache-meter-local',
-                        note: 'Served from GoModel response cache'
-                    },
-                    {
                         key: 'prompt',
                         label: 'Prompt cached',
                         tokens: promptCached,
                         colorVar: '--cache-meter-prompt',
                         note: 'Provider prompt-cache reads'
+                    },
+                    {
+                        key: 'local',
+                        label: 'Locally cached',
+                        tokens: locallyCached,
+                        colorVar: '--cache-meter-local',
+                        note: 'Served from GoModel response cache'
                     }
                 ];
             },

--- a/internal/admin/dashboard/static/js/modules/usage.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/usage.test.cjs
@@ -387,7 +387,7 @@ test('cacheMeterCategories always returns all three categories at 0% when empty'
     const categories = module.cacheMeterCategories();
 
     assert.equal(categories.length, 3);
-    assert.equal(categories.map((c) => c.key).join(','), 'uncached,local,prompt');
+    assert.equal(categories.map((c) => c.key).join(','), 'uncached,prompt,local');
     assert.equal(categories.every((c) => c.pct === 0), true);
     // The bar stays empty while the legend key still renders all three.
     assert.equal(module.cacheMeterSegments().length, 0);

--- a/internal/admin/dashboard/templates/layout.html
+++ b/internal/admin/dashboard/templates/layout.html
@@ -149,6 +149,7 @@
     <script src="{{assetURL "js/modules/conversation-drawer.js"}}"></script>
     <script src="{{assetURL "js/modules/contribution-calendar.js"}}"></script>
     <script src="{{assetURL "js/modules/charts.js"}}"></script>
+    <script src="{{assetURL "js/modules/live-tokens.js"}}"></script>
     <script src="{{assetURL "js/dashboard.js"}}"></script>
 </body>
 </html>{{end}}

--- a/internal/admin/dashboard/templates/page-overview.html
+++ b/internal/admin/dashboard/templates/page-overview.html
@@ -46,7 +46,7 @@
             </div>
         </div>
         <div class="chart-wrapper">
-            <canvas id="liveTokensChart"></canvas>
+            <canvas id="liveTokensChart" role="img" :aria-label="liveTokensChartAriaLabel()"></canvas>
             <div class="chart-empty-overlay live-tokens-empty" x-show="!liveTokensHasData()">
                 <span class="live-tokens-empty-text">Waiting for live requests…</span>
             </div>

--- a/internal/admin/dashboard/templates/page-overview.html
+++ b/internal/admin/dashboard/templates/page-overview.html
@@ -2,6 +2,57 @@
 <!-- Overview Page -->
 <template x-if="page==='overview'">
 <div>
+    <!-- Live Token Throughput -->
+    <div class="chart-container live-tokens">
+        <div class="chart-container-header">
+            <div class="live-tokens-heading">
+                <h3>Live Token Throughput</h3>
+                <span class="live-tokens-subtitle">
+                    <span class="live-dot" :class="{ 'is-streaming': liveTokensActive }" aria-hidden="true"></span>
+                    <span x-text="liveTokensWindowLabel()">Last 60 minutes</span>
+                </span>
+            </div>
+            <div class="interval-picker" role="group" aria-label="Live token throughput granularity">
+                <template x-for="opt in liveTokensGranularityOptions()" :key="opt.value">
+                    <button type="button"
+                            class="interval-btn"
+                            :class="{active: liveTokensGranularity===opt.value}"
+                            :aria-pressed="liveTokensGranularity===opt.value"
+                            @click="setLiveTokensGranularity(opt.value)"
+                            x-text="opt.label">-</button>
+                </template>
+            </div>
+        </div>
+        <div class="live-tokens-legend">
+            <div class="live-tokens-legend-item">
+                <span class="live-tokens-swatch" style="background: var(--token-input)"></span>
+                <span class="live-tokens-legend-label">Input Tokens</span>
+                <span class="live-tokens-legend-value mono" x-text="liveTokensLegendValue('input')">-</span>
+            </div>
+            <div class="live-tokens-legend-item">
+                <span class="live-tokens-swatch" style="background: var(--token-output)"></span>
+                <span class="live-tokens-legend-label">Output Tokens</span>
+                <span class="live-tokens-legend-value mono" x-text="liveTokensLegendValue('output')">-</span>
+            </div>
+            <div class="live-tokens-legend-item">
+                <span class="live-tokens-swatch" style="background: var(--token-prompt)"></span>
+                <span class="live-tokens-legend-label">Prompt (Input) Cached</span>
+                <span class="live-tokens-legend-value mono" x-text="liveTokensLegendValue('prompt')">-</span>
+            </div>
+            <div class="live-tokens-legend-item">
+                <span class="live-tokens-swatch" style="background: var(--token-local)"></span>
+                <span class="live-tokens-legend-label">Locally Cached</span>
+                <span class="live-tokens-legend-value mono" x-text="liveTokensLegendValue('local')">-</span>
+            </div>
+        </div>
+        <div class="chart-wrapper">
+            <canvas id="liveTokensChart"></canvas>
+            <div class="chart-empty-overlay live-tokens-empty" x-show="!liveTokensHasData()">
+                <span class="live-tokens-empty-text">Waiting for live requests…</span>
+            </div>
+        </div>
+    </div>
+
     <div class="page-header">
         <h2>Usage Overview</h2>
         <div class="page-header-controls">
@@ -52,6 +103,13 @@
                 </span>
                 <span class="cache-token-operator">=</span>
                 <span x-text="formatNumber(cacheOverviewTotalTokens())" title="Total tokens">-</span>
+            </div>
+        </div>
+        <div class="card prompt-cache-card" title="Share of input tokens served from the provider prompt cache, over the selected period">
+            <div class="card-label">Prompt Cache Rate</div>
+            <div class="prompt-cache-gauge" role="img" :aria-label="'Prompt cache rate ' + promptCacheRateText()">
+                <canvas id="promptCacheGauge"></canvas>
+                <span class="prompt-cache-gauge-value" x-text="promptCacheRateText()">-</span>
             </div>
         </div>
         <div class="card provider-status-flag" x-show="providerStatus.summary.total > 0" :class="providerStatusSummaryClass()">

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -23,26 +23,28 @@ import (
 
 // mockUsageReader implements usage.UsageReader for testing.
 type mockUsageReader struct {
-	summary            *usage.UsageSummary
-	daily              []usage.DailyUsage
-	modelUsage         []usage.ModelUsage
-	userPathUsage      []usage.UserPathUsage
-	usageLog           *usage.UsageLogResult
-	usageByRequestID   map[string][]usage.UsageLogEntry
-	cacheOverview      *usage.CacheOverview
-	throughput         *usage.TokenThroughput
-	lastUsageLog       usage.UsageLogParams
-	lastRequestIDs     []string
-	lastCacheOverview  usage.UsageQueryParams
-	lastThroughputGran usage.ThroughputGranularity
-	summaryErr         error
-	dailyErr           error
-	modelUsageErr      error
-	userPathUsageErr   error
-	usageLogErr        error
-	usageByRequestErr  error
-	cacheErr           error
-	throughputErr      error
+	summary              *usage.UsageSummary
+	daily                []usage.DailyUsage
+	modelUsage           []usage.ModelUsage
+	userPathUsage        []usage.UserPathUsage
+	usageLog             *usage.UsageLogResult
+	usageByRequestID     map[string][]usage.UsageLogEntry
+	cacheOverview        *usage.CacheOverview
+	throughput           *usage.TokenThroughput
+	lastUsageLog         usage.UsageLogParams
+	lastRequestIDs       []string
+	lastCacheOverview    usage.UsageQueryParams
+	lastThroughputGran   usage.ThroughputGranularity
+	lastThroughputEnd    time.Time
+	lastThroughputOffset int64
+	summaryErr           error
+	dailyErr             error
+	modelUsageErr        error
+	userPathUsageErr     error
+	usageLogErr          error
+	usageByRequestErr    error
+	cacheErr             error
+	throughputErr        error
 }
 
 type mockAuditReader struct {
@@ -120,8 +122,10 @@ func (m *mockUsageReader) GetCacheOverview(_ context.Context, params usage.Usage
 	return m.cacheOverview, nil
 }
 
-func (m *mockUsageReader) GetTokenThroughput(_ context.Context, gran usage.ThroughputGranularity, _ time.Time, _ int64) (*usage.TokenThroughput, error) {
+func (m *mockUsageReader) GetTokenThroughput(_ context.Context, gran usage.ThroughputGranularity, end time.Time, offset int64) (*usage.TokenThroughput, error) {
 	m.lastThroughputGran = gran
+	m.lastThroughputEnd = end
+	m.lastThroughputOffset = offset
 	if m.throughputErr != nil {
 		return nil, m.throughputErr
 	}
@@ -2980,5 +2984,148 @@ var _ = func() usage.UsageQueryParams {
 		StartDate: time.Time{},
 		EndDate:   time.Time{},
 		Interval:  "daily",
+	}
+}
+
+// --- TokenThroughput handler tests ---
+
+func TestTokenThroughput_InvalidGranularity(t *testing.T) {
+	h := NewHandler(&mockUsageReader{}, nil)
+	c, rec := newHandlerContext("/admin/usage/throughput?granularity=weekly")
+	if err := h.TokenThroughput(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rec.Code)
+	}
+	if !containsString(rec.Body.String(), "granularity") {
+		t.Errorf("expected granularity message, got: %s", rec.Body.String())
+	}
+}
+
+func TestTokenThroughput_MissingGranularity(t *testing.T) {
+	h := NewHandler(&mockUsageReader{}, nil)
+	c, rec := newHandlerContext("/admin/usage/throughput")
+	if err := h.TokenThroughput(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestTokenThroughput_NilReaderReturnsEmptyWindow(t *testing.T) {
+	h := NewHandler(nil, nil)
+	c, rec := newHandlerContext("/admin/usage/throughput?granularity=minute")
+	if err := h.TokenThroughput(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	var tp usage.TokenThroughput
+	if err := json.Unmarshal(rec.Body.Bytes(), &tp); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if tp.Granularity != "minute" || tp.BucketSeconds != 60 {
+		t.Errorf("got granularity=%q bucket_seconds=%d, want minute/60", tp.Granularity, tp.BucketSeconds)
+	}
+	if len(tp.Buckets) != 60 {
+		t.Errorf("got %d buckets, want 60 (zero-filled window)", len(tp.Buckets))
+	}
+	for i, b := range tp.Buckets {
+		if b.InputTokens+b.OutputTokens+b.PromptCachedTokens+b.LocallyCachedTokens != 0 {
+			t.Errorf("bucket %d should be zero, got %+v", i, b)
+		}
+	}
+}
+
+func TestTokenThroughput_SuccessForwardsArgs(t *testing.T) {
+	reader := &mockUsageReader{
+		throughput: &usage.TokenThroughput{
+			Granularity:   "minute",
+			BucketSeconds: 60,
+			Buckets: []usage.ThroughputBucket{
+				{InputTokens: 70, OutputTokens: 40, PromptCachedTokens: 30, LocallyCachedTokens: 5},
+			},
+		},
+	}
+	h := NewHandler(reader, nil)
+	c, rec := newHandlerContext("/admin/usage/throughput?granularity=minute")
+	before := time.Now().UTC()
+	if err := h.TokenThroughput(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	var tp usage.TokenThroughput
+	if err := json.Unmarshal(rec.Body.Bytes(), &tp); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if len(tp.Buckets) != 1 || tp.Buckets[0].PromptCachedTokens != 30 {
+		t.Errorf("unexpected throughput body: %+v", tp)
+	}
+	// The handler forwards the parsed granularity, ~now, and a UTC offset by default.
+	if reader.lastThroughputGran.Name != "minute" {
+		t.Errorf("forwarded granularity = %q, want minute", reader.lastThroughputGran.Name)
+	}
+	if reader.lastThroughputOffset != 0 {
+		t.Errorf("forwarded offset = %d, want 0 (default UTC)", reader.lastThroughputOffset)
+	}
+	if reader.lastThroughputEnd.Before(before) || reader.lastThroughputEnd.After(time.Now().UTC().Add(time.Second)) {
+		t.Errorf("forwarded end = %v, want ~now", reader.lastThroughputEnd)
+	}
+}
+
+func TestTokenThroughput_ForwardsTimezoneOffset(t *testing.T) {
+	reader := &mockUsageReader{throughput: &usage.TokenThroughput{Granularity: "day", BucketSeconds: 86400}}
+	h := NewHandler(reader, nil)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/admin/usage/throughput?granularity=day", nil)
+	req.Header.Set("X-GoModel-Timezone", "Asia/Kolkata") // UTC+5:30, no DST
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.TokenThroughput(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	if reader.lastThroughputOffset != int64(5*3600+30*60) {
+		t.Errorf("forwarded offset = %d, want 19800 (Asia/Kolkata)", reader.lastThroughputOffset)
+	}
+}
+
+func TestTokenThroughput_GatewayError(t *testing.T) {
+	reader := &mockUsageReader{
+		throughputErr: core.NewProviderError("test", http.StatusBadGateway, "upstream failed", nil),
+	}
+	h := NewHandler(reader, nil)
+	c, rec := newHandlerContext("/admin/usage/throughput?granularity=hour")
+	if err := h.TokenThroughput(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusBadGateway {
+		t.Errorf("expected 502, got %d", rec.Code)
+	}
+}
+
+func TestTokenThroughput_GenericError(t *testing.T) {
+	reader := &mockUsageReader{
+		throughputErr: errors.New("database connection lost"),
+	}
+	h := NewHandler(reader, nil)
+	c, rec := newHandlerContext("/admin/usage/throughput?granularity=day")
+	if err := h.TokenThroughput(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", rec.Code)
+	}
+	if containsString(rec.Body.String(), "database connection lost") {
+		t.Errorf("original error message should be hidden, got: %s", rec.Body.String())
 	}
 }

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -23,23 +23,26 @@ import (
 
 // mockUsageReader implements usage.UsageReader for testing.
 type mockUsageReader struct {
-	summary           *usage.UsageSummary
-	daily             []usage.DailyUsage
-	modelUsage        []usage.ModelUsage
-	userPathUsage     []usage.UserPathUsage
-	usageLog          *usage.UsageLogResult
-	usageByRequestID  map[string][]usage.UsageLogEntry
-	cacheOverview     *usage.CacheOverview
-	lastUsageLog      usage.UsageLogParams
-	lastRequestIDs    []string
-	lastCacheOverview usage.UsageQueryParams
-	summaryErr        error
-	dailyErr          error
-	modelUsageErr     error
-	userPathUsageErr  error
-	usageLogErr       error
-	usageByRequestErr error
-	cacheErr          error
+	summary            *usage.UsageSummary
+	daily              []usage.DailyUsage
+	modelUsage         []usage.ModelUsage
+	userPathUsage      []usage.UserPathUsage
+	usageLog           *usage.UsageLogResult
+	usageByRequestID   map[string][]usage.UsageLogEntry
+	cacheOverview      *usage.CacheOverview
+	throughput         *usage.TokenThroughput
+	lastUsageLog       usage.UsageLogParams
+	lastRequestIDs     []string
+	lastCacheOverview  usage.UsageQueryParams
+	lastThroughputGran usage.ThroughputGranularity
+	summaryErr         error
+	dailyErr           error
+	modelUsageErr      error
+	userPathUsageErr   error
+	usageLogErr        error
+	usageByRequestErr  error
+	cacheErr           error
+	throughputErr      error
 }
 
 type mockAuditReader struct {
@@ -115,6 +118,14 @@ func (m *mockUsageReader) GetCacheOverview(_ context.Context, params usage.Usage
 		return nil, m.cacheErr
 	}
 	return m.cacheOverview, nil
+}
+
+func (m *mockUsageReader) GetTokenThroughput(_ context.Context, gran usage.ThroughputGranularity, _ time.Time, _ int64) (*usage.TokenThroughput, error) {
+	m.lastThroughputGran = gran
+	if m.throughputErr != nil {
+		return nil, m.throughputErr
+	}
+	return m.throughput, nil
 }
 
 func (m *mockAuditReader) GetLogs(_ context.Context, params auditlog.LogQueryParams) (*auditlog.LogListResult, error) {

--- a/internal/admin/handler_usage.go
+++ b/internal/admin/handler_usage.go
@@ -340,6 +340,50 @@ func (h *Handler) CacheOverview(c *echo.Context) error {
 	return c.JSON(http.StatusOK, overview)
 }
 
+// TokenThroughput handles GET /admin/usage/throughput.
+//
+// @Summary      Get the live token-throughput window
+// @Description  Returns a fixed, trailing window of token-volume buckets
+// @Description  (input / output / prompt-cached / locally-cached) at the
+// @Description  requested granularity, for the overview live chart.
+// @Tags         admin
+// @Produce      json
+// @Security     BearerAuth
+// @Param        granularity  query     string  true   "Bucket granularity: second, minute, hour, day"
+// @Success      200  {object}  usage.TokenThroughput
+// @Failure      400  {object}  core.GatewayError
+// @Failure      401  {object}  core.GatewayError
+// @Router       /admin/usage/throughput [get]
+func (h *Handler) TokenThroughput(c *echo.Context) error {
+	gran, err := usage.ParseThroughputGranularity(c.QueryParam("granularity"))
+	if err != nil {
+		return handleError(c, core.NewInvalidRequestError(err.Error(), nil))
+	}
+
+	now := time.Now().UTC()
+	// Align buckets to the dashboard's timezone so day buckets start at local
+	// midnight (matching the Daily chart), not UTC.
+	_, location := dashboardTimeZone(c)
+	if location == nil {
+		location = time.UTC
+	}
+	_, offsetSeconds := now.In(location).Zone()
+	offset := int64(offsetSeconds)
+
+	if h.usageReader == nil {
+		return c.JSON(http.StatusOK, usage.EmptyTokenThroughput(gran, now, offset))
+	}
+
+	result, err := h.usageReader.GetTokenThroughput(c.Request().Context(), gran, now, offset)
+	if err != nil {
+		return handleError(c, err)
+	}
+	if result == nil {
+		result = usage.EmptyTokenThroughput(gran, now, offset)
+	}
+	return c.JSON(http.StatusOK, result)
+}
+
 type recalculatePricingRequest struct {
 	Days         int    `json:"days,omitempty"`
 	StartDate    string `json:"start_date,omitempty"`

--- a/internal/admin/routes.go
+++ b/internal/admin/routes.go
@@ -25,6 +25,7 @@ func (h *Handler) RegisterRoutes(g RouteRegistrar) {
 	g.GET("/usage/models", h.UsageByModel)
 	g.GET("/usage/user-paths", h.UsageByUserPath)
 	g.GET("/usage/log", h.UsageLog)
+	g.GET("/usage/throughput", h.TokenThroughput)
 	g.POST("/usage/recalculate-pricing", h.RecalculateUsagePricing)
 
 	g.GET("/audit/log", h.AuditLog)

--- a/internal/admin/routes_test.go
+++ b/internal/admin/routes_test.go
@@ -40,6 +40,7 @@ func TestRegisterRoutes_RegistersExpectedPaths(t *testing.T) {
 		"GET /admin/usage/models",
 		"GET /admin/usage/user-paths",
 		"GET /admin/usage/log",
+		"GET /admin/usage/throughput",
 		"POST /admin/usage/recalculate-pricing",
 
 		"GET /admin/audit/log",

--- a/internal/usage/reader.go
+++ b/internal/usage/reader.go
@@ -119,14 +119,76 @@ type UserPathUsage struct {
 // Date holds the period label: YYYY-MM-DD for daily, YYYY-Www for weekly,
 // YYYY-MM for monthly, or YYYY for yearly intervals.
 type DailyUsage struct {
-	Date         string   `json:"date"`
-	Requests     int      `json:"requests"`
-	InputTokens  int64    `json:"input_tokens"`
-	OutputTokens int64    `json:"output_tokens"`
-	TotalTokens  int64    `json:"total_tokens"`
-	InputCost    *float64 `json:"input_cost"`
-	OutputCost   *float64 `json:"output_cost"`
-	TotalCost    *float64 `json:"total_cost"`
+	Date         string `json:"date"`
+	Requests     int    `json:"requests"`
+	InputTokens  int64  `json:"input_tokens"`
+	OutputTokens int64  `json:"output_tokens"`
+	TotalTokens  int64  `json:"total_tokens"`
+	// Provider prompt-cache split of the period's input, folded per row from
+	// raw_data (same source as the summary). Zero when the storage layer does
+	// not populate them.
+	UncachedInputTokens   int64    `json:"uncached_input_tokens,omitempty"`
+	CachedInputTokens     int64    `json:"cached_input_tokens,omitempty"`
+	CacheWriteInputTokens int64    `json:"cache_write_input_tokens,omitempty"`
+	InputCost             *float64 `json:"input_cost"`
+	OutputCost            *float64 `json:"output_cost"`
+	TotalCost             *float64 `json:"total_cost"`
+}
+
+// periodInputSplit holds the provider prompt-cache split for one time period.
+type periodInputSplit struct {
+	Uncached   int64
+	Cached     int64
+	CacheWrite int64
+}
+
+// accumulatePeriodSplit folds one row's input into the split for its period,
+// reusing EntryInputSegments so every backend shares the provider-quirk logic.
+func accumulatePeriodSplit(out map[string]periodInputSplit, period string, inputTokens int, provider string, rawData map[string]any) {
+	uncached, cached, cacheWrite := EntryInputSegments(UsageLogEntry{
+		InputTokens: inputTokens,
+		Provider:    provider,
+		RawData:     rawData,
+	})
+	split := out[period]
+	split.Uncached += uncached
+	split.Cached += cached
+	split.CacheWrite += cacheWrite
+	out[period] = split
+}
+
+// foldPeriodInputSegments folds (period, input_tokens, provider, raw_data) rows
+// into the prompt-cache split per period. Shared by the SQL backends; MongoDB
+// folds its decoded documents with accumulatePeriodSplit directly.
+func foldPeriodInputSegments(rows inputSegmentRows) (map[string]periodInputSplit, error) {
+	out := map[string]periodInputSplit{}
+	for rows.Next() {
+		var period, provider string
+		var inputTokens int
+		var rawDataJSON *string
+		if err := rows.Scan(&period, &inputTokens, &provider, &rawDataJSON); err != nil {
+			return nil, fmt.Errorf("failed to scan daily input segment row: %w", err)
+		}
+		var rawData map[string]any
+		if rawDataJSON != nil && *rawDataJSON != "" {
+			if err := json.Unmarshal([]byte(*rawDataJSON), &rawData); err != nil {
+				slog.Warn("failed to unmarshal raw_data JSON", "error", err)
+			}
+		}
+		accumulatePeriodSplit(out, period, inputTokens, provider, rawData)
+	}
+	return out, rows.Err()
+}
+
+// applyDailyInputSplit merges the per-period split onto matching daily rows.
+func applyDailyInputSplit(daily []DailyUsage, splits map[string]periodInputSplit) {
+	for i := range daily {
+		if split, ok := splits[daily[i].Date]; ok {
+			daily[i].UncachedInputTokens = split.Uncached
+			daily[i].CachedInputTokens = split.Cached
+			daily[i].CacheWriteInputTokens = split.CacheWrite
+		}
+	}
 }
 
 // UsageLogParams specifies query parameters for paginated usage log retrieval.
@@ -267,6 +329,13 @@ type UsageReader interface {
 
 	// GetCacheOverview returns cached-only aggregates for the admin dashboard.
 	GetCacheOverview(ctx context.Context, params UsageQueryParams) (*CacheOverview, error)
+
+	// GetTokenThroughput returns a fixed-width window of token-volume buckets
+	// (input/output/prompt-cached/locally-cached) ending at end, for the
+	// overview live-throughput chart. The window is global (not user-path
+	// scoped). offset is the request timezone's offset from UTC in seconds, so
+	// buckets align to local boundaries (e.g. day buckets at local midnight).
+	GetTokenThroughput(ctx context.Context, gran ThroughputGranularity, end time.Time, offset int64) (*TokenThroughput, error)
 }
 
 func displayUsageProviderName(providerName, provider string) string {

--- a/internal/usage/reader.go
+++ b/internal/usage/reader.go
@@ -164,10 +164,15 @@ func foldPeriodInputSegments(rows inputSegmentRows) (map[string]periodInputSplit
 	out := map[string]periodInputSplit{}
 	for rows.Next() {
 		var period, provider string
+		var cacheType, rawDataJSON *string
 		var inputTokens int
-		var rawDataJSON *string
-		if err := rows.Scan(&period, &inputTokens, &provider, &rawDataJSON); err != nil {
+		if err := rows.Scan(&period, &cacheType, &inputTokens, &provider, &rawDataJSON); err != nil {
 			return nil, fmt.Errorf("failed to scan daily input segment row: %w", err)
+		}
+		// The split describes provider input; local-cache hits aren't provider
+		// requests, so skip them regardless of the query's cache mode.
+		if isLocalCacheType(cacheType) {
+			continue
 		}
 		var rawData map[string]any
 		if rawDataJSON != nil && *rawDataJSON != "" {
@@ -178,6 +183,20 @@ func foldPeriodInputSegments(rows inputSegmentRows) (map[string]periodInputSplit
 		accumulatePeriodSplit(out, period, inputTokens, provider, rawData)
 	}
 	return out, rows.Err()
+}
+
+// isLocalCacheType reports whether a usage row was served from GoModel's local
+// response cache (cache_type set), and so is not provider input.
+func isLocalCacheType(cacheType *string) bool {
+	if cacheType == nil {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(*cacheType)) {
+	case CacheTypeExact, CacheTypeSemantic:
+		return true
+	default:
+		return false
+	}
 }
 
 // applyDailyInputSplit merges the per-period split onto matching daily rows.

--- a/internal/usage/reader_mongodb.go
+++ b/internal/usage/reader_mongodb.go
@@ -758,7 +758,8 @@ func (r *MongoDBReader) GetCacheOverview(ctx context.Context, params UsageQueryP
 // GetTokenThroughput returns the trailing window of token-volume buckets for the
 // overview live-throughput chart. Documents are streamed within the window and
 // bucketed in Go (the prompt-cache split lives in raw_data), mirroring the
-// summary input-segment pass.
+// summary input-segment pass. See foldThroughput in throughput.go for why this
+// streams-and-folds rather than grouping in the database (and TODO(perf) there).
 func (r *MongoDBReader) GetTokenThroughput(ctx context.Context, gran ThroughputGranularity, end time.Time, offset int64) (*TokenThroughput, error) {
 	acc := newThroughputAccumulator(gran, end, offset)
 	bucketSeconds, first, upper := throughputWindow(gran, end, offset)

--- a/internal/usage/reader_mongodb.go
+++ b/internal/usage/reader_mongodb.go
@@ -595,6 +595,7 @@ func (r *MongoDBReader) GetDailyUsage(ctx context.Context, params UsageQueryPara
 			{Key: "date", Value: "$timestamp"},
 			{Key: "timezone", Value: usageTimeZone(params)},
 		}}}},
+		{Key: "cache_type", Value: 1},
 		{Key: "input_tokens", Value: 1},
 		{Key: "provider", Value: 1},
 		{Key: "raw_data", Value: 1},
@@ -608,12 +609,17 @@ func (r *MongoDBReader) GetDailyUsage(ctx context.Context, params UsageQueryPara
 	for splitCursor.Next(ctx) {
 		var row struct {
 			Period      string         `bson:"period"`
+			CacheType   string         `bson:"cache_type"`
 			InputTokens int            `bson:"input_tokens"`
 			Provider    string         `bson:"provider"`
 			RawData     map[string]any `bson:"raw_data"`
 		}
 		if err := splitCursor.Decode(&row); err != nil {
 			return nil, fmt.Errorf("failed to decode daily input segment row: %w", err)
+		}
+		// Skip local-cache hits: they are not provider input.
+		if isLocalCacheType(&row.CacheType) {
+			continue
 		}
 		accumulatePeriodSplit(splits, row.Period, row.InputTokens, row.Provider, row.RawData)
 	}

--- a/internal/usage/reader_mongodb.go
+++ b/internal/usage/reader_mongodb.go
@@ -581,6 +581,47 @@ func (r *MongoDBReader) GetDailyUsage(ctx context.Context, params UsageQueryPara
 		return nil, fmt.Errorf("error iterating daily usage cursor: %w", err)
 	}
 
+	// Second pass: project the same period key onto each document and fold the
+	// prompt-cache split from raw_data in Go (the split is provider-specific and
+	// cannot be computed in the aggregation). Using the same $dateToString keeps
+	// the period keys aligned with the grouped result above.
+	splitPipeline := bson.A{}
+	if len(matchFilters) > 0 {
+		splitPipeline = append(splitPipeline, bson.D{{Key: "$match", Value: matchFilters}})
+	}
+	splitPipeline = append(splitPipeline, bson.D{{Key: "$project", Value: bson.D{
+		{Key: "period", Value: bson.D{{Key: "$dateToString", Value: bson.D{
+			{Key: "format", Value: dateFormat},
+			{Key: "date", Value: "$timestamp"},
+			{Key: "timezone", Value: usageTimeZone(params)},
+		}}}},
+		{Key: "input_tokens", Value: 1},
+		{Key: "provider", Value: 1},
+		{Key: "raw_data", Value: 1},
+	}}})
+	splitCursor, err := r.collection.Aggregate(ctx, splitPipeline)
+	if err != nil {
+		return nil, fmt.Errorf("failed to aggregate daily input segments: %w", err)
+	}
+	defer splitCursor.Close(ctx)
+	splits := map[string]periodInputSplit{}
+	for splitCursor.Next(ctx) {
+		var row struct {
+			Period      string         `bson:"period"`
+			InputTokens int            `bson:"input_tokens"`
+			Provider    string         `bson:"provider"`
+			RawData     map[string]any `bson:"raw_data"`
+		}
+		if err := splitCursor.Decode(&row); err != nil {
+			return nil, fmt.Errorf("failed to decode daily input segment row: %w", err)
+		}
+		accumulatePeriodSplit(splits, row.Period, row.InputTokens, row.Provider, row.RawData)
+	}
+	if err := splitCursor.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating daily input segment cursor: %w", err)
+	}
+	applyDailyInputSplit(result, splits)
+
 	return result, nil
 }
 
@@ -706,6 +747,56 @@ func (r *MongoDBReader) GetCacheOverview(ctx context.Context, params UsageQueryP
 	}
 
 	return overview, nil
+}
+
+// GetTokenThroughput returns the trailing window of token-volume buckets for the
+// overview live-throughput chart. Documents are streamed within the window and
+// bucketed in Go (the prompt-cache split lives in raw_data), mirroring the
+// summary input-segment pass.
+func (r *MongoDBReader) GetTokenThroughput(ctx context.Context, gran ThroughputGranularity, end time.Time, offset int64) (*TokenThroughput, error) {
+	acc := newThroughputAccumulator(gran, end, offset)
+	bucketSeconds, first, upper := throughputWindow(gran, end, offset)
+
+	match := bson.D{{Key: "timestamp", Value: bson.D{
+		{Key: "$gte", Value: time.Unix(first, 0).UTC()},
+		{Key: "$lt", Value: time.Unix(upper, 0).UTC()},
+	}}}
+	projection := bson.D{
+		{Key: "timestamp", Value: 1},
+		{Key: "cache_type", Value: 1},
+		{Key: "input_tokens", Value: 1},
+		{Key: "output_tokens", Value: 1},
+		{Key: "total_tokens", Value: 1},
+		{Key: "provider", Value: 1},
+		{Key: "raw_data", Value: 1},
+	}
+
+	cursor, err := r.collection.Find(ctx, match, options.Find().SetProjection(projection))
+	if err != nil {
+		return nil, fmt.Errorf("failed to query token throughput: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	for cursor.Next(ctx) {
+		var row struct {
+			Timestamp    time.Time      `bson:"timestamp"`
+			CacheType    string         `bson:"cache_type"`
+			InputTokens  int            `bson:"input_tokens"`
+			OutputTokens int            `bson:"output_tokens"`
+			TotalTokens  int            `bson:"total_tokens"`
+			Provider     string         `bson:"provider"`
+			RawData      map[string]any `bson:"raw_data"`
+		}
+		if err := cursor.Decode(&row); err != nil {
+			return nil, fmt.Errorf("failed to decode token throughput row: %w", err)
+		}
+		bucketStart := throughputBucketStart(row.Timestamp.Unix(), bucketSeconds, offset)
+		acc.add(bucketStart, row.CacheType, row.Provider, row.InputTokens, row.OutputTokens, row.TotalTokens, row.RawData)
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating token throughput cursor: %w", err)
+	}
+	return acc.result(gran), nil
 }
 
 func mongoUsageMatchFilters(params UsageQueryParams) (bson.D, error) {

--- a/internal/usage/reader_postgresql.go
+++ b/internal/usage/reader_postgresql.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/goccy/go-json"
 
@@ -347,6 +348,21 @@ func (r *PostgreSQLReader) GetDailyUsage(ctx context.Context, params UsageQueryP
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("error iterating daily usage rows: %w", err)
 	}
+	rows.Close()
+
+	// Second pass: fold the per-period prompt-cache split from raw_data, reusing
+	// the same group expression so the period keys line up.
+	splitQuery := fmt.Sprintf(`SELECT %s AS period, input_tokens, provider, raw_data FROM "usage"%s`, groupExpr, where)
+	splitRows, err := r.pool.Query(ctx, splitQuery, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query daily input segments: %w", err)
+	}
+	defer splitRows.Close()
+	splits, err := foldPeriodInputSegments(splitRows)
+	if err != nil {
+		return nil, err
+	}
+	applyDailyInputSplit(result, splits)
 
 	return result, nil
 }
@@ -418,6 +434,33 @@ func (r *PostgreSQLReader) GetCacheOverview(ctx context.Context, params UsageQue
 	}
 
 	return overview, nil
+}
+
+// GetTokenThroughput returns the trailing window of token-volume buckets for the
+// overview live-throughput chart. Buckets are epoch-aligned; the prompt-cache
+// split is folded in Go (it lives in raw_data), mirroring the summary path.
+func (r *PostgreSQLReader) GetTokenThroughput(ctx context.Context, gran ThroughputGranularity, end time.Time, offset int64) (*TokenThroughput, error) {
+	acc := newThroughputAccumulator(gran, end, offset)
+	bucketSeconds, first, upper := throughputWindow(gran, end, offset)
+
+	conditions := []string{"timestamp >= $1", "timestamp < $2"}
+	args := []any{time.Unix(first, 0).UTC(), time.Unix(upper, 0).UTC()}
+	where := sqlutil.BuildWhereClause(conditions)
+
+	bucketExpr := fmt.Sprintf("(FLOOR((EXTRACT(EPOCH FROM timestamp) + %d) / %d) * %d - %d)::bigint", offset, bucketSeconds, bucketSeconds, offset)
+	query := fmt.Sprintf(`SELECT %s AS bucket, cache_type, input_tokens, output_tokens, total_tokens, provider, raw_data
+		FROM "usage"%s`, bucketExpr, where)
+
+	rows, err := r.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query token throughput: %w", err)
+	}
+	defer rows.Close()
+
+	if err := foldThroughput(rows, acc); err != nil {
+		return nil, err
+	}
+	return acc.result(gran), nil
 }
 
 func pgQuoteLiteral(value string) string {

--- a/internal/usage/reader_postgresql.go
+++ b/internal/usage/reader_postgresql.go
@@ -352,7 +352,7 @@ func (r *PostgreSQLReader) GetDailyUsage(ctx context.Context, params UsageQueryP
 
 	// Second pass: fold the per-period prompt-cache split from raw_data, reusing
 	// the same group expression so the period keys line up.
-	splitQuery := fmt.Sprintf(`SELECT %s AS period, input_tokens, provider, raw_data FROM "usage"%s`, groupExpr, where)
+	splitQuery := fmt.Sprintf(`SELECT %s AS period, cache_type, input_tokens, provider, raw_data FROM "usage"%s`, groupExpr, where)
 	splitRows, err := r.pool.Query(ctx, splitQuery, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query daily input segments: %w", err)

--- a/internal/usage/reader_sqlite.go
+++ b/internal/usage/reader_sqlite.go
@@ -377,6 +377,21 @@ func (r *SQLiteReader) GetDailyUsage(ctx context.Context, params UsageQueryParam
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("error iterating daily usage rows: %w", err)
 	}
+	rows.Close()
+
+	// Second pass: fold the per-period prompt-cache split from raw_data (the
+	// GROUP BY above cannot also return per-row raw_data), reusing the same
+	// group expression so the period keys line up.
+	splitRows, err := r.db.QueryContext(ctx, `SELECT `+groupExpr+` AS period, input_tokens, provider, raw_data FROM usage`+where, queryArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query daily input segments: %w", err)
+	}
+	defer splitRows.Close()
+	splits, err := foldPeriodInputSegments(splitRows)
+	if err != nil {
+		return nil, err
+	}
+	applyDailyInputSplit(result, splits)
 
 	return result, nil
 }
@@ -452,6 +467,34 @@ func (r *SQLiteReader) GetCacheOverview(ctx context.Context, params UsageQueryPa
 	}
 
 	return overview, nil
+}
+
+// GetTokenThroughput returns the trailing window of token-volume buckets for the
+// overview live-throughput chart. Buckets are epoch-aligned; the prompt-cache
+// split is folded in Go (it lives in raw_data), mirroring the summary path.
+func (r *SQLiteReader) GetTokenThroughput(ctx context.Context, gran ThroughputGranularity, end time.Time, offset int64) (*TokenThroughput, error) {
+	acc := newThroughputAccumulator(gran, end, offset)
+	bucketSeconds, first, upper := throughputWindow(gran, end, offset)
+
+	epoch := sqliteTimestampEpochExpr()
+	conditions := []string{epoch + " >= ?", epoch + " < ?"}
+	args := []any{first, upper}
+	where := sqlutil.BuildWhereClause(conditions)
+
+	bucketExpr := fmt.Sprintf("((%s + %d) / %d) * %d - %d", epoch, offset, bucketSeconds, bucketSeconds, offset)
+	query := `SELECT ` + bucketExpr + ` AS bucket, cache_type, input_tokens, output_tokens, total_tokens, provider, raw_data
+		FROM usage` + where
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query token throughput: %w", err)
+	}
+	defer rows.Close()
+
+	if err := foldThroughput(rows, acc); err != nil {
+		return nil, err
+	}
+	return acc.result(gran), nil
 }
 
 func sqliteOffsetModifier(offsetMinutes int) string {

--- a/internal/usage/reader_sqlite.go
+++ b/internal/usage/reader_sqlite.go
@@ -382,7 +382,7 @@ func (r *SQLiteReader) GetDailyUsage(ctx context.Context, params UsageQueryParam
 	// Second pass: fold the per-period prompt-cache split from raw_data (the
 	// GROUP BY above cannot also return per-row raw_data), reusing the same
 	// group expression so the period keys line up.
-	splitRows, err := r.db.QueryContext(ctx, `SELECT `+groupExpr+` AS period, input_tokens, provider, raw_data FROM usage`+where, queryArgs...)
+	splitRows, err := r.db.QueryContext(ctx, `SELECT `+groupExpr+` AS period, cache_type, input_tokens, provider, raw_data FROM usage`+where, queryArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query daily input segments: %w", err)
 	}

--- a/internal/usage/reader_sqlite_daily_split_test.go
+++ b/internal/usage/reader_sqlite_daily_split_test.go
@@ -88,3 +88,59 @@ func TestSQLiteReaderGetDailyUsage_FoldsPromptCacheSplitPerPeriod(t *testing.T) 
 		t.Errorf("day2 split = {uncached:%d cached:%d}, want {50 150}", d2.UncachedInputTokens, d2.CachedInputTokens)
 	}
 }
+
+// Under a non-default cache mode (all), local-cache rows are included in the
+// period totals but must NOT pollute the provider prompt-cache split.
+func TestSQLiteReaderGetDailyUsage_SplitExcludesLocalCacheUnderAllMode(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open sqlite database: %v", err)
+	}
+	defer db.Close()
+
+	store, err := NewSQLiteStore(db, 0)
+	if err != nil {
+		t.Fatalf("failed to create sqlite store: %v", err)
+	}
+
+	ctx := context.Background()
+	day := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+	if err := store.WriteBatch(ctx, []*UsageEntry{
+		{
+			ID: "p1", RequestID: "r1", Timestamp: day, Model: "gpt-5", Provider: "openai",
+			Endpoint: "/v1/chat/completions", InputTokens: 100, OutputTokens: 40, TotalTokens: 140,
+			RawData: map[string]any{"cached_tokens": 30}, // uncached 70 + cached 30
+		},
+		{
+			ID: "c1", RequestID: "r2", Timestamp: day, Model: "gpt-5", Provider: "openai",
+			Endpoint: "/v1/chat/completions", CacheType: CacheTypeExact, InputTokens: 12, OutputTokens: 8, TotalTokens: 20,
+		},
+	}); err != nil {
+		t.Fatalf("failed to seed usage entries: %v", err)
+	}
+
+	reader, err := NewSQLiteReader(db)
+	if err != nil {
+		t.Fatalf("failed to create sqlite reader: %v", err)
+	}
+	daily, err := reader.GetDailyUsage(ctx, UsageQueryParams{
+		StartDate: time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC),
+		EndDate:   time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC),
+		Interval:  "daily",
+		CacheMode: CacheModeAll,
+	})
+	if err != nil {
+		t.Fatalf("GetDailyUsage returned error: %v", err)
+	}
+	if len(daily) != 1 {
+		t.Fatalf("got %d periods, want 1", len(daily))
+	}
+	d := daily[0]
+	if d.InputTokens != 112 {
+		t.Errorf("InputTokens = %d, want 112 (provider + local row counted under all mode)", d.InputTokens)
+	}
+	if d.UncachedInputTokens != 70 || d.CachedInputTokens != 30 || d.CacheWriteInputTokens != 0 {
+		t.Errorf("split = {uncached:%d cached:%d write:%d}, want {70 30 0} (local-cache row excluded from split)",
+			d.UncachedInputTokens, d.CachedInputTokens, d.CacheWriteInputTokens)
+	}
+}

--- a/internal/usage/reader_sqlite_daily_split_test.go
+++ b/internal/usage/reader_sqlite_daily_split_test.go
@@ -1,0 +1,90 @@
+package usage
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+)
+
+// Verifies GetDailyUsage folds the per-period provider prompt-cache split from
+// raw_data and aligns it with the grouped daily rows. Local-cache rows
+// (cache_type set) are excluded by the default uncached cache mode, so they must
+// not affect the split.
+func TestSQLiteReaderGetDailyUsage_FoldsPromptCacheSplitPerPeriod(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open sqlite database: %v", err)
+	}
+	defer db.Close()
+
+	store, err := NewSQLiteStore(db, 0)
+	if err != nil {
+		t.Fatalf("failed to create sqlite store: %v", err)
+	}
+
+	ctx := context.Background()
+	day1 := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+	day2 := time.Date(2026, 1, 16, 10, 0, 0, 0, time.UTC)
+
+	err = store.WriteBatch(ctx, []*UsageEntry{
+		{
+			ID: "d1-a", RequestID: "r1", Timestamp: day1, Model: "gpt-5", Provider: "openai",
+			Endpoint: "/v1/chat/completions", InputTokens: 100, OutputTokens: 40, TotalTokens: 140,
+			RawData: map[string]any{"cached_tokens": 30}, // uncached 70, cached 30
+		},
+		{
+			ID: "d1-b", RequestID: "r2", Timestamp: day1, Model: "gpt-5", Provider: "openai",
+			Endpoint: "/v1/chat/completions", InputTokens: 50, OutputTokens: 10, TotalTokens: 60,
+			// no cache fields => fully uncached
+		},
+		{
+			ID: "d1-cache", RequestID: "r3", Timestamp: day1, Model: "gpt-5", Provider: "openai",
+			Endpoint: "/v1/chat/completions", CacheType: CacheTypeExact, InputTokens: 999, OutputTokens: 999, TotalTokens: 1998,
+		},
+		{
+			ID: "d2-a", RequestID: "r4", Timestamp: day2, Model: "gpt-5", Provider: "openai",
+			Endpoint: "/v1/chat/completions", InputTokens: 200, OutputTokens: 20, TotalTokens: 220,
+			RawData: map[string]any{"cached_tokens": 150},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to seed usage entries: %v", err)
+	}
+
+	reader, err := NewSQLiteReader(db)
+	if err != nil {
+		t.Fatalf("failed to create sqlite reader: %v", err)
+	}
+
+	daily, err := reader.GetDailyUsage(ctx, UsageQueryParams{
+		StartDate: time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC),
+		EndDate:   time.Date(2026, 1, 16, 0, 0, 0, 0, time.UTC),
+		Interval:  "daily",
+	})
+	if err != nil {
+		t.Fatalf("GetDailyUsage returned error: %v", err)
+	}
+
+	by := map[string]DailyUsage{}
+	for _, d := range daily {
+		by[d.Date] = d
+	}
+
+	d1 := by["2026-01-15"]
+	// Provider rows only: input column sum = 150; split = uncached 120 (70+50) + cached 30.
+	if d1.InputTokens != 150 {
+		t.Errorf("day1 InputTokens = %d, want 150 (local-cache row excluded)", d1.InputTokens)
+	}
+	if d1.UncachedInputTokens != 120 {
+		t.Errorf("day1 UncachedInputTokens = %d, want 120", d1.UncachedInputTokens)
+	}
+	if d1.CachedInputTokens != 30 {
+		t.Errorf("day1 CachedInputTokens = %d, want 30", d1.CachedInputTokens)
+	}
+
+	d2 := by["2026-01-16"]
+	if d2.CachedInputTokens != 150 || d2.UncachedInputTokens != 50 {
+		t.Errorf("day2 split = {uncached:%d cached:%d}, want {50 150}", d2.UncachedInputTokens, d2.CachedInputTokens)
+	}
+}

--- a/internal/usage/throughput.go
+++ b/internal/usage/throughput.go
@@ -1,0 +1,174 @@
+package usage
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/goccy/go-json"
+)
+
+// ThroughputGranularity describes one bucket width for the overview live
+// token-throughput chart. WindowCount is how many trailing buckets the chart
+// shows, so the window spans BucketSize * WindowCount.
+type ThroughputGranularity struct {
+	Name        string
+	BucketSize  time.Duration
+	WindowCount int
+}
+
+// throughputGranularities maps the public granularity name to its config. The
+// window counts mirror the overview chart's rolling windows.
+var throughputGranularities = map[string]ThroughputGranularity{
+	"second": {Name: "second", BucketSize: time.Second, WindowCount: 60},
+	"minute": {Name: "minute", BucketSize: time.Minute, WindowCount: 60},
+	"hour":   {Name: "hour", BucketSize: time.Hour, WindowCount: 24},
+	"day":    {Name: "day", BucketSize: 24 * time.Hour, WindowCount: 30},
+}
+
+// ParseThroughputGranularity resolves a public granularity name (second,
+// minute, hour, day) to its bucket configuration.
+func ParseThroughputGranularity(name string) (ThroughputGranularity, error) {
+	gran, ok := throughputGranularities[strings.ToLower(strings.TrimSpace(name))]
+	if !ok {
+		return ThroughputGranularity{}, fmt.Errorf("invalid granularity %q, expected one of second, minute, hour, day", name)
+	}
+	return gran, nil
+}
+
+// ThroughputBucket is one time bucket of token volume, split into the four
+// series the overview live chart stacks. Start is the bucket's inclusive start
+// (UTC); the bucket spans the parent TokenThroughput's BucketSeconds.
+type ThroughputBucket struct {
+	Start               time.Time `json:"start"`
+	InputTokens         int64     `json:"input_tokens"`
+	OutputTokens        int64     `json:"output_tokens"`
+	PromptCachedTokens  int64     `json:"prompt_cached_tokens"`
+	LocallyCachedTokens int64     `json:"locally_cached_tokens"`
+}
+
+// TokenThroughput is a fixed-width window of token-volume buckets ending at the
+// current time, powering the overview live-throughput chart.
+type TokenThroughput struct {
+	Granularity   string             `json:"granularity"`
+	BucketSeconds int                `json:"bucket_seconds"`
+	Buckets       []ThroughputBucket `json:"buckets"`
+}
+
+// throughputWindow returns the bucket width in seconds and the inclusive first
+// and exclusive upper bucket-start unix seconds for the window ending at end.
+// offset is the timezone's offset from UTC (seconds east of UTC) so buckets
+// align to local boundaries — notably the "day" buckets start at local midnight,
+// matching the Daily Token Usage chart instead of UTC midnight.
+func throughputWindow(gran ThroughputGranularity, end time.Time, offset int64) (bucketSeconds, first, upper int64) {
+	bucketSeconds = int64(gran.BucketSize / time.Second)
+	if bucketSeconds <= 0 {
+		bucketSeconds = 1
+	}
+	current := ((end.Unix()+offset)/bucketSeconds)*bucketSeconds - offset
+	first = current - int64(gran.WindowCount-1)*bucketSeconds
+	upper = current + bucketSeconds
+	return bucketSeconds, first, upper
+}
+
+// throughputBucketStart aligns a unix timestamp to its local bucket start, using
+// the same offset math as throughputWindow. SQLite/PostgreSQL compute this in SQL
+// (so they can filter and group on an index); MongoDB and tests use this helper.
+func throughputBucketStart(ts, bucketSeconds, offset int64) int64 {
+	return ((ts+offset)/bucketSeconds)*bucketSeconds - offset
+}
+
+// throughputAccumulator folds streamed usage rows into a fixed, zero-filled set
+// of buckets so the chart can render the window directly.
+type throughputAccumulator struct {
+	bucketSeconds int64
+	first         int64
+	buckets       []ThroughputBucket
+}
+
+func newThroughputAccumulator(gran ThroughputGranularity, end time.Time, offset int64) *throughputAccumulator {
+	bucketSeconds, first, _ := throughputWindow(gran, end, offset)
+	buckets := make([]ThroughputBucket, gran.WindowCount)
+	for i := range buckets {
+		buckets[i].Start = time.Unix(first+int64(i)*bucketSeconds, 0).UTC()
+	}
+	return &throughputAccumulator{bucketSeconds: bucketSeconds, first: first, buckets: buckets}
+}
+
+// add folds one usage row into its bucket. A row with cacheType set
+// (exact/semantic) was served from the local response cache, so all its tokens
+// count as locally cached; otherwise it is a provider request whose input
+// splits into uncached (+ cache writes) and prompt-cache reads — the same split
+// the overview Cache Meter uses, via EntryInputSegments.
+func (a *throughputAccumulator) add(bucketStartUnix int64, cacheType, provider string, inputTokens, outputTokens, totalTokens int, rawData map[string]any) {
+	if a.bucketSeconds <= 0 {
+		return
+	}
+	idx := int((bucketStartUnix - a.first) / a.bucketSeconds)
+	if idx < 0 || idx >= len(a.buckets) {
+		return
+	}
+	bucket := &a.buckets[idx]
+	switch strings.ToLower(strings.TrimSpace(cacheType)) {
+	case CacheTypeExact, CacheTypeSemantic:
+		total := int64(totalTokens)
+		if total == 0 {
+			total = int64(inputTokens) + int64(outputTokens)
+		}
+		bucket.LocallyCachedTokens += total
+	default:
+		uncached, cached, cacheWrite := EntryInputSegments(UsageLogEntry{
+			InputTokens: inputTokens,
+			Provider:    provider,
+			RawData:     rawData,
+		})
+		bucket.InputTokens += uncached + cacheWrite
+		bucket.PromptCachedTokens += cached
+		bucket.OutputTokens += int64(outputTokens)
+	}
+}
+
+func (a *throughputAccumulator) result(gran ThroughputGranularity) *TokenThroughput {
+	return &TokenThroughput{
+		Granularity:   gran.Name,
+		BucketSeconds: int(a.bucketSeconds),
+		Buckets:       a.buckets,
+	}
+}
+
+// EmptyTokenThroughput returns a zero-filled window, used when usage tracking is
+// disabled so the dashboard still renders an (empty) chart.
+func EmptyTokenThroughput(gran ThroughputGranularity, end time.Time, offset int64) *TokenThroughput {
+	return newThroughputAccumulator(gran, end, offset).result(gran)
+}
+
+// foldThroughput scans bucketed usage rows and folds each into the accumulator,
+// so the SQLite and PostgreSQL readers share one row-handling path (only the
+// query/driver differs). MongoDB folds its decoded documents directly. Row
+// columns, in order: bucket-start unix seconds, cache_type, input_tokens,
+// output_tokens, total_tokens, provider, raw_data. The cursor is the same
+// minimal interface used for the summary fold (inputSegmentRows).
+func foldThroughput(rows inputSegmentRows, acc *throughputAccumulator) error {
+	for rows.Next() {
+		var bucketStart int64
+		var cacheType, rawDataJSON *string
+		var inputTokens, outputTokens, totalTokens int
+		var provider string
+		if err := rows.Scan(&bucketStart, &cacheType, &inputTokens, &outputTokens, &totalTokens, &provider, &rawDataJSON); err != nil {
+			return fmt.Errorf("failed to scan throughput row: %w", err)
+		}
+		var rawData map[string]any
+		if rawDataJSON != nil && *rawDataJSON != "" {
+			if err := json.Unmarshal([]byte(*rawDataJSON), &rawData); err != nil {
+				slog.Warn("failed to unmarshal raw_data JSON", "error", err)
+			}
+		}
+		cacheTypeValue := ""
+		if cacheType != nil {
+			cacheTypeValue = *cacheType
+		}
+		acc.add(bucketStart, cacheTypeValue, provider, inputTokens, outputTokens, totalTokens, rawData)
+	}
+	return rows.Err()
+}

--- a/internal/usage/throughput.go
+++ b/internal/usage/throughput.go
@@ -61,6 +61,12 @@ type TokenThroughput struct {
 // offset is the timezone's offset from UTC (seconds east of UTC) so buckets
 // align to local boundaries — notably the "day" buckets start at local midnight,
 // matching the Daily Token Usage chart instead of UTC midnight.
+//
+// TODO(tz): offset is the dashboard timezone's offset at `end` only (a single
+// fixed value), so day/hour buckets that straddle a DST transition within the
+// window can be an hour off. Acceptable for a live preview; the proper fix is to
+// thread the *time.Location through GetTokenThroughput and bucket per the
+// store's own zone (the perf TODO on foldThroughput would enable this for free).
 func throughputWindow(gran ThroughputGranularity, end time.Time, offset int64) (bucketSeconds, first, upper int64) {
 	bucketSeconds = int64(gran.BucketSize / time.Second)
 	if bucketSeconds <= 0 {
@@ -149,6 +155,22 @@ func EmptyTokenThroughput(gran ThroughputGranularity, end time.Time, offset int6
 // columns, in order: bucket-start unix seconds, cache_type, input_tokens,
 // output_tokens, total_tokens, provider, raw_data. The cursor is the same
 // minimal interface used for the summary fold (inputSegmentRows).
+//
+// Why stream-and-fold instead of GROUP BY: the Input/Prompt-cached series come
+// from the provider prompt-cache split, derived per row from raw_data via
+// EntryInputSegments — the single source of truth for the provider-specific
+// quirks (field coalescing, Anthropic additive accounting). That split is
+// per-row non-linear (max/min/branch), so it can't be reconstructed from
+// per-bucket sums, and we deliberately don't reimplement it in SQL across three
+// backends. The query is bounded to the window by the timestamp index, matching
+// the GetSummary / GetDailyUsage fold passes.
+//
+// TODO(perf): the overview polls this endpoint, so the coarse (hour/day) windows
+// re-scan many rows per refresh. The scalable fix is to persist the
+// uncached/cached/cache-write split as columns at write time (computed once via
+// EntryInputSegments); summary, daily and throughput could then GROUP BY in SQL
+// instead of streaming, and day/hour buckets could use the store's own timezone
+// (see throughputWindow's TODO(tz)).
 func foldThroughput(rows inputSegmentRows, acc *throughputAccumulator) error {
 	for rows.Next() {
 		var bucketStart int64

--- a/internal/usage/throughput_test.go
+++ b/internal/usage/throughput_test.go
@@ -1,0 +1,200 @@
+package usage
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+)
+
+func TestParseThroughputGranularity(t *testing.T) {
+	cases := map[string]struct {
+		wantWindow int
+		wantBucket time.Duration
+		wantErr    bool
+	}{
+		"second":  {wantWindow: 60, wantBucket: time.Second},
+		"minute":  {wantWindow: 60, wantBucket: time.Minute},
+		"hour":    {wantWindow: 24, wantBucket: time.Hour},
+		"day":     {wantWindow: 30, wantBucket: 24 * time.Hour},
+		"MINUTE ": {wantWindow: 60, wantBucket: time.Minute},
+		"weekly":  {wantErr: true},
+		"":        {wantErr: true},
+	}
+	for name, tc := range cases {
+		gran, err := ParseThroughputGranularity(name)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("ParseThroughputGranularity(%q) expected error, got none", name)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseThroughputGranularity(%q) unexpected error: %v", name, err)
+			continue
+		}
+		if gran.WindowCount != tc.wantWindow || gran.BucketSize != tc.wantBucket {
+			t.Errorf("ParseThroughputGranularity(%q) = {window:%d bucket:%v}, want {window:%d bucket:%v}",
+				name, gran.WindowCount, gran.BucketSize, tc.wantWindow, tc.wantBucket)
+		}
+	}
+}
+
+func TestEmptyTokenThroughputIsZeroFilledAndAligned(t *testing.T) {
+	gran, _ := ParseThroughputGranularity("minute")
+	end := time.Date(2026, 1, 15, 12, 0, 30, 0, time.UTC)
+	tp := EmptyTokenThroughput(gran, end, 0)
+
+	if tp.BucketSeconds != 60 || tp.Granularity != "minute" {
+		t.Fatalf("got granularity=%q bucketSeconds=%d", tp.Granularity, tp.BucketSeconds)
+	}
+	if len(tp.Buckets) != 60 {
+		t.Fatalf("got %d buckets, want 60", len(tp.Buckets))
+	}
+	// Last bucket starts at the current minute; first is 59 minutes earlier.
+	wantLast := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	if !tp.Buckets[59].Start.Equal(wantLast) {
+		t.Errorf("last bucket start = %v, want %v", tp.Buckets[59].Start, wantLast)
+	}
+	if !tp.Buckets[0].Start.Equal(wantLast.Add(-59 * time.Minute)) {
+		t.Errorf("first bucket start = %v, want %v", tp.Buckets[0].Start, wantLast.Add(-59*time.Minute))
+	}
+	for i, b := range tp.Buckets {
+		if b.InputTokens != 0 || b.OutputTokens != 0 || b.PromptCachedTokens != 0 || b.LocallyCachedTokens != 0 {
+			t.Errorf("bucket %d not zero-filled: %+v", i, b)
+		}
+	}
+}
+
+func TestSQLiteReaderGetTokenThroughput_SplitsAndBuckets(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open sqlite database: %v", err)
+	}
+	defer db.Close()
+
+	store, err := NewSQLiteStore(db, 0)
+	if err != nil {
+		t.Fatalf("failed to create sqlite store: %v", err)
+	}
+
+	ctx := context.Background()
+	end := time.Date(2026, 1, 15, 12, 0, 30, 0, time.UTC)
+	inWindow := time.Date(2026, 1, 15, 12, 0, 10, 0, time.UTC)  // current minute bucket
+	outOfWindow := time.Date(2026, 1, 15, 9, 0, 0, 0, time.UTC) // hours earlier, excluded
+
+	err = store.WriteBatch(ctx, []*UsageEntry{
+		{
+			ID: "provider-row", RequestID: "r1", Timestamp: inWindow,
+			Model: "gpt-5", Provider: "openai", Endpoint: "/v1/chat/completions",
+			InputTokens: 100, OutputTokens: 40, TotalTokens: 140,
+			RawData: map[string]any{"cached_tokens": 30}, // 70 uncached + 30 prompt-cached
+		},
+		{
+			ID: "local-cache-row", RequestID: "r2", Timestamp: inWindow,
+			Model: "gpt-5", Provider: "openai", Endpoint: "/v1/chat/completions",
+			CacheType: CacheTypeExact, InputTokens: 12, OutputTokens: 8, TotalTokens: 20,
+		},
+		{
+			ID: "old-row", RequestID: "r3", Timestamp: outOfWindow,
+			Model: "gpt-5", Provider: "openai", Endpoint: "/v1/chat/completions",
+			InputTokens: 999, OutputTokens: 999, TotalTokens: 1998,
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to seed usage entries: %v", err)
+	}
+
+	reader, err := NewSQLiteReader(db)
+	if err != nil {
+		t.Fatalf("failed to create sqlite reader: %v", err)
+	}
+
+	gran, _ := ParseThroughputGranularity("minute")
+	tp, err := reader.GetTokenThroughput(ctx, gran, end, 0)
+	if err != nil {
+		t.Fatalf("GetTokenThroughput returned error: %v", err)
+	}
+	if len(tp.Buckets) != 60 {
+		t.Fatalf("got %d buckets, want 60", len(tp.Buckets))
+	}
+
+	last := tp.Buckets[59]
+	if last.InputTokens != 70 {
+		t.Errorf("InputTokens = %d, want 70 (uncached portion of provider input)", last.InputTokens)
+	}
+	if last.PromptCachedTokens != 30 {
+		t.Errorf("PromptCachedTokens = %d, want 30", last.PromptCachedTokens)
+	}
+	if last.OutputTokens != 40 {
+		t.Errorf("OutputTokens = %d, want 40", last.OutputTokens)
+	}
+	if last.LocallyCachedTokens != 20 {
+		t.Errorf("LocallyCachedTokens = %d, want 20 (total tokens of the exact-cache hit)", last.LocallyCachedTokens)
+	}
+
+	// Every earlier bucket must be empty — the out-of-window row is excluded.
+	for i := 0; i < 59; i++ {
+		b := tp.Buckets[i]
+		if b.InputTokens+b.OutputTokens+b.PromptCachedTokens+b.LocallyCachedTokens != 0 {
+			t.Errorf("bucket %d should be empty, got %+v", i, b)
+		}
+	}
+}
+
+// Day buckets must start at local midnight (per the timezone offset), so a
+// request late on the local day lands in "today" even if it's already the next
+// UTC day — matching the Daily Token Usage chart.
+func TestSQLiteReaderGetTokenThroughput_DayBucketsUseTimezoneOffset(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open sqlite database: %v", err)
+	}
+	defer db.Close()
+
+	store, err := NewSQLiteStore(db, 0)
+	if err != nil {
+		t.Fatalf("failed to create sqlite store: %v", err)
+	}
+
+	ctx := context.Background()
+	offset := int64(2 * 3600)                            // UTC+2
+	end := time.Date(2026, 1, 15, 0, 30, 0, 0, time.UTC) // 02:30 local on Jan 15
+	// 23:00 UTC Jan 14 == 01:00 local Jan 15, i.e. local "today".
+	rowTime := time.Date(2026, 1, 14, 23, 0, 0, 0, time.UTC)
+
+	if err := store.WriteBatch(ctx, []*UsageEntry{{
+		ID: "tz1", RequestID: "r1", Timestamp: rowTime, Model: "gpt-5", Provider: "openai",
+		Endpoint: "/v1/chat/completions", InputTokens: 10, OutputTokens: 5, TotalTokens: 15,
+	}}); err != nil {
+		t.Fatalf("failed to seed usage entry: %v", err)
+	}
+
+	reader, err := NewSQLiteReader(db)
+	if err != nil {
+		t.Fatalf("failed to create sqlite reader: %v", err)
+	}
+	gran, _ := ParseThroughputGranularity("day")
+
+	tp, err := reader.GetTokenThroughput(ctx, gran, end, offset)
+	if err != nil {
+		t.Fatalf("GetTokenThroughput returned error: %v", err)
+	}
+	today := tp.Buckets[len(tp.Buckets)-1]
+	wantStart := time.Date(2026, 1, 14, 22, 0, 0, 0, time.UTC) // local midnight Jan 15
+	if !today.Start.Equal(wantStart) {
+		t.Errorf("today bucket start = %v, want local midnight %v", today.Start, wantStart)
+	}
+	if today.InputTokens != 10 {
+		t.Errorf("today (local) bucket input = %d, want 10", today.InputTokens)
+	}
+
+	// With UTC alignment (offset 0) the same row falls in *yesterday*, so today is empty.
+	utc, err := reader.GetTokenThroughput(ctx, gran, end, 0)
+	if err != nil {
+		t.Fatalf("GetTokenThroughput (UTC) returned error: %v", err)
+	}
+	if utc.Buckets[len(utc.Buckets)-1].InputTokens != 0 {
+		t.Errorf("UTC-aligned today bucket should be empty (row is yesterday in UTC)")
+	}
+}


### PR DESCRIPTION
## Summary

Overview-dashboard improvements centred on token-usage visibility:

- **Live Token Throughput** (new) — a stacked bar chart at the top of the overview, bucketed by Seconds / Minutes / Hours / Days, fed by the live usage SSE stream plus a new aggregation endpoint. Bars stack Input / Output / Prompt-cached / Locally-cached tokens (touching bars, day-boundary markers, live legend totals). Day/hour buckets align to the dashboard timezone.
- **Prompt Cache Rate** (new) — a compact half-circle gauge in the summary cards showing the share of input tokens served from the provider prompt cache over the selected period.
- **Daily Token Usage** — adds a prompt-cached series, collapses the two local-cache lines into one, and recolours to a cost-based palette (brown = paid, blue = cached, lighter = cheaper). Stays per-period (not cumulative).
- **Cache meter & styling** — the "Tokens" meter and both charts now share one palette/segment order, fonts, gridlines and tooltips.

## Backend

New `GET /admin/usage/throughput?granularity=second|minute|hour|day` returning a fixed trailing window of token-volume buckets, implemented across all three stores (sqlite/postgres/mongodb). Buckets are timezone-aware (offset from the `X-GoModel-Timezone` header) so day buckets start at **local midnight**, matching the Daily chart. The provider prompt-cache split is folded in Go from `raw_data` via the existing `EntryInputSegments`, shared across backends.

`GET /admin/usage/daily` gains the per-period uncached/cached/cache-write split so the Daily chart can plot prompt-cached tokens.

## Provider behaviour

The prompt-cache series reflect provider-reported prompt-cache reads (OpenAI `cached_tokens`, Anthropic `cache_read_input_tokens`, …) — the same normalisation the cache meter already uses. GoModel's own exact-response-cache hits are shown separately as **Locally Cached**.

## Tests

- New Go tests: throughput aggregation, timezone-aware day buckets, daily prompt-cache split.
- Dashboard JS unit tests updated/extended (347 passing).
- `make test-race`, `make lint`, gofmt and the dashboard JS suite pass via pre-commit.

## Notes

- The new endpoint has Swagger annotations; regenerating the published API reference is left as a follow-up.
- Day-bucket timezone alignment uses the offset at "now" (fixed), consistent with the sqlite daily path — a day crossing a DST transition within the window may be off by an hour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Live Token Throughput** chart to the dashboard overview with a streaming indicator, adjustable granularity controls, legend, and empty-state overlay.
  * Added a **Prompt Cache Rate** summary card featuring an improved gauge visualization.
* **Bug Fixes**
  * Improved live dashboard behavior by properly starting/stopping streaming during navigation and refreshing visuals on theme changes.
  * Refined prompt cache gauge rendering (retries/page gating) and updated chart tooltip/tick formatting.
  * Updated cache meter segment ordering and color mapping for consistent labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->