### PR TITLE
fix(dashboard): hide Rate Limits nav item when the feature is disabled

### DIFF
--- a/internal/admin/dashboard/static/js/modules/budgets.js
+++ b/internal/admin/dashboard/static/js/modules/budgets.js
@@ -231,6 +231,9 @@
             },
 
             async fetchBudgetsPage() {
+                if (typeof this.ensureWorkflowRuntimeConfig === 'function') {
+                    await this.ensureWorkflowRuntimeConfig();
+                }
                 if (!this.budgetManagementEnabled()) {
                     this.budgets = [];
                     this.budgetsAvailable = false;

--- a/internal/admin/dashboard/static/js/modules/budgets.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/budgets.test.cjs
@@ -38,6 +38,33 @@ test('budgetManagementEnabled defaults on and respects the runtime flag', () => 
     assert.equal(module.budgetManagementEnabled(), false);
 });
 
+test('fetchBudgetsPage waits for the runtime flags before calling a disabled endpoint', async () => {
+    const calls = [];
+    const module = createBudgetsModule({
+        fetch(url) {
+            calls.push(url);
+            return Promise.resolve({ ok: true, json: async () => ({ budgets: [] }) });
+        }
+    });
+    module.headers = () => ({});
+    module.handleFetchResponse = () => true;
+
+    module.workflowRuntimeConfig = {};
+    module.workflowRuntimeBooleanFlag = (name, fallback) => {
+        const value = String(module.workflowRuntimeConfig[name] || '').trim().toLowerCase();
+        return value === '' ? !!fallback : value === 'on' || value === 'true' || value === '1';
+    };
+    module.ensureWorkflowRuntimeConfig = async () => {
+        await Promise.resolve();
+        module.workflowRuntimeConfig = { BUDGETS_ENABLED: 'off' };
+    };
+
+    await module.fetchBudgetsPage();
+
+    assert.deepEqual(calls, [], 'no request should be issued while budgets are disabled');
+    assert.equal(module.budgetsAvailable, false);
+});
+
 test('budgetSettingsPayload normalizes numeric values before saving', () => {
     const module = createBudgetsModule();
     module.budgetSettings = {

--- a/internal/admin/dashboard/static/js/modules/rate-limits.js
+++ b/internal/admin/dashboard/static/js/modules/rate-limits.js
@@ -222,6 +222,9 @@
             },
 
             async fetchRateLimitsPage() {
+                if (typeof this.ensureWorkflowRuntimeConfig === 'function') {
+                    await this.ensureWorkflowRuntimeConfig();
+                }
                 if (!this.rateLimitsEnabled()) {
                     this.rateLimits = [];
                     this.rateLimitsAvailable = false;

--- a/internal/admin/dashboard/static/js/modules/rate-limits.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/rate-limits.test.cjs
@@ -38,6 +38,38 @@ test('rateLimitsEnabled defaults on and respects the runtime flag', () => {
     assert.equal(module.rateLimitsEnabled(), false);
 });
 
+test('fetchRateLimitsPage waits for the runtime flags before calling a disabled endpoint', async () => {
+    const calls = [];
+    const module = createRateLimitsModule({
+        fetch(url) {
+            calls.push(url);
+            return Promise.resolve({ ok: true, json: async () => ({ rate_limits: [] }) });
+        }
+    });
+    module.headers = () => ({});
+    module.handleFetchResponse = () => true;
+
+    // Mirror the dashboard composition: the flag is unknown until the runtime
+    // config lands, and only then reports the feature as disabled. Reading the
+    // gate too early falls back to its default and hits /admin/rate-limits,
+    // which 503s when the feature is off.
+    module.workflowRuntimeConfig = {};
+    module.workflowRuntimeBooleanFlag = (name, fallback) => {
+        const value = String(module.workflowRuntimeConfig[name] || '').trim().toLowerCase();
+        return value === '' ? !!fallback : value === 'on' || value === 'true' || value === '1';
+    };
+    module.ensureWorkflowRuntimeConfig = async () => {
+        await Promise.resolve();
+        module.workflowRuntimeConfig = { RATE_LIMITS_ENABLED: 'off' };
+    };
+
+    await module.fetchRateLimitsPage();
+
+    assert.deepEqual(calls, [], 'no request should be issued while rate limits are disabled');
+    assert.equal(module.rateLimitsAvailable, false);
+    assert.equal(module.rateLimits.length, 0);
+});
+
 test('period helpers map names and seconds both ways', () => {
     const module = createRateLimitsModule();
     assert.equal(module.rateLimitPeriodSeconds('minute'), 60);

--- a/internal/admin/dashboard/static/js/modules/workflows.js
+++ b/internal/admin/dashboard/static/js/modules/workflows.js
@@ -29,6 +29,8 @@
             workflowsAvailable: true,
             workflowsLoading: false,
             workflowRuntimeConfig: {},
+            workflowRuntimeConfigLoaded: false,
+            workflowRuntimeConfigPromise: null,
             workflowError: '',
             workflowNotice: '',
             workflowFilter: '',
@@ -85,6 +87,7 @@
 	                    'LOGGING_ENABLED',
 	                    'USAGE_ENABLED',
 	                    'BUDGETS_ENABLED',
+	                    'RATE_LIMITS_ENABLED',
 	                    'GUARDRAILS_ENABLED',
 	                    'CACHE_ENABLED',
 	                    'REDIS_URL',
@@ -748,7 +751,36 @@
                 return payload;
             },
 
-            async fetchWorkflowRuntimeConfig() {
+            // Feature gates (rate limits, budgets, guardrails, ...) read
+            // workflowRuntimeConfig, but dashboardDataFetches() starts every page
+            // fetch at once. Sharing the in-flight request lets a gate await the
+            // flags rather than race them, and collapses what used to be a
+            // duplicate /admin/runtime/config GET when two callers overlap.
+            fetchWorkflowRuntimeConfig() {
+                if (this.workflowRuntimeConfigPromise) {
+                    return this.workflowRuntimeConfigPromise;
+                }
+                this.workflowRuntimeConfigPromise = this.loadWorkflowRuntimeConfig().finally(() => {
+                    this.workflowRuntimeConfigLoaded = true;
+                    this.workflowRuntimeConfigPromise = null;
+                });
+                return this.workflowRuntimeConfigPromise;
+            },
+
+            // Resolves once the runtime flags have been fetched at least once, so
+            // callers gated on a flag never fall back to its default by accident.
+            async ensureWorkflowRuntimeConfig() {
+                if (this.workflowRuntimeConfigPromise) {
+                    await this.workflowRuntimeConfigPromise;
+                    return;
+                }
+                if (this.workflowRuntimeConfigLoaded) {
+                    return;
+                }
+                await this.fetchWorkflowRuntimeConfig();
+            },
+
+            async loadWorkflowRuntimeConfig() {
                 const controller = typeof AbortController === 'function' ? new AbortController() : null;
                 const timeoutID = controller && typeof setTimeout === 'function'
                     ? setTimeout(() => controller.abort(), 10000)

--- a/internal/admin/dashboard/static/js/modules/workflows.js
+++ b/internal/admin/dashboard/static/js/modules/workflows.js
@@ -761,14 +761,15 @@
                     return this.workflowRuntimeConfigPromise;
                 }
                 this.workflowRuntimeConfigPromise = this.loadWorkflowRuntimeConfig().finally(() => {
-                    this.workflowRuntimeConfigLoaded = true;
                     this.workflowRuntimeConfigPromise = null;
                 });
                 return this.workflowRuntimeConfigPromise;
             },
 
-            // Resolves once the runtime flags have been fetched at least once, so
-            // callers gated on a flag never fall back to its default by accident.
+            // Resolves once the runtime flags have been loaded successfully at
+            // least once, so callers gated on a flag never fall back to its
+            // default by accident. A failed load leaves the flags unloaded, so
+            // the next gated caller retries rather than trusting an empty config.
             async ensureWorkflowRuntimeConfig() {
                 if (this.workflowRuntimeConfigPromise) {
                     await this.workflowRuntimeConfigPromise;
@@ -797,6 +798,7 @@
                     }
                     if (!handled) {
                         this.workflowRuntimeConfig = {};
+                        this.workflowRuntimeConfigLoaded = false;
                         return;
                     }
                     const payload = await res.json();
@@ -808,12 +810,14 @@
                         }
 	                    }
 	                    this.workflowRuntimeConfig = next;
+	                    this.workflowRuntimeConfigLoaded = true;
 	                    if (typeof this.fetchCacheOverview === 'function') {
 	                        this.fetchCacheOverview();
 	                    }
 	                } catch (e) {
 	                    console.error('Failed to fetch dashboard config:', e);
 	                    this.workflowRuntimeConfig = {};
+	                    this.workflowRuntimeConfigLoaded = false;
                 } finally {
                     if (timeoutID !== null && typeof clearTimeout === 'function') {
                         clearTimeout(timeoutID);

--- a/internal/admin/dashboard/static/js/modules/workflows.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/workflows.test.cjs
@@ -1288,6 +1288,7 @@ test('fetchWorkflowRuntimeConfig loads FAILOVER_ENABLED from the admin config en
                     LOGGING_ENABLED: 'on',
                     USAGE_ENABLED: 'off',
                     BUDGETS_ENABLED: 'on',
+                    RATE_LIMITS_ENABLED: 'off',
                     GUARDRAILS_ENABLED: 'on',
                     REDIS_URL: 'on',
                     SEMANTIC_CACHE_ENABLED: 'off',
@@ -1309,12 +1310,46 @@ test('fetchWorkflowRuntimeConfig loads FAILOVER_ENABLED from the admin config en
             LOGGING_ENABLED: 'on',
             USAGE_ENABLED: 'off',
             BUDGETS_ENABLED: 'on',
+            RATE_LIMITS_ENABLED: 'off',
             GUARDRAILS_ENABLED: 'on',
             REDIS_URL: 'on',
             SEMANTIC_CACHE_ENABLED: 'off',
             USAGE_PRICING_RECALCULATION_ENABLED: 'on'
         })
     );
+});
+
+test('fetchWorkflowRuntimeConfig shares one in-flight request and ensureWorkflowRuntimeConfig awaits it', async () => {
+    let calls = 0;
+    let settleFetch;
+    const module = createWorkflowsModule({
+        fetch() {
+            calls += 1;
+            return new Promise((resolve) => {
+                settleFetch = resolve;
+            });
+        }
+    });
+    module.headers = () => ({});
+    module.handleFetchResponse = () => true;
+
+    const first = module.fetchWorkflowRuntimeConfig();
+    const second = module.fetchWorkflowRuntimeConfig();
+    const ensured = module.ensureWorkflowRuntimeConfig();
+    assert.equal(calls, 1, 'overlapping callers must share one /admin/runtime/config request');
+    assert.equal(first, second);
+
+    settleFetch({ ok: true, json: async () => ({ RATE_LIMITS_ENABLED: 'off' }) });
+    await Promise.all([first, second, ensured]);
+
+    assert.equal(calls, 1);
+    assert.equal(module.workflowRuntimeConfig.RATE_LIMITS_ENABLED, 'off');
+    assert.equal(module.workflowRuntimeConfigLoaded, true);
+    assert.equal(module.workflowRuntimeConfigPromise, null);
+
+    // Flags already loaded: gates resolve without another round trip.
+    await module.ensureWorkflowRuntimeConfig();
+    assert.equal(calls, 1);
 });
 
 test('fetchWorkflowRuntimeConfig delegates cache overview refresh after loading runtime config', async () => {

--- a/internal/admin/dashboard/static/js/modules/workflows.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/workflows.test.cjs
@@ -1352,6 +1352,56 @@ test('fetchWorkflowRuntimeConfig shares one in-flight request and ensureWorkflow
     assert.equal(calls, 1);
 });
 
+test('a failed runtime config load leaves the flags unloaded so ensureWorkflowRuntimeConfig retries', async () => {
+    let calls = 0;
+    const module = createWorkflowsModule({
+        console: { error() {} },
+        fetch() {
+            calls += 1;
+            if (calls === 1) {
+                return Promise.reject(new Error('network down'));
+            }
+            return Promise.resolve({ ok: true, json: async () => ({ RATE_LIMITS_ENABLED: 'off' }) });
+        }
+    });
+    module.headers = () => ({});
+    module.handleFetchResponse = () => true;
+
+    await module.ensureWorkflowRuntimeConfig();
+    assert.equal(calls, 1);
+    assert.equal(module.workflowRuntimeConfigLoaded, false, 'a failed load must not count as loaded');
+    assert.equal(module.workflowRuntimeConfigPromise, null);
+
+    // A later gated caller retries rather than trusting the empty config and
+    // falling back to every feature gate's default.
+    await module.ensureWorkflowRuntimeConfig();
+    assert.equal(calls, 2);
+    assert.equal(module.workflowRuntimeConfigLoaded, true);
+    assert.equal(module.workflowRuntimeConfig.RATE_LIMITS_ENABLED, 'off');
+});
+
+test('an unhandled runtime config response leaves the flags unloaded so ensureWorkflowRuntimeConfig retries', async () => {
+    let calls = 0;
+    const module = createWorkflowsModule({
+        fetch() {
+            calls += 1;
+            return Promise.resolve({ ok: calls > 1, json: async () => ({ RATE_LIMITS_ENABLED: 'off' }) });
+        }
+    });
+    module.headers = () => ({});
+    // Mirrors an auth failure: the response is rejected before it is parsed.
+    module.handleFetchResponse = (res) => res.ok;
+
+    await module.ensureWorkflowRuntimeConfig();
+    assert.equal(calls, 1);
+    assert.equal(module.workflowRuntimeConfigLoaded, false);
+
+    await module.ensureWorkflowRuntimeConfig();
+    assert.equal(calls, 2);
+    assert.equal(module.workflowRuntimeConfigLoaded, true);
+    assert.equal(module.workflowRuntimeConfig.RATE_LIMITS_ENABLED, 'off');
+});
+
 test('fetchWorkflowRuntimeConfig delegates cache overview refresh after loading runtime config', async () => {
     let cacheOverviewCalls = 0;
     const module = createWorkflowsModule({

--- a/internal/admin/dashboard_config_contract_test.go
+++ b/internal/admin/dashboard_config_contract_test.go
@@ -1,0 +1,64 @@
+package admin
+
+import (
+	"os"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// workflowsJSPath holds the dashboard module that mirrors DashboardConfigResponse.
+const workflowsJSPath = "dashboard/static/js/modules/workflows.js"
+
+var (
+	allowlistBlockRe = regexp.MustCompile(`(?s)workflowRuntimeConfigKeys\(\)\s*\{\s*return\s*\[(.*?)\]`)
+	allowlistKeyRe   = regexp.MustCompile(`'([A-Z0-9_]+)'`)
+)
+
+// TestDashboardConfigContract_MatchesFrontendAllowlist pins the runtime-config
+// contract to the dashboard's client-side allowlist.
+//
+// fetchWorkflowRuntimeConfig() copies only allowlisted keys out of the
+// /admin/runtime/config payload, so a flag the backend emits but the JS omits
+// is silently dropped and its feature gate falls back to its default. That is
+// how RATE_LIMITS_ENABLED once left the Rate Limits nav item visible with the
+// feature switched off. Keep both lists in lockstep.
+func TestDashboardConfigContract_MatchesFrontendAllowlist(t *testing.T) {
+	backend := map[string]bool{}
+	rt := reflect.TypeFor[DashboardConfigResponse]()
+	for i := range rt.NumField() {
+		tag := rt.Field(i).Tag.Get("json")
+		if name, _, _ := strings.Cut(tag, ","); name != "" && name != "-" {
+			backend[name] = true
+		}
+	}
+	if len(backend) == 0 {
+		t.Fatal("DashboardConfigResponse exposes no json-tagged fields")
+	}
+
+	source, err := os.ReadFile(workflowsJSPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", workflowsJSPath, err)
+	}
+	block := allowlistBlockRe.FindSubmatch(source)
+	if block == nil {
+		t.Fatalf("workflowRuntimeConfigKeys() allowlist not found in %s", workflowsJSPath)
+	}
+
+	frontend := map[string]bool{}
+	for _, m := range allowlistKeyRe.FindAllSubmatch(block[1], -1) {
+		frontend[string(m[1])] = true
+	}
+
+	for key := range backend {
+		if !frontend[key] {
+			t.Errorf("%s is served by /admin/runtime/config but missing from workflowRuntimeConfigKeys() in %s; the dashboard will drop it and fall back to the gate's default", key, workflowsJSPath)
+		}
+	}
+	for key := range frontend {
+		if !backend[key] {
+			t.Errorf("workflowRuntimeConfigKeys() allowlists %s, but DashboardConfigResponse never emits it", key)
+		}
+	}
+}

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -2256,6 +2256,7 @@ func TestDashboardConfig_ReturnsAllowlistedRuntimeFlags(t *testing.T) {
 		LoggingEnabled:       "on",
 		UsageEnabled:         "off",
 		BudgetsEnabled:       "on",
+		RateLimitsEnabled:    "off",
 		GuardrailsEnabled:    "on",
 		CacheEnabled:         "on",
 		RedisURL:             "on",
@@ -2287,6 +2288,9 @@ func TestDashboardConfig_ReturnsAllowlistedRuntimeFlags(t *testing.T) {
 	}
 	if got := body.BudgetsEnabled; got != "on" {
 		t.Fatalf("BUDGETS_ENABLED = %q, want on", got)
+	}
+	if got := body.RateLimitsEnabled; got != "off" {
+		t.Fatalf("RATE_LIMITS_ENABLED = %q, want off", got)
 	}
 	if got := body.GuardrailsEnabled; got != "on" {
 		t.Fatalf("GUARDRAILS_ENABLED = %q, want on", got)


### PR DESCRIPTION
## Problem

With `RATE_LIMITS_ENABLED=false`, the **Rate Limits** sidebar item stayed visible, and the dashboard kept calling `GET /admin/rate-limits` — which returns **503 `feature_unavailable`** — logging a server-side error on every models-page load.

## Root cause

All the gating was already in place: `sidebar.html` has `x-show="rateLimitsEnabled()"`, and the backend correctly serves `"RATE_LIMITS_ENABLED": "off"`.

The flag never reached the gate. `workflowRuntimeConfigKeys()` in `workflows.js` is a client-side **allowlist** that filters the `/admin/runtime/config` payload, and `RATE_LIMITS_ENABLED` was missing from it. The key was dropped, `workflowRuntimeBooleanFlag` saw an empty value, and fell back to its `true` default. `BUDGETS_ENABLED` and `GUARDRAILS_ENABLED` are allowlisted, which is why only rate limits misbehaved.

## Second defect, found while verifying

Fixing the allowlist hid the nav item, but the dashboard *still* issued the doomed request. `dashboardDataFetches()` starts `fetchWorkflowsPage()` (which loads the flags) and `fetchRateLimitsPage()` in the same eager batch, so the gate read an empty config and defaulted to `true`. A race, not a logic error. `fetchBudgetsPage()` had the identical latent defect.

Fixed at the source: `fetchWorkflowRuntimeConfig()` now shares its in-flight request, and a new `ensureWorkflowRuntimeConfig()` lets a feature gate await the flags instead of racing them. Both gates await it. Side effect: collapses the duplicate `/admin/runtime/config` GET that overlapping callers used to issue.

## Guard against recurrence

The JS allowlist silently duplicates `DashboardConfigResponse`'s json tags — that drift *is* this bug. `internal/admin/dashboard_config_contract_test.go` reflects over the struct, parses the allowlist out of `workflows.js`, and fails in **both** directions (backend emits a key the JS drops; JS allowlists a key the backend never sends).

## Verification

Driven against a real running gateway in headless Chrome (CDP), reading the actual DOM:

| | Sidebar item | `/admin/rate-limits` calls | 503s |
|---|---|---|---|
| `RATE_LIMITS_ENABLED=false` | hidden (`display: none`) | 0 | 0 |
| `RATE_LIMITS_ENABLED=true` | visible | 1 | 0 |

With the feature off, also confirmed: the deep-linked page shows "Rate limit management is unavailable.", the Create button and models-page gauge buttons are hidden, and `/admin/runtime/config` is fetched exactly once.

Each new test was confirmed non-vacuous by reverting the corresponding fix and watching it fail with the right diagnosis.

`go build ./...`, `go vet`, `make test-race`, `make lint`, and 446 dashboard JS tests pass.

## User-visible impact

With `RATE_LIMITS_ENABLED=false`, the Rate Limits nav item is hidden and the dashboard no longer calls the disabled endpoint. **No behavior change when the feature is enabled.** No config, API, or provider behavior changes.

## Notes on scope

Two things deliberately left alone:

- Deep-linking to `/admin/dashboard/rate-limits` still renders the page shell with an "unavailable" warning rather than redirecting — this matches Budgets and Guardrails, so it stays consistent.
- Feature gates fail **open** (default `true` until the config lands), so there is a sub-100ms window on first paint where the item can flash before hiding. That is the pre-existing trade-off shared with the other two flags: a config-fetch failure shows working features rather than hiding them. Changing it would be a broader UX decision than this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the rate-limits feature flag in the dashboard runtime configuration flow.
  * Runtime settings now ensure required flags are loaded before budgets and rate-limits pages determine availability.
* **Bug Fixes**
  * Prevented unnecessary network requests when budgets or rate limits are disabled.
  * Improved handling of overlapping runtime-configuration loads by reusing the same in-flight fetch.
* **Tests**
  * Added/updated async tests for disabled-state behavior, runtime-flag load coalescing, and retry handling.
  * Strengthened backend/frontend allowlist contract coverage to include the rate-limits flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->