### PR TITLE
perf: cut hot-path allocations across streaming, live logs, and request adaptation

### DIFF
--- a/internal/auditlog/stream_observer.go
+++ b/internal/auditlog/stream_observer.go
@@ -51,6 +51,13 @@ func NewStreamLogObserver(logger LoggerInterface, entry *LogEntry, path string) 
 	}
 }
 
+// WantsJSONEvent reports whether this observer consumes stream payloads at
+// all. With body capture disabled it consumes none, letting the observed
+// stream skip per-chunk JSON decoding on its behalf.
+func (o *StreamLogObserver) WantsJSONEvent([]byte) bool {
+	return o.logBodies && o.builder != nil
+}
+
 func (o *StreamLogObserver) OnJSONEvent(event map[string]any) {
 	if !o.logBodies || o.builder == nil {
 		return

--- a/internal/live/broker.go
+++ b/internal/live/broker.go
@@ -77,11 +77,15 @@ type Broker struct {
 	subscriberBuffer int
 	heartbeat        time.Duration
 
-	mu          sync.Mutex
-	nextSeq     uint64
-	nextSubID   uint64
-	closed      bool
+	mu        sync.Mutex
+	nextSeq   uint64
+	nextSubID uint64
+	closed    bool
+	// events is a circular buffer of the most recent events. While it is
+	// filling, head is 0 and events are ordered; once full, head indexes the
+	// oldest event and each publish overwrites it in place (O(1)).
 	events      []Event
+	head        int
 	subscribers map[uint64]chan Event
 	activeAudit map[string]Event
 	activeUsage map[string]Event
@@ -169,30 +173,45 @@ func (b *Broker) Subscribe(cursor uint64) *Subscription {
 }
 
 func (b *Broker) replayAfterLocked(cursor uint64) ([]Event, bool) {
+	count := len(b.events)
 	if cursor == 0 {
 		return b.activeSnapshotsLocked(), false
 	}
-	if len(b.events) == 0 {
+	if count == 0 {
 		return b.activeSnapshotsLocked(), true
 	}
-	latest := b.events[len(b.events)-1].Seq
+	latest := b.eventAtLocked(count - 1).Seq
 	if cursor > latest {
 		return b.activeSnapshotsLocked(), true
 	}
-	oldest := b.events[0].Seq
+	oldest := b.eventAtLocked(0).Seq
 	if cursor < oldest-1 {
 		return b.activeSnapshotsLocked(), true
 	}
 	if cursor < latest && latest-cursor > uint64(b.replayLimit) {
 		return b.activeSnapshotsLocked(), true
 	}
-	replay := make([]Event, 0, min(len(b.events), b.replayLimit))
-	for _, event := range b.events {
-		if event.Seq > cursor {
-			replay = append(replay, event)
-		}
+	// Sequences are consecutive within the buffer, so the first event after
+	// the cursor sits at a computable offset from the oldest.
+	start := 0
+	if cursor >= oldest {
+		start = int(cursor - oldest + 1)
+	}
+	replay := make([]Event, 0, count-start)
+	for i := start; i < count; i++ {
+		replay = append(replay, b.eventAtLocked(i))
 	}
 	return replay, false
+}
+
+// eventAtLocked returns the i-th event in publish order (0 = oldest).
+// Caller must hold b.mu.
+func (b *Broker) eventAtLocked(i int) Event {
+	idx := b.head + i
+	if idx >= len(b.events) {
+		idx -= len(b.events)
+	}
+	return b.events[idx]
 }
 
 func (b *Broker) activeSnapshotsLocked() []Event {
@@ -240,7 +259,7 @@ func (b *Broker) Close() {
 	}
 }
 
-func (b *Broker) publish(eventType, requestID string, timestamp time.Time, payload any) {
+func (b *Broker) publish(eventType, entryID, requestID string, timestamp time.Time, payload any) {
 	if b == nil || !b.enabled {
 		return
 	}
@@ -270,15 +289,15 @@ func (b *Broker) publish(eventType, requestID string, timestamp time.Time, paylo
 		Timestamp: timestamp.UTC(),
 		Data:      data,
 	}
-	b.updateActiveSnapshotsLocked(&event)
-	b.events = append(b.events, event)
-	if len(b.events) > b.bufferSize {
-		drop := len(b.events) - b.bufferSize
-		copy(b.events, b.events[drop:])
-		for i := b.bufferSize; i < len(b.events); i++ {
-			b.events[i] = Event{}
+	b.updateActiveSnapshotsLocked(&event, entryID)
+	if len(b.events) < b.bufferSize {
+		b.events = append(b.events, event)
+	} else {
+		b.events[b.head] = event
+		b.head++
+		if b.head == len(b.events) {
+			b.head = 0
 		}
-		b.events = b.events[:b.bufferSize]
 	}
 
 	for id, ch := range b.subscribers {
@@ -291,21 +310,21 @@ func (b *Broker) publish(eventType, requestID string, timestamp time.Time, paylo
 	}
 }
 
-func (b *Broker) updateActiveSnapshotsLocked(event *Event) {
+func (b *Broker) updateActiveSnapshotsLocked(event *Event, entryID string) {
 	if event == nil {
 		return
 	}
 	switch event.Type {
 	case EventAuditFailed, EventAuditFlushed, EventAuditRemoved:
-		deleteActiveSnapshot(b.activeAudit, auditActiveKeys(*event))
+		deleteActiveSnapshot(b.activeAudit, auditActiveKeys(*event, entryID))
 		return
 	case EventUsageFailed, EventUsageFlushed:
-		deleteActiveSnapshot(b.activeUsage, usageActiveKeys(*event))
+		deleteActiveSnapshot(b.activeUsage, usageActiveKeys(*event, entryID))
 		return
 	}
 
 	if strings.HasPrefix(event.Type, "audit.") {
-		keys := auditActiveKeys(*event)
+		keys := auditActiveKeys(*event, entryID)
 		if keys.canonical == "" {
 			return
 		}
@@ -317,7 +336,7 @@ func (b *Broker) updateActiveSnapshotsLocked(event *Event) {
 		return
 	}
 	if strings.HasPrefix(event.Type, "usage.") {
-		keys := usageActiveKeys(*event)
+		keys := usageActiveKeys(*event, entryID)
 		if keys.canonical == "" {
 			return
 		}
@@ -329,23 +348,14 @@ func (b *Broker) updateActiveSnapshotsLocked(event *Event) {
 	}
 }
 
-type eventIdentity struct {
-	ID        string `json:"id"`
-	RequestID string `json:"request_id"`
-}
-
 type activeSnapshotKeys struct {
 	canonical string
 	aliases   []string
 }
 
-func auditActiveKeys(event Event) activeSnapshotKeys {
-	identity := eventIdentityFromData(event.Data)
+func auditActiveKeys(event Event, id string) activeSnapshotKeys {
 	requestID := strings.TrimSpace(event.RequestID)
-	if requestID == "" {
-		requestID = strings.TrimSpace(identity.RequestID)
-	}
-	id := strings.TrimSpace(identity.ID)
+	id = strings.TrimSpace(id)
 	keys := activeSnapshotKeys{}
 	if requestID != "" {
 		keys.canonical = "request:" + requestID
@@ -360,13 +370,9 @@ func auditActiveKeys(event Event) activeSnapshotKeys {
 	return keys
 }
 
-func usageActiveKeys(event Event) activeSnapshotKeys {
-	identity := eventIdentityFromData(event.Data)
-	id := strings.TrimSpace(identity.ID)
+func usageActiveKeys(event Event, id string) activeSnapshotKeys {
+	id = strings.TrimSpace(id)
 	requestID := strings.TrimSpace(event.RequestID)
-	if requestID == "" {
-		requestID = strings.TrimSpace(identity.RequestID)
-	}
 	keys := activeSnapshotKeys{}
 	if id != "" {
 		keys.canonical = "id:" + id
@@ -406,12 +412,6 @@ func deleteActiveSnapshotAliases(snapshots map[string]Event, keys activeSnapshot
 	for _, key := range keys.aliases {
 		delete(snapshots, key)
 	}
-}
-
-func eventIdentityFromData(data json.RawMessage) eventIdentity {
-	var identity eventIdentity
-	_ = json.Unmarshal(data, &identity)
-	return identity
 }
 
 func mergeEventData(base, patch json.RawMessage) json.RawMessage {
@@ -461,7 +461,7 @@ func (b *Broker) PublishAuditEvent(eventType string, entry *auditlog.LogEntry) {
 		return
 	}
 	payload := auditPreviewFromEntry(eventType, entry)
-	b.publish(eventType, entry.RequestID, entry.Timestamp, payload)
+	b.publish(eventType, entry.ID, entry.RequestID, entry.Timestamp, payload)
 }
 
 // PublishUsageEvent publishes a compact usage log event. Cached usage entries
@@ -472,7 +472,7 @@ func (b *Broker) PublishUsageEvent(eventType string, entry *usage.UsageEntry) {
 		return
 	}
 	payload := usagePreviewFromEntry(entry)
-	b.publish(eventType, entry.RequestID, entry.Timestamp, payload)
+	b.publish(eventType, entry.ID, entry.RequestID, entry.Timestamp, payload)
 }
 
 type auditPreview struct {

--- a/internal/live/broker.go
+++ b/internal/live/broker.go
@@ -414,6 +414,8 @@ func deleteActiveSnapshotAliases(snapshots map[string]Event, keys activeSnapshot
 	}
 }
 
+// mergeEventData recursively merges two JSON objects, with patch members
+// winning on conflict. Whenever either side is not a JSON object, patch wins.
 func mergeEventData(base, patch json.RawMessage) json.RawMessage {
 	var baseObject map[string]json.RawMessage
 	var patchObject map[string]json.RawMessage
@@ -424,29 +426,7 @@ func mergeEventData(base, patch json.RawMessage) json.RawMessage {
 		return append(json.RawMessage(nil), patch...)
 	}
 	for key, value := range patchObject {
-		baseObject[key] = mergeEventDataValue(baseObject[key], value)
-	}
-	merged, err := json.Marshal(baseObject)
-	if err != nil {
-		return append(json.RawMessage(nil), patch...)
-	}
-	return merged
-}
-
-func mergeEventDataValue(base, patch json.RawMessage) json.RawMessage {
-	if len(base) == 0 || len(patch) == 0 {
-		return append(json.RawMessage(nil), patch...)
-	}
-	var baseObject map[string]json.RawMessage
-	var patchObject map[string]json.RawMessage
-	if err := json.Unmarshal(base, &baseObject); err != nil || baseObject == nil {
-		return append(json.RawMessage(nil), patch...)
-	}
-	if err := json.Unmarshal(patch, &patchObject); err != nil || patchObject == nil {
-		return append(json.RawMessage(nil), patch...)
-	}
-	for key, value := range patchObject {
-		baseObject[key] = mergeEventDataValue(baseObject[key], value)
+		baseObject[key] = mergeEventData(baseObject[key], value)
 	}
 	merged, err := json.Marshal(baseObject)
 	if err != nil {

--- a/internal/live/broker.go
+++ b/internal/live/broker.go
@@ -281,6 +281,9 @@ func (b *Broker) publish(eventType, entryID, requestID string, timestamp time.Ti
 		return
 	}
 
+	// Invariant: every assigned sequence is buffered, so sequences inside the
+	// ring are gapless — replayAfterLocked's offset arithmetic depends on it.
+	// Do not return between the increment and the ring write below.
 	b.nextSeq++
 	event := Event{
 		Seq:       b.nextSeq,

--- a/internal/live/broker_test.go
+++ b/internal/live/broker_test.go
@@ -141,11 +141,11 @@ func TestBrokerNormalizesAuditActiveSnapshotAliases(t *testing.T) {
 	b := NewBroker(Config{Enabled: true})
 	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
 
-	b.publish(EventAuditUpdated, "", now, map[string]any{
+	b.publish(EventAuditUpdated, "audit-1", "", now, map[string]any{
 		"id":     "audit-1",
 		"method": "POST",
 	})
-	b.publish(EventAuditUpdated, "req-1", now.Add(time.Second), map[string]any{
+	b.publish(EventAuditUpdated, "audit-1", "req-1", now.Add(time.Second), map[string]any{
 		"id":         "audit-1",
 		"request_id": "req-1",
 		"provider":   "openai",
@@ -168,7 +168,7 @@ func TestBrokerNormalizesAuditActiveSnapshotAliases(t *testing.T) {
 		t.Fatalf("snapshot provider = %v, want openai", got)
 	}
 
-	b.publish(EventAuditFlushed, "", now.Add(2*time.Second), map[string]any{
+	b.publish(EventAuditFlushed, "audit-1", "req-1", now.Add(2*time.Second), map[string]any{
 		"id":         "audit-1",
 		"request_id": "req-1",
 	})
@@ -186,11 +186,11 @@ func TestBrokerNormalizesUsageActiveSnapshotAliases(t *testing.T) {
 	b := NewBroker(Config{Enabled: true})
 	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
 
-	b.publish(EventUsageCompleted, "req-1", now, map[string]any{
+	b.publish(EventUsageCompleted, "", "req-1", now, map[string]any{
 		"request_id":   "req-1",
 		"total_tokens": 14,
 	})
-	b.publish(EventUsageCompleted, "", now.Add(time.Second), map[string]any{
+	b.publish(EventUsageCompleted, "usage-1", "req-1", now.Add(time.Second), map[string]any{
 		"id":         "usage-1",
 		"request_id": "req-1",
 		"model":      "gpt-test",
@@ -213,7 +213,7 @@ func TestBrokerNormalizesUsageActiveSnapshotAliases(t *testing.T) {
 		t.Fatalf("snapshot model = %v, want gpt-test", got)
 	}
 
-	b.publish(EventUsageFlushed, "", now.Add(2*time.Second), map[string]any{
+	b.publish(EventUsageFlushed, "usage-1", "req-1", now.Add(2*time.Second), map[string]any{
 		"id":         "usage-1",
 		"request_id": "req-1",
 	})
@@ -752,4 +752,26 @@ func eventPayload(t *testing.T, event Event) map[string]any {
 		t.Fatalf("unmarshal event payload: %v", err)
 	}
 	return payload
+}
+
+// BenchmarkBrokerPublishSteadyState measures publish cost once the replay
+// buffer is full — the steady state under sustained traffic.
+func BenchmarkBrokerPublishSteadyState(b *testing.B) {
+	broker := NewBroker(Config{Enabled: true, BufferSize: 10000, ReplayLimit: 1000})
+	entry := &usage.UsageEntry{
+		ID:        "usage-bench",
+		RequestID: "req-bench",
+		Timestamp: time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC),
+		Model:     "gpt-test",
+		Provider:  "openai",
+	}
+	for i := 0; i < 10001; i++ {
+		broker.PublishUsageEvent(EventUsageFlushed, entry)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		broker.PublishUsageEvent(EventUsageFlushed, entry)
+	}
 }

--- a/internal/live/broker_test.go
+++ b/internal/live/broker_test.go
@@ -775,3 +775,66 @@ func BenchmarkBrokerPublishSteadyState(b *testing.B) {
 		broker.PublishUsageEvent(EventUsageFlushed, entry)
 	}
 }
+
+// TestBrokerReplayAfterBufferWrap fills the circular replay buffer past
+// capacity so the head index has advanced, then checks replay content and
+// ordering for cursors inside and outside the retained window.
+func TestBrokerReplayAfterBufferWrap(t *testing.T) {
+	b := NewBroker(Config{Enabled: true, BufferSize: 4, ReplayLimit: 4})
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+
+	// Publish 6 usage-flushed events (seq 1..6); the buffer retains seq 3..6
+	// with the ring head pointing mid-slice.
+	for i := 0; i < 6; i++ {
+		b.PublishUsageEvent(EventUsageFlushed, &usage.UsageEntry{
+			ID:        "usage-wrap",
+			RequestID: "req-wrap",
+			Timestamp: now.Add(time.Duration(i) * time.Second),
+		})
+	}
+
+	sub := b.Subscribe(4)
+	if sub == nil {
+		t.Fatal("Subscribe returned nil")
+	}
+	defer sub.Close()
+	if sub.Reset {
+		t.Fatal("Subscribe reset = true, want false for cursor inside retained window")
+	}
+	if len(sub.Replay) != 2 {
+		t.Fatalf("replay len = %d, want 2", len(sub.Replay))
+	}
+	for i, wantSeq := range []uint64{5, 6} {
+		if got := sub.Replay[i].Seq; got != wantSeq {
+			t.Fatalf("replay[%d].Seq = %d, want %d", i, got, wantSeq)
+		}
+	}
+
+	// Cursor exactly one before the oldest retained event replays the whole window.
+	subFull := b.Subscribe(2)
+	if subFull == nil {
+		t.Fatal("Subscribe(2) returned nil")
+	}
+	defer subFull.Close()
+	if subFull.Reset {
+		t.Fatal("Subscribe(2) reset = true, want false")
+	}
+	if len(subFull.Replay) != 4 {
+		t.Fatalf("full replay len = %d, want 4", len(subFull.Replay))
+	}
+	for i, wantSeq := range []uint64{3, 4, 5, 6} {
+		if got := subFull.Replay[i].Seq; got != wantSeq {
+			t.Fatalf("full replay[%d].Seq = %d, want %d", i, got, wantSeq)
+		}
+	}
+
+	// A cursor older than the retained window resets to active snapshots.
+	subStale := b.Subscribe(1)
+	if subStale == nil {
+		t.Fatal("Subscribe(1) returned nil")
+	}
+	defer subStale.Close()
+	if !subStale.Reset {
+		t.Fatal("Subscribe(1) reset = false, want true for cursor before retained window")
+	}
+}

--- a/internal/providers/anthropic/chat_stream.go
+++ b/internal/providers/anthropic/chat_stream.go
@@ -3,7 +3,6 @@ package anthropic
 import (
 	"bufio"
 	"context"
-	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -44,6 +43,7 @@ type streamConverter struct {
 	body              io.ReadCloser
 	model             string
 	msgID             string
+	created           int64
 	nextToolCallIndex int
 	toolCalls         map[int]*streamToolCallState
 	thinkingBlocks    map[int]bool // tracks which content block indices are thinking blocks
@@ -68,6 +68,7 @@ func newStreamConverter(body io.ReadCloser, model string) *streamConverter {
 		reader:         bufio.NewReader(body),
 		body:           body,
 		model:          model,
+		created:        time.Now().Unix(),
 		toolCalls:      make(map[int]*streamToolCallState),
 		thinkingBlocks: make(map[int]bool),
 		buffer:         streaming.NewStreamBuffer(1024),
@@ -162,7 +163,7 @@ func (sc *streamConverter) formatChatChunk(delta map[string]any, finishReason an
 	chunk := map[string]any{
 		"id":       sc.msgID,
 		"object":   "chat.completion.chunk",
-		"created":  time.Now().Unix(),
+		"created":  sc.created,
 		"model":    sc.model,
 		"provider": "anthropic",
 		"choices": []map[string]any{
@@ -183,7 +184,7 @@ func (sc *streamConverter) formatChatChunk(delta map[string]any, finishReason an
 		return ""
 	}
 
-	return fmt.Sprintf("data: %s\n\n", jsonData)
+	return "data: " + string(jsonData) + "\n\n"
 }
 
 func (sc *streamConverter) convertEvent(event *anthropicStreamEvent) string {

--- a/internal/providers/anthropic/chat_stream.go
+++ b/internal/providers/anthropic/chat_stream.go
@@ -4,15 +4,13 @@ import (
 	"bufio"
 	"context"
 	"io"
-	"log/slog"
 	"net/http"
 	"strings"
 	"time"
 
-	"github.com/goccy/go-json"
-
 	"gomodel/internal/core"
 	"gomodel/internal/llmclient"
+	"gomodel/internal/providers"
 	"gomodel/internal/streaming"
 )
 
@@ -160,31 +158,7 @@ func (sc *streamConverter) mapStreamStopReason(reason string) string {
 }
 
 func (sc *streamConverter) formatChatChunk(delta map[string]any, finishReason any, usage *anthropicUsage) string {
-	chunk := map[string]any{
-		"id":       sc.msgID,
-		"object":   "chat.completion.chunk",
-		"created":  sc.created,
-		"model":    sc.model,
-		"provider": "anthropic",
-		"choices": []map[string]any{
-			{
-				"index":         0,
-				"delta":         delta,
-				"finish_reason": finishReason,
-			},
-		},
-	}
-	if usage != nil {
-		chunk["usage"] = anthropicChatUsagePayload(usage)
-	}
-
-	jsonData, err := json.Marshal(chunk)
-	if err != nil {
-		slog.Error("failed to marshal chat completion chunk", "error", err, "msg_id", sc.msgID)
-		return ""
-	}
-
-	return "data: " + string(jsonData) + "\n\n"
+	return providers.FormatChatChunkSSE(sc.msgID, sc.created, sc.model, "anthropic", delta, finishReason, anthropicChatUsagePayload(usage))
 }
 
 func (sc *streamConverter) convertEvent(event *anthropicStreamEvent) string {

--- a/internal/providers/anthropic/responses.go
+++ b/internal/providers/anthropic/responses.go
@@ -3,7 +3,6 @@ package anthropic
 import (
 	"bufio"
 	"context"
-	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -126,6 +125,7 @@ type responsesStreamConverter struct {
 	body            io.ReadCloser
 	model           string
 	responseID      string
+	createdAt       int64
 	output          *providers.ResponsesOutputEventState
 	nextOutputIndex int
 	toolCalls       map[int]*providers.ResponsesOutputToolCallState
@@ -144,6 +144,7 @@ func newResponsesStreamConverter(body io.ReadCloser, model string) *responsesStr
 		body:           body,
 		model:          model,
 		responseID:     responseID,
+		createdAt:      time.Now().Unix(),
 		output:         providers.NewResponsesOutputEventState(responseID),
 		toolCalls:      make(map[int]*providers.ResponsesOutputToolCallState),
 		thinkingBlocks: make(map[int]bool),
@@ -177,7 +178,7 @@ func (sc *responsesStreamConverter) Read(p []byte) (n int, err error) {
 						"status":     "completed",
 						"model":      sc.model,
 						"provider":   "anthropic",
-						"created_at": time.Now().Unix(),
+						"created_at": sc.createdAt,
 					}
 					// Include merged usage data captured across message_start/message_delta.
 					if sc.hasUsage {
@@ -284,7 +285,7 @@ func (sc *responsesStreamConverter) convertEvent(event *anthropicStreamEvent) st
 				"status":     "in_progress",
 				"model":      sc.model,
 				"provider":   "anthropic",
-				"created_at": time.Now().Unix(),
+				"created_at": sc.createdAt,
 			},
 		}
 		jsonData, err := json.Marshal(createdEvent)
@@ -292,7 +293,7 @@ func (sc *responsesStreamConverter) convertEvent(event *anthropicStreamEvent) st
 			slog.Error("failed to marshal response.created event", "error", err, "response_id", sc.responseID)
 			return ""
 		}
-		return fmt.Sprintf("event: response.created\ndata: %s\n\n", jsonData)
+		return "event: response.created\ndata: " + string(jsonData) + "\n\n"
 
 	case "content_block_start":
 		if event.ContentBlock != nil && event.ContentBlock.Type == "thinking" {
@@ -336,7 +337,7 @@ func (sc *responsesStreamConverter) convertEvent(event *anthropicStreamEvent) st
 					slog.Error("failed to marshal content delta event", "error", err, "response_id", sc.responseID)
 					return ""
 				}
-				return prefix + fmt.Sprintf("event: response.output_text.delta\ndata: %s\n\n", jsonData)
+				return prefix + "event: response.output_text.delta\ndata: " + string(jsonData) + "\n\n"
 			}
 		case "input_json_delta":
 			if event.Delta.PartialJSON == "" {

--- a/internal/providers/anthropic/responses.go
+++ b/internal/providers/anthropic/responses.go
@@ -277,7 +277,7 @@ func (sc *responsesStreamConverter) convertEvent(event *anthropicStreamEvent) st
 			sc.hasUsage = true
 		}
 		// Send response.created event
-		createdEvent := map[string]any{
+		return sc.output.WriteEvent("response.created", map[string]any{
 			"type": "response.created",
 			"response": map[string]any{
 				"id":         sc.responseID,
@@ -287,13 +287,7 @@ func (sc *responsesStreamConverter) convertEvent(event *anthropicStreamEvent) st
 				"provider":   "anthropic",
 				"created_at": sc.createdAt,
 			},
-		}
-		jsonData, err := json.Marshal(createdEvent)
-		if err != nil {
-			slog.Error("failed to marshal response.created event", "error", err, "response_id", sc.responseID)
-			return ""
-		}
-		return "event: response.created\ndata: " + string(jsonData) + "\n\n"
+		})
 
 	case "content_block_start":
 		if event.ContentBlock != nil && event.ContentBlock.Type == "thinking" {
@@ -328,16 +322,10 @@ func (sc *responsesStreamConverter) convertEvent(event *anthropicStreamEvent) st
 				sc.reserveAssistantMessageOutput()
 				prefix := sc.output.StartAssistantOutput(0)
 				sc.output.AppendAssistantText(event.Delta.Text)
-				deltaEvent := map[string]any{
+				return prefix + sc.output.WriteEvent("response.output_text.delta", map[string]any{
 					"type":  "response.output_text.delta",
 					"delta": event.Delta.Text,
-				}
-				jsonData, err := json.Marshal(deltaEvent)
-				if err != nil {
-					slog.Error("failed to marshal content delta event", "error", err, "response_id", sc.responseID)
-					return ""
-				}
-				return prefix + "event: response.output_text.delta\ndata: " + string(jsonData) + "\n\n"
+				})
 			}
 		case "input_json_delta":
 			if event.Delta.PartialJSON == "" {

--- a/internal/providers/bedrock/chat_stream.go
+++ b/internal/providers/bedrock/chat_stream.go
@@ -2,9 +2,9 @@ package bedrock
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"log/slog"
+	"strconv"
 	"sync"
 	"time"
 
@@ -59,6 +59,7 @@ type streamConverter struct {
 	stream    *bedrockruntime.ConverseStreamOutput
 	model     string
 	id        string
+	created   int64
 	closeOnce sync.Once
 	buf       []byte
 	done      bool
@@ -82,10 +83,12 @@ type toolStreamState struct {
 }
 
 func newOpenAIStream(out *bedrockruntime.ConverseStreamOutput, model string) *streamConverter {
+	now := time.Now()
 	return &streamConverter{
 		stream:      out,
 		model:       model,
-		id:          fmt.Sprintf("bedrock-%d", time.Now().UnixNano()),
+		id:          "bedrock-" + strconv.FormatInt(now.UnixNano(), 10),
+		created:     now.Unix(),
 		toolByIndex: make(map[int32]*toolStreamState),
 	}
 }
@@ -239,7 +242,7 @@ func (s *streamConverter) formatChunk(delta map[string]any, finishReason any, us
 	chunk := map[string]any{
 		"id":       s.id,
 		"object":   "chat.completion.chunk",
-		"created":  time.Now().Unix(),
+		"created":  s.created,
 		"model":    s.model,
 		"provider": providerName,
 		"choices": []map[string]any{{

--- a/internal/providers/bedrock/chat_stream.go
+++ b/internal/providers/bedrock/chat_stream.go
@@ -3,18 +3,16 @@ package bedrock
 import (
 	"context"
 	"io"
-	"log/slog"
 	"strconv"
 	"sync"
 	"time"
-
-	"github.com/goccy/go-json"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
 	brtypes "github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
 
 	"gomodel/internal/core"
+	"gomodel/internal/providers"
 )
 
 // StreamChatCompletion runs Bedrock ConverseStream and exposes an
@@ -239,31 +237,15 @@ func (s *streamConverter) flushFinish() {
 }
 
 func (s *streamConverter) formatChunk(delta map[string]any, finishReason any, usage *brtypes.TokenUsage) string {
-	chunk := map[string]any{
-		"id":       s.id,
-		"object":   "chat.completion.chunk",
-		"created":  s.created,
-		"model":    s.model,
-		"provider": providerName,
-		"choices": []map[string]any{{
-			"index":         0,
-			"delta":         delta,
-			"finish_reason": finishReason,
-		}},
-	}
+	var usagePayload map[string]any
 	if usage != nil {
-		chunk["usage"] = map[string]any{
+		usagePayload = map[string]any{
 			"prompt_tokens":     int(awssdk.ToInt32(usage.InputTokens)),
 			"completion_tokens": int(awssdk.ToInt32(usage.OutputTokens)),
 			"total_tokens":      int(awssdk.ToInt32(usage.TotalTokens)),
 		}
 	}
-	buf, err := json.Marshal(chunk)
-	if err != nil {
-		slog.Warn("failed to marshal bedrock stream chunk", "error", err)
-		return ""
-	}
-	return "data: " + string(buf) + "\n\n"
+	return providers.FormatChatChunkSSE(s.id, s.created, s.model, providerName, delta, finishReason, usagePayload)
 }
 
 var _ io.ReadCloser = (*streamConverter)(nil)

--- a/internal/providers/chat_chunk_sse.go
+++ b/internal/providers/chat_chunk_sse.go
@@ -6,30 +6,41 @@ import (
 	"github.com/goccy/go-json"
 )
 
+type chatChunkChoice struct {
+	Index        int            `json:"index"`
+	Delta        map[string]any `json:"delta"`
+	FinishReason any            `json:"finish_reason"`
+}
+
+type chatChunkEnvelope struct {
+	ID       string             `json:"id"`
+	Object   string             `json:"object"`
+	Created  int64              `json:"created"`
+	Model    string             `json:"model"`
+	Provider string             `json:"provider"`
+	Choices  [1]chatChunkChoice `json:"choices"`
+	Usage    map[string]any     `json:"usage,omitempty"`
+}
+
 // FormatChatChunkSSE renders a single-choice OpenAI chat.completion.chunk as
 // one SSE data line. It defines the chunk envelope emitted by native-protocol
 // stream converters (Anthropic, Bedrock) so the OpenAI-compatible wire shape
 // lives in one place. A nil usage omits the member; finishReason may be nil.
 func FormatChatChunkSSE(id string, created int64, model, provider string, delta map[string]any, finishReason any, usage map[string]any) string {
-	chunk := map[string]any{
-		"id":       id,
-		"object":   "chat.completion.chunk",
-		"created":  created,
-		"model":    model,
-		"provider": provider,
-		"choices": []map[string]any{
-			{
-				"index":         0,
-				"delta":         delta,
-				"finish_reason": finishReason,
-			},
-		},
-	}
-	if usage != nil {
-		chunk["usage"] = usage
+	chunk := chatChunkEnvelope{
+		ID:       id,
+		Object:   "chat.completion.chunk",
+		Created:  created,
+		Model:    model,
+		Provider: provider,
+		Choices: [1]chatChunkChoice{{
+			Delta:        delta,
+			FinishReason: finishReason,
+		}},
+		Usage: usage,
 	}
 
-	jsonData, err := json.Marshal(chunk)
+	jsonData, err := json.Marshal(&chunk)
 	if err != nil {
 		slog.Error("failed to marshal chat completion chunk", "error", err, "id", id, "provider", provider)
 		return ""

--- a/internal/providers/chat_chunk_sse.go
+++ b/internal/providers/chat_chunk_sse.go
@@ -1,0 +1,38 @@
+package providers
+
+import (
+	"log/slog"
+
+	"github.com/goccy/go-json"
+)
+
+// FormatChatChunkSSE renders a single-choice OpenAI chat.completion.chunk as
+// one SSE data line. It defines the chunk envelope emitted by native-protocol
+// stream converters (Anthropic, Bedrock) so the OpenAI-compatible wire shape
+// lives in one place. A nil usage omits the member; finishReason may be nil.
+func FormatChatChunkSSE(id string, created int64, model, provider string, delta map[string]any, finishReason any, usage map[string]any) string {
+	chunk := map[string]any{
+		"id":       id,
+		"object":   "chat.completion.chunk",
+		"created":  created,
+		"model":    model,
+		"provider": provider,
+		"choices": []map[string]any{
+			{
+				"index":         0,
+				"delta":         delta,
+				"finish_reason": finishReason,
+			},
+		},
+	}
+	if usage != nil {
+		chunk["usage"] = usage
+	}
+
+	jsonData, err := json.Marshal(chunk)
+	if err != nil {
+		slog.Error("failed to marshal chat completion chunk", "error", err, "id", id, "provider", provider)
+		return ""
+	}
+	return "data: " + string(jsonData) + "\n\n"
+}

--- a/internal/providers/chat_chunk_sse_test.go
+++ b/internal/providers/chat_chunk_sse_test.go
@@ -1,0 +1,83 @@
+package providers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-json"
+)
+
+func decodeChunkSSE(t *testing.T, line string) map[string]any {
+	t.Helper()
+	payload, ok := strings.CutPrefix(line, "data: ")
+	if !ok || !strings.HasSuffix(payload, "\n\n") {
+		t.Fatalf("chunk = %q, want data: <json>\\n\\n framing", line)
+	}
+	var chunk map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSuffix(payload, "\n\n")), &chunk); err != nil {
+		t.Fatalf("unmarshal chunk payload: %v", err)
+	}
+	return chunk
+}
+
+func TestFormatChatChunkSSE(t *testing.T) {
+	chunk := decodeChunkSSE(t, FormatChatChunkSSE(
+		"chunk-1", 1700000000, "claude-3", "anthropic",
+		map[string]any{"content": "hi"}, nil, nil,
+	))
+
+	if got := chunk["id"]; got != "chunk-1" {
+		t.Fatalf("id = %v, want chunk-1", got)
+	}
+	if got := chunk["object"]; got != "chat.completion.chunk" {
+		t.Fatalf("object = %v, want chat.completion.chunk", got)
+	}
+	if got := chunk["created"]; got != float64(1700000000) {
+		t.Fatalf("created = %v, want 1700000000", got)
+	}
+	if got := chunk["model"]; got != "claude-3" {
+		t.Fatalf("model = %v, want claude-3", got)
+	}
+	if got := chunk["provider"]; got != "anthropic" {
+		t.Fatalf("provider = %v, want anthropic", got)
+	}
+	if _, present := chunk["usage"]; present {
+		t.Fatal("usage present, want omitted when nil")
+	}
+
+	choices, ok := chunk["choices"].([]any)
+	if !ok || len(choices) != 1 {
+		t.Fatalf("choices = %#v, want exactly one choice", chunk["choices"])
+	}
+	choice := choices[0].(map[string]any)
+	if got := choice["index"]; got != float64(0) {
+		t.Fatalf("choice index = %v, want 0", got)
+	}
+	if choice["finish_reason"] != nil {
+		t.Fatalf("finish_reason = %v, want explicit null", choice["finish_reason"])
+	}
+	delta, _ := choice["delta"].(map[string]any)
+	if got := delta["content"]; got != "hi" {
+		t.Fatalf("delta content = %v, want hi", got)
+	}
+}
+
+func TestFormatChatChunkSSEWithFinishReasonAndUsage(t *testing.T) {
+	chunk := decodeChunkSSE(t, FormatChatChunkSSE(
+		"chunk-2", 1700000000, "claude-3", "anthropic",
+		map[string]any{}, "stop",
+		map[string]any{"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7},
+	))
+
+	choice := chunk["choices"].([]any)[0].(map[string]any)
+	if got := choice["finish_reason"]; got != "stop" {
+		t.Fatalf("finish_reason = %v, want stop", got)
+	}
+	usage, ok := chunk["usage"].(map[string]any)
+	if !ok {
+		t.Fatalf("usage = %#v, want object", chunk["usage"])
+	}
+	if got := usage["total_tokens"]; got != float64(7) {
+		t.Fatalf("usage total_tokens = %v, want 7", got)
+	}
+}

--- a/internal/providers/deepseek/deepseek.go
+++ b/internal/providers/deepseek/deepseek.go
@@ -81,24 +81,24 @@ func adaptChatRequest(req *core.ChatRequest) (any, error) {
 		return req, nil
 	}
 
-	body, err := json.Marshal(req)
-	if err != nil {
-		return nil, core.NewInvalidRequestError("failed to marshal deepseek request: "+err.Error(), err)
-	}
-
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(body, &raw); err != nil {
-		return nil, core.NewInvalidRequestError("failed to decode deepseek request payload: "+err.Error(), err)
-	}
-
-	effort, _ := json.Marshal(normalizeReasoningEffort(req.Reasoning.Effort))
-	raw["reasoning_effort"] = effort
-	// Delete the full reasoning object: DeepSeek accepts reasoning_effort as a
+	// Drop the full reasoning object: DeepSeek accepts reasoning_effort as a
 	// top-level string only. Other reasoning fields (e.g. budget_tokens) are not
 	// forwarded because DeepSeek has no equivalent. Update this if DeepSeek
 	// expands its reasoning API surface.
-	delete(raw, "reasoning")
-	return raw, nil
+	adapted := *req
+	adapted.Reasoning = nil
+	effort, err := json.Marshal(normalizeReasoningEffort(req.Reasoning.Effort))
+	if err != nil {
+		return nil, core.NewInvalidRequestError("failed to adapt deepseek request: "+err.Error(), err)
+	}
+	extra, err := core.MergeUnknownJSONFields(req.ExtraFields, map[string]json.RawMessage{
+		"reasoning_effort": effort,
+	})
+	if err != nil {
+		return nil, core.NewInvalidRequestError("failed to adapt deepseek request: "+err.Error(), err)
+	}
+	adapted.ExtraFields = extra
+	return &adapted, nil
 }
 
 // normalizeReasoningEffort maps GoModel's OpenAI-style effort levels to the two

--- a/internal/providers/deepseek/deepseek.go
+++ b/internal/providers/deepseek/deepseek.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/goccy/go-json"
-
 	"gomodel/internal/core"
 	"gomodel/internal/llmclient"
 	"gomodel/internal/providers"
@@ -80,25 +78,7 @@ func adaptChatRequest(req *core.ChatRequest) (any, error) {
 	if req == nil || req.Reasoning == nil || strings.TrimSpace(req.Reasoning.Effort) == "" {
 		return req, nil
 	}
-
-	// Drop the full reasoning object: DeepSeek accepts reasoning_effort as a
-	// top-level string only. Other reasoning fields (e.g. budget_tokens) are not
-	// forwarded because DeepSeek has no equivalent. Update this if DeepSeek
-	// expands its reasoning API surface.
-	adapted := *req
-	adapted.Reasoning = nil
-	effort, err := json.Marshal(normalizeReasoningEffort(req.Reasoning.Effort))
-	if err != nil {
-		return nil, core.NewInvalidRequestError("failed to adapt deepseek request: "+err.Error(), err)
-	}
-	extra, err := core.MergeUnknownJSONFields(req.ExtraFields, map[string]json.RawMessage{
-		"reasoning_effort": effort,
-	})
-	if err != nil {
-		return nil, core.NewInvalidRequestError("failed to adapt deepseek request: "+err.Error(), err)
-	}
-	adapted.ExtraFields = extra
-	return &adapted, nil
+	return providers.AdaptReasoningEffortRequest(req, normalizeReasoningEffort(req.Reasoning.Effort))
 }
 
 // normalizeReasoningEffort maps GoModel's OpenAI-style effort levels to the two

--- a/internal/providers/gemini/gemini.go
+++ b/internal/providers/gemini/gemini.go
@@ -372,27 +372,12 @@ func nativeBaseURLFromOpenAICompatibleBaseURL(baseURL string) (string, bool) {
 
 // adaptChatRequest rewrites a ChatRequest for Gemini's OpenAI-compatible endpoint.
 // Gemini uses "reasoning_effort" as a top-level string (e.g. "low", "medium", "high"),
-// not the nested "reasoning": {"effort": "..."} format. It works on the typed
-// request directly so the body is marshaled only once, by the HTTP client.
+// not the nested "reasoning": {"effort": "..."} format.
 func adaptChatRequest(req *core.ChatRequest) (*core.ChatRequest, error) {
 	if req.Reasoning == nil || req.Reasoning.Effort == "" {
 		return req, nil
 	}
-
-	adapted := *req
-	adapted.Reasoning = nil
-	effort, err := json.Marshal(req.Reasoning.Effort)
-	if err != nil {
-		return nil, core.NewInvalidRequestError("failed to adapt gemini request: "+err.Error(), err)
-	}
-	extra, err := core.MergeUnknownJSONFields(req.ExtraFields, map[string]json.RawMessage{
-		"reasoning_effort": effort,
-	})
-	if err != nil {
-		return nil, core.NewInvalidRequestError("failed to adapt gemini request: "+err.Error(), err)
-	}
-	adapted.ExtraFields = extra
-	return &adapted, nil
+	return providers.AdaptReasoningEffortRequest(req, req.Reasoning.Effort)
 }
 
 func (p *Provider) openAICompatibleChatBody(req *core.ChatRequest) (any, error) {

--- a/internal/providers/gemini/gemini.go
+++ b/internal/providers/gemini/gemini.go
@@ -372,61 +372,51 @@ func nativeBaseURLFromOpenAICompatibleBaseURL(baseURL string) (string, bool) {
 
 // adaptChatRequest rewrites a ChatRequest for Gemini's OpenAI-compatible endpoint.
 // Gemini uses "reasoning_effort" as a top-level string (e.g. "low", "medium", "high"),
-// not the nested "reasoning": {"effort": "..."} format.
-func adaptChatRequest(req *core.ChatRequest) (any, error) {
+// not the nested "reasoning": {"effort": "..."} format. It works on the typed
+// request directly so the body is marshaled only once, by the HTTP client.
+func adaptChatRequest(req *core.ChatRequest) (*core.ChatRequest, error) {
 	if req.Reasoning == nil || req.Reasoning.Effort == "" {
 		return req, nil
 	}
 
-	body, err := json.Marshal(req)
+	adapted := *req
+	adapted.Reasoning = nil
+	effort, err := json.Marshal(req.Reasoning.Effort)
 	if err != nil {
-		return nil, core.NewInvalidRequestError("failed to marshal gemini request: "+err.Error(), err)
+		return nil, core.NewInvalidRequestError("failed to adapt gemini request: "+err.Error(), err)
 	}
-
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(body, &raw); err != nil {
-		return nil, core.NewInvalidRequestError("failed to decode gemini request payload: "+err.Error(), err)
-	}
-
-	effort, _ := json.Marshal(req.Reasoning.Effort)
-	raw["reasoning_effort"] = effort
-	delete(raw, "reasoning")
-	return raw, nil
-}
-
-func rewriteRequestModel(body any, model string) (any, error) {
-	if strings.TrimSpace(model) == "" {
-		return body, nil
-	}
-	encoded, err := json.Marshal(body)
+	extra, err := core.MergeUnknownJSONFields(req.ExtraFields, map[string]json.RawMessage{
+		"reasoning_effort": effort,
+	})
 	if err != nil {
-		return nil, core.NewInvalidRequestError("failed to marshal gemini request: "+err.Error(), err)
+		return nil, core.NewInvalidRequestError("failed to adapt gemini request: "+err.Error(), err)
 	}
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(encoded, &raw); err != nil {
-		return nil, core.NewInvalidRequestError("failed to decode gemini request payload: "+err.Error(), err)
-	}
-	modelJSON, _ := json.Marshal(model)
-	raw["model"] = modelJSON
-	return raw, nil
+	adapted.ExtraFields = extra
+	return &adapted, nil
 }
 
 func (p *Provider) openAICompatibleChatBody(req *core.ChatRequest) (any, error) {
-	body, err := adaptChatRequest(req)
-	if err != nil {
-		return nil, err
+	if p.backend == geminiBackendVertex {
+		if model := vertexOpenAIModelID(req.Model); strings.TrimSpace(model) != "" {
+			rewritten := *req
+			rewritten.Model = model
+			req = &rewritten
+		}
 	}
-	if p.backend != geminiBackendVertex {
-		return body, nil
-	}
-	return rewriteRequestModel(body, vertexOpenAIModelID(req.Model))
+	return adaptChatRequest(req)
 }
 
 func (p *Provider) openAICompatibleEmbeddingBody(req *core.EmbeddingRequest) (any, error) {
 	if p.backend != geminiBackendVertex {
 		return req, nil
 	}
-	return rewriteRequestModel(req, vertexOpenAIModelID(req.Model))
+	model := vertexOpenAIModelID(req.Model)
+	if strings.TrimSpace(model) == "" {
+		return req, nil
+	}
+	rewritten := *req
+	rewritten.Model = model
+	return &rewritten, nil
 }
 
 // ChatCompletion sends a chat completion request to Gemini

--- a/internal/providers/openai/openai.go
+++ b/internal/providers/openai/openai.go
@@ -3,6 +3,7 @@ package openai
 
 import (
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/goccy/go-json"
@@ -109,23 +110,22 @@ func isReasoningChatModel(model string) bool {
 
 // adaptForReasoningChat rewrites a ChatRequest body for OpenAI reasoning chat
 // models, mapping max_tokens -> max_completion_tokens and dropping temperature
-// while preserving all unknown top-level JSON fields.
+// while preserving all unknown top-level JSON fields. It works on the typed
+// request directly so the body is marshaled only once, by the HTTP client.
 func adaptForReasoningChat(req *core.ChatRequest) (any, error) {
-	body, err := json.Marshal(req)
-	if err != nil {
-		return nil, core.NewInvalidRequestError("failed to marshal reasoning request: "+err.Error(), err)
+	adapted := *req
+	adapted.Temperature = nil
+	if req.MaxTokens != nil {
+		adapted.MaxTokens = nil
+		extra, err := core.MergeUnknownJSONFields(req.ExtraFields, map[string]json.RawMessage{
+			"max_completion_tokens": json.RawMessage(strconv.Itoa(*req.MaxTokens)),
+		})
+		if err != nil {
+			return nil, core.NewInvalidRequestError("failed to adapt reasoning request: "+err.Error(), err)
+		}
+		adapted.ExtraFields = extra
 	}
-
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(body, &raw); err != nil {
-		return nil, core.NewInvalidRequestError("failed to decode reasoning request payload: "+err.Error(), err)
-	}
-	if maxTokens, ok := raw["max_tokens"]; ok {
-		raw["max_completion_tokens"] = maxTokens
-		delete(raw, "max_tokens")
-	}
-	delete(raw, "temperature")
-	return raw, nil
+	return &adapted, nil
 }
 
 // chatRequestBody returns the appropriate request body for the model.

--- a/internal/providers/reasoning_effort.go
+++ b/internal/providers/reasoning_effort.go
@@ -1,0 +1,30 @@
+package providers
+
+import (
+	"github.com/goccy/go-json"
+
+	"gomodel/internal/core"
+)
+
+// AdaptReasoningEffortRequest rewrites GoModel's common nested reasoning shape
+// into the flat "reasoning_effort" string extension used by several
+// OpenAI-compatible providers (Gemini, DeepSeek). It shallow-copies the typed
+// request and merges the effort into ExtraFields, so the body is marshaled
+// only once, by the HTTP client. Other reasoning fields (e.g. budget_tokens)
+// are dropped: these providers accept the flat string only.
+func AdaptReasoningEffortRequest(req *core.ChatRequest, effort string) (*core.ChatRequest, error) {
+	adapted := *req
+	adapted.Reasoning = nil
+	encodedEffort, err := json.Marshal(effort)
+	if err != nil {
+		return nil, core.NewInvalidRequestError("failed to adapt reasoning request: "+err.Error(), err)
+	}
+	extra, err := core.MergeUnknownJSONFields(req.ExtraFields, map[string]json.RawMessage{
+		"reasoning_effort": encodedEffort,
+	})
+	if err != nil {
+		return nil, core.NewInvalidRequestError("failed to adapt reasoning request: "+err.Error(), err)
+	}
+	adapted.ExtraFields = extra
+	return &adapted, nil
+}

--- a/internal/providers/reasoning_effort_test.go
+++ b/internal/providers/reasoning_effort_test.go
@@ -1,0 +1,74 @@
+package providers
+
+import (
+	"testing"
+
+	"github.com/goccy/go-json"
+
+	"gomodel/internal/core"
+)
+
+func TestAdaptReasoningEffortRequest(t *testing.T) {
+	req := &core.ChatRequest{
+		Model:     "some-model",
+		Reasoning: &core.Reasoning{Effort: "high"},
+	}
+
+	adapted, err := AdaptReasoningEffortRequest(req, "high")
+	if err != nil {
+		t.Fatalf("AdaptReasoningEffortRequest: %v", err)
+	}
+
+	if adapted.Reasoning != nil {
+		t.Fatalf("adapted.Reasoning = %#v, want nil (flat extension only)", adapted.Reasoning)
+	}
+	if req.Reasoning == nil {
+		t.Fatal("original request mutated: Reasoning cleared")
+	}
+
+	body, err := json.Marshal(adapted)
+	if err != nil {
+		t.Fatalf("marshal adapted request: %v", err)
+	}
+	var wire map[string]json.RawMessage
+	if err := json.Unmarshal(body, &wire); err != nil {
+		t.Fatalf("unmarshal wire body: %v", err)
+	}
+	if got := string(wire["reasoning_effort"]); got != `"high"` {
+		t.Fatalf("reasoning_effort = %s, want \"high\"", got)
+	}
+	if _, present := wire["reasoning"]; present {
+		t.Fatal("reasoning present on the wire, want dropped")
+	}
+}
+
+func TestAdaptReasoningEffortRequestPreservesExistingExtraFields(t *testing.T) {
+	req := &core.ChatRequest{
+		Model:     "some-model",
+		Reasoning: &core.Reasoning{Effort: "low"},
+		ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+			"custom_field":     json.RawMessage(`"kept"`),
+			"reasoning_effort": json.RawMessage(`"stale"`),
+		}),
+	}
+
+	adapted, err := AdaptReasoningEffortRequest(req, "low")
+	if err != nil {
+		t.Fatalf("AdaptReasoningEffortRequest: %v", err)
+	}
+
+	body, err := json.Marshal(adapted)
+	if err != nil {
+		t.Fatalf("marshal adapted request: %v", err)
+	}
+	var wire map[string]json.RawMessage
+	if err := json.Unmarshal(body, &wire); err != nil {
+		t.Fatalf("unmarshal wire body: %v", err)
+	}
+	if got := string(wire["custom_field"]); got != `"kept"` {
+		t.Fatalf("custom_field = %s, want preserved", got)
+	}
+	if got := string(wire["reasoning_effort"]); got != `"low"` {
+		t.Fatalf("reasoning_effort = %s, want adaptation to win over stale extra field", got)
+	}
+}

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -643,12 +643,12 @@ func splitModelSelector(model string) (providerName, modelID string) {
 	if model == "" {
 		return "", ""
 	}
-	parts := strings.SplitN(model, "/", 2)
-	if len(parts) != 2 {
+	before, after, found := strings.Cut(model, "/")
+	if !found {
 		return "", model
 	}
-	providerName = strings.TrimSpace(parts[0])
-	modelID = strings.TrimSpace(parts[1])
+	providerName = strings.TrimSpace(before)
+	modelID = strings.TrimSpace(after)
 	if providerName == "" || modelID == "" {
 		return "", model
 	}

--- a/internal/providers/responses_converter.go
+++ b/internal/providers/responses_converter.go
@@ -186,12 +186,17 @@ func (sc *OpenAIResponsesStreamConverter) handleToolCallDeltas(toolCalls []openA
 func (sc *OpenAIResponsesStreamConverter) processChunk(data []byte) {
 	var chunk openAIStreamChunk
 	if err := json.Unmarshal(data, &chunk); err != nil {
+		// One off-spec member type aborts the whole typed decode; re-parse
+		// tolerantly so the chunk's remaining deltas and usage still flow
+		// (Postel's law), paying the generic-map cost only for such chunks.
+		sc.processChunkTolerant(data)
 		return
 	}
 
-	// Capture usage data if present (OpenAI sends this in the final chunk)
-	if len(chunk.Usage) > 0 && !bytes.Equal(chunk.Usage, []byte("null")) {
-		sc.cachedUsage = chunk.Usage
+	// Capture usage if present and object-shaped (OpenAI sends it in the
+	// final chunk); anything else must not leak into response.completed.
+	if usage := bytes.TrimSpace(chunk.Usage); len(usage) > 0 && usage[0] == '{' {
+		sc.cachedUsage = usage
 	}
 
 	if len(chunk.Choices) == 0 {
@@ -199,21 +204,8 @@ func (sc *OpenAIResponsesStreamConverter) processChunk(data []byte) {
 	}
 	choice := &chunk.Choices[0]
 
-	if content := choice.Delta.Content; content != "" {
-		sc.reserveAssistantOutput()
-		sc.buffer.AppendString(sc.output.StartAssistantOutput(0))
-		sc.output.AppendAssistantText(content)
-		jsonData, err := json.Marshal(struct {
-			Type  string `json:"type"`
-			Delta string `json:"delta"`
-		}{Type: "response.output_text.delta", Delta: content})
-		if err != nil {
-			slog.Error("failed to marshal content delta event", "error", err, "response_id", sc.responseID)
-			return
-		}
-		sc.buffer.AppendString("event: response.output_text.delta\ndata: ")
-		sc.buffer.AppendBytes(jsonData)
-		sc.buffer.AppendString("\n\n")
+	if choice.Delta.Content != "" {
+		sc.appendTextDelta(choice.Delta.Content)
 	}
 	if len(choice.Delta.ToolCalls) > 0 {
 		sc.buffer.AppendString(sc.handleToolCallDeltas(choice.Delta.ToolCalls))
@@ -221,6 +213,94 @@ func (sc *OpenAIResponsesStreamConverter) processChunk(data []byte) {
 	if choice.FinishReason == "tool_calls" {
 		sc.buffer.AppendString(sc.completePendingToolCalls())
 	}
+}
+
+// processChunkTolerant mirrors processChunk with per-field type assertions, so
+// a single off-spec member only skips itself instead of the whole chunk.
+func (sc *OpenAIResponsesStreamConverter) processChunkTolerant(data []byte) {
+	var chunk map[string]any
+	if err := json.Unmarshal(data, &chunk); err != nil {
+		return
+	}
+
+	if usage, ok := chunk["usage"].(map[string]any); ok {
+		if raw, err := json.Marshal(usage); err == nil {
+			sc.cachedUsage = raw
+		}
+	}
+
+	choices, ok := chunk["choices"].([]any)
+	if !ok || len(choices) == 0 {
+		return
+	}
+	choice, ok := choices[0].(map[string]any)
+	if !ok {
+		return
+	}
+	if delta, ok := choice["delta"].(map[string]any); ok {
+		if content, ok := delta["content"].(string); ok && content != "" {
+			sc.appendTextDelta(content)
+		}
+		if toolCalls, ok := delta["tool_calls"].([]any); ok && len(toolCalls) > 0 {
+			sc.buffer.AppendString(sc.handleToolCallDeltas(chunkToolCallsFromAny(toolCalls)))
+		}
+	}
+	if finishReason, _ := choice["finish_reason"].(string); finishReason == "tool_calls" {
+		sc.buffer.AppendString(sc.completePendingToolCalls())
+	}
+}
+
+// chunkToolCallsFromAny converts generically parsed tool-call deltas into the
+// typed form, dropping entries without a usable numeric index.
+func chunkToolCallsFromAny(items []any) []openAIChunkToolCall {
+	calls := make([]openAIChunkToolCall, 0, len(items))
+	for _, item := range items {
+		toolCall, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		index, ok := normalizeToolCallIndex(toolCall["index"])
+		if !ok {
+			continue
+		}
+		call := openAIChunkToolCall{Index: &index}
+		call.ID, _ = toolCall["id"].(string)
+		if function, ok := toolCall["function"].(map[string]any); ok {
+			call.Function.Name, _ = function["name"].(string)
+			call.Function.Arguments, _ = function["arguments"].(string)
+		}
+		calls = append(calls, call)
+	}
+	return calls
+}
+
+func normalizeToolCallIndex(value any) (int, bool) {
+	switch v := value.(type) {
+	case int:
+		return v, true
+	case float64:
+		return int(v), true
+	default:
+		return 0, false
+	}
+}
+
+// appendTextDelta records assistant text and emits its output_text.delta event.
+func (sc *OpenAIResponsesStreamConverter) appendTextDelta(content string) {
+	sc.reserveAssistantOutput()
+	sc.buffer.AppendString(sc.output.StartAssistantOutput(0))
+	sc.output.AppendAssistantText(content)
+	jsonData, err := json.Marshal(struct {
+		Type  string `json:"type"`
+		Delta string `json:"delta"`
+	}{Type: "response.output_text.delta", Delta: content})
+	if err != nil {
+		slog.Error("failed to marshal content delta event", "error", err, "response_id", sc.responseID)
+		return
+	}
+	sc.buffer.AppendString("event: response.output_text.delta\ndata: ")
+	sc.buffer.AppendBytes(jsonData)
+	sc.buffer.AppendString("\n\n")
 }
 
 // appendCompletedEvents flushes open output items and appends the final

--- a/internal/providers/responses_converter.go
+++ b/internal/providers/responses_converter.go
@@ -23,14 +23,16 @@ type OpenAIResponsesStreamConverter struct {
 	model       string
 	provider    string
 	responseID  string
+	createdAt   int64
 	output      *ResponsesOutputEventState
 	toolCalls   map[int]*ResponsesOutputToolCallState
 	buffer      streaming.StreamBuffer
 	lineBuffer  streaming.StreamBuffer
+	readBuf     []byte
 	closed      bool
 	sentCreate  bool
 	sentDone    bool
-	cachedUsage map[string]any // Stores usage from final chunk for inclusion in response.completed
+	cachedUsage json.RawMessage // Stores usage from final chunk for inclusion in response.completed
 }
 
 // NewOpenAIResponsesStreamConverter creates a new converter that transforms
@@ -42,22 +44,35 @@ func NewOpenAIResponsesStreamConverter(reader io.ReadCloser, model, provider str
 		model:      model,
 		provider:   provider,
 		responseID: responseID,
+		createdAt:  time.Now().Unix(),
 		output:     NewResponsesOutputEventState(responseID),
 		toolCalls:  make(map[int]*ResponsesOutputToolCallState),
 		buffer:     streaming.NewStreamBuffer(4096),
 		lineBuffer: streaming.NewStreamBuffer(1024),
+		readBuf:    make([]byte, 1024),
 	}
 }
 
-func normalizeToolCallIndex(value any) (int, bool) {
-	switch v := value.(type) {
-	case int:
-		return v, true
-	case float64:
-		return int(v), true
-	default:
-		return 0, false
-	}
+// openAIStreamChunk is the subset of an OpenAI chat.completion.chunk the
+// converter consumes. Typed decoding avoids a map[string]any per chunk.
+type openAIStreamChunk struct {
+	Usage   json.RawMessage `json:"usage"`
+	Choices []struct {
+		Delta struct {
+			Content   string                `json:"content"`
+			ToolCalls []openAIChunkToolCall `json:"tool_calls"`
+		} `json:"delta"`
+		FinishReason string `json:"finish_reason"`
+	} `json:"choices"`
+}
+
+type openAIChunkToolCall struct {
+	Index    *int   `json:"index"`
+	ID       string `json:"id"`
+	Function struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"function"`
 }
 
 func (sc *OpenAIResponsesStreamConverter) ensureToolCallState(index int) *ResponsesOutputToolCallState {
@@ -118,34 +133,27 @@ func (sc *OpenAIResponsesStreamConverter) completePendingToolCalls() string {
 	return out.String()
 }
 
-func (sc *OpenAIResponsesStreamConverter) handleToolCallDeltas(toolCalls []any) string {
+func (sc *OpenAIResponsesStreamConverter) handleToolCallDeltas(toolCalls []openAIChunkToolCall) string {
 	var out bytes.Buffer
 
 	if sc.output.AssistantStarted() && !sc.output.AssistantDone() {
 		out.WriteString(sc.output.CompleteAssistantOutput(0))
 	}
 
-	for _, item := range toolCalls {
-		toolCall, ok := item.(map[string]any)
-		if !ok {
-			continue
-		}
-		index, ok := normalizeToolCallIndex(toolCall["index"])
-		if !ok {
+	for _, toolCall := range toolCalls {
+		if toolCall.Index == nil {
 			continue
 		}
 
-		state := sc.ensureToolCallState(index)
-		if callID, _ := toolCall["id"].(string); callID != "" {
-			state.CallID = callID
+		state := sc.ensureToolCallState(*toolCall.Index)
+		if toolCall.ID != "" {
+			state.CallID = toolCall.ID
+		}
+		if toolCall.Function.Name != "" {
+			state.Name = toolCall.Function.Name
 		}
 
-		function, _ := toolCall["function"].(map[string]any)
-		if name, _ := function["name"].(string); name != "" {
-			state.Name = name
-		}
-
-		arguments, _ := function["arguments"].(string)
+		arguments := toolCall.Function.Arguments
 		hadStarted := state.Started
 		if arguments != "" {
 			_, _ = state.Arguments.WriteString(arguments)
@@ -173,6 +181,83 @@ func (sc *OpenAIResponsesStreamConverter) handleToolCallDeltas(toolCalls []any) 
 	return out.String()
 }
 
+// processChunk translates one chat.completion.chunk payload into Responses
+// API events appended to the output buffer.
+func (sc *OpenAIResponsesStreamConverter) processChunk(data []byte) {
+	var chunk openAIStreamChunk
+	if err := json.Unmarshal(data, &chunk); err != nil {
+		return
+	}
+
+	// Capture usage data if present (OpenAI sends this in the final chunk)
+	if len(chunk.Usage) > 0 && !bytes.Equal(chunk.Usage, []byte("null")) {
+		sc.cachedUsage = chunk.Usage
+	}
+
+	if len(chunk.Choices) == 0 {
+		return
+	}
+	choice := &chunk.Choices[0]
+
+	if content := choice.Delta.Content; content != "" {
+		sc.reserveAssistantOutput()
+		sc.buffer.AppendString(sc.output.StartAssistantOutput(0))
+		sc.output.AppendAssistantText(content)
+		jsonData, err := json.Marshal(struct {
+			Type  string `json:"type"`
+			Delta string `json:"delta"`
+		}{Type: "response.output_text.delta", Delta: content})
+		if err != nil {
+			slog.Error("failed to marshal content delta event", "error", err, "response_id", sc.responseID)
+			return
+		}
+		sc.buffer.AppendString("event: response.output_text.delta\ndata: ")
+		sc.buffer.AppendBytes(jsonData)
+		sc.buffer.AppendString("\n\n")
+	}
+	if len(choice.Delta.ToolCalls) > 0 {
+		sc.buffer.AppendString(sc.handleToolCallDeltas(choice.Delta.ToolCalls))
+	}
+	if choice.FinishReason == "tool_calls" {
+		sc.buffer.AppendString(sc.completePendingToolCalls())
+	}
+}
+
+// appendCompletedEvents flushes open output items and appends the final
+// response.completed event plus the trailing [DONE] marker exactly once.
+func (sc *OpenAIResponsesStreamConverter) appendCompletedEvents() {
+	if sc.sentDone {
+		return
+	}
+	sc.sentDone = true
+	sc.buffer.AppendString(sc.output.CompleteAssistantOutput(0))
+	sc.buffer.AppendString(sc.completePendingToolCalls())
+	responseData := map[string]any{
+		"id":         sc.responseID,
+		"object":     "response",
+		"status":     "completed",
+		"model":      sc.model,
+		"provider":   sc.provider,
+		"created_at": sc.createdAt,
+	}
+	// Include usage data if captured from OpenAI stream
+	if sc.cachedUsage != nil {
+		responseData["usage"] = sc.cachedUsage
+	}
+	doneEvent := map[string]any{
+		"type":     "response.completed",
+		"response": responseData,
+	}
+	jsonData, err := json.Marshal(doneEvent)
+	if err != nil {
+		slog.Error("failed to marshal response.completed event", "error", err, "response_id", sc.responseID)
+		return
+	}
+	sc.buffer.AppendString("event: response.completed\ndata: ")
+	sc.buffer.AppendBytes(jsonData)
+	sc.buffer.AppendString("\n\ndata: [DONE]\n\n")
+}
+
 func (sc *OpenAIResponsesStreamConverter) Read(p []byte) (n int, err error) {
 	if sc.closed {
 		return 0, io.EOF
@@ -194,7 +279,7 @@ func (sc *OpenAIResponsesStreamConverter) Read(p []byte) (n int, err error) {
 				"status":     "in_progress",
 				"model":      sc.model,
 				"provider":   sc.provider,
-				"created_at": time.Now().Unix(),
+				"created_at": sc.createdAt,
 			},
 		}
 		jsonData, err := json.Marshal(createdEvent)
@@ -209,10 +294,9 @@ func (sc *OpenAIResponsesStreamConverter) Read(p []byte) (n int, err error) {
 	}
 
 	// Read from the underlying stream
-	tempBuf := make([]byte, 1024)
-	nr, readErr := sc.reader.Read(tempBuf)
+	nr, readErr := sc.reader.Read(sc.readBuf)
 	if nr > 0 {
-		sc.lineBuffer.AppendBytes(tempBuf[:nr])
+		sc.lineBuffer.AppendBytes(sc.readBuf[:nr])
 
 		// Process complete lines
 		for {
@@ -233,80 +317,10 @@ func (sc *OpenAIResponsesStreamConverter) Read(p []byte) (n int, err error) {
 			if after, ok := bytes.CutPrefix(line, []byte("data: ")); ok {
 				data := after
 				if bytes.Equal(data, []byte("[DONE]")) {
-					// Send done event
-					if !sc.sentDone {
-						sc.sentDone = true
-						sc.buffer.AppendString(sc.output.CompleteAssistantOutput(0))
-						sc.buffer.AppendString(sc.completePendingToolCalls())
-						responseData := map[string]any{
-							"id":         sc.responseID,
-							"object":     "response",
-							"status":     "completed",
-							"model":      sc.model,
-							"provider":   sc.provider,
-							"created_at": time.Now().Unix(),
-						}
-						// Include usage data if captured from OpenAI stream
-						if sc.cachedUsage != nil {
-							responseData["usage"] = sc.cachedUsage
-						}
-						doneEvent := map[string]any{
-							"type":     "response.completed",
-							"response": responseData,
-						}
-						jsonData, err := json.Marshal(doneEvent)
-						if err != nil {
-							slog.Error("failed to marshal response.completed event", "error", err, "response_id", sc.responseID)
-							continue
-						}
-						sc.buffer.AppendString("event: response.completed\ndata: ")
-						sc.buffer.AppendBytes(jsonData)
-						sc.buffer.AppendString("\n\ndata: [DONE]\n\n")
-					}
+					sc.appendCompletedEvents()
 					continue
 				}
-
-				// Parse the chat completion chunk
-				var chunk map[string]any
-				if err := json.Unmarshal(data, &chunk); err != nil {
-					continue
-				}
-
-				// Capture usage data if present (OpenAI sends this in the final chunk)
-				if usage, ok := chunk["usage"].(map[string]any); ok {
-					sc.cachedUsage = usage
-				}
-
-				// Extract content delta
-				if choices, ok := chunk["choices"].([]any); ok && len(choices) > 0 {
-					if choice, ok := choices[0].(map[string]any); ok {
-						if delta, ok := choice["delta"].(map[string]any); ok {
-							if content, ok := delta["content"].(string); ok && content != "" {
-								sc.reserveAssistantOutput()
-								sc.buffer.AppendString(sc.output.StartAssistantOutput(0))
-								sc.output.AppendAssistantText(content)
-								deltaEvent := map[string]any{
-									"type":  "response.output_text.delta",
-									"delta": content,
-								}
-								jsonData, err := json.Marshal(deltaEvent)
-								if err != nil {
-									slog.Error("failed to marshal content delta event", "error", err, "response_id", sc.responseID)
-									continue
-								}
-								sc.buffer.AppendString("event: response.output_text.delta\ndata: ")
-								sc.buffer.AppendBytes(jsonData)
-								sc.buffer.AppendString("\n\n")
-							}
-							if toolCalls, ok := delta["tool_calls"].([]any); ok && len(toolCalls) > 0 {
-								sc.buffer.AppendString(sc.handleToolCallDeltas(toolCalls))
-							}
-						}
-						if finishReason, _ := choice["finish_reason"].(string); finishReason == "tool_calls" {
-							sc.buffer.AppendString(sc.completePendingToolCalls())
-						}
-					}
-				}
+				sc.processChunk(data)
 			}
 		}
 	}
@@ -314,35 +328,7 @@ func (sc *OpenAIResponsesStreamConverter) Read(p []byte) (n int, err error) {
 	if readErr != nil {
 		if readErr == io.EOF {
 			// Send final done event if we haven't already
-			if !sc.sentDone {
-				sc.sentDone = true
-				sc.buffer.AppendString(sc.output.CompleteAssistantOutput(0))
-				sc.buffer.AppendString(sc.completePendingToolCalls())
-				responseData := map[string]any{
-					"id":         sc.responseID,
-					"object":     "response",
-					"status":     "completed",
-					"model":      sc.model,
-					"provider":   sc.provider,
-					"created_at": time.Now().Unix(),
-				}
-				// Include usage data if captured from OpenAI stream
-				if sc.cachedUsage != nil {
-					responseData["usage"] = sc.cachedUsage
-				}
-				doneEvent := map[string]any{
-					"type":     "response.completed",
-					"response": responseData,
-				}
-				jsonData, err := json.Marshal(doneEvent)
-				if err != nil {
-					slog.Error("failed to marshal final response.completed event", "error", err, "response_id", sc.responseID)
-				} else {
-					sc.buffer.AppendString("event: response.completed\ndata: ")
-					sc.buffer.AppendBytes(jsonData)
-					sc.buffer.AppendString("\n\ndata: [DONE]\n\n")
-				}
-			}
+			sc.appendCompletedEvents()
 
 			if sc.buffer.Len() > 0 {
 				return sc.buffer.Read(p), nil

--- a/internal/providers/responses_converter_test.go
+++ b/internal/providers/responses_converter_test.go
@@ -242,10 +242,12 @@ func parseTestSSEEvents(t *testing.T, raw string) []testSSEEvent {
 // not discard the chunk's remaining deltas or usage.
 func TestOpenAIResponsesStreamConverter_TolerantChunkFallback(t *testing.T) {
 	// content is an off-spec parts array; usage and finish_reason must survive.
-	// The second chunk carries a float tool-call index (Python-style encoders).
+	// The second chunk carries a float tool-call index (Python-style encoders)
+	// alongside junk entries (non-object, index missing) that must be skipped
+	// without discarding the valid call.
 	mockStream := `data: {"choices":[{"delta":{"content":[{"type":"text","text":"ignored"}]},"finish_reason":null}],"usage":{"prompt_tokens":3,"completion_tokens":4,"total_tokens":7}}
 
-data: {"choices":[{"delta":{"tool_calls":[{"index":0.0,"id":"call_f","type":"function","function":{"name":"lookup","arguments":"{}"}}]},"finish_reason":null}]}
+data: {"choices":[{"delta":{"tool_calls":["junk",{"id":"call_no_index"},{"index":0.0,"id":"call_f","type":"function","function":{"name":"lookup","arguments":"{}"}}]},"finish_reason":null}]}
 
 data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}
 

--- a/internal/providers/responses_converter_test.go
+++ b/internal/providers/responses_converter_test.go
@@ -236,3 +236,87 @@ func parseTestSSEEvents(t *testing.T, raw string) []testSSEEvent {
 
 	return events
 }
+
+// TestOpenAIResponsesStreamConverter_TolerantChunkFallback covers chunks that
+// fail the typed fast-path decode: one off-spec member must only skip itself,
+// not discard the chunk's remaining deltas or usage.
+func TestOpenAIResponsesStreamConverter_TolerantChunkFallback(t *testing.T) {
+	// content is an off-spec parts array; usage and finish_reason must survive.
+	// The second chunk carries a float tool-call index (Python-style encoders).
+	mockStream := `data: {"choices":[{"delta":{"content":[{"type":"text","text":"ignored"}]},"finish_reason":null}],"usage":{"prompt_tokens":3,"completion_tokens":4,"total_tokens":7}}
+
+data: {"choices":[{"delta":{"tool_calls":[{"index":0.0,"id":"call_f","type":"function","function":{"name":"lookup","arguments":"{}"}}]},"finish_reason":null}]}
+
+data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}
+
+data: [DONE]
+`
+
+	converter := NewOpenAIResponsesStreamConverter(io.NopCloser(strings.NewReader(mockStream)), "test-model", "groq")
+	raw, err := io.ReadAll(converter)
+	if err != nil {
+		t.Fatalf("failed to read from converter: %v", err)
+	}
+
+	events := parseTestSSEEvents(t, string(raw))
+	var completed map[string]any
+	foundToolAdded := false
+	for _, event := range events {
+		if event.Done {
+			continue
+		}
+		switch event.Name {
+		case "response.completed":
+			completed, _ = event.Payload["response"].(map[string]any)
+		case "response.output_item.added":
+			item, _ := event.Payload["item"].(map[string]any)
+			if item["type"] == "function_call" && item["name"] == "lookup" {
+				foundToolAdded = true
+			}
+		}
+	}
+
+	if completed == nil {
+		t.Fatal("expected response.completed event")
+	}
+	usage, ok := completed["usage"].(map[string]any)
+	if !ok {
+		t.Fatalf("response.completed usage = %#v, want object captured from off-spec chunk", completed["usage"])
+	}
+	if usage["total_tokens"] != float64(7) {
+		t.Fatalf("usage total_tokens = %v, want 7", usage["total_tokens"])
+	}
+	if !foundToolAdded {
+		t.Fatal("expected function_call output item from float-index tool call delta")
+	}
+}
+
+// TestOpenAIResponsesStreamConverter_DropsNonObjectUsage ensures off-spec
+// non-object usage values never leak into the response.completed payload.
+func TestOpenAIResponsesStreamConverter_DropsNonObjectUsage(t *testing.T) {
+	mockStream := `data: {"choices":[{"delta":{"content":"hi"},"finish_reason":null}],"usage":"n/a"}
+
+data: [DONE]
+`
+
+	converter := NewOpenAIResponsesStreamConverter(io.NopCloser(strings.NewReader(mockStream)), "test-model", "groq")
+	raw, err := io.ReadAll(converter)
+	if err != nil {
+		t.Fatalf("failed to read from converter: %v", err)
+	}
+
+	for _, event := range parseTestSSEEvents(t, string(raw)) {
+		if event.Done || event.Name != "response.completed" {
+			continue
+		}
+		response, _ := event.Payload["response"].(map[string]any)
+		if response == nil {
+			t.Fatal("response.completed missing response object")
+		}
+		if usage, present := response["usage"]; present {
+			t.Fatalf("response.completed usage = %#v, want omitted for non-object usage", usage)
+		}
+		return
+	}
+	t.Fatal("expected response.completed event")
+}

--- a/internal/providers/responses_output_state.go
+++ b/internal/providers/responses_output_state.go
@@ -1,7 +1,6 @@
 package providers
 
 import (
-	"fmt"
 	"log/slog"
 	"strings"
 
@@ -44,7 +43,14 @@ func (s *ResponsesOutputEventState) WriteEvent(eventName string, payload map[str
 		slog.Error("failed to marshal responses stream event", "error", err, "event", eventName, "response_id", s.responseID)
 		return ""
 	}
-	return fmt.Sprintf("event: %s\ndata: %s\n\n", eventName, jsonData)
+	var b strings.Builder
+	b.Grow(len("event: \ndata: \n\n") + len(eventName) + len(jsonData))
+	b.WriteString("event: ")
+	b.WriteString(eventName)
+	b.WriteString("\ndata: ")
+	b.Write(jsonData)
+	b.WriteString("\n\n")
+	return b.String()
 }
 
 // ReserveAssistant marks that the assistant message output item occupies index 0.

--- a/internal/server/audit_attempts.go
+++ b/internal/server/audit_attempts.go
@@ -13,6 +13,11 @@ func enrichAuditEntryWithProviderAttempts(c *echo.Context) {
 	if c == nil || c.Request() == nil {
 		return
 	}
+	// Without an audit entry (audit logging disabled) the snapshot conversion
+	// below — including per-attempt body capture — would be discarded anyway.
+	if auditlog.GetStreamEntryFromContext(c) == nil {
+		return
+	}
 	attempts := auditAttemptsFromGateway(c.Request().Context())
 	if len(attempts) == 0 {
 		return

--- a/internal/streaming/observed_sse_stream.go
+++ b/internal/streaming/observed_sse_stream.go
@@ -37,7 +37,12 @@ type EventFilter interface {
 // and fanning them out to observers.
 type ObservedSSEStream struct {
 	io.ReadCloser
-	observers   []Observer
+	observers []Observer
+	// filters holds each observer's EventFilter, resolved once at
+	// construction. It is authoritative only when every observer contributed
+	// one (len(filters) == len(observers)); otherwise every event is decoded,
+	// which also keeps directly-constructed zero-value streams safe.
+	filters     []EventFilter
 	pending     []byte
 	discardTail []byte
 	closed      bool
@@ -55,10 +60,22 @@ func NewObservedSSEStream(stream io.ReadCloser, observers ...Observer) io.ReadCl
 	if len(filtered) == 0 {
 		return stream
 	}
-	return &ObservedSSEStream{
+
+	observed := &ObservedSSEStream{
 		ReadCloser: stream,
 		observers:  filtered,
 	}
+	for _, observer := range filtered {
+		filter, ok := observer.(EventFilter)
+		if !ok {
+			// An observer without a filter wants every event; leave filters
+			// short so payloadWanted always decodes.
+			observed.filters = nil
+			break
+		}
+		observed.filters = append(observed.filters, filter)
+	}
+	return observed
 }
 
 func (s *ObservedSSEStream) Read(p []byte) (n int, err error) {
@@ -216,9 +233,11 @@ func (s *ObservedSSEStream) dispatchPayload(jsonData []byte) {
 }
 
 func (s *ObservedSSEStream) payloadWanted(jsonData []byte) bool {
-	for _, observer := range s.observers {
-		filter, ok := observer.(EventFilter)
-		if !ok || filter.WantsJSONEvent(jsonData) {
+	if len(s.filters) != len(s.observers) {
+		return true
+	}
+	for _, filter := range s.filters {
+		if filter.WantsJSONEvent(jsonData) {
 			return true
 		}
 	}

--- a/internal/streaming/observed_sse_stream.go
+++ b/internal/streaming/observed_sse_stream.go
@@ -24,6 +24,15 @@ type Observer interface {
 	OnStreamClose()
 }
 
+// EventFilter is an optional Observer extension. Observers that consume only
+// specific payloads can report disinterest from the raw event bytes; when no
+// observer wants an event, the stream skips JSON decoding entirely. Filters
+// must under-approximate disinterest only: an observer may still receive
+// events it did not ask for when another observer wants them.
+type EventFilter interface {
+	WantsJSONEvent(raw []byte) bool
+}
+
 // ObservedSSEStream proxies bytes unchanged while parsing SSE JSON events once
 // and fanning them out to observers.
 type ObservedSSEStream struct {
@@ -165,6 +174,15 @@ func (s *ObservedSSEStream) processBufferedEvents(data []byte) {
 }
 
 func (s *ObservedSSEStream) processEvent(event []byte) {
+	// Fast path: a single-line event (the common shape for chat SSE) needs no
+	// line splitting or payload joining.
+	if bytes.IndexByte(event, '\n') == -1 {
+		if jsonData, ok := parseDataLine(event); ok {
+			s.dispatchPayload(jsonData)
+		}
+		return
+	}
+
 	lines := bytes.Split(event, []byte("\n"))
 	payloadLines := make([][]byte, 0, len(lines))
 	for _, line := range lines {
@@ -177,9 +195,14 @@ func (s *ObservedSSEStream) processEvent(event []byte) {
 	if len(payloadLines) == 0 {
 		return
 	}
+	s.dispatchPayload(bytes.Join(payloadLines, []byte("\n")))
+}
 
-	jsonData := bytes.Join(payloadLines, []byte("\n"))
+func (s *ObservedSSEStream) dispatchPayload(jsonData []byte) {
 	if bytes.Equal(jsonData, donePayload) {
+		return
+	}
+	if !s.payloadWanted(jsonData) {
 		return
 	}
 
@@ -190,6 +213,16 @@ func (s *ObservedSSEStream) processEvent(event []byte) {
 	for _, observer := range s.observers {
 		observer.OnJSONEvent(payload)
 	}
+}
+
+func (s *ObservedSSEStream) payloadWanted(jsonData []byte) bool {
+	for _, observer := range s.observers {
+		filter, ok := observer.(EventFilter)
+		if !ok || filter.WantsJSONEvent(jsonData) {
+			return true
+		}
+	}
+	return false
 }
 
 func nextEventBoundary(data []byte) (idx int, sepLen int) {

--- a/internal/streaming/observed_sse_stream_test.go
+++ b/internal/streaming/observed_sse_stream_test.go
@@ -335,3 +335,95 @@ func TestJoinedSuffix(t *testing.T) {
 		})
 	}
 }
+
+// filteringObserver is a trackingObserver that additionally implements
+// EventFilter with a configurable predicate.
+type filteringObserver struct {
+	trackingObserver
+	wants func(raw []byte) bool
+}
+
+func (o *filteringObserver) WantsJSONEvent(raw []byte) bool {
+	return o.wants(raw)
+}
+
+func TestObservedSSEStreamSkipsDecodingWhenNoObserverWantsEvent(t *testing.T) {
+	uninterested := &filteringObserver{wants: func([]byte) bool { return false }}
+
+	stream := NewObservedSSEStream(
+		io.NopCloser(strings.NewReader("data: {\"a\":1}\n\ndata: {\"b\":2}\n\ndata: [DONE]\n\n")),
+		uninterested,
+	)
+	if _, err := io.Copy(io.Discard, stream); err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if got := uninterested.eventCount; got != 0 {
+		t.Fatalf("uninterested observer received %d events, want 0", got)
+	}
+	if !uninterested.closed {
+		t.Fatal("observer OnStreamClose not called")
+	}
+}
+
+func TestObservedSSEStreamDeliversToAllObserversWhenAnyWantsEvent(t *testing.T) {
+	uninterested := &filteringObserver{wants: func([]byte) bool { return false }}
+	selective := &filteringObserver{wants: func(raw []byte) bool {
+		return strings.Contains(string(raw), `"usage"`)
+	}}
+	plain := &trackingObserver{}
+
+	stream := NewObservedSSEStream(
+		io.NopCloser(strings.NewReader(
+			"data: {\"a\":1}\n\ndata: {\"usage\":{\"total_tokens\":7}}\n\ndata: [DONE]\n\n",
+		)),
+		uninterested, selective, plain,
+	)
+	if _, err := io.Copy(io.Discard, stream); err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// The unfiltered observer forces decoding of every event, so all three
+	// observers see both payloads: filters gate decoding, not delivery.
+	for name, observer := range map[string]*trackingObserver{
+		"uninterested": &uninterested.trackingObserver,
+		"selective":    &selective.trackingObserver,
+		"plain":        plain,
+	} {
+		if got := observer.eventCount; got != 2 {
+			t.Fatalf("%s observer received %d events, want 2", name, got)
+		}
+	}
+}
+
+func TestObservedSSEStreamDecodesOnlyWantedEventsForFilteredObservers(t *testing.T) {
+	selective := &filteringObserver{wants: func(raw []byte) bool {
+		return strings.Contains(string(raw), `"usage"`)
+	}}
+
+	stream := NewObservedSSEStream(
+		io.NopCloser(strings.NewReader(
+			"data: {\"a\":1}\n\ndata: {\"usage\":{\"total_tokens\":7}}\n\ndata: [DONE]\n\n",
+		)),
+		selective,
+	)
+	if _, err := io.Copy(io.Discard, stream); err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if got := selective.eventCount; got != 1 {
+		t.Fatalf("selective observer received %d events, want only the usage event", got)
+	}
+	if _, ok := selective.lastPayload["usage"]; !ok {
+		t.Fatalf("delivered event = %#v, want the usage payload", selective.lastPayload)
+	}
+}

--- a/internal/streaming/stream_buffer.go
+++ b/internal/streaming/stream_buffer.go
@@ -23,18 +23,15 @@ type StreamBuffer struct {
 }
 
 func NewStreamBuffer(initialCapacity int) StreamBuffer {
-	if initialCapacity <= 0 {
+	if initialCapacity < defaultStreamBufferCapacity {
 		initialCapacity = defaultStreamBufferCapacity
 	}
 
 	pooled := streamBufferPool.Get().(*[]byte)
 	data := (*pooled)[:0]
-	if cap(data) == 0 || cap(data) > maxPooledStreamBufferSize {
-		data = make([]byte, 0, defaultStreamBufferCapacity)
-		*pooled = data
-	}
-	if cap(data) < initialCapacity {
+	if cap(data) == 0 || cap(data) > maxPooledStreamBufferSize || cap(data) < initialCapacity {
 		data = make([]byte, 0, initialCapacity)
+		*pooled = data
 	}
 
 	return StreamBuffer{
@@ -101,11 +98,17 @@ func (b *StreamBuffer) Release() {
 	}
 
 	if b.pooled != nil {
-		pooledData := (*b.pooled)[:0]
+		// Prefer returning the live data buffer: appends may have grown it past
+		// the originally pooled allocation, and recycling the grown buffer is
+		// what lets later streams skip re-growing from scratch.
+		pooledData := b.data
 		if cap(pooledData) == 0 || cap(pooledData) > maxPooledStreamBufferSize {
-			pooledData = make([]byte, 0, defaultStreamBufferCapacity)
+			pooledData = *b.pooled
+			if cap(pooledData) == 0 || cap(pooledData) > maxPooledStreamBufferSize {
+				pooledData = make([]byte, 0, defaultStreamBufferCapacity)
+			}
 		}
-		*b.pooled = pooledData
+		*b.pooled = pooledData[:0]
 		streamBufferPool.Put(b.pooled)
 	}
 	b.data = nil

--- a/internal/streaming/stream_buffer.go
+++ b/internal/streaming/stream_buffer.go
@@ -92,6 +92,10 @@ func (b *StreamBuffer) Consume(n int) {
 	b.read += n
 }
 
+// Release returns the buffer's storage to the pool. No slice derived from the
+// buffer (Unread, or bytes handed to a decoder that may alias its input) may
+// be retained past this call: the storage is immediately reusable by another
+// stream and retained views would see another request's data.
 func (b *StreamBuffer) Release() {
 	if b == nil {
 		return

--- a/internal/streaming/stream_buffer_test.go
+++ b/internal/streaming/stream_buffer_test.go
@@ -67,3 +67,38 @@ func TestStreamBufferReleaseKeepsOriginalPooledSliceAfterGrowth(t *testing.T) {
 		t.Fatalf("pooled cap = %d, want original cap %d", got, originalCap)
 	}
 }
+
+func TestStreamBufferReleaseRecyclesGrownBuffer(t *testing.T) {
+	buffer := NewStreamBuffer(0)
+	pooled := buffer.pooled
+	initialCap := cap(*pooled)
+
+	buffer.AppendString(strings.Repeat("x", defaultStreamBufferCapacity*4))
+	grownCap := cap(buffer.data)
+	if grownCap <= initialCap {
+		t.Fatalf("active buffer cap = %d, want growth beyond initial %d", grownCap, initialCap)
+	}
+	if grownCap > maxPooledStreamBufferSize {
+		t.Fatalf("test setup: grown cap %d must stay within pool bound %d", grownCap, maxPooledStreamBufferSize)
+	}
+
+	buffer.Release()
+
+	if got := cap(*pooled); got != grownCap {
+		t.Fatalf("pooled cap = %d, want grown cap %d recycled into the pool", got, grownCap)
+	}
+	if got := len(*pooled); got != 0 {
+		t.Fatalf("pooled len = %d, want 0 after release", got)
+	}
+}
+
+func TestNewStreamBufferKeepsPoolSlotInSyncWithInitialCapacity(t *testing.T) {
+	buffer := NewStreamBuffer(4 * defaultStreamBufferCapacity)
+	if got := cap(buffer.data); got < 4*defaultStreamBufferCapacity {
+		t.Fatalf("buffer cap = %d, want at least requested %d", got, 4*defaultStreamBufferCapacity)
+	}
+	if got, want := cap(*buffer.pooled), cap(buffer.data); got != want {
+		t.Fatalf("pool slot cap = %d, want %d — the slot must track the buffer actually allocated", got, want)
+	}
+	buffer.Release()
+}

--- a/internal/usage/stream_observer.go
+++ b/internal/usage/stream_observer.go
@@ -1,6 +1,7 @@
 package usage
 
 import (
+	"bytes"
 	"log/slog"
 	"strings"
 
@@ -52,6 +53,18 @@ func (o *StreamUsageObserver) SetProviderName(providerName string) {
 		return
 	}
 	o.providerName = strings.TrimSpace(providerName)
+}
+
+// usageKeyLiteral gates WantsJSONEvent: extractUsageFromEvent can only produce
+// an entry from payloads carrying a "usage" member (top-level or nested under
+// "response"), so events without the literal never matter.
+var usageKeyLiteral = []byte(`"usage"`)
+
+// WantsJSONEvent reports whether the raw SSE payload can carry usage data.
+// This lets the observed stream skip JSON decoding for the vast majority of
+// content-delta chunks.
+func (o *StreamUsageObserver) WantsJSONEvent(raw []byte) bool {
+	return bytes.Contains(raw, usageKeyLiteral)
 }
 
 func (o *StreamUsageObserver) OnJSONEvent(chunk map[string]any) {

--- a/internal/usage/stream_observer.go
+++ b/internal/usage/stream_observer.go
@@ -62,7 +62,9 @@ var usageKeyLiteral = []byte(`"usage"`)
 
 // WantsJSONEvent reports whether the raw SSE payload can carry usage data.
 // This lets the observed stream skip JSON decoding for the vast majority of
-// content-delta chunks.
+// content-delta chunks. Known trade-off: a provider that JSON-escapes key
+// characters (e.g. "usage") would slip past this byte scan; no known
+// provider does, and covering it would mean decoding every chunk again.
 func (o *StreamUsageObserver) WantsJSONEvent(raw []byte) bool {
 	return bytes.Contains(raw, usageKeyLiteral)
 }

--- a/tests/perf/README.md
+++ b/tests/perf/README.md
@@ -23,7 +23,10 @@ resolution.
 
 `BenchmarkGatewayHotPathChatCompletionRouted` wires a real `Router` +
 `ModelRegistry` (the production shape) with a representative catalog, so it
-covers the per-request resolution path. This routed path currently allocates an
-order of magnitude more per request because resolution re-copies the full model
-catalog several times; its guard ceilings should tighten significantly once
-resolution is computed once per request and reused.
+covers the per-request resolution path. Resolution goes through an O(1)
+selector index, so the routed path costs only a few allocations more than the
+bare one and is independent of catalog size.
+
+`BenchmarkSharedStreamingObserversDefaultConfig` covers streaming observation
+with audit body capture disabled (the default), where the observed stream
+skips JSON decoding for chunks no observer wants.

--- a/tests/perf/hotpath_test.go
+++ b/tests/perf/hotpath_test.go
@@ -321,6 +321,48 @@ func BenchmarkSharedStreamingAuditAndUsageObservers(b *testing.B) {
 	}
 }
 
+// BenchmarkSharedStreamingObserversDefaultConfig mirrors the observer
+// benchmark above with audit body capture disabled — the default
+// configuration, where the stream can skip decoding content-delta chunks.
+func BenchmarkSharedStreamingObserversDefaultConfig(b *testing.B) {
+	auditLogger := benchAuditLogger{cfg: auditlog.Config{Enabled: true}}
+	usageLogger := benchUsageLogger{cfg: usage.Config{Enabled: true}}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		entry := &auditlog.LogEntry{
+			ID:        "audit-bench",
+			Timestamp: time.Unix(1700000000, 0),
+			RequestID: "req-bench",
+			Method:    http.MethodPost,
+			Path:      "/v1/chat/completions",
+			Data:      &auditlog.LogData{},
+		}
+
+		stream := streaming.NewObservedSSEStream(
+			io.NopCloser(strings.NewReader(sampleChatStream)),
+			auditlog.NewStreamLogObserver(auditLogger, entry, "/v1/chat/completions"),
+			usage.NewStreamUsageObserver(
+				usageLogger,
+				"gpt-4o-mini",
+				"mock",
+				"req-bench",
+				"/v1/chat/completions",
+				nil,
+			),
+		)
+
+		if _, err := io.Copy(io.Discard, stream); err != nil {
+			b.Fatalf("drain wrapped stream: %v", err)
+		}
+		if err := stream.Close(); err != nil {
+			b.Fatalf("close wrapped stream: %v", err)
+		}
+	}
+}
+
 func TestFormatPerfGuardResult(t *testing.T) {
 	result := testing.BenchmarkResult{
 		N:         1,
@@ -388,16 +430,27 @@ func TestHotPathPerfGuard(t *testing.T) {
 			maxBytes:  15104, // baseline ~13.9 KB
 		},
 		{
+			// Typed chunk decoding + reused read buffer keep this converter at a
+			// fraction of its former map[string]any-per-chunk cost (was 202/19.6KB).
 			name:      "openai_responses_stream_converter",
 			bench:     BenchmarkOpenAIResponsesStreamConverter,
-			maxAllocs: 213,   // baseline 202
-			maxBytes:  21120, // baseline ~19.6 KB
+			maxAllocs: 91,        // baseline 86
+			maxBytes:  15 * 1024, // baseline ~13.7 KB
 		},
 		{
 			name:      "shared_stream_audit_and_usage_observers",
 			bench:     BenchmarkSharedStreamingAuditAndUsageObservers,
-			maxAllocs: 167,      // baseline 159
-			maxBytes:  9 * 1024, // baseline ~8.9 KB; already tight
+			maxAllocs: 160,      // baseline 152
+			maxBytes:  9 * 1024, // baseline ~8.2 KB
+		},
+		{
+			// Default configuration: audit body capture off, so the observed
+			// stream must skip JSON decoding for content-delta chunks entirely.
+			// A regression that decodes every chunk again would blow this limit.
+			name:      "shared_stream_observers_default_config",
+			bench:     BenchmarkSharedStreamingObserversDefaultConfig,
+			maxAllocs: 61,       // baseline 57
+			maxBytes:  4 * 1024, // baseline ~3.0 KB
 		},
 	}
 

--- a/tests/perf/hotpath_test.go
+++ b/tests/perf/hotpath_test.go
@@ -434,8 +434,8 @@ func TestHotPathPerfGuard(t *testing.T) {
 			// fraction of its former map[string]any-per-chunk cost (was 202/19.6KB).
 			name:      "openai_responses_stream_converter",
 			bench:     BenchmarkOpenAIResponsesStreamConverter,
-			maxAllocs: 91,        // baseline 86
-			maxBytes:  15 * 1024, // baseline ~13.7 KB
+			maxAllocs: 91,        // baseline 85
+			maxBytes:  12 * 1024, // baseline ~9.7 KB (leaves headroom for pool cold-starts)
 		},
 		{
 			name:      "shared_stream_audit_and_usage_observers",

--- a/tests/perf/hotpath_test.go
+++ b/tests/perf/hotpath_test.go
@@ -283,49 +283,18 @@ func BenchmarkOpenAIResponsesStreamConverter(b *testing.B) {
 }
 
 func BenchmarkSharedStreamingAuditAndUsageObservers(b *testing.B) {
-	auditLogger := benchAuditLogger{cfg: auditlog.Config{Enabled: true, LogBodies: true}}
-	usageLogger := benchUsageLogger{cfg: usage.Config{Enabled: true}}
-
-	b.ReportAllocs()
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		entry := &auditlog.LogEntry{
-			ID:        "audit-bench",
-			Timestamp: time.Unix(1700000000, 0),
-			RequestID: "req-bench",
-			Method:    http.MethodPost,
-			Path:      "/v1/chat/completions",
-			Data:      &auditlog.LogData{},
-		}
-
-		stream := streaming.NewObservedSSEStream(
-			io.NopCloser(strings.NewReader(sampleChatStream)),
-			auditlog.NewStreamLogObserver(auditLogger, entry, "/v1/chat/completions"),
-			usage.NewStreamUsageObserver(
-				usageLogger,
-				"gpt-4o-mini",
-				"mock",
-				"req-bench",
-				"/v1/chat/completions",
-				nil,
-			),
-		)
-
-		if _, err := io.Copy(io.Discard, stream); err != nil {
-			b.Fatalf("drain wrapped stream: %v", err)
-		}
-		if err := stream.Close(); err != nil {
-			b.Fatalf("close wrapped stream: %v", err)
-		}
-	}
+	benchmarkSharedStreamingObservers(b, auditlog.Config{Enabled: true, LogBodies: true})
 }
 
-// BenchmarkSharedStreamingObserversDefaultConfig mirrors the observer
-// benchmark above with audit body capture disabled — the default
-// configuration, where the stream can skip decoding content-delta chunks.
+// BenchmarkSharedStreamingObserversDefaultConfig runs the same pipeline with
+// audit body capture disabled — the default configuration, where the stream
+// can skip decoding content-delta chunks.
 func BenchmarkSharedStreamingObserversDefaultConfig(b *testing.B) {
-	auditLogger := benchAuditLogger{cfg: auditlog.Config{Enabled: true}}
+	benchmarkSharedStreamingObservers(b, auditlog.Config{Enabled: true})
+}
+
+func benchmarkSharedStreamingObservers(b *testing.B, auditCfg auditlog.Config) {
+	auditLogger := benchAuditLogger{cfg: auditCfg}
 	usageLogger := benchUsageLogger{cfg: usage.Config{Enabled: true}}
 
 	b.ReportAllocs()


### PR DESCRIPTION
## Summary

Profile-driven performance pass over the gateway hot paths, plus the simplifications that fell out of it. No config, API, or storage changes; wire format is unchanged apart from JSON key order in some SSE chunks (semantically identical, contract tests unchanged).

### Measured (same machine, `tests/perf` benchmarks vs `main`)

| Path | main | this PR |
|---|---|---|
| Responses stream converter | 10.1µs / 20.1KB / 202 allocs/op | **6.3µs / 9.9KB / 85 allocs/op** |
| Stream observation, default config | ~4.9µs / 160 allocs/op | **2.2µs / 3.2KB / 60 allocs/op** |
| Gateway chat hot path (routed) | 15.0KB / 135 allocs/op | 14.3KB / 126 allocs/op |

### Structural wins not visible in benchmarks

- **Live-logs broker** (`DASHBOARD_LIVE_LOGS_ENABLED` defaults to true): the replay buffer was copy-shifted on every publish once full — ~880KB of memcpy per event under sustained traffic. Now an O(1) circular buffer. Event identity is passed explicitly instead of re-unmarshaling the just-marshaled payload.
- **Stream buffer pool was silently broken**: `Release` re-pooled the original cold 1KB allocation and discarded grown buffers, so every real stream buffer was allocated fresh. It now recycles (aliasing contract documented).
- **Reasoning request adaptation** (OpenAI o-series/gpt-5, Gemini, DeepSeek): marshal→unmarshal→re-marshal round trip replaced by a typed-request rewrite via `ExtraFields`; the body is marshaled once, by the HTTP client.

### How

- Typed chunk decoding + `streaming.EventFilter`: observers that ignore payloads (audit with `LOGGING_LOG_BODIES=false`, usage before the usage chunk) let the stream skip JSON decoding per chunk entirely. Filters gate decoding, not delivery; one unfiltered observer forces full decode.
- Off-spec provider chunks fall back to tolerant per-field parsing (one bad member skips itself, not the whole chunk — including its usage), and non-object `usage` values no longer leak into `response.completed`.
- Per-stream `created` timestamp instead of `time.Now()` per chunk (chunks of one completion now correctly share `created`, matching OpenAI).
- Simplification: single definitions for the OpenAI chunk SSE envelope (`providers.FormatChatChunkSSE`), reasoning-effort adaptation (`providers.AdaptReasoningEffortRequest`), and Responses event rendering; removed `rewriteRequestModel`, a duplicate JSON-merge helper, and duplicated done-event blocks.

## Provider-specific behavior

- Anthropic/Bedrock stream chunks share one envelope formatter; usage payload mapping stays per-provider.
- Gemini Vertex model rewriting now edits the typed request instead of a JSON round trip.

## Testing

- Full suite, `-race`, contract, and integration tests pass; `make perf-check` ceilings tightened to lock the wins in (converter 213→91 allocs, plus a new default-config observer guard).
- New regression tests: circular replay buffer wraparound, EventFilter delivery contract, pool recycling, tolerant chunk fallback (parts-array content, float tool index), non-object usage filtering.
- A multi-angle adversarial review ran over the branch; every confirmed finding is fixed and tested in fa7b68e0 (details in commit message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)