### PR TITLE
feat(providers): add Kilo AI gateway

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -433,6 +433,13 @@
 # OPENROUTER_SITE_URL=https://gomodel.enterpilot.io
 # OPENROUTER_APP_NAME=GoModel
 
+# Kilo AI Gateway (default base URL: https://api.kilo.ai/api/gateway)
+# Model IDs use provider/model and pass through unchanged.
+# KILO_API_KEY=...
+# KILO_BASE_URL=https://api.kilo.ai/api/gateway
+# Optional configured model list; see CONFIGURED_PROVIDER_MODELS_MODE below
+# KILO_MODELS=anthropic/claude-sonnet-4.5,openai/gpt-5.5
+
 # Z.ai (default base URL: https://api.z.ai/api/paas/v4)
 # For GLM Coding Plan, use: https://api.z.ai/api/coding/paas/v4
 # ZAI_API_KEY=...

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ curl http://localhost:8080/v1/chat/completions \
 
 GoModel supports OpenAI, Anthropic, Google Gemini, Vertex AI, DeepSeek, Groq,
 Fireworks AI, Meta (Muse Spark), OpenRouter, Z.ai, xAI (Grok), Alibaba Cloud
-Model Studio (Bailian), MiniMax, Xiaomi MiMo, OpenCode Go, Azure OpenAI,
+Model Studio (Bailian), Kilo AI, MiniMax, Xiaomi MiMo, OpenCode Go, Azure OpenAI,
 Oracle, Ollama, vLLM, Amazon Bedrock, and all OpenAI-compatible providers.
 
 See the [Providers Overview](./docs/providers/overview.mdx) for the full

--- a/cmd/gomodel/docs/docs.go
+++ b/cmd/gomodel/docs/docs.go
@@ -9876,7 +9876,7 @@ var SwaggerInfo = &swag.Spec{
 	BasePath:         "/",
 	Schemes:          []string{"http"},
 	Title:            "GoModel API",
-	Description:      "AI gateway routing requests to multiple LLM providers (OpenAI, Anthropic, Gemini, Groq, Fireworks AI, Meta, OpenRouter, DeepSeek, Z.ai, xAI, MiniMax, Xiaomi MiMo, OpenCode Go, Oracle, Ollama, Bailian). Drop-in OpenAI-compatible API.",
+	Description:      "AI gateway routing requests to multiple LLM providers (OpenAI, Anthropic, Gemini, Groq, Fireworks AI, Meta, OpenRouter, Kilo AI, DeepSeek, Z.ai, xAI, MiniMax, Xiaomi MiMo, OpenCode Go, Oracle, Ollama, Bailian). Drop-in OpenAI-compatible API.",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,
 	LeftDelim:        "{{",

--- a/cmd/gomodel/main.go
+++ b/cmd/gomodel/main.go
@@ -10,7 +10,7 @@ import (
 
 // @title          GoModel API
 // @version        1.0
-// @description    AI gateway routing requests to multiple LLM providers (OpenAI, Anthropic, Gemini, Groq, Fireworks AI, Meta, OpenRouter, DeepSeek, Z.ai, xAI, MiniMax, Xiaomi MiMo, OpenCode Go, Oracle, Ollama, Bailian). Drop-in OpenAI-compatible API.
+// @description    AI gateway routing requests to multiple LLM providers (OpenAI, Anthropic, Gemini, Groq, Fireworks AI, Meta, OpenRouter, Kilo AI, DeepSeek, Z.ai, xAI, MiniMax, Xiaomi MiMo, OpenCode Go, Oracle, Ollama, Bailian). Drop-in OpenAI-compatible API.
 // @BasePath       /
 // @schemes        http
 // @securityDefinitions.apikey BearerAuth

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -13,7 +13,7 @@ server:
   enable_passthrough_routes: true # expose /p/{provider}/{endpoint} passthrough routes
   allow_passthrough_v1_alias: true # allow /p/{provider}/v1/... while keeping /p/{provider}/... canonical
   user_path_header: "X-GoModel-User-Path" # env: USER_PATH_HEADER; inbound header used for user_path scoping
-  enabled_passthrough_providers: ["openai", "anthropic", "openrouter", "zai", "vllm", "deepseek", "bailian"] # providers enabled on /p/{provider}/...
+  enabled_passthrough_providers: ["openai", "anthropic", "openrouter", "kilo", "zai", "vllm", "deepseek", "bailian"] # providers enabled on /p/{provider}/...
   realtime_enabled: true # env: REALTIME_ENABLED; expose /v1/realtime websocket and /p/{provider}/v1/realtime upgrades (OpenAI only)
 
 models:
@@ -426,6 +426,16 @@ providers:
   #   models:
   #     - openai/gpt-oss-120b
   #     - anthropic/claude-sonnet-4
+
+  # Example: Kilo AI Gateway. Model IDs use provider/model and are forwarded
+  # unchanged. You can also set KILO_MODELS as a comma-separated env var.
+  # kilo:
+  #   type: "kilo"
+  #   base_url: "https://api.kilo.ai/api/gateway"
+  #   api_key: "${KILO_API_KEY}"
+  #   models:
+  #     - anthropic/claude-sonnet-4.5
+  #     - openai/gpt-5.5
 
   # Example: Azure OpenAI
   # azure:

--- a/config/config.go
+++ b/config/config.go
@@ -67,6 +67,7 @@ func buildDefaultConfig() *Config {
 				"openai",
 				"anthropic",
 				"openrouter",
+				"kilo",
 				"zai",
 				"vllm",
 				"deepseek",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,6 +22,7 @@ func clearProviderEnvVars(t *testing.T) {
 		"XAI_API_KEY", "XAI_BASE_URL", "XAI_MODELS",
 		"GROQ_API_KEY", "GROQ_BASE_URL", "GROQ_MODELS",
 		"OPENROUTER_API_KEY", "OPENROUTER_BASE_URL", "OPENROUTER_MODELS", "OPENROUTER_SITE_URL", "OPENROUTER_APP_NAME",
+		"KILO_API_KEY", "KILO_BASE_URL", "KILO_MODELS",
 		"ZAI_API_KEY", "ZAI_BASE_URL", "ZAI_MODELS",
 		"AZURE_API_KEY", "AZURE_BASE_URL", "AZURE_API_VERSION", "AZURE_MODELS",
 		"ORACLE_API_KEY", "ORACLE_BASE_URL", "ORACLE_MODELS",
@@ -120,7 +121,7 @@ func TestBuildDefaultConfig(t *testing.T) {
 	if !cfg.Server.AllowPassthroughV1Alias {
 		t.Error("expected Server.AllowPassthroughV1Alias=true")
 	}
-	if got, want := cfg.Server.EnabledPassthroughProviders, []string{"openai", "anthropic", "openrouter", "zai", "vllm", "deepseek"}; !reflect.DeepEqual(got, want) {
+	if got, want := cfg.Server.EnabledPassthroughProviders, []string{"openai", "anthropic", "openrouter", "kilo", "zai", "vllm", "deepseek"}; !reflect.DeepEqual(got, want) {
 		t.Errorf("expected Server.EnabledPassthroughProviders=%v, got %v", want, got)
 	}
 	if cfg.Models.ConfiguredProviderModelsMode != ConfiguredProviderModelsModeFallback {
@@ -1128,7 +1129,7 @@ func TestLoad_ConfigExample_UsesNestedModelCacheSettings(t *testing.T) {
 			t.Fatalf("expected Cache.Model.Redis to be nil in example config, got %+v", result.Config.Cache.Model.Redis)
 		}
 		gotProviders := result.Config.Server.EnabledPassthroughProviders
-		wantProviders := []string{"openai", "anthropic", "openrouter", "zai", "vllm", "deepseek", "bailian"}
+		wantProviders := []string{"openai", "anthropic", "openrouter", "kilo", "zai", "vllm", "deepseek", "bailian"}
 		if !reflect.DeepEqual(gotProviders, wantProviders) {
 			t.Fatalf("Server.EnabledPassthroughProviders = %v, want %v", gotProviders, wantProviders)
 		}

--- a/config/server.go
+++ b/config/server.go
@@ -37,7 +37,7 @@ type ServerConfig struct {
 	UserPathHeader string `yaml:"user_path_header" env:"USER_PATH_HEADER"`
 	// EnabledPassthroughProviders lists the provider types enabled on
 	// /p/{provider}/... passthrough routes. Default:
-	// ["openai", "anthropic", "openrouter", "zai", "vllm", "deepseek"].
+	// ["openai", "anthropic", "openrouter", "kilo", "zai", "vllm", "deepseek"].
 	EnabledPassthroughProviders []string `yaml:"enabled_passthrough_providers" env:"ENABLED_PASSTHROUGH_PROVIDERS"`
 	// RealtimeEnabled exposes the realtime (speech-to-speech) websocket endpoint
 	// at /v1/realtime and the /p/{provider}/v1/realtime passthrough upgrade.

--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -226,6 +226,7 @@ Set these to automatically register providers. No YAML configuration required.
 | `GEMINI_API_KEY`     | Google Gemini                                      |
 | `DEEPSEEK_API_KEY`   | DeepSeek                                           |
 | `OPENROUTER_API_KEY` | OpenRouter                                         |
+| `KILO_API_KEY`       | Kilo AI Gateway                                    |
 | `ZAI_API_KEY`        | Z.ai                                               |
 | `XAI_API_KEY`        | xAI (Grok)                                         |
 | `GROQ_API_KEY`       | Groq                                               |
@@ -234,7 +235,7 @@ Set these to automatically register providers. No YAML configuration required.
 | `OLLAMA_BASE_URL`    | Ollama (no API key needed)                        |
 | `VLLM_BASE_URL`      | vLLM (no API key needed unless upstream requires) |
 
-Most providers can use a custom base URL via `<PROVIDER>_BASE_URL` (for example `OPENAI_BASE_URL`). DeepSeek defaults to `https://api.deepseek.com`; set `DEEPSEEK_BASE_URL` only for a compatible proxy or alternate DeepSeek endpoint. OpenRouter defaults to `https://openrouter.ai/api/v1` and can be overridden with `OPENROUTER_BASE_URL`. Z.ai defaults to `https://api.z.ai/api/paas/v4`; set `ZAI_BASE_URL=https://api.z.ai/api/coding/paas/v4` for the GLM Coding Plan endpoint. vLLM defaults to `http://localhost:8000/v1` when `VLLM_API_KEY` is set, but keyless deployments should set `VLLM_BASE_URL` explicitly to register the provider. Azure uses `AZURE_BASE_URL` for its deployment base URL and accepts an optional `AZURE_API_VERSION` override; otherwise it defaults to `2024-10-21`. Oracle requires `ORACLE_BASE_URL` because its OpenAI-compatible endpoint is region-specific.
+Most providers can use a custom base URL via `<PROVIDER>_BASE_URL` (for example `OPENAI_BASE_URL`). DeepSeek defaults to `https://api.deepseek.com`; set `DEEPSEEK_BASE_URL` only for a compatible proxy or alternate DeepSeek endpoint. OpenRouter defaults to `https://openrouter.ai/api/v1` and can be overridden with `OPENROUTER_BASE_URL`. Kilo AI defaults to `https://api.kilo.ai/api/gateway` and can be overridden with `KILO_BASE_URL`. Z.ai defaults to `https://api.z.ai/api/paas/v4`; set `ZAI_BASE_URL=https://api.z.ai/api/coding/paas/v4` for the GLM Coding Plan endpoint. vLLM defaults to `http://localhost:8000/v1` when `VLLM_API_KEY` is set, but keyless deployments should set `VLLM_BASE_URL` explicitly to register the provider. Azure uses `AZURE_BASE_URL` for its deployment base URL and accepts an optional `AZURE_API_VERSION` override; otherwise it defaults to `2024-10-21`. Oracle requires `ORACLE_BASE_URL` because its OpenAI-compatible endpoint is region-specific.
 
 Every provider type also accepts a comma-separated configured model list via
 `<PROVIDER>_MODELS`, for example `OPENROUTER_MODELS`, `ORACLE_MODELS`,
@@ -360,6 +361,7 @@ export DEEPSEEK_API_KEY="..."        # Registers "deepseek" provider
 export XAI_API_KEY="..."             # Registers "xai" provider
 export GROQ_API_KEY="gsk_..."        # Registers "groq" provider
 export OPENROUTER_API_KEY="sk-or-..." # Registers "openrouter" provider
+export KILO_API_KEY="..."            # Registers "kilo" provider
 export ZAI_API_KEY="..."             # Registers "zai" provider
 # Optional: export ZAI_BASE_URL="https://api.z.ai/api/coding/paas/v4"
 export AZURE_API_KEY="..."           # Registers "azure" provider when paired with AZURE_BASE_URL
@@ -368,6 +370,7 @@ export ORACLE_API_KEY="..."          # Registers "oracle" provider when paired w
 export ORACLE_BASE_URL="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com/20231130/actions/v1"
 export ORACLE_MODELS="openai.gpt-oss-120b,xai.grok-3" # Optional configured model list
 export OPENROUTER_MODELS="openai/gpt-oss-120b,anthropic/claude-sonnet-4"
+export KILO_MODELS="anthropic/claude-sonnet-4.5,openai/gpt-5.5"
 export CONFIGURED_PROVIDER_MODELS_MODE="fallback" # fallback or allowlist
 export OLLAMA_BASE_URL="http://localhost:11434/v1" # Registers "ollama" provider
 export VLLM_BASE_URL="http://localhost:8000/v1" # Registers keyless "vllm" provider

--- a/docs/features/passthrough-api.mdx
+++ b/docs/features/passthrough-api.mdx
@@ -130,7 +130,7 @@ from passthrough requests before forwarding them upstream.
 
 Passthrough is intentionally narrow while the API is in beta.
 
-- `openai`, `anthropic`, `openrouter`, `zai`, `vllm`, and `deepseek` are enabled by
+- `openai`, `anthropic`, `openrouter`, `kilo`, `zai`, `vllm`, and `deepseek` are enabled by
   default.
 - GoModel does not translate passthrough request bodies or response bodies.
 - Provider-native error bodies and status codes are proxied instead of converted
@@ -145,7 +145,7 @@ Passthrough routes are enabled by default:
 ```env
 ENABLE_PASSTHROUGH_ROUTES=true
 ALLOW_PASSTHROUGH_V1_ALIAS=true
-ENABLED_PASSTHROUGH_PROVIDERS=openai,anthropic,openrouter,zai,vllm,deepseek
+ENABLED_PASSTHROUGH_PROVIDERS=openai,anthropic,openrouter,kilo,zai,vllm,deepseek
 ```
 
 Set `ENABLED_PASSTHROUGH_PROVIDERS` to the provider types you want to expose.

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -7,7 +7,7 @@ icon: "rocket"
 ## Run GoModel in 30 Seconds
 
 GoModel is an OpenAI-compatible AI gateway. You can connect one endpoint and
-route traffic across OpenAI, Anthropic, Gemini, DeepSeek, xAI, Groq, OpenRouter,
+route traffic across OpenAI, Anthropic, Gemini, DeepSeek, xAI, Groq, OpenRouter, Kilo AI,
 Z.ai, Azure OpenAI, Oracle GenAI, Ollama, and more while keeping auth, audit logs, and
 admin visibility in one place.
 
@@ -27,7 +27,7 @@ docker run --rm -p 8080:8080 \
 <Note>
   Set at least one provider credential or base URL
   (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`,
-  `DEEPSEEK_API_KEY`, `XAI_API_KEY`, `GROQ_API_KEY`, `OPENROUTER_API_KEY`,
+  `DEEPSEEK_API_KEY`, `XAI_API_KEY`, `GROQ_API_KEY`, `OPENROUTER_API_KEY`, `KILO_API_KEY`,
   `ZAI_API_KEY`, `AZURE_API_KEY` + `AZURE_BASE_URL`,
   `ORACLE_API_KEY` + `ORACLE_BASE_URL`,
   `OLLAMA_BASE_URL`) or GoModel will have no models to route. GoModel also

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "description": "AI gateway routing requests to multiple LLM providers (OpenAI, Anthropic, Gemini, Groq, Fireworks AI, Meta, OpenRouter, DeepSeek, Z.ai, xAI, MiniMax, Xiaomi MiMo, OpenCode Go, Oracle, Ollama, Bailian). Drop-in OpenAI-compatible API.",
+    "description": "AI gateway routing requests to multiple LLM providers (OpenAI, Anthropic, Gemini, Groq, Fireworks AI, Meta, OpenRouter, Kilo AI, DeepSeek, Z.ai, xAI, MiniMax, Xiaomi MiMo, OpenCode Go, Oracle, Ollama, Bailian). Drop-in OpenAI-compatible API.",
     "title": "GoModel API",
     "contact": {},
     "version": "1.0"

--- a/docs/providers/overview.mdx
+++ b/docs/providers/overview.mdx
@@ -28,6 +28,7 @@ support, not every individual model capability exposed by an upstream provider.
 | Fireworks AI | `FIREWORKS_API_KEY` (`FIREWORKS_BASE_URL` optional) | `accounts/fireworks/models/gpt-oss-120b` | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | — |
 | Meta (Muse Spark) | `META_API_KEY` (`META_BASE_URL` optional) | `muse-spark-1.1` | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | — |
 | OpenRouter | `OPENROUTER_API_KEY` | `google/gemini-2.5-flash` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — |
+| Kilo AI | `KILO_API_KEY` (`KILO_BASE_URL` optional) | `anthropic/claude-sonnet-4.5` | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | — |
 | Z.ai | `ZAI_API_KEY` (`ZAI_BASE_URL` optional) | `glm-5.1` | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | — |
 | xAI (Grok) | `XAI_API_KEY` | `grok-4.5` | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | [xAI (Grok)](/providers/xai) |
 | Alibaba Cloud Model Studio (Bailian) | `BAILIAN_API_KEY` (`BAILIAN_BASE_URL` optional) | `qwen3-max` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | [Alibaba Cloud Model Studio](/providers/bailian) |
@@ -55,6 +56,12 @@ support, not every individual model capability exposed by an upstream provider.
   the upstream model catalog yet, so declare `context_window` and `pricing`
   under `providers.meta.models` metadata in `config.yaml` if you want cost
   tracking and context-window reporting.
+- **Kilo AI** — model IDs use `provider/model` (for example,
+  `anthropic/claude-sonnet-4.5`) and are forwarded unchanged. GoModel serves
+  `/v1/responses` by translating it to Kilo's chat-completions endpoint. If
+  another configured provider exposes the same raw model ID, select Kilo
+  explicitly with `kilo/anthropic/claude-sonnet-4.5`; GoModel removes only the
+  outer `kilo/` routing qualifier before forwarding.
 - **Xiaomi MiMo** — TTS (`mimo-v2.5-tts*`) and ASR (`mimo-v2.5-asr`) are served
   through `/v1/audio/speech` and `/v1/audio/transcriptions` (translated to
   MiMo's chat-completions audio dialect) as well as directly via chat
@@ -130,7 +137,7 @@ These are the providers most users hit friction on:
 </Tip>
 
 Providers without a dedicated page (OpenAI, Groq, Fireworks AI, Meta,
-OpenRouter, Z.ai, xAI, MiniMax) follow the same pattern: set the API key (and
+OpenRouter, Kilo AI, Z.ai, xAI, MiniMax) follow the same pattern: set the API key (and
 optional base URL where supported), start GoModel, route by model ID. The full env-var reference
 lives in [Configuration](/advanced/configuration).
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gomodel
-description: High-performance AI gateway for multiple LLM providers (OpenAI, Anthropic, Gemini, DeepSeek, Groq, Z.ai, xAI)
+description: High-performance AI gateway for multiple LLM providers (OpenAI, Anthropic, Gemini, DeepSeek, Groq, Kilo AI, Z.ai, xAI)
 type: application
 version: 0.1.0
 appVersion: "1.0.0"

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # GoModel Helm Chart
 
-High-performance AI gateway for multiple LLM providers (OpenAI, Anthropic, Gemini, DeepSeek, Groq, Z.ai, xAI, Oracle).
+High-performance AI gateway for multiple LLM providers (OpenAI, Anthropic, Gemini, DeepSeek, Groq, Kilo AI, Z.ai, xAI, Oracle).
 
 ## Prerequisites
 
@@ -64,6 +64,8 @@ helm install gomodel ./helm \
 | `providers.xai.enabled`          | Enable xAI                                                                                     | `false`                |
 | `providers.zai.enabled`          | Enable Z.ai                                                                                    | `false`                |
 | `providers.zai.baseUrl`          | Optional Z.ai base URL mapped to `ZAI_BASE_URL`; use Coding Plan endpoint when needed          | `""`                   |
+| `providers.kilo.enabled`         | Enable Kilo AI                                                                                  | `false`                |
+| `providers.kilo.baseUrl`         | Optional Kilo AI Gateway base URL mapped to `KILO_BASE_URL`                                    | `""`                   |
 | `providers.oracle.enabled`       | Enable Oracle                                                                                  | `false`                |
 | `providers.oracle.baseUrl`       | Oracle OpenAI-compatible base URL mapped to `ORACLE_BASE_URL`; required when Oracle is enabled | `""`                   |
 | `providers.vllm.enabled`         | Enable vLLM                                                                                    | `false`                |
@@ -92,6 +94,7 @@ stringData:
   ANTHROPIC_API_KEY: "sk-ant-..."
   GEMINI_API_KEY: "..."
   ZAI_API_KEY: "..."
+  KILO_API_KEY: "..."
   ORACLE_API_KEY: "..."
   VLLM_API_KEY: "..."
 ```

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -189,6 +189,17 @@
       "properties": {
         "providers": {
           "properties": {
+            "kilo": {
+              "properties": { "apiKey": { "minLength": 1 } }
+            }
+          }
+        }
+      }
+    },
+    {
+      "properties": {
+        "providers": {
+          "properties": {
             "oracle": {
               "properties": {
                 "apiKey": { "minLength": 1 },
@@ -276,6 +287,14 @@
           }
         },
         "zai": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "apiKey": { "type": "string" },
+            "baseUrl": { "type": "string" }
+          }
+        },
+        "kilo": {
           "type": "object",
           "properties": {
             "enabled": { "type": "boolean" },

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -42,7 +42,7 @@ auth:
 # LLM Provider configuration
 providers:
   # -- Use an existing secret for all provider API keys
-  # Secret should contain keys: OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, GROQ_API_KEY, XAI_API_KEY, ZAI_API_KEY, ORACLE_API_KEY, VLLM_API_KEY
+  # Secret should contain keys: OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, GROQ_API_KEY, XAI_API_KEY, ZAI_API_KEY, KILO_API_KEY, ORACLE_API_KEY, VLLM_API_KEY
   existingSecret: ""
 
   openai:
@@ -93,6 +93,14 @@ providers:
     # -- Z.ai API key (ignored if providers.existingSecret is set)
     apiKey: ""
     # -- Optional: Override Z.ai base URL; use https://api.z.ai/api/coding/paas/v4 for GLM Coding Plan
+    baseUrl: ""
+
+  kilo:
+    # -- Enable Kilo AI provider (auto-enabled if apiKey is set)
+    enabled: false
+    # -- Kilo AI API key (ignored if providers.existingSecret is set)
+    apiKey: ""
+    # -- Optional: Override Kilo AI Gateway base URL
     baseUrl: ""
 
   oracle:

--- a/internal/providers/config_test.go
+++ b/internal/providers/config_test.go
@@ -41,6 +41,9 @@ var testDiscoveryConfigs = map[string]DiscoveryConfig{
 	"openrouter": {
 		DefaultBaseURL: "https://openrouter.ai/api/v1",
 	},
+	"kilo": {
+		DefaultBaseURL: "https://api.kilo.ai/api/gateway",
+	},
 	"zai": {
 		DefaultBaseURL: "https://api.z.ai/api/paas/v4",
 	},
@@ -506,6 +509,26 @@ func TestApplyProviderEnvVars_DiscoversOpenRouterFromAPIKey(t *testing.T) {
 	}
 	if p.BaseURL != testDiscoveryConfigs["openrouter"].DefaultBaseURL {
 		t.Errorf("BaseURL = %q, want %q", p.BaseURL, testDiscoveryConfigs["openrouter"].DefaultBaseURL)
+	}
+}
+
+func TestApplyProviderEnvVars_DiscoversKiloFromAPIKey(t *testing.T) {
+	t.Setenv("KILO_API_KEY", "kilo-key")
+
+	got := applyProviderEnvVars(map[string]config.RawProviderConfig{}, testDiscoveryConfigs)
+
+	p, exists := got["kilo"]
+	if !exists {
+		t.Fatal("expected kilo to be discovered from env var")
+	}
+	if p.APIKey != "kilo-key" {
+		t.Errorf("APIKey = %q, want kilo-key", p.APIKey)
+	}
+	if p.Type != "kilo" {
+		t.Errorf("Type = %q, want kilo", p.Type)
+	}
+	if p.BaseURL != testDiscoveryConfigs["kilo"].DefaultBaseURL {
+		t.Errorf("BaseURL = %q, want %q", p.BaseURL, testDiscoveryConfigs["kilo"].DefaultBaseURL)
 	}
 }
 

--- a/internal/providers/kilo/kilo.go
+++ b/internal/providers/kilo/kilo.go
@@ -1,0 +1,55 @@
+// Package kilo provides Kilo AI Gateway integration for the LLM gateway.
+package kilo
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/llmclient"
+	"github.com/enterpilot/gomodel/internal/providers"
+	"github.com/enterpilot/gomodel/internal/providers/openai"
+)
+
+const defaultBaseURL = "https://api.kilo.ai/api/gateway"
+
+// Registration provides factory registration for the Kilo AI provider.
+var Registration = providers.Registration{
+	Type:                        "kilo",
+	New:                         New,
+	PassthroughSemanticEnricher: passthroughSemanticEnricher,
+	Discovery: providers.DiscoveryConfig{
+		DefaultBaseURL: defaultBaseURL,
+	},
+}
+
+// Provider implements the core.Provider interface for Kilo AI. Kilo exposes
+// OpenAI-compatible chat completions, streaming, tool calling, and model
+// listing. Its provider/model IDs pass through unchanged.
+type Provider struct {
+	*openai.ChatCompatible
+}
+
+var _ core.Provider = (*Provider)(nil)
+
+// New creates a new Kilo AI provider.
+func New(cfg providers.ProviderConfig, opts providers.ProviderOptions) core.Provider {
+	return &Provider{openai.NewChatCompatible(cfg.APIKey, opts, openai.CompatibleProviderConfig{
+		ProviderName: "kilo",
+		BaseURL:      providers.ResolveBaseURL(cfg.BaseURL, defaultBaseURL),
+	})}
+}
+
+// NewWithHTTPClient creates a new Kilo AI provider with a custom HTTP client.
+// If httpClient is nil, http.DefaultClient is used.
+func NewWithHTTPClient(apiKey, baseURL string, httpClient *http.Client, hooks llmclient.Hooks) *Provider {
+	return &Provider{openai.NewChatCompatibleWithHTTPClient(apiKey, httpClient, hooks, openai.CompatibleProviderConfig{
+		ProviderName: "kilo",
+		BaseURL:      providers.ResolveBaseURL(baseURL, defaultBaseURL),
+	})}
+}
+
+// Embeddings returns an error because Kilo AI does not expose an embeddings endpoint.
+func (p *Provider) Embeddings(_ context.Context, _ *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	return nil, core.NewInvalidRequestError("kilo does not support embeddings", nil)
+}

--- a/internal/providers/kilo/kilo_test.go
+++ b/internal/providers/kilo/kilo_test.go
@@ -1,0 +1,164 @@
+package kilo
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/llmclient"
+)
+
+func TestChatCompletion_UsesBearerAuthAndPreservesModelAndTools(t *testing.T) {
+	var gotPath string
+	var gotAuth string
+	var gotBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			http.Error(w, "decode error", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-kilo",
+			"created":1677652288,
+			"model":"anthropic/claude-sonnet-4.5",
+			"choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"lookup","arguments":"{}"}}]},"finish_reason":"tool_calls"}],
+			"usage":{"prompt_tokens":10,"completion_tokens":2,"total_tokens":12}
+		}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("kilo-key", server.URL, server.Client(), llmclient.Hooks{})
+	resp, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{
+		Model:    "anthropic/claude-sonnet-4.5",
+		Messages: []core.Message{{Role: "user", Content: "Use the tool"}},
+		Tools: []map[string]any{{
+			"type": "function",
+			"function": map[string]any{
+				"name":       "lookup",
+				"parameters": map[string]any{"type": "object"},
+			},
+		}},
+		ToolChoice: "auto",
+	})
+	if err != nil {
+		t.Fatalf("ChatCompletion() error = %v", err)
+	}
+	if gotPath != "/chat/completions" {
+		t.Fatalf("path = %q, want /chat/completions", gotPath)
+	}
+	if gotAuth != "Bearer kilo-key" {
+		t.Fatalf("authorization = %q, want Bearer kilo-key", gotAuth)
+	}
+	if gotBody["model"] != "anthropic/claude-sonnet-4.5" {
+		t.Fatalf("request model = %#v, want slash-delimited model unchanged", gotBody["model"])
+	}
+	if gotBody["tool_choice"] != "auto" {
+		t.Fatalf("tool_choice = %#v, want auto", gotBody["tool_choice"])
+	}
+	tools, ok := gotBody["tools"].([]any)
+	if !ok || len(tools) != 1 {
+		t.Fatalf("tools = %#v, want one tool", gotBody["tools"])
+	}
+	if resp.Model != "anthropic/claude-sonnet-4.5" || len(resp.Choices) != 1 || len(resp.Choices[0].Message.ToolCalls) != 1 {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+func TestStreamChatCompletion_UsesSSEAndPreservesStreamOptions(t *testing.T) {
+	var gotPath string
+	var gotAuth string
+	var gotBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			http.Error(w, "decode error", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"id\":\"chatcmpl-kilo\",\"object\":\"chat.completion.chunk\",\"choices\":[]}\n\ndata: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("kilo-key", server.URL, server.Client(), llmclient.Hooks{})
+	stream, err := provider.StreamChatCompletion(context.Background(), &core.ChatRequest{
+		Model:         "openai/gpt-5.5",
+		Messages:      []core.Message{{Role: "user", Content: "hi"}},
+		StreamOptions: &core.StreamOptions{IncludeUsage: true},
+	})
+	if err != nil {
+		t.Fatalf("StreamChatCompletion() error = %v", err)
+	}
+	defer stream.Close()
+	body, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if gotPath != "/chat/completions" || gotAuth != "Bearer kilo-key" {
+		t.Fatalf("request path/auth = %q/%q", gotPath, gotAuth)
+	}
+	if gotBody["model"] != "openai/gpt-5.5" || gotBody["stream"] != true {
+		t.Fatalf("stream request body = %#v", gotBody)
+	}
+	streamOptions, ok := gotBody["stream_options"].(map[string]any)
+	if !ok || streamOptions["include_usage"] != true {
+		t.Fatalf("stream_options = %#v, want include_usage=true", gotBody["stream_options"])
+	}
+	if !strings.Contains(string(body), "data: [DONE]") {
+		t.Fatalf("stream body = %q, want SSE terminator", body)
+	}
+}
+
+func TestListModels_PreservesProviderQualifiedIDs(t *testing.T) {
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"google/gemini-3.1-pro","object":"model","owned_by":"google"}]}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("kilo-key", server.URL, server.Client(), llmclient.Hooks{})
+	resp, err := provider.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels() error = %v", err)
+	}
+	if gotPath != "/models" {
+		t.Fatalf("path = %q, want /models", gotPath)
+	}
+	if len(resp.Data) != 1 || resp.Data[0].ID != "google/gemini-3.1-pro" {
+		t.Fatalf("models = %+v, want provider-qualified Kilo model", resp.Data)
+	}
+}
+
+func TestEmbeddings_ReturnsUnsupportedError(t *testing.T) {
+	provider := NewWithHTTPClient("kilo-key", "", nil, llmclient.Hooks{})
+	_, err := provider.Embeddings(context.Background(), &core.EmbeddingRequest{Model: "any"})
+	if err == nil || !strings.Contains(err.Error(), "kilo does not support embeddings") {
+		t.Fatalf("Embeddings() error = %v, want unsupported error", err)
+	}
+}
+
+func TestProvider_DoesNotExposeOptionalOpenAICompatibleInterfaces(t *testing.T) {
+	provider := NewWithHTTPClient("kilo-key", "", nil, llmclient.Hooks{})
+
+	if _, ok := any(provider).(core.NativeBatchProvider); ok {
+		t.Fatal("kilo provider should not implement native batch provider")
+	}
+	if _, ok := any(provider).(core.NativeFileProvider); ok {
+		t.Fatal("kilo provider should not implement native file provider")
+	}
+	if _, ok := any(provider).(core.AudioProvider); ok {
+		t.Fatal("kilo provider should not implement audio provider")
+	}
+}

--- a/internal/providers/kilo/passthrough_semantics.go
+++ b/internal/providers/kilo/passthrough_semantics.go
@@ -1,0 +1,7 @@
+package kilo
+
+import "github.com/enterpilot/gomodel/internal/providers"
+
+var passthroughSemanticEnricher = providers.NewSemanticEnricher("kilo", map[string]providers.PassthroughEndpointSemantics{
+	"/chat/completions": {Operation: "kilo.chat_completions", AuditPath: "/v1/chat/completions"},
+})

--- a/internal/providers/kilo/passthrough_semantics_test.go
+++ b/internal/providers/kilo/passthrough_semantics_test.go
@@ -1,0 +1,24 @@
+package kilo
+
+import (
+	"testing"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+func TestPassthroughSemanticEnricher(t *testing.T) {
+	if got := passthroughSemanticEnricher.ProviderType(); got != "kilo" {
+		t.Fatalf("ProviderType() = %q, want kilo", got)
+	}
+
+	got := passthroughSemanticEnricher.Enrich(nil, nil, &core.PassthroughRouteInfo{
+		RawEndpoint:        "v1/chat/completions",
+		NormalizedEndpoint: "chat/completions",
+	})
+	if got == nil {
+		t.Fatal("Enrich() returned nil")
+	}
+	if got.SemanticOperation != "kilo.chat_completions" || got.AuditPath != "/v1/chat/completions" {
+		t.Fatalf("enriched info = %+v", got)
+	}
+}

--- a/run/providers.go
+++ b/run/providers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/enterpilot/gomodel/internal/providers/fireworks"
 	"github.com/enterpilot/gomodel/internal/providers/gemini"
 	"github.com/enterpilot/gomodel/internal/providers/groq"
+	"github.com/enterpilot/gomodel/internal/providers/kilo"
 	"github.com/enterpilot/gomodel/internal/providers/kimicode"
 	"github.com/enterpilot/gomodel/internal/providers/meta"
 	"github.com/enterpilot/gomodel/internal/providers/minimax"
@@ -48,6 +49,7 @@ func defaultProviderFactory(cfg *config.Config) *providers.ProviderFactory {
 	factory.Add(gemini.Registration)
 	factory.Add(vertex.Registration)
 	factory.Add(groq.Registration)
+	factory.Add(kilo.Registration)
 	factory.Add(kimicode.Registration)
 	factory.Add(meta.Registration)
 	factory.Add(minimax.Registration)

--- a/run/providers_test.go
+++ b/run/providers_test.go
@@ -10,7 +10,7 @@ import (
 func TestDefaultProviderFactoryRegistersAllProviderTypes(t *testing.T) {
 	expected := []string{
 		"anthropic", "azure", "bailian", "bedrock", "deepseek", "fireworks",
-		"gemini", "groq", "kimicode", "meta", "minimax", "ollama", "openai", "opencode_go",
+		"gemini", "groq", "kilo", "kimicode", "meta", "minimax", "ollama", "openai", "opencode_go",
 		"openrouter", "oracle", "vertex", "vllm", "xai", "xiaomi", "zai",
 	}
 


### PR DESCRIPTION
## Summary

- add Kilo AI as a native OpenAI-compatible provider using the shared chat transport
- support bearer authentication, chat completions, SSE streaming, tool calling, model discovery, Responses-via-chat, and passthrough
- preserve Kilo provider/model IDs unchanged and support explicit kilo/provider/model routing when model IDs overlap
- auto-discover the provider from KILO_API_KEY with optional KILO_BASE_URL and KILO_MODELS
- document Kilo configuration across the provider overview, quickstart, advanced configuration, examples, OpenAPI metadata, and Helm chart

## Compatibility

Kilo's documented gateway does not expose embeddings, files, batches, or audio endpoints, so the provider deliberately does not advertise those optional capabilities. GoModel translates Responses API calls through Kilo chat completions.

## Validation

- go test ./...
- make test-race
- make lint
- make fix-check
- helm lint ./helm --set providers.kilo.apiKey=test-key --set redis.enabled=false
- mint validate

Closes #537


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kilo AI Gateway as a supported provider for chat completions, streaming, model discovery, passthrough routing, and tool use.
  * Added configuration options for Kilo API credentials, base URL, and optional model allowlists.
  * Added Helm chart support for enabling and configuring Kilo AI.
  * Added Model Studio (Bailian) to the supported provider list.

* **Documentation**
  * Updated setup guides, provider references, API documentation, and configuration examples with Kilo AI details.
  * Documented Kilo’s model routing format and feature limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->