### PR TITLE
feat(demo): add environment-controlled demo mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ run:
 
 # Seed the local SQLite database and start GoModel with a populated dashboard.
 demo: seed-demo-data
-	$(MAKE) run
+	$(MAKE) run GOMODEL_DEMO_MODEL=true
 
 # Clean build artifacts
 clean:

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ run:
 
 # Seed the local SQLite database and start GoModel with a populated dashboard.
 demo: seed-demo-data
-	$(MAKE) run GOMODEL_DEMO_MODEL=true
+	$(MAKE) run GOMODEL_DEMO_MODE=true
 
 # Clean build artifacts
 clean:

--- a/cmd/gomodel/docs/docs.go
+++ b/cmd/gomodel/docs/docs.go
@@ -5828,6 +5828,9 @@ const docTemplate = `{
                 "DASHBOARD_LIVE_LOGS_ENABLED": {
                     "type": "string"
                 },
+                "DEMO_MODE": {
+                    "type": "string"
+                },
                 "FAILOVER_ENABLED": {
                     "type": "string"
                 },

--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -43,11 +43,11 @@ The most common way to configure GoModel. Set any of the variables below to over
 | `PORT`               | HTTP server port                                      | `8080`                 |
 | `BASE_PATH`          | Mount path prefix, for example `/g`                   | `/`                    |
 | `GOMODEL_MASTER_KEY` | Authentication key for securing the gateway           | _(empty, unsafe mode)_ |
-| `GOMODEL_DEMO_MODEL` | Enable public demo warnings in logs and the dashboard  | `false`                |
+| `GOMODEL_DEMO_MODE`  | Enable public demo warnings in logs and the dashboard  | `false`                |
 | `BODY_SIZE_LIMIT`    | Max request body size (e.g., `10M`, `1024K`, `500KB`) | _(no limit)_           |
 | `USER_PATH_HEADER`   | Header used to read/write request `user_path` values  | `X-GoModel-User-Path`  |
 
-Set `GOMODEL_DEMO_MODEL=true` for a public or shared demonstration instance.
+Set `GOMODEL_DEMO_MODE=true` for a public or shared demonstration instance.
 GoModel logs a warning at startup and every five minutes, renders a persistent
 warning at the top of the dashboard, and exposes `DEMO_MODE=on` through the
 allowlisted `/admin/runtime/config` response. Demo mode does not reset storage;

--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -43,8 +43,15 @@ The most common way to configure GoModel. Set any of the variables below to over
 | `PORT`               | HTTP server port                                      | `8080`                 |
 | `BASE_PATH`          | Mount path prefix, for example `/g`                   | `/`                    |
 | `GOMODEL_MASTER_KEY` | Authentication key for securing the gateway           | _(empty, unsafe mode)_ |
+| `GOMODEL_DEMO_MODEL` | Enable public demo warnings in logs and the dashboard  | `false`                |
 | `BODY_SIZE_LIMIT`    | Max request body size (e.g., `10M`, `1024K`, `500KB`) | _(no limit)_           |
 | `USER_PATH_HEADER`   | Header used to read/write request `user_path` values  | `X-GoModel-User-Path`  |
+
+Set `GOMODEL_DEMO_MODEL=true` for a public or shared demonstration instance.
+GoModel logs a warning at startup and every five minutes, renders a persistent
+warning at the top of the dashboard, and exposes `DEMO_MODE=on` through the
+allowlisted `/admin/runtime/config` response. Demo mode does not reset storage;
+schedule that separately in the deployment.
 
 #### MCP Gateway
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -8647,6 +8647,9 @@
           "DASHBOARD_LIVE_LOGS_ENABLED": {
             "type": "string"
           },
+          "DEMO_MODE": {
+            "type": "string"
+          },
           "FAILOVER_ENABLED": {
             "type": "string"
           },

--- a/internal/admin/dashboard/dashboard.go
+++ b/internal/admin/dashboard/dashboard.go
@@ -26,11 +26,18 @@ type Handler struct {
 	indexTmpl *template.Template
 	staticFS  http.Handler
 	basePath  string
+	demoMode  bool
 }
 
 // NewWithBasePath creates a dashboard handler for an app mounted under basePath.
 // It parses templates and sets up the static file server.
 func NewWithBasePath(basePath string) (*Handler, error) {
+	return NewWithDemoMode(basePath, false)
+}
+
+// NewWithDemoMode creates a dashboard handler and controls whether the demo
+// warning is rendered in the main content area.
+func NewWithDemoMode(basePath string, demoMode bool) (*Handler, error) {
 	basePath = config.NormalizeBasePath(basePath)
 	assetVersions, err := buildFrontendAssetVersions()
 	if err != nil {
@@ -58,18 +65,20 @@ func NewWithBasePath(basePath string) (*Handler, error) {
 		indexTmpl: tmpl,
 		staticFS:  http.StripPrefix("/admin/static/", http.FileServer(http.FS(staticSub))),
 		basePath:  basePath,
+		demoMode:  demoMode,
 	}, nil
 }
 
 type templateData struct {
 	BasePath string
 	Version  string
+	DemoMode bool
 }
 
 // Index serves GET /admin/dashboard — the main dashboard page.
 func (h *Handler) Index(c *echo.Context) error {
 	var buf bytes.Buffer
-	if err := h.indexTmpl.ExecuteTemplate(&buf, "layout", templateData{BasePath: h.basePath, Version: version.Info()}); err != nil {
+	if err := h.indexTmpl.ExecuteTemplate(&buf, "layout", templateData{BasePath: h.basePath, Version: version.Info(), DemoMode: h.demoMode}); err != nil {
 		slog.Error("failed to render admin dashboard", "path", c.Request().URL.Path, "error", err)
 		return err
 	}

--- a/internal/admin/dashboard/dashboard_test.go
+++ b/internal/admin/dashboard/dashboard_test.go
@@ -77,6 +77,49 @@ func TestIndex_ReturnsHTML(t *testing.T) {
 	}
 }
 
+func TestIndex_DemoModeShowsWarning(t *testing.T) {
+	h, err := NewWithDemoMode("/", true)
+	if err != nil {
+		t.Fatalf("NewWithDemoMode() returned error: %v", err)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/admin/dashboard", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.Index(c); err != nil {
+		t.Fatalf("Index() returned error: %v", err)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `class="demo-mode-banner"`) {
+		t.Error("expected demo mode banner in page HTML")
+	}
+	if !strings.Contains(body, "Do not enter sensitive or personal data. Demo data is reset regularly.") {
+		t.Error("expected demo mode data warning in page HTML")
+	}
+}
+
+func TestIndex_StandardModeHidesDemoWarning(t *testing.T) {
+	h, err := NewWithBasePath("/")
+	if err != nil {
+		t.Fatalf("NewWithBasePath() returned error: %v", err)
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/admin/dashboard", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.Index(c); err != nil {
+		t.Fatalf("Index() returned error: %v", err)
+	}
+	if strings.Contains(rec.Body.String(), `class="demo-mode-banner"`) {
+		t.Error("did not expect demo mode banner in standard mode")
+	}
+}
+
 func TestIndex_UsesBasePathForGeneratedURLs(t *testing.T) {
 	h, err := NewWithBasePath("g/")
 	if err != nil {

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -667,6 +667,45 @@ body.dashboard-modal-open {
   transition: width 0.2s;
 }
 
+.demo-mode-banner {
+  position: sticky;
+  top: 16px;
+  z-index: 8;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 24px;
+  padding: 12px 16px;
+  border: 1px solid color-mix(in srgb, var(--warning) 55%, var(--border));
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--warning) 14%, var(--bg-surface));
+  color: var(--text);
+  box-shadow: 0 8px 24px color-mix(in srgb, var(--bg) 70%, transparent);
+}
+
+.demo-mode-banner-icon {
+  width: 20px;
+  height: 20px;
+  flex: 0 0 20px;
+  color: var(--warning);
+}
+
+.demo-mode-banner div {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+  font-size: 13px;
+}
+
+.demo-mode-banner strong {
+  flex-shrink: 0;
+  color: var(--warning);
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
 .page-header {
   display: flex;
   align-items: center;
@@ -5352,6 +5391,14 @@ body.conversation-drawer-open {
     width: 100%;
     margin: 0 auto;
     padding: 20px;
+  }
+  .demo-mode-banner {
+    top: 10px;
+    align-items: flex-start;
+  }
+  .demo-mode-banner div {
+    display: grid;
+    gap: 2px;
   }
   .auth-dialog-shell {
     align-items: end;

--- a/internal/admin/dashboard/static/js/modules/workflows.js
+++ b/internal/admin/dashboard/static/js/modules/workflows.js
@@ -83,6 +83,7 @@
 
 	            workflowRuntimeConfigKeys() {
 	                return [
+	                    'DEMO_MODE',
 	                    'FAILOVER_ENABLED',
 	                    'LOGGING_ENABLED',
 	                    'LOGGING_RETENTION_DAYS',

--- a/internal/admin/dashboard/static/js/modules/workflows.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/workflows.test.cjs
@@ -1284,6 +1284,7 @@ test('fetchWorkflowRuntimeConfig loads FAILOVER_ENABLED from the admin config en
             return Promise.resolve({
                 ok: true,
                 json: async () => ({
+                    DEMO_MODE: 'on',
                     FAILOVER_ENABLED: 'on',
                     LOGGING_ENABLED: 'on',
                     LOGGING_RETENTION_DAYS: 30,
@@ -1307,6 +1308,7 @@ test('fetchWorkflowRuntimeConfig loads FAILOVER_ENABLED from the admin config en
     assert.equal(
         JSON.stringify(module.workflowRuntimeConfig),
         JSON.stringify({
+            DEMO_MODE: 'on',
             FAILOVER_ENABLED: 'on',
             LOGGING_ENABLED: 'on',
             LOGGING_RETENTION_DAYS: '30',

--- a/internal/admin/dashboard/templates/layout.html
+++ b/internal/admin/dashboard/templates/layout.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex, nofollow, nosnippet, noimageindex">
     <title>GoModel Dashboard</title>
     <link rel="icon" type="image/svg+xml" href="{{assetURL "favicon.svg"}}">
     <link rel="stylesheet" href="{{assetURL "fonts/inter.css"}}">

--- a/internal/admin/dashboard/templates/layout.html
+++ b/internal/admin/dashboard/templates/layout.html
@@ -76,6 +76,15 @@
     <div class="app">
         {{template "sidebar" .}}
         <main class="content">
+            {{if .DemoMode}}
+            <aside class="demo-mode-banner" role="alert" aria-label="Demo mode notice">
+                <i data-lucide="triangle-alert" class="demo-mode-banner-icon" aria-hidden="true"></i>
+                <div>
+                    <strong>Public demo</strong>
+                    <span>Do not enter sensitive or personal data. Demo data is reset regularly.</span>
+                </div>
+            </aside>
+            {{end}}
             {{template "index" .}}
         </main>
         <div class="auth-dialog-backdrop"

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -62,6 +62,7 @@ type Handler struct {
 type Option func(*Handler)
 
 const (
+	DashboardConfigDemoMode             = "DEMO_MODE"
 	DashboardConfigFailoverEnabled      = "FAILOVER_ENABLED"
 	DashboardConfigLoggingEnabled       = "LOGGING_ENABLED"
 	DashboardConfigLoggingRetentionDays = "LOGGING_RETENTION_DAYS"
@@ -81,6 +82,7 @@ const statusClientClosedRequest = 499
 
 // DashboardConfigResponse is the allowlisted runtime config contract exposed to the dashboard UI.
 type DashboardConfigResponse struct {
+	DemoMode             string `json:"DEMO_MODE,omitempty"`
 	FailoverEnabled      string `json:"FAILOVER_ENABLED,omitempty"`
 	LoggingEnabled       string `json:"LOGGING_ENABLED,omitempty"`
 	LoggingRetentionDays string `json:"LOGGING_RETENTION_DAYS,omitempty"`
@@ -326,6 +328,7 @@ func NewHandler(reader usage.UsageReader, registry *providers.ModelRegistry, opt
 
 func normalizeDashboardRuntimeConfig(values DashboardConfigResponse) DashboardConfigResponse {
 	return DashboardConfigResponse{
+		DemoMode:             strings.TrimSpace(values.DemoMode),
 		FailoverEnabled:      strings.TrimSpace(values.FailoverEnabled),
 		LoggingEnabled:       strings.TrimSpace(values.LoggingEnabled),
 		LoggingRetentionDays: strings.TrimSpace(values.LoggingRetentionDays),

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -2250,6 +2250,7 @@ func TestBuildProviderStatusItem_ClassifyAndDisplayFallbacks(t *testing.T) {
 
 func TestDashboardConfig_ReturnsAllowlistedRuntimeFlags(t *testing.T) {
 	h := NewHandler(nil, nil, WithDashboardRuntimeConfig(DashboardConfigResponse{
+		DemoMode:             "on",
 		FailoverEnabled:      "on",
 		LoggingEnabled:       "on",
 		LoggingRetentionDays: "14",
@@ -2275,6 +2276,9 @@ func TestDashboardConfig_ReturnsAllowlistedRuntimeFlags(t *testing.T) {
 	var body DashboardConfigResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if got := body.DemoMode; got != "on" {
+		t.Fatalf("DEMO_MODE = %q, want on", got)
 	}
 	if got := body.FailoverEnabled; got != "on" {
 		t.Fatalf("FAILOVER_ENABLED = %q, want on", got)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -91,6 +91,10 @@ type Config struct {
 	// rewriters, middleware, routes). The registry is snapshotted here; later
 	// registrations have no effect.
 	Extensions *ext.Registry
+
+	// DemoMode exposes a prominent dashboard warning for public demo instances.
+	// It does not change persistence or security behavior.
+	DemoMode bool
 }
 
 // applyExtensions snapshots a registered extension set into the server
@@ -637,7 +641,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 			taggingResult.Service,
 			mcpResult,
 			app,
-			dashboardRuntimeConfig(appCfg, usageEnabledForDashboard),
+			dashboardRuntimeConfig(appCfg, usageEnabledForDashboard, cfg.DemoMode),
 			app.live,
 			requestHealth,
 			usagePricingRecalculationConfigured(appCfg),
@@ -1162,7 +1166,7 @@ func initAdmin(
 	var dashHandler *dashboard.Handler
 	if uiEnabled {
 		var err error
-		dashHandler, err = dashboard.NewWithBasePath(basePath)
+		dashHandler, err = dashboard.NewWithDemoMode(basePath, runtimeConfig.DemoMode == "on")
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to initialize dashboard: %w", err)
 		}
@@ -1277,8 +1281,9 @@ func defaultWorkflowInput(cfg *config.Config, availableGuardrails []string, conf
 	}
 }
 
-func dashboardRuntimeConfig(cfg *config.Config, usageEnabled bool) admin.DashboardConfigResponse {
+func dashboardRuntimeConfig(cfg *config.Config, usageEnabled, demoMode bool) admin.DashboardConfigResponse {
 	return admin.DashboardConfigResponse{
+		DemoMode:             dashboardEnabledValue(demoMode),
 		FailoverEnabled:      dashboardEnabledValue(failoverFeatureEnabledGlobally(cfg)),
 		LoggingEnabled:       dashboardEnabledValue(cfg != nil && cfg.Logging.Enabled),
 		LoggingRetentionDays: dashboardLoggingRetentionDays(cfg),

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -544,7 +544,7 @@ func TestDashboardRuntimeConfig_ExposesFeatureAvailabilityFlags(t *testing.T) {
 }
 
 func TestDashboardRuntimeConfig_ExposesIndefiniteLoggingRetention(t *testing.T) {
-	values := dashboardRuntimeConfig(&config.Config{}, false)
+	values := dashboardRuntimeConfig(&config.Config{}, false, false)
 	if got := values.LoggingRetentionDays; got != "0" {
 		t.Fatalf("dashboardRuntimeConfig()[%q] = %q, want 0", admin.DashboardConfigLoggingRetentionDays, got)
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -442,9 +442,16 @@ func TestDashboardRuntimeConfig_ExposesFailoverEnabled(t *testing.T) {
 		},
 	}
 
-	values := dashboardRuntimeConfig(cfg, false)
+	values := dashboardRuntimeConfig(cfg, false, false)
 	if got := values.FailoverEnabled; got != "on" {
 		t.Fatalf("dashboardRuntimeConfig()[%q] = %q, want on", admin.DashboardConfigFailoverEnabled, got)
+	}
+}
+
+func TestDashboardRuntimeConfig_ExposesDemoMode(t *testing.T) {
+	values := dashboardRuntimeConfig(&config.Config{}, false, true)
+	if got := values.DemoMode; got != "on" {
+		t.Fatalf("dashboardRuntimeConfig()[%q] = %q, want on", admin.DashboardConfigDemoMode, got)
 	}
 }
 
@@ -455,7 +462,7 @@ func TestDashboardRuntimeConfig_FailoverDisabled(t *testing.T) {
 		},
 	}
 
-	values := dashboardRuntimeConfig(cfg, false)
+	values := dashboardRuntimeConfig(cfg, false, false)
 	if got := values.FailoverEnabled; got != "off" {
 		t.Fatalf("dashboardRuntimeConfig()[%q] = %q, want off", admin.DashboardConfigFailoverEnabled, got)
 	}
@@ -469,7 +476,7 @@ func TestDashboardRuntimeConfig_DefaultModeDoesNotEnableFailover(t *testing.T) {
 		},
 	}
 
-	values := dashboardRuntimeConfig(cfg, false)
+	values := dashboardRuntimeConfig(cfg, false, false)
 	if got := values.FailoverEnabled; got != "off" {
 		t.Fatalf("dashboardRuntimeConfig()[%q] = %q, want off", admin.DashboardConfigFailoverEnabled, got)
 	}
@@ -506,7 +513,7 @@ func TestDashboardRuntimeConfig_ExposesFeatureAvailabilityFlags(t *testing.T) {
 		},
 	}
 
-	values := dashboardRuntimeConfig(cfg, true)
+	values := dashboardRuntimeConfig(cfg, true, false)
 	if got := values.LoggingEnabled; got != "on" {
 		t.Fatalf("dashboardRuntimeConfig()[%q] = %q, want on", admin.DashboardConfigLoggingEnabled, got)
 	}
@@ -559,7 +566,7 @@ func TestDashboardRuntimeConfig_HidesCacheAnalyticsWhenUsageDisabled(t *testing.
 		},
 	}
 
-	values := dashboardRuntimeConfig(cfg, false)
+	values := dashboardRuntimeConfig(cfg, false, false)
 	if got := values.UsageEnabled; got != "off" {
 		t.Fatalf("dashboardRuntimeConfig()[%q] = %q, want off", admin.DashboardConfigUsageEnabled, got)
 	}

--- a/run/demo.go
+++ b/run/demo.go
@@ -1,0 +1,54 @@
+package run
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	envDemoMode             = "GOMODEL_DEMO_MODEL"
+	demoModeWarningInterval = 5 * time.Minute
+)
+
+func demoModeFromEnv() (bool, error) {
+	raw := strings.TrimSpace(os.Getenv(envDemoMode))
+	if raw == "" {
+		return false, nil
+	}
+	enabled, err := strconv.ParseBool(raw)
+	if err != nil {
+		return false, fmt.Errorf("invalid %s %q: expected a boolean", envDemoMode, raw)
+	}
+	return enabled, nil
+}
+
+func startDemoModeWarnings(ctx context.Context) {
+	logDemoModeWarning()
+	go repeatDemoModeWarnings(ctx, demoModeWarningInterval, logDemoModeWarning)
+}
+
+func repeatDemoModeWarnings(ctx context.Context, interval time.Duration, warn func()) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			warn()
+		}
+	}
+}
+
+func logDemoModeWarning() {
+	slog.Warn("DEMO MODE: this environment is public; do not enter sensitive or personal data; demo data is reset regularly",
+		"demo_mode", true,
+		"reminder_interval", demoModeWarningInterval,
+	)
+}

--- a/run/demo.go
+++ b/run/demo.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	envDemoMode             = "GOMODEL_DEMO_MODEL"
+	envDemoMode             = "GOMODEL_DEMO_MODE"
 	demoModeWarningInterval = 5 * time.Minute
 )
 

--- a/run/demo_test.go
+++ b/run/demo_test.go
@@ -1,0 +1,58 @@
+package run
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestRepeatDemoModeWarnings(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var count atomic.Int32
+	done := make(chan struct{})
+	go func() {
+		repeatDemoModeWarnings(ctx, time.Millisecond, func() {
+			if count.Add(1) == 2 {
+				close(done)
+			}
+		})
+	}()
+
+	select {
+	case <-done:
+		cancel()
+	case <-time.After(time.Second):
+		t.Fatalf("received %d warnings, want at least 2", count.Load())
+	}
+}
+
+func TestDemoModeFromEnv(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    bool
+		wantErr bool
+	}{
+		{name: "unset defaults off"},
+		{name: "true", value: "true", want: true},
+		{name: "one", value: "1", want: true},
+		{name: "false", value: "false"},
+		{name: "invalid", value: "sometimes", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(envDemoMode, tt.value)
+			got, err := demoModeFromEnv()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("demoModeFromEnv() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("demoModeFromEnv() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/run/flags_test.go
+++ b/run/flags_test.go
@@ -36,6 +36,12 @@ func TestParseCLI_RejectsUnknownFlags(t *testing.T) {
 	}
 }
 
+func TestParseCLI_RejectsRemovedDemoFlag(t *testing.T) {
+	if _, err := parseCLI("gomodel", []string{"--demo"}, io.Discard); err == nil {
+		t.Fatal("parseCLI(--demo) error = nil, want error")
+	}
+}
+
 func TestParseCLI_RejectsPositionalArgs(t *testing.T) {
 	if _, err := parseCLI("gomodel", []string{"--health", "extra"}, io.Discard); err == nil {
 		t.Fatal("parseCLI(--health extra) error = nil, want error")

--- a/run/run.go
+++ b/run/run.go
@@ -140,9 +140,20 @@ func Run(ctx context.Context, opts Options) error {
 		return nil
 	}
 
+	demoMode, err := demoModeFromEnv()
+	if err != nil {
+		fmt.Fprintln(opts.Stderr, err)
+		return err
+	}
+
 	if err := configureLogging(opts.Stderr); err != nil {
 		fmt.Fprintf(opts.Stderr, "failed to configure logging: %v\n", err)
 		return err
+	}
+	if demoMode {
+		demoCtx, stopDemoWarnings := context.WithCancel(ctx)
+		defer stopDemoWarnings()
+		startDemoModeWarnings(demoCtx)
 	}
 
 	slog.Info("starting "+opts.ProductName,
@@ -169,6 +180,7 @@ func Run(ctx context.Context, opts Options) error {
 		AppConfig:  result,
 		Factory:    defaultProviderFactory(result.Config),
 		Extensions: opts.Extensions,
+		DemoMode:   demoMode,
 	})
 	if err != nil {
 		slog.Error("failed to initialize application", "error", err)

--- a/tests/e2e/admin_test.go
+++ b/tests/e2e/admin_test.go
@@ -229,6 +229,8 @@ func TestAdminDashboard_Enabled_E2E(t *testing.T) {
 		// document. The dashboard layout pins these markers.
 		assert.Contains(t, html, "<title>GoModel Dashboard</title>",
 			"dashboard HTML should carry the expected <title>")
+		assert.Contains(t, html, `<meta name="robots" content="noindex, nofollow, nosnippet, noimageindex">`,
+			"dashboard HTML should prevent search engine indexing")
 		assert.Contains(t, html, "css/dashboard.css",
 			"dashboard HTML should reference its stylesheet bundle")
 		assert.Contains(t, html, "js/dashboard.js",


### PR DESCRIPTION
## Summary

- add environment-only demo mode through `GOMODEL_DEMO_MODEL`, disabled by default
- emit an immediate warning and repeat it every five minutes
- expose `DEMO_MODE` through the allowlisted dashboard runtime configuration
- render a sticky public-demo banner warning against sensitive or personal data
- update `make demo`, configuration docs, and OpenAPI schemas

## Behavior

`GOMODEL_DEMO_MODEL=true` enables demo mode. The removed `--demo` flag is rejected. Demo mode communicates that demo data is reset regularly, but it does not perform storage deletion itself; deployments must schedule resets separately.

## Testing

- `go test ./...`
- `node --test internal/admin/dashboard/static/js/modules/*.test.cjs`
- repository pre-commit suite, including race tests, lint, fix-check, Mintlify validation, and hot-path performance guards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public demo mode via `GOMODEL_DEMO_MODE=true`, including recurring warning logs.
  * Admin dashboard now shows a non-dismissible “Public demo” banner and disallows indexing via a `noindex` meta tag.
  * Demo mode is exposed through dashboard runtime config as `DEMO_MODE`, and reflected in the OpenAPI schema.
* **Documentation**
  * Documented `GOMODEL_DEMO_MODE` behavior and runtime config exposure (`DEMO_MODE=on`).
* **Tests**
  * Added/updated unit and E2E tests for banner/noindex behavior and runtime config/warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->