### PR TITLE
feat(marketing): track first-party referrals

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 <p align="center">
   <a href="https://news.ycombinator.com/item?id=47849097"><img alt="Hacker News" src="https://img.shields.io/badge/Hacker%20News-Apr%2021%20%2726%20%7C%20%234-brightgreen?logo=ycombinator&logoColor=white"></a>
-  <a href="https://gomodel.enterpilot.io/docs"><img alt="docs GoModel" src="https://img.shields.io/badge/Docs-GoModel-blue"></a>
+  <a href="https://gomodel.enterpilot.io/docs?utm_source=gomodel_readme"><img alt="docs GoModel" src="https://img.shields.io/badge/Docs-GoModel-blue"></a>
 </p>
 
 <p align="center">

--- a/docs/about/benchmarks.mdx
+++ b/docs/about/benchmarks.mdx
@@ -11,7 +11,7 @@ This page is a short reference for our latest public benchmark: GoModel against
 the numbers reflect gateway overhead, not model latency.
 
 The full article has the complete write-up, all the context, and the charts:
-[AI Gateway Benchmark 2026: GoModel vs LiteLLM, Portkey & Bifrost](https://enterpilot.io/blog/gomodel-vs-litellm-portkey-bifrost-june-2026/).
+[AI Gateway Benchmark 2026: GoModel vs LiteLLM, Portkey & Bifrost](https://enterpilot.io/blog/gomodel-vs-litellm-portkey-bifrost-june-2026/?utm_source=gomodel_docs).
 
 <Note>
   This is a point-in-time snapshot from a June 2026 run on AWS. Treat it as data,
@@ -93,7 +93,7 @@ just LiteLLM, the older localhost harness is still in
 
 It is meant to give you the result fast, inside the product docs, without a full
 article. For the narrative, the charts, and the methodology details, read the
-[full post](https://enterpilot.io/blog/gomodel-vs-litellm-portkey-bifrost-june-2026/).
+[full post](https://enterpilot.io/blog/gomodel-vs-litellm-portkey-bifrost-june-2026/?utm_source=gomodel_docs).
 
 No single benchmark settles the question for every environment. If you are
 evaluating gateways seriously, reproduce the test against your own traffic and

--- a/docs/about/who-we-are.mdx
+++ b/docs/about/who-we-are.mdx
@@ -7,15 +7,15 @@ icon: "users"
 ## Jakub Wąsek
 
 GoModel is created and maintained by **Jakub Wąsek**, who is also the founder of
-[Enterpilot.io](https://enterpilot.io).
+[Enterpilot.io](https://enterpilot.io?utm_source=gomodel_docs).
 
 Both projects share a single vision: make it easier for teams to build on top of
 large language models without getting locked into one provider.
 
 ## Enterpilot
 
-[Enterpilot](https://enterpilot.io) is a commercial AI access and traffic
-management platform for teams — think Dust.tt but with full
+[Enterpilot](https://enterpilot.io?utm_source=gomodel_docs) is a commercial AI
+access and traffic management platform for teams — think Dust.tt but with full
 control over routing, budgets, and data privacy.
 
 GoModel powers the gateway layer inside Enterpilot, but Enterpilot is a much
@@ -30,5 +30,5 @@ broader product:
 
 ## Links
 
-- **Enterpilot:** [enterpilot.io](https://enterpilot.io)
+- **Enterpilot:** [enterpilot.io](https://enterpilot.io?utm_source=gomodel_docs)
 - **Discord:** [Join our server](https://discord.gg/gaEB9BQSPH)

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -44,7 +44,7 @@ admin visibility in one place.
     <ProviderCredentialsNote />
   </Tab>
   <Tab title="Live Demo" icon="monitor-play">
-    [https://demo.enterpilot.io/admin/dashboard](https://demo.enterpilot.io/admin/dashboard)
+    [https://demo.enterpilot.io/admin/dashboard](https://demo.enterpilot.io/admin/dashboard?utm_source=gomodel_docs)
   </Tab>
 </Tabs>
 

--- a/internal/admin/dashboard/dashboard_test.go
+++ b/internal/admin/dashboard/dashboard_test.go
@@ -99,7 +99,7 @@ func TestIndex_DemoModeShowsWarning(t *testing.T) {
 	if !strings.Contains(body, "Do not enter sensitive or personal data. Demo data is reset regularly.") {
 		t.Error("expected demo mode data warning in page HTML")
 	}
-	if !strings.Contains(body, `href="https://gomodel.enterpilot.io/?utm_source=gomodel_dashboard&amp;utm_medium=demo_banner&amp;utm_campaign=public_demo" target="_blank" rel="noopener noreferrer">gomodel.enterpilot.io</a>`) {
+	if !strings.Contains(body, `href="https://gomodel.enterpilot.io/?utm_source=gomodel_dashboard" target="_blank" rel="noopener noreferrer">gomodel.enterpilot.io</a>`) {
 		t.Error("expected demo mode website link in page HTML")
 	}
 	for _, unwanted := range []string{

--- a/internal/admin/dashboard/static/js/modules/dashboard-layout.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/dashboard-layout.test.cjs
@@ -104,7 +104,7 @@ test("demo notice scrolls normally while page date ranges stay sticky", () => {
   assert.match(layout, /<aside class="demo-mode-banner"/);
   assert.match(
     layout,
-    /href="https:\/\/gomodel\.enterpilot\.io\/\?utm_source=gomodel_dashboard&amp;utm_medium=demo_banner&amp;utm_campaign=public_demo"[^>]*>gomodel\.enterpilot\.io<\/a>/,
+    /href="https:\/\/gomodel\.enterpilot\.io\/\?utm_source=gomodel_dashboard"[^>]*>gomodel\.enterpilot\.io<\/a>/,
   );
   assert.doesNotMatch(layout, /href="https:\/\/gomodel\.enterpilot\.io\/docs"/);
   assert.doesNotMatch(layout, /href="https:\/\/github\.com\/ENTERPILOT\/GoModel"/);

--- a/internal/admin/dashboard/static/js/modules/providers.js
+++ b/internal/admin/dashboard/static/js/modules/providers.js
@@ -326,7 +326,7 @@
                     (provider && (provider.type || (provider.config && provider.config.type))) || ''
                 ).trim().toLowerCase();
                 const slug = type ? PROVIDER_DOC_SLUGS[type] : '';
-                return slug ? PROVIDER_DOCS_BASE_URL + slug : '';
+                return slug ? PROVIDER_DOCS_BASE_URL + slug + '?utm_source=gomodel_dashboard' : '';
             },
 
             providerRetrySummary(provider) {

--- a/internal/admin/dashboard/static/js/modules/providers.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/providers.test.cjs
@@ -100,13 +100,13 @@ test('providerDocUrl links provider types with docs and stays empty otherwise', 
     const module = createProvidersModule();
 
     // Types with a dedicated docs page.
-    assert.equal(module.providerDocUrl({ type: 'anthropic' }), 'https://gomodel.enterpilot.io/docs/providers/anthropic');
-    assert.equal(module.providerDocUrl({ config: { type: 'bedrock' } }), 'https://gomodel.enterpilot.io/docs/providers/bedrock');
-    assert.equal(module.providerDocUrl({ type: 'bedrock-mantle' }), 'https://gomodel.enterpilot.io/docs/providers/bedrock-mantle');
+    assert.equal(module.providerDocUrl({ type: 'anthropic' }), 'https://gomodel.enterpilot.io/docs/providers/anthropic?utm_source=gomodel_dashboard');
+    assert.equal(module.providerDocUrl({ config: { type: 'bedrock' } }), 'https://gomodel.enterpilot.io/docs/providers/bedrock?utm_source=gomodel_dashboard');
+    assert.equal(module.providerDocUrl({ type: 'bedrock-mantle' }), 'https://gomodel.enterpilot.io/docs/providers/bedrock-mantle?utm_source=gomodel_dashboard');
     // Type slug differs from the docs slug.
-    assert.equal(module.providerDocUrl({ type: 'opencode_go' }), 'https://gomodel.enterpilot.io/docs/providers/opencode-go');
+    assert.equal(module.providerDocUrl({ type: 'opencode_go' }), 'https://gomodel.enterpilot.io/docs/providers/opencode-go?utm_source=gomodel_dashboard');
     // Resolves even when the (type) label is hidden because name === type.
-    assert.equal(module.providerDocUrl({ name: 'gemini', type: 'GEMINI' }), 'https://gomodel.enterpilot.io/docs/providers/gemini');
+    assert.equal(module.providerDocUrl({ name: 'gemini', type: 'GEMINI' }), 'https://gomodel.enterpilot.io/docs/providers/gemini?utm_source=gomodel_dashboard');
     // Types without a provider-specific doc → no link (no icon).
     assert.equal(module.providerDocUrl({ type: 'openai' }), '');
     assert.equal(module.providerDocUrl({ type: 'ollama' }), '');

--- a/internal/admin/dashboard/templates/layout.html
+++ b/internal/admin/dashboard/templates/layout.html
@@ -85,7 +85,7 @@
                     <span>Do not enter sensitive or personal data. Demo data is reset regularly.</span>
                 </div>
                 <nav class="demo-mode-banner-links" aria-label="GoModel website">
-                    <a href="https://gomodel.enterpilot.io/?utm_source=gomodel_dashboard&amp;utm_medium=demo_banner&amp;utm_campaign=public_demo" target="_blank" rel="noopener noreferrer">gomodel.enterpilot.io</a>
+                    <a href="https://gomodel.enterpilot.io/?utm_source=gomodel_dashboard" target="_blank" rel="noopener noreferrer">gomodel.enterpilot.io</a>
                 </nav>
             </aside>
             {{end}}


### PR DESCRIPTION
## Summary

- use source-only attribution for dashboard links to the GoModel website and provider documentation
- tag documentation links to the demo, ENTERPILOT website, and ENTERPILOT blog with utm_source=gomodel_docs
- leave third-party links, canonical URLs, and install commands unchanged

## Validation

- go test ./internal/admin/dashboard
- targeted dashboard JavaScript tests
- Mintlify broken-link check and build validation
- repository pre-commit hooks