### PR TITLE
perf(providers): parallelize startup availability checks

### DIFF
--- a/internal/providers/init.go
+++ b/internal/providers/init.go
@@ -273,32 +273,68 @@ func initializeProviders(ctx context.Context, providerMap map[string]ProviderCon
 	}
 	sort.Strings(names)
 
+	type initializedProvider struct {
+		name            string
+		config          ProviderConfig
+		provider        core.Provider
+		createErr       error
+		availabilityErr error
+	}
+	results := make([]initializedProvider, len(names))
+	const maxConcurrentInitializations = 8
+	sem := make(chan struct{}, maxConcurrentInitializations)
+	var wg sync.WaitGroup
+	for i, name := range names {
+		wg.Add(1)
+		go func(i int, name string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			pCfg := providerMap[name]
+			p, err := factory.Create(pCfg)
+			if err != nil {
+				results[i] = initializedProvider{name: name, config: pCfg, createErr: err}
+				return
+			}
+
+			var availabilityErr error
+			if checker, ok := p.(core.AvailabilityChecker); ok {
+				probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+				availabilityErr = checker.CheckAvailability(probeCtx)
+				cancel()
+			}
+			results[i] = initializedProvider{
+				name:            name,
+				config:          pCfg,
+				provider:        p,
+				availabilityErr: availabilityErr,
+			}
+		}(i, name)
+	}
+	wg.Wait()
+
 	var count int
-	for _, name := range names {
-		pCfg := providerMap[name]
-		p, err := factory.Create(pCfg)
-		if err != nil {
+	for _, result := range results {
+		name, pCfg, p := result.name, result.config, result.provider
+		if result.createErr != nil {
 			slog.Error("failed to initialize provider",
 				"name", name,
 				"type", pCfg.Type,
-				"error", err)
+				"error", result.createErr)
 			continue
 		}
 
-		// Availability checks are diagnostics only. Providers stay registered so
-		// async initialization and periodic refresh can discover them later.
-		if checker, ok := p.(core.AvailabilityChecker); ok {
-			probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-			if err := checker.CheckAvailability(probeCtx); err != nil {
-				registry.RecordAvailabilityCheck(name, err)
+		if _, ok := p.(core.AvailabilityChecker); ok {
+			if result.availabilityErr != nil {
+				registry.RecordAvailabilityCheck(name, result.availabilityErr)
 				slog.Warn("provider unavailable at startup; keeping registered for refresh",
 					"name", name,
 					"type", pCfg.Type,
-					"reason", err.Error())
+					"reason", result.availabilityErr.Error())
 			} else {
 				registry.RecordAvailabilityCheck(name, nil)
 			}
-			cancel()
 		}
 
 		registry.RegisterProviderWithNameAndType(p, name, pCfg.Type)

--- a/internal/providers/init.go
+++ b/internal/providers/init.go
@@ -285,10 +285,12 @@ func initializeProviders(ctx context.Context, providerMap map[string]ProviderCon
 	sem := make(chan struct{}, maxConcurrentInitializations)
 	var wg sync.WaitGroup
 	for i, name := range names {
+		// Acquire capacity before launching the worker so configurations with
+		// many providers do not retain one blocked goroutine per provider.
+		sem <- struct{}{}
 		wg.Add(1)
 		go func(i int, name string) {
 			defer wg.Done()
-			sem <- struct{}{}
 			defer func() { <-sem }()
 
 			pCfg := providerMap[name]

--- a/internal/providers/init_test.go
+++ b/internal/providers/init_test.go
@@ -477,3 +477,83 @@ func TestInitializeProviders_AvailabilityCheckUsesCallerContext(t *testing.T) {
 		t.Fatalf("CheckAvailability() context error = %v, want %v", checkErr, context.Canceled)
 	}
 }
+
+func TestInitializeProviders_ParallelizesProbesAndRegistersDeterministically(t *testing.T) {
+	const providerCount = 3
+	var started atomic.Int32
+	var startedOnce sync.Once
+	allStarted := make(chan struct{})
+	release := make(chan struct{})
+	providers := make(map[string]*initTestProvider, providerCount)
+
+	for _, name := range []string{"alpha", "beta", "gamma"} {
+		name := name
+		providers[name] = &initTestProvider{
+			checkAvailability: func(context.Context) error {
+				if started.Add(1) == providerCount {
+					startedOnce.Do(func() { close(allStarted) })
+				}
+				<-release
+				if name == "beta" {
+					return errors.New("beta unavailable")
+				}
+				return nil
+			},
+		}
+	}
+
+	factory := NewProviderFactory()
+	factory.Add(Registration{
+		Type: "test",
+		New: func(cfg ProviderConfig, _ ProviderOptions) core.Provider {
+			return providers[cfg.Name]
+		},
+	})
+	providerConfigs := make(map[string]ProviderConfig, providerCount)
+	for name := range providers {
+		providerConfigs[name] = ProviderConfig{Name: name, Type: "test"}
+	}
+
+	registry := NewModelRegistry()
+	type result struct {
+		count int
+		err   error
+	}
+	done := make(chan result, 1)
+	go func() {
+		count, err := initializeProviders(t.Context(), providerConfigs, factory, registry)
+		done <- result{count: count, err: err}
+	}()
+
+	select {
+	case <-allStarted:
+	case <-time.After(time.Second):
+		t.Fatal("availability checks did not overlap")
+	}
+	close(release)
+
+	select {
+	case got := <-done:
+		if got.err != nil {
+			t.Fatalf("initializeProviders() error = %v, want nil", got.err)
+		}
+		if got.count != providerCount {
+			t.Fatalf("initializeProviders() count = %d, want %d", got.count, providerCount)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("initializeProviders() did not finish")
+	}
+
+	if got := registry.providerNames[registry.providers[0]]; got != "alpha" {
+		t.Fatalf("first registered provider = %q, want alpha", got)
+	}
+	if got := registry.providerNames[registry.providers[1]]; got != "beta" {
+		t.Fatalf("second registered provider = %q, want beta", got)
+	}
+	if got := registry.providerNames[registry.providers[2]]; got != "gamma" {
+		t.Fatalf("third registered provider = %q, want gamma", got)
+	}
+	if got := registry.providerRuntime["beta"].lastAvailabilityError; got != "beta unavailable" {
+		t.Fatalf("beta availability error = %q, want beta unavailable", got)
+	}
+}

--- a/internal/providers/init_test.go
+++ b/internal/providers/init_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -555,5 +556,66 @@ func TestInitializeProviders_ParallelizesProbesAndRegistersDeterministically(t *
 	}
 	if got := registry.providerRuntime["beta"].lastAvailabilityError; got != "beta unavailable" {
 		t.Fatalf("beta availability error = %q, want beta unavailable", got)
+	}
+}
+
+func TestInitializeProviders_DoesNotLaunchUnboundedWorkers(t *testing.T) {
+	const providerCount = 16
+	const maxWorkers = 8
+	started := make(chan struct{}, providerCount)
+	release := make(chan struct{})
+	providers := make(map[string]*initTestProvider, providerCount)
+	for i := range providerCount {
+		name := fmt.Sprintf("provider-%02d", i)
+		providers[name] = &initTestProvider{
+			checkAvailability: func(context.Context) error {
+				started <- struct{}{}
+				<-release
+				return nil
+			},
+		}
+	}
+
+	factory := NewProviderFactory()
+	factory.Add(Registration{
+		Type: "test",
+		New: func(cfg ProviderConfig, _ ProviderOptions) core.Provider {
+			return providers[cfg.Name]
+		},
+	})
+	providerConfigs := make(map[string]ProviderConfig, providerCount)
+	for name := range providers {
+		providerConfigs[name] = ProviderConfig{Name: name, Type: "test"}
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = initializeProviders(t.Context(), providerConfigs, factory, NewModelRegistry())
+		close(done)
+	}()
+
+	for range maxWorkers {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("provider initialization did not start all workers")
+		}
+	}
+
+	select {
+	case <-started:
+		t.Fatal("initializeProviders launched more than the worker limit")
+	default:
+	}
+
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("initializeProviders did not finish")
+	}
+
+	if len(started) != providerCount-maxWorkers {
+		t.Fatalf("started channel retained %d providers, want %d", len(started), providerCount-maxWorkers)
 	}
 }


### PR DESCRIPTION
## Summary

- Parallelize provider construction and startup availability probes with a bounded worker pool.
- Preserve sorted provider registration and logging order while isolating per-provider failures.
- Add a deterministic regression test covering overlapping probes, mixed availability, and registration order.

## Validation

- `go test ./internal/providers -count=1`
- `go vet ./internal/providers`
- `git diff --check`

The full repository test run reached all packages but the dashboard and server dashboard tests require the generated `static/dist/index.html`, which is not present in the repository checkout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Provider initialization and availability checks now run concurrently, reducing startup time.
  * Concurrent checks are safely limited to prevent resource overuse.

* **Reliability**
  * Provider registration remains deterministic.
  * Availability results and errors continue to be recorded consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->