### PR TITLE
feat(models): add option to list bare model IDs at GET /v1/models

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -223,8 +223,8 @@
 # KEEP_ONLY_ALIASES_AT_MODELS_ENDPOINT=false
 # Return bare model IDs from GET /v1/models (gpt-5) instead of provider-qualified ones (openai/gpt-5) (default: false).
 # Useful for clients that validate the requested model against the list and only know plain names.
-# Caveat: when two providers expose the same model ID, only the first provider is listed and
-# an unqualified request routes there. Pin a name to a specific provider with a virtual model,
+# Caveat: when two providers expose the same model ID, only the provider an unqualified request
+# routes to (the first registered one) is listed. Pin a name to a specific provider with a virtual model,
 # e.g. source gpt-5 -> target azure/gpt-5.
 # UNQUALIFIED_MODEL_IDS_AT_MODELS_ENDPOINT=false
 # How providers.<name>.models and <PROVIDER>[_SUFFIX]_MODELS affect provider inventory.

--- a/.env.template
+++ b/.env.template
@@ -221,6 +221,12 @@
 # MODELS_ENABLED_BY_DEFAULT=true
 # Hide provider models from GET /v1/models and expose only enabled aliases (default: false).
 # KEEP_ONLY_ALIASES_AT_MODELS_ENDPOINT=false
+# Return bare model IDs from GET /v1/models (gpt-5) instead of provider-qualified ones (openai/gpt-5) (default: false).
+# Useful for clients that validate the requested model against the list and only know plain names.
+# Caveat: when two providers expose the same model ID, only the first provider is listed and
+# an unqualified request routes there. Pin a name to a specific provider with a virtual model,
+# e.g. source gpt-5 -> target azure/gpt-5.
+# UNQUALIFIED_MODEL_IDS_AT_MODELS_ENDPOINT=false
 # How providers.<name>.models and <PROVIDER>[_SUFFIX]_MODELS affect provider inventory.
 # fallback (default): use configured models only when upstream /models fails, is nil, or is empty.
 # allowlist: expose only the configured models for providers that define a list, and skip their upstream /models calls.

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -19,6 +19,8 @@ server:
 
 models:
   enabled_by_default: true # env: MODELS_ENABLED_BY_DEFAULT; when false, models stay unavailable until an access override allows one or more user paths
+  keep_only_aliases_at_models_endpoint: false # env: KEEP_ONLY_ALIASES_AT_MODELS_ENDPOINT; hide provider models from GET /v1/models and expose only enabled virtual models
+  unqualified_model_ids_at_models_endpoint: false # env: UNQUALIFIED_MODEL_IDS_AT_MODELS_ENDPOINT; list bare model IDs (gpt-5) instead of provider-qualified ones (openai/gpt-5). Caveat: when two providers expose the same model ID only the first provider is listed and unqualified requests route there; pin a name with a virtual model (source gpt-5 -> target azure/gpt-5)
   configured_provider_models_mode: "fallback" # env: CONFIGURED_PROVIDER_MODELS_MODE; "fallback" uses configured lists only when upstream /models is unavailable/empty, "allowlist" exposes only configured models and skips upstream /models for configured lists, "merge" adds configured models on top of the upstream inventory (for models a provider serves but does not list)
 
 # Tagging based on headers: label every request from the listed headers. Labels

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -20,7 +20,7 @@ server:
 models:
   enabled_by_default: true # env: MODELS_ENABLED_BY_DEFAULT; when false, models stay unavailable until an access override allows one or more user paths
   keep_only_aliases_at_models_endpoint: false # env: KEEP_ONLY_ALIASES_AT_MODELS_ENDPOINT; hide provider models from GET /v1/models and expose only enabled virtual models
-  unqualified_model_ids_at_models_endpoint: false # env: UNQUALIFIED_MODEL_IDS_AT_MODELS_ENDPOINT; list bare model IDs (gpt-5) instead of provider-qualified ones (openai/gpt-5). Caveat: when two providers expose the same model ID only the first provider is listed and unqualified requests route there; pin a name with a virtual model (source gpt-5 -> target azure/gpt-5)
+  unqualified_model_ids_at_models_endpoint: false # env: UNQUALIFIED_MODEL_IDS_AT_MODELS_ENDPOINT; list bare model IDs (gpt-5) instead of provider-qualified ones (openai/gpt-5). Caveat: when two providers expose the same model ID only the provider an unqualified request routes to (the first registered one) is listed; pin a name with a virtual model (source gpt-5 -> target azure/gpt-5)
   configured_provider_models_mode: "fallback" # env: CONFIGURED_PROVIDER_MODELS_MODE; "fallback" uses configured lists only when upstream /models is unavailable/empty, "allowlist" exposes only configured models and skips upstream /models for configured lists, "merge" adds configured models on top of the upstream inventory (for models a provider serves but does not list)
 
 # Tagging based on headers: label every request from the listed headers. Labels

--- a/config/config.go
+++ b/config/config.go
@@ -112,9 +112,10 @@ func buildDefaultConfig() *Config {
 			},
 		},
 		Models: ModelsConfig{
-			EnabledByDefault:                true,
-			KeepOnlyAliasesAtModelsEndpoint: false,
-			ConfiguredProviderModelsMode:    ConfiguredProviderModelsModeFallback,
+			EnabledByDefault:                    true,
+			KeepOnlyAliasesAtModelsEndpoint:     false,
+			UnqualifiedModelIDsAtModelsEndpoint: false,
+			ConfiguredProviderModelsMode:        ConfiguredProviderModelsModeFallback,
 		},
 		Cache: CacheConfig{
 			Model: ModelCacheConfig{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -88,7 +88,7 @@ func clearAllConfigEnvVars(t *testing.T) {
 		"DASHBOARD_LIVE_LOGS_REPLAY_LIMIT", "DASHBOARD_LIVE_LOGS_HEARTBEAT_SECONDS",
 		"GUARDRAILS_ENABLED", "ENABLE_GUARDRAILS_FOR_BATCH_PROCESSING",
 		"FAILOVER_MODE", "FAILOVER_MANUAL_RULES_PATH", "FAILOVER_ENABLED", "FAILOVER_RULES_JSON", "FAILOVER_DISABLED_MODELS", "FAILOVER_DISABLED_MODELS_JSON",
-		"MODELS_ENABLED_BY_DEFAULT", "KEEP_ONLY_ALIASES_AT_MODELS_ENDPOINT", "CONFIGURED_PROVIDER_MODELS_MODE",
+		"MODELS_ENABLED_BY_DEFAULT", "KEEP_ONLY_ALIASES_AT_MODELS_ENDPOINT", "UNQUALIFIED_MODEL_IDS_AT_MODELS_ENDPOINT", "CONFIGURED_PROVIDER_MODELS_MODE",
 		"HTTP_TIMEOUT", "HTTP_RESPONSE_HEADER_TIMEOUT",
 		"WORKFLOW_REFRESH_INTERVAL",
 	} {
@@ -248,6 +248,9 @@ func TestBuildDefaultConfig(t *testing.T) {
 	}
 	if cfg.Models.KeepOnlyAliasesAtModelsEndpoint {
 		t.Error("expected Models.KeepOnlyAliasesAtModelsEndpoint=false")
+	}
+	if cfg.Models.UnqualifiedModelIDsAtModelsEndpoint {
+		t.Error("expected Models.UnqualifiedModelIDsAtModelsEndpoint=false")
 	}
 	if cfg.Guardrails.EnableForBatchProcessing {
 		t.Error("expected Guardrails.EnableForBatchProcessing=false")
@@ -705,6 +708,7 @@ server:
 models:
   enabled_by_default: false
   keep_only_aliases_at_models_endpoint: true
+  unqualified_model_ids_at_models_endpoint: true
   configured_provider_models_mode: allowlist
 cache:
   model:
@@ -738,6 +742,9 @@ logging:
 		}
 		if !cfg.Models.KeepOnlyAliasesAtModelsEndpoint {
 			t.Error("expected Models.KeepOnlyAliasesAtModelsEndpoint=true from YAML")
+		}
+		if !cfg.Models.UnqualifiedModelIDsAtModelsEndpoint {
+			t.Error("expected Models.UnqualifiedModelIDsAtModelsEndpoint=true from YAML")
 		}
 		if cfg.Models.ConfiguredProviderModelsMode != ConfiguredProviderModelsModeAllowlist {
 			t.Errorf("expected Models.ConfiguredProviderModelsMode=allowlist from YAML, got %q", cfg.Models.ConfiguredProviderModelsMode)
@@ -1422,6 +1429,7 @@ func TestLoad_EnvOverridesDefaults(t *testing.T) {
 		t.Setenv("PORT", "5555")
 		t.Setenv("MODELS_ENABLED_BY_DEFAULT", "false")
 		t.Setenv("KEEP_ONLY_ALIASES_AT_MODELS_ENDPOINT", "true")
+		t.Setenv("UNQUALIFIED_MODEL_IDS_AT_MODELS_ENDPOINT", "true")
 		t.Setenv("CONFIGURED_PROVIDER_MODELS_MODE", "allowlist")
 		t.Setenv("USAGE_PRICING_RECALCULATION_ENABLED", "false")
 		t.Setenv("STORAGE_TYPE", "postgresql")
@@ -1442,6 +1450,9 @@ func TestLoad_EnvOverridesDefaults(t *testing.T) {
 		}
 		if !cfg.Models.KeepOnlyAliasesAtModelsEndpoint {
 			t.Error("expected aliases-only models endpoint from env")
+		}
+		if !cfg.Models.UnqualifiedModelIDsAtModelsEndpoint {
+			t.Error("expected unqualified model IDs at models endpoint from env")
 		}
 		if cfg.Models.ConfiguredProviderModelsMode != ConfiguredProviderModelsModeAllowlist {
 			t.Errorf("expected configured provider models mode allowlist from env, got %q", cfg.Models.ConfiguredProviderModelsMode)

--- a/config/models.go
+++ b/config/models.go
@@ -14,6 +14,13 @@ type ModelsConfig struct {
 	// Default: false.
 	KeepOnlyAliasesAtModelsEndpoint bool `yaml:"keep_only_aliases_at_models_endpoint" env:"KEEP_ONLY_ALIASES_AT_MODELS_ENDPOINT"`
 
+	// UnqualifiedModelIDsAtModelsEndpoint controls whether GET /v1/models
+	// returns bare model IDs (gpt-5) instead of provider-qualified ones
+	// (openai/gpt-5). When two providers expose the same model ID, only the
+	// entry for the provider an unqualified request routes to is listed.
+	// Default: false.
+	UnqualifiedModelIDsAtModelsEndpoint bool `yaml:"unqualified_model_ids_at_models_endpoint" env:"UNQUALIFIED_MODEL_IDS_AT_MODELS_ENDPOINT"`
+
 	// ConfiguredProviderModelsMode controls how providers.<name>.models and
 	// provider *_MODELS env vars affect the provider model inventory.
 	// Supported values: "fallback", "allowlist", "merge". Default: "fallback".

--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -324,6 +324,16 @@ providers that define a list and skip their upstream `/models` calls. YAML
 `providers.<name>.models` provides the same model-list input for named provider
 blocks.
 
+`GET /v1/models` lists provider-qualified IDs (`openai/gpt-5`) by default. Set
+`UNQUALIFIED_MODEL_IDS_AT_MODELS_ENDPOINT=true` (YAML:
+`models.unqualified_model_ids_at_models_endpoint`) to list bare model IDs
+(`gpt-5`) instead, for clients that validate the requested model against the
+list and only know plain names. Caveat: when two providers expose the same
+model ID, only the first provider is listed and an unqualified request routes
+there. Pin a name to a specific provider with a
+[virtual model](/features/virtual-models#list-bare-model-ids), for example
+`source: gpt-5` with `target: azure/gpt-5`.
+
 To narrow a provider's inventory instead of listing it model by model, use
 `<PROVIDER>_MODEL_FILTER_INCLUDE`, `<PROVIDER>_MODEL_FILTER_EXCLUDE`, and
 `<PROVIDER>_MODEL_FILTER_MAX_PRICE_PER_MTOK` (YAML:
@@ -510,6 +520,10 @@ models:
   # configured models on top of the discovered inventory (models a provider
   # serves but does not list).
   configured_provider_models_mode: fallback
+  # List bare model IDs (gpt-5) from GET /v1/models instead of provider-qualified
+  # ones (openai/gpt-5). When two providers expose the same ID only the first
+  # provider is listed; pin a name with a virtual model (source gpt-5 -> target azure/gpt-5).
+  unqualified_model_ids_at_models_endpoint: false
 
 providers:
   # Override OpenAI base URL

--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -329,8 +329,8 @@ blocks.
 `models.unqualified_model_ids_at_models_endpoint`) to list bare model IDs
 (`gpt-5`) instead, for clients that validate the requested model against the
 list and only know plain names. Caveat: when two providers expose the same
-model ID, only the first provider is listed and an unqualified request routes
-there. Pin a name to a specific provider with a
+model ID, only the provider an unqualified request routes to (the first
+registered one) is listed. Pin a name to a specific provider with a
 [virtual model](/features/virtual-models#list-bare-model-ids), for example
 `source: gpt-5` with `target: azure/gpt-5`.
 
@@ -521,8 +521,9 @@ models:
   # serves but does not list).
   configured_provider_models_mode: fallback
   # List bare model IDs (gpt-5) from GET /v1/models instead of provider-qualified
-  # ones (openai/gpt-5). When two providers expose the same ID only the first
-  # provider is listed; pin a name with a virtual model (source gpt-5 -> target azure/gpt-5).
+  # ones (openai/gpt-5). When two providers expose the same ID only the provider an
+  # unqualified request routes to (the first registered one) is listed; pin a name
+  # with a virtual model (source gpt-5 -> target azure/gpt-5).
   unqualified_model_ids_at_models_endpoint: false
 
 providers:

--- a/docs/features/virtual-models.mdx
+++ b/docs/features/virtual-models.mdx
@@ -279,8 +279,8 @@ The `owned_by` field still carries the provider name. Requests for a bare model
 ID keep working the same way in both modes.
 
 Caveat: when two providers expose the same model ID (for example `gpt-5` on both
-`openai` and `azure`), only the first registered provider is listed and an
-unqualified request routes there. To pin a name to a specific provider, add a
+`openai` and `azure`), only the provider an unqualified request routes to (the
+first registered one) is listed. To pin a name to a specific provider, add a
 virtual model with that name as its source:
 
 ```yaml

--- a/docs/features/virtual-models.mdx
+++ b/docs/features/virtual-models.mdx
@@ -265,6 +265,32 @@ When this is enabled, GoModel returns enabled redirects from `/v1/models`
 instead of the full provider model list. The setting is also listed in
 `.env.template`.
 
+## List bare model IDs
+
+By default `GET /v1/models` returns provider-qualified IDs such as
+`openai/gpt-5`. Some clients validate the model you configure against that list
+and only know plain names, so they never match. To list bare IDs instead, set:
+
+```env
+UNQUALIFIED_MODEL_IDS_AT_MODELS_ENDPOINT=true
+```
+
+The `owned_by` field still carries the provider name. Requests for a bare model
+ID keep working the same way in both modes.
+
+Caveat: when two providers expose the same model ID (for example `gpt-5` on both
+`openai` and `azure`), only the first registered provider is listed and an
+unqualified request routes there. To pin a name to a specific provider, add a
+virtual model with that name as its source:
+
+```yaml
+virtual_models:
+  - source: gpt-5
+    target: azure/gpt-5
+```
+
+The redirect wins over the provider entry in both the model list and routing.
+
 ## Shadow a model
 
 A redirect can "shadow" a model by using the same name as an existing model and

--- a/internal/providers/init.go
+++ b/internal/providers/init.go
@@ -183,6 +183,7 @@ func Init(ctx context.Context, result *config.LoadResult, factory *ProviderFacto
 		modelCache.Close()
 		return nil, fmt.Errorf("failed to create router: %w", err)
 	}
+	router.SetUnqualifiedModelIDs(result.Config.Models.UnqualifiedModelIDsAtModelsEndpoint)
 
 	return &InitResult{
 		ConfiguredProviders:         SanitizeProviderConfigs(providerMap),

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -598,6 +598,30 @@ func (r *ModelRegistry) ListPublicModels() []core.Model {
 	return result
 }
 
+// ListUnqualifiedPublicModels returns advertised models under their bare
+// model IDs, sorted by ID. When several providers expose the same model ID,
+// only the provider an unqualified request resolves to (the global catalog
+// entry, see rebuildGlobalModelMap) is listed, so the response never
+// advertises an ID that would route somewhere else. OwnedBy carries the
+// provider name so callers can still tell which provider serves the model.
+func (r *ModelRegistry) ListUnqualifiedPublicModels() []core.Model {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make([]core.Model, 0, len(r.models))
+	for modelID, info := range r.models {
+		if !r.providerAdvertisedLocked(info.ProviderName) || !providerCanServeModel(info) {
+			continue
+		}
+		model := info.Model
+		model.ID = modelID
+		model.OwnedBy = info.ProviderName
+		result = append(result, model)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].ID < result[j].ID })
+	return result
+}
+
 // providerCanServeModel reports whether the owning provider implements the
 // capabilities a model needs. Upstream inventories and the metadata registry
 // can list audio-only (TTS/STT) or image-only models for providers whose

--- a/internal/providers/router.go
+++ b/internal/providers/router.go
@@ -23,6 +23,9 @@ var ErrRegistryNotInitialized = fmt.Errorf("model registry has no models: ensure
 type Router struct {
 	lookup       core.ModelLookup
 	cachePlanner *cachePlanner
+	// unqualifiedModelIDs makes ListModels advertise bare model IDs instead of
+	// provider-qualified ones.
+	unqualifiedModelIDs bool
 }
 
 type providerTypeRegistry interface {
@@ -47,6 +50,10 @@ type providerNameLister interface {
 
 type publicModelLister interface {
 	ListPublicModels() []core.Model
+}
+
+type unqualifiedPublicModelLister interface {
+	ListUnqualifiedPublicModels() []core.Model
 }
 
 type modelWithProviderLister interface {
@@ -80,6 +87,12 @@ func NewRouter(lookup core.ModelLookup) (*Router, error) {
 		lookup:       lookup,
 		cachePlanner: newCachePlanner(),
 	}, nil
+}
+
+// SetUnqualifiedModelIDs controls whether ListModels advertises bare model IDs
+// (gpt-5) instead of provider-qualified ones (openai/gpt-5).
+func (r *Router) SetUnqualifiedModelIDs(enabled bool) {
+	r.unqualifiedModelIDs = enabled
 }
 
 // checkReady verifies the lookup has models available.
@@ -704,7 +717,9 @@ func (r *Router) ListModels(_ context.Context) (*core.ModelsResponse, error) {
 		return nil, registryUnavailableError(err)
 	}
 	var models []core.Model
-	if public, ok := r.lookup.(publicModelLister); ok {
+	if unqualified, ok := r.lookup.(unqualifiedPublicModelLister); ok && r.unqualifiedModelIDs {
+		models = unqualified.ListUnqualifiedPublicModels()
+	} else if public, ok := r.lookup.(publicModelLister); ok {
 		models = public.ListPublicModels()
 	} else {
 		models = r.lookup.ListModels()

--- a/internal/providers/router_test.go
+++ b/internal/providers/router_test.go
@@ -1818,3 +1818,45 @@ func TestRouterPassthrough_UsesProviderRegistryWithoutModels(t *testing.T) {
 		t.Fatal("provider did not receive passthrough request")
 	}
 }
+
+func TestRouterListModelsUnqualifiedIDs(t *testing.T) {
+	registry := newTestRegistryWithModels(
+		registryModelEntry{provider: &mockProvider{}, providerName: "openai", providerType: "openai", modelID: "gpt-5"},
+		registryModelEntry{provider: &mockProvider{}, providerName: "azure", providerType: "azure", modelID: "gpt-5"},
+		registryModelEntry{provider: &mockProvider{}, providerName: "anthropic", providerType: "anthropic", modelID: "claude-sonnet-4-6"},
+	)
+	router, err := NewRouter(registry)
+	if err != nil {
+		t.Fatalf("NewRouter: %v", err)
+	}
+
+	resp, err := router.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	if len(resp.Data) != 3 {
+		t.Fatalf("expected 3 qualified models by default, got %d", len(resp.Data))
+	}
+
+	router.SetUnqualifiedModelIDs(true)
+	resp, err = router.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	if len(resp.Data) != 2 {
+		t.Fatalf("expected 2 deduplicated models, got %d: %+v", len(resp.Data), resp.Data)
+	}
+	for _, m := range resp.Data {
+		if strings.Contains(m.ID, "/") {
+			t.Errorf("expected bare model ID, got %q", m.ID)
+		}
+	}
+	if resp.Data[0].ID != "claude-sonnet-4-6" || resp.Data[0].OwnedBy != "anthropic" {
+		t.Errorf("unexpected first entry: %+v", resp.Data[0])
+	}
+	// The listed owner must be the provider an unqualified request routes to.
+	want := registry.GetProviderName("gpt-5")
+	if resp.Data[1].ID != "gpt-5" || resp.Data[1].OwnedBy != want {
+		t.Errorf("expected gpt-5 owned by routing winner %q, got %+v", want, resp.Data[1])
+	}
+}


### PR DESCRIPTION
Adds `UNQUALIFIED_MODEL_IDS_AT_MODELS_ENDPOINT` (YAML: `models.unqualified_model_ids_at_models_endpoint`, default `false`). When `true`, `GET /v1/models` returns bare model IDs (`gpt-5`) instead of provider-qualified ones (`openai/gpt-5`); `owned_by` still carries the provider name. Fixes the "model not found" problem in clients that validate the configured model against the list and only know plain names.

When two providers expose the same model ID, only the provider an unqualified request routes to is listed (read from the registry's global catalog, so listing and routing always agree). Pin a name to a specific provider with a virtual model, e.g. `source: gpt-5` → `target: azure/gpt-5`. The caveat is documented in `.env.template`, `config.example.yaml`, and the docs.

Supersedes #333 (predates the current registry; its "first provider" was map-iteration order and could disagree with routing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to list bare model IDs in `GET /v1/models` instead of provider-qualified IDs.
  * Provider information remains available through the model ownership field.
  * Duplicate model IDs are deduplicated and route to the selected provider.
  * Virtual models can pin a model name to a specific provider.

* **Documentation**
  * Added configuration and usage guidance, including environment and YAML settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->