### PR TITLE
fix(virtualmodels): do not chain through a redirect that shadows its own source

### DIFF
--- a/docs/features/failover.mdx
+++ b/docs/features/failover.mdx
@@ -68,10 +68,12 @@ virtual_models:
 A target may also name another virtual model
 ([chaining](/features/virtual-models#chain-virtual-models)); the sweep then
 tries every concrete model behind it. One exception keeps mutual protection
-possible: when one failover chain lists a model that is protected by its own
-chain, that fallback reaches the model only — its fallbacks are not swept in
-turn — which is what lets `gpt-4o` fall back to `claude-sonnet-4-6` while
-`claude-sonnet-4-6` falls back to `gpt-4o`.
+possible: when a chain that shadows a real model lists another model that is
+shadowed the same way, that fallback reaches the model only — its fallbacks
+are not swept in turn — which is what lets `gpt-4o` fall back to
+`claude-sonnet-4-6` while `claude-sonnet-4-6` falls back to `gpt-4o`. Any
+other redirect (an alias, a virtual model under a new name) that lists a
+protected model does sweep that model's fallbacks.
 
 ## When it runs
 

--- a/docs/features/failover.mdx
+++ b/docs/features/failover.mdx
@@ -67,7 +67,10 @@ virtual_models:
 
 A target may also name another virtual model
 ([chaining](/features/virtual-models#chain-virtual-models)); the sweep then
-tries every concrete model behind it.
+tries every concrete model behind it. A target that names a model protected by
+its own failover chain reaches that model only — its fallbacks are not swept
+in turn, which is what lets `gpt-4o` fall back to `claude-sonnet-4-6` while
+`claude-sonnet-4-6` falls back to `gpt-4o`.
 
 ## When it runs
 

--- a/docs/features/failover.mdx
+++ b/docs/features/failover.mdx
@@ -67,9 +67,10 @@ virtual_models:
 
 A target may also name another virtual model
 ([chaining](/features/virtual-models#chain-virtual-models)); the sweep then
-tries every concrete model behind it. A target that names a model protected by
-its own failover chain reaches that model only — its fallbacks are not swept
-in turn, which is what lets `gpt-4o` fall back to `claude-sonnet-4-6` while
+tries every concrete model behind it. One exception keeps mutual protection
+possible: when one failover chain lists a model that is protected by its own
+chain, that fallback reaches the model only — its fallbacks are not swept in
+turn — which is what lets `gpt-4o` fall back to `claude-sonnet-4-6` while
 `claude-sonnet-4-6` falls back to `gpt-4o`.
 
 ## When it runs

--- a/docs/features/virtual-models.mdx
+++ b/docs/features/virtual-models.mdx
@@ -171,6 +171,14 @@ virtual model of that name even though it looks like `provider/model`. Set
 `provider` explicitly (`{ provider: groq, model: llama-3.3-70b }`) to pin a
 target to a concrete model regardless of any virtual model sharing the name.
 
+One exception: a redirect that [shadows a real model](#shadow-a-model) and
+lists that model among its own targets (the shape the Models page creates when
+you add fallbacks to a model) adds failover to the model rather than replacing
+it. Other redirects that name the model reach the model itself, not the
+shadow's fallback list, so two models can fall back to each other without
+forming a cycle. A shadow that does *not* list its source replaces the model
+and is chained through like any other virtual model.
+
 Chains must be acyclic (`a -> b -> a` is rejected, with the cycle spelled out)
 and at most 8 virtual models deep. Both rules are enforced when saving from the
 dashboard and at startup for declarative entries. A target must exist when it is

--- a/docs/features/virtual-models.mdx
+++ b/docs/features/virtual-models.mdx
@@ -171,13 +171,17 @@ virtual model of that name even though it looks like `provider/model`. Set
 `provider` explicitly (`{ provider: groq, model: llama-3.3-70b }`) to pin a
 target to a concrete model regardless of any virtual model sharing the name.
 
-One exception: a redirect that [shadows a real model](#shadow-a-model) and
-lists that model among its own targets (the shape the Models page creates when
-you add fallbacks to a model) adds failover to the model rather than replacing
-it. Other redirects that name the model reach the model itself, not the
-shadow's fallback list, so two models can fall back to each other without
-forming a cycle. A shadow that does *not* list its source replaces the model
-and is chained through like any other virtual model.
+A redirect that [shadows a real model](#shadow-a-model) and lists that model
+among its own targets (the shape the Models page creates when you add
+fallbacks or balancing to a model) covers the model rather than replacing it.
+An alias or any other redirect that names the model chains into that cover, so
+it gets the same balancing and failover a direct request gets — with one
+exception: the fallback reference of one such cover to another covered model
+reaches the model itself, not the other cover's fallback list. That is what
+lets two models protect each other without forming a cycle, and keeps a
+fallback from sweeping the fallbacks of the fallback. A shadow that does *not*
+list its source replaces the model and is chained through like any other
+virtual model.
 
 Chains must be acyclic (`a -> b -> a` is rejected, with the cycle spelled out)
 and at most 8 virtual models deep. Both rules are enforced when saving from the

--- a/docs/features/virtual-models.mdx
+++ b/docs/features/virtual-models.mdx
@@ -179,9 +179,12 @@ it gets the same balancing and failover a direct request gets — with one
 exception: the fallback reference of one such cover to another covered model
 reaches the model itself, not the other cover's fallback list. That is what
 lets two models protect each other without forming a cycle, and keeps a
-fallback from sweeping the fallbacks of the fallback. A shadow that does *not*
-list its source replaces the model and is chained through like any other
-virtual model.
+fallback from sweeping the fallbacks of the fallback. Because a bare
+reference to a covered model names the model rather than the cover, the cover
+can be deleted while such references exist — they simply revert to the
+concrete model. A shadow that does *not* list its source replaces the model
+and is chained through like any other virtual model: references chain into
+its targets, and it cannot be deleted or renamed until they are repointed.
 
 Chains must be acyclic (`a -> b -> a` is rejected, with the cycle spelled out)
 and at most 8 virtual models deep. Both rules are enforced when saving from the

--- a/internal/virtualmodels/chain.go
+++ b/internal/virtualmodels/chain.go
@@ -15,15 +15,22 @@ const MaxChainDepth = 8
 // redirect's source is a chain leg rather than a concrete model — including
 // slash-named sources such as "team/cheap", which parse like a provider
 // prefix but were not declared as one. A target naming owner itself is not a
-// chain: it stands for the concrete model the redirect shadows. Disabled
-// redirects are returned too: the caller decides whether that makes the leg
-// unavailable.
+// chain: it stands for the concrete model the redirect shadows. Neither is a
+// target naming a redirect that shadows its own source (a failover chain
+// added to a real model): that redirect covers the concrete model rather than
+// replacing it, so other redirects reach the model itself — which keeps two
+// models that fall back to each other from forming a cycle, and keeps a
+// fallback from sweeping the fallbacks of the fallback. Disabled redirects
+// are returned too: the caller decides whether that makes the leg unavailable.
 func (s *snapshot) chained(owner string, target resolvedTarget) (*redirectEntry, bool) {
 	if target.explicitProvider || target.qualified == owner {
 		return nil, false
 	}
 	entry, ok := s.redirects[target.qualified]
-	return entry, ok
+	if !ok || entry.shadowsSource() {
+		return nil, false
+	}
+	return entry, true
 }
 
 // viableTargets returns entry's direct targets that can currently serve a
@@ -124,7 +131,7 @@ func (s *snapshot) dependents(source string) []string {
 			continue
 		}
 		for _, target := range s.redirects[name].targets {
-			if !target.explicitProvider && target.qualified == source {
+			if inner, ok := s.chained(name, target); ok && inner.vm.Source == source {
 				out = append(out, name)
 				break
 			}

--- a/internal/virtualmodels/chain.go
+++ b/internal/virtualmodels/chain.go
@@ -16,19 +16,27 @@ const MaxChainDepth = 8
 // slash-named sources such as "team/cheap", which parse like a provider
 // prefix but were not declared as one. A target naming owner itself is not a
 // chain: it stands for the concrete model the redirect shadows. Neither is a
-// target naming a redirect that shadows its own source (a failover chain
-// added to a real model): that redirect covers the concrete model rather than
-// replacing it, so other redirects reach the model itself — which keeps two
-// models that fall back to each other from forming a cycle, and keeps a
-// fallback from sweeping the fallbacks of the fallback. Disabled redirects
-// are returned too: the caller decides whether that makes the leg unavailable.
+// target of one self-shadowing redirect naming another self-shadowing
+// redirect: each of those covers its concrete model rather than replacing it,
+// so one chain's fallback reference reaches the other model itself — which
+// keeps two models that protect each other from forming a cycle, and keeps a
+// fallback from sweeping the fallbacks of the fallback. Every other reference
+// to a self-shadowing redirect still chains, so an alias to a shadowed model
+// gets the same balancing and failover a direct request gets. Disabled
+// redirects are returned too: the caller decides whether that makes the leg
+// unavailable.
 func (s *snapshot) chained(owner string, target resolvedTarget) (*redirectEntry, bool) {
 	if target.explicitProvider || target.qualified == owner {
 		return nil, false
 	}
 	entry, ok := s.redirects[target.qualified]
-	if !ok || entry.shadowsSource() {
+	if !ok {
 		return nil, false
+	}
+	if entry.shadowsSource() {
+		if ownerEntry, ok := s.redirects[owner]; ok && ownerEntry.shadowsSource() {
+			return nil, false
+		}
 	}
 	return entry, true
 }
@@ -124,7 +132,12 @@ func (s *snapshot) representativeLeaf(entry *redirectEntry) (resolvedTarget, boo
 }
 
 // dependents lists the redirects that chain through source, sorted by source.
+// A self-shadowing redirect has none: a bare reference to it names the model
+// it covers, and simply reverts to the concrete model when it is deleted.
 func (s *snapshot) dependents(source string) []string {
+	if entry, ok := s.redirects[source]; ok && entry.shadowsSource() {
+		return nil
+	}
 	var out []string
 	for _, name := range s.order {
 		if name == source {

--- a/internal/virtualmodels/chain_test.go
+++ b/internal/virtualmodels/chain_test.go
@@ -246,3 +246,65 @@ func TestChain_SlashNamedVirtualModelIsChained(t *testing.T) {
 		t.Fatalf("Upsert(pinned) error = %v, want unknown provider rejection", err)
 	}
 }
+
+// A redirect that shadows its own source adds failover to a real model rather
+// than replacing it, so other redirects that name the model reach the model —
+// not the shadow's fallback list. Two models protecting each other is the
+// common legacy failover-rule shape and must not read as a cycle.
+func TestChain_SelfShadowingRedirectIsNotAChainLeg(t *testing.T) {
+	t.Parallel()
+	svc := newBalancingService(t)
+	ctx := context.Background()
+	upsertRedirect(t, svc, "openai/gpt-4o", StrategyFailover, "openai/gpt-4o", "groq/llama")
+	// Mutual protection: previously rejected as openai/gpt-4o -> groq/llama -> openai/gpt-4o.
+	upsertRedirect(t, svc, "groq/llama", StrategyFailover, "groq/llama", "openai/gpt-4o")
+
+	for _, source := range []string{"openai/gpt-4o", "groq/llama"} {
+		sel, _, err := svc.ResolveModel(core.NewRequestedModelSelector(source, ""))
+		if err != nil || sel.QualifiedModel() != source {
+			t.Fatalf("ResolveModel(%s) = %v, %v; want the model itself", source, sel, err)
+		}
+	}
+
+	// An alias on a shadowed model resolves to the concrete model, not through
+	// the shadow's fallbacks, and does not pin the shadow in place.
+	upsertRedirect(t, svc, "prod", "", "openai/gpt-4o")
+	sel, _, err := svc.ResolveModel(core.NewRequestedModelSelector("prod", ""))
+	if err != nil || sel.QualifiedModel() != "openai/gpt-4o" {
+		t.Fatalf("ResolveModel(prod) = %v, %v; want openai/gpt-4o", sel, err)
+	}
+	if err := svc.Delete(ctx, "openai/gpt-4o"); err != nil {
+		t.Fatalf("Delete(self-shadow referenced by prod) error = %v, want success", err)
+	}
+
+	// A redirect that replaces the model (no self target) is still a chain leg.
+	upsertRedirect(t, svc, "openai/gpt-4o", "", "groq/llama")
+	sel, _, err = svc.ResolveModel(core.NewRequestedModelSelector("prod", ""))
+	if err != nil || sel.QualifiedModel() != "groq/llama" {
+		t.Fatalf("ResolveModel(prod) through replacing shadow = %v, %v; want groq/llama", sel, err)
+	}
+	if err := svc.Delete(ctx, "openai/gpt-4o"); err == nil || !IsValidationError(err) {
+		t.Fatalf("Delete(replacing shadow referenced by prod) error = %v, want validation error", err)
+	}
+}
+
+// Legacy failover rules that fall back to each other migrate into a set of
+// self-shadowing redirects that must load together.
+func TestChain_MutualMigratedFailoverRulesLoad(t *testing.T) {
+	t.Parallel()
+	a, ok := failoverModel("openai/gpt-4o", []string{"groq/llama"}, true)
+	if !ok {
+		t.Fatalf("failoverModel(a) = !ok")
+	}
+	b, ok := failoverModel("groq/llama", []string{"openai/gpt-4o"}, true)
+	if !ok {
+		t.Fatalf("failoverModel(b) = !ok")
+	}
+	if _, err := buildSnapshot([]VirtualModel{a, b}, true); err != nil {
+		t.Fatalf("buildSnapshot(mutual rules) error = %v", err)
+	}
+	snap, _ := buildSnapshot([]VirtualModel{a, b}, true)
+	if err := validateChains(&snap); err != nil {
+		t.Fatalf("validateChains(mutual rules) error = %v, want none", err)
+	}
+}

--- a/internal/virtualmodels/chain_test.go
+++ b/internal/virtualmodels/chain_test.go
@@ -247,10 +247,11 @@ func TestChain_SlashNamedVirtualModelIsChained(t *testing.T) {
 	}
 }
 
-// A redirect that shadows its own source adds failover to a real model rather
-// than replacing it, so other redirects that name the model reach the model —
-// not the shadow's fallback list. Two models protecting each other is the
-// common legacy failover-rule shape and must not read as a cycle.
+// A redirect that shadows its own source covers a real model rather than
+// replacing it. Two such chains referencing each other reach each other's
+// concrete model — mutual protection, the common legacy failover-rule shape,
+// must not read as a cycle — while any other reference still chains into the
+// shadow so it gets the same balancing and failover a direct request gets.
 func TestChain_SelfShadowingRedirectIsNotAChainLeg(t *testing.T) {
 	t.Parallel()
 	svc := newBalancingService(t)
@@ -266,8 +267,9 @@ func TestChain_SelfShadowingRedirectIsNotAChainLeg(t *testing.T) {
 		}
 	}
 
-	// An alias on a shadowed model resolves to the concrete model, not through
-	// the shadow's fallbacks, and does not pin the shadow in place.
+	// An alias on a shadowed model chains into the shadow (a failover shadow
+	// serves its primary first), and does not pin the shadow in place: the
+	// alias reverts to the concrete model when the shadow is deleted.
 	upsertRedirect(t, svc, "prod", "", "openai/gpt-4o")
 	sel, _, err := svc.ResolveModel(core.NewRequestedModelSelector("prod", ""))
 	if err != nil || sel.QualifiedModel() != "openai/gpt-4o" {
@@ -276,8 +278,17 @@ func TestChain_SelfShadowingRedirectIsNotAChainLeg(t *testing.T) {
 	if err := svc.Delete(ctx, "openai/gpt-4o"); err != nil {
 		t.Fatalf("Delete(self-shadow referenced by prod) error = %v, want success", err)
 	}
+	sel, _, err = svc.ResolveModel(core.NewRequestedModelSelector("prod", ""))
+	if err != nil || sel.QualifiedModel() != "openai/gpt-4o" {
+		t.Fatalf("ResolveModel(prod) after shadow delete = %v, %v; want openai/gpt-4o", sel, err)
+	}
 
 	// A redirect that replaces the model (no self target) is still a chain leg.
+	// The groq/llama self-shadow must go first: its fallback reference to
+	// openai/gpt-4o would chain into the replacing shadow and genuinely cycle.
+	if err := svc.Delete(ctx, "groq/llama"); err != nil {
+		t.Fatalf("Delete(groq/llama shadow) error = %v", err)
+	}
 	upsertRedirect(t, svc, "openai/gpt-4o", "", "groq/llama")
 	sel, _, err = svc.ResolveModel(core.NewRequestedModelSelector("prod", ""))
 	if err != nil || sel.QualifiedModel() != "groq/llama" {
@@ -286,6 +297,33 @@ func TestChain_SelfShadowingRedirectIsNotAChainLeg(t *testing.T) {
 	if err := svc.Delete(ctx, "openai/gpt-4o"); err == nil || !IsValidationError(err) {
 		t.Fatalf("Delete(replacing shadow referenced by prod) error = %v, want validation error", err)
 	}
+}
+
+// A load-balanced shadow (source enlisted among its targets) balances the
+// same way for a direct request and for an alias that names the model, and
+// two balanced shadows may reference each other without forming a cycle.
+func TestChain_SelfShadowingRedirectBalancesForReferences(t *testing.T) {
+	t.Parallel()
+	svc := newBalancingService(t)
+	upsertRedirect(t, svc, "openai/gpt-4o", StrategyRoundRobin, "openai/gpt-4o", "groq/llama")
+	upsertRedirect(t, svc, "prod", "", "openai/gpt-4o")
+
+	direct := map[string]bool{}
+	for _, got := range resolvedModels(t, svc, "openai/gpt-4o", 8) {
+		direct[got] = true
+	}
+	viaAlias := map[string]bool{}
+	for _, got := range resolvedModels(t, svc, "prod", 8) {
+		viaAlias[got] = true
+	}
+	for _, want := range []string{"openai/gpt-4o", "groq/llama"} {
+		if !direct[want] || !viaAlias[want] {
+			t.Fatalf("rotation: direct=%v viaAlias=%v; want both to include %s", direct, viaAlias, want)
+		}
+	}
+
+	// Mutual balanced shadows load like mutual failover shadows.
+	upsertRedirect(t, svc, "groq/llama", StrategyRoundRobin, "groq/llama", "openai/gpt-4o")
 }
 
 // Legacy failover rules that fall back to each other migrate into a set of


### PR DESCRIPTION
## Summary

Since #788 a bare-name target resolves to a virtual model of that name at request time. A redirect that shadows a real model and lists it first (`source: openai/gpt-4o, targets: [openai/gpt-4o, groq/llama]` — the shape the Models page creates and the shape every migrated legacy failover rule has) was treated as a chain leg too. Two models that fall back to each other therefore read as a cycle and the gateway refused to start:

```
startup failed: failed to initialize virtual models: virtual model chain forms a cycle:
anthropic/claude-sonnet-4-5-20250929 -> openrouter/anthropic/claude-sonnet-4.5 -> anthropic/claude-sonnet-4-5-20250929
```

Any database whose failover rules were migrated by #788 (208 rows in one real dev database) hits this on the next start, and the same declaration in `config.yaml` fails startup.

- A redirect that shadows its own source covers the concrete model rather than replacing it (the reading `failoverEntry` already applies to explicit-provider requests). `chained()` now collapses only an edge **from one such cover to another** to the concrete model — that is the edge that made mutual protection read as a cycle, and it also keeps a fallback from sweeping the fallbacks of the fallback. Every other reference (an alias, a plain redirect) still chains into the cover, so it gets the same balancing and failover a direct request gets; this also applies to load-balanced shadows (`round_robin`/`cost` with the source enlisted among the targets). A shadow that does not list its source replaces the model and is chained through as before.
- `dependents()` treats a self-shadowing cover as having none: a bare reference to it names the model it covers and simply reverts to the concrete model when the cover is deleted, so the cover can be removed while aliases name the model.
- Tests: mutual failover covers load and resolve to themselves; an alias on a covered model chains into the cover, keeps resolving after the cover is deleted, and a round_robin cover balances identically for direct and alias requests; a replacing shadow is still a chain leg and still blocks deletion; two migrated legacy rules referencing each other build a valid snapshot.
- Docs: one paragraph each in virtual-models and failover.

## User-visible impact

Gateways with mutual failover chains (dashboard, `config.yaml`, or migrated legacy rules) start again. When one protected model is a fallback of another protected model, the fallback leg reaches that model only — its fallbacks are not swept in turn. Aliases and other redirects that name a shadowed model keep the shadow's balancing and failover, matching direct requests. Verified by booting the affected database: 212 virtual models load, all valid.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Virtual model shadows can provide balancing and failover while preserving the original model.
  * Aliases and redirects inherit balancing and failover behavior from the referenced model.
  * Mutually protective models can use fallback rules without creating cycle errors.
  * References to covered models continue resolving to the concrete model if the cover is removed.

* **Documentation**
  * Clarified virtual model chaining, shadow redirects, balancing, fallback targets, and failover resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->