### PR TITLE
fix(server): keep the gateway's rate-limit headers on fast-path chat responses

### DIFF
--- a/internal/server/chat_fast_path_test.go
+++ b/internal/server/chat_fast_path_test.go
@@ -222,6 +222,36 @@ func TestChatCompletionStreaming_FastPathRelaysSSEWhenNoPlanApplies(t *testing.T
 	}
 }
 
+// The gateway writes its own X-Ratelimit-* headers before dispatch; the
+// provider's account limits must not replace them on the fast path, while
+// other upstream headers are still relayed.
+func TestChatCompletion_FastPathDropsUpstreamRateLimitHeaders(t *testing.T) {
+	for _, entry := range chatEntryPoints {
+		t.Run(entry.name, func(t *testing.T) {
+			mock := fastPathJSONMock(fastPathUpstreamBody)
+			mock.passthroughResponse.Headers["x-ratelimit-limit-requests"] = []string{"5000"}
+			mock.passthroughResponse.Headers["X-Ratelimit-Remaining-Tokens"] = []string{"1999989"}
+			mock.passthroughResponse.Headers["X-Upstream-Trace"] = []string{"abc"}
+			rec := entry.post(t, mock, fastPathChatRequestBody)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+			}
+			if mock.lastPassthroughReq == nil {
+				t.Fatal("request did not take the fast path")
+			}
+			for key := range rec.Header() {
+				if strings.HasPrefix(http.CanonicalHeaderKey(key), "X-Ratelimit-") {
+					t.Fatalf("upstream rate-limit header %s relayed: %v", key, rec.Header().Values(key))
+				}
+			}
+			if got := rec.Header().Get("X-Upstream-Trace"); got != "abc" {
+				t.Fatalf("X-Upstream-Trace = %q, want abc", got)
+			}
+		})
+	}
+}
+
 func TestChatCompletion_FastPathSkippedWhenRawModelIsNotCanonical(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/server/chat_fast_path_test.go
+++ b/internal/server/chat_fast_path_test.go
@@ -224,31 +224,80 @@ func TestChatCompletionStreaming_FastPathRelaysSSEWhenNoPlanApplies(t *testing.T
 
 // The gateway writes its own X-Ratelimit-* headers before dispatch; the
 // provider's account limits must not replace them on the fast path, while
-// other upstream headers are still relayed.
+// other upstream headers are still relayed. gatewayRateLimitHeader stands in
+// for the value the rate-limit reservation wrote before the handler ran.
 func TestChatCompletion_FastPathDropsUpstreamRateLimitHeaders(t *testing.T) {
-	for _, entry := range chatEntryPoints {
-		t.Run(entry.name, func(t *testing.T) {
-			mock := fastPathJSONMock(fastPathUpstreamBody)
-			mock.passthroughResponse.Headers["x-ratelimit-limit-requests"] = []string{"5000"}
-			mock.passthroughResponse.Headers["X-Ratelimit-Remaining-Tokens"] = []string{"1999989"}
-			mock.passthroughResponse.Headers["X-Upstream-Trace"] = []string{"abc"}
-			rec := entry.post(t, mock, fastPathChatRequestBody)
+	const gatewayRateLimitHeader = "X-Ratelimit-Limit-Tokens"
+	streamData := "data: {\"id\":\"chatcmpl-123\",\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\ndata: [DONE]\n\n"
 
-			if rec.Code != http.StatusOK {
-				t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	tests := []struct {
+		name     string
+		body     string
+		upstream string
+		stream   bool
+	}{
+		{name: "non-streaming", body: fastPathChatRequestBody, upstream: fastPathUpstreamBody},
+		{name: "streaming", body: `{"model":"gpt-4o-mini","stream":true,"messages":[{"role":"user","content":"Hi"}]}`, upstream: streamData, stream: true},
+	}
+	entries := []struct {
+		name string
+		post func(t *testing.T, mock *mockProvider, body string) *httptest.ResponseRecorder
+	}{
+		{name: "handler only", post: func(t *testing.T, mock *mockProvider, body string) *httptest.ResponseRecorder {
+			t.Helper()
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			rec.Header().Set(gatewayRateLimitHeader, "1")
+			if err := NewHandler(mock, nil, nil, nil).ChatCompletion(e.NewContext(req, rec)); err != nil {
+				t.Fatalf("handler returned error: %v", err)
 			}
-			if mock.lastPassthroughReq == nil {
-				t.Fatal("request did not take the fast path")
-			}
-			for key := range rec.Header() {
-				if strings.HasPrefix(http.CanonicalHeaderKey(key), "X-Ratelimit-") {
-					t.Fatalf("upstream rate-limit header %s relayed: %v", key, rec.Header().Values(key))
+			return rec
+		}},
+		{name: "middleware stack", post: func(t *testing.T, mock *mockProvider, body string) *httptest.ResponseRecorder {
+			t.Helper()
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			rec.Header().Set(gatewayRateLimitHeader, "1")
+			New(mock, &Config{}).ServeHTTP(rec, req)
+			return rec
+		}},
+	}
+
+	for _, entry := range entries {
+		for _, tt := range tests {
+			t.Run(entry.name+"/"+tt.name, func(t *testing.T) {
+				mock := fastPathJSONMock(tt.upstream)
+				if tt.stream {
+					mock.passthroughResponse.Headers["Content-Type"] = []string{"text/event-stream"}
 				}
-			}
-			if got := rec.Header().Get("X-Upstream-Trace"); got != "abc" {
-				t.Fatalf("X-Upstream-Trace = %q, want abc", got)
-			}
-		})
+				mock.passthroughResponse.Headers["x-ratelimit-limit-requests"] = []string{"5000"}
+				mock.passthroughResponse.Headers[gatewayRateLimitHeader] = []string{"2000000"}
+				mock.passthroughResponse.Headers["X-Upstream-Trace"] = []string{"abc"}
+				rec := entry.post(t, mock, tt.body)
+
+				if rec.Code != http.StatusOK {
+					t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+				}
+				if mock.lastPassthroughReq == nil {
+					t.Fatal("request did not take the fast path")
+				}
+				if got := rec.Header().Values(gatewayRateLimitHeader); len(got) != 1 || got[0] != "1" {
+					t.Fatalf("%s = %v, want the gateway's [1]", gatewayRateLimitHeader, got)
+				}
+				if got := rec.Header().Values("X-Ratelimit-Limit-Requests"); len(got) != 0 {
+					t.Fatalf("upstream X-Ratelimit-Limit-Requests relayed: %v", got)
+				}
+				if got := rec.Header().Get("X-Upstream-Trace"); got != "abc" {
+					t.Fatalf("X-Upstream-Trace = %q, want abc", got)
+				}
+				if tt.stream && rec.Body.String() != streamData {
+					t.Fatalf("stream body = %q, want %q", rec.Body.String(), streamData)
+				}
+			})
+		}
 	}
 }
 

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -531,6 +531,7 @@ func (s *translatedInferenceService) tryFastPathChatPassthrough(c *echo.Context,
 	if err != nil {
 		return true, handleError(c, err)
 	}
+	dropUpstreamRateLimitHeaders(resp.Headers)
 	if !req.Stream {
 		if err := stampPassthroughChatProvider(resp, providerType); err != nil {
 			_ = resp.Body.Close()
@@ -594,6 +595,19 @@ func bufferedRequestBody(c *echo.Context) ([]byte, bool) {
 	}
 	body, err := requestBodyBytes(c)
 	return body, err == nil
+}
+
+// dropUpstreamRateLimitHeaders removes the provider's own X-Ratelimit-* headers
+// from a fast-path response. The gateway sets its rate-limit headers on the
+// response before dispatch, and copying the upstream values would replace
+// them with the provider account's limits, which the translated path never
+// exposes.
+func dropUpstreamRateLimitHeaders(headers map[string][]string) {
+	for key := range headers {
+		if strings.HasPrefix(http.CanonicalHeaderKey(strings.TrimSpace(key)), "X-Ratelimit-") {
+			delete(headers, key)
+		}
+	}
 }
 
 // bodyValidatorHeaders are response headers derived from the body bytes; they


### PR DESCRIPTION
Regression from #849, caught by release scenarios S156 and S157 on merged `main`.

The gateway applies its `X-Ratelimit-*` headers to the response when the rate-limit reservation is made, before dispatch. The chat fast path then copies the upstream response headers, and the copy replaces same-named headers, so a client saw OpenAI's account limits (`X-Ratelimit-Limit-Requests: 5000`, `X-Ratelimit-Limit-Tokens: 2000000`, `X-Ratelimit-Reset-Requests: 12ms`) instead of the gateway's rule (`X-Ratelimit-Limit-Tokens: 1`). Enforcement was unaffected: the next request was still blocked with 429 and the gateway's headers, and token post-accounting still landed on the rule.

The fast path now drops the provider's `X-Ratelimit-*` headers before relaying the response, streaming or not, which is what the translated path has always done by construction. Other upstream headers are still relayed. Provider-native `/p/{provider}/...` passthrough is unchanged and keeps exposing the raw provider headers.

Test: `TestChatCompletion_FastPathDropsUpstreamRateLimitHeaders` runs through both the bare handler and the middleware stack and fails on `main`. Release scenarios S155-S159 pass on a stack rebuilt from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeodgpchoTafihJFab6u5k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fast-path chat responses no longer expose upstream provider rate-limit headers.
  - Gateway rate-limit information is preserved instead of being replaced by provider account limits.
  - Other upstream response headers continue to be forwarded normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->