### PR TITLE
perf(auditlog): rank session threads in a single pass

### DIFF
--- a/internal/auditlog/reader_sessions_sql.go
+++ b/internal/auditlog/reader_sessions_sql.go
@@ -23,6 +23,10 @@ const auditThreadKey = `COALESCE(NULLIF(session_id, ''), CAST(id AS TEXT))`
 // sort meant every audit body in the window got materialized and sorted just
 // to discard all but one row per thread. The outer join re-reads the complete
 // rows for the page's 25 winners, by primary key.
+//
+// The ranking pass touches every entry in the window, so it runs once: the
+// total comes from the same set of thread heads the page is cut from, rather
+// than from a second COUNT(DISTINCT) scan of the window.
 func (r *SQLReader) GetSessions(ctx context.Context, params LogQueryParams) (*SessionListResult, error) {
 	limit, offset := clampLimitOffset(params.Limit, params.Offset)
 
@@ -32,45 +36,16 @@ func (r *SQLReader) GetSessions(ctx context.Context, params LogQueryParams) (*Se
 	}
 	where := sqlutil.BuildWhereClause(conditions)
 
-	var total int
-	if err := r.db.QueryRow(ctx,
-		"SELECT COUNT(DISTINCT "+auditThreadKey+") FROM audit_logs"+where, args...,
-	).Scan(&total); err != nil {
-		return nil, fmt.Errorf("failed to count audit sessions: %w", err)
-	}
-
-	// The correlated count deliberately applies no active list filters: the
-	// dashboard expands a head with an unfiltered session_id query, so both
-	// operations describe the same complete session.
-	query := `WITH ranked AS (
-		SELECT id, timestamp AS last_ts,
-			ROW_NUMBER() OVER (
-				PARTITION BY ` + auditThreadKey + `
-				ORDER BY timestamp DESC, id DESC
-			) AS rn
-		FROM audit_logs` + where + `
-	), heads AS (
-		SELECT id, last_ts
-		FROM ranked WHERE rn = 1
-		ORDER BY last_ts DESC, id DESC LIMIT ? OFFSET ?
-	)
-	SELECT ` + qualifiedLogColumns("l") + `,
-		CASE WHEN NULLIF(l.session_id, '') IS NULL THEN 1 ELSE (
-			SELECT COUNT(*) FROM audit_logs session_entries
-			WHERE session_entries.session_id = l.session_id
-		) END AS request_count
-	FROM heads h JOIN audit_logs l ON l.id = h.id
-	ORDER BY h.last_ts DESC, h.id DESC`
-
-	rows, err := r.db.Query(ctx, query, append(append([]any(nil), args...), limit, offset)...)
+	rows, err := r.db.Query(ctx, sessionsQuery(where), append(append([]any(nil), args...), limit, offset)...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query audit sessions: %w", err)
 	}
 	defer rows.Close()
 
 	sessions := make([]SessionSummary, 0)
+	total := 0
 	for rows.Next() {
-		summary, err := scanSQLSessionSummary(rows)
+		summary, err := scanSQLSessionSummary(rows, &total)
 		if err != nil {
 			return nil, err
 		}
@@ -79,25 +54,69 @@ func (r *SQLReader) GetSessions(ctx context.Context, params LogQueryParams) (*Se
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("error iterating audit session rows: %w", err)
 	}
+	rows.Close()
+
+	// An empty page carries no total. That is the answer when the window has
+	// no threads at all; past the last page the count still has to be made.
+	if len(sessions) == 0 && offset > 0 {
+		if err := r.db.QueryRow(ctx,
+			"SELECT COUNT(DISTINCT "+auditThreadKey+") FROM audit_logs"+where, args...,
+		).Scan(&total); err != nil {
+			return nil, fmt.Errorf("failed to count audit sessions: %w", err)
+		}
+	}
 	return &SessionListResult{Sessions: sessions, Total: total, Limit: limit, Offset: offset}, nil
 }
 
+// sessionsQuery builds the one-pass sessions page. Bind the filter arguments,
+// then limit and offset. Every row carries the thread total as its last column.
+//
+// The correlated request count deliberately applies no active list filters:
+// the dashboard expands a head with an unfiltered session_id query, so both
+// operations describe the same complete session.
+func sessionsQuery(where string) string {
+	return `WITH ranked AS (
+		SELECT id, timestamp AS last_ts,
+			ROW_NUMBER() OVER (
+				PARTITION BY ` + auditThreadKey + `
+				ORDER BY timestamp DESC, id DESC
+			) AS rn
+		FROM audit_logs` + where + `
+	), heads AS (
+		SELECT id, last_ts FROM ranked WHERE rn = 1
+	), page AS (
+		SELECT id, last_ts FROM heads
+		ORDER BY last_ts DESC, id DESC LIMIT ? OFFSET ?
+	)
+	SELECT ` + qualifiedLogColumns("l") + `,
+		CASE WHEN NULLIF(l.session_id, '') IS NULL THEN 1 ELSE (
+			SELECT COUNT(*) FROM audit_logs session_entries
+			WHERE session_entries.session_id = l.session_id
+		) END AS request_count,
+		(SELECT COUNT(*) FROM heads) AS total
+	FROM page h JOIN audit_logs l ON l.id = h.id
+	ORDER BY h.last_ts DESC, h.id DESC`
+}
+
 // sessionSummaryScanner adapts a session row to the log-entry scanner: the
-// leading columns are exactly a log entry, followed by the request count.
+// leading columns are exactly a log entry, followed by the request count and
+// the thread total.
 type sessionSummaryScanner struct {
 	row          sqlx.Row
 	requestCount *int
+	total        *int
 }
 
 func (s sessionSummaryScanner) Scan(dest ...any) error {
-	return s.row.Scan(append(dest, s.requestCount)...)
+	return s.row.Scan(append(dest, s.requestCount, s.total)...)
 }
 
-func scanSQLSessionSummary(row sqlx.Row) (*SessionSummary, error) {
+func scanSQLSessionSummary(row sqlx.Row, total *int) (*SessionSummary, error) {
 	var summary SessionSummary
 	entry, err := scanSQLLogEntry(sessionSummaryScanner{
 		row:          row,
 		requestCount: &summary.RequestCount,
+		total:        total,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to scan audit session row: %w", err)

--- a/internal/auditlog/session_id_test.go
+++ b/internal/auditlog/session_id_test.go
@@ -583,3 +583,41 @@ func TestCreateStreamEntryFinalizesContextIdentity(t *testing.T) {
 		t.Fatalf("managed-key labels lost on the stream copy: %#v", streamEntry.Data.Labels)
 	}
 }
+
+// The page query yields the thread total on every row, so an empty page has
+// to find it another way: zero when the window holds no threads, the real
+// count when the offset merely ran past the last page.
+func TestSQLReader_GetSessionsTotalOnEmptyPage(t *testing.T) {
+	sqlxtest.Run(t, func(t *testing.T, db sqlx.DB) {
+		store, err := newSQLStoreForTest(t, db, 0)
+		if err != nil {
+			t.Fatalf("failed to create store: %v", err)
+		}
+		defer store.Close()
+		reader, err := NewSQLReader(db)
+		if err != nil {
+			t.Fatalf("failed to create reader: %v", err)
+		}
+		ctx := context.Background()
+
+		empty, err := reader.GetSessions(ctx, LogQueryParams{Limit: 10})
+		if err != nil {
+			t.Fatalf("GetSessions(empty) failed: %v", err)
+		}
+		if empty.Total != 0 || len(empty.Sessions) != 0 {
+			t.Fatalf("empty window: total=%d sessions=%d, want 0/0", empty.Total, len(empty.Sessions))
+		}
+
+		base := time.Date(2026, 7, 27, 10, 0, 0, 0, time.UTC)
+		if err := store.WriteBatch(ctx, sessionThreadFixture(base)); err != nil {
+			t.Fatalf("WriteBatch failed: %v", err)
+		}
+		past, err := reader.GetSessions(ctx, LogQueryParams{Limit: 10, Offset: 50})
+		if err != nil {
+			t.Fatalf("GetSessions(past end) failed: %v", err)
+		}
+		if past.Total != 3 || len(past.Sessions) != 0 {
+			t.Fatalf("past last page: total=%d sessions=%d, want 3/0", past.Total, len(past.Sessions))
+		}
+	})
+}


### PR DESCRIPTION
The grouped audit view (\`GET /admin/audit/sessions\`, the dashboard default) scanned the whole date window twice per page: once for \`COUNT(DISTINCT thread_key)\` and once for the \`ROW_NUMBER()\` ranking that picks each thread's head. Both are O(entries in window) and neither can use an index, since the thread key is an expression.

The total now comes from the same ranked set the page is cut from, so the window is scanned once. An empty page past the last offset still runs the count; an empty window reports zero without one.

Measured on 400k rows (PostgreSQL 18, best of three):

| window | before | after |
|---|---|---|
| 7 days | 178 ms | 98 ms |
| 30 days (dashboard default) | 653 ms | 373 ms |

Raising \`work_mem\` for the statement was also measured and made no difference, so it is not included. The remaining cost is inherent to ranking every entry in the window; a maintained per-thread summary would be the next step if the default page is still too slow on large installations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session listing pagination to report accurate total counts alongside page results.
  * Corrected behavior for empty databases and page offsets beyond the available results.
  * Ensured session lists return no results with the correct total when the requested page is out of range.

* **Tests**
  * Added coverage for empty and out-of-range session pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->