### PR TITLE
fix(admin): report effective resilience for dashboard-registered providers

### DIFF
--- a/internal/admin/handler_provider_credentials.go
+++ b/internal/admin/handler_provider_credentials.go
@@ -25,6 +25,9 @@ type ProviderCredentialsAdmin interface {
 	IsManaged(name string) bool
 	RegisteredTypes() []string
 	CredentialSchemas() []providers.CredentialSchema
+	// ConfiguredProviders returns the effective, admin-safe configuration of
+	// every credential currently installed in the registry.
+	ConfiguredProviders() []providers.SanitizedProviderConfig
 }
 
 // redactedCredentialValue replaces secret values (API keys, service account

--- a/internal/admin/handler_provider_credentials_test.go
+++ b/internal/admin/handler_provider_credentials_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/labstack/echo/v5"
 
+	"github.com/enterpilot/gomodel/internal/core"
 	"github.com/enterpilot/gomodel/internal/providers"
 )
 
@@ -19,11 +20,16 @@ import (
 // handler tests: it stands in for *providers.CredentialsService without
 // touching a real registry/factory.
 type providerCredentialsAdminFake struct {
-	rows      map[string]providers.ManagedProviderCredential
-	managed   map[string]struct{}
-	types     []string
-	upsertErr error
-	deleteErr error
+	rows       map[string]providers.ManagedProviderCredential
+	managed    map[string]struct{}
+	types      []string
+	configured []providers.SanitizedProviderConfig
+	upsertErr  error
+	deleteErr  error
+}
+
+func (f *providerCredentialsAdminFake) ConfiguredProviders() []providers.SanitizedProviderConfig {
+	return f.configured
 }
 
 func newProviderCredentialsAdminFake() *providerCredentialsAdminFake {
@@ -606,5 +612,77 @@ func TestUpsertProviderCredential_BubblesProviderErrorOnStoreFailure(t *testing.
 	}
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("status = %d, want 502 body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestProviderStatus_ReportsCredentialServiceConfigForRuntimeProviders covers
+// dashboard-registered providers: they are absent from the static configured
+// snapshot, so their effective (resilience-merged) config must come from the
+// credentials service instead of being reported as all zeros. A declared
+// provider present in both sources keeps the declarative config.
+func TestProviderStatus_ReportsCredentialServiceConfigForRuntimeProviders(t *testing.T) {
+	registry := providers.NewModelRegistry()
+	for _, name := range []string{"dash-openai", "openai_declared"} {
+		registry.RegisterProviderWithNameAndType(&handlerMockProvider{
+			models: &core.ModelsResponse{Object: "list", Data: []core.Model{{ID: "gpt-4o", Object: "model"}}},
+		}, name, "openai")
+	}
+	if err := registry.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	resilience := func(maxRetries int) providers.SanitizedResilienceConfig {
+		return providers.SanitizedResilienceConfig{
+			Retry:          providers.SanitizedRetryConfig{MaxRetries: maxRetries, InitialBackoff: "1s", MaxBackoff: "30s", BackoffFactor: 2, JitterFactor: 0.1},
+			CircuitBreaker: providers.SanitizedCircuitBreakerConfig{Enabled: true, FailureThreshold: 5, SuccessThreshold: 2, Timeout: "30s"},
+		}
+	}
+	fake := newProviderCredentialsAdminFake()
+	fake.configured = []providers.SanitizedProviderConfig{
+		{Name: "dash-openai", Type: "openai", BaseURL: "https://dash.example.com/v1", Resilience: resilience(3)},
+		{Name: "openai_declared", Type: "openai", Resilience: resilience(9)},
+	}
+	declared := providers.SanitizedProviderConfig{Name: "openai_declared", Type: "openai", Resilience: resilience(1)}
+	h := NewHandler(nil, registry, WithProviderCredentials(fake), WithConfiguredProviders([]providers.SanitizedProviderConfig{declared}))
+
+	c, rec := newHandlerContext("/admin/providers/status")
+	if err := h.ProviderStatus(c); err != nil {
+		t.Fatalf("ProviderStatus() error = %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var body providerStatusResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	byName := make(map[string]providerStatusItemResponse, len(body.Providers))
+	for _, provider := range body.Providers {
+		byName[provider.Name] = provider
+	}
+
+	tests := []struct {
+		name string
+		want providers.SanitizedProviderConfig
+	}{
+		{name: "dash-openai", want: fake.configured[0]},
+		{name: "openai_declared", want: declared},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			item, ok := byName[tt.name]
+			if !ok {
+				t.Fatalf("missing %s in %#v", tt.name, body.Providers)
+			}
+			if item.Config.BaseURL != tt.want.BaseURL {
+				t.Errorf("config.base_url = %q, want %q", item.Config.BaseURL, tt.want.BaseURL)
+			}
+			if item.Config.Resilience != tt.want.Resilience {
+				t.Errorf("config.resilience = %+v, want %+v", item.Config.Resilience, tt.want.Resilience)
+			}
+			if item.Status != "healthy" {
+				t.Errorf("status = %q, want healthy", item.Status)
+			}
+		})
 	}
 }

--- a/internal/admin/handler_provider_credentials_test.go
+++ b/internal/admin/handler_provider_credentials_test.go
@@ -630,6 +630,12 @@ func TestProviderStatus_ReportsCredentialServiceConfigForRuntimeProviders(t *tes
 	if err := registry.Initialize(context.Background()); err != nil {
 		t.Fatalf("Initialize() error = %v", err)
 	}
+	// A dashboard-registered provider installed after startup has no model
+	// inventory until its first refresh; it must still report its effective
+	// configuration and classify as configured rather than unknown.
+	registry.RegisterProviderWithNameAndType(&handlerMockProvider{
+		models: &core.ModelsResponse{Object: "list", Data: []core.Model{}},
+	}, "dash-empty", "openai")
 
 	resilience := func(maxRetries int) providers.SanitizedResilienceConfig {
 		return providers.SanitizedResilienceConfig{
@@ -641,6 +647,7 @@ func TestProviderStatus_ReportsCredentialServiceConfigForRuntimeProviders(t *tes
 	fake.configured = []providers.SanitizedProviderConfig{
 		{Name: "dash-openai", Type: "openai", BaseURL: "https://dash.example.com/v1", Resilience: resilience(3)},
 		{Name: "openai_declared", Type: "openai", Resilience: resilience(9)},
+		{Name: "dash-empty", Type: "openai", BaseURL: "https://empty.example.com/v1", Resilience: resilience(3)},
 	}
 	declared := providers.SanitizedProviderConfig{Name: "openai_declared", Type: "openai", Resilience: resilience(1)}
 	h := NewHandler(nil, registry, WithProviderCredentials(fake), WithConfiguredProviders([]providers.SanitizedProviderConfig{declared}))
@@ -662,11 +669,13 @@ func TestProviderStatus_ReportsCredentialServiceConfigForRuntimeProviders(t *tes
 	}
 
 	tests := []struct {
-		name string
-		want providers.SanitizedProviderConfig
+		name      string
+		want      providers.SanitizedProviderConfig
+		wantLabel string
 	}{
-		{name: "dash-openai", want: fake.configured[0]},
-		{name: "openai_declared", want: declared},
+		{name: "dash-openai", want: fake.configured[0], wantLabel: "Healthy"},
+		{name: "openai_declared", want: declared, wantLabel: "Healthy"},
+		{name: "dash-empty", want: fake.configured[2], wantLabel: "Configured"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -680,8 +689,8 @@ func TestProviderStatus_ReportsCredentialServiceConfigForRuntimeProviders(t *tes
 			if item.Config.Resilience != tt.want.Resilience {
 				t.Errorf("config.resilience = %+v, want %+v", item.Config.Resilience, tt.want.Resilience)
 			}
-			if item.Status != "healthy" {
-				t.Errorf("status = %q, want healthy", item.Status)
+			if item.StatusLabel != tt.wantLabel {
+				t.Errorf("status_label = %q, want %q", item.StatusLabel, tt.wantLabel)
 			}
 		})
 	}

--- a/internal/admin/handler_providers.go
+++ b/internal/admin/handler_providers.go
@@ -91,6 +91,23 @@ func (h *Handler) collectProviderStatusInputs() (
 		configuredByName[name] = cfg
 		nameSet[name] = struct{}{}
 	}
+	// Dashboard-registered credentials are installed after startup, so they
+	// are absent from the static snapshot above; take their effective config
+	// from the credentials service. Declarative providers keep priority: the
+	// service never registers a store row a config/env provider shadows.
+	if h.providerCredentials != nil {
+		for _, cfg := range h.providerCredentials.ConfiguredProviders() {
+			name := strings.TrimSpace(cfg.Name)
+			if name == "" {
+				continue
+			}
+			if _, exists := configuredByName[name]; exists {
+				continue
+			}
+			configuredByName[name] = cfg
+			nameSet[name] = struct{}{}
+		}
+	}
 
 	runtimeByName := make(map[string]providers.ProviderRuntimeSnapshot)
 	if h.registry != nil {

--- a/internal/providers/credentials.go
+++ b/internal/providers/credentials.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/enterpilot/gomodel/config"
@@ -105,6 +107,13 @@ type CredentialsService struct {
 
 	managedNames map[string]struct{}
 	resilience   config.ResilienceConfig
+
+	// configs holds the effective ProviderConfig of every credential that is
+	// currently installed in the registry, so the admin status endpoint can
+	// report the same merged resilience settings for dashboard-registered
+	// providers that it reports for config.yaml/env ones.
+	mu      sync.RWMutex
+	configs map[string]ProviderConfig
 }
 
 // NewCredentialsService builds the service and applies every currently
@@ -134,6 +143,7 @@ func NewCredentialsService(ctx context.Context, factory *ProviderFactory, regist
 		store:        store,
 		managedNames: managed,
 		resilience:   resilience,
+		configs:      make(map[string]ProviderConfig),
 	}
 	if err := s.Reload(ctx); err != nil {
 		return nil, err
@@ -261,7 +271,7 @@ func (s *CredentialsService) Upsert(ctx context.Context, cred ManagedProviderCre
 	if cred.Enabled {
 		s.install(name, provider, cfg)
 	} else {
-		s.registry.UnregisterProvider(name)
+		s.remove(name)
 	}
 	// A Refresh error here means the provider's /models call itself failed
 	// (bad key, unreachable host, ...) -- registration still succeeded, and
@@ -285,7 +295,7 @@ func (s *CredentialsService) Delete(ctx context.Context, name string) error {
 	if err := s.store.Delete(ctx, name); err != nil {
 		return err
 	}
-	s.registry.UnregisterProvider(name)
+	s.remove(name)
 	// See the matching comment in Upsert: a Refresh failure here reflects a
 	// remaining provider's own health, not whether the delete succeeded.
 	if err := s.registry.Refresh(ctx); err != nil {
@@ -334,7 +344,8 @@ func (s *CredentialsService) buildProvider(row ManagedProviderCredential) (core.
 }
 
 // install unregisters whatever is currently registered under name (a no-op
-// if nothing is) and registers provider in its place.
+// if nothing is), registers provider in its place, and records cfg as the
+// provider's effective configuration.
 func (s *CredentialsService) install(name string, provider core.Provider, cfg ProviderConfig) {
 	s.registry.UnregisterProvider(name)
 	s.registry.RegisterProviderWithNameAndType(provider, name, cfg.Type)
@@ -345,4 +356,29 @@ func (s *CredentialsService) install(name string, provider core.Provider, cfg Pr
 		s.registry.SetProviderMetadataOverrides(name, cfg.ModelMetadataOverrides)
 	}
 	s.registry.SetProviderModelFilter(name, cfg.ModelFilter)
+
+	s.mu.Lock()
+	s.configs[name] = cfg
+	s.mu.Unlock()
+}
+
+// remove unregisters name from the registry and forgets its effective
+// configuration.
+func (s *CredentialsService) remove(name string) {
+	s.registry.UnregisterProvider(name)
+
+	s.mu.Lock()
+	delete(s.configs, name)
+	s.mu.Unlock()
+}
+
+// ConfiguredProviders returns the admin-safe effective configuration of every
+// credential currently installed in the registry, in the same shape
+// providers.Init produces for config.yaml/env providers.
+func (s *CredentialsService) ConfiguredProviders() []SanitizedProviderConfig {
+	s.mu.RLock()
+	configs := make(map[string]ProviderConfig, len(s.configs))
+	maps.Copy(configs, s.configs)
+	s.mu.RUnlock()
+	return SanitizeProviderConfigs(configs)
 }

--- a/internal/providers/credentials_test.go
+++ b/internal/providers/credentials_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/enterpilot/gomodel/config"
 	"github.com/enterpilot/gomodel/internal/core"
@@ -409,5 +410,82 @@ func TestCredentialsService_ReloadSkipsShadowedStoreRowsAndAppliesTheRest(t *tes
 	}
 	if registry.ProviderByName("disabled") != nil {
 		t.Error("ProviderByName(disabled) != nil, want nil (disabled row should not register)")
+	}
+}
+
+// TestCredentialsService_ConfiguredProvidersCarryGlobalResilience guards the
+// admin status endpoint's view of dashboard-registered providers: the config
+// the service exposes must carry the same merged resilience settings
+// resolveProviders produces for config.yaml/env providers, and must track
+// the credential's lifecycle (disable, delete).
+func TestCredentialsService_ConfiguredProvidersCarryGlobalResilience(t *testing.T) {
+	ctx := t.Context()
+	global := config.ResilienceConfig{
+		Retry: config.RetryConfig{
+			MaxRetries:     3,
+			InitialBackoff: time.Second,
+			MaxBackoff:     30 * time.Second,
+			BackoffFactor:  2,
+			JitterFactor:   0.1,
+		},
+		CircuitBreaker: config.CircuitBreakerConfig{
+			Enabled:          true,
+			FailureThreshold: 5,
+			SuccessThreshold: 2,
+			Timeout:          30 * time.Second,
+		},
+	}
+	want := SanitizeProviderConfigs(map[string]ProviderConfig{
+		"my-openai": {Type: "test", Resilience: global},
+	})[0]
+
+	svc, err := NewCredentialsService(ctx, newCredentialsTestFactory(t), NewModelRegistry(), newFakeCredentialStore(), nil, global)
+	if err != nil {
+		t.Fatalf("NewCredentialsService() error = %v", err)
+	}
+	if got := svc.ConfiguredProviders(); len(got) != 0 {
+		t.Fatalf("ConfiguredProviders() before any upsert = %#v, want empty", got)
+	}
+
+	cred := ManagedProviderCredential{Name: "my-openai", Type: "test", APIKeys: []string{"sk-test"}, Enabled: true}
+	if err := svc.Upsert(ctx, cred); err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+	got := svc.ConfiguredProviders()
+	if len(got) != 1 {
+		t.Fatalf("ConfiguredProviders() = %#v, want exactly one entry", got)
+	}
+	if got[0].Name != want.Name || got[0].Type != want.Type {
+		t.Errorf("ConfiguredProviders()[0] = %q/%q, want %q/%q", got[0].Name, got[0].Type, want.Name, want.Type)
+	}
+	if got[0].Resilience != want.Resilience {
+		t.Errorf("ConfiguredProviders()[0].Resilience = %+v, want global defaults %+v", got[0].Resilience, want.Resilience)
+	}
+
+	tests := []struct {
+		name string
+		act  func() error
+	}{
+		{name: "disabled", act: func() error {
+			cred.Enabled = false
+			return svc.Upsert(ctx, cred)
+		}},
+		{name: "deleted", act: func() error {
+			cred.Enabled = true
+			if err := svc.Upsert(ctx, cred); err != nil {
+				return err
+			}
+			return svc.Delete(ctx, cred.Name)
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.act(); err != nil {
+				t.Fatalf("%s: error = %v", tt.name, err)
+			}
+			if got := svc.ConfiguredProviders(); len(got) != 0 {
+				t.Errorf("ConfiguredProviders() after %s = %#v, want empty", tt.name, got)
+			}
+		})
 	}
 }

--- a/tests/e2e/manage-release-e2e-stack.sh
+++ b/tests/e2e/manage-release-e2e-stack.sh
@@ -230,6 +230,32 @@ wait_for_health() {
   exit 1
 }
 
+# Deletes every unmanaged (dashboard-registered) provider credential on a
+# running gateway so the stack only carries the providers declared in .env.
+# Config/env providers report `managed: true` and are never touched. Runtime
+# credentials persist in the gateway's storage across restarts, and a leftover
+# one from an earlier session would otherwise show up on
+# /admin/providers/status and skew scenarios such as S219.
+clear_unmanaged_credentials() {
+  local gateway="$1"
+  local port entries name encoded
+  port="$(gateway_port "$gateway")"
+
+  entries="$(curl -fsS "http://localhost:$port/admin/provider-credentials" \
+    -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
+    | jq -r '.[] | select(.managed == false) | "\(.name)\t\(.name | @uri)"')" \
+    || die "failed to list provider credentials on $gateway"
+
+  [[ -n "$entries" ]] || return 0
+  while IFS=$'\t' read -r name encoded; do
+    [[ -n "$encoded" ]] || continue
+    curl -fsS -X DELETE "http://localhost:$port/admin/provider-credentials/$encoded" \
+      -H "Authorization: Bearer $GOMODEL_MASTER_KEY" >/dev/null \
+      || die "failed to delete unmanaged provider credential $name on $gateway"
+    printf 'deleted unmanaged provider credential %s on %s\n' "$name" "$gateway"
+  done <<<"$entries"
+}
+
 start_gateway() {
   local gateway="$1"
   shift
@@ -413,6 +439,11 @@ start_stack() {
   curl -fsS "http://localhost:18084/admin/runtime/config" \
     -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
     | jq -e '.CACHE_ENABLED == "on" and .REDIS_URL == "on"' >/dev/null
+
+  local gateway
+  for gateway in sqlite-main pg-smoke mongo-smoke; do
+    clear_unmanaged_credentials "$gateway"
+  done
 
   printf 'stack_dir=%s\n' "$STACK_DIR"
 }

--- a/tests/e2e/manage-release-e2e-stack.sh
+++ b/tests/e2e/manage-release-e2e-stack.sh
@@ -238,21 +238,24 @@ wait_for_health() {
 # /admin/providers/status and skew scenarios such as S219.
 clear_unmanaged_credentials() {
   local gateway="$1"
-  local port entries name encoded
+  local port entries encoded
   port="$(gateway_port "$gateway")"
 
+  # One URI-encoded name per line: provider names may contain whitespace, so
+  # the encoded form is the only delimiter-safe record (it is also what the
+  # DELETE URL needs).
   entries="$(curl -fsS "http://localhost:$port/admin/provider-credentials" \
     -H "Authorization: Bearer $GOMODEL_MASTER_KEY" \
-    | jq -r '.[] | select(.managed == false) | "\(.name)\t\(.name | @uri)"')" \
+    | jq -r '.[] | select(.managed == false) | .name | @uri')" \
     || die "failed to list provider credentials on $gateway"
 
   [[ -n "$entries" ]] || return 0
-  while IFS=$'\t' read -r name encoded; do
+  while IFS= read -r encoded; do
     [[ -n "$encoded" ]] || continue
     curl -fsS -X DELETE "http://localhost:$port/admin/provider-credentials/$encoded" \
       -H "Authorization: Bearer $GOMODEL_MASTER_KEY" >/dev/null \
-      || die "failed to delete unmanaged provider credential $name on $gateway"
-    printf 'deleted unmanaged provider credential %s on %s\n' "$name" "$gateway"
+      || die "failed to delete unmanaged provider credential $encoded on $gateway"
+    printf 'deleted unmanaged provider credential %s on %s\n' "$encoded" "$gateway"
   done <<<"$entries"
 }
 

--- a/tests/e2e/release-e2e-scenarios.md
+++ b/tests/e2e/release-e2e-scenarios.md
@@ -5524,7 +5524,9 @@ sets no resilience overrides, so every provider must report the documented
 defaults: the breaker on, five failures to open, two successes to close, and a
 30s timeout. Turning the breaker off needs a gateway booted with
 `RESILIENCE_CIRCUIT_BREAKER_ENABLED=false`, so that path is covered by the
-`config` and `internal/llmclient` unit tests.
+`config` and `internal/llmclient` unit tests. The stack manager deletes every
+unmanaged (dashboard-registered) provider credential on `start`, so a leftover
+runtime credential cannot make this assertion nondeterministic.
 
 ```bash
 STATUS_FILE="$QA_RUN_DIR/s219.status.json"


### PR DESCRIPTION
`GET /admin/providers/status` reported an all-zero `config.resilience` block (`max_retries: 0`, `circuit_breaker.enabled: false`) for providers registered through the dashboard or `PUT /admin/provider-credentials`, while the runtime client did use the global defaults (retries and the breaker were verified on a freshly registered credential). Release scenario S219 fails whenever such a credential exists.

The credentials service already merges the global resilience config through the same helper `resolveProviders` uses; the merged config was discarded after the provider was created. The admin handler's `configuredProviders` is a startup snapshot, so runtime providers were synthesized as name-and-type only. The credentials service now keeps the installed provider configs and exposes them as sanitized configs (same shape as file/env providers, no secrets); the status handler merges them for names the declarative snapshot does not know. A registered zero-model runtime credential now classifies as configured instead of unknown.

Test stack: `manage-release-e2e-stack.sh start` now deletes unmanaged provider credentials on the SQLite, PostgreSQL and MongoDB gateways once they are healthy, so leftovers from manual sessions cannot break S219; the scenario text notes it and its assertion is unchanged.

Verified by rebuilding the release stack from this branch (it deleted the stale `mock` credential from Aug 30) and rerunning S192-S196 and S219: all OK. Unit tests for the credentials service and the status handler fail on `main` and pass here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeodgpchoTafihJFab6u5k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider status now includes dashboard-registered credentials and reports their effective configuration, including retry and circuit-breaker settings.
  * Explicitly configured providers continue to take precedence when both configuration sources are present.

* **Bug Fixes**
  * Provider status now stays synchronized when credentials are updated, disabled, or deleted.

* **Documentation**
  * Release scenario documentation now clarifies that unmanaged credentials are cleared during stack startup to keep status checks deterministic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->