### PR TITLE
fix(gateway): skip failover sweep when request context is done

### DIFF
--- a/internal/gateway/failover.go
+++ b/internal/gateway/failover.go
@@ -48,6 +48,14 @@ func tryFailoverResponse[T any](
 ) (T, string, string, string, bool, error) {
 	var zero T
 
+	// A canceled or expired context means the client is gone or the deadline
+	// passed. A failover call on a done context can never succeed; attempting one
+	// only wastes attempts and charges spurious failures to healthy failover
+	// providers' circuit breakers. Short-circuit to the primary error instead.
+	if ctx.Err() != nil {
+		return zero, "", "", "", false, primaryErr
+	}
+
 	failovers := o.FailoverSelectors(workflow)
 	if len(failovers) == 0 || !ShouldAttemptFailover(primaryErr) {
 		return zero, "", "", "", false, primaryErr
@@ -57,6 +65,10 @@ func tryFailoverResponse[T any](
 	primaryModel := currentSelectorForWorkflow(workflow, model, provider)
 	lastErr := primaryErr
 	for _, selector := range failovers {
+		// Stop sweeping if the client disconnected mid-failover.
+		if ctx.Err() != nil {
+			break
+		}
 		if o.modelAuthorizer != nil && !o.modelAuthorizer.AllowsModel(ctx, selector) {
 			continue
 		}
@@ -144,6 +156,12 @@ func tryFailoverStream(
 	primaryErr error,
 	call func(selector core.ModelSelector, providerType, providerName string) (io.ReadCloser, string, string, error),
 ) (io.ReadCloser, string, string, string, string, error) {
+	// See tryFailoverResponse: never sweep failover targets once the context is
+	// done, or the doomed attempts pollute healthy providers' circuit breakers.
+	if ctx.Err() != nil {
+		return nil, "", "", "", "", primaryErr
+	}
+
 	failovers := o.FailoverSelectors(workflow)
 	if len(failovers) == 0 || !ShouldAttemptFailover(primaryErr) {
 		return nil, "", "", "", "", primaryErr
@@ -153,6 +171,10 @@ func tryFailoverStream(
 	primaryModel := currentSelectorForWorkflow(workflow, model, provider)
 	lastErr := primaryErr
 	for _, selector := range failovers {
+		// Stop sweeping if the client disconnected mid-failover.
+		if ctx.Err() != nil {
+			break
+		}
 		if o.modelAuthorizer != nil && !o.modelAuthorizer.AllowsModel(ctx, selector) {
 			continue
 		}

--- a/internal/gateway/failover_test.go
+++ b/internal/gateway/failover_test.go
@@ -1,11 +1,111 @@
 package gateway
 
 import (
+	"context"
+	"errors"
+	"io"
 	"net/http"
 	"testing"
 
 	"gomodel/internal/core"
 )
+
+// stubFailoverResolver returns a fixed selector list regardless of input.
+type stubFailoverResolver struct {
+	selectors []core.ModelSelector
+}
+
+func (s stubFailoverResolver) ResolveFailovers(_ *core.RequestModelResolution, _ core.Operation) []core.ModelSelector {
+	return s.selectors
+}
+
+func failoverTestFixture() (*InferenceOrchestrator, *core.Workflow) {
+	o := &InferenceOrchestrator{
+		failoverResolver: stubFailoverResolver{
+			selectors: []core.ModelSelector{{Provider: "openai", Model: "gpt-5"}},
+		},
+	}
+	workflow := &core.Workflow{
+		Endpoint:   core.EndpointDescriptor{Operation: core.OperationChatCompletions},
+		Resolution: &core.RequestModelResolution{},
+	}
+	return o, workflow
+}
+
+// A canceled context means the client is gone; failover must not sweep providers
+// (doing so wastes attempts and trips healthy providers' circuit breakers).
+func TestTryFailoverResponseSkipsWhenContextCanceled(t *testing.T) {
+	o, workflow := failoverTestFixture()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	primaryErr := core.NewProviderError("openai", http.StatusBadGateway, "context canceled", context.Canceled)
+	called := false
+	call := func(core.ModelSelector, string, string) (string, string, error) {
+		called = true
+		return "", "", core.NewProviderError("openai", http.StatusBadGateway, "unexpected failover call", nil)
+	}
+
+	_, _, _, _, didFailover, err := tryFailoverResponse(ctx, o, workflow, "openai/gpt-4o", "openai", primaryErr, call)
+
+	if called {
+		t.Fatal("tryFailoverResponse invoked a failover provider on a canceled context; it must short-circuit")
+	}
+	if didFailover {
+		t.Fatalf("didFailover = true, want false when context is canceled")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want the primary error wrapping context.Canceled", err)
+	}
+}
+
+// The guard is scoped to a done context: a live request still attempts failover.
+func TestTryFailoverResponseAttemptsWhenContextLive(t *testing.T) {
+	o, workflow := failoverTestFixture()
+
+	primaryErr := core.NewProviderError("openai", http.StatusInternalServerError, "primary boom", nil)
+	called := false
+	call := func(core.ModelSelector, string, string) (string, string, error) {
+		called = true
+		return "ok", "openai", nil
+	}
+
+	resp, _, _, _, didFailover, err := tryFailoverResponse(context.Background(), o, workflow, "openai/gpt-4o", "openai", primaryErr, call)
+
+	if !called {
+		t.Fatal("tryFailoverResponse did not attempt failover on a live context")
+	}
+	if !didFailover || err != nil || resp != "ok" {
+		t.Fatalf("failover result = (resp:%q didFailover:%v err:%v), want (ok true <nil>)", resp, didFailover, err)
+	}
+}
+
+func TestTryFailoverStreamSkipsWhenContextCanceled(t *testing.T) {
+	o, workflow := failoverTestFixture()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	primaryErr := core.NewProviderError("openai", http.StatusBadGateway, "context canceled", context.Canceled)
+	called := false
+	call := func(core.ModelSelector, string, string) (io.ReadCloser, string, string, error) {
+		called = true
+		return nil, "", "", core.NewProviderError("openai", http.StatusBadGateway, "unexpected failover call", nil)
+	}
+
+	stream, _, _, _, _, err := tryFailoverStream(ctx, o, workflow, "openai/gpt-4o", "openai", primaryErr, call)
+
+	if called {
+		t.Fatal("tryFailoverStream invoked a failover provider on a canceled context; it must short-circuit")
+	}
+	if stream != nil {
+		t.Fatal("tryFailoverStream returned a stream on a canceled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want the primary error wrapping context.Canceled", err)
+	}
+}
 
 func TestShouldAttemptFailover(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

Fixes a correctness bug in the translated-route failover path (surfaced during pre-release testing of #444/#450/#451): a **client disconnect or expired deadline triggers a doomed failover sweep that trips healthy providers' circuit breakers**.

When the client goes away mid-request, `http.Client.Do` returns `context.Canceled`, which the provider client maps to a **502**. `ShouldAttemptFailover` treats any `>=500` as retryable and never consulted the context, so the primary failure kicked off a full failover sweep over **every** configured target — on an already-dead context. Each attempt failed instantly but still:

- recorded a `ProviderAttempt` and published a live audit event, and
- charged a failure to that failover provider's **circuit breaker** (`recordCircuitBreakerCompletion` records a failure for *any* non-nil error).

So a burst of client disconnects could open circuit breakers on providers that were never actually unhealthy. **Streaming is always affected**; non-streaming is affected when retries are exhausted/disabled.

## Fix

Guard both `tryFailoverResponse` and `tryFailoverStream` on `ctx.Err()`:

- short-circuit to the primary error before the sweep, and
- break out of the loop if the client disconnects partway through.

A failover call on a done context can never succeed, so this removes no working behavior — it only avoids doomed attempts and the circuit-breaker pollution they cause.

## User-visible impact

- Client disconnects / deadline expiries no longer degrade failover-provider health or flood the audit/live-log layer with phantom failed attempts.
- No change to failover behavior for genuine upstream failures on a live request.

## Tests

- `TestTryFailoverResponseSkipsWhenContextCanceled` / `TestTryFailoverStreamSkipsWhenContextCanceled` — assert no provider call happens on a canceled context (both **fail without this patch**, verified).
- `TestTryFailoverResponseAttemptsWhenContextLive` — positive control: a live context still attempts failover (guards against over-blocking).

Verified locally: full build, `go test -race ./internal/gateway/...`, `golangci-lint` (0 issues), and the hot-path perf guard all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failover now stops immediately when a request has been canceled or has expired, returning the original error instead of continuing retries.
  * Streaming and non-streaming requests both now stop checking additional fallback targets once the client disconnects.
  * This helps avoid unnecessary work and reduces delays after a request is no longer active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->