### PR TITLE
feat(providers): support gemini-3.7-flash and grok-4.6

### DIFF
--- a/docs/providers/overview.mdx
+++ b/docs/providers/overview.mdx
@@ -43,7 +43,7 @@ support, not every individual model capability exposed by an upstream provider.
 | OpenAI | `OPENAI_API_KEY` | `gpt-5.5` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — |
 | Anthropic | `ANTHROPIC_API_KEY` | `claude-sonnet-4-20250514` | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | [Anthropic](/providers/anthropic) |
 | Cohere | `COHERE_API_KEY` | `command-a-plus-05-2026` | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | [Cohere](/providers/cohere) |
-| Google Gemini | `GEMINI_API_KEY` | `gemini-2.5-flash` | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | [Google Gemini](/providers/gemini) |
+| Google Gemini | `GEMINI_API_KEY` | `gemini-3.7-flash` | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | [Google Gemini](/providers/gemini) |
 | Google Vertex AI | `VERTEX_PROJECT` + `VERTEX_LOCATION` + GCP credentials | `google/gemini-2.5-flash` | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | [Google Vertex AI](/providers/vertex) |
 | DeepSeek | `DEEPSEEK_API_KEY` | `deepseek-v4-pro` | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | [DeepSeek](/providers/deepseek) |
 | Groq | `GROQ_API_KEY` | `llama-3.3-70b-versatile` | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | — |
@@ -53,7 +53,7 @@ support, not every individual model capability exposed by an upstream provider.
 | OpenRouter | `OPENROUTER_API_KEY` | `google/gemini-2.5-flash` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — |
 | Kilo AI | `KILO_API_KEY` (`KILO_BASE_URL` optional) | `anthropic/claude-sonnet-4.5` | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | — |
 | Z.ai | `ZAI_API_KEY` (`ZAI_BASE_URL` optional) | `glm-5.1` | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | — |
-| xAI (Grok) | `XAI_API_KEY` | `grok-4.5` | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | [xAI (Grok)](/providers/xai) |
+| xAI (Grok) | `XAI_API_KEY` | `grok-4.6` | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | [xAI (Grok)](/providers/xai) |
 | Alibaba Cloud Model Studio (Bailian) | `BAILIAN_API_KEY` (`BAILIAN_BASE_URL` optional) | `qwen3-max` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | [Alibaba Cloud Model Studio](/providers/bailian) |
 | MiniMax | `MINIMAX_API_KEY` (`MINIMAX_BASE_URL` optional) | `MiniMax-M3` | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | [MiniMax](/providers/minimax) |
 | Xiaomi MiMo | `XIAOMI_API_KEY` (`XIAOMI_BASE_URL` optional) | `mimo-v2.5-pro` | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | [Xiaomi MiMo](/providers/xiaomi) |

--- a/docs/providers/xai.mdx
+++ b/docs/providers/xai.mdx
@@ -42,7 +42,7 @@ and passes through unchanged.
 | Client sends | xAI receives |
 | ------------ | ------------ |
 | `none` / `low` / `medium` / `high` | unchanged |
-| `xhigh` / `max` | `xhigh` on `grok-4.6` and later, and on the multi-agent Grok family (where it selects the agent count); `high` on older models |
+| `xhigh` / `max` | `xhigh` on `grok-4.6` and later, and on the multi-agent Grok family (where it selects the agent count); `high` on older models, including the experimental `grok-4.20` family |
 | anything else | passed through for xAI to judge |
 
 Models without reasoning support reject the field upstream; omit `reasoning`

--- a/docs/providers/xai.mdx
+++ b/docs/providers/xai.mdx
@@ -6,7 +6,7 @@ keywords: ["xAI", "Grok", "reasoning effort", "prompt cache", "provider setup"]
 ---
 
 xAI's API is OpenAI-compatible, including a native Responses API. Models such
-as `grok-4.5` are discovered automatically from xAI's `/models` endpoint — no
+as `grok-4.6` are discovered automatically from xAI's `/models` endpoint — no
 configuration beyond the API key is needed.
 
 ## Configure
@@ -33,7 +33,7 @@ providers:
 
 ## Reasoning effort mapping
 
-Grok reasoning models (e.g. `grok-4.5`, defaulting to `high`) accept
+Grok reasoning models (e.g. `grok-4.6`, defaulting to `high`) accept
 `reasoning_effort` as a top-level string on Chat Completions. GoModel rewrites
 the OpenAI-shaped `"reasoning": {"effort": "..."}` into that flat field — no
 client change required. On the Responses API the nested shape is xAI-native
@@ -42,7 +42,7 @@ and passes through unchanged.
 | Client sends | xAI receives |
 | ------------ | ------------ |
 | `none` / `low` / `medium` / `high` | unchanged |
-| `xhigh` / `max` | `high` (`xhigh` on the multi-agent Grok family, where it selects the agent count) |
+| `xhigh` / `max` | `xhigh` on `grok-4.6` and later, and on the multi-agent Grok family (where it selects the agent count); `high` on older models |
 | anything else | passed through for xAI to judge |
 
 Models without reasoning support reject the field upstream; omit `reasoning`

--- a/internal/providers/gemini/native.go
+++ b/internal/providers/gemini/native.go
@@ -562,7 +562,14 @@ func copyResponseFormat(raw json.RawMessage, cfg map[string]any) {
 		cfg["responseMimeType"] = "application/json"
 		if schemaObj, ok := responseFormat["json_schema"].(map[string]any); ok {
 			if schema, ok := schemaObj["schema"]; ok {
-				cfg["responseSchema"] = schema
+				// responseJsonSchema accepts standard JSON Schema (like the
+				// tools' parametersJsonSchema), while responseSchema is an
+				// OpenAPI subset that rejects common keywords such as
+				// additionalProperties, which OpenAI strict schemas require.
+				if schemaMap, isMap := schema.(map[string]any); isMap {
+					delete(schemaMap, "$schema")
+				}
+				cfg["responseJsonSchema"] = schema
 			}
 		}
 	}

--- a/internal/providers/gemini/native_schema_test.go
+++ b/internal/providers/gemini/native_schema_test.go
@@ -191,3 +191,50 @@ func TestGeminiToolsFromOpenAIRejectsUnsupportedToolShapes(t *testing.T) {
 		})
 	}
 }
+
+func TestCopyResponseFormatJSONSchemaUsesResponseJsonSchema(t *testing.T) {
+	raw := []byte(`{
+		"type": "json_schema",
+		"json_schema": {
+			"name": "planets",
+			"schema": {
+				"$schema": "https://json-schema.org/draft/2020-12/schema",
+				"type": "object",
+				"properties": {"planets": {"type": "array", "items": {"type": "string"}}},
+				"required": ["planets"],
+				"additionalProperties": false
+			}
+		}
+	}`)
+
+	cfg := map[string]any{}
+	copyResponseFormat(raw, cfg)
+
+	if got := cfg["responseMimeType"]; got != "application/json" {
+		t.Fatalf("responseMimeType = %#v, want application/json", got)
+	}
+	if _, ok := cfg["responseSchema"]; ok {
+		t.Fatal("responseSchema should not be set; responseJsonSchema accepts full JSON Schema")
+	}
+	schema, ok := cfg["responseJsonSchema"].(map[string]any)
+	if !ok {
+		t.Fatalf("responseJsonSchema = %#v, want object", cfg["responseJsonSchema"])
+	}
+	if _, ok := schema["$schema"]; ok {
+		t.Fatal("$schema should be stripped")
+	}
+	if got := schema["additionalProperties"]; got != false {
+		t.Fatalf("additionalProperties = %#v, want false (preserved)", got)
+	}
+}
+
+func TestCopyResponseFormatJSONObject(t *testing.T) {
+	cfg := map[string]any{}
+	copyResponseFormat([]byte(`{"type": "json_object"}`), cfg)
+	if got := cfg["responseMimeType"]; got != "application/json" {
+		t.Fatalf("responseMimeType = %#v, want application/json", got)
+	}
+	if _, ok := cfg["responseJsonSchema"]; ok {
+		t.Fatal("responseJsonSchema should not be set for json_object")
+	}
+}

--- a/internal/providers/xai/xai.go
+++ b/internal/providers/xai/xai.go
@@ -91,21 +91,42 @@ func adaptChatRequest(req *core.ChatRequest) (*core.ChatRequest, error) {
 }
 
 // normalizeReasoningEffort downgrades GoModel effort levels xAI does not
-// accept to their nearest equivalent. Only the multi-agent Grok family
-// accepts "xhigh" (it selects the agent count); every other model tops out
+// accept to their nearest equivalent. The multi-agent Grok family accepts
+// "xhigh" (it selects the agent count), and grok-4.6 and later frontier
+// models document it as a regular top effort level; older models top out
 // at "high". Unknown values pass through for the upstream to judge. See
 // docs/providers/xai.mdx for the user-facing table.
 func normalizeReasoningEffort(model, effort string) string {
 	normalized := strings.ToLower(strings.TrimSpace(effort))
 	switch normalized {
 	case "xhigh", "max":
-		if strings.Contains(strings.ToLower(model), "multi-agent") {
+		if supportsXHighEffort(model) {
 			return "xhigh"
 		}
 		return "high"
 	default:
 		return normalized
 	}
+}
+
+// supportsXHighEffort reports whether the model documents the "xhigh"
+// reasoning effort level: the multi-agent family and grok-4.6+.
+func supportsXHighEffort(model string) bool {
+	model = strings.ToLower(model)
+	if strings.Contains(model, "multi-agent") {
+		return true
+	}
+	rest, ok := strings.CutPrefix(model, "grok-4.")
+	if !ok {
+		return false
+	}
+	digits := rest
+	if i := strings.IndexFunc(rest, func(r rune) bool { return r < '0' || r > '9' }); i >= 0 {
+		digits = rest[:i]
+	}
+	// Two-or-more-digit minors (4.20 family) are older experimental
+	// releases, not successors of 4.6.
+	return len(digits) == 1 && digits >= "6"
 }
 
 // SetBaseURL allows configuring a custom base URL for the provider

--- a/internal/providers/xai/xai.go
+++ b/internal/providers/xai/xai.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/goccy/go-json"
@@ -110,7 +111,9 @@ func normalizeReasoningEffort(model, effort string) string {
 }
 
 // supportsXHighEffort reports whether the model documents the "xhigh"
-// reasoning effort level: the multi-agent family and grok-4.6+.
+// reasoning effort level: the multi-agent family and grok-4.6+. The
+// grok-4.20 family is excluded: it predates 4.6 as an experimental
+// release, not a successor.
 func supportsXHighEffort(model string) bool {
 	model = strings.ToLower(model)
 	if strings.Contains(model, "multi-agent") {
@@ -124,9 +127,11 @@ func supportsXHighEffort(model string) bool {
 	if i := strings.IndexFunc(rest, func(r rune) bool { return r < '0' || r > '9' }); i >= 0 {
 		digits = rest[:i]
 	}
-	// Two-or-more-digit minors (4.20 family) are older experimental
-	// releases, not successors of 4.6.
-	return len(digits) == 1 && digits >= "6"
+	minor, err := strconv.Atoi(digits)
+	if err != nil {
+		return false
+	}
+	return minor >= 6 && minor != 20
 }
 
 // SetBaseURL allows configuring a custom base URL for the provider

--- a/internal/providers/xai/xai.go
+++ b/internal/providers/xai/xai.go
@@ -111,9 +111,9 @@ func normalizeReasoningEffort(model, effort string) string {
 }
 
 // supportsXHighEffort reports whether the model documents the "xhigh"
-// reasoning effort level: the multi-agent family and grok-4.6+. The
-// grok-4.20 family is excluded: it predates 4.6 as an experimental
-// release, not a successor.
+// reasoning effort level: the multi-agent family and grok-4.6+.
+// Non-multi-agent grok-4.20 models are excluded: the 4.20 family
+// predates 4.6 as an experimental release, not a successor.
 func supportsXHighEffort(model string) bool {
 	model = strings.ToLower(model)
 	if strings.Contains(model, "multi-agent") {

--- a/internal/providers/xai/xai_test.go
+++ b/internal/providers/xai/xai_test.go
@@ -1005,6 +1005,13 @@ func TestNormalizeReasoningEffort(t *testing.T) {
 		{"grok-4.20-multi-agent-0309", "xhigh", "xhigh"},
 		{"grok-4.20-multi-agent-0309", "max", "xhigh"},
 		{"grok-4.20-multi-agent-0309", "low", "low"},
+		{"grok-4.6", "xhigh", "xhigh"},
+		{"grok-4.6", "max", "xhigh"},
+		{"grok-4.6", "high", "high"},
+		{"grok-4.6-latest", "xhigh", "xhigh"},
+		{"grok-4.7", "xhigh", "xhigh"},
+		{"grok-4.20-0309-reasoning", "xhigh", "high"},
+		{"grok-4.3", "xhigh", "high"},
 		{"grok-4.5", "custom-level", "custom-level"},
 	}
 	for _, tt := range tests {

--- a/internal/providers/xai/xai_test.go
+++ b/internal/providers/xai/xai_test.go
@@ -1011,6 +1011,7 @@ func TestNormalizeReasoningEffort(t *testing.T) {
 		{"grok-4.6-latest", "xhigh", "xhigh"},
 		{"grok-4.7", "xhigh", "xhigh"},
 		{"grok-4.10", "xhigh", "xhigh"},
+		{"grok-4.foo", "xhigh", "high"},
 		{"grok-4.20-0309-reasoning", "xhigh", "high"},
 		{"grok-4.20-0309-reasoning", "max", "high"},
 		{"grok-4.3", "xhigh", "high"},

--- a/internal/providers/xai/xai_test.go
+++ b/internal/providers/xai/xai_test.go
@@ -1010,7 +1010,9 @@ func TestNormalizeReasoningEffort(t *testing.T) {
 		{"grok-4.6", "high", "high"},
 		{"grok-4.6-latest", "xhigh", "xhigh"},
 		{"grok-4.7", "xhigh", "xhigh"},
+		{"grok-4.10", "xhigh", "xhigh"},
 		{"grok-4.20-0309-reasoning", "xhigh", "high"},
+		{"grok-4.20-0309-reasoning", "max", "high"},
 		{"grok-4.3", "xhigh", "high"},
 		{"grok-4.5", "custom-level", "custom-level"},
 	}

--- a/tests/contract/testdata/gemini/models.json
+++ b/tests/contract/testdata/gemini/models.json
@@ -318,6 +318,12 @@
       "object": "model",
       "owned_by": "google",
       "display_name": "Lyria Realtime Experimental"
+    },
+    {
+      "id": "models/gemini-3.7-flash",
+      "object": "model",
+      "owned_by": "google",
+      "display_name": "Gemini 3.7 Flash"
     }
   ]
 }

--- a/tests/contract/testdata/golden/gemini/models.golden.json
+++ b/tests/contract/testdata/golden/gemini/models.golden.json
@@ -185,6 +185,12 @@
       "id": "gemini-2.5-flash-native-audio-preview-12-2025",
       "object": "model",
       "owned_by": "google"
+    },
+    {
+      "created": 0,
+      "id": "gemini-3.7-flash",
+      "object": "model",
+      "owned_by": "google"
     }
   ],
   "object": "list"

--- a/tests/contract/testdata/golden/xai/models.golden.json
+++ b/tests/contract/testdata/golden/xai/models.golden.json
@@ -65,6 +65,12 @@
       "id": "grok-4.5",
       "object": "model",
       "owned_by": "xai"
+    },
+    {
+      "created": 0,
+      "id": "grok-4.6",
+      "object": "model",
+      "owned_by": "xai"
     }
   ],
   "object": "list"

--- a/tests/contract/testdata/xai/models.json
+++ b/tests/contract/testdata/xai/models.json
@@ -65,6 +65,12 @@
       "created": 1783468800,
       "object": "model",
       "owned_by": "xai"
+    },
+    {
+      "id": "grok-4.6",
+      "created": 1786579200,
+      "object": "model",
+      "owned_by": "xai"
     }
   ],
   "object": "list"


### PR DESCRIPTION
## Summary

Verifies the newly released `gemini-3.7-flash` (2026-08-13) and `grok-4.6` (2026-08-12) work through GoModel and closes the two adapter gaps found while testing them live. Both models are auto-discovered from upstream `/models`, so routing itself needed no change.

- **xAI `xhigh` reasoning effort**: grok-4.6 documents `reasoning_effort: xhigh` as a regular top effort level, but the adapter downgraded `xhigh`/`max` to `high` for everything except the multi-agent family. `xhigh`/`max` now pass through as `xhigh` for grok-4.6 and later single-digit minors; the grok-4.20 experimental family and older models keep the downgrade to `high`.
- **Gemini strict structured output**: `response_format: json_schema` was mapped to Gemini's `responseSchema`, an OpenAPI subset that rejects `additionalProperties` — which every OpenAI strict-mode schema includes, so strict structured output always 400'd. Now mapped to `responseJsonSchema` (full JSON Schema, `$schema` stripped), mirroring the tools path's `parametersJsonSchema`.
- Adds both models to the xAI/Gemini contract fixtures and goldens; updates `docs/providers/xai.mdx` (effort mapping table) and the overview's example models.

## User-visible impact

- `reasoning: {effort: "xhigh"}` (or `max`) on grok-4.6 now reaches xAI as `xhigh` instead of being silently reduced to `high`.
- OpenAI strict-mode `json_schema` structured output works on Gemini-translated chat/`/v1/responses` requests instead of returning a Gemini 400.

## Live verification (real Gemini + xAI APIs)

Both models green across `/v1/chat/completions`, `/v1/responses`, and `/v1/messages`, streaming and non-streaming: tool calls (incl. streamed assembly), vision via base64 image, reasoning-token usage, strict structured output (after the fix), Anthropic-dialect event sequences, and per-request cost accounting once pricing metadata is present.

Note: the ai-model-list registry hasn't published since 2026-07-30, so neither model has catalog pricing yet (`total_cost` stays null). The documented `providers.<name>.models` metadata workaround was verified to fill the gap; the durable fix is a registry refresh in that repo.

## Testing

- `go test ./...` and `go test -tags contract ./tests/contract/` green; new unit tests for the effort gate and `copyResponseFormat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Gemini 3.7 Flash and Grok 4.6 model listings.
  - Improved xAI reasoning-effort handling for newer Grok models, including multi-agent variants.
  - Enhanced Gemini structured-output support for full JSON Schema responses.

- **Bug Fixes**
  - Corrected Gemini JSON Schema formatting while preserving schema properties.
  - Ensured `json_object` responses use the appropriate JSON response format.

- **Documentation**
  - Updated provider documentation with current model names and reasoning-effort behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->