### PR TITLE
feat(dashboard): expand guardrail steps from the workflow chart

### DIFF
--- a/internal/admin/handler_workflows.go
+++ b/internal/admin/handler_workflows.go
@@ -69,6 +69,9 @@ type workflowGuardrailItem struct {
 	Type    string   `json:"type,omitempty"`
 	Phases  []string `json:"phases"`
 	Summary string   `json:"summary,omitempty"`
+	// Mutates marks an instance that may edit the request or response; the
+	// gateway runs it after the readers of its step.
+	Mutates bool `json:"mutates"`
 }
 
 // ListWorkflowGuardrails handles GET /admin/workflows/guardrails
@@ -81,7 +84,7 @@ func (h *Handler) ListWorkflowGuardrails(c *echo.Context) error {
 			if phases == nil {
 				phases = []string{}
 			}
-			items = append(items, workflowGuardrailItem{Name: view.Name, Type: view.Type, Phases: phases, Summary: view.Summary})
+			items = append(items, workflowGuardrailItem{Name: view.Name, Type: view.Type, Phases: phases, Summary: view.Summary, Mutates: view.Mutates})
 		}
 	case h.guardrails != nil:
 		for _, name := range h.guardrails.Names() {

--- a/internal/admin/handler_workflows_test.go
+++ b/internal/admin/handler_workflows_test.go
@@ -523,11 +523,12 @@ func TestListWorkflowGuardrails(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("unmarshal response: %v", err)
 	}
-	if len(body) != 1 || body[0].Name != "policy-system" || len(body[0].Phases) != 1 || body[0].Phases[0] != "prompt" {
-		t.Fatalf("body = %#v, want [policy-system] with prompt phase", body)
+	if len(body) != 1 || body[0].Name != "policy-system" || len(body[0].Phases) != 1 || body[0].Phases[0] != "prompt" || body[0].Mutates {
+		t.Fatalf("body = %#v, want [policy-system] with prompt phase and no mutates flag", body)
 	}
 
-	// The full service reports type, phases and summary per instance.
+	// The full service reports type, phases, summary and the mutates flag
+	// per instance (system_prompt edits the prompt).
 	h = NewHandler(nil, nil, WithGuardrailService(registry))
 	c, rec = newHandlerContext("/admin/workflows/guardrails")
 	if err := h.ListWorkflowGuardrails(c); err != nil {
@@ -537,8 +538,8 @@ func TestListWorkflowGuardrails(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("unmarshal response: %v", err)
 	}
-	if len(body) != 1 || body[0].Type != "system_prompt" || body[0].Summary == "" || body[0].Phases[0] != "prompt" {
-		t.Fatalf("body = %#v, want typed item with summary", body)
+	if len(body) != 1 || body[0].Type != "system_prompt" || body[0].Summary == "" || body[0].Phases[0] != "prompt" || !body[0].Mutates {
+		t.Fatalf("body = %#v, want typed mutating item with summary", body)
 	}
 }
 

--- a/internal/guardrails/definitions.go
+++ b/internal/guardrails/definitions.go
@@ -36,6 +36,10 @@ type View struct {
 	// pluginapi.Manifest.Guardrail); an instance of a modifier such as
 	// header_edit is a plugin instance but not a guardrail.
 	Guardrail bool `json:"guardrail"`
+	// Mutates reports whether the instance's plugin may edit the request or
+	// response (see pluginapi.Manifest.Mutates); within one workflow step the
+	// gateway runs such an instance after the step's readers.
+	Mutates bool `json:"mutates"`
 }
 
 // ViewFromDefinition projects one guardrail definition into its admin-facing

--- a/internal/guardrails/service.go
+++ b/internal/guardrails/service.go
@@ -365,6 +365,7 @@ func (s *Service) viewLocked(name string) View {
 	if inst := s.snapshot.instances[name]; inst != nil {
 		view.Phases = phaseNames(inst.Kinds)
 		view.Guardrail = inst.Manifest.Guardrail
+		view.Mutates = inst.Manifest.Mutates
 	}
 	return view
 }

--- a/web/dashboard/messages/de.json
+++ b/web/dashboard/messages/de.json
@@ -1302,6 +1302,8 @@
   "workflows_steps_count": "{count} Schritte",
   "workflows_one_step": "1 Schritt",
   "workflows_step_number": "Schritt {number}",
+  "workflows_guardrail_flow_toggle": "{phase}-Guardrail-Schritte ein- oder ausblenden",
+  "workflows_guardrail_flow_title": "{phase}-Guardrails",
   "workflows_deactivate_action": "Workflow {name} deaktivieren",
   "workflows_deactivate_active": "Aktiven Workflow deaktivieren",
   "workflows_global_no_deactivate": "Der globale Workflow kann nicht deaktiviert werden.",

--- a/web/dashboard/messages/de.json
+++ b/web/dashboard/messages/de.json
@@ -1304,6 +1304,7 @@
   "workflows_step_number": "Schritt {number}",
   "workflows_guardrail_flow_toggle": "{phase}-Guardrail-Schritte ein- oder ausblenden",
   "workflows_guardrail_flow_title": "{phase}-Guardrails",
+  "workflows_guardrail_flow_mutator": "Läuft nach den Prüfungen dieses Schritts und kann Anfrage oder Antwort ändern",
   "workflows_deactivate_action": "Workflow {name} deaktivieren",
   "workflows_deactivate_active": "Aktiven Workflow deaktivieren",
   "workflows_global_no_deactivate": "Der globale Workflow kann nicht deaktiviert werden.",

--- a/web/dashboard/messages/en.json
+++ b/web/dashboard/messages/en.json
@@ -1304,6 +1304,7 @@
   "workflows_step_number": "step {number}",
   "workflows_guardrail_flow_toggle": "Show or hide the {phase} guardrail steps",
   "workflows_guardrail_flow_title": "{phase} guardrails",
+  "workflows_guardrail_flow_mutator": "Runs after the checks of this step and may edit the request or response",
   "workflows_deactivate_action": "Deactivate Workflow {name}",
   "workflows_deactivate_active": "Deactivate active Workflow",
   "workflows_global_no_deactivate": "The global Workflow cannot be deactivated.",

--- a/web/dashboard/messages/en.json
+++ b/web/dashboard/messages/en.json
@@ -1302,6 +1302,8 @@
   "workflows_steps_count": "{count} steps",
   "workflows_one_step": "1 step",
   "workflows_step_number": "step {number}",
+  "workflows_guardrail_flow_toggle": "Show or hide the {phase} guardrail steps",
+  "workflows_guardrail_flow_title": "{phase} guardrails",
   "workflows_deactivate_action": "Deactivate Workflow {name}",
   "workflows_deactivate_active": "Deactivate active Workflow",
   "workflows_global_no_deactivate": "The global Workflow cannot be deactivated.",

--- a/web/dashboard/messages/pl.json
+++ b/web/dashboard/messages/pl.json
@@ -1332,6 +1332,7 @@
   "workflows_step_number": "krok {number}",
   "workflows_guardrail_flow_toggle": "Pokaż lub ukryj kroki guardrails fazy {phase}",
   "workflows_guardrail_flow_title": "Guardrails: {phase}",
+  "workflows_guardrail_flow_mutator": "Uruchamia się po kontrolach tego kroku i może zmienić żądanie lub odpowiedź",
   "workflows_deactivate_action": "Dezaktywuj Workflow {name}",
   "workflows_deactivate_active": "Dezaktywuj aktywny Workflow",
   "workflows_global_no_deactivate": "Globalnego Workflow nie można dezaktywować.",

--- a/web/dashboard/messages/pl.json
+++ b/web/dashboard/messages/pl.json
@@ -1330,6 +1330,8 @@
   "workflows_steps_count": "Kroki: {count}",
   "workflows_one_step": "1 krok",
   "workflows_step_number": "krok {number}",
+  "workflows_guardrail_flow_toggle": "Pokaż lub ukryj kroki guardrails fazy {phase}",
+  "workflows_guardrail_flow_title": "Guardrails: {phase}",
   "workflows_deactivate_action": "Dezaktywuj Workflow {name}",
   "workflows_deactivate_active": "Dezaktywuj aktywny Workflow",
   "workflows_global_no_deactivate": "Globalnego Workflow nie można dezaktywować.",

--- a/web/dashboard/src/pages/workflows/WorkflowCard.svelte
+++ b/web/dashboard/src/pages/workflows/WorkflowCard.svelte
@@ -30,7 +30,7 @@
   const guardrails = $derived(workflowGuardrails(workflow, caps));
   // Steps grouped in execution order: prompt, then response, then stream.
   const stepGroups = $derived(workflowStepGroups(guardrails));
-  const chart = $derived(workflowChart(workflow, caps));
+  const chart = $derived(workflowChart(workflow, caps, wf.guardrailRefs));
   const guardrailKeyPrefix = $derived(
     preview ? "draft-workflow-preview-guardrail-" : workflow.id + "-guardrail-",
   );

--- a/web/dashboard/src/pages/workflows/WorkflowChart.svelte
+++ b/web/dashboard/src/pages/workflows/WorkflowChart.svelte
@@ -4,6 +4,9 @@
   // Renders a chart contract object built by workflowChartLogic.js.
   import Icon from "$lib/components/atoms/Icon.svelte";
   import WorkflowIdBadge from "./WorkflowIdBadge.svelte";
+  import { fly } from "svelte/transition";
+  import { motionDuration } from "$lib/utils/motion.js";
+  import { phaseLabel } from "$lib/utils/pluginPhases.js";
   import {
     ChartColumnIncreasing,
     CircleCheckBig,
@@ -16,29 +19,78 @@
   } from "lucide";
 
   let { chart = {} } = $props();
+
+  // Phase whose guardrail steps are expanded under the pipeline; one panel
+  // at a time, toggled by clicking a Guardrails node.
+  let openPhase = $state(null);
+  const uid = $props.id();
+  const panelID = uid + "-guardrail-flow";
+
+  const openFlow = $derived(
+    openPhase && chart.guardrailFlows ? chart.guardrailFlows[openPhase] || [] : [],
+  );
+
+  function toggleGuardrails(phase) {
+    openPhase = openPhase === phase ? null : phase;
+  }
+
+  // Close the panel when its phase drops out of the chart (audit rows swap
+  // charts in place, editor previews re-render on each keystroke).
+  $effect(() => {
+    if (!openPhase) return;
+    const flows = chart.guardrailFlows || {};
+    if (!(flows[openPhase] && flows[openPhase].length > 0)) openPhase = null;
+  });
 </script>
 
 <!-- One pipeline node. `icon` is a lucide icon (omitted for the AI node);
      `variant` carries the structural class, `state` the computed status
      class from workflowChartLogic.js. -->
+{#snippet nodeBody({ icon, label, variant, sub, badge })}
+  {#if icon}
+    <div
+      class="workflow-node-icon"
+      class:workflow-node-icon-endpoint={variant === "workflow-node-endpoint"}
+    >
+      <Icon {icon} />
+    </div>
+  {/if}
+  <span class="workflow-node-label">{label}</span>
+  {#if badge}
+    <span class="workflow-node-badge">{badge}</span>
+  {/if}
+  {#if sub}
+    <span class="workflow-node-sub">{sub}</span>
+  {/if}
+{/snippet}
+
 {#snippet node({ icon, label, variant = "workflow-node-feature", state, sub, badge })}
   <div class={["workflow-node", variant, state]}>
-    {#if icon}
-      <div
-        class="workflow-node-icon"
-        class:workflow-node-icon-endpoint={variant === "workflow-node-endpoint"}
-      >
-        <Icon {icon} />
-      </div>
-    {/if}
-    <span class="workflow-node-label">{label}</span>
-    {#if badge}
-      <span class="workflow-node-badge">{badge}</span>
-    {/if}
-    {#if sub}
-      <span class="workflow-node-sub">{sub}</span>
-    {/if}
+    {@render nodeBody({ icon, label, variant, sub, badge })}
   </div>
+{/snippet}
+
+<!-- A Guardrails node: a button that expands the phase's step flow under
+     the pipeline. Disabled (plain node) when the phase has no steps to show. -->
+{#snippet guardrailNode({ phase, badge, sub })}
+  {@const flow = (chart.guardrailFlows && chart.guardrailFlows[phase]) || []}
+  {@const open = openPhase === phase}
+  {#if flow.length > 0}
+    <button
+      type="button"
+      class={["workflow-node", "workflow-node-feature", "workflow-node-button"]}
+      class:workflow-node-open={open}
+      aria-expanded={open}
+      aria-controls={open ? panelID : undefined}
+      aria-label={m.workflows_guardrail_flow_toggle({ phase: phaseLabel(phase) })}
+      title={m.workflows_guardrail_flow_toggle({ phase: phaseLabel(phase) })}
+      onclick={() => toggleGuardrails(phase)}
+    >
+      {@render nodeBody({ icon: Shield, label: m.workflows_guardrails(), badge, sub })}
+    </button>
+  {:else}
+    {@render node({ icon: Shield, label: m.workflows_guardrails(), badge, sub })}
+  {/if}
 {/snippet}
 
 <div class="workflow-pipeline">
@@ -78,9 +130,8 @@
 
     {#if chart.showGuardrails}
       <div class="workflow-conn"></div>
-      {@render node({
-        icon: Shield,
-        label: m.workflows_guardrails(),
+      {@render guardrailNode({
+        phase: "prompt",
         badge: chart.guardrailBadge,
         sub: chart.guardrailLabel,
       })}
@@ -107,9 +158,8 @@
 
     {#if chart.showResponseGuardrails}
       <div class={["workflow-conn", chart.responseConnClass]}></div>
-      {@render node({
-        icon: Shield,
-        label: m.workflows_guardrails(),
+      {@render guardrailNode({
+        phase: "response",
         badge: chart.responseGuardrailBadge,
         sub: chart.responseGuardrailLabel,
       })}
@@ -117,9 +167,8 @@
 
     {#if chart.showStreamGuardrails}
       <div class={["workflow-conn", chart.responseConnClass]}></div>
-      {@render node({
-        icon: Shield,
-        label: m.workflows_guardrails(),
+      {@render guardrailNode({
+        phase: "stream",
         badge: chart.streamGuardrailBadge,
         sub: chart.streamGuardrailLabel,
       })}
@@ -134,6 +183,47 @@
       sub: chart.responseNodeSublabel,
     })}
   </div>
+
+  {#if openPhase && openFlow.length > 0}
+    <!-- Step flow of the expanded phase. Steps run left to right (arrows);
+         refs sharing a step stack vertically inside a fork/join bracket,
+         which is how the gateway runs them: concurrently. -->
+    <section
+      id={panelID}
+      class="workflow-guardrail-flow"
+      aria-label={m.workflows_guardrail_flow_title({ phase: phaseLabel(openPhase) })}
+      transition:fly={{ y: -6, duration: motionDuration(150) }}
+    >
+      <div class="workflow-guardrail-flow-head">
+        <span class="workflow-guardrail-flow-title">
+          <Icon icon={Shield} />
+          {m.workflows_guardrail_flow_title({ phase: phaseLabel(openPhase) })}
+        </span>
+      </div>
+      <ol class="workflow-guardrail-flow-row">
+        {#each openFlow as stage, index (openPhase + "-" + stage.step)}
+          {#if index > 0}
+            <li class="workflow-conn workflow-flow-conn" aria-hidden="true"></li>
+          {/if}
+          <!-- The step number is the browser tooltip of the column; the
+               bracket already shows which refs run together. -->
+          <li
+            class="workflow-flow-step"
+            class:workflow-flow-step-parallel={stage.refs.length > 1}
+            title={m.workflows_step_number({ number: stage.step })}
+          >
+            <ul class="workflow-flow-refs">
+              {#each stage.refs as ref, refIndex (refIndex + ":" + ref)}
+                <li class="workflow-flow-ref" class:workflow-flow-ref-blank={!ref}>
+                  {ref || m.workflows_select_guardrail()}
+                </li>
+              {/each}
+            </ul>
+          </li>
+        {/each}
+      </ol>
+    </section>
+  {/if}
 
   {#if chart.showAsync}
     <div class="workflow-pipeline-row workflow-async-section">
@@ -428,6 +518,201 @@
     opacity: 0.55;
     white-space: nowrap;
     flex-shrink: 0;
+  }
+
+  /* ─── Clickable Guardrails node ─── */
+  .workflow-node-button {
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+    appearance: none;
+    transition:
+      border-color 0.12s ease-out,
+      background 0.12s ease-out,
+      box-shadow 0.12s ease-out;
+  }
+
+  .workflow-node-button:hover {
+    border-color: color-mix(in srgb, var(--accent) 70%, var(--border));
+    background: color-mix(in srgb, var(--accent) 14%, var(--bg-surface));
+  }
+
+  .workflow-node-button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  .workflow-node-open {
+    position: relative;
+    border-color: var(--accent);
+    background: color-mix(in srgb, var(--accent) 16%, var(--bg-surface));
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 22%, transparent);
+  }
+
+  /* Filled triangle under the open node, pointing at the panel it expands.
+     It sits in the row's bottom padding, so the row's overflow clip keeps
+     it visible. */
+  .workflow-node-open::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    width: 16px;
+    height: 9px;
+    margin-top: 4px;
+    transform: translateX(-50%);
+    background: var(--accent);
+    clip-path: polygon(0 0, 100% 0, 50% 100%);
+  }
+
+  /* ─── Guardrail step flow panel ───
+   *
+   * Opens under the pipeline for the clicked phase. Steps are columns
+   * joined by the pipeline's own arrow connectors, so order reads left to
+   * right; refs that share a step stack inside a fork/join bracket:
+   *
+   *   [policy] ──→  ┤ [pii-scan]  ├  ──→  [redact]
+   *                 ┤ [toxicity]  ├
+   *
+   * The step number is each column's title tooltip.
+   */
+  .workflow-guardrail-flow {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin: -4px 0 16px;
+    padding: 12px 14px;
+    border-radius: var(--radius);
+    border: 1px solid color-mix(in srgb, var(--accent) 36%, var(--border));
+    background: color-mix(in srgb, var(--accent) 4%, var(--bg-surface));
+  }
+
+  .workflow-guardrail-flow-head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 6px 16px;
+  }
+
+  .workflow-guardrail-flow-title {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 10px;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--accent);
+  }
+
+  .workflow-guardrail-flow-title :global(svg) {
+    width: 12px;
+    height: 12px;
+    stroke: currentcolor;
+    fill: none;
+    stroke-width: 2;
+  }
+
+  .workflow-guardrail-flow-row {
+    display: flex;
+    align-items: center;
+    gap: 0;
+    margin: 0;
+    padding: 4px 0 2px;
+    list-style: none;
+    min-width: 0;
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+
+  .workflow-flow-conn {
+    flex: 0 0 34px;
+    margin: 0 4px;
+  }
+
+  .workflow-flow-step {
+    display: flex;
+    flex-shrink: 0;
+  }
+
+  .workflow-flow-refs {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .workflow-flow-ref {
+    padding: 6px 10px;
+    border-radius: var(--radius);
+    border: 1px solid color-mix(in srgb, var(--accent) 46%, var(--border));
+    background: color-mix(in srgb, var(--accent) 8%, var(--bg-surface));
+    color: var(--text);
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: 11px;
+    font-weight: 600;
+    white-space: nowrap;
+    max-width: 180px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  /* Editor draft step with no ref chosen yet. */
+  .workflow-flow-ref-blank {
+    border-style: dashed;
+    color: var(--text-muted);
+    font-weight: 500;
+  }
+
+  /* Fork/join bracket around a parallel stack: a vertical bar on each side
+     of the column, with a short tick from every ref to the bars. */
+  .workflow-flow-step-parallel .workflow-flow-refs {
+    position: relative;
+    padding: 0 12px;
+  }
+
+  .workflow-flow-step-parallel .workflow-flow-refs::before,
+  .workflow-flow-step-parallel .workflow-flow-refs::after {
+    content: "";
+    position: absolute;
+    top: 14px;
+    bottom: 14px;
+    width: 2px;
+    background: color-mix(in srgb, var(--accent) 44%, var(--border));
+  }
+
+  .workflow-flow-step-parallel .workflow-flow-refs::before {
+    left: 0;
+  }
+
+  .workflow-flow-step-parallel .workflow-flow-refs::after {
+    right: 0;
+  }
+
+  .workflow-flow-step-parallel .workflow-flow-ref {
+    position: relative;
+  }
+
+  .workflow-flow-step-parallel .workflow-flow-ref::before,
+  .workflow-flow-step-parallel .workflow-flow-ref::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    width: 12px;
+    height: 2px;
+    transform: translateY(-50%);
+    background: color-mix(in srgb, var(--accent) 44%, var(--border));
+  }
+
+  .workflow-flow-step-parallel .workflow-flow-ref::before {
+    right: 100%;
+  }
+
+  .workflow-flow-step-parallel .workflow-flow-ref::after {
+    left: 100%;
   }
 
   /* Status variants of the node internals. The state classes

--- a/web/dashboard/src/pages/workflows/WorkflowChart.svelte
+++ b/web/dashboard/src/pages/workflows/WorkflowChart.svelte
@@ -13,6 +13,7 @@
     Database,
     FileText,
     Maximize2,
+    Pencil,
     Shield,
     User,
     Wallet,
@@ -186,8 +187,9 @@
 
   {#if openPhase && openFlow.length > 0}
     <!-- Step flow of the expanded phase. Steps run left to right (arrows);
-         refs sharing a step stack vertically inside a fork/join bracket,
-         which is how the gateway runs them: concurrently. -->
+         the readers sharing a step stack vertically inside a fork/join
+         bracket, which is how the gateway runs them: concurrently. A step's
+         mutating instance follows its readers behind an arrow of its own. -->
     <section
       id={panelID}
       class="workflow-guardrail-flow"
@@ -205,20 +207,36 @@
           {#if index > 0}
             <li class="workflow-conn workflow-flow-conn" aria-hidden="true"></li>
           {/if}
-          <!-- The step number is the browser tooltip of the column; the
-               bracket already shows which refs run together. -->
+          <!-- The step number is the browser tooltip of the column (and
+               screen-reader text); the bracket already shows which refs run
+               together. -->
           <li
             class="workflow-flow-step"
             class:workflow-flow-step-parallel={stage.refs.length > 1}
             title={m.workflows_step_number({ number: stage.step })}
           >
-            <ul class="workflow-flow-refs">
-              {#each stage.refs as ref, refIndex (refIndex + ":" + ref)}
-                <li class="workflow-flow-ref" class:workflow-flow-ref-blank={!ref}>
-                  {ref || m.workflows_select_guardrail()}
-                </li>
-              {/each}
-            </ul>
+            <span class="workflow-sr-only">{m.workflows_step_number({ number: stage.step })}</span>
+            {#if stage.refs.length > 0}
+              <ul class="workflow-flow-refs">
+                {#each stage.refs as ref, refIndex (refIndex + ":" + ref)}
+                  <li class="workflow-flow-ref" class:workflow-flow-ref-blank={!ref}>
+                    {ref || m.workflows_select_guardrail()}
+                  </li>
+                {/each}
+              </ul>
+            {/if}
+            {#if stage.mutator}
+              {#if stage.refs.length > 0}
+                <span class="workflow-conn workflow-flow-conn workflow-flow-conn-mutator" aria-hidden="true"></span>
+              {/if}
+              <span
+                class="workflow-flow-ref workflow-flow-ref-mutator"
+                title={m.workflows_guardrail_flow_mutator()}
+              >
+                <Icon icon={Pencil} />
+                {stage.mutator}
+              </span>
+            {/if}
           </li>
         {/each}
       </ol>
@@ -633,7 +651,45 @@
 
   .workflow-flow-step {
     display: flex;
+    align-items: center;
     flex-shrink: 0;
+  }
+
+  /* Arrow from a step's readers to its mutating instance. */
+  .workflow-flow-conn-mutator {
+    flex: 0 0 22px;
+    margin: 0 3px;
+  }
+
+  /* The instance that may edit the request or response: runs after the
+     readers of its step. */
+  .workflow-flow-ref-mutator {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    border-width: 2px;
+    background: color-mix(in srgb, var(--accent) 16%, var(--bg-surface));
+  }
+
+  .workflow-flow-ref-mutator :global(svg) {
+    width: 11px;
+    height: 11px;
+    flex-shrink: 0;
+    stroke: currentcolor;
+    fill: none;
+    stroke-width: 2;
+  }
+
+  .workflow-sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+    border: 0;
   }
 
   .workflow-flow-refs {

--- a/web/dashboard/src/pages/workflows/workflowChartLogic.js
+++ b/web/dashboard/src/pages/workflows/workflowChartLogic.js
@@ -22,32 +22,54 @@ function workflowPhaseSteps(source, phase) {
   return workflowSourceGuardrails(source).filter((step) => step.phase === wanted);
 }
 
+// workflowPhaseStepCount counts the distinct step numbers of one phase: refs
+// sharing a step number are one step, as the node's "N steps" label and the
+// step flow both describe execution stages.
 function workflowPhaseStepCount(source, phase) {
-  return workflowPhaseSteps(source, phase).length;
+  return new Set(workflowPhaseSteps(source, phase).map((item) => item.step)).size;
+}
+
+// workflowMutatingRefs names the guardrail instances that may edit the
+// request or response, from GET /admin/workflows/guardrails rows.
+function workflowMutatingRefs(guardrailRefs) {
+  const names = new Set();
+  for (const entry of Array.isArray(guardrailRefs) ? guardrailRefs : []) {
+    if (!entry || typeof entry !== "object" || !entry.mutates) continue;
+    const name = String(entry.name || "").trim();
+    if (name) names.add(name);
+  }
+  return names;
 }
 
 // workflowGuardrailFlow is the execution order of one phase's guardrails:
 // steps ascending, each holding the refs that share that step number. The
-// gateway runs the refs of one step concurrently, so a step with several
-// refs is a parallel stage of the flow. Refs keep their configured order; a
-// step whose ref is not chosen yet (editor draft) stays in as "" so the flow
-// matches the node's step count.
-export function workflowGuardrailFlow(source, phase = "prompt") {
+// gateway runs a step's readers concurrently and then its mutating instance
+// (at most one per step), so a stage lists the readers in `refs` and the
+// mutator apart; without instance rows (audit view) every ref is a reader.
+// Refs keep their configured order; a step whose ref is not chosen yet
+// (editor draft) stays in as "" so the flow matches the node's step count.
+export function workflowGuardrailFlow(source, phase = "prompt", guardrailRefs = []) {
+  const mutating = workflowMutatingRefs(guardrailRefs);
   const byStep = new Map();
   for (const item of workflowPhaseSteps(source, phase)) {
     const ref = String(item.ref || "").trim();
-    if (!byStep.has(item.step)) byStep.set(item.step, []);
-    byStep.get(item.step).push(ref);
+    if (!byStep.has(item.step)) byStep.set(item.step, { step: item.step, refs: [], mutator: null });
+    const stage = byStep.get(item.step);
+    if (ref && mutating.has(ref) && !stage.mutator) {
+      stage.mutator = ref;
+    } else {
+      stage.refs.push(ref);
+    }
   }
   return Array.from(byStep.keys())
     .sort((a, b) => a - b)
-    .map((step) => ({ step, refs: byStep.get(step) }));
+    .map((step) => byStep.get(step));
 }
 
-function workflowGuardrailFlows(source, phases) {
+function workflowGuardrailFlows(source, phases, guardrailRefs) {
   const flows = {};
   for (const phase of WORKFLOW_PHASES) {
-    flows[phase] = phases[phase] ? workflowGuardrailFlow(source, phase) : [];
+    flows[phase] = phases[phase] ? workflowGuardrailFlow(source, phase, guardrailRefs) : [];
   }
   return flows;
 }
@@ -468,11 +490,15 @@ function workflowChartModel(source, runtime, options, caps) {
     streamGuardrailLabel: showStreamGuardrails ? workflowGuardrailLabel(source, "stream") : "",
     streamGuardrailBadge: showStreamGuardrails ? phaseLabel("stream") : null,
     // Per-phase step flow behind each guardrail node's click-to-expand panel.
-    guardrailFlows: workflowGuardrailFlows(source, {
-      prompt: showGuardrails,
-      response: showResponseGuardrails,
-      stream: showStreamGuardrails,
-    }),
+    guardrailFlows: workflowGuardrailFlows(
+      source,
+      {
+        prompt: showGuardrails,
+        response: showResponseGuardrails,
+        stream: showStreamGuardrails,
+      },
+      config.guardrailRefs,
+    ),
     showCache: !!config.forceCache || !!features.cache || workflowRuntimeHasCache(runtime),
     cacheNodeClass: workflowCacheNodeClass(runtime, liveStep === "cache"),
     cacheConnClass: workflowCacheConnClass(runtime),
@@ -500,8 +526,11 @@ function workflowChartModel(source, runtime, options, caps) {
   };
 }
 
-export function workflowChart(source, caps) {
-  return workflowChartModel(source, null, { forceCache: false }, caps);
+// workflowChart builds the configuration chart. `guardrailRefs` are the
+// GET /admin/workflows/guardrails rows; they tell the step flow which
+// instance of a step is its mutator.
+export function workflowChart(source, caps, guardrailRefs = []) {
+  return workflowChartModel(source, null, { forceCache: false, guardrailRefs }, caps);
 }
 
 // workflowAuditChart renders a chart for an audit-log entry. The resolved

--- a/web/dashboard/src/pages/workflows/workflowChartLogic.js
+++ b/web/dashboard/src/pages/workflows/workflowChartLogic.js
@@ -11,11 +11,45 @@ import {
   workflowScopeProviderValue,
 } from "./workflowsLogic.js";
 import * as m from "../../lib/paraglide/messages.js";
-import { normalizeWorkflowPhase, phaseLabel } from "../../lib/utils/pluginPhases.js";
+import {
+  WORKFLOW_PHASES,
+  normalizeWorkflowPhase,
+  phaseLabel,
+} from "../../lib/utils/pluginPhases.js";
+
+function workflowPhaseSteps(source, phase) {
+  const wanted = normalizeWorkflowPhase(phase);
+  return workflowSourceGuardrails(source).filter((step) => step.phase === wanted);
+}
 
 function workflowPhaseStepCount(source, phase) {
-  const wanted = normalizeWorkflowPhase(phase);
-  return workflowSourceGuardrails(source).filter((step) => step.phase === wanted).length;
+  return workflowPhaseSteps(source, phase).length;
+}
+
+// workflowGuardrailFlow is the execution order of one phase's guardrails:
+// steps ascending, each holding the refs that share that step number. The
+// gateway runs the refs of one step concurrently, so a step with several
+// refs is a parallel stage of the flow. Refs keep their configured order; a
+// step whose ref is not chosen yet (editor draft) stays in as "" so the flow
+// matches the node's step count.
+export function workflowGuardrailFlow(source, phase = "prompt") {
+  const byStep = new Map();
+  for (const item of workflowPhaseSteps(source, phase)) {
+    const ref = String(item.ref || "").trim();
+    if (!byStep.has(item.step)) byStep.set(item.step, []);
+    byStep.get(item.step).push(ref);
+  }
+  return Array.from(byStep.keys())
+    .sort((a, b) => a - b)
+    .map((step) => ({ step, refs: byStep.get(step) }));
+}
+
+function workflowGuardrailFlows(source, phases) {
+  const flows = {};
+  for (const phase of WORKFLOW_PHASES) {
+    flows[phase] = phases[phase] ? workflowGuardrailFlow(source, phase) : [];
+  }
+  return flows;
 }
 
 // workflowGuardrailLabel is the step-count sublabel of a guardrail node for
@@ -433,6 +467,12 @@ function workflowChartModel(source, runtime, options, caps) {
     showStreamGuardrails,
     streamGuardrailLabel: showStreamGuardrails ? workflowGuardrailLabel(source, "stream") : "",
     streamGuardrailBadge: showStreamGuardrails ? phaseLabel("stream") : null,
+    // Per-phase step flow behind each guardrail node's click-to-expand panel.
+    guardrailFlows: workflowGuardrailFlows(source, {
+      prompt: showGuardrails,
+      response: showResponseGuardrails,
+      stream: showStreamGuardrails,
+    }),
     showCache: !!config.forceCache || !!features.cache || workflowRuntimeHasCache(runtime),
     cacheNodeClass: workflowCacheNodeClass(runtime, liveStep === "cache"),
     cacheConnClass: workflowCacheConnClass(runtime),

--- a/web/dashboard/tests/workflows.test.js
+++ b/web/dashboard/tests/workflows.test.js
@@ -208,8 +208,8 @@ test("workflowChart returns the shared chart contract for workflow sources", () 
       streamGuardrailBadge: null,
       guardrailFlows: {
         prompt: [
-          { step: 10, refs: ["policy-system"] },
-          { step: 20, refs: ["pii"] },
+          { step: 10, refs: ["policy-system"], mutator: null },
+          { step: 20, refs: ["pii"], mutator: null },
         ],
         response: [],
         stream: [],
@@ -339,7 +339,7 @@ test("workflowAuditChart returns the shared chart contract for audit runtime ent
       streamGuardrailLabel: "",
       streamGuardrailBadge: null,
       guardrailFlows: {
-        prompt: [{ step: 10, refs: ["policy-system"] }],
+        prompt: [{ step: 10, refs: ["policy-system"], mutator: null }],
         response: [],
         stream: [],
       },
@@ -1580,11 +1580,13 @@ test("workflowGuardrailFlow orders steps ascending and groups same-step refs as 
     },
   };
   assert.deepEqual(workflowGuardrailFlow(source, "prompt"), [
-    { step: 10, refs: ["reader-a", "mutator", ""] },
-    { step: 20, refs: ["middle"] },
-    { step: 30, refs: ["late"] },
+    { step: 10, refs: ["reader-a", "mutator", ""], mutator: null },
+    { step: 20, refs: ["middle"], mutator: null },
+    { step: 30, refs: ["late"], mutator: null },
   ]);
-  assert.deepEqual(workflowGuardrailFlow(source, "response"), [{ step: 10, refs: ["scan"] }]);
+  assert.deepEqual(workflowGuardrailFlow(source, "response"), [
+    { step: 10, refs: ["scan"], mutator: null },
+  ]);
   assert.deepEqual(workflowGuardrailFlow(source, "stream"), []);
   assert.deepEqual(workflowGuardrailFlow(null), []);
 
@@ -1592,7 +1594,40 @@ test("workflowGuardrailFlow orders steps ascending and groups same-step refs as 
   // the node, so it stays in the flow as a blank placeholder.
   const draft = { features: { guardrails: true }, guardrails: [{ ref: "", phase: "stream", step: 10 }] };
   assert.equal(workflowGuardrailLabel(draft, "stream"), "1 step");
-  assert.deepEqual(workflowGuardrailFlow(draft, "stream"), [{ step: 10, refs: [""] }]);
+  assert.deepEqual(workflowGuardrailFlow(draft, "stream"), [{ step: 10, refs: [""], mutator: null }]);
+});
+
+test("workflowGuardrailFlow sets a step's mutating instance apart from its readers", () => {
+  const source = {
+    features: { guardrails: true },
+    guardrails: [
+      { ref: "pii", phase: "prompt", step: 10 },
+      { ref: "rewrite", phase: "prompt", step: 10 },
+      { ref: "toxicity", phase: "prompt", step: 10 },
+      { ref: "inject", phase: "prompt", step: 20 },
+      { ref: "scan", phase: "prompt", step: 30 },
+    ],
+  };
+  const refs = [
+    { name: "pii", mutates: false },
+    { name: "rewrite", mutates: true },
+    { name: "inject", mutates: true },
+    { name: "toxicity" },
+  ];
+  // Readers keep their order and stack in parallel; the mutator runs after
+  // them. A step with only a mutator has no readers; an unknown ref (scan)
+  // is a reader.
+  assert.deepEqual(workflowGuardrailFlow(source, "prompt", refs), [
+    { step: 10, refs: ["pii", "toxicity"], mutator: "rewrite" },
+    { step: 20, refs: [], mutator: "inject" },
+    { step: 30, refs: ["scan"], mutator: null },
+  ]);
+  // Without instance rows every ref is treated as a reader.
+  assert.deepEqual(workflowGuardrailFlow(source, "prompt"), [
+    { step: 10, refs: ["pii", "rewrite", "toxicity"], mutator: null },
+    { step: 20, refs: ["inject"], mutator: null },
+    { step: 30, refs: ["scan"], mutator: null },
+  ]);
 });
 
 test("workflowChart only carries step flows for phases that have a node", () => {
@@ -1611,10 +1646,28 @@ test("workflowChart only carries step flows for phases that have a node", () => 
     ALL_CAPS,
   );
   assert.deepEqual(chart.guardrailFlows, {
-    prompt: [{ step: 10, refs: ["pii"] }],
+    prompt: [{ step: 10, refs: ["pii"], mutator: null }],
     response: [],
-    stream: [{ step: 5, refs: ["scan", "scan2"] }],
+    stream: [{ step: 5, refs: ["scan", "scan2"], mutator: null }],
   });
+  // Refs sharing a step number are one step on the node, as in the flow.
+  assert.equal(chart.streamGuardrailLabel, "1 step");
+
+  const typed = workflowChart(
+    {
+      workflow_payload: {
+        schema_version: 2,
+        features: { guardrails: true },
+        steps: [
+          { ref: "pii", phase: "prompt", step: 10 },
+          { ref: "rewrite", phase: "prompt", step: 10 },
+        ],
+      },
+    },
+    ALL_CAPS,
+    [{ name: "rewrite", mutates: true }],
+  );
+  assert.deepEqual(typed.guardrailFlows.prompt, [{ step: 10, refs: ["pii"], mutator: "rewrite" }]);
 
   const disabled = workflowChart(
     {

--- a/web/dashboard/tests/workflows.test.js
+++ b/web/dashboard/tests/workflows.test.js
@@ -28,6 +28,7 @@ import {
   workflowChartWorkflowID,
   workflowRuntimeFromEntry,
   workflowGuardrailLabel,
+  workflowGuardrailFlow,
   workflowAsyncNodeClass,
   workflowCacheNodeClass,
   workflowCacheConnClass,
@@ -205,6 +206,14 @@ test("workflowChart returns the shared chart contract for workflow sources", () 
       showStreamGuardrails: false,
       streamGuardrailLabel: "",
       streamGuardrailBadge: null,
+      guardrailFlows: {
+        prompt: [
+          { step: 10, refs: ["policy-system"] },
+          { step: 20, refs: ["pii"] },
+        ],
+        response: [],
+        stream: [],
+      },
       showCache: true,
       cacheNodeClass: "",
       cacheConnClass: "",
@@ -329,6 +338,11 @@ test("workflowAuditChart returns the shared chart contract for audit runtime ent
       showStreamGuardrails: false,
       streamGuardrailLabel: "",
       streamGuardrailBadge: null,
+      guardrailFlows: {
+        prompt: [{ step: 10, refs: ["policy-system"] }],
+        response: [],
+        stream: [],
+      },
       showCache: true,
       cacheNodeClass: "workflow-node-success",
       cacheConnClass: "workflow-conn-hit",
@@ -1547,4 +1561,69 @@ test("workflowChart adds response and stream guardrail nodes after the model", (
   assert.equal(promptOnly.guardrailBadge, null);
   assert.equal(promptOnly.showResponseGuardrails, false);
   assert.equal(promptOnly.showStreamGuardrails, false);
+});
+
+test("workflowGuardrailFlow orders steps ascending and groups same-step refs as parallel", () => {
+  const source = {
+    workflow_payload: {
+      schema_version: 2,
+      features: { guardrails: true },
+      steps: [
+        { ref: "late", phase: "prompt", step: 30 },
+        { ref: "reader-a", phase: "prompt", step: "10" },
+        { ref: "mutator", phase: "prompt", step: 10 },
+        { ref: "  ", phase: "prompt", step: 10 },
+        { ref: "middle", phase: "prompt", step: 20 },
+        { ref: "scan", phase: "response", step: 10 },
+        { ref: "blank", phase: "prompt", step: " " },
+      ],
+    },
+  };
+  assert.deepEqual(workflowGuardrailFlow(source, "prompt"), [
+    { step: 10, refs: ["reader-a", "mutator", ""] },
+    { step: 20, refs: ["middle"] },
+    { step: 30, refs: ["late"] },
+  ]);
+  assert.deepEqual(workflowGuardrailFlow(source, "response"), [{ step: 10, refs: ["scan"] }]);
+  assert.deepEqual(workflowGuardrailFlow(source, "stream"), []);
+  assert.deepEqual(workflowGuardrailFlow(null), []);
+
+  // An editor draft step with no ref chosen yet still counts as a step on
+  // the node, so it stays in the flow as a blank placeholder.
+  const draft = { features: { guardrails: true }, guardrails: [{ ref: "", phase: "stream", step: 10 }] };
+  assert.equal(workflowGuardrailLabel(draft, "stream"), "1 step");
+  assert.deepEqual(workflowGuardrailFlow(draft, "stream"), [{ step: 10, refs: [""] }]);
+});
+
+test("workflowChart only carries step flows for phases that have a node", () => {
+  const chart = workflowChart(
+    {
+      workflow_payload: {
+        schema_version: 2,
+        features: { guardrails: true },
+        steps: [
+          { ref: "pii", phase: "prompt", step: 10 },
+          { ref: "scan", phase: "stream", step: 5 },
+          { ref: "scan2", phase: "stream", step: 5 },
+        ],
+      },
+    },
+    ALL_CAPS,
+  );
+  assert.deepEqual(chart.guardrailFlows, {
+    prompt: [{ step: 10, refs: ["pii"] }],
+    response: [],
+    stream: [{ step: 5, refs: ["scan", "scan2"] }],
+  });
+
+  const disabled = workflowChart(
+    {
+      workflow_payload: {
+        features: { guardrails: false },
+        guardrails: [{ ref: "pii", step: 10 }],
+      },
+    },
+    ALL_CAPS,
+  );
+  assert.deepEqual(disabled.guardrailFlows, { prompt: [], response: [], stream: [] });
 });


### PR DESCRIPTION
The Guardrails nodes in the workflow pipeline chart are now clickable. Clicking one opens a panel under the pipeline showing that phase's steps in execution order: steps flow left to right joined by arrows, and refs that share a step number stack inside a fork/join bracket, matching how the gateway runs same-step readers concurrently; a step's mutating instance is shown after its readers behind its own arrow, marked with a pencil. A filled triangle under the open node marks which hook the panel belongs to, and each step column's tooltip carries its step number.

User-visible impact:

- Prompt, Response, and Stream guardrail nodes toggle a per-phase step panel; one panel open at a time.
- Editor draft steps with no ref chosen yet appear as a dashed "Select a Guardrail…" placeholder so a node showing a step count is always clickable.
- New chart contract field `guardrailFlows` (per phase, steps ascending, readers grouped by step plus the step's mutator). Messages added in en, pl, de.
- The node's "N steps" label counts distinct step numbers, matching the panel.
- `GET /admin/workflows/guardrails` rows and guardrail views gain a `mutates` flag so the chart can tell readers from the mutator. The audit-log chart has no instance rows and keeps showing every ref as a reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeetmcgvZzEcPhhJaKbJr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Guardrail nodes in workflow charts are now interactive, allowing users to expand and view phase-specific steps.
  * Guardrail steps display in order with connectors, parallel references, tooltips, and placeholders where applicable.
  * Guardrail details indicate when a guardrail may modify a request or response.
* **Localization**
  * Added English, German, and Polish translations for guardrail flow titles, toggle labels, and behavior descriptions.
* **Bug Fixes**
  * Guardrail flows now update correctly when phases or guardrail settings change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

