### PR TITLE
perf(gateway): fast-path non-streaming chat passthrough without dropping cache planning

### DIFF
--- a/docs/features/cache.mdx
+++ b/docs/features/cache.mdx
@@ -113,6 +113,11 @@ The plan is applied post-routing so provider-only fields cannot leak through a
 fallback to another backend. Cache keys include the concrete provider instance
 and model, and caller-supplied cache controls always win.
 
+Chat requests to OpenAI-compatible providers that need no rewriting are proxied
+byte for byte, streaming or not. A request whose stable prefix qualifies for a
+cache plan always takes the translated path instead, so the plan is never
+skipped in favor of the proxy.
+
 Provider prompt-cache planning is enabled by default. To disable GoModel's
 automatic planning while continuing to pass through compatible client cache
 directives, set:

--- a/docs/features/cache.mdx
+++ b/docs/features/cache.mdx
@@ -114,8 +114,10 @@ fallback to another backend. Cache keys include the concrete provider instance
 and model, and caller-supplied cache controls always win.
 
 Chat requests to OpenAI-compatible providers that need no rewriting are proxied
-byte for byte, streaming or not. A request whose stable prefix qualifies for a
-cache plan always takes the translated path instead, so the plan is never
+without translation, streaming or not. Streaming responses are relayed byte for
+byte; non-streaming JSON responses are relayed with the resolved `provider`
+member set, as on the translated path. A request whose stable prefix qualifies
+for a cache plan always takes the translated path instead, so the plan is never
 skipped in favor of the proxy.
 
 Provider prompt-cache planning is enabled by default. To disable GoModel's

--- a/internal/gateway/chat_fast_path_test.go
+++ b/internal/gateway/chat_fast_path_test.go
@@ -1,0 +1,109 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+func TestTranslatedSelectorRewriteRequired(t *testing.T) {
+	tests := []struct {
+		name       string
+		resolution *core.RequestModelResolution
+		want       bool
+	}{
+		{name: "nil resolution", want: true},
+		{
+			name: "bare model resolved to a configured provider forwards verbatim",
+			resolution: &core.RequestModelResolution{
+				Requested:        core.NewRequestedModelSelector("gpt-4o", ""),
+				ResolvedSelector: core.ModelSelector{Provider: "openai", Model: "gpt-4o"},
+			},
+		},
+		{
+			name: "provider-qualified model is rewritten for the upstream",
+			resolution: &core.RequestModelResolution{
+				Requested:        core.NewRequestedModelSelector("openai/gpt-4o", ""),
+				ResolvedSelector: core.ModelSelector{Provider: "openai", Model: "gpt-4o"},
+			},
+			want: true,
+		},
+		{
+			name: "alias is rewritten",
+			resolution: &core.RequestModelResolution{
+				Requested:        core.NewRequestedModelSelector("fast", ""),
+				ResolvedSelector: core.ModelSelector{Provider: "openai", Model: "gpt-4o-mini"},
+				AliasApplied:     true,
+			},
+			want: true,
+		},
+		{
+			name: "explicit provider hint is stripped by translation",
+			resolution: &core.RequestModelResolution{
+				Requested:        core.NewRequestedModelSelector("gpt-4o", "openai"),
+				ResolvedSelector: core.ModelSelector{Provider: "openai", Model: "gpt-4o"},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := translatedSelectorRewriteRequired(tt.resolution); got != tt.want {
+				t.Fatalf("translatedSelectorRewriteRequired() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type planningProvider struct {
+	core.RoutableProvider
+	applies bool
+}
+
+func (p planningProvider) PromptCachePlanApplies(string, core.ModelSelector, *core.ChatRequest) bool {
+	return p.applies
+}
+
+func TestCanFastPathChatPassthrough(t *testing.T) {
+	workflow := func(providerType, providerHint string) *core.Workflow {
+		return &core.Workflow{
+			ProviderType: providerType,
+			Resolution: &core.RequestModelResolution{
+				Requested:        core.NewRequestedModelSelector("gpt-4o", providerHint),
+				ResolvedSelector: core.ModelSelector{Provider: providerType, Model: "gpt-4o"},
+				ProviderType:     providerType,
+			},
+		}
+	}
+	// Preparation writes the resolved provider into req.Provider before
+	// dispatch, so every prepared request carries one; the gate must key on
+	// the client's original hint instead.
+	prepared := func(providerType string, stream bool) *core.ChatRequest {
+		return &core.ChatRequest{Model: "gpt-4o", Provider: providerType, Stream: stream}
+	}
+	tests := []struct {
+		name         string
+		providerType string
+		providerHint string
+		req          *core.ChatRequest
+		planApplies  bool
+		want         bool
+	}{
+		{name: "non-streaming openai", providerType: "openai", req: prepared("openai", false), want: true},
+		{name: "streaming openai", providerType: "openai", req: prepared("openai", true), want: true},
+		{name: "azure", providerType: "azure", req: prepared("azure", false), want: true},
+		{name: "anthropic never proxied", providerType: "anthropic", req: prepared("anthropic", false)},
+		{name: "planner would apply", providerType: "openai", req: prepared("openai", false), planApplies: true},
+		{name: "client-supplied provider forces translation", providerType: "openai", providerHint: "openai", req: prepared("openai", false)},
+		{name: "o-series with max_tokens forces translation", providerType: "openai", req: &core.ChatRequest{Model: "o3", Provider: "openai", MaxTokens: new(int)}},
+		{name: "nil request", providerType: "openai"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := NewInferenceOrchestrator(InferenceConfig{Provider: planningProvider{applies: tt.planApplies}})
+			if got := o.CanFastPathChatPassthrough(workflow(tt.providerType, tt.providerHint), tt.req); got != tt.want {
+				t.Fatalf("CanFastPathChatPassthrough() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/gateway/inference_execute.go
+++ b/internal/gateway/inference_execute.go
@@ -172,9 +172,20 @@ func (o *InferenceOrchestrator) routeMetadata(workflow *core.Workflow, failoverM
 	return providerType, providerName, model
 }
 
-// CanFastPathStreamingChatPassthrough reports whether a streaming chat request can bypass translation.
-func (o *InferenceOrchestrator) CanFastPathStreamingChatPassthrough(workflow *core.Workflow, req *core.ChatRequest) bool {
-	if req == nil || !req.Stream {
+// chatCachePlanner is implemented by routers that run a prompt-cache planner
+// after routing. The passthrough fast path bypasses routing, so it must decline
+// any request the planner would have annotated.
+type chatCachePlanner interface {
+	PromptCachePlanApplies(providerType string, selector core.ModelSelector, req *core.ChatRequest) bool
+}
+
+// CanFastPathChatPassthrough reports whether a chat request, streaming or not,
+// can bypass translation and be proxied to the provider byte for byte. It
+// declines whenever the translated path would change the outbound request:
+// slowdown, request patching, enforced usage, selector or body rewrites, and
+// prompt-cache planning.
+func (o *InferenceOrchestrator) CanFastPathChatPassthrough(workflow *core.Workflow, req *core.ChatRequest) bool {
+	if req == nil {
 		return false
 	}
 	if workflowSlowdown(workflow) > 0 {
@@ -194,34 +205,42 @@ func (o *InferenceOrchestrator) CanFastPathStreamingChatPassthrough(workflow *co
 		return false
 	}
 
-	if translatedStreamingSelectorRewriteRequired(workflow.Resolution) {
+	if translatedSelectorRewriteRequired(workflow.Resolution) {
 		return false
 	}
-	if translatedStreamingChatBodyRewriteRequired(req) {
+	if translatedChatBodyRewriteRequired(req) {
+		return false
+	}
+	if planner, ok := o.provider.(chatCachePlanner); ok &&
+		planner.PromptCachePlanApplies(providerType, workflow.Resolution.ResolvedSelector, req) {
 		return false
 	}
 
 	return true
 }
 
-func translatedStreamingSelectorRewriteRequired(resolution *core.RequestModelResolution) bool {
-	if resolution == nil {
+// translatedSelectorRewriteRequired reports whether the model string the client
+// sent differs from the one the provider must receive. Only the model travels
+// upstream: translation strips the "provider" field, and a request carrying one
+// is already declined by translatedChatBodyRewriteRequired. The resolved
+// provider name is therefore not compared; a bare "gpt-4o" that resolves to the
+// configured "openai" instance still forwards "gpt-4o" verbatim, while an alias
+// or a provider-qualified "openai/gpt-4o" does not.
+func translatedSelectorRewriteRequired(resolution *core.RequestModelResolution) bool {
+	if resolution == nil || resolution.Requested.ExplicitProvider {
 		return true
 	}
-
-	requestedModel := strings.TrimSpace(resolution.Requested.Model)
-	requestedProvider := strings.TrimSpace(resolution.Requested.ProviderHint)
-	resolvedModel := strings.TrimSpace(resolution.ResolvedSelector.Model)
-	resolvedProvider := strings.TrimSpace(resolution.ResolvedSelector.Provider)
-
-	return requestedModel != resolvedModel || requestedProvider != resolvedProvider
+	return strings.TrimSpace(resolution.Requested.Model) != strings.TrimSpace(resolution.ResolvedSelector.Model)
 }
 
-func translatedStreamingChatBodyRewriteRequired(req *core.ChatRequest) bool {
+// translatedChatBodyRewriteRequired reports whether translation would change a
+// field other than the model selector. req.Provider is not consulted: by the
+// time dispatch runs, preparation has already written the resolved provider
+// into it, so it no longer says whether the client sent one. A client-supplied
+// provider is caught by Requested.ExplicitProvider in
+// translatedSelectorRewriteRequired.
+func translatedChatBodyRewriteRequired(req *core.ChatRequest) bool {
 	if req == nil {
-		return true
-	}
-	if strings.TrimSpace(req.Provider) != "" {
 		return true
 	}
 

--- a/internal/providers/cache_planner.go
+++ b/internal/providers/cache_planner.go
@@ -55,28 +55,69 @@ func newCachePlanner() *cachePlanner {
 	return &cachePlanner{enabled: enabled}
 }
 
-func (p *cachePlanner) planChat(req *core.ChatRequest, providerType string, selector core.ModelSelector) *core.ChatRequest {
+// chatPlanGate carries what planChat and chatPlanApplies share once the cheap
+// rejections (planner off, short conversation, unsupported provider, client
+// directive present, text-only prefix under the minimum) have passed.
+type chatPlanGate struct {
+	profile promptCacheProfile
+	minimum int
+	prefix  []core.Message
+	// prefixLargeEnough is set when the text-only estimate was conclusive and
+	// already met the minimum. That estimate never exceeds the encoded size,
+	// so the encoded prefix is guaranteed to meet it too.
+	prefixLargeEnough bool
+}
+
+func (p *cachePlanner) gateChat(req *core.ChatRequest, providerType string, selector core.ModelSelector) (chatPlanGate, bool) {
 	profile := promptCacheProfileFor(providerType)
 	if p == nil || !p.enabled || req == nil || len(req.Messages) < 2 || profile.mode == promptCacheUnsupported {
-		return req
+		return chatPlanGate{}, false
 	}
-	minimum := providerCacheMinimum(profile, selector.Model)
-	if tokens, conclusive := estimateSimpleChatPrefixTokens(req); conclusive && tokens < minimum {
-		return req
+	gate := chatPlanGate{profile: profile, minimum: providerCacheMinimum(profile, selector.Model)}
+	if tokens, conclusive := estimateSimpleChatPrefixTokens(req); conclusive {
+		if tokens < gate.minimum {
+			return chatPlanGate{}, false
+		}
+		gate.prefixLargeEnough = true
 	}
-	prefixMessages := req.Messages[:len(req.Messages)-1]
-	if hasChatCacheDirective(req, prefixMessages) {
+	gate.prefix = req.Messages[:len(req.Messages)-1]
+	if hasChatCacheDirective(req, gate.prefix) {
+		return chatPlanGate{}, false
+	}
+	return gate, true
+}
+
+// chatPlanApplies reports whether planChat would return a planned copy of req,
+// without hashing or cloning anything. When the text-only estimate is not
+// conclusive the prefix is encoded once into a byte counter that discards the
+// output, so the answer always agrees with planChat.
+func (p *cachePlanner) chatPlanApplies(req *core.ChatRequest, providerType string, selector core.ModelSelector) bool {
+	gate, ok := p.gateChat(req, providerType, selector)
+	if !ok {
+		return false
+	}
+	if gate.prefixLargeEnough {
+		return true
+	}
+	counter := newPrefixCounter()
+	counter.writeChatPrefix(req.Tools, gate.prefix)
+	return counter.err == nil && counter.tokens() >= gate.minimum
+}
+
+func (p *cachePlanner) planChat(req *core.ChatRequest, providerType string, selector core.ModelSelector) *core.ChatRequest {
+	gate, ok := p.gateChat(req, providerType, selector)
+	if !ok {
 		return req
 	}
 	digest := newPrefixDigest(providerType, selector, req.User)
-	digest.writeChatPrefix(req.Tools, prefixMessages)
-	if digest.err != nil || digest.tokens() < minimum {
+	digest.writeChatPrefix(req.Tools, gate.prefix)
+	if digest.err != nil || digest.tokens() < gate.minimum {
 		return req
 	}
 
 	planned := cloneChatRequest(req)
 	key := digest.key()
-	switch profile.mode {
+	switch gate.profile.mode {
 	case promptCacheOpenAI:
 		planned.ExtraFields = mergeCacheExtras(planned.ExtraFields, map[string]json.RawMessage{
 			"prompt_cache_key": jsonString(key),
@@ -421,6 +462,8 @@ func mergeCacheExtras(base core.UnknownJSONFields, values map[string]json.RawMes
 // the JSON of the prefix object the planner used to marshal in full, which
 // keeps affinity keys stable across gateway versions.
 type prefixDigest struct {
+	// hash is nil for a counter built by newPrefixCounter, which only
+	// measures the prefix and never produces a key.
 	hash hash.Hash
 	enc  *json.Encoder
 	// bytes counts prefix bytes only; the key header is excluded.
@@ -445,6 +488,14 @@ func newPrefixDigest(providerType string, selector core.ModelSelector, user stri
 	return d
 }
 
+// newPrefixCounter returns a digest that measures the encoded prefix without
+// hashing it, for callers that only need to know whether a plan would apply.
+func newPrefixCounter() *prefixDigest {
+	d := &prefixDigest{}
+	d.enc = json.NewEncoder(d)
+	return d
+}
+
 // Write implements io.Writer for the JSON encoder. The newline the encoder
 // emits after each value is not part of the prefix and is dropped.
 func (d *prefixDigest) Write(p []byte) (int, error) {
@@ -452,7 +503,9 @@ func (d *prefixDigest) Write(p []byte) (int, error) {
 	if d.encoding && n > 0 && p[n-1] == '\n' {
 		p = p[:n-1]
 	}
-	d.hash.Write(p)
+	if d.hash != nil {
+		d.hash.Write(p)
+	}
 	d.bytes += len(p)
 	return n, nil
 }

--- a/internal/providers/cache_planner_applies_test.go
+++ b/internal/providers/cache_planner_applies_test.go
@@ -1,0 +1,73 @@
+package providers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-json"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+// TestChatPlanAppliesAgreesWithPlanChat pins the fast-path predicate to the
+// planner: for every fixture, chatPlanApplies must be true exactly when
+// planChat returns a planned copy instead of the caller's request.
+func TestChatPlanAppliesAgreesWithPlanChat(t *testing.T) {
+	long := strings.Repeat("stable context ", 1500)
+	textParts := func(text string) []core.ContentPart {
+		return []core.ContentPart{{Type: "text", Text: text}}
+	}
+	tools := []map[string]any{{"type": "function", "function": map[string]any{"name": "search", "parameters": map[string]any{"type": "object"}}}}
+	tests := []struct {
+		name     string
+		planner  *cachePlanner
+		provider string
+		model    string
+		req      *core.ChatRequest
+	}{
+		{name: "nil planner", provider: "openai", model: "gpt-5.6", req: &core.ChatRequest{Messages: []core.Message{{Role: "system", Content: long}, {Role: "user", Content: "turn"}}}},
+		{name: "planner disabled", planner: &cachePlanner{}, provider: "openai", model: "gpt-5.6", req: &core.ChatRequest{Messages: []core.Message{{Role: "system", Content: long}, {Role: "user", Content: "turn"}}}},
+		{name: "single message", planner: &cachePlanner{enabled: true}, provider: "openai", model: "gpt-5.6", req: &core.ChatRequest{Messages: []core.Message{{Role: "user", Content: long}}}},
+		{name: "unsupported provider", planner: &cachePlanner{enabled: true}, provider: "groq", model: "llama", req: &core.ChatRequest{Messages: []core.Message{{Role: "system", Content: long}, {Role: "user", Content: "turn"}}}},
+		{name: "text prefix below minimum", planner: &cachePlanner{enabled: true}, provider: "openai", model: "gpt-5.6", req: &core.ChatRequest{Messages: []core.Message{{Role: "system", Content: "short"}, {Role: "user", Content: "turn"}}}},
+		{name: "text prefix above minimum", planner: &cachePlanner{enabled: true}, provider: "openai", model: "gpt-5.6", req: &core.ChatRequest{Messages: []core.Message{{Role: "system", Content: long}, {Role: "user", Content: "turn"}}}},
+		{name: "text parts above minimum", planner: &cachePlanner{enabled: true}, provider: "anthropic", model: "claude-sonnet-4-5", req: &core.ChatRequest{Messages: []core.Message{{Role: "system", Content: textParts(long)}, {Role: "user", Content: "turn"}}}},
+		{name: "client directive present", planner: &cachePlanner{enabled: true}, provider: "openai", model: "gpt-5.6", req: &core.ChatRequest{
+			Messages:    []core.Message{{Role: "system", Content: long}, {Role: "user", Content: "turn"}},
+			ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{"prompt_cache_key": json.RawMessage(`"client"`)}),
+		}},
+		{name: "tools inconclusive below minimum", planner: &cachePlanner{enabled: true}, provider: "openai", model: "gpt-5.6", req: &core.ChatRequest{Tools: tools, Messages: []core.Message{{Role: "system", Content: "short"}, {Role: "user", Content: "turn"}}}},
+		{name: "tools inconclusive above minimum", planner: &cachePlanner{enabled: true}, provider: "openai", model: "gpt-5.6", req: &core.ChatRequest{Tools: tools, Messages: []core.Message{{Role: "system", Content: long}, {Role: "user", Content: "turn"}}}},
+		{name: "image part inconclusive below minimum", planner: &cachePlanner{enabled: true}, provider: "openai", model: "gpt-5.6", req: &core.ChatRequest{Messages: []core.Message{
+			{Role: "user", Content: []core.ContentPart{{Type: "image_url"}}},
+			{Role: "user", Content: "turn"},
+		}}},
+		{name: "tool calls inconclusive above minimum", planner: &cachePlanner{enabled: true}, provider: "bedrock", model: "anthropic.claude-sonnet-4-5", req: &core.ChatRequest{Messages: []core.Message{
+			{Role: "system", Content: long},
+			{Role: "assistant", ToolCalls: []core.ToolCall{{ID: "call_1", Type: "function"}}},
+			{Role: "user", Content: "turn"},
+		}}},
+		{name: "gemini above minimum", planner: &cachePlanner{enabled: true}, provider: "gemini", model: "gemini-2.5-pro", req: &core.ChatRequest{Messages: []core.Message{{Role: "system", Content: long}, {Role: "user", Content: "turn"}}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			selector := core.ModelSelector{Provider: tt.provider + "-primary", Model: tt.model}
+			wantApplies := tt.planner.planChat(tt.req, tt.provider, selector) != tt.req
+			if got := tt.planner.chatPlanApplies(tt.req, tt.provider, selector); got != wantApplies {
+				t.Fatalf("chatPlanApplies = %v, planChat applied = %v", got, wantApplies)
+			}
+		})
+	}
+}
+
+func TestRouterPromptCachePlanAppliesWithoutPlanner(t *testing.T) {
+	router := &Router{}
+	req := &core.ChatRequest{Messages: []core.Message{{Role: "system", Content: strings.Repeat("x", 9000)}, {Role: "user", Content: "turn"}}}
+	if router.PromptCachePlanApplies("openai", core.ModelSelector{Model: "gpt-5.6"}, req) {
+		t.Fatal("router without a planner reported an applicable plan")
+	}
+	router.cachePlanner = &cachePlanner{enabled: true}
+	if !router.PromptCachePlanApplies("openai", core.ModelSelector{Model: "gpt-5.6"}, req) {
+		t.Fatal("router with a planner did not report an applicable plan")
+	}
+}

--- a/internal/providers/router_inference.go
+++ b/internal/providers/router_inference.go
@@ -34,6 +34,14 @@ func (r *Router) plannedChatRequest(ctx context.Context, req *core.ChatRequest, 
 	return r.cachePlanner.planChat(forward, route.providerType, route.selector)
 }
 
+// PromptCachePlanApplies reports whether routing req to providerType and
+// selector would attach a prompt-cache directive. The passthrough fast path
+// consults it so a request that bypasses translation never loses a plan the
+// translated path would have applied.
+func (r *Router) PromptCachePlanApplies(providerType string, selector core.ModelSelector, req *core.ChatRequest) bool {
+	return r.cachePlanner.chatPlanApplies(req, providerType, selector)
+}
+
 func (r *Router) plannedResponsesRequest(req *core.ResponsesRequest, route resolvedRoute) *core.ResponsesRequest {
 	forward := forwardResponsesRequest(req, route.selector)
 	if r.cachePlanner == nil {

--- a/internal/server/chat_fast_path_test.go
+++ b/internal/server/chat_fast_path_test.go
@@ -103,6 +103,71 @@ func TestChatCompletion_FastPathLogsUsageFromJSONBody(t *testing.T) {
 	}
 }
 
+func TestChatCompletion_FastPathReplacesUpstreamProviderAndDropsValidators(t *testing.T) {
+	upstream := `{"id":"gen-1","object":"chat.completion","model":"gpt-4o-mini","provider":"OpenAI","choices":[{"provider":"nested"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`
+	mock := fastPathJSONMock(upstream)
+	mock.passthroughResponse.Headers["ETag"] = []string{`"abc"`}
+	mock.passthroughResponse.Headers["Content-MD5"] = []string{"md5"}
+	mock.passthroughResponse.Headers["Digest"] = []string{"sha-256=x"}
+	mock.passthroughResponse.Headers["X-Request-Id"] = []string{"req-1"}
+	rec := postChatCompletion(t, NewHandler(mock, nil, nil, nil), fastPathChatRequestBody)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	want := strings.Replace(upstream, `"provider":"OpenAI"`, `"provider":"openai"`, 1)
+	if got := rec.Body.String(); got != want {
+		t.Fatalf("body = %s\nwant %s", got, want)
+	}
+	if strings.Count(rec.Body.String(), `"provider":`) != 2 {
+		t.Fatalf("body has duplicate or missing provider members: %s", rec.Body.String())
+	}
+	for _, header := range []string{"ETag", "Content-MD5", "Digest"} {
+		if got := rec.Header().Get(header); got != "" {
+			t.Fatalf("%s = %q, want dropped after body rewrite", header, got)
+		}
+	}
+	if got := rec.Header().Get("X-Request-Id"); got != "req-1" {
+		t.Fatalf("X-Request-Id = %q, want forwarded", got)
+	}
+}
+
+func TestChatCompletionStreaming_FastPathRelaysSSEWhenNoPlanApplies(t *testing.T) {
+	streamData := "data: {\"id\":\"chatcmpl-123\",\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\ndata: [DONE]\n\n"
+	mock := fastPathJSONMock(streamData)
+	mock.passthroughResponse.Headers["Content-Type"] = []string{"text/event-stream"}
+	reqBody := `{"model":"gpt-4o-mini","stream":true,"messages":[{"role":"user","content":"Hi"}]}`
+	rec := postChatCompletion(t, NewHandler(mock, nil, nil, nil), reqBody)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != streamData {
+		t.Fatalf("stream body = %q, want %q", got, streamData)
+	}
+	if mock.chatCompletionCalls != 0 {
+		t.Fatalf("ChatCompletion calls = %d, want 0", mock.chatCompletionCalls)
+	}
+	if mock.lastPassthroughReq == nil || !mock.lastPassthroughReq.Stream {
+		t.Fatalf("passthrough request = %+v, want Stream: true", mock.lastPassthroughReq)
+	}
+}
+
+func TestChatCompletion_FastPathSkippedWhenRawModelIsNotCanonical(t *testing.T) {
+	mock := fastPathJSONMock(fastPathUpstreamBody)
+	rec := postChatCompletion(t, NewHandler(mock, nil, nil, nil), `{"model":" gpt-4o-mini ","messages":[{"role":"user","content":"Hi"}]}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if mock.lastPassthroughReq != nil {
+		t.Fatal("padded model took the fast path; the upstream would have received it unnormalized")
+	}
+	if mock.chatCompletionCalls != 1 {
+		t.Fatalf("ChatCompletion calls = %d, want 1", mock.chatCompletionCalls)
+	}
+}
+
 func TestChatCompletion_FastPathSkippedWhenPlannerApplies(t *testing.T) {
 	tests := []struct {
 		name string
@@ -156,10 +221,12 @@ func TestStampJSONObjectProvider(t *testing.T) {
 		body string
 		want string
 	}{
-		{name: "object", body: `{"id":"x"}`, want: `{"id":"x","provider":"openai"}`},
+		{name: "no provider key", body: `{"id":"x"}`, want: `{"id":"x","provider":"openai"}`},
 		{name: "trailing newline", body: "{\"id\":\"x\"}\n", want: "{\"id\":\"x\",\"provider\":\"openai\"}\n"},
 		{name: "empty object", body: `{}`, want: `{"provider":"openai"}`},
-		{name: "upstream provider member is overridden by the last key", body: `{"provider":"OpenAI"}`, want: `{"provider":"OpenAI","provider":"openai"}`},
+		{name: "top-level provider replaced in place", body: `{"id":"x","provider":"OpenAI","model":"m"}`, want: `{"id":"x","provider":"openai","model":"m"}`},
+		{name: "top-level non-string provider replaced", body: `{"provider":{"name":"OpenAI"},"id":"x"}`, want: `{"provider":"openai","id":"x"}`},
+		{name: "nested provider inside choices untouched", body: `{"choices":[{"provider":"OpenAI"}]}`, want: `{"choices":[{"provider":"OpenAI"}],"provider":"openai"}`},
 		{name: "array untouched", body: `[1]`, want: `[1]`},
 		{name: "empty untouched", body: ``, want: ``},
 		{name: "truncated untouched", body: `{"id":`, want: `{"id":`},
@@ -173,15 +240,11 @@ func TestStampJSONObjectProvider(t *testing.T) {
 	}
 }
 
-// BenchmarkChatCompletionNonStreaming compares the translated path (forced by
-// enforced usage data, which the fast path declines) against the passthrough
-// fast path for a ~30 KB request and ~30 KB response through a real router
-// and OpenAI provider talking to an in-process upstream.
-func BenchmarkChatCompletionNonStreaming(b *testing.B) {
-	content := strings.Repeat("The quick brown fox jumps over the lazy dog. ", 660) // ~30 KB
-	requestBody := `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"` + content + `"}]}`
-	responseBody := `{"id":"chatcmpl-bench","object":"chat.completion","model":"gpt-4o-mini","choices":[{"index":0,"message":{"role":"assistant","content":"` + content + `"},"finish_reason":"stop"}],"usage":{"prompt_tokens":7000,"completion_tokens":7000,"total_tokens":14000}}`
-
+// newOpenAIRouter builds a real providers.Router with one OpenAI provider whose
+// upstream is an in-process server answering /models and /chat/completions
+// with responseBody.
+func newOpenAIRouter(tb testing.TB, responseBody string) *providers.Router {
+	tb.Helper()
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
@@ -192,19 +255,63 @@ func BenchmarkChatCompletionNonStreaming(b *testing.B) {
 			_, _ = w.Write([]byte(responseBody))
 		}
 	}))
-	b.Cleanup(upstream.Close)
+	tb.Cleanup(upstream.Close)
 
 	provider := openai.NewWithHTTPClient("test-key", upstream.Client(), llmclient.Hooks{})
 	provider.SetBaseURL(upstream.URL)
 	registry := providers.NewModelRegistry()
 	registry.RegisterProviderWithNameAndType(provider, "openai", "openai")
 	if err := registry.Initialize(context.Background()); err != nil {
-		b.Fatalf("registry initialize: %v", err)
+		tb.Fatalf("registry initialize: %v", err)
 	}
 	router, err := providers.NewRouter(registry)
 	if err != nil {
-		b.Fatalf("new router: %v", err)
+		tb.Fatalf("new router: %v", err)
 	}
+	return router
+}
+
+// TestChatCompletion_FastPathFiresThroughMiddlewareStack drives a bare model
+// id through the full server stack with a real router. The fast path used to
+// be unreachable here: preparation writes the resolved provider into the
+// request, and the gate mistook that for a client-supplied provider.
+func TestChatCompletion_FastPathFiresThroughMiddlewareStack(t *testing.T) {
+	srv := New(newOpenAIRouter(t, fastPathUpstreamBody), &Config{})
+	for _, stream := range []bool{false, true} {
+		body := fastPathChatRequestBody
+		if stream {
+			body = `{"model":"gpt-4o-mini","stream":true,"messages":[{"role":"user","content":"Hi"}]}`
+		}
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("stream=%v status = %d, want 200; body=%s", stream, rec.Code, rec.Body.String())
+		}
+		// The translated path re-encodes core.ChatResponse (provider after
+		// model, no unknown members). A proxied streaming body is the upstream
+		// bytes untouched; a proxied non-streaming body keeps the upstream's
+		// native_finish_reason and carries provider as its last member.
+		want := fastPathUpstreamBody
+		if !stream {
+			want = strings.TrimSuffix(fastPathUpstreamBody, "}") + `,"provider":"openai"}`
+		}
+		if got := rec.Body.String(); got != want {
+			t.Fatalf("stream=%v body was translated instead of proxied:\n got %s\nwant %s", stream, got, want)
+		}
+	}
+}
+
+// BenchmarkChatCompletionNonStreaming compares the translated path (forced by
+// enforced usage data, which the fast path declines) against the passthrough
+// fast path for a ~30 KB request and ~30 KB response through a real router
+// and OpenAI provider talking to an in-process upstream.
+func BenchmarkChatCompletionNonStreaming(b *testing.B) {
+	content := strings.Repeat("The quick brown fox jumps over the lazy dog. ", 660) // ~30 KB
+	requestBody := `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"` + content + `"}]}`
+	responseBody := `{"id":"chatcmpl-bench","object":"chat.completion","model":"gpt-4o-mini","choices":[{"index":0,"message":{"role":"assistant","content":"` + content + `"},"finish_reason":"stop"}],"usage":{"prompt_tokens":7000,"completion_tokens":7000,"total_tokens":14000}}`
+	router := newOpenAIRouter(b, responseBody)
 
 	run := func(b *testing.B, usageCfg usage.Config) {
 		handler := NewHandler(router, nil, &collectingUsageLogger{config: usageCfg}, nil)

--- a/internal/server/chat_fast_path_test.go
+++ b/internal/server/chat_fast_path_test.go
@@ -1,0 +1,232 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/llmclient"
+	"github.com/enterpilot/gomodel/internal/providers"
+	"github.com/enterpilot/gomodel/internal/providers/openai"
+	"github.com/enterpilot/gomodel/internal/usage"
+)
+
+const fastPathChatRequestBody = `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Hi"}]}`
+
+// fastPathUpstreamBody carries members the typed core.ChatResponse does not
+// model (annotations, native_finish_reason, usage.cost) so the test proves the
+// fast path relays the provider body verbatim instead of re-encoding it.
+const fastPathUpstreamBody = `{"id":"chatcmpl-123","object":"chat.completion","model":"gpt-4o-mini","choices":[{"index":0,"message":{"role":"assistant","content":"Hello","annotations":[]},"native_finish_reason":"stop","finish_reason":"stop"}],"usage":{"prompt_tokens":7,"completion_tokens":3,"total_tokens":10,"cost":0.0001}}`
+
+func fastPathJSONMock(body string) *mockProvider {
+	return &mockProvider{
+		supportedModels: []string{"gpt-4o-mini"},
+		providerTypes:   map[string]string{"gpt-4o-mini": "openai"},
+		providerNames:   map[string]string{"gpt-4o-mini": "openai_test"},
+		response:        &core.ChatResponse{ID: "typed", Object: "chat.completion", Model: "gpt-4o-mini"},
+		streamData:      "data: {\"id\":\"typed\"}\n\ndata: [DONE]\n\n",
+		passthroughResponse: &core.PassthroughResponse{
+			StatusCode: http.StatusOK,
+			Headers:    map[string][]string{"Content-Type": {"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+		},
+	}
+}
+
+func postChatCompletion(t *testing.T, handler *Handler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	if err := handler.ChatCompletion(e.NewContext(req, rec)); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	return rec
+}
+
+func TestChatCompletion_FastPathProxiesNonStreamingBodyVerbatim(t *testing.T) {
+	mock := fastPathJSONMock(fastPathUpstreamBody)
+	rec := postChatCompletion(t, NewHandler(mock, nil, nil, nil), fastPathChatRequestBody)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json", got)
+	}
+	want := strings.TrimSuffix(fastPathUpstreamBody, "}") + `,"provider":"openai"}`
+	if got := rec.Body.String(); got != want {
+		t.Fatalf("body = %s\nwant %s", got, want)
+	}
+	if mock.chatCompletionCalls != 0 {
+		t.Fatalf("ChatCompletion calls = %d, want 0 (fast path)", mock.chatCompletionCalls)
+	}
+	if mock.lastPassthroughReq == nil {
+		t.Fatal("passthrough request = nil, want fast path dispatch")
+	}
+	if mock.lastPassthroughReq.Stream {
+		t.Fatal("passthrough request marked as streaming")
+	}
+	if got := mock.lastPassthroughReq.Model; got != "gpt-4o-mini" {
+		t.Fatalf("passthrough model = %q, want gpt-4o-mini", got)
+	}
+	if got := readPassthroughRequestBody(t, mock.lastPassthroughReq.Body); got != fastPathChatRequestBody {
+		t.Fatalf("passthrough body = %q, want %q", got, fastPathChatRequestBody)
+	}
+}
+
+func TestChatCompletion_FastPathLogsUsageFromJSONBody(t *testing.T) {
+	usageLog := &collectingUsageLogger{config: usage.Config{Enabled: true}}
+	mock := fastPathJSONMock(fastPathUpstreamBody)
+	rec := postChatCompletion(t, NewHandler(mock, nil, usageLog, nil), fastPathChatRequestBody)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if len(usageLog.entries) != 1 {
+		t.Fatalf("usage entries = %d, want 1", len(usageLog.entries))
+	}
+	entry := usageLog.entries[0]
+	if entry.InputTokens != 7 || entry.OutputTokens != 3 {
+		t.Fatalf("usage tokens = %d/%d, want 7/3", entry.InputTokens, entry.OutputTokens)
+	}
+	if entry.ProviderName != "openai_test" {
+		t.Fatalf("ProviderName = %q, want openai_test", entry.ProviderName)
+	}
+}
+
+func TestChatCompletion_FastPathSkippedWhenPlannerApplies(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "non-streaming", body: fastPathChatRequestBody},
+		{name: "streaming", body: `{"model":"gpt-4o-mini","stream":true,"messages":[{"role":"user","content":"Hi"}]}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := fastPathJSONMock(fastPathUpstreamBody)
+			mock.promptCachePlanApplies = true
+			rec := postChatCompletion(t, NewHandler(mock, nil, nil, nil), tt.body)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+			}
+			if mock.lastPassthroughReq != nil {
+				t.Fatal("request took the passthrough fast path although the cache planner applies")
+			}
+			if !strings.Contains(rec.Body.String(), `"typed"`) {
+				t.Fatalf("body = %s, want the translated provider response", rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestChatCompletion_FastPathSkippedWithFailoverSelectors(t *testing.T) {
+	mock := fastPathJSONMock(fastPathUpstreamBody)
+	mock.supportedModels = append(mock.supportedModels, "azure/gpt-4o-mini")
+	mock.providerTypes["azure/gpt-4o-mini"] = "azure"
+	handler := newHandler(mock, nil, nil, nil, nil, nil, failoverResolverStub{
+		selectors: []core.ModelSelector{{Provider: "azure", Model: "gpt-4o-mini"}},
+	}, nil)
+	rec := postChatCompletion(t, handler, fastPathChatRequestBody)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if mock.lastPassthroughReq != nil {
+		t.Fatal("request took the passthrough fast path although failover routes exist")
+	}
+	if mock.chatCompletionCalls != 1 {
+		t.Fatalf("ChatCompletion calls = %d, want 1", mock.chatCompletionCalls)
+	}
+}
+
+func TestStampJSONObjectProvider(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "object", body: `{"id":"x"}`, want: `{"id":"x","provider":"openai"}`},
+		{name: "trailing newline", body: "{\"id\":\"x\"}\n", want: "{\"id\":\"x\",\"provider\":\"openai\"}\n"},
+		{name: "empty object", body: `{}`, want: `{"provider":"openai"}`},
+		{name: "upstream provider member is overridden by the last key", body: `{"provider":"OpenAI"}`, want: `{"provider":"OpenAI","provider":"openai"}`},
+		{name: "array untouched", body: `[1]`, want: `[1]`},
+		{name: "empty untouched", body: ``, want: ``},
+		{name: "truncated untouched", body: `{"id":`, want: `{"id":`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := string(stampJSONObjectProvider([]byte(tt.body), "openai")); got != tt.want {
+				t.Fatalf("stamp(%q) = %q, want %q", tt.body, got, tt.want)
+			}
+		})
+	}
+}
+
+// BenchmarkChatCompletionNonStreaming compares the translated path (forced by
+// enforced usage data, which the fast path declines) against the passthrough
+// fast path for a ~30 KB request and ~30 KB response through a real router
+// and OpenAI provider talking to an in-process upstream.
+func BenchmarkChatCompletionNonStreaming(b *testing.B) {
+	content := strings.Repeat("The quick brown fox jumps over the lazy dog. ", 660) // ~30 KB
+	requestBody := `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"` + content + `"}]}`
+	responseBody := `{"id":"chatcmpl-bench","object":"chat.completion","model":"gpt-4o-mini","choices":[{"index":0,"message":{"role":"assistant","content":"` + content + `"},"finish_reason":"stop"}],"usage":{"prompt_tokens":7000,"completion_tokens":7000,"total_tokens":14000}}`
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/models"):
+			_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"gpt-4o-mini","object":"model"}]}`))
+		default:
+			_, _ = io.Copy(io.Discard, r.Body)
+			_, _ = w.Write([]byte(responseBody))
+		}
+	}))
+	b.Cleanup(upstream.Close)
+
+	provider := openai.NewWithHTTPClient("test-key", upstream.Client(), llmclient.Hooks{})
+	provider.SetBaseURL(upstream.URL)
+	registry := providers.NewModelRegistry()
+	registry.RegisterProviderWithNameAndType(provider, "openai", "openai")
+	if err := registry.Initialize(context.Background()); err != nil {
+		b.Fatalf("registry initialize: %v", err)
+	}
+	router, err := providers.NewRouter(registry)
+	if err != nil {
+		b.Fatalf("new router: %v", err)
+	}
+
+	run := func(b *testing.B, usageCfg usage.Config) {
+		handler := NewHandler(router, nil, &collectingUsageLogger{config: usageCfg}, nil)
+		e := echo.New()
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader([]byte(requestBody)))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			if err := handler.ChatCompletion(e.NewContext(req, rec)); err != nil {
+				b.Fatalf("handler error: %v", err)
+			}
+			if rec.Code != http.StatusOK {
+				b.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+			}
+		}
+	}
+	b.Run("translated", func(b *testing.B) {
+		run(b, usage.Config{Enabled: true, EnforceReturningUsageData: true})
+	})
+	b.Run("fast_path", func(b *testing.B) {
+		run(b, usage.Config{Enabled: true})
+	})
+}

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -464,6 +464,8 @@ type mockProvider struct {
 
 	passthroughResponse     *core.PassthroughResponse
 	passthroughErr          error
+	promptCachePlanApplies  bool
+	chatCompletionCalls     int
 	lastPassthroughProvider string
 	lastPassthroughReq      *core.PassthroughRequest
 
@@ -773,6 +775,7 @@ func (p *providerWithoutResponseLifecycle) GetProviderType(model string) string 
 }
 
 func (m *mockProvider) ChatCompletion(_ context.Context, _ *core.ChatRequest) (*core.ChatResponse, error) {
+	m.chatCompletionCalls++
 	if m.err != nil {
 		return nil, m.err
 	}
@@ -823,7 +826,31 @@ func (m *mockProvider) Passthrough(_ context.Context, providerType string, req *
 	if m.passthroughErr != nil {
 		return nil, m.passthroughErr
 	}
-	return m.passthroughResponse, nil
+	if m.passthroughResponse != nil {
+		return m.passthroughResponse, nil
+	}
+	// Tests that only configure the typed chat response still reach the
+	// passthrough fast path; serve the same JSON a real upstream would.
+	if req != nil && !req.Stream && m.response != nil {
+		if m.err != nil {
+			return nil, m.err
+		}
+		body, err := json.Marshal(m.response)
+		if err != nil {
+			return nil, err
+		}
+		return &core.PassthroughResponse{
+			StatusCode: http.StatusOK,
+			Headers:    map[string][]string{"Content-Type": {"application/json"}},
+			Body:       io.NopCloser(bytes.NewReader(body)),
+		}, nil
+	}
+	return nil, nil
+}
+
+// PromptCachePlanApplies lets tests steer the fast path's planner exclusion.
+func (m *mockProvider) PromptCachePlanApplies(string, core.ModelSelector, *core.ChatRequest) bool {
+	return m.promptCachePlanApplies
 }
 
 func (m *mockProvider) GetResponse(_ context.Context, providerType, id string, _ core.ResponseRetrieveParams) (*core.ResponsesResponse, error) {

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -116,19 +117,20 @@ func (s *translatedInferenceService) dispatchChatCompletion(c *echo.Context, req
 	defer adm.release()
 	ctx = adm.dispatchContext(ctx)
 
+	feedbackEnabled := hasResponseFeedbackObservers(c)
+	if !feedbackEnabled && len(s.inference().FailoverSelectors(workflow)) == 0 {
+		if handled, err := s.tryFastPathChatPassthrough(c, workflow, req); handled {
+			return err
+		}
+	}
+
 	if req.Stream {
-		feedbackEnabled := hasResponseFeedbackObservers(c)
 		if feedbackEnabled {
 			req = gateway.CloneChatRequestForStreamUsage(req)
 			if req.StreamOptions == nil {
 				req.StreamOptions = &core.StreamOptions{}
 			}
 			req.StreamOptions.IncludeUsage = true
-		}
-		if !feedbackEnabled && len(s.inference().FailoverSelectors(workflow)) == 0 {
-			if handled, err := s.tryFastPathStreamingChatPassthrough(c, workflow, req); handled {
-				return err
-			}
 		}
 		result, err := s.inference().StreamChatCompletion(ctx, workflow, req)
 		if err != nil {
@@ -487,8 +489,13 @@ func (s *translatedInferenceService) recordResponseSnapshotStoreFailure(rec snap
 	)
 }
 
-func (s *translatedInferenceService) tryFastPathStreamingChatPassthrough(c *echo.Context, workflow *core.Workflow, req *core.ChatRequest) (bool, error) {
-	if !s.inference().CanFastPathStreamingChatPassthrough(workflow, req) {
+// tryFastPathChatPassthrough proxies an OpenAI-compatible chat request byte for
+// byte when translation would not change it (see CanFastPathChatPassthrough).
+// Streaming responses are relayed as-is; non-streaming bodies get the same
+// "provider" stamp the translated path puts on core.ChatResponse so the public
+// response shape does not depend on which path served it.
+func (s *translatedInferenceService) tryFastPathChatPassthrough(c *echo.Context, workflow *core.Workflow, req *core.ChatRequest) (bool, error) {
+	if !s.inference().CanFastPathChatPassthrough(workflow, req) {
 		return false, nil
 	}
 
@@ -502,25 +509,34 @@ func (s *translatedInferenceService) tryFastPathStreamingChatPassthrough(c *echo
 
 	const endpoint = "/chat/completions"
 	providerType := strings.TrimSpace(workflow.ProviderType)
+	providerName := providerNameFromWorkflow(workflow)
+	model := resolvedModelFromWorkflow(workflow, req.Model)
+	auditlog.EnrichEntryWithResolvedRoute(c, qualifyExecutedModel(workflow, model, providerName), providerType, providerName)
 	resp, err := passthroughProvider.Passthrough(ctx, providerType, &core.PassthroughRequest{
 		Method:       c.Request().Method,
 		Endpoint:     endpoint,
 		Operation:    llmclient.OperationChat,
-		Model:        resolvedModelFromWorkflow(workflow, req.Model),
+		Model:        model,
 		Stream:       req.Stream,
 		Body:         c.Request().Body,
 		Headers:      buildPassthroughHeaders(ctx, c.Request().Header),
-		ProviderName: providerNameFromWorkflow(workflow),
+		ProviderName: providerName,
 	})
 	if err != nil {
 		return true, handleError(c, err)
+	}
+	if !req.Stream {
+		if err := stampPassthroughChatProvider(resp, providerType); err != nil {
+			_ = resp.Body.Close()
+			return true, handleError(c, core.NewProviderError(providerType, http.StatusBadGateway, "failed to read provider response", err))
+		}
 	}
 
 	info := &core.PassthroughRouteInfo{
 		Provider:    providerType,
 		RawEndpoint: strings.TrimPrefix(endpoint, "/"),
 		AuditPath:   c.Request().URL.Path,
-		Model:       resolvedModelFromWorkflow(workflow, req.Model),
+		Model:       model,
 	}
 	passthrough := passthroughService{
 		provider:        s.provider,
@@ -528,7 +544,58 @@ func (s *translatedInferenceService) tryFastPathStreamingChatPassthrough(c *echo
 		usageLogger:     s.usageLogger,
 		pricingResolver: s.pricingResolver,
 	}
-	return true, passthrough.proxyPassthroughResponse(c, providerType, providerNameFromWorkflow(workflow), endpoint, info, resp)
+	return true, passthrough.proxyPassthroughResponse(c, providerType, providerName, endpoint, info, resp)
+}
+
+// stampPassthroughChatProvider buffers a successful non-streaming JSON chat
+// body and appends the gateway "provider" field, matching the translated
+// path. Bodies beyond maxObservedJSONResponseBytes are relayed untouched, as
+// the usage observer already declines to buffer them.
+func stampPassthroughChatProvider(resp *core.PassthroughResponse, providerType string) error {
+	if resp == nil || resp.Body == nil || !isObservablePassthroughStatus(resp.StatusCode) ||
+		!isJSONContentType(resp.Headers) || isSSEContentType(resp.Headers) {
+		return nil
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxObservedJSONResponseBytes+1))
+	if err != nil {
+		return err
+	}
+	if len(body) > maxObservedJSONResponseBytes {
+		resp.Body = &combinedReadCloser{Reader: io.MultiReader(bytes.NewReader(body), resp.Body), rc: resp.Body}
+		return nil
+	}
+	resp.Body = &combinedReadCloser{Reader: bytes.NewReader(stampJSONObjectProvider(body, providerType)), rc: resp.Body}
+	return nil
+}
+
+// stampJSONObjectProvider appends "provider":<providerType> as the last member
+// of a JSON object body. Appending last means a provider-supplied "provider"
+// member (OpenRouter emits one) is overridden the same way the typed
+// core.ChatResponse field overrides it on the translated path, since JSON
+// decoders keep the last duplicate key. Bodies that are not a JSON object are
+// returned unchanged.
+func stampJSONObjectProvider(body []byte, providerType string) []byte {
+	end := len(bytes.TrimRight(body, " \t\r\n"))
+	if end == 0 || body[end-1] != '}' {
+		return body
+	}
+	object := body[:end-1]
+	members := bytes.TrimSpace(object)
+	if len(members) == 0 || members[0] != '{' {
+		return body
+	}
+	quoted, err := json.Marshal(providerType)
+	if err != nil {
+		return body
+	}
+	stamped := make([]byte, 0, len(body)+len(quoted)+13)
+	stamped = append(stamped, object...)
+	if len(bytes.TrimSpace(members[1:])) > 0 {
+		stamped = append(stamped, ',')
+	}
+	stamped = append(stamped, `"provider":`...)
+	stamped = append(stamped, quoted...)
+	return append(stamped, body[end-1:]...)
 }
 
 func (s *translatedInferenceService) Embeddings(c *echo.Context) error {

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -7,12 +7,14 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"syscall"
 	"time"
 
 	"github.com/goccy/go-json"
+	"github.com/tidwall/gjson"
 
 	"github.com/labstack/echo/v5"
 
@@ -504,13 +506,17 @@ func (s *translatedInferenceService) tryFastPathChatPassthrough(c *echo.Context,
 		return false, nil
 	}
 
+	model := resolvedModelFromWorkflow(workflow, req.Model)
+	if !rawRequestModelMatches(c, model) {
+		return false, nil
+	}
+
 	ctx, _ := requestContextWithRequestID(c.Request())
 	c.SetRequest(c.Request().WithContext(ctx))
 
 	const endpoint = "/chat/completions"
 	providerType := strings.TrimSpace(workflow.ProviderType)
 	providerName := providerNameFromWorkflow(workflow)
-	model := resolvedModelFromWorkflow(workflow, req.Model)
 	auditlog.EnrichEntryWithResolvedRoute(c, qualifyExecutedModel(workflow, model, providerName), providerType, providerName)
 	resp, err := passthroughProvider.Passthrough(ctx, providerType, &core.PassthroughRequest{
 		Method:       c.Request().Method,
@@ -547,10 +553,28 @@ func (s *translatedInferenceService) tryFastPathChatPassthrough(c *echo.Context,
 	return true, passthrough.proxyPassthroughResponse(c, providerType, providerName, endpoint, info, resp)
 }
 
+// rawRequestModelMatches reports whether the model string exactly as the client
+// wrote it equals the model the upstream must receive. The gateway gate compares
+// normalized selectors, but the fast path forwards the body untouched, so a
+// padded or otherwise non-canonical raw value must take the translated path.
+func rawRequestModelMatches(c *echo.Context, resolvedModel string) bool {
+	if env := core.GetWhiteBoxPrompt(c.Request().Context()); env != nil {
+		return env.JSONBodyParsed && env.RouteHints.Model == resolvedModel
+	}
+	// Without ingress capture (the handler is being used outside the
+	// middleware stack) fall back to the buffered body the decode step read.
+	body, err := requestBodyBytes(c)
+	return err == nil && gjson.GetBytes(body, "model").Str == resolvedModel
+}
+
+// bodyValidatorHeaders are response headers derived from the body bytes; they
+// are dropped whenever the gateway rewrites a proxied body.
+var bodyValidatorHeaders = []string{"Etag", "Content-Md5", "Digest", "Content-Digest", "Repr-Digest"}
+
 // stampPassthroughChatProvider buffers a successful non-streaming JSON chat
-// body and appends the gateway "provider" field, matching the translated
-// path. Bodies beyond maxObservedJSONResponseBytes are relayed untouched, as
-// the usage observer already declines to buffer them.
+// body and sets the gateway "provider" member, matching the translated path.
+// Bodies beyond maxObservedJSONResponseBytes are relayed untouched, as the
+// usage observer already declines to buffer them.
 func stampPassthroughChatProvider(resp *core.PassthroughResponse, providerType string) error {
 	if resp == nil || resp.Body == nil || !isObservablePassthroughStatus(resp.StatusCode) ||
 		!isJSONContentType(resp.Headers) || isSSEContentType(resp.Headers) {
@@ -564,17 +588,40 @@ func stampPassthroughChatProvider(resp *core.PassthroughResponse, providerType s
 		resp.Body = &combinedReadCloser{Reader: io.MultiReader(bytes.NewReader(body), resp.Body), rc: resp.Body}
 		return nil
 	}
-	resp.Body = &combinedReadCloser{Reader: bytes.NewReader(stampJSONObjectProvider(body, providerType)), rc: resp.Body}
+	stamped := stampJSONObjectProvider(body, providerType)
+	if !bytes.Equal(stamped, body) {
+		dropBodyValidatorHeaders(resp.Headers)
+	}
+	resp.Body = &combinedReadCloser{Reader: bytes.NewReader(stamped), rc: resp.Body}
 	return nil
 }
 
-// stampJSONObjectProvider appends "provider":<providerType> as the last member
-// of a JSON object body. Appending last means a provider-supplied "provider"
-// member (OpenRouter emits one) is overridden the same way the typed
-// core.ChatResponse field overrides it on the translated path, since JSON
-// decoders keep the last duplicate key. Bodies that are not a JSON object are
-// returned unchanged.
+func dropBodyValidatorHeaders(headers map[string][]string) {
+	for key := range headers {
+		if slices.Contains(bodyValidatorHeaders, http.CanonicalHeaderKey(strings.TrimSpace(key))) {
+			delete(headers, key)
+		}
+	}
+}
+
+// stampJSONObjectProvider sets "provider":<providerType> on a JSON object
+// body, mirroring how the typed core.ChatResponse field overrides any
+// provider-supplied value on the translated path. An existing top-level member
+// (OpenRouter emits one) is replaced in place so the object never carries
+// duplicate keys; nested members are left alone. Without one the member is
+// appended last. Bodies that are not a JSON object are returned unchanged.
 func stampJSONObjectProvider(body []byte, providerType string) []byte {
+	quoted, err := json.Marshal(providerType)
+	if err != nil {
+		return body
+	}
+	if existing := gjson.GetBytes(body, "provider"); existing.Exists() && existing.Index > 0 {
+		end := existing.Index + len(existing.Raw)
+		stamped := make([]byte, 0, len(body)-len(existing.Raw)+len(quoted))
+		stamped = append(stamped, body[:existing.Index]...)
+		stamped = append(stamped, quoted...)
+		return append(stamped, body[end:]...)
+	}
 	end := len(bytes.TrimRight(body, " \t\r\n"))
 	if end == 0 || body[end-1] != '}' {
 		return body
@@ -582,10 +629,6 @@ func stampJSONObjectProvider(body []byte, providerType string) []byte {
 	object := body[:end-1]
 	members := bytes.TrimSpace(object)
 	if len(members) == 0 || members[0] != '{' {
-		return body
-	}
-	quoted, err := json.Marshal(providerType)
-	if err != nil {
 		return body
 	}
 	stamped := make([]byte, 0, len(body)+len(quoted)+13)


### PR DESCRIPTION
Stacked on #843 (`refactor/split-large-files`); sibling to the `fix/llmclient-retry-timer` branch.

## What changes

**Non-streaming chat takes the passthrough fast path.** `CanFastPathChatPassthrough` replaces `CanFastPathStreamingChatPassthrough` and no longer requires `stream: true`. A non-streaming OpenAI / Azure / OpenRouter chat request that needs no rewriting is proxied byte for byte instead of decode → re-encode → decode → re-encode. The relayed body gets the same `"provider"` member the translated path stamps on `core.ChatResponse`, appended as the last member so the public response shape is unchanged.

**The fast path never drops a cache plan.** The router exposes `PromptCachePlanApplies`, an allocation-free predicate that agrees with `planChat` (pinned by `TestChatPlanAppliesAgreesWithPlanChat`). The gateway declines the fast path when a plan would apply, so planner-eligible requests still get `prompt_cache_key` and friends via the translated path. Previously a streaming request silently lost the plan.

**The fast path now actually fires.** Two gate conditions could never hold with a real router: preparation writes the resolved provider into `req.Provider` before dispatch (the gate read that as a client-supplied provider), and the selector check compared the empty client hint against the resolved provider name. The gate now keys on `Requested.ExplicitProvider` and compares only the model string the upstream receives. Reviewers: this means the existing *streaming* fast path becomes live in production with this PR.

## Behavior changes

- Non-streaming eligible chat requests are proxied. Upstream members the typed `ChatResponse` does not model (e.g. `annotations`, OpenRouter's `native_finish_reason`, `usage.cost`) now reach the client; upstream response headers are forwarded like the streaming fast path already does; member order follows the upstream body.
- Streaming eligible chat requests are proxied for the first time (see above); when the cache planner applies they take the translated path instead.
- Fast-path audit entries now carry the resolved route (`EnrichEntryWithResolvedRoute`), matching the translated path.
- Docs: `docs/features/cache.mdx` describes the rule.

## Benchmark

`BenchmarkChatCompletionNonStreaming`, ~30 KB request and ~30 KB response through a real `providers.Router` + OpenAI provider against an in-process upstream (numbers include the loopback HTTP round trip):

| path | ns/op | B/op | allocs/op |
|---|---|---|---|
| translated | 315 383 | 968 231 | 241 |
| fast path | 175 374 | 708 631 | 281 |

## Verification

`go build ./...`, `go vet` (only pre-existing "repeats json tag" notes), full `go test` over internal/config/ext/run/cmd, `make lint` 0 issues; pre-commit hook ran `make test-race`, `make fix-check`, and the hot-path perf guard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Non-streaming chat completion requests can now use the same direct passthrough path as streaming requests.
  * Successful direct responses include the resolved provider information for consistency with translated responses.

* **Bug Fixes**
  * Requests eligible for prompt caching now use the translated path so cache directives are applied correctly.
  * Direct passthrough is bypassed when routing, failover, or response-processing requirements require translation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->