### PR TITLE
fix(docs): make Discord nav link blue

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -7,8 +7,8 @@
 }
 
 #navigation-items .nav-anchor[href="https://discord.gg/gaEB9BQSPH"] {
-  --discord-nav-light: #755c3d;
-  --discord-nav-dark: #4ade80;
+  --discord-nav-light: #2563eb;
+  --discord-nav-dark: #60a5fa;
 }
 
 #navigation-items .nav-anchor[href="https://discord.gg/gaEB9BQSPH"] img {


### PR DESCRIPTION
## Summary
- Update the custom Discord nav icon colors to match the docs blue theme in light and dark mode.

## Validation
- mint validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Discord navigation icon and background colors to a new blue-themed palette.
  * Light, dark, and hover states now use the refreshed color values consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->