### PR TITLE
fix(telemetry): default OpenTelemetry service.name to the product name

### DIFF
--- a/docs/guides/opentelemetry.mdx
+++ b/docs/guides/opentelemetry.mdx
@@ -68,7 +68,7 @@ wins over the YAML value.
 | Environment variable | `config.yaml` key | Default | Purpose |
 | --- | --- | --- | --- |
 | `OTEL_ENABLED` | `enabled` | `false` | Turn export on. |
-| `OTEL_SERVICE_NAME` | `service_name` | `gomodel` | `service.name` resource attribute. |
+| `OTEL_SERVICE_NAME` | `service_name` | product name (`gomodel`; `gomodel-pro` in Pro) | `service.name` resource attribute. |
 | `OTEL_RESOURCE_ATTRIBUTES` | `resource_attributes` | — | Extra resource attributes such as `deployment.environment`. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `endpoint` | `http://localhost:4318` | Collector endpoint. `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` and `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` override it per signal. |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | `protocol` | `http/protobuf` | `http/protobuf` or `grpc`; overridable per signal with `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` and `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL`. |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -117,6 +117,11 @@ type Config struct {
 	// DemoMode exposes a prominent dashboard warning for public demo instances.
 	// It does not change persistence or security behavior.
 	DemoMode bool
+
+	// ProductName names the running distribution (for example "gomodel-pro")
+	// and becomes the default OpenTelemetry service.name. Empty means
+	// "gomodel".
+	ProductName string
 }
 
 // applyExtensions snapshots a registered extension set into the server
@@ -304,7 +309,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 	// too must exist before the first provider is constructed.
 	if appCfg.OpenTelemetry.Enabled {
 		metricsEndpoint := config.ResolveMetricsEndpointWithPprof(appCfg.Metrics.Endpoint, appCfg.Server.PprofEnabled)
-		app.telemetry, err = telemetry.New(ctx, appCfg.OpenTelemetry, metricsEndpoint)
+		app.telemetry, err = telemetry.New(ctx, appCfg.OpenTelemetry, metricsEndpoint, cfg.ProductName)
 		if err != nil {
 			return fail("failed to initialize opentelemetry", err)
 		}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -69,14 +69,13 @@ type Service struct {
 // collector does not need to be reachable for this call to succeed.
 // metricsEndpoint is the resolved Prometheus path, excluded from HTTP
 // instrumentation together with the other operational endpoints.
-func New(ctx context.Context, cfg config.OpenTelemetryConfig, metricsEndpoint string) (*Service, error) {
+// serviceName is the default service.name resource attribute — the product
+// name of the running distribution — used unless OTEL_SERVICE_NAME or the
+// YAML service_name overrides it. Empty falls back to "gomodel".
+func New(ctx context.Context, cfg config.OpenTelemetryConfig, metricsEndpoint, serviceName string) (*Service, error) {
 	exportEnvironment(cfg.Environment())
 
-	res, err := resource.New(ctx,
-		resource.WithAttributes(semconv.ServiceName(defaultServiceName)),
-		resource.WithTelemetrySDK(),
-		resource.WithFromEnv(),
-	)
+	res, err := newResource(ctx, serviceName)
 	if err != nil {
 		return nil, fmt.Errorf("detect OpenTelemetry resource: %w", err)
 	}
@@ -136,6 +135,20 @@ func (s *Service) Close() error {
 	metricsDone := make(chan error, 1)
 	go func() { metricsDone <- s.meterProvider.Shutdown(ctx) }()
 	return errors.Join(s.tracerProvider.Shutdown(ctx), <-metricsDone)
+}
+
+// newResource describes this process to the telemetry backend. Environment
+// detection runs last so OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES
+// (including their YAML-exported values) override the built-in defaults.
+func newResource(ctx context.Context, serviceName string) (*resource.Resource, error) {
+	if serviceName == "" {
+		serviceName = defaultServiceName
+	}
+	return resource.New(ctx,
+		resource.WithAttributes(semconv.ServiceName(serviceName)),
+		resource.WithTelemetrySDK(),
+		resource.WithFromEnv(),
+	)
 }
 
 func newMiddleware(tp *sdkTrace.TracerProvider, mp *sdkMetric.MeterProvider, propagators propagation.TextMapPropagator, metricsEndpoint string) (echo.MiddlewareFunc, error) {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -20,7 +20,7 @@ func TestNewBuildsMiddlewareAndHooksWithoutExporters(t *testing.T) {
 	t.Setenv("OTEL_TRACES_EXPORTER", "none")
 	t.Setenv("OTEL_METRICS_EXPORTER", "none")
 
-	service, err := New(t.Context(), config.OpenTelemetryConfig{}, "/metrics")
+	service, err := New(t.Context(), config.OpenTelemetryConfig{}, "/metrics", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,7 +34,7 @@ func TestNewBuildsMiddlewareAndHooksWithoutExporters(t *testing.T) {
 
 func TestNewRejectsUnknownExporter(t *testing.T) {
 	t.Setenv("OTEL_TRACES_EXPORTER", "zipkin")
-	_, err := New(t.Context(), config.OpenTelemetryConfig{}, "/metrics")
+	_, err := New(t.Context(), config.OpenTelemetryConfig{}, "/metrics", "")
 	if err == nil || !strings.Contains(err.Error(), "otlp or none") {
 		t.Fatalf("error = %v, want supported-exporter error", err)
 	}
@@ -196,5 +196,45 @@ func TestPlaintextCredentialSignals(t *testing.T) {
 				t.Fatalf("plaintextCredentialSignals() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestNewResourceServiceName(t *testing.T) {
+	t.Setenv("OTEL_SERVICE_NAME", "")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "")
+	serviceName := func(t *testing.T, res *resource.Resource) string {
+		t.Helper()
+		for _, attr := range res.Attributes() {
+			if attr.Key == semconv.ServiceNameKey {
+				return attr.Value.AsString()
+			}
+		}
+		t.Fatal("resource has no service.name")
+		return ""
+	}
+
+	res, err := newResource(t.Context(), "gomodel-pro")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := serviceName(t, res); got != "gomodel-pro" {
+		t.Fatalf("service.name = %q, want the product name", got)
+	}
+
+	res, err = newResource(t.Context(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := serviceName(t, res); got != "gomodel" {
+		t.Fatalf("service.name = %q, want the gomodel default", got)
+	}
+
+	t.Setenv("OTEL_SERVICE_NAME", "from-env")
+	res, err = newResource(t.Context(), "gomodel-pro")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := serviceName(t, res); got != "from-env" {
+		t.Fatalf("service.name = %q, want OTEL_SERVICE_NAME to override the product name", got)
 	}
 }

--- a/internal/telemetry/yaml_test.go
+++ b/internal/telemetry/yaml_test.go
@@ -35,7 +35,7 @@ func TestNewAppliesYAMLSettingsToExporter(t *testing.T) {
 		Protocol:        "http/protobuf",
 		Headers:         map[string]string{"authorization": "Bearer top secret"},
 		MetricsExporter: "none",
-	}, "/metrics")
+	}, "/metrics", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/run/run.go
+++ b/run/run.go
@@ -46,7 +46,8 @@ const (
 // gateway on os.Args.
 type Options struct {
 	// ProductName names the binary in CLI usage output, the startup log line,
-	// and --version output. Default: "gomodel".
+	// --version output, and the default OpenTelemetry service.name. Default:
+	// "gomodel".
 	ProductName string
 	// AppName names the distribution in the X-GoModel-App header and decides
 	// which release manifest the update check reads ("core.txt" or
@@ -233,10 +234,11 @@ func Run(ctx context.Context, opts Options) error {
 		opts.ConfigureSwaggerDocs(result.Config.Server.BasePath)
 
 		application, err := app.New(ctx, app.Config{
-			AppConfig:  result,
-			Factory:    defaultProviderFactory(result.Config),
-			Extensions: opts.Extensions,
-			DemoMode:   demoMode,
+			AppConfig:   result,
+			Factory:     defaultProviderFactory(result.Config),
+			Extensions:  opts.Extensions,
+			DemoMode:    demoMode,
+			ProductName: opts.ProductName,
 		})
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to initialize application: %w", err)


### PR DESCRIPTION
The default `service.name` resource attribute was hardcoded to `gomodel`, so distributions built on `run.Run` (such as GoModel Pro, which previously defaulted to `gomodel-pro`) report telemetry under the wrong service identity unless the operator sets `OTEL_SERVICE_NAME`.

`run.Options.ProductName` now flows through `app.Config` into the telemetry resource as the default `service.name`. `OTEL_SERVICE_NAME` and the YAML `opentelemetry.service_name` still override it; empty still falls back to `gomodel`, so plain GoModel is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenTelemetry service names now identify the running product distribution.
  * Custom product names are used for telemetry when configured.
  * Standard installations default to `gomodel`, while Pro installations use `gomodel-pro`.

* **Documentation**
  * Updated OpenTelemetry guidance to reflect the product-specific default service names.
  * Clarified how configured product names affect telemetry identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->