### PR TITLE
fix(models): scope GET /v1/models by the user-path header

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -590,6 +590,15 @@ func (h *Handler) Health(c *echo.Context) error {
 // @Failure      502  {object}  core.OpenAIErrorEnvelope
 // @Router       /v1/models [get]
 func (h *Handler) ListModels(c *echo.Context) error {
+	// /v1/models is not a model-interaction endpoint, so the snapshot
+	// middleware does not lift the user-path header into the context. A
+	// managed key's bound path (set by auth middleware) still wins; the header
+	// only fills in for header-only and master-key callers, so the list is
+	// filtered by the same user-path policies inference enforces.
+	if ok, err := applyUserPathHeaderToContext(c); !ok {
+		return err
+	}
+
 	// Create context with request ID for provider
 	requestID := c.Request().Header.Get(core.RequestIDHeader)
 	ctx := core.WithRequestID(c.Request().Context(), requestID)

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -7401,3 +7401,85 @@ type staticPipelineResolver struct{ pipeline *guardrails.Pipeline }
 func (s staticPipelineResolver) PipelineForContext(context.Context) *guardrails.Pipeline {
 	return s.pipeline
 }
+
+// A caller that carries only the user-path header (no managed key) must get
+// the same policy-filtered model list that inference enforces for that path.
+func TestListModels_ScopesByUserPathHeader(t *testing.T) {
+	mock := &mockProvider{
+		modelsResponse: &core.ModelsResponse{
+			Object: "list",
+			Data: []core.Model{
+				{ID: "openai/gpt-4o", Object: "model", OwnedBy: "openai"},
+				{ID: "anthropic/claude-sonnet-4-6", Object: "model", OwnedBy: "anthropic"},
+			},
+		},
+	}
+	authorizer := &userPathModelAuthorizer{allowedUnder: map[string]string{
+		"/acme/eng": "anthropic",
+	}}
+
+	e := echo.New()
+	handler := NewHandler(mock, nil, nil, nil)
+	handler.modelAuthorizer = authorizer
+
+	list := func(headers map[string]string) (int, string) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+		for k, v := range headers {
+			req.Header.Set(k, v)
+		}
+		rec := httptest.NewRecorder()
+		require.NoError(t, handler.ListModels(e.NewContext(req, rec)))
+		return rec.Code, rec.Body.String()
+	}
+
+	code, body := list(nil)
+	require.Equal(t, http.StatusOK, code)
+	require.Contains(t, body, `"id":"openai/gpt-4o"`)
+	require.Contains(t, body, `"id":"anthropic/claude-sonnet-4-6"`)
+
+	code, body = list(map[string]string{core.UserPathHeader: "/acme/eng/alice"})
+	require.Equal(t, http.StatusOK, code)
+	require.NotContains(t, body, `"id":"openai/gpt-4o"`)
+	require.Contains(t, body, `"id":"anthropic/claude-sonnet-4-6"`)
+	require.Equal(t, "/acme/eng/alice", authorizer.lastUserPath)
+
+	code, body = list(map[string]string{core.UserPathHeader: "/acme/../eng"})
+	require.Equal(t, http.StatusBadRequest, code)
+	require.Contains(t, body, "invalid "+core.UserPathHeader+" header")
+	require.NotContains(t, body, `"object":"list"`)
+}
+
+// userPathModelAuthorizer allows a provider only under a user-path prefix and
+// records the user path it was consulted with.
+type userPathModelAuthorizer struct {
+	allowedUnder map[string]string
+	lastUserPath string
+}
+
+func (a *userPathModelAuthorizer) ValidateModelAccess(ctx context.Context, selector core.ModelSelector) error {
+	if !a.AllowsModel(ctx, selector) {
+		return core.NewInvalidRequestError("denied", nil)
+	}
+	return nil
+}
+
+func (a *userPathModelAuthorizer) AllowsModel(ctx context.Context, selector core.ModelSelector) bool {
+	a.lastUserPath = core.UserPathFromContext(ctx)
+	for prefix, provider := range a.allowedUnder {
+		if strings.HasPrefix(a.lastUserPath, prefix) {
+			return selector.Provider == provider
+		}
+	}
+	return true
+}
+
+func (a *userPathModelAuthorizer) FilterPublicModels(ctx context.Context, models []core.Model) []core.Model {
+	out := make([]core.Model, 0, len(models))
+	for _, m := range models {
+		selector, err := core.ParseModelSelector(m.ID, "")
+		if err == nil && a.AllowsModel(ctx, selector) {
+			out = append(out, m)
+		}
+	}
+	return out
+}

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/enterpilot/gomodel/internal/admin"
 	"github.com/enterpilot/gomodel/internal/admin/dashboard"
+	"github.com/stretchr/testify/require"
+
 	"github.com/enterpilot/gomodel/internal/core"
 	"github.com/enterpilot/gomodel/internal/providers"
 	"github.com/enterpilot/gomodel/internal/usage"
@@ -1221,4 +1223,49 @@ func TestProviderPassthroughRoute_DisabledRequiresAuthBefore404(t *testing.T) {
 	if mock.lastPassthroughProvider != "" || mock.lastPassthroughReq != nil {
 		t.Fatal("passthrough handler should not be invoked when provider passthrough is disabled")
 	}
+}
+
+// A deployment with a custom user-path header must scope GET /v1/models by
+// that header through the full middleware chain, not only by the default one.
+func TestServerListModelsScopesByConfiguredUserPathHeader(t *testing.T) {
+	mock := &mockProvider{
+		modelsResponse: &core.ModelsResponse{
+			Object: "list",
+			Data: []core.Model{
+				{ID: "openai/gpt-4o", Object: "model", OwnedBy: "openai"},
+				{ID: "anthropic/claude-sonnet-4-6", Object: "model", OwnedBy: "anthropic"},
+			},
+		},
+	}
+	authorizer := &userPathModelAuthorizer{allowedUnder: map[string]string{"/acme/eng": "anthropic"}}
+	srv := New(mock, &Config{
+		UserPathHeader:  "X-Tenant-Path",
+		ModelAuthorizer: authorizer,
+	})
+
+	list := func(header, value string) (int, string) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+		if header != "" {
+			req.Header.Set(header, value)
+		}
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+		return rec.Code, rec.Body.String()
+	}
+
+	code, body := list("X-Tenant-Path", "/acme/eng/alice")
+	require.Equal(t, http.StatusOK, code)
+	require.NotContains(t, body, `"id":"openai/gpt-4o"`)
+	require.Contains(t, body, `"id":"anthropic/claude-sonnet-4-6"`)
+	require.Equal(t, "/acme/eng/alice", authorizer.lastUserPath)
+
+	// The default header is not the configured one, so it carries no identity.
+	code, body = list(core.UserPathHeader, "/acme/eng/alice")
+	require.Equal(t, http.StatusOK, code)
+	require.Contains(t, body, `"id":"openai/gpt-4o"`)
+	require.Equal(t, "", authorizer.lastUserPath)
+
+	code, body = list("X-Tenant-Path", "/acme/../eng")
+	require.Equal(t, http.StatusBadRequest, code)
+	require.Contains(t, body, "invalid X-Tenant-Path header")
 }

--- a/internal/server/request_snapshot.go
+++ b/internal/server/request_snapshot.go
@@ -27,6 +27,10 @@ func RequestSnapshotCapture(userPathHeader ...string) echo.MiddlewareFunc {
 			c.Response().Header().Set(core.RequestIDHeader, requestID)
 			desc := core.DescribeEndpoint(req.Method, req.URL.Path)
 			if !desc.IngressManaged {
+				// The configured header name must reach every handler that
+				// reads the user path itself (GET /v1/models), not only the
+				// model-interaction endpoints below.
+				req = req.WithContext(core.WithUserPathHeaderName(req.Context(), userPathHeaderName))
 				// Model endpoints that own their transport (MCP, realtime,
 				// audio) take no snapshot, but their identity must still reach
 				// the context: rate limits, budgets, session binding, and
@@ -40,8 +44,7 @@ func RequestSnapshotCapture(userPathHeader ...string) echo.MiddlewareFunc {
 					}
 					if userPath != "" {
 						req.Header.Set(userPathHeaderName, userPath)
-						ctx := core.WithUserPathHeaderName(req.Context(), userPathHeaderName)
-						req = req.WithContext(core.WithEffectiveUserPath(ctx, userPath))
+						req = req.WithContext(core.WithEffectiveUserPath(req.Context(), userPath))
 					}
 				}
 				c.SetRequest(req)

--- a/internal/server/request_support.go
+++ b/internal/server/request_support.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
 
 	"github.com/enterpilot/gomodel/internal/core"
 )
@@ -19,6 +20,32 @@ func requestIDFromContextOrHeader(req *http.Request) string {
 		return requestID
 	}
 	return clientRequestID(req.Header)
+}
+
+// applyUserPathHeaderToContext lifts the user-path header into the request
+// context when no user path is bound yet. Endpoints outside the snapshot
+// middleware's model-interaction set (GET /v1/models) use it so header-only
+// callers are scoped like inference requests. An invalid header is rejected
+// with the same 400 the middleware would return; the response is then
+// already written and the handler must stop, which the false return signals.
+func applyUserPathHeaderToContext(c *echo.Context) (bool, error) {
+	req := c.Request()
+	ctx := req.Context()
+	if core.UserPathFromContext(ctx) != "" {
+		return true, nil
+	}
+	headerName := core.UserPathHeaderNameFromContext(ctx)
+	userPath, err := core.NormalizeUserPath(req.Header.Get(headerName))
+	if err != nil {
+		return false, handleError(c, core.NewInvalidRequestError("invalid "+headerName+" header", err))
+	}
+	if userPath == "" {
+		return true, nil
+	}
+	req.Header.Set(headerName, userPath)
+	ctx = core.WithUserPathHeaderName(ctx, headerName)
+	c.SetRequest(req.WithContext(core.WithEffectiveUserPath(ctx, userPath)))
+	return true, nil
 }
 
 // maxClientRequestIDLength bounds the request ID a caller may supply; anything

--- a/tests/e2e/release-e2e-scenarios.md
+++ b/tests/e2e/release-e2e-scenarios.md
@@ -785,7 +785,7 @@ Creates an alias pointing to the newest cheap OpenAI model.
 curl -fsS -X PUT "$BASE_URL/admin/virtual-models" \
   -H 'Content-Type: application/json' \
   -d "{\"source\":\"$QA_OPENAI_ALIAS\",\"target_model\":\"openai/gpt-4.1-nano\",\"description\":\"QA alias for release e2e\"}" \
-  | jq -e --arg source "$QA_OPENAI_ALIAS" '.source == $source and .kind == "redirect" and .resolved_model == "openai/gpt-4.1-nano" and .provider_type == "openai" and .targets[0].provider == "openai" and .targets[0].model == "gpt-4.1-nano" and .enabled == true' >/dev/null
+  | jq -e --arg source "$QA_OPENAI_ALIAS" '.source == $source and .kind == "redirect" and .resolved_model == "openai/gpt-4.1-nano" and .provider_type == "openai" and .targets[0].model == "openai/gpt-4.1-nano" and .enabled == true' >/dev/null
 ```
 
 ### S14 Create Anthropic alias
@@ -796,7 +796,7 @@ Creates an alias pointing to `claude-sonnet-4-6`.
 curl -fsS -X PUT "$BASE_URL/admin/virtual-models" \
   -H 'Content-Type: application/json' \
   -d "{\"source\":\"$QA_ANTHROPIC_ALIAS\",\"target_model\":\"anthropic/claude-sonnet-4-6\",\"description\":\"QA alias for anthropic reasoning\"}" \
-  | jq -e --arg source "$QA_ANTHROPIC_ALIAS" '.source == $source and .kind == "redirect" and .resolved_model == "anthropic/claude-sonnet-4-6" and .provider_type == "anthropic" and .targets[0].provider == "anthropic" and .targets[0].model == "claude-sonnet-4-6" and .enabled == true' >/dev/null
+  | jq -e --arg source "$QA_ANTHROPIC_ALIAS" '.source == $source and .kind == "redirect" and .resolved_model == "anthropic/claude-sonnet-4-6" and .provider_type == "anthropic" and .targets[0].model == "anthropic/claude-sonnet-4-6" and .enabled == true' >/dev/null
 ```
 
 ### S15 Verify aliases are exposed in `/v1/models`
@@ -2699,7 +2699,7 @@ curl -fsS -X PUT "$BASE_URL/admin/virtual-models" \
   | jq -e --arg s "$SRC" '
       .source == $s and .kind == "redirect" and .strategy == "round_robin"
       and (.targets | length) == 2
-      and .targets[0].model == "gpt-4.1-nano" and .targets[1].model == "groq/compound-mini"
+      and .targets[0].model == "openai/gpt-4.1-nano" and .targets[1].model == "groq/groq/compound-mini"
       and .enabled == true
     ' >/dev/null
 curl -fsS -X DELETE "$BASE_URL/admin/virtual-models" \
@@ -3042,7 +3042,7 @@ NAME="qa-failover-$QA_SUFFIX"
 curl -fsS -X PUT "$BASE_URL/admin/virtual-models" \
   -H 'Content-Type: application/json' \
   -d "{\"source\":\"$NAME\",\"strategy\":\"failover\",\"targets\":[{\"model\":\"openai/gpt-4.1-nano\"},{\"model\":\"gemini/gemini-2.5-flash-lite\"}]}" \
-  | jq -e --arg name "$NAME" '.source == $name and .strategy == "failover" and (.targets | map(.model)) == ["gpt-4.1-nano","gemini-2.5-flash-lite"]' >/dev/null
+  | jq -e --arg name "$NAME" '.source == $name and .strategy == "failover" and (.targets | map(.model)) == ["openai/gpt-4.1-nano","gemini/gemini-2.5-flash-lite"]' >/dev/null
 curl -fsS "$BASE_URL/admin/virtual-models" \
   | jq -e --arg name "$NAME" 'map(select(.source == $name)) | length == 1' >/dev/null
 curl -sS -o /dev/null -w '%{http_code}' -X DELETE "$BASE_URL/admin/virtual-models" -H 'Content-Type: application/json' \


### PR DESCRIPTION
## Summary

`GET /v1/models` returned the full catalog to callers that carry only the `X-GoModel-User-Path` header (or the master key plus that header), even when the user-path policy on that path denies most models at inference. Managed keys were already filtered because auth middleware binds their path; header-only requests never had their path lifted into the context since `/v1/models` is not a model-interaction endpoint for the snapshot middleware.

- `ListModels` now normalises the user-path header into the request context when no path is bound yet, so the same authorizer filters the list. A managed key's bound path still wins; an invalid header returns the same 400 the middleware uses.
- Adds a handler test covering unscoped, scoped, and invalid-header cases.
- Updates four release-matrix assertions (S13, S14, S118, S133) to the `targets[]` shape introduced in #788, which had made them fail.

## User-visible impact

Clients that pick a model from `/v1/models` under a restricted user path no longer see models they cannot call. No change for requests without a user path or for managed keys.
