### PR TITLE
feat(config): add GOMODEL_OFFLINE switch and local file model catalog source

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -21,6 +21,13 @@
 # values stay fatal in either mode.
 # CONFIG_STRICT=true
 
+# Air-gapped installs: one switch that disables every outbound call the gateway
+# makes on its own -- the update check (GOMODEL_VERSION_CHECK_*) and the remote
+# model catalog download (MODEL_LIST_URL over HTTP). Configured providers and
+# endpoints you declare yourself (OTLP, MCP upstreams, vector stores) are not
+# affected, and a catalog given as a local file path keeps working.
+# GOMODEL_OFFLINE=false
+
 # Tagging based on headers: label every request from the listed headers (numbered
 # from 1). Labels are recorded in usage tracking and audit logs. A header value can
 # carry several labels split by the delimiter (default: ","). The optional prefix is
@@ -219,8 +226,9 @@
 
 # External model metadata registry (provides pricing, capabilities, context window, etc.)
 # Default: ENTERPILOT/ai-model-list on GitHub. Point this at an internal mirror,
-# or set MODEL_LIST_URL=off to disable the download entirely for fully
-# air-gapped installs -- models then keep provider-reported, configured,
+# at a local file (/etc/gomodel/models.json or file:///etc/gomodel/models.json,
+# re-read on each cache refresh), or set MODEL_LIST_URL=off to disable the
+# catalog entirely -- models then keep provider-reported, configured,
 # heuristic-derived, and any previously cached catalog metadata, so declare
 # pricing in config.yaml if you need cost tracking and budgets. (Setting it
 # to an empty string does NOT disable the fetch: empty env values are

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -137,6 +137,11 @@ cache:
   model:
     refresh_interval: 3600 # how often to refresh the model registry (seconds, default: 3600)
     recheck_interval: 60 # env: PROVIDER_RECHECK_INTERVAL; how often providers whose last refresh failed are re-probed for recovery (seconds, default: 60; 0 disables)
+    # model_list:
+    #   # env: MODEL_LIST_URL. Pricing, context windows, and capabilities. An HTTP
+    #   # URL (default: the public catalog on GitHub), a local file path for
+    #   # air-gapped installs (re-read on each refresh), or "off".
+    #   url: /etc/gomodel/models.json
     local:
       cache_dir: ".cache" # local cache directory; kept as fallback if redis is configured but unreachable
     # Redis is preferred when set. Leave `local` in place to start in degraded mode if Redis is down:
@@ -688,5 +693,10 @@ providers:
 # per-deployment install id, and the visiting browser's user agent and language.
 # Never sends API keys, model names, prompts, usage data, client addresses, or
 # the dashboard hostname. Set enabled: false to stop all outbound traffic.
+# Air-gapped installs: disables the update check and drops HTTP model catalog
+# URLs in one step. Configured providers, declared endpoints, and a catalog
+# given as a local file path are unaffected. Default: false
+# offline: false
+
 # version_check:
 #   enabled: true

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,14 @@ type Config struct {
 	// release manifest. See VersionCheckConfig for what it sends.
 	VersionCheck VersionCheckConfig `yaml:"version_check"`
 
+	// Offline is the one switch for air-gapped installs. It turns off every
+	// outbound call the gateway makes on its own: the update check and the
+	// remote model catalog download. Calls to configured providers and to
+	// anything else the operator declared (OTLP, MCP upstreams, vector
+	// stores) are untouched. A catalog served from a local file keeps working.
+	// Default: false
+	Offline bool `yaml:"offline" env:"GOMODEL_OFFLINE"`
+
 	// Extensions holds configuration owned by custom distributions. Core keeps
 	// the values opaque; an extension decodes its named section with
 	// LoadResult.DecodeExtension.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -62,7 +62,7 @@ func clearAllConfigEnvVars(t *testing.T) {
 	for _, key := range []string{
 		"CONFIG_STRICT",
 		"PORT", "BASE_PATH", "GOMODEL_MASTER_KEY", "BODY_SIZE_LIMIT", "SWAGGER_ENABLED", "PPROF_ENABLED", "ENABLE_PASSTHROUGH_ROUTES", "ALLOW_PASSTHROUGH_V1_ALIAS", "USER_PATH_HEADER", "ENABLED_PASSTHROUGH_PROVIDERS",
-		"GOMODEL_CACHE_DIR", "CACHE_REFRESH_INTERVAL", "MODEL_LIST_URL",
+		"GOMODEL_CACHE_DIR", "CACHE_REFRESH_INTERVAL", "MODEL_LIST_URL", "GOMODEL_OFFLINE", "GOMODEL_VERSION_CHECK_ENABLED",
 		"REDIS_URL", "REDIS_KEY_MODELS", "REDIS_KEY_RESPONSES", "REDIS_TTL_MODELS", "REDIS_TTL_RESPONSES",
 		"RESPONSE_CACHE_SIMPLE_ENABLED",
 		"SEMANTIC_CACHE_ENABLED", "SEMANTIC_CACHE_THRESHOLD", "SEMANTIC_CACHE_TTL", "SEMANTIC_CACHE_MAX_CONV_MESSAGES",
@@ -2196,5 +2196,98 @@ func TestModelFilterValidate(t *testing.T) {
 				t.Errorf("error = %q, want it to name the offending field", err)
 			}
 		})
+	}
+}
+
+func TestOfflineModeDisablesEveryUnsolicitedOutboundCall(t *testing.T) {
+	tests := []struct {
+		name        string
+		modelList   string
+		wantList    string
+		wantVersion bool
+	}{
+		{name: "RemoteCatalogIsDropped", modelList: "", wantList: "", wantVersion: false},
+		{name: "MirrorIsDropped", modelList: "https://mirror.internal/models.min.json", wantList: "", wantVersion: false},
+		{name: "FileURLIsKept", modelList: "file:///etc/gomodel/models.json", wantList: "file:///etc/gomodel/models.json", wantVersion: false},
+		{name: "BarePathIsKept", modelList: "/etc/gomodel/models.json", wantList: "/etc/gomodel/models.json", wantVersion: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearAllConfigEnvVars(t)
+			withTempDir(t, func(_ string) {
+				t.Setenv("GOMODEL_OFFLINE", "true")
+				if tt.modelList != "" {
+					t.Setenv("MODEL_LIST_URL", tt.modelList)
+				}
+				result, err := Load()
+				if err != nil {
+					t.Fatalf("Load() failed: %v", err)
+				}
+				if !result.Config.Offline {
+					t.Fatal("Offline should be true")
+				}
+				if got := result.Config.Cache.Model.ModelList.URL; got != tt.wantList {
+					t.Errorf("ModelList.URL = %q, want %q", got, tt.wantList)
+				}
+				if got := result.Config.VersionCheck.Enabled; got != tt.wantVersion {
+					t.Errorf("VersionCheck.Enabled = %v, want %v", got, tt.wantVersion)
+				}
+			})
+		})
+	}
+
+	t.Run("OfflineWinsOverExplicitVersionCheckEnable", func(t *testing.T) {
+		clearAllConfigEnvVars(t)
+		withTempDir(t, func(dir string) {
+			yaml := "offline: true\nversion_check:\n  enabled: true\n"
+			if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(yaml), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("GOMODEL_VERSION_CHECK_ENABLED", "true")
+			result, err := Load()
+			if err != nil {
+				t.Fatalf("Load() failed: %v", err)
+			}
+			if result.Config.VersionCheck.Enabled {
+				t.Error("offline mode must win over an explicit version_check.enabled")
+			}
+		})
+	})
+
+	t.Run("DefaultIsOnline", func(t *testing.T) {
+		clearAllConfigEnvVars(t)
+		withTempDir(t, func(_ string) {
+			result, err := Load()
+			if err != nil {
+				t.Fatalf("Load() failed: %v", err)
+			}
+			if result.Config.Offline {
+				t.Error("Offline should default to false")
+			}
+			if !result.Config.VersionCheck.Enabled || result.Config.Cache.Model.ModelList.URL == "" {
+				t.Error("online defaults should be untouched")
+			}
+		})
+	})
+}
+
+func TestIsLocalModelListSource(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"", false},
+		{"https://example.com/models.json", false},
+		{"HTTP://example.com/models.json", false},
+		{"file:///etc/gomodel/models.json", true},
+		{"FILE:///etc/gomodel/models.json", true},
+		{"/etc/gomodel/models.json", true},
+		{"./models.json", true},
+		{"models.json", true},
+	}
+	for _, tt := range tests {
+		if got := IsLocalModelListSource(tt.in); got != tt.want {
+			t.Errorf("IsLocalModelListSource(%q) = %v, want %v", tt.in, got, tt.want)
+		}
 	}
 }

--- a/config/env.go
+++ b/config/env.go
@@ -16,7 +16,37 @@ func applyEnvOverrides(cfg *Config) error {
 		return err
 	}
 	normalizeModelListURL(cfg)
+	applyOfflineMode(cfg)
 	return nil
+}
+
+// applyOfflineMode enforces the offline switch after every other source has
+// been applied, so neither config.yaml nor an env var can re-enable an
+// outbound call underneath it. A model catalog read from the local
+// filesystem is kept: it makes no network request.
+func applyOfflineMode(cfg *Config) {
+	if !cfg.Offline {
+		return
+	}
+	cfg.VersionCheck.Enabled = false
+	if url := cfg.Cache.Model.ModelList.URL; url != "" && !IsLocalModelListSource(url) {
+		cfg.Cache.Model.ModelList.URL = ""
+	}
+}
+
+// IsLocalModelListSource reports whether a model list location names a file
+// on the local filesystem ("file://..." or a bare path) rather than an HTTP
+// URL. It mirrors what the catalog fetcher accepts.
+func IsLocalModelListSource(location string) bool {
+	location = strings.TrimSpace(location)
+	if location == "" {
+		return false
+	}
+	lower := strings.ToLower(location)
+	if strings.HasPrefix(lower, "file://") {
+		return true
+	}
+	return !strings.HasPrefix(lower, "http://") && !strings.HasPrefix(lower, "https://")
 }
 
 // normalizeModelListURL maps the sentinel "off" (case-insensitive) to an empty

--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -90,6 +90,8 @@ bodies, headers), see [Audit Logging](#audit-logging) below.
 | `GOMODEL_CACHE_DIR` | Directory for local cache files   | `.cache`         |
 | `CACHE_REFRESH_INTERVAL` | Seconds between provider model re-discovery runs | `3600` (1h) |
 | `PROVIDER_RECHECK_INTERVAL` | Seconds between re-probes of providers whose last refresh failed (`0` disables) | `60` |
+| `MODEL_LIST_URL`    | Model metadata catalog: an HTTP URL, a local file path (`/etc/gomodel/models.json` or `file://...`), or `off` | public catalog on GitHub |
+| `GOMODEL_OFFLINE`   | Air-gap switch: disables the update check and drops HTTP catalog URLs. Local catalog files and configured providers are unaffected | `false` |
 | `REDIS_URL`         | Redis connection URL              | _(empty)_        |
 | `REDIS_KEY_MODELS`     | Redis key for model cache           | `gomodel:models`    |
 | `REDIS_KEY_RESPONSES`  | Redis key for response cache        | `gomodel:response:` |

--- a/docs/advanced/model-metadata.mdx
+++ b/docs/advanced/model-metadata.mdx
@@ -69,6 +69,19 @@ flowchart LR
 If the catalog fetch fails or the deployment is air-gapped, the gateway runs
 normally — only the catalog-supplied defaults (including catalog pricing) are
 missing. Pricing overrides, `config.yaml` metadata, provider discovery signals,
-and the ID heuristic still apply. Mirror `MODEL_LIST_URL` internally, or set
-`MODEL_LIST_URL=off` to turn the download off entirely and declare metadata in
-`config.yaml`; see [Production guide](/guides/production) for details.
+and the ID heuristic still apply.
+
+`MODEL_LIST_URL` accepts a local file as well as an HTTP URL:
+
+```bash
+MODEL_LIST_URL=/etc/gomodel/models.json          # bare path
+MODEL_LIST_URL=file:///etc/gomodel/models.json   # file URL
+```
+
+A file is read on startup and on every cache refresh, and re-parsed only when
+its content changes, so you can update pricing by replacing the file. Because
+a file involves no network request, it keeps working under
+`GOMODEL_OFFLINE=true`, which drops HTTP catalog URLs. Set `MODEL_LIST_URL=off`
+to turn the catalog off entirely and declare metadata in `config.yaml`; see the
+[production guide](/guides/production#air-gapped-and-offline-deployments) for
+the full air-gap checklist.

--- a/docs/advanced/version-awareness.mdx
+++ b/docs/advanced/version-awareness.mdx
@@ -116,7 +116,11 @@ dashboard simply shows no update notice.
 
 ## Air-gapped and mirrored deployments
 
-Point the check at your own host and serve `core.txt` (or `pro.txt`) from it:
+`GOMODEL_OFFLINE=true` turns the check off together with the remote model
+catalog download; see the
+[production guide](/guides/production#air-gapped-and-offline-deployments).
+
+To keep update notices inside an air gap instead, point the check at your own host and serve `core.txt` (or `pro.txt`) from it:
 
 ```bash
 GOMODEL_VERSION_CHECK_URL=https://releases.internal.example.com/version

--- a/docs/guides/production.mdx
+++ b/docs/guides/production.mdx
@@ -174,41 +174,69 @@ call the gateway directly. Add the headers at your proxy if you need that.
 
 ## Air-gapped and offline deployments
 
-**GoModel runs fully air-gapped.** There is no telemetry, no phone-home, no
-update check, and no license check. The admin dashboard is embedded in the
-binary and its fonts are vendored, so the UI loads no CDN assets. Paired with
-local model servers such as [Ollama](/providers/multiple-ollama),
-[SGLang](/providers/sglang), or [vLLM](/providers/vllm), the gateway needs no
-route to the public internet.
+**GoModel runs fully air-gapped.** There is no telemetry, no analytics, and no
+license check. The admin dashboard is embedded in the binary and its fonts are
+vendored, so the UI loads no CDN assets. Paired with local model servers such
+as [Ollama](/providers/multiple-ollama), [SGLang](/providers/sglang), or
+[vLLM](/providers/vllm), the gateway needs no route to the public internet.
 
-There is exactly one outbound call that is not to a configured provider: the
-model metadata registry at `MODEL_LIST_URL`, which supplies pricing, context
-windows, and capabilities. It is fetched in a background goroutine at startup
-and again on each cache refresh.
+By default the gateway makes exactly two outbound calls that are not to a
+configured provider, and one switch turns both off:
 
-That fetch is best-effort. When it fails the gateway boots normally, `/health`
-and `/health/ready` return `200`, provider discovery still works because model
-lists come from each provider's own `/models` endpoint, and requests route
-normally. What you lose is metadata enrichment.
+```bash
+GOMODEL_OFFLINE=true
+```
+
+| Call | What it does | Default |
+| --- | --- | --- |
+| [Update check](/advanced/version-awareness) at `GOMODEL_VERSION_CHECK_URL` | Daily fetch of the latest release number, with an anonymous install id | on |
+| [Model catalog](/advanced/model-metadata) at `MODEL_LIST_URL` | Pricing, context windows, and capabilities, fetched at startup and on each cache refresh | on |
+
+`GOMODEL_OFFLINE=true` (or `offline: true` in `config.yaml`) disables the
+update check and drops any HTTP catalog URL. It is applied after every other
+setting, so nothing in `config.yaml` or the environment can re-enable an
+outbound call underneath it. Calls to configured providers and to anything you
+declared yourself, such as an OTLP collector, MCP upstreams, or a vector
+store, are untouched. The startup log confirms the mode.
+
+You can also control the two calls individually with
+`GOMODEL_VERSION_CHECK_ENABLED=false` and `MODEL_LIST_URL=off`.
+
+The catalog fetch is best-effort. When it is off or fails, the gateway boots
+normally, `/health` and `/health/ready` return `200`, provider discovery still
+works because model lists come from each provider's own `/models` endpoint,
+and requests route normally. What you lose is metadata enrichment.
 
 <Warning>
   Without metadata enrichment, models have **no pricing**. Cost tracking then
   reports no cost, and since [budgets](/features/budgets) read spend from usage
   cost records, budgets have nothing to charge against and will not enforce
   spend limits.
-
-  Fix it either by mirroring the model list internally and pointing
-  `MODEL_LIST_URL` at your mirror, or by declaring pricing per model under
-  `providers.<name>.models[].metadata.pricing` in `config.yaml`.
 </Warning>
 
+Keep pricing in an air gap in one of three ways:
+
+1. **Ship the catalog as a file.** Download `models.min.json` outside the air
+   gap, copy it in, and point the gateway at it. A local file is read, never
+   fetched, so it stays active under `GOMODEL_OFFLINE=true`:
+
+   ```bash
+   MODEL_LIST_URL=/etc/gomodel/models.json   # or file:///etc/gomodel/models.json
+   ```
+
+   The file is re-read on every cache refresh, so replacing it on disk updates
+   pricing without a restart.
+2. **Mirror it.** Serve the file from an internal HTTP host and set
+   `MODEL_LIST_URL` to that URL. Leave `GOMODEL_OFFLINE` unset and disable the
+   update check separately, or point `GOMODEL_VERSION_CHECK_URL` at an
+   internal mirror too.
+3. **Declare pricing per model** under `providers.<name>.models[].metadata.pricing`
+   in `config.yaml`.
+
 <Note>
-  To disable the fetch entirely — for fully air-gapped installs — set
-  `MODEL_LIST_URL=off` (or `cache.model.model_list.url: "off"` in
-  `config.yaml`). Setting the variable to an empty string does **not**
-  disable it: empty env values are skipped, so the default URL survives.
-  To redirect the fetch instead, point `MODEL_LIST_URL` at an internal
-  mirror.
+  Setting `MODEL_LIST_URL` to an empty string does **not** disable the
+  download: empty env values are skipped, so the default URL survives. Use
+  `off` or `GOMODEL_OFFLINE=true`.
 </Note>
 
 If a Bedrock provider is configured, the AWS SDK may also probe the link-local
@@ -384,6 +412,6 @@ if the file size matters.
   `terminationGracePeriodSeconds` above 30.
 - Enable metrics and alert on `gomodel_circuit_breaker_state` and on
   `usage log buffer full`.
-- For air-gapped installs, mirror `MODEL_LIST_URL` (or disable it with
-  `MODEL_LIST_URL=off`) and declare model pricing in config so cost tracking
-  and budgets keep working.
+- For air-gapped installs, set `GOMODEL_OFFLINE=true`, then ship the model
+  catalog as a file or declare model pricing in config so cost tracking and
+  budgets keep working.

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -63,6 +63,14 @@ func newBootstrap(ctx context.Context, cfg Config) *bootstrap {
 	// Install config-file HTTP timeouts before any provider constructs a
 	// transport; env vars still take precedence inside httpclient.
 	httpclient.SetConfiguredTimeouts(appCfg.HTTP.Timeout, appCfg.HTTP.ResponseHeaderTimeout)
+	if appCfg.Offline {
+		catalog := "disabled"
+		if appCfg.Cache.Model.ModelList.URL != "" {
+			catalog = "local file"
+		}
+		slog.Info("offline mode: update check disabled, remote model catalog download disabled; only configured providers and declared endpoints are contacted",
+			"model_catalog", catalog)
+	}
 	if appCfg.Budgets.Enabled && !appCfg.Usage.Enabled {
 		appCfg.Budgets.Enabled = false
 		slog.Warn("budget management disabled because usage tracking is disabled",

--- a/internal/modeldata/fetcher.go
+++ b/internal/modeldata/fetcher.go
@@ -2,9 +2,14 @@ package modeldata
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
+	neturl "net/url"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/goccy/go-json"
@@ -16,6 +21,9 @@ import (
 var httpClient = &http.Client{
 	Timeout: 60 * time.Second,
 }
+
+// maxBodySize caps a catalog, whether downloaded or read from disk.
+const maxBodySize = 10 * 1024 * 1024 // 10 MB
 
 // FetchResult carries the outcome of one conditional model list fetch.
 type FetchResult struct {
@@ -48,6 +56,9 @@ func FetchIfChanged(ctx context.Context, url, etag string) (FetchResult, error) 
 	if url == "" {
 		return FetchResult{}, nil
 	}
+	if path, ok := localPath(url); ok {
+		return readLocal(path, etag)
+	}
 
 	client := httpClient
 
@@ -79,7 +90,6 @@ func FetchIfChanged(ctx context.Context, url, etag string) (FetchResult, error) 
 		return FetchResult{}, fmt.Errorf("unexpected status %d from %s", resp.StatusCode, url)
 	}
 
-	const maxBodySize = 10 * 1024 * 1024 // 10 MB
 	limited := io.LimitReader(resp.Body, maxBodySize+1)
 	raw, err := io.ReadAll(limited)
 	if err != nil {
@@ -95,6 +105,55 @@ func FetchIfChanged(ctx context.Context, url, etag string) (FetchResult, error) 
 	}
 
 	return FetchResult{List: list, Raw: raw, ETag: resp.Header.Get("ETag")}, nil
+}
+
+// localPath reports whether location names a file on the local filesystem
+// and returns the path. Both "file:///etc/gomodel/models.json" and a bare
+// "/etc/gomodel/models.json" (or a relative path) are accepted, so an
+// air-gapped install can ship the catalog next to the binary or mount it.
+func localPath(location string) (string, bool) {
+	trimmed := strings.TrimSpace(location)
+	lower := strings.ToLower(trimmed)
+	switch {
+	case strings.HasPrefix(lower, "file://"):
+		u, err := neturl.Parse(trimmed)
+		if err != nil || u.Path == "" {
+			// "file://relative/path" has a host and no path; treat the
+			// remainder as the path so the mistake still resolves.
+			return strings.TrimPrefix(trimmed[len("file://"):], "/"), true
+		}
+		if u.Host != "" && u.Host != "localhost" {
+			return u.Host + u.Path, true
+		}
+		return u.Path, true
+	case strings.HasPrefix(lower, "http://"), strings.HasPrefix(lower, "https://"):
+		return "", false
+	default:
+		return trimmed, true
+	}
+}
+
+// readLocal loads the catalog from disk. The validator is a digest of the
+// content, so an unchanged file reports NotModified exactly like a 304 and
+// callers skip the reparse and re-enrichment.
+func readLocal(path, etag string) (FetchResult, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return FetchResult{}, fmt.Errorf("reading model list file: %w", err)
+	}
+	if len(raw) > maxBodySize {
+		return FetchResult{}, fmt.Errorf("model list file too large (exceeds %d bytes)", maxBodySize)
+	}
+	sum := sha256.Sum256(raw)
+	digest := `"sha256-` + hex.EncodeToString(sum[:]) + `"`
+	if etag != "" && etag == digest {
+		return FetchResult{ETag: digest, NotModified: true}, nil
+	}
+	list, err := Parse(raw)
+	if err != nil {
+		return FetchResult{}, err
+	}
+	return FetchResult{List: list, Raw: raw, ETag: digest}, nil
 }
 
 // Parse deserializes raw JSON bytes into a ModelList.

--- a/internal/modeldata/fetcher.go
+++ b/internal/modeldata/fetcher.go
@@ -10,6 +10,7 @@ import (
 	neturl "net/url"
 	"os"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/goccy/go-json"
@@ -137,25 +138,27 @@ func localPath(location string) (string, bool) {
 // content, so an unchanged file reports NotModified exactly like a 304 and
 // callers skip the reparse and re-enrichment.
 func readLocal(path, etag string) (FetchResult, error) {
-	// Stat before Open: opening a FIFO or device blocks with no context to
-	// cancel it, and an oversized file is cheaper to reject from metadata
-	// than after allocating it. The read stays bounded in case the file
-	// changes between the check and the read.
-	info, err := os.Stat(path)
+	// Open non-blocking so a FIFO or device at the path returns immediately
+	// instead of hanging with no context to cancel it, then validate the
+	// descriptor we actually hold rather than a path that may have been
+	// swapped underneath us. O_NONBLOCK has no effect on regular files.
+	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		return FetchResult{}, fmt.Errorf("reading model list file: %w", err)
+	}
+	defer f.Close()
+	info, err := f.Stat()
 	if err != nil {
 		return FetchResult{}, fmt.Errorf("reading model list file: %w", err)
 	}
 	if !info.Mode().IsRegular() {
 		return FetchResult{}, fmt.Errorf("model list file %s is not a regular file (%s)", path, info.Mode().Type())
 	}
+	// Reject an oversized file from its metadata before allocating anything,
+	// and keep the read itself bounded in case the file grows in between.
 	if info.Size() > maxBodySize {
 		return FetchResult{}, fmt.Errorf("model list file too large (%d bytes exceeds %d)", info.Size(), maxBodySize)
 	}
-	f, err := os.Open(path)
-	if err != nil {
-		return FetchResult{}, fmt.Errorf("reading model list file: %w", err)
-	}
-	defer f.Close()
 	raw, err := io.ReadAll(io.LimitReader(f, maxBodySize+1))
 	if err != nil {
 		return FetchResult{}, fmt.Errorf("reading model list file: %w", err)

--- a/internal/modeldata/fetcher.go
+++ b/internal/modeldata/fetcher.go
@@ -137,16 +137,25 @@ func localPath(location string) (string, bool) {
 // content, so an unchanged file reports NotModified exactly like a 304 and
 // callers skip the reparse and re-enrichment.
 func readLocal(path, etag string) (FetchResult, error) {
+	// Stat before Open: opening a FIFO or device blocks with no context to
+	// cancel it, and an oversized file is cheaper to reject from metadata
+	// than after allocating it. The read stays bounded in case the file
+	// changes between the check and the read.
+	info, err := os.Stat(path)
+	if err != nil {
+		return FetchResult{}, fmt.Errorf("reading model list file: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return FetchResult{}, fmt.Errorf("model list file %s is not a regular file (%s)", path, info.Mode().Type())
+	}
+	if info.Size() > maxBodySize {
+		return FetchResult{}, fmt.Errorf("model list file too large (%d bytes exceeds %d)", info.Size(), maxBodySize)
+	}
 	f, err := os.Open(path)
 	if err != nil {
 		return FetchResult{}, fmt.Errorf("reading model list file: %w", err)
 	}
 	defer f.Close()
-	// Reject an oversized file from its metadata before allocating anything,
-	// and keep the read itself bounded in case the file grows in between.
-	if info, err := f.Stat(); err == nil && info.Size() > maxBodySize {
-		return FetchResult{}, fmt.Errorf("model list file too large (%d bytes exceeds %d)", info.Size(), maxBodySize)
-	}
 	raw, err := io.ReadAll(io.LimitReader(f, maxBodySize+1))
 	if err != nil {
 		return FetchResult{}, fmt.Errorf("reading model list file: %w", err)

--- a/internal/modeldata/fetcher.go
+++ b/internal/modeldata/fetcher.go
@@ -137,7 +137,17 @@ func localPath(location string) (string, bool) {
 // content, so an unchanged file reports NotModified exactly like a 304 and
 // callers skip the reparse and re-enrichment.
 func readLocal(path, etag string) (FetchResult, error) {
-	raw, err := os.ReadFile(path)
+	f, err := os.Open(path)
+	if err != nil {
+		return FetchResult{}, fmt.Errorf("reading model list file: %w", err)
+	}
+	defer f.Close()
+	// Reject an oversized file from its metadata before allocating anything,
+	// and keep the read itself bounded in case the file grows in between.
+	if info, err := f.Stat(); err == nil && info.Size() > maxBodySize {
+		return FetchResult{}, fmt.Errorf("model list file too large (%d bytes exceeds %d)", info.Size(), maxBodySize)
+	}
+	raw, err := io.ReadAll(io.LimitReader(f, maxBodySize+1))
 	if err != nil {
 		return FetchResult{}, fmt.Errorf("reading model list file: %w", err)
 	}

--- a/internal/modeldata/fetcher_test.go
+++ b/internal/modeldata/fetcher_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -411,5 +413,88 @@ func TestParse_PricingTimeWindows(t *testing.T) {
 	monday := time.Date(2026, 8, 24, 8, 0, 0, 0, time.UTC)
 	if got := pricing.AtTime(monday); *got.InputPerMtok != 0.44 {
 		t.Fatalf("AtTime(monday peak) = %v, want base 0.44", *got.InputPerMtok)
+	}
+}
+
+func TestFetchIfChanged_LocalFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "models.json")
+	content := []byte(`{"models":{"openai/gpt-4o":{"provider":"openai","name":"gpt-4o"}}}`)
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, location := range []string{path, "file://" + path} {
+		t.Run(location, func(t *testing.T) {
+			first, err := FetchIfChanged(context.Background(), location, "")
+			if err != nil {
+				t.Fatalf("first read: %v", err)
+			}
+			if first.List == nil || first.NotModified || first.ETag == "" {
+				t.Fatalf("first read should parse and return a validator: %+v", first)
+			}
+			if len(first.List.Models) != 1 {
+				t.Fatalf("models = %d, want 1", len(first.List.Models))
+			}
+
+			second, err := FetchIfChanged(context.Background(), location, first.ETag)
+			if err != nil {
+				t.Fatalf("second read: %v", err)
+			}
+			if !second.NotModified || second.ETag != first.ETag {
+				t.Fatalf("unchanged file should report NotModified with the same validator: %+v", second)
+			}
+
+			if err := os.WriteFile(path, []byte(`{"models":{}}`), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			third, err := FetchIfChanged(context.Background(), location, first.ETag)
+			if err != nil {
+				t.Fatalf("third read: %v", err)
+			}
+			if third.NotModified || third.List == nil || third.ETag == first.ETag {
+				t.Fatalf("changed file should be re-read with a new validator: %+v", third)
+			}
+			// Restore for the next location.
+			if err := os.WriteFile(path, content, 0o600); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestFetchIfChanged_LocalFileErrors(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := FetchIfChanged(context.Background(), filepath.Join(dir, "missing.json"), ""); err == nil {
+		t.Error("missing file should error")
+	}
+	bad := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(bad, []byte("not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := FetchIfChanged(context.Background(), bad, ""); err == nil {
+		t.Error("invalid JSON should error")
+	}
+}
+
+func TestLocalPath(t *testing.T) {
+	tests := []struct {
+		in       string
+		wantPath string
+		wantOK   bool
+	}{
+		{"https://example.com/m.json", "", false},
+		{"http://example.com/m.json", "", false},
+		{"file:///etc/gomodel/models.json", "/etc/gomodel/models.json", true},
+		{"file://localhost/etc/models.json", "/etc/models.json", true},
+		{"/etc/gomodel/models.json", "/etc/gomodel/models.json", true},
+		{"./models.json", "./models.json", true},
+		{"  /tmp/m.json  ", "/tmp/m.json", true},
+	}
+	for _, tt := range tests {
+		gotPath, gotOK := localPath(tt.in)
+		if gotOK != tt.wantOK || gotPath != tt.wantPath {
+			t.Errorf("localPath(%q) = (%q, %v), want (%q, %v)", tt.in, gotPath, gotOK, tt.wantPath, tt.wantOK)
+		}
 	}
 }

--- a/internal/modeldata/fetcher_test.go
+++ b/internal/modeldata/fetcher_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 )
@@ -479,31 +478,6 @@ func TestFetchIfChanged_LocalFileErrors(t *testing.T) {
 	}
 	if _, err := FetchIfChanged(context.Background(), dir, ""); err == nil || !strings.Contains(err.Error(), "not a regular file") {
 		t.Errorf("directory should be rejected as not a regular file, got %v", err)
-	}
-}
-
-func TestFetchIfChanged_LocalFIFODoesNotBlock(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("no FIFOs on windows")
-	}
-	fifo := filepath.Join(t.TempDir(), "catalog.fifo")
-	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
-		t.Fatal(err)
-	}
-	// Opening a FIFO with no writer blocks forever; readLocal must reject it
-	// from metadata instead of hanging startup.
-	done := make(chan error, 1)
-	go func() {
-		_, err := FetchIfChanged(context.Background(), fifo, "")
-		done <- err
-	}()
-	select {
-	case err := <-done:
-		if err == nil || !strings.Contains(err.Error(), "not a regular file") {
-			t.Errorf("expected not-a-regular-file error, got %v", err)
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("FetchIfChanged blocked on a FIFO")
 	}
 }
 

--- a/internal/modeldata/fetcher_test.go
+++ b/internal/modeldata/fetcher_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -475,6 +476,34 @@ func TestFetchIfChanged_LocalFileErrors(t *testing.T) {
 	}
 	if _, err := FetchIfChanged(context.Background(), bad, ""); err == nil {
 		t.Error("invalid JSON should error")
+	}
+	if _, err := FetchIfChanged(context.Background(), dir, ""); err == nil || !strings.Contains(err.Error(), "not a regular file") {
+		t.Errorf("directory should be rejected as not a regular file, got %v", err)
+	}
+}
+
+func TestFetchIfChanged_LocalFIFODoesNotBlock(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no FIFOs on windows")
+	}
+	fifo := filepath.Join(t.TempDir(), "catalog.fifo")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Opening a FIFO with no writer blocks forever; readLocal must reject it
+	// from metadata instead of hanging startup.
+	done := make(chan error, 1)
+	go func() {
+		_, err := FetchIfChanged(context.Background(), fifo, "")
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "not a regular file") {
+			t.Errorf("expected not-a-regular-file error, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("FetchIfChanged blocked on a FIFO")
 	}
 }
 

--- a/internal/modeldata/fetcher_test.go
+++ b/internal/modeldata/fetcher_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -496,5 +497,31 @@ func TestLocalPath(t *testing.T) {
 		if gotOK != tt.wantOK || gotPath != tt.wantPath {
 			t.Errorf("localPath(%q) = (%q, %v), want (%q, %v)", tt.in, gotPath, gotOK, tt.wantPath, tt.wantOK)
 		}
+	}
+}
+
+func TestFetchIfChanged_LocalFileOversizedIsRejectedBeforeAllocation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "huge.json")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A sparse file well past the limit costs no disk and no memory to
+	// create; a full read would allocate the whole thing.
+	if err := f.Truncate(maxBodySize * 8); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	_, err = FetchIfChanged(context.Background(), path, "")
+	runtime.ReadMemStats(&after)
+	if err == nil || !strings.Contains(err.Error(), "too large") {
+		t.Fatalf("expected size rejection, got %v", err)
+	}
+	if allocated := after.TotalAlloc - before.TotalAlloc; allocated > maxBodySize {
+		t.Fatalf("oversized file allocated %d bytes before rejection; must stay under %d", allocated, maxBodySize)
 	}
 }

--- a/internal/modeldata/fetcher_unix_test.go
+++ b/internal/modeldata/fetcher_unix_test.go
@@ -1,0 +1,34 @@
+//go:build unix
+
+package modeldata
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestFetchIfChanged_LocalFIFODoesNotBlock(t *testing.T) {
+	fifo := filepath.Join(t.TempDir(), "catalog.fifo")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Opening a FIFO with no writer blocks forever; readLocal must reject it
+	// from metadata instead of hanging startup.
+	done := make(chan error, 1)
+	go func() {
+		_, err := FetchIfChanged(context.Background(), fifo, "")
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "not a regular file") {
+			t.Errorf("expected not-a-regular-file error, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("FetchIfChanged blocked on a FIFO")
+	}
+}


### PR DESCRIPTION
## Summary

Two things an air-gapped operator needs from core, plus a doc correction.

**`GOMODEL_OFFLINE=true`** (`offline: true` in `config.yaml`) is one switch that disables every outbound call the gateway makes on its own: the update check and the remote model catalog download. It is applied after every other config source, so neither `config.yaml` nor `GOMODEL_VERSION_CHECK_ENABLED=true` can re-enable a call underneath it. Calls to configured providers and operator-declared endpoints (OTLP, MCP upstreams, vector stores) are untouched. Startup logs the mode. Default: `false`, nothing changes for existing deployments.

**`MODEL_LIST_URL` accepts a local file.** A bare path (`/etc/gomodel/models.json`) or `file://` URL is read on startup and every cache refresh, and re-parsed only when its content changes (validator is a SHA-256 of the file, reusing the existing ETag path so `NotModified` short-circuits exactly like a 304). A local file involves no network request, so it stays active under `GOMODEL_OFFLINE=true`. This lets air-gapped sites keep pricing and budgets without running an HTTP mirror.

**Doc fix.** `docs/guides/production.mdx` claimed "no update check", but the version check ships enabled by default. The air-gap section now lists both outbound calls with their defaults, the single switch, and the three ways to keep pricing offline.

## Docs

- `docs/guides/production.mdx`: rewritten "Air-gapped and offline deployments" section, updated checklist.
- `docs/advanced/model-metadata.mdx`: file source under "Offline behavior".
- `docs/advanced/version-awareness.mdx`: pointer to the offline switch.
- `docs/advanced/configuration.mdx`: `MODEL_LIST_URL` and `GOMODEL_OFFLINE` rows.
- `.env.template`, `config/config.example.yaml`.

## Testing

- `config`: offline drops remote and mirror URLs, keeps file and bare-path sources, wins over an explicit `version_check.enabled: true`; default stays online; `IsLocalModelListSource` table.
- `internal/modeldata`: local file read for path and `file://`, NotModified on unchanged content, re-read on change, missing file and invalid JSON errors, `localPath` table.
- Full `make test-race` and `make lint` pass via pre-commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added offline mode to disable gateway-initiated update checks and remote model catalog downloads.
  * Added support for loading model catalogs from local files, including `file://` paths, with change detection during refresh.
  * Preserved configured providers and local catalog access while offline mode is enabled.
  * Added startup messaging that reports offline mode and catalog status.

* **Documentation**
  * Documented offline configuration, local catalogs, per-call controls, and air-gapped deployment options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->