### PR TITLE
docs: mark dashboard cache visibility as shipped on the roadmap

### DIFF
--- a/docs/about/roadmap.mdx
+++ b/docs/about/roadmap.mdx
@@ -12,7 +12,7 @@ icon: "list-todo"
 
 ## Roadmap to 0.2.0
 
-- [ ] UI visibility for prompt caching and local cache usage
+- [x] UI visibility for prompt caching and local cache usage
 - [ ] Broader provider support, including Cohere, Command A, and Operational
 - [ ] Full support for the OpenAI `/conversations` lifecycle
 - [ ] Guardrails hardening: better UI, simpler architecture, easier custom guardrails, and response-side guardrails before output reaches the client


### PR DESCRIPTION
## Summary
- Ticks "UI visibility for prompt caching and local cache usage" in the 0.2.0 milestone of docs/about/roadmap.mdx - the dashboard cache view is delivered, and the marketing site's roadmap section already shows it as shipped (7 of 11 milestone items done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the roadmap to mark UI visibility for prompt caching and local cache usage as completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->