### PR TITLE
docs(mintlify): add SDK examples alongside curl

### DIFF
--- a/docs/advanced/admin-endpoints.mdx
+++ b/docs/advanced/admin-endpoints.mdx
@@ -36,19 +36,89 @@ The admin REST API endpoints (`/admin/*`) accept two credentials as a Bearer tok
 - **`GOMODEL_MASTER_KEY`** — always has admin access.
 - **A managed API key with dashboard access** — managed keys are created *without* dashboard access by default, so a key handed out for model traffic cannot read the audit log, issue new keys, or change gateway settings. Requests made with a managed key that lacks access return `403` with error code `dashboard_access_denied`.
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
   http://localhost:8080/admin/usage/summary
 ```
 
+```python Python
+import os
+
+import httpx
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080",
+    api_key=os.environ["GOMODEL_MASTER_KEY"],
+)
+summary = client.get("/admin/usage/summary", cast_to=httpx.Response)
+
+print(summary.json())
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080",
+  apiKey: process.env.GOMODEL_MASTER_KEY,
+});
+
+const summary = await client.get("/admin/usage/summary");
+console.log(summary);
+```
+
+</CodeGroup>
+
 Grant or revoke dashboard access per key on the dashboard's API Keys page, at creation time (`"dashboard_access": true` on `POST /admin/auth-keys`), or later:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -X PUT http://localhost:8080/admin/auth-keys/<key-id>/dashboard-access \
   -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
   -H "Content-Type: application/json" \
   -d '{"dashboard_access": true}'
 ```
+
+```python Python
+import os
+
+import httpx
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080",
+    api_key=os.environ["GOMODEL_MASTER_KEY"],
+)
+auth_key = client.put(
+    "/admin/auth-keys/<key-id>/dashboard-access",
+    cast_to=httpx.Response,
+    body={"dashboard_access": True},
+)
+
+print(auth_key.json())
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080",
+  apiKey: process.env.GOMODEL_MASTER_KEY,
+});
+
+const authKey = await client.put(
+  "/admin/auth-keys/<key-id>/dashboard-access",
+  { body: { dashboard_access: true } },
+);
+
+console.log(authKey);
+```
+
+</CodeGroup>
 
 Dashboard access only gates `/admin/*`. Model endpoints and the self-service [`GET /v1/usage`](/advanced/usage-api) endpoint stay available to every managed key.
 

--- a/docs/advanced/anthropic-messages-api.mdx
+++ b/docs/advanced/anthropic-messages-api.mdx
@@ -84,7 +84,9 @@ client.messages.create(
 
 ## Example
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl https://your-gateway/v1/messages \
   -H "Authorization: Bearer $GOMODEL_KEY" \
   -H "Content-Type: application/json" \
@@ -95,6 +97,46 @@ curl https://your-gateway/v1/messages \
     "messages": [{"role": "user", "content": "Hello"}]
   }'
 ```
+
+```python Python
+import os
+
+import anthropic
+
+client = anthropic.Anthropic(
+    base_url="https://your-gateway",
+    api_key=os.environ["GOMODEL_KEY"],
+)
+
+message = client.messages.create(
+    model="claude-sonnet-4-6",
+    max_tokens=256,
+    system="Be concise.",
+    messages=[{"role": "user", "content": "Hello"}],
+)
+
+print(message.content[0].text)
+```
+
+```javascript JavaScript
+import Anthropic from "@anthropic-ai/sdk";
+
+const client = new Anthropic({
+  baseURL: "https://your-gateway",
+  apiKey: process.env.GOMODEL_KEY,
+});
+
+const message = await client.messages.create({
+  model: "claude-sonnet-4-6",
+  max_tokens: 256,
+  system: "Be concise.",
+  messages: [{ role: "user", content: "Hello" }],
+});
+
+console.log(message.content[0].text);
+```
+
+</CodeGroup>
 
 The response uses the Anthropic Messages shape (`type: "message"`, `content` blocks,
 `stop_reason`, `usage`). Errors use the Anthropic error envelope

--- a/docs/advanced/audio-api.mdx
+++ b/docs/advanced/audio-api.mdx
@@ -30,7 +30,9 @@ doesn't support audio returns a clear error rather than mis-routing.
 
 ## Text-to-speech
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl https://your-gateway/v1/audio/speech \
   -H "Authorization: Bearer $GOMODEL_KEY" \
   -H "Content-Type: application/json" \
@@ -43,6 +45,46 @@ curl https://your-gateway/v1/audio/speech \
   --output speech.wav
 ```
 
+```python Python
+import os
+
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://your-gateway/v1",
+    api_key=os.environ["GOMODEL_KEY"],
+)
+
+speech = client.audio.speech.create(
+    model="gpt-4o-mini-tts",
+    input="Hello from GoModel.",
+    voice="alloy",
+    response_format="wav",
+)
+speech.write_to_file("speech.wav")
+```
+
+```javascript JavaScript
+import { writeFile } from "node:fs/promises";
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "https://your-gateway/v1",
+  apiKey: process.env.GOMODEL_KEY,
+});
+
+const speech = await client.audio.speech.create({
+  model: "gpt-4o-mini-tts",
+  input: "Hello from GoModel.",
+  voice: "alloy",
+  response_format: "wav",
+});
+
+await writeFile("speech.wav", Buffer.from(await speech.arrayBuffer()));
+```
+
+</CodeGroup>
+
 `model`, `input`, and `voice` are required. Optional fields — `instructions`,
 `response_format` (`mp3` default, plus `opus`, `aac`, `flac`, `wav`, `pcm`), and
 `speed` — are forwarded to the provider. The response `Content-Type` is derived
@@ -50,13 +92,55 @@ from `response_format` (for example `wav` → `audio/wav`).
 
 ## Speech-to-text
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl https://your-gateway/v1/audio/transcriptions \
   -H "Authorization: Bearer $GOMODEL_KEY" \
   -F "file=@speech.wav" \
   -F "model=gpt-4o-transcribe" \
   -F "response_format=json"
 ```
+
+```python Python
+import os
+
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://your-gateway/v1",
+    api_key=os.environ["GOMODEL_KEY"],
+)
+
+with open("speech.wav", "rb") as audio_file:
+    transcription = client.audio.transcriptions.create(
+        file=audio_file,
+        model="gpt-4o-transcribe",
+        response_format="json",
+    )
+
+print(transcription.text)
+```
+
+```javascript JavaScript
+import { createReadStream } from "node:fs";
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "https://your-gateway/v1",
+  apiKey: process.env.GOMODEL_KEY,
+});
+
+const transcription = await client.audio.transcriptions.create({
+  file: createReadStream("speech.wav"),
+  model: "gpt-4o-transcribe",
+  response_format: "json",
+});
+
+console.log(transcription.text);
+```
+
+</CodeGroup>
 
 `file` and `model` are required. Optional form fields — `language`, `prompt`,
 `response_format`, `temperature`, and `timestamp_granularities[]` — are forwarded.

--- a/docs/advanced/conversations-api.mdx
+++ b/docs/advanced/conversations-api.mdx
@@ -98,7 +98,9 @@ idempotency mechanism when duplicate calls have material cost or side effects.
 
 Create a conversation:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl http://localhost:8080/v1/conversations \
   -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
   -H "Content-Type: application/json" \
@@ -107,16 +109,79 @@ curl http://localhost:8080/v1/conversations \
   }'
 ```
 
+```python Python
+import os
+
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080/v1",
+    api_key=os.environ["GOMODEL_MASTER_KEY"],
+)
+
+conversation = client.conversations.create(metadata={"topic": "support"})
+print(conversation.id)
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080/v1",
+  apiKey: process.env.GOMODEL_MASTER_KEY,
+});
+
+const conversation = await client.conversations.create({
+  metadata: { topic: "support" },
+});
+
+console.log(conversation.id);
+```
+
+</CodeGroup>
+
 Retrieve it:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl http://localhost:8080/v1/conversations/conv_abc123 \
   -H "Authorization: Bearer $GOMODEL_MASTER_KEY"
 ```
 
+```python Python
+import os
+
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080/v1",
+    api_key=os.environ["GOMODEL_MASTER_KEY"],
+)
+
+conversation = client.conversations.retrieve("conv_abc123")
+print(conversation)
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080/v1",
+  apiKey: process.env.GOMODEL_MASTER_KEY,
+});
+
+const conversation = await client.conversations.retrieve("conv_abc123");
+console.log(conversation);
+```
+
+</CodeGroup>
+
 Update its metadata (existing keys not supplied here are retained):
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl http://localhost:8080/v1/conversations/conv_abc123 \
   -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
   -H "Content-Type: application/json" \
@@ -125,9 +190,45 @@ curl http://localhost:8080/v1/conversations/conv_abc123 \
   }'
 ```
 
+```python Python
+import os
+
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080/v1",
+    api_key=os.environ["GOMODEL_MASTER_KEY"],
+)
+
+conversation = client.conversations.update(
+    "conv_abc123",
+    metadata={"topic": "billing"},
+)
+print(conversation)
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080/v1",
+  apiKey: process.env.GOMODEL_MASTER_KEY,
+});
+
+const conversation = await client.conversations.update("conv_abc123", {
+  metadata: { topic: "billing" },
+});
+
+console.log(conversation);
+```
+
+</CodeGroup>
+
 Add advanced Responses items:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl 'http://localhost:8080/v1/conversations/conv_abc123/items?include=reasoning.encrypted_content' \
   -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
   -H "Content-Type: application/json" \
@@ -148,16 +249,147 @@ curl 'http://localhost:8080/v1/conversations/conv_abc123/items?include=reasoning
   }'
 ```
 
+```python Python
+import os
+
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080/v1",
+    api_key=os.environ["GOMODEL_MASTER_KEY"],
+)
+
+items = client.conversations.items.create(
+    "conv_abc123",
+    include=["reasoning.encrypted_content"],
+    items=[
+        {
+            "type": "function_call",
+            "call_id": "call_lookup_1",
+            "name": "lookup_order",
+            "arguments": '{"order_id":"A-42"}',
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_lookup_1",
+            "output": '{"status":"shipped"}',
+        },
+    ],
+)
+
+print(items)
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080/v1",
+  apiKey: process.env.GOMODEL_MASTER_KEY,
+});
+
+const items = await client.conversations.items.create("conv_abc123", {
+  include: ["reasoning.encrypted_content"],
+  items: [
+    {
+      type: "function_call",
+      call_id: "call_lookup_1",
+      name: "lookup_order",
+      arguments: '{"order_id":"A-42"}',
+    },
+    {
+      type: "function_call_output",
+      call_id: "call_lookup_1",
+      output: '{"status":"shipped"}',
+    },
+  ],
+});
+
+console.log(items);
+```
+
+</CodeGroup>
+
 List the next page in chronological order:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl 'http://localhost:8080/v1/conversations/conv_abc123/items?order=asc&limit=10&after=msg_abc123' \
   -H "Authorization: Bearer $GOMODEL_MASTER_KEY"
 ```
 
+```python Python
+import os
+
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080/v1",
+    api_key=os.environ["GOMODEL_MASTER_KEY"],
+)
+
+for item in client.conversations.items.list(
+    "conv_abc123",
+    order="asc",
+    limit=10,
+    after="msg_abc123",
+):
+    print(item)
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080/v1",
+  apiKey: process.env.GOMODEL_MASTER_KEY,
+});
+
+for await (const item of client.conversations.items.list("conv_abc123", {
+  order: "asc",
+  limit: 10,
+  after: "msg_abc123",
+})) {
+  console.log(item);
+}
+```
+
+</CodeGroup>
+
 Delete it:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -X DELETE http://localhost:8080/v1/conversations/conv_abc123 \
   -H "Authorization: Bearer $GOMODEL_MASTER_KEY"
 ```
+
+```python Python
+import os
+
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080/v1",
+    api_key=os.environ["GOMODEL_MASTER_KEY"],
+)
+
+deleted = client.conversations.delete("conv_abc123")
+print(deleted.deleted)
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080/v1",
+  apiKey: process.env.GOMODEL_MASTER_KEY,
+});
+
+const deleted = await client.conversations.delete("conv_abc123");
+console.log(deleted.deleted);
+```
+
+</CodeGroup>

--- a/docs/advanced/responses-api.mdx
+++ b/docs/advanced/responses-api.mdx
@@ -106,7 +106,9 @@ code identifies the unsupported operation, returned with HTTP `501 Not Implement
 
 Create a response:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl http://localhost:8080/v1/responses \
   -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
   -H "Content-Type: application/json" \
@@ -116,16 +118,113 @@ curl http://localhost:8080/v1/responses \
   }'
 ```
 
+```python Python
+import os
+
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080/v1",
+    api_key=os.environ["GOMODEL_MASTER_KEY"],
+)
+
+response = client.responses.create(
+    model="gpt-5-mini",
+    input="Write one short sentence about reliable gateways.",
+)
+
+print(response.output_text)
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080/v1",
+  apiKey: process.env.GOMODEL_MASTER_KEY,
+});
+
+const response = await client.responses.create({
+  model: "gpt-5-mini",
+  input: "Write one short sentence about reliable gateways.",
+});
+
+console.log(response.output_text);
+```
+
+</CodeGroup>
+
 Retrieve it later:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl http://localhost:8080/v1/responses/resp_abc123 \
   -H "Authorization: Bearer $GOMODEL_MASTER_KEY"
 ```
 
+```python Python
+import os
+
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080/v1",
+    api_key=os.environ["GOMODEL_MASTER_KEY"],
+)
+
+response = client.responses.retrieve("resp_abc123")
+print(response.output_text)
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080/v1",
+  apiKey: process.env.GOMODEL_MASTER_KEY,
+});
+
+const response = await client.responses.retrieve("resp_abc123");
+console.log(response.output_text);
+```
+
+</CodeGroup>
+
 List its stored input items:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl http://localhost:8080/v1/responses/resp_abc123/input_items \
   -H "Authorization: Bearer $GOMODEL_MASTER_KEY"
 ```
+
+```python Python
+import os
+
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080/v1",
+    api_key=os.environ["GOMODEL_MASTER_KEY"],
+)
+
+for item in client.responses.input_items.list("resp_abc123"):
+    print(item)
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080/v1",
+  apiKey: process.env.GOMODEL_MASTER_KEY,
+});
+
+for await (const item of client.responses.inputItems.list("resp_abc123")) {
+  console.log(item);
+}
+```
+
+</CodeGroup>

--- a/docs/advanced/usage-api.mdx
+++ b/docs/advanced/usage-api.mdx
@@ -21,10 +21,37 @@ uses for inference. Polling does not consume rate limit quota.
 
 ## Quick example
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl http://localhost:8080/v1/usage \
   -H "Authorization: Bearer sk_gom_..."
 ```
+
+```python Python
+import httpx
+
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8080", api_key="sk_gom_...")
+usage = client.get("/v1/usage", cast_to=httpx.Response)
+
+print(usage.json())
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080",
+  apiKey: "sk_gom_...",
+});
+
+const usage = await client.get("/v1/usage");
+console.log(usage);
+```
+
+</CodeGroup>
 
 ```json
 {
@@ -88,11 +115,44 @@ curl http://localhost:8080/v1/usage \
 - **Master key (or unsafe mode)** — pass `X-GoModel-User-Path` to pick a path,
   or omit it to see `/` (everything):
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl http://localhost:8080/v1/usage \
   -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
   -H "X-GoModel-User-Path: /team/alpha"
 ```
+
+```python Python
+import os
+
+import httpx
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080",
+    api_key=os.environ["GOMODEL_MASTER_KEY"],
+    default_headers={"X-GoModel-User-Path": "/team/alpha"},
+)
+usage = client.get("/v1/usage", cast_to=httpx.Response)
+
+print(usage.json())
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080",
+  apiKey: process.env.GOMODEL_MASTER_KEY,
+  defaultHeaders: { "X-GoModel-User-Path": "/team/alpha" },
+});
+
+const usage = await client.get("/v1/usage");
+console.log(usage);
+```
+
+</CodeGroup>
 
 ## Response fields
 
@@ -140,13 +200,51 @@ The `usage` block defaults to the last 30 days (UTC day boundaries). Narrow it
 with query parameters — `days`, or explicit `start_date`/`end_date`
 (YYYY-MM-DD, 365-day maximum):
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl "http://localhost:8080/v1/usage?days=7" \
   -H "Authorization: Bearer sk_gom_..."
 
 curl "http://localhost:8080/v1/usage?start_date=2026-07-01&end_date=2026-07-07" \
   -H "Authorization: Bearer sk_gom_..."
 ```
+
+```python Python
+import httpx
+
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8080", api_key="sk_gom_...")
+
+last_seven_days = client.get("/v1/usage?days=7", cast_to=httpx.Response)
+date_range = client.get(
+    "/v1/usage?start_date=2026-07-01&end_date=2026-07-07",
+    cast_to=httpx.Response,
+)
+
+print(last_seven_days.json())
+print(date_range.json())
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080",
+  apiKey: "sk_gom_...",
+});
+
+const lastSevenDays = await client.get("/v1/usage?days=7");
+const dateRange = await client.get(
+  "/v1/usage?start_date=2026-07-01&end_date=2026-07-07",
+);
+
+console.log(lastSevenDays);
+console.log(dateRange);
+```
+
+</CodeGroup>
 
 Budgets and rate limits always report their own live periods; the window only
 affects `usage`.

--- a/docs/advanced/workflows.mdx
+++ b/docs/advanced/workflows.mdx
@@ -96,7 +96,9 @@ Even though both have provider type `openai`, they are different workflow scopes
 
 Create a workflow scoped to one configured provider name, one model, and one user-path subtree:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -X POST http://localhost:8080/admin/workflows \
   -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
   -H "Content-Type: application/json" \
@@ -120,6 +122,79 @@ curl -X POST http://localhost:8080/admin/workflows \
     }
   }'
 ```
+
+```python Python
+import os
+
+import httpx
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080",
+    api_key=os.environ["GOMODEL_MASTER_KEY"],
+)
+
+workflow = client.post(
+    "/admin/workflows",
+    cast_to=httpx.Response,
+    body={
+        "scope_provider_name": "openai_primary",
+        "scope_model": "gpt-5",
+        "scope_user_path": "/team/alpha",
+        "name": "team-alpha-openai-primary",
+        "description": "Disable cache for this tenant on the primary OpenAI provider",
+        "workflow_payload": {
+            "schema_version": 1,
+            "features": {
+                "cache": False,
+                "budget": True,
+                "audit": True,
+                "usage": True,
+                "guardrails": False,
+                "failover": True,
+            },
+            "guardrails": [],
+        },
+    },
+)
+
+print(workflow.json())
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080",
+  apiKey: process.env.GOMODEL_MASTER_KEY,
+});
+
+const workflow = await client.post("/admin/workflows", {
+  body: {
+    scope_provider_name: "openai_primary",
+    scope_model: "gpt-5",
+    scope_user_path: "/team/alpha",
+    name: "team-alpha-openai-primary",
+    description: "Disable cache for this tenant on the primary OpenAI provider",
+    workflow_payload: {
+      schema_version: 1,
+      features: {
+        cache: false,
+        budget: true,
+        audit: true,
+        usage: true,
+        guardrails: false,
+        failover: true,
+      },
+      guardrails: [],
+    },
+  },
+});
+
+console.log(workflow);
+```
+
+</CodeGroup>
 
 ## Notes
 

--- a/docs/features/budgets.mdx
+++ b/docs/features/budgets.mdx
@@ -225,16 +225,49 @@ the row-level Reset action to start a new period for one budget, or
 
 Budget management is also available through the admin API:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
   http://localhost:8080/admin/budgets
 ```
+
+```python Python
+import os
+
+import httpx
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080",
+    api_key=os.environ["GOMODEL_MASTER_KEY"],
+)
+budgets = client.get("/admin/budgets", cast_to=httpx.Response)
+
+print(budgets.json())
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080",
+  apiKey: process.env.GOMODEL_MASTER_KEY,
+});
+
+const budgets = await client.get("/admin/budgets");
+console.log(budgets);
+```
+
+</CodeGroup>
 
 Create or update a budget. A budget is identified by its `scope`, `subject`,
 and period; `user_path` is accepted as a shorthand spelling of the subject for
 user-path budgets:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -X PUT http://localhost:8080/admin/budgets \
   -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
   -H "Content-Type: application/json" \
@@ -246,9 +279,57 @@ curl -X PUT http://localhost:8080/admin/budgets \
   }'
 ```
 
+```python Python
+import os
+
+import httpx
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080",
+    api_key=os.environ["GOMODEL_MASTER_KEY"],
+)
+budget = client.put(
+    "/admin/budgets",
+    cast_to=httpx.Response,
+    body={
+        "scope": "user_path",
+        "subject": "/team/alpha",
+        "budget_key": {"period": "daily"},
+        "amount": 10.00,
+    },
+)
+
+print(budget.json())
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080",
+  apiKey: process.env.GOMODEL_MASTER_KEY,
+});
+
+const budget = await client.put("/admin/budgets", {
+  body: {
+    scope: "user_path",
+    subject: "/team/alpha",
+    budget_key: { period: "daily" },
+    amount: 10.0,
+  },
+});
+
+console.log(budget);
+```
+
+</CodeGroup>
+
 The same call for a label budget:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -X PUT http://localhost:8080/admin/budgets \
   -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
   -H "Content-Type: application/json" \
@@ -260,9 +341,57 @@ curl -X PUT http://localhost:8080/admin/budgets \
   }'
 ```
 
+```python Python
+import os
+
+import httpx
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080",
+    api_key=os.environ["GOMODEL_MASTER_KEY"],
+)
+budget = client.put(
+    "/admin/budgets",
+    cast_to=httpx.Response,
+    body={
+        "scope": "label",
+        "subject": "Mobile-App-iOS",
+        "budget_key": {"period": "monthly"},
+        "amount": 500.00,
+    },
+)
+
+print(budget.json())
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080",
+  apiKey: process.env.GOMODEL_MASTER_KEY,
+});
+
+const budget = await client.put("/admin/budgets", {
+  body: {
+    scope: "label",
+    subject: "Mobile-App-iOS",
+    budget_key: { period: "monthly" },
+    amount: 500.0,
+  },
+});
+
+console.log(budget);
+```
+
+</CodeGroup>
+
 Delete a budget:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -X DELETE http://localhost:8080/admin/budgets \
   -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
   -H "Content-Type: application/json" \
@@ -272,5 +401,49 @@ curl -X DELETE http://localhost:8080/admin/budgets \
     "budget_key": { "period": "monthly" }
   }'
 ```
+
+```python Python
+import os
+
+import httpx
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080",
+    api_key=os.environ["GOMODEL_MASTER_KEY"],
+)
+deleted = client.delete(
+    "/admin/budgets",
+    cast_to=httpx.Response,
+    body={
+        "scope": "label",
+        "subject": "Mobile-App-iOS",
+        "budget_key": {"period": "monthly"},
+    },
+)
+
+print(deleted.json())
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080",
+  apiKey: process.env.GOMODEL_MASTER_KEY,
+});
+
+const deleted = await client.delete("/admin/budgets", {
+  body: {
+    scope: "label",
+    subject: "Mobile-App-iOS",
+    budget_key: { period: "monthly" },
+  },
+});
+
+console.log(deleted);
+```
+
+</CodeGroup>
 
 See [Admin Endpoints](/advanced/admin-endpoints) for the endpoint list.

--- a/docs/features/labelling.mdx
+++ b/docs/features/labelling.mdx
@@ -37,12 +37,50 @@ each key. Click **Edit Labels** on a row to change them later.
 
 Or via the admin API:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -X POST http://localhost:8080/admin/auth-keys \
   -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
   -H "Content-Type: application/json" \
   -d '{"name": "team-a-batch", "labels": ["team-a", "batch-jobs"]}'
 ```
+
+```python Python
+import os
+
+import httpx
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080",
+    api_key=os.environ["GOMODEL_MASTER_KEY"],
+)
+auth_key = client.post(
+    "/admin/auth-keys",
+    cast_to=httpx.Response,
+    body={"name": "team-a-batch", "labels": ["team-a", "batch-jobs"]},
+)
+
+print(auth_key.json())
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080",
+  apiKey: process.env.GOMODEL_MASTER_KEY,
+});
+
+const authKey = await client.post("/admin/auth-keys", {
+  body: { name: "team-a-batch", labels: ["team-a", "batch-jobs"] },
+});
+
+console.log(authKey);
+```
+
+</CodeGroup>
 
 Every request authenticated with that key carries those labels — no client
 changes needed. This is the simplest way to attribute traffic per team or
@@ -51,12 +89,50 @@ service: issue each consumer its own labelled key.
 Labels can be changed later without rotating the key, in the dashboard
 (`API Keys -> Edit Labels`) or via the admin API:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -X PUT http://localhost:8080/admin/auth-keys/<key-id>/labels \
   -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
   -H "Content-Type: application/json" \
   -d '{"labels": ["team-a", "realtime"]}'
 ```
+
+```python Python
+import os
+
+import httpx
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080",
+    api_key=os.environ["GOMODEL_MASTER_KEY"],
+)
+auth_key = client.put(
+    "/admin/auth-keys/<key-id>/labels",
+    cast_to=httpx.Response,
+    body={"labels": ["team-a", "realtime"]},
+)
+
+print(auth_key.json())
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080",
+  apiKey: process.env.GOMODEL_MASTER_KEY,
+});
+
+const authKey = await client.put("/admin/auth-keys/<key-id>/labels", {
+  body: { labels: ["team-a", "realtime"] },
+});
+
+console.log(authKey);
+```
+
+</CodeGroup>
 
 The new list replaces the old one; send `[]` to remove all labels. Changes
 apply to new requests immediately on the instance that served the update and

--- a/docs/features/rate-limits.mdx
+++ b/docs/features/rate-limits.mdx
@@ -237,15 +237,48 @@ x-ratelimit-reset-tokens: 42
 
 ## Admin API
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
   http://localhost:8080/admin/rate-limits
 ```
 
+```python Python
+import os
+
+import httpx
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080",
+    api_key=os.environ["GOMODEL_MASTER_KEY"],
+)
+rate_limits = client.get("/admin/rate-limits", cast_to=httpx.Response)
+
+print(rate_limits.json())
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080",
+  apiKey: process.env.GOMODEL_MASTER_KEY,
+});
+
+const rateLimits = await client.get("/admin/rate-limits");
+console.log(rateLimits);
+```
+
+</CodeGroup>
+
 Create or update a rule (`user_path` is shorthand for
 `"scope": "user_path", "subject": ...`):
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -X PUT http://localhost:8080/admin/rate-limits \
   -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
   -H "Content-Type: application/json" \
@@ -257,9 +290,57 @@ curl -X PUT http://localhost:8080/admin/rate-limits \
   }'
 ```
 
+```python Python
+import os
+
+import httpx
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080",
+    api_key=os.environ["GOMODEL_MASTER_KEY"],
+)
+rate_limit = client.put(
+    "/admin/rate-limits",
+    cast_to=httpx.Response,
+    body={
+        "user_path": "/team/alpha",
+        "limit_key": {"period": "minute"},
+        "max_requests": 100,
+        "max_tokens": 50000,
+    },
+)
+
+print(rate_limit.json())
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080",
+  apiKey: process.env.GOMODEL_MASTER_KEY,
+});
+
+const rateLimit = await client.put("/admin/rate-limits", {
+  body: {
+    user_path: "/team/alpha",
+    limit_key: { period: "minute" },
+    max_requests: 100,
+    max_tokens: 50000,
+  },
+});
+
+console.log(rateLimit);
+```
+
+</CodeGroup>
+
 Provider and model rules name their subject explicitly:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -X PUT http://localhost:8080/admin/rate-limits \
   -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
   -H "Content-Type: application/json" \
@@ -271,14 +352,106 @@ curl -X PUT http://localhost:8080/admin/rate-limits \
   }'
 ```
 
+```python Python
+import os
+
+import httpx
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080",
+    api_key=os.environ["GOMODEL_MASTER_KEY"],
+)
+rate_limit = client.put(
+    "/admin/rate-limits",
+    cast_to=httpx.Response,
+    body={
+        "scope": "provider",
+        "subject": "openai",
+        "limit_key": {"period": "minute"},
+        "max_requests": 500,
+    },
+)
+
+print(rate_limit.json())
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080",
+  apiKey: process.env.GOMODEL_MASTER_KEY,
+});
+
+const rateLimit = await client.put("/admin/rate-limits", {
+  body: {
+    scope: "provider",
+    subject: "openai",
+    limit_key: { period: "minute" },
+    max_requests: 500,
+  },
+});
+
+console.log(rateLimit);
+```
+
+</CodeGroup>
+
 Delete a rule:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -X DELETE http://localhost:8080/admin/rate-limits \
   -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
   -H "Content-Type: application/json" \
   -d '{"scope": "provider", "subject": "openai", "limit_key": {"period": "minute"}}'
 ```
+
+```python Python
+import os
+
+import httpx
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080",
+    api_key=os.environ["GOMODEL_MASTER_KEY"],
+)
+deleted = client.delete(
+    "/admin/rate-limits",
+    cast_to=httpx.Response,
+    body={
+        "scope": "provider",
+        "subject": "openai",
+        "limit_key": {"period": "minute"},
+    },
+)
+
+print(deleted.json())
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080",
+  apiKey: process.env.GOMODEL_MASTER_KEY,
+});
+
+const deleted = await client.delete("/admin/rate-limits", {
+  body: {
+    scope: "provider",
+    subject: "openai",
+    limit_key: { period: "minute" },
+  },
+});
+
+console.log(deleted);
+```
+
+</CodeGroup>
 
 Reset live counters for one rule (`POST /admin/rate-limits/reset-one` with
 `{"scope": ..., "subject": ..., "period": ...}`) or for all rules

--- a/docs/features/user-path.mdx
+++ b/docs/features/user-path.mdx
@@ -102,10 +102,37 @@ See [Budgets](/features/budgets) for spend limits and workflow enforcement.
 
 Callers can check their own consumption without admin access:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl http://localhost:8080/v1/usage \
   -H "Authorization: Bearer sk_gom_..."
 ```
+
+```python Python
+import httpx
+
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8080", api_key="sk_gom_...")
+usage = client.get("/v1/usage", cast_to=httpx.Response)
+
+print(usage.json())
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080",
+  apiKey: "sk_gom_...",
+});
+
+const usage = await client.get("/v1/usage");
+console.log(usage);
+```
+
+</CodeGroup>
 
 The response covers the caller's effective user path: recorded usage over a
 date window, plus the status of every budget and rate limit rule gating that

--- a/docs/guides/claude-code.mdx
+++ b/docs/guides/claude-code.mdx
@@ -50,18 +50,49 @@ docker run --rm -p 8080:8080 \
   enterpilot/gomodel
 ```
 
-## 2. Confirm Anthropic passthrough with curl
+## 2. Confirm Anthropic passthrough
 
 Check that the Anthropic passthrough models endpoint responds:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -s http://localhost:8080/p/anthropic/v1/models \
   -H "Authorization: Bearer change-me"
 ```
 
+```python Python
+import anthropic
+
+client = anthropic.Anthropic(
+    base_url="http://localhost:8080/p/anthropic",
+    api_key="change-me",
+)
+
+for model in client.models.list():
+    print(model.id)
+```
+
+```javascript JavaScript
+import Anthropic from "@anthropic-ai/sdk";
+
+const client = new Anthropic({
+  baseURL: "http://localhost:8080/p/anthropic",
+  apiKey: "change-me",
+});
+
+for await (const model of client.models.list()) {
+  console.log(model.id);
+}
+```
+
+</CodeGroup>
+
 Then send one small test message:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -s http://localhost:8080/p/anthropic/v1/messages \
   -H "Authorization: Bearer change-me" \
   -H "Content-Type: application/json" \
@@ -77,6 +108,42 @@ curl -s http://localhost:8080/p/anthropic/v1/messages \
     ]
   }'
 ```
+
+```python Python
+import anthropic
+
+client = anthropic.Anthropic(
+    base_url="http://localhost:8080/p/anthropic",
+    api_key="change-me",
+)
+
+message = client.messages.create(
+    model="claude-3-haiku-20240307",
+    max_tokens=16,
+    messages=[{"role": "user", "content": "Reply with exactly ok"}],
+)
+
+print(message.content[0].text)
+```
+
+```javascript JavaScript
+import Anthropic from "@anthropic-ai/sdk";
+
+const client = new Anthropic({
+  baseURL: "http://localhost:8080/p/anthropic",
+  apiKey: "change-me",
+});
+
+const message = await client.messages.create({
+  model: "claude-3-haiku-20240307",
+  max_tokens: 16,
+  messages: [{ role: "user", content: "Reply with exactly ok" }],
+});
+
+console.log(message.content[0].text);
+```
+
+</CodeGroup>
 
 If the gateway is wired correctly, the response will contain `ok`.
 

--- a/docs/guides/codex.mdx
+++ b/docs/guides/codex.mdx
@@ -1,6 +1,6 @@
 ---
 title: "GoModel & Codex"
-description: "Route OpenAI Codex through GoModel's Responses API: run the gateway with Docker, point Codex at it with a master key, and verify the setup with curl."
+description: "Route OpenAI Codex through GoModel's Responses API: run the gateway with Docker, point Codex at it with a master key, and verify the setup."
 icon: "code-xml"
 keywords: ["Codex", "OpenAI Codex", "coding agent", "setup guide"]
 ---
@@ -36,7 +36,7 @@ docker run --rm -p 8080:8080 \
   enterpilot/gomodel
 ```
 
-## 2. Confirm the Responses API with curl
+## 2. Confirm the Responses API
 
 Before testing Codex itself, you can optionally verify that GoModel answers a
 normal Responses API request:
@@ -45,7 +45,9 @@ This step is optional. If you are sure you have configured a valid
 `OPENAI_API_KEY` in GoModel, you can skip it and go straight to
 [step 3](#3-configure-codex-to-use-gomodel).
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -s http://localhost:8080/v1/responses \
   -H "Authorization: Bearer change-me" \
   -H "Content-Type: application/json" \
@@ -55,6 +57,39 @@ curl -s http://localhost:8080/v1/responses \
     "max_output_tokens": 16
   }'
 ```
+
+```python Python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8080/v1", api_key="change-me")
+
+response = client.responses.create(
+    model="gpt-4.1-mini",
+    input="Reply with exactly ok",
+    max_output_tokens=16,
+)
+
+print(response.output_text)
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080/v1",
+  apiKey: "change-me",
+});
+
+const response = await client.responses.create({
+  model: "gpt-4.1-mini",
+  input: "Reply with exactly ok",
+  max_output_tokens: 16,
+});
+
+console.log(response.output_text);
+```
+
+</CodeGroup>
 
 If the gateway is wired correctly, the response will contain `ok`.
 

--- a/docs/guides/openai-agents-sdk.mdx
+++ b/docs/guides/openai-agents-sdk.mdx
@@ -43,7 +43,9 @@ that your provider exposes through GoModel.
 
 Send one small request through GoModel:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -s http://localhost:8080/v1/responses \
   -H "Authorization: Bearer change-me" \
   -H "Content-Type: application/json" \
@@ -52,6 +54,37 @@ curl -s http://localhost:8080/v1/responses \
     "input": "Reply with exactly ok."
   }'
 ```
+
+```python Python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8080/v1", api_key="change-me")
+
+response = client.responses.create(
+    model="gpt-5-mini",
+    input="Reply with exactly ok.",
+)
+
+print(response.output_text)
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080/v1",
+  apiKey: "change-me",
+});
+
+const response = await client.responses.create({
+  model: "gpt-5-mini",
+  input: "Reply with exactly ok.",
+});
+
+console.log(response.output_text);
+```
+
+</CodeGroup>
 
 If the gateway is wired correctly, the response will contain `ok`.
 

--- a/docs/guides/openclaw.mdx
+++ b/docs/guides/openclaw.mdx
@@ -48,10 +48,36 @@ docker run --rm -p 8080:8080 \
 
 Confirm your model list:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -s http://localhost:8080/v1/models \
   -H "Authorization: Bearer change-me"
 ```
+
+```python Python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8080/v1", api_key="change-me")
+
+for model in client.models.list():
+    print(model.id)
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080/v1",
+  apiKey: "change-me",
+});
+
+for await (const model of client.models.list()) {
+  console.log(model.id);
+}
+```
+
+</CodeGroup>
 
 ## 2. Add a GoModel provider in OpenClaw
 

--- a/docs/guides/opencode-and-other-agents.mdx
+++ b/docs/guides/opencode-and-other-agents.mdx
@@ -36,9 +36,11 @@ docker run --rm -p 8080:8080 \
   upstream provider configured.
 </Note>
 
-## 2. Confirm the OpenAI-compatible API with curl
+## 2. Confirm the OpenAI-compatible API
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -s http://localhost:8080/v1/chat/completions \
   -H "Authorization: Bearer change-me" \
   -H "Content-Type: application/json" \
@@ -52,6 +54,37 @@ curl -s http://localhost:8080/v1/chat/completions \
     ]
   }'
 ```
+
+```python Python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8080/v1", api_key="change-me")
+
+completion = client.chat.completions.create(
+    model="gpt-4.1-mini",
+    messages=[{"role": "user", "content": "Reply with exactly ok"}],
+)
+
+print(completion.choices[0].message.content)
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080/v1",
+  apiKey: "change-me",
+});
+
+const completion = await client.chat.completions.create({
+  model: "gpt-4.1-mini",
+  messages: [{ role: "user", content: "Reply with exactly ok" }],
+});
+
+console.log(completion.choices[0].message.content);
+```
+
+</CodeGroup>
 
 If the gateway is wired correctly, the response will contain `ok`.
 

--- a/docs/guides/prometheus-metrics.mdx
+++ b/docs/guides/prometheus-metrics.mdx
@@ -169,17 +169,72 @@ Start the server and look for log messages:
 
 **When Enabled:**
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl http://localhost:8080/metrics
 # Returns Prometheus metrics in text format
 ```
 
+```python Python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8080", api_key="unused")
+metrics = client.get("/metrics", cast_to=str)
+
+print(metrics)
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080",
+  apiKey: "unused",
+});
+
+const metrics = await client.get("/metrics");
+console.log(metrics);
+```
+
+</CodeGroup>
+
 **When Disabled:**
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl http://localhost:8080/metrics
 # Returns 404 Not Found
 ```
+
+```python Python
+from openai import NotFoundError, OpenAI
+
+client = OpenAI(base_url="http://localhost:8080", api_key="unused")
+
+try:
+    client.get("/metrics", cast_to=str)
+except NotFoundError as error:
+    print(error.status_code)  # 404
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080",
+  apiKey: "unused",
+});
+
+try {
+  await client.get("/metrics");
+} catch (error) {
+  console.log(error.status); // 404
+}
+```
+
+</CodeGroup>
 
 ## Performance Impact
 
@@ -278,7 +333,9 @@ for the three launch forms), then restart GoModel.
 
 **Solution:** make some requests to generate metrics:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -X POST http://localhost:8080/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer your-master-key" \
@@ -287,6 +344,51 @@ curl -X POST http://localhost:8080/v1/chat/completions \
 # Then check metrics
 curl http://localhost:8080/metrics | grep gomodel_requests_total
 ```
+
+```python Python
+from openai import OpenAI
+
+models = OpenAI(
+    base_url="http://localhost:8080/v1",
+    api_key="your-master-key",
+)
+models.chat.completions.create(
+    model="gpt-4",
+    messages=[{"role": "user", "content": "Hi"}],
+)
+
+gateway = OpenAI(base_url="http://localhost:8080", api_key="your-master-key")
+metrics = gateway.get("/metrics", cast_to=str)
+
+for line in metrics.splitlines():
+    if "gomodel_requests_total" in line:
+        print(line)
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const models = new OpenAI({
+  baseURL: "http://localhost:8080/v1",
+  apiKey: "your-master-key",
+});
+await models.chat.completions.create({
+  model: "gpt-4",
+  messages: [{ role: "user", content: "Hi" }],
+});
+
+const gateway = new OpenAI({
+  baseURL: "http://localhost:8080",
+  apiKey: "your-master-key",
+});
+const metrics = await gateway.get("/metrics");
+
+for (const line of metrics.split("\n")) {
+  if (line.includes("gomodel_requests_total")) console.log(line);
+}
+```
+
+</CodeGroup>
 
 ### Custom Endpoint Not Working
 

--- a/docs/providers/azure.mdx
+++ b/docs/providers/azure.mdx
@@ -54,7 +54,9 @@ make build
 
 ## Verify
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -s http://localhost:8080/v1/chat/completions \
   -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
   -H "Content-Type: application/json" \
@@ -64,6 +66,44 @@ curl -s http://localhost:8080/v1/chat/completions \
     "max_tokens": 80
   }'
 ```
+
+```python Python
+import os
+
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080/v1",
+    api_key=os.environ["GOMODEL_MASTER_KEY"],
+)
+
+completion = client.chat.completions.create(
+    model="gpt-5",
+    messages=[{"role": "user", "content": "Reply with the single word ok."}],
+    max_tokens=80,
+)
+
+print(completion.choices[0].message.content)
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080/v1",
+  apiKey: process.env.GOMODEL_MASTER_KEY,
+});
+
+const completion = await client.chat.completions.create({
+  model: "gpt-5",
+  messages: [{ role: "user", content: "Reply with the single word ok." }],
+  max_tokens: 80,
+});
+
+console.log(completion.choices[0].message.content);
+```
+
+</CodeGroup>
 
 `GET /v1/models` returns the deployments the Azure resource exposes with
 `owned_by: "azure"`. Streaming, Responses, embeddings, and batches all work the

--- a/docs/providers/bailian.mdx
+++ b/docs/providers/bailian.mdx
@@ -75,7 +75,9 @@ GoModel transparently maps the standard `max_tokens` parameter to
 `max_tokens` as you normally would, and GoModel rewrites it before forwarding to
 Model Studio.
 
-```bash
+<CodeGroup>
+
+```bash curl
 # max_tokens=4096 is automatically sent as max_completion_tokens=4096
 curl http://localhost:8080/v1/chat/completions \
   -H "Content-Type: application/json" \
@@ -85,6 +87,41 @@ curl http://localhost:8080/v1/chat/completions \
     "max_tokens": 4096
   }'
 ```
+
+```python Python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8080/v1", api_key="unused")
+
+# max_tokens=4096 is automatically sent as max_completion_tokens=4096
+completion = client.chat.completions.create(
+    model="qwen3-max",
+    messages=[{"role": "user", "content": "Hello"}],
+    max_tokens=4096,
+)
+
+print(completion.choices[0].message.content)
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080/v1",
+  apiKey: "unused",
+});
+
+// max_tokens=4096 is automatically sent as max_completion_tokens=4096
+const completion = await client.chat.completions.create({
+  model: "qwen3-max",
+  messages: [{ role: "user", content: "Hello" }],
+  max_tokens: 4096,
+});
+
+console.log(completion.choices[0].message.content);
+```
+
+</CodeGroup>
 
 ## Supported features
 

--- a/docs/providers/bedrock-mantle.mdx
+++ b/docs/providers/bedrock-mantle.mdx
@@ -78,7 +78,9 @@ providers:
 
 ## Call GPT-5.6
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -s http://localhost:8080/v1/responses \
   -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
   -H "Content-Type: application/json" \
@@ -87,6 +89,42 @@ curl -s http://localhost:8080/v1/responses \
     "input": "Explain why idempotency matters in distributed systems."
   }'
 ```
+
+```python Python
+import os
+
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080/v1",
+    api_key=os.environ["GOMODEL_MASTER_KEY"],
+)
+
+response = client.responses.create(
+    model="openai.gpt-5.6-sol",
+    input="Explain why idempotency matters in distributed systems.",
+)
+
+print(response.output_text)
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080/v1",
+  apiKey: process.env.GOMODEL_MASTER_KEY,
+});
+
+const response = await client.responses.create({
+  model: "openai.gpt-5.6-sol",
+  input: "Explain why idempotency matters in distributed systems.",
+});
+
+console.log(response.output_text);
+```
+
+</CodeGroup>
 
 Streaming uses the same gateway endpoint with `"stream": true`.
 `previous_response_id`, tools, reasoning controls, and unknown extension

--- a/docs/providers/bedrock.mdx
+++ b/docs/providers/bedrock.mdx
@@ -54,7 +54,9 @@ make build
 
 ## Verify
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -s http://localhost:8080/v1/chat/completions \
   -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
   -H "Content-Type: application/json" \
@@ -64,6 +66,44 @@ curl -s http://localhost:8080/v1/chat/completions \
     "max_tokens": 80
   }'
 ```
+
+```python Python
+import os
+
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080/v1",
+    api_key=os.environ["GOMODEL_MASTER_KEY"],
+)
+
+completion = client.chat.completions.create(
+    model="anthropic.claude-3-5-haiku-20241022-v1:0",
+    messages=[{"role": "user", "content": "Reply with the single word ok."}],
+    max_tokens=80,
+)
+
+print(completion.choices[0].message.content)
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080/v1",
+  apiKey: process.env.GOMODEL_MASTER_KEY,
+});
+
+const completion = await client.chat.completions.create({
+  model: "anthropic.claude-3-5-haiku-20241022-v1:0",
+  messages: [{ role: "user", content: "Reply with the single word ok." }],
+  max_tokens: 80,
+});
+
+console.log(completion.choices[0].message.content);
+```
+
+</CodeGroup>
 
 `GET /v1/models` returns Bedrock models with `owned_by` set to the originating
 vendor (e.g. `anthropic`, `amazon`). Streaming (`stream: true`) and the

--- a/docs/providers/cohere.mdx
+++ b/docs/providers/cohere.mdx
@@ -34,7 +34,9 @@ model discovery with `COHERE_MODELS`.
 
 Use a Cohere Command model with either OpenAI-compatible endpoint:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl http://localhost:8080/v1/chat/completions \
   -H "Authorization: Bearer $GOMODEL_API_KEY" \
   -H "Content-Type: application/json" \
@@ -43,6 +45,42 @@ curl http://localhost:8080/v1/chat/completions \
     "messages": [{"role": "user", "content": "Explain vector search briefly"}]
   }'
 ```
+
+```python Python
+import os
+
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080/v1",
+    api_key=os.environ["GOMODEL_API_KEY"],
+)
+
+completion = client.chat.completions.create(
+    model="command-a-plus-05-2026",
+    messages=[{"role": "user", "content": "Explain vector search briefly"}],
+)
+
+print(completion.choices[0].message.content)
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080/v1",
+  apiKey: process.env.GOMODEL_API_KEY,
+});
+
+const completion = await client.chat.completions.create({
+  model: "command-a-plus-05-2026",
+  messages: [{ role: "user", content: "Explain vector search briefly" }],
+});
+
+console.log(completion.choices[0].message.content);
+```
+
+</CodeGroup>
 
 Chat streaming, system and developer messages, image URL parts, JSON response
 formats, tool definitions, tool calls, and tool results are translated to the
@@ -68,7 +106,9 @@ Cohere audio uses a dedicated speech-to-text model and endpoint; Command chat
 models do not accept audio content mixed into Chat Completions or Responses.
 Transcribe audio through the OpenAI-compatible endpoint:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl http://localhost:8080/v1/audio/transcriptions \
   -H "Authorization: Bearer $GOMODEL_API_KEY" \
   -F "model=cohere/cohere-transcribe-03-2026" \
@@ -76,6 +116,48 @@ curl http://localhost:8080/v1/audio/transcriptions \
   -F "response_format=json" \
   -F "file=@recording.wav"
 ```
+
+```python Python
+import os
+
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080/v1",
+    api_key=os.environ["GOMODEL_API_KEY"],
+)
+
+with open("recording.wav", "rb") as audio_file:
+    transcription = client.audio.transcriptions.create(
+        file=audio_file,
+        model="cohere/cohere-transcribe-03-2026",
+        language="en",
+        response_format="json",
+    )
+
+print(transcription.text)
+```
+
+```javascript JavaScript
+import { createReadStream } from "node:fs";
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080/v1",
+  apiKey: process.env.GOMODEL_API_KEY,
+});
+
+const transcription = await client.audio.transcriptions.create({
+  file: createReadStream("recording.wav"),
+  model: "cohere/cohere-transcribe-03-2026",
+  language: "en",
+  response_format: "json",
+});
+
+console.log(transcription.text);
+```
+
+</CodeGroup>
 
 The Cohere transcription API requires `language` and returns JSON. GoModel
 accepts the OpenAI-compatible `response_format=json` field but omits it from the
@@ -88,7 +170,9 @@ transcription.
 GoModel supplies Cohere's required embedding fields while retaining the
 OpenAI request shape:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl http://localhost:8080/v1/embeddings \
   -H "Authorization: Bearer $GOMODEL_API_KEY" \
   -H "Content-Type: application/json" \
@@ -99,6 +183,46 @@ curl http://localhost:8080/v1/embeddings \
     "input_type": "search_document"
   }'
 ```
+
+```python Python
+import os
+
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080/v1",
+    api_key=os.environ["GOMODEL_API_KEY"],
+)
+
+embeddings = client.embeddings.create(
+    model="embed-v4.0",
+    input=["first document", "second document"],
+    dimensions=1024,
+    extra_body={"input_type": "search_document"},
+)
+
+print(embeddings.data[0].embedding)
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080/v1",
+  apiKey: process.env.GOMODEL_API_KEY,
+});
+
+const embeddings = await client.embeddings.create({
+  model: "embed-v4.0",
+  input: ["first document", "second document"],
+  dimensions: 1024,
+  input_type: "search_document",
+});
+
+console.log(embeddings.data[0].embedding);
+```
+
+</CodeGroup>
 
 `input_type` defaults to `search_document`. Set it to `search_query`,
 `classification`, or `clustering` when that better describes the input.

--- a/docs/providers/llmd.mdx
+++ b/docs/providers/llmd.mdx
@@ -91,7 +91,9 @@ to `/team/alpha`, and assign the returned value to `TEAM_ALPHA_GOMODEL_KEY`.
 The key binding, rather than a client-asserted header, establishes the fairness
 ID used by this request.
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -s http://localhost:8080/v1/chat/completions \
   -H "Authorization: Bearer ${TEAM_ALPHA_GOMODEL_KEY}" \
   -H "Content-Type: application/json" \
@@ -100,6 +102,42 @@ curl -s http://localhost:8080/v1/chat/completions \
     "messages": [{"role": "user", "content": "Reply with exactly ok."}]
   }'
 ```
+
+```python Python
+import os
+
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080/v1",
+    api_key=os.environ["TEAM_ALPHA_GOMODEL_KEY"],
+)
+
+completion = client.chat.completions.create(
+    model="llmd/Qwen/Qwen2.5-0.5B-Instruct",
+    messages=[{"role": "user", "content": "Reply with exactly ok."}],
+)
+
+print(completion.choices[0].message.content)
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080/v1",
+  apiKey: process.env.TEAM_ALPHA_GOMODEL_KEY,
+});
+
+const completion = await client.chat.completions.create({
+  model: "llmd/Qwen/Qwen2.5-0.5B-Instruct",
+  messages: [{ role: "user", content: "Reply with exactly ok." }],
+});
+
+console.log(completion.choices[0].message.content);
+```
+
+</CodeGroup>
 
 GoModel removes the outer `llmd/` routing qualifier before sending the model
 name upstream. Slash-shaped Hugging Face model IDs remain intact.
@@ -112,7 +150,9 @@ for the other routes in the
 [llm-d HTTP API reference](https://llm-d.ai/docs/dev/api-reference/epp-http-apis),
 including OpenAI completions, Anthropic Messages, and vLLM Generate:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -s http://localhost:8080/p/llmd/completions \
   -H "Authorization: Bearer change-me" \
   -H "Content-Type: application/json" \
@@ -121,6 +161,44 @@ curl -s http://localhost:8080/p/llmd/completions \
     "prompt": "Hello"
   }'
 ```
+
+```python Python
+import httpx
+
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8080", api_key="change-me")
+completion = client.post(
+    "/p/llmd/completions",
+    cast_to=httpx.Response,
+    body={
+        "model": "Qwen/Qwen2.5-0.5B-Instruct",
+        "prompt": "Hello",
+    },
+)
+
+print(completion.json())
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080",
+  apiKey: "change-me",
+});
+
+const completion = await client.post("/p/llmd/completions", {
+  body: {
+    model: "Qwen/Qwen2.5-0.5B-Instruct",
+    prompt: "Hello",
+  },
+});
+
+console.log(completion);
+```
+
+</CodeGroup>
 
 The separate llm-d Batch Gateway is not exposed as GoModel's native batch API.
 Files, audio, and Responses lifecycle utility endpoints are also not

--- a/docs/providers/minimax.mdx
+++ b/docs/providers/minimax.mdx
@@ -41,7 +41,9 @@ a zero or negative temperature to `1.0` so OpenAI-style requests that pin
 [`t2a_v2`](https://platform.minimax.io/docs/api-reference/speech-t2a-v2)
 API and the hex-encoded audio is decoded back to binary:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl https://your-gateway/v1/audio/speech \
   -H "Authorization: Bearer $GOMODEL_KEY" \
   -H "Content-Type: application/json" \
@@ -53,6 +55,46 @@ curl https://your-gateway/v1/audio/speech \
   }' \
   --output speech.mp3
 ```
+
+```python Python
+import os
+
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://your-gateway/v1",
+    api_key=os.environ["GOMODEL_KEY"],
+)
+
+speech = client.audio.speech.create(
+    model="speech-2.6-hd",
+    input="Hello from GoModel.",
+    voice="English_expressive_narrator",
+    response_format="mp3",
+)
+speech.write_to_file("speech.mp3")
+```
+
+```javascript JavaScript
+import { writeFile } from "node:fs/promises";
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "https://your-gateway/v1",
+  apiKey: process.env.GOMODEL_KEY,
+});
+
+const speech = await client.audio.speech.create({
+  model: "speech-2.6-hd",
+  input: "Hello from GoModel.",
+  voice: "English_expressive_narrator",
+  response_format: "mp3",
+});
+
+await writeFile("speech.mp3", Buffer.from(await speech.arrayBuffer()));
+```
+
+</CodeGroup>
 
 - `voice` takes a **MiniMax voice ID** (for example
   `English_expressive_narrator`), not an OpenAI voice name like `alloy`.

--- a/docs/providers/multiple-ollama.mdx
+++ b/docs/providers/multiple-ollama.mdx
@@ -49,7 +49,9 @@ make build
 
 ## Route to a specific backend
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -s http://localhost:8080/v1/chat/completions \
   -H "Authorization: Bearer change-me" \
   -H "Content-Type: application/json" \
@@ -58,6 +60,37 @@ curl -s http://localhost:8080/v1/chat/completions \
     "messages": [{"role": "user", "content": "Reply with exactly ok."}]
   }'
 ```
+
+```python Python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8080/v1", api_key="change-me")
+
+completion = client.chat.completions.create(
+    model="ollama-a/llama3.2",
+    messages=[{"role": "user", "content": "Reply with exactly ok."}],
+)
+
+print(completion.choices[0].message.content)
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080/v1",
+  apiKey: "change-me",
+});
+
+const completion = await client.chat.completions.create({
+  model: "ollama-a/llama3.2",
+  messages: [{ role: "user", content: "Reply with exactly ok." }],
+});
+
+console.log(completion.choices[0].message.content);
+```
+
+</CodeGroup>
 
 `GET /v1/models` returns provider-qualified IDs such as `ollama-a/llama3.2`
 and `ollama-b/llama3.2`. A bare model name is routed to whichever provider

--- a/docs/providers/oracle.mdx
+++ b/docs/providers/oracle.mdx
@@ -74,7 +74,9 @@ make build
 
 ## 4. Verify
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -s http://localhost:8080/v1/chat/completions \
   -H "Authorization: Bearer change-me" \
   -H "Content-Type: application/json" \
@@ -84,6 +86,39 @@ curl -s http://localhost:8080/v1/chat/completions \
     "max_tokens": 80
   }'
 ```
+
+```python Python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8080/v1", api_key="change-me")
+
+completion = client.chat.completions.create(
+    model="openai.gpt-oss-120b",
+    messages=[{"role": "user", "content": "Reply with the single word ok."}],
+    max_tokens=80,
+)
+
+print(completion.choices[0].message.content)
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080/v1",
+  apiKey: "change-me",
+});
+
+const completion = await client.chat.completions.create({
+  model: "openai.gpt-oss-120b",
+  messages: [{ role: "user", content: "Reply with the single word ok." }],
+  max_tokens: 80,
+});
+
+console.log(completion.choices[0].message.content);
+```
+
+</CodeGroup>
 
 `GET /v1/models` returns models such as `openai.gpt-oss-120b` with
 `owned_by: "oracle"`. Responses API works the same way.

--- a/docs/providers/sglang.mdx
+++ b/docs/providers/sglang.mdx
@@ -62,7 +62,9 @@ make build
 
 ## Verify
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -s http://localhost:8080/v1/chat/completions \
   -H "Authorization: Bearer change-me" \
   -H "Content-Type: application/json" \
@@ -72,6 +74,39 @@ curl -s http://localhost:8080/v1/chat/completions \
     "max_tokens": 8
   }'
 ```
+
+```python Python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8080/v1", api_key="change-me")
+
+completion = client.chat.completions.create(
+    model="sglang/Qwen/Qwen2.5-0.5B-Instruct",
+    messages=[{"role": "user", "content": "Reply with exactly ok."}],
+    max_tokens=8,
+)
+
+print(completion.choices[0].message.content)
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080/v1",
+  apiKey: "change-me",
+});
+
+const completion = await client.chat.completions.create({
+  model: "sglang/Qwen/Qwen2.5-0.5B-Instruct",
+  messages: [{ role: "user", content: "Reply with exactly ok." }],
+  max_tokens: 8,
+});
+
+console.log(completion.choices[0].message.content);
+```
+
+</CodeGroup>
 
 `GET /v1/models` returns SGLang model IDs prefixed by provider name, for
 example `sglang/Qwen/Qwen2.5-0.5B-Instruct`.
@@ -94,7 +129,9 @@ underscores become hyphens.
 Passthrough is enabled by default. Root-relative SGLang endpoints such as
 `/generate` are sent without the configured `/v1` prefix:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -s http://localhost:8080/p/sglang/generate \
   -H "Authorization: Bearer change-me" \
   -H "Content-Type: application/json" \
@@ -103,6 +140,44 @@ curl -s http://localhost:8080/p/sglang/generate \
     "sampling_params": {"max_new_tokens": 8}
   }'
 ```
+
+```python Python
+import httpx
+
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8080", api_key="change-me")
+generation = client.post(
+    "/p/sglang/generate",
+    cast_to=httpx.Response,
+    body={
+        "text": "Hello",
+        "sampling_params": {"max_new_tokens": 8},
+    },
+)
+
+print(generation.json())
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080",
+  apiKey: "change-me",
+});
+
+const generation = await client.post("/p/sglang/generate", {
+  body: {
+    text: "Hello",
+    sampling_params: { max_new_tokens: 8 },
+  },
+});
+
+console.log(generation);
+```
+
+</CodeGroup>
 
 Keep the explicit `v1/` segment for SGLang endpoints that include it, such as
 `/v1/rerank` or `/v1/tokenize`:

--- a/docs/providers/vllm.mdx
+++ b/docs/providers/vllm.mdx
@@ -55,7 +55,9 @@ make build
 
 ## Verify
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -s http://localhost:8080/v1/chat/completions \
   -H "Authorization: Bearer change-me" \
   -H "Content-Type: application/json" \
@@ -64,6 +66,37 @@ curl -s http://localhost:8080/v1/chat/completions \
     "messages": [{"role": "user", "content": "Reply with exactly ok."}]
   }'
 ```
+
+```python Python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8080/v1", api_key="change-me")
+
+completion = client.chat.completions.create(
+    model="vllm/meta-llama/Llama-3.1-8B-Instruct",
+    messages=[{"role": "user", "content": "Reply with exactly ok."}],
+)
+
+print(completion.choices[0].message.content)
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080/v1",
+  apiKey: "change-me",
+});
+
+const completion = await client.chat.completions.create({
+  model: "vllm/meta-llama/Llama-3.1-8B-Instruct",
+  messages: [{ role: "user", content: "Reply with exactly ok." }],
+});
+
+console.log(completion.choices[0].message.content);
+```
+
+</CodeGroup>
 
 `GET /v1/models` returns vLLM's model IDs prefixed by provider name, e.g.
 `vllm/meta-llama/Llama-3.1-8B-Instruct`.
@@ -85,12 +118,52 @@ VLLM_TEST_BASE_URL=http://host.docker.internal:8001/v1
 Passthrough is enabled by default. Use it for vLLM-specific endpoints such as
 `/tokenize`, `/detokenize`, `/pooling`, `/rerank`:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -s http://localhost:8080/p/vllm/tokenize \
   -H "Authorization: Bearer change-me" \
   -H "Content-Type: application/json" \
   -d '{"model": "meta-llama/Llama-3.1-8B-Instruct", "prompt": "Hello"}'
 ```
+
+```python Python
+import httpx
+
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8080", api_key="change-me")
+tokens = client.post(
+    "/p/vllm/tokenize",
+    cast_to=httpx.Response,
+    body={
+        "model": "meta-llama/Llama-3.1-8B-Instruct",
+        "prompt": "Hello",
+    },
+)
+
+print(tokens.json())
+```
+
+```javascript JavaScript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8080",
+  apiKey: "change-me",
+});
+
+const tokens = await client.post("/p/vllm/tokenize", {
+  body: {
+    model: "meta-llama/Llama-3.1-8B-Instruct",
+    prompt: "Hello",
+  },
+});
+
+console.log(tokens);
+```
+
+</CodeGroup>
 
 GoModel strips client auth headers before forwarding and applies `VLLM_API_KEY`
 to upstream requests when configured.


### PR DESCRIPTION
## Summary

- add Python and JavaScript SDK tabs alongside 54 existing cURL request examples
- use typed OpenAI and Anthropic SDK methods for compatible endpoints
- use the OpenAI SDK raw request interface for GoModel-specific admin, usage, passthrough, and metrics routes
- keep installer cURL commands shell-only and update cURL-only guide headings

## Validation

- `mint validate`
- `mint broken-links`
- embedded Python syntax checks
- embedded JavaScript syntax checks
- current Python and JavaScript SDK interface checks
- repository pre-commit hooks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Python and JavaScript examples alongside existing Bash/cURL examples across API, provider, admin, and integration guides.
  * Grouped multi-language examples into selectable code tabs for easier comparison and copying.
  * Expanded examples covering authentication, usage, budgets, rate limits, workflows, conversations, audio, responses, metrics, and provider integrations.
  * Updated verification instructions to demonstrate equivalent SDK-based requests and response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->