### PR TITLE
fix(server): log unhandled errors and panics and answer in the gateway envelope

### DIFF
--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -145,6 +145,10 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 		JSONSerializer: goJSONSerializer{},
 	})
 	e.Logger = slog.Default()
+	// Errors that escape the handler chain (recovered panics, response
+	// serialization failures) are logged and rendered in the gateway envelope
+	// instead of echo's silent {"message": "Internal Server Error"}.
+	e.HTTPErrorHandler = unhandledErrorHandler(e.HTTPErrorHandler)
 	basePath := configuredBasePath(cfg)
 	if basePath != "/" {
 		e.Pre(stripBasePathMiddleware(basePath))

--- a/internal/server/unhandled_error.go
+++ b/internal/server/unhandled_error.go
@@ -1,0 +1,90 @@
+package server
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/labstack/echo/v5"
+	"github.com/labstack/echo/v5/middleware"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+// unhandledErrorHandler is the echo HTTPErrorHandler: it receives every error
+// that escapes the handler chain without being rendered — a panic recovered by
+// middleware.Recover, a response serialization failure, or an echo status
+// error raised by a built-in middleware (body limit, method not allowed).
+//
+// echo's default handler answers with a bare {"message": "Internal Server
+// Error"} body and logs nothing, so a panicking admin handler left operators
+// with a 500 and no trace of the cause. Unexpected errors are logged with the
+// request path and, for panics, the stack, and rendered in the gateway error
+// envelope. echo's own HTTPErrors keep their status and body through fallback.
+func unhandledErrorHandler(fallback echo.HTTPErrorHandler) echo.HTTPErrorHandler {
+	return func(c *echo.Context, err error) {
+		if err == nil {
+			return
+		}
+		// echo's own errors (body limit, method not allowed, ...) already
+		// carry a status; leave their rendering to the default handler.
+		if _, ok := errors.AsType[statusCodedError](err); ok {
+			fallback(c, err)
+			return
+		}
+
+		gatewayErr, ok := errors.AsType[*core.GatewayError](err)
+		if !ok {
+			gatewayErr = &core.GatewayError{
+				Type:       "internal_error",
+				Message:    "an unexpected error occurred",
+				StatusCode: http.StatusInternalServerError,
+				Err:        err,
+			}
+		}
+		logUnhandledError(c, gatewayErr)
+
+		if r, _ := echo.UnwrapResponse(c.Response()); r != nil && r.Committed {
+			return
+		}
+		if writeErr := writeGatewayError(c, gatewayErr); writeErr != nil {
+			slog.Error("failed to write error response", "error", writeErr, "path", c.Request().URL.Path)
+		}
+	}
+}
+
+// statusCodedError is an error that already names its HTTP status, as echo's
+// built-in errors do (echo.HTTPStatusCoder plus error).
+type statusCodedError interface {
+	error
+	StatusCode() int
+}
+
+// logUnhandledError records an error that reached the centralized handler. A
+// recovered panic is split into its value and stack so the message stays
+// readable and the stack lands in its own attribute.
+func logUnhandledError(c *echo.Context, gatewayErr *core.GatewayError) {
+	attrs := []any{
+		"type", gatewayErr.Type,
+		"status", gatewayErr.HTTPStatusCode(),
+		"message", gatewayErr.Message,
+	}
+	if panicErr, ok := errors.AsType[*middleware.PanicStackError](gatewayErr.Err); ok {
+		attrs = append(attrs, "panic", panicErr.Err, "stack", string(panicErr.Stack))
+	} else if gatewayErr.Err != nil {
+		attrs = append(attrs, "error", gatewayErr.Err)
+	}
+	if c != nil && c.Request() != nil {
+		req := c.Request()
+		attrs = append(attrs,
+			"method", req.Method,
+			"path", req.URL.Path,
+			"request_id", requestIDFromContextOrHeader(req),
+		)
+	}
+	if gatewayErr.HTTPStatusCode() >= http.StatusInternalServerError {
+		slog.Error("unhandled request error", attrs...)
+		return
+	}
+	slog.Warn("unhandled request error", attrs...)
+}

--- a/internal/server/unhandled_error_test.go
+++ b/internal/server/unhandled_error_test.go
@@ -1,0 +1,108 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v5"
+)
+
+// captureSlog routes the default logger into a buffer for the test's duration.
+func captureSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+	return &buf
+}
+
+func TestUnhandledErrorHandler(t *testing.T) {
+	type badTime struct {
+		At time.Time `json:"at"`
+	}
+	// A year beyond 9999 makes time.Time.MarshalJSON fail, which is how a
+	// stored row can turn a list endpoint into a 500 (#881).
+	unmarshalable := badTime{At: time.Unix(1<<40, 0).UTC()}
+
+	tests := []struct {
+		name         string
+		handler      echo.HandlerFunc
+		wantStatus   int
+		wantBody     string
+		wantLog      []string
+		wantEnvelope bool
+	}{
+		{
+			name:         "panic is logged with stack and rendered in the gateway envelope",
+			handler:      func(c *echo.Context) error { panic("boom") },
+			wantStatus:   http.StatusInternalServerError,
+			wantEnvelope: true,
+			wantLog:      []string{"unhandled request error", "panic=boom", "stack=", "path=/boom", "status=500"},
+		},
+		{
+			name: "serialization failure is logged and rendered in the gateway envelope",
+			handler: func(c *echo.Context) error {
+				return c.JSON(http.StatusOK, []badTime{unmarshalable})
+			},
+			wantStatus:   http.StatusInternalServerError,
+			wantEnvelope: true,
+			wantLog:      []string{"unhandled request error", "year outside of range", "path=/boom"},
+		},
+		{
+			name:       "echo HTTPError keeps its status and body",
+			handler:    func(c *echo.Context) error { return echo.NewHTTPError(http.StatusTeapot, "short and stout") },
+			wantStatus: http.StatusTeapot,
+			wantBody:   `{"message":"short and stout"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logs := captureSlog(t)
+			srv := New(&mockProvider{}, nil)
+			srv.echo.GET("/boom", tt.handler)
+
+			rec := httptest.NewRecorder()
+			srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/boom", nil))
+
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d (body %q)", rec.Code, tt.wantStatus, rec.Body.String())
+			}
+			if tt.wantBody != "" && strings.TrimSpace(rec.Body.String()) != tt.wantBody {
+				t.Fatalf("body = %q, want %q", rec.Body.String(), tt.wantBody)
+			}
+			if tt.wantEnvelope {
+				var body struct {
+					Error struct {
+						Type    string `json:"type"`
+						Message string `json:"message"`
+					} `json:"error"`
+				}
+				if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+					t.Fatalf("body %q is not a gateway error envelope: %v", rec.Body.String(), err)
+				}
+				if body.Error.Type != "internal_error" || body.Error.Message != "an unexpected error occurred" {
+					t.Fatalf("error = %+v", body.Error)
+				}
+				if strings.Contains(rec.Body.String(), "boom") || strings.Contains(rec.Body.String(), "year outside") {
+					t.Fatalf("internal error detail leaked into the response: %s", rec.Body.String())
+				}
+			}
+			for _, want := range tt.wantLog {
+				if !strings.Contains(logs.String(), want) {
+					t.Errorf("log output missing %q:\n%s", want, logs.String())
+				}
+			}
+			if len(tt.wantLog) == 0 && strings.Contains(logs.String(), "unhandled request error") {
+				t.Errorf("echo HTTPError should not be logged as unhandled:\n%s", logs.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #881 (diagnosability). Any error that escaped a handler — a recovered panic or a response serialization failure — was answered with echo's bare `{"message":"Internal Server Error"}` and logged nowhere: `middleware.Recover` in echo v5 only converts the panic into an error, and the default `HTTPErrorHandler` writes the body without logging. That is what the reporter hit on `GET /admin/virtual-models` and `GET /admin/provider-credentials`: a 500 with no gateway error body and no trace of the cause, even with logs captured.

This installs a centralized `HTTPErrorHandler` that:

- logs `unhandled request error` at ERROR level with method, path, request id, and, for panics, the panic value and stack (`stack` attribute);
- renders the response in the gateway error envelope (`{"error":{"type":"internal_error","message":"an unexpected error occurred",...}}`), without leaking the internal error text;
- leaves echo's own status errors (body limit 413, method not allowed 405, ...) to the default handler so their status and body are unchanged.

I could not reproduce the underlying failure of the two admin endpoints on macOS against a real SQLite database, and neither handler changed between 0.1.83 and 0.1.86. With this change the reporter's log will show the actual panic or serialization error (for example a stored timestamp outside the JSON-encodable year range), so the root cause can be fixed in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEgRAh914CS85pUNh92RBh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of unexpected server errors, including panics and response failures.
  - Errors now return a consistent gateway error response instead of a generic error message.
  - Added safeguards to avoid overwriting responses that have already been sent.
  - Preserved existing HTTP error statuses and response bodies for recognized client errors.

- **Monitoring**
  - Unexpected errors are now logged with request details and diagnostic information, including stack traces for recovered panics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->