### PR TITLE
fix(gateway): make the chat fast path fire by default and honor the client's raw model

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -449,7 +449,9 @@
 
 # Enforce returning usage data in streaming responses (default: true)
 # When true, stream_options: {"include_usage": true} is automatically added
-# to streaming requests for OpenAI-compatible providers
+# to streaming requests for OpenAI-compatible providers, which keeps those
+# streams on the translated path instead of the byte-for-byte fast path.
+# Non-streaming requests are unaffected: their JSON response always carries usage.
 # ENFORCE_RETURNING_USAGE_DATA=true
 
 # Enable/disable guardrails globally (default: false)

--- a/docs/features/cache.mdx
+++ b/docs/features/cache.mdx
@@ -116,9 +116,12 @@ and model, and caller-supplied cache controls always win.
 Chat requests to OpenAI-compatible providers that need no rewriting are proxied
 without translation, streaming or not. Streaming responses are relayed byte for
 byte; non-streaming JSON responses are relayed with the resolved `provider`
-member set, as on the translated path. A request whose stable prefix qualifies
-for a cache plan always takes the translated path instead, so the plan is never
-skipped in favor of the proxy.
+member set, as on the translated path, and usage is still recorded from the
+response body. A request whose stable prefix qualifies for a cache plan always
+takes the translated path instead, so the plan is never skipped in favor of the
+proxy. With `ENFORCE_RETURNING_USAGE_DATA=true` (the default), streaming
+requests also take the translated path so `stream_options.include_usage` can
+be injected; non-streaming requests are unaffected.
 
 Provider prompt-cache planning is enabled by default. To disable GoModel's
 automatic planning while continuing to pass through compatible client cache

--- a/internal/gateway/chat_fast_path_test.go
+++ b/internal/gateway/chat_fast_path_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/usage"
 )
 
 func TestTranslatedSelectorRewriteRequired(t *testing.T) {
@@ -87,10 +88,15 @@ func TestCanFastPathChatPassthrough(t *testing.T) {
 		providerHint string
 		req          *core.ChatRequest
 		planApplies  bool
+		enforceUsage bool
 		want         bool
 	}{
 		{name: "non-streaming openai", providerType: "openai", req: prepared("openai", false), want: true},
 		{name: "streaming openai", providerType: "openai", req: prepared("openai", true), want: true},
+		// Usage enforcement only injects stream_options into streaming
+		// requests; a non-streaming JSON response always carries usage.
+		{name: "non-streaming openai with enforced usage", providerType: "openai", req: prepared("openai", false), enforceUsage: true, want: true},
+		{name: "streaming openai with enforced usage", providerType: "openai", req: prepared("openai", true), enforceUsage: true},
 		{name: "azure", providerType: "azure", req: prepared("azure", false), want: true},
 		{name: "anthropic never proxied", providerType: "anthropic", req: prepared("anthropic", false)},
 		{name: "planner would apply", providerType: "openai", req: prepared("openai", false), planApplies: true},
@@ -100,7 +106,11 @@ func TestCanFastPathChatPassthrough(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			o := NewInferenceOrchestrator(InferenceConfig{Provider: planningProvider{applies: tt.planApplies}})
+			cfg := InferenceConfig{Provider: planningProvider{applies: tt.planApplies}}
+			if tt.enforceUsage {
+				cfg.UsageLogger = &usageCaptureLogger{config: usage.Config{Enabled: true, EnforceReturningUsageData: true}}
+			}
+			o := NewInferenceOrchestrator(cfg)
 			if got := o.CanFastPathChatPassthrough(workflow(tt.providerType, tt.providerHint), tt.req); got != tt.want {
 				t.Fatalf("CanFastPathChatPassthrough() = %v, want %v", got, tt.want)
 			}

--- a/internal/gateway/inference_execute.go
+++ b/internal/gateway/inference_execute.go
@@ -182,8 +182,10 @@ type chatCachePlanner interface {
 // CanFastPathChatPassthrough reports whether a chat request, streaming or not,
 // can bypass translation and be proxied to the provider byte for byte. It
 // declines whenever the translated path would change the outbound request:
-// slowdown, request patching, enforced usage, selector or body rewrites, and
-// prompt-cache planning.
+// slowdown, request patching, selector or body rewrites, prompt-cache planning,
+// and enforced usage data. Enforcement only rewrites streaming requests (it
+// injects stream_options.include_usage); a non-streaming JSON response always
+// carries usage, so it does not block the fast path.
 func (o *InferenceOrchestrator) CanFastPathChatPassthrough(workflow *core.Workflow, req *core.ChatRequest) bool {
 	if req == nil {
 		return false
@@ -191,7 +193,10 @@ func (o *InferenceOrchestrator) CanFastPathChatPassthrough(workflow *core.Workfl
 	if workflowSlowdown(workflow) > 0 {
 		return false
 	}
-	if o.translatedRequestPatcher != nil || o.ShouldEnforceReturningUsageData() {
+	if o.translatedRequestPatcher != nil {
+		return false
+	}
+	if req.Stream && o.ShouldEnforceReturningUsageData() {
 		return false
 	}
 	if workflow == nil || workflow.Resolution == nil {

--- a/internal/server/chat_fast_path_test.go
+++ b/internal/server/chat_fast_path_test.go
@@ -52,6 +52,33 @@ func postChatCompletion(t *testing.T, handler *Handler, body string) *httptest.R
 	return rec
 }
 
+// postChatCompletionThroughStack sends the request through the full server
+// middleware stack (request snapshot, whitebox ingress capture, workflow
+// resolution) the way production requests arrive, instead of calling the
+// handler directly.
+func postChatCompletionThroughStack(t *testing.T, mock *mockProvider, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	New(mock, &Config{}).ServeHTTP(rec, req)
+	return rec
+}
+
+// chatEntryPoints lists the two ways a chat request reaches the handler in
+// tests: the bare handler (no ingress capture, so the buffered body is the
+// only raw-model source) and the full middleware stack (whitebox hints
+// present, and already overwritten with the resolved model by dispatch time).
+var chatEntryPoints = []struct {
+	name string
+	post func(t *testing.T, mock *mockProvider, body string) *httptest.ResponseRecorder
+}{
+	{name: "handler only", post: func(t *testing.T, mock *mockProvider, body string) *httptest.ResponseRecorder {
+		return postChatCompletion(t, NewHandler(mock, nil, nil, nil), body)
+	}},
+	{name: "middleware stack", post: postChatCompletionThroughStack},
+}
+
 func TestChatCompletion_FastPathProxiesNonStreamingBodyVerbatim(t *testing.T) {
 	mock := fastPathJSONMock(fastPathUpstreamBody)
 	rec := postChatCompletion(t, NewHandler(mock, nil, nil, nil), fastPathChatRequestBody)
@@ -154,17 +181,21 @@ func TestChatCompletionStreaming_FastPathRelaysSSEWhenNoPlanApplies(t *testing.T
 }
 
 func TestChatCompletion_FastPathSkippedWhenRawModelIsNotCanonical(t *testing.T) {
-	mock := fastPathJSONMock(fastPathUpstreamBody)
-	rec := postChatCompletion(t, NewHandler(mock, nil, nil, nil), `{"model":" gpt-4o-mini ","messages":[{"role":"user","content":"Hi"}]}`)
+	for _, entry := range chatEntryPoints {
+		t.Run(entry.name, func(t *testing.T) {
+			mock := fastPathJSONMock(fastPathUpstreamBody)
+			rec := entry.post(t, mock, `{"model":" gpt-4o-mini ","messages":[{"role":"user","content":"Hi"}]}`)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
-	}
-	if mock.lastPassthroughReq != nil {
-		t.Fatal("padded model took the fast path; the upstream would have received it unnormalized")
-	}
-	if mock.chatCompletionCalls != 1 {
-		t.Fatalf("ChatCompletion calls = %d, want 1", mock.chatCompletionCalls)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+			}
+			if mock.lastPassthroughReq != nil {
+				t.Fatal("padded model took the fast path; the upstream would have received it unnormalized")
+			}
+			if mock.chatCompletionCalls != 1 {
+				t.Fatalf("ChatCompletion calls = %d, want 1", mock.chatCompletionCalls)
+			}
+		})
 	}
 }
 
@@ -176,22 +207,24 @@ func TestChatCompletion_FastPathSkippedWhenPlannerApplies(t *testing.T) {
 		{name: "non-streaming", body: fastPathChatRequestBody},
 		{name: "streaming", body: `{"model":"gpt-4o-mini","stream":true,"messages":[{"role":"user","content":"Hi"}]}`},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mock := fastPathJSONMock(fastPathUpstreamBody)
-			mock.promptCachePlanApplies = true
-			rec := postChatCompletion(t, NewHandler(mock, nil, nil, nil), tt.body)
+	for _, entry := range chatEntryPoints {
+		for _, tt := range tests {
+			t.Run(entry.name+"/"+tt.name, func(t *testing.T) {
+				mock := fastPathJSONMock(fastPathUpstreamBody)
+				mock.promptCachePlanApplies = true
+				rec := entry.post(t, mock, tt.body)
 
-			if rec.Code != http.StatusOK {
-				t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
-			}
-			if mock.lastPassthroughReq != nil {
-				t.Fatal("request took the passthrough fast path although the cache planner applies")
-			}
-			if !strings.Contains(rec.Body.String(), `"typed"`) {
-				t.Fatalf("body = %s, want the translated provider response", rec.Body.String())
-			}
-		})
+				if rec.Code != http.StatusOK {
+					t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+				}
+				if mock.lastPassthroughReq != nil {
+					t.Fatal("request took the passthrough fast path although the cache planner applies")
+				}
+				if !strings.Contains(rec.Body.String(), `"typed"`) {
+					t.Fatalf("body = %s, want the translated provider response", rec.Body.String())
+				}
+			})
+		}
 	}
 }
 

--- a/internal/server/chat_fast_path_test.go
+++ b/internal/server/chat_fast_path_test.go
@@ -223,21 +223,33 @@ func TestChatCompletionStreaming_FastPathRelaysSSEWhenNoPlanApplies(t *testing.T
 }
 
 func TestChatCompletion_FastPathSkippedWhenRawModelIsNotCanonical(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "padded model", body: `{"model":" gpt-4o-mini ","messages":[{"role":"user","content":"Hi"}]}`},
+		// The decoder keeps the last duplicate member, so the resolved model is
+		// canonical, while a parser that keeps the first would see the same;
+		// only the padded copy is what a last-wins upstream would receive.
+		{name: "duplicate model members", body: `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Hi"}],"model":" gpt-4o-mini "}`},
+	}
 	for _, entry := range chatEntryPoints {
-		t.Run(entry.name, func(t *testing.T) {
-			mock := fastPathJSONMock(fastPathUpstreamBody)
-			rec := entry.post(t, mock, `{"model":" gpt-4o-mini ","messages":[{"role":"user","content":"Hi"}]}`)
+		for _, tt := range tests {
+			t.Run(entry.name+"/"+tt.name, func(t *testing.T) {
+				mock := fastPathJSONMock(fastPathUpstreamBody)
+				rec := entry.post(t, mock, tt.body)
 
-			if rec.Code != http.StatusOK {
-				t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
-			}
-			if mock.lastPassthroughReq != nil {
-				t.Fatal("padded model took the fast path; the upstream would have received it unnormalized")
-			}
-			if mock.chatCompletionCalls != 1 {
-				t.Fatalf("ChatCompletion calls = %d, want 1", mock.chatCompletionCalls)
-			}
-		})
+				if rec.Code != http.StatusOK {
+					t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+				}
+				if mock.lastPassthroughReq != nil {
+					t.Fatal("non-canonical model took the fast path; the upstream would have received it unnormalized")
+				}
+				if mock.chatCompletionCalls != 1 {
+					t.Fatalf("ChatCompletion calls = %d, want 1", mock.chatCompletionCalls)
+				}
+			})
+		}
 	}
 }
 

--- a/internal/server/chat_fast_path_test.go
+++ b/internal/server/chat_fast_path_test.go
@@ -130,6 +130,48 @@ func TestChatCompletion_FastPathLogsUsageFromJSONBody(t *testing.T) {
 	}
 }
 
+// TestChatCompletion_FastPathWithEnforcedUsageData covers the default
+// configuration: usage tracking on with ENFORCE_RETURNING_USAGE_DATA=true.
+// Enforcement only rewrites streaming requests (stream_options.include_usage),
+// so a non-streaming request still takes the fast path and records usage from
+// the JSON body, while a streaming request stays on the translated path.
+func TestChatCompletion_FastPathWithEnforcedUsageData(t *testing.T) {
+	tests := []struct {
+		name         string
+		body         string
+		wantFastPath bool
+	}{
+		{name: "non-streaming takes the fast path", body: fastPathChatRequestBody, wantFastPath: true},
+		{name: "streaming stays translated", body: `{"model":"gpt-4o-mini","stream":true,"messages":[{"role":"user","content":"Hi"}]}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			usageLog := &collectingUsageLogger{config: usage.Config{Enabled: true, EnforceReturningUsageData: true}}
+			mock := fastPathJSONMock(fastPathUpstreamBody)
+			rec := postChatCompletion(t, NewHandler(mock, nil, usageLog, nil), tt.body)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+			}
+			if got := mock.lastPassthroughReq != nil; got != tt.wantFastPath {
+				t.Fatalf("fast path taken = %v, want %v", got, tt.wantFastPath)
+			}
+			if !tt.wantFastPath {
+				if !strings.Contains(rec.Body.String(), `"typed"`) {
+					t.Fatalf("body = %s, want the translated provider response", rec.Body.String())
+				}
+				return
+			}
+			if len(usageLog.entries) != 1 {
+				t.Fatalf("usage entries = %d, want 1", len(usageLog.entries))
+			}
+			if entry := usageLog.entries[0]; entry.InputTokens != 7 || entry.OutputTokens != 3 {
+				t.Fatalf("usage tokens = %d/%d, want 7/3", entry.InputTokens, entry.OutputTokens)
+			}
+		})
+	}
+}
+
 func TestChatCompletion_FastPathReplacesUpstreamProviderAndDropsValidators(t *testing.T) {
 	upstream := `{"id":"gen-1","object":"chat.completion","model":"gpt-4o-mini","provider":"OpenAI","choices":[{"provider":"nested"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`
 	mock := fastPathJSONMock(upstream)
@@ -337,17 +379,19 @@ func TestChatCompletion_FastPathFiresThroughMiddlewareStack(t *testing.T) {
 }
 
 // BenchmarkChatCompletionNonStreaming compares the translated path (forced by
-// enforced usage data, which the fast path declines) against the passthrough
-// fast path for a ~30 KB request and ~30 KB response through a real router
-// and OpenAI provider talking to an in-process upstream.
+// a provider-qualified model, which the fast path declines) against the
+// passthrough fast path for a ~30 KB request and ~30 KB response through a
+// real router and OpenAI provider talking to an in-process upstream.
 func BenchmarkChatCompletionNonStreaming(b *testing.B) {
 	content := strings.Repeat("The quick brown fox jumps over the lazy dog. ", 660) // ~30 KB
-	requestBody := `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"` + content + `"}]}`
+	requestBody := func(model string) string {
+		return `{"model":"` + model + `","messages":[{"role":"user","content":"` + content + `"}]}`
+	}
 	responseBody := `{"id":"chatcmpl-bench","object":"chat.completion","model":"gpt-4o-mini","choices":[{"index":0,"message":{"role":"assistant","content":"` + content + `"},"finish_reason":"stop"}],"usage":{"prompt_tokens":7000,"completion_tokens":7000,"total_tokens":14000}}`
 	router := newOpenAIRouter(b, responseBody)
 
-	run := func(b *testing.B, usageCfg usage.Config) {
-		handler := NewHandler(router, nil, &collectingUsageLogger{config: usageCfg}, nil)
+	run := func(b *testing.B, requestBody string) {
+		handler := NewHandler(router, nil, &collectingUsageLogger{config: usage.Config{Enabled: true, EnforceReturningUsageData: true}}, nil)
 		e := echo.New()
 		b.ReportAllocs()
 		b.ResetTimer()
@@ -364,9 +408,9 @@ func BenchmarkChatCompletionNonStreaming(b *testing.B) {
 		}
 	}
 	b.Run("translated", func(b *testing.B) {
-		run(b, usage.Config{Enabled: true, EnforceReturningUsageData: true})
+		run(b, requestBody("openai/gpt-4o-mini"))
 	})
 	b.Run("fast_path", func(b *testing.B) {
-		run(b, usage.Config{Enabled: true})
+		run(b, requestBody("gpt-4o-mini"))
 	})
 }

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -560,9 +560,26 @@ func (s *translatedInferenceService) tryFastPathChatPassthrough(c *echo.Context,
 // The raw value survives only in the buffered body: by dispatch time both the
 // decoded request and the whitebox route hints already carry the resolved
 // model (see storeRequestModelResolution).
+//
+// Every top-level "model" member is checked, not just the first: a body may
+// repeat the member, and the decoder keeps the last value while a provider's
+// parser may keep another, so the request is only forwarded verbatim when all
+// of them already carry the upstream model.
 func rawRequestModelMatches(c *echo.Context, resolvedModel string) bool {
 	body, ok := bufferedRequestBody(c)
-	return ok && gjson.GetBytes(body, "model").Str == resolvedModel
+	if !ok {
+		return false
+	}
+	seen, matched := false, true
+	gjson.ParseBytes(body).ForEach(func(key, value gjson.Result) bool {
+		if key.Str != "model" {
+			return true
+		}
+		seen = true
+		matched = value.Type == gjson.String && value.Str == resolvedModel
+		return matched
+	})
+	return seen && matched
 }
 
 // bufferedRequestBody returns the request body the decode step already

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -557,14 +557,26 @@ func (s *translatedInferenceService) tryFastPathChatPassthrough(c *echo.Context,
 // wrote it equals the model the upstream must receive. The gateway gate compares
 // normalized selectors, but the fast path forwards the body untouched, so a
 // padded or otherwise non-canonical raw value must take the translated path.
+// The raw value survives only in the buffered body: by dispatch time both the
+// decoded request and the whitebox route hints already carry the resolved
+// model (see storeRequestModelResolution).
 func rawRequestModelMatches(c *echo.Context, resolvedModel string) bool {
-	if env := core.GetWhiteBoxPrompt(c.Request().Context()); env != nil {
-		return env.JSONBodyParsed && env.RouteHints.Model == resolvedModel
+	body, ok := bufferedRequestBody(c)
+	return ok && gjson.GetBytes(body, "model").Str == resolvedModel
+}
+
+// bufferedRequestBody returns the request body the decode step already
+// buffered. With a request snapshot that is the captured view (no copy); a
+// body too large to capture reports false instead of re-reading and
+// re-snapshotting the request. Without a snapshot (the handler is being used
+// outside the middleware stack) the rewound request body is read.
+func bufferedRequestBody(c *echo.Context) ([]byte, bool) {
+	if snapshot := core.GetRequestSnapshot(c.Request().Context()); snapshot != nil {
+		body := snapshot.CapturedBodyView()
+		return body, body != nil
 	}
-	// Without ingress capture (the handler is being used outside the
-	// middleware stack) fall back to the buffered body the decode step read.
 	body, err := requestBodyBytes(c)
-	return err == nil && gjson.GetBytes(body, "model").Str == resolvedModel
+	return body, err == nil
 }
 
 // bodyValidatorHeaders are response headers derived from the body bytes; they


### PR DESCRIPTION
Two defects in the chat passthrough fast path from #845, found while testing the release candidate against a mock upstream.

**The fast path never fired under default settings.** `CanFastPathChatPassthrough` declined whenever usage enforcement was on, which is the default (`USAGE_ENABLED` plus `ENFORCE_RETURNING_USAGE_DATA=true`). Enforcement only rewrites streaming requests (it injects `stream_options.include_usage`), and a non-streaming JSON response always carries `usage`, so the gate now applies to streaming requests only. Non-streaming requests are proxied byte for byte and usage is still recorded from the JSON body by the passthrough observer. Streaming requests with enforcement on keep taking the translated path.

**The raw-model guard was a tautology.** `rawRequestModelMatches` compared `RouteHints.Model` with the resolved model, but `storeRequestModelResolution` had already overwritten that hint with the resolved selector, so a padded model such as `" gpt-4o-mini "` was forwarded to the upstream unnormalized and produced its own usage row. The guard now reads the model from the captured request body. Bodies above the 1 MB capture limit take the translated path.

Tests: the fast-path gate table gains enforcement cases, and the server fast-path tests now also run through the real middleware stack, which is where the old padded-model test could not catch the bug. Both new tests fail on `main`.

User-visible impact: OpenAI-compatible non-streaming chat requests that need no rewriting are now proxied without re-serialization out of the box; `docs/features/cache.mdx` and `.env.template` describe the behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeodgpchoTafihJFab6u5k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Non-streaming OpenAI-compatible requests now retain the fast path while returning usage data.
  * Streaming requests include usage data and use the translated processing path when usage enforcement is enabled.
  * Usage continues to be recorded from response bodies on proxied requests.

* **Documentation**
  * Updated configuration and prompt-cache documentation to clarify usage behavior for streaming and non-streaming requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->