### PR TITLE
fix(responses): accept and ignore include for chat-translated providers

### DIFF
--- a/docs/advanced/responses-compatibility.mdx
+++ b/docs/advanced/responses-compatibility.mdx
@@ -38,6 +38,7 @@ function tool loops. They cannot safely execute OpenAI-hosted tools.
 | OpenAI-hosted file search | Provider decides | Rejected |
 | OpenAI-hosted computer use | Provider decides | Rejected |
 | `previous_response_id` and `conversation` | Forwarded | Rejected |
+| `include` annotations | Forwarded | Accepted and ignored, except `message.output_text.logprobs` |
 | Unknown Responses input item types | Preserved | Rejected |
 | Responses websocket transport | Not implemented by GoModel | Not implemented by GoModel |
 
@@ -46,6 +47,19 @@ function tool loops. They cannot safely execute OpenAI-hosted tools.
   `text.verbosity` settings through GoModel's chat translation path. GoModel
   rejects those fields instead of dropping them.
 </Note>
+
+## The `include` field
+
+`include` asks for extra annotations on response items, such as
+`reasoning.encrypted_content` or `file_search_call.results`. It never changes
+what the model does, so chat-translated providers accept it and return a
+response without those annotations, exactly like a native provider that does
+not support them. Clients that always attach `include`, such as Codex with
+`wire_api = "responses"`, work without extra configuration.
+
+The one exception is `message.output_text.logprobs`, which requests real model
+output rather than an annotation. GoModel rejects it for the same reason it
+rejects `top_logprobs`.
 
 ## Hosted tools
 

--- a/docs/guides/codex.mdx
+++ b/docs/guides/codex.mdx
@@ -120,6 +120,12 @@ See the [DeepSeek guide](/providers/deepseek) for the full reasoning effort
 mapping table (DeepSeek V4 only accepts `high` and `max`, so GoModel maps
 `low` and `medium` up to `high`).
 
+Codex attaches `include: ["reasoning.encrypted_content"]` to every Responses
+request. GoModel ignores it on chat-translated providers, so the response
+carries no encrypted reasoning items. See
+[Responses compatibility](/advanced/responses-compatibility) for the full
+feature matrix.
+
 Then use the DeepSeek model name in Codex:
 
 ```toml

--- a/internal/providers/responses_adapter.go
+++ b/internal/providers/responses_adapter.go
@@ -83,8 +83,8 @@ func validateResponsesRequestForChatTranslation(req *core.ResponsesRequest) erro
 	if req.Conversation != nil {
 		return unsupportedResponsesChatTranslationField("conversation")
 	}
-	if len(req.Include) > 0 {
-		return unsupportedResponsesChatTranslationField("include")
+	if err := validateResponsesIncludeForChatTranslation(req.Include); err != nil {
+		return err
 	}
 	if req.Prompt != nil {
 		return unsupportedResponsesChatTranslationField("prompt")
@@ -109,6 +109,30 @@ func validateResponsesRequestForChatTranslation(req *core.ResponsesRequest) erro
 	}
 	if err := validateResponsesToolChoiceForChatTranslation(req.ToolChoice); err != nil {
 		return err
+	}
+	return nil
+}
+
+// responsesIncludeOutputLogprobs asks for token logprobs on output text. It is
+// the only include value that requests real model output rather than an
+// annotation on a provider-hosted item, so it is rejected for the same reason
+// top_logprobs is.
+const responsesIncludeOutputLogprobs = "message.output_text.logprobs"
+
+// validateResponsesIncludeForChatTranslation accepts the Responses "include"
+// field for chat-translated providers. include only asks for extra annotations
+// on response items; it never changes what the model does. Chat translation
+// cannot produce those items — hosted-tool items are rejected at the tools
+// check, and encrypted reasoning has no chat equivalent — so the annotations
+// are simply absent, exactly as they are for a native provider that does not
+// support them. Unrecognized values are dropped too: a stricter allowlist would
+// break clients again every time OpenAI adds a value, and no include value can
+// make a response wrong.
+func validateResponsesIncludeForChatTranslation(include []string) error {
+	for _, value := range include {
+		if strings.TrimSpace(value) == responsesIncludeOutputLogprobs {
+			return unsupportedResponsesChatTranslationField("include")
+		}
 	}
 	return nil
 }

--- a/internal/providers/responses_adapter_test.go
+++ b/internal/providers/responses_adapter_test.go
@@ -414,6 +414,113 @@ func TestConvertResponsesRequestToChat_MapsPortableAgentsSDKFields(t *testing.T)
 	}
 }
 
+func TestConvertResponsesRequestToChat_AcceptsAnnotationOnlyInclude(t *testing.T) {
+	tests := []struct {
+		name    string
+		include []string
+	}{
+		{name: "encrypted reasoning", include: []string{"reasoning.encrypted_content"}},
+		{name: "hosted tool annotations", include: []string{"web_search_call.action.sources", "file_search_call.results", "code_interpreter_call.outputs"}},
+		{name: "input echo annotations", include: []string{"message.input_image.image_url", "computer_call_output.output.image_url"}},
+		{name: "unrecognized future value", include: []string{"some_future_call.details"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &core.ResponsesRequest{Model: "test-model", Input: "Hello", Include: tt.include}
+
+			chatReq, err := ConvertResponsesRequestToChat(req)
+			if err != nil {
+				t.Fatalf("ConvertResponsesRequestToChat() error = %v", err)
+			}
+			if len(chatReq.Messages) != 1 || chatReq.Messages[0].Content != "Hello" {
+				t.Fatalf("Messages = %#v, want the single user message", chatReq.Messages)
+			}
+			if !chatReq.ExtraFields.IsEmpty() {
+				t.Fatalf("ExtraFields = %#v, want include dropped rather than forwarded", chatReq.ExtraFields)
+			}
+			if len(req.Include) != len(tt.include) {
+				t.Fatalf("req.Include = %#v, want the caller's request left unmutated", req.Include)
+			}
+		})
+	}
+}
+
+// TestConvertResponsesRequestToChat_TranslatesCodexRequest locks the payload
+// Codex sends over wire_api = "responses". Codex always attaches
+// include: ["reasoning.encrypted_content"], which used to fail the whole
+// request against chat-translated providers such as DeepSeek (issue #532).
+func TestConvertResponsesRequestToChat_TranslatesCodexRequest(t *testing.T) {
+	const body = `{
+  "model": "deepseek-v4-pro",
+  "instructions": "You are Codex.",
+  "input": [
+    {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "Reply with exactly ok"}]}
+  ],
+  "tools": [
+    {"type": "function", "name": "shell", "description": "run", "strict": false,
+     "parameters": {"type": "object", "properties": {"command": {"type": "string"}}}}
+  ],
+  "tool_choice": "auto",
+  "parallel_tool_calls": false,
+  "reasoning": {"effort": "medium"},
+  "store": false,
+  "stream": true,
+  "include": ["reasoning.encrypted_content"],
+  "text": {"verbosity": "medium"}
+}`
+
+	var req core.ResponsesRequest
+	if err := json.Unmarshal([]byte(body), &req); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	chatReq, err := ConvertResponsesRequestToChat(&req)
+	if err != nil {
+		t.Fatalf("ConvertResponsesRequestToChat() error = %v", err)
+	}
+	if len(chatReq.Messages) != 2 || chatReq.Messages[0].Role != "system" || chatReq.Messages[1].Role != "user" {
+		t.Fatalf("Messages = %#v, want instructions as system plus the user turn", chatReq.Messages)
+	}
+	if len(chatReq.Tools) != 1 {
+		t.Fatalf("Tools = %#v, want the shell function tool", chatReq.Tools)
+	}
+	if _, ok := chatReq.Tools[0]["function"]; !ok {
+		t.Fatalf("Tools[0] = %#v, want chat-shaped function member", chatReq.Tools[0])
+	}
+	if chatReq.Reasoning == nil || chatReq.Reasoning.Effort != "medium" {
+		t.Fatalf("Reasoning = %#v, want effort medium", chatReq.Reasoning)
+	}
+	if !chatReq.Stream {
+		t.Fatal("Stream = false, want true")
+	}
+}
+
+func TestConvertResponsesRequestToChat_RejectsOutputLogprobsInclude(t *testing.T) {
+	tests := []struct {
+		name    string
+		include []string
+	}{
+		{name: "alone", include: []string{"message.output_text.logprobs"}},
+		{name: "mixed with droppable values", include: []string{"reasoning.encrypted_content", "message.output_text.logprobs"}},
+		{name: "padded", include: []string{" message.output_text.logprobs "}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &core.ResponsesRequest{Model: "test-model", Input: "Hello", Include: tt.include}
+
+			_, err := ConvertResponsesRequestToChat(req)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), "include") {
+				t.Fatalf("error = %v, want mention %q", err, "include")
+			}
+		})
+	}
+}
+
 func TestConvertResponsesRequestToChat_NormalizesToolChoiceAliases(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Fixes #532.

## Problem

Codex 0.122+ attaches `include: ["reasoning.encrypted_content"]` to every Responses request when `wire_api = "responses"`. Chat-translated providers rejected the entire request:

```
responses field "include" is only supported by native Responses providers;
use an OpenAI-compatible provider or passthrough for this request
```

That made the DeepSeek + Codex setup documented in `docs/guides/codex.mdx` impossible to use. I replayed a realistic Codex payload through the decoder and converter: `include` was the *only* blocker — instructions, input items, function tools, reasoning effort and the rest already translate cleanly.

## Why accepting it does not weaken the compatibility rule

The adapter's rule is "never silently change the meaning of a request". `include` does not fall under it. Every value in the enum only asks for **extra annotations on response items** — it cannot alter what the model does. Dropping it produces exactly the response a native provider that does not support that annotation would return: an absent optional field, never a wrong answer.

The same line is already drawn elsewhere: `metadata` is silently dropped by this converter, and `store` is honored at the gateway layer rather than the provider. Hosted-tool include values are inert here anyway, since hosted tools are rejected at the tools check.

`message.output_text.logprobs` stays rejected — it requests real model output rather than an annotation, the same reason `top_logprobs` is rejected.

Unrecognized values are dropped too. A strict allowlist buys nothing (no include value can make a response wrong) and would guarantee the next Codex release breaks the integration again — which is exactly this bug.

## Changes

- `internal/providers/responses_adapter.go`: blanket rejection replaced with `validateResponsesIncludeForChatTranslation()`. One function, so it covers every chat-translated provider plus Anthropic's direct call into the converter. The caller's `req.Include` is not mutated — `ChatRequest` never carried it — so response snapshots and failover retries see the original request.
- `internal/providers/responses_adapter_test.go`: table tests for accepted values (encrypted reasoning, hosted-tool annotations, input echoes, an unrecognized future value) and rejected ones (alone, mixed, whitespace-padded), plus a regression test that decodes a real Codex body from JSON and asserts the full translation.
- Docs: `include` row and an explanatory section in `responses-compatibility.mdx`; a note in the Codex guide's DeepSeek section.

## User-visible impact

Codex, and any client that auto-attaches `include`, now works over `/v1/responses` against DeepSeek, Anthropic, Gemini and the other chat-translated providers. Native Responses providers are untouched — they still forward `include` upstream. Responses simply carry no encrypted-reasoning or hosted-tool annotations on translated routes.

## Verification

`gofmt`, `go vet`, `golangci-lint` (0 issues), and `go test ./internal/... ./tests/contract/...` all green; full pre-commit suite (race tests, perf guard, mint validate) passed.

Not covered here: a live Codex → DeepSeek run. `verbosity` and `prompt_cache_key` are still forwarded verbatim to DeepSeek's `/chat/completions`, which is the next thing worth checking against the real API — separate from this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented support for the OpenAI Responses `include` field.
  * Clarified how annotation requests behave across native and chat-translated providers.
  * Added guidance for Codex requests and encrypted reasoning content.

* **Bug Fixes**
  * Chat-translated providers now accept supported annotation-only `include` values.
  * Requests for output log probabilities continue to return a clear validation error.

* **Tests**
  * Added coverage for annotation handling, Codex request translation, and invalid log probability requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->