### PR TITLE
fix(dashboard): stop audit session list and interactions drawer from jumping during live streams

### DIFF
--- a/web/dashboard/src/pages/audit-logs/AuditEntryRow.svelte
+++ b/web/dashboard/src/pages/audit-logs/AuditEntryRow.svelte
@@ -98,13 +98,17 @@
       border-color 0.12s ease-out;
   }
 
+  /* A ring rather than a thicker border: a border-width change shifts every
+     row below by a pixel each time the Interactions drawer moves to another
+     entry. */
   .audit-entry-interactions-open {
-    border-width: 2px;
     border-color: color-mix(
       in srgb,
       var(--prompt-cache-color) 38%,
       var(--border)
     );
+    box-shadow: 0 0 0 1px
+      color-mix(in srgb, var(--prompt-cache-color) 38%, var(--border));
   }
 
   .audit-entry-details {

--- a/web/dashboard/src/pages/audit-logs/ConversationDrawer.svelte
+++ b/web/dashboard/src/pages/audit-logs/ConversationDrawer.svelte
@@ -131,7 +131,7 @@
   }
 
   function scrollToConversationMessage(direction) {
-    const content = document.getElementById("interactions-drawer-content");
+    const content = drawer.conversationContentEl;
     const thread = drawer.conversationThreadEl;
     if (!content || !thread) return;
     const messages = [...thread.querySelectorAll('[data-conversation-message="true"]')];
@@ -377,7 +377,11 @@
     {/if}
   </div>
 
-  <div id="interactions-drawer-content">
+  <div
+    id="interactions-drawer-content"
+    bind:this={drawer.conversationContentEl}
+    onscroll={() => drawer.noteConversationScroll()}
+  >
     {#if drawer.conversationMessages.length > 1}
       <div
         class="conversation-message-navigation"

--- a/web/dashboard/src/pages/audit-logs/conversation-panel.js
+++ b/web/dashboard/src/pages/audit-logs/conversation-panel.js
@@ -59,6 +59,31 @@ export function conversationMessageNavigationTarget(
   };
 }
 
+// conversationPinnedToBottom reports whether a scroll container sits close
+// enough to its bottom edge that a live transcript should keep following new
+// content. Once the operator scrolls up to read history, appends must not
+// yank the view back down.
+export const CONVERSATION_FOLLOW_THRESHOLD_PX = 48;
+
+export function conversationPinnedToBottom(scrollTop, scrollHeight, clientHeight) {
+  const remaining = finite(scrollHeight) - finite(scrollTop) - finite(clientHeight);
+  return remaining <= CONVERSATION_FOLLOW_THRESHOLD_PX;
+}
+
+// conversationAnchorScrollTop returns the scrollTop that centers a message
+// inside its scroll container. Scrolling the container directly — instead of
+// scrollIntoView — leaves the page behind the drawer where it was.
+export function conversationAnchorScrollTop(
+  scrollTop,
+  clientHeight,
+  containerTop,
+  targetTop,
+  targetHeight,
+) {
+  const offset = finite(targetTop) - finite(containerTop) + finite(scrollTop);
+  return Math.max(0, offset - (finite(clientHeight) - finite(targetHeight)) / 2);
+}
+
 function finite(value) {
   const number = Number(value);
   return Number.isFinite(number) ? number : 0;

--- a/web/dashboard/src/pages/audit-logs/conversationDrawer.svelte.js
+++ b/web/dashboard/src/pages/audit-logs/conversationDrawer.svelte.js
@@ -13,6 +13,10 @@ import {
   isLiveAuditRecordChange,
 } from "./audit-records.js";
 import {
+  conversationAnchorScrollTop,
+  conversationPinnedToBottom,
+} from "./conversation-panel.js";
+import {
   REQUEST_STEP_FINAL,
   buildConversationView,
   buildFollowUpHeaders,
@@ -63,7 +67,13 @@ class ConversationDrawerStore {
 
   conversationDialogEl = $state(null);
   conversationCloseBtnEl = $state(null);
+  conversationContentEl = $state(null);
   conversationThreadEl = $state(null);
+  // Whether the transcript view sits at its bottom edge. Tracked from the
+  // content's scroll events (user or programmatic) rather than measured on
+  // demand: by the time a record change reaches the drawer, Svelte has
+  // already grown the DOM, so a fresh measurement always reads "scrolled up".
+  conversationPinned = true;
 
   get conversationEntries() {
     return (this.conversationEntryIDs || [])
@@ -178,6 +188,7 @@ class ConversationDrawerStore {
     this.followUpText = "";
     this.followUpError = "";
     this.followUpRequestID = "";
+    this.conversationPinned = true;
     requestAnimationFrame(() => this._focusConversationDrawer());
 
     // A live entry has no persisted row to fetch yet — render it from the
@@ -288,7 +299,9 @@ class ConversationDrawerStore {
       this.conversationFollowLatest = true;
     }
 
-    this._addConversationRecord(entry);
+    // The operator's own follow-up always comes into view; every other live
+    // update only keeps following while the view is already at the bottom.
+    this._addConversationRecord(entry, !!match.submittedChild);
     const state = String(eventType || entry._live_state || "").trim();
     // A sibling flush says nothing about whether the mutable selected anchor
     // is queryable. Hydrate only when that anchor itself is persisted.
@@ -299,7 +312,7 @@ class ConversationDrawerStore {
     }
   }
 
-  _addConversationRecord(entry) {
+  _addConversationRecord(entry, forceScroll = false) {
     const id = auditRecordKey(entry);
     if (id && !this.conversationEntryIDs.includes(id)) {
       this._setConversationEntryIDs([...this.conversationEntryIDs, id]);
@@ -308,7 +321,7 @@ class ConversationDrawerStore {
       this.conversationSessionID = String(entry.session_id).trim();
     }
     this._applyConversationView();
-    if (this.conversationFollowLatest) this._scheduleLatestScroll();
+    if (this.conversationFollowLatest) this._scheduleLatestScroll(forceScroll);
   }
 
   // conversationLiveWaiting reports whether the open live conversation is
@@ -388,7 +401,11 @@ class ConversationDrawerStore {
       if (anchor && anchor.session_id) this.conversationSessionID = String(anchor.session_id).trim();
       this.conversationTruncated = !!payload.truncated;
       this._applyConversationView();
-      if (this.conversationFollowLatest) this._scheduleLatestScroll();
+      // Opening the drawer (scrollToAnchor) positions the view on the latest
+      // turn or the anchor. The re-hydration after a live flush redraws the
+      // same transcript from storage and must not move a reader who has
+      // scrolled up, so it only keeps an existing pin.
+      if (this.conversationFollowLatest) this._scheduleLatestScroll(scrollToAnchor);
       else if (scrollToAnchor) this._scheduleAnchorScroll();
     } catch (e) {
       if (requestToken !== this.conversationRequestToken) return;
@@ -511,7 +528,7 @@ class ConversationDrawerStore {
           if (child.session_id) this.conversationSessionID = String(child.session_id).trim();
           this._applyConversationView();
           this.conversationFollowLatest = true;
-          this._scheduleLatestScroll();
+          this._scheduleLatestScroll(true);
           return;
         }
       }
@@ -522,26 +539,53 @@ class ConversationDrawerStore {
     }
   }
 
+  // Both scroll helpers move the drawer's own scroll container instead of
+  // calling scrollIntoView: scrollIntoView also scrolls every scrollable
+  // ancestor, so each streamed chunk used to drag the audit list behind the
+  // drawer along with it.
   _scheduleAnchorScroll() {
     requestAnimationFrame(() => {
+      const content = this.conversationContentEl;
       const thread = this.conversationThreadEl;
-      if (!thread) return;
+      if (!content || !thread) return;
       const anchors = thread.querySelectorAll('[data-conversation-anchor="true"]');
       const target = anchors[anchors.length - 1];
-      if (target && typeof target.scrollIntoView === "function") {
-        target.scrollIntoView({ block: "center" });
-      }
+      if (!target) return;
+      const contentRect = content.getBoundingClientRect();
+      const targetRect = target.getBoundingClientRect();
+      content.scrollTop = conversationAnchorScrollTop(
+        content.scrollTop,
+        content.clientHeight,
+        contentRect.top,
+        targetRect.top,
+        targetRect.height,
+      );
     });
   }
 
-  _scheduleLatestScroll() {
+  // noteConversationScroll records whether the view is at the bottom after
+  // every scroll of the drawer content — the operator reading history
+  // unpins it, scrolling back down (or our own follow scroll) re-pins it.
+  noteConversationScroll() {
+    const content = this.conversationContentEl;
+    if (!content) return;
+    this.conversationPinned = conversationPinnedToBottom(
+      content.scrollTop,
+      content.scrollHeight,
+      content.clientHeight,
+    );
+  }
+
+  // _scheduleLatestScroll keeps a followed transcript pinned to its newest
+  // content. Once the operator has scrolled up to read, a streamed chunk
+  // must not pull the view back down. `force` (a fresh hydration, the
+  // operator's own follow-up) re-pins unconditionally.
+  _scheduleLatestScroll(force = false) {
+    if (!force && !this.conversationPinned) return;
+    this.conversationPinned = true;
     requestAnimationFrame(() => {
-      const thread = this.conversationThreadEl;
-      if (!thread) return;
-      const target = thread.lastElementChild;
-      if (target && typeof target.scrollIntoView === "function") {
-        target.scrollIntoView({ block: "end" });
-      }
+      const el = this.conversationContentEl;
+      if (el) el.scrollTop = el.scrollHeight;
     });
   }
 }

--- a/web/dashboard/src/pages/audit-logs/live-logs-logic.js
+++ b/web/dashboard/src/pages/audit-logs/live-logs-logic.js
@@ -5,7 +5,8 @@
 // implementation. The host (`this`) must provide:
 //   - state: auditLog {entries,total,limit,offset}, usageLog {…},
 //     skippedLiveUsageByRequestId, liveLogsLastSeq, auditGroupSessions,
-//     auditThreadChildren ({ [session_id]: {loading, entries, total} })
+//     auditThreadChildren ({ [session_id]: {loading, entries, total} }),
+//     auditLiveHeld (sessionless live rows waiting for placement)
 //   - insert-gate fields: auditSearch, auditMethod, auditStatusCode,
 //     auditStream, customStartDate, customEndDate, usageLogSearch,
 //     usageFilterModel, usageFilterProvider, usageFilterLabel,
@@ -21,6 +22,12 @@ import { consumeEventStream } from "../../lib/api/eventStream.js";
 import * as m from "../../lib/paraglide/messages.js";
 
 const LIVE_LOGS_STREAM_PATH = "/admin/live/logs?types=audit,usage";
+
+// How long a sessionless live row waits off-screen in grouped mode for the
+// session id that SessionCapture publishes right after authentication. Long
+// enough to cover the gateway's own middleware chain plus stream delivery,
+// short enough that a request with no session at all still appears promptly.
+export const LIVE_AUDIT_SESSION_GRACE_MS = 300;
 
 function matchesLiveAuditKey(entry, id, requestID) {
     return (!!id && String(entry && entry.id || '').trim() === id) ||
@@ -131,7 +138,10 @@ export function liveLogsMethods() {
             const requestID = String(incoming.request_id || '').trim();
             const currentEntries = (this.auditLog && Array.isArray(this.auditLog.entries)) ? this.auditLog.entries : [];
             const index = currentEntries.findIndex((entry) => matchesLiveAuditKey(entry, key, requestID));
-            const previous = index >= 0 ? currentEntries[index] || {} : {};
+            const heldIndex = this.heldLiveAuditIndex(key, requestID);
+            const previous = index >= 0
+                ? currentEntries[index] || {}
+                : heldIndex >= 0 ? this.auditLiveHeld[heldIndex] : {};
             // A detail event IS the fetched detail: re-triggering the detail
             // fetch for it would loop.
             const isDetail = eventType === 'audit.detail';
@@ -141,6 +151,9 @@ export function liveLogsMethods() {
                 ? { ...incoming, _detail_loaded: true, _response_partial: false, bodies_omitted: false }
                 : this.liveAuditPatch(previous, incoming, eventType);
             if (index >= 0) {
+                // A page refetch can land the persisted row while its live
+                // copy is still held; the on-screen row wins.
+                if (heldIndex >= 0) this.releaseHeldLiveAudit(heldIndex);
                 const merged = this.mergeLiveAuditPatch(previous, patch);
                 currentEntries.splice(index, 1, merged);
                 this.auditLog.entries = [...currentEntries];
@@ -151,12 +164,28 @@ export function liveLogsMethods() {
                 this.cacheMergedAuditRecord(merged, eventType);
                 return merged;
             }
+            if (heldIndex >= 0) {
+                // The row is waiting for its session: fold the event in and
+                // re-evaluate placement (the session id may just have landed).
+                const merged = this.mergeLiveAuditPatch(previous, patch);
+                this.releaseHeldLiveAudit(heldIndex);
+                return this.placeLiveAuditEntry(merged, eventType, true);
+            }
             const child = this.mergeLiveAuditChild(incoming, patch);
             if (child) {
                 if (!isDetail) this.fetchExpandedAuditDetailIfReady(child);
                 this.cacheMergedAuditRecord(child, eventType);
                 return child;
             }
+            return this.placeLiveAuditEntry(patch, eventType, true);
+        },
+
+        // placeLiveAuditEntry inserts a live row the list does not hold yet:
+        // folded into its on-screen thread, prepended as a new head, or (in
+        // grouped mode, while still sessionless) held back for a moment.
+        placeLiveAuditEntry(patch, eventType, allowHold) {
+            const isDetail = eventType === 'audit.detail';
+            const currentEntries = (this.auditLog && Array.isArray(this.auditLog.entries)) ? this.auditLog.entries : [];
             // List filters and pagination gate visual insertion only. The
             // normalized cache still receives every event so an already-open
             // Interactions drawer cannot lose its live continuation.
@@ -165,6 +194,11 @@ export function liveLogsMethods() {
                 return;
             }
             if (!isDetail && this.auditGroupSessions) {
+                if (allowHold && this.shouldHoldLiveAudit(patch)) {
+                    this.holdLiveAudit(patch);
+                    this.cacheMergedAuditRecord(patch, eventType);
+                    return patch;
+                }
                 const folded = this.foldLiveAuditIntoThread(patch);
                 if (folded) {
                     this.fetchExpandedAuditDetailIfReady(folded);
@@ -178,6 +212,74 @@ export function liveLogsMethods() {
             if (!isDetail) this.fetchExpandedAuditDetailIfReady(inserted);
             this.cacheMergedAuditRecord(inserted, eventType);
             return inserted;
+        },
+
+        // --- Sessionless hold ----------------------------------------------
+        // audit.started fires before session detection, so in grouped mode a
+        // brand-new live row cannot know its thread yet. Inserting it as a
+        // singleton head and re-folding it milliseconds later on the session
+        // update shifts the whole list twice per request. Such rows wait
+        // off-screen until a session id arrives, the request settles, or the
+        // grace period elapses — whichever comes first.
+
+        shouldHoldLiveAudit(entry) {
+            if (!entry || String(entry.session_id || '').trim()) return false;
+            if (this.liveAuditStateSettled(entry._live_state)) return false;
+            // Model/workflow resolution runs after session detection in the
+            // gateway's middleware chain, so once either is stamped a still
+            // missing session id means the request simply has none.
+            return !(entry.requested_model || entry.resolved_model || entry.workflow_version_id);
+        },
+
+        heldLiveAuditIndex(id, requestID) {
+            const held = Array.isArray(this.auditLiveHeld) ? this.auditLiveHeld : [];
+            return held.findIndex((entry) => matchesLiveAuditKey(entry, id, requestID));
+        },
+
+        holdLiveAudit(entry) {
+            const held = Array.isArray(this.auditLiveHeld) ? this.auditLiveHeld : [];
+            this.auditLiveHeld = [...held, entry];
+            if (typeof setTimeout !== 'function') return;
+            const key = String(entry.id || entry.request_id || '').trim();
+            if (!this.auditLiveHoldTimers) this.auditLiveHoldTimers = new Map();
+            if (this.auditLiveHoldTimers.has(key)) return;
+            const timer = setTimeout(() => {
+                this.auditLiveHoldTimers.delete(key);
+                this.expireHeldLiveAudit(key);
+            }, LIVE_AUDIT_SESSION_GRACE_MS);
+            // Under node --test a pending timer must not keep the runner alive.
+            if (timer && typeof timer.unref === 'function') timer.unref();
+            this.auditLiveHoldTimers.set(key, timer);
+        },
+
+        // releaseHeldLiveAudit takes a row out of the hold (its caller decides
+        // where it goes) and cancels its grace timer.
+        releaseHeldLiveAudit(index) {
+            const held = Array.isArray(this.auditLiveHeld) ? this.auditLiveHeld : [];
+            const entry = held[index];
+            if (!entry) return null;
+            this.auditLiveHeld = held.filter((_, i) => i !== index);
+            const key = String(entry.id || entry.request_id || '').trim();
+            const timer = this.auditLiveHoldTimers && this.auditLiveHoldTimers.get(key);
+            if (timer) {
+                clearTimeout(timer);
+                this.auditLiveHoldTimers.delete(key);
+            }
+            return entry;
+        },
+
+        // expireHeldLiveAudit places a row whose grace period ran out without
+        // a session id: it shows as its own thread, and regroupLiveAuditHead
+        // still folds it should the session arrive later.
+        expireHeldLiveAudit(key) {
+            const index = this.heldLiveAuditIndex(key, key);
+            if (index < 0) return null;
+            const entry = this.releaseHeldLiveAudit(index);
+            const id = String(entry.id || '').trim();
+            const requestID = String(entry.request_id || '').trim();
+            const entries = (this.auditLog && Array.isArray(this.auditLog.entries)) ? this.auditLog.entries : [];
+            if (entries.some((row) => matchesLiveAuditKey(row, id, requestID))) return null;
+            return this.placeLiveAuditEntry(entry, entry._live_state, false);
         },
 
         // liveAuditPatch stamps the live lifecycle state onto an incoming
@@ -234,9 +336,9 @@ export function liveLogsMethods() {
 
         // regroupLiveAuditHead folds a list row into another on-screen head of
         // the same session after an in-place merge. This is how a live row
-        // inserted sessionless (audit.started fires before session detection
-        // stamps the context) joins its thread once a later event delivers the
-        // session id: the NEWEST of the two rows becomes the thread head — the
+        // that was placed sessionless (its hold expired before session
+        // detection stamped the context) joins its thread once a later event
+        // delivers the session id: the NEWEST of the two rows becomes the thread head — the
         // event that happens to complete last is not necessarily the newest
         // request — the other is retained in the thread's children slot, and
         // the two rows collapse into one thread (total shrinks by one).
@@ -273,10 +375,13 @@ export function liveLogsMethods() {
             return merged;
         },
 
-        // foldLiveAuditIntoThread makes a fresh live request the new head of
-        // its on-screen thread: the old head moves into the loaded children
-        // list (or waits for the lazy fetch) and the thread bubbles to the
-        // top with its count bumped. Total is unchanged (same thread count).
+        // foldLiveAuditIntoThread joins a fresh live request to its on-screen
+        // thread. A newer request becomes the new head: the old head moves
+        // into the loaded children list (or waits for the lazy fetch) and the
+        // thread bubbles to the top with its count bumped. A request OLDER
+        // than the current head (its events arrived late) slips into the
+        // children instead, and the head stays where it is. Total is
+        // unchanged either way (same thread count).
         foldLiveAuditIntoThread(patch) {
             const sessionId = String((patch && patch.session_id) || '').trim();
             if (!sessionId) return null;
@@ -285,10 +390,18 @@ export function liveLogsMethods() {
             if (headIndex < 0) return null;
             const oldHead = entries[headIndex];
             const oldCount = Number(oldHead.session_count);
-            const newHead = this.mergeLiveAuditUsagePatch({
-                ...patch,
-                session_count: (Number.isFinite(oldCount) && oldCount > 0 ? oldCount : 1) + 1
-            });
+            const count = (Number.isFinite(oldCount) && oldCount > 0 ? oldCount : 1) + 1;
+            const headTime = Date.parse(oldHead && oldHead.timestamp);
+            const patchTime = Date.parse(patch && patch.timestamp);
+            if (Number.isFinite(headTime) && Number.isFinite(patchTime) && headTime > patchTime) {
+                const child = this.mergeLiveAuditUsagePatch({ ...patch });
+                const next = [...entries];
+                next.splice(headIndex, 1, { ...oldHead, session_count: count });
+                this.auditLog.entries = next;
+                this.prependLiveAuditThreadChild(sessionId, child);
+                return child;
+            }
+            const newHead = this.mergeLiveAuditUsagePatch({ ...patch, session_count: count });
             const next = [...entries];
             next.splice(headIndex, 1);
             next.unshift(newHead);
@@ -436,6 +549,8 @@ export function liveLogsMethods() {
             const id = String(incoming.id || '').trim();
             const requestID = String(incoming.request_id || '').trim();
             if (!id && !requestID) return;
+            const heldIndex = this.heldLiveAuditIndex(id, requestID);
+            if (heldIndex >= 0) this.releaseHeldLiveAudit(heldIndex);
             const current = this.auditLog.entries;
             const next = [];
             let removedCount = 0;

--- a/web/dashboard/src/pages/audit-logs/liveLogs.svelte.js
+++ b/web/dashboard/src/pages/audit-logs/liveLogs.svelte.js
@@ -66,6 +66,10 @@ class LiveLogsStore {
     readStored("gomodel_audit_group_sessions", "true") !== "false",
   );
   auditThreadChildren = $state({});
+  // Sessionless live rows held off-screen (grouped mode) until their session
+  // id arrives or the grace period elapses; see live-logs-logic.js.
+  auditLiveHeld = [];
+  auditLiveHoldTimers = null;
   usageLogSearch = $state("");
   usageFilterModel = $state("");
   usageFilterProvider = $state("");

--- a/web/dashboard/tests/conversation-panel.test.js
+++ b/web/dashboard/tests/conversation-panel.test.js
@@ -3,7 +3,9 @@ import assert from "node:assert/strict";
 
 import {
   clampConversationPanelWidth,
+  conversationAnchorScrollTop,
   conversationMessageNavigationTarget,
+  conversationPinnedToBottom,
   conversationOpensFullscreen,
   conversationPanelBounds,
   conversationPanelWidthFromPointer,
@@ -68,4 +70,22 @@ test("the drawer opens fullscreen only on phone-width viewports", () => {
   assert.equal(conversationOpensFullscreen(769), false);
   assert.equal(conversationOpensFullscreen(1440), false);
   assert.equal(conversationOpensFullscreen(undefined), true);
+});
+
+test("a followed transcript stays pinned only while the view sits near the bottom", () => {
+  // scrollHeight 1000, viewport 400: at the bottom (600) and just above it.
+  assert.equal(conversationPinnedToBottom(600, 1000, 400), true);
+  assert.equal(conversationPinnedToBottom(560, 1000, 400), true);
+  // Scrolled up to read history: appends must leave the view alone.
+  assert.equal(conversationPinnedToBottom(500, 1000, 400), false);
+  assert.equal(conversationPinnedToBottom(0, 1000, 400), false);
+  // Content shorter than the viewport is always pinned.
+  assert.equal(conversationPinnedToBottom(0, 300, 400), true);
+});
+
+test("anchor scrolling centers the message inside the drawer's own container", () => {
+  // Container at y=100 scrolled to 200; target at y=700, 100px tall, viewport 400.
+  assert.equal(conversationAnchorScrollTop(200, 400, 100, 700, 100), 650);
+  // Never above the top.
+  assert.equal(conversationAnchorScrollTop(0, 400, 100, 120, 40), 0);
 });

--- a/web/dashboard/tests/live-logs.test.js
+++ b/web/dashboard/tests/live-logs.test.js
@@ -33,6 +33,7 @@ function createLiveLogsApp(overrides = {}) {
     usageLogHideCached: false,
     auditGroupSessions: false,
     auditThreadChildren: {},
+    auditLiveHeld: [],
     auditRecords: {},
     auditRecordChanges: [],
     customStartDate: null,
@@ -922,10 +923,11 @@ test("parent headers do not assign sessions before the server resolves them", ()
     data: { request_headers: { "X-GoModel-Interaction-Parent": "head-a" } },
   }, "audit.started");
 
-  assert.equal(app.auditLog.entries.length, 2);
-  assert.equal(app.auditLog.entries[0].id, "live-3");
-  assert.equal(app.auditLog.entries[0].session_id, undefined);
-  assert.equal(app.auditLog.entries[1].id, "head-a");
+  // Sessionless in grouped mode: the row waits off-screen for the server's
+  // session update instead of guessing from the parent header.
+  assert.deepEqual(app.auditLog.entries.map((entry) => entry.id), ["head-a"]);
+  assert.deepEqual(app.auditLiveHeld.map((entry) => entry.id), ["live-3"]);
+  assert.equal(app.auditLiveHeld[0].session_id, undefined);
 });
 
 test("grouped fold retains the displaced head of an unexpanded thread", () => {
@@ -1125,10 +1127,13 @@ test("a sessionless live row re-folds on the pre-response session update", () =>
   };
 
   // audit.started fires before session detection: the row arrives sessionless
-  // and prepends as its own singleton thread.
+  // and is held off-screen so the list does not shift twice.
   app.mergeLiveAuditEntry({ id: "live-1", request_id: "req-1" }, "audit.started");
-  assert.equal(app.auditLog.entries.length, 2);
-  assert.equal(app.auditLog.total, 2);
+  assert.deepEqual(app.auditLog.entries.map((entry) => entry.id), ["head-a"]);
+  assert.equal(app.auditLog.total, 1);
+  assert.deepEqual(app.auditLiveHeld.map((entry) => entry.id), ["live-1"]);
+  // The cache still received the held row (an open drawer keeps following).
+  assert.equal(app.auditRecords["live-1"]._live_state, "audit.started");
 
   // SessionCapture delivers audit.updated before the provider handler runs:
   // the row folds without waiting for a response or terminal event.
@@ -1139,11 +1144,125 @@ test("a sessionless live row re-folds on the pre-response session update", () =>
 
   assert.deepEqual(app.auditLog.entries.map((entry) => entry.id), ["live-1"]);
   assert.equal(app.auditLog.entries[0].session_count, 3);
+  assert.equal(app.auditLog.entries[0]._live_state, "audit.updated");
   assert.equal(app.auditLog.total, 1);
+  assert.deepEqual(app.auditLiveHeld, []);
   // The displaced head moved into the loaded children.
   assert.deepEqual(
     app.auditThreadChildren["s-a"].entries.map((entry) => entry.id),
     ["head-a", "old-child"],
+  );
+});
+
+test("a held sessionless row is placed when its grace period runs out", () => {
+  const app = createLiveLogsApp({ auditGroupSessions: true });
+  app.auditLog.entries = [{ id: "head-a", session_id: "s-a", session_count: 2 }];
+  app.auditLog.total = 1;
+
+  app.mergeLiveAuditEntry({ id: "live-1", request_id: "req-1" }, "audit.started");
+  assert.deepEqual(app.auditLog.entries.map((entry) => entry.id), ["head-a"]);
+
+  // No session ever arrives: the timer places it as its own thread.
+  app.expireHeldLiveAudit("live-1");
+  assert.deepEqual(app.auditLog.entries.map((entry) => entry.id), ["live-1", "head-a"]);
+  assert.equal(app.auditLog.total, 2);
+  assert.deepEqual(app.auditLiveHeld, []);
+  assert.equal(app.expireHeldLiveAudit("live-1"), null);
+
+  // A late session id still folds the placed row into its thread.
+  app.mergeLiveAuditEntry(
+    { id: "live-1", request_id: "req-1", session_id: "s-a" },
+    "audit.updated",
+  );
+  assert.deepEqual(app.auditLog.entries.map((entry) => entry.id), ["live-1"]);
+  assert.equal(app.auditLog.entries[0].session_count, 3);
+  assert.equal(app.auditLog.total, 1);
+});
+
+test("sessionless rows that cannot gain a session are not held", () => {
+  const app = createLiveLogsApp({ auditGroupSessions: true });
+  app.auditLog.total = 0;
+
+  // Model resolution runs after session detection: a stamped model with no
+  // session means the request has none.
+  app.mergeLiveAuditEntry(
+    { id: "modelled", requested_model: "gpt-5" },
+    "audit.updated",
+  );
+  // A settled request is past every chance of a session update.
+  app.mergeLiveAuditEntry({ id: "done", status_code: 200 }, "audit.completed");
+  // Flat mode never holds.
+  const flat = createLiveLogsApp({ auditGroupSessions: false });
+  flat.mergeLiveAuditEntry({ id: "flat-1" }, "audit.started");
+
+  assert.deepEqual(app.auditLog.entries.map((entry) => entry.id), ["done", "modelled"]);
+  assert.deepEqual(app.auditLiveHeld, []);
+  assert.deepEqual(flat.auditLog.entries.map((entry) => entry.id), ["flat-1"]);
+  assert.deepEqual(flat.auditLiveHeld, []);
+});
+
+test("a held row that settles without a session is placed at once", () => {
+  const app = createLiveLogsApp({ auditGroupSessions: true });
+  app.mergeLiveAuditEntry({ id: "live-1", request_id: "req-1" }, "audit.started");
+  assert.deepEqual(app.auditLog.entries, []);
+
+  app.mergeLiveAuditEntry(
+    { id: "live-1", request_id: "req-1", status_code: 500 },
+    "audit.failed",
+  );
+  assert.deepEqual(app.auditLog.entries.map((entry) => entry.id), ["live-1"]);
+  assert.equal(app.auditLog.entries[0]._live_state, "audit.failed");
+  assert.equal(app.auditLog.entries[0].status_code, 500);
+  assert.deepEqual(app.auditLiveHeld, []);
+});
+
+test("audit.removed drops a held row without touching the list", () => {
+  const app = createLiveLogsApp({ auditGroupSessions: true });
+  app.auditLog.entries = [{ id: "head-a", session_id: "s-a", session_count: 2 }];
+  app.auditLog.total = 1;
+  app.mergeLiveAuditEntry({ id: "live-1", request_id: "req-1" }, "audit.started");
+
+  app.removeLiveAuditEntry({ id: "live-1", request_id: "req-1" });
+  assert.deepEqual(app.auditLiveHeld, []);
+  assert.deepEqual(app.auditLog.entries.map((entry) => entry.id), ["head-a"]);
+  assert.equal(app.auditLog.total, 1);
+  assert.equal(app.expireHeldLiveAudit("live-1"), null);
+});
+
+test("the persisted row of a held request wins when a refetch lands it first", () => {
+  const app = createLiveLogsApp({ auditGroupSessions: true });
+  app.mergeLiveAuditEntry({ id: "live-1", request_id: "req-1" }, "audit.started");
+  // The page refetch delivered the row before the session update arrived.
+  app.auditLog.entries = [{ id: "live-1", request_id: "req-1", session_id: "s-a" }];
+  app.auditLog.total = 1;
+
+  app.mergeLiveAuditEntry(
+    { id: "live-1", request_id: "req-1", session_id: "s-a", status_code: 200 },
+    "audit.completed",
+  );
+  assert.deepEqual(app.auditLog.entries.map((entry) => entry.id), ["live-1"]);
+  assert.equal(app.auditLog.entries[0].status_code, 200);
+  assert.deepEqual(app.auditLiveHeld, []);
+  assert.equal(app.expireHeldLiveAudit("live-1"), null);
+});
+
+test("an older request folds under the current head instead of replacing it", () => {
+  const app = createLiveLogsApp({ auditGroupSessions: true });
+  app.auditLog.entries = [
+    { id: "head-a", session_id: "s-a", session_count: 2, timestamp: "2026-07-28T10:00:05Z" },
+  ];
+  app.auditLog.total = 1;
+
+  app.mergeLiveAuditEntry(
+    { id: "late", session_id: "s-a", timestamp: "2026-07-28T10:00:00Z" },
+    "audit.updated",
+  );
+  assert.deepEqual(app.auditLog.entries.map((entry) => entry.id), ["head-a"]);
+  assert.equal(app.auditLog.entries[0].session_count, 3);
+  assert.equal(app.auditLog.total, 1);
+  assert.deepEqual(
+    app.auditThreadChildren["s-a"].entries.map((entry) => entry.id),
+    ["late"],
   );
 });
 
@@ -1169,6 +1288,8 @@ test("interleaved first-session requests do not inflate the thread count", () =>
   // events. Before the fix each late event for a displaced (and dropped) row
   // re-counted it as a new session member, inflating the badge 2x-3x.
   const app = createLiveLogsApp({ auditGroupSessions: true });
+  // Sessionless requests are held (default mode) — apply the session updates
+  // to the held rows to exercise the placement path.
 
   app.mergeLiveAuditEntry(
     { id: "a", request_id: "req-a", timestamp: "2026-07-28T10:00:00Z" },


### PR DESCRIPTION
## What & why

Two audit-log dashboard UX issues where the view jumps while records stream in real time.

### 1. Session list jumps when live records arrive (grouped mode)

The gateway emits `audit.started` before session detection runs, so a new live request arrives with no `session_id`. The old code inserted it as its own singleton thread at the top of the list, then re-folded it into its real thread milliseconds later when the session update landed — two list mutations per request, shifting the whole list twice.

Now a sessionless live row is held off-screen briefly and placed exactly once, when its outcome is known: the session update arrives (folds straight into its thread), the request settles or a model/workflow is stamped with still no session (placed as its own thread), or a short grace period elapses. Thread folding is also timestamp-aware, so a late-arriving request slips in as a child rather than displacing a newer head. The normalized record cache still receives every event, so an open interactions drawer keeps following.

### 2. Interactions drawer jumps while following a conversation

Two causes: the follow-scroll used `scrollIntoView`, which scrolls every scrollable ancestor (dragging the audit list behind the drawer), and it re-scrolled to the bottom on every record change (yanking a reader who had scrolled up).

The scroll helpers now move the drawer's own container directly, and the follow pin is tracked from the container's scroll events — scrolling up unpins, scrolling back down re-pins. A live flush re-hydrates the transcript without forcing the view down. Separately, the highlighted open-interactions row now uses a box-shadow ring at constant border width instead of a thicker border, so rows below it no longer shift a pixel.

## User-visible impact

- Unfolded session threads stay put as live requests stream in.
- The interactions drawer follows new content only when pinned to the bottom; a reader scrolled up stays where they are.

## Testing

- `npm run check` — 0 errors
- `npm test` — 588 pass / 0 fail (new tests for the hold lifecycle and the drawer pin/anchor helpers)
- Verified live in the browser against a streaming gateway: head row held stable across 153 samples during a live arrival; drawer held position through a full stream + settle when scrolled up, and kept following when pinned.

Frontend only; no Go changes. The embedded dashboard bundle is rebuilt by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8E6hziQAZjaGTch7E9tDa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation drawer scrolling so viewing or streaming messages no longer unexpectedly moves the surrounding audit log.
  * Live conversation updates now continue following the latest content only when the reader is already near the bottom.
  * Selecting a message centers it within the conversation drawer.
  * Reduced visual row shifting when switching between interaction drawers.
  * Improved grouping of live audit entries by briefly waiting for session information before placing entries in the list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->