### PR TITLE
feat(minimax): add native text-to-speech support

### DIFF
--- a/internal/providers/minimax/audio.go
+++ b/internal/providers/minimax/audio.go
@@ -1,0 +1,169 @@
+package minimax
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"io"
+	"math"
+	"net/http"
+	"strings"
+
+	"github.com/goccy/go-json"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+var _ core.AudioProvider = (*Provider)(nil)
+
+type speechRequest struct {
+	Model        string             `json:"model"`
+	Text         string             `json:"text"`
+	Stream       bool               `json:"stream"`
+	OutputFormat string             `json:"output_format"`
+	VoiceSetting speechVoiceSetting `json:"voice_setting"`
+	AudioSetting speechAudioSetting `json:"audio_setting"`
+}
+
+type speechVoiceSetting struct {
+	VoiceID string  `json:"voice_id"`
+	Speed   float64 `json:"speed"`
+}
+
+type speechAudioSetting struct {
+	Format string `json:"format"`
+}
+
+type speechResponse struct {
+	Data *struct {
+		Audio  string `json:"audio"`
+		Status int    `json:"status"`
+	} `json:"data"`
+	BaseResponse struct {
+		StatusCode int    `json:"status_code"`
+		StatusMsg  string `json:"status_msg"`
+	} `json:"base_resp"`
+}
+
+// CreateSpeech translates the OpenAI-compatible request to MiniMax's native
+// synchronous text-to-audio endpoint and decodes its hexadecimal audio payload.
+func (p *Provider) CreateSpeech(ctx context.Context, req *core.AudioSpeechRequest) (*core.AudioResponse, error) {
+	if req == nil {
+		return nil, core.NewInvalidRequestError("audio speech request is required", nil)
+	}
+	model := strings.TrimSpace(req.Model)
+	if model == "" {
+		return nil, core.NewInvalidRequestError("model is required", nil)
+	}
+	if strings.TrimSpace(req.Input) == "" {
+		return nil, core.NewInvalidRequestError("input is required", nil)
+	}
+	voice := strings.TrimSpace(req.Voice)
+	if voice == "" {
+		return nil, core.NewInvalidRequestError("voice is required", nil)
+	}
+	if strings.TrimSpace(req.Instructions) != "" {
+		return nil, core.NewInvalidRequestError("minimax speech does not support instructions", nil)
+	}
+
+	format, err := speechFormat(req.ResponseFormat)
+	if err != nil {
+		return nil, err
+	}
+	speed, err := speechSpeed(req.Speed)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := json.Marshal(speechRequest{
+		Model:        model,
+		Text:         req.Input,
+		Stream:       false,
+		OutputFormat: "hex",
+		VoiceSetting: speechVoiceSetting{
+			VoiceID: voice,
+			Speed:   speed,
+		},
+		AudioSetting: speechAudioSetting{Format: format},
+	})
+	if err != nil {
+		return nil, core.NewInvalidRequestError("failed to encode minimax speech request", err)
+	}
+
+	upstream, err := p.Passthrough(ctx, &core.PassthroughRequest{
+		Method:   http.MethodPost,
+		Endpoint: "/t2a_v2",
+		Body:     io.NopCloser(bytes.NewReader(body)),
+		Headers:  http.Header{"Content-Type": {"application/json"}},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if upstream == nil || upstream.Body == nil {
+		return nil, core.NewEmptyProviderResponseError("minimax")
+	}
+	defer func() { _ = upstream.Body.Close() }()
+
+	responseBody, err := io.ReadAll(upstream.Body)
+	if err != nil {
+		return nil, core.NewProviderError("minimax", http.StatusBadGateway, "failed to read speech response", err)
+	}
+	if upstream.StatusCode < http.StatusOK || upstream.StatusCode >= http.StatusMultipleChoices {
+		return nil, core.ParseProviderError("minimax", upstream.StatusCode, responseBody, nil)
+	}
+
+	var response speechResponse
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return nil, core.NewProviderError("minimax", http.StatusBadGateway, "failed to parse speech response", err)
+	}
+	if response.BaseResponse.StatusCode != 0 {
+		message := "minimax speech request failed"
+		if statusMessage := strings.TrimSpace(response.BaseResponse.StatusMsg); statusMessage != "" {
+			message += ": " + statusMessage
+		}
+		return nil, core.NewProviderError("minimax", http.StatusBadGateway, message, nil)
+	}
+	if response.Data == nil || strings.TrimSpace(response.Data.Audio) == "" {
+		return nil, core.NewProviderError("minimax", http.StatusBadGateway, "speech response contains no audio", nil)
+	}
+	if response.Data.Status != 2 {
+		return nil, core.NewProviderError("minimax", http.StatusBadGateway, "speech response did not complete", nil)
+	}
+
+	audio, err := hex.DecodeString(strings.TrimSpace(response.Data.Audio))
+	if err != nil {
+		return nil, core.NewProviderError("minimax", http.StatusBadGateway, "speech response audio is not valid hexadecimal data", err)
+	}
+	return &core.AudioResponse{
+		ContentType: core.SpeechResponseContentType(format),
+		Data:        audio,
+	}, nil
+}
+
+func speechFormat(responseFormat string) (string, error) {
+	format := strings.ToLower(strings.TrimSpace(responseFormat))
+	if format == "" {
+		format = "mp3"
+	}
+	switch format {
+	case "mp3", "wav", "flac", "pcm":
+		return format, nil
+	default:
+		return "", core.NewInvalidRequestError("minimax speech supports mp3, wav, flac, or pcm response formats", nil)
+	}
+}
+
+func speechSpeed(speed float64) (float64, error) {
+	if speed == 0 {
+		return 1, nil
+	}
+	if math.IsNaN(speed) || math.IsInf(speed, 0) || speed < 0.5 || speed > 2 {
+		return 0, core.NewInvalidRequestError("minimax speech speed must be between 0.5 and 2", nil)
+	}
+	return speed, nil
+}
+
+// CreateTranscription reports the unsupported half of core.AudioProvider.
+func (p *Provider) CreateTranscription(_ context.Context, _ *core.AudioTranscriptionRequest) (*core.AudioResponse, error) {
+	return nil, core.NewInvalidRequestError("minimax does not support speech-to-text", nil)
+}

--- a/internal/providers/minimax/audio_test.go
+++ b/internal/providers/minimax/audio_test.go
@@ -1,0 +1,183 @@
+package minimax
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-json"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/llmclient"
+)
+
+func TestProvider_ImplementsAudioProvider(t *testing.T) {
+	provider := NewWithHTTPClient("key", "", nil, llmclient.Hooks{})
+	if _, ok := any(provider).(core.AudioProvider); !ok {
+		t.Fatal("minimax provider should implement core.AudioProvider")
+	}
+}
+
+func TestCreateSpeech_UsesNativeEndpointAndDecodesHex(t *testing.T) {
+	var gotPath string
+	var gotAuth string
+	var gotRequest speechRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read error", http.StatusInternalServerError)
+			return
+		}
+		if err := json.Unmarshal(body, &gotRequest); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"audio":"000102ff","status":2},"base_resp":{"status_code":0,"status_msg":"success"}}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("minimax-key", server.URL+"/v1", server.Client(), llmclient.Hooks{})
+	resp, err := provider.CreateSpeech(context.Background(), &core.AudioSpeechRequest{
+		Model:          "speech-2.8-hd",
+		Input:          "hello",
+		Voice:          "English_expressive_narrator",
+		ResponseFormat: "wav",
+		Speed:          1.5,
+	})
+	if err != nil {
+		t.Fatalf("CreateSpeech() error = %v", err)
+	}
+
+	if gotPath != "/v1/t2a_v2" {
+		t.Fatalf("path = %q, want /v1/t2a_v2", gotPath)
+	}
+	if gotAuth != "Bearer minimax-key" {
+		t.Fatalf("authorization = %q, want Bearer minimax-key", gotAuth)
+	}
+	if gotRequest.Model != "speech-2.8-hd" || gotRequest.Text != "hello" {
+		t.Fatalf("request model/text = %q/%q", gotRequest.Model, gotRequest.Text)
+	}
+	if gotRequest.Stream {
+		t.Fatal("stream = true, want false")
+	}
+	if gotRequest.OutputFormat != "hex" {
+		t.Fatalf("output_format = %q, want hex", gotRequest.OutputFormat)
+	}
+	if gotRequest.VoiceSetting.VoiceID != "English_expressive_narrator" || gotRequest.VoiceSetting.Speed != 1.5 {
+		t.Fatalf("voice_setting = %+v", gotRequest.VoiceSetting)
+	}
+	if gotRequest.AudioSetting.Format != "wav" {
+		t.Fatalf("audio_setting.format = %q, want wav", gotRequest.AudioSetting.Format)
+	}
+	if resp.ContentType != "audio/wav" {
+		t.Fatalf("content type = %q, want audio/wav", resp.ContentType)
+	}
+	if !bytes.Equal(resp.Data, []byte{0x00, 0x01, 0x02, 0xff}) {
+		t.Fatalf("audio data = %v", resp.Data)
+	}
+}
+
+func TestCreateSpeech_DefaultsToMP3AndNormalSpeed(t *testing.T) {
+	var gotRequest speechRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotRequest)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"audio":"ff","status":2},"base_resp":{"status_code":0}}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("key", server.URL, server.Client(), llmclient.Hooks{})
+	resp, err := provider.CreateSpeech(context.Background(), &core.AudioSpeechRequest{
+		Model: "speech-2.8-hd",
+		Input: "hello",
+		Voice: "voice-id",
+	})
+	if err != nil {
+		t.Fatalf("CreateSpeech() error = %v", err)
+	}
+	if gotRequest.AudioSetting.Format != "mp3" || gotRequest.VoiceSetting.Speed != 1 {
+		t.Fatalf("defaults = format %q, speed %v", gotRequest.AudioSetting.Format, gotRequest.VoiceSetting.Speed)
+	}
+	if resp.ContentType != "audio/mpeg" {
+		t.Fatalf("content type = %q, want audio/mpeg", resp.ContentType)
+	}
+}
+
+func TestCreateSpeech_ValidatesNativeConstraints(t *testing.T) {
+	provider := NewWithHTTPClient("key", "https://example.invalid/v1", nil, llmclient.Hooks{})
+	tests := []struct {
+		name string
+		req  *core.AudioSpeechRequest
+		want string
+	}{
+		{name: "nil request", req: nil, want: "request is required"},
+		{name: "missing model", req: &core.AudioSpeechRequest{Input: "hello", Voice: "voice"}, want: "model is required"},
+		{name: "missing input", req: &core.AudioSpeechRequest{Model: "speech-2.8-hd", Voice: "voice"}, want: "input is required"},
+		{name: "missing voice", req: &core.AudioSpeechRequest{Model: "speech-2.8-hd", Input: "hello"}, want: "voice is required"},
+		{name: "instructions", req: &core.AudioSpeechRequest{Model: "speech-2.8-hd", Input: "hello", Voice: "voice", Instructions: "whisper"}, want: "does not support instructions"},
+		{name: "format", req: &core.AudioSpeechRequest{Model: "speech-2.8-hd", Input: "hello", Voice: "voice", ResponseFormat: "aac"}, want: "supports mp3, wav, flac, or pcm"},
+		{name: "speed", req: &core.AudioSpeechRequest{Model: "speech-2.8-hd", Input: "hello", Voice: "voice", Speed: 0.25}, want: "between 0.5 and 2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := provider.CreateSpeech(context.Background(), tt.req)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("CreateSpeech() error = %v, want substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateSpeech_ReturnsNativeStatusError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":null,"base_resp":{"status_code":1004,"status_msg":"invalid voice"}}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("key", server.URL, server.Client(), llmclient.Hooks{})
+	_, err := provider.CreateSpeech(context.Background(), &core.AudioSpeechRequest{
+		Model: "speech-2.8-hd",
+		Input: "hello",
+		Voice: "voice-id",
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid voice") {
+		t.Fatalf("CreateSpeech() error = %v, want native status message", err)
+	}
+}
+
+func TestCreateSpeech_RejectsMalformedAudio(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"audio":"not-hex","status":2},"base_resp":{"status_code":0}}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("key", server.URL, server.Client(), llmclient.Hooks{})
+	_, err := provider.CreateSpeech(context.Background(), &core.AudioSpeechRequest{
+		Model: "speech-2.8-hd",
+		Input: "hello",
+		Voice: "voice-id",
+	})
+	if err == nil || !strings.Contains(err.Error(), "not valid hexadecimal") {
+		t.Fatalf("CreateSpeech() error = %v, want malformed audio error", err)
+	}
+}
+
+func TestCreateTranscription_IsUnsupported(t *testing.T) {
+	provider := NewWithHTTPClient("key", "", nil, llmclient.Hooks{})
+	_, err := provider.CreateTranscription(context.Background(), &core.AudioTranscriptionRequest{})
+	if err == nil || !strings.Contains(err.Error(), "does not support speech-to-text") {
+		t.Fatalf("CreateTranscription() error = %v", err)
+	}
+}


### PR DESCRIPTION
Reason: Add native MiniMax text-to-speech support through the existing audio route.

## Summary

- Implement `core.AudioProvider` for the synchronous `/t2a_v2` endpoint.
- Translate model, text, voice, speed, and supported audio formats, then decode hexadecimal audio responses.
- Surface native response errors and explicitly reject unsupported transcription requests.
- Add focused tests for request translation, defaults, validation, response errors, and decoded audio.

## Checks

- `go test ./internal/providers/minimax`
- `go vet ./internal/providers/minimax`
- `golangci-lint run ./internal/providers/minimax/...`
- `go test ./internal/...`
- `git diff --check origin/main...HEAD`
- Secret scan over `origin/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MiniMax text-to-speech support, including MP3 and other supported audio formats.
  * Added audio format and playback speed validation, with sensible defaults.
  * Added decoding and validation of generated audio responses.

* **Limitations**
  * Speech-to-text transcription is not supported by the MiniMax audio provider.

* **Tests**
  * Added coverage for successful speech generation, validation, authorization, provider errors, and malformed audio responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->