### PR TITLE
perf(auditlog): store captured bodies as raw JSON instead of decoded maps

### DIFF
--- a/internal/admin/audit_projection.go
+++ b/internal/admin/audit_projection.go
@@ -82,7 +82,7 @@ func slimAuditListEntry(resp *auditLogEntryResponse) {
 // /v1/messages or provider passthrough): a request shaped like a conversation
 // or a response shaped like model output.
 func hasConversationPayload(requestBody, responseBody any) bool {
-	if req, ok := requestBody.(map[string]any); ok {
+	if req, ok := auditlog.BodyDocument(requestBody).(map[string]any); ok {
 		if _, ok := req["messages"].([]any); ok {
 			return true
 		}
@@ -96,7 +96,7 @@ func hasConversationPayload(requestBody, responseBody any) bool {
 			return true
 		}
 	}
-	if resp, ok := responseBody.(map[string]any); ok {
+	if resp, ok := auditlog.BodyDocument(responseBody).(map[string]any); ok {
 		if _, ok := resp["choices"].([]any); ok {
 			return true
 		}

--- a/internal/auditlog/attempt_capture_test.go
+++ b/internal/auditlog/attempt_capture_test.go
@@ -1,6 +1,8 @@
 package auditlog
 
 import (
+	"github.com/goccy/go-json"
+
 	"net/http"
 	"testing"
 )
@@ -10,9 +12,12 @@ func TestCaptureAttemptResponseBody(t *testing.T) {
 		t.Fatalf("empty body = %#v, want nil", got)
 	}
 
-	parsed, ok := CaptureAttemptResponseBody([]byte(`{"error":{"code":"model_not_found"}}`)).(map[string]any)
-	if !ok {
-		t.Fatalf("json body did not parse to a map: %#v", parsed)
+	captured := CaptureAttemptResponseBody([]byte(`{"error":{"code":"model_not_found"}}`))
+	if _, ok := captured.(json.RawMessage); !ok {
+		t.Fatalf("json body = %T, want json.RawMessage", captured)
+	}
+	if _, ok := BodyDocument(captured).(map[string]any); !ok {
+		t.Fatalf("json body did not decode to a map: %#v", BodyDocument(captured))
 	}
 
 	if got := CaptureAttemptResponseBody([]byte("upstream is down")); got != "upstream is down" {

--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -169,9 +169,10 @@ type LogData struct {
 	RequestHeaders  map[string]string `json:"request_headers,omitempty" bson:"request_headers,omitempty"`
 	ResponseHeaders map[string]string `json:"response_headers,omitempty" bson:"response_headers,omitempty"`
 
-	// Optional bodies (when LOGGING_LOG_BODIES=true)
-	// Stored as interface{} so MongoDB serializes as native BSON documents (queryable/readable)
-	// instead of BSON Binary (base64 in Compass)
+	// Optional bodies (when LOGGING_LOG_BODIES=true). Captured JSON is kept
+	// as json.RawMessage; other captures (string fallbacks, audio/image logs,
+	// stream-built responses) keep their own types. The MongoDB writer decodes
+	// raw JSON into documents so they stay queryable — see body.go.
 	RequestBody  any `json:"request_body,omitempty" bson:"request_body,omitempty"`
 	ResponseBody any `json:"response_body,omitempty" bson:"response_body,omitempty"`
 
@@ -212,9 +213,9 @@ type RequestRevisionSnapshot struct {
 	// not report savings.
 	TokensSaved int `json:"tokens_saved,omitempty" bson:"tokens_saved,omitempty"`
 
-	// Body is the request body after this revision (parsed JSON, or a string
-	// when not valid JSON). Populated only when body logging is enabled and
-	// the body is within the capture limit.
+	// Body is the request body after this revision (the raw JSON, or a string
+	// when not valid JSON — see body.go). Populated only when body logging is
+	// enabled and the body is within the capture limit.
 	Body any `json:"body,omitempty" bson:"body,omitempty"`
 
 	// Detail is an optional rewriter-provided structured summary of what

--- a/internal/auditlog/auditlog_test.go
+++ b/internal/auditlog/auditlog_test.go
@@ -487,9 +487,9 @@ func TestMiddleware_UsesIngressFrameRequestBodyWithoutReadingStream(t *testing.T
 		t.Fatalf("len(entries) = %d, want 1", len(logger.entries))
 	}
 
-	requestBody, ok := logger.entries[0].Data.RequestBody.(map[string]any)
+	requestBody, ok := BodyDocument(logger.entries[0].Data.RequestBody).(map[string]any)
 	if !ok {
-		t.Fatalf("RequestBody = %T, want map[string]any", logger.entries[0].Data.RequestBody)
+		t.Fatalf("RequestBody = %T, want JSON object", logger.entries[0].Data.RequestBody)
 	}
 	if requestBody["model"] != "from-ingress" {
 		t.Fatalf("RequestBody.model = %#v, want from-ingress", requestBody["model"])

--- a/internal/auditlog/body.go
+++ b/internal/auditlog/body.go
@@ -1,0 +1,85 @@
+package auditlog
+
+import (
+	"bytes"
+	encjson "encoding/json"
+
+	"github.com/goccy/go-json"
+)
+
+// Captured request and response bodies are stored verbatim.
+//
+// A JSON body is kept as the client's own bytes (json.RawMessage) rather than
+// decoded into maps on the request path: decoding is by far the most
+// expensive step of audit capture, and every JSON consumer — the SQL stores,
+// the live dashboard feed, the admin API — only re-encodes the value anyway.
+// Raw bytes also preserve what the maps lost: large-integer precision, key
+// order, and the exact spelling of numbers.
+//
+// Only MongoDB needs a structured document (it indexes fields inside the
+// body); its writer converts with BodyDocument, off the request path.
+
+// captureLoggedBody converts raw body bytes into the representation audit
+// entries store: the JSON itself when the body is valid JSON, otherwise a
+// valid-UTF-8 string. The bytes are copied because the entry outlives the
+// request buffers it was captured from.
+func captureLoggedBody(bodyBytes []byte) any {
+	bodyBytes = bytes.TrimSpace(bodyBytes)
+	if len(bodyBytes) == 0 {
+		return nil
+	}
+	// encoding/json's validator is a strict, allocation-free scan; goccy's
+	// Valid decodes the document to check it, which is the cost this type
+	// exists to avoid. Strict validation also guarantees every store's
+	// encoder accepts the bytes later.
+	if encjson.Valid(bodyBytes) {
+		return json.RawMessage(bytes.Clone(bodyBytes))
+	}
+	return toValidUTF8String(bodyBytes)
+}
+
+// CaptureLoggedBody is captureLoggedBody for handlers outside this package
+// that capture their own bodies.
+func CaptureLoggedBody(bodyBytes []byte) any {
+	return captureLoggedBody(bodyBytes)
+}
+
+// BodyDocument returns the structured form of a captured body: a JSON body
+// is decoded into maps, slices and scalars; every other value (a decoded
+// document read back from a store, an audio/image capture struct, a string
+// fallback) is returned unchanged. Undecodable JSON, which capture never
+// produces, is returned as-is so nothing is silently dropped.
+func BodyDocument(body any) any {
+	raw, ok := body.(json.RawMessage)
+	if !ok {
+		return body
+	}
+	var document any
+	if err := json.Unmarshal(raw, &document); err != nil {
+		return body
+	}
+	return document
+}
+
+// withBodyDocuments returns a copy of the entry whose captured JSON bodies
+// (request, response, and per-attempt responses) are decoded documents, for
+// stores that need structure. The receiver is left untouched.
+func (e *LogEntry) withBodyDocuments() *LogEntry {
+	if e == nil || e.Data == nil {
+		return e
+	}
+	entry := *e
+	data := *e.Data
+	data.RequestBody = BodyDocument(data.RequestBody)
+	data.ResponseBody = BodyDocument(data.ResponseBody)
+	if len(data.Attempts) > 0 {
+		attempts := make([]AttemptSnapshot, len(data.Attempts))
+		for i, attempt := range data.Attempts {
+			attempt.ResponseBody = BodyDocument(attempt.ResponseBody)
+			attempts[i] = attempt
+		}
+		data.Attempts = attempts
+	}
+	entry.Data = &data
+	return &entry
+}

--- a/internal/auditlog/body.go
+++ b/internal/auditlog/body.go
@@ -62,8 +62,9 @@ func BodyDocument(body any) any {
 }
 
 // withBodyDocuments returns a copy of the entry whose captured JSON bodies
-// (request, response, and per-attempt responses) are decoded documents, for
-// stores that need structure. The receiver is left untouched.
+// (request, response, per-attempt responses, and per-revision bodies) are
+// decoded documents, for stores that need structure. The receiver is left
+// untouched.
 func (e *LogEntry) withBodyDocuments() *LogEntry {
 	if e == nil || e.Data == nil {
 		return e
@@ -79,6 +80,14 @@ func (e *LogEntry) withBodyDocuments() *LogEntry {
 			attempts[i] = attempt
 		}
 		data.Attempts = attempts
+	}
+	if len(data.RequestRevisions) > 0 {
+		revisions := make([]RequestRevisionSnapshot, len(data.RequestRevisions))
+		for i, revision := range data.RequestRevisions {
+			revision.Body = BodyDocument(revision.Body)
+			revisions[i] = revision
+		}
+		data.RequestRevisions = revisions
 	}
 	entry.Data = &data
 	return &entry

--- a/internal/auditlog/body.go
+++ b/internal/auditlog/body.go
@@ -3,6 +3,7 @@ package auditlog
 import (
 	"bytes"
 	encjson "encoding/json"
+	"unicode/utf8"
 
 	"github.com/goccy/go-json"
 )
@@ -30,9 +31,10 @@ func captureLoggedBody(bodyBytes []byte) any {
 	}
 	// encoding/json's validator is a strict, allocation-free scan; goccy's
 	// Valid decodes the document to check it, which is the cost this type
-	// exists to avoid. Strict validation also guarantees every store's
-	// encoder accepts the bytes later.
-	if encjson.Valid(bodyBytes) {
+	// exists to avoid. It does not check UTF-8 inside strings, so that is
+	// checked separately: stores reject invalid UTF-8 (BSON, Postgres jsonb),
+	// and such bodies take the coerced-string fallback exactly as before.
+	if utf8.Valid(bodyBytes) && encjson.Valid(bodyBytes) {
 		return json.RawMessage(bytes.Clone(bodyBytes))
 	}
 	return toValidUTF8String(bodyBytes)

--- a/internal/auditlog/body_test.go
+++ b/internal/auditlog/body_test.go
@@ -80,10 +80,21 @@ func TestWithBodyDocumentsDecodesForDocumentStores(t *testing.T) {
 				{Seq: 1, ResponseBody: json.RawMessage(`{"error":{"code":"overloaded"}}`)},
 				{Seq: 2, ResponseBody: "plain text"},
 			},
+			RequestRevisions: []RequestRevisionSnapshot{
+				{Seq: 1, Rewriter: "compress", Body: json.RawMessage(`{"messages":[]}`)},
+			},
 		},
 	}
 
 	doc := entry.withBodyDocuments()
+
+	revision, ok := doc.Data.RequestRevisions[0].Body.(map[string]any)
+	if !ok || revision["messages"] == nil {
+		t.Fatalf("revision body = %#v, want decoded document", doc.Data.RequestRevisions[0].Body)
+	}
+	if _, ok := entry.Data.RequestRevisions[0].Body.(json.RawMessage); !ok {
+		t.Fatalf("receiver revision body mutated to %T", entry.Data.RequestRevisions[0].Body)
+	}
 
 	req, ok := doc.Data.RequestBody.(map[string]any)
 	if !ok || req["previous_response_id"] != "resp_0" {

--- a/internal/auditlog/body_test.go
+++ b/internal/auditlog/body_test.go
@@ -43,6 +43,10 @@ func TestCaptureLoggedBody(t *testing.T) {
 		if got := captureLoggedBody([]byte("bad \xff utf8")); got != "bad � utf8" {
 			t.Fatalf("invalid utf-8 = %#v", got)
 		}
+		// encoding/json.Valid accepts invalid UTF-8 inside strings; stores do not.
+		if got := captureLoggedBody([]byte("{\"text\":\"\xff\"}")); got != "{\"text\":\"�\"}" {
+			t.Fatalf("json with invalid utf-8 = %#v, want coerced string", got)
+		}
 	})
 
 	t.Run("empty is nil", func(t *testing.T) {

--- a/internal/auditlog/body_test.go
+++ b/internal/auditlog/body_test.go
@@ -1,0 +1,153 @@
+package auditlog
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/goccy/go-json"
+)
+
+func TestCaptureLoggedBody(t *testing.T) {
+	t.Run("json is kept verbatim as raw bytes", func(t *testing.T) {
+		src := []byte(` {"b": 1, "a": [1, 2], "big": 9007199254740993} `)
+		got, ok := captureLoggedBody(src).(json.RawMessage)
+		if !ok {
+			t.Fatalf("captured = %T, want json.RawMessage", captureLoggedBody(src))
+		}
+		if want := bytes.TrimSpace(src); !bytes.Equal(got, want) {
+			t.Fatalf("captured = %s, want %s", got, want)
+		}
+		// The entry outlives the request buffer, so the capture must own its bytes.
+		src[3] = 'x'
+		if bytes.Contains(got, []byte("x")) {
+			t.Fatal("captured body aliases the request buffer")
+		}
+	})
+
+	t.Run("scalars and arrays are json too", func(t *testing.T) {
+		for _, raw := range []string{`"text"`, `42`, `null`, `[1,2]`} {
+			if _, ok := captureLoggedBody([]byte(raw)).(json.RawMessage); !ok {
+				t.Errorf("%s: captured as %T, want json.RawMessage", raw, captureLoggedBody([]byte(raw)))
+			}
+		}
+	})
+
+	t.Run("invalid json falls back to a valid utf-8 string", func(t *testing.T) {
+		if got := captureLoggedBody([]byte("upstream is down")); got != "upstream is down" {
+			t.Fatalf("plain text = %#v", got)
+		}
+		if got := captureLoggedBody([]byte("{\"a\":\"x\x01y\"}")); got != "{\"a\":\"x\x01y\"}" {
+			t.Fatalf("control character body = %#v, want string fallback", got)
+		}
+		if got := captureLoggedBody([]byte("bad \xff utf8")); got != "bad � utf8" {
+			t.Fatalf("invalid utf-8 = %#v", got)
+		}
+	})
+
+	t.Run("empty is nil", func(t *testing.T) {
+		if got := captureLoggedBody(nil); got != nil {
+			t.Fatalf("nil body = %#v", got)
+		}
+		if got := captureLoggedBody([]byte("  \n")); got != nil {
+			t.Fatalf("whitespace body = %#v", got)
+		}
+	})
+}
+
+func TestBodyDocument(t *testing.T) {
+	doc, ok := BodyDocument(json.RawMessage(`{"id":"resp_1","n":[1,2]}`)).(map[string]any)
+	if !ok || doc["id"] != "resp_1" {
+		t.Fatalf("raw json decoded to %#v", BodyDocument(json.RawMessage(`{"id":"resp_1","n":[1,2]}`)))
+	}
+	for _, passthrough := range []any{nil, "text", map[string]any{"already": "decoded"}, AudioBodyLog{ContentType: "audio/mpeg"}} {
+		if got := BodyDocument(passthrough); !reflect.DeepEqual(got, passthrough) {
+			t.Errorf("BodyDocument(%#v) = %#v, want unchanged", passthrough, got)
+		}
+	}
+	if got := BodyDocument(json.RawMessage(`{bad`)); string(got.(json.RawMessage)) != `{bad` {
+		t.Fatalf("undecodable raw = %#v, want unchanged", got)
+	}
+}
+
+func TestWithBodyDocumentsDecodesForDocumentStores(t *testing.T) {
+	entry := &LogEntry{
+		ID: "audit-1",
+		Data: &LogData{
+			RequestBody:  json.RawMessage(`{"previous_response_id":"resp_0"}`),
+			ResponseBody: json.RawMessage(`{"id":"resp_1"}`),
+			Attempts: []AttemptSnapshot{
+				{Seq: 1, ResponseBody: json.RawMessage(`{"error":{"code":"overloaded"}}`)},
+				{Seq: 2, ResponseBody: "plain text"},
+			},
+		},
+	}
+
+	doc := entry.withBodyDocuments()
+
+	req, ok := doc.Data.RequestBody.(map[string]any)
+	if !ok || req["previous_response_id"] != "resp_0" {
+		t.Fatalf("request body = %#v, want decoded document", doc.Data.RequestBody)
+	}
+	resp, ok := doc.Data.ResponseBody.(map[string]any)
+	if !ok || resp["id"] != "resp_1" {
+		t.Fatalf("response body = %#v, want decoded document", doc.Data.ResponseBody)
+	}
+	attempt, ok := doc.Data.Attempts[0].ResponseBody.(map[string]any)
+	if !ok || attempt["error"] == nil {
+		t.Fatalf("attempt body = %#v, want decoded document", doc.Data.Attempts[0].ResponseBody)
+	}
+	if doc.Data.Attempts[1].ResponseBody != "plain text" {
+		t.Fatalf("non-json attempt body = %#v, want unchanged", doc.Data.Attempts[1].ResponseBody)
+	}
+
+	// The original entry is what other stores and the live feed still hold.
+	if _, ok := entry.Data.RequestBody.(json.RawMessage); !ok {
+		t.Fatalf("receiver request body mutated to %T", entry.Data.RequestBody)
+	}
+	if _, ok := entry.Data.Attempts[0].ResponseBody.(json.RawMessage); !ok {
+		t.Fatalf("receiver attempt body mutated to %T", entry.Data.Attempts[0].ResponseBody)
+	}
+
+	if (*LogEntry)(nil).withBodyDocuments() != nil {
+		t.Fatal("nil entry must stay nil")
+	}
+	if got := (&LogEntry{ID: "no-data"}).withBodyDocuments(); got.Data != nil {
+		t.Fatal("entry without data must keep nil data")
+	}
+}
+
+func TestExtractStringFieldReadsRawBodies(t *testing.T) {
+	entry := &LogEntry{Data: &LogData{
+		RequestBody:  json.RawMessage(`{"previous_response_id":" resp_0 "}`),
+		ResponseBody: json.RawMessage(`{"id":"resp_1"}`),
+	}}
+	if got := extractPreviousResponseID(entry); got != "resp_0" {
+		t.Fatalf("previous response id = %q, want resp_0", got)
+	}
+	if got := extractResponseID(entry); got != "resp_1" {
+		t.Fatalf("response id = %q, want resp_1", got)
+	}
+}
+
+func TestMarshalLogDataEmbedsRawBodiesAsJSON(t *testing.T) {
+	data := &LogData{
+		RequestBody:  json.RawMessage(`{ "model" : "gpt-4o", "big": 9007199254740993 }`),
+		ResponseBody: "not json",
+	}
+	out := marshalLogData(data, "audit-1")
+
+	var decoded struct {
+		RequestBody  map[string]any `json:"request_body"`
+		ResponseBody string         `json:"response_body"`
+	}
+	if err := json.Unmarshal(out, &decoded); err != nil {
+		t.Fatalf("stored data is not JSON: %v\n%s", err, out)
+	}
+	if decoded.RequestBody["model"] != "gpt-4o" || decoded.ResponseBody != "not json" {
+		t.Fatalf("stored data = %s", out)
+	}
+	if !bytes.Contains(out, []byte(`9007199254740993`)) {
+		t.Fatalf("large integer lost precision: %s", out)
+	}
+}

--- a/internal/auditlog/conversation_helpers.go
+++ b/internal/auditlog/conversation_helpers.go
@@ -255,7 +255,7 @@ func extractPreviousResponseID(entry *LogEntry) string {
 }
 
 func extractStringField(v any, key string) string {
-	switch obj := v.(type) {
+	switch obj := BodyDocument(v).(type) {
 	case map[string]any:
 		return extractTrimmedString(obj[key])
 	case bson.M:

--- a/internal/auditlog/entry_capture_test.go
+++ b/internal/auditlog/entry_capture_test.go
@@ -114,7 +114,7 @@ func TestCaptureInternalJSONExchange_PreservesHeadersWhenBodyMarshalFails(t *tes
 		if got := entry.Data.ResponseHeaders[http.CanonicalHeaderKey(core.UserPathHeader)]; got != "/team/beta" {
 			t.Fatalf("ResponseHeaders[%s] = %q, want /team/beta", core.UserPathHeader, got)
 		}
-		body, ok := entry.Data.ResponseBody.(map[string]any)
+		body, ok := BodyDocument(entry.Data.ResponseBody).(map[string]any)
 		if !ok {
 			t.Fatalf("ResponseBody = %T, want synthesized error envelope", entry.Data.ResponseBody)
 		}
@@ -149,7 +149,7 @@ func TestCaptureInternalJSONExchange_PreservesHeadersWhenBodyMarshalFails(t *tes
 			LogBodies:  true,
 		})
 
-		body, ok := entry.Data.ResponseBody.(map[string]any)
+		body, ok := BodyDocument(entry.Data.ResponseBody).(map[string]any)
 		if !ok {
 			t.Fatalf("ResponseBody = %T, want synthesized error envelope", entry.Data.ResponseBody)
 		}

--- a/internal/auditlog/middleware.go
+++ b/internal/auditlog/middleware.go
@@ -15,8 +15,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/goccy/go-json"
-
 	"github.com/andybalholm/brotli"
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
@@ -172,14 +170,7 @@ func Middleware(logger LoggerInterface) echo.MiddlewareFunc {
 						}
 					}
 
-					// Parse JSON to any for native BSON storage in MongoDB
-					var parsed any
-					if jsonErr := json.Unmarshal(bodyBytes, &parsed); jsonErr == nil {
-						entry.Data.ResponseBody = parsed
-					} else {
-						// Fallback: store as valid UTF-8 string if not valid JSON
-						entry.Data.ResponseBody = toValidUTF8String(bodyBytes)
-					}
+					captureLoggedResponseBody(entry, bodyBytes)
 				}
 			}
 
@@ -241,21 +232,6 @@ func captureLoggedRequestBody(entry *LogEntry, bodyBytes []byte) {
 
 func captureLoggedResponseBody(entry *LogEntry, bodyBytes []byte) {
 	entry.Data.ResponseBody = captureLoggedBody(bodyBytes)
-}
-
-func captureLoggedBody(bodyBytes []byte) any {
-	if len(bodyBytes) == 0 {
-		return nil
-	}
-
-	// Parse JSON to any for native BSON storage in MongoDB
-	var parsed any
-	if jsonErr := json.Unmarshal(bodyBytes, &parsed); jsonErr == nil {
-		return parsed
-	}
-
-	// Fallback: store as valid UTF-8 string if not valid JSON
-	return toValidUTF8String(bodyBytes)
 }
 
 // responseBodyCapture wraps http.ResponseWriter to capture the response body.
@@ -363,12 +339,6 @@ func hashAPIKey(authHeader string) string {
 
 	hash := sha256.Sum256([]byte(token))
 	return hex.EncodeToString(hash[:APIKeyHashPrefixLength/2])
-}
-
-// CaptureLoggedBody converts raw body bytes into the representation audit
-// entries store: parsed JSON when possible, otherwise a valid-UTF-8 string.
-func CaptureLoggedBody(bodyBytes []byte) any {
-	return captureLoggedBody(bodyBytes)
 }
 
 func auditEnabledForContext(ctx context.Context) bool {

--- a/internal/auditlog/middleware_test.go
+++ b/internal/auditlog/middleware_test.go
@@ -257,9 +257,9 @@ func TestMiddlewarePublishesWorkflowUpdateWithCapturedRequestBody(t *testing.T) 
 	if updated.eventType != LiveEventAuditUpdated {
 		t.Fatalf("second event type = %q, want %q", updated.eventType, LiveEventAuditUpdated)
 	}
-	body, ok := updated.requestBody.(map[string]any)
+	body, ok := BodyDocument(updated.requestBody).(map[string]any)
 	if !ok {
-		t.Fatalf("request body = %T, want map[string]any", updated.requestBody)
+		t.Fatalf("request body = %T, want JSON object", updated.requestBody)
 	}
 	if got := body["model"]; got != "from-snapshot" {
 		t.Fatalf("request body model = %#v, want from-snapshot", got)

--- a/internal/auditlog/store_mongodb.go
+++ b/internal/auditlog/store_mongodb.go
@@ -159,13 +159,15 @@ func (s *MongoDBStore) WriteBatch(ctx context.Context, entries []*LogEntry) erro
 		return nil
 	}
 
-	// Convert entries to BSON documents
+	// Convert entries to BSON documents. Captured JSON bodies are decoded
+	// here so they land as BSON documents the store can index into
+	// (response id / previous_response_id lookups), not as opaque bytes.
 	docs := make([]any, len(entries))
 	for i, e := range entries {
 		if e != nil && e.Data != nil {
 			e.Data.Attempts = normalizeAttemptSnapshots(e.Data.Attempts)
 		}
-		docs[i] = e
+		docs[i] = e.withBodyDocuments()
 	}
 
 	// Use unordered insert for better performance (continues on errors)

--- a/internal/server/image_service_test.go
+++ b/internal/server/image_service_test.go
@@ -336,9 +336,9 @@ func TestImageGenerations_AuditsRequestBody(t *testing.T) {
 				}
 				return
 			}
-			body, ok := entry.Data.RequestBody.(map[string]any)
+			body, ok := auditlog.BodyDocument(entry.Data.RequestBody).(map[string]any)
 			if !ok {
-				t.Fatalf("request body = %T, want decoded JSON object", entry.Data.RequestBody)
+				t.Fatalf("request body = %T, want JSON object", entry.Data.RequestBody)
 			}
 			if body["prompt"] != "a cat" || body["style"] != "vivid" {
 				t.Errorf("audited request body = %v, want prompt and extra fields", body)

--- a/internal/server/mcp_service_test.go
+++ b/internal/server/mcp_service_test.go
@@ -457,9 +457,9 @@ func TestEnrichMCPAuditEntryCapturesRequestBody(t *testing.T) {
 	if entry.Data == nil || entry.Data.RequestBody == nil {
 		t.Fatalf("request body was not captured on the audit entry")
 	}
-	captured, ok := entry.Data.RequestBody.(map[string]any)
+	captured, ok := auditlog.BodyDocument(entry.Data.RequestBody).(map[string]any)
 	if !ok {
-		t.Fatalf("captured body type = %T, want parsed JSON object", entry.Data.RequestBody)
+		t.Fatalf("captured body type = %T, want JSON object", entry.Data.RequestBody)
 	}
 	if captured["method"] != "tools/call" {
 		t.Fatalf("captured method = %v, want tools/call", captured["method"])

--- a/tests/e2e/auditlog_test.go
+++ b/tests/e2e/auditlog_test.go
@@ -230,16 +230,16 @@ func TestAuditLogMiddleware(t *testing.T) {
 		require.NotNil(t, entry.Data.RequestBody)
 		require.NotNil(t, entry.Data.ResponseBody)
 
-		// Verify request body contains our message (now stored as interface{})
-		reqBody, ok := entry.Data.RequestBody.(map[string]any)
-		require.True(t, ok, "RequestBody should be a map[string]interface{}, got %T", entry.Data.RequestBody)
+		// In-memory entries hold the raw JSON; decode it to inspect fields.
+		reqBody, ok := auditlog.BodyDocument(entry.Data.RequestBody).(map[string]any)
+		require.True(t, ok, "RequestBody should be a JSON object, got %T", entry.Data.RequestBody)
 		assert.Equal(t, "gpt-4", reqBody["model"])
 
 		// Verify response body captured the upstream chat completion payload, not
 		// just an empty marker — a regression that stored {} but non-nil would
 		// otherwise slip past a NotNil-only check.
-		respBody, ok := entry.Data.ResponseBody.(map[string]any)
-		require.True(t, ok, "ResponseBody should be a map[string]interface{}, got %T", entry.Data.ResponseBody)
+		respBody, ok := auditlog.BodyDocument(entry.Data.ResponseBody).(map[string]any)
+		require.True(t, ok, "ResponseBody should be a JSON object, got %T", entry.Data.ResponseBody)
 		assert.Equal(t, "chat.completion", respBody["object"])
 		assert.Equal(t, "gpt-4", respBody["model"])
 		assert.NotEmpty(t, respBody["id"], "response id should be captured")

--- a/tests/perf/hotpath_test.go
+++ b/tests/perf/hotpath_test.go
@@ -411,8 +411,8 @@ func TestHotPathPerfGuard(t *testing.T) {
 			// deployments actually run.
 			name:      "gateway_chat_completion_production_shape",
 			bench:     BenchmarkGatewayHotPathProductionShape,
-			maxAllocs: 234,   // baseline 228 (tree-walking session canonicalizer, single-pass header redaction, canonical header keys)
-			maxBytes:  23040, // baseline ~22.3 KB
+			maxAllocs: 160,   // baseline 156 (audit bodies kept as raw JSON instead of decoded into maps)
+			maxBytes:  19968, // baseline ~19.3 KB
 		},
 		{
 			// Typed chunk decoding + reused read buffer keep this converter at a


### PR DESCRIPTION
Audit body capture decoded every request and response body into \`map[string]any\` on the request path. That was the single largest remaining hot-path cost (~80 allocations per request with \`LOGGING_LOG_BODIES\` on), and every JSON consumer only re-encoded the maps anyway.

Captured JSON bodies are now kept verbatim as \`json.RawMessage\` (strictly validated, copied once). The structured form is produced only where a consumer needs it, via one helper, \`auditlog.BodyDocument\`:

- **MongoDB writer** decodes bodies into documents before insert (off the request path), so its indexes on \`data.response_body.id\` / \`data.request_body.previous_response_id\` keep working.
- **SQL stores and the live dashboard feed** marshal the raw bytes straight into the \`data\` JSON — same field paths, so \`json_extract\` / \`#>>\` lookups and indexes are unaffected.
- **Conversation-thread lookup and the admin conversation sniff** go through \`BodyDocument\`, so they accept raw, decoded, or BSON bodies alike.

Measured with \`tests/perf\` (production shape: auth + audit bodies + usage + session + rate limit):

| | Before | After |
|---|---|---|
| allocs/op | 228 | **156** (−32%) |
| bytes/op | 22.3 KB | **19.3 KB** |
| ns/op | ~14.3 µs | **~12.7 µs** |

Behavior: stored bodies are now the client's bytes — large integers keep their precision and key order is preserved (previously bodies were re-encoded from maps: float64 numbers, sorted keys). Field paths, non-JSON string fallback, UTF-8 coercion, and size limits are unchanged. Records written before and after this change coexist in the same store since both are JSON at the same paths.

Note: \`goccy/go-json\`'s \`Valid\` decodes the document to validate it; \`encoding/json.Valid\` is used instead (strict, allocation-free).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Audit log request and response bodies are captured consistently as raw JSON when valid, while preserving readable text for non-JSON content.
  * JSON bodies are decoded when needed for structured storage, searching, and field extraction.
  * Large numeric values retain their precision when audit data is serialized.
* **Performance**
  * Reduced memory allocations and data size used during audit logging.
* **Tests**
  * Expanded coverage for JSON, text, empty, and malformed bodies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->