### PR TITLE
refactor(anthropic): share thinking replay state across stream converters

### DIFF
--- a/docs/advanced/extra-content.mdx
+++ b/docs/advanced/extra-content.mdx
@@ -170,8 +170,11 @@ that matter are shown.
 
 The same member appears on streamed `tool_calls` deltas, on Responses API
 `function_call` items, on Anthropic Messages `tool_use` blocks, and, for
-text-only turns, on the assistant message itself. Only the first call of a
-parallel batch carries a signature. A flat `thought_signature` or
+text-only turns, on the assistant message itself. On the Responses API a
+text-only turn's signature rides on a `reasoning` output item ahead of the
+message, with no reasoning text of its own; echo the item back and the
+signature lands on the assistant turn. Only the first call of a parallel
+batch carries a signature. A flat `thought_signature` or
 `thoughtSignature` on the tool call is accepted too, so clients built against
 other gateways keep working.
 

--- a/internal/anthropicapi/stream_test.go
+++ b/internal/anthropicapi/stream_test.go
@@ -331,3 +331,47 @@ func TestStreamConverterThinkingSignatureNotRepeated(t *testing.T) {
 		t.Fatalf("signature deltas = %v, want each block signed exactly once", signatures)
 	}
 }
+
+// Interleaved thinking puts text between two thinking blocks. The second
+// block's signature must land in the second thinking block, not the first,
+// and the text block in between must be closed before it opens.
+func TestStreamConverterThinkingBlocksAroundText(t *testing.T) {
+	first := `{"type":"thinking","thinking":"a","signature":"sig-a"}`
+	second := `{"type":"thinking","thinking":"b","signature":"sig-b"}`
+	chatStream := strings.Join([]string{
+		`data: {"id":"chatcmpl-1","model":"claude-sonnet-4-5","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		`data: {"choices":[{"index":0,"delta":{"reasoning_content":"a"},"finish_reason":null}]}`,
+		`data: {"choices":[{"index":0,"delta":{"extra_content":{"anthropic":{"thinking_blocks":[` + first + `]}}},"finish_reason":null}]}`,
+		`data: {"choices":[{"index":0,"delta":{"content":"mid"},"finish_reason":null}]}`,
+		`data: {"choices":[{"index":0,"delta":{"reasoning_content":"b"},"finish_reason":null}]}`,
+		`data: {"choices":[{"index":0,"delta":{"extra_content":{"anthropic":{"thinking_blocks":[` + first + `,` + second + `]}}},"finish_reason":null}]}`,
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		`data: [DONE]`,
+		"",
+	}, "\n\n")
+
+	var got []string
+	for _, event := range drainConverter(t, chatStream) {
+		switch event["type"] {
+		case "content_block_start":
+			got = append(got, "start:"+event["content_block"].(map[string]any)["type"].(string))
+		case "content_block_delta":
+			delta := event["delta"].(map[string]any)
+			entry := "delta:" + delta["type"].(string)
+			if sig, ok := delta["signature"].(string); ok {
+				entry += ":" + sig
+			}
+			got = append(got, entry)
+		case "content_block_stop":
+			got = append(got, "stop")
+		}
+	}
+	want := []string{
+		"start:thinking", "delta:thinking_delta", "delta:signature_delta:sig-a", "stop",
+		"start:text", "delta:text_delta", "stop",
+		"start:thinking", "delta:thinking_delta", "delta:signature_delta:sig-b", "stop",
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("content events:\n%s\nwant:\n%s", strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+}

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -6698,3 +6698,128 @@ data: {"type":"message_stop"}
 		t.Errorf("final output[1] = %v, want the assistant message", output[1])
 	}
 }
+
+// interleavedThinkingSSE is a single message with two thinking blocks: with
+// interleaved thinking the model can think again after it has written text.
+const interleavedThinkingSSE = `event: message_start
+data: {"type":"message_start","message":{"id":"msg_two","type":"message","role":"assistant","model":"claude-sonnet-4-5","content":[],"stop_reason":null,"usage":{"input_tokens":10,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"First."}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig-1"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Checking."}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: content_block_start
+data: {"type":"content_block_start","index":2,"content_block":{"type":"thinking","thinking":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"thinking_delta","thinking":"Second."}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"signature_delta","signature":"sig-2"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":2}
+
+event: content_block_start
+data: {"type":"content_block_start","index":3,"content_block":{"type":"tool_use","id":"toolu_1","name":"lookup_weather","input":{}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":3,"delta":{"type":"input_json_delta","partial_json":"{\"city\":\"Warsaw\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":3}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":12}}
+
+event: message_stop
+data: {"type":"message_stop"}
+`
+
+// Every thinking block of the turn must reach the client in order, each one
+// published as it closes and the last publication holding the whole turn.
+func TestStreamChatCompletion_TwoThinkingBlocks(t *testing.T) {
+	deltas := chatStreamDeltas(t, interleavedThinkingSSE)
+
+	var published []string
+	for _, delta := range deltas {
+		if raw, ok := delta[core.ExtraContentField]; ok {
+			encoded, _ := json.Marshal(raw)
+			published = append(published, string(encoded))
+		}
+	}
+	want := []string{
+		`{"anthropic":{"thinking_blocks":[{"signature":"sig-1","thinking":"First.","type":"thinking"}]}}`,
+		`{"anthropic":{"thinking_blocks":[{"signature":"sig-1","thinking":"First.","type":"thinking"},{"signature":"sig-2","thinking":"Second.","type":"thinking"}]}}`,
+	}
+	if len(published) != len(want) {
+		t.Fatalf("extra_content published %d times: %v, want %d", len(published), published, len(want))
+	}
+	for i := range want {
+		if published[i] != want[i] {
+			t.Errorf("publication %d = %s, want %s", i, published[i], want[i])
+		}
+	}
+}
+
+// A Responses stream has one reasoning item, and its output_item.done cannot
+// be taken back. Thinking that arrives after text therefore adds no delta to a
+// closed item, but its signature still has to reach the terminal output: the
+// SDK builds the next turn from response.output, and Anthropic rejects the
+// turn if any block of it lacks its signature.
+func TestStreamResponses_ThinkingAfterTextKeepsStreamValid(t *testing.T) {
+	events := responsesStreamEvents(t, interleavedThinkingSSE)
+
+	reasoningDone := false
+	var lateDeltas []string
+	for _, event := range events {
+		switch event["type"] {
+		case "response.output_item.done":
+			if event["item"].(map[string]any)["type"] == "reasoning" {
+				reasoningDone = true
+			}
+		case "response.reasoning_text.delta":
+			if reasoningDone {
+				lateDeltas = append(lateDeltas, event["delta"].(string))
+			}
+		}
+	}
+	if !reasoningDone {
+		t.Fatal("reasoning item was never closed")
+	}
+	if len(lateDeltas) > 0 {
+		t.Errorf("reasoning deltas %v were emitted after the item closed", lateDeltas)
+	}
+
+	final := events[len(events)-1]
+	output := final["response"].(map[string]any)["output"].([]any)
+	reasoning := output[0].(map[string]any)
+	if reasoning["type"] != "reasoning" {
+		t.Fatalf("final output[0] = %v, want the reasoning item", reasoning["type"])
+	}
+	extra, _ := json.Marshal(reasoning["extra_content"])
+	want := `{"anthropic":{"thinking_blocks":[{"signature":"sig-1","thinking":"First.","type":"thinking"},{"signature":"sig-2","thinking":"Second.","type":"thinking"}]}}`
+	if string(extra) != want {
+		t.Errorf("terminal reasoning extra_content = %s, want both blocks", extra)
+	}
+	if got := output[len(output)-1].(map[string]any)["type"]; got != "function_call" {
+		t.Errorf("final output ends with %v, want the function_call", got)
+	}
+}

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -6823,3 +6823,37 @@ func TestStreamResponses_ThinkingAfterTextKeepsStreamValid(t *testing.T) {
 		t.Errorf("final output ends with %v, want the function_call", got)
 	}
 }
+
+// A signature is the last delta of a thinking block, so a stream cut between
+// it and content_block_stop still holds a block Anthropic will accept back.
+// The incomplete terminal output must carry it: the client continues from
+// response.output, and losing the signature there loses the turn.
+func TestStreamResponses_InterruptedAfterSignatureKeepsReplayState(t *testing.T) {
+	sse := `event: message_start
+data: {"type":"message_start","message":{"id":"msg_cut","type":"message","role":"assistant","model":"claude-sonnet-4-5","content":[],"stop_reason":null,"usage":{"input_tokens":10,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me think."}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig-1"}}
+`
+	events := responsesStreamEvents(t, sse)
+	final := events[len(events)-1]
+	if final["type"] != "response.incomplete" {
+		t.Fatalf("final event = %v, want response.incomplete", final["type"])
+	}
+	output := final["response"].(map[string]any)["output"].([]any)
+	reasoning := output[0].(map[string]any)
+	if reasoning["type"] != "reasoning" {
+		t.Fatalf("final output[0] = %v, want the reasoning item", reasoning["type"])
+	}
+	extra, _ := json.Marshal(reasoning["extra_content"])
+	want := `{"anthropic":{"thinking_blocks":[{"signature":"sig-1","thinking":"Let me think.","type":"thinking"}]}}`
+	if string(extra) != want {
+		t.Errorf("interrupted reasoning extra_content = %s, want the signed block", extra)
+	}
+}

--- a/internal/providers/anthropic/chat.go
+++ b/internal/providers/anthropic/chat.go
@@ -50,7 +50,7 @@ func convertFromAnthropicResponse(resp *anthropicResponse) *core.ChatResponse {
 	}
 	// reasoning_content is the readable text only; the signatures Anthropic
 	// needs back travel as replay state.
-	msg.ExtraFields = withThinkingReplay(msg.ExtraFields, extractThinkingReplay(resp.Content))
+	msg.ExtraFields = withThinkingReplay(msg.ExtraFields, resp.Content)
 
 	return &core.ChatResponse{
 		ID:      resp.ID,

--- a/internal/providers/anthropic/chat_stream.go
+++ b/internal/providers/anthropic/chat_stream.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/goccy/go-json"
-
 	"github.com/enterpilot/gomodel/internal/core"
 	"github.com/enterpilot/gomodel/internal/llmclient"
 	"github.com/enterpilot/gomodel/internal/providers"
@@ -48,17 +46,12 @@ type streamConverter struct {
 	created           int64
 	nextToolCallIndex int
 	toolCalls         map[int]*streamToolCallState
-	thinkingBlocks    map[int]bool // tracks which content block indices are thinking blocks
-	// thinkingReplay accumulates the thinking blocks of this turn, keyed by
-	// upstream content-block index and ordered by thinkingOrder, so the
-	// signatures Anthropic requires back can be handed to the client.
-	thinkingReplay   map[int]*anthropicContent
-	thinkingOrder    []int
-	usage            anthropicUsage
-	hasUsage         bool
-	buffer           streaming.StreamBuffer
-	closed           bool
-	emittedToolCalls bool
+	thinking          thinkingReplayState
+	usage             anthropicUsage
+	hasUsage          bool
+	buffer            streaming.StreamBuffer
+	closed            bool
+	emittedToolCalls  bool
 }
 
 // streamToolCallState tracks per-tool-call bookkeeping for the chat dialect.
@@ -74,14 +67,13 @@ type streamToolCallState struct {
 
 func newStreamConverter(body io.ReadCloser, model string) *streamConverter {
 	return &streamConverter{
-		reader:         bufio.NewReader(body),
-		body:           body,
-		model:          model,
-		created:        time.Now().Unix(),
-		toolCalls:      make(map[int]*streamToolCallState),
-		thinkingBlocks: make(map[int]bool),
-		thinkingReplay: make(map[int]*anthropicContent),
-		buffer:         streaming.NewStreamBuffer(1024),
+		reader:    bufio.NewReader(body),
+		body:      body,
+		model:     model,
+		created:   time.Now().Unix(),
+		toolCalls: make(map[int]*streamToolCallState),
+		thinking:  newThinkingReplayState(),
+		buffer:    streaming.NewStreamBuffer(1024),
 	}
 }
 
@@ -193,15 +185,7 @@ func (sc *streamConverter) convertEvent(event *anthropicStreamEvent) string {
 		return ""
 
 	case "content_block_start":
-		if event.ContentBlock != nil && event.ContentBlock.Type == "thinking" {
-			sc.thinkingBlocks[event.Index] = true
-			sc.trackThinking(event.Index, *event.ContentBlock)
-			return ""
-		}
-		if event.ContentBlock != nil && event.ContentBlock.Type == "redacted_thinking" {
-			// A redacted block arrives whole and has no readable text, so
-			// replay state is the only thing that can carry it.
-			sc.trackThinking(event.Index, *event.ContentBlock)
+		if sc.thinking.track(event.Index, event.ContentBlock) {
 			return ""
 		}
 		if event.ContentBlock != nil && event.ContentBlock.Type == "tool_use" {
@@ -245,10 +229,8 @@ func (sc *streamConverter) convertEvent(event *anthropicStreamEvent) string {
 
 		switch event.Delta.Type {
 		case "thinking_delta":
-			if sc.thinkingBlocks[event.Index] && event.Delta.Thinking != "" {
-				if block := sc.thinkingReplay[event.Index]; block != nil {
-					block.Thinking += event.Delta.Thinking
-				}
+			if sc.thinking.isThinking(event.Index) && event.Delta.Thinking != "" {
+				sc.thinking.appendThinking(event.Index, event.Delta.Thinking)
 				return sc.formatChatChunk(map[string]any{
 					"reasoning_content": event.Delta.Thinking,
 				}, nil, nil)
@@ -257,9 +239,7 @@ func (sc *streamConverter) convertEvent(event *anthropicStreamEvent) string {
 			// A signature has no OpenAI-compatible field of its own; it is
 			// held until the block closes and then handed over as replay
 			// state, which is what the client must echo back.
-			if block := sc.thinkingReplay[event.Index]; block != nil {
-				block.Signature += event.Delta.Signature
-			}
+			sc.thinking.appendSignature(event.Index, event.Delta.Signature)
 			return ""
 		case "text_delta":
 			if event.Delta.Text != "" {
@@ -310,8 +290,11 @@ func (sc *streamConverter) convertEvent(event *anthropicStreamEvent) string {
 		// The completed thinking block is published before any text follows,
 		// so a client that closes it on the first text delta still sees the
 		// signature.
-		if chunk := sc.thinkingReplayChunk(event.Index); chunk != "" {
-			return chunk
+		if sc.thinking.tracked(event.Index) {
+			if extra := sc.thinking.extraContent(); extra != nil {
+				return sc.formatChatChunk(map[string]any{core.ExtraContentField: extra}, nil, nil)
+			}
+			return ""
 		}
 		state := sc.toolCalls[event.Index]
 		if state != nil && !state.Started && state.PlaceholderObject {
@@ -361,40 +344,4 @@ func (sc *streamConverter) convertEvent(event *anthropicStreamEvent) string {
 	}
 
 	return ""
-}
-
-// trackThinking records a thinking or redacted_thinking block so its
-// signature, or its opaque payload, can be replayed on a later turn.
-func (sc *streamConverter) trackThinking(index int, block anthropicContent) {
-	if _, seen := sc.thinkingReplay[index]; seen {
-		return
-	}
-	tracked := block
-	sc.thinkingReplay[index] = &tracked
-	sc.thinkingOrder = append(sc.thinkingOrder, index)
-}
-
-// thinkingReplayChunk emits the thinking blocks accumulated so far when the
-// block at index closes. The value is cumulative rather than incremental so a
-// client that keeps only the most recent extra_content still ends up with the
-// whole turn.
-func (sc *streamConverter) thinkingReplayChunk(index int) string {
-	if _, ok := sc.thinkingReplay[index]; !ok {
-		return ""
-	}
-	blocks := make([]json.RawMessage, 0, len(sc.thinkingOrder))
-	for _, i := range sc.thinkingOrder {
-		if raw, ok := thinkingReplayJSON(*sc.thinkingReplay[i]); ok {
-			blocks = append(blocks, raw)
-		}
-	}
-	raw, err := json.Marshal(map[string][]json.RawMessage{core.ThinkingBlocksField: blocks})
-	if err != nil {
-		return ""
-	}
-	vendors, err := json.Marshal(map[string]json.RawMessage{core.ExtraContentVendorAnthropic: raw})
-	if err != nil {
-		return ""
-	}
-	return sc.formatChatChunk(map[string]any{core.ExtraContentField: json.RawMessage(vendors)}, nil, nil)
 }

--- a/internal/providers/anthropic/responses.go
+++ b/internal/providers/anthropic/responses.go
@@ -276,6 +276,12 @@ func (sc *responsesStreamConverter) appendTerminalEvents() {
 		status = "incomplete"
 		eventName = "response.incomplete"
 	}
+	// A stream cut after a thinking block's signature but before its stop
+	// still holds a block Anthropic accepts back, and this is the client's
+	// only chance to receive it.
+	if extra := sc.thinking.extraContent(); extra != nil {
+		sc.output.SetReasoningExtraContent(extra)
+	}
 	prefix := sc.output.FinishReasoningOutput(sc.reasoningOutputIndex, status) +
 		sc.output.FinishAssistantOutput(sc.assistantOutputIndex, status) +
 		sc.completePendingToolCalls(status)

--- a/internal/providers/anthropic/responses.go
+++ b/internal/providers/anthropic/responses.go
@@ -39,7 +39,7 @@ func convertAnthropicResponseToResponses(resp *anthropicResponse, model string) 
 	}
 	// The reasoning item carries the signatures Anthropic needs back; without
 	// them a Responses client cannot continue a thinking conversation.
-	msg.ExtraFields = withThinkingReplay(msg.ExtraFields, extractThinkingReplay(resp.Content))
+	msg.ExtraFields = withThinkingReplay(msg.ExtraFields, resp.Content)
 	output := providers.BuildResponsesOutputItems(msg)
 
 	return &core.ResponsesResponse{
@@ -138,34 +138,28 @@ type responsesStreamConverter struct {
 	assistantOutputIndex int
 	reasoningOutputIndex int
 	toolCalls            map[int]*providers.ResponsesOutputToolCallState
-	thinkingBlocks       map[int]bool // tracks which content block indices are thinking blocks
-	// thinkingReplay accumulates the turn's thinking blocks, ordered by
-	// thinkingOrder, so the reasoning item can carry the signatures Anthropic
-	// requires back.
-	thinkingReplay map[int]*anthropicContent
-	thinkingOrder  []int
-	buffer         streaming.StreamBuffer
-	closed         bool
-	sentDone       bool
-	sawStop        bool  // upstream signalled the end of the message
-	pendingErr     error // upstream read error deferred until terminal events are drained
-	usage          anthropicUsage
-	hasUsage       bool
+	thinking             thinkingReplayState
+	buffer               streaming.StreamBuffer
+	closed               bool
+	sentDone             bool
+	sawStop              bool  // upstream signalled the end of the message
+	pendingErr           error // upstream read error deferred until terminal events are drained
+	usage                anthropicUsage
+	hasUsage             bool
 }
 
 func newResponsesStreamConverter(body io.ReadCloser, model string) *responsesStreamConverter {
 	responseID := "resp_" + uuid.New().String()
 	return &responsesStreamConverter{
-		reader:         bufio.NewReader(body),
-		body:           body,
-		model:          model,
-		responseID:     responseID,
-		createdAt:      time.Now().Unix(),
-		output:         providers.NewResponsesOutputEventState(responseID),
-		toolCalls:      make(map[int]*providers.ResponsesOutputToolCallState),
-		thinkingBlocks: make(map[int]bool),
-		thinkingReplay: make(map[int]*anthropicContent),
-		buffer:         streaming.NewStreamBuffer(1024),
+		reader:     bufio.NewReader(body),
+		body:       body,
+		model:      model,
+		responseID: responseID,
+		createdAt:  time.Now().Unix(),
+		output:     providers.NewResponsesOutputEventState(responseID),
+		toolCalls:  make(map[int]*providers.ResponsesOutputToolCallState),
+		thinking:   newThinkingReplayState(),
+		buffer:     streaming.NewStreamBuffer(1024),
 	}
 }
 
@@ -254,38 +248,6 @@ func (sc *responsesStreamConverter) reserveReasoningOutput() {
 	sc.output.ReserveReasoning()
 	sc.reasoningOutputIndex = sc.nextOutputIndex
 	sc.nextOutputIndex++
-}
-
-// trackThinkingReplay records a thinking or redacted_thinking block and
-// publishes the accumulated replay state on the reasoning item.
-func (sc *responsesStreamConverter) trackThinkingReplay(index int, block anthropicContent) {
-	if _, seen := sc.thinkingReplay[index]; !seen {
-		tracked := block
-		sc.thinkingReplay[index] = &tracked
-		sc.thinkingOrder = append(sc.thinkingOrder, index)
-	}
-	sc.publishThinkingReplay()
-}
-
-func (sc *responsesStreamConverter) publishThinkingReplay() {
-	blocks := make([]json.RawMessage, 0, len(sc.thinkingOrder))
-	for _, i := range sc.thinkingOrder {
-		if raw, ok := thinkingReplayJSON(*sc.thinkingReplay[i]); ok {
-			blocks = append(blocks, raw)
-		}
-	}
-	if len(blocks) == 0 {
-		return
-	}
-	raw, err := json.Marshal(map[string][]json.RawMessage{core.ThinkingBlocksField: blocks})
-	if err != nil {
-		return
-	}
-	vendors, err := json.Marshal(map[string]json.RawMessage{core.ExtraContentVendorAnthropic: raw})
-	if err != nil {
-		return
-	}
-	sc.output.SetReasoningExtraContent(vendors)
 }
 
 func (sc *responsesStreamConverter) reserveAssistantMessageOutput() {
@@ -409,17 +371,10 @@ func (sc *responsesStreamConverter) convertEvent(event *anthropicStreamEvent) st
 		})
 
 	case "content_block_start":
-		if event.ContentBlock != nil && event.ContentBlock.Type == "thinking" {
-			sc.thinkingBlocks[event.Index] = true
+		if sc.thinking.track(event.Index, event.ContentBlock) {
+			// A redacted block has no readable text; its reasoning item
+			// exists purely to carry the replay state.
 			sc.reserveReasoningOutput()
-			sc.trackThinkingReplay(event.Index, *event.ContentBlock)
-			return ""
-		}
-		if event.ContentBlock != nil && event.ContentBlock.Type == "redacted_thinking" {
-			// A redacted block arrives whole and has no readable text, so the
-			// reasoning item exists purely to carry its replay state.
-			sc.reserveReasoningOutput()
-			sc.trackThinkingReplay(event.Index, *event.ContentBlock)
 			return ""
 		}
 		if event.ContentBlock != nil && event.ContentBlock.Type == "tool_use" {
@@ -442,21 +397,23 @@ func (sc *responsesStreamConverter) convertEvent(event *anthropicStreamEvent) st
 
 		switch event.Delta.Type {
 		case "thinking_delta":
-			if !sc.thinkingBlocks[event.Index] || event.Delta.Thinking == "" {
+			if !sc.thinking.isThinking(event.Index) || event.Delta.Thinking == "" {
 				return ""
 			}
-			if block := sc.thinkingReplay[event.Index]; block != nil {
-				block.Thinking += event.Delta.Thinking
+			sc.thinking.appendThinking(event.Index, event.Delta.Thinking)
+			// A stream has one reasoning item, closed once text or a tool call
+			// follows, and output_item.done cannot be taken back. Thinking
+			// that arrives after that (interleaved thinking) adds no delta;
+			// its text and signature still reach the client inside the
+			// replay state of the terminal output.
+			if sc.output.ReasoningDone() {
+				return ""
 			}
-			sc.reserveReasoningOutput()
 			return sc.output.AppendReasoningDelta(sc.reasoningOutputIndex, event.Delta.Thinking)
 		case "signature_delta":
 			// A signature has no field of its own in the Responses dialect; it
 			// rides on the reasoning item as replay state instead.
-			if block := sc.thinkingReplay[event.Index]; block != nil {
-				block.Signature += event.Delta.Signature
-				sc.publishThinkingReplay()
-			}
+			sc.thinking.appendSignature(event.Index, event.Delta.Signature)
 			return ""
 		case "text_delta":
 			if event.Delta.Text != "" {
@@ -495,6 +452,12 @@ func (sc *responsesStreamConverter) convertEvent(event *anthropicStreamEvent) st
 		return ""
 
 	case "content_block_stop":
+		if sc.thinking.tracked(event.Index) {
+			// The block is complete, signature included, before whatever
+			// closes the reasoning item can arrive.
+			sc.output.SetReasoningExtraContent(sc.thinking.extraContent())
+			return ""
+		}
 		state := sc.toolCalls[event.Index]
 		return sc.output.CompleteToolCall(state, true)
 

--- a/internal/providers/anthropic/thinking_replay.go
+++ b/internal/providers/anthropic/thinking_replay.go
@@ -1,6 +1,9 @@
 package anthropic
 
 import (
+	"maps"
+	"slices"
+
 	"github.com/goccy/go-json"
 
 	"github.com/enterpilot/gomodel/internal/core"
@@ -15,62 +18,107 @@ import (
 // restores upstream. Every dialect therefore round-trips them without knowing
 // what they mean.
 
-// thinkingReplayBlock is a thinking or redacted_thinking block in the exact
-// shape Anthropic requires back. A thinking block always carries its text,
-// which is empty when the model omitted it, so the field is never dropped.
-type thinkingReplayBlock struct {
-	Type      string `json:"type"`
-	Thinking  string `json:"thinking"`
-	Signature string `json:"signature,omitempty"`
-}
-
-type redactedThinkingReplayBlock struct {
-	Type string `json:"type"`
-	Data string `json:"data"`
-}
-
-// thinkingReplayJSON encodes one response content block for replay. ok is
-// false for blocks that are not part of the thinking protocol.
-func thinkingReplayJSON(block anthropicContent) (json.RawMessage, bool) {
+// thinkingReplayBlock encodes one response content block in the exact shape
+// Anthropic requires back, the shape prependThinkingBlocks decodes. A thinking
+// block always carries its text, which is empty when the model omitted it, so
+// the field is never dropped. ok is false for blocks outside the thinking
+// protocol.
+func thinkingReplayBlock(block anthropicContent) (anthropicContentBlock, bool) {
 	switch block.Type {
 	case "thinking":
-		raw, err := json.Marshal(thinkingReplayBlock{Type: block.Type, Thinking: block.Thinking, Signature: block.Signature})
-		return raw, err == nil
+		thinking := block.Thinking
+		return anthropicContentBlock{Type: block.Type, Thinking: &thinking, Signature: block.Signature}, true
 	case "redacted_thinking":
-		raw, err := json.Marshal(redactedThinkingReplayBlock{Type: block.Type, Data: block.Data})
-		return raw, err == nil
+		return anthropicContentBlock{Type: block.Type, Data: block.Data}, true
 	default:
-		return nil, false
+		return anthropicContentBlock{}, false
 	}
 }
 
-// withThinkingReplay attaches thinking blocks to a message's extra fields as
-// extra_content.anthropic.thinking_blocks. Fields are returned unchanged when
-// there is nothing to replay, so a response without thinking keeps the shape
-// it has always had.
-func withThinkingReplay(fields core.UnknownJSONFields, blocks []json.RawMessage) core.UnknownJSONFields {
+// withThinkingReplay attaches the thinking blocks of content to a message's
+// extra fields as extra_content.anthropic.thinking_blocks. Fields are returned
+// unchanged when there is nothing to replay, so a response without thinking
+// keeps the shape it has always had.
+func withThinkingReplay(fields core.UnknownJSONFields, content []anthropicContent) core.UnknownJSONFields {
+	var blocks []anthropicContentBlock
+	for _, c := range content {
+		if block, ok := thinkingReplayBlock(c); ok {
+			blocks = append(blocks, block)
+		}
+	}
 	if len(blocks) == 0 {
 		return fields
 	}
-	raw, err := json.Marshal(map[string][]json.RawMessage{core.ThinkingBlocksField: blocks})
+	vendor, err := json.Marshal(map[string][]anthropicContentBlock{core.ThinkingBlocksField: blocks})
 	if err != nil {
 		return fields
 	}
-	updated, err := fields.WithExtraContent(core.ExtraContentVendorAnthropic, raw)
+	updated, err := fields.WithExtraContent(core.ExtraContentVendorAnthropic, vendor)
 	if err != nil {
 		return fields
 	}
 	return updated
 }
 
-// extractThinkingReplay collects the thinking blocks of a non-streamed
-// response in order.
-func extractThinkingReplay(blocks []anthropicContent) []json.RawMessage {
-	var out []json.RawMessage
-	for _, block := range blocks {
-		if raw, ok := thinkingReplayJSON(block); ok {
-			out = append(out, raw)
-		}
+// thinkingReplayState accumulates the thinking blocks of one streamed turn,
+// keyed by upstream content-block index, so a stream hands the client the
+// same replay state a buffered response carries. Both stream converters own
+// one.
+type thinkingReplayState struct {
+	blocks map[int]*anthropicContent
+}
+
+func newThinkingReplayState() thinkingReplayState {
+	return thinkingReplayState{blocks: make(map[int]*anthropicContent)}
+}
+
+// track records a thinking or redacted_thinking block as it starts and
+// reports whether the block belongs to the thinking protocol at all. A
+// redacted block arrives whole, so tracking it is all there is to do.
+func (s *thinkingReplayState) track(index int, block *anthropicContent) bool {
+	if block == nil || (block.Type != "thinking" && block.Type != "redacted_thinking") {
+		return false
 	}
-	return out
+	if _, seen := s.blocks[index]; !seen {
+		tracked := *block
+		s.blocks[index] = &tracked
+	}
+	return true
+}
+
+// tracked reports whether index is a block of the thinking protocol.
+func (s *thinkingReplayState) tracked(index int) bool {
+	_, ok := s.blocks[index]
+	return ok
+}
+
+// isThinking reports whether index is a readable thinking block; a redacted
+// one has no text to stream.
+func (s *thinkingReplayState) isThinking(index int) bool {
+	block := s.blocks[index]
+	return block != nil && block.Type == "thinking"
+}
+
+func (s *thinkingReplayState) appendThinking(index int, text string) {
+	if block := s.blocks[index]; block != nil {
+		block.Thinking += text
+	}
+}
+
+func (s *thinkingReplayState) appendSignature(index int, signature string) {
+	if block := s.blocks[index]; block != nil {
+		block.Signature += signature
+	}
+}
+
+// extraContent renders every block tracked so far as an extra_content value,
+// in upstream order. It is cumulative rather than incremental so a client
+// that keeps only the most recent value still ends up with the whole turn.
+// nil when nothing has been tracked.
+func (s *thinkingReplayState) extraContent() json.RawMessage {
+	content := make([]anthropicContent, 0, len(s.blocks))
+	for _, index := range slices.Sorted(maps.Keys(s.blocks)) {
+		content = append(content, *s.blocks[index])
+	}
+	return withThinkingReplay(core.UnknownJSONFields{}, content).Lookup(core.ExtraContentField)
 }

--- a/internal/providers/responses_output_test.go
+++ b/internal/providers/responses_output_test.go
@@ -123,3 +123,48 @@ func TestConvertResponsesInputToMessages_ReasoningAttachesToItsTurn(t *testing.T
 		t.Fatal("the assistant turn lost its replay state")
 	}
 }
+
+// Turn-wide replay state on the assistant message (a Gemini 3 text-turn
+// thought signature, an Anthropic thinking signature) has no home on the
+// message item, so it rides on a reasoning item even when there is no
+// reasoning text to show. The client echoes the item and the state comes back
+// on the assistant turn.
+func TestBuildResponsesOutputItems_MessageReplayStateBecomesReasoningItem(t *testing.T) {
+	fields, err := core.UnknownJSONFields{}.WithExtraContent(core.ExtraContentVendorGoogle, json.RawMessage(`{"thought_signature":"sig-1"}`))
+	if err != nil {
+		t.Fatalf("WithExtraContent: %v", err)
+	}
+	items := BuildResponsesOutputItems(core.ResponseMessage{Role: "assistant", Content: "hi", ExtraFields: fields})
+	if len(items) != 2 || items[0].Type != "reasoning" || items[1].Type != "message" {
+		t.Fatalf("items = %+v, want a reasoning item followed by the message", items)
+	}
+	encoded, err := json.Marshal(items[0])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var reasoning map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &reasoning); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := string(reasoning["extra_content"]); got != `{"google":{"thought_signature":"sig-1"}}` {
+		t.Errorf("reasoning extra_content = %s, want the message's replay state", got)
+	}
+	if _, ok := reasoning["content"]; ok {
+		t.Errorf("reasoning item carries content %s, want none for a turn without reasoning text", reasoning["content"])
+	}
+
+	// Echoed back, the item's state lands on the assistant turn it precedes.
+	messages, err := convertResponsesInputItems([]any{
+		map[string]any{"type": "reasoning", "summary": []any{}, "extra_content": map[string]any{"google": map[string]any{"thought_signature": "sig-1"}}},
+		map[string]any{"type": "message", "role": "assistant", "content": "hi"},
+	})
+	if err != nil {
+		t.Fatalf("convertResponsesInputItems: %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("messages = %+v, want one assistant turn", messages)
+	}
+	if got := string(messages[0].ExtraFields.ExtraContent(core.ExtraContentVendorGoogle)); got != `{"thought_signature":"sig-1"}` {
+		t.Errorf("assistant extra_content.google = %s, want the echoed signature", got)
+	}
+}


### PR DESCRIPTION
Follow-up to #928.

The chat and Responses stream converters each carried their own copy of the thinking-block bookkeeping (index map, order slice, and the two-step marshal into `extra_content.anthropic.thinking_blocks`), and a third copy lived in the non-streamed path. They now share one `thinkingReplayState` in `thinking_replay.go`, which also replaces the pre-existing `thinkingBlocks` bool maps. Replay blocks are encoded with the request-side `anthropicContentBlock`, so the type the response writes is the type `prependThinkingBlocks` reads back.

Two behaviour changes, both covered by new tests:

- **Responses stream: thinking after text no longer emits a delta into a closed item.** A stream has one reasoning item, and once text or a tool call closes it, `output_item.done` cannot be taken back. Interleaved thinking that arrives later now adds no `reasoning_text.delta`; its text and signature still reach the client in the replay state of the terminal output, which is what the SDK builds the next turn from. This matches the guard the generic converter already had.
- **Responses API: message-level replay state is pinned as intended.** #928 made `BuildResponsesOutputItems` emit a reasoning item for any turn-wide `extra_content`, which also covers a Gemini 3 text-only turn's thought signature (previously lost on that path). A test now pins the item shape and the echo back onto the assistant turn, and the docs say so.

Also adds coverage for two thinking blocks in one stream on the chat dialect and the Messages dialect renderer, the case the cumulative array exists for.

No change to the wire format of `thinking_blocks`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added guidance for preserving Gemini thought signatures in text-only Responses API turns.

- **Bug Fixes**
  - Improved Anthropic streaming with multiple thinking blocks interleaved with text.
  - Preserved thinking content and signatures across chat and Responses streaming.
  - Prevented reasoning updates after a reasoning item closes.
  - Preserved signed thinking content when a stream is interrupted.
  - Ensured replay metadata attaches to the correct assistant turn.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->