### PR TITLE
feat(http): trust private CAs and client certificates on every outbound connection

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -136,6 +136,16 @@
 # HTTP_TIMEOUT=600
 # Time to wait for response headers (default: 600)
 # HTTP_RESPONSE_HEADER_TIMEOUT=600
+# Outbound proxy: the standard HTTP_PROXY / HTTPS_PROXY / NO_PROXY variables
+# apply to every upstream connection the gateway opens.
+# Client TLS trust for outbound HTTPS. Default: the operating system store.
+# Private CA bundle (PEM) for a TLS-intercepting proxy or internal model servers:
+# HTTP_TLS_CA_FILE=/etc/gomodel/ca.pem
+# Client certificate (mTLS); set both together:
+# HTTP_TLS_CLIENT_CERT_FILE=/etc/gomodel/tls.crt
+# HTTP_TLS_CLIENT_KEY_FILE=/etc/gomodel/tls.key
+# Disable certificate verification (lab use only; logged as a warning):
+# HTTP_TLS_INSECURE_SKIP_VERIFY=false
 
 # Security Configuration
 # CRITICAL: Set this to secure your gateway from unauthorized access

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -299,6 +299,14 @@ opentelemetry:
 http:
   timeout: 600 # seconds (10 minutes)
   response_header_timeout: 600
+  # Client TLS trust for every outbound HTTPS connection (providers, model
+  # catalog, update check, MCP upstreams, vector stores). All optional; the
+  # default trusts the operating system certificate store.
+  tls:
+    # ca_file: /etc/gomodel/ca.pem            # private CA bundle (PEM), appended to the system store
+    # client_cert_file: /etc/gomodel/tls.crt  # mTLS client certificate; set both files together
+    # client_key_file: /etc/gomodel/tls.key
+    # insecure_skip_verify: false             # lab use only; logs a warning
 
 workflows:
   refresh_interval: 1m

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -89,7 +89,7 @@ func clearAllConfigEnvVars(t *testing.T) {
 		"GUARDRAILS_ENABLED", "ENABLE_GUARDRAILS_FOR_BATCH_PROCESSING",
 		"FAILOVER_MODE", "FAILOVER_MANUAL_RULES_PATH", "FAILOVER_ENABLED", "FAILOVER_RULES_JSON", "FAILOVER_DISABLED_MODELS", "FAILOVER_DISABLED_MODELS_JSON",
 		"MODELS_ENABLED_BY_DEFAULT", "KEEP_ONLY_ALIASES_AT_MODELS_ENDPOINT", "UNQUALIFIED_MODEL_IDS_AT_MODELS_ENDPOINT", "CONFIGURED_PROVIDER_MODELS_MODE",
-		"HTTP_TIMEOUT", "HTTP_RESPONSE_HEADER_TIMEOUT",
+		"HTTP_TIMEOUT", "HTTP_RESPONSE_HEADER_TIMEOUT", "HTTP_TLS_CA_FILE", "HTTP_TLS_CLIENT_CERT_FILE", "HTTP_TLS_CLIENT_KEY_FILE", "HTTP_TLS_INSECURE_SKIP_VERIFY",
 		"WORKFLOW_REFRESH_INTERVAL",
 	} {
 		t.Setenv(key, "")
@@ -2289,5 +2289,35 @@ func TestIsLocalModelListSource(t *testing.T) {
 		if got := IsLocalModelListSource(tt.in); got != tt.want {
 			t.Errorf("IsLocalModelListSource(%q) = %v, want %v", tt.in, got, tt.want)
 		}
+	}
+}
+
+func TestLoadHTTPTLSEnvOverrides(t *testing.T) {
+	clearAllConfigEnvVars(t)
+	t.Setenv("HTTP_TLS_CA_FILE", "/etc/gomodel/ca.pem")
+	t.Setenv("HTTP_TLS_CLIENT_CERT_FILE", "/etc/gomodel/client.crt")
+	t.Setenv("HTTP_TLS_CLIENT_KEY_FILE", "/etc/gomodel/client.key")
+	t.Setenv("HTTP_TLS_INSECURE_SKIP_VERIFY", "true")
+
+	result, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	got := result.Config.HTTP.TLS
+	if got.CAFile != "/etc/gomodel/ca.pem" {
+		t.Errorf("CAFile = %q", got.CAFile)
+	}
+	if got.ClientCertFile != "/etc/gomodel/client.crt" || got.ClientKeyFile != "/etc/gomodel/client.key" {
+		t.Errorf("client pair = %q / %q", got.ClientCertFile, got.ClientKeyFile)
+	}
+	if !got.InsecureSkipVerify {
+		t.Error("InsecureSkipVerify should be true")
+	}
+}
+
+func TestDefaultHTTPTLSIsSystemTrust(t *testing.T) {
+	cfg := buildDefaultConfig()
+	if cfg.HTTP.TLS != (HTTPTLSConfig{}) {
+		t.Errorf("expected zero TLS config by default, got %+v", cfg.HTTP.TLS)
 	}
 }

--- a/config/http.go
+++ b/config/http.go
@@ -10,4 +10,27 @@ type HTTPConfig struct {
 
 	// ResponseHeaderTimeout is the time to wait for response headers in seconds (default: 600)
 	ResponseHeaderTimeout int `yaml:"response_header_timeout" env:"HTTP_RESPONSE_HEADER_TIMEOUT"`
+
+	// TLS configures client-side trust for every outbound HTTPS connection.
+	TLS HTTPTLSConfig `yaml:"tls"`
+}
+
+// HTTPTLSConfig configures client TLS trust for outbound connections: providers,
+// the model catalog, the update check, MCP upstreams, vector stores, and
+// embedding endpoints. All fields are optional; the zero value trusts the
+// operating system certificate store.
+type HTTPTLSConfig struct {
+	// CAFile is a PEM bundle of additional root certificates, appended to the
+	// system store. Set it for a private CA behind a TLS-intercepting proxy or
+	// in front of local model servers.
+	CAFile string `yaml:"ca_file" env:"HTTP_TLS_CA_FILE"`
+
+	// ClientCertFile and ClientKeyFile present a client certificate (mTLS) to
+	// upstreams that request one. Both must be set together.
+	ClientCertFile string `yaml:"client_cert_file" env:"HTTP_TLS_CLIENT_CERT_FILE"`
+	ClientKeyFile  string `yaml:"client_key_file" env:"HTTP_TLS_CLIENT_KEY_FILE"`
+
+	// InsecureSkipVerify disables certificate verification for every outbound
+	// connection. Lab use only; the gateway logs a warning at startup.
+	InsecureSkipVerify bool `yaml:"insecure_skip_verify" env:"HTTP_TLS_INSECURE_SKIP_VERIFY"`
 }

--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -291,6 +291,28 @@ These control timeouts for upstream API requests to LLM providers.
 | `HTTP_TIMEOUT`                 | Overall request timeout in seconds           | `600` (10 min) |
 | `HTTP_RESPONSE_HEADER_TIMEOUT` | Time to wait for response headers in seconds | `600` (10 min) |
 
+The standard `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` variables apply to
+every upstream connection.
+
+#### Outbound TLS trust
+
+These apply to every outbound HTTPS connection: providers, the model catalog,
+the update check, MCP upstreams, vector stores, and embedding endpoints. The
+default trusts the operating system certificate store, which is right unless an
+internal CA or a TLS-intercepting proxy sits between the gateway and upstreams.
+
+| Variable                        | Description                                                        | Default |
+| ------------------------------- | ------------------------------------------------------------------ | ------- |
+| `HTTP_TLS_CA_FILE`              | PEM bundle of extra root certificates, appended to the system store | unset   |
+| `HTTP_TLS_CLIENT_CERT_FILE`     | Client certificate for mTLS; set together with the key             | unset   |
+| `HTTP_TLS_CLIENT_KEY_FILE`      | Private key for the client certificate                             | unset   |
+| `HTTP_TLS_INSECURE_SKIP_VERIFY` | Disable certificate verification. Lab use only; logged as a warning | `false` |
+
+A missing or unparseable file is a startup error, so a typo in the path cannot
+silently fall back to trusting nothing extra. See the
+[production guide](/guides/production#private-cas-and-proxies) for a worked
+example.
+
 #### Provider API Keys
 
 Set these to automatically register providers. No YAML configuration required.

--- a/docs/guides/production.mdx
+++ b/docs/guides/production.mdx
@@ -243,6 +243,38 @@ If a Bedrock provider is configured, the AWS SDK may also probe the link-local
 instance metadata endpoint (`169.254.169.254`) for credentials. An air-gapped
 install would not configure Bedrock, but it is worth knowing.
 
+## Private CAs and proxies
+
+Every outbound connection the gateway opens shares one HTTP transport, so
+proxy and trust settings are configured once and apply to providers, the model
+catalog, the update check, MCP upstreams, vector stores, and embedding
+endpoints alike.
+
+**Proxy.** Set the standard `HTTPS_PROXY` (and `NO_PROXY` for local model
+servers). Nothing else is needed.
+
+**Private CA.** Mount the CA bundle and point the gateway at it:
+
+```bash
+HTTP_TLS_CA_FILE=/etc/gomodel/ca.pem
+```
+
+The bundle is appended to the system store, so public providers keep working
+next to internal ones. A missing or empty file fails startup rather than
+silently trusting less than you asked for.
+
+**Mutual TLS.** When an internal model server or egress proxy requires a client
+certificate:
+
+```bash
+HTTP_TLS_CLIENT_CERT_FILE=/etc/gomodel/tls.crt
+HTTP_TLS_CLIENT_KEY_FILE=/etc/gomodel/tls.key
+```
+
+The same settings live under `http.tls` in `config.yaml`. Avoid
+`HTTP_TLS_INSECURE_SKIP_VERIFY=true` outside a lab: it disables verification
+for every upstream, and the gateway warns about it at startup.
+
 ## Running more than one replica
 
 Request handling is stateless, so replicas need no affinity for ordinary

--- a/docs/guides/production.mdx
+++ b/docs/guides/production.mdx
@@ -251,7 +251,9 @@ catalog, the update check, MCP upstreams, vector stores, and embedding
 endpoints alike.
 
 **Proxy.** Set the standard `HTTPS_PROXY` (and `NO_PROXY` for local model
-servers). Nothing else is needed.
+servers). Nothing else is needed. If the proxy needs credentials, give it an
+`https://` URL: the scheme in `HTTPS_PROXY` describes the hop to the proxy,
+and an `http://` proxy URL sends `Proxy-Authorization` in cleartext.
 
 **Private CA.** Mount the CA bundle and point the gateway at it:
 

--- a/docs/guides/production.mdx
+++ b/docs/guides/production.mdx
@@ -250,10 +250,13 @@ proxy and trust settings are configured once and apply to providers, the model
 catalog, the update check, MCP upstreams, vector stores, and embedding
 endpoints alike.
 
-**Proxy.** Set the standard `HTTPS_PROXY` (and `NO_PROXY` for local model
-servers). Nothing else is needed. If the proxy needs credentials, give it an
-`https://` URL: the scheme in `HTTPS_PROXY` describes the hop to the proxy,
-and an `http://` proxy URL sends `Proxy-Authorization` in cleartext.
+**Proxy.** Set the standard `HTTPS_PROXY` and `HTTP_PROXY` (each covers
+upstreams of its own scheme; most deployments only talk to `https://`
+upstreams, but a plain-HTTP model server would bypass a proxy set only through
+`HTTPS_PROXY`), plus `NO_PROXY` for local model servers. Nothing else is
+needed. If the proxy needs credentials, give it an `https://` URL: the scheme
+in the proxy variable describes the hop to the proxy, and an `http://` proxy
+URL sends `Proxy-Authorization` in cleartext.
 
 **Private CA.** Mount the CA bundle and point the gateway at it:
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -23,6 +23,7 @@ import (
 	"github.com/enterpilot/gomodel/internal/core"
 	"github.com/enterpilot/gomodel/internal/filestore"
 	"github.com/enterpilot/gomodel/internal/guardrails"
+	"github.com/enterpilot/gomodel/internal/httpclient"
 	"github.com/enterpilot/gomodel/internal/live"
 	"github.com/enterpilot/gomodel/internal/mcpgateway"
 	"github.com/enterpilot/gomodel/internal/pricingoverrides"
@@ -127,6 +128,18 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 
 	if cfg.Factory == nil {
 		return nil, fmt.Errorf("factory is required")
+	}
+
+	// Outbound trust must be in place before any provider builds a transport,
+	// and a missing CA file is a startup error rather than a silent fallback.
+	tlsCfg := cfg.AppConfig.Config.HTTP.TLS
+	if err := httpclient.SetConfiguredTLS(httpclient.TLSSettings{
+		CAFile:             tlsCfg.CAFile,
+		ClientCertFile:     tlsCfg.ClientCertFile,
+		ClientKeyFile:      tlsCfg.ClientKeyFile,
+		InsecureSkipVerify: tlsCfg.InsecureSkipVerify,
+	}); err != nil {
+		return nil, err
 	}
 
 	b := newBootstrap(ctx, cfg)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -132,6 +132,10 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 
 	// Outbound trust must be in place before any provider builds a transport,
 	// and a missing CA file is a startup error rather than a silent fallback.
+	// On a reload the generation that keeps serving must not inherit settings
+	// its replacement was rejected with, so the previous configuration is put
+	// back whenever construction fails after this point.
+	previousTLS := httpclient.SnapshotTLS()
 	tlsCfg := cfg.AppConfig.Config.HTTP.TLS
 	if err := httpclient.SetConfiguredTLS(httpclient.TLSSettings{
 		CAFile:             tlsCfg.CAFile,
@@ -145,6 +149,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 	b := newBootstrap(ctx, cfg)
 	for _, phase := range b.phases() {
 		if err := phase(); err != nil {
+			httpclient.RestoreTLS(previousTLS)
 			return nil, b.fail(err)
 		}
 	}

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -71,6 +71,9 @@ func newBootstrap(ctx context.Context, cfg Config) *bootstrap {
 		slog.Info("offline mode: update check disabled, remote model catalog download disabled; only configured providers and declared endpoints are contacted",
 			"model_catalog", catalog)
 	}
+	if appCfg.HTTP.TLS.InsecureSkipVerify {
+		slog.Warn("outbound TLS certificate verification is disabled (http.tls.insecure_skip_verify); do not run this in production")
+	}
 	if appCfg.Budgets.Enabled && !appCfg.Usage.Enabled {
 		appCfg.Budgets.Enabled = false
 		slog.Warn("budget management disabled because usage tracking is disabled",

--- a/internal/app/tls_reload_test.go
+++ b/internal/app/tls_reload_test.go
@@ -25,10 +25,11 @@ func TestNewRestoresTLSWhenBootstrapFails(t *testing.T) {
 
 	// The serving generation trusts nothing extra but skips verification;
 	// distinctive enough to detect whether it survives a failed reload.
+	preTest := httpclient.SnapshotTLS()
+	t.Cleanup(func() { httpclient.RestoreTLS(preTest) })
 	if err := httpclient.SetConfiguredTLS(httpclient.TLSSettings{InsecureSkipVerify: true}); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = httpclient.SetConfiguredTLS(httpclient.TLSSettings{}) })
 
 	// The replacement asks for system defaults and then fails a bootstrap
 	// phase: an unusable storage backend trips the first one.

--- a/internal/app/tls_reload_test.go
+++ b/internal/app/tls_reload_test.go
@@ -1,0 +1,43 @@
+package app
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/enterpilot/gomodel/config"
+	"github.com/enterpilot/gomodel/internal/httpclient"
+	"github.com/enterpilot/gomodel/internal/providers"
+)
+
+// A reload whose replacement is rejected must not leave that replacement's
+// outbound trust installed for the generation that keeps serving.
+func TestNewRestoresTLSWhenBootstrapFails(t *testing.T) {
+	t.Setenv("STORAGE_TYPE", "sqlite")
+	t.Setenv("SQLITE_PATH", filepath.Join(t.TempDir(), "tls-reload.db"))
+	t.Setenv("ADMIN_UI_ENABLED", "false")
+	t.Setenv("ADMIN_ENDPOINTS_ENABLED", "false")
+	t.Setenv("MCP_ENABLED", "false")
+	loaded, err := config.Load()
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+
+	// The serving generation trusts nothing extra but skips verification;
+	// distinctive enough to detect whether it survives a failed reload.
+	if err := httpclient.SetConfiguredTLS(httpclient.TLSSettings{InsecureSkipVerify: true}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = httpclient.SetConfiguredTLS(httpclient.TLSSettings{}) })
+
+	// The replacement asks for system defaults and then fails a bootstrap
+	// phase: an unusable storage backend trips the first one.
+	loaded.Config.Storage.Type = "not-a-backend"
+	if _, err := New(context.Background(), Config{AppConfig: loaded, Factory: providers.NewProviderFactory()}); err == nil {
+		t.Fatal("expected bootstrap to fail")
+	}
+	got := httpclient.ConfiguredTLS()
+	if got == nil || !got.InsecureSkipVerify {
+		t.Fatal("rejected replacement leaked: serving generation's TLS configuration was not restored")
+	}
+}

--- a/internal/embedding/embedding.go
+++ b/internal/embedding/embedding.go
@@ -13,6 +13,7 @@ import (
 	"github.com/goccy/go-json"
 
 	"github.com/enterpilot/gomodel/config"
+	"github.com/enterpilot/gomodel/internal/httpclient"
 	"github.com/enterpilot/gomodel/internal/providers"
 )
 
@@ -67,7 +68,7 @@ func NewEmbedder(cfg config.EmbedderConfig, resolvedProviders map[string]config.
 			append([]string{raw.APIKey}, raw.APIKeys...)...,
 		),
 		model:      model,
-		httpClient: &http.Client{Timeout: defaultTimeout},
+		httpClient: httpclient.NewClientWithTimeout(defaultTimeout),
 	}, nil
 }
 

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -122,6 +122,7 @@ func NewHTTPClient(config *ClientConfig) *http.Client {
 		ResponseHeaderTimeout: config.ResponseHeaderTimeout,
 		ForceAttemptHTTP2:     true,
 		ExpectContinueTimeout: 1 * time.Second,
+		TLSClientConfig:       ConfiguredTLS(),
 	}
 
 	return &http.Client{
@@ -134,4 +135,18 @@ func NewHTTPClient(config *ClientConfig) *http.Client {
 // This is a convenience function equivalent to NewHTTPClient(nil).
 func NewDefaultHTTPClient() *http.Client {
 	return NewHTTPClient(nil)
+}
+
+// NewClientWithTimeout returns a client on the shared transport settings
+// (proxy, TLS trust, dial and keep-alive tuning) whose overall request and
+// response-header timeouts are both bound to timeout. Auxiliary callers such
+// as the model catalog fetch, the update check, and vector stores use it so
+// they inherit operator trust settings instead of building bare clients.
+func NewClientWithTimeout(timeout time.Duration) *http.Client {
+	cfg := DefaultConfig()
+	if timeout > 0 {
+		cfg.Timeout = timeout
+		cfg.ResponseHeaderTimeout = timeout
+	}
+	return NewHTTPClient(&cfg)
 }

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -2,6 +2,7 @@
 package httpclient
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -137,13 +138,20 @@ func NewDefaultHTTPClient() *http.Client {
 	return NewHTTPClient(nil)
 }
 
+// maxRedirects mirrors net/http's default redirect limit, which is lost as
+// soon as a custom CheckRedirect is installed.
+const maxRedirects = 10
+
 // NewAWSSDKClient returns a client on the shared transport for use with
 // aws-sdk-go-v2's WithHTTPClient. The SDK's own client follows only 307 and
 // 308 redirects, because a 301/302 would replay a signed request against a
 // different host; a custom client must do the same.
 func NewAWSSDKClient() *http.Client {
 	client := NewDefaultHTTPClient()
-	client.CheckRedirect = func(req *http.Request, _ []*http.Request) error {
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) >= maxRedirects {
+			return fmt.Errorf("stopped after %d redirects", maxRedirects)
+		}
 		if req.Response == nil {
 			return http.ErrUseLastResponse
 		}

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -104,13 +104,76 @@ func DefaultConfig() ClientConfig {
 
 // NewHTTPClient creates a new HTTP client with the provided configuration.
 // If config is nil, DefaultConfig() is used.
+//
+// The client's transport follows the process-wide TLS trust installed with
+// SetConfiguredTLS: a change or rollback applies to the next request on every
+// client, so a client created while a later-rejected reload had its settings
+// installed does not keep them.
 func NewHTTPClient(config *ClientConfig) *http.Client {
 	if config == nil {
 		cfg := DefaultConfig()
 		config = &cfg
 	}
 
-	transport := &http.Transport{
+	dt := &dynamicTransport{config: *config}
+	dt.current()
+	return &http.Client{
+		Transport: dt,
+		Timeout:   config.Timeout,
+	}
+}
+
+// dynamicTransport is the RoundTripper behind every client this package
+// creates. It owns one *http.Transport bound to the trust configuration that
+// was installed when it was built, and swaps in a fresh one when the
+// installed configuration changes. Pooled connections opened under the old
+// trust are closed with it.
+type dynamicTransport struct {
+	config ClientConfig
+	active atomic.Pointer[boundTransport]
+}
+
+type boundTransport struct {
+	trust *trustState
+	rt    *http.Transport
+}
+
+// current returns the transport for the installed trust configuration,
+// building it first if the configuration changed since the last request.
+func (d *dynamicTransport) current() *http.Transport {
+	state := trust.Load()
+	if b := d.active.Load(); b != nil && b.trust == state {
+		return b.rt
+	}
+	fresh := &boundTransport{trust: state, rt: newTransport(&d.config, state)}
+	for {
+		old := d.active.Load()
+		if old != nil && old.trust == state {
+			// Another request rebuilt it first.
+			return old.rt
+		}
+		if d.active.CompareAndSwap(old, fresh) {
+			if old != nil {
+				old.rt.CloseIdleConnections()
+			}
+			return fresh.rt
+		}
+	}
+}
+
+func (d *dynamicTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return d.current().RoundTrip(req)
+}
+
+// CloseIdleConnections lets http.Client.CloseIdleConnections reach the pool.
+func (d *dynamicTransport) CloseIdleConnections() {
+	if b := d.active.Load(); b != nil {
+		b.rt.CloseIdleConnections()
+	}
+}
+
+func newTransport(config *ClientConfig, state *trustState) *http.Transport {
+	return &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
 			Timeout:   config.DialTimeout,
@@ -123,12 +186,7 @@ func NewHTTPClient(config *ClientConfig) *http.Client {
 		ResponseHeaderTimeout: config.ResponseHeaderTimeout,
 		ForceAttemptHTTP2:     true,
 		ExpectContinueTimeout: 1 * time.Second,
-		TLSClientConfig:       ConfiguredTLS(),
-	}
-
-	return &http.Client{
-		Transport: transport,
-		Timeout:   config.Timeout,
+		TLSClientConfig:       state.tlsConfig(),
 	}
 }
 

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -137,6 +137,25 @@ func NewDefaultHTTPClient() *http.Client {
 	return NewHTTPClient(nil)
 }
 
+// NewAWSSDKClient returns a client on the shared transport for use with
+// aws-sdk-go-v2's WithHTTPClient. The SDK's own client follows only 307 and
+// 308 redirects, because a 301/302 would replay a signed request against a
+// different host; a custom client must do the same.
+func NewAWSSDKClient() *http.Client {
+	client := NewDefaultHTTPClient()
+	client.CheckRedirect = func(req *http.Request, _ []*http.Request) error {
+		if req.Response == nil {
+			return http.ErrUseLastResponse
+		}
+		switch req.Response.StatusCode {
+		case http.StatusTemporaryRedirect, http.StatusPermanentRedirect:
+			return nil
+		}
+		return http.ErrUseLastResponse
+	}
+	return client
+}
+
 // NewClientWithTimeout returns a client on the shared transport settings
 // (proxy, TLS trust, dial and keep-alive tuning) whose overall request and
 // response-header timeouts are both bound to timeout. Auxiliary callers such

--- a/internal/httpclient/client_test.go
+++ b/internal/httpclient/client_test.go
@@ -126,10 +126,7 @@ func TestNewHTTPClient(t *testing.T) {
 				return
 			}
 
-			transport, ok := client.Transport.(*http.Transport)
-			if !ok {
-				t.Fatal("Expected transport to be *http.Transport")
-			}
+			transport := underlyingTransport(t, client)
 
 			expectedConfig := tt.config
 			if expectedConfig == nil {
@@ -188,10 +185,7 @@ func TestNewDefaultHTTPClient(t *testing.T) {
 		return
 	}
 
-	transport, ok := client.Transport.(*http.Transport)
-	if !ok {
-		t.Fatal("Expected transport to be *http.Transport")
-	}
+	transport := underlyingTransport(t, client)
 
 	defaultConfig := DefaultConfig()
 
@@ -220,8 +214,8 @@ func TestHTTPClientIsReusable(t *testing.T) {
 	}
 
 	// But they should have the same configuration
-	transport1 := client1.Transport.(*http.Transport)
-	transport2 := client2.Transport.(*http.Transport)
+	transport1 := underlyingTransport(t, client1)
+	transport2 := underlyingTransport(t, client2)
 
 	if transport1.MaxIdleConns != transport2.MaxIdleConns {
 		t.Error("Expected same MaxIdleConns configuration")
@@ -246,7 +240,7 @@ func TestClientConfigZeroValues(t *testing.T) {
 	}
 
 	client := NewHTTPClient(config)
-	transport := client.Transport.(*http.Transport)
+	transport := underlyingTransport(t, client)
 
 	// Zero values should be preserved (not replaced with defaults)
 	if transport.MaxIdleConns != 0 {
@@ -294,4 +288,14 @@ func TestDefaultConfigTimeoutPrecedence(t *testing.T) {
 	if got := DefaultConfig().Timeout; got != 600*time.Second {
 		t.Fatalf("cleared Timeout = %v, want 600s", got)
 	}
+}
+
+// underlyingTransport unwraps the *http.Transport a client currently uses.
+func underlyingTransport(t *testing.T, client *http.Client) *http.Transport {
+	t.Helper()
+	dt, ok := client.Transport.(*dynamicTransport)
+	if !ok {
+		t.Fatalf("Transport is %T, want *dynamicTransport", client.Transport)
+	}
+	return dt.current()
 }

--- a/internal/httpclient/pem_test.go
+++ b/internal/httpclient/pem_test.go
@@ -1,0 +1,16 @@
+package httpclient
+
+import (
+	"bytes"
+	"encoding/pem"
+	"testing"
+)
+
+func pemEncode(t *testing.T, der []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: der}); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}

--- a/internal/httpclient/tls.go
+++ b/internal/httpclient/tls.go
@@ -28,21 +28,37 @@ type TLSSettings struct {
 	InsecureSkipVerify bool
 }
 
-// configuredTLS holds the *tls.Config built by SetConfiguredTLS. Nil means
-// "system defaults", which is also what a zero TLSSettings produces.
-var configuredTLS atomic.Pointer[tls.Config]
+// trustState is one installed trust configuration. Each SetConfiguredTLS
+// call installs a fresh value, so the pointer doubles as a generation
+// marker: a transport bound to a different pointer than the one currently
+// installed is stale and rebuilds itself on its next request (see
+// dynamicTransport). A nil cfg means system defaults.
+type trustState struct{ cfg *tls.Config }
+
+func (s *trustState) tlsConfig() *tls.Config {
+	if s == nil || s.cfg == nil {
+		return nil
+	}
+	return s.cfg.Clone()
+}
+
+// trust holds the installed configuration. Nil means "system defaults",
+// which is also what a zero TLSSettings produces.
+var trust atomic.Pointer[trustState]
 
 // SetConfiguredTLS builds and installs the client TLS configuration used by
-// every HTTP client this package creates. App startup calls it once, before
-// any provider constructs a transport. It returns an error when a referenced
-// file is missing, unreadable, or holds no usable certificate, so a typo in
-// the path fails startup instead of silently trusting nothing extra.
+// every HTTP client this package creates, including clients that already
+// exist: transports pick the change up on their next request. App startup
+// calls it before any provider constructs a transport. It returns an error
+// when a referenced file is missing, unreadable, or holds no usable
+// certificate, so a typo in the path fails startup instead of silently
+// trusting nothing extra.
 func SetConfiguredTLS(settings TLSSettings) error {
 	cfg, err := buildTLSConfig(settings)
 	if err != nil {
 		return err
 	}
-	configuredTLS.Store(cfg)
+	trust.Store(&trustState{cfg: cfg})
 	return nil
 }
 
@@ -50,24 +66,23 @@ func SetConfiguredTLS(settings TLSSettings) error {
 // nil when the gateway runs on system defaults. Callers that build their own
 // transport (websocket dialers, SDK clients) should install it.
 func ConfiguredTLS() *tls.Config {
-	cfg := configuredTLS.Load()
-	if cfg == nil {
-		return nil
-	}
-	return cfg.Clone()
+	return trust.Load().tlsConfig()
 }
 
 // TLSSnapshot is an opaque handle to the installed configuration, taken with
 // SnapshotTLS and given back to RestoreTLS. A reload that fails after
 // installing replacement settings uses it to put the serving generation's
-// trust back, so a rejected configuration never leaks into new clients.
-type TLSSnapshot struct{ cfg *tls.Config }
+// trust back. Because every transport re-checks the installed configuration
+// per request, the rollback also reaches clients that were created while the
+// rejected settings were installed.
+type TLSSnapshot struct{ state *trustState }
 
 // SnapshotTLS captures the currently installed configuration.
-func SnapshotTLS() TLSSnapshot { return TLSSnapshot{cfg: configuredTLS.Load()} }
+func SnapshotTLS() TLSSnapshot { return TLSSnapshot{state: trust.Load()} }
 
-// RestoreTLS reinstalls a configuration captured by SnapshotTLS.
-func RestoreTLS(s TLSSnapshot) { configuredTLS.Store(s.cfg) }
+// RestoreTLS reinstalls a configuration captured by SnapshotTLS. Transports
+// bound to that same configuration keep their connection pools.
+func RestoreTLS(s TLSSnapshot) { trust.Store(s.state) }
 
 func buildTLSConfig(settings TLSSettings) (*tls.Config, error) {
 	caFile := strings.TrimSpace(settings.CAFile)

--- a/internal/httpclient/tls.go
+++ b/internal/httpclient/tls.go
@@ -57,6 +57,18 @@ func ConfiguredTLS() *tls.Config {
 	return cfg.Clone()
 }
 
+// TLSSnapshot is an opaque handle to the installed configuration, taken with
+// SnapshotTLS and given back to RestoreTLS. A reload that fails after
+// installing replacement settings uses it to put the serving generation's
+// trust back, so a rejected configuration never leaks into new clients.
+type TLSSnapshot struct{ cfg *tls.Config }
+
+// SnapshotTLS captures the currently installed configuration.
+func SnapshotTLS() TLSSnapshot { return TLSSnapshot{cfg: configuredTLS.Load()} }
+
+// RestoreTLS reinstalls a configuration captured by SnapshotTLS.
+func RestoreTLS(s TLSSnapshot) { configuredTLS.Store(s.cfg) }
+
 func buildTLSConfig(settings TLSSettings) (*tls.Config, error) {
 	caFile := strings.TrimSpace(settings.CAFile)
 	certFile := strings.TrimSpace(settings.ClientCertFile)

--- a/internal/httpclient/tls.go
+++ b/internal/httpclient/tls.go
@@ -1,0 +1,100 @@
+package httpclient
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"strings"
+	"sync/atomic"
+)
+
+// TLSSettings is the process-wide client TLS trust configuration for every
+// outbound HTTPS connection the gateway opens: providers, the model catalog,
+// the update check, MCP upstreams, vector stores, and embedding endpoints.
+//
+// Everything is optional. With the zero value, connections trust the operating
+// system's certificate store, which is what most deployments want.
+type TLSSettings struct {
+	// CAFile is a PEM bundle appended to the system trust store. Use it for a
+	// private CA that signs local model servers or a TLS-intercepting proxy.
+	CAFile string
+	// ClientCertFile and ClientKeyFile present a client certificate (mTLS) to
+	// every upstream that asks for one. Both must be set together.
+	ClientCertFile string
+	ClientKeyFile  string
+	// InsecureSkipVerify disables certificate verification entirely. It is
+	// meant for a lab, never for production; the gateway logs a warning.
+	InsecureSkipVerify bool
+}
+
+// configuredTLS holds the *tls.Config built by SetConfiguredTLS. Nil means
+// "system defaults", which is also what a zero TLSSettings produces.
+var configuredTLS atomic.Pointer[tls.Config]
+
+// SetConfiguredTLS builds and installs the client TLS configuration used by
+// every HTTP client this package creates. App startup calls it once, before
+// any provider constructs a transport. It returns an error when a referenced
+// file is missing, unreadable, or holds no usable certificate, so a typo in
+// the path fails startup instead of silently trusting nothing extra.
+func SetConfiguredTLS(settings TLSSettings) error {
+	cfg, err := buildTLSConfig(settings)
+	if err != nil {
+		return err
+	}
+	configuredTLS.Store(cfg)
+	return nil
+}
+
+// ConfiguredTLS returns a copy of the installed client TLS configuration, or
+// nil when the gateway runs on system defaults. Callers that build their own
+// transport (websocket dialers, SDK clients) should install it.
+func ConfiguredTLS() *tls.Config {
+	cfg := configuredTLS.Load()
+	if cfg == nil {
+		return nil
+	}
+	return cfg.Clone()
+}
+
+func buildTLSConfig(settings TLSSettings) (*tls.Config, error) {
+	caFile := strings.TrimSpace(settings.CAFile)
+	certFile := strings.TrimSpace(settings.ClientCertFile)
+	keyFile := strings.TrimSpace(settings.ClientKeyFile)
+
+	if caFile == "" && certFile == "" && keyFile == "" && !settings.InsecureSkipVerify {
+		return nil, nil
+	}
+	if (certFile == "") != (keyFile == "") {
+		return nil, fmt.Errorf("http.tls: client_cert_file and client_key_file must be set together")
+	}
+
+	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+
+	if caFile != "" {
+		pool, err := x509.SystemCertPool()
+		if err != nil || pool == nil {
+			pool = x509.NewCertPool()
+		}
+		pem, err := os.ReadFile(caFile)
+		if err != nil {
+			return nil, fmt.Errorf("http.tls: read ca_file: %w", err)
+		}
+		if !pool.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("http.tls: ca_file %s contains no PEM certificates", caFile)
+		}
+		cfg.RootCAs = pool
+	}
+
+	if certFile != "" {
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return nil, fmt.Errorf("http.tls: load client certificate: %w", err)
+		}
+		cfg.Certificates = []tls.Certificate{cert}
+	}
+
+	//nolint:gosec // Operator opt-in for lab environments; startup logs a warning.
+	cfg.InsecureSkipVerify = settings.InsecureSkipVerify
+	return cfg, nil
+}

--- a/internal/httpclient/tls_test.go
+++ b/internal/httpclient/tls_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -158,5 +160,27 @@ func TestNewAWSSDKClientFollowsOnly307And308(t *testing.T) {
 		if !follow && err != http.ErrUseLastResponse {
 			t.Errorf("%d should not be followed, got %v", code, err)
 		}
+	}
+}
+
+func TestNewAWSSDKClientBoundsRedirectLoops(t *testing.T) {
+	var hops atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hops.Add(1)
+		http.Redirect(w, r, "/loop", http.StatusTemporaryRedirect)
+	}))
+	defer srv.Close()
+
+	client := NewAWSSDKClient()
+	client.Timeout = 10 * time.Second
+	resp, err := client.Get(srv.URL)
+	if resp != nil {
+		resp.Body.Close()
+	}
+	if err == nil || !strings.Contains(err.Error(), "stopped after 10 redirects") {
+		t.Fatalf("expected redirect limit error, got %v", err)
+	}
+	if got := hops.Load(); got != maxRedirects {
+		t.Errorf("server saw %d requests, want %d", got, maxRedirects)
 	}
 }

--- a/internal/httpclient/tls_test.go
+++ b/internal/httpclient/tls_test.go
@@ -1,0 +1,129 @@
+package httpclient
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func resetTLS(t *testing.T) {
+	t.Helper()
+	configuredTLS.Store(nil)
+	t.Cleanup(func() { configuredTLS.Store(nil) })
+}
+
+func TestSetConfiguredTLS_ZeroValueKeepsSystemDefaults(t *testing.T) {
+	resetTLS(t)
+	if err := SetConfiguredTLS(TLSSettings{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ConfiguredTLS() != nil {
+		t.Fatal("zero settings should leave system defaults (nil tls.Config)")
+	}
+	transport := NewDefaultHTTPClient().Transport.(*http.Transport)
+	if transport.TLSClientConfig != nil {
+		t.Fatal("transport should not carry a tls.Config on system defaults")
+	}
+}
+
+func TestSetConfiguredTLS_CAFileTrustsPrivateCA(t *testing.T) {
+	resetTLS(t)
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	// Without the CA the self-signed test server must be rejected.
+	if _, err := NewClientWithTimeout(5 * time.Second).Get(srv.URL); err == nil {
+		t.Fatal("expected certificate error without trusted CA")
+	}
+
+	caFile := filepath.Join(t.TempDir(), "ca.pem")
+	if err := os.WriteFile(caFile, pemEncode(t, srv.Certificate().Raw), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := SetConfiguredTLS(TLSSettings{CAFile: caFile}); err != nil {
+		t.Fatalf("SetConfiguredTLS: %v", err)
+	}
+	resp, err := NewClientWithTimeout(5 * time.Second).Get(srv.URL)
+	if err != nil {
+		t.Fatalf("expected private CA to be trusted, got %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("unexpected status %d", resp.StatusCode)
+	}
+}
+
+func TestSetConfiguredTLS_Errors(t *testing.T) {
+	resetTLS(t)
+	dir := t.TempDir()
+	empty := filepath.Join(dir, "empty.pem")
+	if err := os.WriteFile(empty, []byte("not a certificate"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name     string
+		settings TLSSettings
+	}{
+		{"missing ca file", TLSSettings{CAFile: filepath.Join(dir, "missing.pem")}},
+		{"ca file without certificates", TLSSettings{CAFile: empty}},
+		{"client cert without key", TLSSettings{ClientCertFile: empty}},
+		{"client key without cert", TLSSettings{ClientKeyFile: empty}},
+		{"unparseable client pair", TLSSettings{ClientCertFile: empty, ClientKeyFile: empty}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := SetConfiguredTLS(tt.settings); err == nil {
+				t.Fatal("expected an error")
+			}
+			if ConfiguredTLS() != nil {
+				t.Fatal("a failed install must not replace the previous configuration")
+			}
+		})
+	}
+}
+
+func TestSetConfiguredTLS_InsecureSkipVerify(t *testing.T) {
+	resetTLS(t)
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	if err := SetConfiguredTLS(TLSSettings{InsecureSkipVerify: true}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := ConfiguredTLS()
+	if cfg == nil || !cfg.InsecureSkipVerify {
+		t.Fatal("expected InsecureSkipVerify to be set")
+	}
+	if cfg.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("expected TLS 1.2 floor, got %d", cfg.MinVersion)
+	}
+	resp, err := NewDefaultHTTPClient().Get(srv.URL)
+	if err != nil {
+		t.Fatalf("expected the self-signed server to be accepted: %v", err)
+	}
+	resp.Body.Close()
+}
+
+func TestNewClientWithTimeout(t *testing.T) {
+	c := NewClientWithTimeout(7 * time.Second)
+	if c.Timeout != 7*time.Second {
+		t.Fatalf("Timeout = %v, want 7s", c.Timeout)
+	}
+	transport := c.Transport.(*http.Transport)
+	if transport.ResponseHeaderTimeout != 7*time.Second {
+		t.Fatalf("ResponseHeaderTimeout = %v, want 7s", transport.ResponseHeaderTimeout)
+	}
+	if transport.Proxy == nil {
+		t.Fatal("expected proxy-from-environment on the shared transport")
+	}
+	if NewClientWithTimeout(0).Timeout != DefaultConfig().Timeout {
+		t.Fatal("non-positive timeout should keep the default")
+	}
+}

--- a/internal/httpclient/tls_test.go
+++ b/internal/httpclient/tls_test.go
@@ -127,3 +127,36 @@ func TestNewClientWithTimeout(t *testing.T) {
 		t.Fatal("non-positive timeout should keep the default")
 	}
 }
+
+func TestSnapshotAndRestoreTLS(t *testing.T) {
+	resetTLS(t)
+	if err := SetConfiguredTLS(TLSSettings{InsecureSkipVerify: true}); err != nil {
+		t.Fatal(err)
+	}
+	serving := SnapshotTLS()
+	if err := SetConfiguredTLS(TLSSettings{}); err != nil {
+		t.Fatal(err)
+	}
+	if ConfiguredTLS() != nil {
+		t.Fatal("replacement should have installed system defaults")
+	}
+	RestoreTLS(serving)
+	cfg := ConfiguredTLS()
+	if cfg == nil || !cfg.InsecureSkipVerify {
+		t.Fatal("restore should reinstall the serving generation's configuration")
+	}
+}
+
+func TestNewAWSSDKClientFollowsOnly307And308(t *testing.T) {
+	client := NewAWSSDKClient()
+	for code, follow := range map[int]bool{301: false, 302: false, 303: false, 307: true, 308: true} {
+		req := &http.Request{Response: &http.Response{StatusCode: code}}
+		err := client.CheckRedirect(req, nil)
+		if follow && err != nil {
+			t.Errorf("%d should be followed, got %v", code, err)
+		}
+		if !follow && err != http.ErrUseLastResponse {
+			t.Errorf("%d should not be followed, got %v", code, err)
+		}
+	}
+}

--- a/internal/httpclient/tls_test.go
+++ b/internal/httpclient/tls_test.go
@@ -14,8 +14,8 @@ import (
 
 func resetTLS(t *testing.T) {
 	t.Helper()
-	configuredTLS.Store(nil)
-	t.Cleanup(func() { configuredTLS.Store(nil) })
+	trust.Store(nil)
+	t.Cleanup(func() { trust.Store(nil) })
 }
 
 func TestSetConfiguredTLS_ZeroValueKeepsSystemDefaults(t *testing.T) {
@@ -26,7 +26,7 @@ func TestSetConfiguredTLS_ZeroValueKeepsSystemDefaults(t *testing.T) {
 	if ConfiguredTLS() != nil {
 		t.Fatal("zero settings should leave system defaults (nil tls.Config)")
 	}
-	transport := NewDefaultHTTPClient().Transport.(*http.Transport)
+	transport := underlyingTransport(t, NewDefaultHTTPClient())
 	if transport.TLSClientConfig != nil {
 		t.Fatal("transport should not carry a tls.Config on system defaults")
 	}
@@ -118,7 +118,7 @@ func TestNewClientWithTimeout(t *testing.T) {
 	if c.Timeout != 7*time.Second {
 		t.Fatalf("Timeout = %v, want 7s", c.Timeout)
 	}
-	transport := c.Transport.(*http.Transport)
+	transport := underlyingTransport(t, c)
 	if transport.ResponseHeaderTimeout != 7*time.Second {
 		t.Fatalf("ResponseHeaderTimeout = %v, want 7s", transport.ResponseHeaderTimeout)
 	}
@@ -183,4 +183,70 @@ func TestNewAWSSDKClientBoundsRedirectLoops(t *testing.T) {
 	if got := hops.Load(); got != maxRedirects {
 		t.Errorf("server saw %d requests, want %d", got, maxRedirects)
 	}
+}
+
+// A client created while a later-rejected reload had its TLS settings
+// installed must follow the rollback rather than keep the rejected policy.
+func TestClientFollowsTLSRollback(t *testing.T) {
+	resetTLS(t)
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	serving := NewDefaultHTTPClient()
+	servingRT := underlyingTransport(t, serving)
+	before := SnapshotTLS()
+
+	// Replacement settings go in, and a client is built while they are live.
+	if err := SetConfiguredTLS(TLSSettings{InsecureSkipVerify: true}); err != nil {
+		t.Fatal(err)
+	}
+	captured := NewDefaultHTTPClient()
+	if resp, err := captured.Get(srv.URL); err != nil {
+		t.Fatalf("self-signed server should be accepted while skip-verify is installed: %v", err)
+	} else {
+		resp.Body.Close()
+	}
+
+	// The reload is rejected and the serving trust comes back.
+	RestoreTLS(before)
+	for name, c := range map[string]*http.Client{"captured": captured, "serving": serving} {
+		resp, err := c.Get(srv.URL)
+		if resp != nil {
+			resp.Body.Close()
+		}
+		if err == nil || !strings.Contains(err.Error(), "certificate") {
+			t.Errorf("%s client should reject the self-signed server after rollback, got %v", name, err)
+		}
+	}
+	if underlyingTransport(t, serving) != servingRT {
+		t.Error("serving client was rebuilt although its trust configuration was restored unchanged")
+	}
+}
+
+func TestClientPicksUpTLSChangeWithoutRecreation(t *testing.T) {
+	resetTLS(t)
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+	caFile := filepath.Join(t.TempDir(), "ca.pem")
+	if err := os.WriteFile(caFile, pemEncode(t, srv.Certificate().Raw), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	client := NewDefaultHTTPClient()
+	if resp, err := client.Get(srv.URL); err == nil {
+		resp.Body.Close()
+		t.Fatal("expected the private CA to be rejected before it is trusted")
+	}
+	if err := SetConfiguredTLS(TLSSettings{CAFile: caFile}); err != nil {
+		t.Fatal(err)
+	}
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("existing client should trust the CA after SetConfiguredTLS: %v", err)
+	}
+	resp.Body.Close()
 }

--- a/internal/modeldata/fetcher.go
+++ b/internal/modeldata/fetcher.go
@@ -14,14 +14,13 @@ import (
 	"time"
 
 	"github.com/goccy/go-json"
+
+	"github.com/enterpilot/gomodel/internal/httpclient"
 )
 
-// httpClient is a shared HTTP client for model list fetching.
-// The 60-second timeout acts as a safety net; callers should use context
-// deadlines for finer-grained control.
-var httpClient = &http.Client{
-	Timeout: 60 * time.Second,
-}
+// fetchTimeout is a safety net for one catalog download; callers should use
+// context deadlines for finer-grained control.
+const fetchTimeout = 60 * time.Second
 
 // maxBodySize caps a catalog, whether downloaded or read from disk.
 const maxBodySize = 10 * 1024 * 1024 // 10 MB
@@ -61,7 +60,9 @@ func FetchIfChanged(ctx context.Context, url, etag string) (FetchResult, error) 
 		return readLocal(path, etag)
 	}
 
-	client := httpClient
+	// Built per fetch so the client picks up the trust settings installed at
+	// startup (private CA, mTLS) and the proxy environment.
+	client := httpclient.NewClientWithTimeout(fetchTimeout)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {

--- a/internal/modeldata/fetcher.go
+++ b/internal/modeldata/fetcher.go
@@ -25,6 +25,12 @@ const fetchTimeout = 60 * time.Second
 // maxBodySize caps a catalog, whether downloaded or read from disk.
 const maxBodySize = 10 * 1024 * 1024 // 10 MB
 
+// httpClient is shared by every catalog download so refreshes reuse one
+// connection pool. Its transport follows the trust settings (private CA,
+// mTLS) installed at startup or by a reload, so creating it at package init
+// is safe.
+var httpClient = httpclient.NewClientWithTimeout(fetchTimeout)
+
 // FetchResult carries the outcome of one conditional model list fetch.
 type FetchResult struct {
 	List *ModelList
@@ -60,10 +66,6 @@ func FetchIfChanged(ctx context.Context, url, etag string) (FetchResult, error) 
 		return readLocal(path, etag)
 	}
 
-	// Built per fetch so the client picks up the trust settings installed at
-	// startup (private CA, mTLS) and the proxy environment.
-	client := httpclient.NewClientWithTimeout(fetchTimeout)
-
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return FetchResult{}, fmt.Errorf("creating request: %w", err)
@@ -73,7 +75,7 @@ func FetchIfChanged(ctx context.Context, url, etag string) (FetchResult, error) 
 		req.Header.Set("If-None-Match", etag)
 	}
 
-	resp, err := client.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return FetchResult{}, fmt.Errorf("fetching model list: %w", err)
 	}

--- a/internal/providers/bedrock/bedrock.go
+++ b/internal/providers/bedrock/bedrock.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
 
 	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/httpclient"
 	"github.com/enterpilot/gomodel/internal/llmclient"
 	"github.com/enterpilot/gomodel/internal/providers"
 )
@@ -68,7 +69,8 @@ func New(providerCfg providers.ProviderConfig, opts providers.ProviderOptions) c
 	p := &Provider{hooks: opts.Hooks}
 
 	region, endpoint := parseBaseURL(providerCfg.BaseURL)
-	loadOpts := []func(*awsconfig.LoadOptions) error{}
+	// The SDK's own client would ignore the gateway's proxy and TLS trust.
+	loadOpts := []func(*awsconfig.LoadOptions) error{awsconfig.WithHTTPClient(httpclient.NewDefaultHTTPClient())}
 	if region != "" {
 		loadOpts = append(loadOpts, awsconfig.WithRegion(region))
 	}

--- a/internal/providers/bedrock/bedrock.go
+++ b/internal/providers/bedrock/bedrock.go
@@ -70,7 +70,7 @@ func New(providerCfg providers.ProviderConfig, opts providers.ProviderOptions) c
 
 	region, endpoint := parseBaseURL(providerCfg.BaseURL)
 	// The SDK's own client would ignore the gateway's proxy and TLS trust.
-	loadOpts := []func(*awsconfig.LoadOptions) error{awsconfig.WithHTTPClient(httpclient.NewDefaultHTTPClient())}
+	loadOpts := []func(*awsconfig.LoadOptions) error{awsconfig.WithHTTPClient(httpclient.NewAWSSDKClient())}
 	if region != "" {
 		loadOpts = append(loadOpts, awsconfig.WithRegion(region))
 	}

--- a/internal/providers/bedrockmantle/bedrock_mantle.go
+++ b/internal/providers/bedrockmantle/bedrock_mantle.go
@@ -64,7 +64,7 @@ func New(cfg providers.ProviderConfig, opts providers.ProviderOptions) core.Prov
 	if keys.Len() == 0 {
 		awsCfg, loadErr := awsconfig.LoadDefaultConfig(context.Background(),
 			awsconfig.WithRegion(endpoint.region),
-			awsconfig.WithHTTPClient(httpclient.NewDefaultHTTPClient()))
+			awsconfig.WithHTTPClient(httpclient.NewAWSSDKClient()))
 		if loadErr != nil {
 			return &Provider{configErr: fmt.Errorf("load AWS config: %w", loadErr)}
 		}

--- a/internal/providers/bedrockmantle/bedrock_mantle.go
+++ b/internal/providers/bedrockmantle/bedrock_mantle.go
@@ -62,7 +62,9 @@ func New(cfg providers.ProviderConfig, opts providers.ProviderOptions) core.Prov
 
 	var credentials aws.CredentialsProvider
 	if keys.Len() == 0 {
-		awsCfg, loadErr := awsconfig.LoadDefaultConfig(context.Background(), awsconfig.WithRegion(endpoint.region))
+		awsCfg, loadErr := awsconfig.LoadDefaultConfig(context.Background(),
+			awsconfig.WithRegion(endpoint.region),
+			awsconfig.WithHTTPClient(httpclient.NewDefaultHTTPClient()))
 		if loadErr != nil {
 			return &Provider{configErr: fmt.Errorf("load AWS config: %w", loadErr)}
 		}

--- a/internal/providers/googlecommon/auth.go
+++ b/internal/providers/googlecommon/auth.go
@@ -17,6 +17,8 @@ import (
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
+
+	"github.com/enterpilot/gomodel/internal/httpclient"
 )
 
 const DefaultScope = "https://www.googleapis.com/auth/cloud-platform"
@@ -74,6 +76,11 @@ func HasServiceAccount(cfg Config) bool {
 func FindCredentials(ctx context.Context, cfg Config) (*Credentials, error) {
 	if ctx == nil {
 		ctx = context.Background()
+	}
+	// Token exchange goes through the shared client so it honors the
+	// operator's proxy and TLS trust settings like every other upstream call.
+	if ctx.Value(oauth2.HTTPClient) == nil {
+		ctx = context.WithValue(ctx, oauth2.HTTPClient, httpclient.NewDefaultHTTPClient())
 	}
 	scope := strings.TrimSpace(cfg.Scope)
 	if scope == "" {

--- a/internal/realtime/observer.go
+++ b/internal/realtime/observer.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/coder/websocket"
+
+	"github.com/enterpilot/gomodel/internal/httpclient"
 )
 
 // Observe dials the target websocket and consumes frames until the upstream
@@ -20,6 +22,9 @@ import (
 // A dial failure is returned as *DialError; a clean close returns nil.
 func Observe(ctx context.Context, target Target, tap func([]byte)) error {
 	conn, _, err := websocket.Dial(ctx, target.URL, &websocket.DialOptions{
+		// Same shared client as Proxy, so the sideband dial honors the
+		// operator's proxy and TLS trust settings.
+		HTTPClient:   httpclient.NewDefaultHTTPClient(),
 		HTTPHeader:   target.Headers,
 		Subprotocols: target.Subprotocols,
 	})

--- a/internal/realtime/proxy.go
+++ b/internal/realtime/proxy.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
+
+	"github.com/enterpilot/gomodel/internal/httpclient"
 )
 
 // MaxFrameBytes caps a single realtime message. OpenAI streams base64-encoded
@@ -77,6 +79,9 @@ func (h Hooks) clientFrames() func([]byte) []byte {
 // or the terminal transport error (never a *DialError) for the caller to log.
 func Proxy(w http.ResponseWriter, r *http.Request, target Target, hooks Hooks) error {
 	upstream, _, err := websocket.Dial(r.Context(), target.URL, &websocket.DialOptions{
+		// The shared client carries the operator's proxy and TLS trust
+		// settings (private CA, mTLS); the default dialer would not.
+		HTTPClient:   httpclient.NewDefaultHTTPClient(),
 		HTTPHeader:   target.Headers,
 		Subprotocols: target.Subprotocols,
 	})

--- a/internal/responsecache/vecstore_pinecone.go
+++ b/internal/responsecache/vecstore_pinecone.go
@@ -13,6 +13,7 @@ import (
 	"github.com/goccy/go-json"
 
 	"github.com/enterpilot/gomodel/config"
+	"github.com/enterpilot/gomodel/internal/httpclient"
 )
 
 // pineconeMetadataValueMax is a conservative limit for a single metadata string (Pinecone ~40KB UTF-8).
@@ -47,7 +48,7 @@ func newPineconeStore(cfg config.PineconeConfig) (*pineconeStore, error) {
 		apiKey:     cfg.APIKey,
 		namespace:  cfg.Namespace,
 		dimension:  cfg.Dimension,
-		httpClient: &http.Client{Timeout: 60 * time.Second},
+		httpClient: httpclient.NewClientWithTimeout(60 * time.Second),
 	}
 	s.cleanup = startVecCleanup(s)
 	return s, nil

--- a/internal/responsecache/vecstore_qdrant.go
+++ b/internal/responsecache/vecstore_qdrant.go
@@ -14,6 +14,7 @@ import (
 	"github.com/goccy/go-json"
 
 	"github.com/enterpilot/gomodel/config"
+	"github.com/enterpilot/gomodel/internal/httpclient"
 )
 
 type qdrantStore struct {
@@ -41,7 +42,7 @@ func newQdrantStore(cfg config.QdrantConfig) (*qdrantStore, error) {
 		baseURL:    base,
 		collection: coll,
 		apiKey:     cfg.APIKey,
-		httpClient: &http.Client{Timeout: 60 * time.Second},
+		httpClient: httpclient.NewClientWithTimeout(60 * time.Second),
 	}
 	s.cleanup = startVecCleanup(s)
 	return s, nil

--- a/internal/responsecache/vecstore_weaviate.go
+++ b/internal/responsecache/vecstore_weaviate.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/enterpilot/gomodel/config"
+	"github.com/enterpilot/gomodel/internal/httpclient"
 )
 
 type weaviateStore struct {
@@ -41,7 +42,7 @@ func newWeaviateStore(cfg config.WeaviateConfig) (*weaviateStore, error) {
 		baseURL:    base,
 		class:      class,
 		apiKey:     strings.TrimSpace(cfg.APIKey),
-		httpClient: &http.Client{Timeout: 60 * time.Second},
+		httpClient: httpclient.NewClientWithTimeout(60 * time.Second),
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/internal/versioncheck/versioncheck.go
+++ b/internal/versioncheck/versioncheck.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/enterpilot/gomodel/internal/httpclient"
 	"github.com/enterpilot/gomodel/internal/version"
 )
 
@@ -116,7 +117,7 @@ func New(cfg Config) *Checker {
 		cfg.URL = DefaultURL
 	}
 	if cfg.Client == nil {
-		cfg.Client = &http.Client{Timeout: cfg.Timeout}
+		cfg.Client = httpclient.NewClientWithTimeout(cfg.Timeout)
 	}
 	manifest := manifestURL(cfg.URL, cfg.App)
 	return &Checker{cfg: cfg, url: manifest, safeURL: SafeURL(manifest)}


### PR DESCRIPTION
## Summary

Adds client TLS trust configuration for outbound HTTPS and routes every side HTTP client through the shared transport, so proxy and trust settings apply uniformly.

New settings under `http.tls` in `config.yaml`, with env overrides:

| Setting | Env | Default |
| --- | --- | --- |
| `ca_file` | `HTTP_TLS_CA_FILE` | unset (system store) |
| `client_cert_file` / `client_key_file` | `HTTP_TLS_CLIENT_CERT_FILE` / `HTTP_TLS_CLIENT_KEY_FILE` | unset |
| `insecure_skip_verify` | `HTTP_TLS_INSECURE_SKIP_VERIFY` | `false` |

The CA bundle is appended to the system store. A missing or empty file is a startup error. `insecure_skip_verify` logs a warning at startup.

## User-visible impact

- Deployments behind a TLS-intercepting proxy, or with internal-CA-signed model servers, no longer need to bake certificates into the image.
- mTLS to upstreams is now possible.
- The model catalog fetch, update check, embedding client, vector stores (Qdrant, Pinecone, Weaviate), realtime websocket dialer, AWS SDK clients (Bedrock, Bedrock Mantle), and Google OAuth token exchange now use the shared transport. Previously they built bare clients that ignored the configured timeouts and would have ignored these trust settings.

## Docs

- `docs/advanced/configuration.mdx`: new "Outbound TLS trust" table and a note that `HTTPS_PROXY` applies to every upstream.
- `docs/guides/production.mdx`: new "Private CAs and proxies" section.

## Testing

- `internal/httpclient`: private CA is rejected before and trusted after `SetConfiguredTLS`; error cases for missing file, no PEM, half-set client pair; skip-verify path; shared-timeout client.
- `config`: env overrides and zero default.
- Full `make test-race` and `make lint` pass via pre-commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable TLS settings for outbound HTTPS connections, including custom CA bundles, mutual TLS certificates, and optional certificate-verification bypass.
  - Applied shared proxy and TLS settings across providers, model updates, MCP connections, vector stores, authentication, and real-time connections.
  - Invalid or missing certificate files now produce clear startup errors, and disabling certificate verification generates a warning.

- **Documentation**
  - Added guidance for proxy usage, private certificate authorities, mutual TLS, and security considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->