### PR TITLE
docs(pro): document OpenTelemetry and quota templates; fix provider icons

### DIFF
--- a/docs/about/roadmap.mdx
+++ b/docs/about/roadmap.mdx
@@ -7,12 +7,12 @@ keywords: ["roadmap", "milestones", "upcoming features", "releases"]
 
 ## Commercial features
 
-- [ ] Intelligent routing
-- [ ] Context window compression
+- [x] Intelligent routing
+- [x] Context window compression
 - [ ] Cluster mode
-- [ ] OpenTelemetry (OTel) support
+- [x] OpenTelemetry (OTel) support
 - [ ] OAuth authentication
-- [ ] Single sign-on (SSO)
+- [x] Single sign-on (SSO)
 - [ ] Dashboard customization
 - [ ] LDAP integration
 - [ ] Secret manager integrations (Vault, AWS Secrets Manager/KMS, Azure Key Vault, GCP Secret Manager)

--- a/docs/pro.mdx
+++ b/docs/pro.mdx
@@ -177,9 +177,9 @@ OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 ```
 
 `OTEL_TRACES_EXPORTER` and `OTEL_METRICS_EXPORTER` accept `otlp` (default) or
-`none`. Traces emit `gen_ai.client.operation.duration` and
-`gen_ai.client.operation.time_to_first_chunk` histograms, plus a client span
-per non-streaming provider call carrying `gen_ai.operation.name`,
+`none`. Metrics record `gen_ai.client.operation.duration` and
+`gen_ai.client.operation.time_to_first_chunk` histograms. Traces record a
+client span per non-streaming provider call carrying `gen_ai.operation.name`,
 `gen_ai.provider.name`, `gen_ai.request.model`, and `gomodel.provider.name`.
 Streaming calls that error retroactively synthesize a span so failures are
 still traced. HTTP instrumentation excludes client and server addresses from

--- a/docs/pro.mdx
+++ b/docs/pro.mdx
@@ -3,7 +3,7 @@ title: "GoModel Pro"
 description: "GoModel Pro adds licensed prompt compression, intelligent routing, and OIDC SSO to the GoModel gateway."
 icon: "gem"
 noindex: true
-keywords: ["GoModel Pro", "prompt compression", "intelligent routing", "OIDC", "SSO", "license"]
+keywords: ["GoModel Pro", "prompt compression", "intelligent routing", "OIDC", "SSO", "OpenTelemetry", "quota templates", "license"]
 ---
 
 ## What Pro is
@@ -11,7 +11,7 @@ keywords: ["GoModel Pro", "prompt compression", "intelligent routing", "OIDC", "
 GoModel Pro is the commercial distribution of GoModel. It uses the same
 gateway, configuration, providers, dashboard, and APIs as open-source
 GoModel, with licensed extensions for prompt compression, intelligent routing,
-and OIDC single sign-on.
+OIDC single sign-on, OpenTelemetry export, and per-child quota templates.
 
 Without a valid license, the Pro binary starts as the open-source gateway and
 does not block traffic. An explicitly enabled SSO configuration is the
@@ -160,12 +160,52 @@ Successful logins, rejected policies, and logouts are recorded as sanitized
 audit events. Tokens, authorization codes, cookies, raw claims, and provider
 error details are not stored.
 
+## OpenTelemetry
+
+OpenTelemetry export instruments inbound HTTP requests and outbound provider
+calls, using the GenAI semantic conventions for the latter. It never records
+prompts, responses, credentials, or error messages.
+
+Enable it explicitly, then configure exporters, resource attributes, sampling,
+and propagation with the standard `OTEL_*` environment variables:
+
+```env
+PRO_OTEL_ENABLED=true
+OTEL_TRACES_EXPORTER=otlp
+OTEL_METRICS_EXPORTER=otlp
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+```
+
+`OTEL_TRACES_EXPORTER` and `OTEL_METRICS_EXPORTER` accept `otlp` (default) or
+`none`. Traces emit `gen_ai.client.operation.duration` and
+`gen_ai.client.operation.time_to_first_chunk` histograms, plus a client span
+per non-streaming provider call carrying `gen_ai.operation.name`,
+`gen_ai.provider.name`, `gen_ai.request.model`, and `gomodel.provider.name`.
+Streaming calls that error retroactively synthesize a span so failures are
+still traced. HTTP instrumentation excludes client and server addresses from
+span attributes and cardinality-sensitive attributes from metrics, and skips
+`/health`, `/health/ready`, `/metrics`, and `/debug/pprof*`.
+
+Like SSO, `PRO_OTEL_ENABLED=true` without the `opentelemetry` entitlement fails
+startup rather than starting unobserved.
+
+## Quota templates
+
+Per-child quota templates let one `user_path` budget definition apply
+independently to each direct child path instead of one shared subtree budget.
+Set `per_child: true` on a `budgets.user_paths` entry — see
+[Budgets](/features/budgets#dynamic-per-child-budgets) for YAML and
+environment-variable examples and matching rules. Without the
+`quota_templates` entitlement, `per_child: true` in configuration aborts
+startup and admin API writes are rejected with 403
+`quota_templates_not_entitled`.
+
 ## Licensing
 
 Pro features are granted by an offline Ed25519-signed token in
 `GOMODEL_PRO_LICENSE`. Validation requires no network access and works in
 air-gapped environments. A license can independently grant `compression`,
-`routing`, and `sso`.
+`routing`, `sso`, `opentelemetry`, and `quota_templates`.
 
 Use the separate `gomodel-pro` distribution and its documentation for
 installation, production build, and license-issuance instructions.

--- a/docs/providers/elevenlabs.mdx
+++ b/docs/providers/elevenlabs.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ElevenLabs"
 description: "Configure ElevenLabs in GoModel: voice_id vs named voices, supported audio formats, and speech-to-text timestamps."
-icon: "waveform-lines"
+icon: "audio-lines"
 keywords: ["ElevenLabs", "text-to-speech", "TTS", "speech-to-text", "STT", "voice", "provider setup"]
 ---
 

--- a/docs/providers/minimax.mdx
+++ b/docs/providers/minimax.mdx
@@ -1,7 +1,7 @@
 ---
 title: "MiniMax"
 description: "Configure MiniMax in GoModel: chat models, temperature handling, and native text-to-speech through the standard audio endpoint."
-icon: "waveform"
+icon: "audio-waveform"
 keywords: ["MiniMax", "text-to-speech", "TTS", "t2a_v2", "provider setup"]
 ---
 


### PR DESCRIPTION
## Summary
- `pro.mdx` documented compression, routing, and SSO but not the already-shipped `opentelemetry` and `quota_templates` license entitlements (`internal/telemetry`, `internal/license`, `internal/register` in gomodel-pro). Added an OpenTelemetry section (env vars, GenAI trace/metric attributes, privacy exclusions, fail-closed behavior) and a Quota templates section linking to the existing `features/budgets.mdx#dynamic-per-child-budgets` docs.
- `about/roadmap.mdx` still listed Intelligent routing, Context window compression, OpenTelemetry, and SSO as unshipped (`[ ]`) even though all four are live Pro features — flipped to `[x]`.
- `providers/minimax.mdx` and `providers/elevenlabs.mdx` used `icon: "waveform"` / `icon: "waveform-lines"`, which are not valid Lucide icon slugs (the site's configured icon library), so no sidebar icon rendered for either page. Fixed to valid slugs (`audio-waveform`, `audio-lines`).

## Test plan
- [x] `mint validate` (via pre-commit) passes on the changed docs
- [ ] Visually confirm MiniMax/ElevenLabs sidebar icons render after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Marked intelligent routing, context window compression, OpenTelemetry support, and SSO as completed roadmap features.
  * Expanded Pro documentation with OpenTelemetry export, configuration, instrumentation, filtering, quota templates, and entitlement guidance.
  * Updated licensing documentation for OpenTelemetry and quota templates.
  * Refreshed provider icons for ElevenLabs and MiniMax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->