### PR TITLE
feat(server): drop clients that stop reading model responses

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,6 +4,12 @@
 # BASE_PATH=/g
 # Header used to read/write request user_path values (default: X-GoModel-User-Path)
 # USER_PATH_HEADER=X-GoModel-User-Path
+# How long one response write on a model route may wait for the client to read it,
+# in seconds (default: 60). Fires only when a client stops reading a response, never
+# while the provider is slow, and frees the goroutine and upstream connection that
+# client would otherwise hold. 0 disables it. Raise it for clients that legitimately
+# pause reading a stream for over a minute.
+# STREAM_STALL_TIMEOUT=60
 
 # Where the running gateway records its process id so `gomodel --reload` can find it
 # (default: data/gomodel.pid next to a ./data directory, otherwise the per-user data

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -8,6 +8,7 @@ server:
   base_path: "/" # env: BASE_PATH; set to "/g" to serve the gateway under https://example.com/g/
   master_key: "your-secret-key"
   body_size_limit: "10M"
+  stream_stall_timeout: 60 # env: STREAM_STALL_TIMEOUT; seconds one response write on a model route may wait for the client to read it. Fires only when a client stops reading, never while the provider is slow; 0 disables
   swagger_enabled: false # env: SWAGGER_ENABLED; requires a binary built with -tags=swagger
   pprof_enabled: false # expose /debug/pprof/* for local profiling only
   enable_passthrough_routes: true # expose /p/{provider}/{endpoint} passthrough routes

--- a/config/config.go
+++ b/config/config.go
@@ -114,6 +114,7 @@ func buildDefaultConfig() *Config {
 			EnablePassthroughRoutes: true,
 			AllowPassthroughV1Alias: true,
 			RealtimeEnabled:         true,
+			StreamStallTimeout:      DefaultStreamStallTimeoutSeconds,
 			EnabledPassthroughProviders: []string{
 				"openai",
 				"anthropic",
@@ -323,6 +324,9 @@ func Load() (*LoadResult, error) {
 		if err := ValidateBodySizeLimit(cfg.Server.BodySizeLimit); err != nil {
 			return nil, fmt.Errorf("invalid BODY_SIZE_LIMIT: %w", err)
 		}
+	}
+	if cfg.Server.StreamStallTimeout < 0 {
+		return nil, fmt.Errorf("server.stream_stall_timeout must be 0 or a positive number of seconds; got %d", cfg.Server.StreamStallTimeout)
 	}
 
 	if err := ValidateCacheConfig(&cfg.Cache); err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -61,7 +61,7 @@ func clearAllConfigEnvVars(t *testing.T) {
 	t.Helper()
 	for _, key := range []string{
 		"CONFIG_STRICT",
-		"PORT", "BASE_PATH", "GOMODEL_MASTER_KEY", "BODY_SIZE_LIMIT", "SWAGGER_ENABLED", "PPROF_ENABLED", "ENABLE_PASSTHROUGH_ROUTES", "ALLOW_PASSTHROUGH_V1_ALIAS", "USER_PATH_HEADER", "ENABLED_PASSTHROUGH_PROVIDERS",
+		"PORT", "BASE_PATH", "GOMODEL_MASTER_KEY", "BODY_SIZE_LIMIT", "STREAM_STALL_TIMEOUT", "SWAGGER_ENABLED", "PPROF_ENABLED", "ENABLE_PASSTHROUGH_ROUTES", "ALLOW_PASSTHROUGH_V1_ALIAS", "USER_PATH_HEADER", "ENABLED_PASSTHROUGH_PROVIDERS",
 		"GOMODEL_CACHE_DIR", "CACHE_REFRESH_INTERVAL", "MODEL_LIST_URL", "GOMODEL_OFFLINE", "GOMODEL_VERSION_CHECK_ENABLED",
 		"REDIS_URL", "REDIS_KEY_MODELS", "REDIS_KEY_RESPONSES", "REDIS_TTL_MODELS", "REDIS_TTL_RESPONSES",
 		"RESPONSE_CACHE_SIMPLE_ENABLED",
@@ -137,6 +137,9 @@ func TestBuildDefaultConfig(t *testing.T) {
 	}
 	if cfg.Server.SwaggerEnabled {
 		t.Error("expected Server.SwaggerEnabled=false")
+	}
+	if cfg.Server.StreamStallTimeout != DefaultStreamStallTimeoutSeconds {
+		t.Errorf("expected Server.StreamStallTimeout=%d, got %d", DefaultStreamStallTimeoutSeconds, cfg.Server.StreamStallTimeout)
 	}
 	if !cfg.Server.EnablePassthroughRoutes {
 		t.Error("expected Server.EnablePassthroughRoutes=true")
@@ -2290,4 +2293,67 @@ func TestIsLocalModelListSource(t *testing.T) {
 			t.Errorf("IsLocalModelListSource(%q) = %v, want %v", tt.in, got, tt.want)
 		}
 	}
+}
+
+func TestLoad_StreamStallTimeout(t *testing.T) {
+	clearAllConfigEnvVars(t)
+
+	withTempDir(t, func(_ string) {
+		result, err := Load()
+		if err != nil {
+			t.Fatalf("Load() failed: %v", err)
+		}
+		if got := result.Config.Server.StreamStallTimeout; got != DefaultStreamStallTimeoutSeconds {
+			t.Fatalf("Server.StreamStallTimeout = %d, want %d", got, DefaultStreamStallTimeoutSeconds)
+		}
+	})
+
+	withTempDir(t, func(dir string) {
+		yaml := `
+server:
+  stream_stall_timeout: 0
+`
+		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(yaml), 0644); err != nil {
+			t.Fatalf("Failed to write config.yaml: %v", err)
+		}
+
+		result, err := Load()
+		if err != nil {
+			t.Fatalf("Load() failed: %v", err)
+		}
+		if got := result.Config.Server.StreamStallTimeout; got != 0 {
+			t.Fatalf("Server.StreamStallTimeout = %d, want 0 (disabled by YAML)", got)
+		}
+	})
+
+	withTempDir(t, func(dir string) {
+		yaml := `
+server:
+  stream_stall_timeout: 120
+`
+		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(yaml), 0644); err != nil {
+			t.Fatalf("Failed to write config.yaml: %v", err)
+		}
+		t.Setenv("STREAM_STALL_TIMEOUT", "15")
+
+		result, err := Load()
+		if err != nil {
+			t.Fatalf("Load() failed: %v", err)
+		}
+		if got := result.Config.Server.StreamStallTimeout; got != 15 {
+			t.Fatalf("Server.StreamStallTimeout = %d, want 15 (env over YAML)", got)
+		}
+	})
+
+	withTempDir(t, func(_ string) {
+		t.Setenv("STREAM_STALL_TIMEOUT", "-1")
+
+		_, err := Load()
+		if err == nil {
+			t.Fatal("expected Load() to reject a negative STREAM_STALL_TIMEOUT")
+		}
+		if !strings.Contains(err.Error(), "server.stream_stall_timeout") {
+			t.Fatalf("Load() error = %v, want server.stream_stall_timeout", err)
+		}
+	})
 }

--- a/config/server.go
+++ b/config/server.go
@@ -54,7 +54,21 @@ type ServerConfig struct {
 	// needs a restart — it names the process that is already running — so a
 	// reload only warns about it.
 	PIDFile string `yaml:"pid_file" env:"PID_FILE"`
+	// StreamStallTimeout bounds, in seconds, how long a single response write
+	// on a model interaction route may wait for the client to accept bytes
+	// before the connection is dropped. It fires only when the client has
+	// stopped reading (its socket buffer is full), never while the gateway is
+	// waiting on the provider, so slow models are unaffected. Without it a
+	// client that stops reading a stream pins a goroutine and the upstream
+	// provider connection until the provider side times out.
+	// Default: 60 (DefaultStreamStallTimeoutSeconds). 0 disables the limit.
+	StreamStallTimeout int `yaml:"stream_stall_timeout" env:"STREAM_STALL_TIMEOUT"`
 }
+
+// DefaultStreamStallTimeoutSeconds is the default ServerConfig.StreamStallTimeout.
+// It matches the send timeout most reverse proxies apply between two
+// successive writes to a client.
+const DefaultStreamStallTimeoutSeconds = 60
 
 // LegacyPIDFilePath is the pid file location used next to a project-local
 // ./data directory, matching where the SQLite database lands in the same setup.

--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -46,9 +46,18 @@ The most common way to configure GoModel. Set any of the variables below to over
 | `GOMODEL_MASTER_KEY` | Authentication key for securing the gateway           | _(empty, unsafe mode)_ |
 | `GOMODEL_DEMO_MODE`  | Enable public demo warnings in logs and the dashboard  | `false`                |
 | `BODY_SIZE_LIMIT`    | Max request body size (e.g., `10M`, `1024K`, `500KB`) | _(no limit)_           |
+| `STREAM_STALL_TIMEOUT` | Seconds one response write on a model route may wait for the client to read it; `0` disables | `60`                   |
 | `USER_PATH_HEADER`   | Header used to read/write request `user_path` values  | `X-GoModel-User-Path`  |
 | `SWAGGER_ENABLED`    | Expose [Swagger UI](/advanced/swagger-ui); needs a `-tags=swagger` build | `false`                |
 | `PID_FILE`           | Where the running gateway records its process id for `gomodel --reload`. Changing it needs a restart | `data/gomodel.pid` next to a `./data` directory, otherwise the per-user data directory |
+
+`STREAM_STALL_TIMEOUT` (`server.stream_stall_timeout` in YAML) protects the
+gateway from clients that open a streaming response and stop reading it. Each
+write to the client gets a fresh deadline, so it fires only when the client's
+socket stays full for that long, never while a slow model has nothing to send.
+When it fires the connection is closed, the upstream provider request is
+cancelled, and the audit entry records `client_stalled`. Raise it for clients
+that legitimately pause reading a stream for over a minute; set `0` to disable.
 
 Set `GOMODEL_DEMO_MODE=true` for a public or shared demonstration instance.
 GoModel logs a warning at startup and every five minutes, renders a persistent

--- a/docs/guides/production.mdx
+++ b/docs/guides/production.mdx
@@ -391,6 +391,10 @@ if the file size matters.
 - **Keep `BODY_SIZE_LIMIT` sane.** It defaults to `10M` and is what stops an
   oversized body becoming a memory-exhaustion vector. An unparseable value falls
   back to the default with only a warning, so check the spelling.
+- **Keep `STREAM_STALL_TIMEOUT` on.** It defaults to `60` seconds and is what
+  frees the goroutine and upstream provider connection a client holds when it
+  opens a stream and stops reading. Disabling it (`0`) lets such a client pin
+  both until the provider-side `HTTP_TIMEOUT` expires.
 - **Leave `pprof` disabled.** It is off by default and unauthenticated when on.
 - **Scope managed API keys.** Give each consumer its own key with its own
   [user path](/features/user-path), which is also what makes per-consumer rate

--- a/internal/app/init_server.go
+++ b/internal/app/init_server.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/labstack/echo/v5"
 
@@ -123,6 +124,7 @@ func (b *bootstrap) initServerConfig() error {
 		MetricsEnabled:                  appCfg.Metrics.Enabled,
 		MetricsEndpoint:                 appCfg.Metrics.Endpoint,
 		BodySizeLimit:                   appCfg.Server.BodySizeLimit,
+		StreamStallTimeout:              time.Duration(appCfg.Server.StreamStallTimeout) * time.Second,
 		PprofEnabled:                    appCfg.Server.PprofEnabled,
 		AuditLogger:                     app.audit.Logger,
 		UsageLogger:                     b.serverUsageLogger,

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -2411,6 +2411,20 @@ func TestRecordStreamingError_ClassifiesClientDisconnect(t *testing.T) {
 			err:      nil,
 			wantType: "client_disconnected",
 		},
+		{
+			name:     "stall deadline expiry",
+			ctx:      context.Background(),
+			err:      fmt.Errorf("%w for 1m0s: write tcp: i/o timeout", ErrClientStall),
+			wantType: "client_stalled",
+		},
+		{
+			// net/http cancels the request context once a write fails, so a
+			// stall usually arrives with a canceled ctx; the stall still wins.
+			name:     "stall deadline expiry with canceled ctx",
+			ctx:      canceledCtx,
+			err:      fmt.Errorf("%w for 1m0s: write tcp: i/o timeout", ErrClientStall),
+			wantType: "client_stalled",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -72,6 +72,7 @@ type Config struct {
 	MetricsEnabled                  bool                                   // Whether to expose Prometheus metrics endpoint
 	MetricsEndpoint                 string                                 // HTTP path for metrics endpoint (default: /metrics)
 	BodySizeLimit                   string                                 // Max request body size (e.g., "10M", "1024K")
+	StreamStallTimeout              time.Duration                          // Max time one response write on a model route waits for the client to read; 0 disables
 	PprofEnabled                    bool                                   // Whether to expose debug profiling routes at /debug/pprof/*
 	AuditLogger                     auditlog.LoggerInterface               // Optional: Audit logger for request/response logging
 	AuditReader                     auditlog.Reader                        // Optional: audit lookup used for dashboard interaction continuations
@@ -328,7 +329,7 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 	}
 	e.Use(middleware.BodyLimit(parseBodySizeLimitBytes(bodySizeLimit)))
 
-	e.Use(modelInteractionWriteDeadlineMiddleware())
+	e.Use(modelInteractionWriteDeadlineMiddleware(streamStallTimeout(cfg)))
 
 	// Ingress capture (before auth/audit/model validation so they can consume
 	// shared raw request state). Also assigns the per-request ID: the snapshot
@@ -661,22 +662,48 @@ func configureGatewayHTTPServer(server *http.Server) error {
 	return nil
 }
 
-func modelInteractionWriteDeadlineMiddleware() echo.MiddlewareFunc {
+// modelInteractionWriteDeadlineMiddleware swaps the server-wide absolute
+// write deadline for a per-write stall deadline on model interaction routes:
+// a model response may run for minutes, but no single write to the client
+// should wait longer than stallTimeout for the client to read. A stallTimeout
+// of zero only clears the absolute deadline, leaving writes unbounded.
+func modelInteractionWriteDeadlineMiddleware(stallTimeout time.Duration) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c *echo.Context) error {
 			if !core.IsModelInteractionPath(c.Request().URL.Path) {
 				return next(c)
 			}
-			if err := http.NewResponseController(c.Response()).SetWriteDeadline(time.Time{}); err != nil && !errors.Is(err, http.ErrNotSupported) {
+			res := c.Response()
+			ctl := http.NewResponseController(res)
+			if err := ctl.SetWriteDeadline(time.Time{}); err != nil && !errors.Is(err, http.ErrNotSupported) {
 				slog.Warn("failed to clear write deadline for model interaction",
 					"path", c.Request().URL.Path,
 					"request_id", requestIDFromContextOrHeader(c.Request()),
 					"error", err,
 				)
 			}
-			return next(c)
+			if stallTimeout <= 0 {
+				return next(c)
+			}
+			c.SetResponse(newStallDeadlineWriter(res, stallTimeout))
+			err := next(c)
+			// The handler's last deadline would otherwise still apply to the
+			// trailing writes net/http makes after it returns (the chunked
+			// terminator), which may come much later than the last body write.
+			_ = ctl.SetWriteDeadline(time.Time{})
+			return err
 		}
 	}
+}
+
+// streamStallTimeout resolves the per-write client stall deadline for model
+// interaction routes. A nil config (tests constructing the server directly)
+// gets the documented default; an explicit zero disables it.
+func streamStallTimeout(cfg *Config) time.Duration {
+	if cfg == nil {
+		return time.Duration(config.DefaultStreamStallTimeoutSeconds) * time.Second
+	}
+	return cfg.StreamStallTimeout
 }
 
 func parseBodySizeLimitBytes(limit string) int64 {

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -673,8 +673,7 @@ func modelInteractionWriteDeadlineMiddleware(stallTimeout time.Duration) echo.Mi
 			if !core.IsModelInteractionPath(c.Request().URL.Path) {
 				return next(c)
 			}
-			res := c.Response()
-			ctl := http.NewResponseController(res)
+			ctl := http.NewResponseController(c.Response())
 			if err := ctl.SetWriteDeadline(time.Time{}); err != nil && !errors.Is(err, http.ErrNotSupported) {
 				slog.Warn("failed to clear write deadline for model interaction",
 					"path", c.Request().URL.Path,
@@ -685,8 +684,20 @@ func modelInteractionWriteDeadlineMiddleware(stallTimeout time.Duration) echo.Mi
 			if stallTimeout <= 0 {
 				return next(c)
 			}
-			c.SetResponse(newStallDeadlineWriter(res, stallTimeout))
-			err := next(c)
+			// Installed beneath echo's Response rather than around it, so the
+			// stall writer sees the connection's own flush errors and stays
+			// hidden from the wrappers later middleware adds on top.
+			res, err := echo.UnwrapResponse(c.Response())
+			if err != nil {
+				slog.Warn("stream stall timeout not applied: response writer cannot be unwrapped",
+					"path", c.Request().URL.Path,
+					"request_id", requestIDFromContextOrHeader(c.Request()),
+					"error", err,
+				)
+				return next(c)
+			}
+			res.ResponseWriter = newStallDeadlineWriter(res.ResponseWriter, stallTimeout)
+			err = next(c)
 			// The handler's last deadline would otherwise still apply to the
 			// trailing writes net/http makes after it returns (the chunked
 			// terminator), which may come much later than the last body write.

--- a/internal/server/http_start_test.go
+++ b/internal/server/http_start_test.go
@@ -81,7 +81,7 @@ func TestModelInteractionWriteDeadlineMiddleware_ClearsDeadlineForModelRoutes(t 
 			req := httptest.NewRequest(http.MethodPost, path, nil)
 			c := e.NewContext(req, writer)
 
-			handler := modelInteractionWriteDeadlineMiddleware()(func(c *echo.Context) error {
+			handler := modelInteractionWriteDeadlineMiddleware(0)(func(c *echo.Context) error {
 				return c.String(http.StatusOK, "ok")
 			})
 
@@ -98,13 +98,60 @@ func TestModelInteractionWriteDeadlineMiddleware_ClearsDeadlineForModelRoutes(t 
 	}
 }
 
+// With a stall timeout every write re-arms a deadline that far ahead, and the
+// handler's return clears it again so net/http's trailing writes are not held
+// to a deadline armed long before.
+func TestModelInteractionWriteDeadlineMiddleware_ArmsStallDeadlinePerWrite(t *testing.T) {
+	const stall = 45 * time.Second
+	e := echo.New()
+	writer := &deadlineTrackingWriter{ResponseRecorder: httptest.NewRecorder()}
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	c := e.NewContext(req, writer)
+
+	handler := modelInteractionWriteDeadlineMiddleware(stall)(func(c *echo.Context) error {
+		c.Response().WriteHeader(http.StatusOK)
+		for _, chunk := range []string{"data: one\n\n", "data: two\n\n"} {
+			if _, err := c.Response().Write([]byte(chunk)); err != nil {
+				return err
+			}
+			c.Response().(http.Flusher).Flush()
+		}
+		return nil
+	})
+
+	before := time.Now()
+	if err := handler(c); err != nil {
+		t.Fatalf("handler() error = %v", err)
+	}
+	after := time.Now()
+
+	// clear, then (write + flush) x 2, then clear.
+	if got := len(writer.deadlines); got != 6 {
+		t.Fatalf("deadline calls = %d, want 6: %v", got, writer.deadlines)
+	}
+	if !writer.deadlines[0].IsZero() {
+		t.Fatalf("first deadline = %v, want zero time", writer.deadlines[0])
+	}
+	if !writer.deadlines[5].IsZero() {
+		t.Fatalf("last deadline = %v, want zero time", writer.deadlines[5])
+	}
+	for i, deadline := range writer.deadlines[1:5] {
+		if deadline.Before(before.Add(stall)) || deadline.After(after.Add(stall)) {
+			t.Fatalf("deadline[%d] = %v, want within %v of the write", i+1, deadline, stall)
+		}
+	}
+	if got := writer.Body.String(); got != "data: one\n\ndata: two\n\n" {
+		t.Fatalf("body = %q, want both chunks relayed", got)
+	}
+}
+
 func TestModelInteractionWriteDeadlineMiddleware_LeavesNonModelRoutesUntouched(t *testing.T) {
 	e := echo.New()
 	writer := &deadlineTrackingWriter{ResponseRecorder: httptest.NewRecorder()}
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	c := e.NewContext(req, writer)
 
-	handler := modelInteractionWriteDeadlineMiddleware()(func(c *echo.Context) error {
+	handler := modelInteractionWriteDeadlineMiddleware(time.Minute)(func(c *echo.Context) error {
 		return c.String(http.StatusOK, "ok")
 	})
 

--- a/internal/server/stall_deadline.go
+++ b/internal/server/stall_deadline.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"net"
@@ -20,10 +21,17 @@ var ErrClientStall = errors.New("client stopped reading the response")
 // it: only a client that is not draining its socket can. It replaces the
 // server-wide WriteTimeout, an absolute deadline that model routes have to
 // clear because a single response can legitimately outlive it.
+//
+// It is installed directly on the connection's writer, beneath echo's
+// Response, because the flush methods of the wrappers above it (echo's, the
+// audit capture's) return no error. The first stall is therefore remembered
+// here and exposed through StallError, which is how a stall during the final
+// flush of a stream is still reported instead of being logged as a success.
 type stallDeadlineWriter struct {
 	http.ResponseWriter
-	ctl   *http.ResponseController
-	stall time.Duration
+	ctl     *http.ResponseController
+	stall   time.Duration
+	stalled error
 }
 
 func newStallDeadlineWriter(w http.ResponseWriter, stall time.Duration) *stallDeadlineWriter {
@@ -31,6 +39,9 @@ func newStallDeadlineWriter(w http.ResponseWriter, stall time.Duration) *stallDe
 }
 
 func (w *stallDeadlineWriter) Write(p []byte) (int, error) {
+	if w.stalled != nil {
+		return 0, w.stalled
+	}
 	w.armDeadline()
 	// p is relayed unchanged: the handler chose these bytes and their
 	// content type, so this wrapper adds no reflection. lgtm[go/reflected-xss]
@@ -41,6 +52,9 @@ func (w *stallDeadlineWriter) Write(p []byte) (int, error) {
 // FlushError is what http.ResponseController prefers over Flush, so a stalled
 // flush surfaces as an error to callers that go through the controller.
 func (w *stallDeadlineWriter) FlushError() error {
+	if w.stalled != nil {
+		return w.stalled
+	}
 	w.armDeadline()
 	return w.classify(w.ctl.Flush())
 }
@@ -49,10 +63,23 @@ func (w *stallDeadlineWriter) Flush() {
 	_ = w.FlushError()
 }
 
+// Hijack hands the connection over for WebSocket upgrades. The audit capture
+// above looks for http.Hijacker with a direct type assertion rather than
+// through Unwrap, so the method has to exist here. net/http clears the
+// connection deadlines as part of hijacking.
+func (w *stallDeadlineWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.ctl.Hijack()
+}
+
 // Unwrap lets http.ResponseController reach the connection for the
-// operations this wrapper does not intercept (deadlines, hijacking).
+// operations this wrapper does not intercept.
 func (w *stallDeadlineWriter) Unwrap() http.ResponseWriter {
 	return w.ResponseWriter
+}
+
+// StallError returns the stall that ended this response, or nil.
+func (w *stallDeadlineWriter) StallError() error {
+	return w.stalled
 }
 
 func (w *stallDeadlineWriter) armDeadline() {
@@ -61,12 +88,36 @@ func (w *stallDeadlineWriter) armDeadline() {
 	_ = w.ctl.SetWriteDeadline(time.Now().Add(w.stall))
 }
 
-// classify tags a deadline expiry as a client stall. Any other write error
-// (EPIPE, ECONNRESET) keeps its meaning of a client that went away.
+// classify tags a deadline expiry as a client stall and remembers it. Any
+// other write error (EPIPE, ECONNRESET) keeps its meaning of a client that
+// went away.
 func (w *stallDeadlineWriter) classify(err error) error {
 	var netErr net.Error
 	if err != nil && errors.As(err, &netErr) && netErr.Timeout() {
-		return fmt.Errorf("%w for %s: %w", ErrClientStall, w.stall, err)
+		w.stalled = fmt.Errorf("%w for %s: %w", ErrClientStall, w.stall, err)
+		return w.stalled
 	}
 	return err
+}
+
+// stallReporter is implemented by stallDeadlineWriter and looked up through
+// the Unwrap chain of whatever writer a handler holds.
+type stallReporter interface {
+	StallError() error
+}
+
+// findStallReporter walks the Unwrap chain from w down to the stall writer,
+// or returns nil when the route runs without one.
+func findStallReporter(w any) stallReporter {
+	for w != nil {
+		if reporter, ok := w.(stallReporter); ok {
+			return reporter
+		}
+		unwrapper, ok := w.(interface{ Unwrap() http.ResponseWriter })
+		if !ok {
+			return nil
+		}
+		w = unwrapper.Unwrap()
+	}
+	return nil
 }

--- a/internal/server/stall_deadline.go
+++ b/internal/server/stall_deadline.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+)
+
+// ErrClientStall reports that a response write on a model interaction route
+// timed out because the client stopped accepting bytes: its socket buffer
+// stayed full for the whole stream stall timeout.
+var ErrClientStall = errors.New("client stopped reading the response")
+
+// stallDeadlineWriter arms a fresh write deadline immediately before every
+// write and flush, so one operation may block for at most stall. The deadline
+// is re-armed per operation rather than measured from the previous one, so a
+// quiet provider (a long reasoning pause with nothing to send) never trips
+// it: only a client that is not draining its socket can. It replaces the
+// server-wide WriteTimeout, an absolute deadline that model routes have to
+// clear because a single response can legitimately outlive it.
+type stallDeadlineWriter struct {
+	http.ResponseWriter
+	ctl   *http.ResponseController
+	stall time.Duration
+}
+
+func newStallDeadlineWriter(w http.ResponseWriter, stall time.Duration) *stallDeadlineWriter {
+	return &stallDeadlineWriter{ResponseWriter: w, ctl: http.NewResponseController(w), stall: stall}
+}
+
+func (w *stallDeadlineWriter) Write(p []byte) (int, error) {
+	w.armDeadline()
+	n, err := w.ResponseWriter.Write(p)
+	return n, w.classify(err)
+}
+
+// FlushError is what http.ResponseController prefers over Flush, so a stalled
+// flush surfaces as an error to callers that go through the controller.
+func (w *stallDeadlineWriter) FlushError() error {
+	w.armDeadline()
+	return w.classify(w.ctl.Flush())
+}
+
+func (w *stallDeadlineWriter) Flush() {
+	_ = w.FlushError()
+}
+
+// Unwrap lets http.ResponseController reach the connection for the
+// operations this wrapper does not intercept (deadlines, hijacking).
+func (w *stallDeadlineWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
+func (w *stallDeadlineWriter) armDeadline() {
+	// A writer without deadline support (test recorders) keeps writes
+	// unbounded, exactly as they were before this wrapper existed.
+	_ = w.ctl.SetWriteDeadline(time.Now().Add(w.stall))
+}
+
+// classify tags a deadline expiry as a client stall. Any other write error
+// (EPIPE, ECONNRESET) keeps its meaning of a client that went away.
+func (w *stallDeadlineWriter) classify(err error) error {
+	var netErr net.Error
+	if err != nil && errors.As(err, &netErr) && netErr.Timeout() {
+		return fmt.Errorf("%w for %s: %w", ErrClientStall, w.stall, err)
+	}
+	return err
+}

--- a/internal/server/stall_deadline.go
+++ b/internal/server/stall_deadline.go
@@ -32,6 +32,8 @@ func newStallDeadlineWriter(w http.ResponseWriter, stall time.Duration) *stallDe
 
 func (w *stallDeadlineWriter) Write(p []byte) (int, error) {
 	w.armDeadline()
+	// p is relayed unchanged: the handler chose these bytes and their
+	// content type, so this wrapper adds no reflection. lgtm[go/reflected-xss]
 	n, err := w.ResponseWriter.Write(p)
 	return n, w.classify(err)
 }

--- a/internal/server/stall_deadline_test.go
+++ b/internal/server/stall_deadline_test.go
@@ -145,7 +145,7 @@ func (*timeoutError) Temporary() bool { return false }
 // drop flush errors, so a stall during the final flush of a stream must be
 // picked up from the stall writer itself rather than logged as a success.
 func TestFlushStream_ReportsStallDuringFinalFlush(t *testing.T) {
-	inner := &flushStallingWriter{ResponseRecorder: httptest.NewRecorder()}
+	inner := &flushStallingWriter{ResponseRecorder: httptest.NewRecorder(), stallFrom: 2}
 	stallWriter := newStallDeadlineWriter(inner, time.Second)
 	res := echo.NewResponse(stallWriter, nil)
 	capture := &typeAssertingCapture{ResponseWriter: res}
@@ -160,6 +160,27 @@ func TestFlushStream_ReportsStallDuringFinalFlush(t *testing.T) {
 	if _, err := capture.Write([]byte("more")); !errors.Is(err, ErrClientStall) {
 		t.Fatalf("Write after stall error = %v, want ErrClientStall", err)
 	}
+}
+
+// A stall on the header flush must return before the upstream is read at
+// all: the request context is already cancelled by then, so the next read
+// would report a cancellation and misclassify the stall as a disconnect.
+func TestFlushStream_ReportsStallDuringInitialFlush(t *testing.T) {
+	inner := &flushStallingWriter{ResponseRecorder: httptest.NewRecorder(), stallFrom: 1}
+	stallWriter := newStallDeadlineWriter(inner, time.Second)
+	res := echo.NewResponse(stallWriter, nil)
+
+	err := flushStream(res, readerThatMustNotBeRead{t})
+	if !errors.Is(err, ErrClientStall) {
+		t.Fatalf("flushStream() error = %v, want ErrClientStall", err)
+	}
+}
+
+type readerThatMustNotBeRead struct{ t *testing.T }
+
+func (r readerThatMustNotBeRead) Read([]byte) (int, error) {
+	r.t.Fatal("upstream read after the client stalled on the header flush")
+	return 0, io.EOF
 }
 
 // The audit capture finds http.Hijacker with a direct type assertion on the
@@ -214,17 +235,18 @@ func TestModelInteractionWriteDeadlineMiddleware_PreservesHijack(t *testing.T) {
 	}
 }
 
-// flushStallingWriter lets the header flush through and then fails the flush
-// that follows the chunk, the way a net.Conn does once its write deadline
-// passed with the client no longer reading.
+// flushStallingWriter fails every flush from the stallFrom-th one on, the
+// way a net.Conn does once its write deadline passed with the client no
+// longer reading.
 type flushStallingWriter struct {
 	*httptest.ResponseRecorder
-	flushes int
+	stallFrom int
+	flushes   int
 }
 
 func (w *flushStallingWriter) FlushError() error {
 	w.flushes++
-	if w.flushes == 1 {
+	if w.flushes < w.stallFrom {
 		return nil
 	}
 	return &net.OpError{Op: "write", Err: &timeoutError{}}

--- a/internal/server/stall_deadline_test.go
+++ b/internal/server/stall_deadline_test.go
@@ -1,0 +1,139 @@
+package server
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v5"
+)
+
+// A client that opens a stream and never reads it must not hold the handler
+// (and with it the upstream provider connection) for longer than the stall
+// timeout. The handler here stands in for the provider relay: it pushes bytes
+// until the kernel socket buffers on both ends are full and the write blocks.
+func TestStreamStallTimeout_ReleasesHandlerWhenClientStopsReading(t *testing.T) {
+	const stall = 300 * time.Millisecond
+
+	handlerDone := make(chan error, 1)
+	e := echo.New()
+	e.Use(modelInteractionWriteDeadlineMiddleware(stall))
+	e.POST("/v1/chat/completions", func(c *echo.Context) error {
+		c.Response().Header().Set("Content-Type", "text/event-stream")
+		c.Response().WriteHeader(http.StatusOK)
+		chunk := []byte("data: " + string(make([]byte, 64*1024)) + "\n\n")
+		var err error
+		for err == nil {
+			_, err = c.Response().Write(chunk)
+			if err == nil {
+				err = http.NewResponseController(c.Response()).Flush()
+			}
+		}
+		handlerDone <- err
+		return nil
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	server := &http.Server{Handler: e, WriteTimeout: 30 * time.Second}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { _ = server.Close() })
+
+	conn, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	if _, err := fmt.Fprintf(conn, "POST /v1/chat/completions HTTP/1.1\r\nHost: gateway\r\nContent-Length: 0\r\n\r\n"); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	// Read the status line to prove the stream started, then stop reading.
+	if _, err := bufio.NewReader(conn).ReadString('\n'); err != nil {
+		t.Fatalf("read status line: %v", err)
+	}
+
+	select {
+	case err := <-handlerDone:
+		if !errors.Is(err, ErrClientStall) {
+			t.Fatalf("handler error = %v, want ErrClientStall", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("handler still blocked on a client that stopped reading")
+	}
+}
+
+// The stall deadline is armed per write, so a long gap with nothing to send
+// (a slow provider) must not poison the next write.
+func TestStreamStallTimeout_ToleratesQuietProvider(t *testing.T) {
+	const stall = 100 * time.Millisecond
+
+	e := echo.New()
+	e.Use(modelInteractionWriteDeadlineMiddleware(stall))
+	e.POST("/v1/chat/completions", func(c *echo.Context) error {
+		c.Response().Header().Set("Content-Type", "text/event-stream")
+		c.Response().WriteHeader(http.StatusOK)
+		for _, chunk := range []string{"data: first\n\n", "data: second\n\n"} {
+			if _, err := c.Response().Write([]byte(chunk)); err != nil {
+				return err
+			}
+			if err := http.NewResponseController(c.Response()).Flush(); err != nil {
+				return err
+			}
+			time.Sleep(3 * stall)
+		}
+		return nil
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	server := &http.Server{Handler: e, WriteTimeout: 30 * time.Second}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { _ = server.Close() })
+
+	resp, err := http.Post("http://"+listener.Addr().String()+"/v1/chat/completions", "application/json", nil)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	reader := bufio.NewReader(resp.Body)
+	var got string
+	for {
+		line, err := reader.ReadString('\n')
+		got += line
+		if err != nil {
+			break
+		}
+	}
+	if want := "data: first\n\ndata: second\n\n"; got != want {
+		t.Fatalf("body = %q, want %q", got, want)
+	}
+}
+
+func TestStallDeadlineWriter_ClassifiesOnlyTimeouts(t *testing.T) {
+	w := newStallDeadlineWriter(nil, time.Second)
+	timeout := &net.OpError{Op: "write", Err: &timeoutError{}}
+	if got := w.classify(timeout); !errors.Is(got, ErrClientStall) || !errors.Is(got, timeout) {
+		t.Fatalf("classify(timeout) = %v, want ErrClientStall wrapping the cause", got)
+	}
+	reset := &net.OpError{Op: "write", Err: errors.New("connection reset by peer")}
+	if got := w.classify(reset); got != reset {
+		t.Fatalf("classify(reset) = %v, want the error unchanged", got)
+	}
+	if got := w.classify(nil); got != nil {
+		t.Fatalf("classify(nil) = %v, want nil", got)
+	}
+}
+
+type timeoutError struct{}
+
+func (*timeoutError) Error() string   { return "i/o timeout" }
+func (*timeoutError) Timeout() bool   { return true }
+func (*timeoutError) Temporary() bool { return false }

--- a/internal/server/stall_deadline_test.go
+++ b/internal/server/stall_deadline_test.go
@@ -4,8 +4,11 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -137,3 +140,113 @@ type timeoutError struct{}
 func (*timeoutError) Error() string   { return "i/o timeout" }
 func (*timeoutError) Timeout() bool   { return true }
 func (*timeoutError) Temporary() bool { return false }
+
+// The wrappers above the stall writer (echo's Response, the audit capture)
+// drop flush errors, so a stall during the final flush of a stream must be
+// picked up from the stall writer itself rather than logged as a success.
+func TestFlushStream_ReportsStallDuringFinalFlush(t *testing.T) {
+	inner := &flushStallingWriter{ResponseRecorder: httptest.NewRecorder()}
+	stallWriter := newStallDeadlineWriter(inner, time.Second)
+	res := echo.NewResponse(stallWriter, nil)
+	capture := &typeAssertingCapture{ResponseWriter: res}
+
+	err := flushStream(capture, io.NopCloser(strings.NewReader("data: last\n\n")))
+	if !errors.Is(err, ErrClientStall) {
+		t.Fatalf("flushStream() error = %v, want ErrClientStall", err)
+	}
+	if got := inner.Body.String(); got != "data: last\n\n" {
+		t.Fatalf("body = %q, want the chunk written before the stalled flush", got)
+	}
+	if _, err := capture.Write([]byte("more")); !errors.Is(err, ErrClientStall) {
+		t.Fatalf("Write after stall error = %v, want ErrClientStall", err)
+	}
+}
+
+// The audit capture finds http.Hijacker with a direct type assertion on the
+// writer beneath it, not through Unwrap. A realtime upgrade through the
+// middleware must therefore still reach the connection.
+func TestModelInteractionWriteDeadlineMiddleware_PreservesHijack(t *testing.T) {
+	e := echo.New()
+	e.Use(modelInteractionWriteDeadlineMiddleware(time.Second))
+	e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c *echo.Context) error {
+			c.SetResponse(&typeAssertingCapture{ResponseWriter: c.Response()})
+			return next(c)
+		}
+	})
+	e.GET("/v1/realtime", func(c *echo.Context) error {
+		hijacker, ok := c.Response().(http.Hijacker)
+		if !ok {
+			return errors.New("response is not a hijacker")
+		}
+		conn, rw, err := hijacker.Hijack()
+		if err != nil {
+			return err
+		}
+		defer conn.Close()
+		_, _ = rw.WriteString("HTTP/1.1 101 Switching Protocols\r\n\r\nhello")
+		return rw.Flush()
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	server := &http.Server{Handler: e, WriteTimeout: 30 * time.Second}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { _ = server.Close() })
+
+	conn, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+	if _, err := fmt.Fprintf(conn, "GET /v1/realtime HTTP/1.1\r\nHost: gateway\r\n\r\n"); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	got, err := io.ReadAll(conn)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if want := "HTTP/1.1 101 Switching Protocols\r\n\r\nhello"; string(got) != want {
+		t.Fatalf("response = %q, want %q", got, want)
+	}
+}
+
+// flushStallingWriter lets the header flush through and then fails the flush
+// that follows the chunk, the way a net.Conn does once its write deadline
+// passed with the client no longer reading.
+type flushStallingWriter struct {
+	*httptest.ResponseRecorder
+	flushes int
+}
+
+func (w *flushStallingWriter) FlushError() error {
+	w.flushes++
+	if w.flushes == 1 {
+		return nil
+	}
+	return &net.OpError{Op: "write", Err: &timeoutError{}}
+}
+
+// typeAssertingCapture mirrors the audit response capture: it forwards
+// Flush and Hijack by asserting on its immediate inner writer.
+type typeAssertingCapture struct {
+	http.ResponseWriter
+}
+
+func (c *typeAssertingCapture) Flush() {
+	if f, ok := c.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (c *typeAssertingCapture) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if h, ok := c.ResponseWriter.(http.Hijacker); ok {
+		return h.Hijack()
+	}
+	return nil, nil, http.ErrNotSupported
+}
+
+func (c *typeAssertingCapture) Unwrap() http.ResponseWriter { return c.ResponseWriter }

--- a/internal/server/stream_support.go
+++ b/internal/server/stream_support.go
@@ -16,8 +16,14 @@ var streamCopyBufferPool = sync.Pool{
 	},
 }
 
+// flushStream relays stream to w chunk by chunk, flushing after each one. A
+// stall during a flush is not returned by the flush itself (the wrappers
+// above the stall writer drop flush errors), so the stall writer is asked
+// after every flush and at end of stream; otherwise a client that stalled on
+// the final chunk would be recorded as a completed response.
 func flushStream(w io.Writer, stream io.Reader) error {
 	flusher, canFlush := w.(http.Flusher)
+	stalls := findStallReporter(w)
 	if canFlush {
 		flusher.Flush()
 	}
@@ -34,9 +40,17 @@ func flushStream(w io.Writer, stream io.Reader) error {
 			if canFlush {
 				flusher.Flush()
 			}
+			if stalls != nil {
+				if stallErr := stalls.StallError(); stallErr != nil {
+					return stallErr
+				}
+			}
 		}
 		if err != nil {
 			if err == io.EOF {
+				if stalls != nil {
+					return stalls.StallError()
+				}
 				return nil
 			}
 			return err

--- a/internal/server/stream_support.go
+++ b/internal/server/stream_support.go
@@ -26,6 +26,11 @@ func flushStream(w io.Writer, stream io.Reader) error {
 	stalls := findStallReporter(w)
 	if canFlush {
 		flusher.Flush()
+		if stalls != nil {
+			if stallErr := stalls.StallError(); stallErr != nil {
+				return stallErr
+			}
+		}
 	}
 
 	bufPtr := streamCopyBufferPool.Get().(*[]byte)

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -726,7 +726,10 @@ func handleStreamingDispatchError(c *echo.Context, err error) error {
 
 func recordStreamingError(streamEntry *auditlog.LogEntry, model, provider, path, requestID string, ctx context.Context, err error) {
 	errorType := "stream_error"
-	if isClientDisconnect(ctx, err) {
+	switch {
+	case errors.Is(err, ErrClientStall):
+		errorType = "client_stalled"
+	case isClientDisconnect(ctx, err):
 		errorType = "client_disconnected"
 	}
 


### PR DESCRIPTION
## Summary

A client that opened a model response and stopped reading it held the handler goroutine and the upstream provider connection until the provider-side `HTTP_TIMEOUT` (600s) expired. Model routes clear the server-wide 30s write deadline because a response can legitimately outlive it, which left writes to the client unbounded.

This adds a stream stall timeout: on model interaction routes every write and flush to the client re-arms a fresh write deadline, so one write may block at most the configured time. Because the deadline is armed per write rather than measured from the previous one, a slow provider with nothing to send never trips it; only a client whose socket stays full does.

- `STREAM_STALL_TIMEOUT` / `server.stream_stall_timeout`, seconds, default `60` (the send timeout most reverse proxies use between successive writes). `0` disables, negative fails startup, applies on `--reload`.
- Covers every model interaction route, streaming or not, including passthrough.
- A stalled write surfaces as `ErrClientStall`; the streaming audit entry records `client_stalled` instead of a generic `stream_error`.
- The handler's return clears the deadline again so net/http's trailing chunked terminator is not judged by a deadline armed long before.

## Tests

- Real-listener test: a client that reads the status line and then stops is released with `ErrClientStall` within the stall timeout.
- Real-listener test: a provider pausing 3x the stall timeout between chunks still delivers both chunks.
- Middleware unit tests for per-write arming and the final clear; config tests for default, YAML, env precedence, and negative rejection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable streaming stall timeout for model responses, defaulting to 60 seconds.
  - Each response write receives a fresh deadline, allowing slow providers to continue sending between writes.
  - Stalled client connections are closed, upstream requests are released, and activity is recorded as `client_stalled`.
  - Set the timeout to `0` to disable the limit.

- **Bug Fixes**
  - Invalid negative timeout values are rejected during configuration loading.

- **Documentation**
  - Added configuration and production deployment guidance for the new timeout setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->