### PR TITLE
fix(anthropic): keep system-role messages and their cache breakpoints in place

### DIFF
--- a/docs/advanced/anthropic-messages-api.mdx
+++ b/docs/advanced/anthropic-messages-api.mdx
@@ -181,6 +181,11 @@ features that have no canonical equivalent are not preserved end to end:
 
 - **`cache_control`** is preserved on the request, system/content blocks,
   custom tools, and tool-use/tool-result history when routed to Anthropic.
+- **`{"role": "system"}` messages inside `messages`** keep their position and
+  `cache_control` breakpoints when routed to a Claude 4.8+/5-family model
+  (Claude Code appends system reminders this way, and its prompt caching
+  depends on them staying in place). On older Claude models, which reject the
+  role, their text is hoisted into the top-level system prompt instead.
 - **Extended-thinking signatures** and `thinking` blocks on input messages are dropped.
 - **Server/built-in tools** (web search, code execution, …) are rejected with a clear
   `400`; only custom tools (`type` absent or `"custom"`) translate.

--- a/internal/anthropicapi/request.go
+++ b/internal/anthropicapi/request.go
@@ -92,57 +92,35 @@ func ToChatRequest(req *MessagesRequest) (*core.ChatRequest, error) {
 // convertMessages flattens the Anthropic system prompt and messages into the
 // canonical message list. A single Anthropic message may expand into multiple
 // canonical messages: tool_result blocks become standalone role:"tool" messages.
-// Messages with role "system" in the messages array are extracted and prepended
-// to the system prompt, as the Anthropic Messages API requires system content
-// to be in the top-level system field, not in messages.
+// Messages with role "system" stay at their position in the conversation:
+// Claude 4.8+/5-family models accept them natively, and clients (notably
+// Claude Code) rely on their placement and block-level cache_control
+// breakpoints for prompt caching. The Anthropic egress translator hoists them
+// into the top-level system field only for models that reject the role.
 func convertMessages(req *MessagesRequest) ([]core.Message, error) {
 	out := make([]core.Message, 0, len(req.Messages)+1)
-
-	// Collect system messages from the messages array.
-	var systemMessages []string
-	filteredMessages := make([]Message, 0, len(req.Messages))
-	for _, msg := range req.Messages {
-		if msg.Role == "system" {
-			// Extract system content from message
-			text, err := systemText(msg.Content)
-			if err != nil {
-				return nil, core.NewInvalidRequestError("system message content: "+err.Error(), err)
-			}
-			if text != "" {
-				systemMessages = append(systemMessages, text)
-			}
-		} else {
-			filteredMessages = append(filteredMessages, msg)
-		}
-	}
 
 	// Build the system prompt while retaining block-level cache_control metadata.
 	system, err := systemContent(req.System)
 	if err != nil {
 		return nil, core.NewInvalidRequestError(err.Error(), err)
 	}
-	if len(systemMessages) > 0 {
-		appended := strings.TrimSpace(strings.Join(systemMessages, "\n\n"))
-		switch content := system.(type) {
-		case string:
-			if content != "" {
-				system = strings.TrimSpace(content + "\n\n" + appended)
-			} else {
-				system = appended
-			}
-		case []core.ContentPart:
-			if appended != "" {
-				system = append(content, core.ContentPart{Type: "text", Text: appended})
-			}
-		case nil:
-			system = appended
-		}
-	}
 	if system != nil && core.ExtractTextContent(system) != "" {
 		out = append(out, core.Message{Role: "system", Content: system})
 	}
 
-	for i, msg := range filteredMessages {
+	for i, msg := range req.Messages {
+		if msg.Role == "system" {
+			content, err := systemContent(msg.Content)
+			if err != nil {
+				return nil, core.NewInvalidRequestError(fmt.Sprintf("messages[%d]: %v", i, err), err)
+			}
+			if content == nil || core.ExtractTextContent(content) == "" {
+				continue
+			}
+			out = append(out, core.Message{Role: "system", Content: content})
+			continue
+		}
 		if msg.Role != "user" && msg.Role != "assistant" {
 			return nil, core.NewInvalidRequestError(
 				fmt.Sprintf("messages[%d].role must be \"user\" or \"assistant\"", i), nil)

--- a/internal/anthropicapi/request_test.go
+++ b/internal/anthropicapi/request_test.go
@@ -150,7 +150,8 @@ func TestToChatRequestSystemMessageInMessages(t *testing.T) {
 }
 
 func TestToChatRequestSystemMessageCombined(t *testing.T) {
-	// System messages in messages array should be combined with top-level system field
+	// A top-level system field becomes the leading system message; system
+	// messages in the messages array keep their own position and identity.
 	chat, err := ToChatRequest(mustDecode(t, `{
 		"model":"m","max_tokens":10,
 		"system":"top-level system",
@@ -162,25 +163,52 @@ func TestToChatRequestSystemMessageCombined(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ToChatRequest: %v", err)
 	}
-	if len(chat.Messages) != 2 {
-		t.Fatalf("messages = %d, want 2 (system + user)", len(chat.Messages))
+	if len(chat.Messages) != 3 {
+		t.Fatalf("messages = %d, want 3 (system + system + user)", len(chat.Messages))
 	}
-	// System messages should be combined with top-level system
-	if chat.Messages[0].Role != "system" {
-		t.Errorf("first message role = %q, want system", chat.Messages[0].Role)
+	if chat.Messages[0].Role != "system" || chat.Messages[0].Content != "top-level system" {
+		t.Errorf("first message = %+v, want top-level system", chat.Messages[0])
 	}
-	systemContent, ok := chat.Messages[0].Content.(string)
+	if chat.Messages[1].Role != "system" || chat.Messages[1].Content != "message system" {
+		t.Errorf("second message = %+v, want message system", chat.Messages[1])
+	}
+	if chat.Messages[2].Role != "user" || chat.Messages[2].Content != "hello" {
+		t.Errorf("user message = %+v", chat.Messages[2])
+	}
+}
+
+func TestToChatRequestSystemMessageKeepsPositionAndCacheControl(t *testing.T) {
+	// Mid-conversation system messages (Claude Code system reminders) must
+	// keep their position and block-level cache_control breakpoints so
+	// provider prompt caching keeps working through the gateway.
+	chat, err := ToChatRequest(mustDecode(t, `{
+		"model":"m","max_tokens":10,
+		"system":[{"type":"text","text":"base","cache_control":{"type":"ephemeral"}}],
+		"messages":[
+			{"role":"user","content":"hi"},
+			{"role":"assistant","content":"hello"},
+			{"role":"system","content":[{"type":"text","text":"reminder","cache_control":{"type":"ephemeral"}}]}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("ToChatRequest: %v", err)
+	}
+	if len(chat.Messages) != 4 {
+		t.Fatalf("messages = %d, want 4 (system + user + assistant + system)", len(chat.Messages))
+	}
+	last := chat.Messages[3]
+	if last.Role != "system" {
+		t.Fatalf("last message role = %q, want system", last.Role)
+	}
+	parts, ok := last.Content.([]core.ContentPart)
 	if !ok {
-		t.Fatalf("system content is not a string: %T", chat.Messages[0].Content)
+		t.Fatalf("last system content is %T, want []core.ContentPart", last.Content)
 	}
-	if !strings.Contains(systemContent, "top-level system") {
-		t.Errorf("system message should contain top-level system, got: %s", systemContent)
+	if len(parts) != 1 || parts[0].Text != "reminder" {
+		t.Fatalf("last system parts = %+v", parts)
 	}
-	if !strings.Contains(systemContent, "message system") {
-		t.Errorf("system message should contain message system, got: %s", systemContent)
-	}
-	if chat.Messages[1].Role != "user" || chat.Messages[1].Content != "hello" {
-		t.Errorf("user message = %+v", chat.Messages[1])
+	if got := string(parts[0].ExtraFields.Lookup("cache_control")); got != `{"type":"ephemeral"}` {
+		t.Errorf("last system cache_control = %q, want ephemeral marker", got)
 	}
 }
 

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/enterpilot/gomodel/internal/anthropicapi"
 	"github.com/enterpilot/gomodel/internal/core"
 	"github.com/enterpilot/gomodel/internal/llmclient"
 	"github.com/enterpilot/gomodel/internal/providers"
@@ -5419,5 +5420,133 @@ func TestConvertToAnthropicRequest_HonoursDefaultMaxTokensEnv(t *testing.T) {
 	}
 	if got.MaxTokens != 32768 {
 		t.Errorf("MaxTokens = %d, want 32768", got.MaxTokens)
+	}
+}
+
+func TestConvertToAnthropicRequestSystemRoleMessages(t *testing.T) {
+	cacheMarker := core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+		"cache_control": json.RawMessage(`{"type":"ephemeral"}`),
+	})
+	messages := []core.Message{
+		{Role: "system", Content: "leading instructions"},
+		{Role: "user", Content: "hi"},
+		{Role: "assistant", Content: "hello"},
+		{Role: "system", Content: []core.ContentPart{
+			{Type: "text", Text: "mid-conversation reminder", ExtraFields: cacheMarker},
+		}},
+		{Role: "user", Content: "continue"},
+	}
+
+	t.Run("supported model keeps mid-conversation system in place", func(t *testing.T) {
+		out, err := convertToAnthropicRequest(&core.ChatRequest{
+			Model:    "claude-fable-5",
+			Messages: messages,
+		})
+		if err != nil {
+			t.Fatalf("convertToAnthropicRequest() error = %v", err)
+		}
+		if out.System != "leading instructions" {
+			t.Fatalf("System = %#v, want only the leading instructions", out.System)
+		}
+		if len(out.Messages) != 4 {
+			t.Fatalf("len(Messages) = %d, want 4 (user, assistant, system, user)", len(out.Messages))
+		}
+		if out.Messages[2].Role != "system" {
+			t.Fatalf("Messages[2].Role = %q, want system", out.Messages[2].Role)
+		}
+		blocks, ok := out.Messages[2].Content.([]anthropicContentBlock)
+		if !ok || len(blocks) != 1 {
+			t.Fatalf("Messages[2].Content = %#v, want one text block", out.Messages[2].Content)
+		}
+		if blocks[0].Text != "mid-conversation reminder" {
+			t.Fatalf("system block text = %q", blocks[0].Text)
+		}
+		if string(blocks[0].CacheControl) != `{"type":"ephemeral"}` {
+			t.Fatalf("system block cache_control = %q, want ephemeral marker", blocks[0].CacheControl)
+		}
+	})
+
+	t.Run("legacy model hoists mid-conversation system into the system prompt", func(t *testing.T) {
+		out, err := convertToAnthropicRequest(&core.ChatRequest{
+			Model:    "claude-sonnet-4-5-20250929",
+			Messages: messages,
+		})
+		if err != nil {
+			t.Fatalf("convertToAnthropicRequest() error = %v", err)
+		}
+		if len(out.Messages) != 3 {
+			t.Fatalf("len(Messages) = %d, want 3 (user, assistant, user)", len(out.Messages))
+		}
+		blocks, ok := out.System.([]anthropicContentBlock)
+		if !ok || len(blocks) != 2 {
+			t.Fatalf("System = %#v, want leading + hoisted blocks", out.System)
+		}
+		if blocks[1].Text != "mid-conversation reminder" || string(blocks[1].CacheControl) != `{"type":"ephemeral"}` {
+			t.Fatalf("hoisted block = %+v, want reminder with cache_control", blocks[1])
+		}
+	})
+}
+
+func TestSupportsSystemRoleMessages(t *testing.T) {
+	for model, want := range map[string]bool{
+		"claude-fable-5":             true,
+		"claude-mythos-5":            true,
+		"claude-opus-4-8-20260301":   true,
+		"claude-opus-5-20260115":     true,
+		"claude-sonnet-5-20250929":   true,
+		"claude-sonnet-4-5-20250929": false,
+		"claude-opus-4-6":            false,
+		"claude-haiku-4-5-20251001":  false,
+		"claude-3-5-haiku-20241022":  false,
+	} {
+		if got := supportsSystemRoleMessages(model); got != want {
+			t.Errorf("supportsSystemRoleMessages(%q) = %v, want %v", model, got, want)
+		}
+	}
+}
+
+// TestMessagesCacheBreakpointsSurviveTranslation pins the end-to-end invariant
+// that broke prompt caching for Claude Code sessions: a /v1/messages request
+// whose moving cache_control breakpoint rides on an interleaved system-role
+// message must reach the provider with all breakpoints intact and in place.
+func TestMessagesCacheBreakpointsSurviveTranslation(t *testing.T) {
+	decoded, err := anthropicapi.DecodeMessagesRequest([]byte(`{
+		"model": "claude-fable-5",
+		"max_tokens": 100,
+		"system": [
+			{"type":"text","text":"base prompt"},
+			{"type":"text","text":"stable context","cache_control":{"type":"ephemeral"}}
+		],
+		"messages": [
+			{"role":"user","content":[{"type":"text","text":"hi"}]},
+			{"role":"assistant","content":[{"type":"text","text":"hello"}]},
+			{"role":"system","content":[{"type":"text","text":"reminder","cache_control":{"type":"ephemeral"}}]}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("DecodeMessagesRequest: %v", err)
+	}
+	chat, err := anthropicapi.ToChatRequest(decoded)
+	if err != nil {
+		t.Fatalf("ToChatRequest: %v", err)
+	}
+	out, err := convertToAnthropicRequest(chat)
+	if err != nil {
+		t.Fatalf("convertToAnthropicRequest: %v", err)
+	}
+	wire, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if got := strings.Count(string(wire), "cache_control"); got != 2 {
+		t.Fatalf("wire body carries %d cache_control markers, want 2: %s", got, wire)
+	}
+	last := out.Messages[len(out.Messages)-1]
+	if last.Role != "system" {
+		t.Fatalf("last wire message role = %q, want the trailing system reminder", last.Role)
+	}
+	blocks, ok := last.Content.([]anthropicContentBlock)
+	if !ok || len(blocks) != 1 || len(blocks[0].CacheControl) == 0 {
+		t.Fatalf("trailing system message = %#v, want one block with cache_control", last.Content)
 	}
 }

--- a/internal/providers/anthropic/request_translation.go
+++ b/internal/providers/anthropic/request_translation.go
@@ -357,15 +357,30 @@ func convertToAnthropicRequest(req *core.ChatRequest) (*anthropicRequest, error)
 		anthropicReq.ToolChoice = toolChoice
 	}
 
+	conversationStarted := false
 	for _, msg := range req.Messages {
 		if msg.Role == "system" {
 			systemContent, err := buildAnthropicSystemContent(msg.Content)
 			if err != nil {
 				return nil, err
 			}
+			// Leading system messages belong in the top-level system field.
+			// Mid-conversation ones stay in place on models that accept the
+			// role, preserving their position and cache_control breakpoints;
+			// older models get the historical hoist into the system prompt.
+			if conversationStarted && supportsSystemRoleMessages(req.Model) {
+				if !isEmptyAnthropicSystemContent(systemContent) {
+					anthropicReq.Messages = append(anthropicReq.Messages, anthropicMessage{
+						Role:    "system",
+						Content: systemContent,
+					})
+				}
+				continue
+			}
 			anthropicReq.System = appendAnthropicSystemContent(anthropicReq.System, systemContent)
 			continue
 		}
+		conversationStarted = true
 
 		content, err := buildAnthropicMessageContent(msg)
 		if err != nil {
@@ -815,4 +830,26 @@ func prefixAnthropicBatchItemError(index int, err error) error {
 		return &prefixed
 	}
 	return core.NewInvalidRequestError(fmt.Sprintf("batch item %d: %v", index, err), err)
+}
+
+// supportsSystemRoleMessages reports whether the target model accepts
+// {"role": "system"} messages inside the messages array. Anthropic added
+// mid-conversation system messages with the Claude 4.8/5 generation so that
+// new instructions can be appended without invalidating cached prefixes;
+// older models reject any role other than "user" or "assistant". Extend the
+// list when new generations ship — unlisted models fall back to the lossy
+// system-prompt hoist rather than risking a provider rejection.
+func supportsSystemRoleMessages(model string) bool {
+	for _, prefix := range []string{
+		"claude-fable-5",
+		"claude-mythos-5",
+		"claude-opus-4-8",
+		"claude-opus-5",
+		"claude-sonnet-5",
+	} {
+		if strings.HasPrefix(model, prefix) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Problem

Claude Code (CLI ≥ 2.1.x) appends its system reminders as `{"role": "system"}` messages inside `messages` — the pattern Anthropic recommends on Claude 4.8+/5-family models so mid-conversation instructions don't invalidate cached prefixes — and rides its moving `cache_control` breakpoint on the newest one.

The translated `/v1/messages` pipeline hoisted every system-role message into the top-level system prompt and `systemText()` dropped their `cache_control` on the way. Result observed on a live deployment: `cache_read_input_tokens` pinned at the static system prefix (exactly 48,316 tokens for all 59 requests of a session), `cache_creation_input_tokens` zero after the first request, and the entire growing conversation (25K → 81K tokens) billed uncached on every turn — roughly 90% overpayment on the conversation portion.

Native forwarding (#706) already avoids this when it engages; this fixes the translated pipeline, which still handles guardrails-patched, response-cached, and failover-enabled requests, plus chat-completions traffic routed to Anthropic.

## Change

- **Ingress** (`internal/anthropicapi`): system-role messages stay at their position in the canonical message list, with block-level `cache_control` preserved as content-part extra fields, instead of being text-flattened into the system prompt.
- **Egress** (`internal/providers/anthropic`): mid-conversation system messages are forwarded natively on models that accept the role (Fable 5, Mythos 5, Opus 4.8/5, Sonnet 5); older models keep the historical hoist into the system prompt, so nothing is ever sent that a model would reject. Leading system messages still map to the top-level `system` field.
- Regression test pins the end-to-end invariant: client breakpoints in → wire breakpoints out, with the trailing system reminder in place.

## Provider-specific behavior

Only the Anthropic egress changes. Other providers already receive canonical messages with system roles at arbitrary positions from the chat-completions ingress, so the ingress change introduces no new shape for them.