### PR TITLE
docs(install): lead with the one-line installer in README and quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,28 @@
   <img src="docs/2026-07-07_demo.gif" alt="GoModel AI gateway dashboard showing AI usage analytics, observability panel, token and costs tracking, and estimated cost monitoring" width="100%">
 </a>
 
-## Quick Start with Docker
+## Quick Start
 
-**Step 1:** Start GoModel container
+**Step 1:** Install and start GoModel
+
+**macOS / Linux**
+
+```bash
+curl -fsSL https://gomodel.enterpilot.io/install.sh | sh
+OPENAI_API_KEY="your-openai-key" gomodel
+```
+
+**Windows (PowerShell)**
+
+```powershell
+irm https://gomodel.enterpilot.io/install.ps1 | iex
+$env:OPENAI_API_KEY = "your-openai-key"; gomodel
+```
+
+The installer downloads the latest release binary, verifies its checksum, and
+puts `gomodel` on your PATH.
+
+**Docker**
 
 ```bash
 docker run --rm -p 8080:8080 \

--- a/README.md
+++ b/README.md
@@ -48,9 +48,6 @@ irm https://gomodel.enterpilot.io/install.ps1 | iex
 $env:OPENAI_API_KEY = "your-openai-key"; gomodel
 ```
 
-The installer downloads the latest release binary, verifies its checksum, and
-puts `gomodel` on your PATH.
-
 **Docker**
 
 ```bash
@@ -176,7 +173,3 @@ See the [Roadmap](./docs/about/roadmap.mdx) for commercial features and the publ
 ## Community
 
 Join our [Discord](https://discord.gg/gaEB9BQSPH) to connect with other GoModel users.
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=enterpilot/gomodel&type=date&legend=top-left)](https://www.star-history.com/#enterpilot/gomodel&type=date&legend=top-left)

--- a/README.md
+++ b/README.md
@@ -52,10 +52,7 @@ $env:OPENAI_API_KEY = "your-openai-key"; gomodel
 
 ```bash
 docker run --rm -p 8080:8080 \
-  -e LOGGING_ENABLED=true \
-  -e LOGGING_LOG_BODIES=true \
   -e LOG_FORMAT=text \
-  -e LOGGING_LOG_HEADERS=true \
   -e OPENAI_API_KEY="your-openai-key" \
   enterpilot/gomodel
 ```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,8 +21,7 @@ services:
       - POSTGRES_URL=postgres://gomodel:gomodel@postgres:5432/gomodel
       # MongoDB configuration (uncomment to use MongoDB instead)
       - MONGODB_URL=mongodb://mongodb:27017/gomodel
-      # Audit logging - all enabled with PostgreSQL
-      - LOGGING_ENABLED=true
+      # Audit logging is enabled by default; pick its storage backend below
       # - STORAGE_TYPE=postgresql
       - STORAGE_TYPE=mongodb
     depends_on:

--- a/docs/advanced/admin-endpoints.mdx
+++ b/docs/advanced/admin-endpoints.mdx
@@ -128,8 +128,8 @@ Returns an empty array if usage tracking is disabled or no data exists for the p
 Returns time-bucketed request counts grouped into `2xx`/`4xx`/`5xx` status
 classes, an overall success-rate summary, and average request duration per
 provider. This powers the "Requests by Status" and "Provider Latency" charts on
-the dashboard's Overview page. Data comes from the audit log, so it requires
-`LOGGING_ENABLED=true`.
+the dashboard's Overview page. Data comes from the audit log (audit logging is enabled by default;
+`LOGGING_ENABLED`).
 
 **Query parameters:**
 

--- a/docs/features/labelling.mdx
+++ b/docs/features/labelling.mdx
@@ -97,8 +97,8 @@ routes; translated routes never forward client headers anyway.
   each of them.
 - **Request log** — label chips per request, filterable with the `label` query
   param on `GET /admin/usage/log`.
-- **Audit logs** — recorded under `data.labels` on each entry (requires
-  `LOGGING_ENABLED=true`).
+- **Audit logs** — recorded under `data.labels` on each entry (audit logging is enabled
+  by default).
 - **API keys page** — each key's labels are listed alongside its user path.
 
 ## Defaults

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -29,10 +29,7 @@ admin visibility in one place.
   <Tab title="Docker">
     ```bash
     docker run --rm -p 8080:8080 \
-      -e LOGGING_ENABLED=true \
-      -e LOGGING_LOG_BODIES=true \
       -e LOG_FORMAT=text \
-      -e LOGGING_LOG_HEADERS=true \
       -e GOMODEL_MASTER_KEY="change-me" \
       -e OPENAI_API_KEY="sk-..." \
       enterpilot/gomodel

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -19,20 +19,12 @@ admin visibility in one place.
     curl -fsSL https://gomodel.enterpilot.io/install.sh | sh
     GOMODEL_MASTER_KEY="change-me" OPENAI_API_KEY="sk-..." gomodel
     ```
-
-    The installer downloads the latest release binary for your platform,
-    verifies its SHA-256 checksum, and installs it to `/usr/local/bin` (or
-    `~/.local/bin` when that is not writable).
   </Tab>
   <Tab title="Windows">
     ```powershell
     irm https://gomodel.enterpilot.io/install.ps1 | iex
     $env:GOMODEL_MASTER_KEY = "change-me"; $env:OPENAI_API_KEY = "sk-..."; gomodel
     ```
-
-    The installer downloads the latest release, verifies its SHA-256
-    checksum, installs `gomodel.exe` to `%LOCALAPPDATA%\Programs\gomodel`,
-    and adds it to your user PATH (restart the terminal to pick it up).
   </Tab>
   <Tab title="Docker">
     ```bash

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -11,18 +11,42 @@ route traffic across OpenAI, Anthropic, Gemini, DeepSeek, xAI, Groq, OpenRouter,
 Z.ai, Azure OpenAI, Oracle GenAI, Ollama, and more while keeping auth, audit logs, and
 admin visibility in one place.
 
-### 1. Start GoModel
+### 1. Install and start GoModel
 
-```bash
-docker run --rm -p 8080:8080 \
-  -e LOGGING_ENABLED=true \
-  -e LOGGING_LOG_BODIES=true \
-  -e LOG_FORMAT=text \
-  -e LOGGING_LOG_HEADERS=true \
-  -e GOMODEL_MASTER_KEY="change-me" \
-  -e OPENAI_API_KEY="sk-..." \
-  enterpilot/gomodel
-```
+<Tabs>
+  <Tab title="macOS / Linux">
+    ```bash
+    curl -fsSL https://gomodel.enterpilot.io/install.sh | sh
+    GOMODEL_MASTER_KEY="change-me" OPENAI_API_KEY="sk-..." gomodel
+    ```
+
+    The installer downloads the latest release binary for your platform,
+    verifies its SHA-256 checksum, and installs it to `/usr/local/bin` (or
+    `~/.local/bin` when that is not writable).
+  </Tab>
+  <Tab title="Windows">
+    ```powershell
+    irm https://gomodel.enterpilot.io/install.ps1 | iex
+    $env:GOMODEL_MASTER_KEY = "change-me"; $env:OPENAI_API_KEY = "sk-..."; gomodel
+    ```
+
+    The installer downloads the latest release, verifies its SHA-256
+    checksum, installs `gomodel.exe` to `%LOCALAPPDATA%\Programs\gomodel`,
+    and adds it to your user PATH (restart the terminal to pick it up).
+  </Tab>
+  <Tab title="Docker">
+    ```bash
+    docker run --rm -p 8080:8080 \
+      -e LOGGING_ENABLED=true \
+      -e LOGGING_LOG_BODIES=true \
+      -e LOG_FORMAT=text \
+      -e LOGGING_LOG_HEADERS=true \
+      -e GOMODEL_MASTER_KEY="change-me" \
+      -e OPENAI_API_KEY="sk-..." \
+      enterpilot/gomodel
+    ```
+  </Tab>
+</Tabs>
 
 <Note>
   Set at least one provider credential or base URL


### PR DESCRIPTION
## Summary
Makes the one-line installer (#549, live at gomodel.enterpilot.io/install.sh) the primary documented install method:

- **README "Quick Start"** (renamed from "Quick Start with Docker"): Step 1 now offers three labeled options in order - macOS/Linux one-liner, Windows PowerShell one-liner, Docker (existing command and env-file warning unchanged). GitHub markdown has no tabs, so ordering carries the message.
- **docs quickstart**: the same three methods as a Mintlify `<Tabs>` block, each with a short note on what the installer does (checksum verification, install location, PATH).

## Deliberately out of scope
The ~14 other `docker run` snippets in guides/provider pages are contextual env-var illustrations, not install instructions - converting them to tabs would triple their length without communicating anything new. The two entry points above are where install-method choice actually happens.

## User-visible impact
New users see the fastest path first; Docker remains fully documented one scroll below / one tab over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Quick Start to a cross-platform setup with separate macOS/Linux and Windows commands, plus an optional Docker subsection.
  * Revised the Quick Start layout to use tabs for clearer platform-specific guidance.
  * Removed the README “Star History” section.
  * Updated admin audit stats and labeling docs to reflect that audit logging is enabled by default (no longer tied to a specific logging flag).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Also folded in (from closed #556)
`LOGGING_ENABLED` / `LOGGING_LOG_BODIES` / `LOGGING_LOG_HEADERS` default to `true` since #554, so every quickstart-style command stops setting them (README, docs quickstart, docker-compose); prose saying audit data "requires `LOGGING_ENABLED=true`" now says it is on by default. `LOG_FORMAT=text` stays - containers auto-detect to JSON without it. Conditional "when `LOGGING_LOG_BODIES=true`" references and the release-e2e harness pins are deliberately untouched.

Additionally per review: installer explainer notes trimmed (the PATH claim overstated what install.sh does), and the broken star-history chart (endpoint 404s) removed from the README.
