### PR TITLE
fix(test): retry throwaway-schema drops on PostgreSQL catalog races

### DIFF
--- a/internal/storage/sqlx/sqlxtest/sqlxtest.go
+++ b/internal/storage/sqlx/sqlxtest/sqlxtest.go
@@ -16,12 +16,15 @@ package sqlxtest
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "modernc.org/sqlite" // SQLite driver for the in-memory test database
 
@@ -125,8 +128,7 @@ func NewPostgresPool(t *testing.T) *pgxpool.Pool {
 		t.Fatalf("create schema %s: %v", schema, err)
 	}
 	t.Cleanup(func() {
-		_, err := admin.Exec(context.Background(), `DROP SCHEMA `+quoteIdentifier(schema)+` CASCADE`)
-		if err != nil {
+		if err := dropTestSchema(context.Background(), admin, schema); err != nil {
 			t.Errorf("drop schema %s: %v", schema, err)
 		}
 		admin.Close()
@@ -174,4 +176,32 @@ func sanitizeIdentifier(name string) string {
 // quoteIdentifier wraps an identifier in double quotes, escaping any it holds.
 func quoteIdentifier(name string) string {
 	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
+
+// dropTestSchema drops a throwaway schema, retrying the transient catalog
+// races parallel teardowns can hit: PostgreSQL raises XX000 "tuple
+// concurrently updated" (and occasionally a 40P01 deadlock) when concurrent
+// DROP SCHEMA ... CASCADE statements touch shared catalog rows.
+func dropTestSchema(ctx context.Context, admin *pgxpool.Pool, schema string) error {
+	const attempts = 5
+	var err error
+	for attempt := range attempts {
+		_, err = admin.Exec(ctx, `DROP SCHEMA `+quoteIdentifier(schema)+` CASCADE`)
+		if err == nil || !isTransientCatalogRace(err) {
+			return err
+		}
+		time.Sleep(time.Duration(attempt+1) * 100 * time.Millisecond)
+	}
+	return err
+}
+
+func isTransientCatalogRace(err error) bool {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+	if pgErr.Code == "40P01" { // deadlock_detected
+		return true
+	}
+	return pgErr.Code == "XX000" && strings.Contains(pgErr.Message, "tuple concurrently updated")
 }

--- a/internal/storage/sqlx/sqlxtest/sqlxtest.go
+++ b/internal/storage/sqlx/sqlxtest/sqlxtest.go
@@ -185,14 +185,13 @@ func quoteIdentifier(name string) string {
 func dropTestSchema(ctx context.Context, admin *pgxpool.Pool, schema string) error {
 	const attempts = 5
 	var err error
-	for attempt := range attempts {
+	for attempt := 1; ; attempt++ {
 		_, err = admin.Exec(ctx, `DROP SCHEMA `+quoteIdentifier(schema)+` CASCADE`)
-		if err == nil || !isTransientCatalogRace(err) {
+		if err == nil || !isTransientCatalogRace(err) || attempt == attempts {
 			return err
 		}
-		time.Sleep(time.Duration(attempt+1) * 100 * time.Millisecond)
+		time.Sleep(time.Duration(attempt) * 100 * time.Millisecond)
 	}
-	return err
 }
 
 func isTransientCatalogRace(err error) bool {

--- a/internal/storage/sqlx/sqlxtest/sqlxtest_internal_test.go
+++ b/internal/storage/sqlx/sqlxtest/sqlxtest_internal_test.go
@@ -1,0 +1,31 @@
+package sqlxtest
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func TestIsTransientCatalogRace(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "tuple concurrently updated", err: &pgconn.PgError{Code: "XX000", Message: "tuple concurrently updated"}, want: true},
+		{name: "deadlock", err: &pgconn.PgError{Code: "40P01", Message: "deadlock detected"}, want: true},
+		{name: "other internal error", err: &pgconn.PgError{Code: "XX000", Message: "something else broke"}, want: false},
+		{name: "missing schema", err: &pgconn.PgError{Code: "3F000", Message: "schema does not exist"}, want: false},
+		{name: "wrapped pg error", err: errors.Join(errors.New("exec"), &pgconn.PgError{Code: "XX000", Message: "tuple concurrently updated"}), want: true},
+		{name: "non-pg error", err: errors.New("connection reset"), want: false},
+		{name: "nil", err: nil, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTransientCatalogRace(tt.err); got != tt.want {
+				t.Fatalf("isTransientCatalogRace(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The unit-test job intermittently fails in PostgreSQL teardown with `tuple concurrently updated (SQLSTATE XX000)` (seen on #749's CI and again on main yesterday): parallel tests each drop their throwaway schema, and concurrent `DROP SCHEMA ... CASCADE` statements can race on shared catalog rows.

The cleanup now retries the drop up to five times with a short backoff when the error is that specific XX000 message (or a `40P01` deadlock); any other error still fails the test immediately. No production code involved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of temporary database schemas by retrying transient PostgreSQL catalog errors.
  * Reduced test failures caused by deadlocks and concurrent catalog updates during teardown.

* **Tests**
  * Added coverage for transient, wrapped, unrelated, non-PostgreSQL, and empty error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->