### PR TITLE
docs(guides): add Kimi CLI and Cursor setup

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -150,6 +150,8 @@
                     "guides/openclaw",
                     "guides/claude-code",
                     "guides/codex",
+                    "guides/cursor",
+                    "guides/kimi-code-cli",
                     "guides/opencode-and-other-agents",
                     "guides/prometheus-metrics"
                 ]

--- a/docs/guides/cursor.mdx
+++ b/docs/guides/cursor.mdx
@@ -1,0 +1,277 @@
+---
+title: "GoModel & Cursor"
+description: "Route Cursor's OpenAI BYOK model traffic through GoModel, configure a public HTTPS base URL, and understand which Cursor features bypass the gateway."
+icon: "mouse-pointer-click"
+keywords: ["Cursor", "Cursor IDE", "BYOK", "OpenAI base URL", "AI gateway", "setup guide"]
+---
+
+Cursor can use GoModel through its **OpenAI API Key** and **Override OpenAI
+Base URL** settings. This is an available but limited integration path, not a
+gateway for every Cursor feature.
+
+Flow:
+
+`Cursor IDE -> Cursor backend -> GoModel -> upstream model provider`
+
+<Warning>
+  GoModel must be available at a public HTTPS URL. Cursor routes requests
+  through its backend for final prompt building, so
+  `http://localhost:8080/v1` is not a reliable Cursor base URL. Put a deployed
+  GoModel instance behind TLS, or use a secure tunnel for a temporary test.
+</Warning>
+
+## Cursor subscription and GoModel are separate
+
+A paid Cursor subscription can be used alongside GoModel. It provides the
+Cursor editor and features that require Cursor's infrastructure, and Cursor
+currently requires a paid plan for Agent and Edit with BYOK models.
+
+It does not provide upstream model credit to GoModel:
+
+| Route selected in Cursor | Model request goes to | Model inference billing |
+| --- | --- | --- |
+| Cursor-hosted model or Auto | Cursor's infrastructure | Cursor subscription usage |
+| OpenAI BYOK with GoModel base URL | GoModel, then its configured provider | The provider account configured in GoModel |
+| Composer, Grok, or Tab | Cursor's infrastructure | Cursor subscription usage |
+
+<Warning>
+  Cursor's included **Cursor Models** and **Other Models** usage cannot be used
+  as GoModel provider credit. Cursor does not expose subscription models as a
+  general OpenAI-compatible inference API. The Cursor SDK and Cloud Agents API
+  run Cursor agents; they are not raw model endpoints that GoModel can use as
+  an upstream provider.
+</Warning>
+
+When GoModel is selected, you therefore pay for the Cursor plan and for model
+usage on the provider account behind GoModel. Teams and Enterprise customers
+also pay Cursor's token rate on eligible third-party BYOK requests.
+
+## What goes through GoModel
+
+| Cursor feature | GoModel gateway status |
+| --- | --- |
+| OpenAI-family chat models with BYOK | Works through the OpenAI base URL override |
+| Custom OpenAI-compatible models | Available, but Cursor's compatibility varies by model and release |
+| Agent and tool calls | Can work; validate the selected model because Cursor's tool schema has changed between releases |
+| Image attachments | Supported on current Cursor releases; upgrade if an older release ignores the base URL |
+| Tab completion | No; Cursor uses its built-in models |
+| Auto, Cursor-native models, and Background Agents | Not fully replaced by BYOK |
+| Cursor CLI | Custom API keys and base URLs are not currently supported |
+
+The OpenAI base URL override is global for OpenAI-family model routing. Disable
+it before using a Cursor-hosted model that should not go through GoModel.
+
+## Before you start
+
+- Deploy GoModel at a public HTTPS URL, such as
+  `https://gomodel.example.com`.
+- Use a paid Cursor plan for Agent and Edit with the GoModel BYOK route.
+- Configure at least one upstream provider and model in GoModel.
+- Create a dedicated GoModel managed API key for Cursor at
+  **API Keys -> Create API Key** in the dashboard.
+- Install a current Cursor release. Custom-endpoint fixes, including image
+  routing, shipped during June 2026.
+
+<Note>
+  Cursor sends your API key to its backend with each request. Cursor states
+  that the key is encrypted in transit and not persisted, but its Zero Data
+  Retention policy does not apply to BYOK requests. Use a dedicated managed
+  GoModel key rather than `GOMODEL_MASTER_KEY`.
+</Note>
+
+## 1. Run GoModel
+
+This example starts GoModel with an OpenAI upstream. In production, terminate
+TLS at a reverse proxy or load balancer and follow the
+[production deployment guide](/guides/production).
+
+```bash
+docker run --rm -p 8080:8080 \
+  -e GOMODEL_MASTER_KEY="change-me" \
+  -e OPENAI_API_KEY="sk-..." \
+  enterpilot/gomodel
+```
+
+`GOMODEL_MASTER_KEY` administers GoModel. Do not enter it in Cursor after you
+have created a dedicated managed key.
+
+## 2. Verify the public endpoint
+
+Run these checks from a machine that is not on the private network hosting
+GoModel. Replace `sk_gom_...` with the dedicated key created for Cursor.
+
+```bash
+curl -s https://gomodel.example.com/v1/models \
+  -H "Authorization: Bearer sk_gom_..." \
+  | jq '.data[].id'
+```
+
+Then verify a small Chat Completions request:
+
+```bash
+curl -s https://gomodel.example.com/v1/chat/completions \
+  -H "Authorization: Bearer sk_gom_..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4.1-mini",
+    "messages": [
+      {"role": "user", "content": "Reply with exactly ok"}
+    ],
+    "max_tokens": 16
+  }'
+```
+
+The response should contain `ok`.
+
+## 3. Choose a Cursor model name
+
+The simplest setup uses an OpenAI-style model name that Cursor accepts, such as
+`gpt-4.1-mini`. Cursor forwards that model name unchanged to GoModel.
+
+GoModel normally lists provider-qualified selectors such as
+`openai/gpt-4.1-mini`. Create a [virtual model](/features/virtual-models) whose
+short source name matches Cursor and whose target is the exact
+provider-qualified selector:
+
+```yaml
+virtual_models:
+  - source: gpt-4.1-mini
+    target: openai/gpt-4.1-mini
+```
+
+You can also add a custom name in Cursor and use the same name as a GoModel
+virtual model. Avoid custom names beginning with `claude-` or `gemini-` because
+Cursor routes those through its provider-specific BYOK paths instead of the
+OpenAI base URL override.
+
+## 4. Configure Cursor
+
+<Steps>
+  <Step title="Open the Models settings">
+    In Cursor, open **Cursor Settings -> Models**.
+  </Step>
+  <Step title="Set the OpenAI API key">
+    Find **OpenAI API Key**, enable it, and enter the dedicated GoModel managed
+    key.
+  </Step>
+  <Step title="Override the OpenAI base URL">
+    Enable **Override OpenAI Base URL** and enter
+    `https://gomodel.example.com/v1`. Keep `/v1`; do not append
+    `/chat/completions` or `/responses`.
+  </Step>
+  <Step title="Save the settings">
+    Click **Save**. If your Cursor build shows **Verify**, use it as well.
+  </Step>
+  <Step title="Select the model">
+    Open a new chat and select `gpt-4.1-mini`. If you created a custom virtual
+    model, use **Add Model** in the Models settings and enter the exact source
+    name first.
+  </Step>
+</Steps>
+
+## 5. Validate Cursor traffic
+
+Start with a text-only prompt:
+
+```text
+Reply with exactly ok and no punctuation.
+```
+
+Then test Agent mode in a disposable project:
+
+```text
+Create a file named gomodel-cursor-test.txt containing exactly tool-ok
+```
+
+Confirm the edit before accepting it. Sign in to GoModel's dashboard separately
+with the master key or a dashboard-enabled managed key. Open **Audit Logs** and
+check that Cursor reached
+`POST /v1/chat/completions` and used the expected model.
+
+<Warning>
+  A successful text prompt does not prove that every Agent tool works with the
+  selected model. Cursor has previously mixed Responses-style custom tools into
+  Chat Completions requests for some newer GPT models. If Agent mode fails but
+  text chat succeeds, try a standard non-reasoning chat model first and inspect
+  the GoModel audit response before changing the gateway.
+</Warning>
+
+## Troubleshooting
+
+### Cursor cannot reach `localhost`
+
+Use a public HTTPS URL. Cursor's backend must be able to reach GoModel. A local
+address, private IP, or self-signed TLS certificate will not work reliably.
+
+### `401 Unauthorized`
+
+Make sure the value in **OpenAI API Key** is the dedicated GoModel key and that
+the key has not been revoked. Do not enter an upstream provider key in Cursor.
+
+### `Model not found`
+
+Cursor forwards the selected model name to GoModel. Copy the exact selector
+from `/v1/models`, or create a virtual model whose source matches the name
+shown in Cursor.
+
+### Cursor-hosted models stop working
+
+The OpenAI override can affect other OpenAI-family and some Cursor-hosted model
+routes. Disable the custom OpenAI key and base URL before switching back to
+those models, then start a new chat.
+
+### Agent or tool calls fail while text works
+
+Upgrade Cursor, retry with a standard OpenAI chat model, and inspect GoModel's
+audit log for the upstream response. Custom endpoint support has had
+release-specific payload bugs, especially around custom tools on newer GPT
+models.
+
+### Images do not reach GoModel
+
+Upgrade Cursor. Cursor fixed the custom-base-URL image routing issue in release
+`3.9.16` in June 2026. Older releases can validate the GoModel key against
+OpenAI directly and fail before the request reaches GoModel.
+
+## Security and privacy
+
+This setup does not create a direct private connection from the Cursor desktop
+app to GoModel. Cursor's backend remains in the request path for prompt
+construction and context retrieval. It also does not make Cursor Tab or other
+Cursor-hosted features use GoModel.
+
+For an internet-facing GoModel deployment:
+
+- use TLS with a publicly trusted certificate
+- give Cursor its own managed key rather than the master key
+- restrict the key's user path and model access where appropriate
+- protect the admin dashboard separately from the public API
+- rotate the Cursor key if it is pasted or logged anywhere unintended
+
+## References
+
+- Cursor: [Bring your own API key](https://cursor.com/help/models-and-usage/api-keys)
+- Cursor: [Models and pricing](https://cursor.com/docs/models-and-pricing)
+- Cursor: [Cursor token rate](https://cursor.com/help/models-and-usage/token-rate)
+- Cursor staff: [Public HTTPS is required for custom endpoints](https://forum.cursor.com/t/how-can-i-use-a-local-llm-on-my-desktop-ai-computer/152419/3)
+- Cursor staff: [How model routing works with the OpenAI override](https://forum.cursor.com/t/how-can-i-use-a-local-llm-on-my-desktop-ai-computer/152419/8)
+- Cursor staff: [Subscription models are not a general inference API](https://forum.cursor.com/t/can-we-use-llms-in-the-cursor-subscription-outside-cursor-by-and-api-a-key/159598/5)
+- Cursor staff: [Paid plan requirement for BYOK Agent and Edit](https://forum.cursor.com/t/external-models-setup/158906/4)
+- Cursor staff: [Custom endpoint image-routing fix](https://forum.cursor.com/t/bug-images-vision-completely-broken-with-openai-byok-custom-endpoint-override-unauthorized-error/158460/78)
+- Cursor: [Custom endpoint Agent payload discussion](https://forum.cursor.com/t/cursor-agent-sends-responses-api-format-to-chat-completions-endpoint/153019/20)
+
+## Investigated on August 8, 2026
+
+Current Cursor documentation and staff guidance confirm that the OpenAI base
+URL override can route model requests through an OpenAI-compatible gateway.
+GoModel already exposes the required `/v1/models`, `/v1/chat/completions`, and
+`/v1/responses` endpoints, so no GoModel application change is required for the
+documented path. Local GoModel validation with `openai/gpt-4.1-mini` confirmed
+text responses over Chat Completions and Responses, streaming Chat Completions,
+and a standard function tool call.
+
+The local test environment did not contain a runnable Cursor installation, so
+the Cursor UI flow was not claimed as an end-to-end local validation. The
+GoModel endpoints and model/tool behavior were tested separately; repeat
+[step 5](#5-validate-cursor-traffic) with the deployed URL and your Cursor
+release before relying on Agent mode in production.

--- a/docs/guides/kimi-code-cli.mdx
+++ b/docs/guides/kimi-code-cli.mdx
@@ -1,0 +1,194 @@
+---
+title: "GoModel & Kimi Code CLI"
+description: "Route Kimi Code CLI through GoModel without an api.json registry URL, configure a model profile, and verify prompts and tool calls."
+icon: "terminal"
+keywords: ["Kimi Code", "Kimi Code CLI", "Kimi CLI", "api.json", "coding agent", "setup guide"]
+---
+
+Kimi Code CLI can use GoModel as an OpenAI-compatible provider. You configure
+the GoModel base URL, master key, and at least one model in Kimi's
+`~/.kimi-code/config.toml` file.
+
+Flow:
+
+`Kimi Code CLI -> GoModel -> upstream model provider`
+
+## You do not need an `api.json` URL
+
+Kimi's **Custom registry (`api.json`)** option imports a models.dev-shaped
+provider catalog. It is optional and is not the normal OpenAI-compatible setup
+path.
+
+GoModel exposes its model catalog at `/v1/models`, but that response uses the
+OpenAI model-list format rather than Kimi's custom-registry format. Do not paste
+`http://localhost:8080/v1/models` into Kimi's `api.json` prompt. Exit that
+prompt and use the direct configuration below instead.
+
+<Note>
+  If you searched for `pi.json`, the file name shown by Kimi is `api.json`.
+  Neither file is required for this setup.
+</Note>
+
+## Before you start
+
+- Install [Kimi Code CLI](https://www.kimi.com/code/docs/en/kimi-code-cli/guides/getting-started).
+- Choose a GoModel master key, for example `change-me`.
+- Make sure GoModel has an upstream credential for the model you want to use.
+
+## 1. Run GoModel
+
+Start GoModel with a master key and at least one upstream provider. This
+example uses OpenAI:
+
+```bash
+docker run --rm -p 8080:8080 \
+  -e GOMODEL_MASTER_KEY="change-me" \
+  -e OPENAI_API_KEY="sk-..." \
+  enterpilot/gomodel
+```
+
+`GOMODEL_MASTER_KEY` is the credential Kimi sends to GoModel.
+`OPENAI_API_KEY` belongs to GoModel and is used only for the upstream request.
+
+## 2. Choose a model
+
+List the models visible through GoModel:
+
+```bash
+curl -s http://localhost:8080/v1/models \
+  -H "Authorization: Bearer change-me" \
+  | jq '.data[] | {
+      id,
+      context_window: .metadata.context_window,
+      max_output_tokens: .metadata.max_output_tokens
+    }'
+```
+
+This guide uses `openai/gpt-4.1-mini`, with a 1,000,000-token context window
+and a 32,768-token output limit. Prefer a provider-qualified ID from this
+response so GoModel routes the request to the intended provider.
+
+## 3. Configure Kimi Code CLI
+
+Open `~/.kimi-code/config.toml` and add:
+
+```toml
+default_model = "gomodel/gpt-4.1-mini"
+
+[providers.gomodel]
+type = "openai"
+base_url = "http://localhost:8080/v1"
+api_key = "change-me"
+
+[models."gomodel/gpt-4.1-mini"]
+provider = "gomodel"
+model = "openai/gpt-4.1-mini"
+max_context_size = 1000000
+max_output_size = 32768
+capabilities = ["tool_use", "image_in"]
+```
+
+The alias `gomodel/gpt-4.1-mini` is local to Kimi. The `model` value is the
+exact selector Kimi sends to GoModel.
+
+<Warning>
+  Kimi does not automatically read ordinary provider credentials such as
+  `OPENAI_API_KEY` from your shell for persistent providers. In this file,
+  `api_key` must contain the GoModel master key, not an upstream provider key.
+  Restrict access with `chmod 600 ~/.kimi-code/config.toml`.
+</Warning>
+
+Use the `context_window` and `max_output_tokens` values returned by GoModel
+when you configure a different model. Setting `max_output_size` matters: if it
+is omitted, Kimi may send a larger `max_tokens` value than the selected model
+accepts.
+
+If GoModel runs on another host, replace `localhost:8080`. Keep `/v1` in the
+base URL; do not append `/chat/completions`.
+
+## 4. Validate the setup
+
+Check the Kimi configuration:
+
+```bash
+kimi doctor
+```
+
+Then run a small prompt:
+
+```bash
+kimi -p 'Reply with exactly ok and no punctuation.'
+```
+
+The expected model response is:
+
+```text
+ok
+```
+
+You can also verify tool calling:
+
+```bash
+kimi -p 'Use the Shell tool to run pwd. After it succeeds, reply with exactly tool-ok and no punctuation.'
+```
+
+The final model response should be:
+
+```text
+tool-ok
+```
+
+## 5. Check the traffic in GoModel
+
+Open the GoModel dashboard audit logs:
+
+[http://localhost:8080/admin/dashboard/audit](http://localhost:8080/admin/dashboard/audit)
+
+Use the audit trail to confirm that Kimi is sending streaming requests to
+`POST /v1/chat/completions` and that GoModel is routing them to the selected
+provider.
+
+## Troubleshooting
+
+### Kimi asks for an `api.json` URL
+
+You selected Kimi's custom-registry import flow. Cancel it and edit
+`~/.kimi-code/config.toml` as shown above. GoModel does not need a registry
+endpoint for Kimi to work.
+
+### `401 Unauthorized`
+
+Make sure Kimi's `api_key` matches `GOMODEL_MASTER_KEY`. Do not put the
+upstream provider key in Kimi's config.
+
+### `max_tokens is too large`
+
+Set the model's `max_output_size` to the `max_output_tokens` value returned by
+GoModel's `/v1/models` response.
+
+### Model not found
+
+Copy the exact model ID from `/v1/models`. If more than one provider exposes
+the same model, use the provider-qualified ID, such as
+`openai/gpt-4.1-mini`.
+
+## References
+
+- Kimi Code CLI: [Getting started](https://www.kimi.com/code/docs/en/kimi-code-cli/guides/getting-started)
+- Kimi Code CLI: [Providers and models](https://www.kimi.com/code/docs/en/kimi-code-cli/configuration/providers)
+- Kimi Code CLI: [Configuration files](https://www.kimi.com/code/docs/en/kimi-code-cli/configuration/config-files)
+
+## Validated on August 8, 2026
+
+This guide was validated against:
+
+- a local GoModel instance on `http://localhost:8080`
+- Kimi Code CLI `0.34.0`
+- `openai/gpt-4.1-mini` through GoModel's OpenAI-compatible Chat Completions API
+
+Local validation confirmed:
+
+- `kimi doctor` accepted the documented TOML configuration
+- `kimi -p` returned `ok` through `Kimi Code CLI -> GoModel -> OpenAI`
+- Kimi invoked its Shell tool and returned `tool-ok` through the same route
+- no GoModel application change or `api.json` endpoint was required

--- a/docs/guides/kimi-code-cli.mdx
+++ b/docs/guides/kimi-code-cli.mdx
@@ -6,8 +6,8 @@ keywords: ["Kimi Code", "Kimi Code CLI", "Kimi CLI", "api.json", "coding agent",
 ---
 
 Kimi Code CLI can use GoModel as an OpenAI-compatible provider. You configure
-the GoModel base URL, master key, and at least one model in Kimi's
-`~/.kimi-code/config.toml` file.
+the GoModel base URL, a dedicated managed API key, and at least one model in
+Kimi's `~/.kimi/config.toml` file.
 
 Flow:
 
@@ -31,8 +31,9 @@ prompt and use the direct configuration below instead.
 
 ## Before you start
 
-- Install [Kimi Code CLI](https://www.kimi.com/code/docs/en/kimi-code-cli/guides/getting-started).
-- Choose a GoModel master key, for example `change-me`.
+- Install [Kimi Code CLI](https://moonshotai.github.io/kimi-cli/en/guides/getting-started.html).
+- Choose a GoModel master key for gateway administration, for example
+  `change-me`.
 - Make sure GoModel has an upstream credential for the model you want to use.
 
 ## 1. Run GoModel
@@ -47,16 +48,40 @@ docker run --rm -p 8080:8080 \
   enterpilot/gomodel
 ```
 
-`GOMODEL_MASTER_KEY` is the credential Kimi sends to GoModel.
-`OPENAI_API_KEY` belongs to GoModel and is used only for the upstream request.
+`GOMODEL_MASTER_KEY` is the gateway's bootstrap and administrator credential.
+Do not put it in Kimi's persistent configuration. `OPENAI_API_KEY` belongs to
+GoModel and is used only for the upstream request.
 
-## 2. Choose a model
+## 2. Create a dedicated Kimi API key
+
+Open the GoModel dashboard at
+[http://localhost:8080/admin/dashboard](http://localhost:8080/admin/dashboard)
+and sign in with `GOMODEL_MASTER_KEY`. Go to
+`API Keys -> Create API Key`, then:
+
+1. Name the key `kimi-code`.
+2. Set **User Path** to `/agents/kimi`.
+3. Leave **Dashboard access** disabled.
+4. Create the key and copy the `sk_gom_...` value. It is shown only once.
+
+The bound user path gives Kimi its own usage and audit scope. Managed keys bind
+directly to a user path, while model restrictions are configured separately as
+gateway-wide [model access policies](/features/user-path#model-access). If you
+use those policies, allow only the selectors Kimi needs for `/agents/kimi`.
+
+<Warning>
+  Use this managed key in Kimi, not `GOMODEL_MASTER_KEY`. A managed key without
+  dashboard access can call model endpoints but cannot read audit logs, create
+  keys, or change gateway settings. The master key bypasses that restriction.
+</Warning>
+
+## 3. Choose a model
 
 List the models visible through GoModel:
 
 ```bash
 curl -s http://localhost:8080/v1/models \
-  -H "Authorization: Bearer change-me" \
+  -H "Authorization: Bearer sk_gom_..." \
   | jq '.data[] | {
       id,
       context_window: .metadata.context_window,
@@ -64,60 +89,61 @@ curl -s http://localhost:8080/v1/models \
     }'
 ```
 
-This guide uses `openai/gpt-4.1-mini`, with a 1,000,000-token context window
-and a 32,768-token output limit. Prefer a provider-qualified ID from this
+This guide uses `openai/gpt-5-mini`, with a 400,000-token context window and a
+128,000-token output limit. Prefer a provider-qualified ID from this
 response so GoModel routes the request to the intended provider.
 
-## 3. Configure Kimi Code CLI
+## 4. Configure Kimi Code CLI
 
-Open `~/.kimi-code/config.toml` and add:
+Open `~/.kimi/config.toml` and add:
 
 ```toml
-default_model = "gomodel/gpt-4.1-mini"
+default_model = "gomodel/gpt-5-mini"
+default_thinking = true
 
 [providers.gomodel]
-type = "openai"
+type = "openai_legacy"
 base_url = "http://localhost:8080/v1"
-api_key = "change-me"
+api_key = "sk_gom_..."
 
-[models."gomodel/gpt-4.1-mini"]
+[models."gomodel/gpt-5-mini"]
 provider = "gomodel"
-model = "openai/gpt-4.1-mini"
-max_context_size = 1000000
-max_output_size = 32768
-capabilities = ["tool_use", "image_in"]
+model = "openai/gpt-5-mini"
+max_context_size = 400000
+capabilities = ["thinking", "image_in"]
 ```
 
-The alias `gomodel/gpt-4.1-mini` is local to Kimi. The `model` value is the
+The alias `gomodel/gpt-5-mini` is local to Kimi. The `model` value is the
 exact selector Kimi sends to GoModel.
 
 <Warning>
   Kimi does not automatically read ordinary provider credentials such as
   `OPENAI_API_KEY` from your shell for persistent providers. In this file,
-  `api_key` must contain the GoModel master key, not an upstream provider key.
-  Restrict access with `chmod 600 ~/.kimi-code/config.toml`.
+  `api_key` must contain the dedicated GoModel managed key, not the master key
+  or an upstream provider key. Restrict access with
+  `chmod 600 ~/.kimi/config.toml`.
 </Warning>
 
-Use the `context_window` and `max_output_tokens` values returned by GoModel
-when you configure a different model. Setting `max_output_size` matters: if it
-is omitted, Kimi may send a larger `max_tokens` value than the selected model
-accepts.
+Use the `context_window` value returned by GoModel as `max_context_size` when
+you configure a different model. The `thinking` capability and
+`default_thinking = true` match the reasoning model used here. Adjust Kimi's
+capabilities to match another model.
 
 If GoModel runs on another host, replace `localhost:8080`. Keep `/v1` in the
 base URL; do not append `/chat/completions`.
 
-## 4. Validate the setup
+## 5. Validate the setup
 
-Check the Kimi configuration:
+Check the installed Kimi version:
 
 ```bash
-kimi doctor
+kimi --version
 ```
 
 Then run a small prompt:
 
 ```bash
-kimi -p 'Reply with exactly ok and no punctuation.'
+kimi --quiet -p 'Reply with exactly ok and no punctuation.'
 ```
 
 The expected model response is:
@@ -129,7 +155,7 @@ ok
 You can also verify tool calling:
 
 ```bash
-kimi -p 'Use the Shell tool to run pwd. After it succeeds, reply with exactly tool-ok and no punctuation.'
+kimi --quiet -p 'Use the Shell tool to run pwd. After it succeeds, reply with exactly tool-ok and no punctuation.'
 ```
 
 The final model response should be:
@@ -138,7 +164,7 @@ The final model response should be:
 tool-ok
 ```
 
-## 5. Check the traffic in GoModel
+## 6. Check the traffic in GoModel
 
 Open the GoModel dashboard audit logs:
 
@@ -146,49 +172,54 @@ Open the GoModel dashboard audit logs:
 
 Use the audit trail to confirm that Kimi is sending streaming requests to
 `POST /v1/chat/completions` and that GoModel is routing them to the selected
-provider.
+provider. Sign in with the master key or a separate managed key that has
+dashboard access; the Kimi key intentionally cannot open this page.
 
 ## Troubleshooting
 
 ### Kimi asks for an `api.json` URL
 
 You selected Kimi's custom-registry import flow. Cancel it and edit
-`~/.kimi-code/config.toml` as shown above. GoModel does not need a registry
+`~/.kimi/config.toml` as shown above. GoModel does not need a registry
 endpoint for Kimi to work.
 
 ### `401 Unauthorized`
 
-Make sure Kimi's `api_key` matches `GOMODEL_MASTER_KEY`. Do not put the
-upstream provider key in Kimi's config.
+Make sure Kimi's `api_key` matches the active `sk_gom_...` managed key created
+for Kimi. Do not put the master key or upstream provider key in Kimi's config.
 
-### `max_tokens is too large`
+### `reasoning_effort` is rejected
 
-Set the model's `max_output_size` to the `max_output_tokens` value returned by
-GoModel's `/v1/models` response.
+Use a model that accepts reasoning effort, declare the `thinking` capability,
+and enable `default_thinking`, as in the tested example. Kimi CLI 1.49.0 sends
+an explicit `reasoning_effort` value through `openai_legacy`; non-reasoning
+models can reject it.
 
 ### Model not found
 
 Copy the exact model ID from `/v1/models`. If more than one provider exposes
 the same model, use the provider-qualified ID, such as
-`openai/gpt-4.1-mini`.
+`openai/gpt-5-mini`.
 
 ## References
 
-- Kimi Code CLI: [Getting started](https://www.kimi.com/code/docs/en/kimi-code-cli/guides/getting-started)
-- Kimi Code CLI: [Providers and models](https://www.kimi.com/code/docs/en/kimi-code-cli/configuration/providers)
-- Kimi Code CLI: [Configuration files](https://www.kimi.com/code/docs/en/kimi-code-cli/configuration/config-files)
+- Kimi Code CLI: [Getting started](https://moonshotai.github.io/kimi-cli/en/guides/getting-started.html)
+- Kimi Code CLI: [Providers and models](https://moonshotai.github.io/kimi-cli/en/configuration/providers.html)
+- Kimi Code CLI: [Configuration files](https://moonshotai.github.io/kimi-cli/en/configuration/config-files.html)
 
 ## Validated on August 8, 2026
 
 This guide was validated against:
 
 - a local GoModel instance on `http://localhost:8080`
-- Kimi Code CLI `0.34.0`
-- `openai/gpt-4.1-mini` through GoModel's OpenAI-compatible Chat Completions API
+- Kimi Code CLI `1.49.0`
+- `openai/gpt-5-mini` through GoModel's OpenAI-compatible Chat Completions API
 
 Local validation confirmed:
 
-- `kimi doctor` accepted the documented TOML configuration
-- `kimi -p` returned `ok` through `Kimi Code CLI -> GoModel -> OpenAI`
+- Kimi accepted the documented TOML configuration with a dedicated managed key
+  that had `/agents/kimi` as its user path and no dashboard access
+- `kimi --quiet -p` returned `ok` through `Kimi Code CLI -> GoModel -> OpenAI`
 - Kimi invoked its Shell tool and returned `tool-ok` through the same route
+- the Kimi key could list and call models but received `403` from the admin API
 - no GoModel application change or `api.json` endpoint was required


### PR DESCRIPTION
## Summary

- add a validated Kimi Code CLI guide using direct OpenAI-compatible provider configuration
- explain that neither `pi.json` nor an `api.json` registry URL is required for Kimi
- add a Cursor BYOK gateway guide with public HTTPS, model routing, subscription billing, feature limitations, security, and troubleshooting guidance
- add both guides to the Mintlify Guides navigation

## Validation

- `mint validate`
- `mint broken-links --check-anchors`
- Kimi Code CLI `1.49.0`: text prompt and Shell tool call through GoModel using a dedicated managed key without dashboard access
- GoModel: Chat Completions, Responses, streaming, and standard function tool call with `openai/gpt-4.1-mini`

The Cursor UI flow is explicitly marked as investigated rather than end-to-end validated because the test environment did not contain a runnable Cursor installation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive Cursor integration guide, including setup, configuration, supported features, security, privacy, and troubleshooting.
  * Added a Kimi Code CLI integration guide covering Docker startup, provider configuration, validation, audit logs, and troubleshooting.
  * Added both guides to the documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->