### PR TITLE
docs: add an updating guide and explain the licensing split

### DIFF
--- a/docs/about/faq.mdx
+++ b/docs/about/faq.mdx
@@ -7,6 +7,9 @@ keywords: ["faq", "update", "uninstall", "data location", "version pinning", "op
 
 ## How do I update GoModel?
 
+Back up your database first — [Updating GoModel](/guides/updating) has the
+backup commands for each storage backend, plus verification and rollback. Then:
+
 <Tabs>
   <Tab title="macOS / Linux">
     Re-run the installer — it always fetches the latest release and replaces
@@ -34,9 +37,7 @@ keywords: ["faq", "update", "uninstall", "data location", "version pinning", "op
   </Tab>
 </Tabs>
 
-Restart the gateway after updating; there is no in-place hot upgrade. Back up
-your database first — see [Updating GoModel](/guides/updating) for backup
-commands, verification, and rollback.
+Restart the gateway after updating; there is no in-place hot upgrade.
 
 ## How do I check which version I'm running?
 
@@ -60,14 +61,15 @@ On Windows set `$env:GOMODEL_VERSION` first. With Docker, use a version tag
 
 ## Is updating safe for my data?
 
-Yes. The database schema is migrated additively on startup, and updates never
-move or delete your database, configuration, or cache. Rolling back a version
-is equally safe for typical minor upgrades, though a database written by a
-much newer version may contain tables an older binary simply ignores.
+Yes, updating is. The schema is migrated on startup, and an update never moves
+or deletes your database, configuration, or cache.
 
-GoModel still ships fast, so keep a database copy before each update anyway —
-[Updating GoModel](/guides/updating#1-back-up-the-database) has the commands
-for each storage backend.
+Rolling back needs care. Most migrations are additive, and an older binary
+ignores what it does not know about — but some releases rebuild storage into a
+new shape, as scoped budgets and rate limits did, and the older binary will not
+find what it expects. Restore a backup taken before the update instead. GoModel
+ships fast, so take one every update:
+[Updating GoModel](/guides/updating#1-back-up-the-database) has the commands.
 
 ## Where does GoModel store its data?
 

--- a/docs/about/faq.mdx
+++ b/docs/about/faq.mdx
@@ -1,8 +1,8 @@
 ---
 title: "FAQ"
-description: "Updating, pinning, and uninstalling GoModel; where the gateway stores its data and whether updates are safe."
+description: "Updating, pinning, and uninstalling GoModel; where the gateway stores its data, and why part of the project is commercial."
 icon: "lightbulb"
-keywords: ["faq", "update", "uninstall", "data location", "version pinning"]
+keywords: ["faq", "update", "uninstall", "data location", "version pinning", "open source", "license", "pro"]
 ---
 
 ## How do I update GoModel?
@@ -34,7 +34,9 @@ keywords: ["faq", "update", "uninstall", "data location", "version pinning"]
   </Tab>
 </Tabs>
 
-Restart the gateway after updating; there is no in-place hot upgrade.
+Restart the gateway after updating; there is no in-place hot upgrade. Back up
+your database first — see [Updating GoModel](/guides/updating) for backup
+commands, verification, and rollback.
 
 ## How do I check which version I'm running?
 
@@ -62,6 +64,10 @@ Yes. The database schema is migrated additively on startup, and updates never
 move or delete your database, configuration, or cache. Rolling back a version
 is equally safe for typical minor upgrades, though a database written by a
 much newer version may contain tables an older binary simply ignores.
+
+GoModel still ships fast, so keep a database copy before each update anyway —
+[Updating GoModel](/guides/updating#1-back-up-the-database) has the commands
+for each storage backend.
 
 ## Where does GoModel store its data?
 
@@ -94,3 +100,27 @@ rm -rf ~/Library/"Application Support"/gomodel ~/Library/Caches/gomodel   # macO
 On Windows, delete `%LOCALAPPDATA%\Programs\gomodel` (and
 `%LOCALAPPDATA%\gomodel` for data), then remove the folder from your user
 PATH. For Docker, remove the container and image as usual.
+
+## Why isn't GoModel 100% open source?
+
+Almost all of it is. The gateway is MIT-licensed and stays that way. A small
+commercial distribution — [GoModel Pro](/pro/overview), adding OIDC SSO and a
+couple of other extensions — is coming; it accounts for roughly 3% of the
+codebase.
+
+**It may still end up fully open.** A dual license, or something like the BSL,
+would keep the whole codebase readable, auditable, and forkable while still
+protecting it commercially. Opening the project is fairer than closing it, so
+that is the direction we lean.
+
+**But the project has to pay for itself.** After nine months of work, GoModel
+had earned $90 in total (August 2026). That is not a living. Keeping a small
+part commercial asks the companies that profit from a well-built AI gateway to
+pay for it, and leaves it free for everyone else. That seems like the fairest
+trade available.
+
+**Individual features are negotiable.** If something planned for Pro is a
+feature you need as a developer and paying for Pro doesn't make sense for you,
+say so. A cheaper personal-use license — or open-sourcing that particular
+feature — is on the table. Ask on [Discord](https://discord.gg/gaEB9BQSPH) or
+[GitHub](https://github.com/ENTERPILOT/GoModel/issues).

--- a/docs/about/license.mdx
+++ b/docs/about/license.mdx
@@ -48,9 +48,10 @@ license to prevent that kind of extraction.
 
 Building GoModel is how we make a living, and so far it has not paid for
 itself. That is why a commercial distribution — [GoModel Pro](/pro/overview),
-with OIDC SSO and a couple of other extensions — is on the way. The gateway stays MIT-licensed
-and fully usable without a license; Pro targets companies that profit directly
-from the project, not individual developers or small teams building with it.
+with OIDC SSO and a couple of other extensions — is on the way. The gateway is
+MIT-licensed and fully usable without a license; Pro targets companies that
+profit directly from the project, not individual developers or small teams
+building with it.
 
 If a planned Pro feature is one you need and paying for Pro is not an option
 for you, tell us — a cheaper personal-use license, or open-sourcing that

--- a/docs/about/license.mdx
+++ b/docs/about/license.mdx
@@ -7,15 +7,16 @@ keywords: ["license", "MIT", "open source", "sustainability"]
 
 ## Summary
 
-GoModel is currently released under the permissive MIT license. We want to keep
-it open and practical for developers, small teams, and independent projects.
+GoModel is released under the permissive MIT license. We want to keep it open
+and practical for developers, small teams, and independent projects.
 
-There are two cases where we may revisit licensing in the future:
+Two qualifications:
 
-1. We may make the license less permissive to protect the project from
-   extraction by large cloud providers.
-2. We may use a different license for enterprise-grade features to keep the
-   project sustainable.
+1. A small commercial distribution, [GoModel Pro](/pro/overview), is coming. It
+   adds OIDC SSO and a couple of other extensions on top of the same
+   open-source gateway; those extensions are licensed separately, not MIT.
+2. We may make the license of the gateway itself less permissive to protect the
+   project from extraction by large cloud providers.
 
 ## Full story
 
@@ -24,10 +25,9 @@ makes and every model it talks to. That kind of component should be something
 you can read, audit, extend, and trust. This is why GoModel is open source
 today.
 
-That said, we want to be upfront about the future. There are two reasons the
-license could change down the road.
+That said, we want to be upfront about the rest of the picture.
 
-### 1. Protecting the project
+### Protecting the project
 
 There is a well-documented pattern where large cloud
 providers take open-source infrastructure, ship it as a managed service, and
@@ -44,12 +44,18 @@ give nothing back. It has forced other projects to react:
 If GoModel grows to a point where this becomes a real risk, we may adjust the
 license to prevent that kind of extraction.
 
-### 2. Sustainability
+### Sustainability
 
-Building GoModel is how we make a living. Right now the project is fully open
-source, and we intend to keep it that way for as long as possible. If licensing
-changes ever happen, they will target companies that profit directly from the
-project, not individual developers or small teams building with it.
+Building GoModel is how we make a living, and so far it has not paid for
+itself. That is why a commercial distribution — [GoModel Pro](/pro/overview),
+with OIDC SSO and a couple of other extensions — is on the way. The gateway stays MIT-licensed
+and fully usable without a license; Pro targets companies that profit directly
+from the project, not individual developers or small teams building with it.
+
+If a planned Pro feature is one you need and paying for Pro is not an option
+for you, tell us — a cheaper personal-use license, or open-sourcing that
+feature, is negotiable. See the
+[FAQ](/about/faq) for the longer answer.
 
 <Card
   title="Current license"

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -168,6 +168,7 @@
                 "icon": "compass",
                 "pages": [
                     "guides/production",
+                    "guides/updating",
                     "guides/openai-agents-sdk",
                     "guides/openclaw",
                     "guides/n8n",

--- a/docs/guides/updating.mdx
+++ b/docs/guides/updating.mdx
@@ -82,7 +82,12 @@ The logs should show the new version on the first line and a
 
 ### docker run
 
+Recreating the container discards its flags, so read them off the running one
+and pass the same ones back — the example below assumes a `gomodel_data` volume
+and a `.env` file:
+
 ```bash
+docker inspect gomodel --format '{{json .Mounts}} {{.Config.Env}}'
 docker pull enterpilot/gomodel
 docker rm -f gomodel
 docker run -d --name gomodel -p 8080:8080 \
@@ -90,6 +95,10 @@ docker run -d --name gomodel -p 8080:8080 \
   --env-file .env \
   enterpilot/gomodel
 ```
+
+With no mount at `/app/data` the database lives in the container filesystem and
+`docker rm` deletes it. Run `docker cp gomodel:/app/data ./data-backup` first,
+and mount a volume this time.
 
 ### Binary
 
@@ -137,15 +146,15 @@ how to disable it.
 
 ## What migrations do
 
-Migrations are additive and idempotent. On startup GoModel creates any missing
-tables and indexes (`CREATE TABLE IF NOT EXISTS`) and adds any missing columns,
-ignoring the "column already exists" error each engine returns. Nothing is
-dropped, renamed, or rewritten, and a partially applied schema is safe to retry
-on the next start.
+Migrations run on the first start of a new version. There is no separate
+migration command, and an update never moves or deletes your database,
+configuration, or cache.
 
-That is why an update never moves or deletes your database, configuration, or
-cache, and why a rollback across a typical minor version works too: the older
-binary simply ignores tables and columns it does not know about.
+Most are additive: missing tables, indexes, and columns are created, and a
+partially applied schema is safe to retry on the next start. Some releases
+transform storage instead — when budgets and rate limits gained scopes, their
+tables were rebuilt and the old ones dropped. Both are safe going forward, which
+is what makes the reverse direction worth care.
 
 ## Pinning a version
 
@@ -177,9 +186,11 @@ Replace `X.Y.Z` with a
 
 ## Rolling back
 
-Install or pull the previous version the same way and restart. If the new
-version wrote data an older binary mishandles, restore the backup from step 1
-before starting the older binary.
+Install or pull the previous version and restart. That is enough only if every
+migration in between was additive; across a transforming one the older binary
+looks for storage the upgrade rebuilt. You cannot tell the two apart from the
+outside, so **restore the step 1 backup** unless the older version is known to
+start against the migrated database.
 
 ## If something goes wrong
 

--- a/docs/guides/updating.mdx
+++ b/docs/guides/updating.mdx
@@ -1,0 +1,193 @@
+---
+title: "Updating GoModel"
+description: "Update GoModel on Docker or the standalone binary, back up your database first, and understand what the automatic schema migrations do."
+icon: "refresh-cw"
+keywords: ["update", "upgrade", "docker", "migration", "backup", "rollback", "version pinning"]
+---
+
+Updating GoModel is a pull and a restart. Schema migrations are built into the
+binary and run automatically on the first start of the new version, so there is
+no separate migration step and no maintenance window beyond the restart.
+
+<Warning>
+  **Back up your database before every update.** GoModel is under active
+  development and ships often. Migrations are additive and designed to be safe,
+  but a copy of the database is the only thing that makes a bad upgrade a
+  five-minute problem instead of a lost audit trail, usage history, and set of
+  managed API keys.
+</Warning>
+
+## 1. Back up the database
+
+<Tabs>
+  <Tab title="SQLite (Docker volume)">
+    Stop the gateway so the file is not written mid-copy, then archive the
+    volume:
+
+    ```bash
+    docker compose stop gomodel
+    docker run --rm \
+      -v gomodel_data:/data -v "$PWD":/backup alpine \
+      tar czf /backup/gomodel-$(date +%F).tar.gz -C /data .
+    ```
+
+    Replace `gomodel_data` with your volume name (`docker volume ls`). If you
+    bind-mount a host directory instead, `cp -a ./data ./data.bak-$(date +%F)`
+    is enough.
+  </Tab>
+  <Tab title="SQLite (binary)">
+    Stop the gateway, then copy the database file printed at startup as
+    `storage configured`:
+
+    ```bash
+    cp -a ~/.local/share/gomodel/gomodel.db gomodel-$(date +%F).db   # Linux
+    ```
+
+    On macOS the default is
+    `~/Library/Application Support/gomodel/gomodel.db`. See
+    [where GoModel stores its data](/about/faq#where-does-gomodel-store-its-data).
+  </Tab>
+  <Tab title="PostgreSQL">
+    ```bash
+    pg_dump "$POSTGRES_URL" > gomodel-$(date +%F).sql
+    ```
+  </Tab>
+  <Tab title="MongoDB">
+    ```bash
+    mongodump --uri="$MONGODB_URL" --out "gomodel-$(date +%F)"
+    ```
+  </Tab>
+</Tabs>
+
+## 2. Update
+
+### Docker Compose
+
+```bash
+docker compose pull gomodel
+docker compose up -d gomodel
+docker compose logs -f gomodel
+```
+
+The logs should show the new version on the first line and a
+`storage configured` line with your database path.
+
+<Warning>
+  **Check that your database is on a volume before you update.** The image
+  declares none, so a container without a mount at `/app/data` keeps its SQLite
+  database in the container's own filesystem — and loses everything the moment
+  the container is replaced by the update. See
+  [production storage](/guides/production#choose-a-storage-backend).
+</Warning>
+
+### docker run
+
+```bash
+docker pull enterpilot/gomodel
+docker rm -f gomodel
+docker run -d --name gomodel -p 8080:8080 \
+  -v gomodel_data:/app/data \
+  --env-file .env \
+  enterpilot/gomodel
+```
+
+### Binary
+
+Re-run the installer. It fetches the latest release and replaces the binary in
+place:
+
+<Tabs>
+  <Tab title="macOS / Linux">
+    ```bash
+    curl -fsSL https://gomodel.enterpilot.io/install.sh | sh
+    ```
+  </Tab>
+  <Tab title="Windows">
+    ```powershell
+    irm https://gomodel.enterpilot.io/install.ps1 | iex
+    ```
+  </Tab>
+</Tabs>
+
+Restart the gateway afterwards — there is no in-place hot upgrade.
+
+## 3. Verify
+
+```bash
+gomodel --version
+curl -s http://localhost:8080/version
+```
+
+`GET /version` reports the running version, the latest published release, and
+whether an update is available:
+
+```json
+{
+  "app": "GoModel",
+  "version": "0.1.60",
+  "latest": "0.1.60",
+  "update_available": false,
+  "enabled": true
+}
+```
+
+The dashboard's **Settings** page shows the same result. See
+[Version Awareness](/advanced/version-awareness) for how that check works and
+how to disable it.
+
+## What migrations do
+
+Migrations are additive and idempotent. On startup GoModel creates any missing
+tables and indexes (`CREATE TABLE IF NOT EXISTS`) and adds any missing columns,
+ignoring the "column already exists" error each engine returns. Nothing is
+dropped, renamed, or rewritten, and a partially applied schema is safe to retry
+on the next start.
+
+That is why an update never moves or deletes your database, configuration, or
+cache, and why a rollback across a typical minor version works too: the older
+binary simply ignores tables and columns it does not know about.
+
+## Pinning a version
+
+Updates default to the latest release. To stay on a known version, pin it:
+
+<Tabs>
+  <Tab title="Docker">
+    ```bash
+    docker pull enterpilot/gomodel:X.Y.Z
+    ```
+
+    Use the version tag in your compose file instead of `latest`.
+  </Tab>
+  <Tab title="macOS / Linux">
+    ```bash
+    curl -fsSL https://gomodel.enterpilot.io/install.sh | GOMODEL_VERSION=vX.Y.Z sh
+    ```
+  </Tab>
+  <Tab title="Windows">
+    ```powershell
+    $env:GOMODEL_VERSION = "vX.Y.Z"
+    irm https://gomodel.enterpilot.io/install.ps1 | iex
+    ```
+  </Tab>
+</Tabs>
+
+Replace `X.Y.Z` with a
+[published release](https://github.com/ENTERPILOT/GoModel/releases).
+
+## Rolling back
+
+Install or pull the previous version the same way and restart. If the new
+version wrote data an older binary mishandles, restore the backup from step 1
+before starting the older binary.
+
+## If something goes wrong
+
+| Symptom | Cause |
+| --- | --- |
+| Dashboard is empty after the update: no keys, no usage, no logs | The database was not on a volume, or `SQLITE_PATH` resolved somewhere else. Compare the `storage configured` path before and after. |
+| Gateway will not start after the update | Read the first error line. Configuration that was previously ignored can become validated; the release notes list breaking changes. |
+| The version did not change | The old container is still running (`docker ps`), or a second `gomodel` binary earlier in `PATH` is being launched. |
+
+Still stuck? Ask on [Discord](https://discord.gg/gaEB9BQSPH) or open a
+[GitHub issue](https://github.com/ENTERPILOT/GoModel/issues).

--- a/docs/guides/updating.mdx
+++ b/docs/guides/updating.mdx
@@ -97,8 +97,18 @@ docker run -d --name gomodel -p 8080:8080 \
 ```
 
 With no mount at `/app/data` the database lives in the container filesystem and
-`docker rm` deletes it. Run `docker cp gomodel:/app/data ./data-backup` first,
-and mount a volume this time.
+`docker rm` deletes it. Copy it out *before* removing the container, then seed
+the volume you are about to mount — an empty volume hides the copy, and the
+gateway starts with no keys, usage, or logs:
+
+```bash
+docker cp gomodel:/app/data/. ./gomodel-data
+docker run --rm -v gomodel_data:/data -v "$PWD/gomodel-data":/seed alpine \
+  sh -c 'cp -a /seed/. /data/ && chown -R 65532:65532 /data'
+```
+
+`65532` is the image's nonroot UID — the gateway cannot write a volume owned by
+anyone else.
 
 ### Binary
 
@@ -191,6 +201,17 @@ migration in between was additive; across a transforming one the older binary
 looks for storage the upgrade rebuilt. You cannot tell the two apart from the
 outside, so **restore the step 1 backup** unless the older version is known to
 start against the migrated database.
+
+Restoring a SQLite volume backup replaces the volume's contents, so stop the
+gateway first:
+
+```bash
+docker compose stop gomodel
+docker run --rm -v gomodel_data:/data -v "$PWD":/backup alpine \
+  sh -c 'rm -rf /data/* && tar xzf /backup/gomodel-YYYY-MM-DD.tar.gz -C /data \
+         && chown -R 65532:65532 /data'
+docker compose up -d gomodel
+```
 
 ## If something goes wrong
 

--- a/docs/guides/updating.mdx
+++ b/docs/guides/updating.mdx
@@ -11,10 +11,9 @@ no separate migration step and no maintenance window beyond the restart.
 
 <Warning>
   **Back up your database before every update.** GoModel is under active
-  development and ships often. Migrations are additive and designed to be safe,
-  but a copy of the database is the only thing that makes a bad upgrade a
-  five-minute problem instead of a lost audit trail, usage history, and set of
-  managed API keys.
+  development and ships often, and some upgrades transform stored data. A copy
+  is the only thing that makes a bad upgrade a five-minute problem instead of a
+  lost audit trail, usage history, and set of managed API keys.
 </Warning>
 
 ## 1. Back up the database
@@ -83,23 +82,16 @@ The logs should show the new version on the first line and a
 ### docker run
 
 Recreating the container discards its flags, so read them off the running one
-and pass the same ones back — the example below assumes a `gomodel_data` volume
-and a `.env` file:
+first:
 
 ```bash
 docker inspect gomodel --format '{{json .Mounts}} {{.Config.Env}}'
-docker pull enterpilot/gomodel
-docker rm -f gomodel
-docker run -d --name gomodel -p 8080:8080 \
-  -v gomodel_data:/app/data \
-  --env-file .env \
-  enterpilot/gomodel
 ```
 
-With no mount at `/app/data` the database lives in the container filesystem and
-`docker rm` deletes it. Copy it out *before* removing the container, then seed
-the volume you are about to mount — an empty volume hides the copy, and the
-gateway starts with no keys, usage, or logs:
+If nothing is mounted at `/app/data`, the database lives in the container
+filesystem and `docker rm` deletes it. Copy it out and seed the volume you are
+about to mount, while the old container still exists — an empty volume hides the
+copy, and the gateway starts with no keys, usage, or logs:
 
 ```bash
 docker cp gomodel:/app/data/. ./gomodel-data
@@ -109,6 +101,17 @@ docker run --rm -v gomodel_data:/data -v "$PWD/gomodel-data":/seed alpine \
 
 `65532` is the image's nonroot UID — the gateway cannot write a volume owned by
 anyone else.
+
+Then replace the container, passing the same mount and environment flags back:
+
+```bash
+docker pull enterpilot/gomodel
+docker rm -f gomodel
+docker run -d --name gomodel -p 8080:8080 \
+  -v gomodel_data:/app/data \
+  --env-file .env \
+  enterpilot/gomodel
+```
 
 ### Binary
 
@@ -203,14 +206,13 @@ outside, so **restore the step 1 backup** unless the older version is known to
 start against the migrated database.
 
 Restoring a SQLite volume backup replaces the volume's contents, so stop the
-gateway first:
+gateway first — `docker compose stop gomodel`, or `docker stop gomodel` for a
+standalone container — then unpack the archive and start it again:
 
 ```bash
-docker compose stop gomodel
 docker run --rm -v gomodel_data:/data -v "$PWD":/backup alpine \
   sh -c 'rm -rf /data/* && tar xzf /backup/gomodel-YYYY-MM-DD.tar.gz -C /data \
          && chown -R 65532:65532 /data'
-docker compose up -d gomodel
 ```
 
 ## If something goes wrong


### PR DESCRIPTION
Users have been struggling to update GoModel, and the licensing pages did not reflect that a commercial distribution is on the way.

**New: `guides/updating`** (Guides tab, after Production) — Docker-first, then the binary:

- Back up the database first, with commands per backend (SQLite on a Docker volume via a helper container, since the image is distroless; SQLite file, `pg_dump`, `mongodump`).
- Update with Compose or `docker run`, then the installers; restart required, no hot upgrade.
- Verify with `gomodel --version` and `GET /version`.
- What migrations do: additive and idempotent at startup, nothing dropped or rewritten, which is also why a minor-version rollback is safe.
- Version pinning, rollback, and a symptom/cause table for the common failures — most importantly an unmounted `/app/data`, which loses the database exactly when the update replaces the container.

**Licensing:** `about/faq` gains a "Why isn't GoModel 100% open source?" entry, and `about/license` no longer describes a commercial split as hypothetical — it now says Pro is coming with SSO and a couple of other extensions, while the gateway stays MIT.

Docs only; no code or user-visible gateway behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide for updating GoModel installations, including backups, verification, version pinning, rollback, migrations, and troubleshooting.
  * Expanded FAQ content with data safety, licensing, Pro features, and backup guidance.
  * Updated licensing documentation to clarify the MIT-licensed gateway and commercial GoModel Pro offerings.
  * Added the update guide to the documentation navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->