### PR TITLE
fix(auditlog): cast audit thread key to text for legacy uuid schemas

### DIFF
--- a/internal/auditlog/reader_sessions_sql.go
+++ b/internal/auditlog/reader_sessions_sql.go
@@ -10,8 +10,10 @@ import (
 
 // auditThreadKey groups entries into threads: the session id when present,
 // otherwise the entry's own id, which makes sessionless entries singleton
-// threads in the same page.
-const auditThreadKey = `COALESCE(NULLIF(session_id, ''), id)`
+// threads in the same page. The cast matters: PostgreSQL databases created
+// before the unified schema have a uuid id column, and COALESCE cannot match
+// uuid against the text session_id without it.
+const auditThreadKey = `COALESCE(NULLIF(session_id, ''), CAST(id AS TEXT))`
 
 // GetSessions returns a paginated list of audit sessions ordered by latest
 // activity. One window-function pass ranks each thread's entries by recency

--- a/internal/auditlog/session_id_test.go
+++ b/internal/auditlog/session_id_test.go
@@ -123,6 +123,102 @@ func TestSQLReader_GetSessions(t *testing.T) {
 	})
 }
 
+// PostgreSQL databases created before the unified schema keep their original
+// uuid id column — CREATE TABLE IF NOT EXISTS never retypes it. The session
+// thread key coalesces id with the text session_id, so without a cast every
+// GetSessions call on such a database fails with SQLSTATE 42804 ("COALESCE
+// types text and uuid cannot be matched").
+func TestSQLReader_GetSessionsOnLegacyUUIDSchema(t *testing.T) {
+	sqlxtest.Run(t, func(t *testing.T, db sqlx.DB) {
+		if db.Dialect() != sqlx.PostgreSQL {
+			t.Skip("only pre-unification PostgreSQL schemas used a uuid id column")
+		}
+
+		ctx := context.Background()
+		// The audit_logs table exactly as the standalone PostgreSQL store
+		// created it; session_id is absent and arrives via migration.
+		if err := db.Schema(ctx, `
+			CREATE TABLE audit_logs (
+				id UUID PRIMARY KEY,
+				timestamp TIMESTAMPTZ NOT NULL,
+				duration_ns BIGINT DEFAULT 0,
+				requested_model TEXT,
+				resolved_model TEXT,
+				provider TEXT,
+				provider_name TEXT,
+				alias_used BOOLEAN DEFAULT FALSE,
+				workflow_version_id TEXT,
+				cache_type TEXT,
+				status_code INTEGER DEFAULT 0,
+				request_id TEXT,
+				auth_key_id TEXT,
+				auth_method TEXT,
+				client_ip TEXT,
+				method TEXT,
+				path TEXT,
+				user_path TEXT,
+				stream BOOLEAN DEFAULT FALSE,
+				error_type TEXT,
+				data JSONB
+			)`, `
+			CREATE TABLE audit_log_attempts (
+				id BIGSERIAL PRIMARY KEY,
+				audit_log_id UUID NOT NULL REFERENCES audit_logs(id) ON DELETE CASCADE,
+				seq INTEGER NOT NULL,
+				kind TEXT NOT NULL,
+				provider_type TEXT,
+				provider_name TEXT,
+				model TEXT,
+				status_code INTEGER DEFAULT 0,
+				success BOOLEAN DEFAULT FALSE,
+				error_type TEXT,
+				error_code TEXT,
+				error_message TEXT,
+				response_body TEXT,
+				response_headers TEXT,
+				started_at TIMESTAMPTZ,
+				duration_ns BIGINT DEFAULT 0,
+				UNIQUE(audit_log_id, seq)
+			)`); err != nil {
+			t.Fatalf("create legacy tables: %v", err)
+		}
+
+		store, err := newSQLStoreForTest(t, db, 0)
+		if err != nil {
+			t.Fatalf("failed to create store: %v", err)
+		}
+		defer store.Close()
+
+		base := time.Date(2026, 7, 27, 10, 0, 0, 0, time.UTC)
+		entries := []*LogEntry{
+			{ID: "b32d7a52-0000-4000-8000-000000000001", Timestamp: base, Provider: "openai", SessionID: "sess-a", StatusCode: 200},
+			{ID: "b32d7a52-0000-4000-8000-000000000002", Timestamp: base.Add(time.Minute), Provider: "openai", SessionID: "sess-a", StatusCode: 200},
+			{ID: "b32d7a52-0000-4000-8000-000000000003", Timestamp: base.Add(2 * time.Minute), Provider: "openai", StatusCode: 200},
+		}
+		if err := store.WriteBatch(ctx, entries); err != nil {
+			t.Fatalf("WriteBatch failed: %v", err)
+		}
+
+		reader, err := NewSQLReader(db)
+		if err != nil {
+			t.Fatalf("failed to create reader: %v", err)
+		}
+		result, err := reader.GetSessions(ctx, LogQueryParams{Limit: 10})
+		if err != nil {
+			t.Fatalf("GetSessions failed: %v", err)
+		}
+		if result.Total != 2 || len(result.Sessions) != 2 {
+			t.Fatalf("total=%d sessions=%d, want 2/2", result.Total, len(result.Sessions))
+		}
+		if got := result.Sessions[0].Latest.ID; got != "b32d7a52-0000-4000-8000-000000000003" {
+			t.Fatalf("sessions[0].Latest.ID = %q, want the singleton entry", got)
+		}
+		if got := result.Sessions[1]; got.SessionID != "sess-a" || got.Count != 2 {
+			t.Fatalf("sess-a summary = %+v", got)
+		}
+	})
+}
+
 // assertGetSessionsFilters runs the shared filtered-grouping cases against a
 // reader, so both backends prove filters apply to entries before grouping.
 func assertGetSessionsFilters(t *testing.T, reader Reader) {

--- a/internal/auditlog/session_id_test.go
+++ b/internal/auditlog/session_id_test.go
@@ -210,11 +210,20 @@ func TestSQLReader_GetSessionsOnLegacyUUIDSchema(t *testing.T) {
 		if result.Total != 2 || len(result.Sessions) != 2 {
 			t.Fatalf("total=%d sessions=%d, want 2/2", result.Total, len(result.Sessions))
 		}
-		if got := result.Sessions[0].Latest.ID; got != "b32d7a52-0000-4000-8000-000000000003" {
-			t.Fatalf("sessions[0].Latest.ID = %q, want the singleton entry", got)
+		want := []struct {
+			latestID  string
+			sessionID string
+			count     int
+		}{
+			{"b32d7a52-0000-4000-8000-000000000003", "", 1},
+			{"b32d7a52-0000-4000-8000-000000000002", "sess-a", 2},
 		}
-		if got := result.Sessions[1]; got.SessionID != "sess-a" || got.Count != 2 {
-			t.Fatalf("sess-a summary = %+v", got)
+		for i, tt := range want {
+			got := result.Sessions[i]
+			if got.Latest.ID != tt.latestID || got.SessionID != tt.sessionID || got.Count != tt.count {
+				t.Fatalf("sessions[%d] = %+v, want latest %q session %q count %d",
+					i, got, tt.latestID, tt.sessionID, tt.count)
+			}
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Since v0.1.63 the Audit Logs page comes up empty on PostgreSQL deployments upgraded from older releases, and the gateway logs:

```
failed to count audit sessions: ERROR: COALESCE types text and uuid cannot be matched (SQLSTATE 42804)
```

**Root cause:** databases created before the unified schema (#586) have `audit_logs.id` as `uuid` (the old standalone PostgreSQL store's DDL); `CREATE TABLE IF NOT EXISTS` never retypes it. The session thread key added in #602 — `COALESCE(NULLIF(session_id, ''), id)` — then mixes `text` with `uuid`, so every `GET /admin/audit/sessions` call fails, and since group-by-session is the dashboard's default view, the page shows no entries. Fresh databases and SQLite are unaffected, which is why the suite stayed green.

**Fix:** cast the id inside the thread key: `COALESCE(NULLIF(session_id, ''), CAST(id AS TEXT))`. `CAST(… AS TEXT)` is valid on both backends and a no-op on SQLite, where the column is already TEXT.

## User-visible impact

The Audit Logs page (session threads view) works again on PostgreSQL databases upgraded from pre-unification releases. No behavior change for fresh databases or SQLite.

## Testing

- New `TestSQLReader_GetSessionsOnLegacyUUIDSchema` recreates the exact pre-unification PostgreSQL DDL (uuid `id`, uuid `audit_log_id` FK, no `session_id` column — the migration adds it) and runs `GetSessions`. Against the unfixed query it reproduces the reported SQLSTATE 42804 error verbatim; with the fix it passes.
- Full `internal/auditlog` suite green on SQLite and PostgreSQL (`GOMODEL_TEST_POSTGRES_URL` set), build and vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audit session retrieval compatibility with older PostgreSQL audit log schemas.
  * Ensured session thread grouping and computed session details (latest entry, session identifier aggregation, activity counts) work correctly when legacy UUID-based data is present.
* **Tests**
  * Added a regression test that validates session retrieval behavior on legacy PostgreSQL setups, including correct thread count, grouping, and returned per-thread aggregates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->