### PR TITLE
chore(auditlog): log unexpected errors when dropping the legacy Mongo index

### DIFF
--- a/internal/auditlog/store_mongodb.go
+++ b/internal/auditlog/store_mongodb.go
@@ -44,6 +44,14 @@ var auditLogPartialWriteFailures = promauto.NewCounter(
 )
 
 // MongoDBStore implements LogStore for MongoDB.
+const legacyExecutionPlanIndex = "execution_plan_version_id_1"
+
+// isIndexNotFound reports MongoDB's IndexNotFound (code 27) server error.
+func isIndexNotFound(err error) bool {
+	var cmdErr mongo.CommandError
+	return errors.As(err, &cmdErr) && cmdErr.HasErrorCode(27)
+}
+
 type MongoDBStore struct {
 	collection    *mongo.Collection
 	retentionDays int
@@ -127,8 +135,11 @@ func NewMongoDBStore(database *mongo.Database, retentionDays int) (*MongoDBStore
 	}
 
 	// Best-effort: retire the index on the pre-v0.1.17 execution_plan_version_id
-	// field, which the workflow rename left behind on older collections.
-	_ = collection.Indexes().DropOne(ctx, "execution_plan_version_id_1")
+	// field, which the workflow rename left behind on older collections. Most
+	// collections never had it, so "not found" is the expected outcome.
+	if err := collection.Indexes().DropOne(ctx, legacyExecutionPlanIndex); err != nil && !isIndexNotFound(err) {
+		slog.Warn("failed to drop legacy MongoDB index", "index", legacyExecutionPlanIndex, "error", err)
+	}
 
 	_, err := collection.Indexes().CreateMany(ctx, indexes)
 	if err != nil {

--- a/internal/auditlog/store_mongodb_test.go
+++ b/internal/auditlog/store_mongodb_test.go
@@ -1,0 +1,58 @@
+package auditlog
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+
+	"github.com/enterpilot/gomodel/internal/storage/mongotest"
+)
+
+func TestNewMongoDBStoreDropsLegacyExecutionPlanIndex(t *testing.T) {
+	mongotest.Run(t, func(t *testing.T, db *mongo.Database) {
+		ctx := context.Background()
+		coll := db.Collection("audit_logs")
+		// A collection from before v0.1.17 still carries the pre-rename index.
+		if _, err := coll.Indexes().CreateOne(ctx, mongo.IndexModel{Keys: bson.D{{Key: "execution_plan_version_id", Value: 1}}}); err != nil {
+			t.Fatalf("create legacy index: %v", err)
+		}
+
+		if _, err := NewMongoDBStore(db, 0); err != nil {
+			t.Fatalf("NewMongoDBStore: %v", err)
+		}
+
+		cursor, err := coll.Indexes().List(ctx)
+		if err != nil {
+			t.Fatalf("list indexes: %v", err)
+		}
+		var specs []bson.M
+		if err := cursor.All(ctx, &specs); err != nil {
+			t.Fatalf("decode indexes: %v", err)
+		}
+		for _, spec := range specs {
+			if spec["name"] == legacyExecutionPlanIndex {
+				t.Fatalf("legacy index still present after NewMongoDBStore: %v", specs)
+			}
+		}
+
+		// A second start finds no legacy index; that is not an error either.
+		if _, err := NewMongoDBStore(db, 0); err != nil {
+			t.Fatalf("NewMongoDBStore (second start): %v", err)
+		}
+	})
+}
+
+func TestIsIndexNotFound(t *testing.T) {
+	if !isIndexNotFound(mongo.CommandError{Code: 27, Name: "IndexNotFound"}) {
+		t.Fatal("code 27 should be reported as index not found")
+	}
+	if isIndexNotFound(mongo.CommandError{Code: 26, Name: "NamespaceNotFound"}) {
+		t.Fatal("other command errors must not be treated as index not found")
+	}
+	if isIndexNotFound(errors.New("connection reset")) {
+		t.Fatal("non-command errors must not be treated as index not found")
+	}
+}


### PR DESCRIPTION
Follow-up to #735. The best-effort \`DropOne\` of the pre-v0.1.17 \`execution_plan_version_id_1\` index discarded every error. "Index not found" (server code 27) is the normal outcome on most collections and stays silent; any other error — a connection failure, a permissions denial — is now logged at warn level so an operator can see why the index was not retired. Startup still continues either way.

Covered by a MongoDB test that starts the store against a collection carrying the legacy index and verifies it is gone, plus a unit test for the error classification.