### PR TITLE
feat(dashboard): rework usage charts with cache-aware diverging bars

### DIFF
--- a/cmd/gomodel/docs/docs.go
+++ b/cmd/gomodel/docs/docs.go
@@ -10100,6 +10100,16 @@ const docTemplate = `{
         "usage.LabelUsage": {
             "type": "object",
             "properties": {
+                "cache_write_input_tokens": {
+                    "type": "integer"
+                },
+                "cached_input_cost": {
+                    "type": "number",
+                    "x-nullable": true
+                },
+                "cached_input_tokens": {
+                    "type": "integer"
+                },
                 "input_cost": {
                     "type": "number",
                     "x-nullable": true
@@ -10109,6 +10119,12 @@ const docTemplate = `{
                 },
                 "label": {
                     "type": "string"
+                },
+                "local_cached_input_tokens": {
+                    "type": "integer"
+                },
+                "local_cached_output_tokens": {
+                    "type": "integer"
                 },
                 "output_cost": {
                     "type": "number",
@@ -10126,16 +10142,35 @@ const docTemplate = `{
                 },
                 "total_tokens": {
                     "type": "integer"
+                },
+                "uncached_input_tokens": {
+                    "type": "integer"
                 }
             }
         },
         "usage.ModelUsage": {
             "type": "object",
             "properties": {
+                "cache_write_input_tokens": {
+                    "type": "integer"
+                },
+                "cached_input_cost": {
+                    "type": "number",
+                    "x-nullable": true
+                },
+                "cached_input_tokens": {
+                    "type": "integer"
+                },
                 "input_cost": {
                     "type": "number"
                 },
                 "input_tokens": {
+                    "type": "integer"
+                },
+                "local_cached_input_tokens": {
+                    "type": "integer"
+                },
+                "local_cached_output_tokens": {
                     "type": "integer"
                 },
                 "model": {
@@ -10155,6 +10190,9 @@ const docTemplate = `{
                 },
                 "total_cost": {
                     "type": "number"
+                },
+                "uncached_input_tokens": {
+                    "type": "integer"
                 }
             }
         },
@@ -10405,11 +10443,27 @@ const docTemplate = `{
         "usage.UserPathUsage": {
             "type": "object",
             "properties": {
+                "cache_write_input_tokens": {
+                    "type": "integer"
+                },
+                "cached_input_cost": {
+                    "type": "number",
+                    "x-nullable": true
+                },
+                "cached_input_tokens": {
+                    "type": "integer"
+                },
                 "input_cost": {
                     "type": "number",
                     "x-nullable": true
                 },
                 "input_tokens": {
+                    "type": "integer"
+                },
+                "local_cached_input_tokens": {
+                    "type": "integer"
+                },
+                "local_cached_output_tokens": {
                     "type": "integer"
                 },
                 "output_cost": {
@@ -10424,6 +10478,9 @@ const docTemplate = `{
                     "x-nullable": true
                 },
                 "total_tokens": {
+                    "type": "integer"
+                },
+                "uncached_input_tokens": {
                     "type": "integer"
                 },
                 "user_path": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -13165,6 +13165,16 @@
       "usage.LabelUsage": {
         "type": "object",
         "properties": {
+          "cache_write_input_tokens": {
+            "type": "integer"
+          },
+          "cached_input_cost": {
+            "type": "number",
+            "nullable": true
+          },
+          "cached_input_tokens": {
+            "type": "integer"
+          },
           "input_cost": {
             "type": "number",
             "nullable": true
@@ -13174,6 +13184,12 @@
           },
           "label": {
             "type": "string"
+          },
+          "local_cached_input_tokens": {
+            "type": "integer"
+          },
+          "local_cached_output_tokens": {
+            "type": "integer"
           },
           "output_cost": {
             "type": "number",
@@ -13191,16 +13207,35 @@
           },
           "total_tokens": {
             "type": "integer"
+          },
+          "uncached_input_tokens": {
+            "type": "integer"
           }
         }
       },
       "usage.ModelUsage": {
         "type": "object",
         "properties": {
+          "cache_write_input_tokens": {
+            "type": "integer"
+          },
+          "cached_input_cost": {
+            "type": "number",
+            "nullable": true
+          },
+          "cached_input_tokens": {
+            "type": "integer"
+          },
           "input_cost": {
             "type": "number"
           },
           "input_tokens": {
+            "type": "integer"
+          },
+          "local_cached_input_tokens": {
+            "type": "integer"
+          },
+          "local_cached_output_tokens": {
             "type": "integer"
           },
           "model": {
@@ -13220,6 +13255,9 @@
           },
           "total_cost": {
             "type": "number"
+          },
+          "uncached_input_tokens": {
+            "type": "integer"
           }
         }
       },
@@ -13470,11 +13508,27 @@
       "usage.UserPathUsage": {
         "type": "object",
         "properties": {
+          "cache_write_input_tokens": {
+            "type": "integer"
+          },
+          "cached_input_cost": {
+            "type": "number",
+            "nullable": true
+          },
+          "cached_input_tokens": {
+            "type": "integer"
+          },
           "input_cost": {
             "type": "number",
             "nullable": true
           },
           "input_tokens": {
+            "type": "integer"
+          },
+          "local_cached_input_tokens": {
+            "type": "integer"
+          },
+          "local_cached_output_tokens": {
             "type": "integer"
           },
           "output_cost": {
@@ -13489,6 +13543,9 @@
             "nullable": true
           },
           "total_tokens": {
+            "type": "integer"
+          },
+          "uncached_input_tokens": {
             "type": "integer"
           },
           "user_path": {

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -1029,6 +1029,16 @@ body.dashboard-modal-open {
   justify-self: end;
 }
 
+/* Usage page: the Tokens/Costs toggle shares the sticky bar with the date
+   picker so both stay reachable while scrolling. */
+.usage-sticky-controls {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
 /* Interval Picker */
 .interval-picker {
   display: inline-flex;

--- a/internal/admin/dashboard/static/css/dashboard.css
+++ b/internal/admin/dashboard/static/css/dashboard.css
@@ -2999,6 +2999,27 @@ textarea:focus {
   color: #fff;
 }
 
+/* Usage charts flow two per row; a section alone in its row (odd count,
+   or neighbors hidden by x-show) grows to fill the full width. */
+.usage-charts-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  margin-bottom: 24px;
+}
+
+.usage-charts-grid .model-chart-section {
+  flex: 1 1 calc(50% - 24px);
+  min-width: 420px;
+  margin-bottom: 0;
+}
+
+@media (max-width: 520px) {
+  .usage-charts-grid .model-chart-section {
+    min-width: 0;
+  }
+}
+
 /* Usage by Model Chart Section */
 .model-chart-section {
   background: var(--bg-surface);

--- a/internal/admin/dashboard/static/js/modules/charts.js
+++ b/internal/admin/dashboard/static/js/modules/charts.js
@@ -104,63 +104,97 @@
                 };
             },
 
-            _barChartConfig(colors, labels, values, palette) {
+            // Horizontal input/output bars: one row per entity (model, user
+            // path, label). In the default diverging view the input-side
+            // series (paid input, prompt-cached reads) grow left from zero
+            // and the output-side series (output, locally-cached tokens) grow
+            // right; in the stacked view everything piles rightward from zero
+            // as segments of one bar. Series reuse the overview chart's
+            // token palette (paid browns, translucent cache blues) so they
+            // read consistently across the dashboard; the legend (and, when
+            // diverging, the left/right split) carries identity, not color
+            // alone. Cache series appear only when they have data.
+            _horizontalUsageChartConfig(colors, labels, series, stacked) {
+                const resolve = (expr) => (typeof this._resolveLiveTokenColor === 'function' ? this._resolveLiveTokenColor(expr) : expr);
+                const costs = this.usageMode === 'costs';
+                const fmtShort = (v) => costs ? '$' + Math.abs(v).toFixed(2) : this.formatTokensShort(Math.abs(v));
+                const fmtExact = (v) => costs ? '$' + Math.abs(v).toFixed(4) : Math.abs(v).toLocaleString();
+                const inputSide = (values) => values.map((v) => stacked ? Math.abs(v) : -Math.abs(v));
+                const bar = (label, data, color) => ({
+                    label: label,
+                    data: data,
+                    backgroundColor: color,
+                    borderColor: 'transparent',
+                    borderWidth: 0,
+                    borderRadius: 4,
+                    maxBarThickness: 22
+                });
+                const hasData = (values) => (values || []).some((v) => Math.abs(v) > 0);
+                const datasets = [
+                    bar(costs ? 'Input Cost' : 'Input Tokens', inputSide(series.inputs), resolve('var(--token-input)')),
+                    bar(costs ? 'Output Cost' : 'Output Tokens', series.outputs, resolve('var(--token-output)'))
+                ];
+                if (hasData(series.prompts)) {
+                    datasets.push(bar(costs ? 'Prompt Cached Cost' : 'Prompt Cached', inputSide(series.prompts), resolve('var(--token-prompt)')));
+                }
+                // Local cache hits carry both sides, so each joins its own
+                // half of the axis (they pile together in the stacked view).
+                if (!costs && hasData(series.localIns)) {
+                    datasets.push(bar('Locally Cached (Input)', inputSide(series.localIns), resolve('var(--token-local)')));
+                }
+                if (!costs && hasData(series.localOuts)) {
+                    datasets.push(bar('Locally Cached (Output)', series.localOuts, resolve('var(--token-local)')));
+                }
                 return {
                     type: 'bar',
                     data: {
                         labels: labels,
-                        datasets: [{
-                            data: values,
-                            backgroundColor: labels.map((_, i) => palette[i % palette.length]),
-                            borderColor: 'transparent',
-                            borderWidth: 0,
-                            borderRadius: 4
-                        }]
+                        datasets: datasets
                     },
                     options: {
+                        indexAxis: 'y',
                         responsive: true,
                         maintainAspectRatio: false,
                         animation: { duration: 0 },
                         layout: { padding: { top: 8 } },
                         scales: {
                             x: {
-                                grid: { display: false },
-                                ticks: {
-                                    color: colors.text,
-                                    font: { size: 11, family: "'SF Mono', Menlo, Consolas, monospace" },
-                                    maxRotation: 45,
-                                    minRotation: 0
-                                }
-                            },
-                            y: {
-                                grid: { color: colors.grid },
+                                stacked: true,
+                                beginAtZero: true,
+                                // Emphasize the zero divider between the diverging halves.
+                                grid: stacked
+                                    ? { color: colors.grid }
+                                    : { color: (ctx) => (ctx.tick && ctx.tick.value === 0 ? colors.text : colors.grid) },
                                 border: { display: false },
                                 ticks: {
                                     color: colors.text,
-                                    font: { size: 11, family: "'SF Mono', Menlo, Consolas, monospace" },
-                                    callback: (v) => {
-                                        if (this.usageMode === 'costs') return '$' + v.toFixed(2);
-                                        return this.formatTokensShort(v);
-                                    }
+                                    font: this._chartTickFont(),
+                                    callback: (v) => fmtShort(v)
+                                }
+                            },
+                            y: {
+                                stacked: true,
+                                grid: { display: false },
+                                border: { display: false },
+                                ticks: {
+                                    color: colors.text,
+                                    font: this._chartTickFont(),
+                                    autoSkip: false
                                 }
                             }
                         },
                         plugins: {
-                            legend: { display: false },
-                            tooltip: {
-                                backgroundColor: colors.tooltipBg,
-                                borderColor: colors.tooltipBorder,
-                                borderWidth: 1,
-                                titleColor: colors.tooltipText,
-                                bodyColor: colors.tooltipText,
-                                callbacks: {
-                                    label: (c) => {
-                                        const val = c.parsed.y;
-                                        if (this.usageMode === 'costs') return '$' + val.toFixed(4);
-                                        return this.formatTokensShort(val);
-                                    }
+                            legend: {
+                                labels: { color: colors.text, font: { size: 12 } }
+                            },
+                            tooltip: this._chartTooltip(colors, {
+                                label: (c) => c.dataset.label + ': ' + fmtExact(c.parsed.x),
+                                footer: (items) => {
+                                    let total = 0;
+                                    items.forEach((it) => { total += Math.abs(Number(it.parsed.x)) || 0; });
+                                    return 'Total: ' + fmtExact(total);
                                 }
-                            }
+                            })
                         }
                     }
                 };
@@ -356,27 +390,6 @@
                 return ((row && row.input_tokens) || 0) + ((row && row.output_tokens) || 0);
             },
 
-            _barDataFrom(items, labelFor) {
-                const sorted = this._usageRowsBySelectedValue(items);
-
-                const top = sorted.slice(0, 10);
-                const rest = sorted.slice(10);
-
-                const labels = top.map(labelFor);
-                const values = top.map((row) => this._usageAggregateValue(row));
-
-                if (rest.length > 0) {
-                    labels.push('Other');
-                    let otherVal = 0;
-                    rest.forEach((row) => {
-                        otherVal += this._usageAggregateValue(row);
-                    });
-                    values.push(otherVal);
-                }
-
-                return { labels, values };
-            },
-
             _usageRowsBySelectedValue(items) {
                 return [...(items || [])].sort((a, b) => {
                     if (this.usageMode === 'costs') {
@@ -410,18 +423,72 @@
                 return onlyPath !== '' && onlyPath !== '/';
             },
 
-            _barData() {
-                return this._barDataFrom(this.modelUsage, (m) => typeof this.qualifiedModelDisplay === 'function'
-                    ? this.qualifiedModelDisplay(m)
-                    : m.model);
+            // Per-row series split for the diverging charts. Rows keep the
+            // selected-metric ordering; past the top 10 they fold into a
+            // single "Other" row.
+            //
+            // Tokens mode mirrors the overview chart's accounting: the Input
+            // series is paid input (uncached + cache writes; full input when
+            // the split is absent), prompt-cache reads and locally-cached
+            // tokens are their own series. Costs mode splits the estimated
+            // prompt-cached read cost out of the input cost; local cache hits
+            // cost nothing, so they have no cost series.
+            _divergingDataFrom(items, labelFor) {
+                const sorted = this._usageRowsBySelectedValue(items);
+                const costs = this.usageMode === 'costs';
+                const num = (v) => Number(v) || 0;
+                const inputOf = (row) => {
+                    if (costs) return Math.max(0, num(row.input_cost) - num(row.cached_input_cost));
+                    const split = num(row.uncached_input_tokens) + num(row.cached_input_tokens) + num(row.cache_write_input_tokens);
+                    return split > 0 ? num(row.uncached_input_tokens) + num(row.cache_write_input_tokens) : num(row.input_tokens);
+                };
+                const outputOf = (row) => num(costs ? row.output_cost : row.output_tokens);
+                const promptOf = (row) => num(costs ? row.cached_input_cost : row.cached_input_tokens);
+                const localInputOf = (row) => costs ? 0 : num(row.local_cached_input_tokens);
+                const localOutputOf = (row) => costs ? 0 : num(row.local_cached_output_tokens);
+
+                const top = sorted.slice(0, 10);
+                const rest = sorted.slice(10);
+
+                const labels = top.map(labelFor);
+                const inputs = top.map(inputOf);
+                const outputs = top.map(outputOf);
+                const prompts = top.map(promptOf);
+                const localIns = top.map(localInputOf);
+                const localOuts = top.map(localOutputOf);
+
+                if (rest.length > 0) {
+                    labels.push('Other');
+                    const sum = (of) => rest.reduce((total, row) => total + of(row), 0);
+                    inputs.push(sum(inputOf));
+                    outputs.push(sum(outputOf));
+                    prompts.push(sum(promptOf));
+                    localIns.push(sum(localInputOf));
+                    localOuts.push(sum(localOutputOf));
+                }
+
+                return { labels, inputs, outputs, prompts, localIns, localOuts };
             },
 
-            _userPathBarData() {
-                return this._barDataFrom(this.userPathUsage || [], (u) => u.user_path || '/');
+            // A view value that renders on the canvas (as opposed to the table).
+            _isChartView(view) {
+                return (view || 'chart') === 'chart' || view === 'stacked';
             },
 
-            _labelBarData() {
-                return this._barDataFrom(this.labelUsage || [], (l) => l.label);
+            // Shared by the three usage charts: build the diverging or stacked
+            // config, grow the wrapper with the row count so horizontal bars
+            // stay readable instead of squeezing into a fixed height, and
+            // mount the chart.
+            _createUsageBarChart(canvas, items, labelFor, view) {
+                const series = this._divergingDataFrom(items, labelFor);
+                const config = this._horizontalUsageChartConfig(this.chartColors(), series.labels, series, view === 'stacked');
+
+                const wrap = canvas.parentElement;
+                if (wrap) {
+                    wrap.style.height = Math.max(200, series.labels.length * 32 + 72) + 'px';
+                }
+
+                return new Chart(canvas, config);
             },
 
             // Deterministic label -> palette color so a label keeps one color
@@ -438,22 +505,6 @@
 
             labelChipStyle(label) {
                 return { '--label-color': this.labelColor(label) };
-            },
-
-            // The synthetic "Other" bar gets a neutral tone instead of a
-            // hashed identity color.
-            _labelBarPalette(labels) {
-                return labels.map((label) => label === 'Other' ? '#a8a29a' : this.labelColor(label));
-            },
-
-            barLegendItems() {
-                const { labels, values } = this._barData();
-                const colors = this._barColors();
-                return labels.map((label, i) => ({
-                    label,
-                    color: colors[i % colors.length],
-                    value: this.usageMode === 'costs' ? '$' + values[i].toFixed(4) : this.formatTokensShort(values[i])
-                }));
             },
 
             toggleUsageChartView(target, view) {
@@ -478,7 +529,7 @@
             renderBarChart(retries) {
                 if (retries === undefined) retries = 3;
                 this.$nextTick(() => {
-                    if (this.modelUsage.length === 0 || this.page !== 'usage' || (this.modelUsageView || 'chart') !== 'chart') {
+                    if (this.modelUsage.length === 0 || this.page !== 'usage' || !this._isChartView(this.modelUsageView)) {
                         if (this.usageBarChart) {
                             this.usageBarChart.destroy();
                             this.usageBarChart = null;
@@ -494,24 +545,21 @@
                         return;
                     }
 
-                    const colors = this.chartColors();
-                    const { labels, values } = this._barData();
-                    const palette = this._barColors();
-                    const config = this._barChartConfig(colors, labels, values, palette);
-
                     if (this.usageBarChart) {
                         this.usageBarChart.destroy();
                         this.usageBarChart = null;
                     }
 
-                    this.usageBarChart = new Chart(canvas, config);
+                    this.usageBarChart = this._createUsageBarChart(canvas, this.modelUsage, (m) => typeof this.qualifiedModelDisplay === 'function'
+                        ? this.qualifiedModelDisplay(m)
+                        : m.model, this.modelUsageView);
                 });
             },
 
             renderUserPathChart(retries) {
                 if (retries === undefined) retries = 3;
                 this.$nextTick(() => {
-                    if (!this.userPathUsageChartVisible() || this.page !== 'usage' || (this.userPathUsageView || 'chart') !== 'chart') {
+                    if (!this.userPathUsageChartVisible() || this.page !== 'usage' || !this._isChartView(this.userPathUsageView)) {
                         if (this.usageUserPathChart) {
                             this.usageUserPathChart.destroy();
                             this.usageUserPathChart = null;
@@ -527,24 +575,19 @@
                         return;
                     }
 
-                    const colors = this.chartColors();
-                    const { labels, values } = this._userPathBarData();
-                    const palette = this._barColors();
-                    const config = this._barChartConfig(colors, labels, values, palette);
-
                     if (this.usageUserPathChart) {
                         this.usageUserPathChart.destroy();
                         this.usageUserPathChart = null;
                     }
 
-                    this.usageUserPathChart = new Chart(canvas, config);
+                    this.usageUserPathChart = this._createUsageBarChart(canvas, this.userPathUsage || [], (u) => u.user_path || '/', this.userPathUsageView);
                 });
             },
 
             renderLabelChart(retries) {
                 if (retries === undefined) retries = 3;
                 this.$nextTick(() => {
-                    if ((this.labelUsage || []).length === 0 || this.page !== 'usage' || (this.labelUsageView || 'chart') !== 'chart') {
+                    if ((this.labelUsage || []).length === 0 || this.page !== 'usage' || !this._isChartView(this.labelUsageView)) {
                         if (this.usageLabelChart) {
                             this.usageLabelChart.destroy();
                             this.usageLabelChart = null;
@@ -560,17 +603,12 @@
                         return;
                     }
 
-                    const colors = this.chartColors();
-                    const { labels, values } = this._labelBarData();
-                    const palette = this._labelBarPalette(labels);
-                    const config = this._barChartConfig(colors, labels, values, palette);
-
                     if (this.usageLabelChart) {
                         this.usageLabelChart.destroy();
                         this.usageLabelChart = null;
                     }
 
-                    this.usageLabelChart = new Chart(canvas, config);
+                    this.usageLabelChart = this._createUsageBarChart(canvas, this.labelUsage || [], (l) => l.label, this.labelUsageView);
                 });
             }
         };

--- a/internal/admin/dashboard/static/js/modules/charts.js
+++ b/internal/admin/dashboard/static/js/modules/charts.js
@@ -437,13 +437,20 @@
                 const sorted = this._usageRowsBySelectedValue(items);
                 const costs = this.usageMode === 'costs';
                 const num = (v) => Number(v) || 0;
+                // The cached cost is an estimate at current prices while
+                // input_cost is the recorded charge, so cap the cached
+                // segment at the recorded input cost — the two segments then
+                // always sum to it and the bar never exceeds recorded totals.
+                const promptOf = (row) => {
+                    if (!costs) return num(row.cached_input_tokens);
+                    return Math.min(num(row.cached_input_cost), num(row.input_cost));
+                };
                 const inputOf = (row) => {
-                    if (costs) return Math.max(0, num(row.input_cost) - num(row.cached_input_cost));
+                    if (costs) return num(row.input_cost) - promptOf(row);
                     const split = num(row.uncached_input_tokens) + num(row.cached_input_tokens) + num(row.cache_write_input_tokens);
                     return split > 0 ? num(row.uncached_input_tokens) + num(row.cache_write_input_tokens) : num(row.input_tokens);
                 };
                 const outputOf = (row) => num(costs ? row.output_cost : row.output_tokens);
-                const promptOf = (row) => num(costs ? row.cached_input_cost : row.cached_input_tokens);
                 const localInputOf = (row) => costs ? 0 : num(row.local_cached_input_tokens);
                 const localOutputOf = (row) => costs ? 0 : num(row.local_cached_output_tokens);
 

--- a/internal/admin/dashboard/static/js/modules/charts.js
+++ b/internal/admin/dashboard/static/js/modules/charts.js
@@ -1,4 +1,8 @@
 (function(global) {
+    /**
+     * Create chart configuration, data-preparation, and rendering helpers for the dashboard.
+     * @return {Object} The dashboard chart helper and lifecycle methods.
+     */
     function dashboardChartsModule() {
         return {
             // --- Shared overview chart styling, so the line (Daily Token Usage)

--- a/internal/admin/dashboard/static/js/modules/charts.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/charts.test.cjs
@@ -269,6 +269,29 @@ test('renderBarChart costs mode splits estimated cached cost out of input cost',
     assert.ok(!chart.data.datasets.some((d) => d.label.startsWith('Locally Cached')));
 });
 
+test('renderBarChart caps the estimated cached cost at the recorded input cost', () => {
+    FakeChart.instances = [];
+    const { module } = createChartsContext();
+    module.page = 'usage';
+    module.usageMode = 'costs';
+    // Estimated cached cost (current prices) exceeds the recorded charge.
+    module.modelUsage = [
+        {
+            model: 'gpt-5', input_tokens: 100, output_tokens: 20,
+            cached_input_tokens: 60,
+            input_cost: 0.125, output_cost: 0.25, total_cost: 0.375, cached_input_cost: 0.5
+        }
+    ];
+
+    module.renderBarChart();
+
+    const chart = module.usageBarChart;
+    // Segments always sum to the recorded input cost.
+    assert.equal(JSON.stringify(chart.data.datasets[0].data), JSON.stringify([-0]));
+    assert.equal(chart.data.datasets[2].label, 'Prompt Cached Cost');
+    assert.equal(JSON.stringify(chart.data.datasets[2].data), JSON.stringify([-0.125]));
+});
+
 test('renderBarChart folds models past the top 10 into a combined Other row', () => {
     FakeChart.instances = [];
     const { module } = createChartsContext();

--- a/internal/admin/dashboard/static/js/modules/charts.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/charts.test.cjs
@@ -116,6 +116,9 @@ test('renderBarChart recreates the usage bar chart instance on refresh', () => {
 
     assert.equal(FakeChart.instances.length, 1);
     const firstChart = module.usageBarChart;
+    assert.equal(JSON.stringify(firstChart.data.labels), JSON.stringify(['gpt-5', 'gpt-4o']));
+    assert.equal(JSON.stringify(firstChart.data.datasets[0].data), JSON.stringify([-11, -5]));
+    assert.equal(JSON.stringify(firstChart.data.datasets[1].data), JSON.stringify([13, 7]));
 
     module.modelUsage = [
         { model: 'gpt-5', input_tokens: 21, output_tokens: 34, total_cost: 0.03 }
@@ -126,8 +129,166 @@ test('renderBarChart recreates the usage bar chart instance on refresh', () => {
     assert.equal(FakeChart.instances.length, 2);
     assert.equal(firstChart.destroyCalls, 1);
     assert.equal(JSON.stringify(module.usageBarChart.data.labels), JSON.stringify(['gpt-5']));
-    assert.equal(JSON.stringify(module.usageBarChart.data.datasets[0].data), JSON.stringify([55]));
+    assert.equal(JSON.stringify(module.usageBarChart.data.datasets[0].data), JSON.stringify([-21]));
+    assert.equal(JSON.stringify(module.usageBarChart.data.datasets[1].data), JSON.stringify([34]));
+    assert.equal(module.usageBarChart.options.indexAxis, 'y');
     assert.equal(JSON.stringify(firstChart.updateCalls), JSON.stringify([]));
+});
+
+test('renderBarChart splits input and output costs in costs mode', () => {
+    FakeChart.instances = [];
+    const { module } = createChartsContext();
+    module.page = 'usage';
+    module.usageMode = 'costs';
+    module.modelUsage = [
+        { model: 'gpt-4o', input_tokens: 5, output_tokens: 7, input_cost: 0.01, output_cost: 0.04, total_cost: 0.05 },
+        { model: 'gpt-5', input_tokens: 11, output_tokens: 13, input_cost: 0.02, output_cost: 0.06, total_cost: 0.08 }
+    ];
+
+    module.renderBarChart();
+
+    const chart = module.usageBarChart;
+    assert.equal(JSON.stringify(chart.data.labels), JSON.stringify(['gpt-5', 'gpt-4o']));
+    assert.equal(JSON.stringify(chart.data.datasets[0].data), JSON.stringify([-0.02, -0.01]));
+    assert.equal(JSON.stringify(chart.data.datasets[1].data), JSON.stringify([0.06, 0.04]));
+    assert.equal(chart.data.datasets[0].label, 'Input Cost');
+    assert.equal(chart.data.datasets[1].label, 'Output Cost');
+});
+
+test('renderBarChart stacked view piles input and output rightward as positive values', () => {
+    FakeChart.instances = [];
+    const { module } = createChartsContext();
+    module.page = 'usage';
+    module.usageMode = 'tokens';
+    module.modelUsageView = 'stacked';
+    module.modelUsage = [
+        { model: 'gpt-4o', input_tokens: 5, output_tokens: 7, total_cost: 0.01 },
+        { model: 'gpt-5', input_tokens: 11, output_tokens: 13, total_cost: 0.02 }
+    ];
+
+    module.renderBarChart();
+
+    const chart = module.usageBarChart;
+    assert.notEqual(chart, null);
+    assert.equal(JSON.stringify(chart.data.labels), JSON.stringify(['gpt-5', 'gpt-4o']));
+    assert.equal(JSON.stringify(chart.data.datasets[0].data), JSON.stringify([11, 5]));
+    assert.equal(JSON.stringify(chart.data.datasets[1].data), JSON.stringify([13, 7]));
+    assert.equal(chart.options.indexAxis, 'y');
+    assert.equal(chart.options.scales.x.stacked, true);
+});
+
+test('toggleUsageChartView switches between diverging and stacked chart views', () => {
+    FakeChart.instances = [];
+    const { module } = createChartsContext();
+    module.page = 'usage';
+    module.usageMode = 'tokens';
+    module.modelUsageView = 'chart';
+    module.modelUsage = [
+        { model: 'gpt-5', input_tokens: 10, output_tokens: 20, total_cost: 0.01 }
+    ];
+
+    module.renderBarChart();
+    const divergingChart = module.usageBarChart;
+    assert.equal(JSON.stringify(divergingChart.data.datasets[0].data), JSON.stringify([-10]));
+
+    module.toggleUsageChartView('model', 'stacked');
+
+    assert.equal(module.modelUsageView, 'stacked');
+    assert.equal(divergingChart.destroyCalls, 1);
+    assert.equal(JSON.stringify(module.usageBarChart.data.datasets[0].data), JSON.stringify([10]));
+});
+
+test('renderBarChart adds cache series and splits paid input when cache data is present', () => {
+    FakeChart.instances = [];
+    const { module } = createChartsContext();
+    module.page = 'usage';
+    module.usageMode = 'tokens';
+    module.modelUsage = [
+        {
+            model: 'gpt-5', input_tokens: 100, output_tokens: 20,
+            uncached_input_tokens: 30, cached_input_tokens: 60, cache_write_input_tokens: 10,
+            local_cached_input_tokens: 100, local_cached_output_tokens: 20, total_cost: 0.02
+        }
+    ];
+
+    module.renderBarChart();
+
+    const chart = module.usageBarChart;
+    assert.equal(chart.data.datasets.length, 5);
+    // Paid input = uncached + cache writes, on the left.
+    assert.equal(chart.data.datasets[0].label, 'Input Tokens');
+    assert.equal(JSON.stringify(chart.data.datasets[0].data), JSON.stringify([-40]));
+    assert.equal(chart.data.datasets[1].label, 'Output Tokens');
+    assert.equal(JSON.stringify(chart.data.datasets[1].data), JSON.stringify([20]));
+    // Prompt-cache reads join the input side; local cache splits per side.
+    assert.equal(chart.data.datasets[2].label, 'Prompt Cached');
+    assert.equal(JSON.stringify(chart.data.datasets[2].data), JSON.stringify([-60]));
+    assert.equal(chart.data.datasets[3].label, 'Locally Cached (Input)');
+    assert.equal(JSON.stringify(chart.data.datasets[3].data), JSON.stringify([-100]));
+    assert.equal(chart.data.datasets[4].label, 'Locally Cached (Output)');
+    assert.equal(JSON.stringify(chart.data.datasets[4].data), JSON.stringify([20]));
+});
+
+test('renderBarChart keeps two series when rows carry no cache data', () => {
+    FakeChart.instances = [];
+    const { module } = createChartsContext();
+    module.page = 'usage';
+    module.usageMode = 'tokens';
+    module.modelUsage = [
+        { model: 'gpt-5', input_tokens: 100, output_tokens: 20, total_cost: 0.02 }
+    ];
+
+    module.renderBarChart();
+
+    assert.equal(module.usageBarChart.data.datasets.length, 2);
+    assert.equal(JSON.stringify(module.usageBarChart.data.datasets[0].data), JSON.stringify([-100]));
+});
+
+test('renderBarChart costs mode splits estimated cached cost out of input cost', () => {
+    FakeChart.instances = [];
+    const { module } = createChartsContext();
+    module.page = 'usage';
+    module.usageMode = 'costs';
+    module.modelUsage = [
+        {
+            model: 'gpt-5', input_tokens: 100, output_tokens: 20,
+            cached_input_tokens: 60, local_cached_input_tokens: 100, local_cached_output_tokens: 20,
+            input_cost: 0.5, output_cost: 0.3, total_cost: 0.8, cached_input_cost: 0.125
+        }
+    ];
+
+    module.renderBarChart();
+
+    const chart = module.usageBarChart;
+    assert.equal(chart.data.datasets.length, 3);
+    assert.equal(chart.data.datasets[0].label, 'Input Cost');
+    assert.equal(JSON.stringify(chart.data.datasets[0].data), JSON.stringify([-0.375]));
+    assert.equal(chart.data.datasets[2].label, 'Prompt Cached Cost');
+    assert.equal(JSON.stringify(chart.data.datasets[2].data), JSON.stringify([-0.125]));
+    // Local cache hits cost nothing: no cost-mode series for them.
+    assert.ok(!chart.data.datasets.some((d) => d.label.startsWith('Locally Cached')));
+});
+
+test('renderBarChart folds models past the top 10 into a combined Other row', () => {
+    FakeChart.instances = [];
+    const { module } = createChartsContext();
+    module.page = 'usage';
+    module.usageMode = 'tokens';
+    module.modelUsage = Array.from({ length: 12 }, (_, i) => ({
+        model: 'model-' + i,
+        input_tokens: 100 - i,
+        output_tokens: 200 - i,
+        total_cost: 0.01
+    }));
+
+    module.renderBarChart();
+
+    const chart = module.usageBarChart;
+    assert.equal(chart.data.labels.length, 11);
+    assert.equal(chart.data.labels[10], 'Other');
+    // model-10 and model-11 fold together: inputs 90+89, outputs 190+189.
+    assert.equal(chart.data.datasets[0].data[10], -179);
+    assert.equal(chart.data.datasets[1].data[10], 379);
 });
 
 test('renderBarChart prefers provider_name in model labels when available', () => {
@@ -162,11 +323,12 @@ test('renderUserPathChart recreates the user path chart and uses usage mode valu
     assert.equal(FakeChart.instances.length, 1);
     const firstChart = module.usageUserPathChart;
     assert.equal(JSON.stringify(firstChart.data.labels), JSON.stringify(['/team/beta', '/team/alpha']));
-    assert.equal(JSON.stringify(firstChart.data.datasets[0].data), JSON.stringify([24, 12]));
+    assert.equal(JSON.stringify(firstChart.data.datasets[0].data), JSON.stringify([-11, -5]));
+    assert.equal(JSON.stringify(firstChart.data.datasets[1].data), JSON.stringify([13, 7]));
 
     module.usageMode = 'costs';
     module.userPathUsage = [
-        { user_path: '/team/alpha', input_tokens: 21, output_tokens: 34, total_tokens: 55, total_cost: 0.03 }
+        { user_path: '/team/alpha', input_tokens: 21, output_tokens: 34, total_tokens: 55, input_cost: 0.01, output_cost: 0.02, total_cost: 0.03 }
     ];
     module.renderUserPathChart();
 
@@ -174,7 +336,8 @@ test('renderUserPathChart recreates the user path chart and uses usage mode valu
     assert.equal(FakeChart.instances.length, 2);
     assert.equal(firstChart.destroyCalls, 1);
     assert.equal(JSON.stringify(module.usageUserPathChart.data.labels), JSON.stringify(['/team/alpha']));
-    assert.equal(JSON.stringify(module.usageUserPathChart.data.datasets[0].data), JSON.stringify([0.03]));
+    assert.equal(JSON.stringify(module.usageUserPathChart.data.datasets[0].data), JSON.stringify([-0.01]));
+    assert.equal(JSON.stringify(module.usageUserPathChart.data.datasets[1].data), JSON.stringify([0.02]));
 });
 
 test('user path usage chart hides when the only path is root', () => {
@@ -272,7 +435,7 @@ test('labelColor is deterministic and drawn from the shared palette', () => {
     assert.equal(module.labelChipStyle('x')['--label-color'], module.labelColor('x'));
 });
 
-test('renderLabelChart orders bars by selected metric and colors them per label', () => {
+test('renderLabelChart orders rows by selected metric and splits input and output', () => {
     FakeChart.instances = [];
     const { module } = createChartsContext();
     module.page = 'usage';
@@ -288,11 +451,9 @@ test('renderLabelChart orders bars by selected metric and colors them per label'
     assert.equal(FakeChart.instances.length, 1);
     const chart = module.usageLabelChart;
     assert.equal(JSON.stringify(chart.data.labels), JSON.stringify(['prod', 'alpha']));
-    assert.equal(JSON.stringify(chart.data.datasets[0].data), JSON.stringify([24, 12]));
-    assert.equal(
-        JSON.stringify(chart.data.datasets[0].backgroundColor),
-        JSON.stringify([module.labelColor('prod'), module.labelColor('alpha')])
-    );
+    assert.equal(JSON.stringify(chart.data.datasets[0].data), JSON.stringify([-11, -5]));
+    assert.equal(JSON.stringify(chart.data.datasets[1].data), JSON.stringify([13, 7]));
+    assert.equal(chart.options.indexAxis, 'y');
 
     module.labelUsage = [];
     module.renderLabelChart();

--- a/internal/admin/dashboard/static/js/modules/dashboard-layout.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/dashboard-layout.test.cjs
@@ -112,7 +112,7 @@ test("demo notice scrolls normally while page date ranges stay sticky", () => {
   assert.doesNotMatch(demoRule, /position:\s*sticky/);
   assert.doesNotMatch(demoRule, /top:\s*\d/);
 
-  for (const page of [overview, usage, audit]) {
+  for (const page of [overview, audit]) {
     assert.match(page, /<div class="page-with-sticky-date">/);
     assert.match(page, /class="page-header date-range-page-header"/);
     assert.match(
@@ -120,6 +120,15 @@ test("demo notice scrolls normally while page date ranges stay sticky", () => {
       /<div class="sticky-date-range">{{template "date-picker" \.}}<\/div>/,
     );
   }
+
+  // The usage page's sticky bar also hosts the Tokens/Costs mode toggle so
+  // it stays reachable while scrolling.
+  assert.match(usage, /<div class="page-with-sticky-date">/);
+  assert.match(usage, /class="page-header date-range-page-header"/);
+  assert.match(
+    usage,
+    /<div class="sticky-date-range usage-sticky-controls">[\s\S]*class="usage-mode-toggle"[\s\S]*{{template "date-picker" \.}}[\s\S]*<\/div>/,
+  );
 
   const stickyRule = readCSSRule(
     css,

--- a/internal/admin/dashboard/static/js/modules/dashboard-layout.test.cjs
+++ b/internal/admin/dashboard/static/js/modules/dashboard-layout.test.cjs
@@ -1499,11 +1499,11 @@ test("usage charts can switch between chart and table views", () => {
 
   assert.match(
     indexTemplate,
-    /class="chart-view-toggle"[\s\S]*@click="toggleUsageChartView\('model', 'chart'\)"[\s\S]*@click="toggleUsageChartView\('model', 'table'\)"/,
+    /class="chart-view-toggle"[\s\S]*@click="toggleUsageChartView\('model', 'chart'\)"[\s\S]*@click="toggleUsageChartView\('model', 'stacked'\)"[\s\S]*@click="toggleUsageChartView\('model', 'table'\)"/,
   );
   assert.match(
     indexTemplate,
-    /<div class="bar-chart-wrap" x-show="modelUsageView === 'chart'">[\s\S]*<canvas id="usageBarChart"><\/canvas>/,
+    /<div class="bar-chart-wrap" x-show="_isChartView\(modelUsageView\)">[\s\S]*<canvas id="usageBarChart"><\/canvas>/,
   );
   assert.match(
     indexTemplate,
@@ -1511,7 +1511,7 @@ test("usage charts can switch between chart and table views", () => {
   );
   assert.match(
     indexTemplate,
-    /class="chart-view-toggle"[\s\S]*@click="toggleUsageChartView\('userPath', 'chart'\)"[\s\S]*@click="toggleUsageChartView\('userPath', 'table'\)"/,
+    /class="chart-view-toggle"[\s\S]*@click="toggleUsageChartView\('userPath', 'chart'\)"[\s\S]*@click="toggleUsageChartView\('userPath', 'stacked'\)"[\s\S]*@click="toggleUsageChartView\('userPath', 'table'\)"/,
   );
   assert.match(
     indexTemplate,
@@ -1519,7 +1519,7 @@ test("usage charts can switch between chart and table views", () => {
   );
   assert.match(
     indexTemplate,
-    /<div class="bar-chart-wrap" x-show="userPathUsageView === 'chart'">[\s\S]*<canvas id="usageUserPathChart"><\/canvas>/,
+    /<div class="bar-chart-wrap" x-show="_isChartView\(userPathUsageView\)">[\s\S]*<canvas id="usageUserPathChart"><\/canvas>/,
   );
   assert.match(
     indexTemplate,

--- a/internal/admin/dashboard/templates/page-usage.html
+++ b/internal/admin/dashboard/templates/page-usage.html
@@ -4,14 +4,16 @@
 <div class="page-with-sticky-date">
     <div class="page-header date-range-page-header">
         <h2>Usage Analytics</h2>
-        <div class="page-header-controls">
-            <div class="usage-mode-toggle">
-                <button type="button" class="usage-mode-btn" :class="{active: usageMode==='tokens'}" @click="toggleUsageMode('tokens')">Tokens</button>
-                <button type="button" class="usage-mode-btn" :class="{active: usageMode==='costs'}" @click="toggleUsageMode('costs')">Costs</button>
-            </div>
-        </div>
     </div>
-    <div class="sticky-date-range">{{template "date-picker" .}}</div>
+    <!-- The mode toggle lives in the sticky bar so it stays reachable while
+         scrolling, like the date range it changes the meaning of. -->
+    <div class="sticky-date-range usage-sticky-controls">
+        <div class="usage-mode-toggle" role="group" aria-label="Usage mode">
+            <button type="button" class="usage-mode-btn" :class="{active: usageMode==='tokens'}" @click="toggleUsageMode('tokens')">Tokens</button>
+            <button type="button" class="usage-mode-btn" :class="{active: usageMode==='costs'}" @click="toggleUsageMode('costs')">Costs</button>
+        </div>
+        {{template "date-picker" .}}
+    </div>
 
     <!-- Auth Error Banner -->
     {{template "auth-banner" .}}

--- a/internal/admin/dashboard/templates/page-usage.html
+++ b/internal/admin/dashboard/templates/page-usage.html
@@ -72,20 +72,26 @@
         </div>
     </div>
 
+    <!-- Usage charts: two per row, a chart alone in its row stretches to full width -->
+    <div class="usage-charts-grid">
+
     <!-- Usage by Model Chart -->
     <div class="model-chart-section" x-show="modelUsage.length > 0">
         <div class="model-chart-header">
             <h3 x-text="usageMode === 'tokens' ? 'Token Usage by Model' : 'Cost by Model'"></h3>
             <div class="chart-view-toggle" role="group" aria-label="Model usage view">
                 <button type="button" class="chart-view-btn" :class="{active: modelUsageView === 'chart'}" :aria-pressed="modelUsageView === 'chart' ? 'true' : 'false'" aria-label="Show model usage chart" title="Chart" @click="toggleUsageChartView('model', 'chart')">
-                    <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 19V11M12 19V5M19 19v-8"/></svg>
+                    <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 4v16M12 8h7M12 12H7M12 16h4"/></svg>
+                </button>
+                <button type="button" class="chart-view-btn" :class="{active: modelUsageView === 'stacked'}" :aria-pressed="modelUsageView === 'stacked' ? 'true' : 'false'" aria-label="Show model usage stacked chart" title="Stacked" @click="toggleUsageChartView('model', 'stacked')">
+                    <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 4v16M5 8h6m2 0h4M5 12h9m2 0h3M5 16h4m2 0h2"/></svg>
                 </button>
                 <button type="button" class="chart-view-btn" :class="{active: modelUsageView === 'table'}" :aria-pressed="modelUsageView === 'table' ? 'true' : 'false'" aria-label="Show model usage table" title="Table" @click="toggleUsageChartView('model', 'table')">
                     <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 6h16M4 12h16M4 18h16M9 6v12M15 6v12"/></svg>
                 </button>
             </div>
         </div>
-        <div class="bar-chart-wrap" x-show="modelUsageView === 'chart'">
+        <div class="bar-chart-wrap" x-show="_isChartView(modelUsageView)">
             <canvas id="usageBarChart"></canvas>
         </div>
         <template x-if="modelUsageView === 'table'">
@@ -97,6 +103,8 @@
                             <th>Provider</th>
                             <th class="col-price">Input Tokens</th>
                             <th class="col-price">Output Tokens</th>
+                            <th class="col-price" title="Provider prompt-cache reads included in the input tokens">Prompt Cached</th>
+                            <th class="col-price" title="Tokens served from GoModel's local response cache (excluded from the other columns)">Local Cached</th>
                             <th class="col-price">Total Tokens</th>
                             <th class="col-price">Input Cost</th>
                             <th class="col-price">Output Cost</th>
@@ -110,6 +118,8 @@
                                 <td><span class="provider-badge" x-text="providerDisplayValue(row) || '-'"></span></td>
                                 <td class="col-price" x-text="formatNumber(row.input_tokens)"></td>
                                 <td class="col-price" x-text="formatNumber(row.output_tokens)"></td>
+                                <td class="col-price" x-text="formatNumber(row.cached_input_tokens || 0)" :title="row.cached_input_cost != null ? ('~' + formatCost(row.cached_input_cost) + ' at current cached-input pricing') : ''"></td>
+                                <td class="col-price" x-text="formatNumber((row.local_cached_input_tokens || 0) + (row.local_cached_output_tokens || 0))" :title="formatNumber(row.local_cached_input_tokens || 0) + ' input + ' + formatNumber(row.local_cached_output_tokens || 0) + ' output'"></td>
                                 <td class="col-price" x-text="formatNumber(usageRowTotalTokens(row))"></td>
                                 <td class="col-price" x-text="formatCost(row.input_cost)"></td>
                                 <td class="col-price" x-text="formatCost(row.output_cost)"></td>
@@ -128,14 +138,17 @@
             <h3 x-text="usageMode === 'costs' ? 'Cost by User Path' : 'Usage by User Path'"></h3>
             <div class="chart-view-toggle" role="group" aria-label="User path usage view">
                 <button type="button" class="chart-view-btn" :class="{active: userPathUsageView === 'chart'}" :aria-pressed="userPathUsageView === 'chart' ? 'true' : 'false'" aria-label="Show user path usage chart" title="Chart" @click="toggleUsageChartView('userPath', 'chart')">
-                    <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 19V11M12 19V5M19 19v-8"/></svg>
+                    <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 4v16M12 8h7M12 12H7M12 16h4"/></svg>
+                </button>
+                <button type="button" class="chart-view-btn" :class="{active: userPathUsageView === 'stacked'}" :aria-pressed="userPathUsageView === 'stacked' ? 'true' : 'false'" aria-label="Show user path usage stacked chart" title="Stacked" @click="toggleUsageChartView('userPath', 'stacked')">
+                    <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 4v16M5 8h6m2 0h4M5 12h9m2 0h3M5 16h4m2 0h2"/></svg>
                 </button>
                 <button type="button" class="chart-view-btn" :class="{active: userPathUsageView === 'table'}" :aria-pressed="userPathUsageView === 'table' ? 'true' : 'false'" aria-label="Show user path usage table" title="Table" @click="toggleUsageChartView('userPath', 'table')">
                     <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 6h16M4 12h16M4 18h16M9 6v12M15 6v12"/></svg>
                 </button>
             </div>
         </div>
-        <div class="bar-chart-wrap" x-show="userPathUsageView === 'chart'">
+        <div class="bar-chart-wrap" x-show="_isChartView(userPathUsageView)">
             <canvas id="usageUserPathChart"></canvas>
         </div>
         <template x-if="userPathUsageView === 'table'">
@@ -146,6 +159,8 @@
                             <th>User Path</th>
                             <th class="col-price">Input Tokens</th>
                             <th class="col-price">Output Tokens</th>
+                            <th class="col-price" title="Provider prompt-cache reads included in the input tokens">Prompt Cached</th>
+                            <th class="col-price" title="Tokens served from GoModel's local response cache (excluded from the other columns)">Local Cached</th>
                             <th class="col-price">Total Tokens</th>
                             <th class="col-price">Input Cost</th>
                             <th class="col-price">Output Cost</th>
@@ -158,6 +173,8 @@
                                 <td class="mono font-size-md" x-text="row.user_path || '/'"></td>
                                 <td class="col-price" x-text="formatNumber(row.input_tokens)"></td>
                                 <td class="col-price" x-text="formatNumber(row.output_tokens)"></td>
+                                <td class="col-price" x-text="formatNumber(row.cached_input_tokens || 0)" :title="row.cached_input_cost != null ? ('~' + formatCost(row.cached_input_cost) + ' at current cached-input pricing') : ''"></td>
+                                <td class="col-price" x-text="formatNumber((row.local_cached_input_tokens || 0) + (row.local_cached_output_tokens || 0))" :title="formatNumber(row.local_cached_input_tokens || 0) + ' input + ' + formatNumber(row.local_cached_output_tokens || 0) + ' output'"></td>
                                 <td class="col-price" x-text="formatNumber(usageRowTotalTokens(row))"></td>
                                 <td class="col-price" x-text="formatCost(row.input_cost)"></td>
                                 <td class="col-price" x-text="formatCost(row.output_cost)"></td>
@@ -182,14 +199,17 @@
             </div>
             <div class="chart-view-toggle" role="group" aria-label="Label usage view">
                 <button type="button" class="chart-view-btn" :class="{active: labelUsageView === 'chart'}" :aria-pressed="labelUsageView === 'chart' ? 'true' : 'false'" aria-label="Show label usage chart" title="Chart" @click="toggleUsageChartView('label', 'chart')">
-                    <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 19V11M12 19V5M19 19v-8"/></svg>
+                    <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 4v16M12 8h7M12 12H7M12 16h4"/></svg>
+                </button>
+                <button type="button" class="chart-view-btn" :class="{active: labelUsageView === 'stacked'}" :aria-pressed="labelUsageView === 'stacked' ? 'true' : 'false'" aria-label="Show label usage stacked chart" title="Stacked" @click="toggleUsageChartView('label', 'stacked')">
+                    <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 4v16M5 8h6m2 0h4M5 12h9m2 0h3M5 16h4m2 0h2"/></svg>
                 </button>
                 <button type="button" class="chart-view-btn" :class="{active: labelUsageView === 'table'}" :aria-pressed="labelUsageView === 'table' ? 'true' : 'false'" aria-label="Show label usage table" title="Table" @click="toggleUsageChartView('label', 'table')">
                     <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 6h16M4 12h16M4 18h16M9 6v12M15 6v12"/></svg>
                 </button>
             </div>
         </div>
-        <div class="bar-chart-wrap" x-show="labelUsageView === 'chart'">
+        <div class="bar-chart-wrap" x-show="_isChartView(labelUsageView)">
             <canvas id="usageLabelChart"></canvas>
         </div>
         <template x-if="labelUsageView === 'table'">
@@ -201,6 +221,8 @@
                             <th class="col-price">Requests</th>
                             <th class="col-price">Input Tokens</th>
                             <th class="col-price">Output Tokens</th>
+                            <th class="col-price" title="Provider prompt-cache reads included in the input tokens">Prompt Cached</th>
+                            <th class="col-price" title="Tokens served from GoModel's local response cache (excluded from the other columns)">Local Cached</th>
                             <th class="col-price">Total Tokens</th>
                             <th class="col-price">Input Cost</th>
                             <th class="col-price">Output Cost</th>
@@ -218,6 +240,8 @@
                                 <td class="col-price" x-text="formatNumber(row.requests)"></td>
                                 <td class="col-price" x-text="formatNumber(row.input_tokens)"></td>
                                 <td class="col-price" x-text="formatNumber(row.output_tokens)"></td>
+                                <td class="col-price" x-text="formatNumber(row.cached_input_tokens || 0)" :title="row.cached_input_cost != null ? ('~' + formatCost(row.cached_input_cost) + ' at current cached-input pricing') : ''"></td>
+                                <td class="col-price" x-text="formatNumber((row.local_cached_input_tokens || 0) + (row.local_cached_output_tokens || 0))" :title="formatNumber(row.local_cached_input_tokens || 0) + ' input + ' + formatNumber(row.local_cached_output_tokens || 0) + ' output'"></td>
                                 <td class="col-price" x-text="formatNumber(usageRowTotalTokens(row))"></td>
                                 <td class="col-price" x-text="formatCost(row.input_cost)"></td>
                                 <td class="col-price" x-text="formatCost(row.output_cost)"></td>
@@ -228,6 +252,8 @@
                 </table>
             </div>
         </template>
+    </div>
+
     </div>
 
     <!-- Request Log Section -->

--- a/internal/admin/handler_usage.go
+++ b/internal/admin/handler_usage.go
@@ -135,7 +135,11 @@ func (h *Handler) DailyUsage(c *echo.Context) error {
 // @Router       /admin/usage/models [get]
 func (h *Handler) UsageByModel(c *echo.Context) error {
 	return usageSliceResponse(c, h.usageReader, func(ctx context.Context, params usage.UsageQueryParams) ([]usage.ModelUsage, error) {
-		return h.usageReader.GetUsageByModel(ctx, params)
+		rows, err := h.usageReader.GetUsageByModel(ctx, params)
+		for i := range rows {
+			rows[i].CachedInputCost = usage.EstimateCachedInputCost(rows[i].CachedTokensByPricing, h.pricingResolver)
+		}
+		return rows, err
 	})
 }
 
@@ -159,7 +163,11 @@ func (h *Handler) UsageByModel(c *echo.Context) error {
 // @Router       /admin/usage/user-paths [get]
 func (h *Handler) UsageByUserPath(c *echo.Context) error {
 	return usageSliceResponse(c, h.usageReader, func(ctx context.Context, params usage.UsageQueryParams) ([]usage.UserPathUsage, error) {
-		return h.usageReader.GetUsageByUserPath(ctx, params)
+		rows, err := h.usageReader.GetUsageByUserPath(ctx, params)
+		for i := range rows {
+			rows[i].CachedInputCost = usage.EstimateCachedInputCost(rows[i].CachedTokensByPricing, h.pricingResolver)
+		}
+		return rows, err
 	})
 }
 
@@ -186,7 +194,11 @@ func (h *Handler) UsageByUserPath(c *echo.Context) error {
 // @Router       /admin/usage/labels [get]
 func (h *Handler) UsageByLabel(c *echo.Context) error {
 	return usageSliceResponse(c, h.usageReader, func(ctx context.Context, params usage.UsageQueryParams) ([]usage.LabelUsage, error) {
-		return h.usageReader.GetUsageByLabel(ctx, params)
+		rows, err := h.usageReader.GetUsageByLabel(ctx, params)
+		for i := range rows {
+			rows[i].CachedInputCost = usage.EstimateCachedInputCost(rows[i].CachedTokensByPricing, h.pricingResolver)
+		}
+		return rows, err
 	})
 }
 

--- a/internal/usage/group_cache_stats.go
+++ b/internal/usage/group_cache_stats.go
@@ -54,7 +54,7 @@ type usageCacheStatRow struct {
 type groupKeysFunc func(row usageCacheStatRow) []string
 
 // usageModelGroupKey mirrors the SQL grouping (model, provider,
-// COALESCE(NULLIF(TRIM(provider_name), ”), provider)).
+// usageModelGroupKey builds a grouping key from the model, provider, and provider name, using the provider when the trimmed provider name is empty.
 func usageModelGroupKey(model, provider, providerName string) string {
 	name := strings.TrimSpace(providerName)
 	if name == "" {
@@ -64,7 +64,7 @@ func usageModelGroupKey(model, provider, providerName string) string {
 }
 
 // usageUserPathGroupKey mirrors usageGroupedUserPathSQL: blank paths collapse
-// to the tracked root.
+// usageUserPathGroupKey normalizes a user path, using "/" when the path is empty or contains only whitespace.
 func usageUserPathGroupKey(userPath string) string {
 	path := strings.TrimSpace(userPath)
 	if path == "" {
@@ -73,19 +73,24 @@ func usageUserPathGroupKey(userPath string) string {
 	return path
 }
 
+// modelGroupKeys returns the model and provider grouping key for a usage cache-stat row.
 func modelGroupKeys(row usageCacheStatRow) []string {
 	return []string{usageModelGroupKey(row.Model, row.Provider, row.ProviderName)}
 }
 
+// userPathGroupKeys returns the grouping key for a usage row's user path.
 func userPathGroupKeys(row usageCacheStatRow) []string {
 	return []string{usageUserPathGroupKey(row.UserPath)}
 }
 
+// labelGroupKeys returns the labels associated with a usage cache statistic row as grouping keys.
 func labelGroupKeys(row usageCacheStatRow) []string {
 	return row.Labels
 }
 
-// accumulateGroupCacheStats folds one row into every group it belongs to.
+// accumulateGroupCacheStats folds a usage row into each group identified by the grouping function.
+// Local-cache rows update local token and request totals; other rows update uncached, cached, and
+// cache-write token totals and record cached tokens by pricing identity.
 func accumulateGroupCacheStats(out map[string]*GroupCacheStats, keysFor groupKeysFunc, row usageCacheStatRow) {
 	keys := keysFor(row)
 	if len(keys) == 0 {
@@ -140,7 +145,8 @@ func accumulateGroupCacheStats(out map[string]*GroupCacheStats, keysFor groupKey
 // foldUsageCacheRows folds streamed SQL rows (model, provider, provider_name,
 // user_path, labels JSON, cache_type, input_tokens, output_tokens, raw_data)
 // into per-group cache stats. Shared by the SQL backends; MongoDB folds its
-// decoded documents with accumulateGroupCacheStats directly.
+// foldUsageCacheRows aggregates streamed usage cache-stat rows by the keys produced by keysFor.
+// It returns an error if scanning the rows fails or the result set reports an error.
 func foldUsageCacheRows(rows inputSegmentRows, keysFor groupKeysFunc) (map[string]*GroupCacheStats, error) {
 	out := map[string]*GroupCacheStats{}
 	for rows.Next() {
@@ -195,7 +201,8 @@ func (f *GroupCacheFields) assign(stats *GroupCacheStats) {
 
 // applyModelCacheStats merges the fold onto matching by-model rows and
 // materializes rows for local-only groups the uncached aggregates never
-// produced (their cost fields stay nil and provider token counts zero).
+// applyModelCacheStats merges grouped cache statistics into model usage rows and adds
+// rows for model groups with local-cache activity that are absent from the input.
 func applyModelCacheStats(rows []ModelUsage, stats map[string]*GroupCacheStats) []ModelUsage {
 	seen := map[string]bool{}
 	for i := range rows {
@@ -215,7 +222,7 @@ func applyModelCacheStats(rows []ModelUsage, stats map[string]*GroupCacheStats) 
 }
 
 // applyUserPathCacheStats merges the fold onto matching by-user-path rows,
-// materializing local-only groups like applyModelCacheStats.
+// applyUserPathCacheStats merges cache statistics into user-path usage rows and adds rows for user paths with only local-cache activity.
 func applyUserPathCacheStats(rows []UserPathUsage, stats map[string]*GroupCacheStats) []UserPathUsage {
 	seen := map[string]bool{}
 	for i := range rows {
@@ -237,7 +244,7 @@ func applyUserPathCacheStats(rows []UserPathUsage, stats map[string]*GroupCacheS
 // applyLabelCacheStats merges the fold onto matching by-label rows,
 // materializing local-only groups like applyModelCacheStats. Synthetic rows
 // count their local-cache requests so a label row never shows tokens with
-// zero requests.
+// applyLabelCacheStats merges cache statistics into label usage rows and adds rows for labels with local-cache activity.
 func applyLabelCacheStats(rows []LabelUsage, stats map[string]*GroupCacheStats) []LabelUsage {
 	seen := map[string]bool{}
 	for i := range rows {
@@ -260,7 +267,9 @@ func applyLabelCacheStats(rows []LabelUsage, stats map[string]*GroupCacheStats) 
 // estimate: models without a cached-input rate contribute nothing, and it
 // reflects today's prices, not the prices at request time — the same
 // trade-off as pricing recalculation. Returns nil when nothing could be
-// priced.
+// EstimateCachedInputCost estimates cached-input cost using the applicable pricing.
+// It returns a pointer to the estimate when at least one token bucket can be priced,
+// or nil when no pricing is available.
 func EstimateCachedInputCost(byPricing map[CachedPricingKey]int64, resolver PricingResolver) *float64 {
 	if resolver == nil || len(byPricing) == 0 {
 		return nil

--- a/internal/usage/group_cache_stats.go
+++ b/internal/usage/group_cache_stats.go
@@ -1,0 +1,220 @@
+package usage
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/goccy/go-json"
+)
+
+// GroupCacheStats aggregates the cache figures for one chart group (a model,
+// user path, or label) during the second streaming pass the aggregate SQL
+// cannot produce (it needs per-row raw_data).
+type GroupCacheStats struct {
+	UncachedInputTokens     int64
+	CachedInputTokens       int64
+	CacheWriteInputTokens   int64
+	LocalCachedInputTokens  int64
+	LocalCachedOutputTokens int64
+	CachedTokensByPricing   map[CachedPricingKey]int64
+}
+
+// usageCacheStatRow is one streamed usage row for the group cache fold. The
+// fold always streams with cache mode "all": provider rows feed the
+// prompt-cache split, local-cache rows feed the local-cached token counts.
+type usageCacheStatRow struct {
+	Model        string
+	Provider     string
+	ProviderName string
+	UserPath     string
+	Labels       []string
+	CacheType    string
+	InputTokens  int
+	OutputTokens int
+	RawData      map[string]any
+}
+
+// groupKeysFunc derives the fold keys one row contributes to. Most groupings
+// return one key; the label grouping returns one per label.
+type groupKeysFunc func(row usageCacheStatRow) []string
+
+// usageModelGroupKey mirrors the SQL grouping (model, provider,
+// COALESCE(NULLIF(TRIM(provider_name), ”), provider)).
+func usageModelGroupKey(model, provider, providerName string) string {
+	name := strings.TrimSpace(providerName)
+	if name == "" {
+		name = provider
+	}
+	return model + "\x00" + provider + "\x00" + name
+}
+
+// usageUserPathGroupKey mirrors usageGroupedUserPathSQL: blank paths collapse
+// to the tracked root.
+func usageUserPathGroupKey(userPath string) string {
+	path := strings.TrimSpace(userPath)
+	if path == "" {
+		return "/"
+	}
+	return path
+}
+
+func modelGroupKeys(row usageCacheStatRow) []string {
+	return []string{usageModelGroupKey(row.Model, row.Provider, row.ProviderName)}
+}
+
+func userPathGroupKeys(row usageCacheStatRow) []string {
+	return []string{usageUserPathGroupKey(row.UserPath)}
+}
+
+func labelGroupKeys(row usageCacheStatRow) []string {
+	return row.Labels
+}
+
+// accumulateGroupCacheStats folds one row into every group it belongs to.
+func accumulateGroupCacheStats(out map[string]*GroupCacheStats, keysFor groupKeysFunc, row usageCacheStatRow) {
+	keys := keysFor(row)
+	if len(keys) == 0 {
+		return
+	}
+	local := isLocalCacheType(&row.CacheType)
+	var uncached, cached, cacheWrite int64
+	if !local {
+		uncached, cached, cacheWrite = EntryInputSegments(UsageLogEntry{
+			InputTokens: row.InputTokens,
+			Provider:    row.Provider,
+			RawData:     row.RawData,
+		})
+	}
+	for _, key := range keys {
+		stats := out[key]
+		if stats == nil {
+			stats = &GroupCacheStats{}
+			out[key] = stats
+		}
+		if local {
+			stats.LocalCachedInputTokens += int64(row.InputTokens)
+			stats.LocalCachedOutputTokens += int64(row.OutputTokens)
+			continue
+		}
+		stats.UncachedInputTokens += uncached
+		stats.CachedInputTokens += cached
+		stats.CacheWriteInputTokens += cacheWrite
+		if cached > 0 {
+			if stats.CachedTokensByPricing == nil {
+				stats.CachedTokensByPricing = map[CachedPricingKey]int64{}
+			}
+			stats.CachedTokensByPricing[CachedPricingKey{
+				Model:        row.Model,
+				Provider:     row.Provider,
+				ProviderName: strings.TrimSpace(row.ProviderName),
+			}] += cached
+		}
+	}
+}
+
+// foldUsageCacheRows folds streamed SQL rows (model, provider, provider_name,
+// user_path, labels JSON, cache_type, input_tokens, output_tokens, raw_data)
+// into per-group cache stats. Shared by the SQL backends; MongoDB folds its
+// decoded documents with accumulateGroupCacheStats directly.
+func foldUsageCacheRows(rows inputSegmentRows, keysFor groupKeysFunc) (map[string]*GroupCacheStats, error) {
+	out := map[string]*GroupCacheStats{}
+	for rows.Next() {
+		var model, provider string
+		var providerName, userPath, labelsJSON, cacheType, rawDataJSON *string
+		var inputTokens, outputTokens int
+		if err := rows.Scan(&model, &provider, &providerName, &userPath, &labelsJSON, &cacheType, &inputTokens, &outputTokens, &rawDataJSON); err != nil {
+			return nil, fmt.Errorf("failed to scan usage cache stat row: %w", err)
+		}
+		row := usageCacheStatRow{
+			Model:        model,
+			Provider:     provider,
+			InputTokens:  inputTokens,
+			OutputTokens: outputTokens,
+		}
+		if providerName != nil {
+			row.ProviderName = *providerName
+		}
+		if userPath != nil {
+			row.UserPath = *userPath
+		}
+		if cacheType != nil {
+			row.CacheType = *cacheType
+		}
+		if labelsJSON != nil && *labelsJSON != "" {
+			if err := json.Unmarshal([]byte(*labelsJSON), &row.Labels); err != nil {
+				slog.Warn("failed to unmarshal labels JSON", "error", err)
+			}
+		}
+		if rawDataJSON != nil && *rawDataJSON != "" {
+			if err := json.Unmarshal([]byte(*rawDataJSON), &row.RawData); err != nil {
+				slog.Warn("failed to unmarshal raw_data JSON", "error", err)
+			}
+		}
+		accumulateGroupCacheStats(out, keysFor, row)
+	}
+	return out, rows.Err()
+}
+
+// assign copies the fold result onto a row's shared cache fields.
+func (f *GroupCacheFields) assign(stats *GroupCacheStats) {
+	if stats == nil {
+		return
+	}
+	f.UncachedInputTokens = stats.UncachedInputTokens
+	f.CachedInputTokens = stats.CachedInputTokens
+	f.CacheWriteInputTokens = stats.CacheWriteInputTokens
+	f.LocalCachedInputTokens = stats.LocalCachedInputTokens
+	f.LocalCachedOutputTokens = stats.LocalCachedOutputTokens
+	f.CachedTokensByPricing = stats.CachedTokensByPricing
+}
+
+// applyModelCacheStats merges the fold onto matching by-model rows.
+func applyModelCacheStats(rows []ModelUsage, stats map[string]*GroupCacheStats) {
+	for i := range rows {
+		rows[i].assign(stats[usageModelGroupKey(rows[i].Model, rows[i].Provider, rows[i].ProviderName)])
+	}
+}
+
+// applyUserPathCacheStats merges the fold onto matching by-user-path rows.
+func applyUserPathCacheStats(rows []UserPathUsage, stats map[string]*GroupCacheStats) {
+	for i := range rows {
+		rows[i].assign(stats[usageUserPathGroupKey(rows[i].UserPath)])
+	}
+}
+
+// applyLabelCacheStats merges the fold onto matching by-label rows.
+func applyLabelCacheStats(rows []LabelUsage, stats map[string]*GroupCacheStats) {
+	for i := range rows {
+		rows[i].assign(stats[rows[i].Label])
+	}
+}
+
+// EstimateCachedInputCost prices a group's prompt-cached input tokens with
+// current catalog pricing (CachedInputPerMtok per pricing identity). It is an
+// estimate: models without a cached-input rate contribute nothing, and it
+// reflects today's prices, not the prices at request time — the same
+// trade-off as pricing recalculation. Returns nil when nothing could be
+// priced.
+func EstimateCachedInputCost(byPricing map[CachedPricingKey]int64, resolver PricingResolver) *float64 {
+	if resolver == nil || len(byPricing) == 0 {
+		return nil
+	}
+	var total float64
+	priced := false
+	for key, tokens := range byPricing {
+		if tokens <= 0 {
+			continue
+		}
+		pricing := resolver.ResolvePricing(key.Model, effectiveRecalculationPricingProvider(key.Provider, key.ProviderName))
+		if pricing == nil || pricing.CachedInputPerMtok == nil {
+			continue
+		}
+		total += float64(tokens) * *pricing.CachedInputPerMtok / 1_000_000
+		priced = true
+	}
+	if !priced {
+		return nil
+	}
+	return &total
+}

--- a/internal/usage/group_cache_stats.go
+++ b/internal/usage/group_cache_stats.go
@@ -10,14 +10,28 @@ import (
 
 // GroupCacheStats aggregates the cache figures for one chart group (a model,
 // user path, or label) during the second streaming pass the aggregate SQL
-// cannot produce (it needs per-row raw_data).
+// cannot produce (it needs per-row raw_data). The identity fields capture the
+// group's coordinates from the first folded row so groups served entirely
+// from the local cache — which the uncached aggregate pass never surfaces —
+// can still materialize a row.
 type GroupCacheStats struct {
+	Model        string
+	Provider     string
+	ProviderName string
+	UserPath     string
+
 	UncachedInputTokens     int64
 	CachedInputTokens       int64
 	CacheWriteInputTokens   int64
 	LocalCachedInputTokens  int64
 	LocalCachedOutputTokens int64
+	LocalRequests           int
 	CachedTokensByPricing   map[CachedPricingKey]int64
+}
+
+// hasLocalTokens reports whether the group saw any local-cache traffic.
+func (s *GroupCacheStats) hasLocalTokens() bool {
+	return s.LocalCachedInputTokens > 0 || s.LocalCachedOutputTokens > 0
 }
 
 // usageCacheStatRow is one streamed usage row for the group cache fold. The
@@ -89,12 +103,22 @@ func accumulateGroupCacheStats(out map[string]*GroupCacheStats, keysFor groupKey
 	for _, key := range keys {
 		stats := out[key]
 		if stats == nil {
-			stats = &GroupCacheStats{}
+			name := strings.TrimSpace(row.ProviderName)
+			if name == "" {
+				name = row.Provider
+			}
+			stats = &GroupCacheStats{
+				Model:        row.Model,
+				Provider:     row.Provider,
+				ProviderName: name,
+				UserPath:     usageUserPathGroupKey(row.UserPath),
+			}
 			out[key] = stats
 		}
 		if local {
 			stats.LocalCachedInputTokens += int64(row.InputTokens)
 			stats.LocalCachedOutputTokens += int64(row.OutputTokens)
+			stats.LocalRequests++
 			continue
 		}
 		stats.UncachedInputTokens += uncached
@@ -169,25 +193,66 @@ func (f *GroupCacheFields) assign(stats *GroupCacheStats) {
 	f.CachedTokensByPricing = stats.CachedTokensByPricing
 }
 
-// applyModelCacheStats merges the fold onto matching by-model rows.
-func applyModelCacheStats(rows []ModelUsage, stats map[string]*GroupCacheStats) {
+// applyModelCacheStats merges the fold onto matching by-model rows and
+// materializes rows for local-only groups the uncached aggregates never
+// produced (their cost fields stay nil and provider token counts zero).
+func applyModelCacheStats(rows []ModelUsage, stats map[string]*GroupCacheStats) []ModelUsage {
+	seen := map[string]bool{}
 	for i := range rows {
-		rows[i].assign(stats[usageModelGroupKey(rows[i].Model, rows[i].Provider, rows[i].ProviderName)])
+		key := usageModelGroupKey(rows[i].Model, rows[i].Provider, rows[i].ProviderName)
+		seen[key] = true
+		rows[i].assign(stats[key])
 	}
+	for key, s := range stats {
+		if seen[key] || !s.hasLocalTokens() {
+			continue
+		}
+		row := ModelUsage{Model: s.Model, Provider: s.Provider, ProviderName: s.ProviderName}
+		row.assign(s)
+		rows = append(rows, row)
+	}
+	return rows
 }
 
-// applyUserPathCacheStats merges the fold onto matching by-user-path rows.
-func applyUserPathCacheStats(rows []UserPathUsage, stats map[string]*GroupCacheStats) {
+// applyUserPathCacheStats merges the fold onto matching by-user-path rows,
+// materializing local-only groups like applyModelCacheStats.
+func applyUserPathCacheStats(rows []UserPathUsage, stats map[string]*GroupCacheStats) []UserPathUsage {
+	seen := map[string]bool{}
 	for i := range rows {
-		rows[i].assign(stats[usageUserPathGroupKey(rows[i].UserPath)])
+		key := usageUserPathGroupKey(rows[i].UserPath)
+		seen[key] = true
+		rows[i].assign(stats[key])
 	}
+	for key, s := range stats {
+		if seen[key] || !s.hasLocalTokens() {
+			continue
+		}
+		row := UserPathUsage{UserPath: s.UserPath}
+		row.assign(s)
+		rows = append(rows, row)
+	}
+	return rows
 }
 
-// applyLabelCacheStats merges the fold onto matching by-label rows.
-func applyLabelCacheStats(rows []LabelUsage, stats map[string]*GroupCacheStats) {
+// applyLabelCacheStats merges the fold onto matching by-label rows,
+// materializing local-only groups like applyModelCacheStats. Synthetic rows
+// count their local-cache requests so a label row never shows tokens with
+// zero requests.
+func applyLabelCacheStats(rows []LabelUsage, stats map[string]*GroupCacheStats) []LabelUsage {
+	seen := map[string]bool{}
 	for i := range rows {
+		seen[rows[i].Label] = true
 		rows[i].assign(stats[rows[i].Label])
 	}
+	for key, s := range stats {
+		if seen[key] || !s.hasLocalTokens() {
+			continue
+		}
+		row := LabelUsage{Label: key, Requests: s.LocalRequests}
+		row.assign(s)
+		rows = append(rows, row)
+	}
+	return rows
 }
 
 // EstimateCachedInputCost prices a group's prompt-cached input tokens with

--- a/internal/usage/group_cache_stats_test.go
+++ b/internal/usage/group_cache_stats_test.go
@@ -150,6 +150,87 @@ func TestSQLiteGroupCacheStatsFollowFilters(t *testing.T) {
 	}
 }
 
+func TestSQLiteLocalOnlyGroupsMaterializeRows(t *testing.T) {
+	db, ctx := seedGroupCacheStatsFixture(t)
+	store, err := NewSQLiteStore(db, 0)
+	if err != nil {
+		t.Fatalf("failed to create sqlite store: %v", err)
+	}
+	// A model served exclusively from the local cache in the period: the
+	// uncached aggregate pass never produces a row for it.
+	err = store.WriteBatch(ctx, []*UsageEntry{{
+		ID: "usage-local-only", RequestID: "req-4", ProviderID: "p-1",
+		Timestamp: time.Date(2026, 4, 7, 11, 0, 0, 0, time.UTC),
+		Model:     "cache-only-model", Provider: "openai", Endpoint: "/v1/chat/completions",
+		UserPath: "/team/cached", Labels: []string{"cache-only"}, CacheType: CacheTypeSemantic,
+		InputTokens: 50, OutputTokens: 5,
+	}})
+	if err != nil {
+		t.Fatalf("failed to seed local-only entry: %v", err)
+	}
+	reader, err := NewSQLiteReader(db)
+	if err != nil {
+		t.Fatalf("failed to create sqlite reader: %v", err)
+	}
+
+	models, err := reader.GetUsageByModel(ctx, UsageQueryParams{})
+	if err != nil {
+		t.Fatalf("GetUsageByModel returned error: %v", err)
+	}
+	var localOnly *ModelUsage
+	for i := range models {
+		if models[i].Model == "cache-only-model" {
+			localOnly = &models[i]
+		}
+	}
+	if localOnly == nil {
+		t.Fatalf("expected a synthetic row for the local-only model, got %#v", models)
+	}
+	if localOnly.InputTokens != 0 || localOnly.OutputTokens != 0 {
+		t.Fatalf("synthetic row must carry no provider tokens: %+v", localOnly)
+	}
+	if localOnly.LocalCachedInputTokens != 50 || localOnly.LocalCachedOutputTokens != 5 {
+		t.Fatalf("unexpected local tokens on synthetic row: %+v", localOnly.GroupCacheFields)
+	}
+	if localOnly.ProviderName != "openai" {
+		t.Fatalf("expected grouped provider name, got %q", localOnly.ProviderName)
+	}
+
+	labels, err := reader.GetUsageByLabel(ctx, UsageQueryParams{})
+	if err != nil {
+		t.Fatalf("GetUsageByLabel returned error: %v", err)
+	}
+	for _, l := range labels {
+		if l.Label == "cache-only" {
+			if l.Requests != 1 || l.LocalCachedInputTokens != 50 {
+				t.Fatalf("unexpected synthetic label row: %+v", l)
+			}
+			return
+		}
+	}
+	t.Fatalf("expected a synthetic cache-only label row, got %#v", labels)
+}
+
+func TestSQLiteCacheStatsSkippedOutsideUncachedMode(t *testing.T) {
+	db, ctx := seedGroupCacheStatsFixture(t)
+	reader, err := NewSQLiteReader(db)
+	if err != nil {
+		t.Fatalf("failed to create sqlite reader: %v", err)
+	}
+
+	for _, mode := range []string{CacheModeAll, CacheModeCached} {
+		got, err := reader.GetUsageByModel(ctx, UsageQueryParams{CacheMode: mode})
+		if err != nil {
+			t.Fatalf("GetUsageByModel(%s) returned error: %v", mode, err)
+		}
+		for _, row := range got {
+			if row.CachedInputTokens != 0 || row.LocalCachedInputTokens != 0 || row.LocalCachedOutputTokens != 0 {
+				t.Fatalf("cache fields must stay zero in %s mode (local tokens are already inside the sums): %+v", mode, row.GroupCacheFields)
+			}
+		}
+	}
+}
+
 type mapPricingResolver map[string]*core.ModelPricing
 
 func (r mapPricingResolver) ResolvePricing(model, providerType string) *core.ModelPricing {
@@ -161,30 +242,52 @@ func TestEstimateCachedInputCost(t *testing.T) {
 	resolver := mapPricingResolver{
 		"gpt-5/openai": {CachedInputPerMtok: &rate},
 	}
+	want := func(v float64) *float64 { return &v }
 
-	cost := EstimateCachedInputCost(map[CachedPricingKey]int64{
-		{Model: "gpt-5", Provider: "openai"}:    2_000_000,
-		{Model: "unpriced", Provider: "openai"}: 1_000_000,
-	}, resolver)
-	if cost == nil {
-		t.Fatalf("expected an estimated cost, got nil")
-	}
-	if *cost != 1.0 {
-		t.Fatalf("expected $1.00 estimate, got %v", *cost)
+	tests := []struct {
+		name      string
+		byPricing map[CachedPricingKey]int64
+		resolver  PricingResolver
+		want      *float64
+	}{
+		{
+			name: "prices known models and skips unpriced ones",
+			byPricing: map[CachedPricingKey]int64{
+				{Model: "gpt-5", Provider: "openai"}:    2_000_000,
+				{Model: "unpriced", Provider: "openai"}: 1_000_000,
+			},
+			resolver: resolver,
+			want:     want(1.0),
+		},
+		{
+			name:     "nil for empty breakdown",
+			resolver: resolver,
+		},
+		{
+			name: "nil when nothing is priced",
+			byPricing: map[CachedPricingKey]int64{
+				{Model: "unpriced", Provider: "openai"}: 100,
+			},
+			resolver: resolver,
+		},
+		{
+			name: "nil without a resolver",
+			byPricing: map[CachedPricingKey]int64{
+				{Model: "gpt-5", Provider: "openai"}: 100,
+			},
+		},
 	}
 
-	if got := EstimateCachedInputCost(nil, resolver); got != nil {
-		t.Fatalf("expected nil for empty breakdown, got %v", *got)
-	}
-	if got := EstimateCachedInputCost(map[CachedPricingKey]int64{
-		{Model: "unpriced", Provider: "openai"}: 100,
-	}, resolver); got != nil {
-		t.Fatalf("expected nil when nothing is priced, got %v", *got)
-	}
-	if got := EstimateCachedInputCost(map[CachedPricingKey]int64{
-		{Model: "gpt-5", Provider: "openai"}: 100,
-	}, nil); got != nil {
-		t.Fatalf("expected nil without a resolver, got %v", *got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EstimateCachedInputCost(tt.byPricing, tt.resolver)
+			if (got == nil) != (tt.want == nil) {
+				t.Fatalf("EstimateCachedInputCost = %v, want %v", got, tt.want)
+			}
+			if got != nil && *got != *tt.want {
+				t.Fatalf("EstimateCachedInputCost = %v, want %v", *got, *tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/usage/group_cache_stats_test.go
+++ b/internal/usage/group_cache_stats_test.go
@@ -231,6 +231,67 @@ func TestSQLiteCacheStatsSkippedOutsideUncachedMode(t *testing.T) {
 	}
 }
 
+// Err completes the inputSegmentRows interface for the shared pgx-style
+// fixture; the fake never fails mid-iteration.
+func (f *fakePgxRows) Err() error { return nil }
+
+// TestFoldUsageCacheRowsScansNullableColumns drives the SQL-backend scan
+// path through the same pgx-style row interface the PostgreSQL reader uses,
+// covering nil provider_name/user_path/labels/cache_type/raw_data columns,
+// label expansion, and the local-vs-provider row split.
+func TestFoldUsageCacheRowsScansNullableColumns(t *testing.T) {
+	str := func(s string) *string { return &s }
+	rows := &fakePgxRows{rows: [][]any{
+		// model, provider, provider_name, user_path, labels, cache_type, input, output, raw_data
+		{"gpt-5", "openai", str(" primary "), str("/team/alpha"), str(`["prod","batch"]`), nil, 100, 20, str(`{"prompt_cached_tokens": 60}`)},
+		{"gpt-5", "openai", str(" primary "), str("/team/alpha"), nil, str(CacheTypeExact), 100, 20, nil},
+		{"gpt-4o", "openai", nil, nil, nil, nil, 40, 10, nil},
+	}}
+
+	stats, err := foldUsageCacheRows(rows, modelGroupKeys)
+	if err != nil {
+		t.Fatalf("foldUsageCacheRows returned error: %v", err)
+	}
+
+	gpt5 := stats[usageModelGroupKey("gpt-5", "openai", " primary ")]
+	if gpt5 == nil {
+		t.Fatalf("expected gpt-5 stats, got %#v", stats)
+	}
+	if gpt5.CachedInputTokens != 60 || gpt5.UncachedInputTokens != 40 {
+		t.Fatalf("unexpected gpt-5 split: %+v", gpt5)
+	}
+	if gpt5.LocalCachedInputTokens != 100 || gpt5.LocalCachedOutputTokens != 20 || gpt5.LocalRequests != 1 {
+		t.Fatalf("unexpected gpt-5 local stats: %+v", gpt5)
+	}
+	if gpt5.ProviderName != "primary" {
+		t.Fatalf("expected trimmed provider name identity, got %q", gpt5.ProviderName)
+	}
+	key := CachedPricingKey{Model: "gpt-5", Provider: "openai", ProviderName: "primary"}
+	if gpt5.CachedTokensByPricing[key] != 60 {
+		t.Fatalf("unexpected pricing breakdown: %#v", gpt5.CachedTokensByPricing)
+	}
+
+	gpt4o := stats[usageModelGroupKey("gpt-4o", "openai", "")]
+	if gpt4o == nil || gpt4o.UncachedInputTokens != 40 || gpt4o.CachedInputTokens != 0 {
+		t.Fatalf("unexpected gpt-4o stats: %+v", gpt4o)
+	}
+
+	// The same rows folded per label: only the labelled row contributes.
+	labelRows := &fakePgxRows{rows: [][]any{
+		{"gpt-5", "openai", nil, nil, str(`["prod","batch"]`), nil, 100, 20, str(`{"prompt_cached_tokens": 60}`)},
+	}}
+	labelStats, err := foldUsageCacheRows(labelRows, labelGroupKeys)
+	if err != nil {
+		t.Fatalf("foldUsageCacheRows returned error: %v", err)
+	}
+	if labelStats["prod"] == nil || labelStats["batch"] == nil {
+		t.Fatalf("expected stats under both labels, got %#v", labelStats)
+	}
+	if labelStats["prod"].CachedInputTokens != 60 || labelStats["batch"].CachedInputTokens != 60 {
+		t.Fatalf("expected the row's cached tokens under each label, got %#v", labelStats)
+	}
+}
+
 type mapPricingResolver map[string]*core.ModelPricing
 
 func (r mapPricingResolver) ResolvePricing(model, providerType string) *core.ModelPricing {

--- a/internal/usage/group_cache_stats_test.go
+++ b/internal/usage/group_cache_stats_test.go
@@ -1,0 +1,202 @@
+package usage
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+func seedGroupCacheStatsFixture(t *testing.T) (*sql.DB, context.Context) {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open sqlite database: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	store, err := NewSQLiteStore(db, 0)
+	if err != nil {
+		t.Fatalf("failed to create sqlite store: %v", err)
+	}
+
+	ctx := context.Background()
+	ts := time.Date(2026, 4, 7, 10, 0, 0, 0, time.UTC)
+	err = store.WriteBatch(ctx, []*UsageEntry{
+		{
+			// OpenAI-style prompt-cache read inside input_tokens.
+			ID: "usage-cached", RequestID: "req-1", ProviderID: "p-1", Timestamp: ts,
+			Model: "gpt-5", Provider: "openai", Endpoint: "/v1/chat/completions",
+			UserPath: "/team/alpha", Labels: []string{"prod"},
+			InputTokens: 100, OutputTokens: 20,
+			RawData: map[string]any{"prompt_cached_tokens": 60},
+		},
+		{
+			// No provider cache involvement.
+			ID: "usage-plain", RequestID: "req-2", ProviderID: "p-1", Timestamp: ts.Add(time.Minute),
+			Model: "gpt-5", Provider: "openai", Endpoint: "/v1/chat/completions",
+			UserPath: "/team/alpha", Labels: []string{"prod", "batch"},
+			InputTokens: 40, OutputTokens: 10,
+		},
+		{
+			// Served from GoModel's local response cache: excluded from the
+			// uncached aggregates but surfaced as LocalCachedTokens.
+			ID: "usage-local", RequestID: "req-3", ProviderID: "p-1", Timestamp: ts.Add(2 * time.Minute),
+			Model: "gpt-5", Provider: "openai", Endpoint: "/v1/chat/completions",
+			UserPath: "/team/alpha", Labels: []string{"prod"}, CacheType: CacheTypeExact,
+			InputTokens: 100, OutputTokens: 20,
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to seed usage entries: %v", err)
+	}
+	return db, ctx
+}
+
+func TestSQLiteGetUsageByModelIncludesGroupCacheStats(t *testing.T) {
+	db, ctx := seedGroupCacheStatsFixture(t)
+	reader, err := NewSQLiteReader(db)
+	if err != nil {
+		t.Fatalf("failed to create sqlite reader: %v", err)
+	}
+
+	got, err := reader.GetUsageByModel(ctx, UsageQueryParams{})
+	if err != nil {
+		t.Fatalf("GetUsageByModel returned error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 grouped usage row, got %d: %#v", len(got), got)
+	}
+	row := got[0]
+	if row.InputTokens != 140 {
+		t.Fatalf("expected 140 input tokens (local hit excluded), got %d", row.InputTokens)
+	}
+	if row.CachedInputTokens != 60 {
+		t.Fatalf("expected 60 cached input tokens, got %d", row.CachedInputTokens)
+	}
+	if row.UncachedInputTokens != 80 {
+		t.Fatalf("expected 80 uncached input tokens, got %d", row.UncachedInputTokens)
+	}
+	if row.LocalCachedInputTokens != 100 || row.LocalCachedOutputTokens != 20 {
+		t.Fatalf("expected 100/20 local cached tokens, got %d/%d", row.LocalCachedInputTokens, row.LocalCachedOutputTokens)
+	}
+	key := CachedPricingKey{Model: "gpt-5", Provider: "openai"}
+	if row.CachedTokensByPricing[key] != 60 {
+		t.Fatalf("expected 60 cached tokens under %+v, got %#v", key, row.CachedTokensByPricing)
+	}
+}
+
+func TestSQLiteGetUsageByUserPathAndLabelIncludeGroupCacheStats(t *testing.T) {
+	db, ctx := seedGroupCacheStatsFixture(t)
+	reader, err := NewSQLiteReader(db)
+	if err != nil {
+		t.Fatalf("failed to create sqlite reader: %v", err)
+	}
+
+	paths, err := reader.GetUsageByUserPath(ctx, UsageQueryParams{})
+	if err != nil {
+		t.Fatalf("GetUsageByUserPath returned error: %v", err)
+	}
+	if len(paths) != 1 || paths[0].UserPath != "/team/alpha" {
+		t.Fatalf("expected one /team/alpha row, got %#v", paths)
+	}
+	if paths[0].CachedInputTokens != 60 || paths[0].LocalCachedInputTokens != 100 || paths[0].LocalCachedOutputTokens != 20 {
+		t.Fatalf("unexpected user path cache stats: %+v", paths[0].GroupCacheFields)
+	}
+
+	labels, err := reader.GetUsageByLabel(ctx, UsageQueryParams{})
+	if err != nil {
+		t.Fatalf("GetUsageByLabel returned error: %v", err)
+	}
+	byLabel := map[string]LabelUsage{}
+	for _, l := range labels {
+		byLabel[l.Label] = l
+	}
+	prod, ok := byLabel["prod"]
+	if !ok {
+		t.Fatalf("expected a prod label row, got %#v", labels)
+	}
+	if prod.CachedInputTokens != 60 || prod.LocalCachedInputTokens != 100 || prod.LocalCachedOutputTokens != 20 {
+		t.Fatalf("unexpected prod label cache stats: %+v", prod.GroupCacheFields)
+	}
+	batch, ok := byLabel["batch"]
+	if !ok {
+		t.Fatalf("expected a batch label row, got %#v", labels)
+	}
+	if batch.CachedInputTokens != 0 || batch.LocalCachedInputTokens != 0 || batch.LocalCachedOutputTokens != 0 {
+		t.Fatalf("unexpected batch label cache stats: %+v", batch.GroupCacheFields)
+	}
+}
+
+func TestSQLiteGroupCacheStatsFollowFilters(t *testing.T) {
+	db, ctx := seedGroupCacheStatsFixture(t)
+	reader, err := NewSQLiteReader(db)
+	if err != nil {
+		t.Fatalf("failed to create sqlite reader: %v", err)
+	}
+
+	got, err := reader.GetUsageByModel(ctx, UsageQueryParams{Label: "batch"})
+	if err != nil {
+		t.Fatalf("GetUsageByModel returned error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 grouped usage row, got %d", len(got))
+	}
+	// Only the plain entry carries the batch label: no cached or local tokens.
+	if got[0].CachedInputTokens != 0 || got[0].LocalCachedInputTokens != 0 || got[0].LocalCachedOutputTokens != 0 {
+		t.Fatalf("expected no cache stats under batch filter, got %+v", got[0].GroupCacheFields)
+	}
+}
+
+type mapPricingResolver map[string]*core.ModelPricing
+
+func (r mapPricingResolver) ResolvePricing(model, providerType string) *core.ModelPricing {
+	return r[model+"/"+providerType]
+}
+
+func TestEstimateCachedInputCost(t *testing.T) {
+	rate := 0.5 // $ per Mtok
+	resolver := mapPricingResolver{
+		"gpt-5/openai": {CachedInputPerMtok: &rate},
+	}
+
+	cost := EstimateCachedInputCost(map[CachedPricingKey]int64{
+		{Model: "gpt-5", Provider: "openai"}:    2_000_000,
+		{Model: "unpriced", Provider: "openai"}: 1_000_000,
+	}, resolver)
+	if cost == nil {
+		t.Fatalf("expected an estimated cost, got nil")
+	}
+	if *cost != 1.0 {
+		t.Fatalf("expected $1.00 estimate, got %v", *cost)
+	}
+
+	if got := EstimateCachedInputCost(nil, resolver); got != nil {
+		t.Fatalf("expected nil for empty breakdown, got %v", *got)
+	}
+	if got := EstimateCachedInputCost(map[CachedPricingKey]int64{
+		{Model: "unpriced", Provider: "openai"}: 100,
+	}, resolver); got != nil {
+		t.Fatalf("expected nil when nothing is priced, got %v", *got)
+	}
+	if got := EstimateCachedInputCost(map[CachedPricingKey]int64{
+		{Model: "gpt-5", Provider: "openai"}: 100,
+	}, nil); got != nil {
+		t.Fatalf("expected nil without a resolver, got %v", *got)
+	}
+}
+
+func TestEstimateCachedInputCostPrefersProviderName(t *testing.T) {
+	rate := 1.0
+	resolver := mapPricingResolver{
+		"gpt-5/my-azure": {CachedInputPerMtok: &rate},
+	}
+	cost := EstimateCachedInputCost(map[CachedPricingKey]int64{
+		{Model: "gpt-5", Provider: "azure", ProviderName: "my-azure"}: 1_000_000,
+	}, resolver)
+	if cost == nil || *cost != 1.0 {
+		t.Fatalf("expected provider-name pricing to apply, got %v", cost)
+	}
+}

--- a/internal/usage/reader.go
+++ b/internal/usage/reader.go
@@ -113,6 +113,7 @@ type ModelUsage struct {
 	InputCost    *float64 `json:"input_cost"`
 	OutputCost   *float64 `json:"output_cost"`
 	TotalCost    *float64 `json:"total_cost"`
+	GroupCacheFields
 }
 
 // UserPathUsage holds per-user-path token usage aggregates.
@@ -124,6 +125,7 @@ type UserPathUsage struct {
 	InputCost    *float64 `json:"input_cost" extensions:"x-nullable"`
 	OutputCost   *float64 `json:"output_cost" extensions:"x-nullable"`
 	TotalCost    *float64 `json:"total_cost" extensions:"x-nullable"`
+	GroupCacheFields
 }
 
 // LabelUsage holds per-label token usage aggregates. A request carrying
@@ -138,6 +140,41 @@ type LabelUsage struct {
 	InputCost    *float64 `json:"input_cost" extensions:"x-nullable"`
 	OutputCost   *float64 `json:"output_cost" extensions:"x-nullable"`
 	TotalCost    *float64 `json:"total_cost" extensions:"x-nullable"`
+	GroupCacheFields
+}
+
+// GroupCacheFields carries the cache-related figures shared by the chart
+// aggregate rows (per model, user path, or label).
+//
+// The *_input_tokens split is the provider prompt-cache breakdown of the
+// group's input, folded per row from raw_data exactly like the daily series
+// (local-cache hits excluded). LocalCachedInputTokens and
+// LocalCachedOutputTokens count the input and output tokens of rows served
+// from GoModel's local response cache within the same period and filters —
+// populated regardless of the query's cache mode, since uncached aggregates
+// exclude those rows by design. CachedInputCost is a read-time estimate
+// priced by the admin layer from current catalog pricing (see
+// EstimateCachedInputCost); storage layers never populate it.
+type GroupCacheFields struct {
+	UncachedInputTokens     int64    `json:"uncached_input_tokens,omitempty"`
+	CachedInputTokens       int64    `json:"cached_input_tokens,omitempty"`
+	CacheWriteInputTokens   int64    `json:"cache_write_input_tokens,omitempty"`
+	LocalCachedInputTokens  int64    `json:"local_cached_input_tokens,omitempty"`
+	LocalCachedOutputTokens int64    `json:"local_cached_output_tokens,omitempty"`
+	CachedInputCost         *float64 `json:"cached_input_cost,omitempty" extensions:"x-nullable"`
+
+	// CachedTokensByPricing breaks the group's prompt-cached tokens down by
+	// pricing identity so the admin layer can estimate CachedInputCost. Never
+	// serialized.
+	CachedTokensByPricing map[CachedPricingKey]int64 `json:"-" swaggerignore:"true"`
+}
+
+// CachedPricingKey identifies the catalog pricing row for a slice of a
+// group's prompt-cached tokens.
+type CachedPricingKey struct {
+	Model        string
+	Provider     string
+	ProviderName string
 }
 
 // DailyUsage holds usage statistics for a single period.

--- a/internal/usage/reader_mongodb.go
+++ b/internal/usage/reader_mongodb.go
@@ -339,7 +339,7 @@ func (r *MongoDBReader) usageCacheStats(ctx context.Context, params UsageQueryPa
 const mongoCanonicalUserPathField = "_gomodel_user_path"
 
 // mongoCanonicalUserPathAddFieldsStage materializes the canonical user path
-// on each document.
+// mongoCanonicalUserPathAddFieldsStage creates a MongoDB aggregation stage that adds the canonical user path to each document.
 func mongoCanonicalUserPathAddFieldsStage() bson.D {
 	return bson.D{{Key: "$addFields", Value: bson.D{
 		{Key: mongoCanonicalUserPathField, Value: mongoUsageGroupedUserPathExpr()},
@@ -347,7 +347,7 @@ func mongoCanonicalUserPathAddFieldsStage() bson.D {
 }
 
 // mongoCanonicalUserPathMatchStage narrows to the subtree of userPath,
-// matched against the canonical field (which must already be materialized).
+// mongoCanonicalUserPathMatchStage builds a MongoDB match stage for a user-path subtree on the canonical user-path field.
 func mongoCanonicalUserPathMatchStage(userPath string) bson.D {
 	return bson.D{{Key: "$match", Value: bson.D{{Key: mongoCanonicalUserPathField, Value: bson.D{
 		{Key: "$regex", Value: usageUserPathSubtreeRegex(userPath)},
@@ -360,7 +360,9 @@ func mongoCanonicalUserPathMatchStage(userPath string) bson.D {
 // by, so with canonicalUserPath the user-path filter moves onto the
 // materialized canonical field; the model/label aggregates filter the raw
 // field, and so do their folds. Cache mode is always widened to "all" so
-// local-cache rows are counted.
+// mongoUsageCacheStatsPipeline builds a MongoDB aggregation pipeline for cache statistics,
+// including local-cache rows and optionally filtering by canonical user path. It returns an
+// error if the usage filters or user path cannot be normalized.
 func mongoUsageCacheStatsPipeline(params UsageQueryParams, canonicalUserPath bool) (bson.A, error) {
 	params.CacheMode = CacheModeAll
 	matchParams := params
@@ -585,6 +587,7 @@ func (r *MongoDBReader) GetUsageByLabel(ctx context.Context, params UsageQueryPa
 	return result, nil
 }
 
+// mongoUsageGroupedProviderNameExpr builds the MongoDB expression used to derive a grouped provider name, preferring a trimmed provider name and falling back to the trimmed provider value.
 func mongoUsageGroupedProviderNameExpr() bson.D {
 	trimmedProviderName := bson.D{{Key: "$trim", Value: bson.D{
 		{Key: "input", Value: bson.D{{Key: "$ifNull", Value: bson.A{"$provider_name", ""}}}},

--- a/internal/usage/reader_mongodb.go
+++ b/internal/usage/reader_mongodb.go
@@ -299,51 +299,10 @@ func (r *MongoDBReader) usageCacheStats(ctx context.Context, params UsageQueryPa
 	if normalizeCacheMode(params.CacheMode) != CacheModeUncached {
 		return nil, nil
 	}
-	params.CacheMode = CacheModeAll
-	pipeline := bson.A{}
-	// The fold must select the same row set as the aggregate it decorates.
-	// GetUsageByUserPath filters against the canonical (trimmed,
-	// root-normalized) path expression it groups by, so its fold does too;
-	// the model/label aggregates filter the raw field, and so do theirs.
-	matchParams := params
-	if canonicalUserPath {
-		matchParams.UserPath = ""
-	}
-	matchFilters, err := mongoUsageMatchFilters(matchParams)
+	pipeline, err := mongoUsageCacheStatsPipeline(params, canonicalUserPath)
 	if err != nil {
 		return nil, err
 	}
-	if len(matchFilters) > 0 {
-		pipeline = append(pipeline, bson.D{{Key: "$match", Value: matchFilters}})
-	}
-	if canonicalUserPath {
-		userPath, err := normalizeUsageUserPathFilter(params.UserPath)
-		if err != nil {
-			return nil, err
-		}
-		if userPath != "" {
-			const canonicalUserPathField = "_gomodel_user_path"
-			pipeline = append(pipeline,
-				bson.D{{Key: "$addFields", Value: bson.D{
-					{Key: canonicalUserPathField, Value: mongoUsageGroupedUserPathExpr()},
-				}}},
-				bson.D{{Key: "$match", Value: bson.D{{Key: canonicalUserPathField, Value: bson.D{
-					{Key: "$regex", Value: usageUserPathSubtreeRegex(userPath)},
-				}}}}},
-			)
-		}
-	}
-	pipeline = append(pipeline, bson.D{{Key: "$project", Value: bson.D{
-		{Key: "model", Value: 1},
-		{Key: "provider", Value: 1},
-		{Key: "provider_name", Value: 1},
-		{Key: "user_path", Value: 1},
-		{Key: "labels", Value: 1},
-		{Key: "cache_type", Value: 1},
-		{Key: "input_tokens", Value: 1},
-		{Key: "output_tokens", Value: 1},
-		{Key: "raw_data", Value: 1},
-	}}})
 
 	cursor, err := r.collection.Aggregate(ctx, pipeline)
 	if err != nil {
@@ -375,6 +334,73 @@ func (r *MongoDBReader) usageCacheStats(ctx context.Context, params UsageQueryPa
 	return out, nil
 }
 
+// mongoCanonicalUserPathField is the synthetic field holding the canonical
+// (trimmed, root-normalized) user path the user-path aggregate groups by.
+const mongoCanonicalUserPathField = "_gomodel_user_path"
+
+// mongoCanonicalUserPathAddFieldsStage materializes the canonical user path
+// on each document.
+func mongoCanonicalUserPathAddFieldsStage() bson.D {
+	return bson.D{{Key: "$addFields", Value: bson.D{
+		{Key: mongoCanonicalUserPathField, Value: mongoUsageGroupedUserPathExpr()},
+	}}}
+}
+
+// mongoCanonicalUserPathMatchStage narrows to the subtree of userPath,
+// matched against the canonical field (which must already be materialized).
+func mongoCanonicalUserPathMatchStage(userPath string) bson.D {
+	return bson.D{{Key: "$match", Value: bson.D{{Key: mongoCanonicalUserPathField, Value: bson.D{
+		{Key: "$regex", Value: usageUserPathSubtreeRegex(userPath)},
+	}}}}}
+}
+
+// mongoUsageCacheStatsPipeline builds the fold's aggregation pipeline. The
+// fold must select the same row set as the aggregate it decorates:
+// GetUsageByUserPath filters against the canonical path expression it groups
+// by, so with canonicalUserPath the user-path filter moves onto the
+// materialized canonical field; the model/label aggregates filter the raw
+// field, and so do their folds. Cache mode is always widened to "all" so
+// local-cache rows are counted.
+func mongoUsageCacheStatsPipeline(params UsageQueryParams, canonicalUserPath bool) (bson.A, error) {
+	params.CacheMode = CacheModeAll
+	matchParams := params
+	if canonicalUserPath {
+		matchParams.UserPath = ""
+	}
+	matchFilters, err := mongoUsageMatchFilters(matchParams)
+	if err != nil {
+		return nil, err
+	}
+	pipeline := bson.A{}
+	if len(matchFilters) > 0 {
+		pipeline = append(pipeline, bson.D{{Key: "$match", Value: matchFilters}})
+	}
+	if canonicalUserPath {
+		userPath, err := normalizeUsageUserPathFilter(params.UserPath)
+		if err != nil {
+			return nil, err
+		}
+		if userPath != "" {
+			pipeline = append(pipeline,
+				mongoCanonicalUserPathAddFieldsStage(),
+				mongoCanonicalUserPathMatchStage(userPath),
+			)
+		}
+	}
+	pipeline = append(pipeline, bson.D{{Key: "$project", Value: bson.D{
+		{Key: "model", Value: 1},
+		{Key: "provider", Value: 1},
+		{Key: "provider_name", Value: 1},
+		{Key: "user_path", Value: 1},
+		{Key: "labels", Value: 1},
+		{Key: "cache_type", Value: 1},
+		{Key: "input_tokens", Value: 1},
+		{Key: "output_tokens", Value: 1},
+		{Key: "raw_data", Value: 1},
+	}}})
+	return pipeline, nil
+}
+
 // GetUsageByUserPath returns token and cost totals grouped by tracked user path.
 func (r *MongoDBReader) GetUsageByUserPath(ctx context.Context, params UsageQueryParams) ([]UserPathUsage, error) {
 	pipeline := bson.A{}
@@ -388,23 +414,18 @@ func (r *MongoDBReader) GetUsageByUserPath(ctx context.Context, params UsageQuer
 		pipeline = append(pipeline, bson.D{{Key: "$match", Value: matchFilters}})
 	}
 
-	const canonicalUserPathField = "_gomodel_user_path"
-	pipeline = append(pipeline, bson.D{{Key: "$addFields", Value: bson.D{
-		{Key: canonicalUserPathField, Value: mongoUsageGroupedUserPathExpr()},
-	}}})
+	pipeline = append(pipeline, mongoCanonicalUserPathAddFieldsStage())
 
 	userPath, err := normalizeUsageUserPathFilter(params.UserPath)
 	if err != nil {
 		return nil, err
 	}
 	if userPath != "" {
-		pipeline = append(pipeline, bson.D{{Key: "$match", Value: bson.D{{Key: canonicalUserPathField, Value: bson.D{
-			{Key: "$regex", Value: usageUserPathSubtreeRegex(userPath)},
-		}}}}})
+		pipeline = append(pipeline, mongoCanonicalUserPathMatchStage(userPath))
 	}
 
 	pipeline = append(pipeline, bson.D{{Key: "$group", Value: bson.D{
-		{Key: "_id", Value: "$" + canonicalUserPathField},
+		{Key: "_id", Value: "$" + mongoCanonicalUserPathField},
 		{Key: "input_tokens", Value: bson.D{{Key: "$sum", Value: "$input_tokens"}}},
 		{Key: "output_tokens", Value: bson.D{{Key: "$sum", Value: "$output_tokens"}}},
 		{Key: "total_tokens", Value: bson.D{{Key: "$sum", Value: "$total_tokens"}}},

--- a/internal/usage/reader_mongodb.go
+++ b/internal/usage/reader_mongodb.go
@@ -278,7 +278,7 @@ func (r *MongoDBReader) GetUsageByModel(ctx context.Context, params UsageQueryPa
 		return nil, fmt.Errorf("error iterating usage by model cursor: %w", err)
 	}
 
-	stats, err := r.usageCacheStats(ctx, params, modelGroupKeys)
+	stats, err := r.usageCacheStats(ctx, params, false, modelGroupKeys)
 	if err != nil {
 		return nil, err
 	}
@@ -291,7 +291,7 @@ func (r *MongoDBReader) GetUsageByModel(ctx context.Context, params UsageQueryPa
 // and folds cache figures per group. For uncached-mode requests (the
 // default) it streams with cache mode "all" so local-cache rows are counted
 // even though the aggregates exclude them.
-func (r *MongoDBReader) usageCacheStats(ctx context.Context, params UsageQueryParams, keysFor groupKeysFunc) (map[string]*GroupCacheStats, error) {
+func (r *MongoDBReader) usageCacheStats(ctx context.Context, params UsageQueryParams, canonicalUserPath bool, keysFor groupKeysFunc) (map[string]*GroupCacheStats, error) {
 	// The cache fields describe uncached-mode aggregates: for cached/all
 	// modes the local tokens are already inside the aggregate sums (and the
 	// provider split would not partition them), so the pass is skipped and
@@ -300,13 +300,38 @@ func (r *MongoDBReader) usageCacheStats(ctx context.Context, params UsageQueryPa
 		return nil, nil
 	}
 	params.CacheMode = CacheModeAll
-	matchFilters, err := mongoUsageMatchFilters(params)
+	pipeline := bson.A{}
+	// The fold must select the same row set as the aggregate it decorates.
+	// GetUsageByUserPath filters against the canonical (trimmed,
+	// root-normalized) path expression it groups by, so its fold does too;
+	// the model/label aggregates filter the raw field, and so do theirs.
+	matchParams := params
+	if canonicalUserPath {
+		matchParams.UserPath = ""
+	}
+	matchFilters, err := mongoUsageMatchFilters(matchParams)
 	if err != nil {
 		return nil, err
 	}
-	pipeline := bson.A{}
 	if len(matchFilters) > 0 {
 		pipeline = append(pipeline, bson.D{{Key: "$match", Value: matchFilters}})
+	}
+	if canonicalUserPath {
+		userPath, err := normalizeUsageUserPathFilter(params.UserPath)
+		if err != nil {
+			return nil, err
+		}
+		if userPath != "" {
+			const canonicalUserPathField = "_gomodel_user_path"
+			pipeline = append(pipeline,
+				bson.D{{Key: "$addFields", Value: bson.D{
+					{Key: canonicalUserPathField, Value: mongoUsageGroupedUserPathExpr()},
+				}}},
+				bson.D{{Key: "$match", Value: bson.D{{Key: canonicalUserPathField, Value: bson.D{
+					{Key: "$regex", Value: usageUserPathSubtreeRegex(userPath)},
+				}}}}},
+			)
+		}
 	}
 	pipeline = append(pipeline, bson.D{{Key: "$project", Value: bson.D{
 		{Key: "model", Value: 1},
@@ -433,7 +458,7 @@ func (r *MongoDBReader) GetUsageByUserPath(ctx context.Context, params UsageQuer
 		return nil, fmt.Errorf("error iterating usage by user path cursor: %w", err)
 	}
 
-	stats, err := r.usageCacheStats(ctx, params, userPathGroupKeys)
+	stats, err := r.usageCacheStats(ctx, params, true, userPathGroupKeys)
 	if err != nil {
 		return nil, err
 	}
@@ -530,7 +555,7 @@ func (r *MongoDBReader) GetUsageByLabel(ctx context.Context, params UsageQueryPa
 		return nil, err
 	}
 
-	stats, err := r.usageCacheStats(ctx, params, labelGroupKeys)
+	stats, err := r.usageCacheStats(ctx, params, false, labelGroupKeys)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/usage/reader_mongodb.go
+++ b/internal/usage/reader_mongodb.go
@@ -282,16 +282,23 @@ func (r *MongoDBReader) GetUsageByModel(ctx context.Context, params UsageQueryPa
 	if err != nil {
 		return nil, err
 	}
-	applyModelCacheStats(result, stats)
+	result = applyModelCacheStats(result, stats)
 
 	return result, nil
 }
 
 // usageCacheStats runs the second streaming pass behind the chart aggregates
-// and folds cache figures per group. It always streams with cache mode "all"
-// so local-cache rows are counted even though the aggregates themselves
-// default to uncached-only.
+// and folds cache figures per group. For uncached-mode requests (the
+// default) it streams with cache mode "all" so local-cache rows are counted
+// even though the aggregates exclude them.
 func (r *MongoDBReader) usageCacheStats(ctx context.Context, params UsageQueryParams, keysFor groupKeysFunc) (map[string]*GroupCacheStats, error) {
+	// The cache fields describe uncached-mode aggregates: for cached/all
+	// modes the local tokens are already inside the aggregate sums (and the
+	// provider split would not partition them), so the pass is skipped and
+	// the fields stay zero.
+	if normalizeCacheMode(params.CacheMode) != CacheModeUncached {
+		return nil, nil
+	}
 	params.CacheMode = CacheModeAll
 	matchFilters, err := mongoUsageMatchFilters(params)
 	if err != nil {
@@ -430,7 +437,7 @@ func (r *MongoDBReader) GetUsageByUserPath(ctx context.Context, params UsageQuer
 	if err != nil {
 		return nil, err
 	}
-	applyUserPathCacheStats(result, stats)
+	result = applyUserPathCacheStats(result, stats)
 
 	return result, nil
 }
@@ -527,7 +534,7 @@ func (r *MongoDBReader) GetUsageByLabel(ctx context.Context, params UsageQueryPa
 	if err != nil {
 		return nil, err
 	}
-	applyLabelCacheStats(result, stats)
+	result = applyLabelCacheStats(result, stats)
 
 	return result, nil
 }

--- a/internal/usage/reader_mongodb.go
+++ b/internal/usage/reader_mongodb.go
@@ -278,7 +278,69 @@ func (r *MongoDBReader) GetUsageByModel(ctx context.Context, params UsageQueryPa
 		return nil, fmt.Errorf("error iterating usage by model cursor: %w", err)
 	}
 
+	stats, err := r.usageCacheStats(ctx, params, modelGroupKeys)
+	if err != nil {
+		return nil, err
+	}
+	applyModelCacheStats(result, stats)
+
 	return result, nil
+}
+
+// usageCacheStats runs the second streaming pass behind the chart aggregates
+// and folds cache figures per group. It always streams with cache mode "all"
+// so local-cache rows are counted even though the aggregates themselves
+// default to uncached-only.
+func (r *MongoDBReader) usageCacheStats(ctx context.Context, params UsageQueryParams, keysFor groupKeysFunc) (map[string]*GroupCacheStats, error) {
+	params.CacheMode = CacheModeAll
+	matchFilters, err := mongoUsageMatchFilters(params)
+	if err != nil {
+		return nil, err
+	}
+	pipeline := bson.A{}
+	if len(matchFilters) > 0 {
+		pipeline = append(pipeline, bson.D{{Key: "$match", Value: matchFilters}})
+	}
+	pipeline = append(pipeline, bson.D{{Key: "$project", Value: bson.D{
+		{Key: "model", Value: 1},
+		{Key: "provider", Value: 1},
+		{Key: "provider_name", Value: 1},
+		{Key: "user_path", Value: 1},
+		{Key: "labels", Value: 1},
+		{Key: "cache_type", Value: 1},
+		{Key: "input_tokens", Value: 1},
+		{Key: "output_tokens", Value: 1},
+		{Key: "raw_data", Value: 1},
+	}}})
+
+	cursor, err := r.collection.Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil, fmt.Errorf("failed to aggregate usage cache stats: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	out := map[string]*GroupCacheStats{}
+	for cursor.Next(ctx) {
+		var row struct {
+			Model        string         `bson:"model"`
+			Provider     string         `bson:"provider"`
+			ProviderName string         `bson:"provider_name"`
+			UserPath     string         `bson:"user_path"`
+			Labels       []string       `bson:"labels"`
+			CacheType    string         `bson:"cache_type"`
+			InputTokens  int            `bson:"input_tokens"`
+			OutputTokens int            `bson:"output_tokens"`
+			RawData      map[string]any `bson:"raw_data"`
+		}
+		if err := cursor.Decode(&row); err != nil {
+			return nil, fmt.Errorf("failed to decode usage cache stat row: %w", err)
+		}
+		accumulateGroupCacheStats(out, keysFor, usageCacheStatRow(row))
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating usage cache stat cursor: %w", err)
+	}
+	return out, nil
 }
 
 // GetUsageByUserPath returns token and cost totals grouped by tracked user path.
@@ -364,6 +426,12 @@ func (r *MongoDBReader) GetUsageByUserPath(ctx context.Context, params UsageQuer
 		return nil, fmt.Errorf("error iterating usage by user path cursor: %w", err)
 	}
 
+	stats, err := r.usageCacheStats(ctx, params, userPathGroupKeys)
+	if err != nil {
+		return nil, err
+	}
+	applyUserPathCacheStats(result, stats)
+
 	return result, nil
 }
 
@@ -439,7 +507,7 @@ func (r *MongoDBReader) GetUsageByLabel(ctx context.Context, params UsageQueryPa
 	}
 	defer cursor.Close(ctx)
 
-	return decodeGroupedUsageRows(ctx, cursor, "usage by label", func(row mongoGroupedUsageRow) LabelUsage {
+	result, err := decodeGroupedUsageRows(ctx, cursor, "usage by label", func(row mongoGroupedUsageRow) LabelUsage {
 		return LabelUsage{
 			Label:        row.Key,
 			Requests:     row.Requests,
@@ -451,6 +519,17 @@ func (r *MongoDBReader) GetUsageByLabel(ctx context.Context, params UsageQueryPa
 			TotalCost:    costPtr(row.HasTotalCost, row.TotalCost),
 		}
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	stats, err := r.usageCacheStats(ctx, params, labelGroupKeys)
+	if err != nil {
+		return nil, err
+	}
+	applyLabelCacheStats(result, stats)
+
+	return result, nil
 }
 
 func mongoUsageGroupedProviderNameExpr() bson.D {

--- a/internal/usage/reader_mongodb_test.go
+++ b/internal/usage/reader_mongodb_test.go
@@ -169,3 +169,61 @@ func TestMongoUsageLogRowDecodesRewriteSavings(t *testing.T) {
 		})
 	}
 }
+
+// The user-path fold must select the same row set as the user-path aggregate:
+// the raw-field filter is cleared and the subtree match runs against the
+// materialized canonical (trimmed, root-normalized) path instead — via the
+// same shared stages the aggregate itself uses.
+func TestMongoUsageCacheStatsPipelineCanonicalUserPath(t *testing.T) {
+	params := UsageQueryParams{UserPath: "/team/alpha", Model: "gpt-5"}
+
+	pipeline, err := mongoUsageCacheStatsPipeline(params, true)
+	if err != nil {
+		t.Fatalf("mongoUsageCacheStatsPipeline returned error: %v", err)
+	}
+	if len(pipeline) != 4 {
+		t.Fatalf("expected 4 stages (match, addFields, canonical match, project), got %d: %#v", len(pipeline), pipeline)
+	}
+
+	// Stage 1: base filters with the raw user_path condition cleared — the
+	// model filter stays, the subtree match moves to the canonical stage.
+	wantBase, err := mongoUsageMatchFilters(UsageQueryParams{Model: "gpt-5", CacheMode: CacheModeAll})
+	if err != nil {
+		t.Fatalf("mongoUsageMatchFilters returned error: %v", err)
+	}
+	if !reflect.DeepEqual(pipeline[0], bson.D{{Key: "$match", Value: wantBase}}) {
+		t.Fatalf("unexpected base match stage: %#v", pipeline[0])
+	}
+
+	// Stages 2-3: identical canonical stages to the aggregate's own.
+	if !reflect.DeepEqual(pipeline[1], mongoCanonicalUserPathAddFieldsStage()) {
+		t.Fatalf("unexpected addFields stage: %#v", pipeline[1])
+	}
+	if !reflect.DeepEqual(pipeline[2], mongoCanonicalUserPathMatchStage("/team/alpha")) {
+		t.Fatalf("unexpected canonical match stage: %#v", pipeline[2])
+	}
+}
+
+// Model/label folds keep filtering the raw user_path field, matching their
+// aggregates; no canonical stages are inserted.
+func TestMongoUsageCacheStatsPipelineRawUserPath(t *testing.T) {
+	params := UsageQueryParams{UserPath: "/team/alpha"}
+
+	pipeline, err := mongoUsageCacheStatsPipeline(params, false)
+	if err != nil {
+		t.Fatalf("mongoUsageCacheStatsPipeline returned error: %v", err)
+	}
+	if len(pipeline) != 2 {
+		t.Fatalf("expected 2 stages (match, project), got %d: %#v", len(pipeline), pipeline)
+	}
+
+	wantParams := params
+	wantParams.CacheMode = CacheModeAll
+	want, err := mongoUsageMatchFilters(wantParams)
+	if err != nil {
+		t.Fatalf("mongoUsageMatchFilters returned error: %v", err)
+	}
+	if !reflect.DeepEqual(pipeline[0], bson.D{{Key: "$match", Value: want}}) {
+		t.Fatalf("unexpected match stage: %#v", pipeline[0])
+	}
+}

--- a/internal/usage/reader_postgresql.go
+++ b/internal/usage/reader_postgresql.go
@@ -108,7 +108,34 @@ func (r *PostgreSQLReader) GetUsageByModel(ctx context.Context, params UsageQuer
 		return nil, fmt.Errorf("error iterating usage by model rows: %w", err)
 	}
 
+	stats, err := r.usageCacheStats(ctx, params, "user_path", nil, modelGroupKeys)
+	if err != nil {
+		return nil, err
+	}
+	applyModelCacheStats(result, stats)
+
 	return result, nil
+}
+
+// usageCacheStats runs the second streaming pass behind the chart aggregates
+// and folds cache figures per group. It always streams with cache mode "all"
+// so local-cache rows are counted even though the aggregates themselves
+// default to uncached-only.
+func (r *PostgreSQLReader) usageCacheStats(ctx context.Context, params UsageQueryParams, userPathExpr string, extraConditions []string, keysFor groupKeysFunc) (map[string]*GroupCacheStats, error) {
+	params.CacheMode = CacheModeAll
+	conditions, args, _, err := pgUsageConditionsWithUserPathExpr(params, userPathExpr, 1)
+	if err != nil {
+		return nil, err
+	}
+	conditions = append(conditions, extraConditions...)
+	where := sqlutil.BuildWhereClause(conditions)
+
+	rows, err := r.pool.Query(ctx, `SELECT model, provider, provider_name, user_path, labels::text, cache_type, input_tokens, output_tokens, raw_data FROM "usage"`+where, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query usage cache stats: %w", err)
+	}
+	defer rows.Close()
+	return foldUsageCacheRows(rows, keysFor)
 }
 
 // GetUsageByUserPath returns token and cost totals grouped by tracked user path.
@@ -144,6 +171,12 @@ func (r *PostgreSQLReader) GetUsageByUserPath(ctx context.Context, params UsageQ
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("error iterating usage by user path rows: %w", err)
 	}
+
+	stats, err := r.usageCacheStats(ctx, params, userPathExpr, nil, userPathGroupKeys)
+	if err != nil {
+		return nil, err
+	}
+	applyUserPathCacheStats(result, stats)
 
 	return result, nil
 }
@@ -182,6 +215,12 @@ func (r *PostgreSQLReader) GetUsageByLabel(ctx context.Context, params UsageQuer
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("error iterating usage by label rows: %w", err)
 	}
+
+	stats, err := r.usageCacheStats(ctx, params, "user_path", []string{"jsonb_typeof(labels) = 'array'"}, labelGroupKeys)
+	if err != nil {
+		return nil, err
+	}
+	applyLabelCacheStats(result, stats)
 
 	return result, nil
 }

--- a/internal/usage/reader_postgresql.go
+++ b/internal/usage/reader_postgresql.go
@@ -112,16 +112,23 @@ func (r *PostgreSQLReader) GetUsageByModel(ctx context.Context, params UsageQuer
 	if err != nil {
 		return nil, err
 	}
-	applyModelCacheStats(result, stats)
+	result = applyModelCacheStats(result, stats)
 
 	return result, nil
 }
 
 // usageCacheStats runs the second streaming pass behind the chart aggregates
-// and folds cache figures per group. It always streams with cache mode "all"
-// so local-cache rows are counted even though the aggregates themselves
-// default to uncached-only.
+// and folds cache figures per group. For uncached-mode requests (the
+// default) it streams with cache mode "all" so local-cache rows are counted
+// even though the aggregates exclude them.
 func (r *PostgreSQLReader) usageCacheStats(ctx context.Context, params UsageQueryParams, userPathExpr string, extraConditions []string, keysFor groupKeysFunc) (map[string]*GroupCacheStats, error) {
+	// The cache fields describe uncached-mode aggregates: for cached/all
+	// modes the local tokens are already inside the aggregate sums (and the
+	// provider split would not partition them), so the pass is skipped and
+	// the fields stay zero.
+	if normalizeCacheMode(params.CacheMode) != CacheModeUncached {
+		return nil, nil
+	}
 	params.CacheMode = CacheModeAll
 	conditions, args, _, err := pgUsageConditionsWithUserPathExpr(params, userPathExpr, 1)
 	if err != nil {
@@ -176,7 +183,7 @@ func (r *PostgreSQLReader) GetUsageByUserPath(ctx context.Context, params UsageQ
 	if err != nil {
 		return nil, err
 	}
-	applyUserPathCacheStats(result, stats)
+	result = applyUserPathCacheStats(result, stats)
 
 	return result, nil
 }
@@ -220,7 +227,7 @@ func (r *PostgreSQLReader) GetUsageByLabel(ctx context.Context, params UsageQuer
 	if err != nil {
 		return nil, err
 	}
-	applyLabelCacheStats(result, stats)
+	result = applyLabelCacheStats(result, stats)
 
 	return result, nil
 }

--- a/internal/usage/reader_sqlite.go
+++ b/internal/usage/reader_sqlite.go
@@ -106,16 +106,23 @@ func (r *SQLiteReader) GetUsageByModel(ctx context.Context, params UsageQueryPar
 	if err != nil {
 		return nil, err
 	}
-	applyModelCacheStats(result, stats)
+	result = applyModelCacheStats(result, stats)
 
 	return result, nil
 }
 
 // usageCacheStats runs the second streaming pass behind the chart aggregates
-// and folds cache figures per group. It always streams with cache mode "all"
-// so local-cache rows are counted even though the aggregates themselves
-// default to uncached-only.
+// and folds cache figures per group. For uncached-mode requests (the
+// default) it streams with cache mode "all" so local-cache rows are counted
+// even though the aggregates exclude them.
 func (r *SQLiteReader) usageCacheStats(ctx context.Context, params UsageQueryParams, userPathExpr string, extraConditions []string, keysFor groupKeysFunc) (map[string]*GroupCacheStats, error) {
+	// The cache fields describe uncached-mode aggregates: for cached/all
+	// modes the local tokens are already inside the aggregate sums (and the
+	// provider split would not partition them), so the pass is skipped and
+	// the fields stay zero.
+	if normalizeCacheMode(params.CacheMode) != CacheModeUncached {
+		return nil, nil
+	}
 	params.CacheMode = CacheModeAll
 	conditions, args, err := sqliteUsageConditionsWithUserPathExpr(params, userPathExpr)
 	if err != nil {
@@ -170,7 +177,7 @@ func (r *SQLiteReader) GetUsageByUserPath(ctx context.Context, params UsageQuery
 	if err != nil {
 		return nil, err
 	}
-	applyUserPathCacheStats(result, stats)
+	result = applyUserPathCacheStats(result, stats)
 
 	return result, nil
 }
@@ -213,7 +220,7 @@ func (r *SQLiteReader) GetUsageByLabel(ctx context.Context, params UsageQueryPar
 	if err != nil {
 		return nil, err
 	}
-	applyLabelCacheStats(result, stats)
+	result = applyLabelCacheStats(result, stats)
 
 	return result, nil
 }

--- a/internal/usage/reader_sqlite.go
+++ b/internal/usage/reader_sqlite.go
@@ -102,7 +102,34 @@ func (r *SQLiteReader) GetUsageByModel(ctx context.Context, params UsageQueryPar
 		return nil, fmt.Errorf("error iterating usage by model rows: %w", err)
 	}
 
+	stats, err := r.usageCacheStats(ctx, params, "user_path", nil, modelGroupKeys)
+	if err != nil {
+		return nil, err
+	}
+	applyModelCacheStats(result, stats)
+
 	return result, nil
+}
+
+// usageCacheStats runs the second streaming pass behind the chart aggregates
+// and folds cache figures per group. It always streams with cache mode "all"
+// so local-cache rows are counted even though the aggregates themselves
+// default to uncached-only.
+func (r *SQLiteReader) usageCacheStats(ctx context.Context, params UsageQueryParams, userPathExpr string, extraConditions []string, keysFor groupKeysFunc) (map[string]*GroupCacheStats, error) {
+	params.CacheMode = CacheModeAll
+	conditions, args, err := sqliteUsageConditionsWithUserPathExpr(params, userPathExpr)
+	if err != nil {
+		return nil, err
+	}
+	conditions = append(conditions, extraConditions...)
+	where := sqlutil.BuildWhereClause(conditions)
+
+	rows, err := r.db.QueryContext(ctx, `SELECT model, provider, provider_name, user_path, labels, cache_type, input_tokens, output_tokens, raw_data FROM usage`+where, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query usage cache stats: %w", err)
+	}
+	defer rows.Close()
+	return foldUsageCacheRows(rows, keysFor)
 }
 
 // GetUsageByUserPath returns token and cost totals grouped by tracked user path.
@@ -138,6 +165,12 @@ func (r *SQLiteReader) GetUsageByUserPath(ctx context.Context, params UsageQuery
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("error iterating usage by user path rows: %w", err)
 	}
+
+	stats, err := r.usageCacheStats(ctx, params, userPathExpr, nil, userPathGroupKeys)
+	if err != nil {
+		return nil, err
+	}
+	applyUserPathCacheStats(result, stats)
 
 	return result, nil
 }
@@ -175,6 +208,12 @@ func (r *SQLiteReader) GetUsageByLabel(ctx context.Context, params UsageQueryPar
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("error iterating usage by label rows: %w", err)
 	}
+
+	stats, err := r.usageCacheStats(ctx, params, "user_path", []string{"labels IS NOT NULL"}, labelGroupKeys)
+	if err != nil {
+		return nil, err
+	}
+	applyLabelCacheStats(result, stats)
 
 	return result, nil
 }


### PR DESCRIPTION
## Summary

Reworks the usage page's three breakdown charts (by model, by user path, by label) and surfaces cache traffic in them.

### Chart rework
- **Horizontal diverging bars**: one row per model/user path/label; input-side series grow left from zero, output-side series grow right, with an emphasized zero divider. Row height scales with the number of entries (top 10 + "Other").
- **Three-way view toggle** per chart: diverging, stacked (all series piling right as segments of one bar), and the existing table — each with its own icon.
- **Layout**: charts flow two per row; a chart alone in its row (odd count, or a neighbor hidden) stretches to full width.

### Cache series (new)
- **Prompt Cached** (provider prompt-cache reads) joins the input side — in tokens mode as its own series (Input becomes *paid* input: uncached + cache writes, falling back to full input for rows without the split), and in costs mode as an **estimated** cached-read cost split out of Input Cost, priced from current catalog pricing via the existing `PricingResolver` (same trade-off as pricing recalculation).
- **Locally Cached** (GoModel response-cache hits) joins each side it belongs to: cached input on the left, cached output on the right. Local hits are free, so costs mode shows no local series.
- Cache series appear only when they have data; colors reuse the overview chart's token palette so the dashboard reads as one system.
- The table views gain "Prompt Cached" and "Local Cached" columns (with the ~$ estimate and per-side split in tooltips).

### Backend
- `ModelUsage`/`UserPathUsage`/`LabelUsage` gain a shared `GroupCacheFields` block: prompt-cache input split, per-side local-cache tokens, and estimated `cached_input_cost`.
- Populated by a second streaming pass over the same filters (aggregate SQL can't return per-row `raw_data`), folded through one shared accumulator reusing `EntryInputSegments` — the same pattern as the daily series. Implemented for SQLite, PostgreSQL, and MongoDB; label expansion happens in Go, matching each backend's `json_each`/`$unwind` semantics.
- The fold streams with cache mode "all" so local-cache tokens are populated even though the aggregates default to uncached-only.

### User-visible notes
- For additive-accounting providers (Anthropic), a row's input side can exceed the old input bar since cached reads now appear as their own segment (same behavior as the overview chart).
- `cached_input_cost` is a read-time estimate at today's prices; models without a cached-input rate are omitted from it.

## Testing
- New Go tests: shared fold via SQLite integration (by model/user path/label, filter-following) and `EstimateCachedInputCost` unit tests; full `internal/...` suite green.
- Dashboard JS suite extended to 515 tests (diverging/stacked shapes, cache series, costs-mode estimate split, "Other" folding) — all green.
- Rendering verified with headless-Chrome screenshots in both modes and both chart views.
- Swagger docs regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Usage analytics now exposes expanded prompt-cached and locally-cached token metrics for models, user paths, and labels, plus cached input cost when available.
  * Usage charts add a **stacked** view alongside **chart** mode, with improved horizontal bar rendering and an **Other** aggregate for lower-ranked items.
* **UI/Documentation**
  * The Tokens/Costs toggle is now pinned in the sticky date-range controls, and table views include **Prompt Cached** and **Local Cached** columns.
  * Swagger/OpenAPI schema updated to include the new cache-partitioned fields.
* **Tests**
  * Updated usage and dashboard chart tests to cover stacked/diverging rendering and the new cache metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->