### PR TITLE
fix(passthrough): retain models from uncaptured opaque bodies

### DIFF
--- a/internal/core/semantic.go
+++ b/internal/core/semantic.go
@@ -325,6 +325,16 @@ func ApplyBodySelectorHints(env *WhiteBoxPrompt, model, provider string, stream 
 // ApplyBodyStreamHint records independently decoded streaming intent without
 // claiming that the request body or its model selector was fully parsed.
 func ApplyBodyStreamHint(env *WhiteBoxPrompt, stream bool) {
+	applyBodyStreamHint(env, stream, false)
+}
+
+// ApplyPartialBodyStreamHint records streaming intent observed in an incomplete
+// body while preserving that the final value remains uncertain.
+func ApplyPartialBodyStreamHint(env *WhiteBoxPrompt, stream bool) {
+	applyBodyStreamHint(env, stream, true)
+}
+
+func applyBodyStreamHint(env *WhiteBoxPrompt, stream, uncertain bool) {
 	if env == nil {
 		return
 	}
@@ -332,7 +342,7 @@ func ApplyBodyStreamHint(env *WhiteBoxPrompt, stream bool) {
 	if passthrough := env.CachedPassthroughRouteInfo(); passthrough != nil {
 		cloned := *passthrough
 		cloned.Stream = stream
-		cloned.StreamUncertain = false
+		cloned.StreamUncertain = uncertain
 		CachePassthroughRouteInfo(env, &cloned)
 	}
 }

--- a/internal/core/semantic.go
+++ b/internal/core/semantic.go
@@ -322,6 +322,20 @@ func ApplyBodySelectorHints(env *WhiteBoxPrompt, model, provider string, stream 
 	}
 }
 
+// ApplyPartialBodyModelHint records a model decoded from an incomplete request
+// body without claiming that the body or its streaming intent was fully parsed.
+func ApplyPartialBodyModelHint(env *WhiteBoxPrompt, model string) {
+	if env == nil || model == "" {
+		return
+	}
+	env.RouteHints.Model = model
+	if passthrough := env.CachedPassthroughRouteInfo(); passthrough != nil {
+		cloned := *passthrough
+		cloned.Model = model
+		CachePassthroughRouteInfo(env, &cloned)
+	}
+}
+
 // MarkPassthroughStreamUncertain records that bounded opaque-body inspection
 // stopped before it could determine explicit streaming intent.
 func MarkPassthroughStreamUncertain(env *WhiteBoxPrompt) {

--- a/internal/core/semantic.go
+++ b/internal/core/semantic.go
@@ -322,16 +322,17 @@ func ApplyBodySelectorHints(env *WhiteBoxPrompt, model, provider string, stream 
 	}
 }
 
-// ApplyPartialBodyModelHint records a model decoded from an incomplete request
-// body without claiming that the body or its streaming intent was fully parsed.
-func ApplyPartialBodyModelHint(env *WhiteBoxPrompt, model string) {
-	if env == nil || model == "" {
+// ApplyBodyStreamHint records independently decoded streaming intent without
+// claiming that the request body or its model selector was fully parsed.
+func ApplyBodyStreamHint(env *WhiteBoxPrompt, stream bool) {
+	if env == nil {
 		return
 	}
-	env.RouteHints.Model = model
+	env.StreamRequested = stream
 	if passthrough := env.CachedPassthroughRouteInfo(); passthrough != nil {
 		cloned := *passthrough
-		cloned.Model = model
+		cloned.Stream = stream
+		cloned.StreamUncertain = false
 		CachePassthroughRouteInfo(env, &cloned)
 	}
 }

--- a/internal/core/semantic_test.go
+++ b/internal/core/semantic_test.go
@@ -216,6 +216,35 @@ func TestApplyBodyStreamHintPreservesSelectorConfidence(t *testing.T) {
 	}
 }
 
+func TestApplyPartialBodyStreamHintPreservesUncertainty(t *testing.T) {
+	ApplyPartialBodyStreamHint(nil, true)
+
+	env := &WhiteBoxPrompt{RouteHints: RouteHints{Model: "existing-model", Provider: "openai"}}
+	CachePassthroughRouteInfo(env, &PassthroughRouteInfo{
+		Provider: "openai",
+		Model:    "existing-model",
+	})
+
+	ApplyPartialBodyStreamHint(env, true)
+
+	if env.JSONBodyParsed {
+		t.Fatal("JSONBodyParsed = true, want false")
+	}
+	if !env.StreamRequested {
+		t.Fatal("StreamRequested = false, want observed true hint")
+	}
+	if env.RouteHints.Model != "existing-model" || env.RouteHints.Provider != "openai" {
+		t.Fatalf("RouteHints = %+v, want existing selector preserved", env.RouteHints)
+	}
+	info := env.CachedPassthroughRouteInfo()
+	if info == nil {
+		t.Fatal("CachedPassthroughRouteInfo() = nil")
+	}
+	if info.Model != "existing-model" || !info.Stream || !info.StreamUncertain {
+		t.Fatalf("PassthroughRouteInfo = %+v, want model preserved and stream uncertain", info)
+	}
+}
+
 func TestDeriveWhiteBoxPrompt_FilesMetadata(t *testing.T) {
 	frame := NewRequestSnapshot(
 		"GET",

--- a/internal/core/semantic_test.go
+++ b/internal/core/semantic_test.go
@@ -186,6 +186,37 @@ func TestDeriveWhiteBoxPrompt_SkipsBodyParsingWhenIngressBodyWasNotCaptured(t *t
 	}
 }
 
+func TestApplyPartialBodyModelHintPreservesParseAndStreamState(t *testing.T) {
+	env := &WhiteBoxPrompt{StreamRequested: true}
+	CachePassthroughRouteInfo(env, &PassthroughRouteInfo{
+		Provider:        "openai",
+		Stream:          true,
+		StreamUncertain: true,
+	})
+
+	ApplyPartialBodyModelHint(env, "gpt-5-mini")
+
+	if env.JSONBodyParsed {
+		t.Fatal("JSONBodyParsed = true, want false")
+	}
+	if !env.StreamRequested {
+		t.Fatal("StreamRequested = false, want preserved true")
+	}
+	if env.RouteHints.Model != "gpt-5-mini" {
+		t.Fatalf("RouteHints.Model = %q, want gpt-5-mini", env.RouteHints.Model)
+	}
+	info := env.CachedPassthroughRouteInfo()
+	if info == nil {
+		t.Fatal("CachedPassthroughRouteInfo() = nil")
+	}
+	if info.Model != "gpt-5-mini" {
+		t.Fatalf("PassthroughRouteInfo.Model = %q, want gpt-5-mini", info.Model)
+	}
+	if !info.Stream || !info.StreamUncertain {
+		t.Fatalf("stream state = stream %v uncertain %v, want both true", info.Stream, info.StreamUncertain)
+	}
+}
+
 func TestDeriveWhiteBoxPrompt_FilesMetadata(t *testing.T) {
 	frame := NewRequestSnapshot(
 		"GET",

--- a/internal/core/semantic_test.go
+++ b/internal/core/semantic_test.go
@@ -187,6 +187,8 @@ func TestDeriveWhiteBoxPrompt_SkipsBodyParsingWhenIngressBodyWasNotCaptured(t *t
 }
 
 func TestApplyBodyStreamHintPreservesSelectorConfidence(t *testing.T) {
+	ApplyBodyStreamHint(nil, true)
+
 	env := &WhiteBoxPrompt{RouteHints: RouteHints{Model: "existing-model", Provider: "openai"}}
 	CachePassthroughRouteInfo(env, &PassthroughRouteInfo{
 		Provider:        "openai",

--- a/internal/core/semantic_test.go
+++ b/internal/core/semantic_test.go
@@ -217,6 +217,16 @@ func TestApplyPartialBodyModelHintPreservesParseAndStreamState(t *testing.T) {
 	}
 }
 
+func TestApplyPartialBodyModelHintIgnoresMissingInput(t *testing.T) {
+	ApplyPartialBodyModelHint(nil, "gpt-5-mini")
+
+	env := &WhiteBoxPrompt{RouteHints: RouteHints{Model: "existing-model"}}
+	ApplyPartialBodyModelHint(env, "")
+	if env.RouteHints.Model != "existing-model" {
+		t.Fatalf("RouteHints.Model = %q, want existing-model", env.RouteHints.Model)
+	}
+}
+
 func TestDeriveWhiteBoxPrompt_FilesMetadata(t *testing.T) {
 	frame := NewRequestSnapshot(
 		"GET",

--- a/internal/core/semantic_test.go
+++ b/internal/core/semantic_test.go
@@ -186,44 +186,31 @@ func TestDeriveWhiteBoxPrompt_SkipsBodyParsingWhenIngressBodyWasNotCaptured(t *t
 	}
 }
 
-func TestApplyPartialBodyModelHintPreservesParseAndStreamState(t *testing.T) {
-	env := &WhiteBoxPrompt{StreamRequested: true}
+func TestApplyBodyStreamHintPreservesSelectorConfidence(t *testing.T) {
+	env := &WhiteBoxPrompt{RouteHints: RouteHints{Model: "existing-model", Provider: "openai"}}
 	CachePassthroughRouteInfo(env, &PassthroughRouteInfo{
 		Provider:        "openai",
-		Stream:          true,
+		Model:           "existing-model",
 		StreamUncertain: true,
 	})
 
-	ApplyPartialBodyModelHint(env, "gpt-5-mini")
+	ApplyBodyStreamHint(env, true)
 
 	if env.JSONBodyParsed {
 		t.Fatal("JSONBodyParsed = true, want false")
 	}
 	if !env.StreamRequested {
-		t.Fatal("StreamRequested = false, want preserved true")
+		t.Fatal("StreamRequested = false, want true")
 	}
-	if env.RouteHints.Model != "gpt-5-mini" {
-		t.Fatalf("RouteHints.Model = %q, want gpt-5-mini", env.RouteHints.Model)
+	if env.RouteHints.Model != "existing-model" || env.RouteHints.Provider != "openai" {
+		t.Fatalf("RouteHints = %+v, want existing selector preserved", env.RouteHints)
 	}
 	info := env.CachedPassthroughRouteInfo()
 	if info == nil {
 		t.Fatal("CachedPassthroughRouteInfo() = nil")
 	}
-	if info.Model != "gpt-5-mini" {
-		t.Fatalf("PassthroughRouteInfo.Model = %q, want gpt-5-mini", info.Model)
-	}
-	if !info.Stream || !info.StreamUncertain {
-		t.Fatalf("stream state = stream %v uncertain %v, want both true", info.Stream, info.StreamUncertain)
-	}
-}
-
-func TestApplyPartialBodyModelHintIgnoresMissingInput(t *testing.T) {
-	ApplyPartialBodyModelHint(nil, "gpt-5-mini")
-
-	env := &WhiteBoxPrompt{RouteHints: RouteHints{Model: "existing-model"}}
-	ApplyPartialBodyModelHint(env, "")
-	if env.RouteHints.Model != "existing-model" {
-		t.Fatalf("RouteHints.Model = %q, want existing-model", env.RouteHints.Model)
+	if info.Model != "existing-model" || !info.Stream || info.StreamUncertain {
+		t.Fatalf("PassthroughRouteInfo = %+v, want model preserved and stream confirmed", info)
 	}
 }
 

--- a/internal/server/request_selector_peek.go
+++ b/internal/server/request_selector_peek.go
@@ -131,10 +131,19 @@ func decodeRequestBodySelectorHintsWithMode(r io.Reader, requireComplete bool) r
 	var hints requestBodySelectorHints
 	var modelSeen, providerSeen, streamSeen bool
 	var modelAmbiguous, providerAmbiguous, streamAmbiguous bool
+	partialHints := func() requestBodySelectorHints {
+		if requireComplete || !hints.streamParsed || streamAmbiguous {
+			return requestBodySelectorHints{}
+		}
+		return requestBodySelectorHints{
+			stream:       hints.stream,
+			streamParsed: true,
+		}
+	}
 	for dec.More() {
 		keyToken, err := dec.Token()
 		if err != nil {
-			return requestBodySelectorHints{}
+			return partialHints()
 		}
 		key, ok := keyToken.(string)
 		if !ok {
@@ -174,7 +183,7 @@ func decodeRequestBodySelectorHintsWithMode(r io.Reader, requireComplete bool) r
 				return hints
 			}
 		case "stream":
-			if requireComplete && streamSeen {
+			if streamSeen {
 				streamAmbiguous = true
 			}
 			streamSeen = true
@@ -186,7 +195,7 @@ func decodeRequestBodySelectorHintsWithMode(r io.Reader, requireComplete bool) r
 			hints.streamParsed = true
 		default:
 			if err := skipJSONValue(dec); err != nil {
-				return requestBodySelectorHints{}
+				return partialHints()
 			}
 		}
 	}

--- a/internal/server/request_selector_peek.go
+++ b/internal/server/request_selector_peek.go
@@ -27,25 +27,21 @@ func seedRequestBodySelectorHints(req *http.Request, bodyMode core.BodyMode, env
 		return
 	}
 
-	hints := peekRequestBodySelectorHints(req, requestSelectorPeekLimit)
-	if bodyMode == core.BodyModeOpaque && !hints.complete {
-		// A partial selector must not become authoritative because a duplicate
-		// field beyond the peek boundary could change what the provider executes.
-		if hints.model != "" {
-			completeHints := peekCompleteRequestBodySelectorHints(req, requestSelectorPeekLimit)
-			if completeHints.complete {
-				hints = completeHints
-			} else if completeHints.streamParsed {
-				hints.stream = completeHints.stream
-				hints.streamParsed = true
-			}
-		}
+	if bodyMode == core.BodyModeOpaque {
+		hints := peekCompleteRequestBodySelectorHints(req, requestSelectorPeekLimit)
 		if hints.complete {
 			core.ApplyBodySelectorHints(env, hints.model, hints.provider, hints.stream)
 		} else if hints.streamParsed {
 			core.ApplyBodyStreamHint(env, hints.stream)
 		}
-	} else if hints.parsed || hints.streamParsed {
+		if !hints.streamParsed {
+			core.MarkPassthroughStreamUncertain(env)
+		}
+		return
+	}
+
+	hints := peekRequestBodySelectorHints(req, requestSelectorPeekLimit)
+	if hints.parsed || hints.streamParsed {
 		core.ApplyBodySelectorHints(env, hints.model, hints.provider, hints.stream)
 	}
 	if !hints.streamParsed {
@@ -89,11 +85,13 @@ func peekRequestBodySelectorHints(req *http.Request, limit int64) requestBodySel
 	return hints
 }
 
-// peekCompleteRequestBodySelectorHints returns hints only when the entire body
-// fits within limit and has no duplicate selector fields. The body is restored
-// before returning so passthrough forwarding remains byte-for-byte unchanged.
+// peekCompleteRequestBodySelectorHints returns authoritative selector hints
+// only when the entire body fits within limit and has no duplicate selector
+// fields. A unique stream hint may be returned independently from a bounded
+// oversized body. The body is restored before returning so passthrough
+// forwarding remains byte-for-byte unchanged.
 func peekCompleteRequestBodySelectorHints(req *http.Request, limit int64) requestBodySelectorHints {
-	if req == nil || req.Body == nil || limit <= 0 || req.ContentLength > limit {
+	if req == nil || req.Body == nil || limit <= 0 {
 		return requestBodySelectorHints{}
 	}
 
@@ -103,10 +101,24 @@ func peekCompleteRequestBodySelectorHints(req *http.Request, limit int64) reques
 		Reader: io.MultiReader(bytes.NewReader(body), originalBody),
 		rc:     originalBody,
 	}
-	if err != nil || int64(len(body)) > limit {
+	if err != nil {
 		return requestBodySelectorHints{}
 	}
+	if int64(len(body)) > limit {
+		hints := decodeCompleteRequestBodySelectorHints(bytes.NewReader(body[:limit]))
+		return hints.independentStreamHint()
+	}
 	return decodeCompleteRequestBodySelectorHints(bytes.NewReader(body))
+}
+
+func (hints requestBodySelectorHints) independentStreamHint() requestBodySelectorHints {
+	if !hints.streamParsed {
+		return requestBodySelectorHints{}
+	}
+	return requestBodySelectorHints{
+		stream:       hints.stream,
+		streamParsed: true,
+	}
 }
 
 func decodeRequestBodySelectorHints(r io.Reader) requestBodySelectorHints {
@@ -132,13 +144,10 @@ func decodeRequestBodySelectorHintsWithMode(r io.Reader, requireComplete bool) r
 	var modelSeen, providerSeen, streamSeen bool
 	var modelAmbiguous, providerAmbiguous, streamAmbiguous bool
 	partialHints := func() requestBodySelectorHints {
-		if requireComplete || !hints.streamParsed || streamAmbiguous {
+		if !hints.streamParsed || streamAmbiguous {
 			return requestBodySelectorHints{}
 		}
-		return requestBodySelectorHints{
-			stream:       hints.stream,
-			streamParsed: true,
-		}
+		return hints.independentStreamHint()
 	}
 	for dec.More() {
 		keyToken, err := dec.Token()

--- a/internal/server/request_selector_peek.go
+++ b/internal/server/request_selector_peek.go
@@ -30,6 +30,8 @@ func seedRequestBodySelectorHints(req *http.Request, bodyMode core.BodyMode, env
 	hints := peekRequestBodySelectorHints(req, requestSelectorPeekLimit)
 	if hints.parsed || hints.streamParsed {
 		core.ApplyBodySelectorHints(env, hints.model, hints.provider, hints.stream)
+	} else if bodyMode == core.BodyModeOpaque && hints.model != "" {
+		core.ApplyPartialBodyModelHint(env, hints.model)
 	}
 	if !hints.streamParsed {
 		core.MarkPassthroughStreamUncertain(env)

--- a/internal/server/request_selector_peek.go
+++ b/internal/server/request_selector_peek.go
@@ -14,12 +14,13 @@ import (
 const requestSelectorPeekLimit int64 = 64 * 1024
 
 type requestBodySelectorHints struct {
-	model        string
-	provider     string
-	stream       bool
-	streamParsed bool
-	parsed       bool
-	complete     bool
+	model          string
+	provider       string
+	stream         bool
+	streamParsed   bool
+	streamVerified bool
+	parsed         bool
+	complete       bool
 }
 
 func seedRequestBodySelectorHints(req *http.Request, bodyMode core.BodyMode, env *core.WhiteBoxPrompt) {
@@ -32,7 +33,11 @@ func seedRequestBodySelectorHints(req *http.Request, bodyMode core.BodyMode, env
 		if hints.complete {
 			core.ApplyBodySelectorHints(env, hints.model, hints.provider, hints.stream)
 		} else if hints.streamParsed {
-			core.ApplyBodyStreamHint(env, hints.stream)
+			if hints.streamVerified {
+				core.ApplyBodyStreamHint(env, hints.stream)
+			} else {
+				core.ApplyPartialBodyStreamHint(env, hints.stream)
+			}
 		}
 		if !hints.streamParsed {
 			core.MarkPassthroughStreamUncertain(env)
@@ -219,6 +224,7 @@ func decodeRequestBodySelectorHintsWithMode(r io.Reader, requireComplete bool) r
 		if streamAmbiguous {
 			return requestBodySelectorHints{}
 		}
+		hints.streamVerified = hints.streamParsed
 		if modelAmbiguous || providerAmbiguous {
 			hints.model = ""
 			hints.provider = ""

--- a/internal/server/request_selector_peek.go
+++ b/internal/server/request_selector_peek.go
@@ -32,8 +32,12 @@ func seedRequestBodySelectorHints(req *http.Request, bodyMode core.BodyMode, env
 		// A partial selector must not become authoritative because a duplicate
 		// field beyond the peek boundary could change what the provider executes.
 		if hints.model != "" {
-			if completeHints := peekCompleteRequestBodySelectorHints(req, requestSelectorPeekLimit); completeHints.complete {
+			completeHints := peekCompleteRequestBodySelectorHints(req, requestSelectorPeekLimit)
+			if completeHints.complete {
 				hints = completeHints
+			} else if completeHints.streamParsed {
+				hints.stream = completeHints.stream
+				hints.streamParsed = true
 			}
 		}
 		if hints.complete {
@@ -126,6 +130,7 @@ func decodeRequestBodySelectorHintsWithMode(r io.Reader, requireComplete bool) r
 
 	var hints requestBodySelectorHints
 	var modelSeen, providerSeen, streamSeen bool
+	var modelAmbiguous, providerAmbiguous, streamAmbiguous bool
 	for dec.More() {
 		keyToken, err := dec.Token()
 		if err != nil {
@@ -139,7 +144,7 @@ func decodeRequestBodySelectorHintsWithMode(r io.Reader, requireComplete bool) r
 		switch key {
 		case "model":
 			if requireComplete && modelSeen {
-				return requestBodySelectorHints{}
+				modelAmbiguous = true
 			}
 			modelSeen = true
 			model, ok, err := readOptionalJSONString(dec)
@@ -156,7 +161,7 @@ func decodeRequestBodySelectorHintsWithMode(r io.Reader, requireComplete bool) r
 			}
 		case "provider":
 			if requireComplete && providerSeen {
-				return requestBodySelectorHints{}
+				providerAmbiguous = true
 			}
 			providerSeen = true
 			provider, ok, err := readOptionalJSONString(dec)
@@ -170,7 +175,7 @@ func decodeRequestBodySelectorHintsWithMode(r io.Reader, requireComplete bool) r
 			}
 		case "stream":
 			if requireComplete && streamSeen {
-				return requestBodySelectorHints{}
+				streamAmbiguous = true
 			}
 			streamSeen = true
 			stream, ok, err := readOptionalJSONBool(dec)
@@ -192,6 +197,14 @@ func decodeRequestBodySelectorHintsWithMode(r io.Reader, requireComplete bool) r
 		}
 		if _, err := dec.Token(); err != io.EOF {
 			return requestBodySelectorHints{}
+		}
+		if streamAmbiguous {
+			return requestBodySelectorHints{}
+		}
+		if modelAmbiguous || providerAmbiguous {
+			hints.model = ""
+			hints.provider = ""
+			return hints
 		}
 	}
 

--- a/internal/server/request_selector_peek.go
+++ b/internal/server/request_selector_peek.go
@@ -28,10 +28,21 @@ func seedRequestBodySelectorHints(req *http.Request, bodyMode core.BodyMode, env
 	}
 
 	hints := peekRequestBodySelectorHints(req, requestSelectorPeekLimit)
-	if hints.parsed || hints.streamParsed {
+	if bodyMode == core.BodyModeOpaque && !hints.complete {
+		// A partial selector must not become authoritative because a duplicate
+		// field beyond the peek boundary could change what the provider executes.
+		if hints.model != "" {
+			if completeHints := peekCompleteRequestBodySelectorHints(req, requestSelectorPeekLimit); completeHints.complete {
+				hints = completeHints
+			}
+		}
+		if hints.complete {
+			core.ApplyBodySelectorHints(env, hints.model, hints.provider, hints.stream)
+		} else if hints.streamParsed {
+			core.ApplyBodyStreamHint(env, hints.stream)
+		}
+	} else if hints.parsed || hints.streamParsed {
 		core.ApplyBodySelectorHints(env, hints.model, hints.provider, hints.stream)
-	} else if bodyMode == core.BodyModeOpaque && hints.model != "" {
-		core.ApplyPartialBodyModelHint(env, hints.model)
 	}
 	if !hints.streamParsed {
 		core.MarkPassthroughStreamUncertain(env)
@@ -74,7 +85,35 @@ func peekRequestBodySelectorHints(req *http.Request, limit int64) requestBodySel
 	return hints
 }
 
+// peekCompleteRequestBodySelectorHints returns hints only when the entire body
+// fits within limit and has no duplicate selector fields. The body is restored
+// before returning so passthrough forwarding remains byte-for-byte unchanged.
+func peekCompleteRequestBodySelectorHints(req *http.Request, limit int64) requestBodySelectorHints {
+	if req == nil || req.Body == nil || limit <= 0 || req.ContentLength > limit {
+		return requestBodySelectorHints{}
+	}
+
+	originalBody := req.Body
+	body, err := io.ReadAll(io.LimitReader(originalBody, limit+1))
+	req.Body = &combinedReadCloser{
+		Reader: io.MultiReader(bytes.NewReader(body), originalBody),
+		rc:     originalBody,
+	}
+	if err != nil || int64(len(body)) > limit {
+		return requestBodySelectorHints{}
+	}
+	return decodeCompleteRequestBodySelectorHints(bytes.NewReader(body))
+}
+
 func decodeRequestBodySelectorHints(r io.Reader) requestBodySelectorHints {
+	return decodeRequestBodySelectorHintsWithMode(r, false)
+}
+
+func decodeCompleteRequestBodySelectorHints(r io.Reader) requestBodySelectorHints {
+	return decodeRequestBodySelectorHintsWithMode(r, true)
+}
+
+func decodeRequestBodySelectorHintsWithMode(r io.Reader, requireComplete bool) requestBodySelectorHints {
 	dec := json.NewDecoder(r)
 	token, err := dec.Token()
 	if err != nil {
@@ -86,6 +125,7 @@ func decodeRequestBodySelectorHints(r io.Reader) requestBodySelectorHints {
 	}
 
 	var hints requestBodySelectorHints
+	var modelSeen, providerSeen, streamSeen bool
 	for dec.More() {
 		keyToken, err := dec.Token()
 		if err != nil {
@@ -98,29 +138,41 @@ func decodeRequestBodySelectorHints(r io.Reader) requestBodySelectorHints {
 
 		switch key {
 		case "model":
+			if requireComplete && modelSeen {
+				return requestBodySelectorHints{}
+			}
+			modelSeen = true
 			model, ok, err := readOptionalJSONString(dec)
 			if err != nil || !ok {
 				return requestBodySelectorHints{}
 			}
 			hints.model = model
-			if model != "" && hints.provider != "" {
+			if !requireComplete && model != "" && hints.provider != "" {
 				hints.parsed = true
 				return hints
 			}
-			if model != "" {
+			if !requireComplete && model != "" {
 				return hints
 			}
 		case "provider":
+			if requireComplete && providerSeen {
+				return requestBodySelectorHints{}
+			}
+			providerSeen = true
 			provider, ok, err := readOptionalJSONString(dec)
 			if err != nil || !ok {
 				return requestBodySelectorHints{}
 			}
 			hints.provider = provider
-			if hints.provider != "" && hints.model != "" {
+			if !requireComplete && hints.provider != "" && hints.model != "" {
 				hints.parsed = true
 				return hints
 			}
 		case "stream":
+			if requireComplete && streamSeen {
+				return requestBodySelectorHints{}
+			}
+			streamSeen = true
 			stream, ok, err := readOptionalJSONBool(dec)
 			if err != nil || !ok {
 				return requestBodySelectorHints{}
@@ -131,6 +183,15 @@ func decodeRequestBodySelectorHints(r io.Reader) requestBodySelectorHints {
 			if err := skipJSONValue(dec); err != nil {
 				return requestBodySelectorHints{}
 			}
+		}
+	}
+	if requireComplete {
+		closing, err := dec.Token()
+		if err != nil || closing != json.Delim('}') {
+			return requestBodySelectorHints{}
+		}
+		if _, err := dec.Token(); err != io.EOF {
+			return requestBodySelectorHints{}
 		}
 	}
 

--- a/internal/server/request_selector_peek_test.go
+++ b/internal/server/request_selector_peek_test.go
@@ -66,6 +66,35 @@ func TestSeedRequestBodySelectorHintsDoesNotMarkModelOnlyPeekAsParsed(t *testing
 	}
 }
 
+func TestSeedRequestBodySelectorHintsAppliesPartialModelForOpaqueBody(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/p/openai/chat/completions", strings.NewReader(`{"model":"gpt-4o-mini","stream":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	env := &core.WhiteBoxPrompt{}
+	core.CachePassthroughRouteInfo(env, &core.PassthroughRouteInfo{Provider: "openai"})
+
+	seedRequestBodySelectorHints(req, core.BodyModeOpaque, env)
+
+	if env.JSONBodyParsed {
+		t.Fatal("JSONBodyParsed = true, want false for partial model-only peek")
+	}
+	if env.StreamRequested {
+		t.Fatal("StreamRequested = true, want false until stream is parsed")
+	}
+	if env.RouteHints.Model != "gpt-4o-mini" {
+		t.Fatalf("RouteHints.Model = %q, want gpt-4o-mini", env.RouteHints.Model)
+	}
+	info := env.CachedPassthroughRouteInfo()
+	if info == nil {
+		t.Fatal("CachedPassthroughRouteInfo() = nil")
+	}
+	if info.Model != "gpt-4o-mini" {
+		t.Fatalf("PassthroughRouteInfo.Model = %q, want gpt-4o-mini", info.Model)
+	}
+	if !info.StreamUncertain {
+		t.Fatal("PassthroughRouteInfo.StreamUncertain = false, want true")
+	}
+}
+
 func TestSeedRequestBodySelectorHintsTracksStreamConfidenceIndependently(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/server/request_selector_peek_test.go
+++ b/internal/server/request_selector_peek_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -112,10 +113,10 @@ func TestSeedRequestBodySelectorHintsRejectsIncompleteOpaqueModel(t *testing.T) 
 		knownLength   bool
 	}{
 		{name: "model first", prefix: `{"model":"allowed-model","padding":"`, wantUncertain: true},
-		{name: "stream first", prefix: `{"stream":true,"model":"allowed-model","padding":"`, wantStream: true},
-		{name: "model before stream", prefix: `{"model":"allowed-model","stream":true,"padding":"`, wantStream: true},
-		{name: "model before stream with known length", prefix: `{"model":"allowed-model","stream":true,"padding":"`, wantStream: true, knownLength: true},
-		{name: "stream before oversized value", prefix: `{"stream":true,"padding":"`, wantStream: true},
+		{name: "stream first", prefix: `{"stream":true,"model":"allowed-model","padding":"`, wantStream: true, wantUncertain: true},
+		{name: "model before stream", prefix: `{"model":"allowed-model","stream":true,"padding":"`, wantStream: true, wantUncertain: true},
+		{name: "model before stream with known length", prefix: `{"model":"allowed-model","stream":true,"padding":"`, wantStream: true, wantUncertain: true, knownLength: true},
+		{name: "stream before oversized value", prefix: `{"stream":true,"padding":"`, wantStream: true, wantUncertain: true},
 	}
 
 	for _, test := range tests {
@@ -170,6 +171,44 @@ func TestSeedRequestBodySelectorHintsRejectsAmbiguousStreamBeforePeekLimit(t *te
 	}
 	if info.Stream || !info.StreamUncertain {
 		t.Fatalf("stream state = stream %v uncertain %v, want false and true", info.Stream, info.StreamUncertain)
+	}
+}
+
+func TestSeedRequestBodySelectorHintsMarksStreamBeyondPeekBoundaryUncertain(t *testing.T) {
+	body := `{"stream":true,"padding":"` + strings.Repeat("x", int(requestSelectorPeekLimit)) + `","stream":false}`
+	req := httptest.NewRequest(http.MethodPost, "/p/openai/chat/completions", strings.NewReader(body))
+	req.ContentLength = -1
+	req.Header.Set("Content-Type", "application/json")
+	env := &core.WhiteBoxPrompt{}
+	core.CachePassthroughRouteInfo(env, &core.PassthroughRouteInfo{Provider: "openai"})
+
+	seedRequestBodySelectorHints(req, core.BodyModeOpaque, env)
+
+	if !env.StreamRequested {
+		t.Fatal("StreamRequested = false, want observed prefix hint retained")
+	}
+	info := env.CachedPassthroughRouteInfo()
+	if info == nil {
+		t.Fatal("CachedPassthroughRouteInfo() = nil")
+	}
+	if !info.Stream || !info.StreamUncertain {
+		t.Fatalf("stream state = stream %v uncertain %v, want true and true", info.Stream, info.StreamUncertain)
+	}
+	restored, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("read restored body: %v", err)
+	}
+	if string(restored) != body {
+		t.Fatal("restored body differs from original")
+	}
+	var forwarded struct {
+		Stream bool `json:"stream"`
+	}
+	if err := json.Unmarshal(restored, &forwarded); err != nil {
+		t.Fatalf("decode restored body: %v", err)
+	}
+	if forwarded.Stream {
+		t.Fatal("forwarded stream = true, want last duplicate false to demonstrate uncertainty")
 	}
 }
 

--- a/internal/server/request_selector_peek_test.go
+++ b/internal/server/request_selector_peek_test.go
@@ -109,9 +109,12 @@ func TestSeedRequestBodySelectorHintsRejectsIncompleteOpaqueModel(t *testing.T) 
 		prefix        string
 		wantStream    bool
 		wantUncertain bool
+		knownLength   bool
 	}{
 		{name: "model first", prefix: `{"model":"allowed-model","padding":"`, wantUncertain: true},
 		{name: "stream first", prefix: `{"stream":true,"model":"allowed-model","padding":"`, wantStream: true},
+		{name: "model before stream", prefix: `{"model":"allowed-model","stream":true,"padding":"`, wantStream: true},
+		{name: "model before stream with known length", prefix: `{"model":"allowed-model","stream":true,"padding":"`, wantStream: true, knownLength: true},
 		{name: "stream before oversized value", prefix: `{"stream":true,"padding":"`, wantStream: true},
 	}
 
@@ -119,7 +122,9 @@ func TestSeedRequestBodySelectorHintsRejectsIncompleteOpaqueModel(t *testing.T) 
 		t.Run(test.name, func(t *testing.T) {
 			body := test.prefix + strings.Repeat("x", int(requestSelectorPeekLimit)) + `","model":"restricted-model"}`
 			req := httptest.NewRequest(http.MethodPost, "/p/openai/chat/completions", strings.NewReader(body))
-			req.ContentLength = -1
+			if !test.knownLength {
+				req.ContentLength = -1
+			}
 			req.Header.Set("Content-Type", "application/json")
 			env := &core.WhiteBoxPrompt{}
 			core.CachePassthroughRouteInfo(env, &core.PassthroughRouteInfo{Provider: "openai"})
@@ -165,6 +170,51 @@ func TestSeedRequestBodySelectorHintsRejectsAmbiguousStreamBeforePeekLimit(t *te
 	}
 	if info.Stream || !info.StreamUncertain {
 		t.Fatalf("stream state = stream %v uncertain %v, want false and true", info.Stream, info.StreamUncertain)
+	}
+}
+
+func TestSeedRequestBodySelectorHintsRejectsCompleteDuplicateOpaqueFields(t *testing.T) {
+	tests := []struct {
+		name          string
+		body          string
+		wantStream    bool
+		wantUncertain bool
+	}{
+		{
+			name:          "stream",
+			body:          `{"stream":true,"stream":false}`,
+			wantUncertain: true,
+		},
+		{
+			name:       "provider",
+			body:       `{"provider":"first","provider":"second","stream":true}`,
+			wantStream: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/p/openai/chat/completions", strings.NewReader(test.body))
+			req.Header.Set("Content-Type", "application/json")
+			env := &core.WhiteBoxPrompt{}
+			core.CachePassthroughRouteInfo(env, &core.PassthroughRouteInfo{Provider: "openai"})
+
+			seedRequestBodySelectorHints(req, core.BodyModeOpaque, env)
+
+			if env.JSONBodyParsed {
+				t.Fatal("JSONBodyParsed = true, want false for duplicate fields")
+			}
+			if env.RouteHints.Provider != "openai" {
+				t.Fatalf("RouteHints.Provider = %q, want route provider openai", env.RouteHints.Provider)
+			}
+			info := env.CachedPassthroughRouteInfo()
+			if info == nil {
+				t.Fatal("CachedPassthroughRouteInfo() = nil")
+			}
+			if info.Stream != test.wantStream || info.StreamUncertain != test.wantUncertain {
+				t.Fatalf("stream state = stream %v uncertain %v, want stream %v uncertain %v", info.Stream, info.StreamUncertain, test.wantStream, test.wantUncertain)
+			}
+		})
 	}
 }
 

--- a/internal/server/request_selector_peek_test.go
+++ b/internal/server/request_selector_peek_test.go
@@ -146,7 +146,7 @@ func TestSeedRequestBodySelectorHintsRejectsIncompleteOpaqueModel(t *testing.T) 
 }
 
 func TestSeedRequestBodySelectorHintsRejectsDuplicateOpaqueModel(t *testing.T) {
-	req := httptest.NewRequest(http.MethodPost, "/p/openai/chat/completions", strings.NewReader(`{"model":"allowed-model","model":"restricted-model"}`))
+	req := httptest.NewRequest(http.MethodPost, "/p/openai/chat/completions", strings.NewReader(`{"model":"allowed-model","stream":true,"model":"restricted-model"}`))
 	req.ContentLength = -1
 	req.Header.Set("Content-Type", "application/json")
 	env := &core.WhiteBoxPrompt{}
@@ -159,6 +159,16 @@ func TestSeedRequestBodySelectorHintsRejectsDuplicateOpaqueModel(t *testing.T) {
 	}
 	if env.RouteHints.Model != "" {
 		t.Fatalf("RouteHints.Model = %q, want empty", env.RouteHints.Model)
+	}
+	if !env.StreamRequested {
+		t.Fatal("StreamRequested = false, want true from unique stream field")
+	}
+	info := env.CachedPassthroughRouteInfo()
+	if info == nil {
+		t.Fatal("CachedPassthroughRouteInfo() = nil")
+	}
+	if !info.Stream || info.StreamUncertain {
+		t.Fatalf("stream state = stream %v uncertain %v, want true and false", info.Stream, info.StreamUncertain)
 	}
 }
 

--- a/internal/server/request_selector_peek_test.go
+++ b/internal/server/request_selector_peek_test.go
@@ -66,19 +66,20 @@ func TestSeedRequestBodySelectorHintsDoesNotMarkModelOnlyPeekAsParsed(t *testing
 	}
 }
 
-func TestSeedRequestBodySelectorHintsAppliesPartialModelForOpaqueBody(t *testing.T) {
+func TestSeedRequestBodySelectorHintsAppliesCompleteModelForOpaqueBody(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/p/openai/chat/completions", strings.NewReader(`{"model":"gpt-4o-mini","stream":true}`))
+	req.ContentLength = -1
 	req.Header.Set("Content-Type", "application/json")
 	env := &core.WhiteBoxPrompt{}
 	core.CachePassthroughRouteInfo(env, &core.PassthroughRouteInfo{Provider: "openai"})
 
 	seedRequestBodySelectorHints(req, core.BodyModeOpaque, env)
 
-	if env.JSONBodyParsed {
-		t.Fatal("JSONBodyParsed = true, want false for partial model-only peek")
+	if !env.JSONBodyParsed {
+		t.Fatal("JSONBodyParsed = false, want true for complete model-only peek")
 	}
-	if env.StreamRequested {
-		t.Fatal("StreamRequested = true, want false until stream is parsed")
+	if !env.StreamRequested {
+		t.Fatal("StreamRequested = false, want true")
 	}
 	if env.RouteHints.Model != "gpt-4o-mini" {
 		t.Fatalf("RouteHints.Model = %q, want gpt-4o-mini", env.RouteHints.Model)
@@ -90,8 +91,91 @@ func TestSeedRequestBodySelectorHintsAppliesPartialModelForOpaqueBody(t *testing
 	if info.Model != "gpt-4o-mini" {
 		t.Fatalf("PassthroughRouteInfo.Model = %q, want gpt-4o-mini", info.Model)
 	}
-	if !info.StreamUncertain {
-		t.Fatal("PassthroughRouteInfo.StreamUncertain = false, want true")
+	if !info.Stream || info.StreamUncertain {
+		t.Fatalf("stream state = stream %v uncertain %v, want true and false", info.Stream, info.StreamUncertain)
+	}
+	restored, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("read restored body: %v", err)
+	}
+	if string(restored) != `{"model":"gpt-4o-mini","stream":true}` {
+		t.Fatalf("restored body = %q, want original body", string(restored))
+	}
+}
+
+func TestSeedRequestBodySelectorHintsRejectsIncompleteOpaqueModel(t *testing.T) {
+	tests := []struct {
+		name          string
+		prefix        string
+		wantStream    bool
+		wantUncertain bool
+	}{
+		{name: "model first", prefix: `{"model":"allowed-model","padding":"`, wantUncertain: true},
+		{name: "stream first", prefix: `{"stream":true,"model":"allowed-model","padding":"`, wantStream: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			body := test.prefix + strings.Repeat("x", int(requestSelectorPeekLimit)) + `","model":"restricted-model"}`
+			req := httptest.NewRequest(http.MethodPost, "/p/openai/chat/completions", strings.NewReader(body))
+			req.ContentLength = -1
+			req.Header.Set("Content-Type", "application/json")
+			env := &core.WhiteBoxPrompt{}
+			core.CachePassthroughRouteInfo(env, &core.PassthroughRouteInfo{Provider: "openai"})
+
+			seedRequestBodySelectorHints(req, core.BodyModeOpaque, env)
+
+			if env.JSONBodyParsed {
+				t.Fatal("JSONBodyParsed = true, want false for incomplete opaque body")
+			}
+			if env.RouteHints.Model != "" {
+				t.Fatalf("RouteHints.Model = %q, want empty", env.RouteHints.Model)
+			}
+			info := env.CachedPassthroughRouteInfo()
+			if info == nil {
+				t.Fatal("CachedPassthroughRouteInfo() = nil")
+			}
+			if info.Model != "" {
+				t.Fatalf("PassthroughRouteInfo.Model = %q, want empty", info.Model)
+			}
+			if info.Stream != test.wantStream || info.StreamUncertain != test.wantUncertain {
+				t.Fatalf("stream state = stream %v uncertain %v, want stream %v uncertain %v", info.Stream, info.StreamUncertain, test.wantStream, test.wantUncertain)
+			}
+		})
+	}
+}
+
+func TestSeedRequestBodySelectorHintsRejectsDuplicateOpaqueModel(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/p/openai/chat/completions", strings.NewReader(`{"model":"allowed-model","model":"restricted-model"}`))
+	req.ContentLength = -1
+	req.Header.Set("Content-Type", "application/json")
+	env := &core.WhiteBoxPrompt{}
+	core.CachePassthroughRouteInfo(env, &core.PassthroughRouteInfo{Provider: "openai"})
+
+	seedRequestBodySelectorHints(req, core.BodyModeOpaque, env)
+
+	if env.JSONBodyParsed {
+		t.Fatal("JSONBodyParsed = true, want false for duplicate model fields")
+	}
+	if env.RouteHints.Model != "" {
+		t.Fatalf("RouteHints.Model = %q, want empty", env.RouteHints.Model)
+	}
+}
+
+func TestDecodeCompleteRequestBodySelectorHintsRejectsAmbiguousBodies(t *testing.T) {
+	bodies := []string{
+		`{"model":"first","model":"second"}`,
+		`{"provider":"first","provider":"second"}`,
+		`{"stream":false,"stream":true}`,
+		`{"model":"gpt-4o-mini"`,
+		`{"model":"gpt-4o-mini"} {}`,
+	}
+
+	for _, body := range bodies {
+		hints := decodeCompleteRequestBodySelectorHints(strings.NewReader(body))
+		if hints.complete {
+			t.Fatalf("decodeCompleteRequestBodySelectorHints(%q).complete = true, want false", body)
+		}
 	}
 }
 

--- a/internal/server/request_selector_peek_test.go
+++ b/internal/server/request_selector_peek_test.go
@@ -112,6 +112,7 @@ func TestSeedRequestBodySelectorHintsRejectsIncompleteOpaqueModel(t *testing.T) 
 	}{
 		{name: "model first", prefix: `{"model":"allowed-model","padding":"`, wantUncertain: true},
 		{name: "stream first", prefix: `{"stream":true,"model":"allowed-model","padding":"`, wantStream: true},
+		{name: "stream before oversized value", prefix: `{"stream":true,"padding":"`, wantStream: true},
 	}
 
 	for _, test := range tests {
@@ -142,6 +143,28 @@ func TestSeedRequestBodySelectorHintsRejectsIncompleteOpaqueModel(t *testing.T) 
 				t.Fatalf("stream state = stream %v uncertain %v, want stream %v uncertain %v", info.Stream, info.StreamUncertain, test.wantStream, test.wantUncertain)
 			}
 		})
+	}
+}
+
+func TestSeedRequestBodySelectorHintsRejectsAmbiguousStreamBeforePeekLimit(t *testing.T) {
+	body := `{"stream":true,"stream":false,"padding":"` + strings.Repeat("x", int(requestSelectorPeekLimit)) + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/p/openai/chat/completions", strings.NewReader(body))
+	req.ContentLength = -1
+	req.Header.Set("Content-Type", "application/json")
+	env := &core.WhiteBoxPrompt{}
+	core.CachePassthroughRouteInfo(env, &core.PassthroughRouteInfo{Provider: "openai"})
+
+	seedRequestBodySelectorHints(req, core.BodyModeOpaque, env)
+
+	if env.StreamRequested {
+		t.Fatal("StreamRequested = true, want false for duplicate stream fields")
+	}
+	info := env.CachedPassthroughRouteInfo()
+	if info == nil {
+		t.Fatal("CachedPassthroughRouteInfo() = nil")
+	}
+	if info.Stream || !info.StreamUncertain {
+		t.Fatalf("stream state = stream %v uncertain %v, want false and true", info.Stream, info.StreamUncertain)
 	}
 }
 


### PR DESCRIPTION
## Summary

- recover model hints from unknown-length/chunked opaque JSON bodies when the complete body fits the existing 64 KiB selector bound
- require complete, duplicate-key-safe selector parsing before model or provider metadata becomes authoritative
- preserve independently decoded stream intent for oversized bodies without promoting partial model selectors

## Implementation

The server keeps the trust decision at the ingress boundary. A model-only fast peek triggers one bounded complete-body verification pass. Complete bodies reuse the existing `ApplyBodySelectorHints` semantic operation; incomplete or ambiguous bodies do not populate model/provider metadata. A narrow `ApplyBodyStreamHint` operation preserves stream state without claiming that JSON or selector parsing completed.

The original body is reconstructed byte-for-byte before passthrough forwarding. Known bodies larger than 64 KiB skip the verification pass immediately; unknown-length bodies read at most 64 KiB plus one overflow byte.

This addresses the remaining request-body selector gap described in #332 without bringing over that PR's non-streaming response implementation, which was superseded by #709.

## Security

Partial model values are never used for authorization, admission, or audit identity. Complete verification rejects duplicate top-level `model`, `provider`, or `stream` fields, preventing the gateway selector from differing from the value interpreted upstream. This design incorporates the valid Greptile review finding on the initial revision.

## Validation

- `go test ./...`
- `make lint`
- repository pre-commit hooks, including race tests and the hot-path performance guard
- focused coverage for valid chunked bodies, oversized bodies in both selector orderings, duplicate selector fields, malformed bodies, trailing data, body restoration, and independent stream confidence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model and provider detection for incomplete or opaque request bodies.
  * Preserved request parsing and streaming state when only partial data is available.
  * Confirmed streaming requests while retaining detected model and provider routing information.
  * Rejected ambiguous, malformed, or duplicate selector fields instead of applying incomplete hints.

* **Tests**
  * Added regression coverage for complete and incomplete body handling, selector preservation, streaming state, and ambiguous request data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->