### PR TITLE
docs(swagger): document the opt-in Swagger UI build

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -56,8 +56,9 @@
 # Accepts values like "10M", "1G", "500K" (default: 10M)
 # BODY_SIZE_LIMIT=10M
 
-# Enable/disable Swagger UI at /swagger/index.html (default: true)
-# SWAGGER_ENABLED=true
+# Enable/disable Swagger UI at /swagger/index.html (default: false)
+# Requires a binary built with -tags=swagger; see docs/advanced/swagger-ui.mdx
+# SWAGGER_ENABLED=false
 
 # Enable/disable pprof profiling routes at /debug/pprof/* (default: false)
 # PPROF_ENABLED=false

--- a/docs/advanced/api-endpoints.mdx
+++ b/docs/advanced/api-endpoints.mdx
@@ -145,4 +145,4 @@ Admin REST and dashboard routes (`/admin/*`) are covered in
 | `/health`             | GET    | Liveness check (always 200 while the process serves)                               |
 | `/health/ready`       | GET    | Readiness check: pings storage (503 if down) and Redis cache (degraded, still 200) |
 | `/metrics`            | GET    | Prometheus metrics (experimental, when enabled)                                    |
-| `/swagger/index.html` | GET    | Swagger UI (when enabled)                                                          |
+| `/swagger/index.html` | GET    | [Swagger UI](/advanced/swagger-ui) (when built with `-tags=swagger` and enabled)    |

--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -47,6 +47,7 @@ The most common way to configure GoModel. Set any of the variables below to over
 | `GOMODEL_DEMO_MODE`  | Enable public demo warnings in logs and the dashboard  | `false`                |
 | `BODY_SIZE_LIMIT`    | Max request body size (e.g., `10M`, `1024K`, `500KB`) | _(no limit)_           |
 | `USER_PATH_HEADER`   | Header used to read/write request `user_path` values  | `X-GoModel-User-Path`  |
+| `SWAGGER_ENABLED`    | Expose [Swagger UI](/advanced/swagger-ui); needs a `-tags=swagger` build | `false`                |
 | `PID_FILE`           | Where the running gateway records its process id for `gomodel --reload`. Changing it needs a restart | `data/gomodel.pid` next to a `./data` directory, otherwise the per-user data directory |
 
 Set `GOMODEL_DEMO_MODE=true` for a public or shared demonstration instance.

--- a/docs/advanced/swagger-ui.mdx
+++ b/docs/advanced/swagger-ui.mdx
@@ -1,0 +1,59 @@
+---
+title: "Swagger UI"
+description: "Serve an interactive Swagger UI for GoModel's API from a binary built with the swagger build tag."
+icon: "file-code"
+keywords: ["Swagger", "Swagger UI", "OpenAPI", "build tag", "API explorer"]
+---
+
+GoModel can serve an interactive Swagger UI at `/swagger/index.html`. It is
+opt-in at two levels: the binary must be compiled with the `swagger` build tag,
+and `SWAGGER_ENABLED` must be set at runtime.
+
+## Why it is not in the default build
+
+Release binaries and the official Docker image are built **without** the
+`swagger` tag. The embedded spec and UI assets add over 30 MB to the binary
+(roughly 55 MB to 88 MB on an unstripped build) and therefore to the image, and
+the endpoint is rarely needed in production. Leaving it out keeps the artifacts
+small and the exposed surface minimal.
+
+If you only need the API spec, use the checked-in
+[`docs/openapi.json`](https://github.com/ENTERPILOT/GoModel/blob/main/docs/openapi.json)
+in any OpenAPI viewer instead.
+
+## Build with Swagger
+
+```bash
+go build -tags=swagger -o bin/gomodel ./cmd/gomodel
+```
+
+`make run` builds with the tag and enables the UI automatically for local
+development.
+
+## Enable at runtime
+
+| Setting                  | Default | Description                                    |
+| ------------------------ | ------- | ---------------------------------------------- |
+| `SWAGGER_ENABLED`        | `false` | Expose the Swagger UI at `/swagger/index.html` |
+
+```bash
+SWAGGER_ENABLED=true ./bin/gomodel
+```
+
+Or in `config.yaml`:
+
+```yaml
+server:
+  swagger_enabled: true
+```
+
+The UI is served without authentication and respects `BASE_PATH`. If
+`SWAGGER_ENABLED=true` is set on a binary built without the tag, GoModel logs a
+warning at startup and serves nothing at `/swagger/*`.
+
+## Regenerate the spec
+
+Run `make swagger` after changing API annotations to regenerate the embedded
+docs package and `docs/openapi.json`. See
+[DEVELOPMENT.md](https://github.com/ENTERPILOT/GoModel/blob/main/docs/DEVELOPMENT.md)
+for details.

--- a/docs/advanced/swagger-ui.mdx
+++ b/docs/advanced/swagger-ui.mdx
@@ -47,9 +47,16 @@ server:
   swagger_enabled: true
 ```
 
-The UI is served without authentication and respects `BASE_PATH`. If
-`SWAGGER_ENABLED=true` is set on a binary built without the tag, GoModel logs a
-warning at startup and serves nothing at `/swagger/*`.
+<Warning>
+`/swagger/*` bypasses `GOMODEL_MASTER_KEY` and gateway API key authentication,
+so enabling it publishes interactive API documentation to anyone who can reach
+the server. Enable it only in development or trusted environments, or restrict
+the path at the network layer.
+</Warning>
+
+The UI respects `BASE_PATH`. If `SWAGGER_ENABLED=true` is set on a binary built
+without the tag, GoModel logs a warning at startup and serves nothing at
+`/swagger/*`.
 
 ## Regenerate the spec
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -118,6 +118,7 @@
                             "advanced/model-metadata",
                             "advanced/cli",
                             "advanced/api-endpoints",
+                            "advanced/swagger-ui",
                             "advanced/resilience",
                             "advanced/version-awareness",
                             "advanced/responses-api",


### PR DESCRIPTION
Adds `docs/advanced/swagger-ui.mdx` explaining that the Swagger UI requires a `-tags=swagger` build plus `SWAGGER_ENABLED=true`, and why release binaries and the Docker image omit it (adds ~33 MB to the binary, rarely needed in production).

Also:
- Fixes `.env.template`, which stated `SWAGGER_ENABLED` defaults to `true` (actual default is `false`).
- Adds `SWAGGER_ENABLED` to the configuration reference table.
- Links the new page from the API endpoints table and registers it in `docs.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for enabling and serving an interactive Swagger UI.
  * Added configuration guidance for the `SWAGGER_ENABLED` environment variable and YAML setting.
  * Added the Swagger UI guide to the Advanced documentation navigation.

* **Documentation**
  * Clarified that Swagger UI requires a Swagger-tagged build and runtime enablement.
  * Updated the API endpoints documentation with the required build and configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->