### PR TITLE
feat(usage): track prompt tokens and cost saved by request rewriters

### DIFF
--- a/cmd/gomodel/docs/docs.go
+++ b/cmd/gomodel/docs/docs.go
@@ -5540,6 +5540,13 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "request_revisions": {
+                    "description": "RequestRevisions captures the ingress request-rewrite chain: one entry\nper registered rewriter that changed the body, in application order.\nRequestBody always remains the original client request; the last\nrevision is what was forwarded downstream.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/auditlog.RequestRevisionSnapshot"
+                    }
+                },
                 "response_body": {},
                 "response_body_too_big_to_handle": {
                     "type": "boolean"
@@ -5644,6 +5651,29 @@ const docTemplate = `{
                 },
                 "workflow_version_id": {
                     "type": "string"
+                }
+            }
+        },
+        "auditlog.RequestRevisionSnapshot": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "description": "Body is the request body after this revision (parsed JSON, or a string\nwhen not valid JSON). Populated only when body logging is enabled and\nthe body is within the capture limit."
+                },
+                "bytes_after": {
+                    "type": "integer"
+                },
+                "bytes_before": {
+                    "type": "integer"
+                },
+                "detail": {
+                    "description": "Detail is an optional rewriter-provided structured summary of what\nchanged (for example a compression block report)."
+                },
+                "rewriter": {
+                    "type": "string"
+                },
+                "seq": {
+                    "type": "integer"
                 }
             }
         },
@@ -7798,6 +7828,13 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "cached_input_tokens": {
+                    "type": "integer"
+                },
+                "rewrite_cost_saved": {
+                    "type": "number"
+                },
+                "rewrite_tokens_saved": {
+                    "description": "Rewrite savings: prompt tokens request rewriters removed before the\nprovider call, and the estimated input cost avoided (nil when no\nmatched row had a priced savings estimate).",
                     "type": "integer"
                 },
                 "total_cost": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7827,6 +7827,13 @@
               "type": "string"
             }
           },
+          "request_revisions": {
+            "description": "RequestRevisions captures the ingress request-rewrite chain: one entry\nper registered rewriter that changed the body, in application order.\nRequestBody always remains the original client request; the last\nrevision is what was forwarded downstream.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/auditlog.RequestRevisionSnapshot"
+            }
+          },
           "response_body": {},
           "response_body_too_big_to_handle": {
             "type": "boolean"
@@ -7931,6 +7938,29 @@
           },
           "workflow_version_id": {
             "type": "string"
+          }
+        }
+      },
+      "auditlog.RequestRevisionSnapshot": {
+        "type": "object",
+        "properties": {
+          "body": {
+            "description": "Body is the request body after this revision (parsed JSON, or a string\nwhen not valid JSON). Populated only when body logging is enabled and\nthe body is within the capture limit."
+          },
+          "bytes_after": {
+            "type": "integer"
+          },
+          "bytes_before": {
+            "type": "integer"
+          },
+          "detail": {
+            "description": "Detail is an optional rewriter-provided structured summary of what\nchanged (for example a compression block report)."
+          },
+          "rewriter": {
+            "type": "string"
+          },
+          "seq": {
+            "type": "integer"
           }
         }
       },
@@ -10126,6 +10156,13 @@
             "type": "integer"
           },
           "cached_input_tokens": {
+            "type": "integer"
+          },
+          "rewrite_cost_saved": {
+            "type": "number"
+          },
+          "rewrite_tokens_saved": {
+            "description": "Rewrite savings: prompt tokens request rewriters removed before the\nprovider call, and the estimated input cost avoided (nil when no\nmatched row had a priced savings estimate).",
             "type": "integer"
           },
           "total_cost": {

--- a/ext/ext.go
+++ b/ext/ext.go
@@ -55,6 +55,13 @@ type Result struct {
 	// chain and never sent upstream; it must never contain secrets or
 	// request credentials.
 	Detail any
+	// TokensSaved is the rewriter's estimate of prompt tokens its body
+	// change removed from the request. When positive and the rewritten body
+	// is applied, core adds it to the request's usage record together with
+	// the input cost those tokens would have incurred, and the dashboard
+	// aggregates both as rewrite savings. Leave zero when the rewrite does
+	// not shrink the prompt.
+	TokensSaved int
 }
 
 // RequestRewriter rewrites raw JSON request bodies at ingress, after

--- a/internal/admin/dashboard/static/js/modules/usage.js
+++ b/internal/admin/dashboard/static/js/modules/usage.js
@@ -23,7 +23,9 @@
                     cache_write_input_tokens: 0,
                     total_input_cost: null,
                     total_output_cost: null,
-                    total_cost: null
+                    total_cost: null,
+                    rewrite_tokens_saved: 0,
+                    rewrite_cost_saved: null
                 };
             },
 
@@ -517,6 +519,29 @@
                 const summary = this.usageSummary || {};
                 if (summary.total_input_cost === null || summary.total_input_cost === undefined) return '';
                 return this.formatCost(summary.total_input_cost) + ' input + ' + this.formatCost(summary.total_output_cost) + ' output';
+            },
+
+            // --- Rewrite savings (request rewriters, e.g. token compression) ---
+            // Savings ride on provider usage rows, so the uncached summary holds
+            // the full totals. Cards only appear once a rewriter reported savings.
+            usagePageRewriteTokensSaved() {
+                const saved = Number((this.usageSummary && this.usageSummary.rewrite_tokens_saved) || 0);
+                return Number.isFinite(saved) && saved > 0 ? saved : 0;
+            },
+
+            usagePageRewriteSavingsVisible() {
+                return this.usagePageRewriteTokensSaved() > 0;
+            },
+
+            usagePageRewriteCostSaved() {
+                const summary = this.usageSummary || {};
+                return summary.rewrite_cost_saved === undefined ? null : summary.rewrite_cost_saved;
+            },
+
+            usagePageRewriteSavedTitle() {
+                const tokens = this.usagePageRewriteTokensSaved();
+                if (tokens <= 0) return '';
+                return this.formatNumber(tokens) + ' prompt tokens removed by request rewriters before reaching providers';
             },
 
             async fetchModelUsage() {

--- a/internal/admin/dashboard/static/js/modules/usage.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/usage.test.cjs
@@ -388,6 +388,39 @@ test('usage page stat cards follow the log cache scope and derive hits from the 
     assert.equal(module.usagePageCostTitle(), '');
 });
 
+test('usage page rewrite savings cards show only when rewriters saved tokens', () => {
+    const module = createUsageModule();
+    module.formatNumber = (n) => String(n);
+
+    // No savings reported: cards hidden, zero-safe values.
+    module.usageSummary = { total_requests: 10 };
+    assert.equal(module.usagePageRewriteSavingsVisible(), false);
+    assert.equal(module.usagePageRewriteTokensSaved(), 0);
+    assert.equal(module.usagePageRewriteCostSaved(), null);
+    assert.equal(module.usagePageRewriteSavedTitle(), '');
+
+    // Savings with pricing: both cards visible with tokens and cost.
+    module.usageSummary = { rewrite_tokens_saved: 4200, rewrite_cost_saved: 0.0125 };
+    assert.equal(module.usagePageRewriteSavingsVisible(), true);
+    assert.equal(module.usagePageRewriteTokensSaved(), 4200);
+    assert.equal(module.usagePageRewriteCostSaved(), 0.0125);
+    assert.equal(
+        module.usagePageRewriteSavedTitle(),
+        '4200 prompt tokens removed by request rewriters before reaching providers'
+    );
+
+    // Savings without pricing: tokens card carries the value, cost stays null.
+    module.usageSummary = { rewrite_tokens_saved: 100, rewrite_cost_saved: null };
+    assert.equal(module.usagePageRewriteSavingsVisible(), true);
+    assert.equal(module.usagePageRewriteCostSaved(), null);
+
+    // Defensive: negative or garbage totals never surface.
+    module.usageSummary = { rewrite_tokens_saved: -5 };
+    assert.equal(module.usagePageRewriteSavingsVisible(), false);
+    module.usageSummary = { rewrite_tokens_saved: 'NaN?' };
+    assert.equal(module.usagePageRewriteSavingsVisible(), false);
+});
+
 test('fetchUsagePageSummary loads uncached and all cache modes with the page filters', async () => {
     const { app, fetchCalls } = createUsageLogApp({ usageFilterLabel: 'env:prod' });
 

--- a/internal/admin/dashboard/templates/page-usage.html
+++ b/internal/admin/dashboard/templates/page-usage.html
@@ -54,6 +54,14 @@
             <div class="card-label">Estimated Cost</div>
             <div class="card-value" x-text="formatCost(usageSummary.total_cost)" :title="usagePageCostTitle()">-</div>
         </div>
+        <div class="card" x-show="usagePageRewriteSavingsVisible()">
+            <div class="card-label">Rewrite Saved</div>
+            <div class="card-value" x-text="formatCost(usagePageRewriteCostSaved())" :title="usagePageRewriteSavedTitle()">-</div>
+        </div>
+        <div class="card" x-show="usagePageRewriteSavingsVisible()">
+            <div class="card-label">Tokens Saved</div>
+            <div class="card-value" x-text="formatNumber(usagePageRewriteTokensSaved())" :title="usagePageRewriteSavedTitle()">-</div>
+        </div>
         <div class="card" x-show="cacheAnalyticsEnabled()">
             <div class="card-label">Cache Saved</div>
             <div class="card-value" x-text="formatCost(cacheOverview.summary.total_saved_cost)">-</div>

--- a/internal/core/context.go
+++ b/internal/core/context.go
@@ -49,6 +49,11 @@ const (
 	// requestOriginKey stores the logical request origin for internal execution
 	// flows that still reuse the translated request pipeline.
 	requestOriginKey contextKey = "request-origin"
+
+	// rewriteTokensSavedKey stores the total prompt tokens that applied
+	// request rewriters estimate they removed from the request body. Usage
+	// recording folds it into the request's usage entry as rewrite savings.
+	rewriteTokensSavedKey contextKey = "rewrite-tokens-saved"
 )
 
 // RequestOrigin identifies whether a request came from an external caller or an
@@ -224,6 +229,27 @@ func GetFailoverUsed(ctx context.Context) bool {
 		}
 	}
 	return false
+}
+
+// WithRewriteTokensSaved returns a new context carrying the total prompt
+// tokens that applied request rewriters estimate they removed. Non-positive
+// totals leave the context unchanged.
+func WithRewriteTokensSaved(ctx context.Context, tokensSaved int) context.Context {
+	if tokensSaved <= 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, rewriteTokensSavedKey, tokensSaved)
+}
+
+// RewriteTokensSavedFromContext retrieves the request's rewrite savings
+// estimate, or zero when no rewriter reported savings.
+func RewriteTokensSavedFromContext(ctx context.Context) int {
+	if v := ctx.Value(rewriteTokensSavedKey); v != nil {
+		if saved, ok := v.(int); ok && saved > 0 {
+			return saved
+		}
+	}
+	return 0
 }
 
 // WithRequestOrigin returns a new context with the logical request origin attached.

--- a/internal/gateway/usage.go
+++ b/internal/gateway/usage.go
@@ -35,6 +35,7 @@ func (o *InferenceOrchestrator) logUsage(
 		entry.ProviderName = strings.TrimSpace(providerName)
 		entry.UserPath = core.UserPathFromContext(ctx)
 		entry.Labels = core.RequestLabelsFromContext(ctx)
+		usage.ApplyRewriteSavings(entry, core.RewriteTokensSavedFromContext(ctx), pricing)
 		o.usageLogger.Write(entry)
 	}
 }

--- a/internal/server/passthrough_support.go
+++ b/internal/server/passthrough_support.go
@@ -298,6 +298,7 @@ func (s *passthroughService) proxyPassthroughResponse(c *echo.Context, providerT
 			if observer := usage.NewStreamUsageObserver(s.usageLogger, model, providerType, requestID, usagePath, s.pricingResolver, core.UserPathFromContext(c.Request().Context())); observer != nil {
 				observer.SetProviderName(providerName)
 				observer.SetLabels(core.RequestLabelsFromContext(c.Request().Context()))
+				observer.SetRewriteTokensSaved(core.RewriteTokensSavedFromContext(c.Request().Context()))
 				observers = append(observers, observer)
 			}
 		}

--- a/internal/server/request_rewrite.go
+++ b/internal/server/request_rewrite.go
@@ -45,6 +45,7 @@ func RequestRewriteMiddleware(rewriters []ext.RequestRewriter, auditLogger audit
 			}
 
 			changed := false
+			tokensSaved := 0
 			for _, rw := range rewriters {
 				res, rwErr := rw.Rewrite(c.Request().Context(), in)
 				if rwErr != nil {
@@ -58,12 +59,19 @@ func RequestRewriteMiddleware(rewriters []ext.RequestRewriter, auditLogger audit
 					recordRequestRevision(c, auditLogger, rw.Name(), len(in.Body), res)
 					in.Body = res.Body
 					changed = true
+					if res.TokensSaved > 0 {
+						tokensSaved += res.TokensSaved
+					}
 				}
 			}
 
 			if changed {
 				pinOriginalAuditRequestBody(c, auditLogger)
 				applyRewrittenBody(c, in.Body)
+				if tokensSaved > 0 {
+					req := c.Request()
+					c.SetRequest(req.WithContext(core.WithRewriteTokensSaved(req.Context(), tokensSaved)))
+				}
 			}
 			return next(c)
 		}

--- a/internal/server/request_rewrite_test.go
+++ b/internal/server/request_rewrite_test.go
@@ -450,6 +450,13 @@ func TestRequestRewriteMiddlewareStoresTokensSavedInContext(t *testing.T) {
 			return &ext.Result{Body: in.Body, TokensSaved: 7}, nil
 		},
 	}
+	// A savings claim without an applied body rewrite must not count.
+	phantom := &stubRewriter{
+		name: "phantom",
+		rewrite: func(in ext.Input) (*ext.Result, error) {
+			return &ext.Result{TokensSaved: 999}, nil
+		},
+	}
 	noop := &stubRewriter{name: "noop"}
 
 	var got int
@@ -463,12 +470,44 @@ func TestRequestRewriteMiddlewareStoresTokensSavedInContext(t *testing.T) {
 		strings.NewReader(`{"model":"gpt-4o-mini","messages":[]}`))
 	c := e.NewContext(req, httptest.NewRecorder())
 
-	mw := RequestRewriteMiddleware([]ext.RequestRewriter{compressor, trimmer, noop}, nil)
+	mw := RequestRewriteMiddleware([]ext.RequestRewriter{compressor, trimmer, phantom, noop}, nil)
 	if err := mw(next)(c); err != nil {
 		t.Fatalf("middleware returned error: %v", err)
 	}
 	if got != 130 {
-		t.Fatalf("context tokens saved = %d, want 130 (sum across applied rewriters)", got)
+		t.Fatalf("context tokens saved = %d, want 130 (sum across applied rewriters only)", got)
+	}
+}
+
+func TestRequestRewriteMiddlewareIgnoresSavingsWithoutAppliedBody(t *testing.T) {
+	// Header-only annotator claiming savings without returning a body: the
+	// request is unchanged, so no savings may be recorded.
+	annotator := &stubRewriter{
+		name: "annotator",
+		rewrite: func(in ext.Input) (*ext.Result, error) {
+			header := http.Header{}
+			header.Set("X-Annotate", "yes")
+			return &ext.Result{ResponseHeader: header, TokensSaved: 55}, nil
+		},
+	}
+
+	var got int
+	next := func(c *echo.Context) error {
+		got = core.RewriteTokensSavedFromContext(c.Request().Context())
+		return c.NoContent(http.StatusOK)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4o-mini","messages":[]}`))
+	c := e.NewContext(req, httptest.NewRecorder())
+
+	mw := RequestRewriteMiddleware([]ext.RequestRewriter{annotator}, nil)
+	if err := mw(next)(c); err != nil {
+		t.Fatalf("middleware returned error: %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("context tokens saved = %d, want 0 when no body rewrite was applied", got)
 	}
 }
 

--- a/internal/server/request_rewrite_test.go
+++ b/internal/server/request_rewrite_test.go
@@ -436,3 +436,61 @@ func TestRequestRewriteMiddlewareRecordsRevisions(t *testing.T) {
 		}
 	})
 }
+
+func TestRequestRewriteMiddlewareStoresTokensSavedInContext(t *testing.T) {
+	compressor := &stubRewriter{
+		name: "compressor",
+		rewrite: func(in ext.Input) (*ext.Result, error) {
+			return &ext.Result{Body: in.Body, TokensSaved: 123}, nil
+		},
+	}
+	trimmer := &stubRewriter{
+		name: "trimmer",
+		rewrite: func(in ext.Input) (*ext.Result, error) {
+			return &ext.Result{Body: in.Body, TokensSaved: 7}, nil
+		},
+	}
+	noop := &stubRewriter{name: "noop"}
+
+	var got int
+	next := func(c *echo.Context) error {
+		got = core.RewriteTokensSavedFromContext(c.Request().Context())
+		return c.NoContent(http.StatusOK)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4o-mini","messages":[]}`))
+	c := e.NewContext(req, httptest.NewRecorder())
+
+	mw := RequestRewriteMiddleware([]ext.RequestRewriter{compressor, trimmer, noop}, nil)
+	if err := mw(next)(c); err != nil {
+		t.Fatalf("middleware returned error: %v", err)
+	}
+	if got != 130 {
+		t.Fatalf("context tokens saved = %d, want 130 (sum across applied rewriters)", got)
+	}
+}
+
+func TestRequestRewriteMiddlewareNoSavingsLeavesContextZero(t *testing.T) {
+	var got int
+	next := func(c *echo.Context) error {
+		got = core.RewriteTokensSavedFromContext(c.Request().Context())
+		return c.NoContent(http.StatusOK)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4o-mini","messages":[]}`))
+	c := e.NewContext(req, httptest.NewRecorder())
+
+	// A rewriter that changes the body without reporting savings must not
+	// invent a savings value.
+	mw := RequestRewriteMiddleware([]ext.RequestRewriter{replaceBodyRewriter("swap", "gpt", "GPT")}, nil)
+	if err := mw(next)(c); err != nil {
+		t.Fatalf("middleware returned error: %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("context tokens saved = %d, want 0", got)
+	}
+}

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -537,6 +537,7 @@ func (s *translatedInferenceService) handleStreamingReadCloser(
 		if usageObserver != nil {
 			usageObserver.SetProviderName(providerName)
 			usageObserver.SetLabels(core.RequestLabelsFromContext(c.Request().Context()))
+			usageObserver.SetRewriteTokensSaved(core.RewriteTokensSavedFromContext(c.Request().Context()))
 			observers = append(observers, usageObserver)
 		}
 	}

--- a/internal/usage/reader.go
+++ b/internal/usage/reader.go
@@ -46,6 +46,11 @@ type UsageSummary struct {
 	TotalInputCost        *float64 `json:"total_input_cost"`
 	TotalOutputCost       *float64 `json:"total_output_cost"`
 	TotalCost             *float64 `json:"total_cost"`
+	// Rewrite savings: prompt tokens request rewriters removed before the
+	// provider call, and the estimated input cost avoided (nil when no
+	// matched row had a priced savings estimate).
+	RewriteTokensSaved int64    `json:"rewrite_tokens_saved"`
+	RewriteCostSaved   *float64 `json:"rewrite_cost_saved"`
 }
 
 // addInputSegments folds one usage row's provider-cache split into the summary

--- a/internal/usage/reader_mongodb.go
+++ b/internal/usage/reader_mongodb.go
@@ -115,6 +115,9 @@ func (r *MongoDBReader) GetSummary(ctx context.Context, params UsageQueryParams)
 		{Key: "has_input_cost", Value: mongoCostPresenceCount("$input_cost")},
 		{Key: "has_output_cost", Value: mongoCostPresenceCount("$output_cost")},
 		{Key: "has_total_cost", Value: mongoCostPresenceCount("$total_cost")},
+		{Key: "rewrite_tokens_saved", Value: bson.D{{Key: "$sum", Value: "$rewrite_tokens_saved"}}},
+		{Key: "rewrite_cost_saved", Value: mongoCostSum("$rewrite_cost_saved")},
+		{Key: "has_rewrite_cost_saved", Value: mongoCostPresenceCount("$rewrite_cost_saved")},
 	}}})
 
 	cursor, err := r.collection.Aggregate(ctx, pipeline)
@@ -136,6 +139,10 @@ func (r *MongoDBReader) GetSummary(ctx context.Context, params UsageQueryParams)
 			HasInputCost    int     `bson:"has_input_cost"`
 			HasOutputCost   int     `bson:"has_output_cost"`
 			HasTotalCost    int     `bson:"has_total_cost"`
+
+			RewriteTokensSaved  int64   `bson:"rewrite_tokens_saved"`
+			RewriteCostSaved    float64 `bson:"rewrite_cost_saved"`
+			HasRewriteCostSaved int     `bson:"has_rewrite_cost_saved"`
 		}
 		if err := cursor.Decode(&result); err != nil {
 			return nil, fmt.Errorf("failed to decode usage summary: %w", err)
@@ -147,6 +154,8 @@ func (r *MongoDBReader) GetSummary(ctx context.Context, params UsageQueryParams)
 		summary.TotalInputCost = costPtr(result.HasInputCost, result.TotalInputCost)
 		summary.TotalOutputCost = costPtr(result.HasOutputCost, result.TotalOutputCost)
 		summary.TotalCost = costPtr(result.HasTotalCost, result.TotalCost)
+		summary.RewriteTokensSaved = result.RewriteTokensSaved
+		summary.RewriteCostSaved = costPtr(result.HasRewriteCostSaved, result.RewriteCostSaved)
 	}
 
 	if err := cursor.Err(); err != nil {

--- a/internal/usage/reader_postgresql.go
+++ b/internal/usage/reader_postgresql.go
@@ -41,13 +41,15 @@ func (r *PostgreSQLReader) GetSummary(ctx context.Context, params UsageQueryPara
 	where := sqlutil.BuildWhereClause(conditions)
 
 	costCols := `, SUM(input_cost), SUM(output_cost), SUM(total_cost)`
-	query := `SELECT COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)` + costCols + `
+	savingsCols := `, COALESCE(SUM(rewrite_tokens_saved), 0), SUM(rewrite_cost_saved)`
+	query := `SELECT COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)` + costCols + savingsCols + `
 			FROM "usage"` + where
 
 	summary := &UsageSummary{}
 	err = r.pool.QueryRow(ctx, query, args...).Scan(
 		&summary.TotalRequests, &summary.TotalInput, &summary.TotalOutput, &summary.TotalTokens,
 		&summary.TotalInputCost, &summary.TotalOutputCost, &summary.TotalCost,
+		&summary.RewriteTokensSaved, &summary.RewriteCostSaved,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query usage summary: %w", err)

--- a/internal/usage/reader_sqlite.go
+++ b/internal/usage/reader_sqlite.go
@@ -35,13 +35,15 @@ func (r *SQLiteReader) GetSummary(ctx context.Context, params UsageQueryParams) 
 	where := sqlutil.BuildWhereClause(conditions)
 
 	costCols := `, SUM(input_cost), SUM(output_cost), SUM(total_cost)`
-	query := `SELECT COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)` + costCols + `
+	savingsCols := `, COALESCE(SUM(rewrite_tokens_saved), 0), SUM(rewrite_cost_saved)`
+	query := `SELECT COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(total_tokens), 0)` + costCols + savingsCols + `
 			FROM usage` + where
 
 	summary := &UsageSummary{}
 	err = r.db.QueryRowContext(ctx, query, args...).Scan(
 		&summary.TotalRequests, &summary.TotalInput, &summary.TotalOutput, &summary.TotalTokens,
 		&summary.TotalInputCost, &summary.TotalOutputCost, &summary.TotalCost,
+		&summary.RewriteTokensSaved, &summary.RewriteCostSaved,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query usage summary: %w", err)

--- a/internal/usage/recalculate_pricing.go
+++ b/internal/usage/recalculate_pricing.go
@@ -34,24 +34,26 @@ type PricingRecalculator interface {
 }
 
 type recalculationEntry struct {
-	ID           string
-	Model        string
-	Provider     string
-	ProviderName string
-	Endpoint     string
-	InputTokens  int
-	OutputTokens int
-	RawData      map[string]any
+	ID                 string
+	Model              string
+	Provider           string
+	ProviderName       string
+	Endpoint           string
+	InputTokens        int
+	OutputTokens       int
+	RewriteTokensSaved int
+	RawData            map[string]any
 }
 
 type recalculationUpdate struct {
-	ID         string
-	InputCost  *float64
-	OutputCost *float64
-	TotalCost  *float64
-	CostSource string
-	Caveat     string
-	HasPricing bool
+	ID               string
+	InputCost        *float64
+	OutputCost       *float64
+	TotalCost        *float64
+	RewriteCostSaved *float64
+	CostSource       string
+	Caveat           string
+	HasPricing       bool
 }
 
 func normalizedRecalculatePricingParams(params RecalculatePricingParams) RecalculatePricingParams {
@@ -71,13 +73,14 @@ func recalculateEntryCosts(entry recalculationEntry, resolver PricingResolver) r
 	effectivePricing := pricingForEndpoint(pricing, entry.Endpoint)
 	result := CalculateUsageCost(entry.InputTokens, entry.OutputTokens, entry.RawData, entry.Provider, effectivePricing)
 	return recalculationUpdate{
-		ID:         entry.ID,
-		InputCost:  result.InputCost,
-		OutputCost: result.OutputCost,
-		TotalCost:  result.TotalCost,
-		CostSource: result.Source,
-		Caveat:     result.Caveat,
-		HasPricing: result.TotalCost != nil || result.InputCost != nil || result.OutputCost != nil,
+		ID:               entry.ID,
+		InputCost:        result.InputCost,
+		OutputCost:       result.OutputCost,
+		TotalCost:        result.TotalCost,
+		RewriteCostSaved: rewriteCostSaved(entry.InputTokens, entry.OutputTokens, entry.RawData, entry.Provider, effectivePricing, entry.RewriteTokensSaved),
+		CostSource:       result.Source,
+		Caveat:           result.Caveat,
+		HasPricing:       result.TotalCost != nil || result.InputCost != nil || result.OutputCost != nil,
 	}
 }
 

--- a/internal/usage/recalculate_pricing_mongodb.go
+++ b/internal/usage/recalculate_pricing_mongodb.go
@@ -146,28 +146,30 @@ func (s *MongoDBStore) recalculatePricingInMongoTransaction(ctx context.Context,
 	result := RecalculatePricingResult{}
 	for cursor.Next(ctx) {
 		var row struct {
-			ID           string         `bson:"_id"`
-			Model        string         `bson:"model"`
-			Provider     string         `bson:"provider"`
-			ProviderName string         `bson:"provider_name"`
-			Endpoint     string         `bson:"endpoint"`
-			InputTokens  int            `bson:"input_tokens"`
-			OutputTokens int            `bson:"output_tokens"`
-			RawData      map[string]any `bson:"raw_data"`
+			ID                 string         `bson:"_id"`
+			Model              string         `bson:"model"`
+			Provider           string         `bson:"provider"`
+			ProviderName       string         `bson:"provider_name"`
+			Endpoint           string         `bson:"endpoint"`
+			InputTokens        int            `bson:"input_tokens"`
+			OutputTokens       int            `bson:"output_tokens"`
+			RewriteTokensSaved int            `bson:"rewrite_tokens_saved"`
+			RawData            map[string]any `bson:"raw_data"`
 		}
 		if err := cursor.Decode(&row); err != nil {
 			return RecalculatePricingResult{}, fmt.Errorf("scan mongodb usage cost row: %w", err)
 		}
 
 		update := recalculateEntryCosts(recalculationEntry{
-			ID:           row.ID,
-			Model:        row.Model,
-			Provider:     row.Provider,
-			ProviderName: row.ProviderName,
-			Endpoint:     row.Endpoint,
-			InputTokens:  row.InputTokens,
-			OutputTokens: row.OutputTokens,
-			RawData:      row.RawData,
+			ID:                 row.ID,
+			Model:              row.Model,
+			Provider:           row.Provider,
+			ProviderName:       row.ProviderName,
+			Endpoint:           row.Endpoint,
+			InputTokens:        row.InputTokens,
+			OutputTokens:       row.OutputTokens,
+			RewriteTokensSaved: row.RewriteTokensSaved,
+			RawData:            row.RawData,
 		}, resolver)
 
 		if _, err := s.collection.UpdateByID(ctx, update.ID, mongoRecalculationUpdate(update)); err != nil {
@@ -203,6 +205,11 @@ func mongoRecalculationUpdate(update recalculationUpdate) bson.D {
 		set = append(set, bson.E{Key: "total_cost", Value: *update.TotalCost})
 	} else {
 		unset = append(unset, bson.E{Key: "total_cost", Value: ""})
+	}
+	if update.RewriteCostSaved != nil {
+		set = append(set, bson.E{Key: "rewrite_cost_saved", Value: *update.RewriteCostSaved})
+	} else {
+		unset = append(unset, bson.E{Key: "rewrite_cost_saved", Value: ""})
 	}
 	if strings.TrimSpace(update.CostSource) != "" {
 		set = append(set, bson.E{Key: "cost_source", Value: strings.TrimSpace(update.CostSource)})

--- a/internal/usage/recalculate_pricing_postgresql.go
+++ b/internal/usage/recalculate_pricing_postgresql.go
@@ -37,12 +37,13 @@ func (s *PostgreSQLStore) RecalculatePricing(ctx context.Context, params Recalcu
 		update := recalculateEntryCosts(entry, resolver)
 		if _, err := tx.Exec(ctx, `
 			UPDATE usage
-			SET input_cost = $1, output_cost = $2, total_cost = $3, cost_source = $4, costs_calculation_caveat = $5
-			WHERE id = $6::uuid
+			SET input_cost = $1, output_cost = $2, total_cost = $3, rewrite_cost_saved = $4, cost_source = $5, costs_calculation_caveat = $6
+			WHERE id = $7::uuid
 		`,
 			nullableFloat(update.InputCost),
 			nullableFloat(update.OutputCost),
 			nullableFloat(update.TotalCost),
+			nullableFloat(update.RewriteCostSaved),
 			update.CostSource,
 			update.Caveat,
 			update.ID,
@@ -65,7 +66,7 @@ func postgresRecalculationEntries(ctx context.Context, tx pgx.Tx, params Recalcu
 	}
 
 	rows, err := tx.Query(ctx, `
-		SELECT id::text, model, provider, provider_name, endpoint, input_tokens, output_tokens, raw_data::text
+		SELECT id::text, model, provider, provider_name, endpoint, input_tokens, output_tokens, rewrite_tokens_saved, raw_data::text
 		FROM usage`+sqlutil.BuildWhereClause(conditions)+`
 		FOR UPDATE`, args...)
 	if err != nil {
@@ -86,6 +87,7 @@ func postgresRecalculationEntries(ctx context.Context, tx pgx.Tx, params Recalcu
 			&entry.Endpoint,
 			&entry.InputTokens,
 			&entry.OutputTokens,
+			&entry.RewriteTokensSaved,
 			&rawData,
 		); err != nil {
 			return nil, fmt.Errorf("scan postgres usage cost row: %w", err)

--- a/internal/usage/recalculate_pricing_sqlite.go
+++ b/internal/usage/recalculate_pricing_sqlite.go
@@ -26,7 +26,7 @@ func (s *SQLiteStore) RecalculatePricing(ctx context.Context, params Recalculate
 
 	stmt, err := tx.PrepareContext(ctx, `
 		UPDATE usage
-		SET input_cost = ?, output_cost = ?, total_cost = ?, cost_source = ?, costs_calculation_caveat = ?
+		SET input_cost = ?, output_cost = ?, total_cost = ?, rewrite_cost_saved = ?, cost_source = ?, costs_calculation_caveat = ?
 		WHERE id = ?
 	`)
 	if err != nil {
@@ -51,6 +51,7 @@ func (s *SQLiteStore) RecalculatePricing(ctx context.Context, params Recalculate
 				nullableFloat(update.InputCost),
 				nullableFloat(update.OutputCost),
 				nullableFloat(update.TotalCost),
+				nullableFloat(update.RewriteCostSaved),
 				update.CostSource,
 				update.Caveat,
 				update.ID,
@@ -87,7 +88,7 @@ func (s *SQLiteStore) sqliteRecalculationEntries(ctx context.Context, tx *sql.Tx
 	args = append(args, limit)
 
 	rows, err := tx.QueryContext(ctx, `
-		SELECT id, model, provider, provider_name, endpoint, input_tokens, output_tokens, raw_data
+		SELECT id, model, provider, provider_name, endpoint, input_tokens, output_tokens, rewrite_tokens_saved, raw_data
 		FROM usage`+sqlutil.BuildWhereClause(conditions)+`
 		ORDER BY id
 		LIMIT ?`, args...)
@@ -109,6 +110,7 @@ func (s *SQLiteStore) sqliteRecalculationEntries(ctx context.Context, tx *sql.Tx
 			&entry.Endpoint,
 			&entry.InputTokens,
 			&entry.OutputTokens,
+			&entry.RewriteTokensSaved,
 			&rawData,
 		); err != nil {
 			return nil, fmt.Errorf("scan sqlite usage cost row: %w", err)

--- a/internal/usage/savings.go
+++ b/internal/usage/savings.go
@@ -1,0 +1,39 @@
+package usage
+
+import "gomodel/internal/core"
+
+// ApplyRewriteSavings folds a request-rewrite savings estimate into a usage
+// entry: RewriteTokensSaved always, and RewriteCostSaved when pricing allows
+// costing the removed tokens.
+func ApplyRewriteSavings(entry *UsageEntry, tokensSaved int, pricing *core.ModelPricing) {
+	if entry == nil || tokensSaved <= 0 {
+		return
+	}
+	entry.RewriteTokensSaved = tokensSaved
+	effective := pricingForEndpoint(pricing, entry.Endpoint)
+	entry.RewriteCostSaved = rewriteCostSaved(entry.InputTokens, entry.OutputTokens, entry.RawData, entry.Provider, effective, tokensSaved)
+}
+
+// rewriteCostSaved estimates the input cost the removed prompt tokens would
+// have added: the input-cost delta between the request as the client sent it
+// (input tokens + saved tokens) and the request as forwarded, both priced via
+// CalculateGranularCost with the already endpoint-adjusted pricing. Going
+// through the full granular calculation (rather than saved × base input rate)
+// keeps tiered pricing honest: when the un-rewritten prompt would have landed
+// in a higher tier, the delta includes the re-rating of the whole input.
+// Returns nil when pricing cannot cost the input side.
+func rewriteCostSaved(inputTokens, outputTokens int, rawData map[string]any, provider string, effectivePricing *core.ModelPricing, tokensSaved int) *float64 {
+	if tokensSaved <= 0 || effectivePricing == nil {
+		return nil
+	}
+	asSent := CalculateGranularCost(inputTokens+tokensSaved, outputTokens, rawData, provider, effectivePricing)
+	asForwarded := CalculateGranularCost(inputTokens, outputTokens, rawData, provider, effectivePricing)
+	if asSent.InputCost == nil || asForwarded.InputCost == nil {
+		return nil
+	}
+	saved := *asSent.InputCost - *asForwarded.InputCost
+	if saved < 0 {
+		saved = 0
+	}
+	return &saved
+}

--- a/internal/usage/savings_test.go
+++ b/internal/usage/savings_test.go
@@ -1,0 +1,214 @@
+package usage
+
+import (
+	"context"
+	"database/sql"
+	"math"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	"gomodel/internal/core"
+)
+
+func TestApplyRewriteSavings(t *testing.T) {
+	flatPricing := &core.ModelPricing{InputPerMtok: floatPtr(2.0), OutputPerMtok: floatPtr(8.0)}
+
+	t.Run("nil entry and non-positive savings are no-ops", func(t *testing.T) {
+		ApplyRewriteSavings(nil, 100, flatPricing)
+
+		entry := &UsageEntry{InputTokens: 500}
+		ApplyRewriteSavings(entry, 0, flatPricing)
+		if entry.RewriteTokensSaved != 0 || entry.RewriteCostSaved != nil {
+			t.Fatalf("zero savings must not touch the entry, got tokens=%d cost=%v", entry.RewriteTokensSaved, entry.RewriteCostSaved)
+		}
+	})
+
+	t.Run("nil pricing records tokens without cost", func(t *testing.T) {
+		entry := &UsageEntry{InputTokens: 500}
+		ApplyRewriteSavings(entry, 250, nil)
+		if entry.RewriteTokensSaved != 250 {
+			t.Fatalf("tokens saved = %d, want 250", entry.RewriteTokensSaved)
+		}
+		if entry.RewriteCostSaved != nil {
+			t.Fatalf("cost saved must stay nil without pricing, got %v", *entry.RewriteCostSaved)
+		}
+	})
+
+	t.Run("flat input rate prices the removed tokens", func(t *testing.T) {
+		entry := &UsageEntry{Endpoint: "/v1/chat/completions", Provider: "openai", InputTokens: 1000, OutputTokens: 100}
+		ApplyRewriteSavings(entry, 500_000, flatPricing)
+		if entry.RewriteTokensSaved != 500_000 {
+			t.Fatalf("tokens saved = %d, want 500000", entry.RewriteTokensSaved)
+		}
+		if entry.RewriteCostSaved == nil {
+			t.Fatal("expected a cost estimate with flat pricing")
+		}
+		// 500k tokens at $2/Mtok = $1.00; output rate must not leak in.
+		if got, want := *entry.RewriteCostSaved, 1.0; math.Abs(got-want) > 1e-9 {
+			t.Fatalf("cost saved = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("tier crossing re-rates the whole input", func(t *testing.T) {
+		tiered := &core.ModelPricing{
+			InputPerMtok: floatPtr(10.0),
+			Tiers: []core.ModelPricingTier{
+				{UpToTokens: floatPtr(1000), InputPerMtok: floatPtr(1.0)},
+				{UpToTokens: floatPtr(1_000_000), InputPerMtok: floatPtr(3.0)},
+			},
+		}
+		entry := &UsageEntry{Endpoint: "/v1/chat/completions", Provider: "openai", InputTokens: 800}
+		ApplyRewriteSavings(entry, 400, tiered)
+		if entry.RewriteCostSaved == nil {
+			t.Fatal("expected a cost estimate with tiered pricing")
+		}
+		// As forwarded: 800 tokens in the $1/Mtok tier = $0.0008.
+		// As sent: 1200 tokens land in the $3/Mtok tier = $0.0036.
+		if got, want := *entry.RewriteCostSaved, 0.0036-0.0008; math.Abs(got-want) > 1e-9 {
+			t.Fatalf("cost saved = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("batch endpoint uses batch input rate", func(t *testing.T) {
+		pricing := &core.ModelPricing{InputPerMtok: floatPtr(2.0), BatchInputPerMtok: floatPtr(1.0)}
+		entry := &UsageEntry{Endpoint: "/v1/batches", Provider: "openai", InputTokens: 0}
+		ApplyRewriteSavings(entry, 1_000_000, pricing)
+		if entry.RewriteCostSaved == nil {
+			t.Fatal("expected a cost estimate for the batch endpoint")
+		}
+		if got, want := *entry.RewriteCostSaved, 1.0; math.Abs(got-want) > 1e-9 {
+			t.Fatalf("cost saved = %v, want %v (batch rate)", got, want)
+		}
+	})
+}
+
+func TestSQLiteSummaryAggregatesRewriteSavings(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open sqlite database: %v", err)
+	}
+	defer db.Close()
+
+	store, err := NewSQLiteStore(db, 0)
+	if err != nil {
+		t.Fatalf("failed to create sqlite store: %v", err)
+	}
+
+	ctx := context.Background()
+	entries := []*UsageEntry{
+		{
+			ID: "with-savings", RequestID: "req-1", ProviderID: "p-1",
+			Timestamp: time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC),
+			Model:     "gpt-5", Provider: "openai", Endpoint: "/v1/chat/completions",
+			InputTokens: 1000, OutputTokens: 50, TotalTokens: 1050,
+			RewriteTokensSaved: 400, RewriteCostSaved: floatPtr(0.0008),
+		},
+		{
+			ID: "with-unpriced-savings", RequestID: "req-2", ProviderID: "p-2",
+			Timestamp: time.Date(2026, 7, 1, 11, 0, 0, 0, time.UTC),
+			Model:     "local-model", Provider: "ollama", Endpoint: "/v1/chat/completions",
+			InputTokens: 500, OutputTokens: 20, TotalTokens: 520,
+			RewriteTokensSaved: 100,
+		},
+		{
+			ID: "no-savings", RequestID: "req-3", ProviderID: "p-3",
+			Timestamp: time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC),
+			Model:     "gpt-5", Provider: "openai", Endpoint: "/v1/chat/completions",
+			InputTokens: 200, OutputTokens: 10, TotalTokens: 210,
+		},
+	}
+	if err := store.WriteBatch(ctx, entries); err != nil {
+		t.Fatalf("failed to seed usage entries: %v", err)
+	}
+
+	reader, err := NewSQLiteReader(db)
+	if err != nil {
+		t.Fatalf("failed to create sqlite reader: %v", err)
+	}
+
+	summary, err := reader.GetSummary(ctx, UsageQueryParams{})
+	if err != nil {
+		t.Fatalf("GetSummary returned error: %v", err)
+	}
+	if summary.RewriteTokensSaved != 500 {
+		t.Fatalf("rewrite tokens saved = %d, want 500", summary.RewriteTokensSaved)
+	}
+	if summary.RewriteCostSaved == nil {
+		t.Fatal("expected an aggregated rewrite cost")
+	}
+	if got, want := *summary.RewriteCostSaved, 0.0008; math.Abs(got-want) > 1e-9 {
+		t.Fatalf("rewrite cost saved = %v, want %v", got, want)
+	}
+
+	// A slice with no priced savings keeps the cost null rather than zero.
+	unpriced, err := reader.GetSummary(ctx, UsageQueryParams{Provider: "ollama"})
+	if err != nil {
+		t.Fatalf("GetSummary(ollama) returned error: %v", err)
+	}
+	if unpriced.RewriteTokensSaved != 100 {
+		t.Fatalf("ollama rewrite tokens saved = %d, want 100", unpriced.RewriteTokensSaved)
+	}
+	if unpriced.RewriteCostSaved != nil {
+		t.Fatalf("ollama rewrite cost saved = %v, want nil", *unpriced.RewriteCostSaved)
+	}
+}
+
+type staticSavingsPricingResolver struct {
+	pricing *core.ModelPricing
+}
+
+func (r staticSavingsPricingResolver) ResolvePricing(_, _ string) *core.ModelPricing {
+	return r.pricing
+}
+
+func TestSQLiteRecalculatePricingRefreshesRewriteCostSaved(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open sqlite database: %v", err)
+	}
+	defer db.Close()
+
+	store, err := NewSQLiteStore(db, 0)
+	if err != nil {
+		t.Fatalf("failed to create sqlite store: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := store.WriteBatch(ctx, []*UsageEntry{{
+		ID: "stale-savings", RequestID: "req-1", ProviderID: "p-1",
+		Timestamp: time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC),
+		Model:     "gpt-5", Provider: "openai", Endpoint: "/v1/chat/completions",
+		InputTokens: 1000, OutputTokens: 50, TotalTokens: 1050,
+		RewriteTokensSaved: 500_000, RewriteCostSaved: floatPtr(123.0),
+	}}); err != nil {
+		t.Fatalf("failed to seed usage entry: %v", err)
+	}
+
+	resolver := staticSavingsPricingResolver{pricing: &core.ModelPricing{
+		InputPerMtok:  floatPtr(2.0),
+		OutputPerMtok: floatPtr(8.0),
+	}}
+	if _, err := store.RecalculatePricing(ctx, RecalculatePricingParams{}, resolver); err != nil {
+		t.Fatalf("RecalculatePricing returned error: %v", err)
+	}
+
+	reader, err := NewSQLiteReader(db)
+	if err != nil {
+		t.Fatalf("failed to create sqlite reader: %v", err)
+	}
+	summary, err := reader.GetSummary(ctx, UsageQueryParams{})
+	if err != nil {
+		t.Fatalf("GetSummary returned error: %v", err)
+	}
+	if summary.RewriteTokensSaved != 500_000 {
+		t.Fatalf("rewrite tokens saved = %d, want 500000", summary.RewriteTokensSaved)
+	}
+	if summary.RewriteCostSaved == nil {
+		t.Fatal("expected recalculated rewrite cost")
+	}
+	if got, want := *summary.RewriteCostSaved, 1.0; math.Abs(got-want) > 1e-9 {
+		t.Fatalf("recalculated rewrite cost = %v, want %v (500k tokens at $2/Mtok)", got, want)
+	}
+}

--- a/internal/usage/store_postgresql.go
+++ b/internal/usage/store_postgresql.go
@@ -16,14 +16,15 @@ import (
 )
 
 const (
-	usageInsertColumnCount     = 20
+	usageInsertColumnCount     = 22
 	postgresMaxBindParameters  = 65535
 	usageInsertMaxRowsPerQuery = postgresMaxBindParameters / usageInsertColumnCount
 )
 
 const usageInsertPrefix = `
 		INSERT INTO usage (id, request_id, provider_id, timestamp, model, provider, provider_name,
-			endpoint, user_path, cache_type, labels, input_tokens, output_tokens, total_tokens, raw_data,
+			endpoint, user_path, cache_type, labels, input_tokens, output_tokens, total_tokens,
+			rewrite_tokens_saved, rewrite_cost_saved, raw_data,
 			input_cost, output_cost, total_cost, cost_source, costs_calculation_caveat)
 		VALUES `
 
@@ -69,6 +70,8 @@ func NewPostgreSQLStore(pool *pgxpool.Pool, retentionDays int) (*PostgreSQLStore
 			input_tokens INTEGER NOT NULL DEFAULT 0,
 			output_tokens INTEGER NOT NULL DEFAULT 0,
 			total_tokens INTEGER NOT NULL DEFAULT 0,
+			rewrite_tokens_saved INTEGER NOT NULL DEFAULT 0,
+			rewrite_cost_saved DOUBLE PRECISION,
 			raw_data JSONB
 		)
 	`)
@@ -87,6 +90,8 @@ func NewPostgreSQLStore(pool *pgxpool.Pool, retentionDays int) (*PostgreSQLStore
 		"ALTER TABLE usage ADD COLUMN IF NOT EXISTS user_path TEXT",
 		"ALTER TABLE usage ADD COLUMN IF NOT EXISTS cache_type TEXT",
 		"ALTER TABLE usage ADD COLUMN IF NOT EXISTS labels JSONB",
+		"ALTER TABLE usage ADD COLUMN IF NOT EXISTS rewrite_tokens_saved INTEGER NOT NULL DEFAULT 0",
+		"ALTER TABLE usage ADD COLUMN IF NOT EXISTS rewrite_cost_saved DOUBLE PRECISION",
 	}
 	for _, migration := range costMigrations {
 		if _, err := pool.Exec(ctx, migration); err != nil {
@@ -222,6 +227,8 @@ func buildUsageInsert(entries []*UsageEntry) (string, []any) {
 			entry.InputTokens,
 			entry.OutputTokens,
 			entry.TotalTokens,
+			entry.RewriteTokensSaved,
+			entry.RewriteCostSaved,
 			rawDataJSON,
 			entry.InputCost,
 			entry.OutputCost,

--- a/internal/usage/store_postgresql_test.go
+++ b/internal/usage/store_postgresql_test.go
@@ -11,6 +11,7 @@ func TestBuildUsageInsert(t *testing.T) {
 	inputCost := 0.1
 	outputCost := 0.2
 	totalCost := 0.3
+	rewriteCostSaved := 0.05
 
 	query, args := buildUsageInsert([]*UsageEntry{
 		{
@@ -27,6 +28,8 @@ func TestBuildUsageInsert(t *testing.T) {
 			InputTokens:            10,
 			OutputTokens:           5,
 			TotalTokens:            15,
+			RewriteTokensSaved:     42,
+			RewriteCostSaved:       &rewriteCostSaved,
 			RawData:                map[string]any{"cached_tokens": 3},
 			InputCost:              &inputCost,
 			OutputCost:             &outputCost,
@@ -55,12 +58,12 @@ func TestBuildUsageInsert(t *testing.T) {
 	})
 
 	normalized := strings.Join(strings.Fields(query), " ")
-	wantQuery := "INSERT INTO usage (id, request_id, provider_id, timestamp, model, provider, provider_name, endpoint, user_path, cache_type, labels, input_tokens, output_tokens, total_tokens, raw_data, input_cost, output_cost, total_cost, cost_source, costs_calculation_caveat) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20), ($21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40) ON CONFLICT (id) DO NOTHING"
+	wantQuery := "INSERT INTO usage (id, request_id, provider_id, timestamp, model, provider, provider_name, endpoint, user_path, cache_type, labels, input_tokens, output_tokens, total_tokens, rewrite_tokens_saved, rewrite_cost_saved, raw_data, input_cost, output_cost, total_cost, cost_source, costs_calculation_caveat) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22), ($23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44) ON CONFLICT (id) DO NOTHING"
 	if normalized != wantQuery {
 		t.Fatalf("query = %q, want %q", normalized, wantQuery)
 	}
 
-	if got, want := len(args), 40; got != want {
+	if got, want := len(args), 44; got != want {
 		t.Fatalf("len(args) = %d, want %d", got, want)
 	}
 	if got := args[0]; got != "usage-1" {
@@ -69,11 +72,11 @@ func TestBuildUsageInsert(t *testing.T) {
 	if got := args[6]; got != "primary-openai" {
 		t.Fatalf("args[6] = %v, want primary-openai", got)
 	}
-	if got := args[18]; got != CostSourceModelPricing {
-		t.Fatalf("args[18] = %v, want %q", got, CostSourceModelPricing)
+	if got := args[20]; got != CostSourceModelPricing {
+		t.Fatalf("args[20] = %v, want %q", got, CostSourceModelPricing)
 	}
-	if got := args[20]; got != "usage-2" {
-		t.Fatalf("args[20] = %v, want usage-2", got)
+	if got := args[22]; got != "usage-2" {
+		t.Fatalf("args[22] = %v, want usage-2", got)
 	}
 	if got := args[9]; got != CacheTypeExact {
 		t.Fatalf("args[9] = %v, want %q", got, CacheTypeExact)
@@ -81,21 +84,33 @@ func TestBuildUsageInsert(t *testing.T) {
 	if got := args[10]; got != `["alpha","prod"]` {
 		t.Fatalf("args[10] = %v, want labels JSON", got)
 	}
-	if got := string(args[14].([]byte)); got != `{"cached_tokens":3}` {
-		t.Fatalf("args[14] = %q, want %q", got, `{"cached_tokens":3}`)
+	if got := args[14]; got != 42 {
+		t.Fatalf("args[14] = %v, want 42 rewrite_tokens_saved", got)
 	}
-	if got := args[29]; got != nil {
-		t.Fatalf("args[29] = %v, want nil cache_type", got)
+	if got := args[15]; got != &rewriteCostSaved {
+		t.Fatalf("args[15] = %v, want rewrite_cost_saved pointer", got)
 	}
-	if got := args[30]; got != nil {
-		t.Fatalf("args[30] = %v, want nil labels", got)
+	if got := string(args[16].([]byte)); got != `{"cached_tokens":3}` {
+		t.Fatalf("args[16] = %q, want %q", got, `{"cached_tokens":3}`)
 	}
-	rawData, ok := args[34].([]byte)
+	if got := args[31]; got != nil {
+		t.Fatalf("args[31] = %v, want nil cache_type", got)
+	}
+	if got := args[32]; got != nil {
+		t.Fatalf("args[32] = %v, want nil labels", got)
+	}
+	if got := args[36]; got != 0 {
+		t.Fatalf("args[36] = %v, want 0 rewrite_tokens_saved", got)
+	}
+	if got := args[37].(*float64); got != nil {
+		t.Fatalf("args[37] = %v, want nil rewrite_cost_saved", got)
+	}
+	rawData, ok := args[38].([]byte)
 	if !ok {
-		t.Fatalf("args[34] has type %T, want []byte", args[34])
+		t.Fatalf("args[38] has type %T, want []byte", args[38])
 	}
 	if rawData != nil {
-		t.Fatalf("args[34] = %v, want nil raw_data", rawData)
+		t.Fatalf("args[38] = %v, want nil raw_data", rawData)
 	}
 }
 

--- a/internal/usage/store_sqlite.go
+++ b/internal/usage/store_sqlite.go
@@ -18,8 +18,8 @@ import (
 // maxEntriesPerBatch derives from maxSQLiteParams / columnsPerUsageEntry.
 const (
 	maxSQLiteParams      = 999
-	columnsPerUsageEntry = 20
-	maxEntriesPerBatch   = maxSQLiteParams / columnsPerUsageEntry // 52 entries
+	columnsPerUsageEntry = 22
+	maxEntriesPerBatch   = maxSQLiteParams / columnsPerUsageEntry // 45 entries
 )
 
 // SQLiteStore implements UsageStore for SQLite databases.
@@ -55,6 +55,8 @@ func NewSQLiteStore(db *sql.DB, retentionDays int) (*SQLiteStore, error) {
 			input_tokens INTEGER NOT NULL DEFAULT 0,
 			output_tokens INTEGER NOT NULL DEFAULT 0,
 			total_tokens INTEGER NOT NULL DEFAULT 0,
+			rewrite_tokens_saved INTEGER NOT NULL DEFAULT 0,
+			rewrite_cost_saved REAL,
 			raw_data JSON
 		)
 	`)
@@ -73,6 +75,8 @@ func NewSQLiteStore(db *sql.DB, retentionDays int) (*SQLiteStore, error) {
 		"ALTER TABLE usage ADD COLUMN user_path TEXT",
 		"ALTER TABLE usage ADD COLUMN cache_type TEXT",
 		"ALTER TABLE usage ADD COLUMN labels JSON",
+		"ALTER TABLE usage ADD COLUMN rewrite_tokens_saved INTEGER NOT NULL DEFAULT 0",
+		"ALTER TABLE usage ADD COLUMN rewrite_cost_saved REAL",
 	}
 	for _, migration := range costMigrations {
 		if _, err := db.Exec(migration); err != nil {
@@ -135,7 +139,7 @@ func (s *SQLiteStore) WriteBatch(ctx context.Context, entries []*UsageEntry) err
 
 		for j, e := range chunk {
 			e = normalizedUsageEntryForStorage(e)
-			placeholders[j] = "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+			placeholders[j] = "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 
 			rawDataJSON := marshalRawData(e.RawData, e.ID)
 
@@ -160,6 +164,8 @@ func (s *SQLiteStore) WriteBatch(ctx context.Context, entries []*UsageEntry) err
 				e.InputTokens,
 				e.OutputTokens,
 				e.TotalTokens,
+				e.RewriteTokensSaved,
+				e.RewriteCostSaved,
 				rawDataValue,
 				e.InputCost,
 				e.OutputCost,
@@ -170,7 +176,7 @@ func (s *SQLiteStore) WriteBatch(ctx context.Context, entries []*UsageEntry) err
 		}
 
 		query := `INSERT OR IGNORE INTO usage (id, request_id, provider_id, timestamp, model, provider, provider_name,
-			endpoint, user_path, cache_type, labels, input_tokens, output_tokens, total_tokens, raw_data,
+			endpoint, user_path, cache_type, labels, input_tokens, output_tokens, total_tokens, rewrite_tokens_saved, rewrite_cost_saved, raw_data,
 			input_cost, output_cost, total_cost, cost_source, costs_calculation_caveat) VALUES ` +
 			strings.Join(placeholders, ",")
 

--- a/internal/usage/stream_observer.go
+++ b/internal/usage/stream_observer.go
@@ -20,6 +20,7 @@ type StreamUsageObserver struct {
 	endpoint        string
 	userPath        string
 	labels          []string
+	rewriteSaved    int
 	closed          bool
 }
 
@@ -62,6 +63,16 @@ func (o *StreamUsageObserver) SetLabels(labels []string) {
 		return
 	}
 	o.labels = labels
+}
+
+// SetRewriteTokensSaved attaches the request's rewrite savings estimate so
+// the usage entry extracted from the stream records it (with its cost, when
+// pricing is resolvable).
+func (o *StreamUsageObserver) SetRewriteTokensSaved(tokensSaved int) {
+	if o == nil || tokensSaved <= 0 {
+		return
+	}
+	o.rewriteSaved = tokensSaved
 }
 
 // usageKeyLiteral gates WantsJSONEvent: extractUsageFromEvent can only produce
@@ -176,6 +187,11 @@ func (o *StreamUsageObserver) extractUsageFromEvent(chunk map[string]any) *Usage
 		entry.ProviderName = o.providerName
 		entry.UserPath = o.userPath
 		entry.Labels = o.labels
+		var pricing *core.ModelPricing
+		if len(pricingArgs) > 0 {
+			pricing = pricingArgs[0]
+		}
+		ApplyRewriteSavings(entry, o.rewriteSaved, pricing)
 	}
 	return entry
 }

--- a/internal/usage/stream_observer_test.go
+++ b/internal/usage/stream_observer_test.go
@@ -645,3 +645,71 @@ data: [DONE]
 		t.Errorf("TotalTokens = %d, want 8", entry.TotalTokens)
 	}
 }
+
+func TestStreamUsageObserverRecordsRewriteSavings(t *testing.T) {
+	streamData := `data: {"id":"chatcmpl-1","model":"gpt-4","choices":[{"index":0,"delta":{"content":"!"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1000,"completion_tokens":5,"total_tokens":1005}}
+
+data: [DONE]
+
+`
+	logger := &trackingLogger{enabled: true}
+	resolver := &streamPricingCaptureResolver{pricing: &core.ModelPricing{
+		InputPerMtok:  floatPtr(2.0),
+		OutputPerMtok: floatPtr(8.0),
+	}}
+	observer := NewStreamUsageObserver(logger, "gpt-4", "openai", "req-1", "/v1/chat/completions", resolver)
+	observer.SetRewriteTokensSaved(500_000)
+
+	stream := streaming.NewObservedSSEStream(io.NopCloser(strings.NewReader(streamData)), observer)
+	if _, err := io.ReadAll(stream); err != nil {
+		t.Fatalf("ReadAll error: %v", err)
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatalf("Close error: %v", err)
+	}
+
+	entries := logger.getEntries()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	entry := entries[0]
+	if entry.RewriteTokensSaved != 500_000 {
+		t.Errorf("RewriteTokensSaved = %d, want 500000", entry.RewriteTokensSaved)
+	}
+	if entry.RewriteCostSaved == nil {
+		t.Fatal("expected RewriteCostSaved with resolvable pricing")
+	}
+	if got, want := *entry.RewriteCostSaved, 1.0; math.Abs(got-want) > 1e-9 {
+		t.Errorf("RewriteCostSaved = %v, want %v (500k tokens at $2/Mtok)", got, want)
+	}
+}
+
+func TestStreamUsageObserverRewriteSavingsWithoutPricing(t *testing.T) {
+	streamData := `data: {"id":"chatcmpl-1","model":"local","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":2,"total_tokens":12}}
+
+data: [DONE]
+
+`
+	logger := &trackingLogger{enabled: true}
+	observer := NewStreamUsageObserver(logger, "local", "ollama", "req-1", "/v1/chat/completions", nil)
+	observer.SetRewriteTokensSaved(40)
+
+	stream := streaming.NewObservedSSEStream(io.NopCloser(strings.NewReader(streamData)), observer)
+	if _, err := io.ReadAll(stream); err != nil {
+		t.Fatalf("ReadAll error: %v", err)
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatalf("Close error: %v", err)
+	}
+
+	entries := logger.getEntries()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].RewriteTokensSaved != 40 {
+		t.Errorf("RewriteTokensSaved = %d, want 40", entries[0].RewriteTokensSaved)
+	}
+	if entries[0].RewriteCostSaved != nil {
+		t.Errorf("RewriteCostSaved = %v, want nil without pricing", *entries[0].RewriteCostSaved)
+	}
+}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -80,6 +80,17 @@ type UsageEntry struct {
 	// CostsCalculationCaveat describes any incomplete aspects of cost calculation.
 	// Empty means all token types were fully mapped to pricing data.
 	CostsCalculationCaveat string `json:"costs_calculation_caveat,omitempty" bson:"costs_calculation_caveat,omitempty"`
+
+	// RewriteTokensSaved is the prompt tokens that request rewriters (ext
+	// extensions, e.g. token compression) estimate they removed from this
+	// request before it reached the provider. Zero when no rewriter reported
+	// savings.
+	RewriteTokensSaved int `json:"rewrite_tokens_saved,omitempty" bson:"rewrite_tokens_saved,omitempty"`
+
+	// RewriteCostSaved is the estimated input cost those removed tokens
+	// would have added, priced with the same model pricing as the request
+	// (nil = pricing unknown).
+	RewriteCostSaved *float64 `json:"rewrite_cost_saved,omitempty" bson:"rewrite_cost_saved,omitempty"`
 }
 
 // Config holds usage tracking configuration

--- a/tests/integration/admin_test.go
+++ b/tests/integration/admin_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -227,6 +228,59 @@ func TestAdminPricingRecalculationNoMasterKey_PostgreSQL(t *testing.T) {
 	assert.Equal(t, "ok", result.Status)
 	assert.GreaterOrEqual(t, result.Matched, int64(1))
 	assert.GreaterOrEqual(t, result.Recalculated, int64(1))
+
+	fixture.FlushAndClose(t)
+}
+
+func TestAdminPricingRecalculationRefreshesRewriteSavings_PostgreSQL(t *testing.T) {
+	fixture := SetupTestServer(t, TestServerConfig{
+		DBType:                           "postgresql",
+		UsageEnabled:                     true,
+		UsagePricingRecalculationEnabled: true,
+		AdminEndpointsEnabled:            true,
+		OnlyModelInteractions:            false,
+	})
+
+	dbassert.ClearUsage(t, fixture.PgPool)
+
+	payload := newChatRequest("gpt-4", "Hello!")
+	resp := sendChatRequest(t, fixture.ServerURL, payload)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	closeBody(resp)
+
+	time.Sleep(2 * time.Second)
+
+	// Simulate a request-rewriter savings estimate persisted with a stale
+	// cost, as if pricing changed after the row was written.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	tag, err := fixture.PgPool.Exec(ctx,
+		"UPDATE usage SET rewrite_tokens_saved = 500000, rewrite_cost_saved = 123.0")
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, tag.RowsAffected(), int64(1))
+
+	req, err := http.NewRequest(http.MethodPost, fixture.ServerURL+"/admin/usage/recalculate-pricing", bytes.NewBufferString(`{"confirmation":"recalculate"}`))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer closeBody(resp)
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result usage.RecalculatePricingResult
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+	assert.Equal(t, "ok", result.Status)
+	require.GreaterOrEqual(t, result.Recalculated, int64(1))
+
+	// The fixture prices models at a flat $1000/Mtok input, so 500k saved
+	// tokens must recalculate to exactly $500 (input-cost delta), replacing
+	// the stale $123 value.
+	var costSaved *float64
+	require.NoError(t, fixture.PgPool.QueryRow(ctx,
+		"SELECT rewrite_cost_saved FROM usage WHERE rewrite_tokens_saved = 500000 LIMIT 1").Scan(&costSaved))
+	require.NotNil(t, costSaved, "rewrite_cost_saved must be repriced, not cleared")
+	assert.InDelta(t, 500.0, *costSaved, 1e-9)
 
 	fixture.FlushAndClose(t)
 }


### PR DESCRIPTION
## What

Request rewriters registered through the `ext` API can now report how many prompt tokens their rewrite removed (`ext.Result.TokensSaved`), and the gateway turns that into **dashboard-visible savings**: total tokens saved and the estimated money saved, aggregated in usage tracking.

New cards on the Usage page (shown only once a rewriter reports savings — zero visual change otherwise):

| Card | Value |
|---|---|
| Rewrite Saved | estimated input cost avoided (`$`), same period/filters as Estimated Cost |
| Tokens Saved | prompt tokens removed before reaching providers |

## How

- **ext API**: `Result.TokensSaved int` — a rewriter's estimate of prompt tokens its applied body change removed.
- **Middleware**: `RequestRewriteMiddleware` sums the estimates of rewriters whose body was applied and stores the total on the request context (`core.WithRewriteTokensSaved`).
- **Usage recording**: both write paths stamp entries — the orchestrator's non-streaming `logUsage` and `StreamUsageObserver` (`SetRewriteTokensSaved`, wired at both construction sites). Local response-cache hits never carry savings (no provider call was made).
- **Cost math**: `usage.ApplyRewriteSavings` prices removed tokens as the **input-cost delta** between the request as the client sent it (input + saved tokens) and as forwarded, via the existing `CalculateGranularCost` — so endpoint-adjusted (batch) rates and tiered pricing stay honest: when the un-rewritten prompt would have landed in a higher tier, the delta includes re-rating the whole input. Unknown pricing → cost stays `nil`, tokens still counted.
- **Storage**: `rewrite_tokens_saved` / `rewrite_cost_saved` columns in SQLite and PostgreSQL (idempotent migrations, fresh-DB DDL); MongoDB persists via bson tags. `GetSummary` sums them on all three backends with the standard filters.
- **Pricing recalculation** (`/admin/usage/recalculate-pricing`) refreshes `rewrite_cost_saved` from the stored token estimate alongside the other cost fields on all three backends.

## Tests

- `ApplyRewriteSavings` unit table: flat rate, nil pricing, tier crossing, batch endpoint.
- SQLite store→summary roundtrip incl. null-cost semantics (unpriced savings keep cost `null`, not `0`).
- SQLite pricing recalculation refreshes a stale `rewrite_cost_saved`.
- Middleware: sums across applied rewriters into context; body change without a savings claim leaves context zero.
- Stream observer: savings + pricing → cost on the extracted entry; no pricing → tokens only.
- Dashboard cjs: card visibility/formatting incl. defensive inputs (403 dashboard tests pass).
- Full suite: `go test ./...`, `make test-dashboard`, `make test-e2e`, `make lint`, `make build` — all green. Swagger/openapi regenerated.

## Notes for reviewers

- Savings are **estimates** (rewriters estimate tokens; cost uses static model pricing). Provider-reported exact costs (OpenRouter credits, xAI ticks) are not used for the delta since they cannot be recomputed hypothetically.
- First consumer is GoModel Pro's token-compression rewriter (separate repo/PR), but the mechanism is neutral — any rewriter that shrinks prompts can report savings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added request-rewrite revision telemetry to audit logs and the OpenAPI schema.
  * Usage analytics now tracks rewrite savings, including prompt **tokens saved** and **estimated cost saved** (including streaming responses).
  * The usage dashboard now displays “Rewrite savings” cards when savings are available.
* **Bug Fixes**
  * Empty or error usage views now consistently initialize rewrite-savings fields to prevent missing/undefined values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->