### PR TITLE
feat(responses): honor previous_response_id on chat-translated providers

### DIFF
--- a/cmd/gomodel/docs/docs.go
+++ b/cmd/gomodel/docs/docs.go
@@ -10886,6 +10886,10 @@ const docTemplate = `{
                         "$ref": "#/definitions/core.ResponsesOutputItem"
                     }
                 },
+                "previous_response_id": {
+                    "description": "PreviousResponseID names the response this one was chained from, as\nOpenAI echoes it; stored snapshots follow it to rebuild the history.",
+                    "type": "string"
+                },
                 "provider": {
                     "type": "string"
                 },

--- a/docs/advanced/responses-api.mdx
+++ b/docs/advanced/responses-api.mdx
@@ -47,8 +47,14 @@ This enables:
 - `GET /v1/responses/{id}/input_items` for the original normalized input.
 - `DELETE /v1/responses/{id}` even when the provider does not expose native
   response deletion.
+- `previous_response_id` on chat-translated providers such as Anthropic and
+  Gemini: GoModel prepends the stored response's input items and output to the
+  new input, so the provider receives the whole chain each turn. Native
+  Responses providers receive the id itself. An id that is not stored, or
+  belongs to another tenant, returns 404.
 
-Streaming responses are not stored as response snapshots.
+Streaming responses are not stored as response snapshots, so a chained turn
+must follow a non-streaming response.
 
 ## Native provider lookup
 

--- a/docs/advanced/responses-api.mdx
+++ b/docs/advanced/responses-api.mdx
@@ -50,11 +50,12 @@ This enables:
 - `previous_response_id` on chat-translated providers such as Anthropic and
   Gemini: GoModel prepends the stored response's input items and output to the
   new input, so the provider receives the whole chain each turn. Native
-  Responses providers receive the id itself. An id that is not stored, or
-  belongs to another tenant, returns 404.
+  Responses providers receive the id itself. An id that is not stored (the
+  previous response was streamed or sent with `store: false`), or belongs to
+  another tenant, returns 404.
 
 Streaming responses are not stored as response snapshots, so a chained turn
-must follow a non-streaming response.
+must follow a non-streaming response with `store` left on.
 
 ## Native provider lookup
 

--- a/docs/advanced/responses-api.mdx
+++ b/docs/advanced/responses-api.mdx
@@ -49,8 +49,9 @@ This enables:
 - `DELETE /v1/responses/{id}` even when the provider does not expose native
   response deletion.
 - `previous_response_id` on chat-translated providers such as Anthropic and
-  Gemini: GoModel prepends the stored response's input items and output to the
-  new input, so the provider receives the whole chain each turn. On these
+  Gemini: GoModel follows the stored response and each response it was chained
+  from, and prepends their input items and output to the new input, so the
+  provider receives the whole chain each turn. On these
   providers an id that is not stored (the previous response was streamed or
   sent with `store: false`), or belongs to another tenant, returns 404. Native
   Responses providers receive the id itself and resolve it on their side, so

--- a/docs/advanced/responses-api.mdx
+++ b/docs/advanced/responses-api.mdx
@@ -32,8 +32,9 @@ providers, see [Responses compatibility](/advanced/responses-compatibility).
 
 ## Stored responses
 
-For non-streaming `POST /v1/responses` calls, GoModel stores the normalized
-response body and the normalized input items from the request. The snapshot is
+For non-streaming `POST /v1/responses` calls, unless the request sets
+`store: false`, GoModel stores the normalized response body and the normalized
+input items from the request. The snapshot is
 written in the background after the response is returned, so storage latency
 never delays the client. A `GET /v1/responses/{id}` issued immediately after
 the `POST` can arrive before the snapshot is stored; graceful shutdown waits
@@ -49,13 +50,15 @@ This enables:
   response deletion.
 - `previous_response_id` on chat-translated providers such as Anthropic and
   Gemini: GoModel prepends the stored response's input items and output to the
-  new input, so the provider receives the whole chain each turn. Native
-  Responses providers receive the id itself. An id that is not stored (the
-  previous response was streamed or sent with `store: false`), or belongs to
-  another tenant, returns 404.
+  new input, so the provider receives the whole chain each turn. On these
+  providers an id that is not stored (the previous response was streamed or
+  sent with `store: false`), or belongs to another tenant, returns 404. Native
+  Responses providers receive the id itself and resolve it on their side, so
+  they need no GoModel snapshot.
 
-Streaming responses are not stored as response snapshots, so a chained turn
-must follow a non-streaming response with `store` left on.
+Streaming responses are not stored as response snapshots, so on chat-translated
+providers a chained turn must follow a non-streaming response with `store` left
+on.
 
 ## Native provider lookup
 

--- a/docs/advanced/responses-compatibility.mdx
+++ b/docs/advanced/responses-compatibility.mdx
@@ -36,7 +36,8 @@ function tool loops. They cannot safely execute OpenAI-hosted tools.
 | Function call output items | Forwarded | Converted to chat tool-result messages |
 | `text.format` structured output | Forwarded | Converted to `response_format` when the provider supports it |
 | Responses-only tools (`web_search`, `file_search`, `computer_use_preview`, and `namespace`) | Provider decides | Accepted and omitted |
-| `previous_response_id` and `conversation` | Forwarded | Rejected |
+| `previous_response_id` | Forwarded | Resolved by GoModel: the stored previous response's input items and output are prepended to the input (see [Stored responses](/advanced/responses-api#stored-responses)) |
+| `conversation` | Resolved by GoModel from the gateway-managed conversation | Resolved by GoModel from the gateway-managed conversation |
 | `include` annotations | Forwarded | Accepted and ignored, except `message.output_text.logprobs` |
 | Unknown Responses input item types | Preserved | Rejected |
 | Responses websocket transport | Not implemented by GoModel | Not implemented by GoModel |

--- a/docs/advanced/responses-compatibility.mdx
+++ b/docs/advanced/responses-compatibility.mdx
@@ -36,7 +36,7 @@ function tool loops. They cannot safely execute OpenAI-hosted tools.
 | Function call output items | Forwarded | Converted to chat tool-result messages |
 | `text.format` structured output | Forwarded | Converted to `response_format` when the provider supports it |
 | Responses-only tools (`web_search`, `file_search`, `computer_use_preview`, and `namespace`) | Provider decides | Accepted and omitted |
-| `previous_response_id` | Forwarded | Resolved by GoModel: the stored previous response's input items and output are prepended to the input (see [Stored responses](/advanced/responses-api#stored-responses)) |
+| `previous_response_id` | Forwarded | Resolved by GoModel: the stored previous response's input items and output are prepended to the input. The previous response must be a stored, non-streaming response, or the request returns 404 (see [Stored responses](/advanced/responses-api#stored-responses)) |
 | `conversation` | Resolved by GoModel from the gateway-managed conversation | Resolved by GoModel from the gateway-managed conversation |
 | `include` annotations | Forwarded | Accepted and ignored, except `message.output_text.logprobs` |
 | Unknown Responses input item types | Preserved | Rejected |

--- a/docs/guides/openai-agents-sdk.mdx
+++ b/docs/guides/openai-agents-sdk.mdx
@@ -247,9 +247,11 @@ when the upstream provider does not support response retrieval. If the SDK sends
 - Anthropic does not currently accept translated structured-output
   `response_format` or `text.verbosity` settings. GoModel rejects those fields
   instead of silently ignoring them.
-- `previous_response_id` and `conversation` are forwarded to native Responses
-  providers. Chat-translated providers reject them because GoModel cannot safely
-  reconstruct provider-managed state across that translation boundary yet.
+- `previous_response_id` is forwarded to native Responses providers. For
+  chat-translated providers GoModel resolves it from its stored responses and
+  replays the previous turn's input and output, so the previous response must
+  have been created non-streaming with `store` left on. `conversation` is
+  resolved from gateway-managed conversations for every provider.
 - Tracing is separate from model routing. Disable SDK tracing or configure a
   real OpenAI tracing key.
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -14660,6 +14660,10 @@
               "$ref": "#/components/schemas/core.ResponsesOutputItem"
             }
           },
+          "previous_response_id": {
+            "description": "PreviousResponseID names the response this one was chained from, as\nOpenAI echoes it; stored snapshots follow it to rebuild the history.",
+            "type": "string"
+          },
           "provider": {
             "type": "string"
           },

--- a/internal/core/responses.go
+++ b/internal/core/responses.go
@@ -193,6 +193,9 @@ type ResponsesResponse struct {
 	Output    []ResponsesOutputItem `json:"output"`
 	Usage     *ResponsesUsage       `json:"usage,omitempty"`
 	Error     *ResponsesError       `json:"error,omitempty"`
+	// PreviousResponseID names the response this one was chained from, as
+	// OpenAI echoes it; stored snapshots follow it to rebuild the history.
+	PreviousResponseID string `json:"previous_response_id,omitempty"`
 }
 
 // ResponsesOutputItem represents an item in the output array.

--- a/internal/gateway/inference_execute.go
+++ b/internal/gateway/inference_execute.go
@@ -203,7 +203,26 @@ func (o *InferenceOrchestrator) executeResponses(
 	if err := o.validateProviderAndRequest(req != nil, "responses request is required"); err != nil {
 		return nil, ExecutionMeta{}, err
 	}
-	return executeTranslatedProviderRequest(o, ctx, workflow, req, req.Model, req.Provider, CloneResponsesRequestForSelector, o.responsesProviderCall, responsesResponseProvider)
+	return executeTranslatedProviderRequest(o, ctx, workflow, req, req.Model, req.Provider, CloneResponsesRequestForSelector, patchedResponsesCall(o, workflow, o.responsesProviderCall), responsesResponseProvider)
+}
+
+// patchedResponsesCall runs the Responses attempt patcher, when configured,
+// in front of call. The attempt's provider type comes from the request's own
+// selector, which the primary carries after resolution and a failover clone
+// carries from its target, falling back to the workflow's provider type.
+func patchedResponsesCall[T any](o *InferenceOrchestrator, workflow *core.Workflow, call func(context.Context, *core.ResponsesRequest) (T, error)) func(context.Context, *core.ResponsesRequest) (T, error) {
+	if o.responsesAttemptPatcher == nil {
+		return call
+	}
+	return func(ctx context.Context, req *core.ResponsesRequest) (T, error) {
+		providerType := o.ProviderTypeForSelector(core.ModelSelector{Model: req.Model, Provider: req.Provider}, ProviderTypeFromWorkflow(workflow))
+		patched, err := o.responsesAttemptPatcher.PatchResponsesAttempt(ctx, req, providerType)
+		if err != nil {
+			var zero T
+			return zero, err
+		}
+		return call(ctx, patched)
+	}
 }
 
 func (o *InferenceOrchestrator) streamResponses(
@@ -215,7 +234,7 @@ func (o *InferenceOrchestrator) streamResponses(
 	if err := o.validateProviderAndRequest(req != nil, "responses request is required"); err != nil {
 		return nil, ExecutionMeta{}, err
 	}
-	return streamTranslatedProviderRequest(o, ctx, workflow, req, req.Model, req.Provider, providerType, providerName, usageModel, CloneResponsesRequestForSelector, o.streamResponsesProviderCall)
+	return streamTranslatedProviderRequest(o, ctx, workflow, req, req.Model, req.Provider, providerType, providerName, usageModel, CloneResponsesRequestForSelector, patchedResponsesCall(o, workflow, o.streamResponsesProviderCall))
 }
 
 type translatedExecutionSpec[Req any, Resp any, Result any] struct {

--- a/internal/gateway/inference_orchestrator.go
+++ b/internal/gateway/inference_orchestrator.go
@@ -26,6 +26,7 @@ type InferenceConfig struct {
 	FailoverResolver         FailoverResolver
 	FailoverPolicy           *FailoverPolicy // Optional: nil applies the default failover policy
 	TranslatedRequestPatcher TranslatedRequestPatcher
+	ResponsesAttemptPatcher  ResponsesAttemptPatcher // Optional: per-attempt Responses request adaptation
 	UsageLogger              usage.LoggerInterface
 	PricingResolver          usage.PricingResolver
 	RouteGate                RouteGate
@@ -42,6 +43,7 @@ type InferenceOrchestrator struct {
 	failoverResolver         FailoverResolver
 	failoverPolicy           *FailoverPolicy
 	translatedRequestPatcher TranslatedRequestPatcher
+	responsesAttemptPatcher  ResponsesAttemptPatcher
 	usageLogger              usage.LoggerInterface
 	pricingResolver          usage.PricingResolver
 	routeGate                RouteGate
@@ -58,6 +60,7 @@ func NewInferenceOrchestrator(cfg InferenceConfig) *InferenceOrchestrator {
 		failoverResolver:         cfg.FailoverResolver,
 		failoverPolicy:           cfg.FailoverPolicy,
 		translatedRequestPatcher: cfg.TranslatedRequestPatcher,
+		responsesAttemptPatcher:  cfg.ResponsesAttemptPatcher,
 		usageLogger:              cfg.UsageLogger,
 		pricingResolver:          cfg.PricingResolver,
 		routeGate:                cfg.RouteGate,

--- a/internal/gateway/interfaces.go
+++ b/internal/gateway/interfaces.go
@@ -53,6 +53,16 @@ type TranslatedRequestPatcher interface {
 	PatchResponsesRequest(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesRequest, error)
 }
 
+// ResponsesAttemptPatcher adapts a Responses request to the provider one
+// attempt is about to reach, after failover has chosen the target. It runs
+// for the primary attempt and for every failover attempt with that target's
+// provider type, so a field one provider resolves itself (previous_response_id
+// on a native Responses provider) can be rewritten only for targets that
+// cannot.
+type ResponsesAttemptPatcher interface {
+	PatchResponsesAttempt(ctx context.Context, req *core.ResponsesRequest, providerType string) (*core.ResponsesRequest, error)
+}
+
 // BatchRequestPreparer rewrites a native batch request before provider
 // submission. This keeps batch-specific policy out of provider decorators.
 type BatchRequestPreparer interface {

--- a/internal/server/previous_response.go
+++ b/internal/server/previous_response.go
@@ -1,0 +1,89 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/goccy/go-json"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/responsestore"
+)
+
+// applyResponsesPreviousResponse resolves previous_response_id for routes
+// whose provider cannot. A chat-translated provider keeps no response state,
+// so the referenced response is loaded from the gateway's response store and
+// its input items and output are prepended to the request input, the way a
+// gateway-managed conversation is; the field is stripped before dispatch.
+// Native Responses providers keep receiving the id untouched, since they hold
+// that state themselves. A stored response's input items already carry the
+// history it was chained from, so one hop reconstructs the whole chain.
+func (s *translatedInferenceService) applyResponsesPreviousResponse(ctx context.Context, req *core.ResponsesRequest, workflow *core.Workflow) (*core.ResponsesRequest, error) {
+	if req == nil {
+		return req, nil
+	}
+	id := strings.TrimSpace(req.PreviousResponseID)
+	if id == "" || s.providerResolvesPreviousResponse(workflow) {
+		return req, nil
+	}
+	store := s.currentResponseStore()
+	if store == nil {
+		// No local store: keep the historical behavior, where the provider
+		// adapter rejects the field.
+		return req, nil
+	}
+
+	stored, err := store.Get(ctx, id)
+	if err != nil {
+		if errors.Is(err, responsestore.ErrNotFound) {
+			return req, previousResponseNotFound(id)
+		}
+		return req, core.NewProviderError("response_store", http.StatusInternalServerError, "failed to load previous response", err)
+	}
+	// Another tenant's response is indistinguishable from a missing one.
+	if stored == nil || stored.Response == nil || !core.AccessScopeFromContext(ctx).Allows(stored.UserPath) {
+		return req, previousResponseNotFound(id)
+	}
+
+	history := make([]json.RawMessage, 0, len(stored.InputItems)+len(stored.Response.Output))
+	history = append(history, stored.InputItems...)
+	for _, item := range stored.Response.Output {
+		raw, err := json.Marshal(item)
+		if err != nil {
+			return req, core.NewProviderError("response_store", http.StatusInternalServerError, "stored response output is not serializable", err)
+		}
+		history = append(history, raw)
+	}
+	merged, err := mergeConversationInput(history, req.Input)
+	if err != nil {
+		return req, err
+	}
+
+	patched := *req
+	patched.Input = merged
+	patched.PreviousResponseID = ""
+	return &patched, nil
+}
+
+// providerResolvesPreviousResponse reports whether the resolved route's
+// provider supports the native Responses lifecycle and so resolves
+// previous_response_id itself. Without a provider inventory the field is
+// forwarded as before.
+func (s *translatedInferenceService) providerResolvesPreviousResponse(workflow *core.Workflow) bool {
+	if workflow == nil || workflow.ProviderType == "" {
+		return true
+	}
+	native, err := nativeResponseProviderTypes(s.provider)
+	if err != nil {
+		return true
+	}
+	return slices.Contains(native, workflow.ProviderType)
+}
+
+func previousResponseNotFound(id string) error {
+	return core.NewNotFoundError(fmt.Sprintf("Previous response with id '%s' not found.", id))
+}

--- a/internal/server/previous_response.go
+++ b/internal/server/previous_response.go
@@ -15,28 +15,23 @@ import (
 	"github.com/enterpilot/gomodel/internal/responsestore"
 )
 
-// applyResponsesPreviousResponse resolves previous_response_id for routes
-// whose provider cannot. A chat-translated provider keeps no response state,
-// so the referenced response is loaded from the gateway's response store and
-// its input items and output are prepended to the request input, the way a
-// gateway-managed conversation is; the field is stripped before dispatch. A
-// stored response's input items already carry the history it was chained
-// from, so one hop reconstructs the whole chain.
-//
-// A route whose primary and failover targets all support the native
-// Responses lifecycle keeps the id untouched, since those providers hold that
-// state themselves. When any target is chat-translated the history is
-// resolved up front, so a failover attempt never receives an id it cannot use.
-func (s *translatedInferenceService) applyResponsesPreviousResponse(ctx context.Context, req *core.ResponsesRequest, workflow *core.Workflow) (*core.ResponsesRequest, error) {
+// PatchResponsesAttempt resolves previous_response_id for an attempt whose
+// provider cannot. It runs once per dispatch attempt with that attempt's
+// provider type: a native Responses provider keeps the id untouched, since it
+// holds that state itself, while a chat-translated provider keeps no response
+// state, so the referenced response is loaded from the gateway's response
+// store and its input items and output are prepended to the request input,
+// the way a gateway-managed conversation is; the field is stripped before
+// dispatch. A stored response's input items already carry the history it was
+// chained from, so one hop reconstructs the whole chain. Deciding per attempt
+// keeps a native primary's request unchanged and still gives a translated
+// failover target a request it can serve.
+func (s *translatedInferenceService) PatchResponsesAttempt(ctx context.Context, req *core.ResponsesRequest, providerType string) (*core.ResponsesRequest, error) {
 	if req == nil {
 		return req, nil
 	}
 	id := strings.TrimSpace(req.PreviousResponseID)
-	if id == "" {
-		return req, nil
-	}
-	primaryNative := s.providerTypeResolvesPreviousResponse(workflow.ProviderType)
-	if primaryNative && !s.anyFailoverTargetTranslated(workflow) {
+	if id == "" || s.providerTypeResolvesPreviousResponse(providerType) {
 		return req, nil
 	}
 	store := s.currentResponseStore()
@@ -46,37 +41,9 @@ func (s *translatedInferenceService) applyResponsesPreviousResponse(ctx context.
 		return req, nil
 	}
 
-	// The predecessor's snapshot is written in the background; a client that
-	// chains as soon as it has the response must not race that write.
-	s.awaitPendingSnapshot(ctx, id)
-	stored, err := store.Get(ctx, id)
+	history, err := s.previousResponseHistory(ctx, store, id)
 	if err != nil {
-		if !errors.Is(err, responsestore.ErrNotFound) {
-			return req, core.NewProviderError("response_store", http.StatusInternalServerError, "failed to load previous response", err)
-		}
-		if primaryNative {
-			// Not tracked by the gateway; the native provider may still know it.
-			return req, nil
-		}
-		return req, previousResponseNotFound(id)
-	}
-	// Another tenant's response is indistinguishable from a missing one.
-	if stored == nil || stored.Response == nil || !core.AccessScopeFromContext(ctx).Allows(stored.UserPath) {
-		return req, previousResponseNotFound(id)
-	}
-
-	history := make([]json.RawMessage, 0, len(stored.InputItems)+len(stored.Response.Output))
-	history = append(history, stored.InputItems...)
-	for _, item := range stored.Response.Output {
-		item, ok := replayableOutputItem(item)
-		if !ok {
-			continue
-		}
-		raw, err := json.Marshal(item)
-		if err != nil {
-			return req, core.NewProviderError("response_store", http.StatusInternalServerError, "stored response output is not serializable", err)
-		}
-		history = append(history, raw)
+		return req, err
 	}
 	merged, err := mergeConversationInput(history, req.Input)
 	if err != nil {
@@ -87,6 +54,68 @@ func (s *translatedInferenceService) applyResponsesPreviousResponse(ctx context.
 	patched.Input = merged
 	patched.PreviousResponseID = ""
 	return &patched, nil
+}
+
+// maxPreviousResponseChain bounds the walk back through stored responses, so
+// a corrupted or adversarial chain cannot keep a request busy indefinitely.
+const maxPreviousResponseChain = 256
+
+// previousResponseHistory reconstructs the conversation behind a stored
+// response: each stored response holds only its own input items and output,
+// as OpenAI's input_items do, and links to its own predecessor, so the chain
+// is walked back to its root and replayed oldest first. The head must exist
+// for the caller; an ancestor that has expired or is out of scope ends the
+// walk, leaving the history that is still available.
+func (s *translatedInferenceService) previousResponseHistory(ctx context.Context, store responsestore.Store, id string) ([]json.RawMessage, error) {
+	var segments [][]json.RawMessage
+	seen := make(map[string]struct{})
+	for hop := 0; id != ""; hop++ {
+		if hop >= maxPreviousResponseChain {
+			return nil, core.NewInvalidRequestError(fmt.Sprintf("previous_response_id chain exceeds %d responses", maxPreviousResponseChain), nil)
+		}
+		if _, cyclic := seen[id]; cyclic {
+			break
+		}
+		seen[id] = struct{}{}
+
+		// The predecessor's snapshot is written in the background; a client
+		// that chains as soon as it has the response must not race that write.
+		s.awaitPendingSnapshot(ctx, id)
+		stored, err := store.Get(ctx, id)
+		if err != nil && !errors.Is(err, responsestore.ErrNotFound) {
+			return nil, core.NewProviderError("response_store", http.StatusInternalServerError, "failed to load previous response", err)
+		}
+		// Another tenant's response is indistinguishable from a missing one.
+		missing := err != nil || stored == nil || stored.Response == nil || !core.AccessScopeFromContext(ctx).Allows(stored.UserPath)
+		if missing {
+			if hop == 0 {
+				return nil, previousResponseNotFound(id)
+			}
+			break
+		}
+
+		segment := make([]json.RawMessage, 0, len(stored.InputItems)+len(stored.Response.Output))
+		segment = append(segment, stored.InputItems...)
+		for _, item := range stored.Response.Output {
+			item, ok := replayableOutputItem(item)
+			if !ok {
+				continue
+			}
+			raw, err := json.Marshal(item)
+			if err != nil {
+				return nil, core.NewProviderError("response_store", http.StatusInternalServerError, "stored response output is not serializable", err)
+			}
+			segment = append(segment, raw)
+		}
+		segments = append(segments, segment)
+		id = strings.TrimSpace(stored.Response.PreviousResponseID)
+	}
+
+	var history []json.RawMessage
+	for _, segment := range slices.Backward(segments) {
+		history = append(history, segment...)
+	}
+	return history, nil
 }
 
 // replayableOutputItem drops the output_text parts of a message that carry no
@@ -123,20 +152,6 @@ func (s *translatedInferenceService) providerTypeResolvesPreviousResponse(provid
 		return true
 	}
 	return slices.Contains(native, providerType)
-}
-
-// anyFailoverTargetTranslated reports whether a failover attempt could land
-// on a provider without the native Responses lifecycle.
-func (s *translatedInferenceService) anyFailoverTargetTranslated(workflow *core.Workflow) bool {
-	if s.orchestrator == nil {
-		return false
-	}
-	for _, selector := range s.orchestrator.FailoverSelectors(workflow) {
-		if !s.providerTypeResolvesPreviousResponse(s.provider.GetProviderType(selector.QualifiedModel())) {
-			return true
-		}
-	}
-	return false
 }
 
 func previousResponseNotFound(id string) error {

--- a/internal/server/previous_response.go
+++ b/internal/server/previous_response.go
@@ -48,7 +48,7 @@ func (s *translatedInferenceService) applyResponsesPreviousResponse(ctx context.
 
 	// The predecessor's snapshot is written in the background; a client that
 	// chains as soon as it has the response must not race that write.
-	s.awaitPendingSnapshot(ctx, id)
+	s.awaitPendingSnapshot(ctx, pendingSnapshotKey(ctx, id))
 	stored, err := store.Get(ctx, id)
 	if err != nil {
 		if !errors.Is(err, responsestore.ErrNotFound) {
@@ -143,35 +143,42 @@ func previousResponseNotFound(id string) error {
 	return core.NewNotFoundError(fmt.Sprintf("Previous response with id '%s' not found.", id))
 }
 
-// trackPendingSnapshot registers an in-flight snapshot write for a response
-// id, so a request chained on that id can wait for it.
-func (s *translatedInferenceService) trackPendingSnapshot(id string) chan struct{} {
+// pendingSnapshotKey scopes an in-flight snapshot write to the user path it
+// was written under, so a caller can only wait for its own tenant's writes
+// and learns nothing about another tenant's in-flight response ids.
+func pendingSnapshotKey(ctx context.Context, id string) string {
+	return core.UserPathFromContext(ctx) + "\x00" + id
+}
+
+// trackPendingSnapshot registers an in-flight snapshot write under key, so a
+// request chained on that response can wait for it.
+func (s *translatedInferenceService) trackPendingSnapshot(key string) chan struct{} {
 	done := make(chan struct{})
 	s.pendingSnapshotMu.Lock()
 	if s.pendingSnapshots == nil {
 		s.pendingSnapshots = make(map[string]chan struct{})
 	}
-	s.pendingSnapshots[id] = done
+	s.pendingSnapshots[key] = done
 	s.pendingSnapshotMu.Unlock()
 	return done
 }
 
 // finishPendingSnapshot releases the waiters of one snapshot write.
-func (s *translatedInferenceService) finishPendingSnapshot(id string, done chan struct{}) {
+func (s *translatedInferenceService) finishPendingSnapshot(key string, done chan struct{}) {
 	s.pendingSnapshotMu.Lock()
-	if s.pendingSnapshots[id] == done {
-		delete(s.pendingSnapshots, id)
+	if s.pendingSnapshots[key] == done {
+		delete(s.pendingSnapshots, key)
 	}
 	s.pendingSnapshotMu.Unlock()
 	close(done)
 }
 
-// awaitPendingSnapshot blocks until the snapshot write for id, if one is in
-// flight, has finished; it gives up with the request or after the write's
+// awaitPendingSnapshot blocks until the snapshot write under key, if one is
+// in flight, has finished; it gives up with the request or after the write's
 // own timeout, in which case the store lookup decides.
-func (s *translatedInferenceService) awaitPendingSnapshot(ctx context.Context, id string) {
+func (s *translatedInferenceService) awaitPendingSnapshot(ctx context.Context, key string) {
 	s.pendingSnapshotMu.Lock()
-	done := s.pendingSnapshots[id]
+	done := s.pendingSnapshots[key]
 	s.pendingSnapshotMu.Unlock()
 	if done == nil {
 		return

--- a/internal/server/previous_response.go
+++ b/internal/server/previous_response.go
@@ -48,7 +48,7 @@ func (s *translatedInferenceService) applyResponsesPreviousResponse(ctx context.
 
 	// The predecessor's snapshot is written in the background; a client that
 	// chains as soon as it has the response must not race that write.
-	s.awaitPendingSnapshot(ctx, pendingSnapshotKey(ctx, id))
+	s.awaitPendingSnapshot(ctx, id)
 	stored, err := store.Get(ctx, id)
 	if err != nil {
 		if !errors.Is(err, responsestore.ErrNotFound) {
@@ -143,50 +143,53 @@ func previousResponseNotFound(id string) error {
 	return core.NewNotFoundError(fmt.Sprintf("Previous response with id '%s' not found.", id))
 }
 
-// pendingSnapshotKey scopes an in-flight snapshot write to the user path it
-// was written under, so a caller can only wait for its own tenant's writes
-// and learns nothing about another tenant's in-flight response ids.
-func pendingSnapshotKey(ctx context.Context, id string) string {
-	return core.UserPathFromContext(ctx) + "\x00" + id
+// pendingSnapshot is one in-flight snapshot write: the user path it is
+// written under and the channel closed when it lands.
+type pendingSnapshot struct {
+	userPath string
+	done     chan struct{}
 }
 
-// trackPendingSnapshot registers an in-flight snapshot write under key, so a
-// request chained on that response can wait for it.
-func (s *translatedInferenceService) trackPendingSnapshot(key string) chan struct{} {
+// trackPendingSnapshot registers an in-flight snapshot write for a response
+// id, so a request chained on that response can wait for it.
+func (s *translatedInferenceService) trackPendingSnapshot(id, userPath string) chan struct{} {
 	done := make(chan struct{})
 	s.pendingSnapshotMu.Lock()
 	if s.pendingSnapshots == nil {
-		s.pendingSnapshots = make(map[string]chan struct{})
+		s.pendingSnapshots = make(map[string]pendingSnapshot)
 	}
-	s.pendingSnapshots[key] = done
+	s.pendingSnapshots[id] = pendingSnapshot{userPath: userPath, done: done}
 	s.pendingSnapshotMu.Unlock()
 	return done
 }
 
 // finishPendingSnapshot releases the waiters of one snapshot write.
-func (s *translatedInferenceService) finishPendingSnapshot(key string, done chan struct{}) {
+func (s *translatedInferenceService) finishPendingSnapshot(id string, done chan struct{}) {
 	s.pendingSnapshotMu.Lock()
-	if s.pendingSnapshots[key] == done {
-		delete(s.pendingSnapshots, key)
+	if s.pendingSnapshots[id].done == done {
+		delete(s.pendingSnapshots, id)
 	}
 	s.pendingSnapshotMu.Unlock()
 	close(done)
 }
 
-// awaitPendingSnapshot blocks until the snapshot write under key, if one is
-// in flight, has finished; it gives up with the request or after the write's
-// own timeout, in which case the store lookup decides.
-func (s *translatedInferenceService) awaitPendingSnapshot(ctx context.Context, key string) {
+// awaitPendingSnapshot blocks until the snapshot write for id, if one is in
+// flight, has finished; it gives up with the request or after the write's
+// own timeout, in which case the store lookup decides. Only a caller whose
+// access scope covers the write's user path waits, so a tenant learns
+// nothing about another tenant's in-flight response ids, while global and
+// parent scopes keep their race protection.
+func (s *translatedInferenceService) awaitPendingSnapshot(ctx context.Context, id string) {
 	s.pendingSnapshotMu.Lock()
-	done := s.pendingSnapshots[key]
+	pending, ok := s.pendingSnapshots[id]
 	s.pendingSnapshotMu.Unlock()
-	if done == nil {
+	if !ok || !core.AccessScopeFromContext(ctx).Allows(pending.userPath) {
 		return
 	}
 	timer := time.NewTimer(snapshotWriteTimeout)
 	defer timer.Stop()
 	select {
-	case <-done:
+	case <-pending.done:
 	case <-ctx.Done():
 	case <-timer.C:
 	}

--- a/internal/server/previous_response.go
+++ b/internal/server/previous_response.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/goccy/go-json"
 
@@ -18,16 +19,24 @@ import (
 // whose provider cannot. A chat-translated provider keeps no response state,
 // so the referenced response is loaded from the gateway's response store and
 // its input items and output are prepended to the request input, the way a
-// gateway-managed conversation is; the field is stripped before dispatch.
-// Native Responses providers keep receiving the id untouched, since they hold
-// that state themselves. A stored response's input items already carry the
-// history it was chained from, so one hop reconstructs the whole chain.
+// gateway-managed conversation is; the field is stripped before dispatch. A
+// stored response's input items already carry the history it was chained
+// from, so one hop reconstructs the whole chain.
+//
+// A route whose primary and failover targets all support the native
+// Responses lifecycle keeps the id untouched, since those providers hold that
+// state themselves. When any target is chat-translated the history is
+// resolved up front, so a failover attempt never receives an id it cannot use.
 func (s *translatedInferenceService) applyResponsesPreviousResponse(ctx context.Context, req *core.ResponsesRequest, workflow *core.Workflow) (*core.ResponsesRequest, error) {
 	if req == nil {
 		return req, nil
 	}
 	id := strings.TrimSpace(req.PreviousResponseID)
-	if id == "" || s.providerResolvesPreviousResponse(workflow) {
+	if id == "" {
+		return req, nil
+	}
+	primaryNative := s.providerTypeResolvesPreviousResponse(workflow.ProviderType)
+	if primaryNative && !s.anyFailoverTargetTranslated(workflow) {
 		return req, nil
 	}
 	store := s.currentResponseStore()
@@ -37,12 +46,19 @@ func (s *translatedInferenceService) applyResponsesPreviousResponse(ctx context.
 		return req, nil
 	}
 
+	// The predecessor's snapshot is written in the background; a client that
+	// chains as soon as it has the response must not race that write.
+	s.awaitPendingSnapshot(ctx, id)
 	stored, err := store.Get(ctx, id)
 	if err != nil {
-		if errors.Is(err, responsestore.ErrNotFound) {
-			return req, previousResponseNotFound(id)
+		if !errors.Is(err, responsestore.ErrNotFound) {
+			return req, core.NewProviderError("response_store", http.StatusInternalServerError, "failed to load previous response", err)
 		}
-		return req, core.NewProviderError("response_store", http.StatusInternalServerError, "failed to load previous response", err)
+		if primaryNative {
+			// Not tracked by the gateway; the native provider may still know it.
+			return req, nil
+		}
+		return req, previousResponseNotFound(id)
 	}
 	// Another tenant's response is indistinguishable from a missing one.
 	if stored == nil || stored.Response == nil || !core.AccessScopeFromContext(ctx).Allows(stored.UserPath) {
@@ -52,6 +68,10 @@ func (s *translatedInferenceService) applyResponsesPreviousResponse(ctx context.
 	history := make([]json.RawMessage, 0, len(stored.InputItems)+len(stored.Response.Output))
 	history = append(history, stored.InputItems...)
 	for _, item := range stored.Response.Output {
+		item, ok := replayableOutputItem(item)
+		if !ok {
+			continue
+		}
 		raw, err := json.Marshal(item)
 		if err != nil {
 			return req, core.NewProviderError("response_store", http.StatusInternalServerError, "stored response output is not serializable", err)
@@ -69,21 +89,98 @@ func (s *translatedInferenceService) applyResponsesPreviousResponse(ctx context.
 	return &patched, nil
 }
 
-// providerResolvesPreviousResponse reports whether the resolved route's
-// provider supports the native Responses lifecycle and so resolves
-// previous_response_id itself. Without a provider inventory the field is
-// forwarded as before.
-func (s *translatedInferenceService) providerResolvesPreviousResponse(workflow *core.Workflow) bool {
-	if workflow == nil || workflow.ProviderType == "" {
+// replayableOutputItem drops the output_text parts of a message that carry no
+// text, and the message itself when nothing is left: chat translation rejects
+// an empty text part, and an empty assistant turn adds nothing to the history.
+// Other item types (function calls, reasoning) are replayed unchanged.
+func replayableOutputItem(item core.ResponsesOutputItem) (core.ResponsesOutputItem, bool) {
+	if item.Type != "message" {
+		return item, true
+	}
+	content := make([]core.ResponsesContentItem, 0, len(item.Content))
+	for _, part := range item.Content {
+		if part.Type == "output_text" && part.Text == "" {
+			continue
+		}
+		content = append(content, part)
+	}
+	if len(content) == 0 {
+		return item, false
+	}
+	item.Content = content
+	return item, true
+}
+
+// providerTypeResolvesPreviousResponse reports whether a provider type
+// supports the native Responses lifecycle and so resolves previous_response_id
+// itself. Without a provider inventory the field is forwarded as before.
+func (s *translatedInferenceService) providerTypeResolvesPreviousResponse(providerType string) bool {
+	if providerType == "" {
 		return true
 	}
 	native, err := nativeResponseProviderTypes(s.provider)
 	if err != nil {
 		return true
 	}
-	return slices.Contains(native, workflow.ProviderType)
+	return slices.Contains(native, providerType)
+}
+
+// anyFailoverTargetTranslated reports whether a failover attempt could land
+// on a provider without the native Responses lifecycle.
+func (s *translatedInferenceService) anyFailoverTargetTranslated(workflow *core.Workflow) bool {
+	if s.orchestrator == nil {
+		return false
+	}
+	for _, selector := range s.orchestrator.FailoverSelectors(workflow) {
+		if !s.providerTypeResolvesPreviousResponse(s.provider.GetProviderType(selector.QualifiedModel())) {
+			return true
+		}
+	}
+	return false
 }
 
 func previousResponseNotFound(id string) error {
 	return core.NewNotFoundError(fmt.Sprintf("Previous response with id '%s' not found.", id))
+}
+
+// trackPendingSnapshot registers an in-flight snapshot write for a response
+// id, so a request chained on that id can wait for it.
+func (s *translatedInferenceService) trackPendingSnapshot(id string) chan struct{} {
+	done := make(chan struct{})
+	s.pendingSnapshotMu.Lock()
+	if s.pendingSnapshots == nil {
+		s.pendingSnapshots = make(map[string]chan struct{})
+	}
+	s.pendingSnapshots[id] = done
+	s.pendingSnapshotMu.Unlock()
+	return done
+}
+
+// finishPendingSnapshot releases the waiters of one snapshot write.
+func (s *translatedInferenceService) finishPendingSnapshot(id string, done chan struct{}) {
+	s.pendingSnapshotMu.Lock()
+	if s.pendingSnapshots[id] == done {
+		delete(s.pendingSnapshots, id)
+	}
+	s.pendingSnapshotMu.Unlock()
+	close(done)
+}
+
+// awaitPendingSnapshot blocks until the snapshot write for id, if one is in
+// flight, has finished; it gives up with the request or after the write's
+// own timeout, in which case the store lookup decides.
+func (s *translatedInferenceService) awaitPendingSnapshot(ctx context.Context, id string) {
+	s.pendingSnapshotMu.Lock()
+	done := s.pendingSnapshots[id]
+	s.pendingSnapshotMu.Unlock()
+	if done == nil {
+		return
+	}
+	timer := time.NewTimer(snapshotWriteTimeout)
+	defer timer.Stop()
+	select {
+	case <-done:
+	case <-ctx.Done():
+	case <-timer.C:
+	}
 }

--- a/internal/server/previous_response.go
+++ b/internal/server/previous_response.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/goccy/go-json"
 
@@ -22,10 +21,8 @@ import (
 // state, so the referenced response is loaded from the gateway's response
 // store and its input items and output are prepended to the request input,
 // the way a gateway-managed conversation is; the field is stripped before
-// dispatch. A stored response's input items already carry the history it was
-// chained from, so one hop reconstructs the whole chain. Deciding per attempt
-// keeps a native primary's request unchanged and still gives a translated
-// failover target a request it can serve.
+// dispatch. Deciding per attempt keeps a native primary's request unchanged
+// and still gives a translated failover target a request it can serve.
 func (s *translatedInferenceService) PatchResponsesAttempt(ctx context.Context, req *core.ResponsesRequest, providerType string) (*core.ResponsesRequest, error) {
 	if req == nil {
 		return req, nil
@@ -156,56 +153,4 @@ func (s *translatedInferenceService) providerTypeResolvesPreviousResponse(provid
 
 func previousResponseNotFound(id string) error {
 	return core.NewNotFoundError(fmt.Sprintf("Previous response with id '%s' not found.", id))
-}
-
-// pendingSnapshot is one in-flight snapshot write: the user path it is
-// written under and the channel closed when it lands.
-type pendingSnapshot struct {
-	userPath string
-	done     chan struct{}
-}
-
-// trackPendingSnapshot registers an in-flight snapshot write for a response
-// id, so a request chained on that response can wait for it.
-func (s *translatedInferenceService) trackPendingSnapshot(id, userPath string) chan struct{} {
-	done := make(chan struct{})
-	s.pendingSnapshotMu.Lock()
-	if s.pendingSnapshots == nil {
-		s.pendingSnapshots = make(map[string]pendingSnapshot)
-	}
-	s.pendingSnapshots[id] = pendingSnapshot{userPath: userPath, done: done}
-	s.pendingSnapshotMu.Unlock()
-	return done
-}
-
-// finishPendingSnapshot releases the waiters of one snapshot write.
-func (s *translatedInferenceService) finishPendingSnapshot(id string, done chan struct{}) {
-	s.pendingSnapshotMu.Lock()
-	if s.pendingSnapshots[id].done == done {
-		delete(s.pendingSnapshots, id)
-	}
-	s.pendingSnapshotMu.Unlock()
-	close(done)
-}
-
-// awaitPendingSnapshot blocks until the snapshot write for id, if one is in
-// flight, has finished; it gives up with the request or after the write's
-// own timeout, in which case the store lookup decides. Only a caller whose
-// access scope covers the write's user path waits, so a tenant learns
-// nothing about another tenant's in-flight response ids, while global and
-// parent scopes keep their race protection.
-func (s *translatedInferenceService) awaitPendingSnapshot(ctx context.Context, id string) {
-	s.pendingSnapshotMu.Lock()
-	pending, ok := s.pendingSnapshots[id]
-	s.pendingSnapshotMu.Unlock()
-	if !ok || !core.AccessScopeFromContext(ctx).Allows(pending.userPath) {
-		return
-	}
-	timer := time.NewTimer(snapshotWriteTimeout)
-	defer timer.Stop()
-	select {
-	case <-pending.done:
-	case <-ctx.Done():
-	case <-timer.C:
-	}
 }

--- a/internal/server/previous_response_test.go
+++ b/internal/server/previous_response_test.go
@@ -352,3 +352,52 @@ func TestApplyResponsesPreviousResponse_SkipsEmptyReplayText(t *testing.T) {
 		t.Fatalf("second item = %#v, want the function_call kept", items[1])
 	}
 }
+
+// TestResponsesWithPreviousResponseID_UntrackedIDWithTranslatedFailoverIsForwarded
+// keeps forwarding an id the gateway does not track when the primary provider
+// is native, even with a chat-translated failover configured: the native
+// provider may hold that response itself, and refusing up front would break a
+// valid request for the sake of a fallback that could not use it anyway.
+func TestResponsesWithPreviousResponseID_UntrackedIDWithTranslatedFailoverIsForwarded(t *testing.T) {
+	provider := previousResponseTestProvider(t, "openai")
+	provider.providerTypes["anthropic/claude"] = "anthropic"
+	provider.supportedModels = append(provider.supportedModels, "anthropic/claude")
+	handler := newHandler(provider, nil, nil, nil, nil, nil, failoverResolverStub{
+		selectors: []core.ModelSelector{{Provider: "anthropic", Model: "claude"}},
+	}, nil)
+	handler.SetResponseStore(responsestore.NewMemoryStore())
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-5-mini","input":"again?","previous_response_id":"resp_at_provider"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	if err := handler.Responses(echo.New().NewContext(req, rec)); err != nil {
+		t.Fatalf("handler.Responses() error = %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	if got := provider.capturedResponsesReq.PreviousResponseID; got != "resp_at_provider" {
+		t.Fatalf("native primary must still receive the untracked id, got %q", got)
+	}
+}
+
+// TestApplyResponsesPreviousResponse_PendingSnapshotIsScopedToTenant keeps
+// another tenant's in-flight write invisible: the caller does not wait on it.
+func TestApplyResponsesPreviousResponse_PendingSnapshotIsScopedToTenant(t *testing.T) {
+	s := &translatedInferenceService{provider: previousResponseTestProvider(t, "anthropic"), responseStore: responsestore.NewMemoryStore()}
+	ownerCtx := core.WithEffectiveUserPath(context.Background(), "/tenant-b")
+	done := s.trackPendingSnapshot(pendingSnapshotKey(ownerCtx, "resp_t"))
+	defer s.finishPendingSnapshot(pendingSnapshotKey(ownerCtx, "resp_t"), done)
+
+	foreignCtx := core.WithEffectiveUserPath(core.WithAccessScope(context.Background(), core.AccessScope{UserPath: "/tenant-a"}), "/tenant-a")
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		_, _ = s.applyResponsesPreviousResponse(foreignCtx, &core.ResponsesRequest{Model: "gpt-5-mini", Input: "x", PreviousResponseID: "resp_t"}, &core.Workflow{ProviderType: "anthropic"})
+	}()
+	select {
+	case <-finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("a foreign tenant's request waited on another tenant's pending snapshot")
+	}
+}

--- a/internal/server/previous_response_test.go
+++ b/internal/server/previous_response_test.go
@@ -194,9 +194,9 @@ func TestResponsesWithPreviousResponseID_UnknownIDReturns404(t *testing.T) {
 	}
 }
 
-// TestApplyResponsesPreviousResponse_ScopedTenantCannotChainAcrossScopes
+// TestPatchResponsesAttempt_ScopedTenantCannotChainAcrossScopes
 // reports another tenant's stored response exactly like a missing one.
-func TestApplyResponsesPreviousResponse_ScopedTenantCannotChainAcrossScopes(t *testing.T) {
+func TestPatchResponsesAttempt_ScopedTenantCannotChainAcrossScopes(t *testing.T) {
 	store := responsestore.NewMemoryStore()
 	defer func() { _ = store.Close() }()
 	if err := store.Create(context.Background(), &responsestore.StoredResponse{
@@ -373,7 +373,7 @@ func TestResponsesWithPreviousResponseID_ResolvedPerFailoverAttempt(t *testing.T
 	}
 }
 
-func TestApplyResponsesPreviousResponse_SkipsEmptyReplayText(t *testing.T) {
+func TestPatchResponsesAttempt_SkipsEmptyReplayText(t *testing.T) {
 	store := responsestore.NewMemoryStore()
 	defer func() { _ = store.Close() }()
 	if err := store.Create(context.Background(), &responsestore.StoredResponse{
@@ -402,39 +402,11 @@ func TestApplyResponsesPreviousResponse_SkipsEmptyReplayText(t *testing.T) {
 	}
 }
 
-// TestResponsesWithPreviousResponseID_UntrackedIDWithTranslatedFailoverIsForwarded
-// keeps forwarding an id the gateway does not track when the primary provider
-// is native, even with a chat-translated failover configured: the native
-// provider may hold that response itself, and refusing up front would break a
-// valid request for the sake of a fallback that could not use it anyway.
-func TestResponsesWithPreviousResponseID_UntrackedIDWithTranslatedFailoverIsForwarded(t *testing.T) {
-	provider := previousResponseTestProvider(t, "openai")
-	provider.providerTypes["anthropic/claude"] = "anthropic"
-	provider.supportedModels = append(provider.supportedModels, "anthropic/claude")
-	handler := newHandler(provider, nil, nil, nil, nil, nil, failoverResolverStub{
-		selectors: []core.ModelSelector{{Provider: "anthropic", Model: "claude"}},
-	}, nil)
-	handler.SetResponseStore(responsestore.NewMemoryStore())
-
-	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-5-mini","input":"again?","previous_response_id":"resp_at_provider"}`))
-	req.Header.Set("Content-Type", "application/json")
-	rec := httptest.NewRecorder()
-	if err := handler.Responses(echo.New().NewContext(req, rec)); err != nil {
-		t.Fatalf("handler.Responses() error = %v", err)
-	}
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d (%s)", rec.Code, rec.Body.String())
-	}
-	if got := provider.capturedResponsesReq.PreviousResponseID; got != "resp_at_provider" {
-		t.Fatalf("native primary must still receive the untracked id, got %q", got)
-	}
-}
-
-// TestApplyResponsesPreviousResponse_PendingSnapshotWaitFollowsAccessScope
+// TestPatchResponsesAttempt_PendingSnapshotWaitFollowsAccessScope
 // lets a caller wait on an in-flight write only when its access scope covers
 // the write's user path: a foreign tenant learns nothing from the wait, while
 // a globally scoped caller keeps its race protection.
-func TestApplyResponsesPreviousResponse_PendingSnapshotWaitFollowsAccessScope(t *testing.T) {
+func TestPatchResponsesAttempt_PendingSnapshotWaitFollowsAccessScope(t *testing.T) {
 	tests := []struct {
 		name     string
 		ctx      context.Context

--- a/internal/server/previous_response_test.go
+++ b/internal/server/previous_response_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -313,12 +314,16 @@ func (p *chainingFailoverProvider) Responses(ctx context.Context, req *core.Resp
 	return p.failoverProvider.Responses(ctx, req)
 }
 
-// TestResponsesWithPreviousResponseID_ResolvedPerFailoverAttempt keeps the id
-// on the native primary's request and hands the chat-translated failover
-// target the replayed history instead, so a failed native attempt does not
-// leave the fallback with an id it cannot use and a healthy native primary
-// never sees its request rewritten.
-func TestResponsesWithPreviousResponseID_ResolvedPerFailoverAttempt(t *testing.T) {
+func (p *chainingFailoverProvider) StreamResponses(ctx context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
+	p.requests[requestSelector(req.Model, req.Provider)] = req
+	return p.failoverProvider.StreamResponses(ctx, req)
+}
+
+// newChainingFailoverHandler builds a handler whose native primary fails with
+// 503 and whose chat-translated failover target succeeds, with one stored
+// response to chain on.
+func newChainingFailoverHandler(t *testing.T) (*Handler, *chainingFailoverProvider) {
+	t.Helper()
 	provider := &chainingFailoverProvider{
 		failoverProvider: &failoverProvider{
 			responsesErrors: map[string]error{
@@ -326,6 +331,9 @@ func TestResponsesWithPreviousResponseID_ResolvedPerFailoverAttempt(t *testing.T
 			},
 			responsesResponses: map[string]*core.ResponsesResponse{
 				"anthropic/claude": {ID: "resp_failover", Object: "response", Status: "completed", Output: []core.ResponsesOutputItem{}},
+			},
+			responsesStreams: map[string]string{
+				"anthropic/claude": "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_failover\",\"object\":\"response\",\"status\":\"completed\",\"output\":[]}}\n\ndata: [DONE]\n\n",
 			},
 			supportedModels: map[string]string{"gpt-5-mini": "openai", "anthropic/claude": "anthropic"},
 		},
@@ -346,16 +354,13 @@ func TestResponsesWithPreviousResponseID_ResolvedPerFailoverAttempt(t *testing.T
 	}); err != nil {
 		t.Fatalf("store: %v", err)
 	}
+	return handler, provider
+}
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-5-mini","input":"again?","previous_response_id":"resp_native"}`))
-	req.Header.Set("Content-Type", "application/json")
-	rec := httptest.NewRecorder()
-	if err := handler.Responses(echo.New().NewContext(req, rec)); err != nil {
-		t.Fatalf("handler.Responses() error = %v", err)
-	}
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d (%s)", rec.Code, rec.Body.String())
-	}
+// assertResolvedPerAttempt checks that the native primary received the id
+// untouched while the translated failover received the replayed history.
+func assertResolvedPerAttempt(t *testing.T, provider *chainingFailoverProvider) {
+	t.Helper()
 	primary := provider.requests["gpt-5-mini"]
 	if primary == nil || primary.PreviousResponseID != "resp_native" {
 		t.Fatalf("native primary request = %#v, want previous_response_id kept", primary)
@@ -370,6 +375,37 @@ func TestResponsesWithPreviousResponseID_ResolvedPerFailoverAttempt(t *testing.T
 	items, ok := fallback.Input.([]any)
 	if !ok || len(items) != 3 {
 		t.Fatalf("translated failover input = %#v, want replayed history + new input (3 items)", fallback.Input)
+	}
+}
+
+// TestResponsesWithPreviousResponseID_ResolvedPerFailoverAttempt keeps the id
+// on the native primary's request and hands the chat-translated failover
+// target the replayed history instead, so a failed native attempt does not
+// leave the fallback with an id it cannot use and a healthy native primary
+// never sees its request rewritten. Both dispatch paths go through the same
+// per-attempt hook.
+func TestResponsesWithPreviousResponseID_ResolvedPerFailoverAttempt(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(map[bool]string{false: "buffered", true: "streaming"}[stream], func(t *testing.T) {
+			handler, provider := newChainingFailoverHandler(t)
+			body := `{"model":"gpt-5-mini","input":"again?","previous_response_id":"resp_native"}`
+			if stream {
+				body = `{"model":"gpt-5-mini","input":"again?","previous_response_id":"resp_native","stream":true}`
+			}
+			req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			if err := handler.Responses(echo.New().NewContext(req, rec)); err != nil {
+				t.Fatalf("handler.Responses() error = %v", err)
+			}
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d (%s)", rec.Code, rec.Body.String())
+			}
+			if stream && !strings.Contains(rec.Body.String(), "response.completed") {
+				t.Fatalf("streaming fallback body = %s, want the fallback stream", rec.Body.String())
+			}
+			assertResolvedPerAttempt(t, provider)
+		})
 	}
 }
 

--- a/internal/server/previous_response_test.go
+++ b/internal/server/previous_response_test.go
@@ -77,6 +77,9 @@ func TestResponsesWithPreviousResponseID_ResolvesFromStoreForTranslatedProvider(
 	if rec.Code != http.StatusOK {
 		t.Fatalf("chained responses status = %d (%s)", rec.Code, rec.Body.String())
 	}
+	if !strings.Contains(rec.Body.String(), `"previous_response_id":"resp_conv_1"`) {
+		t.Fatalf("chained response must echo previous_response_id: %s", rec.Body.String())
+	}
 	forwarded := provider.capturedResponsesReq
 	if forwarded.PreviousResponseID != "" {
 		t.Fatalf("previous_response_id must be stripped before dispatch, got %q", forwarded.PreviousResponseID)
@@ -121,6 +124,18 @@ func TestResponsesWithPreviousResponseID_ChainCarriesFullHistory(t *testing.T) {
 	items := forwardedInputItems(t, provider.capturingProvider)
 	if len(items) != 5 {
 		t.Fatalf("turn three forwarded %d items, want 5 (two full turns + new input): %#v", len(items), items)
+	}
+	if text, _ := json.Marshal(items[2]["content"]); !strings.Contains(string(text), "turn two") {
+		t.Fatalf("history is not oldest first: %#v", items)
+	}
+
+	// Each snapshot keeps only its own input and links to its predecessor.
+	second, err := store.Get(context.Background(), "resp_conv_2")
+	if err != nil {
+		t.Fatalf("load turn two: %v", err)
+	}
+	if second.Response.PreviousResponseID != "resp_conv_1" || len(second.InputItems) != 1 {
+		t.Fatalf("turn two snapshot previous=%q input items=%d, want resp_conv_1 and 1", second.Response.PreviousResponseID, len(second.InputItems))
 	}
 }
 
@@ -195,16 +210,15 @@ func TestApplyResponsesPreviousResponse_ScopedTenantCannotChainAcrossScopes(t *t
 		t.Fatalf("store: %v", err)
 	}
 	s := &translatedInferenceService{provider: previousResponseTestProvider(t, "anthropic"), responseStore: store}
-	workflow := &core.Workflow{ProviderType: "anthropic"}
 	req := &core.ResponsesRequest{Model: "gpt-5-mini", Input: "again?", PreviousResponseID: "resp_t"}
 
 	foreign := core.WithAccessScope(context.Background(), core.AccessScope{UserPath: "/tenant-a"})
-	if _, err := s.applyResponsesPreviousResponse(foreign, req, workflow); err == nil || !strings.Contains(err.Error(), "not found") {
+	if _, err := s.PatchResponsesAttempt(foreign, req, "anthropic"); err == nil || !strings.Contains(err.Error(), "not found") {
 		t.Fatalf("foreign scope error = %v, want not found", err)
 	}
 
 	owner := core.WithAccessScope(context.Background(), core.AccessScope{UserPath: "/tenant-b"})
-	patched, err := s.applyResponsesPreviousResponse(owner, req, workflow)
+	patched, err := s.PatchResponsesAttempt(owner, req, "anthropic")
 	if err != nil {
 		t.Fatalf("owner scope: %v", err)
 	}
@@ -284,14 +298,40 @@ func TestResponsesWithPreviousResponseID_WaitsForPendingSnapshot(t *testing.T) {
 	}
 }
 
-// TestResponsesWithPreviousResponseID_TranslatedFailoverTargetResolvesUpFront
-// resolves the history before dispatch when a failover target is
-// chat-translated, so a failed native attempt does not hand the fallback an id
-// it cannot use.
-func TestResponsesWithPreviousResponseID_TranslatedFailoverTargetResolvesUpFront(t *testing.T) {
-	provider := previousResponseTestProvider(t, "openai")
-	provider.providerTypes["anthropic/claude"] = "anthropic"
-	provider.supportedModels = append(provider.supportedModels, "anthropic/claude")
+// chainingFailoverProvider records the request each attempt received and
+// reports which provider types resolve previous_response_id natively.
+type chainingFailoverProvider struct {
+	*failoverProvider
+	native   []string
+	requests map[string]*core.ResponsesRequest
+}
+
+func (p *chainingFailoverProvider) NativeResponseProviderTypes() []string { return p.native }
+
+func (p *chainingFailoverProvider) Responses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
+	p.requests[requestSelector(req.Model, req.Provider)] = req
+	return p.failoverProvider.Responses(ctx, req)
+}
+
+// TestResponsesWithPreviousResponseID_ResolvedPerFailoverAttempt keeps the id
+// on the native primary's request and hands the chat-translated failover
+// target the replayed history instead, so a failed native attempt does not
+// leave the fallback with an id it cannot use and a healthy native primary
+// never sees its request rewritten.
+func TestResponsesWithPreviousResponseID_ResolvedPerFailoverAttempt(t *testing.T) {
+	provider := &chainingFailoverProvider{
+		failoverProvider: &failoverProvider{
+			responsesErrors: map[string]error{
+				"gpt-5-mini": core.NewProviderError("openai", http.StatusServiceUnavailable, "model temporarily unavailable", nil),
+			},
+			responsesResponses: map[string]*core.ResponsesResponse{
+				"anthropic/claude": {ID: "resp_failover", Object: "response", Status: "completed", Output: []core.ResponsesOutputItem{}},
+			},
+			supportedModels: map[string]string{"gpt-5-mini": "openai", "anthropic/claude": "anthropic"},
+		},
+		native:   []string{"openai"},
+		requests: map[string]*core.ResponsesRequest{},
+	}
 	handler := newHandler(provider, nil, nil, nil, nil, nil, failoverResolverStub{
 		selectors: []core.ModelSelector{{Provider: "anthropic", Model: "claude"}},
 	}, nil)
@@ -316,11 +356,20 @@ func TestResponsesWithPreviousResponseID_TranslatedFailoverTargetResolvesUpFront
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d (%s)", rec.Code, rec.Body.String())
 	}
-	if provider.capturedResponsesReq.PreviousResponseID != "" {
-		t.Fatal("previous_response_id must be resolved up front when a failover target is chat-translated")
+	primary := provider.requests["gpt-5-mini"]
+	if primary == nil || primary.PreviousResponseID != "resp_native" {
+		t.Fatalf("native primary request = %#v, want previous_response_id kept", primary)
 	}
-	if items := forwardedInputItems(t, provider.capturingProvider); len(items) != 3 {
-		t.Fatalf("forwarded %d items, want 3", len(items))
+	if _, ok := primary.Input.(string); !ok {
+		t.Fatalf("native primary input must be untouched, got %#v", primary.Input)
+	}
+	fallback := provider.requests["anthropic/claude"]
+	if fallback == nil || fallback.PreviousResponseID != "" {
+		t.Fatalf("translated failover request = %#v, want previous_response_id resolved and stripped", fallback)
+	}
+	items, ok := fallback.Input.([]any)
+	if !ok || len(items) != 3 {
+		t.Fatalf("translated failover input = %#v, want replayed history + new input (3 items)", fallback.Input)
 	}
 }
 
@@ -340,7 +389,7 @@ func TestApplyResponsesPreviousResponse_SkipsEmptyReplayText(t *testing.T) {
 		t.Fatalf("store: %v", err)
 	}
 	s := &translatedInferenceService{provider: previousResponseTestProvider(t, "anthropic"), responseStore: store}
-	patched, err := s.applyResponsesPreviousResponse(context.Background(), &core.ResponsesRequest{Model: "gpt-5-mini", Input: "and?", PreviousResponseID: "resp_e"}, &core.Workflow{ProviderType: "anthropic"})
+	patched, err := s.PatchResponsesAttempt(context.Background(), &core.ResponsesRequest{Model: "gpt-5-mini", Input: "and?", PreviousResponseID: "resp_e"}, "anthropic")
 	if err != nil {
 		t.Fatalf("apply: %v", err)
 	}
@@ -403,7 +452,7 @@ func TestApplyResponsesPreviousResponse_PendingSnapshotWaitFollowsAccessScope(t 
 			finished := make(chan struct{})
 			go func() {
 				defer close(finished)
-				_, _ = s.applyResponsesPreviousResponse(tt.ctx, &core.ResponsesRequest{Model: "gpt-5-mini", Input: "x", PreviousResponseID: "resp_t"}, &core.Workflow{ProviderType: "anthropic"})
+				_, _ = s.PatchResponsesAttempt(tt.ctx, &core.ResponsesRequest{Model: "gpt-5-mini", Input: "x", PreviousResponseID: "resp_t"}, "anthropic")
 			}()
 			select {
 			case <-finished:

--- a/internal/server/previous_response_test.go
+++ b/internal/server/previous_response_test.go
@@ -1,0 +1,214 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/responsestore"
+)
+
+// translatedResponsesProvider routes every model to a provider type without
+// the native Responses lifecycle, the way Anthropic and Gemini are served.
+type translatedResponsesProvider struct {
+	*capturingProvider
+	native []string
+}
+
+func (p *translatedResponsesProvider) NativeResponseProviderTypes() []string { return p.native }
+
+func previousResponseTestProvider(t *testing.T, providerType string) *translatedResponsesProvider {
+	t.Helper()
+	inner := conversationTestProvider(t)
+	inner.providerTypes = map[string]string{"gpt-5-mini": providerType}
+	return &translatedResponsesProvider{capturingProvider: inner, native: []string{"openai"}}
+}
+
+func waitForStoredResponse(t *testing.T, store responsestore.Store, id string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := store.Get(context.Background(), id); err == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("response %s was not stored in time", id)
+}
+
+func forwardedInputItems(t *testing.T, provider *capturingProvider) []map[string]any {
+	t.Helper()
+	if provider.capturedResponsesReq == nil {
+		t.Fatal("provider did not receive a responses request")
+	}
+	raw, ok := provider.capturedResponsesReq.Input.([]any)
+	if !ok {
+		t.Fatalf("forwarded input = %#v, want []any", provider.capturedResponsesReq.Input)
+	}
+	items := make([]map[string]any, 0, len(raw))
+	for _, item := range raw {
+		m, ok := item.(map[string]any)
+		if !ok {
+			t.Fatalf("forwarded item = %#v, want object", item)
+		}
+		items = append(items, m)
+	}
+	return items
+}
+
+func TestResponsesWithPreviousResponseID_ResolvesFromStoreForTranslatedProvider(t *testing.T) {
+	provider := previousResponseTestProvider(t, "anthropic")
+	srv := New(provider, nil)
+
+	rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"remember: zebra"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first responses status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	waitForStoredResponse(t, srv.handler.currentResponseStore(), "resp_conv_1")
+
+	rec = postResponses(t, srv, `{"model":"gpt-5-mini","input":"what is the word?","previous_response_id":"resp_conv_1"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("chained responses status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	forwarded := provider.capturedResponsesReq
+	if forwarded.PreviousResponseID != "" {
+		t.Fatalf("previous_response_id must be stripped before dispatch, got %q", forwarded.PreviousResponseID)
+	}
+	items := forwardedInputItems(t, provider.capturingProvider)
+	if len(items) != 3 {
+		t.Fatalf("forwarded %d items, want previous input + previous output + new input: %#v", len(items), items)
+	}
+	if items[0]["role"] != "user" || items[1]["role"] != "assistant" || items[2]["role"] != "user" {
+		t.Fatalf("forwarded roles = %v/%v/%v, want user/assistant/user", items[0]["role"], items[1]["role"], items[2]["role"])
+	}
+	if _, hasID := items[0]["id"]; hasID {
+		t.Fatalf("stored item id must be stripped before dispatch, got %#v", items[0])
+	}
+	if text, _ := json.Marshal(items[1]["content"]); !strings.Contains(string(text), "the word is zebra") {
+		t.Fatalf("previous output not replayed: %#v", items[1])
+	}
+}
+
+// TestResponsesWithPreviousResponseID_ChainCarriesFullHistory covers a third
+// turn chained on the second: the stored input items of a chained response
+// already hold the history it was built from, so one hop replays all of it.
+func TestResponsesWithPreviousResponseID_ChainCarriesFullHistory(t *testing.T) {
+	provider := previousResponseTestProvider(t, "anthropic")
+	srv := New(provider, nil)
+	store := srv.handler.currentResponseStore()
+
+	if rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"turn one"}`); rec.Code != http.StatusOK {
+		t.Fatalf("turn one status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	waitForStoredResponse(t, store, "resp_conv_1")
+
+	provider.responsesResponse.ID = "resp_conv_2"
+	if rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"turn two","previous_response_id":"resp_conv_1"}`); rec.Code != http.StatusOK {
+		t.Fatalf("turn two status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	waitForStoredResponse(t, store, "resp_conv_2")
+
+	if rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"turn three","previous_response_id":"resp_conv_2"}`); rec.Code != http.StatusOK {
+		t.Fatalf("turn three status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	items := forwardedInputItems(t, provider.capturingProvider)
+	if len(items) != 5 {
+		t.Fatalf("turn three forwarded %d items, want 5 (two full turns + new input): %#v", len(items), items)
+	}
+}
+
+func TestResponsesWithPreviousResponseID_StreamingChainedTurn(t *testing.T) {
+	provider := previousResponseTestProvider(t, "anthropic")
+	provider.streamData = "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_s\",\"object\":\"response\",\"status\":\"completed\",\"output\":[]}}\n\ndata: [DONE]\n\n"
+	srv := New(provider, nil)
+
+	if rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"remember: zebra"}`); rec.Code != http.StatusOK {
+		t.Fatalf("first responses status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	waitForStoredResponse(t, srv.handler.currentResponseStore(), "resp_conv_1")
+
+	rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"again?","previous_response_id":"resp_conv_1","stream":true}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("chained streaming status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	if provider.capturedResponsesReq.PreviousResponseID != "" {
+		t.Fatal("previous_response_id must be stripped before a streaming dispatch")
+	}
+	if items := forwardedInputItems(t, provider.capturingProvider); len(items) != 3 {
+		t.Fatalf("streaming chained turn forwarded %d items, want 3", len(items))
+	}
+}
+
+func TestResponsesWithPreviousResponseID_NativeProviderKeepsForwarding(t *testing.T) {
+	provider := previousResponseTestProvider(t, "openai")
+	srv := New(provider, nil)
+
+	rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"hello","previous_response_id":"resp_native_1"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	forwarded := provider.capturedResponsesReq
+	if forwarded == nil || forwarded.PreviousResponseID != "resp_native_1" {
+		t.Fatalf("native provider must receive previous_response_id untouched, got %#v", forwarded)
+	}
+	if _, ok := forwarded.Input.(string); !ok {
+		t.Fatalf("native provider input must be untouched, got %#v", forwarded.Input)
+	}
+}
+
+func TestResponsesWithPreviousResponseID_UnknownIDReturns404(t *testing.T) {
+	provider := previousResponseTestProvider(t, "anthropic")
+	srv := New(provider, nil)
+
+	rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"hello","previous_response_id":"resp_missing"}`)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d (%s), want 404", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "Previous response with id 'resp_missing' not found.") {
+		t.Fatalf("body = %s, want OpenAI-shaped not-found message", rec.Body.String())
+	}
+	if provider.capturedResponsesReq != nil {
+		t.Fatal("a missing previous response must not reach the provider")
+	}
+}
+
+// TestApplyResponsesPreviousResponse_ScopedTenantCannotChainAcrossScopes
+// reports another tenant's stored response exactly like a missing one.
+func TestApplyResponsesPreviousResponse_ScopedTenantCannotChainAcrossScopes(t *testing.T) {
+	store := responsestore.NewMemoryStore()
+	defer func() { _ = store.Close() }()
+	if err := store.Create(context.Background(), &responsestore.StoredResponse{
+		Response: &core.ResponsesResponse{
+			ID: "resp_t", Object: "response", Status: "completed",
+			Output: []core.ResponsesOutputItem{{ID: "msg_1", Type: "message", Role: "assistant", Content: []core.ResponsesContentItem{{Type: "output_text", Text: "zebra"}}}},
+		},
+		InputItems: []json.RawMessage{json.RawMessage(`{"id":"in_1","type":"message","role":"user","content":[{"type":"input_text","text":"remember"}]}`)},
+		UserPath:   "/tenant-b",
+	}); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	s := &translatedInferenceService{provider: previousResponseTestProvider(t, "anthropic"), responseStore: store}
+	workflow := &core.Workflow{ProviderType: "anthropic"}
+	req := &core.ResponsesRequest{Model: "gpt-5-mini", Input: "again?", PreviousResponseID: "resp_t"}
+
+	foreign := core.WithAccessScope(context.Background(), core.AccessScope{UserPath: "/tenant-a"})
+	if _, err := s.applyResponsesPreviousResponse(foreign, req, workflow); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("foreign scope error = %v, want not found", err)
+	}
+
+	owner := core.WithAccessScope(context.Background(), core.AccessScope{UserPath: "/tenant-b"})
+	patched, err := s.applyResponsesPreviousResponse(owner, req, workflow)
+	if err != nil {
+		t.Fatalf("owner scope: %v", err)
+	}
+	if patched.PreviousResponseID != "" {
+		t.Fatalf("previous_response_id = %q, want stripped", patched.PreviousResponseID)
+	}
+	if items, ok := patched.Input.([]any); !ok || len(items) != 3 {
+		t.Fatalf("patched input = %#v, want 3 items", patched.Input)
+	}
+}

--- a/internal/server/previous_response_test.go
+++ b/internal/server/previous_response_test.go
@@ -381,23 +381,42 @@ func TestResponsesWithPreviousResponseID_UntrackedIDWithTranslatedFailoverIsForw
 	}
 }
 
-// TestApplyResponsesPreviousResponse_PendingSnapshotIsScopedToTenant keeps
-// another tenant's in-flight write invisible: the caller does not wait on it.
-func TestApplyResponsesPreviousResponse_PendingSnapshotIsScopedToTenant(t *testing.T) {
-	s := &translatedInferenceService{provider: previousResponseTestProvider(t, "anthropic"), responseStore: responsestore.NewMemoryStore()}
-	ownerCtx := core.WithEffectiveUserPath(context.Background(), "/tenant-b")
-	done := s.trackPendingSnapshot(pendingSnapshotKey(ownerCtx, "resp_t"))
-	defer s.finishPendingSnapshot(pendingSnapshotKey(ownerCtx, "resp_t"), done)
+// TestApplyResponsesPreviousResponse_PendingSnapshotWaitFollowsAccessScope
+// lets a caller wait on an in-flight write only when its access scope covers
+// the write's user path: a foreign tenant learns nothing from the wait, while
+// a globally scoped caller keeps its race protection.
+func TestApplyResponsesPreviousResponse_PendingSnapshotWaitFollowsAccessScope(t *testing.T) {
+	tests := []struct {
+		name     string
+		ctx      context.Context
+		wantWait bool
+	}{
+		{name: "foreign tenant does not wait", ctx: core.WithAccessScope(context.Background(), core.AccessScope{UserPath: "/tenant-a"}), wantWait: false},
+		{name: "global scope waits", ctx: context.Background(), wantWait: true},
+		{name: "owning tenant waits", ctx: core.WithAccessScope(context.Background(), core.AccessScope{UserPath: "/tenant-b"}), wantWait: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &translatedInferenceService{provider: previousResponseTestProvider(t, "anthropic"), responseStore: responsestore.NewMemoryStore()}
+			done := s.trackPendingSnapshot("resp_t", "/tenant-b")
 
-	foreignCtx := core.WithEffectiveUserPath(core.WithAccessScope(context.Background(), core.AccessScope{UserPath: "/tenant-a"}), "/tenant-a")
-	finished := make(chan struct{})
-	go func() {
-		defer close(finished)
-		_, _ = s.applyResponsesPreviousResponse(foreignCtx, &core.ResponsesRequest{Model: "gpt-5-mini", Input: "x", PreviousResponseID: "resp_t"}, &core.Workflow{ProviderType: "anthropic"})
-	}()
-	select {
-	case <-finished:
-	case <-time.After(2 * time.Second):
-		t.Fatal("a foreign tenant's request waited on another tenant's pending snapshot")
+			finished := make(chan struct{})
+			go func() {
+				defer close(finished)
+				_, _ = s.applyResponsesPreviousResponse(tt.ctx, &core.ResponsesRequest{Model: "gpt-5-mini", Input: "x", PreviousResponseID: "resp_t"}, &core.Workflow{ProviderType: "anthropic"})
+			}()
+			select {
+			case <-finished:
+				if tt.wantWait {
+					t.Fatal("request did not wait for the pending snapshot")
+				}
+			case <-time.After(150 * time.Millisecond):
+				if !tt.wantWait {
+					t.Fatal("request waited on a pending snapshot outside its access scope")
+				}
+			}
+			s.finishPendingSnapshot("resp_t", done)
+			<-finished
+		})
 	}
 }

--- a/internal/server/previous_response_test.go
+++ b/internal/server/previous_response_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/labstack/echo/v5"
 
 	"github.com/enterpilot/gomodel/internal/core"
 	"github.com/enterpilot/gomodel/internal/responsestore"
@@ -210,5 +213,142 @@ func TestApplyResponsesPreviousResponse_ScopedTenantCannotChainAcrossScopes(t *t
 	}
 	if items, ok := patched.Input.([]any); !ok || len(items) != 3 {
 		t.Fatalf("patched input = %#v, want 3 items", patched.Input)
+	}
+}
+
+func TestResponsesWithPreviousResponseID_StreamedPredecessorReturns404(t *testing.T) {
+	provider := previousResponseTestProvider(t, "anthropic")
+	provider.streamData = "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_s\",\"object\":\"response\",\"status\":\"completed\",\"output\":[]}}\n\ndata: [DONE]\n\n"
+	srv := New(provider, nil)
+
+	if rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"streamed","stream":true}`); rec.Code != http.StatusOK {
+		t.Fatalf("streaming status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	provider.capturedResponsesReq = nil
+
+	rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"again?","previous_response_id":"resp_s"}`)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d (%s), want 404: streamed responses are not stored", rec.Code, rec.Body.String())
+	}
+	if provider.capturedResponsesReq != nil {
+		t.Fatal("a chained turn on an unstored id must not reach the provider")
+	}
+}
+
+// heldSnapshotStore holds every Create until released, standing in for a
+// slow snapshot write.
+type heldSnapshotStore struct {
+	responsestore.Store
+	release chan struct{}
+}
+
+func (s *heldSnapshotStore) Create(ctx context.Context, response *responsestore.StoredResponse) error {
+	<-s.release
+	return s.Store.Create(ctx, response)
+}
+
+// TestResponsesWithPreviousResponseID_WaitsForPendingSnapshot chains on a
+// response whose snapshot write has not landed yet: the chained turn waits
+// for it instead of reporting the response missing.
+func TestResponsesWithPreviousResponseID_WaitsForPendingSnapshot(t *testing.T) {
+	provider := previousResponseTestProvider(t, "anthropic")
+	srv := New(provider, nil)
+	store := &heldSnapshotStore{Store: responsestore.NewMemoryStore(), release: make(chan struct{})}
+	srv.handler.SetResponseStore(store)
+
+	if rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"remember: zebra"}`); rec.Code != http.StatusOK {
+		t.Fatalf("first responses status = %d (%s)", rec.Code, rec.Body.String())
+	}
+
+	type outcome struct {
+		code int
+		body string
+	}
+	result := make(chan outcome, 1)
+	go func() {
+		rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"what is the word?","previous_response_id":"resp_conv_1"}`)
+		result <- outcome{rec.Code, rec.Body.String()}
+	}()
+	select {
+	case got := <-result:
+		t.Fatalf("chained turn finished before the snapshot was written: %d %s", got.code, got.body)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(store.release)
+	got := <-result
+	if got.code != http.StatusOK {
+		t.Fatalf("chained status = %d (%s), want 200 after the snapshot landed", got.code, got.body)
+	}
+	if items := forwardedInputItems(t, provider.capturingProvider); len(items) != 3 {
+		t.Fatalf("chained turn forwarded %d items, want 3", len(items))
+	}
+}
+
+// TestResponsesWithPreviousResponseID_TranslatedFailoverTargetResolvesUpFront
+// resolves the history before dispatch when a failover target is
+// chat-translated, so a failed native attempt does not hand the fallback an id
+// it cannot use.
+func TestResponsesWithPreviousResponseID_TranslatedFailoverTargetResolvesUpFront(t *testing.T) {
+	provider := previousResponseTestProvider(t, "openai")
+	provider.providerTypes["anthropic/claude"] = "anthropic"
+	provider.supportedModels = append(provider.supportedModels, "anthropic/claude")
+	handler := newHandler(provider, nil, nil, nil, nil, nil, failoverResolverStub{
+		selectors: []core.ModelSelector{{Provider: "anthropic", Model: "claude"}},
+	}, nil)
+	store := responsestore.NewMemoryStore()
+	handler.SetResponseStore(store)
+	if err := store.Create(context.Background(), &responsestore.StoredResponse{
+		Response: &core.ResponsesResponse{
+			ID: "resp_native", Object: "response", Status: "completed",
+			Output: []core.ResponsesOutputItem{{ID: "msg_1", Type: "message", Role: "assistant", Content: []core.ResponsesContentItem{{Type: "output_text", Text: "zebra"}}}},
+		},
+		InputItems: []json.RawMessage{json.RawMessage(`{"id":"in_1","type":"message","role":"user","content":[{"type":"input_text","text":"remember"}]}`)},
+	}); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-5-mini","input":"again?","previous_response_id":"resp_native"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	if err := handler.Responses(echo.New().NewContext(req, rec)); err != nil {
+		t.Fatalf("handler.Responses() error = %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	if provider.capturedResponsesReq.PreviousResponseID != "" {
+		t.Fatal("previous_response_id must be resolved up front when a failover target is chat-translated")
+	}
+	if items := forwardedInputItems(t, provider.capturingProvider); len(items) != 3 {
+		t.Fatalf("forwarded %d items, want 3", len(items))
+	}
+}
+
+func TestApplyResponsesPreviousResponse_SkipsEmptyReplayText(t *testing.T) {
+	store := responsestore.NewMemoryStore()
+	defer func() { _ = store.Close() }()
+	if err := store.Create(context.Background(), &responsestore.StoredResponse{
+		Response: &core.ResponsesResponse{
+			ID: "resp_e", Object: "response", Status: "completed",
+			Output: []core.ResponsesOutputItem{
+				{ID: "msg_1", Type: "message", Role: "assistant", Content: []core.ResponsesContentItem{{Type: "output_text", Text: ""}}},
+				{ID: "fc_1", Type: "function_call", CallID: "call_1", Name: "lookup", Arguments: "{}"},
+			},
+		},
+		InputItems: []json.RawMessage{json.RawMessage(`{"id":"in_1","type":"message","role":"user","content":[{"type":"input_text","text":"look it up"}]}`)},
+	}); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	s := &translatedInferenceService{provider: previousResponseTestProvider(t, "anthropic"), responseStore: store}
+	patched, err := s.applyResponsesPreviousResponse(context.Background(), &core.ResponsesRequest{Model: "gpt-5-mini", Input: "and?", PreviousResponseID: "resp_e"}, &core.Workflow{ProviderType: "anthropic"})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	items, _ := patched.Input.([]any)
+	if len(items) != 3 {
+		t.Fatalf("patched input has %d items, want input + function_call + new input (empty message dropped): %#v", len(items), patched.Input)
+	}
+	if call, _ := items[1].(map[string]any); call["type"] != "function_call" {
+		t.Fatalf("second item = %#v, want the function_call kept", items[1])
 	}
 }

--- a/internal/server/previous_response_test.go
+++ b/internal/server/previous_response_test.go
@@ -410,7 +410,7 @@ func TestApplyResponsesPreviousResponse_PendingSnapshotWaitFollowsAccessScope(t 
 				if tt.wantWait {
 					t.Fatal("request did not wait for the pending snapshot")
 				}
-			case <-time.After(150 * time.Millisecond):
+			case <-time.After(time.Second):
 				if !tt.wantWait {
 					t.Fatal("request waited on a pending snapshot outside its access scope")
 				}

--- a/internal/server/response_snapshot_pending.go
+++ b/internal/server/response_snapshot_pending.go
@@ -1,0 +1,60 @@
+package server
+
+import (
+	"context"
+	"time"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+// pendingSnapshot is one in-flight snapshot write: the user path it is
+// written under and the channel closed when it lands.
+type pendingSnapshot struct {
+	userPath string
+	done     chan struct{}
+}
+
+// trackPendingSnapshot registers an in-flight snapshot write for a response
+// id, so a request chained on that response can wait for it.
+func (s *translatedInferenceService) trackPendingSnapshot(id, userPath string) chan struct{} {
+	done := make(chan struct{})
+	s.pendingSnapshotMu.Lock()
+	if s.pendingSnapshots == nil {
+		s.pendingSnapshots = make(map[string]pendingSnapshot)
+	}
+	s.pendingSnapshots[id] = pendingSnapshot{userPath: userPath, done: done}
+	s.pendingSnapshotMu.Unlock()
+	return done
+}
+
+// finishPendingSnapshot releases the waiters of one snapshot write.
+func (s *translatedInferenceService) finishPendingSnapshot(id string, done chan struct{}) {
+	s.pendingSnapshotMu.Lock()
+	if s.pendingSnapshots[id].done == done {
+		delete(s.pendingSnapshots, id)
+	}
+	s.pendingSnapshotMu.Unlock()
+	close(done)
+}
+
+// awaitPendingSnapshot blocks until the snapshot write for id, if one is in
+// flight, has finished; it gives up with the request or after the write's
+// own timeout, in which case the store lookup decides. Only a caller whose
+// access scope covers the write's user path waits, so a tenant learns
+// nothing about another tenant's in-flight response ids, while global and
+// parent scopes keep their race protection.
+func (s *translatedInferenceService) awaitPendingSnapshot(ctx context.Context, id string) {
+	s.pendingSnapshotMu.Lock()
+	pending, ok := s.pendingSnapshots[id]
+	s.pendingSnapshotMu.Unlock()
+	if !ok || !core.AccessScopeFromContext(ctx).Allows(pending.userPath) {
+		return
+	}
+	timer := time.NewTimer(snapshotWriteTimeout)
+	defer timer.Stop()
+	select {
+	case <-pending.done:
+	case <-ctx.Done():
+	case <-timer.C:
+	}
+}

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -61,7 +61,7 @@ type translatedInferenceService struct {
 	snapshotDraining bool
 	// pendingSnapshots holds the in-flight snapshot write per response id, so
 	// a request chained on a just-returned response can wait for its snapshot.
-	pendingSnapshots  map[string]chan struct{}
+	pendingSnapshots  map[string]pendingSnapshot
 	pendingSnapshotMu sync.Mutex
 
 	orchestrator *gateway.InferenceOrchestrator
@@ -473,10 +473,9 @@ func (s *translatedInferenceService) storeResponseSnapshotAsync(ctx context.Cont
 	}
 
 	writeCtx := context.WithoutCancel(ctx)
-	pendingKey := pendingSnapshotKey(ctx, resp.ID)
-	pending := s.trackPendingSnapshot(pendingKey)
+	pending := s.trackPendingSnapshot(resp.ID, core.UserPathFromContext(ctx))
 	scheduled := s.goSnapshotWrite(func() {
-		defer s.finishPendingSnapshot(pendingKey, pending)
+		defer s.finishPendingSnapshot(resp.ID, pending)
 		writeCtx, cancel := context.WithTimeout(writeCtx, snapshotWriteTimeout)
 		defer cancel()
 		if err := snapshot.Persist(writeCtx, store); err != nil {
@@ -484,7 +483,7 @@ func (s *translatedInferenceService) storeResponseSnapshotAsync(ctx context.Cont
 		}
 	})
 	if !scheduled {
-		s.finishPendingSnapshot(pendingKey, pending)
+		s.finishPendingSnapshot(resp.ID, pending)
 		s.recordResponseSnapshotStoreFailure(failure, errors.New("server shutting down, snapshot write skipped"))
 	}
 }

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -59,6 +59,10 @@ type translatedInferenceService struct {
 	snapshotWrites   sync.WaitGroup
 	snapshotMu       sync.RWMutex
 	snapshotDraining bool
+	// pendingSnapshots holds the in-flight snapshot write per response id, so
+	// a request chained on a just-returned response can wait for its snapshot.
+	pendingSnapshots  map[string]chan struct{}
+	pendingSnapshotMu sync.Mutex
 
 	orchestrator *gateway.InferenceOrchestrator
 
@@ -469,7 +473,9 @@ func (s *translatedInferenceService) storeResponseSnapshotAsync(ctx context.Cont
 	}
 
 	writeCtx := context.WithoutCancel(ctx)
+	pending := s.trackPendingSnapshot(resp.ID)
 	scheduled := s.goSnapshotWrite(func() {
+		defer s.finishPendingSnapshot(resp.ID, pending)
 		writeCtx, cancel := context.WithTimeout(writeCtx, snapshotWriteTimeout)
 		defer cancel()
 		if err := snapshot.Persist(writeCtx, store); err != nil {
@@ -477,6 +483,7 @@ func (s *translatedInferenceService) storeResponseSnapshotAsync(ctx context.Cont
 		}
 	})
 	if !scheduled {
+		s.finishPendingSnapshot(resp.ID, pending)
 		s.recordResponseSnapshotStoreFailure(failure, errors.New("server shutting down, snapshot write skipped"))
 	}
 }

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -89,9 +89,12 @@ func (s *translatedInferenceService) newInferenceOrchestrator() *gateway.Inferen
 		FailoverResolver:         s.failoverResolver,
 		FailoverPolicy:           s.failoverPolicy,
 		TranslatedRequestPatcher: s.translatedRequestPatcher,
-		UsageLogger:              s.usageLogger,
-		PricingResolver:          s.pricingResolver,
-		GuardrailsHash:           s.guardrailsHash,
+		// previous_response_id is resolved per attempt, for targets that
+		// cannot resolve it themselves.
+		ResponsesAttemptPatcher: s,
+		UsageLogger:             s.usageLogger,
+		PricingResolver:         s.pricingResolver,
+		GuardrailsHash:          s.guardrailsHash,
 	}
 	// Guarded assignment keeps the gate nil when rate limits are off (a nil
 	// RateLimiter assigned unconditionally would arrive as a typed non-nil
@@ -272,11 +275,6 @@ func prepareResponsesRequest(
 	// Resolve gateway-managed conversations before caching and dispatch so the
 	// cache key reflects the merged history and providers never see local IDs.
 	ctx, preparedReq, err = s.applyResponsesConversation(ctx, preparedReq)
-	if err != nil {
-		return ctx, preparedReq, workflow, err
-	}
-	// Likewise for a previous_response_id the route's provider cannot resolve.
-	preparedReq, err = s.applyResponsesPreviousResponse(ctx, preparedReq, workflow)
 	return ctx, preparedReq, workflow, err
 }
 
@@ -421,6 +419,9 @@ func (s *translatedInferenceService) dispatchResponses(c *echo.Context, req *cor
 			))
 		}
 	}
+	// A chained response names its predecessor, as OpenAI's does: the client
+	// sees the link, and a later chained turn walks it to rebuild the history.
+	result.Response.PreviousResponseID = req.PreviousResponseID
 	s.storeResponseSnapshotAsync(ctx, workflow, req, result.Response, result.Meta.ProviderType, result.Meta.ProviderName, requestID)
 
 	applyPluginResponseHeaders(c)

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -268,6 +268,11 @@ func prepareResponsesRequest(
 	// Resolve gateway-managed conversations before caching and dispatch so the
 	// cache key reflects the merged history and providers never see local IDs.
 	ctx, preparedReq, err = s.applyResponsesConversation(ctx, preparedReq)
+	if err != nil {
+		return ctx, preparedReq, workflow, err
+	}
+	// Likewise for a previous_response_id the route's provider cannot resolve.
+	preparedReq, err = s.applyResponsesPreviousResponse(ctx, preparedReq, workflow)
 	return ctx, preparedReq, workflow, err
 }
 

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -473,9 +473,10 @@ func (s *translatedInferenceService) storeResponseSnapshotAsync(ctx context.Cont
 	}
 
 	writeCtx := context.WithoutCancel(ctx)
-	pending := s.trackPendingSnapshot(resp.ID)
+	pendingKey := pendingSnapshotKey(ctx, resp.ID)
+	pending := s.trackPendingSnapshot(pendingKey)
 	scheduled := s.goSnapshotWrite(func() {
-		defer s.finishPendingSnapshot(resp.ID, pending)
+		defer s.finishPendingSnapshot(pendingKey, pending)
 		writeCtx, cancel := context.WithTimeout(writeCtx, snapshotWriteTimeout)
 		defer cancel()
 		if err := snapshot.Persist(writeCtx, store); err != nil {
@@ -483,7 +484,7 @@ func (s *translatedInferenceService) storeResponseSnapshotAsync(ctx context.Cont
 		}
 	})
 	if !scheduled {
-		s.finishPendingSnapshot(resp.ID, pending)
+		s.finishPendingSnapshot(pendingKey, pending)
 		s.recordResponseSnapshotStoreFailure(failure, errors.New("server shutting down, snapshot write skipped"))
 	}
 }


### PR DESCRIPTION
`store=true` on Anthropic and Gemini persisted the response, but a follow-up with `previous_response_id` was rejected with "only supported by native Responses providers". The gateway now honors the chain for those providers.

- The gateway runs a per-attempt hook before every Responses dispatch, primary and failover alike, with that target's provider type. A native Responses provider receives `previous_response_id` untouched. For a chat-translated target the referenced response is loaded from the gateway's response store and the chain is walked back through each stored response's `previous_response_id`; the input items and output of every hop are prepended to the request input, oldest first, reusing the merge gateway-managed conversations use, and the field is stripped. Deciding per attempt keeps a native primary's request unchanged and still gives a translated failover a request it can serve.
- A chained response echoes `previous_response_id`, as OpenAI's does, and its snapshot keeps only its own input items plus that link.
- A chained request waits for its predecessor's background snapshot write when the caller's access scope covers it. An id that is not stored, or belongs to another tenant's user path, returns 404 with OpenAI's message shape on translated targets. Empty text parts are dropped from replay.
- Streaming responses are not stored, so a chain must start from a non-streaming response with `store` left on; the chained turn itself may stream.

User-visible impact: clients that chain turns the OpenAI way, such as the OpenAI Agents SDK, now work on chat-translated providers. Each chained turn re-sends the accumulated history, so long chains cost more input tokens than native server-side state. Verified live against Anthropic and Gemini through the OpenAI Python SDK, including a streamed chained turn and a two-hop chain.

Addresses F2 from the pre-release test findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for chaining Responses API requests with `previous_response_id`.
  - Chat-translated providers can rebuild prior conversation history from stored responses.
  - Native Responses providers continue receiving `previous_response_id` directly.
  - Responses now include the originating response ID when applicable.

- **Bug Fixes**
  - Improved handling across provider failover, tenant access checks, and pending response storage.
  - Added clearer not-found behavior for unavailable or inaccessible chained responses.

- **Documentation**
  - Documented response storage requirements, streaming limitations, provider compatibility, and conversation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->