### PR TITLE
refactor(core): derive Responses/chat known-field lists from struct tags

### DIFF
--- a/internal/core/chat_json.go
+++ b/internal/core/chat_json.go
@@ -2,61 +2,25 @@ package core
 
 import "github.com/goccy/go-json"
 
+// chatRequestFields is derived from the struct's json tags at package init so
+// the known-field list cannot drift from the type definition.
+var chatRequestFields = jsonFieldNames(ChatRequest{})
+
+// UnmarshalJSON decodes the typed fields via an alias (so new fields are
+// picked up automatically) and captures every other member in ExtraFields.
 func (r *ChatRequest) UnmarshalJSON(data []byte) error {
-	var raw struct {
-		Temperature       *float64         `json:"temperature,omitempty"`
-		TopP              *float64         `json:"top_p,omitempty"`
-		MaxTokens         *int             `json:"max_tokens,omitempty"`
-		Model             string           `json:"model"`
-		Provider          string           `json:"provider,omitempty"`
-		Messages          []Message        `json:"messages"`
-		Tools             []map[string]any `json:"tools,omitempty"`
-		ToolChoice        any              `json:"tool_choice,omitempty"`
-		ParallelToolCalls *bool            `json:"parallel_tool_calls,omitempty"`
-		Stream            bool             `json:"stream,omitempty"`
-		StreamOptions     *StreamOptions   `json:"stream_options,omitempty"`
-		Reasoning         *Reasoning       `json:"reasoning,omitempty"`
-		User              string           `json:"user,omitempty"`
-		ServiceTier       string           `json:"service_tier,omitempty"`
-	}
+	type alias ChatRequest
+	var raw alias
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
 
-	extraFields, err := extractUnknownJSONFields(data,
-		"temperature",
-		"top_p",
-		"max_tokens",
-		"model",
-		"provider",
-		"messages",
-		"tools",
-		"tool_choice",
-		"parallel_tool_calls",
-		"stream",
-		"stream_options",
-		"reasoning",
-		"user",
-		"service_tier",
-	)
+	extraFields, err := extractUnknownJSONFields(data, chatRequestFields...)
 	if err != nil {
 		return err
 	}
 
-	r.Temperature = raw.Temperature
-	r.TopP = raw.TopP
-	r.MaxTokens = raw.MaxTokens
-	r.Model = raw.Model
-	r.Provider = raw.Provider
-	r.Messages = raw.Messages
-	r.Tools = raw.Tools
-	r.ToolChoice = raw.ToolChoice
-	r.ParallelToolCalls = raw.ParallelToolCalls
-	r.Stream = raw.Stream
-	r.StreamOptions = raw.StreamOptions
-	r.Reasoning = raw.Reasoning
-	r.User = raw.User
-	r.ServiceTier = raw.ServiceTier
+	*r = ChatRequest(raw)
 	r.ExtraFields = extraFields
 	return nil
 }

--- a/internal/core/json_fields.go
+++ b/internal/core/json_fields.go
@@ -4,13 +4,44 @@ import (
 	"bytes"
 	"fmt"
 	"math"
+	"reflect"
 	"slices"
 	"sort"
+	"strings"
 
 	"github.com/goccy/go-json"
 
 	"github.com/tidwall/gjson"
 )
+
+// jsonFieldNames returns the JSON member names of v's exported struct fields,
+// honoring `json` tags and skipping "-". Known-field lists are derived from
+// the struct definitions once at package init so they cannot drift: a
+// hand-maintained list that misses a newly added typed field would preserve
+// that field as an unknown extra too, double-emitting it on marshal.
+func jsonFieldNames(v any) []string {
+	t := reflect.TypeOf(v)
+	names := make([]string, 0, t.NumField())
+	for i := range t.NumField() {
+		field := t.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+		if field.Anonymous {
+			names = append(names, jsonFieldNames(reflect.New(field.Type).Elem().Interface())...)
+			continue
+		}
+		name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+		if name == "-" {
+			continue
+		}
+		if name == "" {
+			name = field.Name
+		}
+		names = append(names, name)
+	}
+	return names
+}
 
 // UnknownJSONFields stores unknown JSON object members as a single raw object.
 // This avoids allocating a map for every decoded chat-family request while

--- a/internal/core/responses.go
+++ b/internal/core/responses.go
@@ -81,35 +81,59 @@ type ResponseInputTokensRequest struct {
 }
 
 // ResponseCompactRequest documents the request body accepted by
-// POST /v1/responses/compact.
-type ResponseCompactRequest struct {
-	Model              string            `json:"model,omitempty"`
-	Provider           string            `json:"provider,omitempty"` // Gateway routing hint; stripped before upstream execution.
-	Input              any               `json:"input,omitempty"`    // string or []ResponsesInputElement — see docs for array form
-	Instructions       string            `json:"instructions,omitempty"`
-	Tools              []map[string]any  `json:"tools,omitempty"`
-	ToolChoice         any               `json:"tool_choice,omitempty"` // string or object
-	ParallelToolCalls  *bool             `json:"parallel_tool_calls,omitempty"`
-	Temperature        *float64          `json:"temperature,omitempty"`
-	TopP               *float64          `json:"top_p,omitempty"`
-	TopLogprobs        *int              `json:"top_logprobs,omitempty"`
-	MaxOutputTokens    *int              `json:"max_output_tokens,omitempty"`
-	Metadata           map[string]string `json:"metadata,omitempty"`
-	Reasoning          *Reasoning        `json:"reasoning,omitempty"`
-	Text               any               `json:"text,omitempty"`
-	Include            []string          `json:"include,omitempty"`
-	Truncation         string            `json:"truncation,omitempty"`
-	Store              *bool             `json:"store,omitempty"`
-	PreviousResponseID string            `json:"previous_response_id,omitempty"`
-	// Conversation accepts either a conversation ID string or an object with id.
-	Conversation         *ResponsesConversationRef `json:"conversation,omitempty"`
-	Prompt               any                       `json:"prompt,omitempty"`
-	PromptCacheRetention string                    `json:"prompt_cache_retention,omitempty"`
-	ContextManagement    any                       `json:"context_management,omitempty"`
-	User                 string                    `json:"user,omitempty"`
-	ServiceTier          string                    `json:"service_tier,omitempty"`
-	SafetyIdentifier     string                    `json:"safety_identifier,omitempty"`
-	ExtraFields          UnknownJSONFields         `json:"-" swaggerignore:"true"`
+// POST /v1/responses/compact. It accepts exactly the same members as
+// ResponseInputTokensRequest, so it is defined from that struct: the field
+// set is written once and both utility endpoints stay in lockstep.
+type ResponseCompactRequest ResponseInputTokensRequest
+
+// InputTokensRequest reduces a full Responses request to the field set shared
+// with the utility endpoints (the streaming controls are dropped — utility
+// endpoints never stream). ExtraFields are cloned. The reduction is defined
+// here, next to the types, so the field knowledge stays in one file; a guard
+// test asserts it covers every non-streaming ResponsesRequest field.
+func (r *ResponsesRequest) InputTokensRequest() *ResponseInputTokensRequest {
+	if r == nil {
+		return nil
+	}
+	return &ResponseInputTokensRequest{
+		Model:                r.Model,
+		Provider:             r.Provider,
+		Input:                r.Input,
+		Instructions:         r.Instructions,
+		Tools:                r.Tools,
+		ToolChoice:           r.ToolChoice,
+		ParallelToolCalls:    r.ParallelToolCalls,
+		Temperature:          r.Temperature,
+		TopP:                 r.TopP,
+		TopLogprobs:          r.TopLogprobs,
+		MaxOutputTokens:      r.MaxOutputTokens,
+		Metadata:             r.Metadata,
+		Reasoning:            r.Reasoning,
+		Text:                 r.Text,
+		Include:              r.Include,
+		Truncation:           r.Truncation,
+		Store:                r.Store,
+		PreviousResponseID:   r.PreviousResponseID,
+		Conversation:         r.Conversation,
+		Prompt:               r.Prompt,
+		PromptCacheRetention: r.PromptCacheRetention,
+		ContextManagement:    r.ContextManagement,
+		User:                 r.User,
+		ServiceTier:          r.ServiceTier,
+		SafetyIdentifier:     r.SafetyIdentifier,
+		ExtraFields:          CloneUnknownJSONFields(r.ExtraFields),
+	}
+}
+
+// CompactRequest reduces a full Responses request for the compact endpoint;
+// see InputTokensRequest.
+func (r *ResponsesRequest) CompactRequest() *ResponseCompactRequest {
+	utility := r.InputTokensRequest()
+	if utility == nil {
+		return nil
+	}
+	compact := ResponseCompactRequest(*utility)
+	return &compact
 }
 
 func (r *ResponsesRequest) semanticSelector() (string, string) {

--- a/internal/core/responses_field_parity_test.go
+++ b/internal/core/responses_field_parity_test.go
@@ -1,0 +1,107 @@
+package core
+
+import (
+	"reflect"
+
+	"github.com/goccy/go-json"
+	"slices"
+	"testing"
+)
+
+// The utility request types must accept exactly the ResponsesRequest field set
+// minus the streaming controls (utility endpoints never stream). This pins the
+// contract so adding a field to one struct without the other fails here
+// instead of silently dropping the field at the other endpoint.
+func TestResponsesUtilityFieldParity(t *testing.T) {
+	full := jsonFieldNames(ResponsesRequest{})
+	utility := jsonFieldNames(ResponseInputTokensRequest{})
+
+	want := make([]string, 0, len(full))
+	for _, name := range full {
+		if name == "stream" || name == "stream_options" {
+			continue
+		}
+		want = append(want, name)
+	}
+	slices.Sort(want)
+	got := slices.Clone(utility)
+	slices.Sort(got)
+	if !slices.Equal(got, want) {
+		t.Fatalf("ResponseInputTokensRequest fields = %v, want ResponsesRequest minus stream controls = %v", got, want)
+	}
+}
+
+// InputTokensRequest must copy every field the utility type declares. Filled
+// via reflection so a newly added field that the reduction forgets to copy
+// fails this test rather than silently arriving zero-valued upstream.
+func TestInputTokensRequestCopiesEveryField(t *testing.T) {
+	var full ResponsesRequest
+	fill(t, reflect.ValueOf(&full).Elem())
+	full.ExtraFields = UnknownJSONFieldsFromMap(map[string]json.RawMessage{"x_custom": json.RawMessage(`1`)})
+
+	reduced := full.InputTokensRequest()
+	if reduced == nil {
+		t.Fatal("InputTokensRequest() = nil")
+	}
+
+	rv := reflect.ValueOf(*reduced)
+	rt := rv.Type()
+	for i := range rt.NumField() {
+		field := rt.Field(i)
+		if field.Name == "ExtraFields" {
+			if reduced.ExtraFields.IsEmpty() {
+				t.Fatal("ExtraFields were not cloned")
+			}
+			continue
+		}
+		if rv.Field(i).IsZero() {
+			t.Fatalf("InputTokensRequest() left %s zero-valued; the reduction must copy it", field.Name)
+		}
+	}
+
+	if compact := full.CompactRequest(); compact == nil || compact.Model != full.Model {
+		t.Fatalf("CompactRequest() = %+v, want model %q", compact, full.Model)
+	}
+	var nilReq *ResponsesRequest
+	if nilReq.InputTokensRequest() != nil || nilReq.CompactRequest() != nil {
+		t.Fatal("nil receiver must reduce to nil")
+	}
+}
+
+// fill sets every exported field of v to a non-zero value.
+func fill(t *testing.T, v reflect.Value) {
+	t.Helper()
+	for i := range v.NumField() {
+		field := v.Field(i)
+		if !field.CanSet() {
+			continue
+		}
+		switch field.Kind() {
+		case reflect.String:
+			field.SetString("x")
+		case reflect.Bool:
+			field.SetBool(true)
+		case reflect.Pointer:
+			field.Set(reflect.New(field.Type().Elem()))
+			switch elem := field.Elem(); elem.Kind() {
+			case reflect.Float64:
+				elem.SetFloat(1)
+			case reflect.Int:
+				elem.SetInt(1)
+			case reflect.Bool:
+				elem.SetBool(true)
+			case reflect.Struct:
+				fill(t, elem)
+			}
+		case reflect.Slice:
+			field.Set(reflect.MakeSlice(field.Type(), 1, 1))
+		case reflect.Map:
+			field.Set(reflect.MakeMapWithSize(field.Type(), 1))
+			field.SetMapIndex(reflect.ValueOf("k"), reflect.ValueOf("v"))
+		case reflect.Interface:
+			field.Set(reflect.ValueOf(any("x")))
+		case reflect.Struct:
+			fill(t, field)
+		}
+	}
+}

--- a/internal/core/responses_json.go
+++ b/internal/core/responses_json.go
@@ -7,113 +7,50 @@ import (
 	"github.com/goccy/go-json"
 )
 
-// responsesUtilityRequestFields lists the JSON fields recognized on responses
-// utility requests; any other field is preserved as an unknown extra field.
-var responsesUtilityRequestFields = []string{
-	"model",
-	"provider",
-	"input",
-	"instructions",
-	"tools",
-	"tool_choice",
-	"parallel_tool_calls",
-	"temperature",
-	"top_p",
-	"top_logprobs",
-	"max_output_tokens",
-	"metadata",
-	"reasoning",
-	"text",
-	"include",
-	"truncation",
-	"store",
-	"previous_response_id",
-	"conversation",
-	"prompt",
-	"prompt_cache_retention",
-	"context_management",
-	"user",
-	"service_tier",
-	"safety_identifier",
-}
+// Known-field lists are derived from the struct definitions (json tags) at
+// package init, so adding a typed field automatically stops it from being
+// captured as an unknown extra field. ContentSchema swagger phantoms share
+// tags with real fields, which is harmless here (duplicates in the list).
+var (
+	responsesRequestFields        = jsonFieldNames(ResponsesRequest{})
+	responsesUtilityRequestFields = jsonFieldNames(ResponseInputTokensRequest{})
+)
 
-// responsesRequestFields additionally recognizes the streaming controls that
-// only apply to full responses requests.
-var responsesRequestFields = append([]string{"stream", "stream_options"}, responsesUtilityRequestFields...)
+// responsesExtrasAndInput finishes a responses-shaped decode: it captures
+// unknown members and decodes the raw input union.
+func responsesExtrasAndInput(data []byte, rawInput json.RawMessage, knownFields []string) (any, UnknownJSONFields, error) {
+	extraFields, err := extractUnknownJSONFields(data, knownFields...)
+	if err != nil {
+		return nil, UnknownJSONFields{}, err
+	}
+	input, err := decodeResponsesInput(rawInput)
+	if err != nil {
+		return nil, UnknownJSONFields{}, err
+	}
+	return input, extraFields, nil
+}
 
 // UnmarshalJSON preserves dynamic input payloads while supporting Swagger-only schema fields.
 // Array inputs are deserialized as []ResponsesInputElement for type-safe downstream handling.
+// The body decodes through an alias embedding so every typed field (present and
+// future) is populated by the JSON package directly — only Input (a raw union)
+// and ExtraFields need explicit handling.
 func (r *ResponsesRequest) UnmarshalJSON(data []byte) error {
+	type alias ResponsesRequest
 	var raw struct {
-		Model                string                    `json:"model"`
-		Provider             string                    `json:"provider,omitempty"`
-		Input                json.RawMessage           `json:"input"`
-		Instructions         string                    `json:"instructions,omitempty"`
-		Tools                []map[string]any          `json:"tools,omitempty"`
-		ToolChoice           any                       `json:"tool_choice,omitempty"`
-		ParallelToolCalls    *bool                     `json:"parallel_tool_calls,omitempty"`
-		Temperature          *float64                  `json:"temperature,omitempty"`
-		TopP                 *float64                  `json:"top_p,omitempty"`
-		TopLogprobs          *int                      `json:"top_logprobs,omitempty"`
-		MaxOutputTokens      *int                      `json:"max_output_tokens,omitempty"`
-		Stream               bool                      `json:"stream,omitempty"`
-		StreamOptions        *StreamOptions            `json:"stream_options,omitempty"`
-		Metadata             map[string]string         `json:"metadata,omitempty"`
-		Reasoning            *Reasoning                `json:"reasoning,omitempty"`
-		Text                 any                       `json:"text,omitempty"`
-		Include              []string                  `json:"include,omitempty"`
-		Truncation           string                    `json:"truncation,omitempty"`
-		Store                *bool                     `json:"store,omitempty"`
-		PreviousResponseID   string                    `json:"previous_response_id,omitempty"`
-		Conversation         *ResponsesConversationRef `json:"conversation,omitempty"`
-		Prompt               any                       `json:"prompt,omitempty"`
-		PromptCacheRetention string                    `json:"prompt_cache_retention,omitempty"`
-		ContextManagement    any                       `json:"context_management,omitempty"`
-		User                 string                    `json:"user,omitempty"`
-		ServiceTier          string                    `json:"service_tier,omitempty"`
-		SafetyIdentifier     string                    `json:"safety_identifier,omitempty"`
+		alias
+		Input json.RawMessage `json:"input"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
-
-	extraFields, err := extractUnknownJSONFields(data, responsesRequestFields...)
+	input, extraFields, err := responsesExtrasAndInput(data, raw.Input, responsesRequestFields)
 	if err != nil {
 		return err
 	}
 
-	input, err := decodeResponsesInput(raw.Input)
-	if err != nil {
-		return err
-	}
-
-	r.Model = raw.Model
-	r.Provider = raw.Provider
+	*r = ResponsesRequest(raw.alias)
 	r.Input = input
-	r.Instructions = raw.Instructions
-	r.Tools = raw.Tools
-	r.ToolChoice = raw.ToolChoice
-	r.ParallelToolCalls = raw.ParallelToolCalls
-	r.Temperature = raw.Temperature
-	r.TopP = raw.TopP
-	r.TopLogprobs = raw.TopLogprobs
-	r.MaxOutputTokens = raw.MaxOutputTokens
-	r.Stream = raw.Stream
-	r.StreamOptions = raw.StreamOptions
-	r.Metadata = raw.Metadata
-	r.Reasoning = raw.Reasoning
-	r.Text = raw.Text
-	r.Include = raw.Include
-	r.Truncation = raw.Truncation
-	r.Store = raw.Store
-	r.PreviousResponseID = raw.PreviousResponseID
-	r.Conversation = raw.Conversation
-	r.Prompt = raw.Prompt
-	r.PromptCacheRetention = raw.PromptCacheRetention
-	r.ContextManagement = raw.ContextManagement
-	r.User = raw.User
-	r.ServiceTier = raw.ServiceTier
-	r.SafetyIdentifier = raw.SafetyIdentifier
 	r.ExtraFields = extraFields
 	return nil
 }
@@ -200,190 +137,46 @@ func (r ResponsesRequest) MarshalJSON() ([]byte, error) {
 	return marshalWithUnknownJSONFields(alias(r), r.ExtraFields)
 }
 
-type responseUtilityRequestJSON struct {
-	Model                string
-	Provider             string
-	Input                any
-	Instructions         string
-	Tools                []map[string]any
-	ToolChoice           any
-	ParallelToolCalls    *bool
-	Temperature          *float64
-	TopP                 *float64
-	TopLogprobs          *int
-	MaxOutputTokens      *int
-	Metadata             map[string]string
-	Reasoning            *Reasoning
-	Text                 any
-	Include              []string
-	Truncation           string
-	Store                *bool
-	PreviousResponseID   string
-	Conversation         *ResponsesConversationRef
-	Prompt               any
-	PromptCacheRetention string
-	ContextManagement    any
-	User                 string
-	ServiceTier          string
-	SafetyIdentifier     string
-	ExtraFields          UnknownJSONFields
-}
-
-func decodeResponseUtilityRequestJSON(data []byte) (responseUtilityRequestJSON, error) {
-	var raw struct {
-		Model                string                    `json:"model,omitempty"`
-		Provider             string                    `json:"provider,omitempty"`
-		Input                json.RawMessage           `json:"input,omitempty"`
-		Instructions         string                    `json:"instructions,omitempty"`
-		Tools                []map[string]any          `json:"tools,omitempty"`
-		ToolChoice           any                       `json:"tool_choice,omitempty"`
-		ParallelToolCalls    *bool                     `json:"parallel_tool_calls,omitempty"`
-		Temperature          *float64                  `json:"temperature,omitempty"`
-		TopP                 *float64                  `json:"top_p,omitempty"`
-		TopLogprobs          *int                      `json:"top_logprobs,omitempty"`
-		MaxOutputTokens      *int                      `json:"max_output_tokens,omitempty"`
-		Metadata             map[string]string         `json:"metadata,omitempty"`
-		Reasoning            *Reasoning                `json:"reasoning,omitempty"`
-		Text                 any                       `json:"text,omitempty"`
-		Include              []string                  `json:"include,omitempty"`
-		Truncation           string                    `json:"truncation,omitempty"`
-		Store                *bool                     `json:"store,omitempty"`
-		PreviousResponseID   string                    `json:"previous_response_id,omitempty"`
-		Conversation         *ResponsesConversationRef `json:"conversation,omitempty"`
-		Prompt               any                       `json:"prompt,omitempty"`
-		PromptCacheRetention string                    `json:"prompt_cache_retention,omitempty"`
-		ContextManagement    any                       `json:"context_management,omitempty"`
-		User                 string                    `json:"user,omitempty"`
-		ServiceTier          string                    `json:"service_tier,omitempty"`
-		SafetyIdentifier     string                    `json:"safety_identifier,omitempty"`
-	}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return responseUtilityRequestJSON{}, err
-	}
-
-	extraFields, err := extractUnknownJSONFields(data, responsesUtilityRequestFields...)
-	if err != nil {
-		return responseUtilityRequestJSON{}, err
-	}
-
-	input, err := decodeResponsesInput(raw.Input)
-	if err != nil {
-		return responseUtilityRequestJSON{}, err
-	}
-	return responseUtilityRequestJSON{
-		Model:                raw.Model,
-		Provider:             raw.Provider,
-		Input:                input,
-		Instructions:         raw.Instructions,
-		Tools:                raw.Tools,
-		ToolChoice:           raw.ToolChoice,
-		ParallelToolCalls:    raw.ParallelToolCalls,
-		Temperature:          raw.Temperature,
-		TopP:                 raw.TopP,
-		TopLogprobs:          raw.TopLogprobs,
-		MaxOutputTokens:      raw.MaxOutputTokens,
-		Metadata:             raw.Metadata,
-		Reasoning:            raw.Reasoning,
-		Text:                 raw.Text,
-		Include:              raw.Include,
-		Truncation:           raw.Truncation,
-		Store:                raw.Store,
-		PreviousResponseID:   raw.PreviousResponseID,
-		Conversation:         raw.Conversation,
-		Prompt:               raw.Prompt,
-		PromptCacheRetention: raw.PromptCacheRetention,
-		ContextManagement:    raw.ContextManagement,
-		User:                 raw.User,
-		ServiceTier:          raw.ServiceTier,
-		SafetyIdentifier:     raw.SafetyIdentifier,
-		ExtraFields:          extraFields,
-	}, nil
-}
-
-func marshalResponseUtilityRequestJSON(raw responseUtilityRequestJSON) ([]byte, error) {
-	return marshalWithUnknownJSONFields(struct {
-		Model                string                    `json:"model,omitempty"`
-		Provider             string                    `json:"provider,omitempty"`
-		Input                any                       `json:"input,omitempty"`
-		Instructions         string                    `json:"instructions,omitempty"`
-		Tools                []map[string]any          `json:"tools,omitempty"`
-		ToolChoice           any                       `json:"tool_choice,omitempty"`
-		ParallelToolCalls    *bool                     `json:"parallel_tool_calls,omitempty"`
-		Temperature          *float64                  `json:"temperature,omitempty"`
-		TopP                 *float64                  `json:"top_p,omitempty"`
-		TopLogprobs          *int                      `json:"top_logprobs,omitempty"`
-		MaxOutputTokens      *int                      `json:"max_output_tokens,omitempty"`
-		Metadata             map[string]string         `json:"metadata,omitempty"`
-		Reasoning            *Reasoning                `json:"reasoning,omitempty"`
-		Text                 any                       `json:"text,omitempty"`
-		Include              []string                  `json:"include,omitempty"`
-		Truncation           string                    `json:"truncation,omitempty"`
-		Store                *bool                     `json:"store,omitempty"`
-		PreviousResponseID   string                    `json:"previous_response_id,omitempty"`
-		Conversation         *ResponsesConversationRef `json:"conversation,omitempty"`
-		Prompt               any                       `json:"prompt,omitempty"`
-		PromptCacheRetention string                    `json:"prompt_cache_retention,omitempty"`
-		ContextManagement    any                       `json:"context_management,omitempty"`
-		User                 string                    `json:"user,omitempty"`
-		ServiceTier          string                    `json:"service_tier,omitempty"`
-		SafetyIdentifier     string                    `json:"safety_identifier,omitempty"`
-	}{
-		Model:                raw.Model,
-		Provider:             raw.Provider,
-		Input:                raw.Input,
-		Instructions:         raw.Instructions,
-		Tools:                raw.Tools,
-		ToolChoice:           raw.ToolChoice,
-		ParallelToolCalls:    raw.ParallelToolCalls,
-		Temperature:          raw.Temperature,
-		TopP:                 raw.TopP,
-		TopLogprobs:          raw.TopLogprobs,
-		MaxOutputTokens:      raw.MaxOutputTokens,
-		Metadata:             raw.Metadata,
-		Reasoning:            raw.Reasoning,
-		Text:                 raw.Text,
-		Include:              raw.Include,
-		Truncation:           raw.Truncation,
-		Store:                raw.Store,
-		PreviousResponseID:   raw.PreviousResponseID,
-		Conversation:         raw.Conversation,
-		Prompt:               raw.Prompt,
-		PromptCacheRetention: raw.PromptCacheRetention,
-		ContextManagement:    raw.ContextManagement,
-		User:                 raw.User,
-		ServiceTier:          raw.ServiceTier,
-		SafetyIdentifier:     raw.SafetyIdentifier,
-	}, raw.ExtraFields)
-}
-
 // UnmarshalJSON preserves the dynamic input payload for gateway utility requests.
 func (r *ResponseInputTokensRequest) UnmarshalJSON(data []byte) error {
-	raw, err := decodeResponseUtilityRequestJSON(data)
+	type alias ResponseInputTokensRequest
+	var raw struct {
+		alias
+		Input json.RawMessage `json:"input"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	input, extraFields, err := responsesExtrasAndInput(data, raw.Input, responsesUtilityRequestFields)
 	if err != nil {
 		return err
 	}
-	*r = ResponseInputTokensRequest(raw)
+
+	*r = ResponseInputTokensRequest(raw.alias)
+	r.Input = input
+	r.ExtraFields = extraFields
 	return nil
 }
 
 // MarshalJSON preserves the dynamic input payload while omitting Swagger-only schema fields.
 func (r ResponseInputTokensRequest) MarshalJSON() ([]byte, error) {
-	return marshalResponseUtilityRequestJSON(responseUtilityRequestJSON(r))
+	type alias ResponseInputTokensRequest
+	return marshalWithUnknownJSONFields(alias(r), r.ExtraFields)
 }
 
 // UnmarshalJSON preserves the dynamic input payload for gateway utility requests.
 func (r *ResponseCompactRequest) UnmarshalJSON(data []byte) error {
-	raw, err := decodeResponseUtilityRequestJSON(data)
-	if err != nil {
+	var utility ResponseInputTokensRequest
+	if err := utility.UnmarshalJSON(data); err != nil {
 		return err
 	}
-	*r = ResponseCompactRequest(raw)
+	*r = ResponseCompactRequest(utility)
 	return nil
 }
 
 // MarshalJSON preserves the dynamic input payload while omitting Swagger-only schema fields.
 func (r ResponseCompactRequest) MarshalJSON() ([]byte, error) {
-	return marshalResponseUtilityRequestJSON(responseUtilityRequestJSON(r))
+	return ResponseInputTokensRequest(r).MarshalJSON()
 }
 
 // UnmarshalJSON deserializes a ResponsesInputElement, switching on the "type"

--- a/internal/providers/openai/compatible_provider.go
+++ b/internal/providers/openai/compatible_provider.go
@@ -288,50 +288,20 @@ func (p *CompatibleProvider) CompactResponse(ctx context.Context, req *core.Resp
 }
 
 func responseInputTokensRequestFromResponses(req *core.ResponsesRequest) *core.ResponseInputTokensRequest {
-	if req == nil {
-		return nil
+	utility := req.InputTokensRequest()
+	if utility != nil {
+		// The provider field is a gateway routing hint, never forwarded upstream.
+		utility.Provider = ""
 	}
-	utility := responseUtilityRequestFromResponses(req)
-	return &utility
+	return utility
 }
 
 func responseCompactRequestFromResponses(req *core.ResponsesRequest) *core.ResponseCompactRequest {
-	if req == nil {
-		return nil
+	compact := req.CompactRequest()
+	if compact != nil {
+		compact.Provider = ""
 	}
-	utility := responseUtilityRequestFromResponses(req)
-	compact := core.ResponseCompactRequest(utility)
-	return &compact
-}
-
-func responseUtilityRequestFromResponses(req *core.ResponsesRequest) core.ResponseInputTokensRequest {
-	return core.ResponseInputTokensRequest{
-		Model:                req.Model,
-		Input:                req.Input,
-		Instructions:         req.Instructions,
-		Tools:                req.Tools,
-		ToolChoice:           req.ToolChoice,
-		ParallelToolCalls:    req.ParallelToolCalls,
-		Temperature:          req.Temperature,
-		TopP:                 req.TopP,
-		TopLogprobs:          req.TopLogprobs,
-		MaxOutputTokens:      req.MaxOutputTokens,
-		Metadata:             req.Metadata,
-		Reasoning:            req.Reasoning,
-		Text:                 req.Text,
-		Include:              req.Include,
-		Truncation:           req.Truncation,
-		Store:                req.Store,
-		PreviousResponseID:   req.PreviousResponseID,
-		Conversation:         req.Conversation,
-		Prompt:               req.Prompt,
-		PromptCacheRetention: req.PromptCacheRetention,
-		ContextManagement:    req.ContextManagement,
-		User:                 req.User,
-		ServiceTier:          req.ServiceTier,
-		SafetyIdentifier:     req.SafetyIdentifier,
-		ExtraFields:          core.CloneUnknownJSONFields(req.ExtraFields),
-	}
+	return compact
 }
 
 func (p *CompatibleProvider) Embeddings(ctx context.Context, req *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {


### PR DESCRIPTION
## Summary

The biggest remaining shotgun-surgery site from the architecture review (doc in #472, §3): the Responses API field set was maintained by hand in ~8 places. Adding one field meant editing three 25-field struct twins, two known-field string lists, two raw decode structs with field-by-field copies, a 25-field marshal struct, and a 24-field provider-side reduction — and a missed site silently dropped the field or double-emitted it via ExtraFields.

After this PR the field set is written **once per type** and everything else derives:

- `jsonFieldNames` derives the known-field lists from `json` tags at package init, so `extractUnknownJSONFields` can never drift from the type definitions.
- Decoding goes through an embedded type alias (with `Input` shadowed as `json.RawMessage` for the string-or-array union), so new typed fields are populated by the JSON package automatically — the triple-entry raw structs and per-field copies are deleted.
- `ResponseCompactRequest` is now `type ResponseCompactRequest ResponseInputTokensRequest` — the byte-identical 25-field twin is gone.
- The full→utility reduction lives next to the types (`ResponsesRequest.InputTokensRequest()` / `.CompactRequest()`); the openai provider keeps stripping the gateway-only `provider` hint at its boundary, unchanged on the wire.
- Same alias treatment for `ChatRequest` decode (its field list was triple-entry too).

## The safety net

Two new guard tests pin the contract mechanically: the utility field set must equal the full set minus the streaming controls, and a reflection-filled `ResponsesRequest` asserts the reduction copies **every** field. The next person who adds a Responses field gets a failing test naming the missed spot, not a silent drop.

## User-visible impact

None — wire behavior is unchanged. The existing round-trip, unknown-field-preservation, and input-union tests pass untouched, which is the strongest evidence the alias decode is byte-equivalent.

## Testing

Full `go build ./...` and `go test ./...`; `go test -race` on core + openai + server; `golangci-lint` 0 issues; pre-commit `make test-race` on the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for request formats that preserve extra, unrecognized fields.
  * Added streamlined conversion to smaller request variants for token-related and compact response workflows.

* **Bug Fixes**
  * Better handling of nested input data and unknown fields when reading and writing requests.
  * More consistent behavior when request objects are empty or unset, including safer nil handling.

* **Tests**
  * Added coverage to verify request field consistency and data preservation during conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->