### PR TITLE
docs(benchmarks): show the gateway versions to rerun the snapshot

### DIFF
--- a/docs/about/benchmarks.mdx
+++ b/docs/about/benchmarks.mdx
@@ -30,9 +30,8 @@ A simple, like-for-like setup:
 
 - One gateway at a time, in Docker, on an AWS `c7i.large` (2 vCPU, 4 GiB), each
   from its latest public image (`enterpilot/gomodel`, `litellm/litellm:main-stable`,
-  `portkeyai/gateway`, `maximhq/bifrost`). The exact image digests of every run
-  are recorded next to its results in the repository, so any run can be repeated
-  byte-for-byte with the `*_IMAGE` overrides.
+  `portkeyai/gateway`, `maximhq/bifrost`). The version and image digest each run
+  measured are recorded next to its results in the repository.
 - The same shared mock backend for everyone, so we measure only gateway overhead.
 - Six workloads: chat completions, the Responses API, and Anthropic messages -
   each streaming and non-streaming.
@@ -100,16 +99,19 @@ concurrency `C=10`; override them as env vars, e.g. `N=5000 REPEATS=2 ./run.sh`
 for a quicker, noisier run. `GOMODEL_SOURCE=../gomodel` benchmarks a local
 checkout instead of the published image.
 
-That measures whatever the four images resolve to today. To repeat the exact
-August 20, 2026 snapshot instead, pin the digests the run recorded:
+That measures whatever the four images resolve to today. To repeat the
+August 20, 2026 snapshot on the same gateway releases, pass their versions:
 
 ```bash
-GOMODEL_IMAGE=enterpilot/gomodel@sha256:395097b75c6f1bcff5d732da328825507e93355daaac6d32874691fc9fbc2a82 \
-LITELLM_IMAGE=litellm/litellm@sha256:468c25f35f3e5ec4e414974f00deab93337b1b4d9953cabcfd3722e59415f834 \
-PORTKEY_IMAGE=portkeyai/gateway@sha256:97f094d9c8a764cbfaa2a7138c0017b247ca923bb06db1b4c13b7f8a33b5200d \
-BIFROST_IMAGE=maximhq/bifrost@sha256:ef8e686b3588884066ec3d0e57f3fc15136b11047ad94678adefe5a9573539af \
+GOMODEL_IMAGE=enterpilot/gomodel:0.1.79 \
+LITELLM_IMAGE=litellm/litellm:v1.97.0 \
+PORTKEY_IMAGE=portkeyai/gateway:1.15.2 \
+BIFROST_IMAGE=maximhq/bifrost:v1.6.11 \
 ./run.sh
-``` The repository README
+```
+
+Every recorded run lists the versions and image digests it measured in its
+`results/<run>/*_image.json` files, so any past run can be repeated the same way. The repository README
 also shows how to run the harness on any Docker host without AWS. For a quick
 local check against just LiteLLM, the older localhost harness is still in
 [`docs/about/benchmark-tools/`](https://github.com/ENTERPILOT/GoModel/tree/main/docs/about/benchmark-tools).


### PR DESCRIPTION
Follow-up to #722. The reproduction snippet now pins the gateway *versions* of the August 20, 2026 run (`enterpilot/gomodel:0.1.79`, `litellm/litellm:v1.97.0`, `portkeyai/gateway:1.15.2`, `maximhq/bifrost:v1.6.11`) instead of raw digests, matching how the benchmark repository documents it (ENTERPILOT/ai-gateway-reproducible-benchmark#4 records versions per run). Digests remain available in each run's `*_image.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated benchmark records to include gateway versions and image digests.
  - Revised reproduction instructions to use pinned gateway release versions.
  - Retained historical run metadata to support reproducing previous benchmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->