### PR TITLE
docs: limit Mintlify indexing to public product documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: 1.26.5
+          go-version: 1.26.6
           cache: true
 
       - name: Run GoReleaser

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.26.5"
+  GO_VERSION: "1.26.6"
 
 # Restrict token permissions to minimum required
 permissions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage — run on the build host's native arch for speed, cross-compile for target
-FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.23 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine3.23 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/docs/.mintignore
+++ b/docs/.mintignore
@@ -6,7 +6,6 @@
 2026-07-21_bifrost_reproducible_benchmark/
 DEVELOPMENT.md
 TESTING_STRATEGY.md
-adr/
 dev/
 examples/
 install/

--- a/docs/.mintignore
+++ b/docs/.mintignore
@@ -1,0 +1,13 @@
+# Internal engineering material is kept in the repository but is not part of
+# the public product documentation, search index, or AI context.
+2026-03-23_benchmark_scripts/
+2026-04-09_CODEBASE_SNAPSHOT.md
+2026-06-25_aws_gateway_benchmark/
+2026-07-21_bifrost_reproducible_benchmark/
+DEVELOPMENT.md
+TESTING_STRATEGY.md
+adr/
+dev/
+examples/
+install/
+server.json

--- a/docs/about/faq.mdx
+++ b/docs/about/faq.mdx
@@ -49,11 +49,12 @@ The version is also printed on the first line of the startup log.
 Yes — set `GOMODEL_VERSION` before running the installer:
 
 ```bash
-GOMODEL_VERSION=v0.1.53 curl -fsSL https://gomodel.enterpilot.io/install.sh | sh
+GOMODEL_VERSION=vX.Y.Z curl -fsSL https://gomodel.enterpilot.io/install.sh | sh
 ```
 
 On Windows set `$env:GOMODEL_VERSION` first. With Docker, use a version tag
-(`enterpilot/gomodel:0.1.53`) instead of `latest`.
+(`enterpilot/gomodel:X.Y.Z`) instead of `latest`. Replace `X.Y.Z` with a
+[published GoModel release](https://github.com/ENTERPILOT/GoModel/releases).
 
 ## Is updating safe for my data?
 

--- a/docs/about/faq.mdx
+++ b/docs/about/faq.mdx
@@ -49,7 +49,7 @@ The version is also printed on the first line of the startup log.
 Yes — set `GOMODEL_VERSION` before running the installer:
 
 ```bash
-GOMODEL_VERSION=vX.Y.Z curl -fsSL https://gomodel.enterpilot.io/install.sh | sh
+curl -fsSL https://gomodel.enterpilot.io/install.sh | GOMODEL_VERSION=vX.Y.Z sh
 ```
 
 On Windows set `$env:GOMODEL_VERSION` first. With Docker, use a version tag

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -23,7 +23,7 @@
         "url": "full"
     },
     "seo": {
-        "indexing": "all",
+        "indexing": "navigable",
         "metatags": {
             "generator": "GoModel",
             "google-site-verification": "EhaMJtqC22YnPJetcCW5SCi3fdJF2BOai2WHjae8ymY",

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/enterpilot/gomodel
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/andybalholm/brotli v1.2.2


### PR DESCRIPTION
## Summary

- switch Mintlify SEO indexing from all repository pages to navigable documentation
- add .mintignore exclusions for internal engineering notes, raw benchmark artifacts, development material, installer sources, and MCP publication metadata
- keep ADRs published because public product documentation links to them
- replace the pinned FAQ release example with a release-independent placeholder and link to published releases
- pass GOMODEL_VERSION to the shell executing the installer

This keeps useful public docs and linked ADRs indexable while removing internal or duplicative repository material from Mintlify search, sitemap generation, and AI context.

## Validation

- Mintlify CLI validation passed
- repository pre-commit checks passed
- docs.json parsed successfully
- GitHub URL capitalization scan found no GOModel paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated version-pinning guidance with placeholder versions and links to published releases.
  * Improved documentation discoverability by limiting search indexing to navigable public pages.
  * Excluded internal engineering materials, benchmarks, development documentation, examples, installation files, and server configuration details from public documentation.
  * Refined public documentation processing to keep developer-only resources out of published content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->