### PR TITLE
docs(roadmap): add image endpoint failover and streaming image generation

### DIFF
--- a/docs/about/roadmap.mdx
+++ b/docs/about/roadmap.mdx
@@ -28,6 +28,8 @@ keywords: ["roadmap", "milestones", "upcoming features", "releases"]
 - [ ] Workflows rework with better UI/UX and a more flexible design
 - [ ] Guardrails hardening: better UI, simpler architecture, easier custom guardrails, and response-side guardrails applied before output reaches the client
 - [ ] Provider-native passthrough for all providers, beyond the current beta coverage
+- [ ] Failover for the image endpoints, so image generation and edits can fall back across providers like chat does
+- [ ] Streaming image generation (SSE relay of partial images on `/v1/images/*`)
 - [x] Full support for the OpenAI `/conversations` lifecycle
 - [x] Full support for the OpenAI `/responses` lifecycle
 - [x] Anthropic-compatible `/messages` ingress and `/messages/count_tokens`


### PR DESCRIPTION
Adds two 0.2.0 roadmap items that came out of the images work (#747/#754): failover for the image endpoints (they currently bypass the orchestrator) and streaming image generation (`stream: true` is currently rejected; OpenAI and Gemini both support it upstream).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added roadmap items for image endpoint failover across providers.
  * Added plans for streaming image generation with partial image updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->