### PR TITLE
test(core): lock tool map canonicalization

### DIFF
--- a/internal/core/chat_json_test.go
+++ b/internal/core/chat_json_test.go
@@ -1,9 +1,33 @@
 package core
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 )
+
+func TestChatRequestJSON_CanonicalizesToolObjectKeyOrder(t *testing.T) {
+	bodies := [][]byte{
+		[]byte(`{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"lookup","parameters":{"type":"object","properties":{"z":{"type":"string"},"a":{"type":"string"}}}}}]}`),
+		[]byte(`{"tools":[{"function":{"parameters":{"properties":{"a":{"type":"string"},"z":{"type":"string"}},"type":"object"},"name":"lookup"},"type":"function"}],"messages":[{"content":"hi","role":"user"}],"model":"gpt-4o-mini"}`),
+	}
+
+	encoded := make([][]byte, len(bodies))
+	for i, body := range bodies {
+		var req ChatRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("json.Unmarshal(body %d) error = %v", i, err)
+		}
+		var err error
+		encoded[i], err = json.Marshal(req)
+		if err != nil {
+			t.Fatalf("json.Marshal(body %d) error = %v", i, err)
+		}
+	}
+	if !bytes.Equal(encoded[0], encoded[1]) {
+		t.Fatalf("equivalent tool maps produced different provider shapes:\nfirst:  %s\nsecond: %s", encoded[0], encoded[1])
+	}
+}
 
 func lookupUnknownField(t *testing.T, fields UnknownJSONFields, key string) json.RawMessage {
 	t.Helper()

--- a/internal/core/responses_json_test.go
+++ b/internal/core/responses_json_test.go
@@ -35,6 +35,29 @@ func TestResponsesRequestUnmarshalJSON_ArrayInput(t *testing.T) {
 	}
 }
 
+func TestResponsesRequestJSON_CanonicalizesToolObjectKeyOrder(t *testing.T) {
+	bodies := [][]byte{
+		[]byte(`{"model":"gpt-4o-mini","input":"hi","tools":[{"type":"function","name":"lookup","parameters":{"type":"object","properties":{"z":{"type":"string"},"a":{"type":"string"}}}}]}`),
+		[]byte(`{"tools":[{"parameters":{"properties":{"a":{"type":"string"},"z":{"type":"string"}},"type":"object"},"name":"lookup","type":"function"}],"input":"hi","model":"gpt-4o-mini"}`),
+	}
+
+	encoded := make([][]byte, len(bodies))
+	for i, body := range bodies {
+		var req ResponsesRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("json.Unmarshal(body %d) error = %v", i, err)
+		}
+		var err error
+		encoded[i], err = json.Marshal(req)
+		if err != nil {
+			t.Fatalf("json.Marshal(body %d) error = %v", i, err)
+		}
+	}
+	if !bytes.Equal(encoded[0], encoded[1]) {
+		t.Fatalf("equivalent tool maps produced different provider shapes:\nfirst:  %s\nsecond: %s", encoded[0], encoded[1])
+	}
+}
+
 func TestResponsesRequestUnmarshalJSON_ArrayInputFunctionCall(t *testing.T) {
 	var req ResponsesRequest
 	if err := json.Unmarshal([]byte(`{"model":"gpt-4o-mini","input":[


### PR DESCRIPTION
## Description

- verify Chat request tool maps serialize identically across equivalent nested object-key orders
- verify Responses request tool maps provide the same deterministic provider shape
- lock the Core behavior relied on by GoModel Pro so Pro does not need a redundant schema-key stabilization pass

Companion to ENTERPILOT/GoModel-pro#15.

## Verification

- `go test ./internal/core`

## AI Generated (optional)

Implemented and verified with Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage ensuring equivalent chat request tool definitions produce consistent JSON regardless of object-key order.
  * Added equivalent coverage for responses request tool definitions after JSON parsing and remarshal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->