### PR TITLE
fix(cache): fall back to local model cache when Redis is unreachable

### DIFF
--- a/config/cache.go
+++ b/config/cache.go
@@ -15,7 +15,8 @@ type CacheConfig struct {
 }
 
 // ModelCacheConfig holds cache configuration for model registry.
-// Exactly one of Local or Redis must be non-nil.
+// At least one of Local or Redis must be non-nil. When both are set, Redis is
+// preferred and Local is the fallback if Redis is unreachable.
 type ModelCacheConfig struct {
 	RefreshInterval int `yaml:"refresh_interval" env:"CACHE_REFRESH_INTERVAL"`
 	// RecheckInterval is how often (seconds) providers whose latest refresh
@@ -135,10 +136,11 @@ type WeaviateConfig struct {
 }
 
 // ValidateCacheConfig validates the cache configuration in c.
-// For the model cache, exactly one backend (Local or Redis) must be configured;
-// having both or neither is an error. When Redis is selected, its URL must be
-// non-empty. Returns a descriptive error if any constraint is violated, or nil
-// if the configuration is valid.
+// For the model cache, at least one backend (Local or Redis) must be configured;
+// having neither is an error. Both may be set: Redis is preferred and Local is
+// the fallback if Redis is unreachable at startup. When Redis is selected, its
+// URL must be non-empty. Returns a descriptive error if any constraint is
+// violated, or nil if the configuration is valid.
 func ValidateCacheConfig(c *CacheConfig) error {
 	if c == nil {
 		return fmt.Errorf("cache: configuration is required")
@@ -147,9 +149,6 @@ func ValidateCacheConfig(c *CacheConfig) error {
 	hasLocal := m.Local != nil
 	hasRedis := m.Redis != nil
 
-	if hasLocal && hasRedis {
-		return fmt.Errorf("cache.model: cannot have both local and redis configured; choose one")
-	}
 	if !hasLocal && !hasRedis {
 		return fmt.Errorf("cache.model: must have either local or redis configured")
 	}

--- a/config/cache_validation_test.go
+++ b/config/cache_validation_test.go
@@ -12,12 +12,8 @@ func TestValidateCacheConfig_BothLocalAndRedis(t *testing.T) {
 			Redis: &RedisModelConfig{URL: "redis://localhost:6379"},
 		},
 	}
-	err := ValidateCacheConfig(cfg)
-	if err == nil {
-		t.Fatal("expected error when both local and redis configured")
-	}
-	if err.Error() != "cache.model: cannot have both local and redis configured; choose one" {
-		t.Errorf("unexpected error: %v", err)
+	if err := ValidateCacheConfig(cfg); err != nil {
+		t.Fatalf("both local and redis should be valid (redis preferred, local is fallback): %v", err)
 	}
 }
 

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -111,8 +111,8 @@ cache:
     refresh_interval: 3600 # how often to refresh the model registry (seconds, default: 3600)
     recheck_interval: 60 # env: PROVIDER_RECHECK_INTERVAL; how often providers whose last refresh failed are re-probed for recovery (seconds, default: 60; 0 disables)
     local:
-      cache_dir: ".cache" # local cache directory
-    # To use Redis instead of local cache, remove `local` and uncomment:
+      cache_dir: ".cache" # local cache directory; kept as fallback if redis is configured but unreachable
+    # Redis is preferred when set. Leave `local` in place to start in degraded mode if Redis is down:
     # redis:
     #   url: "redis://localhost:6379"
     #   key: "gomodel:models"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1905,6 +1905,38 @@ func TestValidateBodySizeLimit(t *testing.T) {
 	}
 }
 
+func TestLoad_LocalYAMLAndRedisURLAreBothKept(t *testing.T) {
+	clearAllConfigEnvVars(t)
+
+	withTempDir(t, func(dir string) {
+		cfgDir := filepath.Join(dir, "config")
+		if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		yamlContent := "cache:\n  model:\n    local:\n      cache_dir: \".cache\"\n"
+		if err := os.WriteFile(filepath.Join(cfgDir, "config.yaml"), []byte(yamlContent), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		t.Setenv("REDIS_URL", "redis://env-host:6379")
+
+		result, err := Load()
+		if err != nil {
+			t.Fatalf("Load() error = %v, want nil", err)
+		}
+		cfg := result.Config
+		if cfg.Cache.Model.Local == nil || cfg.Cache.Model.Local.CacheDir != ".cache" {
+			t.Fatalf("expected local cache kept as fallback, got %+v", cfg.Cache.Model.Local)
+		}
+		if cfg.Cache.Model.Redis == nil {
+			t.Fatal("expected Cache.Model.Redis from REDIS_URL")
+		}
+		if cfg.Cache.Model.Redis.URL != "redis://env-host:6379" {
+			t.Errorf("expected REDIS_URL=redis://env-host:6379, got %s", cfg.Cache.Model.Redis.URL)
+		}
+	})
+}
+
 func TestLoad_EnvOnlyRedisModelCache(t *testing.T) {
 	clearAllConfigEnvVars(t)
 

--- a/internal/providers/init.go
+++ b/internal/providers/init.go
@@ -62,7 +62,7 @@ func (r *InitResult) Close() error {
 //
 // It performs:
 //  1. Provider config resolution (env var overlay, filtering, resilience merging)
-//  2. Cache initialization (local or Redis based on config)
+//  2. Cache initialization (Redis preferred, local fallback if Redis is down)
 //  3. Provider instantiation and registration
 //  4. Async model loading (from cache first, then network refresh)
 //  5. Best-effort background model-list fetch (goroutine with ~45s timeout;
@@ -190,8 +190,11 @@ func Init(ctx context.Context, result *config.LoadResult, factory *ProviderFacto
 }
 
 // initCache initializes the appropriate cache backend based on configuration.
+// Redis is preferred when configured. If Redis is unreachable and a local
+// backend is also configured, startup continues on the local file cache.
 func initCache(cfg *config.Config) (modelcache.Cache, error) {
 	m := cfg.Cache.Model
+	local := newLocalModelCache(m.Local)
 	if m.Redis != nil && m.Redis.URL != "" {
 		ttl := time.Duration(m.Redis.TTL) * time.Second
 		if ttl == 0 {
@@ -204,7 +207,11 @@ func initCache(cfg *config.Config) (modelcache.Cache, error) {
 		}
 		mc, err := modelcache.NewRedisModelCache(redisCfg)
 		if err != nil {
-			return nil, err
+			if local == nil {
+				return nil, err
+			}
+			slog.Warn("redis model cache unavailable; falling back to local file cache", "error", err, "path", localPath(m.Local))
+			return local, nil
 		}
 		key := m.Redis.Key
 		if key == "" {
@@ -213,16 +220,26 @@ func initCache(cfg *config.Config) (modelcache.Cache, error) {
 		slog.Info("using redis cache", "key", key)
 		return mc, nil
 	}
-	if m.Local != nil {
-		cacheDir := m.Local.CacheDir
-		if cacheDir == "" {
-			cacheDir = defaultModelCacheDir()
-		}
-		cacheFile := filepath.Join(cacheDir, "models.json")
-		slog.Info("using local file cache", "path", cacheFile)
-		return modelcache.NewLocalCache(cacheFile), nil
+	if local != nil {
+		slog.Info("using local file cache", "path", localPath(m.Local))
+		return local, nil
 	}
 	return nil, fmt.Errorf("cache.model: must have either local or redis configured")
+}
+
+func newLocalModelCache(local *config.LocalCacheConfig) modelcache.Cache {
+	if local == nil {
+		return nil
+	}
+	return modelcache.NewLocalCache(localPath(local))
+}
+
+func localPath(local *config.LocalCacheConfig) string {
+	cacheDir := local.CacheDir
+	if cacheDir == "" {
+		cacheDir = defaultModelCacheDir()
+	}
+	return filepath.Join(cacheDir, "models.json")
 }
 
 // defaultModelCacheDir keeps the historical ./.cache location whenever it

--- a/internal/providers/init_test.go
+++ b/internal/providers/init_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -309,6 +310,90 @@ func TestInit_NormalizesNilContext(t *testing.T) {
 	}
 	if _, err := os.Stat(cacheFile + ".tmp"); !os.IsNotExist(err) {
 		t.Fatalf("expected no in-progress cache temp file, stat error = %v", err)
+	}
+}
+
+const unreachableRedisURL = "redis://127.0.0.1:1"
+
+func TestInitCache_FallsBackToLocalWhenRedisUnreachable(t *testing.T) {
+	cacheDir := t.TempDir()
+	c, err := initCache(&config.Config{
+		Cache: config.CacheConfig{
+			Model: config.ModelCacheConfig{
+				Redis: &config.RedisModelConfig{URL: unreachableRedisURL},
+				Local: &config.LocalCacheConfig{CacheDir: cacheDir},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("initCache() error = %v, want nil (degraded local fallback)", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+
+	if _, ok := c.(*modelcache.LocalCache); !ok {
+		t.Fatalf("initCache() type = %T, want *modelcache.LocalCache", c)
+	}
+
+	ctx := t.Context()
+	want := &modelcache.ModelCache{
+		Providers: map[string]modelcache.CachedProvider{
+			"test": {ProviderType: "test", OwnedBy: "test"},
+		},
+	}
+	if err := c.Set(ctx, want); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+	got, err := c.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got == nil || got.Providers["test"].ProviderType != "test" {
+		t.Fatalf("Get() = %+v, want local cache to round-trip in degraded mode", got)
+	}
+}
+
+func TestInitCache_FailsWhenRedisUnreachableAndNoLocal(t *testing.T) {
+	c, err := initCache(&config.Config{
+		Cache: config.CacheConfig{
+			Model: config.ModelCacheConfig{
+				Redis: &config.RedisModelConfig{URL: unreachableRedisURL},
+			},
+		},
+	})
+	if c != nil {
+		_ = c.Close()
+		t.Fatal("initCache() cache != nil, want nil when redis is the only backend and is unreachable")
+	}
+	if err == nil {
+		t.Fatal("initCache() error = nil, want redis connection error")
+	}
+	if !strings.Contains(err.Error(), "failed to connect to redis") {
+		t.Fatalf("initCache() error = %v, want failed to connect to redis", err)
+	}
+}
+
+func TestInit_SucceedsWhenRedisUnreachableAndLocalConfigured(t *testing.T) {
+	result, err := Init(t.Context(), &config.LoadResult{
+		Config: &config.Config{
+			Cache: config.CacheConfig{
+				Model: config.ModelCacheConfig{
+					RefreshInterval: 1,
+					Redis:           &config.RedisModelConfig{URL: unreachableRedisURL},
+					Local:           &config.LocalCacheConfig{CacheDir: t.TempDir()},
+				},
+			},
+		},
+		RawProviders: map[string]config.RawProviderConfig{},
+	}, NewProviderFactory())
+	if err != nil {
+		t.Fatalf("Init() error = %v, want nil in degraded mode", err)
+	}
+	t.Cleanup(func() { _ = result.Close() })
+	if result.Router == nil {
+		t.Fatal("Router = nil, want a usable router after redis fallback")
+	}
+	if _, ok := result.Cache.(*modelcache.LocalCache); !ok {
+		t.Fatalf("Cache type = %T, want *modelcache.LocalCache", result.Cache)
 	}
 }
 


### PR DESCRIPTION
If `cache.model.redis` is set but Redis is unreachable at startup, `initCache` used to return the connection error and abort process init even when a local file cache was also configured.

Keep Redis as the preferred backend. When the Redis client cannot connect and a local backend is present, log a warning and continue on the local file cache. Redis-only configurations still fail so a missing cache is not silent.

Config validation now allows both backends together so a YAML local cache can stay in place as the fallback when `REDIS_URL` is also set.

Fixes #630

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redis is now preferred for model caching when configured.
  * Local caching automatically provides a fallback if Redis is unavailable.
  * Configurations may include both Redis and local cache settings.

* **Bug Fixes**
  * Applications no longer fail to start when Redis is unreachable, provided a local cache is configured.
  * Configurations without any cache backend remain invalid.

* **Documentation**
  * Configuration guidance now explains Redis-first behavior and local-cache fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->