### PR TITLE
refactor(responsecache): transport-free cache core, drop httptest from production

### DIFF
--- a/internal/responsecache/exchange.go
+++ b/internal/responsecache/exchange.go
@@ -1,0 +1,176 @@
+package responsecache
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/labstack/echo/v5"
+
+	"gomodel/internal/auditlog"
+)
+
+// exchange abstracts the transport for one cache-mediated request so the
+// cache decision logic (skip checks, hit lookup, replay, miss capture) runs
+// identically for HTTP requests and transport-free internal calls.
+type exchange interface {
+	// Context returns the request context carrying workflow, snapshot,
+	// request-ID, and label values.
+	Context() context.Context
+	// Path is the request path used for cache keying, e.g. "/v1/chat/completions".
+	Path() string
+	Method() string
+	// RequestHeader returns a request header value ("" when absent).
+	RequestHeader(name string) string
+	// ReplayHit writes a cached response to the caller.
+	ReplayHit(requestBody, cached []byte, cacheType string) error
+	// Capture runs next and returns the response bytes when they are a
+	// cacheable success (HTTP 200, valid JSON or SSE, no failover involved).
+	Capture(warnMessage string, next func() error) ([]byte, bool, error)
+	// MarkHit records transport-level side effects of a cache hit (audit
+	// enrichment on the HTTP path; a no-op for internal calls).
+	MarkHit(cacheType string)
+}
+
+// echoExchange adapts an HTTP request served through Echo to the exchange
+// interface. It is the only place cache logic touches the web framework.
+type echoExchange struct {
+	c *echo.Context
+}
+
+func (e *echoExchange) Context() context.Context { return e.c.Request().Context() }
+func (e *echoExchange) Path() string             { return e.c.Request().URL.Path }
+func (e *echoExchange) Method() string           { return e.c.Request().Method }
+
+func (e *echoExchange) RequestHeader(name string) string {
+	return e.c.Request().Header.Get(name)
+}
+
+func (e *echoExchange) ReplayHit(requestBody, cached []byte, cacheType string) error {
+	return writeCachedResponse(e.c, e.Path(), requestBody, cached, cacheType)
+}
+
+func (e *echoExchange) Capture(warnMessage string, next func() error) ([]byte, bool, error) {
+	return captureResponseForCache(e.c, e.Path(), warnMessage, next)
+}
+
+func (e *echoExchange) MarkHit(cacheType string) {
+	auditlog.EnrichEntryWithCacheType(e.c, cacheType)
+}
+
+// InternalResponse is the buffered outcome of the transport-free LLM call a
+// cache miss executes.
+type InternalResponse struct {
+	StatusCode   int
+	ContentType  string
+	Body         []byte
+	FailoverUsed bool
+}
+
+// internalExchange runs the cache for a transport-free internal JSON request:
+// request headers come from the originating request's snapshot (allowlisted),
+// and the response is buffered instead of written to a socket.
+type internalExchange struct {
+	ctx    context.Context
+	method string
+	path   string
+	header http.Header
+
+	next func(ctx context.Context) (*InternalResponse, error)
+
+	status       int
+	respHeader   http.Header
+	respBody     []byte
+	failoverUsed bool
+}
+
+func newInternalExchange(
+	ctx context.Context,
+	method, path string,
+	next func(ctx context.Context) (*InternalResponse, error),
+) *internalExchange {
+	return &internalExchange{
+		ctx:        ctx,
+		method:     method,
+		path:       path,
+		header:     internalRequestHeaders(ctx),
+		next:       next,
+		respHeader: make(http.Header),
+	}
+}
+
+func (e *internalExchange) Context() context.Context { return e.ctx }
+func (e *internalExchange) Path() string             { return e.path }
+func (e *internalExchange) Method() string           { return e.method }
+
+func (e *internalExchange) RequestHeader(name string) string {
+	return e.header.Get(name)
+}
+
+func (e *internalExchange) ReplayHit(requestBody, cached []byte, cacheType string) error {
+	if isStreamingRequest(e.path, requestBody) {
+		e.respHeader.Set("Content-Type", "text/event-stream")
+		e.respHeader.Set("Cache-Control", "no-cache")
+		e.respHeader.Set("Connection", "keep-alive")
+	} else {
+		e.respHeader.Set("Content-Type", "application/json")
+	}
+	e.respHeader.Set("X-Cache", cacheHeaderValue(cacheType))
+	e.status = http.StatusOK
+	e.respBody = bytes.Clone(cached)
+	return nil
+}
+
+// runNext executes the buffered LLM call and records its outcome on the
+// exchange. Cache layers reach it through the next closures handed to
+// handle(), mirroring how the HTTP path executes the real handler.
+func (e *internalExchange) runNext() error {
+	resp, err := e.next(e.ctx)
+	if err != nil {
+		return err
+	}
+	if resp == nil {
+		return errors.New("internal cache request returned no response")
+	}
+	e.status = resp.StatusCode
+	if resp.ContentType != "" {
+		e.respHeader.Set("Content-Type", resp.ContentType)
+	}
+	e.respBody = resp.Body
+	e.failoverUsed = resp.FailoverUsed
+	return nil
+}
+
+func (e *internalExchange) Capture(warnMessage string, next func() error) ([]byte, bool, error) {
+	if err := next(); err != nil {
+		return nil, false, err
+	}
+	if !shouldStoreCapturedResponse(e.status) || len(e.respBody) == 0 {
+		return nil, false, nil
+	}
+	if e.failoverUsed {
+		return nil, false, nil
+	}
+	data, ok := cacheableResponseBody(e.respBody, e.respHeader.Get("Content-Type"))
+	if !ok {
+		slog.Warn(warnMessage, "path", e.path)
+		return nil, false, nil
+	}
+	return data, true, nil
+}
+
+// MarkHit is a no-op: audit entries live in the Echo context store, which a
+// transport-free call does not have. (This matches the previous synthetic-
+// context behavior, where the store was always empty.)
+func (e *internalExchange) MarkHit(string) {}
+
+func (e *internalExchange) result() *InternalHandleResult {
+	return &InternalHandleResult{
+		StatusCode: e.status,
+		Headers:    e.respHeader.Clone(),
+		Body:       bytes.Clone(e.respBody),
+		CacheType:  internalCacheType(e.respHeader.Get("X-Cache")),
+	}
+}

--- a/internal/responsecache/handle_request_test.go
+++ b/internal/responsecache/handle_request_test.go
@@ -116,8 +116,8 @@ func TestHandleInternalRequest_RejectsNilContext(t *testing.T) {
 	m := NewResponseCacheMiddlewareWithStore(cache.NewMapStore(), time.Hour)
 	var nilCtx context.Context
 
-	_, err := m.HandleInternalRequest(nilCtx, http.MethodPost, "/v1/chat/completions", []byte(`{}`), func(c *echo.Context) error {
-		return c.JSON(http.StatusOK, map[string]string{"ok": "1"})
+	_, err := m.HandleInternalRequest(nilCtx, http.MethodPost, "/v1/chat/completions", []byte(`{}`), func(context.Context) (*InternalResponse, error) {
+		return &InternalResponse{StatusCode: http.StatusOK, ContentType: "application/json", Body: []byte(`{"ok":"1"}`)}, nil
 	})
 	if err == nil {
 		t.Fatal("HandleInternalRequest() error = nil, want invalid request error")
@@ -194,8 +194,8 @@ func TestInternalRequestHeaders_AllowlistsSafeSnapshotHeaders(t *testing.T) {
 func TestHandleInternalRequest_RejectsNilMiddleware(t *testing.T) {
 	var m *ResponseCacheMiddleware
 
-	_, err := m.HandleInternalRequest(context.Background(), http.MethodPost, "/v1/chat/completions", []byte(`{}`), func(c *echo.Context) error {
-		return c.JSON(http.StatusOK, map[string]string{"ok": "1"})
+	_, err := m.HandleInternalRequest(context.Background(), http.MethodPost, "/v1/chat/completions", []byte(`{}`), func(context.Context) (*InternalResponse, error) {
+		return &InternalResponse{StatusCode: http.StatusOK, ContentType: "application/json", Body: []byte(`{"ok":"1"}`)}, nil
 	})
 	if err == nil {
 		t.Fatal("HandleInternalRequest() error = nil, want provider error")
@@ -217,8 +217,8 @@ func TestHandleInternalRequest_NormalizesNonGatewayErrors(t *testing.T) {
 	m := NewResponseCacheMiddlewareWithStore(cache.NewMapStore(), time.Hour)
 	originalErr := errors.New("cache executor failed")
 
-	_, err := m.HandleInternalRequest(context.Background(), http.MethodPost, "/v1/chat/completions", []byte(`{}`), func(*echo.Context) error {
-		return originalErr
+	_, err := m.HandleInternalRequest(context.Background(), http.MethodPost, "/v1/chat/completions", []byte(`{}`), func(context.Context) (*InternalResponse, error) {
+		return nil, originalErr
 	})
 	if err == nil {
 		t.Fatal("HandleInternalRequest() error = nil, want provider error")
@@ -239,25 +239,91 @@ func TestHandleInternalRequest_NormalizesNonGatewayErrors(t *testing.T) {
 	}
 }
 
-func TestHandleInternalRequest_RejectsUninitializedEcho(t *testing.T) {
+func TestHandleInternalRequest_ZeroValueMiddlewareIsNoOpCache(t *testing.T) {
+	// A zero-value middleware has no cache layers configured; internal
+	// requests must pass straight through to the LLM call.
 	m := &ResponseCacheMiddleware{}
+	calls := 0
 
-	_, err := m.HandleInternalRequest(context.Background(), http.MethodPost, "/v1/chat/completions", []byte(`{}`), func(c *echo.Context) error {
-		return c.JSON(http.StatusOK, map[string]string{"ok": "1"})
+	result, err := m.HandleInternalRequest(context.Background(), http.MethodPost, "/v1/chat/completions", []byte(`{}`), func(context.Context) (*InternalResponse, error) {
+		calls++
+		return &InternalResponse{StatusCode: http.StatusOK, ContentType: "application/json", Body: []byte(`{"ok":"1"}`)}, nil
 	})
-	if err == nil {
-		t.Fatal("HandleInternalRequest() error = nil, want provider error")
+	if err != nil {
+		t.Fatalf("HandleInternalRequest() error = %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("handler calls = %d, want 1", calls)
+	}
+	if result.StatusCode != http.StatusOK || string(result.Body) != `{"ok":"1"}` {
+		t.Fatalf("result = %d %s, want 200 {\"ok\":\"1\"}", result.StatusCode, result.Body)
+	}
+	if result.CacheType != "" {
+		t.Fatalf("CacheType = %q, want empty on a cacheless pass-through", result.CacheType)
+	}
+}
+
+func TestHandleInternalRequest_ExactMissThenHit(t *testing.T) {
+	m := NewResponseCacheMiddlewareWithStore(cache.NewMapStore(), time.Hour)
+	body := []byte(`{"model":"gpt-test","messages":[{"role":"user","content":"hi"}]}`)
+	response := `{"id":"chatcmpl-1","choices":[]}`
+	calls := 0
+
+	run := func() *InternalHandleResult {
+		t.Helper()
+		result, err := m.HandleInternalRequest(context.Background(), http.MethodPost, "/v1/chat/completions", body, func(context.Context) (*InternalResponse, error) {
+			calls++
+			return &InternalResponse{StatusCode: http.StatusOK, ContentType: "application/json", Body: []byte(response)}, nil
+		})
+		if err != nil {
+			t.Fatalf("HandleInternalRequest() error = %v", err)
+		}
+		return result
 	}
 
-	gatewayErr, ok := err.(*core.GatewayError)
-	if !ok {
-		t.Fatalf("HandleInternalRequest() error = %T, want *core.GatewayError", err)
+	first := run()
+	if first.CacheType != "" {
+		t.Fatalf("first call CacheType = %q, want miss", first.CacheType)
 	}
-	if gatewayErr.Type != core.ErrorTypeProvider {
-		t.Fatalf("error type = %q, want %q", gatewayErr.Type, core.ErrorTypeProvider)
+	if calls != 1 {
+		t.Fatalf("handler calls = %d, want 1", calls)
 	}
-	if gatewayErr.HTTPStatusCode() != http.StatusInternalServerError {
-		t.Fatalf("status code = %d, want %d", gatewayErr.HTTPStatusCode(), http.StatusInternalServerError)
+	m.simple.wg.Wait()
+
+	second := run()
+	if second.CacheType != CacheTypeExact {
+		t.Fatalf("second call CacheType = %q, want %q", second.CacheType, CacheTypeExact)
+	}
+	if calls != 1 {
+		t.Fatalf("exact hit must not call the handler again, calls = %d", calls)
+	}
+	if string(second.Body) != response {
+		t.Fatalf("cached body = %s, want %s", second.Body, response)
+	}
+	if second.StatusCode != http.StatusOK {
+		t.Fatalf("cached status = %d, want 200", second.StatusCode)
+	}
+	if got := second.Headers.Get("X-Cache"); got != CacheHeaderExact {
+		t.Fatalf("X-Cache = %q, want %q", got, CacheHeaderExact)
+	}
+
+	// FailoverUsed responses must never be stored.
+	failoverBody := []byte(`{"model":"gpt-test","messages":[{"role":"user","content":"failover"}]}`)
+	_, err := m.HandleInternalRequest(context.Background(), http.MethodPost, "/v1/chat/completions", failoverBody, func(context.Context) (*InternalResponse, error) {
+		return &InternalResponse{StatusCode: http.StatusOK, ContentType: "application/json", Body: []byte(response), FailoverUsed: true}, nil
+	})
+	if err != nil {
+		t.Fatalf("HandleInternalRequest() error = %v", err)
+	}
+	m.simple.wg.Wait()
+	followUp, err := m.HandleInternalRequest(context.Background(), http.MethodPost, "/v1/chat/completions", failoverBody, func(context.Context) (*InternalResponse, error) {
+		return &InternalResponse{StatusCode: http.StatusOK, ContentType: "application/json", Body: []byte(response)}, nil
+	})
+	if err != nil {
+		t.Fatalf("HandleInternalRequest() error = %v", err)
+	}
+	if followUp.CacheType != "" {
+		t.Fatalf("failover response was cached: CacheType = %q, want miss", followUp.CacheType)
 	}
 }
 

--- a/internal/responsecache/responsecache.go
+++ b/internal/responsecache/responsecache.go
@@ -1,12 +1,10 @@
 package responsecache
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"log/slog"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"time"
 
@@ -41,7 +39,6 @@ var internalRequestHeaderAllowlist = map[string]struct{}{
 type ResponseCacheMiddleware struct {
 	simple   *simpleCacheMiddleware
 	semantic *semanticCacheMiddleware
-	echo     *echo.Echo
 }
 
 // InternalHandleResult is the buffered result of running the cache middleware
@@ -64,7 +61,6 @@ func NewResponseCacheMiddleware(
 	pricingResolver usage.PricingResolver,
 ) (*ResponseCacheMiddleware, error) {
 	m := &ResponseCacheMiddleware{}
-	m.echo = echo.New()
 	hitRecorder := newUsageHitRecorder(usageLogger, pricingResolver)
 
 	switch {
@@ -148,15 +144,22 @@ func (m *ResponseCacheMiddleware) HandleRequest(c *echo.Context, body []byte, ne
 	if m == nil {
 		return next()
 	}
-	if ShouldSkipAllCache(c.Request()) {
+	return m.handle(&echoExchange{c: c}, body, next)
+}
+
+// handle runs the dual-layer cache check against any transport. It contains
+// the full cache decision logic; HandleRequest and HandleInternalRequest are
+// thin transport adapters over it.
+func (m *ResponseCacheMiddleware) handle(ex exchange, body []byte, next func() error) error {
+	if shouldSkipAllCacheHeaders(ex.RequestHeader) {
 		return next()
 	}
 
-	skipExact := ShouldSkipExactCache(c.Request())
-	skipSemantic := m.semantic == nil || strings.EqualFold(c.Request().Header.Get("X-Cache-Type"), CacheTypeExact)
+	skipExact := strings.EqualFold(ex.RequestHeader("X-Cache-Type"), CacheTypeSemantic)
+	skipSemantic := m.semantic == nil || strings.EqualFold(ex.RequestHeader("X-Cache-Type"), CacheTypeExact)
 
 	if !skipExact && m.simple != nil {
-		hit, err := m.simple.TryHit(c, body)
+		hit, err := m.simple.TryHit(ex, body)
 		if err != nil || hit {
 			return err
 		}
@@ -166,45 +169,36 @@ func (m *ResponseCacheMiddleware) HandleRequest(c *echo.Context, body []byte, ne
 	// wrap next inside StoreAfter so both cache layers write on a full miss.
 	innerNext := next
 	if !skipExact && m.simple != nil {
-		innerNext = func() error { return m.simple.StoreAfter(c, body, next) }
+		innerNext = func() error { return m.simple.StoreAfter(ex, body, next) }
 	}
 
 	if !skipSemantic {
-		return m.semantic.Handle(c, body, innerNext)
+		return m.semantic.Handle(ex, body, innerNext)
 	}
 
 	return innerNext()
 }
 
-// HandleInternalRequest runs the normal cache middleware for a transport-free
-// internal request using a minimal synthetic HTTP/Echo context.
+// HandleInternalRequest runs the cache for a transport-free internal JSON
+// request. Request headers are derived from the originating request snapshot
+// (allowlisted), and next executes the LLM call, returning a buffered
+// response instead of writing to a socket.
 func (m *ResponseCacheMiddleware) HandleInternalRequest(
 	ctx context.Context,
 	method, path string,
 	body []byte,
-	next func(*echo.Context) error,
+	next func(ctx context.Context) (*InternalResponse, error),
 ) (*InternalHandleResult, error) {
 	if ctx == nil {
 		return nil, core.NewInvalidRequestError("context is required", nil)
 	}
-
-	req := httptest.NewRequest(method, path, bytes.NewReader(body))
-	req.Header = internalRequestHeaders(ctx)
-	req = req.WithContext(ctx)
-
 	if m == nil {
 		slog.Error("response cache: HandleInternalRequest called on nil middleware")
 		return nil, core.NewProviderError("", http.StatusInternalServerError, "response cache middleware is not initialized", nil)
 	}
-	if m.echo == nil {
-		slog.Error("response cache: HandleInternalRequest called with uninitialized Echo instance")
-		return nil, core.NewProviderError("", http.StatusInternalServerError, "response cache middleware is not initialized", nil)
-	}
 
-	rec := httptest.NewRecorder()
-	c := m.echo.NewContext(req, rec)
-
-	err := m.HandleRequest(c, body, func() error { return next(c) })
+	ex := newInternalExchange(ctx, method, path, next)
+	err := m.handle(ex, body, ex.runNext)
 	if err != nil {
 		var gatewayErr *core.GatewayError
 		if errors.As(err, &gatewayErr) && gatewayErr != nil {
@@ -213,12 +207,7 @@ func (m *ResponseCacheMiddleware) HandleInternalRequest(
 		return nil, core.NewProviderError("", http.StatusInternalServerError, err.Error(), err)
 	}
 
-	return &InternalHandleResult{
-		StatusCode: rec.Code,
-		Headers:    rec.Header().Clone(),
-		Body:       bytes.Clone(rec.Body.Bytes()),
-		CacheType:  internalCacheType(rec.Header().Get("X-Cache")),
-	}, nil
+	return ex.result(), nil
 }
 
 // UsesRedis reports whether a Redis-backed exact (simple) cache is configured.
@@ -304,6 +293,5 @@ func internalCacheType(headerValue string) string {
 func NewResponseCacheMiddlewareWithStore(store cache.Store, ttl time.Duration) *ResponseCacheMiddleware {
 	return &ResponseCacheMiddleware{
 		simple: newSimpleCacheMiddleware(store, ttl, nil),
-		echo:   echo.New(),
 	}
 }

--- a/internal/responsecache/semantic.go
+++ b/internal/responsecache/semantic.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"hash"
-	"io"
 	"log/slog"
 	"net/http"
 	"sort"
@@ -19,10 +18,8 @@ import (
 	"github.com/goccy/go-json"
 
 	"github.com/cespare/xxhash/v2"
-	"github.com/labstack/echo/v5"
 
 	"gomodel/config"
-	"gomodel/internal/auditlog"
 	"gomodel/internal/core"
 	"gomodel/internal/embedding"
 )
@@ -45,7 +42,7 @@ type semanticCacheMiddleware struct {
 	store            VecStore
 	cfg              config.SemanticCacheConfig
 	embedderIdentity string
-	hitRecorder      func(*echo.Context, []byte, string)
+	hitRecorder      func(exchange, []byte, string)
 
 	// Vector-store inserts run on a bounded worker pool so a burst of cache
 	// misses cannot spawn unbounded goroutines against the vector store. wg
@@ -57,7 +54,7 @@ type semanticCacheMiddleware struct {
 	closed  bool
 }
 
-func newSemanticCacheMiddleware(emb embedding.Embedder, store VecStore, cfg config.SemanticCacheConfig, hitRecorder func(*echo.Context, []byte, string)) *semanticCacheMiddleware {
+func newSemanticCacheMiddleware(emb embedding.Embedder, store VecStore, cfg config.SemanticCacheConfig, hitRecorder func(exchange, []byte, string)) *semanticCacheMiddleware {
 	m := &semanticCacheMiddleware{
 		embedder:         emb,
 		store:            store,
@@ -109,21 +106,21 @@ func (m *semanticCacheMiddleware) enqueueWrite(job semanticCacheWriteJob) {
 
 // Handle processes a single request/response cycle for semantic caching.
 // It must be called after guardrail patching so params_hash reflects the final policy.
-func (m *semanticCacheMiddleware) Handle(c *echo.Context, body []byte, next func() error) error {
+func (m *semanticCacheMiddleware) Handle(ex exchange, body []byte, next func() error) error {
 	if m == nil || m.store == nil {
 		return next()
 	}
 
-	path := c.Request().URL.Path
-	if !cacheablePaths[path] || c.Request().Method != http.MethodPost {
+	path := ex.Path()
+	if !cacheablePaths[path] || ex.Method() != http.MethodPost {
 		return next()
 	}
 
-	if shouldSkipSemanticCache(c.Request()) {
+	if shouldSkipSemanticCacheHeaders(ex.RequestHeader) {
 		return next()
 	}
 
-	ctx := c.Request().Context()
+	ctx := ex.Context()
 	plan := core.GetWorkflow(ctx)
 
 	embedText, msgCount := extractEmbedText(body, m.cfg.ExcludeSystemPrompt)
@@ -132,7 +129,7 @@ func (m *semanticCacheMiddleware) Handle(c *echo.Context, body []byte, next func
 	}
 
 	threshold := m.cfg.SimilarityThreshold
-	if v := headerFloat64(c.Request(), "X-Cache-Semantic-Threshold"); v > 0 {
+	if v := headerFloat64(ex.RequestHeader, "X-Cache-Semantic-Threshold"); v > 0 {
 		threshold = v
 	}
 
@@ -160,28 +157,23 @@ func (m *semanticCacheMiddleware) Handle(c *echo.Context, body []byte, next func
 	}
 
 	if len(results) > 0 && float64(results[0].Score) >= threshold {
-		replayErr := writeCachedResponse(c, path, body, results[0].Response, CacheTypeSemantic)
+		replayErr := ex.ReplayHit(body, results[0].Response, CacheTypeSemantic)
 		if replayErr == nil {
-			auditlog.EnrichEntryWithCacheType(c, CacheTypeSemantic)
+			ex.MarkHit(CacheTypeSemantic)
 			if m.hitRecorder != nil {
-				m.hitRecorder(c, results[0].Response, CacheTypeSemantic)
+				m.hitRecorder(ex, results[0].Response, CacheTypeSemantic)
 			}
 			slog.Info("semantic cache hit",
 				"path", path,
 				"score", results[0].Score,
-				"request_id", c.Request().Header.Get("X-Request-ID"),
+				"request_id", ex.RequestHeader("X-Request-ID"),
 			)
 			return nil
 		}
 		slog.Warn("semantic cache replay failed", "path", path, "err", replayErr)
 	}
 
-	data, ok, err := captureResponseForCache(
-		c,
-		path,
-		"semantic cache: failed to capture cacheable response body",
-		next,
-	)
+	data, ok, err := ex.Capture("semantic cache: failed to capture cacheable response body", next)
 	if err != nil {
 		return err
 	}
@@ -193,7 +185,7 @@ func (m *semanticCacheMiddleware) Handle(c *echo.Context, body []byte, next func
 		ttlSec = *m.cfg.TTL
 	}
 	ttl := time.Duration(ttlSec) * time.Second
-	if v := headerDuration(c.Request(), "X-Cache-TTL"); v > 0 {
+	if v := headerDuration(ex.RequestHeader, "X-Cache-TTL"); v > 0 {
 		ttl = v
 	}
 
@@ -553,16 +545,15 @@ func sortedTools(tools []map[string]any) []map[string]any {
 	return sorted
 }
 
-func shouldSkipSemanticCache(req *http.Request) bool {
-	if shouldSkipCache(req) {
+func shouldSkipSemanticCacheHeaders(header func(string) string) bool {
+	if shouldSkipCacheControl(header("Cache-Control")) {
 		return true
 	}
-	ct := req.Header.Get("X-Cache-Type")
-	return strings.EqualFold(ct, "exact")
+	return strings.EqualFold(header("X-Cache-Type"), "exact")
 }
 
-func headerFloat64(req *http.Request, name string) float64 {
-	s := req.Header.Get(name)
+func headerFloat64(header func(string) string, name string) float64 {
+	s := header(name)
 	if s == "" {
 		return 0
 	}
@@ -573,8 +564,8 @@ func headerFloat64(req *http.Request, name string) float64 {
 	return v
 }
 
-func headerDuration(req *http.Request, name string) time.Duration {
-	s := req.Header.Get(name)
+func headerDuration(header func(string) string, name string) time.Duration {
+	s := header(name)
 	if s == "" {
 		return 0
 	}
@@ -647,10 +638,14 @@ func ShouldSkipExactCache(req *http.Request) bool {
 // ShouldSkipAllCache reports whether caching must be bypassed for this request,
 // matching the exact-cache middleware semantics for no-cache and no-store.
 func ShouldSkipAllCache(req *http.Request) bool {
-	if strings.EqualFold(req.Header.Get("X-Cache-Control"), "no-store") {
+	return shouldSkipAllCacheHeaders(req.Header.Get)
+}
+
+func shouldSkipAllCacheHeaders(header func(string) string) bool {
+	if strings.EqualFold(header("X-Cache-Control"), "no-store") {
 		return true
 	}
-	cc := req.Header.Get("Cache-Control")
+	cc := header("Cache-Control")
 	if cc == "" {
 		return false
 	}
@@ -662,15 +657,4 @@ func ShouldSkipAllCache(req *http.Request) bool {
 		}
 	}
 	return false
-}
-
-// IoReadAllBody reads and restores c.Request().Body, returning the raw bytes.
-// Safe to call multiple times — each call resets the body.
-func IoReadAllBody(c *echo.Context) ([]byte, error) {
-	body, err := io.ReadAll(c.Request().Body)
-	if err != nil {
-		return nil, err
-	}
-	c.Request().Body = io.NopCloser(bytes.NewReader(body))
-	return body, nil
 }

--- a/internal/responsecache/semantic.go
+++ b/internal/responsecache/semantic.go
@@ -645,16 +645,5 @@ func shouldSkipAllCacheHeaders(header func(string) string) bool {
 	if strings.EqualFold(header("X-Cache-Control"), "no-store") {
 		return true
 	}
-	cc := header("Cache-Control")
-	if cc == "" {
-		return false
-	}
-	directives := strings.Split(strings.ToLower(cc), ",")
-	for _, d := range directives {
-		d = strings.TrimSpace(d)
-		if d == "no-cache" || d == "no-store" {
-			return true
-		}
-	}
-	return false
+	return shouldSkipCacheControl(header("Cache-Control"))
 }

--- a/internal/responsecache/semantic_test.go
+++ b/internal/responsecache/semantic_test.go
@@ -59,7 +59,7 @@ func serveSemanticRequest(t *testing.T, m *semanticCacheMiddleware, body []byte,
 		req = req.WithContext(ctx)
 	}
 	c := e.NewContext(req, rec)
-	err := m.Handle(c, body, func() error {
+	err := m.Handle(&echoExchange{c: c}, body, func() error {
 		return c.JSON(http.StatusOK, map[string]string{"answer": "42"})
 	})
 	if err != nil {
@@ -343,7 +343,7 @@ func TestSemanticCacheMiddleware_StreamingMissPopulatesStreamingSemanticCacheOnl
 		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()
 		c := e.NewContext(req, rec)
-		if err := m.Handle(c, body, func() error {
+		if err := m.Handle(&echoExchange{c: c}, body, func() error {
 			handlerCalls++
 			if isStreamingRequest(c.Request().URL.Path, body) {
 				c.Response().Header().Set("Content-Type", "text/event-stream")
@@ -434,7 +434,7 @@ func TestSemanticCacheMiddleware_InvalidStreamingBodySkipsSemanticCacheWrite(t *
 		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()
 		c := e.NewContext(req, rec)
-		if err := m.Handle(c, body, func() error {
+		if err := m.Handle(&echoExchange{c: c}, body, func() error {
 			handlerCalls++
 			c.Response().Header().Set("Content-Type", "text/event-stream")
 			c.Response().WriteHeader(http.StatusOK)
@@ -478,7 +478,7 @@ func TestSemanticCacheMiddleware_NoCacheControlSkip(t *testing.T) {
 	c := e.NewContext(req, rec)
 
 	handlerCalled := false
-	err := m.Handle(c, body, func() error {
+	err := m.Handle(&echoExchange{c: c}, body, func() error {
 		handlerCalled = true
 		return c.JSON(http.StatusOK, map[string]string{"r": "1"})
 	})
@@ -519,7 +519,7 @@ func TestSemanticCacheMiddleware_HeaderThresholdOverride(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
-	if err := m.Handle(c, body, func() error {
+	if err := m.Handle(&echoExchange{c: c}, body, func() error {
 		return c.JSON(http.StatusOK, map[string]string{"r": "1"})
 	}); err != nil {
 		t.Fatalf("Handle: %v", err)
@@ -656,7 +656,7 @@ func TestSemanticCacheMiddleware_HitMarksAuditEntryCacheType(t *testing.T) {
 	entry := &auditlog.LogEntry{ID: "semantic-audit-entry"}
 	c.Set(string(auditlog.LogEntryKey), entry)
 
-	if err := m.Handle(c, body, func() error {
+	if err := m.Handle(&echoExchange{c: c}, body, func() error {
 		return c.JSON(http.StatusOK, map[string]string{"answer": "42"})
 	}); err != nil {
 		t.Fatalf("Handle error: %v", err)

--- a/internal/responsecache/simple.go
+++ b/internal/responsecache/simple.go
@@ -17,7 +17,6 @@ import (
 	"github.com/labstack/echo/v5"
 	"github.com/tidwall/gjson"
 
-	"gomodel/internal/auditlog"
 	"gomodel/internal/cache"
 	"gomodel/internal/core"
 )
@@ -44,14 +43,14 @@ type simpleCacheMiddleware struct {
 	wg    sync.WaitGroup
 	jobs  chan cacheWriteJob
 
-	hitRecorder func(*echo.Context, []byte, string)
+	hitRecorder func(exchange, []byte, string)
 
 	workers sync.WaitGroup
 	mu      sync.RWMutex
 	closed  bool
 }
 
-func newSimpleCacheMiddleware(store cache.Store, ttl time.Duration, hitRecorder func(*echo.Context, []byte, string)) *simpleCacheMiddleware {
+func newSimpleCacheMiddleware(store cache.Store, ttl time.Duration, hitRecorder func(exchange, []byte, string)) *simpleCacheMiddleware {
 	m := &simpleCacheMiddleware{
 		store:       store,
 		ttl:         ttl,
@@ -86,40 +85,41 @@ func (m *simpleCacheMiddleware) Middleware() echo.MiddlewareFunc {
 			if shouldSkipCacheForWorkflow(plan) {
 				return next(c)
 			}
-			hit, err := m.TryHit(c, body)
+			ex := &echoExchange{c: c}
+			hit, err := m.TryHit(ex, body)
 			if err != nil || hit {
 				return err
 			}
-			return m.StoreAfter(c, body, func() error { return next(c) })
+			return m.StoreAfter(ex, body, func() error { return next(c) })
 		}
 	}
 }
 
-// TryHit checks the exact-match cache. Returns (true, nil) and writes the cached
-// response if found. Returns (false, nil) on a miss.
-func (m *simpleCacheMiddleware) TryHit(c *echo.Context, body []byte) (bool, error) {
+// TryHit checks the exact-match cache. Returns (true, nil) and replays the
+// cached response if found. Returns (false, nil) on a miss.
+func (m *simpleCacheMiddleware) TryHit(ex exchange, body []byte) (bool, error) {
 	if m == nil || m.store == nil {
 		return false, nil
 	}
-	path := c.Request().URL.Path
-	plan := core.GetWorkflow(c.Request().Context())
+	path := ex.Path()
+	plan := core.GetWorkflow(ex.Context())
 	key := hashRequest(path, body, plan)
-	cached, err := m.store.Get(c.Request().Context(), key)
+	cached, err := m.store.Get(ex.Context(), key)
 	if err != nil {
 		return false, nil
 	}
 	if len(cached) > 0 {
-		if err := writeCachedResponse(c, path, body, cached, CacheTypeExact); err != nil {
+		if err := ex.ReplayHit(body, cached, CacheTypeExact); err != nil {
 			slog.Warn("response cache replay failed", "path", path, "cache_type", CacheTypeExact, "err", err)
 			return false, nil
 		}
-		auditlog.EnrichEntryWithCacheType(c, CacheTypeExact)
+		ex.MarkHit(CacheTypeExact)
 		if m.hitRecorder != nil {
-			m.hitRecorder(c, cached, CacheTypeExact)
+			m.hitRecorder(ex, cached, CacheTypeExact)
 		}
 		slog.Info("response cache hit (exact)",
 			"path", path,
-			"request_id", c.Request().Header.Get("X-Request-ID"),
+			"request_id", ex.RequestHeader("X-Request-ID"),
 		)
 		return true, nil
 	}
@@ -128,20 +128,15 @@ func (m *simpleCacheMiddleware) TryHit(c *echo.Context, body []byte) (bool, erro
 
 // StoreAfter calls next, captures the response, and asynchronously stores it on
 // a cacheable success response.
-func (m *simpleCacheMiddleware) StoreAfter(c *echo.Context, body []byte, next func() error) error {
+func (m *simpleCacheMiddleware) StoreAfter(ex exchange, body []byte, next func() error) error {
 	if m == nil || m.store == nil {
 		return next()
 	}
-	path := c.Request().URL.Path
-	plan := core.GetWorkflow(c.Request().Context())
+	path := ex.Path()
+	plan := core.GetWorkflow(ex.Context())
 	key := hashRequest(path, body, plan)
 
-	data, ok, err := captureResponseForCache(
-		c,
-		path,
-		"response cache: failed to capture cacheable response body",
-		next,
-	)
+	data, ok, err := ex.Capture("response cache: failed to capture cacheable response body", next)
 	if err != nil {
 		return err
 	}
@@ -236,7 +231,10 @@ func requestBodyForCache(req *http.Request) ([]byte, bool, error) {
 }
 
 func shouldSkipCache(req *http.Request) bool {
-	cc := req.Header.Get("Cache-Control")
+	return shouldSkipCacheControl(req.Header.Get("Cache-Control"))
+}
+
+func shouldSkipCacheControl(cc string) bool {
 	if cc == "" {
 		return false
 	}
@@ -294,8 +292,15 @@ func (r *responseCapture) cachedBody(contentType string) ([]byte, bool) {
 	if r == nil || r.body == nil || r.body.Len() == 0 {
 		return nil, false
 	}
+	return cacheableResponseBody(bytes.Clone(r.body.Bytes()), contentType)
+}
 
-	raw := bytes.Clone(r.body.Bytes())
+// cacheableResponseBody validates that raw is storable: well-formed SSE for
+// event streams, valid JSON otherwise.
+func cacheableResponseBody(raw []byte, contentType string) ([]byte, bool) {
+	if len(raw) == 0 {
+		return nil, false
+	}
 	if isEventStreamContentType(contentType) {
 		if !validateCacheableSSE(raw) {
 			return nil, false

--- a/internal/responsecache/usage_hit.go
+++ b/internal/responsecache/usage_hit.go
@@ -4,23 +4,21 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/labstack/echo/v5"
-
 	"gomodel/internal/core"
 	"gomodel/internal/usage"
 )
 
-func newUsageHitRecorder(logger usage.LoggerInterface, pricingResolver usage.PricingResolver) func(*echo.Context, []byte, string) {
+func newUsageHitRecorder(logger usage.LoggerInterface, pricingResolver usage.PricingResolver) func(exchange, []byte, string) {
 	if logger == nil || !logger.Config().Enabled {
 		return nil
 	}
 
-	return func(c *echo.Context, body []byte, cacheType string) {
-		if c == nil {
+	return func(ex exchange, body []byte, cacheType string) {
+		if ex == nil {
 			return
 		}
 
-		ctx := c.Request().Context()
+		ctx := ex.Context()
 		plan := core.GetWorkflow(ctx)
 		if plan != nil && !plan.UsageEnabled() {
 			return
@@ -41,10 +39,10 @@ func newUsageHitRecorder(logger usage.LoggerInterface, pricingResolver usage.Pri
 			return
 		}
 
-		endpoint := c.Request().URL.Path
+		endpoint := ex.Path()
 		requestID := core.GetRequestID(ctx)
 		if requestID == "" {
-			requestID = c.Request().Header.Get("X-Request-ID")
+			requestID = ex.RequestHeader("X-Request-ID")
 		}
 
 		var pricing *core.ModelPricing

--- a/internal/server/internal_chat_completion_executor.go
+++ b/internal/server/internal_chat_completion_executor.go
@@ -11,7 +11,6 @@ import (
 	"github.com/goccy/go-json"
 
 	"github.com/google/uuid"
-	"github.com/labstack/echo/v5"
 
 	"gomodel/internal/auditlog"
 	"gomodel/internal/core"
@@ -147,16 +146,22 @@ func (e *InternalChatCompletionExecutor) executeChatCompletion(
 		failoverModel string
 		usedFailover  bool
 	)
-	result, err := e.responseCache.HandleInternalRequest(ctx, http.MethodPost, "/v1/chat/completions", body, func(c *echo.Context) error {
+	result, err := e.responseCache.HandleInternalRequest(ctx, http.MethodPost, "/v1/chat/completions", body, func(callCtx context.Context) (*responsecache.InternalResponse, error) {
 		var execErr error
-		resp, providerType, providerName, failoverModel, usedFailover, execErr = e.orchestrator.DispatchChatCompletion(c.Request().Context(), workflow, req)
+		resp, providerType, providerName, failoverModel, usedFailover, execErr = e.orchestrator.DispatchChatCompletion(callCtx, workflow, req)
 		if execErr != nil {
-			return execErr
+			return nil, execErr
 		}
-		if usedFailover {
-			c.SetRequest(c.Request().WithContext(core.WithFailoverUsed(c.Request().Context())))
+		respBody, marshalErr := json.Marshal(resp)
+		if marshalErr != nil {
+			return nil, marshalErr
 		}
-		return c.JSON(http.StatusOK, resp)
+		return &responsecache.InternalResponse{
+			StatusCode:   http.StatusOK,
+			ContentType:  "application/json",
+			Body:         respBody,
+			FailoverUsed: usedFailover,
+		}, nil
 	})
 	if err != nil {
 		return nil, "", "", "", false, "", err


### PR DESCRIPTION
## Summary

Third PR from the architecture review (doc in #472; follows #473). The response cache's decision logic was modeled as HTTP middleware, so the internal guardrail LLM path had to fabricate a fake HTTP request/recorder with `net/http/httptest` in production code to pass through it.

This introduces an `exchange` seam — request info, hit replay, miss capture, hit side effects — with two implementations:

- **`echoExchange`**: the HTTP adapter; now the only place cache logic touches the web framework (replay/capture keep their existing echo implementations, including SSE streaming replay).
- **`internalExchange`**: a buffered transport-free call for the guardrail executor; request headers still come from the originating request's snapshot allowlist.

`HandleRequest` (HTTP) and `HandleInternalRequest` (internal) are thin adapters over one shared `handle()` core, so the two paths can no longer drift.

### What's gone
- `httptest` and the synthetic `echo.Echo` instance in production code.
- Dead exported `IoReadAllBody` (zero callers).
- The `m.echo == nil` failure mode: a zero-value middleware is now a working no-op cache (pinned by a test).

### Behavior
Unchanged: same cache keys, same skip-header semantics, same capture rules (200-only, JSON/SSE validation, failover responses never stored), same usage/audit hit recording. Audit enrichment stays HTTP-only — on the old synthetic internal context it was already a silent no-op since the echo store was empty.

New coverage: internal exact miss→hit round trip (incl. failover-responses-never-stored) and the zero-value no-op case.

### Follow-up (intentionally not here)
Deleting the legacy `ResponseCacheMiddleware.Middleware()` path (possible-refactoring #4) — it now shims through the same exchange seam, but its removal requires migrating ~15 middleware-driven tests per that doc's guidance, so it stays a separate focused change.

## Testing
Full `go build ./...` and `go test ./...` pass; `go test -race` on responsecache + server; `golangci-lint` 0 issues; pre-commit `make test-race` on the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Internal requests now use the same response-caching behavior as regular HTTP requests.
  * Streaming responses are handled more consistently, including server-sent events.
  * Cache results now include clearer response details such as status, content type, and failover usage.

* **Bug Fixes**
  * Improved cache hit/miss behavior for internal calls, including proper replay of stored responses.
  * Prevents failover responses from being stored as cacheable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->