### PR TITLE
chore(auditlog): drop the legacy execution_plan_version_id index

### DIFF
--- a/internal/auditlog/store_mongodb.go
+++ b/internal/auditlog/store_mongodb.go
@@ -126,6 +126,10 @@ func NewMongoDBStore(database *mongo.Database, retentionDays int) (*MongoDBStore
 		})
 	}
 
+	// Best-effort: retire the index on the pre-v0.1.17 execution_plan_version_id
+	// field, which the workflow rename left behind on older collections.
+	_ = collection.Indexes().DropOne(ctx, "execution_plan_version_id_1")
+
 	_, err := collection.Indexes().CreateMany(ctx, indexes)
 	if err != nil {
 		// Log warning but don't fail - indexes may already exist

--- a/internal/auditlog/store_sql.go
+++ b/internal/auditlog/store_sql.go
@@ -106,6 +106,9 @@ var sqlIndexes = []string{
 	"CREATE INDEX IF NOT EXISTS idx_audit_status ON audit_logs(status_code)",
 	"CREATE INDEX IF NOT EXISTS idx_audit_provider ON audit_logs(provider)",
 	"CREATE INDEX IF NOT EXISTS idx_audit_provider_name ON audit_logs(provider_name)",
+	// Retires the index on the pre-v0.1.17 execution_plan_version_id column,
+	// which the workflow rename left behind on older databases.
+	"DROP INDEX IF EXISTS idx_audit_execution_plan_version_id",
 	"CREATE INDEX IF NOT EXISTS idx_audit_workflow_version_id ON audit_logs(workflow_version_id)",
 	"CREATE INDEX IF NOT EXISTS idx_audit_request_id ON audit_logs(request_id)",
 	"CREATE INDEX IF NOT EXISTS idx_audit_principal_id ON audit_logs(principal_id)",

--- a/internal/auditlog/store_sql_test.go
+++ b/internal/auditlog/store_sql_test.go
@@ -200,3 +200,30 @@ func TestNewSQLStoreRenamesLegacyModelColumn(t *testing.T) {
 		}
 	})
 }
+
+func TestNewSQLStoreDropsLegacyExecutionPlanIndex(t *testing.T) {
+	sqlxtest.Run(t, func(t *testing.T, db sqlx.DB) {
+		ctx := context.Background()
+		// Databases created before v0.1.17 carry the pre-rename column and index.
+		if err := db.Schema(ctx, `
+			CREATE TABLE audit_logs (
+				id TEXT PRIMARY KEY,
+				timestamp `+sqlx.TypeTimestamp+` NOT NULL,
+				execution_plan_version_id TEXT,
+				status_code INTEGER DEFAULT 0
+			)`,
+			`CREATE INDEX idx_audit_execution_plan_version_id ON audit_logs(execution_plan_version_id)`,
+		); err != nil {
+			t.Fatalf("create legacy table: %v", err)
+		}
+
+		if _, err := NewSQLStore(ctx, db, 0); err != nil {
+			t.Fatalf("NewSQLStore: %v", err)
+		}
+
+		// Recreating the index must succeed, proving the startup drop removed it.
+		if _, err := db.Exec(ctx, `CREATE INDEX idx_audit_execution_plan_version_id ON audit_logs(execution_plan_version_id)`); err != nil {
+			t.Fatalf("legacy index still present after NewSQLStore: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
The v0.1.17 execution-plans → workflows rename added \`workflow_version_id\` but left the old \`execution_plan_version_id\` column and its index behind on databases created earlier. Nothing has read or written them since.

This retires the orphan index on startup: \`DROP INDEX IF EXISTS idx_audit_execution_plan_version_id\` in the best-effort SQL index list, and a best-effort \`DropOne("execution_plan_version_id_1")\` for MongoDB, following the existing pattern in the ratelimit and budget stores. The column itself is left in place (dropping it would rewrite the table on SQLite). Databases created on v0.1.17 or later are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup maintenance for existing audit log databases by removing obsolete indexes.
  * Prevented conflicts caused by legacy indexes across supported database engines.

* **Tests**
  * Added coverage confirming legacy index cleanup and successful recreation of the current index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->