### PR TITLE
refactor(guardrails): own the rule descriptor and hash, drop responsecache import

### DIFF
--- a/internal/admin/handler_workflows_test.go
+++ b/internal/admin/handler_workflows_test.go
@@ -15,7 +15,6 @@ import (
 	"gomodel/internal/core"
 	"gomodel/internal/guardrails"
 	"gomodel/internal/providers"
-	"gomodel/internal/responsecache"
 	"gomodel/internal/workflows"
 )
 
@@ -148,7 +147,7 @@ func newWorkflowRegistry(t *testing.T) *guardrails.Registry {
 	if err != nil {
 		t.Fatalf("NewSystemPromptGuardrail() error = %v", err)
 	}
-	if err := registry.Register(rule, responsecache.GuardrailRuleDescriptor{
+	if err := registry.Register(rule, guardrails.RuleDescriptor{
 		Type:    "system_prompt",
 		Mode:    string(guardrails.SystemPromptInject),
 		Content: "be precise",

--- a/internal/guardrails/definitions.go
+++ b/internal/guardrails/definitions.go
@@ -11,7 +11,6 @@ import (
 	"github.com/goccy/go-json"
 
 	"gomodel/internal/core"
-	"gomodel/internal/responsecache"
 )
 
 // Definition is one persisted reusable guardrail instance.
@@ -249,19 +248,19 @@ func llmBasedAlteringRuntimeConfig(cfg llmBasedAlteringDefinitionConfig, userPat
 	})
 }
 
-func buildDefinition(def Definition, executor ChatCompletionExecutor) (Guardrail, responsecache.GuardrailRuleDescriptor, error) {
+func buildDefinition(def Definition, executor ChatCompletionExecutor) (Guardrail, RuleDescriptor, error) {
 	switch def.Type {
 	case "system_prompt":
 		cfg, err := decodeSystemPromptDefinitionConfig(def.Config)
 		if err != nil {
-			return nil, responsecache.GuardrailRuleDescriptor{}, err
+			return nil, RuleDescriptor{}, err
 		}
 		mode := SystemPromptMode(cfg.Mode)
 		instance, err := NewSystemPromptGuardrail(def.Name, mode, cfg.Content)
 		if err != nil {
-			return nil, responsecache.GuardrailRuleDescriptor{}, newValidationError("build system_prompt guardrail: "+err.Error(), err)
+			return nil, RuleDescriptor{}, newValidationError("build system_prompt guardrail: "+err.Error(), err)
 		}
-		return instance, responsecache.GuardrailRuleDescriptor{
+		return instance, RuleDescriptor{
 			Name:    def.Name,
 			Type:    def.Type,
 			Mode:    string(mode),
@@ -270,11 +269,11 @@ func buildDefinition(def Definition, executor ChatCompletionExecutor) (Guardrail
 	case "llm_based_altering":
 		cfg, err := decodeLLMBasedAlteringDefinitionConfig(def.Config)
 		if err != nil {
-			return nil, responsecache.GuardrailRuleDescriptor{}, err
+			return nil, RuleDescriptor{}, err
 		}
 		runtimeCfg, err := llmBasedAlteringRuntimeConfig(cfg, def.UserPath)
 		if err != nil {
-			return nil, responsecache.GuardrailRuleDescriptor{}, newValidationError("build llm_based_altering guardrail: "+err.Error(), err)
+			return nil, RuleDescriptor{}, newValidationError("build llm_based_altering guardrail: "+err.Error(), err)
 		}
 		if executor == nil {
 			return &unavailableGuardrail{
@@ -289,11 +288,11 @@ func buildDefinition(def Definition, executor ChatCompletionExecutor) (Guardrail
 		}
 		instance, err := NewLLMBasedAlteringGuardrail(def.Name, runtimeCfg, executor)
 		if err != nil {
-			return nil, responsecache.GuardrailRuleDescriptor{}, newValidationError("build llm_based_altering guardrail: "+err.Error(), err)
+			return nil, RuleDescriptor{}, newValidationError("build llm_based_altering guardrail: "+err.Error(), err)
 		}
 		return instance, llmBasedAlteringDescriptor(def.Name, runtimeCfg), nil
 	default:
-		return nil, responsecache.GuardrailRuleDescriptor{}, newValidationError(`unknown guardrail type: "`+def.Type+`"`, nil)
+		return nil, RuleDescriptor{}, newValidationError(`unknown guardrail type: "`+def.Type+`"`, nil)
 	}
 }
 
@@ -432,8 +431,8 @@ func TypeDefinitions() []TypeDefinition {
 	})
 }
 
-func llmBasedAlteringDescriptor(name string, cfg LLMBasedAlteringConfig) responsecache.GuardrailRuleDescriptor {
-	return responsecache.GuardrailRuleDescriptor{
+func llmBasedAlteringDescriptor(name string, cfg LLMBasedAlteringConfig) RuleDescriptor {
+	return RuleDescriptor{
 		Name: name,
 		Type: "llm_based_altering",
 		Mode: strings.Join(cfg.Roles, ","),

--- a/internal/guardrails/hash.go
+++ b/internal/guardrails/hash.go
@@ -1,0 +1,44 @@
+package guardrails
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/cespare/xxhash/v2"
+)
+
+// RuleDescriptor describes a single active guardrail rule for hashing.
+type RuleDescriptor struct {
+	Name    string
+	Type    string
+	Order   int
+	Mode    string
+	Content string
+}
+
+// ComputeGuardrailsHash computes the guardrails_hash for a set of rule identifiers.
+// Each rule is represented as "name:type:order:mode:content_hash". The combined seed is
+// sorted for stability, then passed through SHA-256.
+// Uses xxhash64 per-component and SHA-256 for the final hash to balance speed and
+// collision resistance.
+//
+// The hash is carried on the request context (core.WithGuardrailsHash) and
+// consumed by the response cache as an opaque key component, so guardrail
+// configuration changes invalidate cached completions.
+func ComputeGuardrailsHash(rules []RuleDescriptor) string {
+	if len(rules) == 0 {
+		return ""
+	}
+	seeds := make([]string, len(rules))
+	for i, r := range rules {
+		contentXX := xxhash.Sum64String(r.Content)
+		seeds[i] = fmt.Sprintf("%s:%s:%d:%s:%016x", r.Name, r.Type, r.Order, r.Mode, contentXX)
+	}
+	sort.Strings(seeds)
+	combined := strings.Join(seeds, "|")
+	h := sha256.Sum256([]byte(combined))
+	return hex.EncodeToString(h[:])
+}

--- a/internal/guardrails/hash_test.go
+++ b/internal/guardrails/hash_test.go
@@ -1,0 +1,49 @@
+package guardrails
+
+import "testing"
+
+func TestComputeGuardrailsHash_Stable(t *testing.T) {
+	rules := []RuleDescriptor{
+		{Name: "safety", Type: "system_prompt", Order: 0, Mode: "", Content: "Be safe."},
+		{Name: "privacy", Type: "system_prompt", Order: 0, Mode: "", Content: "No PII."},
+	}
+	h1 := ComputeGuardrailsHash(rules)
+	h2 := ComputeGuardrailsHash(rules)
+	if h1 != h2 {
+		t.Fatal("hash should be stable across calls")
+	}
+}
+
+func TestComputeGuardrailsHash_OrderIndependent(t *testing.T) {
+	rules1 := []RuleDescriptor{
+		{Name: "safety", Type: "system_prompt", Order: 0, Mode: "", Content: "Be safe."},
+		{Name: "privacy", Type: "system_prompt", Order: 0, Mode: "", Content: "No PII."},
+	}
+	rules2 := []RuleDescriptor{
+		{Name: "privacy", Type: "system_prompt", Order: 0, Mode: "", Content: "No PII."},
+		{Name: "safety", Type: "system_prompt", Order: 0, Mode: "", Content: "Be safe."},
+	}
+	if ComputeGuardrailsHash(rules1) != ComputeGuardrailsHash(rules2) {
+		t.Fatal("hash should be order-independent (rules are sorted)")
+	}
+}
+
+func TestComputeGuardrailsHash_ChangesOnContentChange(t *testing.T) {
+	v1 := []RuleDescriptor{{Name: "safety", Type: "system_prompt", Order: 0, Mode: "", Content: "Be safe."}}
+	v2 := []RuleDescriptor{{Name: "safety", Type: "system_prompt", Order: 0, Mode: "", Content: "Be very safe."}}
+	if ComputeGuardrailsHash(v1) == ComputeGuardrailsHash(v2) {
+		t.Fatal("hash should change when rule content changes")
+	}
+}
+
+func TestComputeGuardrailsHash_ChangesOnRuleOrderOrMode(t *testing.T) {
+	base := []RuleDescriptor{{Name: "safety", Type: "system_prompt", Order: 0, Mode: "inject", Content: "Be safe."}}
+	reordered := []RuleDescriptor{{Name: "safety", Type: "system_prompt", Order: 1, Mode: "inject", Content: "Be safe."}}
+	mode := []RuleDescriptor{{Name: "safety", Type: "system_prompt", Order: 0, Mode: "override", Content: "Be safe."}}
+	if ComputeGuardrailsHash(base) == ComputeGuardrailsHash(reordered) {
+		t.Fatal("hash should change when guardrail execution order changes")
+	}
+	if ComputeGuardrailsHash(base) == ComputeGuardrailsHash(mode) {
+		t.Fatal("hash should change when system_prompt mode changes")
+	}
+}

--- a/internal/guardrails/registry.go
+++ b/internal/guardrails/registry.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-
-	"gomodel/internal/responsecache"
 )
 
 // StepReference points to one named guardrail and the step it should run at.
@@ -16,7 +14,7 @@ type StepReference struct {
 
 type registryEntry struct {
 	guardrail  Guardrail
-	descriptor responsecache.GuardrailRuleDescriptor
+	descriptor RuleDescriptor
 }
 
 // Registry stores named guardrails so workflows can reference them by id.
@@ -52,7 +50,7 @@ func (r *Registry) Names() []string {
 }
 
 // Register adds one named guardrail and its hashing descriptor.
-func (r *Registry) Register(g Guardrail, descriptor responsecache.GuardrailRuleDescriptor) error {
+func (r *Registry) Register(g Guardrail, descriptor RuleDescriptor) error {
 	if r == nil {
 		return fmt.Errorf("registry is required")
 	}
@@ -84,7 +82,7 @@ func (r *Registry) BuildPipeline(steps []StepReference) (*Pipeline, string, erro
 	}
 
 	pipeline := NewPipeline()
-	descriptors := make([]responsecache.GuardrailRuleDescriptor, 0, len(steps))
+	descriptors := make([]RuleDescriptor, 0, len(steps))
 	for _, step := range steps {
 		name := strings.TrimSpace(step.Ref)
 		if name == "" {
@@ -99,5 +97,5 @@ func (r *Registry) BuildPipeline(steps []StepReference) (*Pipeline, string, erro
 		descriptor.Order = step.Step
 		descriptors = append(descriptors, descriptor)
 	}
-	return pipeline, responsecache.ComputeGuardrailsHash(descriptors), nil
+	return pipeline, ComputeGuardrailsHash(descriptors), nil
 }

--- a/internal/responsecache/semantic.go
+++ b/internal/responsecache/semantic.go
@@ -590,35 +590,6 @@ func sha256HexOf(s string) string {
 	return hex.EncodeToString(h[:])
 }
 
-// ComputeGuardrailsHash computes the guardrails_hash for a set of rule identifiers.
-// Each rule is represented as "name:type:order:mode:content_hash". The combined seed is
-// sorted for stability, then passed through SHA-256.
-// Uses xxhash64 per-component and SHA-256 for the final hash to balance speed and
-// collision resistance.
-func ComputeGuardrailsHash(rules []GuardrailRuleDescriptor) string {
-	if len(rules) == 0 {
-		return ""
-	}
-	seeds := make([]string, len(rules))
-	for i, r := range rules {
-		contentXX := xxhash.Sum64String(r.Content)
-		seeds[i] = fmt.Sprintf("%s:%s:%d:%s:%016x", r.Name, r.Type, r.Order, r.Mode, contentXX)
-	}
-	sort.Strings(seeds)
-	combined := strings.Join(seeds, "|")
-	h := sha256.Sum256([]byte(combined))
-	return hex.EncodeToString(h[:])
-}
-
-// GuardrailRuleDescriptor describes a single active guardrail rule for hashing.
-type GuardrailRuleDescriptor struct {
-	Name    string
-	Type    string
-	Order   int
-	Mode    string
-	Content string
-}
-
 // GuardrailsHashFromContext retrieves the guardrails hash from the context,
 // using the core package's storage key.
 func GuardrailsHashFromContext(ctx context.Context) string {

--- a/internal/responsecache/semantic_test.go
+++ b/internal/responsecache/semantic_test.go
@@ -576,52 +576,6 @@ func TestMapVecStore_DeleteExpiredOnlyRemovesExpired(t *testing.T) {
 	}
 }
 
-func TestComputeGuardrailsHash_Stable(t *testing.T) {
-	rules := []GuardrailRuleDescriptor{
-		{Name: "safety", Type: "system_prompt", Order: 0, Mode: "", Content: "Be safe."},
-		{Name: "privacy", Type: "system_prompt", Order: 0, Mode: "", Content: "No PII."},
-	}
-	h1 := ComputeGuardrailsHash(rules)
-	h2 := ComputeGuardrailsHash(rules)
-	if h1 != h2 {
-		t.Fatal("hash should be stable across calls")
-	}
-}
-
-func TestComputeGuardrailsHash_OrderIndependent(t *testing.T) {
-	rules1 := []GuardrailRuleDescriptor{
-		{Name: "safety", Type: "system_prompt", Order: 0, Mode: "", Content: "Be safe."},
-		{Name: "privacy", Type: "system_prompt", Order: 0, Mode: "", Content: "No PII."},
-	}
-	rules2 := []GuardrailRuleDescriptor{
-		{Name: "privacy", Type: "system_prompt", Order: 0, Mode: "", Content: "No PII."},
-		{Name: "safety", Type: "system_prompt", Order: 0, Mode: "", Content: "Be safe."},
-	}
-	if ComputeGuardrailsHash(rules1) != ComputeGuardrailsHash(rules2) {
-		t.Fatal("hash should be order-independent (rules are sorted)")
-	}
-}
-
-func TestComputeGuardrailsHash_ChangesOnContentChange(t *testing.T) {
-	v1 := []GuardrailRuleDescriptor{{Name: "safety", Type: "system_prompt", Order: 0, Mode: "", Content: "Be safe."}}
-	v2 := []GuardrailRuleDescriptor{{Name: "safety", Type: "system_prompt", Order: 0, Mode: "", Content: "Be very safe."}}
-	if ComputeGuardrailsHash(v1) == ComputeGuardrailsHash(v2) {
-		t.Fatal("hash should change when rule content changes")
-	}
-}
-
-func TestComputeGuardrailsHash_ChangesOnRuleOrderOrMode(t *testing.T) {
-	base := []GuardrailRuleDescriptor{{Name: "safety", Type: "system_prompt", Order: 0, Mode: "inject", Content: "Be safe."}}
-	reordered := []GuardrailRuleDescriptor{{Name: "safety", Type: "system_prompt", Order: 1, Mode: "inject", Content: "Be safe."}}
-	mode := []GuardrailRuleDescriptor{{Name: "safety", Type: "system_prompt", Order: 0, Mode: "override", Content: "Be safe."}}
-	if ComputeGuardrailsHash(base) == ComputeGuardrailsHash(reordered) {
-		t.Fatal("hash should change when guardrail execution order changes")
-	}
-	if ComputeGuardrailsHash(base) == ComputeGuardrailsHash(mode) {
-		t.Fatal("hash should change when system_prompt mode changes")
-	}
-}
-
 func TestShouldSkipAllCache_CacheControlNoStore(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
 	req.Header.Set("Cache-Control", "private, no-store, max-age=0")

--- a/internal/workflows/compiler_test.go
+++ b/internal/workflows/compiler_test.go
@@ -6,7 +6,6 @@ import (
 
 	"gomodel/internal/core"
 	"gomodel/internal/guardrails"
-	"gomodel/internal/responsecache"
 )
 
 func TestCompilerCompile_Guardrails(t *testing.T) {
@@ -15,7 +14,7 @@ func TestCompilerCompile_Guardrails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSystemPromptGuardrail() error = %v", err)
 	}
-	if err := registry.Register(rule, responsecache.GuardrailRuleDescriptor{
+	if err := registry.Register(rule, guardrails.RuleDescriptor{
 		Type:    "system_prompt",
 		Mode:    string(guardrails.SystemPromptInject),
 		Content: "be precise",
@@ -162,7 +161,7 @@ func TestCompilerCompile_WrapsBuildPipelineErrorsAsGatewayErrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSystemPromptGuardrail() error = %v", err)
 	}
-	if err := registry.Register(rule, responsecache.GuardrailRuleDescriptor{
+	if err := registry.Register(rule, guardrails.RuleDescriptor{
 		Name:    "present",
 		Type:    "system_prompt",
 		Mode:    string(guardrails.SystemPromptInject),


### PR DESCRIPTION
## Summary

Fixes a dependency inversion found in the architecture review (see `docs/dev/2026-07-04_architecture-review.md` on #472): `GuardrailRuleDescriptor` and `ComputeGuardrailsHash` were defined in `responsecache` although they are guardrail-domain concepts, which forced `guardrails` (a domain package) to import the cache layer.

- Both move into `internal/guardrails` (`hash.go`); the descriptor is renamed `RuleDescriptor` to avoid `guardrails.GuardrailRuleDescriptor` stutter.
- `responsecache` never used them in production code — the hash reaches the cache as an opaque context value (`core.WithGuardrailsHash`), which is unchanged. The cache's context helpers stay put.
- Hash tests move with the code; `workflows`/`admin` test references updated.
- `guardrails` no longer imports `responsecache` at all (verified via `go list`).

## User-visible impact

None. Identical hash algorithm and wiring; pure ownership move.

## Testing

Full `go build ./...` and `go test ./...` pass; pre-commit `make test-race` ran on the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved guardrail processing so rule ordering no longer affects the resulting cache/hash behavior.
  * Made guardrail-related results more consistent when rule content or settings change.
  * Removed a dependency on an older internal guardrail descriptor path, reducing inconsistencies in guardrail registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->