### PR TITLE
fix(errors): include provider names in routed failures

### DIFF
--- a/docs/advanced/resilience.mdx
+++ b/docs/advanced/resilience.mdx
@@ -96,7 +96,7 @@ relied on rate limits leaving the breaker closed can set
 `failure_on_statuses: [5xx]` to retain that behavior.
 
 While the circuit is open, requests fail fast with a `503` and the message
-`circuit breaker is open - provider temporarily unavailable`. After
+`circuit breaker is open - provider <name> temporarily unavailable`. After
 `timeout` elapses, a single probe request is let through while concurrent
 requests keep failing fast; `success_threshold` consecutive successful
 probes close the circuit, and a failure matching the breaker policy reopens it. Probes make only one

--- a/internal/llmclient/client_scope.go
+++ b/internal/llmclient/client_scope.go
@@ -46,7 +46,8 @@ func (c *Client) beginRequest(ctx context.Context, req Request, stream bool) (re
 
 	scope.breaker = c.breakerForModel(scope.requestInfo.Model)
 	if scope.breaker == nil && c.circuitBreaker != nil {
-		err := core.NewProviderError(c.config.ProviderName, http.StatusServiceUnavailable, "model circuit breaker capacity exhausted", nil)
+		err := core.NewProviderError(c.config.ProviderName, http.StatusServiceUnavailable,
+			"model circuit breaker capacity exhausted for provider "+c.config.ProviderName, nil)
 		c.finishRequest(scope, http.StatusServiceUnavailable, err)
 		return requestScope{}, err
 	}
@@ -54,7 +55,7 @@ func (c *Client) beginRequest(ctx context.Context, req Request, stream bool) (re
 		allowed, probe := scope.breaker.acquire()
 		if !allowed {
 			err := core.NewProviderError(c.config.ProviderName, http.StatusServiceUnavailable,
-				"circuit breaker is open - provider temporarily unavailable", nil)
+				"circuit breaker is open - provider "+c.config.ProviderName+" temporarily unavailable", nil)
 			c.finishRequest(scope, http.StatusServiceUnavailable, err)
 			return requestScope{}, err
 		}
@@ -197,7 +198,8 @@ func (c *Client) releaseHalfOpenProbe(scope requestScope) {
 // fallback shared by the retrying entry points (DoRaw, DoPassthrough). The
 // returned error is also reported through the scope.
 func (c *Client) failAfterRetries(scope requestScope) error {
-	err := core.NewProviderError(c.config.ProviderName, http.StatusBadGateway, "request failed after retries", nil)
+	err := core.NewProviderError(c.config.ProviderName, http.StatusBadGateway,
+		"request failed after retries for provider "+c.config.ProviderName, nil)
 	c.completeScope(scope, http.StatusBadGateway, err, err)
 	return err
 }

--- a/internal/llmclient/client_test.go
+++ b/internal/llmclient/client_test.go
@@ -1091,6 +1091,9 @@ func TestCircuitBreaker_OpensAfterFailures(t *testing.T) {
 	if !strings.Contains(gatewayErr.Message, "circuit breaker") {
 		t.Errorf("expected circuit breaker message, got: %s", gatewayErr.Message)
 	}
+	if !strings.Contains(gatewayErr.Message, "provider test") {
+		t.Errorf("expected circuit breaker message to identify provider, got: %s", gatewayErr.Message)
+	}
 
 	// Should have made exactly 3 requests (threshold)
 	if attempts.Load() != 3 {

--- a/internal/llmclient/model_breaker_test.go
+++ b/internal/llmclient/model_breaker_test.go
@@ -65,6 +65,14 @@ func TestModelBreakerCapacityRejectsWithoutBypassingProtection(t *testing.T) {
 	}
 }
 
+func TestFailAfterRetriesIncludesProviderName(t *testing.T) {
+	client := New(DefaultConfig("test", ""), nil)
+	err := client.failAfterRetries(requestScope{})
+	if err == nil || !strings.Contains(err.Error(), "request failed after retries for provider test") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
 func TestUnknownModelUsesProviderBreaker(t *testing.T) {
 	cfg := DefaultConfig("test", "")
 	cfg.CircuitBreaker.Scope = "model"

--- a/internal/llmclient/model_breaker_test.go
+++ b/internal/llmclient/model_breaker_test.go
@@ -57,6 +57,9 @@ func TestModelBreakerCapacityRejectsWithoutBypassingProtection(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "capacity exhausted") {
 		t.Fatalf("error=%v", err)
 	}
+	if !strings.Contains(err.Error(), "provider test") {
+		t.Fatalf("error=%v, want provider name", err)
+	}
 	if len(client.modelBreakers) != maxModelBreakers {
 		t.Fatal("capacity exceeded")
 	}

--- a/internal/server/audio_service.go
+++ b/internal/server/audio_service.go
@@ -86,7 +86,7 @@ func (s *audioService) CreateSpeech(c *echo.Context) error {
 		return handleError(c, err)
 	}
 	if resp == nil {
-		return s.respondAudio(c, resp) // emits the 502 guard; no usage for a failed call
+		return s.respondAudio(c, route.providerName, resp) // emits the 502 guard; no usage for a failed call
 	}
 	s.logUsage(ctx, route, func(pricing *core.ModelPricing) *usage.UsageEntry {
 		return usage.ExtractFromSpeechRequest(req.Input, resp.Data, speechResponseFormat(req, resp), route.requestID, route.model, route.providerType, pricing)
@@ -94,7 +94,7 @@ func (s *audioService) CreateSpeech(c *echo.Context) error {
 	if err := waitForModelSlowdownFactor(ctx, route.slowdown, inferenceTime); err != nil {
 		return handleError(c, err)
 	}
-	return s.respondAudio(c, resp)
+	return s.respondAudio(c, route.providerName, resp)
 }
 
 // speechResponseFormat resolves the codec of the synthesized audio so usage can
@@ -171,7 +171,7 @@ func (s *audioService) createAudioTranscription(c *echo.Context, translation boo
 		return handleError(c, err)
 	}
 	if resp == nil {
-		return s.respondAudio(c, resp) // emits the 502 guard before resp.Data is read
+		return s.respondAudio(c, route.providerName, resp) // emits the 502 guard before resp.Data is read
 	}
 	s.logUsage(ctx, route, func(pricing *core.ModelPricing) *usage.UsageEntry {
 		if translation {
@@ -182,7 +182,7 @@ func (s *audioService) createAudioTranscription(c *echo.Context, translation boo
 	if err := waitForModelSlowdownFactor(ctx, route.slowdown, inferenceTime); err != nil {
 		return handleError(c, err)
 	}
-	return s.respondAudio(c, resp)
+	return s.respondAudio(c, route.providerName, resp)
 }
 
 func audioTranscriptionRequestFromForm(c *echo.Context, includeTranscriptionFields bool) (*core.AudioTranscriptionRequest, error) {
@@ -245,9 +245,10 @@ func audioTranscriptionRequestFromForm(c *echo.Context, includeTranscriptionFiel
 	}, nil
 }
 
-func (s *audioService) respondAudio(c *echo.Context, resp *core.AudioResponse) error {
+func (s *audioService) respondAudio(c *echo.Context, providerName string, resp *core.AudioResponse) error {
 	if resp == nil {
-		return handleError(c, core.NewProviderError("", http.StatusBadGateway, "provider returned empty audio response", nil))
+		return handleError(c, core.NewProviderError(providerName, http.StatusBadGateway,
+			"provider "+providerName+" returned empty audio response", nil))
 	}
 	contentType := strings.TrimSpace(resp.ContentType)
 	if contentType == "" {

--- a/internal/server/audio_service_test.go
+++ b/internal/server/audio_service_test.go
@@ -1046,7 +1046,10 @@ func TestAudio_NilResponseSkipsUsage(t *testing.T) {
 		var captured *usage.UsageEntry
 		logger := &capturingUsageLogger{config: usage.Config{Enabled: true}, captured: &captured}
 		svc := &audioService{
-			provider:    &audioMockProvider{mockProvider: &mockProvider{supportedModels: []string{"gpt-4o-transcribe"}}, transcriptionResp: nil},
+			provider: &audioMockProvider{mockProvider: &mockProvider{
+				supportedModels: []string{"gpt-4o-transcribe"},
+				providerNames:   map[string]string{"gpt-4o-transcribe": "audio-transcription"},
+			}, transcriptionResp: nil},
 			usageLogger: logger}
 		c, rec, _ := newTranscriptionRequestWithAuditEntry("speech.mp3", []byte("audio-bytes"))
 
@@ -1056,6 +1059,47 @@ func TestAudio_NilResponseSkipsUsage(t *testing.T) {
 		}
 		if rec.Code != http.StatusBadGateway {
 			t.Fatalf("status = %d, want 502", rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), `"provider":"audio-transcription"`) ||
+			!strings.Contains(rec.Body.String(), "provider audio-transcription returned empty audio response") {
+			t.Errorf("response does not identify the provider: %s", rec.Body.String())
+		}
+		if captured != nil {
+			t.Errorf("no usage should be written for a failed call, got %+v", captured)
+		}
+	})
+
+	t.Run("translation", func(t *testing.T) {
+		var captured *usage.UsageEntry
+		logger := &capturingUsageLogger{config: usage.Config{Enabled: true}, captured: &captured}
+		svc := &audioService{
+			provider: &audioMockProvider{mockProvider: &mockProvider{
+				supportedModels: []string{"gpt-4o-translate"},
+				providerNames:   map[string]string{"gpt-4o-translate": "audio-translation"},
+			}, translationResp: nil},
+			usageLogger: logger,
+		}
+
+		var body bytes.Buffer
+		writer := multipart.NewWriter(&body)
+		_ = writer.WriteField("model", "gpt-4o-translate")
+		part, _ := writer.CreateFormFile("file", "speech.mp3")
+		_, _ = part.Write([]byte("audio-bytes"))
+		_ = writer.Close()
+		req := httptest.NewRequest(http.MethodPost, "/v1/audio/translations", &body)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+		rec := httptest.NewRecorder()
+		c := echo.New().NewContext(req, rec)
+
+		if err := svc.CreateTranslation(c); err != nil {
+			t.Fatalf("CreateTranslation returned error: %v", err)
+		}
+		if rec.Code != http.StatusBadGateway {
+			t.Fatalf("status = %d, want 502", rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), `"provider":"audio-translation"`) ||
+			!strings.Contains(rec.Body.String(), "provider audio-translation returned empty audio response") {
+			t.Errorf("response does not identify the provider: %s", rec.Body.String())
 		}
 		if captured != nil {
 			t.Errorf("no usage should be written for a failed call, got %+v", captured)

--- a/internal/server/audio_service_test.go
+++ b/internal/server/audio_service_test.go
@@ -994,8 +994,11 @@ func TestAudioSpeech_NoAudioBodyWhenBodiesDisabled(t *testing.T) {
 // provider returns no response and no error, the gateway must report a 502.
 func TestAudioSpeech_NilResponseReturns502(t *testing.T) {
 	mock := &audioMockProvider{
-		mockProvider: &mockProvider{supportedModels: []string{"gpt-4o-mini-tts"}},
-		speechResp:   nil, // provider returns (nil, nil)
+		mockProvider: &mockProvider{
+			supportedModels: []string{"gpt-4o-mini-tts"},
+			providerNames:   map[string]string{"gpt-4o-mini-tts": "audio-primary"},
+		},
+		speechResp: nil, // provider returns (nil, nil)
 	}
 	handler := NewHandler(mock, nil, nil, nil)
 
@@ -1010,6 +1013,9 @@ func TestAudioSpeech_NilResponseReturns502(t *testing.T) {
 	}
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("status = %d, want 502", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `"provider":"audio-primary"`) {
+		t.Errorf("response does not identify the provider: %s", rec.Body.String())
 	}
 }
 

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -5830,8 +5830,11 @@ func TestGetFileContent_TypedNilResponseReturnsBadGateway(t *testing.T) {
 	if !strings.Contains(body, "provider_error") {
 		t.Fatalf("expected provider_error body, got: %s", body)
 	}
-	if !strings.Contains(body, "provider returned empty file content response") {
+	if !strings.Contains(body, "provider openai returned empty file content response") {
 		t.Fatalf("expected empty file content response message, got: %s", body)
+	}
+	if !strings.Contains(body, `"provider":"openai"`) {
+		t.Fatalf("expected provider in response body, got: %s", body)
 	}
 }
 

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -5806,6 +5806,9 @@ func TestGetFileContent_TypedNilResponseReturnsBadGateway(t *testing.T) {
 		providerTypes: map[string]string{
 			"gpt-4o-mini": "openai",
 		},
+		providerNames: map[string]string{
+			"gpt-4o-mini": "openai-primary",
+		},
 		fileContentByProv: map[string]*core.FileContentResponse{
 			"openai": nil,
 		},
@@ -5830,10 +5833,10 @@ func TestGetFileContent_TypedNilResponseReturnsBadGateway(t *testing.T) {
 	if !strings.Contains(body, "provider_error") {
 		t.Fatalf("expected provider_error body, got: %s", body)
 	}
-	if !strings.Contains(body, "provider openai returned empty file content response") {
+	if !strings.Contains(body, "provider openai-primary returned empty file content response") {
 		t.Fatalf("expected empty file content response message, got: %s", body)
 	}
-	if !strings.Contains(body, `"provider":"openai"`) {
+	if !strings.Contains(body, `"provider":"openai-primary"`) {
 		t.Fatalf("expected provider in response body, got: %s", body)
 	}
 }

--- a/internal/server/image_edit_service.go
+++ b/internal/server/image_edit_service.go
@@ -68,7 +68,8 @@ func (s *imageService) CreateImageEdit(c *echo.Context) error {
 		return handleError(c, err)
 	}
 	if resp == nil {
-		return handleError(c, core.NewProviderError("", http.StatusBadGateway, "provider returned empty image response", nil))
+		return handleError(c, core.NewProviderError(route.providerName, http.StatusBadGateway,
+			"provider "+route.providerName+" returned empty image response", nil))
 	}
 	s.logUsage(ctx, route, func(pricing *core.ModelPricing) *usage.UsageEntry {
 		return usage.ExtractFromImageEditResponse(resp, route.requestID, route.model, route.providerType, pricing)

--- a/internal/server/image_edit_service_test.go
+++ b/internal/server/image_edit_service_test.go
@@ -272,6 +272,7 @@ func TestImageEdits_ProviderErrorIsSurfaced(t *testing.T) {
 func TestImageEdits_NilProviderResponseIs502(t *testing.T) {
 	mock := newImageEditMock()
 	mock.imageResp = nil
+	mock.providerNames = map[string]string{"gpt-image-1": "image-primary"}
 	var captured *usage.UsageEntry
 	logger := &capturingUsageLogger{config: usage.Config{Enabled: true}, captured: &captured}
 	svc := &imageService{provider: mock, usageLogger: logger}
@@ -282,6 +283,9 @@ func TestImageEdits_NilProviderResponseIs502(t *testing.T) {
 	}
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("status = %d, want 502 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"provider":"image-primary"`) {
+		t.Errorf("response does not identify the provider: %s", rec.Body.String())
 	}
 	if captured != nil {
 		t.Error("no usage entry should be written for a failed call")

--- a/internal/server/image_edit_service_test.go
+++ b/internal/server/image_edit_service_test.go
@@ -287,6 +287,9 @@ func TestImageEdits_NilProviderResponseIs502(t *testing.T) {
 	if !strings.Contains(rec.Body.String(), `"provider":"image-primary"`) {
 		t.Errorf("response does not identify the provider: %s", rec.Body.String())
 	}
+	if !strings.Contains(rec.Body.String(), "provider image-primary returned empty image response") {
+		t.Errorf("response does not identify the provider in its message: %s", rec.Body.String())
+	}
 	if captured != nil {
 		t.Error("no usage entry should be written for a failed call")
 	}

--- a/internal/server/image_service.go
+++ b/internal/server/image_service.go
@@ -78,7 +78,8 @@ func (s *imageService) CreateImage(c *echo.Context) error {
 		return handleError(c, err)
 	}
 	if resp == nil {
-		return handleError(c, core.NewProviderError("", http.StatusBadGateway, "provider returned empty image response", nil))
+		return handleError(c, core.NewProviderError(route.providerName, http.StatusBadGateway,
+			"provider "+route.providerName+" returned empty image response", nil))
 	}
 	s.logUsage(ctx, route, func(pricing *core.ModelPricing) *usage.UsageEntry {
 		return usage.ExtractFromImageResponse(resp, route.requestID, route.model, route.providerType, pricing)

--- a/internal/server/image_service_test.go
+++ b/internal/server/image_service_test.go
@@ -224,6 +224,9 @@ func TestImageGenerations_NilProviderResponseIs502(t *testing.T) {
 	if !strings.Contains(rec.Body.String(), `"provider":"image-primary"`) {
 		t.Errorf("response does not identify the provider: %s", rec.Body.String())
 	}
+	if !strings.Contains(rec.Body.String(), "provider image-primary returned empty image response") {
+		t.Errorf("response does not identify the provider in its message: %s", rec.Body.String())
+	}
 	if captured != nil {
 		t.Error("no usage entry should be written for a failed call")
 	}

--- a/internal/server/image_service_test.go
+++ b/internal/server/image_service_test.go
@@ -209,6 +209,7 @@ func TestImageGenerations_ProviderErrorIsSurfaced(t *testing.T) {
 func TestImageGenerations_NilProviderResponseIs502(t *testing.T) {
 	mock := newImageMock()
 	mock.imageResp = nil
+	mock.providerNames = map[string]string{"dall-e-3": "image-primary"}
 	var captured *usage.UsageEntry
 	logger := &capturingUsageLogger{config: usage.Config{Enabled: true}, captured: &captured}
 	svc := &imageService{provider: mock, usageLogger: logger}
@@ -219,6 +220,9 @@ func TestImageGenerations_NilProviderResponseIs502(t *testing.T) {
 	}
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("status = %d, want 502 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"provider":"image-primary"`) {
+		t.Errorf("response does not identify the provider: %s", rec.Body.String())
 	}
 	if captured != nil {
 		t.Error("no usage entry should be written for a failed call")

--- a/internal/server/native_file_service.go
+++ b/internal/server/native_file_service.go
@@ -40,7 +40,7 @@ func (s *nativeFileService) providerTypes() ([]string, error) {
 func (s *nativeFileService) fileByID(
 	c *echo.Context,
 	callFn func(core.NativeFileRoutableProvider, string, string) (any, error),
-	respondFn func(*echo.Context, any) error,
+	respondFn func(*echo.Context, string, any) error,
 	onSuccess func(context.Context, string, string) error,
 ) error {
 	nativeRouter, err := s.router()
@@ -84,7 +84,7 @@ func (s *nativeFileService) fileByID(
 				return handleError(c, err)
 			}
 		}
-		return respondFn(c, result)
+		return respondFn(c, providerType, result)
 	}
 
 	if tracked {
@@ -97,7 +97,7 @@ func (s *nativeFileService) fileByID(
 					return handleError(c, err)
 				}
 			}
-			return respondFn(c, result)
+			return respondFn(c, providerType, result)
 		}
 		if !isNotFoundGatewayError(err) && !isUnsupportedNativeFilesError(err) {
 			return handleError(c, err)
@@ -127,7 +127,7 @@ func (s *nativeFileService) fileByID(
 					return handleError(c, err)
 				}
 			}
-			return respondFn(c, result)
+			return respondFn(c, candidate, result)
 		}
 		if isNotFoundGatewayError(err) || isUnsupportedNativeFilesError(err) {
 			continue
@@ -280,7 +280,7 @@ func (s *nativeFileService) GetFile(c *echo.Context) error {
 		func(r core.NativeFileRoutableProvider, provider, id string) (any, error) {
 			return r.GetFile(c.Request().Context(), provider, id)
 		},
-		func(c *echo.Context, result any) error {
+		func(c *echo.Context, _ string, result any) error {
 			return c.JSON(http.StatusOK, result)
 		},
 		nil,
@@ -292,7 +292,7 @@ func (s *nativeFileService) DeleteFile(c *echo.Context) error {
 		func(r core.NativeFileRoutableProvider, provider, id string) (any, error) {
 			return r.DeleteFile(c.Request().Context(), provider, id)
 		},
-		func(c *echo.Context, result any) error {
+		func(c *echo.Context, _ string, result any) error {
 			return c.JSON(http.StatusOK, result)
 		},
 		func(ctx context.Context, providerType, id string) error {
@@ -309,10 +309,11 @@ func (s *nativeFileService) GetFileContent(c *echo.Context) error {
 		func(r core.NativeFileRoutableProvider, provider, id string) (any, error) {
 			return r.GetFileContent(c.Request().Context(), provider, id)
 		},
-		func(c *echo.Context, result any) error {
+		func(c *echo.Context, providerName string, result any) error {
 			resp, ok := result.(*core.FileContentResponse)
 			if !ok || resp == nil {
-				return handleError(c, core.NewProviderError("", http.StatusBadGateway, "provider returned empty file content response", nil))
+				return handleError(c, core.NewProviderError(providerName, http.StatusBadGateway,
+					"provider "+providerName+" returned empty file content response", nil))
 			}
 			contentType := strings.TrimSpace(resp.ContentType)
 			if contentType == "" {

--- a/internal/server/native_file_service.go
+++ b/internal/server/native_file_service.go
@@ -21,6 +21,17 @@ type nativeFileService struct {
 	fileStore filestore.Store
 }
 
+// providerName returns the configured provider instance for a native-file
+// provider type, falling back to the type when the router cannot resolve it.
+func (s *nativeFileService) providerName(providerType string) string {
+	if resolver, ok := s.provider.(core.ProviderTypeNameResolver); ok {
+		if providerName := strings.TrimSpace(resolver.GetProviderNameForType(providerType)); providerName != "" {
+			return providerName
+		}
+	}
+	return strings.TrimSpace(providerType)
+}
+
 func (s *nativeFileService) router() (core.NativeFileRoutableProvider, error) {
 	nativeRouter, ok := s.provider.(core.NativeFileRoutableProvider)
 	if !ok {
@@ -84,7 +95,7 @@ func (s *nativeFileService) fileByID(
 				return handleError(c, err)
 			}
 		}
-		return respondFn(c, providerType, result)
+		return respondFn(c, s.providerName(providerType), result)
 	}
 
 	if tracked {
@@ -97,7 +108,7 @@ func (s *nativeFileService) fileByID(
 					return handleError(c, err)
 				}
 			}
-			return respondFn(c, providerType, result)
+			return respondFn(c, s.providerName(providerType), result)
 		}
 		if !isNotFoundGatewayError(err) && !isUnsupportedNativeFilesError(err) {
 			return handleError(c, err)
@@ -127,7 +138,7 @@ func (s *nativeFileService) fileByID(
 					return handleError(c, err)
 				}
 			}
-			return respondFn(c, candidate, result)
+			return respondFn(c, s.providerName(candidate), result)
 		}
 		if isNotFoundGatewayError(err) || isUnsupportedNativeFilesError(err) {
 			continue


### PR DESCRIPTION
Adds the resolved provider name to circuit-breaker, retry-exhaustion, and empty routed-response errors. This makes failures actionable in both the message and OpenAI-compatible `error.provider` field.

Tests:
- `go test ./internal/llmclient -run 'Test(CircuitBreaker_OpensAfterFailures|ModelBreakerCapacityRejectsWithoutBypassingProtection)$'`\n- `go test ./internal/server -run 'Test(ImageGenerations_NilProviderResponseIs502|ImageEdits_NilProviderResponseIs502|AudioSpeech_NilResponseReturns502|GetFileContent_TypedNilResponseReturnsBadGateway)$'`\n\nThe full server suite requires generated dashboard assets not present in this checkout (`internal/admin/dashboard/static/dist`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Error messages now identify the provider involved when circuit breakers reject requests or retries are exhausted.
  - Empty audio, image, and file responses now include the provider name in the resulting error details.
  - Provider-specific information is included consistently in gateway error responses, making failed requests easier to diagnose.

- **Documentation**
  - Updated resilience documentation to show the provider name in open-circuit error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->