### PR TITLE
fix(anthropic): carry thinking signatures back to the client

### DIFF
--- a/cmd/gomodel/docs/docs.go
+++ b/cmd/gomodel/docs/docs.go
@@ -4335,6 +4335,37 @@ const docTemplate = `{
                 ]
             }
         },
+        "/v1/auth/verify": {
+            "get": {
+                "description": "Reports whether the presented credential authenticates against this gateway. Returns 401 when it does not. A gateway with no authentication configured has no credential to confirm and answers 200 with valid=false and method=none. Disabled unless AUTH_VERIFY_ENABLED is set.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Verify an API key",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/server.authVerifyResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/core.OpenAIErrorEnvelope"
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ]
+            }
+        },
         "/v1/batches": {
             "get": {
                 "produces": [
@@ -8706,6 +8737,10 @@ const docTemplate = `{
         "anthropicapi.ResponseContentBlock": {
             "type": "object",
             "properties": {
+                "data": {
+                    "description": "Data is the opaque payload of a redacted_thinking block.",
+                    "type": "string"
+                },
                 "extra_content": {
                     "description": "ExtraContent is provider replay state on a tool_use block; clients echo\nit back on the next turn (see core.ExtraContentField).",
                     "type": "object"
@@ -8718,6 +8753,10 @@ const docTemplate = `{
                     "additionalProperties": true
                 },
                 "name": {
+                    "type": "string"
+                },
+                "signature": {
+                    "description": "Signature authenticates a thinking block. Anthropic requires it back\nverbatim when the conversation continues, so clients must echo it.",
                     "type": "string"
                 },
                 "text": {
@@ -8913,7 +8952,7 @@ const docTemplate = `{
                     }
                 },
                 "request_revisions": {
-                    "description": "RequestRevisions captures the ingress request-rewrite chain: one entry\nper registered rewriter that ran, in application order. Rewriters that\nchanged the body carry the rewritten body; those that left it alone are\nrecorded with NoChange so the audit trail still shows the step ran.\nRequestBody always remains the original client request; the last\nchanged revision is what was forwarded downstream — when every rewriter\nwas a no-op there is no such revision and the original body is what\nwent upstream.",
+                    "description": "RequestRevisions captures the ingress request-rewrite chain: one entry\nper registered rewriter that ran, in application order, followed by the\nprompt-guardrail steps. Rewriters that changed the body carry the\nrewritten body; those that left it alone are recorded with NoChange so\nthe audit trail still shows the step ran. Each prompt guardrail that\nedited the prompt is a changed revision, in step order, carrying the\nrequest as it stood right after that step (the next step's input) with\nits sizes; one that objected (warn, block, respond) or failed without\nediting is a NoChange entry carrying the decision, and a silent allow\nleaves no entry. RequestBody always remains the original client\nrequest; the last changed revision is what was forwarded downstream —\nwhen every step was a no-op there is no such revision and the original\nbody is what went upstream.",
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/auditlog.RequestRevisionSnapshot"
@@ -11150,6 +11189,26 @@ const docTemplate = `{
                 },
                 "display_name": {
                     "type": "string"
+                }
+            }
+        },
+        "server.authVerifyResponse": {
+            "type": "object",
+            "properties": {
+                "key_id": {
+                    "description": "KeyID identifies the managed auth key that authenticated the request.\nAbsent for every other method.",
+                    "type": "string"
+                },
+                "method": {
+                    "description": "Method is \"api_key\" for a managed key stored in the database,\n\"master_key\" for the bootstrap key, an extension-specific value for\nidentities supplied by an authentication extension, or \"none\" when the\nrequest carried no credential this gateway recognizes, which is also\nwhen Valid is false.",
+                    "type": "string"
+                },
+                "user_path": {
+                    "description": "UserPath is the subtree the credential is bound to. Absent when the\ncredential is global, which every master-key caller is.",
+                    "type": "string"
+                },
+                "valid": {
+                    "type": "boolean"
                 }
             }
         },

--- a/cmd/gomodel/docs/docs.go
+++ b/cmd/gomodel/docs/docs.go
@@ -12204,6 +12204,12 @@ const docTemplate = `{
                 "thinking": {
                     "type": "string"
                 },
+                "signature": {
+                    "type": "string"
+                },
+                "data": {
+                    "type": "string"
+                },
                 "tool_use_id": {
                     "type": "string"
                 },

--- a/docs/advanced/anthropic-messages-api.mdx
+++ b/docs/advanced/anthropic-messages-api.mdx
@@ -192,9 +192,11 @@ features that have no canonical equivalent are not preserved end to end:
   (Claude Code appends system reminders this way, and its prompt caching
   depends on them staying in place). On older Claude models, which reject the
   role, their text is hoisted into the top-level system prompt instead.
-- **`thinking` and `redacted_thinking` blocks** on assistant turns are replayed
-  verbatim (signatures included) when routed to Anthropic, so thinking-enabled
-  tool-use turns continue correctly. Other providers never see them.
+- **`thinking` and `redacted_thinking` blocks** travel both ways verbatim,
+  signatures included: responses carry the `signature` Anthropic issued (as a
+  `signature_delta` when streaming), and an assistant turn echoed back is
+  replayed unchanged, so thinking-enabled conversations and tool-use loops
+  continue correctly. Other providers never see them.
 - **`tool_result.is_error`** is preserved when routed to Anthropic. Other
   providers have no equivalent flag and receive the result content only.
 - **`tool_use.extra_content`** carries another provider's replay state, such as

--- a/docs/advanced/extra-content.mdx
+++ b/docs/advanced/extra-content.mdx
@@ -39,9 +39,9 @@ against it work unchanged.
 
 | API | Location |
 | --- | --- |
-| Chat Completions | `tool_calls[].extra_content`; for text-only turns, `message.extra_content`; also on streamed `tool_calls` deltas |
-| Responses | `function_call` output items |
-| Anthropic Messages | `tool_use` content blocks |
+| Chat Completions | `tool_calls[].extra_content`; on the assistant message for turn-wide state such as thinking blocks; also on streamed `tool_calls` and message deltas |
+| Responses | `function_call` output items; `reasoning` output items |
+| Anthropic Messages | `tool_use` content blocks. Thinking blocks use the dialect's own `signature` and `data` fields instead. |
 
 State sits on the unit that maps to one provider part. A tool call becomes one
 Gemini `part`, so a per-call signature lives on the tool call. Thinking blocks
@@ -244,10 +244,64 @@ the flow is:
   </Step>
 </Steps>
 
-GoModel returns `thinking` blocks in Anthropic Messages responses as text
-only. The signature Anthropic issues is not yet carried back on the response
-side, so a replay with signed blocks currently works for histories captured
-from Anthropic directly or through a client that kept them.
+### On the way back
+
+Anthropic signs every thinking block it returns, and rejects a later turn that
+replays one without its signature:
+
+```text
+400 messages.1.content.0.thinking.signature: Field required
+```
+
+So the blocks travel out to the client the same way they travel in. The
+Anthropic Messages API renders them as real content blocks, signature
+included, because that is what an Anthropic client echoes back:
+
+```json
+{
+  "content": [
+    {"type": "thinking", "thinking": "I should call the weather tool.", "signature": "EqQBCkYIBRgC..."},
+    {"type": "tool_use", "id": "toolu_1", "name": "get_weather", "input": {"city": "Kraków"}}
+  ],
+  "stop_reason": "tool_use"
+}
+```
+
+Streaming emits the signature as a `signature_delta` inside the thinking
+block, before it closes, exactly as Anthropic does.
+
+The other dialects have no thinking block, so they carry the same data under
+`extra_content.anthropic.thinking_blocks` — on the assistant message in Chat
+Completions, on the `reasoning` output item in the Responses API. Streaming
+chat deltas carry the value once the thinking block completes, before any
+text, and it is cumulative: the last one seen holds the whole turn.
+
+```json
+{
+  "role": "assistant",
+  "content": "Let me look that up.",
+  "reasoning_content": "I should call the weather tool.",
+  "extra_content": {"anthropic": {"thinking_blocks": [
+    {"type": "thinking", "thinking": "I should call the weather tool.", "signature": "EqQBCkYIBRgC..."}
+  ]}}
+}
+```
+
+`reasoning_content` stays what it has always been: the readable text, and
+nothing to replay. A `redacted_thinking` block has no readable text at all,
+so `extra_content` is the only thing that carries it.
+
+Append the assistant turn to the history as received and the replay is
+automatic. Routing that history to another provider drops the member, as
+every foreign vendor object is dropped, and the conversation continues
+without it.
+
+<Note>
+  Streaming the Responses API against Anthropic does not emit reasoning items,
+  so a streamed `/v1/responses` turn has no thinking to replay. Use the
+  non-streaming call, or the Messages and Chat Completions dialects, when a
+  thinking conversation has to continue.
+</Note>
 
 ## Moving a history between providers
 
@@ -270,4 +324,4 @@ GoModel sends upstream.
 | Vendor | Providers | Members |
 | --- | --- | --- |
 | `google` | `gemini`, `vertex` | `thought_signature`: the Gemini 3 signature of a function call or text turn. |
-| `anthropic` | `anthropic` | `thinking_blocks`: the `thinking` and `redacted_thinking` blocks of an assistant turn; `is_error`: marks a tool result as failed. Set by the Anthropic Messages API ingress. |
+| `anthropic` | `anthropic` | `thinking_blocks`: the `thinking` and `redacted_thinking` blocks of an assistant turn, signatures included, written on responses and read back on requests; `is_error`: marks a tool result as failed, set by the Anthropic Messages API ingress. |

--- a/docs/advanced/extra-content.mdx
+++ b/docs/advanced/extra-content.mdx
@@ -296,12 +296,6 @@ automatic. Routing that history to another provider drops the member, as
 every foreign vendor object is dropped, and the conversation continues
 without it.
 
-<Note>
-  Streaming the Responses API against Anthropic does not emit reasoning items,
-  so a streamed `/v1/responses` turn has no thinking to replay. Use the
-  non-streaming call, or the Messages and Chat Completions dialects, when a
-  thinking conversation has to continue.
-</Note>
 
 ## Moving a history between providers
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -12472,6 +12472,10 @@
       "anthropicapi.ResponseContentBlock": {
         "type": "object",
         "properties": {
+          "data": {
+            "description": "Data is the opaque payload of a redacted_thinking block.",
+            "type": "string"
+          },
           "extra_content": {
             "description": "ExtraContent is provider replay state on a tool_use block; clients echo\nit back on the next turn (see core.ExtraContentField).",
             "type": "object"
@@ -12484,6 +12488,10 @@
             "additionalProperties": true
           },
           "name": {
+            "type": "string"
+          },
+          "signature": {
+            "description": "Signature authenticates a thinking block. Anthropic requires it back\nverbatim when the conversation continues, so clients must echo it.",
             "type": "string"
           },
           "text": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -16052,6 +16052,12 @@
           "thinking": {
             "type": "string"
           },
+          "signature": {
+            "type": "string"
+          },
+          "data": {
+            "type": "string"
+          },
           "tool_use_id": {
             "type": "string"
           },

--- a/internal/anthropicapi/response.go
+++ b/internal/anthropicapi/response.go
@@ -28,7 +28,9 @@ func FromChatResponse(resp *core.ChatResponse) *MessagesResponse {
 
 	if len(resp.Choices) > 0 {
 		choice := resp.Choices[0]
-		if thinking := reasoningContent(choice.Message.ExtraFields); thinking != "" {
+		if blocks, ok := thinkingBlocks(choice.Message.ExtraFields); ok {
+			out.Content = append(out.Content, blocks...)
+		} else if thinking := reasoningContent(choice.Message.ExtraFields); thinking != "" {
 			out.Content = append(out.Content, ResponseContentBlock{Type: "thinking", Thinking: thinking})
 		}
 		if text := core.ExtractTextContent(choice.Message.Content); text != "" {
@@ -80,6 +82,26 @@ func normalizeMessageID(id string) string {
 		return id
 	}
 	return "msg_" + id
+}
+
+// thinkingBlocks renders the thinking blocks a provider preserved as replay
+// state (extra_content.anthropic.thinking_blocks). Anthropic clients echo the
+// content array back verbatim, and Anthropic rejects a thinking block whose
+// signature is missing, so the signature belongs on the block itself rather
+// than in the gateway's own member. ok is false when there is no usable replay
+// state, which is when the caller falls back to reasoning_content text.
+func thinkingBlocks(fields core.UnknownJSONFields) ([]ResponseContentBlock, bool) {
+	raw := fields.ExtraContent(core.ExtraContentVendorAnthropic)
+	if len(raw) == 0 {
+		return nil, false
+	}
+	var extra struct {
+		ThinkingBlocks []ResponseContentBlock `json:"thinking_blocks"`
+	}
+	if err := json.Unmarshal(raw, &extra); err != nil || len(extra.ThinkingBlocks) == 0 {
+		return nil, false
+	}
+	return extra.ThinkingBlocks, true
 }
 
 // reasoningContent extracts the reasoning_content surfaced by providers (e.g.

--- a/internal/anthropicapi/response_test.go
+++ b/internal/anthropicapi/response_test.go
@@ -223,3 +223,65 @@ func TestFromChatResponseStopSequenceDoesNotOverrideToolUse(t *testing.T) {
 		t.Errorf("got stop_reason=%q stop_sequence=%v, want tool_use/nil", out.StopReason, out.StopSequence)
 	}
 }
+
+// FromChatResponse renders thinking from the replay state a provider attached
+// when it has one, and falls back to plain reasoning_content text otherwise —
+// a provider with no thinking protocol of its own (DeepSeek, Cohere, …) still
+// has its reasoning surfaced, just without a signature to replay.
+func TestFromChatResponseThinkingBlocks(t *testing.T) {
+	tests := []struct {
+		name   string
+		fields map[string]json.RawMessage
+		want   string
+	}{
+		{
+			name: "signed blocks are rendered verbatim",
+			fields: map[string]json.RawMessage{
+				"reasoning_content": json.RawMessage(`"Let me think."`),
+				core.ExtraContentField: json.RawMessage(
+					`{"anthropic":{"thinking_blocks":[{"type":"thinking","thinking":"Let me think.","signature":"sig-1"},{"type":"redacted_thinking","data":"opaque"}]}}`),
+			},
+			want: `[{"type":"thinking","thinking":"Let me think.","signature":"sig-1"},{"type":"redacted_thinking","data":"opaque"},{"type":"text","text":"Hi"}]`,
+		},
+		{
+			name:   "reasoning_content alone still renders a thinking block",
+			fields: map[string]json.RawMessage{"reasoning_content": json.RawMessage(`"Let me think."`)},
+			want:   `[{"type":"thinking","thinking":"Let me think."},{"type":"text","text":"Hi"}]`,
+		},
+		{
+			name: "another vendor's replay state is not thinking",
+			fields: map[string]json.RawMessage{
+				core.ExtraContentField: json.RawMessage(`{"google":{"thought_signature":"sig"}}`),
+			},
+			want: `[{"type":"text","text":"Hi"}]`,
+		},
+		{
+			name: "a malformed member falls back to the reasoning text",
+			fields: map[string]json.RawMessage{
+				"reasoning_content":    json.RawMessage(`"Let me think."`),
+				core.ExtraContentField: json.RawMessage(`{"anthropic":{"thinking_blocks":"nope"}}`),
+			},
+			want: `[{"type":"thinking","thinking":"Let me think."},{"type":"text","text":"Hi"}]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &core.ChatResponse{Choices: []core.Choice{{
+				Message: core.ResponseMessage{
+					Role:        "assistant",
+					Content:     "Hi",
+					ExtraFields: core.UnknownJSONFieldsFromMap(tt.fields),
+				},
+				FinishReason: "stop",
+			}}}
+			got, err := json.Marshal(FromChatResponse(resp).Content)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if string(got) != tt.want {
+				t.Errorf("content = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/anthropicapi/stream.go
+++ b/internal/anthropicapi/stream.go
@@ -22,6 +22,9 @@ type chatChunk struct {
 			ReasoningContent string              `json:"reasoning_content"`
 			StopSequence     string              `json:"stop_sequence"`
 			ToolCalls        []chatToolCallDelta `json:"tool_calls"`
+			// ExtraContent is provider replay state for the turn so far;
+			// Anthropic thinking signatures arrive here.
+			ExtraContent json.RawMessage `json:"extra_content"`
 		} `json:"delta"`
 		FinishReason string `json:"finish_reason"`
 	} `json:"choices"`
@@ -87,14 +90,17 @@ type streamConverter struct {
 	buffer streaming.StreamBuffer
 	model  string
 
-	started       bool
-	blockOpen     bool
-	blockType     string
-	curIndex      int
-	nextIndex     int
-	toolBlock     map[int]int
-	stopReason    string
-	stopSequence  string
+	started      bool
+	blockOpen    bool
+	blockType    string
+	curIndex     int
+	nextIndex    int
+	toolBlock    map[int]int
+	stopReason   string
+	stopSequence string
+	// thinkingSeen counts the thinking blocks already rendered from the
+	// cumulative replay state, so a later chunk repeating them adds nothing.
+	thinkingSeen  int
 	inputEstimate int
 	usage         chatUsage
 	finalized     bool
@@ -180,6 +186,7 @@ func (sc *streamConverter) handleChunk(chunk *chatChunk) {
 				"delta": map[string]any{"type": "thinking_delta", "thinking": choice.Delta.ReasoningContent},
 			})
 		}
+		sc.handleThinkingReplay(choice.Delta.ExtraContent)
 		if choice.Delta.Content != "" {
 			sc.ensureBlock("text")
 			sc.emit("content_block_delta", map[string]any{
@@ -198,6 +205,51 @@ func (sc *streamConverter) handleChunk(chunk *chatChunk) {
 			sc.stopReason = stopReasonFromFinish(choice.FinishReason, len(sc.toolBlock) > 0)
 		}
 	}
+}
+
+// handleThinkingReplay renders the Anthropic thinking blocks a chunk carries
+// as replay state. A signed thinking block is closed by writing its
+// signature_delta into the block already open from the reasoning deltas; a
+// redacted block has no deltas at all and is emitted whole. The gateway's own
+// extra_content member never reaches the client here: the Anthropic dialect
+// has native fields for both.
+func (sc *streamConverter) handleThinkingReplay(raw json.RawMessage) {
+	vendor := core.KeepExtraContentVendor(raw, core.ExtraContentVendorAnthropic)
+	if len(vendor) == 0 {
+		return
+	}
+	var extra struct {
+		Anthropic struct {
+			ThinkingBlocks []ResponseContentBlock `json:"thinking_blocks"`
+		} `json:"anthropic"`
+	}
+	if err := json.Unmarshal(vendor, &extra); err != nil {
+		return
+	}
+	blocks := extra.Anthropic.ThinkingBlocks
+	if len(blocks) <= sc.thinkingSeen {
+		return
+	}
+	for _, block := range blocks[sc.thinkingSeen:] {
+		switch block.Type {
+		case "redacted_thinking":
+			sc.closeBlock()
+			sc.openBlock("redacted_thinking", map[string]any{"type": "redacted_thinking", "data": block.Data})
+			sc.closeBlock()
+		default:
+			if block.Signature == "" {
+				continue
+			}
+			sc.ensureBlock("thinking")
+			sc.emit("content_block_delta", map[string]any{
+				"type":  "content_block_delta",
+				"index": sc.curIndex,
+				"delta": map[string]any{"type": "signature_delta", "signature": block.Signature},
+			})
+			sc.closeBlock()
+		}
+	}
+	sc.thinkingSeen = len(blocks)
 }
 
 func (sc *streamConverter) handleToolCall(call chatToolCallDelta) {

--- a/internal/anthropicapi/stream_test.go
+++ b/internal/anthropicapi/stream_test.go
@@ -237,3 +237,97 @@ func TestStreamConverterMessageStartInputEstimate(t *testing.T) {
 		t.Errorf("message_delta usage = %+v, want real 11/1", finalUsage)
 	}
 }
+
+// TestStreamConverterThinkingSignature pins the streaming half of the thinking
+// round trip: a client that assembles the SSE events into an assistant turn
+// must end up with a signature on the thinking block, or its next request is
+// rejected by Anthropic.
+func TestStreamConverterThinkingSignature(t *testing.T) {
+	chatStream := strings.Join([]string{
+		`data: {"id":"chatcmpl-1","model":"claude-sonnet-4-5","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		`data: {"choices":[{"index":0,"delta":{"reasoning_content":"Let me "},"finish_reason":null}]}`,
+		`data: {"choices":[{"index":0,"delta":{"reasoning_content":"think."},"finish_reason":null}]}`,
+		`data: {"choices":[{"index":0,"delta":{"extra_content":{"anthropic":{"thinking_blocks":[{"type":"thinking","thinking":"Let me think.","signature":"sig-1"}]}}},"finish_reason":null}]}`,
+		`data: {"choices":[{"index":0,"delta":{"content":"Done."},"finish_reason":null}]}`,
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		`data: [DONE]`,
+		"",
+	}, "\n\n")
+
+	events := drainConverter(t, chatStream)
+	got := eventTypes(events)
+	want := []string{
+		"message_start",
+		"content_block_start", "content_block_delta", "content_block_delta", "content_block_delta", "content_block_stop",
+		"content_block_start", "content_block_delta", "content_block_stop",
+		"message_delta", "message_stop",
+	}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("event types = %v, want %v", got, want)
+	}
+
+	signature := events[4]["delta"].(map[string]any)
+	if signature["type"] != "signature_delta" || signature["signature"] != "sig-1" {
+		t.Fatalf("event 4 delta = %v, want a signature_delta carrying sig-1", signature)
+	}
+	if idx, _ := events[4]["index"].(float64); int(idx) != 0 {
+		t.Errorf("signature_delta index = %v, want the open thinking block (0)", events[4]["index"])
+	}
+	for _, event := range events {
+		if _, ok := event["extra_content"]; ok {
+			t.Errorf("event %v leaks the gateway's extra_content member", event["type"])
+		}
+	}
+}
+
+// A redacted thinking block has no deltas of its own: it arrives whole, and
+// the converter must open and close a content block for it so the client can
+// replay the opaque payload.
+func TestStreamConverterRedactedThinking(t *testing.T) {
+	chatStream := strings.Join([]string{
+		`data: {"id":"chatcmpl-1","model":"claude-sonnet-4-5","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		`data: {"choices":[{"index":0,"delta":{"extra_content":{"anthropic":{"thinking_blocks":[{"type":"redacted_thinking","data":"opaque"}]}}},"finish_reason":null}]}`,
+		`data: {"choices":[{"index":0,"delta":{"content":"Done."},"finish_reason":null}]}`,
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		`data: [DONE]`,
+		"",
+	}, "\n\n")
+
+	events := drainConverter(t, chatStream)
+	block := events[1]["content_block"].(map[string]any)
+	if events[1]["type"] != "content_block_start" || block["type"] != "redacted_thinking" || block["data"] != "opaque" {
+		t.Fatalf("event 1 = %v, want a redacted_thinking block carrying the opaque data", events[1])
+	}
+	if events[2]["type"] != "content_block_stop" {
+		t.Fatalf("event 2 = %v, want the redacted block closed immediately", events[2]["type"])
+	}
+}
+
+// The cumulative extra_content a chunk carries must not re-emit signatures the
+// converter already wrote: only blocks it has not seen yet produce events.
+func TestStreamConverterThinkingSignatureNotRepeated(t *testing.T) {
+	first := `{"type":"thinking","thinking":"a","signature":"sig-a"}`
+	second := `{"type":"thinking","thinking":"b","signature":"sig-b"}`
+	chatStream := strings.Join([]string{
+		`data: {"id":"chatcmpl-1","model":"claude-sonnet-4-5","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		`data: {"choices":[{"index":0,"delta":{"reasoning_content":"a"},"finish_reason":null}]}`,
+		`data: {"choices":[{"index":0,"delta":{"extra_content":{"anthropic":{"thinking_blocks":[` + first + `]}}},"finish_reason":null}]}`,
+		`data: {"choices":[{"index":0,"delta":{"reasoning_content":"b"},"finish_reason":null}]}`,
+		`data: {"choices":[{"index":0,"delta":{"extra_content":{"anthropic":{"thinking_blocks":[` + first + `,` + second + `]}}},"finish_reason":null}]}`,
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		`data: [DONE]`,
+		"",
+	}, "\n\n")
+
+	signatures := []string{}
+	for _, event := range drainConverter(t, chatStream) {
+		delta, ok := event["delta"].(map[string]any)
+		if !ok || delta["type"] != "signature_delta" {
+			continue
+		}
+		signatures = append(signatures, delta["signature"].(string))
+	}
+	if strings.Join(signatures, ",") != "sig-a,sig-b" {
+		t.Fatalf("signature deltas = %v, want each block signed exactly once", signatures)
+	}
+}

--- a/internal/anthropicapi/types.go
+++ b/internal/anthropicapi/types.go
@@ -118,12 +118,17 @@ type MessagesResponse struct {
 
 // ResponseContentBlock is one element of an Anthropic response content array.
 type ResponseContentBlock struct {
-	Type     string          `json:"type"`
-	Text     string          `json:"text,omitempty"`
-	Thinking string          `json:"thinking,omitempty"`
-	ID       string          `json:"id,omitempty"`
-	Name     string          `json:"name,omitempty"`
-	Input    json.RawMessage `json:"input,omitempty" swaggertype:"object"`
+	Type     string `json:"type"`
+	Text     string `json:"text,omitempty"`
+	Thinking string `json:"thinking,omitempty"`
+	// Signature authenticates a thinking block. Anthropic requires it back
+	// verbatim when the conversation continues, so clients must echo it.
+	Signature string `json:"signature,omitempty"`
+	// Data is the opaque payload of a redacted_thinking block.
+	Data  string          `json:"data,omitempty"`
+	ID    string          `json:"id,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty" swaggertype:"object"`
 	// ExtraContent is provider replay state on a tool_use block; clients echo
 	// it back on the next turn (see core.ExtraContentField).
 	ExtraContent json.RawMessage `json:"extra_content,omitempty" swaggertype:"object"`

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -4406,14 +4406,24 @@ func TestConvertAnthropicResponseToResponses_WithThinkingBlocks(t *testing.T) {
 
 			result := convertAnthropicResponseToResponses(resp, "claude-opus-4-6")
 
-			if len(result.Output) != 1 {
-				t.Fatalf("len(Output) = %d, want 1", len(result.Output))
+			// A thinking block always produces a leading reasoning item: it
+			// carries the signature the next turn has to replay, even when the
+			// model left the thinking text empty.
+			if len(result.Output) != 2 {
+				t.Fatalf("len(Output) = %d, want a reasoning item and a message", len(result.Output))
 			}
-			if len(result.Output[0].Content) == 0 {
-				t.Fatalf("len(Output[0].Content) = 0, want at least 1")
+			reasoning, message := result.Output[0], result.Output[1]
+			if reasoning.Type != "reasoning" {
+				t.Fatalf("Output[0].Type = %q, want reasoning", reasoning.Type)
 			}
-			if result.Output[0].Content[0].Text != tt.expectedText {
-				t.Errorf("expected %q, got %q", tt.expectedText, result.Output[0].Content[0].Text)
+			if raw := reasoning.ExtraFields.Lookup(core.ExtraContentField); len(raw) == 0 {
+				t.Error("the reasoning item must carry the thinking blocks as replay state")
+			}
+			if len(message.Content) == 0 {
+				t.Fatalf("len(Output[1].Content) = 0, want at least 1")
+			}
+			if message.Content[0].Text != tt.expectedText {
+				t.Errorf("expected %q, got %q", tt.expectedText, message.Content[0].Text)
 			}
 			if result.Usage.OutputTokens != 50 {
 				t.Errorf("OutputTokens = %d, want 50", result.Usage.OutputTokens)
@@ -6317,5 +6327,161 @@ func assertAdaptiveHighEffort(t *testing.T, out *anthropicRequest) {
 	}
 	if out.OutputConfig == nil || out.OutputConfig.Effort != "high" {
 		t.Fatalf("OutputConfig = %+v, want effort high", out.OutputConfig)
+	}
+}
+
+// chatStreamDeltas converts an Anthropic SSE stream and returns the delta
+// object of every emitted chat chunk.
+func chatStreamDeltas(t *testing.T, anthropicSSE string) []map[string]any {
+	t.Helper()
+	conv := newStreamConverter(io.NopCloser(strings.NewReader(anthropicSSE)), "claude-sonnet-4-5")
+	defer conv.Close() //nolint:errcheck
+
+	out, err := io.ReadAll(conv)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	deltas := []map[string]any{}
+	for line := range strings.SplitSeq(string(out), "\n") {
+		data, ok := strings.CutPrefix(strings.TrimSpace(line), "data: ")
+		if !ok || data == "[DONE]" {
+			continue
+		}
+		var chunk struct {
+			Choices []struct {
+				Delta map[string]any `json:"delta"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			t.Fatalf("unmarshal chunk %q: %v", data, err)
+		}
+		for _, choice := range chunk.Choices {
+			deltas = append(deltas, choice.Delta)
+		}
+	}
+	return deltas
+}
+
+// lastExtraContent returns the last extra_content value seen on a delta, which
+// is the authoritative cumulative value for a client that keeps only the most
+// recent one. Decoding through map[string]any sorts the members, so the
+// expected values below are in key order rather than wire order.
+func lastExtraContent(deltas []map[string]any) string {
+	for _, delta := range slices.Backward(deltas) {
+		if extra, ok := delta[core.ExtraContentField]; ok {
+			encoded, _ := json.Marshal(extra)
+			return string(encoded)
+		}
+	}
+	return ""
+}
+
+// A streamed thinking block carries its signature in a signature_delta that
+// arrives after the thinking text. Dropping it leaves the client with a
+// thinking block Anthropic will refuse on the next turn, so the converter must
+// surface it as replay state.
+func TestStreamChatCompletion_ThinkingSignatureSurfaced(t *testing.T) {
+	sse := `event: message_start
+data: {"type":"message_start","message":{"id":"msg_sig","type":"message","role":"assistant","model":"claude-sonnet-4-5","content":[],"stop_reason":null,"usage":{"input_tokens":10,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me "}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"think."}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig-1"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Done."}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":9}}
+
+event: message_stop
+data: {"type":"message_stop"}
+`
+	deltas := chatStreamDeltas(t, sse)
+	want := `{"anthropic":{"thinking_blocks":[{"signature":"sig-1","thinking":"Let me think.","type":"thinking"}]}}`
+	if got := lastExtraContent(deltas); got != want {
+		t.Fatalf("extra_content = %s, want %s", got, want)
+	}
+
+	// The signature must not arrive after the text has been streamed: a client
+	// closing the thinking block on the first text delta would drop it.
+	extraAt, textAt := -1, -1
+	for i, delta := range deltas {
+		if _, ok := delta[core.ExtraContentField]; ok && extraAt < 0 {
+			extraAt = i
+		}
+		if _, ok := delta["content"]; ok && textAt < 0 {
+			textAt = i
+		}
+	}
+	if extraAt < 0 || textAt < 0 || extraAt > textAt {
+		t.Errorf("extra_content at %d, first content at %d; want the thinking block completed first", extraAt, textAt)
+	}
+}
+
+// A redacted thinking block arrives whole on content_block_start and has no
+// readable text, so nothing but extra_content can carry it.
+func TestStreamChatCompletion_RedactedThinkingSurfaced(t *testing.T) {
+	sse := `event: message_start
+data: {"type":"message_start","message":{"id":"msg_red","type":"message","role":"assistant","model":"claude-sonnet-4-5","content":[],"stop_reason":null,"usage":{"input_tokens":10,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"redacted_thinking","data":"opaque"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":3}}
+
+event: message_stop
+data: {"type":"message_stop"}
+`
+	want := `{"anthropic":{"thinking_blocks":[{"data":"opaque","type":"redacted_thinking"}]}}`
+	if got := lastExtraContent(chatStreamDeltas(t, sse)); got != want {
+		t.Fatalf("extra_content = %s, want %s", got, want)
+	}
+}
+
+// A stream without thinking must stay byte-identical to what it was before:
+// no empty extra_content member on any delta.
+func TestStreamChatCompletion_NoThinkingNoExtraContent(t *testing.T) {
+	sse := `event: message_start
+data: {"type":"message_start","message":{"id":"msg_plain","type":"message","role":"assistant","model":"claude-sonnet-4-5","content":[],"stop_reason":null,"usage":{"input_tokens":4,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}
+
+event: message_stop
+data: {"type":"message_stop"}
+`
+	if got := lastExtraContent(chatStreamDeltas(t, sse)); got != "" {
+		t.Fatalf("extra_content = %s, want none for a stream with no thinking", got)
 	}
 }

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -4372,23 +4372,37 @@ func TestConvertAnthropicResponseToResponses_WithThinkingBlocks(t *testing.T) {
 		name         string
 		content      []anthropicContent
 		expectedText string
+		wantReplay   string
 	}{
 		{
 			name: "thinking then text",
 			content: []anthropicContent{
-				{Type: "thinking", Text: "The user is asking about geography..."},
+				{Type: "thinking", Thinking: "The user is asking about geography...", Signature: "sig-1"},
 				{Type: "text", Text: "The capital of France is Paris."},
 			},
 			expectedText: "The capital of France is Paris.",
+			wantReplay:   `{"anthropic":{"thinking_blocks":[{"type":"thinking","thinking":"The user is asking about geography...","signature":"sig-1"}]}}`,
 		},
 		{
 			name: "preamble text then thinking then answer",
 			content: []anthropicContent{
 				{Type: "text", Text: "\n\n"},
-				{Type: "thinking", Text: ""},
+				{Type: "thinking", Thinking: "", Signature: "sig-2"},
 				{Type: "text", Text: "The capital of France is Paris."},
 			},
 			expectedText: "The capital of France is Paris.",
+			// A thinking block whose text the model omitted still has to be
+			// replayed: the signature covers the block, not the text.
+			wantReplay: `{"anthropic":{"thinking_blocks":[{"type":"thinking","thinking":"","signature":"sig-2"}]}}`,
+		},
+		{
+			name: "redacted thinking",
+			content: []anthropicContent{
+				{Type: "redacted_thinking", Data: "opaque"},
+				{Type: "text", Text: "The capital of France is Paris."},
+			},
+			expectedText: "The capital of France is Paris.",
+			wantReplay:   `{"anthropic":{"thinking_blocks":[{"type":"redacted_thinking","data":"opaque"}]}}`,
 		},
 	}
 
@@ -4416,8 +4430,8 @@ func TestConvertAnthropicResponseToResponses_WithThinkingBlocks(t *testing.T) {
 			if reasoning.Type != "reasoning" {
 				t.Fatalf("Output[0].Type = %q, want reasoning", reasoning.Type)
 			}
-			if raw := reasoning.ExtraFields.Lookup(core.ExtraContentField); len(raw) == 0 {
-				t.Error("the reasoning item must carry the thinking blocks as replay state")
+			if raw := reasoning.ExtraFields.Lookup(core.ExtraContentField); string(raw) != tt.wantReplay {
+				t.Errorf("reasoning replay state = %s, want %s", raw, tt.wantReplay)
 			}
 			if len(message.Content) == 0 {
 				t.Fatalf("len(Output[1].Content) = 0, want at least 1")

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -6634,3 +6634,67 @@ data: {"type":"message_stop"}
 		}
 	}
 }
+
+// A redacted thinking block has no readable text, so its reasoning item exists
+// only to carry the opaque payload the next turn must replay. It still has to
+// be a well-formed item: opened, closed, and present in the terminal output.
+func TestStreamResponses_RedactedThinkingBecomesReasoningItem(t *testing.T) {
+	sse := `event: message_start
+data: {"type":"message_start","message":{"id":"msg_red","type":"message","role":"assistant","model":"claude-sonnet-4-5","content":[],"stop_reason":null,"usage":{"input_tokens":10,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"redacted_thinking","data":"opaque"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Done."}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":4}}
+
+event: message_stop
+data: {"type":"message_stop"}
+`
+	events := responsesStreamEvents(t, sse)
+
+	added, done := false, false
+	for _, event := range events {
+		item, ok := event["item"].(map[string]any)
+		if !ok || item["type"] != "reasoning" {
+			continue
+		}
+		switch event["type"] {
+		case "response.output_item.added":
+			added = true
+		case "response.output_item.done":
+			done = true
+		}
+	}
+	if !added || !done {
+		t.Errorf("reasoning item added=%v done=%v, want both", added, done)
+	}
+
+	final := events[len(events)-1]
+	output := final["response"].(map[string]any)["output"].([]any)
+	reasoning := output[0].(map[string]any)
+	if reasoning["type"] != "reasoning" {
+		t.Fatalf("final output[0] = %v, want the reasoning item", reasoning["type"])
+	}
+	extra, _ := json.Marshal(reasoning["extra_content"])
+	want := `{"anthropic":{"thinking_blocks":[{"data":"opaque","type":"redacted_thinking"}]}}`
+	if string(extra) != want {
+		t.Errorf("reasoning extra_content = %s, want %s", extra, want)
+	}
+	// The message still follows it, and the redacted item contributes no text.
+	if output[1].(map[string]any)["type"] != "message" {
+		t.Errorf("final output[1] = %v, want the assistant message", output[1])
+	}
+}

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -6499,3 +6499,138 @@ data: {"type":"message_stop"}
 		t.Fatalf("extra_content = %s, want none for a stream with no thinking", got)
 	}
 }
+
+// responsesStreamEvents converts an Anthropic SSE stream to the Responses
+// dialect and returns the decoded events.
+func responsesStreamEvents(t *testing.T, anthropicSSE string) []map[string]any {
+	t.Helper()
+	conv := newResponsesStreamConverter(io.NopCloser(strings.NewReader(anthropicSSE)), "claude-sonnet-4-5")
+	defer conv.Close() //nolint:errcheck
+
+	out, err := io.ReadAll(conv)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	events := []map[string]any{}
+	for line := range strings.SplitSeq(string(out), "\n") {
+		data, ok := strings.CutPrefix(strings.TrimSpace(line), "data: ")
+		if !ok || data == "[DONE]" {
+			continue
+		}
+		var event map[string]any
+		if err := json.Unmarshal([]byte(data), &event); err != nil {
+			t.Fatalf("unmarshal event %q: %v", data, err)
+		}
+		events = append(events, event)
+	}
+	return events
+}
+
+const thinkingResponsesSSE = `event: message_start
+data: {"type":"message_start","message":{"id":"msg_rs","type":"message","role":"assistant","model":"claude-sonnet-4-5","content":[],"stop_reason":null,"usage":{"input_tokens":10,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me "}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"think."}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig-1"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Done."}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":9}}
+
+event: message_stop
+data: {"type":"message_stop"}
+`
+
+// A streamed Responses turn has to expose the same reasoning a non-streamed
+// one does, replay state included; otherwise a thinking conversation cannot be
+// continued on this dialect.
+func TestStreamResponses_ThinkingBecomesReasoningItem(t *testing.T) {
+	events := responsesStreamEvents(t, thinkingResponsesSSE)
+
+	var deltas []string
+	reasoningAdded, messageAdded := -1, -1
+	for i, event := range events {
+		switch event["type"] {
+		case "response.reasoning_text.delta":
+			deltas = append(deltas, event["delta"].(string))
+		case "response.output_item.added":
+			item := event["item"].(map[string]any)
+			if item["type"] == "reasoning" && reasoningAdded < 0 {
+				reasoningAdded = i
+			}
+			if item["type"] == "message" && messageAdded < 0 {
+				messageAdded = i
+			}
+		}
+	}
+	if strings.Join(deltas, "") != "Let me think." {
+		t.Errorf("reasoning deltas = %q, want the thinking text", strings.Join(deltas, ""))
+	}
+	if reasoningAdded < 0 {
+		t.Fatal("no reasoning output item was added")
+	}
+	if messageAdded >= 0 && reasoningAdded > messageAdded {
+		t.Errorf("reasoning item added at %d, message at %d; reasoning must claim the first slot", reasoningAdded, messageAdded)
+	}
+
+	final := events[len(events)-1]
+	output := final["response"].(map[string]any)["output"].([]any)
+	reasoning := output[0].(map[string]any)
+	if reasoning["type"] != "reasoning" {
+		t.Fatalf("final output[0] = %v, want the reasoning item", reasoning["type"])
+	}
+	extra, _ := json.Marshal(reasoning["extra_content"])
+	want := `{"anthropic":{"thinking_blocks":[{"signature":"sig-1","thinking":"Let me think.","type":"thinking"}]}}`
+	if string(extra) != want {
+		t.Errorf("reasoning extra_content = %s, want %s", extra, want)
+	}
+}
+
+// A stream with no thinking must gain no reasoning item.
+func TestStreamResponses_NoThinkingNoReasoningItem(t *testing.T) {
+	sse := `event: message_start
+data: {"type":"message_start","message":{"id":"msg_plain","type":"message","role":"assistant","model":"claude-sonnet-4-5","content":[],"stop_reason":null,"usage":{"input_tokens":4,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}
+
+event: message_stop
+data: {"type":"message_stop"}
+`
+	for _, event := range responsesStreamEvents(t, sse) {
+		if strings.HasPrefix(event["type"].(string), "response.reasoning") {
+			t.Errorf("unexpected reasoning event %v", event["type"])
+		}
+		if added, ok := event["item"].(map[string]any); ok && added["type"] == "reasoning" {
+			t.Error("a stream without thinking must not produce a reasoning item")
+		}
+	}
+}

--- a/internal/providers/anthropic/chat.go
+++ b/internal/providers/anthropic/chat.go
@@ -48,6 +48,9 @@ func convertFromAnthropicResponse(resp *anthropicResponse) *core.ChatResponse {
 			})
 		}
 	}
+	// reasoning_content is the readable text only; the signatures Anthropic
+	// needs back travel as replay state.
+	msg.ExtraFields = withThinkingReplay(msg.ExtraFields, extractThinkingReplay(resp.Content))
 
 	return &core.ChatResponse{
 		ID:      resp.ID,

--- a/internal/providers/anthropic/chat_stream.go
+++ b/internal/providers/anthropic/chat_stream.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/goccy/go-json"
+
 	"github.com/enterpilot/gomodel/internal/core"
 	"github.com/enterpilot/gomodel/internal/llmclient"
 	"github.com/enterpilot/gomodel/internal/providers"
@@ -47,11 +49,16 @@ type streamConverter struct {
 	nextToolCallIndex int
 	toolCalls         map[int]*streamToolCallState
 	thinkingBlocks    map[int]bool // tracks which content block indices are thinking blocks
-	usage             anthropicUsage
-	hasUsage          bool
-	buffer            streaming.StreamBuffer
-	closed            bool
-	emittedToolCalls  bool
+	// thinkingReplay accumulates the thinking blocks of this turn, keyed by
+	// upstream content-block index and ordered by thinkingOrder, so the
+	// signatures Anthropic requires back can be handed to the client.
+	thinkingReplay   map[int]*anthropicContent
+	thinkingOrder    []int
+	usage            anthropicUsage
+	hasUsage         bool
+	buffer           streaming.StreamBuffer
+	closed           bool
+	emittedToolCalls bool
 }
 
 // streamToolCallState tracks per-tool-call bookkeeping for the chat dialect.
@@ -73,6 +80,7 @@ func newStreamConverter(body io.ReadCloser, model string) *streamConverter {
 		created:        time.Now().Unix(),
 		toolCalls:      make(map[int]*streamToolCallState),
 		thinkingBlocks: make(map[int]bool),
+		thinkingReplay: make(map[int]*anthropicContent),
 		buffer:         streaming.NewStreamBuffer(1024),
 	}
 }
@@ -187,6 +195,13 @@ func (sc *streamConverter) convertEvent(event *anthropicStreamEvent) string {
 	case "content_block_start":
 		if event.ContentBlock != nil && event.ContentBlock.Type == "thinking" {
 			sc.thinkingBlocks[event.Index] = true
+			sc.trackThinking(event.Index, *event.ContentBlock)
+			return ""
+		}
+		if event.ContentBlock != nil && event.ContentBlock.Type == "redacted_thinking" {
+			// A redacted block arrives whole and has no readable text, so
+			// replay state is the only thing that can carry it.
+			sc.trackThinking(event.Index, *event.ContentBlock)
 			return ""
 		}
 		if event.ContentBlock != nil && event.ContentBlock.Type == "tool_use" {
@@ -231,13 +246,20 @@ func (sc *streamConverter) convertEvent(event *anthropicStreamEvent) string {
 		switch event.Delta.Type {
 		case "thinking_delta":
 			if sc.thinkingBlocks[event.Index] && event.Delta.Thinking != "" {
+				if block := sc.thinkingReplay[event.Index]; block != nil {
+					block.Thinking += event.Delta.Thinking
+				}
 				return sc.formatChatChunk(map[string]any{
 					"reasoning_content": event.Delta.Thinking,
 				}, nil, nil)
 			}
 		case "signature_delta":
-			// Signature deltas are internal to Anthropic's thinking protocol;
-			// no OpenAI-compatible equivalent to emit.
+			// A signature has no OpenAI-compatible field of its own; it is
+			// held until the block closes and then handed over as replay
+			// state, which is what the client must echo back.
+			if block := sc.thinkingReplay[event.Index]; block != nil {
+				block.Signature += event.Delta.Signature
+			}
 			return ""
 		case "text_delta":
 			if event.Delta.Text != "" {
@@ -285,6 +307,12 @@ func (sc *streamConverter) convertEvent(event *anthropicStreamEvent) string {
 		}
 
 	case "content_block_stop":
+		// The completed thinking block is published before any text follows,
+		// so a client that closes it on the first text delta still sees the
+		// signature.
+		if chunk := sc.thinkingReplayChunk(event.Index); chunk != "" {
+			return chunk
+		}
 		state := sc.toolCalls[event.Index]
 		if state != nil && !state.Started && state.PlaceholderObject {
 			state.Started = true
@@ -333,4 +361,40 @@ func (sc *streamConverter) convertEvent(event *anthropicStreamEvent) string {
 	}
 
 	return ""
+}
+
+// trackThinking records a thinking or redacted_thinking block so its
+// signature, or its opaque payload, can be replayed on a later turn.
+func (sc *streamConverter) trackThinking(index int, block anthropicContent) {
+	if _, seen := sc.thinkingReplay[index]; seen {
+		return
+	}
+	tracked := block
+	sc.thinkingReplay[index] = &tracked
+	sc.thinkingOrder = append(sc.thinkingOrder, index)
+}
+
+// thinkingReplayChunk emits the thinking blocks accumulated so far when the
+// block at index closes. The value is cumulative rather than incremental so a
+// client that keeps only the most recent extra_content still ends up with the
+// whole turn.
+func (sc *streamConverter) thinkingReplayChunk(index int) string {
+	if _, ok := sc.thinkingReplay[index]; !ok {
+		return ""
+	}
+	blocks := make([]json.RawMessage, 0, len(sc.thinkingOrder))
+	for _, i := range sc.thinkingOrder {
+		if raw, ok := thinkingReplayJSON(*sc.thinkingReplay[i]); ok {
+			blocks = append(blocks, raw)
+		}
+	}
+	raw, err := json.Marshal(map[string][]json.RawMessage{core.ThinkingBlocksField: blocks})
+	if err != nil {
+		return ""
+	}
+	vendors, err := json.Marshal(map[string]json.RawMessage{core.ExtraContentVendorAnthropic: raw})
+	if err != nil {
+		return ""
+	}
+	return sc.formatChatChunk(map[string]any{core.ExtraContentField: json.RawMessage(vendors)}, nil, nil)
 }

--- a/internal/providers/anthropic/responses.go
+++ b/internal/providers/anthropic/responses.go
@@ -25,15 +25,22 @@ func convertAnthropicResponseToResponses(resp *anthropicResponse, model string) 
 	content := extractTextContent(resp.Content)
 	toolCalls := extractToolCalls(resp.Content)
 
-	msg := core.Message{
+	msg := core.ResponseMessage{
+		Role:      "assistant",
 		Content:   content,
 		ToolCalls: toolCalls,
 	}
-	output := providers.BuildResponsesOutputItems(core.ResponseMessage{
-		Role:      "assistant",
-		Content:   msg.Content,
-		ToolCalls: msg.ToolCalls,
-	})
+	if thinking := extractThinkingContent(resp.Content); thinking != "" {
+		if raw, err := json.Marshal(thinking); err == nil {
+			msg.ExtraFields = core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+				"reasoning_content": raw,
+			})
+		}
+	}
+	// The reasoning item carries the signatures Anthropic needs back; without
+	// them a Responses client cannot continue a thinking conversation.
+	msg.ExtraFields = withThinkingReplay(msg.ExtraFields, extractThinkingReplay(resp.Content))
+	output := providers.BuildResponsesOutputItems(msg)
 
 	return &core.ResponsesResponse{
 		ID:        resp.ID,

--- a/internal/providers/anthropic/responses.go
+++ b/internal/providers/anthropic/responses.go
@@ -136,15 +136,21 @@ type responsesStreamConverter struct {
 	output               *providers.ResponsesOutputEventState
 	nextOutputIndex      int
 	assistantOutputIndex int
+	reasoningOutputIndex int
 	toolCalls            map[int]*providers.ResponsesOutputToolCallState
 	thinkingBlocks       map[int]bool // tracks which content block indices are thinking blocks
-	buffer               streaming.StreamBuffer
-	closed               bool
-	sentDone             bool
-	sawStop              bool  // upstream signalled the end of the message
-	pendingErr           error // upstream read error deferred until terminal events are drained
-	usage                anthropicUsage
-	hasUsage             bool
+	// thinkingReplay accumulates the turn's thinking blocks, ordered by
+	// thinkingOrder, so the reasoning item can carry the signatures Anthropic
+	// requires back.
+	thinkingReplay map[int]*anthropicContent
+	thinkingOrder  []int
+	buffer         streaming.StreamBuffer
+	closed         bool
+	sentDone       bool
+	sawStop        bool  // upstream signalled the end of the message
+	pendingErr     error // upstream read error deferred until terminal events are drained
+	usage          anthropicUsage
+	hasUsage       bool
 }
 
 func newResponsesStreamConverter(body io.ReadCloser, model string) *responsesStreamConverter {
@@ -158,6 +164,7 @@ func newResponsesStreamConverter(body io.ReadCloser, model string) *responsesStr
 		output:         providers.NewResponsesOutputEventState(responseID),
 		toolCalls:      make(map[int]*providers.ResponsesOutputToolCallState),
 		thinkingBlocks: make(map[int]bool),
+		thinkingReplay: make(map[int]*anthropicContent),
 		buffer:         streaming.NewStreamBuffer(1024),
 	}
 }
@@ -237,6 +244,50 @@ func (sc *responsesStreamConverter) releaseBuffer() {
 	sc.buffer.Release()
 }
 
+// reserveReasoningOutput claims the first output slot for the reasoning item.
+// Anthropic emits thinking before any text or tool call, so reserving on the
+// first thinking block gives it index 0.
+func (sc *responsesStreamConverter) reserveReasoningOutput() {
+	if sc.output.ReasoningReserved() {
+		return
+	}
+	sc.output.ReserveReasoning()
+	sc.reasoningOutputIndex = sc.nextOutputIndex
+	sc.nextOutputIndex++
+}
+
+// trackThinkingReplay records a thinking or redacted_thinking block and
+// publishes the accumulated replay state on the reasoning item.
+func (sc *responsesStreamConverter) trackThinkingReplay(index int, block anthropicContent) {
+	if _, seen := sc.thinkingReplay[index]; !seen {
+		tracked := block
+		sc.thinkingReplay[index] = &tracked
+		sc.thinkingOrder = append(sc.thinkingOrder, index)
+	}
+	sc.publishThinkingReplay()
+}
+
+func (sc *responsesStreamConverter) publishThinkingReplay() {
+	blocks := make([]json.RawMessage, 0, len(sc.thinkingOrder))
+	for _, i := range sc.thinkingOrder {
+		if raw, ok := thinkingReplayJSON(*sc.thinkingReplay[i]); ok {
+			blocks = append(blocks, raw)
+		}
+	}
+	if len(blocks) == 0 {
+		return
+	}
+	raw, err := json.Marshal(map[string][]json.RawMessage{core.ThinkingBlocksField: blocks})
+	if err != nil {
+		return
+	}
+	vendors, err := json.Marshal(map[string]json.RawMessage{core.ExtraContentVendorAnthropic: raw})
+	if err != nil {
+		return
+	}
+	sc.output.SetReasoningExtraContent(vendors)
+}
+
 func (sc *responsesStreamConverter) reserveAssistantMessageOutput() {
 	if sc.output.AssistantReserved() {
 		return
@@ -263,7 +314,9 @@ func (sc *responsesStreamConverter) appendTerminalEvents() {
 		status = "incomplete"
 		eventName = "response.incomplete"
 	}
-	prefix := sc.output.FinishAssistantOutput(sc.assistantOutputIndex, status) + sc.completePendingToolCalls(status)
+	prefix := sc.output.FinishReasoningOutput(sc.reasoningOutputIndex, status) +
+		sc.output.FinishAssistantOutput(sc.assistantOutputIndex, status) +
+		sc.completePendingToolCalls(status)
 	responseData := map[string]any{
 		"id":         sc.responseID,
 		"object":     "response",
@@ -271,7 +324,7 @@ func (sc *responsesStreamConverter) appendTerminalEvents() {
 		"model":      sc.model,
 		"provider":   "anthropic",
 		"created_at": sc.createdAt,
-		"output":     sc.output.FinalOutputItems(0, sc.assistantOutputIndex, sc.toolCalls, true),
+		"output":     sc.output.FinalOutputItems(sc.reasoningOutputIndex, sc.assistantOutputIndex, sc.toolCalls, true),
 	}
 	if status == "incomplete" {
 		responseData["incomplete_details"] = map[string]any{"reason": "interrupted"}
@@ -358,18 +411,27 @@ func (sc *responsesStreamConverter) convertEvent(event *anthropicStreamEvent) st
 	case "content_block_start":
 		if event.ContentBlock != nil && event.ContentBlock.Type == "thinking" {
 			sc.thinkingBlocks[event.Index] = true
+			sc.reserveReasoningOutput()
+			sc.trackThinkingReplay(event.Index, *event.ContentBlock)
+			return ""
+		}
+		if event.ContentBlock != nil && event.ContentBlock.Type == "redacted_thinking" {
+			// A redacted block arrives whole and has no readable text, so the
+			// reasoning item exists purely to carry its replay state.
+			sc.reserveReasoningOutput()
+			sc.trackThinkingReplay(event.Index, *event.ContentBlock)
 			return ""
 		}
 		if event.ContentBlock != nil && event.ContentBlock.Type == "tool_use" {
+			// Thinking precedes the tool call it led to, so the reasoning item
+			// closes here; a thinking-enabled tool-use turn is the common case.
+			prefix := sc.output.CompleteReasoningOutput(sc.reasoningOutputIndex)
 			if sc.output.AssistantStarted() && !sc.output.AssistantDone() {
-				prefix := sc.output.CompleteAssistantOutput(sc.assistantOutputIndex)
-				state := sc.newResponsesToolCallState(event.ContentBlock)
-				sc.toolCalls[event.Index] = state
-				return prefix + sc.output.StartToolCall(state, true)
+				prefix += sc.output.CompleteAssistantOutput(sc.assistantOutputIndex)
 			}
 			state := sc.newResponsesToolCallState(event.ContentBlock)
 			sc.toolCalls[event.Index] = state
-			return sc.output.StartToolCall(state, true)
+			return prefix + sc.output.StartToolCall(state, true)
 		}
 		return ""
 
@@ -379,14 +441,28 @@ func (sc *responsesStreamConverter) convertEvent(event *anthropicStreamEvent) st
 		}
 
 		switch event.Delta.Type {
-		case "thinking_delta", "signature_delta":
-			// Thinking and signature deltas are part of Anthropic's extended thinking;
-			// the Responses API format does not have a direct equivalent, so skip them.
+		case "thinking_delta":
+			if !sc.thinkingBlocks[event.Index] || event.Delta.Thinking == "" {
+				return ""
+			}
+			if block := sc.thinkingReplay[event.Index]; block != nil {
+				block.Thinking += event.Delta.Thinking
+			}
+			sc.reserveReasoningOutput()
+			return sc.output.AppendReasoningDelta(sc.reasoningOutputIndex, event.Delta.Thinking)
+		case "signature_delta":
+			// A signature has no field of its own in the Responses dialect; it
+			// rides on the reasoning item as replay state instead.
+			if block := sc.thinkingReplay[event.Index]; block != nil {
+				block.Signature += event.Delta.Signature
+				sc.publishThinkingReplay()
+			}
 			return ""
 		case "text_delta":
 			if event.Delta.Text != "" {
+				prefix := sc.output.CompleteReasoningOutput(sc.reasoningOutputIndex)
 				sc.reserveAssistantMessageOutput()
-				prefix := sc.output.StartAssistantOutput(sc.assistantOutputIndex)
+				prefix += sc.output.StartAssistantOutput(sc.assistantOutputIndex)
 				sc.output.AppendAssistantText(event.Delta.Text)
 				return prefix + sc.output.WriteEvent("response.output_text.delta", map[string]any{
 					"type":  "response.output_text.delta",

--- a/internal/providers/anthropic/thinking_replay.go
+++ b/internal/providers/anthropic/thinking_replay.go
@@ -1,0 +1,76 @@
+package anthropic
+
+import (
+	"github.com/goccy/go-json"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+// Anthropic signs every thinking block it returns and refuses a later turn
+// that replays one without its signature. The signature has no OpenAI-
+// compatible field, and reasoning_content carries only the text, so the blocks
+// travel back to the client as provider replay state under
+// extra_content.anthropic.thinking_blocks — the same member the Messages
+// ingress fills from a client's own thinking blocks and prependThinkingBlocks
+// restores upstream. Every dialect therefore round-trips them without knowing
+// what they mean.
+
+// thinkingReplayBlock is a thinking or redacted_thinking block in the exact
+// shape Anthropic requires back. A thinking block always carries its text,
+// which is empty when the model omitted it, so the field is never dropped.
+type thinkingReplayBlock struct {
+	Type      string `json:"type"`
+	Thinking  string `json:"thinking"`
+	Signature string `json:"signature,omitempty"`
+}
+
+type redactedThinkingReplayBlock struct {
+	Type string `json:"type"`
+	Data string `json:"data"`
+}
+
+// thinkingReplayJSON encodes one response content block for replay. ok is
+// false for blocks that are not part of the thinking protocol.
+func thinkingReplayJSON(block anthropicContent) (json.RawMessage, bool) {
+	switch block.Type {
+	case "thinking":
+		raw, err := json.Marshal(thinkingReplayBlock{Type: block.Type, Thinking: block.Thinking, Signature: block.Signature})
+		return raw, err == nil
+	case "redacted_thinking":
+		raw, err := json.Marshal(redactedThinkingReplayBlock{Type: block.Type, Data: block.Data})
+		return raw, err == nil
+	default:
+		return nil, false
+	}
+}
+
+// withThinkingReplay attaches thinking blocks to a message's extra fields as
+// extra_content.anthropic.thinking_blocks. Fields are returned unchanged when
+// there is nothing to replay, so a response without thinking keeps the shape
+// it has always had.
+func withThinkingReplay(fields core.UnknownJSONFields, blocks []json.RawMessage) core.UnknownJSONFields {
+	if len(blocks) == 0 {
+		return fields
+	}
+	raw, err := json.Marshal(map[string][]json.RawMessage{core.ThinkingBlocksField: blocks})
+	if err != nil {
+		return fields
+	}
+	updated, err := fields.WithExtraContent(core.ExtraContentVendorAnthropic, raw)
+	if err != nil {
+		return fields
+	}
+	return updated
+}
+
+// extractThinkingReplay collects the thinking blocks of a non-streamed
+// response in order.
+func extractThinkingReplay(blocks []anthropicContent) []json.RawMessage {
+	var out []json.RawMessage
+	for _, block := range blocks {
+		if raw, ok := thinkingReplayJSON(block); ok {
+			out = append(out, raw)
+		}
+	}
+	return out
+}

--- a/internal/providers/anthropic/types.go
+++ b/internal/providers/anthropic/types.go
@@ -93,13 +93,15 @@ type anthropicResponse struct {
 
 // anthropicContent represents content in Anthropic response
 type anthropicContent struct {
-	Type      string          `json:"type"`
-	Text      string          `json:"text,omitempty"`
-	Thinking  string          `json:"thinking,omitempty"`
-	Signature string          `json:"signature,omitempty"`
-	ID        string          `json:"id,omitempty"`
-	Name      string          `json:"name,omitempty"`
-	Input     json.RawMessage `json:"input,omitempty"`
+	Type      string `json:"type"`
+	Text      string `json:"text,omitempty"`
+	Thinking  string `json:"thinking,omitempty"`
+	Signature string `json:"signature,omitempty"`
+	// Data is the opaque payload of a redacted_thinking block.
+	Data  string          `json:"data,omitempty"`
+	ID    string          `json:"id,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
 }
 
 // anthropicUsage represents token usage in Anthropic response

--- a/internal/providers/responses_input.go
+++ b/internal/providers/responses_input.go
@@ -42,6 +42,12 @@ func convertResponsesInputItems(items []any) ([]core.Message, error) {
 	var pendingReasoningExtra json.RawMessage
 
 	flushPendingAssistant := func() error {
+		// A reasoning item describes the assistant turn that follows it. Once
+		// the history has moved past that turn the pending state is spent,
+		// whether or not there was an assistant turn to attach it to; holding
+		// it over would pin one turn's thinking blocks to another.
+		reasoning, reasoningExtra := pendingReasoning, pendingReasoningExtra
+		pendingReasoning, pendingReasoningExtra = "", nil
 		if pendingAssistant == nil {
 			return nil
 		}
@@ -50,8 +56,8 @@ func convertResponsesInputItems(items []any) ([]core.Message, error) {
 		// tool-result request, while reasoning from ordinary assistant turns is
 		// intentionally omitted because it is not part of their next-turn
 		// context.
-		if pendingReasoning != "" && len(pendingAssistant.ToolCalls) > 0 {
-			raw, err := json.Marshal(pendingReasoning)
+		if reasoning != "" && len(pendingAssistant.ToolCalls) > 0 {
+			raw, err := json.Marshal(reasoning)
 			if err != nil {
 				return err
 			}
@@ -63,19 +69,17 @@ func convertResponsesInputItems(items []any) ([]core.Message, error) {
 			}
 			pendingAssistant.ExtraFields = extra
 		}
-		pendingReasoning = ""
 		// Replay state travels with every reasoning item, tool calls or not:
 		// an Anthropic thinking block has to be echoed back on a plain
 		// assistant turn just as much as on a tool-use one.
-		if len(pendingReasoningExtra) > 0 {
+		if len(reasoningExtra) > 0 {
 			extra, err := core.MergeUnknownJSONFields(pendingAssistant.ExtraFields, map[string]json.RawMessage{
-				core.ExtraContentField: pendingReasoningExtra,
+				core.ExtraContentField: reasoningExtra,
 			})
 			if err != nil {
 				return err
 			}
 			pendingAssistant.ExtraFields = extra
-			pendingReasoningExtra = nil
 		}
 		messages = append(messages, *pendingAssistant)
 		pendingAssistant = nil

--- a/internal/providers/responses_input.go
+++ b/internal/providers/responses_input.go
@@ -39,6 +39,7 @@ func convertResponsesInputItems(items []any) ([]core.Message, error) {
 	messages := make([]core.Message, 0, len(items))
 	var pendingAssistant *core.Message
 	var pendingReasoning string
+	var pendingReasoningExtra json.RawMessage
 
 	flushPendingAssistant := func() error {
 		if pendingAssistant == nil {
@@ -61,7 +62,20 @@ func convertResponsesInputItems(items []any) ([]core.Message, error) {
 				return err
 			}
 			pendingAssistant.ExtraFields = extra
-			pendingReasoning = ""
+		}
+		pendingReasoning = ""
+		// Replay state travels with every reasoning item, tool calls or not:
+		// an Anthropic thinking block has to be echoed back on a plain
+		// assistant turn just as much as on a tool-use one.
+		if len(pendingReasoningExtra) > 0 {
+			extra, err := core.MergeUnknownJSONFields(pendingAssistant.ExtraFields, map[string]json.RawMessage{
+				core.ExtraContentField: pendingReasoningExtra,
+			})
+			if err != nil {
+				return err
+			}
+			pendingAssistant.ExtraFields = extra
+			pendingReasoningExtra = nil
 		}
 		messages = append(messages, *pendingAssistant)
 		pendingAssistant = nil
@@ -69,14 +83,12 @@ func convertResponsesInputItems(items []any) ([]core.Message, error) {
 	}
 
 	for i, item := range items {
-		if reasoning, ok := responsesInputReasoningText(item); ok {
+		if reasoning, extra, ok := responsesInputReasoning(item); ok {
 			if err := flushPendingAssistant(); err != nil {
 				return nil, err
 			}
-			pendingReasoning = ""
-			if reasoning != "" {
-				pendingReasoning = reasoning
-			}
+			pendingReasoning = reasoning
+			pendingReasoningExtra = extra
 			continue
 		}
 
@@ -90,7 +102,6 @@ func convertResponsesInputItems(items []any) ([]core.Message, error) {
 				if err := flushPendingAssistant(); err != nil {
 					return nil, err
 				}
-				pendingReasoning = ""
 			}
 			if pendingAssistant == nil {
 				assistant := cloneResponsesMessage(msg)
@@ -120,50 +131,56 @@ func convertResponsesInputItems(items []any) ([]core.Message, error) {
 	return messages, nil
 }
 
-// responsesInputReasoningText recognizes a Responses reasoning item and
-// extracts raw reasoning content. Summary text is accepted as a compatibility
-// fallback for older gateways that mislabeled reasoning_content as a summary.
-// Encrypted-only reasoning stays opaque and is deliberately omitted.
-func responsesInputReasoningText(item any) (string, bool) {
+// responsesInputReasoning recognizes a Responses reasoning item and extracts
+// its raw reasoning content along with any provider replay state the client
+// echoed back. Summary text is accepted as a compatibility fallback for older
+// gateways that mislabeled reasoning_content as a summary. Encrypted-only
+// reasoning stays opaque and is deliberately omitted.
+func responsesInputReasoning(item any) (string, json.RawMessage, bool) {
 	var raw json.RawMessage
 	switch typed := item.(type) {
 	case core.ResponsesInputElement:
 		if typed.Type != "reasoning" {
-			return "", false
+			return "", nil, false
 		}
 		raw = typed.Raw
 		if len(raw) == 0 {
 			encoded, err := json.Marshal(typed)
 			if err != nil {
-				return "", true
+				return "", nil, true
 			}
 			raw = encoded
 		}
 	case map[string]any:
 		itemType, _ := typed["type"].(string)
 		if itemType != "reasoning" {
-			return "", false
+			return "", nil, false
 		}
 		encoded, err := json.Marshal(typed)
 		if err != nil {
-			return "", true
+			return "", nil, true
 		}
 		raw = encoded
 	default:
-		return "", false
+		return "", nil, false
 	}
 
 	var payload struct {
-		Content []responsesReasoningPart `json:"content"`
-		Summary []responsesReasoningPart `json:"summary"`
+		Content      []responsesReasoningPart `json:"content"`
+		Summary      []responsesReasoningPart `json:"summary"`
+		ExtraContent json.RawMessage          `json:"extra_content"`
 	}
 	if err := json.Unmarshal(raw, &payload); err != nil {
-		return "", true
+		return "", nil, true
+	}
+	extra := payload.ExtraContent
+	if core.IsJSONNull(extra) {
+		extra = nil
 	}
 	if text := reasoningTextParts(payload.Content, "reasoning_text"); text != "" {
-		return text, true
+		return text, extra, true
 	}
-	return reasoningTextParts(payload.Summary, "summary_text"), true
+	return reasoningTextParts(payload.Summary, "summary_text"), extra, true
 }
 
 type responsesReasoningPart struct {

--- a/internal/providers/responses_output.go
+++ b/internal/providers/responses_output.go
@@ -123,18 +123,27 @@ func buildResponsesContentItemsFromParts(parts []core.ContentPart) []core.Respon
 // BuildResponsesOutputItems converts a response message into Responses API output items.
 func BuildResponsesOutputItems(msg core.ResponseMessage) []core.ResponsesOutputItem {
 	reasoningContent := responseMessageReasoningContent(msg)
+	// Replay state on the assistant message belongs to its reasoning, not to
+	// its text: Anthropic thinking signatures ride here. It is emitted even
+	// when there is no readable reasoning text, because a redacted thinking
+	// block has none and still has to reach the client.
+	reasoningExtra := msg.ExtraFields.Lookup(core.ExtraContentField)
 	output := make([]core.ResponsesOutputItem, 0, len(msg.ToolCalls)+2)
-	if reasoningContent != "" {
+	if reasoningContent != "" || len(reasoningExtra) > 0 {
+		extra := map[string]json.RawMessage{"summary": json.RawMessage(`[]`)}
+		if len(reasoningExtra) > 0 {
+			extra[core.ExtraContentField] = reasoningExtra
+		}
+		content := []core.ResponsesContentItem{}
+		if reasoningContent != "" {
+			content = append(content, core.ResponsesContentItem{Type: "reasoning_text", Text: reasoningContent})
+		}
 		output = append(output, core.ResponsesOutputItem{
-			ID:     "rs_" + uuid.New().String(),
-			Type:   "reasoning",
-			Status: "completed",
-			Content: []core.ResponsesContentItem{
-				{Type: "reasoning_text", Text: reasoningContent},
-			},
-			ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
-				"summary": json.RawMessage(`[]`),
-			}),
+			ID:          "rs_" + uuid.New().String(),
+			Type:        "reasoning",
+			Status:      "completed",
+			Content:     content,
+			ExtraFields: core.UnknownJSONFieldsFromMap(extra),
 		})
 	}
 	contentItems := buildResponsesMessageContent(msg.Content)

--- a/internal/providers/responses_output_state.go
+++ b/internal/providers/responses_output_state.go
@@ -8,6 +8,8 @@ import (
 	"github.com/goccy/go-json"
 
 	"github.com/google/uuid"
+
+	"github.com/enterpilot/gomodel/internal/core"
 )
 
 // ResponsesOutputToolCallState tracks one function_call item in a Responses stream.
@@ -42,6 +44,9 @@ type ResponsesOutputEventState struct {
 	reasoningItemID      string
 	reasoningText        strings.Builder
 	reasoningFinalStatus string
+	// reasoningExtraContent is provider replay state for the reasoning item,
+	// such as Anthropic thinking-block signatures. Clients echo it back.
+	reasoningExtraContent json.RawMessage
 }
 
 // finalStatusOrCompleted defaults an unset item status to "completed" so items
@@ -189,7 +194,18 @@ func (s *ResponsesOutputEventState) ReasoningItem(status string, includeContent 
 			{"type": "reasoning_text", "text": s.reasoningText.String()},
 		}
 	}
+	if len(s.reasoningExtraContent) > 0 {
+		item[core.ExtraContentField] = s.reasoningExtraContent
+	}
 	return item
+}
+
+// SetReasoningExtraContent attaches provider replay state to the reasoning
+// item. It arrives after the item has been opened — an Anthropic signature
+// only lands when the thinking block closes — so the value is rendered on
+// every item written from here on, including the terminal output.
+func (s *ResponsesOutputEventState) SetReasoningExtraContent(raw json.RawMessage) {
+	s.reasoningExtraContent = raw
 }
 
 // StartReasoningOutput emits the reasoning output_item.added event once before

--- a/internal/providers/responses_output_test.go
+++ b/internal/providers/responses_output_test.go
@@ -65,3 +65,61 @@ func TestBuildResponsesOutputItems_ForwardsOnlyExtraContent(t *testing.T) {
 		t.Fatalf("extra_content = %s, want thought signature", got)
 	}
 }
+
+// A reasoning item belongs to the assistant turn that follows it. When no
+// assistant turn does — the history moves straight on to a user message — the
+// replay state must be dropped, not held over and pinned to whatever assistant
+// turn comes later: replaying another turn's thinking blocks is what Anthropic
+// rejects.
+func TestConvertResponsesInputToMessages_ReasoningDoesNotLeakForward(t *testing.T) {
+	input := []any{
+		map[string]any{"type": "message", "role": "user", "content": "first"},
+		map[string]any{
+			"type":          "reasoning",
+			"content":       []any{map[string]any{"type": "reasoning_text", "text": "thinking about the first"}},
+			"extra_content": map[string]any{"anthropic": map[string]any{"thinking_blocks": []any{map[string]any{"type": "thinking", "thinking": "first", "signature": "sig-first"}}}},
+		},
+		map[string]any{"type": "message", "role": "user", "content": "never mind, something else"},
+		map[string]any{"type": "message", "role": "assistant", "content": "unrelated answer"},
+	}
+
+	messages, err := ConvertResponsesInputToMessages(input)
+	if err != nil {
+		t.Fatalf("ConvertResponsesInputToMessages: %v", err)
+	}
+	for _, msg := range messages {
+		if msg.Role != "assistant" {
+			continue
+		}
+		if raw := msg.ExtraFields.Lookup(core.ExtraContentField); len(raw) > 0 {
+			t.Errorf("assistant turn %q inherited stale replay state: %s", msg.Content, raw)
+		}
+	}
+}
+
+// The ordinary case still attaches: a reasoning item immediately followed by
+// its assistant turn hands the replay state over.
+func TestConvertResponsesInputToMessages_ReasoningAttachesToItsTurn(t *testing.T) {
+	const replay = `{"anthropic":{"thinking_blocks":[{"type":"thinking","thinking":"hm","signature":"sig-1"}]}}`
+	input := []any{
+		map[string]any{"type": "message", "role": "user", "content": "question"},
+		map[string]any{
+			"type":          "reasoning",
+			"content":       []any{map[string]any{"type": "reasoning_text", "text": "hm"}},
+			"extra_content": json.RawMessage(replay),
+		},
+		map[string]any{"type": "message", "role": "assistant", "content": "answer"},
+	}
+
+	messages, err := ConvertResponsesInputToMessages(input)
+	if err != nil {
+		t.Fatalf("ConvertResponsesInputToMessages: %v", err)
+	}
+	assistant := messages[len(messages)-1]
+	if assistant.Role != "assistant" {
+		t.Fatalf("last message role = %q, want assistant", assistant.Role)
+	}
+	if raw := assistant.ExtraFields.Lookup(core.ExtraContentField); len(raw) == 0 {
+		t.Fatal("the assistant turn lost its replay state")
+	}
+}

--- a/internal/streaming/assemble.go
+++ b/internal/streaming/assemble.go
@@ -1,6 +1,7 @@
 package streaming
 
 import (
+	"bytes"
 	"errors"
 	"sort"
 
@@ -26,6 +27,7 @@ type chatAssembleChunk struct {
 			Content          *string         `json:"content"`
 			ReasoningContent json.RawMessage `json:"reasoning_content"`
 			Reasoning        json.RawMessage `json:"reasoning"`
+			ExtraContent     json.RawMessage `json:"extra_content"`
 			ToolCalls        []struct {
 				Index    *int   `json:"index"`
 				ID       string `json:"id"`
@@ -48,6 +50,9 @@ type chatAssembledChoice struct {
 	hasContent   bool
 	reasoning    []byte
 	reasoningKey string
+	// extraContent is the provider replay state of the turn. Chunks carry the
+	// cumulative value, so the last one seen wins rather than accumulating.
+	extraContent json.RawMessage
 	toolCalls    map[int]*core.ToolCall
 	toolOrder    []int
 	finishReason string
@@ -105,6 +110,9 @@ func AssembleChatResponse(events []Event) (*core.ChatResponse, error) {
 				if state.reasoningKey == "" {
 					state.reasoningKey = "reasoning"
 				}
+			}
+			if extra := bytes.TrimSpace(delta.ExtraContent); len(extra) > 0 && !core.IsJSONNull(extra) {
+				state.extraContent = extra
 			}
 			for pos, call := range delta.ToolCalls {
 				index := pos
@@ -182,12 +190,22 @@ func (c *chatAssembledChoice) build() (core.Choice, error) {
 		}
 		message.ToolCalls = append(message.ToolCalls, tool)
 	}
+	fields := map[string]json.RawMessage{}
 	if c.reasoningKey != "" {
 		raw, err := json.Marshal(string(c.reasoning))
 		if err != nil {
 			return core.Choice{}, err
 		}
-		message.ExtraFields = core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{c.reasoningKey: raw})
+		fields[c.reasoningKey] = raw
+	}
+	// Replay state must survive a buffered plugin run: the response is
+	// assembled here and re-synthesized afterwards, and a turn that lost its
+	// Anthropic thinking signature on the way cannot be continued.
+	if len(c.extraContent) > 0 {
+		fields[core.ExtraContentField] = c.extraContent
+	}
+	if len(fields) > 0 {
+		message.ExtraFields = core.UnknownJSONFieldsFromMap(fields)
 	}
 	return core.Choice{Index: c.index, Message: message, FinishReason: c.finishReason}, nil
 }

--- a/internal/streaming/assemble_test.go
+++ b/internal/streaming/assemble_test.go
@@ -284,15 +284,27 @@ func TestSynthesizeChatStream_CarriesReplayState(t *testing.T) {
 	}
 
 	var got string
-	for _, event := range decodeStreamEvents(t, SynthesizeChatStream(resp, false)) {
+	extraAt, textAt := -1, -1
+	for i, event := range decodeStreamEvents(t, SynthesizeChatStream(resp, false)) {
 		delta := event["choices"].([]any)[0].(map[string]any)["delta"].(map[string]any)
 		if extra, ok := delta[core.ExtraContentField]; ok {
 			encoded, _ := json.Marshal(extra)
 			got = string(encoded)
+			if extraAt < 0 {
+				extraAt = i
+			}
+		}
+		if _, ok := delta["content"]; ok && textAt < 0 {
+			textAt = i
 		}
 	}
 	if got == "" {
 		t.Fatal("no chunk carried extra_content")
+	}
+	// The Anthropic Messages converter closes the thinking block when the
+	// first text arrives, so a signature that came after it would be dropped.
+	if textAt >= 0 && extraAt > textAt {
+		t.Errorf("extra_content at chunk %d, first content at %d; want the replay state first", extraAt, textAt)
 	}
 	var want, have any
 	if err := json.Unmarshal([]byte(replay), &want); err != nil {
@@ -303,5 +315,42 @@ func TestSynthesizeChatStream_CarriesReplayState(t *testing.T) {
 	}
 	if !reflect.DeepEqual(want, have) {
 		t.Errorf("extra_content = %s, want %s", got, replay)
+	}
+}
+
+// A buffered plugin run assembles the stream, hands the response to the
+// plugin, and re-synthesizes it. Replay state has to survive that round trip
+// or a response-phase plugin silently strips the Anthropic thinking signature
+// from an otherwise untouched turn.
+func TestAssembleChatResponse_KeepsReplayState(t *testing.T) {
+	const replay = `{"anthropic":{"thinking_blocks":[{"type":"thinking","thinking":"hm","signature":"sig-1"}]}}`
+	stream := strings.Join([]string{
+		`data: {"id":"chatcmpl-4","model":"claude-sonnet-4-5","choices":[{"index":0,"delta":{"role":"assistant"}}]}`,
+		`data: {"choices":[{"index":0,"delta":{"reasoning_content":"hm"}}]}`,
+		`data: {"choices":[{"index":0,"delta":{"extra_content":` + replay + `}}]}`,
+		`data: {"choices":[{"index":0,"delta":{"content":"done"},"finish_reason":"stop"}]}`,
+		"",
+	}, "\n\n")
+
+	resp, err := AssembleChatResponse(decodeChatEvents(t, []byte(stream)))
+	if err != nil {
+		t.Fatalf("AssembleChatResponse: %v", err)
+	}
+	got := resp.Choices[0].Message.ExtraFields.Lookup(core.ExtraContentField)
+	if len(got) == 0 {
+		t.Fatal("the assembled response lost extra_content")
+	}
+	var want, have any
+	if err := json.Unmarshal([]byte(replay), &want); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(got, &have); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(want, have) {
+		t.Errorf("extra_content = %s, want %s", got, replay)
+	}
+	if reasoning := resp.Choices[0].Message.ExtraFields.Lookup("reasoning_content"); string(reasoning) != `"hm"` {
+		t.Errorf("reasoning_content = %s, want \"hm\"", reasoning)
 	}
 }

--- a/internal/streaming/assemble_test.go
+++ b/internal/streaming/assemble_test.go
@@ -260,3 +260,48 @@ func TestAppendOutputText_BoundsContentIndex(t *testing.T) {
 		t.Fatalf("after index 1: %+v", item.Content[:2])
 	}
 }
+
+// A synthesized stream is indistinguishable from a real one to the client, so
+// it must carry the provider replay state the response holds; without it an
+// Anthropic thinking turn cannot be continued.
+func TestSynthesizeChatStream_CarriesReplayState(t *testing.T) {
+	const replay = `{"anthropic":{"thinking_blocks":[{"type":"thinking","thinking":"hm","signature":"sig-1"}]}}`
+	resp := &core.ChatResponse{
+		ID:    "chatcmpl-3",
+		Model: "claude-sonnet-4-5",
+		Choices: []core.Choice{{
+			Index: 0,
+			Message: core.ResponseMessage{
+				Role:    "assistant",
+				Content: "done",
+				ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+					"reasoning_content":    json.RawMessage(`"hm"`),
+					core.ExtraContentField: json.RawMessage(replay),
+				}),
+			},
+			FinishReason: "stop",
+		}},
+	}
+
+	var got string
+	for _, event := range decodeStreamEvents(t, SynthesizeChatStream(resp, false)) {
+		delta := event["choices"].([]any)[0].(map[string]any)["delta"].(map[string]any)
+		if extra, ok := delta[core.ExtraContentField]; ok {
+			encoded, _ := json.Marshal(extra)
+			got = string(encoded)
+		}
+	}
+	if got == "" {
+		t.Fatal("no chunk carried extra_content")
+	}
+	var want, have any
+	if err := json.Unmarshal([]byte(replay), &want); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal([]byte(got), &have); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(want, have) {
+		t.Errorf("extra_content = %s, want %s", got, replay)
+	}
+}

--- a/internal/streaming/synthesize.go
+++ b/internal/streaming/synthesize.go
@@ -48,6 +48,12 @@ func SynthesizeChatStream(resp *core.ChatResponse, includeUsage bool) []byte {
 		if raw := choice.Message.ExtraFields.Lookup("reasoning_content"); len(raw) > 0 {
 			delta(choice.Index, map[string]any{"reasoning_content": json.RawMessage(raw)})
 		}
+		// Replay state (Anthropic thinking signatures) has to reach the client
+		// here too: a synthesized stream is indistinguishable from a real one
+		// to the caller, and its next turn is rejected without it.
+		if raw := choice.Message.ExtraFields.Lookup(core.ExtraContentField); len(raw) > 0 {
+			delta(choice.Index, map[string]any{core.ExtraContentField: json.RawMessage(raw)})
+		}
 		if text := core.ExtractTextContent(choice.Message.Content); text != "" {
 			delta(choice.Index, map[string]any{"content": text})
 		}

--- a/tests/contract/extra_content_roundtrip_test.go
+++ b/tests/contract/extra_content_roundtrip_test.go
@@ -164,3 +164,103 @@ func TestAnthropicThinkingBlocksReplay(t *testing.T) {
 	toolResult := messages[2].(map[string]any)["content"].([]any)[0].(map[string]any)
 	require.Equal(t, true, toolResult["is_error"])
 }
+
+// The signature and the opaque redacted payload of the thinking fixture. A
+// signature is bound to the exact thinking text, so a gateway that rebuilds
+// the block from reasoning_content alone cannot produce a usable one: it has
+// to carry back what the model returned, byte for byte.
+const (
+	signedThinkingSignature = "ErUBCkYIBRgCIkDPthinkingSignatureFixtureForContractTestsEgxSaW5nU2lnbmF0dXJlGgz//8AB"
+	signedThinkingText      = "The user asked for the weather in Paris. I should call get_weather."
+	redactedThinkingData    = "EroBCoYBEncKdG9wYXF1ZS1yZWRhY3RlZC10aGlua2luZy1maXh0dXJl"
+)
+
+// TestAnthropicThinkingSignatureRoundTrip is the response-side mirror of
+// TestAnthropicThinkingBlocksReplay: that test proves a client's thinking
+// blocks survive the trip upstream, this one proves the gateway hands the
+// client blocks worth replaying in the first place. Anthropic rejects a
+// thinking-enabled turn whose thinking block has no signature
+// ("messages.N.content.0.thinking.signature: Field required"), so an agent
+// loop that echoes the assistant turn back fails on the second request unless
+// every dialect carries the signature out and back.
+func TestAnthropicThinkingSignatureRoundTrip(t *testing.T) {
+	const model = "claude-sonnet-4-5"
+	client, captured := newCapturingJSONClient(t, "anthropic/messages_thinking_tool_use.json")
+	provider := anthropic.NewWithHTTPClient("sk-ant-test", client, llmclient.Hooks{})
+	provider.SetBaseURL("https://replay.local")
+
+	user := core.Message{Role: "user", Content: "What is the weather in Paris?"}
+	resp, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{Model: model, Messages: []core.Message{user}, Tools: weatherTools})
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+	message := resp.Choices[0].Message
+	require.Len(t, message.ToolCalls, 1)
+	callID := message.ToolCalls[0].ID
+
+	require.JSONEq(t,
+		`{"thinking_blocks":[
+			{"type":"thinking","thinking":"`+signedThinkingText+`","signature":"`+signedThinkingSignature+`"},
+			{"type":"redacted_thinking","data":"`+redactedThinkingData+`"}
+		]}`,
+		string(message.ExtraFields.ExtraContent(core.ExtraContentVendorAnthropic)),
+		"the chat response must expose the signed thinking blocks under extra_content.anthropic")
+
+	histories := map[string]func(t *testing.T) []core.Message{
+		"chat_completions":   func(t *testing.T) []core.Message { return chatHistory(resp, callID) },
+		"responses":          func(t *testing.T) []core.Message { return responsesHistory(t, resp, callID) },
+		"anthropic_messages": func(t *testing.T) []core.Message { return anthropicHistory(t, resp, callID) },
+	}
+	for name, build := range histories {
+		t.Run(name, func(t *testing.T) {
+			messages := append([]core.Message{user}, build(t)...)
+			_, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{Model: model, Messages: messages, Tools: weatherTools})
+			require.NoError(t, err)
+
+			upstream := captured.jsonBody(t)["messages"].([]any)
+			require.Len(t, upstream, 3, "user, assistant, tool result")
+			assistant := upstream[1].(map[string]any)["content"].([]any)
+			require.GreaterOrEqual(t, len(assistant), 2, "thinking blocks must lead the assistant content")
+
+			thinking, _ := json.Marshal(assistant[0])
+			redacted, _ := json.Marshal(assistant[1])
+			require.JSONEq(t, `{"type":"thinking","thinking":"`+signedThinkingText+`","signature":"`+signedThinkingSignature+`"}`, string(thinking),
+				"the thinking block must be replayed verbatim, signature included")
+			require.JSONEq(t, `{"type":"redacted_thinking","data":"`+redactedThinkingData+`"}`, string(redacted))
+			for _, block := range assistant {
+				require.NotContains(t, block.(map[string]any), "extra_content", "no block may carry the gateway's own member upstream")
+			}
+		})
+	}
+}
+
+// TestAnthropicThinkingSignatureSurvivesMessagesDialect pins the client-facing
+// half of the round trip: /v1/messages must render the signature on the
+// thinking block itself, because that is the only field Anthropic clients know
+// to echo back. extra_content is the carrier for dialects that have no
+// thinking block; it must not leak into the Anthropic response shape.
+func TestAnthropicThinkingSignatureSurvivesMessagesDialect(t *testing.T) {
+	client, _ := newCapturingJSONClient(t, "anthropic/messages_thinking_tool_use.json")
+	provider := anthropic.NewWithHTTPClient("sk-ant-test", client, llmclient.Hooks{})
+	provider.SetBaseURL("https://replay.local")
+
+	resp, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{
+		Model:    "claude-sonnet-4-5",
+		Messages: []core.Message{{Role: "user", Content: "What is the weather in Paris?"}},
+		Tools:    weatherTools,
+	})
+	require.NoError(t, err)
+
+	rendered, err := json.Marshal(anthropicapi.FromChatResponse(resp).Content)
+	require.NoError(t, err)
+	var blocks []map[string]any
+	require.NoError(t, json.Unmarshal(rendered, &blocks))
+
+	require.GreaterOrEqual(t, len(blocks), 2)
+	require.Equal(t, "thinking", blocks[0]["type"])
+	require.Equal(t, signedThinkingText, blocks[0]["thinking"])
+	require.Equal(t, signedThinkingSignature, blocks[0]["signature"])
+	require.NotContains(t, blocks[0], "extra_content", "the Anthropic dialect carries the signature natively")
+	require.Equal(t, "redacted_thinking", blocks[1]["type"])
+	require.Equal(t, redactedThinkingData, blocks[1]["data"])
+	require.NotContains(t, blocks[1], "thinking", "a redacted block has no readable thinking text")
+}

--- a/tests/contract/testdata/anthropic/messages_thinking_tool_use.json
+++ b/tests/contract/testdata/anthropic/messages_thinking_tool_use.json
@@ -1,0 +1,34 @@
+{
+  "model": "claude-sonnet-4-5",
+  "id": "msg_01ThinkingToolUseFixture",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "thinking",
+      "thinking": "The user asked for the weather in Paris. I should call get_weather.",
+      "signature": "ErUBCkYIBRgCIkDPthinkingSignatureFixtureForContractTestsEgxSaW5nU2lnbmF0dXJlGgz//8AB"
+    },
+    {
+      "type": "redacted_thinking",
+      "data": "EroBCoYBEncKdG9wYXF1ZS1yZWRhY3RlZC10aGlua2luZy1maXh0dXJl"
+    },
+    {
+      "type": "text",
+      "text": "Let me look that up."
+    },
+    {
+      "type": "tool_use",
+      "id": "toolu_01WeatherParis",
+      "name": "get_weather",
+      "input": { "city": "Paris" }
+    }
+  ],
+  "stop_reason": "tool_use",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 61,
+    "output_tokens": 88,
+    "output_tokens_details": { "thinking_tokens": 42 }
+  }
+}

--- a/tests/contract/testdata/golden/anthropic/messages_extended_thinking.golden.json
+++ b/tests/contract/testdata/golden/anthropic/messages_extended_thinking.golden.json
@@ -5,6 +5,17 @@
       "index": 0,
       "message": {
         "content": "To solve for x in the equation x + 5 = 12, I need to isolate x.\n\nI'll subtract 5 from both sides:\nx + 5 = 12\nx + 5 - 5 = 12 - 5\nx = 7\n\nLet me verify: 7 + 5 = 12 ✓\n\nTherefore, x = 7.",
+        "extra_content": {
+          "anthropic": {
+            "thinking_blocks": [
+              {
+                "signature": "EoQDCkYICxgCKkD/7LGRV3nhFx7eDr0a8CqN9Q7VPNpcIwqMFQzxg6yM6cO8+q0blgDq+FxNpRMTkCjr3IJM6NaGVts1UOfeU5aNEgxb0pVzXeXVpI7s+Z4aDE478qswmtW5VM64tCIw0s9xrQpgRYkAQXva9t8ffdPRTNonQJha21BqfjukLhWjHR9NjkDoP7Qwsg1Y/puqKusBe7vIpKbZDnINky4NLhrdk10PAhtp428bEsRkJYKhoSfNfmxO6KQUH4xA7zXA4FWNwrrWtbaq8Wjy7A6NQ5RMCzxqOa1gzUpI06JOJf47QcjJuJmu6IzjL8Wj6e0vg1v8AQyiLQRh+vMlTkCmT1p2rmmUfrqGA68oEKWt6HkytfiRrkw3UrbIqjOlPlWYmFSh3ypnYHV91QILr8uoaRivkLko8eTMnS2dq8qKBJyH+nZvKjNnQg2fz4Xj25wfDyiB6dQ2zXPL1vdMurqfzsM2ZKoihxVGCPkfstDG24iadpjrH09hqTriwIVspRgB",
+                "thinking": "I need to solve for x in the equation x + 5 = 12.\n\nTo isolate x, I need to subtract 5 from both sides of the equation:\n\nx + 5 = 12\nx + 5 - 5 = 12 - 5\nx = 7\n\nLet me check: If x = 7, then x + 5 = 7 + 5 = 12 ✓\n\nSo x = 7.",
+                "type": "thinking"
+              }
+            ]
+          }
+        },
         "reasoning_content": "I need to solve for x in the equation x + 5 = 12.\n\nTo isolate x, I need to subtract 5 from both sides of the equation:\n\nx + 5 = 12\nx + 5 - 5 = 12 - 5\nx = 7\n\nLet me check: If x = 7, then x + 5 = 7 + 5 = 12 ✓\n\nSo x = 7.",
         "role": "assistant"
       }

--- a/tools/openapi-postprocess.mjs
+++ b/tools/openapi-postprocess.mjs
@@ -174,6 +174,10 @@ function ensureAnthropicContentBlockSchema() {
       source: stringOrFreeFormObjectSchema(),
       text: { type: "string" },
       thinking: { type: "string" },
+      // thinking blocks are replayed with the signature Anthropic issued;
+      // redacted ones carry their opaque payload instead.
+      signature: { type: "string" },
+      data: { type: "string" },
       tool_use_id: { type: "string" },
       type: { type: "string" },
     },

--- a/tools/swagger-postprocess.mjs
+++ b/tools/swagger-postprocess.mjs
@@ -135,6 +135,10 @@ function ensureAnthropicContentBlockSchema() {
       source: stringOrFreeFormObjectSchema(),
       text: { type: "string" },
       thinking: { type: "string" },
+      // thinking blocks are replayed with the signature Anthropic issued;
+      // redacted ones carry their opaque payload instead.
+      signature: { type: "string" },
+      data: { type: "string" },
       tool_use_id: { type: "string" },
       type: { type: "string" },
     },


### PR DESCRIPTION
Anthropic signs every thinking block it returns and rejects a later turn that replays one without its signature. GoModel dropped the signature on the way out, so the standard agent loop — echo the assistant turn back — always failed on the second request:

```
POST /v1/messages  thinking.enabled  ->  {"type":"thinking","thinking":"..."}   (no signature)
replay that content                  ->  400 messages.1.content.0.thinking.signature: Field required
```

## User-visible impact

Multi-turn extended thinking now works on every dialect routed to Anthropic, tool-use loops included.

The blocks travel out the same way they already travel in, on `extra_content.anthropic.thinking_blocks` (the mechanism added in #895):

- **`/v1/messages`** renders the native `signature` and `data` fields on the content blocks, because that is what an Anthropic client echoes back. Streaming emits a `signature_delta` inside the thinking block before it closes, as Anthropic does. `extra_content` is never leaked into this dialect.
- **Chat Completions** carries the vendor object on the assistant message, next to the unchanged `reasoning_content`. Streaming emits it once the thinking block completes, before any text, cumulatively.
- **Responses** carries it on the `reasoning` output item and restores it from an echoed one.
- Synthesized streams (`SynthesizeChatStream`) carry the message's replay state too, so an un-streamed response is still replayable.

`redacted_thinking` has no readable text, so `extra_content` is the only carrier for it outside the Messages dialect.

## Provider-specific notes

- The Anthropic **Responses** path surfaced no reasoning at all — no `reasoning_content`, no reasoning item. It does now. Streaming `/v1/responses` still emits none (the converter never wired up the shared reasoning state); documented as a limitation rather than fixed here, to keep this change focused.
- Routing a history to another provider drops `extra_content.anthropic` as before; verified live that an Anthropic thinking turn is accepted by OpenAI.
- `SynthesizeChatStream` still drops **tool call** `extra_content` (a separate, pre-existing Gemini gap).

## Tests

Written before the fix, all failing at the time:

- `tests/contract/extra_content_roundtrip_test.go` — response-side mirror of `TestAnthropicThinkingBlocksReplay`: a signed thinking block plus a redacted one must reach the client and come back verbatim on the upstream request through all three ingress dialects.
- Streaming coverage on both sides: `signature_delta` -> replay state (provider) and replay state -> `signature_delta` (egress), including cumulative values not re-emitting, and a guard that a stream with no thinking gains no `extra_content`.
- `FromChatResponse` table: signed blocks verbatim, fallback to `reasoning_content` for providers with no thinking protocol, malformed member falls back, another vendor's state is not thinking.

Verified live against the Anthropic API: two-turn thinking, a streamed turn reassembled and replayed, a tool-use agent loop with parallel calls, and all three dialects. The same script against the pre-fix build fails turn 2 with the 400 above.

`cmd/gomodel/docs/docs.go` also picks up the `/v1/auth/verify` route from #924, which was left stale there; that is regeneration, not a change in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an authentication verification endpoint that reports credential validity and authentication status.
  - Anthropic thinking and redacted-thinking blocks now preserve signatures and opaque data across requests, responses, streaming, and tool-use workflows.
  - Signed thinking blocks replay correctly across chat, Responses, and Anthropic Messages API formats.

- **Documentation**
  - Expanded API documentation for thinking-block fields, replay behavior, streamed deltas, and `extra_content`.
  - Clarified audit-log revision ordering and prompt-guardrail recording behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->