### PR TITLE
refactor(gateway): return ExecutionMeta instead of positional route values

### DIFF
--- a/internal/gateway/edge_cases_test.go
+++ b/internal/gateway/edge_cases_test.go
@@ -182,7 +182,7 @@ func TestStreamResponsesRejectsNilRequest(t *testing.T) {
 func TestDispatchChatCompletionRejectsEmptyProviderResponse(t *testing.T) {
 	orchestrator := NewInferenceOrchestrator(InferenceConfig{Provider: &providerTypeResolverStub{}})
 
-	_, _, _, _, _, err := orchestrator.DispatchChatCompletion(context.Background(), nil, &core.ChatRequest{Model: "gpt-4o-mini"})
+	_, _, err := orchestrator.DispatchChatCompletion(context.Background(), nil, &core.ChatRequest{Model: "gpt-4o-mini"})
 	if err == nil {
 		t.Fatal("DispatchChatCompletion() error = nil, want provider error")
 	}

--- a/internal/gateway/failover.go
+++ b/internal/gateway/failover.go
@@ -43,7 +43,7 @@ func tryFailoverResponse[T any](
 	model, provider string,
 	primaryErr error,
 	call func(selector core.ModelSelector, providerType, providerName string) (T, string, error),
-) (T, string, string, string, bool, error) {
+) (T, ExecutionMeta, error) {
 	var zero T
 
 	// A canceled or expired context means the client is gone or the deadline
@@ -51,12 +51,12 @@ func tryFailoverResponse[T any](
 	// only wastes attempts and charges spurious failures to healthy failover
 	// providers' circuit breakers. Short-circuit to the primary error instead.
 	if ctx.Err() != nil {
-		return zero, "", "", "", false, primaryErr
+		return zero, ExecutionMeta{}, primaryErr
 	}
 
 	failovers := o.FailoverSelectors(workflow)
 	if len(failovers) == 0 || !o.failoverPolicy.ShouldRetry(primaryErr) {
-		return zero, "", "", "", false, primaryErr
+		return zero, ExecutionMeta{}, primaryErr
 	}
 
 	requestID := strings.TrimSpace(core.GetRequestID(ctx))
@@ -102,12 +102,17 @@ func tryFailoverResponse[T any](
 				"to", qualified,
 				"provider_type", resolvedProviderType,
 			)
-			return resp, resolvedProviderType, providerName, qualified, true, nil
+			return resp, ExecutionMeta{
+				ProviderType:  resolvedProviderType,
+				ProviderName:  providerName,
+				FailoverModel: qualified,
+				UsedFailover:  true,
+			}, nil
 		}
 		lastErr = err
 	}
 
-	return zero, "", "", "", false, lastErr
+	return zero, ExecutionMeta{}, lastErr
 }
 
 func executeWithFailoverResponse[T any](
@@ -117,10 +122,10 @@ func executeWithFailoverResponse[T any](
 	model, provider string,
 	primary func() (T, string, string, error),
 	failoverFn func(selector core.ModelSelector, providerType, providerName string) (T, string, error),
-) (T, string, string, string, bool, error) {
+) (T, ExecutionMeta, error) {
 	resp, resolvedProviderType, resolvedProviderName, err := primary()
 	if err == nil {
-		return resp, resolvedProviderType, resolvedProviderName, "", false, nil
+		return resp, ExecutionMeta{ProviderType: resolvedProviderType, ProviderName: resolvedProviderName}, nil
 	}
 	return tryFailoverResponse(ctx, o, workflow, model, provider, err, failoverFn)
 }
@@ -133,7 +138,7 @@ func executeTranslatedWithFailover[Req any, Resp any](
 	model, provider string,
 	cloneForSelector func(Req, core.ModelSelector) Req,
 	call func(context.Context, Req) (Resp, string, error),
-) (Resp, string, string, string, bool, error) {
+) (Resp, ExecutionMeta, error) {
 	return executeWithFailoverResponse(ctx, o, workflow, model, provider,
 		func() (Resp, string, string, error) {
 			started := time.Now()
@@ -171,16 +176,16 @@ func tryFailoverStream(
 	model, provider string,
 	primaryErr error,
 	call func(selector core.ModelSelector, providerType, providerName string) (io.ReadCloser, string, string, error),
-) (io.ReadCloser, string, string, string, string, error) {
+) (io.ReadCloser, ExecutionMeta, error) {
 	// See tryFailoverResponse: never sweep failover targets once the context is
 	// done, or the doomed attempts pollute healthy providers' circuit breakers.
 	if ctx.Err() != nil {
-		return nil, "", "", "", "", primaryErr
+		return nil, ExecutionMeta{}, primaryErr
 	}
 
 	failovers := o.FailoverSelectors(workflow)
 	if len(failovers) == 0 || !o.failoverPolicy.ShouldRetry(primaryErr) {
-		return nil, "", "", "", "", primaryErr
+		return nil, ExecutionMeta{}, primaryErr
 	}
 
 	requestID := strings.TrimSpace(core.GetRequestID(ctx))
@@ -226,12 +231,18 @@ func tryFailoverStream(
 				"to", qualified,
 				"provider_type", resolvedProviderType,
 			)
-			return stream, resolvedProviderType, providerName, usageModel, qualified, nil
+			return stream, ExecutionMeta{
+				ProviderType:  resolvedProviderType,
+				ProviderName:  providerName,
+				Model:         usageModel,
+				FailoverModel: qualified,
+				UsedFailover:  true,
+			}, nil
 		}
 		lastErr = err
 	}
 
-	return nil, "", "", "", "", lastErr
+	return nil, ExecutionMeta{}, lastErr
 }
 
 func firstNonEmptyString(values ...string) string {

--- a/internal/gateway/failover_policy_test.go
+++ b/internal/gateway/failover_policy_test.go
@@ -93,10 +93,10 @@ func TestTryFailoverResponseHonorsMaxAttempts(t *testing.T) {
 				return "", "", core.NewProviderError("openai", http.StatusBadGateway, selector.Model+" down", nil)
 			}
 
-			_, _, _, _, didFailover, err := tryFailoverResponse(context.Background(), o, workflow, "openai/gpt-4o", "openai", primaryErr, call)
+			_, meta, err := tryFailoverResponse(context.Background(), o, workflow, "openai/gpt-4o", "openai", primaryErr, call)
 
-			if didFailover || err == nil {
-				t.Fatalf("expected the sweep to fail, got didFailover=%v err=%v", didFailover, err)
+			if meta.UsedFailover || err == nil {
+				t.Fatalf("expected the sweep to fail, got didFailover=%v err=%v", meta.UsedFailover, err)
 			}
 			if strings.Join(calls, ",") != strings.Join(tt.wantCalls, ",") {
 				t.Fatalf("calls = %v, want %v", calls, tt.wantCalls)
@@ -120,10 +120,10 @@ func TestTryFailoverResponseMaxAttemptsCountsCallsOnly(t *testing.T) {
 		return "ok", "openai", nil
 	}
 
-	_, _, _, model, didFailover, err := tryFailoverResponse(context.Background(), o, workflow, "openai/gpt-4o", "openai", primaryErr, call)
+	_, meta, err := tryFailoverResponse(context.Background(), o, workflow, "openai/gpt-4o", "openai", primaryErr, call)
 
-	if !didFailover || err != nil || model != "openai/b" || len(calls) != 1 {
-		t.Fatalf("result = (model:%q didFailover:%v err:%v calls:%v), want one successful call to openai/b", model, didFailover, err, calls)
+	if !meta.UsedFailover || err != nil || meta.FailoverModel != "openai/b" || len(calls) != 1 {
+		t.Fatalf("result = (model:%q didFailover:%v err:%v calls:%v), want one successful call to openai/b", meta.FailoverModel, meta.UsedFailover, err, calls)
 	}
 }
 
@@ -136,7 +136,7 @@ func TestTryFailoverStreamHonorsMaxAttempts(t *testing.T) {
 		return nil, "", "", core.NewProviderError("openai", http.StatusBadGateway, selector.Model+" down", nil)
 	}
 
-	stream, _, _, _, _, err := tryFailoverStream(context.Background(), o, workflow, "openai/gpt-4o", "openai", primaryErr, call)
+	stream, _, err := tryFailoverStream(context.Background(), o, workflow, "openai/gpt-4o", "openai", primaryErr, call)
 
 	if stream != nil || err == nil || len(calls) != 1 || calls[0] != "openai/a" {
 		t.Fatalf("calls = %v err = %v, want exactly one failed attempt at openai/a", calls, err)
@@ -153,10 +153,10 @@ func TestTryFailoverResponseSkipsWhenPolicyDoesNotMatch(t *testing.T) {
 		return "ok", "openai", nil
 	}
 
-	_, _, _, _, didFailover, err := tryFailoverResponse(context.Background(), o, workflow, "openai/gpt-4o", "openai", primaryErr, call)
+	_, meta, err := tryFailoverResponse(context.Background(), o, workflow, "openai/gpt-4o", "openai", primaryErr, call)
 
-	if called || didFailover || err != primaryErr {
-		t.Fatalf("expected the primary 429 to be returned untouched (called=%v didFailover=%v err=%v)", called, didFailover, err)
+	if called || meta.UsedFailover || err != primaryErr {
+		t.Fatalf("expected the primary 429 to be returned untouched (called=%v didFailover=%v err=%v)", called, meta.UsedFailover, err)
 	}
 }
 
@@ -171,7 +171,7 @@ func TestTryFailoverStreamSkipsWhenPolicyDoesNotMatch(t *testing.T) {
 		return nil, "", "", nil
 	}
 
-	stream, _, _, _, _, err := tryFailoverStream(context.Background(), o, workflow, "openai/gpt-4o", "openai", primaryErr, call)
+	stream, _, err := tryFailoverStream(context.Background(), o, workflow, "openai/gpt-4o", "openai", primaryErr, call)
 
 	if called || stream != nil || err != primaryErr {
 		t.Fatalf("expected the primary 429 to be returned untouched (called=%v stream=%v err=%v)", called, stream, err)

--- a/internal/gateway/failover_test.go
+++ b/internal/gateway/failover_test.go
@@ -48,12 +48,12 @@ func TestTryFailoverResponseSkipsWhenContextCanceled(t *testing.T) {
 		return "", "", core.NewProviderError("openai", http.StatusBadGateway, "unexpected failover call", nil)
 	}
 
-	_, _, _, _, didFailover, err := tryFailoverResponse(ctx, o, workflow, "openai/gpt-4o", "openai", primaryErr, call)
+	_, meta, err := tryFailoverResponse(ctx, o, workflow, "openai/gpt-4o", "openai", primaryErr, call)
 
 	if called {
 		t.Fatal("tryFailoverResponse invoked a failover provider on a canceled context; it must short-circuit")
 	}
-	if didFailover {
+	if meta.UsedFailover {
 		t.Fatalf("didFailover = true, want false when context is canceled")
 	}
 	if !errors.Is(err, context.Canceled) {
@@ -72,13 +72,13 @@ func TestTryFailoverResponseAttemptsWhenContextLive(t *testing.T) {
 		return "ok", "openai", nil
 	}
 
-	resp, _, _, _, didFailover, err := tryFailoverResponse(context.Background(), o, workflow, "openai/gpt-4o", "openai", primaryErr, call)
+	resp, meta, err := tryFailoverResponse(context.Background(), o, workflow, "openai/gpt-4o", "openai", primaryErr, call)
 
 	if !called {
 		t.Fatal("tryFailoverResponse did not attempt failover on a live context")
 	}
-	if !didFailover || err != nil || resp != "ok" {
-		t.Fatalf("failover result = (resp:%q didFailover:%v err:%v), want (ok true <nil>)", resp, didFailover, err)
+	if !meta.UsedFailover || err != nil || resp != "ok" {
+		t.Fatalf("failover result = (resp:%q didFailover:%v err:%v), want (ok true <nil>)", resp, meta.UsedFailover, err)
 	}
 }
 
@@ -108,13 +108,13 @@ func TestTryFailoverResponseSkipsRateLimitedTargets(t *testing.T) {
 		return "ok", "anthropic", nil
 	}
 
-	resp, _, _, failoverModel, didFailover, err := tryFailoverResponse(context.Background(), o, workflow, "openai/gpt-4o", "openai", primaryErr, call)
+	resp, meta, err := tryFailoverResponse(context.Background(), o, workflow, "openai/gpt-4o", "openai", primaryErr, call)
 
 	if len(attempted) != 1 || attempted[0] != "anthropic/claude" {
 		t.Fatalf("attempted = %v, want only anthropic/claude (rate-limited target skipped)", attempted)
 	}
-	if !didFailover || err != nil || resp != "ok" || failoverModel != "anthropic/claude" {
-		t.Fatalf("failover result = (resp:%q model:%q didFailover:%v err:%v), want anthropic success", resp, failoverModel, didFailover, err)
+	if !meta.UsedFailover || err != nil || resp != "ok" || meta.FailoverModel != "anthropic/claude" {
+		t.Fatalf("failover result = (resp:%q model:%q didFailover:%v err:%v), want anthropic success", resp, meta.FailoverModel, meta.UsedFailover, err)
 	}
 }
 
@@ -134,13 +134,13 @@ func TestTryFailoverStreamSkipsRateLimitedTargets(t *testing.T) {
 		return io.NopCloser(strings.NewReader("data")), "anthropic", "claude", nil
 	}
 
-	stream, _, _, _, failoverModel, err := tryFailoverStream(context.Background(), o, workflow, "openai/gpt-4o", "openai", primaryErr, call)
+	stream, meta, err := tryFailoverStream(context.Background(), o, workflow, "openai/gpt-4o", "openai", primaryErr, call)
 
 	if len(attempted) != 1 || attempted[0] != "anthropic/claude" {
 		t.Fatalf("attempted = %v, want only anthropic/claude (rate-limited target skipped)", attempted)
 	}
-	if err != nil || stream == nil || failoverModel != "anthropic/claude" {
-		t.Fatalf("failover result = (stream:%v model:%q err:%v), want anthropic success", stream != nil, failoverModel, err)
+	if err != nil || stream == nil || meta.FailoverModel != "anthropic/claude" {
+		t.Fatalf("failover result = (stream:%v model:%q err:%v), want anthropic success", stream != nil, meta.FailoverModel, err)
 	}
 	stream.Close()
 }
@@ -158,7 +158,7 @@ func TestTryFailoverStreamSkipsWhenContextCanceled(t *testing.T) {
 		return nil, "", "", core.NewProviderError("openai", http.StatusBadGateway, "unexpected failover call", nil)
 	}
 
-	stream, _, _, _, _, err := tryFailoverStream(ctx, o, workflow, "openai/gpt-4o", "openai", primaryErr, call)
+	stream, _, err := tryFailoverStream(ctx, o, workflow, "openai/gpt-4o", "openai", primaryErr, call)
 
 	if called {
 		t.Fatal("tryFailoverStream invoked a failover provider on a canceled context; it must short-circuit")
@@ -228,7 +228,7 @@ func TestExecuteTranslatedSkipsSaturatedPrimaryAndFailsOver(t *testing.T) {
 	ctx := core.WithPrimaryRouteSaturated(context.Background(), saturated)
 
 	var calls []string
-	resp, _, _, failoverModel, didFailover, err := executeTranslatedWithFailover(
+	resp, meta, err := executeTranslatedWithFailover(
 		ctx, o, workflow, "req", "openai/gpt-4o", "openai",
 		func(req string, selector core.ModelSelector) string { return selector.QualifiedModel() },
 		func(_ context.Context, req string) (string, string, error) {
@@ -243,8 +243,8 @@ func TestExecuteTranslatedSkipsSaturatedPrimaryAndFailsOver(t *testing.T) {
 	if len(calls) != 1 || calls[0] != "openai/gpt-5" {
 		t.Fatalf("provider calls = %v, want only the failover target", calls)
 	}
-	if !didFailover || err != nil || resp != "ok" || failoverModel != "openai/gpt-5" {
-		t.Fatalf("result = (resp:%q model:%q didFailover:%v err:%v), want failover success", resp, failoverModel, didFailover, err)
+	if !meta.UsedFailover || err != nil || resp != "ok" || meta.FailoverModel != "openai/gpt-5" {
+		t.Fatalf("result = (resp:%q model:%q didFailover:%v err:%v), want failover success", resp, meta.FailoverModel, meta.UsedFailover, err)
 	}
 }
 
@@ -256,7 +256,7 @@ func TestExecuteTranslatedSaturatedPrimarySurfaces429WhenNoTargetRemains(t *test
 	saturated := core.NewRateLimitError("ratelimit", "rate limit exceeded for provider openai").WithCode("rate_limit_exceeded")
 	ctx := core.WithPrimaryRouteSaturated(context.Background(), saturated)
 
-	_, _, _, _, didFailover, err := executeTranslatedWithFailover(
+	_, meta, err := executeTranslatedWithFailover(
 		ctx, o, workflow, "req", "openai/gpt-4o", "openai",
 		func(req string, selector core.ModelSelector) string { return selector.QualifiedModel() },
 		func(_ context.Context, _ string) (string, string, error) {
@@ -265,7 +265,7 @@ func TestExecuteTranslatedSaturatedPrimarySurfaces429WhenNoTargetRemains(t *test
 		},
 	)
 
-	if didFailover {
+	if meta.UsedFailover {
 		t.Fatal("didFailover = true, want false")
 	}
 	var gatewayErr *core.GatewayError
@@ -281,7 +281,7 @@ func TestStreamTranslatedSkipsSaturatedPrimaryAndFailsOver(t *testing.T) {
 	ctx := core.WithPrimaryRouteSaturated(context.Background(), saturated)
 
 	var calls []string
-	stream, _, _, _, failoverModel, usedFailover, err := streamTranslatedProviderRequest(
+	stream, meta, err := streamTranslatedProviderRequest(
 		o, ctx, workflow, "req", "openai/gpt-4o", "openai",
 		"openai", "openai", "gpt-4o",
 		func(req string, selector core.ModelSelector) string { return selector.QualifiedModel() },
@@ -297,8 +297,8 @@ func TestStreamTranslatedSkipsSaturatedPrimaryAndFailsOver(t *testing.T) {
 	if len(calls) != 1 || calls[0] != "openai/gpt-5" {
 		t.Fatalf("provider calls = %v, want only the failover target", calls)
 	}
-	if err != nil || stream == nil || !usedFailover || failoverModel != "openai/gpt-5" {
-		t.Fatalf("result = (stream:%v model:%q usedFailover:%v err:%v), want failover success", stream != nil, failoverModel, usedFailover, err)
+	if err != nil || stream == nil || !meta.UsedFailover || meta.FailoverModel != "openai/gpt-5" {
+		t.Fatalf("result = (stream:%v model:%q usedFailover:%v err:%v), want failover success", stream != nil, meta.FailoverModel, meta.UsedFailover, err)
 	}
 	stream.Close()
 }

--- a/internal/gateway/inference_execute.go
+++ b/internal/gateway/inference_execute.go
@@ -26,11 +26,11 @@ func (o *InferenceOrchestrator) DispatchChatCompletion(
 	ctx context.Context,
 	workflow *core.Workflow,
 	req *core.ChatRequest,
-) (*core.ChatResponse, string, string, string, bool, error) {
+) (*core.ChatResponse, ExecutionMeta, error) {
 	if err := o.validateProviderAndRequest(req != nil, "chat request is required"); err != nil {
-		return nil, "", "", "", false, err
+		return nil, ExecutionMeta{}, err
 	}
-	return dispatchTranslatedWithSlowdown(ctx, workflow, func() (*core.ChatResponse, string, string, string, bool, error) {
+	return dispatchTranslatedWithSlowdown(ctx, workflow, func() (*core.ChatResponse, ExecutionMeta, error) {
 		return o.executeChatCompletion(ctx, workflow, req)
 	})
 }
@@ -42,7 +42,7 @@ func (o *InferenceOrchestrator) StreamChatCompletion(ctx context.Context, workfl
 	}
 	started := time.Now()
 	streamReq, providerType, providerName, usageModel := o.ResolveChatRoute(workflow, req)
-	stream, resolvedProviderType, resolvedProviderName, resolvedUsageModel, failoverModel, usedFailover, err := o.streamChatCompletion(ctx, workflow, streamReq, providerType, providerName, usageModel)
+	stream, meta, err := o.streamChatCompletion(ctx, workflow, streamReq, providerType, providerName, usageModel)
 	if err != nil {
 		return nil, err
 	}
@@ -50,13 +50,7 @@ func (o *InferenceOrchestrator) StreamChatCompletion(ctx context.Context, workfl
 		Stream:           stream,
 		slowdownFactor:   workflowSlowdown(workflow),
 		inferenceStarted: started,
-		Meta: ExecutionMeta{
-			ProviderType:  resolvedProviderType,
-			ProviderName:  resolvedProviderName,
-			Model:         resolvedUsageModel,
-			FailoverModel: failoverModel,
-			UsedFailover:  usedFailover,
-		},
+		Meta:             meta,
 	}, nil
 }
 
@@ -75,11 +69,11 @@ func (o *InferenceOrchestrator) DispatchResponses(
 	ctx context.Context,
 	workflow *core.Workflow,
 	req *core.ResponsesRequest,
-) (*core.ResponsesResponse, string, string, string, bool, error) {
+) (*core.ResponsesResponse, ExecutionMeta, error) {
 	if err := o.validateProviderAndRequest(req != nil, "responses request is required"); err != nil {
-		return nil, "", "", "", false, err
+		return nil, ExecutionMeta{}, err
 	}
-	return dispatchTranslatedWithSlowdown(ctx, workflow, func() (*core.ResponsesResponse, string, string, string, bool, error) {
+	return dispatchTranslatedWithSlowdown(ctx, workflow, func() (*core.ResponsesResponse, ExecutionMeta, error) {
 		return o.executeResponses(ctx, workflow, req)
 	})
 }
@@ -94,7 +88,7 @@ func (o *InferenceOrchestrator) StreamResponses(ctx context.Context, workflow *c
 	if (workflow == nil || workflow.UsageEnabled()) && o.ShouldEnforceReturningUsageData() {
 		ctx = core.WithEnforceReturningUsageData(ctx, true)
 	}
-	stream, resolvedProviderType, resolvedProviderName, resolvedUsageModel, failoverModel, usedFailover, err := o.streamResponses(ctx, workflow, req, providerType, providerName, usageModel)
+	stream, meta, err := o.streamResponses(ctx, workflow, req, providerType, providerName, usageModel)
 	if err != nil {
 		return nil, err
 	}
@@ -102,13 +96,7 @@ func (o *InferenceOrchestrator) StreamResponses(ctx context.Context, workflow *c
 		Stream:           stream,
 		slowdownFactor:   workflowSlowdown(workflow),
 		inferenceStarted: started,
-		Meta: ExecutionMeta{
-			ProviderType:  resolvedProviderType,
-			ProviderName:  resolvedProviderName,
-			Model:         resolvedUsageModel,
-			FailoverModel: failoverModel,
-			UsedFailover:  usedFailover,
-		},
+		Meta:             meta,
 	}, nil
 }
 
@@ -246,9 +234,9 @@ func (o *InferenceOrchestrator) executeChatCompletion(
 	ctx context.Context,
 	workflow *core.Workflow,
 	req *core.ChatRequest,
-) (*core.ChatResponse, string, string, string, bool, error) {
+) (*core.ChatResponse, ExecutionMeta, error) {
 	if err := o.validateProviderAndRequest(req != nil, "chat request is required"); err != nil {
-		return nil, "", "", "", false, err
+		return nil, ExecutionMeta{}, err
 	}
 	return executeTranslatedProviderRequest(o, ctx, workflow, req, req.Model, req.Provider, CloneChatRequestForSelector, o.chatCompletionProviderCall, chatResponseProvider)
 }
@@ -258,9 +246,9 @@ func (o *InferenceOrchestrator) streamChatCompletion(
 	workflow *core.Workflow,
 	req *core.ChatRequest,
 	providerType, providerName, usageModel string,
-) (io.ReadCloser, string, string, string, string, bool, error) {
+) (io.ReadCloser, ExecutionMeta, error) {
 	if err := o.validateProviderAndRequest(req != nil, "chat request is required"); err != nil {
-		return nil, "", "", "", "", false, err
+		return nil, ExecutionMeta{}, err
 	}
 	return streamTranslatedProviderRequest(o, ctx, workflow, req, req.Model, req.Provider, providerType, providerName, usageModel, CloneChatRequestForSelector, o.streamChatCompletionProviderCall)
 }
@@ -269,9 +257,9 @@ func (o *InferenceOrchestrator) executeResponses(
 	ctx context.Context,
 	workflow *core.Workflow,
 	req *core.ResponsesRequest,
-) (*core.ResponsesResponse, string, string, string, bool, error) {
+) (*core.ResponsesResponse, ExecutionMeta, error) {
 	if err := o.validateProviderAndRequest(req != nil, "responses request is required"); err != nil {
-		return nil, "", "", "", false, err
+		return nil, ExecutionMeta{}, err
 	}
 	return executeTranslatedProviderRequest(o, ctx, workflow, req, req.Model, req.Provider, CloneResponsesRequestForSelector, o.responsesProviderCall, responsesResponseProvider)
 }
@@ -281,15 +269,15 @@ func (o *InferenceOrchestrator) streamResponses(
 	workflow *core.Workflow,
 	req *core.ResponsesRequest,
 	providerType, providerName, usageModel string,
-) (io.ReadCloser, string, string, string, string, bool, error) {
+) (io.ReadCloser, ExecutionMeta, error) {
 	if err := o.validateProviderAndRequest(req != nil, "responses request is required"); err != nil {
-		return nil, "", "", "", "", false, err
+		return nil, ExecutionMeta{}, err
 	}
 	return streamTranslatedProviderRequest(o, ctx, workflow, req, req.Model, req.Provider, providerType, providerName, usageModel, CloneResponsesRequestForSelector, o.streamResponsesProviderCall)
 }
 
 type translatedExecutionSpec[Req any, Resp any, Result any] struct {
-	execute func(*InferenceOrchestrator, context.Context, *core.Workflow, Req) (Resp, string, string, string, bool, error)
+	execute func(*InferenceOrchestrator, context.Context, *core.Workflow, Req) (Resp, ExecutionMeta, error)
 	model   func(Resp) string
 	request func(Req) string
 	usage   func(Resp, string, string, string, *core.ModelPricing) *usage.UsageEntry
@@ -297,7 +285,7 @@ type translatedExecutionSpec[Req any, Resp any, Result any] struct {
 }
 
 var chatExecutionSpec = translatedExecutionSpec[*core.ChatRequest, *core.ChatResponse, *ChatCompletionResult]{
-	execute: executeChatCompletionRequest,
+	execute: (*InferenceOrchestrator).executeChatCompletion,
 	model:   chatResponseModel,
 	request: chatRequestModel,
 	usage: func(resp *core.ChatResponse, requestID, providerType, endpoint string, pricing *core.ModelPricing) *usage.UsageEntry {
@@ -309,7 +297,7 @@ var chatExecutionSpec = translatedExecutionSpec[*core.ChatRequest, *core.ChatRes
 }
 
 var responsesExecutionSpec = translatedExecutionSpec[*core.ResponsesRequest, *core.ResponsesResponse, *ResponsesResult]{
-	execute: executeResponsesRequest,
+	execute: (*InferenceOrchestrator).executeResponses,
 	model:   responsesResponseModel,
 	request: responsesRequestModel,
 	usage: func(resp *core.ResponsesResponse, requestID, providerType, endpoint string, pricing *core.ModelPricing) *usage.UsageEntry {
@@ -329,7 +317,7 @@ func executeTranslatedResult[Req any, Resp any, Result any](
 	spec translatedExecutionSpec[Req, Resp, Result],
 ) (Result, error) {
 	resp, meta, err := executeWithUsage(o, ctx, workflow,
-		func() (Resp, string, string, string, bool, error) {
+		func() (Resp, ExecutionMeta, error) {
 			return spec.execute(o, ctx, workflow, req)
 		},
 		requestModel(req, spec.request),
@@ -349,28 +337,22 @@ func executeWithUsage[Resp any](
 	o *InferenceOrchestrator,
 	ctx context.Context,
 	workflow *core.Workflow,
-	execute func() (Resp, string, string, string, bool, error),
+	execute func() (Resp, ExecutionMeta, error),
 	requestedModel string,
 	modelFromResponse func(Resp) string,
 	entry func(Resp, string, *core.ModelPricing) *usage.UsageEntry,
 ) (Resp, ExecutionMeta, error) {
-	resp, providerType, providerName, failoverModel, usedFailover, err := execute()
+	resp, meta, err := execute()
 	if err != nil {
 		var zero Resp
 		return zero, ExecutionMeta{}, err
 	}
-	model := modelFromResponse(resp)
-	pricingModel := usagePricingModel(workflow, requestedModel, failoverModel, model)
-	o.logUsage(ctx, workflow, pricingModel, providerType, providerName, func(pricing *core.ModelPricing) *usage.UsageEntry {
-		return entry(resp, providerType, pricing)
+	meta.Model = modelFromResponse(resp)
+	pricingModel := usagePricingModel(workflow, requestedModel, meta.FailoverModel, meta.Model)
+	o.logUsage(ctx, workflow, pricingModel, meta.ProviderType, meta.ProviderName, func(pricing *core.ModelPricing) *usage.UsageEntry {
+		return entry(resp, meta.ProviderType, pricing)
 	})
-	return resp, ExecutionMeta{
-		ProviderType:  providerType,
-		ProviderName:  providerName,
-		Model:         model,
-		FailoverModel: failoverModel,
-		UsedFailover:  usedFailover,
-	}, nil
+	return resp, meta, nil
 }
 
 func requestModel[Req any](req Req, model func(Req) string) string {
@@ -401,7 +383,7 @@ func executeTranslatedProviderRequest[Req any, Resp any](
 	cloneForSelector func(Req, core.ModelSelector) Req,
 	call func(context.Context, Req) (Resp, error),
 	responseProvider func(Resp) string,
-) (Resp, string, string, string, bool, error) {
+) (Resp, ExecutionMeta, error) {
 	return executeTranslatedWithFailover(ctx, o, workflow, req, model, provider, cloneForSelector,
 		func(ctx context.Context, req Req) (Resp, string, error) {
 			resp, err := call(ctx, req)
@@ -423,7 +405,7 @@ func streamTranslatedProviderRequest[Req any](
 	providerType, providerName, usageModel string,
 	cloneForSelector func(Req, core.ModelSelector) Req,
 	call func(context.Context, Req) (io.ReadCloser, error),
-) (io.ReadCloser, string, string, string, string, bool, error) {
+) (io.ReadCloser, ExecutionMeta, error) {
 	started := time.Now()
 	var stream io.ReadCloser
 	// See executeTranslatedWithFailover: a rate-saturated primary route skips
@@ -433,7 +415,7 @@ func streamTranslatedProviderRequest[Req any](
 		stream, err = call(ctx, req)
 		if err == nil && stream != nil {
 			recordProviderAttempt(ctx, providerAttemptFromResult(AttemptKindPrimary, providerType, providerName, currentSelectorForWorkflow(workflow, model, provider), started, nil))
-			return stream, providerType, providerName, usageModel, "", false, nil
+			return stream, ExecutionMeta{ProviderType: providerType, ProviderName: providerName, Model: usageModel}, nil
 		}
 		if err == nil {
 			err = emptyProviderStreamError(providerType)
@@ -441,7 +423,7 @@ func streamTranslatedProviderRequest[Req any](
 	}
 	recordProviderAttempt(ctx, providerAttemptFromResult(AttemptKindPrimary, providerType, providerName, currentSelectorForWorkflow(workflow, model, provider), started, err))
 
-	stream, resolvedProviderType, resolvedProviderName, resolvedUsageModel, failoverModel, err := tryFailoverStream(ctx, o, workflow, model, provider, err,
+	return tryFailoverStream(ctx, o, workflow, model, provider, err,
 		func(selector core.ModelSelector, providerType, providerName string) (io.ReadCloser, string, string, error) {
 			stream, err := call(ctx, cloneForSelector(req, selector))
 			if err != nil {
@@ -453,10 +435,6 @@ func streamTranslatedProviderRequest[Req any](
 			return stream, providerType, selector.Model, nil
 		},
 	)
-	if err != nil {
-		return nil, "", "", "", "", false, err
-	}
-	return stream, resolvedProviderType, resolvedProviderName, resolvedUsageModel, failoverModel, true, nil
 }
 
 func (o *InferenceOrchestrator) validateProviderAndRequest(requestPresent bool, requiredMessage string) *core.GatewayError {
@@ -505,24 +483,6 @@ func emptyProviderResponseError(providerType string) *core.GatewayError {
 
 func emptyProviderStreamError(providerType string) *core.GatewayError {
 	return core.NewProviderError(providerType, http.StatusBadGateway, "provider returned empty stream", nil)
-}
-
-func executeChatCompletionRequest(
-	o *InferenceOrchestrator,
-	ctx context.Context,
-	workflow *core.Workflow,
-	req *core.ChatRequest,
-) (*core.ChatResponse, string, string, string, bool, error) {
-	return o.executeChatCompletion(ctx, workflow, req)
-}
-
-func executeResponsesRequest(
-	o *InferenceOrchestrator,
-	ctx context.Context,
-	workflow *core.Workflow,
-	req *core.ResponsesRequest,
-) (*core.ResponsesResponse, string, string, string, bool, error) {
-	return o.executeResponses(ctx, workflow, req)
 }
 
 func chatResponseModel(resp *core.ChatResponse) string {

--- a/internal/gateway/slowdown.go
+++ b/internal/gateway/slowdown.go
@@ -51,17 +51,17 @@ func executeResultWithSlowdown[Result any](
 func dispatchTranslatedWithSlowdown[Response any](
 	ctx context.Context,
 	workflow *core.Workflow,
-	execute func() (Response, string, string, string, bool, error),
-) (Response, string, string, string, bool, error) {
+	execute func() (Response, ExecutionMeta, error),
+) (Response, ExecutionMeta, error) {
 	started := time.Now()
-	resp, providerType, providerName, failoverModel, usedFailover, err := execute()
+	resp, meta, err := execute()
 	if err != nil {
 		var zero Response
-		return zero, "", "", "", false, err
+		return zero, ExecutionMeta{}, err
 	}
 	if err := waitForInferenceSlowdown(ctx, workflow, time.Since(started)); err != nil {
 		var zero Response
-		return zero, "", "", "", false, err
+		return zero, ExecutionMeta{}, err
 	}
-	return resp, providerType, providerName, failoverModel, usedFailover, nil
+	return resp, meta, nil
 }

--- a/internal/server/internal_chat_completion_executor.go
+++ b/internal/server/internal_chat_completion_executor.go
@@ -89,11 +89,9 @@ func (e *InternalChatCompletionExecutor) ChatCompletion(ctx context.Context, req
 	entry := e.newAuditEntry(ctx, requestID, requested)
 	var workflow *core.Workflow
 	var cacheType string
-	var providerType string
-	var providerName string
-	var failoverModel string
+	var meta gateway.ExecutionMeta
 	defer func() {
-		e.finishAuditEntry(ctx, entry, start, workflow, req, resp, err, cacheType, providerType, providerName, failoverModel)
+		e.finishAuditEntry(ctx, entry, start, workflow, req, resp, err, cacheType, meta)
 	}()
 
 	resolution, err := resolveRequestModelWithAuthorizer(ctx, e.provider, e.modelResolver, e.modelAuthorizer, requested)
@@ -113,24 +111,26 @@ func (e *InternalChatCompletionExecutor) ChatCompletion(ctx context.Context, req
 
 	ctx = e.orchestrator.WithCacheRequestContext(ctx, workflow)
 	execReq := gateway.CloneChatRequestForSelector(req, resolution.ResolvedSelector)
-	resp, providerType, providerName, failoverModel, _, cacheType, err = e.executeChatCompletion(ctx, workflow, execReq)
+	resp, meta, cacheType, err = e.executeChatCompletion(ctx, workflow, execReq)
 	if err != nil {
 		return nil, err
 	}
 
 	if cacheType == "" {
-		e.orchestrator.LogUsage(ctx, workflow, resp.Model, providerType, providerName, func(pricing *core.ModelPricing) *usage.UsageEntry {
-			return usage.ExtractFromChatResponse(resp, requestID, providerType, "/v1/chat/completions", pricing)
+		e.orchestrator.LogUsage(ctx, workflow, resp.Model, meta.ProviderType, meta.ProviderName, func(pricing *core.ModelPricing) *usage.UsageEntry {
+			return usage.ExtractFromChatResponse(resp, requestID, meta.ProviderType, "/v1/chat/completions", pricing)
 		})
 	}
 	return resp, nil
 }
 
+// executeChatCompletion dispatches through the response cache when one is
+// configured. The returned cache type is empty for a provider round trip.
 func (e *InternalChatCompletionExecutor) executeChatCompletion(
 	ctx context.Context,
 	workflow *core.Workflow,
 	req *core.ChatRequest,
-) (*core.ChatResponse, string, string, string, bool, string, error) {
+) (*core.ChatResponse, gateway.ExecutionMeta, string, error) {
 	if e.responseCache == nil || (workflow != nil && !workflow.CacheEnabled()) {
 		return e.dispatchChatCompletionNoCache(ctx, workflow, req)
 	}
@@ -142,15 +142,12 @@ func (e *InternalChatCompletionExecutor) executeChatCompletion(
 	}
 
 	var (
-		resp          *core.ChatResponse
-		providerType  string
-		providerName  string
-		failoverModel string
-		usedFailover  bool
+		resp *core.ChatResponse
+		meta gateway.ExecutionMeta
 	)
 	result, err := e.responseCache.HandleInternalRequest(ctx, http.MethodPost, "/v1/chat/completions", body, func(callCtx context.Context) (*responsecache.InternalResponse, error) {
 		var execErr error
-		resp, providerType, providerName, failoverModel, usedFailover, execErr = e.orchestrator.DispatchChatCompletion(callCtx, workflow, req)
+		resp, meta, execErr = e.orchestrator.DispatchChatCompletion(callCtx, workflow, req)
 		if execErr != nil {
 			return nil, execErr
 		}
@@ -162,35 +159,34 @@ func (e *InternalChatCompletionExecutor) executeChatCompletion(
 			StatusCode:   http.StatusOK,
 			ContentType:  "application/json",
 			Body:         respBody,
-			FailoverUsed: usedFailover,
+			FailoverUsed: meta.UsedFailover,
 		}, nil
 	})
 	if err != nil {
-		return nil, "", "", "", false, "", err
+		return nil, gateway.ExecutionMeta{}, "", err
 	}
 	if result != nil && result.CacheType != "" {
 		var cached core.ChatResponse
 		if err := json.Unmarshal(result.Body, &cached); err != nil {
-			return nil, "", "", "", false, "", err
+			return nil, gateway.ExecutionMeta{}, "", err
 		}
-		cachedProviderType := ""
-		cachedProviderName := ""
+		cachedMeta := gateway.ExecutionMeta{}
 		if workflow != nil {
-			cachedProviderType = workflow.ProviderType
-			cachedProviderName = gateway.ProviderNameFromWorkflow(workflow)
+			cachedMeta.ProviderType = workflow.ProviderType
+			cachedMeta.ProviderName = gateway.ProviderNameFromWorkflow(workflow)
 		}
-		return &cached, cachedProviderType, cachedProviderName, "", false, result.CacheType, nil
+		return &cached, cachedMeta, result.CacheType, nil
 	}
-	return resp, providerType, providerName, failoverModel, usedFailover, "", nil
+	return resp, meta, "", nil
 }
 
 func (e *InternalChatCompletionExecutor) dispatchChatCompletionNoCache(
 	ctx context.Context,
 	workflow *core.Workflow,
 	req *core.ChatRequest,
-) (*core.ChatResponse, string, string, string, bool, string, error) {
-	resp, providerType, providerName, failoverModel, usedFailover, err := e.orchestrator.DispatchChatCompletion(ctx, workflow, req)
-	return resp, providerType, providerName, failoverModel, usedFailover, "", err
+) (*core.ChatResponse, gateway.ExecutionMeta, string, error) {
+	resp, meta, err := e.orchestrator.DispatchChatCompletion(ctx, workflow, req)
+	return resp, meta, "", err
 }
 
 func (e *InternalChatCompletionExecutor) newAuditEntry(
@@ -232,9 +228,7 @@ func (e *InternalChatCompletionExecutor) finishAuditEntry(
 	resp *core.ChatResponse,
 	err error,
 	cacheType string,
-	providerType string,
-	providerName string,
-	failoverModel string,
+	meta gateway.ExecutionMeta,
 ) {
 	if entry == nil || e.logger == nil || !e.logger.Config().Enabled {
 		return
@@ -242,9 +236,9 @@ func (e *InternalChatCompletionExecutor) finishAuditEntry(
 
 	entry.DurationNs = time.Since(start).Nanoseconds()
 	auditlog.EnrichLogEntryWithWorkflow(entry, workflow)
-	auditlog.EnrichLogEntryWithFailover(entry, failoverModel)
+	auditlog.EnrichLogEntryWithFailover(entry, meta.FailoverModel)
 	auditlog.EnrichLogEntryWithAttempts(entry, auditlog.GateAttemptCapture(auditAttemptsFromGateway(ctx), e.logger.Config()))
-	auditlog.EnrichLogEntryWithResolvedRoute(entry, qualifyExecutedModel(workflow, chatResponseModel(resp), providerName), providerType, providerName)
+	auditlog.EnrichLogEntryWithResolvedRoute(entry, qualifyExecutedModel(workflow, chatResponseModel(resp), meta.ProviderName), meta.ProviderType, meta.ProviderName)
 	auditlog.EnrichLogEntryWithRequestContext(entry, ctx)
 	if workflow != nil && !workflow.AuditEnabled() {
 		return

--- a/internal/server/internal_chat_completion_executor_test.go
+++ b/internal/server/internal_chat_completion_executor_test.go
@@ -388,7 +388,7 @@ func TestInternalChatCompletionExecutor_CachedNilWorkflowDoesNotPanic(t *testing
 		},
 	}
 
-	_, _, _, _, _, cacheType, err := executor.executeChatCompletion(context.Background(), nil, req)
+	_, _, cacheType, err := executor.executeChatCompletion(context.Background(), nil, req)
 	if err != nil {
 		t.Fatalf("first executeChatCompletion() error = %v", err)
 	}
@@ -399,7 +399,7 @@ func TestInternalChatCompletionExecutor_CachedNilWorkflowDoesNotPanic(t *testing
 		t.Fatalf("ResponseCacheMiddleware.Close() error = %v", err)
 	}
 
-	resp, providerType, providerName, _, _, cacheType, err := executor.executeChatCompletion(context.Background(), nil, req)
+	resp, meta, cacheType, err := executor.executeChatCompletion(context.Background(), nil, req)
 	if err != nil {
 		t.Fatalf("cached executeChatCompletion() error = %v", err)
 	}
@@ -409,11 +409,11 @@ func TestInternalChatCompletionExecutor_CachedNilWorkflowDoesNotPanic(t *testing
 	if resp == nil || resp.ID != "chatcmpl-internal-cache-nil-workflow" {
 		t.Fatalf("resp = %#v, want cached provider response", resp)
 	}
-	if providerType != "" {
-		t.Fatalf("providerType = %q, want empty for nil workflow cache hit", providerType)
+	if meta.ProviderType != "" {
+		t.Fatalf("meta.ProviderType = %q, want empty for nil workflow cache hit", meta.ProviderType)
 	}
-	if providerName != "" {
-		t.Fatalf("providerName = %q, want empty for nil workflow cache hit", providerName)
+	if meta.ProviderName != "" {
+		t.Fatalf("meta.ProviderName = %q, want empty for nil workflow cache hit", meta.ProviderName)
 	}
 	if cacheType != responsecache.CacheTypeExact {
 		t.Fatalf("cacheType = %q, want %q", cacheType, responsecache.CacheTypeExact)

--- a/internal/server/messages_handler.go
+++ b/internal/server/messages_handler.go
@@ -209,20 +209,10 @@ func (s *translatedInferenceService) dispatchMessages(c *echo.Context, req *core
 		if result.Meta.UsedFailover {
 			markRequestFailoverUsed(c)
 		}
-		model := result.Meta.Model
-		return s.handleStreamingReadCloser(
-			c,
-			workflow,
-			model,
-			result.Meta.ProviderType,
-			result.Meta.ProviderName,
-			result.Meta.FailoverModel,
-			result.Stream,
-			func(stream io.ReadCloser) io.ReadCloser {
-				converted := anthropicapi.NewStreamConverter(stream, model, anthropicapi.EstimateChatInputTokens(req))
-				return result.WrapDeliveryStream(ctx, converted)
-			},
-		)
+		return s.handleStreamingReadCloser(c, workflow, result.Meta, result.Stream, func(stream io.ReadCloser) io.ReadCloser {
+			converted := anthropicapi.NewStreamConverter(stream, result.Meta.Model, anthropicapi.EstimateChatInputTokens(req))
+			return result.WrapDeliveryStream(ctx, converted)
+		})
 	}
 
 	result, err := s.inference().ExecuteChatCompletion(ctx, workflow, req, requestID, "/v1/messages")

--- a/internal/server/seams_test.go
+++ b/internal/server/seams_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/enterpilot/gomodel/internal/auditlog"
 	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/gateway"
 	"github.com/enterpilot/gomodel/internal/usage"
 )
 
@@ -86,5 +87,6 @@ func (s *translatedInferenceService) handleStreamingResponse(
 	if err != nil {
 		return handleStreamingDispatchError(c, err)
 	}
-	return s.handleStreamingReadCloser(c, workflow, model, provider, providerName, "", stream, nil)
+	meta := gateway.ExecutionMeta{Model: model, ProviderType: provider, ProviderName: providerName}
+	return s.handleStreamingReadCloser(c, workflow, meta, stream, nil)
 }

--- a/internal/server/stream_slowdown_test.go
+++ b/internal/server/stream_slowdown_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/labstack/echo/v5"
 
+	"github.com/enterpilot/gomodel/internal/gateway"
 	"github.com/enterpilot/gomodel/internal/streaming"
 	"github.com/enterpilot/gomodel/internal/usage"
 )
@@ -48,7 +49,7 @@ func TestSlowedStreamRecordsUsageConsumedBeforeClientCancellation(t *testing.T) 
 			done := make(chan struct{})
 			go func() {
 				_ = handler.translatedInference().handleStreamingReadCloser(
-					c, nil, "gpt-4o", "openai", "primary-openai", "", source,
+					c, nil, gateway.ExecutionMeta{Model: "gpt-4o", ProviderType: "openai", ProviderName: "primary-openai"}, source,
 					func(observed io.ReadCloser) io.ReadCloser {
 						return streaming.NewSlowdownStream(ctx, observed, 10, time.Now().Add(-time.Second))
 					},

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -137,18 +137,9 @@ func (s *translatedInferenceService) dispatchChatCompletion(c *echo.Context, req
 		if result.Meta.UsedFailover {
 			markRequestFailoverUsed(c)
 		}
-		return s.handleStreamingReadCloser(
-			c,
-			workflow,
-			result.Meta.Model,
-			result.Meta.ProviderType,
-			result.Meta.ProviderName,
-			result.Meta.FailoverModel,
-			result.Stream,
-			func(stream io.ReadCloser) io.ReadCloser {
-				return result.WrapDeliveryStream(ctx, stream)
-			},
-		)
+		return s.handleStreamingReadCloser(c, workflow, result.Meta, result.Stream, func(stream io.ReadCloser) io.ReadCloser {
+			return result.WrapDeliveryStream(ctx, stream)
+		})
 	}
 
 	result, err := s.inference().ExecuteChatCompletion(ctx, workflow, req, requestID, "/v1/chat/completions")
@@ -317,18 +308,9 @@ func (s *translatedInferenceService) dispatchResponses(c *echo.Context, req *cor
 		if turn := conversationTurnFromContext(ctx); turn != nil {
 			stream = turn.persistingStream(ctx, stream)
 		}
-		return s.handleStreamingReadCloser(
-			c,
-			workflow,
-			result.Meta.Model,
-			result.Meta.ProviderType,
-			result.Meta.ProviderName,
-			result.Meta.FailoverModel,
-			stream,
-			func(stream io.ReadCloser) io.ReadCloser {
-				return result.WrapDeliveryStream(ctx, stream)
-			},
-		)
+		return s.handleStreamingReadCloser(c, workflow, result.Meta, stream, func(stream io.ReadCloser) io.ReadCloser {
+			return result.WrapDeliveryStream(ctx, stream)
+		})
 	}
 
 	result, err := s.inference().ExecuteResponses(ctx, workflow, req, requestID, "/v1/responses")
@@ -631,15 +613,15 @@ func cacheWorkflowResolutionHints(c *echo.Context, workflow *core.Workflow) {
 func (s *translatedInferenceService) handleStreamingReadCloser(
 	c *echo.Context,
 	workflow *core.Workflow,
-	model, provider, providerName string,
-	failoverModel string,
+	meta gateway.ExecutionMeta,
 	stream io.ReadCloser,
 	outerWrap func(io.ReadCloser) io.ReadCloser,
 ) error {
+	model, provider, providerName := meta.Model, meta.ProviderType, meta.ProviderName
 	auditlog.MarkEntryAsStreaming(c, true)
 	auditlog.EnrichEntryWithStream(c, true)
 	enrichAuditEntryWithProviderAttempts(c)
-	auditlog.EnrichEntryWithFailover(c, failoverModel)
+	auditlog.EnrichEntryWithFailover(c, meta.FailoverModel)
 	auditlog.EnrichEntryWithResolvedRoute(c, qualifyExecutedModel(workflow, model, providerName), provider, providerName)
 
 	entry := auditlog.GetStreamEntryFromContext(c)


### PR DESCRIPTION
Stacked on #840.

Replaces the positional `(resp, providerType, providerName, failoverModel, usedFailover, error)` and streaming `(stream, providerType, providerName, model, failoverModel, usedFailover, error)` returns in `internal/gateway` with the existing `ExecutionMeta` struct. 14 signatures change: `tryFailoverResponse`, `executeWithFailoverResponse`, `executeTranslatedWithFailover`, `tryFailoverStream`, `executeTranslatedProviderRequest`, `streamTranslatedProviderRequest`, `dispatchTranslatedWithSlowdown`, `executeWithUsage`, `translatedExecutionSpec.execute`, the four private `execute*`/`stream*` methods, and the public `DispatchChatCompletion`/`DispatchResponses`.

- `handleStreamingReadCloser` takes `gateway.ExecutionMeta` instead of four separate route strings; its three callers pass `result.Meta` directly.
- The internal chat executor's `executeChatCompletion`/`dispatchChatCompletionNoCache`/`finishAuditEntry` carry the same struct instead of three loose strings.
- `executeChatCompletionRequest`/`executeResponsesRequest` adapters removed; the spec tables use method expressions.
- `Stream*` orchestrator methods no longer rebuild `ExecutionMeta` field by field.

No behavior change. Net -60 lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated provider, model, and failover details into unified execution metadata across chat completions, responses, streaming, failover, and slowdown handling.
  * Updated streaming and audit processing to consume consolidated execution metadata.
  * Simplified internal execution result handling while preserving failover status, provider details, model information, and usage reporting.

* **Tests**
  * Updated gateway and server tests to validate the consolidated execution metadata and revised result handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->