### PR TITLE
feat(resilience): configure status policies and per-model circuit breakers

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -307,12 +307,15 @@ workflows:
 # Individual providers can override any of these values.
 resilience:
   retry:
+    retry_on_statuses: [429, 502, 503, 504, 522, 524] # env: RETRY_ON_STATUSES; [] disables status-based retries
     max_retries: 3
     initial_backoff: 1s
     max_backoff: 30s
     backoff_factor: 2.0
     jitter_factor: 0.1
   circuit_breaker:
+    failure_on_statuses: [429, 5xx] # env: CIRCUIT_BREAKER_FAILURE_ON_STATUSES; [] disables status-based failures
+    scope: provider # env: CIRCUIT_BREAKER_SCOPE; model isolates each model within a provider
     # Set false to never fail fast on a struggling provider (default: true).
     enabled: true
     failure_threshold: 5

--- a/config/config.go
+++ b/config/config.go
@@ -300,6 +300,7 @@ func Load() (*LoadResult, error) {
 		return nil, fmt.Errorf("models.configured_provider_models_mode must be one of: fallback, allowlist, merge")
 	}
 
+	cfg.Resilience.CircuitBreaker.Scope = NormalizeBreakerScope(cfg.Resilience.CircuitBreaker.Scope)
 	if err := validateResilienceConfig(cfg.Resilience, rawProviders); err != nil {
 		return nil, err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -300,6 +300,10 @@ func Load() (*LoadResult, error) {
 		return nil, fmt.Errorf("models.configured_provider_models_mode must be one of: fallback, allowlist, merge")
 	}
 
+	if err := validateResilienceConfig(cfg.Resilience, rawProviders); err != nil {
+		return nil, err
+	}
+
 	if err := loadFailoverConfig(&cfg.Failover); err != nil {
 		return nil, err
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -269,12 +269,12 @@ func TestBuildDefaultConfig(t *testing.T) {
 	}
 
 	expectedRetry := DefaultRetryConfig()
-	if cfg.Resilience.Retry != expectedRetry {
+	if !reflect.DeepEqual(cfg.Resilience.Retry, expectedRetry) {
 		t.Errorf("expected Resilience.Retry=%+v, got %+v", expectedRetry, cfg.Resilience.Retry)
 	}
 
 	expectedCB := DefaultCircuitBreakerConfig()
-	if cfg.Resilience.CircuitBreaker != expectedCB {
+	if !reflect.DeepEqual(cfg.Resilience.CircuitBreaker, expectedCB) {
 		t.Errorf("expected Resilience.CircuitBreaker=%+v, got %+v", expectedCB, cfg.Resilience.CircuitBreaker)
 	}
 }

--- a/config/resilience.go
+++ b/config/resilience.go
@@ -5,27 +5,33 @@ import "time"
 // RetryConfig holds resolved retry settings for an LLM client.
 // This is the canonical type shared between config and llmclient.
 type RetryConfig struct {
-	MaxRetries     int           `yaml:"max_retries"     env:"RETRY_MAX_RETRIES"`
-	InitialBackoff time.Duration `yaml:"initial_backoff" env:"RETRY_INITIAL_BACKOFF"`
-	MaxBackoff     time.Duration `yaml:"max_backoff"     env:"RETRY_MAX_BACKOFF"`
-	BackoffFactor  float64       `yaml:"backoff_factor"  env:"RETRY_BACKOFF_FACTOR"`
-	JitterFactor   float64       `yaml:"jitter_factor"   env:"RETRY_JITTER_FACTOR"`
+	// RetryOnStatuses uses defaults when nil; an empty list disables status triggers.
+	RetryOnStatuses []string      `yaml:"retry_on_statuses" env:"RETRY_ON_STATUSES"`
+	MaxRetries      int           `yaml:"max_retries"     env:"RETRY_MAX_RETRIES"`
+	InitialBackoff  time.Duration `yaml:"initial_backoff" env:"RETRY_INITIAL_BACKOFF"`
+	MaxBackoff      time.Duration `yaml:"max_backoff"     env:"RETRY_MAX_BACKOFF"`
+	BackoffFactor   float64       `yaml:"backoff_factor"  env:"RETRY_BACKOFF_FACTOR"`
+	JitterFactor    float64       `yaml:"jitter_factor"   env:"RETRY_JITTER_FACTOR"`
 }
 
 // DefaultRetryConfig returns the default retry settings.
 func DefaultRetryConfig() RetryConfig {
 	return RetryConfig{
-		MaxRetries:     3,
-		InitialBackoff: 1 * time.Second,
-		MaxBackoff:     30 * time.Second,
-		BackoffFactor:  2.0,
-		JitterFactor:   0.1,
+		RetryOnStatuses: []string{"429", "502", "503", "504", "522", "524"},
+		MaxRetries:      3,
+		InitialBackoff:  1 * time.Second,
+		MaxBackoff:      30 * time.Second,
+		BackoffFactor:   2.0,
+		JitterFactor:    0.1,
 	}
 }
 
 // CircuitBreakerConfig holds resolved circuit breaker settings.
 // This is the canonical type shared between config and llmclient.
 type CircuitBreakerConfig struct {
+	// FailureOnStatuses uses defaults when nil; an empty list disables status triggers.
+	FailureOnStatuses []string `yaml:"failure_on_statuses" env:"CIRCUIT_BREAKER_FAILURE_ON_STATUSES"`
+	Scope             string   `yaml:"scope" env:"CIRCUIT_BREAKER_SCOPE"`
 	// Enabled switches the circuit breaker on or off. When false, requests are
 	// never short-circuited regardless of the thresholds below.
 	// Default: true
@@ -38,10 +44,12 @@ type CircuitBreakerConfig struct {
 // DefaultCircuitBreakerConfig returns the default circuit breaker settings.
 func DefaultCircuitBreakerConfig() CircuitBreakerConfig {
 	return CircuitBreakerConfig{
-		Enabled:          true,
-		FailureThreshold: 5,
-		SuccessThreshold: 2,
-		Timeout:          30 * time.Second,
+		FailureOnStatuses: []string{"429", "5xx"},
+		Scope:             "provider",
+		Enabled:           true,
+		FailureThreshold:  5,
+		SuccessThreshold:  2,
+		Timeout:           30 * time.Second,
 	}
 }
 
@@ -61,18 +69,21 @@ type RawResilienceConfig struct {
 // RawCircuitBreakerConfig holds optional per-provider circuit breaker overrides from YAML.
 // Nil fields inherit from the global CircuitBreakerConfig.
 type RawCircuitBreakerConfig struct {
-	Enabled          *bool          `yaml:"enabled"`
-	FailureThreshold *int           `yaml:"failure_threshold"`
-	SuccessThreshold *int           `yaml:"success_threshold"`
-	Timeout          *time.Duration `yaml:"timeout"`
+	FailureOnStatuses []string       `yaml:"failure_on_statuses"`
+	Scope             *string        `yaml:"scope"`
+	Enabled           *bool          `yaml:"enabled"`
+	FailureThreshold  *int           `yaml:"failure_threshold"`
+	SuccessThreshold  *int           `yaml:"success_threshold"`
+	Timeout           *time.Duration `yaml:"timeout"`
 }
 
 // RawRetryConfig holds optional per-provider retry overrides from YAML.
 // Nil fields inherit from the global RetryConfig.
 type RawRetryConfig struct {
-	MaxRetries     *int           `yaml:"max_retries"`
-	InitialBackoff *time.Duration `yaml:"initial_backoff"`
-	MaxBackoff     *time.Duration `yaml:"max_backoff"`
-	BackoffFactor  *float64       `yaml:"backoff_factor"`
-	JitterFactor   *float64       `yaml:"jitter_factor"`
+	RetryOnStatuses []string       `yaml:"retry_on_statuses"`
+	MaxRetries      *int           `yaml:"max_retries"`
+	InitialBackoff  *time.Duration `yaml:"initial_backoff"`
+	MaxBackoff      *time.Duration `yaml:"max_backoff"`
+	BackoffFactor   *float64       `yaml:"backoff_factor"`
+	JitterFactor    *float64       `yaml:"jitter_factor"`
 }

--- a/config/resilience_policy.go
+++ b/config/resilience_policy.go
@@ -22,7 +22,7 @@ func ParseResilienceStatuses(entries, defaults []string) (map[int]bool, error) {
 }
 
 func validateResilienceConfig(global ResilienceConfig, providers map[string]RawProviderConfig) error {
-	if err := validateResilience(global); err != nil {
+	if err := ValidateResilience(global); err != nil {
 		return fmt.Errorf("resilience: %w", err)
 	}
 	for name, provider := range providers {
@@ -41,14 +41,15 @@ func validateResilienceConfig(global ResilienceConfig, providers map[string]RawP
 				r.CircuitBreaker.Scope = *cb.Scope
 			}
 		}
-		if err := validateResilience(r); err != nil {
+		if err := ValidateResilience(r); err != nil {
 			return fmt.Errorf("providers.%s.resilience: %w", name, err)
 		}
 	}
 	return nil
 }
 
-func validateResilience(r ResilienceConfig) error {
+// ValidateResilience checks policies for both file loading and programmatic providers.
+func ValidateResilience(r ResilienceConfig) error {
 	if _, err := ParseResilienceStatuses(r.Retry.RetryOnStatuses, nil); err != nil {
 		return fmt.Errorf("retry.retry_on_statuses: %w", err)
 	}
@@ -61,4 +62,12 @@ func validateResilience(r ResilienceConfig) error {
 		return fmt.Errorf("circuit_breaker.scope must be provider or model")
 	}
 	return nil
+}
+
+// NormalizeBreakerScope resolves the empty scope to the provider default.
+func NormalizeBreakerScope(scope string) string {
+	if scope == "" {
+		return "provider"
+	}
+	return scope
 }

--- a/config/resilience_policy.go
+++ b/config/resilience_policy.go
@@ -1,0 +1,64 @@
+package config
+
+import "fmt"
+
+// ParseResilienceStatuses expands exact HTTP codes and classes. Nil uses the
+// supplied defaults; an explicit empty list disables status-based matches.
+func ParseResilienceStatuses(entries, defaults []string) (map[int]bool, error) {
+	if entries == nil {
+		entries = defaults
+	}
+	statuses := make(map[int]bool)
+	for _, entry := range entries {
+		codes, ok := expandStatusToken(entry)
+		if !ok {
+			return nil, fmt.Errorf("%q is not an HTTP status code or class such as 5xx", entry)
+		}
+		for _, code := range codes {
+			statuses[code] = true
+		}
+	}
+	return statuses, nil
+}
+
+func validateResilienceConfig(global ResilienceConfig, providers map[string]RawProviderConfig) error {
+	if err := validateResilience(global); err != nil {
+		return fmt.Errorf("resilience: %w", err)
+	}
+	for name, provider := range providers {
+		if provider.Resilience == nil {
+			continue
+		}
+		r := global
+		if retry := provider.Resilience.Retry; retry != nil && retry.RetryOnStatuses != nil {
+			r.Retry.RetryOnStatuses = retry.RetryOnStatuses
+		}
+		if cb := provider.Resilience.CircuitBreaker; cb != nil {
+			if cb.FailureOnStatuses != nil {
+				r.CircuitBreaker.FailureOnStatuses = cb.FailureOnStatuses
+			}
+			if cb.Scope != nil {
+				r.CircuitBreaker.Scope = *cb.Scope
+			}
+		}
+		if err := validateResilience(r); err != nil {
+			return fmt.Errorf("providers.%s.resilience: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func validateResilience(r ResilienceConfig) error {
+	if _, err := ParseResilienceStatuses(r.Retry.RetryOnStatuses, nil); err != nil {
+		return fmt.Errorf("retry.retry_on_statuses: %w", err)
+	}
+	if _, err := ParseResilienceStatuses(r.CircuitBreaker.FailureOnStatuses, nil); err != nil {
+		return fmt.Errorf("circuit_breaker.failure_on_statuses: %w", err)
+	}
+	switch r.CircuitBreaker.Scope {
+	case "", "provider", "model":
+	default:
+		return fmt.Errorf("circuit_breaker.scope must be provider or model")
+	}
+	return nil
+}

--- a/config/resilience_policy_test.go
+++ b/config/resilience_policy_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestResiliencePolicyLoading(t *testing.T) {
+	for _, tc := range []struct{ name, body, wantError string }{
+		{"defaults", "", ""},
+		{"classes", "resilience:\n  retry:\n    retry_on_statuses: [429, 5xx]\n  circuit_breaker:\n    scope: model\n    failure_on_statuses: []\n", ""},
+		{"invalid retry", "resilience:\n  retry:\n    retry_on_statuses: [600]\n", "retry.retry_on_statuses"},
+		{"invalid breaker", "resilience:\n  circuit_breaker:\n    failure_on_statuses: [oops]\n", "circuit_breaker.failure_on_statuses"},
+		{"invalid scope", "resilience:\n  circuit_breaker:\n    scope: global\n", "circuit_breaker.scope"},
+		{"invalid provider", "providers:\n  cloudflare:\n    resilience:\n      retry:\n        retry_on_statuses: [oops]\n", "providers.cloudflare.resilience"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearProviderEnvVars(t)
+			dir := t.TempDir()
+			writeConfigYAML(t, dir, tc.body)
+			t.Chdir(dir)
+			_, err := Load()
+			if tc.wantError == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+			} else if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("error=%v, want %s", err, tc.wantError)
+			}
+		})
+	}
+}
+
+func TestResilienceEmptyListsAndEnvironment(t *testing.T) {
+	cfg := &Config{Resilience: ResilienceConfig{Retry: DefaultRetryConfig(), CircuitBreaker: DefaultCircuitBreakerConfig()}}
+	if err := yaml.Unmarshal([]byte("resilience:\n  retry:\n    retry_on_statuses: []\n  circuit_breaker:\n    failure_on_statuses: []\n"), cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Resilience.Retry.RetryOnStatuses == nil || cfg.Resilience.CircuitBreaker.FailureOnStatuses == nil {
+		t.Fatal("explicit empty lists must remain non-nil")
+	}
+	t.Setenv("RETRY_ON_STATUSES", "429,524")
+	t.Setenv("CIRCUIT_BREAKER_FAILURE_ON_STATUSES", "429,5xx")
+	t.Setenv("CIRCUIT_BREAKER_SCOPE", "model")
+	if err := applyEnvOverrides(cfg); err != nil {
+		t.Fatal(err)
+	}
+	statuses, err := ParseResilienceStatuses(cfg.Resilience.CircuitBreaker.FailureOnStatuses, nil)
+	if err != nil || !statuses[429] || !statuses[524] || cfg.Resilience.CircuitBreaker.Scope != "model" {
+		t.Fatalf("config=%+v err=%v", cfg.Resilience, err)
+	}
+	if strings.Join(cfg.Resilience.Retry.RetryOnStatuses, ",") != "429,524" {
+		t.Fatal("retry environment override missing")
+	}
+}

--- a/docs/advanced/resilience.mdx
+++ b/docs/advanced/resilience.mdx
@@ -105,7 +105,16 @@ HTTP attempt, without retries.
 The circuit breaker is in-memory and per gateway process: each provider
 gets its own breaker by default. With `scope: model`, each model within a
 provider instance gets an independent breaker; requests without a model,
-such as discovery, use a separate provider breaker. State resets on restart
+such as discovery, use a separate provider breaker. Multipart audio uploads
+use their explicit model names.
+
+Each provider retains at most 1,024 model breakers. Idle closed entries expire
+after 10 minutes when a new model is looked up; the oldest idle closed entry
+is evicted sooner when the limit is reached. Active and open breakers are
+preserved. If every slot is protected, a new model receives a failover-eligible
+`503` until a slot becomes available.
+
+State resets on restart
 and nothing is shared between replicas.
 
 ## Environment Variables

--- a/docs/advanced/resilience.mdx
+++ b/docs/advanced/resilience.mdx
@@ -12,7 +12,8 @@ GoModel wraps every upstream provider call with two resilience layers:
 2. **Circuit breaker** — short-circuits calls to a provider that has been
    failing repeatedly, then probes once the timeout elapses.
 
-Both layers apply per provider. They do not switch to a different model or
+Retries apply to the selected target. Circuit breakers apply per provider by
+default, or per model with `scope: model`. They do not switch to a different model or
 provider on failure. For cross-model failover, see
 [Failover](/features/failover).
 
@@ -23,6 +24,9 @@ you need.
 
 | Setting             | Default | Notes                                          |
 | ------------------- | ------- | ---------------------------------------------- |
+| `retry_on_statuses` | `[429, 502, 503, 504, 522, 524]` | HTTP statuses that trigger retries |
+| `failure_on_statuses` | `[429, 5xx]` | HTTP statuses that count as breaker failures |
+| `scope` | `provider` | Breaker isolation: `provider` or `model` |
 | `max_retries`       | `3`     | Maximum retry attempts per request             |
 | `initial_backoff`   | `1s`    | First retry wait                               |
 | `max_backoff`       | `30s`   | Upper cap on retry wait                        |
@@ -50,9 +54,12 @@ the full timeout.
 ## What counts as a failure
 
 **Retries** fire on transport errors (connection refused, resets, DNS
-failures) and on `429`, `502`, `503`, and `504` responses. Other statuses —
-including `500` — are returned to the caller without retrying. Two paths
+failures) and, by default, on `429`, `502`, `503`, `504`, `522`, and `524` responses. Other statuses —
+including `500` — are returned to the caller without retrying. The following paths
 retry less than the table suggests:
+
+- **Local HTTP client timeouts** return immediately without retrying. An
+  expired overall request context also prevents further attempts.
 
 - **Streaming** requests are never retried once dispatched, because partial
   data may already have been sent.
@@ -70,25 +77,36 @@ exactly like a genuine error status, and the response is never cached as a
 success. Passthrough endpoints are exempt: they forward the provider's
 response byte-for-byte.
 
-**The circuit breaker** counts transport errors and `5xx` responses
-(including non-retried `500`s) as failures. It deliberately ignores:
+**The circuit breaker** counts transport errors and, by default, `429` and
+all `5xx` responses as failures. One exhausted retry sequence counts as one
+failure; individual HTTP retries do not increment the breaker. A successful
+sequence records success. Client cancellation is ignored; local client
+timeouts count as failures.
 
-- `429` rate limits — a rate-limited provider is up, so the backpressure
-  signal is passed through instead of opening the circuit. The one
-  exception is a `429` on a half-open probe, which reopens the circuit.
-- `4xx` responses — the provider answered; the request was at fault.
-- Requests canceled by the client — a disconnect says nothing about
-  provider health. Client-side *timeouts* do count as failures.
+Set `retry.retry_on_statuses` and `circuit_breaker.failure_on_statuses`
+independently. Both accept exact codes and classes such as `5xx`. Omitted
+lists use defaults; explicit lists replace them; `[]` disables status-based
+triggers while retaining transport-error handling. For example,
+`failure_on_statuses: [5xx]` excludes rate limits from breaker failures,
+including during recovery probes. Invalid codes or scopes fail configuration
+loading.
+
+The default now includes `429` breaker failures. Deployments that previously
+relied on rate limits leaving the breaker closed can set
+`failure_on_statuses: [5xx]` to retain that behavior.
 
 While the circuit is open, requests fail fast with a `503` and the message
 `circuit breaker is open - provider temporarily unavailable`. After
 `timeout` elapses, a single probe request is let through while concurrent
 requests keep failing fast; `success_threshold` consecutive successful
-probes close the circuit, and any probe failure reopens it.
+probes close the circuit, and a failure matching the breaker policy reopens it. Probes make only one
+HTTP attempt, without retries.
 
 The circuit breaker is in-memory and per gateway process: each provider
-gets its own breaker, state resets on restart, and nothing is shared
-between replicas.
+gets its own breaker by default. With `scope: model`, each model within a
+provider instance gets an independent breaker; requests without a model,
+such as discovery, use a separate provider breaker. State resets on restart
+and nothing is shared between replicas.
 
 ## Environment Variables
 
@@ -99,6 +117,7 @@ in YAML.
 
 | Variable                 | Type     | Default | Description                                |
 | ------------------------ | -------- | ------- | ------------------------------------------ |
+| `RETRY_ON_STATUSES` | comma-separated list | `429,502,503,504,522,524` | HTTP statuses that trigger retries |
 | `RETRY_MAX_RETRIES`      | int      | `3`     | Maximum retry attempts per request         |
 | `RETRY_INITIAL_BACKOFF`  | duration | `1s`    | First retry wait (e.g. `500ms`, `2s`)      |
 | `RETRY_MAX_BACKOFF`      | duration | `30s`   | Upper cap on retry wait                    |
@@ -109,6 +128,8 @@ in YAML.
 
 | Variable                            | Type     | Default | Description                                   |
 | ----------------------------------- | -------- | ------- | --------------------------------------------- |
+| `CIRCUIT_BREAKER_FAILURE_ON_STATUSES` | comma-separated list | `429,5xx` | HTTP statuses counted as failures |
+| `CIRCUIT_BREAKER_SCOPE` | string | `provider` | `provider` or `model` isolation |
 | `CIRCUIT_BREAKER_ENABLED`           | bool     | `true`  | Set `false` to turn the circuit breaker off    |
 | `CIRCUIT_BREAKER_FAILURE_THRESHOLD` | int      | `5`     | Consecutive failures before opening           |
 | `CIRCUIT_BREAKER_SUCCESS_THRESHOLD` | int      | `2`     | Consecutive successes to close again          |
@@ -195,7 +216,9 @@ combines two independent signals:
 The circuit breaker's state is shown on each provider card: expanding a
 card reveals a **Breaker State** chip, an open breaker turns the provider's
 status pill to `Circuit Open`, and a half-open breaker shows `Recovering`.
-A model whose recent requests keep failing (at least 3 errors making up
+With `scope: model`, the provider-level breaker display and metric reflect
+the breaker of the most recently completed request, rather than an aggregate
+of all model breakers. A model whose recent requests keep failing (at least 3 errors making up
 half or more of its windowed requests) marks the provider `Degraded` even
 while model discovery still succeeds — this catches upstreams that list
 models fine but fail real calls, e.g. with misreported `4xx` errors that
@@ -248,7 +271,49 @@ Unhealthy until its first successful fetch.
 
 ## Failover vs. Resilience
 
-The retry and circuit breaker layers stay on a single provider. If you also
+Retries stay on the selected target; the circuit breaker tracks the configured
+provider or model scope. If you also
 want GoModel to try a different model or provider when the primary keeps
 failing, give the model a virtual model with more than one target — the
 remaining targets are its failover chain. See [Failover](/features/failover).
+
+## Retry Cloudflare timeouts, then switch models
+
+For non-streaming translated requests, combine retries with a failover virtual
+model. Merge the following settings into your existing configuration, using
+your configured provider and model names:
+
+```yaml
+providers:
+  cloudflare:
+    # Keep your existing type, base_url, and credentials here.
+    resilience:
+      retry:
+        max_retries: 2
+        retry_on_statuses: [429, 502, 503, 504, 522, 524]
+      circuit_breaker:
+        scope: model
+        failure_on_statuses: [429, 5xx]
+        failure_threshold: 5
+
+virtual_models:
+  - source: resilient-chat
+    strategy: failover
+    targets:
+      - model: cloudflare/model1
+      - model: cloudflare/model2
+
+failover:
+  enabled: true
+  retry_on_statuses: [429, 5xx]
+```
+
+Send `model: resilient-chat`. While model1's breaker is closed, a `524`
+response triggers up to two retries against model1. If all three attempts
+fail, GoModel tries model2 with its own retry budget. Model1's open breaker
+skips its upstream calls without blocking model2. With the default
+`scope: provider`, both models share a breaker instead.
+
+The caller's deadline must allow time for the attempts and backoff. Streaming
+requests do not get this retry sequence; a partially delivered response
+cannot be restarted transparently.

--- a/docs/features/failover.mdx
+++ b/docs/features/failover.mdx
@@ -75,6 +75,10 @@ are not swept in turn — which is what lets `gpt-4o` fall back to
 other redirect (an alias, a virtual model under a new name) that lists a
 protected model does sweep that model's fallbacks.
 
+Provider retries run before failover for non-streaming requests. To retry
+Cloudflare `522`/`524` responses and then switch models on the same provider,
+use [resilience settings with per-model breakers](/advanced/resilience#retry-cloudflare-timeouts-then-switch-models).
+
 ## When it runs
 
 Failover is attempted only after an attempt returns:

--- a/internal/admin/handler_provider_credentials_test.go
+++ b/internal/admin/handler_provider_credentials_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"sort"
 	"testing"
 
@@ -686,7 +687,7 @@ func TestProviderStatus_ReportsCredentialServiceConfigForRuntimeProviders(t *tes
 			if item.Config.BaseURL != tt.want.BaseURL {
 				t.Errorf("config.base_url = %q, want %q", item.Config.BaseURL, tt.want.BaseURL)
 			}
-			if item.Config.Resilience != tt.want.Resilience {
+			if !reflect.DeepEqual(item.Config.Resilience, tt.want.Resilience) {
 				t.Errorf("config.resilience = %+v, want %+v", item.Config.Resilience, tt.want.Resilience)
 			}
 			if item.StatusLabel != tt.wantLabel {

--- a/internal/gateway/resilience_failover_test.go
+++ b/internal/gateway/resilience_failover_test.go
@@ -1,0 +1,68 @@
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/llmclient"
+)
+
+type retryFailoverProvider struct {
+	providerTypeResolverStub
+	client *llmclient.Client
+}
+
+func (p *retryFailoverProvider) ChatCompletion(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+	model := strings.TrimPrefix(req.Model, "cloudflare/")
+	var response core.ChatResponse
+	err := p.client.Do(ctx, llmclient.Request{Method: "GET", Endpoint: "/" + model, Model: model}, &response)
+	return &response, err
+}
+
+func TestCloudflareTimeoutRetriesBeforeModelFailover(t *testing.T) {
+	var calls []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls = append(calls, r.URL.Path)
+		if r.URL.Path == "/model1" {
+			w.WriteHeader(524)
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"backup","model":"model2","choices":[]}`))
+	}))
+	defer server.Close()
+	cfg := llmclient.DefaultConfig("cloudflare", server.URL)
+	cfg.Retry.MaxRetries = 2
+	cfg.Retry.InitialBackoff = time.Nanosecond
+	cfg.CircuitBreaker.Scope = "model"
+	cfg.CircuitBreaker.FailureThreshold = 1
+	provider := &retryFailoverProvider{client: llmclient.New(cfg, nil)}
+	orchestrator := NewInferenceOrchestrator(InferenceConfig{
+		Provider: provider,
+		FailoverResolver: failoverResolverFunc(func(*core.RequestModelResolution, core.Operation) []core.ModelSelector {
+			return []core.ModelSelector{{Provider: "cloudflare", Model: "model2"}}
+		}),
+	})
+	workflow := &core.Workflow{
+		Endpoint:   core.DescribeEndpoint("POST", "/v1/chat/completions"),
+		Resolution: &core.RequestModelResolution{ResolvedSelector: core.ModelSelector{Provider: "cloudflare", Model: "model1"}},
+		Policy:     &core.ResolvedWorkflowPolicy{Features: core.WorkflowFeatures{Failover: true}},
+	}
+	for range 2 {
+		response, _, err := orchestrator.DispatchChatCompletion(context.Background(), workflow, &core.ChatRequest{Model: "model1"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if response.ID != "backup" {
+			t.Fatalf("response=%+v", response)
+		}
+	}
+	// First request exhausts model1; the second skips its open breaker.
+	if got := strings.Join(calls, ","); got != "/model1,/model1,/model1,/model2,/model2" {
+		t.Fatalf("upstream calls=%s", got)
+	}
+}

--- a/internal/llmclient/client.go
+++ b/internal/llmclient/client.go
@@ -107,7 +107,9 @@ type Client struct {
 	config          Config
 	headerSetter    HeaderSetter
 	circuitBreaker  *circuitBreaker
-	modelBreakers   sync.Map // model name -> *circuitBreaker
+	modelBreakersMu sync.Mutex
+	modelBreakers   map[[32]byte]*modelBreakerEntry
+	configErr       error
 	retryStatuses   map[int]bool
 	failureStatuses map[int]bool
 }
@@ -120,10 +122,20 @@ func New(cfg Config, headerSetter HeaderSetter) *Client {
 		headerSetter: headerSetter,
 	}
 
-	// Config loading validates these lists. Programmatic callers receive the
-	// defaults for nil lists, and no matches for invalid lists.
-	c.retryStatuses, _ = config.ParseResilienceStatuses(cfg.Retry.RetryOnStatuses, config.DefaultRetryConfig().RetryOnStatuses)
-	c.failureStatuses, _ = config.ParseResilienceStatuses(cfg.CircuitBreaker.FailureOnStatuses, config.DefaultCircuitBreakerConfig().FailureOnStatuses)
+	// Keep the constructor API stable; direct callers receive invalid-config
+	// errors from request methods. ProviderFactory rejects them before creation.
+	c.configErr = config.ValidateResilience(config.ResilienceConfig{Retry: cfg.Retry, CircuitBreaker: cfg.CircuitBreaker})
+	if c.configErr != nil {
+		return c
+	}
+	c.retryStatuses, c.configErr = config.ParseResilienceStatuses(cfg.Retry.RetryOnStatuses, config.DefaultRetryConfig().RetryOnStatuses)
+	if c.configErr != nil {
+		return c
+	}
+	c.failureStatuses, c.configErr = config.ParseResilienceStatuses(cfg.CircuitBreaker.FailureOnStatuses, config.DefaultCircuitBreakerConfig().FailureOnStatuses)
+	if c.configErr != nil {
+		return c
+	}
 
 	// The breaker is off when explicitly disabled or when it can never trip.
 	if cfg.CircuitBreaker.Enabled && cfg.CircuitBreaker.FailureThreshold > 0 {

--- a/internal/llmclient/client.go
+++ b/internal/llmclient/client.go
@@ -1,7 +1,7 @@
 // Package llmclient provides a base HTTP client for LLM providers with:
 // - Request marshaling/unmarshaling
 // - Retries with exponential backoff and jitter
-// - Standardized error parsing (429, 502, 503, 504), including errors embedded in 200-status bodies
+// - Standardized error parsing, including errors embedded in 200-status bodies
 // - Circuit breaking with half-open state protection
 package llmclient
 
@@ -43,7 +43,7 @@ type ResponseInfo struct {
 	Stream          bool          // Whether this was a streaming request
 	StreamUncertain bool          // Whether request stream intent was unknown at dispatch
 	Error           error         // Error if request failed (nil on success)
-	// CircuitState is the provider's circuit breaker state after this request
+	// CircuitState is the selected provider or model breaker state after this request
 	// completed ("closed", "half-open", "open"); empty when the breaker is
 	// disabled. It reflects the moment of completion, so metrics built from it
 	// update as traffic flows.
@@ -102,11 +102,14 @@ type HeaderSetter func(req *http.Request)
 
 // Client is a base HTTP client for LLM providers
 type Client struct {
-	mu             sync.RWMutex
-	httpClient     *http.Client
-	config         Config
-	headerSetter   HeaderSetter
-	circuitBreaker *circuitBreaker
+	mu              sync.RWMutex
+	httpClient      *http.Client
+	config          Config
+	headerSetter    HeaderSetter
+	circuitBreaker  *circuitBreaker
+	modelBreakers   sync.Map // model name -> *circuitBreaker
+	retryStatuses   map[int]bool
+	failureStatuses map[int]bool
 }
 
 // New creates a new LLM client with the given configuration
@@ -116,6 +119,11 @@ func New(cfg Config, headerSetter HeaderSetter) *Client {
 		config:       cfg,
 		headerSetter: headerSetter,
 	}
+
+	// Config loading validates these lists. Programmatic callers receive the
+	// defaults for nil lists, and no matches for invalid lists.
+	c.retryStatuses, _ = config.ParseResilienceStatuses(cfg.Retry.RetryOnStatuses, config.DefaultRetryConfig().RetryOnStatuses)
+	c.failureStatuses, _ = config.ParseResilienceStatuses(cfg.CircuitBreaker.FailureOnStatuses, config.DefaultCircuitBreakerConfig().FailureOnStatuses)
 
 	// The breaker is off when explicitly disabled or when it can never trip.
 	if cfg.CircuitBreaker.Enabled && cfg.CircuitBreaker.FailureThreshold > 0 {

--- a/internal/llmclient/client_scope.go
+++ b/internal/llmclient/client_scope.go
@@ -18,6 +18,7 @@ type requestScope struct {
 	ctx           context.Context
 	startedAt     time.Time
 	requestInfo   RequestInfo
+	breaker       *circuitBreaker
 	halfOpenProbe bool
 }
 
@@ -40,8 +41,9 @@ func (c *Client) beginRequest(ctx context.Context, req Request, stream bool) (re
 		scope.ctx = c.config.Hooks.OnRequestStart(scope.ctx, scope.requestInfo)
 	}
 
-	if c.circuitBreaker != nil {
-		allowed, probe := c.circuitBreaker.acquire()
+	scope.breaker = c.breakerForModel(scope.requestInfo.Model)
+	if scope.breaker != nil {
+		allowed, probe := scope.breaker.acquire()
 		if !allowed {
 			err := core.NewProviderError(c.config.ProviderName, http.StatusServiceUnavailable,
 				"circuit breaker is open - provider temporarily unavailable", nil)
@@ -66,8 +68,8 @@ func (c *Client) finishRequest(scope requestScope, statusCode int, err error) {
 		return
 	}
 	circuitState := ""
-	if c.circuitBreaker != nil {
-		circuitState = c.circuitBreaker.State()
+	if scope.breaker != nil {
+		circuitState = scope.breaker.State()
 	}
 	c.config.Hooks.OnRequestEnd(scope.ctx, ResponseInfo{
 		Provider:        c.config.ProviderName,
@@ -177,8 +179,8 @@ func (c *Client) finishRequestWithoutBreaker(scope requestScope, statusCode int,
 // releaseHalfOpenProbe frees the breaker's probe slot when this request held
 // it but ended without a success/failure verdict.
 func (c *Client) releaseHalfOpenProbe(scope requestScope) {
-	if c.circuitBreaker != nil && scope.halfOpenProbe {
-		c.circuitBreaker.releaseProbe()
+	if scope.breaker != nil && scope.halfOpenProbe {
+		scope.breaker.releaseProbe()
 	}
 }
 
@@ -203,7 +205,7 @@ func (c *Client) waitForRetryAttempt(ctx context.Context, scope requestScope, at
 }
 
 func (c *Client) recordCircuitBreakerCompletion(scope requestScope, statusCode int, err error) {
-	if c.circuitBreaker == nil {
+	if scope.breaker == nil {
 		return
 	}
 	if err != nil {
@@ -215,27 +217,18 @@ func (c *Client) recordCircuitBreakerCompletion(scope requestScope, statusCode i
 			c.releaseHalfOpenProbe(scope)
 			return
 		}
-		c.circuitBreaker.RecordFailure()
-		return
-	}
-	if statusCode == http.StatusTooManyRequests {
-		if c.circuitBreaker.IsHalfOpen() {
-			c.circuitBreaker.RecordFailure()
-		}
+		scope.breaker.RecordFailure()
 		return
 	}
 	if c.shouldTripCircuitBreaker(statusCode) {
-		c.circuitBreaker.RecordFailure()
+		scope.breaker.RecordFailure()
 		return
 	}
-	c.circuitBreaker.RecordSuccess()
+	scope.breaker.RecordSuccess()
 }
 
 func (c *Client) shouldTripCircuitBreaker(statusCode int) bool {
-	if statusCode == http.StatusTooManyRequests {
-		return false
-	}
-	return c.isRetryable(statusCode) || statusCode >= http.StatusInternalServerError
+	return c.failureStatuses[statusCode]
 }
 
 func (c *Client) maxAttempts() int {
@@ -281,9 +274,5 @@ func (c *Client) calculateBackoff(attempt int) time.Duration {
 
 // isRetryable returns true if the status code indicates a retryable error
 func (c *Client) isRetryable(statusCode int) bool {
-	// Retry on rate limits and specific server errors that are typically transient
-	return statusCode == http.StatusTooManyRequests ||
-		statusCode == http.StatusServiceUnavailable ||
-		statusCode == http.StatusBadGateway ||
-		statusCode == http.StatusGatewayTimeout
+	return c.retryStatuses[statusCode]
 }

--- a/internal/llmclient/client_scope.go
+++ b/internal/llmclient/client_scope.go
@@ -23,6 +23,9 @@ type requestScope struct {
 }
 
 func (c *Client) beginRequest(ctx context.Context, req Request, stream bool) (requestScope, error) {
+	if c.configErr != nil {
+		return requestScope{}, core.NewInvalidRequestError("invalid resilience configuration: "+c.configErr.Error(), c.configErr)
+	}
 	scope := requestScope{
 		ctx:       ctx,
 		startedAt: time.Now(),
@@ -42,6 +45,11 @@ func (c *Client) beginRequest(ctx context.Context, req Request, stream bool) (re
 	}
 
 	scope.breaker = c.breakerForModel(scope.requestInfo.Model)
+	if scope.breaker == nil && c.circuitBreaker != nil {
+		err := core.NewProviderError(c.config.ProviderName, http.StatusServiceUnavailable, "model circuit breaker capacity exhausted", nil)
+		c.finishRequest(scope, http.StatusServiceUnavailable, err)
+		return requestScope{}, err
+	}
 	if scope.breaker != nil {
 		allowed, probe := scope.breaker.acquire()
 		if !allowed {
@@ -64,6 +72,7 @@ func requestModel(req Request) string {
 }
 
 func (c *Client) finishRequest(scope requestScope, statusCode int, err error) {
+	c.releaseModelBreaker(scope.requestInfo.Model, scope.breaker)
 	if c.config.Hooks.OnRequestEnd == nil {
 		return
 	}

--- a/internal/llmclient/client_test.go
+++ b/internal/llmclient/client_test.go
@@ -1385,7 +1385,7 @@ func TestCircuitBreaker_HalfOpenProbeResolvesOnClientError(t *testing.T) {
 	}
 }
 
-func TestCircuitBreaker_RateLimitDoesNotOpenCircuit(t *testing.T) {
+func TestCircuitBreaker_ExcludedRateLimitDoesNotOpenCircuit(t *testing.T) {
 	var attempts atomic.Int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1398,10 +1398,11 @@ func TestCircuitBreaker_RateLimitDoesNotOpenCircuit(t *testing.T) {
 	config := DefaultConfig("test", server.URL)
 	config.Retry.MaxRetries = 0
 	config.CircuitBreaker = goconfig.CircuitBreakerConfig{
-		Enabled:          true,
-		FailureThreshold: 1,
-		SuccessThreshold: 1,
-		Timeout:          time.Second,
+		FailureOnStatuses: []string{"5xx"},
+		Enabled:           true,
+		FailureThreshold:  1,
+		SuccessThreshold:  1,
+		Timeout:           time.Second,
 	}
 	client := New(config, nil)
 

--- a/internal/llmclient/model_breaker.go
+++ b/internal/llmclient/model_breaker.go
@@ -1,14 +1,73 @@
 package llmclient
 
-// Requests without a model (such as discovery) use the provider breaker.
+import (
+	"crypto/sha256"
+	"time"
+)
+
+const maxModelBreakers = 1024
+const modelBreakerIdleTTL = 10 * time.Minute
+
+type modelBreakerEntry struct {
+	breaker  *circuitBreaker
+	active   int
+	lastUsed time.Time
+}
+
+// breakerForModel pins a breaker until finishRequest releases it. Only idle,
+// closed breakers can be evicted, preserving failures and in-flight probes.
+// Fixed-size hashes also bound retained memory for caller-supplied model names.
 func (c *Client) breakerForModel(model string) *circuitBreaker {
-	if c.circuitBreaker == nil || c.config.CircuitBreaker.Scope != "model" || model == "" {
+	if c.circuitBreaker == nil || c.config.CircuitBreaker.Scope != "model" || model == "" || model == UnknownModel {
 		return c.circuitBreaker
 	}
-	if breaker, ok := c.modelBreakers.Load(model); ok {
-		return breaker.(*circuitBreaker)
+	key := sha256.Sum256([]byte(model))
+	c.modelBreakersMu.Lock()
+	defer c.modelBreakersMu.Unlock()
+	if entry := c.modelBreakers[key]; entry != nil {
+		entry.active++
+		return entry.breaker
+	}
+	now := time.Now()
+	var oldestKey [32]byte
+	var oldest *modelBreakerEntry
+	for k, entry := range c.modelBreakers {
+		if entry.active != 0 || entry.breaker.State() != "closed" {
+			continue
+		}
+		if now.Sub(entry.lastUsed) >= modelBreakerIdleTTL {
+			delete(c.modelBreakers, k)
+			continue
+		}
+		if oldest == nil || entry.lastUsed.Before(oldest.lastUsed) {
+			oldestKey, oldest = k, entry
+		}
+	}
+	if len(c.modelBreakers) >= maxModelBreakers {
+		if oldest == nil {
+			return nil
+		} // Fail fast rather than lose an active breaker.
+		delete(c.modelBreakers, oldestKey)
+	}
+	if c.modelBreakers == nil {
+		c.modelBreakers = make(map[[32]byte]*modelBreakerEntry)
 	}
 	cfg := c.config.CircuitBreaker
-	breaker, _ := c.modelBreakers.LoadOrStore(model, newCircuitBreaker(cfg.FailureThreshold, cfg.SuccessThreshold, cfg.Timeout))
-	return breaker.(*circuitBreaker)
+	breaker := newCircuitBreaker(cfg.FailureThreshold, cfg.SuccessThreshold, cfg.Timeout)
+	c.modelBreakers[key] = &modelBreakerEntry{breaker: breaker, active: 1, lastUsed: now}
+	return breaker
+}
+
+// releaseModelBreaker makes a completed request's idle closed entry evictable.
+func (c *Client) releaseModelBreaker(model string, breaker *circuitBreaker) {
+	if breaker == nil || breaker == c.circuitBreaker {
+		return
+	}
+	key := sha256.Sum256([]byte(model))
+	c.modelBreakersMu.Lock()
+	defer c.modelBreakersMu.Unlock()
+	if entry := c.modelBreakers[key]; entry != nil && entry.breaker == breaker {
+		entry.active--
+		entry.lastUsed = time.Now()
+	}
 }

--- a/internal/llmclient/model_breaker.go
+++ b/internal/llmclient/model_breaker.go
@@ -1,0 +1,14 @@
+package llmclient
+
+// Requests without a model (such as discovery) use the provider breaker.
+func (c *Client) breakerForModel(model string) *circuitBreaker {
+	if c.circuitBreaker == nil || c.config.CircuitBreaker.Scope != "model" || model == "" {
+		return c.circuitBreaker
+	}
+	if breaker, ok := c.modelBreakers.Load(model); ok {
+		return breaker.(*circuitBreaker)
+	}
+	cfg := c.config.CircuitBreaker
+	breaker, _ := c.modelBreakers.LoadOrStore(model, newCircuitBreaker(cfg.FailureThreshold, cfg.SuccessThreshold, cfg.Timeout))
+	return breaker.(*circuitBreaker)
+}

--- a/internal/llmclient/model_breaker_test.go
+++ b/internal/llmclient/model_breaker_test.go
@@ -1,0 +1,97 @@
+package llmclient
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestModelBreakerStorageBounded(t *testing.T) {
+	cfg := DefaultConfig("test", "")
+	cfg.CircuitBreaker.Scope = "model"
+	client := New(cfg, nil)
+	// A busy breaker and an open breaker must survive churn.
+	busy := client.breakerForModel("busy")
+	open := client.breakerForModel("open")
+	for range cfg.CircuitBreaker.FailureThreshold {
+		open.RecordFailure()
+	}
+	client.releaseModelBreaker("open", open)
+	for i := range maxModelBreakers * 2 {
+		model := fmt.Sprintf("caller-model-%d", i)
+		breaker := client.breakerForModel(model)
+		if breaker == nil {
+			t.Fatal("idle entries should be evicted")
+		}
+		client.releaseModelBreaker(model, breaker)
+	}
+	if len(client.modelBreakers) > maxModelBreakers {
+		t.Fatal("unbounded storage")
+	}
+	if client.breakerForModel("busy") != busy || client.breakerForModel("open") != open {
+		t.Fatal("evicted protected state")
+	}
+	// Expired idle state is removed on the next new model lookup.
+	key := sha256.Sum256([]byte(fmt.Sprintf("caller-model-%d", maxModelBreakers*2-1)))
+	client.modelBreakers[key].lastUsed = time.Now().Add(-modelBreakerIdleTTL - time.Second)
+	client.breakerForModel("new")
+	if client.modelBreakers[key] != nil {
+		t.Fatal("expired entry retained")
+	}
+}
+
+func TestModelBreakerCapacityRejectsWithoutBypassingProtection(t *testing.T) {
+	cfg := DefaultConfig("test", "")
+	cfg.CircuitBreaker.Scope = "model"
+	client := New(cfg, nil)
+	for i := range maxModelBreakers {
+		client.breakerForModel(fmt.Sprint(i))
+	}
+	_, err := client.DoRaw(t.Context(), Request{Model: "overflow", Method: "GET", Endpoint: "/test"})
+	if err == nil || !strings.Contains(err.Error(), "capacity exhausted") {
+		t.Fatalf("error=%v", err)
+	}
+	if len(client.modelBreakers) != maxModelBreakers {
+		t.Fatal("capacity exceeded")
+	}
+}
+
+func TestUnknownModelUsesProviderBreaker(t *testing.T) {
+	cfg := DefaultConfig("test", "")
+	cfg.CircuitBreaker.Scope = "model"
+	client := New(cfg, nil)
+	scope, err := client.beginRequest(t.Context(), Request{}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scope.breaker != client.circuitBreaker || len(client.modelBreakers) != 0 {
+		t.Fatal("unknown model allocated a model breaker")
+	}
+	client.finishRequest(scope, 200, nil)
+}
+
+func TestInvalidProgrammaticPolicyNeverReachesUpstream(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { t.Error("invalid configuration reached upstream") }))
+	defer server.Close()
+	for _, field := range []string{"retry", "breaker", "scope"} {
+		t.Run(field, func(t *testing.T) {
+			cfg := DefaultConfig("test", server.URL)
+			switch field {
+			case "retry":
+				cfg.Retry.RetryOnStatuses = []string{"oops"}
+			case "breaker":
+				cfg.CircuitBreaker.FailureOnStatuses = []string{"oops"}
+			case "scope":
+				cfg.CircuitBreaker.Scope = "oops"
+			}
+			_, err := New(cfg, nil).DoRaw(t.Context(), Request{Method: "GET", Endpoint: "/test"})
+			if err == nil || !strings.Contains(err.Error(), "invalid resilience configuration") {
+				t.Fatalf("error=%v", err)
+			}
+		})
+	}
+}

--- a/internal/llmclient/resilience_policy_test.go
+++ b/internal/llmclient/resilience_policy_test.go
@@ -1,0 +1,150 @@
+package llmclient
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestStatusPoliciesAndModelBreakers(t *testing.T) {
+	for _, status := range []int{429, 522, 524} {
+		t.Run(strconv.Itoa(status), func(t *testing.T) {
+			var calls []string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls = append(calls, r.URL.Path)
+				if r.URL.Path == "/model1" {
+					w.WriteHeader(status)
+					return
+				}
+				_, _ = w.Write([]byte(`{}`))
+			}))
+			defer server.Close()
+			cfg := DefaultConfig("cloudflare", server.URL)
+			cfg.Retry.MaxRetries = 2
+			cfg.Retry.InitialBackoff = time.Nanosecond
+			cfg.CircuitBreaker.Scope = "model"
+			cfg.CircuitBreaker.FailureThreshold = 1
+			client := New(cfg, nil)
+			var states []string
+			client.config.Hooks.OnRequestEnd = func(_ context.Context, info ResponseInfo) { states = append(states, info.CircuitState) }
+			request := func(model string) error {
+				return client.Do(context.Background(), Request{Method: "GET", Endpoint: "/" + model, Model: model}, nil)
+			}
+			if err := request("model1"); err == nil {
+				t.Fatal("expected exhausted retries")
+			}
+			if len(calls) != 3 {
+				t.Fatalf("calls = %v, want three model1 attempts", calls)
+			}
+			if err := request("model2"); err != nil {
+				t.Fatal(err)
+			}
+			if err := request("model1"); err == nil {
+				t.Fatal("expected open breaker")
+			}
+			if len(calls) != 4 || calls[3] != "/model2" {
+				t.Fatalf("calls = %v", calls)
+			}
+			if states[0] != "open" || states[1] != "closed" || states[2] != "open" {
+				t.Fatalf("states = %v", states)
+			}
+		})
+	}
+}
+
+func TestCustomAndEmptyStatusPolicies(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		retry, failure    []string
+		status, wantCalls int
+		wantState         string
+	}{
+		{"custom retry", []string{"5xx"}, []string{}, 500, 3, "closed"},
+		{"empty retry", []string{}, []string{"524"}, 524, 1, "open"},
+		{"excluded failure", nil, []string{"500"}, 429, 3, "closed"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { calls++; w.WriteHeader(tc.status) }))
+			defer server.Close()
+			cfg := DefaultConfig("test", server.URL)
+			cfg.Retry.MaxRetries = 2
+			cfg.Retry.InitialBackoff = time.Nanosecond
+			cfg.Retry.RetryOnStatuses = tc.retry
+			cfg.CircuitBreaker.FailureOnStatuses = tc.failure
+			cfg.CircuitBreaker.FailureThreshold = 1
+			client := New(cfg, nil)
+			if err := client.Do(context.Background(), Request{Method: "GET", Endpoint: "/test"}, nil); err == nil {
+				t.Fatal("expected failure")
+			}
+			if calls != tc.wantCalls || client.circuitBreaker.State() != tc.wantState {
+				t.Fatalf("calls=%d state=%s", calls, client.circuitBreaker.State())
+			}
+		})
+	}
+}
+
+func TestModelBreakerConcurrentLookup(t *testing.T) {
+	cfg := DefaultConfig("test", "")
+	cfg.CircuitBreaker.Scope = "model"
+	client := New(cfg, nil)
+	want := client.breakerForModel("model1")
+	var wg sync.WaitGroup
+	for range 30 {
+		wg.Go(func() {
+			if got := client.breakerForModel("model1"); got != want {
+				t.Error("model breaker was replaced")
+			}
+		})
+	}
+	wg.Wait()
+	if client.breakerForModel("") != client.circuitBreaker {
+		t.Fatal("discovery should use provider breaker")
+	}
+}
+
+func TestBreakerCountsRetrySequenceOnce(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.WriteHeader(524)
+	}))
+	defer server.Close()
+	cfg := DefaultConfig("test", server.URL)
+	cfg.Retry.MaxRetries = 2
+	cfg.Retry.InitialBackoff = time.Nanosecond
+	cfg.CircuitBreaker.FailureThreshold = 2
+	client := New(cfg, nil)
+	for _, wantState := range []string{"closed", "open"} {
+		if err := client.Do(context.Background(), Request{Method: "GET", Endpoint: "/test"}, nil); err == nil {
+			t.Fatal("expected timeout error")
+		}
+		if got := client.circuitBreaker.State(); got != wantState {
+			t.Fatalf("breaker state=%s, want %s", got, wantState)
+		}
+	}
+	if calls != 6 {
+		t.Fatalf("calls=%d, want two sequences of three attempts", calls)
+	}
+}
+
+func TestExcludedStatusAllowsHalfOpenRecovery(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(429) }))
+	defer server.Close()
+	cfg := DefaultConfig("test", server.URL)
+	cfg.CircuitBreaker.FailureOnStatuses = []string{"5xx"}
+	cfg.CircuitBreaker.SuccessThreshold = 1
+	client := New(cfg, nil)
+	client.circuitBreaker.state = circuitOpen
+	client.circuitBreaker.lastFailure = time.Now().Add(-cfg.CircuitBreaker.Timeout - time.Second)
+	if err := client.Do(context.Background(), Request{Method: "GET", Endpoint: "/test"}, nil); err == nil {
+		t.Fatal("expected rate limit response")
+	}
+	if got := client.circuitBreaker.State(); got != "closed" {
+		t.Fatalf("state=%s, excluded status must not reopen breaker", got)
+	}
+}

--- a/internal/providers/config.go
+++ b/internal/providers/config.go
@@ -237,6 +237,7 @@ func buildProviderConfig(raw config.RawProviderConfig, global config.ResilienceC
 		resolved.FairnessFromUserPath = enabledByDefault(raw.FairnessFromUserPath)
 	}
 
+	resolved.Resilience.CircuitBreaker.Scope = config.NormalizeBreakerScope(resolved.Resilience.CircuitBreaker.Scope)
 	if raw.Resilience == nil {
 		return resolved
 	}
@@ -267,7 +268,7 @@ func buildProviderConfig(raw config.RawProviderConfig, global config.ResilienceC
 			resolved.Resilience.CircuitBreaker.FailureOnStatuses = cb.FailureOnStatuses
 		}
 		if cb.Scope != nil {
-			resolved.Resilience.CircuitBreaker.Scope = *cb.Scope
+			resolved.Resilience.CircuitBreaker.Scope = config.NormalizeBreakerScope(*cb.Scope)
 		}
 		if cb.Enabled != nil {
 			resolved.Resilience.CircuitBreaker.Enabled = *cb.Enabled

--- a/internal/providers/config.go
+++ b/internal/providers/config.go
@@ -241,7 +241,10 @@ func buildProviderConfig(raw config.RawProviderConfig, global config.ResilienceC
 		return resolved
 	}
 
-	if r := raw.Resilience.Retry; r != nil {
+	if r := raw.Resilience.Retry; r != nil { //nolint:dupl // Explicit field overrides preserve nil-as-inherit semantics for retry settings.
+		if r.RetryOnStatuses != nil {
+			resolved.Resilience.Retry.RetryOnStatuses = r.RetryOnStatuses
+		}
 		if r.MaxRetries != nil {
 			resolved.Resilience.Retry.MaxRetries = *r.MaxRetries
 		}
@@ -259,7 +262,13 @@ func buildProviderConfig(raw config.RawProviderConfig, global config.ResilienceC
 		}
 	}
 
-	if cb := raw.Resilience.CircuitBreaker; cb != nil {
+	if cb := raw.Resilience.CircuitBreaker; cb != nil { //nolint:dupl // Breaker settings have independent field overrides with the same inheritance semantics.
+		if cb.FailureOnStatuses != nil {
+			resolved.Resilience.CircuitBreaker.FailureOnStatuses = cb.FailureOnStatuses
+		}
+		if cb.Scope != nil {
+			resolved.Resilience.CircuitBreaker.Scope = *cb.Scope
+		}
 		if cb.Enabled != nil {
 			resolved.Resilience.CircuitBreaker.Enabled = *cb.Enabled
 		}

--- a/internal/providers/config_test.go
+++ b/internal/providers/config_test.go
@@ -1654,6 +1654,7 @@ func TestApplyProviderEnvVars_PreservesUnknownYAMLProviders(t *testing.T) {
 func TestBuildProviderConfig_CircuitBreaker_InheritsGlobal(t *testing.T) {
 	global := globalResilience
 	global.CircuitBreaker = config.CircuitBreakerConfig{
+		Scope:            "provider",
 		FailureThreshold: 5,
 		SuccessThreshold: 2,
 		Timeout:          30 * time.Second,

--- a/internal/providers/config_test.go
+++ b/internal/providers/config_test.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"math"
+	"reflect"
 	"slices"
 	"strings"
 	"testing"
@@ -101,7 +102,7 @@ func TestBuildProviderConfig_InheritsGlobal(t *testing.T) {
 	if got.Type != "openai" {
 		t.Errorf("Type = %q, want openai", got.Type)
 	}
-	if got.Resilience.Retry != globalRetry {
+	if !reflect.DeepEqual(got.Resilience.Retry, globalRetry) {
 		t.Errorf("expected global retry to be inherited\ngot:  %+v\nwant: %+v", got.Resilience.Retry, globalRetry)
 	}
 	if !got.SessionStickyKeys {
@@ -162,7 +163,7 @@ func TestBuildProviderConfig_NilResilience(t *testing.T) {
 	raw := config.RawProviderConfig{Type: "openai", APIKey: "sk", Resilience: nil}
 	got := buildProviderConfig(raw, globalResilience)
 
-	if got.Resilience.Retry != globalRetry {
+	if !reflect.DeepEqual(got.Resilience.Retry, globalRetry) {
 		t.Error("nil Resilience should inherit global")
 	}
 }
@@ -175,7 +176,7 @@ func TestBuildProviderConfig_NilRetry(t *testing.T) {
 	}
 	got := buildProviderConfig(raw, globalResilience)
 
-	if got.Resilience.Retry != globalRetry {
+	if !reflect.DeepEqual(got.Resilience.Retry, globalRetry) {
 		t.Error("nil Retry should inherit global")
 	}
 }
@@ -1660,7 +1661,7 @@ func TestBuildProviderConfig_CircuitBreaker_InheritsGlobal(t *testing.T) {
 	raw := config.RawProviderConfig{Type: "openai", APIKey: "sk"}
 	got := buildProviderConfig(raw, global)
 
-	if got.Resilience.CircuitBreaker != global.CircuitBreaker {
+	if !reflect.DeepEqual(got.Resilience.CircuitBreaker, global.CircuitBreaker) {
 		t.Errorf("expected global circuit breaker to be inherited\ngot:  %+v\nwant: %+v",
 			got.Resilience.CircuitBreaker, global.CircuitBreaker)
 	}
@@ -1676,7 +1677,7 @@ func TestBuildProviderConfig_CircuitBreaker_NilOverride(t *testing.T) {
 	}
 	got := buildProviderConfig(raw, global)
 
-	if got.Resilience.CircuitBreaker != global.CircuitBreaker {
+	if !reflect.DeepEqual(got.Resilience.CircuitBreaker, global.CircuitBreaker) {
 		t.Error("nil CircuitBreaker override should inherit global")
 	}
 }

--- a/internal/providers/credentials_test.go
+++ b/internal/providers/credentials_test.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"context"
 	"errors"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -458,7 +459,7 @@ func TestCredentialsService_ConfiguredProvidersCarryGlobalResilience(t *testing.
 	if got[0].Name != want.Name || got[0].Type != want.Type {
 		t.Errorf("ConfiguredProviders()[0] = %q/%q, want %q/%q", got[0].Name, got[0].Type, want.Name, want.Type)
 	}
-	if got[0].Resilience != want.Resilience {
+	if !reflect.DeepEqual(got[0].Resilience, want.Resilience) {
 		t.Errorf("ConfiguredProviders()[0].Resilience = %+v, want global defaults %+v", got[0].Resilience, want.Resilience)
 	}
 

--- a/internal/providers/factory.go
+++ b/internal/providers/factory.go
@@ -123,6 +123,9 @@ func (f *ProviderFactory) Add(reg Registration) {
 
 // Create instantiates a provider based on its resolved configuration.
 func (f *ProviderFactory) Create(cfg ProviderConfig) (core.Provider, error) {
+	if err := config.ValidateResilience(cfg.Resilience); err != nil {
+		return nil, fmt.Errorf("invalid resilience configuration: %w", err)
+	}
 	f.mu.RLock()
 	builder, ok := f.builders[cfg.Type]
 	hooks := f.hooks

--- a/internal/providers/openai/audio.go
+++ b/internal/providers/openai/audio.go
@@ -92,6 +92,7 @@ func (p *CompatibleProvider) createAudioTranscription(
 		Method:        http.MethodPost,
 		Endpoint:      endpoint,
 		RawBodyReader: body,
+		Model:         req.Model,
 		Headers:       http.Header{"Content-Type": {contentType}},
 	}))
 	if err != nil {

--- a/internal/providers/openai/audio_test.go
+++ b/internal/providers/openai/audio_test.go
@@ -9,8 +9,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/enterpilot/gomodel/config"
 	"github.com/enterpilot/gomodel/internal/core"
 	"github.com/enterpilot/gomodel/internal/llmclient"
+	"github.com/enterpilot/gomodel/internal/providers"
 )
 
 func newSpeechTestProvider(t *testing.T, handler http.HandlerFunc) *CompatibleProvider {
@@ -148,5 +150,43 @@ func TestCreateTranslation_RejectsInvalidRequests(t *testing.T) {
 				t.Fatalf("CreateTranslation() message = %q, want %q", gatewayErr.Message, tt.wantMessage)
 			}
 		})
+	}
+}
+
+func TestMultipartAudioModelBreakerIsolation(t *testing.T) {
+	var models []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseMultipartForm(1024); err != nil {
+			t.Error(err)
+			return
+		}
+		defer func() {
+			if err := r.MultipartForm.RemoveAll(); err != nil {
+				t.Error(err)
+			}
+		}()
+		model := r.FormValue("model")
+		models = append(models, model)
+		if model == "transcribe" {
+			w.WriteHeader(503)
+			return
+		}
+		_, _ = w.Write([]byte(`{"text":"translated"}`))
+	}))
+	defer server.Close()
+	resilience := config.ResilienceConfig{Retry: config.DefaultRetryConfig(), CircuitBreaker: config.DefaultCircuitBreakerConfig()}
+	resilience.CircuitBreaker.Scope = "model"
+	resilience.CircuitBreaker.FailureThreshold = 1
+	provider := NewCompatibleProvider("test", providers.ProviderOptions{Resilience: resilience}, CompatibleProviderConfig{ProviderName: "test", BaseURL: server.URL})
+	_, err := provider.CreateTranscription(t.Context(), &core.AudioTranscriptionRequest{Model: "transcribe", File: []byte("audio")})
+	if err == nil {
+		t.Fatal("expected transcription failure")
+	}
+	_, err = provider.CreateTranslation(t.Context(), &core.AudioTranscriptionRequest{Model: "translate", File: []byte("audio")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(models) != 2 || models[0] != "transcribe" || models[1] != "translate" {
+		t.Fatalf("upstream models=%v", models)
 	}
 }

--- a/internal/providers/provider_status.go
+++ b/internal/providers/provider_status.go
@@ -8,19 +8,22 @@ import (
 
 // SanitizedRetryConfig exposes effective retry settings without secrets.
 type SanitizedRetryConfig struct {
-	MaxRetries     int     `json:"max_retries"`
-	InitialBackoff string  `json:"initial_backoff"`
-	MaxBackoff     string  `json:"max_backoff"`
-	BackoffFactor  float64 `json:"backoff_factor"`
-	JitterFactor   float64 `json:"jitter_factor"`
+	RetryOnStatuses []string `json:"retry_on_statuses"`
+	MaxRetries      int      `json:"max_retries"`
+	InitialBackoff  string   `json:"initial_backoff"`
+	MaxBackoff      string   `json:"max_backoff"`
+	BackoffFactor   float64  `json:"backoff_factor"`
+	JitterFactor    float64  `json:"jitter_factor"`
 }
 
 // SanitizedCircuitBreakerConfig exposes effective circuit-breaker settings.
 type SanitizedCircuitBreakerConfig struct {
-	Enabled          bool   `json:"enabled"`
-	FailureThreshold int    `json:"failure_threshold"`
-	SuccessThreshold int    `json:"success_threshold"`
-	Timeout          string `json:"timeout"`
+	FailureOnStatuses []string `json:"failure_on_statuses"`
+	Scope             string   `json:"scope"`
+	Enabled           bool     `json:"enabled"`
+	FailureThreshold  int      `json:"failure_threshold"`
+	SuccessThreshold  int      `json:"success_threshold"`
+	Timeout           string   `json:"timeout"`
 }
 
 // SanitizedResilienceConfig exposes effective resilience settings.
@@ -107,17 +110,20 @@ func SanitizeProviderConfigs(configs map[string]ProviderConfig) []SanitizedProvi
 			SessionStickyKeys: cfg.SessionStickyKeys,
 			Resilience: SanitizedResilienceConfig{
 				Retry: SanitizedRetryConfig{
-					MaxRetries:     cfg.Resilience.Retry.MaxRetries,
-					InitialBackoff: cfg.Resilience.Retry.InitialBackoff.String(),
-					MaxBackoff:     cfg.Resilience.Retry.MaxBackoff.String(),
-					BackoffFactor:  cfg.Resilience.Retry.BackoffFactor,
-					JitterFactor:   cfg.Resilience.Retry.JitterFactor,
+					RetryOnStatuses: cfg.Resilience.Retry.RetryOnStatuses,
+					MaxRetries:      cfg.Resilience.Retry.MaxRetries,
+					InitialBackoff:  cfg.Resilience.Retry.InitialBackoff.String(),
+					MaxBackoff:      cfg.Resilience.Retry.MaxBackoff.String(),
+					BackoffFactor:   cfg.Resilience.Retry.BackoffFactor,
+					JitterFactor:    cfg.Resilience.Retry.JitterFactor,
 				},
 				CircuitBreaker: SanitizedCircuitBreakerConfig{
-					Enabled:          cfg.Resilience.CircuitBreaker.Enabled,
-					FailureThreshold: cfg.Resilience.CircuitBreaker.FailureThreshold,
-					SuccessThreshold: cfg.Resilience.CircuitBreaker.SuccessThreshold,
-					Timeout:          cfg.Resilience.CircuitBreaker.Timeout.String(),
+					FailureOnStatuses: cfg.Resilience.CircuitBreaker.FailureOnStatuses,
+					Scope:             cfg.Resilience.CircuitBreaker.Scope,
+					Enabled:           cfg.Resilience.CircuitBreaker.Enabled,
+					FailureThreshold:  cfg.Resilience.CircuitBreaker.FailureThreshold,
+					SuccessThreshold:  cfg.Resilience.CircuitBreaker.SuccessThreshold,
+					Timeout:           cfg.Resilience.CircuitBreaker.Timeout.String(),
 				},
 			},
 		})

--- a/internal/providers/provider_status.go
+++ b/internal/providers/provider_status.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"github.com/enterpilot/gomodel/config"
 	"sort"
 	"strings"
 	"time"
@@ -119,7 +120,7 @@ func SanitizeProviderConfigs(configs map[string]ProviderConfig) []SanitizedProvi
 				},
 				CircuitBreaker: SanitizedCircuitBreakerConfig{
 					FailureOnStatuses: cfg.Resilience.CircuitBreaker.FailureOnStatuses,
-					Scope:             cfg.Resilience.CircuitBreaker.Scope,
+					Scope:             config.NormalizeBreakerScope(cfg.Resilience.CircuitBreaker.Scope),
 					Enabled:           cfg.Resilience.CircuitBreaker.Enabled,
 					FailureThreshold:  cfg.Resilience.CircuitBreaker.FailureThreshold,
 					SuccessThreshold:  cfg.Resilience.CircuitBreaker.SuccessThreshold,

--- a/internal/providers/resilience_policy_test.go
+++ b/internal/providers/resilience_policy_test.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/enterpilot/gomodel/config"
@@ -27,5 +28,38 @@ func TestProviderResilienceStatusOverrides(t *testing.T) {
 	}
 	if !reflect.DeepEqual(buildProviderConfig(config.RawProviderConfig{}, global).Resilience, global) {
 		t.Fatal("omitted settings must inherit")
+	}
+}
+
+func TestSanitizedResiliencePolicies(t *testing.T) {
+	for _, scope := range []string{"model", ""} {
+		t.Run("scope="+scope, func(t *testing.T) {
+			global := config.ResilienceConfig{Retry: config.DefaultRetryConfig(), CircuitBreaker: config.DefaultCircuitBreakerConfig()}
+			global.CircuitBreaker.Scope = "model"
+			raw := config.RawProviderConfig{Resilience: &config.RawResilienceConfig{CircuitBreaker: &config.RawCircuitBreakerConfig{Scope: &scope}}}
+			cfg := buildProviderConfig(raw, global)
+			got := SanitizeProviderConfigs(map[string]ProviderConfig{"test": cfg})[0].Resilience
+			wantScope := scope
+			if wantScope == "" {
+				wantScope = "provider"
+			}
+			if got.CircuitBreaker.Scope != wantScope || !reflect.DeepEqual(got.Retry.RetryOnStatuses, global.Retry.RetryOnStatuses) || !reflect.DeepEqual(got.CircuitBreaker.FailureOnStatuses, global.CircuitBreaker.FailureOnStatuses) {
+				t.Fatalf("sanitized settings=%+v", got)
+			}
+		})
+	}
+}
+
+func TestFactoryRejectsInvalidResilience(t *testing.T) {
+	factory := NewProviderFactory()
+	for _, r := range []config.ResilienceConfig{
+		{Retry: config.RetryConfig{RetryOnStatuses: []string{"bad"}}},
+		{CircuitBreaker: config.CircuitBreakerConfig{FailureOnStatuses: []string{"600"}}},
+		{CircuitBreaker: config.CircuitBreakerConfig{Scope: "bad"}},
+	} {
+		_, err := factory.Create(ProviderConfig{Resilience: r})
+		if err == nil || !strings.Contains(err.Error(), "invalid resilience configuration") {
+			t.Fatalf("error=%v", err)
+		}
 	}
 }

--- a/internal/providers/resilience_policy_test.go
+++ b/internal/providers/resilience_policy_test.go
@@ -1,0 +1,31 @@
+package providers
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/enterpilot/gomodel/config"
+	"gopkg.in/yaml.v3"
+)
+
+func TestProviderResilienceStatusOverrides(t *testing.T) {
+	global := config.ResilienceConfig{Retry: config.DefaultRetryConfig(), CircuitBreaker: config.DefaultCircuitBreakerConfig()}
+	var raw config.RawProviderConfig
+	err := yaml.Unmarshal([]byte("type: openai\nresilience:\n  retry:\n    retry_on_statuses: []\n  circuit_breaker:\n    failure_on_statuses: [524]\n    scope: model\n"), &raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := buildProviderConfig(raw, global).Resilience
+	if got.Retry.RetryOnStatuses == nil || len(got.Retry.RetryOnStatuses) != 0 {
+		t.Fatal("empty retry override was lost")
+	}
+	if !reflect.DeepEqual(got.CircuitBreaker.FailureOnStatuses, []string{"524"}) || got.CircuitBreaker.Scope != "model" {
+		t.Fatalf("breaker=%+v", got.CircuitBreaker)
+	}
+	if got.Retry.MaxRetries != global.Retry.MaxRetries || got.CircuitBreaker.FailureThreshold != global.CircuitBreaker.FailureThreshold {
+		t.Fatal("unrelated settings must inherit")
+	}
+	if !reflect.DeepEqual(buildProviderConfig(config.RawProviderConfig{}, global).Resilience, global) {
+		t.Fatal("omitted settings must inherit")
+	}
+}


### PR DESCRIPTION
## Description

Cloudflare HTTP 522/524 responses now retry the selected model before the existing failover chain advances to the next target. Retry status defaults are `[429, 502, 503, 504, 522, 524]`; circuit-breaker failure defaults are `[429, 5xx]`, so exhausted rate limits now count as breaker failures.

Add global and per-provider `retry.retry_on_statuses` and `circuit_breaker.failure_on_statuses` settings, with exact HTTP codes or classes such as `5xx`. Omitted lists inherit defaults, explicit lists replace them, and `[]` disables status-based triggers while retaining transport-error handling. Invalid configuration fails loading.

Add optional `circuit_breaker.scope: model` so a failed model does not open the breaker for its backup on the same provider. The default remains `provider`. Each exhausted retry sequence counts as one breaker failure. Streaming and local client-timeout retry behavior stays unchanged.

Update the resilience guide, failover guide, example configuration, and admin-safe provider settings. The guide includes a complete same-provider fallback example and explains the change to the 429 default.

Model-breaker storage is capped at 1,024 entries per provider using fixed-size model hashes. Only idle closed breakers are evicted; active/open state is preserved, and new models fail with 503 when all slots are protected. Multipart audio uploads propagate their explicit model names, and unattributed requests use the provider breaker. Invalid programmatic policies are rejected by the provider factory; direct client calls return configuration errors before dispatch.

## Validation

- `TZ=UTC go test ./...` passed. Without UTC, two existing version-endpoint tests fail around local/UTC date boundaries.
- Repository pre-commit checks passed: full race suite, performance guard, modernization checks, lint, and documentation validation.
- Gateway regression test verifies model1 → two retries → model2, followed by skipping model1 while its breaker is open.
- `npx mint validate` passed. Broken-link checking reports three existing links to `/features/audit-logging` in `guides/langfuse.mdx`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable HTTP status lists for retries and circuit-breaker failures.
  - Added provider- or model-scoped circuit breakers.
  - Added environment variable overrides for resilience settings.
  - Provider status details now display retry and circuit-breaker policies.
  - Cloudflare 522/524 responses can be retried before model failover.

- **Bug Fixes**
  - Invalid resilience settings are now rejected during configuration loading, including invalid status codes and breaker scopes.
  - Model-scoped breakers now isolate failures between models.

- **Documentation**
  - Updated resilience and failover guidance with new defaults, configuration options, and recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
