### PR TITLE
perf(responses): move response snapshot writes off the request path

### DIFF
--- a/docs/advanced/responses-api.mdx
+++ b/docs/advanced/responses-api.mdx
@@ -33,7 +33,10 @@ providers, see [Responses compatibility](/advanced/responses-compatibility).
 ## Stored responses
 
 For non-streaming `POST /v1/responses` calls, GoModel stores the normalized
-response body and the normalized input items from the request.
+response body and the normalized input items from the request. The snapshot is
+written in the background after the response is returned, so storage latency
+never delays the client. A snapshot write that fails is logged and counted in
+the `gomodel_response_snapshot_store_failures_total` metric.
 
 This enables:
 

--- a/docs/advanced/responses-api.mdx
+++ b/docs/advanced/responses-api.mdx
@@ -35,8 +35,11 @@ providers, see [Responses compatibility](/advanced/responses-compatibility).
 For non-streaming `POST /v1/responses` calls, GoModel stores the normalized
 response body and the normalized input items from the request. The snapshot is
 written in the background after the response is returned, so storage latency
-never delays the client. A snapshot write that fails is logged and counted in
-the `gomodel_response_snapshot_store_failures_total` metric.
+never delays the client. A `GET /v1/responses/{id}` issued immediately after
+the `POST` can arrive before the snapshot is stored; graceful shutdown waits
+for pending snapshot writes, but a hard process exit can lose one that has not
+finished. A snapshot write that fails is logged and counted in the
+`gomodel_response_snapshot_store_failures_total` metric.
 
 This enables:
 

--- a/internal/responsestore/store.go
+++ b/internal/responsestore/store.go
@@ -46,6 +46,12 @@ func cloneResponse(src *StoredResponse) (*StoredResponse, error) {
 	return dst, err
 }
 
+// Clone deep-copies a snapshot. Callers that hand a snapshot to another
+// goroutine use it to detach from later mutations of the source response.
+func Clone(src *StoredResponse) (*StoredResponse, error) {
+	return cloneResponse(src)
+}
+
 // cloneResponseWithSize deep-copies a snapshot and reports its serialized size,
 // which the memory store uses for byte-budget accounting.
 func cloneResponseWithSize(src *StoredResponse) (*StoredResponse, int64, error) {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -240,15 +240,12 @@ func (h *Handler) currentResponseStore() responsestore.Store {
 	return h.responseStore
 }
 
-// drainSnapshotWrites waits for in-flight background response snapshot writes.
-// Called during server shutdown before the response store closes.
+// drainSnapshotWrites stops new background response snapshot writes and waits
+// for in-flight ones. Called during server shutdown before the response store
+// closes. It creates the (lazily initialized) inference service if needed so
+// the drain gate is set even when a request races shutdown into first use.
 func (h *Handler) drainSnapshotWrites() {
-	h.storesMu.RLock()
-	svc := h.translatedSvc
-	h.storesMu.RUnlock()
-	if svc != nil {
-		svc.drainSnapshotWrites()
-	}
+	h.translatedInference().drainSnapshotWrites()
 }
 
 func (h *Handler) realtime() *realtimeService {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -240,6 +240,17 @@ func (h *Handler) currentResponseStore() responsestore.Store {
 	return h.responseStore
 }
 
+// drainSnapshotWrites waits for in-flight background response snapshot writes.
+// Called during server shutdown before the response store closes.
+func (h *Handler) drainSnapshotWrites() {
+	h.storesMu.RLock()
+	svc := h.translatedSvc
+	h.storesMu.RUnlock()
+	if svc != nil {
+		svc.drainSnapshotWrites()
+	}
+}
+
 func (h *Handler) realtime() *realtimeService {
 	return &realtimeService{
 		provider:        h.provider,

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -5183,11 +5183,25 @@ func TestResponsesLifecycle_SnapshotWriteDoesNotBlockResponse(t *testing.T) {
 	}
 	srv := New(provider, &Config{ResponseStore: store})
 
+	// Release the blocked store write on every exit path so a hung request
+	// goroutine cannot outlive the test.
+	releaseOnce := sync.OnceFunc(func() { close(store.release) })
+	t.Cleanup(releaseOnce)
+
 	// The store write is blocked, yet the request must complete.
 	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-5-mini","input":"hello"}`))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
-	srv.ServeHTTP(rec, req)
+	served := make(chan struct{})
+	go func() {
+		defer close(served)
+		srv.ServeHTTP(rec, req)
+	}()
+	select {
+	case <-served:
+	case <-time.After(10 * time.Second):
+		t.Fatal("request blocked on the snapshot write; snapshot persistence must be asynchronous")
+	}
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200 (%s)", rec.Code, rec.Body.String())
 	}
@@ -5196,13 +5210,49 @@ func TestResponsesLifecycle_SnapshotWriteDoesNotBlockResponse(t *testing.T) {
 	}
 
 	// Releasing the write and draining must leave the snapshot stored.
-	close(store.release)
+	releaseOnce()
 	srv.handler.drainSnapshotWrites()
 	if id := <-store.created; id != "resp_async_1" {
 		t.Fatalf("created id = %q, want resp_async_1", id)
 	}
 	if _, err := inner.Get(context.Background(), "resp_async_1"); err != nil {
 		t.Fatalf("store.Get() after drain error = %v", err)
+	}
+}
+
+func TestResponsesLifecycle_SnapshotWriteSkippedAfterDrain(t *testing.T) {
+	observability.ResetMetrics()
+	store := responsestore.NewMemoryStore(responsestore.WithUnboundedRetention())
+	provider := &mockProvider{
+		supportedModels: []string{"gpt-5-mini"},
+		providerTypes: map[string]string{
+			"gpt-5-mini": "mock",
+		},
+		responsesResponse: &core.ResponsesResponse{
+			ID:     "resp_after_drain_1",
+			Object: "response",
+			Model:  "gpt-5-mini",
+			Status: "completed",
+		},
+	}
+	srv := New(provider, &Config{ResponseStore: store})
+	srv.handler.drainSnapshotWrites()
+
+	// A handler outliving the shutdown drain must still answer the client,
+	// but its snapshot write is skipped and recorded as a store failure.
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-5-mini","input":"hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+	if _, err := store.Get(context.Background(), "resp_after_drain_1"); !errors.Is(err, responsestore.ErrNotFound) {
+		t.Fatalf("store.Get() error = %v, want ErrNotFound", err)
+	}
+	counter := observability.ResponseSnapshotStoreFailures.WithLabelValues("mock", "", "store")
+	if got := testutil.ToFloat64(counter); got != 1 {
+		t.Fatalf("snapshot store failures = %v, want 1", got)
 	}
 }
 

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -4990,6 +4990,7 @@ func TestResponsesLifecycle_RetrievesStoredResponseAndInputItems(t *testing.T) {
 	if createRec.Code != http.StatusOK {
 		t.Fatalf("create status = %d, want 200 (%s)", createRec.Code, createRec.Body.String())
 	}
+	srv.handler.drainSnapshotWrites()
 
 	getReq := httptest.NewRequest(http.MethodGet, "/v1/responses/resp_store_1", nil)
 	getRec := httptest.NewRecorder()
@@ -5061,6 +5062,7 @@ func TestResponsesLifecycle_StoresConcreteProviderName(t *testing.T) {
 	if createRec.Code != http.StatusOK {
 		t.Fatalf("create status = %d, want 200 (%s)", createRec.Code, createRec.Body.String())
 	}
+	srv.handler.drainSnapshotWrites()
 
 	stored, err := store.Get(context.Background(), "resp_provider_name_1")
 	if err != nil {
@@ -5097,6 +5099,7 @@ func TestResponsesLifecycle_StoreFalseSkipsLocalSnapshot(t *testing.T) {
 	if createRec.Code != http.StatusOK {
 		t.Fatalf("create status = %d, want 200 (%s)", createRec.Code, createRec.Body.String())
 	}
+	srv.handler.drainSnapshotWrites()
 
 	if _, err := store.Get(context.Background(), "resp_store_false_1"); !errors.Is(err, responsestore.ErrNotFound) {
 		t.Fatalf("store.Get() error = %v, want ErrNotFound", err)
@@ -5134,10 +5137,72 @@ func TestResponsesLifecycle_ReturnsSuccessWhenSnapshotStoreFails(t *testing.T) {
 	if resp.ID != "resp_store_failure_1" {
 		t.Fatalf("response id = %q, want resp_store_failure_1", resp.ID)
 	}
+	srv.handler.drainSnapshotWrites()
 
 	counter := observability.ResponseSnapshotStoreFailures.WithLabelValues("mock", "", "store")
 	if got := testutil.ToFloat64(counter); got != 1 {
 		t.Fatalf("snapshot store failures = %v, want 1", got)
+	}
+}
+
+// blockingResponseStore delays Create until released, to prove the request
+// path does not wait on snapshot persistence.
+type blockingResponseStore struct {
+	responsestore.Store
+	release chan struct{}
+	created chan string
+}
+
+func (s *blockingResponseStore) Create(ctx context.Context, r *responsestore.StoredResponse) error {
+	<-s.release
+	if err := s.Store.Create(ctx, r); err != nil {
+		return err
+	}
+	s.created <- r.Response.ID
+	return nil
+}
+
+func TestResponsesLifecycle_SnapshotWriteDoesNotBlockResponse(t *testing.T) {
+	inner := responsestore.NewMemoryStore(responsestore.WithUnboundedRetention())
+	store := &blockingResponseStore{
+		Store:   inner,
+		release: make(chan struct{}),
+		created: make(chan string, 1),
+	}
+	provider := &mockProvider{
+		supportedModels: []string{"gpt-5-mini"},
+		providerTypes: map[string]string{
+			"gpt-5-mini": "mock",
+		},
+		responsesResponse: &core.ResponsesResponse{
+			ID:     "resp_async_1",
+			Object: "response",
+			Model:  "gpt-5-mini",
+			Status: "completed",
+		},
+	}
+	srv := New(provider, &Config{ResponseStore: store})
+
+	// The store write is blocked, yet the request must complete.
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-5-mini","input":"hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+	if _, err := inner.Get(context.Background(), "resp_async_1"); !errors.Is(err, responsestore.ErrNotFound) {
+		t.Fatalf("snapshot stored before release, Get() error = %v, want ErrNotFound", err)
+	}
+
+	// Releasing the write and draining must leave the snapshot stored.
+	close(store.release)
+	srv.handler.drainSnapshotWrites()
+	if id := <-store.created; id != "resp_async_1" {
+		t.Fatalf("created id = %q, want resp_async_1", id)
+	}
+	if _, err := inner.Get(context.Background(), "resp_async_1"); err != nil {
+		t.Fatalf("store.Get() after drain error = %v", err)
 	}
 }
 
@@ -5238,6 +5303,7 @@ func TestResponsesLifecycle_DeleteStoredResponseWithoutNativeSupport(t *testing.
 	if createRec.Code != http.StatusOK {
 		t.Fatalf("create status = %d, want 200 (%s)", createRec.Code, createRec.Body.String())
 	}
+	srv.handler.drainSnapshotWrites()
 
 	deleteReq := httptest.NewRequest(http.MethodDelete, "/v1/responses/resp_delete_1", nil)
 	deleteRec := httptest.NewRecorder()

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -559,8 +559,8 @@ func (s *Server) StartWithListener(ctx context.Context, listener net.Listener) e
 
 // Shutdown releases server resources. The HTTP server itself is stopped by
 // cancelling the context passed to Start; this method drains any in-flight
-// response cache writes, closes the cache store, and closes the response and
-// conversation stores.
+// response cache and snapshot writes, closes the cache store, and closes the
+// response and conversation stores.
 func (s *Server) Shutdown(_ context.Context) error {
 	var firstErr error
 	if s.responseCacheMiddleware != nil {
@@ -568,6 +568,7 @@ func (s *Server) Shutdown(_ context.Context) error {
 			firstErr = err
 		}
 	}
+	s.handler.drainSnapshotWrites()
 	if s.responseStore != nil {
 		if err := s.responseStore.Close(); err != nil {
 			if firstErr == nil {

--- a/internal/server/passthrough_support_test.go
+++ b/internal/server/passthrough_support_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"net/http"
+	"slices"
 	"testing"
 
 	"github.com/enterpilot/gomodel/internal/core"
@@ -32,13 +33,7 @@ func TestBuildPassthroughHeadersSkipsConfiguredUserPathHeader(t *testing.T) {
 // and the default handler must not reject those requests before contacting the
 // upstream. Caught by greptile P1 on PR #701.
 func TestDefaultEnabledPassthroughProvidersIncludesHetzner(t *testing.T) {
-	found := false
-	for _, p := range defaultEnabledPassthroughProviders {
-		if p == "hetzner" {
-			found = true
-			break
-		}
-	}
+	found := slices.Contains(defaultEnabledPassthroughProviders, "hetzner")
 	if !found {
 		t.Fatalf("defaultEnabledPassthroughProviders = %v, want hetzner included", defaultEnabledPassthroughProviders)
 	}

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -50,8 +50,12 @@ type translatedInferenceService struct {
 	conversationStore        conversationstore.Store
 	conversationStoreMu      sync.RWMutex
 	// snapshotWrites tracks background response snapshot writes so shutdown
-	// can drain them before closing the response store.
-	snapshotWrites sync.WaitGroup
+	// can drain them before closing the response store. snapshotMu gates new
+	// writes against the drain: a handler that outlives the HTTP drain window
+	// must not register a write after drainSnapshotWrites has begun waiting.
+	snapshotWrites   sync.WaitGroup
+	snapshotMu       sync.RWMutex
+	snapshotDraining bool
 
 	orchestrator *gateway.InferenceOrchestrator
 
@@ -403,13 +407,32 @@ func (s *translatedInferenceService) storeResponseSnapshotAsync(ctx context.Cont
 	}
 
 	writeCtx := context.WithoutCancel(ctx)
-	s.snapshotWrites.Go(func() {
+	scheduled := s.goSnapshotWrite(func() {
 		writeCtx, cancel := context.WithTimeout(writeCtx, snapshotWriteTimeout)
 		defer cancel()
 		if err := writeResponseSnapshot(writeCtx, store, stored); err != nil {
 			s.recordResponseSnapshotStoreFailure(workflow, stored.Response, providerType, providerName, requestID, err)
 		}
 	})
+	if !scheduled {
+		s.recordResponseSnapshotStoreFailure(workflow, stored.Response, providerType, providerName, requestID,
+			errors.New("server shutting down, snapshot write skipped"))
+	}
+}
+
+// goSnapshotWrite runs fn as a tracked background snapshot write. It reports
+// false without running fn when draining has begun: registering a write after
+// drainSnapshotWrites starts waiting would race the WaitGroup and could touch
+// a store that shutdown already closed. The read lock is held across the
+// WaitGroup registration so the drain cannot observe it as untracked.
+func (s *translatedInferenceService) goSnapshotWrite(fn func()) bool {
+	s.snapshotMu.RLock()
+	defer s.snapshotMu.RUnlock()
+	if s.snapshotDraining {
+		return false
+	}
+	s.snapshotWrites.Go(fn)
+	return true
 }
 
 // writeResponseSnapshot upserts one snapshot: Create first, falling back to
@@ -425,10 +448,14 @@ func writeResponseSnapshot(ctx context.Context, store responsestore.Store, store
 	return nil
 }
 
-// drainSnapshotWrites blocks until every in-flight background snapshot write
-// finishes. The server calls it during shutdown, before the response store
-// closes.
+// drainSnapshotWrites stops accepting new background snapshot writes and
+// blocks until every in-flight one finishes. The server calls it during
+// shutdown, before the response store closes; writes attempted afterwards are
+// skipped and recorded as store failures.
 func (s *translatedInferenceService) drainSnapshotWrites() {
+	s.snapshotMu.Lock()
+	s.snapshotDraining = true
+	s.snapshotMu.Unlock()
 	s.snapshotWrites.Wait()
 }
 

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -3,12 +3,14 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/goccy/go-json"
 
@@ -47,6 +49,9 @@ type translatedInferenceService struct {
 	responseStoreMu          sync.RWMutex
 	conversationStore        conversationstore.Store
 	conversationStoreMu      sync.RWMutex
+	// snapshotWrites tracks background response snapshot writes so shutdown
+	// can drain them before closing the response store.
+	snapshotWrites sync.WaitGroup
 
 	orchestrator *gateway.InferenceOrchestrator
 
@@ -354,23 +359,35 @@ func (s *translatedInferenceService) dispatchResponses(c *echo.Context, req *cor
 			))
 		}
 	}
-	if err := s.storeResponseSnapshot(ctx, workflow, req, result.Response, result.Meta.ProviderType, result.Meta.ProviderName, requestID); err != nil {
-		s.recordResponseSnapshotStoreFailure(workflow, result.Response, result.Meta.ProviderType, result.Meta.ProviderName, requestID, err)
-	}
+	s.storeResponseSnapshotAsync(ctx, workflow, req, result.Response, result.Meta.ProviderType, result.Meta.ProviderName, requestID)
 
 	return c.JSON(http.StatusOK, result.Response)
 }
 
-func (s *translatedInferenceService) storeResponseSnapshot(ctx context.Context, workflow *core.Workflow, req *core.ResponsesRequest, resp *core.ResponsesResponse, providerType, providerName, requestID string) error {
+// snapshotWriteTimeout bounds one background snapshot write. It covers the
+// Create plus the Update fallback, each of which can wait up to SQLite's 5s
+// busy timeout on the shared connection.
+const snapshotWriteTimeout = 15 * time.Second
+
+// storeResponseSnapshotAsync persists the response snapshot off the request
+// path so the client never waits on storage. A failed write is already
+// non-fatal on the synchronous path (metric plus warning), so deferring it
+// only changes when the failure is observed. The snapshot is deep-copied
+// before the goroutine starts: the background write must not share memory
+// with the response the handler is concurrently serializing to the client.
+// The write context is detached from request cancellation, which ends the
+// moment the response is sent. drainSnapshotWrites waits for in-flight
+// writes at shutdown.
+func (s *translatedInferenceService) storeResponseSnapshotAsync(ctx context.Context, workflow *core.Workflow, req *core.ResponsesRequest, resp *core.ResponsesResponse, providerType, providerName, requestID string) {
 	store := s.currentResponseStore()
 	if store == nil || resp == nil || resp.ID == "" {
-		return nil
+		return
 	}
 	if req != nil && req.Store != nil && !*req.Store {
-		return nil
+		return
 	}
 
-	stored := &responsestore.StoredResponse{
+	stored, err := responsestore.Clone(&responsestore.StoredResponse{
 		Response:           resp,
 		InputItems:         normalizedResponseInputItems(resp.ID, req),
 		Provider:           strings.TrimSpace(providerType),
@@ -379,15 +396,40 @@ func (s *translatedInferenceService) storeResponseSnapshot(ctx context.Context, 
 		RequestID:          requestID,
 		UserPath:           core.UserPathFromContext(ctx),
 		WorkflowVersionID:  workflow.WorkflowVersionID(),
+	})
+	if err != nil {
+		s.recordResponseSnapshotStoreFailure(workflow, resp, providerType, providerName, requestID, err)
+		return
 	}
+
+	writeCtx := context.WithoutCancel(ctx)
+	s.snapshotWrites.Go(func() {
+		writeCtx, cancel := context.WithTimeout(writeCtx, snapshotWriteTimeout)
+		defer cancel()
+		if err := writeResponseSnapshot(writeCtx, store, stored); err != nil {
+			s.recordResponseSnapshotStoreFailure(workflow, stored.Response, providerType, providerName, requestID, err)
+		}
+	})
+}
+
+// writeResponseSnapshot upserts one snapshot: Create first, falling back to
+// Update when the id already exists.
+func writeResponseSnapshot(ctx context.Context, store responsestore.Store, stored *responsestore.StoredResponse) error {
 	if createErr := store.Create(ctx, stored); createErr != nil {
 		updateErr := store.Update(ctx, stored)
 		if updateErr == nil {
 			return nil
 		}
-		return core.NewProviderError("response_store", http.StatusInternalServerError, "failed to persist response", errors.Join(createErr, updateErr))
+		return fmt.Errorf("persist response snapshot: %w", errors.Join(createErr, updateErr))
 	}
 	return nil
+}
+
+// drainSnapshotWrites blocks until every in-flight background snapshot write
+// finishes. The server calls it during shutdown, before the response store
+// closes.
+func (s *translatedInferenceService) drainSnapshotWrites() {
+	s.snapshotWrites.Wait()
 }
 
 func (s *translatedInferenceService) currentResponseStore() responsestore.Store {


### PR DESCRIPTION
Non-streaming `POST /v1/responses` previously blocked the client on a synchronous SQLite upsert of the response snapshot before returning. On SQLite backends that write also contended with audit-log and usage writes on the shared single connection, so tail latency reflected unrelated flushes. `/v1/chat/completions` has no such write, which showed up as a latency gap between the two endpoints.

The snapshot is now written in the background:

- The handler deep-copies the snapshot before returning, so the write shares no memory with the response being serialized to the client (race-detector verified).
- The write uses a cancellation-detached context with a 15s cap (covers Create plus the Update fallback, each bounded by SQLite's 5s busy timeout).
- `Server.Shutdown` drains in-flight snapshot writes before closing the response store, so graceful shutdown loses nothing.
- Failure handling is unchanged: same `gomodel_response_snapshot_store_failures_total` metric and warning log with `request_id`. `store: false` behavior is unchanged.

User-visible impact: `/v1/responses` latency no longer includes storage time. A client that issues `GET /v1/responses/{id}` immediately after the POST may race the background write for a few milliseconds; a hard crash in that window loses the snapshot (falls back to native provider lookup or 404). Both were judged acceptable since a failed snapshot write already did not fail the request.

Design note: this uses one goroutine per request rather than the bounded worker pool `responsecache` uses — snapshots are small and `database/sql` already serializes writes on the single SQLite connection. If snapshot volume ever warrants it, converting to the bounded-queue pattern is a clean follow-up.

Docs updated to state that snapshots are written in the background and to name the failure metric. The small `passthrough_support_test.go` commit applies a `go fix` modernization required by the pre-commit hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Response snapshots are saved asynchronously, allowing responses to return without waiting for storage.
  * Snapshot data now includes normalized response bodies and input items.
  * Pending snapshot writes are completed during graceful server shutdown.

* **Bug Fixes**
  * Snapshot write failures are logged and tracked with a metric.
  * Improved handling of snapshot creation conflicts and persistence errors.
  * Snapshot persistence is safely skipped for writes queued after shutdown draining begins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->