### PR TITLE
refactor(providers): share one availability probe helper

### DIFF
--- a/internal/core/interfaces.go
+++ b/internal/core/interfaces.go
@@ -223,6 +223,10 @@ type AvailabilityChecker interface {
 	// CheckAvailability verifies the provider's backend service is reachable.
 	// Returns nil if available, error otherwise. Initialization logs failures but
 	// keeps the provider registered so later refreshes can retry discovery.
+	//
+	// The caller owns the deadline: implementations honor ctx and must not
+	// impose a timeout of their own, so startup and the request path can each
+	// probe on the budget that suits them.
 	CheckAvailability(ctx context.Context) error
 }
 

--- a/internal/providers/bedrock/bedrock.go
+++ b/internal/providers/bedrock/bedrock.go
@@ -168,14 +168,13 @@ func (p *Provider) ready() error {
 }
 
 // CheckAvailability calls a no-op Bedrock control-plane request to confirm the
-// account has reachability and credentials work.
+// account has reachability and credentials work. The caller owns the probe
+// deadline.
 func (p *Provider) CheckAvailability(ctx context.Context) error {
 	if err := p.ready(); err != nil {
 		return err
 	}
-	probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	_, err := p.control.ListFoundationModels(probeCtx, &bedrock.ListFoundationModelsInput{
+	_, err := p.control.ListFoundationModels(ctx, &bedrock.ListFoundationModelsInput{
 		ByInferenceType: bedrocktypes.InferenceTypeOnDemand,
 	})
 	if err != nil {

--- a/internal/providers/bedrockmantle/bedrock_mantle.go
+++ b/internal/providers/bedrockmantle/bedrock_mantle.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -94,13 +93,13 @@ func (p *Provider) ready() error {
 	return core.NewProviderError(providerName, http.StatusBadGateway, "invalid Bedrock Mantle provider configuration: "+err.Error(), err)
 }
 
+// CheckAvailability confirms the endpoint answers a model list. The caller
+// owns the probe deadline.
 func (p *Provider) CheckAvailability(ctx context.Context) error {
 	if err := p.ready(); err != nil {
 		return err
 	}
-	probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	_, err := p.compatible.ListModels(probeCtx)
+	_, err := p.compatible.ListModels(ctx)
 	return err
 }
 

--- a/internal/providers/init.go
+++ b/internal/providers/init.go
@@ -300,17 +300,11 @@ func initializeProviders(ctx context.Context, providerMap map[string]ProviderCon
 				return
 			}
 
-			var availabilityErr error
-			if checker, ok := p.(core.AvailabilityChecker); ok {
-				probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-				availabilityErr = checker.CheckAvailability(probeCtx)
-				cancel()
-			}
 			results[i] = initializedProvider{
 				name:            name,
 				config:          pCfg,
 				provider:        p,
-				availabilityErr: availabilityErr,
+				availabilityErr: registry.probeAvailability(ctx, p, name, availabilityProbeTimeout),
 			}
 		}(i, name)
 	}
@@ -327,16 +321,15 @@ func initializeProviders(ctx context.Context, providerMap map[string]ProviderCon
 			continue
 		}
 
-		if _, ok := p.(core.AvailabilityChecker); ok {
-			if result.availabilityErr != nil {
-				registry.RecordAvailabilityCheck(name, result.availabilityErr)
-				slog.Warn("provider unavailable at startup; keeping registered for refresh",
-					"name", name,
-					"type", pCfg.Type,
-					"reason", result.availabilityErr.Error())
-			} else {
-				registry.RecordAvailabilityCheck(name, nil)
-			}
+		// Availability checks are diagnostics only, and the probe already
+		// recorded its outcome. Providers stay registered so async
+		// initialization and periodic refresh can discover them later; only the
+		// warning is held back to here, to keep startup logs in name order.
+		if result.availabilityErr != nil {
+			slog.Warn("provider unavailable at startup; keeping registered for refresh",
+				"name", name,
+				"type", pCfg.Type,
+				"reason", result.availabilityErr.Error())
 		}
 
 		registry.RegisterProviderWithNameAndType(p, name, pCfg.Type)

--- a/internal/providers/init_test.go
+++ b/internal/providers/init_test.go
@@ -488,7 +488,6 @@ func TestInitializeProviders_ParallelizesProbesAndRegistersDeterministically(t *
 	providers := make(map[string]*initTestProvider, providerCount)
 
 	for _, name := range []string{"alpha", "beta", "gamma"} {
-		name := name
 		providers[name] = &initTestProvider{
 			checkAvailability: func(context.Context) error {
 				if started.Add(1) == providerCount {

--- a/internal/providers/ollama/ollama.go
+++ b/internal/providers/ollama/ollama.go
@@ -9,7 +9,6 @@ import (
 	"reflect"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/goccy/go-json"
 
@@ -132,11 +131,9 @@ func (p *Provider) SetBaseURL(url string) {
 }
 
 // CheckAvailability verifies that Ollama is running and accessible.
-// Makes a lightweight request to the models endpoint.
+// Makes a lightweight request to the models endpoint. The caller owns the
+// probe deadline.
 func (p *Provider) CheckAvailability(ctx context.Context) error {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
 	_, err := p.ListModels(ctx)
 	return err
 }

--- a/internal/providers/provider_availability.go
+++ b/internal/providers/provider_availability.go
@@ -1,0 +1,34 @@
+package providers
+
+import (
+	"context"
+	"time"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+// availabilityProbeTimeout bounds a single provider availability probe. Callers
+// pass it explicitly so a path with a tighter latency budget than startup can
+// choose its own without touching provider code.
+const availabilityProbeTimeout = 5 * time.Second
+
+// probeAvailability runs providerName's availability probe and records the
+// outcome on the registry. Providers that do not implement
+// core.AvailabilityChecker have nothing to probe and report available.
+//
+// The deadline lives at the call site rather than inside each provider's
+// CheckAvailability so the budget can differ by path, and so a provider that
+// omits a timeout of its own can never leave a probe unbounded.
+func (r *ModelRegistry) probeAvailability(ctx context.Context, provider core.Provider, providerName string, timeout time.Duration) error {
+	checker, ok := provider.(core.AvailabilityChecker)
+	if !ok {
+		return nil
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	err := checker.CheckAvailability(probeCtx)
+	r.RecordAvailabilityCheck(providerName, err)
+	return err
+}

--- a/internal/providers/provider_availability_test.go
+++ b/internal/providers/provider_availability_test.go
@@ -1,0 +1,96 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+func TestProbeAvailability(t *testing.T) {
+	probeErr := errors.New("backend unreachable")
+
+	tests := []struct {
+		name        string
+		provider    core.Provider
+		wantErr     error
+		wantRecord  bool
+		wantMessage string
+	}{
+		{
+			name:     "provider without a checker is available and records nothing",
+			provider: &registryMockProvider{},
+		},
+		{
+			name:       "successful probe records an empty error",
+			provider:   &initTestProvider{},
+			wantRecord: true,
+		},
+		{
+			name:        "failed probe is returned and recorded",
+			provider:    &initTestProvider{availabilityErr: probeErr},
+			wantErr:     probeErr,
+			wantRecord:  true,
+			wantMessage: probeErr.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := NewModelRegistry()
+
+			err := registry.probeAvailability(t.Context(), tt.provider, "probe-target", availabilityProbeTimeout)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("probeAvailability() error = %v, want %v", err, tt.wantErr)
+			}
+
+			state, recorded := registry.providerRuntime["probe-target"]
+			if recorded != tt.wantRecord {
+				t.Fatalf("availability recorded = %t, want %t", recorded, tt.wantRecord)
+			}
+			if recorded && state.lastAvailabilityError != tt.wantMessage {
+				t.Fatalf("recorded error = %q, want %q", state.lastAvailabilityError, tt.wantMessage)
+			}
+		})
+	}
+}
+
+// The deadline lives at the call site now, so a provider that imposes no
+// timeout of its own must still be bounded by the budget the caller passes.
+func TestProbeAvailability_CallerDeadlineBoundsUntimedProvider(t *testing.T) {
+	started := make(chan struct{})
+	provider := &initTestProvider{
+		checkAvailability: func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+
+	registry := NewModelRegistry()
+	done := make(chan error, 1)
+	go func() {
+		done <- registry.probeAvailability(context.Background(), provider, "untimed", 50*time.Millisecond)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("probe did not start")
+	}
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("probeAvailability() error = %v, want %v", err, context.DeadlineExceeded)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("probeAvailability() did not honor the caller's deadline")
+	}
+
+	if got := registry.providerRuntime["untimed"].lastAvailabilityError; got != context.DeadlineExceeded.Error() {
+		t.Fatalf("recorded error = %q, want %q", got, context.DeadlineExceeded.Error())
+	}
+}

--- a/internal/providers/registry_provider_refresh.go
+++ b/internal/providers/registry_provider_refresh.go
@@ -146,13 +146,7 @@ func (r *ModelRegistry) availableProviderRefreshTargets(ctx context.Context, pro
 	var availabilityErrs []error
 
 	for _, target := range targets {
-		checker, ok := target.provider.(core.AvailabilityChecker)
-		if !ok {
-			available = append(available, target)
-			continue
-		}
-		err := checker.CheckAvailability(ctx)
-		r.RecordAvailabilityCheck(target.providerName, err)
+		err := r.probeAvailability(ctx, target.provider, target.providerName, availabilityProbeTimeout)
 		if err != nil {
 			r.markProviderInventoryStale(target.providerName)
 			availabilityErrs = append(availabilityErrs, fmt.Errorf("%s: %w", target.providerName, err))


### PR DESCRIPTION
Follow-up to #805, which parallelized startup probes but left the surrounding duplication in place.

## What changed

`ModelRegistry.probeAvailability` is now the single place that type-asserts `core.AvailabilityChecker`, applies a deadline, and records the outcome. Startup (`initializeProviders`) and request-time refresh (`availableProviderRefreshTargets`) both call it.

The probe deadline moves to the caller. It used to be hardcoded twice: once inside each of `ollama`, `bedrock` and `bedrockmantle`'s `CheckAvailability`, and again at the startup call site — so startup double-wrapped, while the refresh path had no deadline of its own and silently depended on the providers remembering to set one.

## User-visible impact

Request-time refresh is now bounded. It runs on the live request path (`Router.refreshProviderModelsForRequest`, `gateway/request_model_resolution.go`) whenever a requested model misses the inventory; a provider implementing `CheckAvailability` without an internal timeout could previously probe unbounded there. No timing change for the three providers that ship today — they all had a 5s internal cap, and the shared constant is the same 5s.

`CheckAvailability` is no longer called anywhere outside the helper, so the contract holds by construction. Documented on the interface.

## Provider behavior

`ollama`, `bedrock` and `bedrockmantle` no longer wrap their own `context.WithTimeout`. They honor the caller's context, which is what the two call sites now supply.

## Validation

- `go test ./... -race`
- Startup log order, registration order, and the recorded availability state are unchanged; `lastAvailabilityCheckAt` is now stamped at probe time rather than after `wg.Wait()`.
- Also drops a redundant `name := name` loop copy in `init_test.go` that `go fix -diff` flags.

Net −38/+153 lines, the additions being the helper and its tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Availability checks now consistently honor the caller’s cancellation and deadline settings.
  * Provider startup and refresh checks use a standardized five-second probe limit.
  * Availability results and errors are recorded consistently across providers.

* **Documentation**
  * Clarified ownership of availability-check deadlines and cancellation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->