### PR TITLE
fix(session): detect body session signals past the audit capture limit

### DIFF
--- a/docs/features/session-keeping.mdx
+++ b/docs/features/session-keeping.mdx
@@ -55,8 +55,11 @@ The first matching signal wins:
    history (Aider, Cline, Continue, …) still gets a stable session id
    (`auto-…`) with no client changes.
 
-Body-based signals and automatic detection read request bodies up to 1 MiB
-(chunked requests included); larger bodies fall back to header signals.
+Body-based signals and automatic detection read the complete JSON body of
+chat, responses, and messages requests (chunked requests included), so a long
+conversation keeps its session id as its context grows. Only provider
+passthrough bodies are peeked up to 1 MiB; larger passthrough bodies fall back
+to header signals.
 
 Client-provided session ids are scoped by [user path](/features/user-path),
 including UUID-shaped values, so one tenant cannot collide with another by

--- a/internal/server/request_snapshot.go
+++ b/internal/server/request_snapshot.go
@@ -175,19 +175,33 @@ func captureSmallRequestBodyForSnapshot(req *http.Request, bodyMode core.BodyMod
 	if bodyBytes == nil {
 		bodyBytes = []byte{}
 	}
-	body := &bytesReadCloser{}
-	body.Reset(bodyBytes)
-	req.Body = body
+	req.Body = newBytesReadCloser(bodyBytes)
 	return bodyBytes, false, true, nil
 }
 
 // bytesReadCloser is io.NopCloser(bytes.NewReader(b)) in one allocation
-// instead of two; it keeps bytes.Reader's WriteTo for efficient copies.
+// instead of two; it keeps bytes.Reader's WriteTo for efficient copies and
+// remembers its buffer so a handler can take the bytes without re-reading.
 type bytesReadCloser struct {
 	bytes.Reader
+	body []byte
+}
+
+func newBytesReadCloser(body []byte) *bytesReadCloser {
+	b := &bytesReadCloser{body: body}
+	b.Reset(body)
+	return b
 }
 
 func (*bytesReadCloser) Close() error { return nil }
+
+// unread returns the whole buffer while nothing has been read from it yet.
+func (b *bytesReadCloser) unread() ([]byte, bool) {
+	if b == nil || b.Len() != len(b.body) {
+		return nil, false
+	}
+	return b.body, true
+}
 
 func shouldCaptureSmallRequestBody(req *http.Request, bodyMode core.BodyMode) bool {
 	if req == nil || req.Body == nil {
@@ -234,6 +248,14 @@ func requestBodyBytes(c *echo.Context) ([]byte, error) {
 		return []byte{}, nil
 	}
 
+	// A body the session middleware materialized past the audit capture limit
+	// is replayed from memory; hand that buffer out instead of copying it.
+	if replay, ok := req.Body.(*bytesReadCloser); ok {
+		if body, ok := replay.unread(); ok {
+			return body, nil
+		}
+	}
+
 	bodyBytes, err := io.ReadAll(req.Body)
 	if err != nil {
 		return nil, err
@@ -246,14 +268,19 @@ func requestBodyBytes(c *echo.Context) ([]byte, error) {
 	return bodyBytes, nil
 }
 
-func storeRequestBodySnapshot(c *echo.Context, bodyBytes []byte) {
+// storeRequestBodySnapshot records the fully read body on the request snapshot
+// and refreshes the white-box prompt semantics from it. The audit capture on
+// the shared snapshot stops at MaxBodyCapture; the returned snapshot always
+// carries the complete body so callers such as session detection can read an
+// oversized one. It returns nil when the request has no snapshot.
+func storeRequestBodySnapshot(c *echo.Context, bodyBytes []byte) *core.RequestSnapshot {
 	if c == nil {
-		return
+		return nil
 	}
 	req := c.Request()
 	snapshot := core.GetRequestSnapshot(req.Context())
 	if snapshot == nil {
-		return
+		return nil
 	}
 
 	bodyNotCaptured := int64(len(bodyBytes)) > auditlog.MaxBodyCapture
@@ -265,12 +292,13 @@ func storeRequestBodySnapshot(c *echo.Context, bodyBytes []byte) {
 	updated := snapshot.WithOwnedCapturedBody(capturedBody, bodyNotCaptured)
 	ctx := core.WithRequestSnapshot(req.Context(), updated)
 	previous := core.GetWhiteBoxPrompt(req.Context())
-	semanticSnapshot := updated
+	complete := updated
 	if bodyNotCaptured {
-		semanticSnapshot = snapshot.WithOwnedCapturedBody(bodyBytes, false)
+		complete = snapshot.WithOwnedCapturedBody(bodyBytes, false)
 	}
-	if semantics := core.RefreshWhiteBoxPrompt(semanticSnapshot, previous); semantics != nil {
+	if semantics := core.RefreshWhiteBoxPrompt(complete, previous); semantics != nil {
 		ctx = core.WithWhiteBoxPrompt(ctx, semantics)
 	}
 	c.SetRequest(req.WithContext(ctx))
+	return complete
 }

--- a/internal/server/session.go
+++ b/internal/server/session.go
@@ -56,8 +56,8 @@ func sessionCapture(detector *session.Detector, parentLookup interactionParentLo
 			}
 
 			// Header rules do not need the body. Resolve them first so an
-			// explicit session header keeps large/chunked requests on the
-			// zero-copy path.
+			// explicit session header keeps large/chunked requests off the
+			// materialization below.
 			if detectAndStamp(snapshot) {
 				return next(c)
 			}
@@ -65,7 +65,7 @@ func sessionCapture(detector *session.Detector, parentLookup interactionParentLo
 			var err error
 			snapshot, err = sessionDetectionSnapshot(c, snapshot)
 			if err != nil {
-				return handleError(c, core.NewInvalidRequestError("failed to read request body", err))
+				return handleError(c, bodyReadError(err))
 			}
 			detectAndStamp(snapshot)
 			return next(c)
@@ -101,19 +101,58 @@ func interactionParentSession(c *echo.Context, lookup interactionParentLookup, a
 }
 
 // sessionDetectionSnapshot returns a snapshot whose complete body is available
-// for session detection, up to MaxBodyCapture. It never reads a known-oversized
-// body and peeks only limit+1 bytes from an unknown-length body. Oversized
-// bodies are replayed intact for the handler and fall back to header signals.
+// for session detection. JSON endpoints materialize the whole body: the handler
+// decodes every byte of it anyway and the server's body size limit already
+// bounds the read, so a long conversation keeps its body signals and
+// content-derived id past the audit capture limit. Opaque bodies are forwarded
+// upstream as a stream, so they are only peeked up to MaxBodyCapture and
+// replayed intact; larger ones fall back to header signals.
 func sessionDetectionSnapshot(c *echo.Context, snapshot *core.RequestSnapshot) (*core.RequestSnapshot, error) {
-	switch core.DescribeEndpoint(snapshot.Method, snapshot.Path).BodyMode {
-	case core.BodyModeJSON, core.BodyModeOpaque:
-	default:
-		return snapshot, nil
-	}
 	req := c.Request()
 	if req.Body == nil {
 		return snapshot, nil
 	}
+	switch core.DescribeEndpoint(snapshot.Method, snapshot.Path).BodyMode {
+	case core.BodyModeJSON:
+		return materializeSessionBody(c, snapshot)
+	case core.BodyModeOpaque:
+		return peekSessionBody(c, snapshot)
+	default:
+		return snapshot, nil
+	}
+}
+
+// materializeSessionBody reads the complete JSON body once, replays it from
+// memory for the handler, and returns a snapshot carrying every byte for
+// detection. The audit capture on the shared snapshot still stops at
+// MaxBodyCapture; only the detection view sees an oversized body.
+func materializeSessionBody(c *echo.Context, snapshot *core.RequestSnapshot) (*core.RequestSnapshot, error) {
+	req := c.Request()
+	originalBody := req.Body
+	body, err := io.ReadAll(originalBody)
+	if err != nil {
+		// Preserve the bytes already consumed even though this request will be
+		// rejected, keeping the helper's ownership contract explicit.
+		req.Body = &combinedReadCloser{
+			Reader: io.MultiReader(bytes.NewReader(body), originalBody),
+			rc:     originalBody,
+		}
+		return snapshot, err
+	}
+	// The server owns the original body and closes it after the handler;
+	// requestBodyBytes hands this buffer to the handler without another copy.
+	req.Body = newBytesReadCloser(body)
+	if complete := storeRequestBodySnapshot(c, body); complete != nil {
+		return complete, nil
+	}
+	return snapshot, nil
+}
+
+// peekSessionBody reads an opaque body up to MaxBodyCapture for detection and
+// replays it intact. It never reads a known-oversized body and peeks only
+// limit+1 bytes from an unknown-length one.
+func peekSessionBody(c *echo.Context, snapshot *core.RequestSnapshot) (*core.RequestSnapshot, error) {
+	req := c.Request()
 	if req.ContentLength > auditlog.MaxBodyCapture {
 		return markSessionBodyNotCaptured(c, snapshot), nil
 	}
@@ -121,8 +160,6 @@ func sessionDetectionSnapshot(c *echo.Context, snapshot *core.RequestSnapshot) (
 	originalBody := req.Body
 	body, err := io.ReadAll(io.LimitReader(originalBody, auditlog.MaxBodyCapture+1))
 	if err != nil {
-		// Preserve the bytes already consumed even though this request will be
-		// rejected, keeping the helper's ownership contract explicit.
 		req.Body = &combinedReadCloser{
 			Reader: io.MultiReader(bytes.NewReader(body), originalBody),
 			rc:     originalBody,
@@ -140,11 +177,20 @@ func sessionDetectionSnapshot(c *echo.Context, snapshot *core.RequestSnapshot) (
 	// The full body fit. Cache it on the shared snapshot and replay the same
 	// bytes to downstream code without another read or allocation.
 	req.Body = &combinedReadCloser{Reader: bytes.NewReader(body), rc: originalBody}
-	storeRequestBodySnapshot(c, body)
-	if refreshed := core.GetRequestSnapshot(c.Request().Context()); refreshed != nil {
-		return refreshed, nil
+	if complete := storeRequestBodySnapshot(c, body); complete != nil {
+		return complete, nil
 	}
 	return snapshot, nil
+}
+
+// bodyReadError shapes a failed request body read. The body size limit
+// reports its 413 on the error itself; anything else is a client that stopped
+// sending.
+func bodyReadError(err error) error {
+	if echo.StatusCode(err) > 0 {
+		return escapedGatewayError(err)
+	}
+	return core.NewInvalidRequestError("failed to read request body", err)
 }
 
 func markSessionBodyNotCaptured(c *echo.Context, snapshot *core.RequestSnapshot) *core.RequestSnapshot {

--- a/internal/server/session_test.go
+++ b/internal/server/session_test.go
@@ -16,9 +16,19 @@ import (
 	"github.com/enterpilot/gomodel/internal/session"
 )
 
+// partialErrorReadCloser yields data once, then fails with err (a generic
+// failure when unset).
 type partialErrorReadCloser struct {
 	data []byte
+	err  error
 	read bool
+}
+
+func (r *partialErrorReadCloser) failure() error {
+	if r.err != nil {
+		return r.err
+	}
+	return errors.New("injected request body failure")
 }
 
 type sessionLiveEvent struct {
@@ -48,11 +58,11 @@ func (p *sessionLivePublisher) PublishLiveEvent(eventType string, entry *auditlo
 
 func (r *partialErrorReadCloser) Read(p []byte) (int, error) {
 	if r.read {
-		return 0, errors.New("injected request body failure")
+		return 0, r.failure()
 	}
 	r.read = true
 	n := copy(p, r.data)
-	return n, errors.New("injected request body failure")
+	return n, r.failure()
 }
 
 func (r *partialErrorReadCloser) Close() error {
@@ -399,14 +409,101 @@ func TestSessionCaptureMaterializesChunkedBody(t *testing.T) {
 	}
 }
 
-func TestSessionCaptureDoesNotPreReadKnownOversizedBody(t *testing.T) {
+// JSON bodies past the audit capture limit still carry session signals: the
+// handler decodes the whole body anyway, so detection reads it once and the
+// handler reuses the same buffer. Only the audit capture stays bounded.
+func TestSessionCaptureDetectsBodySignalPastAuditCaptureLimit(t *testing.T) {
+	detector := session.NewDetector(session.BuiltinRules(), true)
+	padding := strings.Repeat("x", int(auditlog.MaxBodyCapture))
+	bodyText := `{"model":"gpt-4o","messages":[{"role":"user","content":"` + padding + `"}],"session_id":"huge-body-session"}`
+	body := &countingReadCloser{reader: strings.NewReader(bodyText)}
+
+	c, _ := sessionBodyTestContext(
+		t,
+		"/v1/chat/completions",
+		body,
+		int64(len(bodyText)),
+		true,
+	)
+
+	var got string
+	handler := sessionCapture(detector, nil, false)(func(c *echo.Context) error {
+		got = core.SessionIDFromContext(c.Request().Context())
+		if body.read != int64(len(bodyText)) {
+			t.Fatalf("session detection read = %d, want the complete body %d", body.read, len(bodyText))
+		}
+
+		snapshot := core.GetRequestSnapshot(c.Request().Context())
+		if snapshot == nil || !snapshot.BodyNotCaptured || snapshot.CapturedBodyView() != nil {
+			t.Fatal("audit capture must stay bounded for an oversized body")
+		}
+
+		first, err := requestBodyBytes(c)
+		if err != nil {
+			t.Fatalf("handler body read: %v", err)
+		}
+		if string(first) != bodyText {
+			t.Fatal("handler did not receive the complete body")
+		}
+		second, err := requestBodyBytes(c)
+		if err != nil {
+			t.Fatalf("second handler body read: %v", err)
+		}
+		if &first[0] != &second[0] {
+			t.Fatal("handler copied the materialized body instead of reusing it")
+		}
+		if body.read != int64(len(bodyText)) {
+			t.Fatalf("source read again by handler: %d bytes", body.read)
+		}
+		return nil
+	})
+	if err := handler(c); err != nil {
+		t.Fatalf("handler error = %v", err)
+	}
+	if got != "huge-body-session" {
+		t.Fatalf("session id = %q, want body signal from an oversized body", got)
+	}
+}
+
+func TestSessionCaptureAutoDetectsChunkedBodyPastAuditCaptureLimit(t *testing.T) {
+	detector := session.NewDetector(session.BuiltinRules(), true)
+	padding := strings.Repeat("x", int(auditlog.MaxBodyCapture))
+	bodyText := `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":"` + padding + `"}]}`
+	body := &countingReadCloser{reader: strings.NewReader(bodyText)}
+
+	c, _ := sessionBodyTestContext(t, "/v1/chat/completions", body, -1, false)
+
+	var got string
+	handler := sessionCapture(detector, nil, false)(func(c *echo.Context) error {
+		got = core.SessionIDFromContext(c.Request().Context())
+		remaining, err := io.ReadAll(c.Request().Body)
+		if err != nil {
+			t.Fatalf("handler body read: %v", err)
+		}
+		if string(remaining) != bodyText {
+			t.Fatal("materialized body was not replayed intact")
+		}
+		return nil
+	})
+	if err := handler(c); err != nil {
+		t.Fatalf("handler error = %v", err)
+	}
+	if !strings.HasPrefix(got, "auto-") {
+		t.Fatalf("session id = %q, want content-derived id from an oversized chunked body", got)
+	}
+}
+
+// Opaque bodies are streamed upstream, so detection only peeks them: a
+// known-oversized body is never read ahead of the handler and an
+// unknown-length one is bounded and replayed intact.
+func TestSessionCaptureDoesNotPreReadKnownOversizedOpaqueBody(t *testing.T) {
 	detector := session.NewDetector(session.BuiltinRules(), true)
 	bodyText := strings.Repeat("x", int(auditlog.MaxBodyCapture)+1)
 	body := &countingReadCloser{reader: strings.NewReader(bodyText)}
 
 	c, _ := sessionBodyTestContext(
 		t,
-		"/v1/chat/completions",
+		"/p/openai/v1/chat/completions",
 		body,
 		int64(len(bodyText)),
 		true,
@@ -430,14 +527,14 @@ func TestSessionCaptureDoesNotPreReadKnownOversizedBody(t *testing.T) {
 	}
 }
 
-func TestSessionCaptureBoundsUnknownOversizedBodyAndReplaysIt(t *testing.T) {
+func TestSessionCaptureBoundsUnknownOversizedOpaqueBodyAndReplaysIt(t *testing.T) {
 	detector := session.NewDetector(session.BuiltinRules(), true)
 	bodyText := strings.Repeat("x", int(auditlog.MaxBodyCapture)+128)
 	body := &countingReadCloser{reader: strings.NewReader(bodyText)}
 
 	c, _ := sessionBodyTestContext(
 		t,
-		"/v1/chat/completions",
+		"/p/openai/v1/chat/completions",
 		body,
 		-1,
 		false,
@@ -458,6 +555,30 @@ func TestSessionCaptureBoundsUnknownOversizedBodyAndReplaysIt(t *testing.T) {
 	})
 	if err := handler(c); err != nil {
 		t.Fatalf("handler error = %v", err)
+	}
+}
+
+// The body size limit trips while detection materializes a chunked JSON body;
+// the client must still see the limit's 413, not a generic read failure.
+func TestSessionCaptureKeepsBodyLimitStatus(t *testing.T) {
+	detector := session.NewDetector(session.BuiltinRules(), true)
+	body := &partialErrorReadCloser{data: []byte(`{"model":"gpt-4o"`), err: echo.ErrStatusRequestEntityTooLarge}
+
+	c, rec := sessionBodyTestContext(t, "/v1/chat/completions", body, -1, false)
+
+	called := false
+	handler := sessionCapture(detector, nil, false)(func(c *echo.Context) error {
+		called = true
+		return nil
+	})
+	if err := handler(c); err != nil {
+		t.Fatalf("handler error = %v", err)
+	}
+	if called {
+		t.Fatal("downstream handler called after the body limit tripped")
+	}
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusRequestEntityTooLarge)
 	}
 }
 


### PR DESCRIPTION
## Why

Session detection only read request bodies up to the 1 MiB audit capture limit. A larger JSON body was marked not captured, so body signals (`session_id`, `metadata.user_id`, `prompt_cache_key`, `conversation`) and the content-derived `auto-…` id were skipped unless the client sent a session header. A long coding-agent conversation lost its session id exactly when its context grew, which dropped `x-opencode-session` on OpenCode Go (raised in https://github.com/ENTERPILOT/GoModel/pull/873#issuecomment-5631394512), broke sticky key and virtual-model routing, and split the conversation's audit thread and cache session.

## What

- JSON inference requests materialize the complete body for detection. The handler decodes every byte anyway and the body size limit already bounds the read, so the audit capture stays at 1 MiB while detection sees the whole body.
- The materialized buffer is handed to the handler without a second copy.
- Provider passthrough bodies keep the bounded 1 MiB peek since they are streamed upstream.
- A body size limit tripped during detection still answers 413 instead of a generic 400.

## Docs

Session-keeping page updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Session detection now reads complete JSON request bodies, including chunked requests, so session context remains available in longer conversations.
  - Oversized JSON requests can still be processed while preserving session signals.
  - Provider passthrough bodies continue using limited inspection and fall back to header-based signals when they exceed the limit.
  - Request size-limit errors continue to return the appropriate 413 response.

- **Documentation**
  - Updated session-keeping documentation to describe full-body JSON detection and passthrough behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->