### PR TITLE
fix(responses): carry a streamed Gemini text-turn signature on the message item

### DIFF
--- a/docs/advanced/extra-content.mdx
+++ b/docs/advanced/extra-content.mdx
@@ -40,7 +40,7 @@ against it work unchanged.
 | API | Location |
 | --- | --- |
 | Chat Completions | `tool_calls[].extra_content`; on the assistant message for turn-wide state such as thinking blocks; also on streamed `tool_calls` and message deltas |
-| Responses | `function_call` output items; `reasoning` output items |
+| Responses | `function_call` output items; `reasoning` output items; the assistant `message` item when a text-turn signature arrives while streaming |
 | Anthropic Messages | `tool_use` content blocks. Thinking blocks use the dialect's own `signature` and `data` fields instead. |
 
 State sits on the unit that maps to one provider part. A tool call becomes one

--- a/internal/providers/responses_converter.go
+++ b/internal/providers/responses_converter.go
@@ -68,6 +68,7 @@ type openAIStreamChunk struct {
 			Content          string                `json:"content"`
 			ReasoningContent string                `json:"reasoning_content"`
 			ToolCalls        []openAIChunkToolCall `json:"tool_calls"`
+			ExtraContent     json.RawMessage       `json:"extra_content"`
 		} `json:"delta"`
 		FinishReason string `json:"finish_reason"`
 	} `json:"choices"`
@@ -286,8 +287,20 @@ func (sc *OpenAIResponsesStreamConverter) processChunk(data []byte) {
 	if len(choice.Delta.ToolCalls) > 0 {
 		sc.buffer.AppendString(sc.handleToolCallDeltas(choice.Delta.ToolCalls))
 	}
+	sc.setMessageExtraContent(choice.Delta.ExtraContent)
 	if choice.FinishReason == "tool_calls" {
 		sc.buffer.AppendString(sc.completePendingToolCalls())
+	}
+}
+
+// setMessageExtraContent records turn-wide replay state carried on the
+// message delta (a Gemini 3 text-turn thought signature). It arrives on the
+// last delta, after the reasoning slot is gone, so it rides on the assistant
+// message item, which the Responses input side already replays. A null delta
+// leaves the value alone.
+func (sc *OpenAIResponsesStreamConverter) setMessageExtraContent(raw json.RawMessage) {
+	if extra := bytes.TrimSpace(raw); len(extra) > 0 && !bytes.Equal(extra, []byte("null")) {
+		sc.output.SetAssistantExtraContent(extra)
 	}
 }
 
@@ -329,6 +342,11 @@ func (sc *OpenAIResponsesStreamConverter) processChunkTolerant(data []byte) {
 		}
 		if toolCalls, ok := delta["tool_calls"].([]any); ok && len(toolCalls) > 0 {
 			sc.buffer.AppendString(sc.handleToolCallDeltas(chunkToolCallsFromAny(toolCalls)))
+		}
+		if extra, ok := delta["extra_content"]; ok && extra != nil {
+			if raw, err := json.Marshal(extra); err == nil {
+				sc.setMessageExtraContent(raw)
+			}
 		}
 	}
 	finishReason, _ := choice["finish_reason"].(string)

--- a/internal/providers/responses_converter.go
+++ b/internal/providers/responses_converter.go
@@ -278,6 +278,10 @@ func (sc *OpenAIResponsesStreamConverter) processChunk(data []byte) {
 		sc.sawFinish = true
 	}
 
+	// Recorded before the text and tool calls of the same delta: a tool call
+	// closes the message item on the spot, and its output_item.done must
+	// already carry the state.
+	sc.setMessageExtraContent(choice.Delta.ExtraContent)
 	if choice.Delta.ReasoningContent != "" {
 		sc.appendReasoningDelta(choice.Delta.ReasoningContent)
 	}
@@ -287,7 +291,6 @@ func (sc *OpenAIResponsesStreamConverter) processChunk(data []byte) {
 	if len(choice.Delta.ToolCalls) > 0 {
 		sc.buffer.AppendString(sc.handleToolCallDeltas(choice.Delta.ToolCalls))
 	}
-	sc.setMessageExtraContent(choice.Delta.ExtraContent)
 	if choice.FinishReason == "tool_calls" {
 		sc.buffer.AppendString(sc.completePendingToolCalls())
 	}
@@ -296,8 +299,9 @@ func (sc *OpenAIResponsesStreamConverter) processChunk(data []byte) {
 // setMessageExtraContent records turn-wide replay state carried on the
 // message delta (a Gemini 3 text-turn thought signature). It arrives on the
 // last delta, after the reasoning slot is gone, so it rides on the assistant
-// message item, which the Responses input side already replays. A null delta
-// leaves the value alone.
+// message item, which the Responses input side already replays. Callers
+// record it before the rest of the delta so an item closed by that same delta
+// carries it. A null delta leaves the value alone.
 func (sc *OpenAIResponsesStreamConverter) setMessageExtraContent(raw json.RawMessage) {
 	if extra := bytes.TrimSpace(raw); len(extra) > 0 && !bytes.Equal(extra, []byte("null")) {
 		sc.output.SetAssistantExtraContent(extra)
@@ -334,6 +338,11 @@ func (sc *OpenAIResponsesStreamConverter) processChunkTolerant(data []byte) {
 		return
 	}
 	if delta, ok := choice["delta"].(map[string]any); ok {
+		if extra, ok := delta["extra_content"]; ok && extra != nil {
+			if raw, err := json.Marshal(extra); err == nil {
+				sc.setMessageExtraContent(raw)
+			}
+		}
 		if reasoning, ok := delta["reasoning_content"].(string); ok && reasoning != "" {
 			sc.appendReasoningDelta(reasoning)
 		}
@@ -342,11 +351,6 @@ func (sc *OpenAIResponsesStreamConverter) processChunkTolerant(data []byte) {
 		}
 		if toolCalls, ok := delta["tool_calls"].([]any); ok && len(toolCalls) > 0 {
 			sc.buffer.AppendString(sc.handleToolCallDeltas(chunkToolCallsFromAny(toolCalls)))
-		}
-		if extra, ok := delta["extra_content"]; ok && extra != nil {
-			if raw, err := json.Marshal(extra); err == nil {
-				sc.setMessageExtraContent(raw)
-			}
 		}
 	}
 	finishReason, _ := choice["finish_reason"].(string)

--- a/internal/providers/responses_converter_test.go
+++ b/internal/providers/responses_converter_test.go
@@ -1094,3 +1094,121 @@ data: [DONE]
 		})
 	}
 }
+
+// A Gemini 3 text turn streams its thought signature on the last delta, after
+// the text has started, as message-level extra_content. The reasoning slot is
+// gone by then, so the signature rides on the assistant message item: its
+// output_item.done and the terminal output, which is what the client echoes
+// back. A later null delta must not clear it.
+func TestOpenAIResponsesStreamConverter_MessageExtraContentOnMessageItem(t *testing.T) {
+	mockStream := `data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gemini-3.5-flash","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gemini-3.5-flash","choices":[{"index":0,"delta":{"content":"!","extra_content":{"google":{"thought_signature":"sig-text"}}},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gemini-3.5-flash","choices":[{"index":0,"delta":{"extra_content":null},"finish_reason":"stop"}]}
+
+data: [DONE]
+`
+	converter := NewOpenAIResponsesStreamConverter(io.NopCloser(strings.NewReader(mockStream)), "gemini-3.5-flash", "gemini")
+	raw, err := io.ReadAll(converter)
+	if err != nil {
+		t.Fatalf("failed to read from converter: %v", err)
+	}
+
+	want := map[string]any{"google": map[string]any{"thought_signature": "sig-text"}}
+	sawDone := false
+	for _, event := range parseTestSSEEvents(t, string(raw)) {
+		if event.Done {
+			continue
+		}
+		switch event.Name {
+		case "response.output_item.added":
+			if item, _ := event.Payload["item"].(map[string]any); item["type"] == "reasoning" {
+				t.Error("a text turn with no reasoning text must not gain a reasoning item")
+			}
+		case "response.output_item.done":
+			item, _ := event.Payload["item"].(map[string]any)
+			if item["type"] != "message" {
+				continue
+			}
+			sawDone = true
+			if got := item["extra_content"]; !reflect.DeepEqual(got, want) {
+				t.Errorf("message output_item.done extra_content = %#v, want %#v", got, want)
+			}
+		case "response.completed":
+			output, _ := event.Payload["response"].(map[string]any)["output"].([]any)
+			if len(output) != 1 {
+				t.Fatalf("terminal output = %#v, want the message item alone", output)
+			}
+			if got := output[0].(map[string]any)["extra_content"]; !reflect.DeepEqual(got, want) {
+				t.Errorf("terminal message extra_content = %#v, want %#v", got, want)
+			}
+		}
+	}
+	if !sawDone {
+		t.Fatal("expected a message output_item.done event")
+	}
+}
+
+// The tolerant decode path, taken for off-spec chunks, must carry the member
+// as well.
+func TestOpenAIResponsesStreamConverter_MessageExtraContentTolerantPath(t *testing.T) {
+	mockStream := `data: {"choices":[{"delta":{"content":[{"type":"text","text":"ignored"}],"extra_content":{"google":{"thought_signature":"sig-text"}}},"finish_reason":null}]}
+
+data: {"choices":[{"delta":{"content":"Hi"},"finish_reason":"stop"}]}
+
+data: [DONE]
+`
+	converter := NewOpenAIResponsesStreamConverter(io.NopCloser(strings.NewReader(mockStream)), "gemini-3.5-flash", "gemini")
+	raw, err := io.ReadAll(converter)
+	if err != nil {
+		t.Fatalf("failed to read from converter: %v", err)
+	}
+	want := map[string]any{"google": map[string]any{"thought_signature": "sig-text"}}
+	for _, event := range parseTestSSEEvents(t, string(raw)) {
+		if event.Name != "response.completed" {
+			continue
+		}
+		output, _ := event.Payload["response"].(map[string]any)["output"].([]any)
+		if len(output) != 1 {
+			t.Fatalf("terminal output = %#v, want the message item alone", output)
+		}
+		if got := output[0].(map[string]any)["extra_content"]; !reflect.DeepEqual(got, want) {
+			t.Fatalf("terminal message extra_content = %#v, want %#v", got, want)
+		}
+		return
+	}
+	t.Fatal("expected a response.completed event")
+}
+
+// A tool-call-only turn has no message item to carry a trailing message-level
+// signature. Each call already carries its own, which is the one Gemini
+// requires back, so the trailing one is dropped and the stream stays valid.
+func TestOpenAIResponsesStreamConverter_MessageExtraContentWithoutMessage(t *testing.T) {
+	mockStream := `data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gemini-3.5-flash","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"lookup_weather","arguments":"{}"},"extra_content":{"google":{"thought_signature":"sig-1"}}}]},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gemini-3.5-flash","choices":[{"index":0,"delta":{"extra_content":{"google":{"thought_signature":"sig-text"}}},"finish_reason":"tool_calls"}]}
+
+data: [DONE]
+`
+	converter := NewOpenAIResponsesStreamConverter(io.NopCloser(strings.NewReader(mockStream)), "gemini-3.5-flash", "gemini")
+	raw, err := io.ReadAll(converter)
+	if err != nil {
+		t.Fatalf("failed to read from converter: %v", err)
+	}
+	for _, event := range parseTestSSEEvents(t, string(raw)) {
+		if event.Name != "response.completed" {
+			continue
+		}
+		output, _ := event.Payload["response"].(map[string]any)["output"].([]any)
+		if len(output) != 1 || output[0].(map[string]any)["type"] != "function_call" {
+			t.Fatalf("terminal output = %#v, want the function_call alone", output)
+		}
+		want := map[string]any{"google": map[string]any{"thought_signature": "sig-1"}}
+		if got := output[0].(map[string]any)["extra_content"]; !reflect.DeepEqual(got, want) {
+			t.Errorf("function_call extra_content = %#v, want its own signature", got)
+		}
+		return
+	}
+	t.Fatal("expected a response.completed event")
+}

--- a/internal/providers/responses_converter_test.go
+++ b/internal/providers/responses_converter_test.go
@@ -1212,3 +1212,36 @@ data: [DONE]
 	}
 	t.Fatal("expected a response.completed event")
 }
+
+// One delta can carry text, a tool call, and the message-level signature at
+// once. The tool call closes the message item immediately, so the signature
+// must be recorded before that happens or the message's output_item.done
+// disagrees with the terminal output.
+func TestOpenAIResponsesStreamConverter_MessageExtraContentBeforeToolCallCloses(t *testing.T) {
+	mockStream := `data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gemini-3.5-flash","choices":[{"index":0,"delta":{"role":"assistant","content":"Checking.","tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"lookup_weather","arguments":"{}"},"extra_content":{"google":{"thought_signature":"sig-1"}}}],"extra_content":{"google":{"thought_signature":"sig-text"}}},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gemini-3.5-flash","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}
+
+data: [DONE]
+`
+	converter := NewOpenAIResponsesStreamConverter(io.NopCloser(strings.NewReader(mockStream)), "gemini-3.5-flash", "gemini")
+	raw, err := io.ReadAll(converter)
+	if err != nil {
+		t.Fatalf("failed to read from converter: %v", err)
+	}
+	want := map[string]any{"google": map[string]any{"thought_signature": "sig-text"}}
+	for _, event := range parseTestSSEEvents(t, string(raw)) {
+		if event.Name != "response.output_item.done" {
+			continue
+		}
+		item, _ := event.Payload["item"].(map[string]any)
+		if item["type"] != "message" {
+			continue
+		}
+		if got := item["extra_content"]; !reflect.DeepEqual(got, want) {
+			t.Fatalf("message output_item.done extra_content = %#v, want %#v", got, want)
+		}
+		return
+	}
+	t.Fatal("expected a message output_item.done event")
+}

--- a/internal/providers/responses_output_state.go
+++ b/internal/providers/responses_output_state.go
@@ -37,6 +37,10 @@ type ResponsesOutputEventState struct {
 	assistantMessageID   string
 	assistantText        strings.Builder
 	assistantFinalStatus string
+	// assistantExtraContent is turn-wide provider replay state that arrived
+	// on the message itself, such as a Gemini 3 text-turn thought signature.
+	// Clients echo the message item back with it.
+	assistantExtraContent json.RawMessage
 
 	reasoningReserved    bool
 	reasoningStarted     bool
@@ -123,7 +127,18 @@ func (s *ResponsesOutputEventState) AssistantMessageItem(status string, includeC
 			},
 		}
 	}
+	if len(s.assistantExtraContent) > 0 {
+		item[core.ExtraContentField] = s.assistantExtraContent
+	}
 	return item
+}
+
+// SetAssistantExtraContent attaches provider replay state to the assistant
+// message item. It is rendered on every item written from here on, including
+// the terminal output; a stream that carries it before the message starts
+// still sees it on the item once the message exists.
+func (s *ResponsesOutputEventState) SetAssistantExtraContent(raw json.RawMessage) {
+	s.assistantExtraContent = raw
 }
 
 // StartAssistantOutput emits the assistant message output_item.added event once.


### PR DESCRIPTION
Gemini 3 attaches a thought signature to a text-only turn, and the native adapter surfaces it as message-level `extra_content` on the Chat Completions delta. The buffered Responses path carries it on the reasoning item; the streamed path dropped it, because the generic chat-to-Responses converter read `extra_content` only on tool-call deltas.

The signature arrives on the last delta, after the text has started, so the reasoning slot at output index 0 is already gone. It now rides on the assistant `message` item: its `output_item.done` and the terminal output. The Responses input side already replays a message item's `extra_content` onto the assistant turn, so a client that echoes `response.output` verbatim continues the conversation unchanged. A null delta leaves the value alone, and a tool-call-only turn, which has no message item, drops the trailing text-part signature: every call carries its own, which is the one Gemini requires back.

Verified against the live Gemini API with `gemini/gemini-3-flash-preview`: the streamed message item carries the signature, and a second turn built from the streamed output is accepted.

Tests cover both decode paths of the converter, the null delta, and the tool-call-only turn. Docs list the new location.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved assistant message metadata delivered during streamed text responses.
  - Kept this metadata available in completed response events, including after later `null` updates.
  - Improved compatibility with tolerant streaming responses.
  - Prevented text-turn metadata from creating incorrect reasoning items.
  - Preserved tool-call metadata while excluding unrelated trailing message metadata.

- **Documentation**
  - Clarified that assistant message items can contain `extra_content` during streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->