### PR TITLE
fix(mcp): enforce header user-path identity and accept unique bare tool names

### DIFF
--- a/docs/dev/2026-07-15_release-qa-findings.md
+++ b/docs/dev/2026-07-15_release-qa-findings.md
@@ -1,0 +1,137 @@
+# Release QA findings — 2026-07-15 (post-v0.1.51, HEAD 5cc918e3)
+
+Scope: everything merged since v0.1.51 — MCP gateway (#502), MCP audit body
+logging (#534), provider request health (#521), module rename (#522), dep
+bumps — plus the full standard release matrix.
+
+## Results
+
+- **Standard matrix S01–S162: 162/162 pass, zero regressions.**
+  S151/S152 (Ollama) and S153/S154 (Fireworks) self-skipped: no local Ollama
+  server; Fireworks account still suspended.
+- **New scenarios S163–S172 (this QA round): 10/10 pass**, two of them pin
+  known defects (below) rather than the documented behavior.
+
+## New coverage added
+
+- `tests/e2e/mockmcp`: standalone mock MCP upstream built on the same
+  `modelcontextprotocol/go-sdk` the gateway uses. Serves `alpha`
+  (tools `echo`/`add`, prompt `greeting`, resource `mock://alpha/info`,
+  instructions marker; `X-Mock-Token`-gated when `MOCK_MCP_TOKEN` is set) and
+  `beta` (tools `search`/`fetch`). `manage-release-e2e-stack.sh` builds and
+  runs it on port 18090 and refuses to start when a foreign process holds the
+  port (a stale instance answering `/healthz` once masked a failed bind).
+- Scenarios S163–S172 in `release-e2e-scenarios.md` (matrix now 172): admin
+  MCP CRUD with secret redaction and the catalog inspector; aggregated
+  handshake with merged instructions and deterministic namespaced
+  `tools/list`; `tools/call` with usage-entry assertions; per-server endpoint
+  and `X-MCP-Servers` narrowing; audit JSON-RPC body capture + nosniff;
+  negatives (unknown server 404, unknown tool error, session binding, stdio
+  upsert rejected); `***` secret round-trip proved against the token-gated
+  upstream; provider `request_health`; `mcp_servers` store parity on
+  PostgreSQL and MongoDB; namespaced prompts + resources relay.
+
+## Findings
+
+### F1 — Spec gap: unique bare-name `tools/call` is not implemented
+
+> **FIXED (2026-07-15, same-day follow-up):** the aggregated session now
+> installs a receiving middleware that rewrites a unique bare `tools/call`
+> name to its namespaced registration (`bareToolAliases` +
+> `bareToolCallMiddleware` in `internal/mcpgateway/service.go`). Ambiguous
+> bare names and collisions with literal namespaced names stay errors; the
+> dead `ResolveNamespacedName` was removed. S165 now asserts the spec'd
+> behavior.
+
+The MCP spec (`docs/dev/2026-07-07_mcp-gateway-spec.md`, "longest prefix
+match, falling back to a unique bare name") and CLAUDE.md both promise that
+`tools/call` on `/mcp` accepts a unique bare tool name. The gateway only
+registers namespaced names on the aggregated session, so a unique bare name
+returns JSON-RPC `-32602 unknown tool`. `mcpgateway.ResolveNamespacedName`
+is exported and unit-tested but never called from production code — a
+vestige of the spec'd resolution design. Pinned in S165 (`KNOWN GAP`).
+
+Fix options: register bare aliases when unique, or resolve in a
+`tools/call` interceptor via `ResolveNamespacedName` + uniqueness check.
+
+### F2 — Bug (security-relevant): header-based user paths never reach the MCP layer
+
+> **FIXED (2026-07-15, same-day follow-up):** `RequestSnapshotCapture` now
+> normalizes the user-path header and stamps it into the request context for
+> model-interaction endpoints that are not `IngressManaged` (`/mcp`, realtime,
+> audio), so session binding, `user_paths` scoping, rate limits, budgets, and
+> usage attribution all see header identity. A managed key's bound path still
+> wins (auth middleware runs later and shadows the stamped value). S168 now
+> asserts stolen-session 404, rate-limit 429 on `/mcp` posts, and subtree
+> `user_paths` visibility for header principals.
+
+`/mcp` is deliberately not `IngressManaged`
+(`internal/core/endpoints.go:147`), so `RequestSnapshotCapture` returns
+before stamping `X-GoModel-User-Path` into the request snapshot. As a result
+`core.UserPathFromContext` is `""` for every MCP request whose identity
+comes from the header (unsafe mode, or master-key mode using the header to
+separate consumers). Managed-key callers are unaffected
+(`applyAuthKeyResult` sets the effective user path on the context).
+
+Verified consequences on the running stack (all header-identity):
+
+1. **Session-to-principal binding is a no-op**: a different principal (other
+   header path, or no header) presenting a leaked `Mcp-Session-Id` gets 200
+   and the owner's tool snapshot; docs promise 404. Managed-key intruders
+   are correctly rejected (404), and cross-pinned-endpoint reuse is
+   correctly rejected (404). Pinned in S168 (`KNOWN BUG`).
+2. **`user_paths` server scoping fails closed**: a server scoped to
+   `/team/secret` is invisible to the legitimate `/team/secret/dev` header
+   caller (and everyone else) — the feature is unusable without managed
+   keys.
+3. **User-path rate limits and budgets do not gate MCP posts**: a
+   1 req/min rule on a probe path 429s the second chat call but three `/mcp`
+   POSTs under the same header all pass (admission resolves the path to
+   `/`). `enforceBudget` uses the same source. Contradicts CLAUDE.md
+   ("Every MCP POST is gated by user-path rate limits and budgets").
+4. **Observability disagrees with enforcement**: MCP usage entries record
+   the header path (read raw from the header in `recordToolCall`) and audit
+   entries record it via middleware, so logs look correctly attributed while
+   enforcement never saw the identity.
+
+Why tests miss it: `internal/mcpgateway` unit tests wrap the service in a
+test middleware that stamps `WithEffectiveUserPath` from the header
+themselves. Suggested fix: stamp the normalized user-path header into the
+context (or snapshot) for `OperationMCP` requests, or have the MCP service
+fall back to the raw header the way `recordToolCall` already does.
+
+### F3 — Verified-good list (new features)
+
+- Admin MCP server CRUD; header secrets redacted as `***` in every admin
+  read; `***` on PUT preserves the stored secret (proved end-to-end against
+  the token-gated upstream: reconnect still succeeds, and a wrong token
+  degrades the server with the upstream error surfaced in `last_error`).
+- Aggregation: upstream `instructions` merged into `initialize`,
+  deterministic sorted namespaced `tools/list`, `X-MCP-Servers` narrowing,
+  per-server endpoints expose original names, prompts namespaced, resources
+  and `resources/read` relay verbatim.
+- #534: MCP POST audit entries carry `provider="mcp"`, the JSON-RPC method
+  or tool name as `requested_model`, the request frame in
+  `data.request_body`, and the SSE-decoded response frame in
+  `data.response_body`; `X-Content-Type-Options: nosniff` set on all MCP
+  responses.
+- Usage entries per `tools/call`: `provider="mcp"`, `provider_name`=server
+  slug, `model`=namespaced tool, `request_id`/`user_path` from headers.
+- `mcp_servers` store round-trips on PostgreSQL and MongoDB; tool calls work
+  through both gateways.
+- Runtime stdio registration rejected with 400 (RCE guard); unknown pinned
+  server 404; garbage session id → SDK 404 "session not found".
+- #521 `request_health`: 600s window, per-model counts, `circuit_state`,
+  `last_error_model`; the ≥3-errors-AND-≥50%-rate flag gate verified (4
+  errors over 41 requests correctly leaves the provider Healthy);
+  `status_reason` present on every provider.
+- #522: binary builds and runs as `github.com/enterpilot/gomodel`.
+
+## Notes / minor
+
+- Sessionless MCP POSTs (no `Mcp-Session-Id`) are served statelessly by the
+  SDK (a `tools/list` without initialize works). Part of the streamable
+  spec; worth a deliberate decision on whether admission/binding semantics
+  should differ there.
+- `ResolveNamespacedName` was dead production code — removed with the F1 fix
+  (the bare-name fallback uses a per-session alias map instead).

--- a/internal/mcpgateway/catalog.go
+++ b/internal/mcpgateway/catalog.go
@@ -52,23 +52,6 @@ func NamespacedName(server, name string) string {
 	return server + namespaceSeparator + name
 }
 
-// ResolveNamespacedName splits an aggregated name back into (server, name) by
-// longest-prefix match against the known server names, so server names that
-// themselves contain the separator stay unambiguous.
-func ResolveNamespacedName(full string, servers []string) (server, name string, ok bool) {
-	best := ""
-	for _, candidate := range servers {
-		prefix := candidate + namespaceSeparator
-		if strings.HasPrefix(full, prefix) && len(full) > len(prefix) && len(candidate) > len(best) {
-			best = candidate
-		}
-	}
-	if best == "" {
-		return "", "", false
-	}
-	return best, full[len(best)+len(namespaceSeparator):], true
-}
-
 // filterTools applies the operator-level allow/deny lists to original tool
 // names and returns tools in deterministic (sorted) order. Deterministic
 // ordering keeps downstream tools/list stable, which keeps provider prompt

--- a/internal/mcpgateway/catalog_test.go
+++ b/internal/mcpgateway/catalog_test.go
@@ -8,51 +8,59 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-func TestResolveNamespacedName(t *testing.T) {
+func TestNamespacedName(t *testing.T) {
 	t.Parallel()
-	servers := []string{"github", "git", "git_hub", "beta-tools"}
+	if full := NamespacedName("github", "create_issue"); full != "github_create_issue" {
+		t.Fatalf("NamespacedName() = %q, want github_create_issue", full)
+	}
+}
 
+func TestBareToolAliases(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
-		name       string
-		full       string
-		wantServer string
-		wantTool   string
-		wantOK     bool
+		name   string
+		owners map[string]string
+		want   map[string]string
 	}{
-		{name: "simple", full: "github_create_issue", wantServer: "github", wantTool: "create_issue", wantOK: true},
-		{name: "longest prefix wins over shorter server", full: "git_hub_sync", wantServer: "git_hub", wantTool: "sync", wantOK: true},
-		{name: "shorter server still resolves", full: "git_clone", wantServer: "git", wantTool: "clone", wantOK: true},
-		{name: "hyphenated server", full: "beta-tools_search", wantServer: "beta-tools", wantTool: "search", wantOK: true},
-		{name: "unknown server", full: "ghost_tool", wantOK: false},
-		{name: "no separator", full: "github", wantOK: false},
-		{name: "empty tool part", full: "github_", wantOK: false},
+		{
+			name:   "unique bare names alias",
+			owners: map[string]string{"alpha_echo": "alpha", "beta_search": "beta"},
+			want:   map[string]string{"echo": "alpha_echo", "search": "beta_search"},
+		},
+		{
+			name:   "ambiguous bare name gets no alias",
+			owners: map[string]string{"alpha_echo": "alpha", "beta_echo": "beta"},
+			want:   map[string]string{},
+		},
+		{
+			name: "bare name colliding with a namespaced name gets no alias",
+			// beta's tool is literally named "alpha_echo"; the namespaced
+			// registration must keep winning for that exact name.
+			owners: map[string]string{"alpha_echo": "alpha", "beta_alpha_echo": "beta"},
+			want:   map[string]string{"echo": "alpha_echo"},
+		},
+		{
+			name: "server names containing the separator stay unambiguous",
+			owners: map[string]string{
+				"git_hub_sync": "git_hub",
+				"git_clone":    "git",
+			},
+			want: map[string]string{"sync": "git_hub_sync", "clone": "git_clone"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			server, tool, ok := ResolveNamespacedName(tt.full, servers)
-			if ok != tt.wantOK {
-				t.Fatalf("ResolveNamespacedName(%q) ok = %v, want %v", tt.full, ok, tt.wantOK)
+			got := bareToolAliases(tt.owners)
+			if len(got) != len(tt.want) {
+				t.Fatalf("bareToolAliases() = %v, want %v", got, tt.want)
 			}
-			if !tt.wantOK {
-				return
-			}
-			if server != tt.wantServer || tool != tt.wantTool {
-				t.Fatalf("ResolveNamespacedName(%q) = (%q, %q), want (%q, %q)", tt.full, server, tool, tt.wantServer, tt.wantTool)
+			for bare, exposed := range tt.want {
+				if got[bare] != exposed {
+					t.Fatalf("bareToolAliases()[%q] = %q, want %q", bare, got[bare], exposed)
+				}
 			}
 		})
-	}
-}
-
-func TestNamespacedNameRoundTrip(t *testing.T) {
-	t.Parallel()
-	full := NamespacedName("github", "create_issue")
-	if full != "github_create_issue" {
-		t.Fatalf("NamespacedName() = %q, want github_create_issue", full)
-	}
-	server, tool, ok := ResolveNamespacedName(full, []string{"github"})
-	if !ok || server != "github" || tool != "create_issue" {
-		t.Fatalf("round trip = (%q, %q, %v)", server, tool, ok)
 	}
 }
 

--- a/internal/mcpgateway/service.go
+++ b/internal/mcpgateway/service.go
@@ -359,7 +359,55 @@ func (s *Service) getServer(r *http.Request) *mcp.Server {
 		s.registerPrompts(server, view.Spec.Name, snapshot, prefixNames, promptOwners)
 		s.registerResources(server, view.Spec.Name, snapshot, resourceOwners)
 	}
+	if prefixNames {
+		if aliases := bareToolAliases(toolOwners); len(aliases) > 0 {
+			server.AddReceivingMiddleware(bareToolCallMiddleware(aliases))
+		}
+	}
 	return server
+}
+
+// bareToolAliases maps each unambiguous bare tool name to its namespaced
+// name, so tools/call on the aggregated endpoint accepts a unique bare name
+// (Postel, per the gateway spec). A bare name claimed by several servers, or
+// one that collides with a registered namespaced name, gets no alias — the
+// caller must use the namespaced form.
+func bareToolAliases(owners map[string]string) map[string]string {
+	counts := make(map[string]int, len(owners))
+	aliases := make(map[string]string, len(owners))
+	for exposed, owner := range owners {
+		bare := strings.TrimPrefix(exposed, owner+namespaceSeparator)
+		counts[bare]++
+		aliases[bare] = exposed
+	}
+	for bare := range aliases {
+		if counts[bare] > 1 {
+			delete(aliases, bare)
+			continue
+		}
+		if _, taken := owners[bare]; taken {
+			delete(aliases, bare)
+		}
+	}
+	return aliases
+}
+
+// bareToolCallMiddleware rewrites a bare tools/call name to its namespaced
+// registration before dispatch. Exact namespaced names never reach the alias
+// map (they are excluded at build time), so registered names always win.
+func bareToolCallMiddleware(aliases map[string]string) mcp.Middleware {
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			if method == "tools/call" {
+				if call, ok := req.(*mcp.CallToolRequest); ok && call.Params != nil {
+					if exposed, ok := aliases[call.Params.Name]; ok {
+						call.Params.Name = exposed
+					}
+				}
+			}
+			return next(ctx, method, req)
+		}
+	}
 }
 
 func (s *Service) upstreamCatalog(name string) (*catalog, ServerStatus) {

--- a/internal/mcpgateway/service_test.go
+++ b/internal/mcpgateway/service_test.go
@@ -277,6 +277,68 @@ func TestAggregatedEndpointNamespacesAndRelays(t *testing.T) {
 	}
 }
 
+func TestAggregatedEndpointAcceptsUniqueBareToolName(t *testing.T) {
+	alphaURL := newTestUpstream(t, "alpha", addEchoTool("echo"))
+	betaURL := newTestUpstream(t, "beta", addEchoTool("search"))
+	usageLog := &recordingUsageLogger{}
+	_, gatewayURL := newTestService(t, usageLog,
+		testSpec("alpha", alphaURL, nil),
+		testSpec("beta", betaURL, nil),
+	)
+
+	session := connectClient(t, gatewayURL+"/mcp", nil)
+
+	// tools/list stays namespaced; only tools/call accepts the bare name.
+	names := listToolNames(t, session)
+	if len(names) != 2 || names[0] != "alpha_echo" || names[1] != "beta_search" {
+		t.Fatalf("ListTools() = %v, want [alpha_echo beta_search]", names)
+	}
+
+	result, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "echo",
+		Arguments: map[string]any{"value": 1},
+	})
+	if err != nil {
+		t.Fatalf("CallTool(echo) error = %v", err)
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok || !strings.HasPrefix(text.Text, "echo:") {
+		t.Fatalf("CallTool(echo) content = %#v, want echo:... text", result.Content[0])
+	}
+
+	// Usage accounting stays canonical: the entry records the namespaced name.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && len(usageLog.all()) == 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	entries := usageLog.all()
+	if len(entries) != 1 || entries[0].Model != "alpha_echo" || entries[0].ProviderName != "alpha" {
+		t.Fatalf("usage entries = %+v, want one alpha/alpha_echo entry", entries)
+	}
+}
+
+func TestAggregatedEndpointRejectsAmbiguousBareToolName(t *testing.T) {
+	alphaURL := newTestUpstream(t, "alpha", addEchoTool("echo"))
+	betaURL := newTestUpstream(t, "beta", addEchoTool("echo"))
+	_, gatewayURL := newTestService(t, nil,
+		testSpec("alpha", alphaURL, nil),
+		testSpec("beta", betaURL, nil),
+	)
+
+	session := connectClient(t, gatewayURL+"/mcp", nil)
+
+	if _, err := session.CallTool(context.Background(), &mcp.CallToolParams{Name: "echo"}); err == nil {
+		t.Fatalf("CallTool(echo) succeeded, want unknown-tool error for an ambiguous bare name")
+	}
+
+	// The namespaced forms keep working.
+	for _, name := range []string{"alpha_echo", "beta_echo"} {
+		if _, err := session.CallTool(context.Background(), &mcp.CallToolParams{Name: name}); err != nil {
+			t.Fatalf("CallTool(%s) error = %v", name, err)
+		}
+	}
+}
+
 func TestPerServerEndpointKeepsOriginalNames(t *testing.T) {
 	alphaURL := newTestUpstream(t, "alpha", addEchoTool("echo"))
 	betaURL := newTestUpstream(t, "beta", addEchoTool("search"))

--- a/internal/server/request_snapshot.go
+++ b/internal/server/request_snapshot.go
@@ -27,6 +27,23 @@ func RequestSnapshotCapture(userPathHeader ...string) echo.MiddlewareFunc {
 			c.Response().Header().Set("X-Request-ID", requestID)
 			desc := core.DescribeEndpoint(req.Method, req.URL.Path)
 			if !desc.IngressManaged {
+				// Model endpoints that own their transport (MCP, realtime,
+				// audio) take no snapshot, but their identity must still reach
+				// the context: rate limits, budgets, session binding, and
+				// usage attribution all read core.UserPathFromContext. A
+				// managed key's bound path still wins — auth middleware runs
+				// later and its context value shadows this one.
+				if desc.ModelInteraction {
+					userPath, err := core.NormalizeUserPath(req.Header.Get(userPathHeaderName))
+					if err != nil {
+						return handleError(c, core.NewInvalidRequestError("invalid "+userPathHeaderName+" header", err))
+					}
+					if userPath != "" {
+						req.Header.Set(userPathHeaderName, userPath)
+						ctx := core.WithUserPathHeaderName(req.Context(), userPathHeaderName)
+						req = req.WithContext(core.WithEffectiveUserPath(ctx, userPath))
+					}
+				}
 				c.SetRequest(req)
 				return next(c)
 			}

--- a/internal/server/request_snapshot_test.go
+++ b/internal/server/request_snapshot_test.go
@@ -195,6 +195,65 @@ func TestRequestSnapshotCapture_NormalizesUserPathHeader(t *testing.T) {
 	assert.Equal(t, "/team/alpha/user", c.Request().Header.Get(core.UserPathHeader))
 }
 
+func TestRequestSnapshotCapture_StampsUserPathForNonIngressManagedModelEndpoints(t *testing.T) {
+	// MCP, realtime, and audio endpoints take no snapshot, but their header
+	// identity must still reach the context: session binding, rate limits,
+	// budgets, and usage attribution read core.UserPathFromContext.
+	for _, path := range []string{"/mcp", "/mcp/alpha", "/v1/realtime/calls", "/v1/audio/speech"} {
+		t.Run(path, func(t *testing.T) {
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(`{}`))
+			req.Header.Set(core.UserPathHeader, " team//alpha/ ")
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			var capturedUserPath string
+			handler := RequestSnapshotCapture()(func(c *echo.Context) error {
+				capturedUserPath = core.UserPathFromContext(c.Request().Context())
+				assert.Nil(t, core.GetRequestSnapshot(c.Request().Context()))
+				return c.String(http.StatusOK, "ok")
+			})
+
+			require.NoError(t, handler(c))
+			assert.Equal(t, "/team/alpha", capturedUserPath)
+			assert.Equal(t, "/team/alpha", c.Request().Header.Get(core.UserPathHeader))
+		})
+	}
+}
+
+func TestRequestSnapshotCapture_RejectsInvalidUserPathOnNonIngressManagedModelEndpoints(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{}`))
+	req.Header.Set(core.UserPathHeader, "/team/../escape")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	handler := RequestSnapshotCapture()(func(c *echo.Context) error {
+		t.Fatal("handler must not run for an invalid user-path header")
+		return nil
+	})
+
+	require.NoError(t, handler(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestRequestSnapshotCapture_SkipsUserPathStampingForNonModelEndpoints(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/admin/providers", nil)
+	req.Header.Set(core.UserPathHeader, "/team/alpha")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	var capturedUserPath string
+	handler := RequestSnapshotCapture()(func(c *echo.Context) error {
+		capturedUserPath = core.UserPathFromContext(c.Request().Context())
+		return c.String(http.StatusOK, "ok")
+	})
+
+	require.NoError(t, handler(c))
+	assert.Equal(t, "", capturedUserPath)
+}
+
 func TestRequestSnapshotCapture_UsesConfiguredUserPathHeader(t *testing.T) {
 	e := echo.New()
 	const headerName = "X-Tenant-Path"

--- a/tests/e2e/manage-release-e2e-stack.sh
+++ b/tests/e2e/manage-release-e2e-stack.sh
@@ -8,6 +8,9 @@ BIN="${GOMODEL_RELEASE_BINARY:-$REPO_ROOT/bin/gomodel}"
 ENV_FILE="${GOMODEL_RELEASE_ENV_FILE:-$REPO_ROOT/.env}"
 PG_DATABASE="${GOMODEL_RELEASE_PG_DATABASE:-gomodel_release_e2e}"
 MONGO_DATABASE="${GOMODEL_RELEASE_MONGO_DATABASE:-gomodel_release_e2e}"
+MOCK_MCP_BIN="${GOMODEL_RELEASE_MOCK_MCP_BINARY:-$REPO_ROOT/bin/mockmcp}"
+MOCK_MCP_PORT="${GOMODEL_RELEASE_MOCK_MCP_PORT:-18090}"
+MOCK_MCP_TOKEN="${GOMODEL_RELEASE_MOCK_MCP_TOKEN:-qa-mock-mcp-secret}"
 
 BUILD_BEFORE_START=0
 
@@ -31,6 +34,9 @@ Gateways:
   mongo-smoke           http://localhost:18082
   guardrails            http://localhost:18083
   auth-cache            http://localhost:18084
+
+Helpers:
+  mock-mcp              http://localhost:18090 (mock MCP upstream: /alpha token-gated, /beta open)
 EOF
 }
 
@@ -96,6 +102,81 @@ ensure_binary() {
   if (( BUILD_BEFORE_START == 1 )) || [[ ! -x "$BIN" ]]; then
     (cd "$REPO_ROOT" && make build)
   fi
+  if (( BUILD_BEFORE_START == 1 )) || [[ ! -x "$MOCK_MCP_BIN" ]]; then
+    (cd "$REPO_ROOT" && go build -o "$MOCK_MCP_BIN" ./tests/e2e/mockmcp)
+  fi
+}
+
+start_mock_mcp() {
+  local dir="$STACK_DIR/mock-mcp"
+  local log_file="$dir/logs/server.log"
+  local pid_file="$dir/server.pid"
+
+  mkdir -p "$dir/logs"
+
+  if is_pid_running "$pid_file"; then
+    printf 'mock-mcp already running pid=%s url=http://localhost:%s\n' "$(cat "$pid_file")" "$MOCK_MCP_PORT"
+    return 0
+  fi
+
+  # A foreign process on the port would answer the health probe and mask a
+  # failed bind (e.g. a manually started mockmcp with a different token).
+  if curl -fsS "http://localhost:$MOCK_MCP_PORT/healthz" >/dev/null 2>&1; then
+    die "port $MOCK_MCP_PORT is already in use by an unmanaged process; stop it before starting mock-mcp"
+  fi
+
+  rm -f "$pid_file"
+
+  (
+    cd "$dir"
+    nohup env PORT="$MOCK_MCP_PORT" MOCK_MCP_TOKEN="$MOCK_MCP_TOKEN" "$MOCK_MCP_BIN" >"$log_file" 2>&1 < /dev/null &
+    echo $! >"$pid_file"
+  )
+
+  local attempt
+  for attempt in $(seq 1 15); do
+    if curl -fsS "http://localhost:$MOCK_MCP_PORT/healthz" >/dev/null 2>&1; then
+      printf 'started mock-mcp pid=%s url=http://localhost:%s\n' "$(cat "$pid_file")" "$MOCK_MCP_PORT"
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "failed to start mock-mcp on port $MOCK_MCP_PORT" >&2
+  [[ -f "$log_file" ]] && tail -n 40 "$log_file" >&2
+  exit 1
+}
+
+stop_mock_mcp() {
+  local pid_file="$STACK_DIR/mock-mcp/server.pid"
+  local pid
+
+  if [[ ! -f "$pid_file" ]]; then
+    printf 'mock-mcp not running\n'
+    return 0
+  fi
+
+  pid="$(cat "$pid_file" 2>/dev/null || true)"
+  if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+  fi
+  rm -f "$pid_file"
+  printf 'stopped mock-mcp\n'
+}
+
+status_mock_mcp() {
+  local pid_file="$STACK_DIR/mock-mcp/server.pid"
+  local health="down"
+  local pid="stopped"
+
+  if is_pid_running "$pid_file"; then
+    pid="$(cat "$pid_file")"
+    if curl -fsS "http://localhost:$MOCK_MCP_PORT/healthz" >/dev/null 2>&1; then
+      health="ok"
+    fi
+  fi
+
+  printf '%-12s pid=%-8s url=http://localhost:%s health=%s\n' "mock-mcp" "$pid" "$MOCK_MCP_PORT" "$health"
 }
 
 ensure_pg_database() {
@@ -246,6 +327,7 @@ start_stack() {
   mkdir -p "$STACK_DIR"
   ensure_pg_database
   write_guardrail_config
+  start_mock_mcp
 
   start_gateway sqlite-main \
     -u GOMODEL_MASTER_KEY \
@@ -337,9 +419,11 @@ stop_stack() {
   stop_gateway mongo-smoke
   stop_gateway pg-smoke
   stop_gateway sqlite-main
+  stop_mock_mcp
 }
 
 status_stack() {
+  status_mock_mcp
   status_gateway sqlite-main
   status_gateway pg-smoke
   status_gateway mongo-smoke

--- a/tests/e2e/mockmcp/main.go
+++ b/tests/e2e/mockmcp/main.go
@@ -1,0 +1,105 @@
+// Command mockmcp serves two deterministic MCP upstream servers ("alpha" and
+// "beta") over streamable HTTP for the release E2E curl matrix. It is built
+// with the same MCP SDK the gateway uses, so the wire format matches real
+// upstreams.
+//
+//	alpha (/alpha): tools echo, add; prompt greeting; resource mock://alpha/info;
+//	                instructions "MOCKMCP_ALPHA_INSTRUCTIONS". When
+//	                MOCK_MCP_TOKEN is set, /alpha requires the X-Mock-Token
+//	                header to match, so header forwarding and the admin "***"
+//	                secret round-trip can be exercised end to end.
+//	beta  (/beta):  tools search, fetch.
+//
+// PORT selects the listen port (default 18090). GET /healthz reports liveness.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	sdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func echoTool(name string) (*sdk.Tool, sdk.ToolHandler) {
+	tool := &sdk.Tool{
+		Name:        name,
+		Description: "mockmcp " + name,
+		InputSchema: map[string]any{"type": "object"},
+	}
+	handler := func(_ context.Context, req *sdk.CallToolRequest) (*sdk.CallToolResult, error) {
+		return &sdk.CallToolResult{
+			Content: []sdk.Content{&sdk.TextContent{Text: name + ":" + string(req.Params.Arguments)}},
+		}, nil
+	}
+	return tool, handler
+}
+
+func newAlpha() *sdk.Server {
+	server := sdk.NewServer(
+		&sdk.Implementation{Name: "alpha", Version: "e2e"},
+		&sdk.ServerOptions{Instructions: "MOCKMCP_ALPHA_INSTRUCTIONS"},
+	)
+	server.AddTool(echoTool("echo"))
+	server.AddTool(echoTool("add"))
+	server.AddPrompt(&sdk.Prompt{Name: "greeting", Description: "mockmcp greeting prompt"},
+		func(_ context.Context, _ *sdk.GetPromptRequest) (*sdk.GetPromptResult, error) {
+			return &sdk.GetPromptResult{
+				Description: "mockmcp greeting prompt",
+				Messages: []*sdk.PromptMessage{
+					{Role: "user", Content: &sdk.TextContent{Text: "MOCKMCP_GREETING_OK"}},
+				},
+			}, nil
+		})
+	server.AddResource(&sdk.Resource{URI: "mock://alpha/info", Name: "info", MIMEType: "text/plain"},
+		func(_ context.Context, _ *sdk.ReadResourceRequest) (*sdk.ReadResourceResult, error) {
+			return &sdk.ReadResourceResult{
+				Contents: []*sdk.ResourceContents{
+					{URI: "mock://alpha/info", MIMEType: "text/plain", Text: "MOCKMCP_ALPHA_RESOURCE_OK"},
+				},
+			}, nil
+		})
+	return server
+}
+
+func newBeta() *sdk.Server {
+	server := sdk.NewServer(&sdk.Implementation{Name: "beta", Version: "e2e"}, nil)
+	server.AddTool(echoTool("search"))
+	server.AddTool(echoTool("fetch"))
+	return server
+}
+
+func requireToken(token string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if token != "" && r.Header.Get("X-Mock-Token") != token {
+			http.Error(w, "missing or wrong X-Mock-Token", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "18090"
+	}
+	token := os.Getenv("MOCK_MCP_TOKEN")
+
+	alpha := newAlpha()
+	beta := newBeta()
+
+	mux := http.NewServeMux()
+	mux.Handle("/alpha", requireToken(token,
+		sdk.NewStreamableHTTPHandler(func(*http.Request) *sdk.Server { return alpha }, nil)))
+	mux.Handle("/beta",
+		sdk.NewStreamableHTTPHandler(func(*http.Request) *sdk.Server { return beta }, nil))
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintln(w, "ok")
+	})
+
+	log.Printf("mockmcp listening on :%s (alpha token required: %v)", port, token != "")
+	log.Fatal(http.ListenAndServe(":"+port, mux))
+}

--- a/tests/e2e/release-e2e-scenarios.md
+++ b/tests/e2e/release-e2e-scenarios.md
@@ -1,6 +1,6 @@
 # Release E2E Curl Matrix
 
-This file contains 162 end-to-end curl scenarios for release validation.
+This file contains 172 end-to-end curl scenarios for release validation.
 These scenarios are prepared for execution across these local gateways:
 
 - `http://localhost:18080` - SQLite-backed main test gateway
@@ -8,6 +8,9 @@ These scenarios are prepared for execution across these local gateways:
 - `http://localhost:18082` - MongoDB-backed smoke gateway
 - `http://localhost:18083` - SQLite-backed guardrail gateway
 - `http://localhost:18084` - SQLite-backed auth + exact-cache gateway
+- `http://localhost:18090` - mock MCP upstream (`tests/e2e/mockmcp`, started by
+  the stack manager; `/alpha` requires the `X-Mock-Token` header, `/beta` is
+  open)
 
 ## Recommended runner
 
@@ -75,6 +78,13 @@ Stateful note:
   `$QA_SUFFIX`-scoped probe rules and deletes them, so they are
   self-contained, but `S158` saturates `deepseek/deepseek-v4-flash` for up to
   one minute after it runs
+- `S163`-`S172` exercise the MCP gateway (admin CRUD with secret redaction,
+  aggregation/namespacing, tools/prompts/resources relay, usage and audit
+  logging with JSON-RPC bodies, identity-bound sessions, store parity on
+  PostgreSQL/MongoDB) plus provider `request_health` on
+  `/admin/providers/status`; each scenario registers `$QA_SUFFIX`-scoped
+  servers against the local mock MCP upstream on port 18090 and deletes them,
+  so they are self-contained and rerunnable in any order
 - `S160`-`S162` exercise `/v1/conversations` CRUD, responses/conversations
   persistence on the PostgreSQL and MongoDB backends, and the rewrite-savings
   usage summary fields; they clean up after themselves and are rerunnable in
@@ -248,6 +258,101 @@ assert_embeddings_response() {
     and (.usage.total_tokens | type == "number")
     and (.usage.total_tokens >= $min_total_tokens)
   ' "$file" >/dev/null
+}
+
+export MCP_UPSTREAM_BASE="${MCP_UPSTREAM_BASE:-http://localhost:18090}"
+export MCP_UPSTREAM_TOKEN="${MCP_UPSTREAM_TOKEN:-qa-mock-mcp-secret}"
+# Slug-safe names (lowercase alnum + dashes), so name == derived slug and the
+# DELETE path and {server}_{tool} namespacing can use them directly.
+export QA_MCP_ALPHA="qa-alpha-$QA_SUFFIX"
+export QA_MCP_BETA="qa-beta-$QA_SUFFIX"
+
+# Posts one JSON-RPC frame to an MCP endpoint and prints the decoded reply
+# frames (SSE data lines stripped; plain JSON passed through).
+# usage: mcp_post URL SESSION_ID JSON [extra curl args...]
+mcp_post() {
+  local url="$1" session="$2" body="$3"
+  shift 3
+  local args=(-sS "$url"
+    -H 'Content-Type: application/json'
+    -H 'Accept: application/json, text/event-stream'
+    -H 'MCP-Protocol-Version: 2025-06-18'
+    -d "$body")
+  if [ -n "$session" ]; then
+    args+=(-H "Mcp-Session-Id: $session")
+  fi
+  curl "${args[@]}" "$@" | sed -n -e 's/^data: //p' -e t -e '/^{/p'
+}
+
+# Runs the MCP initialize handshake and prints the assigned session id.
+# usage: mcp_initialize URL HEADERS_FILE BODY_FILE [extra curl args...]
+mcp_initialize() {
+  local url="$1" headers_file="$2" body_file="$3"
+  shift 3
+  curl -sS -D "$headers_file" -o "$body_file" "$url" \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: application/json, text/event-stream' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"qa-release","version":"1"}}}' \
+    "$@"
+  grep -i '^mcp-session-id:' "$headers_file" | awk '{print $2}' | tr -d '\r'
+}
+
+# Sends notifications/initialized to finish the handshake.
+# usage: mcp_initialized URL SESSION_ID [extra curl args...]
+mcp_initialized() {
+  local url="$1" session="$2"
+  shift 2
+  curl -sS -o /dev/null "$url" \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: application/json, text/event-stream' \
+    -H "Mcp-Session-Id: $session" \
+    -H 'MCP-Protocol-Version: 2025-06-18' \
+    -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+    "$@"
+}
+
+# Waits until one admin-registered MCP server reaches the wanted status.
+# usage: mcp_wait_status BASE_URL SERVER_NAME WANTED_STATUS
+mcp_wait_status() {
+  local base="$1" name="$2" wanted="$3"
+  for _ in $(seq 1 20); do
+    if curl -fsS "$base/admin/mcp-servers" \
+      | jq -e --arg n "$name" --arg s "$wanted" 'any(.[]?; .name == $n and .status == $s)' >/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "error: MCP server $name did not reach status $wanted on $base" >&2
+  curl -fsS "$base/admin/mcp-servers" | jq . >&2 || true
+  exit 1
+}
+
+# Registers the token-gated alpha and open beta mock upstreams on one gateway
+# and waits for both to connect.
+# usage: mcp_register_release_servers BASE_URL
+mcp_register_release_servers() {
+  local base="$1"
+  curl -fsS -X PUT "$base/admin/mcp-servers" \
+    -H 'Content-Type: application/json' \
+    -d "{\"name\":\"$QA_MCP_ALPHA\",\"url\":\"$MCP_UPSTREAM_BASE/alpha\",\"transport\":\"http\",\"headers\":{\"X-Mock-Token\":\"$MCP_UPSTREAM_TOKEN\"},\"description\":\"qa release alpha\"}" \
+    > "$QA_RUN_DIR/mcp-alpha.json"
+  curl -fsS -X PUT "$base/admin/mcp-servers" \
+    -H 'Content-Type: application/json' \
+    -d "{\"name\":\"$QA_MCP_BETA\",\"url\":\"$MCP_UPSTREAM_BASE/beta\",\"transport\":\"http\",\"description\":\"qa release beta\"}" \
+    > "$QA_RUN_DIR/mcp-beta.json"
+  export QA_MCP_ALPHA_SLUG QA_MCP_BETA_SLUG
+  QA_MCP_ALPHA_SLUG=$(jq -er '.slug' "$QA_RUN_DIR/mcp-alpha.json")
+  QA_MCP_BETA_SLUG=$(jq -er '.slug' "$QA_RUN_DIR/mcp-beta.json")
+  mcp_wait_status "$base" "$QA_MCP_ALPHA" connected
+  mcp_wait_status "$base" "$QA_MCP_BETA" connected
+}
+
+# Deletes the QA MCP servers; safe to call when they do not exist.
+# usage: mcp_cleanup_release_servers BASE_URL
+mcp_cleanup_release_servers() {
+  local base="$1"
+  curl -sS -o /dev/null -X DELETE "$base/admin/mcp-servers/$QA_MCP_ALPHA" || true
+  curl -sS -o /dev/null -X DELETE "$base/admin/mcp-servers/$QA_MCP_BETA" || true
 }
 
 run_release_budget_enforcement() {
@@ -3587,4 +3692,547 @@ for URL in "$BASE_URL" "$PG_BASE_URL" "$MONGO_BASE_URL"; do
         and has("rewrite_cost_saved")
       ' >/dev/null
 done
+```
+
+## 23. MCP gateway and provider request health
+
+These scenarios cover the post-v0.1.51 features: the aggregating MCP gateway
+(PR #502), JSON-RPC body capture on MCP audit entries (PR #534), and
+real-traffic `request_health` on provider status (PR #521). They need the mock
+MCP upstream on port 18090 (started by `manage-release-e2e-stack.sh`).
+
+### S163 Admin MCP server CRUD with secret redaction and catalog inspector
+
+Registers the token-gated alpha and open beta upstreams, checks the admin
+view (headers redacted as `***`, connection state, tool counts), reads the
+per-server catalog, and deletes both.
+
+```bash
+if ! curl -fsS "$MCP_UPSTREAM_BASE/healthz" >/dev/null 2>&1; then
+  echo "SKIPPED: mock MCP upstream is not running on $MCP_UPSTREAM_BASE"
+  exit 0
+fi
+
+mcp_register_release_servers "$BASE_URL"
+
+LIST_FILE="$QA_RUN_DIR/s163.list.json"
+curl -fsS "$BASE_URL/admin/mcp-servers" > "$LIST_FILE"
+jq -e --arg a "$QA_MCP_ALPHA" --arg b "$QA_MCP_BETA" '
+  any(.[]; .name == $a and .managed == false and .transport == "http" and .status == "connected"
+      and .tool_count == 2 and .prompt_count == 1 and .resource_count == 1
+      and .headers["X-Mock-Token"] == "***")
+  and any(.[]; .name == $b and .managed == false and .status == "connected" and .tool_count == 2)
+' "$LIST_FILE" >/dev/null
+
+CATALOG_FILE="$QA_RUN_DIR/s163.catalog.json"
+curl -fsS "$BASE_URL/admin/mcp-servers/$QA_MCP_ALPHA_SLUG/catalog" > "$CATALOG_FILE"
+jq '.' "$CATALOG_FILE" | head -40
+jq -e '
+  ([.tools[]?.name] | sort == ["add","echo"])
+  and any(.prompts[]?; .name == "greeting")
+  and any(.resources[]?; .uri == "mock://alpha/info")
+' "$CATALOG_FILE" >/dev/null
+
+mcp_cleanup_release_servers "$BASE_URL"
+curl -fsS "$BASE_URL/admin/mcp-servers" \
+  | jq -e --arg a "$QA_MCP_ALPHA" --arg b "$QA_MCP_BETA" 'all(.[]?; .name != $a and .name != $b)' >/dev/null
+```
+
+### S164 Aggregated /mcp initialize with merged instructions and namespaced tools
+
+Runs the streamable-HTTP handshake against `/mcp` with plain curl and checks
+that upstream instructions are merged into the gateway `initialize` result and
+that `tools/list` exposes deterministic `{server}_{tool}` names.
+
+```bash
+if ! curl -fsS "$MCP_UPSTREAM_BASE/healthz" >/dev/null 2>&1; then
+  echo "SKIPPED: mock MCP upstream is not running on $MCP_UPSTREAM_BASE"
+  exit 0
+fi
+
+mcp_register_release_servers "$BASE_URL"
+trap 'mcp_cleanup_release_servers "$BASE_URL"' EXIT
+
+HEADERS_FILE="$QA_RUN_DIR/s164.init.headers"
+INIT_FILE="$QA_RUN_DIR/s164.init.raw"
+SID=$(mcp_initialize "$BASE_URL/mcp" "$HEADERS_FILE" "$INIT_FILE")
+[ -n "$SID" ]
+sed -n -e 's/^data: //p' -e t -e '/^{/p' "$INIT_FILE" | jq -e '
+  .result.protocolVersion != null
+  and (.result.serverInfo.name | type == "string")
+  and (.result.instructions | contains("MOCKMCP_ALPHA_INSTRUCTIONS"))
+' >/dev/null
+mcp_initialized "$BASE_URL/mcp" "$SID"
+
+TOOLS_FILE="$QA_RUN_DIR/s164.tools.json"
+mcp_post "$BASE_URL/mcp" "$SID" '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' > "$TOOLS_FILE"
+jq -c '.result.tools | map(.name)' "$TOOLS_FILE"
+jq -e --arg a "$QA_MCP_ALPHA_SLUG" --arg b "$QA_MCP_BETA_SLUG" '
+  (.result.tools | map(.name)) as $names
+  | ($names | index($a + "_add") != null)
+    and ($names | index($a + "_echo") != null)
+    and ($names | index($b + "_fetch") != null)
+    and ($names | index($b + "_search") != null)
+    and ($names == ($names | sort))
+' "$TOOLS_FILE" >/dev/null
+```
+
+### S165 tools/call by namespaced and bare name plus MCP usage entries
+
+Calls one tool through the aggregated endpoint using its namespaced name and
+another using its unique bare name, then checks the usage entry written for
+the call (`provider="mcp"`, `provider_name`=server, `model`=namespaced tool).
+
+```bash
+if ! curl -fsS "$MCP_UPSTREAM_BASE/healthz" >/dev/null 2>&1; then
+  echo "SKIPPED: mock MCP upstream is not running on $MCP_UPSTREAM_BASE"
+  exit 0
+fi
+
+mcp_register_release_servers "$BASE_URL"
+trap 'mcp_cleanup_release_servers "$BASE_URL"' EXIT
+
+# Session binding pins the session to its initializing principal, so the
+# user-path header must be identical on every request of the session.
+MCP_QA_PATH="/team/mcp/e2e/$QA_SUFFIX"
+HEADERS_FILE="$QA_RUN_DIR/s165.init.headers"
+INIT_FILE="$QA_RUN_DIR/s165.init.raw"
+SID=$(mcp_initialize "$BASE_URL/mcp" "$HEADERS_FILE" "$INIT_FILE" -H "X-GoModel-User-Path: $MCP_QA_PATH")
+mcp_initialized "$BASE_URL/mcp" "$SID" -H "X-GoModel-User-Path: $MCP_QA_PATH"
+
+REQ_ID="qa-mcp-call-$QA_SUFFIX"
+CALL_FILE="$QA_RUN_DIR/s165.call.json"
+mcp_post "$BASE_URL/mcp" "$SID" \
+  "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"${QA_MCP_ALPHA_SLUG}_echo\",\"arguments\":{\"marker\":\"QA_MCP_NAMESPACED_OK\"}}}" \
+  -H "X-Request-ID: $REQ_ID" \
+  -H "X-GoModel-User-Path: $MCP_QA_PATH" \
+  > "$CALL_FILE"
+jq '.' "$CALL_FILE"
+jq -e '
+  (.result.isError // false) == false
+  and any(.result.content[]?; .type == "text" and (.text | contains("echo:") and contains("QA_MCP_NAMESPACED_OK")))
+' "$CALL_FILE" >/dev/null
+
+# A unique bare tool name resolves to its single namespaced registration
+# (spec'd Postel fallback; was a KNOWN GAP until 2026-07-15). "search" exists
+# only on the beta server.
+BARE_FILE="$QA_RUN_DIR/s165.bare.json"
+mcp_post "$BASE_URL/mcp" "$SID" \
+  '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"search","arguments":{"q":"qa-bare"}}}' \
+  -H "X-GoModel-User-Path: $MCP_QA_PATH" \
+  > "$BARE_FILE"
+jq -e '
+  (.result.isError // false) == false
+  and any(.result.content[]?; .type == "text" and (.text | contains("search:") and contains("qa-bare")))
+' "$BARE_FILE" >/dev/null
+
+# A name that matches nothing (namespaced or bare) still errors. Ambiguous
+# bare names (same tool on two servers) are covered by unit tests; the two
+# mock servers expose disjoint tool sets.
+mcp_post "$BASE_URL/mcp" "$SID" \
+  '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"qa-no-such-bare-tool","arguments":{}}}' \
+  -H "X-GoModel-User-Path: $MCP_QA_PATH" \
+  | jq -e '(.error != null) or (.result.isError == true)' >/dev/null
+
+USAGE_FILE="$QA_RUN_DIR/s165.usage.json"
+FOUND=0
+for _ in $(seq 1 15); do
+  curl -fsS "$BASE_URL/admin/usage/log?search=$REQ_ID&limit=5" > "$USAGE_FILE"
+  if jq -e --arg rid "$REQ_ID" --arg model "${QA_MCP_ALPHA_SLUG}_echo" --arg server "$QA_MCP_ALPHA_SLUG" --arg up "$MCP_QA_PATH" '
+    any(.entries[]?; .request_id == $rid and .provider == "mcp" and .provider_name == $server and .model == $model and .user_path == $up)
+  ' "$USAGE_FILE" >/dev/null; then
+    FOUND=1
+    break
+  fi
+  sleep 1
+done
+if [ "$FOUND" -ne 1 ]; then
+  jq '.' "$USAGE_FILE" >&2 || true
+  echo "error: MCP tools/call usage entry was not flushed for $REQ_ID" >&2
+  exit 1
+fi
+```
+
+### S166 Per-server endpoint original names and X-MCP-Servers narrowing
+
+The per-server endpoint `/mcp/{server}` exposes original tool names, and the
+`X-MCP-Servers` request header narrows an aggregated session to a subset.
+
+```bash
+if ! curl -fsS "$MCP_UPSTREAM_BASE/healthz" >/dev/null 2>&1; then
+  echo "SKIPPED: mock MCP upstream is not running on $MCP_UPSTREAM_BASE"
+  exit 0
+fi
+
+mcp_register_release_servers "$BASE_URL"
+trap 'mcp_cleanup_release_servers "$BASE_URL"' EXIT
+
+HEADERS_FILE="$QA_RUN_DIR/s166.init.headers"
+INIT_FILE="$QA_RUN_DIR/s166.init.raw"
+SID=$(mcp_initialize "$BASE_URL/mcp/$QA_MCP_BETA_SLUG" "$HEADERS_FILE" "$INIT_FILE")
+mcp_initialized "$BASE_URL/mcp/$QA_MCP_BETA_SLUG" "$SID"
+mcp_post "$BASE_URL/mcp/$QA_MCP_BETA_SLUG" "$SID" '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
+  | jq -e '(.result.tools | map(.name) | sort) == ["fetch","search"]' >/dev/null
+
+NARROW_HEADERS="$QA_RUN_DIR/s166.narrow.headers"
+NARROW_INIT="$QA_RUN_DIR/s166.narrow.raw"
+NSID=$(mcp_initialize "$BASE_URL/mcp" "$NARROW_HEADERS" "$NARROW_INIT" -H "X-MCP-Servers: $QA_MCP_ALPHA_SLUG")
+mcp_initialized "$BASE_URL/mcp" "$NSID" -H "X-MCP-Servers: $QA_MCP_ALPHA_SLUG"
+mcp_post "$BASE_URL/mcp" "$NSID" '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
+  -H "X-MCP-Servers: $QA_MCP_ALPHA_SLUG" \
+  | jq -e --arg a "$QA_MCP_ALPHA_SLUG" '
+      (.result.tools | map(.name) | sort) == [$a + "_add", $a + "_echo"]
+    ' >/dev/null
+```
+
+### S167 MCP audit entries carry JSON-RPC bodies and nosniff
+
+With `LOGGING_LOG_BODIES` on, an MCP `tools/call` audit entry is labelled with
+the tool name and `provider="mcp"`, and captures both the JSON-RPC request
+frame and the SSE-decoded response frame. The MCP response also carries
+`X-Content-Type-Options: nosniff`.
+
+```bash
+if ! curl -fsS "$MCP_UPSTREAM_BASE/healthz" >/dev/null 2>&1; then
+  echo "SKIPPED: mock MCP upstream is not running on $MCP_UPSTREAM_BASE"
+  exit 0
+fi
+
+mcp_register_release_servers "$BASE_URL"
+trap 'mcp_cleanup_release_servers "$BASE_URL"' EXIT
+
+HEADERS_FILE="$QA_RUN_DIR/s167.init.headers"
+INIT_FILE="$QA_RUN_DIR/s167.init.raw"
+SID=$(mcp_initialize "$BASE_URL/mcp" "$HEADERS_FILE" "$INIT_FILE")
+grep -Eiq '^x-content-type-options: *nosniff' "$HEADERS_FILE"
+mcp_initialized "$BASE_URL/mcp" "$SID"
+
+REQ_ID="qa-mcp-audit-$QA_SUFFIX"
+CALL_HEADERS="$QA_RUN_DIR/s167.call.headers"
+mcp_post "$BASE_URL/mcp" "$SID" \
+  "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"${QA_MCP_ALPHA_SLUG}_echo\",\"arguments\":{\"marker\":\"QA_MCP_AUDIT_BODY_OK\"}}}" \
+  -H "X-Request-ID: $REQ_ID" \
+  -D "$CALL_HEADERS" \
+  > "$QA_RUN_DIR/s167.call.json"
+grep -Eiq '^x-content-type-options: *nosniff' "$CALL_HEADERS"
+
+AUDIT_FILE="$QA_RUN_DIR/s167.audit.json"
+FOUND=0
+for _ in $(seq 1 15); do
+  curl -fsS "$BASE_URL/admin/audit/log?search=$REQ_ID&limit=5" > "$AUDIT_FILE"
+  if jq -e --arg rid "$REQ_ID" --arg tool "${QA_MCP_ALPHA_SLUG}_echo" '
+    any(.entries[]?;
+      .request_id == $rid
+      and .provider == "mcp"
+      and .requested_model == $tool
+      and .status_code == 200
+      and ((.data.request_body | tojson) | contains("QA_MCP_AUDIT_BODY_OK"))
+      and ((.data.response_body | tojson) | (contains("echo:") and contains("QA_MCP_AUDIT_BODY_OK"))))
+  ' "$AUDIT_FILE" >/dev/null; then
+    FOUND=1
+    break
+  fi
+  sleep 1
+done
+if [ "$FOUND" -ne 1 ]; then
+  jq '.' "$AUDIT_FILE" >&2 || true
+  echo "error: MCP audit entry with bodies was not flushed for $REQ_ID" >&2
+  exit 1
+fi
+```
+
+### S168 MCP negatives: unknown server, unknown tool, session identity binding, header-principal enforcement, stdio rejected
+
+Unknown per-server endpoints 404, an unknown tool returns a JSON-RPC error,
+a session initialized by one user path is invisible to another principal,
+header-identified MCP posts are gated by user-path rate limits, `user_paths`
+server scoping admits subtree members and hides the server from outsiders,
+and the admin API rejects runtime-registered stdio servers.
+
+```bash
+if ! curl -fsS "$MCP_UPSTREAM_BASE/healthz" >/dev/null 2>&1; then
+  echo "SKIPPED: mock MCP upstream is not running on $MCP_UPSTREAM_BASE"
+  exit 0
+fi
+
+mcp_register_release_servers "$BASE_URL"
+trap 'mcp_cleanup_release_servers "$BASE_URL"' EXIT
+
+curl -sS -o /dev/null -w '%{http_code}' "$BASE_URL/mcp/qa-no-such-server-$QA_BUDGET_SUFFIX" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"qa","version":"1"}}}' \
+  | grep -q '^404$'
+
+HEADERS_FILE="$QA_RUN_DIR/s168.init.headers"
+INIT_FILE="$QA_RUN_DIR/s168.init.raw"
+SID=$(mcp_initialize "$BASE_URL/mcp" "$HEADERS_FILE" "$INIT_FILE" -H "X-GoModel-User-Path: /team/mcp/owner/$QA_SUFFIX")
+mcp_initialized "$BASE_URL/mcp" "$SID" -H "X-GoModel-User-Path: /team/mcp/owner/$QA_SUFFIX"
+
+mcp_post "$BASE_URL/mcp" "$SID" \
+  '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"qa_totally_unknown_tool","arguments":{}}}' \
+  -H "X-GoModel-User-Path: /team/mcp/owner/$QA_SUFFIX" \
+  | jq -e '(.error != null) or (.result.isError == true)' >/dev/null
+
+# Session-to-principal binding sees header-based user paths (was a KNOWN BUG
+# until 2026-07-15: /mcp was not stamped with the user-path header, so header
+# principals could ride a leaked session ID). A different header principal —
+# or no header at all — presenting the owner's session ID gets 404.
+curl -sS -o "$QA_RUN_DIR/s168.stolen.body" -w '%{http_code}' "$BASE_URL/mcp" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -H 'MCP-Protocol-Version: 2025-06-18' \
+  -H "Mcp-Session-Id: $SID" \
+  -H "X-GoModel-User-Path: /team/mcp/intruder/$QA_SUFFIX" \
+  -d '{"jsonrpc":"2.0","id":4,"method":"tools/list"}' \
+  | grep -q '^404$'
+curl -sS -o /dev/null -w '%{http_code}' "$BASE_URL/mcp" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -H 'MCP-Protocol-Version: 2025-06-18' \
+  -H "Mcp-Session-Id: $SID" \
+  -d '{"jsonrpc":"2.0","id":4,"method":"tools/list"}' \
+  | grep -q '^404$'
+# The owner keeps working under the original header.
+mcp_post "$BASE_URL/mcp" "$SID" '{"jsonrpc":"2.0","id":5,"method":"tools/list"}' \
+  -H "X-GoModel-User-Path: /team/mcp/owner/$QA_SUFFIX" \
+  | jq -e '.result.tools | length > 0' >/dev/null
+
+# Cross-endpoint session reuse IS rejected: a session initialized on one
+# pinned endpoint cannot be presented on another.
+PIN_HEADERS="$QA_RUN_DIR/s168.pin.headers"
+PIN_INIT="$QA_RUN_DIR/s168.pin.raw"
+PSID=$(mcp_initialize "$BASE_URL/mcp/$QA_MCP_ALPHA_SLUG" "$PIN_HEADERS" "$PIN_INIT")
+curl -sS -o /dev/null -w '%{http_code}' "$BASE_URL/mcp/$QA_MCP_BETA_SLUG" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -H 'MCP-Protocol-Version: 2025-06-18' \
+  -H "Mcp-Session-Id: $PSID" \
+  -d '{"jsonrpc":"2.0","id":5,"method":"tools/list"}' \
+  | grep -q '^404$'
+
+curl -sS -o "$QA_RUN_DIR/s168.stdio.body" -w '%{http_code}' -X PUT "$BASE_URL/admin/mcp-servers" \
+  -H 'Content-Type: application/json' \
+  -d "{\"name\":\"qa-stdio-$QA_BUDGET_SUFFIX\",\"transport\":\"stdio\",\"url\":\"\",\"command\":\"/bin/echo\"}" \
+  | grep -q '^400$'
+
+# User-path rate limits gate header-identified MCP posts (was a KNOWN BUG
+# until 2026-07-15: admission resolved the path to "/" because the header was
+# never stamped into the context). Sessionless posts keep the accounting
+# simple: one rule request per POST, no handshake traffic on the counter.
+RL_PATH="/qa/mcp-admission/$QA_SUFFIX"
+trap 'mcp_cleanup_release_servers "$BASE_URL"; curl -sS -o /dev/null -X DELETE "$BASE_URL/admin/rate-limits" -H "Content-Type: application/json" -d "{\"user_path\":\"$RL_PATH\",\"limit_key\":{\"period\":\"minute\"}}" || true' EXIT
+curl -fsS -X PUT "$BASE_URL/admin/rate-limits" \
+  -H 'Content-Type: application/json' \
+  -d "{\"user_path\":\"$RL_PATH\",\"limit_key\":{\"period\":\"minute\"},\"max_requests\":1}" >/dev/null
+curl -sS -o /dev/null -w '%{http_code}' "$BASE_URL/mcp" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -H "X-GoModel-User-Path: $RL_PATH/leaf" \
+  -d '{"jsonrpc":"2.0","id":10,"method":"tools/list"}' \
+  | grep -q '^200$'
+RL_BODY="$QA_RUN_DIR/s168.rl.body"
+RL_HEADERS="$QA_RUN_DIR/s168.rl.headers"
+curl -sS -D "$RL_HEADERS" -o "$RL_BODY" -w '%{http_code}' "$BASE_URL/mcp" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -H "X-GoModel-User-Path: $RL_PATH/leaf" \
+  -d '{"jsonrpc":"2.0","id":11,"method":"tools/list"}' \
+  | grep -q '^429$'
+grep -Eiq '^Retry-After: *[0-9]+' "$RL_HEADERS"
+jq -e '.error.code == "rate_limit_exceeded"' "$RL_BODY" >/dev/null
+
+# user_paths server scoping admits subtree members and hides the server from
+# everyone else (was fail-closed-for-all until 2026-07-15). Re-scoping alpha
+# is the last mutation in this scenario; cleanup deletes the row anyway.
+SECRET_PATH="/team/mcp/secret/$QA_SUFFIX"
+curl -fsS -X PUT "$BASE_URL/admin/mcp-servers" \
+  -H 'Content-Type: application/json' \
+  -d "{\"name\":\"$QA_MCP_ALPHA\",\"url\":\"$MCP_UPSTREAM_BASE/alpha\",\"transport\":\"http\",\"headers\":{\"X-Mock-Token\":\"$MCP_UPSTREAM_TOKEN\"},\"user_paths\":[\"$SECRET_PATH\"],\"description\":\"qa release alpha scoped\"}" >/dev/null
+mcp_wait_status "$BASE_URL" "$QA_MCP_ALPHA" connected
+
+MEMBER_HEADERS="$QA_RUN_DIR/s168.member.headers"
+MEMBER_INIT="$QA_RUN_DIR/s168.member.raw"
+MSID=$(mcp_initialize "$BASE_URL/mcp" "$MEMBER_HEADERS" "$MEMBER_INIT" -H "X-GoModel-User-Path: $SECRET_PATH/dev")
+mcp_initialized "$BASE_URL/mcp" "$MSID" -H "X-GoModel-User-Path: $SECRET_PATH/dev"
+mcp_post "$BASE_URL/mcp" "$MSID" '{"jsonrpc":"2.0","id":12,"method":"tools/list"}' \
+  -H "X-GoModel-User-Path: $SECRET_PATH/dev" \
+  | jq -e --arg a "$QA_MCP_ALPHA_SLUG" 'any(.result.tools[]?; .name == $a + "_echo")' >/dev/null
+
+OUTSIDER_HEADERS="$QA_RUN_DIR/s168.outsider.headers"
+OUTSIDER_INIT="$QA_RUN_DIR/s168.outsider.raw"
+OSID=$(mcp_initialize "$BASE_URL/mcp" "$OUTSIDER_HEADERS" "$OUTSIDER_INIT" -H "X-GoModel-User-Path: /team/mcp/outsider/$QA_SUFFIX")
+mcp_initialized "$BASE_URL/mcp" "$OSID" -H "X-GoModel-User-Path: /team/mcp/outsider/$QA_SUFFIX"
+mcp_post "$BASE_URL/mcp" "$OSID" '{"jsonrpc":"2.0","id":13,"method":"tools/list"}' \
+  -H "X-GoModel-User-Path: /team/mcp/outsider/$QA_SUFFIX" \
+  | jq -e --arg a "$QA_MCP_ALPHA_SLUG" '
+      all(.result.tools[]?; (.name | startswith($a + "_")) | not)
+      and (.result.tools | length > 0)
+    ' >/dev/null
+
+# The pinned endpoint honors the same scoping: outsiders get 404.
+curl -sS -o /dev/null -w '%{http_code}' "$BASE_URL/mcp/$QA_MCP_ALPHA_SLUG" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -H "X-GoModel-User-Path: /team/mcp/outsider/$QA_SUFFIX" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"qa","version":"1"}}}' \
+  | grep -q '^404$'
+```
+
+### S169 Secret *** round-trip preserves the stored header; a wrong secret breaks the dial
+
+Re-upserting the token-gated server with the redaction placeholder must keep
+the stored `X-Mock-Token`, so the reconnect still succeeds; upserting a wrong
+token must leave the server unable to connect.
+
+```bash
+if ! curl -fsS "$MCP_UPSTREAM_BASE/healthz" >/dev/null 2>&1; then
+  echo "SKIPPED: mock MCP upstream is not running on $MCP_UPSTREAM_BASE"
+  exit 0
+fi
+
+mcp_register_release_servers "$BASE_URL"
+trap 'mcp_cleanup_release_servers "$BASE_URL"' EXIT
+
+curl -fsS -X PUT "$BASE_URL/admin/mcp-servers" \
+  -H 'Content-Type: application/json' \
+  -d "{\"name\":\"$QA_MCP_ALPHA\",\"url\":\"$MCP_UPSTREAM_BASE/alpha\",\"transport\":\"http\",\"headers\":{\"X-Mock-Token\":\"***\"},\"description\":\"qa release alpha updated\"}" \
+  | jq -e '.headers["X-Mock-Token"] == "***" and .description == "qa release alpha updated"' >/dev/null
+curl -fsS -X POST "$BASE_URL/admin/mcp-servers/$QA_MCP_ALPHA_SLUG/reconnect" >/dev/null
+mcp_wait_status "$BASE_URL" "$QA_MCP_ALPHA" connected
+
+HEADERS_FILE="$QA_RUN_DIR/s169.init.headers"
+INIT_FILE="$QA_RUN_DIR/s169.init.raw"
+SID=$(mcp_initialize "$BASE_URL/mcp/$QA_MCP_ALPHA_SLUG" "$HEADERS_FILE" "$INIT_FILE")
+mcp_initialized "$BASE_URL/mcp/$QA_MCP_ALPHA_SLUG" "$SID"
+mcp_post "$BASE_URL/mcp/$QA_MCP_ALPHA_SLUG" "$SID" \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"echo","arguments":{"marker":"QA_MCP_SECRET_KEPT"}}}' \
+  | jq -e 'any(.result.content[]?; .text | contains("QA_MCP_SECRET_KEPT"))' >/dev/null
+
+curl -fsS -X PUT "$BASE_URL/admin/mcp-servers" \
+  -H 'Content-Type: application/json' \
+  -d "{\"name\":\"$QA_MCP_ALPHA\",\"url\":\"$MCP_UPSTREAM_BASE/alpha\",\"transport\":\"http\",\"headers\":{\"X-Mock-Token\":\"definitely-wrong\"}}" \
+  > "$QA_RUN_DIR/s169.wrong.json" || true
+
+BROKEN=0
+for _ in $(seq 1 20); do
+  curl -fsS -X POST "$BASE_URL/admin/mcp-servers/$QA_MCP_ALPHA_SLUG/reconnect" > "$QA_RUN_DIR/s169.reconnect.json" || true
+  if curl -fsS "$BASE_URL/admin/mcp-servers" \
+    | jq -e --arg n "$QA_MCP_ALPHA" 'any(.[]?; .name == $n and .status != "connected")' >/dev/null; then
+    BROKEN=1
+    break
+  fi
+  sleep 1
+done
+if [ "$BROKEN" -ne 1 ]; then
+  curl -fsS "$BASE_URL/admin/mcp-servers" | jq . >&2 || true
+  echo "error: alpha stayed connected despite a wrong upstream token" >&2
+  exit 1
+fi
+```
+
+### S170 Provider request health folded into /admin/providers/status
+
+After real chat traffic the provider status carries `request_health`: a
+10-minute window of per-model request counts plus the circuit-breaker state.
+
+```bash
+RESP_FILE="$QA_RUN_DIR/s170.chat.json"
+curl -fsS "$BASE_URL/v1/chat/completions" \
+  -H 'Content-Type: application/json' \
+  -H "X-Request-ID: qa-health-$QA_SUFFIX" \
+  -d '{"model":"gpt-4.1-nano","messages":[{"role":"user","content":"Reply with exactly QA_HEALTH_OK"}],"max_tokens":20}' \
+  > "$RESP_FILE"
+assert_chat_response_contains "$RESP_FILE" "openai" "QA_HEALTH_OK"
+
+STATUS_FILE="$QA_RUN_DIR/s170.status.json"
+FOUND=0
+for _ in $(seq 1 15); do
+  curl -fsS "$BASE_URL/admin/providers/status" > "$STATUS_FILE"
+  if jq -e '
+    any(.providers[]?;
+      .name == "openai"
+      and .request_health != null
+      and .request_health.window_seconds == 600
+      and .request_health.requests >= 1
+      and ((.request_health.circuit_state // "closed") == "closed")
+      and any(.request_health.models[]?; (.model | startswith("gpt-4.1-nano")) and .requests >= 1))
+  ' "$STATUS_FILE" >/dev/null; then
+    FOUND=1
+    break
+  fi
+  sleep 1
+done
+if [ "$FOUND" -ne 1 ]; then
+  jq '{summary, openai: [.providers[]? | select(.name == "openai") | {status, request_health}]}' "$STATUS_FILE" >&2 || true
+  echo "error: openai request_health did not reflect the seeded request" >&2
+  exit 1
+fi
+jq -e 'all(.providers[]?; .status_reason | type == "string" and length > 0)' "$STATUS_FILE" >/dev/null
+```
+
+### S171 MCP server store parity on PostgreSQL and MongoDB
+
+The `mcp_servers` admin store round-trips on both non-SQLite backends, and a
+registered server serves tool calls through each gateway.
+
+```bash
+if ! curl -fsS "$MCP_UPSTREAM_BASE/healthz" >/dev/null 2>&1; then
+  echo "SKIPPED: mock MCP upstream is not running on $MCP_UPSTREAM_BASE"
+  exit 0
+fi
+
+for URL in "$PG_BASE_URL" "$MONGO_BASE_URL"; do
+  curl -fsS -X PUT "$URL/admin/mcp-servers" \
+    -H 'Content-Type: application/json' \
+    -d "{\"name\":\"$QA_MCP_BETA\",\"url\":\"$MCP_UPSTREAM_BASE/beta\",\"transport\":\"http\"}" \
+    | jq -e --arg n "$QA_MCP_BETA" '.name == $n and .managed == false' >/dev/null
+  mcp_wait_status "$URL" "$QA_MCP_BETA" connected
+
+  HEADERS_FILE="$QA_RUN_DIR/s171.init.headers"
+  INIT_FILE="$QA_RUN_DIR/s171.init.raw"
+  SID=$(mcp_initialize "$URL/mcp" "$HEADERS_FILE" "$INIT_FILE")
+  mcp_initialized "$URL/mcp" "$SID"
+  mcp_post "$URL/mcp" "$SID" \
+    "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"${QA_MCP_BETA}_fetch\",\"arguments\":{\"u\":\"qa-parity\"}}}" \
+    | jq -e 'any(.result.content[]?; .text | contains("fetch:") and contains("qa-parity"))' >/dev/null
+
+  curl -fsS -X DELETE "$URL/admin/mcp-servers/$QA_MCP_BETA" >/dev/null
+  curl -fsS "$URL/admin/mcp-servers" \
+    | jq -e --arg n "$QA_MCP_BETA" 'all(.[]?; .name != $n)' >/dev/null
+done
+```
+
+### S172 Namespaced prompts and resources relay through /mcp
+
+Prompts are namespaced like tools; resources and resource templates relay
+verbatim, and `resources/read` returns the upstream payload.
+
+```bash
+if ! curl -fsS "$MCP_UPSTREAM_BASE/healthz" >/dev/null 2>&1; then
+  echo "SKIPPED: mock MCP upstream is not running on $MCP_UPSTREAM_BASE"
+  exit 0
+fi
+
+mcp_register_release_servers "$BASE_URL"
+trap 'mcp_cleanup_release_servers "$BASE_URL"' EXIT
+
+HEADERS_FILE="$QA_RUN_DIR/s172.init.headers"
+INIT_FILE="$QA_RUN_DIR/s172.init.raw"
+SID=$(mcp_initialize "$BASE_URL/mcp" "$HEADERS_FILE" "$INIT_FILE")
+mcp_initialized "$BASE_URL/mcp" "$SID"
+
+mcp_post "$BASE_URL/mcp" "$SID" '{"jsonrpc":"2.0","id":2,"method":"prompts/list"}' \
+  | jq -e --arg a "$QA_MCP_ALPHA_SLUG" 'any(.result.prompts[]?; .name == $a + "_greeting")' >/dev/null
+
+mcp_post "$BASE_URL/mcp" "$SID" \
+  "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"prompts/get\",\"params\":{\"name\":\"${QA_MCP_ALPHA_SLUG}_greeting\"}}" \
+  | jq -e 'any(.result.messages[]?; .content.text == "MOCKMCP_GREETING_OK")' >/dev/null
+
+mcp_post "$BASE_URL/mcp" "$SID" '{"jsonrpc":"2.0","id":4,"method":"resources/list"}' \
+  | jq -e 'any(.result.resources[]?; .uri == "mock://alpha/info")' >/dev/null
+
+mcp_post "$BASE_URL/mcp" "$SID" \
+  '{"jsonrpc":"2.0","id":5,"method":"resources/read","params":{"uri":"mock://alpha/info"}}' \
+  | jq -e 'any(.result.contents[]?; .text == "MOCKMCP_ALPHA_RESOURCE_OK")' >/dev/null
 ```


### PR DESCRIPTION
## Summary

Release QA (post-v0.1.51, findings in `docs/dev/2026-07-15_release-qa-findings.md`) pinned two defects in the MCP gateway (#502). This PR fixes both and adds the e2e coverage that caught them.

### F2 — header-based user paths never reached the MCP layer (security-relevant)

`/mcp` is not `IngressManaged`, so the snapshot middleware never stamped `X-GoModel-User-Path` into the request context and `core.UserPathFromContext` was empty for every MCP request with header identity. Verified consequences:

- **Session-to-principal binding was a no-op for header principals** — a different principal presenting a leaked `Mcp-Session-Id` got 200 with the owner's tool snapshot instead of the documented 404 (managed-key principals were enforced correctly).
- **`user_paths` server scoping failed closed** — a server scoped to `/team/secret` was invisible even to a legitimate `/team/secret/dev` header caller.
- **User-path rate limits and budgets did not gate MCP posts** — admission resolved the path to `/`, contradicting the documented behavior.
- Usage/audit logs *did* record the header path, so observability disagreed with enforcement.

**Fix:** `RequestSnapshotCapture` now normalizes the user-path header and stamps it into the request context for model-interaction endpoints that take no snapshot (`/mcp`, realtime, audio — closing the same latent gap for realtime/audio identity). A managed key's bound path still wins: auth middleware runs later and its context value shadows the stamped one. An invalid header now returns 400 on these endpoints, matching the ingress-managed ones.

### F1 — unique bare-name `tools/call` was not implemented

The gateway spec and CLAUDE.md promise `tools/call` on `/mcp` accepts a unique bare tool name, but only namespaced names were registered, so bare names returned `-32602 unknown tool`.

**Fix:** the aggregated per-session server installs a receiving middleware that rewrites a bare `tools/call` name to its namespaced registration when exactly one visible server exposes it. Namespaced names always win on collision, ambiguous bare names stay errors, `tools/list` stays namespaced, and usage entries keep recording the namespaced name. The dead `ResolveNamespacedName` helper is removed.

## User-visible impact

- Header-identified MCP sessions are now protected against session riding, `user_paths` scoping works for header principals (subtree members admitted, outsiders get 404 on pinned endpoints too), and MCP posts count against user-path rate limits and budgets — matching what the docs already promised.
- `tools/call` with a unique bare name now works (Postel fallback per the spec).
- Realtime and audio endpoints also gain header-path identity for rate limiting and usage attribution.

## Tests

- Unit: snapshot-middleware stamping (valid/invalid/non-model paths), `bareToolAliases` table tests, aggregated bare-name call + ambiguity integration tests over real MCP sessions. Full suite + race + lint green.
- E2E: release matrix grown to 172 with S163–S172 (new `tests/e2e/mockmcp` upstream managed by the stack script); S165/S168 now assert the fixed behavior including stolen-session 404, `/mcp` 429 under a 1 req/min user-path rule, and `user_paths` subtree visibility. **Full matrix 172/172 green** against the rebuilt stack (sqlite/pg/mongo/guardrails/auth gateways).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for calling uniquely named MCP tools without namespaces on aggregated endpoints.
  * Added end-to-end MCP coverage for tools, prompts, resources, authentication, auditing, isolation, and provider health.
  * Added a self-contained mock MCP service for release testing.

* **Bug Fixes**
  * Corrected user-path handling and validation for applicable MCP, realtime, and audio requests.
  * Ambiguous bare tool names are now rejected safely.

* **Documentation**
  * Added comprehensive release QA findings and results for v0.1.51.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->