### PR TITLE
feat(mcp): publish server.json to the official MCP registry on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,3 +181,33 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release edit "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --draft=false --verify-tag
+
+  publish-mcp:
+    name: Publish to MCP Registry
+    runs-on: ubuntu-latest
+    # Registry verification pulls the versioned Docker Hub image, so the tag must exist first
+    needs: docker-promote
+    permissions:
+      id-token: write # GitHub OIDC grants the io.github.enterpilot/* namespace
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install mcp-publisher
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Set release version in server.json
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          jq --arg v "$version" \
+            '.version = $v | .packages[0].identifier = "docker.io/enterpilot/gomodel:" + $v' \
+            server.json > server.json.tmp && mv server.json.tmp server.json
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server to MCP Registry
+        run: ./mcp-publisher publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,16 +187,25 @@ jobs:
     runs-on: ubuntu-latest
     # Registry verification pulls the versioned Docker Hub image, so the tag must exist first
     needs: docker-promote
+    # Best-effort: a registry outage must not fail the release
+    continue-on-error: true
     permissions:
       id-token: write # GitHub OIDC grants the io.github.enterpilot/* namespace
       contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install mcp-publisher
+        env:
+          PUBLISHER_VERSION: v1.8.0
+          PUBLISHER_SHA256: 1370446bbe74d562608e8005a6ccce02d146a661fbd78674e11cc70b9618d6cf
         run: |
-          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          curl -fsSL -o mcp-publisher.tar.gz "https://github.com/modelcontextprotocol/registry/releases/download/${PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz"
+          echo "${PUBLISHER_SHA256}  mcp-publisher.tar.gz" | sha256sum -c -
+          tar xzf mcp-publisher.tar.gz mcp-publisher
 
       - name: Set release version in server.json
         shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,9 @@ RUN mkdir -p /app/.cache /app/data && touch /app/.cache/.keep /app/data/.keep
 # Runtime stage
 FROM gcr.io/distroless/static-debian12:nonroot
 
+# Ownership proof for the MCP Registry; must match the name in server.json
+LABEL io.modelcontextprotocol.server.name="io.github.enterpilot/gomodel"
+
 # Copy binary and runtime config
 COPY --from=builder /gomodel /gomodel
 COPY --from=builder /app/config/*.yaml /app/config/

--- a/server.json
+++ b/server.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.enterpilot/gomodel",
+  "title": "GoModel",
+  "description": "Self-hosted gateway aggregating upstream MCP servers behind one authenticated HTTP endpoint.",
+  "repository": {
+    "url": "https://github.com/ENTERPILOT/GoModel",
+    "source": "github"
+  },
+  "version": "0.1.52",
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "docker.io/enterpilot/gomodel:0.1.52",
+      "runtimeHint": "docker",
+      "transport": {
+        "type": "streamable-http",
+        "url": "http://localhost:8080/mcp"
+      },
+      "environmentVariables": [
+        {
+          "name": "GOMODEL_MASTER_KEY",
+          "description": "Gateway API key clients authenticate with; unset runs the gateway in unsafe (no-auth) mode.",
+          "isRequired": false,
+          "isSecret": true
+        },
+        {
+          "name": "MCP_SERVERS",
+          "description": "JSON object of upstream MCP servers to aggregate, e.g. {\"github\":{\"url\":\"https://api.githubcopilot.com/mcp/\",\"headers\":{\"Authorization\":\"Bearer ${GITHUB_PAT}\"}}}. Servers can also be declared in config.yaml or the admin dashboard.",
+          "isRequired": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Registers GoModel's MCP gateway in the [official MCP Registry](https://registry.modelcontextprotocol.io) (the app-store feed consumed by MCP clients) as `io.github.enterpilot/gomodel`.

The registry is not PR-based — listing happens by publishing a `server.json` with the `mcp-publisher` CLI. This PR wires that up so every release publishes automatically:

- **`server.json`** — registry metadata: OCI package `docker.io/enterpilot/gomodel:<version>`, streamable HTTP transport at `http://localhost:8080/mcp`, and the `GOMODEL_MASTER_KEY` / `MCP_SERVERS` env vars surfaced for configuration. Validated against the official 2025-12-11 schema.
- **`Dockerfile`** — adds the `io.modelcontextprotocol.server.name` LABEL, which is how the registry verifies we own the Docker Hub image (it must match the `server.json` name).
- **`release.yml`** — new `publish-mcp` job, `needs: docker-promote` (verification pulls the versioned image from Docker Hub, so the tag must exist first). Auth is GitHub OIDC — publishing from this repo's CI grants the `io.github.enterpilot/*` namespace, no secrets to manage. The job stamps the tag version into `server.json` before publishing.

## User-visible impact

None at runtime. From the next release (v0.1.53+), GoModel appears in the MCP registry and downstream aggregators (client pickers, mcp.so, etc. consume the registry feed).

## Notes

- The registry is in preview; failures in `publish-mcp` don't block the rest of the release (parallel to `goreleaser`/`github-release`).
- First publish must come from CI on a tag — OIDC namespace ownership is tied to this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic publishing of the release server artifact to the Model Context Protocol (MCP) registry.
  * Introduced `server.json` with MCP server metadata, transport settings, and runtime configuration for the GoModel gateway.
  * Added configurable support for a gateway master key and aggregation of upstream MCP servers.
* **Documentation**
  * Documented the required match between the container image label and MCP server naming.
* **Chores**
  * MCP registry publishing is non-blocking if the registry is temporarily unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->