### PR TITLE
fix(docs): set Mintlify theme colors to blue

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -11,7 +11,9 @@
         "dark": "/logo.svg"
     },
     "colors": {
-        "primary": "#755c3d"
+        "primary": "#2563eb",
+        "light": "#60a5fa",
+        "dark": "#1d4ed8"
     },
     "icons": {
         "library": "lucide"

--- a/docs/style.css
+++ b/docs/style.css
@@ -7,8 +7,8 @@
 }
 
 #navigation-items .nav-anchor[href="https://discord.gg/gaEB9BQSPH"] {
-  --discord-nav-light: #2563eb;
-  --discord-nav-dark: #60a5fa;
+  --discord-nav-light: #755c3d;
+  --discord-nav-dark: #4ade80;
 }
 
 #navigation-items .nav-anchor[href="https://discord.gg/gaEB9BQSPH"] img {


### PR DESCRIPTION
## Summary
- Set Mintlify docs theme colors in docs.json to the prompt-cache blue family for light and dark appearances.
- Revert the accidental Discord-only color override from the prior PR.

## Validation
- jq empty docs/docs.json
- mint validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the app’s theme colors to a brighter blue palette.
  * Refreshed the Discord navigation icon colors in both light and dark modes for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->