### PR TITLE
fix(usage): apply cached-token discounts to all OpenAI-compatible providers

### DIFF
--- a/internal/usage/cost.go
+++ b/internal/usage/cost.go
@@ -60,13 +60,26 @@ type tokenCostMapping struct {
 var openAICompatibleTokenCostMappings = []tokenCostMapping{
 	{rawDataKey: "cached_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, side: sideInput, unit: unitPerMtok, includedInBase: true},
 	{rawDataKey: "prompt_cached_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, side: sideInput, unit: unitPerMtok, includedInBase: true},
+	// DeepSeek reports cache hits as a top-level usage.prompt_cache_hit_tokens
+	// field instead of the nested prompt_tokens_details.cached_tokens, and the
+	// hit count is already part of prompt_tokens (prompt_tokens = hit + miss).
+	// Treat it as a cached-input alias; the miss count needs no rate (the base
+	// input rate already covers it) and is listed in informationalFields.
+	{rawDataKey: "prompt_cache_hit_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, side: sideInput, unit: unitPerMtok, includedInBase: true},
 	{rawDataKey: "reasoning_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, side: sideOutput, unit: unitPerMtok, includedInBase: true},
 	{rawDataKey: "completion_reasoning_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, side: sideOutput, unit: unitPerMtok, includedInBase: true},
 	{rawDataKey: "prompt_audio_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.AudioInputPerMtok }, side: sideInput, unit: unitPerMtok, includedInBase: true},
 	{rawDataKey: "completion_audio_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.AudioOutputPerMtok }, side: sideOutput, unit: unitPerMtok, includedInBase: true},
 }
 
-// providerMappings defines the per-provider RawData key to pricing field mappings.
+// providerMappings defines the per-provider RawData key to pricing field
+// mappings. Providers not listed here fall back to
+// openAICompatibleTokenCostMappings (see tokenCostMappingsForProvider): every
+// other registered provider type (xiaomi, deepseek, zai, minimax, bailian,
+// oracle, azure, vllm, ollama, opencode_go, …) speaks the OpenAI usage schema,
+// so its cached/reasoning/audio token breakdowns must be priced the same way.
+// Only providers whose usage schema differs (anthropic, gemini) or that report
+// extra token types (xai) need an explicit entry.
 var providerMappings = map[string][]tokenCostMapping{
 	"openai":     openAICompatibleTokenCostMappings,
 	"openrouter": openAICompatibleTokenCostMappings,
@@ -105,6 +118,9 @@ var providerMappings = map[string][]tokenCostMapping{
 // input/output counts. They never need separate pricing and should not trigger
 // "unmapped token field" caveats.
 var informationalFields = map[string]struct{}{
+	// DeepSeek's cache-miss count: the non-cached remainder of prompt_tokens,
+	// already priced at the base input rate (see prompt_cache_hit_tokens above).
+	"prompt_cache_miss_tokens":              {},
 	"prompt_text_tokens":                    {},
 	"completion_text_tokens":                {},
 	"prompt_image_tokens":                   {},
@@ -149,47 +165,45 @@ func CalculateGranularCost(inputTokens, outputTokens int, rawData map[string]any
 	// rawData keys map to the same pricing field (e.g. cached_tokens and prompt_cached_tokens
 	// both map to CachedInputPerMtok).
 	appliedFields := make(map[*float64]bool)
-	if mappings, ok := providerMappings[providerType]; ok {
-		for _, m := range mappings {
-			count := extractInt(rawData, m.rawDataKey)
-			if count == 0 {
-				continue
-			}
-			mappedKeys[m.rawDataKey] = true
+	for _, m := range tokenCostMappingsForProvider(providerType) {
+		count := extractInt(rawData, m.rawDataKey)
+		if count == 0 {
+			continue
+		}
+		mappedKeys[m.rawDataKey] = true
 
-			rate := m.pricingField(pricing)
-			if rate == nil {
-				continue // Base rate covers this token type; no adjustment needed
-			}
+		rate := m.pricingField(pricing)
+		if rate == nil {
+			continue // Base rate covers this token type; no adjustment needed
+		}
 
-			if appliedFields[rate] {
-				continue // Already applied via a different rawData key for the same pricing field
-			}
-			appliedFields[rate] = true
+		if appliedFields[rate] {
+			continue // Already applied via a different rawData key for the same pricing field
+		}
+		appliedFields[rate] = true
 
-			effectiveRate := *rate
-			if m.includedInBase && m.unit == unitPerMtok {
-				if baseRate := baseRateForSide(pricing, m.side); baseRate != nil {
-					effectiveRate -= *baseRate
-				}
+		effectiveRate := *rate
+		if m.includedInBase && m.unit == unitPerMtok {
+			if baseRate := baseRateForSide(pricing, m.side); baseRate != nil {
+				effectiveRate -= *baseRate
 			}
+		}
 
-			var cost float64
-			switch m.unit {
-			case unitPerMtok:
-				cost = float64(count) * effectiveRate / 1_000_000
-			case unitPerItem:
-				cost = float64(count) * effectiveRate
-			}
+		var cost float64
+		switch m.unit {
+		case unitPerMtok:
+			cost = float64(count) * effectiveRate / 1_000_000
+		case unitPerItem:
+			cost = float64(count) * effectiveRate
+		}
 
-			switch m.side {
-			case sideInput:
-				inputCost += cost
-				hasInput = true
-			case sideOutput:
-				outputCost += cost
-				hasOutput = true
-			}
+		switch m.side {
+		case sideInput:
+			inputCost += cost
+			hasInput = true
+		case sideOutput:
+			outputCost += cost
+			hasOutput = true
 		}
 	}
 
@@ -355,6 +369,19 @@ func tierLimitTokens(tier core.ModelPricingTier) (float64, bool) {
 		return *tier.UpToMtok * 1_000_000, true
 	}
 	return 0, false
+}
+
+// tokenCostMappingsForProvider returns the token-cost mappings for a provider
+// type, defaulting to the OpenAI-compatible mappings for the many providers
+// that speak the OpenAI usage schema but are not listed in providerMappings.
+// Without this default their cached/reasoning token breakdowns would be billed
+// at the full input/output rate (see issue #435: Xiaomi cached tokens
+// over-charged ~4x for cache-heavy workloads).
+func tokenCostMappingsForProvider(providerType string) []tokenCostMapping {
+	if mappings, ok := providerMappings[providerType]; ok {
+		return mappings
+	}
+	return openAICompatibleTokenCostMappings
 }
 
 func baseRateForSide(pricing *core.ModelPricing, side costSide) *float64 {

--- a/internal/usage/cost_test.go
+++ b/internal/usage/cost_test.go
@@ -712,6 +712,72 @@ func TestCalculateGranularCost_OutputOnlyPricing(t *testing.T) {
 	assertCostNear(t, "TotalCost", result.TotalCost, 7.5)
 }
 
+// TestCalculateGranularCost_OpenAICompatibleProvidersDefaultMappings is a
+// regression test for issue #435. Providers that speak the OpenAI usage schema
+// but are not explicitly listed in providerMappings (xiaomi, deepseek, zai,
+// minimax, bailian, oracle, azure, vllm, ollama, opencode_go) must still apply
+// the cached-input discount instead of billing cached tokens at the full input
+// rate. Previously these providers produced a much higher cost than "openai"
+// for the same response, over-charging cache-heavy workloads.
+func TestCalculateGranularCost_OpenAICompatibleProvidersDefaultMappings(t *testing.T) {
+	pricing := &core.ModelPricing{
+		Currency:           "USD",
+		InputPerMtok:       floatPtr(0.435),
+		OutputPerMtok:      floatPtr(0.87),
+		CachedInputPerMtok: floatPtr(0.0036),
+	}
+	// Cache-heavy workload: 1M input (900k cached), 200k output.
+	rawData := map[string]any{"prompt_cached_tokens": 900_000}
+
+	want := CalculateGranularCost(1_000_000, 200_000, rawData, "openai", pricing)
+	if want.TotalCost == nil {
+		t.Fatal("expected a total cost for the openai baseline")
+	}
+
+	for _, provider := range []string{
+		"xiaomi", "deepseek", "zai", "minimax", "bailian",
+		"oracle", "azure", "vllm", "ollama", "opencode_go",
+	} {
+		got := CalculateGranularCost(1_000_000, 200_000, rawData, provider, pricing)
+		assertCostNear(t, provider+" InputCost", got.InputCost, *want.InputCost)
+		assertCostNear(t, provider+" OutputCost", got.OutputCost, *want.OutputCost)
+		assertCostNear(t, provider+" TotalCost", got.TotalCost, *want.TotalCost)
+		if got.Caveat != "" {
+			t.Fatalf("%s: expected no caveat, got %q", provider, got.Caveat)
+		}
+	}
+}
+
+// TestCalculateGranularCost_DeepSeekTopLevelCacheFields is a regression test for
+// issue #435. DeepSeek does not use the nested prompt_tokens_details.cached_tokens
+// field; it reports top-level prompt_cache_hit_tokens / prompt_cache_miss_tokens,
+// where prompt_tokens == hit + miss. The cache-hit portion must be priced at the
+// cached-input rate, the miss portion is informational, and neither should raise
+// an "unmapped token field" caveat.
+func TestCalculateGranularCost_DeepSeekTopLevelCacheFields(t *testing.T) {
+	pricing := &core.ModelPricing{
+		Currency:           "USD",
+		InputPerMtok:       floatPtr(0.21),
+		OutputPerMtok:      floatPtr(0.79),
+		CachedInputPerMtok: floatPtr(0.021), // DeepSeek cache-hit ≈ 0.1x input
+	}
+	// prompt_tokens = 1_000_000 = 900k hit + 100k miss; 200k output.
+	rawData := map[string]any{
+		"prompt_cache_hit_tokens":  900_000,
+		"prompt_cache_miss_tokens": 100_000,
+	}
+	result := CalculateGranularCost(1_000_000, 200_000, rawData, "deepseek", pricing)
+
+	// Input: 1M * 0.21/1M + 900k * (0.021-0.21)/1M = 0.21 - 0.1701 = 0.0399
+	assertCostNear(t, "InputCost", result.InputCost, 0.0399)
+	// Output: 200k * 0.79/1M = 0.158
+	assertCostNear(t, "OutputCost", result.OutputCost, 0.158)
+	assertCostNear(t, "TotalCost", result.TotalCost, 0.1979)
+	if result.Caveat != "" {
+		t.Fatalf("expected no caveat, got %q", result.Caveat)
+	}
+}
+
 func assertCostNear(t *testing.T, name string, got *float64, want float64) {
 	t.Helper()
 	if got == nil {


### PR DESCRIPTION
## Summary

Fixes #435. Cost calculation only applied per-token-type pricing (cached input, reasoning, audio) for the six provider types listed in `providerMappings` (`openai`, `openrouter`, `anthropic`, `gemini`, `groq`, `xai`). **Every other OpenAI-compatible provider got no mapping at all** — so their cached prompt tokens were billed at the **full input rate** instead of the much cheaper cached-input rate, over-charging cache-heavy workloads.

Affected provider types: `xiaomi`, `deepseek`, `zai`, `minimax`, `bailian`, `oracle`, `azure`, `vllm`, `ollama`, `opencode_go`.

## Why this caused the reported ~4×

Xiaomi MiMo prices cache-hit input at **~1/50th** of cache-miss input (e.g. MiMo-V2.5: ¥0.02 vs ¥1.0 /Mtok). The gateway already captured the cached count (`prompt_tokens_details.cached_tokens` → `prompt_cached_tokens`) but, because `xiaomi` wasn't in `providerMappings`, charged **every** input token at the full rate — and even flagged the cached field as an `"unmapped token field"` caveat. For a cache-heavy workload that lands around 4× the real bill, matching the issue report (~$9.4 vs ~$2.2).

## Changes

- **Default unmapped providers to the OpenAI-compatible token mappings.** They all speak the OpenAI usage schema, so cached/reasoning/audio breakdowns must be priced the same way. Only providers whose usage schema differs (`anthropic`, `gemini`) or that report extra token types (`xai`) keep an explicit entry.
- **Map DeepSeek's non-standard top-level cache fields.** DeepSeek doesn't use `prompt_tokens_details.cached_tokens`; it reports top-level `prompt_cache_hit_tokens` / `prompt_cache_miss_tokens` where `prompt_tokens = hit + miss`. Added `prompt_cache_hit_tokens` as a cached-input alias (`includedInBase`) and `prompt_cache_miss_tokens` as an informational field (no separate rate, no spurious caveat).

The dedup-by-pricing-field guard already in place means a provider emitting several cache aliases can't double-count.

## Provider field-name coverage (verified against official docs)

| Provider | Cache field reported | Handled by |
|---|---|---|
| Xiaomi, Z.ai/GLM, MiniMax, Bailian/Qwen, vLLM | `prompt_tokens_details.cached_tokens` | OpenAI-compatible default |
| Moonshot/Kimi | top-level `cached_tokens` (also nested) | OpenAI-compatible default |
| DeepSeek | top-level `prompt_cache_hit_tokens` / `prompt_cache_miss_tokens` | DeepSeek aliases (new) |
| Oracle | none documented | n/a |

## Not changed (deliberate)

- **`CachedOutputPerMtok` is intentionally not added.** Verified against OpenAI / Anthropic / Gemini / DeepSeek / xAI / GLM docs: prompt caching is **input-only** everywhere; there is no cached-output billing concept. The real cache dimensions are already modeled (`CachedInputPerMtok`, plus Anthropic's `CacheWritePerMtok`).
- **Anthropic-native routing under a non-`anthropic` provider type** (e.g. `opencode_go` models in `OPENCODE_GO_MESSAGES_MODELS`, MiniMax's `/messages` surface) reports `cache_read_input_tokens` / `cache_creation_input_tokens`, which the OpenAI default doesn't map. Narrow case; the clean fix is endpoint/shape-aware mapping selection, left out to keep this change focused.

## Follow-up (data, separate repo)

The discount only applies when the model's registry pricing carries `cached_input_per_mtok`. 303/777 `ai-model-list` models have it (incl. DeepSeek-V3.x, GLM), but **`mimo-v2.5` does not** (only `mimo-v2.5-pro`). A companion `ENTERPILOT/ai-model-list` update is needed to add native Xiaomi cache-hit pricing so `mimo-v2.5` users are fully corrected.

## Tests

- `TestCalculateGranularCost_OpenAICompatibleProvidersDefaultMappings` — all 10 providers now match the `openai` baseline cost for a cache-heavy response, no caveat.
- `TestCalculateGranularCost_DeepSeekTopLevelCacheFields` — DeepSeek top-level hit/miss fields priced correctly (cache-hit at cached rate, miss informational), no caveat.
- Existing cost tests and the `usage`/`gateway`/`budget`/`admin` suites pass; `make test-race` and `make lint` green via pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected token cost handling for OpenAI-compatible providers so cached input is priced appropriately instead of at full input rate.
  * Improved support for DeepSeek-style cache token reporting, preventing unmapped token warnings for cache miss fields and pricing cache hits correctly.
* **Tests**
  * Added regression coverage for OpenAI-compatible provider cost calculations.
  * Added regression coverage for DeepSeek cache token fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->