### PR TITLE
feat(audit): show rewrite token savings on the Rewritten tab

### DIFF
--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -3432,6 +3432,23 @@ textarea:focus {
   border-color: color-mix(in srgb, var(--warning) 30%, var(--border));
 }
 
+/* Tokens saved by a request rewrite (e.g. token compression), shown on the
+   Rewritten tab next to the rewriter pill. Same blue family as the cached
+   tokens in the charts (both derive from --info); the prompt-cache variables
+   carry the per-theme tone mix that keeps the text readable. */
+.audit-tokens-saved-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 7px;
+  border: 1px solid color-mix(in srgb, var(--prompt-cache-color) 45%, var(--border));
+  border-radius: 999px;
+  background: var(--prompt-cache-color-bg);
+  color: var(--prompt-cache-color);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
 .audit-entry-metadata {
   display: flex;
   align-items: center;

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -3432,11 +3432,11 @@ textarea:focus {
   border-color: color-mix(in srgb, var(--warning) 30%, var(--border));
 }
 
-/* Tokens saved by a request rewrite (e.g. token compression), shown on the
-   Rewritten tab next to the rewriter pill. Same blue family as the cached
-   tokens in the charts (both derive from --info); the prompt-cache variables
-   carry the per-theme tone mix that keeps the text readable. */
-.audit-tokens-saved-pill {
+/* Share of the request body removed by a rewrite (e.g. token compression),
+   shown on the Rewritten tab next to the rewriter pill. Same blue family as
+   the cached tokens in the charts (both derive from --info); the prompt-cache
+   variables carry the per-theme tone mix that keeps the text readable. */
+.audit-savings-pill {
   display: inline-flex;
   align-items: center;
   padding: 1px 7px;

--- a/internal/admin/dashboard/static/js/modules/audit-list.js
+++ b/internal/admin/dashboard/static/js/modules/audit-list.js
@@ -541,6 +541,29 @@
                     : [];
             },
 
+            // auditRevisionTokensSaved returns the rewriter-reported prompt
+            // tokens this revision saved (0 when it reported none). Older
+            // entries predate the typed field, so fall back to the compression
+            // report's estimate inside the rewriter detail.
+            auditRevisionTokensSaved(revision) {
+                const typed = Number(revision && revision.tokens_saved);
+                if (Number.isFinite(typed) && typed > 0) return typed;
+                const detail = revision && revision.detail;
+                const estimate = Number(detail && detail.tokens_saved_estimate);
+                return Number.isFinite(estimate) && estimate > 0 ? estimate : 0;
+            },
+
+            // auditRevisionTokensSavedLabel renders the savings as a compact
+            // pill label (e.g. "-12.3K tokens"), or '' when nothing was saved.
+            auditRevisionTokensSavedLabel(revision) {
+                const saved = this.auditRevisionTokensSaved(revision);
+                if (saved <= 0) return '';
+                const amount = typeof this.formatTokensShort === 'function'
+                    ? this.formatTokensShort(saved)
+                    : String(saved);
+                return '-' + amount + ' tokens';
+            },
+
             // auditRequestRevisionPane renders one ingress rewrite: a structured
             // summary of what the rewriter changed plus the rewritten body when
             // it was captured. The original client request stays on the Request
@@ -562,6 +585,7 @@
                     direction: 'request',
                     seq: single ? 0 : Number(revision && revision.seq || 0),
                     kind: (revision && revision.rewriter) ? String(revision.rewriter) : '',
+                    tokensSavedLabel: this.auditRevisionTokensSavedLabel(revision),
                     layout: 'split',
                     entry,
                     copyHeaders: summary,

--- a/internal/admin/dashboard/static/js/modules/audit-list.js
+++ b/internal/admin/dashboard/static/js/modules/audit-list.js
@@ -564,6 +564,53 @@
                 return '-' + amount + ' tokens';
             },
 
+            // auditRevisionPercentLabel renders how much of the request body
+            // this revision removed (e.g. "-21%"), or '' when sizes are
+            // missing or the revision didn't shrink the body.
+            auditRevisionPercentLabel(revision) {
+                const before = Number(revision && revision.bytes_before);
+                const after = Number(revision && revision.bytes_after);
+                if (!Number.isFinite(before) || !Number.isFinite(after) || before <= 0 || after >= before) return '';
+                const pct = (1 - after / before) * 100;
+                return '-' + (pct >= 10 ? String(Math.round(pct)) : pct.toFixed(1)) + '%';
+            },
+
+            // auditRevisionCostSavedLabel renders this revision's share of the
+            // request's priced rewrite savings (e.g. "~$0.0372"), or '' when
+            // usage tracking recorded no cost. The cost lives on the entry's
+            // usage summary (it is priced per request, not per revision), so
+            // it is apportioned by each revision's share of the saved tokens.
+            auditRevisionCostSavedLabel(entry, revision) {
+                const cost = Number(entry && entry.usage && entry.usage.rewrite_cost_saved);
+                if (!Number.isFinite(cost) || cost <= 0) return '';
+                const revisionTokens = this.auditRevisionTokensSaved(revision);
+                if (revisionTokens <= 0) return '';
+                const totalTokens = this.auditRequestRevisions(entry)
+                    .reduce((sum, r) => sum + this.auditRevisionTokensSaved(r), 0);
+                const share = totalTokens > revisionTokens ? revisionTokens / totalTokens : 1;
+                const amount = cost * share;
+                if (typeof this.formatCost === 'function') {
+                    const label = this.formatCost(amount);
+                    return label.startsWith('<') ? label : '~' + label;
+                }
+                return '~$' + amount.toFixed(4);
+            },
+
+            // auditRevisionSavingsLabel combines tokens, percent of body
+            // removed, and priced savings into the Rewritten tab's pill label
+            // (e.g. "-12.3K tokens · -21% · ~$0.0372"). Tokens gate the pill;
+            // the other segments render only when their data is available.
+            auditRevisionSavingsLabel(entry, revision) {
+                const tokens = this.auditRevisionTokensSavedLabel(revision);
+                if (!tokens) return '';
+                const parts = [tokens];
+                const percent = this.auditRevisionPercentLabel(revision);
+                if (percent) parts.push(percent);
+                const cost = this.auditRevisionCostSavedLabel(entry, revision);
+                if (cost) parts.push(cost);
+                return parts.join(' · ');
+            },
+
             // auditRequestRevisionPane renders one ingress rewrite: a structured
             // summary of what the rewriter changed plus the rewritten body when
             // it was captured. The original client request stays on the Request
@@ -585,7 +632,7 @@
                     direction: 'request',
                     seq: single ? 0 : Number(revision && revision.seq || 0),
                     kind: (revision && revision.rewriter) ? String(revision.rewriter) : '',
-                    tokensSavedLabel: this.auditRevisionTokensSavedLabel(revision),
+                    tokensSavedLabel: this.auditRevisionSavingsLabel(entry, revision),
                     layout: 'split',
                     entry,
                     copyHeaders: summary,

--- a/internal/admin/dashboard/static/js/modules/audit-list.js
+++ b/internal/admin/dashboard/static/js/modules/audit-list.js
@@ -541,31 +541,8 @@
                     : [];
             },
 
-            // auditRevisionTokensSaved returns the rewriter-reported prompt
-            // tokens this revision saved (0 when it reported none). Older
-            // entries predate the typed field, so fall back to the compression
-            // report's estimate inside the rewriter detail.
-            auditRevisionTokensSaved(revision) {
-                const typed = Number(revision && revision.tokens_saved);
-                if (Number.isFinite(typed) && typed > 0) return typed;
-                const detail = revision && revision.detail;
-                const estimate = Number(detail && detail.tokens_saved_estimate);
-                return Number.isFinite(estimate) && estimate > 0 ? estimate : 0;
-            },
-
-            // auditRevisionTokensSavedLabel renders the savings as a compact
-            // pill label (e.g. "-12.3K tokens"), or '' when nothing was saved.
-            auditRevisionTokensSavedLabel(revision) {
-                const saved = this.auditRevisionTokensSaved(revision);
-                if (saved <= 0) return '';
-                const amount = typeof this.formatTokensShort === 'function'
-                    ? this.formatTokensShort(saved)
-                    : String(saved);
-                return '-' + amount + ' tokens';
-            },
-
             // auditRevisionPercentLabel renders how much of the request body
-            // this revision removed (e.g. "-21%"), or '' when sizes are
+            // this revision removed (e.g. "-44%"), or '' when sizes are
             // missing or the revision didn't shrink the body.
             auditRevisionPercentLabel(revision) {
                 const before = Number(revision && revision.bytes_before);
@@ -573,42 +550,6 @@
                 if (!Number.isFinite(before) || !Number.isFinite(after) || before <= 0 || after >= before) return '';
                 const pct = (1 - after / before) * 100;
                 return '-' + (pct >= 10 ? String(Math.round(pct)) : pct.toFixed(1)) + '%';
-            },
-
-            // auditRevisionCostSavedLabel renders this revision's share of the
-            // request's priced rewrite savings (e.g. "~$0.0372"), or '' when
-            // usage tracking recorded no cost. The cost lives on the entry's
-            // usage summary (it is priced per request, not per revision), so
-            // it is apportioned by each revision's share of the saved tokens.
-            auditRevisionCostSavedLabel(entry, revision) {
-                const cost = Number(entry && entry.usage && entry.usage.rewrite_cost_saved);
-                if (!Number.isFinite(cost) || cost <= 0) return '';
-                const revisionTokens = this.auditRevisionTokensSaved(revision);
-                if (revisionTokens <= 0) return '';
-                const totalTokens = this.auditRequestRevisions(entry)
-                    .reduce((sum, r) => sum + this.auditRevisionTokensSaved(r), 0);
-                const share = totalTokens > revisionTokens ? revisionTokens / totalTokens : 1;
-                const amount = cost * share;
-                if (typeof this.formatCost === 'function') {
-                    const label = this.formatCost(amount);
-                    return label.startsWith('<') ? label : '~' + label;
-                }
-                return '~$' + amount.toFixed(4);
-            },
-
-            // auditRevisionSavingsLabel combines tokens, percent of body
-            // removed, and priced savings into the Rewritten tab's pill label
-            // (e.g. "-12.3K tokens · -21% · ~$0.0372"). Tokens gate the pill;
-            // the other segments render only when their data is available.
-            auditRevisionSavingsLabel(entry, revision) {
-                const tokens = this.auditRevisionTokensSavedLabel(revision);
-                if (!tokens) return '';
-                const parts = [tokens];
-                const percent = this.auditRevisionPercentLabel(revision);
-                if (percent) parts.push(percent);
-                const cost = this.auditRevisionCostSavedLabel(entry, revision);
-                if (cost) parts.push(cost);
-                return parts.join(' · ');
             },
 
             // auditRequestRevisionPane renders one ingress rewrite: a structured
@@ -632,7 +573,7 @@
                     direction: 'request',
                     seq: single ? 0 : Number(revision && revision.seq || 0),
                     kind: (revision && revision.rewriter) ? String(revision.rewriter) : '',
-                    tokensSavedLabel: this.auditRevisionSavingsLabel(entry, revision),
+                    savingsLabel: this.auditRevisionPercentLabel(revision),
                     layout: 'split',
                     entry,
                     copyHeaders: summary,

--- a/internal/admin/dashboard/static/js/modules/audit-list.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/audit-list.test.cjs
@@ -955,7 +955,7 @@ test('auditPanes inserts request revision tabs between request and response', ()
     assert.equal(pane.headersTitle, 'What changed');
     assert.equal(pane.headers.bytes, '1572 → 1249');
     assert.equal(pane.headers.detail.tokens_saved_estimate, 89);
-    assert.equal(pane.tokensSavedLabel, '-89 tokens');
+    assert.equal(pane.tokensSavedLabel, '-89 tokens · -21%'); // no usage summary → no cost segment
     assert.equal(pane.showBody, true);
     assert.equal(pane.showTooLarge, false);
 
@@ -987,6 +987,62 @@ test('auditRevisionTokensSavedLabel reports rewrite savings as a pill label', ()
     // Large counts use the dashboard's short token format when available.
     module.formatTokensShort = (n) => (n >= 1000 ? (n / 1000).toFixed(1) + 'K' : String(n));
     assert.equal(module.auditRevisionTokensSavedLabel({ tokens_saved: 12340 }), '-12.3K tokens');
+});
+
+test('auditRevisionPercentLabel reports the share of the body removed', () => {
+    const module = createAuditListModule();
+    assert.equal(module.auditRevisionPercentLabel({ bytes_before: 1572, bytes_after: 1249 }), '-21%');
+    assert.equal(module.auditRevisionPercentLabel({ bytes_before: 1000, bytes_after: 954 }), '-4.6%');
+    // Missing sizes or a revision that grew the body renders no percent.
+    assert.equal(module.auditRevisionPercentLabel({ bytes_before: 0, bytes_after: 10 }), '');
+    assert.equal(module.auditRevisionPercentLabel({ bytes_before: 100, bytes_after: 120 }), '');
+    assert.equal(module.auditRevisionPercentLabel({}), '');
+    assert.equal(module.auditRevisionPercentLabel(null), '');
+});
+
+test('auditRevisionCostSavedLabel apportions the priced savings per revision', () => {
+    const module = createAuditListModule();
+    const entry = {
+        usage: { rewrite_cost_saved: 0.03 },
+        data: {
+            request_revisions: [
+                { seq: 1, rewriter: 'a', tokens_saved: 75 },
+                { seq: 2, rewriter: 'b', tokens_saved: 25 }
+            ]
+        }
+    };
+    // 75/100 and 25/100 of $0.03.
+    assert.equal(module.auditRevisionCostSavedLabel(entry, entry.data.request_revisions[0]), '~$0.0225');
+    assert.equal(module.auditRevisionCostSavedLabel(entry, entry.data.request_revisions[1]), '~$0.0075');
+
+    // A single saving revision gets the full amount.
+    const single = { usage: { rewrite_cost_saved: 0.03 }, data: { request_revisions: [{ seq: 1, tokens_saved: 89 }] } };
+    assert.equal(module.auditRevisionCostSavedLabel(single, single.data.request_revisions[0]), '~$0.0300');
+
+    // No usage summary, no priced savings, or no revision tokens → no label.
+    assert.equal(module.auditRevisionCostSavedLabel({}, { tokens_saved: 89 }), '');
+    assert.equal(module.auditRevisionCostSavedLabel({ usage: { rewrite_cost_saved: 0 } }, { tokens_saved: 89 }), '');
+    assert.equal(module.auditRevisionCostSavedLabel(single, { tokens_saved: 0 }), '');
+
+    // The dashboard's cost formatter is used when available.
+    module.formatCost = (v) => (v > 0 && v < 0.0001 ? '<$0.0001' : '$' + v.toFixed(4).replace(/(\.\d{2}\d*?)0+$/, '$1'));
+    assert.equal(module.auditRevisionCostSavedLabel(single, single.data.request_revisions[0]), '~$0.03');
+    const tiny = { usage: { rewrite_cost_saved: 0.00005 }, data: { request_revisions: [{ seq: 1, tokens_saved: 5 }] } };
+    assert.equal(module.auditRevisionCostSavedLabel(tiny, tiny.data.request_revisions[0]), '<$0.0001');
+});
+
+test('auditRevisionSavingsLabel combines tokens, percent, and cost segments', () => {
+    const module = createAuditListModule();
+    const revision = { seq: 1, rewriter: 'pro-token-compression', bytes_before: 1572, bytes_after: 1249, tokens_saved: 89 };
+    const entry = { usage: { rewrite_cost_saved: 0.0372 }, data: { request_revisions: [revision] } };
+    assert.equal(module.auditRevisionSavingsLabel(entry, revision), '-89 tokens · -21% · ~$0.0372');
+
+    // Tokens gate the pill: no tokens saved → empty even with usage costs.
+    assert.equal(module.auditRevisionSavingsLabel(entry, { seq: 2, bytes_before: 100, bytes_after: 80 }), '');
+
+    // Missing segments degrade gracefully.
+    const bare = { seq: 1, tokens_saved: 89 };
+    assert.equal(module.auditRevisionSavingsLabel({ data: { request_revisions: [bare] } }, bare), '-89 tokens');
 });
 
 test('entries without revisions render no revision tabs', () => {

--- a/internal/admin/dashboard/static/js/modules/audit-list.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/audit-list.test.cjs
@@ -955,7 +955,7 @@ test('auditPanes inserts request revision tabs between request and response', ()
     assert.equal(pane.headersTitle, 'What changed');
     assert.equal(pane.headers.bytes, '1572 → 1249');
     assert.equal(pane.headers.detail.tokens_saved_estimate, 89);
-    assert.equal(pane.tokensSavedLabel, '-89 tokens · -21%'); // no usage summary → no cost segment
+    assert.equal(pane.savingsLabel, '-21%');
     assert.equal(pane.showBody, true);
     assert.equal(pane.showTooLarge, false);
 
@@ -963,7 +963,6 @@ test('auditPanes inserts request revision tabs between request and response', ()
     const bare = module.auditRequestRevisionPane(entry, { seq: 2, rewriter: 'x', bytes_before: 10, bytes_after: 8 });
     assert.equal(bare.showBody, false);
     assert.equal(bare.showTooLarge, true);
-    assert.equal(bare.tokensSavedLabel, '');
 
     // Multiple revisions keep their sequence chips and stable tab ids.
     entry.data.request_revisions = [revision, { ...revision, seq: 2 }];
@@ -971,78 +970,16 @@ test('auditPanes inserts request revision tabs between request and response', ()
     assert.equal(module.auditRequestRevisionPane(entry, revision).seq, 1);
 });
 
-test('auditRevisionTokensSavedLabel reports rewrite savings as a pill label', () => {
-    const module = createAuditListModule();
-    // The typed field wins; the compression report estimate inside detail is
-    // the fallback for entries recorded before tokens_saved existed.
-    assert.equal(module.auditRevisionTokensSavedLabel({ tokens_saved: 89 }), '-89 tokens');
-    assert.equal(module.auditRevisionTokensSavedLabel({ detail: { tokens_saved_estimate: 42 } }), '-42 tokens');
-    assert.equal(module.auditRevisionTokensSavedLabel({ tokens_saved: 89, detail: { tokens_saved_estimate: 42 } }), '-89 tokens');
-
-    // No savings renders no pill.
-    assert.equal(module.auditRevisionTokensSavedLabel({}), '');
-    assert.equal(module.auditRevisionTokensSavedLabel({ tokens_saved: 0 }), '');
-    assert.equal(module.auditRevisionTokensSavedLabel(null), '');
-
-    // Large counts use the dashboard's short token format when available.
-    module.formatTokensShort = (n) => (n >= 1000 ? (n / 1000).toFixed(1) + 'K' : String(n));
-    assert.equal(module.auditRevisionTokensSavedLabel({ tokens_saved: 12340 }), '-12.3K tokens');
-});
-
 test('auditRevisionPercentLabel reports the share of the body removed', () => {
     const module = createAuditListModule();
     assert.equal(module.auditRevisionPercentLabel({ bytes_before: 1572, bytes_after: 1249 }), '-21%');
+    assert.equal(module.auditRevisionPercentLabel({ bytes_before: 1000, bytes_after: 560 }), '-44%');
     assert.equal(module.auditRevisionPercentLabel({ bytes_before: 1000, bytes_after: 954 }), '-4.6%');
     // Missing sizes or a revision that grew the body renders no percent.
     assert.equal(module.auditRevisionPercentLabel({ bytes_before: 0, bytes_after: 10 }), '');
     assert.equal(module.auditRevisionPercentLabel({ bytes_before: 100, bytes_after: 120 }), '');
     assert.equal(module.auditRevisionPercentLabel({}), '');
     assert.equal(module.auditRevisionPercentLabel(null), '');
-});
-
-test('auditRevisionCostSavedLabel apportions the priced savings per revision', () => {
-    const module = createAuditListModule();
-    const entry = {
-        usage: { rewrite_cost_saved: 0.03 },
-        data: {
-            request_revisions: [
-                { seq: 1, rewriter: 'a', tokens_saved: 75 },
-                { seq: 2, rewriter: 'b', tokens_saved: 25 }
-            ]
-        }
-    };
-    // 75/100 and 25/100 of $0.03.
-    assert.equal(module.auditRevisionCostSavedLabel(entry, entry.data.request_revisions[0]), '~$0.0225');
-    assert.equal(module.auditRevisionCostSavedLabel(entry, entry.data.request_revisions[1]), '~$0.0075');
-
-    // A single saving revision gets the full amount.
-    const single = { usage: { rewrite_cost_saved: 0.03 }, data: { request_revisions: [{ seq: 1, tokens_saved: 89 }] } };
-    assert.equal(module.auditRevisionCostSavedLabel(single, single.data.request_revisions[0]), '~$0.0300');
-
-    // No usage summary, no priced savings, or no revision tokens → no label.
-    assert.equal(module.auditRevisionCostSavedLabel({}, { tokens_saved: 89 }), '');
-    assert.equal(module.auditRevisionCostSavedLabel({ usage: { rewrite_cost_saved: 0 } }, { tokens_saved: 89 }), '');
-    assert.equal(module.auditRevisionCostSavedLabel(single, { tokens_saved: 0 }), '');
-
-    // The dashboard's cost formatter is used when available.
-    module.formatCost = (v) => (v > 0 && v < 0.0001 ? '<$0.0001' : '$' + v.toFixed(4).replace(/(\.\d{2}\d*?)0+$/, '$1'));
-    assert.equal(module.auditRevisionCostSavedLabel(single, single.data.request_revisions[0]), '~$0.03');
-    const tiny = { usage: { rewrite_cost_saved: 0.00005 }, data: { request_revisions: [{ seq: 1, tokens_saved: 5 }] } };
-    assert.equal(module.auditRevisionCostSavedLabel(tiny, tiny.data.request_revisions[0]), '<$0.0001');
-});
-
-test('auditRevisionSavingsLabel combines tokens, percent, and cost segments', () => {
-    const module = createAuditListModule();
-    const revision = { seq: 1, rewriter: 'pro-token-compression', bytes_before: 1572, bytes_after: 1249, tokens_saved: 89 };
-    const entry = { usage: { rewrite_cost_saved: 0.0372 }, data: { request_revisions: [revision] } };
-    assert.equal(module.auditRevisionSavingsLabel(entry, revision), '-89 tokens · -21% · ~$0.0372');
-
-    // Tokens gate the pill: no tokens saved → empty even with usage costs.
-    assert.equal(module.auditRevisionSavingsLabel(entry, { seq: 2, bytes_before: 100, bytes_after: 80 }), '');
-
-    // Missing segments degrade gracefully.
-    const bare = { seq: 1, tokens_saved: 89 };
-    assert.equal(module.auditRevisionSavingsLabel({ data: { request_revisions: [bare] } }, bare), '-89 tokens');
 });
 
 test('entries without revisions render no revision tabs', () => {

--- a/internal/admin/dashboard/static/js/modules/audit-list.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/audit-list.test.cjs
@@ -955,6 +955,7 @@ test('auditPanes inserts request revision tabs between request and response', ()
     assert.equal(pane.headersTitle, 'What changed');
     assert.equal(pane.headers.bytes, '1572 → 1249');
     assert.equal(pane.headers.detail.tokens_saved_estimate, 89);
+    assert.equal(pane.tokensSavedLabel, '-89 tokens');
     assert.equal(pane.showBody, true);
     assert.equal(pane.showTooLarge, false);
 
@@ -962,11 +963,30 @@ test('auditPanes inserts request revision tabs between request and response', ()
     const bare = module.auditRequestRevisionPane(entry, { seq: 2, rewriter: 'x', bytes_before: 10, bytes_after: 8 });
     assert.equal(bare.showBody, false);
     assert.equal(bare.showTooLarge, true);
+    assert.equal(bare.tokensSavedLabel, '');
 
     // Multiple revisions keep their sequence chips and stable tab ids.
     entry.data.request_revisions = [revision, { ...revision, seq: 2 }];
     assert.equal(module.auditPanes(entry).map((p) => p.id).join(','), 'request,revision-1,revision-2,response');
     assert.equal(module.auditRequestRevisionPane(entry, revision).seq, 1);
+});
+
+test('auditRevisionTokensSavedLabel reports rewrite savings as a pill label', () => {
+    const module = createAuditListModule();
+    // The typed field wins; the compression report estimate inside detail is
+    // the fallback for entries recorded before tokens_saved existed.
+    assert.equal(module.auditRevisionTokensSavedLabel({ tokens_saved: 89 }), '-89 tokens');
+    assert.equal(module.auditRevisionTokensSavedLabel({ detail: { tokens_saved_estimate: 42 } }), '-42 tokens');
+    assert.equal(module.auditRevisionTokensSavedLabel({ tokens_saved: 89, detail: { tokens_saved_estimate: 42 } }), '-89 tokens');
+
+    // No savings renders no pill.
+    assert.equal(module.auditRevisionTokensSavedLabel({}), '');
+    assert.equal(module.auditRevisionTokensSavedLabel({ tokens_saved: 0 }), '');
+    assert.equal(module.auditRevisionTokensSavedLabel(null), '');
+
+    // Large counts use the dashboard's short token format when available.
+    module.formatTokensShort = (n) => (n >= 1000 ? (n / 1000).toFixed(1) + 'K' : String(n));
+    assert.equal(module.auditRevisionTokensSavedLabel({ tokens_saved: 12340 }), '-12.3K tokens');
 });
 
 test('entries without revisions render no revision tabs', () => {

--- a/internal/admin/dashboard/templates/page-audit-logs.html
+++ b/internal/admin/dashboard/templates/page-audit-logs.html
@@ -116,6 +116,7 @@
                                             <span class="audit-pane-tab-label" x-text="p.pane.title"></span>
                                             <span class="audit-pane-seq mono" x-show="p.pane.seq" x-text="'#' + p.pane.seq"></span>
                                             <span class="provider-badge audit-pane-kind" :class="'audit-pane-kind-' + (p.pane.kind || '')" x-show="p.pane.kind" x-text="p.pane.kind"></span>
+                                            <span class="audit-tokens-saved-pill mono" x-show="p.pane.tokensSavedLabel" x-text="p.pane.tokensSavedLabel" title="Estimated prompt tokens saved by this rewrite"></span>
                                             <span class="audit-status-badge" :class="statusCodeClass(p.pane.statusCode)" x-show="p.pane.statusCode" x-text="p.pane.statusCode"></span>
                                         </button>
                                     </template>

--- a/internal/admin/dashboard/templates/page-audit-logs.html
+++ b/internal/admin/dashboard/templates/page-audit-logs.html
@@ -116,7 +116,7 @@
                                             <span class="audit-pane-tab-label" x-text="p.pane.title"></span>
                                             <span class="audit-pane-seq mono" x-show="p.pane.seq" x-text="'#' + p.pane.seq"></span>
                                             <span class="provider-badge audit-pane-kind" :class="'audit-pane-kind-' + (p.pane.kind || '')" x-show="p.pane.kind" x-text="p.pane.kind"></span>
-                                            <span class="audit-tokens-saved-pill mono" x-show="p.pane.tokensSavedLabel" x-text="p.pane.tokensSavedLabel" title="Estimated rewrite savings: prompt tokens, share of request body removed, and input cost"></span>
+                                            <span class="audit-savings-pill mono" x-show="p.pane.savingsLabel" x-text="p.pane.savingsLabel" title="Share of the request body removed by this rewrite"></span>
                                             <span class="audit-status-badge" :class="statusCodeClass(p.pane.statusCode)" x-show="p.pane.statusCode" x-text="p.pane.statusCode"></span>
                                         </button>
                                     </template>

--- a/internal/admin/dashboard/templates/page-audit-logs.html
+++ b/internal/admin/dashboard/templates/page-audit-logs.html
@@ -116,7 +116,7 @@
                                             <span class="audit-pane-tab-label" x-text="p.pane.title"></span>
                                             <span class="audit-pane-seq mono" x-show="p.pane.seq" x-text="'#' + p.pane.seq"></span>
                                             <span class="provider-badge audit-pane-kind" :class="'audit-pane-kind-' + (p.pane.kind || '')" x-show="p.pane.kind" x-text="p.pane.kind"></span>
-                                            <span class="audit-tokens-saved-pill mono" x-show="p.pane.tokensSavedLabel" x-text="p.pane.tokensSavedLabel" title="Estimated prompt tokens saved by this rewrite"></span>
+                                            <span class="audit-tokens-saved-pill mono" x-show="p.pane.tokensSavedLabel" x-text="p.pane.tokensSavedLabel" title="Estimated rewrite savings: prompt tokens, share of request body removed, and input cost"></span>
                                             <span class="audit-status-badge" :class="statusCodeClass(p.pane.statusCode)" x-show="p.pane.statusCode" x-text="p.pane.statusCode"></span>
                                         </button>
                                     </template>

--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -193,6 +193,11 @@ type RequestRevisionSnapshot struct {
 	BytesBefore int    `json:"bytes_before" bson:"bytes_before"`
 	BytesAfter  int    `json:"bytes_after" bson:"bytes_after"`
 
+	// TokensSaved is the rewriter-reported estimate of prompt tokens this
+	// revision saved (e.g. token compression); zero when the rewriter does
+	// not report savings.
+	TokensSaved int `json:"tokens_saved,omitempty" bson:"tokens_saved,omitempty"`
+
 	// Body is the request body after this revision (parsed JSON, or a string
 	// when not valid JSON). Populated only when body logging is enabled and
 	// the body is within the capture limit.

--- a/internal/server/request_rewrite.go
+++ b/internal/server/request_rewrite.go
@@ -137,6 +137,7 @@ func recordRequestRevision(c *echo.Context, auditLogger auditlog.LoggerInterface
 		Rewriter:    name,
 		BytesBefore: bytesBefore,
 		BytesAfter:  len(res.Body),
+		TokensSaved: res.TokensSaved,
 		Detail:      res.Detail,
 	}
 	if cfg.LogBodies && int64(len(res.Body)) <= auditlog.MaxBodyCapture {

--- a/internal/usage/reader.go
+++ b/internal/usage/reader.go
@@ -275,6 +275,8 @@ type UsageLogEntry struct {
 	CostSource             string         `json:"cost_source,omitempty"`
 	RawData                map[string]any `json:"raw_data,omitempty"`
 	CostsCalculationCaveat string         `json:"costs_calculation_caveat,omitempty"`
+	RewriteTokensSaved     int64          `json:"rewrite_tokens_saved,omitempty"`
+	RewriteCostSaved       *float64       `json:"rewrite_cost_saved,omitempty"`
 }
 
 // EnrichUsageLogEntry populates the derived provider-cache fields on entry
@@ -309,15 +311,17 @@ type UsageLogResult struct {
 // cached prompt reads and cache writes are included even when the upstream provider
 // reports them outside the base input token count.
 type RequestUsageSummary struct {
-	Entries                   int     `json:"entries"`
-	InputTokens               int64   `json:"input_tokens"`
-	UncachedInputTokens       int64   `json:"uncached_input_tokens"`
-	CachedInputTokens         int64   `json:"cached_input_tokens"`
-	CacheWriteInputTokens     int64   `json:"cache_write_input_tokens"`
-	OutputTokens              int64   `json:"output_tokens"`
-	TotalTokens               int64   `json:"total_tokens"`
-	CachedInputRatio          float64 `json:"cached_input_ratio"`
-	EstimatedCachedCharacters int64   `json:"estimated_cached_characters"`
+	Entries                   int      `json:"entries"`
+	InputTokens               int64    `json:"input_tokens"`
+	UncachedInputTokens       int64    `json:"uncached_input_tokens"`
+	CachedInputTokens         int64    `json:"cached_input_tokens"`
+	CacheWriteInputTokens     int64    `json:"cache_write_input_tokens"`
+	OutputTokens              int64    `json:"output_tokens"`
+	TotalTokens               int64    `json:"total_tokens"`
+	CachedInputRatio          float64  `json:"cached_input_ratio"`
+	EstimatedCachedCharacters int64    `json:"estimated_cached_characters"`
+	RewriteTokensSaved        int64    `json:"rewrite_tokens_saved,omitempty"`
+	RewriteCostSaved          *float64 `json:"rewrite_cost_saved,omitempty"`
 }
 
 // CacheOverviewSummary holds cached-only aggregate statistics over a time period.

--- a/internal/usage/reader_mongodb.go
+++ b/internal/usage/reader_mongodb.go
@@ -37,6 +37,8 @@ type mongoUsageLogRow struct {
 	CostSource             string         `bson:"cost_source"`
 	RawData                map[string]any `bson:"raw_data"`
 	CostsCalculationCaveat string         `bson:"costs_calculation_caveat"`
+	RewriteTokensSaved     int64          `bson:"rewrite_tokens_saved"`
+	RewriteCostSaved       *float64       `bson:"rewrite_cost_saved"`
 }
 
 func (row mongoUsageLogRow) toUsageLogEntry() UsageLogEntry {
@@ -61,6 +63,8 @@ func (row mongoUsageLogRow) toUsageLogEntry() UsageLogEntry {
 		CostSource:             row.CostSource,
 		RawData:                row.RawData,
 		CostsCalculationCaveat: row.CostsCalculationCaveat,
+		RewriteTokensSaved:     row.RewriteTokensSaved,
+		RewriteCostSaved:       row.RewriteCostSaved,
 	}
 }
 

--- a/internal/usage/reader_mongodb_test.go
+++ b/internal/usage/reader_mongodb_test.go
@@ -109,3 +109,63 @@ func TestMongoUsageLogMatchFiltersEscapesSearchRegex(t *testing.T) {
 		t.Fatalf("mongoUsageLogMatchFilters() = %#v, want %#v", got, want)
 	}
 }
+
+// Locks the BSON-to-field mapping for the rewrite-savings columns on the
+// Mongo decode path: rewrite_tokens_saved and rewrite_cost_saved must reach
+// UsageLogEntry, and a document without them must decode to zero/nil.
+func TestMongoUsageLogRowDecodesRewriteSavings(t *testing.T) {
+	cost := 0.0375
+	cases := []struct {
+		name       string
+		doc        bson.D
+		wantTokens int64
+		wantCost   *float64
+	}{
+		{
+			name: "with priced savings",
+			doc: bson.D{
+				{Key: "_id", Value: "with-savings"},
+				{Key: "request_id", Value: "req-saved"},
+				{Key: "rewrite_tokens_saved", Value: int64(89)},
+				{Key: "rewrite_cost_saved", Value: cost},
+			},
+			wantTokens: 89,
+			wantCost:   &cost,
+		},
+		{
+			name: "without savings",
+			doc: bson.D{
+				{Key: "_id", Value: "without-savings"},
+				{Key: "request_id", Value: "req-plain"},
+			},
+			wantTokens: 0,
+			wantCost:   nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := bson.Marshal(tc.doc)
+			if err != nil {
+				t.Fatalf("bson.Marshal() error = %v", err)
+			}
+			var row mongoUsageLogRow
+			if err := bson.Unmarshal(raw, &row); err != nil {
+				t.Fatalf("bson.Unmarshal() error = %v", err)
+			}
+			entry := row.toUsageLogEntry()
+			if entry.RewriteTokensSaved != tc.wantTokens {
+				t.Errorf("RewriteTokensSaved = %d, want %d", entry.RewriteTokensSaved, tc.wantTokens)
+			}
+			switch {
+			case tc.wantCost == nil:
+				if entry.RewriteCostSaved != nil {
+					t.Errorf("RewriteCostSaved = %v, want nil", *entry.RewriteCostSaved)
+				}
+			case entry.RewriteCostSaved == nil:
+				t.Errorf("RewriteCostSaved = nil, want %v", *tc.wantCost)
+			case *entry.RewriteCostSaved != *tc.wantCost:
+				t.Errorf("RewriteCostSaved = %v, want %v", *entry.RewriteCostSaved, *tc.wantCost)
+			}
+		})
+	}
+}

--- a/internal/usage/reader_postgresql.go
+++ b/internal/usage/reader_postgresql.go
@@ -213,7 +213,8 @@ func (r *PostgreSQLReader) GetUsageLog(ctx context.Context, params UsageLogParam
 
 	// Fetch page
 	dataQuery := fmt.Sprintf(`SELECT id, request_id, provider_id, timestamp, model, provider, provider_name, endpoint, user_path, cache_type, labels,
-		input_tokens, output_tokens, total_tokens, input_cost, output_cost, total_cost, COALESCE(cost_source, ''), raw_data, COALESCE(costs_calculation_caveat, '')
+		input_tokens, output_tokens, total_tokens, input_cost, output_cost, total_cost, COALESCE(cost_source, ''), raw_data, COALESCE(costs_calculation_caveat, ''),
+		COALESCE(rewrite_tokens_saved, 0), rewrite_cost_saved
 		FROM "usage"%s ORDER BY timestamp DESC LIMIT $%d OFFSET $%d`, where, argIdx, argIdx+1)
 	dataArgs := append(append([]any(nil), args...), limit, offset)
 
@@ -255,7 +256,8 @@ func (r *PostgreSQLReader) GetUsageByRequestIDs(ctx context.Context, requestIDs 
 	}
 
 	query := fmt.Sprintf(`SELECT id, request_id, provider_id, timestamp, model, provider, provider_name, endpoint, user_path, cache_type, labels,
-		input_tokens, output_tokens, total_tokens, input_cost, output_cost, total_cost, COALESCE(cost_source, ''), raw_data, COALESCE(costs_calculation_caveat, '')
+		input_tokens, output_tokens, total_tokens, input_cost, output_cost, total_cost, COALESCE(cost_source, ''), raw_data, COALESCE(costs_calculation_caveat, ''),
+		COALESCE(rewrite_tokens_saved, 0), rewrite_cost_saved
 		FROM "usage" WHERE request_id IN (%s) ORDER BY timestamp DESC, id DESC`, strings.Join(placeholders, ", "))
 
 	rows, err := r.pool.Query(ctx, query, args...)
@@ -289,7 +291,8 @@ func scanPostgreSQLUsageLogEntries(rows pgxRows) ([]UsageLogEntry, error) {
 		var cacheType *string
 		var labelsJSON *string
 		if err := rows.Scan(&e.ID, &e.RequestID, &e.ProviderID, &e.Timestamp, &e.Model, &e.Provider, &providerName, &e.Endpoint, &userPath, &cacheType, &labelsJSON,
-			&e.InputTokens, &e.OutputTokens, &e.TotalTokens, &e.InputCost, &e.OutputCost, &e.TotalCost, &e.CostSource, &rawDataJSON, &e.CostsCalculationCaveat); err != nil {
+			&e.InputTokens, &e.OutputTokens, &e.TotalTokens, &e.InputCost, &e.OutputCost, &e.TotalCost, &e.CostSource, &rawDataJSON, &e.CostsCalculationCaveat,
+			&e.RewriteTokensSaved, &e.RewriteCostSaved); err != nil {
 			return nil, fmt.Errorf("failed to scan usage log row: %w", err)
 		}
 		if labelsJSON != nil {

--- a/internal/usage/reader_postgresql_test.go
+++ b/internal/usage/reader_postgresql_test.go
@@ -1,0 +1,81 @@
+package usage
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// fakePgxRows feeds scanPostgreSQLUsageLogEntries rows whose values are laid
+// out in the reader's SELECT column order. Scan assigns via reflection and
+// leaves the destination untouched for nil values, matching how pgx scans SQL
+// NULL into pointer targets. A row/dest length mismatch errors so the fixtures
+// must track the scan target list.
+type fakePgxRows struct {
+	rows [][]any
+	idx  int
+}
+
+func (f *fakePgxRows) Next() bool {
+	if f.idx >= len(f.rows) {
+		return false
+	}
+	f.idx++
+	return true
+}
+
+func (f *fakePgxRows) Scan(dest ...any) error {
+	row := f.rows[f.idx-1]
+	if len(dest) != len(row) {
+		return fmt.Errorf("scan target count %d does not match fixture column count %d", len(dest), len(row))
+	}
+	for i, value := range row {
+		if value == nil {
+			continue
+		}
+		reflect.ValueOf(dest[i]).Elem().Set(reflect.ValueOf(value))
+	}
+	return nil
+}
+
+// Covers the row-scanning half of the PostgreSQL usage log queries, pinning
+// the rewrite-savings columns appended to the SELECT list: id, request_id,
+// provider_id, timestamp, model, provider, provider_name, endpoint, user_path,
+// cache_type, labels, input_tokens, output_tokens, total_tokens, input_cost,
+// output_cost, total_cost, cost_source, raw_data, costs_calculation_caveat,
+// rewrite_tokens_saved, rewrite_cost_saved.
+func TestScanPostgreSQLUsageLogEntries_CarriesRewriteSavings(t *testing.T) {
+	cost := 0.0375
+	ts := time.Date(2026, 1, 16, 12, 0, 0, 0, time.UTC)
+	rows := &fakePgxRows{rows: [][]any{
+		{"with-savings", "req-saved", "provider-1", ts, "gpt-5", "openai", nil, "/v1/chat/completions", nil, nil, nil,
+			100, 10, 110, nil, nil, nil, "", nil, "", int64(89), &cost},
+		{"without-savings", "req-plain", "provider-2", ts, "gpt-5", "openai", nil, "/v1/chat/completions", nil, nil, nil,
+			50, 10, 60, nil, nil, nil, "", nil, "", int64(0), nil},
+	}}
+
+	entries, err := scanPostgreSQLUsageLogEntries(rows)
+	if err != nil {
+		t.Fatalf("scanPostgreSQLUsageLogEntries() error = %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("scanPostgreSQLUsageLogEntries() returned %d entries, want 2", len(entries))
+	}
+
+	saved := entries[0]
+	if saved.RewriteTokensSaved != 89 {
+		t.Errorf("RewriteTokensSaved = %d, want 89", saved.RewriteTokensSaved)
+	}
+	if saved.RewriteCostSaved == nil || *saved.RewriteCostSaved != cost {
+		t.Errorf("RewriteCostSaved = %v, want %v", saved.RewriteCostSaved, cost)
+	}
+
+	plain := entries[1]
+	if plain.RewriteTokensSaved != 0 {
+		t.Errorf("RewriteTokensSaved = %d, want 0", plain.RewriteTokensSaved)
+	}
+	if plain.RewriteCostSaved != nil {
+		t.Errorf("RewriteCostSaved = %v, want nil", *plain.RewriteCostSaved)
+	}
+}

--- a/internal/usage/reader_sqlite.go
+++ b/internal/usage/reader_sqlite.go
@@ -205,7 +205,8 @@ func (r *SQLiteReader) GetUsageLog(ctx context.Context, params UsageLogParams) (
 
 	// Fetch page
 	dataQuery := `SELECT id, request_id, provider_id, timestamp, model, provider, provider_name, endpoint, user_path, cache_type, labels,
-		input_tokens, output_tokens, total_tokens, input_cost, output_cost, total_cost, COALESCE(cost_source, ''), raw_data, COALESCE(costs_calculation_caveat, '')
+		input_tokens, output_tokens, total_tokens, input_cost, output_cost, total_cost, COALESCE(cost_source, ''), raw_data, COALESCE(costs_calculation_caveat, ''),
+		COALESCE(rewrite_tokens_saved, 0), rewrite_cost_saved
 		FROM usage` + where + ` ORDER BY ` + sqliteTimestampEpochExpr() + ` DESC, id DESC LIMIT ? OFFSET ?`
 	dataArgs := append(append([]any(nil), args...), limit, offset)
 
@@ -246,7 +247,8 @@ func (r *SQLiteReader) GetUsageByRequestIDs(ctx context.Context, requestIDs []st
 	}
 
 	query := `SELECT id, request_id, provider_id, timestamp, model, provider, provider_name, endpoint, user_path, cache_type, labels,
-		input_tokens, output_tokens, total_tokens, input_cost, output_cost, total_cost, COALESCE(cost_source, ''), raw_data, COALESCE(costs_calculation_caveat, '')
+		input_tokens, output_tokens, total_tokens, input_cost, output_cost, total_cost, COALESCE(cost_source, ''), raw_data, COALESCE(costs_calculation_caveat, ''),
+		COALESCE(rewrite_tokens_saved, 0), rewrite_cost_saved
 		FROM usage WHERE request_id IN (` + placeholders + `) ORDER BY ` + sqliteTimestampEpochExpr() + ` DESC, id DESC`
 
 	rows, err := r.db.QueryContext(ctx, query, args...)
@@ -282,7 +284,8 @@ func scanSQLiteUsageLogEntries(rows *sql.Rows) ([]UsageLogEntry, error) {
 		var cacheType sql.NullString
 		var labelsJSON *string
 		if err := rows.Scan(&e.ID, &e.RequestID, &e.ProviderID, &ts, &e.Model, &e.Provider, &providerName, &e.Endpoint, &userPath, &cacheType, &labelsJSON,
-			&e.InputTokens, &e.OutputTokens, &e.TotalTokens, &e.InputCost, &e.OutputCost, &e.TotalCost, &e.CostSource, &rawDataJSON, &caveat); err != nil {
+			&e.InputTokens, &e.OutputTokens, &e.TotalTokens, &e.InputCost, &e.OutputCost, &e.TotalCost, &e.CostSource, &rawDataJSON, &caveat,
+			&e.RewriteTokensSaved, &e.RewriteCostSaved); err != nil {
 			return nil, fmt.Errorf("failed to scan usage log row: %w", err)
 		}
 		if labelsJSON != nil {

--- a/internal/usage/reader_sqlite_rewrite_savings_test.go
+++ b/internal/usage/reader_sqlite_rewrite_savings_test.go
@@ -1,0 +1,114 @@
+package usage
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// Covers the rewrite-savings columns on both usage log read paths: the
+// paginated GetUsageLog SELECT and the GetUsageByRequestIDs lookup that backs
+// the audit API's per-request usage summary must surface rewrite_tokens_saved
+// and the nullable rewrite_cost_saved.
+func TestSQLiteReader_UsageLogCarriesRewriteSavings(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open sqlite database: %v", err)
+	}
+	defer db.Close()
+
+	store, err := NewSQLiteStore(db, 0)
+	if err != nil {
+		t.Fatalf("failed to create sqlite store: %v", err)
+	}
+
+	cost := 0.0375
+	ctx := context.Background()
+	err = store.WriteBatch(ctx, []*UsageEntry{
+		{
+			ID:                 "with-savings",
+			RequestID:          "req-saved",
+			ProviderID:         "provider-1",
+			Timestamp:          time.Date(2026, 1, 16, 12, 0, 0, 0, time.UTC),
+			Model:              "gpt-5",
+			Provider:           "openai",
+			Endpoint:           "/v1/chat/completions",
+			InputTokens:        100,
+			OutputTokens:       10,
+			TotalTokens:        110,
+			RewriteTokensSaved: 89,
+			RewriteCostSaved:   &cost,
+		},
+		{
+			ID:           "without-savings",
+			RequestID:    "req-plain",
+			ProviderID:   "provider-2",
+			Timestamp:    time.Date(2026, 1, 16, 12, 1, 0, 0, time.UTC),
+			Model:        "gpt-5",
+			Provider:     "openai",
+			Endpoint:     "/v1/chat/completions",
+			InputTokens:  50,
+			OutputTokens: 10,
+			TotalTokens:  60,
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to write usage entries: %v", err)
+	}
+
+	reader := &SQLiteReader{db: db}
+
+	log, err := reader.GetUsageLog(ctx, UsageLogParams{})
+	if err != nil {
+		t.Fatalf("GetUsageLog() error = %v", err)
+	}
+	logByRequest := make(map[string]UsageLogEntry, len(log.Entries))
+	for _, entry := range log.Entries {
+		logByRequest[entry.RequestID] = entry
+	}
+
+	grouped, err := reader.GetUsageByRequestIDs(ctx, []string{"req-saved", "req-plain"})
+	if err != nil {
+		t.Fatalf("GetUsageByRequestIDs() error = %v", err)
+	}
+
+	cases := []struct {
+		name       string
+		requestID  string
+		wantTokens int64
+		wantCost   *float64
+	}{
+		{name: "priced savings round-trip", requestID: "req-saved", wantTokens: 89, wantCost: &cost},
+		{name: "no savings stays zero with nil cost", requestID: "req-plain", wantTokens: 0, wantCost: nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			byRequest, ok := grouped[tc.requestID]
+			if !ok || len(byRequest) != 1 {
+				t.Fatalf("GetUsageByRequestIDs()[%q] = %v, want one entry", tc.requestID, byRequest)
+			}
+			logEntry, ok := logByRequest[tc.requestID]
+			if !ok {
+				t.Fatalf("GetUsageLog() missing request %q", tc.requestID)
+			}
+			for path, entry := range map[string]UsageLogEntry{"usage log": logEntry, "by request id": byRequest[0]} {
+				if entry.RewriteTokensSaved != tc.wantTokens {
+					t.Errorf("%s RewriteTokensSaved = %d, want %d", path, entry.RewriteTokensSaved, tc.wantTokens)
+				}
+				switch {
+				case tc.wantCost == nil:
+					if entry.RewriteCostSaved != nil {
+						t.Errorf("%s RewriteCostSaved = %v, want nil", path, *entry.RewriteCostSaved)
+					}
+				case entry.RewriteCostSaved == nil:
+					t.Errorf("%s RewriteCostSaved = nil, want %v", path, *tc.wantCost)
+				case *entry.RewriteCostSaved != *tc.wantCost:
+					t.Errorf("%s RewriteCostSaved = %v, want %v", path, *entry.RewriteCostSaved, *tc.wantCost)
+				}
+			}
+		})
+	}
+}

--- a/internal/usage/request_summary.go
+++ b/internal/usage/request_summary.go
@@ -64,6 +64,14 @@ func SummarizeRequestUsage(entries []UsageLogEntry) *RequestUsageSummary {
 		summary.CachedInputTokens += cachedInput
 		summary.CacheWriteInputTokens += cacheWriteInput
 		summary.OutputTokens += int64(entry.OutputTokens)
+		summary.RewriteTokensSaved += entry.RewriteTokensSaved
+		if entry.RewriteCostSaved != nil {
+			total := *entry.RewriteCostSaved
+			if summary.RewriteCostSaved != nil {
+				total += *summary.RewriteCostSaved
+			}
+			summary.RewriteCostSaved = &total
+		}
 	}
 
 	summary.TotalTokens = summary.InputTokens + summary.OutputTokens

--- a/internal/usage/request_summary_test.go
+++ b/internal/usage/request_summary_test.go
@@ -33,6 +33,39 @@ func TestSummarizeRequestUsage_OpenAICompatibleCachedTokens(t *testing.T) {
 	}
 }
 
+func TestSummarizeRequestUsage_AggregatesRewriteSavings(t *testing.T) {
+	cost1 := 0.03125
+	cost2 := 0.015625
+	summary := SummarizeRequestUsage([]UsageLogEntry{
+		{Provider: "openai", InputTokens: 100, RewriteTokensSaved: 89, RewriteCostSaved: &cost1},
+		{Provider: "openai", InputTokens: 50, RewriteTokensSaved: 11, RewriteCostSaved: &cost2},
+	})
+	if summary == nil {
+		t.Fatal("expected non-nil summary")
+	}
+	if summary.RewriteTokensSaved != 100 {
+		t.Fatalf("RewriteTokensSaved = %d, want 100", summary.RewriteTokensSaved)
+	}
+	if summary.RewriteCostSaved == nil || *summary.RewriteCostSaved != 0.046875 {
+		t.Fatalf("RewriteCostSaved = %v, want 0.046875", summary.RewriteCostSaved)
+	}
+}
+
+func TestSummarizeRequestUsage_NoRewriteSavingsLeavesCostNil(t *testing.T) {
+	summary := SummarizeRequestUsage([]UsageLogEntry{
+		{Provider: "openai", InputTokens: 100},
+	})
+	if summary == nil {
+		t.Fatal("expected non-nil summary")
+	}
+	if summary.RewriteTokensSaved != 0 {
+		t.Fatalf("RewriteTokensSaved = %d, want 0", summary.RewriteTokensSaved)
+	}
+	if summary.RewriteCostSaved != nil {
+		t.Fatalf("RewriteCostSaved = %v, want nil", summary.RewriteCostSaved)
+	}
+}
+
 func TestSummarizeRequestUsage_AnthropicSplitCacheAccounting(t *testing.T) {
 	summary := SummarizeRequestUsage([]UsageLogEntry{
 		{

--- a/internal/usage/request_summary_test.go
+++ b/internal/usage/request_summary_test.go
@@ -33,36 +33,61 @@ func TestSummarizeRequestUsage_OpenAICompatibleCachedTokens(t *testing.T) {
 	}
 }
 
-func TestSummarizeRequestUsage_AggregatesRewriteSavings(t *testing.T) {
+func TestSummarizeRequestUsage_RewriteSavings(t *testing.T) {
 	cost1 := 0.03125
 	cost2 := 0.015625
-	summary := SummarizeRequestUsage([]UsageLogEntry{
-		{Provider: "openai", InputTokens: 100, RewriteTokensSaved: 89, RewriteCostSaved: &cost1},
-		{Provider: "openai", InputTokens: 50, RewriteTokensSaved: 11, RewriteCostSaved: &cost2},
-	})
-	if summary == nil {
-		t.Fatal("expected non-nil summary")
+	costSum := cost1 + cost2
+	cases := []struct {
+		name       string
+		entries    []UsageLogEntry
+		wantTokens int64
+		wantCost   *float64
+	}{
+		{
+			name: "aggregates tokens and cost across entries",
+			entries: []UsageLogEntry{
+				{Provider: "openai", InputTokens: 100, RewriteTokensSaved: 89, RewriteCostSaved: &cost1},
+				{Provider: "openai", InputTokens: 50, RewriteTokensSaved: 11, RewriteCostSaved: &cost2},
+			},
+			wantTokens: 100,
+			wantCost:   &costSum,
+		},
+		{
+			name: "cost priced on only one entry",
+			entries: []UsageLogEntry{
+				{Provider: "openai", InputTokens: 100, RewriteTokensSaved: 89, RewriteCostSaved: &cost1},
+				{Provider: "openai", InputTokens: 50, RewriteTokensSaved: 11},
+			},
+			wantTokens: 100,
+			wantCost:   &cost1,
+		},
+		{
+			name:       "no savings leaves cost nil",
+			entries:    []UsageLogEntry{{Provider: "openai", InputTokens: 100}},
+			wantTokens: 0,
+			wantCost:   nil,
+		},
 	}
-	if summary.RewriteTokensSaved != 100 {
-		t.Fatalf("RewriteTokensSaved = %d, want 100", summary.RewriteTokensSaved)
-	}
-	if summary.RewriteCostSaved == nil || *summary.RewriteCostSaved != 0.046875 {
-		t.Fatalf("RewriteCostSaved = %v, want 0.046875", summary.RewriteCostSaved)
-	}
-}
-
-func TestSummarizeRequestUsage_NoRewriteSavingsLeavesCostNil(t *testing.T) {
-	summary := SummarizeRequestUsage([]UsageLogEntry{
-		{Provider: "openai", InputTokens: 100},
-	})
-	if summary == nil {
-		t.Fatal("expected non-nil summary")
-	}
-	if summary.RewriteTokensSaved != 0 {
-		t.Fatalf("RewriteTokensSaved = %d, want 0", summary.RewriteTokensSaved)
-	}
-	if summary.RewriteCostSaved != nil {
-		t.Fatalf("RewriteCostSaved = %v, want nil", summary.RewriteCostSaved)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			summary := SummarizeRequestUsage(tc.entries)
+			if summary == nil {
+				t.Fatal("expected non-nil summary")
+			}
+			if summary.RewriteTokensSaved != tc.wantTokens {
+				t.Fatalf("RewriteTokensSaved = %d, want %d", summary.RewriteTokensSaved, tc.wantTokens)
+			}
+			switch {
+			case tc.wantCost == nil:
+				if summary.RewriteCostSaved != nil {
+					t.Fatalf("RewriteCostSaved = %v, want nil", *summary.RewriteCostSaved)
+				}
+			case summary.RewriteCostSaved == nil:
+				t.Fatalf("RewriteCostSaved = nil, want %v", *tc.wantCost)
+			case *summary.RewriteCostSaved != *tc.wantCost:
+				t.Fatalf("RewriteCostSaved = %v, want %v", *summary.RewriteCostSaved, *tc.wantCost)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Audit log records now show how much a request rewrite compressed the request, as a blue pill on the **Rewritten** tab right next to the rewriter badge — e.g. `-44%` beside `pro-token-compression`.

- **Pill** — the share of the request body the revision removed, computed from the revision's recorded `bytes_before`/`bytes_after`. Hidden when the revision didn't shrink the body. Styled with `--prompt-cache-color` / `--prompt-cache-color-bg` — the same `--info` blue family as the cached-tokens chart lines, with the existing per-theme tone mix keeping the text readable in both themes.
- **Recorded savings data** (not displayed, available to API consumers and future UI): the audit request-revision snapshot records the rewriter-reported savings as a typed `tokens_saved` field (from `ext.Result.TokensSaved`), and usage log entries plus the audit API's per-request usage summary now expose the stored `rewrite_tokens_saved` / `rewrite_cost_saved` columns (SQLite, PostgreSQL, MongoDB readers) — the tier-aware priced savings the Usage page reports.

The pill applies to any rewriter revision that shrank the request, not just compression.

## Test plan

- `audit-list.test.cjs`: pane exposes the percent label; percent edge cases (missing sizes, grown body, sub-10% precision) (38/38 pass)
- `request_summary_test.go`: rewrite savings aggregation across usage entries; nil cost stays nil without savings
- `go test` passes for `usage`, `admin`, `auditlog`, `server`
- Pre-commit suite (race tests, lint, dashboard JS tests, perf guard) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audit logs now show a savings pill with the share of request body removed by a rewrite.
  * Usage summaries now include rewrite-related savings metrics for tokens and estimated cost.

* **Bug Fixes**
  * Rewrite savings are now carried through consistently across log views and summaries.
  * Savings labels are hidden when the data is missing, invalid, or shows no reduction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->