### PR TITLE
feat(dashboard): show audit log retention

### DIFF
--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -3187,6 +3187,12 @@ textarea:focus {
 }
 
 /* Audit Log Section */
+.audit-retention-note {
+  margin-top: 5px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
 .audit-log-section {
   background: var(--bg-surface);
   border: 1px solid var(--border);

--- a/internal/admin/dashboard/static/js/modules/audit-list.js
+++ b/internal/admin/dashboard/static/js/modules/audit-list.js
@@ -123,6 +123,17 @@
             : null;
 
         return {
+            auditRetentionText() {
+                const raw = this.workflowRuntimeConfig && this.workflowRuntimeConfig.LOGGING_RETENTION_DAYS;
+                if (raw === undefined || raw === null || String(raw).trim() === '') return '';
+
+                const days = Number(raw);
+                if (!Number.isInteger(days) || days < 0) return '';
+                if (days === 0) return 'Audit logs are retained indefinitely.';
+                if (days === 1) return 'Audit logs are retained for 1 day.';
+                return 'Audit logs are retained for ' + days + ' days.';
+            },
+
             _auditQueryStr() {
                 if (this.customStartDate && this.customEndDate) {
                     return 'start_date=' + this._formatDate(this.customStartDate) +

--- a/internal/admin/dashboard/static/js/modules/audit-list.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/audit-list.test.cjs
@@ -34,6 +34,32 @@ function loadConversationHelpers() {
     return context.window.DashboardConversationHelpers;
 }
 
+test('auditRetentionText describes finite and indefinite retention', () => {
+    const module = createAuditListModule();
+
+    module.workflowRuntimeConfig = { LOGGING_RETENTION_DAYS: '30' };
+    assert.equal(module.auditRetentionText(), 'Audit logs are retained for 30 days.');
+
+    module.workflowRuntimeConfig.LOGGING_RETENTION_DAYS = '1';
+    assert.equal(module.auditRetentionText(), 'Audit logs are retained for 1 day.');
+
+    module.workflowRuntimeConfig.LOGGING_RETENTION_DAYS = '0';
+    assert.equal(module.auditRetentionText(), 'Audit logs are retained indefinitely.');
+});
+
+test('auditRetentionText hides missing or invalid retention values', () => {
+    const module = createAuditListModule();
+
+    module.workflowRuntimeConfig = {};
+    assert.equal(module.auditRetentionText(), '');
+
+    module.workflowRuntimeConfig.LOGGING_RETENTION_DAYS = '-1';
+    assert.equal(module.auditRetentionText(), '');
+
+    module.workflowRuntimeConfig.LOGGING_RETENTION_DAYS = 'unknown';
+    assert.equal(module.auditRetentionText(), '');
+});
+
 test('auditRequestPane returns the shared request-pane contract', () => {
     const module = createAuditListModule();
     const entry = {

--- a/internal/admin/dashboard/static/js/modules/dashboard-layout.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/dashboard-layout.test.cjs
@@ -864,6 +864,14 @@ test("audit toolbar uses a full-width search row above the select row with a rig
 
   assert.match(
     indexTemplate,
+    /<h2>Audit Logs<\/h2>\s*<p class="audit-retention-note" x-show="auditRetentionText\(\)" x-text="auditRetentionText\(\)"><\/p>/,
+  );
+  const retentionRule = readCSSRule(css, ".audit-retention-note");
+  assert.match(retentionRule, /color:\s*var\(--text-muted\)/);
+  assert.match(retentionRule, /font-size:\s*13px/);
+
+  assert.match(
+    indexTemplate,
     /<div class="audit-filter-row audit-filter-row-search">[\s\S]*id="audit-filter-search"[\s\S]*<\/div>\s*<div class="audit-filter-row audit-filter-row-controls">[\s\S]*id="audit-filter-method"[\s\S]*id="audit-filter-status"[\s\S]*id="audit-filter-stream"[\s\S]*class="pagination-btn audit-clear-btn" @click="clearAuditFilters\(\)"/,
   );
   assert.match(

--- a/internal/admin/dashboard/static/js/modules/workflows.js
+++ b/internal/admin/dashboard/static/js/modules/workflows.js
@@ -85,6 +85,7 @@
 	                return [
 	                    'FAILOVER_ENABLED',
 	                    'LOGGING_ENABLED',
+	                    'LOGGING_RETENTION_DAYS',
 	                    'USAGE_ENABLED',
 	                    'BUDGETS_ENABLED',
 	                    'RATE_LIMITS_ENABLED',

--- a/internal/admin/dashboard/static/js/modules/workflows.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/workflows.test.cjs
@@ -1286,6 +1286,7 @@ test('fetchWorkflowRuntimeConfig loads FAILOVER_ENABLED from the admin config en
                 json: async () => ({
                     FAILOVER_ENABLED: 'on',
                     LOGGING_ENABLED: 'on',
+                    LOGGING_RETENTION_DAYS: 30,
                     USAGE_ENABLED: 'off',
                     BUDGETS_ENABLED: 'on',
                     RATE_LIMITS_ENABLED: 'off',
@@ -1308,6 +1309,7 @@ test('fetchWorkflowRuntimeConfig loads FAILOVER_ENABLED from the admin config en
         JSON.stringify({
             FAILOVER_ENABLED: 'on',
             LOGGING_ENABLED: 'on',
+            LOGGING_RETENTION_DAYS: '30',
             USAGE_ENABLED: 'off',
             BUDGETS_ENABLED: 'on',
             RATE_LIMITS_ENABLED: 'off',

--- a/internal/admin/dashboard/templates/page-audit-logs.html
+++ b/internal/admin/dashboard/templates/page-audit-logs.html
@@ -3,7 +3,10 @@
 <template x-if="page==='audit-logs'">
 <div>
     <div class="page-header">
-        <h2>Audit Logs</h2>
+        <div>
+            <h2>Audit Logs</h2>
+            <p class="audit-retention-note" x-show="auditRetentionText()" x-text="auditRetentionText()"></p>
+        </div>
         <div class="page-header-controls">
             {{template "date-picker" .}}
         </div>

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -64,6 +64,7 @@ type Option func(*Handler)
 const (
 	DashboardConfigFailoverEnabled      = "FAILOVER_ENABLED"
 	DashboardConfigLoggingEnabled       = "LOGGING_ENABLED"
+	DashboardConfigLoggingRetentionDays = "LOGGING_RETENTION_DAYS"
 	DashboardConfigUsageEnabled         = "USAGE_ENABLED"
 	DashboardConfigBudgetsEnabled       = "BUDGETS_ENABLED"
 	DashboardConfigRateLimitsEnabled    = "RATE_LIMITS_ENABLED"
@@ -82,6 +83,7 @@ const statusClientClosedRequest = 499
 type DashboardConfigResponse struct {
 	FailoverEnabled      string `json:"FAILOVER_ENABLED,omitempty"`
 	LoggingEnabled       string `json:"LOGGING_ENABLED,omitempty"`
+	LoggingRetentionDays string `json:"LOGGING_RETENTION_DAYS,omitempty"`
 	UsageEnabled         string `json:"USAGE_ENABLED,omitempty"`
 	BudgetsEnabled       string `json:"BUDGETS_ENABLED,omitempty"`
 	RateLimitsEnabled    string `json:"RATE_LIMITS_ENABLED,omitempty"`
@@ -326,6 +328,7 @@ func normalizeDashboardRuntimeConfig(values DashboardConfigResponse) DashboardCo
 	return DashboardConfigResponse{
 		FailoverEnabled:      strings.TrimSpace(values.FailoverEnabled),
 		LoggingEnabled:       strings.TrimSpace(values.LoggingEnabled),
+		LoggingRetentionDays: strings.TrimSpace(values.LoggingRetentionDays),
 		UsageEnabled:         strings.TrimSpace(values.UsageEnabled),
 		BudgetsEnabled:       strings.TrimSpace(values.BudgetsEnabled),
 		RateLimitsEnabled:    strings.TrimSpace(values.RateLimitsEnabled),

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -2252,6 +2252,7 @@ func TestDashboardConfig_ReturnsAllowlistedRuntimeFlags(t *testing.T) {
 	h := NewHandler(nil, nil, WithDashboardRuntimeConfig(DashboardConfigResponse{
 		FailoverEnabled:      "on",
 		LoggingEnabled:       "on",
+		LoggingRetentionDays: "14",
 		UsageEnabled:         "off",
 		BudgetsEnabled:       "on",
 		RateLimitsEnabled:    "off",
@@ -2280,6 +2281,9 @@ func TestDashboardConfig_ReturnsAllowlistedRuntimeFlags(t *testing.T) {
 	}
 	if got := body.LoggingEnabled; got != "on" {
 		t.Fatalf("LOGGING_ENABLED = %q, want on", got)
+	}
+	if got := body.LoggingRetentionDays; got != "14" {
+		t.Fatalf("LOGGING_RETENTION_DAYS = %q, want 14", got)
 	}
 	if got := body.UsageEnabled; got != "off" {
 		t.Fatalf("USAGE_ENABLED = %q, want off", got)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1281,6 +1281,7 @@ func dashboardRuntimeConfig(cfg *config.Config, usageEnabled bool) admin.Dashboa
 	return admin.DashboardConfigResponse{
 		FailoverEnabled:      dashboardEnabledValue(failoverFeatureEnabledGlobally(cfg)),
 		LoggingEnabled:       dashboardEnabledValue(cfg != nil && cfg.Logging.Enabled),
+		LoggingRetentionDays: dashboardLoggingRetentionDays(cfg),
 		UsageEnabled:         dashboardEnabledValue(cfg != nil && cfg.Usage.Enabled),
 		BudgetsEnabled:       dashboardEnabledValue(cfg != nil && cfg.Budgets.Enabled),
 		RateLimitsEnabled:    dashboardEnabledValue(cfg != nil && cfg.RateLimits.Enabled),
@@ -1290,6 +1291,13 @@ func dashboardRuntimeConfig(cfg *config.Config, usageEnabled bool) admin.Dashboa
 		SemanticCacheEnabled: dashboardEnabledValue(semanticResponseCacheConfigured(cfg)),
 		LiveLogsEnabled:      dashboardEnabledValue(cfg != nil && cfg.Admin.LiveLogsEnabled),
 	}
+}
+
+func dashboardLoggingRetentionDays(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	return fmt.Sprintf("%d", cfg.Logging.RetentionDays)
 }
 
 func usagePricingRecalculationConfigured(cfg *config.Config) bool {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -479,7 +479,8 @@ func TestDashboardRuntimeConfig_ExposesFeatureAvailabilityFlags(t *testing.T) {
 	semanticOff := false
 	cfg := &config.Config{
 		Logging: config.LogConfig{
-			Enabled: true,
+			Enabled:       true,
+			RetentionDays: 14,
 		},
 		Usage: config.UsageConfig{
 			Enabled: true,
@@ -509,6 +510,9 @@ func TestDashboardRuntimeConfig_ExposesFeatureAvailabilityFlags(t *testing.T) {
 	if got := values.LoggingEnabled; got != "on" {
 		t.Fatalf("dashboardRuntimeConfig()[%q] = %q, want on", admin.DashboardConfigLoggingEnabled, got)
 	}
+	if got := values.LoggingRetentionDays; got != "14" {
+		t.Fatalf("dashboardRuntimeConfig()[%q] = %q, want 14", admin.DashboardConfigLoggingRetentionDays, got)
+	}
 	if got := values.UsageEnabled; got != "on" {
 		t.Fatalf("dashboardRuntimeConfig()[%q] = %q, want on", admin.DashboardConfigUsageEnabled, got)
 	}
@@ -529,6 +533,13 @@ func TestDashboardRuntimeConfig_ExposesFeatureAvailabilityFlags(t *testing.T) {
 	}
 	if got := values.LiveLogsEnabled; got != "on" {
 		t.Fatalf("dashboardRuntimeConfig()[%q] = %q, want on", admin.DashboardConfigLiveLogsEnabled, got)
+	}
+}
+
+func TestDashboardRuntimeConfig_ExposesIndefiniteLoggingRetention(t *testing.T) {
+	values := dashboardRuntimeConfig(&config.Config{}, false)
+	if got := values.LoggingRetentionDays; got != "0" {
+		t.Fatalf("dashboardRuntimeConfig()[%q] = %q, want 0", admin.DashboardConfigLoggingRetentionDays, got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- expose the configured audit-log retention period through the dashboard runtime config
- show a discreet retention note beneath the Audit Logs heading
- describe `0` days as indefinite retention and hide invalid or unavailable values

## Tests
- `make test`
- `make test-dashboard`
- commit hooks: race tests, formatting, lint, and fix checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a retention notice to the Audit Logs page.
  * Displays whether logs are retained indefinitely, for one day, or for multiple days.
  * Retention information now reflects the configured logging policy.

* **Bug Fixes**
  * Invalid or unavailable retention settings no longer display misleading information.

* **Tests**
  * Added coverage for finite, indefinite, missing, and invalid retention settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->