### PR TITLE
fix(providers): never overlay a bare env key onto a renamed provider's explicit credentials

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -508,6 +508,11 @@
 # take precedence when both are set for the same provider name (the dashboard
 # marks that provider read-only).
 #
+# Bare <PROVIDER>_* vars apply to the config.yaml provider named after the type
+# ("openai"). A renamed config.yaml provider of that type (alpha: {type: openai})
+# only picks up fields it left empty; its explicit api_key/base_url are kept and
+# the ignored vars are logged as a warning at startup.
+#
 # Add more instances with <PROVIDER>_<SUFFIX>_*.
 # Example: OPENAI_EAST_API_KEY and OPENAI_EAST_BASE_URL register provider openai-east.
 # Underscores in the suffix become hyphens in the provider name.

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -392,6 +392,12 @@ failover:
   #     - "azure/gpt-4o"
   #     - "gemini/gemini-2.5-pro"
 
+# Bare <PROVIDER>_* env vars (OPENAI_API_KEY, OPENAI_BASE_URL, ...) override the
+# provider that carries the type's name ("openai"). For a provider you renamed
+# (alpha: {type: openai}) they only fill fields left empty here; values set
+# explicitly are kept and the ignored env vars are logged as a warning at
+# startup. To run a second instance of a type, use <PROVIDER>_<SUFFIX>_* env
+# vars or another named entry here.
 providers:
   openai:
     type: openai

--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -480,6 +480,12 @@ export LLMD_MODELS="Qwen/Qwen2.5-0.5B-Instruct"
 # Optional: export LLMD_FAIRNESS_FROM_USER_PATH="true"
 ```
 
+Bare `<PROVIDER>_*` variables win over the `config.yaml` provider named after
+the type (`openai`). A provider you renamed (`alpha: {type: openai}`) only picks
+up fields it left empty; its explicit `api_key` or `base_url` is kept and the
+ignored variables are logged as a warning at startup. When several renamed
+providers share a type, the bare variables are ignored with the same warning.
+
 Use suffixed variables to register more than one instance of the same provider
 type without YAML. GoModel normalizes the suffix to lowercase and converts
 underscores to hyphens in the configured provider name:

--- a/internal/providers/config_env.go
+++ b/internal/providers/config_env.go
@@ -613,7 +613,7 @@ func (v providerEnvValues) withoutFieldsSetBy(existing config.RawProviderConfig)
 		env  *string
 		cfg  string
 	}{
-		{"base_url", &v.BaseURL, normalizeResolvedBaseURL(existing.BaseURL)},
+		{"base_url", &v.BaseURL, existing.BaseURL},
 		{"api_version", &v.APIVersion, existing.APIVersion},
 		{"backend", &v.Backend, existing.Backend},
 		{"auth_type", &v.AuthType, existing.AuthType},
@@ -633,12 +633,19 @@ func (v providerEnvValues) withoutFieldsSetBy(existing config.RawProviderConfig)
 
 	drop("session_sticky_keys", v.SessionStickyKeys != nil, existing.SessionStickyKeys != nil, func() { v.SessionStickyKeys = nil })
 	drop("fairness_from_user_path", v.FairnessFromUserPath != nil, existing.FairnessFromUserPath != nil, func() { v.FairnessFromUserPath = nil })
-	drop("models", len(v.Models) > 0, len(existing.Models) > 0, func() { v.Models = nil })
+	drop("models", len(v.Models) > 0, rawProviderHasResolvedModel(existing), func() { v.Models = nil })
 	drop("model_filter.include", len(v.ModelFilterInclude) > 0, len(existing.ModelFilter.Include) > 0, func() { v.ModelFilterInclude = nil })
 	drop("model_filter.exclude", len(v.ModelFilterExclude) > 0, len(existing.ModelFilter.Exclude) > 0, func() { v.ModelFilterExclude = nil })
 	drop("model_filter.max_price_per_mtok", v.ModelFilterMaxPrice != nil, existing.ModelFilter.MaxPricePerMtok != nil, func() { v.ModelFilterMaxPrice = nil })
 
 	return v, ignored
+}
+
+// rawProviderHasResolvedModel reports whether the config provider declares at
+// least one model ID that is not an unresolved ${VAR} placeholder, so a list
+// left to the environment does not block the bare <PROVIDER>_MODELS fill.
+func rawProviderHasResolvedModel(cfg config.RawProviderConfig) bool {
+	return slices.ContainsFunc(cfg.Models, func(m config.RawProviderModel) bool { return HasResolvedProviderValue(m.ID) })
 }
 
 func rawProviderHasAPIKey(cfg config.RawProviderConfig) bool {

--- a/internal/providers/config_env.go
+++ b/internal/providers/config_env.go
@@ -1,9 +1,11 @@
 package providers
 
 import (
+	"log/slog"
 	"maps"
 	"math"
 	"os"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -422,19 +424,39 @@ func applyUnsuffixedProviderEnvVars(result map[string]config.RawProviderConfig, 
 		return
 	}
 
-	targetKey, matched, ambiguous := findEnvOverlayTarget(result, providerType, source)
-	if matched {
-		result[targetKey] = overlayProviderEnvValues(result[targetKey], values, spec)
-		return
+	candidates := envOverlayCandidates(result, providerType, source)
+	switch len(candidates) {
+	case 0:
+		if spec.RequireBaseURL && values.BaseURL == "" {
+			return
+		}
+		result[source.DefaultName] = values.rawConfig(providerType, spec)
+	case 1:
+		targetKey := candidates[0]
+		if targetKey == source.DefaultName {
+			result[targetKey] = overlayProviderEnvValues(result[targetKey], values, spec)
+			return
+		}
+		// A config provider that merely shares the type may borrow the bare env
+		// values for fields it left empty, but its explicit settings win: a stray
+		// OPENAI_API_KEY must never be sent to whatever base_url "alpha" points at.
+		fill, ignored := values.withoutFieldsSetBy(result[targetKey])
+		if len(ignored) > 0 {
+			slog.Warn("provider env vars ignored: a differently named config provider of this type already sets these fields",
+				"env_prefix", source.Prefix,
+				"provider", targetKey,
+				"fields", ignored,
+				"hint", "name the provider after its type or add another instance with "+source.Prefix+"_<SUFFIX>_*")
+		}
+		if !fill.empty() {
+			result[targetKey] = overlayProviderEnvValues(result[targetKey], fill, spec)
+		}
+	default:
+		slog.Warn("provider env vars ignored: several config providers share this type and none is named after it",
+			"env_prefix", source.Prefix,
+			"providers", candidates,
+			"hint", "name one provider after its type or add another instance with "+source.Prefix+"_<SUFFIX>_*")
 	}
-	if ambiguous {
-		return
-	}
-	if spec.RequireBaseURL && values.BaseURL == "" {
-		return
-	}
-
-	result[source.DefaultName] = values.rawConfig(providerType, spec)
 }
 
 func applySuffixedProviderEnvVars(result map[string]config.RawProviderConfig, providerType string, spec DiscoveryConfig, source providerEnvSource, suffix string, values providerEnvValues) {
@@ -569,6 +591,60 @@ func overlayProviderEnvValues(existing config.RawProviderConfig, values provider
 	return existing
 }
 
+// withoutFieldsSetBy drops every env value whose field the config provider
+// already sets explicitly, so the remainder only fills gaps. It returns the
+// YAML names of the dropped fields for logging; values are never returned.
+func (v providerEnvValues) withoutFieldsSetBy(existing config.RawProviderConfig) (providerEnvValues, []string) {
+	var ignored []string
+	drop := func(name string, envSet, cfgSet bool, clear func()) {
+		if envSet && cfgSet {
+			clear()
+			ignored = append(ignored, name)
+		}
+	}
+
+	drop("api_key", v.hasAPIKey(), rawProviderHasAPIKey(existing), func() {
+		v.APIKey = ""
+		v.APIKeysByIndex = nil
+	})
+
+	stringFields := []struct {
+		name string
+		env  *string
+		cfg  string
+	}{
+		{"base_url", &v.BaseURL, normalizeResolvedBaseURL(existing.BaseURL)},
+		{"api_version", &v.APIVersion, existing.APIVersion},
+		{"backend", &v.Backend, existing.Backend},
+		{"auth_type", &v.AuthType, existing.AuthType},
+		{"api_mode", &v.APIMode, existing.APIMode},
+		{"vertex_project", &v.VertexProject, existing.VertexProject},
+		{"vertex_location", &v.VertexLocation, existing.VertexLocation},
+		{"service_account_file", &v.ServiceAccountFile, existing.ServiceAccountFile},
+		{"service_account_json", &v.ServiceAccountJSON, existing.ServiceAccountJSON},
+		{"service_account_json_base64", &v.ServiceAccountJSONBase64, existing.ServiceAccountJSONBase64},
+		{"gcp_scope", &v.GCPScope, existing.GCPScope},
+		{"inference_objective", &v.InferenceObjective, existing.InferenceObjective},
+	}
+	for _, f := range stringFields {
+		env := f.env
+		drop(f.name, strings.TrimSpace(*env) != "", HasResolvedProviderValue(f.cfg), func() { *env = "" })
+	}
+
+	drop("session_sticky_keys", v.SessionStickyKeys != nil, existing.SessionStickyKeys != nil, func() { v.SessionStickyKeys = nil })
+	drop("fairness_from_user_path", v.FairnessFromUserPath != nil, existing.FairnessFromUserPath != nil, func() { v.FairnessFromUserPath = nil })
+	drop("models", len(v.Models) > 0, len(existing.Models) > 0, func() { v.Models = nil })
+	drop("model_filter.include", len(v.ModelFilterInclude) > 0, len(existing.ModelFilter.Include) > 0, func() { v.ModelFilterInclude = nil })
+	drop("model_filter.exclude", len(v.ModelFilterExclude) > 0, len(existing.ModelFilter.Exclude) > 0, func() { v.ModelFilterExclude = nil })
+	drop("model_filter.max_price_per_mtok", v.ModelFilterMaxPrice != nil, existing.ModelFilter.MaxPricePerMtok != nil, func() { v.ModelFilterMaxPrice = nil })
+
+	return v, ignored
+}
+
+func rawProviderHasAPIKey(cfg config.RawProviderConfig) bool {
+	return HasResolvedProviderValue(cfg.APIKey) || slices.ContainsFunc(cfg.APIKeys, HasResolvedProviderValue)
+}
+
 func providerNameForEnvSuffix(source providerEnvSource, suffix string) string {
 	baseName := strings.TrimSpace(source.DefaultName)
 	suffixName := normalizeEnvSuffixForProviderName(suffix, source.NameSeparator)
@@ -600,31 +676,26 @@ func normalizeEnvSuffixForProviderName(suffix, separator string) string {
 	return strings.Trim(b.String(), separator)
 }
 
-func findEnvOverlayTarget(raw map[string]config.RawProviderConfig, providerType string, source providerEnvSource) (string, bool, bool) {
+// envOverlayCandidates returns the config providers the bare (unsuffixed) env
+// vars of a type may apply to: the provider named after the type when it
+// exists, otherwise every provider of that type. An empty result means the env
+// vars register a new provider named after the type.
+func envOverlayCandidates(raw map[string]config.RawProviderConfig, providerType string, source providerEnvSource) []string {
 	if existing, ok := raw[source.DefaultName]; ok && rawProviderMatchesType(existing, providerType) {
-		return source.DefaultName, true, false
+		return []string{source.DefaultName}
 	}
 	if !source.OverlayByType {
-		return "", false, false
+		return nil
 	}
 
-	var matchedKey string
-	var matches int
+	var candidates []string
 	for name, cfg := range raw {
-		if !rawProviderMatchesType(cfg, providerType) {
-			continue
-		}
-		matchedKey = name
-		matches++
-		if matches > 1 {
-			return "", false, true
+		if rawProviderMatchesType(cfg, providerType) {
+			candidates = append(candidates, name)
 		}
 	}
-
-	if matches == 1 {
-		return matchedKey, true, false
-	}
-	return "", false, false
+	sort.Strings(candidates)
+	return candidates
 }
 
 func rawProviderMatchesType(cfg config.RawProviderConfig, providerType string) bool {

--- a/internal/providers/config_env_test.go
+++ b/internal/providers/config_env_test.go
@@ -1,0 +1,137 @@
+package providers
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/enterpilot/gomodel/config"
+)
+
+// captureSlog routes the default logger into a buffer for the test's lifetime.
+func captureSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(original) })
+	return &buf
+}
+
+func TestApplyProviderEnvVars_BareTypeEnvVarsAgainstRenamedProviders(t *testing.T) {
+	const envKey = "sk-env-secret-key"
+
+	tests := []struct {
+		name         string
+		env          map[string]string
+		raw          map[string]config.RawProviderConfig
+		want         map[string]config.RawProviderConfig
+		wantLog      []string // substrings the warning must contain
+		wantNoOpenAI bool
+	}{
+		{
+			name: "renamed provider keeps its explicit api_key and base_url",
+			env:  map[string]string{"OPENAI_API_KEY": envKey, "OPENAI_BASE_URL": "https://env.example.com/v1"},
+			raw: map[string]config.RawProviderConfig{
+				"alpha": {Type: "openai", APIKey: "alpha-key", BaseURL: "http://localhost:9001/v1"},
+			},
+			want: map[string]config.RawProviderConfig{
+				"alpha": {Type: "openai", APIKey: "alpha-key", BaseURL: "http://localhost:9001/v1"},
+			},
+			wantLog:      []string{`"env_prefix":"OPENAI"`, `"provider":"alpha"`, `"api_key"`, `"base_url"`},
+			wantNoOpenAI: true,
+		},
+		{
+			name: "renamed provider with empty api_key receives the env key",
+			env:  map[string]string{"OPENAI_API_KEY": envKey},
+			raw: map[string]config.RawProviderConfig{
+				"alpha": {Type: "openai", BaseURL: "https://proxy.example.com/v1"},
+			},
+			want: map[string]config.RawProviderConfig{
+				"alpha": {Type: "openai", APIKey: envKey, APIKeys: []string{envKey}, BaseURL: "https://proxy.example.com/v1"},
+			},
+			wantNoOpenAI: true,
+		},
+		{
+			name: "renamed provider with unresolved placeholder api_key receives the env key",
+			env:  map[string]string{"OPENAI_API_KEY": envKey},
+			raw: map[string]config.RawProviderConfig{
+				"alpha": {Type: "openai", APIKey: "${MISSING_KEY}"},
+			},
+			want: map[string]config.RawProviderConfig{
+				"alpha": {Type: "openai", APIKey: envKey, APIKeys: []string{envKey}, BaseURL: testDiscoveryConfigs["openai"].DefaultBaseURL},
+			},
+			wantNoOpenAI: true,
+		},
+		{
+			name: "provider named after the type is fully overridden",
+			env:  map[string]string{"OPENAI_API_KEY": envKey},
+			raw: map[string]config.RawProviderConfig{
+				"openai": {Type: "openai", APIKey: "yaml-key", BaseURL: "https://yaml.example.com/v1"},
+			},
+			want: map[string]config.RawProviderConfig{
+				"openai": {Type: "openai", APIKey: envKey, APIKeys: []string{envKey}, BaseURL: "https://yaml.example.com/v1"},
+			},
+		},
+		{
+			name: "two same-type providers keep their keys and the env key is warned about",
+			env:  map[string]string{"OPENAI_API_KEY": envKey},
+			raw: map[string]config.RawProviderConfig{
+				"alpha": {Type: "openai", APIKey: "alpha-key", BaseURL: "https://alpha.example.com/v1"},
+				"beta":  {Type: "openai", APIKey: "beta-key", BaseURL: "https://beta.example.com/v1"},
+			},
+			want: map[string]config.RawProviderConfig{
+				"alpha": {Type: "openai", APIKey: "alpha-key", BaseURL: "https://alpha.example.com/v1"},
+				"beta":  {Type: "openai", APIKey: "beta-key", BaseURL: "https://beta.example.com/v1"},
+			},
+			wantLog:      []string{`"env_prefix":"OPENAI"`, `"providers":["alpha","beta"]`},
+			wantNoOpenAI: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for key, value := range tt.env {
+				t.Setenv(key, value)
+			}
+			logs := captureSlog(t)
+
+			got := applyProviderEnvVars(tt.raw, testDiscoveryConfigs)
+
+			for name, want := range tt.want {
+				p, ok := got[name]
+				if !ok {
+					t.Fatalf("provider %q missing from result", name)
+				}
+				if p.APIKey != want.APIKey {
+					t.Errorf("%s APIKey = %q, want %q", name, p.APIKey, want.APIKey)
+				}
+				if strings.Join(p.APIKeys, ",") != strings.Join(want.APIKeys, ",") {
+					t.Errorf("%s APIKeys = %v, want %v", name, p.APIKeys, want.APIKeys)
+				}
+				if p.BaseURL != want.BaseURL {
+					t.Errorf("%s BaseURL = %q, want %q", name, p.BaseURL, want.BaseURL)
+				}
+			}
+			if tt.wantNoOpenAI {
+				if _, exists := got["openai"]; exists {
+					t.Error("expected no auto-discovered openai provider")
+				}
+			}
+
+			out := logs.String()
+			if len(tt.wantLog) == 0 && out != "" {
+				t.Errorf("expected no warning, got:\n%s", out)
+			}
+			for _, fragment := range tt.wantLog {
+				if !strings.Contains(out, fragment) {
+					t.Errorf("warning missing %s in:\n%s", fragment, out)
+				}
+			}
+			if strings.Contains(out, envKey) {
+				t.Errorf("warning leaked the env api key:\n%s", out)
+			}
+		})
+	}
+}

--- a/internal/providers/config_env_test.go
+++ b/internal/providers/config_env_test.go
@@ -65,6 +65,28 @@ func TestApplyProviderEnvVars_BareTypeEnvVarsAgainstRenamedProviders(t *testing.
 			wantNoOpenAI: true,
 		},
 		{
+			name: "renamed provider with an embedded base_url placeholder receives the env base_url",
+			env:  map[string]string{"OPENAI_BASE_URL": "https://env.example.com/v1"},
+			raw: map[string]config.RawProviderConfig{
+				"alpha": {Type: "openai", APIKey: "alpha-key", BaseURL: "https://${MISSING_HOST}/v1"},
+			},
+			want: map[string]config.RawProviderConfig{
+				"alpha": {Type: "openai", APIKey: "alpha-key", BaseURL: "https://env.example.com/v1"},
+			},
+			wantNoOpenAI: true,
+		},
+		{
+			name: "renamed provider with unresolved model placeholders receives the env models",
+			env:  map[string]string{"OPENAI_MODELS": "gpt-4o-mini,gpt-4o"},
+			raw: map[string]config.RawProviderConfig{
+				"alpha": {Type: "openai", APIKey: "alpha-key", BaseURL: "https://alpha.example.com/v1", Models: []config.RawProviderModel{{ID: "${MISSING_MODELS}"}}},
+			},
+			want: map[string]config.RawProviderConfig{
+				"alpha": {Type: "openai", APIKey: "alpha-key", BaseURL: "https://alpha.example.com/v1", Models: []config.RawProviderModel{{ID: "gpt-4o-mini"}, {ID: "gpt-4o"}}},
+			},
+			wantNoOpenAI: true,
+		},
+		{
 			name: "provider named after the type is fully overridden",
 			env:  map[string]string{"OPENAI_API_KEY": envKey},
 			raw: map[string]config.RawProviderConfig{
@@ -112,6 +134,9 @@ func TestApplyProviderEnvVars_BareTypeEnvVarsAgainstRenamedProviders(t *testing.
 				}
 				if p.BaseURL != want.BaseURL {
 					t.Errorf("%s BaseURL = %q, want %q", name, p.BaseURL, want.BaseURL)
+				}
+				if got, wantIDs := config.ProviderModelIDs(p.Models), config.ProviderModelIDs(want.Models); strings.Join(got, ",") != strings.Join(wantIDs, ",") {
+					t.Errorf("%s Models = %v, want %v", name, got, wantIDs)
 				}
 			}
 			if tt.wantNoOpenAI {


### PR DESCRIPTION
Found while testing the release candidate with a config-file provider of type `openai` under a custom name.

With one renamed provider of a type (for example `alpha: {type: openai, api_key: ..., base_url: http://localhost:9001/v1}`) and a bare `OPENAI_API_KEY` in the environment, the env overlay replaced the provider's explicit key: the third-party base URL received the operator's real OpenAI key. With two renamed providers of the type, the env key was silently ignored with no log line.

The by-type fallback exists (#215) so a renamed provider that leaves a field empty gets it from the bare env var, and that still works. Bare env vars now only fill fields the renamed provider left empty (an unresolved `${VAR}` placeholder counts as empty); explicitly set fields win and a startup WARN names the env prefix, provider, and ignored field names, never values. With two or more renamed providers nothing is applied and the WARN lists them. A provider named after the type is still fully overridden, and a type with no config provider still registers one from the environment.

Provider-specific note: the Vertex config-shape match goes through the same fill-or-warn path. `docs/advanced/configuration.mdx`, `config/config.example.yaml`, and `.env.template` now state the rule and point at `<PROVIDER>_<SUFFIX>_*` for a second instance.

Tests: a table-driven test covers explicit-field preservation, empty-field fill, placeholder fill, type-named override, and the two-provider warning, asserting the secret never appears in the log. The explicit-field and warning cases fail on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeodgpchoTafihJFab6u5k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Improved handling of provider environment variables when providers are renamed or multiple providers share the same type.
  - Explicit API keys and base URLs are preserved; environment variables fill only unset fields where unambiguous.
  - Ambiguous variables are ignored and reported with a startup warning.
  - Additional provider instances can be configured using suffixed environment variables or separate configuration entries.

- **Documentation**
  - Updated configuration guidance and the environment template with examples and precedence rules for provider environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->