### PR TITLE
fix(deepseek): pad missing reasoning content for tool calls

### DIFF
--- a/internal/providers/deepseek/deepseek.go
+++ b/internal/providers/deepseek/deepseek.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/goccy/go-json"
+
 	"github.com/enterpilot/gomodel/internal/core"
 	"github.com/enterpilot/gomodel/internal/llmclient"
 	"github.com/enterpilot/gomodel/internal/providers"
@@ -26,9 +28,8 @@ var Registration = providers.Registration{
 
 // Provider implements the core.Provider interface for DeepSeek. DeepSeek's
 // API is OpenAI-compatible, so all transport goes through the shared
-// chat-centric adapter; the only quirks are the reasoning-effort remap
-// (applied via the AdaptChatRequest hook) and the missing embeddings
-// endpoint.
+// chat-centric adapter. Its request hook handles reasoning-effort mapping and
+// tool-call reasoning replay; DeepSeek does not expose an embeddings endpoint.
 type Provider struct {
 	*openai.ChatCompatible
 }
@@ -66,14 +67,57 @@ func setHeaders(req *http.Request, apiKey string) {
 	})
 }
 
-// adaptChatRequest rewrites GoModel's common reasoning shape into DeepSeek's
-// OpenAI-compatible chat extension. DeepSeek accepts reasoning_effort as a
-// top-level string, not "reasoning": {"effort": "..."}.
+// adaptChatRequest applies DeepSeek's OpenAI-compatible chat extensions.
 func adaptChatRequest(req *core.ChatRequest) (*core.ChatRequest, error) {
-	if req == nil || req.Reasoning == nil || strings.TrimSpace(req.Reasoning.Effort) == "" {
+	if req == nil {
 		return req, nil
 	}
-	return providers.AdaptReasoningEffortRequest(req, normalizeReasoningEffort(req.Reasoning.Effort))
+
+	adapted := req
+	var err error
+	if req.Reasoning != nil && strings.TrimSpace(req.Reasoning.Effort) != "" {
+		adapted, err = providers.AdaptReasoningEffortRequest(req, normalizeReasoningEffort(req.Reasoning.Effort))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return padMissingToolCallReasoningContent(adapted)
+}
+
+// padMissingToolCallReasoningContent satisfies DeepSeek's requirement that assistant
+// tool-call messages replay reasoning_content. Virtual-model clients may not
+// know that DeepSeek will serve the request, so a non-empty neutral value is
+// added when they omit it.
+func padMissingToolCallReasoningContent(req *core.ChatRequest) (*core.ChatRequest, error) {
+	if len(req.Tools) == 0 {
+		return req, nil
+	}
+
+	var adapted *core.ChatRequest
+	for i, message := range req.Messages {
+		if message.Role != "assistant" || len(message.ToolCalls) == 0 || message.ExtraFields.Lookup("reasoning_content") != nil {
+			continue
+		}
+
+		extra, err := core.MergeUnknownJSONFields(message.ExtraFields, map[string]json.RawMessage{
+			"reasoning_content": json.RawMessage(`" "`),
+		})
+		if err != nil {
+			return nil, core.NewInvalidRequestError("failed to adapt DeepSeek tool-call message: "+err.Error(), err)
+		}
+		if adapted == nil {
+			copy := *req
+			copy.Messages = append([]core.Message(nil), req.Messages...)
+			adapted = &copy
+		}
+		adapted.Messages[i].ExtraFields = extra
+	}
+
+	if adapted == nil {
+		return req, nil
+	}
+	return adapted, nil
 }
 
 // normalizeReasoningEffort maps GoModel's OpenAI-style effort levels to the two

--- a/internal/providers/deepseek/deepseek_test.go
+++ b/internal/providers/deepseek/deepseek_test.go
@@ -88,6 +88,76 @@ func TestChatCompletion_MapsReasoningToDeepSeekReasoningEffort(t *testing.T) {
 	}
 }
 
+func TestChatCompletion_PadsMissingReasoningContentForAssistantToolCalls(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			http.Error(w, "decode error", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-deepseek",
+			"created":1,
+			"model":"deepseek-v4-pro",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"done"},"finish_reason":"stop"}]
+		}`))
+	}))
+	defer server.Close()
+
+	var req core.ChatRequest
+	if err := json.Unmarshal([]byte(`{
+		"model":"deepseek-v4-pro",
+		"messages":[
+			{"role":"user","content":"check"},
+			{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"lookup","arguments":"{}"}}]},
+			{"role":"tool","tool_call_id":"call_1","content":"ok"},
+			{"role":"assistant","content":null,"reasoning_content":"client reasoning","tool_calls":[{"id":"call_2","type":"function","function":{"name":"lookup","arguments":"{}"}}]}
+		],
+		"tools":[{"type":"function","function":{"name":"lookup","parameters":{"type":"object"}}}]
+	}`), &req); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	provider := NewWithHTTPClient("deepseek-key", server.URL, server.Client(), llmclient.Hooks{})
+	if _, err := provider.ChatCompletion(context.Background(), &req); err != nil {
+		t.Fatalf("ChatCompletion() error = %v", err)
+	}
+
+	messages, _ := gotBody["messages"].([]any)
+	missingReasoning, _ := messages[1].(map[string]any)
+	if missingReasoning["reasoning_content"] != " " {
+		t.Fatalf("synthesized reasoning_content = %#v, want one space", missingReasoning["reasoning_content"])
+	}
+	preservedReasoning, _ := messages[3].(map[string]any)
+	if preservedReasoning["reasoning_content"] != "client reasoning" {
+		t.Fatalf("preserved reasoning_content = %#v, want client value", preservedReasoning["reasoning_content"])
+	}
+	if req.Messages[1].ExtraFields.Lookup("reasoning_content") != nil {
+		t.Fatal("ChatCompletion() mutated the caller's request")
+	}
+}
+
+func TestAdaptChatRequest_DoesNotPadWithoutTools(t *testing.T) {
+	req := &core.ChatRequest{
+		Messages: []core.Message{{
+			Role:      "assistant",
+			ToolCalls: []core.ToolCall{{ID: "call_1"}},
+		}},
+	}
+
+	adapted, err := adaptChatRequest(req)
+	if err != nil {
+		t.Fatalf("adaptChatRequest() error = %v", err)
+	}
+	if adapted != req {
+		t.Fatal("adaptChatRequest() copied an unchanged request")
+	}
+	if adapted.Messages[0].ExtraFields.Lookup("reasoning_content") != nil {
+		t.Fatal("reasoning_content should not be added when the request has no tools")
+	}
+}
+
 func TestResponses_TranslatesToChatCompletions(t *testing.T) {
 	var gotPath string
 	var gotBody map[string]any


### PR DESCRIPTION
## Summary

- add a single-space `reasoning_content` fallback to DeepSeek assistant tool-call messages when clients omit it
- preserve client-provided reasoning content and leave caller-owned requests unchanged
- keep the adaptation scoped to direct DeepSeek requests that include tools

## Testing

- full pre-commit suite, including race tests, lint, module checks, and the hot-path performance guard
- live DeepSeek V4 Pro validation: the reasoning-free replay returned 400 through raw passthrough and 200 through the patched OpenAI-compatible route

Fixes #676

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DeepSeek chat request handling when assistant messages include tool calls.
  * Preserved existing reasoning content and added compatible fallback content when it is missing.
  * Prevented unintended changes to the original request data.
  * Improved reporting of invalid request adaptation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->