### PR TITLE
fix(messages): accept image blocks inside tool_result

### DIFF
--- a/docs/advanced/anthropic-messages-api.mdx
+++ b/docs/advanced/anthropic-messages-api.mdx
@@ -193,6 +193,10 @@ features that have no canonical equivalent are not preserved end to end:
 - **`top_k`** is dropped — it has no portable OpenAI-compatible equivalent, and
   OpenAI-family providers reject unknown request fields. `temperature` and `top_p`
   are forwarded.
+- **Images inside `tool_result` blocks** (screenshots, image files read by a
+  tool — Claude Code returns them this way) are forwarded as native image blocks
+  when routed to Anthropic. Other providers receive only the text portion of the
+  tool result.
 - **`document` and other non-text/image content blocks** are rejected with a clear
   `400` error rather than silently dropped.
 - **`stop_sequences`** are honored on every provider. Providers that report the

--- a/internal/anthropicapi/request.go
+++ b/internal/anthropicapi/request.go
@@ -187,7 +187,7 @@ func convertBlockMessage(role string, blocks []ContentBlock) ([]core.Message, er
 			if id == "" {
 				return nil, fmt.Errorf("tool_result block is missing tool_use_id")
 			}
-			content, err := toolResultText(block.Content)
+			content, err := toolResultContent(block.Content)
 			if err != nil {
 				return nil, err
 			}
@@ -357,28 +357,52 @@ func validatedCacheControlJSON(raw json.RawMessage) (json.RawMessage, error) {
 	return validated, nil
 }
 
-// toolResultText extracts the text payload of a tool_result block content,
-// which itself may be a string or an array of text blocks. A present but
-// malformed or non-text tool_result content is an error rather than silently
-// dropped: the downstream provider must not receive an empty tool response.
-func toolResultText(raw json.RawMessage) (string, error) {
+// toolResultContent converts a tool_result block content, which itself may be
+// a string or an array of text and image blocks, into canonical message
+// content. Text-only results collapse to a plain string; results carrying
+// images (Claude Code returns screenshots and read image files this way)
+// keep the structured part list so the egress translator can forward them.
+// A present but malformed or otherwise unsupported tool_result content is an
+// error rather than silently dropped: the downstream provider must not
+// receive an empty or truncated tool response.
+func toolResultContent(raw json.RawMessage) (core.MessageContent, error) {
 	text, blocks, err := parseContent(raw)
 	if err != nil {
-		return "", fmt.Errorf("tool_result content: %v", err)
+		return nil, fmt.Errorf("tool_result content: %v", err)
 	}
 	if blocks == nil {
 		return text, nil
 	}
-	parts := make([]string, 0, len(blocks))
+	parts := make([]core.ContentPart, 0, len(blocks))
 	for _, block := range blocks {
-		if block.Type != "text" {
-			return "", fmt.Errorf("tool_result content block type %q is not supported; only text is allowed", block.Type)
+		extra, err := anthropicCacheControlExtra(block.CacheControl)
+		if err != nil {
+			return nil, fmt.Errorf("tool_result content: %v", err)
 		}
-		if block.Text != "" {
-			parts = append(parts, block.Text)
+		switch block.Type {
+		case "text":
+			if block.Text != "" {
+				parts = append(parts, core.ContentPart{Type: "text", Text: block.Text, ExtraFields: extra})
+			}
+		case "image":
+			url, err := imageURLFromSource(block.Source)
+			if err != nil {
+				return nil, fmt.Errorf("tool_result content: %v", err)
+			}
+			parts = append(parts, core.ContentPart{
+				Type:        "image_url",
+				ImageURL:    &core.ImageURLContent{URL: url},
+				ExtraFields: extra,
+			})
+		default:
+			return nil, fmt.Errorf("tool_result content block type %q is not supported; only text and image are allowed", block.Type)
 		}
 	}
-	return strings.Join(parts, "\n"), nil
+	content := collapseParts(parts)
+	if content == nil {
+		return "", nil
+	}
+	return content, nil
 }
 
 func imageURLFromSource(source *Source) (string, error) {
@@ -551,8 +575,8 @@ func EstimateInputTokens(req *MessagesRequest) int {
 		for _, block := range blocks {
 			chars += len(block.Text) + len(block.Thinking)
 			chars += len(bytes.TrimSpace(block.Input))
-			result, _ := toolResultText(block.Content)
-			chars += len(result)
+			result, _ := toolResultContent(block.Content)
+			chars += len(core.ExtractTextContent(result))
 		}
 	}
 	for _, tool := range req.Tools {

--- a/internal/anthropicapi/request_test.go
+++ b/internal/anthropicapi/request_test.go
@@ -71,7 +71,8 @@ func TestToChatRequestRejectsInvalidShapes(t *testing.T) {
 		{name: "malformed system", body: `{"model":"m","max_tokens":10,"system":42,"messages":[{"role":"user","content":"hi"}]}`},
 		{name: "non-text system block", body: `{"model":"m","max_tokens":10,"system":[{"type":"image"}],"messages":[{"role":"user","content":"hi"}]}`},
 		{name: "malformed tool_result content", body: `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":42}]}]}`},
-		{name: "non-text tool_result block", body: `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"image"}]}]}]}`},
+		{name: "unsupported tool_result block", body: `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"document"}]}]}]}`},
+		{name: "tool_result image without source", body: `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"image"}]}]}]}`},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -414,6 +415,59 @@ func TestToChatRequestExtraFields(t *testing.T) {
 	// providers reject unknown request fields; it must be dropped, not carried.
 	if raw := chat.ExtraFields.Lookup("top_k"); len(raw) > 0 {
 		t.Errorf("ExtraFields[top_k] = %s, want dropped", raw)
+	}
+}
+
+func TestToChatRequestToolResultWithImage(t *testing.T) {
+	chat, err := ToChatRequest(mustDecode(t, `{
+		"model":"m","max_tokens":10,
+		"messages":[
+			{"role":"assistant","content":[{"type":"tool_use","id":"tu_1","name":"screenshot","input":{}}]},
+			{"role":"user","content":[
+				{"type":"tool_result","tool_use_id":"tu_1","content":[
+					{"type":"text","text":"captured"},
+					{"type":"image","source":{"type":"base64","media_type":"image/png","data":"aGVsbG8="}}
+				]}
+			]}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("ToChatRequest: %v", err)
+	}
+	if len(chat.Messages) != 2 {
+		t.Fatalf("messages = %d, want assistant, tool", len(chat.Messages))
+	}
+	tool := chat.Messages[1]
+	if tool.Role != "tool" || tool.ToolCallID != "tu_1" {
+		t.Fatalf("tool message = %+v", tool)
+	}
+	parts, ok := tool.Content.([]core.ContentPart)
+	if !ok || len(parts) != 2 {
+		t.Fatalf("tool content = %T %#v, want two structured parts", tool.Content, tool.Content)
+	}
+	if parts[0].Type != "text" || parts[0].Text != "captured" {
+		t.Errorf("parts[0] = %+v, want text part", parts[0])
+	}
+	if parts[1].Type != "image_url" || parts[1].ImageURL == nil || parts[1].ImageURL.URL != "data:image/png;base64,aGVsbG8=" {
+		t.Errorf("parts[1] = %+v, want image_url data URL", parts[1])
+	}
+	if got := EstimateInputTokens(mustDecode(t, `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu_1","content":[{"type":"text","text":"captured"},{"type":"image","source":{"type":"base64","media_type":"image/png","data":"aGVsbG8="}}]}]}]}`)); got != 2 {
+		t.Errorf("EstimateInputTokens = %d, want 2 (text only)", got)
+	}
+}
+
+func TestToChatRequestToolResultTextOnlyStaysString(t *testing.T) {
+	chat, err := ToChatRequest(mustDecode(t, `{
+		"model":"m","max_tokens":10,
+		"messages":[{"role":"user","content":[
+			{"type":"tool_result","tool_use_id":"tu_1","content":[{"type":"text","text":"a"},{"type":"text","text":"b"}]}
+		]}]
+	}`))
+	if err != nil {
+		t.Fatalf("ToChatRequest: %v", err)
+	}
+	if got := chat.Messages[0].Content; got != "a\nb" {
+		t.Errorf("tool content = %#v, want joined string", got)
 	}
 }
 

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -1963,6 +1963,38 @@ func TestConvertToAnthropicRequest_ToolMessageRequiresToolCallID(t *testing.T) {
 	}
 }
 
+func TestConvertToAnthropicRequest_ToolMessageWithImage(t *testing.T) {
+	req, err := convertToAnthropicRequest(&core.ChatRequest{
+		Model: "claude-sonnet-4-5-20250929",
+		Messages: []core.Message{
+			{Role: "tool", ToolCallID: "call_123", Content: []core.ContentPart{
+				{Type: "text", Text: "captured"},
+				{Type: "image_url", ImageURL: &core.ImageURLContent{URL: "data:image/png;base64,aGVsbG8="}},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("convertToAnthropicRequest: %v", err)
+	}
+	if len(req.Messages) != 1 || req.Messages[0].Role != "user" {
+		t.Fatalf("messages = %+v, want one user message", req.Messages)
+	}
+	toolBlocks, ok := req.Messages[0].Content.([]anthropicContentBlock)
+	if !ok || len(toolBlocks) != 1 || toolBlocks[0].Type != "tool_result" || toolBlocks[0].ToolUseID != "call_123" {
+		t.Fatalf("content = %#v, want one tool_result block", req.Messages[0].Content)
+	}
+	inner, ok := toolBlocks[0].Content.([]anthropicContentBlock)
+	if !ok || len(inner) != 2 {
+		t.Fatalf("tool_result content = %#v, want text and image blocks", toolBlocks[0].Content)
+	}
+	if inner[0].Type != "text" || inner[0].Text != "captured" {
+		t.Errorf("inner[0] = %+v, want text block", inner[0])
+	}
+	if inner[1].Type != "image" || inner[1].Source == nil || inner[1].Source.Type != "base64" || inner[1].Source.MediaType != "image/png" || inner[1].Source.Data != "aGVsbG8=" {
+		t.Errorf("inner[1] = %+v, want base64 image block", inner[1])
+	}
+}
+
 func TestConvertToAnthropicRequest_ToolChoiceRequiresTools(t *testing.T) {
 	_, err := convertToAnthropicRequest(&core.ChatRequest{
 		Model: "claude-sonnet-4-5-20250929",

--- a/internal/providers/anthropic/request_translation.go
+++ b/internal/providers/anthropic/request_translation.go
@@ -241,11 +241,18 @@ func buildAnthropicMessageContent(msg core.Message) (any, error) {
 		if err != nil {
 			return nil, err
 		}
+		// Tool results may carry images (screenshots, image files read by a
+		// tool); Anthropic accepts text and image blocks inside tool_result,
+		// so structured content is forwarded as blocks rather than flattened.
+		content, err := convertMessageContentToAnthropic(msg.Content)
+		if err != nil {
+			return nil, err
+		}
 		return []anthropicContentBlock{
 			{
 				Type:         "tool_result",
 				ToolUseID:    toolUseID,
-				Content:      core.ExtractTextContent(msg.Content),
+				Content:      content,
 				CacheControl: cacheControl,
 			},
 		}, nil


### PR DESCRIPTION
## Summary

Claude Code returns screenshots and image files read by tools as `image` blocks inside `tool_result`. The `/v1/messages` ingress rejected them with:

```
400 messages[153]: tool_result content block type "image" is not supported; only text is allowed
```

The rejection was a deliberate "reject rather than silently drop" choice from the original ingress (#343), when the canonical tool message could only carry text. Because translation runs before native forwarding is decided, the request failed even when it would have been forwarded to Anthropic verbatim.

## Changes

- `anthropicapi`: `tool_result` content with `text` and `image` blocks becomes a structured tool message (`text` + `image_url` parts). Text-only results keep the plain-string shape. `document` and other block types are still rejected with a clear 400.
- `providers/anthropic`: tool messages with structured content are emitted as native `tool_result` blocks containing `text` and `image` blocks, instead of being flattened to text.
- Docs: Messages API limitations updated.

## Provider behavior

Anthropic receives the images natively. Other providers keep their existing tool-message handling and see only the text portion of an image-bearing tool result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NXZqcwjkYNEKBUNXizeuC5
