### PR TITLE
fix(modeldata): resolve metadata for models with a routing suffix

### DIFF
--- a/internal/modeldata/merger.go
+++ b/internal/modeldata/merger.go
@@ -51,6 +51,17 @@ func resolveEntries(list *ModelList, providerType string, modelID string) (*Mode
 	return resolveRoutingSuffixAlias(list, providerType, modelID)
 }
 
+// routingSuffixes are the known routing/pricing variants a model ID may carry
+// after a colon. The set is closed on purpose: an arbitrary ":tail" can be
+// provider syntax with a different meaning — Bedrock encodes a model version
+// as "...-v1:0" — and stripping it would attach a neighbouring entry's
+// metadata to a distinct model.
+var routingSuffixes = map[string]struct{}{
+	"floor": {},
+	"free":  {},
+	"nitro": {},
+}
+
 // resolveRoutingSuffixAlias retries the lookup without a trailing routing
 // suffix such as ":floor", ":free" or ":nitro". The suffix picks how a request
 // is routed or billed, not which model answers it, and the registry carries an
@@ -58,7 +69,9 @@ func resolveEntries(list *ModelList, providerType string, modelID string) (*Mode
 // no metadata at all — no display name, no context window, no capabilities —
 // even though the identical unsuffixed ID right next to it is fully described.
 //
-// Runs last so an explicit entry for the suffixed ID always wins.
+// Runs last so an explicit entry for the suffixed ID always wins. The base ID
+// gets the release-date fallback too: an ID like "glm-5.1-20260406:free"
+// carries both a variant and a release date, and each layer strips its own.
 func resolveRoutingSuffixAlias(list *ModelList, providerType string, modelID string) (*ModelEntry, *ProviderModelEntry) {
 	baseID, ok := stripRoutingSuffix(modelID)
 	if !ok {
@@ -70,10 +83,15 @@ func resolveRoutingSuffixAlias(list *ModelList, providerType string, modelID str
 	if model, pm := resolveReverseProviderModelID(list, providerType, baseID); model != nil || pm != nil {
 		return model, pm
 	}
-	return resolveAlias(list, providerType, baseID)
+	if model, pm := resolveAlias(list, providerType, baseID); model != nil || pm != nil {
+		return model, pm
+	}
+	return resolveReleaseDateAlias(list, providerType, baseID)
 }
 
-// stripRoutingSuffix removes one terminal ":variant" segment.
+// stripRoutingSuffix removes one terminal ":variant" segment, and only for
+// the known routing variants: an unrecognized tail is left alone rather than
+// guessed at, so provider version syntax like Bedrock's ":0" never matches.
 //
 // The separator only carries this meaning in the last path element, so an ID
 // whose colon sits before a slash is left alone: provider-qualified IDs like
@@ -84,7 +102,7 @@ func stripRoutingSuffix(modelID string) (string, bool) {
 	if idx <= 0 || idx == len(modelID)-1 {
 		return "", false
 	}
-	if strings.Contains(modelID[idx+1:], "/") {
+	if _, known := routingSuffixes[modelID[idx+1:]]; !known {
 		return "", false
 	}
 	return modelID[:idx], true

--- a/internal/modeldata/merger.go
+++ b/internal/modeldata/merger.go
@@ -2,6 +2,7 @@ package modeldata
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/enterpilot/gomodel/internal/core"
 )
@@ -44,7 +45,49 @@ func resolveEntries(list *ModelList, providerType string, modelID string) (*Mode
 	if model, pm := resolveAlias(list, providerType, modelID); model != nil || pm != nil {
 		return model, pm
 	}
-	return resolveReleaseDateAlias(list, providerType, modelID)
+	if model, pm := resolveReleaseDateAlias(list, providerType, modelID); model != nil || pm != nil {
+		return model, pm
+	}
+	return resolveRoutingSuffixAlias(list, providerType, modelID)
+}
+
+// resolveRoutingSuffixAlias retries the lookup without a trailing routing
+// suffix such as ":floor", ":free" or ":nitro". The suffix picks how a request
+// is routed or billed, not which model answers it, and the registry carries an
+// entry for the base ID only. Without this step such a model is published with
+// no metadata at all — no display name, no context window, no capabilities —
+// even though the identical unsuffixed ID right next to it is fully described.
+//
+// Runs last so an explicit entry for the suffixed ID always wins.
+func resolveRoutingSuffixAlias(list *ModelList, providerType string, modelID string) (*ModelEntry, *ProviderModelEntry) {
+	baseID, ok := stripRoutingSuffix(modelID)
+	if !ok {
+		return nil, nil
+	}
+	if model, pm := resolveDirect(list, providerType, baseID); model != nil || pm != nil {
+		return model, pm
+	}
+	if model, pm := resolveReverseProviderModelID(list, providerType, baseID); model != nil || pm != nil {
+		return model, pm
+	}
+	return resolveAlias(list, providerType, baseID)
+}
+
+// stripRoutingSuffix removes one terminal ":variant" segment.
+//
+// The separator only carries this meaning in the last path element, so an ID
+// whose colon sits before a slash is left alone: provider-qualified IDs like
+// "openrouter/openai/gpt-5.6-luna-pro:floor" keep their slashes, and a leading
+// or trailing colon yields no usable base ID.
+func stripRoutingSuffix(modelID string) (string, bool) {
+	idx := strings.LastIndex(modelID, ":")
+	if idx <= 0 || idx == len(modelID)-1 {
+		return "", false
+	}
+	if strings.Contains(modelID[idx+1:], "/") {
+		return "", false
+	}
+	return modelID[:idx], true
 }
 
 func resolveReleaseDateAlias(list *ModelList, providerType string, modelID string) (*ModelEntry, *ProviderModelEntry) {

--- a/internal/modeldata/merger_test.go
+++ b/internal/modeldata/merger_test.go
@@ -718,6 +718,48 @@ func TestResolve_RoutingSuffixDoesNotShadowExplicitEntry(t *testing.T) {
 	}
 }
 
+func TestResolve_UnknownSuffixDoesNotBorrowMetadata(t *testing.T) {
+	list := &ModelList{
+		Models: map[string]ModelEntry{
+			"anthropic.claude-3-5-haiku-20241022-v1": {
+				DisplayName:   "Claude 3.5 Haiku",
+				ContextWindow: new(200000),
+				Aliases:       []string{"bedrock/anthropic.claude-3-5-haiku-20241022-v1"},
+			},
+		},
+	}
+	list.buildReverseIndex()
+
+	// Bedrock encodes a model version after the colon; ":0" is not a routing
+	// variant, so the fallback must not resolve it to the unsuffixed entry.
+	if meta := Resolve(list, "bedrock", "anthropic.claude-3-5-haiku-20241022-v1:0"); meta != nil {
+		t.Fatalf("Resolve() = %+v, want nil for an unknown suffix", meta)
+	}
+}
+
+func TestResolve_RoutingSuffixComposesWithReleaseDate(t *testing.T) {
+	list := &ModelList{
+		Models: map[string]ModelEntry{
+			"glm-5.1": {
+				DisplayName:   "GLM-5.1",
+				ContextWindow: new(131072),
+				Aliases:       []string{"z-ai/glm-5.1"},
+			},
+		},
+	}
+	list.buildReverseIndex()
+
+	// The ID carries both a release date and a routing variant; each layer
+	// strips its own and the base entry is still found.
+	meta := Resolve(list, "openrouter", "z-ai/glm-5.1-20260406:free")
+	if meta == nil {
+		t.Fatal("Resolve() = nil, want metadata of the base model")
+	}
+	if meta.DisplayName != "GLM-5.1" {
+		t.Errorf("display name = %q", meta.DisplayName)
+	}
+}
+
 func TestStripRoutingSuffix(t *testing.T) {
 	cases := []struct {
 		modelID string
@@ -731,6 +773,10 @@ func TestStripRoutingSuffix(t *testing.T) {
 		{":floor", "", false},
 		// A colon before a slash belongs to the path, not to a variant.
 		{"host:8080/model", "", false},
+		// Only the known routing variants are stripped: a provider version
+		// such as Bedrock's ":0" or an unlisted variant stays untouched.
+		{"anthropic.claude-3-5-haiku-20241022-v1:0", "", false},
+		{"deepseek/deepseek-r1:thinking", "", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.modelID, func(t *testing.T) {

--- a/internal/modeldata/merger_test.go
+++ b/internal/modeldata/merger_test.go
@@ -649,3 +649,95 @@ func TestResolve_AmbiguousModelAliasReturnsNil(t *testing.T) {
 		t.Fatalf("expected nil for ambiguous alias, got %+v", meta)
 	}
 }
+
+func TestResolve_RoutingSuffixFallback(t *testing.T) {
+	list := &ModelList{
+		Models: map[string]ModelEntry{
+			"gpt-5.6-luna-pro": {
+				DisplayName:   "GPT-5.6 Luna Pro",
+				Modes:         []string{"chat"},
+				ContextWindow: new(1050000),
+				Aliases: []string{
+					"openai/gpt-5.6-luna-pro",
+					"openrouter/openai/gpt-5.6-luna-pro",
+				},
+				Pricing: &core.ModelPricing{
+					Currency:      "USD",
+					InputPerMtok:  new(0.20),
+					OutputPerMtok: new(1.20),
+				},
+			},
+		},
+	}
+	list.buildReverseIndex()
+
+	for _, modelID := range []string{
+		"openrouter/openai/gpt-5.6-luna-pro:floor",
+		"openrouter/openai/gpt-5.6-luna-pro:nitro",
+		"openai/gpt-5.6-luna-pro:free",
+	} {
+		t.Run(modelID, func(t *testing.T) {
+			meta := Resolve(list, "openrouter", modelID)
+			if meta == nil {
+				t.Fatal("Resolve() = nil, want metadata of the unsuffixed model")
+			}
+			if meta.DisplayName != "GPT-5.6 Luna Pro" {
+				t.Errorf("display name = %q", meta.DisplayName)
+			}
+			if meta.ContextWindow == nil || *meta.ContextWindow != 1050000 {
+				t.Errorf("context window = %v", meta.ContextWindow)
+			}
+		})
+	}
+}
+
+func TestResolve_RoutingSuffixDoesNotShadowExplicitEntry(t *testing.T) {
+	list := &ModelList{
+		Models: map[string]ModelEntry{
+			"deepseek-r1": {
+				DisplayName:   "DeepSeek R1",
+				ContextWindow: new(128000),
+				Aliases:       []string{"deepseek/deepseek-r1"},
+			},
+			"deepseek-r1-free": {
+				DisplayName:   "DeepSeek R1 (free)",
+				ContextWindow: new(64000),
+				Aliases:       []string{"deepseek/deepseek-r1:free"},
+			},
+		},
+	}
+	list.buildReverseIndex()
+
+	meta := Resolve(list, "openrouter", "deepseek/deepseek-r1:free")
+	if meta == nil {
+		t.Fatal("Resolve() = nil")
+	}
+	// The suffixed ID has an entry of its own, so the fallback must not run.
+	if meta.DisplayName != "DeepSeek R1 (free)" {
+		t.Errorf("display name = %q, want the explicit suffixed entry", meta.DisplayName)
+	}
+}
+
+func TestStripRoutingSuffix(t *testing.T) {
+	cases := []struct {
+		modelID string
+		base    string
+		ok      bool
+	}{
+		{"openrouter/openai/gpt-5.6-luna-pro:floor", "openrouter/openai/gpt-5.6-luna-pro", true},
+		{"qwen/qwen3.7-flash:free", "qwen/qwen3.7-flash", true},
+		{"gpt-5.6-luna", "", false},
+		{"qwen/qwen3.7-flash:", "", false},
+		{":floor", "", false},
+		// A colon before a slash belongs to the path, not to a variant.
+		{"host:8080/model", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.modelID, func(t *testing.T) {
+			base, ok := stripRoutingSuffix(tc.modelID)
+			if ok != tc.ok || base != tc.base {
+				t.Errorf("stripRoutingSuffix(%q) = (%q, %v), want (%q, %v)", tc.modelID, base, ok, tc.base, tc.ok)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

OpenRouter-style variant suffixes — `:floor`, `:free`, `:nitro` — select how a
request is routed or billed, not which model answers it. The model registry
carries an entry for the base ID only, so a model requested under a suffixed ID
is published with no metadata at all: no display name, no context window, no
capabilities.

Seen on a running instance, where two entries of the same catalog sit next to
each other:

| Model | Context window | Display name |
|-------|----------------|--------------|
| `openrouter/openai/gpt-5.6-luna-pro` | 1050000 | OpenAI: GPT-5.6 Luna Pro |
| `openrouter/openai/gpt-5.6-luna-pro:floor` | — | — |

An alias pointing at the `:floor` variant inherits the empty record, so clients
that pick a model by its advertised context window cannot see one.

## Change

`resolveEntries` gains a final step that retries the lookup against the base ID,
mirroring the existing release-date fallback right above it. It runs last, so an
explicit registry entry for a suffixed ID (`deepseek/deepseek-r1:free` and the
like) still wins. A colon that belongs to a path rather than to a variant —
`host:8080/model` — is left alone, as is a leading or trailing colon.

## Tests

- `TestResolve_RoutingSuffixFallback` — `:floor`, `:nitro` and `:free` variants
  resolve to the unsuffixed entry.
- `TestResolve_RoutingSuffixDoesNotShadowExplicitEntry` — an explicit entry for
  the suffixed ID keeps priority.
- `TestStripRoutingSuffix` — boundary cases for the separator.

`go test ./...` on this branch: 82 packages pass. Three fail (`config`,
`internal/admin/dashboard`, `internal/server`) — they fail identically on the
unmodified base commit in the same environment, so they are unrelated to this
change.

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Model metadata now resolves correctly for supported routing suffixes such as `:floor`, `:free`, and `:nitro`.
  * Routing suffix fallback works alongside release-date variants.
  * Explicit entries with suffixed model IDs continue to take precedence.
  * Unknown, malformed, and path-based suffix formats are handled safely without incorrectly borrowing metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->