### PR TITLE
feat(gemini): serve n image generations as parallel generateContent calls

### DIFF
--- a/docs/advanced/images-api.mdx
+++ b/docs/advanced/images-api.mdx
@@ -224,7 +224,10 @@ and `imagen-*` models through Imagen's `predict` API. Google retired Imagen
 from the Gemini API (AI Studio) on August 17, 2026 — use a Gemini image model
 there; Imagen remains available on [Vertex AI](/providers/vertex).
 
-- `n` maps to Imagen's `sampleCount`; `size` maps to the closest supported
+- Gemini image models do not support multi-candidate output, so `n` (up to
+  10) is served as `n` parallel `generateContent` calls whose results are
+  merged — each call is billed by Google. For Imagen, `n` maps to
+  `sampleCount`; `size` maps to the closest supported
   aspect ratio (`1024x1024` → `1:1`, `1536x1024` → `3:2`, ...), and a raw
   ratio such as `"16:9"` passes through. Unknown JSON fields are forwarded
   verbatim, so native parameters (`personGeneration`, `sampleImageSize`,

--- a/internal/providers/gemini/images.go
+++ b/internal/providers/gemini/images.go
@@ -3,11 +3,14 @@ package gemini
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/goccy/go-json"
 
@@ -70,9 +73,9 @@ func (p *Provider) CreateImageEdit(ctx context.Context, req *core.ImageEditReque
 	size, _ := req.Field("size")
 	body := &geminiGenerateContentRequest{
 		Contents:         []geminiContent{{Role: "user", Parts: parts}},
-		GenerationConfig: imageGenerationConfig(size, imageEditCount(req), nil),
+		GenerationConfig: imageGenerationConfig(size, nil),
 	}
-	return p.doGenerateContentImage(ctx, req.Model, body)
+	return p.generateContentImages(ctx, req.Model, body, imageEditCount(req))
 }
 
 func (p *Provider) openAICompatibleCreateImage(ctx context.Context, req *core.ImageGenerationRequest) (*core.ImageGenerationResponse, error) {
@@ -200,6 +203,12 @@ func imagePredictParameters(req *core.ImageGenerationRequest) (map[string]any, e
 
 // Gemini image model generation (generateContent with image modalities).
 
+// maxGeminiImageFanOut bounds n for Gemini image models. They reject
+// candidateCount > 1 ("Multiple candidates is not enabled for this model"),
+// so n is served as n parallel generateContent calls; the cap mirrors
+// OpenAI's images API limit of 10 and keeps a typo from fanning out unbounded.
+const maxGeminiImageFanOut = 10
+
 func (p *Provider) generateContentImage(ctx context.Context, req *core.ImageGenerationRequest) (*core.ImageGenerationResponse, error) {
 	extra, err := imageExtraFields(req)
 	if err != nil {
@@ -207,9 +216,60 @@ func (p *Provider) generateContentImage(ctx context.Context, req *core.ImageGene
 	}
 	body := &geminiGenerateContentRequest{
 		Contents:         []geminiContent{{Role: "user", Parts: []geminiPart{{Text: req.Prompt}}}},
-		GenerationConfig: imageGenerationConfig(req.Size, req.ImageCount(), extra),
+		GenerationConfig: imageGenerationConfig(req.Size, extra),
 	}
-	return p.doGenerateContentImage(ctx, req.Model, body)
+	return p.generateContentImages(ctx, req.Model, body, req.ImageCount())
+}
+
+// generateContentImages serves n images from a model without multi-candidate
+// support by running n identical generateContent calls in parallel and
+// merging the results: images concatenate in call order and token usage sums.
+// Each call is billed by the provider; a failed call cancels the rest and the
+// whole request fails.
+func (p *Provider) generateContentImages(ctx context.Context, model string, body *geminiGenerateContentRequest, count int) (*core.ImageGenerationResponse, error) {
+	if count > maxGeminiImageFanOut {
+		return nil, core.NewInvalidRequestError(fmt.Sprintf("n must be at most %d for Gemini image models", maxGeminiImageFanOut), nil)
+	}
+	if count <= 1 {
+		return p.doGenerateContentImage(ctx, model, body)
+	}
+
+	group, groupCtx := errgroup.WithContext(ctx)
+	results := make([]*core.ImageGenerationResponse, count)
+	for i := range results {
+		group.Go(func() error {
+			resp, err := p.doGenerateContentImage(groupCtx, model, body)
+			if err != nil {
+				return err
+			}
+			results[i] = resp
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+
+	merged := &core.ImageGenerationResponse{
+		Created:  time.Now().Unix(),
+		Data:     []core.ImageData{},
+		Provider: p.responseProviderName(),
+	}
+	var usage core.ImageUsage
+	hasUsage := false
+	for _, resp := range results {
+		merged.Data = append(merged.Data, resp.Data...)
+		if resp.Usage != nil {
+			hasUsage = true
+			usage.InputTokens += resp.Usage.InputTokens
+			usage.OutputTokens += resp.Usage.OutputTokens
+			usage.TotalTokens += resp.Usage.TotalTokens
+		}
+	}
+	if hasUsage {
+		merged.Usage = &usage
+	}
+	return merged, nil
 }
 
 func (p *Provider) doGenerateContentImage(ctx context.Context, model string, body *geminiGenerateContentRequest) (*core.ImageGenerationResponse, error) {
@@ -231,19 +291,14 @@ func (p *Provider) doGenerateContentImage(ctx context.Context, model string, bod
 // request fields merge in verbatim so native options (imageConfig,
 // responseModalities overrides, ...) pass through; the explicit mappings only
 // fill keys the caller did not set.
-func imageGenerationConfig(size string, count int, extra map[string]any) map[string]any {
+func imageGenerationConfig(size string, extra map[string]any) map[string]any {
 	config := extra
 	if config == nil {
-		config = make(map[string]any, 3)
+		config = make(map[string]any, 2)
 	}
 	if _, ok := config["responseModalities"]; !ok {
 		// Gemini image models reject image-only output; TEXT must be allowed.
 		config["responseModalities"] = []string{"TEXT", "IMAGE"}
-	}
-	if count > 1 {
-		if _, ok := config["candidateCount"]; !ok {
-			config["candidateCount"] = count
-		}
 	}
 	aspectRatio := imageAspectRatio(size)
 	if aspectRatio == "" {

--- a/internal/providers/gemini/images_test.go
+++ b/internal/providers/gemini/images_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/enterpilot/gomodel/internal/core"
@@ -321,20 +323,26 @@ func TestImageAspectRatio(t *testing.T) {
 }
 
 func TestCreateImage_GeminiImageModelMultiImage(t *testing.T) {
-	var gotBody map[string]any
+	// Gemini image models reject candidateCount > 1, so n is served as n
+	// parallel single-candidate calls whose results merge.
+	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := calls.Add(1)
 		body, _ := io.ReadAll(r.Body)
-		if err := json.Unmarshal(body, &gotBody); err != nil {
+		var got map[string]any
+		if err := json.Unmarshal(body, &got); err != nil {
 			t.Errorf("request body is not JSON: %v", err)
 		}
+		config, _ := got["generationConfig"].(map[string]any)
+		if _, ok := config["candidateCount"]; ok {
+			t.Errorf("candidateCount sent upstream: %+v", config)
+		}
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{
-			"candidates": [
-				{"content": {"role": "model", "parts": [{"inlineData": {"mimeType": "image/png", "data": "aW1nMQ=="}}]}, "finishReason": "STOP"},
-				{"content": {"role": "model", "parts": [{"inlineData": {"mimeType": "image/png", "data": "aW1nMg=="}}]}, "finishReason": "STOP", "index": 1}
-			],
-			"usageMetadata": {"promptTokenCount": 8, "candidatesTokenCount": 2580, "totalTokenCount": 2588}
-		}`))
+		fmt.Fprintf(w, `{
+			"candidates": [{"content": {"role": "model", "parts": [{"inlineData": {"mimeType": "image/png", "data": "aW1nJTAxZA=="}}]}, "finishReason": "STOP"}],
+			"usageMetadata": {"promptTokenCount": 8, "candidatesTokenCount": 1290, "totalTokenCount": 1298}
+		}`)
+		_ = call
 	}))
 	defer server.Close()
 
@@ -344,15 +352,47 @@ func TestCreateImage_GeminiImageModelMultiImage(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	config, _ := gotBody["generationConfig"].(map[string]any)
-	if config["candidateCount"] != float64(2) {
-		t.Errorf("candidateCount = %v, want 2 for n=2", config["candidateCount"])
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("upstream calls = %d, want one per requested image", got)
 	}
-	if len(resp.Data) != 2 || resp.Data[0].B64JSON != "aW1nMQ==" || resp.Data[1].B64JSON != "aW1nMg==" {
-		t.Fatalf("data = %+v, want both candidates flattened into images", resp.Data)
+	if len(resp.Data) != 2 {
+		t.Fatalf("data = %+v, want both fan-out results merged", resp.Data)
 	}
-	if resp.Usage == nil || resp.Usage.TotalTokens != 2588 {
-		t.Errorf("usage = %+v, want mapped totals", resp.Usage)
+	if resp.Usage == nil || resp.Usage.InputTokens != 16 || resp.Usage.OutputTokens != 2580 || resp.Usage.TotalTokens != 2596 {
+		t.Errorf("usage = %+v, want summed token counts", resp.Usage)
+	}
+}
+
+func TestCreateImage_GeminiImageModelFanOutCap(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("no upstream call expected above the fan-out cap")
+	}))
+	defer server.Close()
+
+	p := newNativeTestProvider(t, server)
+	_, err := p.CreateImage(context.Background(), decodeImageRequest(t, `{"model": "gemini-2.5-flash-image", "prompt": "x", "n": 11}`))
+	if err == nil || !strings.Contains(err.Error(), "at most 10") {
+		t.Fatalf("error = %v, want fan-out cap rejection", err)
+	}
+}
+
+func TestCreateImage_GeminiImageModelFanOutFailureFails(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) == 1 {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"candidates": [{"content": {"role": "model", "parts": [{"inlineData": {"mimeType": "image/png", "data": "aW1n"}}]}, "finishReason": "STOP"}]}`))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error": {"message": "boom"}}`))
+	}))
+	defer server.Close()
+
+	p := newNativeTestProvider(t, server)
+	_, err := p.CreateImage(context.Background(), decodeImageRequest(t, `{"model": "gemini-2.5-flash-image", "prompt": "x", "n": 2}`))
+	if err == nil {
+		t.Fatal("expected a failed fan-out call to fail the request")
 	}
 }
 


### PR DESCRIPTION
Gemini image models reject `candidateCount > 1` ("Multiple candidates is not enabled for this model", verified live), so `n > 1` on `/v1/images/generations` and `/v1/images/edits` previously surfaced that upstream 400.

- `n` is now served as `n` parallel `generateContent` calls whose results merge: images concatenate in call order, token usage sums. A failed call cancels the rest and fails the request.
- `n` is capped at 10 for Gemini image models (mirrors OpenAI's images API limit and bounds fan-out cost); Imagen keeps `sampleCount` untouched.
- `candidateCount` is no longer synthesized; a client passing it explicitly as a native extra still reaches the provider unchanged.

Verified live: `n: 2` returned two distinct images with summed usage (`input 20 / output 2585 / total 2605`). Docs note that each fanned-out call is billed by Google.