### PR TITLE
feat(dashboard): allow reordering virtual model targets via drag handle

### DIFF
--- a/docs/features/virtual-models.mdx
+++ b/docs/features/virtual-models.mdx
@@ -128,6 +128,20 @@ For example, point `smart` at both `openai/gpt-4o` and `anthropic/claude-sonnet-
 with the round-robin strategy to split load, or at a premium and a budget model
 with the cost strategy to always take the cheaper one.
 
+## Reorder targets
+
+The target list is an ordered list, and the editor keeps it editable: drag the
+**grip handle** (☰) left of a target's remove button onto another row to change
+its position. The drop row is not replaced — the dragged row moves into its
+position and the rows in between shift. Keyboard users can focus the handle and
+press **ArrowUp** / **ArrowDown** for the same move.
+
+The handle shows only when the redirect has more than one target, and every
+strategy benefits: for **failover** the order is the priority chain (position
+`1` is tried first), for the balancing strategies position `1` is the first
+slot in the queue. Weights and explicit provider pins stay attached to their
+target when it moves.
+
 ## Chain virtual models
 
 A redirect target can name **another virtual model** instead of a concrete

--- a/docs/features/virtual-models.mdx
+++ b/docs/features/virtual-models.mdx
@@ -131,7 +131,7 @@ with the cost strategy to always take the cheaper one.
 ## Reorder targets
 
 The target list is an ordered list, and the editor keeps it editable: drag the
-**grip handle** (☰) left of a target's remove button onto another row to change
+**grip handle** (☰) at the left edge of each target row onto another row to change
 its position. The drop row is not replaced — the dragged row moves into its
 position and the rows in between shift. Keyboard users can focus the handle and
 press **ArrowUp** / **ArrowDown** for the same move.

--- a/internal/admin/handler_virtualmodels_test.go
+++ b/internal/admin/handler_virtualmodels_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 
 	"github.com/labstack/echo/v5"
@@ -684,8 +685,8 @@ func TestUpsertVirtualModelTargetOrderRoundTrips(t *testing.T) {
 		t.Fatal("stored virtual model missing after initial put")
 	}
 	want := []string{"openai/gpt-4o", "openai/gpt-4o-mini", "anthropic/claude-haiku"}
-	if got := qualifiedTargetNames(vm.Targets); !slicesEqual(got, want) {
-		t.Fatalf("stored order = %v, want %v", got, want)
+	if !slices.Equal(qualifiedTargetNames(vm.Targets), want) {
+		t.Fatalf("stored order = %v, want %v", vm.Targets, want)
 	}
 
 	// Reorder save: what the editor sends after dragging the last target onto
@@ -698,8 +699,8 @@ func TestUpsertVirtualModelTargetOrderRoundTrips(t *testing.T) {
 		t.Fatal("stored virtual model missing after reorder put")
 	}
 	want = []string{"anthropic/claude-haiku", "openai/gpt-4o", "openai/gpt-4o-mini"}
-	if got := qualifiedTargetNames(vm.Targets); !slicesEqual(got, want) {
-		t.Fatalf("stored order after reorder = %v, want %v", got, want)
+	if !slices.Equal(qualifiedTargetNames(vm.Targets), want) {
+		t.Fatalf("stored order after reorder = %v, want %v", vm.Targets, want)
 	}
 
 	// The list view the dashboard renders must return the same order.
@@ -715,8 +716,8 @@ func TestUpsertVirtualModelTargetOrderRoundTrips(t *testing.T) {
 		if view.Source != "smart" {
 			continue
 		}
-		if got := qualifiedTargetNames(view.Targets); !slicesEqual(got, want) {
-			t.Fatalf("view order after reorder = %v, want %v", got, want)
+		if !slices.Equal(qualifiedTargetNames(view.Targets), want) {
+			t.Fatalf("view order after reorder = %v, want %v", view.Targets, want)
 		}
 		return
 	}
@@ -735,14 +736,3 @@ func qualifiedTargetNames(targets []virtualmodels.Target) []string {
 	return names
 }
 
-func slicesEqual(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}

--- a/internal/admin/handler_virtualmodels_test.go
+++ b/internal/admin/handler_virtualmodels_test.go
@@ -649,3 +649,100 @@ func TestDeleteVirtualModelNotFound(t *testing.T) {
 		t.Fatalf("status = %d, want 404 body=%s", rec.Code, rec.Body.String())
 	}
 }
+
+// TestUpsertVirtualModelTargetOrderRoundTrips pins the contract the
+// dashboard's drag-to-reorder relies on: the targets array travels in display
+// order (failover primary first), and a reorder save stores and returns the
+// targets in exactly the order the editor sent them.
+func TestUpsertVirtualModelTargetOrderRoundTrips(t *testing.T) {
+	catalog := newVMTestCatalog()
+	catalog.add("openai/gpt-4o", "openai")
+	catalog.add("openai/gpt-4o-mini", "openai")
+	catalog.add("anthropic/claude-haiku", "anthropic")
+	service := newVMService(t, catalog, newVMTestStore(redirectVM("smart", "openai/gpt-4o", true)), true)
+	h := NewHandler(nil, nil, WithVirtualModels(service))
+	e := echo.New()
+
+	put := func(body string) {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPut, "/admin/virtual-models", bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		if err := h.UpsertVirtualModel(e.NewContext(req, rec)); err != nil {
+			t.Fatalf("UpsertVirtualModel() error = %v", err)
+		}
+		if rec.Code != http.StatusOK {
+			t.Fatalf("put status = %d, want 200 body=%s", rec.Code, rec.Body.String())
+		}
+	}
+
+	// Initial order: gpt-4o is the failover primary.
+	put(`{"source":"smart","strategy":"failover","targets":[{"model":"openai/gpt-4o"},{"model":"openai/gpt-4o-mini"},{"model":"anthropic/claude-haiku"}]}`)
+
+	vm, ok := service.Get("smart")
+	if !ok {
+		t.Fatal("stored virtual model missing after initial put")
+	}
+	want := []string{"openai/gpt-4o", "openai/gpt-4o-mini", "anthropic/claude-haiku"}
+	if got := qualifiedTargetNames(vm.Targets); !slicesEqual(got, want) {
+		t.Fatalf("stored order = %v, want %v", got, want)
+	}
+
+	// Reorder save: what the editor sends after dragging the last target onto
+	// the first row. The new primary must land first, the rest keep their
+	// relative order.
+	put(`{"source":"smart","strategy":"failover","targets":[{"model":"anthropic/claude-haiku"},{"model":"openai/gpt-4o"},{"model":"openai/gpt-4o-mini"}]}`)
+
+	vm, ok = service.Get("smart")
+	if !ok {
+		t.Fatal("stored virtual model missing after reorder put")
+	}
+	want = []string{"anthropic/claude-haiku", "openai/gpt-4o", "openai/gpt-4o-mini"}
+	if got := qualifiedTargetNames(vm.Targets); !slicesEqual(got, want) {
+		t.Fatalf("stored order after reorder = %v, want %v", got, want)
+	}
+
+	// The list view the dashboard renders must return the same order.
+	c, rec := newHandlerContext("/admin/virtual-models")
+	if err := h.ListVirtualModels(c); err != nil {
+		t.Fatalf("ListVirtualModels() error = %v", err)
+	}
+	var views []virtualmodels.View
+	if err := json.Unmarshal(rec.Body.Bytes(), &views); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	for _, view := range views {
+		if view.Source != "smart" {
+			continue
+		}
+		if got := qualifiedTargetNames(view.Targets); !slicesEqual(got, want) {
+			t.Fatalf("view order after reorder = %v, want %v", got, want)
+		}
+		return
+	}
+	t.Fatal("smart missing from list views")
+}
+
+func qualifiedTargetNames(targets []virtualmodels.Target) []string {
+	names := make([]string, 0, len(targets))
+	for _, target := range targets {
+		if target.Provider != "" {
+			names = append(names, target.Provider+"/"+target.Model)
+			continue
+		}
+		names = append(names, target.Model)
+	}
+	return names
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/web/dashboard/messages/en.json
+++ b/web/dashboard/messages/en.json
@@ -630,6 +630,7 @@
   "models_weight": "weight",
   "models_weight_help": "Relative share of requests: 1 is a normal share, 2 gets twice as many, 3 three times (whole numbers, 1 or more).",
   "models_remove_target": "Remove target",
+  "models_move_target": "Drag to reorder (or focus and use the arrow keys)",
   "models_pricing_editor": "Model pricing editor",
   "models_pricing_save": "Save Pricing",
   "models_pricing_override": "Pricing override",

--- a/web/dashboard/messages/pl.json
+++ b/web/dashboard/messages/pl.json
@@ -638,6 +638,7 @@
   "models_weight": "waga",
   "models_weight_help": "Względny udział żądań: 1 to zwykły udział, 2 dostaje dwa razy więcej, 3 trzy razy (liczby całkowite, co najmniej 1).",
   "models_remove_target": "Usuń cel",
+  "models_move_target": "Przeciągnij, aby zmienić kolejność (lub skup i użyj klawiszy strzałek)",
   "models_pricing_editor": "Edytor cen modelu",
   "models_pricing_save": "Zapisz ceny",
   "models_pricing_override": "Nadpisanie cen",

--- a/web/dashboard/messages/pl.json
+++ b/web/dashboard/messages/pl.json
@@ -638,7 +638,7 @@
   "models_weight": "waga",
   "models_weight_help": "Względny udział żądań: 1 to zwykły udział, 2 dostaje dwa razy więcej, 3 trzy razy (liczby całkowite, co najmniej 1).",
   "models_remove_target": "Usuń cel",
-  "models_move_target": "Przeciągnij, aby zmienić kolejność (lub skup i użyj klawiszy strzałek)",
+  "models_move_target": "Przeciągnij, aby zmienić kolejność (lub ustaw fokus na uchwycie i użyj klawiszy strzałek)",
   "models_pricing_editor": "Edytor cen modelu",
   "models_pricing_save": "Zapisz ceny",
   "models_pricing_override": "Nadpisanie cen",

--- a/web/dashboard/src/pages/models/VirtualModelEditor.svelte
+++ b/web/dashboard/src/pages/models/VirtualModelEditor.svelte
@@ -20,8 +20,9 @@
 
   const vm = virtualModelEditor;
 
-  // The handle shows only when there is more than one row to reorder.
-  const canReorder = $derived(vm.vmTargetCount() > 1 && !vm.vmFormManaged);
+  // The handle shows only when there is more than one populated row to
+  // reorder; blank placeholder rows do not count.
+  const canReorder = $derived(vm.vmPopulatedTargetCount() > 1 && !vm.vmFormManaged);
   // Row indices must match the flattened target list the move logic operates
   // on: an empty primary row is not in that list, so extras start at 0 then.
   const hasPrimary = $derived(vmFormHasPrimaryTarget(vm.vmForm));

--- a/web/dashboard/src/pages/models/VirtualModelEditor.svelte
+++ b/web/dashboard/src/pages/models/VirtualModelEditor.svelte
@@ -20,6 +20,9 @@
 
   const vm = virtualModelEditor;
 
+  // The handle shows only when there is more than one row to reorder.
+  const canReorder = $derived(vm.vmTargetCount() > 1 && !vm.vmFormManaged);
+
   // The strategy dropdown is server-driven (VIRTUAL_MODEL_STRATEGIES); make
   // sure the runtime config is loaded by the time the editor shows it.
   $effect(() => {
@@ -81,7 +84,7 @@
     <VmTargetRow
       id="virtual-model-target"
       index={0}
-      draggable={vm.vmTargetCount() > 1 && !vm.vmFormManaged}
+      draggable={canReorder}
       bind:provider={vm.vmForm.target_provider}
       bind:model={vm.vmForm.target_model}
       bind:weight={vm.vmForm.target_weight}
@@ -92,7 +95,7 @@
       <VmTargetRow
         placeholder="groq/llama"
         index={index + 1}
-        draggable={vm.vmTargetCount() > 1 && !vm.vmFormManaged}
+        draggable={canReorder}
         bind:provider={target.provider}
         bind:model={target.model}
         bind:weight={target.weight}

--- a/web/dashboard/src/pages/models/VirtualModelEditor.svelte
+++ b/web/dashboard/src/pages/models/VirtualModelEditor.svelte
@@ -73,11 +73,15 @@
     />
   </FormField>
 
-  <!-- Every target renders the same; two or more turn the redirect into a load balancer. -->
+  <!-- Every target renders the same; two or more turn the redirect into a load balancer.
+       Rows carry their position in the flattened list (primary first) so the drag
+       handle can reorder across the primary/extra boundary. -->
   <div class="form-field">
     <span class="form-field-label">{m.models_targets()}</span>
     <VmTargetRow
       id="virtual-model-target"
+      index={0}
+      draggable={vm.vmTargetCount() > 1 && !vm.vmFormManaged}
       bind:provider={vm.vmForm.target_provider}
       bind:model={vm.vmForm.target_model}
       bind:weight={vm.vmForm.target_weight}
@@ -87,6 +91,8 @@
     {#each vm.vmForm.targets as target, index (index)}
       <VmTargetRow
         placeholder="groq/llama"
+        index={index + 1}
+        draggable={vm.vmTargetCount() > 1 && !vm.vmFormManaged}
         bind:provider={target.provider}
         bind:model={target.model}
         bind:weight={target.weight}

--- a/web/dashboard/src/pages/models/VirtualModelEditor.svelte
+++ b/web/dashboard/src/pages/models/VirtualModelEditor.svelte
@@ -86,7 +86,7 @@
     <span class="form-field-label">{m.models_targets()}</span>
     <VmTargetRow
       id="virtual-model-target"
-      index={0}
+      index={hasPrimary ? 0 : undefined}
       draggable={canReorder && hasPrimary}
       bind:provider={vm.vmForm.target_provider}
       bind:model={vm.vmForm.target_model}
@@ -98,7 +98,7 @@
       <VmTargetRow
         placeholder="groq/llama"
         index={(hasPrimary ? 1 : 0) + index}
-        draggable={canReorder}
+        draggable={canReorder && String(target.model || "").trim() !== ""}
         bind:provider={target.provider}
         bind:model={target.model}
         bind:weight={target.weight}

--- a/web/dashboard/src/pages/models/VirtualModelEditor.svelte
+++ b/web/dashboard/src/pages/models/VirtualModelEditor.svelte
@@ -22,6 +22,9 @@
 
   // The handle shows only when there is more than one row to reorder.
   const canReorder = $derived(vm.vmTargetCount() > 1 && !vm.vmFormManaged);
+  // Row indices must match the flattened target list the move logic operates
+  // on: an empty primary row is not in that list, so extras start at 0 then.
+  const hasPrimary = $derived(vmFormHasPrimaryTarget(vm.vmForm));
 
   // The strategy dropdown is server-driven (VIRTUAL_MODEL_STRATEGIES); make
   // sure the runtime config is loaded by the time the editor shows it.
@@ -84,7 +87,7 @@
     <VmTargetRow
       id="virtual-model-target"
       index={0}
-      draggable={canReorder}
+      draggable={canReorder && hasPrimary}
       bind:provider={vm.vmForm.target_provider}
       bind:model={vm.vmForm.target_model}
       bind:weight={vm.vmForm.target_weight}
@@ -94,7 +97,7 @@
     {#each vm.vmForm.targets as target, index (index)}
       <VmTargetRow
         placeholder="groq/llama"
-        index={index + 1}
+        index={(hasPrimary ? 1 : 0) + index}
         draggable={canReorder}
         bind:provider={target.provider}
         bind:model={target.model}

--- a/web/dashboard/src/pages/models/VmTargetRow.svelte
+++ b/web/dashboard/src/pages/models/VmTargetRow.svelte
@@ -47,6 +47,11 @@
   role="group"
   class:vm-target-dragging={vm.vmDragIndex === index}
   class:vm-target-drop={vm.vmDropIndex === index && vm.vmDragIndex !== null && vm.vmDragIndex !== index}
+  ondragenter={(event) => {
+    if (draggable && vm.vmDragIndex !== null) {
+      event.preventDefault();
+    }
+  }}
   ondragover={(event) => {
     if (draggable && vm.vmDragIndex !== null) {
       event.preventDefault();
@@ -150,6 +155,8 @@
     cursor: grab;
     color: var(--muted, var(--text));
     touch-action: none;
+    user-select: none;
+    -webkit-user-select: none;
   }
 
   .vm-target-move:active {

--- a/web/dashboard/src/pages/models/VmTargetRow.svelte
+++ b/web/dashboard/src/pages/models/VmTargetRow.svelte
@@ -73,35 +73,6 @@
     }
   }}
 >
-  <SearchSelect
-    {id}
-    class="vm-target-model"
-    options={vm.vmTargetOptions()}
-    bind:value={model}
-    onchange={() => {
-      provider = "";
-    }}
-    {placeholder}
-    searchPlaceholder={m.models_target_search_placeholder()}
-    ariaLabel={m.models_target_model()}
-    disabled={vm.vmFormManaged}
-    allowCustom
-    mono
-  />
-  {#if vmFormShowWeights(vm.vmForm)}
-    <input
-      type="number"
-      min="1"
-      step="1"
-      class="mono vm-target-weight"
-      placeholder={m.models_weight()}
-      title={m.models_weight_help()}
-      bind:value={weight}
-      disabled={vm.vmFormManaged}
-      required
-      aria-label={m.models_target_weight()}
-    />
-  {/if}
   {#if draggable}
     <span
       bind:this={moveHandle}
@@ -134,6 +105,35 @@
     >
       <Icon icon={GripVertical} class="table-icon-svg" />
     </span>
+  {/if}
+  <SearchSelect
+    {id}
+    class="vm-target-model"
+    options={vm.vmTargetOptions()}
+    bind:value={model}
+    onchange={() => {
+      provider = "";
+    }}
+    {placeholder}
+    searchPlaceholder={m.models_target_search_placeholder()}
+    ariaLabel={m.models_target_model()}
+    disabled={vm.vmFormManaged}
+    allowCustom
+    mono
+  />
+  {#if vmFormShowWeights(vm.vmForm)}
+    <input
+      type="number"
+      min="1"
+      step="1"
+      class="mono vm-target-weight"
+      placeholder={m.models_weight()}
+      title={m.models_weight_help()}
+      bind:value={weight}
+      disabled={vm.vmFormManaged}
+      required
+      aria-label={m.models_target_weight()}
+    />
   {/if}
   {#if showRemove}
     <TableActionButton

--- a/web/dashboard/src/pages/models/VmTargetRow.svelte
+++ b/web/dashboard/src/pages/models/VmTargetRow.svelte
@@ -1,13 +1,15 @@
 <script>
   // One target row of the virtual-model editor. The primary target and the
   // extra {#each} rows share this shape; two or more rows make the redirect
-  // a load balancer (weights show only for round-robin).
+  // a load balancer (weights show only for round-robin). The ☰ handle drags
+  // a row onto another row to reorder the list; keyboard users get the same
+  // via ArrowUp/ArrowDown on the focused handle.
   import Icon from "$lib/components/atoms/Icon.svelte";
   import SearchSelect from "$lib/components/molecules/SearchSelect.svelte";
   import TableActionButton from "$lib/components/atoms/TableActionButton.svelte";
   import { virtualModelEditor as vm } from "./virtualModelEditor.svelte.js";
-  import { vmFormShowWeights } from "./vmForm.js";
-  import { Trash2 } from "lucide";
+  import { moveFormTarget, vmFormShowWeights } from "./vmForm.js";
+  import { GripVertical, Trash2 } from "lucide";
   import * as m from "$lib/paraglide/messages.js";
 
   // provider is the explicit provider a stored target may carry (API- or
@@ -21,10 +23,33 @@
     placeholder = "openai/gpt-4o",
     showRemove = true,
     onremove,
+    // index is this row's position in the flattened target list (primary
+    // first); draggable turns on the reorder handle.
+    index = undefined,
+    draggable = false,
   } = $props();
 </script>
 
-<div class="vm-target-row">
+<div
+  class="vm-target-row"
+  role="group"
+  class:vm-target-dragging={vm.vmDragIndex === index}
+  class:vm-target-drop={vm.vmDropIndex === index && vm.vmDragIndex !== null && vm.vmDragIndex !== index}
+  ondragover={(event) => {
+    if (draggable && vm.vmDragIndex !== null) {
+      event.preventDefault();
+      event.dataTransfer.dropEffect = "move";
+      vm.enterVmTargetDrop(index);
+    }
+  }}
+  ondrop={(event) => {
+    if (draggable && vm.vmDragIndex !== null) {
+      event.preventDefault();
+      vm.dropVmTarget(index);
+    }
+  }}
+  ondragleave={() => vm.leaveVmTargetDrop(index)}
+>
   <SearchSelect
     {id}
     class="vm-target-model"
@@ -54,6 +79,36 @@
       aria-label={m.models_target_weight()}
     />
   {/if}
+  {#if draggable}
+    <span
+      class="vm-target-move"
+      role="button"
+      tabindex="0"
+      aria-label={m.models_move_target()}
+      title={m.models_move_target()}
+      draggable="true"
+      ondragstart={(event) => {
+        event.dataTransfer.effectAllowed = "move";
+        event.dataTransfer.setData("text/plain", String(index));
+        vm.startVmTargetDrag(index);
+      }}
+      ondragend={() => vm.endVmTargetDrag()}
+      onkeydown={(event) => {
+        if (event.key === "ArrowUp" && index > 0) {
+          event.preventDefault();
+          moveFormTarget(vm.vmForm, index, index - 1);
+        } else if (
+          event.key === "ArrowDown" &&
+          index < vm.vmTargetCount() - 1
+        ) {
+          event.preventDefault();
+          moveFormTarget(vm.vmForm, index, index + 1);
+        }
+      }}
+    >
+      <Icon icon={GripVertical} class="table-icon-svg" />
+    </span>
+  {/if}
   {#if showRemove}
     <TableActionButton
       label={m.models_remove_target()}
@@ -65,3 +120,27 @@
     </TableActionButton>
   {/if}
 </div>
+
+<style>
+  .vm-target-move {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: grab;
+    color: var(--muted, var(--text));
+    touch-action: none;
+  }
+
+  .vm-target-move:active {
+    cursor: grabbing;
+  }
+
+  .vm-target-row.vm-target-dragging {
+    opacity: 0.4;
+  }
+
+  .vm-target-row.vm-target-drop {
+    outline: 2px dashed var(--accent);
+    outline-offset: 2px;
+  }
+</style>

--- a/web/dashboard/src/pages/models/VmTargetRow.svelte
+++ b/web/dashboard/src/pages/models/VmTargetRow.svelte
@@ -28,6 +28,18 @@
     index = undefined,
     draggable = false,
   } = $props();
+
+  let moveHandle = $state(null);
+
+  // After a keyboard move the editor asks for focus at the moved row's new
+  // index; grab it here so repeated arrows walk the same model, not whatever
+  // row now sits at the old index.
+  $effect(() => {
+    if (draggable && vm.vmFocusHandle === index && moveHandle) {
+      moveHandle.focus();
+      vm.clearVmFocusHandle();
+    }
+  });
 </script>
 
 <div
@@ -81,6 +93,7 @@
   {/if}
   {#if draggable}
     <span
+      bind:this={moveHandle}
       class="vm-target-move"
       role="button"
       tabindex="0"
@@ -97,12 +110,14 @@
         if (event.key === "ArrowUp" && index > 0) {
           event.preventDefault();
           moveFormTarget(vm.vmForm, index, index - 1);
+          vm.requestVmFocusHandle(index - 1);
         } else if (
           event.key === "ArrowDown" &&
           index < vm.vmTargetCount() - 1
         ) {
           event.preventDefault();
           moveFormTarget(vm.vmForm, index, index + 1);
+          vm.requestVmFocusHandle(index + 1);
         }
       }}
     >

--- a/web/dashboard/src/pages/models/VmTargetRow.svelte
+++ b/web/dashboard/src/pages/models/VmTargetRow.svelte
@@ -60,7 +60,13 @@
       vm.dropVmTarget(index);
     }
   }}
-  ondragleave={() => vm.leaveVmTargetDrop(index)}
+  ondragleave={(event) => {
+    // Child elements fire dragleave when the cursor moves between them;
+    // only clear the highlight when the cursor left the row itself.
+    if (!event.currentTarget.contains(event.relatedTarget)) {
+      vm.leaveVmTargetDrop(index);
+    }
+  }}
 >
   <SearchSelect
     {id}

--- a/web/dashboard/src/pages/models/virtualModelEditor.svelte.js
+++ b/web/dashboard/src/pages/models/virtualModelEditor.svelte.js
@@ -53,6 +53,11 @@ class VirtualModelEditorStore {
   // the drop highlight). Both reset when the drag ends.
   vmDragIndex = $state(null);
   vmDropIndex = $state(null);
+  // After a keyboard move, focus must follow the moved row: the each block
+  // reuses DOM nodes per position, so without this the focus would stay on
+  // the handle at the old index (now a different model). Set to the moved
+  // row's new index; VmTargetRow focuses that handle and clears it.
+  vmFocusHandle = $state(null);
 
   addVmTarget() {
     if (!Array.isArray(this.vmForm.targets)) {
@@ -108,6 +113,17 @@ class VirtualModelEditorStore {
   endVmTargetDrag() {
     this.vmDragIndex = null;
     this.vmDropIndex = null;
+  }
+
+  // requestVmFocusHandle makes focus follow a keyboard move: the row that
+  // moved to `index` grabs focus so repeated arrows walk the same model up
+  // or down the list. VmTargetRow clears it once the focus lands.
+  requestVmFocusHandle(index) {
+    this.vmFocusHandle = index;
+  }
+
+  clearVmFocusHandle() {
+    this.vmFocusHandle = null;
   }
 
   // vmStrategyOptions builds the strategy dropdown from the strategies this

--- a/web/dashboard/src/pages/models/virtualModelEditor.svelte.js
+++ b/web/dashboard/src/pages/models/virtualModelEditor.svelte.js
@@ -21,9 +21,11 @@ import {
   aliasFormTargets,
   buildVirtualModelSavePayload,
   defaultVirtualModelForm,
+  moveFormTarget,
   normalizeUserPaths,
   removePrimaryTarget as removePrimaryTargetPure,
   virtualModelTargetOptions,
+  vmFormTargetCount,
   vmRoutingSummary,
 } from "./vmForm.js";
 import { virtualModels } from "./virtualModels.svelte.js";
@@ -46,6 +48,11 @@ class VirtualModelEditorStore {
   vmFormOriginalSource = $state("");
   vmFormManaged = $state(false);
   vmForm = $state(defaultVirtualModelForm());
+  // Drag-to-reorder state for the target rows: vmDragIndex is the flattened
+  // row being dragged, vmDropIndex the row currently under the cursor (for
+  // the drop highlight). Both reset when the drag ends.
+  vmDragIndex = $state(null);
+  vmDropIndex = $state(null);
 
   addVmTarget() {
     if (!Array.isArray(this.vmForm.targets)) {
@@ -63,6 +70,44 @@ class VirtualModelEditorStore {
 
   removePrimaryTarget() {
     removePrimaryTargetPure(this.vmForm);
+  }
+
+  // vmTargetCount feeds the drag handle: the handle shows only when there is
+  // more than one row to reorder.
+  vmTargetCount() {
+    return vmFormTargetCount(this.vmForm);
+  }
+
+  startVmTargetDrag(index) {
+    this.vmDragIndex = index;
+  }
+
+  // enterVmTargetDrop marks the row under the cursor as the current drop
+  // target; the editor calls it from the row's dragover (which must
+  // preventDefault for drop to fire).
+  enterVmTargetDrop(index) {
+    this.vmDropIndex = index;
+  }
+
+  leaveVmTargetDrop(index) {
+    if (this.vmDropIndex === index) {
+      this.vmDropIndex = null;
+    }
+  }
+
+  // dropVmTarget moves the dragged row onto `index` and clears the drag
+  // state. A no-op move (same index) just resets the highlight.
+  dropVmTarget(index) {
+    if (this.vmDragIndex != null) {
+      moveFormTarget(this.vmForm, this.vmDragIndex, index);
+    }
+    this.vmDragIndex = null;
+    this.vmDropIndex = null;
+  }
+
+  endVmTargetDrag() {
+    this.vmDragIndex = null;
+    this.vmDropIndex = null;
   }
 
   // vmStrategyOptions builds the strategy dropdown from the strategies this

--- a/web/dashboard/src/pages/models/virtualModelEditor.svelte.js
+++ b/web/dashboard/src/pages/models/virtualModelEditor.svelte.js
@@ -48,15 +48,12 @@ class VirtualModelEditorStore {
   vmFormOriginalSource = $state("");
   vmFormManaged = $state(false);
   vmForm = $state(defaultVirtualModelForm());
-  // Drag-to-reorder state for the target rows: vmDragIndex is the flattened
-  // row being dragged, vmDropIndex the row currently under the cursor (for
-  // the drop highlight). Both reset when the drag ends.
+  // Drag state: vmDragIndex is the row being dragged, vmDropIndex the row
+  // currently under the cursor for the drop highlight.
   vmDragIndex = $state(null);
   vmDropIndex = $state(null);
-  // After a keyboard move, focus must follow the moved row: the each block
-  // reuses DOM nodes per position, so without this the focus would stay on
-  // the handle at the old index (now a different model). Set to the moved
-  // row's new index; VmTargetRow focuses that handle and clears it.
+  // Set to the moved row's new index after a keyboard move so focus follows;
+  // VmTargetRow focuses the handle and clears it.
   vmFocusHandle = $state(null);
 
   addVmTarget() {
@@ -87,9 +84,7 @@ class VirtualModelEditorStore {
     this.vmDragIndex = index;
   }
 
-  // enterVmTargetDrop marks the row under the cursor as the current drop
-  // target; the editor calls it from the row's dragover (which must
-  // preventDefault for drop to fire).
+  // enterVmTargetDrop marks the row under the cursor as the drop target.
   enterVmTargetDrop(index) {
     this.vmDropIndex = index;
   }
@@ -100,8 +95,7 @@ class VirtualModelEditorStore {
     }
   }
 
-  // dropVmTarget moves the dragged row onto `index` and clears the drag
-  // state. A no-op move (same index) just resets the highlight.
+  // dropVmTarget moves the dragged row onto `index` and clears drag state.
   dropVmTarget(index) {
     if (this.vmDragIndex != null) {
       moveFormTarget(this.vmForm, this.vmDragIndex, index);
@@ -115,9 +109,7 @@ class VirtualModelEditorStore {
     this.vmDropIndex = null;
   }
 
-  // requestVmFocusHandle makes focus follow a keyboard move: the row that
-  // moved to `index` grabs focus so repeated arrows walk the same model up
-  // or down the list. VmTargetRow clears it once the focus lands.
+  // requestVmFocusHandle makes focus follow a keyboard move.
   requestVmFocusHandle(index) {
     this.vmFocusHandle = index;
   }

--- a/web/dashboard/src/pages/models/virtualModelEditor.svelte.js
+++ b/web/dashboard/src/pages/models/virtualModelEditor.svelte.js
@@ -25,6 +25,7 @@ import {
   normalizeUserPaths,
   removePrimaryTarget as removePrimaryTargetPure,
   virtualModelTargetOptions,
+  vmFormPopulatedTargetCount,
   vmFormTargetCount,
   vmRoutingSummary,
 } from "./vmForm.js";
@@ -78,6 +79,12 @@ class VirtualModelEditorStore {
   // more than one row to reorder.
   vmTargetCount() {
     return vmFormTargetCount(this.vmForm);
+  }
+
+  // vmPopulatedTargetCount is the reorder gate: blank placeholder rows do not
+  // count, so one filled target plus blank extras stays non-draggable.
+  vmPopulatedTargetCount() {
+    return vmFormPopulatedTargetCount(this.vmForm);
   }
 
   // startVmTargetDrag records the flattened index of the row being dragged.
@@ -187,6 +194,10 @@ class VirtualModelEditorStore {
     this.vmFormSourceLocked = false;
     this.vmFormOriginalSource = "";
     this.vmFormManaged = false;
+    // Transient drag/focus state must not leak into the next form.
+    this.vmDragIndex = null;
+    this.vmDropIndex = null;
+    this.vmFocusHandle = null;
     this.vmForm = defaultVirtualModelForm();
   }
 

--- a/web/dashboard/src/pages/models/virtualModelEditor.svelte.js
+++ b/web/dashboard/src/pages/models/virtualModelEditor.svelte.js
@@ -85,8 +85,12 @@ class VirtualModelEditorStore {
   }
 
   // enterVmTargetDrop marks the row under the cursor as the drop target.
+  // dragover fires continuously; only write on change so fast drags do not
+  // re-render the list on every event.
   enterVmTargetDrop(index) {
-    this.vmDropIndex = index;
+    if (this.vmDropIndex !== index) {
+      this.vmDropIndex = index;
+    }
   }
 
   leaveVmTargetDrop(index) {

--- a/web/dashboard/src/pages/models/virtualModelEditor.svelte.js
+++ b/web/dashboard/src/pages/models/virtualModelEditor.svelte.js
@@ -80,6 +80,7 @@ class VirtualModelEditorStore {
     return vmFormTargetCount(this.vmForm);
   }
 
+  // startVmTargetDrag records the flattened index of the row being dragged.
   startVmTargetDrag(index) {
     this.vmDragIndex = index;
   }
@@ -93,6 +94,7 @@ class VirtualModelEditorStore {
     }
   }
 
+  // leaveVmTargetDrop clears the drop highlight when the cursor leaves a row.
   leaveVmTargetDrop(index) {
     if (this.vmDropIndex === index) {
       this.vmDropIndex = null;
@@ -108,6 +110,7 @@ class VirtualModelEditorStore {
     this.vmDropIndex = null;
   }
 
+  // endVmTargetDrag clears drag state when the drag ends without a drop.
   endVmTargetDrag() {
     this.vmDragIndex = null;
     this.vmDropIndex = null;
@@ -118,6 +121,7 @@ class VirtualModelEditorStore {
     this.vmFocusHandle = index;
   }
 
+  // clearVmFocusHandle clears the pending focus request once it landed.
   clearVmFocusHandle() {
     this.vmFocusHandle = null;
   }

--- a/web/dashboard/src/pages/models/vmForm.js
+++ b/web/dashboard/src/pages/models/vmForm.js
@@ -85,6 +85,19 @@ export function vmFormTargetCount(form) {
   return primary + (Array.isArray(form.targets) ? form.targets.length : 0);
 }
 
+// normalizedTargetWeight mirrors the backend contract: a non-positive or
+// unset weight counts as 1.
+function normalizedTargetWeight(value) {
+  const weight = Number(value);
+  return Number.isFinite(weight) && weight > 0 ? weight : 1;
+}
+
+// vmFormPopulatedTargetCount counts only targets that hold a model; blank
+// placeholder rows do not make reordering meaningful.
+export function vmFormPopulatedTargetCount(form) {
+  return flattenFormTargets(form).filter((target) => target.model !== "").length;
+}
+
 // flattenFormTargets returns the full target list in display order: primary
 // first, so position 0 is the failover primary / first round-robin slot.
 export function flattenFormTargets(form) {
@@ -94,7 +107,7 @@ export function flattenFormTargets(form) {
     list.push({
       provider: String(form.target_provider || ""),
       model: String(form.target_model || "").trim(),
-      weight: form.target_weight || 1,
+      weight: normalizedTargetWeight(form.target_weight),
     });
   }
   if (Array.isArray(form.targets)) {
@@ -102,7 +115,7 @@ export function flattenFormTargets(form) {
       list.push({
         provider: String((target && target.provider) || ""),
         model: String((target && target.model) || ""),
-        weight: (target && target.weight) || 1,
+        weight: normalizedTargetWeight((target && target.weight)),
       });
     }
   }
@@ -124,11 +137,11 @@ export function moveFormTarget(form, from, to) {
   const first = list[0];
   form.target_provider = String(first.provider || "");
   form.target_model = first.model || "";
-  form.target_weight = first.weight || 1;
+  form.target_weight = normalizedTargetWeight(first.weight);
   form.targets = list.slice(1).map((row) => ({
     provider: row.provider || "",
     model: row.model || "",
-    weight: row.weight || 1,
+    weight: normalizedTargetWeight(row.weight),
   }));
   return true;
 }

--- a/web/dashboard/src/pages/models/vmForm.js
+++ b/web/dashboard/src/pages/models/vmForm.js
@@ -78,19 +78,15 @@ export function vmFormHasPrimaryTarget(form) {
   return String((form && form.target_model) || "").trim() !== "";
 }
 
-// vmFormTargetCount is the total number of reorderable rows in the editor:
-// one for the primary target when present, plus every extra target. The drag
-// handle is shown only when this is greater than one.
+// vmFormTargetCount is the total number of reorderable rows in the editor.
 export function vmFormTargetCount(form) {
   if (!form) return 0;
   const primary = vmFormHasPrimaryTarget(form) ? 1 : 0;
   return primary + (Array.isArray(form.targets) ? form.targets.length : 0);
 }
 
-// flattenFormTargets returns the full target list in display order: the
-// primary target (if any) followed by the extra targets. The move logic
-// treats the editor as one contiguous list so position 0 is the failover
-// primary / first round-robin slot.
+// flattenFormTargets returns the full target list in display order: primary
+// first, so position 0 is the failover primary / first round-robin slot.
 export function flattenFormTargets(form) {
   if (!form) return [];
   const list = [];
@@ -113,10 +109,9 @@ export function flattenFormTargets(form) {
   return list;
 }
 
-// moveFormTarget reorders the form's flattened target list in place: it
-// splices the entry at `from` to `to` and writes the result back into the
-// primary slot plus the extras array. Invalid bounds or no-op moves return
-// false; the editor uses that to skip needless writes.
+// moveFormTarget splices the flattened target list in place, writing the
+// result back into the primary slot plus the extras array. Returns false on
+// invalid bounds or no-op moves.
 export function moveFormTarget(form, from, to) {
   if (!form) return false;
   const list = flattenFormTargets(form);

--- a/web/dashboard/src/pages/models/vmForm.js
+++ b/web/dashboard/src/pages/models/vmForm.js
@@ -78,6 +78,66 @@ export function vmFormHasPrimaryTarget(form) {
   return String((form && form.target_model) || "").trim() !== "";
 }
 
+// vmFormTargetCount is the total number of reorderable rows in the editor:
+// one for the primary target when present, plus every extra target. The drag
+// handle is shown only when this is greater than one.
+export function vmFormTargetCount(form) {
+  if (!form) return 0;
+  const primary = vmFormHasPrimaryTarget(form) ? 1 : 0;
+  return primary + (Array.isArray(form.targets) ? form.targets.length : 0);
+}
+
+// flattenFormTargets returns the full target list in display order: the
+// primary target (if any) followed by the extra targets. The move logic
+// treats the editor as one contiguous list so position 0 is the failover
+// primary / first round-robin slot.
+export function flattenFormTargets(form) {
+  if (!form) return [];
+  const list = [];
+  if (vmFormHasPrimaryTarget(form)) {
+    list.push({
+      provider: String(form.target_provider || ""),
+      model: String(form.target_model || "").trim(),
+      weight: form.target_weight || 1,
+    });
+  }
+  if (Array.isArray(form.targets)) {
+    for (const target of form.targets) {
+      list.push({
+        provider: String((target && target.provider) || ""),
+        model: String((target && target.model) || ""),
+        weight: (target && target.weight) || 1,
+      });
+    }
+  }
+  return list;
+}
+
+// moveFormTarget reorders the form's flattened target list in place: it
+// splices the entry at `from` to `to` and writes the result back into the
+// primary slot plus the extras array. Invalid bounds or no-op moves return
+// false; the editor uses that to skip needless writes.
+export function moveFormTarget(form, from, to) {
+  if (!form) return false;
+  const list = flattenFormTargets(form);
+  const length = list.length;
+  if (length < 2) return false;
+  if (from < 0 || to < 0 || from >= length || to >= length) return false;
+  if (from === to) return false;
+  const [entry] = list.splice(from, 1);
+  list.splice(to, 0, entry);
+  const first = list[0];
+  form.target_provider = String(first.provider || "");
+  form.target_model = first.model || "";
+  form.target_weight = first.weight || 1;
+  form.targets = list.slice(1).map((row) => ({
+    provider: row.provider || "",
+    model: row.model || "",
+    weight: row.weight || 1,
+  }));
+  return true;
+}
+
 // vmFormSelfOnly: the editor opened from a real model pins that model as its
 // first target so an added target becomes a fallback rather than a
 // replacement. With nothing added, the pinned row is not a redirect — the

--- a/web/dashboard/tests/models-virtual-models.test.js
+++ b/web/dashboard/tests/models-virtual-models.test.js
@@ -37,6 +37,8 @@ import {
   buildModelTogglePayload,
   buildVirtualModelSavePayload,
   defaultVirtualModelForm,
+  flattenFormTargets,
+  moveFormTarget,
   removePrimaryTarget,
   virtualModelTargetOptions,
   vmFormHasPrimaryTarget,
@@ -46,6 +48,7 @@ import {
   vmFormShowWeights,
   vmFormStrategyPending,
   vmFormSupportsSlowdown,
+  vmFormTargetCount,
   vmRoutingSummary,
 } from "../src/pages/models/vmForm.js";
 
@@ -1066,4 +1069,72 @@ test("rowAnchorID keeps distinct alias names on distinct DOM ids", () => {
   assert.notEqual(id("foo/bar"), id("foo-bar"));
   assert.match(id("team/cheap"), /^alias-row-[A-Za-z0-9%._~-]+$/);
   assert.equal(rowAnchorID({ is_alias: false, alias: { name: "x" } }), "");
+});
+
+test("moveFormTarget reorders the flattened target list across the primary boundary", () => {
+  const form = {
+    ...defaultVirtualModelForm(),
+    target_provider: "azure",
+    target_model: "azure/gpt-4o",
+    target_weight: 1,
+    targets: [
+      { provider: "", model: "gemini/gemini-2.5-pro", weight: 2 },
+      { provider: "", model: "groq/llama", weight: 1 },
+    ],
+  };
+  assert.equal(vmFormTargetCount(form), 3);
+  assert.deepEqual(
+    flattenFormTargets(form).map((t) => t.model),
+    ["azure/gpt-4o", "gemini/gemini-2.5-pro", "groq/llama"],
+  );
+
+  // Last fallback becomes the failover primary; the old primary demotes.
+  assert.equal(moveFormTarget(form, 2, 0), true);
+  assert.equal(form.target_model, "groq/llama");
+  assert.equal(form.target_weight, 1);
+  assert.deepEqual(
+    form.targets.map((t) => t.model),
+    ["azure/gpt-4o", "gemini/gemini-2.5-pro"],
+  );
+
+  // Extras reorder among themselves, weights riding along.
+  assert.equal(moveFormTarget(form, 2, 1), true);
+  assert.equal(form.target_model, "groq/llama");
+  assert.deepEqual(
+    form.targets.map((t) => `${t.model}:${t.weight}`),
+    ["gemini/gemini-2.5-pro:2", "azure/gpt-4o:1"],
+  );
+
+  // Explicit provider pins survive the move.
+  form.targets[1].provider = "azure";
+  assert.equal(moveFormTarget(form, 2, 0), true);
+  assert.equal(form.target_provider, "azure");
+  assert.equal(form.target_model, "azure/gpt-4o");
+  assert.equal(form.targets[0].provider, "");
+});
+
+test("moveFormTarget ignores no-op and out-of-bounds moves", () => {
+  const form = {
+    ...defaultVirtualModelForm(),
+    target_model: "azure/gpt-4o",
+    targets: [{ provider: "", model: "gemini/gemini-2.5-pro", weight: 1 }],
+  };
+  assert.equal(moveFormTarget(form, 0, 0), false);
+  assert.equal(moveFormTarget(form, -1, 1), false);
+  assert.equal(moveFormTarget(form, 0, 5), false);
+  assert.equal(moveFormTarget(form, 5, 0), false);
+  assert.equal(form.target_model, "azure/gpt-4o");
+  assert.deepEqual(
+    form.targets.map((t) => t.model),
+    ["gemini/gemini-2.5-pro"],
+  );
+
+  // A single target has nothing to reorder.
+  const single = {
+    ...defaultVirtualModelForm(),
+    target_model: "azure/gpt-4o",
+    targets: [],
+  };
+  assert.equal(vmFormTargetCount(single), 1);
+  assert.equal(moveFormTarget(single, 0, 0), false);
 });

--- a/web/dashboard/tests/models-virtual-models.test.js
+++ b/web/dashboard/tests/models-virtual-models.test.js
@@ -37,8 +37,6 @@ import {
   buildModelTogglePayload,
   buildVirtualModelSavePayload,
   defaultVirtualModelForm,
-  flattenFormTargets,
-  moveFormTarget,
   removePrimaryTarget,
   virtualModelTargetOptions,
   vmFormHasPrimaryTarget,
@@ -48,7 +46,6 @@ import {
   vmFormShowWeights,
   vmFormStrategyPending,
   vmFormSupportsSlowdown,
-  vmFormTargetCount,
   vmRoutingSummary,
 } from "../src/pages/models/vmForm.js";
 
@@ -1069,72 +1066,4 @@ test("rowAnchorID keeps distinct alias names on distinct DOM ids", () => {
   assert.notEqual(id("foo/bar"), id("foo-bar"));
   assert.match(id("team/cheap"), /^alias-row-[A-Za-z0-9%._~-]+$/);
   assert.equal(rowAnchorID({ is_alias: false, alias: { name: "x" } }), "");
-});
-
-test("moveFormTarget reorders the flattened target list across the primary boundary", () => {
-  const form = {
-    ...defaultVirtualModelForm(),
-    target_provider: "azure",
-    target_model: "azure/gpt-4o",
-    target_weight: 1,
-    targets: [
-      { provider: "", model: "gemini/gemini-2.5-pro", weight: 2 },
-      { provider: "", model: "groq/llama", weight: 1 },
-    ],
-  };
-  assert.equal(vmFormTargetCount(form), 3);
-  assert.deepEqual(
-    flattenFormTargets(form).map((t) => t.model),
-    ["azure/gpt-4o", "gemini/gemini-2.5-pro", "groq/llama"],
-  );
-
-  // Last fallback becomes the failover primary; the old primary demotes.
-  assert.equal(moveFormTarget(form, 2, 0), true);
-  assert.equal(form.target_model, "groq/llama");
-  assert.equal(form.target_weight, 1);
-  assert.deepEqual(
-    form.targets.map((t) => t.model),
-    ["azure/gpt-4o", "gemini/gemini-2.5-pro"],
-  );
-
-  // Extras reorder among themselves, weights riding along.
-  assert.equal(moveFormTarget(form, 2, 1), true);
-  assert.equal(form.target_model, "groq/llama");
-  assert.deepEqual(
-    form.targets.map((t) => `${t.model}:${t.weight}`),
-    ["gemini/gemini-2.5-pro:2", "azure/gpt-4o:1"],
-  );
-
-  // Explicit provider pins survive the move.
-  form.targets[1].provider = "azure";
-  assert.equal(moveFormTarget(form, 2, 0), true);
-  assert.equal(form.target_provider, "azure");
-  assert.equal(form.target_model, "azure/gpt-4o");
-  assert.equal(form.targets[0].provider, "");
-});
-
-test("moveFormTarget ignores no-op and out-of-bounds moves", () => {
-  const form = {
-    ...defaultVirtualModelForm(),
-    target_model: "azure/gpt-4o",
-    targets: [{ provider: "", model: "gemini/gemini-2.5-pro", weight: 1 }],
-  };
-  assert.equal(moveFormTarget(form, 0, 0), false);
-  assert.equal(moveFormTarget(form, -1, 1), false);
-  assert.equal(moveFormTarget(form, 0, 5), false);
-  assert.equal(moveFormTarget(form, 5, 0), false);
-  assert.equal(form.target_model, "azure/gpt-4o");
-  assert.deepEqual(
-    form.targets.map((t) => t.model),
-    ["gemini/gemini-2.5-pro"],
-  );
-
-  // A single target has nothing to reorder.
-  const single = {
-    ...defaultVirtualModelForm(),
-    target_model: "azure/gpt-4o",
-    targets: [],
-  };
-  assert.equal(vmFormTargetCount(single), 1);
-  assert.equal(moveFormTarget(single, 0, 0), false);
 });

--- a/web/dashboard/tests/models-vm-target-reorder.test.js
+++ b/web/dashboard/tests/models-vm-target-reorder.test.js
@@ -161,3 +161,19 @@ test("flattened indices the editor passes to moveFormTarget align with the list"
   assert.equal(moveFormTarget(noPrimary, 1, 0), true);
   assert.deepEqual(modelsOf(noPrimary), ["c", "b"]);
 });
+
+test("non-positive weights normalize to 1, matching the backend contract", () => {
+  // The backend treats a non-positive or unset weight as 1
+  // (internal/virtualmodels/types.go), so the frontend mirrors that instead
+  // of preserving a value the gateway would ignore.
+  const form = {
+    ...defaultVirtualModelForm(),
+    source: "w",
+    target_model: "a",
+    target_weight: 0,
+    targets: [{ provider: "", model: "b", weight: 0 }],
+  };
+  assert.equal(moveFormTarget(form, 1, 0), true);
+  assert.equal(form.target_weight, 1);
+  assert.equal(form.targets[0].weight, 1);
+});

--- a/web/dashboard/tests/models-vm-target-reorder.test.js
+++ b/web/dashboard/tests/models-vm-target-reorder.test.js
@@ -1,4 +1,4 @@
-// Contract tests for virtual-model target reordering (PR #77).
+// Contract tests for virtual-model target reordering.
 // These pin the behavior a reviewer sees in the editor so a future refactor
 // cannot silently change it:
 //   1. Drag-and-move, not drag-and-replace: dropping a row onto another row
@@ -108,5 +108,26 @@ test("weights and explicit provider pins survive a reorder", () => {
   assert.deepEqual(
     form.targets.map((t) => `${t.model}:${t.weight}`),
     ["a:1", "c:1"],
+  );
+});
+
+test("target helpers tolerate a null or malformed form", () => {
+  assert.equal(vmFormTargetCount(null), 0);
+  assert.equal(vmFormTargetCount(undefined), 0);
+  assert.deepEqual(flattenFormTargets(null), []);
+  assert.deepEqual(flattenFormTargets(undefined), []);
+  // Non-array targets still surfaces the primary row; moveFormTarget refuses
+  // because it cannot build a contiguous list.
+  assert.deepEqual(flattenFormTargets({ target_model: "a", targets: "bad" }), [
+    { provider: "", model: "a", weight: 1 },
+  ]);
+  assert.equal(moveFormTarget(null, 0, 1), false);
+  assert.equal(
+    moveFormTarget(
+      { ...defaultVirtualModelForm(), target_model: "a", targets: "bad" },
+      0,
+      1,
+    ),
+    false,
   );
 });

--- a/web/dashboard/tests/models-vm-target-reorder.test.js
+++ b/web/dashboard/tests/models-vm-target-reorder.test.js
@@ -1,0 +1,112 @@
+// Contract tests for virtual-model target reordering (PR #77).
+// These pin the behavior a reviewer sees in the editor so a future refactor
+// cannot silently change it:
+//   1. Drag-and-move, not drag-and-replace: dropping a row onto another row
+//      inserts the dragged row at the drop row's position and shifts the
+//      others down — the drop target is not swapped away.
+//   2. The save payload the editor sends after a reorder lists the targets
+//      in exactly the new display order (failover primary first), so the
+//      stored configuration and the rendered chain agree.
+//   3. Reopening a reordered virtual model restores the saved order.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  aliasFormTargets,
+  buildVirtualModelSavePayload,
+  defaultVirtualModelForm,
+  flattenFormTargets,
+  moveFormTarget,
+  vmFormTargetCount,
+} from "../src/pages/models/vmForm.js";
+
+function formWithTargets(models) {
+  const [primary, ...extras] = models;
+  return {
+    ...defaultVirtualModelForm(),
+    source: "coding",
+    target_provider: "",
+    target_model: primary,
+    target_weight: 1,
+    targets: extras.map((model) => ({ provider: "", model, weight: 1 })),
+  };
+}
+
+function modelsOf(form) {
+  return flattenFormTargets(form).map((t) => t.model);
+}
+
+test("drag onto a row inserts the dragged row at that position (move, not swap)", () => {
+  // The scenario from the PR screenshots: three rows, drag the last onto the
+  // first. The dragged row lands first and the previous rows shift down — the
+  // drop row is not replaced.
+  const form = formWithTargets(["a", "b", "c"]);
+  assert.equal(moveFormTarget(form, 2, 0), true);
+  assert.deepEqual(modelsOf(form), ["c", "a", "b"]);
+
+  // Drag the first row onto the last: it lands last, the middle rows shift up.
+  assert.equal(moveFormTarget(form, 0, 2), true);
+  assert.deepEqual(modelsOf(form), ["a", "b", "c"]);
+
+  // Adjacent move down: insert-between equals "swap with the next row".
+  assert.equal(moveFormTarget(form, 0, 1), true);
+  assert.deepEqual(modelsOf(form), ["b", "a", "c"]);
+});
+
+test("save payload after a reorder lists targets in the new display order", () => {
+  const form = formWithTargets(["a", "b", "c"]);
+  form.strategy = "failover";
+  moveFormTarget(form, 2, 0);
+
+  const { payload, isRedirect } = buildVirtualModelSavePayload(form, "", "edit");
+  assert.equal(isRedirect, true);
+  assert.deepEqual(
+    payload.targets.map((t) => t.model),
+    ["c", "a", "b"],
+  );
+  assert.equal(payload.strategy, "failover");
+});
+
+test("reopening a reordered virtual model restores the saved order", () => {
+  // Stored shape after the reorder save above: primary first, extras after.
+  const stored = {
+    name: "coding",
+    targets: [{ model: "c" }, { model: "a" }, { model: "b" }],
+    strategy: "failover",
+  };
+  const { primaryModel, extraTargets } = aliasFormTargets(stored);
+  assert.equal(primaryModel, "c");
+  assert.deepEqual(
+    extraTargets.map((t) => t.model),
+    ["a", "b"],
+  );
+
+  // Flattened back to one list, the display order matches what was saved.
+  const reopened = formWithTargets(["c", "a", "b"]);
+  assert.equal(vmFormTargetCount(reopened), 3);
+  assert.deepEqual(modelsOf(reopened), ["c", "a", "b"]);
+});
+
+test("weights and explicit provider pins survive a reorder", () => {
+  const form = {
+    ...defaultVirtualModelForm(),
+    source: "pool",
+    strategy: "round_robin",
+    target_provider: "",
+    target_model: "a",
+    target_weight: 1,
+    targets: [
+      { provider: "team", model: "b", weight: 3 },
+      { provider: "", model: "c", weight: 1 },
+    ],
+  };
+  moveFormTarget(form, 1, 0);
+  assert.equal(form.target_model, "b");
+  assert.equal(form.target_provider, "team");
+  assert.equal(form.target_weight, 3);
+  assert.deepEqual(
+    form.targets.map((t) => `${t.model}:${t.weight}`),
+    ["a:1", "c:1"],
+  );
+});

--- a/web/dashboard/tests/models-vm-target-reorder.test.js
+++ b/web/dashboard/tests/models-vm-target-reorder.test.js
@@ -131,3 +131,33 @@ test("target helpers tolerate a null or malformed form", () => {
     false,
   );
 });
+
+test("flattened indices the editor passes to moveFormTarget align with the list", () => {
+  // The editor renders the primary row with index 0 and extras from 1 on —
+  // but only when the primary holds a model: an empty primary row is not in
+  // the flattened list, so extras must start at 0. This pins that contract;
+  // a mismatch made drops on unsaved/new rows land out of bounds.
+  const withPrimary = formWithTargets(["a", "b", "c"]);
+  assert.deepEqual(modelsOf(withPrimary), ["a", "b", "c"]);
+  // UI: primary index 0, extras 1 and 2 — all in bounds.
+  assert.equal(moveFormTarget(withPrimary, 2, 0), true);
+  assert.deepEqual(modelsOf(withPrimary), ["c", "a", "b"]);
+
+  // UI: primary row holds no model (empty slot in a fresh form): the row is
+  // not in the flattened list, so extras must be indexed from 0.
+  const noPrimary = {
+    ...defaultVirtualModelForm(),
+    source: "new-vm",
+    target_model: "",
+    target_weight: 1,
+    targets: [
+      { provider: "", model: "b", weight: 1 },
+      { provider: "", model: "c", weight: 1 },
+    ],
+  };
+  assert.equal(vmFormTargetCount(noPrimary), 2);
+  assert.deepEqual(modelsOf(noPrimary), ["b", "c"]);
+  // UI: extras at indices 0 and 1 — the move the component now sends.
+  assert.equal(moveFormTarget(noPrimary, 1, 0), true);
+  assert.deepEqual(modelsOf(noPrimary), ["c", "b"]);
+});

--- a/web/dashboard/tests/models-vm-target-reorder.test.js
+++ b/web/dashboard/tests/models-vm-target-reorder.test.js
@@ -18,6 +18,7 @@ import {
   defaultVirtualModelForm,
   flattenFormTargets,
   moveFormTarget,
+  vmFormPopulatedTargetCount,
   vmFormTargetCount,
 } from "../src/pages/models/vmForm.js";
 
@@ -176,4 +177,36 @@ test("non-positive weights normalize to 1, matching the backend contract", () =>
   assert.equal(moveFormTarget(form, 1, 0), true);
   assert.equal(form.target_weight, 1);
   assert.equal(form.targets[0].weight, 1);
+
+  // Negative weights follow the same rule: the explicit `weight > 0`
+  // normalization maps them to 1.
+  const negative = {
+    ...defaultVirtualModelForm(),
+    source: "neg",
+    target_model: "a",
+    target_weight: -2,
+    targets: [{ provider: "", model: "b", weight: -1 }],
+  };
+  assert.equal(moveFormTarget(negative, 1, 0), true);
+  assert.equal(negative.target_weight, 1);
+  assert.equal(negative.targets[0].weight, 1);
+});
+
+test("vmFormPopulatedTargetCount ignores blank placeholder rows", () => {
+  const oneFilled = {
+    ...defaultVirtualModelForm(),
+    target_model: "a",
+    targets: [{ provider: "", model: "", weight: 1 }],
+  };
+  assert.equal(vmFormPopulatedTargetCount(oneFilled), 1);
+
+  const twoFilled = {
+    ...defaultVirtualModelForm(),
+    target_model: "a",
+    targets: [
+      { provider: "", model: "b", weight: 1 },
+      { provider: "", model: "", weight: 1 },
+    ],
+  };
+  assert.equal(vmFormPopulatedTargetCount(twoFilled), 2);
 });


### PR DESCRIPTION
## TL;DR

The Virtual Model editor shows fallback targets in the order they were added. There is no way to change that order: users must delete and re-add targets to change the failover priority or the round-robin queue. Add a drag handle to each target row. Drag a row onto another row to move it. The full list is reorderable, including the primary target.

**Files to review (9, +502 / -5):**

| File | Why |
|---|---|
| `web/dashboard/src/pages/models/VmTargetRow.svelte` *(start here)* | The grip handle, drag events, and the drop highlight live here. |
| `web/dashboard/src/pages/models/vmForm.js` | Pure helpers: `flattenFormTargets` and `moveFormTarget`. |
| `web/dashboard/src/pages/models/virtualModelEditor.svelte.js` | Drag state (`vmDragIndex`, `vmDropIndex`) and the drop action. |
| `web/dashboard/src/pages/models/VirtualModelEditor.svelte` | Passes each row its flattened index and enables the handle. |
| `web/dashboard/tests/models-vm-target-reorder.test.js` | Contract tests: move semantics, payload order, reopen round-trip, index alignment. |
| `internal/admin/handler_virtualmodels_test.go` | Go contract test: PUT stores and returns the sent target order. |
| `docs/features/virtual-models.mdx` | "Reorder targets" section. |
| `web/dashboard/messages/en.json`, `pl.json` | `models_move_target` label for the handle. |

## Behavior

![Target rows with drag handles](https://github.com/user-attachments/assets/3de43118-287e-4e5e-a0ef-1b1c4a0beb71)

- The **grip handle (☰)** sits left of each target row's remove button. It shows only when more than one target exists.
- **Drag-and-move, not drag-and-replace.** Dropping a row onto another row moves the dragged row to that position. The other rows keep their relative order and shift down (or up). Nothing is swapped away.
- While dragging, the dragged row fades. The row under the cursor shows the **dashed outline**: that is where the dragged row will land, in between — not a swap.

![Dashed outline marks the drop position](https://github.com/user-attachments/assets/7bb4c9be-123d-47f2-aabf-886f6dade781)

- **Keyboard works the same.** Focus the handle and press **ArrowUp / ArrowDown** to move the row one position. Focus follows the moved row, so holding an arrow walks the same model through the list.
- **Every strategy benefits.** For `failover`, position 1 is the first target the gateway tries. For balancing strategies, position 1 is the first slot in the queue.
- **Weights and provider pins ride along.** A moved row keeps its weight and its explicit provider.
- The summary line under the targets ("…falls back to…") updates live while you reorder, before anything is saved.
- **Saving persists the new order.** The payload lists targets in display order; the backend stores and returns them in that order.

## How

- The editor treats the target list as one contiguous list: primary first, extras after. `moveFormTarget` splices that list and writes the result back into the primary slot plus the extras array.
- **Row indices match the flattened list.** An empty primary row (fresh form, or a cleared primary) is not in the list, so extras are indexed from 0 there — otherwise drops on new rows landed out of bounds and were silently refused.
- The handle uses native HTML5 drag and drop: no dependency. `dragenter`/`dragover` `preventDefault` so `drop` fires in every browser; text selection is disabled on the handle so a fast grab-release commits the drag. The drop target row is tracked in `vmDropIndex` for the highlight, written only on change to avoid re-render storms mid-drag.
- Cross-boundary moves (extra → primary) are the same splice as within the extras.
- The handle shows only when more than one target exists, and hides for managed virtual models.
- No backend change. `buildVirtualModelSavePayload` already serializes targets in array order, and the backend reads that order as the failover priority / queue order.

## Contract tests

The behavior above is pinned so refactors cannot silently change it:

- `web/dashboard/tests/models-vm-target-reorder.test.js` — insert-between move semantics (drop last onto first lands first, others keep relative order); payload lists targets in the new display order after a drag; reopening a reordered model restores the order; weights and provider pins survive; flattened-index alignment for empty and filled primaries; null/malformed form handling.
- `TestUpsertVirtualModelTargetOrderRoundTrips` (`internal/admin/handler_virtualmodels_test.go`) — a reorder PUT stores the targets in exactly the sent order, and the list view the dashboard renders returns the same order.

## Tests

- `npm test` in `web/dashboard`: 596 pass (6 in the reorder contract file).
- `go test ./internal/admin/ ./internal/virtualmodels/`: pass.
- `gofmt -l`: clean. `go vet`: clean. `go build ./...`: clean. `ineffassign`: clean. `errcheck`: clean on the touched files.
- `npm run check`: svelte-check reports 0 errors, 0 warnings.
- Manual verification on a seeded instance: fast grab-release drags, unsaved-row reordering, cross-boundary moves, and save round-trips.
- Not covered: pointer-based drag end-to-end. The drag path is DOM-event wiring; the move logic itself is pure and tested.

## Follow-up

- **Browser-level e2e tests** (Playwright or similar) for the editor drag-and-keyboard interactions. Native HTML5 drag timing (a fast grab-release can skip the drag session; `drop` only fires once `dragover`/`dragenter` are `preventDefault`ed) is exactly what `node:test` cannot pin.

## Links

- Resolves #837 

---
_This PR description was generated with [AI assistance](https://raw.githubusercontent.com/tdhopper/dotfiles2.0/master/.claude/skills/creating-pull-requests/SKILL.md)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added drag-and-drop reordering for virtual-model targets.
  - Added keyboard controls using Arrow Up and Arrow Down.
  - Target order determines failover priority or balancing order.
  - Weights and provider assignments remain attached when targets move.
  - Move controls appear only when multiple targets can be reordered.

- **Documentation**
  - Added English and Polish guidance for reordering targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->