### PR TITLE
feat(openai): detect speech-to-text-only providers without /v1/models

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -546,6 +546,15 @@ providers:
   #   base_url: "https://api.example.com/v1"
   #   api_key: "..."
 
+  # Speech-to-text-only servers that expose /v1/audio/transcriptions without
+  # GET /v1/models (whisper.cpp server, faster-whisper wrappers) are detected
+  # automatically and advertise a "whisper-1" transcription model. Declare
+  # `models:` instead when your server requires its own model name.
+  # local-whisper:
+  #   type: openai
+  #   base_url: "http://localhost:8000/v1"
+  #   api_key: "unused"  # any non-empty value if the server ignores auth
+
   # Example: LM Studio. Despite being "Ollama-like", LM Studio speaks the
   # OpenAI-compatible API (/v1/chat/completions, /v1/embeddings) and has NO
   # native Ollama API. Configure it as "openai" (or "vllm"), NOT "ollama" —

--- a/docs/advanced/audio-api.mdx
+++ b/docs/advanced/audio-api.mdx
@@ -152,6 +152,37 @@ JSON object; `text`, `srt`, and `vtt` return a `text/plain` body.
   also accepts the unbracketed `timestamp_granularities` for client compatibility.
 </Tip>
 
+### Speech-to-text-only servers
+
+Some OpenAI-compatible STT servers (whisper.cpp's server, various
+faster-whisper wrappers) serve `/v1/audio/transcriptions` without implementing
+`GET /v1/models`. GoModel detects this automatically for providers of
+`type: openai`: when the upstream has no `/v1/models` endpoint (or lists no
+models) but responds on `/v1/audio/transcriptions`, the provider advertises a
+`whisper-1` transcription model so requests route to it without configuration.
+
+```yaml
+providers:
+  local-whisper:
+    type: openai
+    base_url: "http://localhost:8000/v1"
+    api_key: "unused" # any non-empty value if the server ignores auth
+```
+
+Most such servers accept or ignore the `model` field, so OpenAI SDK clients
+work with their default `whisper-1`. If your server requires its own model
+name, declare it instead and it takes precedence:
+
+```yaml
+providers:
+  local-whisper:
+    type: openai
+    base_url: "http://localhost:8000/v1"
+    api_key: "unused"
+    models:
+      - id: "Systran/faster-whisper-small"
+```
+
 ## Limitations
 
 The audio endpoints are a thin, model-routed pass to the provider and **do not run

--- a/internal/providers/openai/compatible_provider.go
+++ b/internal/providers/openai/compatible_provider.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync/atomic"
 
 	"github.com/goccy/go-json"
 
@@ -41,6 +42,15 @@ type CompatibleProviderConfig struct {
 	// context and body (e.g. conversation affinity headers). Nil results are
 	// ignored.
 	ChatRequestHeaders func(context.Context, *core.ChatRequest) http.Header
+	// DetectSpeechToText enables the ListModels fallback for STT-only
+	// upstreams: when GET /models is absent or lists nothing, the provider
+	// probes POST /audio/transcriptions and, if the endpoint exists,
+	// advertises a synthesized whisper-1 transcription model (see
+	// stt_fallback.go). Enabled for the generic "openai" type so custom
+	// speech-to-text servers are routable without configuration; other
+	// wrappers leave it off because they either have a reliable catalog or
+	// do not expose the audio surface.
+	DetectSpeechToText bool
 }
 
 // CompatibleProvider is the single transport engine for every
@@ -76,6 +86,10 @@ type CompatibleProvider struct {
 	requestMutator     RequestMutator
 	adaptChatRequest   func(*core.ChatRequest) (*core.ChatRequest, error)
 	chatRequestHeaders func(context.Context, *core.ChatRequest) http.Header
+	detectSpeechToText bool
+	// sttFallbackAnnounced gates the fallback's Info log to the first
+	// detection so periodic registry refreshes do not repeat it.
+	sttFallbackAnnounced atomic.Bool
 }
 
 func NewCompatibleProvider(apiKey string, opts providers.ProviderOptions, cfg CompatibleProviderConfig) *CompatibleProvider {
@@ -85,6 +99,7 @@ func NewCompatibleProvider(apiKey string, opts providers.ProviderOptions, cfg Co
 		requestMutator:     cfg.RequestMutator,
 		adaptChatRequest:   cfg.AdaptChatRequest,
 		chatRequestHeaders: cfg.ChatRequestHeaders,
+		detectSpeechToText: cfg.DetectSpeechToText,
 	}
 	clientCfg := llmclient.Config{
 		ProviderName:   cfg.ProviderName,
@@ -118,6 +133,7 @@ func NewCompatibleProviderWithHTTPClient(apiKey string, httpClient *http.Client,
 		requestMutator:     cfg.RequestMutator,
 		adaptChatRequest:   cfg.AdaptChatRequest,
 		chatRequestHeaders: cfg.ChatRequestHeaders,
+		detectSpeechToText: cfg.DetectSpeechToText,
 	}
 	clientCfg := llmclient.DefaultConfig(cfg.ProviderName, cfg.BaseURL)
 	clientCfg.Hooks = hooks
@@ -239,9 +255,17 @@ func (p *CompatibleProvider) ListModels(ctx context.Context) (*core.ModelsRespon
 		Endpoint: "/models",
 	}, &resp)
 	if err != nil {
+		if fallback := p.speechToTextFallbackModels(ctx, err); fallback != nil {
+			return fallback, nil
+		}
 		return nil, err
 	}
 	normalizeModelsResponse(&resp)
+	if len(resp.Data) == 0 {
+		if fallback := p.speechToTextFallbackModels(ctx, nil); fallback != nil {
+			return fallback, nil
+		}
+	}
 	return &resp, nil
 }
 

--- a/internal/providers/openai/openai.go
+++ b/internal/providers/openai/openai.go
@@ -43,6 +43,11 @@ func New(cfg providers.ProviderConfig, opts providers.ProviderOptions) core.Prov
 			ProviderName: "openai",
 			BaseURL:      baseURL,
 			SetHeaders:   setHeaders,
+			// Operator-declared models are authoritative: with the default
+			// configured-models mode (fallback) they only apply when
+			// ListModels fails, so a synthesized STT inventory succeeding
+			// would silently override them.
+			DetectSpeechToText: len(cfg.Models) == 0,
 		}),
 	}
 }
@@ -52,9 +57,10 @@ func New(cfg providers.ProviderConfig, opts providers.ProviderOptions) core.Prov
 func NewWithHTTPClient(apiKey string, httpClient *http.Client, hooks llmclient.Hooks) *Provider {
 	return &Provider{
 		CompatibleProvider: NewCompatibleProviderWithHTTPClient(apiKey, httpClient, hooks, CompatibleProviderConfig{
-			ProviderName: "openai",
-			BaseURL:      defaultBaseURL,
-			SetHeaders:   setHeaders,
+			ProviderName:       "openai",
+			BaseURL:            defaultBaseURL,
+			SetHeaders:         setHeaders,
+			DetectSpeechToText: true,
 		}),
 	}
 }

--- a/internal/providers/openai/stt_fallback.go
+++ b/internal/providers/openai/stt_fallback.go
@@ -1,0 +1,104 @@
+package openai
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/llmclient"
+)
+
+// sttFallbackModelID is the model advertised for an upstream that serves
+// speech-to-text without a model catalog. OpenAI SDK clients default their
+// transcription calls to whisper-1, and STT-only servers commonly accept or
+// ignore the model field, so this ID makes such providers routable without
+// configuration. Operators whose upstream requires a specific model name can
+// declare it with the provider's models list instead.
+const sttFallbackModelID = "whisper-1"
+
+// speechToTextFallbackModels decides whether the speech-to-text fallback
+// applies to a ListModels outcome and returns the synthesized inventory when
+// it does. The fallback covers OpenAI-compatible STT servers that expose
+// /v1/audio/transcriptions without any model listing: it applies when model
+// discovery is enabled for this provider and the upstream either has no
+// /models endpoint (listErr says the route is missing) or listed no models
+// (listErr is nil), and the transcription endpoint probe confirms the
+// upstream serves it.
+func (p *CompatibleProvider) speechToTextFallbackModels(ctx context.Context, listErr error) *core.ModelsResponse {
+	if !p.detectSpeechToText {
+		return nil
+	}
+	if listErr != nil && !isMissingEndpointError(listErr) {
+		return nil
+	}
+	if !p.hasTranscriptionEndpoint(ctx) {
+		return nil
+	}
+	if p.sttFallbackAnnounced.CompareAndSwap(false, true) {
+		slog.Info("upstream lists no models but serves audio transcriptions, advertising fallback speech-to-text model",
+			"provider", p.providerName,
+			"model", sttFallbackModelID,
+		)
+	}
+	return &core.ModelsResponse{
+		Object: "list",
+		Data: []core.Model{{
+			ID:      sttFallbackModelID,
+			Object:  "model",
+			OwnedBy: p.providerName,
+			Created: time.Now().Unix(),
+			Metadata: &core.ModelMetadata{
+				Description: "Speech-to-text endpoint detected on an upstream without a model catalog.",
+				Modes:       []string{"audio_transcription"},
+				Categories:  core.CategoriesForModes([]string{"audio_transcription"}),
+			},
+		}},
+	}
+}
+
+// hasTranscriptionEndpoint probes POST /audio/transcriptions with a
+// deliberately empty body: no server transcribes anything from it, but one
+// that implements the endpoint rejects it with a request-level error (missing
+// multipart form, unsupported media type, auth required) rather than the
+// route-level 404/405/501 an absent endpoint produces.
+func (p *CompatibleProvider) hasTranscriptionEndpoint(ctx context.Context) bool {
+	_, err := p.client.DoRaw(ctx, p.prepareRequest(llmclient.Request{
+		Method:   http.MethodPost,
+		Endpoint: "/audio/transcriptions",
+	}))
+	if err == nil {
+		return true
+	}
+	var gatewayErr *core.GatewayError
+	if !errors.As(err, &gatewayErr) {
+		return false
+	}
+	switch gatewayErr.StatusCode {
+	case http.StatusBadRequest,
+		http.StatusUnauthorized,
+		http.StatusForbidden,
+		http.StatusRequestEntityTooLarge,
+		http.StatusUnsupportedMediaType,
+		http.StatusUnprocessableEntity:
+		return true
+	}
+	return false
+}
+
+// isMissingEndpointError reports whether a provider error means the route is
+// not implemented upstream, as opposed to an auth, availability, or network
+// failure that says nothing about which endpoints exist.
+func isMissingEndpointError(err error) bool {
+	var gatewayErr *core.GatewayError
+	if !errors.As(err, &gatewayErr) {
+		return false
+	}
+	switch gatewayErr.StatusCode {
+	case http.StatusNotFound, http.StatusMethodNotAllowed, http.StatusNotImplemented:
+		return true
+	}
+	return false
+}

--- a/internal/providers/openai/stt_fallback.go
+++ b/internal/providers/openai/stt_fallback.go
@@ -62,8 +62,11 @@ func (p *CompatibleProvider) speechToTextFallbackModels(ctx context.Context, lis
 // hasTranscriptionEndpoint probes POST /audio/transcriptions with a
 // deliberately empty body: no server transcribes anything from it, but one
 // that implements the endpoint rejects it with a request-level error (missing
-// multipart form, unsupported media type, auth required) rather than the
-// route-level 404/405/501 an absent endpoint produces.
+// multipart form, unsupported media type) rather than the route-level
+// 404/405/501 an absent endpoint produces. Auth failures (401/403) are not
+// accepted as proof: middleware that authenticates before route matching
+// emits them for routes that do not exist, and a provider whose credential
+// cannot pass the endpoint's own auth could not serve transcriptions anyway.
 func (p *CompatibleProvider) hasTranscriptionEndpoint(ctx context.Context) bool {
 	_, err := p.client.DoRaw(ctx, p.prepareRequest(llmclient.Request{
 		Method:   http.MethodPost,
@@ -78,8 +81,6 @@ func (p *CompatibleProvider) hasTranscriptionEndpoint(ctx context.Context) bool 
 	}
 	switch gatewayErr.StatusCode {
 	case http.StatusBadRequest,
-		http.StatusUnauthorized,
-		http.StatusForbidden,
 		http.StatusRequestEntityTooLarge,
 		http.StatusUnsupportedMediaType,
 		http.StatusUnprocessableEntity:

--- a/internal/providers/openai/stt_fallback_test.go
+++ b/internal/providers/openai/stt_fallback_test.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -32,10 +33,20 @@ func (u *sttUpstream) handler() http.Handler {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(u.modelsBody))
 	})
-	mux.HandleFunc("/audio/transcriptions", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/audio/transcriptions", func(w http.ResponseWriter, r *http.Request) {
 		u.probes.Add(1)
+		// The probe contract is a POST with a deliberately empty body; anything
+		// else reaching this handler means the fallback sent a real request.
+		if r.Method != http.MethodPost {
+			http.Error(w, `{"error":{"message":"probe must be a POST"}}`, http.StatusInternalServerError)
+			return
+		}
+		if body, err := io.ReadAll(r.Body); err != nil || len(body) != 0 {
+			http.Error(w, `{"error":{"message":"probe body must be empty"}}`, http.StatusInternalServerError)
+			return
+		}
 		if u.transcriptionStatus == http.StatusNotFound {
-			http.NotFound(w, nil)
+			http.NotFound(w, r)
 			return
 		}
 		http.Error(w, `{"error":{"message":"file is required"}}`, u.transcriptionStatus)
@@ -61,10 +72,13 @@ func TestListModels_SpeechToTextFallback(t *testing.T) {
 			wantProbes:          1,
 		},
 		{
-			name:                "models endpoint missing, transcriptions requires auth",
+			// Middleware that authenticates before route matching answers 401
+			// for absent routes too, so an auth failure must not count as
+			// proof the transcription endpoint exists.
+			name:                "models endpoint missing, transcriptions behind failing auth",
 			modelsStatus:        http.StatusNotFound,
 			transcriptionStatus: http.StatusUnauthorized,
-			wantFallback:        true,
+			wantErrStatus:       http.StatusNotFound,
 			wantProbes:          1,
 		},
 		{

--- a/internal/providers/openai/stt_fallback_test.go
+++ b/internal/providers/openai/stt_fallback_test.go
@@ -1,0 +1,192 @@
+package openai
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/llmclient"
+	"github.com/enterpilot/gomodel/internal/providers"
+)
+
+// sttUpstream simulates an OpenAI-compatible upstream with configurable
+// /models and /audio/transcriptions behavior and counts transcription probes.
+type sttUpstream struct {
+	modelsStatus        int
+	modelsBody          string
+	transcriptionStatus int
+	probes              atomic.Int32
+}
+
+func (u *sttUpstream) handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/models", func(w http.ResponseWriter, _ *http.Request) {
+		if u.modelsStatus != http.StatusOK {
+			http.Error(w, `{"error":{"message":"not found"}}`, u.modelsStatus)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(u.modelsBody))
+	})
+	mux.HandleFunc("/audio/transcriptions", func(w http.ResponseWriter, _ *http.Request) {
+		u.probes.Add(1)
+		if u.transcriptionStatus == http.StatusNotFound {
+			http.NotFound(w, nil)
+			return
+		}
+		http.Error(w, `{"error":{"message":"file is required"}}`, u.transcriptionStatus)
+	})
+	return mux
+}
+
+func TestListModels_SpeechToTextFallback(t *testing.T) {
+	tests := []struct {
+		name                string
+		modelsStatus        int
+		modelsBody          string
+		transcriptionStatus int
+		wantFallback        bool
+		wantErrStatus       int // 0 means no error expected
+		wantProbes          int32
+	}{
+		{
+			name:                "models endpoint missing, transcriptions present",
+			modelsStatus:        http.StatusNotFound,
+			transcriptionStatus: http.StatusUnprocessableEntity,
+			wantFallback:        true,
+			wantProbes:          1,
+		},
+		{
+			name:                "models endpoint missing, transcriptions requires auth",
+			modelsStatus:        http.StatusNotFound,
+			transcriptionStatus: http.StatusUnauthorized,
+			wantFallback:        true,
+			wantProbes:          1,
+		},
+		{
+			name:                "models endpoint missing, transcriptions missing too",
+			modelsStatus:        http.StatusNotFound,
+			transcriptionStatus: http.StatusNotFound,
+			wantErrStatus:       http.StatusNotFound,
+			wantProbes:          1,
+		},
+		{
+			name:                "models endpoint auth failure is not probed",
+			modelsStatus:        http.StatusUnauthorized,
+			transcriptionStatus: http.StatusUnprocessableEntity,
+			wantErrStatus:       http.StatusUnauthorized,
+			wantProbes:          0,
+		},
+		{
+			name:                "empty model list, transcriptions present",
+			modelsStatus:        http.StatusOK,
+			modelsBody:          `{"object":"list","data":[]}`,
+			transcriptionStatus: http.StatusBadRequest,
+			wantFallback:        true,
+			wantProbes:          1,
+		},
+		{
+			name:                "populated model list is returned as-is",
+			modelsStatus:        http.StatusOK,
+			modelsBody:          `{"object":"list","data":[{"id":"gpt-test","object":"model"}]}`,
+			transcriptionStatus: http.StatusUnprocessableEntity,
+			wantProbes:          0,
+		},
+		{
+			name:                "empty model list without transcriptions stays empty",
+			modelsStatus:        http.StatusOK,
+			modelsBody:          `{"object":"list","data":[]}`,
+			transcriptionStatus: http.StatusNotFound,
+			wantProbes:          1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			upstream := &sttUpstream{
+				modelsStatus:        tt.modelsStatus,
+				modelsBody:          tt.modelsBody,
+				transcriptionStatus: tt.transcriptionStatus,
+			}
+			server := httptest.NewServer(upstream.handler())
+			defer server.Close()
+
+			provider := NewWithHTTPClient("test-key", server.Client(), llmclient.Hooks{})
+			provider.SetBaseURL(server.URL)
+
+			resp, err := provider.ListModels(context.Background())
+
+			if tt.wantErrStatus != 0 {
+				if err == nil {
+					t.Fatalf("ListModels() error = nil, want status %d", tt.wantErrStatus)
+				}
+				var gatewayErr *core.GatewayError
+				if !errors.As(err, &gatewayErr) {
+					t.Fatalf("ListModels() error = %v, want *core.GatewayError", err)
+				}
+				if gatewayErr.StatusCode != tt.wantErrStatus {
+					t.Errorf("error status = %d, want %d", gatewayErr.StatusCode, tt.wantErrStatus)
+				}
+			} else if err != nil {
+				t.Fatalf("ListModels() error = %v", err)
+			}
+
+			if tt.wantFallback {
+				if len(resp.Data) != 1 || resp.Data[0].ID != sttFallbackModelID {
+					t.Fatalf("ListModels() = %+v, want single %q model", resp, sttFallbackModelID)
+				}
+				meta := resp.Data[0].Metadata
+				if meta == nil || len(meta.Modes) != 1 || meta.Modes[0] != "audio_transcription" {
+					t.Errorf("fallback model metadata = %+v, want audio_transcription mode", meta)
+				}
+				if resp.Data[0].OwnedBy != "openai" {
+					t.Errorf("fallback model owned_by = %q, want %q", resp.Data[0].OwnedBy, "openai")
+				}
+			}
+
+			if got := upstream.probes.Load(); got != tt.wantProbes {
+				t.Errorf("transcription probes = %d, want %d", got, tt.wantProbes)
+			}
+		})
+	}
+}
+
+func TestNew_ConfiguredModelsDisableSpeechToTextDetection(t *testing.T) {
+	withModels := New(providers.ProviderConfig{
+		APIKey: "test-key",
+		Models: []string{"Systran/faster-whisper-small"},
+	}, providers.ProviderOptions{}).(*Provider)
+	if withModels.detectSpeechToText {
+		t.Error("detectSpeechToText = true with configured models, want false so the configured list stays authoritative")
+	}
+
+	withoutModels := New(providers.ProviderConfig{APIKey: "test-key"}, providers.ProviderOptions{}).(*Provider)
+	if !withoutModels.detectSpeechToText {
+		t.Error("detectSpeechToText = false without configured models, want true")
+	}
+}
+
+func TestListModels_SpeechToTextFallbackDisabledByDefault(t *testing.T) {
+	upstream := &sttUpstream{
+		modelsStatus:        http.StatusNotFound,
+		transcriptionStatus: http.StatusUnprocessableEntity,
+	}
+	server := httptest.NewServer(upstream.handler())
+	defer server.Close()
+
+	provider := NewCompatibleProviderWithHTTPClient("test-key", server.Client(), llmclient.Hooks{}, CompatibleProviderConfig{
+		ProviderName: "custom",
+		BaseURL:      server.URL,
+	})
+
+	if _, err := provider.ListModels(context.Background()); err == nil {
+		t.Fatal("ListModels() error = nil, want missing /models error when detection is off")
+	}
+	if got := upstream.probes.Load(); got != 0 {
+		t.Errorf("transcription probes = %d, want 0", got)
+	}
+}


### PR DESCRIPTION
Fixes #819.

OpenAI-compatible STT servers (whisper.cpp server, faster-whisper wrappers) may expose only `/v1/audio/transcriptions` — no `GET /v1/models`. Today such a provider fails model discovery and never becomes routable.

For providers of `type: openai`, when `GET /models` reports the route missing (404/405/501) or returns an empty list, GoModel now probes `POST /audio/transcriptions` with an empty body. If the upstream rejects it with a request-level error (400/413/415/422), the provider advertises a synthesized `whisper-1` model with the `audio_transcription` mode, so OpenAI SDK clients (which default to `whisper-1`) route to it with zero configuration.

Behavior notes:

- Detection is skipped when the provider declares `models:` — with the default configured-models mode (`fallback`) a successfully synthesized inventory would otherwise silently override the operator's list.
- Auth/availability failures on `/models` are never treated as "endpoint missing", and a 401/403 on the probe is not accepted as proof the endpoint exists (middleware that authenticates before route matching emits those for absent routes too), so bad credentials or outages surface as fetch errors instead of a phantom model.
- Other wrappers of the shared OpenAI-compatible transport (Azure, OpenRouter, chat-centric providers) leave the flag off; nothing changes for them or for api.openai.com, where `/models` always answers.

Docs: `config.example.yaml` and the Audio API page document the detection and the `models:` override for servers that require their own model name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic support for OpenAI-compatible speech-to-text servers that do not provide a model list.
  - These servers now advertise the `whisper-1` transcription model when detected.
  - Custom model configurations take precedence over automatic detection.
- **Documentation**
  - Added configuration examples and guidance for speech-to-text-only servers.
- **Bug Fixes**
  - Improved model discovery when compatible servers omit or return an empty model catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->