### PR TITLE
fix(server): reject duplicate model, provider, and stream fields at ingress

### DIFF
--- a/docs/advanced/api-endpoints.mdx
+++ b/docs/advanced/api-endpoints.mdx
@@ -20,9 +20,12 @@ For request and response details, see the dedicated guides:
 GoModel reads the top-level `model`, `provider`, and `stream` members of a JSON
 body to authorize and route the request. JSON parsers disagree on which value
 wins when an object repeats a member, so a body that repeats any of these three
-at the top level is rejected with `400 invalid_request_error` on every route,
-including passthrough, before anything is authorized, cached, or forwarded.
-Repeated members nested inside other objects are left as sent.
+at the top level is rejected with `400 invalid_request_error` before anything
+is authorized, cached, or forwarded. This applies to the OpenAI-compatible and
+Anthropic-compatible `/v1` routes above and to provider passthrough. Endpoints
+that parse their own body (audio, images, realtime, MCP) decode it into a typed
+request and forward that, so they never route on a different value than they
+authorized. Repeated members nested inside other objects are left as sent.
 
 | Endpoint                          | Method | Description                                                                                                  |
 | --------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------ |

--- a/docs/advanced/api-endpoints.mdx
+++ b/docs/advanced/api-endpoints.mdx
@@ -15,7 +15,14 @@ For request and response details, see the dedicated guides:
 [Audio API](/advanced/audio-api), [Images API](/advanced/images-api), and
 [Usage API](/advanced/usage-api).
 
-## OpenAI-Compatible API
+## Request body validation
+
+GoModel reads the top-level `model`, `provider`, and `stream` members of a JSON
+body to authorize and route the request. JSON parsers disagree on which value
+wins when an object repeats a member, so a body that repeats any of these three
+at the top level is rejected with `400 invalid_request_error` on every route,
+including passthrough, before anything is authorized, cached, or forwarded.
+Repeated members nested inside other objects are left as sent.
 
 | Endpoint                          | Method | Description                                                                                                  |
 | --------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------ |

--- a/docs/advanced/api-endpoints.mdx
+++ b/docs/advanced/api-endpoints.mdx
@@ -22,10 +22,8 @@ body to authorize and route the request. JSON parsers disagree on which value
 wins when an object repeats a member, so a body that repeats any of these three
 at the top level is rejected with `400 invalid_request_error` before anything
 is authorized, cached, or forwarded. This applies to the OpenAI-compatible and
-Anthropic-compatible `/v1` routes above and to provider passthrough. Endpoints
-that parse their own body (audio, images, realtime, MCP) decode it into a typed
-request and forward that, so they never route on a different value than they
-authorized. Repeated members nested inside other objects are left as sent.
+Anthropic-compatible `/v1` inference routes and to provider passthrough.
+Repeated members nested inside other objects are left as sent.
 
 | Endpoint                          | Method | Description                                                                                                  |
 | --------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------ |

--- a/docs/features/passthrough-api.mdx
+++ b/docs/features/passthrough-api.mdx
@@ -65,6 +65,12 @@ GoModel strips client `Authorization` and `X-Api-Key` headers before forwarding
 the request, then applies the upstream provider credential configured on the
 server. For Anthropic, GoModel uses its configured `ANTHROPIC_API_KEY`.
 
+When the body is JSON, GoModel authorizes the top-level `model` it names and
+then forwards the body byte-for-byte. A body that repeats a top-level `model`,
+`provider`, or `stream` member is rejected with `400` instead, because the
+upstream parser could otherwise pick a different value than the one GoModel
+authorized.
+
 Because passthrough is provider-native, the response is also provider-native.
 For Anthropic messages, the response uses Anthropic's message schema, not an
 OpenAI chat completion schema.

--- a/internal/core/selector_uniqueness.go
+++ b/internal/core/selector_uniqueness.go
@@ -1,0 +1,171 @@
+package core
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/tidwall/gjson"
+)
+
+// DuplicateSelectorField reports the first top-level "model", "provider", or
+// "stream" member that a JSON object body repeats, or "" when each appears at
+// most once.
+//
+// JSON parsers disagree on which duplicate wins: gjson keeps the first
+// occurrence, encoding/json and most provider parsers keep the last. A repeated
+// selector could therefore be authorized as one model and executed as another,
+// so the gateway rejects such bodies instead of picking a side.
+//
+// The scan walks only the top-level members and allocates nothing for the
+// common case; it never panics on malformed input but reports "" for it, so
+// callers validate the body separately.
+func DuplicateSelectorField(body []byte) string {
+	i := skipJSONSpace(body, 0)
+	if i >= len(body) || body[i] != '{' {
+		return ""
+	}
+	i++
+	var modelSeen, providerSeen, streamSeen bool
+	for {
+		i = skipJSONSpace(body, i)
+		if i >= len(body) {
+			return ""
+		}
+		switch body[i] {
+		case '}':
+			return ""
+		case ',':
+			i++
+			continue
+		case '"':
+		default:
+			return ""
+		}
+
+		keyStart := i
+		i = skipJSONString(body, i)
+		if i < 0 {
+			return ""
+		}
+		name := jsonMemberName(body[keyStart:i])
+		var seen *bool
+		switch name {
+		case "model":
+			seen = &modelSeen
+		case "provider":
+			seen = &providerSeen
+		case "stream":
+			seen = &streamSeen
+		}
+		if seen != nil {
+			if *seen {
+				return name
+			}
+			*seen = true
+		}
+
+		i = skipJSONSpace(body, i)
+		if i >= len(body) || body[i] != ':' {
+			return ""
+		}
+		i = skipJSONValue(body, i+1)
+		if i < 0 {
+			return ""
+		}
+	}
+}
+
+// jsonMemberName returns the member name for a quoted JSON key. Keys without
+// escapes are viewed in place; escaped keys are decoded so "model" still
+// counts as "model".
+func jsonMemberName(quoted []byte) string {
+	raw := quoted[1 : len(quoted)-1]
+	if slices.Contains(raw, '\\') {
+		return gjson.ParseBytes(quoted).Str
+	}
+	switch string(raw) {
+	case "model":
+		return "model"
+	case "provider":
+		return "provider"
+	case "stream":
+		return "stream"
+	default:
+		return ""
+	}
+}
+
+func skipJSONSpace(body []byte, i int) int {
+	for i < len(body) {
+		switch body[i] {
+		case ' ', '\t', '\n', '\r':
+			i++
+		default:
+			return i
+		}
+	}
+	return i
+}
+
+// skipJSONString returns the index just past the string starting at body[i],
+// or -1 when it is unterminated.
+func skipJSONString(body []byte, i int) int {
+	for i++; i < len(body); i++ {
+		switch body[i] {
+		case '\\':
+			i++
+		case '"':
+			return i + 1
+		}
+	}
+	return -1
+}
+
+// skipJSONValue returns the index just past the value starting at body[i]
+// (after optional whitespace), or -1 when the value is unterminated.
+func skipJSONValue(body []byte, i int) int {
+	i = skipJSONSpace(body, i)
+	if i >= len(body) {
+		return -1
+	}
+	switch body[i] {
+	case '"':
+		return skipJSONString(body, i)
+	case '{', '[':
+		depth := 0
+		for i < len(body) {
+			switch body[i] {
+			case '"':
+				i = skipJSONString(body, i)
+				if i < 0 {
+					return -1
+				}
+				continue
+			case '{', '[':
+				depth++
+			case '}', ']':
+				depth--
+				if depth == 0 {
+					return i + 1
+				}
+			}
+			i++
+		}
+		return -1
+	default:
+		for i < len(body) {
+			switch body[i] {
+			case ',', '}', ']', ' ', '\t', '\n', '\r':
+				return i
+			}
+			i++
+		}
+		return i
+	}
+}
+
+// NewDuplicateSelectorFieldError is the invalid-request error returned for a
+// body that repeats a top-level selector field.
+func NewDuplicateSelectorFieldError(field string) *GatewayError {
+	return NewInvalidRequestError(fmt.Sprintf("duplicate top-level %q field in request body", field), nil)
+}

--- a/internal/core/selector_uniqueness_test.go
+++ b/internal/core/selector_uniqueness_test.go
@@ -1,0 +1,50 @@
+package core
+
+import "testing"
+
+func TestDuplicateSelectorField(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "unique selectors", body: `{"model":"gpt-5-mini","provider":"openai","stream":true}`, want: ""},
+		{name: "no selectors", body: `{"messages":[]}`, want: ""},
+		{name: "empty object", body: `{}`, want: ""},
+		{name: "duplicate model", body: `{"model":"allowed","model":"blocked"}`, want: "model"},
+		{name: "duplicate provider", body: `{"provider":"a","model":"m","provider":"b"}`, want: "provider"},
+		{name: "duplicate stream", body: `{"stream":true,"stream":false}`, want: "stream"},
+		{name: "first repeated field wins the report", body: `{"stream":true,"model":"a","stream":false,"model":"b"}`, want: "stream"},
+		{name: "duplicate with escaped key", body: `{"model":"allowed","mod\u0065l":"blocked"}`, want: "model"},
+		{name: "nested duplicates ignored", body: `{"model":"m","messages":[{"model":"a","model":"b"}],"x":{"stream":true,"stream":false}}`, want: ""},
+		{name: "duplicate other fields ignored", body: `{"model":"m","n":1,"n":2}`, want: ""},
+		{name: "pretty printed duplicate", body: "{\n  \"model\" : \"a\" ,\n  \"messages\": [ {\"x\": [1, 2]} ],\n  \"model\" : \"b\"\n}", want: "model"},
+		{name: "values containing braces and escaped quotes", body: `{"model":"a{\"}","messages":[{"content":"[{]\\"}],"model":"b"}`, want: "model"},
+		{name: "scalar values of every kind", body: `{"n":1.5e3,"b":true,"z":null,"stream":false,"stream":true}`, want: "stream"},
+		{name: "array root", body: `[{"model":"a","model":"b"}]`, want: ""},
+		{name: "not json", body: `nope`, want: ""},
+		{name: "unterminated object", body: `{"model":"a","model":"b"`, want: "model"},
+		{name: "unterminated string", body: `{"model":"a`, want: ""},
+		{name: "unterminated nested value", body: `{"model":"a","x":[1,2`, want: ""},
+		{name: "missing colon", body: `{"model" "a"}`, want: ""},
+		{name: "empty body", body: ``, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DuplicateSelectorField([]byte(tt.body)); got != tt.want {
+				t.Fatalf("DuplicateSelectorField(%s) = %q, want %q", tt.body, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewDuplicateSelectorFieldError(t *testing.T) {
+	err := NewDuplicateSelectorFieldError("model")
+	if err.StatusCode != 400 || err.Type != ErrorTypeInvalidRequest {
+		t.Fatalf("error = %+v, want 400 invalid_request", err)
+	}
+	if want := `duplicate top-level "model" field in request body`; err.Message != want {
+		t.Fatalf("message = %q, want %q", err.Message, want)
+	}
+}

--- a/internal/core/semantic.go
+++ b/internal/core/semantic.go
@@ -80,8 +80,22 @@ type WhiteBoxPrompt struct {
 	// JSONBodyParsed reports that the captured request body was parsed as JSON
 	// (for selector peeking and/or canonical request decode).
 	JSONBodyParsed bool
+	// DuplicateSelectorField names the top-level selector member ("model",
+	// "provider", or "stream") that the captured body repeats. Such a body
+	// yields no selector hints; DuplicateSelectorError rejects the request.
+	DuplicateSelectorField string
 
 	cache map[semanticCacheKey]any
+}
+
+// DuplicateSelectorError returns the invalid-request error for a captured body
+// that repeats a top-level selector field, or nil when the body was unique or
+// not inspected.
+func (env *WhiteBoxPrompt) DuplicateSelectorError() error {
+	if env == nil || env.DuplicateSelectorField == "" {
+		return nil
+	}
+	return NewDuplicateSelectorFieldError(env.DuplicateSelectorField)
 }
 
 // CachedChatRequest returns the cached canonical chat request, if present.
@@ -253,11 +267,15 @@ func DeriveWhiteBoxPrompt(snapshot *RequestSnapshot) *WhiteBoxPrompt {
 		return env
 	}
 
-	model, provider, stream, parsed := deriveSnapshotSelectorHintsGJSON(trimmed)
-	if !parsed {
+	hints := deriveSnapshotSelectorHintsGJSON(trimmed)
+	if hints.duplicate != "" {
+		env.DuplicateSelectorField = hints.duplicate
 		return env
 	}
-	ApplyBodySelectorHints(env, model, provider, stream)
+	if !hints.parsed {
+		return env
+	}
+	ApplyBodySelectorHints(env, hints.model, hints.provider, hints.stream)
 
 	return env
 }
@@ -389,48 +407,63 @@ func derivePassthroughRouteInfoFromTransport(snapshot *RequestSnapshot) *Passthr
 	return info
 }
 
-func deriveSnapshotSelectorHintsGJSON(body []byte) (model, provider string, stream, parsed bool) {
+// snapshotSelectorHints is the sparse selector state peeked from a captured
+// JSON body. duplicate names a repeated top-level selector field; when set the
+// remaining fields are meaningless because the body is rejected.
+type snapshotSelectorHints struct {
+	model     string
+	provider  string
+	stream    bool
+	parsed    bool
+	duplicate string
+}
+
+func deriveSnapshotSelectorHintsGJSON(body []byte) snapshotSelectorHints {
 	if !gjson.ValidBytes(body) {
-		return "", "", false, false
+		return snapshotSelectorHints{}
 	}
 
 	// GetBytes peeks without gjson.ParseBytes's full copy of the body; the
 	// leading byte is the object check the parse used to make.
 	if trimmed := bytes.TrimSpace(body); len(trimmed) == 0 || trimmed[0] != '{' {
-		return "", "", false, false
+		return snapshotSelectorHints{}
 	}
 
-	// gjson returns the first matching top-level field. That differs from
-	// encoding/json on duplicate keys, but the hot-path speedup is worth it here:
-	// duplicate selector keys are not expected from real clients, and we accept
-	// the first-match behavior to keep ingress peeking cheap.
+	// gjson returns the first matching top-level field while encoding/json
+	// keeps the last. Bodies that repeat a selector field are rejected, so for
+	// every body that reaches the lookups below both parsers agree.
+	if field := DuplicateSelectorField(body); field != "" {
+		return snapshotSelectorHints{duplicate: field}
+	}
+
 	modelResult := gjson.GetBytes(body, "model")
 	if !snapshotSelectorStringAllowed(modelResult) {
-		return "", "", false, false
+		return snapshotSelectorHints{}
 	}
 	providerResult := gjson.GetBytes(body, "provider")
 	if !snapshotSelectorStringAllowed(providerResult) {
-		return "", "", false, false
+		return snapshotSelectorHints{}
 	}
 	streamResult := gjson.GetBytes(body, "stream")
 	if !snapshotSelectorBoolAllowed(streamResult) {
-		return "", "", false, false
+		return snapshotSelectorHints{}
 	}
 
 	// GetBytes results own their strings (unlike Parse results, which alias
 	// the body), so these values can land in RouteHints — which lives on the
 	// request context for the whole, possibly streaming, request — without
 	// pinning a request-sized backing string.
+	hints := snapshotSelectorHints{parsed: true}
 	if modelResult.Type == gjson.String {
-		model = modelResult.String()
+		hints.model = modelResult.String()
 	}
 	if providerResult.Type == gjson.String {
-		provider = providerResult.String()
+		hints.provider = providerResult.String()
 	}
 	if streamResult.Type == gjson.True || streamResult.Type == gjson.False {
-		stream = streamResult.Bool()
+		hints.stream = streamResult.Bool()
 	}
-	return model, provider, stream, true
+	return hints
 }
 
 func snapshotSelectorStringAllowed(result gjson.Result) bool {

--- a/internal/core/semantic_test.go
+++ b/internal/core/semantic_test.go
@@ -1,7 +1,9 @@
 package core
 
 import (
+	"errors"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -355,18 +357,22 @@ func TestDeriveWhiteBoxPrompt_BatchResultsMetadata(t *testing.T) {
 
 func TestDeriveSnapshotSelectorHintsGJSON_MatchesStdlibSemantics(t *testing.T) {
 	tests := []struct {
-		name         string
-		body         string
-		wantModel    string
-		wantProvider string
-		wantStream   bool
-		wantParsed   bool
+		name          string
+		body          string
+		wantModel     string
+		wantProvider  string
+		wantStream    bool
+		wantParsed    bool
+		wantDuplicate string
 	}{
 		{name: "valid selector fields", body: `{"provider":"openai","model":"gpt-5-mini","stream":true}`, wantModel: "gpt-5-mini", wantProvider: "openai", wantStream: true, wantParsed: true},
-		{name: "duplicate selector fields use first occurrence", body: `{"model":"blocked","model":"gpt-5-mini","provider":"x","provider":"openai","stream":false,"stream":true}`, wantModel: "blocked", wantProvider: "x", wantStream: false, wantParsed: true},
-		{name: "duplicate null string keeps first value and null stream keeps first bool", body: `{"model":"gpt-5-mini","model":null,"provider":"openai","provider":null,"stream":true,"stream":null}`, wantModel: "gpt-5-mini", wantProvider: "openai", wantStream: true, wantParsed: true},
-		{name: "duplicate invalid selector field keeps first value", body: `{"model":"gpt-5-mini","model":123}`, wantModel: "gpt-5-mini", wantParsed: true},
-		{name: "duplicate invalid stream field keeps first value", body: `{"stream":true,"stream":"yes"}`, wantStream: true, wantParsed: true},
+		{name: "duplicate model is reported instead of picking an occurrence", body: `{"model":"blocked","model":"gpt-5-mini","provider":"x","provider":"openai","stream":false,"stream":true}`, wantDuplicate: "model"},
+		{name: "duplicate provider is reported", body: `{"model":"gpt-5-mini","provider":"x","provider":"openai"}`, wantDuplicate: "provider"},
+		{name: "duplicate stream is reported", body: `{"model":"gpt-5-mini","stream":false,"stream":true}`, wantDuplicate: "stream"},
+		{name: "duplicate null selector is still a duplicate", body: `{"model":"gpt-5-mini","model":null}`, wantDuplicate: "model"},
+		{name: "duplicate invalid selector is still a duplicate", body: `{"model":"gpt-5-mini","model":123}`, wantDuplicate: "model"},
+		{name: "nested duplicate selectors are not top-level", body: `{"model":"gpt-5-mini","messages":[{"model":"a","model":"b"}],"metadata":{"stream":true,"stream":false}}`, wantModel: "gpt-5-mini", wantParsed: true},
+		{name: "duplicate non-selector fields are tolerated", body: `{"model":"gpt-5-mini","n":1,"n":2}`, wantModel: "gpt-5-mini", wantParsed: true},
 		{name: "missing selector fields", body: `{"messages":[{"role":"user","content":"hi"}]}`, wantParsed: true},
 		{name: "null selector fields", body: `{"provider":null,"model":null,"stream":null}`, wantParsed: true},
 		{name: "invalid json", body: `not json`, wantParsed: false},
@@ -379,20 +385,74 @@ func TestDeriveSnapshotSelectorHintsGJSON_MatchesStdlibSemantics(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotModel, gotProvider, gotStream, gotParsed := deriveSnapshotSelectorHintsGJSON([]byte(tt.body))
-			if tt.wantModel != gotModel || tt.wantProvider != gotProvider || tt.wantStream != gotStream || tt.wantParsed != gotParsed {
-				t.Fatalf("gjson mismatch: want (%q, %q, %v, %v), got (%q, %q, %v, %v)", tt.wantModel, tt.wantProvider, tt.wantStream, tt.wantParsed, gotModel, gotProvider, gotStream, gotParsed)
+			got := deriveSnapshotSelectorHintsGJSON([]byte(tt.body))
+			want := snapshotSelectorHints{model: tt.wantModel, provider: tt.wantProvider, stream: tt.wantStream, parsed: tt.wantParsed, duplicate: tt.wantDuplicate}
+			if got != want {
+				t.Fatalf("gjson mismatch: want %+v, got %+v", want, got)
 			}
 		})
+	}
+}
+
+func TestDeriveWhiteBoxPrompt_FlagsDuplicateSelectorFields(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		body string
+		want string
+	}{
+		{name: "chat duplicate model", path: "/v1/chat/completions", body: `{"model":"allowed","model":"blocked","messages":[]}`, want: "model"},
+		{name: "responses duplicate provider", path: "/v1/responses", body: `{"model":"gpt-5-mini","provider":"a","provider":"b","input":"hi"}`, want: "provider"},
+		{name: "passthrough duplicate stream", path: "/p/openai/chat/completions", body: `{"model":"gpt-5-mini","stream":true,"stream":false}`, want: "stream"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			snapshot := NewRequestSnapshot(http.MethodPost, tt.path, nil, nil, nil, "application/json", []byte(tt.body), false, "", nil)
+			env := DeriveWhiteBoxPrompt(snapshot)
+			if env == nil {
+				t.Fatal("DeriveWhiteBoxPrompt() = nil")
+			}
+			if env.DuplicateSelectorField != tt.want {
+				t.Fatalf("DuplicateSelectorField = %q, want %q", env.DuplicateSelectorField, tt.want)
+			}
+			if env.JSONBodyParsed {
+				t.Fatal("JSONBodyParsed = true, want false: a duplicate body yields no selector hints")
+			}
+			if env.RouteHints.Model != "" {
+				t.Fatalf("RouteHints.Model = %q, want empty", env.RouteHints.Model)
+			}
+			err := env.DuplicateSelectorError()
+			if err == nil {
+				t.Fatal("DuplicateSelectorError() = nil, want invalid request error")
+			}
+			var gatewayErr *GatewayError
+			if !errors.As(err, &gatewayErr) || gatewayErr.StatusCode != http.StatusBadRequest {
+				t.Fatalf("DuplicateSelectorError() = %v, want 400 gateway error", err)
+			}
+			if !strings.Contains(err.Error(), `"`+tt.want+`"`) {
+				t.Fatalf("error %q does not name field %q", err.Error(), tt.want)
+			}
+		})
+	}
+}
+
+func TestWhiteBoxPrompt_DuplicateSelectorErrorNilWhenUnique(t *testing.T) {
+	var env *WhiteBoxPrompt
+	if err := env.DuplicateSelectorError(); err != nil {
+		t.Fatalf("nil env error = %v, want nil", err)
+	}
+	if err := (&WhiteBoxPrompt{}).DuplicateSelectorError(); err != nil {
+		t.Fatalf("unique env error = %v, want nil", err)
 	}
 }
 
 func BenchmarkDeriveSnapshotSelectorHintsGJSON(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
-		model, provider, stream, parsed := deriveSnapshotSelectorHintsGJSON(benchmarkSemanticSelectorBody)
-		if !parsed || model != "gpt-5-mini" || provider != "openai" || !stream {
-			b.Fatalf("unexpected selector hints: parsed=%v model=%q provider=%q stream=%v", parsed, model, provider, stream)
+		hints := deriveSnapshotSelectorHintsGJSON(benchmarkSemanticSelectorBody)
+		if !hints.parsed || hints.model != "gpt-5-mini" || hints.provider != "openai" || !hints.stream {
+			b.Fatalf("unexpected selector hints: %+v", hints)
 		}
 	}
 }

--- a/internal/responsecache/simple.go
+++ b/internal/responsecache/simple.go
@@ -248,8 +248,8 @@ func isStreamingRequestGJSON(path string, body []byte) bool {
 		return false
 	}
 	// gjson returns the first matching top-level field. That differs from
-	// encoding/json on duplicate keys, but the cache hot path favors the cheaper
-	// first-match check because duplicate stream fields are not expected.
+	// encoding/json on duplicate keys, but ingress rejects bodies that repeat
+	// the stream field, so the cheaper first-match check is safe here.
 	result := gjson.GetBytes(body, "stream")
 	if !result.Exists() || (result.Type != gjson.True && result.Type != gjson.False) {
 		return false

--- a/internal/server/duplicate_selector_test.go
+++ b/internal/server/duplicate_selector_test.go
@@ -1,0 +1,363 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/enterpilot/gomodel/internal/cache"
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/responsecache"
+)
+
+// JSON parsers disagree on which duplicate object member wins (gjson keeps the
+// first, encoding/json and provider parsers keep the last), so a body such as
+// {"model":"allowed","model":"blocked"} could be authorized as one model and
+// executed as another. These tests pin that every route rejects a repeated
+// top-level model, provider, or stream field before it authorizes, caches,
+// or forwards anything.
+
+const duplicateSelectorErrPrefix = `duplicate top-level \"`
+
+// newDuplicateSelectorPipeline wires the production ingress middleware chain
+// (snapshot capture and workflow resolution) in front of the inference and
+// passthrough handlers.
+func newDuplicateSelectorPipeline(provider *mockProvider, authorizer RequestModelAuthorizer) (*echo.Echo, *Handler) {
+	e := echo.New()
+	e.Use(RequestSnapshotCapture())
+	e.Use(WorkflowResolution(provider))
+	handler := newHandlerWithAuthorizer(provider, nil, nil, nil, nil, authorizer, nil, nil, nil)
+	e.POST("/v1/chat/completions", handler.ChatCompletion)
+	e.POST("/v1/responses", handler.Responses)
+	e.POST("/v1/embeddings", handler.Embeddings)
+	e.POST("/v1/messages", handler.Messages)
+	e.POST("/p/:provider/*", handler.ProviderPassthrough)
+	return e, handler
+}
+
+func newDuplicateSelectorProvider() *mockProvider {
+	return &mockProvider{
+		supportedModels: []string{"allowed-model", "blocked-model", "text-embedding-3-small"},
+		providerTypes: map[string]string{
+			"openai/allowed-model": "openai",
+			"openai/blocked-model": "openai",
+		},
+		// Any provider call would surface as a 502, so a 400 proves the
+		// request never reached the provider.
+		err:          errors.New("provider must not be called for a duplicate selector body"),
+		embeddingErr: errors.New("provider must not be called for a duplicate selector body"),
+		passthroughResponse: &core.PassthroughResponse{
+			StatusCode: http.StatusOK,
+			Headers:    http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+		},
+	}
+}
+
+func assertDuplicateSelectorRejected(t *testing.T, rec *httptest.ResponseRecorder, field string) {
+	t.Helper()
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "body: %s", rec.Body.String())
+	assert.Contains(t, rec.Body.String(), duplicateSelectorErrPrefix+field+`\" field`)
+	assert.NotEqual(t, "text/event-stream", rec.Header().Get("Content-Type"))
+}
+
+func TestDuplicateSelector_TranslatedRoutesRejectedAtIngress(t *testing.T) {
+	tests := []struct {
+		name  string
+		path  string
+		body  string
+		field string
+	}{
+		{
+			name:  "chat duplicate model",
+			path:  "/v1/chat/completions",
+			body:  `{"model":"allowed-model","model":"blocked-model","messages":[{"role":"user","content":"hi"}]}`,
+			field: "model",
+		},
+		{
+			name:  "chat duplicate provider",
+			path:  "/v1/chat/completions",
+			body:  `{"provider":"openai","provider":"groq","model":"allowed-model","messages":[{"role":"user","content":"hi"}]}`,
+			field: "provider",
+		},
+		{
+			name:  "streaming chat duplicate stream",
+			path:  "/v1/chat/completions",
+			body:  `{"model":"allowed-model","stream":true,"stream":false,"messages":[{"role":"user","content":"hi"}]}`,
+			field: "stream",
+		},
+		{
+			name:  "streaming chat duplicate model",
+			path:  "/v1/chat/completions",
+			body:  `{"model":"allowed-model","model":"blocked-model","stream":true,"messages":[{"role":"user","content":"hi"}]}`,
+			field: "model",
+		},
+		{
+			name:  "responses duplicate model",
+			path:  "/v1/responses",
+			body:  `{"model":"allowed-model","model":"blocked-model","input":"hi"}`,
+			field: "model",
+		},
+		{
+			name:  "embeddings duplicate model",
+			path:  "/v1/embeddings",
+			body:  `{"model":"text-embedding-3-small","model":"blocked-model","input":"hi"}`,
+			field: "model",
+		},
+		{
+			name:  "anthropic messages duplicate model",
+			path:  "/v1/messages",
+			body:  `{"model":"allowed-model","model":"blocked-model","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}`,
+			field: "model",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := newDuplicateSelectorProvider()
+			authorizer := &recordingModelAuthorizer{}
+			e, _ := newDuplicateSelectorPipeline(provider, authorizer)
+
+			req := httptest.NewRequest(http.MethodPost, tt.path, strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+
+			assertDuplicateSelectorRejected(t, rec, tt.field)
+			assert.Equal(t, core.ModelSelector{}, authorizer.lastSelector, "no model must be authorized")
+			assert.Equal(t, 0, provider.chatCompletionCalls)
+		})
+	}
+}
+
+func TestDuplicateSelector_TranslatedRouteRejectedWhenBodyIsNotCapturedAtIngress(t *testing.T) {
+	// A duplicate that sits past the selector peek window is only visible once
+	// the full body is read, which must still happen before any dispatch.
+	padding := strings.Repeat("x", int(requestSelectorPeekLimit))
+	tests := []struct {
+		name          string
+		body          string
+		unknownLength bool
+	}{
+		{
+			name:          "unknown length duplicate after first model",
+			body:          `{"model":"allowed-model","messages":[{"role":"user","content":"hi"}],"model":"blocked-model"}`,
+			unknownLength: true,
+		},
+		{
+			name: "oversized body duplicate past the peek window",
+			body: `{"model":"allowed-model","messages":[{"role":"user","content":"` + padding + `"}],"model":"blocked-model"}`,
+		},
+		{
+			name: "oversized body with both selectors peeked then duplicated",
+			body: `{"model":"allowed-model","provider":"openai","messages":[{"role":"user","content":"` + padding + `"}],"model":"blocked-model"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := newDuplicateSelectorProvider()
+			authorizer := &recordingModelAuthorizer{}
+			e, _ := newDuplicateSelectorPipeline(provider, authorizer)
+
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			if tt.unknownLength {
+				req.ContentLength = -1
+			}
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+
+			assertDuplicateSelectorRejected(t, rec, "model")
+			assert.Equal(t, 0, provider.chatCompletionCalls)
+		})
+	}
+}
+
+func TestDuplicateSelector_PassthroughRejectedBeforeForwarding(t *testing.T) {
+	tests := []struct {
+		name          string
+		body          string
+		field         string
+		unknownLength bool
+	}{
+		{
+			name:  "captured body duplicate model",
+			body:  `{"model":"allowed-model","model":"blocked-model","stream":true}`,
+			field: "model",
+		},
+		{
+			name:          "unknown length duplicate model",
+			body:          `{"model":"allowed-model","model":"blocked-model","stream":true}`,
+			field:         "model",
+			unknownLength: true,
+		},
+		{
+			name:  "streaming duplicate stream",
+			body:  `{"model":"allowed-model","stream":true,"stream":false}`,
+			field: "stream",
+		},
+		{
+			name:  "duplicate provider",
+			body:  `{"model":"allowed-model","provider":"openai","provider":"groq"}`,
+			field: "provider",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := newDuplicateSelectorProvider()
+			authorizer := &recordingModelAuthorizer{}
+			e, _ := newDuplicateSelectorPipeline(provider, authorizer)
+
+			req := httptest.NewRequest(http.MethodPost, "/p/openai/chat/completions", strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			if tt.unknownLength {
+				req.ContentLength = -1
+			}
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+
+			assertDuplicateSelectorRejected(t, rec, tt.field)
+			assert.Equal(t, core.ModelSelector{}, authorizer.lastSelector, "no model must be authorized")
+			assert.Nil(t, provider.lastPassthroughReq, "body must not be forwarded upstream")
+		})
+	}
+}
+
+func TestDuplicateSelector_PassthroughHandlerRejectsLateDetectedDuplicate(t *testing.T) {
+	// When ingress only peeked and a later middleware read the whole body
+	// (session detection does this), the handler must still refuse to forward.
+	provider := newDuplicateSelectorProvider()
+	authorizer := &recordingModelAuthorizer{}
+	handler := newHandlerWithAuthorizer(provider, nil, nil, nil, nil, authorizer, nil, nil, nil)
+
+	body := `{"model":"allowed-model","model":"blocked-model"}`
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/p/openai/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	snapshot := core.NewRequestSnapshot(http.MethodPost, "/p/openai/chat/completions", map[string]string{"provider": "openai", "endpoint": "chat/completions"}, nil, nil, "application/json", nil, false, "", nil)
+	ctx := core.WithRequestSnapshot(req.Context(), snapshot)
+	ctx = core.WithWhiteBoxPrompt(ctx, core.DeriveWhiteBoxPrompt(snapshot))
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	// Simulate the late full-body read.
+	_, err := requestBodyBytes(c)
+	require.ErrorContains(t, err, `duplicate top-level "model" field`)
+
+	require.NoError(t, handler.ProviderPassthrough(c))
+	assertDuplicateSelectorRejected(t, rec, "model")
+	assert.Nil(t, provider.lastPassthroughReq, "body must not be forwarded upstream")
+}
+
+type countingCacheStore struct {
+	cache.Store
+	gets int
+	sets int
+}
+
+func (s *countingCacheStore) Get(ctx context.Context, key string) ([]byte, error) {
+	s.gets++
+	return s.Store.Get(ctx, key)
+}
+
+func (s *countingCacheStore) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	s.sets++
+	return s.Store.Set(ctx, key, value, ttl)
+}
+
+func TestDuplicateSelector_CachedRouteRejectedBeforeCacheLookup(t *testing.T) {
+	store := &countingCacheStore{Store: cache.NewMapStore()}
+	rcm := responsecache.NewResponseCacheMiddlewareWithStore(store, time.Hour)
+	defer rcm.Close()
+
+	provider := newDuplicateSelectorProvider()
+	authorizer := &recordingModelAuthorizer{}
+	e, handler := newDuplicateSelectorPipeline(provider, authorizer)
+	handler.responseCache = rcm
+
+	body := `{"model":"allowed-model","model":"blocked-model","messages":[{"role":"user","content":"hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assertDuplicateSelectorRejected(t, rec, "model")
+	assert.Equal(t, 0, store.gets, "cache must not be consulted")
+	assert.Equal(t, 0, store.sets, "cache must not be written")
+}
+
+func TestDuplicateSelector_HandlerRejectsWithoutIngressMiddleware(t *testing.T) {
+	// Embedders and unit tests call handlers directly; the body decode path
+	// must enforce uniqueness on its own.
+	provider := newDuplicateSelectorProvider()
+	authorizer := &recordingModelAuthorizer{}
+	handler := newHandlerWithAuthorizer(provider, nil, nil, nil, nil, authorizer, nil, nil, nil)
+
+	e := echo.New()
+	body := `{"model":"allowed-model","model":"blocked-model","messages":[{"role":"user","content":"hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, handler.ChatCompletion(c))
+	assertDuplicateSelectorRejected(t, rec, "model")
+	assert.Equal(t, core.ModelSelector{}, authorizer.lastSelector)
+	assert.Equal(t, 0, provider.chatCompletionCalls)
+}
+
+func TestDuplicateSelector_UniqueSelectorsStillServed(t *testing.T) {
+	// Only top-level model, provider, and stream must be unique; repeated
+	// members elsewhere keep Postel-style leniency.
+	tests := []struct {
+		name string
+		path string
+		body string
+	}{
+		{
+			name: "chat",
+			path: "/v1/chat/completions",
+			body: `{"model":"allowed-model","messages":[{"role":"user","content":"hi"}]}`,
+		},
+		{
+			name: "chat with nested and non-selector duplicates",
+			path: "/v1/chat/completions",
+			body: `{"model":"allowed-model","n":1,"n":1,"messages":[{"role":"user","content":"hi","model":"a","model":"b"}]}`,
+		},
+		{
+			name: "passthrough",
+			path: "/p/openai/chat/completions",
+			body: `{"model":"allowed-model","stream":false}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := newDuplicateSelectorProvider()
+			provider.err = nil
+			provider.response = &core.ChatResponse{ID: "chatcmpl-1", Object: "chat.completion", Model: "allowed-model"}
+			authorizer := &recordingModelAuthorizer{}
+			e, _ := newDuplicateSelectorPipeline(provider, authorizer)
+
+			req := httptest.NewRequest(http.MethodPost, tt.path, strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+			assert.Equal(t, "allowed-model", authorizer.lastSelector.Model)
+		})
+	}
+}

--- a/internal/server/duplicate_selector_test.go
+++ b/internal/server/duplicate_selector_test.go
@@ -211,6 +211,17 @@ func TestDuplicateSelector_PassthroughRejectedBeforeForwarding(t *testing.T) {
 			body:  `{"model":"allowed-model","provider":"openai","provider":"groq"}`,
 			field: "provider",
 		},
+		{
+			name:  "oversized body with duplicate past the peek window",
+			body:  `{"model":"allowed-model","messages":[{"role":"user","content":"` + strings.Repeat("x", int(requestSelectorPeekLimit)) + `"}],"model":"blocked-model"}`,
+			field: "model",
+		},
+		{
+			name:          "oversized unknown length body with duplicate past the peek window",
+			body:          `{"model":"allowed-model","messages":[{"role":"user","content":"` + strings.Repeat("x", int(requestSelectorPeekLimit)) + `"}],"model":"blocked-model"}`,
+			field:         "model",
+			unknownLength: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -340,6 +351,11 @@ func TestDuplicateSelector_UniqueSelectorsStillServed(t *testing.T) {
 			name: "passthrough",
 			path: "/p/openai/chat/completions",
 			body: `{"model":"allowed-model","stream":false}`,
+		},
+		{
+			name: "oversized passthrough body authorizes the model past the peek window",
+			path: "/p/openai/chat/completions",
+			body: `{"messages":[{"role":"user","content":"` + strings.Repeat("x", int(requestSelectorPeekLimit)) + `"}],"model":"allowed-model"}`,
 		},
 	}
 

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -1169,7 +1169,9 @@ func TestProviderPassthroughRoute_EnabledByDefault(t *testing.T) {
 	}
 }
 
-func TestProviderPassthroughRoute_MarksOversizedStreamIntentUncertain(t *testing.T) {
+func TestProviderPassthroughRoute_ResolvesOversizedBodySelectors(t *testing.T) {
+	// The whole JSON body is scanned before forwarding, so a model or stream
+	// field past the ingress peek window is still authoritative.
 	mock := &mockProvider{
 		passthroughResponse: &core.PassthroughResponse{
 			StatusCode: http.StatusOK,
@@ -1178,7 +1180,7 @@ func TestProviderPassthroughRoute_MarksOversizedStreamIntentUncertain(t *testing
 		},
 	}
 	srv := New(mock, &Config{})
-	body := `{"model":"gpt-5-mini","padding":"` + strings.Repeat("x", 65*1024) + `","stream":true}`
+	body := `{"padding":"` + strings.Repeat("x", 65*1024) + `","model":"gpt-5-mini","stream":true}`
 	req := httptest.NewRequest(http.MethodPost, "/p/openai/responses", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -1188,8 +1190,12 @@ func TestProviderPassthroughRoute_MarksOversizedStreamIntentUncertain(t *testing
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 	}
-	if mock.lastPassthroughReq == nil || !mock.lastPassthroughReq.StreamUncertain {
-		t.Fatalf("passthrough stream metadata = %+v, want uncertain", mock.lastPassthroughReq)
+	got := mock.lastPassthroughReq
+	if got == nil || got.Model != "gpt-5-mini" || !got.Stream || got.StreamUncertain {
+		t.Fatalf("passthrough request = %+v, want model gpt-5-mini with certain stream=true", got)
+	}
+	if forwarded := readPassthroughRequestBody(t, got.Body); forwarded != body {
+		t.Fatal("forwarded body differs from the original")
 	}
 }
 

--- a/internal/server/model_validation.go
+++ b/internal/server/model_validation.go
@@ -146,7 +146,11 @@ func selectorHintsForValidation(c *echo.Context) (model, provider string, parsed
 		}
 	}
 
-	if hints := peekRequestBodySelectorHints(c.Request(), requestSelectorPeekLimit); hints.parsed && (hints.complete || hints.provider != "") {
+	hints := peekRequestBodySelectorHints(c.Request(), requestSelectorPeekLimit)
+	if hints.duplicate != "" {
+		return "", "", false, core.NewDuplicateSelectorFieldError(hints.duplicate)
+	}
+	if hints.parsed && (hints.complete || hints.provider != "") {
 		return hints.model, hints.provider, true, nil
 	}
 
@@ -160,35 +164,37 @@ func selectorHintsForValidation(c *echo.Context) (model, provider string, parsed
 		}
 	}
 
-	model, provider, ok := selectorHintsFromJSONGJSON(bodyBytes)
-	return model, provider, ok, nil
+	return selectorHintsFromJSONGJSON(bodyBytes)
 }
 
 func cachedCanonicalSelectorHints(env *core.WhiteBoxPrompt) (model, provider string, ok bool) {
 	return env.CanonicalSelectorFromCachedRequest()
 }
 
-func selectorHintsFromJSONGJSON(body []byte) (model, provider string, parsed bool) {
+func selectorHintsFromJSONGJSON(body []byte) (model, provider string, parsed bool, err error) {
 	if !gjson.ValidBytes(body) {
-		return "", "", false
+		return "", "", false, nil
 	}
 
 	root := gjson.ParseBytes(body)
 	if !root.IsObject() {
-		return "", "", false
+		return "", "", false, nil
 	}
 
-	// gjson returns the first matching top-level field. That differs from
-	// encoding/json on duplicate keys, but the hot-path speedup is worth it here:
-	// duplicate selector keys are not expected from real clients, and we accept
-	// the first-match behavior to keep workflow resolution fast.
+	// gjson returns the first matching top-level field while encoding/json
+	// keeps the last. A body that repeats a selector field is rejected here so
+	// the model that is authorized is always the model that is executed.
+	if field := core.DuplicateSelectorField(body); field != "" {
+		return "", "", false, core.NewDuplicateSelectorFieldError(field)
+	}
+
 	modelResult := root.Get("model")
 	if !selectorHintValueAllowed(modelResult) {
-		return "", "", false
+		return "", "", false, nil
 	}
 	providerResult := root.Get("provider")
 	if !selectorHintValueAllowed(providerResult) {
-		return "", "", false
+		return "", "", false, nil
 	}
 
 	if modelResult.Type == gjson.String {
@@ -197,7 +203,7 @@ func selectorHintsFromJSONGJSON(body []byte) (model, provider string, parsed boo
 	if providerResult.Type == gjson.String {
 		provider = providerResult.String()
 	}
-	return model, provider, true
+	return model, provider, true, nil
 }
 
 func selectorHintValueAllowed(result gjson.Result) bool {

--- a/internal/server/model_validation_test.go
+++ b/internal/server/model_validation_test.go
@@ -110,6 +110,22 @@ func TestModelValidation(t *testing.T) {
 			handlerCalled:  true,
 		},
 		{
+			name:           "duplicate model field is rejected before resolution",
+			method:         http.MethodPost,
+			path:           "/v1/chat/completions",
+			body:           `{"model":"gpt-4o-mini","model":"openai/gpt-oss-120b","messages":[{"role":"user","content":"hi"}]}`,
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   `duplicate top-level \"model\" field`,
+		},
+		{
+			name:           "duplicate provider field is rejected before resolution",
+			method:         http.MethodPost,
+			path:           "/v1/responses",
+			body:           `{"provider":"openai","provider":"groq","model":"gpt-4o-mini","input":"hello"}`,
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   `duplicate top-level \"provider\" field`,
+		},
+		{
 			name:           "batch path skips root model validation",
 			method:         http.MethodPost,
 			path:           "/v1/batches",
@@ -923,11 +939,12 @@ func TestSelectorHintsFromJSONGJSON_MatchesStdlibSemantics(t *testing.T) {
 		wantModel    string
 		wantProvider string
 		wantParsed   bool
+		wantErr      string
 	}{
 		{name: "model and provider strings", body: `{"provider":"openai","model":"gpt-4o-mini"}`, wantModel: "gpt-4o-mini", wantProvider: "openai", wantParsed: true},
-		{name: "duplicate selector fields use first occurrence", body: `{"provider":"openai","provider":"anthropic","model":"blocked","model":"gpt-4o-mini"}`, wantModel: "blocked", wantProvider: "openai", wantParsed: true},
-		{name: "duplicate null selector keeps first string value", body: `{"provider":"openai","provider":null,"model":"gpt-4o-mini","model":null}`, wantModel: "gpt-4o-mini", wantProvider: "openai", wantParsed: true},
-		{name: "duplicate invalid selector field keeps first value", body: `{"provider":"openai","provider":123}`, wantProvider: "openai", wantParsed: true},
+		{name: "duplicate selector fields are rejected", body: `{"provider":"openai","provider":"anthropic","model":"blocked","model":"gpt-4o-mini"}`, wantErr: "provider"},
+		{name: "duplicate null selector is rejected", body: `{"provider":"openai","model":"gpt-4o-mini","model":null}`, wantErr: "model"},
+		{name: "duplicate invalid selector field is rejected", body: `{"provider":"openai","provider":123}`, wantErr: "provider"},
 		{name: "model only", body: `{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}`, wantModel: "gpt-4o-mini", wantParsed: true},
 		{name: "null selector fields", body: `{"provider":null,"model":null}`, wantParsed: true},
 		{name: "missing selector fields", body: `{"messages":[{"role":"user","content":"hi"}]}`, wantParsed: true},
@@ -940,7 +957,12 @@ func TestSelectorHintsFromJSONGJSON_MatchesStdlibSemantics(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotModel, gotProvider, gotParsed := selectorHintsFromJSONGJSON([]byte(tt.body))
+			gotModel, gotProvider, gotParsed, err := selectorHintsFromJSONGJSON([]byte(tt.body))
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, `duplicate top-level "`+tt.wantErr+`" field`)
+			} else {
+				require.NoError(t, err)
+			}
 			assert.Equal(t, tt.wantModel, gotModel)
 			assert.Equal(t, tt.wantProvider, gotProvider)
 			assert.Equal(t, tt.wantParsed, gotParsed)
@@ -951,8 +973,8 @@ func TestSelectorHintsFromJSONGJSON_MatchesStdlibSemantics(t *testing.T) {
 func BenchmarkSelectorHintsFromJSONGJSON(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
-		model, provider, parsed := selectorHintsFromJSONGJSON(benchmarkSelectorValidationBody)
-		if !parsed || model != "gpt-4o-mini" || provider != "openai" {
+		model, provider, parsed, err := selectorHintsFromJSONGJSON(benchmarkSelectorValidationBody)
+		if err != nil || !parsed || model != "gpt-4o-mini" || provider != "openai" {
 			b.Fatalf("unexpected selector hints: parsed=%v model=%q provider=%q", parsed, model, provider)
 		}
 	}

--- a/internal/server/passthrough_service.go
+++ b/internal/server/passthrough_service.go
@@ -33,6 +33,12 @@ func (s *passthroughService) ProviderPassthrough(c *echo.Context) error {
 	if !isEnabledPassthroughProvider(providerType, s.enabledPassthroughProviders) {
 		return handleError(c, s.unsupportedPassthroughProviderError(providerType))
 	}
+	// The body is forwarded byte-for-byte, so it must not carry a repeated
+	// selector field that the upstream parser could resolve differently from
+	// the selector authorized below.
+	if err := duplicateSelectorError(c); err != nil {
+		return handleError(c, err)
+	}
 	if s.modelAuthorizer != nil {
 		if selector, ok := passthroughAccessSelector(s.provider, info); ok {
 			if err := s.modelAuthorizer.ValidateModelAccess(c.Request().Context(), selector); err != nil {

--- a/internal/server/request_rewrite.go
+++ b/internal/server/request_rewrite.go
@@ -33,6 +33,9 @@ func RequestRewriteMiddleware(rewriters []ext.RequestRewriter, auditLogger audit
 
 			body, err := requestBodyBytes(c)
 			if err != nil {
+				if _, ok := errors.AsType[*core.GatewayError](err); ok {
+					return handleError(c, err)
+				}
 				return handleError(c, core.NewInvalidRequestError("failed to read request body", err))
 			}
 

--- a/internal/server/request_selector_peek.go
+++ b/internal/server/request_selector_peek.go
@@ -36,7 +36,7 @@ func seedRequestBodySelectorHints(req *http.Request, bodyMode core.BodyMode, env
 	}
 
 	if bodyMode == core.BodyModeOpaque {
-		hints := peekCompleteRequestBodySelectorHints(req, requestSelectorPeekLimit)
+		hints := peekCompleteRequestBodySelectorHints(req)
 		if hints.duplicate != "" {
 			return core.NewDuplicateSelectorFieldError(hints.duplicate)
 		}
@@ -104,32 +104,25 @@ func peekRequestBodySelectorHints(req *http.Request, limit int64) requestBodySel
 	return hints
 }
 
-// peekCompleteRequestBodySelectorHints returns authoritative selector hints
-// only when the entire body fits within limit. A unique stream hint may be
-// returned independently from a bounded oversized body, and a duplicate
-// selector field seen anywhere within the window is reported as such. The
-// body is restored before returning so passthrough forwarding remains
-// byte-for-byte unchanged.
-func peekCompleteRequestBodySelectorHints(req *http.Request, limit int64) requestBodySelectorHints {
-	if req == nil || req.Body == nil || limit <= 0 {
+// peekCompleteRequestBodySelectorHints reads the whole JSON body so the
+// selector hints it returns are authoritative for the exact bytes that will
+// be forwarded: a duplicate selector anywhere in the body is reported, and a
+// unique model is retained however large the body is. The body size is
+// already bounded by the body-limit middleware, and the body is restored
+// before returning so passthrough forwarding remains byte-for-byte unchanged.
+func peekCompleteRequestBodySelectorHints(req *http.Request) requestBodySelectorHints {
+	if req == nil || req.Body == nil {
 		return requestBodySelectorHints{}
 	}
 
 	originalBody := req.Body
-	body, err := io.ReadAll(io.LimitReader(originalBody, limit+1))
+	body, err := io.ReadAll(originalBody)
 	req.Body = &combinedReadCloser{
-		Reader: io.MultiReader(bytes.NewReader(body), originalBody),
+		Reader: bytes.NewReader(body),
 		rc:     originalBody,
 	}
 	if err != nil {
 		return requestBodySelectorHints{}
-	}
-	if int64(len(body)) > limit {
-		hints := decodeCompleteRequestBodySelectorHints(bytes.NewReader(body[:limit]))
-		if hints.duplicate != "" {
-			return hints
-		}
-		return hints.independentStreamHint()
 	}
 	return decodeCompleteRequestBodySelectorHints(bytes.NewReader(body))
 }

--- a/internal/server/request_selector_peek.go
+++ b/internal/server/request_selector_peek.go
@@ -21,15 +21,25 @@ type requestBodySelectorHints struct {
 	streamVerified bool
 	parsed         bool
 	complete       bool
+	// duplicate names a top-level selector field the peeked body repeats.
+	// The other fields are meaningless when it is set: the request is
+	// rejected rather than routed on either occurrence.
+	duplicate string
 }
 
-func seedRequestBodySelectorHints(req *http.Request, bodyMode core.BodyMode, env *core.WhiteBoxPrompt) {
+// seedRequestBodySelectorHints peeks selector hints from a body that ingress
+// did not capture. It returns an invalid-request error when the peek sees a
+// repeated top-level selector field.
+func seedRequestBodySelectorHints(req *http.Request, bodyMode core.BodyMode, env *core.WhiteBoxPrompt) error {
 	if !shouldPeekRequestBodySelectors(req, bodyMode, env) {
-		return
+		return nil
 	}
 
 	if bodyMode == core.BodyModeOpaque {
 		hints := peekCompleteRequestBodySelectorHints(req, requestSelectorPeekLimit)
+		if hints.duplicate != "" {
+			return core.NewDuplicateSelectorFieldError(hints.duplicate)
+		}
 		if hints.complete {
 			core.ApplyBodySelectorHints(env, hints.model, hints.provider, hints.stream)
 		} else if hints.streamParsed {
@@ -42,16 +52,20 @@ func seedRequestBodySelectorHints(req *http.Request, bodyMode core.BodyMode, env
 		if !hints.streamParsed {
 			core.MarkPassthroughStreamUncertain(env)
 		}
-		return
+		return nil
 	}
 
 	hints := peekRequestBodySelectorHints(req, requestSelectorPeekLimit)
+	if hints.duplicate != "" {
+		return core.NewDuplicateSelectorFieldError(hints.duplicate)
+	}
 	if hints.parsed || hints.streamParsed {
 		core.ApplyBodySelectorHints(env, hints.model, hints.provider, hints.stream)
 	}
 	if !hints.streamParsed {
 		core.MarkPassthroughStreamUncertain(env)
 	}
+	return nil
 }
 
 func shouldPeekRequestBodySelectors(req *http.Request, bodyMode core.BodyMode, env *core.WhiteBoxPrompt) bool {
@@ -91,10 +105,11 @@ func peekRequestBodySelectorHints(req *http.Request, limit int64) requestBodySel
 }
 
 // peekCompleteRequestBodySelectorHints returns authoritative selector hints
-// only when the entire body fits within limit and has no duplicate selector
-// fields. A unique stream hint may be returned independently from a bounded
-// oversized body. The body is restored before returning so passthrough
-// forwarding remains byte-for-byte unchanged.
+// only when the entire body fits within limit. A unique stream hint may be
+// returned independently from a bounded oversized body, and a duplicate
+// selector field seen anywhere within the window is reported as such. The
+// body is restored before returning so passthrough forwarding remains
+// byte-for-byte unchanged.
 func peekCompleteRequestBodySelectorHints(req *http.Request, limit int64) requestBodySelectorHints {
 	if req == nil || req.Body == nil || limit <= 0 {
 		return requestBodySelectorHints{}
@@ -111,6 +126,9 @@ func peekCompleteRequestBodySelectorHints(req *http.Request, limit int64) reques
 	}
 	if int64(len(body)) > limit {
 		hints := decodeCompleteRequestBodySelectorHints(bytes.NewReader(body[:limit]))
+		if hints.duplicate != "" {
+			return hints
+		}
 		return hints.independentStreamHint()
 	}
 	return decodeCompleteRequestBodySelectorHints(bytes.NewReader(body))
@@ -147,9 +165,8 @@ func decodeRequestBodySelectorHintsWithMode(r io.Reader, requireComplete bool) r
 
 	var hints requestBodySelectorHints
 	var modelSeen, providerSeen, streamSeen bool
-	var modelAmbiguous, providerAmbiguous, streamAmbiguous bool
 	partialHints := func() requestBodySelectorHints {
-		if !hints.streamParsed || streamAmbiguous {
+		if !hints.streamParsed {
 			return requestBodySelectorHints{}
 		}
 		return hints.independentStreamHint()
@@ -166,8 +183,8 @@ func decodeRequestBodySelectorHintsWithMode(r io.Reader, requireComplete bool) r
 
 		switch key {
 		case "model":
-			if requireComplete && modelSeen {
-				modelAmbiguous = true
+			if modelSeen {
+				return requestBodySelectorHints{duplicate: key}
 			}
 			modelSeen = true
 			model, ok, err := readOptionalJSONString(dec)
@@ -183,8 +200,8 @@ func decodeRequestBodySelectorHintsWithMode(r io.Reader, requireComplete bool) r
 				return hints
 			}
 		case "provider":
-			if requireComplete && providerSeen {
-				providerAmbiguous = true
+			if providerSeen {
+				return requestBodySelectorHints{duplicate: key}
 			}
 			providerSeen = true
 			provider, ok, err := readOptionalJSONString(dec)
@@ -198,7 +215,7 @@ func decodeRequestBodySelectorHintsWithMode(r io.Reader, requireComplete bool) r
 			}
 		case "stream":
 			if streamSeen {
-				streamAmbiguous = true
+				return requestBodySelectorHints{duplicate: key}
 			}
 			streamSeen = true
 			stream, ok, err := readOptionalJSONBool(dec)
@@ -221,15 +238,7 @@ func decodeRequestBodySelectorHintsWithMode(r io.Reader, requireComplete bool) r
 		if _, err := dec.Token(); err != io.EOF {
 			return requestBodySelectorHints{}
 		}
-		if streamAmbiguous {
-			return requestBodySelectorHints{}
-		}
 		hints.streamVerified = hints.streamParsed
-		if modelAmbiguous || providerAmbiguous {
-			hints.model = ""
-			hints.provider = ""
-			return hints
-		}
 	}
 
 	hints.parsed = true

--- a/internal/server/request_selector_peek.go
+++ b/internal/server/request_selector_peek.go
@@ -117,8 +117,11 @@ func peekCompleteRequestBodySelectorHints(req *http.Request) requestBodySelector
 
 	originalBody := req.Body
 	body, err := io.ReadAll(originalBody)
+	// Chaining originalBody keeps a read error (such as the body limit being
+	// exceeded) visible to the next reader instead of a clean EOF after the
+	// partial bytes.
 	req.Body = &combinedReadCloser{
-		Reader: bytes.NewReader(body),
+		Reader: io.MultiReader(bytes.NewReader(body), originalBody),
 		rc:     originalBody,
 	}
 	if err != nil {

--- a/internal/server/request_selector_peek_test.go
+++ b/internal/server/request_selector_peek_test.go
@@ -54,7 +54,9 @@ func TestSeedRequestBodySelectorHintsDoesNotMarkModelOnlyPeekAsParsed(t *testing
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-4o-mini","stream":true}`))
 	env := &core.WhiteBoxPrompt{}
 
-	seedRequestBodySelectorHints(req, core.BodyModeJSON, env)
+	if err := seedRequestBodySelectorHints(req, core.BodyModeJSON, env); err != nil {
+		t.Fatalf("seedRequestBodySelectorHints() error = %v", err)
+	}
 
 	if env.JSONBodyParsed {
 		t.Fatal("JSONBodyParsed = true, want false for model-only peek")
@@ -74,7 +76,9 @@ func TestSeedRequestBodySelectorHintsAppliesCompleteModelForOpaqueBody(t *testin
 	env := &core.WhiteBoxPrompt{}
 	core.CachePassthroughRouteInfo(env, &core.PassthroughRouteInfo{Provider: "openai"})
 
-	seedRequestBodySelectorHints(req, core.BodyModeOpaque, env)
+	if err := seedRequestBodySelectorHints(req, core.BodyModeOpaque, env); err != nil {
+		t.Fatalf("seedRequestBodySelectorHints() error = %v", err)
+	}
 
 	if !env.JSONBodyParsed {
 		t.Fatal("JSONBodyParsed = false, want true for complete model-only peek")
@@ -130,7 +134,9 @@ func TestSeedRequestBodySelectorHintsRejectsIncompleteOpaqueModel(t *testing.T) 
 			env := &core.WhiteBoxPrompt{}
 			core.CachePassthroughRouteInfo(env, &core.PassthroughRouteInfo{Provider: "openai"})
 
-			seedRequestBodySelectorHints(req, core.BodyModeOpaque, env)
+			if err := seedRequestBodySelectorHints(req, core.BodyModeOpaque, env); err != nil {
+				t.Fatalf("seedRequestBodySelectorHints() error = %v", err)
+			}
 
 			if env.JSONBodyParsed {
 				t.Fatal("JSONBodyParsed = true, want false for incomplete opaque body")
@@ -160,18 +166,13 @@ func TestSeedRequestBodySelectorHintsRejectsAmbiguousStreamBeforePeekLimit(t *te
 	env := &core.WhiteBoxPrompt{}
 	core.CachePassthroughRouteInfo(env, &core.PassthroughRouteInfo{Provider: "openai"})
 
-	seedRequestBodySelectorHints(req, core.BodyModeOpaque, env)
+	err := seedRequestBodySelectorHints(req, core.BodyModeOpaque, env)
 
-	if env.StreamRequested {
-		t.Fatal("StreamRequested = true, want false for duplicate stream fields")
+	assertDuplicateSelectorError(t, err, "stream")
+	if env.StreamRequested || env.JSONBodyParsed {
+		t.Fatal("duplicate stream fields must not seed any hint")
 	}
-	info := env.CachedPassthroughRouteInfo()
-	if info == nil {
-		t.Fatal("CachedPassthroughRouteInfo() = nil")
-	}
-	if info.Stream || !info.StreamUncertain {
-		t.Fatalf("stream state = stream %v uncertain %v, want false and true", info.Stream, info.StreamUncertain)
-	}
+	assertBodyReplays(t, req, body)
 }
 
 func TestSeedRequestBodySelectorHintsMarksStreamBeyondPeekBoundaryUncertain(t *testing.T) {
@@ -182,7 +183,9 @@ func TestSeedRequestBodySelectorHintsMarksStreamBeyondPeekBoundaryUncertain(t *t
 	env := &core.WhiteBoxPrompt{}
 	core.CachePassthroughRouteInfo(env, &core.PassthroughRouteInfo{Provider: "openai"})
 
-	seedRequestBodySelectorHints(req, core.BodyModeOpaque, env)
+	if err := seedRequestBodySelectorHints(req, core.BodyModeOpaque, env); err != nil {
+		t.Fatalf("seedRequestBodySelectorHints() error = %v", err)
+	}
 
 	if !env.StreamRequested {
 		t.Fatal("StreamRequested = false, want observed prefix hint retained")
@@ -214,21 +217,12 @@ func TestSeedRequestBodySelectorHintsMarksStreamBeyondPeekBoundaryUncertain(t *t
 
 func TestSeedRequestBodySelectorHintsRejectsCompleteDuplicateOpaqueFields(t *testing.T) {
 	tests := []struct {
-		name          string
-		body          string
-		wantStream    bool
-		wantUncertain bool
+		name string
+		body string
 	}{
-		{
-			name:          "stream",
-			body:          `{"stream":true,"stream":false}`,
-			wantUncertain: true,
-		},
-		{
-			name:       "provider",
-			body:       `{"provider":"first","provider":"second","stream":true}`,
-			wantStream: true,
-		},
+		{name: "stream", body: `{"stream":true,"stream":false}`},
+		{name: "provider", body: `{"provider":"first","provider":"second","stream":true}`},
+		{name: "model", body: `{"model":"allowed-model","stream":true,"model":"restricted-model"}`},
 	}
 
 	for _, test := range tests {
@@ -238,65 +232,95 @@ func TestSeedRequestBodySelectorHintsRejectsCompleteDuplicateOpaqueFields(t *tes
 			env := &core.WhiteBoxPrompt{}
 			core.CachePassthroughRouteInfo(env, &core.PassthroughRouteInfo{Provider: "openai"})
 
-			seedRequestBodySelectorHints(req, core.BodyModeOpaque, env)
+			err := seedRequestBodySelectorHints(req, core.BodyModeOpaque, env)
 
+			assertDuplicateSelectorError(t, err, test.name)
 			if env.JSONBodyParsed {
 				t.Fatal("JSONBodyParsed = true, want false for duplicate fields")
 			}
-			if env.RouteHints.Provider != "openai" {
-				t.Fatalf("RouteHints.Provider = %q, want route provider openai", env.RouteHints.Provider)
+			if env.RouteHints.Model != "" {
+				t.Fatalf("RouteHints.Model = %q, want empty", env.RouteHints.Model)
 			}
-			info := env.CachedPassthroughRouteInfo()
-			if info == nil {
-				t.Fatal("CachedPassthroughRouteInfo() = nil")
-			}
-			if info.Stream != test.wantStream || info.StreamUncertain != test.wantUncertain {
-				t.Fatalf("stream state = stream %v uncertain %v, want stream %v uncertain %v", info.Stream, info.StreamUncertain, test.wantStream, test.wantUncertain)
-			}
+			assertBodyReplays(t, req, test.body)
 		})
 	}
 }
 
 func TestSeedRequestBodySelectorHintsRejectsDuplicateOpaqueModel(t *testing.T) {
-	req := httptest.NewRequest(http.MethodPost, "/p/openai/chat/completions", strings.NewReader(`{"model":"allowed-model","stream":true,"model":"restricted-model"}`))
+	body := `{"model":"allowed-model","stream":true,"model":"restricted-model"}`
+	req := httptest.NewRequest(http.MethodPost, "/p/openai/chat/completions", strings.NewReader(body))
 	req.ContentLength = -1
 	req.Header.Set("Content-Type", "application/json")
 	env := &core.WhiteBoxPrompt{}
 	core.CachePassthroughRouteInfo(env, &core.PassthroughRouteInfo{Provider: "openai"})
 
-	seedRequestBodySelectorHints(req, core.BodyModeOpaque, env)
+	err := seedRequestBodySelectorHints(req, core.BodyModeOpaque, env)
 
-	if env.JSONBodyParsed {
-		t.Fatal("JSONBodyParsed = true, want false for duplicate model fields")
+	assertDuplicateSelectorError(t, err, "model")
+	if env.JSONBodyParsed || env.StreamRequested || env.RouteHints.Model != "" {
+		t.Fatalf("env = %+v, want no hints seeded from a duplicate body", env)
 	}
-	if env.RouteHints.Model != "" {
-		t.Fatalf("RouteHints.Model = %q, want empty", env.RouteHints.Model)
+	assertBodyReplays(t, req, body)
+}
+
+func TestSeedRequestBodySelectorHintsRejectsDuplicateTranslatedSelectorWithinPeek(t *testing.T) {
+	body := `{"provider":"openai","provider":"groq","model":"gpt-4o-mini","messages":[]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.ContentLength = -1
+	req.Header.Set("Content-Type", "application/json")
+	env := &core.WhiteBoxPrompt{}
+
+	err := seedRequestBodySelectorHints(req, core.BodyModeJSON, env)
+
+	assertDuplicateSelectorError(t, err, "provider")
+	if env.JSONBodyParsed || env.RouteHints.Provider != "" {
+		t.Fatalf("env = %+v, want no hints seeded from a duplicate body", env)
 	}
-	if !env.StreamRequested {
-		t.Fatal("StreamRequested = false, want true from unique stream field")
+	assertBodyReplays(t, req, body)
+}
+
+func assertDuplicateSelectorError(t *testing.T, err error, field string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("error = nil, want duplicate %q rejection", field)
 	}
-	info := env.CachedPassthroughRouteInfo()
-	if info == nil {
-		t.Fatal("CachedPassthroughRouteInfo() = nil")
+	if !strings.Contains(err.Error(), `duplicate top-level "`+field+`" field`) {
+		t.Fatalf("error = %q, want duplicate %q rejection", err.Error(), field)
 	}
-	if !info.Stream || info.StreamUncertain {
-		t.Fatalf("stream state = stream %v uncertain %v, want true and false", info.Stream, info.StreamUncertain)
+}
+
+// assertBodyReplays verifies the peek left the request body byte-for-byte
+// intact for whoever reads it next.
+func assertBodyReplays(t *testing.T, req *http.Request, want string) {
+	t.Helper()
+	got, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("read replayed body: %v", err)
+	}
+	if string(got) != want {
+		t.Fatalf("replayed body = %q, want %q", got, want)
 	}
 }
 
 func TestDecodeCompleteRequestBodySelectorHintsRejectsAmbiguousBodies(t *testing.T) {
-	bodies := []string{
-		`{"model":"first","model":"second"}`,
-		`{"provider":"first","provider":"second"}`,
-		`{"stream":false,"stream":true}`,
-		`{"model":"gpt-4o-mini"`,
-		`{"model":"gpt-4o-mini"} {}`,
+	tests := []struct {
+		body          string
+		wantDuplicate string
+	}{
+		{body: `{"model":"first","model":"second"}`, wantDuplicate: "model"},
+		{body: `{"provider":"first","provider":"second"}`, wantDuplicate: "provider"},
+		{body: `{"stream":false,"stream":true}`, wantDuplicate: "stream"},
+		{body: `{"model":"gpt-4o-mini"`},
+		{body: `{"model":"gpt-4o-mini"} {}`},
 	}
 
-	for _, body := range bodies {
-		hints := decodeCompleteRequestBodySelectorHints(strings.NewReader(body))
+	for _, tt := range tests {
+		hints := decodeCompleteRequestBodySelectorHints(strings.NewReader(tt.body))
 		if hints.complete {
-			t.Fatalf("decodeCompleteRequestBodySelectorHints(%q).complete = true, want false", body)
+			t.Fatalf("decodeCompleteRequestBodySelectorHints(%q).complete = true, want false", tt.body)
+		}
+		if hints.duplicate != tt.wantDuplicate {
+			t.Fatalf("decodeCompleteRequestBodySelectorHints(%q).duplicate = %q, want %q", tt.body, hints.duplicate, tt.wantDuplicate)
 		}
 	}
 }
@@ -328,7 +352,9 @@ func TestSeedRequestBodySelectorHintsTracksStreamConfidenceIndependently(t *test
 			env := &core.WhiteBoxPrompt{}
 			core.CachePassthroughRouteInfo(env, &core.PassthroughRouteInfo{Provider: "openai"})
 
-			seedRequestBodySelectorHints(req, core.BodyModeJSON, env)
+			if err := seedRequestBodySelectorHints(req, core.BodyModeJSON, env); err != nil {
+				t.Fatalf("seedRequestBodySelectorHints() error = %v", err)
+			}
 
 			info := env.CachedPassthroughRouteInfo()
 			if info == nil {

--- a/internal/server/request_selector_peek_test.go
+++ b/internal/server/request_selector_peek_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -176,6 +177,48 @@ func TestSeedRequestBodySelectorHintsRejectsAmbiguousStreamBeforePeekLimit(t *te
 		t.Fatal("duplicate stream fields must not seed any hint")
 	}
 	assertBodyReplays(t, req, body)
+}
+
+type failingAfterReadCloser struct {
+	reader *strings.Reader
+	err    error
+}
+
+func (r *failingAfterReadCloser) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	if err == io.EOF {
+		return n, r.err
+	}
+	return n, err
+}
+
+func (r *failingAfterReadCloser) Close() error { return nil }
+
+func TestSeedRequestBodySelectorHintsPreservesOpaqueBodyReadError(t *testing.T) {
+	// A body-limit error must reach the forwarding handler, not turn into a
+	// clean EOF after the bytes that were read before it.
+	readErr := errors.New("request entity too large")
+	req := httptest.NewRequest(http.MethodPost, "/p/openai/chat/completions", nil)
+	req.Body = &failingAfterReadCloser{reader: strings.NewReader(`{"model":"gpt-4o-mini"`), err: readErr}
+	req.ContentLength = -1
+	req.Header.Set("Content-Type", "application/json")
+	env := &core.WhiteBoxPrompt{}
+	core.CachePassthroughRouteInfo(env, &core.PassthroughRouteInfo{Provider: "openai"})
+
+	if err := seedRequestBodySelectorHints(req, core.BodyModeOpaque, env); err != nil {
+		t.Fatalf("seedRequestBodySelectorHints() error = %v", err)
+	}
+
+	if env.JSONBodyParsed || env.RouteHints.Model != "" {
+		t.Fatalf("env = %+v, want no hints from an unreadable body", env)
+	}
+	got, err := io.ReadAll(req.Body)
+	if !errors.Is(err, readErr) {
+		t.Fatalf("replayed body error = %v, want %v", err, readErr)
+	}
+	if string(got) != `{"model":"gpt-4o-mini"` {
+		t.Fatalf("replayed body = %q, want the bytes read before the error", got)
+	}
 }
 
 func TestSeedRequestBodySelectorHintsRejectsDuplicateStreamBeyondPeekBoundary(t *testing.T) {

--- a/internal/server/request_selector_peek_test.go
+++ b/internal/server/request_selector_peek_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -108,25 +107,26 @@ func TestSeedRequestBodySelectorHintsAppliesCompleteModelForOpaqueBody(t *testin
 	}
 }
 
-func TestSeedRequestBodySelectorHintsRejectsIncompleteOpaqueModel(t *testing.T) {
+func TestSeedRequestBodySelectorHintsScansOversizedOpaqueBodyCompletely(t *testing.T) {
+	padding := strings.Repeat("x", int(requestSelectorPeekLimit))
 	tests := []struct {
 		name          string
-		prefix        string
+		body          string
+		wantModel     string
 		wantStream    bool
-		wantUncertain bool
+		wantDuplicate string
 		knownLength   bool
 	}{
-		{name: "model first", prefix: `{"model":"allowed-model","padding":"`, wantUncertain: true},
-		{name: "stream first", prefix: `{"stream":true,"model":"allowed-model","padding":"`, wantStream: true, wantUncertain: true},
-		{name: "model before stream", prefix: `{"model":"allowed-model","stream":true,"padding":"`, wantStream: true, wantUncertain: true},
-		{name: "model before stream with known length", prefix: `{"model":"allowed-model","stream":true,"padding":"`, wantStream: true, wantUncertain: true, knownLength: true},
-		{name: "stream before oversized value", prefix: `{"stream":true,"padding":"`, wantStream: true, wantUncertain: true},
+		{name: "model past the peek window", body: `{"stream":true,"padding":"` + padding + `","model":"late-model"}`, wantModel: "late-model", wantStream: true},
+		{name: "model past the peek window with known length", body: `{"stream":false,"padding":"` + padding + `","model":"late-model"}`, wantModel: "late-model", knownLength: true},
+		{name: "duplicate model past the peek window", body: `{"model":"allowed-model","padding":"` + padding + `","model":"restricted-model"}`, wantDuplicate: "model"},
+		{name: "duplicate stream past the peek window", body: `{"stream":true,"padding":"` + padding + `","stream":false}`, wantDuplicate: "stream"},
+		{name: "duplicate provider past the peek window with known length", body: `{"provider":"a","padding":"` + padding + `","provider":"b"}`, wantDuplicate: "provider", knownLength: true},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			body := test.prefix + strings.Repeat("x", int(requestSelectorPeekLimit)) + `","model":"restricted-model"}`
-			req := httptest.NewRequest(http.MethodPost, "/p/openai/chat/completions", strings.NewReader(body))
+			req := httptest.NewRequest(http.MethodPost, "/p/openai/chat/completions", strings.NewReader(test.body))
 			if !test.knownLength {
 				req.ContentLength = -1
 			}
@@ -134,26 +134,29 @@ func TestSeedRequestBodySelectorHintsRejectsIncompleteOpaqueModel(t *testing.T) 
 			env := &core.WhiteBoxPrompt{}
 			core.CachePassthroughRouteInfo(env, &core.PassthroughRouteInfo{Provider: "openai"})
 
-			if err := seedRequestBodySelectorHints(req, core.BodyModeOpaque, env); err != nil {
-				t.Fatalf("seedRequestBodySelectorHints() error = %v", err)
-			}
+			err := seedRequestBodySelectorHints(req, core.BodyModeOpaque, env)
 
-			if env.JSONBodyParsed {
-				t.Fatal("JSONBodyParsed = true, want false for incomplete opaque body")
+			if test.wantDuplicate != "" {
+				assertDuplicateSelectorError(t, err, test.wantDuplicate)
+				if env.JSONBodyParsed || env.RouteHints.Model != "" {
+					t.Fatalf("env = %+v, want no hints seeded from a duplicate body", env)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("seedRequestBodySelectorHints() error = %v", err)
+				}
+				if !env.JSONBodyParsed {
+					t.Fatal("JSONBodyParsed = false, want true for a fully scanned body")
+				}
+				info := env.CachedPassthroughRouteInfo()
+				if info == nil {
+					t.Fatal("CachedPassthroughRouteInfo() = nil")
+				}
+				if info.Model != test.wantModel || info.Stream != test.wantStream || info.StreamUncertain {
+					t.Fatalf("passthrough info = model %q stream %v uncertain %v, want model %q stream %v certain", info.Model, info.Stream, info.StreamUncertain, test.wantModel, test.wantStream)
+				}
 			}
-			if env.RouteHints.Model != "" {
-				t.Fatalf("RouteHints.Model = %q, want empty", env.RouteHints.Model)
-			}
-			info := env.CachedPassthroughRouteInfo()
-			if info == nil {
-				t.Fatal("CachedPassthroughRouteInfo() = nil")
-			}
-			if info.Model != "" {
-				t.Fatalf("PassthroughRouteInfo.Model = %q, want empty", info.Model)
-			}
-			if info.Stream != test.wantStream || info.StreamUncertain != test.wantUncertain {
-				t.Fatalf("stream state = stream %v uncertain %v, want stream %v uncertain %v", info.Stream, info.StreamUncertain, test.wantStream, test.wantUncertain)
-			}
+			assertBodyReplays(t, req, test.body)
 		})
 	}
 }
@@ -175,7 +178,7 @@ func TestSeedRequestBodySelectorHintsRejectsAmbiguousStreamBeforePeekLimit(t *te
 	assertBodyReplays(t, req, body)
 }
 
-func TestSeedRequestBodySelectorHintsMarksStreamBeyondPeekBoundaryUncertain(t *testing.T) {
+func TestSeedRequestBodySelectorHintsRejectsDuplicateStreamBeyondPeekBoundary(t *testing.T) {
 	body := `{"stream":true,"padding":"` + strings.Repeat("x", int(requestSelectorPeekLimit)) + `","stream":false}`
 	req := httptest.NewRequest(http.MethodPost, "/p/openai/chat/completions", strings.NewReader(body))
 	req.ContentLength = -1
@@ -183,36 +186,13 @@ func TestSeedRequestBodySelectorHintsMarksStreamBeyondPeekBoundaryUncertain(t *t
 	env := &core.WhiteBoxPrompt{}
 	core.CachePassthroughRouteInfo(env, &core.PassthroughRouteInfo{Provider: "openai"})
 
-	if err := seedRequestBodySelectorHints(req, core.BodyModeOpaque, env); err != nil {
-		t.Fatalf("seedRequestBodySelectorHints() error = %v", err)
-	}
+	err := seedRequestBodySelectorHints(req, core.BodyModeOpaque, env)
 
-	if !env.StreamRequested {
-		t.Fatal("StreamRequested = false, want observed prefix hint retained")
+	assertDuplicateSelectorError(t, err, "stream")
+	if env.StreamRequested {
+		t.Fatal("StreamRequested = true, want no hint from a duplicate body")
 	}
-	info := env.CachedPassthroughRouteInfo()
-	if info == nil {
-		t.Fatal("CachedPassthroughRouteInfo() = nil")
-	}
-	if !info.Stream || !info.StreamUncertain {
-		t.Fatalf("stream state = stream %v uncertain %v, want true and true", info.Stream, info.StreamUncertain)
-	}
-	restored, err := io.ReadAll(req.Body)
-	if err != nil {
-		t.Fatalf("read restored body: %v", err)
-	}
-	if string(restored) != body {
-		t.Fatal("restored body differs from original")
-	}
-	var forwarded struct {
-		Stream bool `json:"stream"`
-	}
-	if err := json.Unmarshal(restored, &forwarded); err != nil {
-		t.Fatalf("decode restored body: %v", err)
-	}
-	if forwarded.Stream {
-		t.Fatal("forwarded stream = true, want last duplicate false to demonstrate uncertainty")
-	}
+	assertBodyReplays(t, req, body)
 }
 
 func TestSeedRequestBodySelectorHintsRejectsCompleteDuplicateOpaqueFields(t *testing.T) {

--- a/internal/server/request_snapshot.go
+++ b/internal/server/request_snapshot.go
@@ -83,8 +83,15 @@ func RequestSnapshotCapture(userPathHeader ...string) echo.MiddlewareFunc {
 			ctx := core.WithUserPathHeaderName(req.Context(), userPathHeaderName)
 			ctx = core.WithRequestSnapshot(ctx, snapshot)
 			if semantics := core.DeriveWhiteBoxPrompt(snapshot); semantics != nil {
+				// A body that repeats model, provider, or stream is rejected
+				// before any routing, authorization, or forwarding reads it.
+				if err := semantics.DuplicateSelectorError(); err != nil {
+					return handleError(c, err)
+				}
 				if !bodyCaptured {
-					seedRequestBodySelectorHints(req, desc.BodyMode, semantics)
+					if err := seedRequestBodySelectorHints(req, desc.BodyMode, semantics); err != nil {
+						return handleError(c, err)
+					}
 				}
 				ctx = core.WithWhiteBoxPrompt(ctx, semantics)
 			}
@@ -222,9 +229,16 @@ func (c *combinedReadCloser) Close() error {
 	return c.rc.Close()
 }
 
+// requestBodyBytes returns the full request body, reading and caching it on
+// the snapshot when ingress only peeked. It fails with an invalid-request
+// error when the body repeats a top-level selector field, so late readers
+// never act on a body whose model, provider, or stream is ambiguous.
 func requestBodyBytes(c *echo.Context) ([]byte, error) {
 	if snapshot := core.GetRequestSnapshot(c.Request().Context()); snapshot != nil {
 		if body := snapshot.CapturedBodyView(); body != nil {
+			if err := duplicateSelectorError(c); err != nil {
+				return nil, err
+			}
 			return body, nil
 		}
 	}
@@ -243,7 +257,14 @@ func requestBodyBytes(c *echo.Context) ([]byte, error) {
 	}
 	req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 	storeRequestBodySnapshot(c, bodyBytes)
+	if err := duplicateSelectorError(c); err != nil {
+		return nil, err
+	}
 	return bodyBytes, nil
+}
+
+func duplicateSelectorError(c *echo.Context) error {
+	return core.GetWhiteBoxPrompt(c.Request().Context()).DuplicateSelectorError()
 }
 
 func storeRequestBodySnapshot(c *echo.Context, bodyBytes []byte) {

--- a/internal/server/semantic_requests.go
+++ b/internal/server/semantic_requests.go
@@ -34,6 +34,9 @@ func semanticJSONBody(c *echo.Context) ([]byte, *core.WhiteBoxPrompt, error) {
 	}
 	if refreshed := core.GetWhiteBoxPrompt(c.Request().Context()); refreshed != nil {
 		env = refreshed
+	} else if field := core.DuplicateSelectorField(bodyBytes); field != "" {
+		// Without an ingress envelope nobody has checked the body yet.
+		return nil, nil, core.NewDuplicateSelectorFieldError(field)
 	}
 	return bodyBytes, env, nil
 }


### PR DESCRIPTION
## Summary

Selector parsing used gjson's first-duplicate-key semantics while `encoding/json` and upstream provider parsers keep the last key. A body such as `{"model":"allowed-model","model":"blocked-model","stream":true}` on a passthrough route was authorized as `allowed-model` and then forwarded byte-for-byte, so the provider ran `blocked-model`. On translated routes the same body produced a silent mismatch between the requested and executed model.

Every route now rejects a JSON body that repeats a top-level `model`, `provider`, or `stream` member with `400 invalid_request_error` before anything is authorized, cached, or forwarded.

## Changes

- `core.DuplicateSelectorField` is the single check: a zero-copy scan of the top-level members that handles escaped keys and ignores nested duplicates. Ingress hint derivation flags the envelope instead of picking an occurrence.
- `RequestSnapshotCapture` rejects captured bodies at ingress. For translated routes the bounded peek reports a duplicate it sees, and the later full-body read catches the rest.
- Passthrough JSON bodies that ingress did not capture are now read in full (already bounded by the body-limit middleware) before the selector is authorized, so a duplicate or a model past the old 64KB peek window is no longer invisible. As a side effect, oversized passthrough bodies now carry a definite model and stream intent instead of an uncertain one.
- `requestBodyBytes` fails when a late full-body read reveals a duplicate, covering every handler that reads the body itself (including `/v1/messages`).
- The passthrough service refuses to forward a flagged request, and workflow resolution's fallback parser rejects duplicates when no ingress envelope exists.
- Docs: request body validation note in `api-endpoints.mdx` and `passthrough-api.mdx`.

## User-visible impact

Requests that repeat one of the three selector fields at the top level now get a 400 instead of being routed on an arbitrary occurrence. Repeated members nested inside other objects, and repeated non-selector members, are still accepted. Passthrough JSON bodies larger than 64KB are buffered before forwarding, as translated bodies already were.

## Tests

Regression coverage for chat, responses, embeddings, Anthropic messages, streaming, passthrough (captured, unknown-length, streaming, oversized, late detection), the cached route (cache store sees no lookups), oversized bodies whose duplicate sits past the peek window, and the handler-only path without ingress middleware. Ingress hint derivation benchmark stays at 3 allocs/op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YDsyuAJgGrZv4RZzJJpHcs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Requests with duplicate top-level `model`, `provider`, or `stream` fields now return a `400 invalid_request_error`.
  * Validation occurs before authorization, routing, caching, forwarding, or dispatch across translated and passthrough routes.
  * Valid passthrough requests continue to be forwarded byte-for-byte, including oversized bodies.
  * Nested duplicates and repeated non-selector fields remain supported.

* **Documentation**
  * Added guidance on request-body validation and passthrough JSON handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->