### PR TITLE
docs(quickstart): add live demo tab

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -35,11 +35,6 @@
     "navbar": {
         "links": [
             {
-                "label": "Live Demo",
-                "href": "https://demo.enterpilot.io/admin/dashboard",
-                "icon": "monitor-play"
-            },
-            {
                 "type": "github",
                 "href": "https://github.com/ENTERPILOT/GoModel"
             }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -35,6 +35,11 @@
     "navbar": {
         "links": [
             {
+                "label": "Live Demo",
+                "href": "https://demo.enterpilot.io/admin/dashboard",
+                "icon": "monitor-play"
+            },
+            {
                 "type": "github",
                 "href": "https://github.com/ENTERPILOT/GoModel"
             }

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -35,6 +35,21 @@ admin visibility in one place.
       enterpilot/gomodel
     ```
   </Tab>
+  <Tab title="Live Demo" icon="monitor-play">
+    Explore the dashboard without installing GoModel.
+
+    <Card
+      title="Open the live demo"
+      icon="arrow-up-right-from-square"
+      href="https://demo.enterpilot.io/admin/dashboard"
+    >
+      Preview models, usage analytics, and audit logs in a shared demo environment.
+    </Card>
+
+    <Warning>
+      Do not enter sensitive data. Demo data is reset regularly.
+    </Warning>
+  </Tab>
 </Tabs>
 
 <Note>

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -36,15 +36,7 @@ admin visibility in one place.
     ```
   </Tab>
   <Tab title="Live Demo" icon="monitor-play">
-    Explore the dashboard without installing GoModel.
-
-    <Card
-      title="Open the live demo"
-      icon="arrow-up-right-from-square"
-      href="https://demo.enterpilot.io/admin/dashboard"
-    >
-      Preview models, usage analytics, and audit logs in a shared demo environment.
-    </Card>
+    [https://demo.enterpilot.io/admin/dashboard](https://demo.enterpilot.io/admin/dashboard)
 
     <Warning>
       Do not enter sensitive data. Demo data is reset regularly.

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -4,6 +4,8 @@ description: "GoModel AI gateway quick start: run an OpenAI-compatible LLM gatew
 icon: "rocket"
 ---
 
+import ProviderCredentialsNote from "/snippets/provider-credentials-note.mdx";
+
 ## Run GoModel in 30 Seconds
 
 GoModel is an OpenAI-compatible AI gateway. You can connect one endpoint and
@@ -19,12 +21,16 @@ admin visibility in one place.
     curl -fsSL https://gomodel.enterpilot.io/install.sh | sh
     GOMODEL_MASTER_KEY="change-me" OPENAI_API_KEY="sk-..." gomodel
     ```
+
+    <ProviderCredentialsNote />
   </Tab>
   <Tab title="Windows">
     ```powershell
     irm https://gomodel.enterpilot.io/install.ps1 | iex
     $env:GOMODEL_MASTER_KEY = "change-me"; $env:OPENAI_API_KEY = "sk-..."; gomodel
     ```
+
+    <ProviderCredentialsNote />
   </Tab>
   <Tab title="Docker">
     ```bash
@@ -34,25 +40,13 @@ admin visibility in one place.
       -e OPENAI_API_KEY="sk-..." \
       enterpilot/gomodel
     ```
+
+    <ProviderCredentialsNote />
   </Tab>
   <Tab title="Live Demo" icon="monitor-play">
     [https://demo.enterpilot.io/admin/dashboard](https://demo.enterpilot.io/admin/dashboard)
-
-    <Warning>
-      Do not enter sensitive data. Demo data is reset regularly.
-    </Warning>
   </Tab>
 </Tabs>
-
-<Note>
-  Set at least one provider credential or base URL
-  (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`,
-  `DEEPSEEK_API_KEY`, `XAI_API_KEY`, `GROQ_API_KEY`, `OPENROUTER_API_KEY`, `KILO_API_KEY`,
-  `ZAI_API_KEY`, `AZURE_API_KEY` + `AZURE_BASE_URL`,
-  `ORACLE_API_KEY` + `ORACLE_BASE_URL`,
-  `OLLAMA_BASE_URL`) or GoModel will have no models to route. GoModel also
-  works well with additional OpenAI-compatible providers out of the box.
-</Note>
 
 ### 2. Send your first request
 

--- a/docs/snippets/provider-credentials-note.mdx
+++ b/docs/snippets/provider-credentials-note.mdx
@@ -1,0 +1,9 @@
+<Note>
+  Set at least one provider credential or base URL
+  (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`,
+  `DEEPSEEK_API_KEY`, `XAI_API_KEY`, `GROQ_API_KEY`, `OPENROUTER_API_KEY`, `KILO_API_KEY`,
+  `ZAI_API_KEY`, `AZURE_API_KEY` + `AZURE_BASE_URL`,
+  `ORACLE_API_KEY` + `ORACLE_BASE_URL`,
+  `OLLAMA_BASE_URL`) or GoModel will have no models to route. GoModel also
+  works well with additional OpenAI-compatible providers out of the box.
+</Note>


### PR DESCRIPTION
## Summary
- add a Live Demo link to the documentation navbar
- link directly to the public GoModel dashboard

## Validation
- `mint validate`
- `mint broken-links`
- live demo endpoint returns HTTP 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Quick Start platform setup instructions to include an AI-generated provider credentials note under macOS/Linux, Windows, and Docker tabs.
  * Added a new “Live Demo” tab to Quick Start that links to the demo admin dashboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->