### PR TITLE
chore: apply go fix modernizations and guard drift in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,20 @@ repos:
         language: system
         pass_filenames: false
         files: '^(internal/(auditlog|core|providers|server|usage)/.*\.go|tests/perf/.*\.go|Makefile|\.github/workflows/test\.yml)$'
+      # Reports Go modernizations (maps.Copy, slices.Contains, min/max, new(expr),
+      # range-over-int, ...) that `go fix` would apply. Check-only, by design:
+      # `go fix` rewrites source in place, and when it marks a helper
+      # `//go:fix inline` it only inlines the callers on a *later* run, leaving the
+      # helper orphaned and tripping the `unused` linter. An auto-applying hook
+      # would therefore mutate the commit and still fail it. Run `make fix` to
+      # apply, re-run until clean, then delete any now-unused helper.
+      - id: go-fix-check
+        name: make fix-check
+        entry: make fix-check
+        language: system
+        pass_filenames: false
+        files: '(\.go$|^go\.(mod|sum)$|^Makefile$)'
+
       - id: go-lint
         name: make lint
         entry: make lint

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build run clean tidy test test-race test-dashboard test-e2e test-integration test-contract test-all lint lint-fix record-api swagger docs-openapi install-tools perf-check perf-bench infra image seed-demo-data
+.PHONY: all build run clean tidy test test-race test-dashboard test-e2e test-integration test-contract test-all lint lint-fix fix fix-check record-api swagger docs-openapi install-tools perf-check perf-bench infra image seed-demo-data
 
 all: build
 
@@ -9,6 +9,10 @@ DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 DOCS_API_SERVERS ?= http://localhost:8080
 LOG_LEVEL ?= debug
 SWAGGER_ENABLED ?= true
+
+# Build tags covering every file the linter and fixers must see. Without these,
+# tag-gated files (tests/e2e, tests/integration, tests/contract) are skipped.
+BUILD_TAGS ?= swagger,e2e,integration,contract
 
 # Linker flags to inject version info
 LDFLAGS := -X "gomodel/internal/version.Version=$(VERSION)" \
@@ -116,8 +120,22 @@ docs-openapi:
 
 # Run linter
 lint:
-	golangci-lint run --build-tags=swagger,e2e,integration,contract ./cmd/... ./config/... ./internal/... ./tests/...
+	golangci-lint run --build-tags=$(BUILD_TAGS) ./cmd/... ./config/... ./internal/... ./tests/...
 
 # Run linter with auto-fix
 lint-fix:
 	golangci-lint run --fix ./cmd/... ./config/... ./internal/...
+
+# Report modernizations go fix would apply, without touching the tree.
+# Exits non-zero when the tree has drifted; run `make fix` to apply.
+fix-check:
+	go fix -diff -tags=$(BUILD_TAGS) ./...
+
+# Apply go fix modernizations in place.
+#
+# Not idempotent in one pass: when go fix marks a helper `//go:fix inline` it
+# inlines the callers on the *next* run, which can leave the helper orphaned.
+# Re-run until `make fix-check` is clean, then delete any helper `make lint`
+# now reports as unused.
+fix:
+	go fix -tags=$(BUILD_TAGS) ./...

--- a/Makefile
+++ b/Makefile
@@ -122,9 +122,10 @@ docs-openapi:
 lint:
 	golangci-lint run --build-tags=$(BUILD_TAGS) ./cmd/... ./config/... ./internal/... ./tests/...
 
-# Run linter with auto-fix
+# Run linter with auto-fix. Mirrors `lint`: same tags, same packages, so the
+# autofix pass cannot silently skip the tag-gated files under tests/.
 lint-fix:
-	golangci-lint run --fix ./cmd/... ./config/... ./internal/...
+	golangci-lint run --fix --build-tags=$(BUILD_TAGS) ./cmd/... ./config/... ./internal/... ./tests/...
 
 # Report modernizations go fix would apply, without touching the tree.
 # Exits non-zero when the tree has drifted; run `make fix` to apply.

--- a/config/cache.go
+++ b/config/cache.go
@@ -254,14 +254,12 @@ func mergeSemanticResponseDefaults(sem *SemanticCacheConfig) {
 		sem.SimilarityThreshold = 0.92
 	}
 	if sem.TTL == nil {
-		sem.TTL = intPtr(3600)
+		sem.TTL = new(3600)
 	}
 	if sem.MaxConversationMessages == nil {
-		sem.MaxConversationMessages = intPtr(3)
+		sem.MaxConversationMessages = new(3)
 	}
 }
-
-func intPtr(v int) *int { return &v }
 
 func applyResponseSimpleEnv(resp *ResponseCacheConfig) error {
 	v, ok := os.LookupEnv("RESPONSE_CACHE_SIMPLE_ENABLED")

--- a/config/cache_validation_test.go
+++ b/config/cache_validation_test.go
@@ -79,8 +79,6 @@ func TestValidateCacheConfig_RedisOnly(t *testing.T) {
 	}
 }
 
-func boolPtr(b bool) *bool { return &b }
-
 func TestValidateCacheConfig_SemanticDisabledIgnoresInvalidVectorStore(t *testing.T) {
 	cfg := &CacheConfig{
 		Model: ModelCacheConfig{
@@ -89,7 +87,7 @@ func TestValidateCacheConfig_SemanticDisabledIgnoresInvalidVectorStore(t *testin
 		},
 		Response: ResponseCacheConfig{
 			Semantic: &SemanticCacheConfig{
-				Enabled: boolPtr(false),
+				Enabled: new(false),
 				VectorStore: VectorStoreConfig{
 					Type: "qdrant",
 					// Intentionally missing URL — valid because semantic cache is off.
@@ -110,9 +108,9 @@ func TestValidateCacheConfig_SemanticEnabledRequiresQdrantURL(t *testing.T) {
 		},
 		Response: ResponseCacheConfig{
 			Semantic: &SemanticCacheConfig{
-				Enabled:             boolPtr(true),
+				Enabled:             new(true),
 				SimilarityThreshold: 0.9,
-				TTL:                 intPtr(3600),
+				TTL:                 new(3600),
 				Embedder:            EmbedderConfig{Provider: "openai"},
 				VectorStore: VectorStoreConfig{
 					Type: "qdrant",
@@ -133,9 +131,9 @@ func TestValidateCacheConfig_SemanticEnabledRequiresQdrantCollection(t *testing.
 		},
 		Response: ResponseCacheConfig{
 			Semantic: &SemanticCacheConfig{
-				Enabled:             boolPtr(true),
+				Enabled:             new(true),
 				SimilarityThreshold: 0.9,
-				TTL:                 intPtr(3600),
+				TTL:                 new(3600),
 				Embedder:            EmbedderConfig{Provider: "openai"},
 				VectorStore: VectorStoreConfig{
 					Type:   "qdrant",
@@ -157,8 +155,8 @@ func TestValidateCacheConfig_SemanticSimilarityThresholdInvalid(t *testing.T) {
 		},
 		Response: ResponseCacheConfig{
 			Semantic: &SemanticCacheConfig{
-				Enabled:  boolPtr(true),
-				TTL:      intPtr(3600),
+				Enabled:  new(true),
+				TTL:      new(3600),
 				Embedder: EmbedderConfig{Provider: "openai"},
 				VectorStore: VectorStoreConfig{
 					Type: "pgvector",
@@ -203,9 +201,9 @@ func TestValidateCacheConfig_SemanticRequiresEmbedderProvider(t *testing.T) {
 		},
 		Response: ResponseCacheConfig{
 			Semantic: &SemanticCacheConfig{
-				Enabled:             boolPtr(true),
+				Enabled:             new(true),
 				SimilarityThreshold: 0.9,
-				TTL:                 intPtr(3600),
+				TTL:                 new(3600),
 				VectorStore: VectorStoreConfig{
 					Type: "pgvector",
 					PGVector: PGVectorConfig{
@@ -233,9 +231,9 @@ func TestValidateCacheConfig_SemanticRejectsLocalEmbedder(t *testing.T) {
 		},
 		Response: ResponseCacheConfig{
 			Semantic: &SemanticCacheConfig{
-				Enabled:             boolPtr(true),
+				Enabled:             new(true),
 				SimilarityThreshold: 0.9,
-				TTL:                 intPtr(3600),
+				TTL:                 new(3600),
 				Embedder:            EmbedderConfig{Provider: "local"},
 				VectorStore: VectorStoreConfig{
 					Type: "pgvector",
@@ -261,9 +259,9 @@ func TestValidateCacheConfig_SemanticNegativeTTL(t *testing.T) {
 		},
 		Response: ResponseCacheConfig{
 			Semantic: &SemanticCacheConfig{
-				Enabled:             boolPtr(true),
+				Enabled:             new(true),
 				SimilarityThreshold: 0.9,
-				TTL:                 intPtr(-1),
+				TTL:                 new(-1),
 				Embedder:            EmbedderConfig{Provider: "openai"},
 				VectorStore: VectorStoreConfig{
 					Type: "pgvector",

--- a/config/user_path_env.go
+++ b/config/user_path_env.go
@@ -80,7 +80,7 @@ func userPathEnvSuffixPath(suffix string) string {
 		return "/"
 	}
 	segments := make([]string, 0)
-	for _, part := range strings.Split(suffix, "__") {
+	for part := range strings.SplitSeq(suffix, "__") {
 		part = strings.TrimSpace(part)
 		if part != "" {
 			segments = append(segments, part)

--- a/ext/registry_test.go
+++ b/ext/registry_test.go
@@ -63,15 +63,13 @@ func TestRegistryConcurrentRegistration(t *testing.T) {
 	const workers = 16
 
 	var wg sync.WaitGroup
-	for i := 0; i < workers; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range workers {
+		wg.Go(func() {
 			reg.RegisterRewriter(&namedRewriter{name: "w"})
 			reg.UseMiddleware(func(next echo.HandlerFunc) echo.HandlerFunc { return next })
 			reg.AddPublicPaths("/p")
 			_ = reg.Rewriters()
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/internal/admin/dashboard_config_contract_test.go
+++ b/internal/admin/dashboard_config_contract_test.go
@@ -27,8 +27,8 @@ var (
 func TestDashboardConfigContract_MatchesFrontendAllowlist(t *testing.T) {
 	backend := map[string]bool{}
 	rt := reflect.TypeFor[DashboardConfigResponse]()
-	for i := range rt.NumField() {
-		tag := rt.Field(i).Tag.Get("json")
+	for field := range rt.Fields() {
+		tag := field.Tag.Get("json")
 		if name, _, _ := strings.Cut(tag, ","); name != "" && name != "-" {
 			backend[name] = true
 		}

--- a/internal/admin/handler_live.go
+++ b/internal/admin/handler_live.go
@@ -113,7 +113,7 @@ func liveTypeFilter(raw string) liveLogTypeFilter {
 		provided: true,
 		types:    map[string]struct{}{},
 	}
-	for _, item := range strings.Split(raw, ",") {
+	for item := range strings.SplitSeq(raw, ",") {
 		item = strings.ToLower(strings.TrimSpace(item))
 		switch item {
 		case "audit", "usage":

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -2191,7 +2191,7 @@ func TestBuildProviderStatusItem_ClassifyAndDisplayFallbacks(t *testing.T) {
 				Type:                    "openai",
 				Registered:              true,
 				DiscoveredModelCount:    7,
-				LastModelFetchSuccessAt: timePtr(time.Now()),
+				LastModelFetchSuccessAt: new(time.Now()),
 			},
 			wantStatus:  "healthy",
 			wantLabel:   "Healthy",
@@ -2247,8 +2247,6 @@ func TestBuildProviderStatusItem_ClassifyAndDisplayFallbacks(t *testing.T) {
 		})
 	}
 }
-
-func timePtr(t time.Time) *time.Time { return &t }
 
 func TestDashboardConfig_ReturnsAllowlistedRuntimeFlags(t *testing.T) {
 	h := NewHandler(nil, nil, WithDashboardRuntimeConfig(DashboardConfigResponse{

--- a/internal/anthropicapi/stream_test.go
+++ b/internal/anthropicapi/stream_test.go
@@ -20,8 +20,8 @@ func drainConverter(t *testing.T, chatStream string) []map[string]any {
 	}
 
 	var events []map[string]any
-	for _, block := range strings.Split(string(out), "\n\n") {
-		for _, line := range strings.Split(block, "\n") {
+	for block := range strings.SplitSeq(string(out), "\n\n") {
+		for line := range strings.SplitSeq(block, "\n") {
 			data, ok := strings.CutPrefix(line, "data: ")
 			if !ok {
 				continue

--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -221,7 +221,7 @@ type AttemptSnapshot struct {
 	ErrorType    string    `json:"error_type,omitempty" bson:"error_type,omitempty"`
 	ErrorCode    string    `json:"error_code,omitempty" bson:"error_code,omitempty"`
 	ErrorMessage string    `json:"error_message,omitempty" bson:"error_message,omitempty"`
-	StartedAt    time.Time `json:"started_at,omitempty" bson:"started_at,omitempty"`
+	StartedAt    time.Time `json:"started_at" bson:"started_at,omitempty"`
 	DurationNs   int64     `json:"duration_ns,omitempty" bson:"duration_ns,omitempty"`
 
 	// ResponseBody and ResponseHeaders capture the raw upstream error response

--- a/internal/auditlog/middleware_test.go
+++ b/internal/auditlog/middleware_test.go
@@ -1,6 +1,7 @@
 package auditlog
 
 import (
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -330,9 +331,7 @@ func (l *captureLiveLogger) PublishLiveEvent(eventType string, entry *LogEntry) 
 	headers := map[string]string(nil)
 	if entry != nil && entry.Data != nil && entry.Data.RequestHeaders != nil {
 		headers = make(map[string]string, len(entry.Data.RequestHeaders))
-		for key, value := range entry.Data.RequestHeaders {
-			headers[key] = value
-		}
+		maps.Copy(headers, entry.Data.RequestHeaders)
 	}
 	var requestBody any
 	if entry != nil && entry.Data != nil {

--- a/internal/authkeys/service.go
+++ b/internal/authkeys/service.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"sort"
 	"strings"
 	"sync"
@@ -423,15 +424,9 @@ func cloneSnapshot(src snapshot) snapshot {
 		bySecretHash: make(map[string]AuthKey, len(src.bySecretHash)),
 		activeByHash: make(map[string]AuthKey, len(src.activeByHash)),
 	}
-	for id, key := range src.byID {
-		next.byID[id] = key
-	}
-	for hash, key := range src.bySecretHash {
-		next.bySecretHash[hash] = key
-	}
-	for hash, key := range src.activeByHash {
-		next.activeByHash[hash] = key
-	}
+	maps.Copy(next.byID, src.byID)
+	maps.Copy(next.bySecretHash, src.bySecretHash)
+	maps.Copy(next.activeByHash, src.activeByHash)
 	return next
 }
 

--- a/internal/conversationstore/store.go
+++ b/internal/conversationstore/store.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -24,8 +25,8 @@ type StoredConversation struct {
 	Items        []json.RawMessage  `json:"items,omitempty"`
 	UserPath     string             `json:"user_path,omitempty"`
 	RequestID    string             `json:"request_id,omitempty"`
-	StoredAt     time.Time          `json:"stored_at,omitempty"`
-	ExpiresAt    time.Time          `json:"expires_at,omitempty"`
+	StoredAt     time.Time          `json:"stored_at"`
+	ExpiresAt    time.Time          `json:"expires_at"`
 }
 
 // Store defines persistence operations for the Conversations lifecycle API.
@@ -77,9 +78,7 @@ func normalizeStoredConversation(src *StoredConversation) *StoredConversation {
 		conversationCopy := *src.Conversation
 		if conversationCopy.Metadata != nil {
 			metadataCopy := make(map[string]string, len(conversationCopy.Metadata))
-			for key, value := range conversationCopy.Metadata {
-				metadataCopy[key] = value
-			}
+			maps.Copy(metadataCopy, conversationCopy.Metadata)
 			conversationCopy.Metadata = metadataCopy
 		}
 		normalized.Conversation = &conversationCopy

--- a/internal/core/errors_test.go
+++ b/internal/core/errors_test.go
@@ -397,35 +397,35 @@ func TestParseProviderError_OpenRouter_TableDriven(t *testing.T) {
 			body:        []byte(`{"error":{"message":"Provider returned error","code":429,"metadata":{"provider_name":"Together","is_byok":false,"retry_after_seconds":1}},"user_id":"user_test_123"}`),
 			wantType:    ErrorTypeRateLimit,
 			wantMessage: "Provider returned error",
-			wantCode:    stringPointer("429"),
+			wantCode:    new("429"),
 		},
 		{
 			name:        "metadata raw with non generic message preserves original message",
 			body:        []byte(`{"error":{"message":"The selected provider rejected the request","code":"rate_limit_exceeded","metadata":{"raw":"deepseek/deepseek-v4-pro is temporarily rate-limited upstream. Please retry shortly.","provider_name":"Together"}},"user_id":"user_test_123"}`),
 			wantType:    ErrorTypeRateLimit,
 			wantMessage: "The selected provider rejected the request",
-			wantCode:    stringPointer("rate_limit_exceeded"),
+			wantCode:    new("rate_limit_exceeded"),
 		},
 		{
 			name:        "empty message with metadata raw uses raw and numeric code",
 			body:        []byte(`{"error":{"message":"","code":429,"metadata":{"raw":"deepseek/deepseek-v4-pro is temporarily rate-limited upstream. Please retry shortly.","provider_name":"Together","is_byok":false,"retry_after_seconds":1}},"user_id":"user_test_123"}`),
 			wantType:    ErrorTypeRateLimit,
 			wantMessage: "deepseek/deepseek-v4-pro is temporarily rate-limited upstream. Please retry shortly.",
-			wantCode:    stringPointer("429"),
+			wantCode:    new("429"),
 		},
 		{
 			name:        "provider returned prefix with metadata raw uses raw",
 			body:        []byte(`{"error":{"message":"Provider returned an error: upstream rejected the request","code":429,"metadata":{"raw":"deepseek/deepseek-v4-pro is temporarily rate-limited upstream. Please retry shortly.","provider_name":"Together"}},"user_id":"user_test_123"}`),
 			wantType:    ErrorTypeRateLimit,
 			wantMessage: "deepseek/deepseek-v4-pro is temporarily rate-limited upstream. Please retry shortly.",
-			wantCode:    stringPointer("429"),
+			wantCode:    new("429"),
 		},
 		{
 			name:        "malformed metadata falls back to parsed message and numeric code",
 			body:        []byte(`{"error":{"message":"Provider returned error","code":429,"metadata":"not an object"},"user_id":"user_test_123"}`),
 			wantType:    ErrorTypeRateLimit,
 			wantMessage: "Provider returned error",
-			wantCode:    stringPointer("429"),
+			wantCode:    new("429"),
 		},
 		{
 			name:        "missing metadata and object code falls back without code",
@@ -462,10 +462,6 @@ func equalStringPointers(a, b *string) bool {
 	default:
 		return *a == *b
 	}
-}
-
-func stringPointer(value string) *string {
-	return &value
 }
 
 func TestGatewayError_AsError(t *testing.T) {

--- a/internal/core/json_fields.go
+++ b/internal/core/json_fields.go
@@ -22,8 +22,7 @@ import (
 func jsonFieldNames(v any) []string {
 	t := reflect.TypeOf(v)
 	names := make([]string, 0, t.NumField())
-	for i := range t.NumField() {
-		field := t.Field(i)
+	for field := range t.Fields() {
 		if !field.IsExported() {
 			continue
 		}

--- a/internal/core/responses_field_parity_test.go
+++ b/internal/core/responses_field_parity_test.go
@@ -71,8 +71,7 @@ func TestInputTokensRequestCopiesEveryField(t *testing.T) {
 // fill sets every exported field of v to a non-zero value.
 func fill(t *testing.T, v reflect.Value) {
 	t.Helper()
-	for i := range v.NumField() {
-		field := v.Field(i)
+	for _, field := range v.Fields() {
 		if !field.CanSet() {
 			continue
 		}

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -1,6 +1,10 @@
 package core
 
-import "github.com/goccy/go-json"
+import (
+	"maps"
+
+	"github.com/goccy/go-json"
+)
 
 // StreamOptions controls streaming behavior options.
 // This is used to request usage data in streaming responses.
@@ -415,9 +419,7 @@ func (m *ModelMetadata) Clone() *ModelMetadata {
 	}
 	if len(m.Capabilities) > 0 {
 		caps := make(map[string]bool, len(m.Capabilities))
-		for k, v := range m.Capabilities {
-			caps[k] = v
-		}
+		maps.Copy(caps, m.Capabilities)
 		out.Capabilities = caps
 	} else {
 		out.Capabilities = nil
@@ -436,9 +438,7 @@ func (m *ModelMetadata) Clone() *ModelMetadata {
 	out.Pricing = m.Pricing.Clone()
 	if len(m.PricingSources) > 0 {
 		out.PricingSources = make(map[string]string, len(m.PricingSources))
-		for k, v := range m.PricingSources {
-			out.PricingSources[k] = v
-		}
+		maps.Copy(out.PricingSources, m.PricingSources)
 	} else {
 		out.PricingSources = nil
 	}

--- a/internal/core/usage_json.go
+++ b/internal/core/usage_json.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"maps"
+
 	"github.com/goccy/go-json"
 )
 
@@ -248,9 +250,7 @@ func mergeRawUsageObject(dst *map[string]any, raw json.RawMessage) error {
 	if *dst == nil {
 		*dst = make(map[string]any, len(decoded))
 	}
-	for key, value := range decoded {
-		(*dst)[key] = value
-	}
+	maps.Copy(*dst, decoded)
 	return nil
 }
 

--- a/internal/core/user_path_test.go
+++ b/internal/core/user_path_test.go
@@ -23,7 +23,6 @@ func TestNormalizeUserPath(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -68,7 +67,6 @@ func TestUserPathHeaderName(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/failover/resolver.go
+++ b/internal/failover/resolver.go
@@ -2,6 +2,7 @@ package failover
 
 import (
 	"math"
+	"slices"
 	"sort"
 	"strings"
 
@@ -322,13 +323,10 @@ func (r *Resolver) autoSelectorsFor(
 		return a.key < b.key
 	})
 
-	limit := maxAutoFailoverCandidates
-	if len(candidates) < limit {
-		limit = len(candidates)
-	}
+	limit := min(len(candidates), maxAutoFailoverCandidates)
 
 	result := make([]core.ModelSelector, 0, limit)
-	for i := 0; i < limit; i++ {
+	for i := range limit {
 		seen[candidates[i].key] = struct{}{}
 		result = append(result, candidates[i].selector)
 	}
@@ -415,12 +413,7 @@ func supportsCategory(meta *core.ModelMetadata, required core.ModelCategory) boo
 	if required == "" {
 		return true
 	}
-	for _, category := range meta.Categories {
-		if category == required {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(meta.Categories, required)
 }
 
 func preferredRanking(rankings map[string]core.ModelRanking) (string, core.ModelRanking, bool) {

--- a/internal/failover/resolver_test.go
+++ b/internal/failover/resolver_test.go
@@ -341,7 +341,7 @@ func modelInfoWithCategories(
 				Rankings: map[string]core.ModelRanking{
 					"chatbot_arena": {
 						Elo:  &elo,
-						Rank: intPtr(1),
+						Rank: new(1),
 						AsOf: "2026-02-22",
 					},
 				},
@@ -350,8 +350,4 @@ func modelInfoWithCategories(
 		ProviderName: providerName,
 		ProviderType: providerType,
 	}
-}
-
-func intPtr(v int) *int {
-	return &v
 }

--- a/internal/failover/suggest.go
+++ b/internal/failover/suggest.go
@@ -1,6 +1,7 @@
 package failover
 
 import (
+	"slices"
 	"strings"
 
 	"gomodel/config"
@@ -74,10 +75,5 @@ func modelSupportsCategory(meta *core.ModelMetadata, category core.ModelCategory
 	if meta == nil || len(meta.Categories) == 0 {
 		return true
 	}
-	for _, candidate := range meta.Categories {
-		if candidate == category {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(meta.Categories, category)
 }

--- a/internal/gateway/batch_orchestrator.go
+++ b/internal/gateway/batch_orchestrator.go
@@ -203,7 +203,7 @@ func (o *BatchOrchestrator) Create(ctx context.Context, req *core.BatchRequest, 
 			RequestID:                 strings.TrimSpace(meta.RequestID),
 			UserPath:                  core.UserPathFromContext(ctx),
 			WorkflowVersionID:         workflowVersionID(workflow),
-			UsageEnabled:              boolPtr(workflow == nil || workflow.UsageEnabled()),
+			UsageEnabled:              new(workflow == nil || workflow.UsageEnabled()),
 		}
 		if err := o.batchStore.Create(ctx, stored); err != nil {
 			o.rollbackPreparedBatch(ctx, providerType, batchPreparation, providerBatchID)
@@ -500,8 +500,4 @@ func workflowVersionID(workflow *core.Workflow) string {
 		return ""
 	}
 	return workflow.WorkflowVersionID()
-}
-
-func boolPtr(value bool) *bool {
-	return &value
 }

--- a/internal/gateway/model_helpers.go
+++ b/internal/gateway/model_helpers.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"maps"
 	"strings"
 
 	"gomodel/internal/core"
@@ -62,9 +63,7 @@ func CloneResponsesRequestForSelector(req *core.ResponsesRequest, selector core.
 	cloned.Tools = cloneToolMaps(req.Tools)
 	if req.Metadata != nil {
 		cloned.Metadata = make(map[string]string, len(req.Metadata))
-		for key, value := range req.Metadata {
-			cloned.Metadata[key] = value
-		}
+		maps.Copy(cloned.Metadata, req.Metadata)
 	}
 	if req.StreamOptions != nil {
 		streamOptions := *req.StreamOptions
@@ -89,9 +88,7 @@ func cloneToolMaps(tools []map[string]any) []map[string]any {
 			continue
 		}
 		cloned[i] = make(map[string]any, len(tool))
-		for key, value := range tool {
-			cloned[i][key] = value
-		}
+		maps.Copy(cloned[i], tool)
 	}
 	return cloned
 }

--- a/internal/guardrails/llm_based_altering.go
+++ b/internal/guardrails/llm_based_altering.go
@@ -436,8 +436,6 @@ func (g *LLMBasedAlteringGuardrail) rewriteTexts(ctx context.Context, texts []st
 	group.SetLimit(maxConcurrentRewrites)
 
 	for i, text := range texts {
-		i := i
-		text := text
 		group.Go(func() error {
 			result, err := g.rewriteText(groupCtx, text)
 			if err != nil {

--- a/internal/guardrails/responses_message_apply.go
+++ b/internal/guardrails/responses_message_apply.go
@@ -330,9 +330,7 @@ func patchResponsesInputMap(original map[string]any, patched core.ResponsesInput
 	for _, key := range []string{"type", "role", "status", "content", "call_id", "id", "name", "arguments", "output"} {
 		delete(cloned, key)
 	}
-	for key, value := range updated {
-		cloned[key] = value
-	}
+	maps.Copy(cloned, updated)
 	if patched.Type == "function_call_output" {
 		cloned["output"] = restoreResponsesInputOutputValue(original["output"], patched.Output)
 	}

--- a/internal/live/broker_test.go
+++ b/internal/live/broker_test.go
@@ -266,7 +266,7 @@ func TestBrokerStaleCursorReceivesResetAndActiveSnapshots(t *testing.T) {
 	b := NewBroker(Config{Enabled: true, BufferSize: 1, ReplayLimit: 1})
 	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		b.PublishAuditEvent(EventAuditUpdated, &auditlog.LogEntry{
 			ID:        "audit-1",
 			RequestID: "req-1",
@@ -293,7 +293,7 @@ func TestBrokerStaleCursorReceivesResetAndActiveSnapshots(t *testing.T) {
 
 func TestBrokerSignalsResetWhenCursorFallsOutOfReplayWindow(t *testing.T) {
 	b := NewBroker(Config{Enabled: true, BufferSize: 1, ReplayLimit: 1})
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		b.PublishAuditEvent(EventAuditStarted, &auditlog.LogEntry{
 			ID:        "audit",
 			RequestID: "req",
@@ -315,7 +315,7 @@ func TestBrokerSignalsResetWhenReplayGapExceedsLimit(t *testing.T) {
 	b := NewBroker(Config{Enabled: true, BufferSize: 10, ReplayLimit: 2})
 	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		b.PublishAuditEvent(EventAuditUpdated, &auditlog.LogEntry{
 			ID:             "audit-1",
 			RequestID:      "req-1",
@@ -376,7 +376,7 @@ func TestBrokerDropsSlowSubscribers(t *testing.T) {
 	}
 	defer sub.Close()
 
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		b.PublishAuditEvent(EventAuditUpdated, &auditlog.LogEntry{
 			ID:        "audit",
 			RequestID: "req",
@@ -977,7 +977,7 @@ func BenchmarkBrokerPublishSteadyState(b *testing.B) {
 		Model:     "gpt-test",
 		Provider:  "openai",
 	}
-	for i := 0; i < 10001; i++ {
+	for range 10001 {
 		broker.PublishUsageEvent(EventUsageFlushed, entry)
 	}
 
@@ -997,7 +997,7 @@ func TestBrokerReplayAfterBufferWrap(t *testing.T) {
 
 	// Publish 6 usage-flushed events (seq 1..6); the buffer retains seq 3..6
 	// with the ring head pointing mid-slice.
-	for i := 0; i < 6; i++ {
+	for i := range 6 {
 		b.PublishUsageEvent(EventUsageFlushed, &usage.UsageEntry{
 			ID:        "usage-wrap",
 			RequestID: "req-wrap",

--- a/internal/llmclient/client_test.go
+++ b/internal/llmclient/client_test.go
@@ -784,9 +784,7 @@ func TestClient_BuildErrorDoesNotRetryOrChargeBreaker(t *testing.T) {
 	}
 
 	for _, st := range states {
-		st := st
 		for _, e := range entries {
-			e := e
 			t.Run(st.name+"/"+e.name, func(t *testing.T) {
 				var attempts int32
 				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/modeldata/merge.go
+++ b/internal/modeldata/merge.go
@@ -2,6 +2,7 @@ package modeldata
 
 import (
 	"gomodel/internal/core"
+	"maps"
 )
 
 // MergeMetadata merges override onto base field-wise. Non-zero override fields
@@ -51,12 +52,8 @@ func MergeMetadata(base, override *core.ModelMetadata) *core.ModelMetadata {
 	}
 	if len(override.Capabilities) > 0 {
 		out := make(map[string]bool, len(merged.Capabilities)+len(override.Capabilities))
-		for k, v := range merged.Capabilities {
-			out[k] = v
-		}
-		for k, v := range override.Capabilities {
-			out[k] = v
-		}
+		maps.Copy(out, merged.Capabilities)
+		maps.Copy(out, override.Capabilities)
 		merged.Capabilities = out
 	}
 	if len(override.Rankings) > 0 {
@@ -64,9 +61,7 @@ func MergeMetadata(base, override *core.ModelMetadata) *core.ModelMetadata {
 		// merged.Rankings is already a deep clone from base.Clone(), so we can
 		// reuse its values directly; override values must be deep-cloned so the
 		// result does not share Elo/Rank pointers with the caller's input.
-		for k, v := range merged.Rankings {
-			out[k] = v
-		}
+		maps.Copy(out, merged.Rankings)
 		for k, v := range override.Rankings {
 			out[k] = core.CloneModelRanking(v)
 		}
@@ -89,8 +84,6 @@ func clonePricingSources(in map[string]string) map[string]string {
 		return nil
 	}
 	out := make(map[string]string, len(in))
-	for k, v := range in {
-		out[k] = v
-	}
+	maps.Copy(out, in)
 	return out
 }

--- a/internal/modeldata/merge_test.go
+++ b/internal/modeldata/merge_test.go
@@ -6,8 +6,6 @@ import (
 	"gomodel/internal/core"
 )
 
-func intPtr(v int) *int { return &v }
-
 func TestMergeMetadata_BothNil(t *testing.T) {
 	if got := MergeMetadata(nil, nil); got != nil {
 		t.Errorf("got %+v, want nil", got)
@@ -15,7 +13,7 @@ func TestMergeMetadata_BothNil(t *testing.T) {
 }
 
 func TestMergeMetadata_NilOverride(t *testing.T) {
-	base := &core.ModelMetadata{DisplayName: "Base", ContextWindow: intPtr(1024)}
+	base := &core.ModelMetadata{DisplayName: "Base", ContextWindow: new(1024)}
 	got := MergeMetadata(base, nil)
 	if got == nil || got.DisplayName != "Base" || *got.ContextWindow != 1024 {
 		t.Errorf("got %+v", got)
@@ -40,15 +38,15 @@ func TestMergeMetadata_OverrideWinsPerField(t *testing.T) {
 	base := &core.ModelMetadata{
 		DisplayName:     "Base",
 		Description:     "base desc",
-		ContextWindow:   intPtr(1024),
-		MaxOutputTokens: intPtr(256),
+		ContextWindow:   new(1024),
+		MaxOutputTokens: new(256),
 		Modes:           []string{"chat"},
 		Capabilities:    map[string]bool{"tools": false, "vision": true},
 		Pricing:         &core.ModelPricing{Currency: "USD"},
 	}
 	override := &core.ModelMetadata{
 		DisplayName:   "Overridden",
-		ContextWindow: intPtr(131072),
+		ContextWindow: new(131072),
 		Capabilities:  map[string]bool{"tools": true},
 	}
 	got := MergeMetadata(base, override)

--- a/internal/modeldata/types.go
+++ b/internal/modeldata/types.go
@@ -3,6 +3,7 @@
 package modeldata
 
 import (
+	"slices"
 	"strings"
 
 	"gomodel/internal/core"
@@ -75,10 +76,8 @@ func (l *ModelList) addAliasTarget(alias string, target aliasTarget) {
 		return
 	}
 	existing := l.aliasTargetsByID[alias]
-	for _, candidate := range existing {
-		if candidate == target {
-			return
-		}
+	if slices.Contains(existing, target) {
+		return
 	}
 	l.aliasTargetsByID[alias] = append(existing, target)
 }

--- a/internal/pricingoverrides/service_test.go
+++ b/internal/pricingoverrides/service_test.go
@@ -82,19 +82,15 @@ func (r selectivePricingResolver) ResolvePricing(model, provider string) *core.M
 	return r[provider+"/"+model]
 }
 
-func ptr(v float64) *float64 {
-	return &v
-}
-
 func TestServiceResolvePricingAppliesMostSpecificOverride(t *testing.T) {
 	baseInput := 1.0
 	baseOutput := 2.0
 	service, err := NewService(
 		newTestStore(
-			Override{Selector: "/", Pricing: Pricing{InputPerMtok: ptr(10)}},
-			Override{Selector: "openai/", Pricing: Pricing{InputPerMtok: ptr(20)}},
-			Override{Selector: "gpt-4o", Pricing: Pricing{InputPerMtok: ptr(30)}},
-			Override{Selector: "openai/gpt-4o", Pricing: Pricing{InputPerMtok: ptr(40)}},
+			Override{Selector: "/", Pricing: Pricing{InputPerMtok: new(float64(10))}},
+			Override{Selector: "openai/", Pricing: Pricing{InputPerMtok: new(float64(20))}},
+			Override{Selector: "gpt-4o", Pricing: Pricing{InputPerMtok: new(float64(30))}},
+			Override{Selector: "openai/gpt-4o", Pricing: Pricing{InputPerMtok: new(float64(40))}},
 		),
 		testCatalog{providerNames: []string{"openai"}},
 		staticPricingResolver{pricing: &core.ModelPricing{
@@ -127,8 +123,8 @@ func TestServiceResolvePricingAppliesMostSpecificOverride(t *testing.T) {
 func TestServiceResolvePricingModelWideBeatsProviderWide(t *testing.T) {
 	service, err := NewService(
 		newTestStore(
-			Override{Selector: "openai/", Pricing: Pricing{InputPerMtok: ptr(20)}},
-			Override{Selector: "gpt-4o", Pricing: Pricing{InputPerMtok: ptr(30)}},
+			Override{Selector: "openai/", Pricing: Pricing{InputPerMtok: new(float64(20))}},
+			Override{Selector: "gpt-4o", Pricing: Pricing{InputPerMtok: new(float64(30))}},
 		),
 		testCatalog{providerNames: []string{"openai"}},
 		nil,
@@ -149,9 +145,9 @@ func TestServiceResolvePricingModelWideBeatsProviderWide(t *testing.T) {
 func TestServiceResolvePricingPreservesSlashShapedModelIDs(t *testing.T) {
 	service, err := NewService(
 		newTestStore(
-			Override{Selector: "openrouter/", Pricing: Pricing{InputPerMtok: ptr(20)}},
-			Override{Selector: "anthropic/claude-sonnet", Pricing: Pricing{InputPerMtok: ptr(30)}},
-			Override{Selector: "openrouter/anthropic/claude-sonnet", Pricing: Pricing{InputPerMtok: ptr(40)}},
+			Override{Selector: "openrouter/", Pricing: Pricing{InputPerMtok: new(float64(20))}},
+			Override{Selector: "anthropic/claude-sonnet", Pricing: Pricing{InputPerMtok: new(float64(30))}},
+			Override{Selector: "openrouter/anthropic/claude-sonnet", Pricing: Pricing{InputPerMtok: new(float64(40))}},
 		),
 		testCatalog{providerNames: []string{"openrouter"}},
 		nil,
@@ -199,8 +195,8 @@ func TestServiceResolvePricingFallsBackToRawProviderOwnedModelForBasePricing(t *
 func TestServiceResolvePricingSlashShapedModelWideBeatsProviderWide(t *testing.T) {
 	service, err := NewService(
 		newTestStore(
-			Override{Selector: "openrouter/", Pricing: Pricing{InputPerMtok: ptr(20)}},
-			Override{Selector: "anthropic/claude-sonnet", Model: "anthropic/claude-sonnet", Pricing: Pricing{InputPerMtok: ptr(30)}},
+			Override{Selector: "openrouter/", Pricing: Pricing{InputPerMtok: new(float64(20))}},
+			Override{Selector: "anthropic/claude-sonnet", Model: "anthropic/claude-sonnet", Pricing: Pricing{InputPerMtok: new(float64(30))}},
 		),
 		testCatalog{providerNames: []string{"openrouter"}},
 		nil,
@@ -229,7 +225,7 @@ func TestServiceRejectsEmptyAndNegativePricing(t *testing.T) {
 	}
 	if err := service.Upsert(context.Background(), Override{
 		Selector: "openai/gpt-4o",
-		Pricing:  Pricing{InputPerMtok: ptr(-1)},
+		Pricing:  Pricing{InputPerMtok: new(float64(-1))},
 	}); !IsValidationError(err) {
 		t.Fatalf("Upsert(negative) error = %v, want validation", err)
 	}
@@ -248,38 +244,38 @@ func TestServiceRejectsInvalidTieredPricing(t *testing.T) {
 		{
 			name: "missing threshold",
 			pricing: Pricing{Tiers: []PricingTier{
-				{InputPerMtok: ptr(1)},
+				{InputPerMtok: new(float64(1))},
 			}},
 		},
 		{
 			name: "missing rate",
 			pricing: Pricing{Tiers: []PricingTier{
-				{UpToTokens: ptr(1000)},
+				{UpToTokens: new(float64(1000))},
 			}},
 		},
 		{
 			name: "non-increasing thresholds",
 			pricing: Pricing{Tiers: []PricingTier{
-				{UpToTokens: ptr(1000), InputPerMtok: ptr(1)},
-				{UpToTokens: ptr(500), InputPerMtok: ptr(2)},
+				{UpToTokens: new(float64(1000)), InputPerMtok: new(float64(1))},
+				{UpToTokens: new(float64(500)), InputPerMtok: new(float64(2))},
 			}},
 		},
 		{
 			name: "zero threshold",
 			pricing: Pricing{Tiers: []PricingTier{
-				{UpToMtok: ptr(0), InputPerMtok: ptr(1)},
+				{UpToMtok: new(float64(0)), InputPerMtok: new(float64(1))},
 			}},
 		},
 		{
 			name: "both threshold units",
 			pricing: Pricing{Tiers: []PricingTier{
-				{UpToTokens: ptr(1000), UpToMtok: ptr(1), InputPerMtok: ptr(1)},
+				{UpToTokens: new(float64(1000)), UpToMtok: new(float64(1)), InputPerMtok: new(float64(1))},
 			}},
 		},
 		{
 			name: "negative tier rate",
 			pricing: Pricing{Tiers: []PricingTier{
-				{UpToTokens: ptr(1000), InputPerMtok: ptr(-1)},
+				{UpToTokens: new(float64(1000)), InputPerMtok: new(float64(-1))},
 			}},
 		},
 	}
@@ -305,8 +301,8 @@ func TestServiceAcceptsIncreasingTieredPricing(t *testing.T) {
 	err = service.Upsert(context.Background(), Override{
 		Selector: "openai/gpt-4o",
 		Pricing: Pricing{Tiers: []PricingTier{
-			{UpToTokens: ptr(200_000), InputPerMtok: ptr(1)},
-			{UpToMtok: ptr(1), InputPerMtok: ptr(0.5)},
+			{UpToTokens: new(float64(200_000)), InputPerMtok: new(float64(1))},
+			{UpToMtok: new(float64(1)), InputPerMtok: new(0.5)},
 		}},
 	})
 	if err != nil {
@@ -325,7 +321,7 @@ func TestServiceReconcilesSnapshotWhenUpsertRollbackFails(t *testing.T) {
 	store.deleteErr = errors.New("rollback delete failed")
 	err = service.Upsert(context.Background(), Override{
 		Selector: "openai/gpt-4o",
-		Pricing:  Pricing{InputPerMtok: ptr(9)},
+		Pricing:  Pricing{InputPerMtok: new(float64(9))},
 	})
 	if err == nil {
 		t.Fatal("Upsert() error = nil, want refresh/rollback error")
@@ -342,7 +338,7 @@ func TestServiceReconcilesSnapshotWhenDeleteRollbackFails(t *testing.T) {
 		Selector:     "openai/gpt-4o",
 		ProviderName: "openai",
 		Model:        "gpt-4o",
-		Pricing:      Pricing{InputPerMtok: ptr(9)},
+		Pricing:      Pricing{InputPerMtok: new(float64(9))},
 	})
 	service, err := NewService(store, testCatalog{providerNames: []string{"openai"}}, nil)
 	if err != nil {
@@ -371,8 +367,8 @@ func TestServiceBuildSnapshotRejectsDuplicateNormalizedSelectors(t *testing.T) {
 	}
 
 	_, err = service.buildSnapshot([]Override{
-		{Selector: "openai/gpt-4o", ProviderName: "openai", Model: "gpt-4o", Pricing: Pricing{InputPerMtok: ptr(1)}},
-		{Selector: " openai/gpt-4o ", ProviderName: "openai", Model: "gpt-4o", Pricing: Pricing{InputPerMtok: ptr(2)}},
+		{Selector: "openai/gpt-4o", ProviderName: "openai", Model: "gpt-4o", Pricing: Pricing{InputPerMtok: new(float64(1))}},
+		{Selector: " openai/gpt-4o ", ProviderName: "openai", Model: "gpt-4o", Pricing: Pricing{InputPerMtok: new(float64(2))}},
 	})
 	if err == nil {
 		t.Fatal("buildSnapshot() error = nil, want duplicate selector error")

--- a/internal/pricingoverrides/store_sqlite_test.go
+++ b/internal/pricingoverrides/store_sqlite_test.go
@@ -26,7 +26,7 @@ func TestSQLiteStoreStoresPricingWithoutCurrency(t *testing.T) {
 
 	if err := store.Upsert(context.Background(), Override{
 		Selector: "openai/gpt-4o",
-		Pricing:  Pricing{InputPerMtok: ptr(1.25)},
+		Pricing:  Pricing{InputPerMtok: new(1.25)},
 	}); err != nil {
 		t.Fatalf("Upsert() error = %v", err)
 	}

--- a/internal/providers/bedrock/bedrock.go
+++ b/internal/providers/bedrock/bedrock.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -110,11 +111,10 @@ func parseBaseURL(baseURL string) (region, endpoint string) {
 // segments from custom hosts that happen to contain "bedrock." in their name,
 // the host must end with ".amazonaws.com".
 func regionFromHost(rawURL string) string {
-	idx := strings.Index(rawURL, "://")
-	if idx < 0 {
+	_, host, ok := strings.Cut(rawURL, "://")
+	if !ok {
 		return ""
 	}
-	host := rawURL[idx+3:]
 	if slash := strings.IndexByte(host, '/'); slash >= 0 {
 		host = host[:slash]
 	}
@@ -213,12 +213,7 @@ func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error)
 }
 
 func supportsTextOutput(modalities []bedrocktypes.ModelModality) bool {
-	for _, m := range modalities {
-		if m == bedrocktypes.ModelModalityText {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(modalities, bedrocktypes.ModelModalityText)
 }
 
 // Embeddings returns an error: Bedrock embedding models use a different code

--- a/internal/providers/factory.go
+++ b/internal/providers/factory.go
@@ -3,6 +3,7 @@ package providers
 
 import (
 	"fmt"
+	"maps"
 	"sort"
 	"sync"
 
@@ -111,9 +112,7 @@ func (f *ProviderFactory) discoveryConfigsSnapshot() map[string]DiscoveryConfig 
 	defer f.mu.RUnlock()
 
 	snapshot := make(map[string]DiscoveryConfig, len(f.discoveryConfigs))
-	for providerType, cfg := range f.discoveryConfigs {
-		snapshot[providerType] = cfg
-	}
+	maps.Copy(snapshot, f.discoveryConfigs)
 	return snapshot
 }
 

--- a/internal/providers/gemini/gemini.go
+++ b/internal/providers/gemini/gemini.go
@@ -347,11 +347,11 @@ func geminiModelsBaseURL(backend, nativeBaseURL string) string {
 func vertexPublisherModelsBaseURL(nativeBaseURL string) (string, bool) {
 	const projectsPath = "/v1/projects/"
 	nativeBaseURL = strings.TrimRight(strings.TrimSpace(nativeBaseURL), "/")
-	idx := strings.Index(nativeBaseURL, projectsPath)
-	if idx < 0 {
+	before, _, ok := strings.Cut(nativeBaseURL, projectsPath)
+	if !ok {
 		return "", false
 	}
-	root := strings.TrimRight(nativeBaseURL[:idx], "/")
+	root := strings.TrimRight(before, "/")
 	if root == "" {
 		return "", false
 	}

--- a/internal/providers/gemini/gemini_test.go
+++ b/internal/providers/gemini/gemini_test.go
@@ -1475,7 +1475,7 @@ func parseOpenAIStreamChunks(t *testing.T, stream string) []map[string]any {
 	t.Helper()
 
 	var chunks []map[string]any
-	for _, line := range strings.Split(stream, "\n") {
+	for line := range strings.SplitSeq(stream, "\n") {
 		line = strings.TrimSpace(line)
 		if !strings.HasPrefix(line, "data:") {
 			continue

--- a/internal/providers/gemini/native.go
+++ b/internal/providers/gemini/native.go
@@ -95,7 +95,7 @@ type geminiFunctionCallingConfig struct {
 type geminiGenerateContentResponse struct {
 	Candidates     []geminiCandidate   `json:"candidates,omitempty"`
 	PromptFeedback json.RawMessage     `json:"promptFeedback,omitempty"`
-	UsageMetadata  geminiUsageMetadata `json:"usageMetadata,omitempty"`
+	UsageMetadata  geminiUsageMetadata `json:"usageMetadata"`
 	ModelVersion   string              `json:"modelVersion,omitempty"`
 	ResponseID     string              `json:"responseId,omitempty"`
 	ModelStatus    json.RawMessage     `json:"modelStatus,omitempty"`
@@ -107,7 +107,7 @@ type geminiPromptFeedback struct {
 }
 
 type geminiCandidate struct {
-	Content       geminiContent   `json:"content,omitempty"`
+	Content       geminiContent   `json:"content"`
 	FinishReason  string          `json:"finishReason,omitempty"`
 	Index         int             `json:"index,omitempty"`
 	SafetyRatings json.RawMessage `json:"safetyRatings,omitempty"`

--- a/internal/providers/registry_metadata.go
+++ b/internal/providers/registry_metadata.go
@@ -213,9 +213,7 @@ func (r *ModelRegistry) snapshotConfigOverrides() map[string]map[string]*core.Mo
 	out := make(map[string]map[string]*core.ModelMetadata, len(r.configMetadataOverrides))
 	for provider, inner := range r.configMetadataOverrides {
 		innerCopy := make(map[string]*core.ModelMetadata, len(inner))
-		for modelID, meta := range inner {
-			innerCopy[modelID] = meta
-		}
+		maps.Copy(innerCopy, inner)
 		out[provider] = innerCopy
 	}
 	return out
@@ -251,8 +249,8 @@ func collectionEmpty(v reflect.Value) bool {
 // structFieldsEmpty returns true if every field of the given struct value
 // passes collectionEmpty.
 func structFieldsEmpty(v reflect.Value) bool {
-	for i := 0; i < v.NumField(); i++ {
-		if !collectionEmpty(v.Field(i)) {
+	for _, field := range v.Fields() {
+		if !collectionEmpty(field) {
 			return false
 		}
 	}

--- a/internal/providers/registry_metadata_override_test.go
+++ b/internal/providers/registry_metadata_override_test.go
@@ -8,10 +8,6 @@ import (
 	"gomodel/internal/modeldata"
 )
 
-func ctxWindow(v int) *int { return &v }
-
-func price(v float64) *float64 { return &v }
-
 // TestInitialize_AppliesConfigMetadataOverrides verifies that operator-supplied
 // metadata from config.yaml takes precedence over (and merges onto) the remote
 // model registry during provider initialization. Exercises the config-driven
@@ -44,12 +40,12 @@ func TestInitialize_AppliesConfigMetadataOverrides(t *testing.T) {
 	registry.SetProviderMetadataOverrides("nippur", map[string]*core.ModelMetadata{
 		"GLM-4.7-Flash": {
 			DisplayName:   "GLM 4.7 Flash (local)",
-			ContextWindow: ctxWindow(131072),
+			ContextWindow: new(131072),
 			Capabilities:  map[string]bool{"tools": true},
 			Pricing: &core.ModelPricing{
 				Currency:      "USD",
-				InputPerMtok:  price(0),
-				OutputPerMtok: price(0),
+				InputPerMtok:  new(float64(0)),
+				OutputPerMtok: new(float64(0)),
 			},
 		},
 	})
@@ -119,7 +115,7 @@ func TestInitialize_OverrideMergesOnRemoteEnrichment(t *testing.T) {
 
 	// Override only the context window; display name should come from the remote registry.
 	registry.SetProviderMetadataOverrides("openai-main", map[string]*core.ModelMetadata{
-		"shared-model": {ContextWindow: ctxWindow(262144)},
+		"shared-model": {ContextWindow: new(262144)},
 	})
 
 	if err := registry.Initialize(context.Background()); err != nil {
@@ -302,7 +298,7 @@ func TestApplyConfigMetadataOverrides_NoOpPreservesPointerIdentity(t *testing.T)
 			ID: "same-model",
 			Metadata: &core.ModelMetadata{
 				DisplayName:   "Same Display",
-				ContextWindow: ctxWindow(131072),
+				ContextWindow: new(131072),
 				Capabilities:  map[string]bool{"tools": true},
 			},
 		},
@@ -317,7 +313,7 @@ func TestApplyConfigMetadataOverrides_NoOpPreservesPointerIdentity(t *testing.T)
 		"nippur": {
 			"same-model": {
 				DisplayName:   "Same Display",
-				ContextWindow: ctxWindow(131072),
+				ContextWindow: new(131072),
 				Capabilities:  map[string]bool{"tools": true},
 			},
 		},
@@ -383,7 +379,7 @@ func TestMetadataOverrideEmpty(t *testing.T) {
 		{"empty non-nil rankings", &core.ModelMetadata{Rankings: map[string]core.ModelRanking{}}, true},
 		{"pricing with empty tiers", &core.ModelMetadata{Pricing: &core.ModelPricing{Tiers: []core.ModelPricingTier{}}}, true},
 		{"display name set", &core.ModelMetadata{DisplayName: "X"}, false},
-		{"context window set", &core.ModelMetadata{ContextWindow: ctxWindow(1024)}, false},
+		{"context window set", &core.ModelMetadata{ContextWindow: new(1024)}, false},
 		{"capabilities set", &core.ModelMetadata{Capabilities: map[string]bool{"tools": true}}, false},
 		{"modes set", &core.ModelMetadata{Modes: []string{"chat"}}, false},
 		{"pricing currency set", &core.ModelMetadata{Pricing: &core.ModelPricing{Currency: "USD"}}, false},
@@ -429,7 +425,7 @@ func TestSetProviderMetadataOverrides_DeepClonesExternalInput(t *testing.T) {
 		"m": {
 			Modes:         []string{"chat"},
 			Capabilities:  map[string]bool{"tools": true},
-			ContextWindow: ctxWindow(4096),
+			ContextWindow: new(4096),
 			Pricing:       &core.ModelPricing{Currency: "USD"},
 		},
 	}

--- a/internal/providers/resolve_bench_test.go
+++ b/internal/providers/resolve_bench_test.go
@@ -17,7 +17,7 @@ func buildBenchRegistry(providersN, totalModels int) *ModelRegistry {
 		provs[p] = &mockProvider{name: fmt.Sprintf("prov%d", p)}
 	}
 	entries := make([]registryModelEntry, 0, totalModels)
-	for i := 0; i < totalModels; i++ {
+	for i := range totalModels {
 		p := i % providersN
 		entries = append(entries, registryModelEntry{
 			provider:     provs[p],

--- a/internal/providers/responses_converter.go
+++ b/internal/providers/responses_converter.go
@@ -394,8 +394,7 @@ func (sc *OpenAIResponsesStreamConverter) Read(p []byte) (n int, err error) {
 				continue
 			}
 
-			if after, ok := bytes.CutPrefix(line, []byte("data: ")); ok {
-				data := after
+			if data, ok := bytes.CutPrefix(line, []byte("data: ")); ok {
 				if bytes.Equal(data, []byte("[DONE]")) {
 					sc.appendCompletedEvents()
 					continue

--- a/internal/providers/vllm/vllm.go
+++ b/internal/providers/vllm/vllm.go
@@ -143,8 +143,8 @@ func (p *Provider) Passthrough(ctx context.Context, req *core.PassthroughRequest
 
 func passthroughBaseURL(baseURL string) string {
 	trimmed := strings.TrimRight(strings.TrimSpace(baseURL), "/")
-	if strings.HasSuffix(trimmed, "/v1") {
-		return strings.TrimSuffix(trimmed, "/v1")
+	if before, ok := strings.CutSuffix(trimmed, "/v1"); ok {
+		return before
 	}
 	return trimmed
 }

--- a/internal/providers/xai/xai.go
+++ b/internal/providers/xai/xai.go
@@ -161,10 +161,7 @@ func xGrokAnchorMessages(messages []core.Message) []core.Message {
 	if len(messages) == 0 {
 		return nil
 	}
-	limit := 2
-	if len(messages) < limit {
-		limit = len(messages)
-	}
+	limit := min(len(messages), 2)
 	anchor := make([]core.Message, limit)
 	copy(anchor, messages[:limit])
 	return anchor

--- a/internal/ratelimit/limiter.go
+++ b/internal/ratelimit/limiter.go
@@ -33,23 +33,14 @@ func (w *windowCounter) advance(now time.Time, periodSeconds int64) {
 // estimate returns the weighted sliding-window usage at now. advance must be
 // called first for the same now.
 func (w *windowCounter) estimate(now time.Time, periodSeconds int64) int64 {
-	elapsed := now.Unix() - w.windowStart
-	if elapsed < 0 {
-		elapsed = 0
-	}
-	if elapsed > periodSeconds {
-		elapsed = periodSeconds
-	}
+	elapsed := min(max(now.Unix()-w.windowStart, 0), periodSeconds)
 	weight := float64(periodSeconds-elapsed) / float64(periodSeconds)
 	return int64(float64(w.previous)*weight) + w.current
 }
 
 // resetAfter returns the time until the current window rolls over.
 func (w *windowCounter) resetAfter(now time.Time, periodSeconds int64) time.Duration {
-	remaining := w.windowStart + periodSeconds - now.Unix()
-	if remaining < 1 {
-		remaining = 1
-	}
+	remaining := max(w.windowStart+periodSeconds-now.Unix(), 1)
 	return time.Duration(remaining) * time.Second
 }
 
@@ -146,10 +137,7 @@ func (l *limiter) admit(rules []Rule, now time.Time) (HeaderSnapshot, []ruleKey,
 		if rule.MaxRequests != nil {
 			counter := l.requests[key]
 			counter.current++
-			remaining := *rule.MaxRequests - counter.estimate(now, rule.PeriodSeconds)
-			if remaining < 0 {
-				remaining = 0
-			}
+			remaining := max(*rule.MaxRequests-counter.estimate(now, rule.PeriodSeconds), 0)
 			if !headers.HasRequests || remaining < headers.RequestRemaining {
 				headers.HasRequests = true
 				headers.RequestLimit = *rule.MaxRequests
@@ -159,10 +147,7 @@ func (l *limiter) admit(rules []Rule, now time.Time) (HeaderSnapshot, []ruleKey,
 		}
 		if rule.MaxTokens != nil {
 			counter := l.tokens[key]
-			remaining := *rule.MaxTokens - counter.estimate(now, rule.PeriodSeconds)
-			if remaining < 0 {
-				remaining = 0
-			}
+			remaining := max(*rule.MaxTokens-counter.estimate(now, rule.PeriodSeconds), 0)
 			if !headers.HasTokens || remaining < headers.TokenRemaining {
 				headers.HasTokens = true
 				headers.TokenLimit = *rule.MaxTokens

--- a/internal/ratelimit/service_test.go
+++ b/internal/ratelimit/service_test.go
@@ -65,8 +65,6 @@ func (m *memStore) ReplaceConfigRules(ctx context.Context, rules []Rule) error {
 
 func (m *memStore) Close() error { return nil }
 
-func int64Ptr(v int64) *int64 { return &v }
-
 // onPath builds request subjects for user-path-only tests.
 func onPath(path string) Subjects { return Subjects{UserPath: path} }
 
@@ -91,10 +89,10 @@ func TestAcquireEnforcesRequestLimit(t *testing.T) {
 	service := newTestService(t, Rule{
 		Subject:       "/team",
 		PeriodSeconds: PeriodMinuteSeconds,
-		MaxRequests:   int64Ptr(2),
+		MaxRequests:   new(int64(2)),
 	})
 
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		if _, err := service.Acquire(onPath("/team/alice"), windowBase); err != nil {
 			t.Fatalf("Acquire() %d failed: %v", i, err)
 		}
@@ -124,9 +122,9 @@ func TestRetryAfterReflectsSlidingWindowRecovery(t *testing.T) {
 		service := newTestService(t, Rule{
 			Subject:       "/",
 			PeriodSeconds: PeriodMinuteSeconds,
-			MaxRequests:   int64Ptr(10),
+			MaxRequests:   new(int64(10)),
 		})
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			if _, err := service.Acquire(onPath("/"), windowBase); err != nil {
 				t.Fatalf("Acquire() %d failed: %v", i, err)
 			}
@@ -153,7 +151,7 @@ func TestRetryAfterReflectsSlidingWindowRecovery(t *testing.T) {
 		service := newTestService(t, Rule{
 			Subject:       "/",
 			PeriodSeconds: PeriodMinuteSeconds,
-			MaxTokens:     int64Ptr(10),
+			MaxTokens:     new(int64(10)),
 		})
 		// A single response overshoots the token window threefold; recovery
 		// needs the rollover plus enough decay: 30*(60-41)/60 = 9 < 10.
@@ -180,8 +178,8 @@ func TestRetryAfterReflectsSlidingWindowRecovery(t *testing.T) {
 // the minute rule's Retry-After would just earn a second 429.
 func TestAcquireReportsLongestBlockingRule(t *testing.T) {
 	service := newTestService(t,
-		Rule{Subject: "/", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: int64Ptr(1)},
-		Rule{Subject: "/", PeriodSeconds: PeriodDaySeconds, MaxRequests: int64Ptr(1)},
+		Rule{Subject: "/", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(1))},
+		Rule{Subject: "/", PeriodSeconds: PeriodDaySeconds, MaxRequests: new(int64(1))},
 	)
 
 	if _, err := service.Acquire(onPath("/"), windowBase); err != nil {
@@ -204,7 +202,7 @@ func TestAcquireRequestsShareSubtreeCounter(t *testing.T) {
 	service := newTestService(t, Rule{
 		Subject:       "/team",
 		PeriodSeconds: PeriodMinuteSeconds,
-		MaxRequests:   int64Ptr(1),
+		MaxRequests:   new(int64(1)),
 	})
 
 	if _, err := service.Acquire(onPath("/team/alice"), windowBase); err != nil {
@@ -223,10 +221,10 @@ func TestAcquireSlidingWindowWeighsPreviousWindow(t *testing.T) {
 	service := newTestService(t, Rule{
 		Subject:       "/",
 		PeriodSeconds: PeriodMinuteSeconds,
-		MaxRequests:   int64Ptr(10),
+		MaxRequests:   new(int64(10)),
 	})
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if _, err := service.Acquire(onPath("/"), windowBase); err != nil {
 			t.Fatalf("Acquire() %d failed: %v", i, err)
 		}
@@ -255,7 +253,7 @@ func TestTokenLimitIsPostAccounted(t *testing.T) {
 	service := newTestService(t, Rule{
 		Subject:       "/team",
 		PeriodSeconds: PeriodMinuteSeconds,
-		MaxTokens:     int64Ptr(100),
+		MaxTokens:     new(int64(100)),
 	})
 
 	// Tokens are unknown before the response: the first request passes.
@@ -283,7 +281,7 @@ func TestConcurrencyLimitHeldUntilRelease(t *testing.T) {
 	service := newTestService(t, Rule{
 		Subject:       "/team",
 		PeriodSeconds: PeriodConcurrent,
-		MaxRequests:   int64Ptr(1),
+		MaxRequests:   new(int64(1)),
 	})
 
 	first, err := service.Acquire(onPath("/team/alice"), windowBase)
@@ -314,8 +312,8 @@ func TestConcurrencyLimitHeldUntilRelease(t *testing.T) {
 
 func TestAcquireHeadersReportMostConstrainedRule(t *testing.T) {
 	service := newTestService(t,
-		Rule{Subject: "/", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: int64Ptr(100), MaxTokens: int64Ptr(1000)},
-		Rule{Subject: "/team", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: int64Ptr(5)},
+		Rule{Subject: "/", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(100)), MaxTokens: new(int64(1000))},
+		Rule{Subject: "/team", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(5))},
 	)
 
 	reservation, err := service.Acquire(onPath("/team/alice"), windowBase)
@@ -347,10 +345,10 @@ func TestAcquireWithoutMatchingRulesIsUnlimited(t *testing.T) {
 	service := newTestService(t, Rule{
 		Subject:       "/team",
 		PeriodSeconds: PeriodMinuteSeconds,
-		MaxRequests:   int64Ptr(1),
+		MaxRequests:   new(int64(1)),
 	})
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		reservation, err := service.Acquire(onPath("/other"), windowBase)
 		if err != nil {
 			t.Fatalf("Acquire() %d failed: %v", i, err)
@@ -363,8 +361,8 @@ func TestAcquireWithoutMatchingRulesIsUnlimited(t *testing.T) {
 
 func TestRejectedAcquireDoesNotConsumeCounters(t *testing.T) {
 	service := newTestService(t,
-		Rule{Subject: "/team", PeriodSeconds: PeriodConcurrent, MaxRequests: int64Ptr(1)},
-		Rule{Subject: "/team", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: int64Ptr(10)},
+		Rule{Subject: "/team", PeriodSeconds: PeriodConcurrent, MaxRequests: new(int64(1))},
+		Rule{Subject: "/team", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(10))},
 	)
 
 	held, err := service.Acquire(onPath("/team"), windowBase)
@@ -388,8 +386,8 @@ func TestStatusesAndResets(t *testing.T) {
 	service := newTestService(t, Rule{
 		Subject:       "/team",
 		PeriodSeconds: PeriodMinuteSeconds,
-		MaxRequests:   int64Ptr(2),
-		MaxTokens:     int64Ptr(100),
+		MaxRequests:   new(int64(2)),
+		MaxTokens:     new(int64(100)),
 	})
 
 	if _, err := service.Acquire(onPath("/team"), windowBase); err != nil {
@@ -431,10 +429,10 @@ func TestStatusesAndResets(t *testing.T) {
 
 func TestStatusesForUserPathFiltersByScopeAndSubtree(t *testing.T) {
 	service := newTestService(t,
-		Rule{Subject: "/team", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: int64Ptr(5)},
-		Rule{Subject: "/team/alice", PeriodSeconds: PeriodConcurrent, MaxRequests: int64Ptr(2)},
-		Rule{Subject: "/other", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: int64Ptr(5)},
-		Rule{Scope: ScopeProvider, Subject: "openai", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: int64Ptr(100)},
+		Rule{Subject: "/team", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(5))},
+		Rule{Subject: "/team/alice", PeriodSeconds: PeriodConcurrent, MaxRequests: new(int64(2))},
+		Rule{Subject: "/other", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(5))},
+		Rule{Scope: ScopeProvider, Subject: "openai", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(100))},
 	)
 
 	if _, err := service.Acquire(onPath("/team/alice"), windowBase); err != nil {
@@ -488,7 +486,7 @@ func TestUpsertDeleteAndHasTokenRules(t *testing.T) {
 		t.Fatal("HasTokenRules() = true for empty service")
 	}
 	if err := service.UpsertRules(context.Background(), []Rule{
-		{Subject: "/team", PeriodSeconds: PeriodMinuteSeconds, MaxTokens: int64Ptr(100), Source: SourceManual},
+		{Subject: "/team", PeriodSeconds: PeriodMinuteSeconds, MaxTokens: new(int64(100)), Source: SourceManual},
 	}); err != nil {
 		t.Fatalf("UpsertRules() failed: %v", err)
 	}
@@ -527,7 +525,7 @@ func TestProviderScopedRules(t *testing.T) {
 		Scope:         ScopeProvider,
 		Subject:       "openai",
 		PeriodSeconds: PeriodMinuteSeconds,
-		MaxRequests:   int64Ptr(1),
+		MaxRequests:   new(int64(1)),
 	})
 
 	route := Subjects{UserPath: "/team/alice", Provider: "openai", Model: "openai/gpt-4o"}
@@ -563,7 +561,7 @@ func TestModelScopedRules(t *testing.T) {
 			Scope:         ScopeModel,
 			Subject:       "gpt-4o",
 			PeriodSeconds: PeriodMinuteSeconds,
-			MaxRequests:   int64Ptr(1),
+			MaxRequests:   new(int64(1)),
 		})
 		if _, err := service.Acquire(Subjects{UserPath: "/", Provider: "openai", Model: "openai/gpt-4o"}, windowBase); err != nil {
 			t.Fatalf("Acquire() failed: %v", err)
@@ -581,7 +579,7 @@ func TestModelScopedRules(t *testing.T) {
 			Scope:         ScopeModel,
 			Subject:       "openai/gpt-4o",
 			PeriodSeconds: PeriodMinuteSeconds,
-			MaxRequests:   int64Ptr(1),
+			MaxRequests:   new(int64(1)),
 		})
 		// Matches the qualified model, and the bare model when the provider agrees.
 		if _, err := service.Acquire(Subjects{UserPath: "/", Provider: "openai", Model: "gpt-4o"}, windowBase); err != nil {
@@ -599,13 +597,13 @@ func TestModelScopedRules(t *testing.T) {
 
 func TestRouteAvailableProbesWithoutConsuming(t *testing.T) {
 	service := newTestService(t,
-		Rule{Scope: ScopeProvider, Subject: "openai", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: int64Ptr(1)},
-		Rule{Scope: ScopeProvider, Subject: "openai", PeriodSeconds: PeriodConcurrent, MaxRequests: int64Ptr(1)},
-		Rule{Subject: "/team", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: int64Ptr(1)},
+		Rule{Scope: ScopeProvider, Subject: "openai", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(1))},
+		Rule{Scope: ScopeProvider, Subject: "openai", PeriodSeconds: PeriodConcurrent, MaxRequests: new(int64(1))},
+		Rule{Subject: "/team", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(1))},
 	)
 
 	// Probing repeatedly consumes nothing.
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		if !service.routeAvailableAt("openai", "openai/gpt-4o", windowBase) {
 			t.Fatalf("RouteAvailable() probe %d = false, want true", i)
 		}
@@ -636,8 +634,8 @@ func TestRouteAvailableProbesWithoutConsuming(t *testing.T) {
 
 func TestRecordTokensChargesProviderAndModelWindows(t *testing.T) {
 	service := newTestService(t,
-		Rule{Scope: ScopeProvider, Subject: "openai", PeriodSeconds: PeriodMinuteSeconds, MaxTokens: int64Ptr(100)},
-		Rule{Scope: ScopeModel, Subject: "gpt-4o", PeriodSeconds: PeriodMinuteSeconds, MaxTokens: int64Ptr(50)},
+		Rule{Scope: ScopeProvider, Subject: "openai", PeriodSeconds: PeriodMinuteSeconds, MaxTokens: new(int64(100))},
+		Rule{Scope: ScopeModel, Subject: "gpt-4o", PeriodSeconds: PeriodMinuteSeconds, MaxTokens: new(int64(50))},
 	)
 
 	// Usage entries carry the executed provider name and a bare model id.

--- a/internal/ratelimit/store_sqlite_test.go
+++ b/internal/ratelimit/store_sqlite_test.go
@@ -31,10 +31,10 @@ func TestSQLiteStoreRoundTripsNullableLimits(t *testing.T) {
 	store := newSQLiteTestStore(t)
 
 	if err := store.UpsertRules(ctx, []Rule{
-		{Subject: "/team", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: int64Ptr(100), MaxTokens: int64Ptr(5000), Source: SourceManual},
-		{Subject: "/team", PeriodSeconds: PeriodDaySeconds, MaxRequests: int64Ptr(1000), Source: SourceManual},
-		{Subject: "/team", PeriodSeconds: PeriodConcurrent, MaxRequests: int64Ptr(10), Source: SourceManual},
-		{Subject: "/tokens-only", PeriodSeconds: PeriodMinuteSeconds, MaxTokens: int64Ptr(100), Source: SourceManual},
+		{Subject: "/team", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(100)), MaxTokens: new(int64(5000)), Source: SourceManual},
+		{Subject: "/team", PeriodSeconds: PeriodDaySeconds, MaxRequests: new(int64(1000)), Source: SourceManual},
+		{Subject: "/team", PeriodSeconds: PeriodConcurrent, MaxRequests: new(int64(10)), Source: SourceManual},
+		{Subject: "/tokens-only", PeriodSeconds: PeriodMinuteSeconds, MaxTokens: new(int64(100)), Source: SourceManual},
 	}); err != nil {
 		t.Fatalf("UpsertRules() failed: %v", err)
 	}
@@ -76,7 +76,7 @@ func TestSQLiteStoreDeleteRule(t *testing.T) {
 	store := newSQLiteTestStore(t)
 
 	if err := store.UpsertRules(ctx, []Rule{
-		{Subject: "/team", PeriodSeconds: PeriodConcurrent, MaxRequests: int64Ptr(10), Source: SourceManual},
+		{Subject: "/team", PeriodSeconds: PeriodConcurrent, MaxRequests: new(int64(10)), Source: SourceManual},
 	}); err != nil {
 		t.Fatalf("UpsertRules() failed: %v", err)
 	}
@@ -93,15 +93,15 @@ func TestSQLiteStoreReplaceConfigRulesRemovesStaleConfigRowsOnly(t *testing.T) {
 	store := newSQLiteTestStore(t)
 
 	if err := store.UpsertRules(ctx, []Rule{
-		{Subject: "/team", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: int64Ptr(10), Source: SourceConfig},
-		{Subject: "/team", PeriodSeconds: PeriodDaySeconds, MaxRequests: int64Ptr(50), Source: SourceConfig},
-		{Subject: "/manual", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: int64Ptr(5), Source: SourceManual},
+		{Subject: "/team", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(10)), Source: SourceConfig},
+		{Subject: "/team", PeriodSeconds: PeriodDaySeconds, MaxRequests: new(int64(50)), Source: SourceConfig},
+		{Subject: "/manual", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(5)), Source: SourceManual},
 	}); err != nil {
 		t.Fatalf("UpsertRules() failed: %v", err)
 	}
 
 	if err := store.ReplaceConfigRules(ctx, []Rule{
-		{Subject: "/team", PeriodSeconds: PeriodDaySeconds, MaxRequests: int64Ptr(75)},
+		{Subject: "/team", PeriodSeconds: PeriodDaySeconds, MaxRequests: new(int64(75))},
 	}); err != nil {
 		t.Fatalf("ReplaceConfigRules() failed: %v", err)
 	}
@@ -134,12 +134,12 @@ func TestSQLiteStoreReplaceConfigRulesPreservesManualCollision(t *testing.T) {
 	store := newSQLiteTestStore(t)
 
 	if err := store.UpsertRules(ctx, []Rule{
-		{Subject: "/team", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: int64Ptr(10), Source: SourceManual},
+		{Subject: "/team", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(10)), Source: SourceManual},
 	}); err != nil {
 		t.Fatalf("UpsertRules() failed: %v", err)
 	}
 	if err := store.ReplaceConfigRules(ctx, []Rule{
-		{Subject: "/team", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: int64Ptr(99)},
+		{Subject: "/team", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(99))},
 	}); err != nil {
 		t.Fatalf("ReplaceConfigRules() failed: %v", err)
 	}
@@ -161,12 +161,12 @@ func TestSQLiteStoreManualUpsertOverridesConfigRow(t *testing.T) {
 	store := newSQLiteTestStore(t)
 
 	if err := store.UpsertRules(ctx, []Rule{
-		{Subject: "/team", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: int64Ptr(10), Source: SourceConfig},
+		{Subject: "/team", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(10)), Source: SourceConfig},
 	}); err != nil {
 		t.Fatalf("UpsertRules() failed: %v", err)
 	}
 	if err := store.UpsertRules(ctx, []Rule{
-		{Subject: "/team", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: int64Ptr(25), Source: SourceManual},
+		{Subject: "/team", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(25)), Source: SourceManual},
 	}); err != nil {
 		t.Fatalf("manual UpsertRules() failed: %v", err)
 	}
@@ -238,7 +238,7 @@ func TestSQLiteStoreMigratesPreScopeTable(t *testing.T) {
 		t.Fatalf("NewSQLiteStore() second open failed: %v", err)
 	}
 	if err := store.UpsertRules(ctx, []Rule{
-		{Scope: ScopeProvider, Subject: "openai", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: int64Ptr(500), Source: SourceManual},
+		{Scope: ScopeProvider, Subject: "openai", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(500)), Source: SourceManual},
 	}); err != nil {
 		t.Fatalf("UpsertRules() after migration failed: %v", err)
 	}

--- a/internal/ratelimit/types_test.go
+++ b/internal/ratelimit/types_test.go
@@ -14,7 +14,7 @@ func TestNormalizeRule(t *testing.T) {
 	}{
 		{
 			name: "normalizes path and keeps limits",
-			rule: Rule{Subject: "team/alpha/", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: int64Ptr(10)},
+			rule: Rule{Subject: "team/alpha/", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(10))},
 			check: func(t *testing.T, rule Rule) {
 				if rule.Subject != "/team/alpha" {
 					t.Fatalf("user path = %q, want /team/alpha", rule.Subject)
@@ -26,7 +26,7 @@ func TestNormalizeRule(t *testing.T) {
 		},
 		{
 			name: "empty path becomes root",
-			rule: Rule{Subject: "", PeriodSeconds: PeriodMinuteSeconds, MaxTokens: int64Ptr(100)},
+			rule: Rule{Subject: "", PeriodSeconds: PeriodMinuteSeconds, MaxTokens: new(int64(100))},
 			check: func(t *testing.T, rule Rule) {
 				if rule.Subject != "/" {
 					t.Fatalf("user path = %q, want /", rule.Subject)
@@ -35,7 +35,7 @@ func TestNormalizeRule(t *testing.T) {
 		},
 		{
 			name:    "negative period rejected",
-			rule:    Rule{Subject: "/", PeriodSeconds: -1, MaxRequests: int64Ptr(1)},
+			rule:    Rule{Subject: "/", PeriodSeconds: -1, MaxRequests: new(int64(1))},
 			wantErr: "period_seconds",
 		},
 		{
@@ -45,17 +45,17 @@ func TestNormalizeRule(t *testing.T) {
 		},
 		{
 			name:    "zero max_requests rejected",
-			rule:    Rule{Subject: "/", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: int64Ptr(0)},
+			rule:    Rule{Subject: "/", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(0))},
 			wantErr: "max_requests must be greater than 0",
 		},
 		{
 			name:    "zero max_tokens rejected",
-			rule:    Rule{Subject: "/", PeriodSeconds: PeriodMinuteSeconds, MaxTokens: int64Ptr(0)},
+			rule:    Rule{Subject: "/", PeriodSeconds: PeriodMinuteSeconds, MaxTokens: new(int64(0))},
 			wantErr: "max_tokens must be greater than 0",
 		},
 		{
 			name:    "concurrent rule rejects max_tokens",
-			rule:    Rule{Subject: "/", PeriodSeconds: PeriodConcurrent, MaxRequests: int64Ptr(1), MaxTokens: int64Ptr(10)},
+			rule:    Rule{Subject: "/", PeriodSeconds: PeriodConcurrent, MaxRequests: new(int64(1)), MaxTokens: new(int64(10))},
 			wantErr: "max_tokens is not valid",
 		},
 		{
@@ -65,7 +65,7 @@ func TestNormalizeRule(t *testing.T) {
 		},
 		{
 			name: "model subject lowercased to match case-insensitive matching",
-			rule: Rule{Scope: ScopeModel, Subject: "OpenAI/GPT-4o", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: int64Ptr(1)},
+			rule: Rule{Scope: ScopeModel, Subject: "OpenAI/GPT-4o", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(1))},
 			check: func(t *testing.T, rule Rule) {
 				if rule.Subject != "openai/gpt-4o" {
 					t.Fatalf("subject = %q, want openai/gpt-4o", rule.Subject)
@@ -74,7 +74,7 @@ func TestNormalizeRule(t *testing.T) {
 		},
 		{
 			name:    "invalid path rejected",
-			rule:    Rule{Subject: "/a/../b", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: int64Ptr(1)},
+			rule:    Rule{Subject: "/a/../b", PeriodSeconds: PeriodMinuteSeconds, MaxRequests: new(int64(1))},
 			wantErr: "user path",
 		},
 	}

--- a/internal/ratelimit/usage_tap_test.go
+++ b/internal/ratelimit/usage_tap_test.go
@@ -20,7 +20,7 @@ func TestUsageTapFeedsTokenWindowsAndDelegates(t *testing.T) {
 	service := newTestService(t, Rule{
 		Subject:       "/team",
 		PeriodSeconds: PeriodMinuteSeconds,
-		MaxTokens:     int64Ptr(1000),
+		MaxTokens:     new(int64(1000)),
 	})
 	inner := &recordingLogger{}
 	tap := NewUsageTap(inner, service)
@@ -47,8 +47,8 @@ func TestUsageTapFeedsTokenWindowsAndDelegates(t *testing.T) {
 
 func TestUsageTapChargesExecutedProviderAndModel(t *testing.T) {
 	service := newTestService(t,
-		Rule{Scope: ScopeProvider, Subject: "openai-eu", PeriodSeconds: PeriodMinuteSeconds, MaxTokens: int64Ptr(1000)},
-		Rule{Scope: ScopeModel, Subject: "gpt-4o", PeriodSeconds: PeriodMinuteSeconds, MaxTokens: int64Ptr(1000)},
+		Rule{Scope: ScopeProvider, Subject: "openai-eu", PeriodSeconds: PeriodMinuteSeconds, MaxTokens: new(int64(1000))},
+		Rule{Scope: ScopeModel, Subject: "gpt-4o", PeriodSeconds: PeriodMinuteSeconds, MaxTokens: new(int64(1000))},
 	)
 	tap := NewUsageTap(&recordingLogger{}, service)
 

--- a/internal/realtime/registry_test.go
+++ b/internal/realtime/registry_test.go
@@ -61,7 +61,7 @@ func TestCallRegistryEvictsAtCapacity(t *testing.T) {
 	now := time.Unix(1000, 0)
 	r := newTestRegistry(&now)
 
-	for i := 0; i < maxCalls; i++ {
+	for i := range maxCalls {
 		r.Register(fmt.Sprintf("rtc_%d", i), CallRoute{Model: "m"})
 		now = now.Add(time.Millisecond) // strictly ordered expiries
 	}
@@ -82,7 +82,7 @@ func TestCallRegistryReRegisterAtCapacityDoesNotEvict(t *testing.T) {
 	now := time.Unix(1000, 0)
 	r := newTestRegistry(&now)
 
-	for i := 0; i < maxCalls; i++ {
+	for i := range maxCalls {
 		r.Register(fmt.Sprintf("rtc_%d", i), CallRoute{Model: "m"})
 		now = now.Add(time.Millisecond)
 	}

--- a/internal/responsecache/handle_request_test.go
+++ b/internal/responsecache/handle_request_test.go
@@ -63,8 +63,8 @@ func TestHandleRequest_SemanticMissPopulatesExactCache(t *testing.T) {
 	vecStore := NewMapVecStore()
 	semCfg := config.SemanticCacheConfig{
 		SimilarityThreshold:     0.90,
-		TTL:                     intPtr(3600),
-		MaxConversationMessages: intPtr(10),
+		TTL:                     new(3600),
+		MaxConversationMessages: new(10),
 	}
 
 	m := &ResponseCacheMiddleware{
@@ -357,8 +357,8 @@ func TestHandleRequest_FailoverUsedSkipsCacheWrites(t *testing.T) {
 	vecStore := NewMapVecStore()
 	semCfg := config.SemanticCacheConfig{
 		SimilarityThreshold:     0.90,
-		TTL:                     intPtr(3600),
-		MaxConversationMessages: intPtr(10),
+		TTL:                     new(3600),
+		MaxConversationMessages: new(10),
 	}
 
 	m := &ResponseCacheMiddleware{
@@ -625,10 +625,10 @@ func TestHandleRequest_GatewayTimeoutDoesNotPopulateSemanticCache(t *testing.T) 
 	emb := &mockEmbedder{vector: []float32{1, 0, 0}}
 	vecStore := NewMapVecStore()
 	semCfg := config.SemanticCacheConfig{
-		Enabled:                 boolPtr(true),
+		Enabled:                 new(true),
 		SimilarityThreshold:     0.90,
-		TTL:                     intPtr(3600),
-		MaxConversationMessages: intPtr(10),
+		TTL:                     new(3600),
+		MaxConversationMessages: new(10),
 	}
 	m := &ResponseCacheMiddleware{
 		simple:   newSimpleCacheMiddleware(store, time.Hour, nil),
@@ -689,10 +689,10 @@ func TestHandleRequest_CacheControlNoCacheBypassesAllLayers(t *testing.T) {
 	emb := &mockEmbedder{vector: []float32{1, 0, 0}}
 	vecStore := NewMapVecStore()
 	semCfg := config.SemanticCacheConfig{
-		Enabled:                 boolPtr(true),
+		Enabled:                 new(true),
 		SimilarityThreshold:     0.90,
-		TTL:                     intPtr(3600),
-		MaxConversationMessages: intPtr(10),
+		TTL:                     new(3600),
+		MaxConversationMessages: new(10),
 	}
 
 	m := &ResponseCacheMiddleware{

--- a/internal/responsecache/semantic_test.go
+++ b/internal/responsecache/semantic_test.go
@@ -32,16 +32,13 @@ func (m *mockEmbedder) Close() error { return nil }
 
 func (m *mockEmbedder) Identity() string { return "test\x00mock-model" }
 
-func intPtr(v int) *int    { return &v }
-func boolPtr(v bool) *bool { return &v }
-
 func newTestSemanticMiddleware(threshold float64, maxConvMessages int, excludeSystem bool) (*semanticCacheMiddleware, *MapVecStore, *mockEmbedder) {
 	store := NewMapVecStore()
 	emb := &mockEmbedder{vector: []float32{1, 0, 0}}
 	cfg := config.SemanticCacheConfig{
 		SimilarityThreshold:     threshold,
-		TTL:                     intPtr(3600),
-		MaxConversationMessages: intPtr(maxConvMessages),
+		TTL:                     new(3600),
+		MaxConversationMessages: new(maxConvMessages),
 		ExcludeSystemPrompt:     excludeSystem,
 	}
 	m := newSemanticCacheMiddleware(emb, store, cfg, nil)
@@ -164,8 +161,8 @@ func TestSemanticCacheMiddleware_CacheMissOnLowScore(t *testing.T) {
 
 	m := newSemanticCacheMiddleware(emb, store, config.SemanticCacheConfig{
 		SimilarityThreshold:     0.99,
-		TTL:                     intPtr(3600),
-		MaxConversationMessages: intPtr(10),
+		TTL:                     new(3600),
+		MaxConversationMessages: new(10),
 	}, nil)
 
 	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hello"}]}`)
@@ -501,8 +498,8 @@ func TestSemanticCacheMiddleware_HeaderThresholdOverride(t *testing.T) {
 
 	m := newSemanticCacheMiddleware(emb, store, config.SemanticCacheConfig{
 		SimilarityThreshold:     0.99,
-		TTL:                     intPtr(3600),
-		MaxConversationMessages: intPtr(10),
+		TTL:                     new(3600),
+		MaxConversationMessages: new(10),
 	}, nil)
 
 	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hello"}]}`)
@@ -536,8 +533,8 @@ func TestSemanticCacheMiddleware_TTLExpiry(t *testing.T) {
 
 	m := newSemanticCacheMiddleware(emb, store, config.SemanticCacheConfig{
 		SimilarityThreshold:     0.90,
-		TTL:                     intPtr(1),
-		MaxConversationMessages: intPtr(10),
+		TTL:                     new(1),
+		MaxConversationMessages: new(10),
 	}, nil)
 
 	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"expiry test"}]}`)

--- a/internal/responsecache/sse_validation_test.go
+++ b/internal/responsecache/sse_validation_test.go
@@ -87,7 +87,6 @@ func TestValidateCacheableSSE(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := validateCacheableSSE(tt.raw); got != tt.want {

--- a/internal/responsecache/vecstore_cleanup.go
+++ b/internal/responsecache/vecstore_cleanup.go
@@ -17,9 +17,7 @@ type vecCleanup struct {
 func startVecCleanup(store VecStore) *vecCleanup {
 	ctx, cancel := context.WithCancel(context.Background())
 	c := &vecCleanup{cancel: cancel}
-	c.wg.Add(1)
-	go func() {
-		defer c.wg.Done()
+	c.wg.Go(func() {
 		t := time.NewTicker(vecStoreCleanupInterval)
 		defer t.Stop()
 		for {
@@ -35,7 +33,7 @@ func startVecCleanup(store VecStore) *vecCleanup {
 				return
 			}
 		}
-	}()
+	})
 	return c
 }
 

--- a/internal/responsestore/store.go
+++ b/internal/responsestore/store.go
@@ -28,8 +28,8 @@ type StoredResponse struct {
 	RequestID          string                  `json:"request_id,omitempty"`
 	UserPath           string                  `json:"user_path,omitempty"`
 	WorkflowVersionID  string                  `json:"workflow_version_id,omitempty"`
-	StoredAt           time.Time               `json:"stored_at,omitempty"`
-	ExpiresAt          time.Time               `json:"expires_at,omitempty"`
+	StoredAt           time.Time               `json:"stored_at"`
+	ExpiresAt          time.Time               `json:"expires_at"`
 }
 
 // Store defines persistence operations for Responses lifecycle APIs.

--- a/internal/server/audio_service_test.go
+++ b/internal/server/audio_service_test.go
@@ -361,7 +361,7 @@ func TestAudioSpeech_CostsOutputAudioDuration(t *testing.T) {
 	wav := wavBytes(24000, 1, 16, 2.0)
 	mp3 := []byte("\xff\xfbnot-a-wav-body")
 	// gpt-4o-mini-tts-style pricing: tiny text input plus per-second audio output.
-	pricing := &core.ModelPricing{InputPerMtok: floatPtr(0.6), PerSecondOutput: floatPtr(0.00025)}
+	pricing := &core.ModelPricing{InputPerMtok: new(0.6), PerSecondOutput: new(0.00025)}
 
 	tests := []struct {
 		name           string
@@ -425,8 +425,6 @@ func TestAudioSpeech_CostsOutputAudioDuration(t *testing.T) {
 		})
 	}
 }
-
-func floatPtr(v float64) *float64 { return &v }
 
 // wavBytes builds a minimal canonical PCM WAV of the requested duration.
 func wavBytes(sampleRate, channels, bitsPerSample int, seconds float64) []byte {

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -5063,7 +5063,7 @@ func TestHandlerSetResponseStoreIsConcurrentSafe(t *testing.T) {
 	_ = handler.translatedInference()
 
 	var wg sync.WaitGroup
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		wg.Add(2)
 		go func() {
 			defer wg.Done()

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -127,7 +127,7 @@ func TestStartWithListener(t *testing.T) {
 	client := &http.Client{Timeout: 200 * time.Millisecond}
 	url := "http://" + listener.Addr().String() + "/health"
 	var lastErr error
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		resp, err := client.Get(url)
 		if err == nil {
 			_ = resp.Body.Close()

--- a/internal/server/native_conversation_service.go
+++ b/internal/server/native_conversation_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"strings"
 	"time"
@@ -182,9 +183,7 @@ func generatedConversationID() string {
 // conversation carries an empty object rather than null, matching OpenAI.
 func normalizedConversationMetadata(metadata map[string]string) map[string]string {
 	normalized := make(map[string]string, len(metadata))
-	for key, value := range metadata {
-		normalized[key] = value
-	}
+	maps.Copy(normalized, metadata)
 	return normalized
 }
 

--- a/internal/server/native_file_service.go
+++ b/internal/server/native_file_service.go
@@ -299,10 +299,7 @@ func (s *nativeFileService) recordStoredFile(ctx context.Context, resp *core.Fil
 	if strings.TrimSpace(resp.ID) == "" {
 		return nil
 	}
-	createdAt := resp.CreatedAt
-	if createdAt <= 0 {
-		createdAt = 0
-	}
+	createdAt := max(resp.CreatedAt, 0)
 	if err := s.fileStore.Upsert(ctx, &filestore.StoredFile{
 		ID:           resp.ID,
 		ProviderType: providerType,

--- a/internal/server/native_response_service.go
+++ b/internal/server/native_response_service.go
@@ -538,10 +538,7 @@ func paginateStoredResponseInputItems(items []json.RawMessage, params core.Respo
 		limit = 100
 	}
 
-	remaining := count - start
-	if remaining < 0 {
-		remaining = 0
-	}
+	remaining := max(count-start, 0)
 	hasMore := remaining > limit
 	if remaining > limit {
 		remaining = limit

--- a/internal/server/realtime_webrtc_service.go
+++ b/internal/server/realtime_webrtc_service.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"maps"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -176,9 +177,7 @@ func (s *realtimeService) forwardRealtimeHTTP(ctx context.Context, target *core.
 	}
 	if len(query) > 0 {
 		merged := endpoint.Query()
-		for key, values := range query {
-			merged[key] = values
-		}
+		maps.Copy(merged, query)
 		endpoint.RawQuery = merged.Encode()
 	}
 

--- a/internal/server/response_input_items.go
+++ b/internal/server/response_input_items.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/goccy/go-json"
@@ -229,8 +230,6 @@ func cloneAnyMap(src map[string]any) map[string]any {
 		return nil
 	}
 	dst := make(map[string]any, len(src))
-	for key, value := range src {
-		dst[key] = value
-	}
+	maps.Copy(dst, src)
 	return dst
 }

--- a/internal/usage/audio_test.go
+++ b/internal/usage/audio_test.go
@@ -7,8 +7,6 @@ import (
 	"gomodel/internal/core"
 )
 
-func floatPtr(v float64) *float64 { return &v }
-
 func TestExtractFromSpeechRequest(t *testing.T) {
 	entry := ExtractFromSpeechRequest("hello", nil, "", "req-1", "gpt-4o-mini-tts", "openai")
 	if entry == nil {
@@ -37,7 +35,7 @@ func TestExtractFromSpeechRequest_EmptyInput(t *testing.T) {
 
 func TestExtractFromSpeechRequest_PerCharacterPricing(t *testing.T) {
 	// "hello" = 5 characters at $0.00001/char => $0.00005.
-	entry := ExtractFromSpeechRequest("hello", nil, "", "req", "tts-1", "openai", &core.ModelPricing{PerCharacterInput: floatPtr(0.00001)})
+	entry := ExtractFromSpeechRequest("hello", nil, "", "req", "tts-1", "openai", &core.ModelPricing{PerCharacterInput: new(0.00001)})
 	assertCostPtrNear(t, "input cost", entry.InputCost, 0.00005)
 	assertCostPtrNear(t, "total cost", entry.TotalCost, 0.00005)
 }
@@ -46,7 +44,7 @@ func TestExtractFromSpeechRequest_WavOutputPerSecondOutput(t *testing.T) {
 	// A 1-second 24 kHz mono 16-bit WAV at $0.00025/sec => $0.00025 output cost.
 	wav := buildWAV(t, 24000, 1, 16, 1.0)
 	entry := ExtractFromSpeechRequest("hello", wav, "wav", "req", "gpt-4o-mini-tts", "openai",
-		&core.ModelPricing{InputPerMtok: floatPtr(0.6), PerSecondOutput: floatPtr(0.00025)})
+		&core.ModelPricing{InputPerMtok: new(0.6), PerSecondOutput: new(0.00025)})
 
 	if got := entry.RawData[rawKeyAudioOutputSeconds]; got != float64(1) {
 		t.Errorf("audio_output_seconds = %v, want 1", got)
@@ -62,7 +60,7 @@ func TestExtractFromSpeechRequest_PcmOutputPerSecondOutput(t *testing.T) {
 	// Headerless PCM is 48000 bytes/sec; 24000 bytes => 0.5s at $0.00025/sec.
 	pcm := make([]byte, 24000)
 	entry := ExtractFromSpeechRequest("hi", pcm, "pcm", "req", "gpt-4o-mini-tts", "openai",
-		&core.ModelPricing{PerSecondOutput: floatPtr(0.00025)})
+		&core.ModelPricing{PerSecondOutput: new(0.00025)})
 
 	if got := entry.RawData[rawKeyAudioOutputSeconds]; got != 0.5 {
 		t.Errorf("audio_output_seconds = %v, want 0.5", got)
@@ -74,7 +72,7 @@ func TestExtractFromSpeechRequest_CompressedOutputCaveat(t *testing.T) {
 	// mp3 output cannot be measured without decoding; the per-second-output model
 	// must surface a caveat rather than a silent zero.
 	entry := ExtractFromSpeechRequest("hello", []byte("\xff\xfbmp3 frames"), "mp3", "req", "gpt-4o-mini-tts", "openai",
-		&core.ModelPricing{InputPerMtok: floatPtr(0.6), PerSecondOutput: floatPtr(0.00025)})
+		&core.ModelPricing{InputPerMtok: new(0.6), PerSecondOutput: new(0.00025)})
 
 	if _, ok := entry.RawData[rawKeyAudioOutputSeconds]; ok {
 		t.Error("mp3 output should not record a measured duration")
@@ -126,7 +124,7 @@ func TestExtractFromTranscriptionResponse_DurationUsage(t *testing.T) {
 func TestExtractFromTranscriptionResponse_PerSecondCost(t *testing.T) {
 	// 9 seconds of input audio at $0.0001/sec => $0.0009 (whisper-style pricing).
 	body := []byte(`{"usage":{"type":"duration","seconds":9}}`)
-	pricing := &core.ModelPricing{PerSecondInput: floatPtr(0.0001)}
+	pricing := &core.ModelPricing{PerSecondInput: new(0.0001)}
 
 	entry := ExtractFromTranscriptionResponse(body, "req", "whisper-1", "openai", pricing)
 	assertCostPtrNear(t, "input cost", entry.InputCost, 0.0009)
@@ -157,7 +155,7 @@ func TestExtractFromTranscriptionResponse_NoUsage(t *testing.T) {
 
 func TestExtractFromTranscriptionResponse_TokenCost(t *testing.T) {
 	body := []byte(`{"usage":{"input_tokens":1000000,"output_tokens":0,"total_tokens":1000000}}`)
-	pricing := &core.ModelPricing{InputPerMtok: floatPtr(2.5)}
+	pricing := &core.ModelPricing{InputPerMtok: new(2.5)}
 
 	entry := ExtractFromTranscriptionResponse(body, "req", "gpt-4o-transcribe", "openai", pricing)
 	assertCostPtrNear(t, "input cost", entry.InputCost, 2.5)

--- a/internal/usage/cost_test.go
+++ b/internal/usage/cost_test.go
@@ -722,9 +722,9 @@ func TestCalculateGranularCost_OutputOnlyPricing(t *testing.T) {
 func TestCalculateGranularCost_OpenAICompatibleProvidersDefaultMappings(t *testing.T) {
 	pricing := &core.ModelPricing{
 		Currency:           "USD",
-		InputPerMtok:       floatPtr(0.435),
-		OutputPerMtok:      floatPtr(0.87),
-		CachedInputPerMtok: floatPtr(0.0036),
+		InputPerMtok:       new(0.435),
+		OutputPerMtok:      new(0.87),
+		CachedInputPerMtok: new(0.0036),
 	}
 	// Cache-heavy workload: 1M input (900k cached), 200k output.
 	rawData := map[string]any{"prompt_cached_tokens": 900_000}
@@ -757,9 +757,9 @@ func TestCalculateGranularCost_OpenAICompatibleProvidersDefaultMappings(t *testi
 func TestCalculateGranularCost_DeepSeekTopLevelCacheFields(t *testing.T) {
 	pricing := &core.ModelPricing{
 		Currency:           "USD",
-		InputPerMtok:       floatPtr(0.21),
-		OutputPerMtok:      floatPtr(0.79),
-		CachedInputPerMtok: floatPtr(0.021), // DeepSeek cache-hit ≈ 0.1x input
+		InputPerMtok:       new(0.21),
+		OutputPerMtok:      new(0.79),
+		CachedInputPerMtok: new(0.021), // DeepSeek cache-hit ≈ 0.1x input
 	}
 	// prompt_tokens = 1_000_000 = 900k hit + 100k miss; 200k output.
 	rawData := map[string]any{

--- a/internal/usage/dashboard_cost_validation_test.go
+++ b/internal/usage/dashboard_cost_validation_test.go
@@ -41,10 +41,10 @@ func TestDashboardCostAggregation_EndToEnd(t *testing.T) {
 	ts := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
 
 	xiaomiPricing := &core.ModelPricing{
-		Currency: "USD", InputPerMtok: floatPtr(0.435), OutputPerMtok: floatPtr(0.87), CachedInputPerMtok: floatPtr(0.0036),
+		Currency: "USD", InputPerMtok: new(0.435), OutputPerMtok: new(0.87), CachedInputPerMtok: new(0.0036),
 	}
 	deepseekPricing := &core.ModelPricing{
-		Currency: "USD", InputPerMtok: floatPtr(0.21), OutputPerMtok: floatPtr(0.79), CachedInputPerMtok: floatPtr(0.021),
+		Currency: "USD", InputPerMtok: new(0.21), OutputPerMtok: new(0.79), CachedInputPerMtok: new(0.021),
 	}
 
 	// Live request 1: xiaomi, standard nested cache reporting (prompt_cached_tokens).

--- a/internal/usage/reader_fold_test.go
+++ b/internal/usage/reader_fold_test.go
@@ -21,8 +21,6 @@ type fakeSegmentRow struct {
 	raw      *string
 }
 
-func segRaw(s string) *string { return &s }
-
 func (f *fakeInputSegmentRows) Next() bool {
 	f.pos++
 	return f.pos <= len(f.rows)
@@ -49,10 +47,10 @@ func (f *fakeInputSegmentRows) Err() error { return f.iterErr }
 
 func TestFoldInputSegments_FoldsAndToleratesMalformedRawData(t *testing.T) {
 	rows := &fakeInputSegmentRows{rows: []fakeSegmentRow{
-		{input: 120, provider: "openai", raw: segRaw(`{"prompt_cached_tokens":80}`)},                                       // subset → uncached 40, cached 80
-		{input: 50, provider: "anthropic", raw: segRaw(`{"cache_read_input_tokens":90,"cache_creation_input_tokens":30}`)}, // split → uncached 50, cached 90, write 30
-		{input: 70, provider: "openai", raw: segRaw(`{bad json`)},                                                          // malformed → degrades to no cache → uncached 70
-		{input: 10, provider: "openai", raw: nil},                                                                          // nil raw → uncached 10
+		{input: 120, provider: "openai", raw: new(`{"prompt_cached_tokens":80}`)},                                       // subset → uncached 40, cached 80
+		{input: 50, provider: "anthropic", raw: new(`{"cache_read_input_tokens":90,"cache_creation_input_tokens":30}`)}, // split → uncached 50, cached 90, write 30
+		{input: 70, provider: "openai", raw: new(`{bad json`)},                                                          // malformed → degrades to no cache → uncached 70
+		{input: 10, provider: "openai", raw: nil},                                                                       // nil raw → uncached 10
 	}}
 
 	summary := &UsageSummary{}
@@ -86,7 +84,7 @@ func TestFoldInputSegments_ScanErrorPropagates(t *testing.T) {
 func TestFoldInputSegments_IterationErrorPropagates(t *testing.T) {
 	wantErr := errors.New("iter boom")
 	rows := &fakeInputSegmentRows{
-		rows:    []fakeSegmentRow{{input: 10, provider: "openai", raw: segRaw(`{}`)}},
+		rows:    []fakeSegmentRow{{input: 10, provider: "openai", raw: new(`{}`)}},
 		iterErr: wantErr,
 	}
 	err := foldInputSegments(rows, &UsageSummary{})

--- a/internal/usage/recalculate_pricing_issue435_test.go
+++ b/internal/usage/recalculate_pricing_issue435_test.go
@@ -59,7 +59,7 @@ func TestSQLiteStoreRecalculatePricing_CorrectsStaleCachedCosts(t *testing.T) {
 
 	resolver := staticTestPricingResolver{
 		"xiaomi/mimo-v2.5-pro": {
-			Currency: "USD", InputPerMtok: floatPtr(0.435), OutputPerMtok: floatPtr(0.87), CachedInputPerMtok: floatPtr(0.0036),
+			Currency: "USD", InputPerMtok: new(0.435), OutputPerMtok: new(0.87), CachedInputPerMtok: new(0.0036),
 		},
 		// "openai/retired-model" intentionally absent -> resolves to nil.
 	}

--- a/internal/usage/savings_test.go
+++ b/internal/usage/savings_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestApplyRewriteSavings(t *testing.T) {
-	flatPricing := &core.ModelPricing{InputPerMtok: floatPtr(2.0), OutputPerMtok: floatPtr(8.0)}
+	flatPricing := &core.ModelPricing{InputPerMtok: new(2.0), OutputPerMtok: new(8.0)}
 
 	t.Run("nil entry and non-positive savings are no-ops", func(t *testing.T) {
 		ApplyRewriteSavings(nil, 100, flatPricing)
@@ -53,10 +53,10 @@ func TestApplyRewriteSavings(t *testing.T) {
 
 	t.Run("tier crossing re-rates the whole input", func(t *testing.T) {
 		tiered := &core.ModelPricing{
-			InputPerMtok: floatPtr(10.0),
+			InputPerMtok: new(10.0),
 			Tiers: []core.ModelPricingTier{
-				{UpToTokens: floatPtr(1000), InputPerMtok: floatPtr(1.0)},
-				{UpToTokens: floatPtr(1_000_000), InputPerMtok: floatPtr(3.0)},
+				{UpToTokens: new(float64(1000)), InputPerMtok: new(1.0)},
+				{UpToTokens: new(float64(1_000_000)), InputPerMtok: new(3.0)},
 			},
 		}
 		entry := &UsageEntry{Endpoint: "/v1/chat/completions", Provider: "openai", InputTokens: 800}
@@ -72,7 +72,7 @@ func TestApplyRewriteSavings(t *testing.T) {
 	})
 
 	t.Run("batch endpoint uses batch input rate", func(t *testing.T) {
-		pricing := &core.ModelPricing{InputPerMtok: floatPtr(2.0), BatchInputPerMtok: floatPtr(1.0)}
+		pricing := &core.ModelPricing{InputPerMtok: new(2.0), BatchInputPerMtok: new(1.0)}
 		entry := &UsageEntry{Endpoint: "/v1/batches", Provider: "openai", InputTokens: 0}
 		ApplyRewriteSavings(entry, 1_000_000, pricing)
 		if entry.RewriteCostSaved == nil {
@@ -103,7 +103,7 @@ func TestSQLiteSummaryAggregatesRewriteSavings(t *testing.T) {
 			Timestamp: time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC),
 			Model:     "gpt-5", Provider: "openai", Endpoint: "/v1/chat/completions",
 			InputTokens: 1000, OutputTokens: 50, TotalTokens: 1050,
-			RewriteTokensSaved: 400, RewriteCostSaved: floatPtr(0.0008),
+			RewriteTokensSaved: 400, RewriteCostSaved: new(0.0008),
 		},
 		{
 			ID: "with-unpriced-savings", RequestID: "req-2", ProviderID: "p-2",
@@ -181,14 +181,14 @@ func TestSQLiteRecalculatePricingRefreshesRewriteCostSaved(t *testing.T) {
 		Timestamp: time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC),
 		Model:     "gpt-5", Provider: "openai", Endpoint: "/v1/chat/completions",
 		InputTokens: 1000, OutputTokens: 50, TotalTokens: 1050,
-		RewriteTokensSaved: 500_000, RewriteCostSaved: floatPtr(123.0),
+		RewriteTokensSaved: 500_000, RewriteCostSaved: new(123.0),
 	}}); err != nil {
 		t.Fatalf("failed to seed usage entry: %v", err)
 	}
 
 	resolver := staticSavingsPricingResolver{pricing: &core.ModelPricing{
-		InputPerMtok:  floatPtr(2.0),
-		OutputPerMtok: floatPtr(8.0),
+		InputPerMtok:  new(2.0),
+		OutputPerMtok: new(8.0),
 	}}
 	if _, err := store.RecalculatePricing(ctx, RecalculatePricingParams{}, resolver); err != nil {
 		t.Fatalf("RecalculatePricing returned error: %v", err)

--- a/internal/usage/stream_observer_test.go
+++ b/internal/usage/stream_observer_test.go
@@ -654,8 +654,8 @@ data: [DONE]
 `
 	logger := &trackingLogger{enabled: true}
 	resolver := &streamPricingCaptureResolver{pricing: &core.ModelPricing{
-		InputPerMtok:  floatPtr(2.0),
-		OutputPerMtok: floatPtr(8.0),
+		InputPerMtok:  new(2.0),
+		OutputPerMtok: new(8.0),
 	}}
 	observer := NewStreamUsageObserver(logger, "gpt-4", "openai", "req-1", "/v1/chat/completions", resolver)
 	observer.SetRewriteTokensSaved(500_000)

--- a/internal/usage/throughput_test.go
+++ b/internal/usage/throughput_test.go
@@ -134,7 +134,7 @@ func TestSQLiteReaderGetTokenThroughput_SplitsAndBuckets(t *testing.T) {
 	}
 
 	// Every earlier bucket must be empty — the out-of-window row is excluded.
-	for i := 0; i < 59; i++ {
+	for i := range 59 {
 		b := tp.Buckets[i]
 		if b.InputTokens+b.OutputTokens+b.PromptCachedTokens+b.LocallyCachedTokens != 0 {
 			t.Errorf("bucket %d should be empty, got %+v", i, b)

--- a/internal/virtualmodels/balancer_test.go
+++ b/internal/virtualmodels/balancer_test.go
@@ -7,8 +7,6 @@ import (
 	"gomodel/internal/core"
 )
 
-func floatPtr(v float64) *float64 { return &v }
-
 // pricedModel builds a catalog model with input/output per-Mtok pricing.
 func pricedModel(id string, inputPerMtok, outputPerMtok float64) core.Model {
 	return core.Model{
@@ -16,8 +14,8 @@ func pricedModel(id string, inputPerMtok, outputPerMtok float64) core.Model {
 		Object: "model",
 		Metadata: &core.ModelMetadata{
 			Pricing: &core.ModelPricing{
-				InputPerMtok:  floatPtr(inputPerMtok),
-				OutputPerMtok: floatPtr(outputPerMtok),
+				InputPerMtok:  new(inputPerMtok),
+				OutputPerMtok: new(outputPerMtok),
 			},
 		},
 	}
@@ -49,7 +47,7 @@ func newBalancingService(t *testing.T) *Service {
 func resolvedModels(t *testing.T, svc *Service, source string, n int) []string {
 	t.Helper()
 	out := make([]string, 0, n)
-	for i := 0; i < n; i++ {
+	for range n {
 		sel, _, err := svc.ResolveModel(core.NewRequestedModelSelector(source, ""))
 		if err != nil {
 			t.Fatalf("ResolveModel() error = %v", err)
@@ -225,7 +223,7 @@ func TestBalancer_SkipsUnavailableTargets(t *testing.T) {
 func TestBalancer_WeightedIndexPlainWhenEqual(t *testing.T) {
 	t.Parallel()
 	targets := []resolvedTarget{{}, {}, {}}
-	for i := uint64(0); i < 6; i++ {
+	for i := range uint64(6) {
 		if got := weightedIndex(targets, i); got != int(i%3) {
 			t.Fatalf("weightedIndex(%d) = %d, want %d", i, got, i%3)
 		}

--- a/internal/virtualmodels/config_overlay_test.go
+++ b/internal/virtualmodels/config_overlay_test.go
@@ -135,7 +135,6 @@ func TestService_ConfigOverlayRejectsInvalidRedirectTargets(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			svc := newBalancingService(t)
@@ -201,7 +200,6 @@ func TestService_ValidateManagedConfigTargetProviders(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			svc, err := NewService(newSQLiteVMStore(t), testCatalog(), true)

--- a/internal/workflows/types_test.go
+++ b/internal/workflows/types_test.go
@@ -12,7 +12,6 @@ func TestNormalizeScope_RejectsColonDelimitedFields(t *testing.T) {
 	}
 
 	for _, scope := range tests {
-		scope := scope
 		t.Run(scope.Provider+"|"+scope.Model, func(t *testing.T) {
 			t.Parallel()
 
@@ -155,7 +154,6 @@ func TestFeatureFlagsRuntimeFeatures_DisablesBudgetWhenUsageDisabled(t *testing.
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/run/lifecycle_test.go
+++ b/run/lifecycle_test.go
@@ -3,6 +3,7 @@ package run
 import (
 	"context"
 	"errors"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -150,13 +151,7 @@ func TestMain_KimicodeProviderRegistration(t *testing.T) {
 	factory := defaultProviderFactory(&config.Config{})
 
 	registered := factory.RegisteredTypes()
-	found := false
-	for _, typ := range registered {
-		if typ == "kimicode" {
-			found = true
-			break
-		}
-	}
+	found := slices.Contains(registered, "kimicode")
 	if !found {
 		t.Fatalf("kimicode not in RegisteredTypes() = %v", registered)
 	}

--- a/tests/contract/golden_helpers_test.go
+++ b/tests/contract/golden_helpers_test.go
@@ -92,20 +92,17 @@ func normalizeGoldenValue(v any) any {
 }
 
 func normalizeGeneratedID(id string) string {
-	if strings.HasPrefix(id, "resp_") {
-		suffix := strings.TrimPrefix(id, "resp_")
+	if suffix, ok := strings.CutPrefix(id, "resp_"); ok {
 		if isGeneratedIDSuffix(suffix) {
 			return "resp_<generated>"
 		}
 	}
-	if strings.HasPrefix(id, "msg_") {
-		suffix := strings.TrimPrefix(id, "msg_")
+	if suffix, ok := strings.CutPrefix(id, "msg_"); ok {
 		if isGeneratedIDSuffix(suffix) {
 			return "msg_<generated>"
 		}
 	}
-	if strings.HasPrefix(id, "req_") {
-		suffix := strings.TrimPrefix(id, "req_")
+	if suffix, ok := strings.CutPrefix(id, "req_"); ok {
 		if isGeneratedIDSuffix(suffix) {
 			return "req_<generated>"
 		}

--- a/tests/contract/replay_harness_test.go
+++ b/tests/contract/replay_harness_test.go
@@ -36,7 +36,7 @@ func (rt *replayTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	key := replayKey(req.Method, req.URL.RequestURI())
 	route, ok := rt.routes[key]
 	if !ok {
-		notFoundBody := []byte(fmt.Sprintf(`{"error":{"message":"missing replay route: %s"}}`, key))
+		notFoundBody := fmt.Appendf(nil, `{"error":{"message":"missing replay route: %s"}}`, key)
 		return &http.Response{
 			StatusCode: http.StatusNotFound,
 			Status:     "404 Not Found",

--- a/tests/e2e/admin_test.go
+++ b/tests/e2e/admin_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -331,7 +332,7 @@ func TestAdminAPI_UsageEndpoints_E2E(t *testing.T) {
 
 	// Mock provider usage is 10 input + 20 output tokens per request, and this test sends 2 requests.
 	requestWindowStart := time.Now().UTC()
-	for i := 0; i < expectedRequests; i++ {
+	for range expectedRequests {
 		resp := sendJSONRequest(t, ts.URL+chatCompletionsPath, defaultChatReq("Hello usage"))
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		closeBody(resp)
@@ -374,11 +375,8 @@ func TestAdminAPI_UsageEndpoints_E2E(t *testing.T) {
 
 		var matchedEntries []usage.DailyUsage
 		for i := range daily {
-			for _, expectedDate := range expectedDailyDates {
-				if daily[i].Date == expectedDate {
-					matchedEntries = append(matchedEntries, daily[i])
-					break
-				}
+			if slices.Contains(expectedDailyDates, daily[i].Date) {
+				matchedEntries = append(matchedEntries, daily[i])
 			}
 		}
 		require.NotEmpty(t, matchedEntries, "expected daily usage entry for one of %v", expectedDailyDates)

--- a/tests/e2e/auditlog_test.go
+++ b/tests/e2e/auditlog_test.go
@@ -134,7 +134,7 @@ func setupAuditLogTestServer(t *testing.T, cfg auditlog.Config, store *mockLogSt
 
 	// Wait for server to be ready
 	client := &http.Client{Timeout: 2 * time.Second}
-	for i := 0; i < 30; i++ {
+	for range 30 {
 		resp, err := client.Get(serverURL + "/health")
 		if err == nil {
 			_ = resp.Body.Close()
@@ -225,24 +225,24 @@ func TestAuditLogMiddleware(t *testing.T) {
 		require.NotNil(t, entry.Data.ResponseBody)
 
 		// Verify request body contains our message (now stored as interface{})
-		reqBody, ok := entry.Data.RequestBody.(map[string]interface{})
+		reqBody, ok := entry.Data.RequestBody.(map[string]any)
 		require.True(t, ok, "RequestBody should be a map[string]interface{}, got %T", entry.Data.RequestBody)
 		assert.Equal(t, "gpt-4", reqBody["model"])
 
 		// Verify response body captured the upstream chat completion payload, not
 		// just an empty marker — a regression that stored {} but non-nil would
 		// otherwise slip past a NotNil-only check.
-		respBody, ok := entry.Data.ResponseBody.(map[string]interface{})
+		respBody, ok := entry.Data.ResponseBody.(map[string]any)
 		require.True(t, ok, "ResponseBody should be a map[string]interface{}, got %T", entry.Data.ResponseBody)
 		assert.Equal(t, "chat.completion", respBody["object"])
 		assert.Equal(t, "gpt-4", respBody["model"])
 		assert.NotEmpty(t, respBody["id"], "response id should be captured")
-		choices, ok := respBody["choices"].([]interface{})
+		choices, ok := respBody["choices"].([]any)
 		require.True(t, ok, "choices should be an array, got %T", respBody["choices"])
 		require.NotEmpty(t, choices)
-		choice0, ok := choices[0].(map[string]interface{})
+		choice0, ok := choices[0].(map[string]any)
 		require.True(t, ok)
-		msg, ok := choice0["message"].(map[string]interface{})
+		msg, ok := choice0["message"].(map[string]any)
 		require.True(t, ok)
 		assert.Equal(t, "assistant", msg["role"])
 		content, ok := msg["content"].(string)
@@ -495,7 +495,7 @@ func TestAuditLogConcurrency(t *testing.T) {
 		wg.Add(numRequests)
 		results := make(chan result, numRequests)
 
-		for i := 0; i < numRequests; i++ {
+		for i := range numRequests {
 			go func(idx int) {
 				defer wg.Done()
 				payload := defaultChatReq(fmt.Sprintf("Request %d", idx))
@@ -765,7 +765,7 @@ func TestAuditLogOnlyModelInteractions(t *testing.T) {
 		defer cleanup()
 
 		// Make multiple requests to health endpoint
-		for i := 0; i < 3; i++ {
+		for range 3 {
 			resp, err := http.Get(serverURL + "/health")
 			require.NoError(t, err)
 			closeBody(resp)
@@ -825,7 +825,7 @@ func TestAuditLogOnlyModelInteractions(t *testing.T) {
 		defer cleanup()
 
 		// Make multiple health requests (should not be logged)
-		for i := 0; i < 5; i++ {
+		for range 5 {
 			resp, err := http.Get(serverURL + "/health")
 			require.NoError(t, err)
 			closeBody(resp)
@@ -839,7 +839,7 @@ func TestAuditLogOnlyModelInteractions(t *testing.T) {
 		closeBody(resp)
 
 		// Make more health requests (should not be logged)
-		for i := 0; i < 3; i++ {
+		for range 3 {
 			resp, err := http.Get(serverURL + "/health")
 			require.NoError(t, err)
 			closeBody(resp)

--- a/tests/e2e/auth_test.go
+++ b/tests/e2e/auth_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,7 +30,7 @@ func TestAuthenticationE2E(t *testing.T) {
 		endpoint       string
 		method         string
 		authHeader     string
-		body           interface{}
+		body           any
 		expectedStatus int
 		checkResponse  func(t *testing.T, body []byte)
 	}{
@@ -78,9 +79,9 @@ func TestAuthenticationE2E(t *testing.T) {
 			authHeader:     testMasterKey,
 			expectedStatus: http.StatusUnauthorized,
 			checkResponse: func(t *testing.T, body []byte) {
-				var resp map[string]interface{}
+				var resp map[string]any
 				require.NoError(t, json.Unmarshal(body, &resp))
-				errMap := resp["error"].(map[string]interface{})
+				errMap := resp["error"].(map[string]any)
 				assert.Equal(t, "authentication_error", errMap["type"])
 				assert.Contains(t, errMap["message"], "invalid authorization header format")
 			},
@@ -105,9 +106,9 @@ func TestAuthenticationE2E(t *testing.T) {
 			authHeader:     "",
 			expectedStatus: http.StatusUnauthorized,
 			checkResponse: func(t *testing.T, body []byte) {
-				var resp map[string]interface{}
+				var resp map[string]any
 				require.NoError(t, json.Unmarshal(body, &resp))
-				errMap := resp["error"].(map[string]interface{})
+				errMap := resp["error"].(map[string]any)
 				assert.Equal(t, "authentication_error", errMap["type"])
 			},
 		},
@@ -116,7 +117,7 @@ func TestAuthenticationE2E(t *testing.T) {
 			endpoint:   "/v1/chat/completions",
 			method:     http.MethodPost,
 			authHeader: "Bearer " + testMasterKey,
-			body: map[string]interface{}{
+			body: map[string]any{
 				"model": "gpt-4",
 				"messages": []map[string]string{
 					{"role": "user", "content": "Hello"},
@@ -135,7 +136,7 @@ func TestAuthenticationE2E(t *testing.T) {
 			endpoint:   "/v1/chat/completions",
 			method:     http.MethodPost,
 			authHeader: "",
-			body: map[string]interface{}{
+			body: map[string]any{
 				"model": "gpt-4",
 				"messages": []map[string]string{
 					{"role": "user", "content": "Hello"},
@@ -143,9 +144,9 @@ func TestAuthenticationE2E(t *testing.T) {
 			},
 			expectedStatus: http.StatusUnauthorized,
 			checkResponse: func(t *testing.T, body []byte) {
-				var resp map[string]interface{}
+				var resp map[string]any
 				require.NoError(t, json.Unmarshal(body, &resp))
-				errMap := resp["error"].(map[string]interface{})
+				errMap := resp["error"].(map[string]any)
 				assert.Equal(t, "authentication_error", errMap["type"])
 			},
 		},
@@ -154,7 +155,7 @@ func TestAuthenticationE2E(t *testing.T) {
 			endpoint:   "/v1/responses",
 			method:     http.MethodPost,
 			authHeader: "Bearer " + testMasterKey,
-			body: map[string]interface{}{
+			body: map[string]any{
 				"model": "gpt-4",
 				"input": "Hello",
 			},
@@ -170,15 +171,15 @@ func TestAuthenticationE2E(t *testing.T) {
 			endpoint:   "/v1/responses",
 			method:     http.MethodPost,
 			authHeader: "",
-			body: map[string]interface{}{
+			body: map[string]any{
 				"model": "gpt-4",
 				"input": "Hello",
 			},
 			expectedStatus: http.StatusUnauthorized,
 			checkResponse: func(t *testing.T, body []byte) {
-				var resp map[string]interface{}
+				var resp map[string]any
 				require.NoError(t, json.Unmarshal(body, &resp))
-				errMap := resp["error"].(map[string]interface{})
+				errMap := resp["error"].(map[string]any)
 				assert.Equal(t, "authentication_error", errMap["type"])
 			},
 		},
@@ -280,7 +281,7 @@ func TestAuthenticationStreamingEndpoints(t *testing.T) {
 	defer ts.Close()
 
 	t.Run("streaming chat completion with valid auth", func(t *testing.T) {
-		reqBody := map[string]interface{}{
+		reqBody := map[string]any{
 			"model":  "gpt-4",
 			"stream": true,
 			"messages": []map[string]string{
@@ -305,7 +306,7 @@ func TestAuthenticationStreamingEndpoints(t *testing.T) {
 	})
 
 	t.Run("streaming chat completion without auth", func(t *testing.T) {
-		reqBody := map[string]interface{}{
+		reqBody := map[string]any{
 			"model":  "gpt-4",
 			"stream": true,
 			"messages": []map[string]string{
@@ -326,16 +327,16 @@ func TestAuthenticationStreamingEndpoints(t *testing.T) {
 
 		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 
-		var respBody map[string]interface{}
+		var respBody map[string]any
 		err = json.NewDecoder(resp.Body).Decode(&respBody)
 		require.NoError(t, err)
 
-		errMap := respBody["error"].(map[string]interface{})
+		errMap := respBody["error"].(map[string]any)
 		assert.Equal(t, "authentication_error", errMap["type"])
 	})
 
 	t.Run("streaming responses with valid auth", func(t *testing.T) {
-		reqBody := map[string]interface{}{
+		reqBody := map[string]any{
 			"model":  "gpt-4",
 			"stream": true,
 			"input":  "Hello",
@@ -358,7 +359,7 @@ func TestAuthenticationStreamingEndpoints(t *testing.T) {
 	})
 
 	t.Run("streaming responses without auth", func(t *testing.T) {
-		reqBody := map[string]interface{}{
+		reqBody := map[string]any{
 			"model":  "gpt-4",
 			"stream": true,
 			"input":  "Hello",
@@ -377,11 +378,11 @@ func TestAuthenticationStreamingEndpoints(t *testing.T) {
 
 		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 
-		var respBody map[string]interface{}
+		var respBody map[string]any
 		err = json.NewDecoder(resp.Body).Decode(&respBody)
 		require.NoError(t, err)
 
-		errMap := respBody["error"].(map[string]interface{})
+		errMap := respBody["error"].(map[string]any)
 		assert.Equal(t, "authentication_error", errMap["type"])
 	})
 }
@@ -438,9 +439,10 @@ func TestAuthenticationCaseSensitivity(t *testing.T) {
 // TestAuthenticationWithSpecialCharacters verifies that master keys with special characters work
 func TestAuthenticationWithSpecialCharacters(t *testing.T) {
 	// Create a long key with printable characters
-	longKey := "very-long-key-"
-	for i := 0; i < 100; i++ {
-		longKey += "x"
+	var longKey strings.Builder
+	longKey.WriteString("very-long-key-")
+	for range 100 {
+		longKey.WriteString("x")
 	}
 
 	specialKeys := []string{
@@ -450,7 +452,7 @@ func TestAuthenticationWithSpecialCharacters(t *testing.T) {
 		"key$with$dollars",
 		"key!@#$%^&*()",
 		"key with spaces",
-		longKey,
+		longKey.String(),
 	}
 
 	for i, key := range specialKeys {

--- a/tests/e2e/chat_test.go
+++ b/tests/e2e/chat_test.go
@@ -352,10 +352,10 @@ func TestChatCompletionStreaming(t *testing.T) {
 			if chunk.Done || len(chunk.Choices) == 0 {
 				continue
 			}
-			delta, _ := chunk.Choices[0]["delta"].(map[string]interface{})
-			if toolCalls, ok := delta["tool_calls"].([]interface{}); ok && len(toolCalls) == 1 {
-				toolCall, _ := toolCalls[0].(map[string]interface{})
-				function, _ := toolCall["function"].(map[string]interface{})
+			delta, _ := chunk.Choices[0]["delta"].(map[string]any)
+			if toolCalls, ok := delta["tool_calls"].([]any); ok && len(toolCalls) == 1 {
+				toolCall, _ := toolCalls[0].(map[string]any)
+				function, _ := toolCall["function"].(map[string]any)
 				if toolCall["id"] == "call_mock_123" && toolCall["type"] == "function" && function["name"] == "lookup_weather" && function["arguments"] == `{"city":"Warsaw"}` {
 					foundToolCall = true
 				}
@@ -382,7 +382,7 @@ func TestChatCompletionErrors(t *testing.T) {
 	})
 
 	t.Run("missing model", func(t *testing.T) {
-		resp := sendRawChatRequest(t, map[string]interface{}{
+		resp := sendRawChatRequest(t, map[string]any{
 			"messages": []map[string]string{{"role": "user", "content": "Hello"}},
 		})
 		defer closeBody(resp)
@@ -392,7 +392,7 @@ func TestChatCompletionErrors(t *testing.T) {
 
 	t.Run("unsupported model", func(t *testing.T) {
 		// Gateway validates models against registry before routing
-		resp := sendRawChatRequest(t, map[string]interface{}{
+		resp := sendRawChatRequest(t, map[string]any{
 			"model":    "invalid-model-xyz",
 			"messages": []map[string]string{{"role": "user", "content": "Hello"}},
 		})
@@ -439,7 +439,7 @@ func TestChatCompletionConcurrency(t *testing.T) {
 	}
 	results := make(chan result, numRequests)
 
-	for i := 0; i < numRequests; i++ {
+	for i := range numRequests {
 		go func(idx int) {
 			payload := defaultChatReq("Hello " + string(rune('A'+idx)))
 
@@ -457,7 +457,7 @@ func TestChatCompletionConcurrency(t *testing.T) {
 	// Collect all results in the main goroutine before asserting
 	var errors []error
 	successCount := 0
-	for i := 0; i < numRequests; i++ {
+	for range numRequests {
 		select {
 		case r := <-results:
 			if r.err != nil {

--- a/tests/e2e/failover_test.go
+++ b/tests/e2e/failover_test.go
@@ -61,7 +61,7 @@ func TestRateLimitSaturatedPrimaryFailsOver_E2E(t *testing.T) {
 		Scope:         ratelimit.ScopeModel,
 		Subject:       "gpt-4",
 		PeriodSeconds: ratelimit.PeriodMinuteSeconds,
-		MaxRequests:   rateLimitInt64(1),
+		MaxRequests:   new(int64(1)),
 		Source:        ratelimit.SourceManual,
 	}})
 
@@ -102,7 +102,7 @@ func TestRateLimitFullySaturatedAliasReturns429_E2E(t *testing.T) {
 		Scope:         ratelimit.ScopeProvider,
 		Subject:       "test",
 		PeriodSeconds: ratelimit.PeriodMinuteSeconds,
-		MaxRequests:   rateLimitInt64(2),
+		MaxRequests:   new(int64(2)),
 		Source:        ratelimit.SourceManual,
 	}})
 

--- a/tests/e2e/helpers_test.go
+++ b/tests/e2e/helpers_test.go
@@ -39,7 +39,7 @@ func sendChatRequest(t *testing.T, payload core.ChatRequest) *http.Response {
 }
 
 // sendRawChatRequest sends a raw chat request (for testing invalid payloads).
-func sendRawChatRequest(t *testing.T, payload interface{}) *http.Response {
+func sendRawChatRequest(t *testing.T, payload any) *http.Response {
 	t.Helper()
 	return sendJSONRequest(t, gatewayURL+chatCompletionsPath, payload)
 }
@@ -51,13 +51,13 @@ func sendResponsesRequest(t *testing.T, payload core.ResponsesRequest) *http.Res
 }
 
 // sendRawResponsesRequest sends a raw responses request (for testing invalid payloads).
-func sendRawResponsesRequest(t *testing.T, payload interface{}) *http.Response {
+func sendRawResponsesRequest(t *testing.T, payload any) *http.Response {
 	t.Helper()
 	return sendJSONRequest(t, gatewayURL+responsesPath, payload)
 }
 
 // sendJSONRequest sends a JSON POST request and returns the response.
-func sendJSONRequest(t *testing.T, url string, payload interface{}) *http.Response {
+func sendJSONRequest(t *testing.T, url string, payload any) *http.Response {
 	t.Helper()
 	body, err := json.Marshal(payload)
 	require.NoError(t, err)
@@ -85,7 +85,7 @@ func requireErrorResponse(t *testing.T, resp *http.Response, status int, errorTy
 //
 // This is specifically for concurrency tests, where calling t.FailNow / require from
 // goroutines is unsafe.
-func sendJSONRequestNoT(url string, payload interface{}) (*http.Response, error) {
+func sendJSONRequestNoT(url string, payload any) (*http.Response, error) {
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return nil, err
@@ -137,11 +137,11 @@ func requireRecordedResponsesRequest(t *testing.T) core.ResponsesRequest {
 
 // StreamChunk represents a parsed streaming chunk for chat completions.
 type StreamChunk struct {
-	ID      string                   `json:"id"`
-	Object  string                   `json:"object"`
-	Model   string                   `json:"model"`
-	Created int64                    `json:"created"`
-	Choices []map[string]interface{} `json:"choices"`
+	ID      string           `json:"id"`
+	Object  string           `json:"object"`
+	Model   string           `json:"model"`
+	Created int64            `json:"created"`
+	Choices []map[string]any `json:"choices"`
 	Done    bool
 }
 
@@ -177,8 +177,8 @@ func readStreamingResponse(t *testing.T, body io.Reader) []StreamChunk {
 
 // ResponsesStreamEvent represents a streaming event from the Responses API.
 type ResponsesStreamEvent struct {
-	Type string                 `json:"type"`
-	Data map[string]interface{} `json:"data,omitempty"`
+	Type string         `json:"type"`
+	Data map[string]any `json:"data,omitempty"`
 	Done bool
 }
 
@@ -193,19 +193,18 @@ func readResponsesStream(t *testing.T, body io.Reader) []ResponsesStreamEvent {
 	for scanner.Scan() {
 		line := scanner.Text()
 
-		if strings.HasPrefix(line, "event: ") {
-			currentEvent.Type = strings.TrimPrefix(line, "event: ")
+		if after, ok := strings.CutPrefix(line, "event: "); ok {
+			currentEvent.Type = after
 			continue
 		}
 
-		if strings.HasPrefix(line, "data: ") {
-			data := strings.TrimPrefix(line, "data: ")
+		if data, ok := strings.CutPrefix(line, "data: "); ok {
 			if data == "[DONE]" {
 				events = append(events, ResponsesStreamEvent{Done: true})
 				break
 			}
 
-			var eventData map[string]interface{}
+			var eventData map[string]any
 			require.NoError(t, json.Unmarshal([]byte(data), &eventData))
 			currentEvent.Data = eventData
 			if currentEvent.Type == "" {
@@ -227,7 +226,7 @@ func extractStreamContent(chunks []StreamChunk) string {
 	var content strings.Builder
 	for _, chunk := range chunks {
 		if !chunk.Done && len(chunk.Choices) > 0 {
-			if delta, ok := chunk.Choices[0]["delta"].(map[string]interface{}); ok {
+			if delta, ok := chunk.Choices[0]["delta"].(map[string]any); ok {
 				if text, ok := delta["content"].(string); ok {
 					content.WriteString(text)
 				}

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -110,7 +110,7 @@ func cleanup() {
 // waitForServer waits for the server to become healthy.
 func waitForServer(healthURL string) error {
 	client := &http.Client{Timeout: 2 * time.Second}
-	for i := 0; i < 30; i++ {
+	for range 30 {
 		resp, err := client.Get(healthURL)
 		if err == nil {
 			_ = resp.Body.Close()

--- a/tests/e2e/mock_provider.go
+++ b/tests/e2e/mock_provider.go
@@ -250,15 +250,15 @@ func (m *MockLLMServer) handleStreamingResponse(w http.ResponseWriter, req core.
 	chunks := splitIntoChunks(content, 5)
 
 	for i, chunk := range chunks {
-		delta := map[string]interface{}{
+		delta := map[string]any{
 			"id":      "chatcmpl-test-stream",
 			"object":  "chat.completion.chunk",
 			"model":   req.Model,
 			"created": time.Now().Unix(),
-			"choices": []map[string]interface{}{
+			"choices": []map[string]any{
 				{
 					"index": 0,
-					"delta": map[string]interface{}{
+					"delta": map[string]any{
 						"content": chunk,
 					},
 					"finish_reason": nil,
@@ -268,7 +268,7 @@ func (m *MockLLMServer) handleStreamingResponse(w http.ResponseWriter, req core.
 
 		// Last chunk has finish_reason
 		if i == len(chunks)-1 {
-			delta["choices"].([]map[string]interface{})[0]["finish_reason"] = "stop"
+			delta["choices"].([]map[string]any)[0]["finish_reason"] = "stop"
 		}
 
 		data, _ := json.Marshal(delta)
@@ -302,21 +302,21 @@ func (m *MockLLMServer) handleStreamingToolResponse(w http.ResponseWriter, req c
 		},
 	}
 
-	firstChunk := map[string]interface{}{
+	firstChunk := map[string]any{
 		"id":      "chatcmpl-test-stream",
 		"object":  "chat.completion.chunk",
 		"model":   req.Model,
 		"created": time.Now().Unix(),
-		"choices": []map[string]interface{}{
+		"choices": []map[string]any{
 			{
 				"index": 0,
-				"delta": map[string]interface{}{
-					"tool_calls": []map[string]interface{}{
+				"delta": map[string]any{
+					"tool_calls": []map[string]any{
 						{
 							"index": 0,
 							"id":    toolCall.ID,
 							"type":  toolCall.Type,
-							"function": map[string]interface{}{
+							"function": map[string]any{
 								"name":      toolCall.Function.Name,
 								"arguments": toolCall.Function.Arguments,
 							},
@@ -333,15 +333,15 @@ func (m *MockLLMServer) handleStreamingToolResponse(w http.ResponseWriter, req c
 	flusher.Flush()
 	time.Sleep(10 * time.Millisecond)
 
-	finalChunk := map[string]interface{}{
+	finalChunk := map[string]any{
 		"id":      "chatcmpl-test-stream",
 		"object":  "chat.completion.chunk",
 		"model":   req.Model,
 		"created": time.Now().Unix(),
-		"choices": []map[string]interface{}{
+		"choices": []map[string]any{
 			{
 				"index":         0,
-				"delta":         map[string]interface{}{},
+				"delta":         map[string]any{},
 				"finish_reason": "tool_calls",
 			},
 		},
@@ -396,19 +396,19 @@ func (m *MockLLMServer) handleResponses(w http.ResponseWriter, r *http.Request, 
 	inputText := extractInputText(req.Input)
 	responseContent := fmt.Sprintf("Mock response to: %s", inputText)
 
-	response := map[string]interface{}{
+	response := map[string]any{
 		"id":         "resp_test_" + time.Now().Format("20060102150405"),
 		"object":     "response",
 		"created_at": time.Now().Unix(),
 		"model":      req.Model,
 		"status":     "completed",
-		"output": []map[string]interface{}{
+		"output": []map[string]any{
 			{
 				"id":     fmt.Sprintf("msg_%d", time.Now().UnixNano()),
 				"type":   "message",
 				"role":   "assistant",
 				"status": "completed",
-				"content": []map[string]interface{}{
+				"content": []map[string]any{
 					{
 						"type":        "output_text",
 						"text":        responseContent,
@@ -417,7 +417,7 @@ func (m *MockLLMServer) handleResponses(w http.ResponseWriter, r *http.Request, 
 				},
 			},
 		},
-		"usage": map[string]interface{}{
+		"usage": map[string]any{
 			"input_tokens":  10,
 			"output_tokens": 20,
 			"total_tokens":  30,
@@ -447,9 +447,9 @@ func (m *MockLLMServer) handleResponsesStreaming(w http.ResponseWriter, req core
 	chunks := splitIntoChunks(content, 5)
 
 	// Send response.created event
-	createdEvent := map[string]interface{}{
+	createdEvent := map[string]any{
 		"type": "response.created",
-		"response": map[string]interface{}{
+		"response": map[string]any{
 			"id":         responseID,
 			"object":     "response",
 			"status":     "in_progress",
@@ -463,7 +463,7 @@ func (m *MockLLMServer) handleResponsesStreaming(w http.ResponseWriter, req core
 
 	// Send text delta events
 	for _, chunk := range chunks {
-		deltaEvent := map[string]interface{}{
+		deltaEvent := map[string]any{
 			"type":  "response.output_text.delta",
 			"delta": chunk,
 		}
@@ -474,15 +474,15 @@ func (m *MockLLMServer) handleResponsesStreaming(w http.ResponseWriter, req core
 	}
 
 	// Send response.completed event
-	doneEvent := map[string]interface{}{
+	doneEvent := map[string]any{
 		"type": "response.completed",
-		"response": map[string]interface{}{
+		"response": map[string]any{
 			"id":         responseID,
 			"object":     "response",
 			"status":     "completed",
 			"model":      req.Model,
 			"created_at": time.Now().Unix(),
-			"usage": map[string]interface{}{
+			"usage": map[string]any{
 				"input_tokens":  10,
 				"output_tokens": 20,
 				"total_tokens":  30,
@@ -499,22 +499,22 @@ func (m *MockLLMServer) handleResponsesStreaming(w http.ResponseWriter, req core
 }
 
 // extractInputText extracts text content from the input field.
-func extractInputText(input interface{}) string {
+func extractInputText(input any) string {
 	switch v := input.(type) {
 	case string:
 		return v
-	case []interface{}:
+	case []any:
 		// Array input - extract from last user message
 		for i := len(v) - 1; i >= 0; i-- {
-			if msg, ok := v[i].(map[string]interface{}); ok {
+			if msg, ok := v[i].(map[string]any); ok {
 				if role, _ := msg["role"].(string); role == "user" {
 					if content, ok := msg["content"].(string); ok {
 						return content
 					}
 					// Handle complex content (array of content items)
-					if contentArr, ok := msg["content"].([]interface{}); ok {
+					if contentArr, ok := msg["content"].([]any); ok {
 						for _, item := range contentArr {
-							if itemMap, ok := item.(map[string]interface{}); ok {
+							if itemMap, ok := item.(map[string]any); ok {
 								if text, ok := itemMap["text"].(string); ok {
 									return text
 								}
@@ -542,9 +542,9 @@ func generateMockResponse(req core.ChatRequest) string {
 
 func forcedToolName(req core.ChatRequest) string {
 	switch choice := req.ToolChoice.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		if choiceType, _ := choice["type"].(string); choiceType == "function" {
-			if function, ok := choice["function"].(map[string]interface{}); ok {
+			if function, ok := choice["function"].(map[string]any); ok {
 				if name, _ := function["name"].(string); name != "" {
 					return name
 				}
@@ -552,7 +552,7 @@ func forcedToolName(req core.ChatRequest) string {
 		}
 	case string:
 		if choice == "required" && len(req.Tools) > 0 {
-			if function, ok := req.Tools[0]["function"].(map[string]interface{}); ok {
+			if function, ok := req.Tools[0]["function"].(map[string]any); ok {
 				if name, _ := function["name"].(string); name != "" {
 					return name
 				}
@@ -571,10 +571,7 @@ func splitIntoChunks(s string, n int) []string {
 
 	chunks := make([]string, 0)
 	for i := 0; i < len(s); i += n {
-		end := i + n
-		if end > len(s) {
-			end = len(s)
-		}
+		end := min(i+n, len(s))
 		chunks = append(chunks, s[i:end])
 	}
 	return chunks

--- a/tests/e2e/ratelimit_test.go
+++ b/tests/e2e/ratelimit_test.go
@@ -41,21 +41,19 @@ func setupRateLimitService(t *testing.T, rules []ratelimit.Rule) *ratelimit.Serv
 	return service
 }
 
-func rateLimitInt64(v int64) *int64 { return &v }
-
 func TestRateLimitRequestEnforcement_E2E(t *testing.T) {
 	mockServer.ResetRequests()
 	service := setupRateLimitService(t, []ratelimit.Rule{{
 		Subject:       "/team/rl",
 		PeriodSeconds: ratelimit.PeriodMinuteSeconds,
-		MaxRequests:   rateLimitInt64(2),
+		MaxRequests:   new(int64(2)),
 		Source:        ratelimit.SourceManual,
 	}})
 
 	ts := httptest.NewServer(setupE2EServer(t, e2eServerOptions{rateLimiter: service}))
 	defer ts.Close()
 
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		resp := sendBudgetChatRequest(t, ts.URL, "rate limit ok", "rl-ok-"+strconv.Itoa(i), "/team/rl/app")
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		require.Equal(t, "2", resp.Header.Get("x-ratelimit-limit-requests"))
@@ -90,7 +88,7 @@ func TestRateLimitTokenEnforcement_E2E(t *testing.T) {
 	service := setupRateLimitService(t, []ratelimit.Rule{{
 		Subject:       "/team/tokens",
 		PeriodSeconds: ratelimit.PeriodMinuteSeconds,
-		MaxTokens:     rateLimitInt64(5),
+		MaxTokens:     new(int64(5)),
 		Source:        ratelimit.SourceManual,
 	}})
 
@@ -142,7 +140,7 @@ func TestRateLimitConcurrencyEnforcement_E2E(t *testing.T) {
 	service := setupRateLimitService(t, []ratelimit.Rule{{
 		Subject:       "/team/cc",
 		PeriodSeconds: ratelimit.PeriodConcurrent,
-		MaxRequests:   rateLimitInt64(1),
+		MaxRequests:   new(int64(1)),
 		Source:        ratelimit.SourceManual,
 	}})
 
@@ -215,7 +213,7 @@ func TestRateLimitProviderScopeEnforcement_E2E(t *testing.T) {
 		Scope:         ratelimit.ScopeProvider,
 		Subject:       "test",
 		PeriodSeconds: ratelimit.PeriodMinuteSeconds,
-		MaxRequests:   rateLimitInt64(1),
+		MaxRequests:   new(int64(1)),
 		Source:        ratelimit.SourceManual,
 	}})
 

--- a/tests/e2e/responses_test.go
+++ b/tests/e2e/responses_test.go
@@ -70,7 +70,7 @@ func TestResponses(t *testing.T) {
 
 		payload := core.ResponsesRequest{
 			Model: "gpt-4.1",
-			Input: []map[string]interface{}{
+			Input: []map[string]any{
 				{"role": "user", "content": "What is 2 + 2?"},
 				{"role": "assistant", "content": "2 + 2 equals 4."},
 				{"role": "user", "content": "And what is 3 + 3?"},
@@ -231,17 +231,17 @@ func TestResponsesStreaming(t *testing.T) {
 func TestResponsesTools(t *testing.T) {
 	tests := []struct {
 		name  string
-		tools []map[string]interface{}
+		tools []map[string]any
 	}{
 		{
 			name: "file_search tool",
-			tools: []map[string]interface{}{
+			tools: []map[string]any{
 				{"type": "file_search", "vector_store_ids": []string{"vs_test"}},
 			},
 		},
 		{
 			name: "web_search tool",
-			tools: []map[string]interface{}{
+			tools: []map[string]any{
 				{"type": "web_search_preview"},
 			},
 		},
@@ -285,7 +285,7 @@ func TestResponsesErrors(t *testing.T) {
 	})
 
 	t.Run("missing model", func(t *testing.T) {
-		resp := sendRawResponsesRequest(t, map[string]interface{}{"input": "Hello"})
+		resp := sendRawResponsesRequest(t, map[string]any{"input": "Hello"})
 		defer closeBody(resp)
 
 		requireErrorResponse(t, resp, http.StatusBadRequest, core.ErrorTypeInvalidRequest, "model is required")
@@ -353,10 +353,10 @@ func TestResponsesMultimodal(t *testing.T) {
 
 	payload := core.ResponsesRequest{
 		Model: "gpt-4.1",
-		Input: []map[string]interface{}{
+		Input: []map[string]any{
 			{
 				"role": "user",
-				"content": []map[string]interface{}{
+				"content": []map[string]any{
 					{"type": "input_text", "text": "What's in this image?"},
 					{"type": "input_image", "image_url": map[string]string{"url": "https://example.com/image.jpg"}},
 				},
@@ -406,7 +406,7 @@ func TestResponsesConcurrency(t *testing.T) {
 	}
 	results := make(chan result, numRequests)
 
-	for i := 0; i < numRequests; i++ {
+	for i := range numRequests {
 		go func(idx int) {
 			payload := core.ResponsesRequest{
 				Model: "gpt-4.1",
@@ -427,7 +427,7 @@ func TestResponsesConcurrency(t *testing.T) {
 	// Collect all results in the main goroutine before asserting
 	var errors []error
 	successCount := 0
-	for i := 0; i < numRequests; i++ {
+	for range numRequests {
 		select {
 		case r := <-results:
 			if r.err != nil {

--- a/tests/integration/admin_test.go
+++ b/tests/integration/admin_test.go
@@ -31,7 +31,7 @@ func TestAdminUsageSummary_PostgreSQL(t *testing.T) {
 	dbassert.ClearUsage(t, fixture.PgPool)
 
 	// Send 2 chat requests
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		payload := newChatRequest("gpt-4", "Hello!")
 		resp := sendChatRequest(t, fixture.ServerURL, payload)
 		require.Equal(t, 200, resp.StatusCode)
@@ -74,7 +74,7 @@ func TestAdminDailyUsage_PostgreSQL(t *testing.T) {
 	dbassert.ClearUsage(t, fixture.PgPool)
 
 	// Send requests
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		payload := newChatRequest("gpt-4", "Hello!")
 		resp := sendChatRequest(t, fixture.ServerURL, payload)
 		require.Equal(t, 200, resp.StatusCode)
@@ -129,7 +129,7 @@ func TestAdminUsageSummary_MongoDB(t *testing.T) {
 	dbassert.ClearUsageMongo(t, fixture.MongoDb)
 
 	// Send 2 chat requests
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		payload := newChatRequest("gpt-4", "Hello!")
 		resp := sendChatRequest(t, fixture.ServerURL, payload)
 		require.Equal(t, 200, resp.StatusCode)

--- a/tests/integration/auditlog_test.go
+++ b/tests/integration/auditlog_test.go
@@ -220,7 +220,7 @@ func TestAuditLog_MultipleRequests_PostgreSQL(t *testing.T) {
 
 	// Make multiple requests with unique IDs
 	requestIDs := make([]string, 3)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		requestIDs[i] = uuid.New().String()
 		payload := newChatRequest("gpt-4", "Hello!")
 		resp := sendChatRequestWithHeaders(t, fixture.ServerURL, payload, map[string]string{

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -43,7 +43,7 @@ func sendResponsesRequestWithHeaders(t *testing.T, serverURL string, payload cor
 }
 
 // sendJSONRequest sends a JSON POST request and returns the response.
-func sendJSONRequest(t *testing.T, url string, payload interface{}, headers map[string]string) *http.Response {
+func sendJSONRequest(t *testing.T, url string, payload any, headers map[string]string) *http.Response {
 	t.Helper()
 
 	body, err := json.Marshal(payload)

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -54,7 +54,7 @@ func TestMain(m *testing.M) {
 	}()
 
 	// Wait for both containers to start
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		if err := <-errCh; err != nil {
 			log.Printf("Container setup failed: %v", err)
 			cleanup()

--- a/tests/integration/setup_test.go
+++ b/tests/integration/setup_test.go
@@ -371,7 +371,7 @@ func testPricingMetadata() *core.ModelMetadata {
 // waitForServer waits for the server to become healthy.
 func waitForServer(healthURL string) error {
 	client := &http.Client{Timeout: 2 * time.Second}
-	for i := 0; i < 50; i++ {
+	for range 50 {
 		resp, err := client.Get(healthURL)
 		if err == nil {
 			_ = resp.Body.Close()
@@ -524,15 +524,15 @@ func handleChatCompletionStream(w http.ResponseWriter, model string) {
 	// Send content chunks
 	chunks := []string{"Hello", "!", " How", " can", " I", " help", " you", " today", "?"}
 	for i, chunk := range chunks {
-		delta := map[string]interface{}{
+		delta := map[string]any{
 			"id":      "chatcmpl-test-stream",
 			"object":  "chat.completion.chunk",
 			"model":   model,
 			"created": 1700000000,
-			"choices": []map[string]interface{}{
+			"choices": []map[string]any{
 				{
 					"index": 0,
-					"delta": map[string]interface{}{
+					"delta": map[string]any{
 						"content": chunk,
 					},
 					"finish_reason": nil,
@@ -542,8 +542,8 @@ func handleChatCompletionStream(w http.ResponseWriter, model string) {
 
 		// Last chunk has finish_reason and usage
 		if i == len(chunks)-1 {
-			delta["choices"].([]map[string]interface{})[0]["finish_reason"] = "stop"
-			delta["usage"] = map[string]interface{}{
+			delta["choices"].([]map[string]any)[0]["finish_reason"] = "stop"
+			delta["usage"] = map[string]any{
 				"prompt_tokens":     10,
 				"completion_tokens": 8,
 				"total_tokens":      18,
@@ -613,9 +613,9 @@ func handleResponsesStream(w http.ResponseWriter, model string) {
 	}
 
 	// Send response.created event
-	createdEvent := map[string]interface{}{
+	createdEvent := map[string]any{
 		"type": "response.created",
-		"response": map[string]interface{}{
+		"response": map[string]any{
 			"id":         "resp-test-stream",
 			"object":     "response",
 			"created_at": 1700000000,
@@ -630,7 +630,7 @@ func handleResponsesStream(w http.ResponseWriter, model string) {
 	// Send content delta events
 	chunks := []string{"Hello", "!", " How", " can", " I", " help", " you", "?"}
 	for _, chunk := range chunks {
-		deltaEvent := map[string]interface{}{
+		deltaEvent := map[string]any{
 			"type":  "response.output_text.delta",
 			"delta": chunk,
 		}
@@ -640,15 +640,15 @@ func handleResponsesStream(w http.ResponseWriter, model string) {
 	}
 
 	// Send response.completed event with usage
-	doneEvent := map[string]interface{}{
+	doneEvent := map[string]any{
 		"type": "response.completed",
-		"response": map[string]interface{}{
+		"response": map[string]any{
 			"id":         "resp-test-stream",
 			"object":     "response",
 			"created_at": 1700000000,
 			"model":      model,
 			"status":     "completed",
-			"usage": map[string]interface{}{
+			"usage": map[string]any{
 				"input_tokens":  10,
 				"output_tokens": 8,
 				"total_tokens":  18,

--- a/tests/integration/usage_test.go
+++ b/tests/integration/usage_test.go
@@ -139,7 +139,7 @@ func TestUsage_MultipleRequests_PostgreSQL(t *testing.T) {
 	dbassert.ClearUsage(t, fixture.PgPool)
 
 	requestIDs := make([]string, 5)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		requestIDs[i] = uuid.New().String()
 		payload := newChatRequest("gpt-4", "Hello!")
 		resp := sendChatRequestWithHeaders(t, fixture.ServerURL, payload, map[string]string{
@@ -174,7 +174,7 @@ func TestUsage_TokenSummary_PostgreSQL(t *testing.T) {
 	dbassert.ClearUsage(t, fixture.PgPool)
 
 	// Make several requests
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		payload := newChatRequest("gpt-4", "Hello!")
 		resp := sendChatRequest(t, fixture.ServerURL, payload)
 		require.Equal(t, 200, resp.StatusCode)

--- a/tests/integration/workflows_guardrails_test.go
+++ b/tests/integration/workflows_guardrails_test.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"bytes"
 	"encoding/json"
+	"maps"
 	"net/http"
 	"strings"
 	"testing"
@@ -53,7 +54,7 @@ func TestManagedAuthKeyWorkflow_AuditAndUsageValidity_PostgreSQL(t *testing.T) {
 				Audit:      true,
 				Usage:      true,
 				Guardrails: false,
-				Failover:   boolPtr(false),
+				Failover:   new(false),
 			},
 			Guardrails: []workflows.GuardrailStep{},
 		},
@@ -162,7 +163,7 @@ func TestGuardrailWorkflow_RewritesUpstreamRequestAndPreservesAuditUsage_Postgre
 				Audit:      true,
 				Usage:      true,
 				Guardrails: true,
-				Failover:   boolPtr(false),
+				Failover:   new(false),
 			},
 			Guardrails: []workflows.GuardrailStep{
 				{Ref: "policy-system", Step: 10},
@@ -286,9 +287,7 @@ func upsertGuardrail(t *testing.T, serverURL, masterKey, name string, payload ma
 	t.Helper()
 
 	body := make(map[string]any, len(payload)+1)
-	for key, value := range payload {
-		body[key] = value
-	}
+	maps.Copy(body, payload)
 	body["name"] = name
 
 	resp := adminJSONRequest(t, http.MethodPut, serverURL+"/admin/guardrails", masterKey, body)
@@ -316,8 +315,4 @@ func adminJSONRequest(t *testing.T, method, url, masterKey string, payload map[s
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 	return resp
-}
-
-func boolPtr(value bool) *bool {
-	return &value
 }


### PR DESCRIPTION
## What

Ran `go fix ./...` across the module and adopted the modern stdlib idioms it suggests, then added a pre-commit guard so the tree stays modernized.

**Net −112 lines** (`448 insertions`, `560 deletions`) across 95 files. Only `Makefile` and `.pre-commit-config.yaml` are non-Go.

| Idiom | Sites |
|---|---|
| `new(expr)` replacing pointer helpers | 198 |
| `maps.Copy` | 21 |
| `slices.Contains` / `slices.Backward` | 6 |
| `min` / `max` | 10 |
| `strings.SplitSeq` | 5 |
| `strings.CutPrefix` / `bytes.CutPrefix` | 6 |
| range-over-int | 13 |
| `reflect.Type.Fields` | 2 |
| `sync.WaitGroup.Go` | 2 |

Go 1.26's `new(expr)` makes the hand-rolled `intPtr`/`boolPtr`/`stringPtr`/… helpers redundant, so all **19** are deleted, along with the `//go:fix inline` directives `go fix` injected to mark them.

## User-visible impact

**None.** Every change is behavior-preserving.

The only wire-visible candidates were five `,omitempty` tags dropped from **struct-typed** JSON fields — three `time.Time` (`auditlog.AttemptSnapshot.StartedAt`, and `StoredAt`/`ExpiresAt` in the conversation/response stores) and two Gemini decode-only types. `omitempty` is a documented no-op on struct values, so the fields were always emitted. Verified empirically against `goccy/go-json` (which this repo uses in place of `encoding/json`): zero and non-zero values marshal byte-identically with and without the tag.

The two `//go:build`-gated Gemini types (`geminiGenerateContentResponse`, `geminiCandidate`) are never marshaled — decode only — so tags are irrelevant there.

## Two `go fix` gotchas worth knowing

Both are now captured as comments in `Makefile` and `.pre-commit-config.yaml`:

1. **It needs two passes to converge.** When `go fix` marks a helper `//go:fix inline`, it inlines that helper's callers only on the *next* run — leaving the helper orphaned and tripping the `unused` linter. A single `go fix ./...` leaves the tree lint-failing.
2. **It silently skips build-tagged files.** Plain `go fix ./...` never sees `tests/{e2e,integration,contract}` or `swagger`. Those had ~100 KB of unapplied fixes; this PR fixes them too by passing `-tags`.

## Tooling

- `make fix` — apply modernizations (documents the two-pass caveat).
- `make fix-check` — report drift via `go fix -diff`, **non-mutating**, exits non-zero on drift (~0.7 s).
- New `go-fix-check` pre-commit hook runs `make fix-check`.
- Lifted the repeated build-tag string into a `BUILD_TAGS` Makefile variable now that `lint`, `fix`, and `fix-check` all share it. `make lint` expands to the identical command as before.

The hook **checks rather than auto-applies**, deliberately: `go fix` rewrites source in place and (per gotcha 1) can leave an orphaned helper that fails `make lint`. An auto-applying hook would mutate the commit *and still fail it*.

Verified the hook is real by injecting a `for k, v := range` copy loop into a `//go:build e2e` file: plain `go fix -diff ./...` exits 0 (misses it), `make fix-check` exits 2 (catches it). The `-tags` are load-bearing.

## Testing

All 13 pre-commit hooks pass on this commit:

- `make test-race` — 60/60 packages, no data races
- `make lint` — 0 issues (`--build-tags=swagger,e2e,integration,contract`)
- `make perf-check` — hot-path alloc/byte guards within thresholds
- `make fix-check` — tree is a `go fix` fixed point
- `go mod tidy` — clean
- `tests/{e2e,integration,contract}` compile under their build tags

The 3 pre-existing `go vet` `repeats json tag` warnings in `internal/core` are unchanged by this PR (confirmed against baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `fix` and `fix-check` developer commands for Go modernization checks and updates.
* **Bug Fixes**
  * Improved JSON output consistency by always including stored timestamp fields in relevant stored conversation/response data and audit log snapshot payloads.
  * Updated Gemini request/response marshaling to ensure required fields are always encoded.
* **Refactor**
  * Modernized internal Go implementations and tests for safer concurrency and more consistent string/collection handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->