### PR TITLE
fix(dashboard): confirm rate-limit deletes

### DIFF
--- a/web/dashboard/messages/de.json
+++ b/web/dashboard/messages/de.json
@@ -1365,6 +1365,8 @@
   "rate_limits_move_cleanup_failed": "Die neue Regel wurde gespeichert, aber die vorherige konnte nicht entfernt werden. Lösche sie manuell.",
   "rate_limits_delete_failed": "Rate-Limit konnte nicht gelöscht werden.",
   "rate_limits_deleted": "Rate-Limit gelöscht.",
+  "rate_limits_delete_title": "Rate-Limit löschen",
+  "rate_limits_delete_message": "Tippe \"{subject}\", um dieses Rate-Limit endgültig zu löschen. Die dadurch begrenzten Anfragen laufen danach unbegrenzt.",
   "rate_limits_reset_failed": "Rate-Limit konnte nicht zurückgesetzt werden.",
   "rate_limits_reset_success": "Rate-Limit-Zähler zurückgesetzt.",
   "rate_limits_user_path": "Nutzerpfad",

--- a/web/dashboard/messages/en.json
+++ b/web/dashboard/messages/en.json
@@ -1366,7 +1366,7 @@
   "rate_limits_delete_failed": "Unable to delete rate limit.",
   "rate_limits_deleted": "Rate limit deleted.",
   "rate_limits_delete_title": "Delete Rate Limit",
-  "rate_limits_delete_message": "Type \"{subject}\" to permanently delete this rate limit. Requests it capped run uncapped afterwards.",
+  "rate_limits_delete_message": "Type \"{subject}\" to permanently delete this rate limit. Requests previously capped by this rule will run uncapped afterwards.",
   "rate_limits_reset_failed": "Unable to reset rate limit.",
   "rate_limits_reset_success": "Rate limit counters reset.",
   "rate_limits_user_path": "User path",

--- a/web/dashboard/messages/en.json
+++ b/web/dashboard/messages/en.json
@@ -1365,6 +1365,8 @@
   "rate_limits_move_cleanup_failed": "The new rule was saved, but the previous one could not be removed. Delete it manually.",
   "rate_limits_delete_failed": "Unable to delete rate limit.",
   "rate_limits_deleted": "Rate limit deleted.",
+  "rate_limits_delete_title": "Delete Rate Limit",
+  "rate_limits_delete_message": "Type \"{subject}\" to permanently delete this rate limit. Requests it capped run uncapped afterwards.",
   "rate_limits_reset_failed": "Unable to reset rate limit.",
   "rate_limits_reset_success": "Rate limit counters reset.",
   "rate_limits_user_path": "User path",

--- a/web/dashboard/messages/pl.json
+++ b/web/dashboard/messages/pl.json
@@ -1393,6 +1393,8 @@
   "rate_limits_move_cleanup_failed": "Nowa reguła została zapisana, ale poprzedniej nie udało się usunąć. Usuń ją ręcznie.",
   "rate_limits_delete_failed": "Nie udało się usunąć Rate Limitu.",
   "rate_limits_deleted": "Usunięto Rate Limit.",
+  "rate_limits_delete_title": "Usuń Rate Limit",
+  "rate_limits_delete_message": "Wpisz \"{subject}\", aby trwale usunąć ten Rate Limit. Ograniczane przez niego żądania będą potem bez limitu.",
   "rate_limits_reset_failed": "Nie udało się zresetować Rate Limitu.",
   "rate_limits_reset_success": "Zresetowano liczniki Rate Limitu.",
   "rate_limits_user_path": "User Path",

--- a/web/dashboard/messages/zh-CN.json
+++ b/web/dashboard/messages/zh-CN.json
@@ -1236,6 +1236,8 @@
   "rate_limits_move_cleanup_failed": "新规则已保存，但旧规则无法删除，请手动删除。",
   "rate_limits_delete_failed": "无法删除限流。",
   "rate_limits_deleted": "限流已删除。",
+  "rate_limits_delete_title": "删除限流",
+  "rate_limits_delete_message": "输入“{subject}”以永久删除此限流。此后被它限制的请求将不再受限。",
   "rate_limits_reset_failed": "无法重置限流。",
   "rate_limits_reset_success": "限流计数器已重置。",
   "rate_limits_user_path": "用户路径",

--- a/web/dashboard/src/pages/rate-limits/RateLimitList.svelte
+++ b/web/dashboard/src/pages/rate-limits/RateLimitList.svelte
@@ -89,7 +89,7 @@
                         ? m.rate_limits_deleting_action()
                         : m.rate_limits_delete_action()}
                       class="table-action-btn-danger budget-action-btn"
-                      onclick={() => rateLimits.deleteRateLimit(item)}
+                      onclick={() => rateLimits.requestDeleteRateLimit(item)}
                       disabled={rateLimits.rateLimitDeletingKey === rateLimits.rateLimitKey(item)}
                     >
                       <Icon icon={Trash2} class="budget-action-icon" />

--- a/web/dashboard/src/pages/rate-limits/rateLimits.svelte.js
+++ b/web/dashboard/src/pages/rate-limits/rateLimits.svelte.js
@@ -4,11 +4,13 @@
 
 import { loadAdminList, sendAdminMutation } from "$lib/api/adminCrud.js";
 import { flash } from "$lib/stores/flash.svelte.js";
+import { confirmDialog } from "$lib/stores/confirm.svelte.js";
 import { runtimeConfig } from "$lib/stores/runtimeConfig.svelte.js";
 import { access } from "$lib/stores/access.svelte.js";
 import { scopedSubjectAllowed } from "$lib/stores/accessScope.js";
 import * as m from "$lib/paraglide/messages.js";
 import * as logic from "./rateLimitsLogic.js";
+import { Trash2 } from "lucide";
 
 class RateLimitsStore {
   rateLimits = $state([]);
@@ -398,6 +400,25 @@ class RateLimitsStore {
     return true;
   }
 
+  // requestDeleteRateLimit drives the shared typed-confirmation dialog
+  // rather than deleting outright: a stray click on the list row can no
+  // longer remove a rule (#900). The operator types the rule's subject to
+  // confirm.
+  requestDeleteRateLimit(item) {
+    const subject = logic.rateLimitSubject(item) || "/";
+    confirmDialog.open({
+      title: m.rate_limits_delete_title(),
+      titleId: "rateLimitDeleteDialogTitle",
+      inputId: "rate-limit-delete-confirmation",
+      message: m.rate_limits_delete_message({ subject }),
+      requiredText: subject,
+      confirmLabel: m.rate_limits_delete(),
+      icon: Trash2,
+      dialogClass: "budget-reset-dialog",
+      onConfirm: () => this.deleteRateLimit(item),
+    });
+  }
+
   async deleteRateLimit(item) {
     const key = logic.rateLimitKey(item);
     if (this.rateLimitDeletingKey === key) {
@@ -423,12 +444,15 @@ class RateLimitsStore {
       return;
     }
     if (outcome.status !== "ok") {
-      flash.error(outcome.error);
+      // The failure stays inside the confirmation dialog, which is still
+      // open (like the provider-credential delete).
+      confirmDialog.error = outcome.error;
       return;
     }
     this.rateLimits = logic.normalizeRateLimitListPayload(outcome.result.data);
     this.normalizeActiveScope();
     flash.success(m.rate_limits_deleted());
+    confirmDialog.close();
   }
 
   async resetRateLimit(item) {

--- a/web/dashboard/tests/rate-limits.test.js
+++ b/web/dashboard/tests/rate-limits.test.js
@@ -6,7 +6,12 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { overwriteGetLocale } from "../src/lib/paraglide/runtime.js";
+
+const SRC = fileURLToPath(new URL("../src", import.meta.url));
 
 import {
   defaultRateLimitForm,
@@ -682,5 +687,37 @@ test("inspector summary reports in-flight or per-cap usage", () => {
       requests_used: 10,
     }),
     "10/100 req",
+  );
+});
+
+// Guard for the delete-confirmation contract (#900): the list button must
+// open the shared typed-confirmation dialog instead of deleting outright,
+// failures stay inside the dialog, and only a successful delete closes it.
+// There is no DOM test harness in this suite, so this asserts the wiring
+// contract directly on the source (like editor-dialog.test.js).
+test("rate-limit deletes route through the typed confirmation dialog", () => {
+  const storeSource = readFileSync(
+    join(SRC, "pages/rate-limits/rateLimits.svelte.js"),
+    "utf8",
+  );
+  const listSource = readFileSync(
+    join(SRC, "pages/rate-limits/RateLimitList.svelte"),
+    "utf8",
+  );
+
+  // The dialog requires the rule's subject back and deletes on confirm.
+  assert.match(
+    storeSource,
+    /confirmDialog\.open\(\{[\s\S]*?requiredText: subject,[\s\S]*?onConfirm: \(\) => this\.deleteRateLimit\(item\)/,
+  );
+  // Failures stay inside the dialog; success closes it.
+  assert.match(storeSource, /confirmDialog\.error = outcome\.error;/);
+  assert.match(storeSource, /confirmDialog\.close\(\);/);
+  // The list button opens the confirmation; no path deletes outright.
+  assert.match(listSource, /onclick=\{\(\) => rateLimits\.requestDeleteRateLimit\(item\)\}/);
+  assert.equal(
+    listSource.match(/onclick=\{\(\) => rateLimits\.deleteRateLimit\(item\)\}/),
+    null,
+    "a list path deletes without confirmation",
   );
 });

--- a/web/dashboard/tests/rate-limits.test.js
+++ b/web/dashboard/tests/rate-limits.test.js
@@ -705,14 +705,31 @@ test("rate-limit deletes route through the typed confirmation dialog", () => {
     "utf8",
   );
 
-  // The dialog requires the rule's subject back and deletes on confirm.
-  assert.match(
-    storeSource,
-    /confirmDialog\.open\(\{[\s\S]*?requiredText: subject,[\s\S]*?onConfirm: \(\) => this\.deleteRateLimit\(item\)/,
+  // The dialog requires the rule's subject back and deletes on confirm —
+  // asserted inside requestDeleteRateLimit's body, not anywhere in the store.
+  const requestDelete = storeSource.match(
+    /requestDeleteRateLimit\(item\) \{[\s\S]*?\n  \}/,
   );
-  // Failures stay inside the dialog; success closes it.
-  assert.match(storeSource, /confirmDialog\.error = outcome\.error;/);
-  assert.match(storeSource, /confirmDialog\.close\(\);/);
+  assert.ok(requestDelete, "requestDeleteRateLimit method missing");
+  assert.match(requestDelete[0], /requiredText: subject,/);
+  assert.match(
+    requestDelete[0],
+    /onConfirm: \(\) => this\.deleteRateLimit\(item\)/,
+  );
+
+  // Failures stay inside the dialog; only success closes it — asserted
+  // inside deleteRateLimit's body, failure branch before the success close.
+  const deleteRateLimit = storeSource.match(
+    /async deleteRateLimit\(item\) \{[\s\S]*?\n  \}/,
+  );
+  assert.ok(deleteRateLimit, "deleteRateLimit method missing");
+  assert.match(deleteRateLimit[0], /confirmDialog\.error = outcome\.error;/);
+  assert.match(deleteRateLimit[0], /confirmDialog\.close\(\);/);
+  assert.ok(
+    deleteRateLimit[0].indexOf("confirmDialog.error = outcome.error;") <
+      deleteRateLimit[0].indexOf("confirmDialog.close();"),
+    "the failure branch must come before the success close",
+  );
   // The list button opens the confirmation; no path deletes outright.
   assert.match(listSource, /onclick=\{\(\) => rateLimits\.requestDeleteRateLimit\(item\)\}/);
   assert.equal(

--- a/web/dashboard/tests/rate-limits.test.js
+++ b/web/dashboard/tests/rate-limits.test.js
@@ -723,12 +723,17 @@ test("rate-limit deletes route through the typed confirmation dialog", () => {
     /async deleteRateLimit\(item\) \{[\s\S]*?\n  \}/,
   );
   assert.ok(deleteRateLimit, "deleteRateLimit method missing");
-  assert.match(deleteRateLimit[0], /confirmDialog\.error = outcome\.error;/);
-  assert.match(deleteRateLimit[0], /confirmDialog\.close\(\);/);
+  // The failure branch must be guarded by the non-ok status, assign the
+  // dialog error, and return; the close belongs to the success path after
+  // that branch, not inside it.
+  const failureBranch = deleteRateLimit[0].match(
+    /if \(outcome\.status !== "ok"\) \{[\s\S]*?confirmDialog\.error = outcome\.error;[\s\S]*?return;[\s\S]*?\n    \}/,
+  );
+  assert.ok(failureBranch, "deleteRateLimit failure branch missing");
   assert.ok(
-    deleteRateLimit[0].indexOf("confirmDialog.error = outcome.error;") <
+    deleteRateLimit[0].indexOf(failureBranch[0]) <
       deleteRateLimit[0].indexOf("confirmDialog.close();"),
-    "the failure branch must come before the success close",
+    "confirmDialog.close() must run after the failure branch",
   );
   // The list button opens the confirmation; no path deletes outright.
   assert.match(listSource, /onclick=\{\(\) => rateLimits\.requestDeleteRateLimit\(item\)\}/);


### PR DESCRIPTION
## TL;DR

Rate Limits -> Delete removed the rule on a single click, so a stray click lost a live limit (#900). The delete button now opens the shared typed-confirmation dialog: type the rule's subject back to confirm. Follows the existing provider-credential delete pattern. Fixes #900.

## Behavior

| | Before | After |
|---|---|---|
| Click Delete on a rate limit row | Rule deleted instantly | Typed-confirmation dialog opens; typing the subject unlocks Delete |
| Delete fails (network/API error) | Flash banner, dialog closed | Error stays inside the dialog so the operator can retry or cancel |

## Files to review (7, +71 / -2)

| File | Why |
|---|---|
| `web/dashboard/src/pages/rate-limits/rateLimits.svelte.js` *(start here)* | `requestDeleteRateLimit` opens the shared `confirmDialog` with `requiredText: <subject>`; `deleteRateLimit` now reports failures into `confirmDialog.error` and closes the dialog only on success. |
| `web/dashboard/src/pages/rate-limits/RateLimitList.svelte` | Delete button routes through `requestDeleteRateLimit`; no path deletes outright. |
| `web/dashboard/messages/{en,de,pl,zh-CN}.json` | Dialog title and message in all locales. |
| `web/dashboard/tests/rate-limits.test.js` | Source-guard test for the confirmation wiring (dialog opened, failures kept in-dialog, no outright-delete path). |

## How it works

- Reuses the global `confirmDialog` store and `TypedConfirmationDialog`, so the prompt matches the provider-credential delete (type-to-confirm, danger-styled, loading state on submit).
- The typed text is the rule's subject: a user path (`/engineering/ai`), provider, or model name. Same identity used in the DELETE payload, so what you type is what gets deleted.
- The inspector and editor are untouched; reset stays a one-click flash-less action like before.

## Tests

- `make test-dashboard`: 650 pass, 0 fail (includes the new source-guard test).
- `npm run check` (svelte-check): 0 errors, 0 warnings.

## Links

- Fixes #900
- Follow-up to #874 (merged via #918, which introduced the shared confirmation plumbing this reuses).

---
_This PR description was generated with [AI assistance](https://raw.githubusercontent.com/tdhopper/dotfiles2.0/master/.claude/skills/creating-pull-requests/SKILL.md)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Rate-limit deletion now requires typing the rule’s subject to confirm.
  - Deletion errors remain visible in the confirmation dialog, while successful deletions close it automatically.
  - Requests previously limited by a deleted rule are no longer capped.
  - Added localized confirmation text in English, German, Polish, and Simplified Chinese.
- **Tests**
  - Added coverage for typed confirmation, successful deletion, error handling, and preventing accidental direct deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->