### PR TITLE
fix(virtualmodels): keep disabled legacy failover rules as disabled virtual models

### DIFF
--- a/docs/features/failover.mdx
+++ b/docs/features/failover.mdx
@@ -109,9 +109,10 @@ converted automatically:
   the setting is kept. A primary that already has a redirect, a path-scoped
   setting, or is disabled is logged and skipped, and the store is kept until
   it is resolved — add its fallbacks as targets of that virtual model with
-  the failover strategy, then delete the row. A primary listed in
-  `disabled_models` converts as a disabled virtual model: its fallbacks are
-  kept but inactive until you enable it from the Models page.
+  the failover strategy, then delete the row. A mapping switched off in the
+  dashboard, or whose primary is listed in `disabled_models`, converts as a
+  disabled virtual model: its fallbacks are kept but inactive until you
+  enable it from the Models page.
 - `failover.rules`, `manual_rules_path`, `FAILOVER_RULES_JSON`, and
   `disabled_models` still load and are translated into configuration-managed
   virtual models on every start, with a deprecation warning. A rule whose

--- a/internal/virtualmodels/failover_test.go
+++ b/internal/virtualmodels/failover_test.go
@@ -237,7 +237,7 @@ func TestNew_MigratesLegacyFailoverRulesIntoVirtualModels(t *testing.T) {
 	}
 	// A rule switched off in the dashboard keeps its fallbacks as a disabled
 	// virtual model instead of being discarded with the legacy store.
-	if off, ok := result.Service.Get("disabled"); !ok || off.Enabled || off.Strategy != StrategyFailover || len(off.Targets) != 2 {
+	if off, ok := result.Service.Get("disabled"); !ok || off.Enabled || off.Strategy != StrategyFailover || targetModels(off.Targets) != "disabled,groq/llama" {
 		t.Fatalf("disabled rule = %+v, %v; want a disabled failover redirect keeping its fallbacks", off, ok)
 	}
 	for _, source := range []string{"from-config", "self-only"} {
@@ -273,7 +273,7 @@ func TestNew_DisabledModelsMigrateAsDisabledVirtualModels(t *testing.T) {
 	defer result.Close()
 
 	migrated, ok := result.Service.Get("openai/gpt-4o")
-	if !ok || migrated.Enabled || migrated.Strategy != StrategyFailover || len(migrated.Targets) != 2 {
+	if !ok || migrated.Enabled || migrated.Strategy != StrategyFailover || targetModels(migrated.Targets) != "openai/gpt-4o,anthropic/claude" {
 		t.Fatalf("migrated rule = %+v, %v; want a disabled failover redirect keeping its fallbacks", migrated, ok)
 	}
 	if primary, chain := failoverChain(t, result.Service, "openai/gpt-4o"); primary != "openai/gpt-4o" || len(chain) != 0 {
@@ -284,9 +284,18 @@ func TestNew_DisabledModelsMigrateAsDisabledVirtualModels(t *testing.T) {
 	}
 }
 
+func targetModels(targets []Target) string {
+	models := make([]string, len(targets))
+	for i, target := range targets {
+		models[i] = target.Model
+	}
+	return strings.Join(models, ",")
+}
+
 // A start that stopped after writing the converted virtual model but before
 // removing its legacy row must finish the conversion on the next start, not
-// report its own conversion as a collision.
+// report its own conversion as a collision — and must carry over the rule's
+// current state, here a disable applied in the dashboard in between.
 func TestNew_FinishesInterruptedLegacyFailoverMigration(t *testing.T) {
 	ctx := context.Background()
 	conn := newSQLiteStorage(t)
@@ -303,7 +312,7 @@ func TestNew_FinishesInterruptedLegacyFailoverMigration(t *testing.T) {
 	_ = first.Close()
 	for _, stmt := range []string{
 		`CREATE TABLE failover_rules (primary_model TEXT PRIMARY KEY, fallback_models TEXT NOT NULL DEFAULT '[]', enabled INTEGER NOT NULL DEFAULT 1, managed_source TEXT NOT NULL DEFAULT 'dashboard', created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
-		`INSERT INTO failover_rules VALUES ('openai/gpt-4o', '["groq/llama"]', 1, 'dashboard', 0, 0)`,
+		`INSERT INTO failover_rules VALUES ('openai/gpt-4o', '["groq/llama"]', 0, 'dashboard', 0, 0)`,
 	} {
 		if _, err := db.Exec(stmt); err != nil {
 			t.Fatalf("seed: %v", err)
@@ -315,8 +324,8 @@ func TestNew_FinishesInterruptedLegacyFailoverMigration(t *testing.T) {
 		t.Fatalf("New() error = %v", err)
 	}
 	defer result.Close()
-	if vm, ok := result.Service.Get("openai/gpt-4o"); !ok || vm.Strategy != StrategyFailover {
-		t.Fatalf("converted model = %+v, %v", vm, ok)
+	if vm, ok := result.Service.Get("openai/gpt-4o"); !ok || vm.Strategy != StrategyFailover || vm.Enabled {
+		t.Fatalf("converted model = %+v, %v; want the conversion finished as disabled", vm, ok)
 	}
 	var count int
 	if err := db.QueryRow(`SELECT COUNT(*) FROM failover_rules`).Scan(&count); err == nil {

--- a/internal/virtualmodels/failover_test.go
+++ b/internal/virtualmodels/failover_test.go
@@ -235,7 +235,12 @@ func TestNew_MigratesLegacyFailoverRulesIntoVirtualModels(t *testing.T) {
 	if primary != "openai/gpt-4o" || strings.Join(chain, ",") != "groq/llama,anthropic/claude" {
 		t.Fatalf("resolved %q with chain %v; want the shadowed model and its fallbacks", primary, chain)
 	}
-	for _, source := range []string{"disabled", "from-config", "self-only"} {
+	// A rule switched off in the dashboard keeps its fallbacks as a disabled
+	// virtual model instead of being discarded with the legacy store.
+	if off, ok := result.Service.Get("disabled"); !ok || off.Enabled || off.Strategy != StrategyFailover || len(off.Targets) != 2 {
+		t.Fatalf("disabled rule = %+v, %v; want a disabled failover redirect keeping its fallbacks", off, ok)
+	}
+	for _, source := range []string{"from-config", "self-only"} {
 		if _, ok := result.Service.Get(source); ok {
 			t.Fatalf("rule %q must not be migrated", source)
 		}

--- a/internal/virtualmodels/failover_test.go
+++ b/internal/virtualmodels/failover_test.go
@@ -294,8 +294,7 @@ func targetModels(targets []Target) string {
 
 // A start that stopped after writing the converted virtual model but before
 // removing its legacy row must finish the conversion on the next start, not
-// report its own conversion as a collision — and must carry over the rule's
-// current state, here a disable applied in the dashboard in between.
+// report its own conversion as a collision.
 func TestNew_FinishesInterruptedLegacyFailoverMigration(t *testing.T) {
 	ctx := context.Background()
 	conn := newSQLiteStorage(t)
@@ -306,6 +305,7 @@ func TestNew_FinishesInterruptedLegacyFailoverMigration(t *testing.T) {
 		t.Fatalf("New() error = %v", err)
 	}
 	converted, _ := failoverModel("openai/gpt-4o", []string{"groq/llama"}, false)
+	converted.Enabled = false
 	if err := first.Service.Upsert(ctx, converted); err != nil {
 		t.Fatalf("Upsert(converted) error = %v", err)
 	}
@@ -348,6 +348,53 @@ func TestNew_FinishesInterruptedLegacyFailoverMigration(t *testing.T) {
 	}
 	if err := db.QueryRow(`SELECT COUNT(*) FROM failover_rules`).Scan(&count); err != nil || count != 1 {
 		t.Fatalf("failover_rules rows = %d, %v; want the differing rule retained", count, err)
+	}
+}
+
+// A conversion left behind by an interrupted start and then edited by the
+// operator — disabled, slowed down, affinity switched off — is their model
+// now: the next start must keep every edit and retain the legacy row as a
+// collision instead of rewriting the model from the row.
+func TestNew_KeepsOperatorEditsOnInterruptedLegacyFailoverMigration(t *testing.T) {
+	ctx := context.Background()
+	conn := newSQLiteStorage(t)
+	db := conn.DB()
+
+	first, err := New(ctx, &config.Config{}, conn, balancingCatalog(), nil)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	edited, _ := failoverModel("openai/gpt-4o", []string{"groq/llama"}, false)
+	edited.Enabled = false
+	slowdown, affinity := 2.5, false
+	edited.Slowdown = &slowdown
+	edited.SessionAffinity = &affinity
+	if err := first.Service.Upsert(ctx, edited); err != nil {
+		t.Fatalf("Upsert(edited) error = %v", err)
+	}
+	_ = first.Close()
+	for _, stmt := range []string{
+		`CREATE TABLE failover_rules (primary_model TEXT PRIMARY KEY, fallback_models TEXT NOT NULL DEFAULT '[]', enabled INTEGER NOT NULL DEFAULT 1, managed_source TEXT NOT NULL DEFAULT 'dashboard', created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`,
+		`INSERT INTO failover_rules VALUES ('openai/gpt-4o', '["groq/llama"]', 1, 'dashboard', 0, 0)`,
+	} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	result, err := New(ctx, &config.Config{}, conn, balancingCatalog(), nil)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer result.Close()
+	vm, ok := result.Service.Get("openai/gpt-4o")
+	if !ok || vm.Enabled || vm.Slowdown == nil || *vm.Slowdown != slowdown ||
+		vm.SessionAffinity == nil || *vm.SessionAffinity != affinity {
+		t.Fatalf("edited model = %+v, %v; want every operator edit kept", vm, ok)
+	}
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM failover_rules`).Scan(&count); err != nil || count != 1 {
+		t.Fatalf("failover_rules rows = %d, %v; want the rule retained for the operator", count, err)
 	}
 }
 

--- a/internal/virtualmodels/legacy_failover.go
+++ b/internal/virtualmodels/legacy_failover.go
@@ -54,11 +54,11 @@ func (r legacyFailoverRule) enabled() bool {
 // combine, and the store is kept in place so the fallback list stays readable
 // and the warning repeats on every start until it is resolved. Config-managed
 // rows are skipped — the live configuration still declares them and
-// FailoverConfigModels translates it on every start. A rule whose primary is
-// listed in disabled (FAILOVER_DISABLED_MODELS) used to be switched off by
-// that setting at request time; it is converted as a disabled virtual model,
-// so the fallback list survives without becoming active. Databases that never
-// had the store are a no-op.
+// FailoverConfigModels translates it on every start. A rule switched off in
+// the dashboard, or whose primary is listed in disabled
+// (FAILOVER_DISABLED_MODELS), is converted as a disabled virtual model, so the
+// fallback list survives without becoming active. Databases that never had
+// the store are a no-op.
 func importLegacyFailoverRules(ctx context.Context, store Store, conn storage.Storage, disabled map[string]bool) error {
 	rules, keyColumn, err := readLegacyFailoverRules(ctx, conn)
 	if err != nil {
@@ -79,8 +79,8 @@ func importLegacyFailoverRules(ctx context.Context, store Store, conn storage.St
 	migrated, unresolved := 0, 0
 	for _, rule := range rules {
 		model, convertible := failoverModel(rule.Source, rule.fallbacks(), false)
-		model.Enabled = !disabled[rule.Source]
-		if rule.enabled() && rule.ManagedSource != "config" && convertible {
+		model.Enabled = rule.enabled() && !disabled[rule.Source]
+		if rule.ManagedSource != "config" && convertible {
 			existing, exists := taken[rule.Source]
 			switch {
 			case !exists:

--- a/internal/virtualmodels/legacy_failover.go
+++ b/internal/virtualmodels/legacy_failover.go
@@ -83,15 +83,16 @@ func importLegacyFailoverRules(ctx context.Context, store Store, conn storage.St
 		if rule.ManagedSource != "config" && convertible {
 			existing, exists := taken[rule.Source]
 			switch {
-			case !exists:
+			case !exists, isMigratedFailoverModel(existing, model):
+				// Either a fresh conversion or one a previous start left
+				// behind when it stopped between the upsert and the row
+				// delete; writing the rule's current state covers both,
+				// including an enabled flag changed since that start.
 				if err := store.Upsert(ctx, model); err != nil {
 					return fmt.Errorf("migrate legacy failover rule %q: %w", rule.Source, err)
 				}
 				taken[rule.Source] = model
 				migrated++
-			case isMigratedFailoverModel(existing, model):
-				// A previous start that stopped between the upsert and the
-				// row delete left its own conversion behind; finish it.
 			case mergeableFailoverPolicy(existing):
 				merged := mergeFailoverPolicy(existing, model)
 				if err := store.Upsert(ctx, merged); err != nil {

--- a/internal/virtualmodels/legacy_failover.go
+++ b/internal/virtualmodels/legacy_failover.go
@@ -83,15 +83,16 @@ func importLegacyFailoverRules(ctx context.Context, store Store, conn storage.St
 		if rule.ManagedSource != "config" && convertible {
 			existing, exists := taken[rule.Source]
 			switch {
-			case !exists, isMigratedFailoverModel(existing, model):
-				// Either a fresh conversion or one a previous start left
-				// behind when it stopped between the upsert and the row
-				// delete; writing the rule's current state covers both,
-				// including an enabled flag changed since that start.
+			case !exists:
 				if err := store.Upsert(ctx, model); err != nil {
 					return fmt.Errorf("migrate legacy failover rule %q: %w", rule.Source, err)
 				}
 				taken[rule.Source] = model
+				migrated++
+			case isMigratedFailoverModel(existing, model):
+				// A previous start converted the rule and stopped before
+				// deleting its row; the conversion is already stored exactly
+				// as it would be written now, so only the delete remains.
 				migrated++
 			case mergeableFailoverPolicy(existing):
 				merged := mergeFailoverPolicy(existing, model)
@@ -267,10 +268,10 @@ func mergeableFailoverPolicy(vm VirtualModel) bool {
 }
 
 // mergeFailoverPolicy turns a mergeable policy into the failover redirect its
-// legacy rule expressed, keeping the policy's description and slowdown. The
-// provenance marker is used only when the policy had no description, so a
-// start interrupted between this upsert and the row delete reports the row
-// as a collision for the operator rather than converting it twice.
+// legacy rule expressed, keeping the policy's description and slowdown. Either
+// kept setting makes the result differ from a plain conversion, so a start
+// interrupted between this upsert and the row delete reports the row as a
+// collision for the operator instead of overwriting the merge.
 func mergeFailoverPolicy(policy, model VirtualModel) VirtualModel {
 	merged := model
 	merged.Slowdown = policy.Slowdown
@@ -280,11 +281,15 @@ func mergeFailoverPolicy(policy, model VirtualModel) VirtualModel {
 	return merged
 }
 
-// isMigratedFailoverModel reports whether vm is the conversion this migration
-// would write for a rule: it carries the provenance failoverModel stamps and
-// exactly the expected targets. Anything else is the operator's own model.
+// isMigratedFailoverModel reports whether vm is exactly the conversion this
+// migration would write for its rule today: the provenance failoverModel
+// stamps, the same targets and enabled flag, and every other setting still
+// untouched. A model differing anywhere — the operator's own work, or a
+// conversion the operator edited after an interrupted start — is reported as
+// a collision instead, so nothing the operator did is overwritten.
 func isMigratedFailoverModel(vm, expected VirtualModel) bool {
-	if normalizeStrategy(vm.Strategy) != StrategyFailover || vm.Description != migratedFailoverDescription || len(vm.Targets) != len(expected.Targets) {
+	if normalizeStrategy(vm.Strategy) != StrategyFailover || vm.Description != migratedFailoverDescription ||
+		vm.Enabled != expected.Enabled || len(vm.Targets) != len(expected.Targets) {
 		return false
 	}
 	for i, target := range vm.Targets {
@@ -292,7 +297,8 @@ func isMigratedFailoverModel(vm, expected VirtualModel) bool {
 			return false
 		}
 	}
-	return true
+	return vm.Model == "" && vm.ProviderName == "" && len(vm.UserPaths) == 0 &&
+		vm.Slowdown == nil && vm.SessionAffinity == nil && vm.Failover == nil
 }
 
 // deleteLegacyFailoverRule removes one row by its trimmed key; keyColumn is


### PR DESCRIPTION
The legacy `failover_rules` migration skipped rows with `enabled=0` but still deleted them and dropped the table, so a rule an operator had switched off in the dashboard lost its fallback list permanently on upgrade. Found by Greptile on #799.

A disabled dashboard rule is now converted the same way a primary listed in `FAILOVER_DISABLED_MODELS` already is: as a disabled failover virtual model that keeps its targets and can be re-enabled from the dashboard.

User-visible impact: after upgrading, disabled legacy rules appear as disabled virtual models instead of vanishing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Legacy failover mappings disabled in the dashboard are now migrated as disabled virtual models.
  * Fallback targets remain configured but inactive until the mapping is re-enabled.

* **Documentation**
  * Updated migration guidance to explain how disabled failover mappings are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->