### PR TITLE
fix(test): make nil-guard test exits explicit for staticcheck

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,13 @@ jobs:
           # v2.10's staticcheck mis-analyzed `if x == nil { t.Fatal() }` guards
           # under GO_VERSION 1.26.4 and emitted false-positive SA5011 warnings.
           version: v2.12
+          # The shared analysis cache went bad on 2026-08-25: staticcheck lost
+          # t.Fatal no-return facts and every run flagged a different set of
+          # SA5011 false positives in untouched files, on PR branches and main
+          # alike. A cold analysis is deterministic, so skip the cache; it costs
+          # a few minutes per run. Revisit if golangci-lint-action gets a way to
+          # rotate a corrupted cache key.
+          skip-cache: true
           # Temporary workaround: config verification fetches the remote JSON schema and
           # intermittently times out in CI before lint runs. Re-enable by 2026-04-01 once
           # the schema fetch is reliable again; track in this PR/branch discussion.

--- a/internal/admin/audit_projection_test.go
+++ b/internal/admin/audit_projection_test.go
@@ -93,6 +93,7 @@ func TestAuditLogSlimsListEntries(t *testing.T) {
 	d := entry.Data
 	if d == nil {
 		t.Fatal("entry data must survive slimming")
+		return
 	}
 	if d.RequestBody != nil || d.ResponseBody != nil {
 		t.Error("list entry bodies must be stripped")
@@ -217,6 +218,7 @@ func TestAuditConversationSlimsEntries(t *testing.T) {
 	d := result.Entries[0].Data
 	if d == nil {
 		t.Fatal("entry data must survive")
+		return
 	}
 	if d.RequestBody == nil || d.ResponseBody == nil {
 		t.Error("the transcript is built from the bodies; they must survive")

--- a/internal/core/batch_preparation_test.go
+++ b/internal/core/batch_preparation_test.go
@@ -32,6 +32,7 @@ func TestCloneBatchRequestDeepCopiesNestedFields(t *testing.T) {
 	cloned := cloneBatchRequest(original)
 	if cloned == nil {
 		t.Fatal("cloneBatchRequest() returned nil")
+		return
 	}
 
 	cloned.Metadata["provider"] = "anthropic"


### PR DESCRIPTION
CI lint began failing on every open PR today (including a docs-only PR) with SA5011 false positives in files those PRs do not touch — staticcheck intermittently loses the `t.Fatal` no-return fact for `if x == nil { t.Fatal(...) }` guards (the same failure class the workflow comment documents for v2.10 under Go 1.26.4; the same golangci v2.12.2 passed on main this morning, so this is runner/cache drift, not a code change).

Adds an explicit `return` after the three flagged nil-guard `t.Fatal` calls so the guards no longer depend on no-return facts, whatever analyzer state a runner restores. No behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test failure handling to stop execution immediately when required data is unexpectedly missing.
  * Prevented follow-up assertions from running against nil results, producing clearer and safer test outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->