### PR TITLE
fix(llmclient): stop the retry backoff timer when the context is cancelled

### DIFF
--- a/internal/llmclient/client_scope.go
+++ b/internal/llmclient/client_scope.go
@@ -250,11 +250,14 @@ func (c *Client) waitForRetry(ctx context.Context, attempt int) error {
 	if attempt <= 0 {
 		return nil
 	}
-	backoff := c.calculateBackoff(attempt)
+	// A stopped timer releases its resources immediately; time.After would
+	// keep the timer alive until it fires even after the context is cancelled.
+	timer := time.NewTimer(c.calculateBackoff(attempt))
+	defer timer.Stop()
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-time.After(backoff):
+	case <-timer.C:
 		return nil
 	}
 }

--- a/internal/llmclient/client_test.go
+++ b/internal/llmclient/client_test.go
@@ -2046,6 +2046,46 @@ func TestBackoffCalculation_WithJitter(t *testing.T) {
 	}
 }
 
+// TestWaitForRetry_ContextCancelled checks that cancelling the context during
+// a long backoff returns ctx.Err() promptly instead of waiting out the timer.
+func TestWaitForRetry_ContextCancelled(t *testing.T) {
+	config := DefaultConfig("test", "http://test.com")
+	config.Retry.InitialBackoff = time.Hour
+	config.Retry.MaxBackoff = time.Hour
+	config.Retry.JitterFactor = 0
+	client := New(config, nil)
+
+	tests := []struct {
+		name    string
+		attempt int
+		cancel  bool
+		want    error
+	}{
+		{name: "first attempt does not wait", attempt: 0, cancel: false, want: nil},
+		{name: "cancelled during backoff", attempt: 1, cancel: true, want: context.Canceled},
+		{name: "already cancelled", attempt: 3, cancel: true, want: context.Canceled},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if tt.cancel {
+				cancel()
+			}
+
+			start := time.Now()
+			err := client.waitForRetry(ctx, tt.attempt)
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("waitForRetry() error = %v, want %v", err, tt.want)
+			}
+			if elapsed := time.Since(start); elapsed > time.Second {
+				t.Fatalf("waitForRetry() took %v, expected a prompt return", elapsed)
+			}
+		})
+	}
+}
+
 type recordingReadCloser struct {
 	io.Reader
 	closed atomic.Bool

--- a/internal/llmclient/client_test.go
+++ b/internal/llmclient/client_test.go
@@ -2046,8 +2046,11 @@ func TestBackoffCalculation_WithJitter(t *testing.T) {
 	}
 }
 
-// TestWaitForRetry_ContextCancelled checks that cancelling the context during
-// a long backoff returns ctx.Err() promptly instead of waiting out the timer.
+// TestWaitForRetry_ContextCancelled checks that cancelling the context returns
+// ctx.Err() promptly instead of waiting out the backoff timer. The "cancelled
+// while the timer is pending" case cancels from a goroutine after
+// waitForRetry has started blocking, so a precheck-then-time.After
+// implementation would not pass it.
 func TestWaitForRetry_ContextCancelled(t *testing.T) {
 	config := DefaultConfig("test", "http://test.com")
 	config.Retry.InitialBackoff = time.Hour
@@ -2058,29 +2061,35 @@ func TestWaitForRetry_ContextCancelled(t *testing.T) {
 	tests := []struct {
 		name    string
 		attempt int
-		cancel  bool
-		want    error
+		// cancelAfter is the delay before the context is cancelled from a
+		// separate goroutine; a negative value cancels before the call.
+		cancelAfter time.Duration
+		want        error
 	}{
-		{name: "first attempt does not wait", attempt: 0, cancel: false, want: nil},
-		{name: "cancelled during backoff", attempt: 1, cancel: true, want: context.Canceled},
-		{name: "already cancelled", attempt: 3, cancel: true, want: context.Canceled},
+		{name: "first attempt does not wait", attempt: 0, cancelAfter: time.Hour, want: nil},
+		{name: "cancelled while the timer is pending", attempt: 1, cancelAfter: 20 * time.Millisecond, want: context.Canceled},
+		{name: "already cancelled", attempt: 3, cancelAfter: -1, want: context.Canceled},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			if tt.cancel {
+			if tt.cancelAfter < 0 {
 				cancel()
+			} else {
+				timer := time.AfterFunc(tt.cancelAfter, cancel)
+				defer timer.Stop()
 			}
 
 			start := time.Now()
 			err := client.waitForRetry(ctx, tt.attempt)
+			elapsed := time.Since(start)
 			if !errors.Is(err, tt.want) {
 				t.Fatalf("waitForRetry() error = %v, want %v", err, tt.want)
 			}
-			if elapsed := time.Since(start); elapsed > time.Second {
-				t.Fatalf("waitForRetry() took %v, expected a prompt return", elapsed)
+			if elapsed > time.Second {
+				t.Fatalf("waitForRetry() took %v, expected a return well before the backoff", elapsed)
 			}
 		})
 	}


### PR DESCRIPTION
Stacked on #843 (`refactor/split-large-files`).

`waitForRetry` selected on `ctx.Done()` and `time.After(backoff)`. When the caller cancelled during a backoff, the timer stayed alive until it fired (up to `MaxBackoff`), holding its resources for every abandoned retry. It now uses `time.NewTimer` and stops it on exit; return semantics are unchanged.

This was the only `time.After` in a select on request-scoped code across `internal/`, `ext/`, `run/`, and `cmd/`.

Adds `TestWaitForRetry_ContextCancelled` covering no-wait on the first attempt, cancellation mid-backoff, and an already-cancelled context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cancellation handling during retry delays so cancelled operations return promptly and release timer resources sooner.

- **Tests**
  - Added coverage for cancellation before and during retry backoff, including verification of prompt error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->