### PR TITLE
fix(gemini): preserve function-call thought signatures across the round trip

### DIFF
--- a/docs/providers/gemini.mdx
+++ b/docs/providers/gemini.mdx
@@ -89,6 +89,38 @@ Flash reject `minimal`, so GoModel sends the lowest level those models accept
 instead of surfacing Google's 400. An explicit
 `extra_body.google.thinking_config` is always forwarded unchanged.
 
+## Tool calling and thought signatures
+
+Gemini returns a `thoughtSignature` alongside the function call it emits, and
+Gemini 3 requires that signature back, unchanged, on the same function call
+when the conversation history is sent again. A missing one fails the whole
+request with `400 Function call is missing a thought_signature in functionCall
+parts`.
+
+The OpenAI-compatible API has no field for it, so GoModel carries the signature
+on the tool call in `extra_content`, the same member Google's own
+OpenAI-compatible endpoint uses:
+
+```json
+{
+  "id": "call_1",
+  "type": "function",
+  "function": { "name": "ExecCommand", "arguments": "{\"cmd\":\"ls\"}" },
+  "extra_content": { "google": { "thought_signature": "..." } }
+}
+```
+
+Replay the assistant message (or, on the Responses API, the `function_call`
+item) exactly as GoModel returned it and multi-step tool calling works with no
+client change — most agent frameworks already echo tool calls back verbatim.
+Streaming carries the same member on the tool-call delta. Signatures sent as a
+flat `thought_signature` on the tool call are accepted too, so clients built
+against other gateways keep working.
+
+Signatures Gemini attaches to plain text parts are not replayed; Google
+validates those leniently, so they cost some reasoning continuity but never
+fail a request.
+
 ## Sampling parameters on Gemini 3
 
 Google's Gemini 3 migration guides say to remove `temperature`, `top_p` and
@@ -118,3 +150,4 @@ first and send the bytes to `generateContent`.
 
 - [Gemini image understanding](https://ai.google.dev/gemini-api/docs/image-understanding)
 - [Gemini OpenAI compatibility](https://ai.google.dev/gemini-api/docs/openai)
+- [Gemini thought signatures](https://ai.google.dev/gemini-api/docs/generate-content/thought-signatures)

--- a/internal/providers/gemini/native.go
+++ b/internal/providers/gemini/native.go
@@ -211,11 +211,17 @@ func geminiPartsFromMessage(msg core.Message) ([]geminiPart, error) {
 			if len(args) == 0 {
 				args = json.RawMessage(`{}`)
 			}
-			parts = append(parts, geminiPart{FunctionCall: &geminiFunctionCall{
-				ID:   call.ID,
-				Name: call.Function.Name,
-				Args: args,
-			}})
+			parts = append(parts, geminiPart{
+				FunctionCall: &geminiFunctionCall{
+					ID:   call.ID,
+					Name: call.Function.Name,
+					Args: args,
+				},
+				// Gemini 3 rejects a replayed functionCall part whose
+				// thoughtSignature is missing, so restore it to the same part
+				// it was returned on.
+				ThoughtSignature: toolCallThoughtSignature(call),
+			})
 		}
 		return parts, nil
 	}
@@ -848,6 +854,9 @@ func openAIMessageFromGeminiParts(parts []geminiPart) (string, []core.ToolCall) 
 					Name:      call.Name,
 					Arguments: args,
 				},
+				// The signature sits next to the functionCall in the same
+				// part; keep it with the tool call so the client can replay it.
+				ExtraFields: thoughtSignatureExtraFields(part.ThoughtSignature),
 			})
 		}
 	}

--- a/internal/providers/gemini/native_stream.go
+++ b/internal/providers/gemini/native_stream.go
@@ -219,7 +219,7 @@ func (s *geminiStreamState) choiceState(index int) *geminiChoiceStreamState {
 func streamToolCalls(toolCalls []core.ToolCall) []map[string]any {
 	out := make([]map[string]any, 0, len(toolCalls))
 	for i, call := range toolCalls {
-		out = append(out, map[string]any{
+		delta := map[string]any{
 			"index": i,
 			"id":    call.ID,
 			"type":  "function",
@@ -227,7 +227,13 @@ func streamToolCalls(toolCalls []core.ToolCall) []map[string]any {
 				"name":      call.Function.Name,
 				"arguments": call.Function.Arguments,
 			},
-		})
+		}
+		// Streamed tool calls carry the thought signature too: an agent that
+		// replays a streamed turn needs it just as much as a buffered one.
+		if extra := call.ExtraFields.Lookup(extraContentField); len(extra) > 0 {
+			delta[extraContentField] = extra
+		}
+		out = append(out, delta)
 	}
 	return out
 }

--- a/internal/providers/gemini/native_thought_signature_test.go
+++ b/internal/providers/gemini/native_thought_signature_test.go
@@ -1,0 +1,238 @@
+package gemini
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-json"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+// signatureFromResponseToolCall reads the signature back off a tool call the
+// way a client sees it: through the marshaled OpenAI-compatible JSON.
+func signatureFromResponseToolCall(t *testing.T, call core.ToolCall) string {
+	t.Helper()
+	body, err := json.Marshal(call)
+	if err != nil {
+		t.Fatalf("Marshal(tool call) error = %v", err)
+	}
+	var decoded struct {
+		ExtraContent struct {
+			Google struct {
+				ThoughtSignature string `json:"thought_signature"`
+			} `json:"google"`
+		} `json:"extra_content"`
+	}
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("Unmarshal(%s) error = %v", body, err)
+	}
+	return decoded.ExtraContent.Google.ThoughtSignature
+}
+
+func TestOpenAIMessageFromGeminiParts_KeepsThoughtSignature(t *testing.T) {
+	tests := []struct {
+		name  string
+		parts []geminiPart
+		want  []string
+	}{
+		{
+			name: "single call",
+			parts: []geminiPart{
+				{Text: "looking that up"},
+				{FunctionCall: &geminiFunctionCall{Name: "ExecCommand", Args: json.RawMessage(`{"cmd":"ls"}`)}, ThoughtSignature: "sig-1"},
+			},
+			want: []string{"sig-1"},
+		},
+		{
+			name: "parallel calls carry the signature only on the first",
+			parts: []geminiPart{
+				{FunctionCallAlt: &geminiFunctionCall{Name: "ExecCommand"}, ThoughtSignature: "sig-1"},
+				{FunctionCallAlt: &geminiFunctionCall{Name: "ReadFile"}},
+			},
+			want: []string{"sig-1", ""},
+		},
+		{
+			name:  "call without a signature stays plain",
+			parts: []geminiPart{{FunctionCall: &geminiFunctionCall{Name: "ExecCommand"}}},
+			want:  []string{""},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, toolCalls := openAIMessageFromGeminiParts(tc.parts)
+			if len(toolCalls) != len(tc.want) {
+				t.Fatalf("tool calls = %d, want %d", len(toolCalls), len(tc.want))
+			}
+			for i, want := range tc.want {
+				if got := signatureFromResponseToolCall(t, toolCalls[i]); got != want {
+					t.Fatalf("tool call %d signature = %q, want %q", i, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestOpenAIMessageFromGeminiParts_UnsignedToolCallOmitsExtraContent(t *testing.T) {
+	_, toolCalls := openAIMessageFromGeminiParts([]geminiPart{
+		{FunctionCall: &geminiFunctionCall{ID: "call_1", Name: "ExecCommand", Args: json.RawMessage(`{}`)}},
+	})
+	body, err := json.Marshal(toolCalls[0])
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if strings.Contains(string(body), "extra_content") {
+		t.Fatalf("tool call JSON = %s, want no extra_content member", body)
+	}
+}
+
+// A client replaying the gateway's own assistant message must reach Gemini
+// with the signature back on the functionCall part it was returned on;
+// Gemini 3 answers HTTP 400 otherwise.
+func TestConvertChatRequestToGemini_RestoresThoughtSignature(t *testing.T) {
+	tests := []struct {
+		name     string
+		toolCall string
+		want     string
+	}{
+		{
+			name:     "extra_content spelling",
+			toolCall: `{"id":"call_1","type":"function","function":{"name":"ExecCommand","arguments":"{\"cmd\":\"ls\"}"},"extra_content":{"google":{"thought_signature":"sig-1"}}}`,
+			want:     "sig-1",
+		},
+		{
+			name:     "flat snake_case spelling",
+			toolCall: `{"id":"call_1","type":"function","function":{"name":"ExecCommand","arguments":"{}"},"thought_signature":"sig-1"}`,
+			want:     "sig-1",
+		},
+		{
+			name:     "flat camelCase spelling",
+			toolCall: `{"id":"call_1","type":"function","function":{"name":"ExecCommand","arguments":"{}"},"thoughtSignature":"sig-1"}`,
+			want:     "sig-1",
+		},
+		{
+			name:     "signature nested on the function object",
+			toolCall: `{"id":"call_1","type":"function","function":{"name":"ExecCommand","arguments":"{}","thought_signature":"sig-1"}}`,
+			want:     "sig-1",
+		},
+		{
+			name:     "no signature",
+			toolCall: `{"id":"call_1","type":"function","function":{"name":"ExecCommand","arguments":"{}"}}`,
+			want:     "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var req core.ChatRequest
+			body := `{"model":"gemini-3-pro-preview","messages":[` +
+				`{"role":"user","content":"list the files"},` +
+				`{"role":"assistant","content":null,"tool_calls":[` + tc.toolCall + `]},` +
+				`{"role":"tool","tool_call_id":"call_1","content":"ok"}]}`
+			if err := json.Unmarshal([]byte(body), &req); err != nil {
+				t.Fatalf("Unmarshal() error = %v", err)
+			}
+
+			out, err := convertChatRequestToGemini(&req)
+			if err != nil {
+				t.Fatalf("convertChatRequestToGemini() error = %v", err)
+			}
+			if len(out.Contents) != 3 {
+				t.Fatalf("contents = %d, want 3", len(out.Contents))
+			}
+			model := out.Contents[1]
+			if len(model.Parts) != 1 || model.Parts[0].FunctionCall == nil {
+				t.Fatalf("model parts = %#v, want one functionCall part", model.Parts)
+			}
+			if got := model.Parts[0].ThoughtSignature; got != tc.want {
+				t.Fatalf("thoughtSignature = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestConvertChatRequestToGemini_ThoughtSignatureOnTheWire(t *testing.T) {
+	var req core.ChatRequest
+	body := `{"model":"gemini-3-pro-preview","messages":[` +
+		`{"role":"user","content":"list the files"},` +
+		`{"role":"assistant","content":null,"tool_calls":[` +
+		`{"id":"call_1","type":"function","function":{"name":"ExecCommand","arguments":"{}"},` +
+		`"extra_content":{"google":{"thought_signature":"sig-1"}}}]}]}`
+	if err := json.Unmarshal([]byte(body), &req); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	out, err := convertChatRequestToGemini(&req)
+	if err != nil {
+		t.Fatalf("convertChatRequestToGemini() error = %v", err)
+	}
+	encoded, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if !strings.Contains(string(encoded), `"thoughtSignature":"sig-1"`) {
+		t.Fatalf("request body = %s, want thoughtSignature next to the functionCall", encoded)
+	}
+}
+
+// The gateway's own response must replay cleanly: convert a Gemini answer to
+// the OpenAI shape, hand it back as history, and the signature must land on
+// the same part it arrived on.
+func TestGeminiThoughtSignatureRoundTrip(t *testing.T) {
+	upstream := `{"candidates":[{"content":{"role":"model","parts":[` +
+		`{"functionCall":{"name":"ExecCommand","args":{"cmd":"ls"}},"thoughtSignature":"sig-1"},` +
+		`{"functionCall":{"name":"ReadFile","args":{"path":"go.mod"}}}` +
+		`]},"finishReason":"STOP"}]}`
+	var geminiResp geminiGenerateContentResponse
+	if err := json.Unmarshal([]byte(upstream), &geminiResp); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	resp, err := nativeChatResponse(&core.ChatRequest{Model: "gemini-3-pro-preview"}, &geminiResp, "gemini")
+	if err != nil {
+		t.Fatalf("nativeChatResponse() error = %v", err)
+	}
+
+	// The client echoes the assistant message back as chat history.
+	assistant, err := json.Marshal(resp.Choices[0].Message)
+	if err != nil {
+		t.Fatalf("Marshal(message) error = %v", err)
+	}
+	var replay core.ChatRequest
+	replayBody := `{"model":"gemini-3-pro-preview","messages":[{"role":"user","content":"list the files"},` +
+		string(assistant) + `]}`
+	if err := json.Unmarshal([]byte(replayBody), &replay); err != nil {
+		t.Fatalf("Unmarshal(replay) error = %v", err)
+	}
+
+	out, err := convertChatRequestToGemini(&replay)
+	if err != nil {
+		t.Fatalf("convertChatRequestToGemini() error = %v", err)
+	}
+	parts := out.Contents[1].Parts
+	if len(parts) != 2 {
+		t.Fatalf("model parts = %#v, want two functionCall parts", parts)
+	}
+	if parts[0].ThoughtSignature != "sig-1" {
+		t.Fatalf("first part signature = %q, want %q", parts[0].ThoughtSignature, "sig-1")
+	}
+	if parts[1].ThoughtSignature != "" {
+		t.Fatalf("second part signature = %q, want none", parts[1].ThoughtSignature)
+	}
+}
+
+func TestGeminiNativeStream_KeepsThoughtSignature(t *testing.T) {
+	upstream := "data: " + `{"candidates":[{"content":{"role":"model","parts":[` +
+		`{"functionCall":{"name":"ExecCommand","args":{"cmd":"ls"}},"thoughtSignature":"sig-1"}` +
+		`]},"finishReason":"STOP","index":0}],"responseId":"resp-1"}` + "\n\n"
+
+	stream := newGeminiNativeStream(io.NopCloser(strings.NewReader(upstream)), "gemini-3-pro-preview", false, "gemini")
+	defer func() { _ = stream.Close() }()
+	raw, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if !strings.Contains(string(raw), `"extra_content":{"google":{"thought_signature":"sig-1"}}`) {
+		t.Fatalf("stream = %s, want the tool call delta to carry extra_content", raw)
+	}
+}

--- a/internal/providers/gemini/thought_signature.go
+++ b/internal/providers/gemini/thought_signature.go
@@ -1,0 +1,79 @@
+package gemini
+
+import (
+	"github.com/goccy/go-json"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+// Gemini attaches a thoughtSignature to the part that carries a functionCall.
+// Gemini 3 validates it strictly: replaying a functionCall part without the
+// signature it was returned with fails the whole request with HTTP 400
+// ("Function call is missing a thought_signature in functionCall parts").
+//
+// The OpenAI-compatible surface has no field for it, so the signature travels
+// on the tool call as extra_content.google.thought_signature — the same member
+// Google's own OpenAI-compatible endpoint uses, so clients that already
+// round-trip Gemini tool calls need no change.
+const (
+	extraContentField     = "extra_content"
+	thoughtSignatureField = "thought_signature"
+)
+
+// geminiExtraContent is the extra_content payload shape: a per-vendor object
+// holding fields with no OpenAI-compatible equivalent.
+type geminiExtraContent struct {
+	Google struct {
+		ThoughtSignature string `json:"thought_signature,omitempty"`
+	} `json:"google"`
+}
+
+// toolCallThoughtSignature reads the signature a client replayed with an
+// assistant tool call. The canonical spelling is
+// extra_content.google.thought_signature; a flat thought_signature (either
+// case) on the tool call or on its function object is accepted too, because
+// other gateways and SDKs emit the signature that way.
+func toolCallThoughtSignature(call core.ToolCall) string {
+	for _, fields := range [...]core.UnknownJSONFields{call.ExtraFields, call.Function.ExtraFields} {
+		if signature := thoughtSignatureFromFields(fields); signature != "" {
+			return signature
+		}
+	}
+	return ""
+}
+
+func thoughtSignatureFromFields(fields core.UnknownJSONFields) string {
+	if raw := fields.Lookup(extraContentField); len(raw) > 0 {
+		var extra geminiExtraContent
+		if err := json.Unmarshal(raw, &extra); err == nil && extra.Google.ThoughtSignature != "" {
+			return extra.Google.ThoughtSignature
+		}
+	}
+	for _, key := range [...]string{thoughtSignatureField, "thoughtSignature"} {
+		raw := fields.Lookup(key)
+		if len(raw) == 0 {
+			continue
+		}
+		var signature string
+		if err := json.Unmarshal(raw, &signature); err == nil && signature != "" {
+			return signature
+		}
+	}
+	return ""
+}
+
+// thoughtSignatureExtraFields returns the tool-call extras that carry signature
+// back to the client. An empty signature leaves the extras untouched so tool
+// calls without one stay byte-identical to before.
+func thoughtSignatureExtraFields(signature string) core.UnknownJSONFields {
+	if signature == "" {
+		return core.UnknownJSONFields{}
+	}
+	var extra geminiExtraContent
+	extra.Google.ThoughtSignature = signature
+	payload, err := json.Marshal(extra)
+	if err != nil {
+		return core.UnknownJSONFields{}
+	}
+	return core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{extraContentField: payload})
+}

--- a/internal/providers/responses_converter.go
+++ b/internal/providers/responses_converter.go
@@ -85,9 +85,13 @@ type responsesStreamUsage struct {
 }
 
 type openAIChunkToolCall struct {
-	Index    *int   `json:"index"`
-	ID       string `json:"id"`
-	Function struct {
+	Index *int   `json:"index"`
+	ID    string `json:"id"`
+	// ExtraContent relays provider tool-call state with no OpenAI-compatible
+	// field (Gemini's function-call thought signature) onto the function_call
+	// item, so a Responses client can replay the turn.
+	ExtraContent json.RawMessage `json:"extra_content"`
+	Function     struct {
 		Name      string `json:"name"`
 		Arguments string `json:"arguments"`
 	} `json:"function"`
@@ -209,6 +213,9 @@ func (sc *OpenAIResponsesStreamConverter) handleToolCallDeltas(toolCalls []openA
 		}
 		if toolCall.Function.Name != "" {
 			state.Name = toolCall.Function.Name
+		}
+		if len(toolCall.ExtraContent) > 0 {
+			state.ExtraContent = toolCall.ExtraContent
 		}
 
 		arguments := toolCall.Function.Arguments
@@ -350,6 +357,11 @@ func chunkToolCallsFromAny(items []any) []openAIChunkToolCall {
 		}
 		call := openAIChunkToolCall{Index: &index}
 		call.ID, _ = toolCall["id"].(string)
+		if extra, ok := toolCall["extra_content"]; ok && extra != nil {
+			if raw, err := json.Marshal(extra); err == nil {
+				call.ExtraContent = raw
+			}
+		}
 		if function, ok := toolCall["function"].(map[string]any); ok {
 			call.Function.Name, _ = function["name"].(string)
 			call.Function.Arguments, _ = function["arguments"].(string)

--- a/internal/providers/responses_output.go
+++ b/internal/providers/responses_output.go
@@ -159,15 +159,37 @@ func BuildResponsesOutputItems(msg core.ResponseMessage) []core.ResponsesOutputI
 	for _, toolCall := range msg.ToolCalls {
 		callID := ResponsesFunctionCallCallID(toolCall.ID)
 		output = append(output, core.ResponsesOutputItem{
-			ID:        ResponsesFunctionCallItemID(callID),
-			Type:      "function_call",
-			Status:    "completed",
-			CallID:    callID,
-			Name:      toolCall.Function.Name,
-			Arguments: toolCall.Function.Arguments,
+			ID:          ResponsesFunctionCallItemID(callID),
+			Type:        "function_call",
+			Status:      "completed",
+			CallID:      callID,
+			Name:        toolCall.Function.Name,
+			Arguments:   toolCall.Function.Arguments,
+			ExtraFields: ToolCallExtraContent(toolCall.ExtraFields),
 		})
 	}
 	return output
+}
+
+// toolCallExtraContentField is the OpenAI-compatible member holding
+// provider-specific tool-call state, as used by Google's own OpenAI-compatible
+// endpoint (extra_content.google.thought_signature).
+const toolCallExtraContentField = "extra_content"
+
+// ToolCallExtraContent isolates the extra_content member of a chat tool call:
+// provider state with no OpenAI-compatible field that the provider needs back
+// verbatim on the next turn, such as Gemini's function-call thought signature.
+// Responses clients replay function_call items rather than chat messages, so
+// the member has to survive the translation in both directions; the input side
+// already carries unknown item members onto the tool call. The other unknown
+// members of a function_call item are item metadata, not provider state, so
+// only extra_content is forwarded.
+func ToolCallExtraContent(fields core.UnknownJSONFields) core.UnknownJSONFields {
+	raw := fields.Lookup(toolCallExtraContentField)
+	if len(raw) == 0 {
+		return core.UnknownJSONFields{}
+	}
+	return core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{toolCallExtraContentField: raw})
 }
 
 func responseMessageReasoningContent(msg core.ResponseMessage) string {

--- a/internal/providers/responses_output_state.go
+++ b/internal/providers/responses_output_state.go
@@ -12,10 +12,14 @@ import (
 
 // ResponsesOutputToolCallState tracks one function_call item in a Responses stream.
 type ResponsesOutputToolCallState struct {
-	ItemID            string
-	CallID            string
-	Name              string
-	OutputIndex       int
+	ItemID      string
+	CallID      string
+	Name        string
+	OutputIndex int
+	// ExtraContent is the streamed tool call's extra_content member: provider
+	// state the next turn has to replay verbatim, such as Gemini's
+	// function-call thought signature.
+	ExtraContent      json.RawMessage
 	Arguments         strings.Builder
 	Started           bool
 	Completed         bool
@@ -303,7 +307,7 @@ func (s *ResponsesOutputEventState) RenderToolCallItem(state *ResponsesOutputToo
 	if includePlaceholder {
 		arguments = s.ToolCallArguments(state)
 	}
-	return map[string]any{
+	item := map[string]any{
 		"id":        state.ItemID,
 		"type":      "function_call",
 		"status":    status,
@@ -311,6 +315,10 @@ func (s *ResponsesOutputEventState) RenderToolCallItem(state *ResponsesOutputToo
 		"name":      state.Name,
 		"arguments": arguments,
 	}
+	if len(state.ExtraContent) > 0 {
+		item["extra_content"] = state.ExtraContent
+	}
+	return item
 }
 
 // StartToolCall emits the function_call output_item.added event once the item metadata is available.

--- a/internal/providers/responses_tool_call_extra_test.go
+++ b/internal/providers/responses_tool_call_extra_test.go
@@ -1,0 +1,139 @@
+package providers
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+const thoughtSignatureExtra = `{"google":{"thought_signature":"sig-1"}}`
+
+// Gemini's function-call thought signature has to survive the chat/Responses
+// translation: a Responses client replays function_call items, and Gemini 3
+// answers HTTP 400 when a replayed functionCall part has lost its signature.
+func TestBuildResponsesOutputItems_KeepsToolCallExtraContent(t *testing.T) {
+	items := BuildResponsesOutputItems(core.ResponseMessage{
+		Role: "assistant",
+		ToolCalls: []core.ToolCall{
+			{
+				ID:       "call_1",
+				Type:     "function",
+				Function: core.FunctionCall{Name: "ExecCommand", Arguments: `{"cmd":"ls"}`},
+				ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+					"extra_content": json.RawMessage(thoughtSignatureExtra),
+				}),
+			},
+			{
+				ID:       "call_2",
+				Type:     "function",
+				Function: core.FunctionCall{Name: "ReadFile", Arguments: `{}`},
+			},
+		},
+	})
+
+	if len(items) != 2 {
+		t.Fatalf("output items = %#v, want two function_call items", items)
+	}
+	signed, err := json.Marshal(items[0])
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if !strings.Contains(string(signed), `"extra_content":`+thoughtSignatureExtra) {
+		t.Fatalf("function_call item = %s, want extra_content preserved", signed)
+	}
+	unsigned, err := json.Marshal(items[1])
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if strings.Contains(string(unsigned), "extra_content") {
+		t.Fatalf("function_call item = %s, want no extra_content member", unsigned)
+	}
+}
+
+func TestToolCallExtraContent_DropsUnrelatedMembers(t *testing.T) {
+	fields := core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+		"extra_content": json.RawMessage(thoughtSignatureExtra),
+		"status":        json.RawMessage(`"completed"`),
+	})
+
+	out := ToolCallExtraContent(fields)
+	if out.Lookup("status") != nil {
+		t.Fatalf("extras = %v, want item metadata dropped", out)
+	}
+	if string(out.Lookup("extra_content")) != thoughtSignatureExtra {
+		t.Fatalf("extra_content = %s, want %s", out.Lookup("extra_content"), thoughtSignatureExtra)
+	}
+}
+
+// A Responses client sends the signed function_call item back as input; the
+// signature must reach the provider on the chat tool call.
+func TestConvertResponsesToChat_KeepsFunctionCallExtraContent(t *testing.T) {
+	inputs := []any{
+		map[string]any{"type": "message", "role": "user", "content": "list the files"},
+		map[string]any{
+			"type":          "function_call",
+			"call_id":       "call_1",
+			"name":          "ExecCommand",
+			"arguments":     `{"cmd":"ls"}`,
+			"extra_content": map[string]any{"google": map[string]any{"thought_signature": "sig-1"}},
+		},
+	}
+	for _, name := range []string{"map input", "typed input"} {
+		t.Run(name, func(t *testing.T) {
+			input := any(inputs)
+			if name == "typed input" {
+				encoded, err := json.Marshal(inputs)
+				if err != nil {
+					t.Fatalf("Marshal() error = %v", err)
+				}
+				var elements []core.ResponsesInputElement
+				if err := json.Unmarshal(encoded, &elements); err != nil {
+					t.Fatalf("Unmarshal() error = %v", err)
+				}
+				input = elements
+			}
+
+			chat, err := ConvertResponsesRequestToChat(&core.ResponsesRequest{Model: "gemini-3-pro-preview", Input: input})
+			if err != nil {
+				t.Fatalf("ConvertResponsesRequestToChat() error = %v", err)
+			}
+			var toolCall *core.ToolCall
+			for i := range chat.Messages {
+				if len(chat.Messages[i].ToolCalls) > 0 {
+					toolCall = &chat.Messages[i].ToolCalls[0]
+				}
+			}
+			if toolCall == nil {
+				t.Fatalf("messages = %#v, want an assistant tool call", chat.Messages)
+			}
+			if got := string(toolCall.ExtraFields.Lookup("extra_content")); got != thoughtSignatureExtra {
+				t.Fatalf("extra_content = %s, want %s", got, thoughtSignatureExtra)
+			}
+		})
+	}
+}
+
+// The streamed Responses surface emits the same function_call items, so the
+// signature has to ride along there too.
+func TestResponsesStreamConverter_KeepsToolCallExtraContent(t *testing.T) {
+	chunks := strings.Join([]string{
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function",` +
+			`"function":{"name":"ExecCommand","arguments":"{\"cmd\":\"ls\"}"},` +
+			`"extra_content":{"google":{"thought_signature":"sig-1"}}}]},"finish_reason":null}]}`,
+		`data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}`,
+		"data: [DONE]",
+		"",
+	}, "\n\n")
+
+	converter := NewOpenAIResponsesStreamConverter(io.NopCloser(strings.NewReader(chunks)), "gemini-3-pro-preview", "gemini")
+	out, err := io.ReadAll(converter)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if count := strings.Count(string(out), `"extra_content":{"google":{"thought_signature":"sig-1"}}`); count == 0 {
+		t.Fatalf("stream = %s, want function_call items to carry extra_content", out)
+	}
+}

--- a/tests/e2e/gemini_native_tools_test.go
+++ b/tests/e2e/gemini_native_tools_test.go
@@ -1,0 +1,289 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/llmclient"
+	"github.com/enterpilot/gomodel/internal/providers"
+	"github.com/enterpilot/gomodel/internal/providers/gemini"
+)
+
+const geminiToolModel = "gemini-3-pro-preview"
+
+// mockGeminiNativeServer stands in for Gemini's native generateContent API and
+// enforces the rule Gemini 3 enforces: a functionCall part replayed in the
+// conversation history must carry back the thoughtSignature it was returned
+// with, or the whole request fails with HTTP 400.
+type mockGeminiNativeServer struct {
+	server   *httptest.Server
+	requests [][]byte
+}
+
+func newMockGeminiNativeServer(t *testing.T) *mockGeminiNativeServer {
+	t.Helper()
+
+	mock := &mockGeminiNativeServer{}
+	mock.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet && r.URL.Path == "/models" {
+			_, _ = fmt.Fprintf(w, `{"models":[{"name":"models/%s","supportedGenerationMethods":["generateContent","streamGenerateContent"]}]}`, geminiToolModel)
+			return
+		}
+		if !strings.HasSuffix(r.URL.Path, ":generateContent") {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"code":404,"message":"not found"}}`))
+			return
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		mock.requests = append(mock.requests, body)
+
+		position, ok := unsignedFunctionCallPosition(t, body)
+		if !ok {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = fmt.Fprintf(w, `{"error":{"code":400,"status":"INVALID_ARGUMENT","message":`+
+				`"Function call is missing a thought_signature in functionCall parts. This is required for tools to work correctly, `+
+				`and missing thought_signature may lead to degraded model performance. Additional data, function call `+
+				`default_api:ExecCommand, position %d."}}`, position)
+			return
+		}
+
+		if requestHasToolResult(t, body) {
+			_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"go.mod is there."}]},` +
+				`"finishReason":"STOP","index":0}],"usageMetadata":{"promptTokenCount":9,"candidatesTokenCount":5,"totalTokenCount":14},` +
+				`"responseId":"resp-2"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[` +
+			`{"functionCall":{"name":"ExecCommand","args":{"cmd":"ls"}},"thoughtSignature":"sig-e2e-1"}` +
+			`]},"finishReason":"STOP","index":0}],"usageMetadata":{"promptTokenCount":7,"candidatesTokenCount":11,"totalTokenCount":18},` +
+			`"responseId":"resp-1"}`))
+	}))
+	t.Cleanup(mock.server.Close)
+	return mock
+}
+
+// geminiRequestBody is the slice of the native request the signature rule
+// applies to.
+type geminiRequestBody struct {
+	Contents []struct {
+		Role  string `json:"role"`
+		Parts []struct {
+			FunctionCall     json.RawMessage `json:"functionCall"`
+			FunctionResponse json.RawMessage `json:"functionResponse"`
+			ThoughtSignature string          `json:"thoughtSignature"`
+		} `json:"parts"`
+	} `json:"contents"`
+}
+
+func decodeGeminiRequest(t *testing.T, body []byte) geminiRequestBody {
+	t.Helper()
+	var decoded geminiRequestBody
+	require.NoError(t, json.Unmarshal(body, &decoded), "upstream request body: %s", body)
+	return decoded
+}
+
+// unsignedFunctionCallPosition reports the part position of the first replayed
+// functionCall without a thoughtSignature, mirroring Gemini 3's validation.
+func unsignedFunctionCallPosition(t *testing.T, body []byte) (int, bool) {
+	t.Helper()
+	position := 0
+	for _, content := range decodeGeminiRequest(t, body).Contents {
+		for _, part := range content.Parts {
+			if len(part.FunctionCall) > 0 && part.ThoughtSignature == "" {
+				return position, false
+			}
+			position++
+		}
+	}
+	return 0, true
+}
+
+func requestHasToolResult(t *testing.T, body []byte) bool {
+	t.Helper()
+	for _, content := range decodeGeminiRequest(t, body).Contents {
+		for _, part := range content.Parts {
+			if len(part.FunctionResponse) > 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func setupGeminiNativeGateway(t *testing.T) (*httptest.Server, *mockGeminiNativeServer) {
+	t.Helper()
+
+	t.Setenv("USE_GOOGLE_GEMINI_NATIVE_API", "true")
+	upstream := newMockGeminiNativeServer(t)
+
+	provider := gemini.NewWithHTTPClient("sk-test-gemini-key", upstream.server.Client(), llmclient.Hooks{})
+	provider.SetBaseURL(upstream.server.URL)
+	provider.SetModelsURL(upstream.server.URL)
+
+	registry := providers.NewModelRegistry()
+	registry.RegisterProviderWithType(provider, "gemini")
+	require.NoError(t, registry.Initialize(context.Background()))
+
+	gateway := httptest.NewServer(setupE2EServer(t, e2eServerOptions{registry: registry}))
+	t.Cleanup(gateway.Close)
+	return gateway, upstream
+}
+
+func postGeminiChat(t *testing.T, gateway *httptest.Server, payload any) (*http.Response, []byte) {
+	t.Helper()
+
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+	resp, err := gateway.Client().Post(gateway.URL+chatCompletionsPath, "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer closeBody(resp)
+	responseBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp, responseBody
+}
+
+// A multi-step agent turn: the client replays the assistant tool call the
+// gateway handed it, and the second request must reach Gemini with the
+// function call's thought signature intact.
+func TestGeminiNativeToolCallsPreserveThoughtSignature(t *testing.T) {
+	gateway, upstream := setupGeminiNativeGateway(t)
+
+	tools := []map[string]any{{
+		"type": "function",
+		"function": map[string]any{
+			"name":        "ExecCommand",
+			"description": "Run a shell command.",
+			"parameters": map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"cmd": map[string]any{"type": "string"}},
+				"required":   []string{"cmd"},
+			},
+		},
+	}}
+
+	resp, body := postGeminiChat(t, gateway, map[string]any{
+		"model":    geminiToolModel,
+		"messages": []map[string]any{{"role": "user", "content": "is go.mod there?"}},
+		"tools":    tools,
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode, "first turn: %s", body)
+
+	var first core.ChatResponse
+	require.NoError(t, json.Unmarshal(body, &first))
+	require.Len(t, first.Choices, 1)
+	require.Len(t, first.Choices[0].Message.ToolCalls, 1)
+
+	// The client replays the assistant message exactly as the gateway
+	// returned it — the only history an OpenAI-compatible agent has.
+	var assistant map[string]any
+	require.NoError(t, json.Unmarshal(mustMarshal(t, first.Choices[0].Message), &assistant))
+
+	resp, body = postGeminiChat(t, gateway, map[string]any{
+		"model": geminiToolModel,
+		"messages": []any{
+			map[string]any{"role": "user", "content": "is go.mod there?"},
+			assistant,
+			map[string]any{
+				"role":         "tool",
+				"tool_call_id": first.Choices[0].Message.ToolCalls[0].ID,
+				"content":      `{"stdout":"go.mod"}`,
+			},
+		},
+		"tools": tools,
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode, "second turn rejected upstream: %s", body)
+
+	require.Len(t, upstream.requests, 2)
+	replay := decodeGeminiRequest(t, upstream.requests[1])
+	require.Len(t, replay.Contents, 3)
+	modelParts := replay.Contents[1].Parts
+	require.Len(t, modelParts, 1)
+	require.NotEmpty(t, modelParts[0].FunctionCall)
+	assert.Equal(t, "sig-e2e-1", modelParts[0].ThoughtSignature,
+		"the replayed functionCall part lost its thought signature")
+}
+
+// The same round trip over the Responses API, where the client replays
+// function_call items instead of chat messages.
+func TestGeminiNativeResponsesToolCallsPreserveThoughtSignature(t *testing.T) {
+	gateway, upstream := setupGeminiNativeGateway(t)
+
+	tools := []map[string]any{{
+		"type":        "function",
+		"name":        "ExecCommand",
+		"description": "Run a shell command.",
+		"parameters": map[string]any{
+			"type":       "object",
+			"properties": map[string]any{"cmd": map[string]any{"type": "string"}},
+			"required":   []string{"cmd"},
+		},
+	}}
+
+	body, err := json.Marshal(map[string]any{
+		"model": geminiToolModel,
+		"input": "is go.mod there?",
+		"tools": tools,
+	})
+	require.NoError(t, err)
+	resp, err := gateway.Client().Post(gateway.URL+responsesPath, "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer closeBody(resp)
+	first, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "first turn: %s", first)
+
+	var firstResp struct {
+		Output []map[string]any `json:"output"`
+	}
+	require.NoError(t, json.Unmarshal(first, &firstResp))
+	var functionCall map[string]any
+	for _, item := range firstResp.Output {
+		if item["type"] == "function_call" {
+			functionCall = item
+		}
+	}
+	require.NotNil(t, functionCall, "output = %s, want a function_call item", first)
+
+	input := []any{
+		map[string]any{"type": "message", "role": "user", "content": "is go.mod there?"},
+		functionCall,
+		map[string]any{"type": "function_call_output", "call_id": functionCall["call_id"], "output": `{"stdout":"go.mod"}`},
+	}
+	body, err = json.Marshal(map[string]any{"model": geminiToolModel, "input": input, "tools": tools})
+	require.NoError(t, err)
+	resp, err = gateway.Client().Post(gateway.URL+responsesPath, "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer closeBody(resp)
+	second, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "second turn rejected upstream: %s", second)
+
+	require.Len(t, upstream.requests, 2)
+	replay := decodeGeminiRequest(t, upstream.requests[1])
+	require.Len(t, replay.Contents, 3)
+	require.Len(t, replay.Contents[1].Parts, 1)
+	assert.Equal(t, "sig-e2e-1", replay.Contents[1].Parts[0].ThoughtSignature,
+		"the replayed function_call item lost its thought signature")
+}
+
+func mustMarshal(t *testing.T, value any) []byte {
+	t.Helper()
+	body, err := json.Marshal(value)
+	require.NoError(t, err)
+	return body
+}

--- a/tests/e2e/release-e2e-scenarios.md
+++ b/tests/e2e/release-e2e-scenarios.md
@@ -155,11 +155,12 @@ Stateful note:
   defaults `OPENROUTER_MODEL_FILTER_INCLUDE` to `*:free`, which leaves models
   used by the rest of the matrix untouched; the scenario is read-only and
   rerunnable in any order
-- `S225`-`S227` cover recent release regressions: image content nested in an
+- `S225`-`S228` cover recent release regressions: image content nested in an
   Anthropic `tool_result`, time-window pricing merged with an operator override,
-  and tolerant admin listing of a virtual model with corrupt SQL timestamps.
-  They create and clean up their own artifacts and are rerunnable in any order;
-  `S227` reloads the SQLite gateway and therefore stays sequential
+  tolerant admin listing of a virtual model with corrupt SQL timestamps, and a
+  Gemini 3 multi-step tool call replaying its thought signature. They create and
+  clean up their own artifacts and are rerunnable in any order; `S227` reloads
+  the SQLite gateway and therefore stays sequential
 - `S218` exercises Gemini's native `batchEmbedContents` path (batch input,
   `dimensions`); read-only and rerunnable in any order
 - `S219` asserts the effective resilience configuration on
@@ -6105,4 +6106,47 @@ curl -fsS "$BASE_URL/admin/virtual-models" \
     ' >/dev/null
 cleanup_s227
 trap - EXIT
+```
+
+### S228 Gemini 3 multi-step tool call replays the thought signature
+
+Gemini 3 returns a thought signature on the function call it emits and rejects
+the next turn with HTTP 400 when the replayed call has lost it. This is the
+plain OpenAI-compatible agent loop: send tools, echo the assistant message back
+verbatim with the tool result, and the second turn must succeed.
+
+```bash
+TOOLS='[{"type":"function","function":{"name":"get_weather","description":"Get the current weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}]'
+FIRST_FILE="$QA_RUN_DIR/s228.turn1.json"
+SECOND_FILE="$QA_RUN_DIR/s228.turn2.json"
+PAYLOAD_FILE="$QA_RUN_DIR/s228.turn2.request.json"
+
+jq -n --argjson tools "$TOOLS" '{
+  model: "gemini-3.7-flash",
+  messages: [{role:"user", content:"What is the weather in Warsaw? Use the tool."}],
+  tools: $tools
+}' | curl -fsS "$BASE_URL/v1/chat/completions" -H 'Content-Type: application/json' -d @- > "$FIRST_FILE"
+
+# The signature rides on the tool call as extra_content.google.thought_signature.
+jq -e '
+  .provider == "gemini"
+  and .choices[0].finish_reason == "tool_calls"
+  and (.choices[0].message.tool_calls[0].function.name == "get_weather")
+  and (.choices[0].message.tool_calls[0].extra_content.google.thought_signature | type == "string" and length > 0)
+' "$FIRST_FILE" >/dev/null
+
+# Replay the assistant message exactly as returned, as an agent would.
+jq -n --argjson tools "$TOOLS" --slurpfile first "$FIRST_FILE" '{
+  model: "gemini-3.7-flash",
+  messages: [
+    {role:"user", content:"What is the weather in Warsaw? Use the tool."},
+    $first[0].choices[0].message,
+    {role:"tool", tool_call_id: $first[0].choices[0].message.tool_calls[0].id, content:"{\"temperature_c\":21}"}
+  ],
+  tools: $tools
+}' > "$PAYLOAD_FILE"
+curl -fsS "$BASE_URL/v1/chat/completions" -H 'Content-Type: application/json' \
+  -d @"$PAYLOAD_FILE" > "$SECOND_FILE"
+jq '{model,provider,finish_reason:.choices[0].finish_reason}' "$SECOND_FILE"
+jq -e '.provider == "gemini" and (.choices[0].message.content | type == "string" and length > 0)' "$SECOND_FILE" >/dev/null
 ```

--- a/tests/e2e/run-release-e2e.sh
+++ b/tests/e2e/run-release-e2e.sh
@@ -362,7 +362,8 @@ is_parallel_safe() {
     || (number >= 160 && number <= 162) \
     || (number >= 173 && number <= 191) \
     || (number >= 197 && number <= 204) \
-    || (number >= 208 && number <= 226) ))
+    || (number >= 208 && number <= 226) \
+    || number == 228 ))
 }
 
 if (( JOBS > 1 )); then


### PR DESCRIPTION
Gemini returns a thoughtSignature on the part carrying a functionCall and
Gemini 3 rejects the next turn with HTTP 400 when a replayed functionCall part
has lost it. The signature was dropped converting the native response to
OpenAI tool calls and never restored converting history back, so multi-step
agent runs failed once a tool call reached the history.

It now travels on the tool call as extra_content.google.thought_signature, the
member Google's own OpenAI-compatible endpoint uses, through the buffered and
streamed chat surfaces and the Responses API in both directions. A flat
thought_signature is accepted on input too.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011CneM5UC4k3TikAMgEvm8o

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Gemini tool calls now preserve thought signatures across requests, responses, streaming, and multi-step tool interactions.
  - OpenAI-compatible clients can provide and receive signatures through `extra_content.google.thought_signature` and supported flat formats.
  - Gemini 3 tool-call signatures are retained when replaying assistant messages.

- **Documentation**
  - Added guidance on Gemini tool calling and thought signatures, including a link to Google’s reference documentation.

- **Tests**
  - Added coverage for native, streaming, Responses API, and end-to-end Gemini 3 signature preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->