### PR TITLE
feat(versioncheck): keep the install id in the database, with a derived fallback

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,6 +24,11 @@ services:
       # Audit logging is enabled by default; pick its storage backend below
       # - STORAGE_TYPE=postgresql
       - STORAGE_TYPE=mongodb
+    volumes:
+      # The gateway's own state: the SQLite database when STORAGE_TYPE is
+      # sqlite, the pid file, and the install identity. Without this the
+      # directory is part of the container and is lost when it is recreated.
+      - gomodel_data:/app/data
     depends_on:
       redis:
         condition: service_healthy
@@ -106,6 +111,7 @@ services:
     restart: unless-stopped
 
 volumes:
+  gomodel_data:
   redis_data:
   postgres_data:
   mongodb_data:

--- a/docs/advanced/version-awareness.mdx
+++ b/docs/advanced/version-awareness.mdx
@@ -92,7 +92,10 @@ being recreated, and replicas sharing one database report as one deployment.
 An `install-id` file from an earlier release is adopted unchanged the first time
 the gateway starts with this one, unless the database already holds an id — for
 instance because another replica sharing it started first — in which case the
-database's id wins and the file is rewritten to match.
+database's id wins and the file is rewritten to match. If the database cannot
+be reached at startup, the gateway uses the file (or the fallback below) until
+it can, and switches to the database's id on a later check rather than keeping
+a provisional one for the life of the process.
 
 When neither copy exists — a container recreated without a volume, running
 SQLite — the identifier is derived from `GOMODEL_MASTER_KEY` with HMAC-SHA256,

--- a/docs/advanced/version-awareness.mdx
+++ b/docs/advanced/version-awareness.mdx
@@ -90,7 +90,9 @@ It is kept in the deployment's database, under the `install_id` key in the
 data directory. The database copy is authoritative: it survives a container
 being recreated, and replicas sharing one database report as one deployment.
 An `install-id` file from an earlier release is adopted unchanged the first time
-the gateway starts with this one.
+the gateway starts with this one, unless the database already holds an id — for
+instance because another replica sharing it started first — in which case the
+database's id wins and the file is rewritten to match.
 
 When neither copy exists — a container recreated without a volume, running
 SQLite — the identifier is derived from `GOMODEL_MASTER_KEY` with HMAC-SHA256,

--- a/docs/advanced/version-awareness.mdx
+++ b/docs/advanced/version-awareness.mdx
@@ -80,10 +80,24 @@ personal data. Neither is ever sent.
 
 ### The install identifier
 
-A random UUID stored in `install-id` in the gateway's data directory, created on
-first use. It encodes nothing about your host, your organization, or your
-configuration; it exists only so repeated checks from one deployment count as
-one deployment. Disabling the check means it is never created.
+A random UUID created on first use. It encodes nothing about your host, your
+organization, or your configuration; it exists only so repeated checks from one
+deployment count as one deployment. Disabling the check means it is never
+created.
+
+It is kept in the deployment's database, under the `install_id` key in the
+`runtime_settings` table (or collection), and mirrored to `install-id` in the
+data directory. The database copy is authoritative: it survives a container
+being recreated, and replicas sharing one database report as one deployment.
+An `install-id` file from an earlier release is adopted unchanged the first time
+the gateway starts with this one.
+
+When neither copy exists — a container recreated without a volume, running
+SQLite — the identifier is derived from `GOMODEL_MASTER_KEY` with HMAC-SHA256,
+so the same configuration keeps the same identity. The key itself is never
+sent and cannot be recovered from the identifier. Rotating the key in that
+situation reads as a new deployment; without a master key a fresh random id
+is generated on every recreate.
 
 ## Turning it off if you don't want to get the updates
 

--- a/docs/advanced/version-awareness.mdx
+++ b/docs/advanced/version-awareness.mdx
@@ -63,7 +63,7 @@ Every check carries:
 | ------------------- | ----------- | ----------------------------------- |
 | `X-GoModel-Version` | `0.1.81`    | the release you are running         |
 | `X-GoModel-App`     | `GoModel`   | `GoModel` or `GoModel Pro`          |
-| `X-GoModel-Install` | a UUID      | random per-deployment id, see below |
+| `X-GoModel-Install` | a UUID      | anonymous per-deployment id, below  |
 | `X-GoModel-Source`  | `scheduled` | `scheduled` or `dashboard`          |
 
 A check triggered by a dashboard visit also forwards an **allowlisted** slice of

--- a/docs/advanced/version-awareness.mdx
+++ b/docs/advanced/version-awareness.mdx
@@ -80,10 +80,10 @@ personal data. Neither is ever sent.
 
 ### The install identifier
 
-A random UUID created on first use. It encodes nothing about your host, your
-organization, or your configuration; it exists only so repeated checks from one
-deployment count as one deployment. Disabling the check means it is never
-created.
+A UUID chosen on first use: a random one, or one derived from your master key
+as described below. It encodes nothing about your host, your organization, or
+your configuration; it exists only so repeated checks from one deployment count
+as one deployment. Disabling the check means it is never created.
 
 It is kept in the deployment's database, under the `install_id` key in the
 `runtime_settings` table (or collection), and mirrored to `install-id` in the

--- a/docs/guides/production.mdx
+++ b/docs/guides/production.mdx
@@ -72,6 +72,8 @@ high concurrency with budgets or rate limits enabled.
   directory. Without an explicit volume mount, every audit log, usage record,
   budget, managed API key, and stored credential is lost when the container is
   replaced. Always mount a volume at `/app/data`, or move to Postgres/MongoDB.
+  The gateway logs a warning at startup when it detects this situation, and the
+  repository's `docker-compose.yaml` mounts the `gomodel_data` volume there.
 </Warning>
 
 The default SQLite path is `./data/gomodel.db` when a `./data` directory already

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -629,8 +629,9 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 	// The update check owns the only outbound connection core makes that is
 	// not a provider call. It is constructed even when disabled so GET
 	// /version keeps reporting the local build.
-	versionChecker := newVersionChecker(appCfg.VersionCheck)
+	versionChecker := newVersionChecker(ctx, appCfg.VersionCheck, sharedStorage, appCfg.Server.MasterKey)
 	app.versionCheck = versionChecker
+	warnIfDataDirEphemeral(appCfg.Storage.BackendConfig())
 
 	serverCfg := &server.Config{
 		BasePath:                        appCfg.Server.BasePath,

--- a/internal/app/versioncheck.go
+++ b/internal/app/versioncheck.go
@@ -41,11 +41,15 @@ func newVersionChecker(ctx context.Context, cfg config.VersionCheckConfig, backe
 				store = s
 			}
 		}
-		var source versioncheck.InstallIDSource
-		checkerCfg.InstallID, source = versioncheck.ResolveInstallID(ctx, store, masterKey)
+		identity := versioncheck.NewIdentity(store, masterKey)
+		id, source := identity.Resolve(ctx)
 		if source == versioncheck.SourceGenerated || source == versioncheck.SourceDerived {
 			slog.Info("install id created", "source", string(source))
 		}
+		// Resolved again per check rather than fixed here: if the database
+		// was unreachable just now, a later check picks up the id it holds.
+		checkerCfg.InstallID = id
+		checkerCfg.InstallIDFunc = identity.ID
 		if versioncheck.LeaksQueryInCleartext(cfg.URL) {
 			slog.Warn("version check URL sends its query string unencrypted; use https if it carries a credential",
 				"host", versioncheck.SafeURL(cfg.URL))

--- a/internal/app/versioncheck.go
+++ b/internal/app/versioncheck.go
@@ -19,8 +19,8 @@ import (
 // that opted out never writes one.
 //
 // The identifier is kept in the deployment's database first and the data
-// directory second (see versioncheck.ResolveInstallID), with the master key
-// as the fallback that survives a container recreated without either.
+// directory second (see versioncheck.Identity), with the master key as the
+// fallback that survives a container recreated without either.
 func newVersionChecker(ctx context.Context, cfg config.VersionCheckConfig, backend storage.Storage, masterKey string) *versioncheck.Checker {
 	checkerCfg := versioncheck.Config{
 		Enabled:        cfg.Enabled,

--- a/internal/app/versioncheck.go
+++ b/internal/app/versioncheck.go
@@ -1,10 +1,15 @@
 package app
 
 import (
+	"context"
 	"log/slog"
+	"path/filepath"
 	"time"
 
 	"github.com/enterpilot/gomodel/config"
+	"github.com/enterpilot/gomodel/internal/platformdir"
+	"github.com/enterpilot/gomodel/internal/runtimesettings"
+	"github.com/enterpilot/gomodel/internal/storage"
 	"github.com/enterpilot/gomodel/internal/version"
 	"github.com/enterpilot/gomodel/internal/versioncheck"
 )
@@ -12,7 +17,11 @@ import (
 // newVersionChecker builds the update checker from configuration. The install
 // identifier is only materialized when checks are enabled, so a deployment
 // that opted out never writes one.
-func newVersionChecker(cfg config.VersionCheckConfig) *versioncheck.Checker {
+//
+// The identifier is kept in the deployment's database first and the data
+// directory second (see versioncheck.ResolveInstallID), with the master key
+// as the fallback that survives a container recreated without either.
+func newVersionChecker(ctx context.Context, cfg config.VersionCheckConfig, backend storage.Storage, masterKey string) *versioncheck.Checker {
 	checkerCfg := versioncheck.Config{
 		Enabled:        cfg.Enabled,
 		URL:            cfg.URL,
@@ -23,11 +32,45 @@ func newVersionChecker(cfg config.VersionCheckConfig) *versioncheck.Checker {
 		MaxDailyChecks: cfg.MaxDailyChecks,
 	}
 	if cfg.Enabled {
-		checkerCfg.InstallID = versioncheck.InstallID()
+		var store versioncheck.Store
+		if backend != nil {
+			s, err := runtimesettings.NewStore(ctx, backend)
+			if err != nil {
+				slog.Warn("install id will be kept in the data directory only", "error", err)
+			} else {
+				store = s
+			}
+		}
+		var source versioncheck.InstallIDSource
+		checkerCfg.InstallID, source = versioncheck.ResolveInstallID(ctx, store, masterKey)
+		if source == versioncheck.SourceGenerated || source == versioncheck.SourceDerived {
+			slog.Info("install id created", "source", string(source))
+		}
 		if versioncheck.LeaksQueryInCleartext(cfg.URL) {
 			slog.Warn("version check URL sends its query string unencrypted; use https if it carries a credential",
 				"host", versioncheck.SafeURL(cfg.URL))
 		}
 	}
 	return versioncheck.New(checkerCfg)
+}
+
+// warnIfDataDirEphemeral tells an operator whose SQLite database sits on a
+// container's own writable layer that it will not survive the container.
+// Only SQLite is checked: with PostgreSQL or MongoDB the data directory holds
+// nothing that is not also in the database.
+func warnIfDataDirEphemeral(cfg storage.Config) {
+	if cfg.Type != storage.TypeSQLite {
+		return
+	}
+	path := cfg.SQLite.Path
+	if path == "" {
+		path = storage.DefaultSQLitePath()
+	}
+	dir := filepath.Dir(path)
+	if platformdir.Ephemeral(dir) {
+		slog.Warn("data directory is on the container's own filesystem, not a volume: "+
+			"the database (audit logs, usage, budgets, keys) and the install identity are lost when the container is recreated; "+
+			"mount a volume there or use PostgreSQL/MongoDB",
+			"dir", dir)
+	}
 }

--- a/internal/platformdir/ephemeral.go
+++ b/internal/platformdir/ephemeral.go
@@ -1,0 +1,110 @@
+package platformdir
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ephemeralFilesystems are the filesystem types a container's own writable
+// layer and its scratch mounts show up as. Anything written there is gone
+// when the container is recreated.
+var ephemeralFilesystems = map[string]bool{
+	"overlay": true,
+	"tmpfs":   true,
+}
+
+// Ephemeral reports whether dir lives on a filesystem that does not outlive
+// the running container: the image's overlay layer, or a tmpfs. A directory
+// on a mounted volume, a bind mount, or any ordinary disk reports false, and
+// so does every platform without Linux mount tables.
+//
+// It exists so a deployment that keeps its database or its identity in such a
+// directory can be told at startup, before the data is lost, rather than
+// after.
+func Ephemeral(dir string) bool {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return false
+	}
+	f, err := os.Open("/proc/self/mountinfo")
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	fstype, ok := mountFilesystem(f, abs)
+	return ok && ephemeralFilesystems[fstype]
+}
+
+// mountFilesystem returns the filesystem type of the mount that holds dir:
+// the mount whose mount point is the longest prefix of dir. Lines have the
+// form documented in proc(5):
+//
+//	36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue
+//
+// The mount point is the fifth field and the type the first field after the
+// "-" separator; the optional fields in between vary in number.
+func mountFilesystem(mountinfo io.Reader, dir string) (string, bool) {
+	best, bestType := "", ""
+	scanner := bufio.NewScanner(mountinfo)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		sep := -1
+		for i, field := range fields {
+			if field == "-" {
+				sep = i
+				break
+			}
+		}
+		if sep < 5 || sep+1 >= len(fields) {
+			continue
+		}
+		point := unescapeMountPath(fields[4])
+		if !withinMount(dir, point) || len(point) < len(best) {
+			continue
+		}
+		best, bestType = point, fields[sep+1]
+	}
+	return bestType, best != ""
+}
+
+// withinMount reports whether dir is point itself or below it.
+func withinMount(dir, point string) bool {
+	if point == "/" {
+		return true
+	}
+	return dir == point || strings.HasPrefix(dir, point+"/")
+}
+
+// unescapeMountPath decodes the octal escapes the kernel uses for spaces and
+// a few other characters in mount paths ("\040" for a space).
+func unescapeMountPath(path string) string {
+	if !strings.Contains(path, `\`) {
+		return path
+	}
+	var out strings.Builder
+	for i := 0; i < len(path); i++ {
+		if path[i] == '\\' && i+3 < len(path) {
+			if v, ok := octal(path[i+1 : i+4]); ok {
+				out.WriteByte(v)
+				i += 3
+				continue
+			}
+		}
+		out.WriteByte(path[i])
+	}
+	return out.String()
+}
+
+func octal(s string) (byte, bool) {
+	var v int
+	for _, c := range s {
+		if c < '0' || c > '7' {
+			return 0, false
+		}
+		v = v*8 + int(c-'0')
+	}
+	return byte(v), true
+}

--- a/internal/platformdir/ephemeral_test.go
+++ b/internal/platformdir/ephemeral_test.go
@@ -1,0 +1,59 @@
+package platformdir
+
+import (
+	"strings"
+	"testing"
+)
+
+// A trimmed mountinfo from a container with a volume at /app/data and a
+// bind-mounted directory whose name has a space.
+const containerMountinfo = `
+1077 1076 0:245 / / rw,relatime master:301 - overlay overlay rw,lowerdir=/x,upperdir=/y,workdir=/z
+1078 1077 0:249 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw
+1079 1077 0:250 / /dev rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
+1083 1077 0:32 /var/lib/docker/volumes/gomodel_data/_data /app/data rw,relatime master:1 - ext4 /dev/vda1 rw
+1084 1077 0:32 /home/me/my\040configs /app/config rw,relatime - ext4 /dev/vda1 rw
+1085 1077 0:251 / /tmp rw,nosuid,nodev - tmpfs tmpfs rw
+`
+
+func TestMountFilesystem(t *testing.T) {
+	cases := []struct {
+		dir, want string
+	}{
+		{"/app/data", "ext4"},        // the volume itself
+		{"/app/data/sub", "ext4"},    // below the volume
+		{"/app/database", "overlay"}, // shares a prefix but is not inside the mount
+		{"/app", "overlay"},          // the image layer
+		{"/app/config/prod", "ext4"}, // bind mount with an escaped space in its source
+		{"/tmp/scratch", "tmpfs"},    // scratch space
+		{"/", "overlay"},             // the root
+	}
+	for _, tc := range cases {
+		got, ok := mountFilesystem(strings.NewReader(containerMountinfo), tc.dir)
+		if !ok || got != tc.want {
+			t.Errorf("mountFilesystem(%q) = %q, %v; want %q", tc.dir, got, ok, tc.want)
+		}
+	}
+}
+
+func TestMountFilesystemIgnoresMalformedLines(t *testing.T) {
+	got, ok := mountFilesystem(strings.NewReader("garbage\n1 2 3 4\n"), "/app")
+	if ok || got != "" {
+		t.Errorf("mountFilesystem on garbage = %q, %v; want no match", got, ok)
+	}
+}
+
+func TestUnescapeMountPath(t *testing.T) {
+	cases := map[string]string{
+		`/plain`:         "/plain",
+		`/with\040space`: "/with space",
+		`/tab\011here`:   "/tab\there",
+		`/trailing\04`:   `/trailing\04`,
+		`/not\xyz`:       `/not\xyz`,
+	}
+	for in, want := range cases {
+		if got := unescapeMountPath(in); got != want {
+			t.Errorf("unescapeMountPath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/runtimesettings/service.go
+++ b/internal/runtimesettings/service.go
@@ -32,17 +32,29 @@ type Service struct {
 	done     chan struct{}
 }
 
-// New restores registered settings and starts cross-instance reconciliation.
-func New(ctx context.Context, backend storage.Storage, registered []ext.RuntimeSetting) (*Service, error) {
-	if len(registered) == 0 {
-		return nil, nil
-	}
+// NewStore opens the deployment-wide key/value store on the shared backend.
+// Besides the registered settings it holds other small per-deployment state
+// that must live with the database rather than the filesystem, such as the
+// install identifier.
+func NewStore(ctx context.Context, backend storage.Storage) (Store, error) {
 	store, err := storage.ResolveSQLBackend[Store](ctx, backend,
 		func(db sqlx.DB) (Store, error) { return NewSQLStore(ctx, db) },
 		func(database *mongo.Database) (Store, error) { return NewMongoDBStore(ctx, database) },
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create runtime settings store: %w", err)
+	}
+	return store, nil
+}
+
+// New restores registered settings and starts cross-instance reconciliation.
+func New(ctx context.Context, backend storage.Storage, registered []ext.RuntimeSetting) (*Service, error) {
+	if len(registered) == 0 {
+		return nil, nil
+	}
+	store, err := NewStore(ctx, backend)
+	if err != nil {
+		return nil, err
 	}
 	service := &Service{
 		store:    store,

--- a/internal/runtimesettings/service_test.go
+++ b/internal/runtimesettings/service_test.go
@@ -81,13 +81,22 @@ func (s *stubStore) Get(_ context.Context, key string) (string, bool, error) {
 	return value, found, nil
 }
 
-func (s *stubStore) SetDefault(ctx context.Context, key, value string) (string, error) {
-	if stored, found, err := s.Get(ctx, key); err != nil || found {
-		return stored, err
-	}
-	if err := s.Set(ctx, key, value); err != nil {
+func (s *stubStore) SetDefault(_ context.Context, key, value string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.getErrs[key]; err != nil {
 		return "", err
 	}
+	if stored, found := s.values[key]; found {
+		return stored, nil
+	}
+	if s.setErr != nil {
+		return "", s.setErr
+	}
+	if s.values == nil {
+		s.values = make(map[string]string)
+	}
+	s.values[key] = value
 	return value, nil
 }
 

--- a/internal/runtimesettings/service_test.go
+++ b/internal/runtimesettings/service_test.go
@@ -81,6 +81,16 @@ func (s *stubStore) Get(_ context.Context, key string) (string, bool, error) {
 	return value, found, nil
 }
 
+func (s *stubStore) SetDefault(ctx context.Context, key, value string) (string, error) {
+	if stored, found, err := s.Get(ctx, key); err != nil || found {
+		return stored, err
+	}
+	if err := s.Set(ctx, key, value); err != nil {
+		return "", err
+	}
+	return value, nil
+}
+
 func (s *stubStore) Set(_ context.Context, key, value string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/runtimesettings/store.go
+++ b/internal/runtimesettings/store.go
@@ -6,4 +6,9 @@ import "context"
 type Store interface {
 	Get(ctx context.Context, key string) (value string, found bool, err error)
 	Set(ctx context.Context, key, value string) error
+	// SetDefault stores value only when key has no value yet, and returns
+	// whatever is stored afterwards: value, or the one that was already
+	// there. It is atomic, so instances racing to initialise the same key
+	// all end up with the same winner.
+	SetDefault(ctx context.Context, key, value string) (string, error)
 }

--- a/internal/runtimesettings/store_mongodb.go
+++ b/internal/runtimesettings/store_mongodb.go
@@ -41,6 +41,31 @@ func (s *MongoDBStore) Get(ctx context.Context, key string) (string, bool, error
 	return doc.Value, true, nil
 }
 
+// SetDefault inserts value unless key exists, then reads back the winner.
+// An upsert with $setOnInsert is atomic on the _id, so two instances
+// initialising at once cannot both believe they won.
+func (s *MongoDBStore) SetDefault(ctx context.Context, key, value string) (string, error) {
+	_, err := s.settings.UpdateOne(ctx,
+		bson.D{{Key: "_id", Value: key}},
+		bson.D{{Key: "$setOnInsert", Value: bson.D{
+			{Key: "value", Value: value},
+			{Key: "updated_at", Value: time.Now().Unix()},
+		}}},
+		options.UpdateOne().SetUpsert(true),
+	)
+	if err != nil {
+		return "", fmt.Errorf("initialise runtime setting %q: %w", key, err)
+	}
+	stored, found, err := s.Get(ctx, key)
+	if err != nil {
+		return "", err
+	}
+	if !found {
+		return "", fmt.Errorf("initialise runtime setting %q: value missing after insert", key)
+	}
+	return stored, nil
+}
+
 // Set upserts a persisted value.
 func (s *MongoDBStore) Set(ctx context.Context, key, value string) error {
 	doc := mongoDocument{Key: key, Value: value, UpdatedAt: time.Now().Unix()}

--- a/internal/runtimesettings/store_mongodb_test.go
+++ b/internal/runtimesettings/store_mongodb_test.go
@@ -29,5 +29,11 @@ func TestMongoDBStoreRoundTrip(t *testing.T) {
 		if err != nil || !found || value != "high" {
 			t.Fatalf("Get value=%q found=%v err=%v", value, found, err)
 		}
+		if stored, err := store.SetDefault(ctx, "pro.compression.level", "low"); err != nil || stored != "high" {
+			t.Fatalf("SetDefault on an existing key = %q, %v; want the existing value", stored, err)
+		}
+		if stored, err := store.SetDefault(ctx, "install_id", "first"); err != nil || stored != "first" {
+			t.Fatalf("SetDefault on a new key = %q, %v; want the given value", stored, err)
+		}
 	})
 }

--- a/internal/runtimesettings/store_sql.go
+++ b/internal/runtimesettings/store_sql.go
@@ -44,6 +44,27 @@ func (s *SQLStore) Get(ctx context.Context, key string) (string, bool, error) {
 	return value, true, nil
 }
 
+// SetDefault inserts value unless key exists, then reads back the winner.
+// ON CONFLICT DO NOTHING is atomic in both SQLite and PostgreSQL, so two
+// instances inserting at once cannot both believe they won.
+func (s *SQLStore) SetDefault(ctx context.Context, key, value string) (string, error) {
+	_, err := s.db.Exec(ctx, `
+		INSERT INTO runtime_settings (key, value, updated_at) VALUES (?, ?, ?)
+		ON CONFLICT(key) DO NOTHING
+	`, key, value, time.Now().Unix())
+	if err != nil {
+		return "", fmt.Errorf("initialise runtime setting %q: %w", key, err)
+	}
+	stored, found, err := s.Get(ctx, key)
+	if err != nil {
+		return "", err
+	}
+	if !found {
+		return "", fmt.Errorf("initialise runtime setting %q: value missing after insert", key)
+	}
+	return stored, nil
+}
+
 // Set upserts a persisted value.
 func (s *SQLStore) Set(ctx context.Context, key, value string) error {
 	_, err := s.db.Exec(ctx, `

--- a/internal/runtimesettings/store_sql_test.go
+++ b/internal/runtimesettings/store_sql_test.go
@@ -1,0 +1,70 @@
+package runtimesettings
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/enterpilot/gomodel/internal/storage"
+	"github.com/enterpilot/gomodel/internal/storage/sqlx"
+)
+
+func newSQLiteStore(t *testing.T) *SQLStore {
+	t.Helper()
+	backend := newTestStorage(t)
+	store, err := storage.ResolveSQLBackend[*SQLStore](context.Background(), backend,
+		func(db sqlx.DB) (*SQLStore, error) { return NewSQLStore(context.Background(), db) },
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("create SQL store: %v", err)
+	}
+	return store
+}
+
+func TestSQLStoreSetDefaultKeepsFirstValue(t *testing.T) {
+	ctx := context.Background()
+	store := newSQLiteStore(t)
+
+	if stored, err := store.SetDefault(ctx, "install_id", "first"); err != nil || stored != "first" {
+		t.Fatalf("SetDefault on a new key = %q, %v; want the given value", stored, err)
+	}
+	if stored, err := store.SetDefault(ctx, "install_id", "second"); err != nil || stored != "first" {
+		t.Fatalf("SetDefault on an existing key = %q, %v; want the first value", stored, err)
+	}
+	if err := store.Set(ctx, "install_id", "third"); err != nil {
+		t.Fatal(err)
+	}
+	if stored, err := store.SetDefault(ctx, "install_id", "fourth"); err != nil || stored != "third" {
+		t.Fatalf("SetDefault after Set = %q, %v; want the set value", stored, err)
+	}
+}
+
+func TestSQLStoreSetDefaultConvergesConcurrentWriters(t *testing.T) {
+	ctx := context.Background()
+	store := newSQLiteStore(t)
+
+	const writers = 8
+	results := make([]string, writers)
+	var wg sync.WaitGroup
+	for w := range writers {
+		wg.Go(func() {
+			stored, err := store.SetDefault(ctx, "install_id", string(rune('a'+w)))
+			if err != nil {
+				t.Errorf("writer %d: %v", w, err)
+			}
+			results[w] = stored
+		})
+	}
+	wg.Wait()
+
+	winner, found, err := store.Get(ctx, "install_id")
+	if err != nil || !found {
+		t.Fatalf("Get after concurrent SetDefault: found=%v err=%v", found, err)
+	}
+	for w, got := range results {
+		if got != winner {
+			t.Errorf("writer %d got %q, database holds %q", w, got, winner)
+		}
+	}
+}

--- a/internal/versioncheck/installid.go
+++ b/internal/versioncheck/installid.go
@@ -100,12 +100,6 @@ func NewIdentity(store Store, secret string) *Identity {
 	return &Identity{store: store, secret: secret}
 }
 
-// ResolveInstallID resolves the identifier once. It is Identity for callers
-// that do not need to keep retrying the database.
-func ResolveInstallID(ctx context.Context, store Store, secret string) (string, InstallIDSource) {
-	return NewIdentity(store, secret).Resolve(ctx)
-}
-
 // ID returns the identifier for a request, resolving it on first use.
 func (i *Identity) ID(ctx context.Context) string {
 	id, _ := i.Resolve(ctx)
@@ -160,11 +154,13 @@ func (i *Identity) Resolve(ctx context.Context) (string, InstallIDSource) {
 		switch {
 		case err != nil:
 			i.warnStoreOnce("install id could not be saved to the database; it stays in the data directory until it can", err)
-		case stored != i.id:
+		case strings.TrimSpace(stored) != "" && stored != i.id:
 			// Another replica initialised first, or the database already
 			// had an id the Get above missed: theirs is the deployment's.
 			i.adopt(stored, SourceDatabase, true)
 		default:
+			// Ours won — or the key holds a blank value, which must never
+			// become the deployment's id. Either way this id is final.
 			i.settled = true
 		}
 	} else if i.store == nil {

--- a/internal/versioncheck/installid.go
+++ b/internal/versioncheck/installid.go
@@ -1,10 +1,13 @@
 package versioncheck
 
 import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"github.com/google/uuid"
 
@@ -15,31 +18,139 @@ import (
 // gateway's other durable state.
 const installIDFile = "install-id"
 
-// installID memoizes the identifier so a data directory that cannot be written
-// still yields one stable value for the process instead of a fresh id per call.
-var installID = sync.OnceValue(readOrCreateInstallID)
+// InstallIDKey is the key the identifier is kept under in the deployment's
+// database, alongside the runtime settings.
+const InstallIDKey = "install_id"
 
-// InstallID returns a stable, anonymous identifier for this deployment,
-// creating one on first use. It is a random UUID: it encodes nothing about
-// the host, the operator, or the configuration, and only ever leaves the
-// process on an update check.
+// derivedIDPurpose is the fixed message signed with the operator's secret
+// when the identifier has to be derived. It ties the derivation to this use,
+// so the same secret used for anything else yields an unrelated value.
+const derivedIDPurpose = "gomodel install identifier v1"
+
+// Store is the durable key/value the identifier is kept in. It matches
+// runtimesettings.Store: the identifier is per-deployment state exactly like
+// a runtime setting, so it shares the table.
+type Store interface {
+	Get(ctx context.Context, key string) (value string, found bool, err error)
+	Set(ctx context.Context, key, value string) error
+}
+
+// InstallIDSource names where a resolved identifier came from, for the
+// startup log.
+type InstallIDSource string
+
+const (
+	// SourceDatabase: read from the deployment's database.
+	SourceDatabase InstallIDSource = "database"
+	// SourceFile: read from the install-id file in the data directory.
+	SourceFile InstallIDSource = "file"
+	// SourceDerived: computed from the operator's secret because nothing was
+	// stored; stable as long as the secret is.
+	SourceDerived InstallIDSource = "derived"
+	// SourceGenerated: freshly minted; nothing durable was available.
+	SourceGenerated InstallIDSource = "generated"
+)
+
+// ResolveInstallID returns the stable, anonymous identifier for this
+// deployment, creating one on first use. It is a random UUID that encodes
+// nothing about the host, the operator, or the configuration, and only ever
+// leaves the process on an update check.
 //
-// A read-only or unwritable data directory is not an error; the caller gets a
-// process-lifetime identifier instead.
-func InstallID() string { return installID() }
-
-func readOrCreateInstallID() string {
+// "This deployment" is defined by whatever survives longest, in this order:
+//
+//  1. The database, when a store is given. A gateway's database outlives its
+//     container (it is on a volume or on another host), so the identifier
+//     lives there first, and replicas sharing one database count as one.
+//  2. The install-id file in the data directory. The canonical location
+//     before the database was used; an existing id migrates to the database
+//     unchanged, so upgrading never creates a new deployment.
+//  3. An HMAC of the operator's secret, when one is configured. Nothing on
+//     disk survived (a container recreated without a volume) but the
+//     configuration did, and the same configuration is the same deployment.
+//  4. A random UUID.
+//
+// Whichever step wins is written back to the database and the file, so the
+// copies converge and the next start takes the shortest path. When the
+// database and the file disagree, the database wins: the file is the copy that
+// gets recreated by accident, the database the one that gets migrated on
+// purpose.
+//
+// A store that errors is not a store that is empty. The lookup falls through
+// to the file and the write-back is skipped, so a database that is briefly
+// unreachable at startup can never mint a new identity.
+func ResolveInstallID(ctx context.Context, store Store, secret string) (string, InstallIDSource) {
 	path := platformdir.DataFile(installIDFile)
-	if raw, err := os.ReadFile(path); err == nil {
-		if id := strings.TrimSpace(string(raw)); id != "" {
-			return id
+	fileID := readInstallIDFile(path)
+
+	storeUsable := store != nil
+	if storeUsable {
+		id, found, err := store.Get(ctx, InstallIDKey)
+		switch {
+		case err != nil:
+			slog.Warn("install id store unavailable; using the local copy and retrying next start", "error", err)
+			storeUsable = false
+		case found && strings.TrimSpace(id) != "":
+			id = strings.TrimSpace(id)
+			if id != fileID {
+				writeInstallIDFile(path, id)
+			}
+			return id, SourceDatabase
 		}
 	}
-	id := uuid.NewString()
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err == nil {
-		// 0600: the id is not a secret, but it is per-deployment state and
-		// has no reason to be world-readable.
-		_ = os.WriteFile(path, []byte(id+"\n"), 0o600)
+
+	var id string
+	source := SourceFile
+	switch {
+	case fileID != "":
+		id = fileID
+	case secret != "":
+		id, source = deriveInstallID(secret), SourceDerived
+	default:
+		id, source = uuid.NewString(), SourceGenerated
 	}
-	return id
+
+	if storeUsable {
+		if err := store.Set(ctx, InstallIDKey, id); err != nil {
+			slog.Warn("install id could not be saved to the database; it stays in the data directory", "error", err)
+		}
+	}
+	if id != fileID {
+		writeInstallIDFile(path, id)
+	}
+	return id, source
+}
+
+func readInstallIDFile(path string) string {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(raw))
+}
+
+// writeInstallIDFile is best-effort: a read-only or unwritable data
+// directory is not an error, the caller simply has a less durable id.
+func writeInstallIDFile(path, id string) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+	// 0600: the id is not a secret, but it is per-deployment state and has
+	// no reason to be world-readable.
+	_ = os.WriteFile(path, []byte(id+"\n"), 0o600)
+}
+
+// deriveInstallID turns the operator's secret into an identifier shaped like
+// every other one. HMAC-SHA256 is one-way: the identifier reveals nothing
+// about the secret, and the fixed purpose string keeps it unrelated to any
+// other value derived from the same secret.
+func deriveInstallID(secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(derivedIDPurpose))
+	var id uuid.UUID
+	copy(id[:], mac.Sum(nil))
+	// RFC 9562 version 8 marks a UUID whose bits are application-defined,
+	// which is exactly what this is; the variant bits make it well-formed.
+	id[6] = (id[6] & 0x0f) | 0x80
+	id[8] = (id[8] & 0x3f) | 0x80
+	return id.String()
 }

--- a/internal/versioncheck/installid.go
+++ b/internal/versioncheck/installid.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/google/uuid"
 
@@ -27,12 +28,14 @@ const InstallIDKey = "install_id"
 // so the same secret used for anything else yields an unrelated value.
 const derivedIDPurpose = "gomodel install identifier v1"
 
-// Store is the durable key/value the identifier is kept in. It matches
-// runtimesettings.Store: the identifier is per-deployment state exactly like
-// a runtime setting, so it shares the table.
+// Store is the durable key/value the identifier is kept in. It is satisfied
+// by runtimesettings.Store: the identifier is per-deployment state exactly
+// like a runtime setting, so it shares the table.
 type Store interface {
 	Get(ctx context.Context, key string) (value string, found bool, err error)
-	Set(ctx context.Context, key, value string) error
+	// SetDefault stores value only when key has no value yet, and returns
+	// whatever is stored afterwards. It must be atomic across instances.
+	SetDefault(ctx context.Context, key, value string) (string, error)
 }
 
 // InstallIDSource names where a resolved identifier came from, for the
@@ -51,10 +54,10 @@ const (
 	SourceGenerated InstallIDSource = "generated"
 )
 
-// ResolveInstallID returns the stable, anonymous identifier for this
-// deployment, creating one on first use. It is a random UUID that encodes
-// nothing about the host, the operator, or the configuration, and only ever
-// leaves the process on an update check.
+// Identity resolves and remembers the stable, anonymous identifier for this
+// deployment. It is a UUID that encodes nothing about the host, the
+// operator, or the configuration, and only ever leaves the process on an
+// update check.
 //
 // "This deployment" is defined by whatever survives longest, in this order:
 //
@@ -69,55 +72,121 @@ const (
 //     configuration did, and the same configuration is the same deployment.
 //  4. A random UUID.
 //
-// Whichever step wins is written back to the database and the file, so the
-// copies converge and the next start takes the shortest path. When the
-// database and the file disagree, the database wins: the file is the copy that
-// gets recreated by accident, the database the one that gets migrated on
-// purpose.
+// Whichever step wins is written to the database and the file, so the copies
+// converge and the next start takes the shortest path. The database write is
+// insert-if-absent: when two replicas initialise at once, or the file and
+// the database disagree, the database's value wins for everyone. The file is
+// the copy that gets recreated by accident, the database the one that gets
+// migrated on purpose.
 //
-// A store that errors is not a store that is empty. The lookup falls through
-// to the file and the write-back is skipped, so a database that is briefly
-// unreachable at startup can never mint a new identity.
+// A store that errors is not a store that is empty. The candidate from the
+// file or the fallbacks is used for now, and the database is asked again on
+// the next call, so an outage at startup can never mint a new identity or
+// hide the real one for the life of the process.
+type Identity struct {
+	store  Store
+	secret string
+
+	mu       sync.Mutex
+	id       string
+	source   InstallIDSource
+	settled  bool // the database has confirmed id, or there is no database
+	warnedDB bool // the outage has been logged once; retries stay quiet
+}
+
+// NewIdentity prepares a resolver. store may be nil (no database) and secret
+// may be empty (no derived fallback). Nothing is read until Resolve or ID.
+func NewIdentity(store Store, secret string) *Identity {
+	return &Identity{store: store, secret: secret}
+}
+
+// ResolveInstallID resolves the identifier once. It is Identity for callers
+// that do not need to keep retrying the database.
 func ResolveInstallID(ctx context.Context, store Store, secret string) (string, InstallIDSource) {
+	return NewIdentity(store, secret).Resolve(ctx)
+}
+
+// ID returns the identifier for a request, resolving it on first use.
+func (i *Identity) ID(ctx context.Context) string {
+	id, _ := i.Resolve(ctx)
+	return id
+}
+
+// Resolve returns the identifier and where it came from. Once the database
+// has confirmed the value (or there is no database to ask) the answer is
+// fixed; until then each call asks again, but keeps returning the same
+// provisional value rather than minting another.
+func (i *Identity) Resolve(ctx context.Context) (string, InstallIDSource) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.settled {
+		return i.id, i.source
+	}
+
 	path := platformdir.DataFile(installIDFile)
 	fileID := readInstallIDFile(path)
 
-	storeUsable := store != nil
+	storeUsable := i.store != nil
 	if storeUsable {
-		id, found, err := store.Get(ctx, InstallIDKey)
+		stored, found, err := i.store.Get(ctx, InstallIDKey)
 		switch {
 		case err != nil:
-			slog.Warn("install id store unavailable; using the local copy and retrying next start", "error", err)
+			i.warnStoreOnce("install id database unavailable; using the local copy until it answers", err)
 			storeUsable = false
-		case found && strings.TrimSpace(id) != "":
-			id = strings.TrimSpace(id)
-			if id != fileID {
-				writeInstallIDFile(path, id)
+		case found && strings.TrimSpace(stored) != "":
+			i.adopt(strings.TrimSpace(stored), SourceDatabase, true)
+			if i.id != fileID {
+				writeInstallIDFile(path, i.id)
 			}
-			return id, SourceDatabase
+			return i.id, i.source
 		}
 	}
 
-	var id string
-	source := SourceFile
-	switch {
-	case fileID != "":
-		id = fileID
-	case secret != "":
-		id, source = deriveInstallID(secret), SourceDerived
-	default:
-		id, source = uuid.NewString(), SourceGenerated
+	// The provisional id from an earlier call is kept: a database that is
+	// still down must not cause a second fresh id.
+	if i.id == "" {
+		switch {
+		case fileID != "":
+			i.adopt(fileID, SourceFile, false)
+		case i.secret != "":
+			i.adopt(deriveInstallID(i.secret), SourceDerived, false)
+		default:
+			i.adopt(uuid.NewString(), SourceGenerated, false)
+		}
 	}
 
 	if storeUsable {
-		if err := store.Set(ctx, InstallIDKey, id); err != nil {
-			slog.Warn("install id could not be saved to the database; it stays in the data directory", "error", err)
+		stored, err := i.store.SetDefault(ctx, InstallIDKey, i.id)
+		switch {
+		case err != nil:
+			i.warnStoreOnce("install id could not be saved to the database; it stays in the data directory until it can", err)
+		case stored != i.id:
+			// Another replica initialised first, or the database already
+			// had an id the Get above missed: theirs is the deployment's.
+			i.adopt(stored, SourceDatabase, true)
+		default:
+			i.settled = true
 		}
+	} else if i.store == nil {
+		i.settled = true
 	}
-	if id != fileID {
-		writeInstallIDFile(path, id)
+
+	if i.id != fileID {
+		writeInstallIDFile(path, i.id)
 	}
-	return id, source
+	return i.id, i.source
+}
+
+func (i *Identity) adopt(id string, source InstallIDSource, settled bool) {
+	i.id, i.source, i.settled = id, source, settled
+}
+
+func (i *Identity) warnStoreOnce(msg string, err error) {
+	if i.warnedDB {
+		return
+	}
+	i.warnedDB = true
+	slog.Warn(msg, "error", err)
 }
 
 func readInstallIDFile(path string) string {

--- a/internal/versioncheck/installid_test.go
+++ b/internal/versioncheck/installid_test.go
@@ -92,11 +92,17 @@ const (
 	freshID    = "ffffffff-0000-4000-8000-0000000000ff"
 )
 
+// resolveInstallID resolves once with a fresh Identity, the way a gateway
+// start does.
+func resolveInstallID(ctx context.Context, store Store, secret string) (string, InstallIDSource) {
+	return NewIdentity(store, secret).Resolve(ctx)
+}
+
 func TestResolveInstallIDGeneratesAndPersistsEverywhere(t *testing.T) {
 	path := useTempDataDir(t)
 	store := newFakeStore()
 
-	id, source := ResolveInstallID(context.Background(), store, "")
+	id, source := resolveInstallID(context.Background(), store, "")
 
 	if source != SourceGenerated {
 		t.Fatalf("source = %q, want %q", source, SourceGenerated)
@@ -111,7 +117,7 @@ func TestResolveInstallIDGeneratesAndPersistsEverywhere(t *testing.T) {
 		t.Errorf("file holds %q, want %q", got, id+"\n")
 	}
 
-	again, source := ResolveInstallID(context.Background(), store, "")
+	again, source := resolveInstallID(context.Background(), store, "")
 	if again != id || source != SourceDatabase {
 		t.Errorf("second resolve = %q (%s), want %q (%s)", again, source, id, SourceDatabase)
 	}
@@ -122,7 +128,7 @@ func TestResolveInstallIDMigratesExistingFileToDatabaseUnchanged(t *testing.T) {
 	writeFile(t, path, existingID)
 	store := newFakeStore()
 
-	id, source := ResolveInstallID(context.Background(), store, "secret")
+	id, source := resolveInstallID(context.Background(), store, "secret")
 
 	if id != existingID || source != SourceFile {
 		t.Fatalf("resolve = %q (%s), want the file's id from %s", id, source, SourceFile)
@@ -138,7 +144,7 @@ func TestResolveInstallIDDatabaseWinsOverRegeneratedFile(t *testing.T) {
 	store := newFakeStore()
 	store.values[InstallIDKey] = existingID
 
-	id, source := ResolveInstallID(context.Background(), store, "")
+	id, source := resolveInstallID(context.Background(), store, "")
 
 	if id != existingID || source != SourceDatabase {
 		t.Fatalf("resolve = %q (%s), want the database's id", id, source)
@@ -154,7 +160,7 @@ func TestResolveInstallIDKeepsFileWhenDatabaseErrors(t *testing.T) {
 	store := newFakeStore()
 	store.fail(errors.New("connection refused"), nil)
 
-	id, source := ResolveInstallID(context.Background(), store, "secret")
+	id, source := resolveInstallID(context.Background(), store, "secret")
 
 	if id != existingID || source != SourceFile {
 		t.Fatalf("resolve = %q (%s), want the file's id; a failing store must never mint a new one", id, source)
@@ -169,7 +175,7 @@ func TestResolveInstallIDKeepsFileWhenDatabaseWriteFails(t *testing.T) {
 	store := newFakeStore()
 	store.fail(nil, errors.New("read-only transaction"))
 
-	id, source := ResolveInstallID(context.Background(), store, "")
+	id, source := resolveInstallID(context.Background(), store, "")
 	if source != SourceGenerated {
 		t.Fatalf("source = %q, want %q", source, SourceGenerated)
 	}
@@ -178,9 +184,24 @@ func TestResolveInstallIDKeepsFileWhenDatabaseWriteFails(t *testing.T) {
 	}
 
 	// The file is what survives; a later start without the database reads it.
-	again, source := ResolveInstallID(context.Background(), nil, "")
+	again, source := resolveInstallID(context.Background(), nil, "")
 	if again != id || source != SourceFile {
 		t.Errorf("later resolve = %q (%s), want %q (%s)", again, source, id, SourceFile)
+	}
+}
+
+func TestResolveInstallIDNeverAdoptsBlankDatabaseValue(t *testing.T) {
+	useTempDataDir(t)
+	store := newFakeStore()
+	// Pathological: something left a blank value under the key. SetDefault
+	// keeps it (insert-if-absent), so its read-back returns the blank; the
+	// resolved id must be the local candidate, never the blank.
+	store.values[InstallIDKey] = " "
+
+	id, source := resolveInstallID(context.Background(), store, "secret")
+
+	if id == "" || id == " " || source != SourceDerived {
+		t.Fatalf("resolve = %q (%s), want the derived candidate", id, source)
 	}
 }
 
@@ -239,7 +260,7 @@ func TestIdentityConvergesConcurrentFirstStarts(t *testing.T) {
 func TestResolveInstallIDDerivesFromSecretWhenNothingStored(t *testing.T) {
 	useTempDataDir(t)
 
-	first, source := ResolveInstallID(context.Background(), nil, "operator-secret")
+	first, source := resolveInstallID(context.Background(), nil, "operator-secret")
 	if source != SourceDerived {
 		t.Fatalf("source = %q, want %q", source, SourceDerived)
 	}
@@ -249,13 +270,13 @@ func TestResolveInstallIDDerivesFromSecretWhenNothingStored(t *testing.T) {
 
 	// A recreated container: no file, same secret, same id.
 	useTempDataDir(t)
-	second, _ := ResolveInstallID(context.Background(), nil, "operator-secret")
+	second, _ := resolveInstallID(context.Background(), nil, "operator-secret")
 	if second != first {
 		t.Errorf("same secret derived %q then %q", first, second)
 	}
 
 	useTempDataDir(t)
-	other, _ := ResolveInstallID(context.Background(), nil, "another-secret")
+	other, _ := resolveInstallID(context.Background(), nil, "another-secret")
 	if other == first {
 		t.Error("different secrets derived the same id")
 	}
@@ -264,7 +285,7 @@ func TestResolveInstallIDDerivesFromSecretWhenNothingStored(t *testing.T) {
 func TestResolveInstallIDWithoutStoreUsesFile(t *testing.T) {
 	path := useTempDataDir(t)
 
-	id, source := ResolveInstallID(context.Background(), nil, "")
+	id, source := resolveInstallID(context.Background(), nil, "")
 	if source != SourceGenerated {
 		t.Fatalf("source = %q, want %q", source, SourceGenerated)
 	}
@@ -272,7 +293,7 @@ func TestResolveInstallIDWithoutStoreUsesFile(t *testing.T) {
 		t.Fatalf("file holds %q, want %q", got, id)
 	}
 
-	again, source := ResolveInstallID(context.Background(), nil, "")
+	again, source := resolveInstallID(context.Background(), nil, "")
 	if again != id || source != SourceFile {
 		t.Errorf("second resolve = %q (%s), want %q (%s)", again, source, id, SourceFile)
 	}

--- a/internal/versioncheck/installid_test.go
+++ b/internal/versioncheck/installid_test.go
@@ -1,0 +1,179 @@
+package versioncheck
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// useTempDataDir points platformdir's project-local data directory at a fresh
+// temp dir, so each test starts without an install-id file.
+func useTempDataDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+	return filepath.Join(dir, "data", installIDFile)
+}
+
+func writeFile(t *testing.T, path, id string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(id+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(raw)
+}
+
+type fakeStore struct {
+	values map[string]string
+	getErr error
+	setErr error
+	sets   int
+}
+
+func newFakeStore() *fakeStore { return &fakeStore{values: map[string]string{}} }
+
+func (s *fakeStore) Get(_ context.Context, key string) (string, bool, error) {
+	if s.getErr != nil {
+		return "", false, s.getErr
+	}
+	v, ok := s.values[key]
+	return v, ok, nil
+}
+
+func (s *fakeStore) Set(_ context.Context, key, value string) error {
+	s.sets++
+	if s.setErr != nil {
+		return s.setErr
+	}
+	s.values[key] = value
+	return nil
+}
+
+func TestResolveInstallIDGeneratesAndPersistsEverywhere(t *testing.T) {
+	path := useTempDataDir(t)
+	store := newFakeStore()
+
+	id, source := ResolveInstallID(context.Background(), store, "")
+
+	if source != SourceGenerated {
+		t.Fatalf("source = %q, want %q", source, SourceGenerated)
+	}
+	if _, err := uuid.Parse(id); err != nil {
+		t.Fatalf("id %q is not a UUID: %v", id, err)
+	}
+	if got := store.values[InstallIDKey]; got != id {
+		t.Errorf("database holds %q, want %q", got, id)
+	}
+	if got := readFile(t, path); got != id+"\n" {
+		t.Errorf("file holds %q, want %q", got, id+"\n")
+	}
+
+	again, source := ResolveInstallID(context.Background(), store, "")
+	if again != id || source != SourceDatabase {
+		t.Errorf("second resolve = %q (%s), want %q (%s)", again, source, id, SourceDatabase)
+	}
+}
+
+func TestResolveInstallIDMigratesExistingFileToDatabaseUnchanged(t *testing.T) {
+	path := useTempDataDir(t)
+	writeFile(t, path, "3f2a0000-0000-4000-8000-000000000001")
+	store := newFakeStore()
+
+	id, source := ResolveInstallID(context.Background(), store, "secret")
+
+	if id != "3f2a0000-0000-4000-8000-000000000001" || source != SourceFile {
+		t.Fatalf("resolve = %q (%s), want the file's id from %s", id, source, SourceFile)
+	}
+	if got := store.values[InstallIDKey]; got != id {
+		t.Errorf("database holds %q after migration, want %q", got, id)
+	}
+}
+
+func TestResolveInstallIDDatabaseWinsOverRegeneratedFile(t *testing.T) {
+	path := useTempDataDir(t)
+	writeFile(t, path, "ffffffff-0000-4000-8000-00000000fresh")
+	store := newFakeStore()
+	store.values[InstallIDKey] = "3f2a0000-0000-4000-8000-000000000001"
+
+	id, source := ResolveInstallID(context.Background(), store, "")
+
+	if id != "3f2a0000-0000-4000-8000-000000000001" || source != SourceDatabase {
+		t.Fatalf("resolve = %q (%s), want the database's id", id, source)
+	}
+	if got := readFile(t, path); got != id+"\n" {
+		t.Errorf("file not restored from database: %q", got)
+	}
+}
+
+func TestResolveInstallIDKeepsFileWhenDatabaseErrors(t *testing.T) {
+	path := useTempDataDir(t)
+	writeFile(t, path, "3f2a0000-0000-4000-8000-000000000001")
+	store := newFakeStore()
+	store.getErr = errors.New("connection refused")
+
+	id, source := ResolveInstallID(context.Background(), store, "secret")
+
+	if id != "3f2a0000-0000-4000-8000-000000000001" || source != SourceFile {
+		t.Fatalf("resolve = %q (%s), want the file's id; a failing store must never mint a new one", id, source)
+	}
+	if store.sets != 0 {
+		t.Errorf("wrote to a failing store %d times", store.sets)
+	}
+}
+
+func TestResolveInstallIDDerivesFromSecretWhenNothingStored(t *testing.T) {
+	useTempDataDir(t)
+
+	first, source := ResolveInstallID(context.Background(), nil, "operator-secret")
+	if source != SourceDerived {
+		t.Fatalf("source = %q, want %q", source, SourceDerived)
+	}
+	if _, err := uuid.Parse(first); err != nil {
+		t.Fatalf("derived id %q is not a UUID: %v", first, err)
+	}
+
+	// A recreated container: no file, same secret, same id.
+	useTempDataDir(t)
+	second, _ := ResolveInstallID(context.Background(), nil, "operator-secret")
+	if second != first {
+		t.Errorf("same secret derived %q then %q", first, second)
+	}
+
+	useTempDataDir(t)
+	other, _ := ResolveInstallID(context.Background(), nil, "another-secret")
+	if other == first {
+		t.Error("different secrets derived the same id")
+	}
+}
+
+func TestResolveInstallIDWithoutStoreUsesFile(t *testing.T) {
+	path := useTempDataDir(t)
+
+	id, source := ResolveInstallID(context.Background(), nil, "")
+	if source != SourceGenerated {
+		t.Fatalf("source = %q, want %q", source, SourceGenerated)
+	}
+	if got := readFile(t, path); got != id+"\n" {
+		t.Fatalf("file holds %q, want %q", got, id)
+	}
+
+	again, source := ResolveInstallID(context.Background(), nil, "")
+	if again != id || source != SourceFile {
+		t.Errorf("second resolve = %q (%s), want %q (%s)", again, source, id, SourceFile)
+	}
+}

--- a/internal/versioncheck/installid_test.go
+++ b/internal/versioncheck/installid_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/google/uuid"
@@ -38,7 +39,10 @@ func readFile(t *testing.T, path string) string {
 	return string(raw)
 }
 
+// fakeStore is an in-memory Store whose failures can be switched on and off
+// mid-test, standing in for a database that comes and goes.
 type fakeStore struct {
+	mu     sync.Mutex
 	values map[string]string
 	getErr error
 	setErr error
@@ -48,6 +52,8 @@ type fakeStore struct {
 func newFakeStore() *fakeStore { return &fakeStore{values: map[string]string{}} }
 
 func (s *fakeStore) Get(_ context.Context, key string) (string, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.getErr != nil {
 		return "", false, s.getErr
 	}
@@ -55,14 +61,36 @@ func (s *fakeStore) Get(_ context.Context, key string) (string, bool, error) {
 	return v, ok, nil
 }
 
-func (s *fakeStore) Set(_ context.Context, key, value string) error {
+func (s *fakeStore) SetDefault(_ context.Context, key, value string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.sets++
 	if s.setErr != nil {
-		return s.setErr
+		return "", s.setErr
+	}
+	if existing, ok := s.values[key]; ok {
+		return existing, nil
 	}
 	s.values[key] = value
-	return nil
+	return value, nil
 }
+
+func (s *fakeStore) fail(get, set error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.getErr, s.setErr = get, set
+}
+
+func (s *fakeStore) value(key string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.values[key]
+}
+
+const (
+	existingID = "3f2a0000-0000-4000-8000-000000000001"
+	freshID    = "ffffffff-0000-4000-8000-0000000000ff"
+)
 
 func TestResolveInstallIDGeneratesAndPersistsEverywhere(t *testing.T) {
 	path := useTempDataDir(t)
@@ -76,7 +104,7 @@ func TestResolveInstallIDGeneratesAndPersistsEverywhere(t *testing.T) {
 	if _, err := uuid.Parse(id); err != nil {
 		t.Fatalf("id %q is not a UUID: %v", id, err)
 	}
-	if got := store.values[InstallIDKey]; got != id {
+	if got := store.value(InstallIDKey); got != id {
 		t.Errorf("database holds %q, want %q", got, id)
 	}
 	if got := readFile(t, path); got != id+"\n" {
@@ -91,28 +119,28 @@ func TestResolveInstallIDGeneratesAndPersistsEverywhere(t *testing.T) {
 
 func TestResolveInstallIDMigratesExistingFileToDatabaseUnchanged(t *testing.T) {
 	path := useTempDataDir(t)
-	writeFile(t, path, "3f2a0000-0000-4000-8000-000000000001")
+	writeFile(t, path, existingID)
 	store := newFakeStore()
 
 	id, source := ResolveInstallID(context.Background(), store, "secret")
 
-	if id != "3f2a0000-0000-4000-8000-000000000001" || source != SourceFile {
+	if id != existingID || source != SourceFile {
 		t.Fatalf("resolve = %q (%s), want the file's id from %s", id, source, SourceFile)
 	}
-	if got := store.values[InstallIDKey]; got != id {
+	if got := store.value(InstallIDKey); got != id {
 		t.Errorf("database holds %q after migration, want %q", got, id)
 	}
 }
 
 func TestResolveInstallIDDatabaseWinsOverRegeneratedFile(t *testing.T) {
 	path := useTempDataDir(t)
-	writeFile(t, path, "ffffffff-0000-4000-8000-00000000fresh")
+	writeFile(t, path, freshID)
 	store := newFakeStore()
-	store.values[InstallIDKey] = "3f2a0000-0000-4000-8000-000000000001"
+	store.values[InstallIDKey] = existingID
 
 	id, source := ResolveInstallID(context.Background(), store, "")
 
-	if id != "3f2a0000-0000-4000-8000-000000000001" || source != SourceDatabase {
+	if id != existingID || source != SourceDatabase {
 		t.Fatalf("resolve = %q (%s), want the database's id", id, source)
 	}
 	if got := readFile(t, path); got != id+"\n" {
@@ -122,17 +150,89 @@ func TestResolveInstallIDDatabaseWinsOverRegeneratedFile(t *testing.T) {
 
 func TestResolveInstallIDKeepsFileWhenDatabaseErrors(t *testing.T) {
 	path := useTempDataDir(t)
-	writeFile(t, path, "3f2a0000-0000-4000-8000-000000000001")
+	writeFile(t, path, existingID)
 	store := newFakeStore()
-	store.getErr = errors.New("connection refused")
+	store.fail(errors.New("connection refused"), nil)
 
 	id, source := ResolveInstallID(context.Background(), store, "secret")
 
-	if id != "3f2a0000-0000-4000-8000-000000000001" || source != SourceFile {
+	if id != existingID || source != SourceFile {
 		t.Fatalf("resolve = %q (%s), want the file's id; a failing store must never mint a new one", id, source)
 	}
 	if store.sets != 0 {
 		t.Errorf("wrote to a failing store %d times", store.sets)
+	}
+}
+
+func TestResolveInstallIDKeepsFileWhenDatabaseWriteFails(t *testing.T) {
+	path := useTempDataDir(t)
+	store := newFakeStore()
+	store.fail(nil, errors.New("read-only transaction"))
+
+	id, source := ResolveInstallID(context.Background(), store, "")
+	if source != SourceGenerated {
+		t.Fatalf("source = %q, want %q", source, SourceGenerated)
+	}
+	if got := readFile(t, path); got != id+"\n" {
+		t.Fatalf("file holds %q after a failed database write, want %q", got, id)
+	}
+
+	// The file is what survives; a later start without the database reads it.
+	again, source := ResolveInstallID(context.Background(), nil, "")
+	if again != id || source != SourceFile {
+		t.Errorf("later resolve = %q (%s), want %q (%s)", again, source, id, SourceFile)
+	}
+}
+
+func TestIdentityRecoversDatabaseIDAfterOutage(t *testing.T) {
+	useTempDataDir(t)
+	store := newFakeStore()
+	store.values[InstallIDKey] = existingID
+	store.fail(errors.New("connection refused"), errors.New("connection refused"))
+	identity := NewIdentity(store, "secret")
+
+	// No file, database down: a provisional id is the best available, and it
+	// must stay the same provisional id while the outage lasts.
+	provisional, source := identity.Resolve(context.Background())
+	if source != SourceDerived || provisional == existingID {
+		t.Fatalf("during outage: %q (%s), want a derived provisional id", provisional, source)
+	}
+	if again := identity.ID(context.Background()); again != provisional {
+		t.Fatalf("provisional id changed during outage: %q then %q", provisional, again)
+	}
+
+	store.fail(nil, nil)
+	id, source := identity.Resolve(context.Background())
+	if id != existingID || source != SourceDatabase {
+		t.Fatalf("after outage: %q (%s), want the database's id", id, source)
+	}
+	if got := store.value(InstallIDKey); got != existingID {
+		t.Errorf("database overwritten with the provisional id: %q", got)
+	}
+}
+
+func TestIdentityConvergesConcurrentFirstStarts(t *testing.T) {
+	useTempDataDir(t)
+	store := newFakeStore()
+
+	// Replicas share a database but not a data directory, so each has its
+	// own Identity and no file; every one of them must end up with the id
+	// the database kept.
+	const replicas = 16
+	ids := make([]string, replicas)
+	var wg sync.WaitGroup
+	for r := range replicas {
+		wg.Go(func() {
+			ids[r] = NewIdentity(store, "").ID(context.Background())
+		})
+	}
+	wg.Wait()
+
+	winner := store.value(InstallIDKey)
+	for r, id := range ids {
+		if id != winner {
+			t.Errorf("replica %d kept %q, database holds %q", r, id, winner)
+		}
 	}
 }
 

--- a/internal/versioncheck/versioncheck.go
+++ b/internal/versioncheck/versioncheck.go
@@ -50,11 +50,15 @@ const DefaultURL = "https://gomodel.enterpilot.io/version"
 
 // Config configures a Checker. Zero values fall back to package defaults.
 type Config struct {
-	Enabled        bool
-	URL            string
-	App            string
-	Version        string
-	InstallID      string
+	Enabled   bool
+	URL       string
+	App       string
+	Version   string
+	InstallID string
+	// InstallIDFunc, when set, supplies the identifier per request instead
+	// of InstallID. An Identity uses it to keep retrying its database until
+	// it has confirmed which id this deployment has.
+	InstallIDFunc  func(context.Context) string
 	Interval       time.Duration
 	Timeout        time.Duration
 	MaxDailyChecks int
@@ -116,6 +120,13 @@ func New(cfg Config) *Checker {
 	}
 	manifest := manifestURL(cfg.URL, cfg.App)
 	return &Checker{cfg: cfg, url: manifest, safeURL: SafeURL(manifest)}
+}
+
+func (c *Checker) installID(ctx context.Context) string {
+	if c.cfg.InstallIDFunc != nil {
+		return c.cfg.InstallIDFunc(ctx)
+	}
+	return c.cfg.InstallID
 }
 
 // manifestURL appends the distribution's channel file to the configured base.
@@ -308,7 +319,7 @@ func (c *Checker) fetch(ctx context.Context, beacon Beacon) (string, error) {
 	req.Header.Set("User-Agent", fmt.Sprintf("%s/%s", strings.ReplaceAll(c.cfg.App, " ", "-"), c.cfg.Version))
 	req.Header.Set("X-GoModel-Version", c.cfg.Version)
 	req.Header.Set("X-GoModel-App", c.cfg.App)
-	req.Header.Set("X-GoModel-Install", c.cfg.InstallID)
+	req.Header.Set("X-GoModel-Install", c.installID(ctx))
 	beacon.apply(req)
 
 	resp, err := c.cfg.Client.Do(req)

--- a/internal/versioncheck/versioncheck_test.go
+++ b/internal/versioncheck/versioncheck_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -123,6 +124,35 @@ func TestRefreshSendsIdentityHeaders(t *testing.T) {
 		if got.Get(header) != want {
 			t.Errorf("%s = %q, want %q", header, got.Get(header), want)
 		}
+	}
+}
+
+func TestRefreshAsksInstallIDFuncPerRequest(t *testing.T) {
+	var sent []string
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	current := "provisional-id"
+	checker, _ := newTestChecker(t, Config{
+		InstallID:     "fixed-id",
+		InstallIDFunc: func(context.Context) string { return current },
+		Now:           func() time.Time { return now },
+	}, func(w http.ResponseWriter, r *http.Request) {
+		sent = append(sent, r.Header.Get("X-GoModel-Install"))
+		_, _ = w.Write([]byte("0.1.82"))
+	})
+
+	// The database answered between the two checks and the id it holds
+	// differs from the provisional one: the second request must carry it.
+	if _, err := checker.Refresh(context.Background(), Beacon{}); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	current = "database-id"
+	now = now.Add(2 * minRefreshInterval)
+	if _, err := checker.Refresh(context.Background(), Beacon{}); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	if want := []string{"provisional-id", "database-id"}; !slices.Equal(sent, want) {
+		t.Fatalf("X-GoModel-Install per request = %q, want %q (InstallID must not override the func)", sent, want)
 	}
 }
 


### PR DESCRIPTION
## Description

The install id lived only in `install-id` in the data directory. In the Docker image that directory is part of the container, so every `docker compose pull && up` or pod reschedule without a volume minted a new id. In the install-base stats that shows up as a new instance plus a churned one for every recreate: "new instances" is inflated and retention deflated.

**Resolution order** (`versioncheck.ResolveInstallID`), most durable first:

1. `runtime_settings` in the deployment's database (SQLite, PostgreSQL, MongoDB) — the store the runtime settings already use; `runtimesettings.NewStore` is exported for it.
2. The `install-id` file — an existing id is adopted **unchanged** and migrated to the database, so upgrading never creates a new deployment.
3. HMAC-SHA256 of `GOMODEL_MASTER_KEY` — survives a container recreated with no storage at all. The key is never sent and cannot be recovered from the id.
4. A fresh UUID.

Whichever wins is written back to the database and the file. When they disagree the database wins: the file is the copy that gets recreated by accident, the database the one that gets migrated on purpose. A store that *errors* falls through to the file and skips the write-back, so a database that is briefly unreachable at startup can never mint a new identity.

**Startup warning** (`platformdir.Ephemeral`): with SQLite, if the data directory sits on the container's `overlay`/`tmpfs` filesystem the gateway logs that its database and identity will not survive a recreate. Only SQLite is checked; with an external database the data directory holds nothing that isn't also in the database.

**Compose**: `gomodel_data:/app/data` on the `gomodel` service. **Docs**: version-awareness (where the id lives, the derived fallback and its caveat), production (the warning and the compose volume).

Behaviour changes worth knowing:

- Two hosts sharing one database now report as **one** deployment — the intended "one database = one deployment" semantics, but different from today.
- With no volume, no database and no master key, behaviour is unchanged (new id per recreate).
- Rotating the master key on a deployment that relies on the derived fallback reads as a new deployment.

## AI Generated (optional)

Verification:

- Unit tests for the resolution order (generate → persist everywhere; file migrates unchanged; DB wins over a regenerated file; erroring store keeps the file and never writes; derived id is stable per secret and differs per secret) and for the mountinfo parser, whose fixture was checked against a real Docker mountinfo (root `overlay`, volume `ext4`, tmpfs).
- End-to-end with the built binary in Alpine: no volume → `install id created source=derived` plus the warning; with a volume → no warning; second start → id served from the DB, `runtime_settings` holds the row; the derived id was identical across two fresh containers with the same master key.
- Pre-commit hooks passed in full: gofmt/imports, `make test-race`, `go mod tidy`, `make lint`, `mint validate`, `docker compose config`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TDFYG11UbbMiCGVM8gKNF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Gateway state and installation identity now persist across container recreation with the provided Docker Compose configuration.
  - Installation identities are preserved, migrated automatically, or deterministically restored when a master key is configured.
  - Concurrent startup processes now converge on a single installation identity.

- **Bug Fixes**
  - Improved recovery when identity storage is temporarily unavailable.
  - Added warnings when gateway data is stored on ephemeral container storage.

- **Documentation**
  - Added guidance on persistent storage, installation identity behavior, and ephemeral data directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->