### PR TITLE
fix(lifecycle): close leaked goroutines, sessions, and unbounded error reads

### DIFF
--- a/internal/auditlog/middleware.go
+++ b/internal/auditlog/middleware.go
@@ -91,6 +91,17 @@ func Middleware(logger LoggerInterface) echo.MiddlewareFunc {
 			if publisher, ok := logger.(LiveEventEmitter); ok {
 				c.Set(string(LogEntryLivePublisherKey), publisher)
 				publisher.PublishLiveEvent(LiveEventAuditStarted, entry)
+				// A handler panic unwinds past this middleware to the outer
+				// recover, skipping every terminal live event below and
+				// permanently orphaning the entry in live-dashboard
+				// active-snapshot state. Publish the removal, then let the
+				// panic continue to the recover middleware.
+				defer func() {
+					if r := recover(); r != nil {
+						publisher.PublishLiveEvent(LiveEventAuditRemoved, entry)
+						panic(r)
+					}
+				}()
 			}
 
 			// Create response body capture if logging bodies

--- a/internal/auditlog/middleware_test.go
+++ b/internal/auditlog/middleware_test.go
@@ -344,3 +344,38 @@ func (l *captureLiveLogger) PublishLiveEvent(eventType string, entry *LogEntry) 
 		requestBody:    requestBody,
 	})
 }
+
+func TestMiddlewarePublishesRemovalWhenHandlerPanics(t *testing.T) {
+	logger := &captureLiveLogger{cfg: Config{Enabled: true}}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("X-Request-ID", "req-panic")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	handler := Middleware(logger)(func(c *echo.Context) error {
+		panic("handler exploded")
+	})
+
+	// The panic must keep propagating to the outer recover middleware; the
+	// audit middleware only publishes the terminal live event on the way out.
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatal("panic was swallowed by the audit middleware")
+			}
+		}()
+		_ = handler(c)
+	}()
+
+	if len(logger.events) != 2 {
+		t.Fatalf("live events = %d, want started + removed", len(logger.events))
+	}
+	if logger.events[0].eventType != LiveEventAuditStarted {
+		t.Fatalf("first event = %q, want %q", logger.events[0].eventType, LiveEventAuditStarted)
+	}
+	if logger.events[1].eventType != LiveEventAuditRemoved {
+		t.Fatalf("second event = %q, want %q (terminal event that evicts the live snapshot)", logger.events[1].eventType, LiveEventAuditRemoved)
+	}
+}

--- a/internal/llmclient/client.go
+++ b/internal/llmclient/client.go
@@ -164,6 +164,11 @@ type Response struct {
 	Body   []byte
 }
 
+// maxErrorBodyBytes caps how much of an upstream error body is read into
+// memory. It matches core's audit capture cap; a misbehaving upstream that
+// answers an error status with an endless body must not be buffered whole.
+const maxErrorBodyBytes = 64 * 1024
+
 // attachResponseHeaders records the upstream response headers on a provider
 // GatewayError so failed attempts can be audited. It is a no-op for other
 // error types or a nil header set.
@@ -380,6 +385,7 @@ func (c *Client) Do(ctx context.Context, req Request, result any) error {
 func (c *Client) DoRaw(ctx context.Context, req Request) (*Response, error) {
 	scope, err := c.beginRequest(ctx, req, false)
 	if err != nil {
+		closeRawBodyReader(req)
 		return nil, err
 	}
 	ctx = scope.ctx
@@ -394,6 +400,7 @@ func (c *Client) DoRaw(ctx context.Context, req Request) (*Response, error) {
 
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		if err := c.waitForRetryAttempt(ctx, scope, attempt); err != nil {
+			closeRawBodyReader(req)
 			return nil, err
 		}
 
@@ -462,6 +469,7 @@ func (c *Client) DoRaw(ctx context.Context, req Request) (*Response, error) {
 func (c *Client) DoStream(ctx context.Context, req Request) (io.ReadCloser, error) {
 	scope, err := c.beginRequest(ctx, req, true)
 	if err != nil {
+		closeRawBodyReader(req)
 		return nil, err
 	}
 
@@ -479,7 +487,7 @@ func (c *Client) DoStream(ctx context.Context, req Request) (io.ReadCloser, erro
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, readErr := io.ReadAll(resp.Body)
+		respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
 		if readErr != nil {
 			respBody = []byte("failed to read error response")
 		}
@@ -538,6 +546,7 @@ func (c *Client) DoPassthrough(ctx context.Context, req Request) (*http.Response
 	stream := strings.Contains(strings.ToLower(strings.Join(req.Headers.Values("Accept"), ",")), "text/event-stream")
 	scope, err := c.beginRequest(ctx, req, stream)
 	if err != nil {
+		closeRawBodyReader(req)
 		return nil, err
 	}
 	ctx = scope.ctx
@@ -549,6 +558,7 @@ func (c *Client) DoPassthrough(ctx context.Context, req Request) (*http.Response
 
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		if err := c.waitForRetryAttempt(ctx, scope, attempt); err != nil {
+			closeRawBodyReader(req)
 			return nil, err
 		}
 
@@ -629,6 +639,9 @@ func extractStatusCode(err error) int {
 func (c *Client) doHTTPRequest(ctx context.Context, req Request) (*http.Response, error) {
 	httpReq, err := c.buildRequest(ctx, req)
 	if err != nil {
+		// The transport owns closing the body once the request reaches it;
+		// a request that never gets there must release the reader here.
+		closeRawBodyReader(req)
 		return nil, err
 	}
 
@@ -637,6 +650,17 @@ func (c *Client) doHTTPRequest(ctx context.Context, req Request) (*http.Response
 		return nil, core.NewProviderError(c.config.ProviderName, providerErrorStatusCode(err), "failed to send request: "+err.Error(), err)
 	}
 	return resp, nil
+}
+
+// closeRawBodyReader releases a caller-supplied streaming body when the
+// request fails before reaching the HTTP transport, which otherwise closes it
+// on every path. Pipe-backed uploads (files, audio transcription) rely on
+// this to unblock their producer goroutines instead of leaking them — and the
+// upload buffers they pin — for the process lifetime.
+func closeRawBodyReader(req Request) {
+	if closer, ok := req.RawBodyReader.(io.Closer); ok {
+		_ = closer.Close()
+	}
 }
 
 // doRequest executes a single HTTP request without retries.
@@ -651,7 +675,14 @@ func (c *Client) doRequest(ctx context.Context, req Request) (*Response, error) 
 		_ = resp.Body.Close()
 	}()
 
-	body, err := io.ReadAll(resp.Body)
+	// Successful responses are read whole (large results are legitimate);
+	// error bodies are bounded — they only feed error parsing and audit
+	// capture, both of which cap at the same size.
+	reader := io.Reader(resp.Body)
+	if resp.StatusCode >= http.StatusBadRequest {
+		reader = io.LimitReader(resp.Body, maxErrorBodyBytes)
+	}
+	body, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, core.NewProviderError(c.config.ProviderName, providerErrorStatusCode(err), "failed to read response: "+err.Error(), err)
 	}

--- a/internal/llmclient/client_test.go
+++ b/internal/llmclient/client_test.go
@@ -1823,3 +1823,72 @@ func TestBackoffCalculation_WithJitter(t *testing.T) {
 		}
 	}
 }
+
+type recordingReadCloser struct {
+	io.Reader
+	closed atomic.Bool
+}
+
+func (r *recordingReadCloser) Close() error {
+	r.closed.Store(true)
+	return nil
+}
+
+func TestPreTransportErrorsCloseRawBodyReader(t *testing.T) {
+	t.Run("request build error", func(t *testing.T) {
+		client := New(DefaultConfig("test", "http://127.0.0.1:0"), nil)
+		reader := &recordingReadCloser{Reader: strings.NewReader("upload payload")}
+
+		_, err := client.DoRaw(context.Background(), Request{
+			Method:        "bogus method",
+			Endpoint:      "/files",
+			RawBodyReader: reader,
+		})
+		if err == nil {
+			t.Fatal("DoRaw() error = nil, want build error")
+		}
+		if !reader.closed.Load() {
+			t.Fatal("RawBodyReader not closed on request build error")
+		}
+	})
+
+	t.Run("circuit breaker open", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer server.Close()
+
+		config := DefaultConfig("test", server.URL)
+		config.Retry.MaxRetries = 0
+		config.CircuitBreaker = goconfig.CircuitBreakerConfig{
+			FailureThreshold: 1,
+			SuccessThreshold: 1,
+			Timeout:          time.Minute,
+		}
+		client := New(config, nil)
+
+		// Trip the breaker with one failing request.
+		if _, err := client.DoRaw(context.Background(), Request{Method: http.MethodGet, Endpoint: "/test"}); err == nil {
+			t.Fatal("expected failure to trip the breaker")
+		}
+
+		// A pipe-backed upload rejected by the open breaker never reaches the
+		// transport; the client must close the reader so the producer
+		// goroutine (and the buffers it pins) can exit.
+		reader := &recordingReadCloser{Reader: strings.NewReader("upload payload")}
+		_, err := client.DoRaw(context.Background(), Request{
+			Method:        http.MethodPost,
+			Endpoint:      "/files",
+			RawBodyReader: reader,
+		})
+		if err == nil {
+			t.Fatal("DoRaw() error = nil, want circuit breaker open")
+		}
+		if !strings.Contains(err.Error(), "circuit breaker is open") {
+			t.Fatalf("DoRaw() error = %v, want circuit breaker open", err)
+		}
+		if !reader.closed.Load() {
+			t.Fatal("RawBodyReader not closed when the circuit breaker rejected the request")
+		}
+	})
+}

--- a/internal/realtime/export_test.go
+++ b/internal/realtime/export_test.go
@@ -1,0 +1,13 @@
+package realtime
+
+import "time"
+
+// SetHeartbeatCadenceForTest overrides the heartbeat cadence and returns a
+// function restoring the previous values. Test-only.
+func SetHeartbeatCadenceForTest(interval, timeout time.Duration) (restore func()) {
+	prevInterval, prevTimeout := heartbeatInterval, heartbeatTimeout
+	heartbeatInterval, heartbeatTimeout = interval, timeout
+	return func() {
+		heartbeatInterval, heartbeatTimeout = prevInterval, prevTimeout
+	}
+}

--- a/internal/realtime/proxy.go
+++ b/internal/realtime/proxy.go
@@ -7,7 +7,10 @@ package realtime
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net"
 	"net/http"
+	"time"
 
 	"github.com/coder/websocket"
 )
@@ -68,22 +71,72 @@ func Proxy(w http.ResponseWriter, r *http.Request, target Target, onServerFrame 
 	return relay(r.Context(), client, upstream, onServerFrame)
 }
 
-// relay runs the two copy loops, tears both down when either ends, and returns
-// the terminal cause (nil for a normal close).
+// Heartbeat cadence. A silently dead peer (NAT timeout, power loss — no RST,
+// no close frame) leaves both copy loops blocked in Read forever; the
+// heartbeat is the only signal that tears such sessions down. Variables so
+// tests can shrink them.
+var (
+	heartbeatInterval = 30 * time.Second
+	heartbeatTimeout  = 10 * time.Second
+)
+
+// relay runs the two copy loops plus the heartbeat, tears everything down
+// when any of them ends, and returns the terminal cause (nil for a normal
+// close).
 func relay(ctx context.Context, client, upstream *websocket.Conn, onServerFrame func([]byte)) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	done := make(chan error, 2)
+	done := make(chan error, 3)
 	go func() { done <- copyFrames(ctx, upstream, client, nil) }()           // client -> upstream
 	go func() { done <- copyFrames(ctx, client, upstream, onServerFrame) }() // upstream -> client
+	go func() { done <- heartbeat(ctx, client, upstream) }()
 
 	first := <-done
 	cancel()
 	closeBoth(client, upstream, first)
 	<-done
+	<-done
 
 	return normalizeCloseError(first)
+}
+
+// heartbeat pings both peers on an interval so dead connections surface as
+// ping timeouts instead of leaking the session. Pong responses are processed
+// by the concurrent copyFrames reads, which are always in flight.
+func heartbeat(ctx context.Context, client, upstream *websocket.Conn) error {
+	ticker := time.NewTicker(heartbeatInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if err := pingBoth(ctx, client, upstream); err != nil {
+				// A locally closed connection means teardown is already under
+				// way and a copy loop holds the definitive close cause; wait
+				// for it instead of racing to report a secondary error.
+				if errors.Is(err, net.ErrClosed) {
+					<-ctx.Done()
+					return ctx.Err()
+				}
+				return err
+			}
+		}
+	}
+}
+
+func pingBoth(ctx context.Context, client, upstream *websocket.Conn) error {
+	pingCtx, cancel := context.WithTimeout(ctx, heartbeatTimeout)
+	defer cancel()
+	if err := client.Ping(pingCtx); err != nil {
+		return fmt.Errorf("client heartbeat: %w", err)
+	}
+	if err := upstream.Ping(pingCtx); err != nil {
+		return fmt.Errorf("upstream heartbeat: %w", err)
+	}
+	return nil
 }
 
 // copyFrames relays every message from src to dst, invoking tap on each payload

--- a/internal/realtime/proxy.go
+++ b/internal/realtime/proxy.go
@@ -128,15 +128,21 @@ func heartbeat(ctx context.Context, client, upstream *websocket.Conn) error {
 }
 
 func pingBoth(ctx context.Context, client, upstream *websocket.Conn) error {
-	pingCtx, cancel := context.WithTimeout(ctx, heartbeatTimeout)
-	defer cancel()
-	if err := client.Ping(pingCtx); err != nil {
+	// Each peer gets its own full timeout budget: a slow-but-alive first ping
+	// must not leave the second one a nearly expired deadline.
+	if err := ping(ctx, client); err != nil {
 		return fmt.Errorf("client heartbeat: %w", err)
 	}
-	if err := upstream.Ping(pingCtx); err != nil {
+	if err := ping(ctx, upstream); err != nil {
 		return fmt.Errorf("upstream heartbeat: %w", err)
 	}
 	return nil
+}
+
+func ping(ctx context.Context, conn *websocket.Conn) error {
+	pingCtx, cancel := context.WithTimeout(ctx, heartbeatTimeout)
+	defer cancel()
+	return conn.Ping(pingCtx)
 }
 
 // copyFrames relays every message from src to dst, invoking tap on each payload

--- a/internal/realtime/proxy_test.go
+++ b/internal/realtime/proxy_test.go
@@ -207,7 +207,10 @@ func TestProxyHeartbeatTearsDownUnresponsivePeer(t *testing.T) {
 }
 
 func TestProxyHeartbeatLeavesResponsiveSessionAlive(t *testing.T) {
-	restore := realtime.SetHeartbeatCadenceForTest(20*time.Millisecond, 150*time.Millisecond)
+	// Short interval so several pings land inside the loop below, but a
+	// generous pong timeout: a scheduler stall on a loaded CI runner must not
+	// fail a healthy session.
+	restore := realtime.SetHeartbeatCadenceForTest(25*time.Millisecond, 2*time.Second)
 	defer restore()
 
 	upstream := echoServer(t)
@@ -222,7 +225,7 @@ func TestProxyHeartbeatLeavesResponsiveSessionAlive(t *testing.T) {
 
 	// Exchange frames across several heartbeat intervals: an active session
 	// (reads in flight on both sides answer the pings) must not be killed.
-	deadline := time.Now().Add(200 * time.Millisecond)
+	deadline := time.Now().Add(400 * time.Millisecond)
 	for time.Now().Before(deadline) {
 		if err := client.Write(ctx, websocket.MessageText, []byte(`{"ping":"pong"}`)); err != nil {
 			t.Fatalf("client write failed: %v", err)

--- a/internal/realtime/proxy_test.go
+++ b/internal/realtime/proxy_test.go
@@ -110,7 +110,11 @@ func TestProxyRelaysBidirectionally(t *testing.T) {
 func TestProxyRelaysLargeFrame(t *testing.T) {
 	upstream := echoServer(t)
 	defer upstream.Close()
-	proxy := proxyServer(t, wsURL(upstream.URL), nil, nil)
+	// Wait for Proxy to return: Accept hijacks the connection, so
+	// httptest.Server.Close does not wait for the relay goroutines, and a
+	// session leaking past the test races later tests' state.
+	retc := make(chan error, 1)
+	proxy := proxyServer(t, wsURL(upstream.URL), nil, retc)
 	defer proxy.Close()
 
 	client, ctx, cancel := dialClient(t, proxy.URL)
@@ -130,6 +134,9 @@ func TestProxyRelaysLargeFrame(t *testing.T) {
 		t.Errorf("echoed length = %d, want %d", len(data), len(big))
 	}
 	client.Close(websocket.StatusNormalClosure, "")
+	if got := waitProxy(t, retc); got != nil {
+		t.Errorf("Proxy returned %v, want nil on normal close", got)
+	}
 }
 
 func TestProxyDialErrorBeforeUpgrade(t *testing.T) {
@@ -168,5 +175,77 @@ func waitProxy(t *testing.T, retc chan error) error {
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for Proxy to return")
 		return nil
+	}
+}
+
+func TestProxyHeartbeatTearsDownUnresponsivePeer(t *testing.T) {
+	restore := realtime.SetHeartbeatCadenceForTest(30*time.Millisecond, 150*time.Millisecond)
+	defer restore()
+
+	upstream := echoServer(t)
+	defer upstream.Close()
+
+	retc := make(chan error, 1)
+	proxy := proxyServer(t, wsURL(upstream.URL), nil, retc)
+	defer proxy.Close()
+
+	// Connect and go silent: coder/websocket only answers pings while a Read
+	// is in flight, so a client that never reads models a dead peer (NAT
+	// timeout, power loss) that keeps the TCP connection nominally open.
+	client, _, cancel := dialClient(t, proxy.URL)
+	defer cancel()
+	defer client.Close(websocket.StatusNormalClosure, "")
+
+	select {
+	case err := <-retc:
+		if err == nil || !strings.Contains(err.Error(), "heartbeat") {
+			t.Fatalf("Proxy returned %v, want heartbeat failure", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("session with unresponsive peer was not torn down")
+	}
+}
+
+func TestProxyHeartbeatLeavesResponsiveSessionAlive(t *testing.T) {
+	restore := realtime.SetHeartbeatCadenceForTest(20*time.Millisecond, 150*time.Millisecond)
+	defer restore()
+
+	upstream := echoServer(t)
+	defer upstream.Close()
+
+	retc := make(chan error, 1)
+	proxy := proxyServer(t, wsURL(upstream.URL), nil, retc)
+	defer proxy.Close()
+
+	client, ctx, cancel := dialClient(t, proxy.URL)
+	defer cancel()
+
+	// Exchange frames across several heartbeat intervals: an active session
+	// (reads in flight on both sides answer the pings) must not be killed.
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if err := client.Write(ctx, websocket.MessageText, []byte(`{"ping":"pong"}`)); err != nil {
+			t.Fatalf("client write failed: %v", err)
+		}
+		if _, _, err := client.Read(ctx); err != nil {
+			t.Fatalf("client read failed: %v", err)
+		}
+	}
+
+	select {
+	case err := <-retc:
+		t.Fatalf("session ended early: %v", err)
+	default:
+	}
+	if err := client.Close(websocket.StatusNormalClosure, ""); err != nil {
+		t.Fatalf("client close failed: %v", err)
+	}
+	select {
+	case err := <-retc:
+		if err != nil {
+			t.Fatalf("Proxy returned %v after normal close, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("proxy did not finish after client close")
 	}
 }


### PR DESCRIPTION
## Problem

Third slice of the memory-leak investigation (follow-up to #488 and #489): four lifecycle leaks where goroutines, connections, or buffers survive their request instead of being released. None depend on config — all are active in default deployments.

## Changes

**1. Pipe-producer goroutine leak (`internal/llmclient/client.go`)**
File uploads and audio transcriptions stream a multipart body into the request through an `io.Pipe`; the producer goroutine blocks in `Write` until the transport reads it. When the request died *before* reaching the transport — circuit breaker open, request build failure — nothing ever read or closed the pipe, so the producer goroutine plus the entire upload buffer leaked until process restart. Trigger pattern: provider outage trips the breaker while clients retry uploads. `llmclient` now closes `RawBodyReader` (when it implements `io.Closer`) on every pre-transport error return, mirroring net/http's `Do` contract that the body is always closed. Once the request reaches the transport, the transport owns closing it, unchanged.

**2. Live-audit orphan on handler panic (`internal/auditlog/middleware.go`)**
`Recover()` is registered outside the audit middleware, so a handler panic unwound past all the terminal live events — the `audit.started` snapshot stayed in the broker's active-snapshot state forever and was replayed to every dashboard subscriber. The middleware now publishes `audit.removed` from a defer when a panic passes through, then re-panics so the recover middleware behaves exactly as before.

**3. Realtime websocket heartbeat (`internal/realtime/proxy.go`)**
The relay's two copy loops block in `Read`; a silently dead peer (NAT timeout, power loss — no RST, no close frame) never returns from `Read`, leaking two goroutines and both connections per session, indefinitely. The relay now pings both peers every 30s with a 10s timeout — pongs are processed by the always-in-flight reads, so healthy sessions are untouched. One subtlety the new tests caught: a ping failing with `net.ErrClosed` means teardown is already resolving locally, so the heartbeat waits for the copy loop's definitive close cause instead of racing to report a spurious secondary error.

**4. Bounded upstream error-body reads (`internal/llmclient/client.go`)**
`DoStream`'s non-200 path and `doRequest`'s error-status path read the upstream body without a limit; a misbehaving provider answering an error status with an endless body was buffered whole (bounded only by `HTTP_TIMEOUT`). Both now read through a 64KB `LimitReader`, matching `core`'s existing audit-capture cap for error bodies. Successful responses are read whole, unchanged — large legitimate results must not be truncated.

## Tests

- Reader-close contract: pre-transport build error and breaker-open both close a recording `ReadCloser`.
- Panic path: `audit.started` followed by `audit.removed`, and the panic still propagates.
- Heartbeat: an unresponsive peer (connected but never reading, so never ponging) tears the session down with a heartbeat error; an active session across many heartbeat intervals stays alive and still closes cleanly. Cadence is overridable via a test-only export.
- Also fixes `TestProxyRelaysLargeFrame` leaking its hijacked session past the test boundary (`Accept` hijacks the connection, so `httptest.Server.Close` doesn't wait for relay goroutines) — found because the leaked session raced the new tests' cadence override under `-race`.

Full suite passes (62 packages); realtime suite stressed 8× under `-race`.

## User-visible impact

Long-running deployments stop accumulating goroutines/connections from dead realtime sessions and breaker-rejected uploads. Realtime sessions over connections that silently die now end within ~40s with a logged heartbeat error instead of living forever. No API or config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Live audit entries are now cleaned up properly when a request handler panics.
  * Requests with upstream error responses now read bounded error payloads and close caller-supplied streaming bodies on early failures.
  * WebSocket relays now include heartbeat monitoring to tear down sessions with unresponsive peers and avoid hanging.
* **Tests**
  * Added tests covering panic-driven audit removal, pre-transport cleanup on `DoRaw` failures, and heartbeat behavior for responsive vs. unresponsive proxy sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->