### PR TITLE
perf(routing): look up models by selector and memoize resolved-model strings

### DIFF
--- a/internal/auditlog/enrich.go
+++ b/internal/auditlog/enrich.go
@@ -485,7 +485,7 @@ func enrichEntryWithWorkflow(entry *LogEntry, workflow *core.Workflow) {
 	executedProvider := failoverRecorded && strings.TrimSpace(entry.Provider) != ""
 	executedProviderName := failoverRecorded && strings.TrimSpace(entry.ProviderName) != ""
 
-	if resolvedModel := resolvedModelForAuditLog(workflow); resolvedModel != "" && !executedResolvedModel {
+	if resolvedModel := workflow.Resolution.ResolvedRouteModel(); resolvedModel != "" && !executedResolvedModel {
 		entry.ResolvedModel = resolvedModel
 	}
 	if workflow.Mode == core.ExecutionModePassthrough && workflow.Passthrough != nil {
@@ -522,23 +522,6 @@ func enrichEntryWithWorkflow(entry *LogEntry, workflow *core.Workflow) {
 			Failover:   workflow.Policy.Features.Failover,
 		}
 	}
-}
-
-func resolvedModelForAuditLog(workflow *core.Workflow) string {
-	if workflow == nil || workflow.Resolution == nil {
-		return ""
-	}
-	model := strings.TrimSpace(workflow.Resolution.ResolvedSelector.Model)
-	if model == "" {
-		return ""
-	}
-	if providerName := strings.TrimSpace(workflow.Resolution.ProviderName); providerName != "" {
-		return providerName + "/" + model
-	}
-	if provider := strings.TrimSpace(workflow.Resolution.ResolvedSelector.Provider); provider != "" {
-		return provider + "/" + model
-	}
-	return model
 }
 
 func enrichEntryWithResolvedRoute(entry *LogEntry, resolvedModel, providerType, providerName string) {

--- a/internal/core/request_model_resolution.go
+++ b/internal/core/request_model_resolution.go
@@ -1,5 +1,7 @@
 package core
 
+import "strings"
+
 // RequestModelResolution captures the requested model selector at ingress and
 // the concrete selector chosen for execution after alias resolution.
 type RequestModelResolution struct {
@@ -11,6 +13,23 @@ type RequestModelResolution struct {
 	// Slowdown is the extra-time factor selected for this request. A value of
 	// 0.5 adds 50% of measured inference time; zero disables slowdown.
 	Slowdown float64
+
+	// resolvedQualified and resolvedRoute memoize the derived selector strings
+	// (see CacheDerivedSelectors); empty means "compute on demand".
+	resolvedQualified string
+	resolvedRoute     string
+}
+
+// CacheDerivedSelectors precomputes the strings returned by
+// ResolvedQualifiedModel and ResolvedRouteModel, which are read several times
+// per request. Call it once after the resolution is fully populated; the
+// getters fall back to computing the values when it was not called.
+func (r *RequestModelResolution) CacheDerivedSelectors() {
+	if r == nil {
+		return
+	}
+	r.resolvedQualified = r.ResolvedSelector.QualifiedModel()
+	r.resolvedRoute = r.computeResolvedRouteModel()
 }
 
 // RequestedQualifiedModel returns the canonical requested selector.
@@ -26,5 +45,35 @@ func (r *RequestModelResolution) ResolvedQualifiedModel() string {
 	if r == nil {
 		return ""
 	}
+	if r.resolvedQualified != "" {
+		return r.resolvedQualified
+	}
 	return r.ResolvedSelector.QualifiedModel()
+}
+
+// ResolvedRouteModel returns the executed route selector recorded in audit
+// logs: the resolved model qualified by the configured provider instance name
+// when known, falling back to the selector's own provider prefix.
+func (r *RequestModelResolution) ResolvedRouteModel() string {
+	if r == nil {
+		return ""
+	}
+	if r.resolvedRoute != "" {
+		return r.resolvedRoute
+	}
+	return r.computeResolvedRouteModel()
+}
+
+func (r *RequestModelResolution) computeResolvedRouteModel() string {
+	model := strings.TrimSpace(r.ResolvedSelector.Model)
+	if model == "" {
+		return ""
+	}
+	if providerName := strings.TrimSpace(r.ProviderName); providerName != "" {
+		return providerName + "/" + model
+	}
+	if provider := strings.TrimSpace(r.ResolvedSelector.Provider); provider != "" {
+		return provider + "/" + model
+	}
+	return model
 }

--- a/internal/core/request_model_resolution_test.go
+++ b/internal/core/request_model_resolution_test.go
@@ -46,3 +46,73 @@ func TestRequestModelResolutionRequestedQualifiedModel(t *testing.T) {
 		})
 	}
 }
+
+func TestRequestModelResolutionResolvedRouteModel(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *RequestModelResolution
+		want string
+	}{
+		{name: "nil resolution", in: nil, want: ""},
+		{name: "empty model", in: &RequestModelResolution{ProviderName: "openai-primary"}, want: ""},
+		{
+			name: "provider instance name wins over selector provider",
+			in: &RequestModelResolution{
+				ResolvedSelector: ModelSelector{Provider: "openai", Model: "gpt-4o"},
+				ProviderName:     "openai-primary",
+			},
+			want: "openai-primary/gpt-4o",
+		},
+		{
+			name: "selector provider is the fallback prefix",
+			in: &RequestModelResolution{
+				ResolvedSelector: ModelSelector{Provider: "openai", Model: "gpt-4o"},
+			},
+			want: "openai/gpt-4o",
+		},
+		{
+			name: "bare model without any provider",
+			in: &RequestModelResolution{
+				ResolvedSelector: ModelSelector{Model: "gpt-4o"},
+			},
+			want: "gpt-4o",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.in.ResolvedRouteModel(); got != tt.want {
+				t.Fatalf("ResolvedRouteModel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRequestModelResolutionCacheDerivedSelectors(t *testing.T) {
+	resolution := &RequestModelResolution{
+		ResolvedSelector: ModelSelector{Provider: "openai", Model: "gpt-4o"},
+		ProviderName:     "openai-primary",
+	}
+	resolution.CacheDerivedSelectors()
+
+	if got := resolution.ResolvedQualifiedModel(); got != "openai/gpt-4o" {
+		t.Fatalf("ResolvedQualifiedModel() = %q, want openai/gpt-4o", got)
+	}
+	if got := resolution.ResolvedRouteModel(); got != "openai-primary/gpt-4o" {
+		t.Fatalf("ResolvedRouteModel() = %q, want openai-primary/gpt-4o", got)
+	}
+
+	// Without the cache the getters compute the same values.
+	uncached := &RequestModelResolution{
+		ResolvedSelector: ModelSelector{Provider: "openai", Model: "gpt-4o"},
+		ProviderName:     "openai-primary",
+	}
+	if got := uncached.ResolvedQualifiedModel(); got != resolution.ResolvedQualifiedModel() {
+		t.Fatalf("uncached ResolvedQualifiedModel() = %q, want %q", got, resolution.ResolvedQualifiedModel())
+	}
+	if got := uncached.ResolvedRouteModel(); got != resolution.ResolvedRouteModel() {
+		t.Fatalf("uncached ResolvedRouteModel() = %q, want %q", got, resolution.ResolvedRouteModel())
+	}
+
+	(*RequestModelResolution)(nil).CacheDerivedSelectors()
+}

--- a/internal/gateway/model_helpers.go
+++ b/internal/gateway/model_helpers.go
@@ -123,7 +123,10 @@ func QualifyModelWithProvider(model, providerName string) string {
 	if model == "" {
 		return ""
 	}
-	if providerName == "" || strings.HasPrefix(model, providerName+"/") {
+	if providerName == "" {
+		return model
+	}
+	if rest, ok := strings.CutPrefix(model, providerName); ok && strings.HasPrefix(rest, "/") {
 		return model
 	}
 	return providerName + "/" + model

--- a/internal/gateway/request_model_resolution.go
+++ b/internal/gateway/request_model_resolution.go
@@ -144,6 +144,7 @@ func ResolveRequestModelWithAuthorizer(
 	if slowdownResolver, ok := resolver.(ModelSlowdownResolver); ok {
 		resolution.Slowdown = slowdownResolver.ResolveSlowdown(ctx, requested, resolvedSelector)
 	}
+	resolution.CacheDerivedSelectors()
 	return resolution, nil
 }
 

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -397,25 +397,69 @@ func (r *ModelRegistry) UnregisterProvider(providerName string) {
 	r.invalidateSortedCaches()
 }
 
+// modelInfoLocked resolves a qualified or bare model string to its registry
+// entry. A "provider/" prefix consults that provider's bucket first (accepting
+// model IDs that themselves contain the full qualified spelling); an unknown
+// prefix falls through to the global table because the slash may be part of
+// the model ID (e.g. "meta-llama/Meta-Llama-3-70B").
+func (r *ModelRegistry) modelInfoLocked(model string) (*ModelInfo, bool) {
+	providerName, modelID := splitModelSelector(model)
+	if providerName != "" {
+		if providerModels, ok := r.modelsByProvider[providerName]; ok {
+			if info, exists := providerModelInfo(providerModels, modelID, model); exists {
+				return info, true
+			}
+		}
+		if r.hasConfiguredProviderNameLocked(providerName) {
+			return nil, false
+		}
+	}
+	info, ok := r.models[model]
+	return info, ok
+}
+
+// selectorModelInfoLocked is modelInfoLocked for an already-parsed selector.
+// It looks up the same entry the qualified string would find, but only
+// materializes "provider/model" on the rare second-chance paths, keeping the
+// per-request lookups allocation-free.
+func (r *ModelRegistry) selectorModelInfoLocked(selector core.ModelSelector) (*ModelInfo, bool) {
+	providerName := strings.TrimSpace(selector.Provider)
+	modelID := strings.TrimSpace(selector.Model)
+	if providerName == "" || modelID == "" {
+		return r.modelInfoLocked(selector.QualifiedModel())
+	}
+	if providerModels, ok := r.modelsByProvider[providerName]; ok {
+		if info, exists := providerModels[modelID]; exists {
+			return info, true
+		}
+		if info, exists := providerModels[providerName+"/"+modelID]; exists {
+			return info, true
+		}
+	}
+	if r.hasConfiguredProviderNameLocked(providerName) {
+		return nil, false
+	}
+	info, ok := r.models[providerName+"/"+modelID]
+	return info, ok
+}
+
 // GetProvider returns the provider for the given model, or nil if not found
 func (r *ModelRegistry) GetProvider(model string) core.Provider {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	providerName, modelID := splitModelSelector(model)
-	if providerName != "" {
-		if providerModels, ok := r.modelsByProvider[providerName]; ok {
-			if info, exists := providerModelInfo(providerModels, modelID, model); exists {
-				return info.Provider
-			}
-		}
-		if r.hasConfiguredProviderNameLocked(providerName) {
-			return nil
-		}
-		// Fall through: the slash may be part of the model ID (e.g. "meta-llama/Meta-Llama-3-70B")
+	if info, ok := r.modelInfoLocked(model); ok {
+		return info.Provider
 	}
+	return nil
+}
 
-	if info, ok := r.models[model]; ok {
+// GetProviderForSelector is GetProvider for an already-parsed selector.
+func (r *ModelRegistry) GetProviderForSelector(selector core.ModelSelector) core.Provider {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if info, ok := r.selectorModelInfoLocked(selector); ok {
 		return info.Provider
 	}
 	return nil
@@ -427,20 +471,7 @@ func (r *ModelRegistry) GetModel(model string) *ModelInfo {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	providerName, modelID := splitModelSelector(model)
-	if providerName != "" {
-		if providerModels, ok := r.modelsByProvider[providerName]; ok {
-			if info, exists := providerModelInfo(providerModels, modelID, model); exists {
-				return info
-			}
-		}
-		if r.hasConfiguredProviderNameLocked(providerName) {
-			return nil
-		}
-		// Fall through: the slash may be part of the model ID
-	}
-
-	if info, ok := r.models[model]; ok {
+	if info, ok := r.modelInfoLocked(model); ok {
 		return info
 	}
 	return nil
@@ -452,21 +483,7 @@ func (r *ModelRegistry) LookupModel(model string) (*core.Model, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	providerName, modelID := splitModelSelector(model)
-	if providerName != "" {
-		if providerModels, ok := r.modelsByProvider[providerName]; ok {
-			if info, exists := providerModelInfo(providerModels, modelID, model); exists {
-				cloned := info.Model
-				return &cloned, true
-			}
-		}
-		if r.hasConfiguredProviderNameLocked(providerName) {
-			return nil, false
-		}
-		// Fall through: the slash may be part of the model ID
-	}
-
-	if info, ok := r.models[model]; ok {
+	if info, ok := r.modelInfoLocked(model); ok {
 		cloned := info.Model
 		return &cloned, true
 	}
@@ -478,20 +495,16 @@ func (r *ModelRegistry) Supports(model string) bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	providerName, modelID := splitModelSelector(model)
-	if providerName != "" {
-		if providerModels, ok := r.modelsByProvider[providerName]; ok {
-			if _, exists := providerModelInfo(providerModels, modelID, model); exists {
-				return true
-			}
-		}
-		if r.hasConfiguredProviderNameLocked(providerName) {
-			return false
-		}
-		// Fall through: the slash may be part of the model ID
-	}
+	_, ok := r.modelInfoLocked(model)
+	return ok
+}
 
-	_, ok := r.models[model]
+// SupportsSelector is Supports for an already-parsed selector.
+func (r *ModelRegistry) SupportsSelector(selector core.ModelSelector) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	_, ok := r.selectorModelInfoLocked(selector)
 	return ok
 }
 
@@ -676,20 +689,18 @@ func (r *ModelRegistry) GetProviderType(model string) string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	providerName, modelID := splitModelSelector(model)
-	if providerName != "" {
-		if providerModels, ok := r.modelsByProvider[providerName]; ok {
-			if info, exists := providerModelInfo(providerModels, modelID, model); exists {
-				return info.ProviderType
-			}
-		}
-		if r.hasConfiguredProviderNameLocked(providerName) {
-			return ""
-		}
-		// Fall through: the slash may be part of the model ID
+	if info, ok := r.modelInfoLocked(model); ok {
+		return info.ProviderType
 	}
+	return ""
+}
 
-	if info, ok := r.models[model]; ok {
+// GetProviderTypeForSelector is GetProviderType for an already-parsed selector.
+func (r *ModelRegistry) GetProviderTypeForSelector(selector core.ModelSelector) string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if info, ok := r.selectorModelInfoLocked(selector); ok {
 		return info.ProviderType
 	}
 	return ""
@@ -701,19 +712,18 @@ func (r *ModelRegistry) GetProviderName(model string) string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	providerName, modelID := splitModelSelector(model)
-	if providerName != "" {
-		if providerModels, ok := r.modelsByProvider[providerName]; ok {
-			if info, exists := providerModelInfo(providerModels, modelID, model); exists {
-				return strings.TrimSpace(info.ProviderName)
-			}
-		}
-		if r.hasConfiguredProviderNameLocked(providerName) {
-			return ""
-		}
+	if info, ok := r.modelInfoLocked(model); ok {
+		return strings.TrimSpace(info.ProviderName)
 	}
+	return ""
+}
 
-	if info, ok := r.models[model]; ok {
+// GetProviderNameForSelector is GetProviderName for an already-parsed selector.
+func (r *ModelRegistry) GetProviderNameForSelector(selector core.ModelSelector) string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if info, ok := r.selectorModelInfoLocked(selector); ok {
 		return strings.TrimSpace(info.ProviderName)
 	}
 	return ""

--- a/internal/providers/registry_selector_test.go
+++ b/internal/providers/registry_selector_test.go
@@ -1,0 +1,65 @@
+package providers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+// TestRegistrySelectorLookupsMatchStringLookups pins the selector-keyed fast
+// path to the qualified-string lookups it shortcuts: for every selector shape
+// (provider bucket hit, raw slash-shaped model ID, unknown model, unknown
+// provider, configured provider with a foreign model, empty parts), both
+// paths must answer identically.
+func TestRegistrySelectorLookupsMatchStringLookups(t *testing.T) {
+	registry := NewModelRegistry()
+	registry.RegisterProviderWithNameAndType(&registryMockProvider{
+		name: "openai-primary",
+		modelsResponse: &core.ModelsResponse{
+			Object: "list",
+			Data:   []core.Model{{ID: "gpt-4o", Object: "model", OwnedBy: "openai"}},
+		},
+	}, "openai-primary", "openai")
+	registry.RegisterProviderWithNameAndType(&registryMockProvider{
+		name: "groq",
+		modelsResponse: &core.ModelsResponse{
+			Object: "list",
+			Data:   []core.Model{{ID: "meta-llama/llama-3-70b", Object: "model", OwnedBy: "meta"}},
+		},
+	}, "groq", "groq")
+	if err := registry.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	selectors := []core.ModelSelector{
+		{Provider: "openai-primary", Model: "gpt-4o"},
+		{Provider: "groq", Model: "meta-llama/llama-3-70b"},
+		{Provider: "meta-llama", Model: "llama-3-70b"},
+		{Provider: "", Model: "gpt-4o"},
+		{Provider: "", Model: "meta-llama/llama-3-70b"},
+		{Provider: "openai-primary", Model: "missing-model"},
+		{Provider: "unknown-provider", Model: "gpt-4o"},
+		{Provider: "", Model: "missing"},
+		{Provider: "openai-primary", Model: ""},
+		{Provider: "", Model: ""},
+	}
+
+	for _, selector := range selectors {
+		qualified := selector.QualifiedModel()
+		t.Run(qualified, func(t *testing.T) {
+			if got, want := registry.SupportsSelector(selector), registry.Supports(qualified); got != want {
+				t.Errorf("SupportsSelector = %v, Supports(%q) = %v", got, qualified, want)
+			}
+			if got, want := registry.GetProviderForSelector(selector), registry.GetProvider(qualified); got != want {
+				t.Errorf("GetProviderForSelector = %v, GetProvider(%q) = %v", got, qualified, want)
+			}
+			if got, want := registry.GetProviderTypeForSelector(selector), registry.GetProviderType(qualified); got != want {
+				t.Errorf("GetProviderTypeForSelector = %q, GetProviderType(%q) = %q", got, qualified, want)
+			}
+			if got, want := registry.GetProviderNameForSelector(selector), registry.GetProviderName(qualified); got != want {
+				t.Errorf("GetProviderNameForSelector = %q, GetProviderName(%q) = %q", got, qualified, want)
+			}
+		})
+	}
+}

--- a/internal/providers/router.go
+++ b/internal/providers/router.go
@@ -23,6 +23,9 @@ var ErrRegistryNotInitialized = fmt.Errorf("model registry has no models: ensure
 type Router struct {
 	lookup       core.ModelLookup
 	cachePlanner *cachePlanner
+	// selectorLookup is lookup's optional selector-keyed fast path, asserted
+	// once at construction; nil when the lookup only speaks qualified strings.
+	selectorLookup selectorModelLookup
 	// unqualifiedModelIDs makes ListModels advertise bare model IDs instead of
 	// provider-qualified ones.
 	unqualifiedModelIDs bool
@@ -68,6 +71,16 @@ type qualifiedSelectorResolver interface {
 	ResolveProviderSelector(segment, modelID string) (core.ModelSelector, bool)
 }
 
+// selectorModelLookup is an optional lookup fast path that answers the
+// ModelLookup queries for an already-parsed selector without materializing the
+// qualified "provider/model" string on every request.
+type selectorModelLookup interface {
+	SupportsSelector(selector core.ModelSelector) bool
+	GetProviderForSelector(selector core.ModelSelector) core.Provider
+	GetProviderTypeForSelector(selector core.ModelSelector) string
+	GetProviderNameForSelector(selector core.ModelSelector) string
+}
+
 type providerModelRefresher interface {
 	RefreshProviderModels(ctx context.Context, providerSelector string) (int, error)
 }
@@ -83,10 +96,44 @@ func NewRouter(lookup core.ModelLookup) (*Router, error) {
 	if lookup == nil {
 		return nil, fmt.Errorf("lookup cannot be nil")
 	}
-	return &Router{
+	router := &Router{
 		lookup:       lookup,
 		cachePlanner: newCachePlanner(),
-	}, nil
+	}
+	router.selectorLookup, _ = lookup.(selectorModelLookup)
+	return router, nil
+}
+
+// lookupSupports, lookupProvider, lookupProviderType and lookupProviderName
+// answer lookup queries for a parsed selector, using the selector-keyed fast
+// path when the lookup provides one.
+
+func (r *Router) lookupSupports(selector core.ModelSelector) bool {
+	if r.selectorLookup != nil {
+		return r.selectorLookup.SupportsSelector(selector)
+	}
+	return r.lookup.Supports(selector.QualifiedModel())
+}
+
+func (r *Router) lookupProvider(selector core.ModelSelector) core.Provider {
+	if r.selectorLookup != nil {
+		return r.selectorLookup.GetProviderForSelector(selector)
+	}
+	return r.lookup.GetProvider(selector.QualifiedModel())
+}
+
+func (r *Router) lookupProviderType(selector core.ModelSelector) string {
+	if r.selectorLookup != nil {
+		return r.selectorLookup.GetProviderTypeForSelector(selector)
+	}
+	return r.lookup.GetProviderType(selector.QualifiedModel())
+}
+
+func (r *Router) lookupProviderName(selector core.ModelSelector) string {
+	if r.selectorLookup != nil {
+		return r.selectorLookup.GetProviderNameForSelector(selector)
+	}
+	return r.lookup.GetProviderName(selector.QualifiedModel())
 }
 
 // SetUnqualifiedModelIDs controls whether ListModels advertises bare model IDs
@@ -276,8 +323,7 @@ func (r *Router) resolveProvider(ctx context.Context, model, providerHint string
 		}
 	}
 
-	lookupModel := selector.QualifiedModel()
-	p := r.lookup.GetProvider(lookupModel)
+	p := r.lookupProvider(selector)
 	if p == nil && !refreshed {
 		var refreshErr error
 		refreshed, refreshErr = r.refreshProviderModelsForRequest(ctx, requested)
@@ -289,12 +335,11 @@ func (r *Router) resolveProvider(ctx context.Context, model, providerHint string
 			if err != nil {
 				return nil, core.ModelSelector{}, err
 			}
-			lookupModel = selector.QualifiedModel()
-			p = r.lookup.GetProvider(lookupModel)
+			p = r.lookupProvider(selector)
 		}
 	}
 	if p == nil {
-		return nil, core.ModelSelector{}, core.NewNotFoundError("model not found: " + lookupModel)
+		return nil, core.ModelSelector{}, core.NewNotFoundError("model not found: " + selector.QualifiedModel())
 	}
 	return p, selector, nil
 }
@@ -474,7 +519,9 @@ func routeResolvedModelCall[Req any, Resp any](
 	}
 
 	resp, err := call(ctx, p, buildForward(selector))
-	return resp, r.GetProviderType(selector.QualifiedModel()), err
+	// The selector is already concrete (resolveProvider found its provider), so
+	// the lookup answers directly without another resolution round-trip.
+	return resp, r.lookupProviderType(selector), err
 }
 
 func routeStampedModelResponse[Req any, Resp any](
@@ -587,7 +634,7 @@ func (r *Router) forwardChatRequest(ctx context.Context, req *core.ChatRequest, 
 	}
 	// The selector is already concrete, so querying the lookup directly avoids
 	// repeating model resolution on every routed Messages request.
-	return adaptAnthropicCacheControl(&forwardReq, r.lookup.GetProviderType(selector.QualifiedModel()))
+	return adaptAnthropicCacheControl(&forwardReq, r.lookupProviderType(selector))
 }
 
 func forwardResponsesRequest(req *core.ResponsesRequest, selector core.ModelSelector) *core.ResponsesRequest {
@@ -602,7 +649,7 @@ func (r *Router) plannedChatRequest(ctx context.Context, req *core.ChatRequest, 
 	if r.cachePlanner == nil {
 		return forward
 	}
-	return r.cachePlanner.planChat(forward, r.lookup.GetProviderType(selector.QualifiedModel()), selector)
+	return r.cachePlanner.planChat(forward, r.lookupProviderType(selector), selector)
 }
 
 func (r *Router) plannedResponsesRequest(req *core.ResponsesRequest, selector core.ModelSelector) *core.ResponsesRequest {
@@ -610,7 +657,7 @@ func (r *Router) plannedResponsesRequest(req *core.ResponsesRequest, selector co
 	if r.cachePlanner == nil {
 		return forward
 	}
-	return r.cachePlanner.planResponses(forward, r.lookup.GetProviderType(selector.QualifiedModel()), selector)
+	return r.cachePlanner.planResponses(forward, r.lookupProviderType(selector), selector)
 }
 
 func forwardEmbeddingRequest(req *core.EmbeddingRequest, selector core.ModelSelector) *core.EmbeddingRequest {
@@ -667,7 +714,7 @@ func (r *Router) Supports(model string) bool {
 	if err != nil {
 		return false
 	}
-	return r.lookup.Supports(selector.QualifiedModel())
+	return r.lookupSupports(selector)
 }
 
 // ModelCount returns the number of models currently loaded into the router lookup.
@@ -1001,7 +1048,7 @@ func (r *Router) GetProviderType(model string) string {
 	if err != nil {
 		return ""
 	}
-	return r.lookup.GetProviderType(selector.QualifiedModel())
+	return r.lookupProviderType(selector)
 }
 
 // GetProviderName returns the concrete configured provider instance name for
@@ -1011,13 +1058,13 @@ func (r *Router) GetProviderName(model string) string {
 	if err != nil {
 		return ""
 	}
-	if !r.lookup.Supports(selector.QualifiedModel()) {
+	if !r.lookupSupports(selector) {
 		return ""
 	}
 	if selector.Provider != "" {
 		return selector.Provider
 	}
-	return r.lookup.GetProviderName(selector.QualifiedModel())
+	return r.lookupProviderName(selector)
 }
 
 // GetProviderNameForType returns the concrete configured provider instance name
@@ -1085,7 +1132,7 @@ func (r *Router) providerByName(providerName string) core.Provider {
 		if modelID == "" {
 			continue
 		}
-		if provider := r.lookup.GetProvider(core.ModelSelector{Provider: providerName, Model: modelID}.QualifiedModel()); provider != nil {
+		if provider := r.lookupProvider(core.ModelSelector{Provider: providerName, Model: modelID}); provider != nil {
 			return provider
 		}
 	}

--- a/internal/server/request_snapshot.go
+++ b/internal/server/request_snapshot.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"net/textproto"
 	"strings"
 
 	"github.com/google/uuid"
@@ -21,6 +22,11 @@ const requestSnapshotInlineBodyLimit int64 = 64 * 1024
 // stay on the live request stream until the handler actually decodes them.
 func RequestSnapshotCapture(userPathHeader ...string) echo.MiddlewareFunc {
 	userPathHeaderName := configuredUserPathHeaderName(userPathHeader...)
+	// Header.Get/Set canonicalize a non-canonical key on every call, and the
+	// default header name keeps its brand casing ("GoModel"), so canonicalize
+	// it once here. userPathHeaderName stays the user-facing spelling for
+	// error messages and context.
+	canonicalUserPathHeader := textproto.CanonicalMIMEHeaderKey(userPathHeaderName)
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c *echo.Context) error {
 			req, requestID := ensureRequestID(c.Request())
@@ -38,12 +44,12 @@ func RequestSnapshotCapture(userPathHeader ...string) echo.MiddlewareFunc {
 				// managed key's bound path still wins — auth middleware runs
 				// later and its context value shadows this one.
 				if desc.ModelInteraction {
-					userPath, err := core.NormalizeUserPath(req.Header.Get(userPathHeaderName))
+					userPath, err := core.NormalizeUserPath(req.Header.Get(canonicalUserPathHeader))
 					if err != nil {
 						return handleError(c, core.NewInvalidRequestError("invalid "+userPathHeaderName+" header", err))
 					}
 					if userPath != "" {
-						req.Header.Set(userPathHeaderName, userPath)
+						req.Header.Set(canonicalUserPathHeader, userPath)
 						req = req.WithContext(core.WithEffectiveUserPath(req.Context(), userPath))
 					}
 				}
@@ -51,12 +57,12 @@ func RequestSnapshotCapture(userPathHeader ...string) echo.MiddlewareFunc {
 				return next(c)
 			}
 
-			userPath, err := core.NormalizeUserPath(req.Header.Get(userPathHeaderName))
+			userPath, err := core.NormalizeUserPath(req.Header.Get(canonicalUserPathHeader))
 			if err != nil {
 				return handleError(c, core.NewInvalidRequestError("invalid "+userPathHeaderName+" header", err))
 			}
 			if userPath != "" {
-				req.Header.Set(userPathHeaderName, userPath)
+				req.Header.Set(canonicalUserPathHeader, userPath)
 			}
 
 			bodyBytes, bodyNotCaptured, bodyCaptured, err := captureSmallRequestBodyForSnapshot(req, desc.BodyMode)

--- a/tests/perf/hotpath_test.go
+++ b/tests/perf/hotpath_test.go
@@ -389,7 +389,7 @@ func TestHotPathPerfGuard(t *testing.T) {
 		{
 			name:      "gateway_chat_completion_hot_path",
 			bench:     BenchmarkGatewayHotPathChatCompletion,
-			maxAllocs: 88,    // baseline 85 (single-alloc body reader, lazy unknown-field buffer, no context re-wraps)
+			maxAllocs: 87,    // baseline 84 (single-alloc body reader, lazy unknown-field buffer, no context re-wraps)
 			maxBytes:  13440, // baseline ~12.9 KB (incl. per-attempt response body/header capture fields)
 		},
 		{
@@ -400,8 +400,8 @@ func TestHotPathPerfGuard(t *testing.T) {
 			// full catalog several times per request) would blow these limits.
 			name:      "gateway_chat_completion_hot_path_routed",
 			bench:     BenchmarkGatewayHotPathChatCompletionRouted,
-			maxAllocs: 102,   // baseline 99 (see the bare case; plus strings.Cut selector parsing)
-			maxBytes:  13888, // baseline ~13.3 KB
+			maxAllocs: 94,    // baseline 90 (see the bare case; plus selector-keyed catalog lookups)
+			maxBytes:  13760, // baseline ~13.2 KB
 		},
 		{
 			// Default-deployment shape: auth + audit (bodies/headers) + usage +
@@ -411,8 +411,8 @@ func TestHotPathPerfGuard(t *testing.T) {
 			// deployments actually run.
 			name:      "gateway_chat_completion_production_shape",
 			bench:     BenchmarkGatewayHotPathProductionShape,
-			maxAllocs: 160,   // baseline 156 (audit bodies kept as raw JSON instead of decoded into maps)
-			maxBytes:  19968, // baseline ~19.3 KB
+			maxAllocs: 150,   // baseline 145 (selector-keyed lookups + memoized resolved-model strings)
+			maxBytes:  19840, // baseline ~19.2 KB
 		},
 		{
 			// Typed chunk decoding + reused read buffer keep this converter at a


### PR DESCRIPTION
Third round of hot-path allocation work (follows #792/#793). Profiling showed `ModelSelector.QualifiedModel()` as the single largest remaining allocation site: ~12 heap allocations per request spent building the qualified `provider/model` string, which the registry then immediately split apart again.

## Changes

- **Registry**: the six duplicated string-lookup bodies (`GetProvider`, `GetModel`, `LookupModel`, `Supports`, `GetProviderType`, `GetProviderName`) collapse into one shared `modelInfoLocked` helper, and new `*ForSelector` variants answer the same queries for an already-parsed selector without materializing the qualified string (it is only built on the rare second-chance paths, e.g. slash-shaped model IDs). A parity test pins both paths to identical answers across selector shapes.
- **Router**: asserts the selector fast path once at construction (same pattern as the existing `qualifiedSelectorResolver`) and uses it everywhere it previously called `r.lookup.X(selector.QualifiedModel())`. Lookups that only speak qualified strings (test fakes) keep working through the fallback.
- **RequestModelResolution**: memoizes its two derived strings — the resolved qualified model and the audit route label (formerly `resolvedModelForAuditLog`, now `ResolvedRouteModel()` on the resolution) — computed once when the gateway builds the resolution instead of on every audit-enrich pass, rate-limit read and cache read. Getters fall back to computing when the cache wasn't filled, so literal-constructed resolutions behave as before.
- **Small ones**: `QualifyModelWithProvider` no longer allocates for its prefix check; the snapshot middleware canonicalizes the brand-cased `X-GoModel-User-Path` key once at construction instead of on every `Header.Get` (wire format and error messages unchanged).

## Impact

No user-visible behavior change; request/response shapes, audit log contents and the public string-based lookup APIs are unchanged.

| benchmark | main | this PR |
|---|---|---|
| production shape | 157 allocs/op, 19.4 KB | **145 allocs/op, 19.2 KB** |
| routed | 99 allocs/op | **90 allocs/op** |
| bare | 85 allocs/op | **84 allocs/op** |

CI alloc ceilings lowered to match.