### PR TITLE
docs(agents): note automated PR review and outside-diff comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,14 @@ Allowed types: `feat`, `fix`, `perf`, `docs`, `refactor`, `test`, `build`, `ci`,
 
 Squash merges should preserve the PR title as the resulting commit subject.
 
+### Code Review
+
+Greptile and CodeRabbit review new PRs automatically. Monitor CI and the review
+comments; verify each finding and address the valid ones before merging. Some
+findings appear only in the review summary under headings like "Comments
+Outside Diff" — Greptile updates its main comment in place after every push, so
+re-read it after each change.
+
 ### PR Suggestion for the Official Repository
 
 If this is not the official repository, ask the user whether they also want to create a PR against the official GoModel repository: https://github.com/ENTERPILOT/GoModel/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,15 @@ If this repository is not the official GoModel repository, ask the user whether 
 
 [https://github.com/ENTERPILOT/GoModel/](https://github.com/ENTERPILOT/GoModel/)
 
+## Code Review
+
+Greptile and CodeRabbit review new PRs automatically. Monitor CI and the review
+comments; verify each finding and address the valid ones before merging. Some
+findings appear only in the review summary under headings like "Comments
+Outside Diff" — Greptile updates its main comment in place after every push, so
+re-read it after each change.
+
+
 ## Configuration Reference
 
 Full reference: `.env.template` and `config/config.example.yaml`


### PR DESCRIPTION
Adds a short code-review note to AGENTS.md and CLAUDE.md: PRs are reviewed automatically by Greptile and CodeRabbit — monitor CI and the comments and address valid findings before merging, including findings that appear only in review summaries under headings like "Comments Outside Diff" (Greptile edits its main comment in place on every push).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance for monitoring automated code reviews.
  * Clarified how to verify findings, address valid issues, and review updated feedback after each push.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->