### PR TITLE
feat(egress): let a distribution police the connections core dials directly

### DIFF
--- a/egress/egress.go
+++ b/egress/egress.go
@@ -31,29 +31,39 @@ var installed atomic.Pointer[DialFunc]
 // defaultDial is what core uses until a distribution installs a hook.
 var defaultDial DialFunc = (&net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}).DialContext
 
+// Hook is an installed policy, handed to whoever installed it. Removing the
+// policy needs this handle, so a package that merely imports egress cannot
+// take the guarantee away from the clients running under it.
+type Hook struct{ dial *DialFunc }
+
 // Install routes every direct connection core opens from now on through
-// dial. It belongs to whatever composes the process - a distribution's
-// startup path - and there is one: installing over an existing hook is an
-// error rather than a silent replacement, so a policy cannot be swapped out
-// from under the clients enforcing it. Uninstall removes it again.
+// dial, and returns the handle that removes it again. It belongs to
+// whatever composes the process - a distribution's startup path - and there
+// is one: installing over an existing hook is an error rather than a silent
+// replacement.
 //
 // Connections already open are unaffected: a hook installed at startup, as
 // GoModel Pro's air-gapped mode does before the application is built, sees
 // every connection the gateway makes.
-func Install(dial DialFunc) error {
+func Install(dial DialFunc) (*Hook, error) {
 	if dial == nil {
-		return errors.New("egress: dial hook is required; call Uninstall to remove one")
+		return nil, errors.New("egress: dial hook is required")
 	}
 	if !installed.CompareAndSwap(nil, &dial) {
-		return errors.New("egress: a dial hook is already installed")
+		return nil, errors.New("egress: a dial hook is already installed")
 	}
-	return nil
+	return &Hook{dial: &dial}, nil
 }
 
-// Uninstall removes the installed hook, so core's clients dial directly
-// again. Whoever installed the hook calls it: GoModel Pro's guard does on
-// close.
-func Uninstall() { installed.Store(nil) }
+// Uninstall removes this hook, so core's clients dial directly again. A hook
+// that is no longer the installed one leaves it alone, and calling twice is
+// harmless.
+func (h *Hook) Uninstall() {
+	if h == nil {
+		return
+	}
+	installed.CompareAndSwap(h.dial, nil)
+}
 
 // Installed reports whether a distribution has installed a hook.
 func Installed() bool { return installed.Load() != nil }

--- a/egress/egress.go
+++ b/egress/egress.go
@@ -16,6 +16,7 @@ package egress
 
 import (
 	"context"
+	"errors"
 	"net"
 	"sync/atomic"
 	"time"
@@ -31,19 +32,28 @@ var installed atomic.Pointer[DialFunc]
 var defaultDial DialFunc = (&net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}).DialContext
 
 // Install routes every direct connection core opens from now on through
-// dial. A nil dial restores the default dialer. Installing replaces any
-// previous hook, so a distribution keeps one policy rather than a chain.
+// dial. It belongs to whatever composes the process - a distribution's
+// startup path - and there is one: installing over an existing hook is an
+// error rather than a silent replacement, so a policy cannot be swapped out
+// from under the clients enforcing it. Uninstall removes it again.
 //
 // Connections already open are unaffected: a hook installed at startup, as
 // GoModel Pro's air-gapped mode does before the application is built, sees
 // every connection the gateway makes.
-func Install(dial DialFunc) {
+func Install(dial DialFunc) error {
 	if dial == nil {
-		installed.Store(nil)
-		return
+		return errors.New("egress: dial hook is required; call Uninstall to remove one")
 	}
-	installed.Store(&dial)
+	if !installed.CompareAndSwap(nil, &dial) {
+		return errors.New("egress: a dial hook is already installed")
+	}
+	return nil
 }
+
+// Uninstall removes the installed hook, so core's clients dial directly
+// again. Whoever installed the hook calls it: GoModel Pro's guard does on
+// close.
+func Uninstall() { installed.Store(nil) }
 
 // Installed reports whether a distribution has installed a hook.
 func Installed() bool { return installed.Load() != nil }
@@ -56,6 +66,22 @@ func DialContext(ctx context.Context, network, address string) (net.Conn, error)
 		return (*dial)(ctx, network, address)
 	}
 	return defaultDial(ctx, network, address)
+}
+
+// Lookup resolves host for a client that resolves names itself before it
+// dials. With a hook installed the name is passed through untouched, so the
+// hook decides what it may resolve to and dials the address that passed;
+// without one the client's own resolver answers, keeping its behaviour -
+// multiple addresses and their fallbacks included - exactly as it was.
+//
+// It is consulted per connection, never snapshotted at client construction:
+// a client built before the hook was installed would otherwise keep handing
+// it addresses it had already chosen, which no hostname policy can judge.
+func Lookup(ctx context.Context, host string, resolve func(context.Context, string) ([]string, error)) ([]string, error) {
+	if Installed() {
+		return []string{host}, nil
+	}
+	return resolve(ctx, host)
 }
 
 // Dialer adapts DialContext to the interface the MongoDB driver takes.

--- a/egress/egress.go
+++ b/egress/egress.go
@@ -1,0 +1,67 @@
+// Package egress carries the dial hook a distribution installs to police the
+// connections GoModel opens directly.
+//
+// HTTP clients are steered by the standard proxy variables, so a
+// distribution that wants to see every outbound HTTP request only has to set
+// HTTP_PROXY. The database, cache, and vector store clients speak their own
+// protocols over raw TCP and read no such variable: without a hook they
+// connect wherever their URL points, whatever policy the distribution
+// believes it is enforcing. This package is that hook.
+//
+// It is process-wide on purpose, matching the proxy variables it
+// complements: the clients live behind several layers of construction, and a
+// guarantee an operator is told covers the process cannot depend on a
+// parameter each of them remembers to pass along.
+package egress
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"time"
+)
+
+// DialFunc opens one connection. It matches net.Dialer.DialContext, which is
+// what the database and cache clients expect.
+type DialFunc func(ctx context.Context, network, address string) (net.Conn, error)
+
+var installed atomic.Pointer[DialFunc]
+
+// defaultDial is what core uses until a distribution installs a hook.
+var defaultDial DialFunc = (&net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}).DialContext
+
+// Install routes every direct connection core opens from now on through
+// dial. A nil dial restores the default dialer. Installing replaces any
+// previous hook, so a distribution keeps one policy rather than a chain.
+//
+// Connections already open are unaffected: a hook installed at startup, as
+// GoModel Pro's air-gapped mode does before the application is built, sees
+// every connection the gateway makes.
+func Install(dial DialFunc) {
+	if dial == nil {
+		installed.Store(nil)
+		return
+	}
+	installed.Store(&dial)
+}
+
+// Installed reports whether a distribution has installed a hook.
+func Installed() bool { return installed.Load() != nil }
+
+// DialContext opens a connection through the installed hook, or with the
+// default dialer when there is none. Clients that take a dialer are given
+// this function; clients that take an interface are given Dialer.
+func DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	if dial := installed.Load(); dial != nil {
+		return (*dial)(ctx, network, address)
+	}
+	return defaultDial(ctx, network, address)
+}
+
+// Dialer adapts DialContext to the interface the MongoDB driver takes.
+type Dialer struct{}
+
+// DialContext implements the driver's dialer interface.
+func (Dialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	return DialContext(ctx, network, address)
+}

--- a/egress/egress_test.go
+++ b/egress/egress_test.go
@@ -13,7 +13,14 @@ func TestDialContextUsesTheInstalledHook(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer listener.Close()
-	t.Cleanup(func() { installed.Store(nil) })
+	// Cleanup goes through the handles the test holds, the way any other
+	// owner removes a hook - never by reaching into the package's state.
+	var held []*Hook
+	t.Cleanup(func() {
+		for _, hook := range held {
+			hook.Uninstall()
+		}
+	})
 
 	// Without a hook the default dialer connects.
 	conn, err := DialContext(context.Background(), "tcp", listener.Addr().String())
@@ -36,6 +43,7 @@ func TestDialContextUsesTheInstalledHook(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	held = append(held, hook)
 	if !Installed() {
 		t.Fatal("Installed must report the hook")
 	}
@@ -72,6 +80,7 @@ func TestDialContextUsesTheInstalledHook(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	held = append(held, replacement)
 	hook.Uninstall()
 	if !Installed() {
 		t.Fatal("a stale handle must not remove the current hook")
@@ -89,7 +98,6 @@ func TestDialContextUsesTheInstalledHook(t *testing.T) {
 // a hook was installed would otherwise keep handing it addresses it had
 // already chosen, which no hostname policy can judge.
 func TestLookupFollowsTheHookAtCallTime(t *testing.T) {
-	t.Cleanup(func() { installed.Store(nil) })
 	resolved := []string{"10.0.0.4"}
 	resolve := func(context.Context, string) ([]string, error) { return resolved, nil }
 
@@ -103,9 +111,11 @@ func TestLookupFollowsTheHookAtCallTime(t *testing.T) {
 	}
 
 	// The hook arrives afterwards; the same client must now hand it the name.
-	if _, err := Install(func(context.Context, string, string) (net.Conn, error) { return nil, nil }); err != nil {
+	hook, err := Install(func(context.Context, string, string) (net.Conn, error) { return nil, nil })
+	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(hook.Uninstall)
 	got, err = Lookup(context.Background(), "db.internal", resolve)
 	if err != nil {
 		t.Fatal(err)

--- a/egress/egress_test.go
+++ b/egress/egress_test.go
@@ -13,7 +13,7 @@ func TestDialContextUsesTheInstalledHook(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer listener.Close()
-	t.Cleanup(func() { Install(nil) })
+	t.Cleanup(Uninstall)
 
 	// Without a hook the default dialer connects.
 	conn, err := DialContext(context.Background(), "tcp", listener.Addr().String())
@@ -29,10 +29,12 @@ func TestDialContextUsesTheInstalledHook(t *testing.T) {
 	// through the Dialer adapter.
 	refused := errors.New("outside the air gap")
 	var dialed []string
-	Install(func(_ context.Context, _, address string) (net.Conn, error) {
+	if err := Install(func(_ context.Context, _, address string) (net.Conn, error) {
 		dialed = append(dialed, address)
 		return nil, refused
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 	if !Installed() {
 		t.Fatal("Installed must report the hook")
 	}
@@ -46,14 +48,57 @@ func TestDialContextUsesTheInstalledHook(t *testing.T) {
 		t.Fatalf("hook saw %v", dialed)
 	}
 
-	// Installing nil restores the default dialer.
-	Install(nil)
+	// A second hook is refused rather than silently replacing the first: the
+	// policy belongs to whoever composed the process.
+	if err := Install(func(context.Context, string, string) (net.Conn, error) { return nil, nil }); err == nil {
+		t.Fatal("installing over an existing hook must be an error")
+	}
+	if _, err := DialContext(context.Background(), "tcp", "db.example.com:5432"); !errors.Is(err, refused) {
+		t.Fatalf("the first hook must still be in force, got %v", err)
+	}
+	if err := Install(nil); err == nil {
+		t.Fatal("Install(nil) must be an error; Uninstall removes the hook")
+	}
+
+	// Uninstall restores the default dialer.
+	Uninstall()
 	if Installed() {
-		t.Fatal("Install(nil) must remove the hook")
+		t.Fatal("Uninstall must remove the hook")
 	}
 	conn, err = DialContext(context.Background(), "tcp", listener.Addr().String())
 	if err != nil {
 		t.Fatalf("default dialer after removal: %v", err)
 	}
 	conn.Close()
+}
+
+// Clients that resolve a name themselves before dialing ask Lookup which
+// answer to use. The decision is made per connection: a client built before
+// a hook was installed would otherwise keep handing it addresses it had
+// already chosen, which no hostname policy can judge.
+func TestLookupFollowsTheHookAtCallTime(t *testing.T) {
+	t.Cleanup(Uninstall)
+	resolved := []string{"10.0.0.4"}
+	resolve := func(context.Context, string) ([]string, error) { return resolved, nil }
+
+	// A client constructed with no hook installed.
+	got, err := Lookup(context.Background(), "db.internal", resolve)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0] != "10.0.0.4" {
+		t.Fatalf("without a hook the client's own resolver answers, got %v", got)
+	}
+
+	// The hook arrives afterwards; the same client must now hand it the name.
+	if err := Install(func(context.Context, string, string) (net.Conn, error) { return nil, nil }); err != nil {
+		t.Fatal(err)
+	}
+	got, err = Lookup(context.Background(), "db.internal", resolve)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0] != "db.internal" {
+		t.Fatalf("a hook installed later must still see the hostname, got %v", got)
+	}
 }

--- a/egress/egress_test.go
+++ b/egress/egress_test.go
@@ -13,7 +13,7 @@ func TestDialContextUsesTheInstalledHook(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer listener.Close()
-	t.Cleanup(Uninstall)
+	t.Cleanup(func() { installed.Store(nil) })
 
 	// Without a hook the default dialer connects.
 	conn, err := DialContext(context.Background(), "tcp", listener.Addr().String())
@@ -29,10 +29,11 @@ func TestDialContextUsesTheInstalledHook(t *testing.T) {
 	// through the Dialer adapter.
 	refused := errors.New("outside the air gap")
 	var dialed []string
-	if err := Install(func(_ context.Context, _, address string) (net.Conn, error) {
+	hook, err := Install(func(_ context.Context, _, address string) (net.Conn, error) {
 		dialed = append(dialed, address)
 		return nil, refused
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 	if !Installed() {
@@ -50,21 +51,32 @@ func TestDialContextUsesTheInstalledHook(t *testing.T) {
 
 	// A second hook is refused rather than silently replacing the first: the
 	// policy belongs to whoever composed the process.
-	if err := Install(func(context.Context, string, string) (net.Conn, error) { return nil, nil }); err == nil {
+	if _, err := Install(func(context.Context, string, string) (net.Conn, error) { return nil, nil }); err == nil {
 		t.Fatal("installing over an existing hook must be an error")
 	}
 	if _, err := DialContext(context.Background(), "tcp", "db.example.com:5432"); !errors.Is(err, refused) {
 		t.Fatalf("the first hook must still be in force, got %v", err)
 	}
-	if err := Install(nil); err == nil {
-		t.Fatal("Install(nil) must be an error; Uninstall removes the hook")
+	if _, err := Install(nil); err == nil {
+		t.Fatal("a nil dial must be an error; the handle removes a hook")
 	}
 
-	// Uninstall restores the default dialer.
-	Uninstall()
+	// The handle its owner holds restores the default dialer, and says so
+	// only once: a stale handle must not remove a policy someone else
+	// installed afterwards.
+	hook.Uninstall()
 	if Installed() {
-		t.Fatal("Uninstall must remove the hook")
+		t.Fatal("the handle must remove the hook")
 	}
+	replacement, err := Install(func(context.Context, string, string) (net.Conn, error) { return nil, refused })
+	if err != nil {
+		t.Fatal(err)
+	}
+	hook.Uninstall()
+	if !Installed() {
+		t.Fatal("a stale handle must not remove the current hook")
+	}
+	replacement.Uninstall()
 	conn, err = DialContext(context.Background(), "tcp", listener.Addr().String())
 	if err != nil {
 		t.Fatalf("default dialer after removal: %v", err)
@@ -77,7 +89,7 @@ func TestDialContextUsesTheInstalledHook(t *testing.T) {
 // a hook was installed would otherwise keep handing it addresses it had
 // already chosen, which no hostname policy can judge.
 func TestLookupFollowsTheHookAtCallTime(t *testing.T) {
-	t.Cleanup(Uninstall)
+	t.Cleanup(func() { installed.Store(nil) })
 	resolved := []string{"10.0.0.4"}
 	resolve := func(context.Context, string) ([]string, error) { return resolved, nil }
 
@@ -91,7 +103,7 @@ func TestLookupFollowsTheHookAtCallTime(t *testing.T) {
 	}
 
 	// The hook arrives afterwards; the same client must now hand it the name.
-	if err := Install(func(context.Context, string, string) (net.Conn, error) { return nil, nil }); err != nil {
+	if _, err := Install(func(context.Context, string, string) (net.Conn, error) { return nil, nil }); err != nil {
 		t.Fatal(err)
 	}
 	got, err = Lookup(context.Background(), "db.internal", resolve)

--- a/egress/egress_test.go
+++ b/egress/egress_test.go
@@ -1,0 +1,59 @@
+package egress
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+)
+
+func TestDialContextUsesTheInstalledHook(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	t.Cleanup(func() { Install(nil) })
+
+	// Without a hook the default dialer connects.
+	conn, err := DialContext(context.Background(), "tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatalf("default dialer: %v", err)
+	}
+	conn.Close()
+	if Installed() {
+		t.Fatal("no hook is installed yet")
+	}
+
+	// With one, every connection goes through it - including the ones opened
+	// through the Dialer adapter.
+	refused := errors.New("outside the air gap")
+	var dialed []string
+	Install(func(_ context.Context, _, address string) (net.Conn, error) {
+		dialed = append(dialed, address)
+		return nil, refused
+	})
+	if !Installed() {
+		t.Fatal("Installed must report the hook")
+	}
+	if _, err := DialContext(context.Background(), "tcp", "db.example.com:5432"); !errors.Is(err, refused) {
+		t.Fatalf("hook error = %v, want the hook's refusal", err)
+	}
+	if _, err := (Dialer{}).DialContext(context.Background(), "tcp", "cache.example.com:6379"); !errors.Is(err, refused) {
+		t.Fatalf("adapter error = %v, want the hook's refusal", err)
+	}
+	if len(dialed) != 2 || dialed[0] != "db.example.com:5432" || dialed[1] != "cache.example.com:6379" {
+		t.Fatalf("hook saw %v", dialed)
+	}
+
+	// Installing nil restores the default dialer.
+	Install(nil)
+	if Installed() {
+		t.Fatal("Install(nil) must remove the hook")
+	}
+	conn, err = DialContext(context.Background(), "tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatalf("default dialer after removal: %v", err)
+	}
+	conn.Close()
+}

--- a/internal/cache/egress_hook_test.go
+++ b/internal/cache/egress_hook_test.go
@@ -15,11 +15,13 @@ import (
 // URL names.
 func TestRedisStoreDialsThroughTheEgressHook(t *testing.T) {
 	var address string
-	egress.Install(func(_ context.Context, _, addr string) (net.Conn, error) {
+	if err := egress.Install(func(_ context.Context, _, addr string) (net.Conn, error) {
 		address = addr
 		return nil, errors.New("refused by the test hook")
-	})
-	defer egress.Install(nil)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	defer egress.Uninstall()
 
 	if _, err := NewRedisStore(RedisStoreConfig{URL: "redis://cache.example.com:6379/0"}); err == nil {
 		t.Fatal("expected the refused dial to fail the connection")

--- a/internal/cache/egress_hook_test.go
+++ b/internal/cache/egress_hook_test.go
@@ -1,0 +1,30 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/enterpilot/gomodel/egress"
+)
+
+// Redis speaks its own protocol over raw TCP and reads no proxy variable, so
+// an egress policy reaches it only through the hook. The dial is refused on
+// purpose: what matters is that the hook was asked, and for the address the
+// URL names.
+func TestRedisStoreDialsThroughTheEgressHook(t *testing.T) {
+	var address string
+	egress.Install(func(_ context.Context, _, addr string) (net.Conn, error) {
+		address = addr
+		return nil, errors.New("refused by the test hook")
+	})
+	defer egress.Install(nil)
+
+	if _, err := NewRedisStore(RedisStoreConfig{URL: "redis://cache.example.com:6379/0"}); err == nil {
+		t.Fatal("expected the refused dial to fail the connection")
+	}
+	if address != "cache.example.com:6379" {
+		t.Fatalf("hook saw %q, want the configured cache address", address)
+	}
+}

--- a/internal/cache/egress_hook_test.go
+++ b/internal/cache/egress_hook_test.go
@@ -15,13 +15,14 @@ import (
 // URL names.
 func TestRedisStoreDialsThroughTheEgressHook(t *testing.T) {
 	var address string
-	if err := egress.Install(func(_ context.Context, _, addr string) (net.Conn, error) {
+	hook, err := egress.Install(func(_ context.Context, _, addr string) (net.Conn, error) {
 		address = addr
 		return nil, errors.New("refused by the test hook")
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
-	defer egress.Uninstall()
+	defer hook.Uninstall()
 
 	if _, err := NewRedisStore(RedisStoreConfig{URL: "redis://cache.example.com:6379/0"}); err == nil {
 		t.Fatal("expected the refused dial to fail the connection")

--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/redis/go-redis/v9"
+
+	"github.com/enterpilot/gomodel/egress"
 )
 
 const (
@@ -34,6 +36,7 @@ func NewRedisStore(cfg RedisStoreConfig) (*RedisStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid redis URL: %w", err)
 	}
+	opts.Dialer = egress.DialContext
 	client := redis.NewClient(opts)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/internal/responsecache/egress_hook_test.go
+++ b/internal/responsecache/egress_hook_test.go
@@ -1,0 +1,36 @@
+package responsecache
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/enterpilot/gomodel/config"
+	"github.com/enterpilot/gomodel/egress"
+)
+
+// The pgvector store opens its own pool, so it needs the hook wired
+// separately from the PostgreSQL storage backend. The dial is refused on
+// purpose: what matters is that the hook was asked, and for the host the
+// URL names rather than an address pgx resolved on its own.
+func TestPGVectorStoreDialsThroughTheEgressHook(t *testing.T) {
+	var address string
+	if err := egress.Install(func(_ context.Context, _, addr string) (net.Conn, error) {
+		address = addr
+		return nil, errors.New("refused by the test hook")
+	}); err != nil {
+		t.Fatal(err)
+	}
+	defer egress.Uninstall()
+
+	if _, err := newPGVectorStore(config.PGVectorConfig{
+		URL:       "postgres://user:pw@vectors.example.com:5432/gomodel",
+		Dimension: 8,
+	}); err == nil {
+		t.Fatal("expected the refused dial to fail the store")
+	}
+	if address != "vectors.example.com:5432" {
+		t.Fatalf("hook saw %q, want the configured vector store address", address)
+	}
+}

--- a/internal/responsecache/egress_hook_test.go
+++ b/internal/responsecache/egress_hook_test.go
@@ -16,13 +16,14 @@ import (
 // URL names rather than an address pgx resolved on its own.
 func TestPGVectorStoreDialsThroughTheEgressHook(t *testing.T) {
 	var address string
-	if err := egress.Install(func(_ context.Context, _, addr string) (net.Conn, error) {
+	hook, err := egress.Install(func(_ context.Context, _, addr string) (net.Conn, error) {
 		address = addr
 		return nil, errors.New("refused by the test hook")
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
-	defer egress.Uninstall()
+	defer hook.Uninstall()
 
 	if _, err := newPGVectorStore(config.PGVectorConfig{
 		URL:       "postgres://user:pw@vectors.example.com:5432/gomodel",

--- a/internal/responsecache/vecstore_pgvector.go
+++ b/internal/responsecache/vecstore_pgvector.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/enterpilot/gomodel/config"
+	"github.com/enterpilot/gomodel/egress"
 )
 
 type pgVecStore struct {
@@ -34,7 +35,19 @@ func newPGVectorStore(cfg config.PGVectorConfig) (*pgVecStore, error) {
 	if err := validatePGIdentifier(tbl); err != nil {
 		return nil, fmt.Errorf("vecstore pgvector: table: %w", err)
 	}
-	pool, err := pgxpool.New(context.Background(), cfg.URL)
+	poolCfg, err := pgxpool.ParseConfig(cfg.URL)
+	if err != nil {
+		return nil, fmt.Errorf("vecstore pgvector: url: %w", err)
+	}
+	// See NewPostgreSQL: with an egress hook installed the name reaches it
+	// unresolved, so one place decides what it may resolve to.
+	poolCfg.ConnConfig.DialFunc = egress.DialContext
+	if egress.Installed() {
+		poolCfg.ConnConfig.LookupFunc = func(_ context.Context, host string) ([]string, error) {
+			return []string{host}, nil
+		}
+	}
+	pool, err := pgxpool.NewWithConfig(context.Background(), poolCfg)
 	if err != nil {
 		return nil, fmt.Errorf("vecstore pgvector: connect: %w", err)
 	}

--- a/internal/responsecache/vecstore_pgvector.go
+++ b/internal/responsecache/vecstore_pgvector.go
@@ -39,13 +39,12 @@ func newPGVectorStore(cfg config.PGVectorConfig) (*pgVecStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("vecstore pgvector: url: %w", err)
 	}
-	// See NewPostgreSQL: with an egress hook installed the name reaches it
-	// unresolved, so one place decides what it may resolve to.
+	// See NewPostgreSQL: the dial and the lookup before it both go through
+	// the egress hook, decided per connection.
 	poolCfg.ConnConfig.DialFunc = egress.DialContext
-	if egress.Installed() {
-		poolCfg.ConnConfig.LookupFunc = func(_ context.Context, host string) ([]string, error) {
-			return []string{host}, nil
-		}
+	resolve := poolCfg.ConnConfig.LookupFunc
+	poolCfg.ConnConfig.LookupFunc = func(ctx context.Context, host string) ([]string, error) {
+		return egress.Lookup(ctx, host, resolve)
 	}
 	pool, err := pgxpool.NewWithConfig(context.Background(), poolCfg)
 	if err != nil {

--- a/internal/storage/egress_hook_test.go
+++ b/internal/storage/egress_hook_test.go
@@ -45,17 +45,18 @@ func TestMongoDBDialsThroughTheEgressHook(t *testing.T) {
 func recordDials(t *testing.T) (*string, func()) {
 	t.Helper()
 	var address string
-	if err := egress.Install(func(_ context.Context, _, addr string) (net.Conn, error) {
+	hook, err := egress.Install(func(_ context.Context, _, addr string) (net.Conn, error) {
 		address = addr
 		return nil, errors.New("refused by the test hook")
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 	removed := false
 	remove := func() {
 		if !removed {
 			removed = true
-			egress.Uninstall()
+			hook.Uninstall()
 		}
 	}
 	t.Cleanup(remove)

--- a/internal/storage/egress_hook_test.go
+++ b/internal/storage/egress_hook_test.go
@@ -1,0 +1,61 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/enterpilot/gomodel/egress"
+)
+
+// The database clients speak their own protocols over raw TCP and read no
+// proxy variable, so an egress policy reaches them only through the hook.
+// These tests fail the dial on purpose: what matters is that the hook was
+// asked at all, and with the address the URL names.
+func TestPostgreSQLDialsThroughTheEgressHook(t *testing.T) {
+	address, restore := recordDials(t)
+	if _, err := NewPostgreSQL(context.Background(), PostgreSQLConfig{URL: "postgres://user:pw@db.example.com:5432/gomodel"}); err == nil {
+		t.Fatal("expected the refused dial to fail the connection")
+	}
+	restore()
+	if *address != "db.example.com:5432" {
+		t.Fatalf("hook saw %q, want the configured database address", *address)
+	}
+}
+
+func TestMongoDBDialsThroughTheEgressHook(t *testing.T) {
+	address, restore := recordDials(t)
+	_, err := NewMongoDB(context.Background(), MongoDBConfig{
+		URL: "mongodb://db.example.com:27017/gomodel?serverSelectionTimeoutMS=200&connectTimeoutMS=200",
+	})
+	restore()
+	if err == nil {
+		t.Fatal("expected the refused dial to fail the connection")
+	}
+	if *address != "db.example.com:27017" {
+		t.Fatalf("hook saw %q, want the configured database address", *address)
+	}
+}
+
+// recordDials installs a hook that refuses every connection and records the
+// last address it was asked for. The returned func removes it again; call it
+// before asserting, so a failure never leaves the hook installed for the
+// rest of the package's tests.
+func recordDials(t *testing.T) (*string, func()) {
+	t.Helper()
+	var address string
+	egress.Install(func(_ context.Context, _, addr string) (net.Conn, error) {
+		address = addr
+		return nil, errors.New("refused by the test hook")
+	})
+	removed := false
+	remove := func() {
+		if !removed {
+			removed = true
+			egress.Install(nil)
+		}
+	}
+	t.Cleanup(remove)
+	return &address, remove
+}

--- a/internal/storage/egress_hook_test.go
+++ b/internal/storage/egress_hook_test.go
@@ -45,15 +45,17 @@ func TestMongoDBDialsThroughTheEgressHook(t *testing.T) {
 func recordDials(t *testing.T) (*string, func()) {
 	t.Helper()
 	var address string
-	egress.Install(func(_ context.Context, _, addr string) (net.Conn, error) {
+	if err := egress.Install(func(_ context.Context, _, addr string) (net.Conn, error) {
 		address = addr
 		return nil, errors.New("refused by the test hook")
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 	removed := false
 	remove := func() {
 		if !removed {
 			removed = true
-			egress.Install(nil)
+			egress.Uninstall()
 		}
 	}
 	t.Cleanup(remove)

--- a/internal/storage/mongodb.go
+++ b/internal/storage/mongodb.go
@@ -8,6 +8,8 @@ import (
 
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
+
+	"github.com/enterpilot/gomodel/egress"
 )
 
 // DefaultMongoDatabase is the database used when neither the explicit Database
@@ -29,7 +31,7 @@ func NewMongoDB(ctx context.Context, cfg MongoDBConfig) (MongoDBStorage, error) 
 	dbName := resolveMongoDatabase(cfg)
 
 	// Create client options
-	clientOpts := options.Client().ApplyURI(cfg.URL)
+	clientOpts := options.Client().ApplyURI(cfg.URL).SetDialer(egress.Dialer{})
 
 	// Connect to MongoDB
 	client, err := mongo.Connect(clientOpts)

--- a/internal/storage/postgresql.go
+++ b/internal/storage/postgresql.go
@@ -37,15 +37,16 @@ func NewPostgreSQL(ctx context.Context, cfg PostgreSQLConfig) (PostgreSQLStorage
 	}
 
 	// Every connection the pool opens goes through the egress hook, so a
-	// distribution that polices outbound traffic sees the database too. With
-	// a hook installed the hostname is handed to it unresolved: the hook
-	// decides what the name may resolve to and dials the address that
-	// passed, rather than being given addresses pgx already picked.
+	// distribution that polices outbound traffic sees the database too. pgx
+	// resolves the host before it dials, so the lookup is deferred to the
+	// hook as well: with one installed the name reaches it unresolved and
+	// the hook dials the address that passed, and without one pgx's own
+	// resolver answers. Both are decided per connection, so a hook installed
+	// after this pool was built still sees hostnames.
 	poolCfg.ConnConfig.DialFunc = egress.DialContext
-	if egress.Installed() {
-		poolCfg.ConnConfig.LookupFunc = func(_ context.Context, host string) ([]string, error) {
-			return []string{host}, nil
-		}
+	resolve := poolCfg.ConnConfig.LookupFunc
+	poolCfg.ConnConfig.LookupFunc = func(ctx context.Context, host string) ([]string, error) {
+		return egress.Lookup(ctx, host, resolve)
 	}
 
 	// Create the connection pool

--- a/internal/storage/postgresql.go
+++ b/internal/storage/postgresql.go
@@ -6,6 +6,8 @@ import (
 	"math"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/enterpilot/gomodel/egress"
 )
 
 // postgresStorage implements Storage for PostgreSQL
@@ -32,6 +34,18 @@ func NewPostgreSQL(ctx context.Context, cfg PostgreSQLConfig) (PostgreSQLStorage
 		poolCfg.MaxConns = int32(maxConns)
 	} else {
 		poolCfg.MaxConns = 10 // default
+	}
+
+	// Every connection the pool opens goes through the egress hook, so a
+	// distribution that polices outbound traffic sees the database too. With
+	// a hook installed the hostname is handed to it unresolved: the hook
+	// decides what the name may resolve to and dials the address that
+	// passed, rather than being given addresses pgx already picked.
+	poolCfg.ConnConfig.DialFunc = egress.DialContext
+	if egress.Installed() {
+		poolCfg.ConnConfig.LookupFunc = func(_ context.Context, host string) ([]string, error) {
+			return []string{host}, nil
+		}
 	}
 
 	// Create the connection pool


### PR DESCRIPTION
## Why

HTTP clients follow the standard proxy variables, so a distribution that wants to see every outbound request only has to set `HTTP_PROXY`. The database, cache, and vector store clients speak their own protocols over raw TCP and read no such variable — they connect wherever their URL points, whatever policy the distribution believes it is enforcing.

This came out of a review of GoModel Pro's air-gapped mode: its egress guard covers HTTP, so a Postgres, MongoDB, or Redis hostname that passes the startup audit can resolve publicly on a later connection, with no runtime check and no refusal evidence.

## What

- New `egress` package: one process-wide dial hook (`Install` / `DialContext`, plus a `Dialer{}` adapter for the MongoDB driver's interface). With no hook installed the default `net.Dialer` is used, so core's behaviour is unchanged.
- Routed through it: `internal/storage/postgresql.go` (pgx `DialFunc`), `internal/storage/mongodb.go` (`SetDialer`), `internal/cache/redis.go` (`opts.Dialer`), and `internal/responsecache/vecstore_pgvector.go` (now parses the pool config so it can set `DialFunc`).
- With a hook installed, pgx gets a pass-through `LookupFunc` so the hook receives the configured hostname rather than addresses pgx already resolved — otherwise an allowlisted name can never match. The default path keeps pgx's own resolution and multi-address fallback.

## Tests

- `egress/egress_test.go`: default dialer, hook interception, the Mongo adapter, and `Install(nil)` restoring the default.
- `internal/storage/egress_hook_test.go` and `internal/cache/egress_hook_test.go`: refuse the dial from a test hook and assert each client asked the hook for the address its URL names. The PostgreSQL one fails without the `LookupFunc` change.

Full `go test ./...` passes.

## Downstream

GoModel Pro's air-gapped guard installs itself here (`Guard.DialContext`), which is what turns "audited once at startup" into "refused before it is dialled, and recorded in `/admin/pro/egress`". The Pro side needs a release containing this package before it can pin it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5JDPHb6ja5M1UFv12nwUf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable outbound connection routing for database, cache, and vector store connections.
  * Connections can be intercepted and handled through a custom dialing configuration.
  * PostgreSQL, MongoDB, Redis, and pgvector connections now support the configured routing behavior.
  * Hostnames remain available to custom routing for resolution and connection handling.
  * Connections fall back to standard dialing when no custom routing is installed.
* **Tests**
  * Added coverage for custom routing, connection targets, fallback dialing, and hook cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->