### PR TITLE
docs(version): require build metadata for distribution markers in manifests

### DIFF
--- a/docs/advanced/version-awareness.mdx
+++ b/docs/advanced/version-awareness.mdx
@@ -31,7 +31,7 @@ The check reads one plain-text file:
 | Distribution | URL                              | Contents    |
 | ------------ | -------------------------------- | ----------- |
 | GoModel      | `(thiswebsite)/version/core.txt` | `X.Y.Z`     |
-| GoModel Pro  | `(thiswebsite)/version/pro.txt`  | `X.Y.Z-pro` |
+| GoModel Pro  | `(thiswebsite)/version/pro.txt`  | `X.Y.Z+pro` |
 
 ## When it runs
 
@@ -105,6 +105,12 @@ GOMODEL_VERSION_CHECK_URL=https://releases.internal.example.com/version
 
 The gateway appends `/core.txt` or `/pro.txt` based on its distribution, and
 expects a bare version string with no leading `v`.
+
+A mirror may annotate the value with semantic-versioning **build metadata**
+(`1.2.3+mirror`), which is excluded from precedence and therefore safe. Do not
+annotate with a prerelease suffix (`1.2.3-mirror`): that ranks *above* a plain
+`1.2.3` and below `1.2.3-mirrorx`, so gateways would compare against something
+other than the release you published.
 
 ## Configuration
 

--- a/internal/versioncheck/compare_test.go
+++ b/internal/versioncheck/compare_test.go
@@ -34,6 +34,14 @@ func TestIsNewer(t *testing.T) {
 		{"longer prerelease supersedes its prefix", "1.0.0-rc", "1.0.0-rc.1", true},
 		{"double digit prerelease beats single", "1.0.0-rc.9", "1.0.0-rc.10", true},
 		{"identical pro suffix", "1.0.0-pro", "1.0.0-pro", false},
+		// A distribution marker belongs in build metadata, which is excluded
+		// from precedence, so a gateway never reports an update to itself.
+		{"build metadata marker on the manifest", "1.0.0+core.0.1.83", "1.0.0+pro", false},
+		{"build metadata marker on a prerelease", "1.2.3-beta.1+core.0.1.83", "1.2.3-beta.1+pro", false},
+		{"build metadata does not mask a real bump", "1.2.3-beta.1+core.0.1.83", "1.2.4+pro", true},
+		// The same marker as a prerelease suffix silently extends the
+		// identifier and outranks the release it annotates.
+		{"prerelease suffix would outrank its own release", "1.2.3-beta.1+core.0.1.83", "1.2.3-beta.1-pro", true},
 		// A numeric identifier larger than an int must still rank below an
 		// alphanumeric one rather than falling back to a lexical comparison.
 		{"oversized numeric prerelease ranks below alphanumeric", "1.0.0-999999999999999999999", "1.0.0-2foo", true},


### PR DESCRIPTION
A manifest that annotates its version with a prerelease suffix outranks the release it describes, so a gateway reports an update to itself. `1.2.3-beta.1` reading a manifest of `1.2.3-beta.1-pro` compares `beta.1-pro` above `beta.1` and never stops announcing an upgrade. Build metadata is the correct marker because semantic versioning excludes it from precedence, so `1.2.3-beta.1+pro` reduces to the same release the gateway is running. The docs now state this for anyone mirroring the manifests, and four comparator cases pin both behaviours so the rule cannot drift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that GoModel Pro versions use the `X.Y.Z+pro` format.
  * Documented safe version annotations for air-gapped and mirrored deployments.
  * Explained how build metadata and prerelease suffixes affect version comparisons.

* **Tests**
  * Added coverage for version comparisons involving build metadata, stable releases, and prerelease versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->