### PR TITLE
feat(providers/kimicode): add native Responses API support

### DIFF
--- a/docs/providers/kimicode.mdx
+++ b/docs/providers/kimicode.mdx
@@ -7,8 +7,11 @@ keywords: ["Kimi Code", "Moonshot", "quota", "provider setup"]
 
 Kimi Code is an OpenAI-compatible coding assistant served at `https://api.kimi.com/coding/v1`.
 GoModel routes chat, model listing, embeddings, and passthrough requests through the shared
-OpenAI adapter. The `/v1/responses` endpoint is translated through chat completions, while
-files and batches are not supported by the upstream endpoint.
+OpenAI adapter. The `/v1/responses` endpoint is forwarded natively to the upstream Responses
+API, while files and batches are not supported by the upstream endpoint.
+
+The upstream Responses API keeps no state: requests with `store: true` are rewritten to
+`store: false`, and `previous_response_id` is dropped before the request is forwarded.
 
 ## Configure
 

--- a/internal/providers/kimicode/kimicode.go
+++ b/internal/providers/kimicode/kimicode.go
@@ -1,11 +1,14 @@
 // Package kimicode provides Kimi Code API integration for the LLM gateway.
 //
-// The "kimicode" provider routes to Kimi Code's OpenAI-compatible chat
-// completions endpoint, so all transport goes through the shared chat-centric
-// adapter and model IDs are forwarded unchanged.
+// The "kimicode" provider routes to Kimi Code's OpenAI-compatible API: chat
+// completions, model listing, embeddings, and passthrough go through the
+// shared chat-centric adapter, while the Responses API is served natively by
+// the upstream /responses endpoint.
 package kimicode
 
 import (
+	"context"
+	"io"
 	"net/http"
 
 	"github.com/enterpilot/gomodel/internal/core"
@@ -26,21 +29,24 @@ var Registration = providers.Registration{
 }
 
 // Provider implements the core.Provider interface for Kimi Code. Kimi Code is
-// OpenAI-compatible, so all transport goes through the shared chat-centric
+// OpenAI-compatible, so most transport goes through the shared chat-centric
 // adapter: chat completions, model listing, embeddings, and passthrough are
-// exposed via the embedded *openai.ChatCompatible.
+// exposed via the embedded *openai.ChatCompatible. The Responses API is
+// forwarded natively to the upstream /responses endpoint (see responses.go).
 type Provider struct {
 	*openai.ChatCompatible
+	responses *openai.CompatibleProvider
 }
 
 var _ core.Provider = (*Provider)(nil)
 
 // New creates a new Kimi Code provider.
 func New(cfg providers.ProviderConfig, opts providers.ProviderOptions) core.Provider {
-	return &Provider{openai.NewChatCompatible(cfg.APIKey, opts, openai.CompatibleProviderConfig{
-		ProviderName: "kimicode",
-		BaseURL:      providers.ResolveBaseURL(cfg.BaseURL, defaultBaseURL),
-	})}
+	baseURL := providers.ResolveBaseURL(cfg.BaseURL, defaultBaseURL)
+	return &Provider{
+		ChatCompatible: openai.NewChatCompatible(cfg.APIKey, opts, compatibleConfig(baseURL)),
+		responses:      openai.NewCompatibleProvider(cfg.APIKey, opts, compatibleConfig(baseURL)),
+	}
 }
 
 // NewWithHTTPClient creates a new Kimi Code provider with a custom HTTP client.
@@ -49,8 +55,60 @@ func New(cfg providers.ProviderConfig, opts providers.ProviderOptions) core.Prov
 // The signature is intentionally stable and matches every other chat-compatible
 // provider on main: (apiKey, baseURL, httpClient, hooks).
 func NewWithHTTPClient(apiKey string, baseURL string, httpClient *http.Client, hooks llmclient.Hooks) *Provider {
-	return &Provider{openai.NewChatCompatibleWithHTTPClient(apiKey, httpClient, hooks, openai.CompatibleProviderConfig{
+	resolved := providers.ResolveBaseURL(baseURL, defaultBaseURL)
+	return &Provider{
+		ChatCompatible: openai.NewChatCompatibleWithHTTPClient(apiKey, httpClient, hooks, compatibleConfig(resolved)),
+		responses:      openai.NewCompatibleProviderWithHTTPClient(apiKey, httpClient, hooks, compatibleConfig(resolved)),
+	}
+}
+
+// compatibleConfig is the shared OpenAI-compatible configuration for both
+// adapter instances. SetHeaders defaults to plain Bearer auth because
+// NewCompatibleProvider (unlike NewChatCompatible) applies no default.
+func compatibleConfig(baseURL string) openai.CompatibleProviderConfig {
+	return openai.CompatibleProviderConfig{
 		ProviderName: "kimicode",
-		BaseURL:      providers.ResolveBaseURL(baseURL, defaultBaseURL),
-	})}
+		BaseURL:      baseURL,
+		SetHeaders: func(req *http.Request, apiKey string) {
+			providers.SetAuthHeaders(req, apiKey, providers.AuthHeaderConfig{AuthScheme: "Bearer "})
+		},
+	}
+}
+
+// SetBaseURL overrides the upstream endpoint for both the chat-centric
+// adapter and the native Responses adapter.
+func (p *Provider) SetBaseURL(url string) {
+	p.ChatCompatible.SetBaseURL(url)
+	p.responses.SetBaseURL(url)
+}
+
+// Responses serves the Responses API natively through the upstream /responses
+// endpoint, with the state the upstream rejects adapted away first.
+func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
+	return p.responses.Responses(ctx, adaptResponsesRequest(req))
+}
+
+// StreamResponses forwards the request to the upstream /responses endpoint
+// with stream enabled, returning its Responses SSE stream.
+func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
+	return p.responses.StreamResponses(ctx, adaptResponsesRequest(req))
+}
+
+// adaptResponsesRequest removes state the Kimi Code endpoint rejects: the
+// service retains no responses, so store=true and previous_response_id both
+// fail upstream with a 400 (Postel's law — adapt instead of failing).
+func adaptResponsesRequest(req *core.ResponsesRequest) *core.ResponsesRequest {
+	if req == nil {
+		return nil
+	}
+	if (req.Store == nil || !*req.Store) && req.PreviousResponseID == "" {
+		return req
+	}
+	cp := *req
+	if cp.Store != nil && *cp.Store {
+		disabled := false
+		cp.Store = &disabled
+	}
+	cp.PreviousResponseID = ""
+	return &cp
 }

--- a/internal/providers/kimicode/kimicode.go
+++ b/internal/providers/kimicode/kimicode.go
@@ -32,7 +32,8 @@ var Registration = providers.Registration{
 // OpenAI-compatible, so most transport goes through the shared chat-centric
 // adapter: chat completions, model listing, embeddings, and passthrough are
 // exposed via the embedded *openai.ChatCompatible. The Responses API is
-// forwarded natively to the upstream /responses endpoint (see responses.go).
+// forwarded natively to the upstream /responses endpoint (adaptResponsesRequest
+// below removes the state the upstream rejects).
 type Provider struct {
 	*openai.ChatCompatible
 	responses *openai.CompatibleProvider

--- a/internal/providers/kimicode/kimicode_test.go
+++ b/internal/providers/kimicode/kimicode_test.go
@@ -1,9 +1,13 @@
 package kimicode
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/enterpilot/gomodel/internal/core"
@@ -19,6 +23,8 @@ import (
 // its name, behaviour, or availability may change without notice; if Kimi Code rotates the ID
 // these tests (and the provider's embedding round-trip) will need to be updated.
 const kimibgeM3EmbedModel = "bge_m3_embed"
+
+func boolPtr(b bool) *bool { return &b }
 
 func TestNew_ReturnsProvider(t *testing.T) {
 	provider := New(providers.ProviderConfig{APIKey: "test-api-key"}, providers.ProviderOptions{})
@@ -101,5 +107,194 @@ func TestEmbeddings_RoundTrip(t *testing.T) {
 	}
 	if gotAuth != "Bearer kimi-key" {
 		t.Errorf("authorization = %q, want %q", gotAuth, "Bearer kimi-key")
+	}
+}
+
+func TestAdaptResponsesRequest(t *testing.T) {
+	t.Run("nil passes through", func(t *testing.T) {
+		if got := adaptResponsesRequest(nil); got != nil {
+			t.Errorf("adaptResponsesRequest(nil) = %v, want nil", got)
+		}
+	})
+
+	t.Run("clean request is returned unchanged", func(t *testing.T) {
+		req := &core.ResponsesRequest{Model: "kimi-for-coding", Input: "hi"}
+		if got := adaptResponsesRequest(req); got != req {
+			t.Error("clean request should be returned by identity")
+		}
+	})
+
+	t.Run("store true is pinned to false", func(t *testing.T) {
+		req := &core.ResponsesRequest{Model: "kimi-for-coding", Input: "hi", Store: boolPtr(true)}
+		got := adaptResponsesRequest(req)
+		if got == req {
+			t.Fatal("adapted request should be a copy")
+		}
+		if got.Store == nil || *got.Store {
+			t.Errorf("Store = %v, want false", got.Store)
+		}
+		// The caller's request must not be mutated.
+		if req.Store == nil || !*req.Store {
+			t.Error("original request Store was mutated")
+		}
+	})
+
+	t.Run("previous_response_id is dropped", func(t *testing.T) {
+		req := &core.ResponsesRequest{
+			Model:              "kimi-for-coding",
+			Input:              "hi",
+			PreviousResponseID: "resp_old",
+			Store:              boolPtr(false),
+		}
+		got := adaptResponsesRequest(req)
+		if got.PreviousResponseID != "" {
+			t.Errorf("PreviousResponseID = %q, want empty", got.PreviousResponseID)
+		}
+		if got.Store == nil || *got.Store {
+			t.Errorf("explicit store=false should stay false, got %v", got.Store)
+		}
+	})
+}
+
+// responsesGoldenBody mirrors a real non-streaming /responses reply from the
+// Kimi Code upstream (recorded 2026-09-08, trimmed to the members GoModel
+// consumes). The upstream reply keeps extra members (prompt_cache_key,
+// safety_identifier, service_tier); unknown members are ignored on decode.
+const responsesGoldenBody = `{
+	"id": "resp_golden",
+	"object": "response",
+	"created_at": 1788866012,
+	"completed_at": 1788866014,
+	"status": "completed",
+	"output": [
+		{
+			"type": "reasoning",
+			"id": "rs_golden",
+			"status": "completed",
+			"summary": [{"type": "summary_text", "text": "Simple request."}]
+		},
+		{
+			"type": "message",
+			"id": "msg_golden",
+			"status": "completed",
+			"role": "assistant",
+			"content": [{"type": "output_text", "text": "OK", "annotations": []}]
+		}
+	],
+	"usage": {
+		"input_tokens": 88,
+		"input_tokens_details": {"cache_write_tokens": 0, "cached_tokens": 88},
+		"output_tokens": 53,
+		"output_tokens_details": {"reasoning_tokens": 37},
+		"total_tokens": 141
+	},
+	"store": false,
+	"model": "kimi-for-coding"
+}`
+
+func TestResponses_NativeEndpoint(t *testing.T) {
+	var gotPath, gotAuth string
+	var gotBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(responsesGoldenBody))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("kimi-key", server.URL, server.Client(), llmclient.Hooks{})
+
+	resp, err := provider.Responses(context.Background(), &core.ResponsesRequest{
+		Model:              "kimi-for-coding",
+		Input:              "Say OK",
+		Store:              boolPtr(true),
+		PreviousResponseID: "resp_old",
+	})
+	if err != nil {
+		t.Fatalf("Responses() error = %v", err)
+	}
+	if gotPath != "/responses" {
+		t.Errorf("path = %q, want /responses", gotPath)
+	}
+	if gotAuth != "Bearer kimi-key" {
+		t.Errorf("authorization = %q, want %q", gotAuth, "Bearer kimi-key")
+	}
+	// Rejected state is adapted away before the request leaves.
+	if store, ok := gotBody["store"].(bool); !ok || store {
+		t.Errorf("wire store = %v, want false", gotBody["store"])
+	}
+	if _, present := gotBody["previous_response_id"]; present {
+		t.Error("wire body still carries previous_response_id")
+	}
+	if gotBody["stream"] == true {
+		t.Error("non-streaming request must not set stream on the wire")
+	}
+
+	if resp.ID != "resp_golden" {
+		t.Errorf("resp.ID = %q, want %q", resp.ID, "resp_golden")
+	}
+	if resp.Model != "kimi-for-coding" {
+		t.Errorf("resp.Model = %q, want %q", resp.Model, "kimi-for-coding")
+	}
+	if len(resp.Output) != 2 {
+		t.Fatalf("len(resp.Output) = %d, want 2", len(resp.Output))
+	}
+	if resp.Usage == nil || resp.Usage.TotalTokens != 141 {
+		t.Errorf("resp.Usage = %+v, want total_tokens 141", resp.Usage)
+	}
+}
+
+func TestStreamResponses_NativeEndpoint(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "text/event-stream")
+		// No trailing [DONE]: providers.EnsureResponsesDone must append it.
+		_, _ = io.WriteString(w, strings.Join([]string{
+			`event: response.created`,
+			`data: {"type":"response.created","response":{"id":"resp_stream","object":"response","status":"in_progress","model":"kimi-for-coding"}}`,
+			``,
+			`event: response.completed`,
+			`data: {"type":"response.completed","response":{"id":"resp_stream","object":"response","status":"completed","model":"kimi-for-coding"}}`,
+			``,
+		}, "\n"))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("kimi-key", server.URL, server.Client(), llmclient.Hooks{})
+
+	stream, err := provider.StreamResponses(context.Background(), &core.ResponsesRequest{
+		Model: "kimi-for-coding",
+		Input: "Say OK",
+	})
+	if err != nil {
+		t.Fatalf("StreamResponses() error = %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	body, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatalf("reading stream: %v", err)
+	}
+	if gotPath != "/responses" {
+		t.Errorf("path = %q, want /responses", gotPath)
+	}
+	if streamOn, ok := gotBody["stream"].(bool); !ok || !streamOn {
+		t.Errorf("wire stream = %v, want true", gotBody["stream"])
+	}
+	if _, present := gotBody["previous_response_id"]; present {
+		t.Error("wire body still carries previous_response_id")
+	}
+	if !bytes.Contains(body, []byte("event: response.completed")) {
+		t.Error("stream missing response.completed event")
+	}
+	if !bytes.HasSuffix(bytes.TrimSpace(body), []byte("data: [DONE]")) {
+		t.Errorf("stream should end with data: [DONE], got %q", string(body))
 	}
 }

--- a/internal/providers/kimicode/kimicode_test.go
+++ b/internal/providers/kimicode/kimicode_test.go
@@ -270,8 +270,10 @@ func TestStreamResponses_NativeEndpoint(t *testing.T) {
 	provider := NewWithHTTPClient("kimi-key", server.URL, server.Client(), llmclient.Hooks{})
 
 	stream, err := provider.StreamResponses(context.Background(), &core.ResponsesRequest{
-		Model: "kimi-for-coding",
-		Input: "Say OK",
+		Model:              "kimi-for-coding",
+		Input:              "Say OK",
+		Store:              boolPtr(true),
+		PreviousResponseID: "resp_old",
 	})
 	if err != nil {
 		t.Fatalf("StreamResponses() error = %v", err)


### PR DESCRIPTION
## TL;DR

The `kimicode` provider translated Responses API requests through chat completions, losing reasoning and usage shape. Kimi Code now serves the OpenAI Responses API natively at `/responses`. This PR forwards `/v1/responses` natively instead.

**Files to review (3, +270 / -14):**

| File | Why |
|---|---|
| `internal/providers/kimicode/kimicode.go` *(start here)* | Native `Responses`/`StreamResponses` overrides plus request adaptation. |
| `internal/providers/kimicode/kimicode_test.go` | Unit tests: adaptation rules and native round-trips. |
| `docs/providers/kimicode.mdx` | Documents the native Responses path and its caveats. |

## Research

- Official Kimi Code docs list Codex as a supported third-party tool; Codex uses the OpenAI Responses API: https://www.kimi.com/code/docs/en/third-party-tools/codex
- Kimi platform docs list OpenAI Responses (`/responses`) as a supported protocol: https://platform.kimi.ai/docs/api/overview
- Live upstream probe (2026-09-08): non-streaming returns a complete `response` object with reasoning and usage; streaming returns standard Responses SSE events; `store: true` returns 400; `previous_response_id` returns 400.
- A `https://api.kimi.ai/coding/v1` mirror answers with identical data. It is undocumented, and the official docs still list `api.kimi.com/coding/v1`. The base URL stays unchanged.

## Reviewer notes

- **State is adapted, not rejected.** The upstream retains no responses, so `store: true` is rewritten to `false` and `previous_response_id` is dropped before forwarding (Postel's law). Both would otherwise fail upstream with a 400.
- **Two adapter instances.** The provider embeds `openai.ChatCompatible` for chat, models, embeddings, and passthrough, and holds an `openai.CompatibleProvider` for the native Responses transport. `SetBaseURL` updates both.
- **Bearer headers are set explicitly.** `NewCompatibleProvider` applies no `SetHeaders` default, unlike `NewChatCompatible`.

## Tests

- `go build ./...` and `go test ./...` are green (run after `make frontend` for the dashboard-asset tests).
- New tests cover: request adaptation (store pin, `previous_response_id` drop, no caller mutation), a non-streaming native round-trip against a recorded upstream shape, and streaming passthrough including the `[DONE]` marker appended by `providers.EnsureResponsesDone`.

## Links

- Context issue: https://github.com/weselben/GoModel/issues/90

---
_This PR description was generated with [AI assistance](https://raw.githubusercontent.com/tdhopper/dotfiles2.0/master/.claude/skills/creating-pull-requests/SKILL.md)._
