### PR TITLE
feat(models): add merge mode for configured provider models

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -203,6 +203,8 @@
 # How providers.<name>.models and <PROVIDER>[_SUFFIX]_MODELS affect provider inventory.
 # fallback (default): use configured models only when upstream /models fails, is nil, or is empty.
 # allowlist: expose only the configured models for providers that define a list, and skip their upstream /models calls.
+# merge: keep the upstream inventory and add configured models it does not list,
+# so models a provider serves without listing them (preview or unlisted IDs) stay routable.
 # CONFIGURED_PROVIDER_MODELS_MODE=fallback
 # Examples: OPENROUTER_MODELS=..., OPENROUTER_EU_MODELS=..., AZURE_MODELS=..., VLLM_MODELS=...
 

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -19,7 +19,7 @@ server:
 
 models:
   enabled_by_default: true # env: MODELS_ENABLED_BY_DEFAULT; when false, models stay unavailable until an access override allows one or more user paths
-  configured_provider_models_mode: "fallback" # env: CONFIGURED_PROVIDER_MODELS_MODE; "fallback" uses configured lists only when upstream /models is unavailable/empty, "allowlist" exposes only configured models and skips upstream /models for configured lists
+  configured_provider_models_mode: "fallback" # env: CONFIGURED_PROVIDER_MODELS_MODE; "fallback" uses configured lists only when upstream /models is unavailable/empty, "allowlist" exposes only configured models and skips upstream /models for configured lists, "merge" adds configured models on top of the upstream inventory (for models a provider serves but does not list)
 
 # Tagging based on headers: label every request from the listed headers. Labels
 # are recorded in usage tracking and audit logs. A header value can carry several

--- a/config/config.go
+++ b/config/config.go
@@ -269,7 +269,7 @@ func Load() (*LoadResult, error) {
 	}
 	cfg.Models.ConfiguredProviderModelsMode = ResolveConfiguredProviderModelsMode(cfg.Models.ConfiguredProviderModelsMode)
 	if !cfg.Models.ConfiguredProviderModelsMode.Valid() {
-		return nil, fmt.Errorf("models.configured_provider_models_mode must be one of: fallback, allowlist")
+		return nil, fmt.Errorf("models.configured_provider_models_mode must be one of: fallback, allowlist, merge")
 	}
 
 	if err := loadFailoverConfig(&cfg.Failover); err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -838,6 +838,28 @@ failover:
 	})
 }
 
+func TestLoad_MergeConfiguredProviderModelsMode(t *testing.T) {
+	clearAllConfigEnvVars(t)
+
+	withTempDir(t, func(dir string) {
+		yaml := `
+models:
+  configured_provider_models_mode: merge
+`
+		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(yaml), 0644); err != nil {
+			t.Fatalf("Failed to write config.yaml: %v", err)
+		}
+
+		result, err := Load()
+		if err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+		if result.Config.Models.ConfiguredProviderModelsMode != ConfiguredProviderModelsModeMerge {
+			t.Fatalf("mode = %q, want merge", result.Config.Models.ConfiguredProviderModelsMode)
+		}
+	})
+}
+
 func TestLoad_InvalidConfiguredProviderModelsMode(t *testing.T) {
 	clearAllConfigEnvVars(t)
 

--- a/config/models.go
+++ b/config/models.go
@@ -16,7 +16,7 @@ type ModelsConfig struct {
 
 	// ConfiguredProviderModelsMode controls how providers.<name>.models and
 	// provider *_MODELS env vars affect the provider model inventory.
-	// Supported values: "fallback", "allowlist". Default: "fallback".
+	// Supported values: "fallback", "allowlist", "merge". Default: "fallback".
 	ConfiguredProviderModelsMode ConfiguredProviderModelsMode `yaml:"configured_provider_models_mode" env:"CONFIGURED_PROVIDER_MODELS_MODE"`
 }
 
@@ -25,14 +25,22 @@ type ModelsConfig struct {
 type ConfiguredProviderModelsMode string
 
 const (
-	ConfiguredProviderModelsModeFallback  ConfiguredProviderModelsMode = "fallback"
+	// ConfiguredProviderModelsModeFallback uses configured models only when the
+	// upstream /models call fails or returns nothing.
+	ConfiguredProviderModelsModeFallback ConfiguredProviderModelsMode = "fallback"
+	// ConfiguredProviderModelsModeAllowlist exposes only the configured models
+	// and skips the upstream /models call.
 	ConfiguredProviderModelsModeAllowlist ConfiguredProviderModelsMode = "allowlist"
+	// ConfiguredProviderModelsModeMerge unions the upstream inventory with the
+	// configured models, so models a provider serves but does not list stay
+	// routable without hiding the discovered ones.
+	ConfiguredProviderModelsModeMerge ConfiguredProviderModelsMode = "merge"
 )
 
 // Valid reports whether mode is one of the supported configured-provider-models modes.
 func (m ConfiguredProviderModelsMode) Valid() bool {
 	switch NormalizeConfiguredProviderModelsMode(m) {
-	case ConfiguredProviderModelsModeFallback, ConfiguredProviderModelsModeAllowlist:
+	case ConfiguredProviderModelsModeFallback, ConfiguredProviderModelsModeAllowlist, ConfiguredProviderModelsModeMerge:
 		return true
 	default:
 		return false

--- a/docs/advanced/config-yaml.mdx
+++ b/docs/advanced/config-yaml.mdx
@@ -39,9 +39,11 @@ example `OPENROUTER_MODELS`, `ORACLE_MODELS`, `AZURE_MODELS`, `SGLANG_MODELS`,
 `LLMD_<SUFFIX>_INFERENCE_OBJECTIVE` and
 `LLMD_<SUFFIX>_FAIRNESS_FROM_USER_PATH` controls.
 Set `CONFIGURED_PROVIDER_MODELS_MODE=fallback` (default) to use those lists only
-when upstream `/models` fails or is empty, or `allowlist` to expose only the
+when upstream `/models` fails or is empty, `allowlist` to expose only the
 configured models for providers that define a list and skip their upstream
-`/models` calls.
+`/models` calls, or `merge` to add configured models on top of the discovered
+inventory — useful for models a provider serves but does not include in its
+`/models` listing.
 
 ## Priority Order
 

--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -500,7 +500,9 @@ settings), use the YAML file:
 ```yaml
 models:
   # fallback is the default. Use allowlist when configured provider model lists
-  # should hide upstream models and skip upstream /models calls.
+  # should hide upstream models and skip upstream /models calls, or merge to add
+  # configured models on top of the discovered inventory (models a provider
+  # serves but does not list).
   configured_provider_models_mode: fallback
 
 providers:

--- a/internal/providers/configured_models.go
+++ b/internal/providers/configured_models.go
@@ -114,6 +114,9 @@ func mergeConfiguredProviderModelsResponse(providerName, providerType string, co
 		if modelID == "" {
 			continue
 		}
+		// Registry lookups trim requested IDs, so the retained entry must be
+		// indexed under the same normalized key it deduplicates by.
+		model.ID = modelID
 		seen[modelID] = struct{}{}
 		data = append(data, model)
 	}

--- a/internal/providers/configured_models.go
+++ b/internal/providers/configured_models.go
@@ -114,6 +114,11 @@ func mergeConfiguredProviderModelsResponse(providerName, providerType string, co
 		if modelID == "" {
 			continue
 		}
+		if _, ok := seen[modelID]; ok {
+			// Upstream listings can repeat an ID (also via whitespace
+			// variants that normalize to one); the first entry wins.
+			continue
+		}
 		// Registry lookups trim requested IDs, so the retained entry must be
 		// indexed under the same normalized key it deduplicates by.
 		model.ID = modelID
@@ -127,6 +132,7 @@ func mergeConfiguredProviderModelsResponse(providerName, providerType string, co
 		if _, ok := seen[modelID]; ok {
 			continue
 		}
+		seen[modelID] = struct{}{}
 		data = append(data, synthesizedConfiguredModel(modelID, owner, created))
 	}
 

--- a/internal/providers/configured_models.go
+++ b/internal/providers/configured_models.go
@@ -14,6 +14,7 @@ type configuredProviderModelsApplyReason string
 const (
 	configuredProviderModelsNotApplied    configuredProviderModelsApplyReason = ""
 	configuredProviderModelsAllowlist     configuredProviderModelsApplyReason = "allowlist"
+	configuredProviderModelsMerge         configuredProviderModelsApplyReason = "merge"
 	configuredProviderModelsUpstreamError configuredProviderModelsApplyReason = "upstream_error"
 	configuredProviderModelsUpstreamNil   configuredProviderModelsApplyReason = "upstream_nil"
 	configuredProviderModelsUpstreamEmpty configuredProviderModelsApplyReason = "upstream_empty"
@@ -70,7 +71,66 @@ func applyConfiguredProviderModels(
 	if len(upstream.Data) == 0 {
 		return configuredProviderModelsResponse(providerName, providerType, configuredModels, upstream, fallbackCreated), configuredProviderModelsUpstreamEmpty
 	}
+	if mode == config.ConfiguredProviderModelsModeMerge {
+		return mergeConfiguredProviderModelsResponse(providerName, providerType, configuredModels, upstream, fallbackCreated), configuredProviderModelsMerge
+	}
 	return upstream, configuredProviderModelsNotApplied
+}
+
+// configuredModelOwner picks the owned_by value for synthesized entries.
+func configuredModelOwner(providerName, providerType string) string {
+	owner := strings.TrimSpace(providerType)
+	if owner == "" {
+		owner = strings.TrimSpace(providerName)
+	}
+	return owner
+}
+
+func normalizeFallbackCreated(fallbackCreated int64) int64 {
+	if fallbackCreated <= 0 {
+		return time.Now().Unix()
+	}
+	return fallbackCreated
+}
+
+func synthesizedConfiguredModel(modelID, owner string, created int64) core.Model {
+	return core.Model{
+		ID:      modelID,
+		Object:  "model",
+		OwnedBy: owner,
+		Created: created,
+	}
+}
+
+// mergeConfiguredProviderModelsResponse unions a healthy upstream inventory
+// with the configured list: upstream entries stay authoritative and configured
+// models the upstream does not list are appended as synthesized entries, so
+// models a provider serves without listing them remain routable.
+func mergeConfiguredProviderModelsResponse(providerName, providerType string, configuredModels []string, upstream *core.ModelsResponse, fallbackCreated int64) *core.ModelsResponse {
+	seen := make(map[string]struct{}, len(upstream.Data))
+	data := make([]core.Model, 0, len(upstream.Data)+len(configuredModels))
+	for _, model := range upstream.Data {
+		modelID := strings.TrimSpace(model.ID)
+		if modelID == "" {
+			continue
+		}
+		seen[modelID] = struct{}{}
+		data = append(data, model)
+	}
+
+	owner := configuredModelOwner(providerName, providerType)
+	created := normalizeFallbackCreated(fallbackCreated)
+	for _, modelID := range configuredModels {
+		if _, ok := seen[modelID]; ok {
+			continue
+		}
+		data = append(data, synthesizedConfiguredModel(modelID, owner, created))
+	}
+
+	return &core.ModelsResponse{
+		Object: "list",
+		Data:   data,
+	}
 }
 
 func configuredProviderModelsResponse(providerName, providerType string, configuredModels []string, upstream *core.ModelsResponse, fallbackCreated int64) *core.ModelsResponse {
@@ -85,24 +145,14 @@ func configuredProviderModelsResponse(providerName, providerType string, configu
 		}
 	}
 
-	owner := strings.TrimSpace(providerType)
-	if owner == "" {
-		owner = strings.TrimSpace(providerName)
-	}
-	if fallbackCreated <= 0 {
-		fallbackCreated = time.Now().Unix()
-	}
+	owner := configuredModelOwner(providerName, providerType)
+	fallbackCreated = normalizeFallbackCreated(fallbackCreated)
 
 	data := make([]core.Model, 0, len(configuredModels))
 	for _, modelID := range configuredModels {
 		model, ok := byID[modelID]
 		if !ok {
-			model = core.Model{
-				ID:      modelID,
-				Object:  "model",
-				OwnedBy: owner,
-				Created: fallbackCreated,
-			}
+			model = synthesizedConfiguredModel(modelID, owner, fallbackCreated)
 		} else {
 			model.ID = strings.TrimSpace(model.ID)
 			if model.ID == "" {

--- a/internal/providers/configured_models_test.go
+++ b/internal/providers/configured_models_test.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/enterpilot/gomodel/config"
@@ -34,5 +35,68 @@ func TestApplyConfiguredProviderModels_BackfillsZeroCreatedForUpstreamMatch(t *t
 	}
 	if resp.Data[0].OwnedBy != "upstream" {
 		t.Fatalf("OwnedBy = %q, want upstream metadata preserved", resp.Data[0].OwnedBy)
+	}
+}
+
+func TestApplyConfiguredProviderModels_MergeAppendsMissingModels(t *testing.T) {
+	upstream := &core.ModelsResponse{
+		Object: "list",
+		Data: []core.Model{
+			{ID: "listed-model", Object: "model", OwnedBy: "upstream", Created: 42},
+		},
+	}
+	resp, reason := applyConfiguredProviderModels(
+		"test",
+		"test-type",
+		config.ConfiguredProviderModelsModeMerge,
+		[]string{"listed-model", "unlisted-model"},
+		upstream,
+		nil,
+		123,
+	)
+
+	if reason != configuredProviderModelsMerge {
+		t.Fatalf("reason = %q, want %q", reason, configuredProviderModelsMerge)
+	}
+	if resp == nil || len(resp.Data) != 2 {
+		t.Fatalf("resp = %+v, want upstream model plus one synthesized entry", resp)
+	}
+	if resp.Data[0].ID != "listed-model" || resp.Data[0].OwnedBy != "upstream" || resp.Data[0].Created != 42 {
+		t.Fatalf("Data[0] = %+v, want upstream entry kept authoritative", resp.Data[0])
+	}
+	if resp.Data[1].ID != "unlisted-model" || resp.Data[1].OwnedBy != "test-type" || resp.Data[1].Created != 123 {
+		t.Fatalf("Data[1] = %+v, want synthesized configured entry", resp.Data[1])
+	}
+}
+
+func TestApplyConfiguredProviderModels_MergeFallsBackWhenUpstreamFails(t *testing.T) {
+	tests := []struct {
+		name       string
+		upstream   *core.ModelsResponse
+		err        error
+		wantReason configuredProviderModelsApplyReason
+	}{
+		{name: "error", upstream: nil, err: errors.New("upstream down"), wantReason: configuredProviderModelsUpstreamError},
+		{name: "nil", upstream: nil, wantReason: configuredProviderModelsUpstreamNil},
+		{name: "empty", upstream: &core.ModelsResponse{Object: "list"}, wantReason: configuredProviderModelsUpstreamEmpty},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, reason := applyConfiguredProviderModels(
+				"test",
+				"test-type",
+				config.ConfiguredProviderModelsModeMerge,
+				[]string{"configured-model"},
+				tt.upstream,
+				tt.err,
+				123,
+			)
+			if reason != tt.wantReason {
+				t.Fatalf("reason = %q, want %q", reason, tt.wantReason)
+			}
+			if resp == nil || len(resp.Data) != 1 || resp.Data[0].ID != "configured-model" {
+				t.Fatalf("resp = %+v, want configured fallback inventory", resp)
+			}
+		})
 	}
 }

--- a/internal/providers/configured_models_test.go
+++ b/internal/providers/configured_models_test.go
@@ -44,6 +44,8 @@ func TestApplyConfiguredProviderModels_MergeAppendsMissingModels(t *testing.T) {
 		Data: []core.Model{
 			// Padded ID: the retained entry must be normalized, not just deduped.
 			{ID: " listed-model ", Object: "model", OwnedBy: "upstream", Created: 42},
+			// A whitespace variant of the same ID must not create a duplicate.
+			{ID: "listed-model", Object: "model", OwnedBy: "upstream-dup", Created: 43},
 		},
 	}
 	resp, reason := applyConfiguredProviderModels(

--- a/internal/providers/configured_models_test.go
+++ b/internal/providers/configured_models_test.go
@@ -42,7 +42,8 @@ func TestApplyConfiguredProviderModels_MergeAppendsMissingModels(t *testing.T) {
 	upstream := &core.ModelsResponse{
 		Object: "list",
 		Data: []core.Model{
-			{ID: "listed-model", Object: "model", OwnedBy: "upstream", Created: 42},
+			// Padded ID: the retained entry must be normalized, not just deduped.
+			{ID: " listed-model ", Object: "model", OwnedBy: "upstream", Created: 42},
 		},
 	}
 	resp, reason := applyConfiguredProviderModels(

--- a/internal/providers/registry_init.go
+++ b/internal/providers/registry_init.go
@@ -181,6 +181,8 @@ func (r *ModelRegistry) fetchAllProviderModels(
 				slog.Warn("upstream ListModels failed, using configured provider models", attrs...)
 			} else if configuredReason == configuredProviderModelsAllowlist {
 				slog.Debug("using configured provider models", attrs...)
+			} else if configuredReason == configuredProviderModelsMerge {
+				slog.Debug("merged configured provider models into upstream inventory", attrs...)
 			} else {
 				slog.Warn("using configured provider models", attrs...)
 			}
@@ -242,14 +244,20 @@ func (r *ModelRegistry) fetchAllProviderModels(
 		//    response) — reason is configuredProviderModelsNotApplied
 		//  - allowlist mode intentionally skipped upstream and produced the
 		//    inventory from configuration — reason is configuredProviderModelsAllowlist
+		//  - merge mode overlaid configured models on a healthy upstream
+		//    response — reason is configuredProviderModelsMerge
 		// Fallback cases (configured*UpstreamError, *Nil, *Empty) keep
 		// lastModelFetchSuccessAt unset so health surfaces "live refresh failed,
 		// serving configured fallback".
 		if configuredReason == configuredProviderModelsNotApplied ||
-			configuredReason == configuredProviderModelsAllowlist {
+			configuredReason == configuredProviderModelsAllowlist ||
+			configuredReason == configuredProviderModelsMerge {
 			runtimeUpdate.lastModelFetchSuccessAt = fetchAt
 		}
-		if configuredReason == configuredProviderModelsNotApplied {
+		// Merge keeps availability signals too: the upstream call actually
+		// succeeded, unlike the fallback reasons.
+		if configuredReason == configuredProviderModelsNotApplied ||
+			configuredReason == configuredProviderModelsMerge {
 			runtimeUpdate.lastAvailabilityCheckAt = fetchAt
 			runtimeUpdate.lastAvailabilityOKAt = fetchAt
 		}


### PR DESCRIPTION
`CONFIGURED_PROVIDER_MODELS_MODE` supported only `fallback` (configured lists used when upstream `/models` fails or is empty) and `allowlist` (configured lists replace discovery). There was no way to *add* a model alongside the discovered inventory — which matters for models a provider serves but does not list (preview or unlisted IDs; hit in practice with Gemini in #754).

New `merge` mode:

- Keeps the upstream inventory authoritative and appends configured models it does not list as synthesized entries (deduped by ID).
- When upstream fails or returns nothing, behaves exactly like `fallback` (configured-only inventory, same health semantics).
- With a healthy upstream, registry health treats the fetch as successful and available, and the merge is logged at debug with its own `merge` reason.

Default stays `fallback`; no behavior change for existing configurations. Docs, `.env.template`, and `config.example.yaml` updated; the synthesized-entry construction shared by the fallback/allowlist path was extracted into helpers instead of duplicating it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `merge` provider model mode that combines discovered models with configured models.
  * Configured models missing from a provider’s inventory are now included automatically.
  * Upstream model details remain authoritative when models appear in both lists.
  * Providers with unavailable or empty inventories can fall back to configured models.

* **Documentation**
  * Updated configuration examples and reference documentation to describe the new mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->