### PR TITLE
docs: state that streaming responses are cached and that virtual models are not allowlist selectors

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -97,7 +97,7 @@ models:
 #   - path: /acme
 #     allowed_models: [openai/*, anthropic/*]
 #   - path: /acme/eng
-#     allowed_models: [anthropic/*] # provider wildcard, provider/model, or bare model id
+#     allowed_models: [anthropic/*] # provider wildcard, provider/model, or bare model id; virtual models resolve to their targets first, so list the targets, not the virtual model
 #     description: Engineering only ships on Claude
 
 # MCP gateway: aggregate upstream MCP (Model Context Protocol) servers behind the

--- a/docs/features/cache.mdx
+++ b/docs/features/cache.mdx
@@ -7,12 +7,17 @@ keywords: ["response cache", "semantic cache", "exact cache", "cache key", "Redi
 
 ## Overview
 
-GoModel ships with two response-cache layers for non-streaming requests on:
+GoModel ships with two response-cache layers for streaming and non-streaming
+requests on:
 
 - `/v1/chat/completions`
 - `/v1/responses`
 - `/v1/messages`
 - `/v1/embeddings`
+
+Streaming and non-streaming variants of the same request are cached
+independently: a streaming miss stores the raw SSE bytes and a streaming hit
+replays them verbatim as `text/event-stream`.
 
 Exact-match cache returns byte-identical responses with:
 

--- a/docs/features/users.mdx
+++ b/docs/features/users.mdx
@@ -107,8 +107,13 @@ Each entry in an allowlist is one selector:
 | `*`                | every model; redundant unless you want an explicit row, and it never widens a parent's list (rule 3) |
 
 Provider names must match a configured provider; unknown names are rejected
-when the policy is saved. Virtual model aliases resolve to their target before
-the check runs, so allow the target model, not the alias.
+when the policy is saved. Virtual models are not selectors: an alias or a load
+balancer resolves to the concrete provider model before the check runs, so allow
+the target models, not the virtual model. A virtual model name in a list is
+accepted as a bare model ID but never matches anything; a load balancer whose
+targets span providers is only usable when every target it can pick is allowed,
+otherwise requests fail with `400` whenever it picks a disallowed target. The
+user tree shows such a node with an empty effective list.
 
 ## Example
 


### PR DESCRIPTION
Two documentation gaps found while testing v0.1.84+27 end to end.

- `docs/features/cache.mdx` said the response cache applies to non-streaming requests only. Streaming requests are cached too (independently keyed; a hit replays the stored SSE bytes with `X-Cache: HIT (exact)`), as `internal/responsecache` documents and as observed on a running gateway.
- `docs/features/users.mdx` and `config/config.example.yaml` did not say that a virtual model name in `allowed_models` never matches. The entry is accepted as a bare model ID, the virtual model resolves to its target before the check, and a load balancer with a disallowed target returns `400` whenever that target is picked. The docs now say to allow the targets.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeodgpchoTafihJFab6u5k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that response caching supports both streaming and non-streaming requests, with separate cache entries and verbatim replay for streaming responses.
  * Expanded guidance on user model selectors, including virtual model resolution, load-balancer targets, and behavior when targets are not allowed.
  * Updated the example configuration comment to explain that concrete target models should be listed instead of virtual models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->