### PR TITLE
refactor(providers): resolve lookup capabilities once and normalize IDs at registration

### DIFF
--- a/internal/core/interfaces.go
+++ b/internal/core/interfaces.go
@@ -232,6 +232,10 @@ type AvailabilityChecker interface {
 
 // ModelLookup defines the interface for looking up models and their providers.
 // This abstraction allows the Router to be decoupled from the concrete ModelRegistry implementation.
+//
+// Implementations normalize on write: every provider name, provider type, and
+// model ID they return is whitespace-trimmed, so callers compare the values
+// directly.
 type ModelLookup interface {
 	// Supports returns true if the registry has a provider for the given model
 	Supports(model string) bool

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -1020,6 +1020,25 @@ func (r *ModelRegistry) ProviderCount() int {
 	return len(r.providers)
 }
 
+// failureMessage returns the trimmed text of a failure for runtime state. An
+// empty stored message means "no failure", so a message that is empty or only
+// whitespace becomes a fixed marker instead of reading as success.
+func failureMessage(message string) string {
+	if trimmed := strings.TrimSpace(message); trimmed != "" {
+		return trimmed
+	}
+	return "unknown error"
+}
+
+// optionalFailureMessage is failureMessage for fields where "" means no
+// failure occurred.
+func optionalFailureMessage(message string) string {
+	if message == "" {
+		return ""
+	}
+	return failureMessage(message)
+}
+
 // RecordAvailabilityCheck stores the latest startup or explicit availability
 // probe result for a configured provider name.
 func (r *ModelRegistry) RecordAvailabilityCheck(providerName string, err error) {
@@ -1035,7 +1054,7 @@ func (r *ModelRegistry) RecordAvailabilityCheck(providerName string, err error) 
 	state.registered = true
 	state.lastAvailabilityCheckAt = time.Now().UTC()
 	if err != nil {
-		state.lastAvailabilityError = strings.TrimSpace(err.Error())
+		state.lastAvailabilityError = failureMessage(err.Error())
 	} else {
 		state.lastAvailabilityOKAt = state.lastAvailabilityCheckAt
 		state.lastAvailabilityError = ""

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -35,12 +35,17 @@ type ModelInfo struct {
 // newModelInfo registers a model together with the metadata its provider
 // reported for it. Always build ModelInfo through this so Discovered is
 // captured before enrichment has a chance to overwrite Model.Metadata.
+//
+// The model ID, provider name, and provider type are whitespace-trimmed here,
+// at the boundary where inventory enters the registry, so every read path can
+// compare stored values directly.
 func newModelInfo(model core.Model, provider core.Provider, providerName, providerType string) *ModelInfo {
+	model.ID = strings.TrimSpace(model.ID)
 	return &ModelInfo{
 		Model:        model,
 		Provider:     provider,
-		ProviderName: providerName,
-		ProviderType: providerType,
+		ProviderName: strings.TrimSpace(providerName),
+		ProviderType: strings.TrimSpace(providerType),
 		Discovered:   model.Metadata.Clone(),
 	}
 }
@@ -211,20 +216,18 @@ func (r *ModelRegistry) buildSelectorIndexLocked() {
 	byType := make(map[string]core.ModelSelector, total)
 	for providerName, providerModels := range r.modelsByProvider {
 		for _, info := range providerModels {
-			publicName := strings.TrimSpace(providerName)
+			publicName := providerName
 			if info.ProviderName != "" {
-				publicName = strings.TrimSpace(info.ProviderName)
+				publicName = info.ProviderName
 			}
-			id := strings.TrimSpace(info.Model.ID)
+			id := info.Model.ID
 			if publicName == "" || id == "" {
 				continue
 			}
-			// Keys are trimmed to match the trimmed lookup inputs and the
-			// previous scan, which compared trimmed fields on both sides.
-			sel := core.ModelSelector{Provider: publicName, Model: info.Model.ID}
+			sel := core.ModelSelector{Provider: publicName, Model: id}
 			byName[publicName+"/"+id] = sel
-			if providerType := strings.TrimSpace(info.ProviderType); providerType != "" {
-				typeKey := providerType + "/" + id
+			if info.ProviderType != "" {
+				typeKey := info.ProviderType + "/" + id
 				if existing, ok := byType[typeKey]; !ok || sel.Provider < existing.Provider {
 					byType[typeKey] = sel
 				}
@@ -404,6 +407,7 @@ func (r *ModelRegistry) UnregisterProvider(providerName string) {
 // model ID itself (e.g. "meta-llama/Meta-Llama-3-70B"), so the raw selector is
 // tried against the global map. Callers must hold r.mu.
 func (r *ModelRegistry) lookupLocked(model string) (*ModelInfo, bool) {
+	model = strings.TrimSpace(model)
 	providerName, modelID := splitModelSelector(model)
 	if providerName != "" {
 		if providerModels, ok := r.modelsByProvider[providerName]; ok {
@@ -461,20 +465,7 @@ func (r *ModelRegistry) Supports(model string) bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	providerName, modelID := splitModelSelector(model)
-	if providerName != "" {
-		if providerModels, ok := r.modelsByProvider[providerName]; ok {
-			if _, exists := providerModelInfo(providerModels, modelID, model); exists {
-				return true
-			}
-		}
-		if r.hasConfiguredProviderNameLocked(providerName) {
-			return false
-		}
-		// Fall through: the slash may be part of the model ID
-	}
-
-	_, ok := r.models[model]
+	_, ok := r.lookupLocked(model)
 	return ok
 }
 
@@ -487,23 +478,11 @@ func (r *ModelRegistry) ModelAvailable(model string) bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	providerName, modelID := splitModelSelector(model)
-	if providerName != "" {
-		if providerModels, ok := r.modelsByProvider[providerName]; ok {
-			if _, exists := providerModelInfo(providerModels, modelID, model); exists {
-				return !r.providerRuntime[providerName].inventoryStale
-			}
-		}
-		if r.hasConfiguredProviderNameLocked(providerName) {
-			return false
-		}
-		// Fall through: the slash may be part of the model ID
+	info, ok := r.lookupLocked(model)
+	if !ok {
+		return false
 	}
-
-	if info, ok := r.models[model]; ok {
-		return !r.providerRuntime[info.ProviderName].inventoryStale
-	}
-	return false
+	return !r.providerRuntime[info.ProviderName].inventoryStale
 }
 
 // providerAdvertisedLocked reports whether providerName's models belong in
@@ -672,7 +651,7 @@ func (r *ModelRegistry) GetProviderName(model string) string {
 	defer r.mu.RUnlock()
 
 	if info, ok := r.lookupLocked(model); ok {
-		return strings.TrimSpace(info.ProviderName)
+		return info.ProviderName
 	}
 	return ""
 }
@@ -689,10 +668,10 @@ func (r *ModelRegistry) GetProviderNameForType(providerType string) string {
 		return ""
 	}
 	for _, provider := range r.providers {
-		if strings.TrimSpace(r.providerTypes[provider]) != providerType {
+		if r.providerTypes[provider] != providerType {
 			continue
 		}
-		return strings.TrimSpace(r.providerNames[provider])
+		return r.providerNames[provider]
 	}
 	return ""
 }
@@ -708,10 +687,10 @@ func (r *ModelRegistry) GetProviderTypeForName(providerName string) string {
 		return ""
 	}
 	for _, provider := range r.providers {
-		if strings.TrimSpace(r.providerNames[provider]) != providerName {
+		if r.providerNames[provider] != providerName {
 			continue
 		}
-		return strings.TrimSpace(r.providerTypes[provider])
+		return r.providerTypes[provider]
 	}
 	return ""
 }
@@ -746,7 +725,7 @@ func (r *ModelRegistry) ProviderByName(providerName string) core.Provider {
 		return nil
 	}
 	for _, provider := range r.providers {
-		if strings.TrimSpace(r.providerNames[provider]) == providerName {
+		if r.providerNames[provider] == providerName {
 			return provider
 		}
 	}
@@ -762,7 +741,7 @@ func (r *ModelRegistry) ProviderTypes() []string {
 	seen := make(map[string]struct{}, len(r.providerTypes))
 	result := make([]string, 0, len(r.providerTypes))
 	for _, provider := range r.providers {
-		providerType := strings.TrimSpace(r.providerTypes[provider])
+		providerType := r.providerTypes[provider]
 		if providerType == "" {
 			continue
 		}
@@ -783,7 +762,7 @@ func (r *ModelRegistry) ProviderNames() []string {
 
 	result := make([]string, 0, len(r.providers))
 	for _, provider := range r.providers {
-		providerName := strings.TrimSpace(r.providerNames[provider])
+		providerName := r.providerNames[provider]
 		if providerName == "" {
 			continue
 		}
@@ -792,8 +771,9 @@ func (r *ModelRegistry) ProviderNames() []string {
 	return result
 }
 
+// splitModelSelector splits an already-trimmed selector into its provider and
+// model segments. Whitespace around the slash is tolerated.
 func splitModelSelector(model string) (providerName, modelID string) {
-	model = strings.TrimSpace(model)
 	if model == "" {
 		return "", ""
 	}
@@ -810,8 +790,6 @@ func splitModelSelector(model string) (providerName, modelID string) {
 }
 
 func providerModelInfo(providerModels map[string]*ModelInfo, modelID, rawModel string) (*ModelInfo, bool) {
-	modelID = strings.TrimSpace(modelID)
-	rawModel = strings.TrimSpace(rawModel)
 	if info, exists := providerModels[modelID]; exists {
 		return info, true
 	}
@@ -824,8 +802,6 @@ func providerModelInfo(providerModels map[string]*ModelInfo, modelID, rawModel s
 }
 
 func qualifyPublicModelID(providerName, modelID string) string {
-	providerName = strings.TrimSpace(providerName)
-	modelID = strings.TrimSpace(modelID)
 	if providerName == "" {
 		return modelID
 	}
@@ -836,7 +812,6 @@ func qualifyPublicModelID(providerName, modelID string) string {
 }
 
 func (r *ModelRegistry) hasConfiguredProviderNameLocked(providerName string) bool {
-	providerName = strings.TrimSpace(providerName)
 	if providerName == "" {
 		return false
 	}
@@ -1060,7 +1035,7 @@ func (r *ModelRegistry) RecordAvailabilityCheck(providerName string, err error) 
 	state.registered = true
 	state.lastAvailabilityCheckAt = time.Now().UTC()
 	if err != nil {
-		state.lastAvailabilityError = err.Error()
+		state.lastAvailabilityError = strings.TrimSpace(err.Error())
 	} else {
 		state.lastAvailabilityOKAt = state.lastAvailabilityCheckAt
 		state.lastAvailabilityError = ""
@@ -1090,14 +1065,14 @@ func (r *ModelRegistry) markProviderInventoryStale(providerName string) {
 
 	healthyAlternative := false
 	for _, provider := range r.providers {
-		name := strings.TrimSpace(r.providerNames[provider])
+		name := r.providerNames[provider]
 		if name == "" || name == providerName {
 			continue
 		}
 		state := r.providerRuntime[name]
 		if state.registered && !state.inventoryStale &&
-			strings.TrimSpace(state.lastModelFetchError) == "" &&
-			strings.TrimSpace(state.lastAvailabilityError) == "" &&
+			state.lastModelFetchError == "" &&
+			state.lastAvailabilityError == "" &&
 			len(r.modelsByProvider[name]) > 0 {
 			healthyAlternative = true
 			break
@@ -1126,13 +1101,12 @@ func (r *ModelRegistry) FailedProviderNames() []string {
 
 	names := make([]string, 0)
 	for _, provider := range r.providers {
-		providerName := strings.TrimSpace(r.providerNames[provider])
+		providerName := r.providerNames[provider]
 		if providerName == "" {
 			continue
 		}
 		state := r.providerRuntime[providerName]
-		if strings.TrimSpace(state.lastModelFetchError) == "" &&
-			strings.TrimSpace(state.lastAvailabilityError) == "" {
+		if state.lastModelFetchError == "" && state.lastAvailabilityError == "" {
 			continue
 		}
 		names = append(names, providerName)
@@ -1146,22 +1120,22 @@ func (r *ModelRegistry) ProviderRuntimeSnapshots() []ProviderRuntimeSnapshot {
 	r.mu.RLock()
 	result := make([]ProviderRuntimeSnapshot, 0, len(r.providers))
 	for _, provider := range r.providers {
-		providerName := strings.TrimSpace(r.providerNames[provider])
+		providerName := r.providerNames[provider]
 		if providerName == "" {
 			continue
 		}
 		state := r.providerRuntime[providerName]
 		result = append(result, ProviderRuntimeSnapshot{
 			Name:                    providerName,
-			Type:                    strings.TrimSpace(r.providerTypes[provider]),
+			Type:                    r.providerTypes[provider],
 			Registered:              state.registered,
 			DiscoveredModelCount:    len(r.modelsByProvider[providerName]),
 			LastModelFetchAt:        timePtrUTC(state.lastModelFetchAt),
 			LastModelFetchSuccessAt: timePtrUTC(state.lastModelFetchSuccessAt),
-			LastModelFetchError:     strings.TrimSpace(state.lastModelFetchError),
+			LastModelFetchError:     state.lastModelFetchError,
 			LastAvailabilityCheckAt: timePtrUTC(state.lastAvailabilityCheckAt),
 			LastAvailabilityOKAt:    timePtrUTC(state.lastAvailabilityOKAt),
-			LastAvailabilityError:   strings.TrimSpace(state.lastAvailabilityError),
+			LastAvailabilityError:   state.lastAvailabilityError,
 			InventoryStale:          state.inventoryStale,
 		})
 	}

--- a/internal/providers/registry_cache.go
+++ b/internal/providers/registry_cache.go
@@ -69,7 +69,7 @@ func (r *ModelRegistry) LoadFromCache(ctx context.Context) (int, error) {
 				OwnedBy: cachedProv.OwnedBy,
 				Created: cached.Created,
 			}, provider, providerName, providerType)
-			providerModels[cached.ID] = info
+			providerModels[info.Model.ID] = info
 		}
 		newModelsByProvider[providerName] = providerModels
 	}

--- a/internal/providers/registry_cache.go
+++ b/internal/providers/registry_cache.go
@@ -69,6 +69,10 @@ func (r *ModelRegistry) LoadFromCache(ctx context.Context) (int, error) {
 				OwnedBy: cachedProv.OwnedBy,
 				Created: cached.Created,
 			}, provider, providerName, providerType)
+			if _, exists := providerModels[info.Model.ID]; exists {
+				// Trimmed duplicates collapse to one record; first wins.
+				continue
+			}
 			providerModels[info.Model.ID] = info
 		}
 		newModelsByProvider[providerName] = providerModels

--- a/internal/providers/registry_init.go
+++ b/internal/providers/registry_init.go
@@ -270,6 +270,16 @@ func (r *ModelRegistry) fetchAllProviderModels(
 		for _, model := range resp.Data {
 			info := newModelInfo(model, provider, providerName, providerTypes[provider])
 			modelID := info.Model.ID
+			if _, exists := out.modelsByProvider[providerName][modelID]; exists {
+				// IDs are trimmed on entry, so "foo" and " foo " from the same
+				// provider collapse to one record. First wins, matching the
+				// bare-ID map below.
+				slog.Debug("duplicate model in provider response, keeping first",
+					"model", modelID,
+					"provider", providerName,
+				)
+				continue
+			}
 			out.modelsByProvider[providerName][modelID] = info
 
 			if _, exists := out.models[modelID]; exists {
@@ -459,14 +469,14 @@ func (r *ModelRegistry) applyProviderRuntimeUpdatesLocked(updates map[string]pro
 			// old error doesn't survive a subsequent successful refresh —
 			// this matters in particular for allowlist-mode refreshes which
 			// don't bump SuccessAt but still produce usable models.
-			current.lastModelFetchError = strings.TrimSpace(update.lastModelFetchError)
+			current.lastModelFetchError = optionalFailureMessage(update.lastModelFetchError)
 		}
 		if !update.lastModelFetchSuccessAt.IsZero() {
 			current.lastModelFetchSuccessAt = update.lastModelFetchSuccessAt
 		}
 		if !update.lastAvailabilityCheckAt.IsZero() {
 			current.lastAvailabilityCheckAt = update.lastAvailabilityCheckAt
-			current.lastAvailabilityError = strings.TrimSpace(update.lastAvailabilityError)
+			current.lastAvailabilityError = optionalFailureMessage(update.lastAvailabilityError)
 		}
 		if !update.lastAvailabilityOKAt.IsZero() {
 			current.lastAvailabilityOKAt = update.lastAvailabilityOKAt

--- a/internal/providers/registry_init.go
+++ b/internal/providers/registry_init.go
@@ -269,20 +269,21 @@ func (r *ModelRegistry) fetchAllProviderModels(
 
 		for _, model := range resp.Data {
 			info := newModelInfo(model, provider, providerName, providerTypes[provider])
-			out.modelsByProvider[providerName][model.ID] = info
+			modelID := info.Model.ID
+			out.modelsByProvider[providerName][modelID] = info
 
-			if _, exists := out.models[model.ID]; exists {
+			if _, exists := out.models[modelID]; exists {
 				// First provider wins for unqualified lookups; later duplicates
 				// stay reachable via modelsByProvider but lose the bare-id slot.
 				slog.Debug("model already registered, skipping",
-					"model", model.ID,
+					"model", modelID,
 					"provider", providerName,
 					"owner", model.OwnedBy,
 				)
 				continue
 			}
 
-			out.models[model.ID] = info
+			out.models[modelID] = info
 			out.totalModels++
 		}
 	}

--- a/internal/providers/registry_metadata.go
+++ b/internal/providers/registry_metadata.go
@@ -514,10 +514,10 @@ func (a *registryAccessor) GetProviderType(modelID string) string {
 	if !ok {
 		return ""
 	}
-	if providerType := strings.TrimSpace(info.ProviderType); providerType != "" {
-		return providerType
+	if info.ProviderType != "" {
+		return info.ProviderType
 	}
-	return strings.TrimSpace(a.providerTypes[info.Provider])
+	return a.providerTypes[info.Provider]
 }
 
 func (a *registryAccessor) SetMetadata(modelID string, meta *core.ModelMetadata) {

--- a/internal/providers/registry_normalization_test.go
+++ b/internal/providers/registry_normalization_test.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/enterpilot/gomodel/internal/core"
@@ -176,15 +177,16 @@ func TestRouterTrimsSelectorInput(t *testing.T) {
 		model        string
 		providerHint string
 		wantResolved string
+		wantType     string
 		wantErr      bool
 	}{
-		{name: "bare", model: "gpt-4o", wantResolved: "west/gpt-4o"},
-		{name: "bare padded", model: "  gpt-4o  ", wantResolved: "west/gpt-4o"},
-		{name: "name qualified padded", model: " west/gpt-4o ", wantResolved: "west/gpt-4o"},
-		{name: "type qualified padded", model: " openai/gpt-4o ", wantResolved: "west/gpt-4o"},
-		{name: "hint padded", model: " gpt-4o ", providerHint: " west ", wantResolved: "west/gpt-4o"},
-		{name: "type hint padded", model: "gpt-4o", providerHint: " openai ", wantResolved: "west/gpt-4o"},
-		{name: "unknown", model: "east/gpt-4o", wantResolved: "east/gpt-4o"},
+		{name: "bare", model: "gpt-4o", wantResolved: "west/gpt-4o", wantType: "openai"},
+		{name: "bare padded", model: "  gpt-4o  ", wantResolved: "west/gpt-4o", wantType: "openai"},
+		{name: "name qualified padded", model: " west/gpt-4o ", wantResolved: "west/gpt-4o", wantType: "openai"},
+		{name: "type qualified padded", model: " openai/gpt-4o ", wantResolved: "west/gpt-4o", wantType: "openai"},
+		{name: "hint padded", model: " gpt-4o ", providerHint: " west ", wantResolved: "west/gpt-4o", wantType: "openai"},
+		{name: "type hint padded", model: "gpt-4o", providerHint: " openai ", wantResolved: "west/gpt-4o", wantType: "openai"},
+		{name: "unknown", model: "east/gpt-4o", wantResolved: "east/gpt-4o", wantType: ""},
 		{name: "blank", model: "   ", wantErr: true},
 	}
 	for _, tt := range tests {
@@ -199,8 +201,8 @@ func TestRouterTrimsSelectorInput(t *testing.T) {
 			if got := selector.QualifiedModel(); got != tt.wantResolved {
 				t.Fatalf("ResolveModel() = %q, want %q", got, tt.wantResolved)
 			}
-			if got := router.GetProviderType(tt.model); (got == "openai") != (tt.wantResolved == "west/gpt-4o") {
-				t.Fatalf("GetProviderType(%q) = %q", tt.model, got)
+			if got := router.GetProviderType(tt.model); got != tt.wantType {
+				t.Fatalf("GetProviderType(%q) = %q, want %q", tt.model, got, tt.wantType)
 			}
 		})
 	}
@@ -261,5 +263,122 @@ func TestRegistryNormalizesDiscoveredModelIDs(t *testing.T) {
 	}
 	if resp.ID != "chatcmpl-west" || provider.lastChatReq == nil || provider.lastChatReq.Model != "gpt-4o" {
 		t.Fatalf("ChatCompletion() = %+v, forwarded %+v; want west response for gpt-4o", resp, provider.lastChatReq)
+	}
+}
+
+// A provider that lists "foo" and " foo " produces one record after trimming.
+// The provider-scoped map and the bare-ID map must both keep the first one.
+func TestRegistryKeepsFirstDuplicateDiscoveredModel(t *testing.T) {
+	provider := &lazyRefreshProvider{
+		name: "west",
+		modelsResponse: &core.ModelsResponse{
+			Object: "list",
+			Data: []core.Model{
+				{ID: "foo", Object: "model", OwnedBy: "first", Created: 1},
+				{ID: " foo ", Object: "model", OwnedBy: "second", Created: 2},
+			},
+		},
+	}
+	registry := NewModelRegistry()
+	registry.RegisterProviderWithNameAndType(provider, "west", "openai")
+	if err := registry.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	if got := registry.ListModels(); len(got) != 1 || got[0].ID != "foo" {
+		t.Fatalf("ListModels() = %+v, want exactly one model foo", got)
+	}
+	qualified := registry.GetModel("west/foo")
+	bare := registry.GetModel("foo")
+	if qualified == nil || bare == nil {
+		t.Fatalf("GetModel(west/foo) = %v, GetModel(foo) = %v; want both found", qualified, bare)
+	}
+	if qualified != bare {
+		t.Fatalf("provider-scoped and bare-ID maps hold different records: %+v vs %+v", qualified.Model, bare.Model)
+	}
+	if qualified.Model.OwnedBy != "first" || qualified.Model.Created != 1 {
+		t.Fatalf("kept record = %+v, want the first listed (owned_by first, created 1)", qualified.Model)
+	}
+}
+
+// selectorResolverOnlyLookup implements the O(1) qualified-selector fast path
+// without the catalog lister the slow path needs.
+type selectorResolverOnlyLookup struct {
+	*mockModelLookup
+	resolved core.ModelSelector
+	calls    int
+}
+
+func (l *selectorResolverOnlyLookup) ResolveProviderSelector(segment, modelID string) (core.ModelSelector, bool) {
+	l.calls++
+	if segment == "openai" && modelID == l.resolved.Model {
+		return l.resolved, true
+	}
+	return core.ModelSelector{}, false
+}
+
+func TestRouterUsesSelectorResolverWithoutCatalogLister(t *testing.T) {
+	lookup := &selectorResolverOnlyLookup{
+		mockModelLookup: newMockLookup(),
+		resolved:        core.ModelSelector{Provider: "west", Model: "gpt-4o"},
+	}
+	lookup.addModel("west/gpt-4o", &mockProvider{name: "west"}, "openai")
+	router, err := NewRouter(lookup)
+	if err != nil {
+		t.Fatalf("NewRouter() error = %v", err)
+	}
+	if router.caps.modelsWithProvider != nil {
+		t.Fatalf("test lookup unexpectedly implements the catalog lister")
+	}
+
+	selector, changed, err := router.ResolveModel(core.NewRequestedModelSelector("openai/gpt-4o", ""))
+	if err != nil {
+		t.Fatalf("ResolveModel() error = %v", err)
+	}
+	if got := selector.QualifiedModel(); got != "west/gpt-4o" || !changed {
+		t.Fatalf("ResolveModel() = %q (changed=%v), want west/gpt-4o via the resolver fast path", got, changed)
+	}
+	if lookup.calls != 1 {
+		t.Fatalf("resolver calls = %d, want 1", lookup.calls)
+	}
+
+	// A miss on the fast path with no catalog lister leaves the selector as is.
+	selector, changed, err = router.ResolveModel(core.NewRequestedModelSelector("openai/other", ""))
+	if err != nil {
+		t.Fatalf("ResolveModel(miss) error = %v", err)
+	}
+	if got := selector.QualifiedModel(); got != "openai/other" || changed {
+		t.Fatalf("ResolveModel(miss) = %q (changed=%v), want openai/other unchanged", got, changed)
+	}
+}
+
+func TestRecordAvailabilityCheckKeepsFailureMarker(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "plain", err: errors.New("boom"), want: "boom"},
+		{name: "padded", err: errors.New("  boom \n"), want: "boom"},
+		{name: "whitespace only", err: errors.New("   "), want: "unknown error"},
+		{name: "empty", err: errors.New(""), want: "unknown error"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := NewModelRegistry()
+			registry.RegisterProviderWithNameAndType(&mockProvider{name: "west"}, "west", "openai")
+			registry.RecordAvailabilityCheck("west", tt.err)
+
+			if got := registry.providerRuntime["west"].lastAvailabilityError; got != tt.want {
+				t.Fatalf("lastAvailabilityError = %q, want %q", got, tt.want)
+			}
+			if got := registry.FailedProviderNames(); len(got) != 1 || got[0] != "west" {
+				t.Fatalf("FailedProviderNames() = %v, want [west]", got)
+			}
+			snapshots := registry.ProviderRuntimeSnapshots()
+			if len(snapshots) != 1 || snapshots[0].LastAvailabilityError != tt.want {
+				t.Fatalf("ProviderRuntimeSnapshots() = %+v, want LastAvailabilityError %q", snapshots, tt.want)
+			}
+		})
 	}
 }

--- a/internal/providers/registry_normalization_test.go
+++ b/internal/providers/registry_normalization_test.go
@@ -1,0 +1,265 @@
+package providers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+// The registry and router trim caller input at the boundary and store
+// normalized names, types, and model IDs. These tests pin the observable
+// behavior so trims on the read paths can be removed without changing it.
+
+func TestRegistryTrimsProviderRegistrationInput(t *testing.T) {
+	provider := &mockProvider{name: "west"}
+	registry := NewModelRegistry()
+	registry.RegisterProviderWithNameAndType(provider, "  west  ", " openai ")
+
+	if got := registry.ProviderNames(); len(got) != 1 || got[0] != "west" {
+		t.Fatalf("ProviderNames() = %v, want [west]", got)
+	}
+	if got := registry.ProviderTypes(); len(got) != 1 || got[0] != "openai" {
+		t.Fatalf("ProviderTypes() = %v, want [openai]", got)
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		wantType string
+		wantName string
+	}{
+		{name: "exact", input: "west", wantType: "openai"},
+		{name: "padded", input: "  west  ", wantType: "openai"},
+		{name: "unknown", input: "east", wantType: ""},
+		{name: "blank", input: "   ", wantType: ""},
+	}
+	for _, tt := range tests {
+		t.Run("name/"+tt.name, func(t *testing.T) {
+			if got := registry.GetProviderTypeForName(tt.input); got != tt.wantType {
+				t.Fatalf("GetProviderTypeForName(%q) = %q, want %q", tt.input, got, tt.wantType)
+			}
+			wantProvider := tt.wantType != ""
+			if got := registry.ProviderByName(tt.input) != nil; got != wantProvider {
+				t.Fatalf("ProviderByName(%q) found = %v, want %v", tt.input, got, wantProvider)
+			}
+		})
+	}
+
+	typeTests := []struct {
+		name     string
+		input    string
+		wantName string
+	}{
+		{name: "exact", input: "openai", wantName: "west"},
+		{name: "padded", input: " openai ", wantName: "west"},
+		{name: "unknown", input: "anthropic", wantName: ""},
+		{name: "blank", input: "", wantName: ""},
+	}
+	for _, tt := range typeTests {
+		t.Run("type/"+tt.name, func(t *testing.T) {
+			if got := registry.GetProviderNameForType(tt.input); got != tt.wantName {
+				t.Fatalf("GetProviderNameForType(%q) = %q, want %q", tt.input, got, tt.wantName)
+			}
+			wantProvider := tt.wantName != ""
+			if got := registry.ProviderByType(tt.input) != nil; got != wantProvider {
+				t.Fatalf("ProviderByType(%q) found = %v, want %v", tt.input, got, wantProvider)
+			}
+		})
+	}
+}
+
+func TestRegistryLookupsTrimSelectorInput(t *testing.T) {
+	provider := &mockProvider{name: "west"}
+	registry := newTestRegistryWithModels(registryModelEntry{
+		provider:     provider,
+		providerName: "west",
+		providerType: "openai",
+		modelID:      "gpt-4o",
+	})
+
+	tests := []struct {
+		name      string
+		selector  string
+		wantFound bool
+	}{
+		{name: "qualified", selector: "west/gpt-4o", wantFound: true},
+		{name: "qualified padded", selector: "  west/gpt-4o  ", wantFound: true},
+		{name: "qualified inner padded", selector: "west / gpt-4o", wantFound: true},
+		{name: "bare", selector: "gpt-4o", wantFound: true},
+		{name: "bare padded", selector: " gpt-4o ", wantFound: true},
+		{name: "unknown model", selector: "west/nope", wantFound: false},
+		{name: "unknown provider", selector: "east/gpt-4o", wantFound: false},
+		{name: "blank", selector: "   ", wantFound: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := registry.Supports(tt.selector); got != tt.wantFound {
+				t.Fatalf("Supports(%q) = %v, want %v", tt.selector, got, tt.wantFound)
+			}
+			if got := registry.GetProvider(tt.selector) != nil; got != tt.wantFound {
+				t.Fatalf("GetProvider(%q) found = %v, want %v", tt.selector, got, tt.wantFound)
+			}
+			wantType, wantName := "", ""
+			if tt.wantFound {
+				wantType, wantName = "openai", "west"
+			}
+			if got := registry.GetProviderType(tt.selector); got != wantType {
+				t.Fatalf("GetProviderType(%q) = %q, want %q", tt.selector, got, wantType)
+			}
+			if got := registry.GetProviderName(tt.selector); got != wantName {
+				t.Fatalf("GetProviderName(%q) = %q, want %q", tt.selector, got, wantName)
+			}
+			model, ok := registry.LookupModel(tt.selector)
+			if ok != tt.wantFound {
+				t.Fatalf("LookupModel(%q) ok = %v, want %v", tt.selector, ok, tt.wantFound)
+			}
+			if ok && model.ID != "gpt-4o" {
+				t.Fatalf("LookupModel(%q).ID = %q, want gpt-4o", tt.selector, model.ID)
+			}
+		})
+	}
+}
+
+func TestRegistryResolveProviderSelectorTrimsInput(t *testing.T) {
+	provider := &mockProvider{name: "west"}
+	registry := newTestRegistryWithModels(registryModelEntry{
+		provider:     provider,
+		providerName: "west",
+		providerType: "openai",
+		modelID:      "gpt-4o",
+	})
+
+	tests := []struct {
+		name    string
+		segment string
+		modelID string
+		wantOK  bool
+	}{
+		{name: "by name", segment: "west", modelID: "gpt-4o", wantOK: true},
+		{name: "by type", segment: "openai", modelID: "gpt-4o", wantOK: true},
+		{name: "padded", segment: " west ", modelID: " gpt-4o ", wantOK: true},
+		{name: "unknown", segment: "east", modelID: "gpt-4o", wantOK: false},
+		{name: "blank segment", segment: "  ", modelID: "gpt-4o", wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sel, ok := registry.ResolveProviderSelector(tt.segment, tt.modelID)
+			if ok != tt.wantOK {
+				t.Fatalf("ResolveProviderSelector(%q, %q) ok = %v, want %v", tt.segment, tt.modelID, ok, tt.wantOK)
+			}
+			if ok && sel.QualifiedModel() != "west/gpt-4o" {
+				t.Fatalf("ResolveProviderSelector(%q, %q) = %q, want west/gpt-4o", tt.segment, tt.modelID, sel.QualifiedModel())
+			}
+		})
+	}
+}
+
+func TestRouterTrimsSelectorInput(t *testing.T) {
+	provider := &mockProvider{
+		name:         "west",
+		chatResponse: &core.ChatResponse{ID: "chatcmpl-west", Model: "gpt-4o"},
+	}
+	registry := newTestRegistryWithModels(registryModelEntry{
+		provider:     provider,
+		providerName: "west",
+		providerType: "openai",
+		modelID:      "gpt-4o",
+	})
+	router, err := NewRouter(registry)
+	if err != nil {
+		t.Fatalf("NewRouter() error = %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		model        string
+		providerHint string
+		wantResolved string
+		wantErr      bool
+	}{
+		{name: "bare", model: "gpt-4o", wantResolved: "west/gpt-4o"},
+		{name: "bare padded", model: "  gpt-4o  ", wantResolved: "west/gpt-4o"},
+		{name: "name qualified padded", model: " west/gpt-4o ", wantResolved: "west/gpt-4o"},
+		{name: "type qualified padded", model: " openai/gpt-4o ", wantResolved: "west/gpt-4o"},
+		{name: "hint padded", model: " gpt-4o ", providerHint: " west ", wantResolved: "west/gpt-4o"},
+		{name: "type hint padded", model: "gpt-4o", providerHint: " openai ", wantResolved: "west/gpt-4o"},
+		{name: "unknown", model: "east/gpt-4o", wantResolved: "east/gpt-4o"},
+		{name: "blank", model: "   ", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			selector, _, err := router.ResolveModel(core.NewRequestedModelSelector(tt.model, tt.providerHint))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ResolveModel() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if got := selector.QualifiedModel(); got != tt.wantResolved {
+				t.Fatalf("ResolveModel() = %q, want %q", got, tt.wantResolved)
+			}
+			if got := router.GetProviderType(tt.model); (got == "openai") != (tt.wantResolved == "west/gpt-4o") {
+				t.Fatalf("GetProviderType(%q) = %q", tt.model, got)
+			}
+		})
+	}
+
+	resp, err := router.ChatCompletion(context.Background(), &core.ChatRequest{Model: "  openai/gpt-4o  ", Provider: "  "})
+	if err != nil {
+		t.Fatalf("ChatCompletion() error = %v", err)
+	}
+	if resp.ID != "chatcmpl-west" || resp.Provider != "openai" {
+		t.Fatalf("ChatCompletion() = %+v, want west response stamped openai", resp)
+	}
+	if provider.lastChatReq == nil || provider.lastChatReq.Model != "gpt-4o" {
+		t.Fatalf("forwarded model = %+v, want gpt-4o", provider.lastChatReq)
+	}
+	if router.GetProviderNameForType(" openai ") != "west" || router.GetProviderTypeForName(" west ") != "openai" {
+		t.Fatalf("router provider name/type lookups did not trim input")
+	}
+}
+
+// Discovered model IDs are trimmed when they enter the registry, so a
+// provider that pads its IDs stays routable by the clean ID and advertises the
+// clean ID in listings.
+func TestRegistryNormalizesDiscoveredModelIDs(t *testing.T) {
+	provider := &lazyRefreshProvider{
+		name:         "west",
+		chatResponse: &core.ChatResponse{ID: "chatcmpl-west", Model: "gpt-4o"},
+		modelsResponse: &core.ModelsResponse{
+			Object: "list",
+			Data:   []core.Model{{ID: "  gpt-4o  ", Object: "model", OwnedBy: "openai"}},
+		},
+	}
+	registry := NewModelRegistry()
+	registry.RegisterProviderWithNameAndType(provider, "west", "openai")
+	if err := registry.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	models := registry.ListModels()
+	if len(models) != 1 || models[0].ID != "gpt-4o" {
+		t.Fatalf("ListModels() = %+v, want one model with ID gpt-4o", models)
+	}
+	for _, selector := range []string{"gpt-4o", "west/gpt-4o"} {
+		if !registry.Supports(selector) {
+			t.Fatalf("Supports(%q) = false, want true", selector)
+		}
+	}
+	if sel, ok := registry.ResolveProviderSelector("openai", "gpt-4o"); !ok || sel.QualifiedModel() != "west/gpt-4o" {
+		t.Fatalf("ResolveProviderSelector(openai, gpt-4o) = %q, %v; want west/gpt-4o, true", sel.QualifiedModel(), ok)
+	}
+
+	router, err := NewRouter(registry)
+	if err != nil {
+		t.Fatalf("NewRouter() error = %v", err)
+	}
+	resp, err := router.ChatCompletion(context.Background(), &core.ChatRequest{Model: "gpt-4o"})
+	if err != nil {
+		t.Fatalf("ChatCompletion() error = %v", err)
+	}
+	if resp.ID != "chatcmpl-west" || provider.lastChatReq == nil || provider.lastChatReq.Model != "gpt-4o" {
+		t.Fatalf("ChatCompletion() = %+v, forwarded %+v; want west response for gpt-4o", resp, provider.lastChatReq)
+	}
+}

--- a/internal/providers/router.go
+++ b/internal/providers/router.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"slices"
 	"sort"
 	"strings"
 
@@ -21,11 +22,47 @@ var ErrRegistryNotInitialized = fmt.Errorf("model registry has no models: ensure
 // It uses a dynamic model-to-provider mapping that is populated at startup
 // by fetching available models from each provider's /models endpoint.
 type Router struct {
-	lookup       core.ModelLookup
+	lookup core.ModelLookup
+	// caps holds the optional lookup capabilities, resolved once at
+	// construction so the request path never repeats the type assertions.
+	caps         lookupCaps
 	cachePlanner *cachePlanner
 	// unqualifiedModelIDs makes ListModels advertise bare model IDs instead of
 	// provider-qualified ones.
 	unqualifiedModelIDs bool
+}
+
+// lookupCaps records which optional interfaces the lookup implements. A nil
+// field means the lookup lacks that capability and the router uses the
+// fallback path built on the core.ModelLookup contract.
+type lookupCaps struct {
+	typeRegistry            providerTypeRegistry
+	nameRegistry            providerNameRegistry
+	initialized             initializedLookup
+	typeLister              providerTypeLister
+	nameLister              providerNameLister
+	publicModels            publicModelLister
+	unqualifiedPublicModels unqualifiedPublicModelLister
+	modelsWithProvider      modelWithProviderLister
+	selectorResolver        qualifiedSelectorResolver
+	modelInfo               modelInfoLookup
+	refresher               providerModelRefresher
+}
+
+func resolveLookupCaps(lookup core.ModelLookup) lookupCaps {
+	var caps lookupCaps
+	caps.typeRegistry, _ = lookup.(providerTypeRegistry)
+	caps.nameRegistry, _ = lookup.(providerNameRegistry)
+	caps.initialized, _ = lookup.(initializedLookup)
+	caps.typeLister, _ = lookup.(providerTypeLister)
+	caps.nameLister, _ = lookup.(providerNameLister)
+	caps.publicModels, _ = lookup.(publicModelLister)
+	caps.unqualifiedPublicModels, _ = lookup.(unqualifiedPublicModelLister)
+	caps.modelsWithProvider, _ = lookup.(modelWithProviderLister)
+	caps.selectorResolver, _ = lookup.(qualifiedSelectorResolver)
+	caps.modelInfo, _ = lookup.(modelInfoLookup)
+	caps.refresher, _ = lookup.(providerModelRefresher)
+	return caps
 }
 
 type providerTypeRegistry interface {
@@ -92,6 +129,7 @@ func NewRouter(lookup core.ModelLookup) (*Router, error) {
 	}
 	return &Router{
 		lookup:       lookup,
+		caps:         resolveLookupCaps(lookup),
 		cachePlanner: newCachePlanner(),
 	}, nil
 }
@@ -143,10 +181,10 @@ func (r *Router) ResolveModel(requested core.RequestedModelSelector) (core.Model
 }
 
 func (r *Router) resolveUnqualifiedSelector(selector core.ModelSelector) (core.ModelSelector, bool) {
-	if selector.Provider != "" || strings.TrimSpace(selector.Model) == "" {
+	if selector.Provider != "" || selector.Model == "" {
 		return core.ModelSelector{}, false
 	}
-	providerName := strings.TrimSpace(r.lookup.GetProviderName(selector.Model))
+	providerName := r.lookup.GetProviderName(selector.Model)
 	if providerName == "" {
 		return core.ModelSelector{}, false
 	}
@@ -154,21 +192,21 @@ func (r *Router) resolveUnqualifiedSelector(selector core.ModelSelector) (core.M
 }
 
 func (r *Router) resolveQualifiedSelector(requested core.RequestedModelSelector, selector core.ModelSelector) (core.ModelSelector, bool) {
-	models, ok := r.lookup.(modelWithProviderLister)
-	if !ok {
+	if r.caps.modelsWithProvider == nil {
 		return core.ModelSelector{}, false
 	}
 
-	providerSegment := strings.TrimSpace(selector.Provider)
-	modelID := strings.TrimSpace(selector.Model)
+	// selector comes from Normalize(), so both segments are already trimmed.
+	providerSegment := selector.Provider
+	modelID := selector.Model
 	if providerSegment == "" || modelID == "" {
 		return core.ModelSelector{}, false
 	}
 
 	// O(1) fast path: direct provider name/type match. Falls through to the
 	// catalog scan only for raw slash-shaped IDs and other edge cases.
-	if resolver, ok := r.lookup.(qualifiedSelectorResolver); ok {
-		if concrete, ok := resolver.ResolveProviderSelector(providerSegment, modelID); ok {
+	if r.caps.selectorResolver != nil {
+		if concrete, ok := r.caps.selectorResolver.ResolveProviderSelector(providerSegment, modelID); ok {
 			return concrete, true
 		}
 	}
@@ -177,7 +215,7 @@ func (r *Router) resolveQualifiedSelector(requested core.RequestedModelSelector,
 	// raw slash-shaped model IDs the fast path can't key on). The parsed-modelID
 	// pass mirrors the fast path for non-indexed lookups; the requested.Model pass
 	// additionally resolves models whose own IDs contain a slash.
-	entries := models.ListModelsWithProvider()
+	entries := r.caps.modelsWithProvider.ListModelsWithProvider()
 
 	if concrete, ok := resolveProviderOwnedRawSelector(entries, providerSegment, modelID); ok {
 		return concrete, true
@@ -196,12 +234,12 @@ func (r *Router) resolveQualifiedSelector(requested core.RequestedModelSelector,
 		return core.ModelSelector{}, false
 	}
 
-	rawModelID := strings.TrimSpace(requested.Model)
+	rawModelID := requested.Model
 	if rawModelID == "" {
 		return core.ModelSelector{}, false
 	}
 	for _, entry := range entries {
-		if strings.TrimSpace(entry.Model.ID) != rawModelID {
+		if entry.Model.ID != rawModelID {
 			continue
 		}
 		return core.ModelSelector{Provider: entry.ProviderName, Model: entry.Model.ID}, true
@@ -210,52 +248,40 @@ func (r *Router) resolveQualifiedSelector(requested core.RequestedModelSelector,
 	return core.ModelSelector{}, false
 }
 
+// resolveProviderOwnedRawSelector scans the catalog for a trimmed provider
+// segment (name first, then type) and a trimmed raw model ID.
 func resolveProviderOwnedRawSelector(entries []ModelWithProvider, providerSegment, rawModelID string) (core.ModelSelector, bool) {
-	providerSegment = strings.TrimSpace(providerSegment)
-	rawModelID = strings.TrimSpace(rawModelID)
 	if providerSegment == "" || rawModelID == "" {
 		return core.ModelSelector{}, false
 	}
 
 	for _, entry := range entries {
-		if strings.TrimSpace(entry.ProviderName) != providerSegment {
-			continue
+		if entry.ProviderName == providerSegment && entry.Model.ID == rawModelID {
+			return core.ModelSelector{Provider: entry.ProviderName, Model: entry.Model.ID}, true
 		}
-		if strings.TrimSpace(entry.Model.ID) != rawModelID {
-			continue
-		}
-		return core.ModelSelector{Provider: entry.ProviderName, Model: entry.Model.ID}, true
 	}
 
 	for _, entry := range entries {
-		if strings.TrimSpace(entry.ProviderType) != providerSegment {
-			continue
+		if entry.ProviderType == providerSegment && entry.Model.ID == rawModelID {
+			return core.ModelSelector{Provider: entry.ProviderName, Model: entry.Model.ID}, true
 		}
-		if strings.TrimSpace(entry.Model.ID) != rawModelID {
-			continue
-		}
-		return core.ModelSelector{Provider: entry.ProviderName, Model: entry.Model.ID}, true
 	}
 
 	return core.ModelSelector{}, false
 }
 
+// hasConfiguredProviderName reports whether a trimmed provider name is a
+// configured provider instance.
 func (r *Router) hasConfiguredProviderName(providerName string) bool {
-	providerName = strings.TrimSpace(providerName)
 	if providerName == "" {
 		return false
 	}
-	if named, ok := r.lookup.(providerNameLister); ok {
-		for _, candidate := range named.ProviderNames() {
-			if strings.TrimSpace(candidate) == providerName {
-				return true
-			}
-		}
-		return false
+	if r.caps.nameLister != nil {
+		return slices.Contains(r.caps.nameLister.ProviderNames(), providerName)
 	}
-	if models, ok := r.lookup.(modelWithProviderLister); ok {
-		for _, entry := range models.ListModelsWithProvider() {
-			if strings.TrimSpace(entry.ProviderName) == providerName {
+	if r.caps.modelsWithProvider != nil {
+		for _, entry := range r.caps.modelsWithProvider.ListModelsWithProvider() {
+			if entry.ProviderName == providerName {
 				return true
 			}
 		}
@@ -275,8 +301,8 @@ type resolvedRoute struct {
 // lookupRoute fetches the provider and provider type for an already-resolved
 // selector, taking the registry lock once when the lookup supports it.
 func (r *Router) lookupRoute(model string) (core.Provider, string) {
-	if infos, ok := r.lookup.(modelInfoLookup); ok {
-		info := infos.GetModel(model)
+	if r.caps.modelInfo != nil {
+		info := r.caps.modelInfo.GetModel(model)
 		if info == nil || info.Provider == nil {
 			return nil, ""
 		}
@@ -333,8 +359,7 @@ func (r *Router) resolveProvider(ctx context.Context, model, providerHint string
 }
 
 func (r *Router) refreshProviderModelsForRequest(ctx context.Context, requested core.RequestedModelSelector) (bool, error) {
-	refresher, ok := r.lookup.(providerModelRefresher)
-	if !ok {
+	if r.caps.refresher == nil {
 		return false, nil
 	}
 
@@ -342,7 +367,7 @@ func (r *Router) refreshProviderModelsForRequest(ctx context.Context, requested 
 	if err != nil {
 		return false, nil
 	}
-	providerSelector := strings.TrimSpace(selector.Provider)
+	providerSelector := selector.Provider
 	if providerSelector == "" {
 		return false, nil
 	}
@@ -350,7 +375,7 @@ func (r *Router) refreshProviderModelsForRequest(ctx context.Context, requested 
 		return false, nil
 	}
 
-	_, err = refresher.RefreshProviderModels(ctx, providerSelector)
+	_, err = r.caps.refresher.RefreshProviderModels(ctx, providerSelector)
 	return true, err
 }
 
@@ -361,22 +386,22 @@ func (r *Router) RefreshProviderModels(ctx context.Context, providerSelector str
 	if !r.hasRegisteredProviderSelector(providerSelector) {
 		return 0, nil
 	}
-	refresher, ok := r.lookup.(providerModelRefresher)
-	if !ok {
+	if r.caps.refresher == nil {
 		return 0, nil
 	}
-	return refresher.RefreshProviderModels(ctx, providerSelector)
+	return r.caps.refresher.RefreshProviderModels(ctx, providerSelector)
 }
 
+// hasRegisteredProviderSelector reports whether a trimmed selector names a
+// configured provider instance or a registered provider type.
 func (r *Router) hasRegisteredProviderSelector(providerSelector string) bool {
-	providerSelector = strings.TrimSpace(providerSelector)
 	if providerSelector == "" {
 		return false
 	}
 	if r.hasConfiguredProviderName(providerSelector) {
 		return true
 	}
-	if strings.TrimSpace(r.lookup.GetProviderNameForType(providerSelector)) != "" {
+	if r.lookup.GetProviderNameForType(providerSelector) != "" {
 		return true
 	}
 	return r.providerByTypeRegistry(providerSelector) != nil
@@ -408,7 +433,7 @@ func (r *Router) resolveProviderSelector(providerSelector string) (core.Provider
 		return provider, providerSelector, nil
 	}
 	if provider := r.providerByNameRegistry(providerSelector); provider != nil {
-		providerType := strings.TrimSpace(r.GetProviderTypeForName(providerSelector))
+		providerType := r.GetProviderTypeForName(providerSelector)
 		if providerType == "" {
 			providerType = providerSelector
 		}
@@ -418,8 +443,8 @@ func (r *Router) resolveProviderSelector(providerSelector string) (core.Provider
 }
 
 func (r *Router) ensureProviderInventoryReady() error {
-	if initialized, ok := r.lookup.(initializedLookup); ok {
-		if !initialized.IsInitialized() {
+	if r.caps.initialized != nil {
+		if !r.caps.initialized.IsInitialized() {
 			if err := r.checkReady(); err != nil {
 				if errors.Is(err, ErrRegistryNotInitialized) {
 					return registryUnavailableError(err)
@@ -748,10 +773,10 @@ func (r *Router) ListModels(_ context.Context) (*core.ModelsResponse, error) {
 		return nil, registryUnavailableError(err)
 	}
 	var models []core.Model
-	if unqualified, ok := r.lookup.(unqualifiedPublicModelLister); ok && r.unqualifiedModelIDs {
-		models = unqualified.ListUnqualifiedPublicModels()
-	} else if public, ok := r.lookup.(publicModelLister); ok {
-		models = public.ListPublicModels()
+	if r.caps.unqualifiedPublicModels != nil && r.unqualifiedModelIDs {
+		models = r.caps.unqualifiedPublicModels.ListUnqualifiedPublicModels()
+	} else if r.caps.publicModels != nil {
+		models = r.caps.publicModels.ListPublicModels()
 	} else {
 		models = r.lookup.ListModels()
 	}
@@ -1056,7 +1081,7 @@ func (r *Router) GetProviderName(model string) string {
 // GetProviderNameForType returns the concrete configured provider instance name
 // chosen for a provider-typed route.
 func (r *Router) GetProviderNameForType(providerType string) string {
-	return strings.TrimSpace(r.lookup.GetProviderNameForType(providerType))
+	return r.lookup.GetProviderNameForType(providerType)
 }
 
 // GetProviderTypeForName returns the provider type for a concrete configured
@@ -1066,7 +1091,7 @@ func (r *Router) GetProviderTypeForName(providerName string) string {
 	if providerName == "" {
 		return ""
 	}
-	return strings.TrimSpace(r.lookup.GetProviderTypeForName(providerName))
+	return r.lookup.GetProviderTypeForName(providerName)
 }
 
 func (r *Router) providerByType(providerType string) core.Provider {
@@ -1084,8 +1109,8 @@ func (r *Router) providerByType(providerType string) core.Provider {
 }
 
 func (r *Router) providerByTypeRegistry(providerType string) core.Provider {
-	if registry, ok := r.lookup.(providerTypeRegistry); ok {
-		if provider := registry.ProviderByType(providerType); provider != nil {
+	if r.caps.typeRegistry != nil {
+		if provider := r.caps.typeRegistry.ProviderByType(providerType); provider != nil {
 			return provider
 		}
 	}
@@ -1093,32 +1118,24 @@ func (r *Router) providerByTypeRegistry(providerType string) core.Provider {
 }
 
 func (r *Router) providerByNameRegistry(providerName string) core.Provider {
-	if registry, ok := r.lookup.(providerNameRegistry); ok {
-		if provider := registry.ProviderByName(providerName); provider != nil {
+	if r.caps.nameRegistry != nil {
+		if provider := r.caps.nameRegistry.ProviderByName(providerName); provider != nil {
 			return provider
 		}
 	}
 	return r.providerByName(providerName)
 }
 
+// providerByName scans the catalog for a trimmed provider instance name.
 func (r *Router) providerByName(providerName string) core.Provider {
-	providerName = strings.TrimSpace(providerName)
-	if providerName == "" {
+	if providerName == "" || r.caps.modelsWithProvider == nil {
 		return nil
 	}
-	models, ok := r.lookup.(modelWithProviderLister)
-	if !ok {
-		return nil
-	}
-	for _, entry := range models.ListModelsWithProvider() {
-		if strings.TrimSpace(entry.ProviderName) != providerName {
+	for _, entry := range r.caps.modelsWithProvider.ListModelsWithProvider() {
+		if entry.ProviderName != providerName || entry.Model.ID == "" {
 			continue
 		}
-		modelID := strings.TrimSpace(entry.Model.ID)
-		if modelID == "" {
-			continue
-		}
-		if provider := r.lookup.GetProvider(core.ModelSelector{Provider: providerName, Model: modelID}.QualifiedModel()); provider != nil {
+		if provider := r.lookup.GetProvider(core.ModelSelector{Provider: providerName, Model: entry.Model.ID}.QualifiedModel()); provider != nil {
 			return provider
 		}
 	}
@@ -1126,14 +1143,14 @@ func (r *Router) providerByName(providerName string) core.Provider {
 }
 
 func (r *Router) providerTypes() []string {
-	if typed, ok := r.lookup.(providerTypeLister); ok {
-		return typed.ProviderTypes()
+	if r.caps.typeLister != nil {
+		return r.caps.typeLister.ProviderTypes()
 	}
 
 	seen := make(map[string]struct{})
 	result := make([]string, 0)
 	for _, model := range r.lookup.ListModels() {
-		providerType := strings.TrimSpace(r.lookup.GetProviderType(model.ID))
+		providerType := r.lookup.GetProviderType(model.ID)
 		if providerType == "" {
 			continue
 		}
@@ -1190,14 +1207,23 @@ func (r *Router) NativeResponseProviderTypes() []string {
 	})
 }
 
+// requestedProviderName returns the trimmed provider instance name a
+// passthrough request asks for, or "" when it names none.
+func requestedProviderName(req *core.PassthroughRequest) string {
+	if req == nil {
+		return ""
+	}
+	return strings.TrimSpace(req.ProviderName)
+}
+
 // Passthrough routes an opaque provider-native request by provider type.
 // If req.ProviderName is set, routing prefers the named provider instance over
 // the first registered provider of the given type.
 func (r *Router) Passthrough(ctx context.Context, providerType string, req *core.PassthroughRequest) (*core.PassthroughResponse, error) {
 	var pp core.PassthroughProvider
-	if req != nil && strings.TrimSpace(req.ProviderName) != "" {
+	if providerName := requestedProviderName(req); providerName != "" {
 		slog.DebugContext(ctx, "passthrough routing by name", "providerName", req.ProviderName, "providerType", providerType)
-		if p := r.providerByNameRegistry(strings.TrimSpace(req.ProviderName)); p != nil {
+		if p := r.providerByNameRegistry(providerName); p != nil {
 			if named, ok := p.(core.PassthroughProvider); ok {
 				pp = named
 				slog.DebugContext(ctx, "passthrough routed by name", "providerName", req.ProviderName)

--- a/internal/providers/router.go
+++ b/internal/providers/router.go
@@ -192,10 +192,6 @@ func (r *Router) resolveUnqualifiedSelector(selector core.ModelSelector) (core.M
 }
 
 func (r *Router) resolveQualifiedSelector(requested core.RequestedModelSelector, selector core.ModelSelector) (core.ModelSelector, bool) {
-	if r.caps.modelsWithProvider == nil {
-		return core.ModelSelector{}, false
-	}
-
 	// selector comes from Normalize(), so both segments are already trimmed.
 	providerSegment := selector.Provider
 	modelID := selector.Model
@@ -209,6 +205,11 @@ func (r *Router) resolveQualifiedSelector(requested core.RequestedModelSelector,
 		if concrete, ok := r.caps.selectorResolver.ResolveProviderSelector(providerSegment, modelID); ok {
 			return concrete, true
 		}
+	}
+
+	// The remaining passes scan the catalog, which needs the lister.
+	if r.caps.modelsWithProvider == nil {
+		return core.ModelSelector{}, false
 	}
 
 	// Fallback for lookups that don't implement qualifiedSelectorResolver (and for


### PR DESCRIPTION
Stacked on #839 (`refactor/registry-single-lookup`); merge that first.

## What changed

**Router resolves its optional lookup capabilities once.** `NewRouter` now records which optional interfaces the lookup implements (`providerTypeRegistry`, `qualifiedSelectorResolver`, `modelInfoLookup`, `providerModelRefresher`, listers, ...) in a `lookupCaps` struct. Methods check a field for nil instead of repeating 14 `r.lookup.(iface)` type assertions per request. Every fallback path for lookups without a capability is kept, so test fakes and any lookup that only satisfies `core.ModelLookup` behave as before.

**IDs are normalized where they enter the registry, not on every read.** `newModelInfo` trims the model ID, provider name, and provider type; provider registration already trimmed names and types. `RecordAvailabilityCheck` trims the error text at write time (the refresh path already did). With stored values provably trimmed, the read paths compare them directly:

| file | `strings.TrimSpace` before | after |
|---|---|---|
| `internal/providers/registry.go` | 44 | 21 |
| `internal/providers/router.go` | 33 | 7 |

The remaining trims sit on public entry points that receive caller or config input. `core.ModelLookup` now documents that implementations return trimmed values.

**Redundancy removed while there:** `Supports` and `ModelAvailable` still duplicated the selector-split / configured-provider / raw-slash fall-through that #839 collapsed into `lookupLocked`; both are now one-liners on top of it.

## Behavior notes

- Discovered model IDs with surrounding whitespace were previously stored untrimmed and therefore unroutable (map lookups trimmed the input but not the key). They are now trimmed on entry, routable by the clean ID, and advertised with the clean ID. Covered by `TestRegistryNormalizesDiscoveredModelIDs`.
- Registry-level bare selectors with padding (`" gpt-4o "`) now resolve like padded qualified selectors already did (`" west/gpt-4o "`). The router always normalized before calling the registry, so nothing user-visible changes.
- No public API, routing precedence, or refresh-on-miss behavior changes.

## Tests

- New `registry_normalization_test.go`: table-driven coverage of registration input trimming, registry lookups by trimmed/padded/inner-padded selectors, `ResolveProviderSelector`, router `ResolveModel`/`ChatCompletion` with padded model and provider hint, and discovered-ID normalization.
- Full `go test` for `./internal/... ./config/... ./ext/... ./run/... ./cmd/...`, `go vet`, `make lint`, `make test-race`, and the hot-path perf guard pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Provider names, provider types, and model identifiers are consistently normalized when registered and retrieved.
  - Lookups and routing handle leading or trailing whitespace in model selectors and provider hints reliably.
  - Duplicate model identifiers are consolidated while retaining the first available record.
  - Models restored from cache retain consistent identifiers after restart.
  - Provider and model listings present clean, normalized values.
  - Empty or whitespace-only availability errors are reported as “unknown error.”
  - Routing and provider discovery use consistent lookup behavior across refreshes and readiness checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->