### PR TITLE
fix: redact provider api keys, bound cache writers, harden pgvector init

### DIFF
--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -296,6 +296,8 @@ func displayAuditProviderName(providerName, provider string) string {
 var RedactedHeaders = []string{
 	"authorization",
 	"x-api-key",
+	"api-key",        // Azure OpenAI credential header
+	"x-goog-api-key", // Google Gemini / Vertex credential header
 	"cookie",
 	"set-cookie",
 	"x-auth-token",

--- a/internal/auditlog/auditlog_test.go
+++ b/internal/auditlog/auditlog_test.go
@@ -124,6 +124,19 @@ func TestRedactHeaders(t *testing.T) {
 				"X-API-KEY":     "[REDACTED]",
 			},
 		},
+		{
+			name: "redact provider credential headers",
+			input: map[string]string{
+				"api-key":        "azure-secret",
+				"X-Goog-Api-Key": "gemini-secret",
+				"Content-Type":   "application/json",
+			},
+			expected: map[string]string{
+				"api-key":        "[REDACTED]",
+				"X-Goog-Api-Key": "[REDACTED]",
+				"Content-Type":   "application/json",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/core/batch_json.go
+++ b/internal/core/batch_json.go
@@ -35,21 +35,10 @@ func (r *BatchRequest) UnmarshalJSON(data []byte) error {
 }
 
 func (r BatchRequest) MarshalJSON() ([]byte, error) {
-	type batchRequestAlias struct {
-		InputFileID      string             `json:"input_file_id,omitempty"`
-		Endpoint         string             `json:"endpoint,omitempty"`
-		CompletionWindow string             `json:"completion_window,omitempty"`
-		Metadata         map[string]string  `json:"metadata,omitempty"`
-		Requests         []BatchRequestItem `json:"requests,omitempty"`
-	}
-
-	return marshalWithUnknownJSONFields(batchRequestAlias{
-		InputFileID:      r.InputFileID,
-		Endpoint:         r.Endpoint,
-		CompletionWindow: r.CompletionWindow,
-		Metadata:         r.Metadata,
-		Requests:         r.Requests,
-	}, r.ExtraFields)
+	// alias inherits BatchRequest's fields and tags but drops MarshalJSON so
+	// json.Marshal does not recurse; ExtraFields (json:"-") is merged separately.
+	type alias BatchRequest
+	return marshalWithUnknownJSONFields(alias(r), r.ExtraFields)
 }
 
 func (r *BatchRequestItem) UnmarshalJSON(data []byte) error {

--- a/internal/core/chat_json.go
+++ b/internal/core/chat_json.go
@@ -62,37 +62,11 @@ func (r *ChatRequest) UnmarshalJSON(data []byte) error {
 }
 
 func (r ChatRequest) MarshalJSON() ([]byte, error) {
-	type chatRequestAlias struct {
-		Temperature       *float64         `json:"temperature,omitempty"`
-		TopP              *float64         `json:"top_p,omitempty"`
-		MaxTokens         *int             `json:"max_tokens,omitempty"`
-		Model             string           `json:"model"`
-		Provider          string           `json:"provider,omitempty"`
-		Messages          []Message        `json:"messages"`
-		Tools             []map[string]any `json:"tools,omitempty"`
-		ToolChoice        any              `json:"tool_choice,omitempty"`
-		ParallelToolCalls *bool            `json:"parallel_tool_calls,omitempty"`
-		Stream            bool             `json:"stream,omitempty"`
-		StreamOptions     *StreamOptions   `json:"stream_options,omitempty"`
-		Reasoning         *Reasoning       `json:"reasoning,omitempty"`
-		User              string           `json:"user,omitempty"`
-		ServiceTier       string           `json:"service_tier,omitempty"`
-	}
-
-	return marshalWithUnknownJSONFields(chatRequestAlias{
-		Temperature:       r.Temperature,
-		TopP:              r.TopP,
-		MaxTokens:         r.MaxTokens,
-		Model:             r.Model,
-		Provider:          r.Provider,
-		Messages:          r.Messages,
-		Tools:             r.Tools,
-		ToolChoice:        r.ToolChoice,
-		ParallelToolCalls: r.ParallelToolCalls,
-		Stream:            r.Stream,
-		StreamOptions:     r.StreamOptions,
-		Reasoning:         r.Reasoning,
-		User:              r.User,
-		ServiceTier:       r.ServiceTier,
-	}, r.ExtraFields)
+	// alias inherits every field (and json tag) from ChatRequest but drops the
+	// MarshalJSON method, so json.Marshal uses default struct encoding without
+	// recursing. ExtraFields is json:"-", so it is skipped here and merged in
+	// separately. Adding a typed field to ChatRequest therefore round-trips
+	// automatically instead of being silently dropped.
+	type alias ChatRequest
+	return marshalWithUnknownJSONFields(alias(r), r.ExtraFields)
 }

--- a/internal/core/embeddings_json.go
+++ b/internal/core/embeddings_json.go
@@ -35,19 +35,8 @@ func (r *EmbeddingRequest) UnmarshalJSON(data []byte) error {
 }
 
 func (r EmbeddingRequest) MarshalJSON() ([]byte, error) {
-	type embeddingRequestAlias struct {
-		Model          string `json:"model"`
-		Provider       string `json:"provider,omitempty"`
-		Input          any    `json:"input"`
-		EncodingFormat string `json:"encoding_format,omitempty"`
-		Dimensions     *int   `json:"dimensions,omitempty"`
-	}
-
-	return marshalWithUnknownJSONFields(embeddingRequestAlias{
-		Model:          r.Model,
-		Provider:       r.Provider,
-		Input:          r.Input,
-		EncodingFormat: r.EncodingFormat,
-		Dimensions:     r.Dimensions,
-	}, r.ExtraFields)
+	// alias inherits EmbeddingRequest's fields and tags but drops MarshalJSON so
+	// json.Marshal does not recurse; ExtraFields (json:"-") is merged separately.
+	type alias EmbeddingRequest
+	return marshalWithUnknownJSONFields(alias(r), r.ExtraFields)
 }

--- a/internal/core/message_json.go
+++ b/internal/core/message_json.go
@@ -151,17 +151,12 @@ func (t *ToolCall) UnmarshalJSON(data []byte) error {
 }
 
 // ToolCall.MarshalJSON marshals a ToolCall to JSON, including unknown JSON
-// members from ExtraFields.
+// members from ExtraFields. alias inherits ToolCall's fields and tags but drops
+// MarshalJSON so json.Marshal does not recurse; ExtraFields (json:"-") is merged
+// separately.
 func (t ToolCall) MarshalJSON() ([]byte, error) {
-	return marshalWithUnknownJSONFields(struct {
-		ID       string       `json:"id"`
-		Type     string       `json:"type"`
-		Function FunctionCall `json:"function"`
-	}{
-		ID:       t.ID,
-		Type:     t.Type,
-		Function: t.Function,
-	}, t.ExtraFields)
+	type alias ToolCall
+	return marshalWithUnknownJSONFields(alias(t), t.ExtraFields)
 }
 
 // FunctionCall.UnmarshalJSON unmarshals a FunctionCall from JSON, preserving
@@ -189,15 +184,12 @@ func (f *FunctionCall) UnmarshalJSON(data []byte) error {
 }
 
 // FunctionCall.MarshalJSON marshals a FunctionCall to JSON, including unknown
-// JSON members from ExtraFields.
+// JSON members from ExtraFields. alias inherits FunctionCall's fields and tags
+// but drops MarshalJSON so json.Marshal does not recurse; ExtraFields (json:"-")
+// is merged separately.
 func (f FunctionCall) MarshalJSON() ([]byte, error) {
-	return marshalWithUnknownJSONFields(struct {
-		Name      string `json:"name"`
-		Arguments string `json:"arguments"`
-	}{
-		Name:      f.Name,
-		Arguments: f.Arguments,
-	}, f.ExtraFields)
+	type alias FunctionCall
+	return marshalWithUnknownJSONFields(alias(f), f.ExtraFields)
 }
 
 func marshalMessageContent(raw MessageContent, toolCalls []ToolCall) (any, error) {

--- a/internal/core/responses_json.go
+++ b/internal/core/responses_json.go
@@ -192,64 +192,12 @@ func (c ResponsesConversationRef) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalJSON preserves dynamic input payloads while supporting Swagger-only schema fields.
+// alias inherits every field and json tag from ResponsesRequest but drops the
+// MarshalJSON method (so json.Marshal does not recurse); ExtraFields is json:"-"
+// and merged in separately. New typed fields round-trip automatically.
 func (r ResponsesRequest) MarshalJSON() ([]byte, error) {
-	return marshalWithUnknownJSONFields(struct {
-		Model                string                    `json:"model"`
-		Provider             string                    `json:"provider,omitempty"`
-		Input                any                       `json:"input"`
-		Instructions         string                    `json:"instructions,omitempty"`
-		Tools                []map[string]any          `json:"tools,omitempty"`
-		ToolChoice           any                       `json:"tool_choice,omitempty"`
-		ParallelToolCalls    *bool                     `json:"parallel_tool_calls,omitempty"`
-		Temperature          *float64                  `json:"temperature,omitempty"`
-		TopP                 *float64                  `json:"top_p,omitempty"`
-		TopLogprobs          *int                      `json:"top_logprobs,omitempty"`
-		MaxOutputTokens      *int                      `json:"max_output_tokens,omitempty"`
-		Stream               bool                      `json:"stream,omitempty"`
-		StreamOptions        *StreamOptions            `json:"stream_options,omitempty"`
-		Metadata             map[string]string         `json:"metadata,omitempty"`
-		Reasoning            *Reasoning                `json:"reasoning,omitempty"`
-		Text                 any                       `json:"text,omitempty"`
-		Include              []string                  `json:"include,omitempty"`
-		Truncation           string                    `json:"truncation,omitempty"`
-		Store                *bool                     `json:"store,omitempty"`
-		PreviousResponseID   string                    `json:"previous_response_id,omitempty"`
-		Conversation         *ResponsesConversationRef `json:"conversation,omitempty"`
-		Prompt               any                       `json:"prompt,omitempty"`
-		PromptCacheRetention string                    `json:"prompt_cache_retention,omitempty"`
-		ContextManagement    any                       `json:"context_management,omitempty"`
-		User                 string                    `json:"user,omitempty"`
-		ServiceTier          string                    `json:"service_tier,omitempty"`
-		SafetyIdentifier     string                    `json:"safety_identifier,omitempty"`
-	}{
-		Model:                r.Model,
-		Provider:             r.Provider,
-		Input:                r.Input,
-		Instructions:         r.Instructions,
-		Tools:                r.Tools,
-		ToolChoice:           r.ToolChoice,
-		ParallelToolCalls:    r.ParallelToolCalls,
-		Temperature:          r.Temperature,
-		TopP:                 r.TopP,
-		TopLogprobs:          r.TopLogprobs,
-		MaxOutputTokens:      r.MaxOutputTokens,
-		Stream:               r.Stream,
-		StreamOptions:        r.StreamOptions,
-		Metadata:             r.Metadata,
-		Reasoning:            r.Reasoning,
-		Text:                 r.Text,
-		Include:              r.Include,
-		Truncation:           r.Truncation,
-		Store:                r.Store,
-		PreviousResponseID:   r.PreviousResponseID,
-		Conversation:         r.Conversation,
-		Prompt:               r.Prompt,
-		PromptCacheRetention: r.PromptCacheRetention,
-		ContextManagement:    r.ContextManagement,
-		User:                 r.User,
-		ServiceTier:          r.ServiceTier,
-		SafetyIdentifier:     r.SafetyIdentifier,
-	}, r.ExtraFields)
+	type alias ResponsesRequest
+	return marshalWithUnknownJSONFields(alias(r), r.ExtraFields)
 }
 
 type responseUtilityRequestJSON struct {

--- a/internal/gateway/batch_usage.go
+++ b/internal/gateway/batch_usage.go
@@ -54,6 +54,13 @@ func LogBatchUsageFromBatchResults(
 	hasOutputCost := false
 	hasTotalCost := false
 
+	// A batch can carry tens of thousands of items that mostly share a
+	// (model, provider) pair. ResolvePricing takes registry read locks on every
+	// call, so cache resolutions locally to keep this loop off the shared
+	// registry hot path. nil results are cached too so unpriced models resolve
+	// once.
+	pricingCache := make(map[string]*core.ModelPricing)
+
 	for _, item := range result.Data {
 		if item.StatusCode < http.StatusOK || item.StatusCode >= http.StatusMultipleChoices {
 			continue
@@ -84,7 +91,13 @@ func LogBatchUsageFromBatchResults(
 
 		var pricing *core.ModelPricing
 		if pricingResolver != nil && model != "" {
-			pricing = pricingResolver.ResolvePricing(model, provider)
+			cacheKey := model + "\x00" + provider
+			if cached, ok := pricingCache[cacheKey]; ok {
+				pricing = cached
+			} else {
+				pricing = pricingResolver.ResolvePricing(model, provider)
+				pricingCache[cacheKey] = pricing
+			}
 		}
 
 		entry := usage.ExtractFromSSEUsage(

--- a/internal/gateway/batch_usage.go
+++ b/internal/gateway/batch_usage.go
@@ -59,7 +59,8 @@ func LogBatchUsageFromBatchResults(
 	// call, so cache resolutions locally to keep this loop off the shared
 	// registry hot path. nil results are cached too so unpriced models resolve
 	// once.
-	pricingCache := make(map[string]*core.ModelPricing)
+	type pricingCacheKey struct{ model, provider string }
+	pricingCache := make(map[pricingCacheKey]*core.ModelPricing)
 
 	for _, item := range result.Data {
 		if item.StatusCode < http.StatusOK || item.StatusCode >= http.StatusMultipleChoices {
@@ -91,7 +92,7 @@ func LogBatchUsageFromBatchResults(
 
 		var pricing *core.ModelPricing
 		if pricingResolver != nil && model != "" {
-			cacheKey := model + "\x00" + provider
+			cacheKey := pricingCacheKey{model: model, provider: provider}
 			if cached, ok := pricingCache[cacheKey]; ok {
 				pricing = cached
 			} else {

--- a/internal/responsecache/semantic.go
+++ b/internal/responsecache/semantic.go
@@ -27,6 +27,17 @@ import (
 	"gomodel/internal/embedding"
 )
 
+// semanticCacheWriteJob carries one vector-store insert handed to a background
+// worker. Insert arguments are captured by value so the request goroutine can
+// return immediately.
+type semanticCacheWriteJob struct {
+	cacheKey   string
+	vec        []float32
+	data       []byte
+	paramsHash string
+	ttl        time.Duration
+}
+
 // SemanticCacheMiddleware implements the vector-similarity response cache layer.
 // It is the second cache layer, consulted only after an exact-match miss.
 type semanticCacheMiddleware struct {
@@ -34,17 +45,65 @@ type semanticCacheMiddleware struct {
 	store            VecStore
 	cfg              config.SemanticCacheConfig
 	embedderIdentity string
-	wg               sync.WaitGroup
 	hitRecorder      func(*echo.Context, []byte, string)
+
+	// Vector-store inserts run on a bounded worker pool so a burst of cache
+	// misses cannot spawn unbounded goroutines against the vector store. wg
+	// tracks queued jobs; workers drains them; mu guards closed/close(jobs).
+	jobs    chan semanticCacheWriteJob
+	wg      sync.WaitGroup
+	workers sync.WaitGroup
+	mu      sync.RWMutex
+	closed  bool
 }
 
 func newSemanticCacheMiddleware(emb embedding.Embedder, store VecStore, cfg config.SemanticCacheConfig, hitRecorder func(*echo.Context, []byte, string)) *semanticCacheMiddleware {
-	return &semanticCacheMiddleware{
+	m := &semanticCacheMiddleware{
 		embedder:         emb,
 		store:            store,
 		cfg:              cfg,
 		embedderIdentity: emb.Identity(),
 		hitRecorder:      hitRecorder,
+		jobs:             make(chan semanticCacheWriteJob, cacheWriteQueueSize),
+	}
+	m.startWorkers()
+	return m
+}
+
+func (m *semanticCacheMiddleware) startWorkers() {
+	for range cacheWriteWorkerCount {
+		m.workers.Go(func() {
+			for job := range m.jobs {
+				storeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				err := m.store.Insert(storeCtx, job.cacheKey, job.vec, job.data, job.paramsHash, job.ttl)
+				cancel()
+				if err != nil {
+					slog.Warn("semantic cache: store failed", "key", job.cacheKey, "err", err)
+				}
+				m.wg.Done()
+			}
+		})
+	}
+}
+
+// enqueueWrite hands a store insert to the worker pool. It mirrors
+// simpleCacheMiddleware.enqueueWrite: the read lock spans Add+send so close()
+// cannot race an untracked write, and a full queue rolls back the Add rather
+// than blocking the request goroutine.
+func (m *semanticCacheMiddleware) enqueueWrite(job semanticCacheWriteJob) {
+	m.mu.RLock()
+	if m.closed {
+		m.mu.RUnlock()
+		return
+	}
+	m.wg.Add(1)
+	select {
+	case m.jobs <- job:
+		m.mu.RUnlock()
+	default:
+		m.wg.Done()
+		m.mu.RUnlock()
+		slog.Warn("semantic cache write queue full", "key", job.cacheKey)
 	}
 }
 
@@ -140,20 +199,25 @@ func (m *semanticCacheMiddleware) Handle(c *echo.Context, body []byte, next func
 
 	cacheKey := sha256HexOf(embedText + "\x00" + paramsHash)
 
-	m.wg.Add(1)
-	go func() {
-		defer m.wg.Done()
-		storeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if err := m.store.Insert(storeCtx, cacheKey, vec, data, paramsHash, ttl); err != nil {
-			slog.Warn("semantic cache: store failed", "key", cacheKey, "err", err)
-		}
-	}()
+	m.enqueueWrite(semanticCacheWriteJob{
+		cacheKey:   cacheKey,
+		vec:        vec,
+		data:       data,
+		paramsHash: paramsHash,
+		ttl:        ttl,
+	})
 
 	return nil
 }
 
 func (m *semanticCacheMiddleware) close() error {
+	m.mu.Lock()
+	if !m.closed {
+		m.closed = true
+		close(m.jobs)
+	}
+	m.mu.Unlock()
+	m.workers.Wait()
 	m.wg.Wait()
 	if m.embedder != nil {
 		_ = m.embedder.Close() //nolint:errcheck

--- a/internal/responsecache/vecstore_pgvector.go
+++ b/internal/responsecache/vecstore_pgvector.go
@@ -3,6 +3,7 @@ package responsecache
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -47,8 +48,16 @@ func newPGVectorStore(cfg config.PGVectorConfig) (*pgVecStore, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	if _, err := pool.Exec(ctx, `CREATE EXTENSION IF NOT EXISTS vector`); err != nil {
-		pool.Close()
-		return nil, fmt.Errorf("vecstore pgvector: create extension: %w", err)
+		// Managed Postgres (RDS, Cloud SQL, Heroku) often withholds CREATE
+		// EXTENSION from the application role even when a DBA has already
+		// installed pgvector. Tolerate the error only when the extension is
+		// actually present; otherwise it is genuinely missing and we cannot
+		// proceed.
+		if !pgExtensionInstalled(ctx, pool, "vector") {
+			pool.Close()
+			return nil, fmt.Errorf("vecstore pgvector: create extension: %w", err)
+		}
+		slog.Warn("vecstore pgvector: could not create the vector extension; continuing because it is already installed", "err", err)
 	}
 	ddl := fmt.Sprintf(`
 CREATE TABLE IF NOT EXISTS %s (
@@ -75,6 +84,17 @@ CREATE TABLE IF NOT EXISTS %s (
 	}
 	s.cleanup = startVecCleanup(s)
 	return s, nil
+}
+
+// pgExtensionInstalled reports whether a Postgres extension is already present.
+// A query error is treated as "not installed" so the caller surfaces the
+// original CREATE EXTENSION failure rather than masking it.
+func pgExtensionInstalled(ctx context.Context, pool *pgxpool.Pool, name string) bool {
+	var exists bool
+	if err := pool.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = $1)`, name).Scan(&exists); err != nil {
+		return false
+	}
+	return exists
 }
 
 func validatePGIdentifier(name string) error {

--- a/internal/responsecache/vecstore_pgvector.go
+++ b/internal/responsecache/vecstore_pgvector.go
@@ -52,8 +52,13 @@ func newPGVectorStore(cfg config.PGVectorConfig) (*pgVecStore, error) {
 		// EXTENSION from the application role even when a DBA has already
 		// installed pgvector. Tolerate the error only when the extension is
 		// actually present; otherwise it is genuinely missing and we cannot
-		// proceed.
-		if !pgExtensionInstalled(ctx, pool, "vector") {
+		// proceed. Use a fresh timeout so a slow CREATE EXTENSION failure that
+		// drained the outer deadline cannot make this check spuriously report
+		// the extension as missing.
+		checkCtx, checkCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		installed := pgExtensionInstalled(checkCtx, pool, "vector")
+		checkCancel()
+		if !installed {
 			pool.Close()
 			return nil, fmt.Errorf("vecstore pgvector: create extension: %w", err)
 		}

--- a/internal/server/stream_support.go
+++ b/internal/server/stream_support.go
@@ -3,7 +3,18 @@ package server
 import (
 	"io"
 	"net/http"
+	"sync"
 )
+
+// streamCopyBufferPool reuses 32KB copy buffers across streaming responses so
+// each concurrent stream does not allocate (and later garbage-collect) its own
+// buffer. Buffers are pooled by pointer to avoid an allocation on Put.
+var streamCopyBufferPool = sync.Pool{
+	New: func() any {
+		buf := make([]byte, 32*1024)
+		return &buf
+	},
+}
 
 func flushStream(w io.Writer, stream io.Reader) error {
 	flusher, canFlush := w.(http.Flusher)
@@ -11,7 +22,9 @@ func flushStream(w io.Writer, stream io.Reader) error {
 		flusher.Flush()
 	}
 
-	buf := make([]byte, 32*1024)
+	bufPtr := streamCopyBufferPool.Get().(*[]byte)
+	defer streamCopyBufferPool.Put(bufPtr)
+	buf := *bufPtr
 	for {
 		n, err := stream.Read(buf)
 		if n > 0 {


### PR DESCRIPTION
Addresses a batch of code-review findings. Each reported item was validated against source before acting; **three were rejected** as incorrect or already handled (see below) and are intentionally not changed.

## Fixed

- **security(auditlog):** redact `api-key` (Azure) and `x-goog-api-key` (Gemini/Vertex) request headers. `azure.go` sets its credential header as `api-key`, which was missing from `RedactedHeaders`, so it could be persisted in cleartext when header logging is enabled. Added both header names + a test case.
- **reliability(responsecache):** the semantic cache spawned an unbounded `go func()` per cache miss straight at the vector store — a miss storm could exhaust connections. Now uses the same bounded worker pool (`cacheWriteWorkerCount=8`, queued, `wg`-tracked, clean shutdown) that the exact cache already uses.
- **reliability(responsecache):** `CREATE EXTENSION vector` aborted startup on managed Postgres (RDS/Cloud SQL/Heroku) where the app role lacks the privilege even when a DBA already installed pgvector. Now tolerates the error **only** when `pg_extension` confirms the extension is present; otherwise still fails loudly.
- **perf(gateway):** batch usage logging called `ResolvePricing` (registry `RLock`) per item, up to ~50k/batch. Added a loop-local `(model, provider)` pricing cache (caches `nil` too).
- **perf(server):** `flushStream` allocated a fresh 32KB buffer per stream; now drawn from a `sync.Pool`.
- **refactor(core):** collapsed hand-written request `MarshalJSON` boilerplate to `type alias` conversions for `ChatRequest`, `ResponsesRequest`, `EmbeddingRequest`, `BatchRequest`, `ToolCall`, `FunctionCall` (−150 lines), removing the silent field-drop risk when new typed fields are added. Output is byte-identical (verified via existing round-trip tests). `Message`/`ResponseMessage` were **intentionally left explicit** — their duplicate `json:"content"` Swagger tag makes a blind alias unsafe.

## Rejected (with evidence)

- **"O(N·M) JSON field lookup" → map:** would regress. The `slices.Contains` design is deliberate and already benchmarked against exactly this map baseline (`json_fields_bench_test.go`); `UnknownJSONFields` exists to avoid per-request map allocations. M is 14–27 and the `gjson` walk dominates.
- **"Redundant map clone helpers":** already delegate to `maps.Clone`. The premise (hand-rolled loops) is stale; they live in 4 packages and carry intent-revealing names/docs.
- **Synchronous budget aggregate SQL → rollup table:** valid scalability concern, but not a safe drive-by fix. `SumUsageCost` is already period-bounded and indexed (`idx_usage_timestamp`, `idx_usage_user_path`). A rollup must also handle hierarchical user-path prefix matching, cache-type exclusion, period boundaries, and resets across 3 storage backends — a dedicated, designed change.

## Testing

- `go build ./...`, `go vet`, and full `go test ./...` pass.
- Pre-commit hooks pass, including `make test-race`, `make lint`, and the hot-path alloc/byte performance guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added audit log redaction for additional provider credential headers.
  * Improved startup behavior when the database vector extension is already installed.

* **Performance**
  * Reduced repeated pricing lookups during batch processing.
  * Improved semantic cache write behavior by using a bounded worker approach.
  * Improved streaming efficiency with reusable buffers.

* **Refactor**
  * Simplified several request/message serialization implementations while preserving existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->