### PR TITLE
feat(usage): flag zero-usage image and embedding rows with a cost caveat

### DIFF
--- a/docs/advanced/images-api.mdx
+++ b/docs/advanced/images-api.mdx
@@ -178,8 +178,9 @@ Image calls are recorded in [usage tracking](/features/cost-tracking) under the
 - **Per-image models** (DALL·E, `grok-2-image`, Imagen) report no tokens.
   GoModel records the number of returned images (`images` in the raw usage
   data) and prices it with the model's `per_image` rate.
-- When a response carries no `usage` block and no `per_image` price is set,
-  the usage row records no cost and is flagged with a cost-calculation caveat
+- When a response carries no `usage` block and the configured pricing cannot
+  cost it without one (no `per_image` rate to apply to the returned images, no
+  `per_request` rate), the usage row is flagged with a cost-calculation caveat
   so it reads as "unreported usage" rather than a free call.
 
 Set `per_image` through a [pricing override](/features/cost-tracking#override-pricing)

--- a/docs/advanced/images-api.mdx
+++ b/docs/advanced/images-api.mdx
@@ -178,6 +178,9 @@ Image calls are recorded in [usage tracking](/features/cost-tracking) under the
 - **Per-image models** (DALL·E, `grok-2-image`, Imagen) report no tokens.
   GoModel records the number of returned images (`images` in the raw usage
   data) and prices it with the model's `per_image` rate.
+- When a response carries no `usage` block and no `per_image` price is set,
+  the usage row records no cost and is flagged with a cost-calculation caveat
+  so it reads as "unreported usage" rather than a free call.
 
 Set `per_image` through a [pricing override](/features/cost-tracking#override-pricing)
 or in `config.yaml` when the model catalog has no price for an image model:

--- a/docs/providers/gemini.mdx
+++ b/docs/providers/gemini.mdx
@@ -60,7 +60,8 @@ surface; chat, embeddings, and images follow the API mode.
 In native mode, embeddings are served through `models/{model}:batchEmbedContents`.
 `dimensions` maps to `outputDimensionality` and `encoding_format: "base64"` is
 honored. Gemini reports no embedding token usage on either API surface, so
-embedding responses (and usage tracking) carry zero token counts.
+embedding responses carry zero token counts and the usage row is flagged with
+a cost-calculation caveat.
 
 ## Image generation and edits
 

--- a/internal/usage/cost.go
+++ b/internal/usage/cost.go
@@ -51,11 +51,20 @@ func imageCostDetermined(pricing *core.ModelPricing, imageCount int) bool {
 // explicit zero rate, a per-request price, or no pricing at all yields the
 // same cost whether or not the provider reported usage, so a zero-token row
 // priced that way is accurate rather than understated.
+//
+// Tier rates count too. A tier is selected by input token count, so a
+// zero-token row is priced by the base rates alone — but reported usage is
+// precisely what would have selected a tier, which makes a model with a zero
+// base rate and a priced tier understated rather than free.
 func tokenRatesAffectCost(pricing *core.ModelPricing) bool {
 	if pricing == nil {
 		return false
 	}
-	for _, rate := range []*float64{pricing.InputPerMtok, pricing.OutputPerMtok} {
+	rates := []*float64{pricing.InputPerMtok, pricing.OutputPerMtok}
+	for _, tier := range pricing.Tiers {
+		rates = append(rates, tier.InputPerMtok, tier.OutputPerMtok)
+	}
+	for _, rate := range rates {
 		if rate != nil && *rate != 0 {
 			return true
 		}

--- a/internal/usage/cost.go
+++ b/internal/usage/cost.go
@@ -36,14 +36,17 @@ const (
 // The image caveat lifts only when a per_image price has something to count —
 // a stored images total — so the row gains a real cost basis.
 func retainedMissingUsageCaveat(existing string, rawData map[string]any, pricing *core.ModelPricing) string {
-	switch existing {
-	case caveatImageMissingUsage:
+	// A prior recalculation may have joined the missing-usage caveat with its
+	// own caveats, so match by containment and return the canonical constant —
+	// the caller re-joins it with the fresh recalculation caveats.
+	switch {
+	case strings.Contains(existing, caveatImageMissingUsage):
 		if pricing != nil && pricing.PerImage != nil && extractInt(rawData, rawKeyImages) > 0 {
 			return ""
 		}
-		return existing
-	case caveatEmbeddingMissingUsage:
-		return existing
+		return caveatImageMissingUsage
+	case strings.Contains(existing, caveatEmbeddingMissingUsage):
+		return caveatEmbeddingMissingUsage
 	}
 	return ""
 }

--- a/internal/usage/cost.go
+++ b/internal/usage/cost.go
@@ -23,6 +23,30 @@ const (
 // ticks equals 1 USD.
 const xaiUSDTicksPerUSD = 10_000_000_000
 
+// Missing-usage caveats mark rows whose provider reported no usage at all;
+// they describe the usage report, not the price math, so pricing
+// recalculation preserves them (see retainedMissingUsageCaveat).
+const (
+	caveatImageMissingUsage     = "provider returned no token usage; set a per_image price to cost this model"
+	caveatEmbeddingMissingUsage = "provider reported no token usage; cost not calculated"
+)
+
+// retainedMissingUsageCaveat keeps a stored missing-usage caveat across
+// repricing: recalculation cannot conjure usage the provider never reported.
+// The image caveat lifts once a per_image price gives the row a real basis.
+func retainedMissingUsageCaveat(existing string, pricing *core.ModelPricing) string {
+	switch existing {
+	case caveatImageMissingUsage:
+		if pricing != nil && pricing.PerImage != nil {
+			return ""
+		}
+		return existing
+	case caveatEmbeddingMissingUsage:
+		return existing
+	}
+	return ""
+}
+
 // CostResult holds the result of a granular cost calculation.
 type CostResult struct {
 	InputCost  *float64

--- a/internal/usage/cost.go
+++ b/internal/usage/cost.go
@@ -31,21 +31,55 @@ const (
 	caveatEmbeddingMissingUsage = "provider reported no token usage; cost not calculated"
 )
 
+// imageCostDetermined reports whether pricing can cost an image row whose
+// provider reported no usage: a per_image rate is not a basis on its own,
+// there must also be images to multiply it by. An explicit zero rate counts —
+// a deliberately free model is a known price, not a missing one. A per-request
+// rate stands alone, since it does not depend on reported usage at all.
+func imageCostDetermined(pricing *core.ModelPricing, imageCount int) bool {
+	if pricing == nil {
+		return false
+	}
+	if pricing.PerRequest != nil {
+		return true
+	}
+	return imageCount > 0 && pricing.PerImage != nil
+}
+
+// tokenRatesAffectCost reports whether reported token usage would have changed
+// the calculated cost. Only a non-zero token rate consumes token counts: an
+// explicit zero rate, a per-request price, or no pricing at all yields the
+// same cost whether or not the provider reported usage, so a zero-token row
+// priced that way is accurate rather than understated.
+func tokenRatesAffectCost(pricing *core.ModelPricing) bool {
+	if pricing == nil {
+		return false
+	}
+	for _, rate := range []*float64{pricing.InputPerMtok, pricing.OutputPerMtok} {
+		if rate != nil && *rate != 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // retainedMissingUsageCaveat keeps a stored missing-usage caveat across
 // repricing: recalculation cannot conjure usage the provider never reported.
-// The image caveat lifts only when a per_image price has something to count —
-// a stored images total — so the row gains a real cost basis.
+// A caveat lifts once the new pricing determines the cost without that usage.
 func retainedMissingUsageCaveat(existing string, rawData map[string]any, pricing *core.ModelPricing) string {
 	// A prior recalculation may have joined the missing-usage caveat with its
 	// own caveats, so match by containment and return the canonical constant —
 	// the caller re-joins it with the fresh recalculation caveats.
 	switch {
 	case strings.Contains(existing, caveatImageMissingUsage):
-		if pricing != nil && pricing.PerImage != nil && extractInt(rawData, rawKeyImages) > 0 {
+		if imageCostDetermined(pricing, extractInt(rawData, rawKeyImages)) {
 			return ""
 		}
 		return caveatImageMissingUsage
 	case strings.Contains(existing, caveatEmbeddingMissingUsage):
+		if !tokenRatesAffectCost(pricing) {
+			return ""
+		}
 		return caveatEmbeddingMissingUsage
 	}
 	return ""

--- a/internal/usage/cost.go
+++ b/internal/usage/cost.go
@@ -33,11 +33,12 @@ const (
 
 // retainedMissingUsageCaveat keeps a stored missing-usage caveat across
 // repricing: recalculation cannot conjure usage the provider never reported.
-// The image caveat lifts once a per_image price gives the row a real basis.
-func retainedMissingUsageCaveat(existing string, pricing *core.ModelPricing) string {
+// The image caveat lifts only when a per_image price has something to count —
+// a stored images total — so the row gains a real cost basis.
+func retainedMissingUsageCaveat(existing string, rawData map[string]any, pricing *core.ModelPricing) string {
 	switch existing {
 	case caveatImageMissingUsage:
-		if pricing != nil && pricing.PerImage != nil {
+		if pricing != nil && pricing.PerImage != nil && extractInt(rawData, rawKeyImages) > 0 {
 			return ""
 		}
 		return existing

--- a/internal/usage/extractor.go
+++ b/internal/usage/extractor.go
@@ -193,6 +193,12 @@ func ExtractFromEmbeddingResponse(resp *core.EmbeddingResponse, requestID, provi
 	}
 
 	applyUsageCosts(entry, provider, endpoint, pricing...)
+	// Some providers report no embedding token usage at all (Gemini does not,
+	// on either API surface); flag the row so a zero-cost entry reads as
+	// "unreported usage" rather than a free call.
+	if resp.Usage.PromptTokens == 0 && resp.Usage.TotalTokens == 0 && !entryHasCost(entry) && entry.CostsCalculationCaveat == "" {
+		entry.CostsCalculationCaveat = "provider reported no token usage; cost not calculated"
+	}
 
 	return entry
 }

--- a/internal/usage/extractor.go
+++ b/internal/usage/extractor.go
@@ -198,7 +198,7 @@ func ExtractFromEmbeddingResponse(resp *core.EmbeddingResponse, requestID, provi
 	// whatever the pricing, the resulting cost reflects unreported usage — so
 	// flag the row on that condition alone.
 	if resp.Usage.PromptTokens == 0 && resp.Usage.TotalTokens == 0 && entry.CostsCalculationCaveat == "" {
-		entry.CostsCalculationCaveat = "provider reported no token usage; cost not calculated"
+		entry.CostsCalculationCaveat = caveatEmbeddingMissingUsage
 	}
 
 	return entry

--- a/internal/usage/extractor.go
+++ b/internal/usage/extractor.go
@@ -194,9 +194,10 @@ func ExtractFromEmbeddingResponse(resp *core.EmbeddingResponse, requestID, provi
 
 	applyUsageCosts(entry, provider, endpoint, pricing...)
 	// Some providers report no embedding token usage at all (Gemini does not,
-	// on either API surface); flag the row so a zero-cost entry reads as
-	// "unreported usage" rather than a free call.
-	if resp.Usage.PromptTokens == 0 && resp.Usage.TotalTokens == 0 && !entryHasCost(entry) && entry.CostsCalculationCaveat == "" {
+	// on either API surface). Zero reported tokens is the anomaly itself —
+	// whatever the pricing, the resulting cost reflects unreported usage — so
+	// flag the row on that condition alone.
+	if resp.Usage.PromptTokens == 0 && resp.Usage.TotalTokens == 0 && entry.CostsCalculationCaveat == "" {
 		entry.CostsCalculationCaveat = "provider reported no token usage; cost not calculated"
 	}
 

--- a/internal/usage/extractor.go
+++ b/internal/usage/extractor.go
@@ -194,10 +194,14 @@ func ExtractFromEmbeddingResponse(resp *core.EmbeddingResponse, requestID, provi
 
 	applyUsageCosts(entry, provider, endpoint, pricing...)
 	// Some providers report no embedding token usage at all (Gemini does not,
-	// on either API surface). Zero reported tokens is the anomaly itself —
-	// whatever the pricing, the resulting cost reflects unreported usage — so
-	// flag the row on that condition alone.
-	if resp.Usage.PromptTokens == 0 && resp.Usage.TotalTokens == 0 && entry.CostsCalculationCaveat == "" {
+	// on either API surface), so a zero-token row prices at $0 from token
+	// rates and understates the real call. Flag that — but not when the
+	// configured pricing determines the cost without token counts (a
+	// per-request price, or an explicit zero rate), where the recorded cost is
+	// correct and calling it uncalculated would be false.
+	if resp.Usage.PromptTokens == 0 && resp.Usage.TotalTokens == 0 &&
+		tokenRatesAffectCost(effectiveEndpointPricing(endpoint, pricing...)) &&
+		entry.CostsCalculationCaveat == "" {
 		entry.CostsCalculationCaveat = caveatEmbeddingMissingUsage
 	}
 
@@ -353,6 +357,15 @@ func normalizeCachedResponseEndpoint(endpoint string) string {
 		return "/" + cleaned
 	}
 	return cleaned
+}
+
+// effectiveEndpointPricing resolves the pricing that applies to endpoint, or
+// nil when the caller supplied none.
+func effectiveEndpointPricing(endpoint string, pricing ...*core.ModelPricing) *core.ModelPricing {
+	if len(pricing) == 0 {
+		return nil
+	}
+	return pricingForEndpoint(pricing[0], endpoint)
 }
 
 func pricingForEndpoint(pricing *core.ModelPricing, endpoint string) *core.ModelPricing {

--- a/internal/usage/extractor_test.go
+++ b/internal/usage/extractor_test.go
@@ -1000,4 +1000,22 @@ func TestExtractFromEmbeddingResponse_NoUsageCaveat(t *testing.T) {
 			}
 		})
 	}
+
+	// A tier is selected by input token count, so a zero-token row is priced by
+	// the base rate alone — here $0. Reported usage is exactly what would have
+	// selected the priced tier, so the row is understated and keeps the caveat.
+	tiered := &core.ModelPricing{
+		InputPerMtok: new(0.0),
+		Tiers: []core.ModelPricingTier{
+			{UpToTokens: new(200_000.0), InputPerMtok: new(0.15), OutputPerMtok: new(0.6)},
+			{UpToTokens: new(10_000_000.0), InputPerMtok: new(0.3), OutputPerMtok: new(1.2)},
+		},
+	}
+	unreported := ExtractFromEmbeddingResponse(&core.EmbeddingResponse{Model: "tiered-embed"}, "req", "openai", "/v1/embeddings", tiered)
+	if unreported.CostsCalculationCaveat != caveatEmbeddingMissingUsage {
+		t.Fatalf("caveat = %q, want %q for a zero base rate with a priced tier", unreported.CostsCalculationCaveat, caveatEmbeddingMissingUsage)
+	}
+	if retained := retainedMissingUsageCaveat(caveatEmbeddingMissingUsage, nil, tiered); retained != caveatEmbeddingMissingUsage {
+		t.Fatalf("repricing retained %q, want the caveat kept for tiered token rates", retained)
+	}
 }

--- a/internal/usage/extractor_test.go
+++ b/internal/usage/extractor_test.go
@@ -982,4 +982,22 @@ func TestExtractFromEmbeddingResponse_NoUsageCaveat(t *testing.T) {
 	if counted.CostsCalculationCaveat != "" || counted.TotalCost == nil {
 		t.Fatalf("entry = caveat %q cost %v, want costed and caveat-free", counted.CostsCalculationCaveat, counted.TotalCost)
 	}
+
+	// Pricing that does not depend on token counts determines the cost even
+	// with nothing reported, so the row must not claim it was uncalculated.
+	determined := map[string]*core.ModelPricing{
+		"per request":        {PerRequest: new(0.01)},
+		"explicit zero rate": {InputPerMtok: new(0.0)},
+	}
+	for name, priced := range determined {
+		t.Run(name, func(t *testing.T) {
+			entry := ExtractFromEmbeddingResponse(&core.EmbeddingResponse{Model: "free-embed"}, "req", "openai", "/v1/embeddings", priced)
+			if entry.CostsCalculationCaveat != "" {
+				t.Fatalf("caveat = %q, want none when pricing determines the cost", entry.CostsCalculationCaveat)
+			}
+			if entry.TotalCost == nil {
+				t.Fatal("total cost = nil, want the deterministic model-pricing cost")
+			}
+		})
+	}
 }

--- a/internal/usage/extractor_test.go
+++ b/internal/usage/extractor_test.go
@@ -966,3 +966,20 @@ func assertCostPtrNear(t *testing.T, name string, got *float64, want float64) {
 		t.Fatalf("%s = %f, want %f", name, *got, want)
 	}
 }
+
+func TestExtractFromEmbeddingResponse_NoUsageCaveat(t *testing.T) {
+	pricing := &core.ModelPricing{InputPerMtok: new(0.15)}
+
+	zero := ExtractFromEmbeddingResponse(&core.EmbeddingResponse{Model: "gemini-embedding-001"}, "req", "gemini", "/v1/embeddings", pricing)
+	if zero.CostsCalculationCaveat == "" {
+		t.Fatal("expected a caveat when the provider reports no embedding usage")
+	}
+
+	counted := ExtractFromEmbeddingResponse(&core.EmbeddingResponse{
+		Model: "text-embedding-3-small",
+		Usage: core.EmbeddingUsage{PromptTokens: 8, TotalTokens: 8},
+	}, "req", "openai", "/v1/embeddings", pricing)
+	if counted.CostsCalculationCaveat != "" || counted.TotalCost == nil {
+		t.Fatalf("entry = caveat %q cost %v, want costed and caveat-free", counted.CostsCalculationCaveat, counted.TotalCost)
+	}
+}

--- a/internal/usage/images.go
+++ b/internal/usage/images.go
@@ -75,6 +75,16 @@ func extractFromImageResponse(resp *core.ImageGenerationResponse, requestID, mod
 	}
 
 	applyUsageCosts(entry, provider, endpoint, pricing...)
+	// A response without a usage block (Gemini's OpenAI-compatible surface,
+	// per-image models without a per_image price) yields no cost at all, which
+	// is indistinguishable from an unpriced model. Say why the row is empty.
+	if resp.Usage == nil && !entryHasCost(entry) && entry.CostsCalculationCaveat == "" {
+		entry.CostsCalculationCaveat = "provider returned no token usage; set a per_image price to cost this model"
+	}
 
 	return entry
+}
+
+func entryHasCost(entry *UsageEntry) bool {
+	return entry.TotalCost != nil && *entry.TotalCost > 0
 }

--- a/internal/usage/images.go
+++ b/internal/usage/images.go
@@ -80,7 +80,7 @@ func extractFromImageResponse(resp *core.ImageGenerationResponse, requestID, mod
 	// Only a per_image price (any value, including an explicit zero for a free
 	// model) prices such a response, so flag the row when none is set.
 	if resp.Usage == nil && !perImagePriced(endpoint, pricing...) && entry.CostsCalculationCaveat == "" {
-		entry.CostsCalculationCaveat = "provider returned no token usage; set a per_image price to cost this model"
+		entry.CostsCalculationCaveat = caveatImageMissingUsage
 	}
 
 	return entry

--- a/internal/usage/images.go
+++ b/internal/usage/images.go
@@ -77,24 +77,11 @@ func extractFromImageResponse(resp *core.ImageGenerationResponse, requestID, mod
 	applyUsageCosts(entry, provider, endpoint, pricing...)
 	// A response without a usage block cannot be costed by token rates, and
 	// zero-token math quietly yields $0 — indistinguishable from a free call.
-	// A per_image price (any value, including an explicit zero for a free
-	// model) is a real basis only when there are images to count, so flag the
-	// row unless both hold.
-	if resp.Usage == nil && !perImagePriced(len(resp.Data), endpoint, pricing...) && entry.CostsCalculationCaveat == "" {
+	// Flag that unless the configured pricing can cost the row without usage.
+	if resp.Usage == nil && entry.CostsCalculationCaveat == "" &&
+		!imageCostDetermined(effectiveEndpointPricing(endpoint, pricing...), len(resp.Data)) {
 		entry.CostsCalculationCaveat = caveatImageMissingUsage
 	}
 
 	return entry
-}
-
-// perImagePriced reports whether a per_image rate can actually cost this
-// response: the price alone is not a basis, there must also be images to
-// multiply it by. An explicit zero rate counts — a deliberately free model is
-// a known price, not a missing one.
-func perImagePriced(imageCount int, endpoint string, pricing ...*core.ModelPricing) bool {
-	if imageCount <= 0 || len(pricing) == 0 || pricing[0] == nil {
-		return false
-	}
-	effective := pricingForEndpoint(pricing[0], endpoint)
-	return effective != nil && effective.PerImage != nil
 }

--- a/internal/usage/images.go
+++ b/internal/usage/images.go
@@ -87,6 +87,10 @@ func extractFromImageResponse(resp *core.ImageGenerationResponse, requestID, mod
 	return entry
 }
 
+// perImagePriced reports whether a per_image rate can actually cost this
+// response: the price alone is not a basis, there must also be images to
+// multiply it by. An explicit zero rate counts — a deliberately free model is
+// a known price, not a missing one.
 func perImagePriced(imageCount int, endpoint string, pricing ...*core.ModelPricing) bool {
 	if imageCount <= 0 || len(pricing) == 0 || pricing[0] == nil {
 		return false

--- a/internal/usage/images.go
+++ b/internal/usage/images.go
@@ -77,17 +77,18 @@ func extractFromImageResponse(resp *core.ImageGenerationResponse, requestID, mod
 	applyUsageCosts(entry, provider, endpoint, pricing...)
 	// A response without a usage block cannot be costed by token rates, and
 	// zero-token math quietly yields $0 — indistinguishable from a free call.
-	// Only a per_image price (any value, including an explicit zero for a free
-	// model) prices such a response, so flag the row when none is set.
-	if resp.Usage == nil && !perImagePriced(endpoint, pricing...) && entry.CostsCalculationCaveat == "" {
+	// A per_image price (any value, including an explicit zero for a free
+	// model) is a real basis only when there are images to count, so flag the
+	// row unless both hold.
+	if resp.Usage == nil && !perImagePriced(len(resp.Data), endpoint, pricing...) && entry.CostsCalculationCaveat == "" {
 		entry.CostsCalculationCaveat = caveatImageMissingUsage
 	}
 
 	return entry
 }
 
-func perImagePriced(endpoint string, pricing ...*core.ModelPricing) bool {
-	if len(pricing) == 0 || pricing[0] == nil {
+func perImagePriced(imageCount int, endpoint string, pricing ...*core.ModelPricing) bool {
+	if imageCount <= 0 || len(pricing) == 0 || pricing[0] == nil {
 		return false
 	}
 	effective := pricingForEndpoint(pricing[0], endpoint)

--- a/internal/usage/images.go
+++ b/internal/usage/images.go
@@ -75,16 +75,21 @@ func extractFromImageResponse(resp *core.ImageGenerationResponse, requestID, mod
 	}
 
 	applyUsageCosts(entry, provider, endpoint, pricing...)
-	// A response without a usage block (Gemini's OpenAI-compatible surface,
-	// per-image models without a per_image price) yields no cost at all, which
-	// is indistinguishable from an unpriced model. Say why the row is empty.
-	if resp.Usage == nil && !entryHasCost(entry) && entry.CostsCalculationCaveat == "" {
+	// A response without a usage block cannot be costed by token rates, and
+	// zero-token math quietly yields $0 — indistinguishable from a free call.
+	// Only a per_image price (any value, including an explicit zero for a free
+	// model) prices such a response, so flag the row when none is set.
+	if resp.Usage == nil && !perImagePriced(endpoint, pricing...) && entry.CostsCalculationCaveat == "" {
 		entry.CostsCalculationCaveat = "provider returned no token usage; set a per_image price to cost this model"
 	}
 
 	return entry
 }
 
-func entryHasCost(entry *UsageEntry) bool {
-	return entry.TotalCost != nil && *entry.TotalCost > 0
+func perImagePriced(endpoint string, pricing ...*core.ModelPricing) bool {
+	if len(pricing) == 0 || pricing[0] == nil {
+		return false
+	}
+	effective := pricingForEndpoint(pricing[0], endpoint)
+	return effective != nil && effective.PerImage != nil
 }

--- a/internal/usage/images_test.go
+++ b/internal/usage/images_test.go
@@ -133,6 +133,13 @@ func TestExtractFromImageResponse_NoUsageCaveat(t *testing.T) {
 		t.Fatalf("caveat = %q, want none when per-image cost was calculated", priced.CostsCalculationCaveat)
 	}
 
+	// An explicit zero per_image price means a deliberately free model — its
+	// known $0 cost must not read as unavailable.
+	free := ExtractFromImageResponse(resp, "req", "free-image-model", "openai", &core.ModelPricing{PerImage: new(0.0)})
+	if free.CostsCalculationCaveat != "" {
+		t.Fatalf("caveat = %q, want none for an explicitly free per-image model", free.CostsCalculationCaveat)
+	}
+
 	// A usage-carrying response keeps its token costs and stays caveat-free.
 	withUsage := ExtractFromImageResponse(&core.ImageGenerationResponse{
 		Data:  []core.ImageData{{B64JSON: "aGk="}},

--- a/internal/usage/images_test.go
+++ b/internal/usage/images_test.go
@@ -114,3 +114,31 @@ func TestExtractFromImageEditResponse(t *testing.T) {
 		t.Errorf("output cost = %v, want 0.04 per-image", entry.OutputCost)
 	}
 }
+
+func TestExtractFromImageResponse_NoUsageCaveat(t *testing.T) {
+	// A token-priced model whose serving surface returns no usage block
+	// (e.g. Gemini's OpenAI-compatible images endpoint) must say why the
+	// row carries no cost.
+	resp := &core.ImageGenerationResponse{Data: []core.ImageData{{B64JSON: "aGk="}}}
+	pricing := &core.ModelPricing{InputPerMtok: new(0.3), OutputPerMtok: new(30.0)}
+
+	entry := ExtractFromImageResponse(resp, "req", "gemini-2.5-flash-image", "gemini", pricing)
+	if entry.CostsCalculationCaveat == "" {
+		t.Fatal("expected a caveat for a usage-less response without per-image pricing")
+	}
+
+	// With a per_image price the cost is real, so no caveat.
+	priced := ExtractFromImageResponse(resp, "req", "dall-e-3", "openai", &core.ModelPricing{PerImage: new(0.04)})
+	if priced.CostsCalculationCaveat != "" {
+		t.Fatalf("caveat = %q, want none when per-image cost was calculated", priced.CostsCalculationCaveat)
+	}
+
+	// A usage-carrying response keeps its token costs and stays caveat-free.
+	withUsage := ExtractFromImageResponse(&core.ImageGenerationResponse{
+		Data:  []core.ImageData{{B64JSON: "aGk="}},
+		Usage: &core.ImageUsage{InputTokens: 10, OutputTokens: 1000, TotalTokens: 1010},
+	}, "req", "gemini-2.5-flash-image", "gemini", pricing)
+	if withUsage.CostsCalculationCaveat != "" || withUsage.TotalCost == nil {
+		t.Fatalf("entry = caveat %q cost %v, want costed and caveat-free", withUsage.CostsCalculationCaveat, withUsage.TotalCost)
+	}
+}

--- a/internal/usage/images_test.go
+++ b/internal/usage/images_test.go
@@ -147,6 +147,13 @@ func TestExtractFromImageResponse_NoUsageCaveat(t *testing.T) {
 		t.Fatal("expected a caveat when there are no images and no usage to price")
 	}
 
+	// A per-request price does not depend on usage at all, so it costs the
+	// row on its own and needs no caveat.
+	perRequest := ExtractFromImageResponse(resp, "req", "flat-rate-model", "openai", &core.ModelPricing{PerRequest: new(0.02)})
+	if perRequest.CostsCalculationCaveat != "" || perRequest.TotalCost == nil {
+		t.Fatalf("entry = caveat %q cost %v, want costed and caveat-free", perRequest.CostsCalculationCaveat, perRequest.TotalCost)
+	}
+
 	// A usage-carrying response keeps its token costs and stays caveat-free.
 	withUsage := ExtractFromImageResponse(&core.ImageGenerationResponse{
 		Data:  []core.ImageData{{B64JSON: "aGk="}},

--- a/internal/usage/images_test.go
+++ b/internal/usage/images_test.go
@@ -140,6 +140,13 @@ func TestExtractFromImageResponse_NoUsageCaveat(t *testing.T) {
 		t.Fatalf("caveat = %q, want none for an explicitly free per-image model", free.CostsCalculationCaveat)
 	}
 
+	// A per_image price with nothing to count is no basis: an empty response
+	// without usage stays flagged.
+	empty := ExtractFromImageResponse(&core.ImageGenerationResponse{}, "req", "dall-e-3", "openai", &core.ModelPricing{PerImage: new(0.04)})
+	if empty.CostsCalculationCaveat == "" {
+		t.Fatal("expected a caveat when there are no images and no usage to price")
+	}
+
 	// A usage-carrying response keeps its token costs and stays caveat-free.
 	withUsage := ExtractFromImageResponse(&core.ImageGenerationResponse{
 		Data:  []core.ImageData{{B64JSON: "aGk="}},

--- a/internal/usage/recalculate_pricing.go
+++ b/internal/usage/recalculate_pricing.go
@@ -74,7 +74,7 @@ func recalculateEntryCosts(entry recalculationEntry, resolver PricingResolver) r
 	effectivePricing := pricingForEndpoint(pricing, entry.Endpoint)
 	result := CalculateUsageCost(entry.InputTokens, entry.OutputTokens, entry.RawData, entry.Provider, effectivePricing)
 	caveat := result.Caveat
-	if retained := retainedMissingUsageCaveat(entry.Caveat, effectivePricing); retained != "" {
+	if retained := retainedMissingUsageCaveat(entry.Caveat, entry.RawData, effectivePricing); retained != "" {
 		if caveat == "" {
 			caveat = retained
 		} else {

--- a/internal/usage/recalculate_pricing.go
+++ b/internal/usage/recalculate_pricing.go
@@ -43,6 +43,7 @@ type recalculationEntry struct {
 	OutputTokens       int
 	RewriteTokensSaved int
 	RawData            map[string]any
+	Caveat             string
 }
 
 type recalculationUpdate struct {
@@ -72,6 +73,14 @@ func recalculateEntryCosts(entry recalculationEntry, resolver PricingResolver) r
 	}
 	effectivePricing := pricingForEndpoint(pricing, entry.Endpoint)
 	result := CalculateUsageCost(entry.InputTokens, entry.OutputTokens, entry.RawData, entry.Provider, effectivePricing)
+	caveat := result.Caveat
+	if retained := retainedMissingUsageCaveat(entry.Caveat, effectivePricing); retained != "" {
+		if caveat == "" {
+			caveat = retained
+		} else {
+			caveat = retained + "; " + caveat
+		}
+	}
 	return recalculationUpdate{
 		ID:         entry.ID,
 		InputCost:  result.InputCost,
@@ -87,7 +96,7 @@ func recalculateEntryCosts(entry recalculationEntry, resolver PricingResolver) r
 			entry.RewriteTokensSaved,
 		),
 		CostSource: result.Source,
-		Caveat:     result.Caveat,
+		Caveat:     caveat,
 		HasPricing: result.TotalCost != nil || result.InputCost != nil || result.OutputCost != nil,
 	}
 }

--- a/internal/usage/recalculate_pricing_mongodb.go
+++ b/internal/usage/recalculate_pricing_mongodb.go
@@ -155,6 +155,7 @@ func (s *MongoDBStore) recalculatePricingInMongoTransaction(ctx context.Context,
 			OutputTokens       int            `bson:"output_tokens"`
 			RewriteTokensSaved int            `bson:"rewrite_tokens_saved"`
 			RawData            map[string]any `bson:"raw_data"`
+			Caveat             string         `bson:"costs_calculation_caveat"`
 		}
 		if err := cursor.Decode(&row); err != nil {
 			return RecalculatePricingResult{}, fmt.Errorf("scan mongodb usage cost row: %w", err)
@@ -170,6 +171,7 @@ func (s *MongoDBStore) recalculatePricingInMongoTransaction(ctx context.Context,
 			OutputTokens:       row.OutputTokens,
 			RewriteTokensSaved: row.RewriteTokensSaved,
 			RawData:            row.RawData,
+			Caveat:             row.Caveat,
 		}, resolver)
 
 		if _, err := s.collection.UpdateByID(ctx, update.ID, mongoRecalculationUpdate(update)); err != nil {

--- a/internal/usage/recalculate_pricing_postgresql.go
+++ b/internal/usage/recalculate_pricing_postgresql.go
@@ -66,7 +66,7 @@ func postgresRecalculationEntries(ctx context.Context, tx pgx.Tx, params Recalcu
 	}
 
 	rows, err := tx.Query(ctx, `
-		SELECT id::text, model, provider, provider_name, endpoint, input_tokens, output_tokens, rewrite_tokens_saved, raw_data::text
+		SELECT id::text, model, provider, provider_name, endpoint, input_tokens, output_tokens, rewrite_tokens_saved, raw_data::text, COALESCE(costs_calculation_caveat, '')
 		FROM usage`+sqlutil.BuildWhereClause(conditions)+`
 		FOR UPDATE`, args...)
 	if err != nil {
@@ -89,6 +89,7 @@ func postgresRecalculationEntries(ctx context.Context, tx pgx.Tx, params Recalcu
 			&entry.OutputTokens,
 			&entry.RewriteTokensSaved,
 			&rawData,
+			&entry.Caveat,
 		); err != nil {
 			return nil, fmt.Errorf("scan postgres usage cost row: %w", err)
 		}

--- a/internal/usage/recalculate_pricing_sqlite.go
+++ b/internal/usage/recalculate_pricing_sqlite.go
@@ -88,7 +88,7 @@ func (s *SQLiteStore) sqliteRecalculationEntries(ctx context.Context, tx *sql.Tx
 	args = append(args, limit)
 
 	rows, err := tx.QueryContext(ctx, `
-		SELECT id, model, provider, provider_name, endpoint, input_tokens, output_tokens, rewrite_tokens_saved, raw_data
+		SELECT id, model, provider, provider_name, endpoint, input_tokens, output_tokens, rewrite_tokens_saved, raw_data, COALESCE(costs_calculation_caveat, '')
 		FROM usage`+sqlutil.BuildWhereClause(conditions)+`
 		ORDER BY id
 		LIMIT ?`, args...)
@@ -112,6 +112,7 @@ func (s *SQLiteStore) sqliteRecalculationEntries(ctx context.Context, tx *sql.Tx
 			&entry.OutputTokens,
 			&entry.RewriteTokensSaved,
 			&rawData,
+			&entry.Caveat,
 		); err != nil {
 			return nil, fmt.Errorf("scan sqlite usage cost row: %w", err)
 		}

--- a/internal/usage/recalculate_pricing_test.go
+++ b/internal/usage/recalculate_pricing_test.go
@@ -81,6 +81,19 @@ func TestRecalculateEntryCostsPreservesMissingUsageCaveats(t *testing.T) {
 		t.Fatalf("total = %v, want 0.08 from the per_image rate", repriced.TotalCost)
 	}
 
+	// A per_image price cannot lift the caveat for a row that recorded no
+	// image count — there is nothing to price.
+	countless := recalculateEntryCosts(recalculationEntry{
+		ID:       "usage-img-empty",
+		Model:    "gemini-2.5-flash-image",
+		Provider: "gemini",
+		Endpoint: "/v1/images/generations",
+		Caveat:   caveatImageMissingUsage,
+	}, &recordingPricingResolver{pricing: &core.ModelPricing{PerImage: new(0.04)}})
+	if countless.Caveat != caveatImageMissingUsage {
+		t.Fatalf("caveat = %q, want preserved without an image count", countless.Caveat)
+	}
+
 	// Embedding rows keep the caveat unconditionally: no repricing can
 	// recover usage the provider never reported.
 	embedding := recalculateEntryCosts(recalculationEntry{

--- a/internal/usage/recalculate_pricing_test.go
+++ b/internal/usage/recalculate_pricing_test.go
@@ -46,3 +46,63 @@ func TestRecalculateEntryCostsPrefersProviderNameForPricingLookup(t *testing.T) 
 		t.Fatalf("InputCost = %v, want 1.25", update.InputCost)
 	}
 }
+
+func TestRecalculateEntryCostsPreservesMissingUsageCaveats(t *testing.T) {
+	tokenPricing := &core.ModelPricing{InputPerMtok: new(0.3), OutputPerMtok: new(30.0)}
+
+	// An image row without provider usage keeps its caveat when repricing
+	// still has no per_image basis.
+	update := recalculateEntryCosts(recalculationEntry{
+		ID:       "usage-img",
+		Model:    "gemini-2.5-flash-image",
+		Provider: "gemini",
+		Endpoint: "/v1/images/generations",
+		RawData:  map[string]any{"images": 1},
+		Caveat:   caveatImageMissingUsage,
+	}, &recordingPricingResolver{pricing: tokenPricing})
+	if update.Caveat != caveatImageMissingUsage {
+		t.Fatalf("caveat = %q, want the missing-usage caveat preserved", update.Caveat)
+	}
+
+	// Adding a per_image price gives the row a real basis: cost computes and
+	// the caveat lifts.
+	repriced := recalculateEntryCosts(recalculationEntry{
+		ID:       "usage-img",
+		Model:    "gemini-2.5-flash-image",
+		Provider: "gemini",
+		Endpoint: "/v1/images/generations",
+		RawData:  map[string]any{"images": 2},
+		Caveat:   caveatImageMissingUsage,
+	}, &recordingPricingResolver{pricing: &core.ModelPricing{PerImage: new(0.04)}})
+	if repriced.Caveat != "" {
+		t.Fatalf("caveat = %q, want cleared once per_image prices the row", repriced.Caveat)
+	}
+	if repriced.TotalCost == nil || *repriced.TotalCost != 0.08 {
+		t.Fatalf("total = %v, want 0.08 from the per_image rate", repriced.TotalCost)
+	}
+
+	// Embedding rows keep the caveat unconditionally: no repricing can
+	// recover usage the provider never reported.
+	embedding := recalculateEntryCosts(recalculationEntry{
+		ID:       "usage-emb",
+		Model:    "gemini-embedding-001",
+		Provider: "gemini",
+		Endpoint: "/v1/embeddings",
+		Caveat:   caveatEmbeddingMissingUsage,
+	}, &recordingPricingResolver{pricing: tokenPricing})
+	if embedding.Caveat != caveatEmbeddingMissingUsage {
+		t.Fatalf("caveat = %q, want the embedding missing-usage caveat preserved", embedding.Caveat)
+	}
+
+	// Unrelated caveats are recalculation's own business and are replaced.
+	unrelated := recalculateEntryCosts(recalculationEntry{
+		ID:       "usage-other",
+		Model:    "gpt-4o",
+		Provider: "openai",
+		Endpoint: "/v1/chat/completions",
+		Caveat:   "some stale caveat",
+	}, &recordingPricingResolver{pricing: tokenPricing})
+	if unrelated.Caveat != "" {
+		t.Fatalf("caveat = %q, want unrelated caveats recomputed", unrelated.Caveat)
+	}
+}

--- a/internal/usage/recalculate_pricing_test.go
+++ b/internal/usage/recalculate_pricing_test.go
@@ -121,6 +121,19 @@ func TestRecalculateEntryCostsPreservesMissingUsageCaveats(t *testing.T) {
 		t.Fatalf("caveat = %q, want the embedding missing-usage caveat preserved", embedding.Caveat)
 	}
 
+	// Repricing an embedding row onto usage-independent pricing lifts the
+	// caveat: the recalculated cost no longer depends on the missing usage.
+	embeddingRepriced := recalculateEntryCosts(recalculationEntry{
+		ID:       "usage-emb-flat",
+		Model:    "gemini-embedding-001",
+		Provider: "gemini",
+		Endpoint: "/v1/embeddings",
+		Caveat:   caveatEmbeddingMissingUsage,
+	}, &recordingPricingResolver{pricing: &core.ModelPricing{PerRequest: new(0.01)}})
+	if embeddingRepriced.Caveat != "" {
+		t.Fatalf("caveat = %q, want cleared once a per-request price determines the cost", embeddingRepriced.Caveat)
+	}
+
 	// Unrelated caveats are recalculation's own business and are replaced.
 	unrelated := recalculateEntryCosts(recalculationEntry{
 		ID:       "usage-other",

--- a/internal/usage/recalculate_pricing_test.go
+++ b/internal/usage/recalculate_pricing_test.go
@@ -94,6 +94,20 @@ func TestRecalculateEntryCostsPreservesMissingUsageCaveats(t *testing.T) {
 		t.Fatalf("caveat = %q, want preserved without an image count", countless.Caveat)
 	}
 
+	// A caveat compounded by an earlier recalculation still matches; only the
+	// canonical missing-usage part survives re-joining.
+	compound := recalculateEntryCosts(recalculationEntry{
+		ID:       "usage-img-compound",
+		Model:    "gemini-2.5-flash-image",
+		Provider: "gemini",
+		Endpoint: "/v1/images/generations",
+		RawData:  map[string]any{"images": 1},
+		Caveat:   caveatImageMissingUsage + "; unmapped token field: foo",
+	}, &recordingPricingResolver{pricing: tokenPricing})
+	if compound.Caveat != caveatImageMissingUsage {
+		t.Fatalf("caveat = %q, want the canonical missing-usage caveat retained from a compound value", compound.Caveat)
+	}
+
 	// Embedding rows keep the caveat unconditionally: no repricing can
 	// recover usage the provider never reported.
 	embedding := recalculateEntryCosts(recalculationEntry{


### PR DESCRIPTION
Some serving surfaces return no usage at all — Gemini reports no embedding token usage on either API surface, and its OpenAI-compatible images endpoint returns no `usage` block (both verified live). Those rows land with zero tokens and no cost, indistinguishable from a free call or an unpriced model.

- Image generation/edit entries whose response had no `usage` block and produced no cost now carry `costs_calculation_caveat: "provider returned no token usage; set a per_image price to cost this model"`. Per-image-priced models (DALL·E, Imagen) are costed as before and stay caveat-free.
- Embedding entries with zero reported tokens and no cost carry `"provider reported no token usage; cost not calculated"`.

No cost math changes; docs updated. (The other half of the "image cost edges" idea — catalog `per_image` support — turned out to already exist: the model list deserializes full `core.ModelPricing`, including `per_image`, so it is a catalog-data question, not a gateway gap.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Usage reports now distinguish unreported image and embedding usage from calls that genuinely cost nothing.
  * Missing-usage caveats are preserved and correctly updated when pricing is recalculated.
  * Image usage is correctly priced when per-image or per-request pricing is available, including explicitly free pricing.

* **Documentation**
  * Clarified cost reporting for image and Gemini embedding responses when token usage is unavailable.
  * Documented how missing usage is flagged when costs cannot be calculated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->