### PR TITLE
feat(helm): rewrite the chart around env-based configuration

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -38,6 +38,7 @@ jobs:
 
       - name: Validate rendered manifests
         run: |
+          set -o pipefail
           for values in helm/ci/*-values.yaml; do
             echo "== $values"
             helm template gomodel helm -f "$values" --namespace gomodel \

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,0 +1,103 @@
+name: Helm chart
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "helm/**"
+      - ".github/workflows/helm.yml"
+  pull_request:
+    paths:
+      - "helm/**"
+      - ".github/workflows/helm.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint and validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+
+      - name: Install kubeconform
+        run: |
+          curl -fsSL https://github.com/yannh/kubeconform/releases/download/v0.7.0/kubeconform-linux-amd64.tar.gz \
+            | sudo tar -xz -C /usr/local/bin kubeconform
+
+      - name: Lint
+        run: |
+          helm lint --strict helm
+          for values in helm/ci/*-values.yaml; do
+            helm lint --strict helm -f "$values"
+          done
+
+      - name: Validate rendered manifests
+        run: |
+          for values in helm/ci/*-values.yaml; do
+            echo "== $values"
+            helm template gomodel helm -f "$values" --namespace gomodel \
+              | kubeconform -strict -summary -kubernetes-version 1.31.0 \
+                  -schema-location default \
+                  -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+          done
+
+      - name: Reject invalid value combinations
+        run: |
+          ! helm template gomodel helm --set replicaCount=2 >/dev/null 2>&1
+          ! helm template gomodel helm --set storage.type=postgresql >/dev/null 2>&1
+          ! helm template gomodel helm --set httpRoute.enabled=true >/dev/null 2>&1
+          ! helm template gomodel helm --set auth.masterKey=legacy >/dev/null 2>&1
+          ! helm template gomodel helm --set env.PORT=9000 >/dev/null 2>&1
+          helm template gomodel helm --set storage.type=postgresql \
+            --set 'extraEnv[0].name=POSTGRES_URL' --set 'extraEnv[0].value=postgres://x' >/dev/null
+          test "$(helm template gomodel helm --set 'env.BASE_PATH=//g//api/../secure//' -s templates/deployment.yaml | grep -c 'path: /g/secure/health')" = 2
+          helm template gomodel helm --set replicaCount=2 --set storage.type=postgresql --set storage.url=postgres://x \
+            --set podDisruptionBudget.maxUnavailable=0 -s templates/pdb.yaml | grep -q 'maxUnavailable: 0'
+
+  install:
+    name: Install on kind
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+
+      - name: Create kind cluster
+        uses: helm/kind-action@06c1ae10762d3b9c1644e7fe69596ae519e015a2 # v1.15.0
+
+      - name: Install with SQLite on a PVC
+        run: |
+          helm install gomodel helm -n gomodel --create-namespace \
+            -f helm/ci/default-values.yaml --wait --timeout 3m
+          helm test gomodel -n gomodel
+          kubectl -n gomodel logs deploy/gomodel | grep -q '"storage configured","type":"sqlite"'
+          ! kubectl -n gomodel logs deploy/gomodel | grep -q "not a volume"
+
+      - name: Upgrade with config.yaml
+        run: |
+          helm upgrade gomodel helm -n gomodel -f helm/ci/default-values.yaml \
+            --set-string 'config=server: {enable_passthrough_routes: false}' --wait --timeout 3m
+          kubectl -n gomodel logs deploy/gomodel | grep -q '"config file loaded"'
+
+      - name: Install two replicas on PostgreSQL
+        run: |
+          kubectl -n gomodel apply -f helm/ci/postgresql.yaml
+          kubectl -n gomodel rollout status deploy/postgresql --timeout=2m
+          helm install gm-pg helm -n gomodel -f helm/ci/postgresql-values.yaml \
+            --set autoscaling.enabled=false --wait --timeout 3m
+          helm test gm-pg -n gomodel
+          kubectl -n gomodel get pdb gm-pg-gomodel
+
+      - name: Show state on failure
+        if: failure()
+        run: |
+          kubectl -n gomodel get all,pvc
+          kubectl -n gomodel describe pod
+          kubectl -n gomodel logs deploy/gomodel --all-containers --tail=100 || true

--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,11 @@ lint:
 helm-lint:
 	helm lint --strict helm
 	for values in helm/ci/*-values.yaml; do helm lint --strict helm -f "$$values"; done
-	for values in helm/ci/*-values.yaml; do helm template gomodel helm -f "$$values" --namespace gomodel | kubeconform -strict -summary -schema-location default -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'; done
+	rendered=$$(mktemp); trap 'rm -f "$$rendered"' EXIT; \
+	for values in helm/ci/*-values.yaml; do \
+		helm template gomodel helm -f "$$values" --namespace gomodel > "$$rendered" || exit 1; \
+		kubeconform -strict -summary -schema-location default -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' < "$$rendered" || exit 1; \
+	done
 
 # Run linter with auto-fix. Mirrors `lint`: same tags, same packages, so the
 # autofix pass cannot silently skip the tag-gated files under tests/.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build run demo clean tidy mod-check frontend frontend-check test test-race test-dashboard test-e2e test-integration test-contract test-all lint lint-fix fix fix-check record-api swagger docs-openapi install-tools perf-check perf-bench infra image seed-demo-data build-plugins image-plugins example-plugins
+.PHONY: all build run demo clean tidy mod-check frontend frontend-check test test-race test-dashboard test-e2e test-integration test-contract test-all lint lint-fix fix fix-check record-api swagger docs-openapi helm-lint install-tools perf-check perf-bench infra image seed-demo-data build-plugins image-plugins example-plugins
 
 all: frontend build
 
@@ -184,6 +184,13 @@ docs-openapi:
 # Run linter
 lint:
 	$(GOLANGCI_LINT) run --build-tags=$(BUILD_TAGS) ./cmd/... ./config/... ./ext/... ./internal/... ./run/... ./tests/...
+
+# Lint the Helm chart with every CI values profile and validate the rendered
+# manifests against the Kubernetes schemas (requires helm and kubeconform).
+helm-lint:
+	helm lint --strict helm
+	for values in helm/ci/*-values.yaml; do helm lint --strict helm -f "$$values"; done
+	for values in helm/ci/*-values.yaml; do helm template gomodel helm -f "$$values" --namespace gomodel | kubeconform -strict -summary -schema-location default -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'; done
 
 # Run linter with auto-fix. Mirrors `lint`: same tags, same packages, so the
 # autofix pass cannot silently skip the tag-gated files under tests/.

--- a/docs/guides/production.mdx
+++ b/docs/guides/production.mdx
@@ -302,9 +302,11 @@ itself, which works in a distroless image with no shell or `curl`.
 | Liveness | `GET /health` | `gomodel --health` | Nothing. Confirms the listener answers. |
 | Readiness | `GET /health/ready` | `gomodel --ready` | Storage (503 if down), Redis (degraded, still 200). |
 
-Point Kubernetes readiness at `/health/ready`, not `/health`. A Helm chart is
-included in the repository under `helm/`; check its probe paths and its
-`replicaCount` against the storage backend you chose before using it as-is.
+Point Kubernetes readiness at `/health/ready`, not `/health`. The Helm chart in
+the repository's `helm/` directory does this already, runs the gateway as the
+image's non-root user on a read-only filesystem, keeps SQLite on a persistent
+volume, and refuses more than one replica until you switch `storage.type` to
+`postgresql` or `mongodb`. See `helm/README.md` for the values.
 
 <Note>
   Readiness does not wait for the model catalog, which loads asynchronously. A

--- a/helm/.helmignore
+++ b/helm/.helmignore
@@ -1,0 +1,8 @@
+.DS_Store
+.git/
+.gitignore
+*.swp
+*.bak
+*.tmp
+*.orig
+ci/

--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: redis
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 24.1.0
-digest: sha256:46e96c6627f431805f1ded87a1d15a25c3aaf648a1242343f52b8c6a51e2cb2f
-generated: "2026-01-08T06:38:01.742616425+01:00"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,9 +1,10 @@
 apiVersion: v2
 name: gomodel
-description: High-performance AI gateway for multiple LLM providers (OpenAI, Anthropic, Cohere, Gemini, DeepSeek, Groq, Kilo AI, Z.ai, xAI)
+description: GoModel is a lightweight AI gateway that routes OpenAI-compatible requests to many LLM providers.
 type: application
-version: 0.1.0
-appVersion: "1.0.0"
+version: 0.2.0
+appVersion: "0.1.89"
+kubeVersion: ">=1.25.0-0"
 
 keywords:
   - llm
@@ -11,21 +12,13 @@ keywords:
   - gateway
   - openai
   - anthropic
-  - cohere
-  - gemini
-  - groq
-  - xai
   - proxy
 
-home: https://github.com/ENTERPILOT/GoModel
+home: https://gomodel.enterpilot.io
+icon: https://raw.githubusercontent.com/ENTERPILOT/GoModel/main/docs/logo.svg
 sources:
   - https://github.com/ENTERPILOT/GoModel
 
 maintainers:
-  - name: GoModel Team
-
-dependencies:
-  - name: redis
-    version: "^24.0.0"
-    repository: oci://registry-1.docker.io/bitnamicharts
-    condition: redis.enabled
+  - name: ENTERPILOT
+    url: https://github.com/ENTERPILOT

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,182 +1,101 @@
-# GoModel Helm Chart
+# GoModel Helm chart
 
-High-performance AI gateway for multiple LLM providers (OpenAI, Anthropic, Cohere, Gemini, DeepSeek, Groq, Kilo AI, Z.ai, xAI, Oracle, SGLang, vLLM).
+Deploys [GoModel](https://gomodel.enterpilot.io), an OpenAI-compatible AI gateway, on Kubernetes.
 
-## Prerequisites
-
-- Kubernetes 1.29+ (for Gateway API v1 support)
-- Helm 3.x
-- (Optional) Prometheus Operator for ServiceMonitor support
-
-## Installation
-
-### Add the Helm repository (if published)
+## Quick start
 
 ```bash
-helm repo add gomodel https://your-org.github.io/gomodel
-helm repo update
+helm install gomodel ./helm -n gomodel --create-namespace \
+  --set secretEnv.GOMODEL_MASTER_KEY=change-me \
+  --set secretEnv.OPENAI_API_KEY=sk-...
+
+kubectl -n gomodel port-forward svc/gomodel 8080:8080
+curl -H "Authorization: Bearer change-me" http://127.0.0.1:8080/v1/models
 ```
 
-### Install from local chart
-
-```bash
-# Basic install with OpenAI (provider auto-enables when apiKey is set)
-helm install gomodel ./helm \
-  -n gomodel --create-namespace \
-  --set providers.openai.apiKey="sk-..."
-
-# Multi-provider setup with Redis cache
-helm install gomodel ./helm \
-  -n gomodel --create-namespace \
-  --set providers.openai.apiKey="sk-..." \
-  --set providers.anthropic.apiKey="sk-ant-..." \
-  --set redis.enabled=true
-
-# Using existing secrets (GitOps-friendly)
-helm install gomodel ./helm \
-  -n gomodel --create-namespace \
-  --set providers.existingSecret="llm-api-keys" \
-  --set providers.openai.enabled=true \
-  --set providers.anthropic.enabled=true
-```
+The default install runs one pod with SQLite on a 1Gi PersistentVolumeClaim,
+Prometheus metrics on `/metrics`, a read-only root filesystem, and the image's
+non-root user (UID 65532).
 
 ## Configuration
 
-### Key Values
+GoModel is configured entirely through environment variables. Any variable from
+[`.env.template`](../.env.template) goes in one of two maps:
 
-| Parameter                        | Description                                                                                    | Default                |
-| -------------------------------- | ---------------------------------------------------------------------------------------------- | ---------------------- |
-| `replicaCount`                   | Number of replicas                                                                             | `2`                    |
-| `image.repository`               | Image repository                                                                               | `enterpilot/gomodel`   |
-| `image.tag`                      | Image tag                                                                                      | `""` (uses appVersion) |
-| `server.port`                    | Server port                                                                                    | `8080`                 |
-| `server.basePath`                | URL path prefix where GoModel is mounted                                                       | `"/"`                  |
-| `server.userPathHeader`          | Header used to read/write request user_path values                                             | `"X-GoModel-User-Path"` |
-| `server.bodySizeLimit`           | Max request body size                                                                          | `"10M"`                |
-| `auth.masterKey`                 | Master key for auth                                                                            | `""`                   |
-| `auth.existingSecret`            | Existing secret for auth                                                                       | `""`                   |
-| `providers.existingSecret`       | Existing secret for API keys                                                                   | `""`                   |
-| `providers.openai.enabled`       | Enable OpenAI                                                                                  | `false`                |
-| `providers.anthropic.enabled`    | Enable Anthropic                                                                               | `false`                |
-| `providers.cohere.enabled`       | Enable Cohere                                                                                  | `false`                |
-| `providers.cohere.baseUrl`       | Optional Cohere base URL mapped to `COHERE_BASE_URL`                                           | `""`                   |
-| `providers.gemini.enabled`       | Enable Gemini                                                                                  | `false`                |
-| `providers.gemini.useNativeApi`  | Use Gemini native generateContent for chat/responses; set false for Gemini OpenAI compatibility | `true`                 |
-| `providers.groq.enabled`         | Enable Groq                                                                                    | `false`                |
-| `providers.xai.enabled`          | Enable xAI                                                                                     | `false`                |
-| `providers.zai.enabled`          | Enable Z.ai                                                                                    | `false`                |
-| `providers.zai.baseUrl`          | Optional Z.ai base URL mapped to `ZAI_BASE_URL`; use Coding Plan endpoint when needed          | `""`                   |
-| `providers.kilo.enabled`         | Enable Kilo AI                                                                                  | `false`                |
-| `providers.kilo.baseUrl`         | Optional Kilo AI Gateway base URL mapped to `KILO_BASE_URL`                                    | `""`                   |
-| `providers.oracle.enabled`       | Enable Oracle                                                                                  | `false`                |
-| `providers.oracle.baseUrl`       | Oracle OpenAI-compatible base URL mapped to `ORACLE_BASE_URL`; required when Oracle is enabled | `""`                   |
-| `providers.vllm.enabled`         | Enable vLLM                                                                                    | `false`                |
-| `providers.vllm.baseUrl`         | vLLM OpenAI-compatible base URL mapped to `VLLM_BASE_URL`; required when vLLM is enabled       | `""`                   |
-| `providers.sglang.enabled`       | Enable SGLang                                                                                  | `false`                |
-| `providers.sglang.baseUrl`       | SGLang OpenAI-compatible base URL mapped to `SGLANG_BASE_URL`; required when enabled           | `""`                   |
-| `providers.llmd.enabled`         | Enable llm-d                                                                                   | `false`                |
-| `providers.llmd.baseUrl`         | llm-d Router/EPP base URL mapped to `LLMD_BASE_URL`; required when llm-d is enabled            | `""`                   |
-| `providers.llmd.inferenceObjective` | Trusted llm-d objective mapped to `LLMD_INFERENCE_OBJECTIVE`                                | `""`                   |
-| `providers.llmd.fairnessFromUserPath` | Derive llm-d fairness ID from GoModel's effective user path                               | `true`                 |
-| `cache.type`                     | Cache type (local/redis)                                                                       | `"redis"`              |
-| `redis.enabled`                  | Deploy Redis subchart                                                                          | `true`                 |
-| `metrics.enabled`                | Enable Prometheus metrics                                                                      | `true`                 |
-| `metrics.serviceMonitor.enabled` | Create ServiceMonitor                                                                          | `false`                |
-| `logging.format`                 | Log format; empty auto-detects, or set `json`/`text`                                           | `""`                   |
-| `ingress.enabled`                | Enable Ingress                                                                                 | `false`                |
-| `gateway.enabled`                | Enable Gateway API HTTPRoute                                                                   | `false`                |
-| `autoscaling.enabled`            | Enable HPA                                                                                     | `false`                |
+| Value       | Stored in | Use for                                            |
+| ----------- | --------- | -------------------------------------------------- |
+| `env`       | ConfigMap | Plain settings: `LOG_LEVEL`, `REDIS_URL`, `BASE_PATH`, … |
+| `secretEnv` | Secret    | `GOMODEL_MASTER_KEY`, provider API keys, database URLs |
 
-### Using Existing Secrets
-
-Create a secret with your API keys:
+Changing either rolls the pods. To keep secrets out of Helm values, create the
+Secret yourself and reference it:
 
 ```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: llm-api-keys
-type: Opaque
-stringData:
-  OPENAI_API_KEY: "sk-..."
-  ANTHROPIC_API_KEY: "sk-ant-..."
-  COHERE_API_KEY: "..."
-  GEMINI_API_KEY: "..."
-  ZAI_API_KEY: "..."
-  KILO_API_KEY: "..."
-  ORACLE_API_KEY: "..."
-  SGLANG_API_KEY: "..."
-  VLLM_API_KEY: "..."
-  LLMD_API_KEY: "..."
+extraEnvFrom:
+  - secretRef:
+      name: gomodel-keys   # keys: GOMODEL_MASTER_KEY, OPENAI_API_KEY, ...
 ```
 
-Oracle also requires a base URL in values. The chart maps `providers.oracle.baseUrl`
-to the container env var `ORACLE_BASE_URL`.
+Set `GOMODEL_MASTER_KEY`. Without it the gateway accepts unauthenticated requests
+and the install notes print a warning.
 
-vLLM does not require an API key unless the upstream server was started with
-`--api-key`. The chart maps `providers.vllm.baseUrl` to the container env var
-`VLLM_BASE_URL`.
+### config.yaml
 
-llm-d also allows keyless access when its Gateway does not require bearer
-authentication. The chart maps `providers.llmd.baseUrl` to `LLMD_BASE_URL` and
-the optional scheduling controls to their `LLMD_*` environment variables. When
-using `providers.existingSecret`, its `LLMD_API_KEY` entry may be omitted for a
-keyless llm-d route.
+Use `config` for settings that env vars cannot express (per-provider resilience,
+custom provider names, model allowlists). It is mounted at
+`/app/config/config.yaml`; env vars still override it.
 
-SGLang does not require an API key unless the upstream server was started with
-`--api-key`. The chart maps `providers.sglang.baseUrl` to the container env var
-`SGLANG_BASE_URL`.
-
-Then reference it (use `enabled=true` when using existingSecret since apiKey isn't set directly):
-
-```bash
-helm install gomodel ./helm \
-  --set providers.existingSecret="llm-api-keys" \
-  --set providers.openai.enabled=true
+```yaml
+config: |
+  providers:
+    openai-eu:
+      type: openai
+      api_key: ${OPENAI_EU_API_KEY}
+      base_url: https://eu.api.openai.com/v1
 ```
 
-Example Oracle setup with an existing secret:
+Or point `existingConfigMap` at a ConfigMap that has a `config.yaml` key.
 
-```bash
-helm install gomodel ./helm \
-  --set providers.existingSecret="llm-api-keys" \
-  --set providers.oracle.enabled=true \
-  --set providers.oracle.baseUrl="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com/20231130/actions/v1"
+### Storage and replicas
+
+| `storage.type` | Replicas | Data location                                  |
+| -------------- | -------- | ---------------------------------------------- |
+| `sqlite`       | 1        | PVC at `/app/data` (`persistence.enabled: true`) |
+| `postgresql`   | any      | `storage.url` or `POSTGRES_URL`                |
+| `mongodb`      | any      | `storage.url` or `MONGODB_URL`                 |
+
+SQLite is per pod, so the chart refuses `replicaCount > 1` or autoscaling until
+you switch to PostgreSQL or MongoDB:
+
+```yaml
+replicaCount: 3
+storage:
+  type: postgresql
+  url: postgres://gomodel:secret@postgresql:5432/gomodel
 ```
 
-Example keyless vLLM setup:
+`storage.url` lands in the chart Secret. If the URL already lives in a Secret of
+your own, load it through `extraEnvFrom` or an `extraEnv` entry named
+`POSTGRES_URL` / `MONGODB_URL` instead and leave `storage.url` empty.
 
-```bash
-helm install gomodel ./helm \
-  --set providers.vllm.enabled=true \
-  --set providers.vllm.baseUrl="http://vllm.default.svc.cluster.local:8000/v1"
-```
+`helm uninstall` deletes the claim with the release. To keep the database, add
+`persistence.annotations: {helm.sh/resource-policy: keep}`.
 
-Example keyless llm-d setup:
+With SQLite on a ReadWriteOnce volume the Deployment uses the `Recreate`
+strategy, so upgrades briefly stop the gateway. Set `persistence.enabled: false`
+for a throwaway install; the data then lives on an emptyDir and is lost when the
+pod is replaced.
 
-```bash
-helm install gomodel ./helm \
-  --set providers.llmd.enabled=true \
-  --set providers.llmd.baseUrl="http://quickstart-epp.llm-d.svc.cluster.local/v1" \
-  --set providers.llmd.inferenceObjective="standard-traffic"
-```
+### Exposing the gateway
 
-Example keyless SGLang setup:
-
-```bash
-helm install gomodel ./helm \
-  --set providers.sglang.enabled=true \
-  --set providers.sglang.baseUrl="http://sglang.default.svc.cluster.local:30000/v1"
-```
-
-### Ingress Example
+Ingress:
 
 ```yaml
 ingress:
   enabled: true
   className: nginx
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt
   hosts:
     - host: gomodel.example.com
       paths:
@@ -184,36 +103,105 @@ ingress:
           pathType: Prefix
   tls:
     - secretName: gomodel-tls
-      hosts:
-        - gomodel.example.com
+      hosts: [gomodel.example.com]
 ```
 
-### Gateway API Example
+Gateway API:
 
 ```yaml
-gateway:
+httpRoute:
   enabled: true
-  parentRef:
-    name: my-gateway
-    namespace: gateway-system
-  hostnames:
-    - gomodel.example.com
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames: [gomodel.example.com]
 ```
 
-## Upgrading
+To serve under a path prefix set `env.BASE_PATH: /g`; probe, metrics and
+HTTPRoute paths follow automatically.
+
+### Metrics
+
+`metrics.enabled` (default `true`) exposes `/metrics` without authentication.
+With the Prometheus Operator, set `metrics.serviceMonitor.enabled: true` and add
+the labels your Prometheus selects on under `metrics.serviceMonitor.labels`.
+
+### Cloud provider credentials
+
+Give the pod's ServiceAccount a cloud identity for AWS Bedrock or Google Vertex AI:
+
+```yaml
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/gomodel
+```
+
+## Values
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `replicaCount` | `1` | Pods. More than one needs `storage.type` postgresql or mongodb. |
+| `image.repository` | `enterpilot/gomodel` | |
+| `image.tag` | `""` | Defaults to the chart `appVersion`. |
+| `env` | `{}` | Plain environment variables. |
+| `secretEnv` | `{}` | Secret environment variables. |
+| `extraEnvFrom` | `[]` | Existing Secrets/ConfigMaps loaded as env vars. |
+| `extraEnv` | `[]` | Raw container env entries (`valueFrom`). |
+| `config` | `""` | Inline `config.yaml`. |
+| `existingConfigMap` | `""` | ConfigMap with a `config.yaml` key. |
+| `storage.type` | `sqlite` | `sqlite`, `postgresql`, or `mongodb`. |
+| `storage.url` | `""` | Connection URL for postgresql/mongodb. |
+| `persistence.enabled` | `true` | PVC for SQLite data. |
+| `persistence.size` | `1Gi` | |
+| `persistence.storageClass` | `""` | Cluster default. `-` disables dynamic provisioning. |
+| `persistence.existingClaim` | `""` | Reuse a PVC. |
+| `updateStrategy` | `{}` | Overrides the automatic Recreate/RollingUpdate choice. |
+| `metrics.enabled` | `true` | Expose `/metrics`. |
+| `metrics.serviceMonitor.enabled` | `false` | Prometheus Operator ServiceMonitor. |
+| `service.type` | `ClusterIP` | |
+| `service.port` | `8080` | |
+| `ingress.enabled` | `false` | |
+| `httpRoute.enabled` | `false` | Gateway API HTTPRoute; needs `httpRoute.parentRefs`. |
+| `serviceAccount.create` | `true` | |
+| `serviceAccount.annotations` | `{}` | Cloud IAM bindings. |
+| `resources` | `100m/128Mi` requests, `512Mi` limit | No CPU limit by default. |
+| `autoscaling.enabled` | `false` | HPA on CPU (70%) and optionally memory. |
+| `podDisruptionBudget.enabled` | `true` | Created only when more than one pod can run. |
+| `terminationGracePeriodSeconds` | `45` | Covers GoModel's 30s drain. |
+| `livenessProbe` / `readinessProbe` | `/health`, `/health/ready` | Readiness fails while storage is down. |
+| `podSecurityContext` / `securityContext` | non-root 65532, read-only FS | |
+| `extraVolumes` / `extraVolumeMounts` | `[]` | CA bundles, local model catalogs, … |
+| `nodeSelector`, `tolerations`, `affinity`, `topologySpreadConstraints`, `priorityClassName`, `podAnnotations`, `podLabels` | | Standard scheduling knobs. |
+
+## Upgrading from chart 0.1.x
+
+Chart 0.2.0 replaced the per-provider values and the Redis subchart with the
+generic `env` / `secretEnv` maps:
+
+| 0.1.x | 0.2.0 |
+| --- | --- |
+| `auth.masterKey` | `secretEnv.GOMODEL_MASTER_KEY` |
+| `providers.openai.apiKey` | `secretEnv.OPENAI_API_KEY` (same pattern for every provider) |
+| `providers.openai.baseUrl` | `env.OPENAI_BASE_URL` |
+| `providers.existingSecret` | `extraEnvFrom: [{secretRef: {name: ...}}]` |
+| `redis.enabled` / `cache.redis.url` | `env.REDIS_URL` pointing at your own Redis |
+| `gateway.*` | `httpRoute.*` |
+| `server.basePath` | `env.BASE_PATH` |
+
+The chart refuses to render while any of the old top-level keys (`auth`,
+`providers`, `redis`, `cache`, `gateway`, `server`, `logging`) are still present,
+so an upgrade cannot silently drop the master key. The default `replicaCount`
+dropped from 2 to 1 because SQLite is per pod, the pod now runs as the image's
+UID 65532, and `/app/data` is on a PVC.
+
+## Testing the chart
 
 ```bash
-helm upgrade gomodel ./helm -n gomodel -f values.yaml
+helm lint --strict ./helm -f helm/ci/default-values.yaml
+helm template gomodel ./helm -f helm/ci/full-values.yaml | kubeconform -strict
+helm install gomodel ./helm -n gomodel --create-namespace -f helm/ci/default-values.yaml --wait
+helm test gomodel -n gomodel
 ```
 
-## Uninstalling
-
-```bash
-helm uninstall gomodel -n gomodel
-```
-
-# Todo
-
-- Add a values-demo.yaml file with a demo setup ready to run
-- Consider adding prometheus + grafana stack as an optional subchart
-- Add an example for production-ready redis configuration with persistence and authentication enabled
+The `ci/*-values.yaml` profiles are what the CI workflow lints, validates,
+and installs on a kind cluster.

--- a/helm/ci/default-values.yaml
+++ b/helm/ci/default-values.yaml
@@ -1,0 +1,4 @@
+# Lint/install profile: the defaults plus a master key and a provider key.
+secretEnv:
+  GOMODEL_MASTER_KEY: ci-master-key
+  OPENAI_API_KEY: sk-ci-placeholder

--- a/helm/ci/full-values.yaml
+++ b/helm/ci/full-values.yaml
@@ -1,0 +1,69 @@
+# Every optional resource enabled, for template and schema validation.
+env:
+  BASE_PATH: /g
+  METRICS_ENDPOINT: /internal/metrics
+  LOG_FORMAT: json
+extraEnvFrom:
+  - secretRef:
+      name: gomodel-keys
+extraEnv:
+  - name: POD_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+config: |
+  server:
+    enable_passthrough_routes: false
+storage:
+  type: mongodb
+  url: mongodb://mongodb:27017/gomodel
+persistence:
+  enabled: false
+metrics:
+  serviceMonitor:
+    enabled: true
+    labels:
+      release: kube-prometheus-stack
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+  hosts:
+    - host: gomodel.example.com
+      paths:
+        - path: /g
+          pathType: Prefix
+  tls:
+    - secretName: gomodel-tls
+      hosts:
+        - gomodel.example.com
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - gomodel.example.com
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/gomodel
+priorityClassName: system-cluster-critical
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: gomodel
+extraVolumes:
+  - name: models
+    configMap:
+      name: gomodel-models
+extraVolumeMounts:
+  - name: models
+    mountPath: /etc/gomodel
+    readOnly: true
+replicaCount: 3
+podDisruptionBudget:
+  maxUnavailable: 1

--- a/helm/ci/postgresql-values.yaml
+++ b/helm/ci/postgresql-values.yaml
@@ -1,0 +1,15 @@
+# Several replicas on a shared PostgreSQL database.
+replicaCount: 2
+storage:
+  type: postgresql
+  url: postgres://gomodel:gomodel@postgresql:5432/gomodel?sslmode=disable
+secretEnv:
+  GOMODEL_MASTER_KEY: ci-master-key
+  OPENAI_API_KEY: sk-ci-placeholder
+env:
+  LOG_LEVEL: debug
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 4
+  targetMemoryUtilizationPercentage: 80

--- a/helm/ci/postgresql.yaml
+++ b/helm/ci/postgresql.yaml
@@ -1,0 +1,43 @@
+# Throwaway PostgreSQL for the chart's CI install test. Not for production.
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: postgresql
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: postgresql
+      template:
+        metadata:
+          labels:
+            app: postgresql
+        spec:
+          containers:
+            - name: postgresql
+              image: postgres:18-alpine
+              env:
+                - name: POSTGRES_USER
+                  value: gomodel
+                - name: POSTGRES_PASSWORD
+                  value: gomodel
+                - name: POSTGRES_DB
+                  value: gomodel
+              ports:
+                - containerPort: 5432
+              readinessProbe:
+                exec:
+                  command: [pg_isready, -U, gomodel]
+                periodSeconds: 2
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: postgresql
+    spec:
+      selector:
+        app: postgresql
+      ports:
+        - port: 5432

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,60 +1,31 @@
-Thank you for installing {{ .Chart.Name }}!
+GoModel {{ .Values.image.tag | default .Chart.AppVersion }} is installed as release {{ .Release.Name }}.
 
-Your release is named: {{ .Release.Name }}
-
-To get the application URL:
+Reach the gateway:
 {{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ (first $host.paths).path }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}{{ (first .paths).path }}
 {{- end }}
-{{- else if .Values.gateway.enabled }}
-  Configure your Gateway to route traffic to the service.
-  Service: {{ include "gomodel.fullname" . }}:{{ .Values.service.port }}
-{{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "gomodel.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
-  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-  You can watch the status with: kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "gomodel.fullname" . }}
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "gomodel.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
-{{- else if contains "ClusterIP" .Values.service.type }}
-  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "gomodel.fullname" . }} 8080:{{ .Values.service.port }}
-  echo "Visit http://127.0.0.1:8080 to use the API"
+{{- else if .Values.httpRoute.enabled }}
+{{- range .Values.httpRoute.hostnames }}
+  http://{{ . }}{{ include "gomodel.pathWithBasePath" (dict "root" $ "path" "/") }}
 {{- end }}
-
-{{- if not .Values.auth.masterKey }}
-{{- if not .Values.auth.existingSecret }}
-
-⚠️  WARNING: No authentication configured!
-    The gateway is running in UNSAFE MODE without authentication.
-    Set auth.masterKey or auth.existingSecret for production use.
-{{- end }}
-{{- end }}
-
-{{- $enabledProviders := list }}
-{{- if or .Values.providers.openai.enabled .Values.providers.openai.apiKey }}{{ $enabledProviders = append $enabledProviders "openai" }}{{ end }}
-{{- if or .Values.providers.anthropic.enabled .Values.providers.anthropic.apiKey }}{{ $enabledProviders = append $enabledProviders "anthropic" }}{{ end }}
-{{- if or .Values.providers.cohere.enabled .Values.providers.cohere.apiKey }}{{ $enabledProviders = append $enabledProviders "cohere" }}{{ end }}
-{{- if or .Values.providers.gemini.enabled .Values.providers.gemini.apiKey }}{{ $enabledProviders = append $enabledProviders "gemini" }}{{ end }}
-{{- if or .Values.providers.groq.enabled .Values.providers.groq.apiKey }}{{ $enabledProviders = append $enabledProviders "groq" }}{{ end }}
-{{- if or .Values.providers.xai.enabled .Values.providers.xai.apiKey }}{{ $enabledProviders = append $enabledProviders "xai" }}{{ end }}
-{{- if or .Values.providers.zai.enabled .Values.providers.zai.apiKey }}{{ $enabledProviders = append $enabledProviders "zai" }}{{ end }}
-{{- if and .Values.providers.oracle.baseUrl (or .Values.providers.oracle.enabled .Values.providers.oracle.apiKey) }}{{ $enabledProviders = append $enabledProviders "oracle" }}{{ end }}
-
-{{- if eq (len $enabledProviders) 0 }}
-
-⚠️  WARNING: No providers enabled!
-    Provide an API key for at least one provider (e.g., providers.openai.apiKey)
 {{- else }}
-
-Enabled providers: {{ join ", " $enabledProviders }}
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "gomodel.fullname" . }} 8080:{{ .Values.service.port }}
+  curl http://127.0.0.1:8080{{ include "gomodel.pathWithBasePath" (dict "root" . "path" "/health/ready") }}
 {{- end }}
 
-To check the logs:
-  kubectl logs --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "gomodel.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -f
+Dashboard: {{ include "gomodel.pathWithBasePath" (dict "root" . "path" "/admin/dashboard") }}
+{{- if not (or (hasKey .Values.secretEnv "GOMODEL_MASTER_KEY") .Values.extraEnvFrom) }}
 
-To test the health endpoint:
-  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "gomodel.fullname" . }} 8080:{{ .Values.service.port }} &
-  curl http://127.0.0.1:8080/health
+WARNING: GOMODEL_MASTER_KEY is not set. The gateway accepts unauthenticated
+requests. Set secretEnv.GOMODEL_MASTER_KEY or load it with extraEnvFrom.
+{{- end }}
+{{- if and (eq .Values.storage.type "sqlite") (not .Values.persistence.enabled) }}
+
+WARNING: SQLite data is on an emptyDir volume. Audit logs, usage, budgets and
+dashboard-created keys are lost when the pod is replaced. Enable persistence
+or use storage.type postgresql / mongodb.
+{{- end }}
+
+Logs:
+  kubectl --namespace {{ .Release.Namespace }} logs -f deploy/{{ include "gomodel.fullname" . }}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -28,7 +28,7 @@ Create a default fully qualified app name, truncated to the 63 character DNS lim
 {{- define "gomodel.labels" -}}
 helm.sh/chart: {{ include "gomodel.chart" . }}
 {{ include "gomodel.selectorLabels" . }}
-app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | trunc 63 | trimAll "-_." | default .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -6,8 +6,7 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+Create a default fully qualified app name, truncated to the 63 character DNS limit.
 */}}
 {{- define "gomodel.fullname" -}}
 {{- if .Values.fullnameOverride }}
@@ -22,174 +21,110 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end }}
 {{- end }}
 
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
 {{- define "gomodel.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
-{{/*
-Common labels
-*/}}
 {{- define "gomodel.labels" -}}
 helm.sh/chart: {{ include "gomodel.chart" . }}
 {{ include "gomodel.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
-{{/*
-Selector labels
-*/}}
 {{- define "gomodel.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "gomodel.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
-{{/*
-Create the name of the secret containing provider API keys
-*/}}
-{{- define "gomodel.providerSecretName" -}}
-{{- if .Values.providers.existingSecret }}
-{{- .Values.providers.existingSecret }}
+{{- define "gomodel.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "gomodel.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
-{{- include "gomodel.fullname" . }}-providers
+{{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
 
-{{/*
-Create the name of the secret containing auth credentials
-*/}}
-{{- define "gomodel.authSecretName" -}}
-{{- if .Values.auth.existingSecret }}
-{{- .Values.auth.existingSecret }}
-{{- else }}
-{{- include "gomodel.fullname" . }}-auth
-{{- end }}
-{{- end }}
-
-{{/*
-Determine the Redis URL - either from values or auto-generated for subchart
-*/}}
-{{- define "gomodel.redisUrl" -}}
-{{- if .Values.cache.redis.url }}
-{{- .Values.cache.redis.url }}
-{{- else if .Values.redis.enabled }}
-{{- printf "redis://%s-redis-master:6379" .Release.Name }}
-{{- else }}
-{{- "" }}
-{{- end }}
-{{- end }}
-
-{{/*
-Create the image reference
-*/}}
 {{- define "gomodel.image" -}}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion }}
-{{- printf "%s:%s" .Values.image.repository $tag }}
+{{- printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) }}
 {{- end }}
 
 {{/*
-Normalize the public base path used by the application.
+Validate value combinations that would produce a broken deployment.
 */}}
-{{- define "gomodel.basePath" -}}
-{{- $basePath := trim (default "/" .Values.server.basePath) -}}
-{{- if or (eq $basePath "") (eq $basePath "/") -}}
-/
-{{- else -}}
-{{- if not (hasPrefix "/" $basePath) -}}
-{{- $basePath = printf "/%s" $basePath -}}
-{{- end -}}
-{{- $basePath = clean $basePath -}}
-{{- if or (eq $basePath ".") (eq $basePath "/") -}}
-/
-{{- else -}}
-{{- $basePath -}}
-{{- end -}}
-{{- end -}}
+{{- define "gomodel.validate" -}}
+{{- range $key := list "auth" "providers" "redis" "cache" "gateway" "server" "logging" }}
+{{- if hasKey $.Values $key }}
+{{- fail (printf "%s is a chart 0.1.x value that this chart no longer reads; migrate it to env / secretEnv / extraEnvFrom as described in the chart README before upgrading" $key) }}
+{{- end }}
+{{- end }}
+{{- range $key := list "PORT" "STORAGE_TYPE" "METRICS_ENABLED" }}
+{{- if or (hasKey $.Values.env $key) (hasKey $.Values.secretEnv $key) }}
+{{- fail (printf "%s is set by the chart; use storage.type, metrics.enabled, or the fixed container port instead of env.%s" $key $key) }}
+{{- end }}
+{{- end }}
+{{- $type := .Values.storage.type }}
+{{- if not (has $type (list "sqlite" "postgresql" "mongodb")) }}
+{{- fail (printf "storage.type must be sqlite, postgresql, or mongodb (got %q)" $type) }}
+{{- end }}
+{{- if and (eq $type "sqlite") (or (gt (int .Values.replicaCount) 1) .Values.autoscaling.enabled) }}
+{{- fail "SQLite storage is per pod: set storage.type to postgresql or mongodb before running more than one replica" }}
+{{- end }}
+{{- if ne $type "sqlite" }}
+{{- $urlEnv := include "gomodel.storageUrlEnv" . }}
+{{- $fromExtraEnv := false }}
+{{- range .Values.extraEnv }}{{ if eq .name $urlEnv }}{{ $fromExtraEnv = true }}{{ end }}{{ end }}
+{{- if not (or .Values.storage.url .Values.extraEnvFrom $fromExtraEnv (hasKey .Values.secretEnv $urlEnv)) }}
+{{- fail (printf "storage.url is required for storage.type %s (or supply %s through secretEnv, extraEnv, or extraEnvFrom)" $type $urlEnv) }}
+{{- end }}
+{{- end }}
+{{- if and .Values.config .Values.existingConfigMap }}
+{{- fail "set either config or existingConfigMap, not both" }}
+{{- end }}
+{{- if and .Values.httpRoute.enabled (not .Values.httpRoute.parentRefs) }}
+{{- fail "httpRoute.parentRefs is required when httpRoute.enabled is true" }}
+{{- end }}
 {{- end }}
 
 {{/*
-Prefix an application path with server.basePath unless it is already prefixed.
+Environment variable that carries the storage connection URL for the selected backend.
+*/}}
+{{- define "gomodel.storageUrlEnv" -}}
+{{- if eq .Values.storage.type "postgresql" }}POSTGRES_URL{{ else if eq .Values.storage.type "mongodb" }}MONGODB_URL{{ end }}
+{{- end }}
+
+{{/*
+True when SQLite data is kept on a PersistentVolumeClaim.
+*/}}
+{{- define "gomodel.usesPVC" -}}
+{{- if and (eq .Values.storage.type "sqlite") .Values.persistence.enabled }}true{{ end }}
+{{- end }}
+
+{{/*
+Name of the chart-managed Secret; empty when there is nothing to store.
+*/}}
+{{- define "gomodel.secretName" -}}
+{{- if or .Values.secretEnv .Values.storage.url }}{{ include "gomodel.fullname" . }}{{ end }}
+{{- end }}
+
+{{/*
+Name of the ConfigMap holding config.yaml; empty when no file is configured.
+*/}}
+{{- define "gomodel.configMapName" -}}
+{{- if .Values.existingConfigMap }}{{ .Values.existingConfigMap }}{{ else if .Values.config }}{{ include "gomodel.fullname" . }}-config{{ end }}
+{{- end }}
+
+{{/*
+Prefix an application path with env.BASE_PATH so probes and scrapes keep working
+when the gateway is mounted under a prefix. Mirrors the server's
+NormalizeBasePath: trimmed, a leading slash added, then path-cleaned, with root
+rendering as no prefix at all.
 */}}
 {{- define "gomodel.pathWithBasePath" -}}
-{{- $root := .root -}}
-{{- $path := trim (default "/" .path) -}}
-{{- if or (eq $path "") (eq $path "/") -}}
-{{- $path = "/" -}}
-{{- else if not (hasPrefix "/" $path) -}}
-{{- $path = printf "/%s" $path -}}
+{{- $base := "" -}}
+{{- with trim (toString (default "" .root.Values.env.BASE_PATH)) -}}
+{{- $base = clean (printf "/%s" (trimPrefix "/" .)) -}}
+{{- if eq $base "/" -}}{{- $base = "" -}}{{- end -}}
 {{- end -}}
-{{- $basePath := include "gomodel.basePath" $root -}}
-{{- if eq $path "/" -}}
-{{- if eq $basePath "/" -}}
-{{- $path -}}
-{{- else -}}
-{{- $basePath -}}
-{{- end -}}
-{{- else if eq $basePath "/" -}}
-{{- $path -}}
-{{- else if or (eq $path $basePath) (hasPrefix (printf "%s/" $basePath) $path) -}}
-{{- $path -}}
-{{- else -}}
-{{- printf "%s%s" $basePath $path -}}
-{{- end -}}
-{{- end }}
-
-{{/*
-Generate provider API key entries for the Secret stringData.
-*/}}
-{{- define "gomodel.providerSecretData" -}}
-{{- range $name, $config := .Values.providers }}
-  {{- if and (kindIs "map" $config) (hasKey $config "apiKey") $config.apiKey }}
-{{ upper $name }}_API_KEY: {{ $config.apiKey | quote }}
-  {{- end }}
-{{- end }}
-{{- end }}
-
-{{/*
-Generate provider environment variables for the Deployment.
-*/}}
-{{- define "gomodel.providerEnvVars" -}}
-{{- $secretName := include "gomodel.providerSecretName" . -}}
-{{- range $name, $config := .Values.providers }}
-{{- if kindIs "map" $config }}
-{{- $hasAPIKey := and (hasKey $config "apiKey") $config.apiKey }}
-{{- $enabledWithExistingSecret := and $.Values.providers.existingSecret (hasKey $config "enabled") $config.enabled }}
-{{- $enabledWithBaseURL := and (hasKey $config "enabled") $config.enabled $config.baseUrl }}
-{{- if or $hasAPIKey $enabledWithExistingSecret }}
-- name: {{ upper $name }}_API_KEY
-  valueFrom:
-    secretKeyRef:
-      name: {{ $secretName }}
-      key: {{ upper $name }}_API_KEY
-{{- if eq $name "llmd" }}
-      optional: true
-{{- end }}
-{{- end }}
-{{- if or (or $hasAPIKey $enabledWithExistingSecret) $enabledWithBaseURL }}
-{{- if $config.baseUrl }}
-- name: {{ upper $name }}_BASE_URL
-  value: {{ $config.baseUrl | quote }}
-{{- end }}
-{{- end }}
-{{- if and (eq $name "gemini") (hasKey $config "useNativeApi") }}
-- name: USE_GOOGLE_GEMINI_NATIVE_API
-  value: {{ $config.useNativeApi | quote }}
-{{- end }}
-{{- if and (eq $name "llmd") (or (or $hasAPIKey $enabledWithExistingSecret) $enabledWithBaseURL) }}
-{{- if $config.inferenceObjective }}
-- name: LLMD_INFERENCE_OBJECTIVE
-  value: {{ $config.inferenceObjective | quote }}
-{{- end }}
-{{- if hasKey $config "fairnessFromUserPath" }}
-- name: LLMD_FAIRNESS_FROM_USER_PATH
-  value: {{ $config.fairnessFromUserPath | quote }}
-{{- end }}
-{{- end }}
-{{- end }}
-{{- end }}
+{{- printf "%s%s" $base .path -}}
 {{- end }}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -74,8 +74,8 @@ Validate value combinations that would produce a broken deployment.
 {{- $urlEnv := include "gomodel.storageUrlEnv" . }}
 {{- $fromExtraEnv := false }}
 {{- range .Values.extraEnv }}{{ if eq .name $urlEnv }}{{ $fromExtraEnv = true }}{{ end }}{{ end }}
-{{- if not (or .Values.storage.url .Values.extraEnvFrom $fromExtraEnv (hasKey .Values.secretEnv $urlEnv)) }}
-{{- fail (printf "storage.url is required for storage.type %s (or supply %s through secretEnv, extraEnv, or extraEnvFrom)" $type $urlEnv) }}
+{{- if not (or .Values.storage.url .Values.extraEnvFrom $fromExtraEnv (hasKey .Values.secretEnv $urlEnv) (hasKey .Values.env $urlEnv)) }}
+{{- fail (printf "storage.url is required for storage.type %s (or supply %s through env, secretEnv, extraEnv, or extraEnvFrom)" $type $urlEnv) }}
 {{- end }}
 {{- end }}
 {{- if and .Values.config .Values.existingConfigMap }}

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- include "gomodel.validate" . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -5,17 +6,21 @@ metadata:
   labels:
     {{- include "gomodel.labels" . | nindent 4 }}
 data:
-  PORT: {{ .Values.server.port | quote }}
-  BASE_PATH: {{ .Values.server.basePath | default "/" | quote }}
-  USER_PATH_HEADER: {{ .Values.server.userPathHeader | default "X-GoModel-User-Path" | quote }}
-  BODY_SIZE_LIMIT: {{ .Values.server.bodySizeLimit | quote }}
-  {{- if or .Values.redis.enabled .Values.cache.redis.url }}
-  REDIS_KEY_MODELS: {{ .Values.cache.redis.keyModels | default "gomodel:models" | quote }}
-  REDIS_KEY_RESPONSES: {{ .Values.cache.redis.keyResponses | default "gomodel:response:" | quote }}
-  REDIS_TTL_MODELS: {{ .Values.cache.redis.ttlModels | default 86400 | quote }}
-  REDIS_TTL_RESPONSES: {{ .Values.cache.redis.ttlResponses | default 3600 | quote }}
-  RESPONSE_CACHE_SIMPLE_ENABLED: "true"
-  {{- end }}
+  PORT: "8080"
+  STORAGE_TYPE: {{ .Values.storage.type | quote }}
   METRICS_ENABLED: {{ .Values.metrics.enabled | quote }}
-  METRICS_ENDPOINT: {{ .Values.metrics.endpoint | quote }}
-  LOG_FORMAT: {{ .Values.logging.format | quote }}
+  {{- range $key, $value := .Values.env }}
+  {{ $key }}: {{ $value | toString | quote }}
+  {{- end }}
+{{- if .Values.config }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "gomodel.fullname" . }}-config
+  labels:
+    {{- include "gomodel.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    {{- .Values.config | nindent 4 }}
+{{- end }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $usesPVC := include "gomodel.usesPVC" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -7,6 +8,13 @@ metadata:
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  {{- if .Values.updateStrategy }}
+  strategy:
+    {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- else if $usesPVC }}
+  strategy:
+    type: Recreate
   {{- end }}
   selector:
     matchLabels:
@@ -29,116 +37,88 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "gomodel.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+        - name: gomodel
           image: {{ include "gomodel.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           ports:
             - name: http
-              containerPort: {{ .Values.server.port }}
+              containerPort: 8080
               protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "gomodel.fullname" . }}
+            {{- with (include "gomodel.secretName" .) }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
+            {{- with .Values.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.extraEnv }}
           env:
-            # Server configuration
-            - name: PORT
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "gomodel.fullname" . }}
-                  key: PORT
-            - name: BASE_PATH
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "gomodel.fullname" . }}
-                  key: BASE_PATH
-            - name: USER_PATH_HEADER
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "gomodel.fullname" . }}
-                  key: USER_PATH_HEADER
-            - name: BODY_SIZE_LIMIT
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "gomodel.fullname" . }}
-                  key: BODY_SIZE_LIMIT
-            # Cache configuration
-            {{- if or .Values.redis.enabled .Values.cache.redis.url }}
-            - name: REDIS_URL
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "gomodel.providerSecretName" . }}
-                  key: REDIS_URL
-                  optional: true
-            - name: REDIS_KEY_MODELS
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "gomodel.fullname" . }}
-                  key: REDIS_KEY_MODELS
-            - name: REDIS_KEY_RESPONSES
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "gomodel.fullname" . }}
-                  key: REDIS_KEY_RESPONSES
-            - name: REDIS_TTL_MODELS
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "gomodel.fullname" . }}
-                  key: REDIS_TTL_MODELS
-            - name: REDIS_TTL_RESPONSES
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "gomodel.fullname" . }}
-                  key: REDIS_TTL_RESPONSES
-            {{- end }}
-            # Logging configuration
-            - name: LOG_FORMAT
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "gomodel.fullname" . }}
-                  key: LOG_FORMAT
-            # Metrics configuration
-            - name: METRICS_ENABLED
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "gomodel.fullname" . }}
-                  key: METRICS_ENABLED
-            - name: METRICS_ENDPOINT
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "gomodel.fullname" . }}
-                  key: METRICS_ENDPOINT
-            # Authentication
-            {{- if or .Values.auth.masterKey .Values.auth.existingSecret }}
-            - name: GOMODEL_MASTER_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "gomodel.authSecretName" . }}
-                  key: {{ .Values.auth.existingSecretKey | default "master-key" }}
-            {{- end }}
-            # Provider API keys (conditional based on enabled providers)
-{{- include "gomodel.providerEnvVars" . | nindent 12 }}
-          volumeMounts:
-            - name: cache
-              mountPath: /cache
-          {{- $livenessProbe := deepCopy .Values.livenessProbe }}
-          {{- if and $livenessProbe.httpGet $livenessProbe.httpGet.path }}
-          {{- $_ := set $livenessProbe.httpGet "path" (include "gomodel.pathWithBasePath" (dict "root" . "path" $livenessProbe.httpGet.path)) }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.livenessProbe }}
           livenessProbe:
-            {{- toYaml $livenessProbe | nindent 12 }}
-          {{- $readinessProbe := deepCopy .Values.readinessProbe }}
-          {{- if and $readinessProbe.httpGet $readinessProbe.httpGet.path }}
-          {{- $_ := set $readinessProbe.httpGet "path" (include "gomodel.pathWithBasePath" (dict "root" . "path" $readinessProbe.httpGet.path)) }}
+            {{- $probe := deepCopy . }}
+            {{- if $probe.httpGet }}
+            {{- $_ := set $probe.httpGet "path" (include "gomodel.pathWithBasePath" (dict "root" $ "path" $probe.httpGet.path)) }}
+            {{- end }}
+            {{- toYaml $probe | nindent 12 }}
           {{- end }}
+          {{- with .Values.readinessProbe }}
           readinessProbe:
-            {{- toYaml $readinessProbe | nindent 12 }}
+            {{- $probe := deepCopy . }}
+            {{- if $probe.httpGet }}
+            {{- $_ := set $probe.httpGet "path" (include "gomodel.pathWithBasePath" (dict "root" $ "path" $probe.httpGet.path)) }}
+            {{- end }}
+            {{- toYaml $probe | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
+            - name: cache
+              mountPath: /app/.cache
+            {{- if include "gomodel.configMapName" . }}
+            - name: config
+              mountPath: /app/config/config.yaml
+              subPath: config.yaml
+              readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
+        - name: data
+          {{- if $usesPVC }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (printf "%s-data" (include "gomodel.fullname" .)) }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
         - name: cache
           emptyDir: {}
+        {{- with (include "gomodel.configMapName" .) }}
+        - name: config
+          configMap:
+            name: {{ . }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -149,5 +129,9 @@ spec:
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm/templates/hpa.yaml
+++ b/helm/templates/hpa.yaml
@@ -1,7 +1,4 @@
 {{- if .Values.autoscaling.enabled }}
-{{- if not (or .Values.autoscaling.targetCPUUtilizationPercentage .Values.autoscaling.targetMemoryUtilizationPercentage) }}
-{{- fail "autoscaling.targetCPUUtilizationPercentage or autoscaling.targetMemoryUtilizationPercentage must be set when autoscaling is enabled" }}
-{{- end }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -16,20 +13,20 @@ spec:
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- with .Values.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+          averageUtilization: {{ . }}
     {{- end }}
-    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- with .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
         target:
           type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+          averageUtilization: {{ . }}
     {{- end }}
 {{- end }}

--- a/helm/templates/httproute.yaml
+++ b/helm/templates/httproute.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.gateway.enabled -}}
+{{- if .Values.httpRoute.enabled }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -7,21 +7,16 @@ metadata:
     {{- include "gomodel.labels" . | nindent 4 }}
 spec:
   parentRefs:
-    - name: {{ .Values.gateway.parentRef.name }}
-      {{- if .Values.gateway.parentRef.namespace }}
-      namespace: {{ .Values.gateway.parentRef.namespace }}
-      {{- end }}
-  {{- if .Values.gateway.hostnames }}
+    {{- toYaml .Values.httpRoute.parentRefs | nindent 4 }}
+  {{- with .Values.httpRoute.hostnames }}
   hostnames:
-    {{- range .Values.gateway.hostnames }}
-    - {{ . | quote }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
     - matches:
         - path:
             type: PathPrefix
-            value: /
+            value: {{ include "gomodel.pathWithBasePath" (dict "root" . "path" "/") | quote }}
       backendRefs:
         - name: {{ include "gomodel.fullname" . }}
           port: {{ .Values.service.port }}

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -10,18 +10,12 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.ingress.className }}
-  ingressClassName: {{ .Values.ingress.className }}
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
   {{- end }}
-  {{- if .Values.ingress.tls }}
+  {{- with .Values.ingress.tls }}
   tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
@@ -30,12 +24,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            pathType: {{ .pathType }}
+            pathType: {{ .pathType | default "Prefix" }}
             backend:
               service:
                 name: {{ include "gomodel.fullname" $ }}
                 port:
-                  number: {{ $.Values.service.port }}
+                  name: http
           {{- end }}
     {{- end }}
 {{- end }}

--- a/helm/templates/pdb.yaml
+++ b/helm/templates/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.podDisruptionBudget.enabled }}
+{{- if and .Values.podDisruptionBudget.enabled (or (gt (int .Values.replicaCount) 1) .Values.autoscaling.enabled) }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -6,14 +6,10 @@ metadata:
   labels:
     {{- include "gomodel.labels" . | nindent 4 }}
 spec:
-  {{- if and (not .Values.podDisruptionBudget.minAvailable) (not .Values.podDisruptionBudget.maxUnavailable) }}
-  {{- fail "PodDisruptionBudget requires either minAvailable or maxUnavailable to be set" }}
-  {{- end }}
-  {{- if .Values.podDisruptionBudget.minAvailable }}
-  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
-  {{- end }}
-  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  {{- if not (kindIs "invalid" .Values.podDisruptionBudget.maxUnavailable) }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
   {{- end }}
   selector:
     matchLabels:

--- a/helm/templates/pvc.yaml
+++ b/helm/templates/pvc.yaml
@@ -1,0 +1,21 @@
+{{- if and (include "gomodel.usesPVC" .) (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "gomodel.fullname" . }}-data
+  labels:
+    {{- include "gomodel.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ if eq "-" .Values.persistence.storageClass }}""{{ else }}{{ .Values.persistence.storageClass | quote }}{{ end }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end }}

--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -1,26 +1,16 @@
-{{- if not .Values.providers.existingSecret }}
+{{- if include "gomodel.secretName" . }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "gomodel.fullname" . }}-providers
+  name: {{ include "gomodel.secretName" . }}
   labels:
     {{- include "gomodel.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-{{- include "gomodel.providerSecretData" . | nindent 2 }}
-  {{- if or .Values.redis.enabled .Values.cache.redis.url }}
-  REDIS_URL: {{ include "gomodel.redisUrl" . | quote }}
+  {{- if .Values.storage.url }}
+  {{ include "gomodel.storageUrlEnv" . }}: {{ .Values.storage.url | quote }}
   {{- end }}
-{{- end }}
----
-{{- if and .Values.auth.masterKey (not .Values.auth.existingSecret) }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "gomodel.fullname" . }}-auth
-  labels:
-    {{- include "gomodel.labels" . | nindent 4 }}
-type: Opaque
-stringData:
-  master-key: {{ .Values.auth.masterKey | quote }}
+  {{- range $key, $value := .Values.secretEnv }}
+  {{ $key }}: {{ $value | toString | quote }}
+  {{- end }}
 {{- end }}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -11,9 +11,9 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
+    - name: http
+      port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
-      name: http
   selector:
     {{- include "gomodel.selectorLabels" . | nindent 4 }}

--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "gomodel.serviceAccountName" . }}
+  labels:
+    {{- include "gomodel.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/helm/templates/servicemonitor.yaml
+++ b/helm/templates/servicemonitor.yaml
@@ -3,17 +3,21 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "gomodel.fullname" . }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace | default .Release.Namespace }}
   labels:
     {{- include "gomodel.labels" . | nindent 4 }}
     {{- with .Values.metrics.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
   selector:
     matchLabels:
       {{- include "gomodel.selectorLabels" . | nindent 6 }}
   endpoints:
     - port: http
-      path: {{ include "gomodel.pathWithBasePath" (dict "root" . "path" .Values.metrics.endpoint) | quote }}
+      path: {{ include "gomodel.pathWithBasePath" (dict "root" . "path" (.Values.env.METRICS_ENDPOINT | default "/metrics")) | quote }}
       interval: {{ .Values.metrics.serviceMonitor.interval }}
 {{- end }}

--- a/helm/templates/tests/test-connection.yaml
+++ b/helm/templates/tests/test-connection.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "gomodel.fullname" . }}-test-connection
+  labels:
+    {{- include "gomodel.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: curl
+      image: curlimages/curl:8.16.0
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+      command:
+        - curl
+        - --fail
+        - --silent
+        - --show-error
+        - --retry
+        - "5"
+        - --retry-connrefused
+        - {{ printf "http://%s:%d%s" (include "gomodel.fullname" .) (int .Values.service.port) (include "gomodel.pathWithBasePath" (dict "root" . "path" "/health/ready")) | quote }}

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -1,512 +1,70 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
-  "title": "GoModel Helm Chart Values",
+  "title": "GoModel Helm chart values",
   "type": "object",
-  "allOf": [
-    {
-      "if": {
-        "properties": {
-          "gateway": {
-            "properties": { "enabled": { "const": true } }
-          }
-        }
-      },
-      "then": {
-        "properties": {
-          "gateway": {
-            "properties": {
-              "parentRef": {
-                "properties": {
-                  "name": { "minLength": 1 }
-                },
-                "required": ["name"]
-              }
-            },
-            "required": ["parentRef"]
-          }
-        }
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "providers": {
-            "properties": {
-              "oracle": {
-                "properties": { "enabled": { "const": true } }
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "properties": {
-          "providers": {
-            "properties": {
-              "oracle": {
-                "properties": {
-                  "baseUrl": { "minLength": 1 }
-                },
-                "required": ["baseUrl"]
-              }
-            }
-          }
-        }
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "providers": {
-            "properties": {
-              "oracle": {
-                "properties": {
-                  "apiKey": { "minLength": 1 }
-                }
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "properties": {
-          "providers": {
-            "properties": {
-              "oracle": {
-                "properties": {
-                  "baseUrl": { "minLength": 1 }
-                },
-                "required": ["baseUrl"]
-              }
-            }
-          }
-        }
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "providers": {
-            "properties": {
-              "vllm": {
-                "properties": { "enabled": { "const": true } }
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "properties": {
-          "providers": {
-            "properties": {
-              "vllm": {
-                "properties": {
-                  "baseUrl": { "minLength": 1 }
-                },
-                "required": ["baseUrl"]
-              }
-            }
-          }
-        }
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "providers": {
-            "properties": {
-              "llmd": {
-                "properties": { "enabled": { "const": true } }
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "properties": {
-          "providers": {
-            "properties": {
-              "llmd": {
-                "properties": {
-                  "baseUrl": { "minLength": 1 }
-                },
-                "required": ["baseUrl"]
-              }
-            }
-          }
-        }
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "providers": {
-            "properties": {
-              "sglang": {
-                "properties": { "enabled": { "const": true } }
-              }
-            }
-          }
-        }
-      },
-      "then": {
-        "properties": {
-          "providers": {
-            "properties": {
-              "sglang": {
-                "properties": {
-                  "baseUrl": { "minLength": 1 }
-                },
-                "required": ["baseUrl"]
-              }
-            }
-          }
-        }
-      }
-    }
-  ],
-  "anyOf": [
-    {
-      "properties": {
-        "providers": {
-          "properties": { "existingSecret": { "minLength": 1 } }
-        }
-      }
-    },
-    {
-      "properties": {
-        "providers": {
-          "properties": {
-            "openai": {
-              "properties": { "apiKey": { "minLength": 1 } }
-            }
-          }
-        }
-      }
-    },
-    {
-      "properties": {
-        "providers": {
-          "properties": {
-            "anthropic": {
-              "properties": { "apiKey": { "minLength": 1 } }
-            }
-          }
-        }
-      }
-    },
-    {
-      "properties": {
-        "providers": {
-          "properties": {
-            "cohere": {
-              "properties": { "apiKey": { "minLength": 1 } }
-            }
-          }
-        }
-      }
-    },
-    {
-      "properties": {
-        "providers": {
-          "properties": {
-            "gemini": {
-              "properties": { "apiKey": { "minLength": 1 } }
-            }
-          }
-        }
-      }
-    },
-    {
-      "properties": {
-        "providers": {
-          "properties": {
-            "groq": {
-              "properties": { "apiKey": { "minLength": 1 } }
-            }
-          }
-        }
-      }
-    },
-    {
-      "properties": {
-        "providers": {
-          "properties": {
-            "xai": {
-              "properties": { "apiKey": { "minLength": 1 } }
-            }
-          }
-        }
-      }
-    },
-    {
-      "properties": {
-        "providers": {
-          "properties": {
-            "zai": {
-              "properties": { "apiKey": { "minLength": 1 } }
-            }
-          }
-        }
-      }
-    },
-    {
-      "properties": {
-        "providers": {
-          "properties": {
-            "kilo": {
-              "properties": { "apiKey": { "minLength": 1 } }
-            }
-          }
-        }
-      }
-    },
-    {
-      "properties": {
-        "providers": {
-          "properties": {
-            "oracle": {
-              "properties": {
-                "apiKey": { "minLength": 1 },
-                "baseUrl": { "minLength": 1 }
-              }
-            }
-          }
-        }
-      }
-    },
-    {
-      "properties": {
-        "providers": {
-          "properties": {
-            "vllm": {
-              "properties": {
-                "enabled": { "const": true },
-                "baseUrl": { "minLength": 1 }
-              }
-            }
-          }
-        }
-      }
-    },
-    {
-      "properties": {
-        "providers": {
-          "properties": {
-            "llmd": {
-              "properties": {
-                "enabled": { "const": true },
-                "baseUrl": { "minLength": 1 }
-              }
-            }
-          }
-        }
-      }
-    },
-    {
-      "properties": {
-        "providers": {
-          "properties": {
-            "sglang": {
-              "properties": {
-                "enabled": { "const": true },
-                "baseUrl": { "minLength": 1 }
-              }
-            }
-          }
-        }
-      }
-    }
-  ],
   "properties": {
-    "replicaCount": {
-      "type": "integer",
-      "minimum": 1
-    },
+    "replicaCount": { "type": "integer", "minimum": 0 },
     "image": {
       "type": "object",
       "properties": {
-        "repository": { "type": "string" },
-        "pullPolicy": {
-          "type": "string",
-          "enum": ["Always", "IfNotPresent", "Never"]
-        },
-        "tag": { "type": "string" }
-      }
+        "repository": { "type": "string", "minLength": 1 },
+        "tag": { "type": "string" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+      },
+      "required": ["repository"]
     },
-    "providers": {
+    "imagePullSecrets": { "type": "array" },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "env": { "$ref": "#/definitions/envMap" },
+    "secretEnv": { "$ref": "#/definitions/envMap" },
+    "extraEnvFrom": { "type": "array", "items": { "type": "object" } },
+    "extraEnv": {
+      "type": "array",
+      "items": { "type": "object", "required": ["name"], "properties": { "name": { "type": "string" } } }
+    },
+    "config": { "type": "string" },
+    "existingConfigMap": { "type": "string" },
+    "storage": {
       "type": "object",
       "properties": {
-        "existingSecret": { "type": "string" },
-        "openai": {
-          "type": "object",
-          "properties": {
-            "enabled": { "type": "boolean" },
-            "apiKey": { "type": "string" },
-            "baseUrl": { "type": "string" }
-          }
-        },
-        "anthropic": {
-          "type": "object",
-          "properties": {
-            "enabled": { "type": "boolean" },
-            "apiKey": { "type": "string" },
-            "baseUrl": { "type": "string" }
-          }
-        },
-        "cohere": {
-          "type": "object",
-          "properties": {
-            "enabled": { "type": "boolean" },
-            "apiKey": { "type": "string" },
-            "baseUrl": { "type": "string" }
-          }
-        },
-        "gemini": {
-          "type": "object",
-          "properties": {
-            "enabled": { "type": "boolean" },
-            "apiKey": { "type": "string" },
-            "useNativeApi": { "type": "boolean" },
-            "baseUrl": { "type": "string" }
-          }
-        },
-        "groq": {
-          "type": "object",
-          "properties": {
-            "enabled": { "type": "boolean" },
-            "apiKey": { "type": "string" },
-            "baseUrl": { "type": "string" }
-          }
-        },
-        "xai": {
-          "type": "object",
-          "properties": {
-            "enabled": { "type": "boolean" },
-            "apiKey": { "type": "string" },
-            "baseUrl": { "type": "string" }
-          }
-        },
-        "zai": {
-          "type": "object",
-          "properties": {
-            "enabled": { "type": "boolean" },
-            "apiKey": { "type": "string" },
-            "baseUrl": { "type": "string" }
-          }
-        },
-        "kilo": {
-          "type": "object",
-          "properties": {
-            "enabled": { "type": "boolean" },
-            "apiKey": { "type": "string" },
-            "baseUrl": { "type": "string" }
-          }
-        },
-        "oracle": {
-          "type": "object",
-          "properties": {
-            "enabled": { "type": "boolean" },
-            "apiKey": { "type": "string" },
-            "baseUrl": { "type": "string" }
-          }
-        },
-        "vllm": {
-          "type": "object",
-          "properties": {
-            "enabled": { "type": "boolean" },
-            "apiKey": { "type": "string" },
-            "baseUrl": { "type": "string" }
-          }
-        },
-        "llmd": {
-          "type": "object",
-          "properties": {
-            "enabled": { "type": "boolean" },
-            "apiKey": { "type": "string" },
-            "baseUrl": { "type": "string" },
-            "inferenceObjective": { "type": "string" },
-            "fairnessFromUserPath": { "type": "boolean" }
-          }
-        },
-        "sglang": {
-          "type": "object",
-          "properties": {
-            "enabled": { "type": "boolean" },
-            "apiKey": { "type": "string" },
-            "baseUrl": { "type": "string" }
-          }
-        }
-      }
+        "type": { "type": "string", "enum": ["sqlite", "postgresql", "mongodb"] },
+        "url": { "type": "string" }
+      },
+      "required": ["type"]
     },
-    "cache": {
+    "persistence": {
       "type": "object",
       "properties": {
-        "redis": {
-          "type": "object",
-          "properties": {
-            "url": { "type": "string", "description": "Redis connection URL" },
-            "keyModels": { "type": "string", "description": "Redis key prefix for the model registry cache (default: gomodel:models)" },
-            "ttlModels": { "type": "integer", "description": "TTL for model cache entries in seconds (default: 86400)" },
-            "keyResponses": { "type": "string", "description": "Redis key prefix for the response cache (default: gomodel:response:)" },
-            "ttlResponses": { "type": "integer", "description": "TTL for response cache entries in seconds (default: 3600)" }
-          }
-        }
+        "enabled": { "type": "boolean" },
+        "existingClaim": { "type": "string" },
+        "storageClass": { "type": "string" },
+        "accessModes": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+        "size": { "type": "string", "pattern": "^[0-9]+(\\.[0-9]+)?(Ki|Mi|Gi|Ti|Pi|Ei|k|M|G|T|P|E)?$" },
+        "annotations": { "type": "object" }
       }
     },
-    "redis": {
-      "type": "object",
-      "additionalProperties": true
-    },
-    "server": {
-      "type": "object",
-      "properties": {
-        "port": { "type": "integer" },
-        "basePath": { "type": "string" },
-        "userPathHeader": { "type": "string" },
-        "bodySizeLimit": { "type": "string" }
-      }
-    },
-    "auth": {
-      "type": "object",
-      "properties": {
-        "masterKey": { "type": "string" },
-        "existingSecret": { "type": "string" },
-        "existingSecretKey": { "type": "string" }
-      }
-    },
+    "updateStrategy": { "type": "object" },
     "metrics": {
       "type": "object",
       "properties": {
         "enabled": { "type": "boolean" },
-        "endpoint": { "type": "string" },
         "serviceMonitor": {
           "type": "object",
           "properties": {
             "enabled": { "type": "boolean" },
             "interval": { "type": "string" },
+            "namespace": { "type": "string" },
             "labels": { "type": "object" }
           }
-        }
-      }
-    },
-    "logging": {
-      "type": "object",
-      "properties": {
-        "format": {
-          "type": "string",
-          "enum": ["", "json", "text"]
         }
       }
     },
     "service": {
       "type": "object",
       "properties": {
-        "type": {
-          "type": "string",
-          "enum": ["ClusterIP", "LoadBalancer", "NodePort"]
-        },
-        "port": { "type": "integer" },
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
         "annotations": { "type": "object" }
       }
     },
@@ -520,125 +78,83 @@
           "type": "array",
           "items": {
             "type": "object",
+            "required": ["host", "paths"],
             "properties": {
               "host": { "type": "string" },
               "paths": {
                 "type": "array",
+                "minItems": 1,
                 "items": {
                   "type": "object",
+                  "required": ["path"],
                   "properties": {
                     "path": { "type": "string" },
-                    "pathType": {
-                      "type": "string",
-                      "enum": ["Prefix", "Exact", "ImplementationSpecific"]
-                    }
+                    "pathType": { "type": "string", "enum": ["Prefix", "Exact", "ImplementationSpecific"] }
                   }
                 }
               }
             }
           }
         },
-        "tls": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "secretName": { "type": "string" },
-              "hosts": {
-                "type": "array",
-                "items": { "type": "string" }
-              }
-            }
-          }
-        }
+        "tls": { "type": "array" }
       }
     },
-    "gateway": {
+    "httpRoute": {
       "type": "object",
-      "additionalProperties": true
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "parentRefs": { "type": "array", "items": { "type": "object", "required": ["name"] } },
+        "hostnames": { "type": "array", "items": { "type": "string" } }
+      }
     },
-    "resources": {
+    "serviceAccount": {
       "type": "object",
-      "additionalProperties": true
+      "properties": {
+        "create": { "type": "boolean" },
+        "annotations": { "type": "object" },
+        "name": { "type": "string" },
+        "automountServiceAccountToken": { "type": "boolean" }
+      }
     },
+    "resources": { "type": "object" },
     "autoscaling": {
       "type": "object",
       "properties": {
         "enabled": { "type": "boolean" },
-        "minReplicas": {
-          "type": "integer",
-          "minimum": 1
-        },
-        "maxReplicas": {
-          "type": "integer",
-          "minimum": 1
-        },
-        "targetCPUUtilizationPercentage": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 100
-        },
-        "targetMemoryUtilizationPercentage": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 100
-        }
+        "minReplicas": { "type": "integer", "minimum": 1 },
+        "maxReplicas": { "type": "integer", "minimum": 1 },
+        "targetCPUUtilizationPercentage": { "type": ["integer", "null"], "minimum": 1, "maximum": 100 },
+        "targetMemoryUtilizationPercentage": { "type": ["integer", "null"], "minimum": 1, "maximum": 100 }
       }
     },
     "podDisruptionBudget": {
       "type": "object",
-      "additionalProperties": true
-    },
-    "livenessProbe": {
-      "type": "object",
-      "additionalProperties": true
-    },
-    "readinessProbe": {
-      "type": "object",
-      "additionalProperties": true
-    },
-    "podSecurityContext": {
-      "type": "object",
-      "additionalProperties": true
-    },
-    "securityContext": {
-      "type": "object",
-      "additionalProperties": true
-    },
-    "imagePullSecrets": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": { "type": "string", "minLength": 1 }
-        },
-        "required": ["name"]
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minAvailable": { "type": ["integer", "string", "null"] },
+        "maxUnavailable": { "type": ["integer", "string", "null"] }
       }
     },
-    "nameOverride": { "type": "string" },
-    "fullnameOverride": { "type": "string" },
-    "nodeSelector": { "type": "object" },
-    "tolerations": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "key": { "type": "string" },
-          "operator": {
-            "type": "string",
-            "enum": ["Exists", "Equal"]
-          },
-          "value": { "type": "string" },
-          "effect": {
-            "type": "string",
-            "enum": ["NoSchedule", "PreferNoSchedule", "NoExecute", ""]
-          },
-          "tolerationSeconds": { "type": "integer" }
-        }
-      }
-    },
-    "affinity": { "type": "object" },
+    "livenessProbe": { "type": "object" },
+    "readinessProbe": { "type": "object" },
+    "terminationGracePeriodSeconds": { "type": "integer", "minimum": 0 },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
     "podAnnotations": { "type": "object" },
-    "podLabels": { "type": "object" }
+    "podLabels": { "type": "object" },
+    "priorityClassName": { "type": "string" },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array" },
+    "affinity": { "type": "object" },
+    "topologySpreadConstraints": { "type": "array" },
+    "extraVolumes": { "type": "array" },
+    "extraVolumeMounts": { "type": "array" }
+  },
+  "definitions": {
+    "envMap": {
+      "type": "object",
+      "propertyNames": { "pattern": "^[A-Za-z_][A-Za-z0-9_]*$" },
+      "additionalProperties": { "type": ["string", "number", "boolean"] }
+    }
   }
 }

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,326 +1,198 @@
-# Default values for gomodel
-# This is a YAML-formatted file.
+# Default values for the GoModel Helm chart.
+#
+# GoModel is configured through environment variables. Every variable from
+# https://github.com/ENTERPILOT/GoModel/blob/main/.env.template can be set
+# with `env` (plain values) or `secretEnv` (API keys and other secrets).
 
-# -- Number of replicas (ignored if autoscaling.enabled is true)
-replicaCount: 2
+# -- Number of gateway pods. SQLite storage (the default) is per pod, so more
+# than one replica requires storage.type postgresql or mongodb.
+replicaCount: 1
 
 image:
-  # -- Image repository
   repository: enterpilot/gomodel
-  # -- Image pull policy
-  pullPolicy: IfNotPresent
-  # -- Overrides the image tag (default is the chart appVersion)
+  # -- Image tag. Defaults to the chart appVersion.
   tag: ""
+  pullPolicy: IfNotPresent
 
-# -- Image pull secrets
 imagePullSecrets: []
-# -- Override the name of the chart
 nameOverride: ""
-# -- Override the full name of the chart
 fullnameOverride: ""
 
-# Server configuration
-server:
-  # -- Server port
-  port: 8080
-  # -- URL path prefix where GoModel is mounted (for example, "/g")
-  basePath: "/"
-  # -- Header used to read/write request user_path values
-  userPathHeader: "X-GoModel-User-Path"
-  # -- Maximum request body size (e.g., "10M", "1G", "500K")
-  bodySizeLimit: "10M"
+# -- Plain environment variables, stored in a ConfigMap.
+# PORT, STORAGE_TYPE, and METRICS_ENABLED are owned by the chart and rejected here.
+env: {}
+#  LOG_LEVEL: info
+#  OPENAI_BASE_URL: https://my-proxy.example.com/v1
+#  REDIS_URL: redis://redis.cache.svc:6379
 
-# Authentication configuration
-auth:
-  # -- Master key for API authentication (leave empty to disable auth - NOT recommended for production)
-  masterKey: ""
-  # -- Use an existing secret for the master key
-  existingSecret: ""
-  # -- Key in the existing secret containing the master key
-  existingSecretKey: "master-key"
+# -- Sensitive environment variables, stored in a chart-managed Secret.
+# Set GOMODEL_MASTER_KEY here; without it the gateway runs without authentication.
+secretEnv: {}
+#  GOMODEL_MASTER_KEY: change-me
+#  OPENAI_API_KEY: sk-...
+#  ANTHROPIC_API_KEY: sk-ant-...
 
-# LLM Provider configuration
-providers:
-  # -- Use an existing secret for all provider API keys
-  # Secret should contain keys for enabled providers, such as OPENAI_API_KEY, ANTHROPIC_API_KEY, COHERE_API_KEY, GEMINI_API_KEY, GROQ_API_KEY, XAI_API_KEY, ZAI_API_KEY, KILO_API_KEY, ORACLE_API_KEY, SGLANG_API_KEY, VLLM_API_KEY, or LLMD_API_KEY
-  existingSecret: ""
+# -- Existing Secrets or ConfigMaps whose keys become environment variables.
+# Use this to keep API keys out of Helm values (GitOps, external-secrets, ...).
+extraEnvFrom: []
+#  - secretRef:
+#      name: gomodel-provider-keys
 
-  openai:
-    # -- Enable OpenAI provider (auto-enabled if apiKey is set)
-    enabled: false
-    # -- OpenAI API key (ignored if providers.existingSecret is set)
-    apiKey: ""
-    # -- Optional: Override OpenAI base URL
-    baseUrl: ""
+# -- Additional container env entries in Kubernetes form, for valueFrom lookups.
+extraEnv: []
+#  - name: POD_IP
+#    valueFrom:
+#      fieldRef:
+#        fieldPath: status.podIP
 
-  anthropic:
-    # -- Enable Anthropic provider (auto-enabled if apiKey is set)
-    enabled: false
-    # -- Anthropic API key (ignored if providers.existingSecret is set)
-    apiKey: ""
-    # -- Optional: Override Anthropic base URL
-    baseUrl: ""
+# -- Optional config.yaml content, mounted at /app/config/config.yaml.
+# Environment variables always override values in this file.
+config: ""
+#  config: |
+#    providers:
+#      openai:
+#        api_key: ${OPENAI_API_KEY}
 
-  cohere:
-    # -- Enable Cohere provider (auto-enabled if apiKey is set)
-    enabled: false
-    # -- Cohere API key (ignored if providers.existingSecret is set)
-    apiKey: ""
-    # -- Optional: Override Cohere base URL
-    baseUrl: ""
+# -- Name of an existing ConfigMap with a `config.yaml` key, used instead of `config`.
+existingConfigMap: ""
 
-  gemini:
-    # -- Enable Google Gemini provider (auto-enabled if apiKey is set)
-    enabled: false
-    # -- Gemini API key (ignored if providers.existingSecret is set)
-    apiKey: ""
-    # -- Use Gemini native generateContent API for chat/responses. Set false to use Gemini's OpenAI-compatible API.
-    useNativeApi: true
-    # -- Optional: Override Gemini base URL
-    baseUrl: ""
+storage:
+  # -- Storage backend: sqlite, postgresql, or mongodb.
+  # SQLite works for a single pod; use postgresql or mongodb for several replicas.
+  type: sqlite
+  # -- Connection URL for postgresql or mongodb, stored in the chart Secret.
+  # Alternatively supply POSTGRES_URL or MONGODB_URL through extraEnv or extraEnvFrom.
+  url: ""
 
-  groq:
-    # -- Enable Groq provider (auto-enabled if apiKey is set)
-    enabled: false
-    # -- Groq API key (ignored if providers.existingSecret is set)
-    apiKey: ""
-    # -- Optional: Override Groq base URL
-    baseUrl: ""
-
-  xai:
-    # -- Enable xAI (Grok) provider (auto-enabled if apiKey is set)
-    enabled: false
-    # -- xAI API key (ignored if providers.existingSecret is set)
-    apiKey: ""
-    # -- Optional: Override xAI base URL
-    baseUrl: ""
-
-  zai:
-    # -- Enable Z.ai provider (auto-enabled if apiKey is set)
-    enabled: false
-    # -- Z.ai API key (ignored if providers.existingSecret is set)
-    apiKey: ""
-    # -- Optional: Override Z.ai base URL; use https://api.z.ai/api/coding/paas/v4 for GLM Coding Plan
-    baseUrl: ""
-
-  kilo:
-    # -- Enable Kilo AI provider (auto-enabled if apiKey is set)
-    enabled: false
-    # -- Kilo AI API key (ignored if providers.existingSecret is set)
-    apiKey: ""
-    # -- Optional: Override Kilo AI Gateway base URL
-    baseUrl: ""
-
-  oracle:
-    # -- Enable Oracle provider (auto-enabled if apiKey is set)
-    enabled: false
-    # -- Oracle API key (ignored if providers.existingSecret is set)
-    apiKey: ""
-    # -- Required: Oracle OpenAI-compatible base URL
-    baseUrl: ""
-
-  vllm:
-    # -- Enable vLLM provider (API key optional; baseUrl required when enabled)
-    enabled: false
-    # -- Optional vLLM API key, matching vllm serve --api-key when configured
-    apiKey: ""
-    # -- vLLM OpenAI-compatible base URL
-    baseUrl: ""
-
-  llmd:
-    # -- Enable llm-d provider (API key optional; baseUrl required when enabled)
-    enabled: false
-    # -- Optional bearer token required by the Gateway in front of llm-d
-    apiKey: ""
-    # -- llm-d Router / EPP OpenAI-compatible base URL
-    baseUrl: ""
-    # -- Optional trusted llm-d InferenceObjective name
-    inferenceObjective: ""
-    # -- Derive the llm-d fairness ID from GoModel's effective user path
-    fairnessFromUserPath: true
-
-  sglang:
-    # -- Enable SGLang provider (API key optional; baseUrl required when enabled)
-    enabled: false
-    # -- Optional SGLang API key, matching launch_server --api-key when configured
-    apiKey: ""
-    # -- SGLang OpenAI-compatible base URL
-    baseUrl: ""
-
-# Cache configuration
-cache:
-  redis:
-    # -- Redis connection URL (e.g., "redis://redis:6379")
-    # If redis.enabled is true, this is auto-configured to use the subchart.
-    # Set this explicitly to use an external Redis instance instead.
-    url: ""
-    # -- Redis key prefix for storing the model cache
-    keyModels: "gomodel:models"
-    # -- TTL for model cache data in seconds (default: 24 hours)
-    ttlModels: 86400
-    # -- Redis key prefix for storing the response cache
-    keyResponses: "gomodel:response:"
-    # -- TTL for response cache data in seconds (default: 1 hour)
-    ttlResponses: 3600
-
-# Redis subchart configuration (Bitnami Redis)
-redis:
-  # -- Deploy Redis subchart
+# Persistent volume for /app/data (SQLite database, install identity).
+# Only used with storage.type sqlite; other backends keep nothing on disk.
+persistence:
   enabled: true
-  # -- Redis architecture: standalone or replication
-  architecture: standalone
-  auth:
-    # -- Disable Redis authentication for simplicity
-    enabled: false
-  master:
-    persistence:
-      # -- Disable persistence for standalone mode
-      enabled: false
+  # -- Use an existing PersistentVolumeClaim instead of creating one.
+  existingClaim: ""
+  # -- StorageClass name. Empty uses the cluster default; "-" disables dynamic provisioning.
+  storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+  size: 1Gi
+  annotations: {}
 
-# Prometheus metrics configuration
+# -- Deployment update strategy. Defaults to Recreate when SQLite data lives on a
+# ReadWriteOnce volume (two pods cannot share it), RollingUpdate otherwise.
+updateStrategy: {}
+
 metrics:
-  # -- Enable Prometheus metrics
+  # -- Expose Prometheus metrics at /metrics (unauthenticated).
   enabled: true
-  # -- Metrics endpoint path
-  endpoint: "/metrics"
-
   serviceMonitor:
-    # -- Create a ServiceMonitor for Prometheus Operator
+    # -- Create a ServiceMonitor for the Prometheus Operator.
     enabled: false
-    # ServiceMonitor path is automatically prefixed with server.basePath.
-    # -- Scrape interval
-    interval: "15s"
-    # -- Additional labels for the ServiceMonitor
+    interval: 30s
+    # -- Namespace for the ServiceMonitor. Empty uses the release namespace.
+    namespace: ""
     labels: {}
 
-# Logging configuration
-logging:
-  # -- Log format; leave empty to auto-detect, or set to "json" or "text"
-  format: ""
-
-# Kubernetes Service configuration
 service:
-  # -- Service type: ClusterIP, LoadBalancer, NodePort
   type: ClusterIP
-  # -- Service port
   port: 8080
-  # -- Service annotations
   annotations: {}
 
-# Ingress configuration
 ingress:
-  # -- Enable Ingress
   enabled: false
-  # -- Ingress class name
   className: ""
-  # -- Ingress annotations
   annotations: {}
-  # -- Ingress hosts configuration
   hosts:
-    - host: gomodel.local
+    - host: gomodel.example.com
       paths:
         - path: /
           pathType: Prefix
-  # -- Ingress TLS configuration
   tls: []
   #  - secretName: gomodel-tls
   #    hosts:
-  #      - gomodel.local
+  #      - gomodel.example.com
 
-# Gateway API configuration
-gateway:
-  # -- Enable Gateway API HTTPRoute
+# Gateway API HTTPRoute, an alternative to Ingress.
+httpRoute:
   enabled: false
-  # -- Parent Gateway reference
-  parentRef:
-    # -- Gateway name
-    name: ""
-    # -- Gateway namespace (defaults to release namespace)
-    namespace: ""
-  # -- Hostnames for the HTTPRoute
+  parentRefs: []
+  #  - name: my-gateway
+  #    namespace: gateway-system
   hostnames: []
   #  - gomodel.example.com
 
-# Resource requests and limits
+serviceAccount:
+  create: true
+  # -- Annotations, for example cloud IAM bindings (AWS Bedrock, Google Vertex AI).
+  annotations: {}
+  name: ""
+  automountServiceAccountToken: false
+
 resources:
   requests:
     cpu: 100m
     memory: 128Mi
   limits:
-    cpu: 1000m
     memory: 512Mi
 
-# Horizontal Pod Autoscaler configuration
 autoscaling:
-  # -- Enable HPA
   enabled: false
-  # -- Minimum replicas
   minReplicas: 2
-  # -- Maximum replicas
   maxReplicas: 10
-  # -- Target CPU utilization percentage
   targetCPUUtilizationPercentage: 70
-  # -- Target memory utilization percentage (optional)
-  # targetMemoryUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: null
 
-# Pod Disruption Budget configuration
+# Created only when more than one replica can run, so a single pod never blocks node drains.
 podDisruptionBudget:
-  # -- Enable PDB
   enabled: true
-  # -- Minimum available pods
   minAvailable: 1
-  # -- Maximum unavailable pods (alternative to minAvailable)
-  # maxUnavailable: 1
+  maxUnavailable: null
 
-# Liveness probe configuration
-# httpGet.path is automatically prefixed with server.basePath.
+# Probe paths are prefixed with env.BASE_PATH automatically.
 livenessProbe:
   httpGet:
     path: /health
     port: http
-  initialDelaySeconds: 10
+  initialDelaySeconds: 5
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 3
 
-# Readiness probe configuration
-# httpGet.path is automatically prefixed with server.basePath.
+# /health/ready returns 503 while storage is unreachable.
 readinessProbe:
   httpGet:
-    path: /health
+    path: /health/ready
     port: http
-  initialDelaySeconds: 5
   periodSeconds: 5
-  timeoutSeconds: 3
+  timeoutSeconds: 5
   failureThreshold: 3
 
-# Pod security context
+# -- GoModel drains requests for 10s and finishes teardown within 30s after SIGTERM.
+terminationGracePeriodSeconds: 45
+
+# The image runs as the distroless nonroot user (UID 65532).
 podSecurityContext:
   runAsNonRoot: true
-  runAsUser: 1000
-  fsGroup: 1000
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
 
-# Container security context
 securityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
-  runAsNonRoot: true
-  runAsUser: 1000
   capabilities:
     drop:
       - ALL
 
-# -- Node selector
-nodeSelector: {}
-
-# -- Tolerations
-tolerations: []
-
-# -- Affinity rules
-affinity: {}
-
-# -- Additional pod annotations
 podAnnotations: {}
-
-# -- Additional pod labels
 podLabels: {}
+priorityClassName: ""
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+
+# -- Extra volumes and mounts, for example a CA bundle or a local model catalog file.
+extraVolumes: []
+extraVolumeMounts: []

--- a/internal/storage/sqlx/conformance_test.go
+++ b/internal/storage/sqlx/conformance_test.go
@@ -443,3 +443,29 @@ func TestInTxIsAtomicUnderConcurrency(t *testing.T) {
 		}
 	})
 }
+
+func TestSchemaToleratesConcurrentApplication(t *testing.T) {
+	sqlxtest.Run(t, func(t *testing.T, db sqlx.DB) {
+		// Several gateway replicas boot against one empty database at the
+		// same time, and every store constructor applies its schema on
+		// start. PostgreSQL's CREATE TABLE IF NOT EXISTS is not atomic
+		// across sessions: two of them racing on a missing table make the
+		// loser fail with a duplicate pg_type key instead of a no-op.
+		const workers = 8
+		errs := make(chan error, workers)
+		start := make(chan struct{})
+		for range workers {
+			go func() {
+				<-start
+				errs <- db.Schema(context.Background(), conformanceSchema,
+					`CREATE INDEX IF NOT EXISTS conformance_updated_at ON conformance (updated_at)`)
+			}()
+		}
+		close(start)
+		for range workers {
+			if err := <-errs; err != nil {
+				t.Errorf("concurrent schema application failed: %v", err)
+			}
+		}
+	})
+}

--- a/internal/storage/sqlx/conformance_test.go
+++ b/internal/storage/sqlx/conformance_test.go
@@ -451,6 +451,13 @@ func TestSchemaToleratesConcurrentApplication(t *testing.T) {
 		// start. PostgreSQL's CREATE TABLE IF NOT EXISTS is not atomic
 		// across sessions: two of them racing on a missing table make the
 		// loser fail with a duplicate pg_type key instead of a no-op.
+		//
+		// SQLite is single-instance by design (one process applies its
+		// schema store by store), so the property is only pinned for
+		// PostgreSQL.
+		if db.Dialect() != sqlx.PostgreSQL {
+			t.Skip("concurrent schema application is a PostgreSQL property")
+		}
 		const workers = 8
 		errs := make(chan error, workers)
 		start := make(chan struct{})

--- a/internal/storage/sqlx/postgres.go
+++ b/internal/storage/sqlx/postgres.go
@@ -38,8 +38,27 @@ func (p *postgresDB) QueryRow(ctx context.Context, query string, args ...any) Ro
 	return pgQueryRow(ctx, p.pool, query, args...)
 }
 
+// postgresSchemaLockKey is the advisory lock every Schema call takes. One key
+// for the whole gateway is deliberate: each store's DDL is short, and the
+// alternative (a key per store) buys nothing while making the lock easy to
+// forget in a new store.
+const postgresSchemaLockKey int64 = 0x676f6d6f64656c
+
+// Schema applies DDL inside one transaction that holds an advisory lock.
+//
+// PostgreSQL's CREATE TABLE IF NOT EXISTS checks and creates in two steps, so
+// two sessions racing on a missing table leave the loser with a duplicate
+// pg_type key error instead of a no-op. Several replicas booting against one
+// fresh database hit exactly that. The transaction-scoped lock serializes
+// them: the second replica waits, then finds every table present.
+// PostgreSQL DDL is transactional, so a failure leaves nothing half-applied.
 func (p *postgresDB) Schema(ctx context.Context, statements ...string) error {
-	return execSchema(ctx, p, PostgreSQL, statements)
+	return p.InTx(ctx, func(q Querier) error {
+		if _, err := q.Exec(ctx, "SELECT pg_advisory_xact_lock(?)", postgresSchemaLockKey); err != nil {
+			return fmt.Errorf("acquire schema lock: %w", err)
+		}
+		return execSchema(ctx, q, PostgreSQL, statements)
+	})
 }
 
 func (p *postgresDB) InTx(ctx context.Context, fn func(Querier) error) error {

--- a/internal/storage/sqlx/schema.go
+++ b/internal/storage/sqlx/schema.go
@@ -8,10 +8,11 @@ import (
 
 // execSchema runs DDL statements in order with portable type tokens expanded.
 //
-// Statements run outside a transaction: SQLite cannot run every schema change
-// transactionally, and `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT
-// EXISTS` are individually idempotent, so a partial application is safe to
-// retry on the next start.
+// On SQLite the statements run outside a transaction: it cannot run every
+// schema change transactionally, and `CREATE TABLE IF NOT EXISTS` / `CREATE
+// INDEX IF NOT EXISTS` are individually idempotent, so a partial application
+// is safe to retry on the next start. PostgreSQL wraps them in a locked
+// transaction instead; see postgresDB.Schema.
 func execSchema(ctx context.Context, q Querier, dialect Dialect, statements []string) error {
 	for _, statement := range statements {
 		if _, err := q.Exec(ctx, dialect.ExpandTypes(statement)); err != nil {

--- a/internal/usage/pricing_timewindow_test.go
+++ b/internal/usage/pricing_timewindow_test.go
@@ -276,3 +276,33 @@ func TestMongoDBStoreRecalculatePricingAppliesTimeWindowsFromStoredTimestamps(t 
 		return doc.TotalCost
 	})
 }
+
+func TestNewPostgreSQLStoreToleratesConcurrentStartup(t *testing.T) {
+	pool := sqlxtest.NewPostgresPool(t)
+	if pool == nil {
+		return // skipped: no test server configured
+	}
+
+	// Several replicas construct the store against one fresh database at
+	// once; every DDL statement must serialize instead of failing the
+	// losing replica's startup.
+	const workers = 8
+	errs := make(chan error, workers)
+	start := make(chan struct{})
+	for range workers {
+		go func() {
+			<-start
+			store, err := NewPostgreSQLStore(pool, 0)
+			if err == nil {
+				err = store.Close()
+			}
+			errs <- err
+		}()
+	}
+	close(start)
+	for range workers {
+		if err := <-errs; err != nil {
+			t.Errorf("concurrent NewPostgreSQLStore() error = %v", err)
+		}
+	}
+}

--- a/internal/usage/store_postgresql.go
+++ b/internal/usage/store_postgresql.go
@@ -56,14 +56,14 @@ func NewPostgreSQLStore(pool *pgxpool.Pool, retentionDays int) (*PostgreSQLStore
 
 	ctx := context.Background()
 
-	// Create table for usage tracking. sqlx.DB.Schema serializes concurrent
-	// replicas with an advisory lock, so a fresh database can be brought up
-	// by several pods at once.
+	// Every DDL statement goes through sqlx.DB.Schema, which serializes
+	// concurrent replicas with an advisory lock, so a fresh database can be
+	// brought up by several pods at once.
 	schema, err := sqlx.NewPostgreSQL(pool)
 	if err != nil {
 		return nil, err
 	}
-	err = schema.Schema(ctx, `
+	createTable := `
 		CREATE TABLE IF NOT EXISTS usage (
 			id UUID PRIMARY KEY,
 			request_id TEXT NOT NULL,
@@ -83,10 +83,7 @@ func NewPostgreSQLStore(pool *pgxpool.Pool, retentionDays int) (*PostgreSQLStore
 			rewrite_cost_saved DOUBLE PRECISION,
 			raw_data JSONB
 		)
-	`)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create usage table: %w", err)
-	}
+	`
 
 	// Add cost columns (idempotent via IF NOT EXISTS)
 	costMigrations := []string{
@@ -103,10 +100,8 @@ func NewPostgreSQLStore(pool *pgxpool.Pool, retentionDays int) (*PostgreSQLStore
 		"ALTER TABLE usage ADD COLUMN IF NOT EXISTS rewrite_tokens_saved INTEGER NOT NULL DEFAULT 0",
 		"ALTER TABLE usage ADD COLUMN IF NOT EXISTS rewrite_cost_saved DOUBLE PRECISION",
 	}
-	for _, migration := range costMigrations {
-		if _, err := pool.Exec(ctx, migration); err != nil {
-			return nil, fmt.Errorf("failed to run migration: %w", err)
-		}
+	if err := schema.Schema(ctx, append([]string{createTable}, costMigrations...)...); err != nil {
+		return nil, fmt.Errorf("failed to create usage table: %w", err)
 	}
 
 	// Create indexes for common queries
@@ -124,7 +119,7 @@ func NewPostgreSQLStore(pool *pgxpool.Pool, retentionDays int) (*PostgreSQLStore
 		"CREATE INDEX IF NOT EXISTS idx_usage_raw_data_gin ON usage USING GIN (raw_data)",
 	}
 	for _, idx := range indexes {
-		if _, err := pool.Exec(ctx, idx); err != nil {
+		if err := schema.Schema(ctx, idx); err != nil {
 			slog.Warn("failed to create index", "error", err)
 		}
 	}

--- a/internal/usage/store_postgresql.go
+++ b/internal/usage/store_postgresql.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/enterpilot/gomodel/internal/storage"
 	"github.com/enterpilot/gomodel/internal/storage/sqlutil"
+	"github.com/enterpilot/gomodel/internal/storage/sqlx"
 )
 
 const (
@@ -55,8 +56,14 @@ func NewPostgreSQLStore(pool *pgxpool.Pool, retentionDays int) (*PostgreSQLStore
 
 	ctx := context.Background()
 
-	// Create table for usage tracking
-	_, err := pool.Exec(ctx, `
+	// Create table for usage tracking. sqlx.DB.Schema serializes concurrent
+	// replicas with an advisory lock, so a fresh database can be brought up
+	// by several pods at once.
+	schema, err := sqlx.NewPostgreSQL(pool)
+	if err != nil {
+		return nil, err
+	}
+	err = schema.Schema(ctx, `
 		CREATE TABLE IF NOT EXISTS usage (
 			id UUID PRIMARY KEY,
 			request_id TEXT NOT NULL,


### PR DESCRIPTION
## Description

Rewrites the Helm chart in `helm/` so it works out of the box against the published image, and fixes a startup race it exposed.

**Chart (0.2.0)**

- Configuration is now generic: any variable from `.env.template` goes in `env` (ConfigMap) or `secretEnv` (Secret), or comes from your own Secret through `extraEnvFrom`. An optional inline `config` is mounted as `config.yaml`. This replaces the hard-coded provider list, which was already missing several providers.
- Runs as the image's UID 65532 with a read-only root filesystem and writable `/app/data` and `/app/.cache` volumes. The old chart used UID 1000, so SQLite could not be written.
- `storage.type` selects sqlite, postgresql, or mongodb. SQLite data lives on a PVC with a Recreate strategy; the chart refuses more than one replica or autoscaling on SQLite, and refuses postgresql or mongodb without a URL.
- Readiness uses `/health/ready`. Probe, metrics, and HTTPRoute paths follow `env.BASE_PATH`.
- Removes the Bitnami Redis subchart; point `env.REDIS_URL` at your own Redis.
- Adds a ServiceAccount with annotations for cloud IAM, a `helm test` pod, a PDB that renders only when more than one pod can run, a 45s termination grace period, and a values schema.
- New `helm.yml` workflow lints, validates with kubeconform, and installs the chart on kind with SQLite and with two replicas on PostgreSQL. `make helm-lint` runs the first two locally. README documents values and the 0.1.x migration.

**Storage fix**

Two replicas booting against a fresh PostgreSQL database raced on `CREATE TABLE IF NOT EXISTS`, and the loser failed with `duplicate key value violates unique constraint "pg_type_typname_nsp_index"`. `sqlx.DB.Schema` on PostgreSQL now runs inside a transaction holding an advisory lock, and the usage store's table creation goes through the same path. A new conformance test applies a schema from eight goroutines at once; it reproduced the error before the fix.

**Verified**

Installed on a kind cluster: `helm test` passes, the process runs as 65532, an admin-created key survives pod replacement on the PVC, an inline `config.yaml` upgrade is picked up, and a two-replica PostgreSQL release reaches ready with a PDB. Go tests were run with `GOMODEL_TEST_POSTGRES_URL` set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Helm chart 0.2.0 adds environment-based configuration, optional PostgreSQL/MongoDB storage, persistent SQLite volumes, HTTP routes, service accounts, extra volumes, and topology controls.
  * Added support for custom configuration files, secret environment variables, autoscaling, monitoring, and improved ingress settings.
  * Added readiness checks, Helm connection tests, and PostgreSQL schema coordination for multi-replica deployments.

* **Documentation**
  * Updated production guidance and Helm documentation with new configuration, storage, upgrade, and testing instructions.

* **Chores**
  * Added automated Helm linting, Kubernetes manifest validation, and installation testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->