### PR TITLE
fix(responses): normalize translated streams to the OpenAI event lifecycle

### DIFF
--- a/docs/advanced/responses-compatibility.mdx
+++ b/docs/advanced/responses-compatibility.mdx
@@ -31,7 +31,7 @@ function tool loops. They cannot safely execute OpenAI-hosted tools.
 | Feature | Native Responses provider | Chat-translated provider |
 | --- | --- | --- |
 | Text input and `instructions` | Forwarded | Converted to chat messages |
-| Streaming over HTTP/SSE | Forwarded | Converted from chat streaming events |
+| Streaming over HTTP/SSE | Forwarded | Converted from chat streaming events into the OpenAI event sequence: `response.created` and `response.in_progress`, output item and content part lifecycle events, and a `sequence_number` on every event |
 | Function tools | Forwarded | Converted to provider function/tool declarations |
 | Function call output items | Forwarded | Converted to chat tool-result messages |
 | `text.format` structured output | Forwarded | Converted to `response_format` when the provider supports it |

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -6879,3 +6879,157 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta",
 		t.Errorf("interrupted reasoning extra_content = %s, want the signed block", extra)
 	}
 }
+
+// TestStreamResponses_NormalizedTextStream pins the streamed text lifecycle to
+// the shape OpenAI emits: sequence_number on every event, response.in_progress
+// after response.created, and the content part opened and closed around the
+// item-addressed text deltas.
+func TestStreamResponses_NormalizedTextStream(t *testing.T) {
+	stream := `event: message_start
+data: {"type":"message_start","message":{"id":"msg_123","type":"message","role":"assistant","model":"claude-sonnet-4-5-20250929","content":[],"stop_reason":null,"usage":{"input_tokens":10,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" world"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+`
+	converter := newResponsesStreamConverter(io.NopCloser(strings.NewReader(stream)), "claude-sonnet-4-5-20250929")
+	raw, err := io.ReadAll(converter)
+	if err != nil {
+		t.Fatalf("failed to read from converter: %v", err)
+	}
+	events := parseTestSSEEvents(t, string(raw))
+
+	want := []string{
+		"response.created",
+		"response.in_progress",
+		"response.output_item.added",
+		"response.content_part.added",
+		"response.output_text.delta",
+		"response.output_text.delta",
+		"response.output_text.done",
+		"response.content_part.done",
+		"response.output_item.done",
+		"response.completed",
+		"[DONE]",
+	}
+	got := make([]string, 0, len(events))
+	next := 0
+	for _, event := range events {
+		if event.Done {
+			got = append(got, "[DONE]")
+			continue
+		}
+		got = append(got, event.Name)
+		seq, ok := event.Payload["sequence_number"].(float64)
+		if !ok || int(seq) != next {
+			t.Fatalf("event %s sequence_number = %#v, want %d", event.Name, event.Payload["sequence_number"], next)
+		}
+		next++
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("event order = %v, want %v", got, want)
+	}
+
+	item, _ := events[2].Payload["item"].(map[string]any)
+	itemID, _ := item["id"].(string)
+	if itemID == "" {
+		t.Fatalf("output_item.added item has no id: %v", item)
+	}
+	for _, event := range events[3:8] {
+		if event.Payload["item_id"] != itemID || event.Payload["output_index"] != float64(0) || event.Payload["content_index"] != float64(0) {
+			t.Fatalf("%s is not addressed to item %q part 0: %v", event.Name, itemID, event.Payload)
+		}
+	}
+	if events[6].Payload["text"] != "Hello world" {
+		t.Fatalf("output_text.done text = %#v, want %q", events[6].Payload["text"], "Hello world")
+	}
+	part, _ := events[7].Payload["part"].(map[string]any)
+	if part["type"] != "output_text" || part["text"] != "Hello world" {
+		t.Fatalf("content_part.done part = %#v, want full output_text", part)
+	}
+	inProgress, _ := events[1].Payload["response"].(map[string]any)
+	if inProgress["status"] != "in_progress" {
+		t.Fatalf("response.in_progress status = %#v", inProgress["status"])
+	}
+	if output, ok := inProgress["output"].([]any); !ok || len(output) != 0 {
+		t.Fatalf("response.in_progress output = %#v, want empty array", inProgress["output"])
+	}
+}
+
+// TestStreamResponses_NormalizedThinkingToolStream keeps the sequence numbers
+// contiguous across a thinking block and a tool call, a turn with no message
+// item and therefore no content part.
+func TestStreamResponses_NormalizedThinkingToolStream(t *testing.T) {
+	stream := `event: message_start
+data: {"type":"message_start","message":{"id":"msg_123","type":"message","role":"assistant","model":"claude-sonnet-4-5-20250929","content":[],"stop_reason":null,"usage":{"input_tokens":10,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me check"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig-1"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_1","name":"lookup_weather","input":{}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"city\":\"Warsaw\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":9}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+`
+	converter := newResponsesStreamConverter(io.NopCloser(strings.NewReader(stream)), "claude-sonnet-4-5-20250929")
+	raw, err := io.ReadAll(converter)
+	if err != nil {
+		t.Fatalf("failed to read from converter: %v", err)
+	}
+	events := parseTestSSEEvents(t, string(raw))
+	if len(events) < 3 || events[0].Name != "response.created" || events[1].Name != "response.in_progress" {
+		t.Fatalf("stream must open with response.created and response.in_progress, got %v", events)
+	}
+	next := 0
+	for _, event := range events {
+		if event.Done {
+			continue
+		}
+		if strings.HasPrefix(event.Name, "response.content_part.") || strings.HasPrefix(event.Name, "response.output_text.") {
+			t.Fatalf("unexpected %s on a turn without a message item", event.Name)
+		}
+		seq, ok := event.Payload["sequence_number"].(float64)
+		if !ok || int(seq) != next {
+			t.Fatalf("event %s sequence_number = %#v, want %d", event.Name, event.Payload["sequence_number"], next)
+		}
+		next++
+	}
+	if last := events[len(events)-2]; last.Name != "response.completed" {
+		t.Fatalf("terminal event = %s, want response.completed", last.Name)
+	}
+}

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -7033,3 +7033,31 @@ data: {"type":"message_stop"}
 		t.Fatalf("terminal event = %s, want response.completed", last.Name)
 	}
 }
+
+// TestStreamResponses_CutBeforeMessageStartStillOpens covers an upstream body
+// that ends before message_start: the stream must still open with
+// response.created and response.in_progress before response.incomplete, so
+// stream helpers that snapshot the created response can finish cleanly.
+func TestStreamResponses_CutBeforeMessageStartStillOpens(t *testing.T) {
+	converter := newResponsesStreamConverter(io.NopCloser(strings.NewReader("")), "claude-sonnet-4-5-20250929")
+	raw, err := io.ReadAll(converter)
+	if err != nil {
+		t.Fatalf("failed to read from converter: %v", err)
+	}
+	events := parseTestSSEEvents(t, string(raw))
+	want := []string{"response.created", "response.in_progress", "response.incomplete", "[DONE]"}
+	got := make([]string, 0, len(events))
+	for i, event := range events {
+		if event.Done {
+			got = append(got, "[DONE]")
+			continue
+		}
+		got = append(got, event.Name)
+		if seq, ok := event.Payload["sequence_number"].(float64); !ok || int(seq) != i {
+			t.Fatalf("event %s sequence_number = %#v, want %d", event.Name, event.Payload["sequence_number"], i)
+		}
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("event order = %v, want %v", got, want)
+	}
+}

--- a/internal/providers/anthropic/responses.go
+++ b/internal/providers/anthropic/responses.go
@@ -140,6 +140,7 @@ type responsesStreamConverter struct {
 	thinking             thinkingReplayState
 	buffer               streaming.StreamBuffer
 	closed               bool
+	sentCreate           bool
 	sentDone             bool
 	sawStop              bool  // upstream signalled the end of the message
 	pendingErr           error // upstream read error deferred until terminal events are drained
@@ -269,6 +270,9 @@ func (sc *responsesStreamConverter) appendTerminalEvents() {
 		return
 	}
 	sc.sentDone = true
+	// A body cut before message_start still owes the client the opening
+	// events: stream helpers snapshot the created response before anything else.
+	sc.buffer.AppendString(sc.startResponse())
 	status := "completed"
 	eventName := "response.completed"
 	if !sc.sawStop {
@@ -302,6 +306,23 @@ func (sc *responsesStreamConverter) appendTerminalEvents() {
 	}
 	sc.buffer.AppendString(prefix)
 	sc.buffer.AppendString(sc.output.FinishResponse(eventName, responseData))
+}
+
+// startResponse opens the stream with response.created and
+// response.in_progress once.
+func (sc *responsesStreamConverter) startResponse() string {
+	if sc.sentCreate {
+		return ""
+	}
+	sc.sentCreate = true
+	return sc.output.StartResponse(map[string]any{
+		"id":         sc.responseID,
+		"object":     "response",
+		"status":     "in_progress",
+		"model":      sc.model,
+		"provider":   "anthropic",
+		"created_at": sc.createdAt,
+	})
 }
 
 // completePendingToolCalls emits the done events for tool calls the upstream
@@ -349,15 +370,7 @@ func (sc *responsesStreamConverter) convertEvent(event *anthropicStreamEvent) st
 		if mergeAnthropicUsage(&sc.usage, event.Usage) {
 			sc.hasUsage = true
 		}
-		// Open the stream with response.created and response.in_progress
-		return sc.output.StartResponse(map[string]any{
-			"id":         sc.responseID,
-			"object":     "response",
-			"status":     "in_progress",
-			"model":      sc.model,
-			"provider":   "anthropic",
-			"created_at": sc.createdAt,
-		})
+		return sc.startResponse()
 
 	case "content_block_start":
 		if sc.thinking.track(event.Index, event.ContentBlock) {

--- a/internal/providers/anthropic/responses.go
+++ b/internal/providers/anthropic/responses.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"io"
-	"log/slog"
 	"net/http"
 	"slices"
 	"strings"
@@ -301,21 +300,8 @@ func (sc *responsesStreamConverter) appendTerminalEvents() {
 	if sc.hasUsage {
 		responseData["usage"] = anthropicResponsesUsagePayload(&sc.usage)
 	}
-	doneEvent := map[string]any{
-		"type":     eventName,
-		"response": responseData,
-	}
-	jsonData, marshalErr := json.Marshal(doneEvent)
-	if marshalErr != nil {
-		slog.Error("failed to marshal terminal responses event", "error", marshalErr, "event", eventName, "response_id", sc.responseID)
-		return
-	}
 	sc.buffer.AppendString(prefix)
-	sc.buffer.AppendString("event: ")
-	sc.buffer.AppendString(eventName)
-	sc.buffer.AppendString("\ndata: ")
-	sc.buffer.AppendBytes(jsonData)
-	sc.buffer.AppendString("\n\ndata: [DONE]\n\n")
+	sc.buffer.AppendString(sc.output.FinishResponse(eventName, responseData))
 }
 
 // completePendingToolCalls emits the done events for tool calls the upstream
@@ -363,17 +349,14 @@ func (sc *responsesStreamConverter) convertEvent(event *anthropicStreamEvent) st
 		if mergeAnthropicUsage(&sc.usage, event.Usage) {
 			sc.hasUsage = true
 		}
-		// Send response.created event
-		return sc.output.WriteEvent("response.created", map[string]any{
-			"type": "response.created",
-			"response": map[string]any{
-				"id":         sc.responseID,
-				"object":     "response",
-				"status":     "in_progress",
-				"model":      sc.model,
-				"provider":   "anthropic",
-				"created_at": sc.createdAt,
-			},
+		// Open the stream with response.created and response.in_progress
+		return sc.output.StartResponse(map[string]any{
+			"id":         sc.responseID,
+			"object":     "response",
+			"status":     "in_progress",
+			"model":      sc.model,
+			"provider":   "anthropic",
+			"created_at": sc.createdAt,
 		})
 
 	case "content_block_start":
@@ -425,12 +408,7 @@ func (sc *responsesStreamConverter) convertEvent(event *anthropicStreamEvent) st
 			if event.Delta.Text != "" {
 				prefix := sc.output.CompleteReasoningOutput(sc.reasoningOutputIndex)
 				sc.reserveAssistantMessageOutput()
-				prefix += sc.output.StartAssistantOutput(sc.assistantOutputIndex)
-				sc.output.AppendAssistantText(event.Delta.Text)
-				return prefix + sc.output.WriteEvent("response.output_text.delta", map[string]any{
-					"type":  "response.output_text.delta",
-					"delta": event.Delta.Text,
-				})
+				return prefix + sc.output.AppendAssistantDelta(sc.assistantOutputIndex, event.Delta.Text)
 			}
 		case "input_json_delta":
 			if event.Delta.PartialJSON == "" {

--- a/internal/providers/responses_converter.go
+++ b/internal/providers/responses_converter.go
@@ -3,7 +3,6 @@ package providers
 import (
 	"bytes"
 	"io"
-	"log/slog"
 	"slices"
 	"strings"
 	"time"
@@ -418,19 +417,7 @@ func (sc *OpenAIResponsesStreamConverter) appendReasoningDelta(content string) {
 func (sc *OpenAIResponsesStreamConverter) appendTextDelta(content string) {
 	sc.buffer.AppendString(sc.output.CompleteReasoningOutput(reasoningOutputIndex))
 	sc.reserveAssistantOutput()
-	sc.buffer.AppendString(sc.output.StartAssistantOutput(sc.assistantOutputIndex))
-	sc.output.AppendAssistantText(content)
-	jsonData, err := json.Marshal(struct {
-		Type  string `json:"type"`
-		Delta string `json:"delta"`
-	}{Type: "response.output_text.delta", Delta: content})
-	if err != nil {
-		slog.Error("failed to marshal content delta event", "error", err, "response_id", sc.responseID)
-		return
-	}
-	sc.buffer.AppendString("event: response.output_text.delta\ndata: ")
-	sc.buffer.AppendBytes(jsonData)
-	sc.buffer.AppendString("\n\n")
+	sc.buffer.AppendString(sc.output.AppendAssistantDelta(sc.assistantOutputIndex, content))
 }
 
 // appendTerminalEvents flushes open output items and appends the terminal
@@ -473,20 +460,7 @@ func (sc *OpenAIResponsesStreamConverter) appendTerminalEvents() {
 			responseData["usage"] = usage
 		}
 	}
-	doneEvent := map[string]any{
-		"type":     eventName,
-		"response": responseData,
-	}
-	jsonData, err := json.Marshal(doneEvent)
-	if err != nil {
-		slog.Error("failed to marshal terminal responses event", "error", err, "event", eventName, "response_id", sc.responseID)
-		return
-	}
-	sc.buffer.AppendString("event: ")
-	sc.buffer.AppendString(eventName)
-	sc.buffer.AppendString("\ndata: ")
-	sc.buffer.AppendBytes(jsonData)
-	sc.buffer.AppendString("\n\ndata: [DONE]\n\n")
+	sc.buffer.AppendString(sc.output.FinishResponse(eventName, responseData))
 }
 
 func (sc *OpenAIResponsesStreamConverter) appendFailedEvents(raw json.RawMessage) {
@@ -528,18 +502,7 @@ func (sc *OpenAIResponsesStreamConverter) appendFailedEvents(raw json.RawMessage
 			"message": upstream.Message,
 		},
 	}
-	failedEvent := map[string]any{
-		"type":     "response.failed",
-		"response": responseData,
-	}
-	jsonData, err := json.Marshal(failedEvent)
-	if err != nil {
-		slog.Error("failed to marshal response.failed event", "error", err, "response_id", sc.responseID)
-		return
-	}
-	sc.buffer.AppendString("event: response.failed\ndata: ")
-	sc.buffer.AppendBytes(jsonData)
-	sc.buffer.AppendString("\n\ndata: [DONE]\n\n")
+	sc.buffer.AppendString(sc.output.FinishResponse("response.failed", responseData))
 }
 
 // chatUsageToResponsesUsage renames a valid Chat Completions usage object into
@@ -594,28 +557,17 @@ func (sc *OpenAIResponsesStreamConverter) Read(p []byte) (n int, err error) {
 		return 0, pendingErr
 	}
 
-	// Send response.created event first
+	// Open the stream with response.created and response.in_progress first
 	if !sc.sentCreate {
 		sc.sentCreate = true
-		createdEvent := map[string]any{
-			"type": "response.created",
-			"response": map[string]any{
-				"id":         sc.responseID,
-				"object":     "response",
-				"status":     "in_progress",
-				"model":      sc.model,
-				"provider":   sc.provider,
-				"created_at": sc.createdAt,
-			},
-		}
-		jsonData, err := json.Marshal(createdEvent)
-		if err != nil {
-			slog.Error("failed to marshal response.created event", "error", err, "response_id", sc.responseID)
-			return 0, nil
-		}
-		sc.buffer.AppendString("event: response.created\ndata: ")
-		sc.buffer.AppendBytes(jsonData)
-		sc.buffer.AppendString("\n\n")
+		sc.buffer.AppendString(sc.output.StartResponse(map[string]any{
+			"id":         sc.responseID,
+			"object":     "response",
+			"status":     "in_progress",
+			"model":      sc.model,
+			"provider":   sc.provider,
+			"created_at": sc.createdAt,
+		}))
 		return sc.buffer.Read(p), nil
 	}
 

--- a/internal/providers/responses_converter_test.go
+++ b/internal/providers/responses_converter_test.go
@@ -1245,3 +1245,224 @@ data: [DONE]
 	}
 	t.Fatal("expected a message output_item.done event")
 }
+
+// eventNames lists the SSE event names in stream order, with "[DONE]" for the
+// trailing marker.
+func eventNames(events []testSSEEvent) []string {
+	names := make([]string, 0, len(events))
+	for _, event := range events {
+		if event.Done {
+			names = append(names, "[DONE]")
+			continue
+		}
+		names = append(names, event.Name)
+	}
+	return names
+}
+
+// requireNormalizedResponsesStream checks the members OpenAI's Responses
+// stream schema requires on every translated stream: a sequence_number that
+// counts from zero across all events, response.created followed by
+// response.in_progress, and the type member matching the SSE event name.
+func requireNormalizedResponsesStream(t *testing.T, events []testSSEEvent) {
+	t.Helper()
+	if len(events) < 3 {
+		t.Fatalf("events = %v, want at least created, in_progress and a terminal event", eventNames(events))
+	}
+	if events[0].Name != "response.created" || events[1].Name != "response.in_progress" {
+		t.Fatalf("stream opens with %v, want response.created then response.in_progress", eventNames(events)[:2])
+	}
+	for i, name := range []string{"response.created", "response.in_progress"} {
+		response, _ := events[i].Payload["response"].(map[string]any)
+		if response["status"] != "in_progress" {
+			t.Fatalf("%s response.status = %#v, want in_progress", name, response["status"])
+		}
+		// SDK stream helpers snapshot this object and append output items to it.
+		if output, ok := response["output"].([]any); !ok || len(output) != 0 {
+			t.Fatalf("%s response.output = %#v, want empty array", name, response["output"])
+		}
+	}
+	next := 0
+	for _, event := range events {
+		if event.Done {
+			continue
+		}
+		if event.Payload["type"] != event.Name {
+			t.Fatalf("event %s carries type %#v", event.Name, event.Payload["type"])
+		}
+		seq, ok := event.Payload["sequence_number"].(float64)
+		if !ok {
+			t.Fatalf("event %s has no sequence_number: %v", event.Name, event.Payload)
+		}
+		if int(seq) != next {
+			t.Fatalf("event %s sequence_number = %d, want %d", event.Name, int(seq), next)
+		}
+		next++
+	}
+}
+
+// TestOpenAIResponsesStreamConverter_NormalizedTextStream pins the full
+// event lifecycle of a streamed text message to the shape OpenAI emits, so a
+// strict typed SDK sees the same stream whichever provider was routed.
+func TestOpenAIResponsesStreamConverter_NormalizedTextStream(t *testing.T) {
+	mockStream := `data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"test-model","choices":[{"index":0,"delta":{"content":" world"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"test-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+
+data: [DONE]
+`
+	converter := NewOpenAIResponsesStreamConverter(io.NopCloser(strings.NewReader(mockStream)), "test-model", "gemini")
+	raw, err := io.ReadAll(converter)
+	if err != nil {
+		t.Fatalf("failed to read from converter: %v", err)
+	}
+	events := parseTestSSEEvents(t, string(raw))
+	requireNormalizedResponsesStream(t, events)
+
+	want := []string{
+		"response.created",
+		"response.in_progress",
+		"response.output_item.added",
+		"response.content_part.added",
+		"response.output_text.delta",
+		"response.output_text.delta",
+		"response.output_text.done",
+		"response.content_part.done",
+		"response.output_item.done",
+		"response.completed",
+		"[DONE]",
+	}
+	if got := eventNames(events); !reflect.DeepEqual(got, want) {
+		t.Fatalf("event order = %v, want %v", got, want)
+	}
+
+	item, _ := events[2].Payload["item"].(map[string]any)
+	itemID, _ := item["id"].(string)
+	if itemID == "" {
+		t.Fatalf("output_item.added item has no id: %v", item)
+	}
+	for _, event := range events[3:8] {
+		if event.Payload["item_id"] != itemID {
+			t.Fatalf("%s item_id = %#v, want %q", event.Name, event.Payload["item_id"], itemID)
+		}
+		if event.Payload["output_index"] != float64(0) || event.Payload["content_index"] != float64(0) {
+			t.Fatalf("%s indexes = %#v/%#v, want 0/0", event.Name, event.Payload["output_index"], event.Payload["content_index"])
+		}
+	}
+	partAdded, _ := events[3].Payload["part"].(map[string]any)
+	if partAdded["type"] != "output_text" || partAdded["text"] != "" {
+		t.Fatalf("content_part.added part = %#v, want empty output_text", partAdded)
+	}
+	if events[4].Payload["delta"] != "Hello" || events[5].Payload["delta"] != " world" {
+		t.Fatalf("deltas = %#v, %#v", events[4].Payload["delta"], events[5].Payload["delta"])
+	}
+	if events[6].Payload["text"] != "Hello world" {
+		t.Fatalf("output_text.done text = %#v, want %q", events[6].Payload["text"], "Hello world")
+	}
+	partDone, _ := events[7].Payload["part"].(map[string]any)
+	if partDone["type"] != "output_text" || partDone["text"] != "Hello world" {
+		t.Fatalf("content_part.done part = %#v, want full output_text", partDone)
+	}
+	if _, ok := partDone["annotations"].([]any); !ok {
+		t.Fatalf("content_part.done part has no annotations array: %#v", partDone)
+	}
+}
+
+// TestOpenAIResponsesStreamConverter_NormalizedToolCallStream keeps the
+// stream schema members on a reasoning-plus-tool-call turn, which has no
+// message item and therefore no content part.
+func TestOpenAIResponsesStreamConverter_NormalizedToolCallStream(t *testing.T) {
+	mockStream := `data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"test-model","choices":[{"index":0,"delta":{"reasoning_content":"Think"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"test-model","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_123","type":"function","function":{"name":"lookup_weather","arguments":"{\"city\":\"Warsaw\"}"}}]},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"test-model","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}
+
+data: [DONE]
+`
+	converter := NewOpenAIResponsesStreamConverter(io.NopCloser(strings.NewReader(mockStream)), "test-model", "gemini")
+	raw, err := io.ReadAll(converter)
+	if err != nil {
+		t.Fatalf("failed to read from converter: %v", err)
+	}
+	events := parseTestSSEEvents(t, string(raw))
+	requireNormalizedResponsesStream(t, events)
+
+	want := []string{
+		"response.created",
+		"response.in_progress",
+		"response.output_item.added",
+		"response.reasoning_text.delta",
+		"response.reasoning_text.done",
+		"response.output_item.done",
+		"response.output_item.added",
+		"response.function_call_arguments.delta",
+		"response.function_call_arguments.done",
+		"response.output_item.done",
+		"response.completed",
+		"[DONE]",
+	}
+	if got := eventNames(events); !reflect.DeepEqual(got, want) {
+		t.Fatalf("event order = %v, want %v", got, want)
+	}
+}
+
+// TestOpenAIResponsesStreamConverter_InterruptedStreamClosesContentPart
+// closes the open content part before the incomplete message item, so the
+// partial text is restated the way OpenAI does on an interrupted stream.
+func TestOpenAIResponsesStreamConverter_InterruptedStreamClosesContentPart(t *testing.T) {
+	mockStream := `data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant","content":"Hel"},"finish_reason":null}]}
+
+`
+	converter := NewOpenAIResponsesStreamConverter(io.NopCloser(strings.NewReader(mockStream)), "test-model", "gemini")
+	raw, err := io.ReadAll(converter)
+	if err != nil {
+		t.Fatalf("failed to read from converter: %v", err)
+	}
+	events := parseTestSSEEvents(t, string(raw))
+	requireNormalizedResponsesStream(t, events)
+
+	want := []string{
+		"response.created",
+		"response.in_progress",
+		"response.output_item.added",
+		"response.content_part.added",
+		"response.output_text.delta",
+		"response.output_text.done",
+		"response.content_part.done",
+		"response.output_item.done",
+		"response.incomplete",
+		"[DONE]",
+	}
+	if got := eventNames(events); !reflect.DeepEqual(got, want) {
+		t.Fatalf("event order = %v, want %v", got, want)
+	}
+	if events[5].Payload["text"] != "Hel" {
+		t.Fatalf("output_text.done text = %#v, want partial text", events[5].Payload["text"])
+	}
+	item, _ := events[7].Payload["item"].(map[string]any)
+	if item["status"] != "incomplete" {
+		t.Fatalf("message item status = %#v, want incomplete", item["status"])
+	}
+}
+
+// TestOpenAIResponsesStreamConverter_FailedEventIsSequenced keeps the
+// sequence_number on the response.failed terminal event.
+func TestOpenAIResponsesStreamConverter_FailedEventIsSequenced(t *testing.T) {
+	mockStream := `data: {"error":{"message":"upstream exploded","type":"server_error"}}
+
+`
+	converter := NewOpenAIResponsesStreamConverter(io.NopCloser(strings.NewReader(mockStream)), "test-model", "gemini")
+	raw, err := io.ReadAll(converter)
+	if err != nil {
+		t.Fatalf("failed to read from converter: %v", err)
+	}
+	events := parseTestSSEEvents(t, string(raw))
+	requireNormalizedResponsesStream(t, events)
+	want := []string{"response.created", "response.in_progress", "response.failed", "[DONE]"}
+	if got := eventNames(events); !reflect.DeepEqual(got, want) {
+		t.Fatalf("event order = %v, want %v", got, want)
+	}
+}

--- a/internal/providers/responses_output_state.go
+++ b/internal/providers/responses_output_state.go
@@ -30,9 +30,13 @@ type ResponsesOutputToolCallState struct {
 
 // ResponsesOutputEventState manages assistant/tool output items for Responses streams.
 type ResponsesOutputEventState struct {
-	responseID           string
+	responseID string
+	// sequence is the sequence_number stamped on the next event. OpenAI
+	// numbers every stream event from zero, and typed SDK parsers require it.
+	sequence             int
 	assistantReserved    bool
 	assistantStarted     bool
+	assistantPartStarted bool
 	assistantDone        bool
 	assistantMessageID   string
 	assistantText        strings.Builder
@@ -67,21 +71,96 @@ func NewResponsesOutputEventState(responseID string) *ResponsesOutputEventState 
 	return &ResponsesOutputEventState{responseID: responseID}
 }
 
-// WriteEvent renders one SSE event in Responses API format.
+// WriteEvent renders one SSE event in Responses API format, stamping it with
+// the next sequence_number.
 func (s *ResponsesOutputEventState) WriteEvent(eventName string, payload map[string]any) string {
+	payload["sequence_number"] = s.sequence
+	return s.writeEncodedEvent(eventName, payload)
+}
+
+// writeEncodedEvent renders one SSE event whose payload already carries the
+// current sequence_number, then advances the sequence.
+func (s *ResponsesOutputEventState) writeEncodedEvent(eventName string, payload any) string {
+	return s.writeEncodedEventWithTrailer(eventName, payload, "")
+}
+
+// writeEncodedEventWithTrailer is writeEncodedEvent with raw SSE bytes
+// appended after the event, in the same allocation.
+func (s *ResponsesOutputEventState) writeEncodedEventWithTrailer(eventName string, payload any, trailer string) string {
 	jsonData, err := json.Marshal(payload)
 	if err != nil {
 		slog.Error("failed to marshal responses stream event", "error", err, "event", eventName, "response_id", s.responseID)
 		return ""
 	}
+	s.sequence++
 	var b strings.Builder
-	b.Grow(len("event: \ndata: \n\n") + len(eventName) + len(jsonData))
+	b.Grow(len("event: \ndata: \n\n") + len(eventName) + len(jsonData) + len(trailer))
 	b.WriteString("event: ")
 	b.WriteString(eventName)
 	b.WriteString("\ndata: ")
 	b.Write(jsonData)
 	b.WriteString("\n\n")
+	b.WriteString(trailer)
 	return b.String()
+}
+
+// responsesLifecycleEvent is the typed payload of the events that carry the
+// whole response object: response.created, response.in_progress and the
+// terminal event.
+type responsesLifecycleEvent struct {
+	Type           string          `json:"type"`
+	Response       json.RawMessage `json:"response"`
+	SequenceNumber int             `json:"sequence_number"`
+}
+
+// writeLifecycleEvent emits one response-carrying event.
+func (s *ResponsesOutputEventState) writeLifecycleEvent(eventName string, response json.RawMessage) string {
+	return s.writeEncodedEvent(eventName, responsesLifecycleEvent{
+		Type:           eventName,
+		Response:       response,
+		SequenceNumber: s.sequence,
+	})
+}
+
+// encodeResponse renders a response object once for the lifecycle events
+// that repeat it.
+func (s *ResponsesOutputEventState) encodeResponse(eventName string, response map[string]any) (json.RawMessage, bool) {
+	encoded, err := json.Marshal(response)
+	if err != nil {
+		slog.Error("failed to marshal responses stream response object", "error", err, "event", eventName, "response_id", s.responseID)
+		return nil, false
+	}
+	return encoded, true
+}
+
+// StartResponse emits the response.created and response.in_progress events
+// that open every OpenAI Responses stream, both carrying the given in-progress
+// response object. The object gets an empty output array: SDK stream helpers
+// snapshot it from response.created and append each output_item.added to it.
+func (s *ResponsesOutputEventState) StartResponse(response map[string]any) string {
+	response["output"] = []map[string]any{}
+	encoded, ok := s.encodeResponse("response.created", response)
+	if !ok {
+		return ""
+	}
+	return s.writeLifecycleEvent("response.created", encoded) +
+		s.writeLifecycleEvent("response.in_progress", encoded)
+}
+
+// FinishResponse emits the terminal event (response.completed, incomplete or
+// failed) carrying the final response object, followed by the [DONE] marker.
+// Open output items must be finished first so the terminal event sequences
+// after their closing events.
+func (s *ResponsesOutputEventState) FinishResponse(eventName string, response map[string]any) string {
+	encoded, ok := s.encodeResponse(eventName, response)
+	if !ok {
+		return ""
+	}
+	return s.writeEncodedEventWithTrailer(eventName, responsesLifecycleEvent{
+		Type:           eventName,
+		Response:       encoded,
+		SequenceNumber: s.sequence,
+	}, "data: [DONE]\n\n")
 }
 
 // ReserveAssistant marks that the assistant message output item occupies index 0.
@@ -104,9 +183,107 @@ func (s *ResponsesOutputEventState) AssistantDone() bool {
 	return s.assistantDone
 }
 
-// AppendAssistantText appends assistant text content to the output item buffer.
-func (s *ResponsesOutputEventState) AppendAssistantText(text string) {
-	_, _ = s.assistantText.WriteString(text)
+// AppendAssistantDelta starts the assistant message item and its text
+// content part if needed, records the text and emits its output_text.delta
+// event addressed to that part.
+func (s *ResponsesOutputEventState) AppendAssistantDelta(outputIndex int, delta string) string {
+	var b strings.Builder
+	b.WriteString(s.StartAssistantOutput(outputIndex))
+	b.WriteString(s.startAssistantPart(outputIndex))
+	_, _ = s.assistantText.WriteString(delta)
+	b.WriteString(s.writeEncodedEvent("response.output_text.delta", responsesTextDeltaEvent{
+		Type:           "response.output_text.delta",
+		ItemID:         s.assistantMessageID,
+		OutputIndex:    outputIndex,
+		ContentIndex:   0,
+		Delta:          delta,
+		SequenceNumber: s.sequence,
+	}))
+	return b.String()
+}
+
+// responsesTextDeltaEvent is the typed output_text.delta payload: the
+// per-token hot path of a text stream, kept off the generic map encoder.
+type responsesTextDeltaEvent struct {
+	Type           string `json:"type"`
+	ItemID         string `json:"item_id"`
+	OutputIndex    int    `json:"output_index"`
+	ContentIndex   int    `json:"content_index"`
+	Delta          string `json:"delta"`
+	SequenceNumber int    `json:"sequence_number"`
+}
+
+// responsesOutputTextPart is the message's single output_text content part.
+type responsesOutputTextPart struct {
+	Type        string            `json:"type"`
+	Text        string            `json:"text"`
+	Annotations []json.RawMessage `json:"annotations"`
+}
+
+// responsesContentPartEvent is the typed payload of content_part.added/done.
+type responsesContentPartEvent struct {
+	Type           string                  `json:"type"`
+	ItemID         string                  `json:"item_id"`
+	OutputIndex    int                     `json:"output_index"`
+	ContentIndex   int                     `json:"content_index"`
+	Part           responsesOutputTextPart `json:"part"`
+	SequenceNumber int                     `json:"sequence_number"`
+}
+
+// responsesTextDoneEvent is the typed payload of output_text.done.
+type responsesTextDoneEvent struct {
+	Type           string `json:"type"`
+	ItemID         string `json:"item_id"`
+	OutputIndex    int    `json:"output_index"`
+	ContentIndex   int    `json:"content_index"`
+	Text           string `json:"text"`
+	SequenceNumber int    `json:"sequence_number"`
+}
+
+// assistantPart renders the message's output_text content part.
+func assistantPart(text string) map[string]any {
+	return map[string]any{
+		"type":        "output_text",
+		"text":        text,
+		"annotations": []json.RawMessage{},
+	}
+}
+
+// writeAssistantPartEvent emits content_part.added or content_part.done
+// carrying the part with the given text.
+func (s *ResponsesOutputEventState) writeAssistantPartEvent(eventName string, outputIndex int, text string) string {
+	return s.writeEncodedEvent(eventName, responsesContentPartEvent{
+		Type:           eventName,
+		ItemID:         s.assistantMessageID,
+		OutputIndex:    outputIndex,
+		ContentIndex:   0,
+		Part:           responsesOutputTextPart{Type: "output_text", Text: text, Annotations: []json.RawMessage{}},
+		SequenceNumber: s.sequence,
+	})
+}
+
+// startAssistantPart emits response.content_part.added once, before the first
+// text delta of the message.
+func (s *ResponsesOutputEventState) startAssistantPart(outputIndex int) string {
+	if s.assistantPartStarted {
+		return ""
+	}
+	s.assistantPartStarted = true
+	return s.writeAssistantPartEvent("response.content_part.added", outputIndex, "")
+}
+
+// finishAssistantPart emits response.output_text.done and
+// response.content_part.done restating the message's full text.
+func (s *ResponsesOutputEventState) finishAssistantPart(outputIndex int) string {
+	text := s.assistantText.String()
+	return s.writeEncodedEvent("response.output_text.done", responsesTextDoneEvent{
+		Type:           "response.output_text.done",
+		ItemID:         s.assistantMessageID,
+		OutputIndex:    outputIndex,
+		ContentIndex:   0,
+		Text:           text,
+		SequenceNumber: s.sequence,
+	}) + s.writeAssistantPartEvent("response.content_part.done", outputIndex, text)
 }
 
 // AssistantMessageItem renders the assistant message output item payload.
@@ -119,13 +296,7 @@ func (s *ResponsesOutputEventState) AssistantMessageItem(status string, includeC
 		"content": []map[string]any{},
 	}
 	if includeContent {
-		item["content"] = []map[string]any{
-			{
-				"type":        "output_text",
-				"text":        s.assistantText.String(),
-				"annotations": []json.RawMessage{},
-			},
-		}
+		item["content"] = []map[string]any{assistantPart(s.assistantText.String())}
 	}
 	if len(s.assistantExtraContent) > 0 {
 		item[core.ExtraContentField] = s.assistantExtraContent
@@ -162,20 +333,26 @@ func (s *ResponsesOutputEventState) CompleteAssistantOutput(outputIndex int) str
 	return s.FinishAssistantOutput(outputIndex, "completed")
 }
 
-// FinishAssistantOutput emits the assistant message output_item.done event once,
-// carrying the given terminal status ("completed", or "incomplete" when the
-// upstream stream was interrupted before closing the message).
+// FinishAssistantOutput closes the message's content part and emits the
+// assistant message output_item.done event once, carrying the given terminal
+// status ("completed", or "incomplete" when the upstream stream was
+// interrupted before closing the message). The item always renders one
+// output_text part, so the part's lifecycle events are emitted even when no
+// text arrived.
 func (s *ResponsesOutputEventState) FinishAssistantOutput(outputIndex int, status string) string {
 	if !s.assistantReserved || s.assistantDone {
 		return ""
 	}
 	s.assistantDone = true
 	s.assistantFinalStatus = status
-	return s.StartAssistantOutput(outputIndex) + s.WriteEvent("response.output_item.done", map[string]any{
-		"type":         "response.output_item.done",
-		"item":         s.AssistantMessageItem(status, true),
-		"output_index": outputIndex,
-	})
+	return s.StartAssistantOutput(outputIndex) +
+		s.startAssistantPart(outputIndex) +
+		s.finishAssistantPart(outputIndex) +
+		s.WriteEvent("response.output_item.done", map[string]any{
+			"type":         "response.output_item.done",
+			"item":         s.AssistantMessageItem(status, true),
+			"output_index": outputIndex,
+		})
 }
 
 // ReserveReasoning marks that a reasoning output item occupies index 0,

--- a/tests/contract/testdata/golden/anthropic/responses_stream.golden.json
+++ b/tests/contract/testdata/golden/anthropic/responses_stream.golden.json
@@ -9,10 +9,29 @@
           "id": "resp_\u003cgenerated\u003e",
           "model": "claude-sonnet-4-20250514",
           "object": "response",
+          "output": [],
           "provider": "anthropic",
           "status": "in_progress"
         },
+        "sequence_number": 0,
         "type": "response.created"
+      }
+    },
+    {
+      "Done": false,
+      "Name": "response.in_progress",
+      "Payload": {
+        "response": {
+          "created_at": 0,
+          "id": "resp_\u003cgenerated\u003e",
+          "model": "claude-sonnet-4-20250514",
+          "object": "response",
+          "output": [],
+          "provider": "anthropic",
+          "status": "in_progress"
+        },
+        "sequence_number": 1,
+        "type": "response.in_progress"
       }
     },
     {
@@ -27,15 +46,64 @@
           "type": "message"
         },
         "output_index": 0,
+        "sequence_number": 2,
         "type": "response.output_item.added"
+      }
+    },
+    {
+      "Done": false,
+      "Name": "response.content_part.added",
+      "Payload": {
+        "content_index": 0,
+        "item_id": "msg_\u003cgenerated\u003e",
+        "output_index": 0,
+        "part": {
+          "annotations": [],
+          "text": "",
+          "type": "output_text"
+        },
+        "sequence_number": 3,
+        "type": "response.content_part.added"
       }
     },
     {
       "Done": false,
       "Name": "response.output_text.delta",
       "Payload": {
+        "content_index": 0,
         "delta": "Hello World",
+        "item_id": "msg_\u003cgenerated\u003e",
+        "output_index": 0,
+        "sequence_number": 4,
         "type": "response.output_text.delta"
+      }
+    },
+    {
+      "Done": false,
+      "Name": "response.output_text.done",
+      "Payload": {
+        "content_index": 0,
+        "item_id": "msg_\u003cgenerated\u003e",
+        "output_index": 0,
+        "sequence_number": 5,
+        "text": "Hello World",
+        "type": "response.output_text.done"
+      }
+    },
+    {
+      "Done": false,
+      "Name": "response.content_part.done",
+      "Payload": {
+        "content_index": 0,
+        "item_id": "msg_\u003cgenerated\u003e",
+        "output_index": 0,
+        "part": {
+          "annotations": [],
+          "text": "Hello World",
+          "type": "output_text"
+        },
+        "sequence_number": 6,
+        "type": "response.content_part.done"
       }
     },
     {
@@ -56,6 +124,7 @@
           "type": "message"
         },
         "output_index": 0,
+        "sequence_number": 7,
         "type": "response.output_item.done"
       }
     },
@@ -91,6 +160,7 @@
             "total_tokens": 15
           }
         },
+        "sequence_number": 8,
         "type": "response.completed"
       }
     },

--- a/tests/contract/testdata/golden/gemini/responses_stream.golden.json
+++ b/tests/contract/testdata/golden/gemini/responses_stream.golden.json
@@ -9,10 +9,29 @@
           "id": "resp_\u003cgenerated\u003e",
           "model": "gemini-2.5-flash",
           "object": "response",
+          "output": [],
           "provider": "gemini",
           "status": "in_progress"
         },
+        "sequence_number": 0,
         "type": "response.created"
+      }
+    },
+    {
+      "Done": false,
+      "Name": "response.in_progress",
+      "Payload": {
+        "response": {
+          "created_at": 0,
+          "id": "resp_\u003cgenerated\u003e",
+          "model": "gemini-2.5-flash",
+          "object": "response",
+          "output": [],
+          "provider": "gemini",
+          "status": "in_progress"
+        },
+        "sequence_number": 1,
+        "type": "response.in_progress"
       }
     },
     {
@@ -27,15 +46,64 @@
           "type": "message"
         },
         "output_index": 0,
+        "sequence_number": 2,
         "type": "response.output_item.added"
+      }
+    },
+    {
+      "Done": false,
+      "Name": "response.content_part.added",
+      "Payload": {
+        "content_index": 0,
+        "item_id": "msg_\u003cgenerated\u003e",
+        "output_index": 0,
+        "part": {
+          "annotations": [],
+          "text": "",
+          "type": "output_text"
+        },
+        "sequence_number": 3,
+        "type": "response.content_part.added"
       }
     },
     {
       "Done": false,
       "Name": "response.output_text.delta",
       "Payload": {
+        "content_index": 0,
         "delta": "Hello World",
+        "item_id": "msg_\u003cgenerated\u003e",
+        "output_index": 0,
+        "sequence_number": 4,
         "type": "response.output_text.delta"
+      }
+    },
+    {
+      "Done": false,
+      "Name": "response.output_text.done",
+      "Payload": {
+        "content_index": 0,
+        "item_id": "msg_\u003cgenerated\u003e",
+        "output_index": 0,
+        "sequence_number": 5,
+        "text": "Hello World",
+        "type": "response.output_text.done"
+      }
+    },
+    {
+      "Done": false,
+      "Name": "response.content_part.done",
+      "Payload": {
+        "content_index": 0,
+        "item_id": "msg_\u003cgenerated\u003e",
+        "output_index": 0,
+        "part": {
+          "annotations": [],
+          "text": "Hello World",
+          "type": "output_text"
+        },
+        "sequence_number": 6,
+        "type": "response.content_part.done"
       }
     },
     {
@@ -56,6 +124,7 @@
           "type": "message"
         },
         "output_index": 0,
+        "sequence_number": 7,
         "type": "response.output_item.done"
       }
     },
@@ -86,6 +155,7 @@
           "provider": "gemini",
           "status": "completed"
         },
+        "sequence_number": 8,
         "type": "response.completed"
       }
     },

--- a/tests/contract/testdata/golden/groq/responses_stream.golden.json
+++ b/tests/contract/testdata/golden/groq/responses_stream.golden.json
@@ -9,10 +9,29 @@
           "id": "resp_\u003cgenerated\u003e",
           "model": "llama-3.3-70b-versatile",
           "object": "response",
+          "output": [],
           "provider": "groq",
           "status": "in_progress"
         },
+        "sequence_number": 0,
         "type": "response.created"
+      }
+    },
+    {
+      "Done": false,
+      "Name": "response.in_progress",
+      "Payload": {
+        "response": {
+          "created_at": 0,
+          "id": "resp_\u003cgenerated\u003e",
+          "model": "llama-3.3-70b-versatile",
+          "object": "response",
+          "output": [],
+          "provider": "groq",
+          "status": "in_progress"
+        },
+        "sequence_number": 1,
+        "type": "response.in_progress"
       }
     },
     {
@@ -27,14 +46,35 @@
           "type": "message"
         },
         "output_index": 0,
+        "sequence_number": 2,
         "type": "response.output_item.added"
       }
     },
     {
       "Done": false,
+      "Name": "response.content_part.added",
+      "Payload": {
+        "content_index": 0,
+        "item_id": "msg_\u003cgenerated\u003e",
+        "output_index": 0,
+        "part": {
+          "annotations": [],
+          "text": "",
+          "type": "output_text"
+        },
+        "sequence_number": 3,
+        "type": "response.content_part.added"
+      }
+    },
+    {
+      "Done": false,
       "Name": "response.output_text.delta",
       "Payload": {
+        "content_index": 0,
         "delta": "Hello",
+        "item_id": "msg_\u003cgenerated\u003e",
+        "output_index": 0,
+        "sequence_number": 4,
         "type": "response.output_text.delta"
       }
     },
@@ -42,7 +82,11 @@
       "Done": false,
       "Name": "response.output_text.delta",
       "Payload": {
+        "content_index": 0,
         "delta": " World",
+        "item_id": "msg_\u003cgenerated\u003e",
+        "output_index": 0,
+        "sequence_number": 5,
         "type": "response.output_text.delta"
       }
     },
@@ -50,8 +94,40 @@
       "Done": false,
       "Name": "response.output_text.delta",
       "Payload": {
+        "content_index": 0,
         "delta": "!",
+        "item_id": "msg_\u003cgenerated\u003e",
+        "output_index": 0,
+        "sequence_number": 6,
         "type": "response.output_text.delta"
+      }
+    },
+    {
+      "Done": false,
+      "Name": "response.output_text.done",
+      "Payload": {
+        "content_index": 0,
+        "item_id": "msg_\u003cgenerated\u003e",
+        "output_index": 0,
+        "sequence_number": 7,
+        "text": "Hello World!",
+        "type": "response.output_text.done"
+      }
+    },
+    {
+      "Done": false,
+      "Name": "response.content_part.done",
+      "Payload": {
+        "content_index": 0,
+        "item_id": "msg_\u003cgenerated\u003e",
+        "output_index": 0,
+        "part": {
+          "annotations": [],
+          "text": "Hello World!",
+          "type": "output_text"
+        },
+        "sequence_number": 8,
+        "type": "response.content_part.done"
       }
     },
     {
@@ -72,6 +148,7 @@
           "type": "message"
         },
         "output_index": 0,
+        "sequence_number": 9,
         "type": "response.output_item.done"
       }
     },
@@ -107,6 +184,7 @@
             "total_tokens": 42
           }
         },
+        "sequence_number": 10,
         "type": "response.completed"
       }
     },

--- a/tests/perf/hotpath_test.go
+++ b/tests/perf/hotpath_test.go
@@ -479,11 +479,14 @@ func TestHotPathPerfGuard(t *testing.T) {
 			// response.completed now carries the full output array, and the
 			// terminal status became a variable (completed vs incomplete),
 			// boxing a few extra interface values — both once-per-stream costs
-			// independent of chunk count.
+			// independent of chunk count. Normalizing the stream to OpenAI's
+			// event lifecycle added four once-per-stream events
+			// (response.in_progress, content_part.added/done, output_text.done)
+			// with typed payloads; per-delta cost is unchanged.
 			name:      "openai_responses_stream_converter",
 			bench:     BenchmarkOpenAIResponsesStreamConverter,
-			maxAllocs: 107,   // baseline 105
-			maxBytes:  12288, // baseline ~11.3 KB (leaves headroom for pool cold-starts)
+			maxAllocs: 132,   // baseline 126
+			maxBytes:  20480, // baseline ~19.1 KB (leaves headroom for pool cold-starts)
 		},
 		{
 			name:      "shared_stream_audit_and_usage_observers",


### PR DESCRIPTION
Translated Responses streams (Anthropic native routing and every chat-translated provider such as Gemini) now emit the same event lifecycle as OpenAI:

- `sequence_number` on every event, counting from zero
- `response.in_progress` after `response.created`, both carrying an empty `output` array
- `response.content_part.added`, `response.output_text.done` and `response.content_part.done` around a message item's text
- `response.output_text.delta` addressed with `item_id`, `output_index` and `content_index`

User-visible impact: strict typed SDK parsers and stream helpers behave the same whichever model is routed. The OpenAI Python SDK's `responses.stream()` helper, which snapshots `response.created` and appends items to its `output`, previously crashed on translated streams; verified live against Gemini and Anthropic for text and function-call turns.

The lifecycle is implemented once in the shared `ResponsesOutputEventState`; both converters call the new helpers. The four added once-per-stream events use typed payloads and the per-delta cost is unchanged. The converter perf-guard ceiling is re-measured (105 to 126 allocs/op on the three-chunk benchmark stream).

Addresses F1 from the pre-release test findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Standardized streaming responses now include a complete OpenAI Responses event lifecycle, from creation through completion.
  - Stream events include sequential numbering for reliable ordering.
  - Text streams provide consistent output item, content-part, and text-delta events.
  - Reasoning and tool-call streams handle lifecycle events without emitting irrelevant text events.
  - Empty and interrupted streams now emit appropriate lifecycle and terminal events.

- **Documentation**
  - Updated compatibility documentation with the detailed event sequence for streaming over HTTP/SSE.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->