### PR TITLE
fix(gemini): drop sampling parameters and candidate_count for Gemini 3 models

### DIFF
--- a/docs/providers/gemini.mdx
+++ b/docs/providers/gemini.mdx
@@ -73,6 +73,16 @@ require native mode and a Gemini image model; masks are not supported. See the
 [Images API provider notes](/advanced/images-api#google-gemini) for parameter
 mapping and pricing details.
 
+## Sampling parameters on Gemini 3
+
+Google's Gemini 3 migration guides say to remove `temperature`, `top_p` and
+`top_k` from every request because the models are tuned for their defaults,
+and list `candidate_count` as unsupported on Gemini 3.x. In native mode GoModel
+therefore drops those four fields for Gemini 3 and later (`gemini-3-*`,
+`gemini-3.5-*`, `gemini-3.8-*`, ...) and still forwards them for Gemini 2.5,
+Gemma and other models. `max_tokens`, `stop`, penalties, `response_format` and
+thinking settings are unaffected.
+
 ## Image input
 
 | Mode | OpenAI-style `image_url` |

--- a/internal/providers/gemini/native.go
+++ b/internal/providers/gemini/native.go
@@ -493,16 +493,18 @@ func geminiGenerationConfig(req *core.ChatRequest) map[string]any {
 			cfg["maxOutputTokens"] = maxTokens
 		}
 	}
-	if req.Temperature != nil {
-		cfg["temperature"] = *req.Temperature
+	if !dropsSamplingParameters(req.Model) {
+		if req.Temperature != nil {
+			cfg["temperature"] = *req.Temperature
+		}
+		if req.TopP != nil {
+			cfg["topP"] = *req.TopP
+		} else {
+			copyJSONNumber(req.ExtraFields.Lookup("top_p"), cfg, "topP")
+		}
+		copyJSONNumber(req.ExtraFields.Lookup("top_k"), cfg, "topK")
+		copyJSONNumber(req.ExtraFields.Lookup("candidate_count"), cfg, "candidateCount")
 	}
-	if req.TopP != nil {
-		cfg["topP"] = *req.TopP
-	} else {
-		copyJSONNumber(req.ExtraFields.Lookup("top_p"), cfg, "topP")
-	}
-	copyJSONNumber(req.ExtraFields.Lookup("top_k"), cfg, "topK")
-	copyJSONNumber(req.ExtraFields.Lookup("candidate_count"), cfg, "candidateCount")
 	copyJSONNumber(req.ExtraFields.Lookup("presence_penalty"), cfg, "presencePenalty")
 	copyJSONNumber(req.ExtraFields.Lookup("frequency_penalty"), cfg, "frequencyPenalty")
 	copyStopSequences(req.ExtraFields.Lookup("stop"), cfg)
@@ -519,6 +521,45 @@ func geminiGenerationConfig(req *core.ChatRequest) map[string]any {
 		return nil
 	}
 	return cfg
+}
+
+// dropsSamplingParameters reports whether temperature, topP, topK and
+// candidateCount are left out of the generation config. Google's Gemini 3
+// migration guides say to remove the sampling parameters from every request
+// ("Gemini 3's reasoning capabilities are optimized for the default settings")
+// and list candidate_count as unsupported on Gemini 3.x, so they are dropped
+// for Gemini 3 and later while Gemini 2.5 keeps honoring them.
+func dropsSamplingParameters(model string) bool {
+	major, _, ok := geminiGeneration(model)
+	return ok && major >= 3
+}
+
+// geminiGeneration parses the "<major>[.<minor>]" generation that follows the
+// "gemini-" family prefix in a model ID such as "gemini-3.8-flash",
+// "google/gemini-3-pro-preview" or "gemini-2.5-flash-image". It reports
+// ok=false for IDs without that prefix (gemma, imagen, embeddings, tuned
+// models), which then keep the pre-Gemini-3 behavior.
+func geminiGeneration(model string) (major, minor int, ok bool) {
+	model = strings.ToLower(strings.TrimSpace(model))
+	if idx := strings.LastIndex(model, "/"); idx >= 0 {
+		model = model[idx+1:]
+	}
+	rest, found := strings.CutPrefix(model, "gemini-")
+	if !found {
+		return 0, 0, false
+	}
+	version, _, _ := strings.Cut(rest, "-")
+	majorText, minorText, hasMinor := strings.Cut(version, ".")
+	major, err := strconv.Atoi(majorText)
+	if err != nil || major < 0 {
+		return 0, 0, false
+	}
+	if hasMinor {
+		if minor, err = strconv.Atoi(minorText); err != nil || minor < 0 {
+			return 0, 0, false
+		}
+	}
+	return major, minor, true
 }
 
 func copyJSONNumber(raw json.RawMessage, cfg map[string]any, key string) {

--- a/internal/providers/gemini/native_sampling_test.go
+++ b/internal/providers/gemini/native_sampling_test.go
@@ -1,0 +1,85 @@
+package gemini
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+func TestGeminiGeneration(t *testing.T) {
+	tests := []struct {
+		model     string
+		major     int
+		minor     int
+		wantOK    bool
+		wantDrops bool
+	}{
+		{model: "gemini-3.8-flash", major: 3, minor: 8, wantOK: true, wantDrops: true},
+		{model: "gemini-3.8-flash-cyber", major: 3, minor: 8, wantOK: true, wantDrops: true},
+		{model: "gemini-3.5-flash-lite", major: 3, minor: 5, wantOK: true, wantDrops: true},
+		{model: "gemini-3-pro-preview", major: 3, minor: 0, wantOK: true, wantDrops: true},
+		{model: "google/gemini-3.7-flash", major: 3, minor: 7, wantOK: true, wantDrops: true},
+		{model: "Gemini-4-Flash", major: 4, minor: 0, wantOK: true, wantDrops: true},
+		{model: "gemini-2.5-flash", major: 2, minor: 5, wantOK: true},
+		{model: "gemini-2.5-flash-image", major: 2, minor: 5, wantOK: true},
+		{model: "gemini-embedding-001"},
+		{model: "gemma-3-27b-it"},
+		{model: "imagen-4.0-generate-001"},
+		{model: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			major, minor, ok := geminiGeneration(tt.model)
+			if ok != tt.wantOK || major != tt.major || minor != tt.minor {
+				t.Fatalf("geminiGeneration(%q) = (%d, %d, %v), want (%d, %d, %v)", tt.model, major, minor, ok, tt.major, tt.minor, tt.wantOK)
+			}
+			if got := dropsSamplingParameters(tt.model); got != tt.wantDrops {
+				t.Fatalf("dropsSamplingParameters(%q) = %v, want %v", tt.model, got, tt.wantDrops)
+			}
+		})
+	}
+}
+
+func TestGeminiGenerationConfig_DropsSamplingParametersOnGemini3(t *testing.T) {
+	const body = `{"model":%q,"messages":[{"role":"user","content":"hi"}],` +
+		`"max_tokens":32,"temperature":0.2,"top_p":0.9,"top_k":40,"candidate_count":2,` +
+		`"presence_penalty":0.5,"stop":["END"]}`
+	tests := []struct {
+		name     string
+		model    string
+		wantKept bool
+	}{
+		{name: "3.8 flash drops sampling parameters", model: "gemini-3.8-flash"},
+		{name: "3 pro preview drops sampling parameters", model: "gemini-3-pro-preview"},
+		{name: "vertex publisher prefix drops sampling parameters", model: "google/gemini-3.5-flash"},
+		{name: "2.5 flash keeps sampling parameters", model: "gemini-2.5-flash", wantKept: true},
+		{name: "non-gemini model keeps sampling parameters", model: "gemma-3-27b-it", wantKept: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var req core.ChatRequest
+			if err := json.Unmarshal([]byte(fmt.Sprintf(body, tt.model)), &req); err != nil {
+				t.Fatalf("Unmarshal() error = %v", err)
+			}
+			cfg := geminiGenerationConfig(&req)
+
+			for _, key := range []string{"temperature", "topP", "topK", "candidateCount"} {
+				_, present := cfg[key]
+				if present != tt.wantKept {
+					t.Errorf("generationConfig[%q] present = %v, want %v (cfg = %#v)", key, present, tt.wantKept, cfg)
+				}
+			}
+			if got := cfg["maxOutputTokens"]; got != 32 {
+				t.Errorf("maxOutputTokens = %#v, want 32", got)
+			}
+			if _, ok := cfg["presencePenalty"]; !ok {
+				t.Errorf("presencePenalty missing: %#v", cfg)
+			}
+			if _, ok := cfg["stopSequences"]; !ok {
+				t.Errorf("stopSequences missing: %#v", cfg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Google's Gemini 3 migration guides say to remove `temperature`, `top_p` and `top_k` from every request ("Gemini 3's reasoning capabilities are optimized for the default settings", "Remove these parameters from all requests") and list `candidate_count` as unsupported on Gemini 3.x. In native mode GoModel builds the `generationConfig` itself, so it now leaves those four fields out for Gemini 3 and later and keeps forwarding them for Gemini 2.5, Gemma and other model IDs.

- New `geminiGeneration` parser reads the `<major>.<minor>` generation from `gemini-*` IDs, including Vertex `google/` prefixes, and `dropsSamplingParameters` gates on major >= 3.
- `max_tokens`, `stop`, penalties, `response_format` and thinking settings are unchanged.
- OpenAI-compatible mode is untouched; Google's own compatibility layer receives the body as-is.
- Table-driven tests for the parser and the config builder, plus a docs note.

Caveat for reviewers: Google documents these parameters as "no longer recommended" and unsupported, not as returning HTTP 400 today. This is a proactive alignment with the migration guidance (mirrors #856 for Anthropic), and it changes behavior for callers that set `temperature` on a Gemini 3 model. Independent of #862, which fixes an actual 400 on `reasoning_effort: minimal`.

References: [What's new in Gemini 3.5 Flash](https://ai.google.dev/gemini-api/docs/whats-new-gemini-3.5), [What's new in Gemini 3.8 Flash](https://ai.google.dev/gemini-api/docs/latest-model).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Gemini 3 and later models no longer receive unsupported sampling parameters such as temperature, top-p, top-k, and candidate count.
  * Gemini 2.5, Gemma, and other supported models continue to honor these parameters.
  * Maximum output tokens, stop sequences, penalties, response formats, and thinking settings remain unaffected.

* **Documentation**
  * Added guidance describing sampling-parameter behavior across Gemini model versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->