### PR TITLE
fix(gemini): clamp minimal reasoning effort to low on models that reject it

### DIFF
--- a/docs/providers/gemini.mdx
+++ b/docs/providers/gemini.mdx
@@ -73,6 +73,22 @@ require native mode and a Gemini image model; masks are not supported. See the
 [Images API provider notes](/advanced/images-api#google-gemini) for parameter
 mapping and pricing details.
 
+## Reasoning effort
+
+In native mode, `reasoning_effort` (or `reasoning.effort`) is translated to
+Gemini's `thinkingConfig`:
+
+| Model family | `none` / `minimal` | `low` / `medium` / `high` |
+| ------------ | ------------------ | ------------------------- |
+| Gemini 2.5 | `thinkingBudget` 0 / 1024 | `thinkingBudget` 1024 / 8192 / 24576 |
+| Gemini 3 Flash, 3.5, 3.6 | `thinkingLevel: minimal` | `thinkingLevel` as given |
+| Gemini 3 Pro, 3.1 Pro, 3.7 Flash, 3.8 Flash | `thinkingLevel: low` | `thinkingLevel` as given |
+
+Thinking cannot be turned off on Gemini 3, and Pro models plus 3.7 and 3.8
+Flash reject `minimal`, so GoModel sends the lowest level those models accept
+instead of surfacing Google's 400. An explicit
+`extra_body.google.thinking_config` is always forwarded unchanged.
+
 ## Image input
 
 | Mode | OpenAI-style `image_url` |

--- a/internal/providers/gemini/native.go
+++ b/internal/providers/gemini/native.go
@@ -636,10 +636,29 @@ func thinkingConfigForEffort(model, effort string) map[string]any {
 			return nil
 		}
 	}
-	if effort == "none" {
-		effort = "minimal"
+	if effort == "none" || effort == "minimal" {
+		if supportsMinimalThinking(model) {
+			effort = "minimal"
+		} else {
+			effort = "low"
+		}
 	}
 	return map[string]any{"thinkingLevel": effort}
+}
+
+// supportsMinimalThinking reports whether a Gemini 3 model accepts the
+// "minimal" thinkingLevel. Gemini 3 Pro models never had it, and Gemini 3.7
+// and 3.8 Flash dropped it; Google answers HTTP 400 for those, so the lowest
+// accepted level ("low") is sent instead. Thinking cannot be turned off on
+// Gemini 3, so "none" is clamped the same way.
+func supportsMinimalThinking(model string) bool {
+	model = strings.ToLower(model)
+	for _, family := range []string{"gemini-3-pro", "gemini-3.1-pro", "gemini-3.7", "gemini-3.8"} {
+		if strings.Contains(model, family) {
+			return false
+		}
+	}
+	return true
 }
 
 func geminiSafetySettings(req *core.ChatRequest) []map[string]any {

--- a/internal/providers/gemini/native.go
+++ b/internal/providers/gemini/native.go
@@ -646,15 +646,24 @@ func thinkingConfigForEffort(model, effort string) map[string]any {
 	return map[string]any{"thinkingLevel": effort}
 }
 
-// supportsMinimalThinking reports whether a Gemini 3 model accepts the
-// "minimal" thinkingLevel. Gemini 3 Pro models never had it, and Gemini 3.7
-// and 3.8 Flash dropped it; Google answers HTTP 400 for those, so the lowest
-// accepted level ("low") is sent instead. Thinking cannot be turned off on
-// Gemini 3, so "none" is clamped the same way.
+// minimalUnsupportedFamilies lists the Gemini model families whose
+// thinkingLevel enum has no "minimal" member: Gemini 3 Pro models never had
+// it, and Gemini 3.7 and 3.8 Flash dropped it. Google answers HTTP 400 for
+// those, so the lowest accepted level ("low") is sent instead. Thinking cannot
+// be turned off on Gemini 3, so "none" is clamped the same way.
+var minimalUnsupportedFamilies = []string{"gemini-3-pro", "gemini-3.1-pro", "gemini-3.7-flash", "gemini-3.8-flash"}
+
+// supportsMinimalThinking reports whether the model accepts the "minimal"
+// thinkingLevel. A family matches only as a whole dash-delimited prefix of
+// the model ID (after any "publisher/" prefix), so "gemini-3.8-flash-cyber"
+// matches while "gemini-3.8-pro-preview" or "gemini-3.70-flash" do not.
 func supportsMinimalThinking(model string) bool {
-	model = strings.ToLower(model)
-	for _, family := range []string{"gemini-3-pro", "gemini-3.1-pro", "gemini-3.7", "gemini-3.8"} {
-		if strings.Contains(model, family) {
+	model = strings.ToLower(strings.TrimSpace(model))
+	if idx := strings.LastIndex(model, "/"); idx >= 0 {
+		model = model[idx+1:]
+	}
+	for _, family := range minimalUnsupportedFamilies {
+		if rest, ok := strings.CutPrefix(model, family); ok && (rest == "" || rest[0] == '-') {
 			return false
 		}
 	}

--- a/internal/providers/gemini/native.go
+++ b/internal/providers/gemini/native.go
@@ -646,23 +646,20 @@ func thinkingConfigForEffort(model, effort string) map[string]any {
 	return map[string]any{"thinkingLevel": effort}
 }
 
-// minimalUnsupportedFamilies lists the Gemini model families whose
-// thinkingLevel enum has no "minimal" member: Gemini 3 Pro models never had
-// it, and Gemini 3.7 and 3.8 Flash dropped it. Google answers HTTP 400 for
-// those, so the lowest accepted level ("low") is sent instead. Thinking cannot
-// be turned off on Gemini 3, so "none" is clamped the same way.
-var minimalUnsupportedFamilies = []string{"gemini-3-pro", "gemini-3.1-pro", "gemini-3.7-flash", "gemini-3.8-flash"}
-
 // supportsMinimalThinking reports whether the model accepts the "minimal"
-// thinkingLevel. A family matches only as a whole dash-delimited prefix of
-// the model ID (after any "publisher/" prefix), so "gemini-3.8-flash-cyber"
-// matches while "gemini-3.8-pro-preview" or "gemini-3.70-flash" do not.
+// thinkingLevel. Gemini 3 Pro models never had it, and Gemini 3.7 and 3.8
+// Flash dropped it; Google answers HTTP 400 for those, so the lowest accepted
+// level ("low") is sent instead. Thinking cannot be turned off on Gemini 3,
+// so "none" is clamped the same way. A family matches only as a whole
+// dash-delimited prefix of the model ID (after any "publisher/" prefix), so
+// "gemini-3.8-flash-cyber" matches while "gemini-3.8-pro-preview" or
+// "gemini-3.70-flash" do not.
 func supportsMinimalThinking(model string) bool {
 	model = strings.ToLower(strings.TrimSpace(model))
 	if idx := strings.LastIndex(model, "/"); idx >= 0 {
 		model = model[idx+1:]
 	}
-	for _, family := range minimalUnsupportedFamilies {
+	for _, family := range [...]string{"gemini-3-pro", "gemini-3.1-pro", "gemini-3.7-flash", "gemini-3.8-flash"} {
 		if rest, ok := strings.CutPrefix(model, family); ok && (rest == "" || rest[0] == '-') {
 			return false
 		}

--- a/internal/providers/gemini/native_thinking_test.go
+++ b/internal/providers/gemini/native_thinking_test.go
@@ -1,0 +1,58 @@
+package gemini
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+func TestThinkingConfigForEffort(t *testing.T) {
+	tests := []struct {
+		name   string
+		model  string
+		effort string
+		want   map[string]any
+	}{
+		{name: "2.5 none disables thinking", model: "gemini-2.5-flash", effort: "none", want: map[string]any{"thinkingBudget": 0}},
+		{name: "2.5 minimal uses budget", model: "gemini-2.5-flash", effort: "minimal", want: map[string]any{"thinkingBudget": 1024}},
+		{name: "2.5 high uses budget", model: "gemini-2.5-pro", effort: "high", want: map[string]any{"thinkingBudget": 24576}},
+		{name: "2.5 unknown effort is dropped", model: "gemini-2.5-flash", effort: "xhigh", want: nil},
+		{name: "3 flash keeps minimal", model: "gemini-3-flash-preview", effort: "minimal", want: map[string]any{"thinkingLevel": "minimal"}},
+		{name: "3.5 flash none becomes minimal", model: "gemini-3.5-flash", effort: "none", want: map[string]any{"thinkingLevel": "minimal"}},
+		{name: "3.6 flash keeps minimal", model: "gemini-3.6-flash", effort: "MINIMAL", want: map[string]any{"thinkingLevel": "minimal"}},
+		{name: "3.7 flash clamps minimal to low", model: "gemini-3.7-flash", effort: "minimal", want: map[string]any{"thinkingLevel": "low"}},
+		{name: "3.8 flash clamps minimal to low", model: "gemini-3.8-flash", effort: "minimal", want: map[string]any{"thinkingLevel": "low"}},
+		{name: "3.8 flash clamps none to low", model: "gemini-3.8-flash", effort: "none", want: map[string]any{"thinkingLevel": "low"}},
+		{name: "3.8 flash cyber clamps minimal to low", model: "gemini-3.8-flash-cyber", effort: "minimal", want: map[string]any{"thinkingLevel": "low"}},
+		{name: "3.8 flash passes medium through", model: "gemini-3.8-flash", effort: "medium", want: map[string]any{"thinkingLevel": "medium"}},
+		{name: "3.8 flash passes high through", model: "gemini-3.8-flash", effort: " high ", want: map[string]any{"thinkingLevel": "high"}},
+		{name: "3.1 pro clamps minimal to low", model: "gemini-3.1-pro-preview", effort: "minimal", want: map[string]any{"thinkingLevel": "low"}},
+		{name: "vertex publisher prefix is honored", model: "google/gemini-3.8-flash", effort: "none", want: map[string]any{"thinkingLevel": "low"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := thinkingConfigForEffort(tt.model, tt.effort)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("thinkingConfigForEffort(%q, %q) = %#v, want %#v", tt.model, tt.effort, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGeminiGenerationConfig_ExplicitThinkingConfigWins(t *testing.T) {
+	var req core.ChatRequest
+	body := `{"model":"gemini-3.8-flash","messages":[{"role":"user","content":"hi"}],` +
+		`"reasoning":{"effort":"minimal"},` +
+		`"extra_body":{"google":{"thinking_config":{"thinking_level":"minimal"}}}}`
+	if err := json.Unmarshal([]byte(body), &req); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	cfg := geminiGenerationConfig(&req)
+	want := map[string]any{"thinkingLevel": "minimal"}
+	if got := cfg["thinkingConfig"]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("thinkingConfig = %#v, want explicit %#v", got, want)
+	}
+}

--- a/internal/providers/gemini/native_thinking_test.go
+++ b/internal/providers/gemini/native_thinking_test.go
@@ -29,6 +29,7 @@ func TestThinkingConfigForEffort(t *testing.T) {
 		{name: "3.8 flash passes medium through", model: "gemini-3.8-flash", effort: "medium", want: map[string]any{"thinkingLevel": "medium"}},
 		{name: "3.8 flash passes high through", model: "gemini-3.8-flash", effort: " high ", want: map[string]any{"thinkingLevel": "high"}},
 		{name: "3.1 pro clamps minimal to low", model: "gemini-3.1-pro-preview", effort: "minimal", want: map[string]any{"thinkingLevel": "low"}},
+		{name: "3 pro clamps minimal to low", model: "gemini-3-pro-preview", effort: "minimal", want: map[string]any{"thinkingLevel": "low"}},
 		{name: "vertex publisher prefix is honored", model: "google/gemini-3.8-flash", effort: "none", want: map[string]any{"thinkingLevel": "low"}},
 		{name: "3.8 pro is outside the documented clamp set", model: "gemini-3.8-pro-preview", effort: "minimal", want: map[string]any{"thinkingLevel": "minimal"}},
 		{name: "3.70 is not 3.7", model: "gemini-3.70-flash-preview", effort: "none", want: map[string]any{"thinkingLevel": "minimal"}},

--- a/internal/providers/gemini/native_thinking_test.go
+++ b/internal/providers/gemini/native_thinking_test.go
@@ -30,6 +30,9 @@ func TestThinkingConfigForEffort(t *testing.T) {
 		{name: "3.8 flash passes high through", model: "gemini-3.8-flash", effort: " high ", want: map[string]any{"thinkingLevel": "high"}},
 		{name: "3.1 pro clamps minimal to low", model: "gemini-3.1-pro-preview", effort: "minimal", want: map[string]any{"thinkingLevel": "low"}},
 		{name: "vertex publisher prefix is honored", model: "google/gemini-3.8-flash", effort: "none", want: map[string]any{"thinkingLevel": "low"}},
+		{name: "3.8 pro is outside the documented clamp set", model: "gemini-3.8-pro-preview", effort: "minimal", want: map[string]any{"thinkingLevel": "minimal"}},
+		{name: "3.70 is not 3.7", model: "gemini-3.70-flash-preview", effort: "none", want: map[string]any{"thinkingLevel": "minimal"}},
+		{name: "3.8 flash embedded in a longer name is not matched", model: "my-gemini-3.8-flash", effort: "minimal", want: map[string]any{"thinkingLevel": "minimal"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

In native mode, `reasoning_effort: none` / `minimal` was translated to `thinkingLevel: minimal` for every non-2.5 Gemini model. Gemini 3.8 Flash, 3.7 Flash, 3.1 Pro and 3 Pro have no `minimal` level, so Google answered HTTP 400 and the request failed.

- Clamp `none` / `minimal` to `low` on those families (Google's own OpenAI-compat layer does the same for 3.1 Pro). Thinking cannot be turned off on Gemini 3, so `low` is the lowest accepted level.
- Models that still accept `minimal` (3 Flash, 3.5, 3.6) are unchanged.
- An explicit `extra_body.google.thinking_config` is still forwarded as-is.
- Adds a table-driven test for `thinkingConfigForEffort` (it had none) and a docs section on the mapping.

User-visible impact: `reasoning_effort: minimal` on `gemini-3.8-flash` / `gemini-3.7-flash` now succeeds instead of returning a provider 400.

References: [What's new in Gemini 3.8 Flash](https://ai.google.dev/gemini-api/docs/latest-model), [Thinking levels](https://ai.google.dev/gemini-api/docs/thinking).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring Gemini reasoning effort through `reasoning_effort` or `reasoning.effort`.
  - Reasoning settings now map to the appropriate thinking configuration for Gemini 2.5 and Gemini 3 model families.

- **Bug Fixes**
  - Improved compatibility with models that reject the `minimal` thinking level by selecting the lowest accepted setting.
  - Explicit Google thinking configuration is forwarded unchanged and takes precedence over reasoning effort settings.

- **Documentation**
  - Documented model-specific mappings and Gemini 3 thinking limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->