### PR TITLE
feat(dashboard): show tried model on each failover attempt tab

### DIFF
--- a/web/dashboard/messages/en.json
+++ b/web/dashboard/messages/en.json
@@ -260,6 +260,10 @@
   "audit_rewritten_title": "Rewritten",
   "audit_what_changed_title": "What changed",
   "audit_attempt_failed": "Provider attempt failed",
+  "audit_model_strip_requested": "requested",
+  "audit_model_strip_tried": "tried",
+  "audit_model_strip_virtual": "virtual",
+  "audit_model_strip_copy_label": "Copy {label} model {model}",
   "audit_provider_attempts": [
     {
       "declarations": ["input count", "local count_plural = count: plural"],

--- a/web/dashboard/messages/pl.json
+++ b/web/dashboard/messages/pl.json
@@ -264,6 +264,10 @@
   "audit_rewritten_title": "Po przetworzeniu",
   "audit_what_changed_title": "Co się zmieniło",
   "audit_attempt_failed": "Próba dostawcy nie powiodła się",
+  "audit_model_strip_requested": "żądany",
+  "audit_model_strip_tried": "próbowany",
+  "audit_model_strip_virtual": "wirtualny",
+  "audit_model_strip_copy_label": "Skopiuj model {label}: {model}",
   "audit_provider_attempts": [
     {
       "declarations": ["input count", "local count_plural = count: plural"],

--- a/web/dashboard/src/pages/audit-logs/AuditPane.svelte
+++ b/web/dashboard/src/pages/audit-logs/AuditPane.svelte
@@ -59,6 +59,21 @@
     pane.layout === "split" &&
     !(pane.showHeaders && pane.showBody)}
 >
+  {#if pane.modelStrip}
+    <div class="audit-pane-model-strip">
+      {#if pane.modelStrip.virtual}
+        <span class="audit-pane-model-strip-chip">
+          <span class="audit-pane-model-strip-label">virtual</span>
+          <span class="mono">{pane.modelStrip.virtual}</span>
+        </span>
+        <span class="audit-pane-model-strip-arrow" aria-hidden="true">→</span>
+      {/if}
+      <span class="audit-pane-model-strip-chip">
+        <span class="audit-pane-model-strip-label">tried</span>
+        <span class="mono">{pane.modelStrip.tried}</span>
+      </span>
+    </div>
+  {/if}
   {#if pane.showErrorMessage}
     <div class="audit-pane-block audit-pane-block-error">
       <h5>{m.audit_error_message_title()}</h5>
@@ -155,6 +170,51 @@
     grid-template-columns: 1fr 2fr;
     gap: 10px 14px;
     align-items: start;
+  }
+
+  /* Virtual → tried model strip at the top of a failover attempt pane: which
+     virtual model leg this attempt belongs to and which concrete model was
+     actually called. Chips stay on one line, ellipsized when long. */
+  .audit-pane-model-strip {
+    grid-column: 1 / -1;
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 2px;
+  }
+
+  .audit-pane-model-strip-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    max-width: 320px;
+    padding: 3px 9px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--bg-surface);
+    font-size: 11px;
+  }
+
+  .audit-pane-model-strip-chip .mono {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 11px;
+  }
+
+  .audit-pane-model-strip-label {
+    flex: 0 0 auto;
+    color: var(--text-muted);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .audit-pane-model-strip-arrow {
+    color: var(--text-muted);
+    font-size: 12px;
   }
 
   .audit-pane-split-single {

--- a/web/dashboard/src/pages/audit-logs/AuditPane.svelte
+++ b/web/dashboard/src/pages/audit-logs/AuditPane.svelte
@@ -62,13 +62,16 @@
   {#if pane.modelStrip}
     <div class="audit-pane-model-strip">
       {#if pane.modelStrip.source}
-        <span class="audit-pane-model-strip-chip">
+        <span
+          class="audit-pane-model-strip-chip"
+          title={pane.modelStrip.source}
+        >
           <span class="audit-pane-model-strip-label">{pane.modelStrip.label}</span>
           <span class="mono">{pane.modelStrip.source}</span>
         </span>
         <span class="audit-pane-model-strip-arrow" aria-hidden="true">→</span>
       {/if}
-      <span class="audit-pane-model-strip-chip">
+      <span class="audit-pane-model-strip-chip" title={pane.modelStrip.tried}>
         <span class="audit-pane-model-strip-label">tried</span>
         <span class="mono">{pane.modelStrip.tried}</span>
       </span>

--- a/web/dashboard/src/pages/audit-logs/AuditPane.svelte
+++ b/web/dashboard/src/pages/audit-logs/AuditPane.svelte
@@ -61,10 +61,10 @@
 >
   {#if pane.modelStrip}
     <div class="audit-pane-model-strip">
-      {#if pane.modelStrip.virtual}
+      {#if pane.modelStrip.source}
         <span class="audit-pane-model-strip-chip">
-          <span class="audit-pane-model-strip-label">virtual</span>
-          <span class="mono">{pane.modelStrip.virtual}</span>
+          <span class="audit-pane-model-strip-label">{pane.modelStrip.label}</span>
+          <span class="mono">{pane.modelStrip.source}</span>
         </span>
         <span class="audit-pane-model-strip-arrow" aria-hidden="true">→</span>
       {/if}

--- a/web/dashboard/src/pages/audit-logs/AuditPane.svelte
+++ b/web/dashboard/src/pages/audit-logs/AuditPane.svelte
@@ -18,6 +18,16 @@
   const copyBodyState = createCopyState({
     logPrefix: "Failed to copy audit payload:",
   });
+  const copyModelState = createCopyState({
+    logPrefix: "Failed to copy model name:",
+  });
+
+  // The model-strip chips are buttons whose activation copies the full model
+  // name, so the complete value is reachable by keyboard and touch (the
+  // visual text may be ellipsized).
+  function copyModelValue(value) {
+    copyModelState.copy(value, (v) => v);
+  }
   const copyHeadersState = createCopyState({
     logPrefix: "Failed to copy audit payload:",
   });
@@ -62,19 +72,36 @@
   {#if pane.modelStrip}
     <div class="audit-pane-model-strip">
       {#if pane.modelStrip.source}
-        <span
+        <!-- Chip is a button so the full value is keyboard-focusable and
+             touch-operable: activate copies the complete model name. -->
+        <button
+          type="button"
           class="audit-pane-model-strip-chip"
           title={pane.modelStrip.source}
+          aria-label={m.audit_model_strip_copy_label({
+            label: pane.modelStrip.label,
+            model: pane.modelStrip.source,
+          })}
+          onclick={() => copyModelValue(pane.modelStrip.source)}
         >
           <span class="audit-pane-model-strip-label">{pane.modelStrip.label}</span>
           <span class="mono">{pane.modelStrip.source}</span>
-        </span>
+        </button>
         <span class="audit-pane-model-strip-arrow" aria-hidden="true">→</span>
       {/if}
-      <span class="audit-pane-model-strip-chip" title={pane.modelStrip.tried}>
-        <span class="audit-pane-model-strip-label">tried</span>
+      <button
+        type="button"
+        class="audit-pane-model-strip-chip"
+        title={pane.modelStrip.tried}
+        aria-label={m.audit_model_strip_copy_label({
+          label: m.audit_model_strip_tried(),
+          model: pane.modelStrip.tried,
+        })}
+        onclick={() => copyModelValue(pane.modelStrip.tried)}
+      >
+        <span class="audit-pane-model-strip-label">{m.audit_model_strip_tried()}</span>
         <span class="mono">{pane.modelStrip.tried}</span>
-      </span>
+      </button>
     </div>
   {/if}
   {#if pane.showErrorMessage}
@@ -196,7 +223,16 @@
     border: 1px solid var(--border);
     border-radius: 999px;
     background: var(--bg-surface);
+    font-family: inherit;
     font-size: 11px;
+    text-align: left;
+    appearance: none;
+    cursor: pointer;
+  }
+
+  .audit-pane-model-strip-chip:hover {
+    background: color-mix(in srgb, var(--text) 6%, var(--bg-surface));
+    border-color: color-mix(in srgb, var(--border) 60%, var(--text) 40%);
   }
 
   .audit-pane-model-strip-chip .mono {

--- a/web/dashboard/src/pages/audit-logs/AuditPaneTabs.svelte
+++ b/web/dashboard/src/pages/audit-logs/AuditPaneTabs.svelte
@@ -64,11 +64,6 @@
             >{p.pane.kind}</span
           >
         {/if}
-        {#if p.pane.model}
-          <span class="audit-pane-model mono" title={p.pane.modelTitle}
-            >{p.pane.model}</span
-          >
-        {/if}
         {#each p.pane.noChangeSteps || [] as step (step.id)}
           <span class="audit-step-pill" title={step.title}>{step.label}</span>
         {/each}
@@ -213,17 +208,6 @@
     color: var(--warning);
     background: color-mix(in srgb, var(--warning) 14%, var(--bg));
     border-color: color-mix(in srgb, var(--warning) 30%, var(--border));
-  }
-
-  /* Tried model for a failover/retry attempt: the tab's answer to "which
-     model returned this status?". Truncated in the strip; the full attempt
-     summary (#n · kind · status · provider · model) rides the tooltip. */
-  .audit-pane-model {
-    max-width: 220px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    font-size: 11px;
-    color: var(--text-muted);
   }
 
   /* Share of the request body removed by a rewrite (e.g. token compression),

--- a/web/dashboard/src/pages/audit-logs/AuditPaneTabs.svelte
+++ b/web/dashboard/src/pages/audit-logs/AuditPaneTabs.svelte
@@ -64,6 +64,11 @@
             >{p.pane.kind}</span
           >
         {/if}
+        {#if p.pane.model}
+          <span class="audit-pane-model mono" title={p.pane.modelTitle}
+            >{p.pane.model}</span
+          >
+        {/if}
         {#each p.pane.noChangeSteps || [] as step (step.id)}
           <span class="audit-step-pill" title={step.title}>{step.label}</span>
         {/each}
@@ -208,6 +213,17 @@
     color: var(--warning);
     background: color-mix(in srgb, var(--warning) 14%, var(--bg));
     border-color: color-mix(in srgb, var(--warning) 30%, var(--border));
+  }
+
+  /* Tried model for a failover/retry attempt: the tab's answer to "which
+     model returned this status?". Truncated in the strip; the full attempt
+     summary (#n · kind · status · provider · model) rides the tooltip. */
+  .audit-pane-model {
+    max-width: 220px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 11px;
+    color: var(--text-muted);
   }
 
   /* Share of the request body removed by a rewrite (e.g. token compression),

--- a/web/dashboard/src/pages/audit-logs/audit-logic.js
+++ b/web/dashboard/src/pages/audit-logs/audit-logic.js
@@ -644,14 +644,19 @@ function auditAttemptResponsePane(entry, attempt) {
     direction: "response",
     seq: single ? 0 : Number((attempt && attempt.seq) || 0),
     kind: single ? "" : kind === "attempt" ? "" : kind,
-    // In-pane strip under the tab header: the virtual model the request
-    // named and the concrete model this attempt actually tried, so a failed
-    // step reads "virtual → tried" without hovering anything.
+    // In-pane strip under the tab header: the model the request named and
+    // the concrete model this attempt actually tried, so a failed step reads
+    // "requested → tried" without hovering anything. The source is only
+    // called "virtual" when an alias actually resolved — failover rules also
+    // apply to plain concrete models, so a bare requested name must not
+    // mislabel itself as a virtual model.
     modelStrip:
       tried && !single
         ? {
-            virtual: String(
+            label: entry && entry.alias_used ? "virtual" : "requested",
+            source: String(
               (entry && entry.requested_model) ||
+                (entry && entry.model) ||
                 (data && data.request_body && data.request_body.model) ||
                 "",
             ).trim(),

--- a/web/dashboard/src/pages/audit-logs/audit-logic.js
+++ b/web/dashboard/src/pages/audit-logs/audit-logic.js
@@ -633,32 +633,29 @@ function auditAttemptResponsePane(entry, attempt) {
   // With only one response tab the seq/type/status chips are just noise (it's
   // the whole response); show them only to tell apart multiple attempt tabs.
   const single = auditAttempts(entry).length <= 1;
-  // The tried model is the tab badge's reason to exist: without it the tabs
-  // only say which ordinal failed, not which model. Hidden on the single tab
-  // (the row's model column already shows it) and for entries that predate
-  // per-attempt model capture ("-" placeholder).
+  // The tried model drives the in-pane virtual → tried strip. Hidden on the
+  // single tab (the row's model column already shows it) and for entries that
+  // predate per-attempt model capture ("-" placeholder).
   const triedModel = single ? "" : auditAttemptModel(attempt);
-  const model = triedModel === "-" ? "" : triedModel;
+  const tried = triedModel === "-" ? "" : triedModel;
 
   return {
     title: m.audit_response_title(),
     direction: "response",
     seq: single ? 0 : Number((attempt && attempt.seq) || 0),
     kind: single ? "" : kind === "attempt" ? "" : kind,
-    model,
-    modelTitle: model ? auditAttemptSegmentTitle(attempt) : "",
     // In-pane strip under the tab header: the virtual model the request
     // named and the concrete model this attempt actually tried, so a failed
     // step reads "virtual → tried" without hovering anything.
     modelStrip:
-      model && !single
+      tried && !single
         ? {
             virtual: String(
               (entry && entry.requested_model) ||
                 (data && data.request_body && data.request_body.model) ||
                 "",
             ).trim(),
-            tried: model,
+            tried,
           }
         : null,
     statusCode: single ? null : auditAttemptStatusCode(attempt),

--- a/web/dashboard/src/pages/audit-logs/audit-logic.js
+++ b/web/dashboard/src/pages/audit-logs/audit-logic.js
@@ -647,6 +647,20 @@ function auditAttemptResponsePane(entry, attempt) {
     kind: single ? "" : kind === "attempt" ? "" : kind,
     model,
     modelTitle: model ? auditAttemptSegmentTitle(attempt) : "",
+    // In-pane strip under the tab header: the virtual model the request
+    // named and the concrete model this attempt actually tried, so a failed
+    // step reads "virtual → tried" without hovering anything.
+    modelStrip:
+      model && !single
+        ? {
+            virtual: String(
+              (entry && entry.requested_model) ||
+                (data && data.request_body && data.request_body.model) ||
+                "",
+            ).trim(),
+            tried: model,
+          }
+        : null,
     statusCode: single ? null : auditAttemptStatusCode(attempt),
     layout: "split",
     entry,

--- a/web/dashboard/src/pages/audit-logs/audit-logic.js
+++ b/web/dashboard/src/pages/audit-logs/audit-logic.js
@@ -638,15 +638,15 @@ function auditAttemptResponsePane(entry, attempt) {
   // (the row's model column already shows it) and for entries that predate
   // per-attempt model capture ("-" placeholder).
   const triedModel = single ? "" : auditAttemptModel(attempt);
+  const model = triedModel === "-" ? "" : triedModel;
 
   return {
     title: m.audit_response_title(),
     direction: "response",
     seq: single ? 0 : Number((attempt && attempt.seq) || 0),
     kind: single ? "" : kind === "attempt" ? "" : kind,
-    model: triedModel === "-" ? "" : triedModel,
-    modelTitle:
-      triedModel && triedModel !== "-" ? auditAttemptSegmentTitle(attempt) : "",
+    model,
+    modelTitle: model ? auditAttemptSegmentTitle(attempt) : "",
     statusCode: single ? null : auditAttemptStatusCode(attempt),
     layout: "split",
     entry,

--- a/web/dashboard/src/pages/audit-logs/audit-logic.js
+++ b/web/dashboard/src/pages/audit-logs/audit-logic.js
@@ -633,12 +633,20 @@ function auditAttemptResponsePane(entry, attempt) {
   // With only one response tab the seq/type/status chips are just noise (it's
   // the whole response); show them only to tell apart multiple attempt tabs.
   const single = auditAttempts(entry).length <= 1;
+  // The tried model is the tab badge's reason to exist: without it the tabs
+  // only say which ordinal failed, not which model. Hidden on the single tab
+  // (the row's model column already shows it) and for entries that predate
+  // per-attempt model capture ("-" placeholder).
+  const triedModel = single ? "" : auditAttemptModel(attempt);
 
   return {
     title: m.audit_response_title(),
     direction: "response",
     seq: single ? 0 : Number((attempt && attempt.seq) || 0),
     kind: single ? "" : kind === "attempt" ? "" : kind,
+    model: triedModel === "-" ? "" : triedModel,
+    modelTitle:
+      triedModel && triedModel !== "-" ? auditAttemptSegmentTitle(attempt) : "",
     statusCode: single ? null : auditAttemptStatusCode(attempt),
     layout: "split",
     entry,

--- a/web/dashboard/src/pages/audit-logs/audit-logic.js
+++ b/web/dashboard/src/pages/audit-logs/audit-logic.js
@@ -622,6 +622,11 @@ function auditAttemptStatusCode(attempt) {
   return Number.isFinite(code) && code > 0 ? code : null;
 }
 
+/**
+ * Builds one per-attempt response pane: captured body/headers, the normalized
+ * error message, and the model strip naming which model the request named
+ * versus which model this attempt actually tried.
+ */
 function auditAttemptResponsePane(entry, attempt) {
   const success = !!(attempt && attempt.success);
   const data = entry && entry.data ? entry.data : null;
@@ -633,11 +638,17 @@ function auditAttemptResponsePane(entry, attempt) {
   // With only one response tab the seq/type/status chips are just noise (it's
   // the whole response); show them only to tell apart multiple attempt tabs.
   const single = auditAttempts(entry).length <= 1;
-  // The tried model drives the in-pane virtual → tried strip. Hidden on the
-  // single tab (the row's model column already shows it) and for entries that
-  // predate per-attempt model capture ("-" placeholder).
+  // The tried model drives the in-pane model strip. Hidden on the single tab
+  // (the row's model column already shows it) and for entries that predate
+  // per-attempt model capture ("-" placeholder).
   const triedModel = single ? "" : auditAttemptModel(attempt);
   const tried = triedModel === "-" ? "" : triedModel;
+  const source = String(
+    (entry && entry.requested_model) ||
+      (entry && entry.model) ||
+      (data && data.request_body && data.request_body.model) ||
+      "",
+  ).trim();
 
   return {
     title: m.audit_response_title(),
@@ -649,17 +660,17 @@ function auditAttemptResponsePane(entry, attempt) {
     // "requested → tried" without hovering anything. The source is only
     // called "virtual" when an alias actually resolved — failover rules also
     // apply to plain concrete models, so a bare requested name must not
-    // mislabel itself as a virtual model.
+    // mislabel itself as a virtual model. Requires both values: a strip that
+    // named only the tried model would read as if the request model were
+    // unknown by design, which it is not.
     modelStrip:
-      tried && !single
+      tried && !single && source
         ? {
-            label: entry && entry.alias_used ? "virtual" : "requested",
-            source: String(
-              (entry && entry.requested_model) ||
-                (entry && entry.model) ||
-                (data && data.request_body && data.request_body.model) ||
-                "",
-            ).trim(),
+            label:
+              entry && entry.alias_used
+                ? m.audit_model_strip_virtual()
+                : m.audit_model_strip_requested(),
+            source,
             tried,
           }
         : null,

--- a/web/dashboard/tests/audit-list.test.js
+++ b/web/dashboard/tests/audit-list.test.js
@@ -699,7 +699,7 @@ test("entries without revisions render no revision tabs", () => {
 test("per-attempt response panes carry the tried model for the tab badge", () => {
   const entry = {
     data: {
-      request_body: { model: "forge/subagent" },
+      request_body: { model: "virtual-model-a" },
       response_body: { ok: true },
       attempts: [
         {
@@ -740,12 +740,12 @@ test("per-attempt response panes carry the tried model for the tab badge", () =>
   // model the request chose and the concrete model that attempt targeted.
   const first = panes.find((p) => p.id === "response-1").pane;
   assert.deepEqual(first.modelStrip, {
-    virtual: "forge/subagent",
+    virtual: "virtual-model-a",
     tried: "provider-a/Qwen/Qwen3.6-35B-A3B-FP8",
   });
   const second = panes.find((p) => p.id === "response-2").pane;
   assert.deepEqual(second.modelStrip, {
-    virtual: "forge/subagent",
+    virtual: "virtual-model-a",
     tried: "provider-b/glm-5.3-flash",
   });
 

--- a/web/dashboard/tests/audit-list.test.js
+++ b/web/dashboard/tests/audit-list.test.js
@@ -736,17 +736,57 @@ test("per-attempt response panes carry the tried model for the tab badge", () =>
     "request,response-1,response-2,response-3",
   );
 
-  // Each failover pane carries the virtual → tried model strip: the virtual
-  // model the request chose and the concrete model that attempt targeted.
+  // Each failover pane carries the requested → tried model strip: the model
+  // the request named and the concrete model that attempt targeted. Without
+  // an alias resolution the source chip reads "requested", not "virtual".
   const first = panes.find((p) => p.id === "response-1").pane;
   assert.deepEqual(first.modelStrip, {
-    virtual: "virtual-model-a",
+    label: "requested",
+    source: "virtual-model-a",
     tried: "provider-a/Qwen/Qwen3.6-35B-A3B-FP8",
   });
   const second = panes.find((p) => p.id === "response-2").pane;
   assert.deepEqual(second.modelStrip, {
-    virtual: "virtual-model-a",
+    label: "requested",
+    source: "virtual-model-a",
     tried: "provider-b/glm-5.3-flash",
+  });
+
+  // Alias-resolved entries label the source "virtual" and prefer top-level
+  // requested_model over entry.model and the request body (the same
+  // precedence the metadata row uses).
+  const aliased = {
+    requested_model: "smart-vm",
+    model: "entry-model",
+    alias_used: true,
+    data: {
+      request_body: { model: "body-model" },
+      attempts: [
+        { seq: 1, kind: "primary", model: "provider-a/qwen-35b", status_code: 503, success: false },
+        { seq: 2, kind: "failover", model: "provider-b/glm-flash", status_code: 200, success: true },
+      ],
+    },
+  };
+  assert.deepEqual(auditPanes(aliased).find((p) => p.id === "response-1").pane.modelStrip, {
+    label: "virtual",
+    source: "smart-vm",
+    tried: "provider-a/qwen-35b",
+  });
+
+  // Without requested_model, top-level entry.model steps in before the body.
+  const entryModel = {
+    model: "entry-model",
+    data: {
+      attempts: [
+        { seq: 1, kind: "primary", model: "provider-a/qwen-35b", status_code: 503, success: false },
+        { seq: 2, kind: "failover", model: "provider-b/glm-flash", status_code: 200, success: true },
+      ],
+    },
+  };
+  assert.deepEqual(auditPanes(entryModel).find((p) => p.id === "response-1").pane.modelStrip, {
+    label: "requested",
+    source: "entry-model",
+    tried: "provider-a/qwen-35b",
   });
 
   // A single successful attempt collapses to the plain response tab, which
@@ -788,7 +828,8 @@ test("per-attempt response panes carry the tried model for the tab badge", () =>
   const legacyPanes = auditPanes(legacy);
   assert.ok(!legacyPanes.find((p) => p.id === "response-1").pane.modelStrip);
   assert.deepEqual(legacyPanes.find((p) => p.id === "response-2").pane.modelStrip, {
-    virtual: "m",
+    label: "requested",
+    source: "m",
     tried: "m",
   });
 });

--- a/web/dashboard/tests/audit-list.test.js
+++ b/web/dashboard/tests/audit-list.test.js
@@ -705,24 +705,24 @@ test("per-attempt response panes carry the tried model for the tab badge", () =>
         {
           seq: 1,
           kind: "primary",
-          provider_name: "hetzner-weselben",
-          model: "hetzner-weselben/Qwen/Qwen3.6-35B-A3B-FP8",
+          provider_name: "provider-a",
+          model: "provider-a/Qwen/Qwen3.6-35B-A3B-FP8",
           status_code: 503,
           success: false,
         },
         {
           seq: 2,
           kind: "failover",
-          provider_name: "zai-weselben",
-          model: "zai-weselben/glm-5.3-flash",
+          provider_name: "provider-b",
+          model: "provider-b/glm-5.3-flash",
           status_code: 400,
           success: false,
         },
         {
           seq: 3,
           kind: "failover",
-          provider_name: "zai-weselben",
-          model: "zai-weselben/glm-5.3-flash",
+          provider_name: "provider-b",
+          model: "provider-b/glm-5.3-flash",
           status_code: 200,
           success: true,
         },
@@ -739,13 +739,13 @@ test("per-attempt response panes carry the tried model for the tab badge", () =>
   // Each failover tab names the model that attempt targeted, and the tooltip
   // carries the full segment summary (#n · kind · status · provider · model).
   const first = panes.find((p) => p.id === "response-1").pane;
-  assert.equal(first.model, "hetzner-weselben/Qwen/Qwen3.6-35B-A3B-FP8");
+  assert.equal(first.model, "provider-a/Qwen/Qwen3.6-35B-A3B-FP8");
   assert.match(first.modelTitle, /#1/);
   assert.match(first.modelTitle, /primary/);
   assert.match(first.modelTitle, /503/);
   assert.match(first.modelTitle, /Qwen3\.6-35B-A3B-FP8/);
   const second = panes.find((p) => p.id === "response-2").pane;
-  assert.equal(second.model, "zai-weselben/glm-5.3-flash");
+  assert.equal(second.model, "provider-b/glm-5.3-flash");
 
   // A single successful attempt collapses to the plain response tab, which
   // carries no model chip (the row's model column already names it).

--- a/web/dashboard/tests/audit-list.test.js
+++ b/web/dashboard/tests/audit-list.test.js
@@ -736,31 +736,21 @@ test("per-attempt response panes carry the tried model for the tab badge", () =>
     "request,response-1,response-2,response-3",
   );
 
-  // Each failover tab names the model that attempt targeted, and the tooltip
-  // carries the full segment summary (#n · kind · status · provider · model).
+  // Each failover pane carries the virtual → tried model strip: the virtual
+  // model the request chose and the concrete model that attempt targeted.
   const first = panes.find((p) => p.id === "response-1").pane;
-  assert.equal(first.model, "provider-a/Qwen/Qwen3.6-35B-A3B-FP8");
-  assert.match(first.modelTitle, /#1/);
-  assert.match(first.modelTitle, /primary/);
-  assert.match(first.modelTitle, /503/);
-  assert.match(first.modelTitle, /Qwen3\.6-35B-A3B-FP8/);
+  assert.deepEqual(first.modelStrip, {
+    virtual: "forge/subagent",
+    tried: "provider-a/Qwen/Qwen3.6-35B-A3B-FP8",
+  });
   const second = panes.find((p) => p.id === "response-2").pane;
-  assert.equal(second.model, "provider-b/glm-5.3-flash");
-
-  // In-pane model strip names the virtual model the request chose and the
-  // concrete model this attempt tried, so a failed leg reads "virtual → tried".
-  const strip = panes.find((p) => p.id === "response-3").pane.modelStrip;
-  assert.deepEqual(strip, {
+  assert.deepEqual(second.modelStrip, {
     virtual: "forge/subagent",
     tried: "provider-b/glm-5.3-flash",
   });
-  // Every attempt pane carries the strip — the virtual name is the same,
-  // only the tried model changes per attempt.
-  assert.equal(first.modelStrip.virtual, "forge/subagent");
-  assert.equal(first.modelStrip.tried, "provider-a/Qwen/Qwen3.6-35B-A3B-FP8");
 
   // A single successful attempt collapses to the plain response tab, which
-  // carries no model chip (the row's model column already names it).
+  // carries no model strip (the row's model column already names it).
   const single = {
     data: {
       request_body: { model: "m" },
@@ -770,10 +760,10 @@ test("per-attempt response panes carry the tried model for the tab badge", () =>
   };
   const singlePanes = auditPanes(single);
   assert.equal(singlePanes.map((p) => p.id).join(","), "request,response");
-  assert.ok(!singlePanes.find((p) => p.id === "response").pane.model);
+  assert.ok(!singlePanes.find((p) => p.id === "response").pane.modelStrip);
 
   // A single FAILED attempt keeps the per-attempt path but still hides the
-  // chip — the same `single` rule as the seq/kind/status chips.
+  // strip — the same `single` rule as the seq/kind/status chips.
   const loneFailure = {
     data: {
       request_body: { model: "m" },
@@ -782,9 +772,9 @@ test("per-attempt response panes carry the tried model for the tab badge", () =>
   };
   const lonePanes = auditPanes(loneFailure);
   assert.equal(lonePanes.map((p) => p.id).join(","), "request,response-1");
-  assert.equal(lonePanes.find((p) => p.id === "response-1").pane.model, "");
+  assert.ok(!lonePanes.find((p) => p.id === "response-1").pane.modelStrip);
 
-  // Entries that predate per-attempt model capture render no badge instead of
+  // Entries that predate per-attempt model capture render no strip instead of
   // the "-" placeholder.
   const legacy = {
     data: {
@@ -795,7 +785,12 @@ test("per-attempt response panes carry the tried model for the tab badge", () =>
       ],
     },
   };
-  assert.equal(auditPanes(legacy).find((p) => p.id === "response-1").pane.model, "");
+  const legacyPanes = auditPanes(legacy);
+  assert.ok(!legacyPanes.find((p) => p.id === "response-1").pane.modelStrip);
+  assert.deepEqual(legacyPanes.find((p) => p.id === "response-2").pane.modelStrip, {
+    virtual: "m",
+    tried: "m",
+  });
 });
 
 test("formatJSON pretty-prints JSON strings and objects, passing other text through", () => {

--- a/web/dashboard/tests/audit-list.test.js
+++ b/web/dashboard/tests/audit-list.test.js
@@ -696,6 +696,96 @@ test("entries without revisions render no revision tabs", () => {
   assert.equal(auditRequestRevisions(entry).length, 0);
 });
 
+test("per-attempt response panes carry the tried model for the tab badge", () => {
+  const entry = {
+    data: {
+      request_body: { model: "forge/subagent" },
+      response_body: { ok: true },
+      attempts: [
+        {
+          seq: 1,
+          kind: "primary",
+          provider_name: "hetzner-weselben",
+          model: "hetzner-weselben/Qwen/Qwen3.6-35B-A3B-FP8",
+          status_code: 503,
+          success: false,
+        },
+        {
+          seq: 2,
+          kind: "failover",
+          provider_name: "zai-weselben",
+          model: "zai-weselben/glm-5.3-flash",
+          status_code: 400,
+          success: false,
+        },
+        {
+          seq: 3,
+          kind: "failover",
+          provider_name: "zai-weselben",
+          model: "zai-weselben/glm-5.3-flash",
+          status_code: 200,
+          success: true,
+        },
+      ],
+    },
+  };
+
+  const panes = auditPanes(entry);
+  assert.equal(
+    panes.map((p) => p.id).join(","),
+    "request,response-1,response-2,response-3",
+  );
+
+  // Each failover tab names the model that attempt targeted, and the tooltip
+  // carries the full segment summary (#n · kind · status · provider · model).
+  const first = panes.find((p) => p.id === "response-1").pane;
+  assert.equal(first.model, "hetzner-weselben/Qwen/Qwen3.6-35B-A3B-FP8");
+  assert.match(first.modelTitle, /#1/);
+  assert.match(first.modelTitle, /primary/);
+  assert.match(first.modelTitle, /503/);
+  assert.match(first.modelTitle, /Qwen3\.6-35B-A3B-FP8/);
+  const second = panes.find((p) => p.id === "response-2").pane;
+  assert.equal(second.model, "zai-weselben/glm-5.3-flash");
+
+  // A single successful attempt collapses to the plain response tab, which
+  // carries no model chip (the row's model column already names it).
+  const single = {
+    data: {
+      request_body: { model: "m" },
+      response_body: { ok: true },
+      attempts: [{ seq: 1, kind: "primary", model: "m", status_code: 200, success: true }],
+    },
+  };
+  const singlePanes = auditPanes(single);
+  assert.equal(singlePanes.map((p) => p.id).join(","), "request,response");
+  assert.ok(!singlePanes.find((p) => p.id === "response").pane.model);
+
+  // A single FAILED attempt keeps the per-attempt path but still hides the
+  // chip — the same `single` rule as the seq/kind/status chips.
+  const loneFailure = {
+    data: {
+      request_body: { model: "m" },
+      attempts: [{ seq: 1, kind: "primary", model: "m", status_code: 503, success: false }],
+    },
+  };
+  const lonePanes = auditPanes(loneFailure);
+  assert.equal(lonePanes.map((p) => p.id).join(","), "request,response-1");
+  assert.equal(lonePanes.find((p) => p.id === "response-1").pane.model, "");
+
+  // Entries that predate per-attempt model capture render no badge instead of
+  // the "-" placeholder.
+  const legacy = {
+    data: {
+      request_body: { model: "m" },
+      attempts: [
+        { seq: 1, kind: "primary", status_code: 503, success: false },
+        { seq: 2, kind: "failover", model: "m", status_code: 200, success: true },
+      ],
+    },
+  };
+  assert.equal(auditPanes(legacy).find((p) => p.id === "response-1").pane.model, "");
+});
+
 test("formatJSON pretty-prints JSON strings and objects, passing other text through", () => {
   assert.equal(formatJSON(null), "Not captured");
   assert.equal(formatJSON(""), "Not captured");

--- a/web/dashboard/tests/audit-list.test.js
+++ b/web/dashboard/tests/audit-list.test.js
@@ -789,6 +789,21 @@ test("per-attempt response panes carry the tried model for the tab badge", () =>
     tried: "provider-a/qwen-35b",
   });
 
+  // Without any request-model value anywhere, no strip renders at all — a
+  // lone "tried" chip would read as if the request model were unknown by
+  // design, which it is not.
+  const noSource = {
+    data: {
+      attempts: [
+        { seq: 1, kind: "primary", model: "provider-a/qwen-35b", status_code: 503, success: false },
+        { seq: 2, kind: "failover", model: "provider-b/glm-flash", status_code: 200, success: true },
+      ],
+    },
+  };
+  const noSourcePanes = auditPanes(noSource);
+  assert.ok(!noSourcePanes.find((p) => p.id === "response-1").pane.modelStrip);
+  assert.ok(!noSourcePanes.find((p) => p.id === "response-2").pane.modelStrip);
+
   // A single successful attempt collapses to the plain response tab, which
   // carries no model strip (the row's model column already names it).
   const single = {

--- a/web/dashboard/tests/audit-list.test.js
+++ b/web/dashboard/tests/audit-list.test.js
@@ -747,6 +747,18 @@ test("per-attempt response panes carry the tried model for the tab badge", () =>
   const second = panes.find((p) => p.id === "response-2").pane;
   assert.equal(second.model, "provider-b/glm-5.3-flash");
 
+  // In-pane model strip names the virtual model the request chose and the
+  // concrete model this attempt tried, so a failed leg reads "virtual → tried".
+  const strip = panes.find((p) => p.id === "response-3").pane.modelStrip;
+  assert.deepEqual(strip, {
+    virtual: "forge/subagent",
+    tried: "provider-b/glm-5.3-flash",
+  });
+  // Every attempt pane carries the strip — the virtual name is the same,
+  // only the tried model changes per attempt.
+  assert.equal(first.modelStrip.virtual, "forge/subagent");
+  assert.equal(first.modelStrip.tried, "provider-a/Qwen/Qwen3.6-35B-A3B-FP8");
+
   // A single successful attempt collapses to the plain response tab, which
   // carries no model chip (the row's model column already names it).
   const single = {


### PR DESCRIPTION
## TL;DR

When a request fails over across several models, the expanded audit entry's per-attempt Response panes show only the error body — to find which model returned a given failure you have to hover the tiny collapsed-row attempt pips, and the metadata strip names only the final serving model. Each attempt pane now opens with a small strip naming the **model the request named** and the **concrete model that leg actually tried** (`VIRTUAL <model> → TRIED <model>`), so a cascade like `primary 503 → failover 400 → failover 200` is readable leg by leg.

No backend, storage, or projection change: every provider call already records `Model` (`internal/gateway/attempts.go:ProviderAttempt`), persisted as `auditlog.AttemptSnapshot.Model` in `entry.data.attempts` and carried through both the detail endpoint and the slim list projection. This PR only renders it.
 
<img width="1441" height="732" alt="image" src="https://github.com/user-attachments/assets/4ec8be53-d3a6-4d04-be85-8628bb8b72d3" />


**Files to review (3):**

| File | Why |
|---|---|
| `web/dashboard/src/pages/audit-logs/audit-logic.js` *(start here)* | `auditAttemptResponsePane()` adds `modelStrip` (`{label, source, tried}`) to per-attempt response panes. `label` is `virtual` only when `alias_used` resolved, `requested` otherwise (failover rules also apply to plain concrete models). `source` resolves through `requested_model → entry.model → request_body.model`, matching the metadata row. Hidden on the single-attempt tab and for entries that predate model capture. |
| `web/dashboard/src/pages/audit-logs/AuditPane.svelte` | Renders the strip at the top of the pane, above the error/headers/body blocks: two chips (`source → tried`), ellipsized with a `title` carrying the full value. |
| `web/dashboard/tests/audit-list.test.js` | Contract tests: multi-attempt entries expose the strip per pane; single-attempt entries (success or failure) carry no strip; legacy entries without a captured model render no strip; alias-resolved entries use the `virtual` label; top-level `entry.model` falls back before `request_body.model`. |

## Behavior

- Each per-attempt `Response #n` pane (failover/retry chains split into one pane per attempt) opens with a chip strip: `VIRTUAL <requested model>` (or `REQUESTED` when the request wasn't a virtual model) → `TRIED <model this attempt called>`.
- Walking the tabs of a multi-leg chain keeps the source chip constant while the tried model changes per leg — the failover sweep is visible step by step.
- The strip follows the existing `single` rule: with one attempt (success or failure) the pane hides seq/kind/status **and** the strip — the row's model column already names it.
- Entries recorded before per-attempt model capture (empty `model`, `"-"` placeholder) render no strip instead of a placeholder.
- Long model names truncate with ellipsis; both chips carry a `title` with the full value, so a truncated model is still discoverable on hover.

## Contract

- `web/dashboard/tests/audit-list.test.js` — a 3-attempt chain exposes `{label, source, tried}` on every response pane; an alias-resolved entry uses `label: "virtual"` and prefers `requested_model`; a non-aliased entry falls back to top-level `entry.model` before the request body; a lone successful attempt collapses to the plain response tab with no strip; a lone failed attempt keeps the per-attempt tab but hides the strip; an entry whose first attempt predates model capture renders no strip on that pane while a later pane with a captured model still shows one.

## Tests

- `npm test` in `web/dashboard`: 604 pass.
- `npm run check`: svelte-check reports 0 errors, 0 warnings.
- No Go changes; `gofmt`/`go vet` not applicable to the diff.
- Not covered: visual rendering of the strip — the pane data is pure and tested; the strip is presentational markup only.

## Follow-up

- **Attempt-chain summary** near the metadata strip (`tried: a (503) → b (400) → c (served)`) — holds until the pane strip proves useful; graduates when it does.
- **Surfacing the chain on the pipeline chart** — green-tail block on the Failover node; tracked separately.
- **Browser-level e2e** for the audit panes.

---

_This PR description was generated with [AI assistance](https://raw.githubusercontent.com/tdhopper/dotfiles2.0/master/.claude/skills/creating-pull-requests/SKILL.md)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Audit log failover attempts now display a model strip showing the requested or virtual model and the concrete model that was tried.
  - Multi-attempt response panes provide clearer per-attempt model details.
  - Model information is shown only when relevant, keeping single-attempt and legacy entries unchanged.
  - Select model chips to copy the full model name, with accessible labels and localized messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->