### PR TITLE
feat(opencode_go): send x-opencode-session and client identification headers

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -641,6 +641,10 @@
 # (default: low). Some models always think and reject requests that omit it.
 # Accepts low, high, max; set to "none" (or "off") to inject nothing.
 # OPENCODE_GO_DEFAULT_REASONING_EFFORT=low
+# Forward x-opencode-session (the client's own header, else the detected session
+# id) so OpenCode Zen can keep one conversation's prompt cache warm. Upstream
+# requires it; leave enabled unless asked otherwise (default: true).
+# OPENCODE_GO_SESSION_HEADER=true
 
 # Azure OpenAI
 # AZURE_API_KEY=...

--- a/docs/features/session-keeping.mdx
+++ b/docs/features/session-keeping.mdx
@@ -34,6 +34,7 @@ The first matching signal wins:
    | Header | Sent by |
    |---|---|
    | `X-Session-Id` | OpenCode, Kilo Code, generic clients |
+   | `X-Opencode-Session` | OpenCode, pi, and other clients speaking OpenCode Zen's dialect |
    | `X-Claude-Code-Session-Id` | Claude Code (documented for gateways) |
    | `Session-Id` / `Session_id` | Codex CLI (current / older), Roo Code |
    | `X-Litellm-Session-Id` | LiteLLM convention |

--- a/docs/providers/opencode-go.mdx
+++ b/docs/providers/opencode-go.mdx
@@ -68,6 +68,33 @@ OPENCODE_GO_MESSAGES_MODELS=qwen3.7-max
   once the upstream model list distinguishes endpoints.
 </Note>
 
+## Session header
+
+OpenCode Zen asks every client to send an `x-opencode-session` header so it
+can route one conversation to the same upstream and keep its prompt cache
+warm. Upstream has announced that requests without it may start failing.
+GoModel adds the header to every OpenCode Go request by default, on both the
+`/chat/completions` and `/messages` paths, using the first available value:
+
+1. An `x-opencode-session` header sent by the client (OpenCode itself, pi, and
+   other tools that speak OpenCode Zen's dialect) is forwarded verbatim.
+2. Otherwise the session GoModel detected through
+   [session keeping](/features/session-keeping): OpenCode's `X-Session-Id`,
+   Claude Code's session id, a session body field, or the content-derived
+   `auto-…` id for agents that send no signal at all.
+
+A request with no detectable session is sent without the header. GoModel also
+identifies itself with `x-opencode-client` (forwarding the client's own value
+when present, `gomodel` otherwise) and a `gomodel/<version>` User-Agent, as
+the upstream [usage guidelines](https://opencode.ai/docs/go/#where-can-i-use-it)
+require.
+
+Disable session forwarding only if upstream asks you to:
+
+```bash
+OPENCODE_GO_SESSION_HEADER=false
+```
+
 ## Reasoning
 
 Some OpenCode Zen models always think and reject requests that leave the

--- a/internal/providers/anthropic/anthropic.go
+++ b/internal/providers/anthropic/anthropic.go
@@ -59,6 +59,10 @@ var allowedAnthropicImageMediaTypes = map[string]struct{}{
 type Provider struct {
 	client *llmclient.Client
 	keys   *providers.Keyring
+	// requestHeaders optionally adds per-request headers to every outbound
+	// call; providers that reuse the Anthropic dialect behind another
+	// upstream (OpenCode Go) use it for their identification headers.
+	requestHeaders func(context.Context) http.Header
 
 	batchEndpointsMu sync.RWMutex
 	// batchResultEndpoints keeps endpoint hints by provider batch id and custom_id.
@@ -102,6 +106,12 @@ func NewWithHTTPClient(apiKey string, httpClient *http.Client, hooks llmclient.H
 // SetBaseURL allows configuring a custom base URL for the provider
 func (p *Provider) SetBaseURL(url string) {
 	p.client.SetBaseURL(url)
+}
+
+// SetRequestHeaders installs a hook whose headers are added to every outbound
+// request after the standard auth and version headers.
+func (p *Provider) SetRequestHeaders(fn func(context.Context) http.Header) {
+	p.requestHeaders = fn
 }
 
 func cloneBatchResultEndpoints(endpoints map[string]string) map[string]string {
@@ -196,6 +206,15 @@ func (p *Provider) setHeaders(req *http.Request) {
 	// Forward request ID if present in context
 	if requestID := core.GetRequestID(req.Context()); requestID != "" {
 		req.Header.Set("X-Request-Id", requestID)
+	}
+
+	if p.requestHeaders != nil {
+		for name, values := range p.requestHeaders(req.Context()) {
+			req.Header.Del(name)
+			for _, value := range values {
+				req.Header.Add(name, value)
+			}
+		}
 	}
 }
 

--- a/internal/providers/anthropic/request_headers_test.go
+++ b/internal/providers/anthropic/request_headers_test.go
@@ -1,0 +1,47 @@
+package anthropic
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/llmclient"
+)
+
+func TestSetRequestHeaders_AddsHookHeadersToEveryRequest(t *testing.T) {
+	var got http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("test-api-key", server.Client(), llmclient.Hooks{})
+	provider.SetBaseURL(server.URL)
+	provider.SetRequestHeaders(func(ctx context.Context) http.Header {
+		return http.Header{
+			"X-Extra":    {"from-hook", "second"},
+			"User-Agent": {"gomodel-test"},
+		}
+	})
+
+	_, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{
+		Model:    "claude-sonnet-4-6",
+		Messages: []core.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("ChatCompletion() error = %v", err)
+	}
+	if v := got.Values("X-Extra"); len(v) != 2 || v[0] != "from-hook" || v[1] != "second" {
+		t.Fatalf("X-Extra = %v, want [from-hook second]", v)
+	}
+	if v := got.Get("User-Agent"); v != "gomodel-test" {
+		t.Fatalf("User-Agent = %q, want gomodel-test (hook replaces the default)", v)
+	}
+	if got.Get("x-api-key") != "test-api-key" || got.Get("anthropic-version") == "" {
+		t.Fatalf("standard headers must survive the hook, got %v", got)
+	}
+}

--- a/internal/providers/anthropic/request_headers_test.go
+++ b/internal/providers/anthropic/request_headers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/enterpilot/gomodel/internal/core"
@@ -11,9 +12,14 @@ import (
 )
 
 func TestSetRequestHeaders_AddsHookHeadersToEveryRequest(t *testing.T) {
-	var got http.Header
+	var (
+		mu  sync.Mutex
+		got http.Header
+	)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		got = r.Header.Clone()
+		mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
 	}))
@@ -35,6 +41,8 @@ func TestSetRequestHeaders_AddsHookHeadersToEveryRequest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ChatCompletion() error = %v", err)
 	}
+	mu.Lock()
+	defer mu.Unlock()
 	if v := got.Values("X-Extra"); len(v) != 2 || v[0] != "from-hook" || v[1] != "second" {
 		t.Fatalf("X-Extra = %v, want [from-hook second]", v)
 	}

--- a/internal/providers/opencodego/opencodego.go
+++ b/internal/providers/opencodego/opencodego.go
@@ -209,6 +209,8 @@ func withDefaultHeaders(headers, defaults http.Header) http.Header {
 	return merged
 }
 
+// hasHeader reports whether headers carries a non-empty entry for name under
+// any casing of the key.
 func hasHeader(headers http.Header, name string) bool {
 	for key, values := range headers {
 		if strings.EqualFold(key, name) && len(values) > 0 {

--- a/internal/providers/opencodego/opencodego.go
+++ b/internal/providers/opencodego/opencodego.go
@@ -72,10 +72,14 @@ var _ core.Provider = (*Provider)(nil)
 // New creates a new OpenCode Go provider.
 func New(cfg providers.ProviderConfig, opts providers.ProviderOptions) core.Provider {
 	baseURL := providers.ResolveBaseURL(cfg.BaseURL, defaultBaseURL)
-	chat := openai.NewChatCompatible(cfg.APIKey, opts, compatibleConfig(baseURL))
+	headers := requestHeaders(loadSessionHeaderEnabled())
+	chat := openai.NewChatCompatible(cfg.APIKey, opts, compatibleConfig(baseURL, headers))
 	// opts carries the shared keyring, so the /messages client rotates in step
 	// with the chat client above rather than pinning the primary key.
 	messages := anthropic.New(providers.ProviderConfig{APIKey: cfg.APIKey, APIKeys: cfg.APIKeys, BaseURL: baseURL}, opts)
+	if native, ok := messages.(*anthropic.Provider); ok {
+		native.SetRequestHeaders(headers)
+	}
 	return &Provider{
 		ChatCompatible: chat,
 		messages:       messages,
@@ -87,9 +91,11 @@ func New(cfg providers.ProviderConfig, opts providers.ProviderOptions) core.Prov
 // If httpClient is nil, http.DefaultClient is used.
 func NewWithHTTPClient(apiKey string, baseURL string, httpClient *http.Client, hooks llmclient.Hooks) *Provider {
 	resolved := providers.ResolveBaseURL(baseURL, defaultBaseURL)
-	chat := openai.NewChatCompatibleWithHTTPClient(apiKey, httpClient, hooks, compatibleConfig(resolved))
+	headers := requestHeaders(loadSessionHeaderEnabled())
+	chat := openai.NewChatCompatibleWithHTTPClient(apiKey, httpClient, hooks, compatibleConfig(resolved, headers))
 	messages := anthropic.NewWithHTTPClient(apiKey, httpClient, hooks)
 	messages.SetBaseURL(resolved)
+	messages.SetRequestHeaders(headers)
 	return &Provider{
 		ChatCompatible: chat,
 		messages:       messages,
@@ -99,13 +105,15 @@ func NewWithHTTPClient(apiKey string, baseURL string, httpClient *http.Client, h
 
 // compatibleConfig describes the OpenAI-compatible /chat/completions half of
 // the provider. The AdaptChatRequest hook carries OpenCode Zen's reasoning
-// quirk (see reasoning.go), so /v1/responses picks it up through
-// ResponsesViaChat as well.
-func compatibleConfig(baseURL string) openai.CompatibleProviderConfig {
+// quirk (see reasoning.go) and ChatRequestHeaders its session/client
+// identification headers (see session.go), so /v1/responses picks both up
+// through ResponsesViaChat as well.
+func compatibleConfig(baseURL string, headers func(context.Context) http.Header) openai.CompatibleProviderConfig {
 	return openai.CompatibleProviderConfig{
-		ProviderName:     "opencode_go",
-		BaseURL:          baseURL,
-		AdaptChatRequest: adaptChatRequest(loadDefaultReasoningEffort()),
+		ProviderName:       "opencode_go",
+		BaseURL:            baseURL,
+		AdaptChatRequest:   adaptChatRequest(loadDefaultReasoningEffort()),
+		ChatRequestHeaders: chatRequestHeaders(headers),
 	}
 }
 

--- a/internal/providers/opencodego/opencodego.go
+++ b/internal/providers/opencodego/opencodego.go
@@ -65,6 +65,10 @@ type Provider struct {
 	*openai.ChatCompatible
 	messages       messagesProvider
 	messagesModels map[string]struct{}
+	// headers yields the session/client identification headers (session.go).
+	// Typed requests receive them through the ChatCompatible and Anthropic
+	// hooks; Passthrough merges them under the caller's opaque headers.
+	headers func(context.Context) http.Header
 }
 
 var _ core.Provider = (*Provider)(nil)
@@ -84,6 +88,7 @@ func New(cfg providers.ProviderConfig, opts providers.ProviderOptions) core.Prov
 		ChatCompatible: chat,
 		messages:       messages,
 		messagesModels: loadMessagesModels(),
+		headers:        headers,
 	}
 }
 
@@ -100,6 +105,7 @@ func NewWithHTTPClient(apiKey string, baseURL string, httpClient *http.Client, h
 		ChatCompatible: chat,
 		messages:       messages,
 		messagesModels: loadMessagesModels(),
+		headers:        headers,
 	}
 }
 
@@ -171,6 +177,45 @@ func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*
 // /v1/responses honors the per-model /messages routing.
 func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
 	return providers.StreamResponsesViaChat(ctx, p, req, "opencode_go")
+}
+
+// Passthrough forwards an opaque request with the identification headers
+// filled in wherever the caller did not send its own. Passthrough is opaque
+// by contract, so a caller-provided x-opencode-session, x-opencode-client, or
+// User-Agent always wins over the gateway's value.
+func (p *Provider) Passthrough(ctx context.Context, req *core.PassthroughRequest) (*core.PassthroughResponse, error) {
+	if req == nil || p.headers == nil {
+		return p.ChatCompatible.Passthrough(ctx, req)
+	}
+	merged := *req
+	merged.Headers = withDefaultHeaders(req.Headers, p.headers(ctx))
+	return p.ChatCompatible.Passthrough(ctx, &merged)
+}
+
+// withDefaultHeaders returns a copy of headers with every entry of defaults
+// added that headers does not already carry. Names are compared
+// case-insensitively so a non-canonical caller key still counts as present.
+func withDefaultHeaders(headers, defaults http.Header) http.Header {
+	merged := headers.Clone()
+	if merged == nil {
+		merged = make(http.Header, len(defaults))
+	}
+	for name, values := range defaults {
+		if hasHeader(merged, name) {
+			continue
+		}
+		merged[http.CanonicalHeaderKey(name)] = values
+	}
+	return merged
+}
+
+func hasHeader(headers http.Header, name string) bool {
+	for key, values := range headers {
+		if strings.EqualFold(key, name) && len(values) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // Embeddings returns an error because OpenCode Go does not expose an embeddings endpoint.

--- a/internal/providers/opencodego/session.go
+++ b/internal/providers/opencodego/session.go
@@ -1,0 +1,113 @@
+package opencodego
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/version"
+)
+
+const (
+	// sessionHeader is the header OpenCode Zen uses to route every request of
+	// one conversation to the same upstream so its prompt cache stays warm.
+	// Upstream documents it as required for third-party clients.
+	sessionHeader = "x-opencode-session"
+	// clientHeader identifies the calling tool to OpenCode Zen. Upstream asks
+	// clients to identify themselves instead of using generic user agents.
+	clientHeader = "x-opencode-client"
+	// defaultClient is sent when the inbound request carries no client name.
+	defaultClient = "gomodel"
+)
+
+// sessionHeaderEnvVar toggles forwarding of x-opencode-session. It defaults to
+// enabled; set it to false to leave the header out.
+const sessionHeaderEnvVar = "OPENCODE_GO_SESSION_HEADER"
+
+// loadSessionHeaderEnabled reports whether x-opencode-session should be sent,
+// honoring OPENCODE_GO_SESSION_HEADER. Unset, empty, or unparsable values keep
+// the default of true.
+func loadSessionHeaderEnabled() bool {
+	raw, configured := os.LookupEnv(sessionHeaderEnvVar)
+	if !configured || strings.TrimSpace(raw) == "" {
+		return true
+	}
+	enabled, err := strconv.ParseBool(strings.TrimSpace(raw))
+	if err != nil {
+		slog.Warn("invalid OpenCode Go session header flag; using default",
+			"env", sessionHeaderEnvVar,
+			"value", raw,
+			"default", true)
+		return true
+	}
+	return enabled
+}
+
+// requestHeaders returns the per-request identification headers OpenCode Zen
+// expects from a gateway: x-opencode-session (when enabled and a session is
+// known), x-opencode-client, and a non-generic User-Agent. The same set is
+// applied on both the /chat/completions and /messages paths.
+func requestHeaders(sessionEnabled bool) func(context.Context) http.Header {
+	userAgent := "gomodel/" + version.Version
+	return func(ctx context.Context) http.Header {
+		headers := make(http.Header, 3)
+		headers.Set("User-Agent", userAgent)
+		client := inboundHeader(ctx, clientHeader)
+		if client == "" {
+			client = defaultClient
+		}
+		headers.Set(clientHeader, client)
+		if sessionEnabled {
+			if id := sessionID(ctx); id != "" {
+				headers.Set(sessionHeader, id)
+			}
+		}
+		return headers
+	}
+}
+
+// chatRequestHeaders adapts requestHeaders to the ChatRequestHeaders hook
+// signature of the OpenAI-compatible provider.
+func chatRequestHeaders(fn func(context.Context) http.Header) func(context.Context, *core.ChatRequest) http.Header {
+	return func(ctx context.Context, _ *core.ChatRequest) http.Header {
+		return fn(ctx)
+	}
+}
+
+// sessionID resolves the value for x-opencode-session. A client that already
+// speaks OpenCode Zen's dialect (OpenCode itself, pi, …) sends the header and
+// its value is forwarded verbatim; otherwise the session id GoModel detected
+// (X-Session-Id, Claude Code's session, a body field, or the content-derived
+// auto id) stands in, so any coding agent gets cache affinity for free.
+func sessionID(ctx context.Context) string {
+	if id := inboundHeader(ctx, sessionHeader); id != "" {
+		return id
+	}
+	return core.SessionIDFromContext(ctx)
+}
+
+// inboundHeader returns the first usable value of name on the captured
+// inbound request, or "" when absent. Values carrying line breaks are
+// ignored so a client cannot inject headers upstream.
+func inboundHeader(ctx context.Context, name string) string {
+	snapshot := core.GetRequestSnapshot(ctx)
+	if snapshot == nil {
+		return ""
+	}
+	for key, values := range snapshot.HeadersView() {
+		if !strings.EqualFold(key, name) {
+			continue
+		}
+		for _, value := range values {
+			value = strings.TrimSpace(value)
+			if value != "" && !strings.ContainsAny(value, "\r\n") {
+				return value
+			}
+		}
+	}
+	return ""
+}

--- a/internal/providers/opencodego/session_test.go
+++ b/internal/providers/opencodego/session_test.go
@@ -1,0 +1,195 @@
+package opencodego
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/version"
+)
+
+// headerServer records the request headers of the last call and answers with
+// a minimal chat completion (or SSE stream) so both endpoint dialects succeed.
+func headerServer(t *testing.T) (*httptest.Server, func() http.Header) {
+	t.Helper()
+	var (
+		mu   sync.Mutex
+		last http.Header
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		last = r.Header.Clone()
+		mu.Unlock()
+		if r.Header.Get("Accept") == "text/event-stream" {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = w.Write([]byte("data: [DONE]\n\n"))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/messages" {
+			_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","model":"qwen3.7-max","content":[{"type":"text","text":"hello"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-1","created":1,"model":"glm-5.1","choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}]}`))
+	}))
+	t.Cleanup(server.Close)
+	return server, func() http.Header {
+		mu.Lock()
+		defer mu.Unlock()
+		return last
+	}
+}
+
+func snapshotContext(ctx context.Context, headers map[string][]string) context.Context {
+	snapshot := core.NewRequestSnapshot(http.MethodPost, "/v1/chat/completions", nil, nil, headers, "application/json", nil, false, "req-1", nil)
+	return core.WithRequestSnapshot(ctx, snapshot)
+}
+
+func chatRequest(model string) *core.ChatRequest {
+	return &core.ChatRequest{Model: model, Messages: []core.Message{{Role: "user", Content: "hi"}}}
+}
+
+func TestRequestHeaders_DetectedSessionForwarded(t *testing.T) {
+	server, last := headerServer(t)
+	ctx := core.WithSessionID(context.Background(), "session-123")
+
+	for _, model := range []string{"glm-5.1", "qwen3.7-max"} {
+		t.Run(model, func(t *testing.T) {
+			if _, err := newTestProvider(server.URL, server.Client()).ChatCompletion(ctx, chatRequest(model)); err != nil {
+				t.Fatalf("ChatCompletion() error = %v", err)
+			}
+			got := last()
+			if v := got.Get(sessionHeader); v != "session-123" {
+				t.Fatalf("%s = %q, want session-123", sessionHeader, v)
+			}
+			if v := got.Get(clientHeader); v != defaultClient {
+				t.Fatalf("%s = %q, want %s", clientHeader, v, defaultClient)
+			}
+			if v := got.Get("User-Agent"); v != "gomodel/"+version.Version {
+				t.Fatalf("User-Agent = %q, want gomodel/%s", v, version.Version)
+			}
+		})
+	}
+}
+
+func TestRequestHeaders_StreamCarriesSession(t *testing.T) {
+	server, last := headerServer(t)
+	ctx := core.WithSessionID(context.Background(), "session-stream")
+
+	for _, model := range []string{"glm-5.1", "qwen3.7-max"} {
+		t.Run(model, func(t *testing.T) {
+			body, err := newTestProvider(server.URL, server.Client()).StreamChatCompletion(ctx, chatRequest(model))
+			if err != nil {
+				t.Fatalf("StreamChatCompletion() error = %v", err)
+			}
+			_, _ = io.ReadAll(body)
+			_ = body.Close()
+			if v := last().Get(sessionHeader); v != "session-stream" {
+				t.Fatalf("%s = %q, want session-stream", sessionHeader, v)
+			}
+		})
+	}
+}
+
+func TestRequestHeaders_InboundOpenCodeHeadersWin(t *testing.T) {
+	server, last := headerServer(t)
+	ctx := core.WithSessionID(context.Background(), "scoped-detected")
+	ctx = snapshotContext(ctx, map[string][]string{
+		"X-Opencode-Session": {"ses_client"},
+		"X-Opencode-Client":  {"pi"},
+	})
+
+	if _, err := newTestProvider(server.URL, server.Client()).ChatCompletion(ctx, chatRequest("glm-5.1")); err != nil {
+		t.Fatalf("ChatCompletion() error = %v", err)
+	}
+	got := last()
+	if v := got.Get(sessionHeader); v != "ses_client" {
+		t.Fatalf("%s = %q, want ses_client", sessionHeader, v)
+	}
+	if v := got.Get(clientHeader); v != "pi" {
+		t.Fatalf("%s = %q, want pi", clientHeader, v)
+	}
+}
+
+func TestRequestHeaders_NoSessionSendsNoSessionHeader(t *testing.T) {
+	server, last := headerServer(t)
+
+	if _, err := newTestProvider(server.URL, server.Client()).ChatCompletion(context.Background(), chatRequest("glm-5.1")); err != nil {
+		t.Fatalf("ChatCompletion() error = %v", err)
+	}
+	got := last()
+	if _, ok := got[http.CanonicalHeaderKey(sessionHeader)]; ok {
+		t.Fatalf("%s should be absent without a session, got %q", sessionHeader, got.Get(sessionHeader))
+	}
+	if v := got.Get(clientHeader); v != defaultClient {
+		t.Fatalf("%s = %q, want %s", clientHeader, v, defaultClient)
+	}
+}
+
+func TestRequestHeaders_Disabled(t *testing.T) {
+	t.Setenv(sessionHeaderEnvVar, "false")
+	server, last := headerServer(t)
+	ctx := core.WithSessionID(context.Background(), "session-123")
+	ctx = snapshotContext(ctx, map[string][]string{"X-Opencode-Session": {"ses_client"}})
+
+	for _, model := range []string{"glm-5.1", "qwen3.7-max"} {
+		t.Run(model, func(t *testing.T) {
+			if _, err := newTestProvider(server.URL, server.Client()).ChatCompletion(ctx, chatRequest(model)); err != nil {
+				t.Fatalf("ChatCompletion() error = %v", err)
+			}
+			got := last()
+			if _, ok := got[http.CanonicalHeaderKey(sessionHeader)]; ok {
+				t.Fatalf("%s should be absent when disabled, got %q", sessionHeader, got.Get(sessionHeader))
+			}
+			if v := got.Get(clientHeader); v != defaultClient {
+				t.Fatalf("%s = %q, want %s (identification is not gated)", clientHeader, v, defaultClient)
+			}
+		})
+	}
+}
+
+func TestInboundHeader_RejectsLineBreaks(t *testing.T) {
+	ctx := snapshotContext(context.Background(), map[string][]string{
+		"X-Opencode-Session": {"bad\r\nvalue", "  good  "},
+	})
+	if got := inboundHeader(ctx, sessionHeader); got != "good" {
+		t.Fatalf("inboundHeader() = %q, want good", got)
+	}
+	if got := inboundHeader(context.Background(), sessionHeader); got != "" {
+		t.Fatalf("inboundHeader() without snapshot = %q, want empty", got)
+	}
+}
+
+func TestLoadSessionHeaderEnabled(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		unset bool
+		want  bool
+	}{
+		{name: "unset defaults on", unset: true, want: true},
+		{name: "empty defaults on", value: "  ", want: true},
+		{name: "false", value: "false", want: false},
+		{name: "zero", value: "0", want: false},
+		{name: "true", value: "true", want: true},
+		{name: "garbage defaults on", value: "maybe", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.unset {
+				t.Setenv(sessionHeaderEnvVar, "") // registers cleanup, then unset for real
+				_ = os.Unsetenv(sessionHeaderEnvVar)
+			} else {
+				t.Setenv(sessionHeaderEnvVar, tt.value)
+			}
+			if got := loadSessionHeaderEnabled(); got != tt.want {
+				t.Fatalf("loadSessionHeaderEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/providers/opencodego/session_test.go
+++ b/internal/providers/opencodego/session_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 
@@ -150,6 +151,59 @@ func TestRequestHeaders_Disabled(t *testing.T) {
 				t.Fatalf("%s = %q, want %s (identification is not gated)", clientHeader, v, defaultClient)
 			}
 		})
+	}
+}
+
+func TestPassthrough_FillsMissingIdentificationHeaders(t *testing.T) {
+	server, last := headerServer(t)
+	ctx := core.WithSessionID(context.Background(), "session-pass")
+
+	resp, err := newTestProvider(server.URL, server.Client()).Passthrough(ctx, &core.PassthroughRequest{
+		Method:   http.MethodPost,
+		Endpoint: "chat/completions",
+		Body:     io.NopCloser(strings.NewReader(`{"model":"glm-5.1","messages":[{"role":"user","content":"hi"}]}`)),
+		Headers:  http.Header{"Content-Type": {"application/json"}, "X-Opencode-Client": {"curl-script"}},
+	})
+	if err != nil {
+		t.Fatalf("Passthrough() error = %v", err)
+	}
+	_ = resp.Body.Close()
+	got := last()
+	if v := got.Get(sessionHeader); v != "session-pass" {
+		t.Fatalf("%s = %q, want session-pass", sessionHeader, v)
+	}
+	if v := got.Get(clientHeader); v != "curl-script" {
+		t.Fatalf("%s = %q, want caller value curl-script", clientHeader, v)
+	}
+	if v := got.Get("User-Agent"); v != "gomodel/"+version.Version {
+		t.Fatalf("User-Agent = %q, want gomodel/%s", v, version.Version)
+	}
+}
+
+func TestWithDefaultHeaders(t *testing.T) {
+	defaults := http.Header{"X-Opencode-Session": {"gw"}, "User-Agent": {"gomodel/dev"}}
+	merged := withDefaultHeaders(nil, defaults)
+	if merged.Get("X-Opencode-Session") != "gw" || merged.Get("User-Agent") != "gomodel/dev" {
+		t.Fatalf("nil headers should take every default, got %v", merged)
+	}
+	// A non-canonical caller key still counts as present and is not duplicated.
+	caller := http.Header{}
+	caller[strings.ToLower("X-Opencode-Session")] = []string{"mine"}
+	merged = withDefaultHeaders(caller, defaults)
+	var sessionValues []string
+	for key, values := range merged {
+		if strings.EqualFold(key, "X-Opencode-Session") {
+			sessionValues = append(sessionValues, values...)
+		}
+	}
+	if len(sessionValues) != 1 || sessionValues[0] != "mine" {
+		t.Fatalf("caller value should win without duplication, got %v", merged)
+	}
+	if merged.Get("User-Agent") != "gomodel/dev" {
+		t.Fatalf("missing default should be added, got %v", merged)
+	}
+	if len(caller) != 1 {
+		t.Fatalf("caller headers must not be mutated, got %v", caller)
 	}
 }
 

--- a/internal/providers/opencodego/session_test.go
+++ b/internal/providers/opencodego/session_test.go
@@ -19,13 +19,23 @@ import (
 // a minimal chat completion (or SSE stream) so both endpoint dialects succeed.
 func headerServer(t *testing.T) (*httptest.Server, func() http.Header) {
 	t.Helper()
+	server, last, _ := headerServerWithPath(t)
+	return server, last
+}
+
+// headerServerWithPath is headerServer with a third accessor for the request
+// path of the last call.
+func headerServerWithPath(t *testing.T) (*httptest.Server, func() http.Header, func() string) {
+	t.Helper()
 	var (
-		mu   sync.Mutex
-		last http.Header
+		mu       sync.Mutex
+		last     http.Header
+		lastSeen string
 	)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
 		last = r.Header.Clone()
+		lastSeen = r.URL.Path
 		mu.Unlock()
 		if r.Header.Get("Accept") == "text/event-stream" {
 			w.Header().Set("Content-Type", "text/event-stream")
@@ -41,10 +51,14 @@ func headerServer(t *testing.T) (*httptest.Server, func() http.Header) {
 	}))
 	t.Cleanup(server.Close)
 	return server, func() http.Header {
-		mu.Lock()
-		defer mu.Unlock()
-		return last
-	}
+			mu.Lock()
+			defer mu.Unlock()
+			return last
+		}, func() string {
+			mu.Lock()
+			defer mu.Unlock()
+			return lastSeen
+		}
 }
 
 func snapshotContext(ctx context.Context, headers map[string][]string) context.Context {
@@ -156,16 +170,31 @@ func TestRequestHeaders_Disabled(t *testing.T) {
 }
 
 func TestNew_FactoryConstructorWiresHeadersOnBothPaths(t *testing.T) {
-	server, last := headerServer(t)
+	// Pin the env-driven defaults so an inherited override cannot disable the
+	// header or reroute the /messages model through /chat/completions.
+	t.Setenv(sessionHeaderEnvVar, "")
+	t.Setenv(messagesModelsEnvVar, "qwen3.7-max")
+	server, last, lastPath := headerServerWithPath(t)
 	ctx := core.WithSessionID(context.Background(), "session-factory")
 	provider := New(providers.ProviderConfig{APIKey: "sk-opencode", BaseURL: server.URL}, providers.ProviderOptions{})
 
-	for _, model := range []string{"glm-5.1", "qwen3.7-max"} {
-		t.Run(model, func(t *testing.T) {
-			if _, err := provider.ChatCompletion(ctx, chatRequest(model)); err != nil {
+	tests := []struct {
+		model    string
+		wantPath string
+	}{
+		{model: "glm-5.1", wantPath: "/chat/completions"},
+		{model: "qwen3.7-max", wantPath: "/messages"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			if _, err := provider.ChatCompletion(ctx, chatRequest(tt.model)); err != nil {
 				t.Fatalf("ChatCompletion() error = %v", err)
 			}
-			if v := last().Get(sessionHeader); v != "session-factory" {
+			got, path := last(), lastPath()
+			if path != tt.wantPath {
+				t.Fatalf("path = %q, want %s", path, tt.wantPath)
+			}
+			if v := got.Get(sessionHeader); v != "session-factory" {
 				t.Fatalf("%s = %q, want session-factory", sessionHeader, v)
 			}
 		})

--- a/internal/providers/opencodego/session_test.go
+++ b/internal/providers/opencodego/session_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/providers"
 	"github.com/enterpilot/gomodel/internal/version"
 )
 
@@ -149,6 +150,23 @@ func TestRequestHeaders_Disabled(t *testing.T) {
 			}
 			if v := got.Get(clientHeader); v != defaultClient {
 				t.Fatalf("%s = %q, want %s (identification is not gated)", clientHeader, v, defaultClient)
+			}
+		})
+	}
+}
+
+func TestNew_FactoryConstructorWiresHeadersOnBothPaths(t *testing.T) {
+	server, last := headerServer(t)
+	ctx := core.WithSessionID(context.Background(), "session-factory")
+	provider := New(providers.ProviderConfig{APIKey: "sk-opencode", BaseURL: server.URL}, providers.ProviderOptions{})
+
+	for _, model := range []string{"glm-5.1", "qwen3.7-max"} {
+		t.Run(model, func(t *testing.T) {
+			if _, err := provider.ChatCompletion(ctx, chatRequest(model)); err != nil {
+				t.Fatalf("ChatCompletion() error = %v", err)
+			}
+			if v := last().Get(sessionHeader); v != "session-factory" {
+				t.Fatalf("%s = %q, want session-factory", sessionHeader, v)
 			}
 		})
 	}

--- a/internal/session/detect_test.go
+++ b/internal/session/detect_test.go
@@ -43,6 +43,14 @@ func TestDetectPrecedence(t *testing.T) {
 			want: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
 		},
 		{
+			name: "opencode zen session header",
+			headers: map[string][]string{
+				"X-Opencode-Session": {"ses_0123456789abcdef"},
+			},
+			body: body,
+			want: "ses_0123456789abcdef",
+		},
+		{
 			name: "codex session-id header",
 			headers: map[string][]string{
 				"Session-Id": {"99999999-8888-7777-6666-555555555555"},

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -37,7 +37,8 @@ const (
 // fields). Sources: Claude Code documents x-claude-code-session-id for
 // gateways; Codex CLI sends session-id (older releases session_id, which Roo
 // Code also uses on Responses API providers); OpenCode and Kilo Code send
-// x-session-id; Goose sends agent-session-id; x-litellm-session-id and
+// x-session-id; clients speaking OpenCode Zen's dialect (OpenCode, pi) send
+// x-opencode-session; Goose sends agent-session-id; x-litellm-session-id and
 // helicone-session-id are gateway conventions. Body fields: metadata.user_id
 // (Claude Code via /v1/messages), session_id (OpenRouter convention),
 // litellm_session_id (LiteLLM), prompt_cache_key (Zed and other OpenAI
@@ -45,6 +46,7 @@ const (
 // conversation references.
 var builtinRules = []Rule{
 	{Source: SourceHeader, Header: "X-Session-Id"},
+	{Source: SourceHeader, Header: "X-Opencode-Session"},
 	{Source: SourceHeader, Header: "X-Claude-Code-Session-Id"},
 	{Source: SourceHeader, Header: "Session-Id"},
 	{Source: SourceHeader, Header: "Session_id"},


### PR DESCRIPTION
## Why

OpenCode Go now [requires](https://opencode.ai/docs/go/#where-can-i-use-it) third-party clients to send an `x-opencode-session` header so it can keep one conversation's prompt cache warm, and has announced that requests without it may start erroring on 09/06. OpenCode itself only sends that header when talking to an `opencode*` provider directly; through GoModel it sends `X-Session-Id`, which GoModel detected but never forwarded. The same guidelines also ask clients to identify themselves instead of using a generic user agent, and GoModel was sending Go's default `Go-http-client/1.1`.

## What

- The `opencode_go` provider adds `x-opencode-session` to every upstream request, on both the `/chat/completions` and Anthropic-dialect `/messages` paths. The value is the client's own `x-opencode-session` when present (OpenCode direct, pi), otherwise the session id GoModel detected (`X-Session-Id`, Claude Code session, body fields, or the content-derived `auto-…` id). No session means no header.
- It also sends `x-opencode-client` (client's value if sent, else `gomodel`) and a `gomodel/<version>` User-Agent.
- New `OPENCODE_GO_SESSION_HEADER` env var, default `true`, disables session forwarding.
- The Anthropic provider gains a `SetRequestHeaders` hook so dialect-reusing providers can add per-request headers.
- `X-Opencode-Session` joins the built-in session-keeping rules.

## Docs

Provider page, session-keeping header table, and `.env.template` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KeyPkFdzL2CC77MxgDBSEx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - OpenCode Go requests now include session, client identification, and User-Agent headers when available.
  - Session information can be forwarded from incoming requests or detected automatically.
  - Caller-provided identification headers are preserved during passthrough requests.
  - Session header forwarding is enabled by default and can be disabled with `OPENCODE_GO_SESSION_HEADER=false`.

- **Documentation**
  - Added guidance for OpenCode Go session, client, and User-Agent headers.
  - Documented recognition of the `X-Opencode-Session` header across supported clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->