### PR TITLE
feat(models): filter provider inventory by glob pattern and price cap

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -216,7 +216,8 @@
 # INCLUDE keeps only matching models; EXCLUDE then drops matching models.
 # MAX_PRICE_PER_MTOK caps a model's highest per-million-token rate (the larger of
 # input and output). A model with no known price is dropped while the cap is set.
-# The cap must be a finite number of 0 or more; anything else fails startup.
+# The cap must be a finite number of 0 or more; anything else (including a value
+# that is not a number at all) fails startup rather than leaving the cap unset.
 # Set per provider: <PROVIDER>[_SUFFIX]_MODEL_FILTER_INCLUDE, ..._EXCLUDE, ..._MAX_PRICE_PER_MTOK
 # OPENROUTER_MODEL_FILTER_INCLUDE=*:free
 # OPENROUTER_MODEL_FILTER_EXCLUDE=*-preview:free

--- a/.env.template
+++ b/.env.template
@@ -216,6 +216,7 @@
 # INCLUDE keeps only matching models; EXCLUDE then drops matching models.
 # MAX_PRICE_PER_MTOK caps a model's highest per-million-token rate (the larger of
 # input and output). A model with no known price is dropped while the cap is set.
+# The cap must be a finite number of 0 or more; anything else fails startup.
 # Set per provider: <PROVIDER>[_SUFFIX]_MODEL_FILTER_INCLUDE, ..._EXCLUDE, ..._MAX_PRICE_PER_MTOK
 # OPENROUTER_MODEL_FILTER_INCLUDE=*:free
 # OPENROUTER_MODEL_FILTER_EXCLUDE=*-preview:free

--- a/.env.template
+++ b/.env.template
@@ -208,6 +208,19 @@
 # CONFIGURED_PROVIDER_MODELS_MODE=fallback
 # Examples: OPENROUTER_MODELS=..., OPENROUTER_EU_MODELS=..., AZURE_MODELS=..., VLLM_MODELS=...
 
+# Narrow a provider's model inventory to what you actually want routable. Applied
+# to the final inventory, so it also narrows models added by <PROVIDER>_MODELS.
+# Patterns are comma-separated globs matched case-insensitively against the raw
+# model ID: `*` matches any run of characters (including `/`, so `*:free` matches
+# `deepseek/deepseek-r1:free`) and `?` matches exactly one.
+# INCLUDE keeps only matching models; EXCLUDE then drops matching models.
+# MAX_PRICE_PER_MTOK caps a model's highest per-million-token rate (the larger of
+# input and output). A model with no known price is dropped while the cap is set.
+# Set per provider: <PROVIDER>[_SUFFIX]_MODEL_FILTER_INCLUDE, ..._EXCLUDE, ..._MAX_PRICE_PER_MTOK
+# OPENROUTER_MODEL_FILTER_INCLUDE=*:free
+# OPENROUTER_MODEL_FILTER_EXCLUDE=*-preview:free
+# OPENROUTER_MODEL_FILTER_MAX_PRICE_PER_MTOK=0
+
 # Virtual models as infrastructure-as-code (JSON array). Declares redirects, load
 # balancers, and access policies; overrides admin-store rows with the same source
 # and is read-only in the dashboard. The same entries can be declared under
@@ -520,6 +533,8 @@
 # OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 # Optional configured model list; see CONFIGURED_PROVIDER_MODELS_MODE below
 # OPENROUTER_MODELS=openai/gpt-oss-120b,anthropic/claude-sonnet-4
+# Free models only; see <PROVIDER>_MODEL_FILTER_* above
+# OPENROUTER_MODEL_FILTER_INCLUDE=*:free
 # OPENROUTER_SITE_URL=https://gomodel.enterpilot.io
 # OPENROUTER_APP_NAME=GoModel
 

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -518,7 +518,8 @@ providers:
   #     include: ["*:free"]         # keep only these models (empty keeps all)
   #     exclude: ["*-preview:free"] # then drop these
   #     # Cap the highest per-million-token rate (the larger of input and output).
-  #     # A model with no known price is dropped while a cap is set.
+  #     # A model with no known price is dropped while a cap is set. Must be a
+  #     # finite number of 0 or more.
   #     max_price_per_mtok: 0
 
   # Example: Kilo AI Gateway. Model IDs use provider/model and are forwarded

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -511,6 +511,15 @@ providers:
   #   models:
   #     - openai/gpt-oss-120b
   #     - anthropic/claude-sonnet-4
+  #   # Narrow the inventory to what should be routable. Patterns are globs
+  #   # matched case-insensitively against the raw model ID; `*` also matches `/`,
+  #   # so `*:free` matches `deepseek/deepseek-r1:free`.
+  #   model_filter:
+  #     include: ["*:free"]         # keep only these models (empty keeps all)
+  #     exclude: ["*-preview:free"] # then drop these
+  #     # Cap the highest per-million-token rate (the larger of input and output).
+  #     # A model with no known price is dropped while a cap is set.
+  #     max_price_per_mtok: 0
 
   # Example: Kilo AI Gateway. Model IDs use provider/model and are forwarded
   # unchanged. You can also set KILO_MODELS as a comma-separated env var.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"math"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -25,6 +26,7 @@ func clearProviderEnvVars(t *testing.T) {
 		"XAI_API_KEY", "XAI_BASE_URL", "XAI_MODELS",
 		"GROQ_API_KEY", "GROQ_BASE_URL", "GROQ_MODELS",
 		"OPENROUTER_API_KEY", "OPENROUTER_BASE_URL", "OPENROUTER_MODELS", "OPENROUTER_SITE_URL", "OPENROUTER_APP_NAME",
+		"OPENROUTER_MODEL_FILTER_INCLUDE", "OPENROUTER_MODEL_FILTER_EXCLUDE", "OPENROUTER_MODEL_FILTER_MAX_PRICE_PER_MTOK",
 		"KILO_API_KEY", "KILO_BASE_URL", "KILO_MODELS",
 		"ZAI_API_KEY", "ZAI_BASE_URL", "ZAI_MODELS",
 		"AZURE_API_KEY", "AZURE_BASE_URL", "AZURE_API_VERSION", "AZURE_MODELS",
@@ -2115,6 +2117,36 @@ func TestModelFilterEmptyAndNormalize(t *testing.T) {
 				if strings.TrimSpace(pattern) == "" {
 					t.Errorf("Normalize() kept a blank pattern in %+v", normalized)
 				}
+			}
+		})
+	}
+}
+
+// A cap that cannot express a real limit must fail loudly: NaN rejects every
+// model, +Inf disables the cap, and a negative cap can never be met.
+func TestModelFilterValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cap     *float64
+		wantErr bool
+	}{
+		{name: "unset", cap: nil},
+		{name: "zero", cap: new(0.0)},
+		{name: "positive", cap: new(1.5)},
+		{name: "negative", cap: new(-1.0), wantErr: true},
+		{name: "NaN", cap: new(math.NaN()), wantErr: true},
+		{name: "positive infinity", cap: new(math.Inf(1)), wantErr: true},
+		{name: "negative infinity", cap: new(math.Inf(-1)), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ModelFilter{MaxPricePerMtok: tt.cap}.Validate("providers.openrouter.model_filter")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil && !strings.Contains(err.Error(), "providers.openrouter.model_filter.max_price_per_mtok") {
+				t.Errorf("error = %q, want it to name the offending field", err)
 			}
 		})
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2049,3 +2049,73 @@ func TestParseBodySizeLimitBytes(t *testing.T) {
 		})
 	}
 }
+
+func TestLoad_ProviderModelFilterFromYAML(t *testing.T) {
+	clearAllConfigEnvVars(t)
+
+	withTempDir(t, func(dir string) {
+		yaml := `
+providers:
+  openrouter:
+    type: openrouter
+    api_key: "sk-yaml-key"
+    model_filter:
+      include:
+        - "*:free"
+      exclude:
+        - "*-preview:free"
+      max_price_per_mtok: 0
+`
+		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(yaml), 0644); err != nil {
+			t.Fatalf("Failed to write config.yaml: %v", err)
+		}
+
+		result, err := Load()
+		if err != nil {
+			t.Fatalf("Load() failed: %v", err)
+		}
+
+		filter := result.RawProviders["openrouter"].ModelFilter
+		if len(filter.Include) != 1 || filter.Include[0] != "*:free" {
+			t.Errorf("Include = %v, want [*:free]", filter.Include)
+		}
+		if len(filter.Exclude) != 1 || filter.Exclude[0] != "*-preview:free" {
+			t.Errorf("Exclude = %v, want [*-preview:free]", filter.Exclude)
+		}
+		if filter.MaxPricePerMtok == nil || *filter.MaxPricePerMtok != 0 {
+			t.Errorf("MaxPricePerMtok = %v, want 0", filter.MaxPricePerMtok)
+		}
+		if filter.Empty() {
+			t.Error("Empty() = true, want false for a declared filter")
+		}
+	})
+}
+
+func TestModelFilterEmptyAndNormalize(t *testing.T) {
+	tests := []struct {
+		name      string
+		filter    ModelFilter
+		wantEmpty bool
+	}{
+		{name: "zero value", filter: ModelFilter{}, wantEmpty: true},
+		{name: "blank patterns only", filter: ModelFilter{Include: []string{" ", ""}}, wantEmpty: true},
+		{name: "include", filter: ModelFilter{Include: []string{"*:free"}}, wantEmpty: false},
+		{name: "exclude", filter: ModelFilter{Exclude: []string{"*-preview"}}, wantEmpty: false},
+		// A zero cap means "free models only", not "no cap configured".
+		{name: "zero price cap", filter: ModelFilter{MaxPricePerMtok: new(float64)}, wantEmpty: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.filter.Empty(); got != tt.wantEmpty {
+				t.Errorf("Empty() = %v, want %v", got, tt.wantEmpty)
+			}
+			normalized := tt.filter.Normalize()
+			for _, pattern := range append(normalized.Include, normalized.Exclude...) {
+				if strings.TrimSpace(pattern) == "" {
+					t.Errorf("Normalize() kept a blank pattern in %+v", normalized)
+				}
+			}
+		})
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -17,7 +17,7 @@ import (
 // clearProviderEnvVars unsets all known provider-related environment variables.
 func clearProviderEnvVars(t *testing.T) {
 	t.Helper()
-	for _, key := range []string{
+	keys := []string{
 		"OPENAI_API_KEY", "OPENAI_BASE_URL", "OPENAI_MODELS",
 		"ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_MODELS",
 		"COHERE_API_KEY", "COHERE_BASE_URL", "COHERE_MODELS",
@@ -26,7 +26,6 @@ func clearProviderEnvVars(t *testing.T) {
 		"XAI_API_KEY", "XAI_BASE_URL", "XAI_MODELS",
 		"GROQ_API_KEY", "GROQ_BASE_URL", "GROQ_MODELS",
 		"OPENROUTER_API_KEY", "OPENROUTER_BASE_URL", "OPENROUTER_MODELS", "OPENROUTER_SITE_URL", "OPENROUTER_APP_NAME",
-		"OPENROUTER_MODEL_FILTER_INCLUDE", "OPENROUTER_MODEL_FILTER_EXCLUDE", "OPENROUTER_MODEL_FILTER_MAX_PRICE_PER_MTOK",
 		"KILO_API_KEY", "KILO_BASE_URL", "KILO_MODELS",
 		"ZAI_API_KEY", "ZAI_BASE_URL", "ZAI_MODELS",
 		"AZURE_API_KEY", "AZURE_BASE_URL", "AZURE_API_VERSION", "AZURE_MODELS",
@@ -35,7 +34,23 @@ func clearProviderEnvVars(t *testing.T) {
 		"LLMD_API_KEY", "LLMD_BASE_URL", "LLMD_MODELS", "LLMD_INFERENCE_OBJECTIVE", "LLMD_FAIRNESS_FROM_USER_PATH",
 		"SGLANG_API_KEY", "SGLANG_BASE_URL", "SGLANG_MODELS",
 		"OLLAMA_API_KEY", "OLLAMA_BASE_URL", "OLLAMA_MODELS",
-	} {
+	}
+	// Model filters are accepted for every provider prefix, so clear them for
+	// each prefix above rather than tracking them provider by provider.
+	prefixes := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		if prefix, _, ok := strings.Cut(key, "_"); ok {
+			prefixes[prefix] = struct{}{}
+		}
+	}
+	for prefix := range prefixes {
+		keys = append(keys,
+			prefix+"_MODEL_FILTER_INCLUDE",
+			prefix+"_MODEL_FILTER_EXCLUDE",
+			prefix+"_MODEL_FILTER_MAX_PRICE_PER_MTOK",
+		)
+	}
+	for _, key := range keys {
 		t.Setenv(key, "")
 		os.Unsetenv(key)
 	}

--- a/config/model_filter.go
+++ b/config/model_filter.go
@@ -1,6 +1,10 @@
 package config
 
-import "strings"
+import (
+	"fmt"
+	"math"
+	"strings"
+)
 
 // ModelFilter narrows a provider's discovered model inventory. It is declared
 // under providers.<name>.model_filter and applied after metadata enrichment, so
@@ -26,6 +30,21 @@ type ModelFilter struct {
 	// dropped while the cap is set: a price cap that lets unpriced models
 	// through is not a cap. Nil disables price filtering.
 	MaxPricePerMtok *float64 `yaml:"max_price_per_mtok"`
+}
+
+// Validate rejects a price cap that cannot express a real limit. NaN silently
+// rejects every model, +Inf silently disables the cap, and a negative cap can
+// never be met — each turns a cost control into something other than what was
+// written, so they fail startup rather than mislead.
+func (f ModelFilter) Validate(field string) error {
+	if f.MaxPricePerMtok == nil {
+		return nil
+	}
+	limit := *f.MaxPricePerMtok
+	if math.IsNaN(limit) || math.IsInf(limit, 0) || limit < 0 {
+		return fmt.Errorf("%s.max_price_per_mtok must be a finite number of 0 or more", field)
+	}
+	return nil
 }
 
 // Normalize trims patterns and drops empty ones.

--- a/config/model_filter.go
+++ b/config/model_filter.go
@@ -1,0 +1,61 @@
+package config
+
+import "strings"
+
+// ModelFilter narrows a provider's discovered model inventory. It is declared
+// under providers.<name>.model_filter and applied after metadata enrichment, so
+// price rules see both registry pricing and whatever the provider reported.
+//
+//	providers:
+//	  openrouter:
+//	    model_filter:
+//	      include: ["*:free"]      # keep only matching models
+//	      exclude: ["*-preview"]   # then drop matching models
+//	      max_price_per_mtok: 0    # drop models priced above the cap
+//
+// Patterns are globs matched case-insensitively against the raw provider model
+// ID: `*` matches any run of characters (including `/`, unlike shell globs, so
+// `*:free` matches `deepseek/deepseek-r1:free`) and `?` matches exactly one.
+type ModelFilter struct {
+	// Include keeps only models matching at least one pattern. Empty keeps all.
+	Include []string `yaml:"include"`
+	// Exclude drops models matching any pattern. It is applied after Include.
+	Exclude []string `yaml:"exclude"`
+	// MaxPricePerMtok caps a model's highest per-million-token rate — the
+	// larger of its input and output rate. A model with no known pricing is
+	// dropped while the cap is set: a price cap that lets unpriced models
+	// through is not a cap. Nil disables price filtering.
+	MaxPricePerMtok *float64 `yaml:"max_price_per_mtok"`
+}
+
+// Normalize trims patterns and drops empty ones.
+func (f ModelFilter) Normalize() ModelFilter {
+	return ModelFilter{
+		Include:         normalizeModelFilterPatterns(f.Include),
+		Exclude:         normalizeModelFilterPatterns(f.Exclude),
+		MaxPricePerMtok: f.MaxPricePerMtok,
+	}
+}
+
+// Empty reports whether the filter would keep every model.
+func (f ModelFilter) Empty() bool {
+	return len(normalizeModelFilterPatterns(f.Include)) == 0 &&
+		len(normalizeModelFilterPatterns(f.Exclude)) == 0 &&
+		f.MaxPricePerMtok == nil
+}
+
+func normalizeModelFilterPatterns(patterns []string) []string {
+	if len(patterns) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(patterns))
+	for _, pattern := range patterns {
+		if pattern = strings.TrimSpace(pattern); pattern != "" {
+			out = append(out, pattern)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/config/providers.go
+++ b/config/providers.go
@@ -31,7 +31,11 @@ type RawProviderConfig struct {
 	// FairnessFromUserPath controls whether the llmd provider derives its
 	// fairness ID from GoModel's effective (authenticated) user path. It
 	// defaults to true; nil preserves that default.
-	FairnessFromUserPath *bool                `yaml:"fairness_from_user_path"`
-	Models               []RawProviderModel   `yaml:"models"`
-	Resilience           *RawResilienceConfig `yaml:"resilience"`
+	FairnessFromUserPath *bool              `yaml:"fairness_from_user_path"`
+	Models               []RawProviderModel `yaml:"models"`
+	// ModelFilter narrows the provider's model inventory to the models that
+	// match its patterns and price cap. It applies to the final inventory, so
+	// it also narrows models added by `models` in merge or allowlist mode.
+	ModelFilter ModelFilter          `yaml:"model_filter"`
+	Resilience  *RawResilienceConfig `yaml:"resilience"`
 }

--- a/docs/advanced/config-yaml.mdx
+++ b/docs/advanced/config-yaml.mdx
@@ -45,6 +45,59 @@ configured models for providers that define a list and skip their upstream
 inventory — useful for models a provider serves but does not include in its
 `/models` listing.
 
+## Filtering a provider's models
+
+`model_filter` narrows a provider's inventory to the models you actually want
+routable. Use it when a provider's catalog is far larger than what you want to
+expose — for example running OpenRouter's free tier for experiments while a
+separate provider serves production traffic.
+
+```yaml
+providers:
+  openrouter:
+    type: openrouter
+    api_key: "${OPENROUTER_API_KEY}"
+    model_filter:
+      include: ["*:free"]
+      exclude: ["*-preview:free"]
+      max_price_per_mtok: 0
+```
+
+| Field | Default | Behavior |
+| --- | --- | --- |
+| `include` | empty (keep all) | Keeps only models matching at least one pattern. |
+| `exclude` | empty | Drops models matching any pattern. Applied after `include`. |
+| `max_price_per_mtok` | unset (no cap) | Drops models whose highest per-million-token rate — the larger of input and output — is above the cap. |
+
+Patterns are globs matched case-insensitively against the raw provider model ID.
+`*` matches any run of characters **including `/`**, so `*:free` matches
+`deepseek/deepseek-r1:free`; `?` matches exactly one character.
+
+A model with no known pricing is dropped while `max_price_per_mtok` is set: a
+price cap that lets models of unknown price through is not a cap. Prices come
+from the model registry and from what the provider itself reports — OpenRouter
+publishes its own rates, so its catalog (`:free` variants included) is priced
+without extra configuration. Local providers usually report no pricing at all,
+so filter those by pattern rather than by price.
+
+Filtering applies to the final inventory, after
+`configured_provider_models_mode` has resolved, so it also narrows models added
+by `models`. Filtered models leave the catalog entirely: they disappear from
+`GET /v1/models` and requests for them return "model not found".
+
+The same filters are available per provider in env:
+
+```bash
+OPENROUTER_MODEL_FILTER_INCLUDE="*:free"
+OPENROUTER_MODEL_FILTER_EXCLUDE="*-preview:free"
+OPENROUTER_MODEL_FILTER_MAX_PRICE_PER_MTOK=0
+```
+
+Each rule overlays independently, so an env price cap narrows a YAML pattern
+filter without restating the patterns. Suffixed instances use the same rule as
+other provider env vars: `OPENROUTER_EU_MODEL_FILTER_INCLUDE` configures
+`openrouter-eu`.
+
 ## Priority Order
 
 Effective precedence is:

--- a/docs/advanced/config-yaml.mdx
+++ b/docs/advanced/config-yaml.mdx
@@ -82,7 +82,8 @@ so filter those by pattern rather than by price.
 
 `max_price_per_mtok` must be a finite number of 0 or more. A negative, `NaN`, or
 infinite cap fails startup rather than silently rejecting every model or
-disabling the cap.
+disabling the cap, and so does an env value that is not a number at all — a cost
+control the operator believes is in force must never be quietly absent.
 
 Filtering applies to the final inventory, after
 `configured_provider_models_mode` has resolved, so it also narrows models added

--- a/docs/advanced/config-yaml.mdx
+++ b/docs/advanced/config-yaml.mdx
@@ -80,10 +80,19 @@ publishes its own rates, so its catalog (`:free` variants included) is priced
 without extra configuration. Local providers usually report no pricing at all,
 so filter those by pattern rather than by price.
 
+`max_price_per_mtok` must be a finite number of 0 or more. A negative, `NaN`, or
+infinite cap fails startup rather than silently rejecting every model or
+disabling the cap.
+
 Filtering applies to the final inventory, after
 `configured_provider_models_mode` has resolved, so it also narrows models added
-by `models`. Filtered models leave the catalog entirely: they disappear from
-`GET /v1/models` and requests for them return "model not found".
+by `models`. Filtered models leave the routable catalog entirely: they disappear
+from `GET /v1/models` and requests for them return "model not found".
+
+Filtering is a view over what a provider serves, not a deletion. The gateway
+keeps the unfiltered inventory in memory and in its model cache, so loosening a
+filter — or a model becoming cheap enough to pass the cap — restores it at the
+next metadata refresh, without waiting for a successful upstream `/models` call.
 
 The same filters are available per provider in env:
 

--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -324,6 +324,12 @@ providers that define a list and skip their upstream `/models` calls. YAML
 `providers.<name>.models` provides the same model-list input for named provider
 blocks.
 
+To narrow a provider's inventory instead of listing it model by model, use
+`<PROVIDER>_MODEL_FILTER_INCLUDE`, `<PROVIDER>_MODEL_FILTER_EXCLUDE`, and
+`<PROVIDER>_MODEL_FILTER_MAX_PRICE_PER_MTOK` (YAML:
+`providers.<name>.model_filter`). See
+[Filtering a provider's models](/advanced/config-yaml#filtering-a-providers-models).
+
 For OpenRouter, GoModel also sends default attribution headers unless the request already sets them. Override those defaults with `OPENROUTER_SITE_URL` and `OPENROUTER_APP_NAME`.
 
 ### 2. `.env` File

--- a/docs/providers/overview.mdx
+++ b/docs/providers/overview.mdx
@@ -163,6 +163,11 @@ support, not every individual model capability exposed by an upstream provider.
   `/models` is unavailable or empty. Set
   `CONFIGURED_PROVIDER_MODELS_MODE=allowlist` to expose only configured models
   for providers that define a list, skipping their upstream `/models` calls.
+- **Model filters** — narrow a large catalog by glob pattern or price instead of
+  listing models one by one: `OPENROUTER_MODEL_FILTER_INCLUDE=*:free` keeps only
+  OpenRouter's free tier, and `<PROVIDER>_MODEL_FILTER_MAX_PRICE_PER_MTOK` caps
+  what a provider may route to. See
+  [Filtering a provider's models](/advanced/config-yaml#filtering-a-providers-models).
 - **Model categories (chat vs embeddings vs audio)** — a model's category comes
   from its `modes`, resolved from four sources in precedence order: the remote
   model registry, operator metadata declared under `providers.<name>.models` in

--- a/internal/providers/config.go
+++ b/internal/providers/config.go
@@ -48,7 +48,10 @@ type ProviderConfig struct {
 	// these onto remote-registry metadata after enrichment; non-zero fields here
 	// win. Empty/nil when no per-model metadata is declared in YAML.
 	ModelMetadataOverrides map[string]*core.ModelMetadata
-	Resilience             config.ResilienceConfig
+	// ModelFilter narrows the provider's discovered inventory by glob pattern
+	// and price cap. Zero value keeps every model.
+	ModelFilter config.ModelFilter
+	Resilience  config.ResilienceConfig
 }
 
 // resolveProviders applies env var overrides to the raw YAML provider map, filters
@@ -151,6 +154,9 @@ const (
 	providerEnvFieldSessionStickyKeys
 	providerEnvFieldInferenceObjective
 	providerEnvFieldFairnessFromUserPath
+	providerEnvFieldModelFilterInclude
+	providerEnvFieldModelFilterExclude
+	providerEnvFieldModelFilterMaxPrice
 )
 
 type providerEnvSource struct {
@@ -179,8 +185,20 @@ type providerEnvValues struct {
 	GCPScope                 string
 	InferenceObjective       string
 	Models                   []string
+	ModelFilterInclude       []string
+	ModelFilterExclude       []string
+	ModelFilterMaxPrice      *float64
 	SessionStickyKeys        *bool
 	FairnessFromUserPath     *bool
+}
+
+// modelFilter assembles the filter this env group declares.
+func (v providerEnvValues) modelFilter() config.ModelFilter {
+	return config.ModelFilter{
+		Include:         v.ModelFilterInclude,
+		Exclude:         v.ModelFilterExclude,
+		MaxPricePerMtok: v.ModelFilterMaxPrice,
+	}
 }
 
 // apiKeys returns the ordered key set this env group declares: the unsuffixed
@@ -249,7 +267,8 @@ func (v providerEnvValues) empty() bool {
 		strings.TrimSpace(v.InferenceObjective) == "" &&
 		v.SessionStickyKeys == nil &&
 		v.FairnessFromUserPath == nil &&
-		len(v.Models) == 0
+		len(v.Models) == 0 &&
+		v.modelFilter().Empty()
 }
 
 func providerEnvSources(providerType string, spec DiscoveryConfig) []providerEnvSource {
@@ -297,6 +316,14 @@ func collectProviderEnvValues(prefix string, spec DiscoveryConfig, environ []str
 			values.APIVersion = value
 		case providerEnvFieldModels:
 			values.Models = parseCSVEnvList(value)
+		case providerEnvFieldModelFilterInclude:
+			values.ModelFilterInclude = parseCSVEnvList(value)
+		case providerEnvFieldModelFilterExclude:
+			values.ModelFilterExclude = parseCSVEnvList(value)
+		case providerEnvFieldModelFilterMaxPrice:
+			if parsed, err := strconv.ParseFloat(strings.TrimSpace(value), 64); err == nil {
+				values.ModelFilterMaxPrice = &parsed
+			}
 		case providerEnvFieldBackend:
 			values.Backend = value
 		case providerEnvFieldAuthType:
@@ -377,6 +404,9 @@ func parseProviderEnvKey(prefix, key string, spec DiscoveryConfig) (string, prov
 		{name: "API_MODE", field: providerEnvFieldAPIMode},
 		{name: "BACKEND", field: providerEnvFieldBackend},
 		{name: "API_KEY", field: providerEnvFieldAPIKey},
+		{name: "MODEL_FILTER_MAX_PRICE_PER_MTOK", field: providerEnvFieldModelFilterMaxPrice},
+		{name: "MODEL_FILTER_INCLUDE", field: providerEnvFieldModelFilterInclude},
+		{name: "MODEL_FILTER_EXCLUDE", field: providerEnvFieldModelFilterExclude},
 		{name: "MODELS", field: providerEnvFieldModels},
 	}
 	if strings.EqualFold(prefix, "VERTEX") {
@@ -546,6 +576,7 @@ func (v providerEnvValues) rawConfig(providerType string, spec DiscoveryConfig) 
 		InferenceObjective:       v.InferenceObjective,
 		FairnessFromUserPath:     v.FairnessFromUserPath,
 		Models:                   rawProviderModelsFromIDs(v.Models),
+		ModelFilter:              v.modelFilter(),
 		SessionStickyKeys:        v.SessionStickyKeys,
 	}
 }
@@ -612,6 +643,17 @@ func overlayProviderEnvValues(existing config.RawProviderConfig, values provider
 	}
 	if len(values.Models) > 0 {
 		existing.Models = rawProviderModelsFromIDs(values.Models)
+	}
+	// Each filter rule overlays independently, so an env price cap can narrow a
+	// YAML pattern filter (and vice versa) without restating the other rule.
+	if len(values.ModelFilterInclude) > 0 {
+		existing.ModelFilter.Include = values.ModelFilterInclude
+	}
+	if len(values.ModelFilterExclude) > 0 {
+		existing.ModelFilter.Exclude = values.ModelFilterExclude
+	}
+	if values.ModelFilterMaxPrice != nil {
+		existing.ModelFilter.MaxPricePerMtok = values.ModelFilterMaxPrice
 	}
 	return existing
 }
@@ -880,6 +922,7 @@ func buildProviderConfig(raw config.RawProviderConfig, global config.ResilienceC
 		GCPScope:                 raw.GCPScope,
 		Models:                   config.ProviderModelIDs(raw.Models),
 		ModelMetadataOverrides:   config.ProviderModelMetadataOverrides(raw.Models),
+		ModelFilter:              raw.ModelFilter.Normalize(),
 		Resilience:               global,
 	}
 	if resolved.Type == "llmd" {

--- a/internal/providers/config.go
+++ b/internal/providers/config.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"maps"
+	"math"
 	"os"
 	"sort"
 	"strconv"
@@ -321,9 +322,15 @@ func collectProviderEnvValues(prefix string, spec DiscoveryConfig, environ []str
 		case providerEnvFieldModelFilterExclude:
 			values.ModelFilterExclude = parseCSVEnvList(value)
 		case providerEnvFieldModelFilterMaxPrice:
-			if parsed, err := strconv.ParseFloat(strings.TrimSpace(value), 64); err == nil {
-				values.ModelFilterMaxPrice = &parsed
+			parsed, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+			if err != nil {
+				// A price cap is a cost control: a malformed value must fail
+				// validation, not quietly leave the cap unset and let every
+				// model through. NaN carries "not a number" to the validator,
+				// which rejects it the same way it rejects a literal NaN.
+				parsed = math.NaN()
 			}
+			values.ModelFilterMaxPrice = &parsed
 		case providerEnvFieldBackend:
 			values.Backend = value
 		case providerEnvFieldAuthType:

--- a/internal/providers/config_test.go
+++ b/internal/providers/config_test.go
@@ -1955,3 +1955,74 @@ func TestBuildProviderConfig_Hetzner_ResolvesBaseURL(t *testing.T) {
 		t.Errorf("BaseURL = %q, want %q", p.BaseURL, testDiscoveryConfigs["hetzner"].DefaultBaseURL)
 	}
 }
+
+func TestApplyProviderEnvVars_ModelFilter(t *testing.T) {
+	t.Setenv("OPENROUTER_API_KEY", "sk-openrouter")
+	t.Setenv("OPENROUTER_MODEL_FILTER_INCLUDE", "*:free, *:nitro")
+	t.Setenv("OPENROUTER_MODEL_FILTER_EXCLUDE", "*-preview:free")
+	t.Setenv("OPENROUTER_MODEL_FILTER_MAX_PRICE_PER_MTOK", "0")
+
+	got := applyProviderEnvVars(map[string]config.RawProviderConfig{}, testDiscoveryConfigs)
+
+	p, exists := got["openrouter"]
+	if !exists {
+		t.Fatal("expected openrouter to be discovered from env var")
+	}
+	if want := []string{"*:free", "*:nitro"}; !slices.Equal(p.ModelFilter.Include, want) {
+		t.Errorf("Include = %v, want %v", p.ModelFilter.Include, want)
+	}
+	if want := []string{"*-preview:free"}; !slices.Equal(p.ModelFilter.Exclude, want) {
+		t.Errorf("Exclude = %v, want %v", p.ModelFilter.Exclude, want)
+	}
+	if p.ModelFilter.MaxPricePerMtok == nil || *p.ModelFilter.MaxPricePerMtok != 0 {
+		t.Errorf("MaxPricePerMtok = %v, want 0", p.ModelFilter.MaxPricePerMtok)
+	}
+}
+
+// Each filter rule overlays independently so an env price cap can narrow a YAML
+// pattern filter without restating it.
+func TestApplyProviderEnvVars_ModelFilterOverlaysYAMLPerRule(t *testing.T) {
+	t.Setenv("OPENROUTER_MODEL_FILTER_MAX_PRICE_PER_MTOK", "0.5")
+
+	raw := map[string]config.RawProviderConfig{
+		"openrouter": {
+			Type:        "openrouter",
+			APIKey:      "sk-yaml",
+			ModelFilter: config.ModelFilter{Include: []string{"qwen/*"}},
+		},
+	}
+	got := applyProviderEnvVars(raw, testDiscoveryConfigs)
+
+	filter := got["openrouter"].ModelFilter
+	if want := []string{"qwen/*"}; !slices.Equal(filter.Include, want) {
+		t.Errorf("Include = %v, want %v preserved from YAML", filter.Include, want)
+	}
+	if filter.MaxPricePerMtok == nil || *filter.MaxPricePerMtok != 0.5 {
+		t.Errorf("MaxPricePerMtok = %v, want 0.5 from env", filter.MaxPricePerMtok)
+	}
+}
+
+// An unparseable cap must not resolve to a silent zero, which would hide every
+// paid model instead of applying no cap at all.
+func TestApplyProviderEnvVars_ModelFilterIgnoresInvalidPrice(t *testing.T) {
+	t.Setenv("OPENROUTER_API_KEY", "sk-openrouter")
+	t.Setenv("OPENROUTER_MODEL_FILTER_MAX_PRICE_PER_MTOK", "cheap")
+
+	got := applyProviderEnvVars(map[string]config.RawProviderConfig{}, testDiscoveryConfigs)
+
+	if cap := got["openrouter"].ModelFilter.MaxPricePerMtok; cap != nil {
+		t.Errorf("MaxPricePerMtok = %v, want nil", *cap)
+	}
+}
+
+func TestBuildProviderConfig_NormalizesModelFilter(t *testing.T) {
+	resolved := buildProviderConfig(config.RawProviderConfig{
+		Type:        "openrouter",
+		APIKey:      "sk-openrouter",
+		ModelFilter: config.ModelFilter{Include: []string{" *:free ", "", "  "}},
+	}, globalResilience)
+
+	if want := []string{"*:free"}; !slices.Equal(resolved.ModelFilter.Include, want) {
+		t.Errorf("Include = %v, want %v", resolved.ModelFilter.Include, want)
+	}
+}

--- a/internal/providers/config_test.go
+++ b/internal/providers/config_test.go
@@ -2004,16 +2004,42 @@ func TestApplyProviderEnvVars_ModelFilterOverlaysYAMLPerRule(t *testing.T) {
 	}
 }
 
-// An unparseable cap must not resolve to a silent zero, which would hide every
-// paid model instead of applying no cap at all.
-func TestApplyProviderEnvVars_ModelFilterIgnoresInvalidPrice(t *testing.T) {
+// A malformed cap must not resolve to a silent zero (hiding every paid model)
+// nor to an absent cap (routing above the operator's intended limit). It is
+// carried through as NaN so startup validation rejects it.
+func TestApplyProviderEnvVars_ModelFilterRejectsMalformedPrice(t *testing.T) {
 	t.Setenv("OPENROUTER_API_KEY", "sk-openrouter")
 	t.Setenv("OPENROUTER_MODEL_FILTER_MAX_PRICE_PER_MTOK", "cheap")
 
 	got := applyProviderEnvVars(map[string]config.RawProviderConfig{}, testDiscoveryConfigs)
 
-	if cap := got["openrouter"].ModelFilter.MaxPricePerMtok; cap != nil {
-		t.Errorf("MaxPricePerMtok = %v, want nil", *cap)
+	limit := got["openrouter"].ModelFilter.MaxPricePerMtok
+	if limit == nil || !math.IsNaN(*limit) {
+		t.Fatalf("MaxPricePerMtok = %v, want NaN so validation rejects it", limit)
+	}
+	if err := got["openrouter"].ModelFilter.Validate("providers.openrouter.model_filter"); err == nil {
+		t.Error("Validate() = nil, want an error for a malformed price cap")
+	}
+}
+
+// The malformed value must survive the whole resolution path, not just the env
+// parser: a cost cap that vanishes between parsing and validation is worse than
+// no cap, because the operator believes one is in force.
+func TestResolveProviders_RejectsMalformedModelFilterPrice(t *testing.T) {
+	t.Setenv("OPENROUTER_API_KEY", "sk-openrouter")
+	t.Setenv("OPENROUTER_MODEL_FILTER_MAX_PRICE_PER_MTOK", "cheap")
+
+	resolved, _ := resolveProviders(map[string]config.RawProviderConfig{}, globalResilience, testDiscoveryConfigs)
+
+	if _, ok := resolved["openrouter"]; !ok {
+		t.Fatal("openrouter was not resolved, want it present so validation can reject its cap")
+	}
+	err := validateProviderModelFilters(resolved)
+	if err == nil {
+		t.Fatal("validateProviderModelFilters() = nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "providers.openrouter.model_filter.max_price_per_mtok") {
+		t.Errorf("error = %q, want it to name the offending field", err)
 	}
 }
 

--- a/internal/providers/config_test.go
+++ b/internal/providers/config_test.go
@@ -1,7 +1,9 @@
 package providers
 
 import (
+	"math"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -2024,5 +2026,37 @@ func TestBuildProviderConfig_NormalizesModelFilter(t *testing.T) {
 
 	if want := []string{"*:free"}; !slices.Equal(resolved.ModelFilter.Include, want) {
 		t.Errorf("Include = %v, want %v", resolved.ModelFilter.Include, want)
+	}
+}
+
+// A price cap that parses but cannot express a real limit must fail startup:
+// NaN rejects every model, +Inf disables the cap, and a negative cap can never
+// be met. Validation runs after the env overlay, so it covers both sources.
+func TestValidateProviderModelFilters(t *testing.T) {
+	tests := []struct {
+		name    string
+		filter  config.ModelFilter
+		wantErr bool
+	}{
+		{name: "no filter"},
+		{name: "patterns only", filter: config.ModelFilter{Include: []string{"*:free"}}},
+		{name: "zero cap", filter: config.ModelFilter{MaxPricePerMtok: new(0.0)}},
+		{name: "negative cap", filter: config.ModelFilter{MaxPricePerMtok: new(-1.0)}, wantErr: true},
+		{name: "NaN cap", filter: config.ModelFilter{MaxPricePerMtok: new(math.NaN())}, wantErr: true},
+		{name: "infinite cap", filter: config.ModelFilter{MaxPricePerMtok: new(math.Inf(1))}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateProviderModelFilters(map[string]ProviderConfig{
+				"openrouter": {Type: "openrouter", ModelFilter: tt.filter},
+			})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateProviderModelFilters() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil && !strings.Contains(err.Error(), "providers.openrouter.model_filter") {
+				t.Errorf("error = %q, want it to name the offending provider", err)
+			}
+		})
 	}
 }

--- a/internal/providers/credentials.go
+++ b/internal/providers/credentials.go
@@ -344,4 +344,5 @@ func (s *CredentialsService) install(name string, provider core.Provider, cfg Pr
 	if len(cfg.ModelMetadataOverrides) > 0 {
 		s.registry.SetProviderMetadataOverrides(name, cfg.ModelMetadataOverrides)
 	}
+	s.registry.SetProviderModelFilter(name, cfg.ModelFilter)
 }

--- a/internal/providers/init.go
+++ b/internal/providers/init.go
@@ -83,6 +83,12 @@ func Init(ctx context.Context, result *config.LoadResult, factory *ProviderFacto
 	}
 
 	providerMap, credentialResolved := resolveProviders(result.RawProviders, result.Config.Resilience, factory.discoveryConfigsSnapshot())
+	// Validated after the env overlay so one rule covers both sources: a bad
+	// price cap must not start the gateway with a cost control that silently
+	// admits everything.
+	if err := validateProviderModelFilters(providerMap); err != nil {
+		return nil, err
+	}
 	fromFile, fromEnv := providerOrigins(result.RawProviders, providerMap)
 	slog.Info("providers resolved",
 		"total", len(providerMap),
@@ -290,4 +296,21 @@ func initializeProviders(ctx context.Context, providerMap map[string]ProviderCon
 	}
 
 	return count, nil
+}
+
+// validateProviderModelFilters rejects model filters that cannot express what
+// they were configured to express, naming the provider so the operator knows
+// which declaration (or `<PROVIDER>_MODEL_FILTER_*` variable) to fix.
+func validateProviderModelFilters(providerMap map[string]ProviderConfig) error {
+	names := make([]string, 0, len(providerMap))
+	for name := range providerMap {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if err := providerMap[name].ModelFilter.Validate("providers." + name + ".model_filter"); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/providers/init.go
+++ b/internal/providers/init.go
@@ -284,6 +284,7 @@ func initializeProviders(ctx context.Context, providerMap map[string]ProviderCon
 		if len(pCfg.ModelMetadataOverrides) > 0 {
 			registry.SetProviderMetadataOverrides(name, pCfg.ModelMetadataOverrides)
 		}
+		registry.SetProviderModelFilter(name, pCfg.ModelFilter)
 		count++
 		slog.Info("provider registered", "name", name, "type", pCfg.Type)
 	}

--- a/internal/providers/model_filter.go
+++ b/internal/providers/model_filter.go
@@ -1,0 +1,159 @@
+package providers
+
+import (
+	"log/slog"
+	"strings"
+
+	"github.com/enterpilot/gomodel/config"
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+// modelFilter is the resolved form of config.ModelFilter, evaluated against one
+// provider's inventory after metadata enrichment.
+type modelFilter struct {
+	include         []string
+	exclude         []string
+	maxPricePerMtok *float64
+}
+
+// newModelFilter resolves cfg. The second return value is false when the filter
+// would keep every model, so callers can skip storing and evaluating it.
+func newModelFilter(cfg config.ModelFilter) (modelFilter, bool) {
+	normalized := cfg.Normalize()
+	if normalized.Empty() {
+		return modelFilter{}, false
+	}
+	return modelFilter{
+		include:         normalized.Include,
+		exclude:         normalized.Exclude,
+		maxPricePerMtok: normalized.MaxPricePerMtok,
+	}, true
+}
+
+// keep reports whether model survives the filter.
+func (f modelFilter) keep(model core.Model) bool {
+	modelID := strings.TrimSpace(model.ID)
+	if len(f.include) > 0 && !matchesAnyGlob(f.include, modelID) {
+		return false
+	}
+	if matchesAnyGlob(f.exclude, modelID) {
+		return false
+	}
+	if f.maxPricePerMtok == nil {
+		return true
+	}
+	price, priced := modelMaxPricePerMtok(model)
+	// An unpriced model is dropped rather than admitted: a cost cap that lets
+	// models of unknown price through is not a cap.
+	return priced && price <= *f.maxPricePerMtok
+}
+
+// modelMaxPricePerMtok returns a model's highest per-million-token rate — the
+// larger of its input and output rate — and whether it is priced at all. Rates
+// come from the model registry, from the provider's own listing, or from
+// operator metadata overrides, whichever enrichment resolved last.
+func modelMaxPricePerMtok(model core.Model) (float64, bool) {
+	if model.Metadata == nil || model.Metadata.Pricing == nil {
+		return 0, false
+	}
+	pricing := model.Metadata.Pricing
+	price, priced := 0.0, false
+	if pricing.InputPerMtok != nil {
+		price, priced = *pricing.InputPerMtok, true
+	}
+	if pricing.OutputPerMtok != nil && (!priced || *pricing.OutputPerMtok > price) {
+		price, priced = *pricing.OutputPerMtok, true
+	}
+	return price, priced
+}
+
+// filterProviderModelMaps drops the models each provider's filter excludes and
+// returns how many were dropped.
+func (r *ModelRegistry) filterProviderModelMaps(modelsByProvider map[string]map[string]*ModelInfo) int {
+	return filterProviderModelMaps(r.snapshotProviderModelFilters(), modelsByProvider)
+}
+
+// filterProviderModelMaps applies filters to modelsByProvider. It runs after
+// metadata enrichment so price rules see resolved pricing, and it never removes
+// a provider's map: a filter that matches nothing leaves the provider present
+// with an empty inventory rather than looking like a failed refresh.
+func filterProviderModelMaps(filters map[string]modelFilter, modelsByProvider map[string]map[string]*ModelInfo) int {
+	if len(filters) == 0 {
+		return 0
+	}
+
+	dropped := 0
+	for providerName, providerModels := range modelsByProvider {
+		filter, ok := filters[providerName]
+		if !ok || len(providerModels) == 0 {
+			continue
+		}
+		before := len(providerModels)
+		for modelID, info := range providerModels {
+			if info == nil || !filter.keep(info.Model) {
+				delete(providerModels, modelID)
+			}
+		}
+		removed := before - len(providerModels)
+		if removed == 0 {
+			continue
+		}
+		dropped += removed
+		if len(providerModels) == 0 {
+			slog.Warn("model_filter removed every model of a provider",
+				"provider", providerName,
+				"dropped", removed,
+			)
+			continue
+		}
+		slog.Debug("model_filter applied",
+			"provider", providerName,
+			"kept", len(providerModels),
+			"dropped", removed,
+		)
+	}
+	return dropped
+}
+
+// matchesAnyGlob reports whether value matches at least one pattern.
+func matchesAnyGlob(patterns []string, value string) bool {
+	for _, pattern := range patterns {
+		if matchesGlob(pattern, value) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchesGlob reports whether value matches pattern, case-insensitively: `*`
+// matches any run of characters and `?` exactly one. Unlike filepath.Match,
+// `*` also matches `/`, because model IDs are paths ("deepseek/deepseek-r1")
+// rather than file paths and `*:free` must match across the vendor segment.
+func matchesGlob(pattern, value string) bool {
+	p := []rune(strings.ToLower(pattern))
+	v := []rune(strings.ToLower(value))
+
+	// Standard backtracking glob match: on a mismatch, resume at the character
+	// after the last `*` with one more character consumed by it.
+	var pi, vi int
+	star, starMatch := -1, 0
+	for vi < len(v) {
+		switch {
+		case pi < len(p) && (p[pi] == '?' || p[pi] == v[vi]):
+			pi++
+			vi++
+		case pi < len(p) && p[pi] == '*':
+			star, starMatch = pi, vi
+			pi++
+		case star >= 0:
+			starMatch++
+			pi, vi = star+1, starMatch
+		default:
+			return false
+		}
+	}
+	for pi < len(p) && p[pi] == '*' {
+		pi++
+	}
+	return pi == len(p)
+}

--- a/internal/providers/model_filter.go
+++ b/internal/providers/model_filter.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"log/slog"
+	"maps"
 	"strings"
 
 	"github.com/enterpilot/gomodel/config"
@@ -67,10 +68,29 @@ func modelMaxPricePerMtok(model core.Model) (float64, bool) {
 	return price, priced
 }
 
-// filterProviderModelMaps drops the models each provider's filter excludes and
-// returns how many were dropped.
-func (r *ModelRegistry) filterProviderModelMaps(modelsByProvider map[string]map[string]*ModelInfo) int {
-	return filterProviderModelMaps(r.snapshotProviderModelFilters(), modelsByProvider)
+// publishFilteredInventoryLocked rebuilds the routable catalog from the
+// unfiltered inventory by applying each provider's model filter, and returns how
+// many models the filters excluded. Filtering is a view over
+// discoveredByProvider, never a deletion from it: a model a filter rejects today
+// returns as soon as its pricing or the filter changes, and the persisted cache
+// keeps everything the provider actually served.
+//
+// Caller must hold r.mu for writing.
+func (r *ModelRegistry) publishFilteredInventoryLocked() int {
+	published := make(map[string]map[string]*ModelInfo, len(r.discoveredByProvider))
+	for providerName, providerModels := range r.discoveredByProvider {
+		if _, filtered := r.providerModelFilters[providerName]; filtered {
+			// Only a filtered provider needs its own copy; filtering deletes
+			// from the published map and must not touch the inventory.
+			published[providerName] = maps.Clone(providerModels)
+			continue
+		}
+		published[providerName] = providerModels
+	}
+	dropped := filterProviderModelMaps(r.providerModelFilters, published)
+	r.modelsByProvider = published
+	r.models = rebuildGlobalModelMap(published, r.freshFirstProviderOrderLocked())
+	return dropped
 }
 
 // filterProviderModelMaps applies filters to modelsByProvider. It runs after

--- a/internal/providers/model_filter_test.go
+++ b/internal/providers/model_filter_test.go
@@ -2,9 +2,12 @@ package providers
 
 import (
 	"context"
+	"errors"
+	"path/filepath"
 	"testing"
 
 	"github.com/enterpilot/gomodel/config"
+	"github.com/enterpilot/gomodel/internal/cache/modelcache"
 	"github.com/enterpilot/gomodel/internal/core"
 	"github.com/enterpilot/gomodel/internal/modeldata"
 )
@@ -156,48 +159,50 @@ func TestNewModelFilterEmpty(t *testing.T) {
 	}
 }
 
-func TestFilterProviderModelMaps(t *testing.T) {
+func TestPublishFilteredInventory(t *testing.T) {
 	registry := NewModelRegistry()
 	registry.SetProviderModelFilter("openrouter", config.ModelFilter{Include: []string{"*:free"}})
-
-	modelsByProvider := map[string]map[string]*ModelInfo{
+	registry.discoveredByProvider = map[string]map[string]*ModelInfo{
 		"openrouter": {
 			"deepseek/deepseek-r1:free": {Model: core.Model{ID: "deepseek/deepseek-r1:free"}},
 			"openai/gpt-4o":             {Model: core.Model{ID: "openai/gpt-4o"}},
 		},
-		// A provider without a filter keeps its whole inventory.
+		// A provider without a filter publishes its whole inventory.
 		"openai": {
 			"gpt-4o": {Model: core.Model{ID: "gpt-4o"}},
 		},
 	}
 
-	if dropped := registry.filterProviderModelMaps(modelsByProvider); dropped != 1 {
+	if dropped := registry.publishFilteredInventoryLocked(); dropped != 1 {
 		t.Fatalf("dropped = %d, want 1", dropped)
 	}
-	if _, ok := modelsByProvider["openrouter"]["deepseek/deepseek-r1:free"]; !ok {
-		t.Error("free model was dropped, want kept")
+	if _, ok := registry.modelsByProvider["openrouter"]["deepseek/deepseek-r1:free"]; !ok {
+		t.Error("free model was dropped, want published")
 	}
-	if _, ok := modelsByProvider["openrouter"]["openai/gpt-4o"]; ok {
-		t.Error("paid model was kept, want dropped")
+	if _, ok := registry.modelsByProvider["openrouter"]["openai/gpt-4o"]; ok {
+		t.Error("paid model was published, want filtered out")
 	}
-	if len(modelsByProvider["openai"]) != 1 {
-		t.Errorf("unfiltered provider models = %d, want 1", len(modelsByProvider["openai"]))
+	if len(registry.modelsByProvider["openai"]) != 1 {
+		t.Errorf("unfiltered provider models = %d, want 1", len(registry.modelsByProvider["openai"]))
+	}
+	// The inventory itself must not be edited: filtering is a view over it.
+	if len(registry.discoveredByProvider["openrouter"]) != 2 {
+		t.Errorf("inventory models = %d, want 2 retained", len(registry.discoveredByProvider["openrouter"]))
 	}
 }
 
 // A filter that matches nothing must leave the provider present with an empty
-// inventory: dropping the key would read as a failed refresh and resurrect the
-// previous inventory through the carry-forward path.
-func TestFilterProviderModelMapsKeepsEmptiedProvider(t *testing.T) {
+// published inventory: dropping the key would read as a failed refresh and
+// resurrect the previous inventory through the carry-forward path.
+func TestPublishFilteredInventoryKeepsEmptiedProvider(t *testing.T) {
 	registry := NewModelRegistry()
 	registry.SetProviderModelFilter("openrouter", config.ModelFilter{Include: []string{"*:free"}})
-
-	modelsByProvider := map[string]map[string]*ModelInfo{
+	registry.discoveredByProvider = map[string]map[string]*ModelInfo{
 		"openrouter": {"openai/gpt-4o": {Model: core.Model{ID: "openai/gpt-4o"}}},
 	}
-	registry.filterProviderModelMaps(modelsByProvider)
+	registry.publishFilteredInventoryLocked()
 
-	models, ok := modelsByProvider["openrouter"]
+	models, ok := registry.modelsByProvider["openrouter"]
 	if !ok {
 		t.Fatal("provider key was removed, want retained with an empty inventory")
 	}
@@ -253,6 +258,89 @@ func TestInitialize_AppliesProviderModelFilter(t *testing.T) {
 	}
 }
 
+// Filtering is a view, not a deletion: once the model list prices a model back
+// under the cap, it returns to the catalog without waiting for a refetch.
+func TestEnrichModels_ReadmitsModelThatPricesBackUnderCap(t *testing.T) {
+	provider := &registryMockProvider{
+		name: "openrouter",
+		modelsResponse: &core.ModelsResponse{
+			Object: "list",
+			Data:   []core.Model{{ID: "vendor/volatile", Object: "model"}},
+		},
+	}
+
+	registry := NewModelRegistry()
+	registry.RegisterProviderWithNameAndType(provider, "openrouter", "openai")
+	registry.SetProviderModelFilter("openrouter", config.ModelFilter{MaxPricePerMtok: new(1.0)})
+
+	// Unpriced at fetch, so the cap rejects it.
+	if err := registry.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() failed: %v", err)
+	}
+	if registry.GetModel("openrouter/vendor/volatile") != nil {
+		t.Fatal("unpriced model was admitted under a price cap, want dropped")
+	}
+
+	enrich := func(outputPerMtok string) {
+		raw := []byte(`{"version":1,"updated_at":"2025-01-01T00:00:00Z","providers":{},"models":{` +
+			`"vendor/volatile":{"pricing":{"currency":"USD","input_per_mtok":0.1,"output_per_mtok":` + outputPerMtok + `}}` +
+			`},"provider_models":{}}`)
+		list, err := modeldata.Parse(raw)
+		if err != nil {
+			t.Fatalf("Parse: %v", err)
+		}
+		registry.SetModelList(list, raw)
+		registry.EnrichModels()
+	}
+
+	enrich("9")
+	if registry.GetModel("openrouter/vendor/volatile") != nil {
+		t.Fatal("model priced above the cap is in the catalog, want dropped")
+	}
+
+	// The inventory kept the model, so a price drop re-admits it.
+	enrich("0.4")
+	if registry.GetModel("openrouter/vendor/volatile") == nil {
+		t.Error("model priced back under the cap was not re-admitted")
+	}
+	if registry.GetProvider("vendor/volatile") == nil {
+		t.Error("re-admitted model is not routable by bare ID")
+	}
+}
+
+// Clearing a filter must restore the models it was hiding without a refetch.
+func TestSetProviderModelFilter_RepublishesCatalog(t *testing.T) {
+	provider := &registryMockProvider{
+		name: "openrouter",
+		modelsResponse: &core.ModelsResponse{
+			Object: "list",
+			Data: []core.Model{
+				{ID: "deepseek/deepseek-r1:free", Object: "model"},
+				{ID: "openai/gpt-4o", Object: "model"},
+			},
+		},
+	}
+
+	registry := NewModelRegistry()
+	registry.RegisterProviderWithNameAndType(provider, "openrouter", "openai")
+	registry.SetProviderModelFilter("openrouter", config.ModelFilter{Include: []string{"*:free"}})
+	if err := registry.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() failed: %v", err)
+	}
+	if registry.GetModel("openrouter/openai/gpt-4o") != nil {
+		t.Fatal("filtered model is in the catalog, want dropped")
+	}
+
+	registry.SetProviderModelFilter("openrouter", config.ModelFilter{})
+
+	if registry.GetModel("openrouter/openai/gpt-4o") == nil {
+		t.Error("clearing the filter did not restore the model")
+	}
+	if registry.GetModel("openrouter/deepseek/deepseek-r1:free") == nil {
+		t.Error("clearing the filter dropped a model it had kept")
+	}
+}
+
 // A model admitted while unpriced must leave the catalog once the remote model
 // list prices it above the cap, rather than staying routable until the next
 // provider fetch sweep.
@@ -297,5 +385,50 @@ func TestEnrichModels_ReappliesPriceCap(t *testing.T) {
 	}
 	if registry.GetProvider("vendor/pricey") != nil {
 		t.Error("model priced above the cap is still routable by bare ID, want dropped")
+	}
+}
+
+// The cache must hold what the provider actually served, not what the filter
+// currently admits. Persisting the filtered absence would make a loosened
+// filter unrecoverable on a restart where the upstream listing is unreachable.
+func TestSaveToCache_PersistsUnfilteredInventory(t *testing.T) {
+	cacheFile := filepath.Join(t.TempDir(), "models.json")
+	provider := &registryMockProvider{
+		name: "openrouter",
+		modelsResponse: &core.ModelsResponse{
+			Object: "list",
+			Data: []core.Model{
+				{ID: "deepseek/deepseek-r1:free", Object: "model", OwnedBy: "openrouter"},
+				{ID: "openai/gpt-4o", Object: "model", OwnedBy: "openrouter"},
+			},
+		},
+	}
+
+	registry := NewModelRegistry()
+	registry.SetCache(modelcache.NewLocalCache(cacheFile))
+	registry.RegisterProviderWithNameAndType(provider, "openrouter", "openai")
+	registry.SetProviderModelFilter("openrouter", config.ModelFilter{Include: []string{"*:free"}})
+	if err := registry.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() failed: %v", err)
+	}
+	if err := registry.SaveToCache(context.Background()); err != nil {
+		t.Fatalf("SaveToCache() failed: %v", err)
+	}
+
+	// Restore into a registry whose filter has since been removed, with the
+	// provider unreachable so only the cache can supply the catalog.
+	offline := &registryMockProvider{name: "openrouter", err: errors.New("connection refused")}
+	restored := NewModelRegistry()
+	restored.SetCache(modelcache.NewLocalCache(cacheFile))
+	restored.RegisterProviderWithNameAndType(offline, "openrouter", "openai")
+	loaded, err := restored.LoadFromCache(context.Background())
+	if err != nil {
+		t.Fatalf("LoadFromCache() failed: %v", err)
+	}
+	if loaded != 2 {
+		t.Fatalf("loaded = %d, want 2 models restored from cache", loaded)
+	}
+	if restored.GetModel("openrouter/openai/gpt-4o") == nil {
+		t.Error("the filtered-out model was not persisted, want the cache to hold it")
 	}
 }

--- a/internal/providers/model_filter_test.go
+++ b/internal/providers/model_filter_test.go
@@ -1,0 +1,301 @@
+package providers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/enterpilot/gomodel/config"
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/modeldata"
+)
+
+func TestMatchesGlob(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		value   string
+		want    bool
+	}{
+		// The motivating case: `*` must cross the vendor separator, which
+		// filepath.Match would refuse.
+		{name: "star crosses slash", pattern: "*:free", value: "deepseek/deepseek-r1:free", want: true},
+		{name: "free suffix required", pattern: "*:free", value: "deepseek/deepseek-r1", want: false},
+		{name: "vendor prefix", pattern: "openai/*", value: "openai/gpt-4o", want: true},
+		{name: "vendor prefix mismatch", pattern: "openai/*", value: "google/gemini-2.5-pro", want: false},
+		{name: "exact literal", pattern: "gpt-4o", value: "gpt-4o", want: true},
+		{name: "literal mismatch", pattern: "gpt-4o", value: "gpt-4o-mini", want: false},
+		{name: "case insensitive", pattern: "*:FREE", value: "qwen/qwen3:free", want: true},
+		{name: "question mark matches one", pattern: "gpt-?", value: "gpt-4", want: true},
+		{name: "question mark needs a character", pattern: "gpt-?", value: "gpt-", want: false},
+		{name: "multiple stars", pattern: "*qwen*free*", value: "qwen/qwen3-coder:free", want: true},
+		{name: "leading star backtracks", pattern: "*-r1:free", value: "deepseek/deepseek-r1-r1:free", want: true},
+		{name: "bare star matches all", pattern: "*", value: "anything/at-all", want: true},
+		{name: "empty pattern matches empty", pattern: "", value: "", want: true},
+		{name: "empty pattern rejects value", pattern: "", value: "gpt-4o", want: false},
+		{name: "trailing stars are optional", pattern: "gpt-4o**", value: "gpt-4o", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchesGlob(tt.pattern, tt.value); got != tt.want {
+				t.Errorf("matchesGlob(%q, %q) = %v, want %v", tt.pattern, tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestModelFilterKeep(t *testing.T) {
+	priced := func(input, output float64) *core.ModelMetadata {
+		return &core.ModelMetadata{Pricing: &core.ModelPricing{
+			Currency:      "USD",
+			InputPerMtok:  &input,
+			OutputPerMtok: &output,
+		}}
+	}
+
+	tests := []struct {
+		name   string
+		filter config.ModelFilter
+		model  core.Model
+		want   bool
+	}{
+		{
+			name:   "include keeps match",
+			filter: config.ModelFilter{Include: []string{"*:free"}},
+			model:  core.Model{ID: "deepseek/deepseek-r1:free"},
+			want:   true,
+		},
+		{
+			name:   "include drops non-match",
+			filter: config.ModelFilter{Include: []string{"*:free"}},
+			model:  core.Model{ID: "openai/gpt-4o"},
+			want:   false,
+		},
+		{
+			name:   "non-matching exclude keeps included model",
+			filter: config.ModelFilter{Include: []string{"*:free"}, Exclude: []string{"*-preview:free"}},
+			model:  core.Model{ID: "google/gemini-flash:free"},
+			want:   true,
+		},
+		{
+			name:   "exclude narrows include",
+			filter: config.ModelFilter{Include: []string{"*:free"}, Exclude: []string{"*-preview:free"}},
+			model:  core.Model{ID: "google/gemini-preview:free"},
+			want:   false,
+		},
+		{
+			name:   "exclude drops match",
+			filter: config.ModelFilter{Include: []string{"*"}, Exclude: []string{"*preview*"}},
+			model:  core.Model{ID: "google/gemini-preview:free"},
+			want:   false,
+		},
+		{
+			name:   "price cap keeps model at the cap",
+			filter: config.ModelFilter{MaxPricePerMtok: new(0.0)},
+			model:  core.Model{ID: "qwen/qwen3:free", Metadata: priced(0, 0)},
+			want:   true,
+		},
+		{
+			name:   "price cap uses the higher rate",
+			filter: config.ModelFilter{MaxPricePerMtok: new(1.0)},
+			model:  core.Model{ID: "vendor/cheap-in-pricey-out", Metadata: priced(0.1, 5)},
+			want:   false,
+		},
+		{
+			name:   "price cap keeps model under both rates",
+			filter: config.ModelFilter{MaxPricePerMtok: new(1.0)},
+			model:  core.Model{ID: "vendor/cheap", Metadata: priced(0.1, 0.4)},
+			want:   true,
+		},
+		{
+			// A cap that admits models of unknown price is not a cap.
+			name:   "price cap drops unpriced model",
+			filter: config.ModelFilter{MaxPricePerMtok: new(1.0)},
+			model:  core.Model{ID: "vendor/unknown"},
+			want:   false,
+		},
+		{
+			name:   "unpriced model survives pattern-only filter",
+			filter: config.ModelFilter{Include: []string{"vendor/*"}},
+			model:  core.Model{ID: "vendor/unknown"},
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter, ok := newModelFilter(tt.filter)
+			if !ok {
+				t.Fatalf("newModelFilter(%+v) reported an empty filter", tt.filter)
+			}
+			if got := filter.keep(tt.model); got != tt.want {
+				t.Errorf("keep(%q) = %v, want %v", tt.model.ID, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewModelFilterEmpty(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter config.ModelFilter
+		want   bool
+	}{
+		{name: "zero value", filter: config.ModelFilter{}, want: false},
+		{name: "blank patterns", filter: config.ModelFilter{Include: []string{"", "  "}}, want: false},
+		{name: "include", filter: config.ModelFilter{Include: []string{"*:free"}}, want: true},
+		{name: "zero price cap is a real cap", filter: config.ModelFilter{MaxPricePerMtok: new(0.0)}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, ok := newModelFilter(tt.filter); ok != tt.want {
+				t.Errorf("newModelFilter(%+v) ok = %v, want %v", tt.filter, ok, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterProviderModelMaps(t *testing.T) {
+	registry := NewModelRegistry()
+	registry.SetProviderModelFilter("openrouter", config.ModelFilter{Include: []string{"*:free"}})
+
+	modelsByProvider := map[string]map[string]*ModelInfo{
+		"openrouter": {
+			"deepseek/deepseek-r1:free": {Model: core.Model{ID: "deepseek/deepseek-r1:free"}},
+			"openai/gpt-4o":             {Model: core.Model{ID: "openai/gpt-4o"}},
+		},
+		// A provider without a filter keeps its whole inventory.
+		"openai": {
+			"gpt-4o": {Model: core.Model{ID: "gpt-4o"}},
+		},
+	}
+
+	if dropped := registry.filterProviderModelMaps(modelsByProvider); dropped != 1 {
+		t.Fatalf("dropped = %d, want 1", dropped)
+	}
+	if _, ok := modelsByProvider["openrouter"]["deepseek/deepseek-r1:free"]; !ok {
+		t.Error("free model was dropped, want kept")
+	}
+	if _, ok := modelsByProvider["openrouter"]["openai/gpt-4o"]; ok {
+		t.Error("paid model was kept, want dropped")
+	}
+	if len(modelsByProvider["openai"]) != 1 {
+		t.Errorf("unfiltered provider models = %d, want 1", len(modelsByProvider["openai"]))
+	}
+}
+
+// A filter that matches nothing must leave the provider present with an empty
+// inventory: dropping the key would read as a failed refresh and resurrect the
+// previous inventory through the carry-forward path.
+func TestFilterProviderModelMapsKeepsEmptiedProvider(t *testing.T) {
+	registry := NewModelRegistry()
+	registry.SetProviderModelFilter("openrouter", config.ModelFilter{Include: []string{"*:free"}})
+
+	modelsByProvider := map[string]map[string]*ModelInfo{
+		"openrouter": {"openai/gpt-4o": {Model: core.Model{ID: "openai/gpt-4o"}}},
+	}
+	registry.filterProviderModelMaps(modelsByProvider)
+
+	models, ok := modelsByProvider["openrouter"]
+	if !ok {
+		t.Fatal("provider key was removed, want retained with an empty inventory")
+	}
+	if len(models) != 0 {
+		t.Errorf("models = %d, want 0", len(models))
+	}
+}
+
+func TestSetProviderModelFilterClears(t *testing.T) {
+	registry := NewModelRegistry()
+	registry.SetProviderModelFilter("openrouter", config.ModelFilter{Include: []string{"*:free"}})
+	registry.SetProviderModelFilter("openrouter", config.ModelFilter{})
+
+	if filters := registry.snapshotProviderModelFilters(); len(filters) != 0 {
+		t.Errorf("filters = %+v, want cleared", filters)
+	}
+}
+
+// End-to-end through Initialize: the filter must narrow what the catalog
+// actually serves, not just the per-provider map, so a filtered-out model is
+// unroutable rather than merely hidden from /v1/models.
+func TestInitialize_AppliesProviderModelFilter(t *testing.T) {
+	free := 0.0
+	paid := 3.0
+	provider := &registryMockProvider{
+		name: "openrouter",
+		modelsResponse: &core.ModelsResponse{
+			Object: "list",
+			Data: []core.Model{
+				{ID: "deepseek/deepseek-r1:free", Object: "model", Metadata: &core.ModelMetadata{
+					Pricing: &core.ModelPricing{Currency: "USD", InputPerMtok: &free, OutputPerMtok: &free},
+				}},
+				{ID: "openai/gpt-4o", Object: "model", Metadata: &core.ModelMetadata{
+					Pricing: &core.ModelPricing{Currency: "USD", InputPerMtok: &paid, OutputPerMtok: &paid},
+				}},
+			},
+		},
+	}
+
+	registry := NewModelRegistry()
+	registry.RegisterProviderWithNameAndType(provider, "openrouter", "openrouter")
+	registry.SetProviderModelFilter("openrouter", config.ModelFilter{MaxPricePerMtok: &free})
+
+	if err := registry.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() failed: %v", err)
+	}
+
+	if got := registry.GetProvider("deepseek/deepseek-r1:free"); got == nil {
+		t.Error("free model is not routable, want kept")
+	}
+	if got := registry.GetProvider("openai/gpt-4o"); got != nil {
+		t.Error("model above the price cap is routable, want dropped")
+	}
+}
+
+// A model admitted while unpriced must leave the catalog once the remote model
+// list prices it above the cap, rather than staying routable until the next
+// provider fetch sweep.
+func TestEnrichModels_ReappliesPriceCap(t *testing.T) {
+	provider := &registryMockProvider{
+		name: "openrouter",
+		modelsResponse: &core.ModelsResponse{
+			Object: "list",
+			Data: []core.Model{
+				{ID: "vendor/cheap", Object: "model"},
+				{ID: "vendor/pricey", Object: "model"},
+			},
+		},
+	}
+
+	registry := NewModelRegistry()
+	registry.RegisterProviderWithNameAndType(provider, "openrouter", "openai")
+
+	// The cap is applied only after enrichment supplies prices, so both models
+	// must first enter the catalog with no pricing at all.
+	if err := registry.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() failed: %v", err)
+	}
+	registry.SetProviderModelFilter("openrouter", config.ModelFilter{MaxPricePerMtok: new(1.0)})
+
+	raw := []byte(`{"version":1,"updated_at":"2025-01-01T00:00:00Z","providers":{},"models":{` +
+		`"vendor/cheap":{"pricing":{"currency":"USD","input_per_mtok":0.2,"output_per_mtok":0.4}},` +
+		`"vendor/pricey":{"pricing":{"currency":"USD","input_per_mtok":0.2,"output_per_mtok":9}}` +
+		`},"provider_models":{}}`)
+	list, err := modeldata.Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	registry.SetModelList(list, raw)
+	registry.EnrichModels()
+
+	if registry.GetModel("openrouter/vendor/cheap") == nil {
+		t.Error("model under the cap was dropped, want kept")
+	}
+	if registry.GetModel("openrouter/vendor/pricey") != nil {
+		t.Error("model priced above the cap is still in the catalog, want dropped")
+	}
+	if registry.GetProvider("vendor/pricey") != nil {
+		t.Error("model priced above the cap is still routable by bare ID, want dropped")
+	}
+}

--- a/internal/providers/openrouter/openrouter.go
+++ b/internal/providers/openrouter/openrouter.go
@@ -2,6 +2,7 @@ package openrouter
 
 import (
 	"context"
+	"math"
 	"net/http"
 	"os"
 	"strconv"
@@ -229,13 +230,20 @@ func openrouterPricing(m openrouterModel) *core.ModelPricing {
 }
 
 // perMtok parses a per-token USD rate and scales it to per million tokens.
-// Unparseable and negative rates report no price rather than a wrong one.
+// Rates that are unparseable, negative, or non-finite report no price rather
+// than a wrong one: ParseFloat accepts "NaN" and "Inf", and scaling a huge rate
+// can overflow to infinity, either of which would corrupt every downstream
+// price comparison and cost calculation.
 func perMtok(rate string) (float64, bool) {
 	perToken, err := strconv.ParseFloat(strings.TrimSpace(rate), 64)
-	if err != nil || perToken < 0 {
+	if err != nil || perToken < 0 || math.IsNaN(perToken) || math.IsInf(perToken, 0) {
 		return 0, false
 	}
-	return perToken * 1_000_000, true
+	scaled := perToken * 1_000_000
+	if math.IsInf(scaled, 0) {
+		return 0, false
+	}
+	return scaled, true
 }
 
 func setHeaders(req *http.Request, apiKey string) {

--- a/internal/providers/openrouter/openrouter.go
+++ b/internal/providers/openrouter/openrouter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/enterpilot/gomodel/internal/core"
@@ -94,6 +95,12 @@ type openrouterModel struct {
 		InputModalities  []string `json:"input_modalities"`
 		OutputModalities []string `json:"output_modalities"`
 	} `json:"architecture"`
+	// Pricing holds OpenRouter's per-token USD rates as decimal strings.
+	// "-1" marks a rate OpenRouter cannot state up front (auto-routed models).
+	Pricing struct {
+		Prompt     string `json:"prompt"`
+		Completion string `json:"completion"`
+	} `json:"pricing"`
 }
 
 // ListModels parses OpenRouter's native models listing so architecture
@@ -183,7 +190,8 @@ func openrouterMetadata(m openrouterModel) *core.ModelMetadata {
 			modes = append(modes, "audio_transcription")
 		}
 	}
-	if len(modes) == 0 && m.ContextLength <= 0 {
+	pricing := openrouterPricing(m)
+	if len(modes) == 0 && m.ContextLength <= 0 && pricing == nil {
 		return nil
 	}
 	meta := &core.ModelMetadata{}
@@ -195,7 +203,39 @@ func openrouterMetadata(m openrouterModel) *core.ModelMetadata {
 		contextWindow := m.ContextLength
 		meta.ContextWindow = &contextWindow
 	}
+	meta.Pricing = pricing
 	return meta
+}
+
+// openrouterPricing converts OpenRouter's per-token rates into the gateway's
+// per-million-token pricing. OpenRouter prices each model itself, including the
+// ":free" variants it publishes at zero, so its own listing is more current
+// than the remote model registry for this catalog — and enrichment already
+// treats what a provider reports as the override.
+func openrouterPricing(m openrouterModel) *core.ModelPricing {
+	input, hasInput := perMtok(m.Pricing.Prompt)
+	output, hasOutput := perMtok(m.Pricing.Completion)
+	if !hasInput && !hasOutput {
+		return nil
+	}
+	pricing := &core.ModelPricing{Currency: "USD"}
+	if hasInput {
+		pricing.InputPerMtok = &input
+	}
+	if hasOutput {
+		pricing.OutputPerMtok = &output
+	}
+	return pricing
+}
+
+// perMtok parses a per-token USD rate and scales it to per million tokens.
+// Unparseable and negative rates report no price rather than a wrong one.
+func perMtok(rate string) (float64, bool) {
+	perToken, err := strconv.ParseFloat(strings.TrimSpace(rate), 64)
+	if err != nil || perToken < 0 {
+		return 0, false
+	}
+	return perToken * 1_000_000, true
 }
 
 func setHeaders(req *http.Request, apiKey string) {

--- a/internal/providers/openrouter/openrouter_test.go
+++ b/internal/providers/openrouter/openrouter_test.go
@@ -421,3 +421,52 @@ func TestListModels_StampsPricing(t *testing.T) {
 		t.Errorf("unpriced model pricing = %+v, want none", unpriced.Pricing)
 	}
 }
+
+// strconv.ParseFloat accepts "NaN" and "Inf", and scaling a huge per-token rate
+// to per-Mtok can overflow. Either would corrupt every downstream price
+// comparison and cost calculation, so such rates report no price at all.
+func TestListModels_RejectsNonFinitePricing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[
+			{"id":"acme/nan","architecture":{"output_modalities":["text"]},
+			 "pricing":{"prompt":"NaN","completion":"NaN"}},
+			{"id":"acme/inf","architecture":{"output_modalities":["text"]},
+			 "pricing":{"prompt":"Inf","completion":"Inf"}},
+			{"id":"acme/overflow","architecture":{"output_modalities":["text"]},
+			 "pricing":{"prompt":"1e308","completion":"1e308"}},
+			{"id":"acme/partial","architecture":{"output_modalities":["text"]},
+			 "pricing":{"prompt":"0.000001","completion":"NaN"}}
+		]}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("test-api-key", server.Client(), llmclient.Hooks{})
+	provider.SetBaseURL(server.URL)
+
+	resp, err := provider.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	byID := map[string]core.Model{}
+	for _, m := range resp.Data {
+		byID[m.ID] = m
+	}
+
+	for _, id := range []string{"acme/nan", "acme/inf", "acme/overflow"} {
+		if meta := byID[id].Metadata; meta != nil && meta.Pricing != nil {
+			t.Errorf("%s pricing = %+v, want none", id, meta.Pricing)
+		}
+	}
+
+	// One unusable rate must not discard the other, usable one.
+	partial := byID["acme/partial"].Metadata
+	if partial == nil || partial.Pricing == nil || partial.Pricing.InputPerMtok == nil {
+		t.Fatalf("acme/partial pricing = %+v, want the parseable input rate", partial)
+	}
+	if *partial.Pricing.InputPerMtok != 1 {
+		t.Errorf("InputPerMtok = %v, want 1", *partial.Pricing.InputPerMtok)
+	}
+	if partial.Pricing.OutputPerMtok != nil {
+		t.Errorf("OutputPerMtok = %v, want none", *partial.Pricing.OutputPerMtok)
+	}
+}

--- a/internal/providers/openrouter/openrouter_test.go
+++ b/internal/providers/openrouter/openrouter_test.go
@@ -355,3 +355,69 @@ func TestPassthrough_PreservesUserProvidedAttributionHeaders(t *testing.T) {
 		t.Fatalf("X-OpenRouter-Title = %q, want empty when caller provided X-Title", gotTitle)
 	}
 }
+
+// OpenRouter prices its own catalog, including the ":free" variants it
+// publishes at zero, so ListModels must carry those rates into metadata:
+// enrichment treats what a provider reports as the override, and price-based
+// model filtering and cost-based load balancing both read them.
+func TestListModels_StampsPricing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[
+			{"id":"openai/gpt-4o-mini","context_length":128000,
+			 "architecture":{"output_modalities":["text"]},
+			 "pricing":{"prompt":"0.00000015","completion":"0.0000006"}},
+			{"id":"deepseek/deepseek-r1:free",
+			 "architecture":{"output_modalities":["text"]},
+			 "pricing":{"prompt":"0","completion":"0"}},
+			{"id":"openrouter/auto",
+			 "architecture":{"output_modalities":["text"]},
+			 "pricing":{"prompt":"-1","completion":"-1"}},
+			{"id":"acme/unpriced","architecture":{"output_modalities":["text"]}}
+		]}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("test-api-key", server.Client(), llmclient.Hooks{})
+	provider.SetBaseURL(server.URL)
+
+	resp, err := provider.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	byID := map[string]core.Model{}
+	for _, m := range resp.Data {
+		byID[m.ID] = m
+	}
+
+	paid := byID["openai/gpt-4o-mini"].Metadata
+	if paid == nil || paid.Pricing == nil {
+		t.Fatalf("gpt-4o-mini pricing = %+v, want per-Mtok rates", paid)
+	}
+	if paid.Pricing.Currency != "USD" {
+		t.Errorf("Currency = %q, want USD", paid.Pricing.Currency)
+	}
+	// Per-token rates are scaled to per million tokens.
+	if paid.Pricing.InputPerMtok == nil || *paid.Pricing.InputPerMtok != 0.15 {
+		t.Errorf("InputPerMtok = %v, want 0.15", paid.Pricing.InputPerMtok)
+	}
+	if paid.Pricing.OutputPerMtok == nil || *paid.Pricing.OutputPerMtok != 0.6 {
+		t.Errorf("OutputPerMtok = %v, want 0.6", paid.Pricing.OutputPerMtok)
+	}
+
+	free := byID["deepseek/deepseek-r1:free"].Metadata
+	if free == nil || free.Pricing == nil || free.Pricing.InputPerMtok == nil {
+		t.Fatalf("free model pricing = %+v, want an explicit zero rate", free)
+	}
+	if *free.Pricing.InputPerMtok != 0 || *free.Pricing.OutputPerMtok != 0 {
+		t.Errorf("free model rates = %v/%v, want 0/0", *free.Pricing.InputPerMtok, *free.Pricing.OutputPerMtok)
+	}
+
+	// "-1" means OpenRouter cannot state the rate up front; reporting it as a
+	// negative price would make an auto-routed model look cheaper than free.
+	if auto := byID["openrouter/auto"].Metadata; auto != nil && auto.Pricing != nil {
+		t.Errorf("auto-router pricing = %+v, want none", auto.Pricing)
+	}
+	if unpriced := byID["acme/unpriced"].Metadata; unpriced != nil && unpriced.Pricing != nil {
+		t.Errorf("unpriced model pricing = %+v, want none", unpriced.Pricing)
+	}
+}

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -3,6 +3,7 @@ package providers
 
 import (
 	"fmt"
+	"maps"
 	"slices"
 	"sort"
 	"strings"
@@ -77,6 +78,10 @@ type ModelRegistry struct {
 	// are fallback-only or an allowlist over the discovered upstream inventory.
 	configuredProviderModels     map[string][]string
 	configuredProviderModelsMode config.ConfiguredProviderModelsMode
+	// providerModelFilters holds operator-supplied inventory filters keyed by
+	// configured provider instance name. Applied after metadata enrichment;
+	// providers without a filter are absent from the map.
+	providerModelFilters map[string]modelFilter
 
 	// Cached sorted slices, rebuilt lazily after models change.
 	// nil means cache needs rebuilding. Protected by mu.
@@ -285,6 +290,38 @@ func (r *ModelRegistry) SetProviderConfiguredModels(providerName string, models 
 	r.configuredProviderModels[providerName] = normalized
 }
 
+// SetProviderModelFilter records the inventory filter declared for a configured
+// provider instance. Call with an empty filter to clear it.
+func (r *ModelRegistry) SetProviderModelFilter(providerName string, filter config.ModelFilter) {
+	providerName = strings.TrimSpace(providerName)
+	if providerName == "" {
+		return
+	}
+	resolved, ok := newModelFilter(filter)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !ok {
+		delete(r.providerModelFilters, providerName)
+		return
+	}
+	if r.providerModelFilters == nil {
+		r.providerModelFilters = make(map[string]modelFilter)
+	}
+	r.providerModelFilters[providerName] = resolved
+}
+
+// snapshotProviderModelFilters copies the configured filters under a read lock.
+func (r *ModelRegistry) snapshotProviderModelFilters() map[string]modelFilter {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if len(r.providerModelFilters) == 0 {
+		return nil
+	}
+	out := make(map[string]modelFilter, len(r.providerModelFilters))
+	maps.Copy(out, r.providerModelFilters)
+	return out
+}
+
 // RegisterProviderWithNameAndType adds a provider with a configured provider instance name and type.
 // Name is used for unambiguous provider/model selection (e.g. "provider/model") and cache persistence.
 func (r *ModelRegistry) RegisterProviderWithNameAndType(provider core.Provider, providerName, providerType string) {
@@ -338,6 +375,7 @@ func (r *ModelRegistry) UnregisterProvider(providerName string) {
 	delete(r.providerRuntime, providerName)
 	delete(r.configMetadataOverrides, providerName)
 	delete(r.configuredProviderModels, providerName)
+	delete(r.providerModelFilters, providerName)
 	delete(r.modelsByProvider, providerName)
 	r.models = rebuildGlobalModelMap(r.modelsByProvider, r.freshFirstProviderOrderLocked())
 	r.invalidateSortedCaches()

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -49,20 +49,29 @@ func newModelInfo(model core.Model, provider core.Provider, providerName, provid
 // It fetches models from providers on startup and caches them in memory.
 // Supports loading from a cache (local file or Redis) for instant startup.
 type ModelRegistry struct {
-	mu               sync.RWMutex
-	models           map[string]*ModelInfo            // model ID -> model info (first provider wins)
+	mu     sync.RWMutex
+	models map[string]*ModelInfo // model ID -> model info (first provider wins)
+	// modelsByProvider is the ROUTABLE catalog: discoveredByProvider with each
+	// provider's model filter applied. Everything that serves, lists, or
+	// resolves a model reads this map.
 	modelsByProvider map[string]map[string]*ModelInfo // provider instance name -> model ID -> model info
-	providers        []core.Provider
-	providerTypes    map[core.Provider]string // provider -> type string
-	providerNames    map[core.Provider]string // provider -> configured provider instance name
-	providerRuntime  map[string]providerRuntimeState
-	cache            modelcache.Cache     // cache backend (local or redis)
-	initialized      bool                 // true when at least one successful network fetch completed
-	initMu           sync.Mutex           // protects initialized flag
-	refreshCh        chan struct{}        // serializes provider/model-list refresh cycles
-	refreshOnce      sync.Once            // initializes refreshCh for zero-value safety
-	modelList        *modeldata.ModelList // parsed model list (nil = not loaded)
-	modelListRaw     json.RawMessage      // raw bytes for cache persistence
+	// discoveredByProvider is the unfiltered inventory as fetched or restored
+	// from cache, before model filters. It is what enrichment runs over and
+	// what is persisted, so a model a filter currently rejects returns as soon
+	// as its pricing or the filter changes, without waiting for a refetch.
+	// Providers without a filter share their inner map with modelsByProvider.
+	discoveredByProvider map[string]map[string]*ModelInfo
+	providers            []core.Provider
+	providerTypes        map[core.Provider]string // provider -> type string
+	providerNames        map[core.Provider]string // provider -> configured provider instance name
+	providerRuntime      map[string]providerRuntimeState
+	cache                modelcache.Cache     // cache backend (local or redis)
+	initialized          bool                 // true when at least one successful network fetch completed
+	initMu               sync.Mutex           // protects initialized flag
+	refreshCh            chan struct{}        // serializes provider/model-list refresh cycles
+	refreshOnce          sync.Once            // initializes refreshCh for zero-value safety
+	modelList            *modeldata.ModelList // parsed model list (nil = not loaded)
+	modelListRaw         json.RawMessage      // raw bytes for cache persistence
 	// modelListETag is the validator for conditional refetches and
 	// modelListETagURL the URL it was issued by; the validator is only sent
 	// back to that same URL, so a reconfigured MODEL_LIST_URL always fetches
@@ -117,6 +126,7 @@ func NewModelRegistry() *ModelRegistry {
 	return &ModelRegistry{
 		models:                       make(map[string]*ModelInfo),
 		modelsByProvider:             make(map[string]map[string]*ModelInfo),
+		discoveredByProvider:         make(map[string]map[string]*ModelInfo),
 		providerTypes:                make(map[core.Provider]string),
 		providerNames:                make(map[core.Provider]string),
 		providerRuntime:              make(map[string]providerRuntimeState),
@@ -302,12 +312,18 @@ func (r *ModelRegistry) SetProviderModelFilter(providerName string, filter confi
 	defer r.mu.Unlock()
 	if !ok {
 		delete(r.providerModelFilters, providerName)
-		return
+	} else {
+		if r.providerModelFilters == nil {
+			r.providerModelFilters = make(map[string]modelFilter)
+		}
+		r.providerModelFilters[providerName] = resolved
 	}
-	if r.providerModelFilters == nil {
-		r.providerModelFilters = make(map[string]modelFilter)
+	// Republish so a filter set or cleared after the catalog loaded takes effect
+	// immediately rather than at the next refresh.
+	if len(r.discoveredByProvider) > 0 {
+		r.publishFilteredInventoryLocked()
+		r.invalidateSortedCaches()
 	}
-	r.providerModelFilters[providerName] = resolved
 }
 
 // snapshotProviderModelFilters copies the configured filters under a read lock.
@@ -376,8 +392,8 @@ func (r *ModelRegistry) UnregisterProvider(providerName string) {
 	delete(r.configMetadataOverrides, providerName)
 	delete(r.configuredProviderModels, providerName)
 	delete(r.providerModelFilters, providerName)
-	delete(r.modelsByProvider, providerName)
-	r.models = rebuildGlobalModelMap(r.modelsByProvider, r.freshFirstProviderOrderLocked())
+	delete(r.discoveredByProvider, providerName)
+	r.publishFilteredInventoryLocked()
 	r.invalidateSortedCaches()
 }
 

--- a/internal/providers/registry_cache.go
+++ b/internal/providers/registry_cache.go
@@ -38,22 +38,14 @@ func (r *ModelRegistry) LoadFromCache(ctx context.Context) (int, error) {
 	r.mu.RLock()
 	nameToProvider := make(map[string]core.Provider, len(r.providerNames))
 	nameToProviderType := make(map[string]string, len(r.providerNames))
-	providerOrderNames := make([]string, 0, len(r.providers))
-	for _, provider := range r.providers {
-		providerName := r.providerNames[provider]
-		if providerName == "" {
-			continue
-		}
-		providerOrderNames = append(providerOrderNames, providerName)
-	}
 	for provider, pName := range r.providerNames {
 		nameToProvider[pName] = provider
 		nameToProviderType[pName] = r.providerTypes[provider]
 	}
 	r.mu.RUnlock()
 
-	// Populate model maps from grouped cache structure. Unqualified lookups keep "first provider wins".
-	newModels := make(map[string]*ModelInfo)
+	// Populate the per-provider inventory from the grouped cache structure. The
+	// global "first provider wins" map is derived from it when publishing.
 	newModelsByProvider := make(map[string]map[string]*ModelInfo)
 	cachedProviderTypes := make(map[string]string, len(modelCache.Providers))
 	for providerName, cachedProv := range modelCache.Providers {
@@ -78,9 +70,6 @@ func (r *ModelRegistry) LoadFromCache(ctx context.Context) (int, error) {
 				Created: cached.Created,
 			}, provider, providerName, providerType)
 			providerModels[cached.ID] = info
-			if _, exists := newModels[cached.ID]; !exists {
-				newModels[cached.ID] = info
-			}
 		}
 		newModelsByProvider[providerName] = providerModels
 	}
@@ -126,15 +115,12 @@ func (r *ModelRegistry) LoadFromCache(ctx context.Context) (int, error) {
 	metadataStats.Enriched += applyConfigMetadataOverrides(configOverrides, newModelsByProvider, nil)
 	metadataStats.Enriched += applyInferredModelMetadata(newModelsByProvider, nil)
 
-	// Filtering follows enrichment so price rules see resolved pricing, and
-	// precedes the global map rebuild so filtered models never claim a bare-ID
-	// slot ahead of a model another provider still serves.
-	r.filterProviderModelMaps(newModelsByProvider)
-	newModels = rebuildGlobalModelMap(newModelsByProvider, providerOrderNames)
-
 	r.mu.Lock()
-	r.models = newModels
-	r.modelsByProvider = newModelsByProvider
+	// Publishing applies model filters after enrichment, so price rules see the
+	// cached pricing while the restored inventory itself stays unfiltered.
+	r.discoveredByProvider = newModelsByProvider
+	r.publishFilteredInventoryLocked()
+	loadedModels := len(r.models)
 	r.invalidateSortedCaches()
 	if list != nil {
 		r.modelList = list
@@ -144,21 +130,24 @@ func (r *ModelRegistry) LoadFromCache(ctx context.Context) (int, error) {
 	r.mu.Unlock()
 
 	attrs := []any{
-		"models", len(newModels),
+		"models", loadedModels,
 		"cache_updated_at", modelCache.UpdatedAt,
 	}
 	attrs = append(attrs, metadataStats.slogAttrs()...)
 	slog.Info("loaded models from cache", attrs...)
 
-	return len(newModels), nil
+	return loadedModels, nil
 }
 
 // SaveToCache saves the current model list to the cache backend.
 func (r *ModelRegistry) SaveToCache(ctx context.Context) error {
 	r.mu.RLock()
 	cacheBackend := r.cache
-	modelsByProvider := make(map[string]map[string]*ModelInfo, len(r.modelsByProvider))
-	for providerName, models := range r.modelsByProvider {
+	// Persist the unfiltered inventory: model filters are a view over what a
+	// provider serves, so a restart with a loosened filter must be able to
+	// re-admit models without waiting for a successful upstream fetch.
+	modelsByProvider := make(map[string]map[string]*ModelInfo, len(r.discoveredByProvider))
+	for providerName, models := range r.discoveredByProvider {
 		// A stale inventory was carried forward from before the provider went
 		// offline; persisting it would resurrect the offline provider's models
 		// on every restart. The provider re-enters the cache once a refresh

--- a/internal/providers/registry_cache.go
+++ b/internal/providers/registry_cache.go
@@ -105,7 +105,6 @@ func (r *ModelRegistry) LoadFromCache(ctx context.Context) (int, error) {
 			newModelsByProvider[providerName] = modelInfoMapFromResponse(resp, provider, providerName, providerType)
 		}
 	}
-	newModels = rebuildGlobalModelMap(newModelsByProvider, providerOrderNames)
 
 	// Load model list data from cache if available
 	var list *modeldata.ModelList
@@ -126,6 +125,12 @@ func (r *ModelRegistry) LoadFromCache(ctx context.Context) (int, error) {
 	configOverrides := r.snapshotConfigOverrides()
 	metadataStats.Enriched += applyConfigMetadataOverrides(configOverrides, newModelsByProvider, nil)
 	metadataStats.Enriched += applyInferredModelMetadata(newModelsByProvider, nil)
+
+	// Filtering follows enrichment so price rules see resolved pricing, and
+	// precedes the global map rebuild so filtered models never claim a bare-ID
+	// slot ahead of a model another provider still serves.
+	r.filterProviderModelMaps(newModelsByProvider)
+	newModels = rebuildGlobalModelMap(newModelsByProvider, providerOrderNames)
 
 	r.mu.Lock()
 	r.models = newModels

--- a/internal/providers/registry_init.go
+++ b/internal/providers/registry_init.go
@@ -305,7 +305,6 @@ func (r *ModelRegistry) applyFetchedInventory(
 	totalProviders int,
 ) {
 	metadataStats := r.enrichFetchedProviderModelMaps(providerTypes, fetched.modelsByProvider)
-	fetched.totalModels -= r.filterProviderModelMaps(fetched.modelsByProvider)
 
 	r.mu.Lock()
 	r.dropUnregisteredFetchedProvidersLocked(&fetched)
@@ -315,7 +314,7 @@ func (r *ModelRegistry) applyFetchedInventory(
 		if _, ok := fetched.modelsByProvider[name]; ok {
 			continue // this sweep produced authoritative inventory
 		}
-		previous := r.modelsByProvider[name]
+		previous := r.discoveredByProvider[name]
 		if len(previous) == 0 {
 			continue // nothing to carry forward
 		}
@@ -323,14 +322,17 @@ func (r *ModelRegistry) applyFetchedInventory(
 		stale[name] = true
 		carriedForward++
 	}
-	r.modelsByProvider = fetched.modelsByProvider
+	r.discoveredByProvider = fetched.modelsByProvider
 	r.applyProviderRuntimeUpdatesLocked(fetched.runtimeUpdates)
 	for name := range fetched.runtimeUpdates {
 		state := r.providerRuntime[name]
 		state.inventoryStale = stale[name]
 		r.providerRuntime[name] = state
 	}
-	r.models = rebuildGlobalModelMap(r.modelsByProvider, r.freshFirstProviderOrderLocked())
+	r.publishFilteredInventoryLocked()
+	// Count what the catalog actually serves: filters can hide models, and one
+	// bare ID served by several providers still resolves to a single entry.
+	fetched.totalModels = len(r.models)
 	r.invalidateSortedCaches()
 	r.mu.Unlock()
 

--- a/internal/providers/registry_init.go
+++ b/internal/providers/registry_init.go
@@ -305,6 +305,7 @@ func (r *ModelRegistry) applyFetchedInventory(
 	totalProviders int,
 ) {
 	metadataStats := r.enrichFetchedProviderModelMaps(providerTypes, fetched.modelsByProvider)
+	fetched.totalModels -= r.filterProviderModelMaps(fetched.modelsByProvider)
 
 	r.mu.Lock()
 	r.dropUnregisteredFetchedProvidersLocked(&fetched)

--- a/internal/providers/registry_metadata.go
+++ b/internal/providers/registry_metadata.go
@@ -55,6 +55,12 @@ func (r *ModelRegistry) enrichModelsLocked() metadataEnrichmentStats {
 	}
 	stats.Enriched += applyConfigMetadataOverrides(r.configMetadataOverrides, r.modelsByProvider, replacements)
 	stats.Enriched += applyInferredModelMetadata(r.modelsByProvider, replacements)
+	// Re-filter: this pass can change the pricing a price cap is evaluated
+	// against, and a model that has become too expensive must leave the catalog
+	// now rather than staying routable until the next provider fetch sweep.
+	if filterProviderModelMaps(r.providerModelFilters, r.modelsByProvider) > 0 {
+		r.models = rebuildGlobalModelMap(r.modelsByProvider, r.freshFirstProviderOrderLocked())
+	}
 	for modelID, info := range r.models {
 		if replacement, ok := replacements[info]; ok {
 			r.models[modelID] = replacement

--- a/internal/providers/registry_metadata.go
+++ b/internal/providers/registry_metadata.go
@@ -41,31 +41,26 @@ func (r *ModelRegistry) enrichModels() metadataEnrichmentStats {
 }
 
 func (r *ModelRegistry) enrichModelsLocked() metadataEnrichmentStats {
-	if len(r.models) == 0 {
+	if len(r.discoveredByProvider) == 0 {
 		return metadataEnrichmentStats{}
 	}
 
 	providerTypes := make(map[core.Provider]string, len(r.providerTypes))
 	maps.Copy(providerTypes, r.providerTypes)
 
+	// Enrichment runs over the unfiltered inventory, so a model a price cap
+	// currently rejects still gets its metadata refreshed and is re-admitted by
+	// the republish below once it prices under the cap again.
 	replacements := make(map[*ModelInfo]*ModelInfo, len(r.models))
 	stats := metadataEnrichmentStats{}
 	if r.modelList != nil {
-		stats = enrichProviderModelMaps(r.modelList, providerTypes, r.modelsByProvider, replacements)
+		stats = enrichProviderModelMaps(r.modelList, providerTypes, r.discoveredByProvider, replacements)
 	}
-	stats.Enriched += applyConfigMetadataOverrides(r.configMetadataOverrides, r.modelsByProvider, replacements)
-	stats.Enriched += applyInferredModelMetadata(r.modelsByProvider, replacements)
-	// Re-filter: this pass can change the pricing a price cap is evaluated
-	// against, and a model that has become too expensive must leave the catalog
-	// now rather than staying routable until the next provider fetch sweep.
-	if filterProviderModelMaps(r.providerModelFilters, r.modelsByProvider) > 0 {
-		r.models = rebuildGlobalModelMap(r.modelsByProvider, r.freshFirstProviderOrderLocked())
-	}
-	for modelID, info := range r.models {
-		if replacement, ok := replacements[info]; ok {
-			r.models[modelID] = replacement
-		}
-	}
+	stats.Enriched += applyConfigMetadataOverrides(r.configMetadataOverrides, r.discoveredByProvider, replacements)
+	stats.Enriched += applyInferredModelMetadata(r.discoveredByProvider, replacements)
+	// This pass can change the pricing a cap is evaluated against in either
+	// direction, so the routable catalog is rebuilt rather than patched.
+	r.publishFilteredInventoryLocked()
 	r.invalidateSortedCaches()
 	return stats
 }

--- a/internal/providers/registry_provider_refresh.go
+++ b/internal/providers/registry_provider_refresh.go
@@ -191,6 +191,7 @@ func fetchedProviderRefreshError(fetched fetchedInventory) error {
 
 func (r *ModelRegistry) applyFetchedProviderInventory(providerTypes map[core.Provider]string, fetched fetchedInventory) {
 	metadataStats := r.enrichFetchedProviderModelMaps(providerTypes, fetched.modelsByProvider)
+	fetched.totalModels -= r.filterProviderModelMaps(fetched.modelsByProvider)
 
 	r.mu.Lock()
 	r.dropUnregisteredFetchedProvidersLocked(&fetched)

--- a/internal/providers/registry_provider_refresh.go
+++ b/internal/providers/registry_provider_refresh.go
@@ -191,19 +191,21 @@ func fetchedProviderRefreshError(fetched fetchedInventory) error {
 
 func (r *ModelRegistry) applyFetchedProviderInventory(providerTypes map[core.Provider]string, fetched fetchedInventory) {
 	metadataStats := r.enrichFetchedProviderModelMaps(providerTypes, fetched.modelsByProvider)
-	fetched.totalModels -= r.filterProviderModelMaps(fetched.modelsByProvider)
 
 	r.mu.Lock()
 	r.dropUnregisteredFetchedProvidersLocked(&fetched)
 	for providerName, providerModels := range fetched.modelsByProvider {
-		r.modelsByProvider[providerName] = providerModels
+		r.discoveredByProvider[providerName] = providerModels
 		// A refresh that produced inventory is authoritative again.
 		state := r.providerRuntime[providerName]
 		state.inventoryStale = false
 		r.providerRuntime[providerName] = state
 	}
 	r.applyProviderRuntimeUpdatesLocked(fetched.runtimeUpdates)
-	r.models = rebuildGlobalModelMap(r.modelsByProvider, r.freshFirstProviderOrderLocked())
+	r.publishFilteredInventoryLocked()
+	// Report what these providers actually serve after filtering, keeping the
+	// count scoped to the refreshed providers rather than the whole catalog.
+	fetched.totalModels = r.publishedModelCountLocked(fetched.modelsByProvider)
 	r.invalidateSortedCaches()
 	r.mu.Unlock()
 
@@ -248,4 +250,17 @@ func (r *ModelRegistry) freshFirstProviderOrderLocked() []string {
 		fresh = append(fresh, name)
 	}
 	return append(fresh, staleNames...)
+}
+
+// publishedModelCountLocked counts the distinct model IDs the named providers
+// currently publish, mirroring how the global catalog resolves a bare ID to a
+// single provider. Caller must hold r.mu.
+func (r *ModelRegistry) publishedModelCountLocked(scope map[string]map[string]*ModelInfo) int {
+	seen := make(map[string]struct{})
+	for providerName := range scope {
+		for modelID := range r.modelsByProvider[providerName] {
+			seen[modelID] = struct{}{}
+		}
+	}
+	return len(seen)
 }

--- a/internal/providers/router_test.go
+++ b/internal/providers/router_test.go
@@ -45,8 +45,9 @@ func newTestRegistryWithModels(entries ...registryModelEntry) *ModelRegistry {
 		registry.RegisterProviderWithNameAndType(entry.provider, entry.providerName, entry.providerType)
 	}
 
-	registry.models = make(map[string]*ModelInfo)
-	registry.modelsByProvider = make(map[string]map[string]*ModelInfo)
+	// Seed the unfiltered inventory; the routable maps are derived from it the
+	// same way the production paths publish them.
+	registry.discoveredByProvider = make(map[string]map[string]*ModelInfo)
 	for _, entry := range entries {
 		info := &ModelInfo{
 			Model: core.Model{
@@ -57,14 +58,12 @@ func newTestRegistryWithModels(entries ...registryModelEntry) *ModelRegistry {
 			ProviderName: entry.providerName,
 			ProviderType: entry.providerType,
 		}
-		if _, ok := registry.modelsByProvider[entry.providerName]; !ok {
-			registry.modelsByProvider[entry.providerName] = make(map[string]*ModelInfo)
+		if _, ok := registry.discoveredByProvider[entry.providerName]; !ok {
+			registry.discoveredByProvider[entry.providerName] = make(map[string]*ModelInfo)
 		}
-		registry.modelsByProvider[entry.providerName][entry.modelID] = info
-		if _, exists := registry.models[entry.modelID]; !exists {
-			registry.models[entry.modelID] = info
-		}
+		registry.discoveredByProvider[entry.providerName][entry.modelID] = info
 	}
+	registry.publishFilteredInventoryLocked()
 	return registry
 }
 


### PR DESCRIPTION
Closes #757.

Adds `providers.<name>.model_filter` so a provider's catalog can be narrowed to the models that should be routable, instead of listing every model by hand. The motivating case from the issue: run OpenRouter's free tier for experiments while other providers serve real work.

```yaml
providers:
  openrouter:
    type: openrouter
    api_key: "${OPENROUTER_API_KEY}"
    model_filter:
      include: ["*:free"]
      exclude: ["*-preview:free"]
      max_price_per_mtok: 0
```

| Field | Default | Behavior |
| --- | --- | --- |
| `include` | empty (keep all) | Keeps only models matching at least one pattern. |
| `exclude` | empty | Drops models matching any pattern. Applied after `include`. |
| `max_price_per_mtok` | unset (no cap) | Drops models whose highest per-million-token rate — the larger of input and output — is above the cap. |

Same rules in env, per provider: `OPENROUTER_MODEL_FILTER_INCLUDE`, `..._EXCLUDE`, `..._MAX_PRICE_PER_MTOK`. Each rule overlays YAML independently, so an env price cap narrows a YAML pattern filter without restating it.

## User-visible impact

- No behavior change without configuration: an unset filter keeps every model.
- Filtered models leave the catalog entirely — absent from `GET /v1/models`, and requests for them return "model not found". That is the point of the feature, but it is a routing change, not just a listing change.
- **A model with no known pricing is dropped while `max_price_per_mtok` is set.** A cap that admits models of unknown price is not a cap, so this fails closed. Local providers usually report no pricing at all — filter those by pattern, not by price.
- Patterns are globs matched case-insensitively against the raw provider model ID. `*` matches any run of characters **including `/`** (unlike `filepath.Match`), so `*:free` matches `deepseek/deepseek-r1:free`.

## Provider-specific behavior

OpenRouter's `/models` payload carries per-token prices that `ListModels` was discarding. It now maps them to per-Mtok metadata, so the `:free` tier is priced at zero without any registry entry. Rates of `-1` (auto-routed models, where OpenRouter cannot state a price up front) are reported as unpriced rather than as a negative price that would look cheaper than free. Enrichment already treats what a provider reports as the override, so this also fixes `strategy: cost` load balancing on OpenRouter, which previously fell back to "first target" for most of that catalog.

## Implementation notes

- Filtering runs after metadata enrichment, so price rules see resolved pricing, and after `configured_provider_models_mode` resolves, so it also narrows models added by `models` in merge/allowlist mode.
- It re-runs on live re-enrichment (`EnrichModels`): a model that becomes too expensive when the remote model list refreshes leaves the catalog then, rather than staying routable until the next provider fetch sweep.
- A filter that matches nothing leaves the provider present with an empty inventory. Dropping the provider key would read as a failed refresh and resurrect the previous inventory through the carry-forward path; the case is logged at WARN instead.

## Not included

Glob patterns as *virtual model targets* (a `free` alias that round-robins across every `:free` model) are the natural companion and reuse the same matcher, but they touch the virtual-model snapshot and catalog interface and are kept out of this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provider model filtering with case-insensitive include/exclude glob patterns.
  * Added optional maximum price limits per million tokens.
  * Filters apply to fetched, configured, and cached model inventories.
  * Models without pricing are excluded when a price limit is active.
  * OpenRouter pricing metadata now supports filtering, including free models.

* **Documentation**
  * Added YAML and environment-variable configuration guidance, examples, validation rules, and provider references.
  * Documented filtering behavior and interactions with model inventory settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->