### PR TITLE
fix(virtualmodels): persist session_affinity in the MongoDB store

### DIFF
--- a/internal/virtualmodels/store_mongodb.go
+++ b/internal/virtualmodels/store_mongodb.go
@@ -13,17 +13,18 @@ import (
 )
 
 type mongoVirtualModelDocument struct {
-	ID           string    `bson:"_id"`
-	Targets      []Target  `bson:"targets,omitempty"`
-	Strategy     string    `bson:"strategy,omitempty"`
-	ProviderName string    `bson:"provider_name,omitempty"`
-	Model        string    `bson:"model,omitempty"`
-	UserPaths    []string  `bson:"user_paths,omitempty"`
-	Description  string    `bson:"description,omitempty"`
-	Slowdown     *float64  `bson:"slowdown,omitempty"`
-	Enabled      bool      `bson:"enabled"`
-	CreatedAt    time.Time `bson:"created_at"`
-	UpdatedAt    time.Time `bson:"updated_at"`
+	ID              string    `bson:"_id"`
+	Targets         []Target  `bson:"targets,omitempty"`
+	Strategy        string    `bson:"strategy,omitempty"`
+	SessionAffinity *bool     `bson:"session_affinity,omitempty"`
+	ProviderName    string    `bson:"provider_name,omitempty"`
+	Model           string    `bson:"model,omitempty"`
+	UserPaths       []string  `bson:"user_paths,omitempty"`
+	Description     string    `bson:"description,omitempty"`
+	Slowdown        *float64  `bson:"slowdown,omitempty"`
+	Enabled         bool      `bson:"enabled"`
+	CreatedAt       time.Time `bson:"created_at"`
+	UpdatedAt       time.Time `bson:"updated_at"`
 }
 
 type mongoVirtualModelIDFilter struct {
@@ -94,15 +95,16 @@ func (s *MongoDBStore) Upsert(ctx context.Context, vm VirtualModel) error {
 	stampUpsert(&vm)
 	update := bson.M{
 		"$set": bson.M{
-			"targets":       vm.Targets,
-			"strategy":      vm.Strategy,
-			"provider_name": vm.ProviderName,
-			"model":         vm.Model,
-			"user_paths":    vm.UserPaths,
-			"description":   vm.Description,
-			"slowdown":      vm.Slowdown,
-			"enabled":       vm.Enabled,
-			"updated_at":    vm.UpdatedAt,
+			"targets":          vm.Targets,
+			"strategy":         vm.Strategy,
+			"session_affinity": vm.SessionAffinity,
+			"provider_name":    vm.ProviderName,
+			"model":            vm.Model,
+			"user_paths":       vm.UserPaths,
+			"description":      vm.Description,
+			"slowdown":         vm.Slowdown,
+			"enabled":          vm.Enabled,
+			"updated_at":       vm.UpdatedAt,
 		},
 		"$setOnInsert": bson.M{
 			"created_at": vm.CreatedAt,
@@ -132,15 +134,16 @@ func (s *MongoDBStore) Close() error {
 
 func virtualModelFromMongo(doc mongoVirtualModelDocument) VirtualModel {
 	vm := VirtualModel{
-		Source:       doc.ID,
-		Strategy:     doc.Strategy,
-		ProviderName: doc.ProviderName,
-		Model:        doc.Model,
-		Description:  doc.Description,
-		Slowdown:     doc.Slowdown,
-		Enabled:      doc.Enabled,
-		CreatedAt:    doc.CreatedAt.UTC(),
-		UpdatedAt:    doc.UpdatedAt.UTC(),
+		Source:          doc.ID,
+		Strategy:        doc.Strategy,
+		SessionAffinity: doc.SessionAffinity,
+		ProviderName:    doc.ProviderName,
+		Model:           doc.Model,
+		Description:     doc.Description,
+		Slowdown:        doc.Slowdown,
+		Enabled:         doc.Enabled,
+		CreatedAt:       doc.CreatedAt.UTC(),
+		UpdatedAt:       doc.UpdatedAt.UTC(),
 	}
 	if len(doc.Targets) > 0 {
 		vm.Targets = append([]Target(nil), doc.Targets...)

--- a/internal/virtualmodels/store_test.go
+++ b/internal/virtualmodels/store_test.go
@@ -12,11 +12,12 @@ func TestStore_RoundTripRedirectAndPolicy(t *testing.T) {
 		ctx := context.Background()
 
 		redirect := VirtualModel{
-			Source:      "fast",
-			Targets:     []Target{{Provider: "openai", Model: "gpt-4o"}},
-			Description: "primary",
-			Slowdown:    new(0.4),
-			Enabled:     true,
+			Source:          "fast",
+			Targets:         []Target{{Provider: "openai", Model: "gpt-4o"}},
+			Description:     "primary",
+			Slowdown:        new(0.4),
+			SessionAffinity: new(false),
+			Enabled:         true,
 		}
 		policy := VirtualModel{
 			Source:       "openai/gpt-4o",
@@ -63,6 +64,9 @@ func TestStore_RoundTripRedirectAndPolicy(t *testing.T) {
 		if gotRedirect.Slowdown == nil || *gotRedirect.Slowdown != 0.4 {
 			t.Fatalf("Get(fast).Slowdown = %v, want 0.4", gotRedirect.Slowdown)
 		}
+		if gotRedirect.SessionAffinity == nil || *gotRedirect.SessionAffinity {
+			t.Fatalf("Get(fast).SessionAffinity = %v, want explicit false", gotRedirect.SessionAffinity)
+		}
 
 		gotPolicy, err := store.Get(ctx, "openai/gpt-4o")
 		if err != nil {
@@ -76,6 +80,9 @@ func TestStore_RoundTripRedirectAndPolicy(t *testing.T) {
 		}
 		if gotPolicy.Slowdown == nil || *gotPolicy.Slowdown != 0.2 {
 			t.Fatalf("Get(policy).Slowdown = %v, want 0.2", gotPolicy.Slowdown)
+		}
+		if gotPolicy.SessionAffinity != nil {
+			t.Fatalf("Get(policy).SessionAffinity = %v, want nil (unset)", *gotPolicy.SessionAffinity)
 		}
 
 		gotDisabled, err := store.Get(ctx, "no-slowdown")


### PR DESCRIPTION
The MongoDB virtual-models store never wrote or read \`session_affinity\`: the document struct had no field for it, \`Upsert\` did not \`$set\` it, and the decoder dropped it. On MongoDB, setting \`session_affinity: false\` on a load-balanced redirect silently reverted to the default (sticky sessions enabled) on the next refresh. The SQL stores were unaffected.

This adds the field to the Mongo document, writes it on upsert, reads it back, and extends the cross-backend store round-trip test so an explicit \`false\` survives and an unset value stays \`nil\`. The test fails on \`main\` against MongoDB and passes with the fix; SQLite and PostgreSQL pass before and after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Session affinity settings now persist correctly when virtual models are saved and loaded.
  - Redirect configurations explicitly set to disabled retain that setting.
  - Policies without a session affinity value continue to preserve an unset state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->