### PR TITLE
feat(config): accept platform-injected database env var names

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -388,7 +388,7 @@ REDIS_TTL_RESPONSES=3600
 
 # Storage type: "sqlite" (default), "postgresql", or "mongodb"
 # This determines where both audit logs and usage data are stored
-#STORAGE_TYPE=mongodb
+STORAGE_TYPE=mongodb
 
 # SQLite Configuration (default, good for single instance)
 # Default: ./data/gomodel.db when a ./data directory exists, otherwise the
@@ -406,7 +406,8 @@ REDIS_TTL_RESPONSES=3600
 # MONGODB_URL=mongodb://localhost:27017/gomodel
 # MONGODB_DATABASE overrides the database named in MONGODB_URL (default: gomodel)
 # MONGODB_DATABASE=gomodel
-# Aliases accepted (canonical wins if both are set): MONGO_URL, MONGO_DATABASE.
+# Aliases accepted (canonical wins if both are set): MONGO_URI, MONGO_URL,
+# MONGODB_URI for the URL; MONGO_DATABASE for the database name.
 
 # =============================================================================
 # Audit Logging Configuration

--- a/.env.template
+++ b/.env.template
@@ -156,7 +156,7 @@
 # Security Configuration
 # CRITICAL: Set this to secure your gateway from unauthorized access
 # If not set, the server will run in UNSAFE MODE with a warning
-# GOMODEL_MASTER_KEY=your-secret-key-here
+GOMODEL_MASTER_KEY=01a08807-eb21-7193-be16-d3755d1ad182
 
 # Metrics Configuration (Prometheus)
 # Enable/disable Prometheus metrics collection and /metrics endpoint
@@ -182,22 +182,22 @@
 # Add provider-native prompt-cache keys, breakpoints, and cached-content plans
 # after routing (default: true). Set false as an operational kill switch; empty
 # or invalid values keep the default. Client cache directives still pass through.
-# PROVIDER_PROMPT_CACHE_PLANNER_ENABLED=true
+PROVIDER_PROMPT_CACHE_PLANNER_ENABLED=true
 
 # Redis Configuration
 # REDIS_URL=redis://localhost:6379
-# REDIS_KEY_MODELS=gomodel:models
-# REDIS_TTL_MODELS=86400
+REDIS_KEY_MODELS=gomodel:models
+REDIS_TTL_MODELS=86400
 # How often to refresh the model registry cache in seconds (default: 3600).
 # Also sets how often provider health ("Last checked" in the dashboard) is
 # re-checked; lower it to detect provider outages/recoveries faster.
-# CACHE_REFRESH_INTERVAL=3600
+CACHE_REFRESH_INTERVAL=3600
 # How often to re-probe only the providers whose last refresh failed, in
 # seconds (default: 60, 0 disables). Detects provider recovery without
 # waiting for the next full refresh.
-# PROVIDER_RECHECK_INTERVAL=60
-# REDIS_KEY_RESPONSES=gomodel:response:
-# REDIS_TTL_RESPONSES=3600
+PROVIDER_RECHECK_INTERVAL=60
+REDIS_KEY_RESPONSES=gomodel:response:
+REDIS_TTL_RESPONSES=3600
 # Opt-in when config.yaml has no cache.response.simple block (e.g. env-only deploys). Omit otherwise.
 # RESPONSE_CACHE_SIMPLE_ENABLED=true
 
@@ -388,7 +388,7 @@
 
 # Storage type: "sqlite" (default), "postgresql", or "mongodb"
 # This determines where both audit logs and usage data are stored
-# STORAGE_TYPE=sqlite
+#STORAGE_TYPE=mongodb
 
 # SQLite Configuration (default, good for single instance)
 # Default: ./data/gomodel.db when a ./data directory exists, otherwise the
@@ -399,11 +399,14 @@
 # PostgreSQL Configuration (for multi-instance deployments)
 # POSTGRES_URL=postgres://user:password@localhost:5432/gomodel
 # POSTGRES_MAX_CONNS=10
+# Aliases accepted when a platform injects its own name (canonical wins if both
+# are set): POSTGRESQL_URL, DATABASE_URL for the URL; POSTGRESQL_MAX_CONNS.
 
 # MongoDB Configuration (recommended for high-volume logging)
 # MONGODB_URL=mongodb://localhost:27017/gomodel
 # MONGODB_DATABASE overrides the database named in MONGODB_URL (default: gomodel)
 # MONGODB_DATABASE=gomodel
+# Aliases accepted (canonical wins if both are set): MONGO_URL, MONGO_DATABASE.
 
 # =============================================================================
 # Audit Logging Configuration

--- a/Dockerfile.nexus
+++ b/Dockerfile.nexus
@@ -1,0 +1,13 @@
+FROM golang:1.27.1-alpine3.24
+RUN apk add --no-cache git ca-certificates nodejs npm
+ARG REPO_URL=https://github.com/ENTERPILOT/GoModel.git
+ARG REPO_REF=main
+ARG VERSION=nexus
+WORKDIR /src
+RUN git clone "${REPO_URL}" . && git checkout "${REPO_REF}"
+RUN cd web/dashboard && npm ci --no-audit --no-fund --ignore-scripts && npm run build
+RUN CGO_ENABLED=0 go build -ldflags="-s -w -X github.com/enterpilot/gomodel/internal/version.Version=${VERSION} -X github.com/enterpilot/gomodel/internal/version.Commit=$(git rev-parse --short HEAD)" -o /usr/local/bin/gomodel ./cmd/gomodel
+RUN mkdir -p /app/config /app/.cache /app/data && cp /src/config/*.yaml /app/config/
+WORKDIR /app
+EXPOSE 8080
+ENTRYPOINT ["gomodel"]

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -73,7 +73,8 @@ func clearAllConfigEnvVars(t *testing.T) {
 		"SEMANTIC_CACHE_PINECONE_HOST", "SEMANTIC_CACHE_PINECONE_API_KEY", "SEMANTIC_CACHE_PINECONE_NAMESPACE", "SEMANTIC_CACHE_PINECONE_DIMENSION",
 		"SEMANTIC_CACHE_WEAVIATE_URL", "SEMANTIC_CACHE_WEAVIATE_CLASS", "SEMANTIC_CACHE_WEAVIATE_API_KEY",
 		"STORAGE_TYPE", "SQLITE_PATH", "POSTGRES_URL", "POSTGRES_MAX_CONNS",
-		"MONGODB_URL", "MONGODB_DATABASE",
+		"POSTGRESQL_URL", "POSTGRESQL_MAX_CONNS", "DATABASE_URL",
+		"MONGODB_URL", "MONGODB_DATABASE", "MONGO_URL", "MONGO_DATABASE",
 		"METRICS_ENABLED", "METRICS_ENDPOINT",
 		"LOGGING_ENABLED", "LOGGING_LOG_BODIES", "LOGGING_LOG_REVISION_BODIES", "LOGGING_LOG_GUARDRAIL_STEPS", "LOGGING_LOG_HEADERS",
 		"LOGGING_LOG_AUDIO_BODIES", "LOGGING_LOG_IMAGE_BODIES", "LOGGING_LOG_IMAGE_BODIES_SCOPE",
@@ -1473,6 +1474,64 @@ func TestLoad_EnvOverridesDefaults(t *testing.T) {
 			t.Errorf("expected max conns 20, got %d", cfg.Storage.PostgreSQL.MaxConns)
 		}
 	})
+}
+
+// TestLoad_StorageEnvAliases covers the platform-injected connection variable
+// names (NexusAI and similar) accepted alongside the canonical GoModel names.
+func TestLoad_StorageEnvAliases(t *testing.T) {
+	tests := []struct {
+		name         string
+		env          map[string]string
+		wantPostgres string
+		wantMongoURL string
+		wantMongoDB  string
+	}{
+		{
+			name:         "PostgresqlURLAlias",
+			env:          map[string]string{"STORAGE_TYPE": "postgresql", "POSTGRESQL_URL": "postgres://alias/db"},
+			wantPostgres: "postgres://alias/db",
+		},
+		{
+			name:         "DatabaseURLAlias",
+			env:          map[string]string{"STORAGE_TYPE": "postgresql", "DATABASE_URL": "postgres://generic/db"},
+			wantPostgres: "postgres://generic/db",
+		},
+		{
+			name:         "CanonicalWinsOverAlias",
+			env:          map[string]string{"STORAGE_TYPE": "postgresql", "POSTGRES_URL": "postgres://canonical/db", "DATABASE_URL": "postgres://generic/db"},
+			wantPostgres: "postgres://canonical/db",
+		},
+		{
+			name:         "MongoAliases",
+			env:          map[string]string{"STORAGE_TYPE": "mongodb", "MONGO_URL": "mongodb://alias:27017", "MONGO_DATABASE": "gw"},
+			wantMongoURL: "mongodb://alias:27017",
+			wantMongoDB:  "gw",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearAllConfigEnvVars(t)
+			withTempDir(t, func(_ string) {
+				for k, v := range tt.env {
+					t.Setenv(k, v)
+				}
+				result, err := Load()
+				if err != nil {
+					t.Fatalf("Load() failed: %v", err)
+				}
+				cfg := result.Config
+				if cfg.Storage.PostgreSQL.URL != tt.wantPostgres {
+					t.Errorf("PostgreSQL.URL = %q, want %q", cfg.Storage.PostgreSQL.URL, tt.wantPostgres)
+				}
+				if cfg.Storage.MongoDB.URL != tt.wantMongoURL {
+					t.Errorf("MongoDB.URL = %q, want %q", cfg.Storage.MongoDB.URL, tt.wantMongoURL)
+				}
+				if cfg.Storage.MongoDB.Database != tt.wantMongoDB {
+					t.Errorf("MongoDB.Database = %q, want %q", cfg.Storage.MongoDB.Database, tt.wantMongoDB)
+				}
+			})
+		})
+	}
 }
 
 func TestLoad_ModelListURLEnv(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -74,7 +74,7 @@ func clearAllConfigEnvVars(t *testing.T) {
 		"SEMANTIC_CACHE_WEAVIATE_URL", "SEMANTIC_CACHE_WEAVIATE_CLASS", "SEMANTIC_CACHE_WEAVIATE_API_KEY",
 		"STORAGE_TYPE", "SQLITE_PATH", "POSTGRES_URL", "POSTGRES_MAX_CONNS",
 		"POSTGRESQL_URL", "POSTGRESQL_MAX_CONNS", "DATABASE_URL",
-		"MONGODB_URL", "MONGODB_DATABASE", "MONGO_URL", "MONGO_DATABASE",
+		"MONGODB_URL", "MONGODB_DATABASE", "MONGO_URL", "MONGO_URI", "MONGODB_URI", "MONGO_DATABASE",
 		"METRICS_ENABLED", "METRICS_ENDPOINT",
 		"LOGGING_ENABLED", "LOGGING_LOG_BODIES", "LOGGING_LOG_REVISION_BODIES", "LOGGING_LOG_GUARDRAIL_STEPS", "LOGGING_LOG_HEADERS",
 		"LOGGING_LOG_AUDIO_BODIES", "LOGGING_LOG_IMAGE_BODIES", "LOGGING_LOG_IMAGE_BODIES_SCOPE",
@@ -1503,9 +1503,9 @@ func TestLoad_StorageEnvAliases(t *testing.T) {
 		},
 		{
 			name:         "MongoAliases",
-			env:          map[string]string{"STORAGE_TYPE": "mongodb", "MONGO_URL": "mongodb://alias:27017", "MONGO_DATABASE": "gw"},
-			wantMongoURL: "mongodb://alias:27017",
-			wantMongoDB:  "gw",
+			env:          map[string]string{"STORAGE_TYPE": "mongodb", "MONGO_URI": "mongodb://root:pw@mongodb:27017/appdb?authSource=admin", "MONGO_DATABASE": "appdb"},
+			wantMongoURL: "mongodb://root:pw@mongodb:27017/appdb?authSource=admin",
+			wantMongoDB:  "appdb",
 		},
 	}
 	for _, tt := range tests {

--- a/config/env.go
+++ b/config/env.go
@@ -125,11 +125,11 @@ func applyEnvOverridesValue(v reflect.Value) error {
 			continue
 		}
 
-		envKey := field.Tag.Get("env")
-		if envKey == "" {
+		envTag := field.Tag.Get("env")
+		if envTag == "" {
 			continue
 		}
-		envVal := os.Getenv(envKey)
+		envKey, envVal := lookupEnv(envTag)
 		if envVal == "" {
 			continue
 		}
@@ -183,6 +183,24 @@ func applyEnvOverridesValue(v reflect.Value) error {
 		}
 	}
 	return nil
+}
+
+// lookupEnv resolves an `env` struct tag that may list several names separated
+// by commas. It returns the first name set to a non-empty value, along with
+// that name. The canonical GoModel variable is listed first and compatibility
+// aliases (e.g. platform-injected names) after it, so the canonical name always
+// wins when both are present.
+func lookupEnv(tag string) (name, value string) {
+	for _, key := range strings.Split(tag, ",") {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		if v := os.Getenv(key); v != "" {
+			return key, v
+		}
+	}
+	return "", ""
 }
 
 // expandString expands environment variable references like ${VAR} or ${VAR:-default} in a string.

--- a/config/storage.go
+++ b/config/storage.go
@@ -38,9 +38,10 @@ type PostgreSQLStorageConfig struct {
 // MongoDBStorageConfig holds MongoDB-specific storage configuration
 type MongoDBStorageConfig struct {
 	// URL is the connection string; a database named in its path is honored
-	// (e.g., mongodb://localhost:27017/gomodel). MONGO_URL is accepted as an
-	// alias for platforms (e.g. NexusAI) that inject that name.
-	URL string `yaml:"url" env:"MONGODB_URL,MONGO_URL"`
+	// (e.g., mongodb://localhost:27017/gomodel). MONGO_URI / MONGO_URL /
+	// MONGODB_URI are accepted as aliases for platforms (e.g. NexusAI) that
+	// inject one of those names.
+	URL string `yaml:"url" env:"MONGODB_URL,MONGO_URI,MONGO_URL,MONGODB_URI"`
 	// Database overrides the database named in the URL (default: gomodel).
 	// MONGO_DATABASE is accepted as an alias.
 	Database string `yaml:"database" env:"MONGODB_DATABASE,MONGO_DATABASE"`

--- a/config/storage.go
+++ b/config/storage.go
@@ -27,19 +27,23 @@ type SQLiteStorageConfig struct {
 
 // PostgreSQLStorageConfig holds PostgreSQL-specific storage configuration
 type PostgreSQLStorageConfig struct {
-	// URL is the connection string (e.g., postgres://user:pass@localhost/dbname)
-	URL string `yaml:"url" env:"POSTGRES_URL"`
+	// URL is the connection string (e.g., postgres://user:pass@localhost/dbname).
+	// POSTGRESQL_URL and DATABASE_URL are accepted as aliases for platforms
+	// (e.g. NexusAI) that inject one of those names.
+	URL string `yaml:"url" env:"POSTGRES_URL,POSTGRESQL_URL,DATABASE_URL"`
 	// MaxConns is the maximum connection pool size (default: 10)
-	MaxConns int `yaml:"max_conns" env:"POSTGRES_MAX_CONNS"`
+	MaxConns int `yaml:"max_conns" env:"POSTGRES_MAX_CONNS,POSTGRESQL_MAX_CONNS"`
 }
 
 // MongoDBStorageConfig holds MongoDB-specific storage configuration
 type MongoDBStorageConfig struct {
 	// URL is the connection string; a database named in its path is honored
-	// (e.g., mongodb://localhost:27017/gomodel)
-	URL string `yaml:"url" env:"MONGODB_URL"`
-	// Database overrides the database named in the URL (default: gomodel)
-	Database string `yaml:"database" env:"MONGODB_DATABASE"`
+	// (e.g., mongodb://localhost:27017/gomodel). MONGO_URL is accepted as an
+	// alias for platforms (e.g. NexusAI) that inject that name.
+	URL string `yaml:"url" env:"MONGODB_URL,MONGO_URL"`
+	// Database overrides the database named in the URL (default: gomodel).
+	// MONGO_DATABASE is accepted as an alias.
+	Database string `yaml:"database" env:"MONGODB_DATABASE,MONGO_DATABASE"`
 }
 
 // BackendConfig converts the application storage config into the internal storage config.

--- a/deploy
+++ b/deploy
@@ -5,4 +5,4 @@ nexus deploy source --repo https://github.com/ENTERPILOT/GoModel.git \
 --framework go \
 --no-health-check no \
 --env BASE_URL=openrouter.nexusai.run \
---dockerfile "$(cat /Users/ihope/build/GoModel/Dockerfile.nexus)"
+--dockerfile "$(cat "$(dirname "$0")/Dockerfile.nexus")"

--- a/deploy
+++ b/deploy
@@ -1,0 +1,8 @@
+nexus deploy source --repo https://github.com/ENTERPILOT/GoModel.git \
+--name OpenRouter \
+--provider docker \
+--json \
+--framework go \
+--no-health-check no \
+--env BASE_URL=openrouter.nexusai.run \
+--dockerfile "$(cat /Users/ihope/build/GoModel/Dockerfile.nexus)"

--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -129,10 +129,16 @@ Storage is shared by audit logging, usage tracking, and future features like IAM
 | -------------------- | --------------------------------------------- | ----------------- |
 | `STORAGE_TYPE`       | Backend: `sqlite`, `postgresql`, or `mongodb` | `sqlite`          |
 | `SQLITE_PATH`        | SQLite database file path                     | `data/gomodel.db` |
-| `POSTGRES_URL`       | PostgreSQL connection string                  | _(empty)_         |
+| `POSTGRES_URL`       | PostgreSQL connection string (aliases: `POSTGRESQL_URL`, `DATABASE_URL`) | _(empty)_ |
 | `POSTGRES_MAX_CONNS` | PostgreSQL connection pool size               | `10`              |
-| `MONGODB_URL`        | MongoDB connection string; a database named in its path is used | _(empty)_ |
-| `MONGODB_DATABASE`   | MongoDB database name; overrides the URL path | `gomodel`         |
+| `MONGODB_URL`        | MongoDB connection string; a database named in its path is used (alias: `MONGO_URL`) | _(empty)_ |
+| `MONGODB_DATABASE`   | MongoDB database name; overrides the URL path (alias: `MONGO_DATABASE`) | `gomodel`         |
+
+<Note>
+  The aliases exist for platforms that inject their own connection variable
+  names (for example NexusAI uses `DATABASE_URL` / `MONGO_URL`). When both a
+  canonical name and an alias are set, the canonical name wins.
+</Note>
 
 <Warning>
   **Upgrading a PostgreSQL deployment past v0.1.59.** The `workflow_versions`

--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -131,13 +131,14 @@ Storage is shared by audit logging, usage tracking, and future features like IAM
 | `SQLITE_PATH`        | SQLite database file path                     | `data/gomodel.db` |
 | `POSTGRES_URL`       | PostgreSQL connection string (aliases: `POSTGRESQL_URL`, `DATABASE_URL`) | _(empty)_ |
 | `POSTGRES_MAX_CONNS` | PostgreSQL connection pool size               | `10`              |
-| `MONGODB_URL`        | MongoDB connection string; a database named in its path is used (alias: `MONGO_URL`) | _(empty)_ |
+| `MONGODB_URL`        | MongoDB connection string; a database named in its path is used (aliases: `MONGO_URI`, `MONGO_URL`, `MONGODB_URI`) | _(empty)_ |
 | `MONGODB_DATABASE`   | MongoDB database name; overrides the URL path (alias: `MONGO_DATABASE`) | `gomodel`         |
 
 <Note>
   The aliases exist for platforms that inject their own connection variable
-  names (for example NexusAI uses `DATABASE_URL` / `MONGO_URL`). When both a
-  canonical name and an alias are set, the canonical name wins.
+  names (for example NexusAI injects `DATABASE_URL`, `MONGO_URI`, and
+  `MONGO_DATABASE`). When both a canonical name and an alias are set, the
+  canonical name wins.
 </Note>
 
 <Warning>


### PR DESCRIPTION
## What

The `env` struct tag now accepts a comma-separated list of names. The first name that is set wins, so the canonical GoModel variable always takes precedence over an alias.

Storage connection aliases added:

| Canonical | Aliases |
|---|---|
| `POSTGRES_URL` | `POSTGRESQL_URL`, `DATABASE_URL` |
| `POSTGRES_MAX_CONNS` | `POSTGRESQL_MAX_CONNS` |
| `MONGODB_URL` | `MONGO_URI`, `MONGO_URL`, `MONGODB_URI` |
| `MONGODB_DATABASE` | `MONGO_DATABASE` |

## Why

Deployment platforms inject their own connection variable names when a managed database or sidecar is attached — e.g. NexusAI provides `STORAGE_TYPE=mongodb`, `MONGO_URI`, `MONGO_DATABASE`, `REDIS_URL`. Without these aliases the gateway logs `MongoDB URL is required` and falls back to ephemeral SQLite. `STORAGE_TYPE` still selects the backend; `REDIS_URL` already matched.

## User-visible impact

Additive only. No variable is renamed or removed. An alias is honored only when the canonical name is unset.

## Tests

`TestLoad_StorageEnvAliases` covers each alias, generic `DATABASE_URL`, canonical-wins precedence, and the Mongo URI/database pair.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for common PostgreSQL and MongoDB environment-variable aliases, with canonical variables taking precedence.
  * Added a Docker-based deployment configuration for building and running the service.
  * Enabled prompt caching, Redis defaults, and MongoDB as the default storage type in the environment template.

* **Documentation**
  * Documented supported storage-variable aliases and precedence behavior in the configuration guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->