### PR TITLE
refactor(server): keep per-request state in one scope instead of re-wrapping the context

### DIFF
--- a/internal/core/context.go
+++ b/internal/core/context.go
@@ -87,6 +87,9 @@ const (
 
 // WithRequestID returns a new context with the request ID attached.
 func WithRequestID(ctx context.Context, requestID string) context.Context {
+	if scoped, ok := withScope(ctx, func(s *RequestScope) { s.SetRequestID(requestID) }); ok {
+		return scoped
+	}
 	return context.WithValue(ctx, requestIDKey, requestID)
 }
 
@@ -99,6 +102,9 @@ const RequestIDHeader = "X-Request-Id"
 // GetRequestID retrieves the request ID from the context.
 // Returns empty string if not found.
 func GetRequestID(ctx context.Context) string {
+	if scope := RequestScopeFromContext(ctx); scope != nil {
+		return scope.requestID
+	}
 	if v := ctx.Value(requestIDKey); v != nil {
 		if id, ok := v.(string); ok {
 			return id
@@ -109,11 +115,17 @@ func GetRequestID(ctx context.Context) string {
 
 // WithRequestSnapshot returns a new context with the request snapshot attached.
 func WithRequestSnapshot(ctx context.Context, snapshot *RequestSnapshot) context.Context {
+	if scoped, ok := withScope(ctx, func(s *RequestScope) { s.SetSnapshot(snapshot) }); ok {
+		return scoped
+	}
 	return context.WithValue(ctx, requestSnapshotKey, snapshot)
 }
 
 // GetRequestSnapshot retrieves the request snapshot from the context.
 func GetRequestSnapshot(ctx context.Context) *RequestSnapshot {
+	if scope := RequestScopeFromContext(ctx); scope != nil {
+		return scope.snapshot
+	}
 	if v := ctx.Value(requestSnapshotKey); v != nil {
 		if snapshot, ok := v.(*RequestSnapshot); ok {
 			return snapshot
@@ -124,11 +136,17 @@ func GetRequestSnapshot(ctx context.Context) *RequestSnapshot {
 
 // WithWhiteBoxPrompt returns a new context with the white-box prompt attached.
 func WithWhiteBoxPrompt(ctx context.Context, prompt *WhiteBoxPrompt) context.Context {
+	if scoped, ok := withScope(ctx, func(s *RequestScope) { s.SetWhiteBoxPrompt(prompt) }); ok {
+		return scoped
+	}
 	return context.WithValue(ctx, whiteBoxPromptKey, prompt)
 }
 
 // GetWhiteBoxPrompt retrieves the white-box prompt from the context.
 func GetWhiteBoxPrompt(ctx context.Context) *WhiteBoxPrompt {
+	if scope := RequestScopeFromContext(ctx); scope != nil {
+		return scope.whiteBoxPrompt
+	}
 	if v := ctx.Value(whiteBoxPromptKey); v != nil {
 		if prompt, ok := v.(*WhiteBoxPrompt); ok {
 			return prompt
@@ -144,11 +162,17 @@ func WithWorkflow(ctx context.Context, workflow *Workflow) context.Context {
 	if GetWorkflow(ctx) == workflow {
 		return ctx
 	}
+	if scoped, ok := withScope(ctx, func(s *RequestScope) { s.SetWorkflow(workflow) }); ok {
+		return scoped
+	}
 	return context.WithValue(ctx, workflowKey, workflow)
 }
 
 // GetWorkflow retrieves the workflow from the context.
 func GetWorkflow(ctx context.Context) *Workflow {
+	if scope := RequestScopeFromContext(ctx); scope != nil {
+		return scope.workflow
+	}
 	if v := ctx.Value(workflowKey); v != nil {
 		if workflow, ok := v.(*Workflow); ok {
 			return workflow
@@ -162,12 +186,18 @@ func WithSessionID(ctx context.Context, sessionID string) context.Context {
 	if sessionID == "" {
 		return ctx
 	}
+	if scoped, ok := withScope(ctx, func(s *RequestScope) { s.SetSessionID(sessionID) }); ok {
+		return scoped
+	}
 	return context.WithValue(ctx, sessionIDKey, sessionID)
 }
 
 // SessionIDFromContext retrieves the detected client session id, or "" when
 // the request carries no session signal.
 func SessionIDFromContext(ctx context.Context) string {
+	if scope := RequestScopeFromContext(ctx); scope != nil {
+		return scope.sessionID
+	}
 	if v := ctx.Value(sessionIDKey); v != nil {
 		if id, ok := v.(string); ok {
 			return id
@@ -194,11 +224,17 @@ func RequestDialectFromContext(ctx context.Context) RequestDialect {
 
 // WithAuthKeyID returns a new context with the authenticated managed auth key id attached.
 func WithAuthKeyID(ctx context.Context, id string) context.Context {
+	if scoped, ok := withScope(ctx, func(s *RequestScope) { s.SetAuthKeyID(id) }); ok {
+		return scoped
+	}
 	return context.WithValue(ctx, authKeyIDKey, id)
 }
 
 // GetAuthKeyID retrieves the managed auth key id from the context.
 func GetAuthKeyID(ctx context.Context) string {
+	if scope := RequestScopeFromContext(ctx); scope != nil {
+		return scope.authKeyID
+	}
 	if v := ctx.Value(authKeyIDKey); v != nil {
 		if id, ok := v.(string); ok {
 			return id
@@ -210,6 +246,9 @@ func GetAuthKeyID(ctx context.Context) string {
 // WithCredentialAllowedModels returns a new context carrying the model
 // allowlist bound to the authenticated credential. An empty list clears it.
 func WithCredentialAllowedModels(ctx context.Context, allowed []string) context.Context {
+	if scoped, ok := withScope(ctx, func(s *RequestScope) { s.SetCredentialAllowedModels(allowed) }); ok {
+		return scoped
+	}
 	if len(allowed) == 0 {
 		return context.WithValue(ctx, credentialAllowedModelsKey, []string(nil))
 	}
@@ -219,6 +258,9 @@ func WithCredentialAllowedModels(ctx context.Context, allowed []string) context.
 // GetCredentialAllowedModels retrieves the credential-bound model allowlist.
 // Nil means the credential does not restrict models.
 func GetCredentialAllowedModels(ctx context.Context) []string {
+	if scope := RequestScopeFromContext(ctx); scope != nil {
+		return scope.credentialAllowedModels
+	}
 	if v := ctx.Value(credentialAllowedModelsKey); v != nil {
 		if allowed, ok := v.([]string); ok {
 			return allowed
@@ -229,11 +271,17 @@ func GetCredentialAllowedModels(ctx context.Context) []string {
 
 // WithEffectiveUserPath returns a new context with an effective user path override attached.
 func WithEffectiveUserPath(ctx context.Context, userPath string) context.Context {
+	if scoped, ok := withScope(ctx, func(s *RequestScope) { s.SetEffectiveUserPath(userPath) }); ok {
+		return scoped
+	}
 	return context.WithValue(ctx, effectiveUserPathKey, userPath)
 }
 
 // GetEffectiveUserPath retrieves the effective user path override from context.
 func GetEffectiveUserPath(ctx context.Context) string {
+	if scope := RequestScopeFromContext(ctx); scope != nil {
+		return scope.effectiveUserPath
+	}
 	if v := ctx.Value(effectiveUserPathKey); v != nil {
 		if userPath, ok := v.(string); ok {
 			return userPath
@@ -249,6 +297,9 @@ func WithUserPathHeaderName(ctx context.Context, headerName string) context.Cont
 	headerName = UserPathHeaderName(headerName)
 	if headerName == UserPathHeader {
 		return ctx
+	}
+	if scoped, ok := withScope(ctx, func(s *RequestScope) { s.SetUserPathHeaderName(headerName) }); ok {
+		return scoped
 	}
 	return context.WithValue(ctx, userPathHeaderNameKey, headerName)
 }
@@ -326,11 +377,17 @@ func GetGuardrailsHash(ctx context.Context) string {
 
 // WithFailoverUsed returns a new context marked as having used a failover model.
 func WithFailoverUsed(ctx context.Context) context.Context {
+	if scoped, ok := withScope(ctx, func(s *RequestScope) { s.SetFailoverUsed() }); ok {
+		return scoped
+	}
 	return context.WithValue(ctx, failoverUsedKey, true)
 }
 
 // GetFailoverUsed reports whether the request was served by a failover model.
 func GetFailoverUsed(ctx context.Context) bool {
+	if scope := RequestScopeFromContext(ctx); scope != nil {
+		return scope.failoverUsed
+	}
 	if v := ctx.Value(failoverUsedKey); v != nil {
 		if used, ok := v.(bool); ok {
 			return used
@@ -346,12 +403,18 @@ func WithRewriteTokensSaved(ctx context.Context, tokensSaved int) context.Contex
 	if tokensSaved <= 0 {
 		return ctx
 	}
+	if scoped, ok := withScope(ctx, func(s *RequestScope) { s.SetRewriteTokensSaved(tokensSaved) }); ok {
+		return scoped
+	}
 	return context.WithValue(ctx, rewriteTokensSavedKey, tokensSaved)
 }
 
 // RewriteTokensSavedFromContext retrieves the request's rewrite savings
 // estimate, or zero when no rewriter reported savings.
 func RewriteTokensSavedFromContext(ctx context.Context) int {
+	if scope := RequestScopeFromContext(ctx); scope != nil {
+		return scope.rewriteTokensSaved
+	}
 	if v := ctx.Value(rewriteTokensSavedKey); v != nil {
 		if saved, ok := v.(int); ok && saved > 0 {
 			return saved

--- a/internal/core/labels.go
+++ b/internal/core/labels.go
@@ -35,6 +35,9 @@ func WithRequestLabels(ctx context.Context, labels []string) context.Context {
 	if len(labels) == 0 {
 		return ctx
 	}
+	if scoped, ok := withScope(ctx, func(s *RequestScope) { s.SetLabels(labels) }); ok {
+		return scoped
+	}
 	return context.WithValue(ctx, requestLabelsKey, labels)
 }
 
@@ -43,6 +46,9 @@ func WithRequestLabels(ctx context.Context, labels []string) context.Context {
 func RequestLabelsFromContext(ctx context.Context) []string {
 	if ctx == nil {
 		return nil
+	}
+	if scope := RequestScopeFromContext(ctx); scope != nil {
+		return scope.labels
 	}
 	if labels, ok := ctx.Value(requestLabelsKey).([]string); ok {
 		return labels
@@ -56,6 +62,9 @@ func WithTaggingStripHeaders(ctx context.Context, headers map[string]struct{}) c
 	if len(headers) == 0 {
 		return ctx
 	}
+	if scoped, ok := withScope(ctx, func(s *RequestScope) { s.SetTaggingStripHeaders(headers) }); ok {
+		return scoped
+	}
 	return context.WithValue(ctx, taggingStripHeadersKey, headers)
 }
 
@@ -65,6 +74,9 @@ func WithTaggingStripHeaders(ctx context.Context, headers map[string]struct{}) c
 func TaggingStripHeadersFromContext(ctx context.Context) map[string]struct{} {
 	if ctx == nil {
 		return nil
+	}
+	if scope := RequestScopeFromContext(ctx); scope != nil {
+		return scope.taggingStripHeaders
 	}
 	if headers, ok := ctx.Value(taggingStripHeadersKey).(map[string]struct{}); ok {
 		return headers

--- a/internal/core/request_scope.go
+++ b/internal/core/request_scope.go
@@ -1,0 +1,158 @@
+package core
+
+import "context"
+
+// requestScopeKey stores the mutable per-request scope installed at ingress.
+const requestScopeKey contextKey = "request-scope"
+
+// RequestScope holds the per-request values that the HTTP middleware chain
+// fills in as a request moves through ingress capture, tagging, auth, session
+// detection and workflow resolution. It is installed once by the ingress
+// middleware and mutated in place afterwards, so the chain does not re-wrap
+// the request context (and copy *http.Request) at every stage.
+//
+// The With* accessors keep context-value semantics: on a context that carries
+// a scope they clone it and layer the clone, so a context derived before the
+// call never observes the change. Only the Set* methods mutate in place; the
+// middleware chain uses them on the request goroutine before any concurrent
+// work starts.
+type RequestScope struct {
+	requestID               string
+	snapshot                *RequestSnapshot
+	whiteBoxPrompt          *WhiteBoxPrompt
+	workflow                *Workflow
+	sessionID               string
+	authKeyID               string
+	credentialAllowedModels []string
+	effectiveUserPath       string
+	userPathHeaderName      string
+	labels                  []string
+	taggingStripHeaders     map[string]struct{}
+	rewriteTokensSaved      int
+	failoverUsed            bool
+}
+
+// WithRequestScope installs a request scope on ctx and returns it. The scope
+// is seeded from the values ctx already carries, so readers see exactly what
+// they would have seen before the scope existed. When ctx already carries a
+// scope it is returned unchanged.
+func WithRequestScope(ctx context.Context) (context.Context, *RequestScope) {
+	if scope := RequestScopeFromContext(ctx); scope != nil {
+		return ctx, scope
+	}
+	scope := &RequestScope{
+		requestID:               GetRequestID(ctx),
+		snapshot:                GetRequestSnapshot(ctx),
+		whiteBoxPrompt:          GetWhiteBoxPrompt(ctx),
+		workflow:                GetWorkflow(ctx),
+		sessionID:               SessionIDFromContext(ctx),
+		authKeyID:               GetAuthKeyID(ctx),
+		credentialAllowedModels: GetCredentialAllowedModels(ctx),
+		effectiveUserPath:       GetEffectiveUserPath(ctx),
+		userPathHeaderName:      userPathHeaderNameValue(ctx),
+		labels:                  RequestLabelsFromContext(ctx),
+		taggingStripHeaders:     TaggingStripHeadersFromContext(ctx),
+		rewriteTokensSaved:      RewriteTokensSavedFromContext(ctx),
+		failoverUsed:            GetFailoverUsed(ctx),
+	}
+	return context.WithValue(ctx, requestScopeKey, scope), scope
+}
+
+// RequestScopeFromContext returns the request scope carried by ctx, or nil.
+func RequestScopeFromContext(ctx context.Context) *RequestScope {
+	if ctx == nil {
+		return nil
+	}
+	scope, _ := ctx.Value(requestScopeKey).(*RequestScope)
+	return scope
+}
+
+// withScope applies update to a clone of the scope carried by ctx and layers
+// the clone on top, preserving context-value semantics. It reports false when
+// ctx carries no scope so the caller can fall back to a plain context value.
+func withScope(ctx context.Context, update func(*RequestScope)) (context.Context, bool) {
+	scope := RequestScopeFromContext(ctx)
+	if scope == nil {
+		return ctx, false
+	}
+	clone := *scope
+	update(&clone)
+	return context.WithValue(ctx, requestScopeKey, &clone), true
+}
+
+// SetRequestID records the gateway request id.
+func (s *RequestScope) SetRequestID(requestID string) { s.requestID = requestID }
+
+// SetSnapshot replaces the transport snapshot.
+func (s *RequestScope) SetSnapshot(snapshot *RequestSnapshot) { s.snapshot = snapshot }
+
+// SetWhiteBoxPrompt replaces the semantic extraction.
+func (s *RequestScope) SetWhiteBoxPrompt(prompt *WhiteBoxPrompt) { s.whiteBoxPrompt = prompt }
+
+// SetWorkflow replaces the request workflow.
+func (s *RequestScope) SetWorkflow(workflow *Workflow) { s.workflow = workflow }
+
+// SetSessionID records the detected client session id. An empty id is ignored,
+// matching WithSessionID.
+func (s *RequestScope) SetSessionID(sessionID string) {
+	if sessionID == "" {
+		return
+	}
+	s.sessionID = sessionID
+}
+
+// SetAuthKeyID records the managed auth key id.
+func (s *RequestScope) SetAuthKeyID(id string) { s.authKeyID = id }
+
+// SetCredentialAllowedModels replaces the credential-bound model allowlist.
+// An empty list clears it, matching WithCredentialAllowedModels.
+func (s *RequestScope) SetCredentialAllowedModels(allowed []string) {
+	if len(allowed) == 0 {
+		allowed = nil
+	}
+	s.credentialAllowedModels = allowed
+}
+
+// SetEffectiveUserPath replaces the effective user path override. An empty
+// value clears it, matching WithEffectiveUserPath.
+func (s *RequestScope) SetEffectiveUserPath(userPath string) { s.effectiveUserPath = userPath }
+
+// SetUserPathHeaderName records a non-default user-path header name. The
+// default header is a no-op, matching WithUserPathHeaderName.
+func (s *RequestScope) SetUserPathHeaderName(headerName string) {
+	headerName = UserPathHeaderName(headerName)
+	if headerName == UserPathHeader {
+		return
+	}
+	s.userPathHeaderName = headerName
+}
+
+// SetLabels replaces the request labels. An empty list is ignored, matching
+// WithRequestLabels.
+func (s *RequestScope) SetLabels(labels []string) {
+	if len(labels) == 0 {
+		return
+	}
+	s.labels = labels
+}
+
+// SetTaggingStripHeaders replaces the do-not-pass header set. An empty set is
+// ignored, matching WithTaggingStripHeaders.
+func (s *RequestScope) SetTaggingStripHeaders(headers map[string]struct{}) {
+	if len(headers) == 0 {
+		return
+	}
+	s.taggingStripHeaders = headers
+}
+
+// SetRewriteTokensSaved records the rewrite savings estimate. Non-positive
+// totals are ignored, matching WithRewriteTokensSaved.
+func (s *RequestScope) SetRewriteTokensSaved(tokensSaved int) {
+	if tokensSaved <= 0 {
+		return
+	}
+	s.rewriteTokensSaved = tokensSaved
+}
+
+// SetFailoverUsed marks the request as served by a failover model.
+func (s *RequestScope) SetFailoverUsed() { s.failoverUsed = true }

--- a/internal/core/request_scope_test.go
+++ b/internal/core/request_scope_test.go
@@ -1,0 +1,186 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// scopedValue describes one context value both in its plain-context form and
+// through the request scope, so a single table proves the two agree.
+type scopedValue struct {
+	name  string
+	with  func(context.Context) context.Context
+	read  func(context.Context) any
+	want  any
+	empty any
+}
+
+func requestScopeValues() []scopedValue {
+	snapshot := &RequestSnapshot{Method: "POST", Path: "/v1/chat/completions"}
+	prompt := &WhiteBoxPrompt{OperationType: "chat_completions"}
+	workflow := &Workflow{RequestID: "wf"}
+	strip := map[string]struct{}{"X-Team": {}}
+	return []scopedValue{
+		{"request id", func(ctx context.Context) context.Context { return WithRequestID(ctx, "req-1") },
+			func(ctx context.Context) any { return GetRequestID(ctx) }, "req-1", ""},
+		{"snapshot", func(ctx context.Context) context.Context { return WithRequestSnapshot(ctx, snapshot) },
+			func(ctx context.Context) any { return GetRequestSnapshot(ctx) }, snapshot, (*RequestSnapshot)(nil)},
+		{"white-box prompt", func(ctx context.Context) context.Context { return WithWhiteBoxPrompt(ctx, prompt) },
+			func(ctx context.Context) any { return GetWhiteBoxPrompt(ctx) }, prompt, (*WhiteBoxPrompt)(nil)},
+		{"workflow", func(ctx context.Context) context.Context { return WithWorkflow(ctx, workflow) },
+			func(ctx context.Context) any { return GetWorkflow(ctx) }, workflow, (*Workflow)(nil)},
+		{"session id", func(ctx context.Context) context.Context { return WithSessionID(ctx, "sess") },
+			func(ctx context.Context) any { return SessionIDFromContext(ctx) }, "sess", ""},
+		{"auth key id", func(ctx context.Context) context.Context { return WithAuthKeyID(ctx, "key") },
+			func(ctx context.Context) any { return GetAuthKeyID(ctx) }, "key", ""},
+		{"allowed models", func(ctx context.Context) context.Context { return WithCredentialAllowedModels(ctx, []string{"gpt-4o"}) },
+			func(ctx context.Context) any { return GetCredentialAllowedModels(ctx) }, []string{"gpt-4o"}, []string(nil)},
+		{"effective user path", func(ctx context.Context) context.Context { return WithEffectiveUserPath(ctx, "/acme") },
+			func(ctx context.Context) any { return GetEffectiveUserPath(ctx) }, "/acme", ""},
+		{"user path header name", func(ctx context.Context) context.Context { return WithUserPathHeaderName(ctx, "x-tenant") },
+			func(ctx context.Context) any { return UserPathHeaderNameFromContext(ctx) }, "X-Tenant", UserPathHeader},
+		{"labels", func(ctx context.Context) context.Context { return WithRequestLabels(ctx, []string{"a", "b"}) },
+			func(ctx context.Context) any { return RequestLabelsFromContext(ctx) }, []string{"a", "b"}, []string(nil)},
+		{"strip headers", func(ctx context.Context) context.Context { return WithTaggingStripHeaders(ctx, strip) },
+			func(ctx context.Context) any { return TaggingStripHeadersFromContext(ctx) }, strip, map[string]struct{}(nil)},
+		{"rewrite tokens saved", func(ctx context.Context) context.Context { return WithRewriteTokensSaved(ctx, 42) },
+			func(ctx context.Context) any { return RewriteTokensSavedFromContext(ctx) }, 42, 0},
+		{"failover used", func(ctx context.Context) context.Context { return WithFailoverUsed(ctx) },
+			func(ctx context.Context) any { return GetFailoverUsed(ctx) }, true, false},
+	}
+}
+
+func TestRequestScopeAccessorsMatchPlainContext(t *testing.T) {
+	for _, v := range requestScopeValues() {
+		t.Run(v.name, func(t *testing.T) {
+			plain := context.Background()
+			scoped, _ := WithRequestScope(context.Background())
+
+			assert.Equal(t, v.empty, v.read(plain), "plain: unset")
+			assert.Equal(t, v.empty, v.read(scoped), "scoped: unset")
+			assert.Equal(t, v.want, v.read(v.with(plain)), "plain: set")
+			assert.Equal(t, v.want, v.read(v.with(scoped)), "scoped: set")
+		})
+	}
+}
+
+func TestRequestScopeSeedsFromExistingValues(t *testing.T) {
+	// Values installed by an outer middleware before the scope exists must
+	// stay visible through the scope.
+	for _, v := range requestScopeValues() {
+		t.Run(v.name, func(t *testing.T) {
+			ctx := v.with(context.Background())
+			scoped, scope := WithRequestScope(ctx)
+			require.NotNil(t, scope)
+			assert.Equal(t, v.want, v.read(scoped))
+		})
+	}
+}
+
+func TestRequestScopeWithKeepsContextValueSemantics(t *testing.T) {
+	// With* on a scoped context layers a clone: the parent and any context
+	// derived before the call keep the earlier value, and a later With* wins
+	// on the derived chain. This is what guardrail-internal calls rely on when
+	// they override the effective user path for their own upstream request.
+	base, _ := WithRequestScope(context.Background())
+	base = WithEffectiveUserPath(base, "/tenant")
+	earlier := context.WithValue(base, contextKey("marker"), 1)
+
+	internal := WithEffectiveUserPath(base, "/internal/guardrail")
+	assert.Equal(t, "/internal/guardrail", GetEffectiveUserPath(internal))
+	assert.Equal(t, "/tenant", GetEffectiveUserPath(base))
+	assert.Equal(t, "/tenant", GetEffectiveUserPath(earlier))
+
+	later := WithEffectiveUserPath(internal, "/tenant/child")
+	assert.Equal(t, "/tenant/child", GetEffectiveUserPath(later))
+	assert.Equal(t, "/internal/guardrail", GetEffectiveUserPath(internal))
+
+	assert.Same(t, RequestScopeFromContext(base), RequestScopeFromContext(earlier))
+	assert.NotSame(t, RequestScopeFromContext(base), RequestScopeFromContext(internal))
+}
+
+func TestRequestScopeSetMutatesInPlace(t *testing.T) {
+	// Set* is the in-place path used by the middleware chain: every context
+	// sharing the scope, including ones derived earlier, observes the update.
+	ctx, scope := WithRequestScope(context.Background())
+	derived := context.WithValue(ctx, contextKey("marker"), 1)
+
+	scope.SetRequestID("req-9")
+	scope.SetSessionID("sess")
+	scope.SetFailoverUsed()
+	assert.Equal(t, "req-9", GetRequestID(derived))
+	assert.Equal(t, "sess", SessionIDFromContext(derived))
+	assert.True(t, GetFailoverUsed(derived))
+
+	// The same context is returned when a scope is already installed.
+	again, sameScope := WithRequestScope(derived)
+	assert.Same(t, scope, sameScope)
+	assert.Equal(t, derived, again)
+}
+
+func TestRequestScopeSettersMirrorWithNoOps(t *testing.T) {
+	tests := []struct {
+		name  string
+		set   func(*RequestScope)
+		with  func(context.Context) context.Context
+		read  func(context.Context) any
+		start func(context.Context) context.Context
+	}{
+		{"empty session id keeps previous",
+			func(s *RequestScope) { s.SetSessionID("") },
+			func(ctx context.Context) context.Context { return WithSessionID(ctx, "") },
+			func(ctx context.Context) any { return SessionIDFromContext(ctx) },
+			func(ctx context.Context) context.Context { return WithSessionID(ctx, "keep") }},
+		{"default header name keeps previous",
+			func(s *RequestScope) { s.SetUserPathHeaderName(UserPathHeader) },
+			func(ctx context.Context) context.Context { return WithUserPathHeaderName(ctx, UserPathHeader) },
+			func(ctx context.Context) any { return UserPathHeaderNameFromContext(ctx) },
+			func(ctx context.Context) context.Context { return WithUserPathHeaderName(ctx, "X-Tenant") }},
+		{"empty labels keep previous",
+			func(s *RequestScope) { s.SetLabels(nil) },
+			func(ctx context.Context) context.Context { return WithRequestLabels(ctx, nil) },
+			func(ctx context.Context) any { return RequestLabelsFromContext(ctx) },
+			func(ctx context.Context) context.Context { return WithRequestLabels(ctx, []string{"keep"}) }},
+		{"empty strip set keeps previous",
+			func(s *RequestScope) { s.SetTaggingStripHeaders(nil) },
+			func(ctx context.Context) context.Context { return WithTaggingStripHeaders(ctx, nil) },
+			func(ctx context.Context) any { return TaggingStripHeadersFromContext(ctx) },
+			func(ctx context.Context) context.Context {
+				return WithTaggingStripHeaders(ctx, map[string]struct{}{"X-Keep": {}})
+			}},
+		{"non-positive rewrite savings keep previous",
+			func(s *RequestScope) { s.SetRewriteTokensSaved(0) },
+			func(ctx context.Context) context.Context { return WithRewriteTokensSaved(ctx, 0) },
+			func(ctx context.Context) any { return RewriteTokensSavedFromContext(ctx) },
+			func(ctx context.Context) context.Context { return WithRewriteTokensSaved(ctx, 7) }},
+		{"empty allowlist clears",
+			func(s *RequestScope) { s.SetCredentialAllowedModels(nil) },
+			func(ctx context.Context) context.Context { return WithCredentialAllowedModels(ctx, nil) },
+			func(ctx context.Context) any { return GetCredentialAllowedModels(ctx) },
+			func(ctx context.Context) context.Context { return WithCredentialAllowedModels(ctx, []string{"gpt-4o"}) }},
+		{"empty effective user path clears",
+			func(s *RequestScope) { s.SetEffectiveUserPath("") },
+			func(ctx context.Context) context.Context { return WithEffectiveUserPath(ctx, "") },
+			func(ctx context.Context) any { return GetEffectiveUserPath(ctx) },
+			func(ctx context.Context) context.Context { return WithEffectiveUserPath(ctx, "/acme") }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plain := tt.with(tt.start(context.Background()))
+			scopedCtx, scope := WithRequestScope(tt.start(context.Background()))
+			tt.set(scope)
+			assert.Equal(t, tt.read(plain), tt.read(scopedCtx), "in-place Set must match plain With")
+			assert.Equal(t, tt.read(plain), tt.read(tt.with(scopedCtx)), "scoped With must match plain With")
+		})
+	}
+}
+
+func TestRequestScopeWithWorkflowIsIdempotent(t *testing.T) {
+	workflow := &Workflow{RequestID: "wf"}
+	ctx, _ := WithRequestScope(context.Background())
+	ctx = WithWorkflow(ctx, workflow)
+	assert.Equal(t, ctx, WithWorkflow(ctx, workflow), "same workflow must not layer a clone")
+}

--- a/internal/core/user_path.go
+++ b/internal/core/user_path.go
@@ -24,12 +24,25 @@ func UserPathHeaderName(raw string) string {
 // UserPathHeaderNameFromContext returns the request-scoped user-path header
 // name, falling back to the default public header.
 func UserPathHeaderNameFromContext(ctx context.Context) string {
-	if ctx != nil {
-		if value, ok := ctx.Value(userPathHeaderNameKey).(string); ok {
-			return UserPathHeaderName(value)
-		}
+	if name := userPathHeaderNameValue(ctx); name != "" {
+		return UserPathHeaderName(name)
 	}
 	return UserPathHeader
+}
+
+// userPathHeaderNameValue returns the raw configured header name carried by
+// ctx, or "" when only the default applies.
+func userPathHeaderNameValue(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if scope := RequestScopeFromContext(ctx); scope != nil {
+		return scope.userPathHeaderName
+	}
+	if value, ok := ctx.Value(userPathHeaderNameKey).(string); ok {
+		return value
+	}
+	return ""
 }
 
 // NormalizeUserPath canonicalizes one user hierarchy path from request ingress.

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -71,10 +71,10 @@ func AuthMiddlewareWithRequestAuthenticators(masterKey string, authenticator Bea
 				// the response header would leave downstream context consumers scoped
 				// to the wrong principal.
 				setAuthenticationUserHeader(c, "")
-				ctx := ext.WithoutAuthentication(c.Request().Context())
-				ctx = core.WithEffectiveUserPath(ctx, "")
-				ctx = core.WithCredentialAllowedModels(ctx, nil)
-				c.SetRequest(c.Request().WithContext(ctx))
+				c.SetRequest(c.Request().WithContext(ext.WithoutAuthentication(c.Request().Context())))
+				scope := requestScope(c)
+				scope.SetEffectiveUserPath("")
+				scope.SetCredentialAllowedModels(nil)
 				if tokenErr != "" {
 					authErr := authenticationError(c, tokenErr)
 					return writeGatewayError(c, authErr)
@@ -170,19 +170,14 @@ func applyExtensionAuthResult(c *echo.Context, result *ext.Authentication, userP
 	ctx := context.WithValue(c.Request().Context(), managedDashboardAccessKey{}, normalized.DashboardAccess)
 	ctx = context.WithValue(ctx, interactionContinuationAllowedKey{}, normalized.DashboardAccess)
 	ctx = ext.WithAuthentication(ctx, normalized)
+	c.SetRequest(c.Request().WithContext(ctx))
+	scope := requestScope(c)
 	if len(normalized.Labels) > 0 {
-		ctx = core.WithRequestLabels(ctx, core.MergeLabels(core.RequestLabelsFromContext(ctx), normalized.Labels))
+		scope.SetLabels(core.MergeLabels(core.RequestLabelsFromContext(ctx), normalized.Labels))
 	}
 	if userPath != "" {
-		ctx = core.WithEffectiveUserPath(ctx, userPath)
-		ctx = core.WithUserPathHeaderName(ctx, userPathHeaderName)
-		if snapshot := core.GetRequestSnapshot(ctx); snapshot != nil {
-			ctx = core.WithRequestSnapshot(ctx, snapshot.WithUserPathHeader(userPath, userPathHeaderName))
-		}
-		c.Request().Header.Set(userPathHeaderName, userPath)
-		auditlog.EnrichEntryWithUserPath(c, userPath)
+		bindScopeUserPath(c, scope, userPath, userPathHeaderName)
 	}
-	c.SetRequest(c.Request().WithContext(ctx))
 	setAuthenticationUserHeader(c, userPath)
 	auditlog.EnrichEntryWithAuthMethod(c, normalized.Method)
 	auditlog.EnrichEntryWithPrincipalID(c, normalized.PrincipalID)
@@ -269,29 +264,37 @@ func interactionContinuationAllowed(ctx context.Context) bool {
 // applyAuthKeyResult enriches the request context and audit entry with the
 // authenticated managed key's identity, labels, and bound user path.
 func applyAuthKeyResult(c *echo.Context, authResult authkeys.AuthenticationResult, userPathHeaderName string) {
-	ctx := core.WithAuthKeyID(c.Request().Context(), authResult.ID)
-	ctx = context.WithValue(ctx, managedDashboardAccessKey{}, authResult.DashboardAccess)
+	ctx := context.WithValue(c.Request().Context(), managedDashboardAccessKey{}, authResult.DashboardAccess)
 	ctx = context.WithValue(ctx, interactionContinuationAllowedKey{}, authResult.DashboardAccess)
+	c.SetRequest(c.Request().WithContext(ctx))
+	scope := requestScope(c)
+	scope.SetAuthKeyID(authResult.ID)
 	if len(authResult.AllowedModels) > 0 {
-		ctx = core.WithCredentialAllowedModels(ctx, authResult.AllowedModels)
+		scope.SetCredentialAllowedModels(authResult.AllowedModels)
 	}
 	if len(authResult.Labels) > 0 {
 		// Key labels join any labels the tagging middleware already
 		// extracted from request headers; duplicates collapse.
-		ctx = core.WithRequestLabels(ctx, core.MergeLabels(core.RequestLabelsFromContext(ctx), authResult.Labels))
+		scope.SetLabels(core.MergeLabels(core.RequestLabelsFromContext(ctx), authResult.Labels))
 	}
 	if userPath := strings.TrimSpace(authResult.UserPath); userPath != "" {
-		ctx = core.WithEffectiveUserPath(ctx, userPath)
-		ctx = core.WithUserPathHeaderName(ctx, userPathHeaderName)
-		if snapshot := core.GetRequestSnapshot(ctx); snapshot != nil {
-			ctx = core.WithRequestSnapshot(ctx, snapshot.WithUserPathHeader(userPath, userPathHeaderName))
-		}
-		c.Request().Header.Set(userPathHeaderName, userPath)
-		auditlog.EnrichEntryWithUserPath(c, userPath)
+		bindScopeUserPath(c, scope, userPath, userPathHeaderName)
 	}
-	c.SetRequest(c.Request().WithContext(ctx))
 	setAuthenticationUserHeader(c, strings.TrimSpace(authResult.UserPath))
 	auditlog.EnrichEntryWithAuthKeyID(c, authResult.ID)
+}
+
+// bindScopeUserPath binds a credential's user path to the request: the
+// effective path, the configured header name, the captured snapshot, the
+// live header, and the audit entry all follow it.
+func bindScopeUserPath(c *echo.Context, scope *core.RequestScope, userPath, userPathHeaderName string) {
+	scope.SetEffectiveUserPath(userPath)
+	scope.SetUserPathHeaderName(userPathHeaderName)
+	if snapshot := core.GetRequestSnapshot(c.Request().Context()); snapshot != nil {
+		scope.SetSnapshot(snapshot.WithUserPathHeader(userPath, userPathHeaderName))
+	}
+	c.Request().Header.Set(userPathHeaderName, userPath)
+	auditlog.EnrichEntryWithUserPath(c, userPath)
 }
 
 func setAuthenticationUserHeader(c *echo.Context, userPath string) {

--- a/internal/server/model_call_service.go
+++ b/internal/server/model_call_service.go
@@ -63,7 +63,6 @@ func (s *modelCallService) prepare(c *echo.Context, model, providerHint string) 
 	auditlog.EnrichEntry(c, selector.Model, "")
 
 	ctx, requestID := requestContextWithRequestID(c.Request())
-	c.SetRequest(c.Request().WithContext(ctx))
 	route := s.routeFor(selector, requestID)
 	// Stamp the executed route so audit rows carry the resolved model and
 	// provider, as the inference orchestrator does for chat.

--- a/internal/server/model_validation.go
+++ b/internal/server/model_validation.go
@@ -52,7 +52,7 @@ func deriveWorkflowWithPolicy(
 
 	requestID := requestIDFromContextOrHeader(c.Request())
 	if requestID != "" && strings.TrimSpace(core.GetRequestID(c.Request().Context())) != requestID {
-		c.SetRequest(c.Request().WithContext(core.WithRequestID(c.Request().Context(), requestID)))
+		requestScope(c).SetRequestID(requestID)
 	}
 
 	desc := core.DescribeEndpoint(c.Request().Method, c.Request().URL.Path)
@@ -127,10 +127,10 @@ func storeWorkflow(c *echo.Context, workflow *core.Workflow) {
 		return
 	}
 	// Resolution stores the workflow once and the inference path stores it
-	// again after preparation; skip the context wrap (and request copy) when
-	// the context already carries this exact workflow.
-	if ctx := c.Request().Context(); core.GetWorkflow(ctx) != workflow {
-		c.SetRequest(c.Request().WithContext(core.WithWorkflow(ctx, workflow)))
+	// again after preparation; skip the scope update when the context already
+	// carries this exact workflow.
+	if core.GetWorkflow(c.Request().Context()) != workflow {
+		requestScope(c).SetWorkflow(workflow)
 	}
 	auditlog.EnrichEntryWithWorkflow(c, workflow)
 }

--- a/internal/server/native_response_service.go
+++ b/internal/server/native_response_service.go
@@ -199,7 +199,6 @@ func (s *nativeResponseService) DeleteResponse(c *echo.Context) error {
 
 func (s *nativeResponseService) CountResponseInputTokens(c *echo.Context) error {
 	ctx, _ := requestContextWithRequestID(c.Request())
-	c.SetRequest(c.Request().WithContext(ctx))
 
 	req, providerType, err := s.utilityRequest(c)
 	if err != nil {
@@ -229,7 +228,6 @@ func (s *nativeResponseService) CountResponseInputTokens(c *echo.Context) error 
 
 func (s *nativeResponseService) CompactResponse(c *echo.Context) error {
 	ctx, _ := requestContextWithRequestID(c.Request())
-	c.SetRequest(c.Request().WithContext(ctx))
 
 	req, providerType, err := s.utilityRequest(c)
 	if err != nil {

--- a/internal/server/passthrough_semantic_enrichment_test.go
+++ b/internal/server/passthrough_semantic_enrichment_test.go
@@ -47,7 +47,8 @@ func TestPassthroughSemanticEnrichment_EnrichesPromptBeforeWorkflowResolution(t 
 		return c.String(http.StatusOK, "ok")
 	}))
 
-	ctxReq, _ := ensureRequestID(c.Request())
+	ctxReq, scope := installRequestScope(c.Request())
+	ensureRequestID(ctxReq, scope)
 	c.SetRequest(ctxReq)
 	err := RequestSnapshotCapture()(handler)(c)
 	require.NoError(t, err)

--- a/internal/server/passthrough_service.go
+++ b/internal/server/passthrough_service.go
@@ -47,7 +47,6 @@ func (s *passthroughService) ProviderPassthrough(c *echo.Context) error {
 	defer adm.release()
 
 	ctx, _ := requestContextWithRequestID(c.Request())
-	c.SetRequest(c.Request().WithContext(ctx))
 	resp, err := passthroughProvider.Passthrough(ctx, providerType, &core.PassthroughRequest{
 		Method:          c.Request().Method,
 		Endpoint:        endpoint,

--- a/internal/server/realtime_service.go
+++ b/internal/server/realtime_service.go
@@ -225,7 +225,6 @@ func (s *realtimeService) prepare(c *echo.Context, model, providerHint string) (
 	auditlog.EnrichEntry(c, selector.Model, "")
 
 	ctx, requestID := requestContextWithRequestID(c.Request())
-	c.SetRequest(c.Request().WithContext(ctx))
 
 	qualified := selector.QualifiedModel()
 	route := realtimeRoute{

--- a/internal/server/request_model_resolution.go
+++ b/internal/server/request_model_resolution.go
@@ -68,16 +68,14 @@ func storeRequestModelResolution(c *echo.Context, resolution *core.RequestModelR
 		return
 	}
 
-	ctx := c.Request().Context()
-	if workflow := core.GetWorkflow(ctx); workflow != nil {
+	if workflow := core.GetWorkflow(c.Request().Context()); workflow != nil {
 		cloned := *workflow
 		cloned.ProviderType = resolution.ProviderType
 		cloned.Resolution = resolution
-		ctx = core.WithWorkflow(ctx, &cloned)
-		c.SetRequest(c.Request().WithContext(ctx))
+		requestScope(c).SetWorkflow(&cloned)
 		auditlog.EnrichEntryWithWorkflow(c, &cloned)
 	}
-	if env := core.GetWhiteBoxPrompt(ctx); env != nil {
+	if env := core.GetWhiteBoxPrompt(c.Request().Context()); env != nil {
 		env.RouteHints.Model = resolution.ResolvedSelector.Model
 		env.RouteHints.Provider = resolution.ResolvedSelector.Provider
 	}

--- a/internal/server/request_rewrite.go
+++ b/internal/server/request_rewrite.go
@@ -83,10 +83,7 @@ func RequestRewriteMiddleware(rewriters []ext.RequestRewriter, auditLogger audit
 			if changed {
 				pinOriginalAuditRequestBody(c, auditLogger)
 				applyRewrittenBody(c, in.Body)
-				if tokensSaved > 0 {
-					req := c.Request()
-					c.SetRequest(req.WithContext(core.WithRewriteTokensSaved(req.Context(), tokensSaved)))
-				}
+				requestScope(c).SetRewriteTokensSaved(tokensSaved)
 			}
 			if len(feedbackObservers) > 0 {
 				setResponseFeedbackObservers(c, feedbackObservers)

--- a/internal/server/request_scope.go
+++ b/internal/server/request_scope.go
@@ -1,0 +1,22 @@
+package server
+
+import (
+	"github.com/labstack/echo/v5"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+// requestScope returns the request's mutable scope. RequestSnapshotCapture
+// installs it for every request that passes through the middleware chain;
+// handlers reached directly (tests, embedded use) get one installed here so
+// later stages can update request state in place without re-wrapping the
+// request context.
+func requestScope(c *echo.Context) *core.RequestScope {
+	req := c.Request()
+	if scope := core.RequestScopeFromContext(req.Context()); scope != nil {
+		return scope
+	}
+	ctx, scope := core.WithRequestScope(req.Context())
+	c.SetRequest(req.WithContext(ctx))
+	return scope
+}

--- a/internal/server/request_scope_bench_test.go
+++ b/internal/server/request_scope_bench_test.go
@@ -1,0 +1,63 @@
+package server
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/session"
+	"github.com/enterpilot/gomodel/internal/tagging"
+)
+
+// BenchmarkMiddlewareChainChatCompletion drives a small non-streaming chat
+// request through the full server middleware chain (snapshot capture,
+// tagging, auth, session detection, workflow resolution) against an
+// in-memory provider. It measures per-request overhead that the request
+// scope refactor targets, not provider or serialization cost.
+func BenchmarkMiddlewareChainChatCompletion(b *testing.B) {
+	mock := &mockProvider{
+		supportedModels: []string{"gpt-4o-mini"},
+		response: &core.ChatResponse{
+			ID:      "chatcmpl-bench",
+			Object:  "chat.completion",
+			Created: 1234567890,
+			Model:   "gpt-4o-mini",
+			Choices: []core.Choice{{
+				Index:        0,
+				Message:      core.ResponseMessage{Role: "assistant", Content: "Hello!"},
+				FinishReason: "stop",
+			}},
+			Usage: core.Usage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15},
+		},
+	}
+	srv := New(mock, &Config{
+		MasterKey:       "bench-master-key",
+		SessionDetector: session.NewDetector(nil, true),
+		Tagging:         tagging.NewService([]tagging.Rule{{Header: "X-Team", DoNotPass: true}}, nil),
+	})
+
+	// The request logger would otherwise dominate the measurement.
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	b.Cleanup(func() { slog.SetDefault(previous) })
+
+	body := []byte(`{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Hello"}]}`)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer bench-master-key")
+		req.Header.Set("X-Team", "platform")
+		req.Header.Set(core.UserPathHeader, "/acme/platform")
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			b.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+		}
+	}
+}

--- a/internal/server/request_snapshot.go
+++ b/internal/server/request_snapshot.go
@@ -23,14 +23,17 @@ func RequestSnapshotCapture(userPathHeader ...string) echo.MiddlewareFunc {
 	userPathHeaderName := configuredUserPathHeaderName(userPathHeader...)
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c *echo.Context) error {
-			req, requestID := ensureRequestID(c.Request())
+			// One context wrap installs the request scope; every later stage
+			// fills it in place instead of re-wrapping (and copying) the request.
+			req, scope := installRequestScope(c.Request())
+			requestID := ensureRequestID(req, scope)
 			c.Response().Header().Set(core.RequestIDHeader, requestID)
 			desc := core.DescribeEndpoint(req.Method, req.URL.Path)
 			if !desc.IngressManaged {
 				// The configured header name must reach every handler that
 				// reads the user path itself (GET /v1/models), not only the
 				// model-interaction endpoints below.
-				req = req.WithContext(core.WithUserPathHeaderName(req.Context(), userPathHeaderName))
+				scope.SetUserPathHeaderName(userPathHeaderName)
 				// Model endpoints that own their transport (MCP, realtime,
 				// audio) take no snapshot, but their identity must still reach
 				// the context: rate limits, budgets, session binding, and
@@ -44,7 +47,7 @@ func RequestSnapshotCapture(userPathHeader ...string) echo.MiddlewareFunc {
 					}
 					if userPath != "" {
 						req.Header.Set(userPathHeaderName, userPath)
-						req = req.WithContext(core.WithEffectiveUserPath(req.Context(), userPath))
+						scope.SetEffectiveUserPath(userPath)
 					}
 				}
 				c.SetRequest(req)
@@ -80,15 +83,15 @@ func RequestSnapshotCapture(userPathHeader ...string) echo.MiddlewareFunc {
 				userPath,
 			)
 
-			ctx := core.WithUserPathHeaderName(req.Context(), userPathHeaderName)
-			ctx = core.WithRequestSnapshot(ctx, snapshot)
+			scope.SetUserPathHeaderName(userPathHeaderName)
+			scope.SetSnapshot(snapshot)
 			if semantics := core.DeriveWhiteBoxPrompt(snapshot); semantics != nil {
 				if !bodyCaptured {
 					seedRequestBodySelectorHints(req, desc.BodyMode, semantics)
 				}
-				ctx = core.WithWhiteBoxPrompt(ctx, semantics)
+				scope.SetWhiteBoxPrompt(semantics)
 			}
-			c.SetRequest(req.WithContext(ctx))
+			c.SetRequest(req)
 
 			return next(c)
 		}
@@ -102,7 +105,19 @@ func configuredUserPathHeaderName(headerNames ...string) string {
 	return core.UserPathHeaderName(headerNames[0])
 }
 
-func ensureRequestID(req *http.Request) (*http.Request, string) {
+// installRequestScope returns req carrying a request scope, wrapping its
+// context once when it has none yet.
+func installRequestScope(req *http.Request) (*http.Request, *core.RequestScope) {
+	if scope := core.RequestScopeFromContext(req.Context()); scope != nil {
+		return req, scope
+	}
+	ctx, scope := core.WithRequestScope(req.Context())
+	return req.WithContext(ctx), scope
+}
+
+// ensureRequestID resolves the request id (context, client header, or a fresh
+// UUID), mirrors it into the request header, and records it on the scope.
+func ensureRequestID(req *http.Request, scope *core.RequestScope) string {
 	if req.Header == nil {
 		req.Header = make(http.Header)
 	}
@@ -115,10 +130,8 @@ func ensureRequestID(req *http.Request) (*http.Request, string) {
 	}
 
 	req.Header.Set(core.RequestIDHeader, requestID)
-	if current := strings.TrimSpace(core.GetRequestID(req.Context())); current != requestID {
-		req = req.WithContext(core.WithRequestID(req.Context(), requestID))
-	}
-	return req, requestID
+	scope.SetRequestID(requestID)
+	return requestID
 }
 
 func snapshotRouteParams(path string, params map[string]string) map[string]string {
@@ -263,14 +276,14 @@ func storeRequestBodySnapshot(c *echo.Context, bodyBytes []byte) {
 	}
 
 	updated := snapshot.WithOwnedCapturedBody(capturedBody, bodyNotCaptured)
-	ctx := core.WithRequestSnapshot(req.Context(), updated)
+	scope := requestScope(c)
+	scope.SetSnapshot(updated)
 	previous := core.GetWhiteBoxPrompt(req.Context())
 	semanticSnapshot := updated
 	if bodyNotCaptured {
 		semanticSnapshot = snapshot.WithOwnedCapturedBody(bodyBytes, false)
 	}
 	if semantics := core.RefreshWhiteBoxPrompt(semanticSnapshot, previous); semantics != nil {
-		ctx = core.WithWhiteBoxPrompt(ctx, semantics)
+		scope.SetWhiteBoxPrompt(semantics)
 	}
-	c.SetRequest(req.WithContext(ctx))
 }

--- a/internal/server/request_support.go
+++ b/internal/server/request_support.go
@@ -43,8 +43,9 @@ func applyUserPathHeaderToContext(c *echo.Context) (bool, error) {
 		return true, nil
 	}
 	req.Header.Set(headerName, userPath)
-	ctx = core.WithUserPathHeaderName(ctx, headerName)
-	c.SetRequest(req.WithContext(core.WithEffectiveUserPath(ctx, userPath)))
+	scope := requestScope(c)
+	scope.SetUserPathHeaderName(headerName)
+	scope.SetEffectiveUserPath(userPath)
 	return true, nil
 }
 
@@ -88,8 +89,12 @@ func requestContextWithRequestID(req *http.Request) (context.Context, string) {
 
 	ctx := req.Context()
 	if strings.TrimSpace(core.GetRequestID(ctx)) != requestID {
-		ctx = core.WithRequestID(ctx, requestID)
-		*req = *req.WithContext(ctx)
+		if scope := core.RequestScopeFromContext(ctx); scope != nil {
+			scope.SetRequestID(requestID)
+		} else {
+			ctx = core.WithRequestID(ctx, requestID)
+			*req = *req.WithContext(ctx)
+		}
 	}
 
 	return ctx, requestID

--- a/internal/server/semantic_requests.go
+++ b/internal/server/semantic_requests.go
@@ -22,7 +22,7 @@ func ensureWhiteBoxPrompt(c *echo.Context) *core.WhiteBoxPrompt {
 		return nil
 	}
 
-	c.SetRequest(c.Request().WithContext(core.WithWhiteBoxPrompt(ctx, semantics)))
+	requestScope(c).SetWhiteBoxPrompt(semantics)
 	return semantics
 }
 

--- a/internal/server/session.go
+++ b/internal/server/session.go
@@ -37,8 +37,7 @@ func sessionCapture(detector *session.Detector, parentLookup interactionParentLo
 				if id == "" {
 					return false
 				}
-				req := c.Request()
-				c.SetRequest(req.WithContext(core.WithSessionID(req.Context(), id)))
+				requestScope(c).SetSessionID(id)
 				auditlog.EnrichEntryWithSessionID(c, id)
 				return true
 			}
@@ -149,7 +148,6 @@ func sessionDetectionSnapshot(c *echo.Context, snapshot *core.RequestSnapshot) (
 
 func markSessionBodyNotCaptured(c *echo.Context, snapshot *core.RequestSnapshot) *core.RequestSnapshot {
 	updated := snapshot.WithOwnedCapturedBody(nil, true)
-	req := c.Request()
-	c.SetRequest(req.WithContext(core.WithRequestSnapshot(req.Context(), updated)))
+	requestScope(c).SetSnapshot(updated)
 	return updated
 }

--- a/internal/server/tagging.go
+++ b/internal/server/tagging.go
@@ -3,7 +3,6 @@ package server
 import (
 	"github.com/labstack/echo/v5"
 
-	"github.com/enterpilot/gomodel/internal/core"
 	"github.com/enterpilot/gomodel/internal/tagging"
 )
 
@@ -17,20 +16,9 @@ func TaggingCapture(service *tagging.Service) echo.MiddlewareFunc {
 			if service == nil || !service.HasRules() {
 				return next(c)
 			}
-			req := c.Request()
-			ctx := req.Context()
-			changed := false
-			if labels := service.ExtractLabels(req.Header); len(labels) > 0 {
-				ctx = core.WithRequestLabels(ctx, labels)
-				changed = true
-			}
-			if strip := service.StripHeaders(); len(strip) > 0 {
-				ctx = core.WithTaggingStripHeaders(ctx, strip)
-				changed = true
-			}
-			if changed {
-				c.SetRequest(req.WithContext(ctx))
-			}
+			scope := requestScope(c)
+			scope.SetLabels(service.ExtractLabels(c.Request().Header))
+			scope.SetTaggingStripHeaders(service.StripHeaders())
 			return next(c)
 		}
 	}

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -512,7 +512,6 @@ func (s *translatedInferenceService) tryFastPathChatPassthrough(c *echo.Context,
 	}
 
 	ctx, _ := requestContextWithRequestID(c.Request())
-	c.SetRequest(c.Request().WithContext(ctx))
 
 	const endpoint = "/chat/completions"
 	providerType := strings.TrimSpace(workflow.ProviderType)
@@ -886,7 +885,7 @@ func markRequestFailoverUsed(c *echo.Context) {
 	if c == nil || c.Request() == nil {
 		return
 	}
-	c.SetRequest(c.Request().WithContext(core.WithFailoverUsed(c.Request().Context())))
+	requestScope(c).SetFailoverUsed()
 }
 
 func resolvedModelFromWorkflow(workflow *core.Workflow, fallback string) string {

--- a/internal/server/workflow_helpers.go
+++ b/internal/server/workflow_helpers.go
@@ -106,10 +106,8 @@ func translatedWorkflowForRequest(
 	}
 
 	requestID := requestIDFromContextOrHeader(c.Request())
-	ctx := c.Request().Context()
-	if requestID != "" && strings.TrimSpace(core.GetRequestID(ctx)) != requestID {
-		ctx = core.WithRequestID(ctx, requestID)
-		c.SetRequest(c.Request().WithContext(ctx))
+	if requestID != "" && strings.TrimSpace(core.GetRequestID(c.Request().Context())) != requestID {
+		requestScope(c).SetRequestID(requestID)
 	}
 
 	return translatedWorkflow(


### PR DESCRIPTION
Stacked on #845 (`perf/chat-fast-path-non-streaming`).

## What

The middleware chain used to re-wrap the request context (and copy `*http.Request`) at every stage that attached a value: snapshot, user path, request id, tagging labels, auth identity, session id, workflow, body snapshot refresh, rewrite savings, failover marker. Reads then walked the whole chain for each key.

`RequestSnapshotCapture` now installs one `core.RequestScope` per request; later stages fill it in place through `Set*` methods. `SetRequest` sites in `internal/server`: 27 → 10. The remaining ones install the scope itself, carry `ext`/server-local context keys (auth), adopt the gateway-prepared context, install the attempt observer, or clone the request for base-path stripping.

## Semantics preserved

- Every `core.With*`/`Get*` accessor keeps its public contract. On a context carrying a scope, `With*` clones the scope and layers the clone, so a context derived before the call never observes the change (this is what the guardrail-internal LLM call relies on when it overrides the effective user path for its own request; covered by `TestRequestScopeWithKeepsContextValueSemantics`).
- Only the in-place `Set*` methods mutate, and only the ingress chain uses them, on the request goroutine.
- The scope is seeded from values already on the context, so anything an outer extension middleware attached stays visible.
- No-op rules (`WithSessionID("")`, default user-path header name, empty labels/strip set, non-positive rewrite savings, idempotent `WithWorkflow`) are shared between `With*` and `Set*` and pinned by `TestRequestScopeSettersMirrorWithNoOps`.
- Redundancy removed: six handlers called `requestContextWithRequestID` (which already updates the request in place) and then re-set the same request; those second calls are gone.

## Numbers

`BenchmarkMiddlewareChainChatCompletion` (new): full `server.New` chain with master-key auth, tagging, session detection, workflow resolution, in-memory provider, small non-streaming chat body. Medians of 6 runs:

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| before | 10 800 | 16 020 | 122 |
| after | 10 420 | 14 462 | 108 |

About 4% wall time, 10% bytes, 11% allocations per request. The benchmark includes routing, JSON decode/encode and the provider call, so the share attributable to the middleware chain is larger than the headline figure.

## Verification

`go build ./...`, `go vet`, full `go test` over internal/config/ext/run/cmd, `go test -race` for `internal/server` and `internal/core`, `make lint` (0 issues); the pre-commit hook ran the race suite, fix-check and lint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved consistency of request metadata throughout processing, including request IDs, sessions, workflows, authentication, labels, and user-path settings.
  - Preserved request information more reliably across middleware and service operations.
  - Improved tracking of rewrite savings and failover activity.
  - Maintained compatibility with existing request-context behavior when scoped request state is unavailable.

- **Performance**
  - Added coverage to measure request-processing overhead across the middleware chain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->