### PR TITLE
perf(auditlog): index free-text search with pg_trgm on PostgreSQL

### DIFF
--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -153,6 +153,15 @@ can appear live but are not written to storage and disappear after a page
 refresh. When audit logging is enabled, writes are asynchronous and can take up
 to `LOGGING_FLUSH_INTERVAL` seconds to appear through the stored-log API.
 
+<Note>
+  On PostgreSQL, the audit log's free-text search uses a trigram index from the
+  bundled `pg_trgm` extension. GoModel installs the extension and builds the
+  index on startup when its database role is allowed to; otherwise the search
+  still works but scans every entry in the selected date range. To enable it on
+  a restricted role, run `CREATE EXTENSION pg_trgm;` as a superuser once and
+  restart GoModel.
+</Note>
+
 <Warning>
   When `LOGGING_LOG_BODIES` is enabled, request and response bodies are stored
   in full. These may contain sensitive data such as PII or API keys embedded in

--- a/internal/auditlog/reader_sessions_sql.go
+++ b/internal/auditlog/reader_sessions_sql.go
@@ -26,7 +26,7 @@ const auditThreadKey = `COALESCE(NULLIF(session_id, ''), CAST(id AS TEXT))`
 func (r *SQLReader) GetSessions(ctx context.Context, params LogQueryParams) (*SessionListResult, error) {
 	limit, offset := clampLimitOffset(params.Limit, params.Offset)
 
-	conditions, args, err := r.logFilters(params)
+	conditions, args, err := r.logFilters(ctx, params)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/auditlog/reader_sql.go
+++ b/internal/auditlog/reader_sql.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync/atomic"
+	"unicode/utf8"
 	"time"
 
 	"github.com/goccy/go-json"
@@ -266,8 +267,9 @@ func (r *SQLReader) searchFilter(search string, indexed bool) (string, []any) {
 	pattern := "%" + sqlutil.EscapeLikeWildcards(search) + "%"
 	// With the trigram index, one match against the indexed expression is an
 	// index lookup. Shorter terms yield no trigram and would scan the whole
-	// index only to recheck every row, so they keep the column sweep.
-	if indexed && len(search) >= minTrigramSearchLength {
+	// index only to recheck every row, so they keep the column sweep. pg_trgm
+	// counts characters, not bytes: a single CJK character is one character.
+	if indexed && utf8.RuneCountInString(search) >= minTrigramSearchLength {
 		return r.likeClause(searchText(r.dialect.errorMessage)), []any{pattern}
 	}
 	clauses := make([]string, 0, len(searchColumns)+1)

--- a/internal/auditlog/reader_sql.go
+++ b/internal/auditlog/reader_sql.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/goccy/go-json"
@@ -18,6 +19,12 @@ import (
 type SQLReader struct {
 	db      sqlx.DB
 	dialect readerDialect
+
+	// searchIndexed caches that the trigram search index exists, so free-text
+	// search matches the indexed searchText expression instead of sweeping
+	// each column. The store builds the index in the background, so until it
+	// is seen each search re-probes; the probe is a catalog lookup.
+	searchIndexed atomic.Bool
 }
 
 // NewSQLReader creates an audit log reader over a SQL database.
@@ -26,6 +33,18 @@ func NewSQLReader(db sqlx.DB) (*SQLReader, error) {
 		return nil, fmt.Errorf("database connection is required")
 	}
 	return &SQLReader{db: db, dialect: readerDialectFor(db.Dialect())}, nil
+}
+
+// searchIsIndexed reports whether free-text search can use the trigram index.
+func (r *SQLReader) searchIsIndexed(ctx context.Context) bool {
+	if r.searchIndexed.Load() {
+		return true
+	}
+	if !hasTrigramSearchIndex(ctx, r.db) {
+		return false
+	}
+	r.searchIndexed.Store(true)
+	return true
 }
 
 // readerDialect holds the handful of spellings the two engines genuinely
@@ -67,7 +86,7 @@ func readerDialectFor(dialect sqlx.Dialect) readerDialect {
 			like:               "ILIKE",
 			idColumn:           "id::text",
 			attemptIDColumn:    "audit_log_id::text",
-			errorMessage:       `data->>'error_message'`,
+			errorMessage:       postgresErrorMessage,
 			responseID:         `data #>> '{response_body,id}'`,
 			previousResponseID: `data #>> '{request_body,previous_response_id}'`,
 			timestampBound:     func(t time.Time) any { return t.UTC() },
@@ -112,7 +131,7 @@ func qualifiedLogColumns(alias string) string {
 func (r *SQLReader) GetLogs(ctx context.Context, params LogQueryParams) (*LogListResult, error) {
 	limit, offset := clampLimitOffset(params.Limit, params.Offset)
 
-	conditions, args, err := r.logFilters(params)
+	conditions, args, err := r.logFilters(ctx, params)
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +173,7 @@ func (r *SQLReader) GetLogs(ctx context.Context, params LogQueryParams) (*LogLis
 
 // logFilters builds the WHERE conditions for a log query. Placeholders are
 // written as `?` throughout; the adapter renumbers them for PostgreSQL.
-func (r *SQLReader) logFilters(params LogQueryParams) ([]string, []any, error) {
+func (r *SQLReader) logFilters(ctx context.Context, params LogQueryParams) ([]string, []any, error) {
 	userPath, err := normalizeAuditUserPathFilter(params.UserPath)
 	if err != nil {
 		return nil, nil, err
@@ -215,7 +234,7 @@ func (r *SQLReader) logFilters(params LogQueryParams) ([]string, []any, error) {
 		add("stream = ?", *params.Stream)
 	}
 	if params.Search != "" {
-		condition, values := r.searchFilter(params.Search)
+		condition, values := r.searchFilter(params.Search, r.searchIsIndexed(ctx))
 		add(condition, values...)
 	}
 	return conditions, args, nil
@@ -229,7 +248,7 @@ func (r *SQLReader) logFilters(params LogQueryParams) ([]string, []any, error) {
 // lookups instead of the leading-wildcard LIKE scan every other term needs.
 // The trade is deliberate: a full UUID that only appears inside an error
 // message no longer matches, and identifiers live in these columns.
-func (r *SQLReader) searchFilter(search string) (string, []any) {
+func (r *SQLReader) searchFilter(search string, indexed bool) (string, []any) {
 	if isCanonicalUUID(search) {
 		// Equality is case-sensitive (unlike the LIKE path), and pasted UUIDs
 		// may be uppercase while stored ones are not; match both spellings.
@@ -245,9 +264,11 @@ func (r *SQLReader) searchFilter(search string) (string, []any) {
 	}
 
 	pattern := "%" + sqlutil.EscapeLikeWildcards(search) + "%"
-	searchColumns := []string{
-		"request_id", "auth_key_id", "requested_model", "provider", "provider_name",
-		"method", "path", "user_path", "session_id", "error_type",
+	// With the trigram index, one match against the indexed expression is an
+	// index lookup. Shorter terms yield no trigram and would scan the whole
+	// index only to recheck every row, so they keep the column sweep.
+	if indexed && len(search) >= minTrigramSearchLength {
+		return r.likeClause(searchText(r.dialect.errorMessage)), []any{pattern}
 	}
 	clauses := make([]string, 0, len(searchColumns)+1)
 	values := make([]any, 0, len(searchColumns)+1)

--- a/internal/auditlog/reader_sql.go
+++ b/internal/auditlog/reader_sql.go
@@ -7,8 +7,8 @@ import (
 	"log/slog"
 	"strings"
 	"sync/atomic"
-	"unicode/utf8"
 	"time"
+	"unicode/utf8"
 
 	"github.com/goccy/go-json"
 

--- a/internal/auditlog/search_index.go
+++ b/internal/auditlog/search_index.go
@@ -19,7 +19,8 @@ var searchColumns = []string{
 
 const trigramSearchIndex = "idx_audit_search_trgm"
 
-// minTrigramSearchLength is the shortest term that yields a trigram.
+// minTrigramSearchLength is the shortest term, in characters, that yields a
+// trigram.
 const minTrigramSearchLength = 3
 
 // postgresErrorMessage extracts the error message from the JSON data blob.

--- a/internal/auditlog/search_index.go
+++ b/internal/auditlog/search_index.go
@@ -1,0 +1,93 @@
+package auditlog
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/enterpilot/gomodel/internal/storage/sqlx"
+)
+
+// searchColumns are the plain-text columns the free-text search sweeps, in
+// addition to the error message inside the JSON data blob.
+var searchColumns = []string{
+	"request_id", "auth_key_id", "requested_model", "provider", "provider_name",
+	"method", "path", "user_path", "session_id", "error_type",
+}
+
+const trigramSearchIndex = "idx_audit_search_trgm"
+
+// minTrigramSearchLength is the shortest term that yields a trigram.
+const minTrigramSearchLength = 3
+
+// postgresErrorMessage extracts the error message from the JSON data blob.
+const postgresErrorMessage = `data->>'error_message'`
+
+// searchText is the single text the trigram index covers: every search
+// column joined by spaces, plus the error message — parsed out of the JSON
+// blob only for rows that carry an error type, as the column sweep does.
+// The reader must match against this exact expression for the planner to
+// pick the index, so it is built once and shared.
+func searchText(errorMessage string) string {
+	parts := make([]string, 0, len(searchColumns)+1)
+	for _, column := range searchColumns {
+		parts = append(parts, "COALESCE("+column+", '')")
+	}
+	parts = append(parts,
+		"(CASE WHEN error_type IS NOT NULL AND error_type <> '' THEN COALESCE("+errorMessage+", '') ELSE '' END)")
+	return "(" + strings.Join(parts, " || ' ' || ") + ")"
+}
+
+// ensureTrigramSearchIndex gives PostgreSQL a trigram index over searchText so
+// a free-text search is an index lookup instead of a LIKE sweep of every row
+// in the window. It is best-effort: pg_trgm ships with PostgreSQL but the role
+// may not be allowed to install it, in which case the search keeps its slow
+// path and the reason is logged once. The index builds CONCURRENTLY so an
+// existing large table keeps accepting writes while it builds; a build
+// interrupted midway leaves an invalid index, which is dropped and rebuilt.
+func ensureTrigramSearchIndex(ctx context.Context, db sqlx.DB, errorMessage string) {
+	if db.Dialect() != sqlx.PostgreSQL {
+		return
+	}
+	if _, err := db.Exec(ctx, "CREATE EXTENSION IF NOT EXISTS pg_trgm"); err != nil {
+		slog.Info("auditlog: pg_trgm extension unavailable, free-text search stays unindexed; install it with CREATE EXTENSION pg_trgm", "error", err)
+		return
+	}
+	var schema string
+	if err := db.QueryRow(ctx, `SELECT n.nspname FROM pg_extension e JOIN pg_namespace n ON n.oid = e.extnamespace WHERE e.extname = 'pg_trgm'`).Scan(&schema); err != nil {
+		slog.Warn("auditlog: failed to locate pg_trgm", "error", err)
+		return
+	}
+	var valid *bool
+	if err := db.QueryRow(ctx, `SELECT i.indisvalid FROM pg_index i WHERE i.indexrelid = to_regclass(?)`, trigramSearchIndex).Scan(&valid); err == nil && valid != nil && !*valid {
+		slog.Warn("auditlog: rebuilding interrupted trigram search index")
+		if _, err := db.Exec(ctx, "DROP INDEX "+trigramSearchIndex); err != nil {
+			slog.Warn("auditlog: failed to drop invalid trigram search index", "error", err)
+			return
+		}
+	}
+	if hasTrigramSearchIndex(ctx, db) {
+		return
+	}
+	statement := fmt.Sprintf(`CREATE INDEX CONCURRENTLY IF NOT EXISTS %s ON audit_logs USING GIN (%s %s.gin_trgm_ops)`,
+		trigramSearchIndex, searchText(errorMessage), `"`+strings.ReplaceAll(schema, `"`, `""`)+`"`)
+	started := time.Now()
+	if _, err := db.Exec(ctx, statement); err != nil {
+		slog.Warn("auditlog: failed to create trigram search index", "error", err)
+		return
+	}
+	slog.Info("auditlog: built trigram search index", "duration", time.Since(started).Round(time.Millisecond))
+}
+
+// hasTrigramSearchIndex reports whether the trigram index exists and is
+// valid, so the reader knows whether matching against searchText pays off.
+func hasTrigramSearchIndex(ctx context.Context, db sqlx.DB) bool {
+	if db.Dialect() != sqlx.PostgreSQL {
+		return false
+	}
+	var valid bool
+	err := db.QueryRow(ctx, `SELECT COALESCE(i.indisvalid, FALSE) FROM pg_index i WHERE i.indexrelid = to_regclass(?)`, trigramSearchIndex).Scan(&valid)
+	return err == nil && valid
+}

--- a/internal/auditlog/search_index_test.go
+++ b/internal/auditlog/search_index_test.go
@@ -1,0 +1,131 @@
+package auditlog
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/enterpilot/gomodel/internal/storage/sqlx"
+	"github.com/enterpilot/gomodel/internal/storage/sqlx/sqlxtest"
+)
+
+// requireTrigramIndex opens a store and reader on a PostgreSQL database that
+// managed to build the trigram index, skipping where pg_trgm cannot be installed.
+func requireTrigramIndex(t *testing.T, db sqlx.DB) (*SQLStore, *SQLReader) {
+	t.Helper()
+	if db.Dialect() != sqlx.PostgreSQL {
+		t.Skip("trigram search index is PostgreSQL only")
+	}
+	ctx := context.Background()
+	store, err := newSQLStoreForTest(t, db, 0)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	store.indexBuild.Wait()
+	if !hasTrigramSearchIndex(ctx, db) {
+		t.Skip("pg_trgm could not be installed on the test server")
+	}
+	reader, err := NewSQLReader(db)
+	if err != nil {
+		t.Fatalf("failed to create reader: %v", err)
+	}
+	if !reader.searchIsIndexed(ctx) {
+		t.Fatal("reader did not detect the trigram search index")
+	}
+	return store, reader
+}
+
+func TestSQLReader_SearchUsesTrigramIndex(t *testing.T) {
+	sqlxtest.Run(t, func(t *testing.T, db sqlx.DB) {
+		store, reader := requireTrigramIndex(t, db)
+		defer store.Close()
+		ctx := context.Background()
+
+		// The predicate must be the indexed expression, verbatim, or the
+		// planner cannot use the index: prove it by reading the plan. On an
+		// empty table a sequential scan is always cheaper, so it is disabled
+		// for the check — a mismatched expression would still seq-scan.
+		condition, args := reader.searchFilter("timeout awaiting", true)
+		var plan []string
+		err := db.InTx(ctx, func(q sqlx.Querier) error {
+			if _, err := q.Exec(ctx, "SET LOCAL enable_seqscan = off"); err != nil {
+				return err
+			}
+			rows, err := q.Query(ctx, "EXPLAIN "+selectLogColumns+" WHERE "+condition, args...)
+			if err != nil {
+				return err
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var line string
+				if err := rows.Scan(&line); err != nil {
+					return err
+				}
+				plan = append(plan, line)
+			}
+			return rows.Err()
+		})
+		if err != nil {
+			t.Fatalf("EXPLAIN: %v", err)
+		}
+		if joined := strings.Join(plan, "\n"); !strings.Contains(joined, trigramSearchIndex) {
+			t.Fatalf("plan does not use %s:\n%s", trigramSearchIndex, joined)
+		}
+	})
+}
+
+func TestSQLReader_SearchViaTrigramIndexKeepsSemantics(t *testing.T) {
+	sqlxtest.Run(t, func(t *testing.T, db sqlx.DB) {
+		store, reader := requireTrigramIndex(t, db)
+		defer store.Close()
+		ctx := context.Background()
+
+		at := time.Date(2026, 1, 16, 12, 0, 0, 0, time.UTC)
+		if err := store.WriteBatch(ctx, []*LogEntry{
+			{ID: "path-hit", Timestamp: at, RequestedModel: "gpt-5", UserPath: "/team/alpha"},
+			{ID: "error-hit", Timestamp: at, RequestedModel: "gpt-5", ErrorType: "provider_error",
+				Data: &LogData{ErrorMessage: "http2: timeout awaiting response headers"}},
+			// An error message on a row without an error type is not searched,
+			// exactly as the column sweep gates it.
+			{ID: "ungated", Timestamp: at, RequestedModel: "gpt-5",
+				Data: &LogData{ErrorMessage: "timeout awaiting nothing"}},
+			{ID: "wild", Timestamp: at, RequestedModel: "gpt-5", Path: "/v1/100%_done"},
+		}); err != nil {
+			t.Fatalf("WriteBatch: %v", err)
+		}
+
+		expect := func(search string, want ...string) {
+			t.Helper()
+			result, err := reader.GetLogs(ctx, LogQueryParams{Search: search, Limit: 10})
+			if err != nil {
+				t.Fatalf("GetLogs(%q): %v", search, err)
+			}
+			got := make([]string, 0, len(result.Entries))
+			for _, entry := range result.Entries {
+				got = append(got, entry.ID)
+			}
+			if strings.Join(got, ",") != strings.Join(want, ",") || result.Total != len(want) {
+				t.Fatalf("search %q = %v (total %d), want %v", search, got, result.Total, want)
+			}
+		}
+		expect("team/alpha", "path-hit")
+		expect("TEAM/ALPHA", "path-hit")
+		expect("timeout awaiting", "error-hit")
+		expect("100%_done", "wild")
+		expect("nothing")
+	})
+}
+
+func TestSQLReader_ShortSearchKeepsColumnSweep(t *testing.T) {
+	reader := &SQLReader{dialect: readerDialectFor(sqlx.PostgreSQL)}
+	if condition, _ := reader.searchFilter("ab", true); !strings.Contains(condition, "request_id ILIKE") {
+		t.Fatalf("two-character search should sweep columns, got %s", condition)
+	}
+	if condition, _ := reader.searchFilter("abc", true); strings.Contains(condition, "request_id ILIKE") {
+		t.Fatalf("three-character search should use the indexed expression, got %s", condition)
+	}
+	if condition, _ := reader.searchFilter("abc", false); !strings.Contains(condition, "request_id ILIKE") {
+		t.Fatalf("without the index the search should sweep columns, got %s", condition)
+	}
+}

--- a/internal/auditlog/search_index_test.go
+++ b/internal/auditlog/search_index_test.go
@@ -125,6 +125,14 @@ func TestSQLReader_ShortSearchKeepsColumnSweep(t *testing.T) {
 	if condition, _ := reader.searchFilter("abc", true); strings.Contains(condition, "request_id ILIKE") {
 		t.Fatalf("three-character search should use the indexed expression, got %s", condition)
 	}
+	// Characters, not bytes: one CJK character is three bytes but yields no
+	// trigram, while three of them do.
+	if condition, _ := reader.searchFilter("中", true); !strings.Contains(condition, "request_id ILIKE") {
+		t.Fatalf("single multibyte character should sweep columns, got %s", condition)
+	}
+	if condition, _ := reader.searchFilter("中文字", true); strings.Contains(condition, "request_id ILIKE") {
+		t.Fatalf("three multibyte characters should use the indexed expression, got %s", condition)
+	}
 	if condition, _ := reader.searchFilter("abc", false); !strings.Contains(condition, "request_id ILIKE") {
 		t.Fatalf("without the index the search should sweep columns, got %s", condition)
 	}

--- a/internal/auditlog/store_sql.go
+++ b/internal/auditlog/store_sql.go
@@ -30,6 +30,13 @@ type SQLStore struct {
 	retentionDays int
 	stopCleanup   chan struct{}
 	closeOnce     sync.Once
+
+	// indexBuild tracks the background trigram search index build, so tests
+	// can wait for it; production never blocks on it. Close cancels a build
+	// still in flight rather than holding shutdown for it — the interrupted
+	// index is dropped and rebuilt on the next start.
+	indexBuild       sync.WaitGroup
+	cancelIndexBuild context.CancelFunc
 }
 
 var sqlTables = []string{
@@ -170,6 +177,14 @@ func NewSQLStore(ctx context.Context, db sqlx.DB, retentionDays int) (*SQLStore,
 		retentionDays: retentionDays,
 		stopCleanup:   make(chan struct{}),
 	}
+	// The trigram search index can take minutes to build on a large existing
+	// table, so it is built off the startup path (and CONCURRENTLY, so writes
+	// keep flowing); readers pick it up as soon as it exists.
+	buildCtx, cancel := context.WithCancel(context.Background())
+	store.cancelIndexBuild = cancel
+	store.indexBuild.Go(func() {
+		ensureTrigramSearchIndex(buildCtx, db, postgresErrorMessage)
+	})
 	if retentionDays > 0 {
 		go storage.RunCleanupLoop(store.stopCleanup, CleanupInterval, store.cleanup)
 	}
@@ -317,11 +332,14 @@ func (s *SQLStore) Flush(_ context.Context) error {
 // Close stops the cleanup goroutine. The connection is managed by the storage
 // layer. Safe to call multiple times.
 func (s *SQLStore) Close() error {
-	if s.retentionDays > 0 && s.stopCleanup != nil {
-		s.closeOnce.Do(func() {
+	s.closeOnce.Do(func() {
+		if s.cancelIndexBuild != nil {
+			s.cancelIndexBuild()
+		}
+		if s.retentionDays > 0 && s.stopCleanup != nil {
 			close(s.stopCleanup)
-		})
-	}
+		}
+	})
 	return nil
 }
 


### PR DESCRIPTION
The audit log search box runs ten \`ILIKE '%term%'\` terms plus a JSON error-message extract against every entry in the date window; no btree index can serve a contains-match, so rare terms cost the most (the page walk visits the whole window before giving up).

On PostgreSQL the store now installs the bundled \`pg_trgm\` extension and builds a GIN trigram index over one expression joining the search columns (error message included only for rows with an error type, as the sweep already gates it). The reader matches against that same expression when the index exists and the term is at least three characters (shorter terms yield no trigram and would scan the whole index). Everything is best-effort: where the role may not create extensions, the search keeps its current path and the reason is logged once.

Measured on 400k rows, 7-day window (PostgreSQL 18):

| term | before | after |
|---|---|---|
| \`req-1234\` (rare) | 298 ms | 5 ms |
| \`exploded\` (uncommon) | 97 ms | 13 ms |
| \`gpt\` (40% of rows) | — | 66 ms count / 1 ms page |

The index is 57 MB on a 965 MB table and builds in the background with \`CREATE INDEX CONCURRENTLY\`, so startup and writes never wait for it; readers pick it up as soon as it is valid. Shutdown cancels an in-flight build, and a build interrupted that way is dropped and rebuilt on the next start.

Semantics: a term can now also match across adjacent column boundaries (\`POST /v1\`); identifier fast path for UUIDs, wildcard escaping, case-insensitivity and the error-type gate are unchanged, covered by the new tests. SQLite and MongoDB are untouched. Documented in the Audit Logging configuration section.