### PR TITLE
docs(agents): use plain URL for official repository reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ Before opening a PR:
 
 If this repository is not the official GoModel repository, ask the user whether they also want to create a PR against the official repository:
 
-[https://github.com/ENTERPILOT/GoModel/](https://github.com/ENTERPILOT/GoModel/)
+https://github.com/ENTERPILOT/GoModel/
 
 ## Code Review
 


### PR DESCRIPTION
## TL;DR

`AGENTS.md` rendered the official repository URL as a Markdown link. Maintainer feedback on #907 asked for a plain URL string — agents read this file, a link adds nothing. The line is now a plain string: `https://github.com/ENTERPILOT/GoModel/`.

Links:

- Maintainer comment: https://github.com/ENTERPILOT/GoModel/pull/907#discussion_r3960737816

---

_This PR description was generated with [AI assistance](https://raw.githubusercontent.com/tdhopper/dotfiles2.0/master/.claude/skills/creating-pull-requests/SKILL.md)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the repository URL formatting in the pull request guidance from a Markdown hyperlink to plain text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->