### PR TITLE
fix(realtime): resolve virtual-model aliases on realtime and audio endpoints

### DIFF
--- a/internal/server/audio_service.go
+++ b/internal/server/audio_service.go
@@ -19,6 +19,7 @@ import (
 // validate, authorize, enforce budget, route, and proxy the resulting bytes.
 type audioService struct {
 	provider        core.RoutableProvider
+	modelResolver   RequestModelResolver
 	modelAuthorizer RequestModelAuthorizer
 	budgetChecker   BudgetChecker
 	rateLimiter     RateLimiter
@@ -71,6 +72,8 @@ func (s *audioService) CreateSpeech(c *echo.Context) error {
 	if err != nil {
 		return handleError(c, err)
 	}
+	// Dispatch on the resolved model: an alias never reaches the provider lookup.
+	req.Model, req.Provider = route.selector.Model, route.selector.Provider
 	release, err := enforceRateLimit(c, s.rateLimiter, rateLimitRoute{provider: route.providerName, model: route.model})
 	if err != nil {
 		return handleError(c, err)
@@ -130,6 +133,8 @@ func (s *audioService) CreateTranscription(c *echo.Context) error {
 	if err != nil {
 		return handleError(c, err)
 	}
+	// Dispatch on the resolved model: an alias never reaches the provider lookup.
+	req.Model, req.Provider = route.selector.Model, route.selector.Provider
 	release, err := enforceRateLimit(c, s.rateLimiter, rateLimitRoute{provider: route.providerName, model: route.model})
 	if err != nil {
 		return handleError(c, err)
@@ -148,16 +153,12 @@ func (s *audioService) CreateTranscription(c *echo.Context) error {
 	return s.respondAudio(c, resp)
 }
 
-// selectorResolver maps a requested model selector to the concrete registry
-// selector. The production provider (the Router) implements it; when absent, audio
-// authorizes on the parsed selector as a fallback.
-type selectorResolver interface {
-	ResolveModel(core.RequestedModelSelector) (core.ModelSelector, bool, error)
-}
-
 // audioRoute carries the resolved routing identity for a single audio call,
 // used to label its usage entry the same way the inference orchestrator does.
+// selector is the fully resolved model, kept so callers can rewrite the outgoing
+// request to the concrete provider model rather than the requested alias.
 type audioRoute struct {
+	selector     core.ModelSelector
 	model        string
 	providerType string
 	providerName string
@@ -166,23 +167,14 @@ type audioRoute struct {
 
 // prepare resolves and authorizes the model, enforces budget, and stamps the
 // request id, returning the context to dispatch with and the resolved route.
-// Authorization runs on the registry-resolved selector so model-override and
+// Authorization runs on the fully resolved selector so model-override and
 // user-path rules see the same concrete provider name as the inference orchestrator.
 func (s *audioService) prepare(c *echo.Context, model, providerHint string) (context.Context, audioRoute, error) {
-	selector, err := core.ParseModelSelector(model, providerHint)
+	// Surface resolution failures (unknown alias, registry not ready, malformed
+	// selector) instead of authorizing an unresolved selector.
+	selector, err := resolveServiceModel(c.Request().Context(), s.provider, s.modelResolver, model, providerHint)
 	if err != nil {
-		return nil, audioRoute{}, core.NewInvalidRequestError(err.Error(), err)
-	}
-	if resolver, ok := s.provider.(selectorResolver); ok {
-		// Surface resolution failures (registry not ready, malformed selector)
-		// instead of authorizing the unresolved selector. The boolean is "did the
-		// selector change", not a found flag — on no change resolved already
-		// equals the normalized selector, so it is always safe to adopt.
-		resolved, _, resolveErr := resolver.ResolveModel(core.NewRequestedModelSelector(model, providerHint))
-		if resolveErr != nil {
-			return nil, audioRoute{}, resolveErr
-		}
-		selector = resolved
+		return nil, audioRoute{}, err
 	}
 	if s.modelAuthorizer != nil {
 		if err := s.modelAuthorizer.ValidateModelAccess(c.Request().Context(), selector); err != nil {
@@ -205,6 +197,7 @@ func (s *audioService) prepare(c *echo.Context, model, providerHint string) (con
 func (s *audioService) routeFor(selector core.ModelSelector, requestID string) audioRoute {
 	qualified := selector.QualifiedModel()
 	route := audioRoute{
+		selector:     selector,
 		model:        selector.Model,
 		providerType: s.provider.GetProviderType(qualified),
 		providerName: selector.Provider,

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -202,6 +202,7 @@ func (h *Handler) audio() *audioService {
 	}
 	return &audioService{
 		provider:        h.provider,
+		modelResolver:   h.modelResolver,
 		modelAuthorizer: h.modelAuthorizer,
 		budgetChecker:   h.budgetChecker,
 		rateLimiter:     h.rateLimiter,
@@ -238,6 +239,7 @@ func (h *Handler) currentResponseStore() responsestore.Store {
 func (h *Handler) realtime() *realtimeService {
 	return &realtimeService{
 		provider:        h.provider,
+		modelResolver:   h.modelResolver,
 		modelAuthorizer: h.modelAuthorizer,
 		budgetChecker:   h.budgetChecker,
 		rateLimiter:     h.rateLimiter,

--- a/internal/server/realtime_audio_alias_resolution_test.go
+++ b/internal/server/realtime_audio_alias_resolution_test.go
@@ -1,0 +1,231 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+
+	"gomodel/internal/core"
+	"gomodel/internal/virtualmodels"
+)
+
+// These tests lock in that virtual-model (alias) resolution reaches the realtime
+// and audio endpoints, which resolve their model in the service layer rather than
+// through the workflow middleware that covers chat/responses/embeddings.
+//
+// The regression they guard is subtle: the provider double resolves like the real
+// Router — registry-only, so an unknown alias is a 404 and never resolved. Aliases
+// only work when a real virtualmodels.Service is wired as the modelResolver and its
+// resolved concrete model is forwarded upstream. A prior version wired neither, so
+// every alias 404'd on these routes while the (green) unit tests injected a mock
+// that faked resolution the Router never performs. Building on the real
+// virtualmodels.Service is deliberate: it is the component whose absence caused the
+// bug.
+
+// newAliasResolvingService builds a real virtualmodels.Service that redirects
+// aliasSource to the concrete openai/<targetModel>.
+func newAliasResolvingService(t *testing.T, aliasSource, targetModel string) *virtualmodels.Service {
+	t.Helper()
+	qualified := "openai/" + targetModel
+	catalog := &aliasesTestCatalog{
+		supported:     map[string]bool{qualified: true},
+		providerTypes: map[string]string{qualified: "openai"},
+		models:        map[string]core.Model{qualified: {ID: targetModel, Object: "model"}},
+	}
+	service, err := virtualmodels.NewService(newAliasesTestStore(
+		redirectVM(aliasSource, targetModel, "openai", true),
+	), catalog, true)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+	return service
+}
+
+func TestRealtimeClientSecrets_ResolvesAliasThroughVirtualModels(t *testing.T) {
+	var upstreamModel string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Session struct {
+				Model string `json:"model"`
+			} `json:"session"`
+		}
+		_ = json.Unmarshal(body, &payload)
+		upstreamModel = payload.Session.Model
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"value":"ek_test","expires_at":1}`))
+	}))
+	defer upstream.Close()
+
+	// resolved == nil: the mock resolves registry-only, exactly like the Router,
+	// so the alias must be resolved by the wired service before it gets here.
+	mock := &realtimeWebRTCMock{
+		mockProvider: &mockProvider{supportedModels: []string{"gpt-realtime-2"}},
+		secretTarget: &core.RealtimeHTTPTarget{URL: upstream.URL + "/v1/realtime/client_secrets"},
+	}
+	service := newAliasResolvingService(t, "voice-alias", "gpt-realtime-2")
+	handler := newHandler(mock, nil, nil, nil, service, nil, nil, nil)
+	handler.realtimeEnabled = true
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/realtime/client_secrets",
+		strings.NewReader(`{"session":{"type":"realtime","model":"voice-alias"}}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := echo.New().NewContext(req, rec)
+
+	if err := handler.RealtimeClientSecrets(c); err != nil {
+		t.Fatalf("RealtimeClientSecrets returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (alias should resolve, not 404) (body: %s)", rec.Code, rec.Body.String())
+	}
+	if mock.capturedSecret == nil || mock.capturedSecret.Model != "gpt-realtime-2" {
+		t.Errorf("router received %+v, want the resolved model gpt-realtime-2", mock.capturedSecret)
+	}
+	if upstreamModel != "gpt-realtime-2" {
+		t.Errorf("upstream session.model = %q, want the alias rewritten to gpt-realtime-2", upstreamModel)
+	}
+}
+
+func TestRealtimeCalls_ResolvesAliasThroughVirtualModels(t *testing.T) {
+	var upstreamModelQuery string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		upstreamModelQuery = r.URL.Query().Get("model")
+		w.Header().Set("Content-Type", "application/sdp")
+		w.Header().Set("Location", "/v1/realtime/calls/rtc_alias1")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte("v=0 answer"))
+	}))
+	defer upstream.Close()
+
+	mock := &realtimeWebRTCMock{
+		mockProvider: &mockProvider{supportedModels: []string{"gpt-realtime-2"}},
+		callTarget:   &core.RealtimeHTTPTarget{URL: upstream.URL + "/v1/realtime/calls"},
+	}
+	service := newAliasResolvingService(t, "voice-alias", "gpt-realtime-2")
+	handler := newHandler(mock, nil, nil, nil, service, nil, nil, nil)
+	handler.realtimeEnabled = true
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/realtime/calls?model=voice-alias", strings.NewReader("v=0 offer"))
+	req.Header.Set("Content-Type", "application/sdp")
+	rec := httptest.NewRecorder()
+	c := echo.New().NewContext(req, rec)
+
+	if err := handler.RealtimeCalls(c); err != nil {
+		t.Fatalf("RealtimeCalls returned error: %v", err)
+	}
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201 (alias should resolve, not 404) (body: %s)", rec.Code, rec.Body.String())
+	}
+	if mock.capturedCall == nil || mock.capturedCall.Model != "gpt-realtime-2" {
+		t.Errorf("router received %+v, want the resolved model gpt-realtime-2", mock.capturedCall)
+	}
+	if upstreamModelQuery != "gpt-realtime-2" {
+		t.Errorf("upstream model query = %q, want the alias rewritten to gpt-realtime-2", upstreamModelQuery)
+	}
+	// The call is registered under the resolved model so a later sideband attach
+	// gates on the concrete model, not the alias.
+	if route, ok := handler.realtimeCalls.Lookup("rtc_alias1"); !ok || route.Model != "gpt-realtime-2" {
+		t.Errorf("registry entry = %+v (found %v), want the resolved model registered", route, ok)
+	}
+}
+
+func TestRealtimeWebsocket_ResolvesAliasThroughVirtualModels(t *testing.T) {
+	mock := &realtimeWebRTCMock{
+		mockProvider: &mockProvider{supportedModels: []string{"gpt-realtime-2"}},
+	}
+	service := newAliasResolvingService(t, "voice-alias", "gpt-realtime-2")
+	handler := newHandler(mock, nil, nil, nil, service, nil, nil, nil)
+	handler.realtimeEnabled = true
+
+	// The websocket dial fails (no upstream), but resolution happens before the
+	// dial: the captured RealtimeTarget request proves the concrete model — not the
+	// alias — reached the router. A 404 here would mean the alias never resolved.
+	req := httptest.NewRequest(http.MethodGet, "/v1/realtime?model=voice-alias", nil)
+	rec := httptest.NewRecorder()
+	c := echo.New().NewContext(req, rec)
+
+	_ = handler.Realtime(c)
+
+	if rec.Code == http.StatusNotFound {
+		t.Fatalf("status = 404, alias failed to resolve (body: %s)", rec.Body.String())
+	}
+	if mock.capturedRealtime == nil || mock.capturedRealtime.Model != "gpt-realtime-2" {
+		t.Errorf("router received %+v, want the resolved model gpt-realtime-2", mock.capturedRealtime)
+	}
+}
+
+func TestAudioSpeech_ResolvesAliasThroughVirtualModels(t *testing.T) {
+	mock := &audioMockProvider{
+		mockProvider: &mockProvider{supportedModels: []string{"gpt-4o-mini-tts"}},
+		speechResp:   &core.AudioResponse{ContentType: "audio/mpeg", Data: []byte("audio")},
+	}
+	service := newAliasResolvingService(t, "voice-alias", "gpt-4o-mini-tts")
+	handler := newHandler(mock, nil, nil, nil, service, nil, nil, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/speech",
+		strings.NewReader(`{"model":"voice-alias","input":"hello","voice":"alloy"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := echo.New().NewContext(req, rec)
+
+	if err := handler.AudioSpeech(c); err != nil {
+		t.Fatalf("AudioSpeech returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (alias should resolve, not 404) (body: %s)", rec.Code, rec.Body.String())
+	}
+	// The provider must be dispatched on the resolved model, not the alias.
+	if mock.capturedSpeech == nil || mock.capturedSpeech.Model != "gpt-4o-mini-tts" {
+		t.Errorf("provider received %+v, want the resolved model gpt-4o-mini-tts", mock.capturedSpeech)
+	}
+}
+
+func TestAudioTranscription_ResolvesAliasThroughVirtualModels(t *testing.T) {
+	mock := &audioMockProvider{
+		mockProvider:      &mockProvider{supportedModels: []string{"gpt-4o-transcribe"}},
+		transcriptionResp: &core.AudioResponse{ContentType: "application/json", Data: []byte(`{"text":"hi"}`)},
+	}
+	service := newAliasResolvingService(t, "scribe-alias", "gpt-4o-transcribe")
+	handler := newHandler(mock, nil, nil, nil, service, nil, nil, nil)
+
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	_ = w.WriteField("model", "scribe-alias")
+	part, err := w.CreateFormFile("file", "speech.mp3")
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	_, _ = part.Write([]byte("audio-bytes"))
+	if err := w.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", &buf)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	rec := httptest.NewRecorder()
+	c := echo.New().NewContext(req, rec)
+
+	if err := handler.AudioTranscriptions(c); err != nil {
+		t.Fatalf("AudioTranscriptions returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (alias should resolve, not 404) (body: %s)", rec.Code, rec.Body.String())
+	}
+	if mock.capturedTranscription == nil || mock.capturedTranscription.Model != "gpt-4o-transcribe" {
+		t.Errorf("provider received %+v, want the resolved model gpt-4o-transcribe", mock.capturedTranscription)
+	}
+}

--- a/internal/server/realtime_service.go
+++ b/internal/server/realtime_service.go
@@ -28,6 +28,7 @@ var responseDoneMarker = []byte(`"response.done"`)
 // or response translation happens here.
 type realtimeService struct {
 	provider        core.RoutableProvider
+	modelResolver   RequestModelResolver
 	modelAuthorizer RequestModelAuthorizer
 	budgetChecker   BudgetChecker
 	rateLimiter     RateLimiter
@@ -41,8 +42,10 @@ type realtimeService struct {
 // realtimeRoute carries the resolved routing identity for one session, used to
 // label its usage entries and lifecycle logs the same way audio does. endpoint,
 // when set, overrides the usage entry endpoint so WebRTC calls are
-// distinguishable from websocket sessions.
+// distinguishable from websocket sessions. selector is the fully resolved model,
+// used to route upstream on the concrete model rather than the requested alias.
 type realtimeRoute struct {
+	selector     core.ModelSelector
 	model        string
 	providerType string
 	providerName string
@@ -110,7 +113,8 @@ func (s *realtimeService) handle(c *echo.Context, model, providerHint string) er
 		return handleError(c, err)
 	}
 	defer release()
-	target, err := router.RealtimeTarget(ctx, &core.RealtimeRequest{Model: model, Provider: providerHint, CallID: callID})
+	// Route on the resolved selector: an alias never reaches the provider lookup.
+	target, err := router.RealtimeTarget(ctx, &core.RealtimeRequest{Model: route.selector.Model, Provider: route.selector.Provider, CallID: callID})
 	if err != nil {
 		return handleError(c, err)
 	}
@@ -127,16 +131,9 @@ func (s *realtimeService) handle(c *echo.Context, model, providerHint string) er
 // request id. It mirrors audioService.prepare so realtime sessions are gated by
 // the same model-access and budget rules as the other model endpoints.
 func (s *realtimeService) prepare(c *echo.Context, model, providerHint string) (context.Context, realtimeRoute, error) {
-	selector, err := core.ParseModelSelector(model, providerHint)
+	selector, err := resolveServiceModel(c.Request().Context(), s.provider, s.modelResolver, model, providerHint)
 	if err != nil {
-		return nil, realtimeRoute{}, core.NewInvalidRequestError(err.Error(), err)
-	}
-	if resolver, ok := s.provider.(selectorResolver); ok {
-		resolved, _, resolveErr := resolver.ResolveModel(core.NewRequestedModelSelector(model, providerHint))
-		if resolveErr != nil {
-			return nil, realtimeRoute{}, resolveErr
-		}
-		selector = resolved
+		return nil, realtimeRoute{}, err
 	}
 	if s.modelAuthorizer != nil {
 		if err := s.modelAuthorizer.ValidateModelAccess(c.Request().Context(), selector); err != nil {
@@ -153,6 +150,7 @@ func (s *realtimeService) prepare(c *echo.Context, model, providerHint string) (
 
 	qualified := selector.QualifiedModel()
 	route := realtimeRoute{
+		selector:     selector,
 		model:        selector.Model,
 		providerType: s.provider.GetProviderType(qualified),
 		providerName: selector.Provider,

--- a/internal/server/realtime_webrtc_service.go
+++ b/internal/server/realtime_webrtc_service.go
@@ -57,7 +57,8 @@ func (s *realtimeService) RealtimeCalls(c *echo.Context) error {
 	}
 	defer release()
 
-	target, err := router.RealtimeCallTarget(ctx, &core.RealtimeRequest{Model: offer.model, Provider: providerHint})
+	// Route on the resolved selector: an alias never reaches the provider lookup.
+	target, err := router.RealtimeCallTarget(ctx, &core.RealtimeRequest{Model: route.selector.Model, Provider: route.selector.Provider})
 	if err != nil {
 		return handleError(c, err)
 	}
@@ -124,7 +125,8 @@ func (s *realtimeService) RealtimeClientSecrets(c *echo.Context) error {
 	}
 	defer release()
 
-	target, err := router.RealtimeClientSecretTarget(ctx, &core.RealtimeRequest{Model: model, Provider: providerHint})
+	// Route on the resolved selector: an alias never reaches the provider lookup.
+	target, err := router.RealtimeClientSecretTarget(ctx, &core.RealtimeRequest{Model: route.selector.Model, Provider: route.selector.Provider})
 	if err != nil {
 		return handleError(c, err)
 	}

--- a/internal/server/realtime_webrtc_service_test.go
+++ b/internal/server/realtime_webrtc_service_test.go
@@ -183,8 +183,8 @@ func TestRealtimeCalls_MultipartRewritesSessionModel(t *testing.T) {
 		t.Fatalf("status = %d, want 201 (body: %s)", rec.Code, rec.Body.String())
 	}
 	// The alias routes the request; the provider must see the resolved model.
-	if mock.capturedCall == nil || mock.capturedCall.Model != "voice-alias" {
-		t.Errorf("router received %+v, want the requested model", mock.capturedCall)
+	if mock.capturedCall == nil || mock.capturedCall.Model != "gpt-realtime-2" {
+		t.Errorf("router received %+v, want the resolved model gpt-realtime-2", mock.capturedCall)
 	}
 
 	_, params, err := mime.ParseMediaType(upstreamContentType)

--- a/internal/server/request_model_resolution.go
+++ b/internal/server/request_model_resolution.go
@@ -32,6 +32,37 @@ func resolveRequestModelWithAuthorizer(
 	return gateway.ResolveRequestModelWithAuthorizer(ctx, provider, resolver, authorizer, requested)
 }
 
+// resolveServiceModel maps a requested model to the concrete provider selector:
+// virtual-model (alias) resolution first, then the provider registry. It is the
+// same two-step gateway.ResolveExecutionSelector performs for chat, responses,
+// and embeddings.
+//
+// The audio and realtime endpoints do not run the workflow middleware — their
+// operations are absent from resolveWorkflow — so ensureRequestModelResolution
+// never runs for them and they must resolve here instead. Resolving against the
+// provider alone (the Router) only canonicalizes concrete registry ids and
+// leaves an alias untouched, which then fails the downstream provider lookup.
+//
+// ctx must carry the effective request user path so user_path-scoped redirects
+// apply. A nil resolver degrades to provider-only resolution.
+func resolveServiceModel(
+	ctx context.Context,
+	provider core.RoutableProvider,
+	resolver RequestModelResolver,
+	model, providerHint string,
+) (core.ModelSelector, error) {
+	// Parse first so a malformed selector is a 400 rather than whatever the
+	// resolver chain reports for it.
+	if _, err := core.ParseModelSelector(model, providerHint); err != nil {
+		return core.ModelSelector{}, core.NewInvalidRequestError(err.Error(), err)
+	}
+	selector, _, err := gateway.ResolveExecutionSelector(ctx, provider, resolver, core.NewRequestedModelSelector(model, providerHint))
+	if err != nil {
+		return core.ModelSelector{}, err
+	}
+	return selector, nil
+}
+
 func storeRequestModelResolution(c *echo.Context, resolution *core.RequestModelResolution) {
 	if c == nil || resolution == nil {
 		return


### PR DESCRIPTION
## Problem

Virtual-model aliases 404 on every realtime and audio endpoint, while resolving correctly on chat, responses, and embeddings. Commit 2c3ab682 (#500) and `CLAUDE.md` both claim aliases work on these routes — they don't.

Reproduced against live OpenAI (alias → `openai/gpt-realtime`, target present in `/v1/models`):

| Endpoint | Alias (before) | Concrete |
|---|---|---|
| `POST /v1/realtime/calls?model=…` | **404** | 201 |
| `POST /v1/realtime/client_secrets` (`session.model`) | **404** | 200 |
| `GET /v1/realtime?model=…` (websocket) | **404** | 101 |
| `POST /v1/audio/speech` | **404** | 200 |
| `POST /v1/audio/transcriptions` | **404** | 200 |
| `POST /v1/chat/completions` (control) | 200 | 200 |

## Root cause

Two independent defects, both required to reach the bug:

1. **The resolver was never wired.** `realtimeService` and `audioService` copied `provider`, `modelAuthorizer`, `budgetChecker`, `rateLimiter` — but not `h.modelResolver` (the `virtualmodels.Service`). `prepare()` type-asserted the registry-only `selectorResolver` on the Router, which canonicalizes concrete ids and returns an alias unchanged with no error.
2. **The raw model was forwarded anyway.** The parsed selector was discarded and the raw request model was passed to `router.Realtime*Target` / `CreateSpeech` / `CreateTranscription`, which then 404'd in the provider lookup.

These endpoints resolve their model in the service layer because `OperationRealtime` and the audio operations are absent from the workflow middleware's `resolveWorkflow` switch, so `ensureRequestModelResolution` (the chat path's route to the alias resolver) never runs for them.

## Fix

Both services now resolve through a shared `resolveServiceModel` helper that runs the same two-step `gateway.ResolveExecutionSelector` (alias table → provider registry) used by chat/responses/embeddings, and forward the **resolved concrete selector** upstream. Wiring added in both service constructors.

## Why the existing test missed it

`realtime_webrtc_service_test.go` injected a mock whose `ResolveModel` faked the alias resolution the production Router never performs, and asserted the router received the raw alias (`"voice-alias"`) under a comment claiming the opposite. That assertion is corrected, and new regression tests in `realtime_audio_alias_resolution_test.go` drive a **real `virtualmodels.Service`** through a registry-only provider double across all three realtime routes plus speech and transcription. Each new test fails if the resolver is unwired **or** the raw model is forwarded (both verified by reverting each half independently).

## Verification

- `internal/server`, `internal/providers`, `internal/gateway`, `internal/virtualmodels`: green; `make test-race` + `make lint` pass in pre-commit.
- Live end-to-end against OpenAI: all five endpoints now resolve the alias (client_secrets 200 with `session.model` rewritten; calls 201 with `Location`; websocket 101; speech 200; transcription 200).
- Full 162-scenario release E2E matrix: **162/162 PASS**, no regressions.

Found during pre-release QA of the current release branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Audio and realtime requests now correctly use resolved model names before routing, so aliases are handled consistently across speech, transcription, web, and websocket flows.
  * Multipart and session-based requests now forward the concrete model to downstream routing instead of the original alias.
  * Invalid or unresolvable model requests now fail cleanly with clearer request errors.

* **Tests**
  * Added coverage for alias resolution across realtime and audio request paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->