### PR TITLE
fix(messages): close the remaining Anthropic content-block gaps

### DIFF
--- a/cmd/gomodel/docs/docs.go
+++ b/cmd/gomodel/docs/docs.go
@@ -16,6 +16,37 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/admin/access": {
+            "get": {
+                "description": "Reports whether the credential administers the whole gateway\nor only one user-path subtree, so clients can adapt what\nthey offer before hitting scoped endpoints.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Describe the caller's admin scope",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.accessResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ]
+            }
+        },
         "/admin/audit/conversation": {
             "get": {
                 "description": "Thread entries carry the request/response bodies the\ntranscript is built from; attempts, request revisions, and\nresponse headers are omitted; redacted request headers and\nper-request usage summaries are retained for continuation\nand prompt-cache visualization.",
@@ -56,6 +87,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/core.GatewayError"
                         }
@@ -102,6 +139,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/core.GatewayError"
                         }
@@ -246,6 +289,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/core.GatewayError"
                         }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
                     }
                 },
                 "security": [
@@ -369,6 +418,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/core.GatewayError"
                         }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
                     }
                 },
                 "security": [
@@ -406,6 +461,12 @@ const docTemplate = `{
                         "description": "End date (YYYY-MM-DD)",
                         "name": "end_date",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by tracked user path subtree",
+                        "name": "user_path",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -423,6 +484,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/core.GatewayError"
                         }
@@ -453,6 +520,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/core.GatewayError"
                         }
@@ -511,6 +584,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/core.GatewayError"
                         }
                     },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
@@ -561,6 +640,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/core.GatewayError"
                         }
@@ -621,6 +706,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/core.GatewayError"
                         }
                     },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
@@ -677,6 +768,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/core.GatewayError"
                         }
                     },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
@@ -709,6 +806,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/core.GatewayError"
                         }
@@ -763,6 +866,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/core.GatewayError"
                         }
@@ -867,6 +976,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/core.GatewayError"
                         }
@@ -1625,6 +1740,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/core.GatewayError"
                         }
                     },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
@@ -1679,6 +1800,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/core.GatewayError"
                         }
                     },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
@@ -1729,6 +1856,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/core.GatewayError"
                         }
@@ -1789,6 +1922,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/core.GatewayError"
                         }
                     },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
@@ -1841,6 +1980,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/core.GatewayError"
                         }
@@ -2071,6 +2216,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/core.GatewayError"
                         }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
                     }
                 },
                 "security": [
@@ -2164,6 +2315,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/core.GatewayError"
                         }
@@ -2277,6 +2434,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/core.GatewayError"
                         }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
                     }
                 },
                 "security": [
@@ -2372,6 +2535,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/core.GatewayError"
                         }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
                     }
                 },
                 "security": [
@@ -2419,6 +2588,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/core.GatewayError"
                         }
@@ -2533,6 +2708,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/core.GatewayError"
                         }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
                     }
                 },
                 "security": [
@@ -2625,6 +2806,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/core.GatewayError"
                         }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
                     }
                 },
                 "security": [
@@ -2668,6 +2855,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/core.GatewayError"
                         }
@@ -2763,6 +2956,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.GatewayError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/core.GatewayError"
                         }
@@ -7200,6 +7399,19 @@ const docTemplate = `{
                 }
             }
         },
+        "admin.accessResponse": {
+            "type": "object",
+            "properties": {
+                "scope": {
+                    "description": "Scope is \"global\" for the master key and unscoped credentials, or\n\"user_path\" for a credential confined to one user-path subtree.",
+                    "type": "string"
+                },
+                "user_path": {
+                    "description": "UserPath is the subtree root of a user_path-scoped credential.",
+                    "type": "string"
+                }
+            }
+        },
         "admin.auditConversationResponse": {
             "type": "object",
             "properties": {
@@ -9281,6 +9493,9 @@ const docTemplate = `{
         "core.ContentPart": {
             "type": "object",
             "properties": {
+                "file": {
+                    "$ref": "#/definitions/core.FileContent"
+                },
                 "image_url": {
                     "$ref": "#/definitions/core.ImageURLContent"
                 },
@@ -9475,15 +9690,31 @@ const docTemplate = `{
                 "rate_limit_error",
                 "invalid_request_error",
                 "authentication_error",
-                "not_found_error"
+                "not_found_error",
+                "permission_error"
             ],
             "x-enum-varnames": [
                 "ErrorTypeProvider",
                 "ErrorTypeRateLimit",
                 "ErrorTypeInvalidRequest",
                 "ErrorTypeAuthentication",
-                "ErrorTypeNotFound"
+                "ErrorTypeNotFound",
+                "ErrorTypePermission"
             ]
+        },
+        "core.FileContent": {
+            "type": "object",
+            "properties": {
+                "file_data": {
+                    "type": "string"
+                },
+                "file_id": {
+                    "type": "string"
+                },
+                "filename": {
+                    "type": "string"
+                }
+            }
         },
         "core.FileDeleteResponse": {
             "type": "object",
@@ -10384,6 +10615,16 @@ const docTemplate = `{
                     "items": {
                         "type": "object"
                     }
+                },
+                "file_data": {
+                    "description": "input_file items carry their file fields flat, unlike chat file parts.",
+                    "type": "string"
+                },
+                "file_id": {
+                    "type": "string"
+                },
+                "filename": {
+                    "type": "string"
                 },
                 "image_url": {
                     "$ref": "#/definitions/core.ImageURLContent"

--- a/cmd/gomodel/docs/docs.go
+++ b/cmd/gomodel/docs/docs.go
@@ -9711,6 +9711,9 @@ const docTemplate = `{
                 "file_id": {
                     "type": "string"
                 },
+                "file_url": {
+                    "type": "string"
+                },
                 "filename": {
                     "type": "string"
                 }
@@ -10621,6 +10624,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "file_id": {
+                    "type": "string"
+                },
+                "file_url": {
                     "type": "string"
                 },
                 "filename": {

--- a/docs/advanced/anthropic-messages-api.mdx
+++ b/docs/advanced/anthropic-messages-api.mdx
@@ -208,9 +208,10 @@ features that have no canonical equivalent are not preserved end to end:
   native `image` and `document` blocks when routed to Anthropic. Other providers
   receive only the text portion of the tool result.
 - **`document` blocks** (PDF, plain text, URL, or Files API `file_id` sources)
-  translate to the OpenAI-style `file` content part. Anthropic gets the document
-  back natively with its `title`; Gemini receives inline data; OpenAI-compatible
-  providers receive the `file` part as-is. Citation settings and `context` are
+  translate to the OpenAI-style `file` content part (`file_data` for inline
+  content, `file_url` for remote URLs, `file_id` for uploads). Anthropic gets the
+  document back natively with its `title`; Gemini receives inline data only;
+  OpenAI-compatible providers receive the `file` part as-is. Citation settings and `context` are
   dropped. The custom-content variant (`source.type: "content"`) degrades to text.
 - **`search_result` blocks** degrade to text (title, source URL, and content);
   citation metadata is dropped.

--- a/docs/advanced/anthropic-messages-api.mdx
+++ b/docs/advanced/anthropic-messages-api.mdx
@@ -39,6 +39,11 @@ when a feature that operates on the canonical request is in play: guardrails
 request patching, the response cache, or failover routing. Requests resolving
 to any non-Anthropic provider always translate.
 
+Because the body is forwarded verbatim, none of the [translation limitations](#limitations)
+apply on this path: server-tool history (`server_tool_use`, `web_search_tool_result`, …),
+container uploads, and any other block the canonical request cannot represent reach
+Anthropic unchanged.
+
 ## Supported endpoints
 
 | Endpoint | Behavior |
@@ -187,18 +192,30 @@ features that have no canonical equivalent are not preserved end to end:
   (Claude Code appends system reminders this way, and its prompt caching
   depends on them staying in place). On older Claude models, which reject the
   role, their text is hoisted into the top-level system prompt instead.
-- **Extended-thinking signatures** and `thinking` blocks on input messages are dropped.
-- **Server/built-in tools** (web search, code execution, …) are rejected with a clear
+- **`thinking` and `redacted_thinking` blocks** on assistant turns are replayed
+  verbatim (signatures included) when routed to Anthropic, so thinking-enabled
+  tool-use turns continue correctly. Other providers never see them.
+- **`tool_result.is_error`** is preserved when routed to Anthropic. Other
+  providers have no equivalent flag and receive the result content only.
+- **Server/built-in tools** (web search, code execution, …) and their history
+  blocks (`server_tool_use`, `web_search_tool_result`, …) are rejected with a clear
   `400`; only custom tools (`type` absent or `"custom"`) translate.
 - **`top_k`** is dropped — it has no portable OpenAI-compatible equivalent, and
   OpenAI-family providers reject unknown request fields. `temperature` and `top_p`
   are forwarded.
-- **Images inside `tool_result` blocks** (screenshots, image files read by a
-  tool — Claude Code returns them this way) are forwarded as native image blocks
-  when routed to Anthropic. Other providers receive only the text portion of the
-  tool result.
-- **`document` and other non-text/image content blocks** are rejected with a clear
-  `400` error rather than silently dropped.
+- **Images and documents inside `tool_result` blocks** (screenshots, image and
+  PDF files read by a tool — Claude Code returns them this way) are forwarded as
+  native `image` and `document` blocks when routed to Anthropic. Other providers
+  receive only the text portion of the tool result.
+- **`document` blocks** (PDF, plain text, URL, or Files API `file_id` sources)
+  translate to the OpenAI-style `file` content part. Anthropic gets the document
+  back natively with its `title`; Gemini receives inline data; OpenAI-compatible
+  providers receive the `file` part as-is. Citation settings and `context` are
+  dropped. The custom-content variant (`source.type: "content"`) degrades to text.
+- **`search_result` blocks** degrade to text (title, source URL, and content);
+  citation metadata is dropped.
+- **Other content blocks** (`container_upload`, `tool_reference`, …) are rejected
+  with a clear `400` error rather than silently dropped.
 - **`stop_sequences`** are honored on every provider. Providers that report the
   matched sequence natively (Anthropic) get the full contract back:
   `stop_reason: "stop_sequence"` plus the `stop_sequence` value. OpenAI-family

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -13439,6 +13439,9 @@
           "file_id": {
             "type": "string"
           },
+          "file_url": {
+            "type": "string"
+          },
           "filename": {
             "type": "string"
           }
@@ -14372,6 +14375,9 @@
             "type": "string"
           },
           "file_id": {
+            "type": "string"
+          },
+          "file_url": {
             "type": "string"
           },
           "filename": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -13221,6 +13221,9 @@
       "core.ContentPart": {
         "type": "object",
         "properties": {
+          "file": {
+            "$ref": "#/components/schemas/core.FileContent"
+          },
           "image_url": {
             "$ref": "#/components/schemas/core.ImageURLContent"
           },
@@ -13426,6 +13429,20 @@
           "ErrorTypeNotFound",
           "ErrorTypePermission"
         ]
+      },
+      "core.FileContent": {
+        "type": "object",
+        "properties": {
+          "file_data": {
+            "type": "string"
+          },
+          "file_id": {
+            "type": "string"
+          },
+          "filename": {
+            "type": "string"
+          }
+        }
       },
       "core.FileDeleteResponse": {
         "type": "object",
@@ -14349,6 +14366,16 @@
             "items": {
               "type": "object"
             }
+          },
+          "file_data": {
+            "description": "input_file items carry their file fields flat, unlike chat file parts.",
+            "type": "string"
+          },
+          "file_id": {
+            "type": "string"
+          },
+          "filename": {
+            "type": "string"
           },
           "image_url": {
             "$ref": "#/components/schemas/core.ImageURLContent"

--- a/internal/anthropicapi/request.go
+++ b/internal/anthropicapi/request.go
@@ -324,7 +324,7 @@ func documentPart(block ContentBlock, extra core.UnknownJSONFields) (core.Conten
 		if source.URL == "" {
 			return core.ContentPart{}, false, fmt.Errorf("url document source requires url")
 		}
-		file.FileData = source.URL
+		file.FileURL = source.URL
 	case "file":
 		if strings.TrimSpace(source.FileID) == "" {
 			return core.ContentPart{}, false, fmt.Errorf("file document source requires file_id")

--- a/internal/anthropicapi/request.go
+++ b/internal/anthropicapi/request.go
@@ -331,6 +331,9 @@ func documentPart(block ContentBlock, extra core.UnknownJSONFields) (core.Conten
 		}
 		file.FileID = strings.TrimSpace(source.FileID)
 	case "content":
+		if core.IsJSONNull(bytes.TrimSpace(source.Content)) {
+			return core.ContentPart{}, false, fmt.Errorf("content document source requires content")
+		}
 		text, err := textBlocksText(source.Content)
 		if err != nil {
 			return core.ContentPart{}, false, fmt.Errorf("document content: %v", err)

--- a/internal/anthropicapi/request.go
+++ b/internal/anthropicapi/request.go
@@ -2,6 +2,7 @@ package anthropicapi
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"strings"
@@ -34,8 +35,23 @@ func DecodeMessagesRequest(body []byte) (*MessagesRequest, error) {
 
 // ToChatRequest translates an Anthropic Messages request into the canonical
 // chat request. The translation is provider-agnostic: the resulting request
-// runs through the standard chat-completions pipeline.
+// runs through the standard chat-completions pipeline. Content the canonical
+// request cannot represent is rejected with a 400 rather than dropped.
 func ToChatRequest(req *MessagesRequest) (*core.ChatRequest, error) {
+	return toChatRequest(req, false)
+}
+
+// ToChatRequestLenient is ToChatRequest for routing decisions only: blocks and
+// tools that have no canonical equivalent (server tools, server-tool results,
+// …) are dropped instead of rejected. The result carries enough of the request
+// (model, stream, messages) to resolve a workflow and decide whether the
+// original body can be forwarded natively; it must not be dispatched through
+// the translated pipeline.
+func ToChatRequestLenient(req *MessagesRequest) (*core.ChatRequest, error) {
+	return toChatRequest(req, true)
+}
+
+func toChatRequest(req *MessagesRequest, lenient bool) (*core.ChatRequest, error) {
 	if req == nil {
 		return nil, core.NewInvalidRequestError("messages request is required", nil)
 	}
@@ -52,7 +68,7 @@ func ToChatRequest(req *MessagesRequest) (*core.ChatRequest, error) {
 		return nil, core.NewInvalidRequestError(err.Error(), err).WithParam("cache_control")
 	}
 
-	messages, err := convertMessages(req)
+	messages, err := convertMessages(req, lenient)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +90,7 @@ func ToChatRequest(req *MessagesRequest) (*core.ChatRequest, error) {
 		chat.StreamOptions = &core.StreamOptions{IncludeUsage: true}
 	}
 
-	tools, err := convertTools(req.Tools)
+	tools, err := convertTools(req.Tools, lenient)
 	if err != nil {
 		return nil, err
 	}
@@ -97,11 +113,11 @@ func ToChatRequest(req *MessagesRequest) (*core.ChatRequest, error) {
 // Claude Code) rely on their placement and block-level cache_control
 // breakpoints for prompt caching. The Anthropic egress translator hoists them
 // into the top-level system field only for models that reject the role.
-func convertMessages(req *MessagesRequest) ([]core.Message, error) {
+func convertMessages(req *MessagesRequest, lenient bool) ([]core.Message, error) {
 	out := make([]core.Message, 0, len(req.Messages)+1)
 
 	// Build the system prompt while retaining block-level cache_control metadata.
-	system, err := systemContent(req.System)
+	system, err := systemContent(req.System, lenient)
 	if err != nil {
 		return nil, core.NewInvalidRequestError(err.Error(), err)
 	}
@@ -111,7 +127,7 @@ func convertMessages(req *MessagesRequest) ([]core.Message, error) {
 
 	for i, msg := range req.Messages {
 		if msg.Role == "system" {
-			content, err := systemContent(msg.Content)
+			content, err := systemContent(msg.Content, lenient)
 			if err != nil {
 				return nil, core.NewInvalidRequestError(fmt.Sprintf("messages[%d]: %v", i, err), err)
 			}
@@ -133,7 +149,7 @@ func convertMessages(req *MessagesRequest) ([]core.Message, error) {
 			out = append(out, core.Message{Role: msg.Role, Content: text})
 			continue
 		}
-		converted, err := convertBlockMessage(msg.Role, blocks)
+		converted, err := convertBlockMessage(msg.Role, blocks, lenient)
 		if err != nil {
 			return nil, core.NewInvalidRequestError(fmt.Sprintf("messages[%d]: %v", i, err), err)
 		}
@@ -143,14 +159,18 @@ func convertMessages(req *MessagesRequest) ([]core.Message, error) {
 }
 
 // convertBlockMessage converts one Anthropic block-content message. tool_result
-// blocks are emitted as separate role:"tool" messages (OpenAI representation);
-// text/image blocks and tool_use blocks collapse into a single user/assistant
-// message.
-func convertBlockMessage(role string, blocks []ContentBlock) ([]core.Message, error) {
+// blocks become standalone role:"tool" messages that precede the remaining
+// content, matching the OpenAI ordering where tool responses follow the
+// assistant tool call and any user follow-up comes after. Assistant thinking
+// blocks are preserved verbatim on the message so the Anthropic provider can
+// replay them; they have no meaning for other providers and are stripped
+// before the request reaches one.
+func convertBlockMessage(role string, blocks []ContentBlock, lenient bool) ([]core.Message, error) {
 	var (
 		toolMessages []core.Message
 		parts        []core.ContentPart
 		toolCalls    []core.ToolCall
+		thinking     []json.RawMessage
 	)
 	for _, block := range blocks {
 		extra, err := anthropicCacheControlExtra(block.CacheControl)
@@ -158,20 +178,14 @@ func convertBlockMessage(role string, blocks []ContentBlock) ([]core.Message, er
 			return nil, err
 		}
 		switch block.Type {
-		case "text":
-			if block.Text != "" {
-				parts = append(parts, core.ContentPart{Type: "text", Text: block.Text, ExtraFields: extra})
-			}
-		case "image":
-			url, err := imageURLFromSource(block.Source)
+		case "text", "image", "document", "search_result":
+			part, ok, err := payloadPart(block, extra)
 			if err != nil {
 				return nil, err
 			}
-			parts = append(parts, core.ContentPart{
-				Type:        "image_url",
-				ImageURL:    &core.ImageURLContent{URL: url},
-				ExtraFields: extra,
-			})
+			if ok {
+				parts = append(parts, part)
+			}
 		case "tool_use":
 			if strings.TrimSpace(block.Name) == "" {
 				return nil, fmt.Errorf("tool_use block is missing name")
@@ -187,7 +201,7 @@ func convertBlockMessage(role string, blocks []ContentBlock) ([]core.Message, er
 			if id == "" {
 				return nil, fmt.Errorf("tool_result block is missing tool_use_id")
 			}
-			content, err := toolResultContent(block.Content)
+			content, err := toolResultContent(block.Content, lenient)
 			if err != nil {
 				return nil, err
 			}
@@ -195,30 +209,242 @@ func convertBlockMessage(role string, blocks []ContentBlock) ([]core.Message, er
 				Role:        "tool",
 				ToolCallID:  id,
 				Content:     content,
-				ExtraFields: extra,
+				ExtraFields: toolResultExtra(extra, block.IsError),
 			})
 		case "thinking", "redacted_thinking":
-			// Extended-thinking history has no canonical chat equivalent; drop
-			// it. It is an assistant-side artifact, so dropping it does not lose
-			// caller intent.
+			// Only assistant turns carry thinking; anywhere else it is an
+			// artifact with nothing to replay.
+			if role == "assistant" {
+				thinking = append(thinking, thinkingBlockJSON(block))
+			}
 		default:
-			// Block types that carry caller payload (e.g. document) have no
-			// canonical chat equivalent. Reject them rather than silently
-			// dropping the data, which would make the model answer as if the
-			// attachment were never sent.
+			if lenient {
+				continue
+			}
+			// Block types that carry caller payload (server-tool results,
+			// container uploads, …) have no canonical chat equivalent. Reject
+			// them rather than silently dropping the data, which would make
+			// the model answer as if the content were never sent.
 			return nil, fmt.Errorf("unsupported content block type %q; use the /p/anthropic/v1/messages passthrough for provider-native features", block.Type)
 		}
 	}
 
 	messages := toolMessages
-	if content := collapseParts(parts); content != nil || len(toolCalls) > 0 {
-		messages = append(messages, core.Message{
+	content := collapseParts(parts)
+	if content != nil || len(toolCalls) > 0 || len(thinking) > 0 {
+		msg := core.Message{
 			Role:      role,
 			Content:   content,
 			ToolCalls: toolCalls,
-		})
+		}
+		if len(thinking) > 0 {
+			raw, err := json.Marshal(thinking)
+			if err != nil {
+				return nil, fmt.Errorf("thinking blocks: %v", err)
+			}
+			msg.ExtraFields = core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+				core.ThinkingBlocksField: raw,
+			})
+		}
+		messages = append(messages, msg)
 	}
 	return messages, nil
+}
+
+// payloadPart converts a payload-carrying block (text, image, document,
+// search_result) into a canonical content part. ok is false when the block is
+// empty and contributes nothing.
+func payloadPart(block ContentBlock, extra core.UnknownJSONFields) (core.ContentPart, bool, error) {
+	switch block.Type {
+	case "text":
+		if block.Text == "" {
+			return core.ContentPart{}, false, nil
+		}
+		return core.ContentPart{Type: "text", Text: block.Text, ExtraFields: extra}, true, nil
+	case "image":
+		source, err := decodeSource(block.Source)
+		if err != nil {
+			return core.ContentPart{}, false, fmt.Errorf("image block: %v", err)
+		}
+		url, err := imageURLFromSource(source)
+		if err != nil {
+			return core.ContentPart{}, false, err
+		}
+		return core.ContentPart{
+			Type:        "image_url",
+			ImageURL:    &core.ImageURLContent{URL: url},
+			ExtraFields: extra,
+		}, true, nil
+	case "document":
+		return documentPart(block, extra)
+	case "search_result":
+		text, err := searchResultText(block)
+		if err != nil {
+			return core.ContentPart{}, false, err
+		}
+		if text == "" {
+			return core.ContentPart{}, false, nil
+		}
+		return core.ContentPart{Type: "text", Text: text, ExtraFields: extra}, true, nil
+	default:
+		return core.ContentPart{}, false, fmt.Errorf("unsupported content block type %q", block.Type)
+	}
+}
+
+// documentPart maps an Anthropic document block onto the canonical file part.
+// PDF and plain-text sources become data: URLs, URL and file_id sources are
+// carried as-is, and the custom-content variant (an array of text blocks)
+// degrades to a text part. The document title becomes the filename; citation
+// settings and context have no canonical equivalent and are dropped.
+func documentPart(block ContentBlock, extra core.UnknownJSONFields) (core.ContentPart, bool, error) {
+	source, err := decodeSource(block.Source)
+	if err != nil {
+		return core.ContentPart{}, false, fmt.Errorf("document block: %v", err)
+	}
+	if source == nil {
+		return core.ContentPart{}, false, fmt.Errorf("document block is missing source")
+	}
+	file := &core.FileContent{Filename: strings.TrimSpace(block.Title)}
+	switch source.Type {
+	case "base64":
+		if source.MediaType == "" || source.Data == "" {
+			return core.ContentPart{}, false, fmt.Errorf("base64 document source requires media_type and data")
+		}
+		file.FileData = "data:" + source.MediaType + ";base64," + source.Data
+	case "text":
+		if source.Data == "" {
+			return core.ContentPart{}, false, fmt.Errorf("text document source requires data")
+		}
+		mediaType := source.MediaType
+		if mediaType == "" {
+			mediaType = "text/plain"
+		}
+		file.FileData = "data:" + mediaType + ";base64," + base64.StdEncoding.EncodeToString([]byte(source.Data))
+	case "url":
+		if source.URL == "" {
+			return core.ContentPart{}, false, fmt.Errorf("url document source requires url")
+		}
+		file.FileData = source.URL
+	case "file":
+		if strings.TrimSpace(source.FileID) == "" {
+			return core.ContentPart{}, false, fmt.Errorf("file document source requires file_id")
+		}
+		file.FileID = strings.TrimSpace(source.FileID)
+	case "content":
+		text, err := textBlocksText(source.Content)
+		if err != nil {
+			return core.ContentPart{}, false, fmt.Errorf("document content: %v", err)
+		}
+		if title := strings.TrimSpace(block.Title); title != "" && text != "" {
+			text = title + "\n\n" + text
+		}
+		if text == "" {
+			return core.ContentPart{}, false, nil
+		}
+		return core.ContentPart{Type: "text", Text: text, ExtraFields: extra}, true, nil
+	default:
+		return core.ContentPart{}, false, fmt.Errorf("unsupported document source type %q", source.Type)
+	}
+	return core.ContentPart{Type: "file", File: file, ExtraFields: extra}, true, nil
+}
+
+// searchResultText flattens a search_result block (source URL, title, text
+// content) into text. Citation metadata has no canonical equivalent.
+func searchResultText(block ContentBlock) (string, error) {
+	var source string
+	if trimmed := bytes.TrimSpace(block.Source); len(trimmed) > 0 && trimmed[0] == '"' {
+		if err := json.Unmarshal(trimmed, &source); err != nil {
+			return "", fmt.Errorf("search_result source: %v", err)
+		}
+	}
+	body, err := textBlocksText(block.Content)
+	if err != nil {
+		return "", fmt.Errorf("search_result content: %v", err)
+	}
+	var lines []string
+	if title := strings.TrimSpace(block.Title); title != "" {
+		lines = append(lines, "Title: "+title)
+	}
+	if source = strings.TrimSpace(source); source != "" {
+		lines = append(lines, "Source: "+source)
+	}
+	if body != "" {
+		if len(lines) > 0 {
+			lines = append(lines, "")
+		}
+		lines = append(lines, body)
+	}
+	return strings.Join(lines, "\n"), nil
+}
+
+// textBlocksText joins the text of a string-or-text-block-array content value.
+func textBlocksText(raw json.RawMessage) (string, error) {
+	text, blocks, err := parseContent(raw)
+	if err != nil {
+		return "", err
+	}
+	if blocks == nil {
+		return text, nil
+	}
+	parts := make([]string, 0, len(blocks))
+	for _, block := range blocks {
+		if block.Type != "text" {
+			return "", fmt.Errorf("block type %q is not supported; only text is allowed", block.Type)
+		}
+		if block.Text != "" {
+			parts = append(parts, block.Text)
+		}
+	}
+	return strings.Join(parts, "\n"), nil
+}
+
+// thinkingBlockJSON re-encodes a thinking block exactly as Anthropic expects
+// it back: thinking blocks always carry their text (possibly empty) and
+// signature, redacted blocks carry their opaque data.
+func thinkingBlockJSON(block ContentBlock) json.RawMessage {
+	var raw []byte
+	if block.Type == "redacted_thinking" {
+		raw, _ = json.Marshal(struct {
+			Type string `json:"type"`
+			Data string `json:"data"`
+		}{Type: block.Type, Data: block.Data})
+	} else {
+		raw, _ = json.Marshal(struct {
+			Type      string `json:"type"`
+			Thinking  string `json:"thinking"`
+			Signature string `json:"signature,omitempty"`
+		}{Type: block.Type, Thinking: block.Thinking, Signature: block.Signature})
+	}
+	return raw
+}
+
+// toolResultExtra adds the is_error marker to a tool message's extras.
+func toolResultExtra(extra core.UnknownJSONFields, isError bool) core.UnknownJSONFields {
+	if !isError {
+		return extra
+	}
+	fields := map[string]json.RawMessage{core.ToolResultIsErrorField: json.RawMessage("true")}
+	if raw := extra.Lookup("cache_control"); len(raw) > 0 {
+		fields["cache_control"] = raw
+	}
+	return core.UnknownJSONFieldsFromMap(fields)
+}
+
+// decodeSource decodes an image/document source object. A nil result means
+// the block had no source.
+func decodeSource(raw json.RawMessage) (*Source, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || core.IsJSONNull(trimmed) {
+		return nil, nil
+	}
+	if trimmed[0] != '{' {
+		return nil, fmt.Errorf("source must be an object")
+	}
+	var source Source
+	if err := json.Unmarshal(trimmed, &source); err != nil {
+		return nil, fmt.Errorf("source: %v", err)
+	}
+	return &source, nil
 }
 
 // collapseParts reduces content parts to a plain string when they are all text,
@@ -285,7 +511,7 @@ func systemText(raw json.RawMessage) (string, error) {
 	parts := make([]string, 0, len(blocks))
 	for _, block := range blocks {
 		if block.Type != "text" {
-			return "", fmt.Errorf("system block type %q is not supported; only text is allowed", block.Type)
+			continue
 		}
 		if block.Text != "" {
 			parts = append(parts, block.Text)
@@ -297,7 +523,7 @@ func systemText(raw json.RawMessage) (string, error) {
 // systemContent is systemText's metadata-preserving counterpart. It keeps a
 // structured representation only when at least one block carries cache_control;
 // ordinary system prompts retain the historical compact string representation.
-func systemContent(raw json.RawMessage) (core.MessageContent, error) {
+func systemContent(raw json.RawMessage, lenient bool) (core.MessageContent, error) {
 	text, blocks, err := parseContent(raw)
 	if err != nil {
 		return nil, fmt.Errorf("system: %v", err)
@@ -313,6 +539,9 @@ func systemContent(raw json.RawMessage) (core.MessageContent, error) {
 	hasCacheControl := false
 	for _, block := range blocks {
 		if block.Type != "text" {
+			if lenient {
+				continue
+			}
 			return nil, fmt.Errorf("system block type %q is not supported; only text is allowed", block.Type)
 		}
 		if block.Text == "" {
@@ -358,14 +587,15 @@ func validatedCacheControlJSON(raw json.RawMessage) (json.RawMessage, error) {
 }
 
 // toolResultContent converts a tool_result block content, which itself may be
-// a string or an array of text and image blocks, into canonical message
-// content. Text-only results collapse to a plain string; results carrying
-// images (Claude Code returns screenshots and read image files this way)
-// keep the structured part list so the egress translator can forward them.
-// A present but malformed or otherwise unsupported tool_result content is an
-// error rather than silently dropped: the downstream provider must not
-// receive an empty or truncated tool response.
-func toolResultContent(raw json.RawMessage) (core.MessageContent, error) {
+// a string or an array of text, image, document, and search_result blocks,
+// into canonical message content. Text-only results collapse to a plain
+// string; results carrying attachments (Claude Code returns screenshots and
+// read image/PDF files this way) keep the structured part list so the egress
+// translator can forward them. A present but malformed or otherwise
+// unsupported tool_result content is an error rather than silently dropped:
+// the downstream provider must not receive an empty or truncated tool
+// response.
+func toolResultContent(raw json.RawMessage, lenient bool) (core.MessageContent, error) {
 	text, blocks, err := parseContent(raw)
 	if err != nil {
 		return nil, fmt.Errorf("tool_result content: %v", err)
@@ -380,22 +610,19 @@ func toolResultContent(raw json.RawMessage) (core.MessageContent, error) {
 			return nil, fmt.Errorf("tool_result content: %v", err)
 		}
 		switch block.Type {
-		case "text":
-			if block.Text != "" {
-				parts = append(parts, core.ContentPart{Type: "text", Text: block.Text, ExtraFields: extra})
-			}
-		case "image":
-			url, err := imageURLFromSource(block.Source)
+		case "text", "image", "document", "search_result":
+			part, ok, err := payloadPart(block, extra)
 			if err != nil {
 				return nil, fmt.Errorf("tool_result content: %v", err)
 			}
-			parts = append(parts, core.ContentPart{
-				Type:        "image_url",
-				ImageURL:    &core.ImageURLContent{URL: url},
-				ExtraFields: extra,
-			})
+			if ok {
+				parts = append(parts, part)
+			}
 		default:
-			return nil, fmt.Errorf("tool_result content block type %q is not supported; only text and image are allowed", block.Type)
+			if lenient {
+				continue
+			}
+			return nil, fmt.Errorf("tool_result content block type %q is not supported; only text, image, document, and search_result are allowed", block.Type)
 		}
 	}
 	content := collapseParts(parts)
@@ -439,7 +666,7 @@ func rawToArguments(raw json.RawMessage) string {
 	return compact.String()
 }
 
-func convertTools(tools []Tool) ([]map[string]any, error) {
+func convertTools(tools []Tool, lenient bool) ([]map[string]any, error) {
 	if len(tools) == 0 {
 		return nil, nil
 	}
@@ -450,6 +677,9 @@ func convertTools(tools []Tool) ([]map[string]any, error) {
 		// canonical chat equivalent; reject them rather than mistranslating
 		// them into a phantom custom function the gateway cannot execute.
 		if t := strings.TrimSpace(tool.Type); t != "" && t != "custom" {
+			if lenient {
+				continue
+			}
 			return nil, core.NewInvalidRequestError(fmt.Sprintf("tools[%d]: server tool type %q is not supported; use the /p/anthropic/v1/messages passthrough for provider-native tools", i, tool.Type), nil)
 		}
 		if strings.TrimSpace(tool.Name) == "" {
@@ -575,7 +805,7 @@ func EstimateInputTokens(req *MessagesRequest) int {
 		for _, block := range blocks {
 			chars += len(block.Text) + len(block.Thinking)
 			chars += len(bytes.TrimSpace(block.Input))
-			result, _ := toolResultContent(block.Content)
+			result, _ := toolResultContent(block.Content, true)
 			chars += len(core.ExtractTextContent(result))
 		}
 	}

--- a/internal/anthropicapi/request_test.go
+++ b/internal/anthropicapi/request_test.go
@@ -71,7 +71,8 @@ func TestToChatRequestRejectsInvalidShapes(t *testing.T) {
 		{name: "malformed system", body: `{"model":"m","max_tokens":10,"system":42,"messages":[{"role":"user","content":"hi"}]}`},
 		{name: "non-text system block", body: `{"model":"m","max_tokens":10,"system":[{"type":"image"}],"messages":[{"role":"user","content":"hi"}]}`},
 		{name: "malformed tool_result content", body: `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":42}]}]}`},
-		{name: "unsupported tool_result block", body: `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"document"}]}]}]}`},
+		{name: "unsupported tool_result block", body: `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"browser_state"}]}]}]}`},
+		{name: "tool_result document without source", body: `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"document"}]}]}]}`},
 		{name: "tool_result image without source", body: `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"image"}]}]}]}`},
 	}
 	for _, tc := range tests {
@@ -538,17 +539,17 @@ func TestToChatRequestRejectsUnsupportedContentBlock(t *testing.T) {
 		"model":"m","max_tokens":10,
 		"messages":[{"role":"user","content":[
 			{"type":"text","text":"summarize"},
-			{"type":"document","source":{"type":"base64","media_type":"application/pdf","data":"eA=="}}
+			{"type":"container_upload","file_id":"file_1"}
 		]}]
 	}`))
 	if err == nil {
-		t.Fatal("expected error for unsupported document content block")
+		t.Fatal("expected error for unsupported container_upload content block")
 	}
 	gatewayErr, ok := err.(*core.GatewayError)
 	if !ok || gatewayErr.Type != core.ErrorTypeInvalidRequest {
 		t.Fatalf("expected invalid_request_error, got %T: %v", err, err)
 	}
-	if !strings.Contains(gatewayErr.Message, "document") {
+	if !strings.Contains(gatewayErr.Message, "container_upload") {
 		t.Errorf("error message should name the block type: %q", gatewayErr.Message)
 	}
 }
@@ -649,5 +650,210 @@ func TestEstimateChatInputTokens(t *testing.T) {
 				t.Errorf("estimate = %d, want %d", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestToChatRequestDocumentBlocks(t *testing.T) {
+	tests := []struct {
+		name     string
+		block    string
+		wantType string
+		wantText string
+		check    func(t *testing.T, part core.ContentPart)
+	}{
+		{
+			name:     "base64 pdf",
+			block:    `{"type":"document","title":"report.pdf","source":{"type":"base64","media_type":"application/pdf","data":"JVBERi0="},"cache_control":{"type":"ephemeral"}}`,
+			wantType: "file",
+			check: func(t *testing.T, part core.ContentPart) {
+				if part.File.FileData != "data:application/pdf;base64,JVBERi0=" || part.File.Filename != "report.pdf" {
+					t.Errorf("file = %+v", part.File)
+				}
+				if got := string(part.ExtraFields.Lookup("cache_control")); got != `{"type":"ephemeral"}` {
+					t.Errorf("cache_control = %s", got)
+				}
+			},
+		},
+		{
+			name:     "plain text",
+			block:    `{"type":"document","source":{"type":"text","media_type":"text/plain","data":"hello"}}`,
+			wantType: "file",
+			check: func(t *testing.T, part core.ContentPart) {
+				if part.File.FileData != "data:text/plain;base64,aGVsbG8=" {
+					t.Errorf("file = %+v", part.File)
+				}
+			},
+		},
+		{
+			name:     "url",
+			block:    `{"type":"document","source":{"type":"url","url":"https://example.com/a.pdf"}}`,
+			wantType: "file",
+			check: func(t *testing.T, part core.ContentPart) {
+				if part.File.FileData != "https://example.com/a.pdf" {
+					t.Errorf("file = %+v", part.File)
+				}
+			},
+		},
+		{
+			name:     "file id",
+			block:    `{"type":"document","source":{"type":"file","file_id":"file_123"}}`,
+			wantType: "file",
+			check: func(t *testing.T, part core.ContentPart) {
+				if part.File.FileID != "file_123" || part.File.FileData != "" {
+					t.Errorf("file = %+v", part.File)
+				}
+			},
+		},
+		{
+			name:     "custom content degrades to text",
+			block:    `{"type":"document","title":"Notes","source":{"type":"content","content":[{"type":"text","text":"one"},{"type":"text","text":"two"}]}}`,
+			wantType: "text",
+			wantText: "Notes\n\none\ntwo",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			chat, err := ToChatRequest(mustDecode(t, `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":[{"type":"text","text":"read"},`+tc.block+`]}]}`))
+			if err != nil {
+				t.Fatalf("ToChatRequest: %v", err)
+			}
+			if tc.wantType == "text" {
+				// Text-only content collapses to a string.
+				if got := chat.Messages[0].Content; got != "read\n"+tc.wantText {
+					t.Fatalf("content = %#v, want %q", got, "read\n"+tc.wantText)
+				}
+				return
+			}
+			parts, ok := chat.Messages[0].Content.([]core.ContentPart)
+			if !ok || len(parts) != 2 {
+				t.Fatalf("content = %#v, want two parts", chat.Messages[0].Content)
+			}
+			if parts[1].Type != tc.wantType {
+				t.Fatalf("parts[1].Type = %q, want %q", parts[1].Type, tc.wantType)
+			}
+			tc.check(t, parts[1])
+		})
+	}
+}
+
+func TestToChatRequestDocumentInsideToolResult(t *testing.T) {
+	chat, err := ToChatRequest(mustDecode(t, `{
+		"model":"m","max_tokens":10,
+		"messages":[{"role":"user","content":[
+			{"type":"tool_result","tool_use_id":"tu_1","content":[
+				{"type":"document","source":{"type":"base64","media_type":"application/pdf","data":"JVBERi0="}}
+			]}
+		]}]
+	}`))
+	if err != nil {
+		t.Fatalf("ToChatRequest: %v", err)
+	}
+	parts, ok := chat.Messages[0].Content.([]core.ContentPart)
+	if !ok || len(parts) != 1 || parts[0].Type != "file" || parts[0].File.FileData != "data:application/pdf;base64,JVBERi0=" {
+		t.Fatalf("tool content = %#v, want one file part", chat.Messages[0].Content)
+	}
+}
+
+func TestToChatRequestSearchResultBlock(t *testing.T) {
+	chat, err := ToChatRequest(mustDecode(t, `{
+		"model":"m","max_tokens":10,
+		"messages":[{"role":"user","content":[
+			{"type":"tool_result","tool_use_id":"tu_1","content":[
+				{"type":"search_result","source":"https://example.com/doc","title":"Doc","content":[{"type":"text","text":"body"}],"citations":{"enabled":true}}
+			]}
+		]}]
+	}`))
+	if err != nil {
+		t.Fatalf("ToChatRequest: %v", err)
+	}
+	if got := chat.Messages[0].Content; got != "Title: Doc\nSource: https://example.com/doc\n\nbody" {
+		t.Errorf("tool content = %#v", got)
+	}
+}
+
+func TestToChatRequestToolResultIsError(t *testing.T) {
+	chat, err := ToChatRequest(mustDecode(t, `{
+		"model":"m","max_tokens":10,
+		"messages":[{"role":"user","content":[
+			{"type":"tool_result","tool_use_id":"tu_1","content":"boom","is_error":true,"cache_control":{"type":"ephemeral"}},
+			{"type":"tool_result","tool_use_id":"tu_2","content":"fine"}
+		]}]
+	}`))
+	if err != nil {
+		t.Fatalf("ToChatRequest: %v", err)
+	}
+	if got := string(chat.Messages[0].ExtraFields.Lookup(core.ToolResultIsErrorField)); got != "true" {
+		t.Errorf("is_error = %q, want true", got)
+	}
+	if got := string(chat.Messages[0].ExtraFields.Lookup("cache_control")); got != `{"type":"ephemeral"}` {
+		t.Errorf("cache_control = %s, want preserved alongside is_error", got)
+	}
+	if got := chat.Messages[1].ExtraFields.Lookup(core.ToolResultIsErrorField); len(got) != 0 {
+		t.Errorf("messages[1] is_error = %s, want absent", got)
+	}
+}
+
+func TestToChatRequestPreservesAssistantThinkingBlocks(t *testing.T) {
+	chat, err := ToChatRequest(mustDecode(t, `{
+		"model":"m","max_tokens":10,
+		"messages":[
+			{"role":"user","content":"hi"},
+			{"role":"assistant","content":[
+				{"type":"thinking","thinking":"","signature":"sig1"},
+				{"type":"redacted_thinking","data":"opaque"},
+				{"type":"tool_use","id":"tu_1","name":"lookup","input":{}}
+			]},
+			{"role":"user","content":[{"type":"thinking","thinking":"stray"},{"type":"text","text":"ok"}]}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("ToChatRequest: %v", err)
+	}
+	assistant := chat.Messages[1]
+	want := `[{"type":"thinking","thinking":"","signature":"sig1"},{"type":"redacted_thinking","data":"opaque"}]`
+	if got := string(assistant.ExtraFields.Lookup(core.ThinkingBlocksField)); got != want {
+		t.Errorf("thinking_blocks = %s, want %s", got, want)
+	}
+	if len(assistant.ToolCalls) != 1 {
+		t.Errorf("tool calls = %+v", assistant.ToolCalls)
+	}
+	if got := chat.Messages[2].ExtraFields.Lookup(core.ThinkingBlocksField); len(got) != 0 {
+		t.Errorf("user thinking_blocks = %s, want dropped", got)
+	}
+	if chat.Messages[2].Content != "ok" {
+		t.Errorf("user content = %#v", chat.Messages[2].Content)
+	}
+}
+
+func TestToChatRequestLenientDropsUnsupportedContent(t *testing.T) {
+	body := `{
+		"model":"m","max_tokens":10,
+		"system":[{"type":"text","text":"sys"},{"type":"image","source":{"type":"url","url":"https://x/y.png"}}],
+		"tools":[{"type":"web_search_20250305","name":"web_search"},{"name":"lookup","input_schema":{"type":"object"}}],
+		"messages":[
+			{"role":"user","content":"search"},
+			{"role":"assistant","content":[
+				{"type":"server_tool_use","id":"srv_1","name":"web_search","input":{"query":"q"}},
+				{"type":"web_search_tool_result","tool_use_id":"srv_1","content":[]},
+				{"type":"text","text":"found"}
+			]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu_1","content":[{"type":"tool_reference","tool_name":"x"}]}]}
+		]
+	}`
+	if _, err := ToChatRequest(mustDecode(t, body)); err == nil {
+		t.Fatal("strict translation should reject server tools and server-tool blocks")
+	}
+	chat, err := ToChatRequestLenient(mustDecode(t, body))
+	if err != nil {
+		t.Fatalf("ToChatRequestLenient: %v", err)
+	}
+	if chat.Model != "m" || len(chat.Tools) != 1 {
+		t.Errorf("model = %q tools = %d, want m and one custom tool", chat.Model, len(chat.Tools))
+	}
+	if len(chat.Messages) != 4 || chat.Messages[0].Content != "sys" || chat.Messages[2].Content != "found" || chat.Messages[3].Role != "tool" {
+		t.Errorf("messages = %+v", chat.Messages)
+	}
+	if _, err := ToChatRequestLenient(mustDecode(t, `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":42}]}`)); err == nil {
+		t.Error("lenient translation should still reject malformed content")
 	}
 }

--- a/internal/anthropicapi/request_test.go
+++ b/internal/anthropicapi/request_test.go
@@ -73,6 +73,7 @@ func TestToChatRequestRejectsInvalidShapes(t *testing.T) {
 		{name: "malformed tool_result content", body: `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":42}]}]}`},
 		{name: "unsupported tool_result block", body: `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"browser_state"}]}]}]}`},
 		{name: "tool_result document without source", body: `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"document"}]}]}]}`},
+		{name: "document content source without content", body: `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":[{"type":"document","source":{"type":"content"}}]}]}`},
 		{name: "tool_result image without source", body: `{"model":"m","max_tokens":10,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"image"}]}]}]}`},
 	}
 	for _, tc := range tests {

--- a/internal/anthropicapi/request_test.go
+++ b/internal/anthropicapi/request_test.go
@@ -689,7 +689,7 @@ func TestToChatRequestDocumentBlocks(t *testing.T) {
 			block:    `{"type":"document","source":{"type":"url","url":"https://example.com/a.pdf"}}`,
 			wantType: "file",
 			check: func(t *testing.T, part core.ContentPart) {
-				if part.File.FileData != "https://example.com/a.pdf" {
+				if part.File.FileURL != "https://example.com/a.pdf" || part.File.FileData != "" {
 					t.Errorf("file = %+v", part.File)
 				}
 			},

--- a/internal/anthropicapi/types.go
+++ b/internal/anthropicapi/types.go
@@ -42,16 +42,21 @@ type Message struct {
 // is a union; only the fields relevant to Type are populated.
 type ContentBlock struct {
 	Type string `json:"type"`
-	// text / thinking
-	Text     string `json:"text,omitempty"`
-	Thinking string `json:"thinking,omitempty"`
-	// image
-	Source *Source `json:"source,omitempty"`
+	// text / thinking / redacted_thinking
+	Text      string `json:"text,omitempty"`
+	Thinking  string `json:"thinking,omitempty"`
+	Signature string `json:"signature,omitempty"`
+	Data      string `json:"data,omitempty"`
+	// image / document (object) or search_result (string); decoded per type
+	Source json.RawMessage `json:"source,omitempty" swaggertype:"object"`
+	// document / search_result
+	Title string `json:"title,omitempty"`
 	// tool_use
 	ID    string          `json:"id,omitempty"`
 	Name  string          `json:"name,omitempty"`
 	Input json.RawMessage `json:"input,omitempty" swaggertype:"object"`
-	// tool_result
+	// tool_result (Content also carries search_result text blocks and the
+	// custom-content variant of document sources)
 	ToolUseID string          `json:"tool_use_id,omitempty"`
 	Content   json.RawMessage `json:"content,omitempty" swaggertype:"object"`
 	IsError   bool            `json:"is_error,omitempty"`
@@ -60,12 +65,15 @@ type ContentBlock struct {
 	CacheControl json.RawMessage `json:"cache_control,omitempty" swaggertype:"object"`
 }
 
-// Source describes an Anthropic image source (base64 inline data or a URL).
+// Source describes an Anthropic image or document source: base64 inline
+// data, plain text, a URL, a Files API file_id, or custom content blocks.
 type Source struct {
-	Type      string `json:"type"`
-	MediaType string `json:"media_type,omitempty"`
-	Data      string `json:"data,omitempty"`
-	URL       string `json:"url,omitempty"`
+	Type      string          `json:"type"`
+	MediaType string          `json:"media_type,omitempty"`
+	Data      string          `json:"data,omitempty"`
+	URL       string          `json:"url,omitempty"`
+	FileID    string          `json:"file_id,omitempty"`
+	Content   json.RawMessage `json:"content,omitempty" swaggertype:"object"`
 }
 
 // Tool is an Anthropic tool definition. A custom tool has no Type (or Type

--- a/internal/core/anthropic_fields.go
+++ b/internal/core/anthropic_fields.go
@@ -1,0 +1,15 @@
+package core
+
+// Message-level extra fields that carry Anthropic Messages history through the
+// canonical chat request. They are set by the Anthropic ingress translator,
+// consumed by the Anthropic provider, and stripped before any other provider
+// sees the request (see providers.adaptAnthropicCacheControl).
+const (
+	// ThinkingBlocksField holds the raw thinking/redacted_thinking blocks of an
+	// assistant turn as a JSON array. Anthropic requires them back verbatim
+	// (with signatures) when a thinking-enabled tool-use turn continues.
+	ThinkingBlocksField = "thinking_blocks"
+	// ToolResultIsErrorField marks a tool message as a failed tool call
+	// (Anthropic tool_result.is_error).
+	ToolResultIsErrorField = "is_error"
+)

--- a/internal/core/chat_content.go
+++ b/internal/core/chat_content.go
@@ -19,20 +19,23 @@ type ContentPart struct {
 }
 
 // FileContent carries a document attachment for file parts, mirroring the
-// OpenAI Chat Completions file input. FileData is a data: URL (PDF or plain
-// text) or an http(s) URL; FileID references a provider-side uploaded file.
+// OpenAI Chat Completions file input. FileData is inline content as a data:
+// URL (PDF or plain text); FileURL is a remote http(s) document (the Responses
+// API input_file.file_url); FileID references a provider-side uploaded file.
 // Anthropic document blocks translate to and from this part.
 type FileContent struct {
 	FileData    string            `json:"file_data,omitempty"`
+	FileURL     string            `json:"file_url,omitempty"`
 	FileID      string            `json:"file_id,omitempty"`
 	Filename    string            `json:"filename,omitempty"`
 	ExtraFields UnknownJSONFields `json:"-" swaggerignore:"true"`
 }
 
-// ValidFilePayload reports whether a file part carries an attachment: either
-// inline/remote file_data or a provider file_id.
+// ValidFilePayload reports whether a file part carries an attachment: inline
+// file_data, a remote file_url, or a provider file_id.
 func ValidFilePayload(file *FileContent) bool {
-	return file != nil && (strings.TrimSpace(file.FileData) != "" || strings.TrimSpace(file.FileID) != "")
+	return file != nil && (strings.TrimSpace(file.FileData) != "" ||
+		strings.TrimSpace(file.FileURL) != "" || strings.TrimSpace(file.FileID) != "")
 }
 
 // ImageURLContent contains an image reference for image_url parts.
@@ -138,7 +141,7 @@ func (p ContentPart) MarshalJSON() ([]byte, error) {
 		}, p.ExtraFields)
 	case "file", "input_file":
 		if !ValidFilePayload(p.File) {
-			return nil, fmt.Errorf("file part is missing file.file_data or file.file_id")
+			return nil, fmt.Errorf("file part is missing file.file_data, file.file_url, or file.file_id")
 		}
 		return marshalWithUnknownJSONFields(struct {
 			Type string       `json:"type"`
@@ -158,7 +161,7 @@ func (c *FileContent) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &decoded); err != nil {
 		return err
 	}
-	extraFields, err := extractUnknownJSONFields(data, "file_data", "file_id", "filename")
+	extraFields, err := extractUnknownJSONFields(data, "file_data", "file_url", "file_id", "filename")
 	if err != nil {
 		return err
 	}
@@ -170,10 +173,12 @@ func (c *FileContent) UnmarshalJSON(data []byte) error {
 func (c FileContent) MarshalJSON() ([]byte, error) {
 	return marshalWithUnknownJSONFields(struct {
 		FileData string `json:"file_data,omitempty"`
+		FileURL  string `json:"file_url,omitempty"`
 		FileID   string `json:"file_id,omitempty"`
 		Filename string `json:"filename,omitempty"`
 	}{
 		FileData: c.FileData,
+		FileURL:  c.FileURL,
 		FileID:   c.FileID,
 		Filename: c.Filename,
 	}, c.ExtraFields)
@@ -487,7 +492,7 @@ func unmarshalContentPart(data []byte) (ContentPart, error) {
 		}, nil
 	case "file", "input_file":
 		if !ValidFilePayload(raw.File) {
-			return ContentPart{}, fmt.Errorf("file part is missing file.file_data or file.file_id")
+			return ContentPart{}, fmt.Errorf("file part is missing file.file_data, file.file_url, or file.file_id")
 		}
 		return ContentPart{
 			Type:        "file",
@@ -542,7 +547,7 @@ func normalizeTypedContentPart(part ContentPart) (ContentPart, error) {
 		}, nil
 	case "file", "input_file":
 		if !ValidFilePayload(part.File) {
-			return ContentPart{}, fmt.Errorf("file part is missing file.file_data or file.file_id")
+			return ContentPart{}, fmt.Errorf("file part is missing file.file_data, file.file_url, or file.file_id")
 		}
 		file := *part.File
 		file.ExtraFields = CloneUnknownJSONFields(part.File.ExtraFields)

--- a/internal/core/chat_content.go
+++ b/internal/core/chat_content.go
@@ -14,7 +14,25 @@ type ContentPart struct {
 	Text        string             `json:"text,omitempty"`
 	ImageURL    *ImageURLContent   `json:"image_url,omitempty"`
 	InputAudio  *InputAudioContent `json:"input_audio,omitempty"`
+	File        *FileContent       `json:"file,omitempty"`
 	ExtraFields UnknownJSONFields  `json:"-" swaggerignore:"true"`
+}
+
+// FileContent carries a document attachment for file parts, mirroring the
+// OpenAI Chat Completions file input. FileData is a data: URL (PDF or plain
+// text) or an http(s) URL; FileID references a provider-side uploaded file.
+// Anthropic document blocks translate to and from this part.
+type FileContent struct {
+	FileData    string            `json:"file_data,omitempty"`
+	FileID      string            `json:"file_id,omitempty"`
+	Filename    string            `json:"filename,omitempty"`
+	ExtraFields UnknownJSONFields `json:"-" swaggerignore:"true"`
+}
+
+// ValidFilePayload reports whether a file part carries an attachment: either
+// inline/remote file_data or a provider file_id.
+func ValidFilePayload(file *FileContent) bool {
+	return file != nil && (strings.TrimSpace(file.FileData) != "" || strings.TrimSpace(file.FileID) != "")
 }
 
 // ImageURLContent contains an image reference for image_url parts.
@@ -118,9 +136,47 @@ func (p ContentPart) MarshalJSON() ([]byte, error) {
 			Type:       "input_audio",
 			InputAudio: p.InputAudio,
 		}, p.ExtraFields)
+	case "file", "input_file":
+		if !ValidFilePayload(p.File) {
+			return nil, fmt.Errorf("file part is missing file.file_data or file.file_id")
+		}
+		return marshalWithUnknownJSONFields(struct {
+			Type string       `json:"type"`
+			File *FileContent `json:"file"`
+		}{
+			Type: "file",
+			File: p.File,
+		}, p.ExtraFields)
 	default:
 		return nil, fmt.Errorf("unsupported content part type %q", p.Type)
 	}
+}
+
+func (c *FileContent) UnmarshalJSON(data []byte) error {
+	type plain FileContent
+	var decoded plain
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	extraFields, err := extractUnknownJSONFields(data, "file_data", "file_id", "filename")
+	if err != nil {
+		return err
+	}
+	*c = FileContent(decoded)
+	c.ExtraFields = extraFields
+	return nil
+}
+
+func (c FileContent) MarshalJSON() ([]byte, error) {
+	return marshalWithUnknownJSONFields(struct {
+		FileData string `json:"file_data,omitempty"`
+		FileID   string `json:"file_id,omitempty"`
+		Filename string `json:"filename,omitempty"`
+	}{
+		FileData: c.FileData,
+		FileID:   c.FileID,
+		Filename: c.Filename,
+	}, c.ExtraFields)
 }
 
 func (c *ImageURLContent) UnmarshalJSON(data []byte) error {
@@ -383,6 +439,7 @@ func unmarshalContentPart(data []byte) (ContentPart, error) {
 		Text       *string         `json:"text,omitempty"`
 		ImageURL   json.RawMessage `json:"image_url,omitempty"`
 		InputAudio json.RawMessage `json:"input_audio,omitempty"`
+		File       *FileContent    `json:"file,omitempty"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return ContentPart{}, err
@@ -392,6 +449,7 @@ func unmarshalContentPart(data []byte) (ContentPart, error) {
 		"text",
 		"image_url",
 		"input_audio",
+		"file",
 	)
 	if err != nil {
 		return ContentPart{}, err
@@ -425,6 +483,15 @@ func unmarshalContentPart(data []byte) (ContentPart, error) {
 		return ContentPart{
 			Type:        "input_audio",
 			InputAudio:  audio,
+			ExtraFields: extraFields,
+		}, nil
+	case "file", "input_file":
+		if !ValidFilePayload(raw.File) {
+			return ContentPart{}, fmt.Errorf("file part is missing file.file_data or file.file_id")
+		}
+		return ContentPart{
+			Type:        "file",
+			File:        raw.File,
 			ExtraFields: extraFields,
 		}, nil
 	default:
@@ -471,6 +538,17 @@ func normalizeTypedContentPart(part ContentPart) (ContentPart, error) {
 				Format:      part.InputAudio.Format,
 				ExtraFields: CloneUnknownJSONFields(part.InputAudio.ExtraFields),
 			},
+			ExtraFields: CloneUnknownJSONFields(part.ExtraFields),
+		}, nil
+	case "file", "input_file":
+		if !ValidFilePayload(part.File) {
+			return ContentPart{}, fmt.Errorf("file part is missing file.file_data or file.file_id")
+		}
+		file := *part.File
+		file.ExtraFields = CloneUnknownJSONFields(part.File.ExtraFields)
+		return ContentPart{
+			Type:        "file",
+			File:        &file,
 			ExtraFields: CloneUnknownJSONFields(part.ExtraFields),
 		}, nil
 	default:

--- a/internal/core/chat_content_file_test.go
+++ b/internal/core/chat_content_file_test.go
@@ -71,3 +71,33 @@ func TestNormalizeMessageContentFilePart(t *testing.T) {
 		t.Errorf("ExtractTextContent = %q", ExtractTextContent(parts))
 	}
 }
+
+func TestContentPartFileURLRoundTrip(t *testing.T) {
+	raw := `{"type":"input_file","file":{"file_url":"https://example.com/a.pdf","filename":"a.pdf","x_file":1}}`
+	var part ContentPart
+	if err := json.Unmarshal([]byte(raw), &part); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if part.Type != "file" || part.File == nil || part.File.FileURL != "https://example.com/a.pdf" || part.File.FileData != "" {
+		t.Fatalf("part = %+v", part)
+	}
+	if got := string(part.File.ExtraFields.Lookup("x_file")); got != "1" {
+		t.Errorf("x_file = %s, want 1", got)
+	}
+	encoded, err := json.Marshal(part)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var decoded struct {
+		File map[string]any `json:"file"`
+	}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if decoded.File["file_url"] != "https://example.com/a.pdf" || decoded.File["x_file"] != float64(1) {
+		t.Errorf("encoded = %s", encoded)
+	}
+	if _, ok := decoded.File["file_data"]; ok {
+		t.Errorf("encoded emitted empty file_data: %s", encoded)
+	}
+}

--- a/internal/core/chat_content_file_test.go
+++ b/internal/core/chat_content_file_test.go
@@ -1,0 +1,73 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/goccy/go-json"
+)
+
+func TestContentPartFileRoundTrip(t *testing.T) {
+	raw := `{"type":"file","file":{"file_data":"data:application/pdf;base64,JVBERi0=","filename":"report.pdf"},"cache_control":{"type":"ephemeral"}}`
+	var part ContentPart
+	if err := json.Unmarshal([]byte(raw), &part); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if part.Type != "file" || part.File == nil || part.File.FileData != "data:application/pdf;base64,JVBERi0=" || part.File.Filename != "report.pdf" {
+		t.Fatalf("part = %+v", part)
+	}
+	if got := string(part.ExtraFields.Lookup("cache_control")); got != `{"type":"ephemeral"}` {
+		t.Errorf("cache_control = %s", got)
+	}
+	encoded, err := json.Marshal(part)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	file, _ := decoded["file"].(map[string]any)
+	if decoded["type"] != "file" || file["file_data"] != "data:application/pdf;base64,JVBERi0=" || file["filename"] != "report.pdf" {
+		t.Errorf("encoded = %s", encoded)
+	}
+	if _, ok := decoded["cache_control"]; !ok {
+		t.Errorf("encoded lost cache_control: %s", encoded)
+	}
+}
+
+func TestContentPartFileRequiresPayload(t *testing.T) {
+	for _, raw := range []string{
+		`{"type":"file"}`,
+		`{"type":"file","file":{}}`,
+		`{"type":"file","file":{"filename":"x.pdf"}}`,
+	} {
+		var part ContentPart
+		if err := json.Unmarshal([]byte(raw), &part); err == nil {
+			t.Errorf("Unmarshal(%s) = nil error, want payload error", raw)
+		}
+	}
+	var part ContentPart
+	if err := json.Unmarshal([]byte(`{"type":"input_file","file":{"file_id":"file_123"}}`), &part); err != nil {
+		t.Fatalf("Unmarshal file_id: %v", err)
+	}
+	if part.Type != "file" || part.File.FileID != "file_123" {
+		t.Errorf("part = %+v", part)
+	}
+}
+
+func TestNormalizeMessageContentFilePart(t *testing.T) {
+	normalized, err := NormalizeMessageContent([]any{
+		map[string]any{"type": "text", "text": "read this"},
+		map[string]any{"type": "file", "file": map[string]any{"file_id": "file_123", "filename": "a.pdf"}},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeMessageContent: %v", err)
+	}
+	parts, ok := normalized.([]ContentPart)
+	if !ok || len(parts) != 2 || parts[1].Type != "file" || parts[1].File == nil || parts[1].File.FileID != "file_123" {
+		t.Fatalf("normalized = %#v", normalized)
+	}
+	if ExtractTextContent(parts) != "read this" {
+		t.Errorf("ExtractTextContent = %q", ExtractTextContent(parts))
+	}
+}

--- a/internal/core/responses.go
+++ b/internal/core/responses.go
@@ -217,6 +217,10 @@ type ResponsesContentItem struct {
 	Text       string             `json:"text,omitempty"`
 	ImageURL   *ImageURLContent   `json:"image_url,omitempty"`
 	InputAudio *InputAudioContent `json:"input_audio,omitempty"`
+	// input_file items carry their file fields flat, unlike chat file parts.
+	FileData string `json:"file_data,omitempty"`
+	FileID   string `json:"file_id,omitempty"`
+	Filename string `json:"filename,omitempty"`
 	// Providers can return structured annotation objects here (for example
 	// citations from native tools), so keep the payload shape liberal.
 	Annotations []json.RawMessage `json:"annotations,omitempty" swaggertype:"array,object"`

--- a/internal/core/responses.go
+++ b/internal/core/responses.go
@@ -219,6 +219,7 @@ type ResponsesContentItem struct {
 	InputAudio *InputAudioContent `json:"input_audio,omitempty"`
 	// input_file items carry their file fields flat, unlike chat file parts.
 	FileData string `json:"file_data,omitempty"`
+	FileURL  string `json:"file_url,omitempty"`
 	FileID   string `json:"file_id,omitempty"`
 	Filename string `json:"filename,omitempty"`
 	// Providers can return structured annotation objects here (for example

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -2003,7 +2003,8 @@ func TestConvertToAnthropicRequest_FilePartsBecomeDocuments(t *testing.T) {
 	}{
 		{name: "pdf", file: core.FileContent{FileData: "data:application/pdf;base64,JVBERi0=", Filename: "a.pdf"}, want: anthropicContentSource{Type: "base64", MediaType: "application/pdf", Data: "JVBERi0="}},
 		{name: "text", file: core.FileContent{FileData: "data:text/plain;base64,aGVsbG8="}, want: anthropicContentSource{Type: "text", MediaType: "text/plain", Data: "hello"}},
-		{name: "url", file: core.FileContent{FileData: "https://example.com/a.pdf"}, want: anthropicContentSource{Type: "url", URL: "https://example.com/a.pdf"}},
+		{name: "url", file: core.FileContent{FileURL: "https://example.com/a.pdf"}, want: anthropicContentSource{Type: "url", URL: "https://example.com/a.pdf"}},
+		{name: "url in file_data", file: core.FileContent{FileData: "https://example.com/a.pdf"}, want: anthropicContentSource{Type: "url", URL: "https://example.com/a.pdf"}},
 		{name: "file id", file: core.FileContent{FileID: "file_123"}, want: anthropicContentSource{Type: "file", FileID: "file_123"}},
 	}
 	for _, tc := range tests {
@@ -2072,8 +2073,8 @@ func TestConvertToAnthropicRequest_ReplaysThinkingBlocks(t *testing.T) {
 		Messages: []core.Message{
 			{Role: "user", Content: "hi"},
 			{
-				Role:    "assistant",
-				Content: "calling",
+				Role:      "assistant",
+				Content:   "calling",
 				ToolCalls: []core.ToolCall{{ID: "tu_1", Type: "function", Function: core.FunctionCall{Name: "lookup", Arguments: "{}"}}},
 				ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
 					core.ThinkingBlocksField: json.RawMessage(`[{"type":"thinking","thinking":"","signature":"sig1"},{"type":"redacted_thinking","data":"opaque"}]`),

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -1995,6 +1995,118 @@ func TestConvertToAnthropicRequest_ToolMessageWithImage(t *testing.T) {
 	}
 }
 
+func TestConvertToAnthropicRequest_FilePartsBecomeDocuments(t *testing.T) {
+	tests := []struct {
+		name string
+		file core.FileContent
+		want anthropicContentSource
+	}{
+		{name: "pdf", file: core.FileContent{FileData: "data:application/pdf;base64,JVBERi0=", Filename: "a.pdf"}, want: anthropicContentSource{Type: "base64", MediaType: "application/pdf", Data: "JVBERi0="}},
+		{name: "text", file: core.FileContent{FileData: "data:text/plain;base64,aGVsbG8="}, want: anthropicContentSource{Type: "text", MediaType: "text/plain", Data: "hello"}},
+		{name: "url", file: core.FileContent{FileData: "https://example.com/a.pdf"}, want: anthropicContentSource{Type: "url", URL: "https://example.com/a.pdf"}},
+		{name: "file id", file: core.FileContent{FileID: "file_123"}, want: anthropicContentSource{Type: "file", FileID: "file_123"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			file := tc.file
+			req, err := convertToAnthropicRequest(&core.ChatRequest{
+				Model: "claude-sonnet-4-5-20250929",
+				Messages: []core.Message{{Role: "user", Content: []core.ContentPart{
+					{Type: "text", Text: "read"},
+					{Type: "file", File: &file},
+				}}},
+			})
+			if err != nil {
+				t.Fatalf("convertToAnthropicRequest: %v", err)
+			}
+			blocks, ok := req.Messages[0].Content.([]anthropicContentBlock)
+			if !ok || len(blocks) != 2 || blocks[1].Type != "document" || blocks[1].Source == nil {
+				t.Fatalf("content = %#v, want text + document blocks", req.Messages[0].Content)
+			}
+			if *blocks[1].Source != tc.want {
+				t.Errorf("source = %+v, want %+v", *blocks[1].Source, tc.want)
+			}
+			if blocks[1].Title != tc.file.Filename {
+				t.Errorf("title = %q, want %q", blocks[1].Title, tc.file.Filename)
+			}
+		})
+	}
+
+	_, err := convertToAnthropicRequest(&core.ChatRequest{
+		Model: "claude-sonnet-4-5-20250929",
+		Messages: []core.Message{{Role: "user", Content: []core.ContentPart{
+			{Type: "file", File: &core.FileContent{FileData: "data:image/png;base64,aGVsbG8="}},
+		}}},
+	})
+	if err == nil {
+		t.Error("expected error for unsupported document media type")
+	}
+}
+
+func TestConvertToAnthropicRequest_ToolMessageIsError(t *testing.T) {
+	req, err := convertToAnthropicRequest(&core.ChatRequest{
+		Model: "claude-sonnet-4-5-20250929",
+		Messages: []core.Message{
+			{Role: "tool", ToolCallID: "call_1", Content: "boom", ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+				core.ToolResultIsErrorField: json.RawMessage("true"),
+			})},
+			{Role: "tool", ToolCallID: "call_2", Content: "fine"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("convertToAnthropicRequest: %v", err)
+	}
+	first := req.Messages[0].Content.([]anthropicContentBlock)[0]
+	second := req.Messages[1].Content.([]anthropicContentBlock)[0]
+	if !first.IsError || first.Content != "boom" {
+		t.Errorf("first tool_result = %+v, want is_error", first)
+	}
+	if second.IsError {
+		t.Errorf("second tool_result = %+v, want no is_error", second)
+	}
+}
+
+func TestConvertToAnthropicRequest_ReplaysThinkingBlocks(t *testing.T) {
+	req, err := convertToAnthropicRequest(&core.ChatRequest{
+		Model: "claude-sonnet-4-5-20250929",
+		Messages: []core.Message{
+			{Role: "user", Content: "hi"},
+			{
+				Role:    "assistant",
+				Content: "calling",
+				ToolCalls: []core.ToolCall{{ID: "tu_1", Type: "function", Function: core.FunctionCall{Name: "lookup", Arguments: "{}"}}},
+				ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+					core.ThinkingBlocksField: json.RawMessage(`[{"type":"thinking","thinking":"","signature":"sig1"},{"type":"redacted_thinking","data":"opaque"}]`),
+				}),
+			},
+			{Role: "tool", ToolCallID: "tu_1", Content: "result"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("convertToAnthropicRequest: %v", err)
+	}
+	blocks, ok := req.Messages[1].Content.([]anthropicContentBlock)
+	if !ok || len(blocks) != 4 {
+		t.Fatalf("assistant content = %#v, want thinking, redacted_thinking, text, tool_use", req.Messages[1].Content)
+	}
+	if blocks[0].Type != "thinking" || blocks[0].Thinking == nil || *blocks[0].Thinking != "" || blocks[0].Signature != "sig1" {
+		t.Errorf("blocks[0] = %+v", blocks[0])
+	}
+	if blocks[1].Type != "redacted_thinking" || blocks[1].Data != "opaque" {
+		t.Errorf("blocks[1] = %+v", blocks[1])
+	}
+	if blocks[2].Type != "text" || blocks[3].Type != "tool_use" {
+		t.Errorf("blocks[2:] = %+v", blocks[2:])
+	}
+	encoded, err := json.Marshal(blocks[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(encoded) != `{"type":"thinking","thinking":"","signature":"sig1"}` {
+		t.Errorf("encoded thinking block = %s, want empty thinking text kept", encoded)
+	}
+}
+
 func TestConvertToAnthropicRequest_ToolChoiceRequiresTools(t *testing.T) {
 	_, err := convertToAnthropicRequest(&core.ChatRequest{
 		Model: "claude-sonnet-4-5-20250929",

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -2042,6 +2042,21 @@ func TestConvertToAnthropicRequest_FilePartsBecomeDocuments(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for unsupported document media type")
 	}
+
+	for _, file := range []core.FileContent{
+		{FileURL: "ftp://example.com/a.pdf"},
+		{FileURL: "not a url"},
+		{FileData: "ftp://example.com/a.pdf"},
+		{FileData: "/relative/a.pdf"},
+	} {
+		_, err := convertToAnthropicRequest(&core.ChatRequest{
+			Model:    "claude-sonnet-4-5-20250929",
+			Messages: []core.Message{{Role: "user", Content: []core.ContentPart{{Type: "file", File: &file}}}},
+		})
+		if gatewayErr, ok := err.(*core.GatewayError); !ok || gatewayErr.Type != core.ErrorTypeInvalidRequest {
+			t.Errorf("file %+v: error = %v, want invalid_request_error", file, err)
+		}
+	}
 }
 
 func TestConvertToAnthropicRequest_ToolMessageIsError(t *testing.T) {

--- a/internal/providers/anthropic/request_translation.go
+++ b/internal/providers/anthropic/request_translation.go
@@ -915,10 +915,13 @@ func anthropicImageSource(raw, mediaTypeHint string) (*anthropicContentSource, e
 // plain text is decoded into a text source), or an http(s) URL.
 func anthropicDocumentSource(file *core.FileContent) (*anthropicContentSource, error) {
 	if !core.ValidFilePayload(file) {
-		return nil, core.NewInvalidRequestError("anthropic document content requires file.file_data or file.file_id", nil)
+		return nil, core.NewInvalidRequestError("anthropic document content requires file.file_data, file.file_url, or file.file_id", nil)
 	}
 	if fileID := strings.TrimSpace(file.FileID); fileID != "" {
 		return &anthropicContentSource{Type: "file", FileID: fileID}, nil
+	}
+	if fileURL := strings.TrimSpace(file.FileURL); fileURL != "" {
+		return anthropicURLDocumentSource(fileURL, "anthropic file.file_url must be an http/https URL")
 	}
 	raw := strings.TrimSpace(file.FileData)
 	if strings.HasPrefix(raw, "data:") {
@@ -958,9 +961,17 @@ func anthropicDocumentSource(file *core.FileContent) (*anthropicContentSource, e
 			return nil, core.NewInvalidRequestError("anthropic document media type is not supported: "+mediaType, nil)
 		}
 	}
+	// Remote URLs in file_data are accepted leniently for clients that never
+	// adopted file_url.
+	return anthropicURLDocumentSource(raw, "anthropic file.file_data must be a data: URL or http/https URL")
+}
+
+// anthropicURLDocumentSource builds a url document source, rejecting anything
+// that is not an absolute http(s) URL with the given message.
+func anthropicURLDocumentSource(raw, rejectMessage string) (*anthropicContentSource, error) {
 	parsed, err := url.Parse(raw)
 	if err != nil || !parsed.IsAbs() || parsed.Hostname() == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
-		return nil, core.NewInvalidRequestError("anthropic file.file_data must be a data: URL or http/https URL", nil)
+		return nil, core.NewInvalidRequestError(rejectMessage, nil)
 	}
 	return &anthropicContentSource{Type: "url", URL: raw}, nil
 }

--- a/internal/providers/anthropic/request_translation.go
+++ b/internal/providers/anthropic/request_translation.go
@@ -2,6 +2,7 @@ package anthropic
 
 import (
 	"bytes"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -253,12 +254,17 @@ func buildAnthropicMessageContent(msg core.Message) (any, error) {
 				Type:         "tool_result",
 				ToolUseID:    toolUseID,
 				Content:      content,
+				IsError:      bytes.Equal(bytes.TrimSpace(msg.ExtraFields.Lookup(core.ToolResultIsErrorField)), []byte("true")),
 				CacheControl: cacheControl,
 			},
 		}, nil
 	}
 
 	content, err := convertMessageContentToAnthropic(msg.Content)
+	if err != nil {
+		return nil, err
+	}
+	content, err = prependThinkingBlocks(msg, content)
 	if err != nil {
 		return nil, err
 	}
@@ -308,6 +314,38 @@ func buildAnthropicMessageContent(msg core.Message) (any, error) {
 			Input:        input,
 			CacheControl: cacheControl,
 		})
+	}
+	return blocks, nil
+}
+
+// prependThinkingBlocks restores the thinking blocks the Anthropic ingress
+// preserved on an assistant message. They must lead the content, unchanged,
+// so a thinking-enabled tool-use turn can continue; Anthropic ignores them
+// on models other than the one that produced them.
+func prependThinkingBlocks(msg core.Message, content any) (any, error) {
+	if msg.Role != "assistant" {
+		return content, nil
+	}
+	raw := msg.ExtraFields.Lookup(core.ThinkingBlocksField)
+	if len(bytes.TrimSpace(raw)) == 0 || core.IsJSONNull(bytes.TrimSpace(raw)) {
+		return content, nil
+	}
+	var thinking []anthropicContentBlock
+	if err := json.Unmarshal(raw, &thinking); err != nil {
+		return nil, core.NewInvalidRequestError("invalid "+core.ThinkingBlocksField+" payload", err)
+	}
+	if len(thinking) == 0 {
+		return content, nil
+	}
+	blocks := make([]anthropicContentBlock, 0, len(thinking)+1)
+	blocks = append(blocks, thinking...)
+	switch c := content.(type) {
+	case string:
+		if strings.TrimSpace(c) != "" {
+			blocks = append(blocks, anthropicContentBlock{Type: "text", Text: c})
+		}
+	case []anthropicContentBlock:
+		blocks = append(blocks, c...)
 	}
 	return blocks, nil
 }
@@ -794,6 +832,17 @@ func convertMessageContentToAnthropic(content any) (any, error) {
 				Source:       source,
 				CacheControl: cacheControl,
 			})
+		case "file":
+			source, err := anthropicDocumentSource(part.File)
+			if err != nil {
+				return nil, err
+			}
+			blocks = append(blocks, anthropicContentBlock{
+				Type:         "document",
+				Source:       source,
+				Title:        strings.TrimSpace(part.File.Filename),
+				CacheControl: cacheControl,
+			})
 		case "input_audio":
 			return nil, core.NewInvalidRequestError("anthropic chat does not support input_audio content", nil)
 		default:
@@ -859,6 +908,61 @@ func anthropicImageSource(raw, mediaTypeHint string) (*anthropicContentSource, e
 		Type: "url",
 		URL:  raw,
 	}, nil
+}
+
+// anthropicDocumentSource maps a canonical file part onto an Anthropic
+// document source: a provider file_id, a base64 data: URL (PDF stays base64,
+// plain text is decoded into a text source), or an http(s) URL.
+func anthropicDocumentSource(file *core.FileContent) (*anthropicContentSource, error) {
+	if !core.ValidFilePayload(file) {
+		return nil, core.NewInvalidRequestError("anthropic document content requires file.file_data or file.file_id", nil)
+	}
+	if fileID := strings.TrimSpace(file.FileID); fileID != "" {
+		return &anthropicContentSource{Type: "file", FileID: fileID}, nil
+	}
+	raw := strings.TrimSpace(file.FileData)
+	if strings.HasPrefix(raw, "data:") {
+		comma := strings.IndexByte(raw, ',')
+		if comma < 0 {
+			return nil, core.NewInvalidRequestError("invalid anthropic document data URL", nil)
+		}
+		tokens := strings.Split(raw[len("data:"):comma], ";")
+		mediaType := strings.ToLower(strings.TrimSpace(tokens[0]))
+		hasBase64 := false
+		for _, token := range tokens[1:] {
+			if strings.EqualFold(strings.TrimSpace(token), "base64") {
+				hasBase64 = true
+				break
+			}
+		}
+		data := raw[comma+1:]
+		if data == "" {
+			return nil, core.NewInvalidRequestError("anthropic document data URL is missing file data", nil)
+		}
+		switch {
+		case mediaType == "application/pdf" && hasBase64:
+			return &anthropicContentSource{Type: "base64", MediaType: mediaType, Data: data}, nil
+		case mediaType == "text/plain" || strings.HasPrefix(mediaType, "text/"):
+			text := data
+			if hasBase64 {
+				decoded, err := base64.StdEncoding.DecodeString(data)
+				if err != nil {
+					return nil, core.NewInvalidRequestError("anthropic document data URL is not valid base64", err)
+				}
+				text = string(decoded)
+			} else if unescaped, err := url.PathUnescape(data); err == nil {
+				text = unescaped
+			}
+			return &anthropicContentSource{Type: "text", MediaType: "text/plain", Data: text}, nil
+		default:
+			return nil, core.NewInvalidRequestError("anthropic document media type is not supported: "+mediaType, nil)
+		}
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || !parsed.IsAbs() || parsed.Hostname() == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return nil, core.NewInvalidRequestError("anthropic file.file_data must be a data: URL or http/https URL", nil)
+	}
+	return &anthropicContentSource{Type: "url", URL: raw}, nil
 }
 
 func isAllowedAnthropicImageMediaType(mediaType string) bool {

--- a/internal/providers/anthropic/types.go
+++ b/internal/providers/anthropic/types.go
@@ -53,8 +53,14 @@ type anthropicMessage struct {
 }
 
 type anthropicContentBlock struct {
-	Type         string                  `json:"type"`
-	Text         string                  `json:"text,omitempty"`
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+	// Thinking is a pointer so a thinking block whose text was omitted by the
+	// model (display: omitted) still round-trips as "thinking": "".
+	Thinking     *string                 `json:"thinking,omitempty"`
+	Signature    string                  `json:"signature,omitempty"`
+	Data         string                  `json:"data,omitempty"`
+	Title        string                  `json:"title,omitempty"`
 	ID           string                  `json:"id,omitempty"`
 	Name         string                  `json:"name,omitempty"`
 	Input        any                     `json:"input,omitempty"`
@@ -70,6 +76,7 @@ type anthropicContentSource struct {
 	MediaType string `json:"media_type,omitempty"`
 	Data      string `json:"data,omitempty"`
 	URL       string `json:"url,omitempty"`
+	FileID    string `json:"file_id,omitempty"`
 }
 
 // anthropicResponse represents the Anthropic API response format

--- a/internal/providers/cache_control.go
+++ b/internal/providers/cache_control.go
@@ -74,8 +74,12 @@ func hasAnthropicOnlyMessageFields(req *core.ChatRequest) bool {
 // canonical chat items produced by the Anthropic Message Batches ingress.
 // Ordinary OpenAI-compatible batches remain opaque and caller-owned.
 func adaptAnthropicBatchCacheControl(ctx context.Context, req *core.BatchRequest, providerType string) (*core.BatchRequest, error) {
-	if req == nil || core.RequestDialectFromContext(ctx) != core.RequestDialectAnthropicMessages ||
-		providerAcceptsAnthropicCacheControl(providerType) {
+	if req == nil || core.RequestDialectFromContext(ctx) != core.RequestDialectAnthropicMessages {
+		return req, nil
+	}
+	// Only Anthropic itself accepts every Anthropic extra; OpenRouter accepts
+	// cache_control but still needs the message-level extras removed.
+	if providerAcceptsAnthropicCacheControl(providerType) && normalizedProviderType(providerType) == "anthropic" {
 		return req, nil
 	}
 

--- a/internal/providers/cache_control.go
+++ b/internal/providers/cache_control.go
@@ -12,33 +12,62 @@ import (
 
 const anthropicCacheControlField = "cache_control"
 
-// adaptAnthropicCacheControl removes Anthropic-only cache directives after the
-// route is known unless the selected provider accepts Anthropic request shapes.
-// The caller's request remains unchanged.
+// anthropicOnlyMessageFields are message extras the Anthropic ingress sets for
+// the Anthropic provider alone. Every other provider forwards message extras
+// verbatim and would reject or misread them.
+var anthropicOnlyMessageFields = []string{core.ThinkingBlocksField, core.ToolResultIsErrorField}
+
+// adaptAnthropicCacheControl removes Anthropic-only cache directives and
+// message extras after the route is known unless the selected provider
+// accepts Anthropic request shapes. The caller's request remains unchanged.
 func adaptAnthropicCacheControl(req *core.ChatRequest, providerType string) *core.ChatRequest {
-	if req == nil || providerAcceptsAnthropicCacheControl(providerType) || !hasAnthropicCacheControl(req) {
+	if req == nil {
+		return req
+	}
+	stripCacheControl := !providerAcceptsAnthropicCacheControl(providerType) && hasAnthropicCacheControl(req)
+	stripMessageFields := normalizedProviderType(providerType) != "anthropic" && hasAnthropicOnlyMessageFields(req)
+	if !stripCacheControl && !stripMessageFields {
 		return req
 	}
 
 	adapted := *req
-	adapted.ExtraFields = req.ExtraFields.Without(anthropicCacheControlField)
+	if stripCacheControl {
+		adapted.ExtraFields = req.ExtraFields.Without(anthropicCacheControlField)
 
-	adapted.Tools = make([]map[string]any, len(req.Tools))
-	for i, tool := range req.Tools {
-		cloned := make(map[string]any, len(tool))
-		for key, value := range tool {
-			if key != anthropicCacheControlField {
-				cloned[key] = value
+		adapted.Tools = make([]map[string]any, len(req.Tools))
+		for i, tool := range req.Tools {
+			cloned := make(map[string]any, len(tool))
+			for key, value := range tool {
+				if key != anthropicCacheControlField {
+					cloned[key] = value
+				}
 			}
+			adapted.Tools[i] = cloned
 		}
-		adapted.Tools[i] = cloned
 	}
 
 	adapted.Messages = make([]core.Message, len(req.Messages))
 	for i, message := range req.Messages {
-		adapted.Messages[i] = withoutAnthropicMessageCacheControl(message)
+		if stripCacheControl {
+			message = withoutAnthropicMessageCacheControl(message)
+		}
+		if stripMessageFields {
+			message.ExtraFields = message.ExtraFields.Without(anthropicOnlyMessageFields...)
+		}
+		adapted.Messages[i] = message
 	}
 	return &adapted
+}
+
+func hasAnthropicOnlyMessageFields(req *core.ChatRequest) bool {
+	return slices.ContainsFunc(req.Messages, func(message core.Message) bool {
+		for _, field := range anthropicOnlyMessageFields {
+			if len(message.ExtraFields.Lookup(field)) > 0 {
+				return true
+			}
+		}
+		return false
+	})
 }
 
 // adaptAnthropicBatchCacheControl applies the same post-routing policy to
@@ -105,7 +134,8 @@ func messageHasAnthropicCacheControl(message core.Message) bool {
 	for _, part := range parts {
 		if len(part.ExtraFields.Lookup(anthropicCacheControlField)) > 0 ||
 			(part.ImageURL != nil && len(part.ImageURL.ExtraFields.Lookup(anthropicCacheControlField)) > 0) ||
-			(part.InputAudio != nil && len(part.InputAudio.ExtraFields.Lookup(anthropicCacheControlField)) > 0) {
+			(part.InputAudio != nil && len(part.InputAudio.ExtraFields.Lookup(anthropicCacheControlField)) > 0) ||
+			(part.File != nil && len(part.File.ExtraFields.Lookup(anthropicCacheControlField)) > 0) {
 			return true
 		}
 	}
@@ -138,6 +168,11 @@ func withoutAnthropicMessageCacheControl(message core.Message) core.Message {
 			audio := *parts[i].InputAudio
 			audio.ExtraFields = audio.ExtraFields.Without(anthropicCacheControlField)
 			parts[i].InputAudio = &audio
+		}
+		if parts[i].File != nil {
+			file := *parts[i].File
+			file.ExtraFields = file.ExtraFields.Without(anthropicCacheControlField)
+			parts[i].File = &file
 		}
 	}
 	message.Content = parts

--- a/internal/providers/cache_planner.go
+++ b/internal/providers/cache_planner.go
@@ -315,7 +315,7 @@ func markOpenAIChatBreakpoint(messages *[]core.Message) bool {
 			return true
 		case []core.ContentPart:
 			for j := len(content) - 1; j >= 0; j-- {
-				if content[j].Type == "text" || content[j].Type == "image_url" || content[j].Type == "input_audio" {
+				if content[j].Type == "text" || content[j].Type == "image_url" || content[j].Type == "input_audio" || content[j].Type == "file" {
 					parts := slices.Clone(content)
 					parts[j].ExtraFields = mergeCacheExtras(parts[j].ExtraFields, map[string]json.RawMessage{
 						"prompt_cache_breakpoint": json.RawMessage(`{"mode":"explicit"}`),

--- a/internal/providers/gemini/native.go
+++ b/internal/providers/gemini/native.go
@@ -302,6 +302,22 @@ func geminiPartsFromContentParts(parts []core.ContentPart) ([]geminiPart, error)
 				MimeType: mimeTypeForAudioFormat(part.InputAudio.Format),
 				Data:     part.InputAudio.Data,
 			}})
+		case "file":
+			if part.File == nil {
+				continue
+			}
+			rawURL := strings.TrimSpace(part.File.FileData)
+			if !strings.HasPrefix(rawURL, "data:") {
+				return nil, core.NewInvalidRequestError(
+					"gemini native file content supports only data: URLs; file_id and remote URLs are not supported",
+					nil,
+				)
+			}
+			mimeType, data, err := parseDataURL(rawURL)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, geminiPart{InlineData: &geminiBlob{MimeType: mimeType, Data: data}})
 		}
 	}
 	return out, nil

--- a/internal/providers/gemini/native.go
+++ b/internal/providers/gemini/native.go
@@ -307,9 +307,9 @@ func geminiPartsFromContentParts(parts []core.ContentPart) ([]geminiPart, error)
 				continue
 			}
 			rawURL := strings.TrimSpace(part.File.FileData)
-			if !strings.HasPrefix(rawURL, "data:") {
+			if !strings.HasPrefix(rawURL, "data:") || part.File.FileURL != "" || part.File.FileID != "" {
 				return nil, core.NewInvalidRequestError(
-					"gemini native file content supports only data: URLs; file_id and remote URLs are not supported",
+					"gemini native file content supports only inline data: URLs in file_data; file_url and file_id are not supported",
 					nil,
 				)
 			}

--- a/internal/providers/gemini/native.go
+++ b/internal/providers/gemini/native.go
@@ -313,7 +313,7 @@ func geminiPartsFromContentParts(parts []core.ContentPart) ([]geminiPart, error)
 					nil,
 				)
 			}
-			mimeType, data, err := parseDataURL(rawURL)
+			mimeType, data, err := parseDataURL(rawURL, "file_data")
 			if err != nil {
 				return nil, err
 			}
@@ -326,7 +326,7 @@ func geminiPartsFromContentParts(parts []core.ContentPart) ([]geminiPart, error)
 func geminiPartFromImageURL(image *core.ImageURLContent) (geminiPart, error) {
 	rawURL := strings.TrimSpace(image.URL)
 	if strings.HasPrefix(rawURL, "data:") {
-		mimeType, data, err := parseDataURL(rawURL)
+		mimeType, data, err := parseDataURL(rawURL, "image_url")
 		if err != nil {
 			return geminiPart{}, err
 		}
@@ -345,10 +345,12 @@ func geminiPartFromImageURL(image *core.ImageURLContent) (geminiPart, error) {
 	)
 }
 
-func parseDataURL(rawURL string) (string, string, error) {
+// parseDataURL splits a data: URL into media type and base64 payload; field
+// names the request field reported in validation errors.
+func parseDataURL(rawURL, field string) (string, string, error) {
 	header, data, ok := strings.Cut(rawURL, ",")
 	if !ok {
-		return "", "", core.NewInvalidRequestError("invalid data URL in image_url", nil)
+		return "", "", core.NewInvalidRequestError("invalid data URL in "+field, nil)
 	}
 	mediaType := strings.TrimPrefix(header, "data:")
 	mediaType = strings.TrimSuffix(mediaType, ";base64")
@@ -356,7 +358,7 @@ func parseDataURL(rawURL string) (string, string, error) {
 		mediaType = parsed
 	}
 	if _, err := base64.StdEncoding.DecodeString(data); err != nil {
-		return "", "", core.NewInvalidRequestError("invalid base64 data in image_url", err)
+		return "", "", core.NewInvalidRequestError("invalid base64 data in "+field, err)
 	}
 	return mediaType, data, nil
 }

--- a/internal/providers/gemini/native_file_test.go
+++ b/internal/providers/gemini/native_file_test.go
@@ -1,0 +1,55 @@
+package gemini
+
+import (
+	"testing"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+func TestGeminiPartsFromContentParts_FileProjection(t *testing.T) {
+	tests := []struct {
+		name     string
+		file     core.FileContent
+		wantMime string
+		wantData string
+		wantErr  bool
+	}{
+		{
+			name:     "inline pdf data url",
+			file:     core.FileContent{FileData: "data:application/pdf;base64,JVBERi0=", Filename: "a.pdf"},
+			wantMime: "application/pdf",
+			wantData: "JVBERi0=",
+		},
+		{name: "malformed data url", file: core.FileContent{FileData: "data:application/pdf;base64"}, wantErr: true},
+		{name: "remote url", file: core.FileContent{FileURL: "https://example.com/a.pdf"}, wantErr: true},
+		{name: "remote url in file_data", file: core.FileContent{FileData: "https://example.com/a.pdf"}, wantErr: true},
+		{name: "file id", file: core.FileContent{FileID: "file_123"}, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			file := tc.file
+			parts, err := geminiPartsFromContentParts([]core.ContentPart{
+				{Type: "text", Text: "read"},
+				{Type: "file", File: &file},
+			})
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected invalid-request error, got parts %#v", parts)
+				}
+				if gatewayErr, ok := err.(*core.GatewayError); !ok || gatewayErr.Type != core.ErrorTypeInvalidRequest {
+					t.Fatalf("error = %v, want invalid_request_error", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("geminiPartsFromContentParts: %v", err)
+			}
+			if len(parts) != 2 || parts[1].InlineData == nil {
+				t.Fatalf("parts = %#v, want text + inline_data", parts)
+			}
+			if parts[1].InlineData.MimeType != tc.wantMime || parts[1].InlineData.Data != tc.wantData {
+				t.Errorf("inline_data = %+v, want mime %q data %q", *parts[1].InlineData, tc.wantMime, tc.wantData)
+			}
+		})
+	}
+}

--- a/internal/providers/responses_content.go
+++ b/internal/providers/responses_content.go
@@ -190,6 +190,7 @@ func normalizeTypedResponsesContentPart(part core.ContentPart) (core.ContentPart
 			Type: "file",
 			File: &core.FileContent{
 				FileData:    strings.TrimSpace(part.File.FileData),
+				FileURL:     strings.TrimSpace(part.File.FileURL),
 				FileID:      strings.TrimSpace(part.File.FileID),
 				Filename:    strings.TrimSpace(part.File.Filename),
 				ExtraFields: core.CloneUnknownJSONFields(part.File.ExtraFields),

--- a/internal/providers/responses_content.go
+++ b/internal/providers/responses_content.go
@@ -85,6 +85,29 @@ func convertResponsesContentParts(parts []any) (any, bool) {
 				InputAudio:  inputAudio,
 				ExtraFields: core.UnknownJSONFieldsFromMap(rawJSONMapFromUnknownKeys(partMap, "type", "input_audio")),
 			})
+		case "input_file", "file":
+			// Responses carries file fields flat on the part; chat nests them
+			// under "file". Accept both shapes.
+			fileMap := partMap
+			if nested, ok := partMap["file"].(map[string]any); ok {
+				fileMap = nested
+			}
+			fileData, _ := fileMap["file_data"].(string)
+			fileID, _ := fileMap["file_id"].(string)
+			filename, _ := fileMap["filename"].(string)
+			file := &core.FileContent{
+				FileData: strings.TrimSpace(fileData),
+				FileID:   strings.TrimSpace(fileID),
+				Filename: strings.TrimSpace(filename),
+			}
+			if !core.ValidFilePayload(file) {
+				return nil, false
+			}
+			typedParts = append(typedParts, core.ContentPart{
+				Type:        "file",
+				File:        file,
+				ExtraFields: core.UnknownJSONFieldsFromMap(rawJSONMapFromUnknownKeys(partMap, "type", "file", "file_data", "file_id", "filename")),
+			})
 		default:
 			if nested, ok := partMap["content"]; ok {
 				text := ExtractContentFromInput(nested)
@@ -148,6 +171,20 @@ func normalizeTypedResponsesContentPart(part core.ContentPart) (core.ContentPart
 				Data:        data,
 				Format:      format,
 				ExtraFields: core.CloneUnknownJSONFields(part.InputAudio.ExtraFields),
+			},
+			ExtraFields: core.CloneUnknownJSONFields(part.ExtraFields),
+		}, true
+	case "file", "input_file":
+		if !core.ValidFilePayload(part.File) {
+			return core.ContentPart{}, false
+		}
+		return core.ContentPart{
+			Type: "file",
+			File: &core.FileContent{
+				FileData:    strings.TrimSpace(part.File.FileData),
+				FileID:      strings.TrimSpace(part.File.FileID),
+				Filename:    strings.TrimSpace(part.File.Filename),
+				ExtraFields: core.CloneUnknownJSONFields(part.File.ExtraFields),
 			},
 			ExtraFields: core.CloneUnknownJSONFields(part.ExtraFields),
 		}, true

--- a/internal/providers/responses_content.go
+++ b/internal/providers/responses_content.go
@@ -89,16 +89,24 @@ func convertResponsesContentParts(parts []any) (any, bool) {
 			// Responses carries file fields flat on the part; chat nests them
 			// under "file". Accept both shapes.
 			fileMap := partMap
+			fileKeys := []string{"type", "file", "file_data", "file_url", "file_id", "filename"}
+			var fileExtras map[string]json.RawMessage
 			if nested, ok := partMap["file"].(map[string]any); ok {
+				// Unknown keys inside the nested object belong to the file, not
+				// the part.
 				fileMap = nested
+				fileExtras = rawJSONMapFromUnknownKeys(nested, "file_data", "file_url", "file_id", "filename")
 			}
 			fileData, _ := fileMap["file_data"].(string)
+			fileURL, _ := fileMap["file_url"].(string)
 			fileID, _ := fileMap["file_id"].(string)
 			filename, _ := fileMap["filename"].(string)
 			file := &core.FileContent{
-				FileData: strings.TrimSpace(fileData),
-				FileID:   strings.TrimSpace(fileID),
-				Filename: strings.TrimSpace(filename),
+				FileData:    strings.TrimSpace(fileData),
+				FileURL:     strings.TrimSpace(fileURL),
+				FileID:      strings.TrimSpace(fileID),
+				Filename:    strings.TrimSpace(filename),
+				ExtraFields: core.UnknownJSONFieldsFromMap(fileExtras),
 			}
 			if !core.ValidFilePayload(file) {
 				return nil, false
@@ -106,7 +114,7 @@ func convertResponsesContentParts(parts []any) (any, bool) {
 			typedParts = append(typedParts, core.ContentPart{
 				Type:        "file",
 				File:        file,
-				ExtraFields: core.UnknownJSONFieldsFromMap(rawJSONMapFromUnknownKeys(partMap, "type", "file", "file_data", "file_id", "filename")),
+				ExtraFields: core.UnknownJSONFieldsFromMap(rawJSONMapFromUnknownKeys(partMap, fileKeys...)),
 			})
 		default:
 			if nested, ok := partMap["content"]; ok {

--- a/internal/providers/responses_content_file_test.go
+++ b/internal/providers/responses_content_file_test.go
@@ -1,0 +1,68 @@
+package providers
+
+import (
+	"testing"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+func TestConvertResponsesContentToChatContent_NestedFileKeepsExtras(t *testing.T) {
+	content, ok := ConvertResponsesContentToChatContent([]any{
+		map[string]any{"type": "text", "text": "read"},
+		map[string]any{
+			"type":   "file",
+			"x_part": true,
+			"file": map[string]any{
+				"file_id":  "file_123",
+				"filename": "a.pdf",
+				"x_file":   "keep",
+			},
+		},
+		map[string]any{"type": "input_file", "file_url": "https://example.com/b.pdf", "filename": "b.pdf"},
+	})
+	if !ok {
+		t.Fatal("conversion failed")
+	}
+	parts, isParts := content.([]core.ContentPart)
+	if !isParts || len(parts) != 3 {
+		t.Fatalf("content = %#v, want three parts", content)
+	}
+	nested := parts[1]
+	if nested.Type != "file" || nested.File == nil || nested.File.FileID != "file_123" || nested.File.Filename != "a.pdf" {
+		t.Fatalf("nested part = %+v", nested)
+	}
+	if got := string(nested.File.ExtraFields.Lookup("x_file")); got != `"keep"` {
+		t.Errorf("nested file extra x_file = %s, want \"keep\"", got)
+	}
+	if got := string(nested.ExtraFields.Lookup("x_part")); got != "true" {
+		t.Errorf("part extra x_part = %s, want true", got)
+	}
+	if len(nested.ExtraFields.Lookup("x_file")) != 0 {
+		t.Errorf("file extra leaked onto the part: %s", nested.ExtraFields.Lookup("x_file"))
+	}
+	flat := parts[2]
+	if flat.Type != "file" || flat.File == nil || flat.File.FileURL != "https://example.com/b.pdf" || flat.File.FileData != "" {
+		t.Fatalf("flat part = %+v", flat)
+	}
+}
+
+func TestBuildResponsesContentItemsFromParts_FileURLAndData(t *testing.T) {
+	items := buildResponsesContentItemsFromParts([]core.ContentPart{
+		{Type: "file", File: &core.FileContent{FileURL: "https://example.com/remote.pdf", Filename: "remote.pdf"}},
+		{Type: "file", File: &core.FileContent{FileData: "data:application/pdf;base64,JVBERi0="}},
+		{Type: "file", File: &core.FileContent{FileID: "file_123"}},
+		{Type: "file", File: &core.FileContent{Filename: "empty.pdf"}},
+	})
+	if len(items) != 3 {
+		t.Fatalf("items = %#v, want three input_file items", items)
+	}
+	if items[0].Type != "input_file" || items[0].FileURL != "https://example.com/remote.pdf" || items[0].FileData != "" || items[0].Filename != "remote.pdf" {
+		t.Errorf("remote item = %+v, want file_url only", items[0])
+	}
+	if items[1].FileData != "data:application/pdf;base64,JVBERi0=" || items[1].FileURL != "" {
+		t.Errorf("inline item = %+v, want file_data only", items[1])
+	}
+	if items[2].FileID != "file_123" {
+		t.Errorf("file id item = %+v", items[2])
+	}
+}

--- a/internal/providers/responses_content_file_test.go
+++ b/internal/providers/responses_content_file_test.go
@@ -66,3 +66,16 @@ func TestBuildResponsesContentItemsFromParts_FileURLAndData(t *testing.T) {
 		t.Errorf("file id item = %+v", items[2])
 	}
 }
+
+func TestConvertResponsesContentToChatContent_TypedFileURLSurvives(t *testing.T) {
+	content, ok := ConvertResponsesContentToChatContent([]core.ContentPart{
+		{Type: "input_file", File: &core.FileContent{FileURL: " https://example.com/a.pdf ", Filename: "a.pdf"}},
+	})
+	if !ok {
+		t.Fatal("conversion failed")
+	}
+	parts, isParts := content.([]core.ContentPart)
+	if !isParts || len(parts) != 1 || parts[0].File == nil || parts[0].File.FileURL != "https://example.com/a.pdf" {
+		t.Fatalf("content = %#v, want a file part keeping file_url", content)
+	}
+}

--- a/internal/providers/responses_output.go
+++ b/internal/providers/responses_output.go
@@ -111,6 +111,7 @@ func buildResponsesContentItemsFromParts(parts []core.ContentPart) []core.Respon
 			items = append(items, core.ResponsesContentItem{
 				Type:     "input_file",
 				FileData: strings.TrimSpace(part.File.FileData),
+				FileURL:  strings.TrimSpace(part.File.FileURL),
 				FileID:   strings.TrimSpace(part.File.FileID),
 				Filename: strings.TrimSpace(part.File.Filename),
 			})

--- a/internal/providers/responses_output.go
+++ b/internal/providers/responses_output.go
@@ -104,6 +104,16 @@ func buildResponsesContentItemsFromParts(parts []core.ContentPart) []core.Respon
 					ExtraFields: core.CloneUnknownJSONFields(part.InputAudio.ExtraFields),
 				},
 			})
+		case "file":
+			if !core.ValidFilePayload(part.File) {
+				continue
+			}
+			items = append(items, core.ResponsesContentItem{
+				Type:     "input_file",
+				FileData: strings.TrimSpace(part.File.FileData),
+				FileID:   strings.TrimSpace(part.File.FileID),
+				Filename: strings.TrimSpace(part.File.Filename),
+			})
 		}
 	}
 	return items

--- a/internal/providers/router_test.go
+++ b/internal/providers/router_test.go
@@ -988,6 +988,39 @@ func TestAdaptAnthropicCacheControl_PreservesSupportedProviders(t *testing.T) {
 	}
 }
 
+func TestAdaptAnthropicCacheControl_StripsAnthropicOnlyMessageFields(t *testing.T) {
+	req := &core.ChatRequest{Messages: []core.Message{
+		{Role: "assistant", Content: "x", ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+			core.ThinkingBlocksField: json.RawMessage(`[{"type":"thinking","thinking":"t","signature":"s"}]`),
+			"x_keep":                 json.RawMessage("true"),
+		})},
+		{Role: "tool", ToolCallID: "c1", Content: "boom", ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+			core.ToolResultIsErrorField: json.RawMessage("true"),
+		})},
+	}}
+	if got := adaptAnthropicCacheControl(req, "anthropic"); got != req {
+		t.Fatal("anthropic must receive thinking_blocks and is_error untouched")
+	}
+	for _, providerType := range []string{"openai", "openrouter", "gemini"} {
+		got := adaptAnthropicCacheControl(req, providerType)
+		if got == req {
+			t.Fatalf("provider %q did not adapt the request", providerType)
+		}
+		if raw := got.Messages[0].ExtraFields.Lookup(core.ThinkingBlocksField); len(raw) != 0 {
+			t.Errorf("provider %q kept thinking_blocks: %s", providerType, raw)
+		}
+		if raw := got.Messages[1].ExtraFields.Lookup(core.ToolResultIsErrorField); len(raw) != 0 {
+			t.Errorf("provider %q kept is_error: %s", providerType, raw)
+		}
+		if raw := got.Messages[0].ExtraFields.Lookup("x_keep"); string(raw) != "true" {
+			t.Errorf("provider %q dropped unrelated extra: %s", providerType, raw)
+		}
+	}
+	if raw := req.Messages[0].ExtraFields.Lookup(core.ThinkingBlocksField); len(raw) == 0 {
+		t.Error("adaptation mutated the caller's request")
+	}
+}
+
 func TestRouterChatCompletion_PrefixedModelSelector(t *testing.T) {
 	westResp := &core.ChatResponse{ID: "west", Model: "gpt-4o"}
 	west := &mockProvider{name: "openai-west", chatResponse: westResp}

--- a/internal/providers/router_test.go
+++ b/internal/providers/router_test.go
@@ -1970,3 +1970,43 @@ func TestRouterListModelsUnqualifiedIDs(t *testing.T) {
 		t.Errorf("expected gpt-5 owned by routing winner %q, got %+v", want, resp.Data[1])
 	}
 }
+
+func TestAdaptAnthropicBatchCacheControl_StripsAnthropicOnlyMessageFieldsForOpenRouter(t *testing.T) {
+	body := `{"model":"claude-sonnet-4-5","messages":[
+		{"role":"assistant","content":"x","thinking_blocks":[{"type":"thinking","thinking":"t","signature":"s"}],"cache_control":{"type":"ephemeral"}},
+		{"role":"tool","tool_call_id":"c1","content":"boom","is_error":true}
+	]}`
+	request := &core.BatchRequest{
+		Endpoint: "/v1/chat/completions",
+		Requests: []core.BatchRequestItem{{
+			CustomID: "item-1",
+			Method:   http.MethodPost,
+			URL:      "/v1/chat/completions",
+			Body:     json.RawMessage(body),
+		}},
+	}
+	ctx := core.WithRequestDialect(context.Background(), core.RequestDialectAnthropicMessages)
+
+	if got, err := adaptAnthropicBatchCacheControl(ctx, request, "anthropic"); err != nil || got != request {
+		t.Fatalf("anthropic batch = %#v, %v; want the request untouched", got, err)
+	}
+
+	adapted, err := adaptAnthropicBatchCacheControl(ctx, request, "openrouter")
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := core.DecodeKnownBatchItemRequest(adapted.Endpoint, adapted.Requests[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	chat := decoded.Request.(*core.ChatRequest)
+	if raw := chat.Messages[0].ExtraFields.Lookup(core.ThinkingBlocksField); len(raw) != 0 {
+		t.Errorf("openrouter batch kept thinking_blocks: %s", raw)
+	}
+	if raw := chat.Messages[1].ExtraFields.Lookup(core.ToolResultIsErrorField); len(raw) != 0 {
+		t.Errorf("openrouter batch kept is_error: %s", raw)
+	}
+	if got := string(chat.Messages[0].ExtraFields.Lookup("cache_control")); got != `{"type":"ephemeral"}` {
+		t.Errorf("openrouter batch lost cache_control: %s", got)
+	}
+}

--- a/internal/server/messages_handler.go
+++ b/internal/server/messages_handler.go
@@ -151,9 +151,21 @@ func (h *Handler) MessagesBatchResults(c *echo.Context) error {
 // Messages translates an Anthropic Messages request and dispatches it through
 // the shared chat-completions pipeline (workflow resolution, response cache).
 func (s *translatedInferenceService) Messages(c *echo.Context) error {
-	req, err := decodeMessagesChatRequest(c)
+	decoded, err := decodeMessagesRequest(c)
 	if err != nil {
 		return handleError(c, err)
+	}
+	req, translateErr := anthropicapi.ToChatRequest(decoded)
+	if translateErr != nil {
+		// Content the canonical translation cannot represent (server-tool
+		// history, container uploads, …) is still fine to forward natively:
+		// the original body reaches Anthropic byte-for-byte. Resolve the
+		// route from a lenient translation and report the strict error only
+		// when the request has to go through the translated pipeline.
+		req, err = anthropicapi.ToChatRequestLenient(decoded)
+		if err != nil {
+			return handleError(c, translateErr)
+		}
 	}
 
 	ctx := core.WithRequestDialect(c.Request().Context(), core.RequestDialectAnthropicMessages)
@@ -165,6 +177,9 @@ func (s *translatedInferenceService) Messages(c *echo.Context) error {
 
 	if s.canForwardMessagesNatively(workflow) {
 		return s.dispatchMessagesNative(c, prepared, workflow)
+	}
+	if translateErr != nil {
+		return handleError(c, translateErr)
 	}
 	return handleWithCache(s, c, prepared, workflow, s.dispatchMessages)
 }
@@ -234,9 +249,9 @@ func (s *translatedInferenceService) dispatchMessages(c *echo.Context, req *core
 	return c.JSON(http.StatusOK, anthropicapi.FromChatResponse(result.Response))
 }
 
-// decodeMessagesChatRequest reads the request body, decodes the Anthropic
-// Messages request, and translates it to the canonical chat request.
-func decodeMessagesChatRequest(c *echo.Context) (*core.ChatRequest, error) {
+// decodeMessagesRequest reads and decodes the Anthropic Messages request body
+// without translating it.
+func decodeMessagesRequest(c *echo.Context) (*anthropicapi.MessagesRequest, error) {
 	body, err := requestBodyBytes(c)
 	if err != nil {
 		return nil, core.NewInvalidRequestError("invalid request body: "+err.Error(), err)
@@ -245,5 +260,5 @@ func decodeMessagesChatRequest(c *echo.Context) (*core.ChatRequest, error) {
 	if err != nil {
 		return nil, core.NewInvalidRequestError("invalid request body: "+err.Error(), err)
 	}
-	return anthropicapi.ToChatRequest(req)
+	return req, nil
 }

--- a/internal/server/messages_handler_test.go
+++ b/internal/server/messages_handler_test.go
@@ -179,6 +179,73 @@ func TestMessages_NativeAnthropicForwarding(t *testing.T) {
 	}
 }
 
+func TestMessages_NativeForwardingSurvivesUntranslatableContent(t *testing.T) {
+	// Server-tool history (Claude Code's WebSearch) has no canonical
+	// equivalent. On an Anthropic route the body is forwarded verbatim, so
+	// the translation gap must not fail the request.
+	nativeResponse := `{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"text","text":"native"}],"model":"claude-test","stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`
+	provider := &mockProvider{
+		supportedModels: []string{"claude-test"},
+		providerTypes:   map[string]string{"claude-test": "anthropic"},
+		passthroughResponse: &core.PassthroughResponse{
+			StatusCode: http.StatusOK,
+			Headers:    map[string][]string{"Content-Type": {"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(nativeResponse)),
+		},
+	}
+	e := echo.New()
+	handler := NewHandler(provider, nil, nil, nil)
+
+	reqBody := `{"model":"claude-test","max_tokens":64,"tools":[{"type":"web_search_20250305","name":"web_search"}],"messages":[{"role":"user","content":"search"},{"role":"assistant","content":[{"type":"server_tool_use","id":"srv_1","name":"web_search","input":{"query":"q"}},{"type":"web_search_tool_result","tool_use_id":"srv_1","content":[]}]},{"role":"user","content":"and?"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	if err := handler.Messages(e.NewContext(req, rec)); err != nil {
+		t.Fatalf("Messages: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if provider.lastPassthroughReq == nil {
+		t.Fatal("provider did not receive a passthrough request")
+	}
+	forwardedBody, err := io.ReadAll(provider.lastPassthroughReq.Body)
+	if err != nil {
+		t.Fatalf("read forwarded body: %v", err)
+	}
+	if string(forwardedBody) != reqBody {
+		t.Errorf("forwarded body = %s, want original request verbatim", forwardedBody)
+	}
+}
+
+func TestMessages_TranslatedPipelineStillRejectsUntranslatableContent(t *testing.T) {
+	provider := &mockProvider{
+		supportedModels: []string{"gpt-test"},
+		providerTypes:   map[string]string{"gpt-test": "openai"},
+	}
+	e := echo.New()
+	handler := NewHandler(provider, nil, nil, nil)
+
+	reqBody := `{"model":"gpt-test","max_tokens":64,"messages":[{"role":"user","content":[{"type":"container_upload","file_id":"file_1"}]}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	if err := handler.Messages(e.NewContext(req, rec)); err != nil {
+		t.Fatalf("Messages: %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "container_upload") {
+		t.Errorf("body = %s, want the strict translation error", rec.Body.String())
+	}
+	if provider.lastPassthroughReq != nil {
+		t.Error("request must not be forwarded natively to a non-Anthropic provider")
+	}
+}
+
 func TestRewriteMessagesModel(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## Summary

Follow-up to #878. Claude Code hits several more `/v1/messages` translation gaps; this closes them and fixes the ordering problem that made every gap fail even on a plain Anthropic route.

## Changes

- **Native forwarding is decided before translation errors surface.** The handler resolves the route from a lenient translation and reports the strict 400 only when the request must go through the translated pipeline. On an Anthropic route the original body is forwarded verbatim, so server-tool history (Claude Code's WebSearch), container uploads, and anything else the canonical request cannot represent no longer fail.
- **`document` blocks translate** to a new canonical `file` content part (`{"type":"file","file":{"file_data"|"file_id","filename"}}`, mirroring OpenAI's Chat Completions file input). PDF and plain-text sources become data URLs, URL and `file_id` sources are carried as-is, the custom-content variant degrades to text. Anthropic gets a native `document` block with its `title`; Gemini receives inline data; OpenAI-compatible providers receive the `file` part unchanged. Responses API `input_file` maps to the same part.
- **`search_result` blocks** degrade to text (title, source, content).
- **`tool_result.is_error`** is preserved and restored on the Anthropic egress.
- **`thinking` / `redacted_thinking` blocks** on assistant turns are replayed verbatim (signatures included) to Anthropic. Without them, thinking-enabled tool-use turns fail on the translated path.
- `is_error` and thinking blocks ride on message extras and are stripped before any non-Anthropic provider sees the request, alongside the existing `cache_control` stripping.
- Docs updated; swagger regenerated (the regen also picked up the `/admin/access` endpoint from #868, which had not been regenerated).

## Provider behavior

Anthropic receives everything natively. Other providers keep their existing tool-message handling and see only the text portion of an image- or document-bearing tool result. Audio is not in scope: the Anthropic Messages API has no audio block type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NXZqcwjkYNEKBUNXizeuC5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added file content support for chat and responses APIs, including file IDs, URLs, base64 data, and filenames.
  * Added Anthropic document and search-result content handling.
  * Preserved and replayed Anthropic thinking and redacted-thinking blocks.
  * Retained tool-result error status for Anthropic requests.
  * Enabled verbatim forwarding of native Anthropic requests with provider-specific content.

* **Documentation**
  * Updated API specifications and guidance for file content and Anthropic content behavior.
  * Added admin access reporting, audit filtering, and permission-related responses to the API documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->