### PR TITLE
fix(anthropic): drop rejected sampling params and relax forced tool choice on Fable 5.1

### DIFF
--- a/docs/providers/anthropic.mdx
+++ b/docs/providers/anthropic.mdx
@@ -70,7 +70,7 @@ depends on whether the model supports **adaptive thinking**.
 
 | Model generation | Thinking config | Effort destination |
 | ---------------- | --------------- | ------------------ |
-| Adaptive — `claude-fable-5`, `claude-opus-4-8`, `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6` (and dated snapshots of each) | `thinking: {type: "adaptive"}` | `output_config.effort` (passed through) |
+| Adaptive — `claude-fable-5`, `claude-fable-5-1`, `claude-opus-5`, `claude-sonnet-5`, `claude-opus-4-8`, `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6` (and dated snapshots of each) | `thinking: {type: "adaptive"}` | `output_config.effort` (passed through) |
 | Legacy (everything else, e.g. `claude-opus-4-5`, `claude-3-5-sonnet`) | `thinking: {type: "enabled", budget_tokens: N}` | mapped to a token budget |
 
 <Note>
@@ -103,16 +103,52 @@ so on legacy models they are capped at the `high` budget rather than inflating
 </Note>
 
 <Note>
-  Effort levels are model-gated upstream: `xhigh` is only available on Fable 5
-  and Opus 4.8/4.7, and `max` on Fable 5, Opus 4.8/4.7/4.6, and Sonnet 4.6.
-  GoModel forwards the level you send; Anthropic rejects it with a 400 if the
-  target model does not support it. Manual `budget_tokens` thinking is rejected
-  on Fable 5 and Opus 4.7/4.8, which is why GoModel uses adaptive thinking for
-  those models.
+  Effort levels are model-gated upstream: `xhigh` is available on Fable 5/5.1,
+  Opus 5, Sonnet 5, and Opus 4.8/4.7; `max` on those plus Opus 4.6 and
+  Sonnet 4.6. GoModel forwards the level you send; Anthropic rejects it with a
+  400 if the target model does not support it. Manual `budget_tokens` thinking
+  is rejected from Opus 4.7 onward, which is why GoModel uses adaptive thinking
+  for those models.
 </Note>
 
-When extended thinking is engaged, Anthropic requires `temperature = 1`. GoModel
-drops any other temperature value (and logs it) rather than failing the request.
+<Note>
+  On Fable 5.1 (and Mythos 5.1) thinking is always on, whether or not you send
+  `reasoning`. The tokens it spends are reported as
+  `usage.completion_reasoning_tokens` in Chat Completions responses. The
+  reasoning text itself is not returned; only the token count is.
+</Note>
+
+## Sampling parameters
+
+Anthropic removed `temperature` and `top_p` from Fable 5/5.1, Mythos 5/5.1,
+Opus 5, Sonnet 5, and Opus 4.8/4.7 — any value, including the OpenAI SDK
+default of `temperature: 1`, is rejected upstream with a 400. GoModel drops
+both fields for those models and logs the discarded values, so clients that
+always send a temperature keep working. Older models still receive them as
+sent.
+
+Independently of the model, when extended thinking is engaged Anthropic
+requires `temperature = 1`. GoModel drops any other temperature value (and logs
+it) rather than failing the request.
+
+## Forced tool choice on Fable 5.1
+
+Fable 5.1 and Mythos 5.1 accept only `tool_choice: "auto"` and `"none"`;
+forcing a call with `"required"` or `{"type": "function", ...}` returns a 400
+from Anthropic. GoModel follows Anthropic's documented replacement: the choice
+is downgraded to `auto` and an instruction is appended to the system prompt —
+"You must respond by calling one of the provided tools." for `required`, or
+"You must respond by calling the tool named `<name>`." for a named function.
+The downgrade is logged. `parallel_tool_calls: false` is still honored. Fable 5
+and every other Claude model keep forced tool use unchanged.
+
+<Warning>
+  The instruction is strong guidance, not a hard guarantee: the model can still
+  answer in text. If you relied on forced tool choice to obtain JSON, check
+  `finish_reason` and retry, or use the
+  [native passthrough](#native-passthrough) with Anthropic's structured
+  outputs instead.
+</Warning>
 
 ## Native passthrough
 

--- a/docs/providers/anthropic.mdx
+++ b/docs/providers/anthropic.mdx
@@ -70,7 +70,7 @@ depends on whether the model supports **adaptive thinking**.
 
 | Model generation | Thinking config | Effort destination |
 | ---------------- | --------------- | ------------------ |
-| Adaptive — `claude-fable-5`, `claude-fable-5-1`, `claude-opus-5`, `claude-sonnet-5`, `claude-opus-4-8`, `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6` (and dated snapshots of each) | `thinking: {type: "adaptive"}` | `output_config.effort` (passed through) |
+| Adaptive — `claude-fable-5`, `claude-fable-5-1`, `claude-mythos-5`, `claude-mythos-5-1`, `claude-opus-5`, `claude-sonnet-5`, `claude-opus-4-8`, `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6` (and dated snapshots of each) | `thinking: {type: "adaptive"}` | `output_config.effort` (passed through) |
 | Legacy (everything else, e.g. `claude-opus-4-5`, `claude-3-5-sonnet`) | `thinking: {type: "enabled", budget_tokens: N}` | mapped to a token budget |
 
 <Note>

--- a/docs/providers/anthropic.mdx
+++ b/docs/providers/anthropic.mdx
@@ -93,9 +93,11 @@ so on legacy models they are capped at the `high` budget rather than inflating
 | `high` / `xhigh` / `max` | 20000 |
 
 <Note>
-  Omit `reasoning` to leave thinking off. On the adaptive models above, GoModel
-  only sets `thinking: {type: "adaptive"}` when you pass `reasoning.effort`;
-  without it those models do not engage extended thinking. Effort is a separate
+  Omit `reasoning` to leave thinking at the model's default. GoModel only sets
+  `thinking: {type: "adaptive"}` when you pass `reasoning.effort`. Without it,
+  Opus 4.6 to 4.8 and Sonnet 4.6/5 do not engage extended thinking, while
+  Fable 5/5.1, Mythos 5/5.1, and Opus 5 think adaptively on their own (see the
+  always-on note below). Effort is a separate
   control that governs overall token spend (text and tool calls) whether or not
   thinking is engaged, and Anthropic defaults it to `high` when unset. It is a
   behavioral signal for depth and verbosity, not a hard budget — actual usage
@@ -112,10 +114,11 @@ so on legacy models they are capped at the `high` budget rather than inflating
 </Note>
 
 <Note>
-  On Fable 5.1 (and Mythos 5.1) thinking is always on, whether or not you send
-  `reasoning`. The tokens it spends are reported as
-  `usage.completion_reasoning_tokens` in Chat Completions responses. The
-  reasoning text itself is not returned; only the token count is.
+  On Fable 5/5.1, Mythos 5/5.1, and Opus 5 thinking is always on, whether or
+  not you send `reasoning`; `reasoning.effort` only tunes its depth. The tokens
+  it spends are reported as `usage.completion_reasoning_tokens` in Chat
+  Completions responses. The reasoning text itself is not returned; only the
+  token count is.
 </Note>
 
 ## Sampling parameters

--- a/docs/providers/anthropic.mdx
+++ b/docs/providers/anthropic.mdx
@@ -94,7 +94,8 @@ so on legacy models they are capped at the `high` budget rather than inflating
 
 <Note>
   Omit `reasoning` to leave thinking at the model's default. GoModel only sets
-  `thinking: {type: "adaptive"}` when you pass `reasoning.effort`. Without it,
+  `thinking: {type: "adaptive"}` when you pass `reasoning.effort` (or
+  `reasoning_effort`). Without it,
   Opus 4.6 to 4.8 and Sonnet 4.6/5 do not engage extended thinking, while
   Fable 5/5.1, Mythos 5/5.1, and Opus 5 think adaptively on their own (see the
   always-on note below). Effort is a separate

--- a/internal/providers/anthropic/anthropic.go
+++ b/internal/providers/anthropic/anthropic.go
@@ -304,9 +304,10 @@ func rejectsForcedToolChoice(model string) bool {
 	return matchesModelPrefix(model, forcedToolChoiceRejectedPrefixes)
 }
 
-// matchesModelPrefix reports whether model is one of the prefixes exactly or a
-// dated snapshot of one ("<prefix>-YYYYMMDD"). The trailing dash keeps
-// "claude-opus-4-6" from matching "claude-opus-4-65".
+// matchesModelPrefix reports whether model is one of the prefixes exactly or
+// extends one past a dash, which covers dated snapshots ("claude-opus-4-8-20260301")
+// and point releases ("claude-fable-5" matches "claude-fable-5-1"). The trailing
+// dash keeps "claude-opus-4-6" from matching "claude-opus-4-65".
 func matchesModelPrefix(model string, prefixes []string) bool {
 	for _, prefix := range prefixes {
 		if model == prefix || strings.HasPrefix(model, prefix+"-") {

--- a/internal/providers/anthropic/anthropic.go
+++ b/internal/providers/anthropic/anthropic.go
@@ -271,7 +271,43 @@ var adaptiveThinkingPrefixes = []string{
 }
 
 func isAdaptiveThinkingModel(model string) bool {
-	for _, prefix := range adaptiveThinkingPrefixes {
+	return matchesModelPrefix(model, adaptiveThinkingPrefixes)
+}
+
+// samplingRejectedPrefixes lists the model families that removed the
+// temperature and top_p sampling parameters. Anthropic rejects a request that
+// carries either of them with a 400 ("`temperature` is deprecated for this
+// model"), regardless of the value, so GoModel drops them instead of failing.
+var samplingRejectedPrefixes = []string{
+	"claude-fable-5",
+	"claude-mythos-5",
+	"claude-opus-5",
+	"claude-sonnet-5",
+	"claude-opus-4-8",
+	"claude-opus-4-7",
+}
+
+func rejectsSamplingParameters(model string) bool {
+	return matchesModelPrefix(model, samplingRejectedPrefixes)
+}
+
+// forcedToolChoiceRejectedPrefixes lists the models that no longer accept
+// tool_choice type "any" or "tool" (only "auto" and "none" remain). Fable 5.1
+// introduced the restriction; Fable 5 still honors forced tool use.
+var forcedToolChoiceRejectedPrefixes = []string{
+	"claude-fable-5-1",
+	"claude-mythos-5-1",
+}
+
+func rejectsForcedToolChoice(model string) bool {
+	return matchesModelPrefix(model, forcedToolChoiceRejectedPrefixes)
+}
+
+// matchesModelPrefix reports whether model is one of the prefixes exactly or a
+// dated snapshot of one ("<prefix>-YYYYMMDD"). The trailing dash keeps
+// "claude-opus-4-6" from matching "claude-opus-4-65".
+func matchesModelPrefix(model string, prefixes []string) bool {
+	for _, prefix := range prefixes {
 		if model == prefix || strings.HasPrefix(model, prefix+"-") {
 			return true
 		}

--- a/internal/providers/anthropic/anthropic.go
+++ b/internal/providers/anthropic/anthropic.go
@@ -262,6 +262,7 @@ func (p *Provider) Passthrough(ctx context.Context, req *core.PassthroughRequest
 
 var adaptiveThinkingPrefixes = []string{
 	"claude-fable-5",
+	"claude-mythos-5",
 	"claude-opus-5",
 	"claude-sonnet-5",
 	"claude-opus-4-8",

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -4374,6 +4374,9 @@ func TestIsAdaptiveThinkingModel(t *testing.T) {
 	}{
 		{"claude-fable-5", true},
 		{"claude-fable-5-20260601", true},
+		{"claude-fable-5-1", true},
+		{"claude-mythos-5", true},
+		{"claude-mythos-5-1-20260901", true},
 		{"claude-opus-5", true},
 		{"claude-opus-5-20260601", true},
 		{"claude-sonnet-5", true},
@@ -5720,5 +5723,42 @@ func TestConvertToAnthropicRequest_RelaxesForcedToolChoice(t *testing.T) {
 				t.Fatalf("System = %q, want %q", gotSystem, tt.wantInstruction)
 			}
 		})
+	}
+}
+
+func TestConvertToAnthropicRequest_AdaptiveThinkingForDatedFableAndMythos(t *testing.T) {
+	for _, model := range []string{"claude-fable-5-1-20260901", "claude-mythos-5-1-20260901"} {
+		t.Run("chat "+model, func(t *testing.T) {
+			out, err := convertToAnthropicRequest(&core.ChatRequest{
+				Model:     model,
+				Reasoning: &core.Reasoning{Effort: "high"},
+				Messages:  []core.Message{{Role: "user", Content: "Hello"}},
+			})
+			if err != nil {
+				t.Fatalf("convertToAnthropicRequest() error = %v", err)
+			}
+			assertAdaptiveHighEffort(t, out)
+		})
+		t.Run("responses "+model, func(t *testing.T) {
+			out, err := convertResponsesRequestToAnthropic(&core.ResponsesRequest{
+				Model:     model,
+				Input:     "Hello",
+				Reasoning: &core.Reasoning{Effort: "high"},
+			})
+			if err != nil {
+				t.Fatalf("convertResponsesRequestToAnthropic() error = %v", err)
+			}
+			assertAdaptiveHighEffort(t, out)
+		})
+	}
+}
+
+func assertAdaptiveHighEffort(t *testing.T, out *anthropicRequest) {
+	t.Helper()
+	if out.Thinking == nil || out.Thinking.Type != "adaptive" || out.Thinking.BudgetTokens != 0 {
+		t.Fatalf("Thinking = %+v, want adaptive without budget_tokens", out.Thinking)
+	}
+	if out.OutputConfig == nil || out.OutputConfig.Effort != "high" {
+		t.Fatalf("OutputConfig = %+v, want effort high", out.OutputConfig)
 	}
 }

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -5550,3 +5550,175 @@ func TestMessagesCacheBreakpointsSurviveTranslation(t *testing.T) {
 		t.Fatalf("trailing system message = %#v, want one block with cache_control", last.Content)
 	}
 }
+
+func TestRejectsSamplingParameters(t *testing.T) {
+	for model, want := range map[string]bool{
+		"claude-fable-5":             true,
+		"claude-fable-5-1":           true,
+		"claude-mythos-5-1":          true,
+		"claude-opus-5":              true,
+		"claude-sonnet-5-20260601":   true,
+		"claude-opus-4-8":            true,
+		"claude-opus-4-7-20260101":   true,
+		"claude-opus-4-6":            false,
+		"claude-sonnet-4-6":          false,
+		"claude-sonnet-4-5-20250929": false,
+		"claude-haiku-4-5-20251001":  false,
+		"claude-opus-4-75":           false,
+		"":                           false,
+	} {
+		if got := rejectsSamplingParameters(model); got != want {
+			t.Errorf("rejectsSamplingParameters(%q) = %v, want %v", model, got, want)
+		}
+	}
+}
+
+func TestRejectsForcedToolChoice(t *testing.T) {
+	for model, want := range map[string]bool{
+		"claude-fable-5-1":          true,
+		"claude-fable-5-1-20260901": true,
+		"claude-mythos-5-1":         true,
+		"claude-fable-5":            false,
+		"claude-fable-5-20260601":   false,
+		"claude-fable-5-10":         false,
+		"claude-opus-5":             false,
+		"claude-sonnet-4-6":         false,
+	} {
+		if got := rejectsForcedToolChoice(model); got != want {
+			t.Errorf("rejectsForcedToolChoice(%q) = %v, want %v", model, got, want)
+		}
+	}
+}
+
+func TestConvertToAnthropicRequest_DropsSamplingForModelsThatRejectIt(t *testing.T) {
+	temp := 0.2
+	topP := 0.9
+	tests := []struct {
+		name     string
+		model    string
+		wantKept bool
+	}{
+		{name: "fable 5.1 drops temperature and top_p", model: "claude-fable-5-1"},
+		{name: "opus 4.7 drops temperature and top_p", model: "claude-opus-4-7"},
+		{name: "sonnet 4.6 keeps sampling parameters", model: "claude-sonnet-4-6", wantKept: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := convertToAnthropicRequest(&core.ChatRequest{
+				Model:       tt.model,
+				Temperature: &temp,
+				TopP:        &topP,
+				Messages:    []core.Message{{Role: "user", Content: "Hello"}},
+			})
+			if err != nil {
+				t.Fatalf("convertToAnthropicRequest() error = %v", err)
+			}
+			if tt.wantKept {
+				if out.Temperature == nil || *out.Temperature != temp || out.TopP == nil || *out.TopP != topP {
+					t.Fatalf("Temperature = %v, TopP = %v, want %v and %v", out.Temperature, out.TopP, temp, topP)
+				}
+				return
+			}
+			if out.Temperature != nil || out.TopP != nil {
+				t.Fatalf("Temperature = %v, TopP = %v, want both dropped", out.Temperature, out.TopP)
+			}
+		})
+	}
+}
+
+func TestConvertToAnthropicRequest_RelaxesForcedToolChoice(t *testing.T) {
+	tools := []map[string]any{{
+		"type": "function",
+		"function": map[string]any{
+			"name":       "get_weather",
+			"parameters": map[string]any{"type": "object"},
+		},
+	}}
+	parallelOff := false
+	tests := []struct {
+		name            string
+		model           string
+		toolChoice      any
+		system          string
+		parallel        *bool
+		wantType        string
+		wantName        string
+		wantInstruction string
+	}{
+		{
+			name:            "required becomes auto with a generic instruction",
+			model:           "claude-fable-5-1",
+			toolChoice:      "required",
+			wantType:        "auto",
+			wantInstruction: "You must respond by calling one of the provided tools.",
+		},
+		{
+			name:            "named function becomes auto with a named instruction",
+			model:           "claude-mythos-5-1",
+			toolChoice:      map[string]any{"type": "function", "function": map[string]any{"name": "get_weather"}},
+			wantType:        "auto",
+			wantInstruction: `You must respond by calling the tool named "get_weather".`,
+		},
+		{
+			name:            "instruction is appended after an existing system prompt",
+			model:           "claude-fable-5-1",
+			toolChoice:      "required",
+			system:          "You are terse.",
+			wantType:        "auto",
+			wantInstruction: "You are terse.\n\nYou must respond by calling one of the provided tools.",
+		},
+		{
+			name:            "parallel_tool_calls=false survives the downgrade",
+			model:           "claude-fable-5-1",
+			toolChoice:      "required",
+			parallel:        &parallelOff,
+			wantType:        "auto",
+			wantInstruction: "You must respond by calling one of the provided tools.",
+		},
+		{
+			name:       "auto is forwarded untouched",
+			model:      "claude-fable-5-1",
+			toolChoice: "auto",
+			wantType:   "auto",
+		},
+		{
+			name:       "fable 5 keeps forced tool use",
+			model:      "claude-fable-5",
+			toolChoice: map[string]any{"type": "function", "function": map[string]any{"name": "get_weather"}},
+			wantType:   "tool",
+			wantName:   "get_weather",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			messages := []core.Message{}
+			if tt.system != "" {
+				messages = append(messages, core.Message{Role: "system", Content: tt.system})
+			}
+			messages = append(messages, core.Message{Role: "user", Content: "Weather in Warsaw?"})
+			out, err := convertToAnthropicRequest(&core.ChatRequest{
+				Model:             tt.model,
+				Tools:             tools,
+				ToolChoice:        tt.toolChoice,
+				ParallelToolCalls: tt.parallel,
+				Messages:          messages,
+			})
+			if err != nil {
+				t.Fatalf("convertToAnthropicRequest() error = %v", err)
+			}
+			if out.ToolChoice == nil {
+				t.Fatalf("ToolChoice = nil, want type %q", tt.wantType)
+			}
+			if out.ToolChoice.Type != tt.wantType || out.ToolChoice.Name != tt.wantName {
+				t.Fatalf("ToolChoice = %+v, want type %q name %q", out.ToolChoice, tt.wantType, tt.wantName)
+			}
+			if tt.parallel != nil && (out.ToolChoice.DisableParallelToolUse == nil || !*out.ToolChoice.DisableParallelToolUse) {
+				t.Fatalf("DisableParallelToolUse = %v, want true", out.ToolChoice.DisableParallelToolUse)
+			}
+			gotSystem, _ := out.System.(string)
+			if gotSystem != tt.wantInstruction {
+				t.Fatalf("System = %q, want %q", gotSystem, tt.wantInstruction)
+			}
+		})
+	}
+}

--- a/internal/providers/anthropic/request_translation.go
+++ b/internal/providers/anthropic/request_translation.go
@@ -334,6 +334,8 @@ func convertToAnthropicRequest(req *core.ChatRequest) (*anthropicRequest, error)
 		anthropicReq.MaxTokens = resolveDefaultMaxTokens()
 	}
 
+	dropUnsupportedSamplingParameters(anthropicReq)
+
 	if effort := resolveAnthropicReasoningEffort(req); effort != "" {
 		applyReasoning(anthropicReq, req.Model, effort)
 	}
@@ -343,6 +345,7 @@ func convertToAnthropicRequest(req *core.ChatRequest) (*anthropicRequest, error)
 		return nil, err
 	}
 	anthropicReq.Tools = tools
+	var forcedToolInstruction string
 	if toolChoice, disableTools, err := convertOpenAIToolChoiceToAnthropic(req.ToolChoice); err != nil {
 		return nil, err
 	} else if err := validateAnthropicToolChoice(toolChoice, anthropicReq.Tools, disableTools); err != nil {
@@ -353,6 +356,7 @@ func convertToAnthropicRequest(req *core.ChatRequest) (*anthropicRequest, error)
 		if toolChoice == nil && req.ParallelToolCalls != nil && !*req.ParallelToolCalls {
 			toolChoice = &anthropicToolChoice{Type: "auto"}
 		}
+		toolChoice, forcedToolInstruction = relaxForcedToolChoice(toolChoice, req.Model)
 		toolChoice = applyParallelToolCalls(toolChoice, req.ParallelToolCalls)
 		anthropicReq.ToolChoice = toolChoice
 	}
@@ -396,7 +400,57 @@ func convertToAnthropicRequest(req *core.ChatRequest) (*anthropicRequest, error)
 		})
 	}
 
+	if forcedToolInstruction != "" {
+		anthropicReq.System = appendAnthropicSystemContent(anthropicReq.System, forcedToolInstruction)
+	}
+
 	return anthropicReq, nil
+}
+
+// dropUnsupportedSamplingParameters removes temperature and top_p for models
+// that reject them outright (Opus 4.7 onward and the Claude 5 generation).
+// The values are logged so operators can see the client intent that was
+// discarded; failing the request would break every OpenAI SDK default.
+func dropUnsupportedSamplingParameters(req *anthropicRequest) {
+	if !rejectsSamplingParameters(req.Model) || (req.Temperature == nil && req.TopP == nil) {
+		return
+	}
+	attrs := []any{"model", req.Model}
+	if req.Temperature != nil {
+		attrs = append(attrs, "temperature", *req.Temperature)
+	}
+	if req.TopP != nil {
+		attrs = append(attrs, "top_p", *req.TopP)
+	}
+	slog.Warn("dropping sampling parameters the model does not accept", attrs...)
+	req.Temperature = nil
+	req.TopP = nil
+}
+
+// relaxForcedToolChoice downgrades tool_choice "any" and "tool" to "auto" on
+// models that reject forced tool use (Fable 5.1 and Mythos 5.1). Anthropic's
+// documented replacement is "auto" plus a prompt instruction naming the tool,
+// so the returned instruction is appended to the system prompt to preserve the
+// caller's intent as closely as the provider allows.
+func relaxForcedToolChoice(choice *anthropicToolChoice, model string) (*anthropicToolChoice, string) {
+	if choice == nil || !rejectsForcedToolChoice(model) {
+		return choice, ""
+	}
+	var instruction string
+	switch choice.Type {
+	case "any":
+		instruction = "You must respond by calling one of the provided tools."
+	case "tool":
+		instruction = "You must respond by calling the tool named " + strconv.Quote(choice.Name) + "."
+	default:
+		return choice, ""
+	}
+	slog.Warn("tool_choice downgraded to auto; model rejects forced tool use",
+		"model", model, "tool_choice", choice.Type, "tool", choice.Name)
+	relaxed := *choice
+	relaxed.Type = "auto"
+	relaxed.Name = ""
+	return &relaxed, instruction
 }
 
 func validateAnthropicUnsupportedChatExtras(extra core.UnknownJSONFields) error {


### PR DESCRIPTION
Verified live against `claude-fable-5-1`: chat, streaming, Responses, native `/v1/messages`, passthrough, tool calling and cost metering all worked already, but three requests that OpenAI clients send routinely failed with an upstream 400.

## User-visible impact

- **Sampling parameters no longer fail requests.** Fable 5/5.1, Mythos 5/5.1, Opus 5, Sonnet 5 and Opus 4.8/4.7 reject `temperature` and `top_p` outright (`` `temperature` is deprecated for this model ``). GoModel now drops both for those models and logs the discarded values. Older models still receive them unchanged.
- **Forced tool choice works on Fable 5.1 / Mythos 5.1.** These models return 400 for `tool_choice` `any`/`tool`. GoModel downgrades `required` and `{"type":"function",...}` to `auto` and appends Anthropic's documented replacement, an instruction naming the tool, to the system prompt. `parallel_tool_calls: false` is preserved. Fable 5 and every other model keep forced tool use as before.
- **Docs** list Fable 5.1, Opus 5 and Sonnet 5 as adaptive-thinking models, correct the effort-level gating, and document always-on thinking, the sampling drop and the tool-choice downgrade.

## Tests

Table-driven tests cover the model prefix matchers, the sampling drop (Fable 5.1, Opus 4.7, Sonnet 4.6 control), and the tool-choice downgrade (required, named function, existing system prompt, parallel off, auto untouched, Fable 5 control). `go test ./internal/providers/...`, contract tests and `make lint` pass. Live check on Fable 5.1 after the change: all four previously failing requests return 200 and the model calls the tool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for additional Anthropic models with adaptive-thinking capabilities.
  * Added model-specific handling for unsupported sampling parameters and forced tool selection.

* **Bug Fixes**
  * Prevented unsupported temperature and top-p settings from being sent to affected models.
  * Converted unsupported forced tool choices to automatic selection while preserving the requested intent.

* **Documentation**
  * Expanded guidance on thinking defaults, effort levels, reasoning usage, sampling parameters, and forced tool-choice behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->