### PR TITLE
fix(models): keep provider-reported model metadata across restarts

### DIFF
--- a/internal/cache/modelcache/modelcache.go
+++ b/internal/cache/modelcache/modelcache.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/goccy/go-json"
+
+	"github.com/enterpilot/gomodel/internal/core"
 )
 
 // ModelCache represents the cached model data structure.
@@ -38,6 +40,12 @@ type CachedProvider struct {
 type CachedModel struct {
 	ID      string `json:"id"`
 	Created int64  `json:"created"`
+	// Metadata is what the provider itself reported about the model at
+	// discovery — never the catalog-enriched result. A restart restores it as
+	// the model's discovered metadata, so a provider that is slow or briefly
+	// unreachable does not fall back to catalog-only values (or to none) for
+	// its real context window, output limit, modes, and capabilities.
+	Metadata *core.ModelMetadata `json:"metadata,omitempty"`
 }
 
 // Cache defines the interface for model cache storage.

--- a/internal/providers/registry_cache.go
+++ b/internal/providers/registry_cache.go
@@ -61,13 +61,16 @@ func (r *ModelRegistry) LoadFromCache(ctx context.Context) (int, error) {
 		}
 		providerModels := make(map[string]*ModelInfo, len(cachedProv.Models))
 		for _, cached := range cachedProv.Models {
-			// The cache stores no metadata, so nothing was discovered yet; the
-			// next live refresh supplies it.
+			// Restore what the provider reported for the model, so enrichment
+			// merges the catalog under it exactly as it would after a live
+			// fetch. Caches written before this field existed carry none, and
+			// those models keep catalog-only metadata until the next refresh.
 			info := newModelInfo(core.Model{
-				ID:      cached.ID,
-				Object:  "model",
-				OwnedBy: cachedProv.OwnedBy,
-				Created: cached.Created,
+				ID:       cached.ID,
+				Object:   "model",
+				OwnedBy:  cachedProv.OwnedBy,
+				Created:  cached.Created,
+				Metadata: cached.Metadata.Clone(),
 			}, provider, providerName, providerType)
 			if _, exists := providerModels[info.Model.ID]; exists {
 				// Trimmed duplicates collapse to one record; first wins.
@@ -216,6 +219,11 @@ func (r *ModelRegistry) SaveToCache(ctx context.Context) error {
 			cachedModels = append(cachedModels, modelcache.CachedModel{
 				ID:      modelID,
 				Created: info.Model.Created,
+				// Persist the provider's own report, not Model.Metadata: that
+				// one carries whatever the catalog contributed at enrichment
+				// time, and storing it would pin a stale catalog entry across
+				// restarts instead of letting each pass re-merge.
+				Metadata: info.Discovered.Clone(),
 			})
 		}
 		mc.Providers[providerName] = modelcache.CachedProvider{

--- a/internal/providers/registry_cache_test.go
+++ b/internal/providers/registry_cache_test.go
@@ -927,3 +927,129 @@ func TestCacheFile_ModelListETagRoundtrip(t *testing.T) {
 		t.Fatalf("currentModelListETag() for another URL = %q, want empty", got)
 	}
 }
+
+// A restart must not swap the provider's own report for the catalog's entry.
+// The catalog resolves plain IDs like "gpt-oss" for any provider type, and its
+// entry for one carries no context window, output limit, or capabilities — so a
+// cached inventory that lost the provider's report publishes a local model with
+// a truncated mode list and no limits at all until the next live fetch lands.
+func TestCacheRoundTripKeepsProviderReportedMetadata(t *testing.T) {
+	tmpDir := t.TempDir()
+	cacheFile := filepath.Join(tmpDir, "models.json")
+
+	raw := []byte(`{"version": 1, "providers": {}, "models": {"gpt-oss": {"display_name": "gpt-oss", "description": "open-weight models", "modes": ["chat"]}}, "provider_models": {}}`)
+	list, err := modeldata.Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	contextWindow := 922000
+	maxOutputTokens := 128000
+	mock := &registryMockProvider{
+		name: "local",
+		modelsResponse: &core.ModelsResponse{
+			Object: "list",
+			Data: []core.Model{{
+				ID: "gpt-oss", Object: "model", OwnedBy: "local",
+				Metadata: &core.ModelMetadata{
+					DisplayName:     "My Local gpt-oss",
+					Modes:           []string{"chat", "responses"},
+					ContextWindow:   &contextWindow,
+					MaxOutputTokens: &maxOutputTokens,
+					Capabilities:    map[string]bool{"function_calling": true, "reasoning": true},
+				},
+			}},
+		},
+	}
+
+	saving := NewModelRegistry()
+	saving.SetCache(modelcache.NewLocalCache(cacheFile))
+	saving.RegisterProviderWithNameAndType(mock, "local", "openai")
+	if err := saving.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	saving.setModelListAndEnrich(list, raw, "", "")
+	if err := saving.SaveToCache(context.Background()); err != nil {
+		t.Fatalf("SaveToCache() error = %v", err)
+	}
+
+	// A fresh registry that has not reached the provider yet: everything it
+	// publishes comes from the cache plus the cached catalog.
+	loading := NewModelRegistry()
+	loading.SetCache(modelcache.NewLocalCache(cacheFile))
+	loading.RegisterProviderWithNameAndType(mock, "local", "openai")
+	if _, err := loading.LoadFromCache(context.Background()); err != nil {
+		t.Fatalf("LoadFromCache() error = %v", err)
+	}
+
+	model, ok := loading.LookupModel("local/gpt-oss")
+	if !ok {
+		t.Fatal("expected local/gpt-oss in the restored inventory")
+	}
+	meta := model.Metadata
+	if meta == nil {
+		t.Fatal("expected restored metadata, got nil")
+	}
+	if meta.ContextWindow == nil || *meta.ContextWindow != contextWindow {
+		t.Errorf("ContextWindow = %v, want %d", meta.ContextWindow, contextWindow)
+	}
+	if meta.MaxOutputTokens == nil || *meta.MaxOutputTokens != maxOutputTokens {
+		t.Errorf("MaxOutputTokens = %v, want %d", meta.MaxOutputTokens, maxOutputTokens)
+	}
+	if !meta.Capabilities["function_calling"] || !meta.Capabilities["reasoning"] {
+		t.Errorf("Capabilities = %v, want the provider-reported flags", meta.Capabilities)
+	}
+	if len(meta.Modes) != 2 || meta.Modes[0] != "chat" || meta.Modes[1] != "responses" {
+		t.Errorf("Modes = %v, want [chat responses]", meta.Modes)
+	}
+	if meta.DisplayName != "My Local gpt-oss" {
+		t.Errorf("DisplayName = %q, want the provider's own", meta.DisplayName)
+	}
+	// The catalog still fills in what the provider never reported.
+	if meta.Description != "open-weight models" {
+		t.Errorf("Description = %q, want the catalog's", meta.Description)
+	}
+}
+
+// Caches written before provider metadata was persisted carry none; they must
+// still load, with the catalog supplying what it can until the next refresh.
+func TestLoadFromCacheAcceptsEntriesWithoutMetadata(t *testing.T) {
+	tmpDir := t.TempDir()
+	cacheFile := filepath.Join(tmpDir, "models.json")
+
+	modelCache := modelcache.ModelCache{
+		UpdatedAt: time.Now().UTC(),
+		Providers: map[string]modelcache.CachedProvider{
+			"local": {
+				ProviderType: "openai",
+				OwnedBy:      "local",
+				Models:       []modelcache.CachedModel{{ID: "gpt-oss", Created: 1234567890}},
+			},
+		},
+	}
+	data, _ := json.Marshal(modelCache)
+	if err := os.WriteFile(cacheFile, data, 0o644); err != nil {
+		t.Fatalf("failed to write cache file: %v", err)
+	}
+
+	registry := NewModelRegistry()
+	registry.SetCache(modelcache.NewLocalCache(cacheFile))
+	registry.RegisterProviderWithNameAndType(&registryMockProvider{name: "local"}, "local", "openai")
+
+	loaded, err := registry.LoadFromCache(context.Background())
+	if err != nil {
+		t.Fatalf("LoadFromCache() error = %v", err)
+	}
+	if loaded != 1 {
+		t.Fatalf("LoadFromCache() = %d, want 1", loaded)
+	}
+	registry.mu.RLock()
+	info, ok := registry.models["gpt-oss"]
+	registry.mu.RUnlock()
+	if !ok {
+		t.Fatal("expected local/gpt-oss in the restored inventory")
+	}
+	if info.Discovered != nil {
+		t.Errorf("Discovered = %#v, want nil for a pre-upgrade cache entry", info.Discovered)
+	}
+}


### PR DESCRIPTION
Fixes #901.

## User-visible impact

A model whose ID the remote catalog resolves was published with the catalog's metadata instead of the provider's whenever the inventory came from the model cache — after a restart, and again on any `CredentialsService.Reload`, until the next successful live fetch. A local OpenAI-compatible deployment lost its real `context_window`, `max_output_tokens` and `capabilities`, and its `modes` narrowed to whatever the catalog lists (`["chat"]` for entries like `gpt-oss`). Catalog entries for plain IDs commonly carry no limits at all, so those fields disappeared entirely rather than being merely wrong.

## Cause

`CachedModel` persisted only `id` and `created`, so `LoadFromCache` rebuilt every `ModelInfo` with `Discovered == nil`. `Enrich` then had nothing to merge the catalog under, and its documented layering — catalog as base, provider's report as override — collapsed to catalog-only.

## Change

`CachedModel` gains a `metadata` field holding the provider's own report. `SaveToCache` persists `info.Discovered`, and `LoadFromCache` restores it onto the rebuilt model so `newModelInfo` captures it again, making the merge after a cache load identical to the merge after a live fetch.

`Model.Metadata` is deliberately not what gets stored: it carries whatever the catalog contributed at enrichment time, and persisting it would pin a stale catalog entry across restarts instead of letting each pass re-merge from the same inputs.

## Compatibility

The field is `omitempty` and nil-safe on read, so caches written by an older binary load unchanged and keep the previous behaviour until the next refresh; an older binary ignores the new field on rollback. No config or API surface changes.

## Tests

- `TestCacheRoundTripKeepsProviderReportedMetadata` — save a live-discovered model, reload it against a catalog entry shaped like the real `gpt-oss` one (display name + description + `modes: ["chat"]`, no limits) and assert the provider's values win while the catalog still fills in the description. Verified to fail on `main` with exactly the symptoms from #901.
- `TestLoadFromCacheAcceptsEntriesWithoutMetadata` — a pre-upgrade cache entry still loads, with `Discovered` nil.

Also verified end to end against a built binary: with the provider unreachable at startup and today's catalog, `/v1/models` went from `context_window: null, modes: ["chat"]` to the provider's `922000` and `["chat","responses"]`, with catalog-only capabilities still merged underneath.

## Note for triage

Part of what #901 reports is not a code regression: the values shown were the catalog's all along, and `ai-model-list` dropped `context_window`/`max_output_tokens` from `deepseek-v3.2`, `deepseek-v3.2-exp` and `deepseek-v4-flash-0731` on 2026-09-05 (and `capabilities` from `gemma-3n-E4B-it` and `ministral-8b` in late August). That is worth a separate fix in the catalog pipeline; this PR stops the gateway from substituting catalog data for the provider's own report in the first place.

Separately, `LoadFromCache` still replaces `discoveredByProvider` wholesale, so a mid-session reload rewinds an already-live provider to its cached snapshot. That is no longer lossy for metadata, but a model discovered since the last cache write still disappears until the next fetch — left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jiw4jRPKhaTsh3dPkcUGuo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider-reported model metadata, including capabilities, limits, modes, and display names, is now retained across cache reloads.
  * Catalog descriptions continue to be combined with restored provider metadata.

* **Bug Fixes**
  * Improved compatibility with existing cached models that do not include metadata.
  * Prevented catalog-provided metadata from being permanently pinned in cached data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->