### PR TITLE
fix(failover): fail over on relayed upstream failures wearing 4xx statuses

### DIFF
--- a/docs/features/failover.mdx
+++ b/docs/features/failover.mdx
@@ -80,6 +80,9 @@ Failover is attempted only after the primary request returns:
 - `5xx`
 - `429`
 - model unavailable, unsupported, or not found style errors
+- upstream failure messages relayed with a `4xx` status (aggregator providers
+  such as OpenCode Zen can report a transient failure of their own upstream as
+  `400 "Upstream request failed"`)
 
 It currently applies to translated `/v1/chat/completions`, `/v1/responses`,
 and `/v1/messages` requests, not `/v1/embeddings`.

--- a/internal/gateway/failover.go
+++ b/internal/gateway/failover.go
@@ -230,6 +230,55 @@ func tryFailoverStream(
 	return nil, "", "", "", "", lastErr
 }
 
+// Message fragments that mark an error as failover-eligible when they appear
+// alongside the anchor word checked in ShouldAttemptFailover.
+var (
+	// modelUnavailableFragments signal the model itself is gone or refused,
+	// regardless of the status code the provider chose.
+	modelUnavailableFragments = []string{
+		"not found",
+		"does not exist",
+		"unsupported",
+		"unavailable",
+		"not available",
+		"deprecated",
+		"retired",
+		"disabled",
+	}
+	// upstreamFailureFragments signal an aggregator-style provider (OpenCode
+	// Zen, OpenRouter) relaying a transient failure of *its* upstream, e.g.
+	// OpenCode's 400 "Upstream request failed". These are server-side
+	// failures wearing a client-error status, so a failover target may still
+	// succeed.
+	upstreamFailureFragments = []string{
+		"failed",
+		"error",
+		"unavailable",
+		"timed out",
+		"timeout",
+	}
+	// retiredModel404Fragments cover 404s with availability phrasing but no
+	// literal "model": providers report retired models this way. Plain
+	// endpoint 404s must not match — those are genuine routing misses.
+	retiredModel404Fragments = []string{
+		"unsupported",
+		"unavailable",
+		"not available",
+		"deprecated",
+		"retired",
+		"disabled",
+	}
+)
+
+func containsAny(message string, fragments []string) bool {
+	for _, fragment := range fragments {
+		if strings.Contains(message, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
 // ShouldAttemptFailover reports whether err should trigger translated failover.
 func ShouldAttemptFailover(err error) bool {
 	var gatewayErr *core.GatewayError
@@ -252,36 +301,14 @@ func ShouldAttemptFailover(err error) bool {
 	}
 
 	message := strings.ToLower(strings.TrimSpace(gatewayErr.Message))
-	if strings.Contains(message, "model") {
-		for _, fragment := range []string{
-			"not found",
-			"does not exist",
-			"unsupported",
-			"unavailable",
-			"not available",
-			"deprecated",
-			"retired",
-			"disabled",
-		} {
-			if strings.Contains(message, fragment) {
-				return true
-			}
-		}
+	if strings.Contains(message, "model") && containsAny(message, modelUnavailableFragments) {
+		return true
 	}
-
-	if status == http.StatusNotFound {
-		for _, fragment := range []string{
-			"unsupported",
-			"unavailable",
-			"not available",
-			"deprecated",
-			"retired",
-			"disabled",
-		} {
-			if strings.Contains(message, fragment) {
-				return true
-			}
-		}
+	if strings.Contains(message, "upstream") && containsAny(message, upstreamFailureFragments) {
+		return true
+	}
+	if status == http.StatusNotFound && containsAny(message, retiredModel404Fragments) {
+		return true
 	}
 
 	return false

--- a/internal/gateway/failover_test.go
+++ b/internal/gateway/failover_test.go
@@ -196,6 +196,16 @@ func TestShouldAttemptFailover(t *testing.T) {
 		{"route 404", http.StatusNotFound, "404 page not found", false},
 		{"unknown path 404", http.StatusNotFound, "no route for /v1/foo", false},
 
+		// Aggregator providers relay transient failures of their own upstream
+		// as 4xx client errors; those must fall back (issue #605).
+		{"opencode upstream 400", http.StatusBadRequest, "Error from provider (Console Go): Upstream request failed", true},
+		{"upstream timeout 400", http.StatusBadRequest, "upstream timed out", true},
+		{"upstream unavailable 400", http.StatusBadRequest, "upstream provider is currently unavailable", true},
+
+		// Mentioning an upstream without failure phrasing is a genuine
+		// validation error and must NOT fall back.
+		{"upstream capability 400", http.StatusBadRequest, "parameter tools is not supported by the upstream provider", false},
+
 		// A plain client error without availability phrasing is not retried.
 		{"plain 400", http.StatusBadRequest, "invalid request", false},
 	}


### PR DESCRIPTION
## Summary

Closes #605.

OpenCode Zen (and other aggregator-style providers) can relay a transient failure of *their* upstream as a 4xx client error — e.g. `400 "Error from provider (Console Go): Upstream request failed"`. Failover previously ran only on `5xx`, `429`, and model-availability errors, so a request whose primary model had configured failover targets still returned the raw 400.

`ShouldAttemptFailover` now also fires when the error message blames an upstream: it must contain `"upstream"` **plus** failure phrasing (`failed` / `error` / `unavailable` / `timed out` / `timeout`), regardless of the status code the provider chose. Messages that merely mention an upstream without failure phrasing (e.g. `"parameter tools is not supported by the upstream provider"`) still do not fail over, so genuine validation errors don't sweep targets.

No new configuration: this follows the same message-heuristic pattern as the existing model-availability trigger, keeping the default behavior right without a knob.

## Changes

- `internal/gateway/failover.go`: new upstream-failure trigger; the three inline fragment-scan loops are extracted into named fragment lists (`modelUnavailableFragments`, `upstreamFailureFragments`, `retiredModel404Fragments`) checked via one `containsAny` helper.
- `internal/gateway/failover_test.go`: table cases for the exact reported OpenCode message, upstream timeout/unavailable, and a no-failover guard for upstream capability errors.
- `docs/features/failover.mdx`: "When It Runs" documents the new trigger.

## User-visible impact

- Requests failing with a relayed upstream error now try their failover targets instead of returning the provider's 4xx.
- Existing sweep semantics apply: if every failover target also fails, the client receives the last target's error rather than the primary 4xx.
- Provider note: motivated by OpenCode Zen, but the trigger is provider-agnostic and applies to any translated route with failover rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded automatic failover support for transient upstream failures reported with HTTP 4xx responses.
  * Added handling for model unavailability and retired-model availability messages.
* **Documentation**
  * Updated failover documentation to describe upstream-relayed 4xx failure conditions that can trigger fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->