### PR TITLE
refactor(providers): resolve model info with a single registry lookup

### DIFF
--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -397,25 +397,35 @@ func (r *ModelRegistry) UnregisterProvider(providerName string) {
 	r.invalidateSortedCaches()
 }
 
+// lookupLocked resolves a model selector to its registry entry. Qualified
+// selectors ("<provider>/<model>") are looked up under the configured provider
+// name first; a qualified selector naming a configured provider that does not
+// serve the model is a definitive miss. Otherwise the slash may be part of the
+// model ID itself (e.g. "meta-llama/Meta-Llama-3-70B"), so the raw selector is
+// tried against the global map. Callers must hold r.mu.
+func (r *ModelRegistry) lookupLocked(model string) (*ModelInfo, bool) {
+	providerName, modelID := splitModelSelector(model)
+	if providerName != "" {
+		if providerModels, ok := r.modelsByProvider[providerName]; ok {
+			if info, exists := providerModelInfo(providerModels, modelID, model); exists {
+				return info, true
+			}
+		}
+		if r.hasConfiguredProviderNameLocked(providerName) {
+			return nil, false
+		}
+	}
+
+	info, ok := r.models[model]
+	return info, ok
+}
+
 // GetProvider returns the provider for the given model, or nil if not found
 func (r *ModelRegistry) GetProvider(model string) core.Provider {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	providerName, modelID := splitModelSelector(model)
-	if providerName != "" {
-		if providerModels, ok := r.modelsByProvider[providerName]; ok {
-			if info, exists := providerModelInfo(providerModels, modelID, model); exists {
-				return info.Provider
-			}
-		}
-		if r.hasConfiguredProviderNameLocked(providerName) {
-			return nil
-		}
-		// Fall through: the slash may be part of the model ID (e.g. "meta-llama/Meta-Llama-3-70B")
-	}
-
-	if info, ok := r.models[model]; ok {
+	if info, ok := r.lookupLocked(model); ok {
 		return info.Provider
 	}
 	return nil
@@ -427,20 +437,7 @@ func (r *ModelRegistry) GetModel(model string) *ModelInfo {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	providerName, modelID := splitModelSelector(model)
-	if providerName != "" {
-		if providerModels, ok := r.modelsByProvider[providerName]; ok {
-			if info, exists := providerModelInfo(providerModels, modelID, model); exists {
-				return info
-			}
-		}
-		if r.hasConfiguredProviderNameLocked(providerName) {
-			return nil
-		}
-		// Fall through: the slash may be part of the model ID
-	}
-
-	if info, ok := r.models[model]; ok {
+	if info, ok := r.lookupLocked(model); ok {
 		return info
 	}
 	return nil
@@ -452,21 +449,7 @@ func (r *ModelRegistry) LookupModel(model string) (*core.Model, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	providerName, modelID := splitModelSelector(model)
-	if providerName != "" {
-		if providerModels, ok := r.modelsByProvider[providerName]; ok {
-			if info, exists := providerModelInfo(providerModels, modelID, model); exists {
-				cloned := info.Model
-				return &cloned, true
-			}
-		}
-		if r.hasConfiguredProviderNameLocked(providerName) {
-			return nil, false
-		}
-		// Fall through: the slash may be part of the model ID
-	}
-
-	if info, ok := r.models[model]; ok {
+	if info, ok := r.lookupLocked(model); ok {
 		cloned := info.Model
 		return &cloned, true
 	}
@@ -676,20 +659,7 @@ func (r *ModelRegistry) GetProviderType(model string) string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	providerName, modelID := splitModelSelector(model)
-	if providerName != "" {
-		if providerModels, ok := r.modelsByProvider[providerName]; ok {
-			if info, exists := providerModelInfo(providerModels, modelID, model); exists {
-				return info.ProviderType
-			}
-		}
-		if r.hasConfiguredProviderNameLocked(providerName) {
-			return ""
-		}
-		// Fall through: the slash may be part of the model ID
-	}
-
-	if info, ok := r.models[model]; ok {
+	if info, ok := r.lookupLocked(model); ok {
 		return info.ProviderType
 	}
 	return ""
@@ -701,19 +671,7 @@ func (r *ModelRegistry) GetProviderName(model string) string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	providerName, modelID := splitModelSelector(model)
-	if providerName != "" {
-		if providerModels, ok := r.modelsByProvider[providerName]; ok {
-			if info, exists := providerModelInfo(providerModels, modelID, model); exists {
-				return strings.TrimSpace(info.ProviderName)
-			}
-		}
-		if r.hasConfiguredProviderNameLocked(providerName) {
-			return ""
-		}
-	}
-
-	if info, ok := r.models[model]; ok {
+	if info, ok := r.lookupLocked(model); ok {
 		return strings.TrimSpace(info.ProviderName)
 	}
 	return ""

--- a/internal/providers/resolve_bench_test.go
+++ b/internal/providers/resolve_bench_test.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -61,6 +62,34 @@ func BenchmarkResolvePerRequest(b *testing.B) {
 				_ = router.Supports(sel)
 				_ = router.GetProviderType(sel)
 				_ = router.GetProviderName(sel)
+			}
+		})
+	}
+}
+
+// BenchmarkRouterChatCompletion measures a full Router.ChatCompletion dispatch
+// against a populated catalog with an in-memory provider, so the number of
+// registry lock acquisitions per request shows up in ns/op.
+func BenchmarkRouterChatCompletion(b *testing.B) {
+	for _, n := range []int{50, 1000} {
+		b.Run(fmt.Sprintf("models=%d", n), func(b *testing.B) {
+			reg := buildBenchRegistry(6, n)
+			router, err := NewRouter(reg)
+			if err != nil {
+				b.Fatalf("NewRouter: %v", err)
+			}
+			ctx := context.Background()
+			req := &core.ChatRequest{
+				Model:    benchSelector(6, n),
+				Messages: []core.Message{{Role: "user", Content: "hello"}},
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := router.ChatCompletion(ctx, req); err != nil {
+					b.Fatalf("ChatCompletion: %v", err)
+				}
 			}
 		})
 	}

--- a/internal/providers/router.go
+++ b/internal/providers/router.go
@@ -68,6 +68,13 @@ type qualifiedSelectorResolver interface {
 	ResolveProviderSelector(segment, modelID string) (core.ModelSelector, bool)
 }
 
+// modelInfoLookup is an optional fast path: the registry hands back provider,
+// provider type, and provider name under one lock instead of one lock per
+// accessor. Lookups without it fall back to GetProvider + GetProviderType.
+type modelInfoLookup interface {
+	GetModel(model string) *ModelInfo
+}
+
 type providerModelRefresher interface {
 	RefreshProviderModels(ctx context.Context, providerSelector string) (int, error)
 }
@@ -256,8 +263,34 @@ func (r *Router) hasConfiguredProviderName(providerName string) bool {
 	return false
 }
 
+// resolvedRoute is the outcome of resolving a request's model selector: the
+// provider instance to call, the concrete selector to forward, and the
+// provider type used for response stamping and request planning.
+type resolvedRoute struct {
+	provider     core.Provider
+	selector     core.ModelSelector
+	providerType string
+}
+
+// lookupRoute fetches the provider and provider type for an already-resolved
+// selector, taking the registry lock once when the lookup supports it.
+func (r *Router) lookupRoute(model string) (core.Provider, string) {
+	if infos, ok := r.lookup.(modelInfoLookup); ok {
+		info := infos.GetModel(model)
+		if info == nil || info.Provider == nil {
+			return nil, ""
+		}
+		return info.Provider, info.ProviderType
+	}
+	p := r.lookup.GetProvider(model)
+	if p == nil {
+		return nil, ""
+	}
+	return p, r.lookup.GetProviderType(model)
+}
+
 // resolveProvider validates readiness, parses the model selector, and finds the target provider.
-func (r *Router) resolveProvider(ctx context.Context, model, providerHint string) (core.Provider, core.ModelSelector, error) {
+func (r *Router) resolveProvider(ctx context.Context, model, providerHint string) (resolvedRoute, error) {
 	requested := core.NewRequestedModelSelector(model, providerHint)
 	selector, _, err := r.ResolveModel(requested)
 	refreshed := false
@@ -265,38 +298,38 @@ func (r *Router) resolveProvider(ctx context.Context, model, providerHint string
 		var refreshErr error
 		refreshed, refreshErr = r.refreshProviderModelsForRequest(ctx, requested)
 		if refreshErr != nil {
-			return nil, core.ModelSelector{}, refreshErr
+			return resolvedRoute{}, refreshErr
 		}
 		if !refreshed {
-			return nil, core.ModelSelector{}, err
+			return resolvedRoute{}, err
 		}
 		selector, _, err = r.ResolveModel(requested)
 		if err != nil {
-			return nil, core.ModelSelector{}, err
+			return resolvedRoute{}, err
 		}
 	}
 
 	lookupModel := selector.QualifiedModel()
-	p := r.lookup.GetProvider(lookupModel)
+	p, providerType := r.lookupRoute(lookupModel)
 	if p == nil && !refreshed {
 		var refreshErr error
 		refreshed, refreshErr = r.refreshProviderModelsForRequest(ctx, requested)
 		if refreshErr != nil {
-			return nil, core.ModelSelector{}, refreshErr
+			return resolvedRoute{}, refreshErr
 		}
 		if refreshed {
 			selector, _, err = r.ResolveModel(requested)
 			if err != nil {
-				return nil, core.ModelSelector{}, err
+				return resolvedRoute{}, err
 			}
 			lookupModel = selector.QualifiedModel()
-			p = r.lookup.GetProvider(lookupModel)
+			p, providerType = r.lookupRoute(lookupModel)
 		}
 	}
 	if p == nil {
-		return nil, core.ModelSelector{}, core.NewNotFoundError("model not found: " + lookupModel)
+		return resolvedRoute{}, core.NewNotFoundError("model not found: " + lookupModel)
 	}
-	return p, selector, nil
+	return resolvedRoute{provider: p, selector: selector, providerType: providerType}, nil
 }
 
 func (r *Router) refreshProviderModelsForRequest(ctx context.Context, requested core.RequestedModelSelector) (bool, error) {
@@ -464,17 +497,17 @@ func routeResolvedModelCall[Req any, Resp any](
 	ctx context.Context,
 	model string,
 	providerHint string,
-	buildForward func(core.ModelSelector) Req,
+	buildForward func(resolvedRoute) Req,
 	call func(context.Context, core.Provider, Req) (Resp, error),
 ) (Resp, string, error) {
-	p, selector, err := r.resolveProvider(ctx, model, providerHint)
+	route, err := r.resolveProvider(ctx, model, providerHint)
 	if err != nil {
 		var zero Resp
 		return zero, "", err
 	}
 
-	resp, err := call(ctx, p, buildForward(selector))
-	return resp, r.GetProviderType(selector.QualifiedModel()), err
+	resp, err := call(ctx, route.provider, buildForward(route))
+	return resp, route.providerType, err
 }
 
 func routeStampedModelResponse[Req any, Resp any](
@@ -482,7 +515,7 @@ func routeStampedModelResponse[Req any, Resp any](
 	ctx context.Context,
 	model string,
 	providerHint string,
-	buildForward func(core.ModelSelector) Req,
+	buildForward func(resolvedRoute) Req,
 	call func(context.Context, core.Provider, Req) (Resp, error),
 ) (Resp, error) {
 	resp, providerType, err := routeResolvedModelCall(r, ctx, model, providerHint, buildForward, call)
@@ -497,7 +530,7 @@ func routeModelStream[Req any](
 	r *Router,
 	ctx context.Context,
 	model, providerHint string,
-	buildForward func(core.ModelSelector) Req,
+	buildForward func(resolvedRoute) Req,
 	call func(context.Context, core.Provider, Req) (io.ReadCloser, error),
 ) (io.ReadCloser, error) {
 	stream, _, err := routeResolvedModelCall(r, ctx, model, providerHint, buildForward, call)
@@ -578,16 +611,14 @@ func stampProvider[T any](resp T, providerType string) T {
 
 // Provider is gateway routing metadata on OpenAI-compatible request structs and
 // must be removed before dispatching to an upstream provider implementation.
-func (r *Router) forwardChatRequest(ctx context.Context, req *core.ChatRequest, selector core.ModelSelector) *core.ChatRequest {
+func forwardChatRequest(ctx context.Context, req *core.ChatRequest, route resolvedRoute) *core.ChatRequest {
 	forwardReq := *req
-	forwardReq.Model = selector.Model
+	forwardReq.Model = route.selector.Model
 	forwardReq.Provider = ""
 	if core.RequestDialectFromContext(ctx) != core.RequestDialectAnthropicMessages {
 		return &forwardReq
 	}
-	// The selector is already concrete, so querying the lookup directly avoids
-	// repeating model resolution on every routed Messages request.
-	return adaptAnthropicCacheControl(&forwardReq, r.lookup.GetProviderType(selector.QualifiedModel()))
+	return adaptAnthropicCacheControl(&forwardReq, route.providerType)
 }
 
 func forwardResponsesRequest(req *core.ResponsesRequest, selector core.ModelSelector) *core.ResponsesRequest {
@@ -597,20 +628,20 @@ func forwardResponsesRequest(req *core.ResponsesRequest, selector core.ModelSele
 	return &forwardReq
 }
 
-func (r *Router) plannedChatRequest(ctx context.Context, req *core.ChatRequest, selector core.ModelSelector) *core.ChatRequest {
-	forward := r.forwardChatRequest(ctx, req, selector)
+func (r *Router) plannedChatRequest(ctx context.Context, req *core.ChatRequest, route resolvedRoute) *core.ChatRequest {
+	forward := forwardChatRequest(ctx, req, route)
 	if r.cachePlanner == nil {
 		return forward
 	}
-	return r.cachePlanner.planChat(forward, r.lookup.GetProviderType(selector.QualifiedModel()), selector)
+	return r.cachePlanner.planChat(forward, route.providerType, route.selector)
 }
 
-func (r *Router) plannedResponsesRequest(req *core.ResponsesRequest, selector core.ModelSelector) *core.ResponsesRequest {
-	forward := forwardResponsesRequest(req, selector)
+func (r *Router) plannedResponsesRequest(req *core.ResponsesRequest, route resolvedRoute) *core.ResponsesRequest {
+	forward := forwardResponsesRequest(req, route.selector)
 	if r.cachePlanner == nil {
 		return forward
 	}
-	return r.cachePlanner.planResponses(forward, r.lookup.GetProviderType(selector.QualifiedModel()), selector)
+	return r.cachePlanner.planResponses(forward, route.providerType, route.selector)
 }
 
 func forwardEmbeddingRequest(req *core.EmbeddingRequest, selector core.ModelSelector) *core.EmbeddingRequest {
@@ -686,8 +717,8 @@ func (r *Router) ChatCompletion(ctx context.Context, req *core.ChatRequest) (*co
 		ctx,
 		req.Model,
 		req.Provider,
-		func(selector core.ModelSelector) *core.ChatRequest {
-			return r.plannedChatRequest(ctx, req, selector)
+		func(route resolvedRoute) *core.ChatRequest {
+			return r.plannedChatRequest(ctx, req, route)
 		},
 		callChatCompletion,
 	)
@@ -701,8 +732,8 @@ func (r *Router) StreamChatCompletion(ctx context.Context, req *core.ChatRequest
 		ctx,
 		req.Model,
 		req.Provider,
-		func(selector core.ModelSelector) *core.ChatRequest {
-			return r.plannedChatRequest(ctx, req, selector)
+		func(route resolvedRoute) *core.ChatRequest {
+			return r.plannedChatRequest(ctx, req, route)
 		},
 		func(ctx context.Context, provider core.Provider, forwardReq *core.ChatRequest) (io.ReadCloser, error) {
 			return provider.StreamChatCompletion(ctx, forwardReq)
@@ -738,8 +769,8 @@ func (r *Router) Responses(ctx context.Context, req *core.ResponsesRequest) (*co
 		ctx,
 		req.Model,
 		req.Provider,
-		func(selector core.ModelSelector) *core.ResponsesRequest {
-			return r.plannedResponsesRequest(req, selector)
+		func(route resolvedRoute) *core.ResponsesRequest {
+			return r.plannedResponsesRequest(req, route)
 		},
 		callResponses,
 	)
@@ -753,8 +784,8 @@ func (r *Router) StreamResponses(ctx context.Context, req *core.ResponsesRequest
 		ctx,
 		req.Model,
 		req.Provider,
-		func(selector core.ModelSelector) *core.ResponsesRequest {
-			return r.plannedResponsesRequest(req, selector)
+		func(route resolvedRoute) *core.ResponsesRequest {
+			return r.plannedResponsesRequest(req, route)
 		},
 		func(ctx context.Context, provider core.Provider, forwardReq *core.ResponsesRequest) (io.ReadCloser, error) {
 			return provider.StreamResponses(ctx, forwardReq)
@@ -769,8 +800,8 @@ func (r *Router) Embeddings(ctx context.Context, req *core.EmbeddingRequest) (*c
 		ctx,
 		req.Model,
 		req.Provider,
-		func(selector core.ModelSelector) *core.EmbeddingRequest {
-			return forwardEmbeddingRequest(req, selector)
+		func(route resolvedRoute) *core.EmbeddingRequest {
+			return forwardEmbeddingRequest(req, route.selector)
 		},
 		callEmbeddings,
 	)
@@ -788,8 +819,8 @@ func (r *Router) Embeddings(ctx context.Context, req *core.EmbeddingRequest) (*c
 func (r *Router) CreateSpeech(ctx context.Context, req *core.AudioSpeechRequest) (*core.AudioResponse, error) {
 	return routeAudioCall(
 		r, ctx, req.Model, req.Provider,
-		func(selector core.ModelSelector) *core.AudioSpeechRequest {
-			return forwardAudioSpeechRequest(req, selector)
+		func(route resolvedRoute) *core.AudioSpeechRequest {
+			return forwardAudioSpeechRequest(req, route.selector)
 		},
 		func(ctx context.Context, ap core.AudioProvider, forwardReq *core.AudioSpeechRequest) (*core.AudioResponse, error) {
 			return ap.CreateSpeech(ctx, forwardReq)
@@ -801,8 +832,8 @@ func (r *Router) CreateSpeech(ctx context.Context, req *core.AudioSpeechRequest)
 func (r *Router) CreateTranscription(ctx context.Context, req *core.AudioTranscriptionRequest) (*core.AudioResponse, error) {
 	return routeAudioCall(
 		r, ctx, req.Model, req.Provider,
-		func(selector core.ModelSelector) *core.AudioTranscriptionRequest {
-			return forwardAudioTranscriptionRequest(req, selector)
+		func(route resolvedRoute) *core.AudioTranscriptionRequest {
+			return forwardAudioTranscriptionRequest(req, route.selector)
 		},
 		func(ctx context.Context, ap core.AudioProvider, forwardReq *core.AudioTranscriptionRequest) (*core.AudioResponse, error) {
 			return ap.CreateTranscription(ctx, forwardReq)
@@ -818,8 +849,8 @@ func (r *Router) CreateTranslation(ctx context.Context, req *core.AudioTranscrip
 	}
 	resp, _, err := routeResolvedModelCall(
 		r, ctx, req.Model, req.Provider,
-		func(selector core.ModelSelector) *core.AudioTranscriptionRequest {
-			return forwardAudioTranscriptionRequest(req, selector)
+		func(route resolvedRoute) *core.AudioTranscriptionRequest {
+			return forwardAudioTranscriptionRequest(req, route.selector)
 		},
 		func(ctx context.Context, provider core.Provider, forwardReq *core.AudioTranscriptionRequest) (*core.AudioResponse, error) {
 			translator, ok := provider.(core.AudioTranslationProvider)
@@ -840,8 +871,8 @@ func (r *Router) CreateImage(ctx context.Context, req *core.ImageGenerationReque
 	}
 	return routeImageCall(
 		r, ctx, req.Model, req.Provider, "image generation",
-		func(selector core.ModelSelector) *core.ImageGenerationRequest {
-			return forwardImageGenerationRequest(req, selector)
+		func(route resolvedRoute) *core.ImageGenerationRequest {
+			return forwardImageGenerationRequest(req, route.selector)
 		},
 		core.ImageProvider.CreateImage,
 	)
@@ -855,8 +886,8 @@ func (r *Router) CreateImageEdit(ctx context.Context, req *core.ImageEditRequest
 	}
 	return routeImageCall(
 		r, ctx, req.Model, req.Provider, "image edits",
-		func(selector core.ModelSelector) *core.ImageEditRequest {
-			return forwardImageEditRequest(req, selector)
+		func(route resolvedRoute) *core.ImageEditRequest {
+			return forwardImageEditRequest(req, route.selector)
 		},
 		core.ImageEditProvider.CreateImageEdit,
 	)
@@ -869,7 +900,7 @@ func routeImageCall[Req any, P any](
 	r *Router,
 	ctx context.Context,
 	model, providerHint, capability string,
-	forward func(core.ModelSelector) Req,
+	forward func(resolvedRoute) Req,
 	call func(P, context.Context, Req) (*core.ImageGenerationResponse, error),
 ) (*core.ImageGenerationResponse, error) {
 	return routeStampedModelResponse(
@@ -891,7 +922,7 @@ func routeAudioCall[Req any](
 	r *Router,
 	ctx context.Context,
 	model, providerHint string,
-	forward func(core.ModelSelector) Req,
+	forward func(resolvedRoute) Req,
 	call func(context.Context, core.AudioProvider, Req) (*core.AudioResponse, error),
 ) (*core.AudioResponse, error) {
 	resp, _, err := routeResolvedModelCall(
@@ -919,10 +950,11 @@ func (r *Router) RealtimeTarget(ctx context.Context, req *core.RealtimeRequest) 
 	if req == nil {
 		return nil, core.NewInvalidRequestError("realtime request is required", nil)
 	}
-	p, selector, err := r.resolveProvider(ctx, req.Model, req.Provider)
+	route, err := r.resolveProvider(ctx, req.Model, req.Provider)
 	if err != nil {
 		return nil, err
 	}
+	p, selector := route.provider, route.selector
 	rp, ok := p.(core.RealtimeProvider)
 	if !ok {
 		return nil, core.NewInvalidRequestError(fmt.Sprintf("model %q does not support realtime sessions", req.Model), nil)
@@ -961,10 +993,11 @@ func (r *Router) realtimeCallTarget(
 	if req == nil {
 		return nil, core.NewInvalidRequestError("realtime request is required", nil)
 	}
-	p, selector, err := r.resolveProvider(ctx, req.Model, req.Provider)
+	route, err := r.resolveProvider(ctx, req.Model, req.Provider)
 	if err != nil {
 		return nil, err
 	}
+	p, selector := route.provider, route.selector
 	rp, ok := p.(core.RealtimeCallProvider)
 	if !ok {
 		return nil, core.NewInvalidRequestError(fmt.Sprintf("model %q does not support realtime calls", req.Model), nil)

--- a/internal/providers/router_test.go
+++ b/internal/providers/router_test.go
@@ -630,6 +630,83 @@ func TestRouterChatCompletion(t *testing.T) {
 	}
 }
 
+// TestRouterChatCompletion_ResolvedRouteDispatch pins the resolvedRoute
+// contract for both lookup shapes: a registry that serves provider, type, and
+// name under one lock (modelInfoLookup) and a plain core.ModelLookup without
+// that capability. Either way the upstream sees the concrete model with the
+// gateway-only Provider hint stripped, and the response is stamped with the
+// resolved provider type.
+func TestRouterChatCompletion_ResolvedRouteDispatch(t *testing.T) {
+	tests := []struct {
+		name         string
+		newLookup    func(provider core.Provider) core.ModelLookup
+		wantInfoPath bool
+		model        string
+		providerHint string
+	}{
+		{
+			name: "registry with modelInfoLookup",
+			newLookup: func(provider core.Provider) core.ModelLookup {
+				return newTestRegistryWithModels(registryModelEntry{
+					provider:     provider,
+					providerName: "openai-primary",
+					providerType: "openai",
+					modelID:      "gpt-4o",
+				})
+			},
+			wantInfoPath: true,
+			model:        "gpt-4o",
+			providerHint: "openai-primary",
+		},
+		{
+			name: "lookup without modelInfoLookup",
+			newLookup: func(provider core.Provider) core.ModelLookup {
+				lookup := newMockLookup()
+				lookup.addModel("gpt-4o", provider, "openai")
+				return lookup
+			},
+			wantInfoPath: false,
+			model:        "gpt-4o",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &mockProvider{name: "upstream", chatResponse: &core.ChatResponse{ID: "resp", Model: "gpt-4o"}}
+			lookup := tt.newLookup(provider)
+			if _, ok := lookup.(modelInfoLookup); ok != tt.wantInfoPath {
+				t.Fatalf("lookup implements modelInfoLookup = %v, want %v", ok, tt.wantInfoPath)
+			}
+			router, err := NewRouter(lookup)
+			if err != nil {
+				t.Fatalf("NewRouter: %v", err)
+			}
+
+			req := &core.ChatRequest{Model: tt.model, Provider: tt.providerHint}
+			resp, err := router.ChatCompletion(context.Background(), req)
+			if err != nil {
+				t.Fatalf("ChatCompletion: %v", err)
+			}
+
+			if provider.lastChatReq == nil {
+				t.Fatal("provider was not called")
+			}
+			if got := provider.lastChatReq.Model; got != "gpt-4o" {
+				t.Fatalf("forwarded model = %q, want concrete gpt-4o", got)
+			}
+			if got := provider.lastChatReq.Provider; got != "" {
+				t.Fatalf("forwarded provider hint = %q, want empty", got)
+			}
+			if resp.Provider != "openai" {
+				t.Fatalf("response provider = %q, want resolved provider type openai", resp.Provider)
+			}
+			if req.Model != tt.model || req.Provider != tt.providerHint {
+				t.Fatalf("caller request mutated: %+v", req)
+			}
+		})
+	}
+}
+
 func TestRouterChatCompletion_ProviderSelector(t *testing.T) {
 	eastResp := &core.ChatResponse{ID: "east", Model: "gpt-4o"}
 	westResp := &core.ChatResponse{ID: "west", Model: "gpt-4o"}


### PR DESCRIPTION
Stacked on #838 (`refactor/cache-planner-shallow-clone`); merge that first.

## What changed

- `ModelRegistry`: the five public lookups (`GetProvider`, `GetModel`, `LookupModel`, `GetProviderType`, `GetProviderName`) repeated the same qualified-selector / configured-provider short-circuit / raw-slash fall-through. They are now thin wrappers over one `lookupLocked`. Behavior is unchanged.
- `Router`: per-request resolution now takes the registry lock once after selector resolution. `resolveProvider` returns a `resolvedRoute` (provider, concrete selector, provider type) via a new optional `modelInfoLookup` interface backed by the existing `GetModel`. `routeResolvedModelCall`, `plannedChatRequest`, `plannedResponsesRequest`, and the Anthropic-dialect `forwardChatRequest` path read the provider type from the route instead of re-querying the registry (previously four to five lock acquisitions per chat request, one of which re-ran full selector resolution). Lookups that do not implement `modelInfoLookup` (test fakes) keep the old two-call path. Refresh-on-miss behavior is untouched.
- New `BenchmarkRouterChatCompletion` covers a full `Router.ChatCompletion` dispatch against an in-memory provider.

No user-visible behavior change.

## Benchmarks (Apple M-series, `-count=3` medians)

| Benchmark | Before | After |
|---|---|---|
| `RouterChatCompletion/models=50` | 347 ns/op, 288 B, 5 allocs | 169 ns/op, 240 B, 2 allocs |
| `RouterChatCompletion/models=1000` | 356 ns/op, 288 B, 5 allocs | 169 ns/op, 240 B, 2 allocs |
| `ResolvePerRequest/models=50` | 422 ns/op, 48 B, 3 allocs | 402 ns/op, 48 B, 3 allocs |
| `ResolvePerRequest/models=1000` | 437 ns/op, 48 B, 3 allocs | 415 ns/op, 48 B, 3 allocs |

`ResolvePerRequest` exercises only public accessors, so it barely moves; the dispatch benchmark is where the lock reduction shows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved model routing efficiency by resolving provider, model, and provider type together, reducing repeated lookups during requests.
  - Added coverage for routing performance across catalogs containing 50 and 1,000 models.

- **Refactor**
  - Consolidated model-resolution behavior to improve consistency across provider and model lookup operations without changing existing resolution behavior.
  - Standardized routed request handling so model selection, provider dispatch, and response metadata remain aligned without modifying caller requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->