### PR TITLE
ci: give the postgres service only to the suite that uses it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,18 +40,24 @@ jobs:
           # the schema fetch is reliable again; track in this PR/branch discussion.
           verify: false
 
-  # Unit, E2E, integration, and contract suites share identical setup and
-  # differ only in the test command, so they run as one matrix.
-  go-tests:
-    name: ${{ matrix.name }}
+  # The unit suite is the only one that needs a database service: one store
+  # implementation now serves SQLite and PostgreSQL, and without this service
+  # GOMODEL_TEST_POSTGRES_URL is unset, every PostgreSQL subtest skips, and CI
+  # stays green while covering only SQLite.
+  #
+  # It runs on its own rather than in the matrix below because a service
+  # container is pulled before the job starts, so a registry hiccup fails the
+  # job outright. Attaching it to suites that never open a database put three
+  # extra jobs at that risk for no coverage.
+  unit-tests:
+    name: Unit Tests
     runs-on: ubuntu-latest
-    # One store implementation now serves SQLite and PostgreSQL, so the store
-    # suites run against both. Without this service GOMODEL_TEST_POSTGRES_URL
-    # is unset, every PostgreSQL subtest skips, and CI stays green while
-    # covering only SQLite.
     services:
       postgres:
-        image: postgres:18-alpine
+        # Mirrors Docker Hub's official image. Anonymous pulls of
+        # registry-1.docker.io intermittently time out on GitHub runners, which
+        # fails the job before a single test runs.
+        image: public.ecr.aws/docker/library/postgres:18-alpine
         env:
           POSTGRES_USER: gomodel
           POSTGRES_PASSWORD: gomodel
@@ -63,13 +69,40 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Run tests
+        run: make test-race
+        env:
+          # Deliberately not POSTGRES_URL: the suite creates and drops schemas,
+          # so pointing it at a configured application database is opt-in.
+          GOMODEL_TEST_POSTGRES_URL: postgres://gomodel:gomodel@localhost:5432/gomodel
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v7
+        with:
+          files: ./coverage.out
+          fail_ci_if_error: false
+        continue-on-error: true
+
+  # The E2E, integration, and contract suites share identical setup and differ
+  # only in the test command, so they run as one matrix. None of them reads
+  # GOMODEL_TEST_POSTGRES_URL — the integration suite brings up its own
+  # containers in TestMain — so none takes a service container.
+  go-tests:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: Unit Tests
-            cmd: make test-race
-            coverage: true
           - name: E2E Tests
             cmd: go test -v -tags=e2e -timeout=5m ./tests/e2e/...
           - name: Integration Tests
@@ -87,18 +120,6 @@ jobs:
 
       - name: Run tests
         run: ${{ matrix.cmd }}
-        env:
-          # Deliberately not POSTGRES_URL: the suite creates and drops schemas,
-          # so pointing it at a configured application database is opt-in.
-          GOMODEL_TEST_POSTGRES_URL: postgres://gomodel:gomodel@localhost:5432/gomodel
-
-      - name: Upload coverage
-        if: matrix.coverage
-        uses: codecov/codecov-action@v7
-        with:
-          files: ./coverage.out
-          fail_ci_if_error: false
-        continue-on-error: true
 
   test-dashboard:
     name: Dashboard Unit Tests

--- a/tests/integration/docker_test.go
+++ b/tests/integration/docker_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"net/url"
 	"os"
 	"os/exec"
@@ -15,6 +16,54 @@ import (
 
 type dockerContainer struct {
 	id string
+}
+
+const (
+	dockerPullAttempts = 4
+	dockerPullBackoff  = 3 * time.Second
+)
+
+// dockerPullImages fetches images up front, one at a time, rather than letting
+// `docker run` pull them as a side effect.
+//
+// Two things make the implicit pull unreliable in CI. The containers start
+// concurrently, so both pulls would leave at the same instant, and registries
+// meter anonymous pulls per second — ECR Public rejects the second one with
+// "toomanyrequests: Rate exceeded". Separately, an implicit pull gets no retry
+// of its own, so a single transient registry error fails the whole suite before
+// a test has run. Pulling serially with backoff addresses both.
+func dockerPullImages(ctx context.Context, images ...string) error {
+	for _, image := range images {
+		if err := dockerPullImage(ctx, image); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func dockerPullImage(ctx context.Context, image string) error {
+	var lastErr error
+
+	for attempt := 1; attempt <= dockerPullAttempts; attempt++ {
+		if _, err := runDocker(ctx, "pull", image); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+
+		if attempt == dockerPullAttempts {
+			break
+		}
+
+		log.Printf("Pull of %s failed (attempt %d/%d), retrying: %v", image, attempt, dockerPullAttempts, lastErr)
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("pull %s: %w: last error: %v", image, ctx.Err(), lastErr)
+		case <-time.After(time.Duration(attempt) * dockerPullBackoff):
+		}
+	}
+
+	return fmt.Errorf("pull %s after %d attempts: %w", image, dockerPullAttempts, lastErr)
 }
 
 func dockerRunDetached(ctx context.Context, options []string, image string, command ...string) (*dockerContainer, error) {

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -38,6 +38,16 @@ var (
 
 const mongoReplicaSetName = "rs"
 
+// Images come from the AWS ECR Public mirror of Docker Hub's official library,
+// not from Docker Hub. Anonymous pulls of registry-1.docker.io intermittently
+// time out on GitHub runners and fail the job before a single test runs; the
+// mirror carries the same images over a different path and without Docker Hub's
+// anonymous pull limit.
+const (
+	postgresImage = "public.ecr.aws/docker/library/postgres:16-alpine"
+	mongoImage    = "public.ecr.aws/docker/library/mongo:7"
+)
+
 // TestMain sets up and tears down the Docker-backed test databases.
 func TestMain(m *testing.M) {
 	testCtx, cancelFunc = context.WithTimeout(context.Background(), 10*time.Minute)
@@ -87,7 +97,7 @@ func setupPostgreSQL(ctx context.Context) error {
 			"-e", "POSTGRES_USER=test",
 			"-e", "POSTGRES_PASSWORD=test",
 		},
-		"postgres:16-alpine",
+		postgresImage,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to start PostgreSQL container: %w", err)
@@ -128,7 +138,7 @@ func setupMongoDB(ctx context.Context) error {
 	mongoContainer, err = dockerRunDetached(
 		ctx,
 		[]string{"-P"},
-		"mongo:7",
+		mongoImage,
 		"--replSet", mongoReplicaSetName,
 		"--bind_ip_all",
 	)

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -52,6 +52,14 @@ const (
 func TestMain(m *testing.M) {
 	testCtx, cancelFunc = context.WithTimeout(context.Background(), 10*time.Minute)
 
+	// Pull before starting anything: the containers come up concurrently below,
+	// and two simultaneous anonymous pulls trip the registry's rate limit.
+	if err := dockerPullImages(testCtx, postgresImage, mongoImage); err != nil {
+		log.Printf("Image pull failed: %v", err)
+		cancelFunc()
+		os.Exit(1)
+	}
+
 	// Start containers in parallel
 	errCh := make(chan error, 2)
 


### PR DESCRIPTION
## What was failing

Two CI runs died within six hours of each other, both before any test executed:

```
/usr/bin/docker pull postgres:18-alpine
Error response from daemon: Get "https://registry-1.docker.io/v2/":
  net/http: request canceled while waiting for connection
##[error]Docker pull failed with exit code 1
```

Service containers are pulled during job init, so a registry hiccup fails the job outright. The two runs hit different jobs — `30160708337` took out Integration Tests, `30171320448` took out E2E Tests — because the failing job is just whichever leg loses the coin toss.

## Why it started

`fbe18ff9` (#586) attached a Postgres service to **all four** legs of the `go-tests` matrix. Only one of them connects to it:

- `GOMODEL_TEST_POSTGRES_URL` is read solely by `internal/storage/sqlx/sqlxtest`, which the `tests/*` suites never import.
- The integration suite brings up its own containers in `TestMain`, ignoring the service entirely.

So three jobs pulled a database they never opened, taking on the registry risk for no coverage.

## The change

- Unit tests move to their own job, keeping the service.
- E2E, Integration, and Contract share a matrix with no services.
- The remaining pulls — the service image, and the integration suite's two `docker run`s — go through the AWS ECR Public mirror of Docker Hub's official library rather than Docker Hub's anonymous endpoint.

Job names are unchanged, so required status checks keep matching. No test is dropped or skipped: the PostgreSQL subtests still run against a real 18, the integration suite still against its own 16 and Mongo 7.

## Verification

The mirrored images are the same images, not lookalikes:

```
postgres:16-alpine  hub=250f6b8f71c7e045  ecr=250f6b8f71c7e045  SAME
mongo:7             hub=0fe38991953131ed  ecr=0fe38991953131ed  SAME
```

Locally, against the mirrored images: integration `ok 25.8s`, e2e `ok 7.0s`, contract `ok 0.5s`, plus the full pre-commit gate (`test-race`, `lint`, `fix-check`, perf guard).

One honest caveat: the failure mode was a connection timeout rather than a 429, so moving off Docker Hub's anonymous endpoint is a well-established mitigation rather than a proven one. If it recurs on the unit job, the fallback is the runner's preinstalled PostgreSQL 16.14, which removes the registry from that job altogether.

Supersedes #592, which diagnosed the same root cause but pulled only E2E out of the matrix — the job that happened to fail in the run it looked at, rather than the three that never needed the service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved automated unit-test coverage by adding a dedicated unit-test workflow job with an available PostgreSQL service, avoiding skips when DB configuration is missing.
  * Updated integration tests to pull and use consistent PostgreSQL and MongoDB container images before starting test containers.
  * Enhanced Docker test helpers with serialized image pre-pulling, retry, and backoff for more reliable integration runs.
  * Streamlined the main Go test matrix to focus on E2E, integration, and contract suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->