### PR TITLE
feat(realtime): support OpenAI transcription sessions via intent=transcription

### DIFF
--- a/internal/core/realtime.go
+++ b/internal/core/realtime.go
@@ -27,6 +27,13 @@ type RealtimeTarget struct {
 	URL          string
 	Headers      http.Header
 	Subprotocols []string
+	// PinSessionModel, when non-empty, names the model the gateway must force
+	// into the client's session.update frames. Providers set it when the
+	// upstream URL carries no model — as in OpenAI transcription sessions —
+	// so the session payload, not the URL, selects the model; pinning keeps
+	// that selection on the model the caller was authorized for. Providers
+	// whose URL fixes the model leave it empty and no frame mapping happens.
+	PinSessionModel string
 }
 
 // RealtimeProvider is implemented by providers that expose an OpenAI-compatible

--- a/internal/core/realtime.go
+++ b/internal/core/realtime.go
@@ -9,11 +9,14 @@ import (
 // (speech-to-speech) websocket session. The model selects the provider; the
 // optional Provider hint mirrors the audio endpoints. CallID, when set, attaches
 // to an existing WebRTC/SIP call as a sideband websocket instead of opening a
-// fresh model session.
+// fresh model session. Intent, when set to "transcription", asks the provider
+// for a transcription session instead of a conversation session; the model
+// still routes the request inside the gateway.
 type RealtimeRequest struct {
 	Model    string
 	Provider string
 	CallID   string
+	Intent   string
 }
 
 // RealtimeTarget describes the upstream websocket a provider exposes for realtime

--- a/internal/providers/openai/realtime.go
+++ b/internal/providers/openai/realtime.go
@@ -20,6 +20,7 @@ func (p *Provider) RealtimeTarget(ctx context.Context, req *core.RealtimeRequest
 		return nil, core.NewInvalidRequestError("model is required for realtime sessions", nil)
 	}
 
+	transcription := false
 	var endpoint string
 	var err error
 	if strings.TrimSpace(req.CallID) != "" {
@@ -27,6 +28,7 @@ func (p *Provider) RealtimeTarget(ctx context.Context, req *core.RealtimeRequest
 	} else if strings.TrimSpace(req.Model) == "" {
 		return nil, core.NewInvalidRequestError("model is required for realtime sessions", nil)
 	} else if strings.EqualFold(strings.TrimSpace(req.Intent), "transcription") {
+		transcription = true
 		// Transcription sessions pick their model via session.update; OpenAI
 		// rejects a model query parameter in this mode, so the requested model
 		// only routed the request to this provider and is dropped from the URL.
@@ -40,7 +42,14 @@ func (p *Provider) RealtimeTarget(ctx context.Context, req *core.RealtimeRequest
 	// Note: the legacy "OpenAI-Beta: realtime=v1" header is intentionally NOT set.
 	// The GA endpoint rejects it ("The Realtime Beta API is no longer supported").
 
-	return &core.RealtimeTarget{URL: endpoint, Headers: p.realtimeAuthHeaders(ctx)}, nil
+	target := &core.RealtimeTarget{URL: endpoint, Headers: p.realtimeAuthHeaders(ctx)}
+	if transcription {
+		// The URL carries no model in transcription mode, so the session.update
+		// payload selects it; ask the gateway to pin that selection to the
+		// routed model.
+		target.PinSessionModel = strings.TrimSpace(req.Model)
+	}
+	return target, nil
 }
 
 // RealtimeCallTarget implements core.RealtimeCallProvider for OpenAI's WebRTC SDP

--- a/internal/providers/openai/realtime.go
+++ b/internal/providers/openai/realtime.go
@@ -26,6 +26,11 @@ func (p *Provider) RealtimeTarget(ctx context.Context, req *core.RealtimeRequest
 		endpoint, err = providers.OpenAIRealtimeAttachURL(p.GetBaseURL(), req.CallID)
 	} else if strings.TrimSpace(req.Model) == "" {
 		return nil, core.NewInvalidRequestError("model is required for realtime sessions", nil)
+	} else if strings.EqualFold(strings.TrimSpace(req.Intent), "transcription") {
+		// Transcription sessions pick their model via session.update; OpenAI
+		// rejects a model query parameter in this mode, so the requested model
+		// only routed the request to this provider and is dropped from the URL.
+		endpoint, err = providers.OpenAIRealtimeTranscriptionURL(p.GetBaseURL())
 	} else {
 		endpoint, err = providers.OpenAIRealtimeURL(p.GetBaseURL(), req.Model)
 	}

--- a/internal/providers/openai/realtime_test.go
+++ b/internal/providers/openai/realtime_test.go
@@ -131,3 +131,36 @@ func TestRealtimeCallTargetFollowsSetBaseURL(t *testing.T) {
 		t.Errorf("url = %q, want the SetBaseURL host", target.URL)
 	}
 }
+
+func TestRealtimeTargetTranscriptionIntent(t *testing.T) {
+	// A transcription session must dial ?intent=transcription without a model
+	// parameter: OpenAI rejects transcription models as the session model, and
+	// picks the actual model later via session.update. The requested model only
+	// routes the request inside the gateway.
+	p := New(providers.ProviderConfig{APIKey: "k"}, providers.ProviderOptions{}).(*Provider)
+
+	for _, intent := range []string{"transcription", " Transcription "} {
+		target, err := p.RealtimeTarget(context.Background(), &core.RealtimeRequest{Model: "gpt-4o-transcribe", Intent: intent})
+		if err != nil {
+			t.Fatalf("intent %q: unexpected error: %v", intent, err)
+		}
+		if target.URL != "wss://api.openai.com/v1/realtime?intent=transcription" {
+			t.Errorf("intent %q: url = %q, want intent-only realtime URL", intent, target.URL)
+		}
+	}
+
+	// The model still gates the request: without one there is nothing to route
+	// or attribute usage to, transcription intent or not.
+	if _, err := p.RealtimeTarget(context.Background(), &core.RealtimeRequest{Intent: "transcription"}); err == nil {
+		t.Error("expected error for transcription intent without model")
+	}
+
+	// Unknown intents keep today's conversation-session behavior.
+	target, err := p.RealtimeTarget(context.Background(), &core.RealtimeRequest{Model: "gpt-realtime", Intent: "conversation"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(target.URL, "model=gpt-realtime") {
+		t.Errorf("url = %q, want model parameter for non-transcription intent", target.URL)
+	}
+}

--- a/internal/providers/openai/realtime_test.go
+++ b/internal/providers/openai/realtime_test.go
@@ -147,6 +147,11 @@ func TestRealtimeTargetTranscriptionIntent(t *testing.T) {
 		if target.URL != "wss://api.openai.com/v1/realtime?intent=transcription" {
 			t.Errorf("intent %q: url = %q, want intent-only realtime URL", intent, target.URL)
 		}
+		// The URL carries no model, so the provider must ask the gateway to pin
+		// the session.update model selection to the routed model.
+		if target.PinSessionModel != "gpt-4o-transcribe" {
+			t.Errorf("intent %q: PinSessionModel = %q, want the routed model", intent, target.PinSessionModel)
+		}
 	}
 
 	// The model still gates the request: without one there is nothing to route
@@ -162,5 +167,8 @@ func TestRealtimeTargetTranscriptionIntent(t *testing.T) {
 	}
 	if !strings.Contains(target.URL, "model=gpt-realtime") {
 		t.Errorf("url = %q, want model parameter for non-transcription intent", target.URL)
+	}
+	if target.PinSessionModel != "" {
+		t.Errorf("PinSessionModel = %q, want empty: the URL already fixes the model", target.PinSessionModel)
 	}
 }

--- a/internal/providers/realtime_url.go
+++ b/internal/providers/realtime_url.go
@@ -25,6 +25,23 @@ func OpenAIRealtimeURL(baseURL, model string) (string, error) {
 	return u.String(), nil
 }
 
+// OpenAIRealtimeTranscriptionURL derives the websocket URL for an OpenAI
+// transcription session: https://host/v1 -> wss://host/v1/realtime?intent=transcription.
+// OpenAI selects the transcription model through the session.update event, and
+// rejects a model query parameter in transcription mode ("transcription model
+// cannot be used as the realtime session model"), so unlike OpenAIRealtimeURL no
+// model is placed in the URL — the caller's model only routes inside the gateway.
+func OpenAIRealtimeTranscriptionURL(baseURL string) (string, error) {
+	u, err := openAIRealtimeBase(baseURL, "ws", "wss")
+	if err != nil {
+		return "", err
+	}
+	q := url.Values{}
+	q.Set("intent", "transcription")
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
 // OpenAIRealtimeAttachURL derives the websocket URL that attaches to an existing
 // realtime call as a sideband channel: https://host/v1 -> wss://host/v1/realtime?call_id=...
 // The call already owns a model, so no model parameter is sent.

--- a/internal/providers/realtime_url_test.go
+++ b/internal/providers/realtime_url_test.go
@@ -119,3 +119,42 @@ func TestOpenAIRealtimeHTTPURL(t *testing.T) {
 		})
 	}
 }
+
+func TestOpenAIRealtimeTranscriptionURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		want    string
+		wantErr bool
+	}{
+		// OpenAI rejects a model query parameter in transcription mode, so the
+		// URL must carry intent=transcription and nothing else.
+		{name: "openai https to wss", baseURL: "https://api.openai.com/v1", want: "wss://api.openai.com/v1/realtime?intent=transcription"},
+		{name: "http maps to ws", baseURL: "http://localhost:9000/v1", want: "ws://localhost:9000/v1/realtime?intent=transcription"},
+		{name: "empty base", baseURL: "", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := OpenAIRealtimeTranscriptionURL(tt.baseURL)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("url = %q, want %q", got, tt.want)
+			}
+			u, parseErr := url.Parse(got)
+			if parseErr != nil {
+				t.Fatalf("result is not a valid URL: %v", parseErr)
+			}
+			if u.Query().Has("model") {
+				t.Errorf("url %q carries a model parameter; transcription sessions must not send one", got)
+			}
+		})
+	}
+}

--- a/internal/providers/router.go
+++ b/internal/providers/router.go
@@ -916,6 +916,7 @@ func (r *Router) RealtimeTarget(ctx context.Context, req *core.RealtimeRequest) 
 		Model:    selector.Model,
 		Provider: selector.Provider,
 		CallID:   req.CallID,
+		Intent:   req.Intent,
 	})
 }
 

--- a/internal/providers/router_realtime_test.go
+++ b/internal/providers/router_realtime_test.go
@@ -79,6 +79,23 @@ func TestRouterRealtimeTargetForwardsCallID(t *testing.T) {
 	}
 }
 
+func TestRouterRealtimeTargetForwardsIntent(t *testing.T) {
+	// Transcription sessions carry intent=transcription end to end; the router
+	// must not drop it while re-shaping the request around the resolved selector.
+	rt := &realtimeMockProvider{}
+	lookup := newMockLookup()
+	lookup.addModel("gpt-4o-transcribe", rt, "openai")
+	router, _ := NewRouter(lookup)
+
+	_, err := router.RealtimeTarget(context.Background(), &core.RealtimeRequest{Model: "gpt-4o-transcribe", Intent: "transcription"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rt.lastReq == nil || rt.lastReq.Intent != "transcription" {
+		t.Errorf("provider received %+v, want forwarded intent", rt.lastReq)
+	}
+}
+
 func TestRouterRealtimeCallTargetRoutesByModel(t *testing.T) {
 	rt := &realtimeMockProvider{}
 	lookup := newMockLookup()

--- a/internal/realtime/proxy.go
+++ b/internal/realtime/proxy.go
@@ -39,13 +39,16 @@ func (e *DialError) Unwrap() error { return e.Err }
 // Proxy upgrades the client request to a websocket, dials the upstream target,
 // and relays frames bidirectionally until either side closes. onServerFrame, if
 // non-nil, observes each upstream->client frame for usage tracking; it must be
-// fast and must not block.
+// fast and must not block. mapClientFrame, if non-nil, maps each client->upstream
+// frame before it is forwarded (returning the frame unchanged when it has nothing
+// to do); it carries session policy such as pinning the transcription model, and
+// must be fast and must not block.
 //
 // The upstream is dialed first: if it fails, the client is not yet upgraded, so a
 // *DialError is returned and the caller may write an HTTP error. Once the client
 // is upgraded the connection is hijacked; Proxy then returns nil on a clean close
 // or the terminal transport error (never a *DialError) for the caller to log.
-func Proxy(w http.ResponseWriter, r *http.Request, target Target, onServerFrame func([]byte)) error {
+func Proxy(w http.ResponseWriter, r *http.Request, target Target, onServerFrame func([]byte), mapClientFrame func([]byte) []byte) error {
 	upstream, _, err := websocket.Dial(r.Context(), target.URL, &websocket.DialOptions{
 		HTTPHeader:   target.Headers,
 		Subprotocols: target.Subprotocols,
@@ -68,7 +71,7 @@ func Proxy(w http.ResponseWriter, r *http.Request, target Target, onServerFrame 
 	}
 	client.SetReadLimit(MaxFrameBytes)
 
-	return relay(r.Context(), client, upstream, onServerFrame)
+	return relay(r.Context(), client, upstream, onServerFrame, mapClientFrame)
 }
 
 // Heartbeat cadence. A silently dead peer (NAT timeout, power loss — no RST,
@@ -83,13 +86,13 @@ var (
 // relay runs the two copy loops plus the heartbeat, tears everything down
 // when any of them ends, and returns the terminal cause (nil for a normal
 // close).
-func relay(ctx context.Context, client, upstream *websocket.Conn, onServerFrame func([]byte)) error {
+func relay(ctx context.Context, client, upstream *websocket.Conn, onServerFrame func([]byte), mapClientFrame func([]byte) []byte) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	done := make(chan error, 3)
-	go func() { done <- copyFrames(ctx, upstream, client, nil) }()           // client -> upstream
-	go func() { done <- copyFrames(ctx, client, upstream, onServerFrame) }() // upstream -> client
+	go func() { done <- copyFrames(ctx, upstream, client, mapClientFrame) }()         // client -> upstream
+	go func() { done <- copyFrames(ctx, client, upstream, observe(onServerFrame)) }() // upstream -> client
 	go func() {
 		done <- heartbeat(ctx, func(ctx context.Context) error { return pingBoth(ctx, client, upstream) })
 	}()
@@ -148,21 +151,32 @@ func ping(ctx context.Context, conn *websocket.Conn) error {
 	return conn.Ping(pingCtx)
 }
 
-// copyFrames relays every message from src to dst, invoking tap on each payload
-// before forwarding. It returns the first read or write error, which ends the
-// session.
-func copyFrames(ctx context.Context, dst, src *websocket.Conn, tap func([]byte)) error {
+// copyFrames relays every message from src to dst, passing each payload through
+// mapFrame before forwarding. It returns the first read or write error, which
+// ends the session.
+func copyFrames(ctx context.Context, dst, src *websocket.Conn, mapFrame func([]byte) []byte) error {
 	for {
 		typ, data, err := src.Read(ctx)
 		if err != nil {
 			return err
 		}
-		if tap != nil {
-			tap(data)
+		if mapFrame != nil {
+			data = mapFrame(data)
 		}
 		if err := dst.Write(ctx, typ, data); err != nil {
 			return err
 		}
+	}
+}
+
+// observe adapts a read-only frame tap to copyFrames' mapping shape.
+func observe(tap func([]byte)) func([]byte) []byte {
+	if tap == nil {
+		return nil
+	}
+	return func(frame []byte) []byte {
+		tap(frame)
+		return frame
 	}
 }
 

--- a/internal/realtime/proxy_test.go
+++ b/internal/realtime/proxy_test.go
@@ -1,6 +1,7 @@
 package realtime_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"net/http"
@@ -46,8 +47,14 @@ func echoServer(t *testing.T) *httptest.Server {
 // reports each Proxy return value on retc.
 func proxyServer(t *testing.T, upstreamWS string, onServerFrame func([]byte), retc chan<- error) *httptest.Server {
 	t.Helper()
+	return mappingProxyServer(t, upstreamWS, onServerFrame, nil, retc)
+}
+
+// mappingProxyServer is proxyServer with a client->upstream frame mapper.
+func mappingProxyServer(t *testing.T, upstreamWS string, onServerFrame func([]byte), mapClientFrame func([]byte) []byte, retc chan<- error) *httptest.Server {
+	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := realtime.Proxy(w, r, realtime.Target{URL: upstreamWS}, onServerFrame)
+		err := realtime.Proxy(w, r, realtime.Target{URL: upstreamWS}, onServerFrame, mapClientFrame)
 		if retc != nil {
 			retc <- err
 		}
@@ -144,7 +151,7 @@ func TestProxyDialErrorBeforeUpgrade(t *testing.T) {
 	// *DialError before upgrading the client so the caller can write an HTTP error.
 	retc := make(chan error, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := realtime.Proxy(w, r, realtime.Target{URL: "ws://127.0.0.1:1/realtime"}, nil)
+		err := realtime.Proxy(w, r, realtime.Target{URL: "ws://127.0.0.1:1/realtime"}, nil, nil)
 		retc <- err
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadGateway)
@@ -250,5 +257,32 @@ func TestProxyHeartbeatLeavesResponsiveSessionAlive(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("proxy did not finish after client close")
+	}
+}
+
+func TestProxyMapsClientFrames(t *testing.T) {
+	// The client->upstream mapper carries session policy (e.g. pinning the
+	// transcription model), so the upstream must see the mapped frame while the
+	// echoed reply proves the session still relays normally.
+	upstream := echoServer(t)
+	defer upstream.Close()
+	proxy := mappingProxyServer(t, wsURL(upstream.URL), nil, func(frame []byte) []byte {
+		return bytes.ReplaceAll(frame, []byte("client"), []byte("mapped"))
+	}, nil)
+	defer proxy.Close()
+
+	c, ctx, cancel := dialClient(t, proxy.URL)
+	defer cancel()
+	defer c.Close(websocket.StatusNormalClosure, "done")
+
+	if err := c.Write(ctx, websocket.MessageText, []byte(`{"from":"client"}`)); err != nil {
+		t.Fatalf("client write failed: %v", err)
+	}
+	_, echoed, err := c.Read(ctx)
+	if err != nil {
+		t.Fatalf("client read failed: %v", err)
+	}
+	if got := string(echoed); got != `{"from":"mapped"}` {
+		t.Errorf("upstream saw %q, want the mapped frame", got)
 	}
 }

--- a/internal/server/realtime_service.go
+++ b/internal/server/realtime_service.go
@@ -115,7 +115,14 @@ func (s *realtimeService) handle(c *echo.Context, model, providerHint string) er
 	}
 	defer release()
 	// Route on the resolved selector: an alias never reaches the provider lookup.
-	target, err := router.RealtimeTarget(ctx, &core.RealtimeRequest{Model: route.selector.Model, Provider: route.selector.Provider, CallID: callID})
+	target, err := router.RealtimeTarget(ctx, &core.RealtimeRequest{
+		Model:    route.selector.Model,
+		Provider: route.selector.Provider,
+		CallID:   callID,
+		// intent=transcription asks OpenAI for a transcription session; the model
+		// still resolves routing, access, and usage attribution above.
+		Intent: strings.TrimSpace(c.QueryParam("intent")),
+	})
 	if err != nil {
 		return handleError(c, err)
 	}

--- a/internal/server/realtime_service.go
+++ b/internal/server/realtime_service.go
@@ -16,10 +16,15 @@ import (
 	"github.com/enterpilot/gomodel/internal/usage"
 )
 
-// responseDoneMarker gates realtime usage parsing: only frames containing a
-// "response.done" event carry usage, so a cheap byte scan avoids JSON-parsing
-// every audio delta on the relay hot path.
-var responseDoneMarker = []byte(`"response.done"`)
+// Usage markers gate realtime usage parsing: conversation sessions report usage
+// in "response.done" events, transcription sessions in
+// "conversation.item.input_audio_transcription.completed" events. A cheap byte
+// scan avoids JSON-parsing every audio delta on the relay hot path.
+var (
+	responseDoneMarker       = []byte(`"response.done"`)
+	transcriptionUsageMarker = []byte(`"conversation.item.input_audio_transcription.completed"`)
+	transcriptionIntent      = "transcription"
+)
 
 // realtimeService adapts Echo requests to the realtime websocket reverse proxy.
 // It stays a thin transport layer: validate, authorize, enforce budget, resolve
@@ -115,13 +120,14 @@ func (s *realtimeService) handle(c *echo.Context, model, providerHint string) er
 	}
 	defer release()
 	// Route on the resolved selector: an alias never reaches the provider lookup.
+	// intent=transcription asks OpenAI for a transcription session; the model
+	// still resolves routing, access, and usage attribution above.
+	intent := strings.TrimSpace(c.QueryParam("intent"))
 	target, err := router.RealtimeTarget(ctx, &core.RealtimeRequest{
 		Model:    route.selector.Model,
 		Provider: route.selector.Provider,
 		CallID:   callID,
-		// intent=transcription asks OpenAI for a transcription session; the model
-		// still resolves routing, access, and usage attribution above.
-		Intent: strings.TrimSpace(c.QueryParam("intent")),
+		Intent:   intent,
 	})
 	if err != nil {
 		return handleError(c, err)
@@ -132,7 +138,14 @@ func (s *realtimeService) handle(c *echo.Context, model, providerHint string) er
 		// usage; tapping the attach session too would double-count every response.
 		tap = nil
 	}
-	return s.proxy(c, ctx, target, route, tap)
+	// A transcription session's upstream URL carries no model, so the client's
+	// session.update picks it; pin it to the routed model the caller was
+	// authorized for.
+	var mapClientFrame func([]byte) []byte
+	if strings.EqualFold(intent, transcriptionIntent) {
+		mapClientFrame = pinTranscriptionModel(route.selector.Model)
+	}
+	return s.proxy(c, ctx, target, route, tap, mapClientFrame)
 }
 
 // prepare resolves and authorizes the model, enforces budget, and stamps the
@@ -178,7 +191,7 @@ func (s *realtimeService) prepare(c *echo.Context, model, providerHint string) (
 // proxy injects credentials, relays frames, and logs the session lifecycle. A
 // pre-upgrade dial failure becomes a normal HTTP error; once upgraded the
 // connection is hijacked and the outcome is logged.
-func (s *realtimeService) proxy(c *echo.Context, ctx context.Context, target *core.RealtimeTarget, route realtimeRoute, tap func([]byte)) error {
+func (s *realtimeService) proxy(c *echo.Context, ctx context.Context, target *core.RealtimeTarget, route realtimeRoute, tap func([]byte), mapClientFrame func([]byte) []byte) error {
 	if target == nil || strings.TrimSpace(target.URL) == "" {
 		return handleError(c, core.NewProviderError(route.providerType, http.StatusBadGateway, "provider returned no realtime target", nil))
 	}
@@ -190,7 +203,7 @@ func (s *realtimeService) proxy(c *echo.Context, ctx context.Context, target *co
 	}
 
 	slog.Info("realtime session opened", "request_id", route.requestID, "model", route.model, "provider", route.providerType)
-	err := realtime.Proxy(c.Response(), c.Request(), t, tap)
+	err := realtime.Proxy(c.Response(), c.Request(), t, tap, mapClientFrame)
 
 	var de *realtime.DialError
 	if errors.As(err, &de) {
@@ -206,7 +219,8 @@ func (s *realtimeService) proxy(c *echo.Context, ctx context.Context, target *co
 }
 
 // usageTap returns a frame observer that records one usage entry per realtime
-// "response.done" event, or nil when usage tracking is off (so the proxy skips
+// usage event ("response.done", or the transcription completed event for
+// transcription sessions), or nil when usage tracking is off (so the proxy skips
 // the tap entirely). It honors both the global usage setting and per-workflow
 // usage policy, mirroring the other streaming paths. usageLogger.Write is
 // non-blocking, so the tap runs inline.
@@ -218,7 +232,8 @@ func (s *realtimeService) usageTap(ctx context.Context, route realtimeRoute) fun
 		return nil
 	}
 	return func(frame []byte) {
-		if !bytes.Contains(frame, responseDoneMarker) {
+		isResponseDone := bytes.Contains(frame, responseDoneMarker)
+		if !isResponseDone && !bytes.Contains(frame, transcriptionUsageMarker) {
 			return
 		}
 		var pricing *core.ModelPricing
@@ -229,7 +244,12 @@ func (s *realtimeService) usageTap(ctx context.Context, route realtimeRoute) fun
 			}
 			pricing = s.pricingResolver.ResolvePricing(route.model, provider)
 		}
-		entry := usage.ExtractFromRealtimeResponseDone(frame, route.requestID, route.model, route.providerType, pricing)
+		var entry *usage.UsageEntry
+		if isResponseDone {
+			entry = usage.ExtractFromRealtimeResponseDone(frame, route.requestID, route.model, route.providerType, pricing)
+		} else {
+			entry = usage.ExtractFromRealtimeTranscriptionCompleted(frame, route.requestID, route.model, route.providerType, pricing)
+		}
 		if entry == nil {
 			return
 		}

--- a/internal/server/realtime_service.go
+++ b/internal/server/realtime_service.go
@@ -23,7 +23,6 @@ import (
 var (
 	responseDoneMarker       = []byte(`"response.done"`)
 	transcriptionUsageMarker = []byte(`"conversation.item.input_audio_transcription.completed"`)
-	transcriptionIntent      = "transcription"
 )
 
 // realtimeService adapts Echo requests to the realtime websocket reverse proxy.
@@ -138,12 +137,12 @@ func (s *realtimeService) handle(c *echo.Context, model, providerHint string) er
 		// usage; tapping the attach session too would double-count every response.
 		tap = nil
 	}
-	// A transcription session's upstream URL carries no model, so the client's
-	// session.update picks it; pin it to the routed model the caller was
-	// authorized for.
+	// A provider that leaves the model out of the upstream URL (OpenAI
+	// transcription sessions) asks the gateway to pin the client's in-session
+	// model selection to the routed model the caller was authorized for.
 	var mapClientFrame func([]byte) []byte
-	if strings.EqualFold(intent, transcriptionIntent) {
-		mapClientFrame = pinTranscriptionModel(route.selector.Model)
+	if model := strings.TrimSpace(target.PinSessionModel); model != "" {
+		mapClientFrame = pinTranscriptionModel(model)
 	}
 	return s.proxy(c, ctx, target, route, tap, mapClientFrame)
 }

--- a/internal/server/realtime_service_test.go
+++ b/internal/server/realtime_service_test.go
@@ -3,7 +3,10 @@ package server
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/labstack/echo/v5"
 )
 
 func TestIsWebSocketUpgrade(t *testing.T) {
@@ -62,5 +65,31 @@ func TestRealtimeUpstreamHeaders(t *testing.T) {
 		if len(key) >= 13 && http.CanonicalHeaderKey(key)[:13] == "Sec-Websocket" {
 			t.Errorf("handshake header leaked upstream: %q", key)
 		}
+	}
+}
+
+func TestRealtimeForwardsTrimmedIntent(t *testing.T) {
+	// The handler translates the intent query parameter into the provider
+	// request: trimmed, alongside the resolved model. The websocket dial fails
+	// (no upstream), but the request is captured before the dial.
+	mock := &realtimeWebRTCMock{
+		mockProvider: &mockProvider{supportedModels: []string{"gpt-4o-transcribe"}},
+	}
+	handler := newRealtimeTestHandler(mock, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/realtime?model=gpt-4o-transcribe&intent=%20transcription%20", nil)
+	rec := httptest.NewRecorder()
+	c := echo.New().NewContext(req, rec)
+
+	_ = handler.Realtime(c)
+
+	if mock.capturedRealtime == nil {
+		t.Fatalf("router received no request (status %d, body %s)", rec.Code, rec.Body.String())
+	}
+	if mock.capturedRealtime.Intent != "transcription" {
+		t.Errorf("intent = %q, want trimmed %q", mock.capturedRealtime.Intent, "transcription")
+	}
+	if mock.capturedRealtime.Model != "gpt-4o-transcribe" || mock.capturedRealtime.CallID != "" {
+		t.Errorf("router received %+v, want the resolved model and no call id", mock.capturedRealtime)
 	}
 }

--- a/internal/server/realtime_transcription.go
+++ b/internal/server/realtime_transcription.go
@@ -31,7 +31,11 @@ func pinTranscriptionModel(model string) func([]byte) []byte {
 		}
 		// GA shape: session.audio.input.transcription.model. Missing levels are
 		// created so a session.update without a model is pinned too.
-		childMap(childMap(childMap(session, "audio"), "input"), "transcription")["model"] = model
+		transcription, ok := ensurePath(session, "audio", "input", "transcription")
+		if !ok {
+			return frame
+		}
+		transcription["model"] = model
 		// Legacy beta shape: session.input_audio_transcription.model. Only pinned
 		// when the client sent it, so the gateway never introduces the old field.
 		if legacy, ok := session["input_audio_transcription"].(map[string]any); ok {
@@ -45,13 +49,23 @@ func pinTranscriptionModel(model string) func([]byte) []byte {
 	}
 }
 
-// childMap returns parent[key] as an object, creating it when absent or of
-// another type.
-func childMap(parent map[string]any, key string) map[string]any {
-	if m, ok := parent[key].(map[string]any); ok {
-		return m
+// ensurePath descends the nested objects named by keys, creating levels that
+// are absent (or null). An existing non-object value on the path means the
+// frame is malformed: ensurePath reports false so the caller forwards the
+// original frame for the upstream to reject, instead of destroying the
+// client's value.
+func ensurePath(parent map[string]any, keys ...string) (map[string]any, bool) {
+	for _, key := range keys {
+		switch child := parent[key].(type) {
+		case map[string]any:
+			parent = child
+		case nil:
+			m := map[string]any{}
+			parent[key] = m
+			parent = m
+		default:
+			return nil, false
+		}
 	}
-	m := map[string]any{}
-	parent[key] = m
-	return m
+	return parent, true
 }

--- a/internal/server/realtime_transcription.go
+++ b/internal/server/realtime_transcription.go
@@ -1,0 +1,61 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// sessionUpdateMarker gates transcription-model pinning: only session.update
+// frames can select a model, so a cheap byte scan skips the audio appends that
+// dominate the relay hot path.
+var sessionUpdateMarker = []byte(`"session.update"`)
+
+// pinTranscriptionModel returns a client-frame mapper for transcription
+// sessions that rewrites every session.update to carry the gateway-routed
+// model. The relay otherwise forwards frames verbatim, which would let a caller
+// authorized (and billed) for one transcription model select another inside the
+// session payload. Pinning makes model access, rate limits, and usage
+// attribution correct by construction — and lets clients omit the model from
+// session.update entirely.
+//
+// Frames that are not session.update, or that do not parse, are forwarded
+// unchanged: the upstream is the authority on rejecting malformed events.
+func pinTranscriptionModel(model string) func([]byte) []byte {
+	return func(frame []byte) []byte {
+		if !bytes.Contains(frame, sessionUpdateMarker) {
+			return frame
+		}
+		var event map[string]any
+		if err := json.Unmarshal(frame, &event); err != nil || event["type"] != "session.update" {
+			return frame
+		}
+		session, ok := event["session"].(map[string]any)
+		if !ok {
+			return frame
+		}
+		// GA shape: session.audio.input.transcription.model. Missing levels are
+		// created so a session.update without a model is pinned too.
+		childMap(childMap(childMap(session, "audio"), "input"), "transcription")["model"] = model
+		// Legacy beta shape: session.input_audio_transcription.model. Only pinned
+		// when the client sent it, so the gateway never introduces the old field.
+		if legacy, ok := session["input_audio_transcription"].(map[string]any); ok {
+			legacy["model"] = model
+		}
+		pinned, err := json.Marshal(event)
+		if err != nil {
+			return frame
+		}
+		return pinned
+	}
+}
+
+// childMap returns parent[key] as an object, creating it when absent or of
+// another type.
+func childMap(parent map[string]any, key string) map[string]any {
+	if m, ok := parent[key].(map[string]any); ok {
+		return m
+	}
+	m := map[string]any{}
+	parent[key] = m
+	return m
+}

--- a/internal/server/realtime_transcription.go
+++ b/internal/server/realtime_transcription.go
@@ -1,14 +1,8 @@
 package server
 
 import (
-	"bytes"
 	"encoding/json"
 )
-
-// sessionUpdateMarker gates transcription-model pinning: only session.update
-// frames can select a model, so a cheap byte scan skips the audio appends that
-// dominate the relay hot path.
-var sessionUpdateMarker = []byte(`"session.update"`)
 
 // pinTranscriptionModel returns a client-frame mapper for transcription
 // sessions that rewrites every session.update to carry the gateway-routed
@@ -20,11 +14,13 @@ var sessionUpdateMarker = []byte(`"session.update"`)
 //
 // Frames that are not session.update, or that do not parse, are forwarded
 // unchanged: the upstream is the authority on rejecting malformed events.
+//
+// Every frame is JSON-decoded to find its type: a raw byte-marker pre-filter
+// would be cheaper, but JSON string escapes ("session\u002eupdate") would slip
+// past it and reopen the model bypass this mapper exists to close. Decoding a
+// few audio frames per second is well below the relay's transport cost.
 func pinTranscriptionModel(model string) func([]byte) []byte {
 	return func(frame []byte) []byte {
-		if !bytes.Contains(frame, sessionUpdateMarker) {
-			return frame
-		}
 		var event map[string]any
 		if err := json.Unmarshal(frame, &event); err != nil || event["type"] != "session.update" {
 			return frame

--- a/internal/server/realtime_transcription_test.go
+++ b/internal/server/realtime_transcription_test.go
@@ -1,0 +1,60 @@
+package server
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestPinTranscriptionModel(t *testing.T) {
+	pin := pinTranscriptionModel("gpt-4o-transcribe")
+
+	tests := []struct {
+		name  string
+		frame string
+		want  string // "" means the frame must pass through unchanged
+	}{
+		{
+			name:  "rewrites a client-chosen model",
+			frame: `{"type":"session.update","session":{"type":"transcription","audio":{"input":{"transcription":{"model":"whisper-1","language":"pl"}}}}}`,
+			want:  `{"session":{"audio":{"input":{"transcription":{"language":"pl","model":"gpt-4o-transcribe"}}},"type":"transcription"},"type":"session.update"}`,
+		},
+		{
+			name:  "pins when the client omits the model",
+			frame: `{"type":"session.update","session":{"type":"transcription"}}`,
+			want:  `{"session":{"audio":{"input":{"transcription":{"model":"gpt-4o-transcribe"}}},"type":"transcription"},"type":"session.update"}`,
+		},
+		{
+			name:  "pins the legacy beta field only when the client sent it",
+			frame: `{"type":"session.update","session":{"input_audio_transcription":{"model":"whisper-1"}}}`,
+			want:  `{"session":{"audio":{"input":{"transcription":{"model":"gpt-4o-transcribe"}}},"input_audio_transcription":{"model":"gpt-4o-transcribe"}},"type":"session.update"}`,
+		},
+		{name: "audio append passes untouched", frame: `{"type":"input_audio_buffer.append","audio":"AAAA"}`},
+		{name: "marker in a string value is not a session.update", frame: `{"type":"conversation.item.create","text":"say \"session.update\""}`},
+		{name: "session.update without session object passes to upstream to reject", frame: `{"type":"session.update"}`},
+		{name: "invalid JSON passes to upstream to reject", frame: `{"type":"session.update",`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := string(pin([]byte(tt.frame)))
+			want := tt.want
+			if want == "" {
+				want = tt.frame
+			}
+			if !jsonOrRawEqual(got, want) {
+				t.Errorf("mapped frame = %s, want %s", got, want)
+			}
+		})
+	}
+}
+
+// jsonOrRawEqual compares JSON payloads structurally, falling back to raw string
+// comparison for non-JSON frames.
+func jsonOrRawEqual(a, b string) bool {
+	var av, bv any
+	if json.Unmarshal([]byte(a), &av) != nil || json.Unmarshal([]byte(b), &bv) != nil {
+		return a == b
+	}
+	aj, _ := json.Marshal(av)
+	bj, _ := json.Marshal(bv)
+	return string(aj) == string(bj)
+}

--- a/internal/server/realtime_transcription_test.go
+++ b/internal/server/realtime_transcription_test.go
@@ -28,6 +28,13 @@ func TestPinTranscriptionModel(t *testing.T) {
 			frame: `{"type":"session.update","session":{"input_audio_transcription":{"model":"whisper-1"}}}`,
 			want:  `{"session":{"audio":{"input":{"transcription":{"model":"gpt-4o-transcribe"}}},"input_audio_transcription":{"model":"gpt-4o-transcribe"}},"type":"session.update"}`,
 		},
+		{
+			// A raw byte-marker gate would miss the escaped type and let the
+			// frame through unpinned; the decoded type must be what counts.
+			name:  "escape-encoded session.update is still pinned",
+			frame: `{"type":"session\u002eupdate","session":{"audio":{"input":{"transcription":{"model":"whisper-1"}}}}}`,
+			want:  `{"session":{"audio":{"input":{"transcription":{"model":"gpt-4o-transcribe"}}}},"type":"session.update"}`,
+		},
 		{name: "audio append passes untouched", frame: `{"type":"input_audio_buffer.append","audio":"AAAA"}`},
 		{name: "marker in a string value is not a session.update", frame: `{"type":"conversation.item.create","text":"say \"session.update\""}`},
 		{name: "session.update without session object passes to upstream to reject", frame: `{"type":"session.update"}`},

--- a/internal/server/realtime_transcription_test.go
+++ b/internal/server/realtime_transcription_test.go
@@ -38,6 +38,19 @@ func TestPinTranscriptionModel(t *testing.T) {
 		{name: "audio append passes untouched", frame: `{"type":"input_audio_buffer.append","audio":"AAAA"}`},
 		{name: "marker in a string value is not a session.update", frame: `{"type":"conversation.item.create","text":"say \"session.update\""}`},
 		{name: "session.update without session object passes to upstream to reject", frame: `{"type":"session.update"}`},
+		{
+			// Pinning must never destroy a client value: a non-object where the
+			// transcription config nests is the upstream's error to report.
+			name:  "scalar audio passes to upstream to reject",
+			frame: `{"type":"session.update","session":{"audio":"bogus"}}`,
+		},
+		{name: "array input passes to upstream to reject", frame: `{"type":"session.update","session":{"audio":{"input":[1,2]}}}`},
+		{name: "scalar transcription passes to upstream to reject", frame: `{"type":"session.update","session":{"audio":{"input":{"transcription":7}}}}`},
+		{
+			name:  "null audio is treated as absent and pinned",
+			frame: `{"type":"session.update","session":{"audio":null}}`,
+			want:  `{"session":{"audio":{"input":{"transcription":{"model":"gpt-4o-transcribe"}}}},"type":"session.update"}`,
+		},
 		{name: "invalid JSON passes to upstream to reject", frame: `{"type":"session.update",`},
 	}
 	for _, tt := range tests {

--- a/internal/usage/realtime.go
+++ b/internal/usage/realtime.go
@@ -81,8 +81,40 @@ func ExtractFromRealtimeResponseDone(payload []byte, requestID, model, provider 
 	if event.Type != "response.done" || event.Response.Usage == nil {
 		return nil
 	}
-	u := event.Response.Usage
+	return realtimeUsageEntry(event.Response.Usage, requestID, model, provider, pricing...)
+}
 
+// ExtractFromRealtimeTranscriptionCompleted builds a usage entry from a
+// "conversation.item.input_audio_transcription.completed" event, which is how
+// transcription sessions report usage — they never emit response.done. Token
+// usage prices like other realtime traffic; whisper-style duration usage is
+// recorded in rawData for visibility rather than priced.
+func ExtractFromRealtimeTranscriptionCompleted(payload []byte, requestID, model, provider string, pricing ...*core.ModelPricing) *UsageEntry {
+	var event struct {
+		Type  string `json:"type"`
+		Usage *struct {
+			realtimeUsage
+			Kind    string  `json:"type"`
+			Seconds float64 `json:"seconds"`
+		} `json:"usage"`
+	}
+	if json.Unmarshal(payload, &event) != nil {
+		return nil
+	}
+	if event.Type != "conversation.item.input_audio_transcription.completed" || event.Usage == nil {
+		return nil
+	}
+	if event.Usage.Kind == "duration" {
+		entry := realtimeUsageEntry(&realtimeUsage{}, requestID, model, provider, pricing...)
+		entry.RawData = map[string]any{"duration_seconds": event.Usage.Seconds}
+		return entry
+	}
+	return realtimeUsageEntry(&event.Usage.realtimeUsage, requestID, model, provider, pricing...)
+}
+
+// realtimeUsageEntry builds the usage entry shared by every realtime usage
+// event shape.
+func realtimeUsageEntry(u *realtimeUsage, requestID, model, provider string, pricing ...*core.ModelPricing) *UsageEntry {
 	entry := &UsageEntry{
 		ID:           uuid.New().String(),
 		RequestID:    requestID,

--- a/internal/usage/realtime.go
+++ b/internal/usage/realtime.go
@@ -88,7 +88,8 @@ func ExtractFromRealtimeResponseDone(payload []byte, requestID, model, provider 
 // "conversation.item.input_audio_transcription.completed" event, which is how
 // transcription sessions report usage — they never emit response.done. Token
 // usage prices like other realtime traffic; whisper-style duration usage is
-// recorded in rawData for visibility rather than priced.
+// carried as input audio seconds so the per-second input rate prices it, the
+// same as HTTP transcription (see usage/audio.go).
 func ExtractFromRealtimeTranscriptionCompleted(payload []byte, requestID, model, provider string, pricing ...*core.ModelPricing) *UsageEntry {
 	var event struct {
 		Type  string `json:"type"`
@@ -105,8 +106,16 @@ func ExtractFromRealtimeTranscriptionCompleted(payload []byte, requestID, model,
 		return nil
 	}
 	if event.Usage.Kind == "duration" {
-		entry := realtimeUsageEntry(&realtimeUsage{}, requestID, model, provider, pricing...)
-		entry.RawData = map[string]any{"duration_seconds": event.Usage.Seconds}
+		entry := &UsageEntry{
+			ID:        uuid.New().String(),
+			RequestID: requestID,
+			Timestamp: time.Now().UTC(),
+			Model:     model,
+			Provider:  provider,
+			Endpoint:  endpointRealtime,
+			RawData:   map[string]any{rawKeyAudioSeconds: event.Usage.Seconds},
+		}
+		applyUsageCosts(entry, provider, endpointRealtime, pricing...)
 		return entry
 	}
 	return realtimeUsageEntry(&event.Usage.realtimeUsage, requestID, model, provider, pricing...)

--- a/internal/usage/realtime_test.go
+++ b/internal/usage/realtime_test.go
@@ -168,23 +168,26 @@ func TestExtractFromRealtimeTranscriptionCompleted(t *testing.T) {
 }
 
 func TestExtractFromRealtimeTranscriptionCompletedDuration(t *testing.T) {
-	// whisper-1 reports duration usage instead of tokens; it is recorded for
-	// visibility, not priced.
+	// whisper-1 reports duration usage instead of tokens: it must carry the
+	// same rawData key as HTTP transcription so the per-second input rate
+	// prices it. 2.5 s at $0.0001/s => $0.00025.
 	payload := []byte(`{
 		"type": "conversation.item.input_audio_transcription.completed",
 		"usage": {"type": "duration", "seconds": 2.5}
 	}`)
+	pricing := &core.ModelPricing{PerSecondInput: new(0.0001)}
 
-	entry := ExtractFromRealtimeTranscriptionCompleted(payload, "req-1", "whisper-1", "openai")
+	entry := ExtractFromRealtimeTranscriptionCompleted(payload, "req-1", "whisper-1", "openai", pricing)
 	if entry == nil {
 		t.Fatal("expected a usage entry")
 	}
 	if entry.TotalTokens != 0 {
 		t.Errorf("tokens = %d, want 0 for duration usage", entry.TotalTokens)
 	}
-	if entry.RawData["duration_seconds"] != 2.5 {
-		t.Errorf("duration missing/miskeyed: %v", entry.RawData)
+	if entry.RawData[rawKeyAudioSeconds] != 2.5 {
+		t.Errorf("audio seconds missing/miskeyed: %v", entry.RawData)
 	}
+	assertCostPtrNear(t, "input cost", entry.InputCost, 0.00025)
 }
 
 func TestExtractFromRealtimeTranscriptionCompletedSkipsNonBillable(t *testing.T) {

--- a/internal/usage/realtime_test.go
+++ b/internal/usage/realtime_test.go
@@ -136,3 +136,65 @@ func TestExtractFromRealtimeResponseDoneSkipsNonBillable(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractFromRealtimeTranscriptionCompleted(t *testing.T) {
+	// The real event shape from a gpt-4o-transcribe transcription session.
+	payload := []byte(`{
+		"type": "conversation.item.input_audio_transcription.completed",
+		"item_id": "item_1",
+		"transcript": "Hello there.",
+		"usage": {
+			"type": "tokens",
+			"total_tokens": 30,
+			"input_tokens": 25,
+			"output_tokens": 5,
+			"input_token_details": {"text_tokens": 0, "audio_tokens": 25}
+		}
+	}`)
+
+	entry := ExtractFromRealtimeTranscriptionCompleted(payload, "req-1", "gpt-4o-transcribe", "openai")
+	if entry == nil {
+		t.Fatal("expected a usage entry")
+	}
+	if entry.Endpoint != endpointRealtime {
+		t.Errorf("endpoint = %q, want %q", entry.Endpoint, endpointRealtime)
+	}
+	if entry.InputTokens != 25 || entry.OutputTokens != 5 || entry.TotalTokens != 30 {
+		t.Errorf("tokens = (%d,%d,%d), want (25,5,30)", entry.InputTokens, entry.OutputTokens, entry.TotalTokens)
+	}
+	if entry.RawData["prompt_audio_tokens"] != 25 {
+		t.Errorf("audio token breakdown missing/miskeyed: %v", entry.RawData)
+	}
+}
+
+func TestExtractFromRealtimeTranscriptionCompletedDuration(t *testing.T) {
+	// whisper-1 reports duration usage instead of tokens; it is recorded for
+	// visibility, not priced.
+	payload := []byte(`{
+		"type": "conversation.item.input_audio_transcription.completed",
+		"usage": {"type": "duration", "seconds": 2.5}
+	}`)
+
+	entry := ExtractFromRealtimeTranscriptionCompleted(payload, "req-1", "whisper-1", "openai")
+	if entry == nil {
+		t.Fatal("expected a usage entry")
+	}
+	if entry.TotalTokens != 0 {
+		t.Errorf("tokens = %d, want 0 for duration usage", entry.TotalTokens)
+	}
+	if entry.RawData["duration_seconds"] != 2.5 {
+		t.Errorf("duration missing/miskeyed: %v", entry.RawData)
+	}
+}
+
+func TestExtractFromRealtimeTranscriptionCompletedSkipsNonBillable(t *testing.T) {
+	for name, payload := range map[string]string{
+		"delta event":     `{"type":"conversation.item.input_audio_transcription.delta","delta":"He"}`,
+		"missing usage":   `{"type":"conversation.item.input_audio_transcription.completed","transcript":"Hi."}`,
+		"malformed frame": `{"type":`,
+	} {
+		if entry := ExtractFromRealtimeTranscriptionCompleted([]byte(payload), "req-1", "m", "openai"); entry != nil {
+			t.Errorf("%s: expected nil entry, got %+v", name, entry)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

OpenAI's realtime **transcription sessions** dial `wss://api.openai.com/v1/realtime?intent=transcription` and **reject a `model` query parameter** in that mode:

- `?model=gpt-4o-transcribe` → `"Model ... is a transcription model and cannot be used as the realtime session model"`
- `?intent=transcription&model=...` → also rejected
- a `session.update` with `type: "transcription"` on a conversation session → `"Passing a transcription session update to a realtime session is not allowed"`

The relay always set `model` on the upstream URL and dropped `intent` (`OpenAIRealtimeURL`), so streaming STT could not work through the gateway at all.

## Fix

Forward the client's `intent` query parameter end to end — handler → router → provider — and when it equals `transcription` (case-insensitive), dial the intent-only URL via a new `OpenAIRealtimeTranscriptionURL`. 

The requested model keeps doing everything else it does today: **routing, model-access checks, rate limits, budget, and usage attribution** — it is only omitted from the upstream URL, because in this mode OpenAI selects the transcription model through the client's `session.update` event (which the relay already passes through verbatim).

No behavior change for conversation sessions, attach-by-`call_id`, or any other provider (xAI etc. ignore the field).

## Testing

- Unit tests at all three layers: URL builder (no `model` param leaks), OpenAI provider (intent routing, model-still-required, unknown intents unchanged), router (intent not dropped when re-shaping the request — this was an actual bug found during live testing).
- **Verified live** against `api.openai.com` through the relay: connected `ws://localhost:8099/v1/realtime?model=openai/gpt-4o-transcribe&intent=transcription`, sent a transcription `session.update`, streamed 3.2 s of PCM → `session.updated`, per-word `conversation.item.input_audio_transcription.delta` events, and the correct final transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VV48RBH3hiB57Gqf1VK15S

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for realtime transcription sessions.
  * Transcription sessions use dedicated connections and preserve the selected model in session updates.
  * Intent values are trimmed and normalized automatically.
  * Added client-frame processing for transcription sessions.

* **Bug Fixes**
  * Preserved transcription intent during realtime gateway routing.
  * Added usage tracking for transcription completion events, including token- and duration-based usage.
  * Maintained standard model-based realtime conversations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->