### PR TITLE
feat(gemini): serve embeddings and image endpoints through the native API

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -474,8 +474,10 @@
 
 # Google Gemini
 # GEMINI_API_KEY=...
-# Use Gemini's native generateContent API for chat/responses (default: true).
-# Set to false to use Gemini's OpenAI-compatible API for chat/responses.
+# Use Gemini's native APIs (default: true): generateContent for chat/responses
+# and image models, batchEmbedContents for embeddings, predict for Imagen.
+# Set to false to use Gemini's OpenAI-compatible API instead (image edits are
+# then unavailable; the OpenAI-compatible surface has no edits endpoint).
 # Native mode supports inline image data via data: URLs, but GoModel does not
 # fetch remote image URLs or upload them through Gemini Files API yet. Set this
 # to false when you need OpenAI-compatible image_url pass-through behavior.

--- a/.env.template
+++ b/.env.template
@@ -475,7 +475,8 @@
 # Google Gemini
 # GEMINI_API_KEY=...
 # Use Gemini's native APIs (default: true): generateContent for chat/responses
-# and image models, batchEmbedContents for embeddings, predict for Imagen.
+# and image models, batchEmbedContents for embeddings, predict for Imagen
+# (Vertex backend; Google retired Imagen from the AI Studio API in Aug 2026).
 # Set to false to use Gemini's OpenAI-compatible API instead (image edits are
 # then unavailable; the OpenAI-compatible surface has no edits endpoint).
 # Native mode supports inline image data via data: URLs, but GoModel does not

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -377,9 +377,9 @@ providers:
   gemini:
     type: gemini
     api_key: "..."
-    # Chat/responses use Gemini's native generateContent API by default.
+    # Chat/responses, embeddings, and images use Gemini's native APIs by default.
     # Set GEMINI_API_MODE=openai_compatible or api_mode: openai_compatible to use
-    # Gemini's OpenAI-compatible API instead.
+    # Gemini's OpenAI-compatible API instead (image edits require native mode).
     # Native mode accepts image data URLs but does not fetch remote image URLs yet.
 
   vertex:

--- a/docs/advanced/api-endpoints.mdx
+++ b/docs/advanced/api-endpoints.mdx
@@ -39,7 +39,7 @@ For request and response details, see the dedicated guides:
 | `/v1/models`                      | GET    | List available models                                                                                        |
 | `/v1/audio/speech`                | POST   | Text-to-speech, returning binary audio                                                                       |
 | `/v1/audio/transcriptions`        | POST   | Speech-to-text from a multipart upload                                                                       |
-| `/v1/images/generations`          | POST   | Image generation from a text prompt (DALL·E, gpt-image-1, grok-2-image)                                     |
+| `/v1/images/generations`          | POST   | Image generation from a text prompt (DALL·E, gpt-image-1, grok-2-image, Imagen, Gemini image models)                                     |
 | `/v1/images/edits`                | POST   | Image editing / inpainting from a multipart upload (image, optional mask, prompt)                             |
 | `/v1/realtime`                    | GET    | Realtime speech-to-speech websocket upgrade; `?call_id=` attaches to an existing WebRTC/SIP call as a sideband channel (when `REALTIME_ENABLED`) |
 | `/v1/realtime/calls`              | POST   | Realtime WebRTC SDP exchange: `application/sdp` offer with `?model=`, or multipart `sdp` + `session` fields (when `REALTIME_ENABLED`)            |

--- a/docs/advanced/images-api.mdx
+++ b/docs/advanced/images-api.mdx
@@ -16,9 +16,12 @@ embeddings, so `model` selection, `provider` hints, virtual models, per-key mode
 access rules ([user paths](/features/user-path)), [budgets](/features/budgets),
 and [rate limits](/features/rate-limits) all apply. Image generation is served by
 OpenAI and the OpenAI-compatible providers that implement the endpoint
-(Azure OpenAI, OpenRouter, [xAI](/providers/xai)); image edits by OpenAI and
-Azure OpenAI, plus any OpenAI-compatible provider that accepts OpenAI's
-multipart upload on `/images/edits`. A provider without the capability returns
+(Azure OpenAI, OpenRouter, [xAI](/providers/xai)), and by
+[Google Gemini](/providers/gemini) — Imagen and Gemini image models through
+Gemini's native API. Image edits are served by OpenAI and Azure OpenAI, by
+Gemini image models (`gemini-2.5-flash-image`, ...), plus any
+OpenAI-compatible provider that accepts OpenAI's multipart upload on
+`/images/edits`. A provider without the capability returns
 a clear `model "…" does not support image generation` (or `image edits`) error
 rather than mis-routing, and image-only models are hidden from `/v1/models` for
 providers without image support.
@@ -169,9 +172,9 @@ Image calls are recorded in [usage tracking](/features/cost-tracking) under the
 - **Token-billed models** (`gpt-image-1` and similar) report `usage` in the
   response; GoModel stores the input/output token counts and prices them with the
   model's `input_per_mtok` / `output_per_mtok` rates.
-- **Per-image models** (DALL·E, `grok-2-image`) report no tokens. GoModel records
-  the number of returned images (`images` in the raw usage data) and prices it
-  with the model's `per_image` rate.
+- **Per-image models** (DALL·E, `grok-2-image`, Imagen) report no tokens.
+  GoModel records the number of returned images (`images` in the raw usage
+  data) and prices it with the model's `per_image` rate.
 
 Set `per_image` through a [pricing override](/features/cost-tracking#override-pricing)
 or in `config.yaml` when the model catalog has no price for an image model:
@@ -204,9 +207,34 @@ run through the full inference orchestrator**. Compared with `/v1/chat/completio
 - **Variations** (`/v1/images/variations`) are not exposed. Use the
   [passthrough API](/features/passthrough-api) (`/p/{provider}/v1/images/...`)
   to reach them on a specific provider.
-- **OpenAI request shape in, OpenAI-compatible providers out** — providers whose
-  native image API differs from OpenAI's (for example Gemini Imagen) are not
-  translated behind this endpoint; use passthrough for those.
+- **OpenAI request shape in** — Google Gemini's native image APIs (Imagen
+  `predict`, Gemini image model `generateContent`) are translated behind these
+  endpoints; see [provider notes](#google-gemini) below. Other providers whose
+  native image API differs from OpenAI's are not translated; use passthrough
+  for those.
+
+## Google Gemini
+
+With the Gemini provider in native API mode (the default), `imagen-*` models
+generate through Imagen's `predict` API and Gemini image models
+(`gemini-2.5-flash-image`, ...) through `generateContent`:
+
+- `n` maps to Imagen's `sampleCount`; `size` maps to the closest supported
+  aspect ratio (`1024x1024` → `1:1`, `1536x1024` → `3:2`, ...), and a raw
+  ratio such as `"16:9"` passes through. Unknown JSON fields are forwarded
+  verbatim, so native parameters (`personGeneration`, `sampleImageSize`,
+  `imageConfig`, ...) work unchanged.
+- Images always return as `b64_json`. Any text a Gemini image model produces
+  alongside the image is surfaced as `revised_prompt`.
+- Gemini image models report token `usage` (token-billed); Imagen reports
+  none (price it `per_image`).
+- Edits work with Gemini image models only: uploads become inline image
+  parts ahead of the prompt. `mask` is not supported — describe the region to
+  change in the prompt. Imagen models only generate.
+
+In OpenAI-compatible mode, generation forwards to Gemini's
+`/openai/images/generations` endpoint and edits are rejected (that surface has
+no edits endpoint).
 
 ## Audit logging
 

--- a/docs/advanced/images-api.mdx
+++ b/docs/advanced/images-api.mdx
@@ -17,8 +17,9 @@ access rules ([user paths](/features/user-path)), [budgets](/features/budgets),
 and [rate limits](/features/rate-limits) all apply. Image generation is served by
 OpenAI and the OpenAI-compatible providers that implement the endpoint
 (Azure OpenAI, OpenRouter, [xAI](/providers/xai)), and by
-[Google Gemini](/providers/gemini) — Imagen and Gemini image models through
-Gemini's native API. Image edits are served by OpenAI and Azure OpenAI, by
+[Google Gemini](/providers/gemini) — Gemini image models through the native
+API, plus Imagen on [Vertex AI](/providers/vertex). Image edits are served by
+OpenAI and Azure OpenAI, by
 Gemini image models (`gemini-2.5-flash-image`, ...), plus any
 OpenAI-compatible provider that accepts OpenAI's multipart upload on
 `/images/edits`. A provider without the capability returns
@@ -98,6 +99,8 @@ await writeFile("lighthouse.png", Buffer.from(result.data[0].b64_json, "base64")
 `moderation`, `user`, and any future parameter — is **forwarded to the provider
 unchanged**, so model-specific options work without a gateway update. The
 provider decides which values it accepts and returns its own error otherwise.
+The exception is Gemini's native adapter, which translates `n` and `size` to
+their native equivalents — see [Google Gemini](#google-gemini).
 
 The response is the OpenAI images envelope. `data[]` entries carry either a
 hosted `url` (DALL·E, `response_format: "url"`) or inline `b64_json`
@@ -215,9 +218,11 @@ run through the full inference orchestrator**. Compared with `/v1/chat/completio
 
 ## Google Gemini
 
-With the Gemini provider in native API mode (the default), `imagen-*` models
-generate through Imagen's `predict` API and Gemini image models
-(`gemini-2.5-flash-image`, ...) through `generateContent`:
+With the Gemini provider in native API mode (the default), Gemini image
+models (`gemini-2.5-flash-image`, ...) generate through `generateContent`,
+and `imagen-*` models through Imagen's `predict` API. Google retired Imagen
+from the Gemini API (AI Studio) on August 17, 2026 — use a Gemini image model
+there; Imagen remains available on [Vertex AI](/providers/vertex).
 
 - `n` maps to Imagen's `sampleCount`; `size` maps to the closest supported
   aspect ratio (`1024x1024` → `1:1`, `1536x1024` → `3:2`, ...), and a raw
@@ -231,9 +236,6 @@ generate through Imagen's `predict` API and Gemini image models
 - Edits work with Gemini image models only: uploads become inline image
   parts ahead of the prompt. `mask` is not supported — describe the region to
   change in the prompt. Imagen models only generate.
-- Google's model listing omits Imagen, so GoModel seeds the documented
-  `imagen-*` IDs into `/v1/models`. Imagen on the Gemini API requires a paid
-  tier; free-tier keys receive Google's not-found error.
 
 In OpenAI-compatible mode, generation forwards to Gemini's
 `/openai/images/generations` endpoint and edits are rejected (that surface has

--- a/docs/advanced/images-api.mdx
+++ b/docs/advanced/images-api.mdx
@@ -231,6 +231,9 @@ generate through Imagen's `predict` API and Gemini image models
 - Edits work with Gemini image models only: uploads become inline image
   parts ahead of the prompt. `mask` is not supported — describe the region to
   change in the prompt. Imagen models only generate.
+- Google's model listing omits Imagen, so GoModel seeds the documented
+  `imagen-*` IDs into `/v1/models`. Imagen on the Gemini API requires a paid
+  tier; free-tier keys receive Google's not-found error.
 
 In OpenAI-compatible mode, generation forwards to Gemini's
 `/openai/images/generations` endpoint and edits are rejected (that surface has

--- a/docs/providers/gemini.mdx
+++ b/docs/providers/gemini.mdx
@@ -66,10 +66,10 @@ you need token counts from Gemini embeddings.
 ## Image generation and edits
 
 In native mode the [OpenAI-compatible image endpoints](/advanced/images-api)
-work with both Imagen (`imagen-*`, via `predict`; requires a paid-tier API
-key) and Gemini image models (`gemini-2.5-flash-image`, ..., via
-`generateContent`). Image edits require native mode and a Gemini image model;
-masks are not supported. See the
+work with Gemini image models (`gemini-2.5-flash-image`, ..., via
+`generateContent`). Google retired Imagen from the AI Studio API in August
+2026; Imagen is still served on [Vertex AI](/providers/vertex). Image edits
+require native mode and a Gemini image model; masks are not supported. See the
 [Images API provider notes](/advanced/images-api#google-gemini) for parameter
 mapping and pricing details.
 

--- a/docs/providers/gemini.mdx
+++ b/docs/providers/gemini.mdx
@@ -8,10 +8,11 @@ keywords: ["Google Gemini", "AI Studio", "native Gemini API", "provider setup"]
 This page covers Gemini through **Google AI Studio** API keys. For Gemini on
 Google Cloud's Vertex AI, see the [Google Vertex AI guide](/providers/vertex).
 
-By default, GoModel routes Gemini chat and Responses requests through Gemini's
-native `generateContent` API. Switch to the OpenAI-compatible endpoint when
-you need compatibility behavior the native adapter does not implement yet
-(notably remote `image_url` values).
+By default, GoModel routes Gemini chat, Responses, embeddings, and
+[image](/advanced/images-api) requests through Gemini's native APIs
+(`generateContent`, `batchEmbedContents`, Imagen `predict`). Switch to the
+OpenAI-compatible endpoint when you need compatibility behavior the native
+adapter does not implement yet (notably remote `image_url` values).
 
 ## Configure
 
@@ -51,8 +52,25 @@ OpenAI-compatible API:
 
 `GEMINI_BASE_URL` overrides them. When the value ends in `/openai`, GoModel
 uses it for the OpenAI-compatible client and derives the native base by
-stripping `/openai`. Embeddings, files, and batches always use the
-OpenAI-compatible surface.
+stripping `/openai`. Files and batches always use the OpenAI-compatible
+surface; chat, embeddings, and images follow the API mode.
+
+## Embeddings
+
+In native mode, embeddings are served through `models/{model}:batchEmbedContents`.
+`dimensions` maps to `outputDimensionality` and `encoding_format: "base64"` is
+honored. The native API reports no token usage, so embedding responses (and
+usage tracking) carry zero token counts; switch to `openai_compatible` mode if
+you need token counts from Gemini embeddings.
+
+## Image generation and edits
+
+In native mode the [OpenAI-compatible image endpoints](/advanced/images-api)
+work with both Imagen (`imagen-*`, via `predict`) and Gemini image models
+(`gemini-2.5-flash-image`, ..., via `generateContent`). Image edits require
+native mode and a Gemini image model; masks are not supported. See the
+[Images API provider notes](/advanced/images-api#google-gemini) for parameter
+mapping and pricing details.
 
 ## Image input
 

--- a/docs/providers/gemini.mdx
+++ b/docs/providers/gemini.mdx
@@ -59,9 +59,8 @@ surface; chat, embeddings, and images follow the API mode.
 
 In native mode, embeddings are served through `models/{model}:batchEmbedContents`.
 `dimensions` maps to `outputDimensionality` and `encoding_format: "base64"` is
-honored. The native API reports no token usage, so embedding responses (and
-usage tracking) carry zero token counts; switch to `openai_compatible` mode if
-you need token counts from Gemini embeddings.
+honored. Gemini reports no embedding token usage on either API surface, so
+embedding responses (and usage tracking) carry zero token counts.
 
 ## Image generation and edits
 

--- a/docs/providers/gemini.mdx
+++ b/docs/providers/gemini.mdx
@@ -66,9 +66,10 @@ you need token counts from Gemini embeddings.
 ## Image generation and edits
 
 In native mode the [OpenAI-compatible image endpoints](/advanced/images-api)
-work with both Imagen (`imagen-*`, via `predict`) and Gemini image models
-(`gemini-2.5-flash-image`, ..., via `generateContent`). Image edits require
-native mode and a Gemini image model; masks are not supported. See the
+work with both Imagen (`imagen-*`, via `predict`; requires a paid-tier API
+key) and Gemini image models (`gemini-2.5-flash-image`, ..., via
+`generateContent`). Image edits require native mode and a Gemini image model;
+masks are not supported. See the
 [Images API provider notes](/advanced/images-api#google-gemini) for parameter
 mapping and pricing details.
 

--- a/docs/providers/vertex.mdx
+++ b/docs/providers/vertex.mdx
@@ -72,9 +72,11 @@ Default bases are derived from project and location:
 - native Gemini: `.../projects/{project}/locations/{location}/publishers/google`
 
 Vertex embeddings use Vertex AI native prediction regardless of
-`VERTEX_API_MODE`. The [image endpoints](/advanced/images-api) are served in
-native mode through the publisher endpoints (Imagen via `predict`, Gemini
-image models via `generateContent`). Vertex does not expose Gemini Files or
+`VERTEX_API_MODE`. In native mode (the default) the
+[image endpoints](/advanced/images-api) are served through the publisher
+endpoints (Imagen via `predict`, Gemini image models via `generateContent`);
+in `openai_compatible` mode image generation forwards to the OpenAI-compatible
+endpoint and image edits are rejected. Vertex does not expose Gemini Files or
 OpenAI-compatible batch operations.
 
 ## Image input

--- a/docs/providers/vertex.mdx
+++ b/docs/providers/vertex.mdx
@@ -72,8 +72,10 @@ Default bases are derived from project and location:
 - native Gemini: `.../projects/{project}/locations/{location}/publishers/google`
 
 Vertex embeddings use Vertex AI native prediction regardless of
-`VERTEX_API_MODE`. Vertex does not expose Gemini Files or OpenAI-compatible
-batch operations.
+`VERTEX_API_MODE`. The [image endpoints](/advanced/images-api) are served in
+native mode through the publisher endpoints (Imagen via `predict`, Gemini
+image models via `generateContent`). Vertex does not expose Gemini Files or
+OpenAI-compatible batch operations.
 
 ## Image input
 

--- a/internal/providers/embedding_values.go
+++ b/internal/providers/embedding_values.go
@@ -1,0 +1,65 @@
+package providers
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"math"
+	"strings"
+
+	"github.com/goccy/go-json"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+// EmbeddingInputs normalizes an OpenAI embeddings input value into a list of
+// strings for providers whose native APIs embed text only. Token-array inputs
+// are rejected because they cannot be translated faithfully.
+func EmbeddingInputs(input any) ([]string, error) {
+	switch v := input.(type) {
+	case string:
+		if strings.TrimSpace(v) == "" {
+			return nil, core.NewInvalidRequestError("embedding input is required", nil)
+		}
+		return []string{v}, nil
+	case []string:
+		return nonEmptyEmbeddingInputs(v)
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			text, ok := item.(string)
+			if !ok {
+				return nil, core.NewInvalidRequestError("embeddings support string inputs", nil)
+			}
+			out = append(out, text)
+		}
+		return nonEmptyEmbeddingInputs(out)
+	default:
+		return nil, core.NewInvalidRequestError("embeddings support string inputs", nil)
+	}
+}
+
+func nonEmptyEmbeddingInputs(inputs []string) ([]string, error) {
+	for _, input := range inputs {
+		if strings.TrimSpace(input) == "" {
+			return nil, core.NewInvalidRequestError("embedding input must not be empty", nil)
+		}
+	}
+	if len(inputs) == 0 {
+		return nil, core.NewInvalidRequestError("embedding input is required", nil)
+	}
+	return inputs, nil
+}
+
+// EncodeEmbeddingValues renders one embedding vector the way the OpenAI API
+// does: a JSON float array by default, or a base64-encoded little-endian
+// float32 buffer when the request asked for encoding_format "base64".
+func EncodeEmbeddingValues(values []float64, encodingFormat string) (json.RawMessage, error) {
+	if strings.EqualFold(strings.TrimSpace(encodingFormat), "base64") {
+		buf := make([]byte, len(values)*4)
+		for i, value := range values {
+			binary.LittleEndian.PutUint32(buf[i*4:], math.Float32bits(float32(value)))
+		}
+		return json.Marshal(base64.StdEncoding.EncodeToString(buf))
+	}
+	return json.Marshal(values)
+}

--- a/internal/providers/gemini/embeddings.go
+++ b/internal/providers/gemini/embeddings.go
@@ -2,6 +2,7 @@ package gemini
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 
@@ -13,9 +14,13 @@ import (
 // Native Gemini embeddings (models/{model}:batchEmbedContents). One batch call
 // covers single- and multi-input OpenAI requests alike.
 type geminiEmbedContentRequest struct {
-	Model                string        `json:"model"`
-	Content              geminiContent `json:"content"`
-	OutputDimensionality *int          `json:"outputDimensionality,omitempty"`
+	Model   string        `json:"model"`
+	Content geminiContent `json:"content"`
+	// The REST reference marks this field deprecated in favor of a nested
+	// EmbedContentConfig, but the live batchEmbedContents endpoint silently
+	// ignores the nested spelling (verified: dimensions come back at the
+	// model default) and honors the top-level field, so this stays.
+	OutputDimensionality *int `json:"outputDimensionality,omitempty"`
 }
 
 type geminiBatchEmbedContentsRequest struct {
@@ -67,6 +72,11 @@ func (p *Provider) nativeEmbeddings(ctx context.Context, req *core.EmbeddingRequ
 	}, &resp)
 	if err != nil {
 		return nil, err
+	}
+	// A mismatched count would silently misalign indexes with inputs.
+	if len(resp.Embeddings) != len(inputs) {
+		return nil, core.NewProviderError(p.responseProviderName(), http.StatusBadGateway,
+			fmt.Sprintf("Gemini returned %d embeddings for %d inputs", len(resp.Embeddings), len(inputs)), nil)
 	}
 
 	out := &core.EmbeddingResponse{

--- a/internal/providers/gemini/embeddings.go
+++ b/internal/providers/gemini/embeddings.go
@@ -1,0 +1,90 @@
+package gemini
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/llmclient"
+	"github.com/enterpilot/gomodel/internal/providers"
+)
+
+// Native Gemini embeddings (models/{model}:batchEmbedContents). One batch call
+// covers single- and multi-input OpenAI requests alike.
+type geminiEmbedContentRequest struct {
+	Model                string        `json:"model"`
+	Content              geminiContent `json:"content"`
+	OutputDimensionality *int          `json:"outputDimensionality,omitempty"`
+}
+
+type geminiBatchEmbedContentsRequest struct {
+	Requests []geminiEmbedContentRequest `json:"requests"`
+}
+
+type geminiBatchEmbedContentsResponse struct {
+	Embeddings []geminiEmbeddingValues `json:"embeddings"`
+}
+
+type geminiEmbeddingValues struct {
+	Values []float64 `json:"values"`
+}
+
+func nativeBatchEmbedEndpoint(model string) string {
+	return "/models/" + url.PathEscape(normalizeGeminiModelID(model)) + ":batchEmbedContents"
+}
+
+// nativeEmbeddings serves an OpenAI embeddings request through Gemini's native
+// batchEmbedContents API. The native response carries no token usage, so the
+// OpenAI usage block is returned zeroed.
+func (p *Provider) nativeEmbeddings(ctx context.Context, req *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	inputs, err := providers.EmbeddingInputs(req.Input)
+	if err != nil {
+		return nil, err
+	}
+	model := "models/" + normalizeGeminiModelID(req.Model)
+	body := geminiBatchEmbedContentsRequest{
+		Requests: make([]geminiEmbedContentRequest, 0, len(inputs)),
+	}
+	for _, input := range inputs {
+		request := geminiEmbedContentRequest{
+			Model:   model,
+			Content: geminiContent{Parts: []geminiPart{{Text: input}}},
+		}
+		if req.Dimensions != nil && *req.Dimensions > 0 {
+			request.OutputDimensionality = req.Dimensions
+		}
+		body.Requests = append(body.Requests, request)
+	}
+
+	var resp geminiBatchEmbedContentsResponse
+	err = p.nativeClient.Do(ctx, llmclient.Request{
+		Method:    http.MethodPost,
+		Endpoint:  nativeBatchEmbedEndpoint(req.Model),
+		Operation: llmclient.OperationEmbeddings,
+		Model:     req.Model,
+		Body:      &body,
+	}, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &core.EmbeddingResponse{
+		Object:   "list",
+		Data:     make([]core.EmbeddingData, 0, len(resp.Embeddings)),
+		Model:    req.Model,
+		Provider: p.responseProviderName(),
+	}
+	for i, embedding := range resp.Embeddings {
+		encoded, err := providers.EncodeEmbeddingValues(embedding.Values, req.EncodingFormat)
+		if err != nil {
+			return nil, core.NewProviderError(p.responseProviderName(), http.StatusBadGateway, "failed to encode Gemini embedding response", err)
+		}
+		out.Data = append(out.Data, core.EmbeddingData{
+			Object:    "embedding",
+			Embedding: encoded,
+			Index:     i,
+		})
+	}
+	return out, nil
+}

--- a/internal/providers/gemini/embeddings_test.go
+++ b/internal/providers/gemini/embeddings_test.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/enterpilot/gomodel/internal/core"
@@ -166,5 +167,33 @@ func TestEmbeddings_CompatModeUsesOpenAIEndpoint(t *testing.T) {
 	}
 	if len(resp.Data) != 1 || resp.Usage.TotalTokens != 3 {
 		t.Fatalf("response = %+v, want compat passthrough with usage", resp)
+	}
+}
+
+func TestNativeEmbeddings_RejectsMismatchedCount(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "short", body: `{"embeddings": [{"values": [0.1]}]}`},
+		{name: "surplus", body: `{"embeddings": [{"values": [0.1]}, {"values": [0.2]}, {"values": [0.3]}]}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			p := newNativeTestProvider(t, server)
+			_, err := p.Embeddings(context.Background(), &core.EmbeddingRequest{
+				Model: "gemini-embedding-001",
+				Input: []any{"first", "second"},
+			})
+			if err == nil || !strings.Contains(err.Error(), "embeddings for 2 inputs") {
+				t.Fatalf("error = %v, want mismatched-count rejection", err)
+			}
+		})
 	}
 }

--- a/internal/providers/gemini/embeddings_test.go
+++ b/internal/providers/gemini/embeddings_test.go
@@ -1,0 +1,170 @@
+package gemini
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/llmclient"
+)
+
+// newNativeTestProvider builds an AI Studio provider in native mode pointed at
+// the test server; the native base derives from the /openai suffix.
+func newNativeTestProvider(t *testing.T, server *httptest.Server) *Provider {
+	t.Helper()
+	t.Setenv(useNativeAPIEnvVar, "true")
+	p := NewWithHTTPClient("test-api-key", server.Client(), llmclient.Hooks{})
+	p.SetBaseURL(server.URL + "/v1beta/openai")
+	return p
+}
+
+func newCompatTestProvider(t *testing.T, server *httptest.Server) *Provider {
+	t.Helper()
+	t.Setenv(useNativeAPIEnvVar, "false")
+	p := NewWithHTTPClient("test-api-key", server.Client(), llmclient.Hooks{})
+	p.SetBaseURL(server.URL + "/v1beta/openai")
+	return p
+}
+
+func TestNativeEmbeddings_BatchEmbedContents(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1beta/models/gemini-embedding-001:batchEmbedContents" {
+			t.Errorf("path = %q, want /v1beta/models/gemini-embedding-001:batchEmbedContents", r.URL.Path)
+		}
+		if got := r.Header.Get("x-goog-api-key"); got != "test-api-key" {
+			t.Errorf("x-goog-api-key = %q, want test-api-key", got)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &gotBody); err != nil {
+			t.Errorf("request body is not JSON: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"embeddings": [{"values": [0.1, 0.2]}, {"values": [0.3, 0.4]}]}`))
+	}))
+	defer server.Close()
+
+	p := newNativeTestProvider(t, server)
+	dims := 128
+	resp, err := p.Embeddings(context.Background(), &core.EmbeddingRequest{
+		Model:      "gemini-embedding-001",
+		Input:      []any{"first", "second"},
+		Dimensions: &dims,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	requests, ok := gotBody["requests"].([]any)
+	if !ok || len(requests) != 2 {
+		t.Fatalf("requests = %+v, want 2 entries", gotBody["requests"])
+	}
+	first, _ := requests[0].(map[string]any)
+	if first["model"] != "models/gemini-embedding-001" {
+		t.Errorf("request model = %v, want models/gemini-embedding-001", first["model"])
+	}
+	if first["outputDimensionality"] != float64(128) {
+		t.Errorf("outputDimensionality = %v, want 128", first["outputDimensionality"])
+	}
+	content, _ := first["content"].(map[string]any)
+	parts, _ := content["parts"].([]any)
+	if len(parts) != 1 || parts[0].(map[string]any)["text"] != "first" {
+		t.Errorf("content parts = %+v, want single text part 'first'", parts)
+	}
+
+	if resp.Object != "list" || len(resp.Data) != 2 {
+		t.Fatalf("response = %+v, want list with 2 embeddings", resp)
+	}
+	if resp.Model != "gemini-embedding-001" || resp.Provider != "gemini" {
+		t.Errorf("model/provider = %q/%q, want gemini-embedding-001/gemini", resp.Model, resp.Provider)
+	}
+	var values []float64
+	if err := json.Unmarshal(resp.Data[1].Embedding, &values); err != nil || len(values) != 2 || values[0] != 0.3 {
+		t.Errorf("second embedding = %s, want [0.3, 0.4]", resp.Data[1].Embedding)
+	}
+	if resp.Data[1].Index != 1 || resp.Data[1].Object != "embedding" {
+		t.Errorf("second entry = %+v, want index 1 object embedding", resp.Data[1])
+	}
+	if resp.Usage.TotalTokens != 0 {
+		t.Errorf("usage = %+v, want zero (native API reports no usage)", resp.Usage)
+	}
+}
+
+func TestNativeEmbeddings_Base64EncodingFormat(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"embeddings": [{"values": [1.5, -2.0]}]}`))
+	}))
+	defer server.Close()
+
+	p := newNativeTestProvider(t, server)
+	resp, err := p.Embeddings(context.Background(), &core.EmbeddingRequest{
+		Model:          "gemini-embedding-001",
+		Input:          "hello",
+		EncodingFormat: "base64",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var encoded string
+	if err := json.Unmarshal(resp.Data[0].Embedding, &encoded); err != nil {
+		t.Fatalf("embedding is not a base64 string: %s", resp.Data[0].Embedding)
+	}
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil || len(raw) != 8 {
+		t.Fatalf("embedding buffer = %d bytes (err %v), want 8", len(raw), err)
+	}
+	if got := math.Float32frombits(binary.LittleEndian.Uint32(raw[0:])); got != 1.5 {
+		t.Errorf("first value = %v, want 1.5", got)
+	}
+	if got := math.Float32frombits(binary.LittleEndian.Uint32(raw[4:])); got != -2.0 {
+		t.Errorf("second value = %v, want -2.0", got)
+	}
+}
+
+func TestNativeEmbeddings_RejectsNonStringInput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("no upstream call expected for invalid input")
+	}))
+	defer server.Close()
+
+	p := newNativeTestProvider(t, server)
+	_, err := p.Embeddings(context.Background(), &core.EmbeddingRequest{
+		Model: "gemini-embedding-001",
+		Input: []any{float64(1), float64(2)},
+	})
+	if err == nil {
+		t.Fatal("expected token-array input to be rejected")
+	}
+}
+
+func TestEmbeddings_CompatModeUsesOpenAIEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1beta/openai/embeddings" {
+			t.Errorf("path = %q, want /v1beta/openai/embeddings", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object": "list", "data": [{"object": "embedding", "embedding": [0.5], "index": 0}], "model": "gemini-embedding-001", "usage": {"prompt_tokens": 3, "total_tokens": 3}}`))
+	}))
+	defer server.Close()
+
+	p := newCompatTestProvider(t, server)
+	resp, err := p.Embeddings(context.Background(), &core.EmbeddingRequest{
+		Model: "gemini-embedding-001",
+		Input: "hello",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Data) != 1 || resp.Usage.TotalTokens != 3 {
+		t.Fatalf("response = %+v, want compat passthrough with usage", resp)
+	}
+}

--- a/internal/providers/gemini/gemini.go
+++ b/internal/providers/gemini/gemini.go
@@ -711,13 +711,27 @@ type geminiModelsResponse struct {
 	PublisherModels []geminiModel `json:"publisherModels"`
 }
 
-func geminiModelSupportedMethods(modelID string, methods []string) (supportsGenerate, supportsEmbed bool) {
+func geminiModelSupportedMethods(modelID string, methods []string) (supportsGenerate, supportsEmbed, supportsImage bool) {
+	normalized := normalizeGeminiModelID(modelID)
 	if len(methods) == 0 {
-		normalized := normalizeGeminiModelID(modelID)
-		return strings.HasPrefix(normalized, "gemini-"), strings.HasPrefix(normalized, "text-embedding-")
+		return strings.HasPrefix(normalized, "gemini-"), strings.HasPrefix(normalized, "text-embedding-"),
+			strings.HasPrefix(normalized, "imagen-")
 	}
-	return slices.Contains(methods, "generateContent") || slices.Contains(methods, "streamGenerateContent"),
-		slices.Contains(methods, "embedContent")
+	supportsGenerate = slices.Contains(methods, "generateContent") || slices.Contains(methods, "streamGenerateContent")
+	// Imagen models list only the predict method; Gemini image models carry
+	// generateContent, so their image capability is inferred from the ID.
+	supportsImage = (strings.HasPrefix(normalized, "imagen-") && slices.Contains(methods, "predict")) ||
+		(supportsGenerate && isGeminiImageModelID(normalized))
+	return supportsGenerate, slices.Contains(methods, "embedContent"), supportsImage
+}
+
+// isGeminiImageModelID recognizes generateContent models with image output
+// (gemini-2.5-flash-image, gemini-2.0-flash-preview-image-generation,
+// gemini-3-pro-image-preview, ...) by the -image marker Google uses in their
+// IDs. This only seeds discovery metadata; registry enrichment overrides it.
+func isGeminiImageModelID(normalized string) bool {
+	return strings.HasPrefix(normalized, "gemini-") &&
+		(strings.Contains(normalized, "-image-") || strings.HasSuffix(normalized, "-image"))
 }
 
 // geminiDiscoveredMetadata stamps modes/categories from the native listing's
@@ -725,13 +739,21 @@ func geminiModelSupportedMethods(modelID string, methods []string) (supportsGene
 // remote model registry has no entry (new or preview IDs). Registry enrichment
 // replaces this metadata whenever it does have an entry, and operator config
 // merges on top, so the discovery stamp is only the lowest-precedence signal.
-func geminiDiscoveredMetadata(supportsGenerate, supportsEmbed bool) *core.ModelMetadata {
-	modes := make([]string, 0, 2)
+func geminiDiscoveredMetadata(supportsGenerate, supportsEmbed, supportsImage bool) *core.ModelMetadata {
+	modes := make([]string, 0, 3)
 	if supportsGenerate {
 		modes = append(modes, "chat")
 	}
 	if supportsEmbed {
 		modes = append(modes, "embedding")
+	}
+	if supportsImage {
+		modes = append(modes, "image_generation")
+		if supportsGenerate {
+			// Only generateContent image models accept input images to edit;
+			// Imagen predict models generate from text alone.
+			modes = append(modes, "image_edit")
+		}
 	}
 	if len(modes) == 0 {
 		return nil
@@ -786,17 +808,15 @@ func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error)
 		for _, gm := range modelEntries {
 			modelID := displayModelIDFromGemini(gm.Name, p.backend)
 
-			// Only include models that support generateContent (chat/completion)
-			supportsGenerate, supportsEmbed := geminiModelSupportedMethods(modelID, gm.SupportedMethods)
+			supportsGenerate, supportsEmbed, supportsImage := geminiModelSupportedMethods(modelID, gm.SupportedMethods)
 
-			isOpenAICompatModel := isGeminiExposedModel(modelID)
-			if (supportsGenerate || supportsEmbed) && isOpenAICompatModel {
+			if (supportsGenerate || supportsEmbed || supportsImage) && isGeminiExposedModel(modelID) {
 				models = append(models, core.Model{
 					ID:       modelID,
 					Object:   "model",
 					OwnedBy:  "google",
 					Created:  now,
-					Metadata: geminiDiscoveredMetadata(supportsGenerate, supportsEmbed),
+					Metadata: geminiDiscoveredMetadata(supportsGenerate, supportsEmbed, supportsImage),
 				})
 			}
 		}
@@ -845,13 +865,20 @@ func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*
 	return providers.ResponsesViaChat(ctx, p, req)
 }
 
-// Embeddings sends an embeddings request to Gemini via its OpenAI-compatible endpoint
+// Embeddings sends an embeddings request to Gemini: the native
+// batchEmbedContents API in native mode, or the OpenAI-compatible endpoint
+// otherwise. The Vertex backend always uses the OpenAI-compatible surface —
+// Vertex has no batchEmbedContents; its native prediction path is served by
+// the dedicated vertex provider.
 func (p *Provider) Embeddings(ctx context.Context, req *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
 	if err := p.ready(); err != nil {
 		return nil, err
 	}
 	if req == nil {
 		return nil, core.NewInvalidRequestError("embedding request is required", nil)
+	}
+	if p.useNativeAPI && p.backend == geminiBackendAIStudio {
+		return p.nativeEmbeddings(ctx, req)
 	}
 	body, err := p.openAICompatibleEmbeddingBody(req)
 	if err != nil {

--- a/internal/providers/gemini/gemini.go
+++ b/internal/providers/gemini/gemini.go
@@ -764,6 +764,43 @@ func geminiDiscoveredMetadata(supportsGenerate, supportsEmbed, supportsImage boo
 	}
 }
 
+// knownImagenModels are the Imagen models the Gemini API documents for
+// AI Studio. Google serves them but omits them from its model listings, so
+// without seeding they could never be routed; discovery metadata marks them
+// image-only and registry enrichment overrides it when the catalog knows more.
+var knownImagenModels = []string{
+	"imagen-3.0-generate-002",
+	"imagen-4.0-generate-001",
+	"imagen-4.0-fast-generate-001",
+	"imagen-4.0-ultra-generate-001",
+}
+
+// appendKnownImagenModels adds the documented Imagen models missing from an
+// AI Studio listing. Vertex lists Imagen in its publisher models already, so
+// only the AI Studio backend is seeded.
+func (p *Provider) appendKnownImagenModels(models []core.Model, now int64) []core.Model {
+	if p.backend != geminiBackendAIStudio {
+		return models
+	}
+	seen := make(map[string]struct{}, len(models))
+	for _, model := range models {
+		seen[normalizeGeminiModelID(model.ID)] = struct{}{}
+	}
+	for _, id := range knownImagenModels {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		models = append(models, core.Model{
+			ID:       id,
+			Object:   "model",
+			OwnedBy:  "google",
+			Created:  now,
+			Metadata: geminiDiscoveredMetadata(false, false, true),
+		})
+	}
+	return models
+}
+
 // ListModels retrieves the list of available models from Gemini
 func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error) {
 	if err := p.ready(); err != nil {
@@ -823,7 +860,7 @@ func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error)
 
 		return &core.ModelsResponse{
 			Object: "list",
-			Data:   models,
+			Data:   p.appendKnownImagenModels(models, now),
 		}, nil
 	}
 
@@ -846,7 +883,7 @@ func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error)
 		}
 		return &core.ModelsResponse{
 			Object: "list",
-			Data:   models,
+			Data:   p.appendKnownImagenModels(models, now),
 		}, nil
 	}
 

--- a/internal/providers/gemini/gemini.go
+++ b/internal/providers/gemini/gemini.go
@@ -834,9 +834,11 @@ func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error)
 		}
 		modelEntries := append(geminiResp.Models, geminiResp.PublisherModels...)
 		if len(modelEntries) == 0 {
+			// Still seed Imagen: Google serves those models without ever
+			// listing them, so an explicitly empty inventory must not hide them.
 			return &core.ModelsResponse{
 				Object: "list",
-				Data:   []core.Model{},
+				Data:   p.appendKnownImagenModels([]core.Model{}, now),
 			}, nil
 		}
 

--- a/internal/providers/gemini/gemini.go
+++ b/internal/providers/gemini/gemini.go
@@ -714,7 +714,8 @@ type geminiModelsResponse struct {
 func geminiModelSupportedMethods(modelID string, methods []string) (supportsGenerate, supportsEmbed, supportsImage bool) {
 	normalized := normalizeGeminiModelID(modelID)
 	if len(methods) == 0 {
-		return strings.HasPrefix(normalized, "gemini-"), strings.HasPrefix(normalized, "text-embedding-"),
+		isEmbedding := strings.HasPrefix(normalized, "text-embedding-") || strings.HasPrefix(normalized, "gemini-embedding-")
+		return strings.HasPrefix(normalized, "gemini-") && !isEmbedding, isEmbedding,
 			strings.HasPrefix(normalized, "imagen-")
 	}
 	supportsGenerate = slices.Contains(methods, "generateContent") || slices.Contains(methods, "streamGenerateContent")
@@ -764,43 +765,6 @@ func geminiDiscoveredMetadata(supportsGenerate, supportsEmbed, supportsImage boo
 	}
 }
 
-// knownImagenModels are the Imagen models the Gemini API documents for
-// AI Studio. Google serves them but omits them from its model listings, so
-// without seeding they could never be routed; discovery metadata marks them
-// image-only and registry enrichment overrides it when the catalog knows more.
-var knownImagenModels = []string{
-	"imagen-3.0-generate-002",
-	"imagen-4.0-generate-001",
-	"imagen-4.0-fast-generate-001",
-	"imagen-4.0-ultra-generate-001",
-}
-
-// appendKnownImagenModels adds the documented Imagen models missing from an
-// AI Studio listing. Vertex lists Imagen in its publisher models already, so
-// only the AI Studio backend is seeded.
-func (p *Provider) appendKnownImagenModels(models []core.Model, now int64) []core.Model {
-	if p.backend != geminiBackendAIStudio {
-		return models
-	}
-	seen := make(map[string]struct{}, len(models))
-	for _, model := range models {
-		seen[normalizeGeminiModelID(model.ID)] = struct{}{}
-	}
-	for _, id := range knownImagenModels {
-		if _, ok := seen[id]; ok {
-			continue
-		}
-		models = append(models, core.Model{
-			ID:       id,
-			Object:   "model",
-			OwnedBy:  "google",
-			Created:  now,
-			Metadata: geminiDiscoveredMetadata(false, false, true),
-		})
-	}
-	return models
-}
-
 // ListModels retrieves the list of available models from Gemini
 func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error) {
 	if err := p.ready(); err != nil {
@@ -834,11 +798,9 @@ func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error)
 		}
 		modelEntries := append(geminiResp.Models, geminiResp.PublisherModels...)
 		if len(modelEntries) == 0 {
-			// Still seed Imagen: Google serves those models without ever
-			// listing them, so an explicitly empty inventory must not hide them.
 			return &core.ModelsResponse{
 				Object: "list",
-				Data:   p.appendKnownImagenModels([]core.Model{}, now),
+				Data:   []core.Model{},
 			}, nil
 		}
 
@@ -862,7 +824,7 @@ func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error)
 
 		return &core.ModelsResponse{
 			Object: "list",
-			Data:   p.appendKnownImagenModels(models, now),
+			Data:   models,
 		}, nil
 	}
 
@@ -885,7 +847,7 @@ func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error)
 		}
 		return &core.ModelsResponse{
 			Object: "list",
-			Data:   p.appendKnownImagenModels(models, now),
+			Data:   models,
 		}, nil
 	}
 

--- a/internal/providers/gemini/gemini_test.go
+++ b/internal/providers/gemini/gemini_test.go
@@ -621,8 +621,8 @@ func TestSetBaseURLDerivesModelsURL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(resp.Data) != 1+len(knownImagenModels) || resp.Data[0].ID != "gemini-2.5-flash" {
-		t.Fatalf("models = %+v, want gemini-2.5-flash plus seeded Imagen models", resp.Data)
+	if len(resp.Data) != 1 || resp.Data[0].ID != "gemini-2.5-flash" {
+		t.Fatalf("models = %+v, want gemini-2.5-flash", resp.Data)
 	}
 	if !modelsHit {
 		t.Fatal("models server was not called")
@@ -1908,8 +1908,8 @@ func TestListModels(t *testing.T) {
 				if resp.Object != "list" {
 					t.Errorf("Object = %q, want %q", resp.Object, "list")
 				}
-				if len(resp.Data) != 2+len(knownImagenModels) {
-					t.Fatalf("len(Data) = %d, want 2 listed plus seeded Imagen models", len(resp.Data))
+				if len(resp.Data) != 2 {
+					t.Fatalf("len(Data) = %d, want 2", len(resp.Data))
 				}
 				if resp.Data[0].ID != "gemini-2.0-flash" {
 					t.Errorf("Data[0].ID = %q, want %q", resp.Data[0].ID, "gemini-2.0-flash")
@@ -2284,5 +2284,24 @@ data: {"responseId":"gemini-native-stream-response","candidates":[{"content":{"r
 	}
 	if !strings.Contains(stream, "data: [DONE]") {
 		t.Fatalf("stream = %q, want [DONE]", stream)
+	}
+}
+
+func TestGeminiModelSupportedMethods_EmptyMethodFallback(t *testing.T) {
+	tests := []struct {
+		model                          string
+		wantChat, wantEmbed, wantImage bool
+	}{
+		{model: "gemini-2.5-flash", wantChat: true},
+		{model: "gemini-embedding-001", wantEmbed: true},
+		{model: "text-embedding-004", wantEmbed: true},
+		{model: "imagen-4.0-generate-001", wantImage: true},
+	}
+	for _, tt := range tests {
+		gotChat, gotEmbed, gotImage := geminiModelSupportedMethods(tt.model, nil)
+		if gotChat != tt.wantChat || gotEmbed != tt.wantEmbed || gotImage != tt.wantImage {
+			t.Errorf("geminiModelSupportedMethods(%q, nil) = %v/%v/%v, want %v/%v/%v",
+				tt.model, gotChat, gotEmbed, gotImage, tt.wantChat, tt.wantEmbed, tt.wantImage)
+		}
 	}
 }

--- a/internal/providers/gemini/gemini_test.go
+++ b/internal/providers/gemini/gemini_test.go
@@ -987,11 +987,14 @@ func TestVertexListModelsAcceptsPublisherModelsResponse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(resp.Data) != 2 {
-		t.Fatalf("models = %+v, want 2 Gemini-compatible models", resp.Data)
+	if len(resp.Data) != 3 {
+		t.Fatalf("models = %+v, want 3 Gemini-compatible models", resp.Data)
 	}
-	if resp.Data[0].ID != "google/gemini-2.5-flash" || resp.Data[1].ID != "google/text-embedding-005" {
-		t.Fatalf("models = %+v, want google/gemini-2.5-flash and google/text-embedding-005", resp.Data)
+	if resp.Data[0].ID != "google/gemini-2.5-flash" || resp.Data[1].ID != "google/text-embedding-005" || resp.Data[2].ID != "google/imagen-4.0" {
+		t.Fatalf("models = %+v, want gemini-2.5-flash, text-embedding-005, and imagen-4.0", resp.Data)
+	}
+	if modes := resp.Data[2].Metadata.Modes; len(modes) != 1 || modes[0] != "image_generation" {
+		t.Fatalf("imagen modes = %+v, want [image_generation]", modes)
 	}
 }
 

--- a/internal/providers/gemini/gemini_test.go
+++ b/internal/providers/gemini/gemini_test.go
@@ -621,8 +621,8 @@ func TestSetBaseURLDerivesModelsURL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(resp.Data) != 1 || resp.Data[0].ID != "gemini-2.5-flash" {
-		t.Fatalf("models = %+v, want gemini-2.5-flash", resp.Data)
+	if len(resp.Data) != 1+len(knownImagenModels) || resp.Data[0].ID != "gemini-2.5-flash" {
+		t.Fatalf("models = %+v, want gemini-2.5-flash plus seeded Imagen models", resp.Data)
 	}
 	if !modelsHit {
 		t.Fatal("models server was not called")
@@ -1908,8 +1908,8 @@ func TestListModels(t *testing.T) {
 				if resp.Object != "list" {
 					t.Errorf("Object = %q, want %q", resp.Object, "list")
 				}
-				if len(resp.Data) != 2 {
-					t.Fatalf("len(Data) = %d, want 2", len(resp.Data))
+				if len(resp.Data) != 2+len(knownImagenModels) {
+					t.Fatalf("len(Data) = %d, want 2 listed plus seeded Imagen models", len(resp.Data))
 				}
 				if resp.Data[0].ID != "gemini-2.0-flash" {
 					t.Errorf("Data[0].ID = %q, want %q", resp.Data[0].ID, "gemini-2.0-flash")

--- a/internal/providers/gemini/images.go
+++ b/internal/providers/gemini/images.go
@@ -265,8 +265,8 @@ func (p *Provider) imageResponseFromGenerateContent(resp *geminiGenerateContentR
 	var text strings.Builder
 	for _, candidate := range resp.Candidates {
 		for _, part := range candidate.Content.Parts {
-			if part.InlineData != nil && part.InlineData.Data != "" {
-				out.Data = append(out.Data, core.ImageData{B64JSON: part.InlineData.Data})
+			if blob := part.inlineData(); blob != nil && blob.Data != "" {
+				out.Data = append(out.Data, core.ImageData{B64JSON: blob.Data})
 				continue
 			}
 			if part.Text != "" {

--- a/internal/providers/gemini/images.go
+++ b/internal/providers/gemini/images.go
@@ -1,0 +1,414 @@
+package gemini
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/goccy/go-json"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/llmclient"
+)
+
+// CreateImage implements OpenAI-compatible image generation for Gemini.
+// In native mode Imagen models are served through models/{model}:predict and
+// Gemini image models (gemini-2.5-flash-image, ...) through generateContent
+// with image response modalities. In OpenAI-compatible mode the request is
+// forwarded to Gemini's /openai/images/generations endpoint unchanged.
+func (p *Provider) CreateImage(ctx context.Context, req *core.ImageGenerationRequest) (*core.ImageGenerationResponse, error) {
+	if err := p.ready(); err != nil {
+		return nil, err
+	}
+	if err := core.ValidateImageGenerationRequest(req); err != nil {
+		return nil, err
+	}
+	if !p.useNativeAPI {
+		return p.openAICompatibleCreateImage(ctx, req)
+	}
+	if isImagenModel(req.Model) {
+		return p.predictImage(ctx, req)
+	}
+	return p.generateContentImage(ctx, req)
+}
+
+// CreateImageEdit implements OpenAI-compatible image edits for Gemini image
+// models through the native generateContent API: uploaded images become
+// inline_data parts ahead of the prompt text. Imagen models only generate, and
+// the OpenAI-compatible surface has no edits endpoint, so both are rejected
+// with a pointer to what works.
+func (p *Provider) CreateImageEdit(ctx context.Context, req *core.ImageEditRequest) (*core.ImageGenerationResponse, error) {
+	if err := p.ready(); err != nil {
+		return nil, err
+	}
+	if err := core.ValidateImageEditRequest(req); err != nil {
+		return nil, err
+	}
+	if !p.useNativeAPI {
+		return nil, core.NewInvalidRequestError("image edits require Gemini native API mode; set api_mode: native (or USE_GOOGLE_GEMINI_NATIVE_API=true)", nil)
+	}
+	if isImagenModel(req.Model) {
+		return nil, core.NewInvalidRequestError("model \""+req.Model+"\" does not support image edits; use a Gemini image model such as gemini-2.5-flash-image", nil)
+	}
+	if req.Mask != nil {
+		return nil, core.NewInvalidRequestError("Gemini image edits do not support mask; describe the region to change in the prompt", nil)
+	}
+
+	parts := make([]geminiPart, 0, len(req.Images)+1)
+	for _, image := range req.Images {
+		parts = append(parts, geminiPart{InlineData: &geminiBlob{
+			MimeType: imageEditMimeType(image.ContentType),
+			Data:     base64.StdEncoding.EncodeToString(image.Data),
+		}})
+	}
+	parts = append(parts, geminiPart{Text: req.Prompt})
+
+	size, _ := req.Field("size")
+	body := &geminiGenerateContentRequest{
+		Contents:         []geminiContent{{Role: "user", Parts: parts}},
+		GenerationConfig: imageGenerationConfig(size, imageEditCount(req), nil),
+	}
+	return p.doGenerateContentImage(ctx, req.Model, body)
+}
+
+func (p *Provider) openAICompatibleCreateImage(ctx context.Context, req *core.ImageGenerationRequest) (*core.ImageGenerationResponse, error) {
+	if p.backend == geminiBackendVertex {
+		if model := vertexOpenAIModelID(req.Model); strings.TrimSpace(model) != "" {
+			rewritten := *req
+			rewritten.Model = model
+			req = &rewritten
+		}
+	}
+	var resp core.ImageGenerationResponse
+	err := p.client.Do(ctx, llmclient.Request{
+		Method:   http.MethodPost,
+		Endpoint: "/images/generations",
+		Model:    req.Model,
+		Body:     req,
+	}, &resp)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Created == 0 {
+		resp.Created = time.Now().Unix()
+	}
+	if resp.Data == nil {
+		resp.Data = []core.ImageData{}
+	}
+	if resp.Provider == "" {
+		resp.Provider = p.responseProviderName()
+	}
+	return &resp, nil
+}
+
+// Imagen prediction (models/imagen-*:predict).
+
+type geminiImagePredictRequest struct {
+	Instances  []geminiImagePredictInstance `json:"instances"`
+	Parameters map[string]any               `json:"parameters,omitempty"`
+}
+
+type geminiImagePredictInstance struct {
+	Prompt string `json:"prompt"`
+}
+
+type geminiImagePredictResponse struct {
+	Predictions []geminiImagePrediction `json:"predictions"`
+}
+
+type geminiImagePrediction struct {
+	BytesBase64Encoded string `json:"bytesBase64Encoded,omitempty"`
+	MimeType           string `json:"mimeType,omitempty"`
+	Prompt             string `json:"prompt,omitempty"`
+	RaiFilteredReason  string `json:"raiFilteredReason,omitempty"`
+}
+
+func (p *Provider) predictImage(ctx context.Context, req *core.ImageGenerationRequest) (*core.ImageGenerationResponse, error) {
+	parameters, err := imagePredictParameters(req)
+	if err != nil {
+		return nil, err
+	}
+	body := &geminiImagePredictRequest{
+		Instances:  []geminiImagePredictInstance{{Prompt: req.Prompt}},
+		Parameters: parameters,
+	}
+	var predictResp geminiImagePredictResponse
+	err = p.nativeClient.Do(ctx, llmclient.Request{
+		Method:   http.MethodPost,
+		Endpoint: "/models/" + url.PathEscape(normalizeGeminiModelID(req.Model)) + ":predict",
+		Model:    req.Model,
+		Body:     body,
+	}, &predictResp)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &core.ImageGenerationResponse{
+		Created:  time.Now().Unix(),
+		Data:     make([]core.ImageData, 0, len(predictResp.Predictions)),
+		Provider: p.responseProviderName(),
+	}
+	filteredReason := ""
+	for _, prediction := range predictResp.Predictions {
+		if prediction.BytesBase64Encoded == "" {
+			if prediction.RaiFilteredReason != "" {
+				filteredReason = prediction.RaiFilteredReason
+			}
+			continue
+		}
+		resp.Data = append(resp.Data, core.ImageData{
+			B64JSON:       prediction.BytesBase64Encoded,
+			RevisedPrompt: prediction.Prompt,
+		})
+	}
+	if len(resp.Data) == 0 {
+		message := "Gemini returned no images"
+		if filteredReason != "" {
+			message += ": " + filteredReason
+		}
+		return nil, core.NewProviderError(p.responseProviderName(), http.StatusBadGateway, message, nil)
+	}
+	return resp, nil
+}
+
+// imagePredictParameters maps the OpenAI request onto Imagen predict
+// parameters: n becomes sampleCount (explicitly, so OpenAI's default of one
+// image wins over Imagen's default of four) and size becomes aspectRatio.
+// Unknown request fields are forwarded verbatim so native parameters
+// (personGeneration, sampleImageSize, ...) work without a gateway change;
+// OpenAI fields with no Imagen equivalent (quality, response_format, user)
+// are dropped. Imagen always returns base64 image bytes.
+func imagePredictParameters(req *core.ImageGenerationRequest) (map[string]any, error) {
+	parameters, err := imageExtraFields(req)
+	if err != nil {
+		return nil, err
+	}
+	parameters["sampleCount"] = req.ImageCount()
+	if aspectRatio := imageAspectRatio(req.Size); aspectRatio != "" {
+		if _, ok := parameters["aspectRatio"]; !ok {
+			parameters["aspectRatio"] = aspectRatio
+		}
+	}
+	return parameters, nil
+}
+
+// Gemini image model generation (generateContent with image modalities).
+
+func (p *Provider) generateContentImage(ctx context.Context, req *core.ImageGenerationRequest) (*core.ImageGenerationResponse, error) {
+	extra, err := imageExtraFields(req)
+	if err != nil {
+		return nil, err
+	}
+	body := &geminiGenerateContentRequest{
+		Contents:         []geminiContent{{Role: "user", Parts: []geminiPart{{Text: req.Prompt}}}},
+		GenerationConfig: imageGenerationConfig(req.Size, req.ImageCount(), extra),
+	}
+	return p.doGenerateContentImage(ctx, req.Model, body)
+}
+
+func (p *Provider) doGenerateContentImage(ctx context.Context, model string, body *geminiGenerateContentRequest) (*core.ImageGenerationResponse, error) {
+	var geminiResp geminiGenerateContentResponse
+	err := p.nativeClient.Do(ctx, llmclient.Request{
+		Method:    http.MethodPost,
+		Endpoint:  nativeGenerateEndpoint(model),
+		Operation: llmclient.OperationGenerateContent,
+		Model:     model,
+		Body:      body,
+	}, &geminiResp)
+	if err != nil {
+		return nil, err
+	}
+	return p.imageResponseFromGenerateContent(&geminiResp)
+}
+
+// imageGenerationConfig builds the generationConfig for image output. Extra
+// request fields merge in verbatim so native options (imageConfig,
+// responseModalities overrides, ...) pass through; the explicit mappings only
+// fill keys the caller did not set.
+func imageGenerationConfig(size string, count int, extra map[string]any) map[string]any {
+	config := extra
+	if config == nil {
+		config = make(map[string]any, 3)
+	}
+	if _, ok := config["responseModalities"]; !ok {
+		// Gemini image models reject image-only output; TEXT must be allowed.
+		config["responseModalities"] = []string{"TEXT", "IMAGE"}
+	}
+	if count > 1 {
+		if _, ok := config["candidateCount"]; !ok {
+			config["candidateCount"] = count
+		}
+	}
+	aspectRatio := imageAspectRatio(size)
+	if aspectRatio == "" {
+		return config
+	}
+	if _, ok := config["imageConfig"]; !ok {
+		config["imageConfig"] = map[string]any{"aspectRatio": aspectRatio}
+	}
+	return config
+}
+
+// imageResponseFromGenerateContent flattens candidate parts into the OpenAI
+// images envelope: inline image data becomes b64_json entries and any model
+// commentary is surfaced as revised_prompt on the first image.
+func (p *Provider) imageResponseFromGenerateContent(resp *geminiGenerateContentResponse) (*core.ImageGenerationResponse, error) {
+	out := &core.ImageGenerationResponse{
+		Created:  time.Now().Unix(),
+		Data:     []core.ImageData{},
+		Provider: p.responseProviderName(),
+	}
+	var text strings.Builder
+	for _, candidate := range resp.Candidates {
+		for _, part := range candidate.Content.Parts {
+			if part.InlineData != nil && part.InlineData.Data != "" {
+				out.Data = append(out.Data, core.ImageData{B64JSON: part.InlineData.Data})
+				continue
+			}
+			if part.Text != "" {
+				if text.Len() > 0 {
+					text.WriteString("\n")
+				}
+				text.WriteString(part.Text)
+			}
+		}
+	}
+	if len(out.Data) == 0 {
+		return nil, core.NewProviderError(p.responseProviderName(), http.StatusBadGateway, imageFailureMessage(resp, text.String()), nil)
+	}
+	if text.Len() > 0 {
+		out.Data[0].RevisedPrompt = text.String()
+	}
+	if usage := resp.UsageMetadata; usage.TotalTokenCount > 0 {
+		out.Usage = &core.ImageUsage{
+			InputTokens:  usage.PromptTokenCount,
+			OutputTokens: usage.CandidatesTokenCount + usage.ThoughtsTokenCount,
+			TotalTokens:  usage.TotalTokenCount,
+		}
+	}
+	return out, nil
+}
+
+// imageFailureMessage explains a generateContent response that carried no
+// image: a prompt-feedback block reason when present, otherwise the model's
+// own text, trimmed to stay log-friendly.
+func imageFailureMessage(resp *geminiGenerateContentResponse, text string) string {
+	message := "Gemini returned no images"
+	var feedback geminiPromptFeedback
+	if len(resp.PromptFeedback) > 0 && json.Unmarshal(resp.PromptFeedback, &feedback) == nil && feedback.BlockReason != "" {
+		message += ": blocked (" + feedback.BlockReason + ")"
+		if feedback.BlockReasonMessage != "" {
+			message += " " + feedback.BlockReasonMessage
+		}
+		return message
+	}
+	text = strings.TrimSpace(text)
+	if text != "" {
+		const maxLen = 240
+		if len(text) > maxLen {
+			text = text[:maxLen] + "..."
+		}
+		message += ": " + text
+	}
+	return message
+}
+
+// imageExtraFields returns the request fields the gateway does not type,
+// keyed as the client sent them. Marshaling the request merges ExtraFields
+// back in, so decoding that and dropping the typed keys yields exactly the
+// passthrough set.
+func imageExtraFields(req *core.ImageGenerationRequest) (map[string]any, error) {
+	if req.ExtraFields.IsEmpty() {
+		return map[string]any{}, nil
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, core.NewInvalidRequestError("invalid image generation request: "+err.Error(), err)
+	}
+	fields := make(map[string]any)
+	if err := json.Unmarshal(body, &fields); err != nil {
+		return nil, core.NewInvalidRequestError("invalid image generation request: "+err.Error(), err)
+	}
+	for _, key := range []string{"model", "prompt", "n", "response_format", "size", "quality", "user", "stream", "provider"} {
+		delete(fields, key)
+	}
+	return fields, nil
+}
+
+// imageAspectRatio translates an OpenAI size to a Gemini aspect ratio. Ratio
+// strings ("16:9") pass through for clients speaking native Gemini already;
+// "WxH" pixel sizes reduce to the closest ratio Gemini documents. Anything
+// else (including "auto") is omitted so the model default applies.
+func imageAspectRatio(size string) string {
+	size = strings.ToLower(strings.TrimSpace(size))
+	if size == "" || size == "auto" {
+		return ""
+	}
+	if strings.Contains(size, ":") {
+		return size
+	}
+	width, height, ok := strings.Cut(size, "x")
+	w, errW := strconv.Atoi(width)
+	h, errH := strconv.Atoi(height)
+	if !ok || errW != nil || errH != nil || w <= 0 || h <= 0 {
+		return ""
+	}
+	// The DALL·E landscape/portrait sizes have no exact Gemini ratio; 16:9 and
+	// 9:16 are the closest supported shapes.
+	switch {
+	case w == 1792 && h == 1024:
+		return "16:9"
+	case w == 1024 && h == 1792:
+		return "9:16"
+	}
+	divisor := gcd(w, h)
+	return strconv.Itoa(w/divisor) + ":" + strconv.Itoa(h/divisor)
+}
+
+func gcd(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+// isImagenModel reports whether the model belongs to the Imagen family, which
+// generates through :predict rather than generateContent.
+func isImagenModel(model string) bool {
+	return strings.HasPrefix(normalizeGeminiModelID(model), "imagen-")
+}
+
+func imageEditMimeType(contentType string) string {
+	contentType = strings.TrimSpace(contentType)
+	if contentType == "" {
+		return "image/png"
+	}
+	if mediaType, _, ok := strings.Cut(contentType, ";"); ok {
+		return strings.TrimSpace(mediaType)
+	}
+	return contentType
+}
+
+// imageEditCount reads the n form field; malformed values fall back to one
+// image (core validation already rejected non-positive n).
+func imageEditCount(req *core.ImageEditRequest) int {
+	value, _ := req.Field("n")
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 1
+	}
+	count, err := strconv.Atoi(value)
+	if err != nil || count < 1 {
+		return 1
+	}
+	return count
+}
+
+var (
+	_ core.ImageProvider     = (*Provider)(nil)
+	_ core.ImageEditProvider = (*Provider)(nil)
+)

--- a/internal/providers/gemini/images.go
+++ b/internal/providers/gemini/images.go
@@ -187,7 +187,9 @@ func imagePredictParameters(req *core.ImageGenerationRequest) (map[string]any, e
 	if err != nil {
 		return nil, err
 	}
-	parameters["sampleCount"] = req.ImageCount()
+	if _, ok := parameters["sampleCount"]; !ok {
+		parameters["sampleCount"] = req.ImageCount()
+	}
 	if aspectRatio := imageAspectRatio(req.Size); aspectRatio != "" {
 		if _, ok := parameters["aspectRatio"]; !ok {
 			parameters["aspectRatio"] = aspectRatio

--- a/internal/providers/gemini/images_test.go
+++ b/internal/providers/gemini/images_test.go
@@ -357,3 +357,59 @@ func TestListModels_SeedsKnownImagenModels(t *testing.T) {
 		}
 	}
 }
+
+func TestCreateImage_GeminiImageModelMultiImage(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &gotBody); err != nil {
+			t.Errorf("request body is not JSON: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"candidates": [
+				{"content": {"role": "model", "parts": [{"inlineData": {"mimeType": "image/png", "data": "aW1nMQ=="}}]}, "finishReason": "STOP"},
+				{"content": {"role": "model", "parts": [{"inlineData": {"mimeType": "image/png", "data": "aW1nMg=="}}]}, "finishReason": "STOP", "index": 1}
+			],
+			"usageMetadata": {"promptTokenCount": 8, "candidatesTokenCount": 2580, "totalTokenCount": 2588}
+		}`))
+	}))
+	defer server.Close()
+
+	p := newNativeTestProvider(t, server)
+	resp, err := p.CreateImage(context.Background(), decodeImageRequest(t, `{"model": "gemini-2.5-flash-image", "prompt": "two variants", "n": 2}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	config, _ := gotBody["generationConfig"].(map[string]any)
+	if config["candidateCount"] != float64(2) {
+		t.Errorf("candidateCount = %v, want 2 for n=2", config["candidateCount"])
+	}
+	if len(resp.Data) != 2 || resp.Data[0].B64JSON != "aW1nMQ==" || resp.Data[1].B64JSON != "aW1nMg==" {
+		t.Fatalf("data = %+v, want both candidates flattened into images", resp.Data)
+	}
+	if resp.Usage == nil || resp.Usage.TotalTokens != 2588 {
+		t.Errorf("usage = %+v, want mapped totals", resp.Usage)
+	}
+}
+
+func TestListModels_SeedsImagenOnExplicitlyEmptyInventory(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"models": []}`))
+	}))
+	defer server.Close()
+
+	p := newNativeTestProvider(t, server)
+	resp, err := p.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Data) != len(knownImagenModels) {
+		t.Fatalf("models = %+v, want the seeded Imagen models on an empty inventory", resp.Data)
+	}
+	if resp.Data[0].ID != knownImagenModels[0] {
+		t.Errorf("first model = %q, want %q", resp.Data[0].ID, knownImagenModels[0])
+	}
+}

--- a/internal/providers/gemini/images_test.go
+++ b/internal/providers/gemini/images_test.go
@@ -1,0 +1,321 @@
+package gemini
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+func decodeImageRequest(t *testing.T, body string) *core.ImageGenerationRequest {
+	t.Helper()
+	req, err := core.DecodeImageGenerationRequest([]byte(body), nil)
+	if err != nil {
+		t.Fatalf("decode image request: %v", err)
+	}
+	return req
+}
+
+func TestCreateImage_ImagenPredict(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1beta/models/imagen-4.0-generate-001:predict" {
+			t.Errorf("path = %q, want /v1beta/models/imagen-4.0-generate-001:predict", r.URL.Path)
+		}
+		if got := r.Header.Get("x-goog-api-key"); got != "test-api-key" {
+			t.Errorf("x-goog-api-key = %q, want test-api-key", got)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &gotBody); err != nil {
+			t.Errorf("request body is not JSON: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"predictions": [
+			{"bytesBase64Encoded": "aW1nMQ==", "mimeType": "image/png", "prompt": "an enhanced prompt"},
+			{"bytesBase64Encoded": "aW1nMg==", "mimeType": "image/png"}
+		]}`))
+	}))
+	defer server.Close()
+
+	p := newNativeTestProvider(t, server)
+	req := decodeImageRequest(t, `{
+		"model": "imagen-4.0-generate-001",
+		"prompt": "a lighthouse at dawn",
+		"n": 2,
+		"size": "1024x1024",
+		"personGeneration": "allow_adult"
+	}`)
+	resp, err := p.CreateImage(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	instances, _ := gotBody["instances"].([]any)
+	if len(instances) != 1 || instances[0].(map[string]any)["prompt"] != "a lighthouse at dawn" {
+		t.Errorf("instances = %+v, want single prompt instance", gotBody["instances"])
+	}
+	parameters, _ := gotBody["parameters"].(map[string]any)
+	if parameters["sampleCount"] != float64(2) {
+		t.Errorf("sampleCount = %v, want 2", parameters["sampleCount"])
+	}
+	if parameters["aspectRatio"] != "1:1" {
+		t.Errorf("aspectRatio = %v, want 1:1", parameters["aspectRatio"])
+	}
+	if parameters["personGeneration"] != "allow_adult" {
+		t.Errorf("personGeneration = %v, want extra field forwarded verbatim", parameters["personGeneration"])
+	}
+
+	if len(resp.Data) != 2 {
+		t.Fatalf("data = %+v, want 2 images", resp.Data)
+	}
+	if resp.Data[0].B64JSON != "aW1nMQ==" || resp.Data[0].RevisedPrompt != "an enhanced prompt" {
+		t.Errorf("first image = %+v, want b64 bytes and revised prompt", resp.Data[0])
+	}
+	if resp.Provider != "gemini" || resp.Created == 0 {
+		t.Errorf("provider/created = %q/%d, want gemini and non-zero created", resp.Provider, resp.Created)
+	}
+}
+
+func TestCreateImage_ImagenAllFilteredIsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"predictions": [{"raiFilteredReason": "blocked by safety filters"}]}`))
+	}))
+	defer server.Close()
+
+	p := newNativeTestProvider(t, server)
+	_, err := p.CreateImage(context.Background(), decodeImageRequest(t, `{"model": "imagen-4.0-generate-001", "prompt": "x"}`))
+	if err == nil || !strings.Contains(err.Error(), "blocked by safety filters") {
+		t.Fatalf("error = %v, want filtered reason surfaced", err)
+	}
+}
+
+func TestCreateImage_GeminiImageModelGenerateContent(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1beta/models/gemini-2.5-flash-image:generateContent" {
+			t.Errorf("path = %q, want /v1beta/models/gemini-2.5-flash-image:generateContent", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &gotBody); err != nil {
+			t.Errorf("request body is not JSON: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"candidates": [{
+				"content": {"role": "model", "parts": [
+					{"text": "Here is your image."},
+					{"inline_data": {"mime_type": "image/png", "data": "aW1n"}}
+				]},
+				"finishReason": "STOP"
+			}],
+			"usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 1290, "totalTokenCount": 1300}
+		}`))
+	}))
+	defer server.Close()
+
+	p := newNativeTestProvider(t, server)
+	req := decodeImageRequest(t, `{"model": "gemini-2.5-flash-image", "prompt": "a lighthouse", "size": "1536x1024"}`)
+	resp, err := p.CreateImage(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	contents, _ := gotBody["contents"].([]any)
+	if len(contents) != 1 {
+		t.Fatalf("contents = %+v, want one user turn", gotBody["contents"])
+	}
+	parts, _ := contents[0].(map[string]any)["parts"].([]any)
+	if len(parts) != 1 || parts[0].(map[string]any)["text"] != "a lighthouse" {
+		t.Errorf("parts = %+v, want single prompt text part", parts)
+	}
+	config, _ := gotBody["generationConfig"].(map[string]any)
+	modalities, _ := config["responseModalities"].([]any)
+	if len(modalities) != 2 || modalities[0] != "TEXT" || modalities[1] != "IMAGE" {
+		t.Errorf("responseModalities = %+v, want [TEXT IMAGE]", config["responseModalities"])
+	}
+	imageConfig, _ := config["imageConfig"].(map[string]any)
+	if imageConfig["aspectRatio"] != "3:2" {
+		t.Errorf("imageConfig = %+v, want aspectRatio 3:2 for 1536x1024", config["imageConfig"])
+	}
+	if _, ok := config["candidateCount"]; ok {
+		t.Errorf("candidateCount present for n=1: %+v", config)
+	}
+
+	if len(resp.Data) != 1 || resp.Data[0].B64JSON != "aW1n" {
+		t.Fatalf("data = %+v, want one inline image", resp.Data)
+	}
+	if resp.Data[0].RevisedPrompt != "Here is your image." {
+		t.Errorf("revised_prompt = %q, want model text surfaced", resp.Data[0].RevisedPrompt)
+	}
+	if resp.Usage == nil || resp.Usage.InputTokens != 10 || resp.Usage.OutputTokens != 1290 || resp.Usage.TotalTokens != 1300 {
+		t.Errorf("usage = %+v, want mapped token counts", resp.Usage)
+	}
+}
+
+func TestCreateImage_GeminiImageModelNoImageIsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"candidates": [{"content": {"role": "model", "parts": [{"text": "I cannot draw that."}]}, "finishReason": "STOP"}]}`))
+	}))
+	defer server.Close()
+
+	p := newNativeTestProvider(t, server)
+	_, err := p.CreateImage(context.Background(), decodeImageRequest(t, `{"model": "gemini-2.5-flash-image", "prompt": "x"}`))
+	if err == nil || !strings.Contains(err.Error(), "I cannot draw that.") {
+		t.Fatalf("error = %v, want model text surfaced", err)
+	}
+}
+
+func TestCreateImage_CompatModeUsesOpenAIEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1beta/openai/images/generations" {
+			t.Errorf("path = %q, want /v1beta/openai/images/generations", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-api-key" {
+			t.Errorf("Authorization = %q, want Bearer key on compat surface", got)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"created": 1700000000, "data": [{"b64_json": "aW1n"}]}`))
+	}))
+	defer server.Close()
+
+	p := newCompatTestProvider(t, server)
+	resp, err := p.CreateImage(context.Background(), decodeImageRequest(t, `{"model": "imagen-4.0-generate-001", "prompt": "x"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Data) != 1 || resp.Data[0].B64JSON != "aW1n" || resp.Provider != "gemini" {
+		t.Fatalf("response = %+v, want compat passthrough with provider stamp", resp)
+	}
+}
+
+func TestCreateImageEdit_GenerateContent(t *testing.T) {
+	imageBytes := []byte{0x89, 0x50, 0x4e, 0x47}
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1beta/models/gemini-2.5-flash-image:generateContent" {
+			t.Errorf("path = %q, want generateContent on the edit model", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &gotBody); err != nil {
+			t.Errorf("request body is not JSON: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"candidates": [{"content": {"role": "model", "parts": [{"inline_data": {"mime_type": "image/png", "data": "ZWRpdGVk"}}]}, "finishReason": "STOP"}]}`))
+	}))
+	defer server.Close()
+
+	p := newNativeTestProvider(t, server)
+	resp, err := p.CreateImageEdit(context.Background(), &core.ImageEditRequest{
+		Model:  "gemini-2.5-flash-image",
+		Prompt: "add a sailboat",
+		Images: []core.ImageFile{
+			{Filename: "a.png", ContentType: "image/png", Data: imageBytes},
+			{Filename: "b.jpg", ContentType: "image/jpeg; charset=binary", Data: []byte{0xff}},
+		},
+		Fields: []core.FormField{{Name: "size", Value: "1024x1536"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	contents, _ := gotBody["contents"].([]any)
+	parts, _ := contents[0].(map[string]any)["parts"].([]any)
+	if len(parts) != 3 {
+		t.Fatalf("parts = %+v, want two images then the prompt", parts)
+	}
+	first, _ := parts[0].(map[string]any)["inline_data"].(map[string]any)
+	if first["mime_type"] != "image/png" || first["data"] != base64.StdEncoding.EncodeToString(imageBytes) {
+		t.Errorf("first inline part = %+v, want base64 png upload", first)
+	}
+	second, _ := parts[1].(map[string]any)["inline_data"].(map[string]any)
+	if second["mime_type"] != "image/jpeg" {
+		t.Errorf("second inline mime = %v, want media type without parameters", second["mime_type"])
+	}
+	if parts[2].(map[string]any)["text"] != "add a sailboat" {
+		t.Errorf("last part = %+v, want the prompt text", parts[2])
+	}
+	config, _ := gotBody["generationConfig"].(map[string]any)
+	imageConfig, _ := config["imageConfig"].(map[string]any)
+	if imageConfig["aspectRatio"] != "2:3" {
+		t.Errorf("imageConfig = %+v, want aspectRatio 2:3 for 1024x1536", config["imageConfig"])
+	}
+
+	if len(resp.Data) != 1 || resp.Data[0].B64JSON != "ZWRpdGVk" {
+		t.Fatalf("data = %+v, want the edited image", resp.Data)
+	}
+}
+
+func TestCreateImageEdit_Rejections(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("no upstream call expected")
+	}))
+	defer server.Close()
+
+	baseRequest := func() *core.ImageEditRequest {
+		return &core.ImageEditRequest{
+			Model:  "gemini-2.5-flash-image",
+			Prompt: "edit",
+			Images: []core.ImageFile{{Filename: "a.png", Data: []byte{1}}},
+		}
+	}
+
+	t.Run("mask unsupported", func(t *testing.T) {
+		p := newNativeTestProvider(t, server)
+		req := baseRequest()
+		req.Mask = &core.ImageFile{Filename: "mask.png", Data: []byte{1}}
+		_, err := p.CreateImageEdit(context.Background(), req)
+		if err == nil || !strings.Contains(err.Error(), "mask") {
+			t.Fatalf("error = %v, want mask rejection", err)
+		}
+	})
+
+	t.Run("imagen models cannot edit", func(t *testing.T) {
+		p := newNativeTestProvider(t, server)
+		req := baseRequest()
+		req.Model = "imagen-4.0-generate-001"
+		_, err := p.CreateImageEdit(context.Background(), req)
+		if err == nil || !strings.Contains(err.Error(), "does not support image edits") {
+			t.Fatalf("error = %v, want imagen edit rejection", err)
+		}
+	})
+
+	t.Run("compat mode requires native API", func(t *testing.T) {
+		p := newCompatTestProvider(t, server)
+		_, err := p.CreateImageEdit(context.Background(), baseRequest())
+		if err == nil || !strings.Contains(err.Error(), "native API mode") {
+			t.Fatalf("error = %v, want native-mode requirement", err)
+		}
+	})
+}
+
+func TestImageAspectRatio(t *testing.T) {
+	tests := []struct {
+		size string
+		want string
+	}{
+		{"", ""},
+		{"auto", ""},
+		{"1024x1024", "1:1"},
+		{"1536x1024", "3:2"},
+		{"1024x1536", "2:3"},
+		{"1792x1024", "16:9"},
+		{"1024x1792", "9:16"},
+		{"16:9", "16:9"},
+		{"512X512", "1:1"},
+		{"bogus", ""},
+		{"0x100", ""},
+	}
+	for _, tt := range tests {
+		if got := imageAspectRatio(tt.size); got != tt.want {
+			t.Errorf("imageAspectRatio(%q) = %q, want %q", tt.size, got, tt.want)
+		}
+	}
+}

--- a/internal/providers/gemini/images_test.go
+++ b/internal/providers/gemini/images_test.go
@@ -111,7 +111,7 @@ func TestCreateImage_GeminiImageModelGenerateContent(t *testing.T) {
 			"candidates": [{
 				"content": {"role": "model", "parts": [
 					{"text": "Here is your image."},
-					{"inline_data": {"mime_type": "image/png", "data": "aW1n"}}
+					{"inlineData": {"mimeType": "image/png", "data": "aW1n"}}
 				]},
 				"finishReason": "STOP"
 			}],
@@ -316,6 +316,44 @@ func TestImageAspectRatio(t *testing.T) {
 	for _, tt := range tests {
 		if got := imageAspectRatio(tt.size); got != tt.want {
 			t.Errorf("imageAspectRatio(%q) = %q, want %q", tt.size, got, tt.want)
+		}
+	}
+}
+
+func TestListModels_SeedsKnownImagenModels(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// One Imagen model listed upstream must not be seeded twice.
+		_, _ = w.Write([]byte(`{"models": [
+			{"name": "models/gemini-2.5-flash", "supportedGenerationMethods": ["generateContent"]},
+			{"name": "models/imagen-4.0-generate-001", "supportedGenerationMethods": ["predict"]}
+		]}`))
+	}))
+	defer server.Close()
+
+	p := newNativeTestProvider(t, server)
+	resp, err := p.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	counts := make(map[string]int)
+	for _, model := range resp.Data {
+		counts[model.ID]++
+	}
+	for _, id := range knownImagenModels {
+		if counts[id] != 1 {
+			t.Errorf("model %q listed %d times, want exactly once", id, counts[id])
+		}
+	}
+	if counts["gemini-2.5-flash"] != 1 {
+		t.Errorf("gemini-2.5-flash listed %d times, want once", counts["gemini-2.5-flash"])
+	}
+	for _, model := range resp.Data {
+		if strings.HasPrefix(model.ID, "imagen-") {
+			if model.Metadata == nil || len(model.Metadata.Modes) != 1 || model.Metadata.Modes[0] != "image_generation" {
+				t.Errorf("imagen model %q metadata = %+v, want image_generation only", model.ID, model.Metadata)
+			}
 		}
 	}
 }

--- a/internal/providers/gemini/images_test.go
+++ b/internal/providers/gemini/images_test.go
@@ -320,44 +320,6 @@ func TestImageAspectRatio(t *testing.T) {
 	}
 }
 
-func TestListModels_SeedsKnownImagenModels(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		// One Imagen model listed upstream must not be seeded twice.
-		_, _ = w.Write([]byte(`{"models": [
-			{"name": "models/gemini-2.5-flash", "supportedGenerationMethods": ["generateContent"]},
-			{"name": "models/imagen-4.0-generate-001", "supportedGenerationMethods": ["predict"]}
-		]}`))
-	}))
-	defer server.Close()
-
-	p := newNativeTestProvider(t, server)
-	resp, err := p.ListModels(context.Background())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	counts := make(map[string]int)
-	for _, model := range resp.Data {
-		counts[model.ID]++
-	}
-	for _, id := range knownImagenModels {
-		if counts[id] != 1 {
-			t.Errorf("model %q listed %d times, want exactly once", id, counts[id])
-		}
-	}
-	if counts["gemini-2.5-flash"] != 1 {
-		t.Errorf("gemini-2.5-flash listed %d times, want once", counts["gemini-2.5-flash"])
-	}
-	for _, model := range resp.Data {
-		if strings.HasPrefix(model.ID, "imagen-") {
-			if model.Metadata == nil || len(model.Metadata.Modes) != 1 || model.Metadata.Modes[0] != "image_generation" {
-				t.Errorf("imagen model %q metadata = %+v, want image_generation only", model.ID, model.Metadata)
-			}
-		}
-	}
-}
-
 func TestCreateImage_GeminiImageModelMultiImage(t *testing.T) {
 	var gotBody map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -394,22 +356,25 @@ func TestCreateImage_GeminiImageModelMultiImage(t *testing.T) {
 	}
 }
 
-func TestListModels_SeedsImagenOnExplicitlyEmptyInventory(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+func TestCreateImage_ImagenNativeSampleCountWins(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"models": []}`))
+		_, _ = w.Write([]byte(`{"predictions": [{"bytesBase64Encoded": "aW1n"}]}`))
 	}))
 	defer server.Close()
 
 	p := newNativeTestProvider(t, server)
-	resp, err := p.ListModels(context.Background())
+	// A client speaking native Imagen sends sampleCount directly; the OpenAI
+	// n default must not overwrite it (same precedence rule as aspectRatio).
+	_, err := p.CreateImage(context.Background(), decodeImageRequest(t, `{"model": "imagen-4.0-generate-001", "prompt": "x", "sampleCount": 3}`))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(resp.Data) != len(knownImagenModels) {
-		t.Fatalf("models = %+v, want the seeded Imagen models on an empty inventory", resp.Data)
-	}
-	if resp.Data[0].ID != knownImagenModels[0] {
-		t.Errorf("first model = %q, want %q", resp.Data[0].ID, knownImagenModels[0])
+	parameters, _ := gotBody["parameters"].(map[string]any)
+	if parameters["sampleCount"] != float64(3) {
+		t.Errorf("sampleCount = %v, want client-sent 3 preserved", parameters["sampleCount"])
 	}
 }

--- a/internal/providers/gemini/native.go
+++ b/internal/providers/gemini/native.go
@@ -34,6 +34,7 @@ type geminiContent struct {
 type geminiPart struct {
 	Text                string                  `json:"text,omitempty"`
 	InlineData          *geminiBlob             `json:"inline_data,omitempty"`
+	InlineDataAlt       *geminiBlob             `json:"inlineData,omitempty"`
 	FileData            *geminiFileData         `json:"file_data,omitempty"`
 	FunctionCall        *geminiFunctionCall     `json:"functionCall,omitempty"`
 	FunctionCallAlt     *geminiFunctionCall     `json:"function_call,omitempty"`
@@ -41,6 +42,16 @@ type geminiPart struct {
 	FunctionResponseAlt *geminiFunctionResponse `json:"function_response,omitempty"`
 	Thought             bool                    `json:"thought,omitempty"`
 	ThoughtSignature    string                  `json:"thoughtSignature,omitempty"`
+}
+
+// inlineData returns the inline blob under either spelling: requests are sent
+// snake_case (inline_data), but Gemini REST responses come back camelCase
+// (inlineData).
+func (p geminiPart) inlineData() *geminiBlob {
+	if p.InlineData != nil {
+		return p.InlineData
+	}
+	return p.InlineDataAlt
 }
 
 func (p geminiPart) functionCall() *geminiFunctionCall {
@@ -52,7 +63,10 @@ func (p geminiPart) functionCall() *geminiFunctionCall {
 
 type geminiBlob struct {
 	MimeType string `json:"mime_type,omitempty"`
-	Data     string `json:"data,omitempty"`
+	// MimeTypeAlt captures the camelCase spelling Gemini REST responses use;
+	// requests populate MimeType only.
+	MimeTypeAlt string `json:"mimeType,omitempty"`
+	Data        string `json:"data,omitempty"`
 }
 
 type geminiFileData struct {

--- a/internal/providers/gemini/native.go
+++ b/internal/providers/gemini/native.go
@@ -910,7 +910,8 @@ func displayModelIDFromGemini(model, backend string) string {
 // Families such as imagen-* use different upstream endpoints.
 func isGeminiExposedModel(modelID string) bool {
 	modelID = normalizeGeminiModelID(modelID)
-	return strings.HasPrefix(modelID, "gemini-") || strings.HasPrefix(modelID, "text-embedding-")
+	return strings.HasPrefix(modelID, "gemini-") || strings.HasPrefix(modelID, "text-embedding-") ||
+		strings.HasPrefix(modelID, "imagen-")
 }
 
 func nativeProviderError(providerName, message string, err error) *core.GatewayError {

--- a/internal/providers/vertex/vertex.go
+++ b/internal/providers/vertex/vertex.go
@@ -3,16 +3,11 @@ package vertex
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/binary"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"net/url"
 	"strings"
-
-	"github.com/goccy/go-json"
 
 	"github.com/enterpilot/gomodel/internal/core"
 	"github.com/enterpilot/gomodel/internal/httpclient"
@@ -228,7 +223,7 @@ func (p *Provider) Embeddings(ctx context.Context, req *core.EmbeddingRequest) (
 	if req == nil {
 		return nil, core.NewInvalidRequestError("embedding request is required", nil)
 	}
-	inputs, err := embeddingInputs(req.Input)
+	inputs, err := providers.EmbeddingInputs(req.Input)
 	if err != nil {
 		return nil, err
 	}
@@ -288,42 +283,6 @@ type vertexEmbeddingStatistics struct {
 	Truncated  bool `json:"truncated"`
 }
 
-func embeddingInputs(input any) ([]string, error) {
-	switch v := input.(type) {
-	case string:
-		if strings.TrimSpace(v) == "" {
-			return nil, core.NewInvalidRequestError("embedding input is required", nil)
-		}
-		return []string{v}, nil
-	case []string:
-		return nonEmptyEmbeddingInputs(v)
-	case []any:
-		out := make([]string, 0, len(v))
-		for _, item := range v {
-			text, ok := item.(string)
-			if !ok {
-				return nil, core.NewInvalidRequestError("vertex AI embeddings support string inputs", nil)
-			}
-			out = append(out, text)
-		}
-		return nonEmptyEmbeddingInputs(out)
-	default:
-		return nil, core.NewInvalidRequestError("vertex AI embeddings support string inputs", nil)
-	}
-}
-
-func nonEmptyEmbeddingInputs(inputs []string) ([]string, error) {
-	for _, input := range inputs {
-		if strings.TrimSpace(input) == "" {
-			return nil, core.NewInvalidRequestError("embedding input must not be empty", nil)
-		}
-	}
-	if len(inputs) == 0 {
-		return nil, core.NewInvalidRequestError("embedding input is required", nil)
-	}
-	return inputs, nil
-}
-
 func openAIEmbeddingResponse(req *core.EmbeddingRequest, resp *vertexEmbeddingPredictResponse) (*core.EmbeddingResponse, error) {
 	out := &core.EmbeddingResponse{
 		Object:   "list",
@@ -336,7 +295,7 @@ func openAIEmbeddingResponse(req *core.EmbeddingRequest, resp *vertexEmbeddingPr
 		if len(values) == 0 {
 			values = prediction.Values
 		}
-		embedding, err := encodeEmbedding(values, req.EncodingFormat)
+		embedding, err := providers.EncodeEmbeddingValues(values, req.EncodingFormat)
 		if err != nil {
 			return nil, core.NewProviderError("vertex", http.StatusBadGateway, "failed to encode Vertex AI embedding response", err)
 		}
@@ -349,17 +308,6 @@ func openAIEmbeddingResponse(req *core.EmbeddingRequest, resp *vertexEmbeddingPr
 	}
 	out.Usage.TotalTokens = out.Usage.PromptTokens
 	return out, nil
-}
-
-func encodeEmbedding(values []float64, encodingFormat string) (json.RawMessage, error) {
-	if strings.EqualFold(strings.TrimSpace(encodingFormat), "base64") {
-		buf := make([]byte, len(values)*4)
-		for i, value := range values {
-			binary.LittleEndian.PutUint32(buf[i*4:], math.Float32bits(float32(value)))
-		}
-		return json.Marshal(base64.StdEncoding.EncodeToString(buf))
-	}
-	return json.Marshal(values)
 }
 
 func vertexNativeBaseURL(providerCfg providers.ProviderConfig) string {

--- a/internal/providers/vertex/vertex.go
+++ b/internal/providers/vertex/vertex.go
@@ -191,6 +191,25 @@ func (p *Provider) StreamChatCompletion(ctx context.Context, req *core.ChatReque
 	return p.gemini.StreamChatCompletion(ctx, req)
 }
 
+// CreateImage sends an image generation request through the embedded Gemini
+// adapter, whose Vertex backend serves Imagen through :predict and Gemini
+// image models through generateContent on the publisher endpoints.
+func (p *Provider) CreateImage(ctx context.Context, req *core.ImageGenerationRequest) (*core.ImageGenerationResponse, error) {
+	if err := p.ready(); err != nil {
+		return nil, err
+	}
+	return p.gemini.CreateImage(ctx, req)
+}
+
+// CreateImageEdit sends an image edit request through the embedded Gemini
+// adapter (Gemini image models only; see the gemini package for the rules).
+func (p *Provider) CreateImageEdit(ctx context.Context, req *core.ImageEditRequest) (*core.ImageGenerationResponse, error) {
+	if err := p.ready(); err != nil {
+		return nil, err
+	}
+	return p.gemini.CreateImageEdit(ctx, req)
+}
+
 // ListModels retrieves Vertex AI publisher models.
 func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error) {
 	if err := p.ready(); err != nil {
@@ -330,4 +349,8 @@ func normalizeVertexModelID(model string) string {
 	return model
 }
 
-var _ core.Provider = (*Provider)(nil)
+var (
+	_ core.Provider          = (*Provider)(nil)
+	_ core.ImageProvider     = (*Provider)(nil)
+	_ core.ImageEditProvider = (*Provider)(nil)
+)

--- a/internal/providers/vertex/vertex_test.go
+++ b/internal/providers/vertex/vertex_test.go
@@ -494,3 +494,36 @@ func vertexServiceAccountCredentials(t *testing.T, tokenURL string) string {
 	}
 	return string(encoded)
 }
+
+func TestCreateImageDelegatesToGeminiPredict(t *testing.T) {
+	t.Setenv("USE_GOOGLE_GEMINI_NATIVE_API", "true")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/projects/prod-ai/locations/us-central1/publishers/google/models/imagen-4.0-generate-001:predict" {
+			t.Errorf("Path = %q, want Vertex Imagen predict endpoint", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer vertex-token" {
+			t.Errorf("Authorization = %q, want Bearer vertex-token", got)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"predictions": [{"bytesBase64Encoded": "aW1n", "mimeType": "image/png"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := testConfig()
+	cfg.BaseURL = server.URL + "/v1/projects/prod-ai/locations/us-central1/publishers/google"
+	provider := newProvider(cfg, providers.ProviderOptions{}, authedTestClient(server.Client()))
+
+	resp, err := provider.CreateImage(context.Background(), &core.ImageGenerationRequest{
+		Model:  "google/imagen-4.0-generate-001",
+		Prompt: "a mountain",
+	})
+	if err != nil {
+		t.Fatalf("CreateImage() error = %v", err)
+	}
+	if len(resp.Data) != 1 || resp.Data[0].B64JSON != "aW1n" {
+		t.Fatalf("data = %+v, want the predicted image", resp.Data)
+	}
+	if resp.Provider != "vertex" {
+		t.Fatalf("Provider = %q, want vertex", resp.Provider)
+	}
+}

--- a/tests/contract/testdata/golden/gemini/models.golden.json
+++ b/tests/contract/testdata/golden/gemini/models.golden.json
@@ -221,20 +221,6 @@
       "id": "gemini-3.7-flash",
       "object": "model",
       "owned_by": "google"
-    },
-    {
-      "created": 0,
-      "id": "imagen-3.0-generate-002",
-      "metadata": {
-        "categories": [
-          "image"
-        ],
-        "modes": [
-          "image_generation"
-        ]
-      },
-      "object": "model",
-      "owned_by": "google"
     }
   ],
   "object": "list"

--- a/tests/contract/testdata/golden/gemini/models.golden.json
+++ b/tests/contract/testdata/golden/gemini/models.golden.json
@@ -170,6 +170,36 @@
     },
     {
       "created": 0,
+      "id": "imagen-4.0-generate-preview-06-06",
+      "object": "model",
+      "owned_by": "google"
+    },
+    {
+      "created": 0,
+      "id": "imagen-4.0-ultra-generate-preview-06-06",
+      "object": "model",
+      "owned_by": "google"
+    },
+    {
+      "created": 0,
+      "id": "imagen-4.0-generate-001",
+      "object": "model",
+      "owned_by": "google"
+    },
+    {
+      "created": 0,
+      "id": "imagen-4.0-ultra-generate-001",
+      "object": "model",
+      "owned_by": "google"
+    },
+    {
+      "created": 0,
+      "id": "imagen-4.0-fast-generate-001",
+      "object": "model",
+      "owned_by": "google"
+    },
+    {
+      "created": 0,
       "id": "gemini-2.5-flash-native-audio-latest",
       "object": "model",
       "owned_by": "google"
@@ -189,6 +219,20 @@
     {
       "created": 0,
       "id": "gemini-3.7-flash",
+      "object": "model",
+      "owned_by": "google"
+    },
+    {
+      "created": 0,
+      "id": "imagen-3.0-generate-002",
+      "metadata": {
+        "categories": [
+          "image"
+        ],
+        "modes": [
+          "image_generation"
+        ]
+      },
       "object": "model",
       "owned_by": "google"
     }


### PR DESCRIPTION
Closes #747

Gemini native API mode (`USE_GOOGLE_GEMINI_NATIVE_API` / `api_mode: native`, default on) previously covered only chat/Responses. This extends it to embeddings and the image endpoints.

## Embeddings
- Native mode (AI Studio backend) now uses `models/{model}:batchEmbedContents`; `dimensions` maps to `outputDimensionality`, `encoding_format: "base64"` is honored, and a response with a mismatched embedding count is rejected instead of misaligning indexes. The native API reports no token usage, so usage is zeroed — verified live, Gemini reports no embedding usage on either API surface (documented).
- Vertex backend keeps the OpenAI-compatible surface (Vertex has no `batchEmbedContents`; its native `:predict` path is served by the `vertex` provider).
- Shared `EmbeddingInputs` / `EncodeEmbeddingValues` helpers extracted from the vertex provider.

## Images (`/v1/images/generations`, `/v1/images/edits`)
- The Gemini provider implements `ImageProvider` and `ImageEditProvider`; the Vertex provider delegates both to its embedded Gemini adapter, so discovered Vertex Imagen models route to `:predict` on the publisher endpoints.
- Native mode: Gemini image models (`gemini-2.5-flash-image`, ...) generate through `generateContent` with `responseModalities: [TEXT, IMAGE]` — token usage is mapped and model commentary surfaces as `revised_prompt`; `imagen-*` generates through `:predict` (`n` → `sampleCount`, `size` → aspect ratio, unknown fields forwarded verbatim, client-sent native parameters take precedence). Google retired Imagen from the AI Studio API on 2026-08-17, so that path is primarily for Vertex.
- Edits: Gemini image models only; uploads become inline image parts ahead of the prompt. `mask`, Imagen edits, and edits in OpenAI-compatible mode are rejected with clear errors.
- OpenAI-compatible mode forwards generation to `/openai/images/generations` unchanged.
- Response parsing accepts the camelCase `inlineData`/`mimeType` spellings Gemini REST responses use (requests keep snake_case).
- `ListModels` exposes image models with `image_generation`/`image_edit` metadata; the empty-methods fallback now classifies `gemini-embedding-*` as embedding models.

Verified live against the Gemini API: native embeddings (multi-input, `dimensions` honored — note the REST endpoint honors the top-level `outputDimensionality` and silently ignores the nested `embedContentConfig` spelling), `gemini-2.5-flash-image` generation and edit (real PNGs, usage mapped), and the rejection paths.

Docs: provider pages (Gemini, Vertex), Images API page, `.env.template`, `config.example.yaml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native Gemini and Vertex support for image generation, including Imagen and Gemini image models.
  * Added native Gemini image editing with inline image data.
  * Added native Gemini embedding support with dimensionality and encoding options.
  * Added model discovery for image-generation and embedding capabilities.

* **Bug Fixes**
  * Improved handling of Gemini image response formats and content types.

* **Documentation**
  * Updated provider, Images API, endpoint, and configuration documentation with routing, capability, and limitation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->