### PR TITLE
fix(responses): end interrupted translated streams with response.incomplete

### DIFF
--- a/internal/auditlog/stream_observer.go
+++ b/internal/auditlog/stream_observer.go
@@ -342,7 +342,7 @@ func parseResponsesAPIEvent(builder *streamResponseBuilder, event map[string]any
 
 	eventType, _ := event["type"].(string)
 	switch eventType {
-	case "response.created", "response.completed", "response.done":
+	case "response.created", "response.completed", "response.done", "response.incomplete":
 		if resp, ok := event["response"].(map[string]any); ok {
 			if id, ok := resp["id"].(string); ok {
 				builder.ResponseID = id

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -3247,6 +3247,71 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta"
 	}
 }
 
+// failingReadCloser returns its data on the first read and the configured
+// error afterwards, mimicking an upstream body that dies mid-transfer.
+type failingReadCloser struct {
+	data []byte
+	err  error
+	read bool
+}
+
+func (r *failingReadCloser) Read(p []byte) (int, error) {
+	if !r.read {
+		r.read = true
+		return copy(p, r.data), nil
+	}
+	return 0, r.err
+}
+
+func (r *failingReadCloser) Close() error { return nil }
+
+// TestStreamResponses_NonEOFReadErrorEndsIncomplete covers an upstream body
+// that fails with a non-EOF error mid-message: the client must still receive
+// the response.incomplete terminal event and [DONE] before the error surfaces.
+func TestStreamResponses_NonEOFReadErrorEndsIncomplete(t *testing.T) {
+	reader := &failingReadCloser{
+		data: []byte(`event: message_start
+data: {"type":"message_start","message":{"id":"msg_123","type":"message","role":"assistant","model":"claude-sonnet-4-5-20250929","content":[],"stop_reason":null,"usage":{"input_tokens":10,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hel"}}
+
+`),
+		err: io.ErrUnexpectedEOF,
+	}
+
+	converter := newResponsesStreamConverter(reader, "claude-sonnet-4-5-20250929")
+	raw, err := io.ReadAll(converter)
+	if err != io.ErrUnexpectedEOF {
+		t.Fatalf("ReadAll() error = %v, want io.ErrUnexpectedEOF surfaced after terminal events", err)
+	}
+
+	var response map[string]any
+	sawDone := false
+	for _, event := range parseTestSSEEvents(t, string(raw)) {
+		if event.Done {
+			sawDone = true
+			continue
+		}
+		if event.Name == "response.incomplete" {
+			response, _ = event.Payload["response"].(map[string]any)
+		}
+	}
+
+	if response == nil {
+		t.Fatal("expected response.incomplete terminal event before the read error")
+	}
+	if !sawDone {
+		t.Fatal("expected trailing [DONE] before the read error")
+	}
+	if response["status"] != "incomplete" {
+		t.Fatalf("response.status = %v, want incomplete", response["status"])
+	}
+}
+
 // TestStreamResponses_StopReasonWithoutMessageStopCompletes covers a stream cut
 // after message_delta carried a stop_reason but before message_stop arrived:
 // Anthropic finished generating, so the stream must still end with

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -3161,8 +3161,8 @@ data: {"type":"message_stop"}
 
 // TestStreamResponses_TruncatedToolCallFinalizedAtEOF covers an upstream stream
 // that dies mid tool call (no content_block_stop / message_stop). The converter
-// must emit the tool call's done events before response.completed so the
-// terminal output only reports items the stream actually closed.
+// must close the tool call with status "incomplete" and end the stream with
+// response.incomplete instead of fabricating completion.
 func TestStreamResponses_TruncatedToolCallFinalizedAtEOF(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -3196,8 +3196,9 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta"
 	}
 
 	foundArgumentsDone := false
-	foundItemDone := false
-	var output []any
+	itemDoneStatus := ""
+	foundCompleted := false
+	var response map[string]any
 	for _, event := range parseTestSSEEvents(t, string(raw)) {
 		if event.Done {
 			continue
@@ -3208,26 +3209,99 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta"
 		case "response.output_item.done":
 			item, _ := event.Payload["item"].(map[string]any)
 			if item["type"] == "function_call" {
-				foundItemDone = true
+				itemDoneStatus, _ = item["status"].(string)
 			}
 		case "response.completed":
-			response, _ := event.Payload["response"].(map[string]any)
-			output, _ = response["output"].([]any)
+			foundCompleted = true
+		case "response.incomplete":
+			response, _ = event.Payload["response"].(map[string]any)
 		}
 	}
 
+	if foundCompleted {
+		t.Fatal("truncated stream must not end with response.completed")
+	}
+	if response == nil {
+		t.Fatal("expected response.incomplete terminal event on truncated stream")
+	}
 	if !foundArgumentsDone {
-		t.Fatal("expected response.function_call_arguments.done before response.completed on truncated stream")
+		t.Fatal("expected response.function_call_arguments.done before the terminal event on truncated stream")
 	}
-	if !foundItemDone {
-		t.Fatal("expected function_call response.output_item.done before response.completed on truncated stream")
+	if itemDoneStatus != "incomplete" {
+		t.Fatalf("function_call output_item.done status = %q, want %q", itemDoneStatus, "incomplete")
 	}
+	if response["status"] != "incomplete" {
+		t.Fatalf("response.status = %v, want incomplete", response["status"])
+	}
+	details, _ := response["incomplete_details"].(map[string]any)
+	if details["reason"] != "interrupted" {
+		t.Fatalf("incomplete_details = %#v, want reason interrupted", response["incomplete_details"])
+	}
+	output, _ := response["output"].([]any)
 	if len(output) != 1 {
-		t.Fatalf("response.completed output has %d items, want 1: %#v", len(output), output)
+		t.Fatalf("response.incomplete output has %d items, want 1: %#v", len(output), output)
 	}
 	toolCall, _ := output[0].(map[string]any)
-	if toolCall["type"] != "function_call" || toolCall["call_id"] != "toolu_123" || toolCall["arguments"] != `{"city":"War` {
-		t.Fatalf("output[0] = %#v, want finalized function_call with accumulated arguments", toolCall)
+	if toolCall["type"] != "function_call" || toolCall["call_id"] != "toolu_123" || toolCall["status"] != "incomplete" || toolCall["arguments"] != `{"city":"War` {
+		t.Fatalf("output[0] = %#v, want incomplete function_call with accumulated arguments", toolCall)
+	}
+}
+
+// TestStreamResponses_StopReasonWithoutMessageStopCompletes covers a stream cut
+// after message_delta carried a stop_reason but before message_stop arrived:
+// Anthropic finished generating, so the stream must still end with
+// response.completed.
+func TestStreamResponses_StopReasonWithoutMessageStopCompletes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`event: message_start
+data: {"type":"message_start","message":{"id":"msg_123","type":"message","role":"assistant","model":"claude-sonnet-4-5-20250929","content":[],"stop_reason":null,"usage":{"input_tokens":10,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}
+`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("test-api-key", nil, llmclient.Hooks{})
+	provider.SetBaseURL(server.URL)
+
+	body, err := provider.StreamResponses(context.Background(), &core.ResponsesRequest{
+		Model: "claude-sonnet-4-5-20250929",
+		Input: "Hello",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = body.Close() }()
+
+	raw, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+
+	var response map[string]any
+	for _, event := range parseTestSSEEvents(t, string(raw)) {
+		if event.Done || event.Name != "response.completed" {
+			continue
+		}
+		response, _ = event.Payload["response"].(map[string]any)
+	}
+
+	if response == nil {
+		t.Fatal("expected response.completed when the stream ends after a stop_reason without message_stop")
+	}
+	if response["status"] != "completed" {
+		t.Fatalf("response.status = %v, want completed", response["status"])
 	}
 }
 

--- a/internal/providers/anthropic/responses.go
+++ b/internal/providers/anthropic/responses.go
@@ -134,7 +134,8 @@ type responsesStreamConverter struct {
 	buffer               streaming.StreamBuffer
 	closed               bool
 	sentDone             bool
-	sawStop              bool // upstream signalled the end of the message
+	sawStop              bool  // upstream signalled the end of the message
+	pendingErr           error // upstream read error deferred until terminal events are drained
 	usage                anthropicUsage
 	hasUsage             bool
 }
@@ -165,67 +166,36 @@ func (sc *responsesStreamConverter) Read(p []byte) (n int, err error) {
 		return sc.buffer.Read(p), nil
 	}
 
+	// Terminal events for a failed upstream read have been drained; surface
+	// the deferred error now.
+	if sc.pendingErr != nil {
+		pendingErr := sc.pendingErr
+		sc.closed = true
+		sc.releaseBuffer()
+		_ = sc.body.Close() //nolint:errcheck
+		if pendingErr == io.EOF {
+			return 0, io.EOF
+		}
+		return 0, pendingErr
+	}
+
 	// Read the next SSE event from Anthropic
 	for {
 		line, err := sc.reader.ReadBytes('\n')
 		if err != nil {
+			// Any upstream read failure — clean EOF, io.ErrUnexpectedEOF from
+			// a chunked body cut mid-transfer, a connection reset — ends the
+			// upstream stream, so emit the terminal events before surfacing a
+			// non-EOF error.
+			sc.appendTerminalEvents()
+			if sc.buffer.Len() > 0 {
+				sc.pendingErr = err
+				return sc.buffer.Read(p), nil
+			}
+			sc.closed = true
+			sc.releaseBuffer()
+			_ = sc.body.Close() //nolint:errcheck
 			if err == io.EOF {
-				// Send final done event and [DONE] message
-				if !sc.sentDone {
-					sc.sentDone = true
-					// A stream that ends without Anthropic signalling the end
-					// of the message (message_stop or a stop_reason) was
-					// interrupted: report it as incomplete instead of
-					// fabricating completion.
-					status := "completed"
-					eventName := "response.completed"
-					if !sc.sawStop {
-						status = "incomplete"
-						eventName = "response.incomplete"
-					}
-					// Finalize items still open at EOF so the terminal output
-					// only reports items whose done events were emitted; on an
-					// interrupted stream they close with status "incomplete".
-					prefix := sc.output.FinishAssistantOutput(sc.assistantOutputIndex, status) + sc.completePendingToolCalls(status)
-					responseData := map[string]any{
-						"id":         sc.responseID,
-						"object":     "response",
-						"status":     status,
-						"model":      sc.model,
-						"provider":   "anthropic",
-						"created_at": sc.createdAt,
-						"output":     sc.output.FinalOutputItems(0, sc.assistantOutputIndex, sc.toolCalls, true),
-					}
-					if status == "incomplete" {
-						responseData["incomplete_details"] = map[string]any{"reason": "interrupted"}
-					}
-					// Include merged usage data captured across message_start/message_delta.
-					if sc.hasUsage {
-						responseData["usage"] = anthropicResponsesUsagePayload(&sc.usage)
-					}
-					doneEvent := map[string]any{
-						"type":     eventName,
-						"response": responseData,
-					}
-					jsonData, marshalErr := json.Marshal(doneEvent)
-					if marshalErr != nil {
-						slog.Error("failed to marshal terminal responses event", "error", marshalErr, "event", eventName, "response_id", sc.responseID)
-						sc.closed = true
-						sc.releaseBuffer()
-						_ = sc.body.Close() //nolint:errcheck
-						return 0, io.EOF
-					}
-					sc.buffer.AppendString(prefix)
-					sc.buffer.AppendString("event: ")
-					sc.buffer.AppendString(eventName)
-					sc.buffer.AppendString("\ndata: ")
-					sc.buffer.AppendBytes(jsonData)
-					sc.buffer.AppendString("\n\ndata: [DONE]\n\n")
-					return sc.buffer.Read(p), nil
-				}
-				sc.closed = true
-				sc.releaseBuffer()
-				_ = sc.body.Close() //nolint:errcheck
 				return 0, io.EOF
 			}
 			return 0, err
@@ -267,6 +237,57 @@ func (sc *responsesStreamConverter) reserveAssistantMessageOutput() {
 	sc.output.ReserveAssistant()
 	sc.assistantOutputIndex = sc.nextOutputIndex
 	sc.nextOutputIndex++
+}
+
+// appendTerminalEvents finalizes items still open when the upstream stream
+// ends and appends the terminal event plus the trailing [DONE] marker exactly
+// once. A stream that ends without Anthropic signalling the end of the message
+// (message_stop or a stop_reason) was interrupted: it ends with
+// response.incomplete instead of fabricating completion, and its open items
+// close with status "incomplete".
+func (sc *responsesStreamConverter) appendTerminalEvents() {
+	if sc.sentDone {
+		return
+	}
+	sc.sentDone = true
+	status := "completed"
+	eventName := "response.completed"
+	if !sc.sawStop {
+		status = "incomplete"
+		eventName = "response.incomplete"
+	}
+	prefix := sc.output.FinishAssistantOutput(sc.assistantOutputIndex, status) + sc.completePendingToolCalls(status)
+	responseData := map[string]any{
+		"id":         sc.responseID,
+		"object":     "response",
+		"status":     status,
+		"model":      sc.model,
+		"provider":   "anthropic",
+		"created_at": sc.createdAt,
+		"output":     sc.output.FinalOutputItems(0, sc.assistantOutputIndex, sc.toolCalls, true),
+	}
+	if status == "incomplete" {
+		responseData["incomplete_details"] = map[string]any{"reason": "interrupted"}
+	}
+	// Include merged usage data captured across message_start/message_delta.
+	if sc.hasUsage {
+		responseData["usage"] = anthropicResponsesUsagePayload(&sc.usage)
+	}
+	doneEvent := map[string]any{
+		"type":     eventName,
+		"response": responseData,
+	}
+	jsonData, marshalErr := json.Marshal(doneEvent)
+	if marshalErr != nil {
+		slog.Error("failed to marshal terminal responses event", "error", marshalErr, "event", eventName, "response_id", sc.responseID)
+		return
+	}
+	sc.buffer.AppendString(prefix)
+	sc.buffer.AppendString("event: ")
+	sc.buffer.AppendString(eventName)
+	sc.buffer.AppendString("\ndata: ")
+	sc.buffer.AppendBytes(jsonData)
+	sc.buffer.AppendString("\n\ndata: [DONE]\n\n")
 }
 
 // completePendingToolCalls emits the done events for tool calls the upstream
@@ -370,7 +391,10 @@ func (sc *responsesStreamConverter) convertEvent(event *anthropicStreamEvent) st
 				return ""
 			}
 			state := sc.toolCalls[event.Index]
-			if state == nil {
+			// A delta for an already-closed call (stray event after its
+			// content_block_stop) must not mutate the arguments its
+			// output_item.done event declared.
+			if state == nil || state.Completed {
 				return ""
 			}
 			if state.PlaceholderObject {

--- a/internal/providers/anthropic/responses.go
+++ b/internal/providers/anthropic/responses.go
@@ -134,6 +134,7 @@ type responsesStreamConverter struct {
 	buffer               streaming.StreamBuffer
 	closed               bool
 	sentDone             bool
+	sawStop              bool // upstream signalled the end of the message
 	usage                anthropicUsage
 	hasUsage             bool
 }
@@ -172,38 +173,52 @@ func (sc *responsesStreamConverter) Read(p []byte) (n int, err error) {
 				// Send final done event and [DONE] message
 				if !sc.sentDone {
 					sc.sentDone = true
-					// Finalize items still open at EOF (e.g. a truncated
-					// stream that never sent content_block_stop) so the
-					// terminal output only reports items whose done events
-					// were emitted.
-					prefix := sc.output.CompleteAssistantOutput(sc.assistantOutputIndex) + sc.completePendingToolCalls()
+					// A stream that ends without Anthropic signalling the end
+					// of the message (message_stop or a stop_reason) was
+					// interrupted: report it as incomplete instead of
+					// fabricating completion.
+					status := "completed"
+					eventName := "response.completed"
+					if !sc.sawStop {
+						status = "incomplete"
+						eventName = "response.incomplete"
+					}
+					// Finalize items still open at EOF so the terminal output
+					// only reports items whose done events were emitted; on an
+					// interrupted stream they close with status "incomplete".
+					prefix := sc.output.FinishAssistantOutput(sc.assistantOutputIndex, status) + sc.completePendingToolCalls(status)
 					responseData := map[string]any{
 						"id":         sc.responseID,
 						"object":     "response",
-						"status":     "completed",
+						"status":     status,
 						"model":      sc.model,
 						"provider":   "anthropic",
 						"created_at": sc.createdAt,
 						"output":     sc.output.FinalOutputItems(0, sc.assistantOutputIndex, sc.toolCalls, true),
+					}
+					if status == "incomplete" {
+						responseData["incomplete_details"] = map[string]any{"reason": "interrupted"}
 					}
 					// Include merged usage data captured across message_start/message_delta.
 					if sc.hasUsage {
 						responseData["usage"] = anthropicResponsesUsagePayload(&sc.usage)
 					}
 					doneEvent := map[string]any{
-						"type":     "response.completed",
+						"type":     eventName,
 						"response": responseData,
 					}
 					jsonData, marshalErr := json.Marshal(doneEvent)
 					if marshalErr != nil {
-						slog.Error("failed to marshal response.completed event", "error", marshalErr, "response_id", sc.responseID)
+						slog.Error("failed to marshal terminal responses event", "error", marshalErr, "event", eventName, "response_id", sc.responseID)
 						sc.closed = true
 						sc.releaseBuffer()
 						_ = sc.body.Close() //nolint:errcheck
 						return 0, io.EOF
 					}
 					sc.buffer.AppendString(prefix)
-					sc.buffer.AppendString("event: response.completed\ndata: ")
+					sc.buffer.AppendString("event: ")
+					sc.buffer.AppendString(eventName)
+					sc.buffer.AppendString("\ndata: ")
 					sc.buffer.AppendBytes(jsonData)
 					sc.buffer.AppendString("\n\ndata: [DONE]\n\n")
 					return sc.buffer.Read(p), nil
@@ -255,8 +270,8 @@ func (sc *responsesStreamConverter) reserveAssistantMessageOutput() {
 }
 
 // completePendingToolCalls emits the done events for tool calls the upstream
-// stream left open, in content-block order.
-func (sc *responsesStreamConverter) completePendingToolCalls() string {
+// stream left open, in content-block order, carrying the given terminal status.
+func (sc *responsesStreamConverter) completePendingToolCalls(status string) string {
 	indices := make([]int, 0, len(sc.toolCalls))
 	for index := range sc.toolCalls {
 		indices = append(indices, index)
@@ -265,7 +280,7 @@ func (sc *responsesStreamConverter) completePendingToolCalls() string {
 
 	var out strings.Builder
 	for _, index := range indices {
-		out.WriteString(sc.output.CompleteToolCall(sc.toolCalls[index], true))
+		out.WriteString(sc.output.FinishToolCall(sc.toolCalls[index], status, true))
 	}
 	return out.String()
 }
@@ -381,6 +396,11 @@ func (sc *responsesStreamConverter) convertEvent(event *anthropicStreamEvent) st
 		if mergeAnthropicUsage(&sc.usage, event.Usage) {
 			sc.hasUsage = true
 		}
+		// A stop_reason means Anthropic finished generating, even if the
+		// stream is cut before message_stop arrives.
+		if event.Delta != nil && event.Delta.StopReason != "" {
+			sc.sawStop = true
+		}
 		if !sc.output.AssistantReserved() && len(sc.toolCalls) == 0 {
 			sc.reserveAssistantMessageOutput()
 		}
@@ -388,6 +408,7 @@ func (sc *responsesStreamConverter) convertEvent(event *anthropicStreamEvent) st
 
 	case "message_stop":
 		// Will be handled in Read() when we get EOF
+		sc.sawStop = true
 		return ""
 	}
 

--- a/internal/providers/responses_converter.go
+++ b/internal/providers/responses_converter.go
@@ -35,6 +35,7 @@ type OpenAIResponsesStreamConverter struct {
 	closed               bool
 	sentCreate           bool
 	sentDone             bool
+	sawFinish            bool            // upstream signalled completion (finish_reason or [DONE])
 	cachedUsage          json.RawMessage // Stores usage from final chunk for inclusion in response.completed
 }
 
@@ -157,6 +158,10 @@ func (sc *OpenAIResponsesStreamConverter) forceStartToolCall(state *ResponsesOut
 }
 
 func (sc *OpenAIResponsesStreamConverter) completePendingToolCalls() string {
+	return sc.finishPendingToolCalls("completed")
+}
+
+func (sc *OpenAIResponsesStreamConverter) finishPendingToolCalls(status string) string {
 	indices := make([]int, 0, len(sc.toolCalls))
 	for index := range sc.toolCalls {
 		indices = append(indices, index)
@@ -173,7 +178,7 @@ func (sc *OpenAIResponsesStreamConverter) completePendingToolCalls() string {
 		if !state.Started {
 			continue
 		}
-		out.WriteString(sc.output.CompleteToolCall(state, false))
+		out.WriteString(sc.output.FinishToolCall(state, status, false))
 	}
 
 	return out.String()
@@ -255,6 +260,12 @@ func (sc *OpenAIResponsesStreamConverter) processChunk(data []byte) {
 	}
 	choice := &chunk.Choices[0]
 
+	// Any finish_reason means the model finished generating; some providers
+	// close the stream without a trailing [DONE] marker (Postel's law).
+	if choice.FinishReason != "" {
+		sc.sawFinish = true
+	}
+
 	if choice.Delta.ReasoningContent != "" {
 		sc.appendReasoningDelta(choice.Delta.ReasoningContent)
 	}
@@ -309,7 +320,11 @@ func (sc *OpenAIResponsesStreamConverter) processChunkTolerant(data []byte) {
 			sc.buffer.AppendString(sc.handleToolCallDeltas(chunkToolCallsFromAny(toolCalls)))
 		}
 	}
-	if finishReason, _ := choice["finish_reason"].(string); finishReason == "tool_calls" {
+	finishReason, _ := choice["finish_reason"].(string)
+	if finishReason != "" {
+		sc.sawFinish = true
+	}
+	if finishReason == "tool_calls" {
 		sc.buffer.AppendString(sc.completePendingToolCalls())
 	}
 }
@@ -382,24 +397,36 @@ func (sc *OpenAIResponsesStreamConverter) appendTextDelta(content string) {
 	sc.buffer.AppendString("\n\n")
 }
 
-// appendCompletedEvents flushes open output items and appends the final
-// response.completed event plus the trailing [DONE] marker exactly once.
-func (sc *OpenAIResponsesStreamConverter) appendCompletedEvents() {
+// appendTerminalEvents flushes open output items and appends the terminal
+// event plus the trailing [DONE] marker exactly once. Streams the upstream
+// finished (a finish_reason or [DONE] was seen) end with response.completed;
+// interrupted streams end with response.incomplete and close their open items
+// with status "incomplete" instead of fabricating completion.
+func (sc *OpenAIResponsesStreamConverter) appendTerminalEvents() {
 	if sc.sentDone {
 		return
 	}
 	sc.sentDone = true
-	sc.buffer.AppendString(sc.output.CompleteReasoningOutput(reasoningOutputIndex))
-	sc.buffer.AppendString(sc.output.CompleteAssistantOutput(sc.assistantOutputIndex))
-	sc.buffer.AppendString(sc.completePendingToolCalls())
+	status := "completed"
+	eventName := "response.completed"
+	if !sc.sawFinish {
+		status = "incomplete"
+		eventName = "response.incomplete"
+	}
+	sc.buffer.AppendString(sc.output.FinishReasoningOutput(reasoningOutputIndex, status))
+	sc.buffer.AppendString(sc.output.FinishAssistantOutput(sc.assistantOutputIndex, status))
+	sc.buffer.AppendString(sc.finishPendingToolCalls(status))
 	responseData := map[string]any{
 		"id":         sc.responseID,
 		"object":     "response",
-		"status":     "completed",
+		"status":     status,
 		"model":      sc.model,
 		"provider":   sc.provider,
 		"created_at": sc.createdAt,
 		"output":     sc.output.FinalOutputItems(reasoningOutputIndex, sc.assistantOutputIndex, sc.toolCalls, false),
+	}
+	if status == "incomplete" {
+		responseData["incomplete_details"] = map[string]any{"reason": "interrupted"}
 	}
 	// Include usage data if captured from OpenAI stream, renamed from Chat
 	// Completions field names (prompt_tokens/completion_tokens) to the
@@ -411,15 +438,17 @@ func (sc *OpenAIResponsesStreamConverter) appendCompletedEvents() {
 		}
 	}
 	doneEvent := map[string]any{
-		"type":     "response.completed",
+		"type":     eventName,
 		"response": responseData,
 	}
 	jsonData, err := json.Marshal(doneEvent)
 	if err != nil {
-		slog.Error("failed to marshal response.completed event", "error", err, "response_id", sc.responseID)
+		slog.Error("failed to marshal terminal responses event", "error", err, "event", eventName, "response_id", sc.responseID)
 		return
 	}
-	sc.buffer.AppendString("event: response.completed\ndata: ")
+	sc.buffer.AppendString("event: ")
+	sc.buffer.AppendString(eventName)
+	sc.buffer.AppendString("\ndata: ")
 	sc.buffer.AppendBytes(jsonData)
 	sc.buffer.AppendString("\n\ndata: [DONE]\n\n")
 }
@@ -564,7 +593,8 @@ func (sc *OpenAIResponsesStreamConverter) Read(p []byte) (n int, err error) {
 
 			if data, ok := bytes.CutPrefix(line, []byte("data: ")); ok {
 				if bytes.Equal(data, []byte("[DONE]")) {
-					sc.appendCompletedEvents()
+					sc.sawFinish = true
+					sc.appendTerminalEvents()
 					continue
 				}
 				sc.processChunk(data)
@@ -575,7 +605,7 @@ func (sc *OpenAIResponsesStreamConverter) Read(p []byte) (n int, err error) {
 	if readErr != nil {
 		if readErr == io.EOF {
 			// Send final done event if we haven't already
-			sc.appendCompletedEvents()
+			sc.appendTerminalEvents()
 
 			if sc.buffer.Len() > 0 {
 				return sc.buffer.Read(p), nil

--- a/internal/providers/responses_converter.go
+++ b/internal/providers/responses_converter.go
@@ -36,6 +36,7 @@ type OpenAIResponsesStreamConverter struct {
 	sentCreate           bool
 	sentDone             bool
 	sawFinish            bool            // upstream signalled completion (finish_reason or [DONE])
+	pendingErr           error           // upstream read error deferred until terminal events are drained
 	cachedUsage          json.RawMessage // Stores usage from final chunk for inclusion in response.completed
 }
 
@@ -198,6 +199,11 @@ func (sc *OpenAIResponsesStreamConverter) handleToolCallDeltas(toolCalls []openA
 		}
 
 		state := sc.ensureToolCallState(*toolCall.Index)
+		// A delta for an already-closed call (stray chunk after its
+		// output_item.done) must not mutate the arguments that event declared.
+		if state.Completed {
+			continue
+		}
 		if toolCall.ID != "" {
 			state.CallID = toolCall.ID
 		}
@@ -545,6 +551,19 @@ func (sc *OpenAIResponsesStreamConverter) Read(p []byte) (n int, err error) {
 		return sc.buffer.Read(p), nil
 	}
 
+	// Terminal events for a failed upstream read have been drained; surface
+	// the deferred error now.
+	if sc.pendingErr != nil {
+		pendingErr := sc.pendingErr
+		sc.closed = true
+		sc.releaseBuffers()
+		_ = sc.reader.Close()
+		if pendingErr == io.EOF {
+			return 0, io.EOF
+		}
+		return 0, pendingErr
+	}
+
 	// Send response.created event first
 	if !sc.sentCreate {
 		sc.sentCreate = true
@@ -603,17 +622,21 @@ func (sc *OpenAIResponsesStreamConverter) Read(p []byte) (n int, err error) {
 	}
 
 	if readErr != nil {
+		// Any upstream read failure — clean EOF, io.ErrUnexpectedEOF from a
+		// chunked body cut mid-transfer, a connection reset — ends the
+		// upstream stream, so emit the terminal events (response.incomplete
+		// unless completion was signalled) before surfacing a non-EOF error.
+		sc.appendTerminalEvents()
+
+		if sc.buffer.Len() > 0 {
+			sc.pendingErr = readErr
+			return sc.buffer.Read(p), nil
+		}
+
+		sc.closed = true
+		sc.releaseBuffers()
+		_ = sc.reader.Close()
 		if readErr == io.EOF {
-			// Send final done event if we haven't already
-			sc.appendTerminalEvents()
-
-			if sc.buffer.Len() > 0 {
-				return sc.buffer.Read(p), nil
-			}
-
-			sc.closed = true
-			sc.releaseBuffers()
-			_ = sc.reader.Close()
 			return 0, io.EOF
 		}
 		return 0, readErr

--- a/internal/providers/responses_converter_test.go
+++ b/internal/providers/responses_converter_test.go
@@ -409,6 +409,119 @@ func TestOpenAIResponsesStreamConverter_CompletedEmptyOutputIsArray(t *testing.T
 	}
 }
 
+// TestOpenAIResponsesStreamConverter_TruncatedStreamEndsIncomplete covers an
+// upstream stream that dies without a finish_reason or [DONE]. The converter
+// must close open items with status "incomplete" and end the stream with
+// response.incomplete instead of fabricating completion.
+func TestOpenAIResponsesStreamConverter_TruncatedStreamEndsIncomplete(t *testing.T) {
+	mockStream := `data: {"choices":[{"delta":{"content":"Hel"},"finish_reason":null}]}
+
+data: {"choices":[{"delta":{"content":"lo"},"finish_reason":null}]}
+`
+
+	converter := NewOpenAIResponsesStreamConverter(io.NopCloser(strings.NewReader(mockStream)), "test-model", "mock")
+	raw, err := io.ReadAll(converter)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+
+	itemDoneStatus := ""
+	foundCompleted := false
+	var response map[string]any
+	sawDone := false
+	for _, event := range parseTestSSEEvents(t, string(raw)) {
+		if event.Done {
+			sawDone = true
+			continue
+		}
+		switch event.Name {
+		case "response.output_item.done":
+			item, _ := event.Payload["item"].(map[string]any)
+			if item["type"] == "message" {
+				itemDoneStatus, _ = item["status"].(string)
+			}
+		case "response.completed":
+			foundCompleted = true
+		case "response.incomplete":
+			response, _ = event.Payload["response"].(map[string]any)
+		}
+	}
+
+	if foundCompleted {
+		t.Fatal("truncated stream must not end with response.completed")
+	}
+	if response == nil {
+		t.Fatal("expected response.incomplete terminal event on truncated stream")
+	}
+	if !sawDone {
+		t.Fatal("expected trailing [DONE] after response.incomplete")
+	}
+	if itemDoneStatus != "incomplete" {
+		t.Fatalf("message output_item.done status = %q, want %q", itemDoneStatus, "incomplete")
+	}
+	if response["status"] != "incomplete" {
+		t.Fatalf("response.status = %v, want incomplete", response["status"])
+	}
+	details, _ := response["incomplete_details"].(map[string]any)
+	if details["reason"] != "interrupted" {
+		t.Fatalf("incomplete_details = %#v, want reason interrupted", response["incomplete_details"])
+	}
+	output, _ := response["output"].([]any)
+	if len(output) != 1 {
+		t.Fatalf("response.incomplete output has %d items, want 1: %#v", len(output), output)
+	}
+	message, _ := output[0].(map[string]any)
+	if message["type"] != "message" || message["status"] != "incomplete" {
+		t.Fatalf("output[0] = %#v, want incomplete assistant message", message)
+	}
+	messageContent, _ := message["content"].([]any)
+	if len(messageContent) != 1 {
+		t.Fatalf("message content = %#v, want one output_text part", message["content"])
+	}
+	if part, _ := messageContent[0].(map[string]any); part["text"] != "Hello" {
+		t.Fatalf("partial text = %#v, want %q", part["text"], "Hello")
+	}
+}
+
+// TestOpenAIResponsesStreamConverter_FinishReasonWithoutDoneCompletes covers
+// providers that close the stream after the finish_reason chunk without a
+// trailing [DONE] marker: the model finished, so the stream must still end
+// with response.completed.
+func TestOpenAIResponsesStreamConverter_FinishReasonWithoutDoneCompletes(t *testing.T) {
+	mockStream := `data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}
+
+data: {"choices":[{"delta":{},"finish_reason":"stop"}]}
+`
+
+	converter := NewOpenAIResponsesStreamConverter(io.NopCloser(strings.NewReader(mockStream)), "test-model", "mock")
+	raw, err := io.ReadAll(converter)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+
+	var response map[string]any
+	for _, event := range parseTestSSEEvents(t, string(raw)) {
+		if event.Done || event.Name != "response.completed" {
+			continue
+		}
+		response, _ = event.Payload["response"].(map[string]any)
+	}
+
+	if response == nil {
+		t.Fatal("expected response.completed when the stream ends after finish_reason without [DONE]")
+	}
+	if response["status"] != "completed" {
+		t.Fatalf("response.status = %v, want completed", response["status"])
+	}
+	output, _ := response["output"].([]any)
+	if len(output) != 1 {
+		t.Fatalf("response.completed output has %d items, want 1: %#v", len(output), output)
+	}
+	if message, _ := output[0].(map[string]any); message["status"] != "completed" {
+		t.Fatalf("output[0] = %#v, want completed assistant message", message)
+	}
+}
+
 func TestOpenAIResponsesStreamConverter_OutOfOrderToolCallsKeepUniqueIndexes(t *testing.T) {
 	mockStream := `data: {"choices":[{"delta":{"reasoning_content":"Plan."},"finish_reason":null}]}
 

--- a/internal/providers/responses_converter_test.go
+++ b/internal/providers/responses_converter_test.go
@@ -431,6 +431,9 @@ data: {"choices":[{"delta":{"content":"lo"},"finish_reason":null}]}
 	sawDone := false
 	for _, event := range parseTestSSEEvents(t, string(raw)) {
 		if event.Done {
+			if response == nil {
+				t.Fatal("[DONE] arrived before the response.incomplete terminal event")
+			}
 			sawDone = true
 			continue
 		}
@@ -480,6 +483,113 @@ data: {"choices":[{"delta":{"content":"lo"},"finish_reason":null}]}
 	}
 	if part, _ := messageContent[0].(map[string]any); part["text"] != "Hello" {
 		t.Fatalf("partial text = %#v, want %q", part["text"], "Hello")
+	}
+}
+
+// failingReadCloser returns its data on the first read and the configured
+// error afterwards, mimicking an upstream body that dies mid-transfer.
+type failingReadCloser struct {
+	data []byte
+	err  error
+	read bool
+}
+
+func (r *failingReadCloser) Read(p []byte) (int, error) {
+	if !r.read {
+		r.read = true
+		return copy(p, r.data), nil
+	}
+	return 0, r.err
+}
+
+func (r *failingReadCloser) Close() error { return nil }
+
+// TestOpenAIResponsesStreamConverter_NonEOFReadErrorEndsIncomplete covers an
+// upstream body that fails with a non-EOF error (io.ErrUnexpectedEOF from a
+// chunked body cut mid-transfer, a connection reset). The client must still
+// receive the response.incomplete terminal event and [DONE] before the error
+// surfaces.
+func TestOpenAIResponsesStreamConverter_NonEOFReadErrorEndsIncomplete(t *testing.T) {
+	reader := &failingReadCloser{
+		data: []byte("data: {\"choices\":[{\"delta\":{\"content\":\"Hel\"},\"finish_reason\":null}]}\n\n"),
+		err:  io.ErrUnexpectedEOF,
+	}
+
+	converter := NewOpenAIResponsesStreamConverter(reader, "test-model", "mock")
+	raw, err := io.ReadAll(converter)
+	if err != io.ErrUnexpectedEOF {
+		t.Fatalf("ReadAll() error = %v, want io.ErrUnexpectedEOF surfaced after terminal events", err)
+	}
+
+	var response map[string]any
+	sawDone := false
+	for _, event := range parseTestSSEEvents(t, string(raw)) {
+		if event.Done {
+			sawDone = true
+			continue
+		}
+		if event.Name == "response.incomplete" {
+			response, _ = event.Payload["response"].(map[string]any)
+		}
+	}
+
+	if response == nil {
+		t.Fatal("expected response.incomplete terminal event before the read error")
+	}
+	if !sawDone {
+		t.Fatal("expected trailing [DONE] before the read error")
+	}
+	if response["status"] != "incomplete" {
+		t.Fatalf("response.status = %v, want incomplete", response["status"])
+	}
+}
+
+// TestOpenAIResponsesStreamConverter_IgnoresDeltaAfterToolCallClosed covers a
+// stray argument delta arriving after finish_reason "tool_calls" closed the
+// call: it must not mutate the arguments the output_item.done event declared,
+// so the terminal output array stays identical to the emitted done events.
+func TestOpenAIResponsesStreamConverter_IgnoresDeltaAfterToolCallClosed(t *testing.T) {
+	mockStream := `data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"lookup","arguments":"{\"city\":\"Warsaw\"}"}}]},"finish_reason":null}]}
+
+data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}
+
+data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"garbage"}}]},"finish_reason":null}]}
+
+data: [DONE]
+`
+
+	converter := NewOpenAIResponsesStreamConverter(io.NopCloser(strings.NewReader(mockStream)), "test-model", "mock")
+	raw, err := io.ReadAll(converter)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+
+	doneArguments := ""
+	var output []any
+	for _, event := range parseTestSSEEvents(t, string(raw)) {
+		if event.Done {
+			continue
+		}
+		switch event.Name {
+		case "response.output_item.done":
+			item, _ := event.Payload["item"].(map[string]any)
+			if item["type"] == "function_call" {
+				doneArguments, _ = item["arguments"].(string)
+			}
+		case "response.completed":
+			response, _ := event.Payload["response"].(map[string]any)
+			output, _ = response["output"].([]any)
+		}
+	}
+
+	if doneArguments != `{"city":"Warsaw"}` {
+		t.Fatalf("output_item.done arguments = %q, want %q", doneArguments, `{"city":"Warsaw"}`)
+	}
+	if len(output) != 1 {
+		t.Fatalf("response.completed output has %d items, want 1: %#v", len(output), output)
+	}
+	if toolCall, _ := output[0].(map[string]any); toolCall["arguments"] != `{"city":"Warsaw"}` {
+		t.Fatalf("terminal output arguments = %v, want the arguments the done event declared", toolCall["arguments"])
 	}
 }
 

--- a/internal/providers/responses_done_wrapper.go
+++ b/internal/providers/responses_done_wrapper.go
@@ -14,6 +14,7 @@ var responsesDataPrefix = []byte("data: ")
 var responsesCompletionPatterns = [][]byte{
 	[]byte(`"type":"response.completed"`),
 	[]byte(`"type":"response.done"`),
+	[]byte(`"type":"response.incomplete"`),
 }
 
 // EnsureResponsesDone normalizes Responses API streams so clients always receive

--- a/internal/providers/responses_done_wrapper_test.go
+++ b/internal/providers/responses_done_wrapper_test.go
@@ -42,6 +42,23 @@ func TestEnsureResponsesDone_AppendsDoneMarker(t *testing.T) {
 	}
 }
 
+func TestEnsureResponsesDone_AppendsDoneMarkerAfterIncomplete(t *testing.T) {
+	stream := io.NopCloser(strings.NewReader("event: response.incomplete\ndata: {\"type\":\"response.incomplete\"}\n\n"))
+
+	data, err := io.ReadAll(EnsureResponsesDone(stream))
+	if err != nil {
+		t.Fatalf("read stream: %v", err)
+	}
+
+	got := string(data)
+	if !strings.HasSuffix(got, "data: [DONE]\n\n") {
+		t.Fatalf("expected stream to end with done marker, got %q", got)
+	}
+	if strings.Count(got, "[DONE]") != 1 {
+		t.Fatalf("expected exactly one done marker, got %q", got)
+	}
+}
+
 func TestEnsureResponsesDone_InsertsEventSeparatorBeforeDoneMarker(t *testing.T) {
 	stream := io.NopCloser(strings.NewReader("event: response.completed\ndata: {\"type\":\"response.completed\"}\n"))
 

--- a/internal/providers/responses_output_state.go
+++ b/internal/providers/responses_output_state.go
@@ -19,23 +19,35 @@ type ResponsesOutputToolCallState struct {
 	Arguments         strings.Builder
 	Started           bool
 	Completed         bool
+	FinalStatus       string // status carried by the item's output_item.done event
 	PlaceholderObject bool
 }
 
 // ResponsesOutputEventState manages assistant/tool output items for Responses streams.
 type ResponsesOutputEventState struct {
-	responseID         string
-	assistantReserved  bool
-	assistantStarted   bool
-	assistantDone      bool
-	assistantMessageID string
-	assistantText      strings.Builder
+	responseID           string
+	assistantReserved    bool
+	assistantStarted     bool
+	assistantDone        bool
+	assistantMessageID   string
+	assistantText        strings.Builder
+	assistantFinalStatus string
 
-	reasoningReserved bool
-	reasoningStarted  bool
-	reasoningDone     bool
-	reasoningItemID   string
-	reasoningText     strings.Builder
+	reasoningReserved    bool
+	reasoningStarted     bool
+	reasoningDone        bool
+	reasoningItemID      string
+	reasoningText        strings.Builder
+	reasoningFinalStatus string
+}
+
+// finalStatusOrCompleted defaults an unset item status to "completed" so items
+// finished before status tracking existed keep their historical shape.
+func finalStatusOrCompleted(status string) string {
+	if status == "" {
+		return "completed"
+	}
+	return status
 }
 
 // NewResponsesOutputEventState creates a new Responses output-item state manager.
@@ -124,13 +136,21 @@ func (s *ResponsesOutputEventState) StartAssistantOutput(outputIndex int) string
 
 // CompleteAssistantOutput emits the assistant message output_item.done event once.
 func (s *ResponsesOutputEventState) CompleteAssistantOutput(outputIndex int) string {
+	return s.FinishAssistantOutput(outputIndex, "completed")
+}
+
+// FinishAssistantOutput emits the assistant message output_item.done event once,
+// carrying the given terminal status ("completed", or "incomplete" when the
+// upstream stream was interrupted before closing the message).
+func (s *ResponsesOutputEventState) FinishAssistantOutput(outputIndex int, status string) string {
 	if !s.assistantReserved || s.assistantDone {
 		return ""
 	}
 	s.assistantDone = true
+	s.assistantFinalStatus = status
 	return s.StartAssistantOutput(outputIndex) + s.WriteEvent("response.output_item.done", map[string]any{
 		"type":         "response.output_item.done",
-		"item":         s.AssistantMessageItem("completed", true),
+		"item":         s.AssistantMessageItem(status, true),
 		"output_index": outputIndex,
 	})
 }
@@ -205,10 +225,17 @@ func (s *ResponsesOutputEventState) AppendReasoningDelta(outputIndex int, delta 
 // CompleteReasoningOutput emits the raw reasoning completion and
 // output_item.done events once.
 func (s *ResponsesOutputEventState) CompleteReasoningOutput(outputIndex int) string {
+	return s.FinishReasoningOutput(outputIndex, "completed")
+}
+
+// FinishReasoningOutput emits the raw reasoning completion and output_item.done
+// events once, carrying the given terminal status.
+func (s *ResponsesOutputEventState) FinishReasoningOutput(outputIndex int, status string) string {
 	if !s.reasoningReserved || s.reasoningDone {
 		return ""
 	}
 	s.reasoningDone = true
+	s.reasoningFinalStatus = status
 	var b strings.Builder
 	b.WriteString(s.StartReasoningOutput(outputIndex))
 	b.WriteString(s.WriteEvent("response.reasoning_text.done", map[string]any{
@@ -220,18 +247,19 @@ func (s *ResponsesOutputEventState) CompleteReasoningOutput(outputIndex int) str
 	}))
 	b.WriteString(s.WriteEvent("response.output_item.done", map[string]any{
 		"type":         "response.output_item.done",
-		"item":         s.ReasoningItem("completed", true),
+		"item":         s.ReasoningItem(status, true),
 		"output_index": outputIndex,
 	}))
 	return b.String()
 }
 
 // FinalOutputItems assembles the full output array for the terminal
-// response.completed event, mirroring the output_item.done payloads already
-// emitted on the stream, ordered by output index. OpenAI includes the complete
-// output in response.completed, and strict SDK clients index into it. Only
-// tool calls whose output_item.done has been emitted are included — callers
-// must finalize pending tool calls first.
+// response.completed (or response.incomplete) event, mirroring the
+// output_item.done payloads already emitted on the stream, ordered by output
+// index. OpenAI includes the complete output in the terminal event, and strict
+// SDK clients index into it. Each item carries the status its output_item.done
+// event declared, and only tool calls whose output_item.done has been emitted
+// are included — callers must finalize pending tool calls first.
 func (s *ResponsesOutputEventState) FinalOutputItems(reasoningIndex, assistantIndex int, toolCalls map[int]*ResponsesOutputToolCallState, includePlaceholder bool) []map[string]any {
 	type indexedItem struct {
 		index int
@@ -239,16 +267,16 @@ func (s *ResponsesOutputEventState) FinalOutputItems(reasoningIndex, assistantIn
 	}
 	items := make([]indexedItem, 0, 2+len(toolCalls))
 	if s.reasoningStarted {
-		items = append(items, indexedItem{reasoningIndex, s.ReasoningItem("completed", true)})
+		items = append(items, indexedItem{reasoningIndex, s.ReasoningItem(finalStatusOrCompleted(s.reasoningFinalStatus), true)})
 	}
 	if s.assistantStarted {
-		items = append(items, indexedItem{assistantIndex, s.AssistantMessageItem("completed", true)})
+		items = append(items, indexedItem{assistantIndex, s.AssistantMessageItem(finalStatusOrCompleted(s.assistantFinalStatus), true)})
 	}
 	for _, state := range toolCalls {
 		if state == nil || !state.Started || !state.Completed {
 			continue
 		}
-		items = append(items, indexedItem{state.OutputIndex, s.RenderToolCallItem(state, "completed", includePlaceholder)})
+		items = append(items, indexedItem{state.OutputIndex, s.RenderToolCallItem(state, finalStatusOrCompleted(state.FinalStatus), includePlaceholder)})
 	}
 	slices.SortStableFunc(items, func(a, b indexedItem) int { return a.index - b.index })
 	output := make([]map[string]any, 0, len(items))
@@ -305,10 +333,17 @@ func (s *ResponsesOutputEventState) StartToolCall(state *ResponsesOutputToolCall
 
 // CompleteToolCall emits the argument completion and output_item.done events once.
 func (s *ResponsesOutputEventState) CompleteToolCall(state *ResponsesOutputToolCallState, includePlaceholder bool) string {
+	return s.FinishToolCall(state, "completed", includePlaceholder)
+}
+
+// FinishToolCall emits the argument completion and output_item.done events
+// once, carrying the given terminal status.
+func (s *ResponsesOutputEventState) FinishToolCall(state *ResponsesOutputToolCallState, status string, includePlaceholder bool) string {
 	if state == nil || state.Completed {
 		return ""
 	}
 	state.Completed = true
+	state.FinalStatus = status
 	return s.WriteEvent("response.function_call_arguments.done", map[string]any{
 		"type":         "response.function_call_arguments.done",
 		"item_id":      state.ItemID,
@@ -316,7 +351,7 @@ func (s *ResponsesOutputEventState) CompleteToolCall(state *ResponsesOutputToolC
 		"arguments":    s.ToolCallArguments(state),
 	}) + s.WriteEvent("response.output_item.done", map[string]any{
 		"type":         "response.output_item.done",
-		"item":         s.RenderToolCallItem(state, "completed", includePlaceholder),
+		"item":         s.RenderToolCallItem(state, status, includePlaceholder),
 		"output_index": state.OutputIndex,
 	})
 }

--- a/internal/responsecache/sse_validation.go
+++ b/internal/responsecache/sse_validation.go
@@ -6,9 +6,18 @@ import (
 	"github.com/goccy/go-json"
 )
 
+// nonCacheableEventPatterns marks streams that must never be replayed from
+// cache: a response that ended incomplete (interrupted upstream) or failed is
+// not a reusable answer even though it is fully framed and ends with [DONE].
+var nonCacheableEventPatterns = [][]byte{
+	[]byte(`"type":"response.incomplete"`),
+	[]byte(`"type":"response.failed"`),
+}
+
 // validateCacheableSSE reports whether raw is a complete, cache-safe SSE body.
 // Cacheable streams must be fully framed, contain at least one JSON data payload,
-// and terminate with a final [DONE] event.
+// terminate with a final [DONE] event, and not carry an incomplete or failed
+// terminal Responses event.
 func validateCacheableSSE(raw []byte) bool {
 	if len(raw) == 0 {
 		return false
@@ -43,6 +52,11 @@ func validateCacheableSSE(raw []byte) bool {
 		}
 		if !json.Valid(payload) {
 			return false
+		}
+		for _, pattern := range nonCacheableEventPatterns {
+			if bytes.Contains(payload, pattern) {
+				return false
+			}
 		}
 		sawJSONPayload = true
 	}

--- a/internal/responsecache/sse_validation.go
+++ b/internal/responsecache/sse_validation.go
@@ -6,12 +6,22 @@ import (
 	"github.com/goccy/go-json"
 )
 
-// nonCacheableEventPatterns marks streams that must never be replayed from
-// cache: a response that ended incomplete (interrupted upstream) or failed is
-// not a reusable answer even though it is fully framed and ends with [DONE].
-var nonCacheableEventPatterns = [][]byte{
-	[]byte(`"type":"response.incomplete"`),
-	[]byte(`"type":"response.failed"`),
+// isNonCacheableTerminalEvent reports whether a payload is a terminal
+// Responses event that must never be replayed from cache: a response that
+// ended incomplete (interrupted upstream) or failed is not a reusable answer
+// even though it is fully framed and ends with [DONE]. The type field is
+// decoded rather than substring-matched so whitespace or key order in the
+// payload cannot smuggle such an event past validation.
+func isNonCacheableTerminalEvent(payload []byte) bool {
+	var event struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(payload, &event); err != nil {
+		// json.Valid already accepted the payload; a non-object payload
+		// simply has no event type.
+		return false
+	}
+	return event.Type == "response.incomplete" || event.Type == "response.failed"
 }
 
 // validateCacheableSSE reports whether raw is a complete, cache-safe SSE body.
@@ -53,10 +63,8 @@ func validateCacheableSSE(raw []byte) bool {
 		if !json.Valid(payload) {
 			return false
 		}
-		for _, pattern := range nonCacheableEventPatterns {
-			if bytes.Contains(payload, pattern) {
-				return false
-			}
+		if isNonCacheableTerminalEvent(payload) {
+			return false
 		}
 		sawJSONPayload = true
 	}

--- a/internal/responsecache/sse_validation_test.go
+++ b/internal/responsecache/sse_validation_test.go
@@ -75,6 +75,14 @@ func TestValidateCacheableSSE(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "rejects incomplete event with whitespace formatting",
+			raw: []byte(
+				"event: response.incomplete\ndata: { \"response\" : {\"id\":\"resp_1\"}, \"type\" : \"response.incomplete\" }\n\n" +
+					"data: [DONE]\n\n",
+			),
+			want: false,
+		},
+		{
 			name: "rejects payload after done",
 			raw: []byte(
 				"data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\"}}\n\n" +

--- a/internal/responsecache/sse_validation_test.go
+++ b/internal/responsecache/sse_validation_test.go
@@ -58,6 +58,23 @@ func TestValidateCacheableSSE(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "rejects incomplete responses stream",
+			raw: []byte(
+				"event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n" +
+					"event: response.incomplete\ndata: {\"type\":\"response.incomplete\",\"response\":{\"id\":\"resp_1\",\"status\":\"incomplete\"}}\n\n" +
+					"data: [DONE]\n\n",
+			),
+			want: false,
+		},
+		{
+			name: "rejects failed responses stream",
+			raw: []byte(
+				"event: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp_1\",\"status\":\"failed\"}}\n\n" +
+					"data: [DONE]\n\n",
+			),
+			want: false,
+		},
+		{
 			name: "rejects payload after done",
 			raw: []byte(
 				"data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\"}}\n\n" +

--- a/internal/usage/stream_observer.go
+++ b/internal/usage/stream_observer.go
@@ -177,7 +177,7 @@ func (o *StreamUsageObserver) extractUsageFromEvent(chunk map[string]any) *Usage
 	usageRaw, ok := chunk["usage"]
 	if !ok {
 		switch eventType, _ := chunk["type"].(string); eventType {
-		case "response.completed", "response.done":
+		case "response.completed", "response.done", "response.incomplete":
 			if response, respOK := chunk["response"].(map[string]any); respOK {
 				usageRaw, ok = response["usage"]
 				if id, idOK := response["id"].(string); idOK && id != "" {

--- a/internal/usage/stream_observer_test.go
+++ b/internal/usage/stream_observer_test.go
@@ -469,6 +469,48 @@ data: [DONE]
 	}
 }
 
+// TestStreamUsageObserverResponsesAPIIncomplete verifies usage is still logged
+// when an interrupted stream ends with response.incomplete — the tokens were
+// consumed even though the response did not finish.
+func TestStreamUsageObserverResponsesAPIIncomplete(t *testing.T) {
+	streamData := `event: response.created
+data: {"type":"response.created","response":{"id":"resp-123","object":"response","status":"in_progress","model":"gpt-5"}}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","delta":"Hel"}
+
+event: response.incomplete
+data: {"type":"response.incomplete","response":{"id":"resp-123","object":"response","status":"incomplete","model":"gpt-5","incomplete_details":{"reason":"interrupted"},"output":[],"usage":{"input_tokens":15,"output_tokens":2,"total_tokens":17}}}
+
+data: [DONE]
+
+`
+	logger := &trackingLogger{enabled: true}
+	stream := streaming.NewObservedSSEStream(
+		io.NopCloser(strings.NewReader(streamData)),
+		NewStreamUsageObserver(logger, "gpt-5", "openai", "req-resp-2", "/v1/responses", nil),
+	)
+
+	if _, err := io.ReadAll(stream); err != nil {
+		t.Fatalf("ReadAll error: %v", err)
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatalf("Close error: %v", err)
+	}
+
+	entries := logger.getEntries()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	entry := entries[0]
+	if entry.InputTokens != 15 || entry.OutputTokens != 2 || entry.TotalTokens != 17 {
+		t.Errorf("usage = %d/%d/%d, want 15/2/17", entry.InputTokens, entry.OutputTokens, entry.TotalTokens)
+	}
+	if entry.ProviderID != "resp-123" {
+		t.Errorf("ProviderID = %s, want resp-123", entry.ProviderID)
+	}
+}
+
 func TestStreamUsageObserverResponsesAPIWithDetailedUsage(t *testing.T) {
 	logger := &trackingLogger{enabled: true}
 	observer := NewStreamUsageObserver(logger, "gpt-5", "openai", "req-resp-detailed", "/v1/responses", nil)

--- a/tests/perf/hotpath_test.go
+++ b/tests/perf/hotpath_test.go
@@ -476,12 +476,14 @@ func TestHotPathPerfGuard(t *testing.T) {
 		{
 			// Typed chunk decoding + reused read buffer keep this converter at a
 			// fraction of its former map[string]any-per-chunk cost (was 202/19.6KB).
-			// response.completed now carries the full output array, a once-per-
-			// stream cost independent of chunk count.
+			// response.completed now carries the full output array, and the
+			// terminal status became a variable (completed vs incomplete),
+			// boxing a few extra interface values — both once-per-stream costs
+			// independent of chunk count.
 			name:      "openai_responses_stream_converter",
 			bench:     BenchmarkOpenAIResponsesStreamConverter,
-			maxAllocs: 103,   // baseline 101
-			maxBytes:  12288, // baseline ~11.2 KB (leaves headroom for pool cold-starts)
+			maxAllocs: 107,   // baseline 105
+			maxBytes:  12288, // baseline ~11.3 KB (leaves headroom for pool cold-starts)
 		},
 		{
 			name:      "shared_stream_audit_and_usage_observers",


### PR DESCRIPTION
Follow-up to #831 (review discussion): a translated stream whose upstream dies mid-message previously ended with a fabricated `response.completed` wrapping truncated content — an interrupted tool call surfaced as a completed invocation with partial JSON arguments.

Interrupted streams now use the protocol's own vocabulary: items left open at EOF close with `status: "incomplete"` (in their `output_item.done` events and the terminal `output` array alike, rendered from the same recorded state so they cannot disagree), and the stream terminates with `response.incomplete` carrying `incomplete_details: {"reason": "interrupted"}` plus the trailing `[DONE]`. Partial output is preserved, and the malformed-arguments risk is gone because nothing incomplete claims to be completed.

Completion detection is deliberately generous (Postel):
- Anthropic native: `message_stop` **or** a `stop_reason` in `message_delta` — a stream cut between the two still completes.
- Chat-translated providers (Gemini, Groq, DeepSeek, …): any `finish_reason` **or** `[DONE]` — providers that omit the `[DONE]` marker are not misclassified as interrupted.

Healthy streams are byte-for-byte unchanged (contract goldens untouched). Terminal-event consumers are wired up in the same change:
- Response cache: streams ending in `response.incomplete` or `response.failed` are no longer cacheable (previously a truncated stream ending in `[DONE]` could be replayed to other users).
- Usage observer: extracts usage from `response.incomplete` — the tokens were consumed.
- Audit log: records the incomplete terminal status.
- `EnsureResponsesDone`: appends `[DONE]` after a native `response.incomplete`, matching completed.
- Conversation persistence: intentionally unchanged — interrupted turns stay out of history.

Perf: the terminal status becoming a variable boxes four extra interface values once per stream (not per chunk); the hot-path guard baseline is updated (101→105 allocs/op) with the cause documented.

Out of scope, noted for a possible follow-up: mapping healthy finish states (`max_tokens`/`length`) to `response.incomplete` with `reason: "max_output_tokens"`, which changes behavior for common non-interrupted streams.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Interrupted streaming responses are now reported as incomplete instead of incorrectly marked completed.
  - Partial assistant messages, reasoning, and tool calls retain an incomplete status when streams end unexpectedly.
  - Streams that receive a finish signal are correctly marked completed, even without a trailing completion marker.
  - Usage data is now captured from incomplete responses.
  - Incomplete and failed responses are excluded from response caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->