### PR TITLE
fix(responses): always emit annotations on output_text parts

### DIFF
--- a/internal/core/responses_json.go
+++ b/internal/core/responses_json.go
@@ -344,6 +344,25 @@ func (i ResponsesOutputItem) MarshalJSON() ([]byte, error) {
 	return marshalWithUnknownJSONFields(alias(i), i.ExtraFields)
 }
 
+// MarshalJSON keeps `annotations` on the wire for output_text parts. OpenAI
+// always returns `annotations: []` there and OpenAI SDK consumers (for
+// example LangChain's Responses converter) index into it without a nil
+// check, so an omitted field breaks them. Input parts keep the field only
+// when a caller supplied it.
+func (c ResponsesContentItem) MarshalJSON() ([]byte, error) {
+	type alias ResponsesContentItem
+	if c.Annotations == nil {
+		if c.Type != "output_text" {
+			return json.Marshal(alias(c))
+		}
+		c.Annotations = []json.RawMessage{}
+	}
+	return json.Marshal(struct {
+		alias
+		Annotations []json.RawMessage `json:"annotations"`
+	}{alias(c), c.Annotations})
+}
+
 // cloneRawMessage returns a detached, whitespace-trimmed copy of a raw JSON
 // value so stored Raw fields stay independent of the decoder's backing buffer.
 func cloneRawMessage(data []byte) json.RawMessage {

--- a/internal/core/responses_json.go
+++ b/internal/core/responses_json.go
@@ -351,10 +351,10 @@ func (i ResponsesOutputItem) MarshalJSON() ([]byte, error) {
 // when a caller supplied it.
 func (c ResponsesContentItem) MarshalJSON() ([]byte, error) {
 	type alias ResponsesContentItem
+	if c.Type != "output_text" {
+		return json.Marshal(alias(c))
+	}
 	if c.Annotations == nil {
-		if c.Type != "output_text" {
-			return json.Marshal(alias(c))
-		}
 		c.Annotations = []json.RawMessage{}
 	}
 	return json.Marshal(struct {

--- a/internal/core/responses_json_test.go
+++ b/internal/core/responses_json_test.go
@@ -1107,6 +1107,8 @@ func TestResponsesContentItemMarshalJSON_Annotations(t *testing.T) {
 		{"output_text empty annotations", ResponsesContentItem{Type: "output_text", Text: "hi", Annotations: []json.RawMessage{}}, `{"type":"output_text","text":"hi","annotations":[]}`},
 		{"output_text with annotations", ResponsesContentItem{Type: "output_text", Text: "hi", Annotations: []json.RawMessage{json.RawMessage(`{"type":"url_citation"}`)}}, `{"type":"output_text","text":"hi","annotations":[{"type":"url_citation"}]}`},
 		{"input_text omits annotations", ResponsesContentItem{Type: "input_text", Text: "hi"}, `{"type":"input_text","text":"hi"}`},
+		{"input_text omits empty annotations", ResponsesContentItem{Type: "input_text", Text: "hi", Annotations: []json.RawMessage{}}, `{"type":"input_text","text":"hi"}`},
+		{"input_text keeps supplied annotations", ResponsesContentItem{Type: "input_text", Text: "hi", Annotations: []json.RawMessage{json.RawMessage(`{"type":"url_citation"}`)}}, `{"type":"input_text","text":"hi","annotations":[{"type":"url_citation"}]}`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/core/responses_json_test.go
+++ b/internal/core/responses_json_test.go
@@ -1096,3 +1096,27 @@ func TestResponsesInputElementRoundTrip(t *testing.T) {
 		t.Fatalf("round-trip Input[2] = %+v, want function_call_output with output preserved", input2[2])
 	}
 }
+
+func TestResponsesContentItemMarshalJSON_Annotations(t *testing.T) {
+	tests := []struct {
+		name string
+		item ResponsesContentItem
+		want string
+	}{
+		{"output_text nil annotations", ResponsesContentItem{Type: "output_text", Text: "hi"}, `{"type":"output_text","text":"hi","annotations":[]}`},
+		{"output_text empty annotations", ResponsesContentItem{Type: "output_text", Text: "hi", Annotations: []json.RawMessage{}}, `{"type":"output_text","text":"hi","annotations":[]}`},
+		{"output_text with annotations", ResponsesContentItem{Type: "output_text", Text: "hi", Annotations: []json.RawMessage{json.RawMessage(`{"type":"url_citation"}`)}}, `{"type":"output_text","text":"hi","annotations":[{"type":"url_citation"}]}`},
+		{"input_text omits annotations", ResponsesContentItem{Type: "input_text", Text: "hi"}, `{"type":"input_text","text":"hi"}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := json.Marshal(tt.item)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if string(got) != tt.want {
+				t.Fatalf("got %s, want %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/tests/contract/testdata/golden/anthropic/responses.golden.json
+++ b/tests/contract/testdata/golden/anthropic/responses.golden.json
@@ -7,6 +7,7 @@
     {
       "content": [
         {
+          "annotations": [],
           "text": "Hello World",
           "type": "output_text"
         }

--- a/tests/contract/testdata/golden/gemini/responses.golden.json
+++ b/tests/contract/testdata/golden/gemini/responses.golden.json
@@ -7,6 +7,7 @@
     {
       "content": [
         {
+          "annotations": [],
           "text": "Hello World",
           "type": "output_text"
         }

--- a/tests/contract/testdata/golden/groq/responses.golden.json
+++ b/tests/contract/testdata/golden/groq/responses.golden.json
@@ -7,6 +7,7 @@
     {
       "content": [
         {
+          "annotations": [],
           "text": "Hello World!",
           "type": "output_text"
         }

--- a/tests/contract/testdata/golden/openai/responses.golden.json
+++ b/tests/contract/testdata/golden/openai/responses.golden.json
@@ -7,6 +7,7 @@
     {
       "content": [
         {
+          "annotations": [],
           "text": "Hello, World!",
           "type": "output_text"
         }

--- a/tests/contract/testdata/golden/xai/responses.golden.json
+++ b/tests/contract/testdata/golden/xai/responses.golden.json
@@ -19,6 +19,7 @@
     {
       "content": [
         {
+          "annotations": [],
           "text": "Hello, World!",
           "type": "output_text"
         }


### PR DESCRIPTION
## Summary

`ResponsesContentItem.Annotations` is tagged `omitempty`, which also drops empty slices, so the `annotations: []` every output builder sets (since #136) never reached the wire — on native OpenAI passthrough too, since OpenAI's own `[]` was decoded and dropped on re-marshal.

OpenAI always returns `annotations: []` on `output_text` parts and OpenAI SDK consumers rely on it: LangChain's Responses converter calls `part.annotations.map(...)` unguarded, so every n8n **OpenAI Chat Model** call with *Use Responses API* on (the n8n 2.x default) failed with `Cannot read properties of undefined (reading 'map')` — for OpenAI, Anthropic, and Gemini models alike.

Adds `ResponsesContentItem.MarshalJSON` that emits `annotations: []` for `output_text` parts and leaves other part types (input items) untouched.

## User-visible impact

`/v1/responses` output_text parts now carry `annotations` (`[]` when empty), matching OpenAI. Verified end to end with n8n 2.36 AI Agent + tool calls on OpenAI, Anthropic, and Gemini.

## Tests

Table test for output_text nil/empty/populated annotations and input_text omission in `responses_json_test.go`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized response output by including an empty `annotations` array for output text content.
  * Preserved omission of `annotations` where it does not apply, keeping response payloads consistent.
  * Ensured populated annotations continue to be included in responses.

* **Tests**
  * Expanded response serialization coverage across supported providers and content types.
  * Updated expected response examples to reflect the standardized annotations field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->