### PR TITLE
fix(cache): classify a stalled or vanished client on a cache-served stream

### DIFF
--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -57,8 +57,9 @@ gateway from clients that open a streaming response and stop reading it. Each
 write to the client gets a fresh deadline, so it fires only when the client's
 socket stays full for that long, never while a slow model has nothing to send.
 When it fires the connection is closed, the upstream provider request is
-cancelled, and the audit entry records `client_stalled`. Raise it for clients
-that legitimately pause reading a stream for over a minute; set `0` to disable.
+cancelled, and the audit entry records `client_stalled`, also when the stream
+was served from the response cache. Raise it for clients that legitimately
+pause reading a stream for over a minute; set `0` to disable.
 
 Set `GOMODEL_DEMO_MODE=true` for a public or shared demonstration instance.
 GoModel logs a warning at startup and every five minutes, renders a persistent

--- a/internal/responsecache/handle_request_test.go
+++ b/internal/responsecache/handle_request_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"syscall"
 	"testing"
 	"time"
 
@@ -1080,5 +1081,86 @@ func TestHandleRequest_InvalidStreamingBodySkipsExactCacheWrite(t *testing.T) {
 	}
 	if handlerCalls != 2 {
 		t.Fatalf("expected invalid stream to bypass cache on follow-up, got %d calls", handlerCalls)
+	}
+}
+
+// failingResponseWriter simulates a client that stopped draining the
+// connection: Write returns writeErr, and StallError reports flushErr the way
+// the server's stall deadline writer reports a stalled flush.
+type failingResponseWriter struct {
+	http.ResponseWriter
+	writeErr error
+	flushErr error
+}
+
+func (w *failingResponseWriter) Write(p []byte) (int, error) {
+	if w.writeErr != nil {
+		return 0, w.writeErr
+	}
+	return w.ResponseWriter.Write(p)
+}
+
+func (w *failingResponseWriter) StallError() error           { return w.flushErr }
+func (w *failingResponseWriter) Unwrap() http.ResponseWriter { return w.ResponseWriter }
+
+// TestHandleRequest_StreamHitReportsClientWriteFailure returns the write or
+// flush error of a cached stream replay as a ReplayError, so the caller can
+// record a stalled or vanished client instead of a clean 200.
+func TestHandleRequest_StreamHitReportsClientWriteFailure(t *testing.T) {
+	stallErr := errors.New("client stopped reading the response for 3s: write tcp: i/o timeout")
+	tests := []struct {
+		name     string
+		writeErr error
+		flushErr error
+	}{
+		{name: "write fails", writeErr: syscall.EPIPE},
+		{name: "final flush stalls", flushErr: stallErr},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := cache.NewMapStore()
+			defer store.Close()
+			m := &ResponseCacheMiddleware{simple: newSimpleCacheMiddleware(store, time.Hour, nil)}
+			body := []byte(`{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"replay-` + tt.name + `"}]}`)
+			rawStream := []byte("data: {\"id\":\"chatcmpl-stream\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"streamed\"},\"finish_reason\":null}]}\n\n" +
+				"data: {\"id\":\"chatcmpl-stream\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":9,\"completion_tokens\":1,\"total_tokens\":10}}\n\n" +
+				"data: [DONE]\n\n")
+			e := echo.New()
+
+			newContext := func(w http.ResponseWriter) *echo.Context {
+				req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+				req.Header.Set("Content-Type", "application/json")
+				return e.NewContext(req, w)
+			}
+			primeCtx := newContext(httptest.NewRecorder())
+			if err := m.HandleRequest(primeCtx, body, func() error {
+				primeCtx.Response().Header().Set("Content-Type", "text/event-stream")
+				primeCtx.Response().WriteHeader(http.StatusOK)
+				_, _ = primeCtx.Response().Write(rawStream)
+				return nil
+			}); err != nil {
+				t.Fatalf("prime: %v", err)
+			}
+			m.simple.wg.Wait()
+
+			c := newContext(&failingResponseWriter{ResponseWriter: httptest.NewRecorder(), writeErr: tt.writeErr, flushErr: tt.flushErr})
+			err := m.HandleRequest(c, body, func() error {
+				t.Fatal("cached stream must not reach the handler")
+				return nil
+			})
+			if _, ok := errors.AsType[*ReplayError](err); !ok {
+				t.Fatalf("HandleRequest() error = %v, want *ReplayError", err)
+			}
+			want := tt.writeErr
+			if want == nil {
+				want = tt.flushErr
+			}
+			if !errors.Is(err, want) {
+				t.Fatalf("ReplayError does not wrap the client error: %v", err)
+			}
+			if got := c.Response().Header().Get("X-Cache"); got != "HIT (exact)" {
+				t.Fatalf("X-Cache = %q, want the replay to have been attempted", got)
+			}
+		})
 	}
 }

--- a/internal/responsecache/semantic.go
+++ b/internal/responsecache/semantic.go
@@ -159,7 +159,7 @@ func (m *semanticCacheMiddleware) Handle(ex exchange, body []byte, next func() e
 
 	if len(results) > 0 && float64(results[0].Score) >= threshold {
 		replayErr := ex.ReplayHit(body, results[0].Response, CacheTypeSemantic)
-		if replayErr == nil {
+		if replayErr == nil || replayCommitted(replayErr) {
 			ex.MarkHit(CacheTypeSemantic)
 			if m.hitRecorder != nil {
 				m.hitRecorder(ex, results[0].Response, CacheTypeSemantic)
@@ -169,7 +169,7 @@ func (m *semanticCacheMiddleware) Handle(ex exchange, body []byte, next func() e
 				"score", results[0].Score,
 				"request_id", core.GetRequestID(ex.Context()),
 			)
-			return nil
+			return replayErr
 		}
 		slog.Warn("semantic cache replay failed", "path", path, "err", replayErr)
 	}

--- a/internal/responsecache/simple.go
+++ b/internal/responsecache/simple.go
@@ -82,7 +82,8 @@ func (m *simpleCacheMiddleware) TryHit(ex exchange, body []byte) (bool, error) {
 		return false, nil
 	}
 	if len(cached) > 0 {
-		if err := ex.ReplayHit(body, cached, CacheTypeExact); err != nil {
+		err := ex.ReplayHit(body, cached, CacheTypeExact)
+		if err != nil && !replayCommitted(err) {
 			slog.Warn("response cache replay failed", "path", path, "cache_type", CacheTypeExact, "err", err)
 			return false, nil
 		}
@@ -94,7 +95,7 @@ func (m *simpleCacheMiddleware) TryHit(ex exchange, body []byte) (bool, error) {
 			"path", path,
 			"request_id", core.GetRequestID(ex.Context()),
 		)
-		return true, nil
+		return true, err
 	}
 	return false, nil
 }
@@ -130,14 +131,15 @@ func (m *simpleCacheMiddleware) StoreAfter(ex exchange, body []byte, next func()
 		_, err := m.captureAndStore(ex, key, next)
 		return err
 	}
-	if err := ex.ReplayHit(body, call.data, CacheTypeExact); err != nil {
+	err := ex.ReplayHit(body, call.data, CacheTypeExact)
+	if err != nil && !replayCommitted(err) {
 		return next()
 	}
 	ex.MarkHit(CacheTypeExact)
 	if m.hitRecorder != nil {
 		m.hitRecorder(ex, call.data, CacheTypeExact)
 	}
-	return nil
+	return err
 }
 
 // captureAndStore executes one cache miss without joining the coalescing

--- a/internal/responsecache/stream_cache.go
+++ b/internal/responsecache/stream_cache.go
@@ -3,6 +3,7 @@ package responsecache
 import (
 	"bytes"
 	stdjson "encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/enterpilot/gomodel/internal/auditlog"
 	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/streaming"
 )
 
 var (
@@ -145,6 +147,26 @@ func isEventStreamContentType(contentType string) bool {
 	return strings.EqualFold(strings.TrimSpace(mediaType), "text/event-stream")
 }
 
+// ReplayError reports that a cached stream could not be delivered to the
+// client: the write or the final flush failed after the response was
+// committed. The caller records the cause (a stalled or vanished client)
+// instead of writing an error response.
+type ReplayError struct {
+	Err error
+}
+
+func (e *ReplayError) Error() string { return "replay cached stream: " + e.Err.Error() }
+func (e *ReplayError) Unwrap() error { return e.Err }
+
+// replayCommitted reports whether a failed replay had already committed the
+// response to the client. Such a request is served as far as it can be: it
+// must not fall through to the handler, which would spend on a provider call
+// for a client that is gone and write a second response.
+func replayCommitted(err error) bool {
+	_, ok := errors.AsType[*ReplayError](err)
+	return ok
+}
+
 func writeCachedResponse(c *echo.Context, path string, requestBody, cached []byte, cacheType string) error {
 	cacheHeader := cacheHeaderValue(cacheType)
 	if isStreamingRequest(path, requestBody) {
@@ -155,7 +177,21 @@ func writeCachedResponse(c *echo.Context, path string, requestBody, cached []byt
 		c.Response().Header().Set("Connection", "keep-alive")
 		c.Response().Header().Set("X-Cache", cacheHeader)
 		c.Response().WriteHeader(http.StatusOK)
-		_, _ = c.Response().Write(cached)
+		if _, err := c.Response().Write(cached); err != nil {
+			return &ReplayError{Err: err}
+		}
+		// The write may only have filled the socket buffer; a client that
+		// stopped reading is caught by the flush, which the route's stall
+		// deadline bounds. The wrappers above the stall writer drop flush
+		// errors, so the stall is asked for directly, as the live path does.
+		if err := http.NewResponseController(c.Response()).Flush(); err != nil && !errors.Is(err, http.ErrNotSupported) {
+			return &ReplayError{Err: err}
+		}
+		if stalls := streaming.FindStallReporter(c.Response()); stalls != nil {
+			if err := stalls.StallError(); err != nil {
+				return &ReplayError{Err: err}
+			}
+		}
 		return nil
 	}
 

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/enterpilot/gomodel/internal/auditlog"
 	batchstore "github.com/enterpilot/gomodel/internal/batch"
+	"github.com/enterpilot/gomodel/internal/cache"
 	"github.com/enterpilot/gomodel/internal/core"
 	"github.com/enterpilot/gomodel/internal/filestore"
 	"github.com/enterpilot/gomodel/internal/gateway"
@@ -34,6 +35,7 @@ import (
 	"github.com/enterpilot/gomodel/internal/observability"
 	"github.com/enterpilot/gomodel/internal/plugins"
 	provideradapter "github.com/enterpilot/gomodel/internal/providers"
+	"github.com/enterpilot/gomodel/internal/responsecache"
 	"github.com/enterpilot/gomodel/internal/responsestore"
 	"github.com/enterpilot/gomodel/internal/usage"
 	"github.com/enterpilot/gomodel/internal/virtualmodels"
@@ -7286,4 +7288,74 @@ func (a *userPathModelAuthorizer) FilterPublicModels(ctx context.Context, models
 		}
 	}
 	return out
+}
+
+// stalledCachedClientWriter fails every body write the way the stall
+// deadline writer does once the client stops reading.
+type stalledCachedClientWriter struct {
+	http.ResponseWriter
+}
+
+func (w *stalledCachedClientWriter) Write([]byte) (int, error) {
+	return 0, fmt.Errorf("%w for 3s: write tcp: i/o timeout", ErrClientStall)
+}
+
+func (w *stalledCachedClientWriter) Unwrap() http.ResponseWriter { return w.ResponseWriter }
+
+// TestHandleWithCache_ClassifiesStalledClientOnCachedStream records a client
+// that stalled while a cached stream was replayed: the audit entry carries
+// error_type client_stalled instead of a clean cache hit, matching the live
+// stream path.
+func TestHandleWithCache_ClassifiesStalledClientOnCachedStream(t *testing.T) {
+	store := cache.NewMapStore()
+	defer store.Close()
+	mw := responsecache.NewResponseCacheMiddlewareWithStore(store, time.Hour)
+	s := &translatedInferenceService{responseCache: mw}
+
+	req := &core.ChatRequest{Model: "gpt-4o-mini", Stream: true, Messages: []core.Message{{Role: "user", Content: "cached-stall"}}}
+	body, err := marshalRequestBody(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	e := echo.New()
+	newContext := func(w http.ResponseWriter) *echo.Context {
+		r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+		r.Header.Set("Content-Type", "application/json")
+		return e.NewContext(r, w)
+	}
+
+	primeCtx := newContext(httptest.NewRecorder())
+	if err := mw.HandleRequest(primeCtx, body, func() error {
+		primeCtx.Response().Header().Set("Content-Type", "text/event-stream")
+		primeCtx.Response().WriteHeader(http.StatusOK)
+		_, _ = primeCtx.Response().Write([]byte("data: {\"id\":\"chatcmpl-stream\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"streamed\"},\"finish_reason\":null}]}\n\n" +
+			"data: {\"id\":\"chatcmpl-stream\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":9,\"completion_tokens\":1,\"total_tokens\":10}}\n\n" +
+			"data: [DONE]\n\n"))
+		return nil
+	}); err != nil {
+		t.Fatalf("prime cache: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("wait for cache write: %v", err)
+	}
+
+	c := newContext(&stalledCachedClientWriter{ResponseWriter: httptest.NewRecorder()})
+	entry := &auditlog.LogEntry{ID: "audit-entry"}
+	c.Set(string(auditlog.LogEntryKey), entry)
+	err = handleWithCache(s, c, req, nil, func(*echo.Context, *core.ChatRequest, *core.Workflow) error {
+		t.Fatal("cached stream must not dispatch to the provider")
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("handleWithCache() error = %v, want nil after recording the stall", err)
+	}
+	if entry.ErrorType != "client_stalled" {
+		t.Fatalf("error_type = %q, want client_stalled", entry.ErrorType)
+	}
+	if entry.Data == nil || !strings.Contains(entry.Data.ErrorMessage, ErrClientStall.Error()) {
+		t.Fatalf("error_message = %#v, want the stall cause", entry.Data)
+	}
+	if entry.CacheType != auditlog.CacheTypeExact {
+		t.Fatalf("cache_type = %q, want %q", entry.CacheType, auditlog.CacheTypeExact)
+	}
 }

--- a/internal/server/stall_deadline.go
+++ b/internal/server/stall_deadline.go
@@ -99,25 +99,3 @@ func (w *stallDeadlineWriter) classify(err error) error {
 	}
 	return err
 }
-
-// stallReporter is implemented by stallDeadlineWriter and looked up through
-// the Unwrap chain of whatever writer a handler holds.
-type stallReporter interface {
-	StallError() error
-}
-
-// findStallReporter walks the Unwrap chain from w down to the stall writer,
-// or returns nil when the route runs without one.
-func findStallReporter(w any) stallReporter {
-	for w != nil {
-		if reporter, ok := w.(stallReporter); ok {
-			return reporter
-		}
-		unwrapper, ok := w.(interface{ Unwrap() http.ResponseWriter })
-		if !ok {
-			return nil
-		}
-		w = unwrapper.Unwrap()
-	}
-	return nil
-}

--- a/internal/server/stream_support.go
+++ b/internal/server/stream_support.go
@@ -4,6 +4,8 @@ import (
 	"io"
 	"net/http"
 	"sync"
+
+	"github.com/enterpilot/gomodel/internal/streaming"
 )
 
 // streamCopyBufferPool reuses 32KB copy buffers across streaming responses so
@@ -23,7 +25,7 @@ var streamCopyBufferPool = sync.Pool{
 // the final chunk would be recorded as a completed response.
 func flushStream(w io.Writer, stream io.Reader) error {
 	flusher, canFlush := w.(http.Flusher)
-	stalls := findStallReporter(w)
+	stalls := streaming.FindStallReporter(w)
 	if canFlush {
 		flusher.Flush()
 		if stalls != nil {

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -328,9 +328,14 @@ func handleWithCache[R any](
 		if marshalErr != nil {
 			slog.Debug("marshalRequestBody failed", "err", marshalErr)
 		} else {
-			return s.responseCache.HandleRequest(c, body, func() error {
+			err := s.responseCache.HandleRequest(c, body, func() error {
 				return dispatch(c, req, workflow)
 			})
+			if replayErr, ok := errors.AsType[*responsecache.ReplayError](err); ok {
+				recordCachedStreamError(c, replayErr.Err)
+				return nil
+			}
+			return err
 		}
 	}
 
@@ -724,14 +729,34 @@ func handleStreamingDispatchError(c *echo.Context, err error) error {
 	return handleError(c, err)
 }
 
-func recordStreamingError(streamEntry *auditlog.LogEntry, model, provider, path, requestID string, ctx context.Context, err error) {
-	errorType := "stream_error"
+// classifyStreamError names the audit error_type of a failure while writing
+// a stream to the client.
+func classifyStreamError(ctx context.Context, err error) string {
 	switch {
 	case errors.Is(err, ErrClientStall):
-		errorType = "client_stalled"
+		return "client_stalled"
 	case isClientDisconnect(ctx, err):
-		errorType = "client_disconnected"
+		return "client_disconnected"
 	}
+	return "stream_error"
+}
+
+// recordCachedStreamError records a cache-served stream the client stopped
+// reading or abandoned, so the audit entry does not show a clean 200 for a
+// stalled client just because the response happened to be cached.
+func recordCachedStreamError(c *echo.Context, err error) {
+	errorType := classifyStreamError(c.Request().Context(), err)
+	auditlog.EnrichEntryWithError(c, errorType, err.Error(), "")
+	slog.Warn("cached stream terminated abnormally",
+		"error", err,
+		"error_type", errorType,
+		"path", c.Request().URL.Path,
+		"request_id", requestIDFromContextOrHeader(c.Request()),
+	)
+}
+
+func recordStreamingError(streamEntry *auditlog.LogEntry, model, provider, path, requestID string, ctx context.Context, err error) {
+	errorType := classifyStreamError(ctx, err)
 
 	// The nil-err branch in isClientDisconnect is reachable for callers that
 	// only have a canceled context to report. Fall back to the context error

--- a/internal/streaming/stall_reporter.go
+++ b/internal/streaming/stall_reporter.go
@@ -1,0 +1,27 @@
+package streaming
+
+import "net/http"
+
+// StallReporter is implemented by the server's stall deadline writer, which
+// sits beneath the response wrappers whose flush methods return no error.
+// It is looked up through the Unwrap chain of whatever writer a handler
+// holds, and asked after a flush whether the client stopped reading.
+type StallReporter interface {
+	StallError() error
+}
+
+// FindStallReporter walks the Unwrap chain from w down to the stall writer,
+// or returns nil when the route runs without one.
+func FindStallReporter(w any) StallReporter {
+	for w != nil {
+		if reporter, ok := w.(StallReporter); ok {
+			return reporter
+		}
+		unwrapper, ok := w.(interface{ Unwrap() http.ResponseWriter })
+		if !ok {
+			return nil
+		}
+		w = unwrapper.Unwrap()
+	}
+	return nil
+}


### PR DESCRIPTION
A streaming request served from the response cache discarded the client write error, so a client that stopped reading (or went away) was recorded as a clean 200 with `cache_type=exact` and no `error_type`, while the same request on the live path records `client_stalled` or `client_disconnected`.

- The cached stream replay now returns a `ReplayError` when the write, the final flush, or the route's stall deadline fails after the response was committed.
- The cache layers treat that as a served hit rather than falling through to the handler, which would have dispatched to the provider for a client that is gone and written a second response.
- The translated inference service records it on the audit entry with the same classification as the live stream path (`client_stalled`, `client_disconnected`, otherwise `stream_error`).
- The stall reporter lookup moved from `server` to `streaming` so both packages share it.

User-visible impact: audit entries for cache-served streams now show why the stream ended abnormally. Non-streaming cache hits are unchanged, matching the live JSON path, which does not classify write failures either.

Addresses F7 from the pre-release test findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of cached streaming failures, including write, flush, client stall, and disconnection errors.
  * Cached stream failures are now classified and recorded accurately without triggering unnecessary provider requests.
  * Preserved cache-hit reporting when a cached response cannot be fully delivered.
* **Documentation**
  * Clarified that client stalls are recorded for streams served from the response cache.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->