### PR TITLE
fix(providers): keep Responses content vocabulary on explicit prompt-cache breakpoints

### DIFF
--- a/internal/core/responses_json.go
+++ b/internal/core/responses_json.go
@@ -363,6 +363,29 @@ func (c ResponsesContentItem) MarshalJSON() ([]byte, error) {
 	}{alias(c), c.Annotations})
 }
 
+// ResponsesBlocksFromContentParts converts typed parts into generic content
+// blocks with their type kept verbatim, or returns nil when a part cannot be
+// encoded. ContentPart is the Chat content type: its MarshalJSON rewrites
+// "input_text" to "text", which the Responses API rejects, so code that
+// places typed parts into Responses input must convert them with this helper
+// instead of serializing them directly.
+func ResponsesBlocksFromContentParts(parts []ContentPart) []any {
+	blocks := make([]any, 0, len(parts))
+	for _, part := range parts {
+		encoded, err := json.Marshal(part)
+		if err != nil {
+			return nil
+		}
+		var block map[string]any
+		if err := json.Unmarshal(encoded, &block); err != nil {
+			return nil
+		}
+		block["type"] = part.Type
+		blocks = append(blocks, block)
+	}
+	return blocks
+}
+
 // cloneRawMessage returns a detached, whitespace-trimmed copy of a raw JSON
 // value so stored Raw fields stay independent of the decoder's backing buffer.
 func cloneRawMessage(data []byte) json.RawMessage {

--- a/internal/core/responses_json.go
+++ b/internal/core/responses_json.go
@@ -376,8 +376,11 @@ func ResponsesBlocksFromContentParts(parts []ContentPart) []any {
 		if err != nil {
 			return nil
 		}
+		// UseNumber keeps integer extras above 2^53 exact through re-encoding.
+		decoder := json.NewDecoder(bytes.NewReader(encoded))
+		decoder.UseNumber()
 		var block map[string]any
-		if err := json.Unmarshal(encoded, &block); err != nil {
+		if err := decoder.Decode(&block); err != nil {
 			return nil
 		}
 		block["type"] = part.Type

--- a/internal/core/responses_json_test.go
+++ b/internal/core/responses_json_test.go
@@ -1122,3 +1122,42 @@ func TestResponsesContentItemMarshalJSON_Annotations(t *testing.T) {
 		})
 	}
 }
+
+func TestResponsesBlocksFromContentPartsKeepsVocabularyAndExtras(t *testing.T) {
+	parts := []ContentPart{
+		{
+			Type: "input_text", Text: "hello",
+			ExtraFields: UnknownJSONFieldsFromMap(map[string]json.RawMessage{"x_note": json.RawMessage(`"keep"`)}),
+		},
+		{Type: "input_image", ImageURL: &ImageURLContent{URL: "https://example.com/a.png", Detail: "low"}},
+	}
+	blocks := ResponsesBlocksFromContentParts(parts)
+	if len(blocks) != 2 {
+		t.Fatalf("blocks = %v, want 2", blocks)
+	}
+	text, _ := blocks[0].(map[string]any)
+	if text["type"] != "input_text" || text["text"] != "hello" || text["x_note"] != "keep" {
+		t.Fatalf("text block = %v", text)
+	}
+	image, _ := blocks[1].(map[string]any)
+	imageURL, _ := image["image_url"].(map[string]any)
+	if image["type"] != "input_image" || imageURL["url"] != "https://example.com/a.png" || imageURL["detail"] != "low" {
+		t.Fatalf("image block = %v", image)
+	}
+	encoded, err := json.Marshal(blocks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(encoded, []byte(`"type":"text"`)) {
+		t.Fatalf("blocks serialized with Chat vocabulary: %s", encoded)
+	}
+}
+
+func TestResponsesBlocksFromContentPartsRejectsUnencodablePart(t *testing.T) {
+	if got := ResponsesBlocksFromContentParts([]ContentPart{{Type: "input_file"}}); got != nil {
+		t.Fatalf("expected nil for an unencodable part, got %v", got)
+	}
+	if got := ResponsesBlocksFromContentParts(nil); len(got) != 0 {
+		t.Fatalf("expected no blocks for no parts, got %v", got)
+	}
+}

--- a/internal/core/responses_json_test.go
+++ b/internal/core/responses_json_test.go
@@ -1161,3 +1161,22 @@ func TestResponsesBlocksFromContentPartsRejectsUnencodablePart(t *testing.T) {
 		t.Fatalf("expected no blocks for no parts, got %v", got)
 	}
 }
+
+func TestResponsesBlocksFromContentPartsKeepsLargeIntegersExact(t *testing.T) {
+	parts := []ContentPart{{
+		Type: "input_text", Text: "hello",
+		ExtraFields: UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+			"x_id":    json.RawMessage(`9007199254740993`),
+			"x_ratio": json.RawMessage(`0.1`),
+		}),
+	}}
+	encoded, err := json.Marshal(ResponsesBlocksFromContentParts(parts))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`"x_id":9007199254740993`, `"x_ratio":0.1`} {
+		if !bytes.Contains(encoded, []byte(want)) {
+			t.Fatalf("blocks = %s, want %s", encoded, want)
+		}
+	}
+}

--- a/internal/guardrails/provider_test.go
+++ b/internal/guardrails/provider_test.go
@@ -1,6 +1,7 @@
 package guardrails
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -2351,5 +2352,70 @@ func TestApplyMessagesToResponses_RewritesStructuredArrayInputPreservingInputTex
 	}
 	if firstPart["text"] != "[|---|](PERSON_1)" {
 		t.Fatalf("first content text = %#v, want rewritten value", firstPart["text"])
+	}
+}
+
+func TestApplyGuardedResponsesContent_TypedPartsKeepResponsesVocabulary(t *testing.T) {
+	tests := []struct {
+		name      string
+		original  []core.ContentPart
+		rewritten string
+		wantTypes []string
+		wantText  string
+	}{
+		{
+			name:      "prepends rewritten text to image-only content",
+			original:  []core.ContentPart{{Type: "input_image", ImageURL: &core.ImageURLContent{URL: "https://example.com/a.png"}}},
+			rewritten: "clean",
+			wantTypes: []string{"input_text", "input_image"},
+			wantText:  "clean",
+		},
+		{
+			name: "rewrites the single text part in place",
+			original: []core.ContentPart{{
+				Type: "input_text", Text: "dirty",
+				ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{"x_note": json.RawMessage(`"keep"`)}),
+			}},
+			rewritten: "clean",
+			wantTypes: []string{"input_text"},
+			wantText:  "clean",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := applyGuardedResponsesContentToOriginal(tt.original, tt.rewritten, false)
+			if err != nil {
+				t.Fatalf("applyGuardedResponsesContentToOriginal() error = %v", err)
+			}
+			encoded, err := json.Marshal(got)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if bytes.Contains(encoded, []byte(`"type":"text"`)) {
+				t.Fatalf("rewrite emitted Chat content vocabulary: %s", encoded)
+			}
+			var blocks []map[string]any
+			if err := json.Unmarshal(encoded, &blocks); err != nil {
+				t.Fatalf("rewritten content is not a block array: %s", encoded)
+			}
+			if len(blocks) != len(tt.wantTypes) {
+				t.Fatalf("blocks = %s, want %d blocks", encoded, len(tt.wantTypes))
+			}
+			for i, want := range tt.wantTypes {
+				if blocks[i]["type"] != want {
+					t.Fatalf("block %d type = %v, want %s: %s", i, blocks[i]["type"], want, encoded)
+				}
+			}
+			if blocks[0]["text"] != tt.wantText {
+				t.Fatalf("block 0 text = %v, want %q", blocks[0]["text"], tt.wantText)
+			}
+			if !tt.original[0].ExtraFields.IsEmpty() && blocks[0]["x_note"] != "keep" {
+				t.Fatalf("extra fields lost: %s", encoded)
+			}
+		})
+	}
+
+	if _, err := applyGuardedResponsesContentToOriginal([]core.ContentPart{{Type: "input_file"}}, "clean", false); err == nil {
+		t.Fatal("expected an error for a typed part that cannot be encoded")
 	}
 }

--- a/internal/guardrails/responses_message_apply.go
+++ b/internal/guardrails/responses_message_apply.go
@@ -403,7 +403,13 @@ func isResponsesStructuredContent(content any) bool {
 func rewriteStructuredResponsesContentWithTextRewrite(originalContent any, rewrittenText string) (any, error) {
 	switch typed := originalContent.(type) {
 	case []core.ContentPart:
-		return rewriteStructuredResponsesTypedContentParts(typed, rewrittenText)
+		// Typed parts are converted to generic blocks so the rewrite keeps the
+		// Responses content vocabulary; core.ContentPart serializes as Chat content.
+		blocks := core.ResponsesBlocksFromContentParts(typed)
+		if blocks == nil {
+			return nil, core.NewInvalidRequestError("unsupported structured responses content part", nil)
+		}
+		return rewriteStructuredResponsesInterfaceContentParts(blocks, rewrittenText)
 	case []any:
 		return rewriteStructuredResponsesInterfaceContentParts(typed, rewrittenText)
 	case []map[string]any:
@@ -419,68 +425,6 @@ func rewriteStructuredResponsesContentWithTextRewrite(originalContent any, rewri
 		}
 		return rewriteStructuredResponsesInterfaceContentParts(parts, rewrittenText)
 	}
-}
-
-func rewriteStructuredResponsesTypedContentParts(parts []core.ContentPart, rewrittenText string) (any, error) {
-	textIndexes := make([]int, 0, len(parts))
-	originalTexts := make([]string, 0, len(parts))
-	for i, part := range parts {
-		if !isResponsesTextPartType(part.Type) || part.Text == "" {
-			continue
-		}
-		textIndexes = append(textIndexes, i)
-		originalTexts = append(originalTexts, part.Text)
-	}
-
-	if len(textIndexes) == 0 {
-		if rewrittenText == "" {
-			if len(parts) == 0 {
-				return []core.ContentPart{}, nil
-			}
-			return cloneContentParts(parts), nil
-		}
-		prepended := []core.ContentPart{{Type: "input_text", Text: rewrittenText}}
-		prepended = append(prepended, cloneContentParts(parts)...)
-		return prepended, nil
-	}
-
-	if len(textIndexes) == 1 {
-		merged := cloneContentParts(parts)
-		textIndex := textIndexes[0]
-		if rewrittenText == "" {
-			merged = append(merged[:textIndex], merged[textIndex+1:]...)
-		} else {
-			merged[textIndex].Text = rewrittenText
-		}
-		if len(merged) == 0 {
-			return nil, core.NewInvalidRequestError("guardrails produced empty structured responses content after rewrite", nil)
-		}
-		return merged, nil
-	}
-
-	if rewrittenText == strings.Join(originalTexts, " ") {
-		return cloneContentParts(parts), nil
-	}
-
-	merged := make([]core.ContentPart, 0, len(parts))
-	insertedRewrittenText := false
-	for _, part := range parts {
-		if isResponsesTextPartType(part.Type) {
-			if !insertedRewrittenText && rewrittenText != "" {
-				rewrittenPart := cloneContentPart(part)
-				rewrittenPart.Text = rewrittenText
-				merged = append(merged, rewrittenPart)
-				insertedRewrittenText = true
-			}
-			continue
-		}
-		merged = append(merged, cloneContentPart(part))
-	}
-
-	if len(merged) == 0 {
-		return nil, core.NewInvalidRequestError("guardrails produced empty structured responses content after rewrite", nil)
-	}
-	return merged, nil
 }
 
 func rewriteStructuredResponsesInterfaceContentParts(parts []any, rewrittenText string) (any, error) {

--- a/internal/providers/cache_planner.go
+++ b/internal/providers/cache_planner.go
@@ -335,70 +335,82 @@ func markOpenAIResponsesBreakpoint(req *core.ResponsesRequest) bool {
 		return false
 	}
 	for i := len(items) - 2; i >= 0; i-- {
+		var blocks []any
 		switch content := items[i].Content.(type) {
 		case string:
 			if content == "" {
 				continue
 			}
-			items[i].Content = []core.ContentPart{{
-				Type: "input_text", Text: content,
-				ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
-					"prompt_cache_breakpoint": json.RawMessage(`{"mode":"explicit"}`),
-				}),
-			}}
-			req.Input = items
-			return true
+			blocks = []any{map[string]any{"type": "input_text", "text": content}}
 		case []core.ContentPart:
-			for j := len(content) - 1; j >= 0; j-- {
-				if content[j].Type == "text" || content[j].Type == "input_text" || content[j].Type == "input_image" || content[j].Type == "input_file" {
-					parts := slices.Clone(content)
-					parts[j].ExtraFields = mergeCacheExtras(parts[j].ExtraFields, map[string]json.RawMessage{
-						"prompt_cache_breakpoint": json.RawMessage(`{"mode":"explicit"}`),
-					})
-					items[i].Content = parts
-					req.Input = items
-					return true
-				}
-			}
+			blocks = responsesBlocksFromContentParts(content)
 		case []any:
-			for j, c := range slices.Backward(content) {
-				block, ok := c.(map[string]any)
-				if !ok {
-					continue
-				}
-				blockType, _ := block["type"].(string)
-				if blockType == "text" || blockType == "input_text" || blockType == "input_image" || blockType == "input_file" {
-					if _, exists := block["prompt_cache_breakpoint"]; !exists {
-						marked := maps.Clone(block)
-						marked["prompt_cache_breakpoint"] = map[string]any{"mode": "explicit"}
-						blocks := slices.Clone(content)
-						blocks[j] = marked
-						content = blocks
-					}
-					items[i].Content = content
-					req.Input = items
-					return true
-				}
-			}
+			blocks = content
 		case []map[string]any:
-			for j, c := range slices.Backward(content) {
-				blockType, _ := c["type"].(string)
-				if blockType == "text" || blockType == "input_text" || blockType == "input_image" || blockType == "input_file" {
-					if _, exists := c["prompt_cache_breakpoint"]; !exists {
-						marked := maps.Clone(c)
-						marked["prompt_cache_breakpoint"] = map[string]any{"mode": "explicit"}
-						blocks := slices.Clone(content)
-						blocks[j] = marked
-						content = blocks
-					}
-					items[i].Content = content
-					req.Input = items
-					return true
-				}
+			blocks = make([]any, len(content))
+			for j, block := range content {
+				blocks[j] = block
 			}
+		default:
+			continue
 		}
+		marked, ok := markResponsesBlockBreakpoint(blocks)
+		if !ok {
+			continue
+		}
+		items[i].Content = marked
+		req.Input = items
+		return true
 	}
 	return false
+}
+
+// markResponsesBlockBreakpoint attaches the explicit breakpoint to the last
+// cacheable block and returns the updated slice, or false when no block
+// qualifies. Blocks stay generic maps so the Responses content vocabulary
+// (input_text, input_image, ...) reaches the provider verbatim.
+func markResponsesBlockBreakpoint(blocks []any) ([]any, bool) {
+	for j, c := range slices.Backward(blocks) {
+		block, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		blockType, _ := block["type"].(string)
+		if blockType != "text" && blockType != "input_text" && blockType != "input_image" && blockType != "input_file" {
+			continue
+		}
+		if _, exists := block["prompt_cache_breakpoint"]; exists {
+			return blocks, true
+		}
+		marked := maps.Clone(block)
+		marked["prompt_cache_breakpoint"] = map[string]any{"mode": "explicit"}
+		updated := slices.Clone(blocks)
+		updated[j] = marked
+		return updated, true
+	}
+	return nil, false
+}
+
+// responsesBlocksFromContentParts converts typed parts into generic blocks
+// with their type kept verbatim, or returns nil when a part cannot be
+// encoded so the item is left untouched. core.ContentPart is the Chat content
+// type: its MarshalJSON rewrites "input_text" to "text", which the Responses
+// API rejects, so typed parts must not be serialized directly on this path.
+func responsesBlocksFromContentParts(parts []core.ContentPart) []any {
+	blocks := make([]any, 0, len(parts))
+	for _, part := range parts {
+		encoded, err := json.Marshal(part)
+		if err != nil {
+			return nil
+		}
+		var block map[string]any
+		if err := json.Unmarshal(encoded, &block); err != nil {
+			return nil
+		}
+		block["type"] = part.Type
+		blocks = append(blocks, block)
+	}
+	return blocks
 }
 
 func mergeCacheExtras(base core.UnknownJSONFields, values map[string]json.RawMessage) core.UnknownJSONFields {

--- a/internal/providers/cache_planner.go
+++ b/internal/providers/cache_planner.go
@@ -343,7 +343,7 @@ func markOpenAIResponsesBreakpoint(req *core.ResponsesRequest) bool {
 			}
 			blocks = []any{map[string]any{"type": "input_text", "text": content}}
 		case []core.ContentPart:
-			blocks = responsesBlocksFromContentParts(content)
+			blocks = core.ResponsesBlocksFromContentParts(content)
 		case []any:
 			blocks = content
 		case []map[string]any:
@@ -389,28 +389,6 @@ func markResponsesBlockBreakpoint(blocks []any) ([]any, bool) {
 		return updated, true
 	}
 	return nil, false
-}
-
-// responsesBlocksFromContentParts converts typed parts into generic blocks
-// with their type kept verbatim, or returns nil when a part cannot be
-// encoded so the item is left untouched. core.ContentPart is the Chat content
-// type: its MarshalJSON rewrites "input_text" to "text", which the Responses
-// API rejects, so typed parts must not be serialized directly on this path.
-func responsesBlocksFromContentParts(parts []core.ContentPart) []any {
-	blocks := make([]any, 0, len(parts))
-	for _, part := range parts {
-		encoded, err := json.Marshal(part)
-		if err != nil {
-			return nil
-		}
-		var block map[string]any
-		if err := json.Unmarshal(encoded, &block); err != nil {
-			return nil
-		}
-		block["type"] = part.Type
-		blocks = append(blocks, block)
-	}
-	return blocks
 }
 
 func mergeCacheExtras(base core.UnknownJSONFields, values map[string]json.RawMessage) core.UnknownJSONFields {

--- a/internal/providers/cache_planner_test.go
+++ b/internal/providers/cache_planner_test.go
@@ -147,6 +147,7 @@ func TestCachePlannerResponsesShapesAndCallerOwnership(t *testing.T) {
 		{name: "string", content: prefix},
 		{name: "typed parts", content: []core.ContentPart{{Type: "input_text", Text: prefix}}},
 		{name: "generic parts", content: []any{map[string]any{"type": "input_text", "text": prefix}}},
+		{name: "map parts", content: []map[string]any{{"type": "input_text", "text": prefix}}},
 	}
 	for _, shape := range shapes {
 		t.Run(shape.name, func(t *testing.T) {
@@ -167,6 +168,18 @@ func TestCachePlannerResponsesShapesAndCallerOwnership(t *testing.T) {
 			if err != nil || !bytes.Contains(plannedJSON, []byte(`"prompt_cache_breakpoint"`)) {
 				t.Fatalf("Responses plan lacks explicit breakpoint: %s (err=%v)", plannedJSON, err)
 			}
+			// The Responses API rejects the Chat content vocabulary, so a
+			// breakpoint must never downgrade a part to {"type":"text"}.
+			if bytes.Contains(plannedJSON, []byte(`"type":"text"`)) {
+				t.Fatalf("Responses plan emitted Chat content vocabulary: %s", plannedJSON)
+			}
+			if !bytes.Contains(plannedJSON, []byte(`"type":"input_text"`)) {
+				t.Fatalf("Responses plan lost the input_text vocabulary: %s", plannedJSON)
+			}
+			assertResponsesBreakpointBlock(t, plannedJSON, map[string]any{
+				"type": "input_text", "text": prefix,
+				"prompt_cache_breakpoint": map[string]any{"mode": "explicit"},
+			})
 			after, err := json.Marshal(req)
 			if err != nil {
 				t.Fatal(err)
@@ -452,4 +465,85 @@ func TestGeminiPlanKeyIncludesEntireNativePrefixAndBoundary(t *testing.T) {
 	if len(keys) != 4 {
 		t.Fatalf("system, boundary, or tools were omitted from Gemini keys: %v", keys)
 	}
+}
+
+// assertResponsesBreakpointBlock decodes the planned request and checks the
+// first input item's content is exactly one block equal to want.
+func assertResponsesBreakpointBlock(t *testing.T, plannedJSON []byte, want map[string]any) {
+	t.Helper()
+	blocks := decodePrefixContentBlocks(t, plannedJSON)
+	if len(blocks) != 1 {
+		t.Fatalf("expected one content block on the prefix item: %s", plannedJSON)
+	}
+	got, err := json.Marshal(blocks[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected, err := json.Marshal(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(expected) {
+		t.Fatalf("breakpoint block mismatch:\n got: %s\nwant: %s", got, expected)
+	}
+}
+
+func TestCachePlannerResponsesTypedPartsKeepVocabularyAndExtras(t *testing.T) {
+	planner := &cachePlanner{enabled: true}
+	prefix := strings.Repeat("stable response context ", 1200)
+	req := &core.ResponsesRequest{Model: "gpt-5.6", Input: []core.ResponsesInputElement{
+		{Role: "user", Content: []core.ContentPart{
+			{
+				Type: "input_text", Text: prefix,
+				ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{"x_note": json.RawMessage(`"keep"`)}),
+			},
+			{Type: "input_image", ImageURL: &core.ImageURLContent{URL: "https://example.com/a.png", Detail: "low"}},
+		}},
+		{Role: "user", Content: "dynamic"},
+	}}
+	planned := planner.planResponses(req, "openai", core.ModelSelector{Provider: "openai-primary", Model: "gpt-5.6"})
+	if planned == req {
+		t.Fatal("expected a planned Responses request")
+	}
+	plannedJSON, err := json.Marshal(planned)
+	if err != nil {
+		t.Fatal(err)
+	}
+	blocks := decodePrefixContentBlocks(t, plannedJSON)
+	if len(blocks) != 2 {
+		t.Fatalf("expected two content blocks: %s", plannedJSON)
+	}
+	if blocks[0]["type"] != "input_text" || blocks[0]["x_note"] != "keep" || blocks[0]["prompt_cache_breakpoint"] != nil {
+		t.Fatalf("text block lost vocabulary or extras, or gained a breakpoint: %v", blocks[0])
+	}
+	image := blocks[1]
+	if image["type"] != "input_image" || image["prompt_cache_breakpoint"] == nil {
+		t.Fatalf("last cacheable block should carry the breakpoint with input_image type: %v", image)
+	}
+	imageURL, _ := image["image_url"].(map[string]any)
+	if imageURL["url"] != "https://example.com/a.png" || imageURL["detail"] != "low" {
+		t.Fatalf("image payload not preserved: %v", image)
+	}
+}
+
+// decodePrefixContentBlocks returns the content blocks of the first input item
+// of a marshalled Responses request.
+func decodePrefixContentBlocks(t *testing.T, plannedJSON []byte) []map[string]any {
+	t.Helper()
+	var decoded struct {
+		Input []struct {
+			Content json.RawMessage `json:"content"`
+		} `json:"input"`
+	}
+	if err := json.Unmarshal(plannedJSON, &decoded); err != nil {
+		t.Fatalf("decode planned request: %v", err)
+	}
+	if len(decoded.Input) == 0 {
+		t.Fatalf("planned request has no input items: %s", plannedJSON)
+	}
+	var blocks []map[string]any
+	if err := json.Unmarshal(decoded.Input[0].Content, &blocks); err != nil {
+		t.Fatalf("prefix item content is not a block array: %s", decoded.Input[0].Content)
+	}
+	return blocks
 }

--- a/internal/providers/cache_planner_test.go
+++ b/internal/providers/cache_planner_test.go
@@ -547,3 +547,32 @@ func decodePrefixContentBlocks(t *testing.T, plannedJSON []byte) []map[string]an
 	}
 	return blocks
 }
+
+func TestMarkOpenAIResponsesBreakpointEdgeCases(t *testing.T) {
+	t.Run("keeps an existing breakpoint untouched", func(t *testing.T) {
+		block := map[string]any{"type": "input_text", "text": "prefix", "prompt_cache_breakpoint": map[string]any{"mode": "explicit"}}
+		req := &core.ResponsesRequest{Input: []core.ResponsesInputElement{
+			{Role: "user", Content: []any{block}},
+			{Role: "user", Content: "dynamic"},
+		}}
+		if !markOpenAIResponsesBreakpoint(req) {
+			t.Fatal("expected the existing breakpoint to count as marked")
+		}
+		items := req.Input.([]core.ResponsesInputElement)
+		blocks, _ := items[0].Content.([]any)
+		if len(blocks) != 1 || blocks[0].(map[string]any)["prompt_cache_breakpoint"] == nil {
+			t.Fatalf("breakpoint block changed: %v", items[0].Content)
+		}
+	})
+	t.Run("skips typed parts that cannot be encoded and unsupported shapes", func(t *testing.T) {
+		req := &core.ResponsesRequest{Input: []core.ResponsesInputElement{
+			{Role: "user", Content: 42},
+			{Role: "user", Content: []core.ContentPart{{Type: "input_file"}}},
+			{Role: "user", Content: []any{"not a block"}},
+			{Role: "user", Content: "dynamic"},
+		}}
+		if markOpenAIResponsesBreakpoint(req) {
+			t.Fatalf("marked an item with no cacheable block: %+v", req.Input)
+		}
+	})
+}


### PR DESCRIPTION
## Description

Fixes #861.

When the prompt-cache planner attached an explicit breakpoint to a `/v1/responses` request, it built the marked part as a `core.ContentPart`. That is the Chat content type, and its `MarshalJSON` rewrites `input_text` to `text`. The Responses API rejects that vocabulary, so every planned request for a `gpt-5.6` model with a prefix over the 1024-token OpenAI minimum failed with a 400 before reaching the model.

Changes:

- `core.ResponsesBlocksFromContentParts` converts typed parts into generic blocks with their `type` kept verbatim. It is the one place that knows typed parts must not be serialized directly on the Responses path.
- The planner marks generic map blocks on every content shape. The three per-shape marking loops are folded into one helper, and typed parts go through the new conversion.
- The guardrails rewrite for typed Responses content had the same defect: it prepended a typed `input_text` part that would serialize as `text`. That branch now converts to blocks and delegates to the existing map-based rewrite, which removes the duplicated typed implementation. This path is only reachable with in-process typed content, so it was latent rather than user-visible.

User-visible impact: explicit prompt caching on `/v1/responses` for OpenAI `gpt-5.6` models works again. No other provider or path changes.

Tests: the Responses shape test asserts the emitted part type and exact breakpoint block, and fails on `main` for the string and typed-parts shapes. New tests cover typed parts carrying extra fields and an `input_image` part, the already-marked and unencodable edge cases, the core helper, and the guardrails typed rewrite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenAI Responses API content handling while preserving Responses-specific content types and additional fields.
  * Prompt-cache breakpoints are now applied to the last eligible content block, including typed text, image, and file content.
  * Unsupported or unencodable content is handled safely without producing invalid requests.
  * Existing cache breakpoints remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->