### PR TITLE
feat(streaming): rewrite tool-call arguments in transform streams

### DIFF
--- a/docs/advanced/guardrails.mdx
+++ b/docs/advanced/guardrails.mdx
@@ -470,8 +470,8 @@ docker run -d -p 5002:3000 ghcr.io/data-privacy-stack/presidio-analyzer:latest
 | `restore` | No | `false` | Put the original values back where the model repeats a placeholder. Needs `operator: replace`; see below. |
 | `message` | No | `Request blocked: it contains personal data` | Error message for `block`, assistant reply for `respond`, audit note for `warn`. |
 | `block_status` | No | phase default | One HTTP status code between 400 and 599 for `block`. Empty means 400 when the prompt is blocked, 502 when the response is blocked. |
-| `stream_chunk` | No | `256` | Characters of streamed text collected before the analyzer runs on them, so it sees whole sentences and runs once per chunk. The client waits for at most this much text at a time. |
-| `stream_lookbehind` | No | `64` | Characters of streamed text held back so a value or placeholder split across two chunks is still handled. |
+| `stream_chunk` | No | `256` | Characters of streamed text (or tool-call arguments) collected before the analyzer runs on them, so it sees whole sentences and runs once per chunk. The client waits for at most this much text at a time. |
+| `stream_lookbehind` | No | `64` | Characters of streamed text (or tool-call arguments) held back so a value or placeholder split across two chunks is still handled. |
 
 Every text part is analyzed on its own (one analyzer call each, up to eight
 in flight), so the analyzer never sees the whole conversation as one text and
@@ -512,9 +512,8 @@ a placeholder, so a user cannot make the model reveal it. A value the model
 produced on its own is still anonymized on the way out. Such responses are
 kept out of the [response cache](/features/cache).
 
-Streamed tool-call arguments are not rewritten in the stream phase; use the
-response phase (which buffers the stream) when agents must receive restored
-arguments.
+Streamed tool-call arguments are restored in flight as well, each call's
+arguments as a window of its own under `stream_lookbehind`.
 
 #### Example
 

--- a/docs/advanced/plugins.mdx
+++ b/docs/advanced/plugins.mdx
@@ -167,9 +167,10 @@ characters per window and presents each delta together with that tail, so a
 pattern spanning two chunks (a phone number, an API key) is visible in one
 event before any of it reaches the client. A choice's text is one window and
 the arguments of each of its tool calls (`StreamEvent.Call`) another, so a
-placeholder split across two argument deltas is rewritten the same way; a
-delta for another window of the same choice flushes that choice's other
-windows first, so events keep their order. A pattern of up to
+placeholder split across two argument deltas is rewritten the same way. A
+delta of another kind for the same choice flushes that choice's windows of
+other kinds first, so text and tool calls keep their order, while parallel
+tool calls stream independently. A pattern of up to
 `LookbehindChars + 1` characters is always caught. `0` disables it. The tail
 comes back already carrying the plugin's earlier edits, and
 `StreamEvent.Overlap` says how many leading characters it spans: a plugin

--- a/docs/advanced/plugins.mdx
+++ b/docs/advanced/plugins.mdx
@@ -159,13 +159,17 @@ one of three modes in `StreamHook.StreamPolicy()`:
 | Mode | What the plugin can do | Latency cost |
 | --- | --- | --- |
 | `observe` | read every event; decisions are ignored except `terminate` | none |
-| `transform` | `pass`, `drop`, `replace` (text and reasoning deltas), or `terminate` each event | `LookbehindChars` characters of delay per choice, plus up to `MinChunkChars` while a run is collected |
+| `transform` | `pass`, `drop`, `replace` (text, reasoning, and tool-call argument deltas), or `terminate` each event | `LookbehindChars` characters of delay per window, plus up to `MinChunkChars` while a run is collected |
 | `buffer` | nothing per event; GoModel collects the whole stream and runs the plugin's `OnResponse` on the assembled completion (a `buffer` plugin must implement `ResponseHook`; loading fails otherwise) | time-to-first-token becomes time-to-last-token |
 
 **Lookbehind** (`transform` only): GoModel withholds the last `LookbehindChars`
-characters of text per choice and presents each delta together with that
-tail, so a pattern spanning two chunks (a phone number, an API key) is
-visible in one event before any of it reaches the client. A pattern of up to
+characters per window and presents each delta together with that tail, so a
+pattern spanning two chunks (a phone number, an API key) is visible in one
+event before any of it reaches the client. A choice's text is one window and
+the arguments of each of its tool calls (`StreamEvent.Call`) another, so a
+placeholder split across two argument deltas is rewritten the same way; a
+delta for another window of the same choice flushes that choice's other
+windows first, so events keep their order. A pattern of up to
 `LookbehindChars + 1` characters is always caught. `0` disables it. The tail
 comes back already carrying the plugin's earlier edits, and
 `StreamEvent.Overlap` says how many leading characters it spans: a plugin

--- a/internal/plugins/builtin/presidio/plugin_test.go
+++ b/internal/plugins/builtin/presidio/plugin_test.go
@@ -739,3 +739,27 @@ func TestAPIKeyIsNotFollowedToPlainHTTP(t *testing.T) {
 		t.Fatalf("err = %v", err)
 	}
 }
+
+func TestStreamRestoresToolCallArguments(t *testing.T) {
+	a := newAnalyzer(t, "Ann Lee")
+	in := newPlugin(t, a, `{"restore": true}`)
+	out := newPlugin(t, a, `{"restore": true, "stream_lookbehind": 12}`)
+	x := plugintest.Exchange(plugintest.Prompt(plugintest.Text(pluginapi.RoleUser, "m1", "Email ann@x.io for Ann Lee")), nil)
+	if _, err := in.OnPrompt(context.Background(), x); err != nil {
+		t.Fatal(err)
+	}
+	res, err := plugintest.RunStream(context.Background(), out, x, []*pluginapi.StreamEvent{
+		plugintest.TextDelta("Sending to <PERSON_1>."),
+		{Kind: pluginapi.EventToolCallDelta, Call: 0, Text: `{"to":"<EMAIL_ADD`},
+		{Kind: pluginapi.EventToolCallDelta, Call: 0, Text: `RESS_1>","cc":"bob@y.io"}`},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Text[0] != "Sending to Ann Lee." || res.ToolArguments[0][0] != `{"to":"ann@x.io","cc":"<EMAIL_ADDRESS_2>"}` {
+		t.Errorf("result = %+v", res)
+	}
+	if res.End.Detail.(map[string]any)["restored"] != 2 {
+		t.Errorf("end = %+v", res.End)
+	}
+}

--- a/internal/plugins/builtin/presidio/stream.go
+++ b/internal/plugins/builtin/presidio/stream.go
@@ -19,11 +19,12 @@ func (p *Plugin) StreamPolicy() pluginapi.StreamPolicy {
 	}
 }
 
-// OnStreamEvent analyzes each text window, rewrites it for anonymize, puts
-// restorable values back, and cuts the stream when a blocking entity type
-// appears. Under a buffering policy every event passes; OnResponse decides.
+// OnStreamEvent analyzes each text or tool-call argument window, rewrites
+// it for anonymize, puts restorable values back, and cuts the stream when a
+// blocking entity type appears. Under a buffering policy every event
+// passes; OnResponse decides.
 func (p *Plugin) OnStreamEvent(ctx context.Context, x *pluginapi.Exchange, ev *pluginapi.StreamEvent) (pluginapi.StreamDecision, error) {
-	if ev == nil || ev.Kind != pluginapi.EventTextDelta || ev.Text == "" || x == nil {
+	if ev == nil || x == nil || ev.Text == "" || (ev.Kind != pluginapi.EventTextDelta && ev.Kind != pluginapi.EventToolCallDelta) {
 		return pluginapi.Pass(), nil
 	}
 	if p.action == ActionBlock || p.action == ActionRespond {

--- a/internal/server/plugin_stream.go
+++ b/internal/server/plugin_stream.go
@@ -302,7 +302,7 @@ func chainHas(chain *plugins.Chain, inst *plugins.Instance) bool {
 // the walk, so a later instance's OnStreamEnd sees replaced and dropped
 // text that way rather than the original.
 func (ps *pluginStream) OnEvent(ev *streaming.Event) (streaming.Decision, error) {
-	pev := &pluginapi.StreamEvent{Seq: ev.Seq + 1, Kind: pluginEventKind(ev.Kind), Choice: ev.Choice, Text: ev.Text, Overlap: ev.Overlap, Raw: ev.Data}
+	pev := &pluginapi.StreamEvent{Seq: ev.Seq + 1, Kind: pluginEventKind(ev.Kind), Choice: ev.Choice, Call: ev.Call, Text: ev.Text, Overlap: ev.Overlap, Raw: ev.Data}
 	result := streaming.Decision{Action: streaming.ActionPass}
 	for _, entry := range ps.inFlight {
 		inst, observe := entry.inst, entry.observe
@@ -336,7 +336,7 @@ func (ps *pluginStream) OnEvent(ev *streaming.Event) (streaming.Decision, error)
 			ps.x.Stream.ReplaceTail(pev, ev.Overlap, "")
 			return streaming.Decision{Action: streaming.ActionDrop}, nil
 		case pluginapi.StreamReplace:
-			if observe || pev.Kind != pluginapi.EventTextDelta && pev.Kind != pluginapi.EventReasoningDelta {
+			if observe || !replaceable(pev.Kind) {
 				continue
 			}
 			pev.Text = decision.Text
@@ -401,6 +401,12 @@ func (ps *pluginStream) appendState(ev *pluginapi.StreamEvent, overlap int) {
 	fresh := *ev
 	fresh.Text = ev.Text[offset:]
 	ps.x.Stream.Append(&fresh)
+}
+
+// replaceable reports whether a replace decision applies to the kind: text,
+// reasoning, and tool-call argument deltas.
+func replaceable(kind pluginapi.EventKind) bool {
+	return kind == pluginapi.EventTextDelta || kind == pluginapi.EventReasoningDelta || kind == pluginapi.EventToolCallDelta
 }
 
 func pluginEventKind(kind streaming.EventKind) pluginapi.EventKind {

--- a/internal/streaming/chat_codec.go
+++ b/internal/streaming/chat_codec.go
@@ -36,6 +36,7 @@ type chatDeltaView struct {
 }
 
 type chatToolCallView struct {
+	Index    *int `json:"index"`
 	Function *struct {
 		Arguments string `json:"arguments"`
 	} `json:"function"`
@@ -97,6 +98,9 @@ func (c *chatCodec) Decode(raw RawEvent, seq int) Event {
 			}
 			if len(delta.ToolCalls) > 0 {
 				ev.Kind = KindToolCallDelta
+				if idx := delta.ToolCalls[0].Index; idx != nil {
+					ev.Call = *idx
+				}
 				if fn := delta.ToolCalls[0].Function; fn != nil {
 					ev.Text = fn.Arguments
 				}
@@ -146,7 +150,7 @@ func (c *chatCodec) Track(ev Event) {
 }
 
 func (c *chatCodec) RewriteText(ev Event, text string) (Event, error) {
-	if ev.Kind != KindTextDelta && ev.Kind != KindReasoningDelta {
+	if !isDelta(ev.Kind) {
 		return ev, ErrNotTextEvent
 	}
 	var top map[string]json.RawMessage
@@ -168,20 +172,26 @@ func (c *chatCodec) RewriteText(ev Event, text string) (Event, error) {
 	if delta == nil {
 		delta = make(map[string]json.RawMessage, 1)
 	}
-	key := "content"
-	if ev.Kind == KindReasoningDelta {
-		key = "reasoning_content"
+	encoded, err := json.Marshal(text)
+	if err != nil {
+		return ev, err
+	}
+	switch ev.Kind {
+	case KindToolCallDelta:
+		if err := rewriteToolArguments(delta, encoded); err != nil {
+			return ev, err
+		}
+	case KindReasoningDelta:
+		key := "reasoning_content"
 		if _, ok := delta["reasoning_content"]; !ok {
 			if _, ok := delta["reasoning"]; ok {
 				key = "reasoning"
 			}
 		}
+		delta[key] = encoded
+	default:
+		delta["content"] = encoded
 	}
-	encoded, err := json.Marshal(text)
-	if err != nil {
-		return ev, err
-	}
-	delta[key] = encoded
 	if choices[pos]["delta"], err = json.Marshal(delta); err != nil {
 		return ev, err
 	}
@@ -197,10 +207,45 @@ func (c *chatCodec) RewriteText(ev Event, text string) (Event, error) {
 	return ev, nil
 }
 
+// rewriteToolArguments sets the arguments of the delta's first tool call
+// (the one Decode classified on) to the encoded JSON string.
+func rewriteToolArguments(delta map[string]json.RawMessage, encoded json.RawMessage) error {
+	var calls []map[string]json.RawMessage
+	if err := json.Unmarshal(delta["tool_calls"], &calls); err != nil || len(calls) == 0 {
+		return fmt.Errorf("streaming: chat delta carries no tool call: %w", err)
+	}
+	var fn map[string]json.RawMessage
+	if raw, ok := calls[0]["function"]; ok && jsonNonNull(raw) {
+		if err := json.Unmarshal(raw, &fn); err != nil {
+			return fmt.Errorf("streaming: decode tool call function: %w", err)
+		}
+	}
+	if fn == nil {
+		fn = make(map[string]json.RawMessage, 1)
+	}
+	fn["arguments"] = encoded
+	encodedFn, err := json.Marshal(fn)
+	if err != nil {
+		return err
+	}
+	calls[0]["function"] = encodedFn
+	encodedCalls, err := json.Marshal(calls)
+	if err != nil {
+		return err
+	}
+	delta["tool_calls"] = encodedCalls
+	return nil
+}
+
+// isDelta reports whether kind carries rewritable delta text.
+func isDelta(kind EventKind) bool {
+	return kind == KindTextDelta || kind == KindReasoningDelta || kind == KindToolCallDelta
+}
+
 // StripTerminal drops a non-null finish_reason of the event's choice and a
 // non-null top-level usage.
 func (c *chatCodec) StripTerminal(ev Event) (Event, bool) {
-	if ev.Kind != KindTextDelta && ev.Kind != KindReasoningDelta {
+	if !isDelta(ev.Kind) {
 		return ev, false
 	}
 	var top map[string]json.RawMessage

--- a/internal/streaming/chat_codec.go
+++ b/internal/streaming/chat_codec.go
@@ -395,6 +395,10 @@ func splitToolCalls(choice json.RawMessage) ([]json.RawMessage, bool) {
 		callDelta["tool_calls"] = single
 		deltas = append(deltas, callDelta)
 	}
+	// The role announces the message once; it stays on the first part only.
+	for _, partDelta := range deltas[1:] {
+		delete(partDelta, "role")
+	}
 	out := make([]json.RawMessage, 0, len(deltas))
 	for i, partDelta := range deltas {
 		partChoice := make(map[string]json.RawMessage, len(obj))

--- a/internal/streaming/chat_codec.go
+++ b/internal/streaming/chat_codec.go
@@ -289,8 +289,9 @@ func jsonNonNull(raw json.RawMessage) bool {
 }
 
 // Split turns a chunk with several choices into one chunk per choice, and
-// a choice whose delta carries several tool calls into one chunk per tool
-// call, so each is decoded and transformed on its own. Every top-level
+// a choice whose delta carries several tool calls, or text alongside tool
+// calls, into one chunk per part, so each is decoded and transformed on
+// its own. Every top-level
 // member is copied; usage and a choice's finish_reason stay on the last
 // part only so downstream accounting sees them once.
 func (c *chatCodec) Split(raw RawEvent) []RawEvent {
@@ -338,10 +339,16 @@ func (c *chatCodec) Split(raw RawEvent) []RawEvent {
 	return out
 }
 
-// splitToolCalls returns one copy of the choice per entry of its delta's
-// tool_calls, each carrying a single tool call; the choice's finish_reason
-// stays on the last copy. A choice with at most one tool call is returned
-// as is. ok is false when the choice cannot be decoded.
+// textMembers are the delta members Decode classifies on before tool
+// calls; a delta carrying one of them alongside tool calls is split so the
+// text and every call are transformed on their own.
+var textMembers = []string{"content", "reasoning_content", "reasoning"}
+
+// splitToolCalls divides a choice whose delta carries several tool calls, or
+// text alongside tool calls, into copies that each carry one thing: the
+// text first, then one tool call each. The choice's finish_reason stays on
+// the last copy. A choice that needs no splitting is returned as is. ok
+// is false when the choice cannot be decoded.
 func splitToolCalls(choice json.RawMessage) ([]json.RawMessage, bool) {
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(choice, &obj); err != nil {
@@ -359,24 +366,44 @@ func splitToolCalls(choice json.RawMessage) ([]json.RawMessage, bool) {
 	} else if err := json.Unmarshal(raw, &calls); err != nil {
 		return nil, false
 	}
-	if len(calls) <= 1 {
+	hasText := false
+	for _, member := range textMembers {
+		if text, ok := jsonStringOf(delta[member]); ok && text != "" {
+			hasText = true
+		}
+	}
+	if len(calls) == 0 || (len(calls) == 1 && !hasText) {
 		return []json.RawMessage{choice}, true
 	}
-	out := make([]json.RawMessage, 0, len(calls))
-	for i, call := range calls {
-		partDelta := make(map[string]json.RawMessage, len(delta))
-		maps.Copy(partDelta, delta)
+	var deltas []map[string]json.RawMessage
+	if hasText {
+		textDelta := make(map[string]json.RawMessage, len(delta))
+		maps.Copy(textDelta, delta)
+		delete(textDelta, "tool_calls")
+		deltas = append(deltas, textDelta)
+	}
+	for _, call := range calls {
+		callDelta := make(map[string]json.RawMessage, len(delta))
+		maps.Copy(callDelta, delta)
+		for _, member := range textMembers {
+			delete(callDelta, member)
+		}
 		single, err := json.Marshal([]json.RawMessage{call})
 		if err != nil {
 			return nil, false
 		}
-		partDelta["tool_calls"] = single
+		callDelta["tool_calls"] = single
+		deltas = append(deltas, callDelta)
+	}
+	out := make([]json.RawMessage, 0, len(deltas))
+	for i, partDelta := range deltas {
 		partChoice := make(map[string]json.RawMessage, len(obj))
 		maps.Copy(partChoice, obj)
+		var err error
 		if partChoice["delta"], err = json.Marshal(partDelta); err != nil {
 			return nil, false
 		}
-		if i < len(calls)-1 && jsonNonNull(partChoice["finish_reason"]) {
+		if i < len(deltas)-1 && jsonNonNull(partChoice["finish_reason"]) {
 			partChoice["finish_reason"] = json.RawMessage("null")
 		}
 		encoded, err := json.Marshal(partChoice)

--- a/internal/streaming/chat_codec.go
+++ b/internal/streaming/chat_codec.go
@@ -288,9 +288,11 @@ func jsonNonNull(raw json.RawMessage) bool {
 	return len(trimmed) > 0 && string(trimmed) != "null"
 }
 
-// Split turns a chunk with several choices into one chunk per choice. Every
-// top-level member is copied; usage, when present, stays on the last chunk
-// only so downstream accounting sees it once.
+// Split turns a chunk with several choices into one chunk per choice, and
+// a choice whose delta carries several tool calls into one chunk per tool
+// call, so each is decoded and transformed on its own. Every top-level
+// member is copied; usage and a choice's finish_reason stay on the last
+// part only so downstream accounting sees them once.
 func (c *chatCodec) Split(raw RawEvent) []RawEvent {
 	if raw.Comment || raw.Oversized || !jsonObject(raw.Data) {
 		return nil
@@ -300,11 +302,22 @@ func (c *chatCodec) Split(raw RawEvent) []RawEvent {
 		return nil
 	}
 	var choices []json.RawMessage
-	if err := json.Unmarshal(top["choices"], &choices); err != nil || len(choices) <= 1 {
+	if err := json.Unmarshal(top["choices"], &choices); err != nil || len(choices) == 0 {
 		return nil
 	}
-	out := make([]RawEvent, 0, len(choices))
-	for i, choice := range choices {
+	var parts []json.RawMessage
+	for _, choice := range choices {
+		split, ok := splitToolCalls(choice)
+		if !ok {
+			return nil
+		}
+		parts = append(parts, split...)
+	}
+	if len(parts) <= 1 {
+		return nil
+	}
+	out := make([]RawEvent, 0, len(parts))
+	for i, choice := range parts {
 		part := make(map[string]json.RawMessage, len(top))
 		maps.Copy(part, top)
 		single, err := json.Marshal([]json.RawMessage{choice})
@@ -312,7 +325,7 @@ func (c *chatCodec) Split(raw RawEvent) []RawEvent {
 			return nil
 		}
 		part["choices"] = single
-		if i < len(choices)-1 {
+		if i < len(parts)-1 {
 			delete(part, "usage")
 		}
 		data, err := json.Marshal(part)
@@ -323,6 +336,56 @@ func (c *chatCodec) Split(raw RawEvent) []RawEvent {
 		out = append(out, RawEvent{Name: raw.Name, Data: data, Raw: ev.Encode()})
 	}
 	return out
+}
+
+// splitToolCalls returns one copy of the choice per entry of its delta's
+// tool_calls, each carrying a single tool call; the choice's finish_reason
+// stays on the last copy. A choice with at most one tool call is returned
+// as is. ok is false when the choice cannot be decoded.
+func splitToolCalls(choice json.RawMessage) ([]json.RawMessage, bool) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(choice, &obj); err != nil {
+		return nil, false
+	}
+	var delta map[string]json.RawMessage
+	if raw, ok := obj["delta"]; !ok || !jsonObject(raw) {
+		return []json.RawMessage{choice}, true
+	} else if err := json.Unmarshal(raw, &delta); err != nil {
+		return nil, false
+	}
+	var calls []json.RawMessage
+	if raw, ok := delta["tool_calls"]; !ok || len(bytes.TrimSpace(raw)) == 0 || bytes.TrimSpace(raw)[0] != '[' {
+		return []json.RawMessage{choice}, true
+	} else if err := json.Unmarshal(raw, &calls); err != nil {
+		return nil, false
+	}
+	if len(calls) <= 1 {
+		return []json.RawMessage{choice}, true
+	}
+	out := make([]json.RawMessage, 0, len(calls))
+	for i, call := range calls {
+		partDelta := make(map[string]json.RawMessage, len(delta))
+		maps.Copy(partDelta, delta)
+		single, err := json.Marshal([]json.RawMessage{call})
+		if err != nil {
+			return nil, false
+		}
+		partDelta["tool_calls"] = single
+		partChoice := make(map[string]json.RawMessage, len(obj))
+		maps.Copy(partChoice, obj)
+		if partChoice["delta"], err = json.Marshal(partDelta); err != nil {
+			return nil, false
+		}
+		if i < len(calls)-1 && jsonNonNull(partChoice["finish_reason"]) {
+			partChoice["finish_reason"] = json.RawMessage("null")
+		}
+		encoded, err := json.Marshal(partChoice)
+		if err != nil {
+			return nil, false
+		}
+		out = append(out, encoded)
+	}
+	return out, true
 }
 
 // Restate is a no-op: chat chunks never repeat streamed text.

--- a/internal/streaming/responses_codec.go
+++ b/internal/streaming/responses_codec.go
@@ -37,6 +37,10 @@ type responsesItem struct {
 	raw          json.RawMessage
 	text         strings.Builder
 	arguments    strings.Builder
+	// argsOpen says an arguments delta was decoded for the item, so the
+	// events restating its arguments are rewritten to what was emitted
+	// even when that is nothing.
+	argsOpen     bool
 	contentIndex int
 	partOpen     bool
 	done         bool
@@ -109,7 +113,7 @@ func (c *responsesCodec) Decode(raw RawEvent, seq int) Event {
 	case "response.reasoning_summary_text.delta", "response.reasoning_text.delta":
 		ev.Kind, ev.Text = KindReasoningDelta, view.Delta
 	case "response.function_call_arguments.delta":
-		ev.Kind, ev.Text = KindToolCallDelta, view.Delta
+		ev.Kind, ev.Text, ev.Call = KindToolCallDelta, view.Delta, view.OutputIndex
 	case "response.completed", "response.incomplete", "response.failed":
 		ev.Kind = KindFinish
 	}
@@ -143,6 +147,9 @@ func (c *responsesCodec) remember(view *responsesEventView) {
 		c.openPart()
 	case "response.function_call_arguments.delta":
 		c.argsIndex = view.OutputIndex
+		if item := c.items[c.argsIndex]; item != nil {
+			item.argsOpen = true
+		}
 	}
 }
 
@@ -226,7 +233,7 @@ func (c *responsesCodec) Track(ev Event) {
 }
 
 func (c *responsesCodec) RewriteText(ev Event, text string) (Event, error) {
-	if ev.Kind != KindTextDelta && ev.Kind != KindReasoningDelta {
+	if !isDelta(ev.Kind) {
 		return ev, ErrNotTextEvent
 	}
 	var top map[string]json.RawMessage
@@ -277,6 +284,8 @@ func (c *responsesCodec) Restate(ev Event) (Event, bool) {
 		changed = c.restateText(top, "text", view.OutputIndex, view.ContentIndex, false)
 	case "response.reasoning_summary_text.done":
 		changed = c.restateText(top, "text", view.OutputIndex, view.SummaryIndex, true)
+	case "response.function_call_arguments.done":
+		changed = c.restateArguments(top, c.items[view.OutputIndex])
 	case "response.content_part.done":
 		changed = c.restateNested(top, "part", func(part map[string]json.RawMessage) bool {
 			return c.restateText(part, "text", view.OutputIndex, view.ContentIndex, false)
@@ -330,6 +339,23 @@ func (c *responsesCodec) restateText(obj map[string]json.RawMessage, key string,
 	return true
 }
 
+// restateArguments sets obj["arguments"] to the emitted arguments of a
+// function-call item when deltas were tracked for it and they differ.
+func (c *responsesCodec) restateArguments(obj map[string]json.RawMessage, item *responsesItem) bool {
+	if item == nil || !item.argsOpen {
+		return false
+	}
+	if current, ok := jsonStringOf(obj["arguments"]); ok && current == item.arguments.String() {
+		return false
+	}
+	encoded, err := json.Marshal(item.arguments.String())
+	if err != nil {
+		return false
+	}
+	obj["arguments"] = encoded
+	return true
+}
+
 // restateNested decodes obj[key] as an object, lets fn edit it, and writes
 // it back when fn reports a change.
 func (c *responsesCodec) restateNested(obj map[string]json.RawMessage, key string, fn func(map[string]json.RawMessage) bool) bool {
@@ -355,7 +381,7 @@ func (c *responsesCodec) restateItem(obj map[string]json.RawMessage, item *respo
 	if item == nil {
 		return false
 	}
-	changed := false
+	changed := c.restateArguments(obj, item)
 	for _, member := range []struct {
 		key     string
 		emitted map[int]*strings.Builder

--- a/internal/streaming/responses_codec.go
+++ b/internal/streaming/responses_codec.go
@@ -31,12 +31,12 @@ type responsesEventView struct {
 // responsesItem tracks an output item announced by response.output_item.added
 // so a cut stream can close it.
 type responsesItem struct {
-	index        int
-	id           string
-	itemType     string
-	raw          json.RawMessage
-	text         strings.Builder
-	arguments    strings.Builder
+	index     int
+	id        string
+	itemType  string
+	raw       json.RawMessage
+	text      strings.Builder
+	arguments strings.Builder
 	// argsOpen says an arguments delta was decoded for the item, so the
 	// events restating its arguments are rewritten to what was emitted
 	// even when that is nothing.

--- a/internal/streaming/responses_codec.go
+++ b/internal/streaming/responses_codec.go
@@ -81,14 +81,14 @@ type responsesCodec struct {
 	seq                 int
 	items               map[int]*responsesItem
 	order               []int
-	// textIndex and argsIndex are the output_index of the most recently
-	// decoded text and function-call delta; emitted deltas (which may be
-	// re-segmented copies) are attributed to them by Track. textPart is
-	// the content or summary index of that text delta and textSummary says
-	// which of the two it is.
-	textIndex, argsIndex int
-	textPart             int
-	textSummary          bool
+	// textIndex is the output_index of the most recently decoded text
+	// delta; emitted text deltas (which may be re-segmented copies) are
+	// attributed to it by Track. textPart is the content or summary index
+	// of that delta and textSummary says which of the two it is. Tool-call
+	// deltas carry their item in Event.Call instead.
+	textIndex   int
+	textPart    int
+	textSummary bool
 }
 
 // ResponsesCodec returns a codec for Responses API event streams.
@@ -146,8 +146,7 @@ func (c *responsesCodec) remember(view *responsesEventView) {
 		c.textIndex, c.textPart, c.textSummary = view.OutputIndex, view.SummaryIndex, true
 		c.openPart()
 	case "response.function_call_arguments.delta":
-		c.argsIndex = view.OutputIndex
-		if item := c.items[c.argsIndex]; item != nil {
+		if item := c.items[view.OutputIndex]; item != nil {
 			item.argsOpen = true
 		}
 	}
@@ -189,7 +188,9 @@ func (c *responsesCodec) Track(ev Event) {
 		}
 		return
 	case KindToolCallDelta:
-		if item := c.items[c.argsIndex]; item != nil {
+		// The event names its item: a window flushed by a later item's
+		// delta must not be credited to that later item.
+		if item := c.items[ev.Call]; item != nil {
 			item.arguments.WriteString(ev.Text)
 		}
 		return

--- a/internal/streaming/sse_event.go
+++ b/internal/streaming/sse_event.go
@@ -24,13 +24,18 @@ type Event struct {
 	Kind EventKind
 	// Choice is the chat choice index; always 0 for Responses streams.
 	Choice int
+	// Call is the index of the tool call a tool-call delta belongs to: the
+	// delta's tool_calls[].index in a chat stream, the output_index of the
+	// function_call item in a Responses stream. 0 for other kinds.
+	Call int
 	// Text is the delta text for text and reasoning deltas, and the arguments
 	// fragment carried by a tool call delta. Empty for other kinds.
 	Text string
 	// Overlap is the number of leading characters (runes) of Text that were
-	// already shown in the previous text event of this choice. It is non-zero
-	// only for text deltas re-segmented under lookbehind, where consecutive
-	// windows overlap; Text[Overlap:] is the new text.
+	// already shown in the previous event of this window (a choice's text,
+	// or one of its tool calls' arguments). It is non-zero only for deltas
+	// re-segmented under lookbehind, where consecutive windows overlap;
+	// Text[Overlap:] is the new text.
 	Overlap int
 	// ClosesChoice marks a delta event whose chunk also carries the
 	// finish_reason of its choice (a chat stream may end text and finish in

--- a/internal/streaming/transformed_sse_stream.go
+++ b/internal/streaming/transformed_sse_stream.go
@@ -20,8 +20,8 @@ const (
 // Decision is a Transformer's verdict on one event.
 type Decision struct {
 	Action Action
-	// Text is the replacement delta text for ActionReplace. Only text and
-	// reasoning deltas can be replaced.
+	// Text is the replacement delta text for ActionReplace. Text,
+	// reasoning, and tool-call argument deltas can be replaced.
 	Text string
 	// Terminate describes how to end the stream for ActionTerminate; nil
 	// selects the codec defaults (finish_reason "content_filter").
@@ -89,19 +89,28 @@ const MaxMinChunkChars = 16 * 1024
 // Reads return io.EOF.
 //
 // Lookbehind re-segmentation (LookbehindChars = N > 0) applies to text
-// deltas only and works per choice with a withheld tail of at most N
-// characters (runes), initially empty:
+// deltas and to tool-call argument deltas, each kind in its own window: a
+// choice's text is one window and each of its tool calls' arguments
+// (Event.Call) another, with a withheld tail of at most N characters
+// (runes), initially empty:
 //
-//  1. When a text delta arrives, t sees one text event whose Text is the
+//  1. When a delta arrives, t sees one event of its kind whose Text is the
 //     window tail+delta (Event.Overlap is the tail's length). Its decision
 //     applies to the whole window: pass keeps it, replace substitutes
 //     Decision.Text for it, drop discards it (tail included).
 //  2. Of the resulting window, everything but the last N characters is
 //     emitted to the client; the last N become the new tail.
-//  3. A non-text event of any kind (tool call, finish, usage, other) first
-//     flushes every choice's tail, and the upstream end flushes them before
-//     OnEnd: t sees the tail once more as a text event (Overlap equal to
-//     its length) and the result is emitted in full.
+//  3. An event that is not held (reasoning, finish, usage, other, a tool
+//     call announced with empty arguments) first flushes every window, a
+//     delta for another window of the same choice flushes that choice's
+//     other windows, and the upstream end flushes them all before OnEnd:
+//     t sees the tail once more (Overlap equal to its length) and the
+//     result is emitted in full. Events therefore keep their order.
+//
+// The first chunk of a window's run stays the template of its re-segmented
+// events until something is emitted from it, so members only that chunk
+// carries (a tool call's id and name sent with its first arguments) reach
+// the client once.
 //
 // Consequently a pattern of up to N+1 characters is always visible to t in
 // one event before any of its characters reaches the client, at the cost of
@@ -134,7 +143,7 @@ func NewTransformedSSEStream(upstream io.ReadCloser, codec Codec, t Transformer,
 		opts:     opts,
 		scanner:  EventScanner{MaxEventBytes: opts.MaxEventBytes},
 		readBuf:  make([]byte, transformReadBufferSize),
-		pending:  make(map[int]*pendingText),
+		pending:  make(map[pendingKey]*pendingText),
 	}
 }
 
@@ -150,8 +159,8 @@ type transformedSSEStream struct {
 	outPos int
 	seq    int
 
-	pending      map[int]*pendingText
-	pendingOrder []int
+	pending      map[pendingKey]*pendingText
+	pendingOrder []pendingKey
 
 	ended          bool
 	endCalled      bool
@@ -160,7 +169,30 @@ type transformedSSEStream struct {
 	finalErr       error
 }
 
-// pendingText is the withheld text of one choice: the lookbehind tail the
+// pendingKey identifies a window: a choice's text, or the arguments of one
+// of its tool calls.
+type pendingKey struct {
+	choice int
+	call   int
+	kind   EventKind
+}
+
+func keyOf(ev Event) pendingKey {
+	key := pendingKey{choice: ev.Choice, kind: ev.Kind}
+	if ev.Kind == KindToolCallDelta {
+		key.call = ev.Call
+	}
+	return key
+}
+
+// held reports whether ev is re-segmented rather than relayed: text deltas
+// and tool-call deltas carrying arguments. A tool call announced with
+// empty arguments passes through, so its id and name are relayed at once.
+func held(ev Event) bool {
+	return ev.Kind == KindTextDelta || (ev.Kind == KindToolCallDelta && ev.Text != "")
+}
+
+// pendingText is the withheld text of one window: the lookbehind tail the
 // transformer already saw and the pending run it has not, together with the
 // chunks re-segmented events are rendered from.
 type pendingText struct {
@@ -178,7 +210,10 @@ type pendingText struct {
 	template         Event
 	head             Event
 	templateTerminal bool
-	dataBuf          []byte
+	// armed says the template is the first chunk of the run and nothing
+	// was emitted from it yet, so it is kept until something is.
+	armed   bool
+	dataBuf []byte
 	// closer is the latest chunk of the run that carried once-per-choice
 	// members (a chat chunk's finish_reason and usage), owed to the client
 	// while terminal is set.
@@ -318,7 +353,7 @@ func (s *transformedSSEStream) handleOne(raw RawEvent) {
 		s.write(raw.Raw)
 		return
 	}
-	if (s.opts.LookbehindChars > 0 || s.opts.MinChunkChars > 0) && ev.Kind == KindTextDelta {
+	if (s.opts.LookbehindChars > 0 || s.opts.MinChunkChars > 0) && held(ev) {
 		s.hold(ev)
 		return
 	}
@@ -431,22 +466,29 @@ func (s *transformedSSEStream) callEnd() {
 	}
 }
 
-// hold adds the delta to the pending text of the event's choice and, once
+// hold adds the delta to the pending text of its window and, once
 // MinChunkChars are pending, shows the transformer the window tail+pending,
 // emits all but the last N characters of the result and keeps the rest as
-// the new tail.
+// the new tail. A delta for another window of the same choice first
+// flushes that choice's other windows, so events keep their order.
 func (s *transformedSSEStream) hold(ev Event) {
-	p := s.pending[ev.Choice]
+	key := keyOf(ev)
+	s.flushOthers(key)
+	if s.ended {
+		return
+	}
+	p := s.pending[key]
 	if p == nil {
 		p = &pendingText{}
-		s.pending[ev.Choice] = p
+		s.pending[key] = p
 	}
 	if !p.queued {
 		p.queued = true
-		s.pendingOrder = append(s.pendingOrder, ev.Choice)
+		s.pendingOrder = append(s.pendingOrder, key)
 	}
-	if p.pending == "" {
+	if p.pending == "" && !p.armed {
 		s.setTemplate(p, ev)
+		p.armed = true
 	}
 	if _, terminal := s.codec.StripTerminal(ev); terminal {
 		s.setCloser(p, ev)
@@ -458,75 +500,105 @@ func (s *transformedSSEStream) hold(ev Event) {
 	}
 	window := p.tail + p.pending
 	p.pending = ""
-	result, ok := s.inspect(ev.Choice, p, window, utf8.RuneCountInString(p.tail))
+	result, ok := s.inspect(key, p, window, utf8.RuneCountInString(p.tail))
 	if !ok {
 		p.tail = ""
 		return
 	}
 	head, tail := splitTail(result, s.opts.LookbehindChars)
 	p.tail = tail
-	s.emitText(ev.Choice, p.head, head)
+	if head != "" {
+		s.emitText(key, p.head, head)
+		p.armed = false
+	}
 	// The withheld tail continues under the latest chunk, so once-per-choice
-	// members it carries go out with the choice's last text.
-	s.setTemplate(p, ev)
+	// members it carries go out with the choice's last text; a template
+	// nothing was emitted from yet stays.
+	if !p.armed {
+		s.setTemplate(p, ev)
+	}
 }
 
-// flushPending shows the transformer every choice's tail (once more) and
+// flushPending shows the transformer every window's tail (once more) and
 // pending text and emits the results in full, in the order the windows were
 // opened.
 func (s *transformedSSEStream) flushPending() {
-	for _, choice := range s.pendingOrder {
-		p := s.pending[choice]
-		if p == nil {
-			continue
-		}
-		p.queued = false
-		window := p.tail + p.pending
-		if window == "" {
-			s.emitEnvelope(choice, p)
-			continue
-		}
-		overlap := utf8.RuneCountInString(p.tail)
-		p.tail, p.pending = "", ""
-		result, ok := s.inspect(choice, p, window, overlap)
+	for _, key := range s.pendingOrder {
+		s.flushOne(key)
 		if s.ended {
 			return
-		}
-		switch {
-		case !ok || result == "":
-			s.emitEnvelope(choice, p)
-		case p.terminal && !p.templateTerminal:
-			// The run's template is not the chunk that carries the
-			// once-per-choice members: the text goes out from it and the
-			// owed chunk follows with empty text.
-			s.emitText(choice, p.head, result)
-			s.emitEnvelope(choice, p)
-		default:
-			s.emitText(choice, p.template, result)
-			p.terminal = false
 		}
 	}
 	s.pendingOrder = s.pendingOrder[:0]
 }
 
+// flushOthers flushes the windows of key's choice other than key.
+func (s *transformedSSEStream) flushOthers(key pendingKey) {
+	kept := s.pendingOrder[:0]
+	for _, other := range s.pendingOrder {
+		if other.choice != key.choice || other == key {
+			kept = append(kept, other)
+			continue
+		}
+		s.flushOne(other)
+		if s.ended {
+			return
+		}
+	}
+	s.pendingOrder = kept
+}
+
+func (s *transformedSSEStream) flushOne(key pendingKey) {
+	p := s.pending[key]
+	if p == nil {
+		return
+	}
+	p.queued = false
+	window := p.tail + p.pending
+	if window == "" {
+		s.emitEnvelope(key, p)
+		return
+	}
+	overlap := utf8.RuneCountInString(p.tail)
+	p.tail, p.pending = "", ""
+	result, ok := s.inspect(key, p, window, overlap)
+	if s.ended {
+		return
+	}
+	switch {
+	case !ok || result == "":
+		s.emitEnvelope(key, p)
+	case p.terminal && !p.templateTerminal:
+		// The run's template is not the chunk that carries the
+		// once-per-choice members: the text goes out from it and the
+		// owed chunk follows with empty text.
+		s.emitText(key, p.head, result)
+		s.emitEnvelope(key, p)
+	default:
+		s.emitText(key, p.template, result)
+		p.terminal = false
+	}
+	p.armed = false
+}
+
 // emitEnvelope delivers the owed once-per-choice members when their chunk's
 // text was dropped, emptied, or emitted from another template: the chunk
 // goes out with empty text. Nothing is emitted when none are owed.
-func (s *transformedSSEStream) emitEnvelope(choice int, p *pendingText) {
+func (s *transformedSSEStream) emitEnvelope(key pendingKey, p *pendingText) {
 	if !p.terminal {
 		return
 	}
 	p.terminal = false
-	ev := s.resegment(choice, p.closer, "")
+	ev := s.resegment(key, p.closer, "")
 	s.codec.Track(ev)
 	s.out = ev.appendEncoded(s.out)
 }
 
-// inspect hands text to the transformer as one text event built from the
-// choice's template chunk and returns the text to emit; ok is false when
-// nothing should be emitted (drop) or the stream ended.
-func (s *transformedSSEStream) inspect(choice int, p *pendingText, text string, overlap int) (string, bool) {
-	ev := s.resegment(choice, p.template, text)
+// inspect hands text to the transformer as one event of the window's kind
+// built from its template chunk and returns the text to emit; ok is false
+// when nothing should be emitted (drop) or the stream ended.
+func (s *transformedSSEStream) inspect(key pendingKey, p *pendingText, text string, overlap int) (string, bool) {
+	ev := s.resegment(key, p.template, text)
 	ev.Seq = s.seq
 	ev.Overlap = overlap
 	s.seq++
@@ -544,26 +616,26 @@ func (s *transformedSSEStream) inspect(choice int, p *pendingText, text string, 
 	}
 }
 
-// emitText renders text as a re-segmented event of the choice built from
+// emitText renders text as a re-segmented event of the window built from
 // template.
-func (s *transformedSSEStream) emitText(choice int, template Event, text string) {
+func (s *transformedSSEStream) emitText(key pendingKey, template Event, text string) {
 	if text == "" {
 		return
 	}
-	ev := s.resegment(choice, template, text)
+	ev := s.resegment(key, template, text)
 	s.codec.Track(ev)
 	s.out = ev.appendEncoded(s.out)
 }
 
-func (s *transformedSSEStream) resegment(choice int, template Event, text string) Event {
+func (s *transformedSSEStream) resegment(key pendingKey, template Event, text string) Event {
 	ev := template
-	ev.Choice = choice
+	ev.Choice = key.choice
 	if ev.Text == text {
 		return ev
 	}
 	rewritten, err := s.codec.RewriteText(ev, text)
 	if err != nil {
-		s.report(fmt.Errorf("streaming: re-segment text for choice %d: %w", choice, err))
+		s.report(fmt.Errorf("streaming: re-segment %s for choice %d: %w", ev.Kind, key.choice, err))
 		ev.Text = text
 		return ev
 	}

--- a/internal/streaming/transformed_sse_stream.go
+++ b/internal/streaming/transformed_sse_stream.go
@@ -102,10 +102,12 @@ const MaxMinChunkChars = 16 * 1024
 //     emitted to the client; the last N become the new tail.
 //  3. An event that is not held (reasoning, finish, usage, other, a tool
 //     call announced with empty arguments) first flushes every window, a
-//     delta for another window of the same choice flushes that choice's
-//     other windows, and the upstream end flushes them all before OnEnd:
-//     t sees the tail once more (Overlap equal to its length) and the
-//     result is emitted in full. Events therefore keep their order.
+//     delta of another kind for the same choice flushes that choice's
+//     windows of other kinds (its text before its first tool call), and
+//     the upstream end flushes them all before OnEnd: t sees the tail once
+//     more (Overlap equal to its length) and the result is emitted in
+//     full. Windows of one kind (parallel tool calls) are independent and
+//     may interleave without flushing each other.
 //
 // The first chunk of a window's run stays the template of its re-segmented
 // events until something is emitted from it, so members only that chunk
@@ -469,8 +471,9 @@ func (s *transformedSSEStream) callEnd() {
 // hold adds the delta to the pending text of its window and, once
 // MinChunkChars are pending, shows the transformer the window tail+pending,
 // emits all but the last N characters of the result and keeps the rest as
-// the new tail. A delta for another window of the same choice first
-// flushes that choice's other windows, so events keep their order.
+// the new tail. A delta of another kind for the same choice first flushes
+// that choice's windows of other kinds, so text and tool calls keep their
+// order.
 func (s *transformedSSEStream) hold(ev Event) {
 	key := keyOf(ev)
 	s.flushOthers(key)
@@ -532,11 +535,11 @@ func (s *transformedSSEStream) flushPending() {
 	s.pendingOrder = s.pendingOrder[:0]
 }
 
-// flushOthers flushes the windows of key's choice other than key.
+// flushOthers flushes the windows of key's choice that are of another kind.
 func (s *transformedSSEStream) flushOthers(key pendingKey) {
 	kept := s.pendingOrder[:0]
 	for _, other := range s.pendingOrder {
-		if other.choice != key.choice || other == key {
+		if other.choice != key.choice || other.kind == key.kind {
 			kept = append(kept, other)
 			continue
 		}

--- a/internal/streaming/transformed_sse_stream_test.go
+++ b/internal/streaming/transformed_sse_stream_test.go
@@ -493,7 +493,9 @@ func TestTransformedSSEStream_LookbehindOrderingWithToolCallAndFinish(t *testing
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []EventKind{KindTextDelta, KindTextDelta, KindToolCallDelta, KindTextDelta, KindTextDelta, KindFinish}
+	// The tool call's arguments are a window of their own: seen once on
+	// arrival and once more when the next text delta flushes them.
+	want := []EventKind{KindTextDelta, KindTextDelta, KindToolCallDelta, KindToolCallDelta, KindTextDelta, KindTextDelta, KindFinish}
 	if strings.Join(kindStrings(kinds(tr.seen)), ",") != strings.Join(kindStrings(want), ",") {
 		t.Errorf("transformer saw %v, want %v", kinds(tr.seen), want)
 	}

--- a/internal/streaming/transformed_tool_calls_test.go
+++ b/internal/streaming/transformed_tool_calls_test.go
@@ -94,9 +94,10 @@ func TestTransformedSSEStream_ToolCallsAreSeparateWindows(t *testing.T) {
 			seen = append(seen, string(rune('0'+ev.Call))+":"+ev.Text)
 		}
 	}
-	// Each window is seen on arrival and once more when it is flushed:
-	// call 0 by call 1's first delta, call 1 by the finish chunk.
-	want := []string{`0:{"a":"<EMA`, `0:{"a":"<EMA`, `1:{"b":"<EMA`, `1:{"b":"<EMAIL_1>"}`, `1:"b":"a@b.c"}`}
+	// Parallel calls are independent windows: call 1's deltas do not
+	// flush call 0. Each is seen on arrival and once more, in order, when
+	// the finish chunk flushes them.
+	want := []string{`0:{"a":"<EMA`, `1:{"b":"<EMA`, `1:{"b":"<EMAIL_1>"}`, `0:{"a":"<EMA`, `1:"b":"a@b.c"}`}
 	if !equalStrings(seen, want) {
 		t.Errorf("windows = %q, want %q", seen, want)
 	}
@@ -142,8 +143,14 @@ func TestCodecs_RewriteToolCallArguments(t *testing.T) {
 		t.Errorf("chat rewrite = %s, %v", rewritten.Data, err)
 	}
 	stripped, ok := chat.StripTerminal(ev)
-	if !ok || strings.Contains(string(stripped.Data), "tool_calls\"}") && strings.Contains(string(stripped.Data), `"finish_reason":"tool_calls"`) {
-		t.Errorf("strip = %s, %v", stripped.Data, ok)
+	if !ok || stripped.ClosesChoice {
+		t.Errorf("strip reported no change: %s", stripped.Data)
+	}
+	if strings.Contains(string(stripped.Data), `"finish_reason":"tool_calls"`) {
+		t.Errorf("finish_reason not stripped: %s", stripped.Data)
+	}
+	if !strings.Contains(string(stripped.Data), `"arguments":"{\"x\""`) {
+		t.Errorf("arguments lost by strip: %s", stripped.Data)
 	}
 	responses := ResponsesCodec()
 	ev = responses.Decode(RawEvent{Name: "response.function_call_arguments.delta", Data: []byte(`{"type":"response.function_call_arguments.delta","output_index":3,"delta":"ab"}`)}, 0)
@@ -178,9 +185,9 @@ func TestTransformedSSEStream_ParallelToolCallsInOneDelta(t *testing.T) {
 			calls = append(calls, ev.Call)
 		}
 	}
-	// Call 0 is seen on arrival and once more when call 1's delta flushes
-	// it; call 1 on arrival, on its second delta, and at the final flush.
-	if strings.Trim(strings.Join(strings.Fields(strings.Trim(fmt.Sprint(calls), "[]")), ","), ",") != "0,0,1,1,1" {
+	// Both calls are seen on arrival, call 1 again on its second delta,
+	// and both once more at the final flush.
+	if strings.Trim(strings.Join(strings.Fields(strings.Trim(fmt.Sprint(calls), "[]")), ","), ",") != "0,1,1,0,1" {
 		t.Errorf("transformer saw calls %v", calls)
 	}
 	resp, err := AssembleChatResponse(decodeChatEvents(t, got))
@@ -196,5 +203,36 @@ func TestTransformedSSEStream_ParallelToolCallsInOneDelta(t *testing.T) {
 	}
 	if n := strings.Count(string(got), `"finish_reason":"tool_calls"`); n != 1 {
 		t.Errorf("finish_reason emitted %d times", n)
+	}
+}
+
+func TestTransformedSSEStream_ResponsesInterleavedToolCalls(t *testing.T) {
+	// Two function-call items stream their arguments turn by turn. Each
+	// flush of the older window must be credited to its own item, so the
+	// restating events carry the right arguments.
+	item := func(i int, name string) string {
+		return "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"output_index\":" + string(rune('0'+i)) + ",\"item\":{\"id\":\"fc_" + string(rune('0'+i)) + "\",\"type\":\"function_call\",\"call_id\":\"c" + string(rune('0'+i)) + "\",\"name\":\"" + name + "\",\"arguments\":\"\"}}\n\n"
+	}
+	delta := func(i int, text string) string {
+		return "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"output_index\":" + string(rune('0'+i)) + ",\"delta\":\"" + text + "\"}\n\n"
+	}
+	done := func(i int, args string) string {
+		return "event: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"output_index\":" + string(rune('0'+i)) + ",\"arguments\":\"" + args + "\"}\n\n"
+	}
+	input := item(0, "f") + item(1, "g") +
+		delta(0, "{\\\"a\\\":\\\"<EMA") + delta(1, "{\\\"b\\\":1") + delta(0, "IL_1>\\\"}") + delta(1, "}") +
+		done(0, "{\\\"a\\\":\\\"<EMAIL_1>\\\"}") + done(1, "{\\\"b\\\":1}")
+	tr := restoreTransformer()
+	stream := NewTransformedSSEStream(io.NopCloser(strings.NewReader(input)), ResponsesCodec(), tr, TransformOptions{LookbehindChars: 12})
+	got, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(got)
+	if strings.Contains(out, "EMAIL_1") {
+		t.Errorf("placeholder leaked:\n%s", out)
+	}
+	if !strings.Contains(out, `"arguments":"{\"a\":\"a@b.c\"}"`) || !strings.Contains(out, `"arguments":"{\"b\":1}"`) {
+		t.Errorf("done events restated wrongly:\n%s", out)
 	}
 }

--- a/internal/streaming/transformed_tool_calls_test.go
+++ b/internal/streaming/transformed_tool_calls_test.go
@@ -1,0 +1,156 @@
+package streaming
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+// restoreTransformer puts "a@b.c" in place of "<EMAIL_1>" in every delta
+// window, tool-call arguments included, skipping matches that end inside
+// the overlap.
+func restoreTransformer() *funcTransformer {
+	return &funcTransformer{onEvent: func(ev *Event) (Decision, error) {
+		if !isDelta(ev.Kind) {
+			return Decision{Action: ActionPass}, nil
+		}
+		skip := 0
+		for i := 0; i < ev.Overlap && skip < len(ev.Text); i++ {
+			skip++
+		}
+		idx := strings.Index(ev.Text, "<EMAIL_1>")
+		if idx < 0 || idx+len("<EMAIL_1>") <= skip {
+			return Decision{Action: ActionPass}, nil
+		}
+		return Decision{Action: ActionReplace, Text: strings.ReplaceAll(ev.Text, "<EMAIL_1>", "a@b.c")}, nil
+	}}
+}
+
+func TestTransformedSSEStream_ToolCallArgumentsAcrossChunks(t *testing.T) {
+	// The first chunk carries the call's id and name with its first
+	// arguments; the placeholder is split across the next two.
+	input := `data: {"choices":[{"index":0,"delta":{"role":"assistant","content":null},"finish_reason":null}]}` + "\n\n" +
+		`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"send","arguments":"{\"to\":\""}}]},"finish_reason":null}]}` + "\n\n" +
+		`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"<EMA"}}]},"finish_reason":null}]}` + "\n\n" +
+		`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"IL_1>\"}"}}]},"finish_reason":null}]}` + "\n\n" +
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\n" +
+		"data: [DONE]\n\n"
+	tr := restoreTransformer()
+	stream := NewTransformedSSEStream(io.NopCloser(strings.NewReader(input)), ChatCodec(), tr, TransformOptions{LookbehindChars: 12})
+	got, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(got), "<EMA") {
+		t.Errorf("placeholder fragment leaked:\n%s", got)
+	}
+	for _, ev := range tr.seen {
+		if ev.Kind == KindToolCallDelta && ev.Call != 0 {
+			t.Errorf("call index = %d", ev.Call)
+		}
+	}
+	resp, err := AssembleChatResponse(decodeChatEvents(t, got))
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls := resp.Choices[0].Message.ToolCalls
+	if len(calls) != 1 || calls[0].ID != "call_1" || calls[0].Function.Name != "send" || calls[0].Function.Arguments != `{"to":"a@b.c"}` {
+		t.Errorf("assembled tool calls = %+v", calls)
+	}
+	if resp.Choices[0].FinishReason != "tool_calls" {
+		t.Errorf("finish = %q", resp.Choices[0].FinishReason)
+	}
+	if n := strings.Count(string(got), `"finish_reason":"tool_calls"`); n != 1 {
+		t.Errorf("finish_reason emitted %d times", n)
+	}
+}
+
+func TestTransformedSSEStream_ToolCallsAreSeparateWindows(t *testing.T) {
+	input := `data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"c0","function":{"name":"f","arguments":"{\"a\":\"<EMA"}}]}}]}` + "\n\n" +
+		`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"id":"c1","function":{"name":"g","arguments":"{\"b\":\"<EMA"}}]}}]}` + "\n\n" +
+		`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"function":{"arguments":"IL_1>\"}"}}]}}]}` + "\n\n" +
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\n" +
+		"data: [DONE]\n\n"
+	tr := restoreTransformer()
+	stream := NewTransformedSSEStream(io.NopCloser(strings.NewReader(input)), ChatCodec(), tr, TransformOptions{LookbehindChars: 12})
+	got, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Call 1's first delta flushed call 0's window; call 0 keeps its
+	// unfinished fragment, call 1 is restored whole.
+	resp, err := AssembleChatResponse(decodeChatEvents(t, got))
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls := resp.Choices[0].Message.ToolCalls
+	if len(calls) != 2 || calls[0].Function.Arguments != `{"a":"<EMA` || calls[1].Function.Arguments != `{"b":"a@b.c"}` || calls[1].ID != "c1" {
+		t.Errorf("assembled tool calls = %+v", calls)
+	}
+	var seen []string
+	for _, ev := range tr.seen {
+		if ev.Kind == KindToolCallDelta {
+			seen = append(seen, string(rune('0'+ev.Call))+":"+ev.Text)
+		}
+	}
+	// Each window is seen on arrival and once more when it is flushed:
+	// call 0 by call 1's first delta, call 1 by the finish chunk.
+	want := []string{`0:{"a":"<EMA`, `0:{"a":"<EMA`, `1:{"b":"<EMA`, `1:{"b":"<EMAIL_1>"}`, `1:"b":"a@b.c"}`}
+	if !equalStrings(seen, want) {
+		t.Errorf("windows = %q, want %q", seen, want)
+	}
+}
+
+func TestTransformedSSEStream_ResponsesToolCallArgumentsRestated(t *testing.T) {
+	input := "event: response.created\ndata: {\"type\":\"response.created\",\"sequence_number\":0,\"response\":{\"id\":\"r1\",\"model\":\"m\",\"created_at\":1}}\n\n" +
+		"event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"sequence_number\":1,\"output_index\":0,\"item\":{\"id\":\"fc_1\",\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"send\",\"arguments\":\"\"}}\n\n" +
+		"event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"sequence_number\":2,\"item_id\":\"fc_1\",\"output_index\":0,\"delta\":\"{\\\"to\\\":\\\"<EMA\"}\n\n" +
+		"event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"sequence_number\":3,\"item_id\":\"fc_1\",\"output_index\":0,\"delta\":\"IL_1>\\\"}\"}\n\n" +
+		"event: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"sequence_number\":4,\"item_id\":\"fc_1\",\"output_index\":0,\"arguments\":\"{\\\"to\\\":\\\"<EMAIL_1>\\\"}\"}\n\n" +
+		"event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"sequence_number\":5,\"output_index\":0,\"item\":{\"id\":\"fc_1\",\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"send\",\"arguments\":\"{\\\"to\\\":\\\"<EMAIL_1>\\\"}\",\"status\":\"completed\"}}\n\n" +
+		"event: response.completed\ndata: {\"type\":\"response.completed\",\"sequence_number\":6,\"response\":{\"id\":\"r1\",\"model\":\"m\",\"created_at\":1,\"status\":\"completed\",\"output\":[{\"id\":\"fc_1\",\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"send\",\"arguments\":\"{\\\"to\\\":\\\"<EMAIL_1>\\\"}\",\"status\":\"completed\"}]}}\n\n"
+	tr := restoreTransformer()
+	stream := NewTransformedSSEStream(io.NopCloser(strings.NewReader(input)), ResponsesCodec(), tr, TransformOptions{LookbehindChars: 12})
+	got, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(got), "EMAIL_1") || strings.Contains(string(got), "<EMA") {
+		t.Errorf("placeholder leaked:\n%s", got)
+	}
+	if n := strings.Count(string(got), `a@b.c`); n != 4 {
+		t.Errorf("restored value appears %d times (delta, done, item.done, completed), want 4:\n%s", n, got)
+	}
+	resp, err := AssembleResponsesResponse(decodeResponsesEvents(t, got))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Output) != 1 || resp.Output[0].Arguments != `{"to":"a@b.c"}` || resp.Output[0].CallID != "call_1" {
+		t.Errorf("assembled = %+v", resp.Output)
+	}
+}
+
+func TestCodecs_RewriteToolCallArguments(t *testing.T) {
+	chat := ChatCodec()
+	ev := chat.Decode(RawEvent{Data: []byte(`{"choices":[{"index":0,"delta":{"tool_calls":[{"index":2,"id":"c","function":{"name":"f","arguments":"{\"x\""}}]},"finish_reason":"tool_calls"}]}`)}, 0)
+	if ev.Kind != KindToolCallDelta || ev.Call != 2 || ev.Text != `{"x"` || !ev.ClosesChoice {
+		t.Fatalf("decoded = %+v", ev)
+	}
+	rewritten, err := chat.RewriteText(ev, `{"y"`)
+	if err != nil || rewritten.Text != `{"y"` || !strings.Contains(string(rewritten.Data), `"arguments":"{\"y\""`) || !strings.Contains(string(rewritten.Data), `"name":"f"`) {
+		t.Errorf("chat rewrite = %s, %v", rewritten.Data, err)
+	}
+	stripped, ok := chat.StripTerminal(ev)
+	if !ok || strings.Contains(string(stripped.Data), "tool_calls\"}") && strings.Contains(string(stripped.Data), `"finish_reason":"tool_calls"`) {
+		t.Errorf("strip = %s, %v", stripped.Data, ok)
+	}
+	responses := ResponsesCodec()
+	ev = responses.Decode(RawEvent{Name: "response.function_call_arguments.delta", Data: []byte(`{"type":"response.function_call_arguments.delta","output_index":3,"delta":"ab"}`)}, 0)
+	if ev.Kind != KindToolCallDelta || ev.Call != 3 {
+		t.Fatalf("decoded = %+v", ev)
+	}
+	rewritten, err = responses.RewriteText(ev, "cd")
+	if err != nil || !strings.Contains(string(rewritten.Data), `"delta":"cd"`) {
+		t.Errorf("responses rewrite = %s, %v", rewritten.Data, err)
+	}
+}

--- a/internal/streaming/transformed_tool_calls_test.go
+++ b/internal/streaming/transformed_tool_calls_test.go
@@ -271,4 +271,7 @@ func TestTransformedSSEStream_TextAlongsideToolCalls(t *testing.T) {
 	if resp.Choices[0].FinishReason != "tool_calls" || strings.Count(string(got), `"finish_reason":"tool_calls"`) != 1 {
 		t.Errorf("finish = %q", resp.Choices[0].FinishReason)
 	}
+	if strings.Count(string(got), `"role":"assistant"`) != 1 {
+		t.Errorf("role repeated across the split parts:\n%s", got)
+	}
 }

--- a/internal/streaming/transformed_tool_calls_test.go
+++ b/internal/streaming/transformed_tool_calls_test.go
@@ -236,3 +236,39 @@ func TestTransformedSSEStream_ResponsesInterleavedToolCalls(t *testing.T) {
 		t.Errorf("done events restated wrongly:\n%s", out)
 	}
 }
+
+func TestTransformedSSEStream_TextAlongsideToolCalls(t *testing.T) {
+	// One delta carries content and two tool calls: the text is emitted
+	// once and every call is transformed.
+	input := `data: {"choices":[{"index":0,"delta":{"role":"assistant","content":"hi <EMAIL_1>","tool_calls":[{"index":0,"id":"c0","function":{"name":"f","arguments":"{\"a\":\"<EMAIL_1>\"}"}},{"index":1,"id":"c1","function":{"name":"g","arguments":"{\"b\":\"<EMAIL_1>\"}"}}]},"finish_reason":"tool_calls"}]}` + "\n\n" +
+		"data: [DONE]\n\n"
+	tr := restoreTransformer()
+	stream := NewTransformedSSEStream(io.NopCloser(strings.NewReader(input)), ChatCodec(), tr, TransformOptions{LookbehindChars: 12})
+	got, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(got), "EMAIL_1") {
+		t.Errorf("placeholder leaked:\n%s", got)
+	}
+	var seen []string
+	for _, ev := range tr.seen {
+		seen = append(seen, string(ev.Kind))
+	}
+	// The text part comes first and is flushed (seen once more) by the
+	// first tool-call part, another kind.
+	if !strings.HasPrefix(strings.Join(seen, ","), "text_delta,text_delta,tool_call_delta,tool_call_delta") {
+		t.Errorf("transformer saw %v", seen)
+	}
+	resp, err := AssembleChatResponse(decodeChatEvents(t, got))
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg := resp.Choices[0].Message
+	if msg.Content != "hi a@b.c" || len(msg.ToolCalls) != 2 || msg.ToolCalls[0].Function.Arguments != `{"a":"a@b.c"}` || msg.ToolCalls[1].Function.Arguments != `{"b":"a@b.c"}` || msg.ToolCalls[1].ID != "c1" {
+		t.Errorf("assembled = %+v", msg)
+	}
+	if resp.Choices[0].FinishReason != "tool_calls" || strings.Count(string(got), `"finish_reason":"tool_calls"`) != 1 {
+		t.Errorf("finish = %q", resp.Choices[0].FinishReason)
+	}
+}

--- a/internal/streaming/transformed_tool_calls_test.go
+++ b/internal/streaming/transformed_tool_calls_test.go
@@ -1,6 +1,7 @@
 package streaming
 
 import (
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -152,5 +153,48 @@ func TestCodecs_RewriteToolCallArguments(t *testing.T) {
 	rewritten, err = responses.RewriteText(ev, "cd")
 	if err != nil || !strings.Contains(string(rewritten.Data), `"delta":"cd"`) {
 		t.Errorf("responses rewrite = %s, %v", rewritten.Data, err)
+	}
+}
+
+func TestTransformedSSEStream_ParallelToolCallsInOneDelta(t *testing.T) {
+	// One delta announces two tool calls with their first arguments; the
+	// second one's placeholder is completed by a later delta. The
+	// finish_reason arrives on the multi-call chunk's choice.
+	input := `data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"c0","function":{"name":"f","arguments":"{\"a\":\"<EMAIL_1>\"}"}},{"index":1,"id":"c1","function":{"name":"g","arguments":"{\"b\":\"<EMA"}}]},"finish_reason":null}]}` + "\n\n" +
+		`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"function":{"arguments":"IL_1>\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}` + "\n\n" +
+		"data: [DONE]\n\n"
+	tr := restoreTransformer()
+	stream := NewTransformedSSEStream(io.NopCloser(strings.NewReader(input)), ChatCodec(), tr, TransformOptions{LookbehindChars: 12})
+	got, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(got), "EMAIL_1") || strings.Contains(string(got), "<EMA") {
+		t.Errorf("placeholder leaked:\n%s", got)
+	}
+	var calls []int
+	for _, ev := range tr.seen {
+		if ev.Kind == KindToolCallDelta {
+			calls = append(calls, ev.Call)
+		}
+	}
+	// Call 0 is seen on arrival and once more when call 1's delta flushes
+	// it; call 1 on arrival, on its second delta, and at the final flush.
+	if strings.Trim(strings.Join(strings.Fields(strings.Trim(fmt.Sprint(calls), "[]")), ","), ",") != "0,0,1,1,1" {
+		t.Errorf("transformer saw calls %v", calls)
+	}
+	resp, err := AssembleChatResponse(decodeChatEvents(t, got))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tc := resp.Choices[0].Message.ToolCalls
+	if len(tc) != 2 || tc[0].ID != "c0" || tc[0].Function.Arguments != `{"a":"a@b.c"}` || tc[1].ID != "c1" || tc[1].Function.Arguments != `{"b":"a@b.c"}` {
+		t.Errorf("assembled = %+v", tc)
+	}
+	if resp.Choices[0].FinishReason != "tool_calls" || resp.Usage.TotalTokens != 3 {
+		t.Errorf("finish = %q usage = %+v", resp.Choices[0].FinishReason, resp.Usage)
+	}
+	if n := strings.Count(string(got), `"finish_reason":"tool_calls"`); n != 1 {
+		t.Errorf("finish_reason emitted %d times", n)
 	}
 }

--- a/pluginapi/plugintest/plugintest_test.go
+++ b/pluginapi/plugintest/plugintest_test.go
@@ -284,10 +284,33 @@ func TestRunStreamToolCallWindows(t *testing.T) {
 		t.Errorf("result = %+v", res)
 	}
 	// Every window is shown on arrival and once more, in full, when it is
-	// flushed: the text by call 0's first delta, call 0 by call 1's, call
-	// 1 by the end of the stream.
-	want := []string{"text se", "t se", `{"a":"se`, `:"secret"}`, `x]"}`, `{"b":1}`, `":1}`}
+	// flushed: the text by call 0's first delta (another kind), both calls
+	// by the end of the stream. Parallel calls do not flush each other.
+	want := []string{"text se", "t se", `{"a":"se`, `:"secret"}`, `{"b":1}`, `x]"}`, `":1}`}
 	if strings.Join(a.windows, "|") != strings.Join(want, "|") {
 		t.Errorf("windows = %q, want %q", a.windows, want)
+	}
+}
+
+func TestRunStreamReopenedWindowQueuesBehindPending(t *testing.T) {
+	a := &argsRedactor{redactor{policy: pluginapi.StreamPolicy{Mode: pluginapi.StreamTransform, MinChunkChars: 100}}}
+	res, err := RunStream(context.Background(), a, nil, []*pluginapi.StreamEvent{
+		{Kind: pluginapi.EventTextDelta, Choice: 0, Text: "zero-a"},
+		{Kind: pluginapi.EventTextDelta, Choice: 1, Text: "one"},
+		{Kind: pluginapi.EventToolCallDelta, Choice: 0, Call: 0, Text: "{}"}, // flushes choice 0's text
+		{Kind: pluginapi.EventTextDelta, Choice: 0, Text: "zero-b"},          // reopens it, behind choice 1
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var order []string
+	for _, ev := range res.Events {
+		order = append(order, string(ev.Kind)+":"+ev.Text)
+	}
+	// The tool-call delta flushed choice 0's text; reopening that text
+	// flushed the tool call and queued the text behind choice 1's.
+	want := "text_delta:zero-a,tool_call_delta:{},text_delta:one,text_delta:zero-b"
+	if strings.Join(order, ",") != want {
+		t.Errorf("order = %v, want %s", order, want)
 	}
 }

--- a/pluginapi/plugintest/plugintest_test.go
+++ b/pluginapi/plugintest/plugintest_test.go
@@ -73,14 +73,16 @@ func TestRunStreamTransformLookbehind(t *testing.T) {
 	if res.Text[0] != "my [x] is safe" {
 		t.Errorf("text = %q", res.Text[0])
 	}
-	// Window 2 shows the withheld tail "y se" in front of "cret is".
-	if len(r.windows) != 3 || r.windows[1] != "y secret is" {
+	// Window 2 shows the withheld tail "y se" in front of "cret is"; the
+	// finish event flushes the last tail, shown once more on its own.
+	if len(r.windows) != 4 || r.windows[1] != "y secret is" || r.windows[3] != "safe" {
 		t.Errorf("windows = %q", r.windows)
 	}
 	if res.End.Message != "my [x] is safe" {
 		t.Errorf("stream state at end = %q", res.End.Message)
 	}
-	if res.Terminated != nil || len(res.Events) == 0 || res.Events[len(res.Events)-2].Kind != pluginapi.EventFinish {
+	// The finish event flushed the tail before it was delivered itself.
+	if res.Terminated != nil || len(res.Events) != 5 || res.Events[3].Text != "safe" || res.Events[4].Kind != pluginapi.EventFinish {
 		t.Errorf("events = %+v", res.Events)
 	}
 }
@@ -249,5 +251,43 @@ func TestHostReplyMayInspectHost(t *testing.T) {
 	c, err := h.Complete(context.Background(), pluginapi.InferenceRequest{})
 	if err != nil || c.Text(0) != "n=1" || h.Recorded().Counts["seen"] != 1 {
 		t.Errorf("reply = %+v, %v", c, err)
+	}
+}
+
+// argsRedactor replaces "secret" in text and tool-call windows.
+type argsRedactor struct{ redactor }
+
+func (a *argsRedactor) OnStreamEvent(ctx context.Context, x *pluginapi.Exchange, ev *pluginapi.StreamEvent) (pluginapi.StreamDecision, error) {
+	if ev.Kind == pluginapi.EventToolCallDelta {
+		copy := *ev
+		copy.Kind = pluginapi.EventTextDelta
+		return a.redactor.OnStreamEvent(ctx, x, &copy)
+	}
+	return a.redactor.OnStreamEvent(ctx, x, ev)
+}
+
+func TestRunStreamToolCallWindows(t *testing.T) {
+	a := &argsRedactor{redactor{policy: pluginapi.StreamPolicy{Mode: pluginapi.StreamTransform, LookbehindChars: 4}}}
+	res, err := RunStream(context.Background(), a, nil, []*pluginapi.StreamEvent{
+		TextDelta("text se"),
+		{Kind: pluginapi.EventToolCallDelta, Call: 0, Text: `{"a":"se`},
+		{Kind: pluginapi.EventToolCallDelta, Call: 0, Text: `cret"}`},
+		{Kind: pluginapi.EventToolCallDelta, Call: 1, Text: `{"b":1}`},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The first tool-call delta flushed the text window, so its
+	// unfinished "se" was delivered as is; call 0's split match was
+	// rewritten; call 1 has its own window.
+	if res.Text[0] != "text se" || res.ToolArguments[0][0] != `{"a":"[x]"}` || res.ToolArguments[0][1] != `{"b":1}` {
+		t.Errorf("result = %+v", res)
+	}
+	// Every window is shown on arrival and once more, in full, when it is
+	// flushed: the text by call 0's first delta, call 0 by call 1's, call
+	// 1 by the end of the stream.
+	want := []string{"text se", "t se", `{"a":"se`, `:"secret"}`, `x]"}`, `{"b":1}`, `":1}`}
+	if strings.Join(a.windows, "|") != strings.Join(want, "|") {
+		t.Errorf("windows = %q, want %q", a.windows, want)
 	}
 }

--- a/pluginapi/plugintest/stream.go
+++ b/pluginapi/plugintest/stream.go
@@ -15,6 +15,9 @@ import (
 type StreamResult struct {
 	// Text is the delivered text per choice, after the hook's edits.
 	Text map[int]string
+	// ToolArguments is the delivered tool-call arguments per choice and
+	// call index, after the hook's edits.
+	ToolArguments map[int]map[int]string
 	// Events are the delivered events in order, text and reasoning deltas
 	// carrying the text as delivered.
 	Events []*pluginapi.StreamEvent
@@ -30,13 +33,16 @@ type StreamResult struct {
 }
 
 // RunStream drives hook with events the way GoModel does under its
-// StreamPolicy: in transform mode text deltas of a choice are coalesced
-// until MinChunkChars runes are pending, the last LookbehindChars runes of
-// delivered text are withheld and shown again in front of the next delta
-// with Overlap set, and pass, replace, drop, and terminate are applied to
-// the whole window. Reasoning deltas are presented as they arrive and may
-// be replaced or dropped too. A non-text event and the end of the stream
-// flush what is pending. In observe mode only terminate has an effect.
+// StreamPolicy: in transform mode the text deltas of a choice, and the
+// argument deltas of each of its tool calls, form windows that are
+// coalesced until MinChunkChars runes are pending; the last LookbehindChars
+// runes of a delivered window are withheld and shown again in front of the
+// next delta with Overlap set, and pass, replace, drop, and terminate are
+// applied to the whole window. Reasoning deltas are presented as they
+// arrive and may be replaced or dropped too. A delta for another window of
+// the same choice flushes that choice's other windows, an event that is
+// not held flushes every window, and so does the end of the stream. In
+// observe mode only terminate has an effect.
 //
 // In buffer mode nothing is presented per event: the deltas are assembled
 // into a completion (text and reasoning parts, "stop" as finish reason)
@@ -60,15 +66,19 @@ func RunStream(ctx context.Context, hook pluginapi.StreamHook, x *pluginapi.Exch
 	if policy.Mode == pluginapi.StreamBuffer {
 		return runBuffered(ctx, hook, x, events)
 	}
-	d := &driver{hook: hook, x: x, policy: policy, result: &StreamResult{Text: map[int]string{}}, pending: map[int]string{}, tail: map[int]string{}}
+	d := &driver{hook: hook, x: x, policy: policy, result: &StreamResult{Text: map[int]string{}, ToolArguments: map[int]map[int]string{}}, pending: map[window]string{}, tail: map[window]string{}}
 	for _, ev := range events {
 		if ev == nil {
 			continue
 		}
-		if ev.Kind == pluginapi.EventTextDelta {
-			d.hold(ev.Choice, ev.Text)
-			if policy.Mode != pluginapi.StreamTransform || policy.MinChunkChars == 0 || utf8.RuneCountInString(d.pending[ev.Choice]) >= policy.MinChunkChars {
-				if err := d.flush(ctx, ev.Choice); err != nil || d.result.Terminated != nil {
+		if ev.Kind == pluginapi.EventTextDelta || (ev.Kind == pluginapi.EventToolCallDelta && ev.Text != "") {
+			w := windowOf(ev)
+			if err := d.flushOthers(ctx, w); err != nil || d.result.Terminated != nil {
+				return d.result, err
+			}
+			d.hold(w, ev.Text)
+			if policy.Mode != pluginapi.StreamTransform || policy.MinChunkChars == 0 || utf8.RuneCountInString(d.pending[w]) >= policy.MinChunkChars {
+				if err := d.present(ctx, w, false); err != nil || d.result.Terminated != nil {
 					return d.result, err
 				}
 			}
@@ -84,11 +94,6 @@ func RunStream(ctx context.Context, hook pluginapi.StreamHook, x *pluginapi.Exch
 	if err := d.flushAll(ctx); err != nil || d.result.Terminated != nil {
 		return d.result, err
 	}
-	for _, choice := range d.order {
-		if tail := d.tail[choice]; tail != "" {
-			d.deliverText(choice, tail)
-		}
-	}
 	end, err := hook.OnStreamEnd(ctx, x)
 	if err != nil {
 		return d.result, err
@@ -97,52 +102,78 @@ func RunStream(ctx context.Context, hook pluginapi.StreamHook, x *pluginapi.Exch
 	return d.result, nil
 }
 
+// window identifies a choice's text or one of its tool calls' arguments.
+type window struct {
+	choice int
+	call   int
+	kind   pluginapi.EventKind
+}
+
+func windowOf(ev *pluginapi.StreamEvent) window {
+	w := window{choice: ev.Choice, kind: ev.Kind}
+	if ev.Kind == pluginapi.EventToolCallDelta {
+		w.call = ev.Call
+	}
+	return w
+}
+
 type driver struct {
 	hook    pluginapi.StreamHook
 	x       *pluginapi.Exchange
 	policy  pluginapi.StreamPolicy
 	result  *StreamResult
-	pending map[int]string
-	tail    map[int]string
-	order   []int // choices in order of first appearance
+	pending map[window]string
+	tail    map[window]string
+	order   []window // windows in order of first appearance
 	seq     int
 }
 
-func (d *driver) hold(choice int, text string) {
-	if !slices.Contains(d.order, choice) {
-		d.order = append(d.order, choice)
+func (d *driver) hold(w window, text string) {
+	if !slices.Contains(d.order, w) {
+		d.order = append(d.order, w)
 	}
-	d.pending[choice] += text
+	d.pending[w] += text
 }
 
-// flushAll presents the pending text of every choice, in order of first
-// appearance, as the host does before a non-text event and at the end.
+// flushAll shows the transformer every window's tail once more with its
+// pending text and delivers the results in full, as the host does before
+// an event that is not held and at the end.
 func (d *driver) flushAll(ctx context.Context) error {
-	for _, choice := range d.order {
-		if err := d.flush(ctx, choice); err != nil || d.result.Terminated != nil {
+	for _, w := range d.order {
+		if err := d.present(ctx, w, true); err != nil || d.result.Terminated != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// flush presents the pending text of a choice, if any.
-func (d *driver) flush(ctx context.Context, choice int) error {
-	text := d.pending[choice]
-	if text == "" {
-		return nil
+// flushOthers flushes the other windows of w's choice, as the host does
+// when a delta for another window arrives.
+func (d *driver) flushOthers(ctx context.Context, w window) error {
+	for _, other := range d.order {
+		if other.choice != w.choice || other == w {
+			continue
+		}
+		if err := d.present(ctx, other, true); err != nil || d.result.Terminated != nil {
+			return err
+		}
 	}
-	d.pending[choice] = ""
-	return d.present(ctx, choice, text)
+	return nil
 }
 
-// present shows text to the hook with the withheld tail in front of it
-// and applies the decision to the whole window.
-func (d *driver) present(ctx context.Context, choice int, text string) error {
+// present shows the window (the withheld tail followed by the pending
+// text) to the hook and applies the decision to all of it. A final flush
+// delivers the result in full; otherwise the last LookbehindChars runes
+// are withheld as the new tail.
+func (d *driver) present(ctx context.Context, w window, final bool) error {
+	full := d.tail[w] + d.pending[w]
+	if full == "" {
+		return nil
+	}
+	overlap := utf8.RuneCountInString(d.tail[w])
+	d.tail[w], d.pending[w] = "", ""
 	d.seq++
-	overlap := utf8.RuneCountInString(d.tail[choice])
-	window := d.tail[choice] + text
-	ev := &pluginapi.StreamEvent{Seq: d.seq, Kind: pluginapi.EventTextDelta, Choice: choice, Text: window, Overlap: overlap}
+	ev := &pluginapi.StreamEvent{Seq: d.seq, Kind: w.kind, Choice: w.choice, Call: w.call, Text: full, Overlap: overlap}
 	decision, err := d.hook.OnStreamEvent(ctx, d.x, ev)
 	if err != nil {
 		return err
@@ -151,7 +182,7 @@ func (d *driver) present(ctx context.Context, choice int, text string) error {
 		d.terminate(decision)
 		return nil
 	}
-	out := window
+	out := full
 	if d.policy.Mode == pluginapi.StreamTransform {
 		switch decision.Action {
 		case pluginapi.StreamReplace:
@@ -162,7 +193,7 @@ func (d *driver) present(ctx context.Context, choice int, text string) error {
 	}
 	d.x.Stream.ReplaceTail(ev, overlap, out)
 	keep := 0
-	if d.policy.Mode == pluginapi.StreamTransform {
+	if d.policy.Mode == pluginapi.StreamTransform && !final {
 		keep = d.policy.LookbehindChars
 	}
 	cut := len(out)
@@ -170,9 +201,9 @@ func (d *driver) present(ctx context.Context, choice int, text string) error {
 		_, size := utf8.DecodeLastRuneInString(out[:cut])
 		cut -= size
 	}
-	d.tail[choice] = out[cut:]
+	d.tail[w] = out[cut:]
 	if cut > 0 {
-		d.deliverText(choice, out[:cut])
+		d.deliver(w, out[:cut])
 	}
 	return nil
 }
@@ -208,9 +239,16 @@ func (d *driver) other(ctx context.Context, ev *pluginapi.StreamEvent) error {
 	return nil
 }
 
-func (d *driver) deliverText(choice int, text string) {
-	d.result.Text[choice] += text
-	d.result.Events = append(d.result.Events, &pluginapi.StreamEvent{Kind: pluginapi.EventTextDelta, Choice: choice, Text: text})
+func (d *driver) deliver(w window, text string) {
+	if w.kind == pluginapi.EventToolCallDelta {
+		if d.result.ToolArguments[w.choice] == nil {
+			d.result.ToolArguments[w.choice] = map[int]string{}
+		}
+		d.result.ToolArguments[w.choice][w.call] += text
+	} else {
+		d.result.Text[w.choice] += text
+	}
+	d.result.Events = append(d.result.Events, &pluginapi.StreamEvent{Kind: w.kind, Choice: w.choice, Call: w.call, Text: text})
 }
 
 func (d *driver) terminate(decision pluginapi.StreamDecision) {

--- a/pluginapi/plugintest/stream.go
+++ b/pluginapi/plugintest/stream.go
@@ -39,10 +39,10 @@ type StreamResult struct {
 // runes of a delivered window are withheld and shown again in front of the
 // next delta with Overlap set, and pass, replace, drop, and terminate are
 // applied to the whole window. Reasoning deltas are presented as they
-// arrive and may be replaced or dropped too. A delta for another window of
-// the same choice flushes that choice's other windows, an event that is
-// not held flushes every window, and so does the end of the stream. In
-// observe mode only terminate has an effect.
+// arrive and may be replaced or dropped too. A delta of another kind for
+// the same choice flushes that choice's windows of other kinds, an event
+// that is not held flushes every window, and so does the end of the
+// stream. In observe mode only terminate has an effect.
 //
 // In buffer mode nothing is presented per event: the deltas are assembled
 // into a completion (text and reasoning parts, "stop" as finish reason)
@@ -139,7 +139,9 @@ func (d *driver) hold(w window, text string) {
 // pending text and delivers the results in full, as the host does before
 // an event that is not held and at the end.
 func (d *driver) flushAll(ctx context.Context) error {
-	for _, w := range d.order {
+	order := d.order
+	d.order = nil
+	for _, w := range order {
 		if err := d.present(ctx, w, true); err != nil || d.result.Terminated != nil {
 			return err
 		}
@@ -147,17 +149,22 @@ func (d *driver) flushAll(ctx context.Context) error {
 	return nil
 }
 
-// flushOthers flushes the other windows of w's choice, as the host does
-// when a delta for another window arrives.
+// flushOthers flushes the windows of w's choice that are of another kind,
+// as the host does when a delta of another kind arrives.
 func (d *driver) flushOthers(ctx context.Context, w window) error {
+	kept := d.order[:0:0]
 	for _, other := range d.order {
-		if other.choice != w.choice || other == w {
+		if other.choice != w.choice || other.kind == w.kind {
+			kept = append(kept, other)
 			continue
 		}
 		if err := d.present(ctx, other, true); err != nil || d.result.Terminated != nil {
 			return err
 		}
 	}
+	// A flushed window leaves the order and is requeued by its next
+	// delta, behind windows still pending.
+	d.order = kept
 	return nil
 }
 

--- a/pluginapi/stream.go
+++ b/pluginapi/stream.go
@@ -14,8 +14,8 @@ const (
 	// decisions are ignored except [StreamTerminate].
 	StreamObserve StreamMode = "observe"
 	// StreamTransform lets the hook rewrite, drop, or terminate events in
-	// flight, holding back LookbehindChars of text so a match spanning
-	// events can be rewritten.
+	// flight, holding back LookbehindChars of text (and of tool-call
+	// arguments, per call) so a match spanning events can be rewritten.
 	StreamTransform StreamMode = "transform"
 	// StreamBuffer collects the whole stream (up to MaxBufferBytes) and runs
 	// the plugin's [ResponseHook] on the assembled completion.
@@ -29,7 +29,8 @@ type StreamPolicy struct {
 	// transform mode so the hook can rewrite text that spans events.
 	LookbehindChars int
 	// MinChunkChars, in transform mode, makes GoModel collect the text
-	// deltas of a choice until at least this many new characters (runes)
+	// deltas of a choice (and, per call, its tool-call argument deltas)
+	// until at least this many new characters (runes)
 	// are pending and present them to the hook as one text event, so a
 	// hook whose per-call cost is high (a classifier, a named-entity
 	// detector) runs on windows of useful size instead of on every token.
@@ -67,14 +68,19 @@ type StreamEvent struct {
 	Kind EventKind
 	// Choice is the choice index the event belongs to.
 	Choice int
+	// Call is the index of the tool call a tool-call delta belongs to
+	// within its choice; 0 for other kinds. Each tool call's arguments are
+	// a window of their own under lookbehind and coalescing.
+	Call int
 	// Text is the delta text for text, tool-call argument, and reasoning
 	// deltas.
 	Text string
 	// Overlap is the number of leading characters (runes) of Text that were
-	// already presented in an earlier event of this choice: under a
-	// lookbehind StreamPolicy GoModel withholds a tail of text and shows it
-	// again in front of the next delta, after this plugin's earlier decision
-	// was applied to it. An edit whose match ends within the first Overlap
+	// already presented in an earlier event of this window (a choice's
+	// text, or the arguments of one of its tool calls): under a lookbehind
+	// StreamPolicy GoModel withholds a tail of text and shows it again in
+	// front of the next delta, after this plugin's earlier decision was
+	// applied to it. An edit whose match ends within the first Overlap
 	// characters was applied then and must not be applied again; edits that
 	// extend past Overlap are new. 0 when nothing was withheld.
 	Overlap int
@@ -91,7 +97,7 @@ const (
 	// StreamDrop suppresses the event.
 	StreamDrop StreamAction = "drop"
 	// StreamReplace forwards the event with StreamDecision.Text instead of
-	// its own text.
+	// its own text: a text, reasoning, or tool-call argument delta.
 	StreamReplace StreamAction = "replace"
 	// StreamTerminate ends the stream with StreamDecision.Terminate.
 	StreamTerminate StreamAction = "terminate"

--- a/tests/e2e/plugins_presidio_test.go
+++ b/tests/e2e/plugins_presidio_test.go
@@ -101,6 +101,43 @@ func TestPlugins_Presidio_E2E(t *testing.T) {
 		assert.True(t, chunks[len(chunks)-1].Done)
 	})
 
+	t.Run("streamed tool-call arguments are restored in flight", func(t *testing.T) {
+		t.Cleanup(func() { fx.reset(t) })
+		scriptMockToolStream(t, "send_email", []string{`{"to":"<EMAIL_ADD`, `RESS_1>","body":"Hi <PERS`, `ON_1>"}`})
+		fx.mustPutGuardrail(t, guardrailDef("pii-in", "presidio", presidioConfig(analyzer.URL, nil), nil))
+		fx.mustPutGuardrail(t, guardrailDef("pii-out", "presidio", presidioConfig(analyzer.URL, map[string]any{"stream_chunk": 8, "stream_lookbehind": 16}), nil))
+		fx.activate(t, workflowStep{Ref: "pii-in", Phase: "prompt", Step: 1}, workflowStep{Ref: "pii-out", Phase: "stream", Step: 1})
+
+		resp := fx.chat(t, userText, true)
+		defer closeBody(resp)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		chunks := readStreamingResponse(t, resp.Body)
+		require.NotEmpty(t, chunks)
+		args, id, name := "", "", ""
+		for _, chunk := range chunks {
+			for _, choice := range chunk.Choices {
+				delta, _ := choice["delta"].(map[string]any)
+				calls, _ := delta["tool_calls"].([]any)
+				for _, c := range calls {
+					call, _ := c.(map[string]any)
+					if v, _ := call["id"].(string); v != "" {
+						id = v
+					}
+					fn, _ := call["function"].(map[string]any)
+					if v, _ := fn["name"].(string); v != "" {
+						name = v
+					}
+					v, _ := fn["arguments"].(string)
+					args += v
+				}
+			}
+		}
+		assert.Equal(t, "call_1", id)
+		assert.Equal(t, "send_email", name)
+		assert.Equal(t, `{"to":"ann@example.com","body":"Hi Ann Lee"}`, args)
+		assert.True(t, chunks[len(chunks)-1].Done)
+	})
+
 	t.Run("blocking entity rejects the prompt", func(t *testing.T) {
 		t.Cleanup(func() { fx.reset(t) })
 		fx.mustPutGuardrail(t, guardrailDef("pii-in", "presidio", presidioConfig(analyzer.URL, map[string]any{"block_entities": []string{"EMAIL_ADDRESS"}, "message": "no e-mail addresses"}), nil))
@@ -126,4 +163,41 @@ func TestPlugins_Presidio_E2E(t *testing.T) {
 		require.Len(t, views, 1)
 		assert.Equal(t, "degraded", views[0].Health)
 	})
+}
+
+// scriptMockToolStream makes the shared mock answer streaming chat
+// completions with one tool call whose arguments arrive in the given
+// chunks: the first chunk carries the call's id and name, the last the
+// finish_reason.
+func scriptMockToolStream(t *testing.T, name string, argChunks []string) {
+	t.Helper()
+	mockServer.SetCustomHandler(func(w http.ResponseWriter, r *http.Request) bool {
+		req, ok := decodeMockChat(r)
+		if !ok || !req.Stream {
+			return false
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		for i, chunk := range argChunks {
+			call := map[string]any{"index": 0, "function": map[string]any{"arguments": chunk}}
+			if i == 0 {
+				call["id"] = "call_1"
+				call["type"] = "function"
+				call["function"] = map[string]any{"name": name, "arguments": chunk}
+			}
+			choice := map[string]any{"index": 0, "delta": map[string]any{"tool_calls": []any{call}}, "finish_reason": nil}
+			if i == len(argChunks)-1 {
+				choice["finish_reason"] = "tool_calls"
+			}
+			data, _ := json.Marshal(map[string]any{"id": "chatcmpl-tool-stream", "object": "chat.completion.chunk", "model": req.Model, "created": 1, "choices": []any{choice}})
+			_, _ = w.Write([]byte("data: " + string(data) + "\n\n"))
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+		return true
+	})
+	t.Cleanup(resetMock)
 }


### PR DESCRIPTION
Transform-mode stream plugins can now rewrite tool-call argument deltas, not only text and reasoning deltas. A guardrail that restores anonymized values (presidio with `restore`) therefore restores them inside streamed tool calls too, so an agent client receives the real address instead of `<EMAIL_ADDRESS_1>` without having to buffer the stream in the response phase.

**Streaming**
- Each tool call's arguments form a window of their own under lookbehind and coalescing, keyed by the new `Event.Call` (the delta's `tool_calls[].index` for chat, the `output_index` for Responses). A delta for another window of the same choice flushes that choice's other windows first, so events keep their order. A tool call announced with empty arguments passes through at once, so its id and name are relayed immediately.
- The first chunk of a window's run stays the template of its re-segmented events until something is emitted from it, so members only that chunk carries (a tool call's id and name sent with its first arguments) reach the client once. This also closes a latent gap for text runs whose first chunk carries the role with non-empty content.
- Both codecs rewrite tool-call deltas; the Responses codec restates `function_call_arguments.done`, `output_item.done`, and `response.completed` with the emitted arguments.

**Plugin contract**: `pluginapi.StreamEvent.Call` (additive); `replace` documented for tool-call argument deltas; `plugintest.RunStream` drives tool-call windows and reports `ToolArguments`, and now shows a window's tail once more at a flush like the host does.

**presidio**: the stream hook handles tool-call argument windows; the docs no longer list streamed tool-call arguments as a limitation.

Tests: transform stream (chat split placeholder with id/name on the first chunk, two calls as separate windows, Responses restating), codecs, presidio, plugintest, and an e2e scenario streaming a tool call through the real pipeline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stream transformations now support tool-call arguments alongside text and reasoning.
  * Tool-call arguments can be restored or replaced across streamed chunks, including parallel calls.
  * Lookbehind and chunk coalescing operate independently for each tool call while preserving event order.
  * Final streamed events now accurately reflect transformed tool-call arguments.

* **Documentation**
  * Clarified streamed tool-call argument handling and per-call lookbehind behavior.

* **Tests**
  * Added coverage for restoration, replacement, chunk boundaries, parallel calls, and final-event flushing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->