### PR TITLE
feat(providers): add Eden AI as an OpenAI-compatible provider

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -399,6 +399,16 @@ providers:
   #     - openai/gpt-oss-120b
   #     - anthropic/claude-sonnet-4
 
+  # Example: Eden AI. EU-hosted, OpenAI-compatible gateway to 100+ models.
+  # Models use the "provider/model" scheme; the full id is sent upstream.
+  # edenai:
+  #   type: "edenai"
+  #   base_url: "https://api.edenai.run/v3"
+  #   api_key: "${EDENAI_API_KEY}"
+  #   models:
+  #     - anthropic/claude-sonnet-4-5
+  #     - mistral/codestral-latest
+
   # Example: Azure OpenAI
   # azure:
   #   type: "azure"

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -133,6 +133,7 @@
                     "providers/gemini",
                     "providers/deepseek",
                     "providers/xai",
+                    "providers/edenai",
                     "providers/bailian",
                     "providers/xiaomi",
                     "providers/opencode-go",

--- a/docs/providers/edenai.mdx
+++ b/docs/providers/edenai.mdx
@@ -1,0 +1,39 @@
+---
+title: "Eden AI"
+description: "Configure Eden AI in GoModel — an EU-hosted, OpenAI-compatible gateway to 100+ models via a single API key."
+icon: "globe"
+---
+
+[Eden AI](https://www.edenai.co) is an EU-hosted, OpenAI-compatible gateway that
+exposes 100+ models from many providers (OpenAI, Anthropic, Google, Mistral,
+DeepSeek, and more) through a single endpoint and API key. Models use the
+`provider/model` naming scheme (e.g. `anthropic/claude-sonnet-4-5`); GoModel
+sends the full id upstream unchanged.
+
+## Configure
+
+```bash
+EDENAI_API_KEY=...
+```
+
+Or in `config.yaml`:
+
+```yaml
+providers:
+  edenai:
+    type: edenai
+    base_url: "https://api.edenai.run/v3"
+    api_key: "${EDENAI_API_KEY}"
+    models:
+      - anthropic/claude-sonnet-4-5
+      - mistral/codestral-latest
+```
+
+<Note>
+  The default endpoint is `https://api.edenai.run/v3`. For EU-only data
+  residency, set `base_url` to `https://api.eu.edenai.run/v3`.
+</Note>
+
+Because Eden AI is fully OpenAI-compatible, GoModel routes chat completions,
+embeddings, and model discovery through its shared OpenAI-compatible adapter
+with no request quirks.

--- a/internal/providers/edenai/edenai.go
+++ b/internal/providers/edenai/edenai.go
@@ -1,0 +1,65 @@
+// Package edenai provides Eden AI integration for the LLM gateway.
+package edenai
+
+import (
+	"net/http"
+
+	"gomodel/internal/core"
+	"gomodel/internal/llmclient"
+	"gomodel/internal/providers"
+	"gomodel/internal/providers/openai"
+)
+
+// Eden AI (https://www.edenai.co) is an EU-hosted, OpenAI-compatible gateway
+// that exposes 100+ models from many providers through a single endpoint and
+// API key. Models use the "provider/model" naming scheme (e.g.
+// "anthropic/claude-sonnet-4-5"); the full id is sent upstream unchanged.
+const defaultBaseURL = "https://api.edenai.run/v3"
+
+// Registration provides factory registration for the Eden AI provider.
+var Registration = providers.Registration{
+	Type:                        "edenai",
+	New:                         New,
+	PassthroughSemanticEnricher: openai.Registration.PassthroughSemanticEnricher,
+	Discovery: providers.DiscoveryConfig{
+		DefaultBaseURL: defaultBaseURL,
+	},
+}
+
+// Provider implements the core.Provider interface for Eden AI. Eden AI's API
+// is OpenAI-compatible, so all transport goes through the shared compatible
+// provider with no request quirks.
+type Provider struct {
+	*openai.CompatibleProvider
+}
+
+var _ core.Provider = (*Provider)(nil)
+
+// New creates a new Eden AI provider.
+func New(cfg providers.ProviderConfig, opts providers.ProviderOptions) core.Provider {
+	return &Provider{
+		CompatibleProvider: openai.NewCompatibleProvider(cfg.APIKey, opts, compatibleConfig(providers.ResolveBaseURL(cfg.BaseURL, defaultBaseURL))),
+	}
+}
+
+// NewWithHTTPClient creates a new Eden AI provider with a custom HTTP client.
+// If httpClient is nil, http.DefaultClient is used.
+func NewWithHTTPClient(apiKey string, baseURL string, httpClient *http.Client, hooks llmclient.Hooks) *Provider {
+	return &Provider{
+		CompatibleProvider: openai.NewCompatibleProviderWithHTTPClient(apiKey, httpClient, hooks, compatibleConfig(providers.ResolveBaseURL(baseURL, defaultBaseURL))),
+	}
+}
+
+func compatibleConfig(baseURL string) openai.CompatibleProviderConfig {
+	return openai.CompatibleProviderConfig{
+		ProviderName: "edenai",
+		BaseURL:      baseURL,
+		SetHeaders:   setHeaders,
+	}
+}
+
+func setHeaders(req *http.Request, apiKey string) {
+	providers.SetAuthHeaders(req, apiKey, providers.AuthHeaderConfig{
+		AuthScheme: "Bearer ",
+	})
+}

--- a/internal/providers/edenai/edenai_test.go
+++ b/internal/providers/edenai/edenai_test.go
@@ -1,0 +1,67 @@
+package edenai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"gomodel/internal/core"
+	"gomodel/internal/llmclient"
+	"gomodel/internal/providers"
+)
+
+func TestRegistration(t *testing.T) {
+	if Registration.Type != "edenai" {
+		t.Fatalf("Registration.Type = %q, want edenai", Registration.Type)
+	}
+	if Registration.Discovery.DefaultBaseURL != defaultBaseURL {
+		t.Fatalf("DefaultBaseURL = %q, want %q", Registration.Discovery.DefaultBaseURL, defaultBaseURL)
+	}
+	if p := New(providers.ProviderConfig{APIKey: "eden-key"}, providers.ProviderOptions{}); p == nil {
+		t.Fatal("New() returned nil")
+	}
+}
+
+func TestChatCompletion_UsesBearerAuthAndChatEndpoint(t *testing.T) {
+	var gotPath string
+	var gotAuth string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-edenai",
+			"created":1677652288,
+			"model":"anthropic/claude-sonnet-4-5",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":3,"completion_tokens":1,"total_tokens":4}
+		}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("eden-key", server.URL, server.Client(), llmclient.Hooks{})
+
+	resp, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{
+		Model: "anthropic/claude-sonnet-4-5",
+		Messages: []core.Message{
+			{Role: "user", Content: "hi"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ChatCompletion() error = %v", err)
+	}
+	if resp.Model != "anthropic/claude-sonnet-4-5" {
+		t.Fatalf("resp.Model = %q, want anthropic/claude-sonnet-4-5", resp.Model)
+	}
+	if resp.Usage.TotalTokens != 4 {
+		t.Fatalf("resp.Usage = %+v, want total_tokens=4", resp.Usage)
+	}
+	if gotPath != "/chat/completions" {
+		t.Fatalf("path = %q, want /chat/completions", gotPath)
+	}
+	if gotAuth != "Bearer eden-key" {
+		t.Fatalf("Authorization = %q, want Bearer eden-key", gotAuth)
+	}
+}

--- a/run/providers.go
+++ b/run/providers.go
@@ -9,6 +9,7 @@ import (
 	"gomodel/internal/providers/bailian"
 	"gomodel/internal/providers/bedrock"
 	"gomodel/internal/providers/deepseek"
+	"gomodel/internal/providers/edenai"
 	"gomodel/internal/providers/fireworks"
 	"gomodel/internal/providers/gemini"
 	"gomodel/internal/providers/groq"
@@ -44,6 +45,7 @@ func defaultProviderFactory(cfg *config.Config) *providers.ProviderFactory {
 	factory.Add(anthropic.Registration)
 	factory.Add(bedrock.Registration)
 	factory.Add(deepseek.Registration)
+	factory.Add(edenai.Registration)
 	factory.Add(fireworks.Registration)
 	factory.Add(gemini.Registration)
 	factory.Add(vertex.Registration)


### PR DESCRIPTION
## Description

Adds **Eden AI** (https://www.edenai.co) as a first-class OpenAI-compatible provider (`type: edenai`). Eden AI is an EU-hosted gateway that exposes 100+ models from many providers (OpenAI, Anthropic, Google, Mistral, DeepSeek, …) through a single endpoint and API key. Models use the `provider/model` naming scheme; the full id is sent upstream unchanged (like OpenRouter).

- `internal/providers/edenai/edenai.go` — provider reusing the shared OpenAI-compatible transport (`defaultBaseURL: https://api.edenai.run/v3`, Bearer auth) + factory `Registration`
- `run/providers.go` — `factory.Add(edenai.Registration)`
- `config/config.example.yaml` — example config
- `docs/providers/edenai.mdx` (+ nav in `docs/docs.json`)
- `internal/providers/edenai/edenai_test.go` — registration + chat-completion tests

## Configure

```yaml
providers:
  edenai:
    type: edenai
    base_url: "https://api.edenai.run/v3"
    api_key: "${EDENAI_API_KEY}"
    models:
      - anthropic/claude-sonnet-4-5
      - mistral/codestral-latest
```

## Testing

- `go build ./...`, `go vet`, `gofmt` clean.
- `go test ./internal/providers/...` all pass, incl. new `edenai` tests (no regressions).
- Verified live against the Eden AI API (`/v3/chat/completions` → 200).
- API key via `EDENAI_API_KEY` only; never hardcoded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Eden AI as a supported provider.
  - Added Eden AI setup documentation and a commented example configuration (including API key via environment variable and model allowlisting).
  - Included Eden AI in the Providers navigation and default provider list.
- **Bug Fixes**
  - Ensured Eden AI requests use the expected Bearer authentication header and the correct `/chat/completions` routing.
- **Tests**
  - Added tests covering provider registration and chat completion request/auth behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->