### PR TITLE
docs: drop audit-logging flags that are now defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,7 @@
 
 ```bash
 docker run --rm -p 8080:8080 \
-  -e LOGGING_ENABLED=true \
-  -e LOGGING_LOG_BODIES=true \
   -e LOG_FORMAT=text \
-  -e LOGGING_LOG_HEADERS=true \
   -e OPENAI_API_KEY="your-openai-key" \
   enterpilot/gomodel
 ```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,8 +21,7 @@ services:
       - POSTGRES_URL=postgres://gomodel:gomodel@postgres:5432/gomodel
       # MongoDB configuration (uncomment to use MongoDB instead)
       - MONGODB_URL=mongodb://mongodb:27017/gomodel
-      # Audit logging - all enabled with PostgreSQL
-      - LOGGING_ENABLED=true
+      # Audit logging is enabled by default; pick its storage backend below
       # - STORAGE_TYPE=postgresql
       - STORAGE_TYPE=mongodb
     depends_on:

--- a/docs/advanced/admin-endpoints.mdx
+++ b/docs/advanced/admin-endpoints.mdx
@@ -128,8 +128,8 @@ Returns an empty array if usage tracking is disabled or no data exists for the p
 Returns time-bucketed request counts grouped into `2xx`/`4xx`/`5xx` status
 classes, an overall success-rate summary, and average request duration per
 provider. This powers the "Requests by Status" and "Provider Latency" charts on
-the dashboard's Overview page. Data comes from the audit log, so it requires
-`LOGGING_ENABLED=true`.
+the dashboard's Overview page. Data comes from the audit log (audit logging is enabled by default;
+`LOGGING_ENABLED`).
 
 **Query parameters:**
 

--- a/docs/features/labelling.mdx
+++ b/docs/features/labelling.mdx
@@ -97,8 +97,8 @@ routes; translated routes never forward client headers anyway.
   each of them.
 - **Request log** — label chips per request, filterable with the `label` query
   param on `GET /admin/usage/log`.
-- **Audit logs** — recorded under `data.labels` on each entry (requires
-  `LOGGING_ENABLED=true`).
+- **Audit logs** — recorded under `data.labels` on each entry (audit logging is enabled
+  by default).
 - **API keys page** — each key's labels are listed alongside its user path.
 
 ## Defaults

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -15,10 +15,7 @@ admin visibility in one place.
 
 ```bash
 docker run --rm -p 8080:8080 \
-  -e LOGGING_ENABLED=true \
-  -e LOGGING_LOG_BODIES=true \
   -e LOG_FORMAT=text \
-  -e LOGGING_LOG_HEADERS=true \
   -e GOMODEL_MASTER_KEY="change-me" \
   -e OPENAI_API_KEY="sk-..." \
   enterpilot/gomodel


### PR DESCRIPTION
## Summary
Follow-up to #554: `LOGGING_ENABLED`, `LOGGING_LOG_BODIES`, and `LOGGING_LOG_HEADERS` default to `true` now, so every quickstart-style command stops setting them:

- **README** and **docs quickstart**: docker commands shrink to `LOG_FORMAT=text` + keys (`LOG_FORMAT` stays - containers still auto-detect to JSON without it).
- **docker-compose.yaml**: redundant `LOGGING_ENABLED=true` env removed, comment updated.
- **admin-endpoints / labelling docs**: "requires `LOGGING_ENABLED=true`" prose updated to "enabled by default".

## Deliberately untouched
- Conditional references ("when `LOGGING_LOG_BODIES=true`") in code comments, OpenAPI descriptions, and the MCP docs - they name the gating flag, which is still accurate.
- `tests/e2e/manage-release-e2e-stack.sh` - the release-QA harness pins env explicitly because it runs across releases, including ones predating the new defaults.

## Merge order
#553 also touches the README/quickstart install sections; whichever merges second, I'll rebase the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Quick Start and Docker examples to use simplified logging configuration.
  - Clarified that audit logging is enabled by default and no longer requires an explicit enablement setting.
  - Updated audit statistics documentation to reflect default audit-log availability.
  - Clarified that label information is recorded in `data.labels` by default.
  - Retained storage backend configuration guidance for Docker Compose deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->