### PR TITLE
docs: add permission-feature items to commercial roadmap

### DIFF
--- a/docs/about/roadmap.mdx
+++ b/docs/about/roadmap.mdx
@@ -15,6 +15,11 @@ keywords: ["roadmap", "milestones", "upcoming features", "releases"]
 - [ ] Single sign-on (SSO)
 - [ ] Dashboard customization
 - [ ] LDAP integration
+- [ ] Secret manager integrations (Vault, AWS Secrets Manager/KMS, Azure Key Vault, GCP Secret Manager)
+- [ ] Audit-log export/streaming to object storage and data lakes
+- [ ] IP / CIDR allowlists
+- [ ] LTS channel with signed artifacts, SBOM, and CVE pre-notification
+- [ ] SAML 2.0 + SCIM directory sync
 
 ## Roadmap to 0.2.0
 


### PR DESCRIPTION
## Summary
- Adds secret manager integrations, audit-log export/streaming, IP/CIDR allowlists, an LTS/signed-artifacts channel, and SAML+SCIM directory sync to the Commercial features roadmap.
- These are gaps identified against competitor gating (LiteLLM, Bifrost, Portkey) that aren't currently listed.

## Test plan
- [x] `mint validate` (pre-commit hook)
- [x] Docs-only change, no code paths affected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added roadmap items for secret manager integrations.
  * Added plans for audit-log export and streaming.
  * Added IP/CIDR allowlists.
  * Added a long-term support channel with signed artifacts and security metadata.
  * Added SAML 2.0 and SCIM directory synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->