### PR TITLE
refactor(providers): route deepseek, xai, and ollama through the shared OpenAI-compatible core

### DIFF
--- a/internal/providers/deepseek/deepseek.go
+++ b/internal/providers/deepseek/deepseek.go
@@ -3,13 +3,13 @@ package deepseek
 
 import (
 	"context"
-	"io"
 	"net/http"
 	"strings"
 
 	"gomodel/internal/core"
 	"gomodel/internal/llmclient"
 	"gomodel/internal/providers"
+	"gomodel/internal/providers/openai"
 )
 
 const defaultBaseURL = "https://api.deepseek.com"
@@ -24,48 +24,43 @@ var Registration = providers.Registration{
 	},
 }
 
-// Provider implements the core.Provider interface for DeepSeek.
+// Provider implements the core.Provider interface for DeepSeek. DeepSeek's
+// API is OpenAI-compatible, so all transport goes through the shared
+// chat-centric adapter; the only quirks are the reasoning-effort remap
+// (applied via the AdaptChatRequest hook) and the missing embeddings
+// endpoint.
 type Provider struct {
-	client *llmclient.Client
-	apiKey string
+	*openai.ChatCompatible
 }
 
 var _ core.Provider = (*Provider)(nil)
 
 // New creates a new DeepSeek provider.
 func New(cfg providers.ProviderConfig, opts providers.ProviderOptions) core.Provider {
-	p := &Provider{apiKey: cfg.APIKey}
-	clientCfg := llmclient.Config{
-		ProviderName:   "deepseek",
-		BaseURL:        providers.ResolveBaseURL(cfg.BaseURL, defaultBaseURL),
-		Retry:          opts.Resilience.Retry,
-		Hooks:          opts.Hooks,
-		CircuitBreaker: opts.Resilience.CircuitBreaker,
+	return &Provider{
+		ChatCompatible: openai.NewChatCompatible(cfg.APIKey, opts, compatibleConfig(providers.ResolveBaseURL(cfg.BaseURL, defaultBaseURL))),
 	}
-	p.client = llmclient.New(clientCfg, p.setHeaders)
-	return p
 }
 
 // NewWithHTTPClient creates a new DeepSeek provider with a custom HTTP client.
 // If httpClient is nil, http.DefaultClient is used.
 func NewWithHTTPClient(apiKey string, baseURL string, httpClient *http.Client, hooks llmclient.Hooks) *Provider {
-	if httpClient == nil {
-		httpClient = http.DefaultClient
+	return &Provider{
+		ChatCompatible: openai.NewChatCompatibleWithHTTPClient(apiKey, httpClient, hooks, compatibleConfig(providers.ResolveBaseURL(baseURL, defaultBaseURL))),
 	}
-	p := &Provider{apiKey: apiKey}
-	cfg := llmclient.DefaultConfig("deepseek", providers.ResolveBaseURL(baseURL, defaultBaseURL))
-	cfg.Hooks = hooks
-	p.client = llmclient.NewWithHTTPClient(httpClient, cfg, p.setHeaders)
-	return p
 }
 
-// SetBaseURL allows configuring a custom base URL for the provider.
-func (p *Provider) SetBaseURL(url string) {
-	p.client.SetBaseURL(url)
+func compatibleConfig(baseURL string) openai.CompatibleProviderConfig {
+	return openai.CompatibleProviderConfig{
+		ProviderName:     "deepseek",
+		BaseURL:          baseURL,
+		SetHeaders:       setHeaders,
+		AdaptChatRequest: adaptChatRequest,
+	}
 }
 
-func (p *Provider) setHeaders(req *http.Request) {
-	providers.SetAuthHeaders(req, p.apiKey, providers.AuthHeaderConfig{
+func setHeaders(req *http.Request, apiKey string) {
+	providers.SetAuthHeaders(req, apiKey, providers.AuthHeaderConfig{
 		AuthScheme:      "Bearer ",
 		RequestIDHeader: "X-Request-Id",
 	})
@@ -74,7 +69,7 @@ func (p *Provider) setHeaders(req *http.Request) {
 // adaptChatRequest rewrites GoModel's common reasoning shape into DeepSeek's
 // OpenAI-compatible chat extension. DeepSeek accepts reasoning_effort as a
 // top-level string, not "reasoning": {"effort": "..."}.
-func adaptChatRequest(req *core.ChatRequest) (any, error) {
+func adaptChatRequest(req *core.ChatRequest) (*core.ChatRequest, error) {
 	if req == nil || req.Reasoning == nil || strings.TrimSpace(req.Reasoning.Effort) == "" {
 		return req, nil
 	}
@@ -98,102 +93,7 @@ func normalizeReasoningEffort(effort string) string {
 	}
 }
 
-// ChatCompletion sends a chat completion request to DeepSeek.
-func (p *Provider) ChatCompletion(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
-	if req == nil {
-		return nil, core.NewInvalidRequestError("chat request is required", nil)
-	}
-	body, err := adaptChatRequest(req)
-	if err != nil {
-		return nil, err
-	}
-	var resp core.ChatResponse
-	err = p.client.Do(ctx, llmclient.Request{
-		Method:   http.MethodPost,
-		Endpoint: "/chat/completions",
-		Body:     body,
-	}, &resp)
-	if err != nil {
-		return nil, err
-	}
-	core.EnsureModel(&resp.Model, req.Model)
-	return &resp, nil
-}
-
-// StreamChatCompletion returns a raw response body for streaming.
-func (p *Provider) StreamChatCompletion(ctx context.Context, req *core.ChatRequest) (io.ReadCloser, error) {
-	if req == nil {
-		return nil, core.NewInvalidRequestError("chat request is required", nil)
-	}
-	streamReq := req.WithStreaming()
-	body, err := adaptChatRequest(streamReq)
-	if err != nil {
-		return nil, err
-	}
-	stream, err := p.client.DoStream(ctx, llmclient.Request{
-		Method:   http.MethodPost,
-		Endpoint: "/chat/completions",
-		Body:     body,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return providers.EnsureChatCompletionSSE(stream), nil
-}
-
-// ListModels retrieves the list of available models from DeepSeek.
-func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error) {
-	var resp core.ModelsResponse
-	err := p.client.Do(ctx, llmclient.Request{
-		Method:   http.MethodGet,
-		Endpoint: "/models",
-	}, &resp)
-	if err != nil {
-		return nil, err
-	}
-	return &resp, nil
-}
-
-// Responses sends a Responses API request to DeepSeek using chat-completions translation.
-func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
-	if req == nil {
-		return nil, core.NewInvalidRequestError("responses request is required", nil)
-	}
-	return providers.ResponsesViaChat(ctx, p, req)
-}
-
-// StreamResponses streams a Responses API request to DeepSeek using chat-completions translation.
-func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
-	if req == nil {
-		return nil, core.NewInvalidRequestError("responses request is required", nil)
-	}
-	return providers.StreamResponsesViaChat(ctx, p, req, "deepseek")
-}
-
 // Embeddings returns an error because DeepSeek does not expose an embeddings endpoint.
 func (p *Provider) Embeddings(_ context.Context, _ *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
 	return nil, core.NewInvalidRequestError("deepseek does not support embeddings", nil)
-}
-
-// Passthrough forwards a raw request to DeepSeek without any transformation,
-// enabling direct access to provider-native endpoints such as /beta/completions
-// (FIM) that GOModel does not expose as first-class typed operations.
-func (p *Provider) Passthrough(ctx context.Context, req *core.PassthroughRequest) (*core.PassthroughResponse, error) {
-	if req == nil {
-		return nil, core.NewInvalidRequestError("passthrough request is required", nil)
-	}
-	resp, err := p.client.DoPassthrough(ctx, llmclient.Request{
-		Method:        req.Method,
-		Endpoint:      providers.PassthroughEndpoint(req.Endpoint),
-		RawBodyReader: req.Body,
-		Headers:       req.Headers,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return &core.PassthroughResponse{
-		StatusCode: resp.StatusCode,
-		Headers:    providers.CloneHTTPHeaders(resp.Header),
-		Body:       resp.Body,
-	}, nil
 }

--- a/internal/providers/ollama/ollama.go
+++ b/internal/providers/ollama/ollama.go
@@ -15,6 +15,7 @@ import (
 	"gomodel/internal/core"
 	"gomodel/internal/llmclient"
 	"gomodel/internal/providers"
+	"gomodel/internal/providers/openai"
 )
 
 // Registration provides factory registration for the Ollama provider.
@@ -33,9 +34,14 @@ const (
 	defaultNativeBaseURL = defaultRootURL
 )
 
-// Provider implements the core.Provider interface for Ollama
+// Provider implements the core.Provider interface for Ollama. The /v1
+// OpenAI-compatible surface goes through the shared compatible provider;
+// embeddings use Ollama's native /api/embed endpoint via a second client
+// rooted at the server root. Methods are delegated explicitly rather than
+// embedded because Ollama's upstream lacks parts of the full OpenAI
+// surface (passthrough, audio) and embedding cannot subtract methods.
 type Provider struct {
-	client       *llmclient.Client
+	compat       *openai.CompatibleProvider
 	nativeClient *llmclient.Client
 	apiKey       string // Accepted but ignored by Ollama
 }
@@ -43,14 +49,7 @@ type Provider struct {
 // New creates a new Ollama provider.
 func New(providerCfg providers.ProviderConfig, opts providers.ProviderOptions) core.Provider {
 	p := &Provider{apiKey: providerCfg.APIKey}
-	clientCfg := llmclient.Config{
-		ProviderName:   "ollama",
-		BaseURL:        defaultBaseURL,
-		Retry:          opts.Resilience.Retry,
-		Hooks:          opts.Hooks,
-		CircuitBreaker: opts.Resilience.CircuitBreaker,
-	}
-	p.client = llmclient.New(clientCfg, p.setHeaders)
+	p.compat = openai.NewCompatibleProvider(providerCfg.APIKey, opts, compatibleConfig(defaultBaseURL))
 
 	nativeCfg := llmclient.Config{
 		ProviderName:   "ollama",
@@ -59,7 +58,7 @@ func New(providerCfg providers.ProviderConfig, opts providers.ProviderOptions) c
 		Hooks:          opts.Hooks,
 		CircuitBreaker: opts.Resilience.CircuitBreaker,
 	}
-	p.nativeClient = llmclient.New(nativeCfg, p.setHeaders)
+	p.nativeClient = llmclient.New(nativeCfg, p.setNativeHeaders)
 	p.SetBaseURL(providers.ResolveBaseURL(providerCfg.BaseURL, defaultBaseURL))
 	return p
 }
@@ -71,20 +70,26 @@ func NewWithHTTPClient(apiKey string, httpClient *http.Client, hooks llmclient.H
 		httpClient = http.DefaultClient
 	}
 	p := &Provider{apiKey: apiKey}
-	cfg := llmclient.DefaultConfig("ollama", defaultBaseURL)
-	cfg.Hooks = hooks
-	p.client = llmclient.NewWithHTTPClient(httpClient, cfg, p.setHeaders)
+	p.compat = openai.NewCompatibleProviderWithHTTPClient(apiKey, httpClient, hooks, compatibleConfig(defaultBaseURL))
 
 	nativeCfg := llmclient.DefaultConfig("ollama", defaultNativeBaseURL)
 	nativeCfg.Hooks = hooks
-	p.nativeClient = llmclient.NewWithHTTPClient(httpClient, nativeCfg, p.setHeaders)
+	p.nativeClient = llmclient.NewWithHTTPClient(httpClient, nativeCfg, p.setNativeHeaders)
 	return p
+}
+
+func compatibleConfig(baseURL string) openai.CompatibleProviderConfig {
+	return openai.CompatibleProviderConfig{
+		ProviderName: "ollama",
+		BaseURL:      baseURL,
+		SetHeaders:   setHeaders,
+	}
 }
 
 // SetBaseURL allows configuring a custom base URL for the provider.
 // Also updates the native client by deriving the root URL (stripping /v1 suffix).
 func (p *Provider) SetBaseURL(url string) {
-	p.client.SetBaseURL(url)
+	p.compat.SetBaseURL(url)
 	normalized := strings.TrimRight(url, "/")
 	normalized = strings.TrimSuffix(normalized, "/v1")
 	p.nativeClient.SetBaseURL(normalized)
@@ -100,51 +105,34 @@ func (p *Provider) CheckAvailability(ctx context.Context) error {
 	return err
 }
 
-// setHeaders sets the required headers for Ollama API requests
-func (p *Provider) setHeaders(req *http.Request) {
-	// Ollama doesn't require authentication, but accepts a Bearer token if provided.
-	providers.SetAuthHeaders(req, p.apiKey, providers.AuthHeaderConfig{
+// setHeaders sets the required headers for Ollama API requests.
+// Ollama doesn't require authentication, but accepts a Bearer token if provided.
+func setHeaders(req *http.Request, apiKey string) {
+	providers.SetAuthHeaders(req, apiKey, providers.AuthHeaderConfig{
 		AuthScheme:      "Bearer ",
 		RequestIDHeader: "X-Request-ID",
 		OptionalAPIKey:  true,
 	})
 }
 
+// setNativeHeaders applies the same header policy on the native /api client.
+func (p *Provider) setNativeHeaders(req *http.Request) {
+	setHeaders(req, p.apiKey)
+}
+
 // ChatCompletion sends a chat completion request to Ollama
 func (p *Provider) ChatCompletion(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
-	var resp core.ChatResponse
-	err := p.client.Do(ctx, llmclient.Request{
-		Method:   http.MethodPost,
-		Endpoint: "/chat/completions",
-		Body:     req,
-	}, &resp)
-	if err != nil {
-		return nil, err
-	}
-	core.EnsureModel(&resp.Model, req.Model)
-	return &resp, nil
+	return p.compat.ChatCompletion(ctx, req)
 }
 
 // StreamChatCompletion returns a raw response body for streaming (caller must close)
 func (p *Provider) StreamChatCompletion(ctx context.Context, req *core.ChatRequest) (io.ReadCloser, error) {
-	return p.client.DoStream(ctx, llmclient.Request{
-		Method:   http.MethodPost,
-		Endpoint: "/chat/completions",
-		Body:     req.WithStreaming(),
-	})
+	return p.compat.StreamChatCompletion(ctx, req)
 }
 
 // ListModels retrieves the list of available models from Ollama
 func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error) {
-	var resp core.ModelsResponse
-	err := p.client.Do(ctx, llmclient.Request{
-		Method:   http.MethodGet,
-		Endpoint: "/models",
-	}, &resp)
-	if err != nil {
-		return nil, err
-	}
-	return &resp, nil
+	return p.compat.ListModels(ctx)
 }
 
 // Responses sends a Responses API request to Ollama (converted to chat format)

--- a/internal/providers/ollama/ollama_test.go
+++ b/internal/providers/ollama/ollama_test.go
@@ -23,8 +23,8 @@ func TestNew(t *testing.T) {
 	if provider.apiKey != apiKey {
 		t.Errorf("apiKey = %q, want %q", provider.apiKey, apiKey)
 	}
-	if provider.client == nil {
-		t.Error("client should not be nil")
+	if provider.compat == nil {
+		t.Error("compat should not be nil")
 	}
 	if provider.nativeClient == nil {
 		t.Error("nativeClient should not be nil")
@@ -46,8 +46,8 @@ func TestNew_WithoutAPIKey(t *testing.T) {
 	if provider.apiKey != "" {
 		t.Errorf("apiKey = %q, want empty", provider.apiKey)
 	}
-	if provider.client == nil {
-		t.Error("client should not be nil")
+	if provider.compat == nil {
+		t.Error("compat should not be nil")
 	}
 }
 
@@ -725,8 +725,8 @@ func TestNewWithHTTPClient(t *testing.T) {
 	if provider.apiKey != apiKey {
 		t.Errorf("apiKey = %q, want %q", provider.apiKey, apiKey)
 	}
-	if provider.client == nil {
-		t.Error("client should not be nil")
+	if provider.compat == nil {
+		t.Error("compat should not be nil")
 	}
 	if provider.nativeClient == nil {
 		t.Error("nativeClient should not be nil")

--- a/internal/providers/openai/compatible_provider.go
+++ b/internal/providers/openai/compatible_provider.go
@@ -20,20 +20,59 @@ type CompatibleProviderConfig struct {
 	BaseURL        string
 	SetHeaders     func(*http.Request, string)
 	RequestMutator RequestMutator
+	// AdaptChatRequest rewrites the typed chat request before provider
+	// dispatch on ChatCompletion and StreamChatCompletion. Providers use it
+	// for parameter quirks (e.g. remapping reasoning effort levels) instead
+	// of overriding the chat methods, so Responses-via-chat translation picks
+	// the adaptation up automatically. It must not mutate its argument;
+	// return a shallow copy when changes are needed.
+	AdaptChatRequest func(*core.ChatRequest) (*core.ChatRequest, error)
+	// ChatRequestHeaders returns extra per-request HTTP headers for
+	// ChatCompletion and StreamChatCompletion, derived from the request
+	// context and body (e.g. conversation affinity headers). Nil results are
+	// ignored.
+	ChatRequestHeaders func(context.Context, *core.ChatRequest) http.Header
 }
 
+// CompatibleProvider is the single transport engine for every
+// OpenAI-compatible upstream. Provider packages must not hand-roll
+// llmclient calls for OpenAI-shaped endpoints; they wrap this type in one
+// of three ways, chosen by how much of the OpenAI surface the upstream
+// actually implements:
+//
+//   - Embed *ChatCompatible for chat-centric upstreams (chat, models,
+//     embeddings, passthrough; Responses translated via chat) — e.g.
+//     xiaomi, zai, fireworks, deepseek.
+//   - Embed *CompatibleProvider only when the upstream implements the
+//     full surface, including audio, files, batches, and native response
+//     lifecycle management — e.g. openrouter, azure.
+//   - Compose an unexported *CompatibleProvider field and delegate the
+//     supported methods explicitly when the upstream implements a partial
+//     surface — e.g. groq (no passthrough), xai (no audio/passthrough),
+//     ollama (native embeddings, no passthrough). Go embedding cannot
+//     subtract methods, and an accidentally inherited method advertises a
+//     capability the upstream lacks (the router discovers capabilities by
+//     interface assertion).
+//
+// Provider quirks belong in CompatibleProviderConfig hooks (SetHeaders,
+// AdaptChatRequest, ChatRequestHeaders, RequestMutator), not in copies of
+// the transport methods.
 type CompatibleProvider struct {
-	client         *llmclient.Client
-	apiKey         string
-	providerName   string
-	requestMutator RequestMutator
+	client             *llmclient.Client
+	apiKey             string
+	providerName       string
+	requestMutator     RequestMutator
+	adaptChatRequest   func(*core.ChatRequest) (*core.ChatRequest, error)
+	chatRequestHeaders func(context.Context, *core.ChatRequest) http.Header
 }
 
 func NewCompatibleProvider(apiKey string, opts providers.ProviderOptions, cfg CompatibleProviderConfig) *CompatibleProvider {
 	p := &CompatibleProvider{
-		apiKey:         apiKey,
-		providerName:   cfg.ProviderName,
-		requestMutator: cfg.RequestMutator,
+		apiKey:             apiKey,
+		providerName:       cfg.ProviderName,
+		requestMutator:     cfg.RequestMutator,
+		adaptChatRequest:   cfg.AdaptChatRequest,
+		chatRequestHeaders: cfg.ChatRequestHeaders,
 	}
 	clientCfg := llmclient.Config{
 		ProviderName:   cfg.ProviderName,
@@ -55,9 +94,11 @@ func NewCompatibleProviderWithHTTPClient(apiKey string, httpClient *http.Client,
 		httpClient = http.DefaultClient
 	}
 	p := &CompatibleProvider{
-		apiKey:         apiKey,
-		providerName:   cfg.ProviderName,
-		requestMutator: cfg.RequestMutator,
+		apiKey:             apiKey,
+		providerName:       cfg.ProviderName,
+		requestMutator:     cfg.RequestMutator,
+		adaptChatRequest:   cfg.AdaptChatRequest,
+		chatRequestHeaders: cfg.ChatRequestHeaders,
 	}
 	clientCfg := llmclient.DefaultConfig(cfg.ProviderName, cfg.BaseURL)
 	clientCfg.Hooks = hooks
@@ -99,8 +140,12 @@ func (p *CompatibleProvider) ChatCompletion(ctx context.Context, req *core.ChatR
 	if req == nil {
 		return nil, core.NewInvalidRequestError("chat request is required", nil)
 	}
+	adapted, err := p.adaptedChatRequest(req)
+	if err != nil {
+		return nil, err
+	}
 	var resp core.ChatResponse
-	body, err := chatRequestBody(req)
+	body, err := chatRequestBody(adapted)
 	if err != nil {
 		return nil, err
 	}
@@ -108,6 +153,7 @@ func (p *CompatibleProvider) ChatCompletion(ctx context.Context, req *core.ChatR
 		Method:   http.MethodPost,
 		Endpoint: "/chat/completions",
 		Body:     body,
+		Headers:  p.chatHeaders(ctx, adapted),
 	}, &resp)
 	if err != nil {
 		return nil, err
@@ -120,7 +166,11 @@ func (p *CompatibleProvider) StreamChatCompletion(ctx context.Context, req *core
 	if req == nil {
 		return nil, core.NewInvalidRequestError("chat request is required", nil)
 	}
-	streamReq := req.WithStreaming()
+	adapted, err := p.adaptedChatRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	streamReq := adapted.WithStreaming()
 	body, err := chatRequestBody(streamReq)
 	if err != nil {
 		return nil, err
@@ -129,11 +179,26 @@ func (p *CompatibleProvider) StreamChatCompletion(ctx context.Context, req *core
 		Method:   http.MethodPost,
 		Endpoint: "/chat/completions",
 		Body:     body,
+		Headers:  p.chatHeaders(ctx, streamReq),
 	}))
 	if err != nil {
 		return nil, err
 	}
 	return providers.EnsureChatCompletionSSE(stream), nil
+}
+
+func (p *CompatibleProvider) adaptedChatRequest(req *core.ChatRequest) (*core.ChatRequest, error) {
+	if p.adaptChatRequest == nil {
+		return req, nil
+	}
+	return p.adaptChatRequest(req)
+}
+
+func (p *CompatibleProvider) chatHeaders(ctx context.Context, req *core.ChatRequest) http.Header {
+	if p.chatRequestHeaders == nil {
+		return nil
+	}
+	return p.chatRequestHeaders(ctx, req)
 }
 
 func (p *CompatibleProvider) ListModels(ctx context.Context) (*core.ModelsResponse, error) {

--- a/internal/providers/openai/compatible_provider_test.go
+++ b/internal/providers/openai/compatible_provider_test.go
@@ -2,8 +2,10 @@ package openai
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"gomodel/internal/core"
@@ -92,5 +94,142 @@ func TestCompatibleProvider_ListModels_ReturnsUpstreamError(t *testing.T) {
 	}
 	if gatewayErr.Type != core.ErrorTypeProvider && gatewayErr.Type != core.ErrorTypeNotFound {
 		t.Errorf("gatewayErr.Type = %q, want provider_error or not_found_error", gatewayErr.Type)
+	}
+}
+
+func TestCompatibleProvider_AdaptChatRequest_RewritesBodyOnChatAndStream(t *testing.T) {
+	var bodies []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		bodies = append(bodies, string(raw))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp","model":"quirk-1","choices":[]}`))
+	}))
+	defer server.Close()
+
+	provider := NewCompatibleProviderWithHTTPClient(
+		"test-key",
+		server.Client(),
+		llmclient.Hooks{},
+		CompatibleProviderConfig{
+			ProviderName: "quirky",
+			BaseURL:      server.URL,
+			AdaptChatRequest: func(req *core.ChatRequest) (*core.ChatRequest, error) {
+				adapted := *req
+				adapted.User = "adapted-user"
+				return &adapted, nil
+			},
+		},
+	)
+
+	original := &core.ChatRequest{Model: "quirk-1", User: "original-user"}
+	if _, err := provider.ChatCompletion(context.Background(), original); err != nil {
+		t.Fatalf("ChatCompletion() error = %v", err)
+	}
+	stream, err := provider.StreamChatCompletion(context.Background(), original)
+	if err != nil {
+		t.Fatalf("StreamChatCompletion() error = %v", err)
+	}
+	_, _ = io.ReadAll(stream)
+	stream.Close()
+
+	if len(bodies) != 2 {
+		t.Fatalf("upstream requests = %d, want 2", len(bodies))
+	}
+	for i, body := range bodies {
+		if !strings.Contains(body, `"adapted-user"`) {
+			t.Fatalf("request %d body = %s, want adapted user", i, body)
+		}
+	}
+	if original.User != "original-user" {
+		t.Fatalf("original request mutated: User = %q", original.User)
+	}
+}
+
+func TestCompatibleProvider_AdaptChatRequest_ErrorAborts(t *testing.T) {
+	upstreamCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalled = true
+	}))
+	defer server.Close()
+
+	provider := NewCompatibleProviderWithHTTPClient(
+		"test-key",
+		server.Client(),
+		llmclient.Hooks{},
+		CompatibleProviderConfig{
+			ProviderName: "quirky",
+			BaseURL:      server.URL,
+			AdaptChatRequest: func(*core.ChatRequest) (*core.ChatRequest, error) {
+				return nil, core.NewInvalidRequestError("cannot adapt", nil)
+			},
+		},
+	)
+
+	if _, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{Model: "m"}); err == nil {
+		t.Fatal("ChatCompletion() error = nil, want adapter error")
+	}
+	if _, err := provider.StreamChatCompletion(context.Background(), &core.ChatRequest{Model: "m"}); err == nil {
+		t.Fatal("StreamChatCompletion() error = nil, want adapter error")
+	}
+	if upstreamCalled {
+		t.Fatal("upstream called despite adapter error")
+	}
+}
+
+func TestCompatibleProvider_ChatRequestHeaders_AppliedToChatOnly(t *testing.T) {
+	headersByPath := map[string][]string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		headersByPath[r.URL.Path] = append(headersByPath[r.URL.Path], r.Header.Get("X-Conv-Id"))
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/models":
+			_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
+		default:
+			_, _ = w.Write([]byte(`{"id":"resp","model":"m","choices":[]}`))
+		}
+	}))
+	defer server.Close()
+
+	provider := NewCompatibleProviderWithHTTPClient(
+		"test-key",
+		server.Client(),
+		llmclient.Hooks{},
+		CompatibleProviderConfig{
+			ProviderName: "affine",
+			BaseURL:      server.URL,
+			ChatRequestHeaders: func(_ context.Context, req *core.ChatRequest) http.Header {
+				h := make(http.Header, 1)
+				h.Set("X-Conv-Id", "conv-"+req.Model)
+				return h
+			},
+		},
+	)
+
+	if _, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{Model: "m"}); err != nil {
+		t.Fatalf("ChatCompletion() error = %v", err)
+	}
+	stream, err := provider.StreamChatCompletion(context.Background(), &core.ChatRequest{Model: "m"})
+	if err != nil {
+		t.Fatalf("StreamChatCompletion() error = %v", err)
+	}
+	_, _ = io.ReadAll(stream)
+	stream.Close()
+	if _, err := provider.ListModels(context.Background()); err != nil {
+		t.Fatalf("ListModels() error = %v", err)
+	}
+
+	for _, got := range headersByPath["/chat/completions"] {
+		if got != "conv-m" {
+			t.Fatalf("chat X-Conv-Id = %q, want conv-m", got)
+		}
+	}
+	if len(headersByPath["/chat/completions"]) != 2 {
+		t.Fatalf("chat requests = %d, want 2", len(headersByPath["/chat/completions"]))
+	}
+	for _, got := range headersByPath["/models"] {
+		if got != "" {
+			t.Fatalf("models X-Conv-Id = %q, want empty", got)
+		}
 	}
 }

--- a/internal/providers/xai/realtime.go
+++ b/internal/providers/xai/realtime.go
@@ -18,7 +18,7 @@ func (p *Provider) RealtimeTarget(_ context.Context, req *core.RealtimeRequest) 
 		return nil, core.NewInvalidRequestError("model is required for realtime sessions", nil)
 	}
 
-	endpoint, err := providers.OpenAIRealtimeURL(p.client.BaseURL(), req.Model)
+	endpoint, err := providers.OpenAIRealtimeURL(p.compat.GetBaseURL(), req.Model)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/providers/xai/xai.go
+++ b/internal/providers/xai/xai.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/goccy/go-json"
@@ -15,6 +14,7 @@ import (
 	"gomodel/internal/core"
 	"gomodel/internal/llmclient"
 	"gomodel/internal/providers"
+	"gomodel/internal/providers/openai"
 )
 
 // Registration provides factory registration for the xAI provider.
@@ -31,47 +31,52 @@ const (
 	grokConvIDHeader = "X-Grok-Conv-Id"
 )
 
-// Provider implements the core.Provider interface for xAI
+// Provider implements the core.Provider interface for xAI. The API is
+// OpenAI-compatible, so transport goes through the shared compatible
+// provider; xAI's only chat quirk is the conversation affinity header
+// (X-Grok-Conv-Id), injected via the ChatRequestHeaders hook. Methods are
+// delegated explicitly rather than embedded because xAI's upstream lacks
+// parts of the full OpenAI surface (audio, passthrough, response
+// lifecycle management) and embedding cannot subtract methods.
 type Provider struct {
-	client *llmclient.Client
-	apiKey string
+	compat *openai.CompatibleProvider
+	apiKey string // retained to inject auth on the realtime websocket target
 }
 
 // New creates a new xAI provider.
 func New(providerCfg providers.ProviderConfig, opts providers.ProviderOptions) core.Provider {
-	p := &Provider{apiKey: providerCfg.APIKey}
-	clientCfg := llmclient.Config{
-		ProviderName:   "xai",
-		BaseURL:        providers.ResolveBaseURL(providerCfg.BaseURL, defaultBaseURL),
-		Retry:          opts.Resilience.Retry,
-		Hooks:          opts.Hooks,
-		CircuitBreaker: opts.Resilience.CircuitBreaker,
+	return &Provider{
+		compat: openai.NewCompatibleProvider(providerCfg.APIKey, opts, compatibleConfig(providers.ResolveBaseURL(providerCfg.BaseURL, defaultBaseURL))),
+		apiKey: providerCfg.APIKey,
 	}
-	p.client = llmclient.New(clientCfg, p.setHeaders)
-	return p
 }
 
 // NewWithHTTPClient creates a new xAI provider with a custom HTTP client.
 // If httpClient is nil, http.DefaultClient is used.
 func NewWithHTTPClient(apiKey string, httpClient *http.Client, hooks llmclient.Hooks) *Provider {
-	if httpClient == nil {
-		httpClient = http.DefaultClient
+	return &Provider{
+		compat: openai.NewCompatibleProviderWithHTTPClient(apiKey, httpClient, hooks, compatibleConfig(defaultBaseURL)),
+		apiKey: apiKey,
 	}
-	p := &Provider{apiKey: apiKey}
-	cfg := llmclient.DefaultConfig("xai", defaultBaseURL)
-	cfg.Hooks = hooks
-	p.client = llmclient.NewWithHTTPClient(httpClient, cfg, p.setHeaders)
-	return p
+}
+
+func compatibleConfig(baseURL string) openai.CompatibleProviderConfig {
+	return openai.CompatibleProviderConfig{
+		ProviderName:       "xai",
+		BaseURL:            baseURL,
+		SetHeaders:         setHeaders,
+		ChatRequestHeaders: xGrokConversationHeaders,
+	}
 }
 
 // SetBaseURL allows configuring a custom base URL for the provider
 func (p *Provider) SetBaseURL(url string) {
-	p.client.SetBaseURL(url)
+	p.compat.SetBaseURL(url)
 }
 
 // setHeaders sets the required headers for xAI API requests
-func (p *Provider) setHeaders(req *http.Request) {
-	providers.SetAuthHeaders(req, p.apiKey, providers.AuthHeaderConfig{
+func setHeaders(req *http.Request, apiKey string) {
+	providers.SetAuthHeaders(req, apiKey, providers.AuthHeaderConfig{
 		AuthScheme:      "Bearer ",
 		RequestIDHeader: "X-Request-ID",
 	})
@@ -169,63 +174,22 @@ func cleanXGrokConversationID(value string) string {
 
 // ChatCompletion sends a chat completion request to xAI
 func (p *Provider) ChatCompletion(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
-	var resp core.ChatResponse
-	err := p.client.Do(ctx, llmclient.Request{
-		Method:   http.MethodPost,
-		Endpoint: "/chat/completions",
-		Body:     req,
-		Headers:  xGrokConversationHeaders(ctx, req),
-	}, &resp)
-	if err != nil {
-		return nil, err
-	}
-	core.EnsureModel(&resp.Model, req.Model)
-	return &resp, nil
+	return p.compat.ChatCompletion(ctx, req)
 }
 
 // StreamChatCompletion returns a raw response body for streaming (caller must close)
 func (p *Provider) StreamChatCompletion(ctx context.Context, req *core.ChatRequest) (io.ReadCloser, error) {
-	if req == nil {
-		return nil, core.NewInvalidRequestError("chat request is required", nil)
-	}
-	stream, err := p.client.DoStream(ctx, llmclient.Request{
-		Method:   http.MethodPost,
-		Endpoint: "/chat/completions",
-		Body:     req.WithStreaming(),
-		Headers:  xGrokConversationHeaders(ctx, req),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return providers.EnsureChatCompletionSSE(stream), nil
+	return p.compat.StreamChatCompletion(ctx, req)
 }
 
 // ListModels retrieves the list of available models from xAI
 func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error) {
-	var resp core.ModelsResponse
-	err := p.client.Do(ctx, llmclient.Request{
-		Method:   http.MethodGet,
-		Endpoint: "/models",
-	}, &resp)
-	if err != nil {
-		return nil, err
-	}
-	return &resp, nil
+	return p.compat.ListModels(ctx)
 }
 
-// Responses sends a Responses API request to xAI
+// Responses sends a Responses API request to xAI's native /responses endpoint.
 func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
-	var resp core.ResponsesResponse
-	err := p.client.Do(ctx, llmclient.Request{
-		Method:   http.MethodPost,
-		Endpoint: "/responses",
-		Body:     req,
-	}, &resp)
-	if err != nil {
-		return nil, err
-	}
-	core.EnsureModel(&resp.Model, req.Model)
-	return &resp, nil
+	return p.compat.Responses(ctx, req)
 }
 
 // StreamResponses returns a normalized streaming Responses API body.
@@ -234,135 +198,60 @@ func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*
 // synthesize a terminal `data: [DONE]` marker on completed streams. Callers
 // remain responsible for closing the returned stream.
 func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
-	stream, err := p.client.DoStream(ctx, llmclient.Request{
-		Method:   http.MethodPost,
-		Endpoint: "/responses",
-		Body:     req.WithStreaming(),
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return providers.EnsureResponsesDone(stream), nil
+	return p.compat.StreamResponses(ctx, req)
 }
 
 // Embeddings sends an embeddings request to xAI
 func (p *Provider) Embeddings(ctx context.Context, req *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
-	var resp core.EmbeddingResponse
-	err := p.client.Do(ctx, llmclient.Request{
-		Method:   http.MethodPost,
-		Endpoint: "/embeddings",
-		Body:     req,
-	}, &resp)
-	if err != nil {
-		return nil, err
-	}
-	core.EnsureModel(&resp.Model, req.Model)
-	return &resp, nil
+	return p.compat.Embeddings(ctx, req)
 }
 
 // CreateBatch creates a native xAI batch job.
 func (p *Provider) CreateBatch(ctx context.Context, req *core.BatchRequest) (*core.BatchResponse, error) {
-	var resp core.BatchResponse
-	err := p.client.Do(ctx, llmclient.Request{
-		Method:   http.MethodPost,
-		Endpoint: "/batches",
-		Body:     req,
-	}, &resp)
-	if err != nil {
-		return nil, err
-	}
-	providers.EnsureProviderBatchID(&resp)
-	return &resp, nil
+	return p.compat.CreateBatch(ctx, req)
 }
 
 // GetBatch retrieves a native xAI batch job.
 func (p *Provider) GetBatch(ctx context.Context, id string) (*core.BatchResponse, error) {
-	var resp core.BatchResponse
-	err := p.client.Do(ctx, llmclient.Request{
-		Method:   http.MethodGet,
-		Endpoint: "/batches/" + url.PathEscape(id),
-	}, &resp)
-	if err != nil {
-		return nil, err
-	}
-	providers.EnsureProviderBatchID(&resp)
-	return &resp, nil
+	return p.compat.GetBatch(ctx, id)
 }
 
 // ListBatches lists native xAI batch jobs.
 func (p *Provider) ListBatches(ctx context.Context, limit int, after string) (*core.BatchListResponse, error) {
-	endpoint := providers.PaginatedEndpoint("/batches", limit, "after", after)
-
-	var resp core.BatchListResponse
-	err := p.client.Do(ctx, llmclient.Request{
-		Method:   http.MethodGet,
-		Endpoint: endpoint,
-	}, &resp)
-	if err != nil {
-		return nil, err
-	}
-	providers.EnsureProviderBatchIDs(&resp)
-	return &resp, nil
+	return p.compat.ListBatches(ctx, limit, after)
 }
 
 // CancelBatch cancels a native xAI batch job.
 func (p *Provider) CancelBatch(ctx context.Context, id string) (*core.BatchResponse, error) {
-	var resp core.BatchResponse
-	err := p.client.Do(ctx, llmclient.Request{
-		Method:   http.MethodPost,
-		Endpoint: "/batches/" + url.PathEscape(id) + "/cancel",
-	}, &resp)
-	if err != nil {
-		return nil, err
-	}
-	providers.EnsureProviderBatchID(&resp)
-	return &resp, nil
+	return p.compat.CancelBatch(ctx, id)
 }
 
 // GetBatchResults fetches xAI batch results via the output file API.
 func (p *Provider) GetBatchResults(ctx context.Context, id string) (*core.BatchResultsResponse, error) {
-	return providers.FetchBatchResultsFromOutputFile(ctx, p.client, "xai", id)
+	return p.compat.GetBatchResults(ctx, id)
 }
 
 // CreateFile uploads a file through xAI's OpenAI-compatible /files API.
 func (p *Provider) CreateFile(ctx context.Context, req *core.FileCreateRequest) (*core.FileObject, error) {
-	resp, err := providers.CreateOpenAICompatibleFile(ctx, p.client, req)
-	if err != nil {
-		return nil, err
-	}
-	resp.Provider = "xai"
-	return resp, nil
+	return p.compat.CreateFile(ctx, req)
 }
 
 // ListFiles lists files through xAI's OpenAI-compatible /files API.
 func (p *Provider) ListFiles(ctx context.Context, purpose string, limit int, after string) (*core.FileListResponse, error) {
-	resp, err := providers.ListOpenAICompatibleFiles(ctx, p.client, purpose, limit, after)
-	if err != nil {
-		return nil, err
-	}
-	for i := range resp.Data {
-		resp.Data[i].Provider = "xai"
-	}
-	return resp, nil
+	return p.compat.ListFiles(ctx, purpose, limit, after)
 }
 
 // GetFile retrieves one file object through xAI's OpenAI-compatible /files API.
 func (p *Provider) GetFile(ctx context.Context, id string) (*core.FileObject, error) {
-	resp, err := providers.GetOpenAICompatibleFile(ctx, p.client, id)
-	if err != nil {
-		return nil, err
-	}
-	resp.Provider = "xai"
-	return resp, nil
+	return p.compat.GetFile(ctx, id)
 }
 
 // DeleteFile deletes a file object through xAI's OpenAI-compatible /files API.
 func (p *Provider) DeleteFile(ctx context.Context, id string) (*core.FileDeleteResponse, error) {
-	return providers.DeleteOpenAICompatibleFile(ctx, p.client, id)
+	return p.compat.DeleteFile(ctx, id)
 }
 
 // GetFileContent fetches raw file bytes through xAI's /files/{id}/content API.
 func (p *Provider) GetFileContent(ctx context.Context, id string) (*core.FileContentResponse, error) {
-	return providers.GetOpenAICompatibleFileContent(ctx, p.client, id)
+	return p.compat.GetFileContent(ctx, id)
 }

--- a/internal/providers/xai/xai_test.go
+++ b/internal/providers/xai/xai_test.go
@@ -22,8 +22,8 @@ func TestNew(t *testing.T) {
 	if provider.apiKey != apiKey {
 		t.Errorf("apiKey = %q, want %q", provider.apiKey, apiKey)
 	}
-	if provider.client == nil {
-		t.Error("client should not be nil")
+	if provider.compat == nil {
+		t.Error("compat should not be nil")
 	}
 }
 
@@ -90,8 +90,8 @@ func TestNewWithHTTPClient(t *testing.T) {
 		t.Fatal("provider should not be nil")
 		return
 	}
-	if provider.client == nil {
-		t.Fatal("provider.client should not be nil")
+	if provider.compat == nil {
+		t.Fatal("provider.compat should not be nil")
 	}
 	if provider.apiKey != "test-api-key" {
 		t.Errorf("apiKey = %q, want %q", provider.apiKey, "test-api-key")


### PR DESCRIPTION
## What

Kills the "full re-implementation" provider style (architecture review §4, roadmap item 5 phase 1). deepseek, xai, and ollama were the last three providers hand-rolling `llmclient` transport for OpenAI-shaped endpoints — ~350 lines re-doing what `openai.CompatibleProvider` already owns, with real drift (see Behavior notes).

## How

- **Two opt-in hooks on `CompatibleProviderConfig`** so provider quirks stop forcing method overrides:
  - `AdaptChatRequest func(*core.ChatRequest) (*core.ChatRequest, error)` — typed request rewrite applied on chat + stream before dispatch. Because it runs inside the engine, Responses-via-chat translation picks it up automatically (removes the "override ChatCompletion ⇒ must also override Responses" trap).
  - `ChatRequestHeaders func(ctx, *core.ChatRequest) http.Header` — context-derived per-request headers on chat calls only.
- **deepseek** → embeds `*openai.ChatCompatible` (its surface matches exactly: chat, models, responses-via-chat, embeddings-unsupported, passthrough). The reasoning-effort remap becomes the `AdaptChatRequest` hook. 199 → 101 lines.
- **xai** → composes `*openai.CompatibleProvider` with explicit delegation, because xAI's upstream lacks audio, passthrough, and response lifecycle management — embedding cannot subtract methods, and the router discovers capabilities by interface assertion. The Grok conversation-affinity header (`X-Grok-Conv-Id`) becomes the `ChatRequestHeaders` hook; generated conversation IDs are hash-identical to before (the anchor never included the stream flag). 368 → 269 lines, all remaining lines are genuine novelty.
- **ollama** → composes `*openai.CompatibleProvider` for the `/v1` side; the native `/api/embed` client, batch stubs, dual-URL `SetBaseURL`, and `CheckAvailability` stay. Still no passthrough.
- `CompatibleProvider` now documents the **three sanctioned wrapper shapes** (embed `ChatCompatible` for chat-centric / embed `CompatibleProvider` for full-surface / compose + delegate for partial-surface) so the next provider doesn't invent a fourth style.

## User-visible impact

None intended. Wire behavior is preserved except two conservative normalizations the other ten OpenAI-compatible providers already had:

- **xai** model listings now default empty `object` fields to `list`/`model` (fill-if-empty only).
- **ollama** chat streams are wrapped by `EnsureChatCompletionSSE` — pass-through for genuine SSE, converts buffered-JSON replies from upstreams that ignore `stream:true` into one SSE chunk + `[DONE]` (protects the misconfigured-OpenAI-server-as-ollama case).
- Edge note: deepseek/xai/ollama chat now goes through the shared engine's OpenAI reasoning-model name matcher (`o<digit>*`/`gpt-5*` → `max_completion_tokens`, drop `temperature`), same as groq/vllm/bailian/azure/openrouter today. Real DeepSeek/Grok/Ollama model IDs never match; only a local model deliberately named like an OpenAI reasoning model would see it.

## Provider capability surfaces (unchanged)

Verified method-set parity: deepseek gains only the `GetBaseURL` getter (not a capability interface); xai and ollama gain nothing (delegation, not embedding).

## Tests

- 3 new engine tests: adapter applied on chat+stream and non-mutating, adapter error aborts before dispatch, per-request headers on chat only.
- Existing deepseek/xai/ollama suites (414/917/954 lines, httptest-driven) pass unchanged except two field renames (`provider.client` → `provider.compat`).
- Full suite, `-race` on `internal/providers/...`, lint 0 issues, pre-commit green.

Remaining phases (separate PRs): compress the groq/oracle/bailian/vllm delegation blocks (facet surfaces or hook migration for bailian's max_tokens adapter), then remove the 16 test-only `NewWithHTTPClient` constructors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for several AI providers, making chat, streaming, model listing, and response requests work more consistently.
  * Fixed provider behavior so unsupported features are handled more clearly.

* **Refactor**
  * Updated provider handling to use a shared compatibility layer, which should make integrations more reliable and easier to maintain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->