### PR TITLE
perf(memory): stop pinning request-sized buffers for the stream lifetime

### DIFF
--- a/internal/core/json_fields.go
+++ b/internal/core/json_fields.go
@@ -272,7 +272,12 @@ func extractUnknownJSONFields(data []byte, knownFields ...string) (UnknownJSONFi
 		return UnknownJSONFields{}, fmt.Errorf("expected JSON object")
 	}
 
-	buf := bytes.NewBuffer(make([]byte, 0, len(data)))
+	// Pre-size for typical unknown-field payloads without reserving
+	// request-sized capacity: the result is retained on the decoded request
+	// for its whole lifetime, so a body-sized backing array would pin a full
+	// body copy per decoded object even when the extras are a few bytes.
+	var buf bytes.Buffer
+	buf.Grow(min(len(data), 256))
 	buf.WriteByte('{')
 	wrote := false
 	root.ForEach(func(key, value gjson.Result) bool {
@@ -293,7 +298,13 @@ func extractUnknownJSONFields(data []byte, knownFields ...string) (UnknownJSONFi
 	}
 
 	buf.WriteByte('}')
-	return UnknownJSONFields{raw: buf.Bytes()}, nil
+	raw := buf.Bytes()
+	// Re-copy only when the buffer over-grew, so the retained extras never
+	// pin significantly more capacity than their own length.
+	if cap(raw)-len(raw) > 1024 {
+		raw = bytes.Clone(raw)
+	}
+	return UnknownJSONFields{raw: raw}, nil
 }
 
 func marshalWithUnknownJSONFields(base any, extraFields UnknownJSONFields) ([]byte, error) {

--- a/internal/core/json_fields_test.go
+++ b/internal/core/json_fields_test.go
@@ -3,7 +3,9 @@ package core
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"math"
+	"strings"
 	"testing"
 )
 
@@ -253,5 +255,25 @@ func TestDecoderLeniencyIsBounded(t *testing.T) {
 func TestMergedJSONObjectCap_Overflow(t *testing.T) {
 	if _, err := mergedJSONObjectCap(math.MaxInt, 2); err == nil {
 		t.Fatal("mergedJSONObjectCap() error = nil, want overflow error")
+	}
+}
+
+func TestExtractUnknownJSONFields_DoesNotRetainBodySizedCapacity(t *testing.T) {
+	// A large request with tiny unknown extras: the retained raw bytes are
+	// kept for the decoded request's whole lifetime, so they must not pin a
+	// body-sized backing array (regression: the buffer was pre-sized to
+	// len(data)).
+	body := fmt.Sprintf(`{"model":"gpt-test","messages":[{"role":"user","content":%q}],"custom_flag":true}`,
+		strings.Repeat("x", 1<<20))
+
+	fields, err := extractUnknownJSONFields([]byte(body), "model", "messages")
+	if err != nil {
+		t.Fatalf("extractUnknownJSONFields() error = %v", err)
+	}
+	if got := string(fields.raw); got != `{"custom_flag":true}` {
+		t.Fatalf("raw = %q, want custom_flag only", got)
+	}
+	if c := cap(fields.raw); c > 4096 {
+		t.Fatalf("retained capacity = %d bytes for %d bytes of extras, want small", c, len(fields.raw))
 	}
 }

--- a/internal/core/semantic.go
+++ b/internal/core/semantic.go
@@ -339,11 +339,15 @@ func deriveSnapshotSelectorHintsGJSON(body []byte) (model, provider string, stre
 		return "", "", false, false
 	}
 
+	// Clone the extracted strings: gjson results alias the full parsed body,
+	// and these values land in RouteHints, which lives on the request context
+	// for the whole (possibly streaming) request — without the clone, two
+	// short selector strings pin a request-sized backing string.
 	if modelResult.Type == gjson.String {
-		model = modelResult.String()
+		model = strings.Clone(modelResult.String())
 	}
 	if providerResult.Type == gjson.String {
-		provider = providerResult.String()
+		provider = strings.Clone(providerResult.String())
 	}
 	if streamResult.Type == gjson.True || streamResult.Type == gjson.False {
 		stream = streamResult.Bool()

--- a/internal/llmclient/client.go
+++ b/internal/llmclient/client.go
@@ -490,6 +490,15 @@ func (c *Client) DoStream(ctx context.Context, req Request) (io.ReadCloser, erro
 		return nil, providerErr
 	}
 
+	// The stream can outlive the request by minutes while transport internals
+	// keep resp.Request reachable. GetBody closes over the fully marshaled
+	// request payload; redirects and transparent transport retries only
+	// consult it inside Do, so dropping it here releases the payload for the
+	// stream's lifetime without changing behavior.
+	if resp.Request != nil {
+		resp.Request.GetBody = nil
+	}
+
 	c.completeScope(scope, resp.StatusCode, nil, nil)
 	return resp.Body, nil
 }

--- a/internal/providers/anthropic/chat_stream.go
+++ b/internal/providers/anthropic/chat_stream.go
@@ -52,10 +52,12 @@ type streamConverter struct {
 	emittedToolCalls  bool
 }
 
+// streamToolCallState tracks per-tool-call bookkeeping for the chat dialect.
+// Unlike the Responses converter, the chat path relays argument deltas
+// verbatim and never needs the accumulated argument text, so none is kept.
 type streamToolCallState struct {
 	ID                string
 	Name              string
-	Arguments         strings.Builder
 	Index             int
 	Started           bool
 	PlaceholderObject bool
@@ -204,9 +206,6 @@ func (sc *streamConverter) convertEvent(event *anthropicStreamEvent) string {
 				sc.toolCalls[event.Index] = state
 				return ""
 			}
-			if initialArguments != "" {
-				_, _ = state.Arguments.WriteString(initialArguments)
-			}
 			state.Started = true
 			sc.toolCalls[event.Index] = state
 			sc.emittedToolCalls = true
@@ -257,11 +256,7 @@ func (sc *streamConverter) convertEvent(event *anthropicStreamEvent) string {
 			if state == nil {
 				return ""
 			}
-			if state.PlaceholderObject {
-				state.Arguments = strings.Builder{}
-				state.PlaceholderObject = false
-			}
-			_, _ = state.Arguments.WriteString(event.Delta.PartialJSON)
+			state.PlaceholderObject = false
 			if !state.Started {
 				state.Started = true
 				sc.emittedToolCalls = true

--- a/tests/perf/hotpath_test.go
+++ b/tests/perf/hotpath_test.go
@@ -389,7 +389,7 @@ func TestHotPathPerfGuard(t *testing.T) {
 		{
 			name:      "gateway_chat_completion_hot_path",
 			bench:     BenchmarkGatewayHotPathChatCompletion,
-			maxAllocs: 110,   // baseline 108
+			maxAllocs: 112,   // baseline 110 (incl. +1 strings.Clone that unpins the body from RouteHints)
 			maxBytes:  14080, // baseline ~13.5 KB (incl. per-attempt response body/header capture fields)
 		},
 		{
@@ -400,7 +400,7 @@ func TestHotPathPerfGuard(t *testing.T) {
 			// full catalog several times per request) would blow these limits.
 			name:      "gateway_chat_completion_hot_path_routed",
 			bench:     BenchmarkGatewayHotPathChatCompletionRouted,
-			maxAllocs: 128,   // baseline 126
+			maxAllocs: 130,   // baseline 128 (incl. +1 strings.Clone that unpins the body from RouteHints)
 			maxBytes:  14656, // baseline ~14.0 KB
 		},
 		{


### PR DESCRIPTION
## Problem

Follow-up to #488. Large streamed requests (coding-agent workloads) keep roughly 4-6x their body size live until stream close, which sets the RSS high-water mark that Go's GC then holds. This PR removes the per-stream pins that were cheap to fix without architectural change — four verified pin points from the memory investigation.

## Changes

- **RouteHints** (`internal/core/semantic.go`): gjson result strings alias the full parsed body, and the two short selector strings stored on the request context pinned a request-sized backing string for the whole (possibly streaming) request. `strings.Clone` unpins it.
- **ExtraFields** (`internal/core/json_fields.go`): the unknown-fields buffer was pre-sized to `len(body)`, so one small unknown field retained a body-sized array per decoded object — request, message, tool call (13 call sites share the helper). The buffer now starts at 256B and re-copies only when it over-grew (>1KB slack), bounding retained capacity near the extras' own length. New regression test asserts a 1MB body with tiny extras retains <4KB.
- **`llmclient.DoStream`** (`internal/llmclient/client.go`): `GetBody` closes over the fully marshaled request payload and stays reachable through `resp.Request` while the stream is open. It is dropped once the response arrives.
- **Anthropic chat stream** (`internal/providers/anthropic/chat_stream.go`): the converter accumulated every tool-call argument delta into a `strings.Builder` nothing on the chat path reads (the Responses converter uses its own `ResponsesOutputToolCallState`, which legitimately accumulates). For tool calls carrying file contents this doubled tool-payload memory per stream. Deleted.

## Design notes for review

- **Why `GetBody` is cleared after `Do`, not before:** nil-ing it pre-send would disable net/http's transparent retry of requests that fail on a stale pooled connection — a reliability regression for streaming, since `DoStream` never retries at our layer. Redirects and transport retries only consult `GetBody` inside `Do`, so post-response clearing is a pure reference release with no behavior change. `resp.Request.Body` is deliberately left untouched (the h1 write loop can still reference it on early-response paths — clearing it would race). Known limitation: on HTTP/2 the transport's stream state can still hold the drained request reader until stream end; that part is Go internals.
- **Perf-guard baselines** (`tests/perf/hotpath_test.go`): the `strings.Clone` adds +1 small alloc per request on the chat hot paths. Main already measured at cap−1 from drift, so the two alloc ceilings move up by 2 with a comment documenting the intentional trade. Byte ceilings unchanged.

## Measured impact

- `BenchmarkExtractUnknownJSONFieldsObject_Chat`: 1792 → 1152 B/op, allocs unchanged (2), time flat.
- `BenchmarkExtractUnknownJSONFieldsObject_Responses`: 896 → 704 B/op, allocs unchanged.
- Hot-path guard: +1 alloc, ~+50 B/op on the chat paths (the Clone); all thresholds pass.
- Retention per active stream drops by roughly one full marshaled request copy (GetBody), one full-body string (RouteHints), body-sized arrays per decoded object with unknown fields (ExtraFields), and the accumulated tool-call payload (Anthropic chat).

## Verification

Full suite passes (61 packages); pre-commit race tests, lint, and the hot-path perf guard all pass. Anthropic stream converter behavior is covered by the existing chat-stream tests (argument deltas are relayed verbatim; the deferred-placeholder logic at `chat_stream.go:292` is preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced memory usage when handling requests with extra JSON fields, helping prevent large request bodies from being kept in memory longer than needed.
  * Improved streaming request handling so request payload data is released earlier during long-lived streams.
  * Fixed tool-call streaming behavior to avoid unnecessary accumulation of intermediate argument text.

* **Performance**
  * Lowered memory retention in routing and selector handling, which can improve stability under heavier traffic.

* **Tests**
  * Added regression coverage for memory retention behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->