### PR TITLE
feat(dashboard): request status code and provider latency charts

### DIFF
--- a/cmd/gomodel/docs/docs.go
+++ b/cmd/gomodel/docs/docs.go
@@ -247,6 +247,63 @@ const docTemplate = `{
                 ]
             }
         },
+        "/admin/audit/stats": {
+            "get": {
+                "description": "Returns request counts grouped into 2xx/4xx/5xx status classes\nper time bucket, an overall success-rate summary, and average\nrequest duration per provider for the dashboard charts.\nRanges up to 3 days use hourly buckets, longer ranges daily.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Get time-bucketed request status and latency stats",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Number of days (default 30)",
+                        "name": "days",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Start date (YYYY-MM-DD)",
+                        "name": "start_date",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End date (YYYY-MM-DD)",
+                        "name": "end_date",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/auditlog.RequestStats"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ]
+            }
+        },
         "/admin/budgets": {
             "get": {
                 "produces": [
@@ -1194,6 +1251,262 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/admin/rate-limits": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "List rate limit rules with live counter status",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.rateLimitListResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ]
+            },
+            "put": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Create or update one rate limit rule",
+                "parameters": [
+                    {
+                        "description": "Rate limit key and limits",
+                        "name": "rule",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/admin.upsertRateLimitRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.rateLimitListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ]
+            },
+            "delete": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Delete one rate limit rule",
+                "parameters": [
+                    {
+                        "description": "Rate limit key",
+                        "name": "rule",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/admin.deleteRateLimitRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.rateLimitListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/admin/rate-limits/reset": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Reset the live counters of all rate limit rules",
+                "parameters": [
+                    {
+                        "description": "Reset confirmation",
+                        "name": "confirmation",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/admin.resetRateLimitsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.resetRateLimitsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/admin/rate-limits/reset-one": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Reset the live counters of one rate limit rule",
+                "parameters": [
+                    {
+                        "description": "Rate limit key",
+                        "name": "rule",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/admin.resetRateLimitRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.rateLimitListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
                         "schema": {
                             "$ref": "#/definitions/core.GatewayError"
                         }
@@ -4684,6 +4997,9 @@ const docTemplate = `{
                 "LOGGING_ENABLED": {
                     "type": "string"
                 },
+                "RATE_LIMITS_ENABLED": {
+                    "type": "string"
+                },
                 "REDIS_URL": {
                     "type": "string"
                 },
@@ -4902,6 +5218,23 @@ const docTemplate = `{
                 }
             }
         },
+        "admin.deleteRateLimitRequest": {
+            "type": "object",
+            "properties": {
+                "limit_key": {
+                    "$ref": "#/definitions/admin.rateLimitKeyRequest"
+                },
+                "scope": {
+                    "type": "string"
+                },
+                "subject": {
+                    "type": "string"
+                },
+                "user_path": {
+                    "type": "string"
+                }
+            }
+        },
         "admin.deleteVirtualModelRequest": {
             "type": "object",
             "properties": {
@@ -4967,6 +5300,87 @@ const docTemplate = `{
                 }
             }
         },
+        "admin.rateLimitKeyRequest": {
+            "type": "object",
+            "properties": {
+                "period": {
+                    "type": "string"
+                },
+                "period_seconds": {
+                    "type": "integer"
+                }
+            }
+        },
+        "admin.rateLimitListResponse": {
+            "type": "object",
+            "properties": {
+                "rate_limits": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/admin.rateLimitStatusResponse"
+                    }
+                },
+                "server_time": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.rateLimitStatusResponse": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "in_flight": {
+                    "type": "integer"
+                },
+                "max_requests": {
+                    "type": "integer"
+                },
+                "max_tokens": {
+                    "type": "integer"
+                },
+                "period_label": {
+                    "type": "string"
+                },
+                "period_seconds": {
+                    "type": "integer"
+                },
+                "requests_remaining": {
+                    "type": "integer"
+                },
+                "requests_used": {
+                    "type": "integer"
+                },
+                "scope": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "subject": {
+                    "type": "string"
+                },
+                "tokens_remaining": {
+                    "type": "integer"
+                },
+                "tokens_used": {
+                    "type": "integer"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "user_path": {
+                    "type": "string"
+                },
+                "window_end": {
+                    "type": "string"
+                },
+                "window_start": {
+                    "type": "string"
+                }
+            }
+        },
         "admin.recalculatePricingRequest": {
             "type": "object",
             "properties": {
@@ -5019,6 +5433,42 @@ const docTemplate = `{
             }
         },
         "admin.resetBudgetsResponse": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.resetRateLimitRequest": {
+            "type": "object",
+            "properties": {
+                "period": {
+                    "type": "string"
+                },
+                "period_seconds": {
+                    "type": "integer"
+                },
+                "scope": {
+                    "type": "string"
+                },
+                "subject": {
+                    "type": "string"
+                },
+                "user_path": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.resetRateLimitsRequest": {
+            "type": "object",
+            "properties": {
+                "confirmation": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.resetRateLimitsResponse": {
             "type": "object",
             "properties": {
                 "status": {
@@ -5120,6 +5570,29 @@ const docTemplate = `{
                     "$ref": "#/definitions/pricingoverrides.Pricing"
                 },
                 "selector": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.upsertRateLimitRequest": {
+            "type": "object",
+            "properties": {
+                "limit_key": {
+                    "$ref": "#/definitions/admin.rateLimitKeyRequest"
+                },
+                "max_requests": {
+                    "type": "integer"
+                },
+                "max_tokens": {
+                    "type": "integer"
+                },
+                "scope": {
+                    "type": "string"
+                },
+                "subject": {
+                    "type": "string"
+                },
+                "user_path": {
                     "type": "string"
                 }
             }
@@ -5654,6 +6127,26 @@ const docTemplate = `{
                 }
             }
         },
+        "auditlog.ProviderLatencySeries": {
+            "type": "object",
+            "properties": {
+                "avg_duration_ms": {
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "requests": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                }
+            }
+        },
         "auditlog.RequestRevisionSnapshot": {
             "type": "object",
             "properties": {
@@ -5674,6 +6167,78 @@ const docTemplate = `{
                 },
                 "seq": {
                     "type": "integer"
+                }
+            }
+        },
+        "auditlog.RequestStats": {
+            "type": "object",
+            "properties": {
+                "buckets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/auditlog.RequestStatsBucket"
+                    }
+                },
+                "interval": {
+                    "type": "string"
+                },
+                "provider_latency": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/auditlog.ProviderLatencySeries"
+                    }
+                },
+                "summary": {
+                    "$ref": "#/definitions/auditlog.RequestStatsSummary"
+                }
+            }
+        },
+        "auditlog.RequestStatsBucket": {
+            "type": "object",
+            "properties": {
+                "requests": {
+                    "type": "integer"
+                },
+                "start": {
+                    "type": "string"
+                },
+                "status_2xx": {
+                    "type": "integer"
+                },
+                "status_4xx": {
+                    "type": "integer"
+                },
+                "status_5xx": {
+                    "type": "integer"
+                },
+                "status_other": {
+                    "type": "integer"
+                }
+            }
+        },
+        "auditlog.RequestStatsSummary": {
+            "type": "object",
+            "properties": {
+                "avg_duration_ms": {
+                    "type": "number"
+                },
+                "requests": {
+                    "type": "integer"
+                },
+                "status_2xx": {
+                    "type": "integer"
+                },
+                "status_4xx": {
+                    "type": "integer"
+                },
+                "status_5xx": {
+                    "type": "integer"
+                },
+                "status_other": {
+                    "type": "integer"
+                },
+                "success_rate": {
+                    "type": "number"
                 }
             }
         },

--- a/docs/advanced/admin-endpoints.mdx
+++ b/docs/advanced/admin-endpoints.mdx
@@ -128,7 +128,7 @@ Returns an empty array if usage tracking is disabled or no data exists for the p
 Returns time-bucketed request counts grouped into `2xx`/`4xx`/`5xx` status
 classes, an overall success-rate summary, and average request duration per
 provider. This powers the "Requests by Status" and "Provider Latency" charts on
-the dashboard's Audit Logs page. Data comes from the audit log, so it requires
+the dashboard's Overview page. Data comes from the audit log, so it requires
 `LOGGING_ENABLED=true`.
 
 **Query parameters:**

--- a/docs/advanced/admin-endpoints.mdx
+++ b/docs/advanced/admin-endpoints.mdx
@@ -123,6 +123,66 @@ The `date` field in the response changes format based on the interval: `YYYY-MM-
 
 Returns an empty array if usage tracking is disabled or no data exists for the period.
 
+### GET /admin/audit/stats
+
+Returns time-bucketed request counts grouped into `2xx`/`4xx`/`5xx` status
+classes, an overall success-rate summary, and average request duration per
+provider. This powers the "Requests by Status" and "Provider Latency" charts on
+the dashboard's Audit Logs page. Data comes from the audit log, so it requires
+`LOGGING_ENABLED=true`.
+
+**Query parameters:**
+
+| Parameter    | Type   | Description                                              | Default              |
+| ------------ | ------ | -------------------------------------------------------- | -------------------- |
+| `start_date` | string | Range start in `YYYY-MM-DD` format                       | 29 days before end   |
+| `end_date`   | string | Range end in `YYYY-MM-DD` format                         | Today                |
+| `days`       | int    | Shorthand for look-back window (ignored if dates are set) | `30`                |
+
+Ranges up to 3 days use hourly buckets (`"interval": "hour"`); longer ranges use
+daily buckets (`"interval": "day"`). Buckets are zero-filled from the range
+start up to the current time.
+
+**Response:**
+
+```json
+{
+  "interval": "day",
+  "buckets": [
+    {
+      "start": "2026-02-17T00:00:00Z",
+      "requests": 84,
+      "status_2xx": 80,
+      "status_4xx": 3,
+      "status_5xx": 1,
+      "status_other": 0
+    }
+  ],
+  "summary": {
+    "requests": 84,
+    "status_2xx": 80,
+    "status_4xx": 3,
+    "status_5xx": 1,
+    "status_other": 0,
+    "success_rate": 0.952,
+    "avg_duration_ms": 812.4
+  },
+  "provider_latency": [
+    {
+      "provider": "openai",
+      "requests": [78],
+      "avg_duration_ms": [795.1]
+    }
+  ]
+}
+```
+
+Each `provider_latency` series aligns index-by-index with `buckets`. Entries are
+`null` for buckets where the provider served no successful request, and the
+averages cover only successful (2xx) requests that reached the provider — local
+response-cache hits and failed requests are excluded. If audit logging is
+disabled, returns empty buckets.
+
 ### Budget endpoints
 
 Budgets are managed under `/admin/budgets`. These endpoints are

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -322,6 +322,83 @@
         }
       }
     },
+    "/admin/audit/stats": {
+      "get": {
+        "description": "Returns request counts grouped into 2xx/4xx/5xx status classes\nper time bucket, an overall success-rate summary, and average\nrequest duration per provider for the dashboard charts.\nRanges up to 3 days use hourly buckets, longer ranges daily.",
+        "tags": [
+          "admin"
+        ],
+        "summary": "Get time-bucketed request status and latency stats",
+        "parameters": [
+          {
+            "description": "Number of days (default 30)",
+            "name": "days",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Start date (YYYY-MM-DD)",
+            "name": "start_date",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "End date (YYYY-MM-DD)",
+            "name": "end_date",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/auditlog.RequestStats"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/audit/stats"
+          }
+        }
+      }
+    },
     "/admin/budgets": {
       "get": {
         "tags": [
@@ -1587,6 +1664,336 @@
         "x-mint": {
           "metadata": {
             "sidebarTitle": "/admin/models/categories"
+          }
+        }
+      }
+    },
+    "/admin/rate-limits": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "List rate limit rules with live counter status",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/admin.rateLimitListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/rate-limits"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Create or update one rate limit rule",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/admin.upsertRateLimitRequest"
+              }
+            }
+          },
+          "description": "Rate limit key and limits",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/admin.rateLimitListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/rate-limits"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Delete one rate limit rule",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/admin.deleteRateLimitRequest"
+              }
+            }
+          },
+          "description": "Rate limit key",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/admin.rateLimitListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/rate-limits"
+          }
+        }
+      }
+    },
+    "/admin/rate-limits/reset": {
+      "post": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Reset the live counters of all rate limit rules",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/admin.resetRateLimitsRequest"
+              }
+            }
+          },
+          "description": "Reset confirmation",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/admin.resetRateLimitsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/rate-limits/reset"
+          }
+        }
+      }
+    },
+    "/admin/rate-limits/reset-one": {
+      "post": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Reset the live counters of one rate limit rule",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/admin.resetRateLimitRequest"
+              }
+            }
+          },
+          "description": "Rate limit key",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/admin.rateLimitListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.GatewayError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/admin/rate-limits/reset-one"
           }
         }
       }
@@ -6942,6 +7349,9 @@
           "LOGGING_ENABLED": {
             "type": "string"
           },
+          "RATE_LIMITS_ENABLED": {
+            "type": "string"
+          },
           "REDIS_URL": {
             "type": "string"
           },
@@ -7178,6 +7588,23 @@
           "selector"
         ]
       },
+      "admin.deleteRateLimitRequest": {
+        "type": "object",
+        "properties": {
+          "limit_key": {
+            "$ref": "#/components/schemas/admin.rateLimitKeyRequest"
+          },
+          "scope": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "user_path": {
+            "type": "string"
+          }
+        }
+      },
       "admin.deleteVirtualModelRequest": {
         "type": "object",
         "properties": {
@@ -7243,6 +7670,87 @@
           }
         }
       },
+      "admin.rateLimitKeyRequest": {
+        "type": "object",
+        "properties": {
+          "period": {
+            "type": "string"
+          },
+          "period_seconds": {
+            "type": "integer"
+          }
+        }
+      },
+      "admin.rateLimitListResponse": {
+        "type": "object",
+        "properties": {
+          "rate_limits": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/admin.rateLimitStatusResponse"
+            }
+          },
+          "server_time": {
+            "type": "string"
+          }
+        }
+      },
+      "admin.rateLimitStatusResponse": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "in_flight": {
+            "type": "integer"
+          },
+          "max_requests": {
+            "type": "integer"
+          },
+          "max_tokens": {
+            "type": "integer"
+          },
+          "period_label": {
+            "type": "string"
+          },
+          "period_seconds": {
+            "type": "integer"
+          },
+          "requests_remaining": {
+            "type": "integer"
+          },
+          "requests_used": {
+            "type": "integer"
+          },
+          "scope": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "tokens_remaining": {
+            "type": "integer"
+          },
+          "tokens_used": {
+            "type": "integer"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "user_path": {
+            "type": "string"
+          },
+          "window_end": {
+            "type": "string"
+          },
+          "window_start": {
+            "type": "string"
+          }
+        }
+      },
       "admin.recalculatePricingRequest": {
         "type": "object",
         "properties": {
@@ -7298,6 +7806,42 @@
         }
       },
       "admin.resetBudgetsResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string"
+          }
+        }
+      },
+      "admin.resetRateLimitRequest": {
+        "type": "object",
+        "properties": {
+          "period": {
+            "type": "string"
+          },
+          "period_seconds": {
+            "type": "integer"
+          },
+          "scope": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "user_path": {
+            "type": "string"
+          }
+        }
+      },
+      "admin.resetRateLimitsRequest": {
+        "type": "object",
+        "properties": {
+          "confirmation": {
+            "type": "string"
+          }
+        }
+      },
+      "admin.resetRateLimitsResponse": {
         "type": "object",
         "properties": {
           "status": {
@@ -7410,6 +7954,29 @@
           "pricing",
           "selector"
         ]
+      },
+      "admin.upsertRateLimitRequest": {
+        "type": "object",
+        "properties": {
+          "limit_key": {
+            "$ref": "#/components/schemas/admin.rateLimitKeyRequest"
+          },
+          "max_requests": {
+            "type": "integer"
+          },
+          "max_tokens": {
+            "type": "integer"
+          },
+          "scope": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "user_path": {
+            "type": "string"
+          }
+        }
       },
       "admin.upsertVirtualModelRequest": {
         "type": "object",
@@ -7941,6 +8508,26 @@
           }
         }
       },
+      "auditlog.ProviderLatencySeries": {
+        "type": "object",
+        "properties": {
+          "avg_duration_ms": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          },
+          "provider": {
+            "type": "string"
+          },
+          "requests": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          }
+        }
+      },
       "auditlog.RequestRevisionSnapshot": {
         "type": "object",
         "properties": {
@@ -7961,6 +8548,78 @@
           },
           "seq": {
             "type": "integer"
+          }
+        }
+      },
+      "auditlog.RequestStats": {
+        "type": "object",
+        "properties": {
+          "buckets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/auditlog.RequestStatsBucket"
+            }
+          },
+          "interval": {
+            "type": "string"
+          },
+          "provider_latency": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/auditlog.ProviderLatencySeries"
+            }
+          },
+          "summary": {
+            "$ref": "#/components/schemas/auditlog.RequestStatsSummary"
+          }
+        }
+      },
+      "auditlog.RequestStatsBucket": {
+        "type": "object",
+        "properties": {
+          "requests": {
+            "type": "integer"
+          },
+          "start": {
+            "type": "string"
+          },
+          "status_2xx": {
+            "type": "integer"
+          },
+          "status_4xx": {
+            "type": "integer"
+          },
+          "status_5xx": {
+            "type": "integer"
+          },
+          "status_other": {
+            "type": "integer"
+          }
+        }
+      },
+      "auditlog.RequestStatsSummary": {
+        "type": "object",
+        "properties": {
+          "avg_duration_ms": {
+            "type": "number"
+          },
+          "requests": {
+            "type": "integer"
+          },
+          "status_2xx": {
+            "type": "integer"
+          },
+          "status_4xx": {
+            "type": "integer"
+          },
+          "status_5xx": {
+            "type": "integer"
+          },
+          "status_other": {
+            "type": "integer"
+          },
+          "success_rate": {
+            "type": "number"
           }
         }
       },

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -3027,6 +3027,51 @@ textarea:focus {
   background: color-mix(in srgb, var(--label-color, var(--accent)) 14%, var(--bg));
 }
 
+/* Audit stats charts (Requests by Status / Provider Latency) */
+.audit-stats-header {
+  align-items: flex-start;
+}
+
+.audit-stats-kpis {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 14px;
+}
+
+.audit-stats-kpi {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.audit-stats-kpi-value {
+  color: var(--text);
+  font-size: 13px;
+}
+
+.audit-stats-kpi-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.audit-stats-dot-2xx {
+  background: var(--success);
+}
+
+.audit-stats-dot-4xx {
+  background: var(--warning);
+}
+
+.audit-stats-dot-5xx {
+  background: var(--danger);
+}
+
 /* Audit Log Section */
 .audit-log-section {
   background: var(--bg-surface);

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -3028,6 +3028,13 @@ textarea:focus {
 }
 
 /* Audit stats charts (Requests by Status / Provider Latency) */
+/* The Activity calendar above only spaces itself upward, so these sections
+   bring their own top margin; between the two charts it collapses with the
+   24px bottom margin into a single gap. */
+.audit-stats-section {
+  margin-top: 24px;
+}
+
 .audit-stats-header {
   align-items: flex-start;
 }

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -188,6 +188,15 @@ function dashboard() {
     auditStream: "",
     auditFetchToken: 0,
     auditExpandedEntries: {},
+    auditStats: {
+      interval: "day",
+      buckets: [],
+      summary: { requests: 0 },
+      provider_latency: [],
+    },
+    auditStatsFetchToken: 0,
+    auditStatusChart: null,
+    auditLatencyChart: null,
 
     // Conversation drawer state
     conversationOpen: false,
@@ -244,7 +253,10 @@ function dashboard() {
 
       if (page === "usage" && sub === "costs") this.usageMode = "costs";
       if (page === "usage" && sub !== "costs") this.usageMode = "tokens";
-      if (page === "audit-logs") this.fetchAuditLog(true);
+      if (page === "audit-logs") {
+        this.fetchAuditLog(true);
+        if (typeof this.fetchAuditStats === "function") this.fetchAuditStats();
+      }
       if (page === "auth-keys" && typeof this.fetchAuthKeys === "function")
         this.fetchAuthKeys();
       if (
@@ -394,6 +406,9 @@ function dashboard() {
       this.renderBarChart();
       this.renderUserPathChart();
       this.renderLabelChart();
+      if (typeof this.renderAuditStatsCharts === "function") {
+        this.renderAuditStatsCharts();
+      }
       if (typeof this.redrawLiveTokensChart === "function") {
         // Force a rebuild so the bars pick up the new theme's colors.
         this.redrawLiveTokensChart();
@@ -748,6 +763,9 @@ function dashboard() {
         typeof this.fetchAuditLog === "function"
       ) {
         requests.push(this.fetchAuditLog(true));
+        if (typeof this.fetchAuditStats === "function") {
+          requests.push(this.fetchAuditStats());
+        }
       }
       if (
         this.page === "auth-keys" &&
@@ -1172,6 +1190,12 @@ function dashboard() {
         ? dashboardAuditListModule
         : null,
       "dashboardAuditListModule",
+    ),
+    resolveModuleFactory(
+      typeof dashboardAuditStatsModule === "function"
+        ? dashboardAuditStatsModule
+        : null,
+      "dashboardAuditStatsModule",
     ),
     resolveModuleFactory(
       typeof dashboardLiveLogsModule === "function"

--- a/internal/admin/dashboard/static/js/dashboard.js
+++ b/internal/admin/dashboard/static/js/dashboard.js
@@ -253,10 +253,7 @@ function dashboard() {
 
       if (page === "usage" && sub === "costs") this.usageMode = "costs";
       if (page === "usage" && sub !== "costs") this.usageMode = "tokens";
-      if (page === "audit-logs") {
-        this.fetchAuditLog(true);
-        if (typeof this.fetchAuditStats === "function") this.fetchAuditStats();
-      }
+      if (page === "audit-logs") this.fetchAuditLog(true);
       if (page === "auth-keys" && typeof this.fetchAuthKeys === "function")
         this.fetchAuthKeys();
       if (
@@ -295,6 +292,7 @@ function dashboard() {
       }
       if (page === "overview") {
         this.renderChart();
+        if (typeof this.fetchAuditStats === "function") this.fetchAuditStats();
         if (typeof this.startLiveTokens === "function") this.startLiveTokens();
       }
       if (page === "usage") this.fetchUsagePage();
@@ -763,9 +761,6 @@ function dashboard() {
         typeof this.fetchAuditLog === "function"
       ) {
         requests.push(this.fetchAuditLog(true));
-        if (typeof this.fetchAuditStats === "function") {
-          requests.push(this.fetchAuditStats());
-        }
       }
       if (
         this.page === "auth-keys" &&

--- a/internal/admin/dashboard/static/js/modules/audit-stats.js
+++ b/internal/admin/dashboard/static/js/modules/audit-stats.js
@@ -82,25 +82,47 @@
                 return Math.round(v) + ' ms';
             },
 
-            // Axis/legend labels: hourly buckets show the hour and mark local
-            // midnight with the short date; daily buckets show the short date.
+            // Date parts in the dashboard's effective timezone: the server
+            // buckets by the same X-GoModel-Timezone the dashboard sends, so
+            // labels must not drift to the browser's locale when the two
+            // timezones differ.
+            _auditStatsDateParts(d) {
+                const zone = typeof this.effectiveTimezone === 'function' ? this.effectiveTimezone() : undefined;
+                try {
+                    const byType = {};
+                    new Intl.DateTimeFormat('en-US', {
+                        timeZone: zone,
+                        year: 'numeric',
+                        month: 'short',
+                        day: 'numeric',
+                        hour: '2-digit',
+                        hourCycle: 'h23'
+                    }).formatToParts(d).forEach((part) => { byType[part.type] = part.value; });
+                    return { year: byType.year, month: byType.month, day: byType.day, hour: Number(byType.hour) };
+                } catch (e) {
+                    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+                    return { year: String(d.getFullYear()), month: months[d.getMonth()], day: String(d.getDate()), hour: d.getHours() };
+                }
+            },
+
+            // Axis labels: hourly buckets show the hour and mark midnight with
+            // the short date; daily buckets show the short date.
             _auditStatsBucketLabel(bucket) {
                 const d = new Date(bucket.start);
                 if (Number.isNaN(d.getTime())) return String(bucket.start || '');
-                const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-                const day = months[d.getMonth()] + ' ' + d.getDate();
+                const parts = this._auditStatsDateParts(d);
+                const day = parts.month + ' ' + parts.day;
                 if (this.auditStats.interval !== 'hour') return day;
-                if (d.getHours() === 0) return day;
-                return String(d.getHours()).padStart(2, '0') + ':00';
+                if (parts.hour === 0) return day;
+                return String(parts.hour).padStart(2, '0') + ':00';
             },
 
             _auditStatsTooltipTitle(bucket) {
                 const d = new Date(bucket.start);
                 if (Number.isNaN(d.getTime())) return String(bucket.start || '');
                 if (this.auditStats.interval === 'hour') return this.formatTimestamp(bucket.start);
-                return d.getFullYear() + '-' +
-                    String(d.getMonth() + 1).padStart(2, '0') + '-' +
-                    String(d.getDate()).padStart(2, '0');
+                const parts = this._auditStatsDateParts(d);
+                return parts.month + ' ' + parts.day + ', ' + parts.year;
             },
 
             // Charts resolve the dashboard's status tokens (success/warning/
@@ -258,7 +280,7 @@
             _renderAuditChart(chartKey, canvasId, visible, buildConfig, retries) {
                 if (retries === undefined) retries = 3;
                 this.$nextTick(() => {
-                    if (this.page !== 'audit-logs' || !visible()) {
+                    if (this.page !== 'overview' || !visible()) {
                         if (this[chartKey]) {
                             this[chartKey].destroy();
                             this[chartKey] = null;

--- a/internal/admin/dashboard/static/js/modules/audit-stats.js
+++ b/internal/admin/dashboard/static/js/modules/audit-stats.js
@@ -1,0 +1,306 @@
+(function(global) {
+    function dashboardAuditStatsModule() {
+        return {
+            _auditStatsQueryStr() {
+                if (this.customStartDate && this.customEndDate) {
+                    return 'start_date=' + this._formatDate(this.customStartDate) +
+                        '&end_date=' + this._formatDate(this.customEndDate);
+                }
+                return 'days=' + this.days;
+            },
+
+            async fetchAuditStats() {
+                const requestToken = ++this.auditStatsFetchToken;
+                try {
+                    const request = typeof this.requestOptions === 'function' ? this.requestOptions() : { headers: this.headers() };
+                    const res = await fetch('/admin/audit/stats?' + this._auditStatsQueryStr(), request);
+                    const handled = this.handleFetchResponse(res, 'audit stats', request);
+                    if (typeof this.isStaleAuthFetchResult === 'function' && this.isStaleAuthFetchResult(handled)) {
+                        return;
+                    }
+                    if (!handled) {
+                        if (requestToken !== this.auditStatsFetchToken) return;
+                        this.auditStats = this.emptyAuditStats();
+                        this.renderAuditStatsCharts();
+                        return;
+                    }
+                    const payload = await res.json();
+                    if (requestToken !== this.auditStatsFetchToken) return;
+                    this.auditStats = this.normalizeAuditStats(payload);
+                    this.renderAuditStatsCharts();
+                } catch (e) {
+                    console.error('Failed to fetch audit stats:', e);
+                    if (requestToken !== this.auditStatsFetchToken) return;
+                    this.auditStats = this.emptyAuditStats();
+                    this.renderAuditStatsCharts();
+                }
+            },
+
+            emptyAuditStats() {
+                return { interval: 'day', buckets: [], summary: { requests: 0 }, provider_latency: [] };
+            },
+
+            normalizeAuditStats(payload) {
+                const stats = payload && typeof payload === 'object' ? payload : {};
+                return {
+                    interval: stats.interval === 'hour' ? 'hour' : 'day',
+                    buckets: Array.isArray(stats.buckets) ? stats.buckets : [],
+                    summary: stats.summary && typeof stats.summary === 'object' ? stats.summary : { requests: 0 },
+                    provider_latency: Array.isArray(stats.provider_latency) ? stats.provider_latency : []
+                };
+            },
+
+            auditStatsHasData() {
+                return Number(this.auditStats && this.auditStats.summary && this.auditStats.summary.requests || 0) > 0;
+            },
+
+            auditLatencyHasData() {
+                return (this.auditStats && Array.isArray(this.auditStats.provider_latency) ? this.auditStats.provider_latency : []).length > 0;
+            },
+
+            auditStatsSuccessRateText() {
+                const rate = this.auditStats && this.auditStats.summary ? this.auditStats.summary.success_rate : null;
+                if (rate === null || rate === undefined) return '—';
+                return (Math.round(Number(rate) * 1000) / 10).toFixed(1) + '%';
+            },
+
+            auditStatsSummaryCount(key) {
+                return this.formatNumber(Number(this.auditStats && this.auditStats.summary && this.auditStats.summary[key] || 0));
+            },
+
+            auditStatsAvgLatencyText() {
+                const avg = this.auditStats && this.auditStats.summary ? this.auditStats.summary.avg_duration_ms : null;
+                if (avg === null || avg === undefined) return '—';
+                return this.formatDurationMs(Number(avg));
+            },
+
+            formatDurationMs(ms) {
+                const v = Number(ms);
+                if (!Number.isFinite(v)) return '-';
+                if (v >= 60000) return (v / 60000).toFixed(1) + ' min';
+                if (v >= 1000) return (v / 1000).toFixed(2) + ' s';
+                return Math.round(v) + ' ms';
+            },
+
+            // Axis/legend labels: hourly buckets show the hour and mark local
+            // midnight with the short date; daily buckets show the short date.
+            _auditStatsBucketLabel(bucket) {
+                const d = new Date(bucket.start);
+                if (Number.isNaN(d.getTime())) return String(bucket.start || '');
+                const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+                const day = months[d.getMonth()] + ' ' + d.getDate();
+                if (this.auditStats.interval !== 'hour') return day;
+                if (d.getHours() === 0) return day;
+                return String(d.getHours()).padStart(2, '0') + ':00';
+            },
+
+            _auditStatsTooltipTitle(bucket) {
+                const d = new Date(bucket.start);
+                if (Number.isNaN(d.getTime())) return String(bucket.start || '');
+                if (this.auditStats.interval === 'hour') return this.formatTimestamp(bucket.start);
+                return d.getFullYear() + '-' +
+                    String(d.getMonth() + 1).padStart(2, '0') + '-' +
+                    String(d.getDate()).padStart(2, '0');
+            },
+
+            // Charts resolve the dashboard's status tokens (success/warning/
+            // danger) so the stacked bars match the status badges in the log
+            // list below, in both themes.
+            _auditStatsColors() {
+                const resolve = (expr) => (typeof this._resolveLiveTokenColor === 'function' ? this._resolveLiveTokenColor(expr) : expr);
+                return {
+                    ok: resolve('var(--success)'),
+                    clientError: resolve('var(--warning)'),
+                    serverError: resolve('var(--danger)'),
+                    other: resolve('color-mix(in srgb, var(--text-muted) 55%, transparent)')
+                };
+            },
+
+            _auditStatusChartConfig(colors, buckets) {
+                const labels = buckets.map((b) => this._auditStatsBucketLabel(b));
+                const statusColors = this._auditStatsColors();
+                const surface = typeof this._resolveLiveTokenColor === 'function'
+                    ? this._resolveLiveTokenColor('var(--bg-surface)')
+                    : 'transparent';
+                const num = (v) => Number(v) || 0;
+                // Surface-colored borders read as gaps where stacked segments
+                // touch, keeping the status classes separable without relying
+                // on hue alone.
+                const bar = (label, data, color) => ({
+                    label: label,
+                    data: data,
+                    backgroundColor: color,
+                    borderColor: surface,
+                    borderWidth: 1,
+                    borderSkipped: false,
+                    borderRadius: 2,
+                    maxBarThickness: 28
+                });
+                const datasets = [
+                    bar('2xx', buckets.map((b) => num(b.status_2xx)), statusColors.ok),
+                    bar('4xx', buckets.map((b) => num(b.status_4xx)), statusColors.clientError),
+                    bar('5xx', buckets.map((b) => num(b.status_5xx)), statusColors.serverError)
+                ];
+                if (buckets.some((b) => num(b.status_other) > 0)) {
+                    datasets.push(bar('Other', buckets.map((b) => num(b.status_other)), statusColors.other));
+                }
+                return {
+                    type: 'bar',
+                    data: { labels: labels, datasets: datasets },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        animation: { duration: 0 },
+                        interaction: { mode: 'index', intersect: false },
+                        plugins: {
+                            legend: { labels: { color: colors.text, font: { size: 12 } } },
+                            tooltip: this._chartTooltip(colors, {
+                                title: (items) => items.length ? this._auditStatsTooltipTitle(buckets[items[0].dataIndex]) : '',
+                                label: (c) => c.dataset.label + ': ' + c.parsed.y.toLocaleString(),
+                                footer: (items) => {
+                                    let total = 0;
+                                    items.forEach((it) => { total += Number(it.parsed.y) || 0; });
+                                    return 'Total: ' + total.toLocaleString();
+                                }
+                            })
+                        },
+                        scales: {
+                            x: {
+                                stacked: true,
+                                grid: { display: false },
+                                border: { display: false },
+                                ticks: { color: colors.text, font: this._chartTickFont(), maxRotation: 0, autoSkip: true, maxTicksLimit: 12 }
+                            },
+                            y: {
+                                stacked: true,
+                                beginAtZero: true,
+                                grid: { color: colors.grid },
+                                border: { display: false },
+                                ticks: { color: colors.text, font: this._chartTickFont(), precision: 0, callback: (v) => this.formatTokensShort(v) }
+                            }
+                        }
+                    }
+                };
+            },
+
+            // Distinct categorical colors handed out in first-seen order, so a
+            // provider keeps its color while the dashboard stays open and
+            // near-identical hues (which hashing can produce) never end up as
+            // neighboring lines.
+            auditProviderColor(provider) {
+                if (!this._auditProviderColors) this._auditProviderColors = {};
+                if (!(provider in this._auditProviderColors)) {
+                    const palette = typeof this._barColors === 'function' ? this._barColors() : ['#c2845a'];
+                    this._auditProviderColors[provider] = palette[Object.keys(this._auditProviderColors).length % palette.length];
+                }
+                return this._auditProviderColors[provider];
+            },
+
+            _auditLatencyChartConfig(colors, buckets, series) {
+                const labels = buckets.map((b) => this._auditStatsBucketLabel(b));
+                const datasets = series.map((s) => ({
+                    label: s.provider,
+                    data: (s.avg_duration_ms || []).map((v) => (v === null || v === undefined ? null : Number(v))),
+                    borderColor: this.auditProviderColor(s.provider),
+                    backgroundColor: this.auditProviderColor(s.provider),
+                    fill: false,
+                    tension: 0.3,
+                    borderWidth: 2,
+                    pointRadius: 0,
+                    pointHoverRadius: 4,
+                    // Bridge a single quiet bucket so one idle hour doesn't cut
+                    // the line, but keep longer outages visible as gaps. The
+                    // category axis measures gaps in bucket indices.
+                    spanGaps: this.auditStats.interval === 'hour' ? 2 : false
+                }));
+                return {
+                    type: 'line',
+                    data: { labels: labels, datasets: datasets },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        animation: { duration: 0 },
+                        interaction: { mode: 'index', intersect: false },
+                        plugins: {
+                            legend: { labels: { color: colors.text, font: { size: 12 } } },
+                            tooltip: this._chartTooltip(colors, {
+                                title: (items) => items.length ? this._auditStatsTooltipTitle(buckets[items[0].dataIndex]) : '',
+                                label: (c) => {
+                                    const requests = (series[c.datasetIndex] && series[c.datasetIndex].requests || [])[c.dataIndex];
+                                    const count = Number(requests) || 0;
+                                    return c.dataset.label + ': ' + this.formatDurationMs(c.parsed.y) +
+                                        (count > 0 ? ' (' + count.toLocaleString() + ' req)' : '');
+                                }
+                            })
+                        },
+                        scales: {
+                            x: {
+                                grid: { color: colors.grid },
+                                border: { display: false },
+                                ticks: { color: colors.text, font: this._chartTickFont(), maxRotation: 0, autoSkip: true, maxTicksLimit: 12 }
+                            },
+                            y: {
+                                beginAtZero: true,
+                                grid: { color: colors.grid },
+                                border: { display: false },
+                                ticks: { color: colors.text, font: this._chartTickFont(), callback: (v) => this.formatDurationMs(v) }
+                            }
+                        }
+                    }
+                };
+            },
+
+            renderAuditStatsCharts() {
+                this.renderAuditStatusChart();
+                this.renderAuditLatencyChart();
+            },
+
+            _renderAuditChart(chartKey, canvasId, visible, buildConfig, retries) {
+                if (retries === undefined) retries = 3;
+                this.$nextTick(() => {
+                    if (this.page !== 'audit-logs' || !visible()) {
+                        if (this[chartKey]) {
+                            this[chartKey].destroy();
+                            this[chartKey] = null;
+                        }
+                        return;
+                    }
+                    const canvas = document.getElementById(canvasId);
+                    if (!canvas || canvas.offsetWidth === 0) {
+                        if (retries > 0) {
+                            setTimeout(() => this._renderAuditChart(chartKey, canvasId, visible, buildConfig, retries - 1), 100);
+                        }
+                        return;
+                    }
+                    if (this[chartKey]) {
+                        this[chartKey].destroy();
+                        this[chartKey] = null;
+                    }
+                    this[chartKey] = new Chart(canvas, buildConfig(this.chartColors()));
+                });
+            },
+
+            renderAuditStatusChart(retries) {
+                this._renderAuditChart(
+                    'auditStatusChart',
+                    'auditStatusChartCanvas',
+                    () => this.auditStatsHasData(),
+                    (colors) => this._auditStatusChartConfig(colors, this.auditStats.buckets),
+                    retries
+                );
+            },
+
+            renderAuditLatencyChart(retries) {
+                this._renderAuditChart(
+                    'auditLatencyChart',
+                    'auditLatencyChartCanvas',
+                    () => this.auditStatsHasData() && this.auditLatencyHasData(),
+                    (colors) => this._auditLatencyChartConfig(colors, this.auditStats.buckets, this.auditStats.provider_latency),
+                    retries
+                );
+            }
+        };
+    }
+
+    global.dashboardAuditStatsModule = dashboardAuditStatsModule;
+})(window);

--- a/internal/admin/dashboard/static/js/modules/audit-stats.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/audit-stats.test.cjs
@@ -1,0 +1,265 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function loadAuditStatsModuleFactory(overrides = {}) {
+    const source = fs.readFileSync(path.join(__dirname, 'audit-stats.js'), 'utf8');
+    const window = {
+        ...(overrides.window || {})
+    };
+    const context = {
+        console,
+        ...overrides,
+        window
+    };
+    vm.createContext(context);
+    vm.runInContext(source, context);
+    return context.window.dashboardAuditStatsModule;
+}
+
+class FakeChart {
+    constructor(canvas, config) {
+        this.canvas = canvas;
+        this.config = config;
+        this.data = config.data;
+        this.options = config.options;
+        this.destroyCalls = 0;
+        FakeChart.instances.push(this);
+    }
+
+    destroy() {
+        this.destroyCalls++;
+    }
+}
+
+FakeChart.instances = [];
+
+function createModule(overrides = {}, contextOverrides = {}) {
+    const canvas = { offsetWidth: 800 };
+    const factory = loadAuditStatsModuleFactory({
+        Chart: FakeChart,
+        document: {
+            getElementById() {
+                return canvas;
+            }
+        },
+        ...contextOverrides
+    });
+    const module = factory();
+
+    module.$nextTick = (callback) => callback();
+    module.page = 'audit-logs';
+    module.days = '30';
+    module.customStartDate = null;
+    module.customEndDate = null;
+    module.auditStats = module.emptyAuditStats();
+    module.auditStatsFetchToken = 0;
+    module.auditStatusChart = null;
+    module.auditLatencyChart = null;
+    module.chartColors = () => ({
+        grid: '#111',
+        text: '#222',
+        tooltipBg: '#333',
+        tooltipBorder: '#444',
+        tooltipText: '#555'
+    });
+    module.formatNumber = (n) => String(n);
+    module.formatTokensShort = (n) => String(n);
+    module.formatTimestamp = (ts) => 'ts:' + ts;
+    module._barColors = () => ['#c2845a', '#7a9e7e', '#d4a574'];
+    module._resolveLiveTokenColor = (expr) => expr;
+    module._chartTickFont = () => ({ size: 11 });
+    module._chartTooltip = (colors, callbacks) => ({ callbacks });
+    module.headers = () => ({});
+    module.handleFetchResponse = (res) => res && res.ok;
+
+    Object.assign(module, overrides);
+    return { module, canvas };
+}
+
+test('normalizeAuditStats tolerates malformed payloads', () => {
+    const { module } = createModule();
+
+    const empty = module.normalizeAuditStats(null);
+    assert.equal(empty.interval, 'day');
+    assert.equal(empty.buckets.length, 0);
+    assert.equal(empty.provider_latency.length, 0);
+
+    const normalized = module.normalizeAuditStats({
+        interval: 'hour',
+        buckets: [{ start: '2026-01-16T10:00:00Z', requests: 3 }],
+        summary: { requests: 3 },
+        provider_latency: 'nope'
+    });
+    assert.equal(normalized.interval, 'hour');
+    assert.equal(normalized.buckets.length, 1);
+    assert.equal(normalized.provider_latency.length, 0);
+});
+
+test('auditStatsHasData follows the summary request count', () => {
+    const { module } = createModule();
+    assert.equal(module.auditStatsHasData(), false);
+
+    module.auditStats.summary = { requests: 12 };
+    assert.equal(module.auditStatsHasData(), true);
+});
+
+test('auditStatsSuccessRateText formats the ratio and its absence', () => {
+    const { module } = createModule();
+    assert.equal(module.auditStatsSuccessRateText(), '—');
+
+    module.auditStats.summary = { requests: 4, success_rate: 0.9944 };
+    assert.equal(module.auditStatsSuccessRateText(), '99.4%');
+});
+
+test('formatDurationMs scales through ms, s, and min', () => {
+    const { module } = createModule();
+    assert.equal(module.formatDurationMs(812.4), '812 ms');
+    assert.equal(module.formatDurationMs(2350), '2.35 s');
+    assert.equal(module.formatDurationMs(90000), '1.5 min');
+    assert.equal(module.formatDurationMs('nope'), '-');
+});
+
+test('status chart stacks 2xx/4xx/5xx and adds Other only when present', () => {
+    const { module } = createModule();
+    module.auditStats = module.normalizeAuditStats({
+        interval: 'day',
+        buckets: [
+            { start: '2026-01-16T00:00:00Z', requests: 5, status_2xx: 3, status_4xx: 1, status_5xx: 1, status_other: 0 },
+            { start: '2026-01-17T00:00:00Z', requests: 2, status_2xx: 2, status_4xx: 0, status_5xx: 0, status_other: 0 }
+        ],
+        summary: { requests: 7 }
+    });
+
+    const config = module._auditStatusChartConfig(module.chartColors(), module.auditStats.buckets);
+    assert.equal(config.type, 'bar');
+    assert.equal(config.data.datasets.length, 3);
+    assert.deepEqual([...config.data.datasets.map((d) => d.label)], ['2xx', '4xx', '5xx']);
+    assert.deepEqual([...config.data.datasets[0].data], [3, 2]);
+    assert.equal(config.options.scales.x.stacked, true);
+    assert.equal(config.options.scales.y.stacked, true);
+
+    module.auditStats.buckets[0].status_other = 2;
+    const withOther = module._auditStatusChartConfig(module.chartColors(), module.auditStats.buckets);
+    assert.equal(withOther.data.datasets.length, 4);
+    assert.equal(withOther.data.datasets[3].label, 'Other');
+});
+
+test('latency chart keeps nil buckets as gaps and colors by provider identity', () => {
+    const { module } = createModule();
+    module.auditStats = module.normalizeAuditStats({
+        interval: 'hour',
+        buckets: [
+            { start: '2026-01-16T10:00:00Z' },
+            { start: '2026-01-16T11:00:00Z' }
+        ],
+        summary: { requests: 3 },
+        provider_latency: [
+            { provider: 'openai', requests: [2, 0], avg_duration_ms: [200.5, null] },
+            { provider: 'anthropic', requests: [1, 1], avg_duration_ms: [400, 410] }
+        ]
+    });
+
+    const config = module._auditLatencyChartConfig(module.chartColors(), module.auditStats.buckets, module.auditStats.provider_latency);
+    assert.equal(config.type, 'line');
+    assert.equal(config.data.datasets.length, 2);
+    assert.deepEqual([...config.data.datasets[0].data], [200.5, null]);
+    // Distinct palette colors in first-seen order, stable across re-renders.
+    assert.equal(config.data.datasets[0].borderColor, '#c2845a');
+    assert.equal(config.data.datasets[1].borderColor, '#7a9e7e');
+    assert.equal(module.auditProviderColor('openai'), '#c2845a');
+});
+
+test('hourly labels mark local midnight with the short date', () => {
+    const { module } = createModule();
+    module.auditStats.interval = 'hour';
+
+    const midnight = new Date(2026, 0, 16, 0, 0, 0);
+    const afternoon = new Date(2026, 0, 16, 14, 0, 0);
+    assert.equal(module._auditStatsBucketLabel({ start: midnight.toISOString() }), 'Jan 16');
+    assert.equal(module._auditStatsBucketLabel({ start: afternoon.toISOString() }), '14:00');
+
+    module.auditStats.interval = 'day';
+    assert.equal(module._auditStatsBucketLabel({ start: afternoon.toISOString() }), 'Jan 16');
+});
+
+test('renderAuditStatsCharts destroys charts when leaving the page', () => {
+    FakeChart.instances = [];
+    const { module } = createModule();
+    module.auditStats = module.normalizeAuditStats({
+        interval: 'day',
+        buckets: [{ start: '2026-01-16T00:00:00Z', requests: 5, status_2xx: 5 }],
+        summary: { requests: 5 },
+        provider_latency: [{ provider: 'openai', requests: [5], avg_duration_ms: [100] }]
+    });
+
+    module.renderAuditStatsCharts();
+    assert.equal(FakeChart.instances.length, 2);
+    assert.ok(module.auditStatusChart);
+    assert.ok(module.auditLatencyChart);
+
+    module.page = 'overview';
+    module.renderAuditStatsCharts();
+    assert.equal(module.auditStatusChart, null);
+    assert.equal(module.auditLatencyChart, null);
+    assert.equal(FakeChart.instances[0].destroyCalls, 1);
+    assert.equal(FakeChart.instances[1].destroyCalls, 1);
+});
+
+test('fetchAuditStats stores normalized payloads and renders', async () => {
+    const payload = {
+        interval: 'hour',
+        buckets: [{ start: '2026-01-16T10:00:00Z', requests: 2, status_2xx: 2 }],
+        summary: { requests: 2, success_rate: 1 },
+        provider_latency: []
+    };
+    let requestedUrl = null;
+    const { module } = createModule({}, {
+        fetch(url) {
+            requestedUrl = url;
+            return Promise.resolve({ ok: true, json: async () => payload });
+        }
+    });
+    let rendered = 0;
+    module.renderAuditStatsCharts = () => { rendered++; };
+    module.requestOptions = () => ({ headers: {} });
+
+    await module.fetchAuditStats();
+
+    assert.ok(String(requestedUrl).includes('/admin/audit/stats?days=30'));
+    assert.equal(module.auditStats.interval, 'hour');
+    assert.equal(module.auditStats.summary.requests, 2);
+    assert.equal(rendered, 1);
+});
+
+test('fetchAuditStats resets to empty stats on failure', async () => {
+    const loggedErrors = [];
+    const { module } = createModule({}, {
+        console: {
+            error(...args) {
+                loggedErrors.push(args);
+            }
+        },
+        fetch() {
+            return Promise.reject(new Error('network down'));
+        }
+    });
+    let rendered = 0;
+    module.renderAuditStatsCharts = () => { rendered++; };
+    module.requestOptions = () => ({ headers: {} });
+    module.auditStats = module.normalizeAuditStats({
+        interval: 'hour',
+        buckets: [{ start: '2026-01-16T10:00:00Z', requests: 2 }],
+        summary: { requests: 2 },
+        provider_latency: []
+    });
+
+    await module.fetchAuditStats();
+
+    assert.equal(module.auditStats.summary.requests, 0);
+    assert.equal(module.auditStats.buckets.length, 0);
+    assert.equal(rendered, 1);
+    assert.equal(loggedErrors.length, 1);
+});

--- a/internal/admin/dashboard/static/js/modules/audit-stats.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/audit-stats.test.cjs
@@ -50,7 +50,7 @@ function createModule(overrides = {}, contextOverrides = {}) {
     const module = factory();
 
     module.$nextTick = (callback) => callback();
-    module.page = 'audit-logs';
+    module.page = 'overview';
     module.days = '30';
     module.customStartDate = null;
     module.customEndDate = null;
@@ -185,6 +185,23 @@ test('hourly labels mark local midnight with the short date', () => {
     assert.equal(module._auditStatsBucketLabel({ start: afternoon.toISOString() }), 'Jan 16');
 });
 
+test('labels follow the dashboard effective timezone, not the browser locale', () => {
+    const { module } = createModule();
+    module.auditStats.interval = 'hour';
+
+    // Midnight UTC is 09:00 in Tokyo — an hourly bucket must label the hour
+    // in the dashboard's timezone, and the day flip must follow it too.
+    module.effectiveTimezone = () => 'Asia/Tokyo';
+    assert.equal(module._auditStatsBucketLabel({ start: '2026-01-16T00:00:00Z' }), '09:00');
+    assert.equal(module._auditStatsBucketLabel({ start: '2026-01-15T15:00:00Z' }), 'Jan 16');
+
+    module.effectiveTimezone = () => 'UTC';
+    assert.equal(module._auditStatsBucketLabel({ start: '2026-01-16T00:00:00Z' }), 'Jan 16');
+
+    module.auditStats.interval = 'day';
+    assert.equal(module._auditStatsTooltipTitle({ start: '2026-01-16T00:00:00Z' }), 'Jan 16, 2026');
+});
+
 test('renderAuditStatsCharts destroys charts when leaving the page', () => {
     FakeChart.instances = [];
     const { module } = createModule();
@@ -200,7 +217,7 @@ test('renderAuditStatsCharts destroys charts when leaving the page', () => {
     assert.ok(module.auditStatusChart);
     assert.ok(module.auditLatencyChart);
 
-    module.page = 'overview';
+    module.page = 'audit-logs';
     module.renderAuditStatsCharts();
     assert.equal(module.auditStatusChart, null);
     assert.equal(module.auditLatencyChart, null);

--- a/internal/admin/dashboard/static/js/modules/usage.js
+++ b/internal/admin/dashboard/static/js/modules/usage.js
@@ -348,7 +348,10 @@
                         this.fetchCacheOverview();
                     }
                     if (this.page === 'usage') this.fetchUsagePage();
-                    if (this.page === 'audit-logs') this.fetchAuditLog(true);
+                    if (this.page === 'audit-logs') {
+                        this.fetchAuditLog(true);
+                        if (typeof this.fetchAuditStats === 'function') this.fetchAuditStats();
+                    }
                 } catch (e) {
                     if (typeof this._isAbortError === 'function' && this._isAbortError(e)) {
                         return;

--- a/internal/admin/dashboard/static/js/modules/usage.js
+++ b/internal/admin/dashboard/static/js/modules/usage.js
@@ -348,10 +348,8 @@
                         this.fetchCacheOverview();
                     }
                     if (this.page === 'usage') this.fetchUsagePage();
-                    if (this.page === 'audit-logs') {
-                        this.fetchAuditLog(true);
-                        if (typeof this.fetchAuditStats === 'function') this.fetchAuditStats();
-                    }
+                    if (this.page === 'audit-logs') this.fetchAuditLog(true);
+                    if (this.page === 'overview' && typeof this.fetchAuditStats === 'function') this.fetchAuditStats();
                 } catch (e) {
                     if (typeof this._isAbortError === 'function' && this._isAbortError(e)) {
                         return;

--- a/internal/admin/dashboard/templates/layout.html
+++ b/internal/admin/dashboard/templates/layout.html
@@ -314,6 +314,7 @@
     <script src="{{assetURL "js/modules/providers.js"}}"></script>
     <script src="{{assetURL "js/modules/usage.js"}}"></script>
     <script src="{{assetURL "js/modules/audit-list.js"}}"></script>
+    <script src="{{assetURL "js/modules/audit-stats.js"}}"></script>
     <script src="{{assetURL "js/modules/live-logs.js"}}"></script>
     <script src="{{assetURL "js/modules/virtual-models.js"}}"></script>
     <script src="{{assetURL "js/modules/failover.js"}}"></script>

--- a/internal/admin/dashboard/templates/page-audit-logs.html
+++ b/internal/admin/dashboard/templates/page-audit-logs.html
@@ -12,59 +12,6 @@
     <!-- Auth Error Banner -->
     {{template "auth-banner" .}}
 
-    <!-- Requests by Status Chart -->
-    <div class="model-chart-section" x-show="auditStatsHasData()">
-        <div class="model-chart-header audit-stats-header">
-            <h3>Requests by Status</h3>
-            <div class="audit-stats-kpis" role="group" aria-label="Request status summary">
-                <span class="audit-stats-kpi" title="Share of requests answered with a 2xx status">
-                    <span class="audit-stats-kpi-label">Success</span>
-                    <span class="audit-stats-kpi-value mono" x-text="auditStatsSuccessRateText()"></span>
-                </span>
-                <span class="audit-stats-kpi">
-                    <span class="audit-stats-kpi-dot audit-stats-dot-2xx" aria-hidden="true"></span>
-                    <span class="audit-stats-kpi-label">2xx</span>
-                    <span class="audit-stats-kpi-value mono" x-text="auditStatsSummaryCount('status_2xx')"></span>
-                </span>
-                <span class="audit-stats-kpi">
-                    <span class="audit-stats-kpi-dot audit-stats-dot-4xx" aria-hidden="true"></span>
-                    <span class="audit-stats-kpi-label">4xx</span>
-                    <span class="audit-stats-kpi-value mono" x-text="auditStatsSummaryCount('status_4xx')"></span>
-                </span>
-                <span class="audit-stats-kpi">
-                    <span class="audit-stats-kpi-dot audit-stats-dot-5xx" aria-hidden="true"></span>
-                    <span class="audit-stats-kpi-label">5xx</span>
-                    <span class="audit-stats-kpi-value mono" x-text="auditStatsSummaryCount('status_5xx')"></span>
-                </span>
-            </div>
-        </div>
-        <div class="bar-chart-wrap">
-            <canvas id="auditStatusChartCanvas"></canvas>
-        </div>
-    </div>
-
-    <!-- Provider Latency Chart -->
-    <div class="model-chart-section" x-show="auditStatsHasData() && auditLatencyHasData()">
-        <div class="model-chart-header audit-stats-header">
-            <div class="inline-help-section" x-data="{ open: false, copyId: 'audit-latency-help-copy', showLabel: 'Show provider latency help', hideLabel: 'Hide provider latency help', text: 'Average duration of successful requests as measured at the gateway, per provider. Local cache hits and failed requests are excluded; streamed responses count until the stream completes.' }">
-                <div class="inline-help-title-row">
-                    <h3>Provider Latency</h3>
-                    {{template "inline-help-toggle" .}}
-                </div>
-                <p :id="copyId" class="inline-help-copy" x-show="open" x-transition.opacity.duration.200ms x-text="text"></p>
-            </div>
-            <div class="audit-stats-kpis">
-                <span class="audit-stats-kpi" title="Average duration of successful, uncached requests across all providers">
-                    <span class="audit-stats-kpi-label">Avg</span>
-                    <span class="audit-stats-kpi-value mono" x-text="auditStatsAvgLatencyText()"></span>
-                </span>
-            </div>
-        </div>
-        <div class="bar-chart-wrap">
-            <canvas id="auditLatencyChartCanvas"></canvas>
-        </div>
-    </div>
-
     <div class="audit-log-section">
         <div class="audit-log-toolbar">
             <div class="audit-filter-row audit-filter-row-search">

--- a/internal/admin/dashboard/templates/page-audit-logs.html
+++ b/internal/admin/dashboard/templates/page-audit-logs.html
@@ -12,6 +12,59 @@
     <!-- Auth Error Banner -->
     {{template "auth-banner" .}}
 
+    <!-- Requests by Status Chart -->
+    <div class="model-chart-section" x-show="auditStatsHasData()">
+        <div class="model-chart-header audit-stats-header">
+            <h3>Requests by Status</h3>
+            <div class="audit-stats-kpis" role="group" aria-label="Request status summary">
+                <span class="audit-stats-kpi" title="Share of requests answered with a 2xx status">
+                    <span class="audit-stats-kpi-label">Success</span>
+                    <span class="audit-stats-kpi-value mono" x-text="auditStatsSuccessRateText()"></span>
+                </span>
+                <span class="audit-stats-kpi">
+                    <span class="audit-stats-kpi-dot audit-stats-dot-2xx" aria-hidden="true"></span>
+                    <span class="audit-stats-kpi-label">2xx</span>
+                    <span class="audit-stats-kpi-value mono" x-text="auditStatsSummaryCount('status_2xx')"></span>
+                </span>
+                <span class="audit-stats-kpi">
+                    <span class="audit-stats-kpi-dot audit-stats-dot-4xx" aria-hidden="true"></span>
+                    <span class="audit-stats-kpi-label">4xx</span>
+                    <span class="audit-stats-kpi-value mono" x-text="auditStatsSummaryCount('status_4xx')"></span>
+                </span>
+                <span class="audit-stats-kpi">
+                    <span class="audit-stats-kpi-dot audit-stats-dot-5xx" aria-hidden="true"></span>
+                    <span class="audit-stats-kpi-label">5xx</span>
+                    <span class="audit-stats-kpi-value mono" x-text="auditStatsSummaryCount('status_5xx')"></span>
+                </span>
+            </div>
+        </div>
+        <div class="bar-chart-wrap">
+            <canvas id="auditStatusChartCanvas"></canvas>
+        </div>
+    </div>
+
+    <!-- Provider Latency Chart -->
+    <div class="model-chart-section" x-show="auditStatsHasData() && auditLatencyHasData()">
+        <div class="model-chart-header audit-stats-header">
+            <div class="inline-help-section" x-data="{ open: false, copyId: 'audit-latency-help-copy', showLabel: 'Show provider latency help', hideLabel: 'Hide provider latency help', text: 'Average duration of successful requests as measured at the gateway, per provider. Local cache hits and failed requests are excluded; streamed responses count until the stream completes.' }">
+                <div class="inline-help-title-row">
+                    <h3>Provider Latency</h3>
+                    {{template "inline-help-toggle" .}}
+                </div>
+                <p :id="copyId" class="inline-help-copy" x-show="open" x-transition.opacity.duration.200ms x-text="text"></p>
+            </div>
+            <div class="audit-stats-kpis">
+                <span class="audit-stats-kpi" title="Average duration of successful, uncached requests across all providers">
+                    <span class="audit-stats-kpi-label">Avg</span>
+                    <span class="audit-stats-kpi-value mono" x-text="auditStatsAvgLatencyText()"></span>
+                </span>
+            </div>
+        </div>
+        <div class="bar-chart-wrap">
+            <canvas id="auditLatencyChartCanvas"></canvas>
+        </div>
+    </div>
+
     <div class="audit-log-section">
         <div class="audit-log-toolbar">
             <div class="audit-filter-row audit-filter-row-search">

--- a/internal/admin/dashboard/templates/page-overview.html
+++ b/internal/admin/dashboard/templates/page-overview.html
@@ -228,6 +228,59 @@
          x-text="calendarTooltip.text"
          :style="'left: ' + calendarTooltip.x + 'px; top: ' + (calendarTooltip.y - 40) + 'px'"></div>
 
+    <!-- Requests by Status Chart -->
+    <div class="model-chart-section" x-show="auditStatsHasData()">
+        <div class="model-chart-header audit-stats-header">
+            <h3>Requests by Status</h3>
+            <div class="audit-stats-kpis" role="group" aria-label="Request status summary">
+                <span class="audit-stats-kpi" title="Share of requests answered with a 2xx status">
+                    <span class="audit-stats-kpi-label">Success</span>
+                    <span class="audit-stats-kpi-value mono" x-text="auditStatsSuccessRateText()"></span>
+                </span>
+                <span class="audit-stats-kpi">
+                    <span class="audit-stats-kpi-dot audit-stats-dot-2xx" aria-hidden="true"></span>
+                    <span class="audit-stats-kpi-label">2xx</span>
+                    <span class="audit-stats-kpi-value mono" x-text="auditStatsSummaryCount('status_2xx')"></span>
+                </span>
+                <span class="audit-stats-kpi">
+                    <span class="audit-stats-kpi-dot audit-stats-dot-4xx" aria-hidden="true"></span>
+                    <span class="audit-stats-kpi-label">4xx</span>
+                    <span class="audit-stats-kpi-value mono" x-text="auditStatsSummaryCount('status_4xx')"></span>
+                </span>
+                <span class="audit-stats-kpi">
+                    <span class="audit-stats-kpi-dot audit-stats-dot-5xx" aria-hidden="true"></span>
+                    <span class="audit-stats-kpi-label">5xx</span>
+                    <span class="audit-stats-kpi-value mono" x-text="auditStatsSummaryCount('status_5xx')"></span>
+                </span>
+            </div>
+        </div>
+        <div class="bar-chart-wrap">
+            <canvas id="auditStatusChartCanvas"></canvas>
+        </div>
+    </div>
+
+    <!-- Provider Latency Chart -->
+    <div class="model-chart-section" x-show="auditStatsHasData() && auditLatencyHasData()">
+        <div class="model-chart-header audit-stats-header">
+            <div class="inline-help-section" x-data="{ open: false, copyId: 'audit-latency-help-copy', showLabel: 'Show provider latency help', hideLabel: 'Hide provider latency help', text: 'Average duration of successful requests as measured at the gateway, per provider. Local cache hits and failed requests are excluded; streamed responses count until the stream completes.' }">
+                <div class="inline-help-title-row">
+                    <h3>Provider Latency</h3>
+                    {{template "inline-help-toggle" .}}
+                </div>
+                <p :id="copyId" class="inline-help-copy" x-show="open" x-transition.opacity.duration.200ms x-text="text"></p>
+            </div>
+            <div class="audit-stats-kpis">
+                <span class="audit-stats-kpi" title="Average duration of successful, uncached requests across all providers">
+                    <span class="audit-stats-kpi-label">Avg</span>
+                    <span class="audit-stats-kpi-value mono" x-text="auditStatsAvgLatencyText()"></span>
+                </span>
+            </div>
+        </div>
+        <div class="bar-chart-wrap">
+            <canvas id="auditLatencyChartCanvas"></canvas>
+        </div>
+    </div>
+
     <div id="provider-status-section" class="provider-status-section" tabindex="-1" x-show="providerStatus.providers.length > 0">
         <div class="provider-status-section-header">
             <div>

--- a/internal/admin/dashboard/templates/page-overview.html
+++ b/internal/admin/dashboard/templates/page-overview.html
@@ -229,7 +229,7 @@
          :style="'left: ' + calendarTooltip.x + 'px; top: ' + (calendarTooltip.y - 40) + 'px'"></div>
 
     <!-- Requests by Status Chart -->
-    <div class="model-chart-section" x-show="auditStatsHasData()">
+    <div class="model-chart-section audit-stats-section" x-show="auditStatsHasData()">
         <div class="model-chart-header audit-stats-header">
             <h3>Requests by Status</h3>
             <div class="audit-stats-kpis" role="group" aria-label="Request status summary">
@@ -260,7 +260,7 @@
     </div>
 
     <!-- Provider Latency Chart -->
-    <div class="model-chart-section" x-show="auditStatsHasData() && auditLatencyHasData()">
+    <div class="model-chart-section audit-stats-section" x-show="auditStatsHasData() && auditLatencyHasData()">
         <div class="model-chart-header audit-stats-header">
             <div class="inline-help-section" x-data="{ open: false, copyId: 'audit-latency-help-copy', showLabel: 'Show provider latency help', hideLabel: 'Hide provider latency help', text: 'Average duration of successful requests as measured at the gateway, per provider. Local cache hits and failed requests are excluded; streamed responses count until the stream completes.' }">
                 <div class="inline-help-title-row">

--- a/internal/admin/handler_audit.go
+++ b/internal/admin/handler_audit.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/labstack/echo/v5"
 
@@ -179,6 +180,67 @@ func (h *Handler) auditLogResponse(ctx context.Context, result *auditlog.LogList
 	}
 
 	return response, nil
+}
+
+// auditStatsHourlyRangeDays is the largest date-range span (in days) that
+// still gets hourly buckets; longer ranges fall back to daily buckets so the
+// chart stays readable.
+const auditStatsHourlyRangeDays = 3
+
+// AuditStats handles GET /admin/audit/stats
+//
+// @Summary      Get time-bucketed request status and latency stats
+// @Description  Returns request counts grouped into 2xx/4xx/5xx status classes
+// @Description  per time bucket, an overall success-rate summary, and average
+// @Description  request duration per provider for the dashboard charts.
+// @Description  Ranges up to 3 days use hourly buckets, longer ranges daily.
+// @Tags         admin
+// @Produce      json
+// @Security     BearerAuth
+// @Param        days        query     int     false  "Number of days (default 30)"
+// @Param        start_date  query     string  false  "Start date (YYYY-MM-DD)"
+// @Param        end_date    query     string  false  "End date (YYYY-MM-DD)"
+// @Success      200  {object}  auditlog.RequestStats
+// @Failure      400  {object}  core.GatewayError
+// @Failure      401  {object}  core.GatewayError
+// @Router       /admin/audit/stats [get]
+func (h *Handler) AuditStats(c *echo.Context) error {
+	// Validate request shape before the disabled-reader fast path so callers
+	// always get a 400 for malformed inputs, regardless of whether audit
+	// logging is configured.
+	dateRange, err := parseDateRangeParams(c)
+	if err != nil {
+		return handleError(c, err)
+	}
+
+	interval := auditlog.StatsIntervalDay
+	if dateRange.EndDate.Sub(dateRange.StartDate) < auditStatsHourlyRangeDays*24*time.Hour {
+		interval = auditlog.StatsIntervalHour
+	}
+
+	if h.auditReader == nil {
+		return c.JSON(http.StatusOK, auditlog.EmptyRequestStats(interval))
+	}
+
+	_, location := dashboardTimeZone(c)
+	params := auditlog.RequestStatsParams{
+		QueryParams: auditlog.QueryParams{
+			StartDate: dateRange.StartDate,
+			EndDate:   dateRange.EndDate,
+		},
+		Interval: interval,
+		Location: location,
+		Now:      timeNow(),
+	}
+
+	stats, err := h.auditReader.GetRequestStats(c.Request().Context(), params)
+	if err != nil {
+		return handleError(c, err)
+	}
+	if stats == nil {
+		stats = auditlog.EmptyRequestStats(interval)
+	}
+	return c.JSON(http.StatusOK, stats)
 }
 
 // AuditLogDetail handles GET /admin/audit/detail.

--- a/internal/admin/handler_audit_stats_test.go
+++ b/internal/admin/handler_audit_stats_test.go
@@ -1,0 +1,126 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"gomodel/internal/auditlog"
+)
+
+func TestAuditStats_NilReader(t *testing.T) {
+	h := NewHandler(nil, nil)
+	c, rec := newHandlerContext("/admin/audit/stats?days=7")
+
+	if err := h.AuditStats(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	var result auditlog.RequestStats
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if result.Interval != auditlog.StatsIntervalDay {
+		t.Fatalf("interval = %q, want day", result.Interval)
+	}
+	if result.Buckets == nil || len(result.Buckets) != 0 {
+		t.Fatalf("buckets = %#v, want empty slice", result.Buckets)
+	}
+	if result.ProviderLatency == nil || len(result.ProviderLatency) != 0 {
+		t.Fatalf("provider_latency = %#v, want empty slice", result.ProviderLatency)
+	}
+}
+
+func TestAuditStats_InvalidDate(t *testing.T) {
+	h := NewHandler(nil, nil, WithAuditReader(&mockAuditReader{}))
+	c, rec := newHandlerContext("/admin/audit/stats?start_date=not-a-date")
+
+	if err := h.AuditStats(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "invalid start_date") {
+		t.Fatalf("body = %q, want start_date error", rec.Body.String())
+	}
+}
+
+func TestAuditStats_IntervalFollowsRangeSpan(t *testing.T) {
+	cases := []struct {
+		query string
+		want  string
+	}{
+		{query: "days=1", want: auditlog.StatsIntervalHour},
+		{query: "days=3", want: auditlog.StatsIntervalHour},
+		{query: "days=4", want: auditlog.StatsIntervalDay},
+		{query: "days=30", want: auditlog.StatsIntervalDay},
+	}
+
+	for _, tc := range cases {
+		reader := &mockAuditReader{statsResult: auditlog.EmptyRequestStats("")}
+		h := NewHandler(nil, nil, WithAuditReader(reader))
+		c, rec := newHandlerContext("/admin/audit/stats?" + tc.query)
+
+		if err := h.AuditStats(c); err != nil {
+			t.Fatalf("%s: unexpected error: %v", tc.query, err)
+		}
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s: status = %d, want 200", tc.query, rec.Code)
+		}
+		if reader.lastStatsParams.Interval != tc.want {
+			t.Fatalf("%s: interval = %q, want %q", tc.query, reader.lastStatsParams.Interval, tc.want)
+		}
+		if reader.lastStatsParams.Location == nil {
+			t.Fatalf("%s: expected a location to be passed", tc.query)
+		}
+		if reader.lastStatsParams.Now.IsZero() {
+			t.Fatalf("%s: expected Now to be passed", tc.query)
+		}
+	}
+}
+
+func TestAuditStats_PassesThroughReaderResult(t *testing.T) {
+	start := time.Date(2026, 1, 16, 0, 0, 0, 0, time.UTC)
+	rate := 0.5
+	reader := &mockAuditReader{
+		statsResult: &auditlog.RequestStats{
+			Interval: auditlog.StatsIntervalDay,
+			Buckets: []auditlog.RequestStatsBucket{
+				{Start: start, Requests: 4, Status2xx: 2, Status4xx: 1, Status5xx: 1},
+			},
+			Summary: auditlog.RequestStatsSummary{Requests: 4, Status2xx: 2, SuccessRate: &rate},
+			ProviderLatency: []auditlog.ProviderLatencySeries{
+				{Provider: "openai", Requests: []int64{2}, AvgDurationMs: []*float64{&rate}},
+			},
+		},
+	}
+	h := NewHandler(nil, nil, WithAuditReader(reader))
+	c, rec := newHandlerContext("/admin/audit/stats?days=7")
+
+	if err := h.AuditStats(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	var result auditlog.RequestStats
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if len(result.Buckets) != 1 || result.Buckets[0].Requests != 4 {
+		t.Fatalf("buckets = %#v", result.Buckets)
+	}
+	if result.Summary.SuccessRate == nil || *result.Summary.SuccessRate != 0.5 {
+		t.Fatalf("success rate = %v, want 0.5", result.Summary.SuccessRate)
+	}
+	if len(result.ProviderLatency) != 1 || result.ProviderLatency[0].Provider != "openai" {
+		t.Fatalf("provider_latency = %#v", result.ProviderLatency)
+	}
+}

--- a/internal/admin/handler_audit_stats_test.go
+++ b/internal/admin/handler_audit_stats_test.go
@@ -51,6 +51,18 @@ func TestAuditStats_InvalidDate(t *testing.T) {
 	}
 }
 
+func TestAuditStats_NilReaderInvalidDate(t *testing.T) {
+	h := NewHandler(nil, nil)
+	c, rec := newHandlerContext("/admin/audit/stats?start_date=not-a-date")
+
+	if err := h.AuditStats(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 even with a nil reader", rec.Code)
+	}
+}
+
 func TestAuditStats_IntervalFollowsRangeSpan(t *testing.T) {
 	cases := []struct {
 		query string

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -59,6 +59,9 @@ type mockAuditReader struct {
 	conversationErr     error
 	lastConversationID  string
 	lastConversationLim int
+	statsResult         *auditlog.RequestStats
+	statsErr            error
+	lastStatsParams     auditlog.RequestStatsParams
 }
 
 type mockRuntimeRefresher struct {
@@ -154,6 +157,14 @@ func (m *mockAuditReader) GetLogByID(_ context.Context, _ string) (*auditlog.Log
 		return nil, m.logByIDErr
 	}
 	return m.logByID, nil
+}
+
+func (m *mockAuditReader) GetRequestStats(_ context.Context, params auditlog.RequestStatsParams) (*auditlog.RequestStats, error) {
+	m.lastStatsParams = params
+	if m.statsErr != nil {
+		return nil, m.statsErr
+	}
+	return m.statsResult, nil
 }
 
 func (m *mockAuditReader) GetConversation(_ context.Context, logID string, limit int) (*auditlog.ConversationResult, error) {

--- a/internal/admin/routes.go
+++ b/internal/admin/routes.go
@@ -30,6 +30,7 @@ func (h *Handler) RegisterRoutes(g RouteRegistrar) {
 	g.POST("/usage/recalculate-pricing", h.RecalculateUsagePricing)
 
 	g.GET("/audit/log", h.AuditLog)
+	g.GET("/audit/stats", h.AuditStats)
 	g.GET("/audit/detail", h.AuditLogDetail)
 	g.GET("/audit/conversation", h.AuditConversation)
 

--- a/internal/admin/routes_test.go
+++ b/internal/admin/routes_test.go
@@ -45,6 +45,7 @@ func TestRegisterRoutes_RegistersExpectedPaths(t *testing.T) {
 		"POST /admin/usage/recalculate-pricing",
 
 		"GET /admin/audit/log",
+		"GET /admin/audit/stats",
 		"GET /admin/audit/detail",
 		"GET /admin/audit/conversation",
 

--- a/internal/auditlog/reader.go
+++ b/internal/auditlog/reader.go
@@ -54,4 +54,8 @@ type Reader interface {
 	// It follows Responses API linkage fields when available:
 	// request_body.previous_response_id and response_body.id.
 	GetConversation(ctx context.Context, logID string, limit int) (*ConversationResult, error)
+
+	// GetRequestStats returns time-bucketed status-class counts and
+	// per-provider latency aggregates for the dashboard charts.
+	GetRequestStats(ctx context.Context, params RequestStatsParams) (*RequestStats, error)
 }

--- a/internal/auditlog/stats.go
+++ b/internal/auditlog/stats.go
@@ -1,0 +1,253 @@
+package auditlog
+
+import (
+	"sort"
+	"time"
+)
+
+// Request stats bucket granularities. The admin handler picks hourly buckets
+// for short ranges and daily buckets for longer ones.
+const (
+	StatsIntervalHour = "hour"
+	StatsIntervalDay  = "day"
+)
+
+// statsHourLayout parses the UTC hour keys the storage backends group by.
+const statsHourLayout = "2006-01-02T15"
+
+// RequestStatsParams selects the range and bucketing for GetRequestStats.
+type RequestStatsParams struct {
+	QueryParams
+
+	// Interval is the bucket granularity: StatsIntervalHour or StatsIntervalDay.
+	Interval string
+
+	// Location is the dashboard timezone. Daily buckets start at local
+	// midnight in this location; hourly buckets are timezone-independent.
+	Location *time.Location
+
+	// Now bounds zero-filling: buckets are emitted from the range start up to
+	// the earlier of the range end and Now, so a range ending today does not
+	// trail empty future buckets.
+	Now time.Time
+}
+
+// RequestStats is the time-bucketed request breakdown for the dashboard's
+// status-code and provider-latency charts.
+type RequestStats struct {
+	Interval        string                  `json:"interval"`
+	Buckets         []RequestStatsBucket    `json:"buckets"`
+	Summary         RequestStatsSummary     `json:"summary"`
+	ProviderLatency []ProviderLatencySeries `json:"provider_latency"`
+}
+
+// RequestStatsBucket counts requests by status class within one time bucket.
+type RequestStatsBucket struct {
+	Start       time.Time `json:"start"`
+	Requests    int64     `json:"requests"`
+	Status2xx   int64     `json:"status_2xx"`
+	Status4xx   int64     `json:"status_4xx"`
+	Status5xx   int64     `json:"status_5xx"`
+	StatusOther int64     `json:"status_other"`
+}
+
+// RequestStatsSummary aggregates the whole range. SuccessRate is the 2xx share
+// of all requests; AvgDurationMs averages successful, uncached requests. Both
+// are nil when the range has no qualifying requests.
+type RequestStatsSummary struct {
+	Requests      int64    `json:"requests"`
+	Status2xx     int64    `json:"status_2xx"`
+	Status4xx     int64    `json:"status_4xx"`
+	Status5xx     int64    `json:"status_5xx"`
+	StatusOther   int64    `json:"status_other"`
+	SuccessRate   *float64 `json:"success_rate,omitempty"`
+	AvgDurationMs *float64 `json:"avg_duration_ms,omitempty"`
+}
+
+// ProviderLatencySeries is one provider's average request duration per bucket,
+// aligned index-by-index with RequestStats.Buckets. Entries are nil for
+// buckets where the provider served no successful uncached request, so charts
+// can render gaps instead of misleading zeros. Durations are gateway-observed
+// request durations of successful (2xx) requests, excluding local cache hits.
+type ProviderLatencySeries struct {
+	Provider      string     `json:"provider"`
+	Requests      []int64    `json:"requests"`
+	AvgDurationMs []*float64 `json:"avg_duration_ms"`
+}
+
+// statsRow is one (UTC hour, provider) aggregate scanned from a storage
+// backend. Duration sums cover only latency-eligible requests: status 2xx,
+// duration recorded, and not served from the local response cache.
+type statsRow struct {
+	HourUTC       time.Time
+	Provider      string
+	Requests      int64
+	Status2xx     int64
+	Status4xx     int64
+	Status5xx     int64
+	DurationNsSum int64
+	DurationCount int64
+}
+
+// EmptyRequestStats returns a zero-value result for the disabled-reader fast
+// path so the response shape matches an enabled reader's.
+func EmptyRequestStats(interval string) *RequestStats {
+	return &RequestStats{
+		Interval:        normalizeStatsInterval(interval),
+		Buckets:         []RequestStatsBucket{},
+		ProviderLatency: []ProviderLatencySeries{},
+	}
+}
+
+func normalizeStatsInterval(interval string) string {
+	if interval == StatsIntervalHour {
+		return StatsIntervalHour
+	}
+	return StatsIntervalDay
+}
+
+// foldRequestStats aggregates per-hour rows into the requested bucket
+// granularity. Backends group by UTC hour so one query serves both
+// granularities; folding hours into local days here keeps daily bucketing
+// correct across DST transitions without per-backend timezone SQL.
+func foldRequestStats(rows []statsRow, params RequestStatsParams) *RequestStats {
+	interval := normalizeStatsInterval(params.Interval)
+	location := params.Location
+	if location == nil {
+		location = time.UTC
+	}
+	now := params.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	bucketStart := func(t time.Time) time.Time {
+		if interval == StatsIntervalHour {
+			return t.UTC().Truncate(time.Hour)
+		}
+		local := t.In(location)
+		return time.Date(local.Year(), local.Month(), local.Day(), 0, 0, 0, 0, location)
+	}
+	nextBucket := func(t time.Time) time.Time {
+		if interval == StatsIntervalHour {
+			return t.Add(time.Hour)
+		}
+		return t.AddDate(0, 0, 1)
+	}
+
+	buckets := make(map[int64]*RequestStatsBucket)
+	ensureBucket := func(start time.Time) *RequestStatsBucket {
+		key := start.Unix()
+		if b, ok := buckets[key]; ok {
+			return b
+		}
+		b := &RequestStatsBucket{Start: start}
+		buckets[key] = b
+		return b
+	}
+
+	// Zero-fill the requested range so quiet periods stay visible, but never
+	// past "now": a range ending today should stop at the current bucket.
+	if !params.StartDate.IsZero() && !params.EndDate.IsZero() {
+		endExclusive := params.EndDate.In(location).AddDate(0, 0, 1)
+		for start := bucketStart(params.StartDate); start.Before(endExclusive) && !start.After(now); start = nextBucket(start) {
+			ensureBucket(start)
+		}
+	}
+
+	type latencyCell struct {
+		durationNs int64
+		requests   int64
+	}
+	providerCells := make(map[string]map[int64]*latencyCell)
+	providerRequests := make(map[string]int64)
+
+	var summary RequestStatsSummary
+	var totalDurationNs, totalDurationCount int64
+	for _, row := range rows {
+		start := bucketStart(row.HourUTC)
+		b := ensureBucket(start)
+		b.Requests += row.Requests
+		b.Status2xx += row.Status2xx
+		b.Status4xx += row.Status4xx
+		b.Status5xx += row.Status5xx
+
+		summary.Requests += row.Requests
+		summary.Status2xx += row.Status2xx
+		summary.Status4xx += row.Status4xx
+		summary.Status5xx += row.Status5xx
+		totalDurationNs += row.DurationNsSum
+		totalDurationCount += row.DurationCount
+
+		if row.Provider == "" || row.DurationCount == 0 {
+			continue
+		}
+		cells, ok := providerCells[row.Provider]
+		if !ok {
+			cells = make(map[int64]*latencyCell)
+			providerCells[row.Provider] = cells
+		}
+		cell, ok := cells[start.Unix()]
+		if !ok {
+			cell = &latencyCell{}
+			cells[start.Unix()] = cell
+		}
+		cell.durationNs += row.DurationNsSum
+		cell.requests += row.DurationCount
+		providerRequests[row.Provider] += row.DurationCount
+	}
+
+	ordered := make([]RequestStatsBucket, 0, len(buckets))
+	for _, b := range buckets {
+		b.StatusOther = b.Requests - b.Status2xx - b.Status4xx - b.Status5xx
+		ordered = append(ordered, *b)
+	}
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].Start.Before(ordered[j].Start) })
+
+	summary.StatusOther = summary.Requests - summary.Status2xx - summary.Status4xx - summary.Status5xx
+	if summary.Requests > 0 {
+		rate := float64(summary.Status2xx) / float64(summary.Requests)
+		summary.SuccessRate = &rate
+	}
+	if totalDurationCount > 0 {
+		avg := float64(totalDurationNs) / float64(totalDurationCount) / 1e6
+		summary.AvgDurationMs = &avg
+	}
+
+	providers := make([]string, 0, len(providerCells))
+	for provider := range providerCells {
+		providers = append(providers, provider)
+	}
+	// Busiest providers first so chart legend order matches relevance.
+	sort.Slice(providers, func(i, j int) bool {
+		if providerRequests[providers[i]] != providerRequests[providers[j]] {
+			return providerRequests[providers[i]] > providerRequests[providers[j]]
+		}
+		return providers[i] < providers[j]
+	})
+
+	latency := make([]ProviderLatencySeries, 0, len(providers))
+	for _, provider := range providers {
+		cells := providerCells[provider]
+		series := ProviderLatencySeries{
+			Provider:      provider,
+			Requests:      make([]int64, len(ordered)),
+			AvgDurationMs: make([]*float64, len(ordered)),
+		}
+		for i, b := range ordered {
+			if cell, ok := cells[b.Start.Unix()]; ok && cell.requests > 0 {
+				avg := float64(cell.durationNs) / float64(cell.requests) / 1e6
+				series.Requests[i] = cell.requests
+				series.AvgDurationMs[i] = &avg
+			}
+		}
+		latency = append(latency, series)
+	}
+
+	return &RequestStats{
+		Interval:        interval,
+		Buckets:         ordered,
+		Summary:         summary,
+		ProviderLatency: latency,
+	}
+}

--- a/internal/auditlog/stats_mongodb.go
+++ b/internal/auditlog/stats_mongodb.go
@@ -1,0 +1,120 @@
+package auditlog
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+// GetRequestStats returns time-bucketed status-class counts and per-provider
+// latency aggregates for the dashboard charts.
+func (r *MongoDBReader) GetRequestStats(ctx context.Context, params RequestStatsParams) (*RequestStats, error) {
+	match := bson.D{}
+	if tsFilter := mongoDateRangeFilter(params.QueryParams); tsFilter != nil {
+		match = append(match, bson.E{Key: "timestamp", Value: tsFilter})
+	}
+
+	// Latency covers successful requests with a recorded duration that
+	// actually reached a provider (local response-cache hits complete in
+	// microseconds and would drag averages toward zero).
+	statusIn := func(low, high int) bson.D {
+		return bson.D{{Key: "$and", Value: bson.A{
+			bson.D{{Key: "$gte", Value: bson.A{"$status_code", low}}},
+			bson.D{{Key: "$lte", Value: bson.A{"$status_code", high}}},
+		}}}
+	}
+	countWhen := func(cond bson.D) bson.D {
+		return bson.D{{Key: "$sum", Value: bson.D{{Key: "$cond", Value: bson.A{cond, 1, 0}}}}}
+	}
+	latencyEligible := bson.D{{Key: "$and", Value: bson.A{
+		statusIn(200, 299),
+		bson.D{{Key: "$gt", Value: bson.A{bson.D{{Key: "$ifNull", Value: bson.A{"$duration_ns", 0}}}, 0}}},
+		bson.D{{Key: "$not", Value: bson.A{
+			bson.D{{Key: "$in", Value: bson.A{
+				bson.D{{Key: "$ifNull", Value: bson.A{"$cache_type", ""}}},
+				bson.A{CacheTypeExact, CacheTypeSemantic},
+			}}},
+		}}},
+	}}}
+
+	// Group by UTC hour and provider; foldRequestStats folds hours into the
+	// requested bucket granularity.
+	pipeline := mongo.Pipeline{
+		bson.D{{Key: "$match", Value: match}},
+		bson.D{{Key: "$group", Value: bson.D{
+			{Key: "_id", Value: bson.D{
+				{Key: "hour", Value: bson.D{{Key: "$dateToString", Value: bson.D{
+					{Key: "format", Value: "%Y-%m-%dT%H"},
+					{Key: "date", Value: "$timestamp"},
+				}}}},
+				{Key: "provider", Value: bson.D{{Key: "$let", Value: bson.D{
+					{Key: "vars", Value: bson.D{{Key: "name", Value: bson.D{{Key: "$trim", Value: bson.D{
+						{Key: "input", Value: bson.D{{Key: "$ifNull", Value: bson.A{"$provider_name", ""}}}},
+					}}}}}},
+					{Key: "in", Value: bson.D{{Key: "$cond", Value: bson.A{
+						bson.D{{Key: "$eq", Value: bson.A{"$$name", ""}}},
+						bson.D{{Key: "$trim", Value: bson.D{
+							{Key: "input", Value: bson.D{{Key: "$ifNull", Value: bson.A{"$provider", ""}}}},
+						}}},
+						"$$name",
+					}}}},
+				}}}},
+			}},
+			{Key: "requests", Value: bson.D{{Key: "$sum", Value: 1}}},
+			{Key: "status_2xx", Value: countWhen(statusIn(200, 299))},
+			{Key: "status_4xx", Value: countWhen(statusIn(400, 499))},
+			{Key: "status_5xx", Value: countWhen(bson.D{{Key: "$gte", Value: bson.A{"$status_code", 500}}})},
+			{Key: "duration_ns_sum", Value: bson.D{{Key: "$sum", Value: bson.D{{Key: "$cond", Value: bson.A{
+				latencyEligible, bson.D{{Key: "$ifNull", Value: bson.A{"$duration_ns", 0}}}, 0,
+			}}}}}},
+			{Key: "duration_count", Value: countWhen(latencyEligible)},
+		}}},
+	}
+
+	cursor, err := r.collection.Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil, fmt.Errorf("failed to aggregate audit request stats: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	var raw []mongoStatsRow
+	if err := cursor.All(ctx, &raw); err != nil {
+		return nil, fmt.Errorf("failed to decode audit request stats: %w", err)
+	}
+
+	stats := make([]statsRow, 0, len(raw))
+	for _, row := range raw {
+		hour, err := time.ParseInLocation(statsHourLayout, row.ID.Hour, time.UTC)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse audit request stats hour %q: %w", row.ID.Hour, err)
+		}
+		stats = append(stats, statsRow{
+			HourUTC:       hour,
+			Provider:      row.ID.Provider,
+			Requests:      row.Requests,
+			Status2xx:     row.Status2xx,
+			Status4xx:     row.Status4xx,
+			Status5xx:     row.Status5xx,
+			DurationNsSum: row.DurationNsSum,
+			DurationCount: row.DurationCount,
+		})
+	}
+
+	return foldRequestStats(stats, params), nil
+}
+
+type mongoStatsRow struct {
+	ID struct {
+		Hour     string `bson:"hour"`
+		Provider string `bson:"provider"`
+	} `bson:"_id"`
+	Requests      int64 `bson:"requests"`
+	Status2xx     int64 `bson:"status_2xx"`
+	Status4xx     int64 `bson:"status_4xx"`
+	Status5xx     int64 `bson:"status_5xx"`
+	DurationNsSum int64 `bson:"duration_ns_sum"`
+	DurationCount int64 `bson:"duration_count"`
+}

--- a/internal/auditlog/stats_postgresql.go
+++ b/internal/auditlog/stats_postgresql.go
@@ -1,0 +1,61 @@
+package auditlog
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"gomodel/internal/storage/sqlutil"
+)
+
+// GetRequestStats returns time-bucketed status-class counts and per-provider
+// latency aggregates for the dashboard charts.
+func (r *PostgreSQLReader) GetRequestStats(ctx context.Context, params RequestStatsParams) (*RequestStats, error) {
+	conditions, args, _ := pgDateRangeConditions(params.QueryParams, 1)
+	where := sqlutil.BuildWhereClause(conditions)
+
+	// Group by UTC hour and provider; foldRequestStats folds hours into the
+	// requested bucket granularity.
+	query := `SELECT
+		date_trunc('hour', timestamp AT TIME ZONE 'UTC') AS hour,
+		COALESCE(NULLIF(TRIM(provider_name), ''), TRIM(provider), '') AS prov,
+		COUNT(*),
+		SUM(CASE WHEN status_code BETWEEN 200 AND 299 THEN 1 ELSE 0 END),
+		SUM(CASE WHEN status_code BETWEEN 400 AND 499 THEN 1 ELSE 0 END),
+		SUM(CASE WHEN status_code >= 500 THEN 1 ELSE 0 END),
+		COALESCE(SUM(CASE WHEN ` + postgresStatsLatencyPredicate + ` THEN duration_ns ELSE 0 END), 0),
+		COALESCE(SUM(CASE WHEN ` + postgresStatsLatencyPredicate + ` THEN 1 ELSE 0 END), 0)
+		FROM audit_logs` + where + `
+		GROUP BY hour, prov`
+
+	rows, err := r.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query audit request stats: %w", err)
+	}
+	defer rows.Close()
+
+	stats := make([]statsRow, 0)
+	for rows.Next() {
+		var row statsRow
+		var hour time.Time
+		if err := rows.Scan(&hour, &row.Provider, &row.Requests, &row.Status2xx, &row.Status4xx, &row.Status5xx, &row.DurationNsSum, &row.DurationCount); err != nil {
+			return nil, fmt.Errorf("failed to scan audit request stats row: %w", err)
+		}
+		// date_trunc over "AT TIME ZONE 'UTC'" yields a timestamp without
+		// time zone holding UTC wall-clock values; pin the location so the
+		// fold buckets it correctly regardless of driver defaults.
+		row.HourUTC = time.Date(hour.Year(), hour.Month(), hour.Day(), hour.Hour(), 0, 0, 0, time.UTC)
+		stats = append(stats, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating audit request stats rows: %w", err)
+	}
+
+	return foldRequestStats(stats, params), nil
+}
+
+// Latency covers successful requests with a recorded duration that actually
+// reached a provider (local response-cache hits complete in microseconds and
+// would drag averages toward zero).
+const postgresStatsLatencyPredicate = `status_code BETWEEN 200 AND 299 AND duration_ns > 0
+		AND (cache_type IS NULL OR cache_type = '')`

--- a/internal/auditlog/stats_sqlite.go
+++ b/internal/auditlog/stats_sqlite.go
@@ -1,0 +1,63 @@
+package auditlog
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"gomodel/internal/storage/sqlutil"
+)
+
+// GetRequestStats returns time-bucketed status-class counts and per-provider
+// latency aggregates for the dashboard charts.
+func (r *SQLiteReader) GetRequestStats(ctx context.Context, params RequestStatsParams) (*RequestStats, error) {
+	conditions, args := sqliteDateRangeConditions(params.QueryParams)
+	where := sqlutil.BuildWhereClause(conditions)
+
+	// Group by UTC hour and provider; foldRequestStats folds hours into the
+	// requested bucket granularity. strftime normalizes stored timestamp
+	// variants (space separator, fractional seconds, offsets) to UTC.
+	query := `SELECT
+		strftime('%Y-%m-%dT%H', REPLACE(timestamp, ' ', 'T')) AS hour,
+		COALESCE(NULLIF(TRIM(provider_name), ''), TRIM(provider), '') AS prov,
+		COUNT(*),
+		SUM(CASE WHEN status_code BETWEEN 200 AND 299 THEN 1 ELSE 0 END),
+		SUM(CASE WHEN status_code BETWEEN 400 AND 499 THEN 1 ELSE 0 END),
+		SUM(CASE WHEN status_code >= 500 THEN 1 ELSE 0 END),
+		COALESCE(SUM(CASE WHEN ` + sqliteStatsLatencyPredicate + ` THEN duration_ns ELSE 0 END), 0),
+		COALESCE(SUM(CASE WHEN ` + sqliteStatsLatencyPredicate + ` THEN 1 ELSE 0 END), 0)
+		FROM audit_logs` + where + `
+		GROUP BY hour, prov`
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query audit request stats: %w", err)
+	}
+	defer rows.Close()
+
+	stats := make([]statsRow, 0)
+	for rows.Next() {
+		var row statsRow
+		var hour string
+		if err := rows.Scan(&hour, &row.Provider, &row.Requests, &row.Status2xx, &row.Status4xx, &row.Status5xx, &row.DurationNsSum, &row.DurationCount); err != nil {
+			return nil, fmt.Errorf("failed to scan audit request stats row: %w", err)
+		}
+		parsed, err := time.ParseInLocation(statsHourLayout, hour, time.UTC)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse audit request stats hour %q: %w", hour, err)
+		}
+		row.HourUTC = parsed
+		stats = append(stats, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating audit request stats rows: %w", err)
+	}
+
+	return foldRequestStats(stats, params), nil
+}
+
+// Latency covers successful requests with a recorded duration that actually
+// reached a provider (local response-cache hits complete in microseconds and
+// would drag averages toward zero).
+const sqliteStatsLatencyPredicate = `status_code BETWEEN 200 AND 299 AND duration_ns > 0
+		AND (cache_type IS NULL OR cache_type = '')`

--- a/internal/auditlog/stats_test.go
+++ b/internal/auditlog/stats_test.go
@@ -1,0 +1,251 @@
+package auditlog
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func hourRow(hour time.Time, provider string, mutate func(*statsRow)) statsRow {
+	row := statsRow{HourUTC: hour, Provider: provider}
+	if mutate != nil {
+		mutate(&row)
+	}
+	return row
+}
+
+func TestFoldRequestStats_HourInterval(t *testing.T) {
+	day := time.Date(2026, 1, 16, 0, 0, 0, 0, time.UTC)
+	rows := []statsRow{
+		hourRow(day.Add(10*time.Hour), "openai-prod", func(r *statsRow) {
+			r.Requests = 3
+			r.Status2xx = 2
+			r.Status4xx = 1
+			r.DurationNsSum = 400e6
+			r.DurationCount = 2
+		}),
+		hourRow(day.Add(10*time.Hour), "anthropic", func(r *statsRow) {
+			r.Requests = 1
+			r.Status2xx = 1
+			r.DurationNsSum = 900e6
+			r.DurationCount = 1
+		}),
+		hourRow(day.Add(11*time.Hour), "openai-prod", func(r *statsRow) {
+			r.Requests = 2
+			r.Status5xx = 1
+			r.Status2xx = 0
+			// One request never resolved a status (recorded as 0) -> other.
+			r.Status4xx = 0
+		}),
+	}
+
+	stats := foldRequestStats(rows, RequestStatsParams{
+		QueryParams: QueryParams{StartDate: day, EndDate: day},
+		Interval:    StatsIntervalHour,
+		Location:    time.UTC,
+		Now:         day.Add(12*time.Hour + 30*time.Minute),
+	})
+
+	if stats.Interval != StatsIntervalHour {
+		t.Fatalf("interval = %q, want hour", stats.Interval)
+	}
+	// Zero-filled from local midnight through the bucket containing Now.
+	if len(stats.Buckets) != 13 {
+		t.Fatalf("bucket count = %d, want 13", len(stats.Buckets))
+	}
+	if !stats.Buckets[0].Start.Equal(day) {
+		t.Fatalf("first bucket = %v, want %v", stats.Buckets[0].Start, day)
+	}
+
+	ten := stats.Buckets[10]
+	if ten.Requests != 4 || ten.Status2xx != 3 || ten.Status4xx != 1 || ten.Status5xx != 0 || ten.StatusOther != 0 {
+		t.Fatalf("10:00 bucket = %+v", ten)
+	}
+	eleven := stats.Buckets[11]
+	if eleven.Requests != 2 || eleven.Status5xx != 1 || eleven.StatusOther != 1 {
+		t.Fatalf("11:00 bucket = %+v", eleven)
+	}
+
+	if stats.Summary.Requests != 6 || stats.Summary.Status2xx != 3 || stats.Summary.StatusOther != 1 {
+		t.Fatalf("summary = %+v", stats.Summary)
+	}
+	if stats.Summary.SuccessRate == nil || *stats.Summary.SuccessRate != float64(3)/float64(6) {
+		t.Fatalf("success rate = %v", stats.Summary.SuccessRate)
+	}
+	wantAvg := (400e6 + 900e6) / 3 / 1e6
+	if stats.Summary.AvgDurationMs == nil || *stats.Summary.AvgDurationMs != wantAvg {
+		t.Fatalf("avg duration = %v, want %v", stats.Summary.AvgDurationMs, wantAvg)
+	}
+
+	if len(stats.ProviderLatency) != 2 {
+		t.Fatalf("provider series = %d, want 2", len(stats.ProviderLatency))
+	}
+	// Busiest provider (by latency-eligible requests) first.
+	if stats.ProviderLatency[0].Provider != "openai-prod" || stats.ProviderLatency[1].Provider != "anthropic" {
+		t.Fatalf("provider order = %q, %q", stats.ProviderLatency[0].Provider, stats.ProviderLatency[1].Provider)
+	}
+	openai := stats.ProviderLatency[0]
+	if len(openai.AvgDurationMs) != len(stats.Buckets) {
+		t.Fatalf("series length = %d, want %d", len(openai.AvgDurationMs), len(stats.Buckets))
+	}
+	if openai.AvgDurationMs[10] == nil || *openai.AvgDurationMs[10] != 200 {
+		t.Fatalf("openai 10:00 avg = %v, want 200", openai.AvgDurationMs[10])
+	}
+	if openai.Requests[10] != 2 {
+		t.Fatalf("openai 10:00 requests = %d, want 2", openai.Requests[10])
+	}
+	// The 11:00 failure bucket has no eligible requests -> a gap, not zero.
+	if openai.AvgDurationMs[11] != nil {
+		t.Fatalf("openai 11:00 avg = %v, want nil gap", openai.AvgDurationMs[11])
+	}
+}
+
+func TestFoldRequestStats_DayIntervalFoldsHoursIntoLocalDays(t *testing.T) {
+	location, err := time.LoadLocation("Europe/Warsaw")
+	if err != nil {
+		t.Fatalf("failed to load location: %v", err)
+	}
+
+	// 23:30 UTC on Jan 16 is already Jan 17 00:30 in Warsaw (UTC+1).
+	rows := []statsRow{
+		hourRow(time.Date(2026, 1, 16, 23, 0, 0, 0, time.UTC), "openai", func(r *statsRow) {
+			r.Requests = 1
+			r.Status2xx = 1
+		}),
+		hourRow(time.Date(2026, 1, 17, 10, 0, 0, 0, time.UTC), "openai", func(r *statsRow) {
+			r.Requests = 2
+			r.Status2xx = 2
+		}),
+		hourRow(time.Date(2026, 1, 16, 10, 0, 0, 0, time.UTC), "openai", func(r *statsRow) {
+			r.Requests = 4
+			r.Status2xx = 4
+		}),
+	}
+
+	start := time.Date(2026, 1, 16, 0, 0, 0, 0, location)
+	end := time.Date(2026, 1, 17, 0, 0, 0, 0, location)
+	stats := foldRequestStats(rows, RequestStatsParams{
+		QueryParams: QueryParams{StartDate: start, EndDate: end},
+		Interval:    StatsIntervalDay,
+		Location:    location,
+		Now:         time.Date(2026, 1, 18, 12, 0, 0, 0, location),
+	})
+
+	if len(stats.Buckets) != 2 {
+		t.Fatalf("bucket count = %d, want 2", len(stats.Buckets))
+	}
+	if !stats.Buckets[0].Start.Equal(start) || !stats.Buckets[1].Start.Equal(end) {
+		t.Fatalf("bucket starts = %v, %v", stats.Buckets[0].Start, stats.Buckets[1].Start)
+	}
+	if stats.Buckets[0].Requests != 4 {
+		t.Fatalf("Jan 16 requests = %d, want 4", stats.Buckets[0].Requests)
+	}
+	if stats.Buckets[1].Requests != 3 {
+		t.Fatalf("Jan 17 requests = %d, want 3 (late UTC hour folds into the next local day)", stats.Buckets[1].Requests)
+	}
+}
+
+func TestFoldRequestStats_ZeroFillStopsAtNow(t *testing.T) {
+	location := time.UTC
+	start := time.Date(2026, 1, 10, 0, 0, 0, 0, location)
+	end := time.Date(2026, 1, 20, 0, 0, 0, 0, location)
+
+	stats := foldRequestStats(nil, RequestStatsParams{
+		QueryParams: QueryParams{StartDate: start, EndDate: end},
+		Interval:    StatsIntervalDay,
+		Location:    location,
+		Now:         time.Date(2026, 1, 12, 15, 0, 0, 0, location),
+	})
+
+	if len(stats.Buckets) != 3 {
+		t.Fatalf("bucket count = %d, want 3 (10th-12th)", len(stats.Buckets))
+	}
+	if stats.Summary.SuccessRate != nil || stats.Summary.AvgDurationMs != nil {
+		t.Fatalf("empty summary rates = %+v, want nil", stats.Summary)
+	}
+	if len(stats.ProviderLatency) != 0 {
+		t.Fatalf("provider series = %d, want 0", len(stats.ProviderLatency))
+	}
+}
+
+func TestSQLiteReaderGetRequestStats(t *testing.T) {
+	db := createTestDB(t)
+	defer db.Close()
+
+	store, err := NewSQLiteStore(db, 0)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+
+	day := time.Date(2026, 1, 16, 0, 0, 0, 0, time.UTC)
+	entries := []*LogEntry{
+		{ID: "ok-1", Timestamp: day.Add(10*time.Hour + 15*time.Minute), Provider: "openai", ProviderName: "openai-prod", StatusCode: 200, DurationNs: 100e6},
+		{ID: "ok-2", Timestamp: day.Add(10*time.Hour + 45*time.Minute), Provider: "openai", ProviderName: "openai-prod", StatusCode: 201, DurationNs: 300e6},
+		{ID: "client-err", Timestamp: day.Add(10*time.Hour + 50*time.Minute), Provider: "openai", ProviderName: "openai-prod", StatusCode: 429, DurationNs: 5e6},
+		{ID: "server-err", Timestamp: day.Add(11*time.Hour + 5*time.Minute), Provider: "openai", ProviderName: "openai-prod", StatusCode: 502, DurationNs: 2e9},
+		// Local cache hit: counted as 2xx but excluded from latency.
+		{ID: "cache-hit", Timestamp: day.Add(11*time.Hour + 10*time.Minute), Provider: "openai", ProviderName: "openai-prod", StatusCode: 200, DurationNs: 1e6, CacheType: CacheTypeExact},
+		// Empty provider name falls back to the provider type.
+		{ID: "fallback-name", Timestamp: day.Add(11*time.Hour + 20*time.Minute), Provider: "anthropic", StatusCode: 200, DurationNs: 700e6},
+		// Outside the queried range.
+		{ID: "next-day", Timestamp: day.Add(30 * time.Hour), Provider: "openai", ProviderName: "openai-prod", StatusCode: 200, DurationNs: 100e6},
+	}
+	if err := store.WriteBatch(context.Background(), entries); err != nil {
+		t.Fatalf("failed to seed audit logs: %v", err)
+	}
+
+	reader, err := NewSQLiteReader(db)
+	if err != nil {
+		t.Fatalf("failed to create reader: %v", err)
+	}
+
+	stats, err := reader.GetRequestStats(context.Background(), RequestStatsParams{
+		QueryParams: QueryParams{StartDate: day, EndDate: day},
+		Interval:    StatsIntervalHour,
+		Location:    time.UTC,
+		Now:         day.Add(23 * time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("GetRequestStats failed: %v", err)
+	}
+
+	if stats.Summary.Requests != 6 {
+		t.Fatalf("summary requests = %d, want 6", stats.Summary.Requests)
+	}
+	if stats.Summary.Status2xx != 4 || stats.Summary.Status4xx != 1 || stats.Summary.Status5xx != 1 || stats.Summary.StatusOther != 0 {
+		t.Fatalf("summary = %+v", stats.Summary)
+	}
+
+	byStart := map[int]RequestStatsBucket{}
+	for _, b := range stats.Buckets {
+		byStart[b.Start.UTC().Hour()] = b
+	}
+	if b := byStart[10]; b.Requests != 3 || b.Status2xx != 2 || b.Status4xx != 1 {
+		t.Fatalf("10:00 bucket = %+v", b)
+	}
+	if b := byStart[11]; b.Requests != 3 || b.Status2xx != 2 || b.Status5xx != 1 {
+		t.Fatalf("11:00 bucket = %+v", b)
+	}
+
+	if len(stats.ProviderLatency) != 2 {
+		t.Fatalf("provider series = %d, want 2", len(stats.ProviderLatency))
+	}
+	if stats.ProviderLatency[0].Provider != "openai-prod" {
+		t.Fatalf("first provider = %q, want openai-prod", stats.ProviderLatency[0].Provider)
+	}
+	openai := stats.ProviderLatency[0]
+	if openai.AvgDurationMs[10] == nil || *openai.AvgDurationMs[10] != 200 {
+		t.Fatalf("openai 10:00 avg = %v, want 200 (2xx only)", openai.AvgDurationMs[10])
+	}
+	// The 11:00 openai bucket only saw a 502 and a cache hit -> gap.
+	if openai.AvgDurationMs[11] != nil {
+		t.Fatalf("openai 11:00 avg = %v, want nil", openai.AvgDurationMs[11])
+	}
+	anthropic := stats.ProviderLatency[1]
+	if anthropic.Provider != "anthropic" {
+		t.Fatalf("second provider = %q, want anthropic", anthropic.Provider)
+	}
+	if anthropic.AvgDurationMs[11] == nil || *anthropic.AvgDurationMs[11] != 700 {
+		t.Fatalf("anthropic 11:00 avg = %v, want 700", anthropic.AvgDurationMs[11])
+	}
+}

--- a/internal/auditlog/stats_test.go
+++ b/internal/auditlog/stats_test.go
@@ -2,6 +2,7 @@ package auditlog
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 )
@@ -72,8 +73,8 @@ func TestFoldRequestStats_HourInterval(t *testing.T) {
 	if stats.Summary.SuccessRate == nil || *stats.Summary.SuccessRate != float64(3)/float64(6) {
 		t.Fatalf("success rate = %v", stats.Summary.SuccessRate)
 	}
-	wantAvg := (400e6 + 900e6) / 3 / 1e6
-	if stats.Summary.AvgDurationMs == nil || *stats.Summary.AvgDurationMs != wantAvg {
+	wantAvg := float64(400e6+900e6) / 3 / 1e6
+	if stats.Summary.AvgDurationMs == nil || math.Abs(*stats.Summary.AvgDurationMs-wantAvg) > 1e-9 {
 		t.Fatalf("avg duration = %v, want %v", stats.Summary.AvgDurationMs, wantAvg)
 	}
 

--- a/tools/seed-demo-data.sh
+++ b/tools/seed-demo-data.sh
@@ -426,7 +426,17 @@ INSERT INTO audit_logs (
 SELECT
   audit_id,
   timestamp,
-  CASE WHEN cache_type IS NOT NULL THEN 8000000 + (token_noise % 12000000) ELSE 90000000 + (token_noise % 260000000) END,
+  -- Each provider gets its own latency profile so the dashboard's provider
+  -- latency chart shows distinct, plausible lines instead of overlapping noise.
+  CASE WHEN cache_type IS NOT NULL THEN 8000000 + (token_noise % 12000000)
+    ELSE CAST((90000000 + (token_noise % 260000000)) * CASE provider
+      WHEN 'groq' THEN 0.45
+      WHEN 'gemini' THEN 0.8
+      WHEN 'anthropic' THEN 1.6
+      WHEN 'bailian' THEN 2.2
+      ELSE 1.0
+    END AS INTEGER)
+  END,
   provider_name || '/' || model,
   provider_name || '/' || model,
   provider,
@@ -434,7 +444,11 @@ SELECT
   0,
   NULL,
   cache_type,
-  CASE WHEN abs(token_noise / 131) % 1000 < 994 THEN 200 ELSE 500 END,
+  CASE
+    WHEN abs(token_noise / 131) % 1000 < 985 THEN 200
+    WHEN abs(token_noise / 131) % 1000 < 994 THEN 429
+    ELSE 500
+  END,
   request_id,
   NULL,
   'master_key',
@@ -443,7 +457,11 @@ SELECT
   endpoint,
   user_path,
   0,
-  CASE WHEN abs(token_noise / 131) % 1000 < 994 THEN '' ELSE 'provider_error' END,
+  CASE
+    WHEN abs(token_noise / 131) % 1000 < 985 THEN ''
+    WHEN abs(token_noise / 131) % 1000 < 994 THEN 'rate_limit_exceeded'
+    ELSE 'provider_error'
+  END,
   json_object(
     'demo_seed', 1,
     'workflow_features', json_object(
@@ -538,6 +556,14 @@ SELECT
           'type', 'provider_error',
           'code', 'demo_provider_error',
           'param', 'model'
+        )
+      )
+      WHEN abs(token_noise / 131) % 1000 >= 985 THEN json_object(
+        'error', json_object(
+          'message', 'Synthetic rate limit for demo audit inspection. Retry after a moment.',
+          'type', 'rate_limit_exceeded',
+          'code', 'demo_rate_limit',
+          'param', NULL
         )
       )
       WHEN label IN ('chat-openai', 'chat-groq', 'chat-gemini', 'chat-bailian') THEN json_object(


### PR DESCRIPTION
Closes #459

## What

Two new charts on the dashboard's **Overview** page, placed right before Providers Overview so error rates, provider latency, and provider availability read as one health block (they follow the shared date-range picker):

- **Requests by Status** — a stacked bar chart of request counts grouped into 2xx / 4xx / 5xx (plus an "Other" series that appears only when 1xx/3xx/unset statuses exist), with header KPIs for the overall success rate and per-class counts. This is the chart requested in #459.
- **Provider Latency** (bonus from the issue discussion) — the audit log already records per-request duration, so a line chart shows the average duration of successful requests per provider over the same buckets. Local response-cache hits and failed requests are excluded so averages reflect real provider round trips; buckets with no data render as gaps, not zeros.

Both are powered by a new admin endpoint:

- `GET /admin/audit/stats?days=|start_date=&end_date=` — time-bucketed status-class counts, a success-rate summary, and per-provider latency series. Ranges up to 3 days use hourly buckets; longer ranges use daily buckets aligned to the dashboard timezone. Buckets are zero-filled up to the current time.

## How

- Storage backends (SQLite, PostgreSQL, MongoDB) each run a single query grouping audit entries by UTC hour and provider; shared Go code (`foldRequestStats`) folds hours into hourly or timezone-correct daily buckets, so daily bucketing stays right across DST without per-backend timezone SQL.
- The charts use the dashboard's existing status tokens (matching the status badges in the audit log) and hand out distinct categorical palette colors to providers in first-seen order, so a provider keeps its color while the page is open. Bucket labels format in the dashboard's effective timezone — the same one the server buckets by.
- Charts appear only when audit data exists; with `LOGGING_ENABLED=false` the endpoint returns an empty result and the page looks unchanged.
- The demo seed (`tools/seed-demo-data.sh`) now emits 429s alongside 500s and gives each provider a distinct latency profile so the charts are legible out of the box.

## User-visible impact

- New charts on the Overview dashboard page; no behavior change elsewhere.
- New documented admin endpoint `GET /admin/audit/stats` (swagger/openapi regenerated, docs page updated).
- Requires audit logging (`LOGGING_ENABLED=true`) to show data.

## Tests

- `foldRequestStats` unit tests (hour/day intervals, DST-safe local-day folding, zero-fill truncation at "now", latency gap semantics, tolerance-based float comparison) and a SQLite reader integration test.
- Admin handler tests: interval selection by range span, nil-reader fast path, validation-before-nil-reader ordering, invalid date validation, result passthrough.
- New JS module tests (11 cases: payload normalization, chart configs, render/destroy lifecycle, fetch success/failure paths, effective-timezone labels).
- Verified visually against seeded demo data (hourly and daily buckets, dark theme, provider latency separation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)