### PR TITLE
fix(gemini): preserve thought signatures across tool-call round trips

### DIFF
--- a/docs/providers/gemini.mdx
+++ b/docs/providers/gemini.mdx
@@ -99,6 +99,38 @@ therefore drops those four fields for Gemini 3 and later (`gemini-3-*`,
 Gemma and other models. `max_tokens`, `stop`, penalties, `response_format` and
 thinking settings are unaffected.
 
+## Thought signatures
+
+Gemini 3 attaches an encrypted `thoughtSignature` to the function calls it
+emits and rejects a follow-up request (HTTP 400, "Function call is missing a
+thought_signature") when that call comes back in the history without it. In
+native mode GoModel exposes the signature the same way Google's own
+OpenAI-compatible endpoint does, so a client that echoes assistant messages
+back unchanged keeps working:
+
+```json
+{
+  "role": "assistant",
+  "tool_calls": [{
+    "id": "call_1",
+    "type": "function",
+    "function": {"name": "lookup_weather", "arguments": "{\"city\":\"Warsaw\"}"},
+    "extra_content": {"google": {"thought_signature": "EvACCu0CARFNMg..."}}
+  }]
+}
+```
+
+The same `extra_content` member appears on streamed `tool_calls` deltas, on
+Responses API `function_call` output items, and (for text-only turns) on the
+assistant message itself. Send it back verbatim; only the first call of a
+parallel batch carries a signature.
+
+When a Gemini 3 history contains a function call without any signature (the
+conversation started on another model, or the client dropped the field),
+GoModel sends Google's documented `skip_thought_signature_validator`
+placeholder instead of surfacing the 400. Reasoning continuity is reduced for
+that turn, so prefer echoing the real signature.
+
 ## Image input
 
 | Mode | OpenAI-style `image_url` |

--- a/docs/providers/gemini.mdx
+++ b/docs/providers/gemini.mdx
@@ -123,7 +123,9 @@ back unchanged keeps working:
 The same `extra_content` member appears on streamed `tool_calls` deltas, on
 Responses API `function_call` output items, and (for text-only turns) on the
 assistant message itself. Send it back verbatim; only the first call of a
-parallel batch carries a signature.
+parallel batch carries a signature. A flat `thought_signature` (or
+`thoughtSignature`) on the tool call or its `function` object is accepted too,
+so clients built against other gateways keep working.
 
 When a Gemini 3 history contains a function call without any signature (the
 conversation started on another model, or the client dropped the field),

--- a/internal/providers/gemini/native.go
+++ b/internal/providers/gemini/native.go
@@ -74,6 +74,53 @@ type geminiFileData struct {
 	FileURI  string `json:"file_uri,omitempty"`
 }
 
+// Thought signatures cross the OpenAI-compatible API the way Google's own
+// OpenAI-compatible endpoint exposes them: a functionCall part's signature as
+// tool_calls[].extra_content.google.thought_signature and a text part's as
+// message.extra_content.google.thought_signature. Gemini 3 rejects (HTTP 400)
+// any functionCall in the history that comes back without its signature.
+const (
+	extraContentField = "extra_content"
+	// skipThoughtSignatureValidator is the placeholder Google documents for
+	// function calls that never had a signature: a history transferred from
+	// another model or a call injected by the client.
+	skipThoughtSignatureValidator = "skip_thought_signature_validator"
+)
+
+func thoughtSignatureExtraFields(signature string) core.UnknownJSONFields {
+	if signature == "" {
+		return core.UnknownJSONFields{}
+	}
+	encoded, err := json.Marshal(map[string]any{"google": map[string]any{"thought_signature": signature}})
+	if err != nil {
+		return core.UnknownJSONFields{}
+	}
+	return core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{extraContentField: encoded})
+}
+
+func thoughtSignatureFromExtraFields(fields core.UnknownJSONFields) string {
+	raw := fields.Lookup(extraContentField)
+	if len(raw) == 0 {
+		return ""
+	}
+	var extra struct {
+		Google struct {
+			ThoughtSignature string `json:"thought_signature"`
+		} `json:"google"`
+	}
+	if err := json.Unmarshal(raw, &extra); err != nil {
+		return ""
+	}
+	return extra.Google.ThoughtSignature
+}
+
+// requiresThoughtSignature reports whether Gemini validates that every
+// functionCall in the history carries a thought signature (Gemini 3 and later).
+func requiresThoughtSignature(model string) bool {
+	major, _, ok := geminiGeneration(model)
+	return ok && major >= 3
+}
+
 type geminiFunctionCall struct {
 	ID   string          `json:"id,omitempty"`
 	Name string          `json:"name,omitempty"`
@@ -151,6 +198,7 @@ func convertChatRequestToGemini(req *core.ChatRequest) (*geminiGenerateContentRe
 
 	systemParts := make([]geminiPart, 0)
 	toolCallNames := make(map[string]string)
+	signatureRequired := requiresThoughtSignature(req.Model)
 	for _, msg := range req.Messages {
 		var (
 			parts []geminiPart
@@ -159,7 +207,7 @@ func convertChatRequestToGemini(req *core.ChatRequest) (*geminiGenerateContentRe
 		if strings.TrimSpace(msg.Role) == "tool" {
 			parts, err = geminiPartsFromToolMessage(msg, toolCallNames[msg.ToolCallID])
 		} else {
-			parts, err = geminiPartsFromMessage(msg)
+			parts, err = geminiPartsFromMessage(msg, signatureRequired)
 		}
 		if err != nil {
 			return nil, err
@@ -200,27 +248,69 @@ func convertChatRequestToGemini(req *core.ChatRequest) (*geminiGenerateContentRe
 	return out, nil
 }
 
-func geminiPartsFromMessage(msg core.Message) ([]geminiPart, error) {
+// geminiPartsFromMessage converts a system, user or assistant message. With
+// signatureRequired set, assistant function calls that carry no thought
+// signature get Google's validator-skipping placeholder so a history that did
+// not originate from this Gemini model (another provider, a client that
+// dropped extra_content) is not rejected outright.
+func geminiPartsFromMessage(msg core.Message, signatureRequired bool) ([]geminiPart, error) {
 	if len(msg.ToolCalls) > 0 {
-		parts := make([]geminiPart, 0, len(msg.ToolCalls)+1)
-		if text := strings.TrimSpace(core.ExtractTextContent(msg.Content)); text != "" {
-			parts = append(parts, geminiPart{Text: text})
+		return geminiPartsFromToolCallMessage(msg, signatureRequired), nil
+	}
+	parts, err := geminiPartsFromContent(msg.Content)
+	if err != nil || strings.TrimSpace(msg.Role) != "assistant" {
+		return parts, err
+	}
+	return withThoughtSignature(parts, thoughtSignatureFromExtraFields(msg.ExtraFields)), nil
+}
+
+func geminiPartsFromToolCallMessage(msg core.Message, signatureRequired bool) []geminiPart {
+	parts := make([]geminiPart, 0, len(msg.ToolCalls)+1)
+	if text := strings.TrimSpace(core.ExtractTextContent(msg.Content)); text != "" {
+		parts = append(parts, geminiPart{Text: text})
+	}
+	signed := false
+	for _, call := range msg.ToolCalls {
+		args := json.RawMessage(strings.TrimSpace(call.Function.Arguments))
+		if len(args) == 0 {
+			args = json.RawMessage(`{}`)
 		}
-		for _, call := range msg.ToolCalls {
-			args := json.RawMessage(strings.TrimSpace(call.Function.Arguments))
-			if len(args) == 0 {
-				args = json.RawMessage(`{}`)
-			}
-			parts = append(parts, geminiPart{FunctionCall: &geminiFunctionCall{
+		signature := thoughtSignatureFromExtraFields(call.ExtraFields)
+		signed = signed || signature != ""
+		parts = append(parts, geminiPart{
+			FunctionCall: &geminiFunctionCall{
 				ID:   call.ID,
 				Name: call.Function.Name,
 				Args: args,
-			}})
-		}
-		return parts, nil
+			},
+			ThoughtSignature: signature,
+		})
 	}
+	// Only the first call of a parallel batch carries a signature, so a turn
+	// with at least one signed call is a genuine Gemini turn and is sent back
+	// exactly as received.
+	if signatureRequired && !signed {
+		for i := range parts {
+			if parts[i].FunctionCall != nil {
+				parts[i].ThoughtSignature = skipThoughtSignatureValidator
+			}
+		}
+	}
+	return parts
+}
 
-	switch content := msg.Content.(type) {
+// withThoughtSignature attaches a text turn's signature to its last part, the
+// position Gemini returned it in.
+func withThoughtSignature(parts []geminiPart, signature string) []geminiPart {
+	if signature == "" || len(parts) == 0 {
+		return parts
+	}
+	parts[len(parts)-1].ThoughtSignature = signature
+	return parts
+}
+
+func geminiPartsFromContent(content core.MessageContent) ([]geminiPart, error) {
+	switch content := content.(type) {
 	case nil:
 		return nil, nil
 	case string:
@@ -775,13 +865,21 @@ func nativeChatResponse(req *core.ChatRequest, geminiResp *geminiGenerateContent
 		if index == 0 && i > 0 {
 			index = i
 		}
-		content, toolCalls := openAIMessageFromGeminiParts(candidate.Content.Parts)
+		content, toolCalls, signature := openAIMessageFromGeminiParts(candidate.Content.Parts)
+		// A tool-call-only turn carries content: null in OpenAI responses; an
+		// empty string would surface as an empty Responses message item that
+		// clients cannot echo back.
+		var messageContent core.MessageContent = content
+		if content == "" && len(toolCalls) > 0 {
+			messageContent = nil
+		}
 		resp.Choices = append(resp.Choices, core.Choice{
 			Index: index,
 			Message: core.ResponseMessage{
-				Role:      "assistant",
-				Content:   content,
-				ToolCalls: toolCalls,
+				Role:        "assistant",
+				Content:     messageContent,
+				ToolCalls:   toolCalls,
+				ExtraFields: thoughtSignatureExtraFields(signature),
 			},
 			FinishReason: finishReasonFromGemini(candidate.FinishReason, len(toolCalls) > 0),
 		})
@@ -820,14 +918,23 @@ func geminiPromptBlockReason(raw json.RawMessage) string {
 	}
 }
 
-func openAIMessageFromGeminiParts(parts []geminiPart) (string, []core.ToolCall) {
+// openAIMessageFromGeminiParts flattens candidate parts into OpenAI text and
+// tool calls. A functionCall part's thought signature rides on its tool call;
+// the signature of a text turn (Gemini puts it on the last part) is returned
+// separately for the message.
+func openAIMessageFromGeminiParts(parts []geminiPart) (string, []core.ToolCall, string) {
 	var text strings.Builder
+	var signature string
 	toolCalls := make([]core.ToolCall, 0)
 	for i, part := range parts {
 		if part.Text != "" && !part.Thought {
 			text.WriteString(part.Text)
 		}
-		if call := part.functionCall(); call != nil {
+		call := part.functionCall()
+		if call == nil && part.ThoughtSignature != "" {
+			signature = part.ThoughtSignature
+		}
+		if call != nil {
 			id := call.ID
 			if id == "" {
 				id = "call_" + strconv.Itoa(i)
@@ -848,10 +955,11 @@ func openAIMessageFromGeminiParts(parts []geminiPart) (string, []core.ToolCall) 
 					Name:      call.Name,
 					Arguments: args,
 				},
+				ExtraFields: thoughtSignatureExtraFields(part.ThoughtSignature),
 			})
 		}
 	}
-	return text.String(), toolCalls
+	return text.String(), toolCalls, signature
 }
 
 func usageFromGemini(usage geminiUsageMetadata) core.Usage {

--- a/internal/providers/gemini/native.go
+++ b/internal/providers/gemini/native.go
@@ -98,20 +98,41 @@ func thoughtSignatureExtraFields(signature string) core.UnknownJSONFields {
 	return core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{extraContentField: encoded})
 }
 
+// thoughtSignatureFromExtraFields reads a replayed signature. The canonical
+// spelling is extra_content.google.thought_signature; a flat thought_signature
+// or thoughtSignature member is accepted too, because other gateways and SDKs
+// emit the signature that way.
 func thoughtSignatureFromExtraFields(fields core.UnknownJSONFields) string {
-	raw := fields.Lookup(extraContentField)
-	if len(raw) == 0 {
-		return ""
+	if raw := fields.Lookup(extraContentField); len(raw) > 0 {
+		var extra struct {
+			Google struct {
+				ThoughtSignature string `json:"thought_signature"`
+			} `json:"google"`
+		}
+		if err := json.Unmarshal(raw, &extra); err == nil && extra.Google.ThoughtSignature != "" {
+			return extra.Google.ThoughtSignature
+		}
 	}
-	var extra struct {
-		Google struct {
-			ThoughtSignature string `json:"thought_signature"`
-		} `json:"google"`
+	for _, key := range [...]string{"thought_signature", "thoughtSignature"} {
+		raw := fields.Lookup(key)
+		if len(raw) == 0 {
+			continue
+		}
+		var signature string
+		if err := json.Unmarshal(raw, &signature); err == nil && signature != "" {
+			return signature
+		}
 	}
-	if err := json.Unmarshal(raw, &extra); err != nil {
-		return ""
+	return ""
+}
+
+// toolCallThoughtSignature reads the signature a client replayed with an
+// assistant tool call, on the call itself or nested on its function object.
+func toolCallThoughtSignature(call core.ToolCall) string {
+	if signature := thoughtSignatureFromExtraFields(call.ExtraFields); signature != "" {
+		return signature
 	}
-	return extra.Google.ThoughtSignature
+	return thoughtSignatureFromExtraFields(call.Function.ExtraFields)
 }
 
 // requiresThoughtSignature reports whether Gemini validates that every
@@ -267,7 +288,9 @@ func geminiPartsFromMessage(msg core.Message, signatureRequired bool) ([]geminiP
 func geminiPartsFromToolCallMessage(msg core.Message, signatureRequired bool) []geminiPart {
 	parts := make([]geminiPart, 0, len(msg.ToolCalls)+1)
 	if text := strings.TrimSpace(core.ExtractTextContent(msg.Content)); text != "" {
-		parts = append(parts, geminiPart{Text: text})
+		// A mixed turn keeps the text part's own signature (message-level
+		// extra_content) next to the per-call ones.
+		parts = append(parts, geminiPart{Text: text, ThoughtSignature: thoughtSignatureFromExtraFields(msg.ExtraFields)})
 	}
 	signed := false
 	for _, call := range msg.ToolCalls {
@@ -275,7 +298,7 @@ func geminiPartsFromToolCallMessage(msg core.Message, signatureRequired bool) []
 		if len(args) == 0 {
 			args = json.RawMessage(`{}`)
 		}
-		signature := thoughtSignatureFromExtraFields(call.ExtraFields)
+		signature := toolCallThoughtSignature(call)
 		signed = signed || signature != ""
 		parts = append(parts, geminiPart{
 			FunctionCall: &geminiFunctionCall{

--- a/internal/providers/gemini/native_stream.go
+++ b/internal/providers/gemini/native_stream.go
@@ -172,13 +172,16 @@ func (s *geminiStreamState) chatChunkChoice(candidate geminiCandidate, fallbackI
 		state.roleSent = true
 	}
 
-	content, toolCalls := openAIMessageFromGeminiParts(candidate.Content.Parts)
+	content, toolCalls, signature := openAIMessageFromGeminiParts(candidate.Content.Parts)
 	if content != "" {
 		delta["content"] = content
 	}
 	if len(toolCalls) > 0 {
 		state.sawToolCalls = true
 		delta["tool_calls"] = streamToolCalls(toolCalls)
+	}
+	if signature != "" {
+		delta[extraContentField] = thoughtSignatureExtraFields(signature).Lookup(extraContentField)
 	}
 
 	finish := finishReasonFromGemini(candidate.FinishReason, state.sawToolCalls)
@@ -219,7 +222,7 @@ func (s *geminiStreamState) choiceState(index int) *geminiChoiceStreamState {
 func streamToolCalls(toolCalls []core.ToolCall) []map[string]any {
 	out := make([]map[string]any, 0, len(toolCalls))
 	for i, call := range toolCalls {
-		out = append(out, map[string]any{
+		chunk := map[string]any{
 			"index": i,
 			"id":    call.ID,
 			"type":  "function",
@@ -227,7 +230,11 @@ func streamToolCalls(toolCalls []core.ToolCall) []map[string]any {
 				"name":      call.Function.Name,
 				"arguments": call.Function.Arguments,
 			},
-		})
+		}
+		if extra := call.ExtraFields.Lookup(extraContentField); len(extra) > 0 {
+			chunk[extraContentField] = extra
+		}
+		out = append(out, chunk)
 	}
 	return out
 }

--- a/internal/providers/gemini/native_thought_signature_test.go
+++ b/internal/providers/gemini/native_thought_signature_test.go
@@ -1,0 +1,277 @@
+package gemini
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-json"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/llmclient"
+)
+
+const testExtraContent = `{"google":{"thought_signature":"sig-1"}}`
+
+func toolCallWithSignature(id, name, signature string) core.ToolCall {
+	return core.ToolCall{
+		ID:          id,
+		Type:        "function",
+		Function:    core.FunctionCall{Name: name, Arguments: `{"city":"Warsaw"}`},
+		ExtraFields: thoughtSignatureExtraFields(signature),
+	}
+}
+
+func TestConvertChatRequestToGemini_ThoughtSignatures(t *testing.T) {
+	tests := []struct {
+		name     string
+		model    string
+		message  core.Message
+		wantSigs []string // per part, in order
+	}{
+		{
+			name:  "signed tool call is sent back verbatim",
+			model: "gemini-3.5-flash",
+			message: core.Message{Role: "assistant", ToolCalls: []core.ToolCall{
+				toolCallWithSignature("call_1", "lookup_weather", "sig-1"),
+			}},
+			wantSigs: []string{"sig-1"},
+		},
+		{
+			name:  "unsigned tool call on Gemini 3 gets the validator placeholder",
+			model: "gemini-3.5-flash",
+			message: core.Message{Role: "assistant", ToolCalls: []core.ToolCall{
+				toolCallWithSignature("call_1", "lookup_weather", ""),
+			}},
+			wantSigs: []string{skipThoughtSignatureValidator},
+		},
+		{
+			name:  "unsigned tool call on Gemini 2.5 stays unsigned",
+			model: "gemini-2.5-flash",
+			message: core.Message{Role: "assistant", ToolCalls: []core.ToolCall{
+				toolCallWithSignature("call_1", "lookup_weather", ""),
+			}},
+			wantSigs: []string{""},
+		},
+		{
+			name:  "parallel batch keeps only its first call signed",
+			model: "gemini-3.5-flash",
+			message: core.Message{Role: "assistant", Content: "Checking both.", ToolCalls: []core.ToolCall{
+				toolCallWithSignature("call_1", "lookup_weather", "sig-1"),
+				toolCallWithSignature("call_2", "lookup_weather", ""),
+			}},
+			wantSigs: []string{"", "sig-1", ""},
+		},
+		{
+			name:  "text turn signature lands on the last part",
+			model: "gemini-3.5-flash",
+			message: core.Message{
+				Role:        "assistant",
+				Content:     "Hello",
+				ExtraFields: thoughtSignatureExtraFields("sig-text"),
+			},
+			wantSigs: []string{"sig-text"},
+		},
+		{
+			name:  "user extra_content is ignored",
+			model: "gemini-3.5-flash",
+			message: core.Message{
+				Role:        "user",
+				Content:     "Hello",
+				ExtraFields: thoughtSignatureExtraFields("sig-user"),
+			},
+			wantSigs: []string{""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := convertChatRequestToGemini(&core.ChatRequest{
+				Model:    tt.model,
+				Messages: []core.Message{{Role: "user", Content: "Weather?"}, tt.message},
+			})
+			if err != nil {
+				t.Fatalf("convertChatRequestToGemini() error = %v", err)
+			}
+			parts := req.Contents[len(req.Contents)-1].Parts
+			if len(parts) != len(tt.wantSigs) {
+				t.Fatalf("parts = %d, want %d: %+v", len(parts), len(tt.wantSigs), parts)
+			}
+			for i, want := range tt.wantSigs {
+				if got := parts[i].ThoughtSignature; got != want {
+					t.Errorf("part %d thoughtSignature = %q, want %q", i, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestNativeChatResponse_ExposesThoughtSignatures(t *testing.T) {
+	var geminiResp geminiGenerateContentResponse
+	if err := json.Unmarshal([]byte(`{"candidates":[{"content":{"role":"model","parts":[
+		{"text":"Let me check.","thoughtSignature":"sig-text"},
+		{"functionCall":{"id":"call_1","name":"lookup_weather","args":{"city":"Warsaw"}},"thoughtSignature":"sig-1"},
+		{"functionCall":{"id":"call_2","name":"lookup_weather","args":{"city":"Krakow"}}}
+	]},"finishReason":"STOP"}]}`), &geminiResp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	resp, err := nativeChatResponse(&core.ChatRequest{Model: "gemini-3.5-flash"}, &geminiResp, "gemini")
+	if err != nil {
+		t.Fatalf("nativeChatResponse() error = %v", err)
+	}
+	encoded, err := json.Marshal(resp.Choices[0].Message)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var wire struct {
+		ExtraContent json.RawMessage `json:"extra_content"`
+		ToolCalls    []struct {
+			ExtraContent json.RawMessage `json:"extra_content"`
+		} `json:"tool_calls"`
+	}
+	if err := json.Unmarshal(encoded, &wire); err != nil {
+		t.Fatalf("unmarshal wire message: %v", err)
+	}
+	if got := string(wire.ExtraContent); got != `{"google":{"thought_signature":"sig-text"}}` {
+		t.Fatalf("message extra_content = %s, want text signature", got)
+	}
+	if len(wire.ToolCalls) != 2 {
+		t.Fatalf("tool_calls = %d, want 2", len(wire.ToolCalls))
+	}
+	if got := string(wire.ToolCalls[0].ExtraContent); got != testExtraContent {
+		t.Fatalf("tool_calls[0].extra_content = %s, want %s", got, testExtraContent)
+	}
+	if got := string(wire.ToolCalls[1].ExtraContent); got != "" {
+		t.Fatalf("tool_calls[1].extra_content = %s, want absent", got)
+	}
+}
+
+// TestChatCompletion_NativeThoughtSignatureRoundTrip replays a Gemini tool
+// call exactly as an OpenAI-compatible client would: the tool_calls from the
+// first response, re-decoded from JSON, are sent back in the next request and
+// must reach Gemini with their original thoughtSignature.
+func TestChatCompletion_NativeThoughtSignatureRoundTrip(t *testing.T) {
+	t.Setenv(useNativeAPIEnvVar, "true")
+
+	var requests [][]byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		requests = append(requests, body)
+		w.WriteHeader(http.StatusOK)
+		if len(requests) == 1 {
+			_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[
+				{"functionCall":{"id":"call_1","name":"lookup_weather","args":{"city":"Warsaw"}},"thoughtSignature":"sig-1"}
+			]},"finishReason":"STOP"}]}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"Sunny."}]},"finishReason":"STOP"}]}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("test-api-key", nil, llmclient.Hooks{})
+	provider.SetModelsURL(server.URL)
+
+	first, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{
+		Model:    "gemini-3.5-flash",
+		Messages: []core.Message{{Role: "user", Content: "Weather?"}},
+	})
+	if err != nil {
+		t.Fatalf("first ChatCompletion() error = %v", err)
+	}
+
+	// Serialize the assistant message the way it leaves the gateway and decode
+	// it the way the next request arrives.
+	encoded, err := json.Marshal(first.Choices[0].Message)
+	if err != nil {
+		t.Fatalf("marshal assistant message: %v", err)
+	}
+	var assistant core.Message
+	if err := json.Unmarshal(encoded, &assistant); err != nil {
+		t.Fatalf("unmarshal assistant message: %v", err)
+	}
+
+	if _, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{
+		Model: "gemini-3.5-flash",
+		Messages: []core.Message{
+			{Role: "user", Content: "Weather?"},
+			assistant,
+			{Role: "tool", ToolCallID: "call_1", Content: `{"result":"sunny"}`},
+		},
+	}); err != nil {
+		t.Fatalf("second ChatCompletion() error = %v", err)
+	}
+
+	var payload geminiGenerateContentRequest
+	if err := json.Unmarshal(requests[1], &payload); err != nil {
+		t.Fatalf("unmarshal second request: %v", err)
+	}
+	if len(payload.Contents) != 3 {
+		t.Fatalf("contents = %d, want 3", len(payload.Contents))
+	}
+	call := payload.Contents[1].Parts[0]
+	if call.FunctionCall == nil || call.FunctionCall.Name != "lookup_weather" {
+		t.Fatalf("model part = %+v, want functionCall", call)
+	}
+	if call.ThoughtSignature != "sig-1" {
+		t.Fatalf("thoughtSignature = %q, want sig-1", call.ThoughtSignature)
+	}
+}
+
+func TestStreamChatCompletion_NativeThoughtSignatures(t *testing.T) {
+	t.Setenv(useNativeAPIEnvVar, "true")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"id":"call_1","name":"lookup_weather","args":{"city":"Warsaw"}},"thoughtSignature":"sig-1"}]},"finishReason":"STOP"}]}
+
+data: {"candidates":[{"content":{"role":"model","parts":[{"text":"","thoughtSignature":"sig-text"}]},"finishReason":"STOP"}]}
+
+`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("test-api-key", nil, llmclient.Hooks{})
+	provider.SetModelsURL(server.URL)
+
+	body, err := provider.StreamChatCompletion(context.Background(), &core.ChatRequest{
+		Model:    "gemini-3.5-flash",
+		Messages: []core.Message{{Role: "user", Content: "Weather?"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = body.Close() }()
+
+	raw, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("failed to read stream: %v", err)
+	}
+	stream := string(raw)
+	if !strings.Contains(stream, `"tool_calls":[{"extra_content":{"google":{"thought_signature":"sig-1"}}`) {
+		t.Fatalf("stream lacks tool call extra_content: %s", stream)
+	}
+	if !strings.Contains(stream, `"delta":{"extra_content":{"google":{"thought_signature":"sig-text"}}}`) {
+		t.Fatalf("stream lacks text turn extra_content: %s", stream)
+	}
+}
+
+func TestNativeChatResponse_ToolCallOnlyTurnHasNullContent(t *testing.T) {
+	var geminiResp geminiGenerateContentResponse
+	if err := json.Unmarshal([]byte(`{"candidates":[{"content":{"role":"model","parts":[
+		{"functionCall":{"id":"call_1","name":"lookup_weather","args":{}}}
+	]},"finishReason":"STOP"}]}`), &geminiResp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	resp, err := nativeChatResponse(&core.ChatRequest{Model: "gemini-3.5-flash"}, &geminiResp, "gemini")
+	if err != nil {
+		t.Fatalf("nativeChatResponse() error = %v", err)
+	}
+	if got := resp.Choices[0].Message.Content; got != nil {
+		t.Fatalf("content = %#v, want nil for a tool-call-only turn", got)
+	}
+}

--- a/internal/providers/gemini/native_thought_signature_test.go
+++ b/internal/providers/gemini/native_thought_signature_test.go
@@ -25,6 +25,14 @@ func toolCallWithSignature(id, name, signature string) core.ToolCall {
 	}
 }
 
+func rawFields(pairs map[string]string) core.UnknownJSONFields {
+	fields := make(map[string]json.RawMessage, len(pairs))
+	for key, value := range pairs {
+		fields[key] = json.RawMessage(value)
+	}
+	return core.UnknownJSONFieldsFromMap(fields)
+}
+
 func TestConvertChatRequestToGemini_ThoughtSignatures(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -64,6 +72,49 @@ func TestConvertChatRequestToGemini_ThoughtSignatures(t *testing.T) {
 				toolCallWithSignature("call_2", "lookup_weather", ""),
 			}},
 			wantSigs: []string{"", "sig-1", ""},
+		},
+		{
+			name:  "flat snake_case spelling on the tool call",
+			model: "gemini-3.5-flash",
+			message: core.Message{Role: "assistant", ToolCalls: []core.ToolCall{{
+				ID: "call_1", Type: "function",
+				Function:    core.FunctionCall{Name: "lookup_weather", Arguments: "{}"},
+				ExtraFields: rawFields(map[string]string{"thought_signature": `"sig-flat"`}),
+			}}},
+			wantSigs: []string{"sig-flat"},
+		},
+		{
+			name:  "flat camelCase spelling nested on the function object",
+			model: "gemini-3.5-flash",
+			message: core.Message{Role: "assistant", ToolCalls: []core.ToolCall{{
+				ID: "call_1", Type: "function",
+				Function: core.FunctionCall{
+					Name: "lookup_weather", Arguments: "{}",
+					ExtraFields: rawFields(map[string]string{"thoughtSignature": `"sig-func"`}),
+				},
+			}}},
+			wantSigs: []string{"sig-func"},
+		},
+		{
+			name:  "malformed extra_content falls back to the placeholder",
+			model: "gemini-3.5-flash",
+			message: core.Message{Role: "assistant", ToolCalls: []core.ToolCall{{
+				ID: "call_1", Type: "function",
+				Function:    core.FunctionCall{Name: "lookup_weather", Arguments: "{}"},
+				ExtraFields: rawFields(map[string]string{"extra_content": `{"google":"not-an-object"}`}),
+			}}},
+			wantSigs: []string{skipThoughtSignatureValidator},
+		},
+		{
+			name:  "mixed turn keeps the text signature and the call signature",
+			model: "gemini-3.5-flash",
+			message: core.Message{
+				Role:        "assistant",
+				Content:     "Checking.",
+				ExtraFields: thoughtSignatureExtraFields("sig-text"),
+				ToolCalls:   []core.ToolCall{toolCallWithSignature("call_1", "lookup_weather", "sig-1")},
+			},
+			wantSigs: []string{"sig-text", "sig-1"},
 		},
 		{
 			name:  "text turn signature lands on the last part",

--- a/internal/providers/responses_converter.go
+++ b/internal/providers/responses_converter.go
@@ -91,6 +91,7 @@ type openAIChunkToolCall struct {
 		Name      string `json:"name"`
 		Arguments string `json:"arguments"`
 	} `json:"function"`
+	ExtraContent json.RawMessage `json:"extra_content"`
 }
 
 func (sc *OpenAIResponsesStreamConverter) ensureToolCallState(index int) *ResponsesOutputToolCallState {
@@ -209,6 +210,9 @@ func (sc *OpenAIResponsesStreamConverter) handleToolCallDeltas(toolCalls []openA
 		}
 		if toolCall.Function.Name != "" {
 			state.Name = toolCall.Function.Name
+		}
+		if len(toolCall.ExtraContent) > 0 {
+			state.ExtraContent = toolCall.ExtraContent
 		}
 
 		arguments := toolCall.Function.Arguments
@@ -353,6 +357,9 @@ func chunkToolCallsFromAny(items []any) []openAIChunkToolCall {
 		if function, ok := toolCall["function"].(map[string]any); ok {
 			call.Function.Name, _ = function["name"].(string)
 			call.Function.Arguments, _ = function["arguments"].(string)
+		}
+		if extra, ok := toolCall["extra_content"]; ok && extra != nil {
+			call.ExtraContent, _ = json.Marshal(extra)
 		}
 		calls = append(calls, call)
 	}

--- a/internal/providers/responses_converter.go
+++ b/internal/providers/responses_converter.go
@@ -211,8 +211,9 @@ func (sc *OpenAIResponsesStreamConverter) handleToolCallDeltas(toolCalls []openA
 		if toolCall.Function.Name != "" {
 			state.Name = toolCall.Function.Name
 		}
-		if len(toolCall.ExtraContent) > 0 {
-			state.ExtraContent = toolCall.ExtraContent
+		// A later delta's explicit null must not erase a signature already seen.
+		if extra := bytes.TrimSpace(toolCall.ExtraContent); len(extra) > 0 && !bytes.Equal(extra, []byte("null")) {
+			state.ExtraContent = extra
 		}
 
 		arguments := toolCall.Function.Arguments

--- a/internal/providers/responses_converter_test.go
+++ b/internal/providers/responses_converter_test.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"encoding/json"
 	"io"
+	"reflect"
 	"slices"
 	"strings"
 	"testing"
@@ -77,6 +78,43 @@ data: [DONE]
 	}
 	if !foundItemDone {
 		t.Fatal("expected response.output_item.done for function_call")
+	}
+}
+
+// TestOpenAIResponsesStreamConverter_ToolCallExtraContent keeps a provider's
+// extra_content (Gemini's thought signature) on the function_call item so a
+// client that echoes the item restores it.
+func TestOpenAIResponsesStreamConverter_ToolCallExtraContent(t *testing.T) {
+	mockStream := `data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"test-model","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_123","type":"function","function":{"name":"lookup_weather","arguments":"{}"},"extra_content":{"google":{"thought_signature":"sig-1"}}}]},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"test-model","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}
+
+data: [DONE]
+`
+
+	converter := NewOpenAIResponsesStreamConverter(io.NopCloser(strings.NewReader(mockStream)), "test-model", "gemini")
+	raw, err := io.ReadAll(converter)
+	if err != nil {
+		t.Fatalf("failed to read from converter: %v", err)
+	}
+
+	want := map[string]any{"google": map[string]any{"thought_signature": "sig-1"}}
+	seen := 0
+	for _, event := range parseTestSSEEvents(t, string(raw)) {
+		if event.Name != "response.output_item.added" && event.Name != "response.output_item.done" {
+			continue
+		}
+		item, _ := event.Payload["item"].(map[string]any)
+		if item["type"] != "function_call" {
+			continue
+		}
+		seen++
+		if got := item["extra_content"]; !reflect.DeepEqual(got, want) {
+			t.Fatalf("%s extra_content = %#v, want %#v", event.Name, got, want)
+		}
+	}
+	if seen != 2 {
+		t.Fatalf("function_call item events = %d, want added and done", seen)
 	}
 }
 

--- a/internal/providers/responses_converter_test.go
+++ b/internal/providers/responses_converter_test.go
@@ -118,6 +118,42 @@ data: [DONE]
 	}
 }
 
+// TestOpenAIResponsesStreamConverter_NullExtraContentDeltaKeepsSignature: a
+// later argument delta carrying extra_content: null must not erase the
+// signature the first delta set.
+func TestOpenAIResponsesStreamConverter_NullExtraContentDeltaKeepsSignature(t *testing.T) {
+	mockStream := `data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"test-model","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_123","type":"function","function":{"name":"lookup_weather","arguments":"{"},"extra_content":{"google":{"thought_signature":"sig-1"}}}]},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"test-model","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"}"},"extra_content":null}]},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"test-model","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}
+
+data: [DONE]
+`
+
+	converter := NewOpenAIResponsesStreamConverter(io.NopCloser(strings.NewReader(mockStream)), "test-model", "gemini")
+	raw, err := io.ReadAll(converter)
+	if err != nil {
+		t.Fatalf("failed to read from converter: %v", err)
+	}
+
+	want := map[string]any{"google": map[string]any{"thought_signature": "sig-1"}}
+	for _, event := range parseTestSSEEvents(t, string(raw)) {
+		if event.Name != "response.output_item.done" {
+			continue
+		}
+		item, _ := event.Payload["item"].(map[string]any)
+		if item["type"] != "function_call" {
+			continue
+		}
+		if got := item["extra_content"]; !reflect.DeepEqual(got, want) {
+			t.Fatalf("extra_content after null delta = %#v, want %#v", got, want)
+		}
+		return
+	}
+	t.Fatal("expected a function_call output_item.done event")
+}
+
 // TestOpenAIResponsesStreamConverter_ReasoningContent covers DeepSeek-style
 // reasoning_content deltas. reasoning_content is raw reasoning, so it must be
 // exposed as reasoning_text rather than mislabeled as a readable summary. The

--- a/internal/providers/responses_output.go
+++ b/internal/providers/responses_output.go
@@ -158,13 +158,16 @@ func BuildResponsesOutputItems(msg core.ResponseMessage) []core.ResponsesOutputI
 	}
 	for _, toolCall := range msg.ToolCalls {
 		callID := ResponsesFunctionCallCallID(toolCall.ID)
+		// Provider extensions on the tool call (Gemini's extra_content thought
+		// signature) stay on the item so a client echoing it back restores them.
 		output = append(output, core.ResponsesOutputItem{
-			ID:        ResponsesFunctionCallItemID(callID),
-			Type:      "function_call",
-			Status:    "completed",
-			CallID:    callID,
-			Name:      toolCall.Function.Name,
-			Arguments: toolCall.Function.Arguments,
+			ID:          ResponsesFunctionCallItemID(callID),
+			Type:        "function_call",
+			Status:      "completed",
+			CallID:      callID,
+			Name:        toolCall.Function.Name,
+			Arguments:   toolCall.Function.Arguments,
+			ExtraFields: core.CloneUnknownJSONFields(toolCall.ExtraFields),
 		})
 	}
 	return output

--- a/internal/providers/responses_output.go
+++ b/internal/providers/responses_output.go
@@ -158,8 +158,6 @@ func BuildResponsesOutputItems(msg core.ResponseMessage) []core.ResponsesOutputI
 	}
 	for _, toolCall := range msg.ToolCalls {
 		callID := ResponsesFunctionCallCallID(toolCall.ID)
-		// Provider extensions on the tool call (Gemini's extra_content thought
-		// signature) stay on the item so a client echoing it back restores them.
 		output = append(output, core.ResponsesOutputItem{
 			ID:          ResponsesFunctionCallItemID(callID),
 			Type:        "function_call",
@@ -167,10 +165,27 @@ func BuildResponsesOutputItems(msg core.ResponseMessage) []core.ResponsesOutputI
 			CallID:      callID,
 			Name:        toolCall.Function.Name,
 			Arguments:   toolCall.Function.Arguments,
-			ExtraFields: core.CloneUnknownJSONFields(toolCall.ExtraFields),
+			ExtraFields: toolCallExtraContent(toolCall.ExtraFields),
 		})
 	}
 	return output
+}
+
+// toolCallExtraContentField is the OpenAI-compatible member holding provider
+// state a chat tool call needs back verbatim on the next turn, as used by
+// Google's OpenAI-compatible endpoint (extra_content.google.thought_signature).
+const toolCallExtraContentField = "extra_content"
+
+// toolCallExtraContent isolates the extra_content member of a chat tool call
+// so it survives on the Responses function_call item that clients replay. The
+// other unknown tool-call members are provider metadata, not replay state, so
+// only extra_content is forwarded.
+func toolCallExtraContent(fields core.UnknownJSONFields) core.UnknownJSONFields {
+	raw := fields.Lookup(toolCallExtraContentField)
+	if len(raw) == 0 {
+		return core.UnknownJSONFields{}
+	}
+	return core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{toolCallExtraContentField: raw})
 }
 
 func responseMessageReasoningContent(msg core.ResponseMessage) string {

--- a/internal/providers/responses_output_state.go
+++ b/internal/providers/responses_output_state.go
@@ -21,6 +21,9 @@ type ResponsesOutputToolCallState struct {
 	Completed         bool
 	FinalStatus       string // status carried by the item's output_item.done event
 	PlaceholderObject bool
+	// ExtraContent is the tool call's extra_content member (Gemini thought
+	// signature), echoed on the function_call item.
+	ExtraContent json.RawMessage
 }
 
 // ResponsesOutputEventState manages assistant/tool output items for Responses streams.
@@ -303,7 +306,7 @@ func (s *ResponsesOutputEventState) RenderToolCallItem(state *ResponsesOutputToo
 	if includePlaceholder {
 		arguments = s.ToolCallArguments(state)
 	}
-	return map[string]any{
+	item := map[string]any{
 		"id":        state.ItemID,
 		"type":      "function_call",
 		"status":    status,
@@ -311,6 +314,10 @@ func (s *ResponsesOutputEventState) RenderToolCallItem(state *ResponsesOutputToo
 		"name":      state.Name,
 		"arguments": arguments,
 	}
+	if len(state.ExtraContent) > 0 {
+		item["extra_content"] = state.ExtraContent
+	}
+	return item
 }
 
 // StartToolCall emits the function_call output_item.added event once the item metadata is available.

--- a/internal/providers/responses_output_test.go
+++ b/internal/providers/responses_output_test.go
@@ -1,0 +1,38 @@
+package providers
+
+import (
+	"testing"
+
+	"github.com/goccy/go-json"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+func TestBuildResponsesOutputItems_KeepsToolCallExtraFields(t *testing.T) {
+	extra := core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+		"extra_content": json.RawMessage(`{"google":{"thought_signature":"sig-1"}}`),
+	})
+	items := BuildResponsesOutputItems(core.ResponseMessage{
+		Role: "assistant",
+		ToolCalls: []core.ToolCall{{
+			ID:          "call_1",
+			Type:        "function",
+			Function:    core.FunctionCall{Name: "lookup_weather", Arguments: `{"city":"Warsaw"}`},
+			ExtraFields: extra,
+		}},
+	})
+	if len(items) != 1 || items[0].Type != "function_call" {
+		t.Fatalf("items = %+v, want one function_call", items)
+	}
+	encoded, err := json.Marshal(items[0])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var wire map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &wire); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := string(wire["extra_content"]); got != `{"google":{"thought_signature":"sig-1"}}` {
+		t.Fatalf("extra_content = %s, want thought signature", got)
+	}
+}

--- a/internal/providers/responses_output_test.go
+++ b/internal/providers/responses_output_test.go
@@ -36,3 +36,32 @@ func TestBuildResponsesOutputItems_KeepsToolCallExtraFields(t *testing.T) {
 		t.Fatalf("extra_content = %s, want thought signature", got)
 	}
 }
+
+func TestBuildResponsesOutputItems_ForwardsOnlyExtraContent(t *testing.T) {
+	items := BuildResponsesOutputItems(core.ResponseMessage{
+		Role: "assistant",
+		ToolCalls: []core.ToolCall{{
+			ID:       "call_1",
+			Type:     "function",
+			Function: core.FunctionCall{Name: "lookup_weather", Arguments: "{}"},
+			ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+				"extra_content":  json.RawMessage(`{"google":{"thought_signature":"sig-1"}}`),
+				"provider_index": json.RawMessage(`7`),
+			}),
+		}},
+	})
+	encoded, err := json.Marshal(items[0])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var wire map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &wire); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, present := wire["provider_index"]; present {
+		t.Fatalf("provider_index leaked onto the function_call item: %s", encoded)
+	}
+	if got := string(wire["extra_content"]); got != `{"google":{"thought_signature":"sig-1"}}` {
+		t.Fatalf("extra_content = %s, want thought signature", got)
+	}
+}

--- a/tests/e2e/gemini_native_tools_test.go
+++ b/tests/e2e/gemini_native_tools_test.go
@@ -1,0 +1,354 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/llmclient"
+	"github.com/enterpilot/gomodel/internal/providers"
+	"github.com/enterpilot/gomodel/internal/providers/gemini"
+)
+
+const geminiToolModel = "gemini-3.5-flash-lite"
+
+// mockGeminiNativeServer stands in for Gemini's native generateContent API and
+// enforces the rule Gemini 3 enforces: a functionCall part replayed in the
+// conversation history must carry back the thoughtSignature it was returned
+// with, or the whole request fails with HTTP 400.
+type mockGeminiNativeServer struct {
+	server   *httptest.Server
+	requests [][]byte
+}
+
+func newMockGeminiNativeServer(t *testing.T) *mockGeminiNativeServer {
+	t.Helper()
+
+	mock := &mockGeminiNativeServer{}
+	mock.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet && r.URL.Path == "/models" {
+			_, _ = fmt.Fprintf(w, `{"models":[{"name":"models/%s","supportedGenerationMethods":["generateContent","streamGenerateContent"]}]}`, geminiToolModel)
+			return
+		}
+		if !strings.HasSuffix(r.URL.Path, ":generateContent") {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"code":404,"message":"not found"}}`))
+			return
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		mock.requests = append(mock.requests, body)
+
+		position, ok := unsignedFunctionCallPosition(t, body)
+		if !ok {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = fmt.Fprintf(w, `{"error":{"code":400,"status":"INVALID_ARGUMENT","message":`+
+				`"Function call is missing a thought_signature in functionCall parts. This is required for tools to work correctly, `+
+				`and missing thought_signature may lead to degraded model performance. Additional data, function call `+
+				`default_api:ExecCommand, position %d."}}`, position)
+			return
+		}
+
+		if requestHasToolResult(t, body) {
+			_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"go.mod is there."}]},` +
+				`"finishReason":"STOP","index":0}],"usageMetadata":{"promptTokenCount":9,"candidatesTokenCount":5,"totalTokenCount":14},` +
+				`"responseId":"resp-2"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[` +
+			`{"functionCall":{"name":"ExecCommand","args":{"cmd":"ls"}},"thoughtSignature":"sig-e2e-1"}` +
+			`]},"finishReason":"STOP","index":0}],"usageMetadata":{"promptTokenCount":7,"candidatesTokenCount":11,"totalTokenCount":18},` +
+			`"responseId":"resp-1"}`))
+	}))
+	t.Cleanup(mock.server.Close)
+	return mock
+}
+
+// geminiRequestBody is the slice of the native request the signature rule
+// applies to.
+type geminiRequestBody struct {
+	Contents []struct {
+		Role  string `json:"role"`
+		Parts []struct {
+			FunctionCall     json.RawMessage `json:"functionCall"`
+			FunctionResponse json.RawMessage `json:"functionResponse"`
+			ThoughtSignature string          `json:"thoughtSignature"`
+		} `json:"parts"`
+	} `json:"contents"`
+}
+
+func decodeGeminiRequest(t *testing.T, body []byte) geminiRequestBody {
+	t.Helper()
+	var decoded geminiRequestBody
+	require.NoError(t, json.Unmarshal(body, &decoded), "upstream request body: %s", body)
+	return decoded
+}
+
+// unsignedFunctionCallPosition reports the part position of the first replayed
+// functionCall without a thoughtSignature, mirroring Gemini 3's validation.
+func unsignedFunctionCallPosition(t *testing.T, body []byte) (int, bool) {
+	t.Helper()
+	position := 0
+	for _, content := range decodeGeminiRequest(t, body).Contents {
+		for _, part := range content.Parts {
+			if len(part.FunctionCall) > 0 && part.ThoughtSignature == "" {
+				return position, false
+			}
+			position++
+		}
+	}
+	return 0, true
+}
+
+func requestHasToolResult(t *testing.T, body []byte) bool {
+	t.Helper()
+	for _, content := range decodeGeminiRequest(t, body).Contents {
+		for _, part := range content.Parts {
+			if len(part.FunctionResponse) > 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func setupGeminiNativeGateway(t *testing.T) (*httptest.Server, *mockGeminiNativeServer) {
+	t.Helper()
+
+	t.Setenv("USE_GOOGLE_GEMINI_NATIVE_API", "true")
+	upstream := newMockGeminiNativeServer(t)
+
+	provider := gemini.NewWithHTTPClient("sk-test-gemini-key", upstream.server.Client(), llmclient.Hooks{})
+	provider.SetBaseURL(upstream.server.URL)
+	provider.SetModelsURL(upstream.server.URL)
+
+	registry := providers.NewModelRegistry()
+	registry.RegisterProviderWithType(provider, "gemini")
+	require.NoError(t, registry.Initialize(context.Background()))
+
+	gateway := httptest.NewServer(setupE2EServer(t, e2eServerOptions{registry: registry}))
+	t.Cleanup(gateway.Close)
+	return gateway, upstream
+}
+
+func postGeminiChat(t *testing.T, gateway *httptest.Server, payload any) (*http.Response, []byte) {
+	t.Helper()
+
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+	resp, err := gateway.Client().Post(gateway.URL+chatCompletionsPath, "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer closeBody(resp)
+	responseBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp, responseBody
+}
+
+// A multi-step agent turn: the client replays the assistant tool call the
+// gateway handed it, and the second request must reach Gemini with the
+// function call's thought signature intact.
+func TestGeminiNativeToolCallsPreserveThoughtSignature(t *testing.T) {
+	gateway, upstream := setupGeminiNativeGateway(t)
+
+	tools := []map[string]any{{
+		"type": "function",
+		"function": map[string]any{
+			"name":        "ExecCommand",
+			"description": "Run a shell command.",
+			"parameters": map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"cmd": map[string]any{"type": "string"}},
+				"required":   []string{"cmd"},
+			},
+		},
+	}}
+
+	resp, body := postGeminiChat(t, gateway, map[string]any{
+		"model":    geminiToolModel,
+		"messages": []map[string]any{{"role": "user", "content": "is go.mod there?"}},
+		"tools":    tools,
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode, "first turn: %s", body)
+
+	var first core.ChatResponse
+	require.NoError(t, json.Unmarshal(body, &first))
+	require.Len(t, first.Choices, 1)
+	require.Len(t, first.Choices[0].Message.ToolCalls, 1)
+
+	// The client replays the assistant message exactly as the gateway
+	// returned it — the only history an OpenAI-compatible agent has.
+	var assistant map[string]any
+	require.NoError(t, json.Unmarshal(mustMarshal(t, first.Choices[0].Message), &assistant))
+
+	resp, body = postGeminiChat(t, gateway, map[string]any{
+		"model": geminiToolModel,
+		"messages": []any{
+			map[string]any{"role": "user", "content": "is go.mod there?"},
+			assistant,
+			map[string]any{
+				"role":         "tool",
+				"tool_call_id": first.Choices[0].Message.ToolCalls[0].ID,
+				"content":      `{"stdout":"go.mod"}`,
+			},
+		},
+		"tools": tools,
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode, "second turn rejected upstream: %s", body)
+
+	require.Len(t, upstream.requests, 2)
+	replay := decodeGeminiRequest(t, upstream.requests[1])
+	require.Len(t, replay.Contents, 3)
+	modelParts := replay.Contents[1].Parts
+	require.Len(t, modelParts, 1)
+	require.NotEmpty(t, modelParts[0].FunctionCall)
+	assert.Equal(t, "sig-e2e-1", modelParts[0].ThoughtSignature,
+		"the replayed functionCall part lost its thought signature")
+}
+
+// The same round trip over the Responses API, where the client replays
+// function_call items instead of chat messages.
+func TestGeminiNativeResponsesToolCallsPreserveThoughtSignature(t *testing.T) {
+	gateway, upstream := setupGeminiNativeGateway(t)
+
+	tools := []map[string]any{{
+		"type":        "function",
+		"name":        "ExecCommand",
+		"description": "Run a shell command.",
+		"parameters": map[string]any{
+			"type":       "object",
+			"properties": map[string]any{"cmd": map[string]any{"type": "string"}},
+			"required":   []string{"cmd"},
+		},
+	}}
+
+	body, err := json.Marshal(map[string]any{
+		"model": geminiToolModel,
+		"input": "is go.mod there?",
+		"tools": tools,
+	})
+	require.NoError(t, err)
+	resp, err := gateway.Client().Post(gateway.URL+responsesPath, "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer closeBody(resp)
+	first, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "first turn: %s", first)
+
+	var firstResp struct {
+		Output []map[string]any `json:"output"`
+	}
+	require.NoError(t, json.Unmarshal(first, &firstResp))
+	var functionCall map[string]any
+	for _, item := range firstResp.Output {
+		if item["type"] == "function_call" {
+			functionCall = item
+		}
+	}
+	require.NotNil(t, functionCall, "output = %s, want a function_call item", first)
+
+	input := []any{
+		map[string]any{"type": "message", "role": "user", "content": "is go.mod there?"},
+		functionCall,
+		map[string]any{"type": "function_call_output", "call_id": functionCall["call_id"], "output": `{"stdout":"go.mod"}`},
+	}
+	body, err = json.Marshal(map[string]any{"model": geminiToolModel, "input": input, "tools": tools})
+	require.NoError(t, err)
+	resp, err = gateway.Client().Post(gateway.URL+responsesPath, "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer closeBody(resp)
+	second, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "second turn rejected upstream: %s", second)
+
+	require.Len(t, upstream.requests, 2)
+	replay := decodeGeminiRequest(t, upstream.requests[1])
+	require.Len(t, replay.Contents, 3)
+	require.Len(t, replay.Contents[1].Parts, 1)
+	assert.Equal(t, "sig-e2e-1", replay.Contents[1].Parts[0].ThoughtSignature,
+		"the replayed function_call item lost its thought signature")
+}
+
+// A Responses client that echoes response.output as returned (message item
+// included) must be accepted: a tool-call-only turn has no empty message item
+// that the input side would reject.
+func TestGeminiNativeResponsesFullOutputEchoIsAccepted(t *testing.T) {
+	gateway, upstream := setupGeminiNativeGateway(t)
+
+	tools := []map[string]any{{
+		"type":       "function",
+		"name":       "ExecCommand",
+		"parameters": map[string]any{"type": "object", "properties": map[string]any{"cmd": map[string]any{"type": "string"}}},
+	}}
+	body := mustMarshal(t, map[string]any{"model": geminiToolModel, "input": "is go.mod there?", "tools": tools})
+	resp, err := gateway.Client().Post(gateway.URL+responsesPath, "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer closeBody(resp)
+	first, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "first turn: %s", first)
+
+	var firstResp struct {
+		Output []map[string]any `json:"output"`
+	}
+	require.NoError(t, json.Unmarshal(first, &firstResp))
+	require.Len(t, firstResp.Output, 1, "output = %s, want only the function_call item", first)
+	require.Equal(t, "function_call", firstResp.Output[0]["type"])
+
+	input := []any{map[string]any{"type": "message", "role": "user", "content": "is go.mod there?"}}
+	for _, item := range firstResp.Output {
+		input = append(input, item)
+	}
+	input = append(input, map[string]any{"type": "function_call_output", "call_id": firstResp.Output[0]["call_id"], "output": `{"stdout":"go.mod"}`})
+	body = mustMarshal(t, map[string]any{"model": geminiToolModel, "input": input, "tools": tools})
+	resp, err = gateway.Client().Post(gateway.URL+responsesPath, "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer closeBody(resp)
+	second, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "echoed output rejected: %s", second)
+	require.Len(t, upstream.requests, 2)
+}
+
+// A history whose tool call never had a signature (it came from another
+// provider, or the client dropped extra_content) reaches Gemini 3 with the
+// documented placeholder instead of failing the request.
+func TestGeminiNativeUnsignedToolCallGetsPlaceholder(t *testing.T) {
+	gateway, upstream := setupGeminiNativeGateway(t)
+
+	resp, body := postGeminiChat(t, gateway, map[string]any{
+		"model": geminiToolModel,
+		"messages": []map[string]any{
+			{"role": "user", "content": "is go.mod there?"},
+			{"role": "assistant", "content": nil, "tool_calls": []map[string]any{{
+				"id": "call_from_openai", "type": "function",
+				"function": map[string]any{"name": "ExecCommand", "arguments": `{"cmd":"ls"}`},
+			}}},
+			{"role": "tool", "tool_call_id": "call_from_openai", "content": `{"stdout":"go.mod"}`},
+		},
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode, "unsigned history rejected: %s", body)
+	require.Len(t, upstream.requests, 1)
+	replay := decodeGeminiRequest(t, upstream.requests[0])
+	require.Len(t, replay.Contents, 3)
+	assert.Equal(t, "skip_thought_signature_validator", replay.Contents[1].Parts[0].ThoughtSignature)
+}
+
+func mustMarshal(t *testing.T, value any) []byte {
+	t.Helper()
+	body, err := json.Marshal(value)
+	require.NoError(t, err)
+	return body
+}

--- a/tests/e2e/release-e2e-scenarios.md
+++ b/tests/e2e/release-e2e-scenarios.md
@@ -155,11 +155,12 @@ Stateful note:
   defaults `OPENROUTER_MODEL_FILTER_INCLUDE` to `*:free`, which leaves models
   used by the rest of the matrix untouched; the scenario is read-only and
   rerunnable in any order
-- `S225`-`S227` cover recent release regressions: image content nested in an
+- `S225`-`S228` cover recent release regressions: image content nested in an
   Anthropic `tool_result`, time-window pricing merged with an operator override,
-  and tolerant admin listing of a virtual model with corrupt SQL timestamps.
-  They create and clean up their own artifacts and are rerunnable in any order;
-  `S227` reloads the SQLite gateway and therefore stays sequential
+  tolerant admin listing of a virtual model with corrupt SQL timestamps, and a
+  Gemini 3 tool call replayed with its thought signature. They create and clean
+  up their own artifacts and are rerunnable in any order; `S227` reloads the
+  SQLite gateway and therefore stays sequential
 - `S218` exercises Gemini's native `batchEmbedContents` path (batch input,
   `dimensions`); read-only and rerunnable in any order
 - `S219` asserts the effective resilience configuration on

--- a/tests/e2e/release-e2e-scenarios.md
+++ b/tests/e2e/release-e2e-scenarios.md
@@ -6106,3 +6106,40 @@ curl -fsS "$BASE_URL/admin/virtual-models" \
 cleanup_s227
 trap - EXIT
 ```
+
+### S228 Gemini 3 tool-call round trip preserves the thought signature
+
+Gemini 3 attaches a `thoughtSignature` to every function call and rejects a
+follow-up request whose history lacks it (HTTP 400). The gateway must expose
+it as `tool_calls[].extra_content.google.thought_signature` and send it back
+when the client echoes the assistant turn verbatim, as OpenAI SDK agent loops
+do.
+
+```bash
+CALL_FILE="$QA_RUN_DIR/s228.call.json"
+FOLLOW_FILE="$QA_RUN_DIR/s228.followup.json"
+TOOLS='[{"type":"function","function":{"name":"lookup_weather","description":"Get the current weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}]'
+curl -fsS "$BASE_URL/v1/chat/completions" \
+  -H 'Content-Type: application/json' \
+  -d "{\"model\":\"gemini-3.5-flash-lite\",\"tools\":$TOOLS,\"tool_choice\":{\"type\":\"function\",\"function\":{\"name\":\"lookup_weather\"}},\"messages\":[{\"role\":\"user\",\"content\":\"What is the weather in Warsaw?\"}]}" \
+  > "$CALL_FILE"
+jq '{finish_reason:.choices[0].finish_reason,tool_calls:.choices[0].message.tool_calls}' "$CALL_FILE"
+jq -e '
+    .choices[0].finish_reason == "tool_calls"
+    and (.choices[0].message.tool_calls[0].function.name == "lookup_weather")
+    and (.choices[0].message.tool_calls[0].extra_content.google.thought_signature | type == "string" and length > 0)
+  ' "$CALL_FILE" >/dev/null
+jq -c --argjson tools "$TOOLS" '{
+    model: "gemini-3.5-flash-lite",
+    tools: $tools,
+    messages: [
+      {role: "user", content: "What is the weather in Warsaw?"},
+      .choices[0].message,
+      {role: "tool", tool_call_id: .choices[0].message.tool_calls[0].id, content: "sunny, 22C"}
+    ]
+  }' "$CALL_FILE" \
+  | curl -fsS "$BASE_URL/v1/chat/completions" -H 'Content-Type: application/json' -d @- \
+  > "$FOLLOW_FILE"
+jq '{provider,answer:.choices[0].message.content}' "$FOLLOW_FILE"
+assert_chat_response_contains "$FOLLOW_FILE" "gemini" "22"
+```

--- a/tests/e2e/run-release-e2e.sh
+++ b/tests/e2e/run-release-e2e.sh
@@ -362,7 +362,8 @@ is_parallel_safe() {
     || (number >= 160 && number <= 162) \
     || (number >= 173 && number <= 191) \
     || (number >= 197 && number <= 204) \
-    || (number >= 208 && number <= 226) ))
+    || (number >= 208 && number <= 226) \
+    || number == 228 ))
 }
 
 if (( JOBS > 1 )); then


### PR DESCRIPTION
Closes #891

## Problem

Gemini 3 attaches an encrypted `thoughtSignature` to every `functionCall` part and rejects a follow-up request whose history lacks it:

```
400: Function call is missing a thought_signature in functionCall parts.
```

The native adapter dropped the signature when converting the Gemini response to OpenAI `tool_calls`, and had no way to restore it when the client echoed the assistant turn back. Any multi-step agent loop on Gemini 3 failed on the second request.

## Change

- **Response → client:** a function call's signature is exposed as `tool_calls[].extra_content.google.thought_signature`, the shape Google's own OpenAI-compatible endpoint uses, so clients written for that endpoint keep working. A text turn's signature lands on `message.extra_content`. Streamed `tool_calls` deltas and Responses API `function_call` items (non-stream and stream) carry the same member; only `extra_content` is forwarded onto Responses items.
- **Client → Gemini:** the signature is read back from `extra_content` (a flat `thought_signature` / `thoughtSignature` on the tool call or its `function` object is accepted too) and placed on the matching `functionCall` part. Mixed text-and-tool turns keep both the text signature and the per-call ones. Parallel batches are sent back exactly as received (only the first call is signed).
- **Fallback:** on Gemini 3, an assistant turn whose calls carry no signature at all (history from another model, client that dropped the field, Anthropic Messages ingress) gets Google's documented `skip_thought_signature_validator` placeholder instead of surfacing the 400.
- **Responses API:** a tool-call-only Gemini turn now has `content: null` like OpenAI, instead of an empty message item that the Responses ingress refused to accept when echoed back.

Only the native Gemini/Vertex path changes; `openai_compatible` mode already passed `extra_content` through. OpenAI accepts the extra member on echoed tool calls, so fallback chains are unaffected.

## Verification

- Unit tests for request/response/stream translation, the placeholder rules, flat spellings, mixed turns, the Responses output item and stream converter (including an `extra_content: null` delta).
- Mock-upstream e2e tests (`tests/e2e/gemini_native_tools_test.go`) enforce Gemini 3's rule in CI: chat and Responses round trips, full `response.output` echo, and the placeholder path.
- Live against `gemini-3.5-flash`: sequential and parallel tool calls over `/v1/chat/completions` (stream and non-stream) and `/v1/responses` (stream and non-stream), plus the stripped-signature fallback.
- New release e2e scenario `S228` echoes a Gemini 3 tool call back through the gateway; the existing matrix only ran Gemini single-turn on 2.5 (which does not validate signatures) and tool round trips on OpenAI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for preserving Gemini 3 thought signatures across tool calls, text responses, streaming, and follow-up requests.
  * Preserved provider metadata when converting tool calls through the Responses API.
  * Tool-call-only responses now return `null` content instead of an empty string.

* **Documentation**
  * Added guidance for handling Gemini 3 thought signatures, including streaming, parallel calls, and fallback scenarios.

* **Tests**
  * Added coverage for thought-signature round trips and Responses API metadata preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->