### PR TITLE
fix(responses): include output array in streamed response.completed

### DIFF
--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -3159,6 +3159,159 @@ data: {"type":"message_stop"}
 	}
 }
 
+// TestStreamResponses_TruncatedToolCallFinalizedAtEOF covers an upstream stream
+// that dies mid tool call (no content_block_stop / message_stop). The converter
+// must emit the tool call's done events before response.completed so the
+// terminal output only reports items the stream actually closed.
+func TestStreamResponses_TruncatedToolCallFinalizedAtEOF(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`event: message_start
+data: {"type":"message_start","message":{"id":"msg_123","type":"message","role":"assistant","model":"claude-sonnet-4-5-20250929","content":[],"stop_reason":null,"usage":{"input_tokens":10,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_123","name":"lookup_weather","input":{}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"city\":\"War"}}
+`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("test-api-key", nil, llmclient.Hooks{})
+	provider.SetBaseURL(server.URL)
+
+	body, err := provider.StreamResponses(context.Background(), &core.ResponsesRequest{
+		Model: "claude-sonnet-4-5-20250929",
+		Input: "What's the weather?",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = body.Close() }()
+
+	raw, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+
+	foundArgumentsDone := false
+	foundItemDone := false
+	var output []any
+	for _, event := range parseTestSSEEvents(t, string(raw)) {
+		if event.Done {
+			continue
+		}
+		switch event.Name {
+		case "response.function_call_arguments.done":
+			foundArgumentsDone = true
+		case "response.output_item.done":
+			item, _ := event.Payload["item"].(map[string]any)
+			if item["type"] == "function_call" {
+				foundItemDone = true
+			}
+		case "response.completed":
+			response, _ := event.Payload["response"].(map[string]any)
+			output, _ = response["output"].([]any)
+		}
+	}
+
+	if !foundArgumentsDone {
+		t.Fatal("expected response.function_call_arguments.done before response.completed on truncated stream")
+	}
+	if !foundItemDone {
+		t.Fatal("expected function_call response.output_item.done before response.completed on truncated stream")
+	}
+	if len(output) != 1 {
+		t.Fatalf("response.completed output has %d items, want 1: %#v", len(output), output)
+	}
+	toolCall, _ := output[0].(map[string]any)
+	if toolCall["type"] != "function_call" || toolCall["call_id"] != "toolu_123" || toolCall["arguments"] != `{"city":"War` {
+		t.Fatalf("output[0] = %#v, want finalized function_call with accumulated arguments", toolCall)
+	}
+}
+
+// TestStreamResponses_ToolCallBeforeTextKeepsOutputOrder covers a tool_use
+// block preceding the first text block. The assistant message must claim the
+// next free output index (not collide with the tool call at index 0) and the
+// terminal output must preserve stream order.
+func TestStreamResponses_ToolCallBeforeTextKeepsOutputOrder(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`event: message_start
+data: {"type":"message_start","message":{"id":"msg_123","type":"message","role":"assistant","model":"claude-sonnet-4-5-20250929","content":[],"stop_reason":null,"usage":{"input_tokens":10,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_123","name":"lookup_weather","input":{}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"city\":\"Warsaw\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Looking it up."}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_stop
+data: {"type":"message_stop"}
+`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("test-api-key", nil, llmclient.Hooks{})
+	provider.SetBaseURL(server.URL)
+
+	body, err := provider.StreamResponses(context.Background(), &core.ResponsesRequest{
+		Model: "claude-sonnet-4-5-20250929",
+		Input: "What's the weather?",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = body.Close() }()
+
+	raw, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+
+	addedIndexes := make(map[string]float64)
+	var output []any
+	for _, event := range parseTestSSEEvents(t, string(raw)) {
+		if event.Done {
+			continue
+		}
+		switch event.Name {
+		case "response.output_item.added":
+			item, _ := event.Payload["item"].(map[string]any)
+			itemType, _ := item["type"].(string)
+			addedIndexes[itemType], _ = event.Payload["output_index"].(float64)
+		case "response.completed":
+			response, _ := event.Payload["response"].(map[string]any)
+			output, _ = response["output"].([]any)
+		}
+	}
+
+	if addedIndexes["function_call"] != 0 || addedIndexes["message"] != 1 {
+		t.Fatalf("output indexes = %#v, want function_call at 0 and message at 1", addedIndexes)
+	}
+	if len(output) != 2 {
+		t.Fatalf("response.completed output has %d items, want 2: %#v", len(output), output)
+	}
+	first, _ := output[0].(map[string]any)
+	second, _ := output[1].(map[string]any)
+	if first["type"] != "function_call" || second["type"] != "message" {
+		t.Fatalf("output order = [%v, %v], want [function_call, message]", first["type"], second["type"])
+	}
+}
+
 func TestStreamResponses_WithEmptyToolArguments(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -3071,6 +3071,94 @@ data: {"type":"message_stop"}
 	}
 }
 
+// TestStreamResponses_CompletedIncludesOutput verifies the terminal
+// response.completed event carries the full output array (assistant message,
+// then function_call), matching OpenAI's native behavior — strict SDK clients
+// index into response.output.
+func TestStreamResponses_CompletedIncludesOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`event: message_start
+data: {"type":"message_start","message":{"id":"msg_123","type":"message","role":"assistant","model":"claude-sonnet-4-5-20250929","content":[],"stop_reason":null,"usage":{"input_tokens":10,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I'll check that for you."}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_123","name":"lookup_weather","input":{}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"city\":\"Warsaw\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"input_tokens":10,"output_tokens":4}}
+
+event: message_stop
+data: {"type":"message_stop"}
+`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("test-api-key", nil, llmclient.Hooks{})
+	provider.SetBaseURL(server.URL)
+
+	body, err := provider.StreamResponses(context.Background(), &core.ResponsesRequest{
+		Model: "claude-sonnet-4-5-20250929",
+		Input: "What's the weather?",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = body.Close() }()
+
+	raw, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+
+	var output []any
+	for _, event := range parseTestSSEEvents(t, string(raw)) {
+		if event.Done || event.Name != "response.completed" {
+			continue
+		}
+		response, _ := event.Payload["response"].(map[string]any)
+		output, _ = response["output"].([]any)
+	}
+
+	if len(output) != 2 {
+		t.Fatalf("response.completed output has %d items, want 2: %#v", len(output), output)
+	}
+
+	message, _ := output[0].(map[string]any)
+	if message["type"] != "message" || message["role"] != "assistant" || message["status"] != "completed" {
+		t.Fatalf("output[0] = %#v, want completed assistant message", message)
+	}
+	messageContent, _ := message["content"].([]any)
+	if len(messageContent) != 1 {
+		t.Fatalf("message content = %#v, want one output_text part", message["content"])
+	}
+	if part, _ := messageContent[0].(map[string]any); part["type"] != "output_text" || part["text"] != "I'll check that for you." {
+		t.Fatalf("message part = %#v, want output_text %q", messageContent[0], "I'll check that for you.")
+	}
+
+	toolCall, _ := output[1].(map[string]any)
+	if toolCall["type"] != "function_call" || toolCall["status"] != "completed" {
+		t.Fatalf("output[1] = %#v, want completed function_call", toolCall)
+	}
+	if toolCall["call_id"] != "toolu_123" || toolCall["name"] != "lookup_weather" || toolCall["arguments"] != `{"city":"Warsaw"}` {
+		t.Fatalf("function_call = %#v, want toolu_123 lookup_weather with recorded arguments", toolCall)
+	}
+}
+
 func TestStreamResponses_WithEmptyToolArguments(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/internal/providers/anthropic/responses.go
+++ b/internal/providers/anthropic/responses.go
@@ -178,6 +178,7 @@ func (sc *responsesStreamConverter) Read(p []byte) (n int, err error) {
 						"model":      sc.model,
 						"provider":   "anthropic",
 						"created_at": sc.createdAt,
+						"output":     sc.output.FinalOutputItems(0, 0, sc.toolCalls, true),
 					}
 					// Include merged usage data captured across message_start/message_delta.
 					if sc.hasUsage {

--- a/internal/providers/anthropic/responses.go
+++ b/internal/providers/anthropic/responses.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -120,20 +121,21 @@ func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesReque
 
 // responsesStreamConverter wraps an Anthropic stream and converts it to Responses API format
 type responsesStreamConverter struct {
-	reader          *bufio.Reader
-	body            io.ReadCloser
-	model           string
-	responseID      string
-	createdAt       int64
-	output          *providers.ResponsesOutputEventState
-	nextOutputIndex int
-	toolCalls       map[int]*providers.ResponsesOutputToolCallState
-	thinkingBlocks  map[int]bool // tracks which content block indices are thinking blocks
-	buffer          streaming.StreamBuffer
-	closed          bool
-	sentDone        bool
-	usage           anthropicUsage
-	hasUsage        bool
+	reader               *bufio.Reader
+	body                 io.ReadCloser
+	model                string
+	responseID           string
+	createdAt            int64
+	output               *providers.ResponsesOutputEventState
+	nextOutputIndex      int
+	assistantOutputIndex int
+	toolCalls            map[int]*providers.ResponsesOutputToolCallState
+	thinkingBlocks       map[int]bool // tracks which content block indices are thinking blocks
+	buffer               streaming.StreamBuffer
+	closed               bool
+	sentDone             bool
+	usage                anthropicUsage
+	hasUsage             bool
 }
 
 func newResponsesStreamConverter(body io.ReadCloser, model string) *responsesStreamConverter {
@@ -170,7 +172,11 @@ func (sc *responsesStreamConverter) Read(p []byte) (n int, err error) {
 				// Send final done event and [DONE] message
 				if !sc.sentDone {
 					sc.sentDone = true
-					prefix := sc.output.CompleteAssistantOutput(0)
+					// Finalize items still open at EOF (e.g. a truncated
+					// stream that never sent content_block_stop) so the
+					// terminal output only reports items whose done events
+					// were emitted.
+					prefix := sc.output.CompleteAssistantOutput(sc.assistantOutputIndex) + sc.completePendingToolCalls()
 					responseData := map[string]any{
 						"id":         sc.responseID,
 						"object":     "response",
@@ -178,7 +184,7 @@ func (sc *responsesStreamConverter) Read(p []byte) (n int, err error) {
 						"model":      sc.model,
 						"provider":   "anthropic",
 						"created_at": sc.createdAt,
-						"output":     sc.output.FinalOutputItems(0, 0, sc.toolCalls, true),
+						"output":     sc.output.FinalOutputItems(0, sc.assistantOutputIndex, sc.toolCalls, true),
 					}
 					// Include merged usage data captured across message_start/message_delta.
 					if sc.hasUsage {
@@ -244,7 +250,24 @@ func (sc *responsesStreamConverter) reserveAssistantMessageOutput() {
 		return
 	}
 	sc.output.ReserveAssistant()
+	sc.assistantOutputIndex = sc.nextOutputIndex
 	sc.nextOutputIndex++
+}
+
+// completePendingToolCalls emits the done events for tool calls the upstream
+// stream left open, in content-block order.
+func (sc *responsesStreamConverter) completePendingToolCalls() string {
+	indices := make([]int, 0, len(sc.toolCalls))
+	for index := range sc.toolCalls {
+		indices = append(indices, index)
+	}
+	slices.Sort(indices)
+
+	var out strings.Builder
+	for _, index := range indices {
+		out.WriteString(sc.output.CompleteToolCall(sc.toolCalls[index], true))
+	}
+	return out.String()
 }
 
 func (sc *responsesStreamConverter) newResponsesToolCallState(contentBlock *anthropicContent) *providers.ResponsesOutputToolCallState {
@@ -296,7 +319,7 @@ func (sc *responsesStreamConverter) convertEvent(event *anthropicStreamEvent) st
 		}
 		if event.ContentBlock != nil && event.ContentBlock.Type == "tool_use" {
 			if sc.output.AssistantStarted() && !sc.output.AssistantDone() {
-				prefix := sc.output.CompleteAssistantOutput(0)
+				prefix := sc.output.CompleteAssistantOutput(sc.assistantOutputIndex)
 				state := sc.newResponsesToolCallState(event.ContentBlock)
 				sc.toolCalls[event.Index] = state
 				return prefix + sc.output.StartToolCall(state, true)
@@ -320,7 +343,7 @@ func (sc *responsesStreamConverter) convertEvent(event *anthropicStreamEvent) st
 		case "text_delta":
 			if event.Delta.Text != "" {
 				sc.reserveAssistantMessageOutput()
-				prefix := sc.output.StartAssistantOutput(0)
+				prefix := sc.output.StartAssistantOutput(sc.assistantOutputIndex)
 				sc.output.AppendAssistantText(event.Delta.Text)
 				return prefix + sc.output.WriteEvent("response.output_text.delta", map[string]any{
 					"type":  "response.output_text.delta",

--- a/internal/providers/responses_converter.go
+++ b/internal/providers/responses_converter.go
@@ -399,6 +399,7 @@ func (sc *OpenAIResponsesStreamConverter) appendCompletedEvents() {
 		"model":      sc.model,
 		"provider":   sc.provider,
 		"created_at": sc.createdAt,
+		"output":     sc.output.FinalOutputItems(reasoningOutputIndex, sc.assistantOutputIndex, sc.toolCalls, false),
 	}
 	// Include usage data if captured from OpenAI stream, renamed from Chat
 	// Completions field names (prompt_tokens/completion_tokens) to the

--- a/internal/providers/responses_converter_test.go
+++ b/internal/providers/responses_converter_test.go
@@ -309,6 +309,106 @@ data: [DONE]
 	}
 }
 
+// TestOpenAIResponsesStreamConverter_CompletedIncludesOutput verifies the
+// terminal response.completed event carries the full output array (reasoning,
+// message, function_call in stream order), matching OpenAI's native behavior —
+// strict SDK clients index into response.output.
+func TestOpenAIResponsesStreamConverter_CompletedIncludesOutput(t *testing.T) {
+	mockStream := `data: {"choices":[{"delta":{"reasoning_content":"Need the weather."},"finish_reason":null}]}
+
+data: {"choices":[{"delta":{"content":"Checking."},"finish_reason":null}]}
+
+data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"lookup_weather","arguments":"{\"city\":\"Warsaw\"}"}}]},"finish_reason":null}]}
+
+data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}
+
+data: [DONE]
+`
+
+	converter := NewOpenAIResponsesStreamConverter(io.NopCloser(strings.NewReader(mockStream)), "test-model", "mock")
+	raw, err := io.ReadAll(converter)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+
+	var output []any
+	for _, event := range parseTestSSEEvents(t, string(raw)) {
+		if event.Done || event.Name != "response.completed" {
+			continue
+		}
+		response, _ := event.Payload["response"].(map[string]any)
+		output, _ = response["output"].([]any)
+	}
+
+	if len(output) != 3 {
+		t.Fatalf("response.completed output has %d items, want 3: %#v", len(output), output)
+	}
+
+	reasoning, _ := output[0].(map[string]any)
+	if reasoning["type"] != "reasoning" || reasoning["status"] != "completed" {
+		t.Fatalf("output[0] = %#v, want completed reasoning item", reasoning)
+	}
+	reasoningContent, _ := reasoning["content"].([]any)
+	if len(reasoningContent) != 1 {
+		t.Fatalf("reasoning content = %#v, want one reasoning_text part", reasoning["content"])
+	}
+	if part, _ := reasoningContent[0].(map[string]any); part["text"] != "Need the weather." {
+		t.Fatalf("reasoning text = %#v, want %q", part["text"], "Need the weather.")
+	}
+
+	message, _ := output[1].(map[string]any)
+	if message["type"] != "message" || message["role"] != "assistant" || message["status"] != "completed" {
+		t.Fatalf("output[1] = %#v, want completed assistant message", message)
+	}
+	messageContent, _ := message["content"].([]any)
+	if len(messageContent) != 1 {
+		t.Fatalf("message content = %#v, want one output_text part", message["content"])
+	}
+	if part, _ := messageContent[0].(map[string]any); part["type"] != "output_text" || part["text"] != "Checking." {
+		t.Fatalf("message part = %#v, want output_text %q", messageContent[0], "Checking.")
+	}
+
+	toolCall, _ := output[2].(map[string]any)
+	if toolCall["type"] != "function_call" || toolCall["status"] != "completed" {
+		t.Fatalf("output[2] = %#v, want completed function_call", toolCall)
+	}
+	if toolCall["call_id"] != "call_1" || toolCall["name"] != "lookup_weather" || toolCall["arguments"] != `{"city":"Warsaw"}` {
+		t.Fatalf("function_call = %#v, want call_1 lookup_weather with recorded arguments", toolCall)
+	}
+}
+
+// TestOpenAIResponsesStreamConverter_CompletedEmptyOutputIsArray verifies a
+// stream with no output items still yields output: [] rather than omitting the
+// field or emitting null.
+func TestOpenAIResponsesStreamConverter_CompletedEmptyOutputIsArray(t *testing.T) {
+	mockStream := "data: [DONE]\n"
+
+	converter := NewOpenAIResponsesStreamConverter(io.NopCloser(strings.NewReader(mockStream)), "test-model", "mock")
+	raw, err := io.ReadAll(converter)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+
+	found := false
+	for _, event := range parseTestSSEEvents(t, string(raw)) {
+		if event.Done || event.Name != "response.completed" {
+			continue
+		}
+		found = true
+		response, _ := event.Payload["response"].(map[string]any)
+		output, ok := response["output"].([]any)
+		if !ok {
+			t.Fatalf("response.completed output = %#v, want an array", response["output"])
+		}
+		if len(output) != 0 {
+			t.Fatalf("response.completed output = %#v, want empty array", output)
+		}
+	}
+	if !found {
+		t.Fatal("expected response.completed event")
+	}
+}
+
 func TestOpenAIResponsesStreamConverter_OutOfOrderToolCallsKeepUniqueIndexes(t *testing.T) {
 	mockStream := `data: {"choices":[{"delta":{"reasoning_content":"Plan."},"finish_reason":null}]}
 

--- a/internal/providers/responses_converter_test.go
+++ b/internal/providers/responses_converter_test.go
@@ -352,8 +352,8 @@ data: [DONE]
 	if len(reasoningContent) != 1 {
 		t.Fatalf("reasoning content = %#v, want one reasoning_text part", reasoning["content"])
 	}
-	if part, _ := reasoningContent[0].(map[string]any); part["text"] != "Need the weather." {
-		t.Fatalf("reasoning text = %#v, want %q", part["text"], "Need the weather.")
+	if part, _ := reasoningContent[0].(map[string]any); part["type"] != "reasoning_text" || part["text"] != "Need the weather." {
+		t.Fatalf("reasoning part = %#v, want reasoning_text %q", reasoningContent[0], "Need the weather.")
 	}
 
 	message, _ := output[1].(map[string]any)

--- a/internal/providers/responses_output_state.go
+++ b/internal/providers/responses_output_state.go
@@ -229,7 +229,9 @@ func (s *ResponsesOutputEventState) CompleteReasoningOutput(outputIndex int) str
 // FinalOutputItems assembles the full output array for the terminal
 // response.completed event, mirroring the output_item.done payloads already
 // emitted on the stream, ordered by output index. OpenAI includes the complete
-// output in response.completed, and strict SDK clients index into it.
+// output in response.completed, and strict SDK clients index into it. Only
+// tool calls whose output_item.done has been emitted are included — callers
+// must finalize pending tool calls first.
 func (s *ResponsesOutputEventState) FinalOutputItems(reasoningIndex, assistantIndex int, toolCalls map[int]*ResponsesOutputToolCallState, includePlaceholder bool) []map[string]any {
 	type indexedItem struct {
 		index int
@@ -243,7 +245,7 @@ func (s *ResponsesOutputEventState) FinalOutputItems(reasoningIndex, assistantIn
 		items = append(items, indexedItem{assistantIndex, s.AssistantMessageItem("completed", true)})
 	}
 	for _, state := range toolCalls {
-		if state == nil || !state.Started {
+		if state == nil || !state.Started || !state.Completed {
 			continue
 		}
 		items = append(items, indexedItem{state.OutputIndex, s.RenderToolCallItem(state, "completed", includePlaceholder)})

--- a/internal/providers/responses_output_state.go
+++ b/internal/providers/responses_output_state.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"log/slog"
+	"slices"
 	"strings"
 
 	"github.com/goccy/go-json"
@@ -223,6 +224,36 @@ func (s *ResponsesOutputEventState) CompleteReasoningOutput(outputIndex int) str
 		"output_index": outputIndex,
 	}))
 	return b.String()
+}
+
+// FinalOutputItems assembles the full output array for the terminal
+// response.completed event, mirroring the output_item.done payloads already
+// emitted on the stream, ordered by output index. OpenAI includes the complete
+// output in response.completed, and strict SDK clients index into it.
+func (s *ResponsesOutputEventState) FinalOutputItems(reasoningIndex, assistantIndex int, toolCalls map[int]*ResponsesOutputToolCallState, includePlaceholder bool) []map[string]any {
+	type indexedItem struct {
+		index int
+		item  map[string]any
+	}
+	items := make([]indexedItem, 0, 2+len(toolCalls))
+	if s.reasoningStarted {
+		items = append(items, indexedItem{reasoningIndex, s.ReasoningItem("completed", true)})
+	}
+	if s.assistantStarted {
+		items = append(items, indexedItem{assistantIndex, s.AssistantMessageItem("completed", true)})
+	}
+	for _, state := range toolCalls {
+		if state == nil || !state.Started {
+			continue
+		}
+		items = append(items, indexedItem{state.OutputIndex, s.RenderToolCallItem(state, "completed", includePlaceholder)})
+	}
+	slices.SortStableFunc(items, func(a, b indexedItem) int { return a.index - b.index })
+	output := make([]map[string]any, 0, len(items))
+	for _, entry := range items {
+		output = append(output, entry.item)
+	}
+	return output
 }
 
 // ToolCallArguments returns the serialized argument payload for a function_call item.

--- a/tests/contract/testdata/golden/anthropic/responses_stream.golden.json
+++ b/tests/contract/testdata/golden/anthropic/responses_stream.golden.json
@@ -68,6 +68,21 @@
           "id": "resp_\u003cgenerated\u003e",
           "model": "claude-sonnet-4-20250514",
           "object": "response",
+          "output": [
+            {
+              "content": [
+                {
+                  "annotations": [],
+                  "text": "Hello World",
+                  "type": "output_text"
+                }
+              ],
+              "id": "msg_\u003cgenerated\u003e",
+              "role": "assistant",
+              "status": "completed",
+              "type": "message"
+            }
+          ],
           "provider": "anthropic",
           "status": "completed",
           "usage": {

--- a/tests/contract/testdata/golden/gemini/responses_stream.golden.json
+++ b/tests/contract/testdata/golden/gemini/responses_stream.golden.json
@@ -68,6 +68,21 @@
           "id": "resp_\u003cgenerated\u003e",
           "model": "gemini-2.5-flash",
           "object": "response",
+          "output": [
+            {
+              "content": [
+                {
+                  "annotations": [],
+                  "text": "Hello World",
+                  "type": "output_text"
+                }
+              ],
+              "id": "msg_\u003cgenerated\u003e",
+              "role": "assistant",
+              "status": "completed",
+              "type": "message"
+            }
+          ],
           "provider": "gemini",
           "status": "completed"
         },

--- a/tests/contract/testdata/golden/groq/responses_stream.golden.json
+++ b/tests/contract/testdata/golden/groq/responses_stream.golden.json
@@ -84,6 +84,21 @@
           "id": "resp_\u003cgenerated\u003e",
           "model": "llama-3.3-70b-versatile",
           "object": "response",
+          "output": [
+            {
+              "content": [
+                {
+                  "annotations": [],
+                  "text": "Hello World!",
+                  "type": "output_text"
+                }
+              ],
+              "id": "msg_\u003cgenerated\u003e",
+              "role": "assistant",
+              "status": "completed",
+              "type": "message"
+            }
+          ],
           "provider": "groq",
           "status": "completed",
           "usage": {

--- a/tests/perf/hotpath_test.go
+++ b/tests/perf/hotpath_test.go
@@ -417,10 +417,12 @@ func TestHotPathPerfGuard(t *testing.T) {
 		{
 			// Typed chunk decoding + reused read buffer keep this converter at a
 			// fraction of its former map[string]any-per-chunk cost (was 202/19.6KB).
+			// response.completed now carries the full output array, a once-per-
+			// stream cost independent of chunk count.
 			name:      "openai_responses_stream_converter",
 			bench:     BenchmarkOpenAIResponsesStreamConverter,
-			maxAllocs: 87,    // baseline 85
-			maxBytes:  10752, // baseline ~9.7 KB (leaves headroom for pool cold-starts)
+			maxAllocs: 103,   // baseline 101
+			maxBytes:  12288, // baseline ~11.2 KB (leaves headroom for pool cold-starts)
 		},
 		{
 			name:      "shared_stream_audit_and_usage_observers",


### PR DESCRIPTION
OpenAI's native Responses API includes the full `output` array in the terminal `response.completed` event, but GoModel's translated streams (Anthropic native, and every chat-translated provider via the shared converter: Gemini, Groq, DeepSeek, etc.) omitted it. Strict SDK consumers that index into `response.output` crash on the streamed path even though the non-streaming path works — same class of breakage as the annotations fix (#807). It also broke conversation persistence for translated streams, which reads `response.output` from the terminal event and was saving empty exchanges.

The terminal event now carries the completed output items (reasoning, assistant message, function calls) in output-index order, rendered by the same code that produces the `response.output_item.done` events, so the final array always matches what was streamed. Empty streams yield `output: []`, consistent with `response.failed`.

- Provider-specific behavior: applies to Anthropic's native translation and all providers using `OpenAIResponsesStreamConverter`; native OpenAI/Azure/xAI passthrough streams are unchanged.
- Perf: the array is built once per stream at the terminal event; the hot-path guard baseline is updated (85→101 allocs/op).
- Contract goldens for anthropic/gemini/groq regenerated; new unit tests cover reasoning + text + tool-call ordering and the empty-output case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Completed streaming responses now include the full output array.
  * Final output includes assistant messages, reasoning, and function-call details in the correct order.
  * Empty streams now return an explicit empty output array instead of omitting it.
* **Tests**
  * Added coverage across supported providers to verify completed response output and streaming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->