### PR TITLE
feat(server): add opt-in GET /v1/auth/verify key check

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -101,6 +101,15 @@
 # (calls are team-gated by xAI), and Azure OpenAI (GA v1 surface).
 # REALTIME_ENABLED=true
 
+# Expose GET /v1/auth/verify (default: false). It answers 200 {"valid":true,...} when
+# the API key the request carries authenticates against this gateway, and 401 when it
+# does not, so a service in front of GoModel can validate keys without holding a copy
+# of them. The response also reports which mechanism accepted the key ("api_key" for a
+# managed key stored in the database, "master_key" for the bootstrap key) plus the
+# key's id and bound user path. The route sits outside /admin, so it keeps working
+# with ADMIN_ENDPOINTS_ENABLED=false.
+# AUTH_VERIFY_ENABLED=false
+
 # Version awareness: check https://gomodel.enterpilot.io/version once a day, and
 # again the first time each browser opens the dashboard on a new day, so operators
 # learn that a newer release exists. The dashboard shows the result in Settings;

--- a/.env.template
+++ b/.env.template
@@ -104,7 +104,8 @@
 # Expose GET /v1/auth/verify (default: false). It answers 200 {"valid":true,...} when
 # the API key the request carries authenticates against this gateway, and 401 when it
 # does not, so a service in front of GoModel can validate keys without holding a copy
-# of them. The response also reports which mechanism accepted the key ("api_key" for a
+# of them. A gateway with no authentication configured accepts every request and has
+# no key to confirm: there the answer is 200 {"valid":false,"method":"none"}. The response also reports which mechanism accepted the key ("api_key" for a
 # managed key stored in the database, "master_key" for the bootstrap key) plus the
 # key's id and bound user path. The route sits outside /admin, so it keeps working
 # with ADMIN_ENDPOINTS_ENABLED=false.

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -15,6 +15,7 @@ server:
   allow_passthrough_v1_alias: true # allow /p/{provider}/v1/... while keeping /p/{provider}/... canonical
   user_path_header: "X-GoModel-User-Path" # env: USER_PATH_HEADER; inbound header used for user_path scoping
   enabled_passthrough_providers: ["openai", "anthropic", "cohere", "openrouter", "kilo", "zai", "sglang", "vllm", "llmd", "deepseek", "bailian"] # providers enabled on /p/{provider}/...
+  auth_verify_enabled: false # env: AUTH_VERIFY_ENABLED; expose GET /v1/auth/verify, which reports whether the API key a request carries authenticates against this gateway (401 when it does not). Outside /admin, so it works with the admin API disabled
   realtime_enabled: true # env: REALTIME_ENABLED; expose the /v1/realtime and /v1/realtime/translations websockets, their calls/client_secrets siblings, and /p/{provider}/v1/realtime upgrades
   pid_file: "data/gomodel.pid" # env: PID_FILE; where the running gateway records its process id so `gomodel --reload` can find it. Set per instance when several gateways share a host; empty writes no pid file and disables --reload; changing it needs a restart, not a reload
 

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -15,7 +15,7 @@ server:
   allow_passthrough_v1_alias: true # allow /p/{provider}/v1/... while keeping /p/{provider}/... canonical
   user_path_header: "X-GoModel-User-Path" # env: USER_PATH_HEADER; inbound header used for user_path scoping
   enabled_passthrough_providers: ["openai", "anthropic", "cohere", "openrouter", "kilo", "zai", "sglang", "vllm", "llmd", "deepseek", "bailian"] # providers enabled on /p/{provider}/...
-  auth_verify_enabled: false # env: AUTH_VERIFY_ENABLED; expose GET /v1/auth/verify, which reports whether the API key a request carries authenticates against this gateway (401 when it does not). Outside /admin, so it works with the admin API disabled
+  auth_verify_enabled: false # env: AUTH_VERIFY_ENABLED; expose GET /v1/auth/verify, which reports whether the API key a request carries authenticates against this gateway (401 when it does not; 200 with {"valid":false,"method":"none"} when the gateway has no authentication configured). Outside /admin, so it works with the admin API disabled
   realtime_enabled: true # env: REALTIME_ENABLED; expose the /v1/realtime and /v1/realtime/translations websockets, their calls/client_secrets siblings, and /p/{provider}/v1/realtime upgrades
   pid_file: "data/gomodel.pid" # env: PID_FILE; where the running gateway records its process id so `gomodel --reload` can find it. Set per instance when several gateways share a host; empty writes no pid file and disables --reload; changing it needs a restart, not a reload
 

--- a/config/config.go
+++ b/config/config.go
@@ -114,6 +114,7 @@ func buildDefaultConfig() *Config {
 			EnablePassthroughRoutes: true,
 			AllowPassthroughV1Alias: true,
 			RealtimeEnabled:         true,
+			AuthVerifyEnabled:       false,
 			StreamStallTimeout:      DefaultStreamStallTimeoutSeconds,
 			EnabledPassthroughProviders: []string{
 				"openai",

--- a/config/server.go
+++ b/config/server.go
@@ -46,6 +46,12 @@ type ServerConfig struct {
 	// siblings, and the /p/{provider}/v1/realtime passthrough upgrade.
 	// Default: true. Only providers implementing realtime accept sessions.
 	RealtimeEnabled bool `yaml:"realtime_enabled" env:"REALTIME_ENABLED"`
+	// AuthVerifyEnabled exposes GET /v1/auth/verify, which reports whether the
+	// API key a request carries authenticates against this gateway. It sits
+	// outside /admin so it keeps working when the admin API is disabled.
+	// Default: false — turn it on only when a service in front of the gateway
+	// needs to validate keys without holding a copy of them.
+	AuthVerifyEnabled bool `yaml:"auth_verify_enabled" env:"AUTH_VERIFY_ENABLED"`
 	// PIDFile records the process id of the running gateway so `gomodel --reload`
 	// can find it. Default: DefaultPIDFilePath(). Set it per instance when
 	// several gateways share a host, or to "" in config.yaml to write no pid

--- a/docs/advanced/api-endpoints.mdx
+++ b/docs/advanced/api-endpoints.mdx
@@ -115,6 +115,35 @@ metered.
 | Endpoint    | Method | Description                                                                                                                              |
 | ----------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | `/v1/usage` | GET    | Self-service usage, budget, and rate limit status for the caller's effective user path — see [Usage API](/advanced/usage-api) |
+| `/v1/auth/verify` | GET | Report whether the API key the request carries is valid (when `AUTH_VERIFY_ENABLED`) |
+
+### Key verification
+
+`GET /v1/auth/verify` lets a service in front of the gateway check an API key
+without holding a copy of the key list. It is **disabled by default**; enable it
+with `AUTH_VERIFY_ENABLED=true` (`server.auth_verify_enabled`). It is not an
+`/admin` route, so it keeps working when the admin API is disabled.
+
+```bash
+curl http://localhost:8080/v1/auth/verify \
+  -H "Authorization: Bearer sk_gom_..."
+```
+
+```json
+{ "valid": true, "method": "api_key", "key_id": "key_01H...", "user_path": "/acme/eng" }
+```
+
+An unknown, disabled, or expired key is rejected by the gateway's normal
+authentication with `401`, so a `200` means the key authenticates. `method`
+says which mechanism accepted it: `api_key` is a managed key stored in the
+database, `master_key` the bootstrap key from `GOMODEL_MASTER_KEY`. `key_id`
+and `user_path` are present only for managed keys bound to them.
+
+<Note>
+  On a gateway with no authentication configured at all, every request is
+  accepted and there is no key to confirm: the endpoint answers `200` with
+  `{"valid": false, "method": "none"}` rather than claiming the key is valid.
+</Note>
 
 ## Provider Passthrough
 

--- a/docs/advanced/api-endpoints.mdx
+++ b/docs/advanced/api-endpoints.mdx
@@ -140,9 +140,12 @@ database, `master_key` the bootstrap key from `GOMODEL_MASTER_KEY`. `key_id`
 and `user_path` are present only for managed keys bound to them.
 
 <Note>
-  On a gateway with no authentication configured at all, every request is
-  accepted and there is no key to confirm: the endpoint answers `200` with
+  Where the gateway admits unauthenticated callers — no authentication
+  configured at all, or a route an extension excluded from it — there is no key
+  to confirm, and the endpoint answers `200` with
   `{"valid": false, "method": "none"}` rather than claiming the key is valid.
+  A status-code consumer such as Caddy's `forward_auth` treats that as allowed,
+  matching what the gateway itself does with those requests.
 </Note>
 
 ## Provider Passthrough

--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -49,6 +49,7 @@ The most common way to configure GoModel. Set any of the variables below to over
 | `STREAM_STALL_TIMEOUT` | Seconds one response write on a model route may wait for the client to read it; `0` disables | `60`                   |
 | `USER_PATH_HEADER`   | Header used to read/write request `user_path` values  | `X-GoModel-User-Path`  |
 | `SWAGGER_ENABLED`    | Expose [Swagger UI](/advanced/swagger-ui); needs a `-tags=swagger` build | `false`                |
+| `AUTH_VERIFY_ENABLED` | Expose [`GET /v1/auth/verify`](/advanced/api-endpoints#key-verification), which reports whether the API key a request carries is valid | `false`                |
 | `PID_FILE`           | Where the running gateway records its process id for `gomodel --reload`. Changing it needs a restart | `data/gomodel.pid` next to a `./data` directory, otherwise the per-user data directory |
 
 `STREAM_STALL_TIMEOUT` (`server.stream_stall_timeout` in YAML) protects the

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -172,6 +172,7 @@
                 "pages": [
                     "guides/production",
                     "guides/updating",
+                    "guides/caddy",
                     "guides/openai-agents-sdk",
                     "guides/openclaw",
                     "guides/n8n",

--- a/docs/guides/caddy.mdx
+++ b/docs/guides/caddy.mdx
@@ -1,0 +1,148 @@
+---
+title: "GoModel & Caddy"
+description: "Use Caddy's forward_auth with GoModel's key verification endpoint to reject unauthenticated traffic at the edge and gate other services on GoModel API keys."
+icon: "shield-check"
+keywords: ["Caddy", "forward_auth", "reverse proxy", "API key verification", "/v1/auth/verify", "edge authentication", "block unauthenticated traffic"]
+---
+
+## Overview
+
+Caddy's [`forward_auth`](https://caddyserver.com/docs/caddyfile/directives/forward_auth)
+asks another service whether a request may proceed. Point it at GoModel's
+[`GET /v1/auth/verify`](/advanced/api-endpoints#key-verification) and Caddy
+gates traffic on GoModel API keys — without a copy of those keys anywhere in
+the proxy.
+
+Two things this is good for:
+
+- **Reject unauthenticated traffic at the edge.** Requests without a usable key
+  never reach the gateway, so scanners and misconfigured clients do not open
+  connections to it or land in its audit log. GoModel still authenticates every
+  request it serves; the edge check is a filter in front, not a replacement.
+- **Gate other services on GoModel keys.** An internal dashboard, a docs site,
+  or a metrics endpoint on the same host can require a valid GoModel key
+  without implementing authentication of its own.
+
+`/v1/auth/verify` is **disabled by default**. Enable it with
+`AUTH_VERIFY_ENABLED=true` (`server.auth_verify_enabled`). It is not an
+`/admin` route, so it keeps working with `ADMIN_ENDPOINTS_ENABLED=false`.
+
+## Why it works
+
+`forward_auth` decides on the **status code** alone:
+
+| GoModel answers | Caddy does |
+| --------------- | ---------- |
+| `200` — the key authenticates | Passes the request to the upstream |
+| `401` — unknown, disabled, or expired key, or no credential | Copies the response to the client and stops |
+
+GoModel's `401` body is its normal OpenAI-shaped error envelope, so a client
+that already understands GoModel errors sees a familiar shape from the proxy.
+The `200` body (`valid`, `method`, `key_id`, `user_path`) is ignored by Caddy —
+it is there for scripts and services that want to know *which* key answered.
+
+## Gate another service on GoModel keys
+
+The upstream here is any app you want behind GoModel's keys.
+
+```caddyfile
+{
+	auto_https off # drop this in production and use a real hostname
+}
+
+:8090 {
+	forward_auth 127.0.0.1:8080 {
+		uri /v1/auth/verify
+		copy_headers X-Gomodel-Auth-User
+	}
+
+	reverse_proxy 127.0.0.1:9000
+}
+```
+
+`forward_auth` sends the incoming request's own headers to GoModel, so the
+caller's `Authorization: Bearer sk_gom_...` (or `x-api-key`) is what gets
+checked. Nothing else is needed to make the credential reach the gateway.
+
+`copy_headers X-Gomodel-Auth-User` forwards GoModel's answer about *who* the
+caller is: for a managed key bound to a [user path](/features/user-path), the
+upstream receives that path and can scope what it shows. The header is empty
+for master-key callers and for keys with no bound path.
+
+Check it:
+
+```bash
+# No credential — rejected at the edge, upstream never sees it
+curl -i http://localhost:8090/
+
+# Valid managed key — reaches the upstream
+curl -i http://localhost:8090/ -H "Authorization: Bearer sk_gom_..."
+```
+
+## Filter traffic in front of the gateway
+
+To put the same check in front of GoModel itself, verify against the gateway
+and proxy to it:
+
+```caddyfile
+api.example.com {
+	forward_auth 127.0.0.1:8080 {
+		uri /v1/auth/verify
+	}
+
+	reverse_proxy 127.0.0.1:8080
+}
+```
+
+Every proxied request now costs one extra round trip to the gateway, and the
+gateway authenticates the request a second time when it serves it. That is the
+price of dropping unauthenticated traffic before it reaches the application —
+worth it at an internet-facing edge, not worth it on a private network where
+GoModel's own authentication is already the only gate.
+
+Two routes must stay reachable without a key if you use them:
+
+```caddyfile
+api.example.com {
+	@public path /health /health/ready /metrics
+	handle @public {
+		reverse_proxy 127.0.0.1:8080
+	}
+
+	handle {
+		forward_auth 127.0.0.1:8080 {
+			uri /v1/auth/verify
+		}
+		reverse_proxy 127.0.0.1:8080
+	}
+}
+```
+
+Health checks and Prometheus scrapes carry no API key, so without this they
+would be rejected by the edge gate even though GoModel serves them
+unauthenticated.
+
+<Warning>
+  **The gate is only as strong as the gateway's own authentication.** On a
+  GoModel instance with no master key and no managed keys — the unsafe
+  development default — every request is accepted, `/v1/auth/verify` answers
+  `200` with `{"valid": false, "method": "none"}` because there is no key to
+  confirm, and `forward_auth` passes everything through. Set
+  `GOMODEL_MASTER_KEY` or issue [managed keys](/features/users) before relying
+  on this to block anything.
+</Warning>
+
+## Notes
+
+- Caddy re-checks the key on every request. There is no result cache in
+  `forward_auth`, so the gateway sees one verification call per proxied
+  request; `/v1/auth/verify` does no provider work and answers from the key
+  store.
+- The endpoint answers `Cache-Control: no-store` — the answer describes one
+  caller's credential and must not be served to anyone else.
+- Enabling the endpoint exposes a key oracle: anyone who can reach it can test
+  whether a key is valid. Expose it only where you need it, and keep GoModel's
+  [rate limits](/features/rate-limits) in front of untrusted callers.
+- Caddy adds `X-Forwarded-Method` and `X-Forwarded-Uri` to the verification
+  subrequest. GoModel ignores both; the check is about the credential, not the
+  route being requested.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -6676,6 +6676,49 @@
         }
       }
     },
+    "/v1/auth/verify": {
+      "get": {
+        "description": "Reports whether the presented credential authenticates against this gateway. Returns 401 when it does not. Disabled unless AUTH_VERIFY_ENABLED is set.",
+        "tags": [
+          "auth"
+        ],
+        "summary": "Verify an API key",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/server.authVerifyResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/core.OpenAIErrorEnvelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "x-mint": {
+          "metadata": {
+            "sidebarTitle": "/v1/auth/verify",
+            "title": "Verify an API key",
+            "description": "GoModel API reference for GET /v1/auth/verify: Verify an API key."
+          }
+        }
+      }
+    },
     "/v1/batches": {
       "get": {
         "tags": [
@@ -14914,6 +14957,26 @@
           },
           "display_name": {
             "type": "string"
+          }
+        }
+      },
+      "server.authVerifyResponse": {
+        "type": "object",
+        "properties": {
+          "key_id": {
+            "description": "KeyID identifies the managed auth key that authenticated the request.\nEmpty for every other method.",
+            "type": "string"
+          },
+          "method": {
+            "description": "Method is \"api_key\" for a managed key stored in the database,\n\"master_key\" for the bootstrap key, an extension-specific value for\nidentities supplied by an authentication extension, or \"none\" when the\ngateway checked no credential.",
+            "type": "string"
+          },
+          "user_path": {
+            "description": "UserPath is the subtree the credential is bound to, empty when the\ncredential is global.",
+            "type": "string"
+          },
+          "valid": {
+            "type": "boolean"
           }
         }
       },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -14964,7 +14964,7 @@
         "type": "object",
         "properties": {
           "key_id": {
-            "description": "KeyID identifies the managed auth key that authenticated the request.\nEmpty for every other method.",
+            "description": "KeyID identifies the managed auth key that authenticated the request.\nAbsent for every other method.",
             "type": "string"
           },
           "method": {
@@ -14972,7 +14972,7 @@
             "type": "string"
           },
           "user_path": {
-            "description": "UserPath is the subtree the credential is bound to, empty when the\ncredential is global.",
+            "description": "UserPath is the subtree the credential is bound to. Absent when the\ncredential is global, which every master-key caller is.",
             "type": "string"
           },
           "valid": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -6678,7 +6678,7 @@
     },
     "/v1/auth/verify": {
       "get": {
-        "description": "Reports whether the presented credential authenticates against this gateway. Returns 401 when it does not. Disabled unless AUTH_VERIFY_ENABLED is set.",
+        "description": "Reports whether the presented credential authenticates against this gateway. Returns 401 when it does not. A gateway with no authentication configured has no credential to confirm and answers 200 with valid=false and method=none. Disabled unless AUTH_VERIFY_ENABLED is set.",
         "tags": [
           "auth"
         ],
@@ -14968,7 +14968,7 @@
             "type": "string"
           },
           "method": {
-            "description": "Method is \"api_key\" for a managed key stored in the database,\n\"master_key\" for the bootstrap key, an extension-specific value for\nidentities supplied by an authentication extension, or \"none\" when the\ngateway checked no credential.",
+            "description": "Method is \"api_key\" for a managed key stored in the database,\n\"master_key\" for the bootstrap key, an extension-specific value for\nidentities supplied by an authentication extension, or \"none\" when the\nrequest carried no credential this gateway recognizes, which is also\nwhen Valid is false.",
             "type": "string"
           },
           "user_path": {

--- a/internal/app/init_server.go
+++ b/internal/app/init_server.go
@@ -149,6 +149,7 @@ func (b *bootstrap) initServerConfig() error {
 		DisablePassthroughRoutes:        !appCfg.Server.EnablePassthroughRoutes,
 		EnabledPassthroughProviders:     appCfg.Server.EnabledPassthroughProviders,
 		RealtimeEnabled:                 appCfg.Server.RealtimeEnabled,
+		AuthVerifyEnabled:               appCfg.Server.AuthVerifyEnabled,
 		AllowPassthroughV1Alias:         &allowPassthroughV1Alias,
 		UserPathHeader:                  appCfg.Server.UserPathHeader,
 		SwaggerEnabled:                  b.swaggerEnabled,

--- a/internal/server/auth_verify_handler.go
+++ b/internal/server/auth_verify_handler.go
@@ -30,10 +30,10 @@ type authVerifyResponse struct {
 	// when Valid is false.
 	Method string `json:"method"`
 	// KeyID identifies the managed auth key that authenticated the request.
-	// Empty for every other method.
+	// Absent for every other method.
 	KeyID string `json:"key_id,omitempty"`
-	// UserPath is the subtree the credential is bound to, empty when the
-	// credential is global.
+	// UserPath is the subtree the credential is bound to. Absent when the
+	// credential is global, which every master-key caller is.
 	UserPath string `json:"user_path,omitempty"`
 }
 

--- a/internal/server/auth_verify_handler.go
+++ b/internal/server/auth_verify_handler.go
@@ -1,0 +1,99 @@
+package server
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/labstack/echo/v5"
+
+	"github.com/enterpilot/gomodel/ext"
+	"github.com/enterpilot/gomodel/internal/auditlog"
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+// authVerifyMethodNone is reported when the request reached the handler
+// without any credential being checked, which only happens on a gateway that
+// has no authentication configured at all.
+const authVerifyMethodNone = "none"
+
+// authVerifyResponse is the answer of the credential check: whether the
+// presented key authenticates against this gateway, and which mechanism
+// accepted it. It never echoes the credential itself.
+type authVerifyResponse struct {
+	Valid bool `json:"valid"`
+	// Method is "api_key" for a managed key stored in the database,
+	// "master_key" for the bootstrap key, an extension-specific value for
+	// identities supplied by an authentication extension, or "none" when the
+	// gateway checked no credential.
+	Method string `json:"method"`
+	// KeyID identifies the managed auth key that authenticated the request.
+	// Empty for every other method.
+	KeyID string `json:"key_id,omitempty"`
+	// UserPath is the subtree the credential is bound to, empty when the
+	// credential is global.
+	UserPath string `json:"user_path,omitempty"`
+}
+
+// AuthVerify handles GET /v1/auth/verify.
+//
+// The route exists so a service in front of the gateway can ask whether an API
+// key is usable without holding a copy of the key list. It is disabled by
+// default and enabled with server.auth_verify_enabled (AUTH_VERIFY_ENABLED);
+// it lives outside /admin so it stays reachable when the admin API is off.
+//
+// The endpoint adds no credential check of its own: the request passes the
+// same authentication middleware as every model route, so an invalid, expired,
+// or unknown key is rejected there with 401 and never reaches this handler. A
+// 200 therefore means the credential authenticates, and the body reports which
+// mechanism accepted it — "api_key" is the managed-key case, the one backed by
+// a database row. On a gateway with no authentication configured every request
+// is accepted, so the answer is valid=false with method "none": there is no
+// key to confirm.
+//
+// @Summary      Verify an API key
+// @Description  Reports whether the presented credential authenticates against this gateway. Returns 401 when it does not. Disabled unless AUTH_VERIFY_ENABLED is set.
+// @Tags         auth
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200  {object}  authVerifyResponse
+// @Failure      401  {object}  core.OpenAIErrorEnvelope
+// @Router       /v1/auth/verify [get]
+func (h *Handler) AuthVerify(c *echo.Context) error {
+	ctx := c.Request().Context()
+
+	method := h.authVerifyMethod(ctx)
+	response := authVerifyResponse{
+		Valid:    method != authVerifyMethodNone,
+		Method:   method,
+		KeyID:    core.GetAuthKeyID(ctx),
+		UserPath: core.AccessScopeFromContext(ctx).UserPath,
+	}
+
+	// The answer describes the caller's credential, so no proxy in between
+	// may serve it to anyone else.
+	c.Response().Header().Set("Cache-Control", "no-store")
+	return c.JSON(http.StatusOK, response)
+}
+
+// authVerifyMethod names the mechanism that let the request through. It is
+// read back from what the authentication middleware already attached to the
+// context rather than published as another context value, so the credential
+// check costs the model routes nothing.
+func (h *Handler) authVerifyMethod(ctx context.Context) string {
+	if core.GetAuthKeyID(ctx) != "" {
+		return auditlog.AuthMethodAPIKey
+	}
+	if authentication, ok := ext.AuthenticationFromContext(ctx); ok {
+		if method := auditlog.NormalizeAuthMethod(authentication.Method); method != "" {
+			return method
+		}
+		return auditlog.AuthMethodExtension
+	}
+	// Nothing else can have satisfied the middleware: without a master key,
+	// a request carrying no managed or extension identity never reaches a
+	// handler unless the gateway authenticates nobody at all.
+	if h.masterKeyConfigured {
+		return auditlog.AuthMethodMasterKey
+	}
+	return authVerifyMethodNone
+}

--- a/internal/server/auth_verify_handler.go
+++ b/internal/server/auth_verify_handler.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"context"
+	"crypto/subtle"
 	"net/http"
 
 	"github.com/labstack/echo/v5"
@@ -11,9 +11,11 @@ import (
 	"github.com/enterpilot/gomodel/internal/core"
 )
 
-// authVerifyMethodNone is reported when the request reached the handler
-// without any credential being checked, which only happens on a gateway that
-// has no authentication configured at all.
+// authVerifyMethodNone is reported when the request carried no credential this
+// gateway recognizes. Requests with an unusable credential are rejected by the
+// authentication middleware long before the handler, so this is reached only
+// where that middleware admits unauthenticated callers: a gateway with no
+// authentication configured, or a route an extension excluded from it.
 const authVerifyMethodNone = "none"
 
 // authVerifyResponse is the answer of the credential check: whether the
@@ -24,7 +26,8 @@ type authVerifyResponse struct {
 	// Method is "api_key" for a managed key stored in the database,
 	// "master_key" for the bootstrap key, an extension-specific value for
 	// identities supplied by an authentication extension, or "none" when the
-	// gateway checked no credential.
+	// request carried no credential this gateway recognizes, which is also
+	// when Valid is false.
 	Method string `json:"method"`
 	// KeyID identifies the managed auth key that authenticated the request.
 	// Empty for every other method.
@@ -51,7 +54,7 @@ type authVerifyResponse struct {
 // key to confirm.
 //
 // @Summary      Verify an API key
-// @Description  Reports whether the presented credential authenticates against this gateway. Returns 401 when it does not. Disabled unless AUTH_VERIFY_ENABLED is set.
+// @Description  Reports whether the presented credential authenticates against this gateway. Returns 401 when it does not. A gateway with no authentication configured has no credential to confirm and answers 200 with valid=false and method=none. Disabled unless AUTH_VERIFY_ENABLED is set.
 // @Tags         auth
 // @Produce      json
 // @Security     BearerAuth
@@ -61,7 +64,7 @@ type authVerifyResponse struct {
 func (h *Handler) AuthVerify(c *echo.Context) error {
 	ctx := c.Request().Context()
 
-	method := h.authVerifyMethod(ctx)
+	method := h.authVerifyMethod(c)
 	response := authVerifyResponse{
 		Valid:    method != authVerifyMethodNone,
 		Method:   method,
@@ -75,11 +78,18 @@ func (h *Handler) AuthVerify(c *echo.Context) error {
 	return c.JSON(http.StatusOK, response)
 }
 
-// authVerifyMethod names the mechanism that let the request through. It is
-// read back from what the authentication middleware already attached to the
-// context rather than published as another context value, so the credential
-// check costs the model routes nothing.
-func (h *Handler) authVerifyMethod(ctx context.Context) string {
+// authVerifyMethod names the mechanism that authenticated the request. Every
+// answer rests on positive evidence rather than on the request having reached
+// the handler: an endpoint that attests authentication must not infer it from
+// a configuration where the middleware would normally have rejected the
+// caller. A route excluded from authentication (an extension's skip path)
+// therefore reports no credential instead of the configured master key.
+//
+// Managed keys and extension identities are read back from what the middleware
+// already attached to the context, so the model routes pay nothing for this
+// route; only the master key is re-compared here, on this request alone.
+func (h *Handler) authVerifyMethod(c *echo.Context) string {
+	ctx := c.Request().Context()
 	if core.GetAuthKeyID(ctx) != "" {
 		return auditlog.AuthMethodAPIKey
 	}
@@ -89,11 +99,11 @@ func (h *Handler) authVerifyMethod(ctx context.Context) string {
 		}
 		return auditlog.AuthMethodExtension
 	}
-	// Nothing else can have satisfied the middleware: without a master key,
-	// a request carrying no managed or extension identity never reaches a
-	// handler unless the gateway authenticates nobody at all.
-	if h.masterKeyConfigured {
-		return auditlog.AuthMethodMasterKey
+	if h.masterKey != "" {
+		if token, _ := requestAuthToken(c.Request()); token != "" &&
+			subtle.ConstantTimeCompare([]byte(token), []byte(h.masterKey)) == 1 {
+			return auditlog.AuthMethodMasterKey
+		}
 	}
 	return authVerifyMethodNone
 }

--- a/internal/server/auth_verify_handler_test.go
+++ b/internal/server/auth_verify_handler_test.go
@@ -73,6 +73,69 @@ func TestAuthVerify_ExtensionIdentity(t *testing.T) {
 	assert.Equal(t, authVerifyResponse{Valid: true, Method: "oidc", UserPath: "/team"}, body)
 }
 
+// A route excluded from authentication reaches the handler with no credential
+// checked. The answer must rest on the request itself: a configured master key
+// is not evidence that this caller presented one.
+func TestAuthVerify_SkippedAuthenticationDoesNotClaimMasterKey(t *testing.T) {
+	cfg := &Config{
+		AuthVerifyEnabled:  true,
+		MasterKey:          "master",
+		ExtraAuthSkipPaths: []string{"/v1/auth/verify"},
+	}
+
+	rec, body := getAuthVerify(t, cfg, "")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, authVerifyResponse{Valid: false, Method: "none"}, body)
+
+	rec, body = getAuthVerify(t, cfg, "not-the-master-key")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, authVerifyResponse{Valid: false, Method: "none"}, body)
+
+	// The same skipped route still confirms a caller that does present it.
+	rec, body = getAuthVerify(t, cfg, "master")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, authVerifyResponse{Valid: true, Method: "master_key"}, body)
+}
+
+// The other cases decode into the response type, which cannot catch a changed
+// JSON tag or a dropped omitempty. This one asserts the wire shape itself.
+func TestAuthVerify_JSONShape(t *testing.T) {
+	cfg := &Config{
+		AuthVerifyEnabled: true,
+		MasterKey:         "master",
+		Authenticator: mockAuthenticator{
+			enabled:   true,
+			tokenToID: map[string]string{"sk_gom_token": "key-123"},
+			tokenPath: map[string]string{"sk_gom_token": "/team"},
+		},
+	}
+
+	srv := New(&mockProvider{}, cfg)
+	decode := func(token string) map[string]any {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/v1/auth/verify", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body), "body: %s", rec.Body.String())
+		return body
+	}
+
+	assert.Equal(t, map[string]any{
+		"valid":     true,
+		"method":    "api_key",
+		"key_id":    "key-123",
+		"user_path": "/team",
+	}, decode("sk_gom_token"))
+
+	// key_id and user_path belong to managed keys only; they must be absent
+	// rather than empty strings for every other method.
+	assert.Equal(t, map[string]any{"valid": true, "method": "master_key"}, decode("master"))
+}
+
 func TestAuthVerify_InvalidKeyIsRejected(t *testing.T) {
 	cfg := &Config{
 		AuthVerifyEnabled: true,

--- a/internal/server/auth_verify_handler_test.go
+++ b/internal/server/auth_verify_handler_test.go
@@ -1,0 +1,112 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/enterpilot/gomodel/ext"
+)
+
+func getAuthVerify(t *testing.T, cfg *Config, token string) (*httptest.ResponseRecorder, authVerifyResponse) {
+	t.Helper()
+	srv := New(&mockProvider{}, cfg)
+	req := httptest.NewRequest(http.MethodGet, "/v1/auth/verify", nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	var body authVerifyResponse
+	if rec.Code == http.StatusOK {
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body), "body: %s", rec.Body.String())
+	}
+	return rec, body
+}
+
+func TestAuthVerify_RouteDisabledByDefault(t *testing.T) {
+	rec, _ := getAuthVerify(t, &Config{MasterKey: "master"}, "master")
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestAuthVerify_ManagedKey(t *testing.T) {
+	cfg := &Config{
+		AuthVerifyEnabled: true,
+		MasterKey:         "master",
+		Authenticator: mockAuthenticator{
+			enabled:   true,
+			tokenToID: map[string]string{"sk_gom_token": "key-123"},
+			tokenPath: map[string]string{"sk_gom_token": "/team"},
+		},
+	}
+
+	rec, body := getAuthVerify(t, cfg, "sk_gom_token")
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "no-store", rec.Header().Get("Cache-Control"))
+	assert.Equal(t, authVerifyResponse{Valid: true, Method: "api_key", KeyID: "key-123", UserPath: "/team"}, body)
+}
+
+func TestAuthVerify_MasterKey(t *testing.T) {
+	rec, body := getAuthVerify(t, &Config{AuthVerifyEnabled: true, MasterKey: "master"}, "master")
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, authVerifyResponse{Valid: true, Method: "master_key"}, body)
+}
+
+func TestAuthVerify_ExtensionIdentity(t *testing.T) {
+	cfg := &Config{
+		AuthVerifyEnabled: true,
+		RequestAuthenticators: []ext.RequestAuthenticator{&mockRequestAuthenticator{
+			result: &ext.Authentication{PrincipalID: "principal-1", UserPath: "/team", Method: "oidc"},
+		}},
+	}
+
+	rec, body := getAuthVerify(t, cfg, "")
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, authVerifyResponse{Valid: true, Method: "oidc", UserPath: "/team"}, body)
+}
+
+func TestAuthVerify_InvalidKeyIsRejected(t *testing.T) {
+	cfg := &Config{
+		AuthVerifyEnabled: true,
+		Authenticator: mockAuthenticator{
+			enabled:   true,
+			tokenToID: map[string]string{"sk_gom_token": "key-123"},
+		},
+	}
+
+	rec, _ := getAuthVerify(t, cfg, "sk_gom_unknown")
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.NotContains(t, rec.Body.String(), "sk_gom_unknown")
+}
+
+func TestAuthVerify_MissingCredentialIsRejected(t *testing.T) {
+	rec, _ := getAuthVerify(t, &Config{AuthVerifyEnabled: true, MasterKey: "master"}, "")
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// A gateway without any configured authentication accepts every request, so
+// the endpoint has no credential to confirm and says so instead of claiming
+// the presented key is valid.
+func TestAuthVerify_NoAuthenticationConfigured(t *testing.T) {
+	for name, cfg := range map[string]*Config{
+		"no auth mechanism":         {AuthVerifyEnabled: true},
+		"authenticator not enabled": {AuthVerifyEnabled: true, Authenticator: mockAuthenticator{}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			rec, body := getAuthVerify(t, cfg, "anything")
+
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.Equal(t, authVerifyResponse{Valid: false, Method: "none"}, body)
+		})
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -58,10 +58,10 @@ type Handler struct {
 	storageProbe                 ReadinessProbe
 	cacheProbe                   ReadinessProbe
 	versionChecker               *versioncheck.Checker
-	// masterKeyConfigured mirrors Config.MasterKey without keeping the secret
-	// itself; GET /v1/auth/verify uses it to name the mechanism that
-	// authenticated a request.
-	masterKeyConfigured bool
+	// masterKey mirrors Config.MasterKey so GET /v1/auth/verify can confirm a
+	// master-key caller from the request itself instead of inferring it. It is
+	// only ever compared against, never logged or returned.
+	masterKey string
 
 	translatedSvc     *translatedInferenceService // snapshot of handler fields at first use; server.New sets cache/hash before traffic
 	translatedSvcOnce sync.Once

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -58,6 +58,10 @@ type Handler struct {
 	storageProbe                 ReadinessProbe
 	cacheProbe                   ReadinessProbe
 	versionChecker               *versioncheck.Checker
+	// masterKeyConfigured mirrors Config.MasterKey without keeping the secret
+	// itself; GET /v1/auth/verify uses it to name the mechanism that
+	// authenticated a request.
+	masterKeyConfigured bool
 
 	translatedSvc     *translatedInferenceService // snapshot of handler fields at first use; server.New sets cache/hash before traffic
 	translatedSvcOnce sync.Once

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -214,7 +214,7 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 	handler.realtimeEnabled = cfg == nil || cfg.RealtimeEnabled
 	if cfg != nil {
 		handler.versionChecker = cfg.VersionChecker
-		handler.masterKeyConfigured = cfg.MasterKey != ""
+		handler.masterKey = cfg.MasterKey
 	}
 	if cfg != nil {
 		handler.mcpEnabled = cfg.MCPEnabled

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -99,6 +99,7 @@ type Config struct {
 	LogOnlyModelInteractions        bool                                   // Only log AI model endpoints (default: true)
 	DisablePassthroughRoutes        bool                                   // Disable /p/{provider}/{endpoint} route registration
 	RealtimeEnabled                 bool                                   // Enable the realtime websocket routes (/v1/realtime, /v1/realtime/translations) and passthrough upgrades
+	AuthVerifyEnabled               bool                                   // Enable the credential check route (GET /v1/auth/verify); off by default
 	MCPEnabled                      bool                                   // Enable the MCP gateway routes /mcp and /mcp/{server}
 	MCPGateway                      *mcpgateway.Service                    // MCP gateway service (nil if disabled or not wired)
 	EnabledPassthroughProviders     []string                               // Provider types enabled on /p/{provider}/... passthrough routes
@@ -213,6 +214,7 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 	handler.realtimeEnabled = cfg == nil || cfg.RealtimeEnabled
 	if cfg != nil {
 		handler.versionChecker = cfg.VersionChecker
+		handler.masterKeyConfigured = cfg.MasterKey != ""
 	}
 	if cfg != nil {
 		handler.mcpEnabled = cfg.MCPEnabled
@@ -430,6 +432,11 @@ func New(provider core.RoutableProvider, cfg *Config) *Server {
 	}
 	e.GET("/v1/models", handler.ListModels)
 	e.GET("/v1/usage", handler.UsageStatus)
+	// Opt-in: the route answers questions about credentials, so it is only
+	// mounted where an operator asked for it.
+	if cfg != nil && cfg.AuthVerifyEnabled {
+		e.GET("/v1/auth/verify", handler.AuthVerify)
+	}
 	e.POST("/v1/chat/completions", handler.ChatCompletion)
 	e.POST("/v1/messages", handler.Messages)
 	e.POST("/v1/messages/count_tokens", handler.CountMessageTokens)


### PR DESCRIPTION
Adds `GET /v1/auth/verify`, which reports whether the API key a request carries authenticates against this gateway, so a service in front of GoModel can validate keys without holding a copy of them.

- Disabled by default; enabled with `AUTH_VERIFY_ENABLED` / `server.auth_verify_enabled`.
- Not an `/admin` route, so it keeps working with the admin API disabled.
- The endpoint adds no credential check of its own: the request passes the usual authentication middleware, so an unknown, disabled, or expired key is rejected there with 401 and a 200 means the key authenticates. The body reports `method` (`api_key` for a managed key stored in the database, `master_key` for the bootstrap key, the extension's method for extension identities) plus `key_id` and `user_path` for managed keys.
- On a gateway with no authentication configured, every request is accepted and there is no key to confirm, so the answer is `{"valid": false, "method": "none"}` rather than a false positive.

The method is derived from what the middleware already put in the request context, so the model hot path is unchanged (perf guard passes at its current thresholds).

Docs: API endpoints reference, configuration table, `.env.template`, `config.example.yaml`, regenerated `docs/openapi.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `GET /v1/auth/verify` endpoint for checking gateway credentials.
  * Reports authentication status and method without exposing credentials.
  * Supports managed API keys, master keys, and extension-based authentication.
  * Returns unauthorized for invalid credentials; unauthenticated gateways report no configured authentication.
  * Disabled by default and enabled through configuration.

* **Documentation**
  * Added configuration, API reference, OpenAPI, and Caddy integration documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->