### PR TITLE
perf(providers): avoid JSON round trips in the prompt cache planner

### DIFF
--- a/internal/providers/cache_planner.go
+++ b/internal/providers/cache_planner.go
@@ -3,7 +3,9 @@ package providers
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"hash"
 	"log/slog"
+	"maps"
 	"os"
 	"slices"
 	"strconv"
@@ -66,19 +68,14 @@ func (p *cachePlanner) planChat(req *core.ChatRequest, providerType string, sele
 	if hasChatCacheDirective(req, prefixMessages) {
 		return req
 	}
-	prefixBody, err := json.Marshal(struct {
-		Tools    []map[string]any `json:"tools,omitempty"`
-		Messages []core.Message   `json:"messages"`
-	}{req.Tools, prefixMessages})
-	if err != nil || estimatedTokens(prefixBody) < minimum {
+	digest := newPrefixDigest(providerType, selector, req.User)
+	digest.writeChatPrefix(req.Tools, prefixMessages)
+	if digest.err != nil || digest.tokens() < minimum {
 		return req
 	}
 
-	planned, ok := cloneChatRequest(req)
-	if !ok {
-		return req
-	}
-	key := cacheAffinityKey(providerType, selector, req.User, prefixBody)
+	planned := cloneChatRequest(req)
+	key := digest.key()
 	switch profile.mode {
 	case promptCacheOpenAI:
 		planned.ExtraFields = mergeCacheExtras(planned.ExtraFields, map[string]json.RawMessage{
@@ -117,19 +114,13 @@ func (p *cachePlanner) planResponses(req *core.ResponsesRequest, providerType st
 	if !ok || len(items) < 2 || hasResponsesCacheDirective(req, items[:len(items)-1]) {
 		return req
 	}
-	prefixBody, err := json.Marshal(struct {
-		Instructions string                       `json:"instructions,omitempty"`
-		Tools        []map[string]any             `json:"tools,omitempty"`
-		Input        []core.ResponsesInputElement `json:"input"`
-	}{req.Instructions, req.Tools, items[:len(items)-1]})
-	if err != nil || estimatedTokens(prefixBody) < providerCacheMinimum(profile, selector.Model) {
+	digest := newPrefixDigest(providerType, selector, req.User)
+	digest.writeResponsesPrefix(req.Instructions, req.Tools, items[:len(items)-1])
+	if digest.err != nil || digest.tokens() < providerCacheMinimum(profile, selector.Model) {
 		return req
 	}
-	planned, ok := cloneResponsesRequest(req)
-	if !ok {
-		return req
-	}
-	key := cacheAffinityKey(providerType, selector, req.User, prefixBody)
+	planned := cloneResponsesRequest(req, items)
+	key := digest.key()
 	switch profile.mode {
 	case promptCacheOpenAI:
 		planned.ExtraFields = mergeCacheExtras(planned.ExtraFields, map[string]json.RawMessage{
@@ -148,32 +139,28 @@ func (p *cachePlanner) planResponses(req *core.ResponsesRequest, providerType st
 	return planned
 }
 
-func cloneChatRequest(req *core.ChatRequest) (*core.ChatRequest, bool) {
-	body, err := json.Marshal(req)
-	if err != nil {
-		return nil, false
-	}
-	var clone core.ChatRequest
-	if err := json.Unmarshal(body, &clone); err != nil {
-		return nil, false
-	}
+// cloneChatRequest returns a copy the planner may annotate without touching
+// the caller's request. Only what the planner writes is duplicated: the
+// request struct, the Messages slice header, and the internal cache plan.
+// ExtraFields values are immutable raw JSON, and the mark* helpers copy any
+// nested content slice or map before writing into it.
+func cloneChatRequest(req *core.ChatRequest) *core.ChatRequest {
+	clone := *req
+	clone.Messages = slices.Clone(req.Messages)
 	if req.PromptCachePlan != nil {
 		plan := *req.PromptCachePlan
 		clone.PromptCachePlan = &plan
 	}
-	return &clone, true
+	return &clone
 }
 
-func cloneResponsesRequest(req *core.ResponsesRequest) (*core.ResponsesRequest, bool) {
-	body, err := json.Marshal(req)
-	if err != nil {
-		return nil, false
-	}
-	var clone core.ResponsesRequest
-	if err := json.Unmarshal(body, &clone); err != nil {
-		return nil, false
-	}
-	return &clone, true
+// cloneResponsesRequest mirrors cloneChatRequest for the Responses API. items
+// is req.Input already asserted to its typed slice form; the clone owns a
+// fresh slice header so per-item writes never reach the caller.
+func cloneResponsesRequest(req *core.ResponsesRequest, items []core.ResponsesInputElement) *core.ResponsesRequest {
+	clone := *req
+	clone.Input = slices.Clone(items)
+	return &clone
 }
 
 var cacheDirectiveKeys = []string{
@@ -329,10 +316,11 @@ func markOpenAIChatBreakpoint(messages *[]core.Message) bool {
 		case []core.ContentPart:
 			for j := len(content) - 1; j >= 0; j-- {
 				if content[j].Type == "text" || content[j].Type == "image_url" || content[j].Type == "input_audio" {
-					content[j].ExtraFields = mergeCacheExtras(content[j].ExtraFields, map[string]json.RawMessage{
+					parts := slices.Clone(content)
+					parts[j].ExtraFields = mergeCacheExtras(parts[j].ExtraFields, map[string]json.RawMessage{
 						"prompt_cache_breakpoint": json.RawMessage(`{"mode":"explicit"}`),
 					})
-					msg.Content = content
+					msg.Content = parts
 					return true
 				}
 			}
@@ -363,16 +351,17 @@ func markOpenAIResponsesBreakpoint(req *core.ResponsesRequest) bool {
 		case []core.ContentPart:
 			for j := len(content) - 1; j >= 0; j-- {
 				if content[j].Type == "text" || content[j].Type == "input_text" || content[j].Type == "input_image" || content[j].Type == "input_file" {
-					content[j].ExtraFields = mergeCacheExtras(content[j].ExtraFields, map[string]json.RawMessage{
+					parts := slices.Clone(content)
+					parts[j].ExtraFields = mergeCacheExtras(parts[j].ExtraFields, map[string]json.RawMessage{
 						"prompt_cache_breakpoint": json.RawMessage(`{"mode":"explicit"}`),
 					})
-					items[i].Content = content
+					items[i].Content = parts
 					req.Input = items
 					return true
 				}
 			}
 		case []any:
-			for _, c := range slices.Backward(content) {
+			for j, c := range slices.Backward(content) {
 				block, ok := c.(map[string]any)
 				if !ok {
 					continue
@@ -380,7 +369,11 @@ func markOpenAIResponsesBreakpoint(req *core.ResponsesRequest) bool {
 				blockType, _ := block["type"].(string)
 				if blockType == "text" || blockType == "input_text" || blockType == "input_image" || blockType == "input_file" {
 					if _, exists := block["prompt_cache_breakpoint"]; !exists {
-						block["prompt_cache_breakpoint"] = map[string]any{"mode": "explicit"}
+						marked := maps.Clone(block)
+						marked["prompt_cache_breakpoint"] = map[string]any{"mode": "explicit"}
+						blocks := slices.Clone(content)
+						blocks[j] = marked
+						content = blocks
 					}
 					items[i].Content = content
 					req.Input = items
@@ -388,11 +381,15 @@ func markOpenAIResponsesBreakpoint(req *core.ResponsesRequest) bool {
 				}
 			}
 		case []map[string]any:
-			for _, c := range slices.Backward(content) {
+			for j, c := range slices.Backward(content) {
 				blockType, _ := c["type"].(string)
 				if blockType == "text" || blockType == "input_text" || blockType == "input_image" || blockType == "input_file" {
 					if _, exists := c["prompt_cache_breakpoint"]; !exists {
-						c["prompt_cache_breakpoint"] = map[string]any{"mode": "explicit"}
+						marked := maps.Clone(c)
+						marked["prompt_cache_breakpoint"] = map[string]any{"mode": "explicit"}
+						blocks := slices.Clone(content)
+						blocks[j] = marked
+						content = blocks
 					}
 					items[i].Content = content
 					req.Input = items
@@ -418,21 +415,110 @@ func mergeCacheExtras(base core.UnknownJSONFields, values map[string]json.RawMes
 	return merged
 }
 
-func cacheAffinityKey(providerType string, selector core.ModelSelector, user string, prefix []byte) string {
-	hash := sha256.New()
-	hash.Write([]byte(normalizedProviderType(providerType)))
-	hash.Write([]byte{0})
-	hash.Write([]byte(selector.Provider))
-	hash.Write([]byte{0})
-	hash.Write([]byte(selector.Model))
-	hash.Write([]byte{0})
-	hash.Write([]byte(user))
-	hash.Write([]byte{0})
-	hash.Write(prefix)
-	return "gomodel-" + hex.EncodeToString(hash.Sum(nil)[:16])
+// prefixDigest hashes the cache-relevant request prefix as it is encoded, so
+// the affinity key and the token estimate derive from the same bytes without
+// materializing the serialized prefix. The bytes fed to the hash are exactly
+// the JSON of the prefix object the planner used to marshal in full, which
+// keeps affinity keys stable across gateway versions.
+type prefixDigest struct {
+	hash hash.Hash
+	enc  *json.Encoder
+	// bytes counts prefix bytes only; the key header is excluded.
+	bytes int
+	err   error
+	// encoding is set while the encoder writes one value so the newline it
+	// appends after every value can be dropped instead of hashed.
+	encoding bool
 }
 
-func estimatedTokens(body []byte) int { return (len(body) + 3) / 4 }
+func newPrefixDigest(providerType string, selector core.ModelSelector, user string) *prefixDigest {
+	d := &prefixDigest{hash: sha256.New()}
+	d.enc = json.NewEncoder(d)
+	d.hash.Write([]byte(normalizedProviderType(providerType)))
+	d.hash.Write([]byte{0})
+	d.hash.Write([]byte(selector.Provider))
+	d.hash.Write([]byte{0})
+	d.hash.Write([]byte(selector.Model))
+	d.hash.Write([]byte{0})
+	d.hash.Write([]byte(user))
+	d.hash.Write([]byte{0})
+	return d
+}
+
+// Write implements io.Writer for the JSON encoder. The newline the encoder
+// emits after each value is not part of the prefix and is dropped.
+func (d *prefixDigest) Write(p []byte) (int, error) {
+	n := len(p)
+	if d.encoding && n > 0 && p[n-1] == '\n' {
+		p = p[:n-1]
+	}
+	d.hash.Write(p)
+	d.bytes += len(p)
+	return n, nil
+}
+
+func (d *prefixDigest) literal(s string) {
+	if d.err == nil {
+		_, _ = d.Write([]byte(s))
+	}
+}
+
+func (d *prefixDigest) encode(value any) {
+	if d.err != nil {
+		return
+	}
+	d.encoding = true
+	d.err = d.enc.Encode(value)
+	d.encoding = false
+}
+
+// writeChatPrefix streams {"tools":[...],"messages":[...]} into the digest.
+func (d *prefixDigest) writeChatPrefix(tools []map[string]any, messages []core.Message) {
+	d.literal("{")
+	if len(tools) > 0 {
+		d.literal(`"tools":`)
+		d.encode(tools)
+		d.literal(",")
+	}
+	d.literal(`"messages":[`)
+	for i := range messages {
+		if i > 0 {
+			d.literal(",")
+		}
+		d.encode(messages[i])
+	}
+	d.literal("]}")
+}
+
+// writeResponsesPrefix streams {"instructions":"...","tools":[...],"input":[...]}
+// into the digest.
+func (d *prefixDigest) writeResponsesPrefix(instructions string, tools []map[string]any, items []core.ResponsesInputElement) {
+	d.literal("{")
+	if instructions != "" {
+		d.literal(`"instructions":`)
+		d.encode(instructions)
+		d.literal(",")
+	}
+	if len(tools) > 0 {
+		d.literal(`"tools":`)
+		d.encode(tools)
+		d.literal(",")
+	}
+	d.literal(`"input":[`)
+	for i := range items {
+		if i > 0 {
+			d.literal(",")
+		}
+		d.encode(items[i])
+	}
+	d.literal("]}")
+}
+
+func (d *prefixDigest) tokens() int { return (d.bytes + 3) / 4 }
+
+func (d *prefixDigest) key() string {
+	return "gomodel-" + hex.EncodeToString(d.hash.Sum(nil)[:16])
+}
 
 func providerCacheMinimum(profile promptCacheProfile, model string) int {
 	model = strings.NewReplacer(".", "-", "_", "-").Replace(strings.ToLower(model))

--- a/internal/providers/cache_planner_bench_test.go
+++ b/internal/providers/cache_planner_bench_test.go
@@ -1,0 +1,54 @@
+package providers
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+// benchChatRequest builds a multi-turn conversation of ~1.8KB messages, the
+// shape of agentic traffic the planner sees on every OpenAI-family request.
+func benchChatRequest(messages int, withTools bool) *core.ChatRequest {
+	text := strings.Repeat("The quick brown fox jumps over the lazy dog. ", 40)
+	req := &core.ChatRequest{Model: "gpt-4o"}
+	for i := range messages {
+		role := "user"
+		if i%2 == 1 {
+			role = "assistant"
+		}
+		req.Messages = append(req.Messages, core.Message{Role: role, Content: text})
+	}
+	if withTools {
+		req.Tools = []map[string]any{{
+			"type": "function",
+			"function": map[string]any{
+				"name":       "search",
+				"parameters": map[string]any{"type": "object"},
+			},
+		}}
+	}
+	return req
+}
+
+// BenchmarkPlanChat measures the per-request cost of prompt-cache planning for
+// an eligible OpenAI chat request (prefix above the cache minimum, no client
+// directives), which is the common case for long conversations.
+func BenchmarkPlanChat(b *testing.B) {
+	planner := &cachePlanner{enabled: true}
+	selector := core.ModelSelector{Provider: "openai", Model: "gpt-4o"}
+	for _, messages := range []int{20, 60} {
+		for _, withTools := range []bool{false, true} {
+			req := benchChatRequest(messages, withTools)
+			b.Run(fmt.Sprintf("messages=%d/tools=%v", messages, withTools), func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					if planned := planner.planChat(req, "openai", selector); planned == req {
+						b.Fatal("request was not planned")
+					}
+				}
+			})
+		}
+	}
+}

--- a/internal/providers/cache_planner_test.go
+++ b/internal/providers/cache_planner_test.go
@@ -2,6 +2,8 @@ package providers
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"strings"
 	"testing"
@@ -232,13 +234,193 @@ func TestCachePlannerSkipsUnsupportedResponsesModesBeforeCloning(t *testing.T) {
 
 func TestCloneChatRequestPreservesInternalCachePlan(t *testing.T) {
 	req := &core.ChatRequest{PromptCachePlan: &core.PromptCachePlan{Key: "stable"}}
-	clone, ok := cloneChatRequest(req)
-	if !ok || clone.PromptCachePlan == nil || clone.PromptCachePlan.Key != "stable" {
+	clone := cloneChatRequest(req)
+	if clone.PromptCachePlan == nil || clone.PromptCachePlan.Key != "stable" {
 		t.Fatalf("clone lost internal cache metadata: %+v", clone)
 	}
 	if clone.PromptCachePlan == req.PromptCachePlan {
 		t.Fatal("clone aliases internal cache metadata")
 	}
+}
+
+// The planner clones shallowly, so every write it performs must land on a
+// copied slice element or map rather than on memory the caller still holds.
+func TestCachePlannerDoesNotAliasCallerContentOrExtras(t *testing.T) {
+	planner := &cachePlanner{enabled: true}
+	prefix := strings.Repeat("stable context ", 1500)
+
+	t.Run("chat parts and message extras", func(t *testing.T) {
+		parts := []core.ContentPart{{Type: "text", Text: prefix}}
+		req := &core.ChatRequest{
+			Model:       "gpt-5.6",
+			Messages:    []core.Message{{Role: "system", Content: parts}, {Role: "user", Content: "new turn"}},
+			ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{"seed": json.RawMessage(`1`)}),
+		}
+		before, err := json.Marshal(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		planned := planner.planChat(req, "openai", core.ModelSelector{Provider: "openai-primary", Model: "gpt-5.6"})
+		if planned == req {
+			t.Fatal("planner returned caller-owned request")
+		}
+		plannedParts, ok := planned.Messages[0].Content.([]core.ContentPart)
+		if !ok || len(plannedParts) != 1 || len(plannedParts[0].ExtraFields.Lookup("prompt_cache_breakpoint")) == 0 {
+			t.Fatalf("planned content lacks breakpoint: %#v", planned.Messages[0].Content)
+		}
+		if &plannedParts[0] == &parts[0] || !parts[0].ExtraFields.IsEmpty() {
+			t.Fatal("planner wrote into the caller's content parts")
+		}
+		if &planned.Messages[0] == &req.Messages[0] {
+			t.Fatal("planner aliases the caller's messages slice")
+		}
+		if len(req.ExtraFields.Lookup("prompt_cache_key")) != 0 || len(req.ExtraFields.Lookup("seed")) == 0 {
+			t.Fatal("planner rewrote the caller's extra fields")
+		}
+		after, err := json.Marshal(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(before) != string(after) {
+			t.Fatalf("planner mutated caller: before=%s after=%s", before, after)
+		}
+		bedrock := planner.planChat(req, "bedrock", core.ModelSelector{Provider: "bedrock-primary", Model: "anthropic.claude-sonnet-4-5"})
+		if len(bedrock.Messages[0].ExtraFields.Lookup(core.GatewayCachePointField)) == 0 || !req.Messages[0].ExtraFields.IsEmpty() {
+			t.Fatal("bedrock marker leaked into caller message")
+		}
+	})
+
+	t.Run("responses generic blocks", func(t *testing.T) {
+		block := map[string]any{"type": "input_text", "text": prefix}
+		blocks := []any{block}
+		req := &core.ResponsesRequest{Model: "gpt-5.6", Input: []core.ResponsesInputElement{
+			{Role: "user", Content: blocks},
+			{Role: "user", Content: "dynamic"},
+		}}
+		planned := planner.planResponses(req, "openai", core.ModelSelector{Provider: "openai-primary", Model: "gpt-5.6"})
+		items, ok := planned.Input.([]core.ResponsesInputElement)
+		if !ok || planned == req {
+			t.Fatalf("unexpected plan: %+v", planned)
+		}
+		plannedBlocks, ok := items[0].Content.([]any)
+		if !ok || len(plannedBlocks) != 1 {
+			t.Fatalf("unexpected planned content: %#v", items[0].Content)
+		}
+		marked, _ := plannedBlocks[0].(map[string]any)
+		if _, exists := marked["prompt_cache_breakpoint"]; !exists {
+			t.Fatal("planned block lacks breakpoint")
+		}
+		if _, leaked := block["prompt_cache_breakpoint"]; leaked {
+			t.Fatal("planner wrote into the caller's block map")
+		}
+		if &plannedBlocks[0] == &blocks[0] {
+			t.Fatal("planner aliases the caller's block slice")
+		}
+		original := req.Input.([]core.ResponsesInputElement)
+		if &items[0] == &original[0] {
+			t.Fatal("planner aliases the caller's input slice")
+		}
+	})
+
+	t.Run("responses typed map blocks", func(t *testing.T) {
+		block := map[string]any{"type": "input_text", "text": prefix}
+		req := &core.ResponsesRequest{Model: "gpt-5.6", Input: []core.ResponsesInputElement{
+			{Role: "user", Content: []map[string]any{block}},
+			{Role: "user", Content: "dynamic"},
+		}}
+		planned := planner.planResponses(req, "openai", core.ModelSelector{Provider: "openai-primary", Model: "gpt-5.6"})
+		body, err := json.Marshal(planned)
+		if err != nil || !bytes.Contains(body, []byte(`"prompt_cache_breakpoint"`)) {
+			t.Fatalf("plan lacks breakpoint: %s (err=%v)", body, err)
+		}
+		if _, leaked := block["prompt_cache_breakpoint"]; leaked {
+			t.Fatal("planner wrote into the caller's block map")
+		}
+	})
+}
+
+// legacyCacheAffinityKey is the pre-streaming key derivation: sha256 over the
+// header fields followed by the fully marshaled prefix object. The streaming
+// digest must produce the same key so deployed cache affinity survives upgrades.
+func legacyCacheAffinityKey(t *testing.T, providerType string, selector core.ModelSelector, user string, prefix any) (string, int) {
+	t.Helper()
+	body, err := json.Marshal(prefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hash := sha256.New()
+	for _, part := range []string{normalizedProviderType(providerType), selector.Provider, selector.Model, user} {
+		hash.Write([]byte(part))
+		hash.Write([]byte{0})
+	}
+	hash.Write(body)
+	return "gomodel-" + hex.EncodeToString(hash.Sum(nil)[:16]), (len(body) + 3) / 4
+}
+
+func TestPrefixDigestMatchesLegacyMarshaledPrefix(t *testing.T) {
+	selector := core.ModelSelector{Provider: "openai-primary", Model: "gpt-5.6"}
+	tools := []map[string]any{{"type": "function", "function": map[string]any{"name": "lookup", "description": "a <b> & c"}}}
+	messages := []core.Message{
+		{Role: "system", Content: "line one\nline \"two\" <html> & more"},
+		{Role: "user", Content: []core.ContentPart{{Type: "text", Text: "part"}, {Type: "image_url", ImageURL: &core.ImageURLContent{URL: "https://x/y?a=1&b=2"}}}},
+		{Role: "assistant", ToolCalls: []core.ToolCall{{ID: "call_1", Type: "function", Function: core.FunctionCall{Name: "lookup", Arguments: `{"q":"x"}`}}},
+			ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{"name": json.RawMessage(`"bot"`)})},
+		{Role: "tool", ToolCallID: "call_1", Content: "result"},
+	}
+
+	t.Run("chat", func(t *testing.T) {
+		for _, withTools := range []bool{false, true} {
+			var reqTools []map[string]any
+			if withTools {
+				reqTools = tools
+			}
+			want, wantTokens := legacyCacheAffinityKey(t, "OpenAI ", selector, "user-1", struct {
+				Tools    []map[string]any `json:"tools,omitempty"`
+				Messages []core.Message   `json:"messages"`
+			}{reqTools, messages})
+			digest := newPrefixDigest("OpenAI ", selector, "user-1")
+			digest.writeChatPrefix(reqTools, messages)
+			if digest.err != nil {
+				t.Fatal(digest.err)
+			}
+			if got := digest.key(); got != want {
+				t.Fatalf("tools=%v key mismatch: got %s want %s", withTools, got, want)
+			}
+			if got := digest.tokens(); got != wantTokens {
+				t.Fatalf("tools=%v token estimate mismatch: got %d want %d", withTools, got, wantTokens)
+			}
+		}
+	})
+
+	t.Run("responses", func(t *testing.T) {
+		items := []core.ResponsesInputElement{
+			{Role: "user", Content: "hello <there>"},
+			{Role: "user", Content: []core.ContentPart{{Type: "input_text", Text: "typed"}}},
+			{Role: "user", Content: []any{map[string]any{"type": "input_text", "text": "generic"}}},
+			{Type: "function_call", CallID: "c1", Name: "lookup", Arguments: `{}`},
+		}
+		for _, tc := range []struct {
+			instructions string
+			tools        []map[string]any
+		}{{}, {instructions: "be brief"}, {tools: tools}, {instructions: "be brief", tools: tools}} {
+			want, wantTokens := legacyCacheAffinityKey(t, "openai", selector, "", struct {
+				Instructions string                       `json:"instructions,omitempty"`
+				Tools        []map[string]any             `json:"tools,omitempty"`
+				Input        []core.ResponsesInputElement `json:"input"`
+			}{tc.instructions, tc.tools, items})
+			digest := newPrefixDigest("openai", selector, "")
+			digest.writeResponsesPrefix(tc.instructions, tc.tools, items)
+			if digest.err != nil {
+				t.Fatal(digest.err)
+			}
+			if got := digest.key(); got != want {
+				t.Fatalf("%+v key mismatch: got %s want %s", tc, got, want)
+			}
+			if got := digest.tokens(); got != wantTokens {
+				t.Fatalf("%+v token estimate mismatch: got %d want %d", tc, got, wantTokens)
+			}
+		}
+	})
 }
 
 func TestGeminiPlanKeyIncludesEntireNativePrefixAndBoundary(t *testing.T) {


### PR DESCRIPTION
## Summary

The prompt-cache planner ran on every eligible chat and Responses request (OpenAI, Anthropic, Bedrock, Gemini; two or more messages above the provider cache minimum) and serialized the request three times: a full marshal of the prefix to estimate tokens and derive the affinity key, then a marshal plus unmarshal of the whole request as a deep clone. The provider then marshaled it a fourth time.

- The prefix is now streamed through `json.Encoder` into the SHA-256 digest, counting bytes as it goes. The bytes hashed are identical to the old `json.Marshal` output, so `prompt_cache_key` values and Gemini cache keys are unchanged (asserted by `TestPrefixDigestMatchesLegacyMarshaledPrefix`).
- The deep clone is replaced with a shallow struct copy plus a cloned `Messages` / `Input` slice. The `mark*` helpers copy the one content-part slice or block map they annotate before writing, so the caller's request is never touched (asserted by `TestCachePlannerDoesNotAliasCallerContentOrExtras`).

No user-visible behavior change: same cache directives, same keys, same eligibility rules.

## Benchmark

`BenchmarkPlanChat` (new), OpenAI profile, ~1.8 KB messages, Apple M-series:

| Case | Before | After |
|---|---|---|
| 20 messages, no tools | 243 µs, 648 KB, 343 allocs | 57 µs, 49 KB, 123 allocs |
| 20 messages, tools | 249 µs, 630 KB, 371 allocs | 54 µs, 48 KB, 130 allocs |
| 60 messages, no tools | 708 µs, 1.84 MB, 984 allocs | 165 µs, 144 KB, 323 allocs |
| 60 messages, tools | 719 µs, 1.85 MB, 1013 allocs | 165 µs, 145 KB, 330 allocs |

Remaining allocations are the per-message `Message.MarshalJSON` buffers the encoder needs for custom marshalers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved prompt-cache planning efficiency by reducing serialization and allocation overhead.
  * Added performance benchmarks for planning requests with varying message counts and tool configurations.

* **Reliability**
  * Prevented request planning from mutating caller-provided content, metadata, and nested data.
  * Preserved existing cache-affinity keys and token estimates across chat and Responses requests.

* **Tests**
  * Expanded coverage for request isolation, cache-key consistency, token estimates, tools, and optional instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->