### PR TITLE
fix(elevenlabs): request pcm_24000 for pcm speech output

### DIFF
--- a/docs/providers/elevenlabs.mdx
+++ b/docs/providers/elevenlabs.mdx
@@ -57,7 +57,7 @@ surface via passthrough, not just voice listing — see "Not implemented" below.
 
 `response_format` accepts `mp3` (default), `opus`, `pcm`, and `wav`; each maps
 to a fixed ElevenLabs `output_format` (`mp3_44100_128`, `opus_48000_128`,
-`pcm_44100`, `wav_44100`). `aac` and `flac` are not supported and return
+`pcm_24000`, `wav_44100`). `aac` and `flac` are not supported and return
 `invalid_request_error`. `speed`, when set, is clamped to ElevenLabs' `0.7`-`1.2`
 voice setting range (OpenAI accepts `0.25`-`4.0`); `instructions` is not
 supported.

--- a/internal/providers/elevenlabs/audio.go
+++ b/internal/providers/elevenlabs/audio.go
@@ -72,7 +72,9 @@ func speechFormat(responseFormat string) (openAIFormat, outputFormat string, err
 	case "opus":
 		return format, "opus_48000_128", nil
 	case "pcm":
-		return format, "pcm_44100", nil
+		// pcm_44100 is gated to ElevenLabs Pro plans and above; 24 kHz is what OpenAI-
+		// compatible callers expect for "pcm" anyway and is available on every plan.
+		return format, "pcm_24000", nil
 	case "wav":
 		return format, "wav_44100", nil
 	default:

--- a/internal/providers/elevenlabs/audio_test.go
+++ b/internal/providers/elevenlabs/audio_test.go
@@ -74,7 +74,7 @@ func TestCreateSpeech_MapsResponseFormats(t *testing.T) {
 	}{
 		{"default mp3", "", "output_format=mp3_44100_128", "audio/mpeg"},
 		{"opus", "opus", "output_format=opus_48000_128", "audio/ogg"},
-		{"pcm", "pcm", "output_format=pcm_44100", "audio/pcm"},
+		{"pcm", "pcm", "output_format=pcm_24000", "audio/pcm"},
 		{"wav", "wav", "output_format=wav_44100", "audio/wav"},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
ElevenLabs gates `pcm_44100` to Pro plans and above, so `response_format: pcm` on `/v1/audio/speech` failed with 403 ("Output format 'pcm_44100' is only available on the Pro tier and above") for every lower plan. `pcm_24000` is available on all plans and is the sample rate OpenAI-compatible callers already expect for `pcm` (it is what OpenAI returns).

Verified against a Creator-plan key: `pcm_24000` and `pcm_16000` → 200, `pcm_44100` → 403. Tests and the provider doc updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VV48RBH3hiB57Gqf1VK15S

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected PCM speech output to use the 24 kHz format, improving compatibility with supported speech integrations.
  - PCM output is now available across all supported plan levels instead of requiring a higher-tier format.

- **Documentation**
  - Updated ElevenLabs provider documentation to reflect the correct PCM output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->