### PR TITLE
docs(faq): add install-lifecycle FAQ (update, pin, data location, uninstall)

### DIFF
--- a/docs/about/faq.mdx
+++ b/docs/about/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: "FAQ"
 description: "Updating, pinning, and uninstalling GoModel; where the gateway stores its data and whether updates are safe."
-icon: "circle-question"
+icon: "circle-help"
 ---
 
 ## How do I update GoModel?

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -59,8 +59,7 @@
                         "group": "Getting Started",
                         "icon": "rocket",
                         "pages": [
-                            "getting-started/quickstart",
-                            "getting-started/faq"
+                            "getting-started/quickstart"
                         ]
                     },
                     {
@@ -115,7 +114,8 @@
                             "about/technical-philosophy",
                             "about/roadmap",
                             "about/license",
-                            "about/benchmarks"
+                            "about/benchmarks",
+                            "about/faq"
                         ]
                     }
                 ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -59,7 +59,8 @@
                         "group": "Getting Started",
                         "icon": "rocket",
                         "pages": [
-                            "getting-started/quickstart"
+                            "getting-started/quickstart",
+                            "getting-started/faq"
                         ]
                     },
                     {

--- a/docs/getting-started/faq.mdx
+++ b/docs/getting-started/faq.mdx
@@ -1,0 +1,93 @@
+---
+title: "FAQ"
+description: "Updating, pinning, and uninstalling GoModel; where the gateway stores its data and whether updates are safe."
+icon: "circle-question"
+---
+
+## How do I update GoModel?
+
+<Tabs>
+  <Tab title="macOS / Linux">
+    Re-run the installer — it always fetches the latest release and replaces
+    the binary in place:
+
+    ```bash
+    curl -fsSL https://gomodel.enterpilot.io/install.sh | sh
+    ```
+  </Tab>
+  <Tab title="Windows">
+    ```powershell
+    irm https://gomodel.enterpilot.io/install.ps1 | iex
+    ```
+  </Tab>
+  <Tab title="Docker">
+    ```bash
+    docker pull enterpilot/gomodel
+    ```
+
+    Then recreate the container. With Docker Compose:
+
+    ```bash
+    docker compose pull && docker compose up -d
+    ```
+  </Tab>
+</Tabs>
+
+Restart the gateway after updating; there is no in-place hot upgrade.
+
+## How do I check which version I'm running?
+
+```bash
+gomodel --version
+```
+
+The version is also printed on the first line of the startup log.
+
+## Can I install a specific version, or roll back?
+
+Yes — set `GOMODEL_VERSION` before running the installer:
+
+```bash
+GOMODEL_VERSION=v0.1.53 curl -fsSL https://gomodel.enterpilot.io/install.sh | sh
+```
+
+On Windows set `$env:GOMODEL_VERSION` first. With Docker, use a version tag
+(`enterpilot/gomodel:0.1.53`) instead of `latest`.
+
+## Is updating safe for my data?
+
+Yes. The database schema is migrated additively on startup, and updates never
+move or delete your database, configuration, or cache. Rolling back a version
+is equally safe for typical minor upgrades, though a database written by a
+much newer version may contain tables an older binary simply ignores.
+
+## Where does GoModel store its data?
+
+When a `./data` directory exists next to where you launch GoModel (existing
+deployments, the Docker image), the database stays at `./data/gomodel.db`.
+Otherwise the binary uses your OS's conventional per-user directories:
+
+| | Database | Model cache |
+| --- | --- | --- |
+| Linux | `~/.local/share/gomodel/` | `~/.cache/gomodel/` |
+| macOS | `~/Library/Application Support/gomodel/` | `~/Library/Caches/gomodel/` |
+| Windows | `%LocalAppData%\gomodel\` | `%LocalAppData%\gomodel\cache\` |
+
+The resolved database path is printed at startup (`storage configured`), and
+`GOMODEL_SQLITE_PATH` / `GOMODEL_CACHE_DIR` override it. Available from
+v0.1.54; older binaries always use `./data` relative to the working
+directory.
+
+## How do I uninstall?
+
+Remove the binary and, if you want a clean slate, the data directories:
+
+```bash
+rm "$(command -v gomodel)"
+rm -rf ~/.local/share/gomodel ~/.cache/gomodel   # Linux
+rm -rf ~/Library/"Application Support"/gomodel ~/Library/Caches/gomodel   # macOS
+```
+
+On Windows, delete `%LOCALAPPDATA%\Programs\gomodel` (and
+`%LOCALAPPDATA%\gomodel` for data), then remove the folder from your user
+PATH. For Docker, remove the container and image as usual.

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -134,6 +134,7 @@ Use one of those model IDs in your requests.
 
 ## Next Steps
 
+- Update, pin a version, or uninstall: [FAQ](/getting-started/faq)
 - Understand response caching: [Cache](/features/cache)
 - Add spend limits: [Budgets](/features/budgets)
 - Configure production settings: [Configuration](/advanced/configuration)

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -134,7 +134,7 @@ Use one of those model IDs in your requests.
 
 ## Next Steps
 
-- Update, pin a version, or uninstall: [FAQ](/getting-started/faq)
+- Update, pin a version, or uninstall: [FAQ](/about/faq)
 - Understand response caching: [Cache](/features/cache)
 - Add spend limits: [Budgets](/features/budgets)
 - Configure production settings: [Configuration](/advanced/configuration)


### PR DESCRIPTION
## Summary
Binary installs had no documented update story. New `getting-started/faq` page (in the docs nav after Quickstart, linked from the quickstart Next Steps) answering:

- **How do I update?** - re-run the installer (it is idempotent and always fetches the latest release); `docker pull` / `compose pull` for containers.
- **How do I check the running version?** - `gomodel --version` / startup log.
- **Pin or roll back** - `GOMODEL_VERSION=vX.Y.Z` with the installer, version tags with Docker.
- **Is updating safe for my data?** - yes; additive migrations, nothing moved or deleted.
- **Where does GoModel store data?** - the `./data`-exists rule plus the per-OS directory table (noted as v0.1.54+; older binaries always use `./data`).
- **Uninstall** - per-platform removal commands.

## User-visible impact
Docs-only; answers the most predictable post-install questions before they become issues/Discord threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new FAQ page covering updates, version pinning, rollback, storage locations, data safety, and uninstalling GoModel.
  * Added the FAQ page to the Documentation navigation under “About.”
  * Linked to the FAQ from the Quick Start guide’s “Next Steps” section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->