### PR TITLE
feat(xai): support grok-4.5 reasoning effort mapping

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -127,6 +127,7 @@
                     "providers/anthropic",
                     "providers/gemini",
                     "providers/deepseek",
+                    "providers/xai",
                     "providers/bailian",
                     "providers/xiaomi",
                     "providers/opencode-go",

--- a/docs/providers/overview.mdx
+++ b/docs/providers/overview.mdx
@@ -28,7 +28,7 @@ support, not every individual model capability exposed by an upstream provider.
 | Fireworks AI | `FIREWORKS_API_KEY` (`FIREWORKS_BASE_URL` optional) | `accounts/fireworks/models/gpt-oss-120b` | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | — |
 | OpenRouter | `OPENROUTER_API_KEY` | `google/gemini-2.5-flash` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — |
 | Z.ai | `ZAI_API_KEY` (`ZAI_BASE_URL` optional) | `glm-5.1` | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | — |
-| xAI (Grok) | `XAI_API_KEY` | `grok-4` | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | — |
+| xAI (Grok) | `XAI_API_KEY` | `grok-4.5` | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | [xAI (Grok)](/providers/xai) |
 | Alibaba Cloud Model Studio (Bailian) | `BAILIAN_API_KEY` (`BAILIAN_BASE_URL` optional) | `qwen3-max` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | [Alibaba Cloud Model Studio](/providers/bailian) |
 | MiniMax | `MINIMAX_API_KEY` (`MINIMAX_BASE_URL` optional) | `MiniMax-M3` | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | — |
 | Xiaomi MiMo | `XIAOMI_API_KEY` (`XIAOMI_BASE_URL` optional) | `mimo-v2.5-pro` | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | [Xiaomi MiMo](/providers/xiaomi) |

--- a/docs/providers/xai.mdx
+++ b/docs/providers/xai.mdx
@@ -1,0 +1,60 @@
+---
+title: "xAI (Grok)"
+description: "Configure xAI Grok models in GoModel and understand how reasoning effort and prompt-cache affinity are handled."
+icon: "x"
+---
+
+xAI's API is OpenAI-compatible, including a native Responses API. Models such
+as `grok-4.5` are discovered automatically from xAI's `/models` endpoint — no
+configuration beyond the API key is needed.
+
+## Configure
+
+```bash
+XAI_API_KEY=...
+```
+
+Or in `config.yaml`:
+
+```yaml
+providers:
+  xai:
+    type: xai
+    base_url: "https://api.x.ai/v1"
+    api_key: "${XAI_API_KEY}"
+```
+
+<Note>
+  Voice models (e.g. `grok-voice-latest`) are not listed by xAI's `/models`
+  endpoint. To route realtime sessions to them, add them explicitly via
+  `XAI_MODELS=grok-voice-latest` or a configured model list.
+</Note>
+
+## Reasoning effort mapping
+
+Grok reasoning models (e.g. `grok-4.5`, defaulting to `high`) accept
+`reasoning_effort` as a top-level string on Chat Completions. GoModel rewrites
+the OpenAI-shaped `"reasoning": {"effort": "..."}` into that flat field — no
+client change required. On the Responses API the nested shape is xAI-native
+and passes through unchanged.
+
+| Client sends | xAI receives |
+| ------------ | ------------ |
+| `none` / `low` / `medium` / `high` | unchanged |
+| `xhigh` / `max` | `high` (`xhigh` on the multi-agent Grok family, where it selects the agent count) |
+| anything else | passed through for xAI to judge |
+
+Models without reasoning support reject the field upstream; omit `reasoning`
+for those.
+
+## Prompt-cache affinity
+
+xAI routes a conversation's requests to the same server via the
+`x-grok-conv-id` header; without it, cache hits are unreliable and input
+tokens are often billed at the uncached price.
+
+- **Chat Completions:** GoModel forwards a client-supplied `X-Grok-Conv-Id`
+  header, and otherwise derives a stable one from the conversation's opening
+  messages — cache affinity works with no client change.
+- **Responses API:** pass `prompt_cache_key` in the request body; GoModel
+  forwards it verbatim.

--- a/internal/providers/keyring_test.go
+++ b/internal/providers/keyring_test.go
@@ -114,14 +114,12 @@ func TestKeyringNextIsConcurrentAndEven(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range total {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			key := ring.Next()
 			mu.Lock()
 			counts[key]++
 			mu.Unlock()
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/internal/providers/xai/xai.go
+++ b/internal/providers/xai/xai.go
@@ -73,7 +73,38 @@ func compatibleConfig(baseURL string) openai.CompatibleProviderConfig {
 		ProviderName:       "xai",
 		BaseURL:            baseURL,
 		SetHeaders:         setHeaders,
+		AdaptChatRequest:   adaptChatRequest,
 		ChatRequestHeaders: xGrokConversationHeaders,
+	}
+}
+
+// adaptChatRequest rewrites GoModel's common reasoning shape into xAI's
+// OpenAI-compatible chat extension. The xAI Chat Completions API accepts
+// reasoning_effort as a top-level string (e.g. grok-4.5: low/medium/high,
+// default high), not "reasoning": {"effort": "..."}; the nested shape is
+// native only to xAI's Responses API, which passes through untouched.
+func adaptChatRequest(req *core.ChatRequest) (*core.ChatRequest, error) {
+	if req == nil || req.Reasoning == nil || strings.TrimSpace(req.Reasoning.Effort) == "" {
+		return req, nil
+	}
+	return providers.AdaptReasoningEffortRequest(req, normalizeReasoningEffort(req.Model, req.Reasoning.Effort))
+}
+
+// normalizeReasoningEffort downgrades GoModel effort levels xAI does not
+// accept to their nearest equivalent. Only the multi-agent Grok family
+// accepts "xhigh" (it selects the agent count); every other model tops out
+// at "high". Unknown values pass through for the upstream to judge. See
+// docs/providers/xai.mdx for the user-facing table.
+func normalizeReasoningEffort(model, effort string) string {
+	normalized := strings.ToLower(strings.TrimSpace(effort))
+	switch normalized {
+	case "xhigh", "max":
+		if strings.Contains(strings.ToLower(model), "multi-agent") {
+			return "xhigh"
+		}
+		return "high"
+	default:
+		return normalized
 	}
 }
 

--- a/internal/providers/xai/xai_test.go
+++ b/internal/providers/xai/xai_test.go
@@ -915,3 +915,101 @@ func TestResponsesWithContext(t *testing.T) {
 		t.Error("expected error when context is cancelled, got nil")
 	}
 }
+
+func TestChatCompletion_MapsReasoningToXAIReasoningEffort(t *testing.T) {
+	var gotBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			http.Error(w, "decode error", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-xai",
+			"created":1677652288,
+			"model":"grok-4.5",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}]
+		}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("test-api-key", nil, llmclient.Hooks{})
+	provider.SetBaseURL(server.URL)
+
+	_, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{
+		Model:     "grok-4.5",
+		Messages:  []core.Message{{Role: "user", Content: "hi"}},
+		Reasoning: &core.Reasoning{Effort: "medium"},
+	})
+	if err != nil {
+		t.Fatalf("ChatCompletion() error = %v", err)
+	}
+	if gotBody["reasoning"] != nil {
+		t.Fatalf("request body should not include nested reasoning, got %#v", gotBody["reasoning"])
+	}
+	if gotBody["reasoning_effort"] != "medium" {
+		t.Fatalf("reasoning_effort = %#v, want medium", gotBody["reasoning_effort"])
+	}
+}
+
+func TestChatCompletion_OmitsReasoningEffortWhenReasoningAbsent(t *testing.T) {
+	var gotBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			http.Error(w, "decode error", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-xai",
+			"created":1677652288,
+			"model":"grok-4.5",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}]
+		}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("test-api-key", nil, llmclient.Hooks{})
+	provider.SetBaseURL(server.URL)
+
+	_, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{
+		Model:    "grok-4.5",
+		Messages: []core.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("ChatCompletion() error = %v", err)
+	}
+	if _, ok := gotBody["reasoning_effort"]; ok {
+		t.Fatalf("reasoning_effort should be absent, got %#v", gotBody["reasoning_effort"])
+	}
+	if _, ok := gotBody["reasoning"]; ok {
+		t.Fatalf("reasoning should be absent, got %#v", gotBody["reasoning"])
+	}
+}
+
+func TestNormalizeReasoningEffort(t *testing.T) {
+	tests := []struct {
+		model  string
+		effort string
+		want   string
+	}{
+		{"grok-4.5", "low", "low"},
+		{"grok-4.5", "medium", "medium"},
+		{"grok-4.5", "high", "high"},
+		{"grok-4.5", "none", "none"},
+		{"grok-4.5", " High ", "high"},
+		{"grok-4.5", "xhigh", "high"},
+		{"grok-4.5", "max", "high"},
+		{"grok-4.20-multi-agent-0309", "xhigh", "xhigh"},
+		{"grok-4.20-multi-agent-0309", "max", "xhigh"},
+		{"grok-4.20-multi-agent-0309", "low", "low"},
+		{"grok-4.5", "custom-level", "custom-level"},
+	}
+	for _, tt := range tests {
+		if got := normalizeReasoningEffort(tt.model, tt.effort); got != tt.want {
+			t.Errorf("normalizeReasoningEffort(%q, %q) = %q, want %q", tt.model, tt.effort, got, tt.want)
+		}
+	}
+}

--- a/tests/contract/testdata/golden/xai/models.golden.json
+++ b/tests/contract/testdata/golden/xai/models.golden.json
@@ -59,6 +59,12 @@
       "id": "grok-2-image-1212",
       "object": "model",
       "owned_by": "xai"
+    },
+    {
+      "created": 0,
+      "id": "grok-4.5",
+      "object": "model",
+      "owned_by": "xai"
     }
   ],
   "object": "list"

--- a/tests/contract/testdata/xai/models.json
+++ b/tests/contract/testdata/xai/models.json
@@ -59,6 +59,12 @@
       "created": 1736726400,
       "object": "model",
       "owned_by": "xai"
+    },
+    {
+      "id": "grok-4.5",
+      "created": 1783468800,
+      "object": "model",
+      "owned_by": "xai"
     }
   ],
   "object": "list"


### PR DESCRIPTION
## Summary

Adds first-class support for xAI's new `grok-4.5` model ([announcement](https://x.ai/news/grok-4-5)). The model itself is auto-discovered from xAI's `/models` endpoint; the one gap was reasoning control:

- **`AdaptChatRequest` hook for the xai provider** (same pattern as deepseek/gemini): rewrites GoModel's normalized `"reasoning": {"effort": "..."}` into the flat `reasoning_effort` string xAI documents for Chat Completions (grok-4.5: `low`/`medium`/`high`, default `high`). `xhigh`/`max` downgrade to `high`, except on the multi-agent Grok family where `xhigh` is native (it selects the agent count). The Responses API is untouched — the nested shape is xAI-native there.
- **Contract fixture**: `grok-4.5` added to the xai models replay fixture + regenerated golden.
- **Docs**: new `docs/providers/xai.mdx` (config, reasoning mapping table, prompt-cache affinity via `X-Grok-Conv-Id` / `prompt_cache_key`), registered in navigation; overview example bumped to `grok-4.5`.
- Includes one mechanical `go fix` modernization in `keyring_test.go` to keep the pre-commit fix-check guard green under the current toolchain.

## User-visible impact

Clients using the OpenAI-style nested `reasoning.effort` now get it applied on xAI chat completions in the documented shape — no client changes needed. Requests without `reasoning` are unaffected.

## Provider-specific behavior

Verified against the live xAI API: reasoning token counts scale with the mapped effort level (flat-low 774 vs flat-high 1526 on the same prompt); `xhigh` is accepted upstream on grok-4.5 but appears clamped, so the gateway downgrades it per the documented ladder.

## Testing

- Unit tests: nested→flat reshaping, omission when `reasoning` is absent, effort normalization table.
- Contract suite (`-tags=contract`) green; `go build ./...`, `go vet` clean.
- Live E2E against api.x.ai through the gateway: chat, vision, streamed multimodal + tool calls, tool round-trip, native + streamed `/v1/responses` (nested reasoning, `prompt_cache_key`, `json_object`), bare-name routing, per-model cost accounting, and prompt-cache affinity (derived conv-id stable across turns; upstream reported 2176/2289 cached tokens on a growing conversation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the xAI Grok 4.5 model.
  * Improved compatibility with xAI reasoning settings, including normalized effort levels.
  * Added support for xAI provider configuration, voice models, prompt caching, and API usage guidance.

* **Documentation**
  * Added a dedicated xAI (Grok) provider guide.
  * Updated the provider directory with Grok 4.5 details and a link to its setup guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->