### PR TITLE
docs: name shipped SSO as OIDC and widen the measured savings range

### DIFF
--- a/docs/about/roadmap.mdx
+++ b/docs/about/roadmap.mdx
@@ -7,12 +7,12 @@ keywords: ["roadmap", "milestones", "upcoming features", "releases"]
 
 ## Commercial features
 
-- [x] Intelligent routing
-- [x] Context window compression
+- [x] Intelligent routing ([GoModel Pro](/pro/intelligent-routing), beta)
+- [x] Context window compression ([GoModel Pro](/pro/compression))
 - [ ] Cluster mode
 - [x] OpenTelemetry (OTel) support
 - [ ] OAuth authentication
-- [x] Single sign-on (SSO)
+- [x] OIDC single sign-on ([GoModel Pro](/pro/sso))
 - [ ] Dashboard customization
 - [ ] LDAP integration
 - [ ] Secret manager integrations (Vault, AWS Secrets Manager/KMS, Azure Key Vault, GCP Secret Manager)

--- a/docs/pro/compression.mdx
+++ b/docs/pro/compression.mdx
@@ -26,10 +26,10 @@ agentic coding, chat, and tool-heavy workloads.
   about a 2% *increase* in prompt-cache hits, since shorter, more stable
   requests fit the cache better — which adds savings on top of the compression
   itself.
-- **Real savings of 5%–15%** for our testers, depending on the use case.
-  Agents that re-read files, replay tool output, or carry long histories sit
-  at the top of that range; short, non-repetitive chat sits at the bottom,
-  where the compressor simply forwards requests unchanged.
+- **Real savings of 2%–20%** of input tokens for our testers, depending on
+  the use case. Agents that re-read files, replay tool output, or carry long
+  histories sit at the top of that range; short, non-repetitive chat sits at
+  the bottom, where the compressor simply forwards requests unchanged.
 - **Full control.** Choose the level per gateway or per request, exclude
   models by glob, protect pre-existing history with `new_messages_only`, keep
   source code verbatim, and inspect every rewrite through response headers,


### PR DESCRIPTION
## What

- `docs/about/roadmap.mdx`: the shipped commercial items now say what they are and link to their Pro docs - **OIDC single sign-on** (not bare "SSO", since SAML is a separate, still-open roadmap item), intelligent routing (marked beta), and context window compression.
- `docs/pro/compression.mdx`: the measured savings claim becomes **2%-20% of input tokens**, matching the range published on the marketing site's /pro page so the two never disagree.

## Why

An unqualified "SSO shipped" claim invites the SAML question as a support ticket; naming the protocol answers it up front. The savings range previously said 5%-15% here and 2-20% elsewhere - one number, everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PcUWMyxGKse8GuyMFFMYiP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the commercial roadmap to highlight intelligent routing, context window compression, and OIDC single sign-on as available features.
  - Clarified that cluster mode remains planned.
  - Updated documented prompt compression savings to reflect a range of 2%–20% of input tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->