### PR TITLE
chore: apply go fix modernizations for Go 1.27

### DIFF
--- a/internal/admin/handler_audit.go
+++ b/internal/admin/handler_audit.go
@@ -348,13 +348,11 @@ func (h *Handler) AuditStats(c *echo.Context) error {
 
 	_, location := dashboardTimeZone(c)
 	params := auditlog.RequestStatsParams{
-		QueryParams: auditlog.QueryParams{
-			StartDate: dateRange.StartDate,
-			EndDate:   dateRange.EndDate,
-		},
-		Interval: interval,
-		Location: location,
-		Now:      timeNow(),
+		StartDate: dateRange.StartDate,
+		EndDate:   dateRange.EndDate,
+		Interval:  interval,
+		Location:  location,
+		Now:       timeNow(),
 	}
 
 	stats, err := h.auditReader.GetRequestStats(c.Request().Context(), params)

--- a/internal/admin/handler_provider_credentials.go
+++ b/internal/admin/handler_provider_credentials.go
@@ -478,8 +478,7 @@ func providerCredentialWriteError(err error) error {
 	if err == nil {
 		return nil
 	}
-	var fieldErr *providers.CredentialFieldError
-	if errors.As(err, &fieldErr) {
+	if fieldErr, ok := errors.AsType[*providers.CredentialFieldError](err); ok {
 		invalid := core.NewInvalidRequestError(fieldErr.Message, err)
 		if fieldErr.Field == "" {
 			// Bad input the form cannot pin on one input; still a 400.

--- a/internal/anthropicapi/response.go
+++ b/internal/anthropicapi/response.go
@@ -63,9 +63,9 @@ func usageFromCore(usage core.Usage) Usage {
 	out := Usage{
 		InputTokens:  usage.PromptTokens,
 		OutputTokens: usage.CompletionTokens,
-	}
-	out.CacheCreationInputTokens = intFromRaw(usage.RawUsage["cache_creation_input_tokens"])
-	out.CacheReadInputTokens = intFromRaw(usage.RawUsage["cache_read_input_tokens"])
+
+		CacheCreationInputTokens: intFromRaw(usage.RawUsage["cache_creation_input_tokens"]),
+		CacheReadInputTokens:     intFromRaw(usage.RawUsage["cache_read_input_tokens"])}
 	return out
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -165,14 +165,14 @@ func routeSelectorHooks(selector ext.RouteSelector) llmclient.Hooks {
 			observe("attempt_end", func() {
 				source, sessionID := routeAffinityContext(ctx)
 				selector.OnAttemptEnd(ext.RouteOutcome{
-					RouteTarget: ext.RouteTarget{Provider: info.Provider, Model: info.Model},
-					Source:      source,
-					SessionID:   sessionID,
-					Endpoint:    info.Endpoint,
-					StatusCode:  info.StatusCode,
-					Duration:    info.Duration,
-					Stream:      info.Stream,
-					Err:         info.Error,
+					Provider: info.Provider, Model: info.Model,
+					Source:     source,
+					SessionID:  sessionID,
+					Endpoint:   info.Endpoint,
+					StatusCode: info.StatusCode,
+					Duration:   info.Duration,
+					Stream:     info.Stream,
+					Err:        info.Error,
 				})
 			})
 		},

--- a/internal/app/subsystems.go
+++ b/internal/app/subsystems.go
@@ -3,6 +3,7 @@ package app
 import (
 	"errors"
 	"reflect"
+	"slices"
 )
 
 // Subsystem teardown.
@@ -88,8 +89,8 @@ func (a *App) register(name string, owner closerOwner, closeFn func() error) {
 // of these components, so reverse construction is the correct order.
 func (a *App) unwind() error {
 	var errs []error
-	for i := len(a.registered) - 1; i >= 0; i-- {
-		if closeFn := a.registered[i].close; closeFn != nil {
+	for _, v := range slices.Backward(a.registered) {
+		if closeFn := v.close; closeFn != nil {
 			errs = append(errs, closeFn())
 		}
 	}

--- a/internal/auditlog/reader_sql_boundary_test.go
+++ b/internal/auditlog/reader_sql_boundary_test.go
@@ -54,12 +54,10 @@ func TestSQLReaderGetLogs_IncludesFractionalStartBoundaryAndExcludesFractionalEn
 		}
 
 		result, err := reader.GetLogs(ctx, LogQueryParams{
-			QueryParams: QueryParams{
-				StartDate: time.Date(2026, 1, 16, 0, 0, 0, 0, location),
-				EndDate:   time.Date(2026, 1, 16, 0, 0, 0, 0, location),
-			},
-			Limit:  10,
-			Offset: 0,
+			StartDate: time.Date(2026, 1, 16, 0, 0, 0, 0, location),
+			EndDate:   time.Date(2026, 1, 16, 0, 0, 0, 0, location),
+			Limit:     10,
+			Offset:    0,
 		})
 		if err != nil {
 			t.Fatalf("GetLogs returned error: %v", err)

--- a/internal/auditlog/stats_test.go
+++ b/internal/auditlog/stats_test.go
@@ -44,10 +44,10 @@ func TestFoldRequestStats_HourInterval(t *testing.T) {
 	}
 
 	stats := foldRequestStats(rows, RequestStatsParams{
-		QueryParams: QueryParams{StartDate: day, EndDate: day},
-		Interval:    StatsIntervalHour,
-		Location:    time.UTC,
-		Now:         day.Add(12*time.Hour + 30*time.Minute),
+		StartDate: day, EndDate: day,
+		Interval: StatsIntervalHour,
+		Location: time.UTC,
+		Now:      day.Add(12*time.Hour + 30*time.Minute),
 	})
 
 	if stats.Interval != StatsIntervalHour {
@@ -129,10 +129,10 @@ func TestFoldRequestStats_DayIntervalFoldsHoursIntoLocalDays(t *testing.T) {
 	start := time.Date(2026, 1, 16, 0, 0, 0, 0, location)
 	end := time.Date(2026, 1, 17, 0, 0, 0, 0, location)
 	stats := foldRequestStats(rows, RequestStatsParams{
-		QueryParams: QueryParams{StartDate: start, EndDate: end},
-		Interval:    StatsIntervalDay,
-		Location:    location,
-		Now:         time.Date(2026, 1, 18, 12, 0, 0, 0, location),
+		StartDate: start, EndDate: end,
+		Interval: StatsIntervalDay,
+		Location: location,
+		Now:      time.Date(2026, 1, 18, 12, 0, 0, 0, location),
 	})
 
 	if len(stats.Buckets) != 2 {
@@ -155,10 +155,10 @@ func TestFoldRequestStats_ZeroFillStopsAtNow(t *testing.T) {
 	end := time.Date(2026, 1, 20, 0, 0, 0, 0, location)
 
 	stats := foldRequestStats(nil, RequestStatsParams{
-		QueryParams: QueryParams{StartDate: start, EndDate: end},
-		Interval:    StatsIntervalDay,
-		Location:    location,
-		Now:         time.Date(2026, 1, 12, 15, 0, 0, 0, location),
+		StartDate: start, EndDate: end,
+		Interval: StatsIntervalDay,
+		Location: location,
+		Now:      time.Date(2026, 1, 12, 15, 0, 0, 0, location),
 	})
 
 	if len(stats.Buckets) != 3 {
@@ -203,10 +203,10 @@ func TestSQLReaderGetRequestStats(t *testing.T) {
 		}
 
 		stats, err := reader.GetRequestStats(context.Background(), RequestStatsParams{
-			QueryParams: QueryParams{StartDate: day, EndDate: day},
-			Interval:    StatsIntervalHour,
-			Location:    time.UTC,
-			Now:         day.Add(23 * time.Hour),
+			StartDate: day, EndDate: day,
+			Interval: StatsIntervalHour,
+			Location: time.UTC,
+			Now:      day.Add(23 * time.Hour),
 		})
 		if err != nil {
 			t.Fatalf("GetRequestStats failed: %v", err)

--- a/internal/authkeys/service.go
+++ b/internal/authkeys/service.go
@@ -197,11 +197,9 @@ func (s *Service) Create(ctx context.Context, input CreateInput) (*IssuedKey, er
 	s.refreshBestEffort(ctx, "create")
 
 	return &IssuedKey{
-		View: View{
-			AuthKey: key,
-			Active:  key.Active(now),
-		},
-		Value: value,
+		AuthKey: key,
+		Active:  key.Active(now),
+		Value:   value,
 	}, nil
 }
 

--- a/internal/budget/store_mongodb.go
+++ b/internal/budget/store_mongodb.go
@@ -343,8 +343,7 @@ func (e *mongoTransactionFallbackError) Error() string {
 }
 
 func mongoTransactionFallbackCause(err error) error {
-	var fallbackErr *mongoTransactionFallbackError
-	if errors.As(err, &fallbackErr) {
+	if fallbackErr, ok := errors.AsType[*mongoTransactionFallbackError](err); ok {
 		return fallbackErr.err
 	}
 	return nil

--- a/internal/guardrails/service_test.go
+++ b/internal/guardrails/service_test.go
@@ -292,8 +292,7 @@ func TestServiceRefresh_ReturnsGatewayErrorOnStoreFailure(t *testing.T) {
 	if err == nil {
 		t.Fatal("Refresh() error = nil, want gateway error")
 	}
-	var gatewayErr *core.GatewayError
-	if !errors.As(err, &gatewayErr) {
+	if _, ok := errors.AsType[*core.GatewayError](err); !ok {
 		t.Fatalf("Refresh() error = %T, want *core.GatewayError", err)
 	}
 }
@@ -305,8 +304,7 @@ func TestServiceBuildPipeline_ReturnsGatewayErrorWhenCatalogMissing(t *testing.T
 	if err == nil {
 		t.Fatal("BuildPipeline() error = nil, want gateway error")
 	}
-	var gatewayErr *core.GatewayError
-	if !errors.As(err, &gatewayErr) {
+	if _, ok := errors.AsType[*core.GatewayError](err); !ok {
 		t.Fatalf("BuildPipeline() error = %T, want *core.GatewayError", err)
 	}
 }

--- a/internal/llmclient/client.go
+++ b/internal/llmclient/client.go
@@ -712,8 +712,7 @@ func extractModel(body any) string {
 
 // extractStatusCode tries to extract HTTP status code from an error
 func extractStatusCode(err error) int {
-	var gwErr *core.GatewayError
-	if errors.As(err, &gwErr) {
+	if gwErr, ok := errors.AsType[*core.GatewayError](err); ok {
 		return gwErr.StatusCode
 	}
 

--- a/internal/llmclient/client_test.go
+++ b/internal/llmclient/client_test.go
@@ -181,10 +181,10 @@ func TestClient_Do_ErrorParsing(t *testing.T) {
 }
 
 func TestClient_Do_Retries(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		count := atomic.AddInt32(&attempts, 1)
+		count := attempts.Add(1)
 		if count < 3 {
 			w.WriteHeader(http.StatusTooManyRequests)
 			_, _ = w.Write([]byte(`{"error":{"message":"Rate limited"}}`))
@@ -215,16 +215,16 @@ func TestClient_Do_Retries(t *testing.T) {
 	if !result.Success {
 		t.Error("expected success to be true")
 	}
-	if atomic.LoadInt32(&attempts) != 3 {
-		t.Errorf("expected 3 attempts, got %d", atomic.LoadInt32(&attempts))
+	if attempts.Load() != 3 {
+		t.Errorf("expected 3 attempts, got %d", attempts.Load())
 	}
 }
 
 func TestClient_Do_RetriesContinueAfterCircuitTrips(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		count := atomic.AddInt32(&attempts, 1)
+		count := attempts.Add(1)
 		if count < 3 {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_, _ = w.Write([]byte(`{"error":{"message":"temporary failure"}}`))
@@ -263,16 +263,16 @@ func TestClient_Do_RetriesContinueAfterCircuitTrips(t *testing.T) {
 	if !result.Success {
 		t.Fatal("expected success response after retries")
 	}
-	if got := atomic.LoadInt32(&attempts); got != 3 {
+	if got := attempts.Load(); got != 3 {
 		t.Fatalf("expected request to use full retry budget after circuit trips, got %d attempts", got)
 	}
 }
 
 func TestClient_Do_RetriesExhausted(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&attempts, 1)
+		attempts.Add(1)
 		w.WriteHeader(http.StatusTooManyRequests)
 		_, _ = w.Write([]byte(`{"error":{"message":"Rate limited"}}`))
 	}))
@@ -293,8 +293,8 @@ func TestClient_Do_RetriesExhausted(t *testing.T) {
 		t.Fatal("expected error after retries exhausted")
 	}
 	// 1 initial + 2 retries = 3 attempts
-	if atomic.LoadInt32(&attempts) != 3 {
-		t.Errorf("expected 3 attempts, got %d", atomic.LoadInt32(&attempts))
+	if attempts.Load() != 3 {
+		t.Errorf("expected 3 attempts, got %d", attempts.Load())
 	}
 }
 
@@ -364,10 +364,10 @@ func TestClient_DoRaw_Error(t *testing.T) {
 
 // TestClient_DoRaw_WithRetries tests that DoRaw properly handles retries
 func TestClient_DoRaw_WithRetries(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		count := atomic.AddInt32(&attempts, 1)
+		count := attempts.Add(1)
 		if count < 2 {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_, _ = w.Write([]byte(`{"error":{"message":"Service unavailable"}}`))
@@ -395,16 +395,16 @@ func TestClient_DoRaw_WithRetries(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected status 200, got %d", resp.StatusCode)
 	}
-	if atomic.LoadInt32(&attempts) != 2 {
-		t.Errorf("expected 2 attempts, got %d", atomic.LoadInt32(&attempts))
+	if attempts.Load() != 2 {
+		t.Errorf("expected 2 attempts, got %d", attempts.Load())
 	}
 }
 
 func TestClient_DoRaw_DoesNotRetryRawBodyReader(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&attempts, 1)
+		attempts.Add(1)
 		w.WriteHeader(http.StatusServiceUnavailable)
 		_, _ = w.Write([]byte(`{"error":{"message":"retryable"}}`))
 	}))
@@ -430,16 +430,16 @@ func TestClient_DoRaw_DoesNotRetryRawBodyReader(t *testing.T) {
 	if resp != nil {
 		t.Fatalf("expected nil response, got %+v", resp)
 	}
-	if got := atomic.LoadInt32(&attempts); got != 1 {
+	if got := attempts.Load(); got != 1 {
 		t.Fatalf("attempts = %d, want 1", got)
 	}
 }
 
 func TestClient_DoPassthrough_WithRetries(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		count := atomic.AddInt32(&attempts, 1)
+		count := attempts.Add(1)
 		if count < 3 {
 			w.WriteHeader(http.StatusTooManyRequests)
 			_, _ = w.Write([]byte(`{"error":{"message":"rate limited"}}`))
@@ -475,16 +475,16 @@ func TestClient_DoPassthrough_WithRetries(t *testing.T) {
 	if got := string(body); got != `{"ok":true}` {
 		t.Fatalf("body = %q, want success response", got)
 	}
-	if got := atomic.LoadInt32(&attempts); got != 3 {
+	if got := attempts.Load(); got != 3 {
 		t.Fatalf("attempts = %d, want 3", got)
 	}
 }
 
 func TestClient_DoPassthrough_ReturnsLastRetryableResponseAfterRetries(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		count := atomic.AddInt32(&attempts, 1)
+		count := attempts.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusServiceUnavailable)
 		_, _ = w.Write([]byte(`{"attempt":` + strconv.FormatInt(int64(count), 10) + `}`))
@@ -518,16 +518,16 @@ func TestClient_DoPassthrough_ReturnsLastRetryableResponseAfterRetries(t *testin
 	if got := string(body); got != `{"attempt":3}` {
 		t.Fatalf("body = %q, want final retry response", got)
 	}
-	if got := atomic.LoadInt32(&attempts); got != 3 {
+	if got := attempts.Load(); got != 3 {
 		t.Fatalf("attempts = %d, want 3", got)
 	}
 }
 
 func TestClient_DoPassthrough_HTTPTimeoutDoesNotRetry(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&attempts, 1)
+		attempts.Add(1)
 		time.Sleep(200 * time.Millisecond)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{}`))
@@ -565,7 +565,7 @@ func TestClient_DoPassthrough_HTTPTimeoutDoesNotRetry(t *testing.T) {
 	if gatewayErr.StatusCode != http.StatusGatewayTimeout {
 		t.Fatalf("StatusCode = %d, want %d", gatewayErr.StatusCode, http.StatusGatewayTimeout)
 	}
-	if got := atomic.LoadInt32(&attempts); got != 1 {
+	if got := attempts.Load(); got != 1 {
 		t.Fatalf("upstream attempts = %d, want 1 for client-side timeout", got)
 	}
 	if state := client.circuitBreaker.State(); state != "closed" {
@@ -574,10 +574,10 @@ func TestClient_DoPassthrough_HTTPTimeoutDoesNotRetry(t *testing.T) {
 }
 
 func TestClient_DoPassthrough_DoesNotRetryNonReplaySafeMethod(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&attempts, 1)
+		attempts.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusTooManyRequests)
 		_, _ = w.Write([]byte(`{"error":"rate limited"}`))
@@ -606,16 +606,16 @@ func TestClient_DoPassthrough_DoesNotRetryNonReplaySafeMethod(t *testing.T) {
 	if resp.StatusCode != http.StatusTooManyRequests {
 		t.Fatalf("status = %d, want 429", resp.StatusCode)
 	}
-	if got := atomic.LoadInt32(&attempts); got != 1 {
+	if got := attempts.Load(); got != 1 {
 		t.Fatalf("attempts = %d, want 1", got)
 	}
 }
 
 func TestClient_DoPassthrough_RetriesWhenIdempotencyKeyPresent(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		count := atomic.AddInt32(&attempts, 1)
+		count := attempts.Add(1)
 		if count < 3 {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusServiceUnavailable)
@@ -652,7 +652,7 @@ func TestClient_DoPassthrough_RetriesWhenIdempotencyKeyPresent(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
-	if got := atomic.LoadInt32(&attempts); got != 3 {
+	if got := attempts.Load(); got != 3 {
 		t.Fatalf("attempts = %d, want 3", got)
 	}
 }
@@ -934,9 +934,9 @@ func TestClient_BuildErrorDoesNotRetryOrChargeBreaker(t *testing.T) {
 	for _, st := range states {
 		for _, e := range entries {
 			t.Run(st.name+"/"+e.name, func(t *testing.T) {
-				var attempts int32
+				var attempts atomic.Int32
 				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					atomic.AddInt32(&attempts, 1)
+					attempts.Add(1)
 				}))
 				defer server.Close()
 
@@ -964,7 +964,7 @@ func TestClient_BuildErrorDoesNotRetryOrChargeBreaker(t *testing.T) {
 				if gwErr.Type != core.ErrorTypeInvalidRequest {
 					t.Errorf("error type = %s, want %s", gwErr.Type, core.ErrorTypeInvalidRequest)
 				}
-				if got := atomic.LoadInt32(&attempts); got != 0 {
+				if got := attempts.Load(); got != 0 {
 					t.Errorf("server received %d attempts; want 0 (build errors must not be retried)", got)
 				}
 				if state := client.circuitBreaker.State(); state != st.wantState {
@@ -1044,10 +1044,10 @@ func TestRequest_Validation(t *testing.T) {
 }
 
 func TestCircuitBreaker_OpensAfterFailures(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&attempts, 1)
+		attempts.Add(1)
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = w.Write([]byte(`{"error":{"message":"Server error"}}`))
 	}))
@@ -1092,17 +1092,17 @@ func TestCircuitBreaker_OpensAfterFailures(t *testing.T) {
 	}
 
 	// Should have made exactly 3 requests (threshold)
-	if atomic.LoadInt32(&attempts) != 3 {
-		t.Errorf("expected 3 attempts before circuit opened, got %d", atomic.LoadInt32(&attempts))
+	if attempts.Load() != 3 {
+		t.Errorf("expected 3 attempts before circuit opened, got %d", attempts.Load())
 	}
 }
 
 func TestCircuitBreaker_ClosesAfterTimeout(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 	var shouldSucceed atomic.Bool
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&attempts, 1)
+		attempts.Add(1)
 		if shouldSucceed.Load() {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"success":true}`))
@@ -1166,10 +1166,10 @@ func TestCircuitBreaker_ClosesAfterTimeout(t *testing.T) {
 // TestCircuitBreaker_HalfOpenPreventsThunderingHerd tests that only one request
 // is allowed through in half-open state to prevent thundering herd
 func TestCircuitBreaker_HalfOpenPreventsThunderingHerd(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&attempts, 1)
+		attempts.Add(1)
 		time.Sleep(50 * time.Millisecond) // Simulate slow response
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true}`))
@@ -1247,10 +1247,10 @@ func TestCircuitBreaker_HalfOpenPreventsThunderingHerd(t *testing.T) {
 }
 
 func TestCircuitBreaker_HalfOpenProbeDoesNotRetry(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&attempts, 1)
+		attempts.Add(1)
 		w.WriteHeader(http.StatusServiceUnavailable)
 		_, _ = w.Write([]byte(`{"error":{"message":"temporary failure"}}`))
 	}))
@@ -1296,7 +1296,7 @@ func TestCircuitBreaker_HalfOpenProbeDoesNotRetry(t *testing.T) {
 	if strings.Contains(gatewayErr.Message, "circuit breaker is open") {
 		t.Fatalf("expected original upstream error, got circuit breaker error: %s", gatewayErr.Message)
 	}
-	if got := atomic.LoadInt32(&attempts); got != 1 {
+	if got := attempts.Load(); got != 1 {
 		t.Fatalf("expected exactly 1 upstream attempt in half-open state, got %d", got)
 	}
 	if state := client.circuitBreaker.State(); state != "open" {
@@ -1318,16 +1318,16 @@ func TestCircuitBreaker_HalfOpenProbeDoesNotRetry(t *testing.T) {
 	if !strings.Contains(gatewayErr.Message, "circuit breaker is open") {
 		t.Fatalf("expected circuit breaker error after failed half-open probe, got %s", gatewayErr.Message)
 	}
-	if got := atomic.LoadInt32(&attempts); got != 1 {
+	if got := attempts.Load(); got != 1 {
 		t.Fatalf("expected follow-up request to be blocked without another upstream attempt, got %d attempts", got)
 	}
 }
 
 func TestCircuitBreaker_HalfOpenProbeResolvesOnClientError(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&attempts, 1)
+		attempts.Add(1)
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte(`{"error":{"message":"bad request"}}`))
 	}))
@@ -1368,7 +1368,7 @@ func TestCircuitBreaker_HalfOpenProbeResolvesOnClientError(t *testing.T) {
 	if state := client.circuitBreaker.State(); state != "closed" {
 		t.Fatalf("expected circuit to close after non-retryable probe, got %q", state)
 	}
-	if got := atomic.LoadInt32(&attempts); got != 1 {
+	if got := attempts.Load(); got != 1 {
 		t.Fatalf("expected 1 upstream attempt, got %d", got)
 	}
 
@@ -1379,16 +1379,16 @@ func TestCircuitBreaker_HalfOpenProbeResolvesOnClientError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected provider error on follow-up request")
 	}
-	if got := atomic.LoadInt32(&attempts); got != 2 {
+	if got := attempts.Load(); got != 2 {
 		t.Fatalf("expected follow-up request to reach upstream, got %d attempts", got)
 	}
 }
 
 func TestCircuitBreaker_RateLimitDoesNotOpenCircuit(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&attempts, 1)
+		attempts.Add(1)
 		w.WriteHeader(http.StatusTooManyRequests)
 		_, _ = w.Write([]byte(`{"error":{"message":"rate limit exceeded"}}`))
 	}))
@@ -1425,16 +1425,16 @@ func TestCircuitBreaker_RateLimitDoesNotOpenCircuit(t *testing.T) {
 	if state := client.circuitBreaker.State(); state != "closed" {
 		t.Fatalf("expected circuit to remain closed after rate limits, got %q", state)
 	}
-	if got := atomic.LoadInt32(&attempts); got != 2 {
+	if got := attempts.Load(); got != 2 {
 		t.Fatalf("expected both requests to reach upstream, got %d attempts", got)
 	}
 }
 
 func TestCircuitBreaker_HalfOpenProbeReopensOnRateLimit(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&attempts, 1)
+		attempts.Add(1)
 		w.WriteHeader(http.StatusTooManyRequests)
 		_, _ = w.Write([]byte(`{"error":{"message":"rate limit exceeded"}}`))
 	}))
@@ -1490,7 +1490,7 @@ func TestCircuitBreaker_HalfOpenProbeReopensOnRateLimit(t *testing.T) {
 	if !strings.Contains(gatewayErr.Message, "circuit breaker is open") {
 		t.Fatalf("expected circuit breaker error after rate-limited half-open probe, got %s", gatewayErr.Message)
 	}
-	if got := atomic.LoadInt32(&attempts); got != 1 {
+	if got := attempts.Load(); got != 1 {
 		t.Fatalf("expected follow-up request to be blocked without another upstream attempt, got %d attempts", got)
 	}
 }
@@ -1760,10 +1760,10 @@ func TestClient_Do_HTTPTimeoutReturnsGatewayTimeout(t *testing.T) {
 }
 
 func TestClient_Do_HTTPTimeoutDoesNotRetry(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&attempts, 1)
+		attempts.Add(1)
 		time.Sleep(200 * time.Millisecond)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{}`))
@@ -1799,7 +1799,7 @@ func TestClient_Do_HTTPTimeoutDoesNotRetry(t *testing.T) {
 	if gatewayErr.StatusCode != http.StatusGatewayTimeout {
 		t.Fatalf("StatusCode = %d, want %d", gatewayErr.StatusCode, http.StatusGatewayTimeout)
 	}
-	if got := atomic.LoadInt32(&attempts); got != 1 {
+	if got := attempts.Load(); got != 1 {
 		t.Fatalf("upstream attempts = %d, want 1 for client-side timeout", got)
 	}
 	if state := client.circuitBreaker.State(); state != "closed" {
@@ -1808,10 +1808,10 @@ func TestClient_Do_HTTPTimeoutDoesNotRetry(t *testing.T) {
 }
 
 func TestCircuitBreakerCountsRetriedRequestOnce(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&attempts, 1)
+		attempts.Add(1)
 		w.WriteHeader(http.StatusServiceUnavailable)
 		_, _ = w.Write([]byte(`{"error":{"message":"temporary failure"}}`))
 	}))
@@ -1848,7 +1848,7 @@ func TestCircuitBreakerCountsRetriedRequestOnce(t *testing.T) {
 		}
 
 		wantAttempts := int32((i + 1) * (cfg.Retry.MaxRetries + 1))
-		if got := atomic.LoadInt32(&attempts); got != wantAttempts {
+		if got := attempts.Load(); got != wantAttempts {
 			t.Fatalf("request %d: upstream attempts = %d, want %d", i+1, got, wantAttempts)
 		}
 	}
@@ -1867,7 +1867,7 @@ func TestCircuitBreakerCountsRetriedRequestOnce(t *testing.T) {
 	if !strings.Contains(gatewayErr.Message, "circuit breaker is open") {
 		t.Fatalf("expected circuit breaker error, got %s", gatewayErr.Message)
 	}
-	if got, want := atomic.LoadInt32(&attempts), int32(2*(cfg.Retry.MaxRetries+1)); got != want {
+	if got, want := attempts.Load(), int32(2*(cfg.Retry.MaxRetries+1)); got != want {
 		t.Fatalf("upstream attempts after circuit rejection = %d, want %d", got, want)
 	}
 }
@@ -1973,10 +1973,10 @@ func TestClient_SetBaseURL_Concurrent(t *testing.T) {
 }
 
 func TestClient_NonRetryableErrors(t *testing.T) {
-	var attempts int32
+	var attempts atomic.Int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&attempts, 1)
+		attempts.Add(1)
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte(`{"error":{"message":"Bad request"}}`))
 	}))
@@ -1995,8 +1995,8 @@ func TestClient_NonRetryableErrors(t *testing.T) {
 		t.Fatal("expected error")
 	}
 	// Should NOT retry on 400 errors
-	if atomic.LoadInt32(&attempts) != 1 {
-		t.Errorf("expected 1 attempt (no retries on 400), got %d", atomic.LoadInt32(&attempts))
+	if attempts.Load() != 1 {
+		t.Errorf("expected 1 attempt (no retries on 400), got %d", attempts.Load())
 	}
 }
 

--- a/internal/mcpgateway/service_test.go
+++ b/internal/mcpgateway/service_test.go
@@ -115,9 +115,8 @@ func newTestService(t *testing.T, usageLogger usage.LoggerInterface, specs ...Se
 			pinned = rest
 		}
 		if err := service.ServeHTTP(w, r, pinned); err != nil {
-			var gatewayErr *core.GatewayError
 			status := http.StatusInternalServerError
-			if errors.As(err, &gatewayErr) {
+			if gatewayErr, ok := errors.AsType[*core.GatewayError](err); ok {
 				status = gatewayErr.HTTPStatusCode()
 			}
 			http.Error(w, err.Error(), status)

--- a/internal/providers/bedrock/bedrock.go
+++ b/internal/providers/bedrock/bedrock.go
@@ -255,10 +255,14 @@ func mapAWSError(err error) error {
 		return nil
 	}
 
-	type httpStatus interface{ HTTPStatusCode() int }
-	var hs httpStatus
+	// Every value in an error chain is an error, so embedding it only lets
+	// errors.AsType target the interface; the match is the same as before.
+	type httpStatus interface {
+		error
+		HTTPStatusCode() int
+	}
 	status := http.StatusBadGateway
-	if errors.As(err, &hs) {
+	if hs, ok := errors.AsType[httpStatus](err); ok {
 		if code := hs.HTTPStatusCode(); code > 0 {
 			status = code
 		}
@@ -269,9 +273,8 @@ func mapAWSError(err error) error {
 		ErrorCode() string
 		ErrorMessage() string
 	}
-	var ae apiErr
 	message := err.Error()
-	if errors.As(err, &ae) {
+	if ae, ok := errors.AsType[apiErr](err); ok {
 		if msg := strings.TrimSpace(ae.ErrorMessage()); msg != "" {
 			message = fmt.Sprintf("%s: %s", ae.ErrorCode(), msg)
 		}

--- a/internal/providers/bedrock/chat.go
+++ b/internal/providers/bedrock/chat.go
@@ -107,9 +107,8 @@ func isCachePointValidationError(err error) bool {
 		ErrorCode() string
 		ErrorMessage() string
 	}
-	var apiErr apiError
 	code, message := "", err.Error()
-	if errors.As(err, &apiErr) {
+	if apiErr, ok := errors.AsType[apiError](err); ok {
 		code, message = apiErr.ErrorCode(), apiErr.ErrorMessage()
 	}
 	code = strings.ToLower(code)

--- a/internal/providers/cache_planner.go
+++ b/internal/providers/cache_planner.go
@@ -372,8 +372,8 @@ func markOpenAIResponsesBreakpoint(req *core.ResponsesRequest) bool {
 				}
 			}
 		case []any:
-			for j := len(content) - 1; j >= 0; j-- {
-				block, ok := content[j].(map[string]any)
+			for _, c := range slices.Backward(content) {
+				block, ok := c.(map[string]any)
 				if !ok {
 					continue
 				}
@@ -388,11 +388,11 @@ func markOpenAIResponsesBreakpoint(req *core.ResponsesRequest) bool {
 				}
 			}
 		case []map[string]any:
-			for j := len(content) - 1; j >= 0; j-- {
-				blockType, _ := content[j]["type"].(string)
+			for _, c := range slices.Backward(content) {
+				blockType, _ := c["type"].(string)
 				if blockType == "text" || blockType == "input_text" || blockType == "input_image" || blockType == "input_file" {
-					if _, exists := content[j]["prompt_cache_breakpoint"]; !exists {
-						content[j]["prompt_cache_breakpoint"] = map[string]any{"mode": "explicit"}
+					if _, exists := c["prompt_cache_breakpoint"]; !exists {
+						c["prompt_cache_breakpoint"] = map[string]any{"mode": "explicit"}
 					}
 					items[i].Content = content
 					req.Input = items

--- a/internal/providers/credential_schema.go
+++ b/internal/providers/credential_schema.go
@@ -95,8 +95,8 @@ func credentialSchema(providerType string, spec DiscoveryConfig) CredentialSchem
 	if len(fields) == 0 {
 		fields = defaultCredentialFields(spec)
 	}
-	schema := CredentialSchema{Type: providerType, DefaultBaseURL: spec.DefaultBaseURL}
-	schema.Fields = make([]CredentialField, 0, len(fields)+2)
+	schema := CredentialSchema{Type: providerType, DefaultBaseURL: spec.DefaultBaseURL,
+		Fields: make([]CredentialField, 0, len(fields)+2)}
 	schema.Fields = append(schema.Fields, fields...)
 	for _, field := range fields {
 		if field.Name == CredentialFieldAPIKeys {

--- a/internal/providers/file_adapter_openai_compat_test.go
+++ b/internal/providers/file_adapter_openai_compat_test.go
@@ -54,8 +54,7 @@ func TestValidatedOpenAICompatibleFileID(t *testing.T) {
 				if err == nil {
 					t.Fatal("expected error")
 				}
-				var gwErr *core.GatewayError
-				if !errors.As(err, &gwErr) {
+				if _, ok := errors.AsType[*core.GatewayError](err); !ok {
 					t.Fatalf("expected GatewayError, got %T: %v", err, err)
 				}
 				return
@@ -210,8 +209,7 @@ func TestGetOpenAICompatibleFileContent(t *testing.T) {
 				if err == nil {
 					t.Fatal("expected error")
 				}
-				var gwErr *core.GatewayError
-				if !errors.As(err, &gwErr) {
+				if _, ok := errors.AsType[*core.GatewayError](err); !ok {
 					t.Fatalf("expected GatewayError, got %T: %v", err, err)
 				}
 				return

--- a/internal/providers/openrouter/openrouter_test.go
+++ b/internal/providers/openrouter/openrouter_test.go
@@ -123,8 +123,7 @@ func TestListModels_UpstreamErrorPropagates(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error, got response: %+v", resp)
 	}
-	var gatewayErr *core.GatewayError
-	if !errors.As(err, &gatewayErr) {
+	if _, ok := errors.AsType[*core.GatewayError](err); !ok {
 		t.Fatalf("error type = %T, want *core.GatewayError: %v", err, err)
 	}
 }

--- a/internal/providers/router_test.go
+++ b/internal/providers/router_test.go
@@ -824,7 +824,7 @@ func TestRouterCreateBatch_AdaptsAnthropicCacheControlAfterRouting(t *testing.T)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			provider := &mockBatchProvider{mockProvider: mockProvider{name: tt.providerType}}
+			provider := &mockBatchProvider{name: tt.providerType}
 			lookup := newMockLookup()
 			lookup.addModel("gpt-4o", provider, tt.providerType)
 			router, _ := NewRouter(lookup)
@@ -934,10 +934,8 @@ func TestRouterChatCompletion_PrefixedModelSelector(t *testing.T) {
 
 func TestRouterChatCompletion_RefreshesProviderModelsForQualifiedRequest(t *testing.T) {
 	provider := &lazyRefreshProvider{
-		mockProvider: mockProvider{
-			name:         "ollama",
-			chatResponse: &core.ChatResponse{ID: "chatcmpl-later", Model: "later-model"},
-		},
+		name:         "ollama",
+		chatResponse: &core.ChatResponse{ID: "chatcmpl-later", Model: "later-model"},
 		modelsResponse: &core.ModelsResponse{
 			Object: "list",
 			Data: []core.Model{
@@ -980,10 +978,8 @@ func TestRouterChatCompletion_RefreshesMissingProviderWithoutDroppingExistingMod
 		chatResponse: &core.ChatResponse{ID: "openai", Model: "gpt-4o"},
 	}
 	ollama := &lazyRefreshProvider{
-		mockProvider: mockProvider{
-			name:         "ollama",
-			chatResponse: &core.ChatResponse{ID: "ollama", Model: "local-model"},
-		},
+		name:         "ollama",
+		chatResponse: &core.ChatResponse{ID: "ollama", Model: "local-model"},
 		modelsResponse: &core.ModelsResponse{
 			Object: "list",
 			Data: []core.Model{
@@ -1021,10 +1017,8 @@ func TestRouterChatCompletion_RefreshesMissingProviderWithoutDroppingExistingMod
 
 func TestRouterChatCompletion_RequestTimeRefreshUnavailableProvider(t *testing.T) {
 	provider := &lazyRefreshProvider{
-		mockProvider: mockProvider{
-			name:         "ollama",
-			chatResponse: &core.ChatResponse{ID: "should-not-run"},
-		},
+		name:            "ollama",
+		chatResponse:    &core.ChatResponse{ID: "should-not-run"},
 		availabilityErr: errors.New("connection refused"),
 		modelsResponse: &core.ModelsResponse{
 			Object: "list",
@@ -1678,8 +1672,7 @@ func TestRouterEmbeddings_ProviderError(t *testing.T) {
 	if err == nil {
 		t.Error("expected error from provider")
 	}
-	var gatewayErr *core.GatewayError
-	if !errors.As(err, &gatewayErr) {
+	if _, ok := errors.AsType[*core.GatewayError](err); !ok {
 		t.Errorf("expected GatewayError, got %T: %v", err, err)
 	}
 }
@@ -1760,8 +1753,7 @@ func TestRouterPassthrough_ErrorCases(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error")
 		}
-		var gwErr *core.GatewayError
-		if !errors.As(err, &gwErr) {
+		if _, ok := errors.AsType[*core.GatewayError](err); !ok {
 			t.Fatalf("expected GatewayError, got %T: %v", err, err)
 		}
 	})

--- a/internal/ratelimit/store_mongodb.go
+++ b/internal/ratelimit/store_mongodb.go
@@ -458,8 +458,7 @@ func (e *mongoTransactionFallbackError) Error() string {
 }
 
 func mongoTransactionFallbackCause(err error) error {
-	var fallbackErr *mongoTransactionFallbackError
-	if errors.As(err, &fallbackErr) {
+	if fallbackErr, ok := errors.AsType[*mongoTransactionFallbackError](err); ok {
 		return fallbackErr.err
 	}
 	return nil

--- a/internal/ratelimit/store_mongodb_test.go
+++ b/internal/ratelimit/store_mongodb_test.go
@@ -23,7 +23,7 @@ func TestIsOnlyDuplicateKeyErrors(t *testing.T) {
 			name: "single duplicate key write error",
 			err: mongo.BulkWriteException{
 				WriteErrors: []mongo.BulkWriteError{
-					{WriteError: mongo.WriteError{Code: 11000, Message: "E11000 duplicate key error"}},
+					{Code: 11000, Message: "E11000 duplicate key error"},
 				},
 			},
 			want: true,
@@ -32,8 +32,8 @@ func TestIsOnlyDuplicateKeyErrors(t *testing.T) {
 			name: "all duplicate key write errors",
 			err: mongo.BulkWriteException{
 				WriteErrors: []mongo.BulkWriteError{
-					{WriteError: mongo.WriteError{Code: 11000}},
-					{WriteError: mongo.WriteError{Code: 11000}},
+					{Code: 11000},
+					{Code: 11000},
 				},
 			},
 			want: true,
@@ -42,8 +42,8 @@ func TestIsOnlyDuplicateKeyErrors(t *testing.T) {
 			name: "mixed write errors keep failing",
 			err: mongo.BulkWriteException{
 				WriteErrors: []mongo.BulkWriteError{
-					{WriteError: mongo.WriteError{Code: 11000}},
-					{WriteError: mongo.WriteError{Code: 121, Message: "document validation failure"}},
+					{Code: 11000},
+					{Code: 121, Message: "document validation failure"},
 				},
 			},
 			want: false,
@@ -52,7 +52,7 @@ func TestIsOnlyDuplicateKeyErrors(t *testing.T) {
 			name: "write concern error keeps failing",
 			err: mongo.BulkWriteException{
 				WriteErrors: []mongo.BulkWriteError{
-					{WriteError: mongo.WriteError{Code: 11000}},
+					{Code: 11000},
 				},
 				WriteConcernError: &mongo.WriteConcernError{Code: 64},
 			},
@@ -85,7 +85,7 @@ func TestDuplicateKeyErrorsOnConfigRulesOnly(t *testing.T) {
 		exc := mongo.BulkWriteException{}
 		for _, index := range indexes {
 			exc.WriteErrors = append(exc.WriteErrors, mongo.BulkWriteError{
-				WriteError: mongo.WriteError{Index: index, Code: 11000},
+				Index: index, Code: 11000,
 			})
 		}
 		return exc
@@ -123,7 +123,7 @@ func TestDuplicateKeyErrorsOnConfigRulesOnly(t *testing.T) {
 		},
 		{
 			name:  "non duplicate-key code keeps failing",
-			err:   mongo.BulkWriteException{WriteErrors: []mongo.BulkWriteError{{WriteError: mongo.WriteError{Index: 0, Code: 121}}}},
+			err:   mongo.BulkWriteException{WriteErrors: []mongo.BulkWriteError{{Index: 0, Code: 121}}},
 			rules: []Rule{configRule},
 			want:  false,
 		},
@@ -152,7 +152,7 @@ func TestClassifyBulkWriteError(t *testing.T) {
 	manualRule := Rule{Scope: ScopeUserPath, Subject: "/manual", PeriodSeconds: PeriodMinuteSeconds, Source: SourceManual}
 	dup := func(index int) mongo.BulkWriteException {
 		return mongo.BulkWriteException{WriteErrors: []mongo.BulkWriteError{
-			{WriteError: mongo.WriteError{Index: index, Code: 11000}},
+			{Index: index, Code: 11000},
 		}}
 	}
 
@@ -166,7 +166,7 @@ func TestClassifyBulkWriteError(t *testing.T) {
 		{"config duplicate is shadowing", dup(0), []Rule{configRule}, bulkWriteShadowedByManual},
 		{"manual duplicate is a race worth retrying", dup(1), []Rule{configRule, manualRule}, bulkWriteRetryManualRace},
 		{"non-duplicate error fails", mongo.BulkWriteException{WriteErrors: []mongo.BulkWriteError{
-			{WriteError: mongo.WriteError{Index: 0, Code: 121}},
+			{Index: 0, Code: 121},
 		}}, []Rule{manualRule}, bulkWriteFailed},
 		{"unrelated error fails", errors.New("network down"), []Rule{manualRule}, bulkWriteFailed},
 	}

--- a/internal/realtime/observer_test.go
+++ b/internal/realtime/observer_test.go
@@ -61,8 +61,7 @@ func TestObserveTapsFramesUntilClose(t *testing.T) {
 
 func TestObserveReturnsDialError(t *testing.T) {
 	err := Observe(context.Background(), Target{URL: "ws://127.0.0.1:1/v1/realtime"}, nil)
-	var de *DialError
-	if !errors.As(err, &de) {
+	if _, ok := errors.AsType[*DialError](err); !ok {
 		t.Fatalf("err = %v, want *DialError", err)
 	}
 }
@@ -118,8 +117,7 @@ func TestObserveStopsOnContextCancel(t *testing.T) {
 	if err == nil {
 		return // normalized cancellation is acceptable
 	}
-	var de *DialError
-	if errors.As(err, &de) {
+	if _, ok := errors.AsType[*DialError](err); ok {
 		t.Fatalf("err = %v, want a post-dial termination, not a dial error", err)
 	}
 }

--- a/internal/realtime/proxy.go
+++ b/internal/realtime/proxy.go
@@ -213,8 +213,7 @@ func observe(tap func([]byte)) func([]byte) []byte {
 func closeBoth(client, upstream *websocket.Conn, cause error) {
 	status := websocket.StatusNormalClosure
 	reason := ""
-	var ce websocket.CloseError
-	if errors.As(cause, &ce) {
+	if ce, ok := errors.AsType[websocket.CloseError](cause); ok {
 		status = ce.Code
 		reason = ce.Reason
 	}
@@ -229,8 +228,7 @@ func normalizeCloseError(err error) error {
 	if err == nil || errors.Is(err, context.Canceled) {
 		return nil
 	}
-	var ce websocket.CloseError
-	if errors.As(err, &ce) {
+	if ce, ok := errors.AsType[websocket.CloseError](err); ok {
 		switch ce.Code {
 		case websocket.StatusNormalClosure, websocket.StatusGoingAway:
 			return nil

--- a/internal/responsecache/semantic.go
+++ b/internal/responsecache/semantic.go
@@ -9,6 +9,7 @@ import (
 	"hash"
 	"log/slog"
 	"net/http"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -324,8 +325,8 @@ func conversationInvariantFingerprint(body []byte, excludeSystem bool) (fingerpr
 	}
 
 	lastUser := -1
-	for i := len(included) - 1; i >= 0; i-- {
-		if included[i].role == "user" {
+	for i, part := range slices.Backward(included) {
+		if part.role == "user" {
 			lastUser = i
 			break
 		}

--- a/internal/server/audio_service_test.go
+++ b/internal/server/audio_service_test.go
@@ -309,7 +309,7 @@ func TestAudioSpeech_AuthorizesResolvedSelector(t *testing.T) {
 		speechResp:   &core.AudioResponse{ContentType: "audio/mpeg", Data: []byte("audio")},
 	}
 	authorizer := &recordingModelAuthorizer{}
-	svc := &audioService{modelCallService: modelCallService{provider: mock, modelAuthorizer: authorizer}}
+	svc := &audioService{provider: mock, modelAuthorizer: authorizer}
 
 	body := `{"model":"gpt-4o-mini-tts","input":"hello","voice":"alloy"}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/audio/speech", strings.NewReader(body))
@@ -337,7 +337,7 @@ func TestAudioSpeech_AuthorizerDeniesAccess(t *testing.T) {
 		resolved:     &core.ModelSelector{Provider: "openai", Model: "gpt-4o-mini-tts"},
 	}
 	authorizer := &recordingModelAuthorizer{err: core.NewInvalidRequestError("denied", nil)}
-	svc := &audioService{modelCallService: modelCallService{provider: mock, modelAuthorizer: authorizer}}
+	svc := &audioService{provider: mock, modelAuthorizer: authorizer}
 
 	body := `{"model":"gpt-4o-mini-tts","input":"hello","voice":"alloy"}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/audio/speech", strings.NewReader(body))
@@ -612,7 +612,7 @@ func newTranscriptionMock() *audioMockProvider {
 // the upload metadata attached. Content type falls back to the filename
 // extension when the multipart part declares a non-audio type.
 func TestAudioTranscription_LogsUploadedAudioWhenEnabled(t *testing.T) {
-	svc := &audioService{modelCallService: modelCallService{provider: newTranscriptionMock()}, logBodies: true, logAudioBodies: true}
+	svc := &audioService{provider: newTranscriptionMock(), logBodies: true, logAudioBodies: true}
 	c, rec, entry := newTranscriptionRequestWithAuditEntry("speech.mp3", []byte("uploaded-audio-bytes"))
 
 	if err := svc.CreateTranscription(c); err != nil {
@@ -642,7 +642,7 @@ func TestAudioTranscription_LogsUploadedAudioWhenEnabled(t *testing.T) {
 // but LogAudioBodies off, the upload metadata is still recorded as a placeholder
 // (no audio bytes), mirroring the speech-response behavior.
 func TestAudioTranscription_MetadataPlaceholderWhenAudioDisabled(t *testing.T) {
-	svc := &audioService{modelCallService: modelCallService{provider: newTranscriptionMock()}, logBodies: true, logAudioBodies: false}
+	svc := &audioService{provider: newTranscriptionMock(), logBodies: true, logAudioBodies: false}
 	c, _, entry := newTranscriptionRequestWithAuditEntry("speech.mp3", []byte("uploaded-audio-bytes"))
 
 	if err := svc.CreateTranscription(c); err != nil {
@@ -663,7 +663,7 @@ func TestAudioTranscription_MetadataPlaceholderWhenAudioDisabled(t *testing.T) {
 // TestAudioTranscription_NoCaptureWhenBodiesDisabled: nothing is captured when
 // the master LogBodies switch is off.
 func TestAudioTranscription_NoCaptureWhenBodiesDisabled(t *testing.T) {
-	svc := &audioService{modelCallService: modelCallService{provider: newTranscriptionMock()}, logBodies: false, logAudioBodies: true}
+	svc := &audioService{provider: newTranscriptionMock(), logBodies: false, logAudioBodies: true}
 	c, _, entry := newTranscriptionRequestWithAuditEntry("speech.mp3", []byte("uploaded-audio-bytes"))
 
 	if err := svc.CreateTranscription(c); err != nil {
@@ -679,7 +679,7 @@ func TestAudioTranscription_NoCaptureWhenBodiesDisabled(t *testing.T) {
 func TestAudioSpeech_LogsUsage(t *testing.T) {
 	var captured *usage.UsageEntry
 	logger := &capturingUsageLogger{config: usage.Config{Enabled: true}, captured: &captured}
-	svc := &audioService{modelCallService: modelCallService{provider: newSpeechMock(), usageLogger: logger}}
+	svc := &audioService{provider: newSpeechMock(), usageLogger: logger}
 	c, rec, _ := newSpeechRequestWithAuditEntry()
 
 	if err := svc.CreateSpeech(c); err != nil {
@@ -738,7 +738,7 @@ func TestAudioSpeech_CostsOutputAudioDuration(t *testing.T) {
 				mockProvider: &mockProvider{supportedModels: []string{"gpt-4o-mini-tts"}},
 				speechResp:   &core.AudioResponse{ContentType: tt.contentType, Data: tt.data},
 			}
-			svc := &audioService{modelCallService: modelCallService{provider: mock, usageLogger: logger, pricingResolver: &mockPricingResolver{pricing: pricing}}}
+			svc := &audioService{provider: mock, usageLogger: logger, pricingResolver: &mockPricingResolver{pricing: pricing}}
 
 			body := `{"model":"gpt-4o-mini-tts","input":"hello","voice":"alloy"`
 			if tt.responseFormat != "" {
@@ -804,7 +804,7 @@ func wavBytes(sampleRate, channels, bitsPerSample int, seconds float64) []byte {
 func TestAudioTranscription_LogsUsage(t *testing.T) {
 	var captured *usage.UsageEntry
 	logger := &capturingUsageLogger{config: usage.Config{Enabled: true}, captured: &captured}
-	svc := &audioService{modelCallService: modelCallService{provider: newTranscriptionMock(), usageLogger: logger}}
+	svc := &audioService{provider: newTranscriptionMock(), usageLogger: logger}
 	c, rec, _ := newTranscriptionRequestWithAuditEntry("speech.mp3", []byte("audio-bytes"))
 
 	if err := svc.CreateTranscription(c); err != nil {
@@ -829,7 +829,7 @@ func TestAudioTranscription_LogsUsage(t *testing.T) {
 func TestAudioSpeech_NoUsageWhenDisabled(t *testing.T) {
 	var captured *usage.UsageEntry
 	logger := &capturingUsageLogger{config: usage.Config{Enabled: false}, captured: &captured}
-	svc := &audioService{modelCallService: modelCallService{provider: newSpeechMock(), usageLogger: logger}}
+	svc := &audioService{provider: newSpeechMock(), usageLogger: logger}
 	c, rec, _ := newSpeechRequestWithAuditEntry()
 
 	if err := svc.CreateSpeech(c); err != nil {
@@ -915,7 +915,7 @@ func newSpeechMock() *audioMockProvider {
 // LogAudioBodies on, the speech input is logged and the audio output is stored
 // losslessly as base64 for playback.
 func TestAudioSpeech_LogsAudioBodiesWhenEnabled(t *testing.T) {
-	svc := &audioService{modelCallService: modelCallService{provider: newSpeechMock()}, logBodies: true, logAudioBodies: true}
+	svc := &audioService{provider: newSpeechMock(), logBodies: true, logAudioBodies: true}
 	c, rec, entry := newSpeechRequestWithAuditEntry()
 
 	if err := svc.CreateSpeech(c); err != nil {
@@ -950,7 +950,7 @@ func TestAudioSpeech_LogsAudioBodiesWhenEnabled(t *testing.T) {
 // LogAudioBodies off, the audio response is a metadata-only placeholder and the
 // input is not captured.
 func TestAudioSpeech_PlaceholderWhenAudioDisabled(t *testing.T) {
-	svc := &audioService{modelCallService: modelCallService{provider: newSpeechMock()}, logBodies: true, logAudioBodies: false}
+	svc := &audioService{provider: newSpeechMock(), logBodies: true, logAudioBodies: false}
 	c, _, entry := newSpeechRequestWithAuditEntry()
 
 	if err := svc.CreateSpeech(c); err != nil {
@@ -975,7 +975,7 @@ func TestAudioSpeech_PlaceholderWhenAudioDisabled(t *testing.T) {
 // TestAudioSpeech_NoAudioBodyWhenBodiesDisabled: LogBodies is the master switch.
 // With it off, no audio body is captured even if LogAudioBodies is on.
 func TestAudioSpeech_NoAudioBodyWhenBodiesDisabled(t *testing.T) {
-	svc := &audioService{modelCallService: modelCallService{provider: newSpeechMock()}, logBodies: false, logAudioBodies: true}
+	svc := &audioService{provider: newSpeechMock(), logBodies: false, logAudioBodies: true}
 	c, rec, entry := newSpeechRequestWithAuditEntry()
 
 	if err := svc.CreateSpeech(c); err != nil {
@@ -1020,10 +1020,9 @@ func TestAudio_NilResponseSkipsUsage(t *testing.T) {
 	t.Run("speech", func(t *testing.T) {
 		var captured *usage.UsageEntry
 		logger := &capturingUsageLogger{config: usage.Config{Enabled: true}, captured: &captured}
-		svc := &audioService{modelCallService: modelCallService{
+		svc := &audioService{
 			provider:    &audioMockProvider{mockProvider: &mockProvider{supportedModels: []string{"gpt-4o-mini-tts"}}, speechResp: nil},
-			usageLogger: logger,
-		}}
+			usageLogger: logger}
 		c, rec, _ := newSpeechRequestWithAuditEntry()
 
 		if err := svc.CreateSpeech(c); err != nil {
@@ -1040,10 +1039,9 @@ func TestAudio_NilResponseSkipsUsage(t *testing.T) {
 	t.Run("transcription", func(t *testing.T) {
 		var captured *usage.UsageEntry
 		logger := &capturingUsageLogger{config: usage.Config{Enabled: true}, captured: &captured}
-		svc := &audioService{modelCallService: modelCallService{
+		svc := &audioService{
 			provider:    &audioMockProvider{mockProvider: &mockProvider{supportedModels: []string{"gpt-4o-transcribe"}}, transcriptionResp: nil},
-			usageLogger: logger,
-		}}
+			usageLogger: logger}
 		c, rec, _ := newTranscriptionRequestWithAuditEntry("speech.mp3", []byte("audio-bytes"))
 
 		// Must not panic on resp.Data when resp is nil.

--- a/internal/server/budget_support.go
+++ b/internal/server/budget_support.go
@@ -49,8 +49,7 @@ func enforceBudgetForContext(ctx context.Context, checker BudgetChecker) error {
 }
 
 func budgetCheckError(err error) error {
-	var exceeded *budget.ExceededError
-	if errors.As(err, &exceeded) {
+	if exceeded, ok := errors.AsType[*budget.ExceededError](err); ok {
 		message := exceeded.Error()
 		if message == "" {
 			message = "budget exceeded"

--- a/internal/server/conversation_responses_test.go
+++ b/internal/server/conversation_responses_test.go
@@ -24,7 +24,7 @@ func (s *appendFailingConversationStore) AppendItems(context.Context, string, []
 
 func conversationTestProvider(t *testing.T) *capturingProvider {
 	t.Helper()
-	return &capturingProvider{mockProvider: mockProvider{
+	return &capturingProvider{
 		supportedModels: []string{"gpt-5-mini"},
 		providerTypes:   map[string]string{"gpt-5-mini": "mock"},
 		responsesResponse: &core.ResponsesResponse{
@@ -42,8 +42,7 @@ func conversationTestProvider(t *testing.T) *capturingProvider {
 					},
 				},
 			},
-		},
-	}}
+		}}
 }
 
 func createTestConversation(t *testing.T, srv http.Handler, body string) string {

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -1205,19 +1205,17 @@ func TestChatCompletion(t *testing.T) {
 
 func TestChatCompletion_BindsMultimodalContent(t *testing.T) {
 	provider := &capturingProvider{
-		mockProvider: mockProvider{
-			supportedModels: []string{"gpt-4o-mini"},
-			response: &core.ChatResponse{
-				ID:      "chatcmpl-123",
-				Object:  "chat.completion",
-				Created: 1234567890,
-				Model:   "gpt-4o-mini",
-				Choices: []core.Choice{
-					{
-						Index:        0,
-						Message:      core.ResponseMessage{Role: "assistant", Content: "ok"},
-						FinishReason: "stop",
-					},
+		supportedModels: []string{"gpt-4o-mini"},
+		response: &core.ChatResponse{
+			ID:      "chatcmpl-123",
+			Object:  "chat.completion",
+			Created: 1234567890,
+			Model:   "gpt-4o-mini",
+			Choices: []core.Choice{
+				{
+					Index:        0,
+					Message:      core.ResponseMessage{Role: "assistant", Content: "ok"},
+					FinishReason: "stop",
 				},
 			},
 		},
@@ -1260,19 +1258,17 @@ func TestChatCompletion_BindsMultimodalContent(t *testing.T) {
 
 func TestChatCompletion_PreservesUnknownTopLevelFields(t *testing.T) {
 	provider := &capturingProvider{
-		mockProvider: mockProvider{
-			supportedModels: []string{"gpt-5-mini"},
-			response: &core.ChatResponse{
-				ID:      "chatcmpl-123",
-				Object:  "chat.completion",
-				Created: 1234567890,
-				Model:   "gpt-5-mini",
-				Choices: []core.Choice{
-					{
-						Index:        0,
-						Message:      core.ResponseMessage{Role: "assistant", Content: "ok"},
-						FinishReason: "stop",
-					},
+		supportedModels: []string{"gpt-5-mini"},
+		response: &core.ChatResponse{
+			ID:      "chatcmpl-123",
+			Object:  "chat.completion",
+			Created: 1234567890,
+			Model:   "gpt-5-mini",
+			Choices: []core.Choice{
+				{
+					Index:        0,
+					Message:      core.ResponseMessage{Role: "assistant", Content: "ok"},
+					FinishReason: "stop",
 				},
 			},
 		},
@@ -1318,19 +1314,17 @@ func TestChatCompletion_PreservesUnknownTopLevelFields(t *testing.T) {
 
 func TestChatCompletion_PreservesUnknownNestedFields(t *testing.T) {
 	provider := &capturingProvider{
-		mockProvider: mockProvider{
-			supportedModels: []string{"gpt-5-mini"},
-			response: &core.ChatResponse{
-				ID:      "chatcmpl-123",
-				Object:  "chat.completion",
-				Created: 1234567890,
-				Model:   "gpt-5-mini",
-				Choices: []core.Choice{
-					{
-						Index:        0,
-						Message:      core.ResponseMessage{Role: "assistant", Content: "ok"},
-						FinishReason: "stop",
-					},
+		supportedModels: []string{"gpt-5-mini"},
+		response: &core.ChatResponse{
+			ID:      "chatcmpl-123",
+			Object:  "chat.completion",
+			Created: 1234567890,
+			Model:   "gpt-5-mini",
+			Choices: []core.Choice{
+				{
+					Index:        0,
+					Message:      core.ResponseMessage{Role: "assistant", Content: "ok"},
+					FinishReason: "stop",
 				},
 			},
 		},
@@ -1387,19 +1381,17 @@ func TestChatCompletion_PreservesUnknownNestedFields(t *testing.T) {
 
 func TestChatCompletion_UsesIngressFrameForDecoding(t *testing.T) {
 	provider := &capturingProvider{
-		mockProvider: mockProvider{
-			supportedModels: []string{"gpt-5-mini"},
-			response: &core.ChatResponse{
-				ID:      "chatcmpl-123",
-				Object:  "chat.completion",
-				Created: 1234567890,
-				Model:   "gpt-5-mini",
-				Choices: []core.Choice{
-					{
-						Index:        0,
-						Message:      core.ResponseMessage{Role: "assistant", Content: "ok"},
-						FinishReason: "stop",
-					},
+		supportedModels: []string{"gpt-5-mini"},
+		response: &core.ChatResponse{
+			ID:      "chatcmpl-123",
+			Object:  "chat.completion",
+			Created: 1234567890,
+			Model:   "gpt-5-mini",
+			Choices: []core.Choice{
+				{
+					Index:        0,
+					Message:      core.ResponseMessage{Role: "assistant", Content: "ok"},
+					FinishReason: "stop",
 				},
 			},
 		},
@@ -1459,20 +1451,18 @@ func TestChatCompletion_UsesIngressFrameForDecoding(t *testing.T) {
 
 func TestChatCompletion_NormalizesSemanticSelectorHints(t *testing.T) {
 	provider := &capturingProvider{
-		mockProvider: mockProvider{
-			supportedModels: []string{"gpt-5-mini"},
-			response: &core.ChatResponse{
-				ID:     "chatcmpl_123",
-				Object: "chat.completion",
-				Model:  "gpt-5-mini",
-				Choices: []core.Choice{
-					{
-						Index:        0,
-						FinishReason: "stop",
-						Message: core.ResponseMessage{
-							Role:    "assistant",
-							Content: "ok",
-						},
+		supportedModels: []string{"gpt-5-mini"},
+		response: &core.ChatResponse{
+			ID:     "chatcmpl_123",
+			Object: "chat.completion",
+			Model:  "gpt-5-mini",
+			Choices: []core.Choice{
+				{
+					Index:        0,
+					FinishReason: "stop",
+					Message: core.ResponseMessage{
+						Role:    "assistant",
+						Content: "ok",
 					},
 				},
 			},
@@ -1562,24 +1552,22 @@ func TestChatCompletion_UsesExplicitAliasResolverWithoutProviderDecorator(t *tes
 	}
 
 	inner := &capturingProvider{
-		mockProvider: mockProvider{
-			supportedModels: []string{"gpt-5-nano"},
-			providerTypes: map[string]string{
-				"openai/gpt-5-nano": "openai",
-			},
-			response: &core.ChatResponse{
-				ID:       "chatcmpl_alias_resolver_123",
-				Object:   "chat.completion",
-				Model:    "gpt-5-nano",
-				Provider: "openai",
-				Choices: []core.Choice{
-					{
-						Index:        0,
-						FinishReason: "stop",
-						Message: core.ResponseMessage{
-							Role:    "assistant",
-							Content: "ok",
-						},
+		supportedModels: []string{"gpt-5-nano"},
+		providerTypes: map[string]string{
+			"openai/gpt-5-nano": "openai",
+		},
+		response: &core.ChatResponse{
+			ID:       "chatcmpl_alias_resolver_123",
+			Object:   "chat.completion",
+			Model:    "gpt-5-nano",
+			Provider: "openai",
+			Choices: []core.Choice{
+				{
+					Index:        0,
+					FinishReason: "stop",
+					Message: core.ResponseMessage{
+						Role:    "assistant",
+						Content: "ok",
 					},
 				},
 			},
@@ -1651,24 +1639,22 @@ func TestChatCompletion_UsesExplicitTranslatedRequestPatcher(t *testing.T) {
 	pipeline.Add(systemPrompt, 0)
 
 	inner := &capturingProvider{
-		mockProvider: mockProvider{
-			supportedModels: []string{"gpt-5-nano"},
-			providerTypes: map[string]string{
-				"gpt-5-nano": "mock",
-			},
-			response: &core.ChatResponse{
-				ID:       "chatcmpl_guardrail_123",
-				Object:   "chat.completion",
-				Model:    "gpt-5-nano",
-				Provider: "mock",
-				Choices: []core.Choice{
-					{
-						Index:        0,
-						FinishReason: "stop",
-						Message: core.ResponseMessage{
-							Role:    "assistant",
-							Content: "ok",
-						},
+		supportedModels: []string{"gpt-5-nano"},
+		providerTypes: map[string]string{
+			"gpt-5-nano": "mock",
+		},
+		response: &core.ChatResponse{
+			ID:       "chatcmpl_guardrail_123",
+			Object:   "chat.completion",
+			Model:    "gpt-5-nano",
+			Provider: "mock",
+			Choices: []core.Choice{
+				{
+					Index:        0,
+					FinishReason: "stop",
+					Message: core.ResponseMessage{
+						Role:    "assistant",
+						Content: "ok",
 					},
 				},
 			},
@@ -1794,15 +1780,13 @@ func TestBatches_UsesExplicitGuardrailBatchPreparer(t *testing.T) {
 
 func TestResponses_UsesIngressFrameForDecoding(t *testing.T) {
 	provider := &capturingProvider{
-		mockProvider: mockProvider{
-			supportedModels: []string{"gpt-5-mini"},
-			responsesResponse: &core.ResponsesResponse{
-				ID:        "resp_123",
-				Object:    "response",
-				CreatedAt: 1234567890,
-				Model:     "gpt-5-mini",
-				Status:    "completed",
-			},
+		supportedModels: []string{"gpt-5-mini"},
+		responsesResponse: &core.ResponsesResponse{
+			ID:        "resp_123",
+			Object:    "response",
+			CreatedAt: 1234567890,
+			Model:     "gpt-5-mini",
+			Status:    "completed",
 		},
 	}
 
@@ -1861,14 +1845,12 @@ func TestResponses_UsesIngressFrameForDecoding(t *testing.T) {
 
 func TestEmbeddings_UsesIngressFrameForDecoding(t *testing.T) {
 	provider := &capturingProvider{
-		mockProvider: mockProvider{
-			supportedModels: []string{"text-embedding-3-large"},
-			embeddingResponse: &core.EmbeddingResponse{
-				Object: "list",
-				Model:  "text-embedding-3-large",
-				Data: []core.EmbeddingData{
-					{Object: "embedding", Embedding: json.RawMessage(`[0.1,0.2]`), Index: 0},
-				},
+		supportedModels: []string{"text-embedding-3-large"},
+		embeddingResponse: &core.EmbeddingResponse{
+			Object: "list",
+			Model:  "text-embedding-3-large",
+			Data: []core.EmbeddingData{
+				{Object: "embedding", Embedding: json.RawMessage(`[0.1,0.2]`), Index: 0},
 			},
 		},
 	}
@@ -2268,19 +2250,17 @@ func TestChatCompletionStreaming_FastPathUsageCarriesResolvedProviderName(t *tes
 func TestChatCompletionStreaming_FastPathSkipsQualifiedModelRewrite(t *testing.T) {
 	streamData := "data: {\"id\":\"chatcmpl-123\",\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\ndata: [DONE]\n\n"
 	provider := &capturingProvider{
-		mockProvider: mockProvider{
-			supportedModels: []string{"gpt-4o-mini"},
-			providerTypes: map[string]string{
-				"gpt-4o-mini": "openai",
+		supportedModels: []string{"gpt-4o-mini"},
+		providerTypes: map[string]string{
+			"gpt-4o-mini": "openai",
+		},
+		streamData: streamData,
+		passthroughResponse: &core.PassthroughResponse{
+			StatusCode: http.StatusOK,
+			Headers: map[string][]string{
+				"Content-Type": {"text/event-stream"},
 			},
-			streamData: streamData,
-			passthroughResponse: &core.PassthroughResponse{
-				StatusCode: http.StatusOK,
-				Headers: map[string][]string{
-					"Content-Type": {"text/event-stream"},
-				},
-				Body: io.NopCloser(strings.NewReader("data: should-not-be-used\n\n")),
-			},
+			Body: io.NopCloser(strings.NewReader("data: should-not-be-used\n\n")),
 		},
 	}
 
@@ -2318,19 +2298,17 @@ func TestChatCompletionStreaming_FastPathSkipsQualifiedModelRewrite(t *testing.T
 func TestChatCompletionStreaming_FastPathSkipsProviderFieldRewrite(t *testing.T) {
 	streamData := "data: {\"id\":\"chatcmpl-123\",\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\ndata: [DONE]\n\n"
 	provider := &capturingProvider{
-		mockProvider: mockProvider{
-			supportedModels: []string{"gpt-4o-mini"},
-			providerTypes: map[string]string{
-				"openai/gpt-4o-mini": "openai",
+		supportedModels: []string{"gpt-4o-mini"},
+		providerTypes: map[string]string{
+			"openai/gpt-4o-mini": "openai",
+		},
+		streamData: streamData,
+		passthroughResponse: &core.PassthroughResponse{
+			StatusCode: http.StatusOK,
+			Headers: map[string][]string{
+				"Content-Type": {"text/event-stream"},
 			},
-			streamData: streamData,
-			passthroughResponse: &core.PassthroughResponse{
-				StatusCode: http.StatusOK,
-				Headers: map[string][]string{
-					"Content-Type": {"text/event-stream"},
-				},
-				Body: io.NopCloser(strings.NewReader("data: should-not-be-used\n\n")),
-			},
+			Body: io.NopCloser(strings.NewReader("data: should-not-be-used\n\n")),
 		},
 	}
 
@@ -2672,9 +2650,7 @@ func TestChatCompletionStreaming_FlushesBeforeNextChunkArrives(t *testing.T) {
 	releaseSecondChunk := make(chan struct{})
 
 	provider := &streamingProviderWithCustomReader{
-		mockProvider: mockProvider{
-			supportedModels: []string{"gpt-4o-mini"},
-		},
+		supportedModels: []string{"gpt-4o-mini"},
 		reader: &delayedChunkReadCloser{
 			chunks: []delayedChunk{
 				{data: []byte("data: {\"id\":\"1\"}\n\n")},
@@ -3351,9 +3327,7 @@ func TestChatCompletion_InvalidJSON(t *testing.T) {
 
 func TestChatCompletion_InvalidContentType(t *testing.T) {
 	provider := &capturingProvider{
-		mockProvider: mockProvider{
-			supportedModels: []string{"gpt-4o-mini"},
-		},
+		supportedModels: []string{"gpt-4o-mini"},
 	}
 
 	e := echo.New()
@@ -5568,13 +5542,9 @@ func TestStreamingResponses_ChatBackedProviderInjectsUsageWhenEnforced(t *testin
 		"",
 	}, "\n\n")
 	provider := &chatBackedResponsesProvider{
-		capturingProvider: capturingProvider{
-			mockProvider: mockProvider{
-				supportedModels: []string{"gpt-4o-mini"},
-				streamData:      streamData,
-			},
-		},
-		providerName: "gemini",
+		supportedModels: []string{"gpt-4o-mini"},
+		streamData:      streamData,
+		providerName:    "gemini",
 	}
 
 	usageLog := &mockUsageLogger{
@@ -5615,13 +5585,9 @@ func TestStreamingResponses_ChatBackedProviderInjectsUsageWhenEnforced(t *testin
 
 func TestStreamingResponses_ChatBackedProviderDoesNotInjectUsageWhenDisabled(t *testing.T) {
 	provider := &chatBackedResponsesProvider{
-		capturingProvider: capturingProvider{
-			mockProvider: mockProvider{
-				supportedModels: []string{"gpt-4o-mini"},
-				streamData:      "data: [DONE]\n\n",
-			},
-		},
-		providerName: "gemini",
+		supportedModels: []string{"gpt-4o-mini"},
+		streamData:      "data: [DONE]\n\n",
+		providerName:    "gemini",
 	}
 
 	usageLog := &mockUsageLogger{
@@ -5654,10 +5620,8 @@ func TestStreamingResponses_ChatBackedProviderDoesNotInjectUsageWhenDisabled(t *
 func TestStreamingResponses_NativeProviderRequestRemainsUnchanged(t *testing.T) {
 	streamData := "data: {\"type\":\"response.completed\"}\n\ndata: [DONE]\n\n"
 	provider := &capturingProvider{
-		mockProvider: mockProvider{
-			supportedModels: []string{"gpt-4o-mini"},
-			streamData:      streamData,
-		},
+		supportedModels: []string{"gpt-4o-mini"},
+		streamData:      streamData,
 	}
 
 	usageLog := &mockUsageLogger{
@@ -5698,13 +5662,9 @@ func TestStreamingResponses_ChatBackedProviderWritesExactlyOneUsageEntry(t *test
 		"",
 	}, "\n\n")
 	provider := &chatBackedResponsesProvider{
-		capturingProvider: capturingProvider{
-			mockProvider: mockProvider{
-				supportedModels: []string{"gemini-2.0-flash"},
-				streamData:      streamData,
-			},
-		},
-		providerName: "gemini",
+		supportedModels: []string{"gemini-2.0-flash"},
+		streamData:      streamData,
+		providerName:    "gemini",
 	}
 	usageLog := &collectingUsageLogger{
 		config: usage.Config{
@@ -5746,23 +5706,21 @@ func TestStreamingResponses_ChatBackedProviderWritesExactlyOneUsageEntry(t *test
 
 func TestResponses_PreservesUnknownNestedFields(t *testing.T) {
 	provider := &capturingProvider{
-		mockProvider: mockProvider{
-			supportedModels: []string{"gpt-5-mini"},
-			responsesResponse: &core.ResponsesResponse{
-				ID:        "resp_123",
-				Object:    "response",
-				CreatedAt: 1234567890,
-				Model:     "gpt-5-mini",
-				Status:    "completed",
-				Output: []core.ResponsesOutputItem{
-					{
-						ID:     "msg_123",
-						Type:   "message",
-						Role:   "assistant",
-						Status: "completed",
-						Content: []core.ResponsesContentItem{
-							{Type: "output_text", Text: "ok"},
-						},
+		supportedModels: []string{"gpt-5-mini"},
+		responsesResponse: &core.ResponsesResponse{
+			ID:        "resp_123",
+			Object:    "response",
+			CreatedAt: 1234567890,
+			Model:     "gpt-5-mini",
+			Status:    "completed",
+			Output: []core.ResponsesOutputItem{
+				{
+					ID:     "msg_123",
+					Type:   "message",
+					Role:   "assistant",
+					Status: "completed",
+					Content: []core.ResponsesContentItem{
+						{Type: "output_text", Text: "ok"},
 					},
 				},
 			},
@@ -5815,13 +5773,11 @@ func TestResponses_PreservesUnknownNestedFields(t *testing.T) {
 func TestStreamingChatCompletion_InjectsStreamOptions(t *testing.T) {
 	streamData := "data: {\"id\":\"chatcmpl-1\",\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n"
 	provider := &capturingProvider{
-		mockProvider: mockProvider{
-			supportedModels: []string{"gpt-4o-mini"},
-			providerTypes: map[string]string{
-				"gpt-4o-mini": "openai",
-			},
-			streamData: streamData,
+		supportedModels: []string{"gpt-4o-mini"},
+		providerTypes: map[string]string{
+			"gpt-4o-mini": "openai",
 		},
+		streamData: streamData,
 	}
 
 	usageLog := &mockUsageLogger{

--- a/internal/server/image_edit_service_test.go
+++ b/internal/server/image_edit_service_test.go
@@ -87,7 +87,7 @@ var catPNG = editFormFile{field: "image", filename: "cat.png", contentType: "ima
 
 func TestImageEdits_ReturnsProviderResponse(t *testing.T) {
 	mock := newImageEditMock()
-	svc := &imageService{modelCallService: modelCallService{provider: mock}}
+	svc := &imageService{provider: mock}
 	c, rec := newImageEditRequest(t,
 		[][2]string{{"model", "gpt-image-1"}, {"prompt", "add a hat"}, {"n", "1"}, {"size", "1024x1024"}, {"input_fidelity", "high"}},
 		catPNG,
@@ -138,7 +138,7 @@ func TestImageEdits_ReturnsProviderResponse(t *testing.T) {
 
 func TestImageEdits_CollectsImageArray(t *testing.T) {
 	mock := newImageEditMock()
-	svc := &imageService{modelCallService: modelCallService{provider: mock}}
+	svc := &imageService{provider: mock}
 	c, rec := newImageEditRequest(t,
 		[][2]string{{"model", "gpt-image-1"}, {"prompt", "combine"}},
 		editFormFile{field: "image[]", filename: "one.png", data: "one"},
@@ -172,7 +172,7 @@ func TestImageEdits_RejectsInvalidRequests(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := newImageEditMock()
-			svc := &imageService{modelCallService: modelCallService{provider: mock}}
+			svc := &imageService{provider: mock}
 			c, rec := newImageEditRequest(t, tt.values, tt.files...)
 
 			if err := svc.CreateImageEdit(c); err != nil {
@@ -192,7 +192,7 @@ func TestImageEdits_RejectsInvalidRequests(t *testing.T) {
 }
 
 func TestImageEdits_RejectsNonMultipartBody(t *testing.T) {
-	svc := &imageService{modelCallService: modelCallService{provider: newImageEditMock()}}
+	svc := &imageService{provider: newImageEditMock()}
 	req := httptest.NewRequest(http.MethodPost, "/v1/images/edits", strings.NewReader(`{"model":"gpt-image-1","prompt":"x"}`))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -207,7 +207,7 @@ func TestImageEdits_RejectsNonMultipartBody(t *testing.T) {
 
 func TestImageEdits_RouterWithoutEditSupport(t *testing.T) {
 	// A router that generates images but cannot edit them.
-	svc := &imageService{modelCallService: modelCallService{provider: newImageMock()}}
+	svc := &imageService{provider: newImageMock()}
 	c, rec := newImageEditRequest(t, [][2]string{{"model", "dall-e-3"}, {"prompt", "x"}}, catPNG)
 
 	if err := svc.CreateImageEdit(c); err != nil {
@@ -223,7 +223,7 @@ func TestImageEdits_AuthorizesResolvedSelector(t *testing.T) {
 		mock := newImageEditMock()
 		mock.resolved = &core.ModelSelector{Provider: "openai", Model: "gpt-image-1"}
 		authorizer := &recordingModelAuthorizer{}
-		svc := &imageService{modelCallService: modelCallService{provider: mock, modelAuthorizer: authorizer}}
+		svc := &imageService{provider: mock, modelAuthorizer: authorizer}
 		c, rec := newImageEditRequest(t, [][2]string{{"model", "gpt-image-1"}, {"prompt", "x"}}, catPNG)
 
 		if err := svc.CreateImageEdit(c); err != nil {
@@ -240,7 +240,7 @@ func TestImageEdits_AuthorizesResolvedSelector(t *testing.T) {
 	t.Run("denied", func(t *testing.T) {
 		mock := newImageEditMock()
 		authorizer := &recordingModelAuthorizer{err: core.NewInvalidRequestError("denied", nil)}
-		svc := &imageService{modelCallService: modelCallService{provider: mock, modelAuthorizer: authorizer}}
+		svc := &imageService{provider: mock, modelAuthorizer: authorizer}
 		c, rec := newImageEditRequest(t, [][2]string{{"model", "gpt-image-1"}, {"prompt", "x"}}, catPNG)
 
 		if err := svc.CreateImageEdit(c); err != nil {
@@ -258,7 +258,7 @@ func TestImageEdits_AuthorizesResolvedSelector(t *testing.T) {
 func TestImageEdits_ProviderErrorIsSurfaced(t *testing.T) {
 	mock := newImageEditMock()
 	mock.imageErr = core.NewProviderError("openai", http.StatusBadRequest, "Invalid image format", nil)
-	svc := &imageService{modelCallService: modelCallService{provider: mock}}
+	svc := &imageService{provider: mock}
 	c, rec := newImageEditRequest(t, [][2]string{{"model", "gpt-image-1"}, {"prompt", "x"}}, catPNG)
 
 	if err := svc.CreateImageEdit(c); err != nil {
@@ -274,7 +274,7 @@ func TestImageEdits_NilProviderResponseIs502(t *testing.T) {
 	mock.imageResp = nil
 	var captured *usage.UsageEntry
 	logger := &capturingUsageLogger{config: usage.Config{Enabled: true}, captured: &captured}
-	svc := &imageService{modelCallService: modelCallService{provider: mock, usageLogger: logger}}
+	svc := &imageService{provider: mock, usageLogger: logger}
 	c, rec := newImageEditRequest(t, [][2]string{{"model", "gpt-image-1"}, {"prompt", "x"}}, catPNG)
 
 	if err := svc.CreateImageEdit(c); err != nil {
@@ -293,11 +293,10 @@ func TestImageEdits_LogsUsage(t *testing.T) {
 	logger := &capturingUsageLogger{config: usage.Config{Enabled: true}, captured: &captured}
 	mock := newImageEditMock()
 	pricing := &core.ModelPricing{PerImage: new(0.04)}
-	svc := &imageService{modelCallService: modelCallService{
+	svc := &imageService{
 		provider:        mock,
 		usageLogger:     logger,
-		pricingResolver: &mockPricingResolver{pricing: pricing},
-	}}
+		pricingResolver: &mockPricingResolver{pricing: pricing}}
 	c, rec := newImageEditRequest(t, [][2]string{{"model", "gpt-image-1"}, {"prompt", "x"}}, catPNG)
 
 	if err := svc.CreateImageEdit(c); err != nil {
@@ -372,10 +371,10 @@ func TestImageEdits_AuditsRequestMetadata(t *testing.T) {
 			mock := newImageEditMock()
 			mock.resolved = &core.ModelSelector{Provider: "openai", Model: "gpt-image-1"}
 			svc := &imageService{
-				modelCallService: modelCallService{provider: mock},
-				logBodies:        tt.logBodies,
-				logImageInputs:   tt.logImageInputs,
-				logImageOutputs:  tt.logImageOutputs,
+				provider:        mock,
+				logBodies:       tt.logBodies,
+				logImageInputs:  tt.logImageInputs,
+				logImageOutputs: tt.logImageOutputs,
 			}
 			c, rec := newImageEditRequest(t,
 				[][2]string{{"model", "gpt-image-1"}, {"prompt", "add a hat"}, {"size", "1024x1024"}, {"provider", "openai"}},

--- a/internal/server/image_service_test.go
+++ b/internal/server/image_service_test.go
@@ -60,7 +60,7 @@ func newImageRequest(body string) (*echo.Context, *httptest.ResponseRecorder) {
 
 func TestImageGenerations_ReturnsProviderResponse(t *testing.T) {
 	mock := newImageMock()
-	svc := &imageService{modelCallService: modelCallService{provider: mock}}
+	svc := &imageService{provider: mock}
 	c, rec := newImageRequest(`{"model":"dall-e-3","prompt":"a cat","n":1,"size":"1024x1024","style":"vivid"}`)
 
 	if err := svc.CreateImage(c); err != nil {
@@ -115,7 +115,7 @@ func TestImageGenerations_RejectsInvalidRequests(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := newImageMock()
-			svc := &imageService{modelCallService: modelCallService{provider: mock}}
+			svc := &imageService{provider: mock}
 			c, rec := newImageRequest(tt.body)
 
 			if err := svc.CreateImage(c); err != nil {
@@ -135,7 +135,7 @@ func TestImageGenerations_RejectsInvalidRequests(t *testing.T) {
 }
 
 func TestImageGenerations_RouterWithoutImageSupport(t *testing.T) {
-	svc := &imageService{modelCallService: modelCallService{provider: &mockProvider{supportedModels: []string{"dall-e-3"}}}}
+	svc := &imageService{provider: &mockProvider{supportedModels: []string{"dall-e-3"}}}
 	c, rec := newImageRequest(`{"model":"dall-e-3","prompt":"a cat"}`)
 
 	if err := svc.CreateImage(c); err != nil {
@@ -157,7 +157,7 @@ func TestImageGenerations_AuthorizesResolvedSelector(t *testing.T) {
 		mock := newImageMock()
 		mock.resolved = &core.ModelSelector{Provider: "openai", Model: "dall-e-3"}
 		authorizer := &recordingModelAuthorizer{}
-		svc := &imageService{modelCallService: modelCallService{provider: mock, modelAuthorizer: authorizer}}
+		svc := &imageService{provider: mock, modelAuthorizer: authorizer}
 		c, rec := newImageRequest(`{"model":"dall-e-3","prompt":"a cat"}`)
 
 		if err := svc.CreateImage(c); err != nil {
@@ -174,7 +174,7 @@ func TestImageGenerations_AuthorizesResolvedSelector(t *testing.T) {
 	t.Run("denied", func(t *testing.T) {
 		mock := newImageMock()
 		authorizer := &recordingModelAuthorizer{err: core.NewInvalidRequestError("denied", nil)}
-		svc := &imageService{modelCallService: modelCallService{provider: mock, modelAuthorizer: authorizer}}
+		svc := &imageService{provider: mock, modelAuthorizer: authorizer}
 		c, rec := newImageRequest(`{"model":"dall-e-3","prompt":"a cat"}`)
 
 		if err := svc.CreateImage(c); err != nil {
@@ -192,7 +192,7 @@ func TestImageGenerations_AuthorizesResolvedSelector(t *testing.T) {
 func TestImageGenerations_ProviderErrorIsSurfaced(t *testing.T) {
 	mock := newImageMock()
 	mock.imageErr = core.NewProviderError("openai", http.StatusBadRequest, "Your request was rejected by the safety system.", nil)
-	svc := &imageService{modelCallService: modelCallService{provider: mock}}
+	svc := &imageService{provider: mock}
 	c, rec := newImageRequest(`{"model":"dall-e-3","prompt":"a cat"}`)
 
 	if err := svc.CreateImage(c); err != nil {
@@ -211,7 +211,7 @@ func TestImageGenerations_NilProviderResponseIs502(t *testing.T) {
 	mock.imageResp = nil
 	var captured *usage.UsageEntry
 	logger := &capturingUsageLogger{config: usage.Config{Enabled: true}, captured: &captured}
-	svc := &imageService{modelCallService: modelCallService{provider: mock, usageLogger: logger}}
+	svc := &imageService{provider: mock, usageLogger: logger}
 	c, rec := newImageRequest(`{"model":"dall-e-3","prompt":"a cat"}`)
 
 	if err := svc.CreateImage(c); err != nil {
@@ -231,11 +231,10 @@ func TestImageGenerations_LogsUsage(t *testing.T) {
 	mock := newImageMock()
 	mock.imageResp.Data = append(mock.imageResp.Data, core.ImageData{URL: "https://img/2.png"})
 	pricing := &core.ModelPricing{PerImage: new(0.04)}
-	svc := &imageService{modelCallService: modelCallService{
+	svc := &imageService{
 		provider:        mock,
 		usageLogger:     logger,
-		pricingResolver: &mockPricingResolver{pricing: pricing},
-	}}
+		pricingResolver: &mockPricingResolver{pricing: pricing}}
 	c, rec := newImageRequest(`{"model":"dall-e-3","prompt":"a cat","n":2}`)
 
 	if err := svc.CreateImage(c); err != nil {
@@ -264,7 +263,7 @@ func TestImageGenerations_LogsUsage(t *testing.T) {
 func TestImageGenerations_UsageDisabledWritesNothing(t *testing.T) {
 	var captured *usage.UsageEntry
 	logger := &capturingUsageLogger{config: usage.Config{Enabled: false}, captured: &captured}
-	svc := &imageService{modelCallService: modelCallService{provider: newImageMock(), usageLogger: logger}}
+	svc := &imageService{provider: newImageMock(), usageLogger: logger}
 	c, rec := newImageRequest(`{"model":"dall-e-3","prompt":"a cat"}`)
 
 	if err := svc.CreateImage(c); err != nil {
@@ -316,7 +315,7 @@ func TestImageGenerations_AuditsRequestBody(t *testing.T) {
 		t.Run(map[bool]string{true: "enabled", false: "disabled"}[logBodies], func(t *testing.T) {
 			mock := newImageMock()
 			mock.resolved = &core.ModelSelector{Provider: "openai", Model: "dall-e-3"}
-			svc := &imageService{modelCallService: modelCallService{provider: mock}, logBodies: logBodies}
+			svc := &imageService{provider: mock, logBodies: logBodies}
 			c, rec := newImageRequest(`{"model":"dall-e-3","prompt":"a cat","style":"vivid"}`)
 			entry := &auditlog.LogEntry{}
 			c.Set(string(auditlog.LogEntryKey), entry)
@@ -371,7 +370,7 @@ func TestImageGenerations_AuditsResponseImages(t *testing.T) {
 				Data:    []core.ImageData{{B64JSON: "aGVsbG8="}, {URL: "https://img/2.png"}},
 				Usage:   &core.ImageUsage{TotalTokens: 300},
 			}
-			svc := &imageService{modelCallService: modelCallService{provider: mock}, logBodies: tt.logBodies, logImageOutputs: tt.logImageOutputs}
+			svc := &imageService{provider: mock, logBodies: tt.logBodies, logImageOutputs: tt.logImageOutputs}
 			c, rec := newImageRequest(`{"model":"dall-e-3","prompt":"a cat"}`)
 			entry := &auditlog.LogEntry{}
 			c.Set(string(auditlog.LogEntryKey), entry)

--- a/internal/server/internal_chat_completion_executor_test.go
+++ b/internal/server/internal_chat_completion_executor_test.go
@@ -30,26 +30,22 @@ func TestInternalChatCompletionExecutor_UsesTranslatedPlanAndAuditMetadata(t *te
 		config: auditlog.Config{Enabled: true},
 	}
 	provider := &contextCapturingProvider{
-		capturingProvider: capturingProvider{
-			mockProvider: mockProvider{
-				supportedModels: []string{"rewrite-model"},
-				providerTypes: map[string]string{
-					"rewrite-model": "openai",
-				},
-				response: &core.ChatResponse{
-					ID:       "chatcmpl-internal-1",
-					Object:   "chat.completion",
-					Model:    "rewrite-model",
-					Provider: "openai",
-					Choices: []core.Choice{
-						{
-							Index:        0,
-							FinishReason: "stop",
-							Message: core.ResponseMessage{
-								Role:    "assistant",
-								Content: "rewritten",
-							},
-						},
+		supportedModels: []string{"rewrite-model"},
+		providerTypes: map[string]string{
+			"rewrite-model": "openai",
+		},
+		response: &core.ChatResponse{
+			ID:       "chatcmpl-internal-1",
+			Object:   "chat.completion",
+			Model:    "rewrite-model",
+			Provider: "openai",
+			Choices: []core.Choice{
+				{
+					Index:        0,
+					FinishReason: "stop",
+					Message: core.ResponseMessage{
+						Role:    "assistant",
+						Content: "rewritten",
 					},
 				},
 			},
@@ -131,26 +127,22 @@ func TestInternalChatCompletionExecutor_DoesNotReuseParentWorkflowResolution(t *
 		config: auditlog.Config{Enabled: true},
 	}
 	provider := &contextCapturingProvider{
-		capturingProvider: capturingProvider{
-			mockProvider: mockProvider{
-				supportedModels: []string{"gpt-4o-mini"},
-				providerTypes: map[string]string{
-					"openai/gpt-4o-mini": "openai",
-				},
-				response: &core.ChatResponse{
-					ID:       "chatcmpl-internal-2",
-					Object:   "chat.completion",
-					Model:    "gpt-4o-mini",
-					Provider: "openai",
-					Choices: []core.Choice{
-						{
-							Index:        0,
-							FinishReason: "stop",
-							Message: core.ResponseMessage{
-								Role:    "assistant",
-								Content: "rewritten",
-							},
-						},
+		supportedModels: []string{"gpt-4o-mini"},
+		providerTypes: map[string]string{
+			"openai/gpt-4o-mini": "openai",
+		},
+		response: &core.ChatResponse{
+			ID:       "chatcmpl-internal-2",
+			Object:   "chat.completion",
+			Model:    "gpt-4o-mini",
+			Provider: "openai",
+			Choices: []core.Choice{
+				{
+					Index:        0,
+					FinishReason: "stop",
+					Message: core.ResponseMessage{
+						Role:    "assistant",
+						Content: "rewritten",
 					},
 				},
 			},
@@ -216,26 +208,22 @@ func TestInternalChatCompletionExecutor_PreservesBoundedAuditCapture(t *testing.
 	bigPrompt := strings.Repeat("x", auditlog.MaxBodyCapture+2048)
 	bigResponse := strings.Repeat("y", auditlog.MaxBodyCapture+2048)
 	provider := &contextCapturingProvider{
-		capturingProvider: capturingProvider{
-			mockProvider: mockProvider{
-				supportedModels: []string{"rewrite-model"},
-				providerTypes: map[string]string{
-					"rewrite-model": "openai",
-				},
-				response: &core.ChatResponse{
-					ID:       "chatcmpl-internal-3",
-					Object:   "chat.completion",
-					Model:    "rewrite-model",
-					Provider: "openai",
-					Choices: []core.Choice{
-						{
-							Index:        0,
-							FinishReason: "stop",
-							Message: core.ResponseMessage{
-								Role:    "assistant",
-								Content: bigResponse,
-							},
-						},
+		supportedModels: []string{"rewrite-model"},
+		providerTypes: map[string]string{
+			"rewrite-model": "openai",
+		},
+		response: &core.ChatResponse{
+			ID:       "chatcmpl-internal-3",
+			Object:   "chat.completion",
+			Model:    "rewrite-model",
+			Provider: "openai",
+			Choices: []core.Choice{
+				{
+					Index:        0,
+					FinishReason: "stop",
+					Message: core.ResponseMessage{
+						Role:    "assistant",
+						Content: bigResponse,
 					},
 				},
 			},
@@ -308,26 +296,22 @@ func TestInternalChatCompletionExecutor_RoutesThroughResponseCache(t *testing.T)
 
 	rcm := responsecache.NewResponseCacheMiddlewareWithStore(store, time.Hour)
 	provider := &contextCapturingProvider{
-		capturingProvider: capturingProvider{
-			mockProvider: mockProvider{
-				supportedModels: []string{"rewrite-model"},
-				providerTypes: map[string]string{
-					"rewrite-model": "openai",
-				},
-				response: &core.ChatResponse{
-					ID:       "chatcmpl-internal-cache",
-					Object:   "chat.completion",
-					Model:    "rewrite-model",
-					Provider: "openai",
-					Choices: []core.Choice{
-						{
-							Index:        0,
-							FinishReason: "stop",
-							Message: core.ResponseMessage{
-								Role:    "assistant",
-								Content: "rewritten",
-							},
-						},
+		supportedModels: []string{"rewrite-model"},
+		providerTypes: map[string]string{
+			"rewrite-model": "openai",
+		},
+		response: &core.ChatResponse{
+			ID:       "chatcmpl-internal-cache",
+			Object:   "chat.completion",
+			Model:    "rewrite-model",
+			Provider: "openai",
+			Choices: []core.Choice{
+				{
+					Index:        0,
+					FinishReason: "stop",
+					Message: core.ResponseMessage{
+						Role:    "assistant",
+						Content: "rewritten",
 					},
 				},
 			},
@@ -372,26 +356,22 @@ func TestInternalChatCompletionExecutor_CachedNilWorkflowDoesNotPanic(t *testing
 
 	rcm := responsecache.NewResponseCacheMiddlewareWithStore(store, time.Hour)
 	provider := &contextCapturingProvider{
-		capturingProvider: capturingProvider{
-			mockProvider: mockProvider{
-				supportedModels: []string{"rewrite-model"},
-				providerTypes: map[string]string{
-					"rewrite-model": "openai",
-				},
-				response: &core.ChatResponse{
-					ID:       "chatcmpl-internal-cache-nil-workflow",
-					Object:   "chat.completion",
-					Model:    "rewrite-model",
-					Provider: "openai",
-					Choices: []core.Choice{
-						{
-							Index:        0,
-							FinishReason: "stop",
-							Message: core.ResponseMessage{
-								Role:    "assistant",
-								Content: "rewritten",
-							},
-						},
+		supportedModels: []string{"rewrite-model"},
+		providerTypes: map[string]string{
+			"rewrite-model": "openai",
+		},
+		response: &core.ChatResponse{
+			ID:       "chatcmpl-internal-cache-nil-workflow",
+			Object:   "chat.completion",
+			Model:    "rewrite-model",
+			Provider: "openai",
+			Choices: []core.Choice{
+				{
+					Index:        0,
+					FinishReason: "stop",
+					Message: core.ResponseMessage{
+						Role:    "assistant",
+						Content: "rewritten",
 					},
 				},
 			},
@@ -446,26 +426,22 @@ func TestInternalChatCompletionExecutor_MarshalFailureFallsBackToNoCacheDispatch
 
 	rcm := responsecache.NewResponseCacheMiddlewareWithStore(store, time.Hour)
 	provider := &contextCapturingProvider{
-		capturingProvider: capturingProvider{
-			mockProvider: mockProvider{
-				supportedModels: []string{"rewrite-model"},
-				providerTypes: map[string]string{
-					"rewrite-model": "openai",
-				},
-				response: &core.ChatResponse{
-					ID:       "chatcmpl-internal-marshal-fallback",
-					Object:   "chat.completion",
-					Model:    "rewrite-model",
-					Provider: "openai",
-					Choices: []core.Choice{
-						{
-							Index:        0,
-							FinishReason: "stop",
-							Message: core.ResponseMessage{
-								Role:    "assistant",
-								Content: "rewritten",
-							},
-						},
+		supportedModels: []string{"rewrite-model"},
+		providerTypes: map[string]string{
+			"rewrite-model": "openai",
+		},
+		response: &core.ChatResponse{
+			ID:       "chatcmpl-internal-marshal-fallback",
+			Object:   "chat.completion",
+			Model:    "rewrite-model",
+			Provider: "openai",
+			Choices: []core.Choice{
+				{
+					Index:        0,
+					FinishReason: "stop",
+					Message: core.ResponseMessage{
+						Role:    "assistant",
+						Content: "rewritten",
 					},
 				},
 			},

--- a/internal/server/messages_handler_test.go
+++ b/internal/server/messages_handler_test.go
@@ -15,19 +15,17 @@ import (
 
 func TestMessages_NonStreaming(t *testing.T) {
 	provider := &capturingProvider{
-		mockProvider: mockProvider{
-			supportedModels: []string{"claude-test"},
-			response: &core.ChatResponse{
-				ID:     "resp-1",
-				Object: "chat.completion",
-				Model:  "claude-test",
-				Choices: []core.Choice{{
-					Index:        0,
-					Message:      core.ResponseMessage{Role: "assistant", Content: "Hello back"},
-					FinishReason: "stop",
-				}},
-				Usage: core.Usage{PromptTokens: 9, CompletionTokens: 3, TotalTokens: 12},
-			},
+		supportedModels: []string{"claude-test"},
+		response: &core.ChatResponse{
+			ID:     "resp-1",
+			Object: "chat.completion",
+			Model:  "claude-test",
+			Choices: []core.Choice{{
+				Index:        0,
+				Message:      core.ResponseMessage{Role: "assistant", Content: "Hello back"},
+				FinishReason: "stop",
+			}},
+			Usage: core.Usage{PromptTokens: 9, CompletionTokens: 3, TotalTokens: 12},
 		},
 	}
 
@@ -88,10 +86,8 @@ func TestMessages_Streaming(t *testing.T) {
 	}, "\n\n")
 
 	provider := &capturingProvider{
-		mockProvider: mockProvider{
-			supportedModels: []string{"claude-test"},
-			streamData:      chatSSE,
-		},
+		supportedModels: []string{"claude-test"},
+		streamData:      chatSSE,
 	}
 
 	e := echo.New()

--- a/internal/server/ratelimit_support.go
+++ b/internal/server/ratelimit_support.go
@@ -153,8 +153,7 @@ func acquireRateLimitForContext(ctx context.Context, limiter RateLimiter, route 
 }
 
 func rateLimitCheckError(err error) error {
-	var exceeded *ratelimit.ExceededError
-	if errors.As(err, &exceeded) {
+	if exceeded, ok := errors.AsType[*ratelimit.ExceededError](err); ok {
 		message := exceeded.Error()
 		if message == "" {
 			message = "rate limit exceeded"

--- a/internal/server/realtime_service.go
+++ b/internal/server/realtime_service.go
@@ -263,8 +263,7 @@ func (s *realtimeService) proxy(c *echo.Context, ctx context.Context, target *co
 	slog.Info("realtime session opened", "request_id", route.requestID, "model", route.model, "provider", route.providerType)
 	err := realtime.Proxy(c.Response(), c.Request(), t, hooks)
 
-	var de *realtime.DialError
-	if errors.As(err, &de) {
+	if de, ok := errors.AsType[*realtime.DialError](err); ok {
 		slog.Warn("realtime upstream dial failed", "request_id", route.requestID, "provider", route.providerType, "error", de.Err)
 		return handleError(c, core.NewProviderError(route.providerType, http.StatusBadGateway, "failed to connect to realtime upstream", de.Err))
 	}

--- a/internal/server/realtime_webrtc_service.go
+++ b/internal/server/realtime_webrtc_service.go
@@ -318,8 +318,7 @@ func (s *realtimeService) observeCall(ctx context.Context, route realtimeRoute, 
 		obsCtx, cancel := context.WithTimeout(context.Background(), realtime.DefaultCallTTL)
 		defer cancel()
 		err := realtime.Observe(obsCtx, t, tap)
-		var de *realtime.DialError
-		if errors.As(err, &de) {
+		if de, ok := errors.AsType[*realtime.DialError](err); ok {
 			slog.Warn("realtime call observer failed to attach; usage will not be recorded",
 				"request_id", route.requestID, "call_id", callID, "error", de.Err)
 			return

--- a/internal/server/request_rewrite.go
+++ b/internal/server/request_rewrite.go
@@ -240,8 +240,7 @@ func applyRewriteResponseHeaders(c *echo.Context, headers http.Header) {
 // Only the rewriter name and error are logged — never request bodies or
 // headers.
 func rewriterGatewayError(name string, err error) error {
-	var rejection *ext.RejectionError
-	if errors.As(err, &rejection) {
+	if rejection, ok := errors.AsType[*ext.RejectionError](err); ok {
 		status := rejection.Status
 		if status < http.StatusBadRequest || status > 599 {
 			status = http.StatusBadRequest

--- a/internal/server/request_rewrite_test.go
+++ b/internal/server/request_rewrite_test.go
@@ -63,19 +63,17 @@ func replaceBodyRewriter(name, old, new string) *stubRewriter {
 
 func newRewriteTestProvider() *capturingProvider {
 	return &capturingProvider{
-		mockProvider: mockProvider{
-			supportedModels: []string{"gpt-4o-mini"},
-			response: &core.ChatResponse{
-				ID:      "chatcmpl-rewrite",
-				Object:  "chat.completion",
-				Created: 1234567890,
-				Model:   "gpt-4o-mini",
-				Choices: []core.Choice{
-					{
-						Index:        0,
-						Message:      core.ResponseMessage{Role: "assistant", Content: "ok"},
-						FinishReason: "stop",
-					},
+		supportedModels: []string{"gpt-4o-mini"},
+		response: &core.ChatResponse{
+			ID:      "chatcmpl-rewrite",
+			Object:  "chat.completion",
+			Created: 1234567890,
+			Model:   "gpt-4o-mini",
+			Choices: []core.Choice{
+				{
+					Index:        0,
+					Message:      core.ResponseMessage{Role: "assistant", Content: "ok"},
+					FinishReason: "stop",
 				},
 			},
 		},
@@ -144,7 +142,7 @@ func TestRequestRewriteMiddlewareDeliversProviderFeedback(t *testing.T) {
 		PromptTokens:        2048,
 		PromptTokensDetails: &core.PromptTokensDetails{CachedTokens: 1536},
 	}
-	rewriter := &feedbackRewriter{stubRewriter: stubRewriter{name: "feedback"}}
+	rewriter := &feedbackRewriter{name: "feedback"}
 	srv := New(provider, &Config{
 		RequestRewriters: []ext.RequestRewriter{rewriter},
 		SessionDetector:  session.NewDetector(session.BuiltinRules(), false),
@@ -173,8 +171,8 @@ func TestRequestRewriteMiddlewareDeliversProviderFeedback(t *testing.T) {
 func TestRequestRewriteMiddlewareHonorsResponseFeedbackFilter(t *testing.T) {
 	for _, want := range []bool{false, true} {
 		rewriter := &filteredFeedbackRewriter{
-			feedbackRewriter: feedbackRewriter{stubRewriter: stubRewriter{name: "filtered"}},
-			want:             want,
+			name: "filtered",
+			want: want,
 		}
 		var attached bool
 		next := func(c *echo.Context) error {
@@ -197,8 +195,8 @@ func TestRequestRewriteMiddlewareHonorsResponseFeedbackFilter(t *testing.T) {
 func TestRequestRewriteMiddlewareIsolatesResponseFeedbackFilterPanic(t *testing.T) {
 	provider := newRewriteTestProvider()
 	rewriter := &filteredFeedbackRewriter{
-		feedbackRewriter: feedbackRewriter{stubRewriter: stubRewriter{name: "panicking-filter"}},
-		panicFilter:      true,
+		name:        "panicking-filter",
+		panicFilter: true,
 	}
 	srv := New(provider, &Config{RequestRewriters: []ext.RequestRewriter{rewriter}})
 

--- a/internal/server/response_feedback.go
+++ b/internal/server/response_feedback.go
@@ -130,8 +130,8 @@ func (o *responseFeedbackStreamObserver) OnJSONEvent(payload map[string]any) {
 	if !ok {
 		return
 	}
-	usage := responseCacheUsage{observed: true}
-	usage.input = firstNumericInt(usageMap, "prompt_tokens", "input_tokens")
+	usage := responseCacheUsage{observed: true,
+		input: firstNumericInt(usageMap, "prompt_tokens", "input_tokens")}
 	usage.read, usage.write = cacheTokensFromMap(usageMap)
 	if details, ok := nestedMap(usageMap["prompt_tokens_details"]); ok {
 		usage.read = max(usage.read, firstNumericInt(details, "cached_tokens"))

--- a/internal/usage/labels_sqlite_test.go
+++ b/internal/usage/labels_sqlite_test.go
@@ -199,7 +199,7 @@ func TestSQLiteAggregatesRespectDataFilters(t *testing.T) {
 func TestSQLiteUsageLogLabelFilter(t *testing.T) {
 	reader := newLabelledSQLiteReader(t)
 
-	result, err := reader.GetUsageLog(context.Background(), UsageLogParams{UsageQueryParams: UsageQueryParams{Label: "prod"}})
+	result, err := reader.GetUsageLog(context.Background(), UsageLogParams{Label: "prod"})
 	if err != nil {
 		t.Fatalf("GetUsageLog() error = %v", err)
 	}
@@ -211,7 +211,7 @@ func TestSQLiteUsageLogLabelFilter(t *testing.T) {
 	}
 
 	// A label that is a substring of an existing one must not match.
-	empty, err := reader.GetUsageLog(context.Background(), UsageLogParams{UsageQueryParams: UsageQueryParams{Label: "pro"}})
+	empty, err := reader.GetUsageLog(context.Background(), UsageLogParams{Label: "pro"})
 	if err != nil {
 		t.Fatalf("GetUsageLog() error = %v", err)
 	}

--- a/internal/usage/reader_mongodb.go
+++ b/internal/usage/reader_mongodb.go
@@ -322,10 +322,10 @@ func (r *MongoDBReader) GetUsageByModel(ctx context.Context, params UsageQueryPa
 			ProviderName: displayUsageProviderName(row.ID.ProviderName, row.ID.Provider),
 			InputTokens:  row.InputTokens,
 			OutputTokens: row.OutputTokens,
-		}
-		m.InputCost = costPtr(row.HasInputCost, row.InputCost)
-		m.OutputCost = costPtr(row.HasOutputCost, row.OutputCost)
-		m.TotalCost = costPtr(row.HasTotalCost, row.TotalCost)
+
+			InputCost:  costPtr(row.HasInputCost, row.InputCost),
+			OutputCost: costPtr(row.HasOutputCost, row.OutputCost),
+			TotalCost:  costPtr(row.HasTotalCost, row.TotalCost)}
 		result = append(result, m)
 	}
 
@@ -1131,8 +1131,8 @@ func (r *MongoDBReader) GetCacheOverview(ctx context.Context, params UsageQueryP
 			InputTokens:  row.InputTokens,
 			OutputTokens: row.OutputTokens,
 			TotalTokens:  row.TotalTokens,
-		}
-		entry.SavedCost = costPtr(row.HasSavedCost, row.SavedCost)
+
+			SavedCost: costPtr(row.HasSavedCost, row.SavedCost)}
 		overview.Daily = append(overview.Daily, entry)
 	}
 

--- a/internal/usage/reader_mongodb_test.go
+++ b/internal/usage/reader_mongodb_test.go
@@ -11,9 +11,9 @@ import (
 
 func TestMongoSessionUsagePipelinesArePagedAndExcludeCachedCost(t *testing.T) {
 	dataPipeline, countPipeline, limit, offset, err := mongoSessionUsagePipelines(SessionUsageParams{
-		UsageQueryParams: UsageQueryParams{SessionID: "scoped-session", CacheMode: CacheModeUncached},
-		Limit:            12,
-		Offset:           7,
+		SessionID: "scoped-session", CacheMode: CacheModeUncached,
+		Limit:  12,
+		Offset: 7,
 	})
 	if err != nil {
 		t.Fatalf("mongoSessionUsagePipelines: %v", err)
@@ -62,10 +62,8 @@ func TestSessionCostPtrUsesZeroForCacheOnlySession(t *testing.T) {
 
 func TestMongoUsageLogMatchFiltersAndSearchWithCacheMode(t *testing.T) {
 	got, err := mongoUsageLogMatchFilters(UsageLogParams{
-		UsageQueryParams: UsageQueryParams{
-			CacheMode: CacheModeUncached,
-		},
-		Search: "gpt",
+		CacheMode: CacheModeUncached,
+		Search:    "gpt",
 	})
 	if err != nil {
 		t.Fatalf("mongoUsageLogMatchFilters() error = %v", err)
@@ -95,10 +93,8 @@ func TestMongoUsageLogMatchFiltersAndSearchWithCacheMode(t *testing.T) {
 
 func TestMongoUsageLogMatchFiltersLabel(t *testing.T) {
 	got, err := mongoUsageLogMatchFilters(UsageLogParams{
-		UsageQueryParams: UsageQueryParams{
-			CacheMode: CacheModeAll,
-			Label:     "team-alpha",
-		},
+		CacheMode: CacheModeAll,
+		Label:     "team-alpha",
 	})
 	if err != nil {
 		t.Fatalf("mongoUsageLogMatchFilters() error = %v", err)
@@ -141,10 +137,8 @@ func TestMongoUsageMatchFiltersDataFilters(t *testing.T) {
 
 func TestMongoUsageLogMatchFiltersEscapesSearchRegex(t *testing.T) {
 	got, err := mongoUsageLogMatchFilters(UsageLogParams{
-		UsageQueryParams: UsageQueryParams{
-			CacheMode: CacheModeAll,
-		},
-		Search: "gpt.4+",
+		CacheMode: CacheModeAll,
+		Search:    "gpt.4+",
 	})
 	if err != nil {
 		t.Fatalf("mongoUsageLogMatchFilters() error = %v", err)

--- a/internal/usage/reader_postgresql_test.go
+++ b/internal/usage/reader_postgresql_test.go
@@ -10,9 +10,9 @@ import (
 
 func TestPostgreSQLSessionUsageQueriesArePagedAndExcludeCachedCost(t *testing.T) {
 	countQuery, dataQuery, args, dataArgs, limit, offset, err := postgresqlSessionUsageQueries(SessionUsageParams{
-		UsageQueryParams: UsageQueryParams{SessionID: "scoped-session", CacheMode: CacheModeUncached},
-		Limit:            25,
-		Offset:           10,
+		SessionID: "scoped-session", CacheMode: CacheModeUncached,
+		Limit:  25,
+		Offset: 10,
 	})
 	if err != nil {
 		t.Fatalf("postgresqlSessionUsageQueries: %v", err)

--- a/internal/usage/reader_sqlite_boundary_test.go
+++ b/internal/usage/reader_sqlite_boundary_test.go
@@ -844,10 +844,8 @@ func TestSQLiteReader_GetUsageLogFiltersByUserPathSubtree(t *testing.T) {
 	}
 
 	log, err := reader.GetUsageLog(ctx, UsageLogParams{
-		UsageQueryParams: UsageQueryParams{
-			UserPath: "/team",
-		},
-		Limit: 10,
+		UserPath: "/team",
+		Limit:    10,
 	})
 	if err != nil {
 		t.Fatalf("GetUsageLog returned error: %v", err)

--- a/internal/usage/recalculate_pricing_issue435_test.go
+++ b/internal/usage/recalculate_pricing_issue435_test.go
@@ -65,11 +65,9 @@ func TestSQLiteStoreRecalculatePricing_CorrectsStaleCachedCosts(t *testing.T) {
 	}
 
 	result, err := store.RecalculatePricing(ctx, RecalculatePricingParams{
-		UsageQueryParams: UsageQueryParams{
-			StartDate: time.Date(2026, 6, 16, 0, 0, 0, 0, time.UTC),
-			EndDate:   time.Date(2026, 6, 16, 0, 0, 0, 0, time.UTC),
-			TimeZone:  "UTC",
-		},
+		StartDate: time.Date(2026, 6, 16, 0, 0, 0, 0, time.UTC),
+		EndDate:   time.Date(2026, 6, 16, 0, 0, 0, 0, time.UTC),
+		TimeZone:  "UTC",
 	}, resolver)
 	if err != nil {
 		t.Fatalf("RecalculatePricing: %v", err)

--- a/internal/usage/recalculate_pricing_mongodb.go
+++ b/internal/usage/recalculate_pricing_mongodb.go
@@ -109,8 +109,7 @@ func (e *mongoTransactionFallbackError) Error() string {
 }
 
 func mongoTransactionFallbackCause(err error) error {
-	var fallbackErr *mongoTransactionFallbackError
-	if errors.As(err, &fallbackErr) {
+	if fallbackErr, ok := errors.AsType[*mongoTransactionFallbackError](err); ok {
 		return fallbackErr.err
 	}
 	return nil

--- a/internal/usage/recalculate_pricing_mongodb_test.go
+++ b/internal/usage/recalculate_pricing_mongodb_test.go
@@ -61,7 +61,7 @@ func TestMongoDBStoreRecalculatePricingTransactionFlow(t *testing.T) {
 	}
 
 	result, err := store.RecalculatePricing(context.Background(), RecalculatePricingParams{
-		UsageQueryParams: UsageQueryParams{Model: " gpt-4o ", Provider: " primary-openai "},
+		Model: " gpt-4o ", Provider: " primary-openai ",
 	}, staticTestPricingResolver{})
 	if err != nil {
 		t.Fatalf("RecalculatePricing() error = %v", err)
@@ -184,7 +184,7 @@ func TestMongoDBStoreRecalculatePricingUsesProviderNameForPricing(t *testing.T) 
 	}
 
 	result, err := store.RecalculatePricing(context.Background(), RecalculatePricingParams{
-		UsageQueryParams: UsageQueryParams{Model: "gpt-4o", Provider: " primary-openai "},
+		Model: "gpt-4o", Provider: " primary-openai ",
 	}, resolver)
 	if err != nil {
 		t.Fatalf("RecalculatePricing() error = %v", err)

--- a/internal/usage/recalculate_pricing_sqlite_test.go
+++ b/internal/usage/recalculate_pricing_sqlite_test.go
@@ -69,13 +69,11 @@ func TestSQLiteStoreRecalculatePricingUpdatesFilteredUsageCosts(t *testing.T) {
 	inputRate := 2.0
 	outputRate := 6.0
 	result, err := store.RecalculatePricing(ctx, RecalculatePricingParams{
-		UsageQueryParams: UsageQueryParams{
-			StartDate: time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC),
-			EndDate:   time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC),
-			UserPath:  "/team",
-			Provider:  "primary-openai",
-			Model:     "gpt-4o",
-		},
+		StartDate: time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC),
+		EndDate:   time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC),
+		UserPath:  "/team",
+		Provider:  "primary-openai",
+		Model:     "gpt-4o",
 	}, staticTestPricingResolver{
 		"primary-openai/gpt-4o": {
 			InputPerMtok:  &inputRate,
@@ -147,7 +145,7 @@ func TestSQLiteStoreRecalculatePricingFiltersByLabel(t *testing.T) {
 	inputRate := 2.0
 	// The padded label exercises normalizedRecalculatePricingParams trimming.
 	result, err := store.RecalculatePricing(ctx, RecalculatePricingParams{
-		UsageQueryParams: UsageQueryParams{Label: " env:prod "},
+		Label: " env:prod ",
 	}, staticTestPricingResolver{
 		"openai/gpt-4o": {InputPerMtok: &inputRate},
 	})
@@ -218,7 +216,7 @@ func TestSQLiteStoreRecalculatePricingProcessesBatches(t *testing.T) {
 
 	inputRate := 2.0
 	result, err := store.RecalculatePricing(ctx, RecalculatePricingParams{
-		UsageQueryParams: UsageQueryParams{Model: "gpt-4o"},
+		Model: "gpt-4o",
 	}, staticTestPricingResolver{
 		"openai/gpt-4o": {
 			InputPerMtok: &inputRate,

--- a/internal/usage/session_sqlite_test.go
+++ b/internal/usage/session_sqlite_test.go
@@ -74,7 +74,7 @@ func TestSQLiteSessionUsageRoundTripAggregationAndFilter(t *testing.T) {
 	}
 
 	result, err := reader.GetUsageBySession(context.Background(), SessionUsageParams{
-		UsageQueryParams: UsageQueryParams{CacheMode: CacheModeUncached},
+		CacheMode: CacheModeUncached,
 	})
 	if err != nil {
 		t.Fatalf("GetUsageBySession: %v", err)
@@ -106,10 +106,9 @@ func TestSQLiteSessionUsageRoundTripAggregationAndFilter(t *testing.T) {
 		t.Fatalf("session page = %+v", page)
 	}
 
-	logResult, err := reader.GetUsageLog(context.Background(), UsageLogParams{UsageQueryParams: UsageQueryParams{
+	logResult, err := reader.GetUsageLog(context.Background(), UsageLogParams{
 		SessionID: "scoped-session-b",
-		CacheMode: CacheModeAll,
-	}})
+		CacheMode: CacheModeAll})
 	if err != nil {
 		t.Fatalf("GetUsageLog session filter: %v", err)
 	}

--- a/internal/workflows/compiler_test.go
+++ b/internal/workflows/compiler_test.go
@@ -149,8 +149,7 @@ func TestCompilerCompile_ReturnsGatewayErrorWhenGuardrailsCatalogIsEmpty(t *test
 	if err == nil {
 		t.Fatal("Compile() error = nil, want gateway error")
 	}
-	var gatewayErr *core.GatewayError
-	if !errors.As(err, &gatewayErr) {
+	if _, ok := errors.AsType[*core.GatewayError](err); !ok {
 		t.Fatalf("Compile() error = %T, want *core.GatewayError", err)
 	}
 }
@@ -185,8 +184,7 @@ func TestCompilerCompile_WrapsBuildPipelineErrorsAsGatewayErrors(t *testing.T) {
 	if err == nil {
 		t.Fatal("Compile() error = nil, want gateway error")
 	}
-	var gatewayErr *core.GatewayError
-	if !errors.As(err, &gatewayErr) {
+	if _, ok := errors.AsType[*core.GatewayError](err); !ok {
 		t.Fatalf("Compile() error = %T, want *core.GatewayError", err)
 	}
 }

--- a/internal/workflows/service_test.go
+++ b/internal/workflows/service_test.go
@@ -201,13 +201,13 @@ func (s *concurrentStore) Close() error { return nil }
 type blockingCompiler struct {
 	delegate  Compiler
 	blockCall int32
-	callCount int32
+	callCount atomic.Int32
 	blocked   chan struct{}
 	release   chan struct{}
 }
 
 func (c *blockingCompiler) Compile(version Version) (*CompiledWorkflow, error) {
-	call := atomic.AddInt32(&c.callCount, 1)
+	call := c.callCount.Add(1)
 	if call == c.blockCall {
 		close(c.blocked)
 		<-c.release
@@ -1302,19 +1302,17 @@ func TestServiceCreateRejectsEmptyCompiledPreviewBeforePersisting(t *testing.T) 
 
 func TestServiceCreateRefreshIgnoresRequestContextCancellationAfterPersist(t *testing.T) {
 	store := &contextCancelingStore{
-		staticStore: staticStore{
-			versions: []Version{
-				{
-					ID:       "global-v1",
-					Scope:    Scope{},
-					ScopeKey: "global",
-					Version:  1,
-					Active:   true,
-					Name:     "global",
-					Payload: Payload{
-						SchemaVersion: 1,
-						Features:      FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
-					},
+		versions: []Version{
+			{
+				ID:       "global-v1",
+				Scope:    Scope{},
+				ScopeKey: "global",
+				Version:  1,
+				Active:   true,
+				Name:     "global",
+				Payload: Payload{
+					SchemaVersion: 1,
+					Features:      FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
 				},
 			},
 		},
@@ -1360,19 +1358,17 @@ func TestServiceCreateRefreshIgnoresRequestContextCancellationAfterPersist(t *te
 
 func TestServiceCreateReturnsSuccessWhenReloadRefreshFailsAfterPersist(t *testing.T) {
 	store := &refreshFailingStore{
-		staticStore: staticStore{
-			versions: []Version{
-				{
-					ID:       "global-v1",
-					Scope:    Scope{},
-					ScopeKey: "global",
-					Version:  1,
-					Active:   true,
-					Name:     "global",
-					Payload: Payload{
-						SchemaVersion: 1,
-						Features:      FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
-					},
+		versions: []Version{
+			{
+				ID:       "global-v1",
+				Scope:    Scope{},
+				ScopeKey: "global",
+				Version:  1,
+				Active:   true,
+				Name:     "global",
+				Payload: Payload{
+					SchemaVersion: 1,
+					Features:      FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
 				},
 			},
 		},
@@ -1415,31 +1411,29 @@ func TestServiceCreateReturnsSuccessWhenReloadRefreshFailsAfterPersist(t *testin
 
 func TestServiceDeactivateRefreshIgnoresRequestContextCancellationAfterPersist(t *testing.T) {
 	store := &contextCancelingStore{
-		staticStore: staticStore{
-			versions: []Version{
-				{
-					ID:       "global-v1",
-					Scope:    Scope{},
-					ScopeKey: "global",
-					Version:  1,
-					Active:   true,
-					Name:     "global",
-					Payload: Payload{
-						SchemaVersion: 1,
-						Features:      FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
-					},
+		versions: []Version{
+			{
+				ID:       "global-v1",
+				Scope:    Scope{},
+				ScopeKey: "global",
+				Version:  1,
+				Active:   true,
+				Name:     "global",
+				Payload: Payload{
+					SchemaVersion: 1,
+					Features:      FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
 				},
-				{
-					ID:       "provider-v1",
-					Scope:    Scope{Provider: "openai"},
-					ScopeKey: "provider:openai",
-					Version:  1,
-					Active:   true,
-					Name:     "openai",
-					Payload: Payload{
-						SchemaVersion: 1,
-						Features:      FeatureFlags{Cache: false, Audit: true, Usage: true, Guardrails: false},
-					},
+			},
+			{
+				ID:       "provider-v1",
+				Scope:    Scope{Provider: "openai"},
+				ScopeKey: "provider:openai",
+				Version:  1,
+				Active:   true,
+				Name:     "openai",
+				Payload: Payload{
+					SchemaVersion: 1,
+					Features:      FeatureFlags{Cache: false, Audit: true, Usage: true, Guardrails: false},
 				},
 			},
 		},
@@ -1473,31 +1467,29 @@ func TestServiceDeactivateRefreshIgnoresRequestContextCancellationAfterPersist(t
 
 func TestServiceDeactivateReturnsSuccessWhenReloadRefreshFailsAfterPersist(t *testing.T) {
 	store := &refreshFailingStore{
-		staticStore: staticStore{
-			versions: []Version{
-				{
-					ID:       "global-v1",
-					Scope:    Scope{},
-					ScopeKey: "global",
-					Version:  1,
-					Active:   true,
-					Name:     "global",
-					Payload: Payload{
-						SchemaVersion: 1,
-						Features:      FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
-					},
+		versions: []Version{
+			{
+				ID:       "global-v1",
+				Scope:    Scope{},
+				ScopeKey: "global",
+				Version:  1,
+				Active:   true,
+				Name:     "global",
+				Payload: Payload{
+					SchemaVersion: 1,
+					Features:      FeatureFlags{Cache: true, Audit: true, Usage: true, Guardrails: false},
 				},
-				{
-					ID:       "provider-v1",
-					Scope:    Scope{Provider: "openai"},
-					ScopeKey: "provider:openai",
-					Version:  1,
-					Active:   true,
-					Name:     "openai",
-					Payload: Payload{
-						SchemaVersion: 1,
-						Features:      FeatureFlags{Cache: false, Audit: true, Usage: true, Guardrails: false},
-					},
+			},
+			{
+				ID:       "provider-v1",
+				Scope:    Scope{Provider: "openai"},
+				ScopeKey: "provider:openai",
+				Version:  1,
+				Active:   true,
+				Name:     "openai",
+				Payload: Payload{
+					SchemaVersion: 1,
+					Features:      FeatureFlags{Cache: false, Audit: true, Usage: true, Guardrails: false},
 				},
 			},
 		},

--- a/run/run.go
+++ b/run/run.go
@@ -117,8 +117,7 @@ func ExitCode(err error) int {
 	if err == nil {
 		return 0
 	}
-	var usage *usageError
-	if errors.As(err, &usage) {
+	if _, ok := errors.AsType[*usageError](err); ok {
 		return 2
 	}
 	return 1

--- a/tests/e2e/mock_provider.go
+++ b/tests/e2e/mock_provider.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"sync"
 	"time"
 
@@ -505,8 +506,8 @@ func extractInputText(input any) string {
 		return v
 	case []any:
 		// Array input - extract from last user message
-		for i := len(v) - 1; i >= 0; i-- {
-			if msg, ok := v[i].(map[string]any); ok {
+		for _, v0 := range slices.Backward(v) {
+			if msg, ok := v0.(map[string]any); ok {
 				if role, _ := msg["role"].(string); role == "user" {
 					if content, ok := msg["content"].(string); ok {
 						return content


### PR DESCRIPTION
Applies `go fix` under the pinned Go 1.27 toolchain so the `make fix-check` pre-commit hook passes again on a clean tree (it currently reports 53 files on `main`).

Mechanical rewrites only: `min`/`max` builtins, `strings.Contains`/`strings.NewReader`, `for range`, `any`, `errors.AsType`, `slices.Backward`. Two rewrites needed a hand adjustment:

- `internal/providers/bedrock/bedrock.go`: `errors.AsType[httpStatus]` requires an error type, so the local `httpStatus` interface now embeds `error` (every value in an error chain already is one; the match is unchanged).
- `internal/responsecache/semantic.go`: the `slices.Backward` rewrite shadowed the index (`for i, i := range`); the element is renamed.

No behaviour change. `make fix-check` is clean, lint 0 issues, full unit suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized internal error handling and collection iteration.
  * Simplified parameter and data initialization across auditing, usage, provider, and response processing.
  * Streamlined subsystem cleanup and provider/model callback handling.

* **Tests**
  * Updated test fixtures and assertions to match the streamlined interfaces.
  * Maintained coverage for usage filtering, pricing, retries, error handling, and provider behavior.

* **Bug Fixes**
  * No user-facing behavior changes; existing error classification, teardown ordering, and response handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->