### PR TITLE
docs: add an unlisted GoModel Pro page

### DIFF
--- a/docs/pro.mdx
+++ b/docs/pro.mdx
@@ -1,0 +1,129 @@
+---
+title: "GoModel Pro"
+description: "GoModel Pro is the commercial distribution of GoModel: the same gateway plus licensed features. Token compression, how it works, and how to turn it off."
+icon: "gem"
+noindex: true
+keywords: ["GoModel Pro", "token compression", "prompt compression", "license"]
+---
+
+## What Pro is
+
+GoModel Pro is the same gateway as open-source GoModel, in one binary, plus
+licensed features. Every core capability — routing, failover, budgets, rate
+limits, virtual models, caching, audit, the dashboard — works identically and
+is configured the same way.
+
+Without a valid license the binary starts as the plain open-source core. Pro
+never blocks traffic.
+
+## Token compression
+
+The one Pro feature available today. It rewrites each inference request
+before it reaches the provider, cutting prompt-token spend on agentic
+traffic.
+
+Two passes run on every request:
+
+**Normalization** removes structure that costs tokens but carries no
+information:
+
+- the line-number gutter on file reads becomes a single `lines N-M:` header
+- replayed reasoning is dropped from assistant history (chat-completions only)
+- tool-result envelopes collapse to a `# path` header
+- search results, command logs and unified diffs each get a content-aware
+  cleanup
+
+**Deduplication** then replaces repeated runs of lines with a reference to
+their first occurrence:
+
+```
+(Open file: /src/marshmallow/fields.py)… (same as message 16, 3 lines)
+```
+
+Measured on a corpus of real agent conversations at default settings:
+**-19.4% of request bytes**, up to -49.3% on the heaviest sessions.
+
+### What it never touches
+
+- tool-call arguments, non-text content parts, and unknown JSON fields
+- first occurrences — only later duplicates are replaced
+- anything, if estimated savings fall below the threshold; the request
+  passes through byte-identical
+
+Compression is a pure function of the request body, so the same request
+always compresses the same way and the provider's prompt-cache prefix stays
+stable as a conversation grows. It fails open: if the engine errors, the
+request is forwarded unchanged.
+
+Covered endpoints: `POST /v1/chat/completions` and `POST /v1/messages`.
+
+## Turn it off
+
+Four levels, narrowest to broadest.
+
+**One request** — send a header:
+
+```http
+X-GoModel-Compression: off
+```
+
+**Specific models** — comma-separated globs, matched against the model the
+client asked for:
+
+```bash
+PRO_COMPRESSION_EXCLUDE_MODELS="ollama/*,gpt-4o-mini"
+```
+
+**The whole gateway**:
+
+```bash
+PRO_COMPRESSION_ENABLED=false
+```
+
+Startup then logs `token compression disabled via
+PRO_COMPRESSION_ENABLED=false`, and no rewriter is placed in the request
+path at all.
+
+**The entitlement** — run a license without the `compression` feature, or no
+license. The gateway starts as open-source core.
+
+<Note>
+  Settings are read once at startup. Changing one needs a gateway restart.
+</Note>
+
+If you want compression but no rewriting of already-sent history, use
+`PRO_COMPRESSION_SCOPE=new_messages_only` instead of disabling it. Only
+messages after the last assistant turn are rewritten — lower savings, maximum
+prompt-cache reuse.
+
+## Main settings
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `PRO_COMPRESSION_ENABLED` | `true` | Master switch |
+| `PRO_COMPRESSION_SCOPE` | `full_history` | `new_messages_only` rewrites only after the last assistant turn |
+| `PRO_COMPRESSION_EXCLUDE_MODELS` | — | Model globs to skip |
+| `PRO_COMPRESSION_MIN_SAVINGS_TOKENS` | `64` | Minimum estimated savings to rewrite at all |
+| `PRO_COMPRESSION_NORMALIZE` | `true` | Master switch for the normalization pass |
+| `PRO_COMPRESSION_STRIP_LINE_NUMBERS` | `true` | Strip the line-number gutter from file reads |
+| `PRO_COMPRESSION_DROP_REASONING` | `true` | Drop replayed reasoning from assistant history |
+
+Each normalization transform has its own `PRO_COMPRESSION_*` flag if you
+need to disable just one.
+
+## Seeing what it did
+
+**Per request** — the response carries:
+
+```http
+X-GoModel-Pro-Tokens-Saved: 1843
+X-GoModel-Pro-Compression-Blocks: 12
+```
+
+Audit entries keep the **original** client request plus a revision chain
+showing exactly what each rewriter changed, so the full before/after is
+always recoverable.
+
+**Aggregate** — Prometheus counters on `/metrics`, all prefixed
+`gomodel_pro_compression_`, and the dashboard **Usage** page shows "Tokens
+Saved" and "Rewrite Saved" (estimated money) next to Estimated Cost.


### PR DESCRIPTION
## Summary

Adds `docs/pro.mdx` — a single, deliberately short page covering what GoModel Pro is, the token-compression feature as it stands today, and how to turn compression off.

**Not added to `docs.json` navigation.** Mintlify builds and serves every `.mdx` under `docs/`, so the page is reachable at **`/pro`** without appearing in the sidebar or in any nav group. `docs.json` is untouched by this PR.

## Contents

- What Pro is — same gateway, one binary, licensed features; unlicensed builds run as plain open-source core and never block traffic
- Token compression — the normalization pass and the deduplication pass, in plain terms, with the measured `-19.4%` corpus figure
- What it never touches — tool-call arguments, first occurrences, sub-threshold requests; pure function of the body, fails open
- **Turn it off** — the four levels: `X-GoModel-Compression: off` header, `PRO_COMPRESSION_EXCLUDE_MODELS` globs, `PRO_COMPRESSION_ENABLED=false`, or a license without the `compression` feature
- Main settings — seven env vars, not the full seventeen
- Seeing what it did — response headers, the audit revision chain, Prometheus counters and the dashboard Usage cards

Kept intentionally lean: it is a landing page for someone evaluating or operating Pro, not a reference manual. The full env-var matrix lives in the pro repo's README.

## Two decisions worth a second opinion

**`noindex: true` is set** in the frontmatter, so the page stays out of search engines while it is unlinked. If the intent is for prospects to find it organically, delete that one line. Note that an unlinked page **does** still appear in the docs site's own search — hiding it from the sidebar is not the same as hiding it entirely.

**No pricing, no purchase link, no license-acquisition instructions.** The page explains the feature and the config surface only. Add those when there is a URL to point at.

## Test plan

- `mint validate` passes (runs in pre-commit)
- `docs.json` unmodified — confirmed with `git diff --stat docs/docs.json`
- Verify after deploy: `/pro` renders, and the page appears in no sidebar group

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for GoModel Pro and its licensed token compression feature.
  * Explained compression behavior, supported endpoints, error handling, and ways to disable it.
  * Documented configuration options, request-level controls, audit trails, response headers, and monitoring metrics.
  * Added guidance for limiting rewriting to newly added messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->