### PR TITLE
refactor(release): publish core.txt with a deploy key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,24 +207,25 @@ jobs:
   publish-version-manifest:
     name: Publish version manifest
     runs-on: ubuntu-latest
-    # Runs after the GitHub release exists: the website regenerates
-    # public/version/core.txt from the latest release, so dispatching earlier
-    # would republish the previous version.
+    # Gateways check this manifest daily, so it must only ever advertise a
+    # release operators can actually download.
     needs: github-release
-    # Prereleases (v1.2.3-rc1) are not "latest" on GitHub, so the website
-    # would regenerate the same manifest it already serves.
+    # Prereleases are not an upgrade the manifest should offer.
     if: ${{ !contains(github.ref_name, '-') }}
-    # Best-effort: running gateways keep working on a stale manifest, and the
-    # website's nightly deploy regenerates it anyway.
+    # Best-effort: running gateways keep working on a stale manifest.
     continue-on-error: true
     steps:
-      - name: Dispatch website deploy
-        env:
-          GH_TOKEN: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}
-        run: |
-          gh api repos/ENTERPILOT/gomodel.enterpilot.io/dispatches \
-            -f event_type=gomodel-release \
-            -f "client_payload[version]=${GITHUB_REF_NAME#v}"
+      - name: Checkout website repository
+        uses: actions/checkout@v7
+        with:
+          repository: ENTERPILOT/gomodel.enterpilot.io
+          # A deploy key is scoped to that one repository and carries no user
+          # identity. Pushing the manifest is itself the website's deploy
+          # trigger, so the new version is served within minutes.
+          ssh-key: ${{ secrets.WEBSITE_PUSH_KEY }}
+
+      - name: Publish core.txt
+        run: ./scripts/publish-version.sh core "${GITHUB_REF_NAME#v}"
 
   publish-mcp:
     name: Publish to MCP Registry


### PR DESCRIPTION
The `Publish version manifest` job dispatched an event to the website repository using `WEBSITE_DISPATCH_TOKEN`, a secret that was never set. The job has failed on every release — `continue-on-error: true` hid it — and only the website's nightly rebuild kept `core.txt` current.

It now checks the website out with a deploy key, which is scoped to that one repository and carries no user identity, and runs `scripts/publish-version.sh` from there. That script is shared with the GoModel Pro release, replacing two near-identical copies of the same publishing logic. Pushing the manifest is itself the website's deploy trigger, so a new release is advertised within minutes instead of waiting for the next nightly run.

Requires ENTERPILOT/gomodel.enterpilot.io#20, which adds the script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process to publish version information directly to the website repository.
  * Improved reliability by removing the intermediate webhook-based regeneration step.
  * Preserved prerelease handling and best-effort publishing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->