### PR TITLE
perf(gateway): cut per-request allocations on the inference hot path

### DIFF
--- a/ext/auth.go
+++ b/ext/auth.go
@@ -16,7 +16,7 @@ type clearedAuthentication struct{}
 const (
 	AuthenticationLoginHeader  = "X-GoModel-Auth-Login"
 	AuthenticationLogoutHeader = "X-GoModel-Auth-Logout"
-	AuthenticationUserHeader   = "X-GoModel-Auth-User"
+	AuthenticationUserHeader   = "X-Gomodel-Auth-User" // canonical textproto spelling; header names are case-insensitive
 )
 
 // Authentication describes an identity established by an extension.

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -603,5 +603,5 @@ func requestIDFromAdminContextOrHeader(req *http.Request) string {
 	if requestID := strings.TrimSpace(core.GetRequestID(req.Context())); requestID != "" {
 		return requestID
 	}
-	return strings.TrimSpace(req.Header.Get("X-Request-ID"))
+	return strings.TrimSpace(req.Header.Get(core.RequestIDHeader))
 }

--- a/internal/auditlog/audio_body.go
+++ b/internal/auditlog/audio_body.go
@@ -31,8 +31,9 @@ type AudioBodyLog struct {
 
 // IsAudioContentType reports whether a Content-Type denotes an audio payload.
 func IsAudioContentType(contentType string) bool {
-	mediaType := strings.ToLower(strings.TrimSpace(strings.Split(contentType, ";")[0]))
-	return strings.HasPrefix(mediaType, "audio/")
+	mediaType, _, _ := strings.Cut(contentType, ";")
+	mediaType = strings.TrimSpace(mediaType)
+	return len(mediaType) >= 6 && strings.EqualFold(mediaType[:6], "audio/")
 }
 
 // BuildAudioResponseBody builds the audit value for a binary audio response.

--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -366,15 +366,20 @@ func RedactHeaders(headers map[string]string) map[string]string {
 
 	result := make(map[string]string, len(headers))
 	for key, value := range headers {
-		if core.IsCredentialHeader(key) {
-			result[key] = "[REDACTED]"
-		} else if strings.EqualFold(key, "Location") {
-			result[key] = core.RedactSensitiveURLQuery(value)
-		} else {
-			result[key] = value
-		}
+		result[key] = redactHeaderValue(key, value)
 	}
 	return result
+}
+
+// redactHeaderValue returns the audit-safe value of one header.
+func redactHeaderValue(key, value string) string {
+	if core.IsCredentialHeader(key) {
+		return "[REDACTED]"
+	}
+	if strings.EqualFold(key, "Location") {
+		return core.RedactSensitiveURLQuery(value)
+	}
+	return value
 }
 
 // Config holds audit logging configuration

--- a/internal/auditlog/entry_capture.go
+++ b/internal/auditlog/entry_capture.go
@@ -206,7 +206,7 @@ func internalJSONAuditHeaders(ctx context.Context, requestID string) http.Header
 	headers := make(http.Header)
 	headers.Set("Content-Type", "application/json")
 	if requestID != "" {
-		headers.Set("X-Request-ID", requestID)
+		headers.Set(core.RequestIDHeader, requestID)
 	}
 	if userPath := strings.TrimSpace(core.UserPathFromContext(ctx)); userPath != "" {
 		headers.Set(core.UserPathHeaderNameFromContext(ctx), userPath)

--- a/internal/auditlog/middleware.go
+++ b/internal/auditlog/middleware.go
@@ -58,7 +58,7 @@ func Middleware(logger LoggerInterface) echo.MiddlewareFunc {
 			req := c.Request()
 
 			// Read request ID (always set by the request ID middleware in http.go)
-			requestID := req.Header.Get("X-Request-ID")
+			requestID := req.Header.Get(core.RequestIDHeader)
 			userPath := core.UserPathFromContext(req.Context())
 			if userPath == "" {
 				userPath = "/"
@@ -334,20 +334,21 @@ func isEventStreamContentType(contentType string) bool {
 	if contentType == "" {
 		return false
 	}
-	mediaType := strings.ToLower(strings.TrimSpace(strings.Split(contentType, ";")[0]))
-	return mediaType == "text/event-stream"
+	mediaType, _, _ := strings.Cut(contentType, ";")
+	return strings.EqualFold(strings.TrimSpace(mediaType), "text/event-stream")
 }
 
 // extractHeaders extracts headers from a map[string][]string (http.Header or echo headers),
-// taking the first value for each key and redacting sensitive headers.
+// taking the first value for each key and redacting sensitive headers in the
+// same pass (the same rules as RedactHeaders).
 func extractHeaders(headers map[string][]string) map[string]string {
 	result := make(map[string]string, len(headers))
 	for key, values := range headers {
 		if len(values) > 0 {
-			result[key] = values[0]
+			result[key] = redactHeaderValue(key, values[0])
 		}
 	}
-	return RedactHeaders(result)
+	return result
 }
 
 // hashAPIKey creates a short hash of the API key for identification.
@@ -361,7 +362,7 @@ func hashAPIKey(authHeader string) string {
 	}
 
 	hash := sha256.Sum256([]byte(token))
-	return hex.EncodeToString(hash[:])[:APIKeyHashPrefixLength]
+	return hex.EncodeToString(hash[:APIKeyHashPrefixLength/2])
 }
 
 // CaptureLoggedBody converts raw body bytes into the representation audit

--- a/internal/core/context.go
+++ b/internal/core/context.go
@@ -86,6 +86,12 @@ func WithRequestID(ctx context.Context, requestID string) context.Context {
 	return context.WithValue(ctx, requestIDKey, requestID)
 }
 
+// RequestIDHeader is the request/response header carrying the gateway request
+// id, spelled in canonical textproto form ("X-Request-Id") so Header.Get/Set
+// need not canonicalize (and copy) the key on every call. Clients may send it
+// in any case; lookups are case-insensitive.
+const RequestIDHeader = "X-Request-Id"
+
 // GetRequestID retrieves the request ID from the context.
 // Returns empty string if not found.
 func GetRequestID(ctx context.Context) string {
@@ -129,6 +135,11 @@ func GetWhiteBoxPrompt(ctx context.Context) *WhiteBoxPrompt {
 
 // WithWorkflow returns a new context with the workflow attached.
 func WithWorkflow(ctx context.Context, workflow *Workflow) context.Context {
+	// Idempotent: resolution, preparation and cache setup each attach the
+	// same workflow, so re-wrapping would only add context layers.
+	if GetWorkflow(ctx) == workflow {
+		return ctx
+	}
 	return context.WithValue(ctx, workflowKey, workflow)
 }
 

--- a/internal/core/credential_headers.go
+++ b/internal/core/credential_headers.go
@@ -18,9 +18,27 @@ var credentialHeaders = map[string]struct{}{
 	"x-gomodel-key":       {},
 }
 
+// maxCredentialHeaderLen bounds the lowercase scratch buffer below; every
+// credentialHeaders key is shorter, so longer names can never match.
+const maxCredentialHeaderLen = 32
+
 // IsCredentialHeader reports whether the header name carries credentials.
-// Matching is case-insensitive and ignores surrounding whitespace.
+// Matching is case-insensitive and ignores surrounding whitespace. It runs
+// for every header of every audited request, so the fold happens in a stack
+// buffer rather than through strings.ToLower.
 func IsCredentialHeader(name string) bool {
-	_, ok := credentialHeaders[strings.ToLower(strings.TrimSpace(name))]
+	name = strings.TrimSpace(name)
+	if len(name) > maxCredentialHeaderLen {
+		return false
+	}
+	var lower [maxCredentialHeaderLen]byte
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		if 'A' <= c && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		lower[i] = c
+	}
+	_, ok := credentialHeaders[string(lower[:len(name)])]
 	return ok
 }

--- a/internal/core/json_fields.go
+++ b/internal/core/json_fields.go
@@ -344,13 +344,13 @@ func extractUnknownJSONFieldsWith(data []byte, isKnown func(string) bool) (Unkno
 		return UnknownJSONFields{}, fmt.Errorf("expected JSON object")
 	}
 
-	// Pre-size for typical unknown-field payloads without reserving
-	// request-sized capacity: the result is retained on the decoded request
-	// for its whole lifetime, so a body-sized backing array would pin a full
-	// body copy per decoded object even when the extras are a few bytes.
+	// The buffer is sized on the first unknown member so objects without
+	// extras (the common case) allocate nothing here. It is pre-sized for
+	// typical unknown-field payloads without reserving request-sized
+	// capacity: the result is retained on the decoded request for its whole
+	// lifetime, so a body-sized backing array would pin a full body copy per
+	// decoded object even when the extras are a few bytes.
 	var buf bytes.Buffer
-	buf.Grow(min(len(data), 256))
-	buf.WriteByte('{')
 	wrote := false
 	root.ForEach(func(key, value gjson.Result) bool {
 		if isKnown(key.String()) {
@@ -358,6 +358,9 @@ func extractUnknownJSONFieldsWith(data []byte, isKnown func(string) bool) (Unkno
 		}
 		if wrote {
 			buf.WriteByte(',')
+		} else {
+			buf.Grow(min(len(data), 256))
+			buf.WriteByte('{')
 		}
 		buf.WriteString(key.Raw)
 		buf.WriteByte(':')

--- a/internal/core/model_selector.go
+++ b/internal/core/model_selector.go
@@ -58,12 +58,12 @@ func ParseModelSelector(model, provider string) (ModelSelector, error) {
 }
 
 func splitQualifiedModel(model string) (prefix, rest string, ok bool) {
-	parts := strings.SplitN(model, "/", 2)
-	if len(parts) != 2 {
+	prefix, rest, ok = strings.Cut(model, "/")
+	if !ok {
 		return "", "", false
 	}
-	prefix = strings.TrimSpace(parts[0])
-	rest = strings.TrimSpace(parts[1])
+	prefix = strings.TrimSpace(prefix)
+	rest = strings.TrimSpace(rest)
 	if prefix == "" || rest == "" {
 		return "", "", false
 	}

--- a/internal/core/request_snapshot.go
+++ b/internal/core/request_snapshot.go
@@ -224,15 +224,22 @@ func cloneMultiMap(src map[string][]string) map[string][]string {
 	if len(src) == 0 {
 		return nil
 	}
+	// One backing array for every value slice (the http.Header.Clone trick):
+	// two allocations per snapshot instead of one per header.
+	total := 0
+	for _, values := range src {
+		total += len(values)
+	}
+	backing := make([]string, total)
 	dst := make(map[string][]string, len(src))
 	for key, values := range src {
 		if len(values) == 0 {
 			dst[key] = nil
 			continue
 		}
-		cloned := make([]string, len(values))
-		copy(cloned, values)
-		dst[key] = cloned
+		n := copy(backing, values)
+		dst[key] = backing[:n:n]
+		backing = backing[n:]
 	}
 	return dst
 }

--- a/internal/core/semantic.go
+++ b/internal/core/semantic.go
@@ -369,8 +369,9 @@ func deriveSnapshotSelectorHintsGJSON(body []byte) (model, provider string, stre
 		return "", "", false, false
 	}
 
-	root := gjson.ParseBytes(body)
-	if !root.IsObject() {
+	// GetBytes peeks without gjson.ParseBytes's full copy of the body; the
+	// leading byte is the object check the parse used to make.
+	if trimmed := bytes.TrimSpace(body); len(trimmed) == 0 || trimmed[0] != '{' {
 		return "", "", false, false
 	}
 
@@ -378,28 +379,28 @@ func deriveSnapshotSelectorHintsGJSON(body []byte) (model, provider string, stre
 	// encoding/json on duplicate keys, but the hot-path speedup is worth it here:
 	// duplicate selector keys are not expected from real clients, and we accept
 	// the first-match behavior to keep ingress peeking cheap.
-	modelResult := root.Get("model")
+	modelResult := gjson.GetBytes(body, "model")
 	if !snapshotSelectorStringAllowed(modelResult) {
 		return "", "", false, false
 	}
-	providerResult := root.Get("provider")
+	providerResult := gjson.GetBytes(body, "provider")
 	if !snapshotSelectorStringAllowed(providerResult) {
 		return "", "", false, false
 	}
-	streamResult := root.Get("stream")
+	streamResult := gjson.GetBytes(body, "stream")
 	if !snapshotSelectorBoolAllowed(streamResult) {
 		return "", "", false, false
 	}
 
-	// Clone the extracted strings: gjson results alias the full parsed body,
-	// and these values land in RouteHints, which lives on the request context
-	// for the whole (possibly streaming) request — without the clone, two
-	// short selector strings pin a request-sized backing string.
+	// GetBytes results own their strings (unlike Parse results, which alias
+	// the body), so these values can land in RouteHints — which lives on the
+	// request context for the whole, possibly streaming, request — without
+	// pinning a request-sized backing string.
 	if modelResult.Type == gjson.String {
-		model = strings.Clone(modelResult.String())
+		model = modelResult.String()
 	}
 	if providerResult.Type == gjson.String {
-		provider = strings.Clone(providerResult.String())
+		provider = providerResult.String()
 	}
 	if streamResult.Type == gjson.True || streamResult.Type == gjson.False {
 		stream = streamResult.Bool()

--- a/internal/mcpgateway/usage.go
+++ b/internal/mcpgateway/usage.go
@@ -1,6 +1,8 @@
 package mcpgateway
 
 import (
+	"github.com/enterpilot/gomodel/internal/core"
+
 	"encoding/json"
 	"strings"
 	"time"
@@ -39,7 +41,7 @@ func (s *Service) recordToolCall(req *mcp.CallToolRequest, server, exposedTool, 
 	}
 
 	if extra := req.GetExtra(); extra != nil && extra.Header != nil {
-		entry.RequestID = strings.TrimSpace(extra.Header.Get("X-Request-ID"))
+		entry.RequestID = strings.TrimSpace(extra.Header.Get(core.RequestIDHeader))
 		entry.UserPath = strings.TrimSpace(extra.Header.Get(s.userPathHeader))
 		entry.Labels = parseLabelsHeader(extra.Header.Get(labelsHeader))
 	}

--- a/internal/responsecache/responsecache.go
+++ b/internal/responsecache/responsecache.go
@@ -32,7 +32,7 @@ var internalRequestHeaderAllowlist = map[string]struct{}{
 	http.CanonicalHeaderKey("X-Cache-Semantic-Threshold"): {},
 	http.CanonicalHeaderKey("X-Cache-TTL"):                {},
 	http.CanonicalHeaderKey("X-Cache-Type"):               {},
-	http.CanonicalHeaderKey("X-Request-ID"):               {},
+	core.RequestIDHeader:                                  {},
 }
 
 // ResponseCacheMiddleware wraps response cache logic. App and server only see this type.
@@ -256,8 +256,8 @@ func internalRequestHeaders(ctx context.Context) http.Header {
 	if headers.Get("Content-Type") == "" {
 		headers.Set("Content-Type", "application/json")
 	}
-	if requestID := strings.TrimSpace(core.GetRequestID(ctx)); requestID != "" && headers.Get("X-Request-ID") == "" {
-		headers.Set("X-Request-ID", requestID)
+	if requestID := strings.TrimSpace(core.GetRequestID(ctx)); requestID != "" && headers.Get(core.RequestIDHeader) == "" {
+		headers.Set(core.RequestIDHeader, requestID)
 	}
 	return headers
 }

--- a/internal/responsecache/semantic.go
+++ b/internal/responsecache/semantic.go
@@ -167,7 +167,7 @@ func (m *semanticCacheMiddleware) Handle(ex exchange, body []byte, next func() e
 			slog.Info("semantic cache hit",
 				"path", path,
 				"score", results[0].Score,
-				"request_id", ex.RequestHeader("X-Request-ID"),
+				"request_id", ex.RequestHeader(core.RequestIDHeader),
 			)
 			return nil
 		}

--- a/internal/responsecache/semantic.go
+++ b/internal/responsecache/semantic.go
@@ -167,7 +167,7 @@ func (m *semanticCacheMiddleware) Handle(ex exchange, body []byte, next func() e
 			slog.Info("semantic cache hit",
 				"path", path,
 				"score", results[0].Score,
-				"request_id", ex.RequestHeader(core.RequestIDHeader),
+				"request_id", core.GetRequestID(ex.Context()),
 			)
 			return nil
 		}

--- a/internal/responsecache/simple.go
+++ b/internal/responsecache/simple.go
@@ -92,7 +92,7 @@ func (m *simpleCacheMiddleware) TryHit(ex exchange, body []byte) (bool, error) {
 		}
 		slog.Info("response cache hit (exact)",
 			"path", path,
-			"request_id", ex.RequestHeader(core.RequestIDHeader),
+			"request_id", core.GetRequestID(ex.Context()),
 		)
 		return true, nil
 	}

--- a/internal/responsecache/simple.go
+++ b/internal/responsecache/simple.go
@@ -92,7 +92,7 @@ func (m *simpleCacheMiddleware) TryHit(ex exchange, body []byte) (bool, error) {
 		}
 		slog.Info("response cache hit (exact)",
 			"path", path,
-			"request_id", ex.RequestHeader("X-Request-ID"),
+			"request_id", ex.RequestHeader(core.RequestIDHeader),
 		)
 		return true, nil
 	}

--- a/internal/responsecache/stream_cache.go
+++ b/internal/responsecache/stream_cache.go
@@ -141,8 +141,8 @@ func isEventStreamContentType(contentType string) bool {
 	if contentType == "" {
 		return false
 	}
-	mediaType := strings.ToLower(strings.TrimSpace(strings.Split(contentType, ";")[0]))
-	return mediaType == "text/event-stream"
+	mediaType, _, _ := strings.Cut(contentType, ";")
+	return strings.EqualFold(strings.TrimSpace(mediaType), "text/event-stream")
 }
 
 func writeCachedResponse(c *echo.Context, path string, requestBody, cached []byte, cacheType string) error {

--- a/internal/responsecache/usage_hit.go
+++ b/internal/responsecache/usage_hit.go
@@ -42,7 +42,7 @@ func newUsageHitRecorder(logger usage.LoggerInterface, pricingResolver usage.Pri
 		endpoint := ex.Path()
 		requestID := core.GetRequestID(ctx)
 		if requestID == "" {
-			requestID = ex.RequestHeader("X-Request-ID")
+			requestID = ex.RequestHeader(core.RequestIDHeader)
 		}
 
 		var pricing *core.ModelPricing

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -588,7 +588,7 @@ func (h *Handler) Health(c *echo.Context) error {
 // @Router       /v1/models [get]
 func (h *Handler) ListModels(c *echo.Context) error {
 	// Create context with request ID for provider
-	requestID := c.Request().Header.Get("X-Request-ID")
+	requestID := c.Request().Header.Get(core.RequestIDHeader)
 	ctx := core.WithRequestID(c.Request().Context(), requestID)
 
 	resp, err := h.provider.ListModels(ctx)

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -291,18 +291,20 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 			LogRequestID:     true,
 			LogContentLength: true,
 			LogResponseSize:  true,
+			// LogAttrs with typed attrs: slog.Info's variadic ...any would box
+			// every value (an allocation each) on every model request.
 			LogValuesFunc: func(c *echo.Context, v middleware.RequestLoggerValues) error {
-				slog.Info("REQUEST",
-					"method", v.Method,
-					"uri", v.URI,
-					"status", v.Status,
-					"latency", v.Latency.String(),
-					"host", v.Host,
-					"bytes_in", v.ContentLength,
-					"bytes_out", v.ResponseSize,
-					"user_agent", v.UserAgent,
-					"remote_ip", v.RemoteIP,
-					"request_id", v.RequestID,
+				slog.LogAttrs(context.Background(), slog.LevelInfo, "REQUEST",
+					slog.String("method", v.Method),
+					slog.String("uri", v.URI),
+					slog.Int("status", v.Status),
+					slog.String("latency", v.Latency.String()),
+					slog.String("host", v.Host),
+					slog.String("bytes_in", v.ContentLength),
+					slog.Int64("bytes_out", v.ResponseSize),
+					slog.String("user_agent", v.UserAgent),
+					slog.String("remote_ip", v.RemoteIP),
+					slog.String("request_id", v.RequestID),
 				)
 				return nil
 			},

--- a/internal/server/model_validation.go
+++ b/internal/server/model_validation.go
@@ -126,8 +126,12 @@ func storeWorkflow(c *echo.Context, workflow *core.Workflow) {
 	if c == nil || workflow == nil {
 		return
 	}
-	ctx := core.WithWorkflow(c.Request().Context(), workflow)
-	c.SetRequest(c.Request().WithContext(ctx))
+	// Resolution stores the workflow once and the inference path stores it
+	// again after preparation; skip the context wrap (and request copy) when
+	// the context already carries this exact workflow.
+	if ctx := c.Request().Context(); core.GetWorkflow(ctx) != workflow {
+		c.SetRequest(c.Request().WithContext(core.WithWorkflow(ctx, workflow)))
+	}
 	auditlog.EnrichEntryWithWorkflow(c, workflow)
 }
 

--- a/internal/server/passthrough_support.go
+++ b/internal/server/passthrough_support.go
@@ -107,12 +107,12 @@ func buildPassthroughHeaders(ctx context.Context, src http.Header) http.Header {
 		copy(clonedValues, values)
 		dst[canonicalKey] = clonedValues
 	}
-	requestID := strings.TrimSpace(src.Get("X-Request-ID"))
+	requestID := strings.TrimSpace(src.Get(core.RequestIDHeader))
 	if requestID == "" {
 		requestID = strings.TrimSpace(core.GetRequestID(ctx))
 	}
-	if requestID != "" && strings.TrimSpace(dst.Get("X-Request-ID")) == "" {
-		dst.Set("X-Request-ID", requestID)
+	if requestID != "" && strings.TrimSpace(dst.Get(core.RequestIDHeader)) == "" {
+		dst.Set(core.RequestIDHeader, requestID)
 	}
 	if len(dst) == 0 {
 		return nil

--- a/internal/server/ratelimit_support.go
+++ b/internal/server/ratelimit_support.go
@@ -172,6 +172,18 @@ func rateLimitCheckError(err error) error {
 		WithCode("rate_limit_check_failed")
 }
 
+// Rate-limit response headers in canonical textproto form: Header.Set only
+// skips copying/canonicalizing the key when it is already canonical, and these
+// are set on every rate-limited request.
+const (
+	rateLimitLimitRequestsHeader     = "X-Ratelimit-Limit-Requests"
+	rateLimitRemainingRequestsHeader = "X-Ratelimit-Remaining-Requests"
+	rateLimitResetRequestsHeader     = "X-Ratelimit-Reset-Requests"
+	rateLimitLimitTokensHeader       = "X-Ratelimit-Limit-Tokens"
+	rateLimitRemainingTokensHeader   = "X-Ratelimit-Remaining-Tokens"
+	rateLimitResetTokensHeader       = "X-Ratelimit-Reset-Tokens"
+)
+
 func rateLimitBreachHeaders(exceeded *ratelimit.ExceededError) http.Header {
 	headers := http.Header{}
 	headers.Set("Retry-After", strconv.FormatInt(retryAfterSeconds(exceeded.RetryAfter), 10))
@@ -179,27 +191,27 @@ func rateLimitBreachHeaders(exceeded *ratelimit.ExceededError) http.Header {
 	limit := strconv.FormatInt(exceeded.Limit, 10)
 	switch exceeded.Scope {
 	case ratelimit.ScopeRequests:
-		headers.Set("x-ratelimit-limit-requests", limit)
-		headers.Set("x-ratelimit-remaining-requests", "0")
-		headers.Set("x-ratelimit-reset-requests", reset)
+		headers.Set(rateLimitLimitRequestsHeader, limit)
+		headers.Set(rateLimitRemainingRequestsHeader, "0")
+		headers.Set(rateLimitResetRequestsHeader, reset)
 	case ratelimit.ScopeTokens:
-		headers.Set("x-ratelimit-limit-tokens", limit)
-		headers.Set("x-ratelimit-remaining-tokens", "0")
-		headers.Set("x-ratelimit-reset-tokens", reset)
+		headers.Set(rateLimitLimitTokensHeader, limit)
+		headers.Set(rateLimitRemainingTokensHeader, "0")
+		headers.Set(rateLimitResetTokensHeader, reset)
 	}
 	return headers
 }
 
 func applyRateLimitHeaders(target http.Header, snapshot ratelimit.HeaderSnapshot) {
 	if snapshot.HasRequests {
-		target.Set("x-ratelimit-limit-requests", strconv.FormatInt(snapshot.RequestLimit, 10))
-		target.Set("x-ratelimit-remaining-requests", strconv.FormatInt(snapshot.RequestRemaining, 10))
-		target.Set("x-ratelimit-reset-requests", strconv.FormatInt(retryAfterSeconds(snapshot.RequestResetAfter), 10))
+		target.Set(rateLimitLimitRequestsHeader, strconv.FormatInt(snapshot.RequestLimit, 10))
+		target.Set(rateLimitRemainingRequestsHeader, strconv.FormatInt(snapshot.RequestRemaining, 10))
+		target.Set(rateLimitResetRequestsHeader, strconv.FormatInt(retryAfterSeconds(snapshot.RequestResetAfter), 10))
 	}
 	if snapshot.HasTokens {
-		target.Set("x-ratelimit-limit-tokens", strconv.FormatInt(snapshot.TokenLimit, 10))
-		target.Set("x-ratelimit-remaining-tokens", strconv.FormatInt(snapshot.TokenRemaining, 10))
-		target.Set("x-ratelimit-reset-tokens", strconv.FormatInt(retryAfterSeconds(snapshot.TokenResetAfter), 10))
+		target.Set(rateLimitLimitTokensHeader, strconv.FormatInt(snapshot.TokenLimit, 10))
+		target.Set(rateLimitRemainingTokensHeader, strconv.FormatInt(snapshot.TokenRemaining, 10))
+		target.Set(rateLimitResetTokensHeader, strconv.FormatInt(retryAfterSeconds(snapshot.TokenResetAfter), 10))
 	}
 }
 

--- a/internal/server/request_snapshot.go
+++ b/internal/server/request_snapshot.go
@@ -24,7 +24,7 @@ func RequestSnapshotCapture(userPathHeader ...string) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c *echo.Context) error {
 			req, requestID := ensureRequestID(c.Request())
-			c.Response().Header().Set("X-Request-ID", requestID)
+			c.Response().Header().Set(core.RequestIDHeader, requestID)
 			desc := core.DescribeEndpoint(req.Method, req.URL.Path)
 			if !desc.IngressManaged {
 				// Model endpoints that own their transport (MCP, realtime,
@@ -105,13 +105,13 @@ func ensureRequestID(req *http.Request) (*http.Request, string) {
 	}
 	requestID := strings.TrimSpace(core.GetRequestID(req.Context()))
 	if requestID == "" {
-		requestID = strings.TrimSpace(req.Header.Get("X-Request-ID"))
+		requestID = strings.TrimSpace(req.Header.Get(core.RequestIDHeader))
 	}
 	if requestID == "" {
 		requestID = uuid.NewString()
 	}
 
-	req.Header.Set("X-Request-ID", requestID)
+	req.Header.Set(core.RequestIDHeader, requestID)
 	if current := strings.TrimSpace(core.GetRequestID(req.Context())); current != requestID {
 		req = req.WithContext(core.WithRequestID(req.Context(), requestID))
 	}
@@ -172,9 +172,19 @@ func captureSmallRequestBodyForSnapshot(req *http.Request, bodyMode core.BodyMod
 	if bodyBytes == nil {
 		bodyBytes = []byte{}
 	}
-	req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	body := &bytesReadCloser{}
+	body.Reset(bodyBytes)
+	req.Body = body
 	return bodyBytes, false, true, nil
 }
+
+// bytesReadCloser is io.NopCloser(bytes.NewReader(b)) in one allocation
+// instead of two; it keeps bytes.Reader's WriteTo for efficient copies.
+type bytesReadCloser struct {
+	bytes.Reader
+}
+
+func (*bytesReadCloser) Close() error { return nil }
 
 func shouldCaptureSmallRequestBody(req *http.Request, bodyMode core.BodyMode) bool {
 	if req == nil || req.Body == nil {

--- a/internal/server/request_support.go
+++ b/internal/server/request_support.go
@@ -18,7 +18,7 @@ func requestIDFromContextOrHeader(req *http.Request) string {
 	if requestID != "" {
 		return requestID
 	}
-	return strings.TrimSpace(req.Header.Get("X-Request-ID"))
+	return strings.TrimSpace(req.Header.Get(core.RequestIDHeader))
 }
 
 func requestContextWithRequestID(req *http.Request) (context.Context, string) {
@@ -35,7 +35,7 @@ func requestContextWithRequestID(req *http.Request) (context.Context, string) {
 	if req.Header == nil {
 		req.Header = make(http.Header)
 	}
-	req.Header.Set("X-Request-ID", requestID)
+	req.Header.Set(core.RequestIDHeader, requestID)
 
 	ctx := req.Context()
 	if strings.TrimSpace(core.GetRequestID(ctx)) != requestID {

--- a/internal/session/canonical.go
+++ b/internal/session/canonical.go
@@ -1,0 +1,236 @@
+package session
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"slices"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/goccy/go-json"
+	"github.com/tidwall/gjson"
+)
+
+// canonicalSegment gives semantically equivalent JSON the same session
+// anchor. In particular, object-key order, insignificant whitespace, and
+// equivalent string escapes must not split one conversation into multiple
+// auto-detected sessions. Number spelling/precision is preserved while arrays
+// retain their original order.
+//
+// The output is byte-identical to Marshal of the segment decoded into `any`
+// with UseNumber (pinned by TestCanonicalSegmentMatchesStdlib and the
+// randomized TestCanonicalSegmentMatchesOracle), so auto-detected ids stay
+// stable across implementations. The common path walks the already
+// tokenized gjson tree and appends straight into one buffer instead of
+// decoding into maps and re-encoding; inputs the walker cannot reproduce
+// exactly fall back to that decode/encode path.
+func canonicalSegment(result gjson.Result) json.RawMessage {
+	if !result.Exists() || len(result.Raw) == 0 {
+		return nil
+	}
+	if gjson.Valid(result.Raw) {
+		buf := make([]byte, 0, len(result.Raw)+8)
+		if buf, ok := appendCanonical(buf, result); ok {
+			return buf
+		}
+	}
+	return canonicalSegmentDecoded(rawSegment(result))
+}
+
+// rawSegment clones a gjson result's raw JSON. gjson results alias the parsed
+// body, so the copy keeps the anchor independent of the request buffer.
+func rawSegment(result gjson.Result) json.RawMessage {
+	if !result.Exists() {
+		return nil
+	}
+	return json.RawMessage(strings.Clone(result.Raw))
+}
+
+// canonicalSegmentDecoded is the decode/encode reference path. The
+// trailing-data guard must decode to io.EOF rather than check Decoder.More:
+// More treats a stray closing bracket ("1]", "1}") as end of input, which
+// would canonicalize malformed raw segments instead of falling back to their
+// exact bytes.
+func canonicalSegmentDecoded(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return nil
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return raw
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return raw
+	}
+	canonical, err := json.Marshal(value)
+	if err != nil {
+		return raw
+	}
+	return canonical
+}
+
+// appendCanonical appends the canonical encoding of a valid gjson value. It
+// reports false when the value contains a string the walker cannot decode
+// exactly like encoding/json (see canonicalStringOK), in which case the
+// caller must use the reference path.
+func appendCanonical(buf []byte, r gjson.Result) ([]byte, bool) {
+	switch r.Type {
+	case gjson.Null:
+		return append(buf, "null"...), true
+	case gjson.False:
+		return append(buf, "false"...), true
+	case gjson.True:
+		return append(buf, "true"...), true
+	case gjson.Number:
+		return append(buf, strings.TrimSpace(r.Raw)...), true
+	case gjson.String:
+		if !canonicalStringOK(r) {
+			return buf, false
+		}
+		return appendJSONString(buf, r.Str), true
+	}
+	if r.IsArray() {
+		buf = append(buf, '[')
+		first := true
+		ok := true
+		r.ForEach(func(_, value gjson.Result) bool {
+			if !first {
+				buf = append(buf, ',')
+			}
+			first = false
+			buf, ok = appendCanonical(buf, value)
+			return ok
+		})
+		if !ok {
+			return buf, false
+		}
+		return append(buf, ']'), true
+	}
+	if r.IsObject() {
+		return appendCanonicalObject(buf, r)
+	}
+	return buf, false
+}
+
+type canonicalMember struct {
+	key   string
+	value gjson.Result
+}
+
+// appendCanonicalObject writes members sorted by decoded key, as encoding/json
+// does for maps. A duplicated key keeps its last value, matching map decoding.
+func appendCanonicalObject(buf []byte, r gjson.Result) ([]byte, bool) {
+	var members []canonicalMember
+	ok := true
+	r.ForEach(func(key, value gjson.Result) bool {
+		if !canonicalStringOK(key) {
+			ok = false
+			return false
+		}
+		members = append(members, canonicalMember{key: key.Str, value: value})
+		return true
+	})
+	if !ok {
+		return buf, false
+	}
+	slices.SortStableFunc(members, func(a, b canonicalMember) int {
+		return strings.Compare(a.key, b.key)
+	})
+	buf = append(buf, '{')
+	written := 0
+	for i, member := range members {
+		if i+1 < len(members) && members[i+1].key == member.key {
+			continue
+		}
+		if written > 0 {
+			buf = append(buf, ',')
+		}
+		written++
+		buf = appendJSONString(buf, member.key)
+		buf = append(buf, ':')
+		buf, ok = appendCanonical(buf, member.value)
+		if !ok {
+			return buf, false
+		}
+	}
+	return append(buf, '}'), true
+}
+
+// canonicalStringOK reports whether gjson's decoded form of a string token is
+// guaranteed to equal encoding/json's. The two diverge only on malformed
+// input: raw control characters (gjson tolerates them, encoding/json rejects
+// the document), invalid UTF-8 (encoding/json substitutes U+FFFD per byte)
+// and \u escapes in the surrogate range (unpaired or mismatched surrogates
+// are consumed differently). All are left to the reference decoder.
+func canonicalStringOK(r gjson.Result) bool {
+	if !utf8.ValidString(r.Str) {
+		return false
+	}
+	raw := r.Raw
+	for i := 0; i < len(raw); i++ {
+		if raw[i] < 0x20 {
+			return false
+		}
+	}
+	for {
+		i := strings.Index(raw, `\u`)
+		if i < 0 {
+			return true
+		}
+		raw = raw[i+2:]
+		if len(raw) >= 4 && (raw[0] == 'd' || raw[0] == 'D') && raw[1] >= '8' {
+			return false
+		}
+	}
+}
+
+const hexDigits = "0123456789abcdef"
+
+// appendJSONString appends s as a JSON string exactly as goccy's Marshal does
+// with HTML escaping on: \n, \r and \t use their short escapes, other control
+// characters (including \b and \f, unlike encoding/json), '<', '>', '&' and
+// U+2028/U+2029 are \u-escaped, and everything else is written verbatim.
+func appendJSONString(buf []byte, s string) []byte {
+	buf = append(buf, '"')
+	start := 0
+	for i := 0; i < len(s); {
+		c := s[i]
+		if c < utf8.RuneSelf {
+			if c >= 0x20 && c != '"' && c != '\\' && c != '<' && c != '>' && c != '&' {
+				i++
+				continue
+			}
+			buf = append(buf, s[start:i]...)
+			switch c {
+			case '\\', '"':
+				buf = append(buf, '\\', c)
+			case '\n':
+				buf = append(buf, '\\', 'n')
+			case '\r':
+				buf = append(buf, '\\', 'r')
+			case '\t':
+				buf = append(buf, '\\', 't')
+			default:
+				buf = append(buf, '\\', 'u', '0', '0', hexDigits[c>>4], hexDigits[c&0xF])
+			}
+			i++
+			start = i
+			continue
+		}
+		rn, size := utf8.DecodeRuneInString(s[i:])
+		if rn == '\u2028' || rn == '\u2029' {
+			buf = append(buf, s[start:i]...)
+			buf = append(buf, '\\', 'u', '2', '0', '2', hexDigits[rn&0xF])
+			i += size
+			start = i
+			continue
+		}
+		i += size
+	}
+	buf = append(buf, s[start:]...)
+	return append(buf, '"')
+}

--- a/internal/session/canonical_oracle_test.go
+++ b/internal/session/canonical_oracle_test.go
@@ -1,0 +1,130 @@
+package session
+
+import (
+	"bytes"
+	"math/rand"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-json"
+	"github.com/tidwall/gjson"
+)
+
+// TestCanonicalSegmentMatchesOracle drives the tree-walking canonicalizer
+// with generated documents (nested objects, duplicate keys, every escape
+// class, awkward numbers, malformed input) and pins it byte-for-byte to the
+// decode/re-encode path it replaced, so auto-detected session ids do not
+// change with the implementation.
+func TestCanonicalSegmentMatchesOracle(t *testing.T) {
+	fixed := []string{
+		`"\b\f\n\r\t"`,
+		"\"<b>&amp;</b>     <\"",
+		`"  escaped separator"`,
+		`"😀 paired surrogate"`,
+		`"\ud800 lone surrogate"`,
+		`"\ud800A mismatched surrogate"`,
+		`"😀 upper hex"`,
+		`"\/ solidus \" quote \\ backslash"`,
+		"\"invalid \xff utf8\"",
+		`{"a":1,"a":2,"b":3}`,
+		`{"a":1,"a":2}`,
+		`{"b":{"z":1,"a":[]},"a":{}}`,
+		`{"":"empty key","x":""}`,
+		`[[[]],[{}],[null,true,false]]`,
+		`-0`,
+		`0.000`,
+		`1E+2`,
+		`-1.5e-7`,
+		` 42 `,
+		`{"k" : "v" , "n" : [ 1 , 2 ] }`,
+		`{"é":"ü","😀":"x"}`,
+		`{"a":1}{"b":2}`,
+		`1]`,
+		`{"unterminated":`,
+	}
+	for _, raw := range fixed {
+		assertCanonicalMatchesOracle(t, raw)
+	}
+
+	rng := rand.New(rand.NewSource(1))
+	for range 2000 {
+		assertCanonicalMatchesOracle(t, randomJSON(rng, 0))
+	}
+}
+
+func assertCanonicalMatchesOracle(t *testing.T, raw string) {
+	t.Helper()
+	result := gjson.Parse(raw)
+	if !result.Exists() {
+		result = gjson.Result{Type: gjson.JSON, Raw: raw}
+	}
+	got := canonicalSegment(result)
+	want := canonicalSegmentDecoded(json.RawMessage(strings.Clone(result.Raw)))
+	if !bytes.Equal(got, want) {
+		t.Errorf("canonicalSegment(%q) = %q, oracle = %q", raw, got, want)
+	}
+}
+
+var randomStringPieces = []string{
+	"a", "Z", " ", "é", "😀", `\n`, `\t`, `\"`, `\\`, `\/`, `A`, `é`,
+	`😀`, ` `, "<", ">", "&", `<`, " ", "\x01",
+}
+
+func randomJSON(rng *rand.Rand, depth int) string {
+	kind := rng.Intn(7)
+	if depth > 3 {
+		kind = rng.Intn(4)
+	}
+	switch kind {
+	case 0:
+		return []string{"null", "true", "false"}[rng.Intn(3)]
+	case 1:
+		return randomNumber(rng)
+	case 2, 3:
+		return randomString(rng)
+	case 4, 5:
+		n := rng.Intn(4)
+		parts := make([]string, n)
+		for i := range parts {
+			parts[i] = randomJSON(rng, depth+1)
+		}
+		return "[" + strings.Join(parts, randomSpace(rng)+","+randomSpace(rng)) + "]"
+	default:
+		n := rng.Intn(4)
+		parts := make([]string, n)
+		keys := []string{`"a"`, `"b"`, `"a"`, `"b"`, `""`, `"z z"`}
+		for i := range parts {
+			parts[i] = keys[rng.Intn(len(keys))] + randomSpace(rng) + ":" + randomSpace(rng) + randomJSON(rng, depth+1)
+		}
+		return "{" + randomSpace(rng) + strings.Join(parts, ",") + randomSpace(rng) + "}"
+	}
+}
+
+func randomNumber(rng *rand.Rand) string {
+	switch rng.Intn(4) {
+	case 0:
+		return strconv.Itoa(rng.Intn(2000) - 1000)
+	case 1:
+		return strconv.FormatFloat(rng.NormFloat64()*1e6, 'g', -1, 64)
+	case 2:
+		return []string{"0", "-0", "1.0", "1e5", "1E-5", "12345678901234567890", "0.1000"}[rng.Intn(7)]
+	default:
+		return strconv.FormatFloat(rng.Float64(), 'e', rng.Intn(10), 64)
+	}
+}
+
+func randomString(rng *rand.Rand) string {
+	n := rng.Intn(6)
+	var b strings.Builder
+	b.WriteByte('"')
+	for range n {
+		b.WriteString(randomStringPieces[rng.Intn(len(randomStringPieces))])
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+func randomSpace(rng *rand.Rand) string {
+	return []string{"", " ", "\n\t"}[rng.Intn(3)]
+}

--- a/internal/session/detect.go
+++ b/internal/session/detect.go
@@ -1,11 +1,8 @@
 package session
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
-	"io"
 	"strings"
 
 	"github.com/goccy/go-json"
@@ -159,7 +156,11 @@ func contentSessionID(snapshot *core.RequestSnapshot, body []byte, userPath stri
 		return ""
 	}
 	sum := sha256.Sum256(payload)
-	return "auto-" + hex.EncodeToString(sum[:16])
+	const prefix = "auto-"
+	var id [len(prefix) + 32]byte
+	copy(id[:], prefix)
+	hex.Encode(id[len(prefix):], sum[:16])
+	return string(id[:])
 }
 
 // maxOpeningMessages bounds the anchor when a conversation opens with an
@@ -180,48 +181,4 @@ func openingMessages(messages gjson.Result) []json.RawMessage {
 		return true
 	})
 	return opening
-}
-
-// rawSegment clones a gjson result's raw JSON. gjson results alias the parsed
-// body, so the copy keeps the anchor independent of the request buffer.
-func rawSegment(result gjson.Result) json.RawMessage {
-	if !result.Exists() {
-		return nil
-	}
-	return json.RawMessage(strings.Clone(result.Raw))
-}
-
-// canonicalSegment gives semantically equivalent JSON the same session
-// anchor. In particular, object-key order, insignificant whitespace, and
-// equivalent string escapes must not split one conversation into multiple
-// auto-detected sessions. UseNumber preserves number spelling/precision while
-// arrays retain their original order.
-//
-// The goccy canonical bytes are byte-identical to encoding/json's (pinned by
-// TestCanonicalSegmentMatchesStdlib), so auto-detected ids are stable across
-// the library switch. The trailing-data guard must decode to io.EOF rather
-// than check Decoder.More: More treats a stray closing bracket ("1]", "1}")
-// as end of input, which would canonicalize malformed raw segments instead of
-// falling back to their exact bytes. For valid input the extra decode reads
-// only the empty remainder, so it costs nothing on the hot path.
-func canonicalSegment(result gjson.Result) json.RawMessage {
-	raw := rawSegment(result)
-	if len(raw) == 0 {
-		return nil
-	}
-	decoder := json.NewDecoder(bytes.NewReader(raw))
-	decoder.UseNumber()
-	var value any
-	if err := decoder.Decode(&value); err != nil {
-		return raw
-	}
-	var trailing any
-	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
-		return raw
-	}
-	canonical, err := json.Marshal(value)
-	if err != nil {
-		return raw
-	}
-	return canonical
 }

--- a/tests/perf/hotpath_test.go
+++ b/tests/perf/hotpath_test.go
@@ -389,8 +389,8 @@ func TestHotPathPerfGuard(t *testing.T) {
 		{
 			name:      "gateway_chat_completion_hot_path",
 			bench:     BenchmarkGatewayHotPathChatCompletion,
-			maxAllocs: 108,   // baseline 106 (goccy response serializer + single ensureRequestID)
-			maxBytes:  14080, // baseline ~13.5 KB (incl. per-attempt response body/header capture fields)
+			maxAllocs: 88,    // baseline 85 (single-alloc body reader, lazy unknown-field buffer, no context re-wraps)
+			maxBytes:  13440, // baseline ~12.9 KB (incl. per-attempt response body/header capture fields)
 		},
 		{
 			// Production-shaped path: request resolves through a real Router +
@@ -400,8 +400,8 @@ func TestHotPathPerfGuard(t *testing.T) {
 			// full catalog several times per request) would blow these limits.
 			name:      "gateway_chat_completion_hot_path_routed",
 			bench:     BenchmarkGatewayHotPathChatCompletionRouted,
-			maxAllocs: 128,   // baseline 126 (goccy response serializer + single ensureRequestID)
-			maxBytes:  14656, // baseline ~14.0 KB
+			maxAllocs: 102,   // baseline 99 (see the bare case; plus strings.Cut selector parsing)
+			maxBytes:  13888, // baseline ~13.3 KB
 		},
 		{
 			// Default-deployment shape: auth + audit (bodies/headers) + usage +
@@ -411,8 +411,8 @@ func TestHotPathPerfGuard(t *testing.T) {
 			// deployments actually run.
 			name:      "gateway_chat_completion_production_shape",
 			bench:     BenchmarkGatewayHotPathProductionShape,
-			maxAllocs: 306,   // baseline 300
-			maxBytes:  26496, // baseline ~25.1 KB
+			maxAllocs: 234,   // baseline 228 (tree-walking session canonicalizer, single-pass header redaction, canonical header keys)
+			maxBytes:  23040, // baseline ~22.3 KB
 		},
 		{
 			// Typed chunk decoding + reused read buffer keep this converter at a


### PR DESCRIPTION
Reduces allocations on the chat-completion hot path without changing public behavior. Measured with the existing \`tests/perf\` harness:

| Benchmark | Before | After |
|---|---|---|
| Production shape (auth + audit + usage + session + rate limit) | 301 allocs · 25.6 KB · 15.5 µs | 228 allocs · 22.3 KB · 14.3 µs |
| Bare chat completion | 105 allocs · 13.8 KB | 85 allocs · 12.9 KB |
| Routed chat completion | 125 allocs · 14.4 KB | 99 allocs · 13.3 KB |

Changes:
- Session auto-detect canonicalizes JSON segments by walking the parsed gjson tree into one buffer instead of decoding to \`map[string]any\` and re-marshaling. Output is pinned byte-for-byte to the previous path by a randomized oracle test, so auto session ids are unchanged; unsupported inputs fall back to the old path.
- Audit header capture redacts in a single pass; \`IsCredentialHeader\` folds case in a stack buffer.
- Header keys used on every request (\`X-Request-Id\`, \`X-Ratelimit-*\`, \`X-Gomodel-Auth-User\`) are spelled in canonical form so \`Header.Get/Set\` skip per-call canonicalization. Wire format is unchanged.
- Request logger uses typed \`slog.LogAttrs\`; \`core.WithWorkflow\` is idempotent so the request context is wrapped once.
- Smaller cleanups: \`strings.Cut\` over \`Split\`, single backing array in header clone, lazy unknown-field buffer, single-alloc body reader, \`gjson.GetBytes\` instead of a full-body copy for selector peeking.
- Perf-guard ceilings tightened to the new baselines.

User-visible impact: none intended; lower memory and GC pressure per request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request ID handling across requests, logs, caching, and passthrough operations.
  * Standardized authentication and rate-limit response header names.
  * Improved recognition of audio and event-stream content types despite casing or formatting differences.
  * Enhanced protection of sensitive header and URL information in audit data.
  * Improved consistency when processing JSON session data.

* **Performance**
  * Reduced overhead in request snapshots, JSON inspection, session handling, and frequently used request paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->