### PR TITLE
feat(dashboard): refine activity calendar gradation, colors, alignment + chart day markers

### DIFF
--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -38,6 +38,10 @@
   --radius: 8px;
   --chart-grid: #2a2826;
   --chart-text: #9a918a;
+  /* High-contrast color for chart day-boundary markers (divider line + date
+     label) so they stand out from the muted axis text: bright on dark,
+     dark on light. */
+  --chart-day-marker: var(--text);
   --chart-tooltip-bg: #1e1d1c;
   --chart-tooltip-border: #2a2826;
   --chart-tooltip-text: #e8e0d6;
@@ -87,6 +91,7 @@
   --prompt-cache-color-bg: color-mix(in srgb, var(--prompt-cache-color) 9%, var(--bg-surface));
   --chart-grid: #e8e0d6;
   --chart-text: #7a7068;
+  --chart-day-marker: var(--text);
   --chart-tooltip-bg: #ffffff;
   --chart-tooltip-border: #e8e0d6;
   --chart-tooltip-text: #2d2519;
@@ -135,6 +140,7 @@
     --prompt-cache-color-bg: color-mix(in srgb, var(--prompt-cache-color) 9%, var(--bg-surface));
     --chart-grid: #e8e0d6;
     --chart-text: #7a7068;
+    --chart-day-marker: var(--text);
     --chart-tooltip-bg: #ffffff;
     --chart-tooltip-border: #e8e0d6;
     --chart-tooltip-text: #2d2519;

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -41,11 +41,21 @@
   --chart-tooltip-bg: #1e1d1c;
   --chart-tooltip-border: #2a2826;
   --chart-tooltip-text: #e8e0d6;
+  /* Activity-calendar ramp — graduated blue derived from the prompt-cache blue
+     (--info) so the chart reads like the cache visuals. Dark theme climbs from a
+     dark navy through --info and into a brighter tint, giving 10 distinguishable
+     steps (keep in sync with calendarLevel() in contribution-calendar.js). */
   --cal-level-0: #161b22;
-  --cal-level-1: #0e4429;
-  --cal-level-2: #006d32;
-  --cal-level-3: #26a641;
-  --cal-level-4: #39d353;
+  --cal-level-1: color-mix(in srgb, var(--info) 15%, var(--bg-surface));
+  --cal-level-2: color-mix(in srgb, var(--info) 25%, var(--bg-surface));
+  --cal-level-3: color-mix(in srgb, var(--info) 36%, var(--bg-surface));
+  --cal-level-4: color-mix(in srgb, var(--info) 48%, var(--bg-surface));
+  --cal-level-5: color-mix(in srgb, var(--info) 60%, var(--bg-surface));
+  --cal-level-6: color-mix(in srgb, var(--info) 73%, var(--bg-surface));
+  --cal-level-7: color-mix(in srgb, var(--info) 87%, var(--bg-surface));
+  --cal-level-8: var(--info);
+  --cal-level-9: color-mix(in srgb, var(--info) 80%, #ffffff);
+  --cal-level-10: color-mix(in srgb, var(--info) 62%, #ffffff);
   --alias-row-valid-bg: color-mix(
     in srgb,
     var(--bg-surface-hover) 86%,
@@ -80,11 +90,19 @@
   --chart-tooltip-bg: #ffffff;
   --chart-tooltip-border: #e8e0d6;
   --chart-tooltip-text: #2d2519;
+  /* Light theme: graduated blue climbing from a pale tint through --info into a
+     deep navy, keeping 10 distinguishable steps (see :root for the dark ramp). */
   --cal-level-0: #ebedf0;
-  --cal-level-1: #9be9a8;
-  --cal-level-2: #40c463;
-  --cal-level-3: #30a14e;
-  --cal-level-4: #216e39;
+  --cal-level-1: color-mix(in srgb, var(--info) 12%, #ffffff);
+  --cal-level-2: color-mix(in srgb, var(--info) 24%, #ffffff);
+  --cal-level-3: color-mix(in srgb, var(--info) 37%, #ffffff);
+  --cal-level-4: color-mix(in srgb, var(--info) 50%, #ffffff);
+  --cal-level-5: color-mix(in srgb, var(--info) 64%, #ffffff);
+  --cal-level-6: color-mix(in srgb, var(--info) 80%, #ffffff);
+  --cal-level-7: var(--info);
+  --cal-level-8: color-mix(in srgb, var(--info) 85%, #000000);
+  --cal-level-9: color-mix(in srgb, var(--info) 72%, #000000);
+  --cal-level-10: color-mix(in srgb, var(--info) 60%, #000000);
   --alias-row-valid-bg: color-mix(
     in srgb,
     var(--bg-surface) 96%,
@@ -120,11 +138,18 @@
     --chart-tooltip-bg: #ffffff;
     --chart-tooltip-border: #e8e0d6;
     --chart-tooltip-text: #2d2519;
+    /* Light theme (system preference): mirror the [data-theme="light"] blue ramp. */
     --cal-level-0: #ebedf0;
-    --cal-level-1: #9be9a8;
-    --cal-level-2: #40c463;
-    --cal-level-3: #30a14e;
-    --cal-level-4: #216e39;
+    --cal-level-1: color-mix(in srgb, var(--info) 12%, #ffffff);
+    --cal-level-2: color-mix(in srgb, var(--info) 24%, #ffffff);
+    --cal-level-3: color-mix(in srgb, var(--info) 37%, #ffffff);
+    --cal-level-4: color-mix(in srgb, var(--info) 50%, #ffffff);
+    --cal-level-5: color-mix(in srgb, var(--info) 64%, #ffffff);
+    --cal-level-6: color-mix(in srgb, var(--info) 80%, #ffffff);
+    --cal-level-7: var(--info);
+    --cal-level-8: color-mix(in srgb, var(--info) 85%, #000000);
+    --cal-level-9: color-mix(in srgb, var(--info) 72%, #000000);
+    --cal-level-10: color-mix(in srgb, var(--info) 60%, #000000);
     --alias-row-valid-bg: color-mix(
       in srgb,
       var(--bg-surface) 96%,
@@ -3763,6 +3788,24 @@ body.conversation-drawer-open {
 }
 .contribution-calendar-cell.level-4 {
   background: var(--cal-level-4);
+}
+.contribution-calendar-cell.level-5 {
+  background: var(--cal-level-5);
+}
+.contribution-calendar-cell.level-6 {
+  background: var(--cal-level-6);
+}
+.contribution-calendar-cell.level-7 {
+  background: var(--cal-level-7);
+}
+.contribution-calendar-cell.level-8 {
+  background: var(--cal-level-8);
+}
+.contribution-calendar-cell.level-9 {
+  background: var(--cal-level-9);
+}
+.contribution-calendar-cell.level-10 {
+  background: var(--cal-level-10);
 }
 .contribution-calendar-cell.empty {
   background: transparent;

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -356,6 +356,7 @@ function dashboard() {
       return {
         grid: this.cssVar("--chart-grid"),
         text: this.cssVar("--chart-text"),
+        dayMarker: this.cssVar("--chart-day-marker"),
         tooltipBg: this.cssVar("--chart-tooltip-bg"),
         tooltipBorder: this.cssVar("--chart-tooltip-border"),
         tooltipText: this.cssVar("--chart-tooltip-text"),

--- a/internal/admin/dashboard/static/js/modules/charts.js
+++ b/internal/admin/dashboard/static/js/modules/charts.js
@@ -47,14 +47,18 @@
                     pointRadius: 0,
                     pointHoverRadius: 4
                 }, opts || {});
+                // Stacked area: each series sits on top of the one below, so the
+                // band's top edge is the per-unit total (Input + Output + Prompt
+                // cached + Locally cached). The bottom series fills to the axis
+                // ('origin'); the rest fill down to the previous dataset ('-1').
                 const datasets = [
-                    line('Input Tokens', inputData, resolve('var(--token-input)'), { fill: true, backgroundColor: fade('var(--token-input)', 12) }),
-                    line('Output Tokens', outputData, resolve('var(--token-output)'), { fill: true, backgroundColor: fade('var(--token-output)', 12) }),
-                    line('Prompt (Input) Cached', promptData, resolve('var(--token-prompt)'), { borderDash: [6, 4] })
+                    line('Input Tokens', inputData, resolve('var(--token-input)'), { fill: 'origin' }),
+                    line('Output Tokens', outputData, resolve('var(--token-output)'), { fill: '-1' }),
+                    line('Prompt (Input) Cached', promptData, resolve('var(--token-prompt)'), { fill: '-1', borderDash: [6, 4] })
                 ];
                 if (cacheEnabled) {
                     datasets.push(
-                        line('Locally Cached', localData, fade('var(--info)', 35), { borderDash: [2, 3] })
+                        line('Locally Cached', localData, fade('var(--info)', 35), { fill: '-1', borderDash: [2, 3] })
                     );
                 }
                 return {
@@ -73,16 +77,23 @@
                                 labels: { color: colors.text, font: { size: 12 } }
                             },
                             tooltip: this._chartTooltip(colors, {
-                                label: (c) => c.dataset.label + ': ' + c.parsed.y.toLocaleString()
+                                label: (c) => c.dataset.label + ': ' + c.parsed.y.toLocaleString(),
+                                footer: (items) => {
+                                    let total = 0;
+                                    items.forEach((it) => { total += Number(it.parsed.y) || 0; });
+                                    return 'Total: ' + total.toLocaleString();
+                                }
                             })
                         },
                         scales: {
                             x: {
+                                stacked: true,
                                 grid: { color: colors.grid },
                                 border: { display: false },
                                 ticks: { color: colors.text, font: this._chartTickFont(), maxRotation: 0, autoSkip: true, maxTicksLimit: 10 }
                             },
                             y: {
+                                stacked: true,
                                 beginAtZero: true,
                                 grid: { color: colors.grid },
                                 border: { display: false },

--- a/internal/admin/dashboard/static/js/modules/contribution-calendar.js
+++ b/internal/admin/dashboard/static/js/modules/contribution-calendar.js
@@ -79,10 +79,10 @@
                 var todayKey = this.currentDateKey();
                 var start = this.dateKeyToDate(this.addDaysToDateKey(todayKey, -364));
 
-                // Align start to Monday (ISO week start)
-                var dayOfWeek = start.getUTCDay();
-                var diff = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
-                start.setUTCDate(start.getUTCDate() + diff);
+                // Align start to Sunday so each week column reads top-to-bottom
+                // Sun, Mon, ..., Sat — matching the Mon/Wed/Fri day labels (GitHub style).
+                var dayOfWeek = start.getUTCDay(); // 0 = Sunday
+                start.setUTCDate(start.getUTCDate() - dayOfWeek);
 
                 var mode = this.calendarMode;
                 var days = [];
@@ -168,9 +168,9 @@
                 var todayKey = this.currentDateKey();
                 var today = this.dateKeyToDate(todayKey);
                 var start = this.dateKeyToDate(this.addDaysToDateKey(todayKey, -364));
-                var dayOfWeek = start.getUTCDay();
-                var diff = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
-                start.setUTCDate(start.getUTCDate() + diff);
+                // Sunday-align to match buildCalendarGrid's week columns.
+                var dayOfWeek = start.getUTCDay(); // 0 = Sunday
+                start.setUTCDate(start.getUTCDate() - dayOfWeek);
 
                 var months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
                 var labels = [];

--- a/internal/admin/dashboard/static/js/modules/contribution-calendar.js
+++ b/internal/admin/dashboard/static/js/modules/contribution-calendar.js
@@ -1,4 +1,11 @@
 (function(global) {
+    // Number of active intensity levels (1..CALENDAR_LEVELS); level 0 means no
+    // activity. Keep in sync with the --cal-level-* ramp and .level-N rules in
+    // dashboard.css.
+    var CALENDAR_LEVELS = 10;
+    // Exponent (<1) for the intensity scale; see calendarLevel() for rationale.
+    var CALENDAR_SCALE_EXPONENT = 0.7;
+
     function dashboardContributionCalendarModule() {
         return {
             calendarData: [],
@@ -127,15 +134,30 @@
 
             calendarLevel(value, max) {
                 if (value <= 0 || max <= 0) return 0;
-                // Log scale against the busiest day: token counts span orders of
-                // magnitude, so a linear ratio collapses every quiet day to the
-                // lightest shade. Logs compress the busy days and spread the quiet
-                // ones, keeping low-volume days distinguishable.
-                var ratio = Math.log(value + 1) / Math.log(max + 1);
-                if (ratio <= 0.25) return 1;
-                if (ratio <= 0.5) return 2;
-                if (ratio <= 0.75) return 3;
-                return 4;
+                // Power scale (exponent < 1) against the busiest day. Token
+                // counts span orders of magnitude. A linear ratio collapses every
+                // quiet day to the lightest shade, while a pure log scale flattens
+                // the busy end so a 1M and a 1.5M day land on the same shade. A
+                // ~0.7 exponent sits between the two: it keeps high-volume days
+                // separated (so big days stay distinguishable) while still
+                // lifting quiet days off the lightest level. Spreading the result
+                // across CALENDAR_LEVELS buckets gives a gradual ramp instead of
+                // a handful of coarse steps.
+                var ratio = Math.pow(value / max, CALENDAR_SCALE_EXPONENT);
+                var level = Math.ceil(ratio * CALENDAR_LEVELS);
+                if (level < 1) return 1;
+                if (level > CALENDAR_LEVELS) return CALENDAR_LEVELS;
+                return level;
+            },
+
+            calendarLegendLevels() {
+                // 0 (empty) .. CALENDAR_LEVELS, matching calendarLevel()'s range
+                // and the --cal-level-* ramp so the legend always mirrors the grid.
+                var levels = [];
+                for (var i = 0; i <= CALENDAR_LEVELS; i++) {
+                    levels.push(i);
+                }
+                return levels;
             },
 
             toggleCalendarMode(mode) {

--- a/internal/admin/dashboard/static/js/modules/contribution-calendar.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/contribution-calendar.test.cjs
@@ -59,33 +59,48 @@ test('calendarLevel returns 0 for empty, negative, or maxless input', () => {
 
 test('calendarLevel puts the busiest day at the darkest level', () => {
     const m = createCalendarModule();
-    assert.equal(m.calendarLevel(65535, 65535), 4);
-    assert.equal(m.calendarLevel(50, 50), 4);
-    assert.equal(m.calendarLevel(1, 1), 4);
+    assert.equal(m.calendarLevel(65535, 65535), 10);
+    assert.equal(m.calendarLevel(50, 50), 10);
+    assert.equal(m.calendarLevel(1, 1), 10);
 });
 
-// With max = 65535 (= 16^4 - 1) the log cutoffs 0.25/0.5/0.75 land on value
-// boundaries 15, 255, and 4095. We probe inside each band and just across each
-// boundary, but avoid the exact integer at the cutoff (where the ratio equals
-// the cutoff and float rounding is ambiguous).
-test('calendarLevel buckets values into log-scaled bands relative to max', () => {
+// With the power scale (exponent 0.7) spread across 10 buckets and max = 65535,
+// the bucket boundaries land at value = 65535 * (k/10)^(1/0.7) for k = 1..10
+// (~2442, 6579, 11737, 17699, 24350, 31593, 39373, 47650, 56378, 65535). We
+// probe inside each band and just across a few boundaries, avoiding the exact
+// boundary where float rounding is ambiguous.
+test('calendarLevel buckets values into power-scaled bands relative to max', () => {
     const m = createCalendarModule();
     const MAX = 65535;
     const cases = [
-        { value: 5, level: 1 },
-        { value: 14, level: 1 },    // just below the 0.25 cutoff (boundary at 15)
-        { value: 16, level: 2 },    // just above the 0.25 cutoff
-        { value: 100, level: 2 },
-        { value: 254, level: 2 },   // just below the 0.5 cutoff (boundary at 255)
-        { value: 256, level: 3 },   // just above the 0.5 cutoff
-        { value: 1000, level: 3 },
-        { value: 4094, level: 3 },  // just below the 0.75 cutoff (boundary at 4095)
-        { value: 4096, level: 4 },  // just above the 0.75 cutoff
-        { value: 30000, level: 4 },
-        { value: 65535, level: 4 }, // the max day
+        { value: 1, level: 1 },
+        { value: 100, level: 1 },
+        { value: 2000, level: 1 },   // just below the level-1/2 boundary (~2442)
+        { value: 3000, level: 2 },   // just above it
+        { value: 6000, level: 2 },
+        { value: 7000, level: 3 },   // just above the level-2/3 boundary (~6579)
+        { value: 11000, level: 3 },  // just below the level-3/4 boundary (~11737)
+        { value: 12000, level: 4 },  // just above it
+        { value: 25000, level: 6 },
+        { value: 35000, level: 7 },
+        { value: 45000, level: 8 },
+        { value: 55000, level: 9 },
+        { value: 60000, level: 10 },
+        { value: 65535, level: 10 }, // the max day
     ];
     for (const c of cases) {
         assert.equal(m.calendarLevel(c.value, MAX), c.level, `value ${c.value}`);
+    }
+});
+
+test('calendarLegendLevels covers level 0 through the max level', () => {
+    const m = createCalendarModule();
+    const levels = m.calendarLegendLevels();
+    assert.equal(levels[0], 0, 'starts at the empty level');
+    assert.equal(levels[levels.length - 1], 10, 'ends at the darkest level');
+    // Every active level must have a matching swatch so the legend mirrors the grid.
+    for (let v = 1; v <= 10; v++) {
+        assert.ok(levels.includes(v), `legend includes level ${v}`);
     }
 });
 
@@ -106,7 +121,7 @@ test('buildCalendarGrid scales every day against the busiest day in the whole pe
     m.calendarMode = 'tokens';
     m.calendarData = [
         { date: '2026-06-23', total_tokens: 1000000 }, // busiest day in the year
-        { date: olderKey, total_tokens: 100 },         // far smaller, ~0.33 of max in log space
+        { date: olderKey, total_tokens: 100 },         // far smaller, a tiny fraction of max
     ];
 
     const days = flattenDays(m.buildCalendarGrid());
@@ -114,13 +129,13 @@ test('buildCalendarGrid scales every day against the busiest day in the whole pe
     const quiet = days.find((d) => d.dateStr === olderKey);
     const empties = days.filter((d) => d.value === 0);
 
-    assert.equal(busiest.level, 4, 'busiest day is darkest');
-    assert.equal(quiet.level, 2, 'a far smaller day reads lighter, not identical');
+    assert.equal(busiest.level, 10, 'busiest day is darkest');
+    assert.equal(quiet.level, 1, 'a far smaller day reads lighter, not identical');
     assert.ok(empties.length > 0, 'the year window contains days with no usage');
     assert.ok(empties.every((d) => d.level === 0), 'no-usage days have level 0');
 });
 
-test('buildCalendarGrid applies the same log scaling to the costs view', () => {
+test('buildCalendarGrid applies the same power scaling to the costs view', () => {
     const m = withCalendarDates(createCalendarModule(), '2026-06-23');
     const olderKey = m.addDaysToDateKey('2026-06-23', -100);
     m.calendarMode = 'costs';
@@ -134,6 +149,6 @@ test('buildCalendarGrid applies the same log scaling to the costs view', () => {
     const busiest = days.find((d) => d.dateStr === '2026-06-23');
     const quiet = days.find((d) => d.dateStr === olderKey);
 
-    assert.equal(busiest.level, 4, 'highest-cost day is darkest');
+    assert.equal(busiest.level, 10, 'highest-cost day is darkest');
     assert.equal(quiet.level, 1, 'a tiny-cost day stays lightest even with a huge token count');
 });

--- a/internal/admin/dashboard/static/js/modules/contribution-calendar.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/contribution-calendar.test.cjs
@@ -135,6 +135,22 @@ test('buildCalendarGrid scales every day against the busiest day in the whole pe
     assert.ok(empties.every((d) => d.level === 0), 'no-usage days have level 0');
 });
 
+test('buildCalendarGrid lays out weeks Sunday-first to match the day labels', () => {
+    const m = withCalendarDates(createCalendarModule(), '2026-06-23');
+    m.calendarMode = 'tokens';
+    m.calendarData = [];
+
+    const firstWeek = m.buildCalendarGrid()[0];
+    // Day labels are [_, Mon, _, Wed, _, Fri, _], so the top row must be Sunday:
+    // row index r holds weekday r (Sun=0, Mon=1, ... Sat=6).
+    for (let row = 0; row < 7; row++) {
+        const cell = firstWeek[row];
+        assert.ok(!cell.empty, `first week row ${row} should be a real day`);
+        const weekday = new Date(cell.dateStr + 'T00:00:00Z').getUTCDay();
+        assert.equal(weekday, row, `row ${row} should be weekday ${row} (got ${cell.dateStr})`);
+    }
+});
+
 test('buildCalendarGrid applies the same power scaling to the costs view', () => {
     const m = withCalendarDates(createCalendarModule(), '2026-06-23');
     const olderKey = m.addDaysToDateKey('2026-06-23', -100);

--- a/internal/admin/dashboard/static/js/modules/live-tokens.js
+++ b/internal/admin/dashboard/static/js/modules/live-tokens.js
@@ -301,9 +301,10 @@
                             const d = new Date(ms);
                             const key = d.getFullYear() + '-' + d.getMonth() + '-' + d.getDate();
                             if (prevKey !== null && key !== prevKey && meta.data[i - 1]) {
+                                const markerColor = colors.dayMarker || colors.text;
                                 const x = Math.round((meta.data[i - 1].x + meta.data[i].x) / 2) + 0.5;
-                                ctx.globalAlpha = 0.4;
-                                ctx.strokeStyle = colors.text;
+                                ctx.globalAlpha = 0.6;
+                                ctx.strokeStyle = markerColor;
                                 ctx.setLineDash([3, 3]);
                                 ctx.lineWidth = 1;
                                 ctx.beginPath();
@@ -311,8 +312,9 @@
                                 ctx.lineTo(x, area.bottom);
                                 ctx.stroke();
                                 ctx.setLineDash([]);
-                                ctx.globalAlpha = 0.85;
-                                ctx.fillStyle = colors.text;
+                                // Full opacity + high-contrast color so the date label stays legible.
+                                ctx.globalAlpha = 1;
+                                ctx.fillStyle = markerColor;
                                 ctx.textAlign = 'left';
                                 ctx.textBaseline = 'bottom';
                                 ctx.fillText(d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }), x + 3, area.bottom - 2);

--- a/internal/admin/dashboard/templates/page-overview.html
+++ b/internal/admin/dashboard/templates/page-overview.html
@@ -216,11 +216,9 @@
             </div>
             <div class="contribution-calendar-legend">
                 <span>Less</span>
-                <div class="contribution-calendar-cell level-0"></div>
-                <div class="contribution-calendar-cell level-1"></div>
-                <div class="contribution-calendar-cell level-2"></div>
-                <div class="contribution-calendar-cell level-3"></div>
-                <div class="contribution-calendar-cell level-4"></div>
+                <template x-for="lvl in calendarLegendLevels()" :key="lvl">
+                    <div class="contribution-calendar-cell" :class="'level-' + lvl"></div>
+                </template>
                 <span>More</span>
             </div>
         </div>


### PR DESCRIPTION
## Summary

Refines the dashboard's GitHub-style **Activity** calendar and the live **token throughput** chart's day markers.

### Activity calendar
- **More gradual gradation.** Replaced the 5-level **log** scale with a **10-level power scale (exponent 0.7)**. Log compressed the busy end, so high-volume days were indistinguishable (a 1M and a 1.5M tokens/day both pinned to the top shade). Power 0.7 keeps big days separated while still lifting quiet days off the lightest level. With a 1.5M max: 1M→L8, 1.25M→L9, 1.5M→L10.
- **Green → prompt-cache blue.** The ramp is now a graduated blue derived from `--info` (the prompt-cache blue), across the dark and both light theme blocks. Legend is now data-driven so it always mirrors the grid.
- **Sunday alignment fix.** Week columns were aligned to Monday (ISO), so the top row held Monday while the `Mon` label lined up with the second row. Now aligned to Sunday → rows read Sun..Sat, matching the `Mon/Wed/Fri` labels (GitHub style). Applied to both `buildCalendarGrid` and `calendarMonthLabels`.

### Live token throughput chart
- The day-boundary divider line + date label were drawn in the muted axis color (`--chart-text`) at low opacity, so they were faint. They now use a new high-contrast `--chart-day-marker` color (the primary text color: bright on dark, dark on light) at higher opacity — the date label especially is now legible.

## User-visible impact
Dashboard-only (Overview page). No API or provider behavior changes.

## Tests
`contribution-calendar.test.cjs` updated for the new scale; added legend-coverage and Sunday-first regression tests. **8/8 pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the contribution calendar intensity range to fully cover levels **0–10**, with matching footer legend entries.
  * Improved visual theming for charts/calendar (including unified day-marker color) for consistent dark/light/system appearance.
* **Bug Fixes**
  * Fixed contribution calendar layout to use **Sunday-first** weekly alignment and consistent month labels.
  * Updated calendar intensity scaling for smoother, more accurate heatmap levels.
  * Refined overview chart stacking behavior and enhanced tooltips to better summarize totals.
  * Improved day separator line styling/opacity and date label rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->