### PR TITLE
feat(route): expose affinity context after upstream attempts

### DIFF
--- a/ext/route.go
+++ b/ext/route.go
@@ -54,6 +54,11 @@ func (t RouteTarget) Qualified() string { return t.Provider + "/" + t.Model }
 // scores slower than a target that succeeds at once.
 type RouteOutcome struct {
 	RouteTarget
+	// Source is the virtual model originally addressed when this attempt was
+	// selected through one. SessionID is the detected client session. Together
+	// they let selectors update cache affinity only after a successful attempt.
+	Source    string
+	SessionID string
 	// Endpoint is the upstream API endpoint (e.g. "/chat/completions").
 	Endpoint string
 	// StatusCode is the final upstream HTTP status; 0 on a network error.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -146,10 +146,13 @@ func routeSelectorHooks(selector ext.RouteSelector) llmclient.Hooks {
 			})
 			return ctx
 		},
-		OnRequestEnd: func(_ context.Context, info llmclient.ResponseInfo) {
+		OnRequestEnd: func(ctx context.Context, info llmclient.ResponseInfo) {
 			observe("attempt_end", func() {
+				source, sessionID := routeAffinityContext(ctx)
 				selector.OnAttemptEnd(ext.RouteOutcome{
 					RouteTarget: ext.RouteTarget{Provider: info.Provider, Model: info.Model},
+					Source:      source,
+					SessionID:   sessionID,
 					Endpoint:    info.Endpoint,
 					StatusCode:  info.StatusCode,
 					Duration:    info.Duration,
@@ -159,6 +162,15 @@ func routeSelectorHooks(selector ext.RouteSelector) llmclient.Hooks {
 			})
 		},
 	}
+}
+
+func routeAffinityContext(ctx context.Context) (source, sessionID string) {
+	sessionID = core.SessionIDFromContext(ctx)
+	workflow := core.GetWorkflow(ctx)
+	if workflow == nil || workflow.Resolution == nil || !workflow.Resolution.AliasApplied {
+		return "", sessionID
+	}
+	return workflow.Resolution.RequestedQualifiedModel(), sessionID
 }
 
 // selectorLabel returns the selector's name for logs, tolerating a panicking

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -17,9 +17,39 @@ import (
 	"github.com/enterpilot/gomodel/internal/core"
 	"github.com/enterpilot/gomodel/internal/guardrails"
 	"github.com/enterpilot/gomodel/internal/live"
+	"github.com/enterpilot/gomodel/internal/llmclient"
 	"github.com/enterpilot/gomodel/internal/providers"
 	"github.com/enterpilot/gomodel/internal/server"
 )
+
+type routeObservationSelector struct {
+	outcome ext.RouteOutcome
+}
+
+func (*routeObservationSelector) Name() string                           { return "observer" }
+func (*routeObservationSelector) Select(ext.RouteRequest) (string, bool) { return "", false }
+func (*routeObservationSelector) OnAttemptStart(ext.RouteTarget)         {}
+func (s *routeObservationSelector) OnAttemptEnd(outcome ext.RouteOutcome) {
+	s.outcome = outcome
+}
+
+func TestRouteSelectorHooksExposeSuccessfulRouteAffinityContext(t *testing.T) {
+	selector := &routeObservationSelector{}
+	hooks := routeSelectorHooks(selector)
+	ctx := core.WithSessionID(context.Background(), "session-a")
+	ctx = core.WithWorkflow(ctx, &core.Workflow{Resolution: &core.RequestModelResolution{
+		Requested:        core.NewRequestedModelSelector("smart", ""),
+		ResolvedSelector: core.ModelSelector{Provider: "openai", Model: "gpt"},
+		AliasApplied:     true,
+	}})
+	ctx = hooks.OnRequestStart(ctx, llmclient.RequestInfo{Provider: "openai", Model: "gpt"})
+	hooks.OnRequestEnd(ctx, llmclient.ResponseInfo{Provider: "openai", Model: "gpt", StatusCode: http.StatusOK})
+
+	if selector.outcome.Source != "smart" || selector.outcome.SessionID != "session-a" {
+		t.Fatalf("route affinity context = %q/%q, want smart/session-a",
+			selector.outcome.Source, selector.outcome.SessionID)
+	}
+}
 
 type runtimeRefreshMockProvider struct {
 	models *core.ModelsResponse


### PR DESCRIPTION
Adds virtual-model source and session metadata to route outcomes so extensions can update prompt-cache affinity after the attempt that actually succeeds, including failover attempts.\n\nThis is the small core companion required by GoModel Pro PR #10.\n\nTests: `go test ./ext ./internal/app`; full pre-commit suite passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Route outcomes now include the originating model and client session details.
  * Requests using aliased workflows can preserve and report their requested model information.

* **Improvements**
  * Enhanced route tracking helps provide clearer visibility into model selection and session-affinity behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->