### PR TITLE
feat(failover): make retry statuses, error phrases, and max attempts configurable

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -267,11 +267,11 @@
 # Cap on failover targets tried per request; 0 (default) sweeps every remaining target.
 # FAILOVER_MAX_ATTEMPTS=0
 # Upstream statuses that trigger failover (exact codes or a class like 5xx).
-# Setting it replaces the default 429,5xx.
+# A non-empty value replaces the default 429,5xx.
 # FAILOVER_RETRY_ON_STATUSES=429,5xx
 # Error phrases that trigger failover regardless of status; every word of a phrase
 # must appear in the error (a numeric word like 404 matches the status instead).
-# Setting it replaces the default "model not found"-style, "upstream failed", and
+# A non-empty value replaces the default "model not found"-style, "upstream failed", and
 # retired-model 404 phrases. See docs/features/failover.mdx for the full default.
 # FAILOVER_RETRY_ON_ERRORS=model not found,upstream failed,404 deprecated
 # Deprecated: inline rules are translated into managed failover-strategy virtual

--- a/.env.template
+++ b/.env.template
@@ -264,6 +264,16 @@
 # redirect's remaining targets are tried in order (use strategy "failover" for a
 # strict priority list). Enabled by default; false switches the sweep off globally.
 # FAILOVER_ENABLED=true
+# Cap on failover targets tried per request; 0 (default) sweeps every remaining target.
+# FAILOVER_MAX_ATTEMPTS=0
+# Upstream statuses that trigger failover (exact codes or a class like 5xx).
+# Setting it replaces the default 429,5xx.
+# FAILOVER_RETRY_ON_STATUSES=429,5xx
+# Error phrases that trigger failover regardless of status; every word of a phrase
+# must appear in the error (a numeric word like 404 matches the status instead).
+# Setting it replaces the default "model not found"-style, "upstream failed", and
+# retired-model 404 phrases. See docs/features/failover.mdx for the full default.
+# FAILOVER_RETRY_ON_ERRORS=model not found,upstream failed,404 deprecated
 # Deprecated: inline rules are translated into managed failover-strategy virtual
 # models shadowing the primary model. Declare them in VIRTUAL_MODELS instead.
 # FAILOVER_RULES_JSON={"gpt-4o":["azure/gpt-4o","gemini/gemini-2.5-pro"]}

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -343,12 +343,13 @@ failover:
   # fails. 0 (default) sweeps every remaining target in order.
   # max_attempts: 0 # env: FAILOVER_MAX_ATTEMPTS
   # Upstream HTTP statuses that trigger failover: exact codes or a class such
-  # as 5xx. Listing any replaces the default [429, 5xx] entirely.
+  # as 5xx. A non-empty list replaces the default [429, 5xx] entirely; an
+  # empty list keeps the default.
   # retry_on_statuses: [429, 5xx] # env: FAILOVER_RETRY_ON_STATUSES=429,5xx
   # Error phrases that trigger failover whatever the status: every word must
   # appear in the error code or message (case-insensitive); a numeric word
-  # such as 404 or 4xx constrains the status instead. Listing any replaces the
-  # default, which covers "model not found / unsupported / deprecated" style
+  # such as 404 or 4xx constrains the status instead. A non-empty list replaces
+  # the default (an empty one keeps it), which covers "model not found / unsupported / deprecated" style
   # errors, aggregator "upstream failed" 4xx relays, and retired-model 404s.
   # retry_on_errors: ["model not found", "upstream failed", "404 deprecated"] # env: FAILOVER_RETRY_ON_ERRORS (comma-separated)
   # Deprecated: `rules`, `manual_rules_path`, `rules_json`, and `disabled_models`

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -339,6 +339,18 @@ guardrails:
 # failover sweep off for every request.
 failover:
   enabled: true # env: FAILOVER_ENABLED; default true
+  # How many failover targets one request may try after its first attempt
+  # fails. 0 (default) sweeps every remaining target in order.
+  # max_attempts: 0 # env: FAILOVER_MAX_ATTEMPTS
+  # Upstream HTTP statuses that trigger failover: exact codes or a class such
+  # as 5xx. Listing any replaces the default [429, 5xx] entirely.
+  # retry_on_statuses: [429, 5xx] # env: FAILOVER_RETRY_ON_STATUSES=429,5xx
+  # Error phrases that trigger failover whatever the status: every word must
+  # appear in the error code or message (case-insensitive); a numeric word
+  # such as 404 or 4xx constrains the status instead. Listing any replaces the
+  # default, which covers "model not found / unsupported / deprecated" style
+  # errors, aggregator "upstream failed" 4xx relays, and retired-model 404s.
+  # retry_on_errors: ["model not found", "upstream failed", "404 deprecated"] # env: FAILOVER_RETRY_ON_ERRORS (comma-separated)
   # Deprecated: `rules`, `manual_rules_path`, `rules_json`, and `disabled_models`
   # still load and are translated into managed failover-strategy virtual models
   # that shadow the primary model. Move them under virtual_models.

--- a/config/failover.go
+++ b/config/failover.go
@@ -48,6 +48,23 @@ type FailoverConfig struct {
 	// and workflow policy decide whether any request has failover candidates.
 	Enabled bool `yaml:"enabled" env:"FAILOVER_ENABLED"`
 
+	// MaxAttempts caps how many failover targets one request may try after
+	// its primary attempt fails. Zero (the default) sweeps every remaining
+	// target in order.
+	MaxAttempts int `yaml:"max_attempts" env:"FAILOVER_MAX_ATTEMPTS"`
+
+	// RetryOnStatuses lists the upstream HTTP statuses that trigger failover:
+	// exact codes (408) or whole classes (5xx). Setting it replaces the
+	// default DefaultFailoverRetryStatuses; an empty list keeps the default.
+	RetryOnStatuses []string `yaml:"retry_on_statuses" env:"FAILOVER_RETRY_ON_STATUSES"`
+
+	// RetryOnErrors lists phrases that trigger failover regardless of status:
+	// an error qualifies when every word of a phrase appears in its code or
+	// message. A numeric word (404, 4xx) matches the HTTP status instead of
+	// the text. Setting it replaces the default DefaultFailoverRetryErrors; an
+	// empty list keeps the default.
+	RetryOnErrors []string `yaml:"retry_on_errors" env:"FAILOVER_RETRY_ON_ERRORS"`
+
 	// DefaultMode is a deprecated compatibility field. It is accepted from old
 	// config files and FAILOVER_MODE, but runtime failover is manual-only.
 	DefaultMode FailoverMode `yaml:"default_mode" env:"FAILOVER_MODE"`
@@ -79,6 +96,14 @@ type FailoverConfig struct {
 
 	// Disabled holds normalized per-model failover disables.
 	Disabled map[string]bool `yaml:"-"`
+
+	// RetryStatuses is the parsed RetryOnStatuses (or its default): the set of
+	// HTTP statuses that trigger failover.
+	RetryStatuses map[int]bool `yaml:"-"`
+
+	// RetryErrors is the parsed RetryOnErrors (or its default): one lower-cased
+	// word list per phrase.
+	RetryErrors []FailoverErrorPhrase `yaml:"-"`
 }
 
 func loadFailoverConfig(cfg *FailoverConfig) error {
@@ -103,6 +128,25 @@ func loadFailoverConfig(cfg *FailoverConfig) error {
 		return err
 	}
 	cfg.Disabled = disabled
+	return LoadFailoverPolicy(cfg)
+}
+
+// LoadFailoverPolicy validates the retry policy fields of cfg and fills the
+// parsed RetryStatuses and RetryErrors, applying the defaults for empty lists.
+func LoadFailoverPolicy(cfg *FailoverConfig) error {
+	if cfg.MaxAttempts < 0 {
+		return fmt.Errorf("failover.max_attempts: must be zero or positive, got %d", cfg.MaxAttempts)
+	}
+	statuses, err := parseFailoverRetryStatuses(cfg.RetryOnStatuses)
+	if err != nil {
+		return err
+	}
+	cfg.RetryStatuses = statuses
+	phrases, err := parseFailoverRetryErrors(cfg.RetryOnErrors)
+	if err != nil {
+		return err
+	}
+	cfg.RetryErrors = phrases
 	return nil
 }
 

--- a/config/failover_policy.go
+++ b/config/failover_policy.go
@@ -1,0 +1,120 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// DefaultFailoverRetryStatuses is the failover.retry_on_statuses default: rate
+// limits and every server-side failure.
+var DefaultFailoverRetryStatuses = []string{"429", "5xx"}
+
+// DefaultFailoverRetryErrors is the failover.retry_on_errors default. The
+// phrases cover a model that is gone or refused whatever status the provider
+// chose, an aggregator provider relaying a failure of its own upstream behind
+// a 4xx, and retired-model 404s that avoid the word "model". Plain endpoint
+// 404s and validation errors match none of them.
+var DefaultFailoverRetryErrors = []string{
+	"model not found",
+	"model does not exist",
+	"model unsupported",
+	"model unavailable",
+	"model not available",
+	"model deprecated",
+	"model retired",
+	"model disabled",
+	"upstream failed",
+	"upstream error",
+	"upstream unavailable",
+	"upstream timed out",
+	"upstream timeout",
+	"404 unsupported",
+	"404 unavailable",
+	"404 not available",
+	"404 deprecated",
+	"404 retired",
+	"404 disabled",
+}
+
+// FailoverErrorPhrase is one parsed retry_on_errors entry. Every Word must
+// appear in the error text and every status constraint must hold.
+type FailoverErrorPhrase struct {
+	// Words are the lower-cased text fragments the error must contain.
+	Words []string
+	// Statuses are HTTP statuses the error must carry; empty means any.
+	Statuses map[int]bool
+}
+
+// parseFailoverRetryStatuses expands status entries into the set of matching
+// HTTP status codes. An empty list yields the default.
+func parseFailoverRetryStatuses(entries []string) (map[int]bool, error) {
+	if len(entries) == 0 {
+		entries = DefaultFailoverRetryStatuses
+	}
+	statuses := make(map[int]bool)
+	for _, entry := range entries {
+		codes, ok := expandStatusToken(entry)
+		if !ok {
+			return nil, fmt.Errorf("failover.retry_on_statuses: %q is not an HTTP status code or class such as 5xx", entry)
+		}
+		for _, code := range codes {
+			statuses[code] = true
+		}
+	}
+	return statuses, nil
+}
+
+// parseFailoverRetryErrors lower-cases each phrase into its word list, lifting
+// numeric words into status constraints. An empty list yields the default.
+func parseFailoverRetryErrors(entries []string) ([]FailoverErrorPhrase, error) {
+	if len(entries) == 0 {
+		entries = DefaultFailoverRetryErrors
+	}
+	phrases := make([]FailoverErrorPhrase, 0, len(entries))
+	for _, entry := range entries {
+		var phrase FailoverErrorPhrase
+		for word := range strings.FieldsSeq(strings.ToLower(entry)) {
+			if codes, ok := expandStatusToken(word); ok {
+				if phrase.Statuses == nil {
+					phrase.Statuses = make(map[int]bool, len(codes))
+				}
+				for _, code := range codes {
+					phrase.Statuses[code] = true
+				}
+				continue
+			}
+			phrase.Words = append(phrase.Words, word)
+		}
+		if len(phrase.Words) == 0 {
+			return nil, fmt.Errorf("failover.retry_on_errors: %q must contain at least one non-numeric word", entry)
+		}
+		phrases = append(phrases, phrase)
+	}
+	return phrases, nil
+}
+
+// expandStatusToken turns "503" into [503] and "5xx" into 500..599. It reports
+// false for anything else.
+func expandStatusToken(token string) ([]int, bool) {
+	token = strings.ToLower(strings.TrimSpace(token))
+	if len(token) != 3 {
+		return nil, false
+	}
+	if strings.HasSuffix(token, "xx") {
+		class := int(token[0] - '0')
+		if class < 1 || class > 5 {
+			return nil, false
+		}
+		codes := make([]int, 0, 100)
+		for code := class * 100; code < (class+1)*100; code++ {
+			codes = append(codes, code)
+		}
+		return codes, true
+	}
+	code, err := strconv.Atoi(token)
+	if err != nil || code < 100 || code > 599 {
+		return nil, false
+	}
+	return []int{code}, true
+}

--- a/config/failover_policy_test.go
+++ b/config/failover_policy_test.go
@@ -1,0 +1,139 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseFailoverRetryStatuses(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []string
+		want    []int
+		wantNot []int
+		wantErr string
+	}{
+		{"default", nil, []int{429, 500, 529, 599}, []int{408, 404, 400}, ""},
+		{"exact codes", []string{"408", "503"}, []int{408, 503}, []int{429, 500}, ""},
+		{"class", []string{"4xx"}, []int{400, 429, 499}, []int{500}, ""},
+		{"mixed case class", []string{"5XX"}, []int{500}, nil, ""},
+		{"invalid code", []string{"999"}, nil, nil, "not an HTTP status code"},
+		{"invalid class", []string{"6xx"}, nil, nil, "not an HTTP status code"},
+		{"garbage", []string{"abc"}, nil, nil, "not an HTTP status code"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseFailoverRetryStatuses(tt.entries)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			for _, code := range tt.want {
+				if !got[code] {
+					t.Errorf("status %d missing", code)
+				}
+			}
+			for _, code := range tt.wantNot {
+				if got[code] {
+					t.Errorf("status %d unexpectedly present", code)
+				}
+			}
+		})
+	}
+}
+
+func TestParseFailoverRetryErrors(t *testing.T) {
+	phrases, err := parseFailoverRetryErrors([]string{"Model Not Found", "404 deprecated", "4xx upstream"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(phrases) != 3 {
+		t.Fatalf("got %d phrases, want 3", len(phrases))
+	}
+	if got := strings.Join(phrases[0].Words, " "); got != "model not found" || phrases[0].Statuses != nil {
+		t.Errorf("phrase 0 = %+v, want lower-cased words and no status", phrases[0])
+	}
+	if got := strings.Join(phrases[1].Words, " "); got != "deprecated" || !phrases[1].Statuses[404] || phrases[1].Statuses[400] {
+		t.Errorf("phrase 1 = %+v, want word 'deprecated' scoped to 404", phrases[1])
+	}
+	if !phrases[2].Statuses[400] || !phrases[2].Statuses[499] || phrases[2].Statuses[500] {
+		t.Errorf("phrase 2 = %+v, want status class 4xx", phrases[2])
+	}
+
+	if defaults, err := parseFailoverRetryErrors(nil); err != nil || len(defaults) != len(DefaultFailoverRetryErrors) {
+		t.Errorf("empty list: got %d phrases, err %v; want the %d defaults", len(defaults), err, len(DefaultFailoverRetryErrors))
+	}
+	if _, err := parseFailoverRetryErrors([]string{"404"}); err == nil {
+		t.Error("a status-only phrase must be rejected")
+	}
+	if _, err := parseFailoverRetryErrors([]string{"  "}); err == nil {
+		t.Error("a blank phrase must be rejected")
+	}
+}
+
+func TestLoadFailoverConfig_Policy(t *testing.T) {
+	cfg := FailoverConfig{Enabled: true}
+	if err := loadFailoverConfig(&cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.MaxAttempts != 0 || !cfg.RetryStatuses[429] || !cfg.RetryStatuses[502] || len(cfg.RetryErrors) == 0 {
+		t.Errorf("defaults not applied: %+v", cfg)
+	}
+
+	cfg = FailoverConfig{Enabled: true, MaxAttempts: -1}
+	if err := loadFailoverConfig(&cfg); err == nil || !strings.Contains(err.Error(), "max_attempts") {
+		t.Errorf("negative max_attempts: err = %v", err)
+	}
+
+	cfg = FailoverConfig{Enabled: true, RetryOnStatuses: []string{"503"}, RetryOnErrors: []string{"overloaded"}}
+	if err := loadFailoverConfig(&cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.RetryStatuses[429] || !cfg.RetryStatuses[503] || len(cfg.RetryErrors) != 1 {
+		t.Errorf("overrides must replace defaults: %+v", cfg)
+	}
+}
+
+func TestLoadFailoverPolicy_FromYAML(t *testing.T) {
+	var cfg FailoverConfig
+	withTempDir(t, func(dir string) {
+		writeConfigYAML(t, dir, "failover:\n  max_attempts: 2\n  retry_on_statuses: [408, 5xx]\n  retry_on_errors: [\"model not found\", overloaded]\n")
+		result, err := Load()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		cfg = result.Config.Failover
+	})
+	if cfg.MaxAttempts != 2 {
+		t.Errorf("MaxAttempts = %d, want 2", cfg.MaxAttempts)
+	}
+	if !cfg.RetryStatuses[408] || !cfg.RetryStatuses[503] || cfg.RetryStatuses[429] {
+		t.Errorf("RetryStatuses = %v, want 408 and 5xx only", cfg.RetryStatuses)
+	}
+	if len(cfg.RetryErrors) != 2 || strings.Join(cfg.RetryErrors[1].Words, " ") != "overloaded" {
+		t.Errorf("RetryErrors = %+v, want the two configured phrases", cfg.RetryErrors)
+	}
+}
+
+func TestLoadFailoverPolicy_FromEnv(t *testing.T) {
+	t.Setenv("FAILOVER_MAX_ATTEMPTS", "3")
+	t.Setenv("FAILOVER_RETRY_ON_STATUSES", "503, 4xx")
+	t.Setenv("FAILOVER_RETRY_ON_ERRORS", "overloaded,404 gone")
+
+	result, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cfg := result.Config.Failover
+	if cfg.MaxAttempts != 3 || !cfg.RetryStatuses[503] || !cfg.RetryStatuses[400] || cfg.RetryStatuses[500] {
+		t.Errorf("env policy not applied: max=%d statuses=%v", cfg.MaxAttempts, cfg.RetryStatuses)
+	}
+	if len(cfg.RetryErrors) != 2 || !cfg.RetryErrors[1].Statuses[404] {
+		t.Errorf("RetryErrors = %+v, want two phrases with the second scoped to 404", cfg.RetryErrors)
+	}
+}

--- a/docs/features/failover.mdx
+++ b/docs/features/failover.mdx
@@ -95,6 +95,68 @@ Set `FAILOVER_ENABLED=false` (or `failover.enabled: false`) to switch the
 sweep off globally; a [workflow](/advanced/workflows) can also turn it off for
 its scope. The chosen target is still served, without retries.
 
+## Tune the failover policy
+
+The defaults above fit most deployments. Three settings under `failover`
+(or the matching environment variables) adjust them:
+
+| Setting | Env | Default | Meaning |
+| --- | --- | --- | --- |
+| `max_attempts` | `FAILOVER_MAX_ATTEMPTS` | `0` (all remaining targets) | How many failover targets one request may try after its first attempt fails. Targets skipped without a call (a saturated rate limit) do not count. |
+| `retry_on_statuses` | `FAILOVER_RETRY_ON_STATUSES` | `[429, 5xx]` | Upstream HTTP statuses that trigger failover: exact codes (`408`) or a whole class (`5xx`). |
+| `retry_on_errors` | `FAILOVER_RETRY_ON_ERRORS` | see below | Error phrases that trigger failover whatever the status. |
+
+Each list **replaces** its default when set, so repeat the defaults you want
+to keep. In the environment, separate entries with commas.
+
+A `retry_on_errors` phrase matches when every one of its words appears in the
+error code or message (case-insensitive, substring): `model not found`
+matches `The model 'gpt-9' was not found`. A numeric word — `404` or `4xx` —
+constrains the HTTP status instead of the text, so `404 deprecated` matches a
+404 whose message mentions "deprecated" and nothing else. The default list is:
+
+```yaml
+retry_on_errors:
+  - model not found
+  - model does not exist
+  - model unsupported
+  - model unavailable
+  - model not available
+  - model deprecated
+  - model retired
+  - model disabled
+  - upstream failed
+  - upstream error
+  - upstream unavailable
+  - upstream timed out
+  - upstream timeout
+  - 404 unsupported
+  - 404 unavailable
+  - 404 not available
+  - 404 deprecated
+  - 404 retired
+  - 404 disabled
+```
+
+Example: try at most one backup, treat timeouts as failover-eligible but
+keep serving `429` responses to the client, and add a provider-specific
+overload message:
+
+```yaml
+failover:
+  max_attempts: 1
+  retry_on_statuses: [408, 5xx]
+  retry_on_errors:
+    - model not found
+    - model does not exist
+    - upstream failed
+    - overloaded
+```
+
+The client receives the error of the last target tried, so with
+`max_attempts: 1` a request that exhausts its cap reports the backup's
+failure, not the primary's.
+
 ## Migrating from failover rules
 
 Earlier releases managed failover as separate per-model mappings (the shuffle

--- a/docs/features/failover.mdx
+++ b/docs/features/failover.mdx
@@ -106,8 +106,9 @@ The defaults above fit most deployments. Three settings under `failover`
 | `retry_on_statuses` | `FAILOVER_RETRY_ON_STATUSES` | `[429, 5xx]` | Upstream HTTP statuses that trigger failover: exact codes (`408`) or a whole class (`5xx`). |
 | `retry_on_errors` | `FAILOVER_RETRY_ON_ERRORS` | see below | Error phrases that trigger failover whatever the status. |
 
-Each list **replaces** its default when set, so repeat the defaults you want
-to keep. In the environment, separate entries with commas.
+A non-empty list **replaces** its default, so repeat the defaults you want
+to keep; an empty or omitted list keeps the default (use `enabled: false` to
+switch failover off). In the environment, separate entries with commas.
 
 A `retry_on_errors` phrase matches when every one of its words appears in the
 error code or message (case-insensitive, substring): `model not found`

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -28,6 +28,7 @@ import (
 	"github.com/enterpilot/gomodel/internal/conversationstore"
 	"github.com/enterpilot/gomodel/internal/core"
 	"github.com/enterpilot/gomodel/internal/filestore"
+	"github.com/enterpilot/gomodel/internal/gateway"
 	"github.com/enterpilot/gomodel/internal/guardrails"
 	"github.com/enterpilot/gomodel/internal/httpclient"
 	"github.com/enterpilot/gomodel/internal/live"
@@ -740,6 +741,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		ModelResolver:                   vm,
 		ModelAuthorizer:                 vm,
 		FailoverResolver:                failoverResolver(appCfg, vm),
+		FailoverPolicy:                  gateway.NewFailoverPolicy(appCfg.Failover),
 		WorkflowPolicyResolver:          workflowResult.Service,
 		TranslatedRequestPatcher:        translatedRequestPatcher,
 		BatchRequestPreparer:            batchRequestPreparer,
@@ -875,6 +877,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		ModelAuthorizer:        vm,
 		WorkflowPolicyResolver: workflowResult.Service,
 		FailoverResolver:       serverCfg.FailoverResolver,
+		FailoverPolicy:         serverCfg.FailoverPolicy,
 		AuditLogger:            auditResult.Logger,
 		// The tapped logger, so guardrail LLM calls count toward the
 		// request's rate limit token windows like any other completion.

--- a/internal/gateway/failover.go
+++ b/internal/gateway/failover.go
@@ -2,10 +2,8 @@ package gateway
 
 import (
 	"context"
-	"errors"
 	"io"
 	"log/slog"
-	"net/http"
 	"strings"
 	"time"
 
@@ -57,16 +55,18 @@ func tryFailoverResponse[T any](
 	}
 
 	failovers := o.FailoverSelectors(workflow)
-	if len(failovers) == 0 || !ShouldAttemptFailover(primaryErr) {
+	if len(failovers) == 0 || !o.failoverPolicy.ShouldRetry(primaryErr) {
 		return zero, "", "", "", false, primaryErr
 	}
 
 	requestID := strings.TrimSpace(core.GetRequestID(ctx))
 	primaryModel := currentSelectorForWorkflow(workflow, model, provider)
 	lastErr := primaryErr
+	attempts := 0
 	for _, selector := range failovers {
-		// Stop sweeping if the client disconnected mid-failover.
-		if ctx.Err() != nil {
+		// Stop sweeping if the client disconnected mid-failover or the policy
+		// cap on failover attempts is reached.
+		if ctx.Err() != nil || o.failoverPolicy.attemptsExhausted(attempts) {
 			break
 		}
 		if o.modelAuthorizer != nil && !o.modelAuthorizer.AllowsModel(ctx, selector) {
@@ -92,6 +92,7 @@ func tryFailoverResponse[T any](
 		)
 
 		started := time.Now()
+		attempts++
 		resp, resolvedProviderType, err := call(selector, providerType, providerName)
 		recordProviderAttempt(ctx, providerAttemptFromResult(AttemptKindFailover, firstNonEmptyString(resolvedProviderType, providerType), providerName, qualified, started, err))
 		if err == nil {
@@ -178,16 +179,18 @@ func tryFailoverStream(
 	}
 
 	failovers := o.FailoverSelectors(workflow)
-	if len(failovers) == 0 || !ShouldAttemptFailover(primaryErr) {
+	if len(failovers) == 0 || !o.failoverPolicy.ShouldRetry(primaryErr) {
 		return nil, "", "", "", "", primaryErr
 	}
 
 	requestID := strings.TrimSpace(core.GetRequestID(ctx))
 	primaryModel := currentSelectorForWorkflow(workflow, model, provider)
 	lastErr := primaryErr
+	attempts := 0
 	for _, selector := range failovers {
-		// Stop sweeping if the client disconnected mid-failover.
-		if ctx.Err() != nil {
+		// Stop sweeping if the client disconnected mid-failover or the policy
+		// cap on failover attempts is reached.
+		if ctx.Err() != nil || o.failoverPolicy.attemptsExhausted(attempts) {
 			break
 		}
 		if o.modelAuthorizer != nil && !o.modelAuthorizer.AllowsModel(ctx, selector) {
@@ -213,6 +216,7 @@ func tryFailoverStream(
 		)
 
 		started := time.Now()
+		attempts++
 		stream, resolvedProviderType, usageModel, err := call(selector, providerType, providerName)
 		recordProviderAttempt(ctx, providerAttemptFromResult(AttemptKindFailover, firstNonEmptyString(resolvedProviderType, providerType), providerName, qualified, started, err))
 		if err == nil {
@@ -228,90 +232,6 @@ func tryFailoverStream(
 	}
 
 	return nil, "", "", "", "", lastErr
-}
-
-// Message fragments that mark an error as failover-eligible when they appear
-// alongside the anchor word checked in ShouldAttemptFailover.
-var (
-	// modelUnavailableFragments signal the model itself is gone or refused,
-	// regardless of the status code the provider chose.
-	modelUnavailableFragments = []string{
-		"not found",
-		"does not exist",
-		"unsupported",
-		"unavailable",
-		"not available",
-		"deprecated",
-		"retired",
-		"disabled",
-	}
-	// upstreamFailureFragments signal an aggregator-style provider (OpenCode
-	// Zen, OpenRouter) relaying a transient failure of *its* upstream, e.g.
-	// OpenCode's 400 "Upstream request failed". These are server-side
-	// failures wearing a client-error status, so a failover target may still
-	// succeed.
-	upstreamFailureFragments = []string{
-		"failed",
-		"error",
-		"unavailable",
-		"timed out",
-		"timeout",
-	}
-	// retiredModel404Fragments cover 404s with availability phrasing but no
-	// literal "model": providers report retired models this way. Plain
-	// endpoint 404s must not match — those are genuine routing misses.
-	retiredModel404Fragments = []string{
-		"unsupported",
-		"unavailable",
-		"not available",
-		"deprecated",
-		"retired",
-		"disabled",
-	}
-)
-
-func containsAny(message string, fragments []string) bool {
-	for _, fragment := range fragments {
-		if strings.Contains(message, fragment) {
-			return true
-		}
-	}
-	return false
-}
-
-// ShouldAttemptFailover reports whether err should trigger translated failover.
-func ShouldAttemptFailover(err error) bool {
-	var gatewayErr *core.GatewayError
-	if !errors.As(err, &gatewayErr) || gatewayErr == nil {
-		return false
-	}
-
-	status := gatewayErr.HTTPStatusCode()
-	if status >= http.StatusInternalServerError || status == http.StatusTooManyRequests {
-		return true
-	}
-
-	code := ""
-	if gatewayErr.Code != nil {
-		code = strings.ToLower(strings.TrimSpace(*gatewayErr.Code))
-	}
-	if code != "" && strings.Contains(code, "model") &&
-		(strings.Contains(code, "not_found") || strings.Contains(code, "unsupported") || strings.Contains(code, "unavailable")) {
-		return true
-	}
-
-	message := strings.ToLower(strings.TrimSpace(gatewayErr.Message))
-	if strings.Contains(message, "model") && containsAny(message, modelUnavailableFragments) {
-		return true
-	}
-	if strings.Contains(message, "upstream") && containsAny(message, upstreamFailureFragments) {
-		return true
-	}
-	if status == http.StatusNotFound && containsAny(message, retiredModel404Fragments) {
-		return true
-	}
-
-	return false
 }
 
 func firstNonEmptyString(values ...string) string {

--- a/internal/gateway/failover_policy.go
+++ b/internal/gateway/failover_policy.go
@@ -1,0 +1,102 @@
+package gateway
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/enterpilot/gomodel/config"
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+// FailoverPolicy decides which failed attempts trigger a failover sweep and
+// how many targets the sweep may try. Build one with NewFailoverPolicy; a nil
+// policy, or one with no matchers, retries on the documented defaults.
+type FailoverPolicy struct {
+	// MaxAttempts caps the failover targets tried per request; zero sweeps
+	// every remaining target.
+	MaxAttempts int
+	statuses    map[int]bool
+	phrases     []config.FailoverErrorPhrase
+}
+
+// NewFailoverPolicy compiles the failover section of the configuration. A
+// config that was not loaded through config.Load (so its parsed fields are
+// empty) falls back to the documented defaults.
+func NewFailoverPolicy(cfg config.FailoverConfig) *FailoverPolicy {
+	policy := &FailoverPolicy{
+		MaxAttempts: max(cfg.MaxAttempts, 0),
+		statuses:    cfg.RetryStatuses,
+		phrases:     cfg.RetryErrors,
+	}
+	if len(policy.statuses) == 0 || len(policy.phrases) == 0 {
+		defaults := config.FailoverConfig{}
+		if err := config.LoadFailoverPolicy(&defaults); err != nil {
+			panic("gateway: default failover policy must parse: " + err.Error())
+		}
+		if len(policy.statuses) == 0 {
+			policy.statuses = defaults.RetryStatuses
+		}
+		if len(policy.phrases) == 0 {
+			policy.phrases = defaults.RetryErrors
+		}
+	}
+	return policy
+}
+
+var defaultFailoverPolicy = NewFailoverPolicy(config.FailoverConfig{})
+
+// ShouldRetry reports whether err should trigger a failover sweep: its HTTP
+// status is in retry_on_statuses, or its code and message contain every word
+// of a retry_on_errors phrase (with that phrase's status constraint, if any).
+func (p *FailoverPolicy) ShouldRetry(err error) bool {
+	if p == nil {
+		p = defaultFailoverPolicy
+	}
+	statuses, phrases := p.statuses, p.phrases
+	if len(statuses) == 0 && len(phrases) == 0 {
+		statuses, phrases = defaultFailoverPolicy.statuses, defaultFailoverPolicy.phrases
+	}
+	var gatewayErr *core.GatewayError
+	if !errors.As(err, &gatewayErr) || gatewayErr == nil {
+		return false
+	}
+
+	status := gatewayErr.HTTPStatusCode()
+	if statuses[status] {
+		return true
+	}
+
+	text := strings.ToLower(gatewayErr.Message)
+	if gatewayErr.Code != nil {
+		text = strings.ToLower(*gatewayErr.Code) + " " + text
+	}
+	for _, phrase := range phrases {
+		if len(phrase.Statuses) > 0 && !phrase.Statuses[status] {
+			continue
+		}
+		if containsAll(text, phrase.Words) {
+			return true
+		}
+	}
+	return false
+}
+
+// attemptsExhausted reports whether attempts has reached the policy cap.
+func (p *FailoverPolicy) attemptsExhausted(attempts int) bool {
+	return p != nil && p.MaxAttempts > 0 && attempts >= p.MaxAttempts
+}
+
+func containsAll(text string, words []string) bool {
+	for _, word := range words {
+		if !strings.Contains(text, word) {
+			return false
+		}
+	}
+	return true
+}
+
+// ShouldAttemptFailover reports whether err should trigger translated failover
+// under the default policy.
+func ShouldAttemptFailover(err error) bool {
+	return defaultFailoverPolicy.ShouldRetry(err)
+}

--- a/internal/gateway/failover_policy_test.go
+++ b/internal/gateway/failover_policy_test.go
@@ -159,3 +159,21 @@ func TestTryFailoverResponseSkipsWhenPolicyDoesNotMatch(t *testing.T) {
 		t.Fatalf("expected the primary 429 to be returned untouched (called=%v didFailover=%v err=%v)", called, didFailover, err)
 	}
 }
+
+// The stream path applies the same gate: a primary failure the policy does
+// not list is returned untouched, without calling any target.
+func TestTryFailoverStreamSkipsWhenPolicyDoesNotMatch(t *testing.T) {
+	o, workflow := threeTargetFixture(loadedFailoverPolicy(t, config.FailoverConfig{RetryOnStatuses: []string{"503"}}))
+	primaryErr := core.NewProviderError("openai", http.StatusTooManyRequests, "slow down", nil)
+	called := false
+	call := func(core.ModelSelector, string, string) (io.ReadCloser, string, string, error) {
+		called = true
+		return nil, "", "", nil
+	}
+
+	stream, _, _, _, _, err := tryFailoverStream(context.Background(), o, workflow, "openai/gpt-4o", "openai", primaryErr, call)
+
+	if called || stream != nil || err != primaryErr {
+		t.Fatalf("expected the primary 429 to be returned untouched (called=%v stream=%v err=%v)", called, stream, err)
+	}
+}

--- a/internal/gateway/failover_policy_test.go
+++ b/internal/gateway/failover_policy_test.go
@@ -1,0 +1,161 @@
+package gateway
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/enterpilot/gomodel/config"
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+func loadedFailoverPolicy(t *testing.T, cfg config.FailoverConfig) *FailoverPolicy {
+	t.Helper()
+	if err := config.LoadFailoverPolicy(&cfg); err != nil {
+		t.Fatalf("load failover policy: %v", err)
+	}
+	return NewFailoverPolicy(cfg)
+}
+
+func TestFailoverPolicyShouldRetry(t *testing.T) {
+	custom := loadedFailoverPolicy(t, config.FailoverConfig{
+		RetryOnStatuses: []string{"408", "503"},
+		RetryOnErrors:   []string{"overloaded", "4xx quota exceeded"},
+	})
+
+	tests := []struct {
+		name    string
+		policy  *FailoverPolicy
+		status  int
+		code    string
+		message string
+		want    bool
+	}{
+		{"nil policy uses defaults: 5xx", nil, http.StatusBadGateway, "", "bad gateway", true},
+		{"nil policy uses defaults: plain 400", nil, http.StatusBadRequest, "", "invalid request", false},
+		{"default matches error code words", nil, http.StatusBadRequest, "model_not_found", "nope", true},
+		{"custom status listed", custom, http.StatusRequestTimeout, "", "slow", true},
+		{"custom status replaces default 429", custom, http.StatusTooManyRequests, "", "slow down", false},
+		{"custom status replaces default 500", custom, http.StatusInternalServerError, "", "boom", false},
+		{"custom phrase", custom, http.StatusBadRequest, "", "Engine Overloaded, retry later", true},
+		{"custom phrase replaces default model heuristics", custom, http.StatusBadRequest, "", "model gpt-9 does not exist", false},
+		{"status-scoped phrase within class", custom, http.StatusForbidden, "", "quota exceeded for org", true},
+		{"status-scoped phrase outside class", custom, http.StatusInternalServerError, "", "quota exceeded for org", false},
+		{"all words required", custom, http.StatusForbidden, "", "quota fine", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := core.NewProviderError("openai", tt.status, tt.message, nil)
+			if tt.code != "" {
+				err = err.WithCode(tt.code)
+			}
+			if got := tt.policy.ShouldRetry(err); got != tt.want {
+				t.Fatalf("ShouldRetry(%d, %q, %q) = %v, want %v", tt.status, tt.code, tt.message, got, tt.want)
+			}
+		})
+	}
+
+	if got := custom.ShouldRetry(io.EOF); got {
+		t.Error("a non-gateway error must never trigger failover")
+	}
+}
+
+func threeTargetFixture(policy *FailoverPolicy) (*InferenceOrchestrator, *core.Workflow) {
+	o, workflow := failoverTestFixture()
+	o.failoverPolicy = policy
+	o.failoverResolver = stubFailoverResolver{selectors: []core.ModelSelector{
+		{Provider: "openai", Model: "a"},
+		{Provider: "openai", Model: "b"},
+		{Provider: "openai", Model: "c"},
+	}}
+	return o, workflow
+}
+
+func TestTryFailoverResponseHonorsMaxAttempts(t *testing.T) {
+	tests := []struct {
+		name        string
+		maxAttempts int
+		wantCalls   []string
+	}{
+		{"zero sweeps every target", 0, []string{"openai/a", "openai/b", "openai/c"}},
+		{"cap stops the sweep", 2, []string{"openai/a", "openai/b"}},
+		{"cap above the target count is harmless", 5, []string{"openai/a", "openai/b", "openai/c"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o, workflow := threeTargetFixture(&FailoverPolicy{MaxAttempts: tt.maxAttempts})
+			primaryErr := core.NewProviderError("openai", http.StatusBadGateway, "primary down", nil)
+			var calls []string
+			call := func(selector core.ModelSelector, _, _ string) (string, string, error) {
+				calls = append(calls, selector.QualifiedModel())
+				return "", "", core.NewProviderError("openai", http.StatusBadGateway, selector.Model+" down", nil)
+			}
+
+			_, _, _, _, didFailover, err := tryFailoverResponse(context.Background(), o, workflow, "openai/gpt-4o", "openai", primaryErr, call)
+
+			if didFailover || err == nil {
+				t.Fatalf("expected the sweep to fail, got didFailover=%v err=%v", didFailover, err)
+			}
+			if strings.Join(calls, ",") != strings.Join(tt.wantCalls, ",") {
+				t.Fatalf("calls = %v, want %v", calls, tt.wantCalls)
+			}
+			// The client sees the last attempted target's error, not the cap itself.
+			if want := tt.wantCalls[len(tt.wantCalls)-1]; !strings.Contains(err.Error(), strings.TrimPrefix(want, "openai/")+" down") {
+				t.Fatalf("err = %v, want the error of %s", err, want)
+			}
+		})
+	}
+}
+
+// Targets skipped before a call (rate-limited routes) do not consume attempts.
+func TestTryFailoverResponseMaxAttemptsCountsCallsOnly(t *testing.T) {
+	o, workflow := threeTargetFixture(&FailoverPolicy{MaxAttempts: 1})
+	o.routeGate = blockingRouteGate{blocked: map[string]bool{"openai/a": true}}
+	primaryErr := core.NewProviderError("openai", http.StatusBadGateway, "primary down", nil)
+	var calls []string
+	call := func(selector core.ModelSelector, _, _ string) (string, string, error) {
+		calls = append(calls, selector.QualifiedModel())
+		return "ok", "openai", nil
+	}
+
+	_, _, _, model, didFailover, err := tryFailoverResponse(context.Background(), o, workflow, "openai/gpt-4o", "openai", primaryErr, call)
+
+	if !didFailover || err != nil || model != "openai/b" || len(calls) != 1 {
+		t.Fatalf("result = (model:%q didFailover:%v err:%v calls:%v), want one successful call to openai/b", model, didFailover, err, calls)
+	}
+}
+
+func TestTryFailoverStreamHonorsMaxAttempts(t *testing.T) {
+	o, workflow := threeTargetFixture(&FailoverPolicy{MaxAttempts: 1})
+	primaryErr := core.NewProviderError("openai", http.StatusBadGateway, "primary down", nil)
+	var calls []string
+	call := func(selector core.ModelSelector, _, _ string) (io.ReadCloser, string, string, error) {
+		calls = append(calls, selector.QualifiedModel())
+		return nil, "", "", core.NewProviderError("openai", http.StatusBadGateway, selector.Model+" down", nil)
+	}
+
+	stream, _, _, _, _, err := tryFailoverStream(context.Background(), o, workflow, "openai/gpt-4o", "openai", primaryErr, call)
+
+	if stream != nil || err == nil || len(calls) != 1 || calls[0] != "openai/a" {
+		t.Fatalf("calls = %v err = %v, want exactly one failed attempt at openai/a", calls, err)
+	}
+}
+
+// A policy that does not list the primary's failure leaves the request alone.
+func TestTryFailoverResponseSkipsWhenPolicyDoesNotMatch(t *testing.T) {
+	o, workflow := threeTargetFixture(loadedFailoverPolicy(t, config.FailoverConfig{RetryOnStatuses: []string{"503"}}))
+	primaryErr := core.NewProviderError("openai", http.StatusTooManyRequests, "slow down", nil)
+	called := false
+	call := func(core.ModelSelector, string, string) (string, string, error) {
+		called = true
+		return "ok", "openai", nil
+	}
+
+	_, _, _, _, didFailover, err := tryFailoverResponse(context.Background(), o, workflow, "openai/gpt-4o", "openai", primaryErr, call)
+
+	if called || didFailover || err != primaryErr {
+		t.Fatalf("expected the primary 429 to be returned untouched (called=%v didFailover=%v err=%v)", called, didFailover, err)
+	}
+}

--- a/internal/gateway/inference_orchestrator.go
+++ b/internal/gateway/inference_orchestrator.go
@@ -24,6 +24,7 @@ type InferenceConfig struct {
 	ModelAuthorizer          ModelAuthorizer
 	WorkflowPolicyResolver   WorkflowPolicyResolver
 	FailoverResolver         FailoverResolver
+	FailoverPolicy           *FailoverPolicy // Optional: nil applies the default failover policy
 	TranslatedRequestPatcher TranslatedRequestPatcher
 	UsageLogger              usage.LoggerInterface
 	PricingResolver          usage.PricingResolver
@@ -39,6 +40,7 @@ type InferenceOrchestrator struct {
 	modelAuthorizer          ModelAuthorizer
 	workflowPolicyResolver   WorkflowPolicyResolver
 	failoverResolver         FailoverResolver
+	failoverPolicy           *FailoverPolicy
 	translatedRequestPatcher TranslatedRequestPatcher
 	usageLogger              usage.LoggerInterface
 	pricingResolver          usage.PricingResolver
@@ -54,6 +56,7 @@ func NewInferenceOrchestrator(cfg InferenceConfig) *InferenceOrchestrator {
 		modelAuthorizer:          cfg.ModelAuthorizer,
 		workflowPolicyResolver:   cfg.WorkflowPolicyResolver,
 		failoverResolver:         cfg.FailoverResolver,
+		failoverPolicy:           cfg.FailoverPolicy,
 		translatedRequestPatcher: cfg.TranslatedRequestPatcher,
 		usageLogger:              cfg.UsageLogger,
 		pricingResolver:          cfg.PricingResolver,

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/enterpilot/gomodel/internal/conversationstore"
 	"github.com/enterpilot/gomodel/internal/core"
 	"github.com/enterpilot/gomodel/internal/filestore"
+	"github.com/enterpilot/gomodel/internal/gateway"
 	"github.com/enterpilot/gomodel/internal/httpclient"
 	"github.com/enterpilot/gomodel/internal/mcpgateway"
 	"github.com/enterpilot/gomodel/internal/realtime"
@@ -29,6 +30,7 @@ type Handler struct {
 	modelResolver                   RequestModelResolver
 	modelAuthorizer                 RequestModelAuthorizer
 	failoverResolver                RequestFailoverResolver
+	failoverPolicy                  *gateway.FailoverPolicy
 	workflowPolicyResolver          RequestWorkflowPolicyResolver
 	translatedRequestPatcher        TranslatedRequestPatcher
 	batchRequestPreparer            BatchRequestPreparer
@@ -155,6 +157,7 @@ func (h *Handler) translatedInference() *translatedInferenceService {
 			modelAuthorizer:          h.modelAuthorizer,
 			workflowPolicyResolver:   h.workflowPolicyResolver,
 			failoverResolver:         h.failoverResolver,
+			failoverPolicy:           h.failoverPolicy,
 			translatedRequestPatcher: h.translatedRequestPatcher,
 			logger:                   h.logger,
 			usageLogger:              h.usageLogger,

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -25,6 +25,7 @@ import (
 	"github.com/enterpilot/gomodel/internal/conversationstore"
 	"github.com/enterpilot/gomodel/internal/core"
 	"github.com/enterpilot/gomodel/internal/filestore"
+	"github.com/enterpilot/gomodel/internal/gateway"
 	"github.com/enterpilot/gomodel/internal/mcpgateway"
 	"github.com/enterpilot/gomodel/internal/responsecache"
 	"github.com/enterpilot/gomodel/internal/responsestore"
@@ -83,6 +84,7 @@ type Config struct {
 	ModelAuthorizer                 RequestModelAuthorizer                 // Optional: request-scoped concrete model access controller
 	WorkflowPolicyResolver          RequestWorkflowPolicyResolver          // Optional: persisted workflow resolver used during workflow resolution
 	FailoverResolver                RequestFailoverResolver                // Optional: translated-route failover resolver
+	FailoverPolicy                  *gateway.FailoverPolicy                // Optional: which errors trigger failover and how many targets to try; nil applies the defaults
 	TranslatedRequestPatcher        TranslatedRequestPatcher               // Optional: request patcher for translated routes after workflow resolution
 	BatchRequestPreparer            BatchRequestPreparer                   // Optional: batch request preparer before native provider submission
 	ExposedModelLister              ExposedModelLister                     // Optional: additional public models to merge into GET /v1/models
@@ -183,6 +185,7 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 	handler := newHandlerWithAuthorizer(provider, auditLogger, usageLogger, pricingResolver, modelResolver, modelAuthorizer, workflowPolicyResolver, failoverResolver, translatedRequestPatcher)
 	handler.budgetChecker = budgetChecker
 	if cfg != nil {
+		handler.failoverPolicy = cfg.FailoverPolicy
 		handler.rateLimiter = cfg.RateLimiter
 		handler.usageSummarizer = cfg.UsageSummarizer
 	}

--- a/internal/server/internal_chat_completion_executor.go
+++ b/internal/server/internal_chat_completion_executor.go
@@ -26,6 +26,7 @@ type InternalChatCompletionExecutorConfig struct {
 	ModelAuthorizer        RequestModelAuthorizer
 	WorkflowPolicyResolver RequestWorkflowPolicyResolver
 	FailoverResolver       RequestFailoverResolver
+	FailoverPolicy         *gateway.FailoverPolicy
 	AuditLogger            auditlog.LoggerInterface
 	UsageLogger            usage.LoggerInterface
 	PricingResolver        usage.PricingResolver
@@ -60,6 +61,7 @@ func NewInternalChatCompletionExecutor(provider core.RoutableProvider, cfg Inter
 			ModelAuthorizer:          cfg.ModelAuthorizer,
 			WorkflowPolicyResolver:   cfg.WorkflowPolicyResolver,
 			FailoverResolver:         cfg.FailoverResolver,
+			FailoverPolicy:           cfg.FailoverPolicy,
 			UsageLogger:              cfg.UsageLogger,
 			PricingResolver:          cfg.PricingResolver,
 			TranslatedRequestPatcher: nil,

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -36,6 +36,7 @@ type translatedInferenceService struct {
 	modelAuthorizer          RequestModelAuthorizer
 	workflowPolicyResolver   RequestWorkflowPolicyResolver
 	failoverResolver         RequestFailoverResolver
+	failoverPolicy           *gateway.FailoverPolicy
 	translatedRequestPatcher TranslatedRequestPatcher
 	logger                   auditlog.LoggerInterface
 	usageLogger              usage.LoggerInterface
@@ -79,6 +80,7 @@ func (s *translatedInferenceService) newInferenceOrchestrator() *gateway.Inferen
 		ModelAuthorizer:          s.modelAuthorizer,
 		WorkflowPolicyResolver:   s.workflowPolicyResolver,
 		FailoverResolver:         s.failoverResolver,
+		FailoverPolicy:           s.failoverPolicy,
 		TranslatedRequestPatcher: s.translatedRequestPatcher,
 		UsageLogger:              s.usageLogger,
 		PricingResolver:          s.pricingResolver,


### PR DESCRIPTION
## Summary

Three new settings under `failover` (and matching env vars) replace the hardcoded failover trigger rules:

| Setting | Env | Default |
| --- | --- | --- |
| `max_attempts` | `FAILOVER_MAX_ATTEMPTS` | `0` — sweep every remaining target (previous behavior) |
| `retry_on_statuses` | `FAILOVER_RETRY_ON_STATUSES` | `[429, 5xx]` |
| `retry_on_errors` | `FAILOVER_RETRY_ON_ERRORS` | the previous model-unavailable / upstream-failure / retired-404 heuristics, expressed as phrases |

Setting either list replaces its default. A `retry_on_errors` phrase matches when every word appears in the error code or message; a numeric word (`404`, `4xx`) constrains the status instead, which is how the default list reproduces the old 404-scoped rule.

## User-visible impact

- Defaults are unchanged: the existing `TestShouldAttemptFailover` table passes as-is against the phrase-based defaults.
- Operators can now e.g. add `408`, stop failing over on `429`, cap a sweep at one backup, or add a provider-specific overload message.
- With `max_attempts` set, the client receives the error of the last target tried. Targets skipped without a call (saturated rate limits) do not consume attempts.

Docs: `docs/features/failover.mdx` ("Tune the failover policy"), `config/config.example.yaml`, `.env.template`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable failover limits through `max_attempts`.
  - Added customizable HTTP status and error-phrase triggers.
  - Supports YAML and environment-variable configuration.
  - Applies failover settings to standard and streaming requests.
  - Returns the final attempted target’s error when all attempts fail.

- **Documentation**
  - Added configuration guidance, defaults, matching rules, and examples.

- **Bug Fixes**
  - Prevents failover when errors do not match the configured policy.
  - Ensures rate-limited targets are skipped according to failover rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->