### PR TITLE
fix(playground): send the configured USER_PATH_HEADER

### DIFF
--- a/cmd/gomodel/docs/docs.go
+++ b/cmd/gomodel/docs/docs.go
@@ -7190,6 +7190,10 @@ const docTemplate = `{
                 "USAGE_PRICING_RECALCULATION_ENABLED": {
                     "type": "string"
                 },
+                "USER_PATH_HEADER": {
+                    "description": "UserPathHeader is the canonical name of the inbound header the gateway\nreads user paths from (server.user_path_header), so the Playground sends\nthe header this deployment actually honors.",
+                    "type": "string"
+                },
                 "VIRTUAL_MODEL_STRATEGIES": {
                     "description": "VirtualModelStrategies is the comma-separated list of load-balancing\nstrategies this deployment supports. \"adaptive\" appears only when a\nroute-selector extension is registered, so the dashboard never offers\na strategy that would silently fall back to round robin.",
                     "type": "string"

--- a/docs/features/playground.mdx
+++ b/docs/features/playground.mdx
@@ -23,15 +23,15 @@ Virtual models can be restricted to specific `user_paths`, and Playground reques
 authenticated with the master key can scope themselves to one of those paths with
 the **User path** field next to the model picker. When you select a model whose
 policy declares `user_paths`, the field is prefilled with the first entry; you can
-edit it before sending. On send, the value is carried on the
-`X-GoModel-User-Path` request header, exactly as an external client would send it,
-so the gateway records the path on the request snapshot and grants access to models
-restricted to that path — a request without the header is denied for those models.
+edit it before sending. On send, the value is carried on the user-path request
+header, exactly as an external client would send it, so the gateway records the
+path on the request snapshot and grants access to models restricted to that path —
+a request without the header is denied for those models.
 
-Note: the dashboard always sends the default `X-GoModel-User-Path` header name. If
-you customize the header through the `USER_PATH_HEADER` server configuration, the
-dashboard does not pick that up, and Playground requests stop carrying the scoped
-path.
+The header name is `X-GoModel-User-Path` by default. If you customize it through
+`USER_PATH_HEADER` (or `server.user_path_header`), the dashboard reads the
+effective name from `GET /admin/runtime/config` and sends the scoped path under
+that header, so no extra dashboard configuration is needed.
 
 <img
   src="/features/playground.png"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -10750,6 +10750,10 @@
           "USAGE_PRICING_RECALCULATION_ENABLED": {
             "type": "string"
           },
+          "USER_PATH_HEADER": {
+            "description": "UserPathHeader is the canonical name of the inbound header the gateway\nreads user paths from (server.user_path_header), so the Playground sends\nthe header this deployment actually honors.",
+            "type": "string"
+          },
           "VIRTUAL_MODEL_STRATEGIES": {
             "description": "VirtualModelStrategies is the comma-separated list of load-balancing\nstrategies this deployment supports. \"adaptive\" appears only when a\nroute-selector extension is registered, so the dashboard never offers\na strategy that would silently fall back to round robin.",
             "type": "string"

--- a/internal/admin/handler.go
+++ b/internal/admin/handler.go
@@ -82,6 +82,7 @@ const (
 	DashboardConfigLiveLogsEnabled      = "DASHBOARD_LIVE_LOGS_ENABLED"
 	DashboardConfigMCPEnabled           = "MCP_ENABLED"
 	DashboardConfigVMStrategies         = "VIRTUAL_MODEL_STRATEGIES"
+	DashboardConfigUserPathHeader       = "USER_PATH_HEADER"
 )
 
 // statusClientClosedRequest is the de facto status used by proxies for client-aborted requests.
@@ -109,6 +110,10 @@ type DashboardConfigResponse struct {
 	// route-selector extension is registered, so the dashboard never offers
 	// a strategy that would silently fall back to round robin.
 	VirtualModelStrategies string `json:"VIRTUAL_MODEL_STRATEGIES,omitempty"`
+	// UserPathHeader is the canonical name of the inbound header the gateway
+	// reads user paths from (server.user_path_header), so the Playground sends
+	// the header this deployment actually honors.
+	UserPathHeader string `json:"USER_PATH_HEADER,omitempty"`
 }
 
 type providerStatusSummaryResponse struct {
@@ -415,6 +420,7 @@ func normalizeDashboardRuntimeConfig(values DashboardConfigResponse) DashboardCo
 		LiveLogsEnabled:        strings.TrimSpace(values.LiveLogsEnabled),
 		MCPEnabled:             strings.TrimSpace(values.MCPEnabled),
 		VirtualModelStrategies: strings.TrimSpace(values.VirtualModelStrategies),
+		UserPathHeader:         strings.TrimSpace(values.UserPathHeader),
 	}
 }
 

--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -2435,6 +2435,7 @@ func TestDashboardConfig_ReturnsAllowlistedRuntimeFlags(t *testing.T) {
 		LiveLogsEnabled:        "on",
 		MCPEnabled:             "off",
 		VirtualModelStrategies: "round_robin,cost,adaptive",
+		UserPathHeader:         " X-Tenant-Path ",
 	}))
 	c, rec := newHandlerContext("/admin/runtime/config")
 
@@ -2496,6 +2497,9 @@ func TestDashboardConfig_ReturnsAllowlistedRuntimeFlags(t *testing.T) {
 	}
 	if got := body.VirtualModelStrategies; got != "round_robin,cost,adaptive" {
 		t.Fatalf("VIRTUAL_MODEL_STRATEGIES = %q, want round_robin,cost,adaptive", got)
+	}
+	if got := body.UserPathHeader; got != "X-Tenant-Path" {
+		t.Fatalf("USER_PATH_HEADER = %q, want X-Tenant-Path", got)
 	}
 	if rec.Body.String() == "" || strings.Contains(rec.Body.String(), "UNRELATED_FLAG") {
 		t.Fatal("UNRELATED_FLAG should not be exposed")

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -617,6 +617,30 @@ func TestDashboardRuntimeConfig_VirtualModelStrategies(t *testing.T) {
 	}
 }
 
+func TestDashboardRuntimeConfig_ExposesUserPathHeader(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *config.Config
+		want string
+	}{
+		{name: "nil config falls back to default", cfg: nil, want: "X-GoModel-User-Path"},
+		{name: "unset header falls back to default", cfg: &config.Config{}, want: "X-GoModel-User-Path"},
+		{
+			name: "custom header is canonicalized",
+			cfg:  &config.Config{Server: config.ServerConfig{UserPathHeader: "x-tenant-path"}},
+			want: "X-Tenant-Path",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values := dashboardRuntimeConfig(tt.cfg, false, false, false)
+			if got := values.UserPathHeader; got != tt.want {
+				t.Fatalf("dashboardRuntimeConfig()[%q] = %q, want %q", admin.DashboardConfigUserPathHeader, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDashboardRuntimeConfig_HidesCacheAnalyticsWhenUsageDisabled(t *testing.T) {
 	cfg := &config.Config{
 		Usage: config.UsageConfig{

--- a/internal/app/init_admin.go
+++ b/internal/app/init_admin.go
@@ -11,6 +11,7 @@ import (
 	"github.com/enterpilot/gomodel/internal/auditlog"
 	"github.com/enterpilot/gomodel/internal/authkeys"
 	"github.com/enterpilot/gomodel/internal/budget"
+	"github.com/enterpilot/gomodel/internal/core"
 	"github.com/enterpilot/gomodel/internal/guardrails"
 	"github.com/enterpilot/gomodel/internal/live"
 	"github.com/enterpilot/gomodel/internal/mcpgateway"
@@ -226,7 +227,18 @@ func dashboardRuntimeConfig(cfg *config.Config, usageEnabled, demoMode, adaptive
 		LiveLogsEnabled:        dashboardEnabledValue(cfg != nil && cfg.Admin.LiveLogsEnabled),
 		MCPEnabled:             dashboardEnabledValue(cfg != nil && cfg.MCP.Enabled),
 		VirtualModelStrategies: dashboardVirtualModelStrategies(adaptiveRouting),
+		UserPathHeader:         dashboardUserPathHeader(cfg),
 	}
+}
+
+// dashboardUserPathHeader is the canonical user-path header name the public
+// API reads, so the Playground sends the configured USER_PATH_HEADER rather
+// than assuming the default.
+func dashboardUserPathHeader(cfg *config.Config) string {
+	if cfg == nil {
+		return core.UserPathHeader
+	}
+	return core.UserPathHeaderName(cfg.Server.UserPathHeader)
 }
 
 // dashboardVirtualModelStrategies lists the load-balancing strategies the

--- a/internal/server/master_key_user_path_test.go
+++ b/internal/server/master_key_user_path_test.go
@@ -17,9 +17,10 @@ import (
 
 // TestMasterKeyUserPathHeaderScopesRestrictedModelAccess pins the contract the
 // dashboard Playground relies on: a master-key request may scope itself to a
-// user path through the X-GoModel-User-Path header, and that path both lands
-// in the request snapshot and satisfies user_path-restricted virtual-model
-// policies. Without the header the same master-key request is denied.
+// user path through the user-path header (X-GoModel-User-Path by default, or
+// the configured USER_PATH_HEADER), and that path both lands in the request
+// snapshot and satisfies user_path-restricted virtual-model policies. Without
+// the header the same master-key request is denied.
 func TestMasterKeyUserPathHeaderScopesRestrictedModelAccess(t *testing.T) {
 	service, err := virtualmodels.NewService(newAliasesTestStore(virtualmodels.VirtualModel{
 		Source:    "openai/gpt-4o",
@@ -34,8 +35,14 @@ func TestMasterKeyUserPathHeaderScopesRestrictedModelAccess(t *testing.T) {
 	require.NoError(t, service.Refresh(context.Background()))
 	selector := core.ModelSelector{Provider: "openai", Model: "gpt-4o"}
 
+	const customHeader = "X-Tenant-Path"
+
 	tests := []struct {
-		name           string
+		name string
+		// configuredHeader is the server's USER_PATH_HEADER; empty keeps the default.
+		configuredHeader string
+		// sentHeader is the header name the request carries; empty means the default.
+		sentHeader     string
 		userPathHeader string
 		wantSnapshot   string
 		wantAllowed    bool
@@ -56,14 +63,26 @@ func TestMasterKeyUserPathHeaderScopesRestrictedModelAccess(t *testing.T) {
 			wantSnapshot:   "/team/y",
 			wantAllowed:    false,
 		},
+		{
+			name:             "configured header name passes restricted model",
+			configuredHeader: customHeader,
+			sentHeader:       customHeader,
+			userPathHeader:   "/team/x",
+			wantSnapshot:     "/team/x",
+			wantAllowed:      true,
+		},
+		{
+			name:             "default header is ignored when a custom name is configured",
+			configuredHeader: customHeader,
+			userPathHeader:   "/team/x",
+			wantAllowed:      false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := echo.New()
-			// This test uses the default header name; TestRequestSnapshotCapture_UsesConfiguredUserPathHeader
-			// covers the configured-name path.
-			chain := RequestSnapshotCapture()(AuthMiddleware("master-key", nil)(func(c *echo.Context) error {
+			chain := RequestSnapshotCapture(tt.configuredHeader)(AuthMiddleware("master-key", nil)(func(c *echo.Context) error {
 				ctx := c.Request().Context()
 				snapshot := core.GetRequestSnapshot(ctx)
 				require.NotNil(t, snapshot)
@@ -77,7 +96,7 @@ func TestMasterKeyUserPathHeaderScopesRestrictedModelAccess(t *testing.T) {
 			req.Header.Set("Content-Type", "application/json")
 			req.Header.Set("Authorization", "Bearer master-key")
 			if tt.userPathHeader != "" {
-				req.Header.Set(core.UserPathHeader, tt.userPathHeader)
+				req.Header.Set(core.UserPathHeaderName(tt.sentHeader), tt.userPathHeader)
 			}
 			rec := httptest.NewRecorder()
 

--- a/web/dashboard/messages/en.json
+++ b/web/dashboard/messages/en.json
@@ -18,7 +18,7 @@
   "playground_model_search_placeholder": "Search models or type a name…",
   "playground_user_path_label": "User path",
   "playground_user_path_placeholder": "Pick a user path",
-  "playground_user_path_help": "Sent as the X-GoModel-User-Path header. Only paths the selected model allows are offered; type one to override.",
+  "playground_user_path_help": "Sent as the {header} header. Only paths the selected model allows are offered; type one to override.",
   "search_select_search_placeholder": "Search…",
   "search_select_no_matches": "No matches",
   "search_select_use_custom": "Use “{value}”",

--- a/web/dashboard/messages/en.json
+++ b/web/dashboard/messages/en.json
@@ -39,6 +39,7 @@
   "playground_sending": "Waiting for the model…",
   "playground_model_required": "Pick a model first.",
   "playground_request_failed": "The request failed. Check the gateway logs for details.",
+  "playground_config_unavailable": "Could not load the dashboard configuration needed to send the user path. Try again.",
   "playground_empty_response": "The model returned no text. See the Response JSON for the full payload.",
   "playground_json_show": "Show JSON",
   "playground_json_hide": "Hide JSON",

--- a/web/dashboard/messages/pl.json
+++ b/web/dashboard/messages/pl.json
@@ -39,6 +39,7 @@
   "playground_sending": "Oczekiwanie na model…",
   "playground_model_required": "Najpierw wybierz model.",
   "playground_request_failed": "Żądanie nie powiodło się. Sprawdź logi bramki.",
+  "playground_config_unavailable": "Nie udało się wczytać konfiguracji panelu potrzebnej do wysłania ścieżki użytkownika. Spróbuj ponownie.",
   "playground_empty_response": "Model nie zwrócił tekstu. Pełną odpowiedź znajdziesz w JSON odpowiedzi.",
   "playground_json_show": "Pokaż JSON",
   "playground_json_hide": "Ukryj JSON",

--- a/web/dashboard/messages/pl.json
+++ b/web/dashboard/messages/pl.json
@@ -18,7 +18,7 @@
   "playground_model_search_placeholder": "Szukaj modeli lub wpisz nazwę…",
   "playground_user_path_label": "Ścieżka użytkownika",
   "playground_user_path_placeholder": "Wybierz ścieżkę użytkownika",
-  "playground_user_path_help": "Wysyłane jako nagłówek X-GoModel-User-Path. Lista pokazuje tylko ścieżki dozwolone dla wybranego modelu; wpisz własną, aby ją nadpisać.",
+  "playground_user_path_help": "Wysyłane jako nagłówek {header}. Lista pokazuje tylko ścieżki dozwolone dla wybranego modelu; wpisz własną, aby ją nadpisać.",
   "search_select_search_placeholder": "Szukaj…",
   "search_select_no_matches": "Brak wyników",
   "search_select_use_custom": "Użyj „{value}”",

--- a/web/dashboard/src/lib/stores/runtimeConfig.svelte.js
+++ b/web/dashboard/src/lib/stores/runtimeConfig.svelte.js
@@ -23,6 +23,7 @@ const CONFIG_KEYS = [
   "DASHBOARD_LIVE_LOGS_ENABLED",
   "MCP_ENABLED",
   "VIRTUAL_MODEL_STRATEGIES",
+  "USER_PATH_HEADER",
 ];
 
 // Strategies every gateway supports; used when the backend predates the
@@ -59,6 +60,13 @@ class RuntimeConfigStore {
       .map((s) => s.trim())
       .filter(Boolean);
     return list.length > 0 ? list : DEFAULT_VM_STRATEGIES;
+  }
+
+  // userPathHeader is the canonical header name the gateway reads user paths
+  // from (USER_PATH_HEADER), or "" when the backend predates the key or the
+  // config has not loaded; callers fall back to the default name.
+  userPathHeader() {
+    return String((this.config && this.config.USER_PATH_HEADER) || "").trim();
   }
 
   // cacheVisible is a tri-source gate: an explicit CACHE_ENABLED wins;

--- a/web/dashboard/src/pages/playground/PlaygroundToolbar.svelte
+++ b/web/dashboard/src/pages/playground/PlaygroundToolbar.svelte
@@ -61,7 +61,7 @@
         mono
       />
     </div>
-    <div class="playground-field playground-field-user-path" title={m.playground_user_path_help()}>
+    <div class="playground-field playground-field-user-path" title={m.playground_user_path_help({ header: store.userPathHeaderName })}>
       <label class="playground-field-label" for="playground-user-path">{m.playground_user_path_label()}</label>
       <SearchSelect
         id="playground-user-path"

--- a/web/dashboard/src/pages/playground/playground.svelte.js
+++ b/web/dashboard/src/pages/playground/playground.svelte.js
@@ -8,6 +8,7 @@ import { errorPayloadMessage, isGatewayAuthError } from "$lib/api/errors.js";
 import { consumeEventStream } from "$lib/api/eventStream.js";
 import { auth } from "$lib/stores/auth.svelte.js";
 import { modelsStore } from "$lib/stores/models.svelte.js";
+import { runtimeConfig } from "$lib/stores/runtimeConfig.svelte.js";
 import { readStored, writeStored } from "$lib/utils/storage.js";
 import { moveItem } from "$lib/utils/sortable.js";
 import * as m from "$lib/paraglide/messages.js";
@@ -15,6 +16,7 @@ import {
   buildPlaygroundRequest,
   createStreamAccumulator,
   defaultUserPathForModel,
+  effectiveUserPathHeaderName,
   endpointById,
   extractResponseText,
   extractUsage,
@@ -34,9 +36,9 @@ const STORAGE = {
 class PlaygroundStore {
   endpoint = $state(normalizeEndpoint(readStored(STORAGE.endpoint, "")));
   model = $state(readStored(STORAGE.model, "") || "");
-  // Session-only: the user path to send as X-GoModel-User-Path. Defaults to
-  // the selected model's first allowed path when setModel picks a
-  // restricted model; never persisted to localStorage.
+  // Session-only: the user path to send on the user-path header (see
+  // userPathHeaderName). Defaults to the selected model's first allowed path
+  // when setModel picks a restricted model; never persisted to localStorage.
   userPath = $state("");
   stream = $state(readStored(STORAGE.stream, "true") !== "false");
   // [{ id, role, content, pending }] — the conversation the user edits.
@@ -76,6 +78,12 @@ class PlaygroundStore {
 
   get canSend() {
     return !this.sending && (this.draft.trim() !== "" || this.messages.length > 0);
+  }
+
+  // Header name the selected user path is sent under: the deployment's
+  // USER_PATH_HEADER when customized, otherwise X-GoModel-User-Path.
+  get userPathHeaderName() {
+    return effectiveUserPathHeaderName(runtimeConfig.userPathHeader());
   }
 
   setEndpoint(id) {
@@ -171,10 +179,13 @@ class PlaygroundStore {
     const meta = { status: 0, durationMs: 0, streamed: false, events: 0, usage: null };
 
     try {
+      // A customized USER_PATH_HEADER only reaches the gateway under its
+      // configured name, so make sure the runtime config is known first.
+      await runtimeConfig.ensureLoaded();
       const options = {
         method: "POST",
         body: JSON.stringify(body),
-        headers: playgroundUserPathHeader(this.userPath),
+        headers: playgroundUserPathHeader(this.userPath, this.userPathHeaderName),
         signal: controller.signal,
       };
       const res = await apiFetch(endpoint.path, options);

--- a/web/dashboard/src/pages/playground/playground.svelte.js
+++ b/web/dashboard/src/pages/playground/playground.svelte.js
@@ -13,6 +13,7 @@ import { readStored, writeStored } from "$lib/utils/storage.js";
 import { moveItem } from "$lib/utils/sortable.js";
 import * as m from "$lib/paraglide/messages.js";
 import {
+  abortable,
   buildPlaygroundRequest,
   createStreamAccumulator,
   defaultUserPathForModel,
@@ -179,9 +180,17 @@ class PlaygroundStore {
     const meta = { status: 0, durationMs: 0, streamed: false, events: 0, usage: null };
 
     try {
-      // A customized USER_PATH_HEADER only reaches the gateway under its
-      // configured name, so make sure the runtime config is known first.
-      await runtimeConfig.ensureLoaded();
+      // The selected path only reaches the gateway under the configured
+      // USER_PATH_HEADER, so never guess the name: a scoped send needs the
+      // runtime config and fails (retryably) when it cannot be loaded. Stop
+      // aborts the wait like any other phase of the request.
+      if (String(this.userPath || "").trim()) {
+        await abortable(runtimeConfig.ensureLoaded(), controller.signal);
+        if (!runtimeConfig.loaded) {
+          this.error = m.playground_config_unavailable();
+          return;
+        }
+      }
       const options = {
         method: "POST",
         body: JSON.stringify(body),

--- a/web/dashboard/src/pages/playground/playgroundLogic.js
+++ b/web/dashboard/src/pages/playground/playgroundLogic.js
@@ -376,12 +376,11 @@ export function abortable(promise, signal) {
   if (!signal) return promise;
   return new Promise((resolve, reject) => {
     const abort = () => reject(new DOMException("Aborted", "AbortError"));
-    if (signal.aborted) {
-      abort();
-      return;
-    }
     signal.addEventListener("abort", abort, { once: true });
-    promise.then(resolve, reject).finally(() => signal.removeEventListener("abort", abort));
+    // Always observe the promise, even when already aborted, so a later
+    // rejection never surfaces as an unhandled one.
+    Promise.resolve(promise).then(resolve, reject).finally(() => signal.removeEventListener("abort", abort));
+    if (signal.aborted) abort();
   });
 }
 

--- a/web/dashboard/src/pages/playground/playgroundLogic.js
+++ b/web/dashboard/src/pages/playground/playgroundLogic.js
@@ -330,10 +330,14 @@ export function playgroundModelOptions(inventory) {
 
 // --- User-path picker --------------------------------------------------------
 
+// Header name the gateway reads user paths from unless USER_PATH_HEADER is
+// customized server-side.
+const DEFAULT_USER_PATH_HEADER = "X-GoModel-User-Path";
+
 // User paths the selected inventory entry is restricted to
 // (access.user_paths), as { value, label } objects; empty when the model is
-// unknown or unrestricted. The playground sends the chosen path as
-// X-GoModel-User-Path so a restricted model can be exercised from the picker.
+// unknown or unrestricted. The playground sends the chosen path on the
+// user-path header so a restricted model can be exercised from the picker.
 export function playgroundUserPathOptions(inventory, selector) {
   const id = String(selector || "").trim();
   const entry = (Array.isArray(inventory) ? inventory : []).find(
@@ -353,10 +357,17 @@ export function defaultUserPathForModel(inventory, selector) {
   return playgroundUserPathOptions(inventory, selector)[0]?.value || "";
 }
 
-// Build the header to send when a non-empty user path is selected.
-export function playgroundUserPathHeader(userPath) {
+// Effective user-path header name: the server-configured USER_PATH_HEADER
+// (from /admin/runtime/config) or the default when unset.
+export function effectiveUserPathHeaderName(configured) {
+  return String(configured || "").trim() || DEFAULT_USER_PATH_HEADER;
+}
+
+// Build the header to send when a non-empty user path is selected, under the
+// configured header name so a customized USER_PATH_HEADER is honored.
+export function playgroundUserPathHeader(userPath, headerName) {
   const path = String(userPath || "").trim();
-  return path ? { "X-GoModel-User-Path": path } : {};
+  return path ? { [effectiveUserPathHeaderName(headerName)]: path } : {};
 }
 
 // --- JSON panel sizing -------------------------------------------------------

--- a/web/dashboard/src/pages/playground/playgroundLogic.js
+++ b/web/dashboard/src/pages/playground/playgroundLogic.js
@@ -370,6 +370,21 @@ export function playgroundUserPathHeader(userPath, headerName) {
   return path ? { [effectiveUserPathHeaderName(headerName)]: path } : {};
 }
 
+// Resolve with `promise`, or reject with an AbortError as soon as `signal`
+// aborts, so a preflight that has no signal of its own still honors Stop.
+export function abortable(promise, signal) {
+  if (!signal) return promise;
+  return new Promise((resolve, reject) => {
+    const abort = () => reject(new DOMException("Aborted", "AbortError"));
+    if (signal.aborted) {
+      abort();
+      return;
+    }
+    signal.addEventListener("abort", abort, { once: true });
+    promise.then(resolve, reject).finally(() => signal.removeEventListener("abort", abort));
+  });
+}
+
 // --- JSON panel sizing -------------------------------------------------------
 
 export const DEFAULT_JSON_PANEL_WIDTH = 420;

--- a/web/dashboard/tests/playground.test.js
+++ b/web/dashboard/tests/playground.test.js
@@ -412,6 +412,15 @@ test("abortable rejects with an AbortError when the signal fires", async () => {
   await assert.rejects(pending, (error) => error.name === "AbortError");
   // An already-aborted signal rejects without waiting on the promise.
   await assert.rejects(abortable(new Promise(() => {}), controller.signal), (error) => error.name === "AbortError");
+  // A promise that later rejects after an abort is still observed (no
+  // unhandled rejection) and the caller sees the AbortError.
+  let rejectLater;
+  const late = new Promise((_, reject) => {
+    rejectLater = reject;
+  });
+  await assert.rejects(abortable(late, controller.signal), (error) => error.name === "AbortError");
+  rejectLater(new Error("late"));
+  await new Promise((resolve) => setImmediate(resolve));
 });
 
 test("clampJsonPanelWidth keeps the panel inside the viewport", () => {

--- a/web/dashboard/tests/playground.test.js
+++ b/web/dashboard/tests/playground.test.js
@@ -8,6 +8,7 @@ import {
   clampJsonPanelWidth,
   createStreamAccumulator,
   defaultUserPathForModel,
+  effectiveUserPathHeaderName,
   extractResponseText,
   extractUsage,
   initialJsonPanelOpen,
@@ -366,14 +367,32 @@ test("defaultUserPathForModel returns the first allowed path or empty", () => {
   assert.equal(defaultUserPathForModel(undefined, "team-model"), "");
 });
 
-test("playgroundUserPathHeader sends X-GoModel-User-Path only when non-empty", () => {
+test("effectiveUserPathHeaderName falls back to the default header name", () => {
+  assert.equal(effectiveUserPathHeaderName(undefined), "X-GoModel-User-Path");
+  assert.equal(effectiveUserPathHeaderName(""), "X-GoModel-User-Path");
+  assert.equal(effectiveUserPathHeaderName("   "), "X-GoModel-User-Path");
+  // A customized USER_PATH_HEADER from /admin/runtime/config wins.
+  assert.equal(effectiveUserPathHeaderName("X-Tenant-Path"), "X-Tenant-Path");
+  assert.equal(effectiveUserPathHeaderName("  X-Tenant-Path  "), "X-Tenant-Path");
+});
+
+test("playgroundUserPathHeader sends the default header name only when non-empty", () => {
   assert.deepEqual(playgroundUserPathHeader("/team/alpha"), { "X-GoModel-User-Path": "/team/alpha" });
+  assert.deepEqual(playgroundUserPathHeader("/team/alpha", ""), { "X-GoModel-User-Path": "/team/alpha" });
   // Surrounding whitespace is trimmed before the header is built.
   assert.deepEqual(playgroundUserPathHeader("  /team/alpha  "), { "X-GoModel-User-Path": "/team/alpha" });
   // Unrestricted selection or blank input drops the header.
   assert.deepEqual(playgroundUserPathHeader(""), {});
   assert.deepEqual(playgroundUserPathHeader("   "), {});
   assert.deepEqual(playgroundUserPathHeader(undefined), {});
+});
+
+test("playgroundUserPathHeader honors a customized USER_PATH_HEADER", () => {
+  assert.deepEqual(playgroundUserPathHeader("/team/alpha", "X-Tenant-Path"), { "X-Tenant-Path": "/team/alpha" });
+  assert.deepEqual(playgroundUserPathHeader("  /team/alpha  ", "X-Tenant-Path"), { "X-Tenant-Path": "/team/alpha" });
+  // A blank path still produces no header, whatever the configured name.
+  assert.deepEqual(playgroundUserPathHeader("", "X-Tenant-Path"), {});
+  assert.deepEqual(playgroundUserPathHeader("   ", "X-Tenant-Path"), {});
 });
 
 test("clampJsonPanelWidth keeps the panel inside the viewport", () => {

--- a/web/dashboard/tests/playground.test.js
+++ b/web/dashboard/tests/playground.test.js
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   DEFAULT_MAX_TOKENS,
   ENDPOINTS,
+  abortable,
   buildPlaygroundRequest,
   clampJsonPanelWidth,
   createStreamAccumulator,
@@ -393,6 +394,24 @@ test("playgroundUserPathHeader honors a customized USER_PATH_HEADER", () => {
   // A blank path still produces no header, whatever the configured name.
   assert.deepEqual(playgroundUserPathHeader("", "X-Tenant-Path"), {});
   assert.deepEqual(playgroundUserPathHeader("   ", "X-Tenant-Path"), {});
+});
+
+test("abortable resolves normally while the signal stays live", async () => {
+  const controller = new AbortController();
+  assert.equal(await abortable(Promise.resolve("ok"), controller.signal), "ok");
+  // Without a signal the promise passes straight through.
+  assert.equal(await abortable(Promise.resolve("plain"), undefined), "plain");
+  // Rejections propagate unchanged.
+  await assert.rejects(abortable(Promise.reject(new Error("boom")), controller.signal), /boom/);
+});
+
+test("abortable rejects with an AbortError when the signal fires", async () => {
+  const controller = new AbortController();
+  const pending = abortable(new Promise(() => {}), controller.signal);
+  controller.abort();
+  await assert.rejects(pending, (error) => error.name === "AbortError");
+  // An already-aborted signal rejects without waiting on the promise.
+  await assert.rejects(abortable(new Promise(() => {}), controller.signal), (error) => error.name === "AbortError");
 });
 
 test("clampJsonPanelWidth keeps the panel inside the viewport", () => {


### PR DESCRIPTION
Closes #858

The Playground always sent `X-GoModel-User-Path`, so on deployments with a customized `USER_PATH_HEADER` the gateway ignored the selected user path and denied requests to user-path-restricted models.

## Changes

- `GET /admin/runtime/config` now exposes `USER_PATH_HEADER`, the canonical name of the configured user-path header.
- The dashboard allowlists that key and the Playground builds its user-path header from it, falling back to `X-GoModel-User-Path` when the backend predates the key. Empty or whitespace-only paths still send no header.
- The user-path field's tooltip shows the effective header name.
- Docs: `docs/features/playground.mdx` no longer documents the limitation; OpenAPI schema updated.

## Tests

- Go: runtime-config wiring (default, unset, canonicalized custom name), handler contract, and the master-key user-path test now covers a configured header name (custom name honored, default name ignored).
- Dashboard: `playgroundUserPathHeader` with the default and a customized header, plus the fallback helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0178EG24ePPqUha2mzFMyCGm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The Playground now honors a server-configured user-path header when sending requests.
  * Runtime configuration exposes the effective user-path header, defaulting to `X-GoModel-User-Path`.
  * User-path help text dynamically displays the configured header name.
  * The Playground reports an error when required runtime configuration cannot be loaded.

* **Documentation**
  * Updated Playground and API documentation to describe configurable user-path headers and user-path prefilling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->