### PR TITLE
docs(pro): Responses compression coverage and revision-body toggle

### DIFF
--- a/docs/pro.mdx
+++ b/docs/pro.mdx
@@ -47,6 +47,10 @@ Measured on a corpus of real agent conversations at default settings:
 
 - tool-call arguments, non-text content parts, and unknown JSON fields
 - first occurrences — only later duplicates are replaced
+- on `/v1/responses`: replayed reasoning items (the API requires them back
+  verbatim when `store` is off, so `PRO_COMPRESSION_DROP_REASONING` has no
+  effect there) and text parts carrying citation annotations, whose
+  start/end offsets a rewrite would break
 - anything, if estimated savings fall below the threshold; the request
   passes through byte-identical
 
@@ -55,7 +59,9 @@ always compresses the same way and the provider's prompt-cache prefix stays
 stable as a conversation grows. It fails open: if the engine errors, the
 request is forwarded unchanged.
 
-Covered endpoints: `POST /v1/chat/completions` and `POST /v1/messages`.
+Covered endpoints: `POST /v1/chat/completions`, `POST /v1/messages`, and
+`POST /v1/responses` — including function and custom tool-call outputs on
+the Responses API.
 
 ## Turn it off
 
@@ -122,7 +128,10 @@ X-GoModel-Pro-Compression-Blocks: 12
 
 Audit entries keep the **original** client request plus a revision chain
 showing exactly what each rewriter changed, so the full before/after is
-always recoverable.
+always recoverable. Storing the rewritten body copy is governed by
+`LOGGING_LOG_REVISION_BODIES` (default `true`): turning it off keeps the
+revision metadata — rewriter, sizes, tokens saved, the block report — while
+roughly halving audit storage per compressed request.
 
 **Aggregate** — Prometheus counters on `/metrics`, all prefixed
 `gomodel_pro_compression_`, and the dashboard **Usage** page shows a "Pro


### PR DESCRIPTION
Updates the Pro page for two in-flight changes:

- **Covered endpoints** now include `POST /v1/responses` (lands with [GoModel-pro#7](https://github.com/ENTERPILOT/GoModel-pro/pull/7)), with the Responses-specific exemptions in "What it never touches": replayed reasoning items (`PRO_COMPRESSION_DROP_REASONING` is a no-op there — the API requires them back verbatim when `store` is off) and citation-annotated text parts, whose offsets a rewrite would break.
- **Audit revision chain** paragraph documents `LOGGING_LOG_REVISION_BODIES` (lands with #603): default `true`; off keeps revision metadata but skips the stored rewritten-body copy, roughly halving audit storage per compressed request.

Merge after GoModel-pro#7 and #603 so the docs don't run ahead of the binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified token-compression exceptions for Responses API requests, including replayed reasoning items and citation-bearing text.
  * Expanded documented endpoint coverage to include Responses API requests and tool-call outputs.
  * Clarified audit and revision storage behavior, including the option to reduce audit storage while retaining revision metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->