### PR TITLE
feat(run): add a ReloadConfig hook for every reloaded configuration

### DIFF
--- a/run/run.go
+++ b/run/run.go
@@ -82,6 +82,13 @@ type Options struct {
 	// extensions. Configuration registered here is startup-only; reloads reuse
 	// the resulting extension instances.
 	SetupConfig func(ctx context.Context, result *config.LoadResult) error
+	// ReloadConfig runs for every configuration generation after the first,
+	// once a reload has re-read the configuration and before the replacement
+	// application is built. It lets a distribution apply to the reloaded
+	// configuration the same policy SetupConfig applied at startup, such as
+	// disabling a setting or rejecting an endpoint. A returned error rejects
+	// the reload; the serving generation keeps running.
+	ReloadConfig func(ctx context.Context, result *config.LoadResult) error
 }
 
 func (o Options) withDefaults() Options {
@@ -213,7 +220,7 @@ func Run(ctx context.Context, opts Options) error {
 		}
 	}
 
-	setupConfigDone := false
+	configure := configHooks(ctx, opts)
 
 	// build produces one generation of the gateway from the configuration as it
 	// stands right now. It is called again for every reload, which is what lets
@@ -225,11 +232,8 @@ func Run(ctx context.Context, opts Options) error {
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to load config: %w", err)
 		}
-		if !setupConfigDone && opts.SetupConfig != nil {
-			if err := opts.SetupConfig(ctx, result); err != nil {
-				return nil, nil, fmt.Errorf("failed to set up configured extensions: %w", err)
-			}
-			setupConfigDone = true
+		if err := configure(result); err != nil {
+			return nil, nil, err
 		}
 		opts.ConfigureSwaggerDocs(result.Config.Server.BasePath)
 
@@ -311,6 +315,29 @@ func Run(ctx context.Context, opts Options) error {
 		return err
 	}
 	return nil
+}
+
+// configHooks sequences a distribution's configuration hooks across
+// generations: SetupConfig for the first, ReloadConfig for every later one.
+func configHooks(ctx context.Context, opts Options) func(*config.LoadResult) error {
+	first := true
+	return func(result *config.LoadResult) error {
+		if first {
+			first = false
+			if opts.SetupConfig != nil {
+				if err := opts.SetupConfig(ctx, result); err != nil {
+					return fmt.Errorf("failed to set up configured extensions: %w", err)
+				}
+			}
+			return nil
+		}
+		if opts.ReloadConfig != nil {
+			if err := opts.ReloadConfig(ctx, result); err != nil {
+				return fmt.Errorf("configured extensions rejected the reloaded configuration: %w", err)
+			}
+		}
+		return nil
+	}
 }
 
 func versionLine(productName string) string {

--- a/run/run_test.go
+++ b/run/run_test.go
@@ -46,6 +46,38 @@ func TestRunVersionSkipsSetup(t *testing.T) {
 	}
 }
 
+func TestConfigHooksRunSetupOnceThenReloadForEveryLaterGeneration(t *testing.T) {
+	var setups, reloads int
+	rejected := errors.New("endpoint outside the policy")
+	configure := configHooks(t.Context(), Options{
+		SetupConfig: func(context.Context, *config.LoadResult) error {
+			setups++
+			return nil
+		},
+		ReloadConfig: func(context.Context, *config.LoadResult) error {
+			reloads++
+			if reloads == 2 {
+				return rejected
+			}
+			return nil
+		},
+	})
+	result := &config.LoadResult{Config: &config.Config{}}
+	for i, wantErr := range []error{nil, nil, rejected} {
+		err := configure(result)
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("generation %d: error = %v, want %v", i+1, err, wantErr)
+		}
+	}
+	if setups != 1 || reloads != 2 {
+		t.Fatalf("SetupConfig ran %d times and ReloadConfig %d, want 1 and 2", setups, reloads)
+	}
+	// Without hooks every generation passes.
+	if err := configHooks(t.Context(), Options{})(result); err != nil {
+		t.Fatalf("no hooks: %v", err)
+	}
+}
+
 func TestRunSetupConfigReceivesLoadedConfiguration(t *testing.T) {
 	t.Chdir(t.TempDir())
 	wantErr := errors.New("configured extension stopped startup")

--- a/run/run_test.go
+++ b/run/run_test.go
@@ -73,8 +73,11 @@ func TestConfigHooksRunSetupOnceThenReloadForEveryLaterGeneration(t *testing.T) 
 		t.Fatalf("SetupConfig ran %d times and ReloadConfig %d, want 1 and 2", setups, reloads)
 	}
 	// Without hooks every generation passes.
-	if err := configHooks(t.Context(), Options{})(result); err != nil {
-		t.Fatalf("no hooks: %v", err)
+	noHooks := configHooks(t.Context(), Options{})
+	for generation := 1; generation <= 2; generation++ {
+		if err := noHooks(result); err != nil {
+			t.Fatalf("no hooks, generation %d: %v", generation, err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

`run.Options.SetupConfig` runs once, so a distribution that validates or adjusts the loaded configuration at startup never sees a reloaded one. `ReloadConfig` runs for every generation after the first, after the reload re-read the configuration and before the replacement application is built. An error rejects the reload and the serving generation keeps running, the same way a failed build already does.

Needed by GoModel Pro's air-gapped mode, whose endpoint audit otherwise applies only to the startup configuration.

## Impact

No behavior change for distributions that do not set the hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwHQpf7a8fJq3SdVDRJRdh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for custom configuration reload handling.
  - Initial configuration setup runs once; subsequent configuration generations trigger reload handling.
  - Reload handling can reject invalid changes while the current serving generation continues running.

- **Bug Fixes**
  - Improved configuration generation handling to preserve service availability when a reload is rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->