### PR TITLE
fix(vllm): rename legacy reasoning_content to reasoning on replayed assistant messages

### DIFF
--- a/internal/providers/vllm/reasoning.go
+++ b/internal/providers/vllm/reasoning.go
@@ -1,0 +1,59 @@
+// Package vllm provides vLLM OpenAI-compatible API integration for the LLM gateway.
+package vllm
+
+import (
+	"github.com/goccy/go-json"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+// adaptChatRequest renames the legacy reasoning_content field to reasoning on
+// replayed assistant messages.
+//
+// vLLM >=0.20 (vllm-project/vllm RFC #27755) reads only the "reasoning"
+// field on incoming assistant messages and silently discards
+// "reasoning_content" before its chat template ever runs. Clients built
+// against the older field name (e.g. OpenCode) intend to replay a prior
+// turn's thinking so Qwen3-family "preserve thinking" behavior keeps
+// working across turns, but that content is dropped on the floor with no
+// error, degrading multi-turn/agentic quality silently.
+//
+// Renaming here restores that continuity without requiring a client change.
+// It only acts when reasoning_content is present and reasoning is absent, so
+// it never overrides a client already using the current field name and never
+// touches requests that carry neither field.
+func adaptChatRequest(req *core.ChatRequest) (*core.ChatRequest, error) {
+	if req == nil {
+		return req, nil
+	}
+
+	var adapted *core.ChatRequest
+	for i, message := range req.Messages {
+		if message.Role != "assistant" {
+			continue
+		}
+
+		legacy := message.ExtraFields.Lookup("reasoning_content")
+		if legacy == nil || message.ExtraFields.Lookup("reasoning") != nil {
+			continue
+		}
+
+		extra, err := core.MergeUnknownJSONFields(message.ExtraFields.Without("reasoning_content"), map[string]json.RawMessage{
+			"reasoning": legacy,
+		})
+		if err != nil {
+			return nil, core.NewInvalidRequestError("failed to adapt vLLM reasoning field: "+err.Error(), err)
+		}
+		if adapted == nil {
+			copy := *req
+			copy.Messages = append([]core.Message(nil), req.Messages...)
+			adapted = &copy
+		}
+		adapted.Messages[i].ExtraFields = extra
+	}
+
+	if adapted == nil {
+		return req, nil
+	}
+	return adapted, nil
+}

--- a/internal/providers/vllm/reasoning_test.go
+++ b/internal/providers/vllm/reasoning_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/enterpilot/gomodel/internal/core"
 	"github.com/enterpilot/gomodel/internal/llmclient"
+	"github.com/enterpilot/gomodel/internal/providers"
 )
 
 func TestChatCompletion_RenamesLegacyReasoningContentOnAssistantMessages(t *testing.T) {
@@ -135,5 +136,79 @@ func TestAdaptChatRequest_NilRequest(t *testing.T) {
 	}
 	if adapted != nil {
 		t.Fatal("adaptChatRequest(nil) should return nil")
+	}
+}
+
+// TestChatCompletion_AppliesAdaptChatRequestThroughStandardConstructor covers
+// the production wiring path: New (used by the factory from config), not
+// NewWithHTTPClient (test-only). The other tests in this file construct the
+// provider via NewWithHTTPClient, which would not catch AdaptChatRequest
+// being wired into one constructor but not the other.
+func TestChatCompletion_AppliesAdaptChatRequestThroughStandardConstructor(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			http.Error(w, "decode error", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-vllm",
+			"created":1,
+			"model":"Qwen3.8-27B",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"done"},"finish_reason":"stop"}]
+		}`))
+	}))
+	defer server.Close()
+
+	var req core.ChatRequest
+	if err := json.Unmarshal([]byte(`{
+		"model":"Qwen3.8-27B",
+		"messages":[
+			{"role":"assistant","content":"12-15 years","reasoning_content":"prior turn reasoning"}
+		]
+	}`), &req); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	provider, ok := New(providers.ProviderConfig{BaseURL: server.URL}, providers.ProviderOptions{}).(*Provider)
+	if !ok {
+		t.Fatal("New() did not return a *Provider")
+	}
+
+	if _, err := provider.ChatCompletion(context.Background(), &req); err != nil {
+		t.Fatalf("ChatCompletion() error = %v", err)
+	}
+
+	messages, _ := gotBody["messages"].([]any)
+	assistantMsg, _ := messages[0].(map[string]any)
+	if assistantMsg["reasoning"] != "prior turn reasoning" {
+		t.Fatalf("reasoning = %#v, want AdaptChatRequest applied through New()", assistantMsg["reasoning"])
+	}
+}
+
+// TestAdaptChatRequest_SkipsMalformedReasoningContentWithoutError documents
+// that a syntactically invalid reasoning_content value is never seen by
+// adaptChatRequest at all: UnknownJSONFields.Lookup decodes each value with
+// a streaming json.Decoder, so a malformed value fails to decode and Lookup
+// returns nil (see UnknownJSONFields.Lookup) rather than surfacing invalid
+// bytes. adaptChatRequest then treats the field as absent. There is no
+// reachable path back into core.MergeUnknownJSONFields with invalid JSON
+// here, since Lookup only ever returns bytes it has already decoded
+// successfully, so this request is left unmodified rather than erroring.
+func TestAdaptChatRequest_SkipsMalformedReasoningContentWithoutError(t *testing.T) {
+	req := &core.ChatRequest{
+		Messages: []core.Message{{Role: "assistant", Content: "hi"}},
+	}
+	req.Messages[0].ExtraFields = core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+		"reasoning_content": json.RawMessage(`not-valid-json{{{`),
+	})
+
+	adapted, err := adaptChatRequest(req)
+	if err != nil {
+		t.Fatalf("adaptChatRequest() error = %v, want nil (malformed value is silently skipped)", err)
+	}
+	if adapted != req {
+		t.Fatal("adaptChatRequest() should not have adapted a message whose reasoning_content failed to decode")
 	}
 }

--- a/internal/providers/vllm/reasoning_test.go
+++ b/internal/providers/vllm/reasoning_test.go
@@ -1,0 +1,139 @@
+package vllm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/llmclient"
+)
+
+func TestChatCompletion_RenamesLegacyReasoningContentOnAssistantMessages(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			http.Error(w, "decode error", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-vllm",
+			"created":1,
+			"model":"Qwen3.8-27B",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"done"},"finish_reason":"stop"}]
+		}`))
+	}))
+	defer server.Close()
+
+	var req core.ChatRequest
+	if err := json.Unmarshal([]byte(`{
+		"model":"Qwen3.8-27B",
+		"messages":[
+			{"role":"user","content":"what is the median life-expectancy of a cat"},
+			{"role":"assistant","content":"12-15 years","reasoning_content":"the user wants a quick factual answer"},
+			{"role":"user","content":"and a dog's?"}
+		]
+	}`), &req); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	provider := NewWithHTTPClient("", server.URL, server.Client(), llmclient.Hooks{})
+	if _, err := provider.ChatCompletion(context.Background(), &req); err != nil {
+		t.Fatalf("ChatCompletion() error = %v", err)
+	}
+
+	messages, _ := gotBody["messages"].([]any)
+	assistantMsg, _ := messages[1].(map[string]any)
+	if assistantMsg["reasoning"] != "the user wants a quick factual answer" {
+		t.Fatalf("reasoning = %#v, want the replayed reasoning_content value", assistantMsg["reasoning"])
+	}
+	if _, present := assistantMsg["reasoning_content"]; present {
+		t.Fatal("reasoning_content should be renamed away, not duplicated alongside reasoning")
+	}
+	if req.Messages[1].ExtraFields.Lookup("reasoning") != nil {
+		t.Fatal("ChatCompletion() mutated the caller's request")
+	}
+}
+
+func TestChatCompletion_DoesNotOverrideExistingReasoningField(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			http.Error(w, "decode error", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-vllm",
+			"created":1,
+			"model":"Qwen3.8-27B",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"done"},"finish_reason":"stop"}]
+		}`))
+	}))
+	defer server.Close()
+
+	var req core.ChatRequest
+	if err := json.Unmarshal([]byte(`{
+		"model":"Qwen3.8-27B",
+		"messages":[
+			{"role":"assistant","content":"12-15 years","reasoning":"current field","reasoning_content":"stale legacy value"}
+		]
+	}`), &req); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	provider := NewWithHTTPClient("", server.URL, server.Client(), llmclient.Hooks{})
+	if _, err := provider.ChatCompletion(context.Background(), &req); err != nil {
+		t.Fatalf("ChatCompletion() error = %v", err)
+	}
+
+	messages, _ := gotBody["messages"].([]any)
+	assistantMsg, _ := messages[0].(map[string]any)
+	if assistantMsg["reasoning"] != "current field" {
+		t.Fatalf("reasoning = %#v, want the untouched current-field value", assistantMsg["reasoning"])
+	}
+}
+
+func TestAdaptChatRequest_NoOpWithoutLegacyReasoningContent(t *testing.T) {
+	req := &core.ChatRequest{
+		Messages: []core.Message{{Role: "assistant", Content: "hi"}},
+	}
+
+	adapted, err := adaptChatRequest(req)
+	if err != nil {
+		t.Fatalf("adaptChatRequest() error = %v", err)
+	}
+	if adapted != req {
+		t.Fatal("adaptChatRequest() copied a request it didn't need to change")
+	}
+}
+
+func TestAdaptChatRequest_IgnoresNonAssistantMessages(t *testing.T) {
+	req := &core.ChatRequest{
+		Messages: []core.Message{{Role: "tool", Content: "ok"}},
+	}
+	req.Messages[0].ExtraFields = core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+		"reasoning_content": json.RawMessage(`"should not move"`),
+	})
+
+	adapted, err := adaptChatRequest(req)
+	if err != nil {
+		t.Fatalf("adaptChatRequest() error = %v", err)
+	}
+	if adapted != req {
+		t.Fatal("adaptChatRequest() should not adapt non-assistant messages")
+	}
+}
+
+func TestAdaptChatRequest_NilRequest(t *testing.T) {
+	adapted, err := adaptChatRequest(nil)
+	if err != nil {
+		t.Fatalf("adaptChatRequest(nil) error = %v", err)
+	}
+	if adapted != nil {
+		t.Fatal("adaptChatRequest(nil) should return nil")
+	}
+}

--- a/internal/providers/vllm/vllm.go
+++ b/internal/providers/vllm/vllm.go
@@ -38,9 +38,10 @@ func New(cfg providers.ProviderConfig, opts providers.ProviderOptions) core.Prov
 	rootBaseURL := passthroughBaseURL(baseURL)
 	return &Provider{
 		compatible: openai.NewCompatibleProvider(cfg.APIKey, opts, openai.CompatibleProviderConfig{
-			ProviderName: "vllm",
-			BaseURL:      baseURL,
-			SetHeaders:   setHeaders,
+			ProviderName:     "vllm",
+			BaseURL:          baseURL,
+			SetHeaders:       setHeaders,
+			AdaptChatRequest: adaptChatRequest,
 		}),
 		rootClient: llmclient.New(llmclient.Config{
 			ProviderName:   "vllm",
@@ -62,9 +63,10 @@ func NewWithHTTPClient(apiKey string, baseURL string, httpClient *http.Client, h
 	rootClientCfg.Hooks = hooks
 	return &Provider{
 		compatible: openai.NewCompatibleProviderWithHTTPClient(apiKey, httpClient, hooks, openai.CompatibleProviderConfig{
-			ProviderName: "vllm",
-			BaseURL:      resolvedBaseURL,
-			SetHeaders:   setHeaders,
+			ProviderName:     "vllm",
+			BaseURL:          resolvedBaseURL,
+			SetHeaders:       setHeaders,
+			AdaptChatRequest: adaptChatRequest,
 		}),
 		rootClient: llmclient.NewWithHTTPClient(httpClient, rootClientCfg, func(req *http.Request) {
 			setHeaders(req, apiKey)


### PR DESCRIPTION
## Summary

- vLLM >=0.20 (vllm-project/vllm RFC #27755) renamed the reasoning field
  from `reasoning_content` to `reasoning` on incoming assistant messages,
  and silently discards the legacy key — no error, it just never reaches
  the chat template.
- Clients built against the older field name replay real prior-turn
  reasoning under `reasoning_content`, intending to preserve it for
  Qwen3-family "preserve thinking" behavior, but that content is dropped
  on the floor before vLLM ever sees it.
- Add an `AdaptChatRequest` hook for the vLLM provider (same extension
  point the DeepSeek provider uses) that renames `reasoning_content` ->
  `reasoning` on replayed assistant messages, only when `reasoning` isn't
  already present. No-op for clients already on the current field name or
  sending neither field.

## Context

Found while debugging why Qwen3.8-27B (served via vLLM 0.20.0, behind
GoModel) wasn't benefiting from multi-turn reasoning continuity. Empirically
confirmed via GoModel's own `audit_logs` that:

- LibreChat and Crush never send any reasoning field on replayed assistant
  messages at all.
- OpenCode sends real reasoning content, but under the legacy
  `reasoning_content` key — silently dropped by vLLM 0.20+.

This PR fixes the OpenCode case (real content, wrong key). The LibreChat/
Crush case is a different problem — no reasoning sent by the client at all —
and would need GoModel to reconstruct history server-side from its own
stored response bodies. Out of scope here; happy to follow up separately if
there's interest.

## Testing

- `go build ./...`
- `go vet ./internal/providers/vllm/...`
- `golangci-lint run ./internal/providers/vllm/...`
- `go test ./internal/providers/vllm/...` — all passing, including 5 new
  tests: rename-on-replay, don't-override-existing-`reasoning`, no-op
  without the legacy field, non-`assistant` messages ignored, nil request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved vLLM compatibility by automatically translating legacy assistant reasoning fields into the supported format.
  - Preserves existing reasoning data and leaves unrelated messages and requests unchanged.
  - Applies consistently across standard and custom HTTP client configurations.

- **Tests**
  - Added coverage for field translation, preservation, no-op scenarios, non-assistant messages, nil requests, request immutability, and outgoing payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->