### PR TITLE
fix(usage): meter realtime transcription audio when a session reports none

### DIFF
--- a/docs/advanced/api-endpoints.mdx
+++ b/docs/advanced/api-endpoints.mdx
@@ -88,6 +88,21 @@ audio it relays, at the model's per-second input rate. WebRTC translation calls
 are the exception: their media never transits the gateway, so they are not
 metered.
 
+### Realtime transcription sessions
+
+Transcription sessions (`/v1/realtime?intent=transcription`) pick their model in
+`session.update` rather than in the URL; the `model` query parameter routes the
+request and the gateway pins the in-session selection to it.
+
+Most transcription models report usage in their
+`conversation.item.input_audio_transcription.completed` event — tokens, or
+seconds for whisper-style models — and that report prices the session. A model
+that omits usage there reports nothing, so the gateway falls back to the input
+audio it relayed, at the per-second input rate. The fallback applies only when a
+session reported no usage of its own, so a session is never billed twice. As with
+translation, WebRTC calls carry their media outside the gateway and are not
+metered.
+
 ## Anthropic-Compatible API
 
 | Endpoint                    | Method | Description                                                                   |

--- a/internal/core/realtime.go
+++ b/internal/core/realtime.go
@@ -59,11 +59,17 @@ type RealtimeTarget struct {
 	// whose URL fixes the model leave it empty and no frame mapping happens.
 	PinSessionModel string
 	// MeterInputAudio asks the gateway to bill the session from the input audio
-	// it relays, at the model's per-second input rate. Providers set it for
-	// session types that report no usage of their own — OpenAI translation
-	// sessions emit only transcript and audio deltas, never a usage event — so
-	// such a session is recorded with its real duration instead of as free.
-	// Sessions that report their own usage leave it false.
+	// it relays, at the model's per-second input rate, when the session reports
+	// no usage of its own. Providers set it for session types that may report
+	// nothing: OpenAI translation sessions emit only transcript and audio
+	// deltas and never a usage event, and a transcription session whose model
+	// omits usage from its completed event reports nothing either. Such a
+	// session is then recorded with its real duration instead of as free.
+	//
+	// It is a fallback, not a second meter: a session that recorded even one
+	// usage entry of its own is already billed, and metering the same audio on
+	// top of it would double-count the session. Session types that always
+	// report their own usage leave it false and are never metered.
 	MeterInputAudio bool
 }
 

--- a/internal/providers/openai/realtime.go
+++ b/internal/providers/openai/realtime.go
@@ -41,6 +41,11 @@ func (p *Provider) RealtimeTarget(ctx context.Context, req *core.RealtimeRequest
 		// Pinning keeps the in-session selection on the routed model.
 		endpoint, err = providers.OpenAIRealtimeTranscriptionURL(p.GetBaseURL())
 		target.PinSessionModel = strings.TrimSpace(req.Model)
+		// Most transcription models report usage in their completed event, and
+		// that report is what bills the session. A model that omits usage there,
+		// or streams only transcript deltas, would otherwise record the session
+		// as free, so the relayed audio backs it as a fallback.
+		target.MeterInputAudio = true
 	default:
 		endpoint, err = providers.OpenAIRealtimeURL(p.GetBaseURL(), req.Model)
 	}

--- a/internal/providers/openai/realtime_test.go
+++ b/internal/providers/openai/realtime_test.go
@@ -217,6 +217,13 @@ func TestRealtimeTargetTranscriptionIntent(t *testing.T) {
 		if target.PinSessionModel != "gpt-4o-transcribe" {
 			t.Errorf("intent %q: PinSessionModel = %q, want the routed model", intent, target.PinSessionModel)
 		}
+		// Transcription models usually report usage in their completed event,
+		// but a model that omits it would otherwise leave the session free, so
+		// the relayed audio has to back it. The gateway meters it only when the
+		// session reports nothing, so this never double-bills the common case.
+		if !target.MeterInputAudio {
+			t.Errorf("intent %q: MeterInputAudio = false, want the session metered as a fallback", intent)
+		}
 	}
 
 	// The model still gates the request: without one there is nothing to route

--- a/internal/server/realtime_service.go
+++ b/internal/server/realtime_service.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"sync/atomic"
 
 	"github.com/labstack/echo/v5"
 
@@ -150,7 +151,10 @@ func (s *realtimeService) handle(c *echo.Context, model, providerHint, intent st
 	if err != nil {
 		return handleError(c, err)
 	}
-	tap := s.usageTap(ctx, route)
+	// Raised by the tap when the session records usage of its own; it decides
+	// whether a metered session falls back to billing the audio it relayed.
+	var reported atomic.Bool
+	tap := s.usageTap(ctx, route, &reported)
 	if registered {
 		// The gateway created this call and its sideband observer already records
 		// usage; tapping the attach session too would double-count every response.
@@ -163,8 +167,11 @@ func (s *realtimeService) handle(c *echo.Context, model, providerHint, intent st
 	if model := strings.TrimSpace(target.PinSessionModel); model != "" {
 		hooks.MapClientFrame = pinTranscriptionModel(model)
 	}
-	// A session that reports no usage of its own (OpenAI translation sessions)
-	// is billed from the audio the gateway relays into it.
+	// A session that may report no usage of its own — translation sessions never
+	// do, transcription sessions do unless their model omits usage from the
+	// completed event — is billed from the audio the gateway relays into it.
+	// The audio is metered as it flows, because the session only reveals at its
+	// end whether it reported anything, and by then the frames are gone.
 	var meter *usage.RealtimeInputAudioMeter
 	if target.MeterInputAudio && tap != nil {
 		meter = &usage.RealtimeInputAudioMeter{}
@@ -172,15 +179,17 @@ func (s *realtimeService) handle(c *echo.Context, model, providerHint, intent st
 	}
 
 	err = s.proxy(c, ctx, target, route, hooks)
-	s.recordMeteredUsage(route, meter)
+	s.recordMeteredUsage(route, meter, reported.Load())
 	return err
 }
 
 // recordMeteredUsage writes the single usage entry for a metered session once it
-// ends. Metered sessions carry no usage events, so this is their only accounting;
-// a session that relayed no audio produced no billable duration and is skipped.
-func (s *realtimeService) recordMeteredUsage(route realtimeRoute, meter *usage.RealtimeInputAudioMeter) {
-	if meter == nil {
+// ends. It is a fallback for sessions that reported no usage of their own, so it
+// is their only accounting; a session that relayed no audio produced no billable
+// duration and is skipped. A session that did report is already billed by its
+// own usage events, and billing the same audio again would double-count it.
+func (s *realtimeService) recordMeteredUsage(route realtimeRoute, meter *usage.RealtimeInputAudioMeter, reported bool) {
+	if meter == nil || reported {
 		return
 	}
 	seconds := meter.Seconds()
@@ -267,7 +276,12 @@ func (s *realtimeService) proxy(c *echo.Context, ctx context.Context, target *co
 // the tap entirely). It honors both the global usage setting and per-workflow
 // usage policy, mirroring the other streaming paths. usageLogger.Write is
 // non-blocking, so the tap runs inline.
-func (s *realtimeService) usageTap(ctx context.Context, route realtimeRoute) func([]byte) {
+//
+// reported, when non-nil, is raised as soon as the session records usage of its
+// own, which tells a metered session it is already billed and must not be
+// metered on top. It is set on the relay goroutine and read after the session
+// ends, so it is atomic.
+func (s *realtimeService) usageTap(ctx context.Context, route realtimeRoute, reported *atomic.Bool) func([]byte) {
 	if s.usageLogger == nil || !s.usageLogger.Config().Enabled {
 		return nil
 	}
@@ -285,6 +299,11 @@ func (s *realtimeService) usageTap(ctx context.Context, route realtimeRoute) fun
 			entry = usage.ExtractFromRealtimeResponseDone(frame, route.requestID, route.model, route.providerType, pricing)
 		} else {
 			entry = usage.ExtractFromRealtimeTranscriptionCompleted(frame, route.requestID, route.model, route.providerType, pricing)
+		}
+		// An event that carries no usage (a completed event whose model omits
+		// the usage object) bills nothing and leaves the session unreported.
+		if entry != nil && reported != nil {
+			reported.Store(true)
 		}
 		s.writeUsage(entry, route)
 	}

--- a/internal/server/realtime_service.go
+++ b/internal/server/realtime_service.go
@@ -188,6 +188,12 @@ func (s *realtimeService) handle(c *echo.Context, model, providerHint, intent st
 // is their only accounting; a session that relayed no audio produced no billable
 // duration and is skipped. A session that did report is already billed by its
 // own usage events, and billing the same audio again would double-count it.
+//
+// The fallback is all or nothing by design. A session that reports usage for
+// only part of what it heard leaves the rest unbilled, because the gateway
+// cannot tell which audio a partial report already covered, and billing the
+// whole session on top of it would overcharge for the part that was reported.
+// Undercounting a provider that reports inconsistently is the safer error.
 func (s *realtimeService) recordMeteredUsage(route realtimeRoute, meter *usage.RealtimeInputAudioMeter, reported bool) {
 	if meter == nil || reported {
 		return
@@ -300,9 +306,11 @@ func (s *realtimeService) usageTap(ctx context.Context, route realtimeRoute, rep
 		} else {
 			entry = usage.ExtractFromRealtimeTranscriptionCompleted(frame, route.requestID, route.model, route.providerType, pricing)
 		}
-		// An event that carries no usage (a completed event whose model omits
-		// the usage object) bills nothing and leaves the session unreported.
-		if entry != nil && reported != nil {
+		// Only billable usage counts as a report. An event that carries no usage
+		// object bills nothing, and neither does one whose usage is present but
+		// all zeros, so in both cases the session is still unaccounted for and
+		// the fallback must remain free to meter the audio it relayed.
+		if reported != nil && usage.HasBillableUsage(entry) {
 			reported.Store(true)
 		}
 		s.writeUsage(entry, route)

--- a/internal/server/realtime_transcription_usage_test.go
+++ b/internal/server/realtime_transcription_usage_test.go
@@ -1,0 +1,165 @@
+package server
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"math"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/labstack/echo/v5"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/realtime"
+	"github.com/enterpilot/gomodel/internal/usage"
+)
+
+// newTranscriptionSession opens a transcription session against an echoing
+// upstream and returns the client socket plus the logger that captured its
+// usage. The target mirrors a real OpenAI transcription target: the model is
+// pinned in-session (the URL carries none) and the session is metered as a
+// fallback for models that report no usage of their own.
+func newTranscriptionSession(t *testing.T, upstream *realtimeUpstream) (*websocket.Conn, *usageCaptureLogger, func([]byte)) {
+	t.Helper()
+	mock := &realtimeWebRTCMock{
+		mockProvider: &mockProvider{supportedModels: []string{"gpt-4o-transcribe"}},
+		realtimeTarget: &core.RealtimeTarget{
+			URL:             "ws" + strings.TrimPrefix(upstream.URL, "http"),
+			PinSessionModel: "gpt-4o-transcribe",
+			MeterInputAudio: true,
+		},
+	}
+	usageLogger := &usageCaptureLogger{config: usage.Config{Enabled: true}}
+	handler := newRealtimeTestHandler(mock, usageLogger)
+
+	e := echo.New()
+	e.GET("/v1/realtime", handler.Realtime)
+	gateway := httptest.NewServer(e)
+	t.Cleanup(gateway.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+	client, _, err := websocket.Dial(ctx,
+		"ws"+strings.TrimPrefix(gateway.URL, "http")+"/v1/realtime?model=gpt-4o-transcribe&intent=transcription", nil)
+	if err != nil {
+		t.Fatalf("client dial failed: %v", err)
+	}
+	// Audio frames are far larger than the library default read limit; a real
+	// realtime client raises it the same way the relay does.
+	client.SetReadLimit(realtime.MaxFrameBytes)
+
+	// send writes one frame and waits for the upstream echo. The echo proves the
+	// relay already read — and therefore metered and tapped — the frame, so the
+	// close that ends the session cannot outrun its accounting.
+	send := func(frame []byte) {
+		t.Helper()
+		if err := client.Write(ctx, websocket.MessageText, frame); err != nil {
+			t.Fatalf("client write failed: %v", err)
+		}
+		if _, _, err := client.Read(ctx); err != nil {
+			t.Fatalf("client read failed: %v", err)
+		}
+	}
+	return client, usageLogger, send
+}
+
+// realtimeAudioFrame builds an input audio append carrying seconds of PCM16
+// mono at 24 kHz, the format realtime input defaults to.
+func realtimeAudioFrame(t *testing.T, seconds int) []byte {
+	t.Helper()
+	frame, err := json.Marshal(map[string]any{
+		"type":  "input_audio_buffer.append",
+		"audio": base64.StdEncoding.EncodeToString(make([]byte, seconds*24000*2)),
+	})
+	if err != nil {
+		t.Fatalf("failed to build audio frame: %v", err)
+	}
+	return frame
+}
+
+func TestRealtimeTranscriptionWithoutUsageEventsRecordsAudioDuration(t *testing.T) {
+	// A transcription session whose model reports no usage — no completed event,
+	// or one without a usage object — would be recorded as free. The relayed
+	// audio backs it instead: two seconds in, one duration entry out.
+	upstream := newEchoingRealtimeUpstream(t)
+	defer upstream.Close()
+
+	client, usageLogger, send := newTranscriptionSession(t, upstream)
+	frame := realtimeAudioFrame(t, 1)
+	for range 2 {
+		send(frame)
+	}
+	// Transcript deltas carry no usage, so they must not count as a report and
+	// suppress the fallback.
+	send([]byte(`{"type":"conversation.item.input_audio_transcription.delta","delta":"He"}`))
+	_ = client.Close(websocket.StatusNormalClosure, "done")
+
+	entries := waitForUsageEntries(t, usageLogger, 1)
+	entry := entries[0]
+	if entry.Endpoint != "/v1/realtime" {
+		t.Errorf("endpoint = %q, want the realtime surface", entry.Endpoint)
+	}
+	if entry.Model != "gpt-4o-transcribe" {
+		t.Errorf("model = %q, want the routed model", entry.Model)
+	}
+	seconds, ok := entry.RawData["audio_seconds"].(float64)
+	if !ok {
+		t.Fatalf("raw data = %v, want metered audio seconds", entry.RawData)
+	}
+	if math.Abs(seconds-2) > 1e-9 {
+		t.Errorf("audio seconds = %v, want 2", seconds)
+	}
+}
+
+func TestRealtimeTranscriptionReportingUsageIsNotMeteredTwice(t *testing.T) {
+	// The common case: the model reports usage in its completed event, and that
+	// report bills the session. Metering the relayed audio on top would bill the
+	// same speech twice, so the fallback must stay out of the way.
+	upstream := newEchoingRealtimeUpstream(t)
+	defer upstream.Close()
+
+	client, usageLogger, send := newTranscriptionSession(t, upstream)
+	send(realtimeAudioFrame(t, 1))
+	// Echoed back by the upstream, this reaches the gateway as the server event
+	// a transcription session reports its usage in.
+	send([]byte(`{
+		"type": "conversation.item.input_audio_transcription.completed",
+		"item_id": "item_1",
+		"transcript": "Hello there.",
+		"usage": {"type": "tokens", "total_tokens": 30, "input_tokens": 25, "output_tokens": 5}
+	}`))
+	_ = client.Close(websocket.StatusNormalClosure, "done")
+
+	entries := waitForUsageEntries(t, usageLogger, 1)
+	entry := entries[0]
+	if entry.TotalTokens != 30 || entry.InputTokens != 25 {
+		t.Errorf("tokens = (%d,%d), want the reported (25,30)", entry.InputTokens, entry.TotalTokens)
+	}
+	if _, metered := entry.RawData["audio_seconds"]; metered {
+		t.Errorf("raw data = %v, want no metered duration for a session that reported usage", entry.RawData)
+	}
+}
+
+func TestRealtimeTranscriptionWithoutAudioRecordsNothing(t *testing.T) {
+	// A session that opened but relayed no audio produced nothing billable, so
+	// the fallback must not write a zero-duration entry.
+	upstream := newEchoingRealtimeUpstream(t)
+	defer upstream.Close()
+
+	client, usageLogger, send := newTranscriptionSession(t, upstream)
+	send([]byte(`{"type":"session.update","session":{"type":"transcription"}}`))
+	_ = client.Close(websocket.StatusNormalClosure, "done")
+
+	select {
+	case <-upstream.closed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("upstream session did not end")
+	}
+	if entries := usageLogger.Entries(); len(entries) != 0 {
+		t.Errorf("usage entries = %d, want none for a session that relayed no audio", len(entries))
+	}
+}

--- a/internal/server/realtime_transcription_usage_test.go
+++ b/internal/server/realtime_transcription_usage_test.go
@@ -93,9 +93,12 @@ func TestRealtimeTranscriptionWithoutUsageEventsRecordsAudioDuration(t *testing.
 	for range 2 {
 		send(frame)
 	}
-	// Transcript deltas carry no usage, so they must not count as a report and
-	// suppress the fallback.
+	// Neither a transcript delta nor a completed event without a usage object
+	// reports anything billable, so neither may suppress the fallback. The
+	// completed event matters most: it takes the extraction path that does
+	// produce entries, and only its missing usage keeps this session unbilled.
 	send([]byte(`{"type":"conversation.item.input_audio_transcription.delta","delta":"He"}`))
+	send([]byte(`{"type":"conversation.item.input_audio_transcription.completed","transcript":"Hello there."}`))
 	_ = client.Close(websocket.StatusNormalClosure, "done")
 
 	entries := waitForUsageEntries(t, usageLogger, 1)
@@ -141,6 +144,34 @@ func TestRealtimeTranscriptionReportingUsageIsNotMeteredTwice(t *testing.T) {
 	}
 	if _, metered := entry.RawData["audio_seconds"]; metered {
 		t.Errorf("raw data = %v, want no metered duration for a session that reported usage", entry.RawData)
+	}
+}
+
+func TestRealtimeTranscriptionZeroUsageStillMetersAudio(t *testing.T) {
+	// A usage object of all zeros reports a number, not a bill. Treating it as a
+	// report would leave the relayed speech unbilled, so the fallback still
+	// meters it; the provider's own zero-value entry is recorded alongside,
+	// because what a provider reported is worth keeping even at zero.
+	upstream := newEchoingRealtimeUpstream(t)
+	defer upstream.Close()
+
+	client, usageLogger, send := newTranscriptionSession(t, upstream)
+	send(realtimeAudioFrame(t, 2))
+	send([]byte(`{
+		"type": "conversation.item.input_audio_transcription.completed",
+		"transcript": "Hello there.",
+		"usage": {"type": "duration", "seconds": 0}
+	}`))
+	_ = client.Close(websocket.StatusNormalClosure, "done")
+
+	entries := waitForUsageEntries(t, usageLogger, 2)
+	var metered float64
+	for _, entry := range entries {
+		seconds, _ := entry.RawData["audio_seconds"].(float64)
+		metered += seconds
+	}
+	if math.Abs(metered-2) > 1e-9 {
+		t.Errorf("metered audio seconds = %v, want the 2 seconds relayed: %+v", metered, entries)
 	}
 }
 

--- a/internal/server/realtime_webrtc_service.go
+++ b/internal/server/realtime_webrtc_service.go
@@ -288,7 +288,10 @@ func realtimeCallIDFromLocation(location string) string {
 // the call; if it cannot attach, the call proceeds untracked and a warning is
 // logged. No-op when usage tracking is off.
 func (s *realtimeService) observeCall(ctx context.Context, route realtimeRoute, callID string) {
-	tap := s.usageTap(ctx, route)
+	// A WebRTC call carries its audio on the media plane, direct between client
+	// and provider, so there is no relayed audio to fall back on and nothing to
+	// gate: the sideband observer is this session's only accounting.
+	tap := s.usageTap(ctx, route, nil)
 	if tap == nil {
 		return
 	}

--- a/internal/usage/realtime.go
+++ b/internal/usage/realtime.go
@@ -111,6 +111,22 @@ func ExtractFromRealtimeTranscriptionCompleted(payload []byte, requestID, model,
 	return realtimeUsageEntry(&event.Usage.realtimeUsage, requestID, model, provider, pricing...)
 }
 
+// HasBillableUsage reports whether an entry carries usage worth billing: tokens,
+// or metered audio seconds. A provider that answers with a usage object of all
+// zeros has reported a number, not a bill, so a session holding only such
+// entries is still unaccounted for and a metered session must fall back to the
+// audio it relayed rather than treat itself as already billed.
+func HasBillableUsage(entry *UsageEntry) bool {
+	if entry == nil {
+		return false
+	}
+	if entry.TotalTokens > 0 || entry.InputTokens > 0 || entry.OutputTokens > 0 {
+		return true
+	}
+	seconds, _ := entry.RawData[rawKeyAudioSeconds].(float64)
+	return seconds > 0
+}
+
 // NewRealtimeDurationEntry builds a usage entry for realtime audio billed by
 // duration rather than tokens. The duration is carried as input audio seconds so
 // the model's per-second input rate prices it, the same as HTTP transcription

--- a/internal/usage/realtime_test.go
+++ b/internal/usage/realtime_test.go
@@ -226,3 +226,28 @@ func TestExtractFromRealtimeTranscriptionCompletedSkipsNonBillable(t *testing.T)
 		}
 	}
 }
+
+func TestHasBillableUsage(t *testing.T) {
+	// The gateway meters a session's relayed audio only when the session itself
+	// reported nothing billable, so a zero-value report must not read as a bill.
+	tests := []struct {
+		name  string
+		entry *UsageEntry
+		want  bool
+	}{
+		{name: "nil entry"},
+		{name: "tokens", entry: &UsageEntry{TotalTokens: 30, InputTokens: 25}, want: true},
+		{name: "output tokens only", entry: &UsageEntry{OutputTokens: 5}, want: true},
+		{name: "audio seconds", entry: &UsageEntry{RawData: map[string]any{rawKeyAudioSeconds: 2.5}}, want: true},
+		{name: "zero tokens", entry: &UsageEntry{}},
+		{name: "zero seconds", entry: &UsageEntry{RawData: map[string]any{rawKeyAudioSeconds: 0.0}}},
+		{name: "unrelated raw data", entry: &UsageEntry{RawData: map[string]any{"prompt_text_tokens": 0}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HasBillableUsage(tt.entry); got != tt.want {
+				t.Errorf("HasBillableUsage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Realtime transcription sessions bill from the usage their
`conversation.item.input_audio_transcription.completed` event carries — tokens,
or seconds for whisper-style models. A model that omits the `usage` object
there, or that streams only transcript deltas, reports nothing, and the session
was recorded as free.

The relayed input audio now backs those sessions at the model's per-second input
rate, reusing the meter added for translation sessions in #770.

**It is a fallback, not a second meter.** Most transcription models do report
usage, and metering their audio on top would bill the same speech twice. The
gateway tracks whether a session recorded usage of its own and skips the
duration entry when it did. Audio is metered as it flows, because a session only
reveals at its end whether it reported anything, and by then the frames are
gone.

Translation sessions are unchanged in practice (they never report usage) and are
now also protected if that ever changes. WebRTC calls carry their media outside
the gateway, so they have no relayed audio to fall back on and stay unmetered.

## User-visible impact

Transcription sessions from models that report no usage now appear in usage and
cost reporting with their real duration instead of as free. Sessions that report
usage are billed exactly as before.

## Provider behavior

OpenAI transcription targets set the fallback flag alongside the existing
in-session model pin. Providers whose session types always report their own
usage leave it off and are never metered.

## Tests

- transcription session with no usage events → one duration entry
- transcription session reporting usage → exactly one entry, no duration line
- transcription session that relayed no audio → no entry
- provider target sets the fallback flag for the transcription intent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added usage metering for realtime transcription sessions when the transcription model does not report usage directly.
  - Prevented duplicate billing when a session already reports its own usage.
  - WebRTC transcription sessions remain unmetered for relayed audio because media does not pass through the gateway.

- **Documentation**
  - Documented transcription session model selection, usage reporting, fallback metering, and pricing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->