### PR TITLE
ci(release): trigger demo deploy webhook after tag promotion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,6 +182,27 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release edit "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --draft=false --verify-tag
 
+  deploy-demo:
+    name: Update demo.enterpilot.io
+    runs-on: ubuntu-latest
+    # Must run after tag promotion: the demo pulls :latest, which is what
+    # docker-promote pushes.
+    needs: docker-promote
+    # :latest is only promoted for stable releases (see "Detect prerelease
+    # tag"), so skip prereleases like v1.2.3-rc1 — the demo wouldn't change.
+    if: ${{ !contains(github.ref_name, '-') }}
+    # Best-effort: a demo host outage must not fail the release
+    continue-on-error: true
+    steps:
+      - name: Trigger demo deploy webhook
+        env:
+          DEMO_HOOK_TOKEN: ${{ secrets.DEMO_HOOK_TOKEN }}
+        run: |
+          curl -fsS --retry 3 --retry-delay 5 -X PUT \
+            -H "X-Hook-Token: ${DEMO_HOOK_TOKEN}" \
+            -d "deploy ${GITHUB_REF_NAME}" \
+            https://demo.enterpilot.io/hooks/update-demo
+
   publish-mcp:
     name: Publish to MCP Registry
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,7 +198,8 @@ jobs:
         env:
           DEMO_HOOK_TOKEN: ${{ secrets.DEMO_HOOK_TOKEN }}
         run: |
-          curl -fsS --retry 3 --retry-delay 5 -X PUT \
+          curl -fsS --connect-timeout 10 --max-time 20 --retry-max-time 40 \
+            --retry 3 --retry-delay 5 -X PUT \
             -H "X-Hook-Token: ${DEMO_HOOK_TOKEN}" \
             -d "deploy ${GITHUB_REF_NAME}" \
             https://demo.enterpilot.io/hooks/update-demo


### PR DESCRIPTION
## What

Adds a `deploy-demo` job to the release workflow that pings the demo host's update hook after the release image tags are promoted, so [demo.enterpilot.io](https://demo.enterpilot.io) refreshes on every stable release instead of needing a manual nudge.

## Details

- **Runs after `docker-promote`** — the demo pulls `:latest`, which is exactly what that job pushes, so triggering earlier would redeploy the previous image.
- **Skips prereleases** (`if: !contains(github.ref_name, '-')`) — `:latest` is only promoted for stable tags (see the "Detect prerelease tag" step), so a `v1.2.3-rc1` run would deploy nothing.
- **Best-effort** (`continue-on-error: true`) — same treatment as `publish-mcp`: a demo host outage shouldn't turn a good release red. `curl -fsS --retry 3 --retry-delay 5` already covers transient failures.

## Setup required

The repo needs an Actions secret `DEMO_HOOK_TOKEN` matching the hook's `X-Hook-Token`. Without it the header is sent empty and the job fails (harmlessly, given `continue-on-error`).

## User-visible impact

None for gateway users — CI/release automation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated demo deployment step after stable releases to notify the demo environment with the current Git tag.
  * Demo updates now run only for stable tags; prerelease/preview builds are skipped.
  * Demo update webhook failures are handled as best-effort, so they don’t block the rest of the release workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->