### PR TITLE
feat(responses): store streamed responses so previous_response_id can chain on them

### DIFF
--- a/docs/advanced/responses-api.mdx
+++ b/docs/advanced/responses-api.mdx
@@ -34,8 +34,8 @@ providers, see [Responses compatibility](/advanced/responses-compatibility).
 
 For `POST /v1/responses` calls, unless the request sets `store: false`,
 GoModel stores the normalized response body and the normalized input items
-from the request. A streamed response is stored from its terminal
-`response.completed` event. The snapshot is written in the background after
+from the request. A streamed response is stored from its terminal event
+(`response.completed`, `response.incomplete`, or `response.failed`). The snapshot is written in the background after
 the response is returned, so storage latency never delays the client. A
 `GET /v1/responses/{id}` issued immediately after the `POST` can arrive before
 the snapshot is stored; graceful shutdown waits

--- a/docs/advanced/responses-api.mdx
+++ b/docs/advanced/responses-api.mdx
@@ -22,7 +22,7 @@ providers, see [Responses compatibility](/advanced/responses-compatibility).
 
 | Endpoint | Behavior |
 | --- | --- |
-| `POST /v1/responses` | Creates a response through translated model routing. Non-streaming responses are stored for later retrieval. |
+| `POST /v1/responses` | Creates a response through translated model routing. Responses are stored for later retrieval. |
 | `GET /v1/responses/{id}` | Returns a stored gateway response when available. Otherwise, proxies to a native provider lookup when supported. |
 | `GET /v1/responses/{id}/input_items` | Returns normalized input items captured from the original create request when available. Otherwise, proxies to a native provider lookup when supported. |
 | `POST /v1/responses/{id}/cancel` | Cancels the response through the native provider when supported. |
@@ -32,12 +32,13 @@ providers, see [Responses compatibility](/advanced/responses-compatibility).
 
 ## Stored responses
 
-For non-streaming `POST /v1/responses` calls, unless the request sets
-`store: false`, GoModel stores the normalized response body and the normalized
-input items from the request. The snapshot is
-written in the background after the response is returned, so storage latency
-never delays the client. A `GET /v1/responses/{id}` issued immediately after
-the `POST` can arrive before the snapshot is stored; graceful shutdown waits
+For `POST /v1/responses` calls, unless the request sets `store: false`,
+GoModel stores the normalized response body and the normalized input items
+from the request. A streamed response is stored from its terminal
+`response.completed` event. The snapshot is written in the background after
+the response is returned, so storage latency never delays the client. A
+`GET /v1/responses/{id}` issued immediately after the `POST` can arrive before
+the snapshot is stored; graceful shutdown waits
 for pending snapshot writes, but a hard process exit can lose one that has not
 finished. A snapshot write that fails is logged and counted in the
 `gomodel_response_snapshot_store_failures_total` metric.
@@ -52,14 +53,10 @@ This enables:
   Gemini: GoModel follows the stored response and each response it was chained
   from, and prepends their input items and output to the new input, so the
   provider receives the whole chain each turn. On these
-  providers an id that is not stored (the previous response was streamed or
-  sent with `store: false`), or belongs to another tenant, returns 404. Native
+  providers an id that is not stored (the previous response was sent with
+  `store: false`), or belongs to another tenant, returns 404. Native
   Responses providers receive the id itself and resolve it on their side, so
   they need no GoModel snapshot.
-
-Streaming responses are not stored as response snapshots, so on chat-translated
-providers a chained turn must follow a non-streaming response with `store` left
-on.
 
 ## Native provider lookup
 

--- a/docs/advanced/responses-compatibility.mdx
+++ b/docs/advanced/responses-compatibility.mdx
@@ -36,7 +36,7 @@ function tool loops. They cannot safely execute OpenAI-hosted tools.
 | Function call output items | Forwarded | Converted to chat tool-result messages |
 | `text.format` structured output | Forwarded | Converted to `response_format` when the provider supports it |
 | Responses-only tools (`web_search`, `file_search`, `computer_use_preview`, and `namespace`) | Provider decides | Accepted and omitted |
-| `previous_response_id` | Forwarded | Resolved by GoModel: the stored previous response's input items and output are prepended to the input. The previous response must be a stored, non-streaming response, or the request returns 404 (see [Stored responses](/advanced/responses-api#stored-responses)) |
+| `previous_response_id` | Forwarded | Resolved by GoModel: the stored previous response's input items and output are prepended to the input. The previous response must be stored (`store` left on), or the request returns 404 (see [Stored responses](/advanced/responses-api#stored-responses)) |
 | `conversation` | Resolved by GoModel from the gateway-managed conversation | Resolved by GoModel from the gateway-managed conversation |
 | `include` annotations | Forwarded | Accepted and ignored, except `message.output_text.logprobs` |
 | Unknown Responses input item types | Preserved | Rejected |

--- a/docs/guides/openai-agents-sdk.mdx
+++ b/docs/guides/openai-agents-sdk.mdx
@@ -250,7 +250,7 @@ when the upstream provider does not support response retrieval. If the SDK sends
 - `previous_response_id` is forwarded to native Responses providers. For
   chat-translated providers GoModel resolves it from its stored responses and
   replays the previous turn's input and output, so the previous response must
-  have been created non-streaming with `store` left on. `conversation` is
+  have been created with `store` left on. `conversation` is
   resolved from gateway-managed conversations for every provider.
 - Tracing is separate from model routing. Disable SDK tracing or configure a
   real OpenAI tracing key.

--- a/internal/server/previous_response_test.go
+++ b/internal/server/previous_response_test.go
@@ -231,19 +231,77 @@ func TestPatchResponsesAttempt_ScopedTenantCannotChainAcrossScopes(t *testing.T)
 	}
 }
 
-func TestResponsesWithPreviousResponseID_StreamedPredecessorReturns404(t *testing.T) {
+func streamedResponseData(id, text string) string {
+	return "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"" + id +
+		"\",\"object\":\"response\",\"status\":\"completed\",\"output\":[{\"id\":\"msg_" + id +
+		"\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"" + text +
+		"\"}]}]}}\n\ndata: [DONE]\n\n"
+}
+
+// TestResponsesWithPreviousResponseID_StreamedPredecessorChains covers the
+// common agent loop: every turn streams, and each one chains on the last. A
+// streamed response is snapshotted from its terminal event, so a later turn
+// can chain on it and replays the whole streamed chain.
+func TestResponsesWithPreviousResponseID_StreamedPredecessorChains(t *testing.T) {
 	provider := previousResponseTestProvider(t, "anthropic")
-	provider.streamData = "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_s\",\"object\":\"response\",\"status\":\"completed\",\"output\":[]}}\n\ndata: [DONE]\n\n"
+	provider.streamData = streamedResponseData("resp_s1", "the word is zebra")
+	srv := New(provider, nil)
+	store := srv.handler.currentResponseStore()
+
+	if rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"remember: zebra","stream":true}`); rec.Code != http.StatusOK {
+		t.Fatalf("turn one status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	waitForStoredResponse(t, store, "resp_s1")
+	stored, err := store.Get(context.Background(), "resp_s1")
+	if err != nil {
+		t.Fatalf("get resp_s1: %v", err)
+	}
+	if len(stored.InputItems) != 1 || len(stored.Response.Output) != 1 {
+		t.Fatalf("streamed snapshot holds %d input items and %d output items, want 1 and 1", len(stored.InputItems), len(stored.Response.Output))
+	}
+
+	provider.streamData = streamedResponseData("resp_s2", "still zebra")
+	if rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"sure?","previous_response_id":"resp_s1","stream":true}`); rec.Code != http.StatusOK {
+		t.Fatalf("turn two status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	waitForStoredResponse(t, store, "resp_s2")
+	stored, err = store.Get(context.Background(), "resp_s2")
+	if err != nil {
+		t.Fatalf("get resp_s2: %v", err)
+	}
+	if stored.Response.PreviousResponseID != "resp_s1" {
+		t.Fatalf("streamed chained snapshot links to %q, want resp_s1", stored.Response.PreviousResponseID)
+	}
+
+	provider.capturedResponsesReq = nil
+	if rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"what is the word?","previous_response_id":"resp_s2"}`); rec.Code != http.StatusOK {
+		t.Fatalf("turn three status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	items := forwardedInputItems(t, provider.capturingProvider)
+	if len(items) != 5 {
+		t.Fatalf("forwarded %d items, want two streamed turns plus the new input: %#v", len(items), items)
+	}
+	if items[1]["role"] != "assistant" || items[3]["role"] != "assistant" {
+		t.Fatalf("forwarded roles = %v/%v, want assistant at 1 and 3", items[1]["role"], items[3]["role"])
+	}
+	if text, _ := json.Marshal(items[1]["content"]); !strings.Contains(string(text), "the word is zebra") {
+		t.Fatalf("streamed output not replayed: %#v", items[1])
+	}
+}
+
+func TestResponsesWithPreviousResponseID_StreamedWithStoreFalseIsNotStored(t *testing.T) {
+	provider := previousResponseTestProvider(t, "anthropic")
+	provider.streamData = streamedResponseData("resp_s", "not kept")
 	srv := New(provider, nil)
 
-	if rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"streamed","stream":true}`); rec.Code != http.StatusOK {
+	if rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"streamed","stream":true,"store":false}`); rec.Code != http.StatusOK {
 		t.Fatalf("streaming status = %d (%s)", rec.Code, rec.Body.String())
 	}
 	provider.capturedResponsesReq = nil
 
 	rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"again?","previous_response_id":"resp_s"}`)
 	if rec.Code != http.StatusNotFound {
-		t.Fatalf("status = %d (%s), want 404: streamed responses are not stored", rec.Code, rec.Body.String())
+		t.Fatalf("status = %d (%s), want 404: store:false responses are not stored", rec.Code, rec.Body.String())
 	}
 	if provider.capturedResponsesReq != nil {
 		t.Fatal("a chained turn on an unstored id must not reach the provider")

--- a/internal/server/previous_response_test.go
+++ b/internal/server/previous_response_test.go
@@ -232,8 +232,12 @@ func TestPatchResponsesAttempt_ScopedTenantCannotChainAcrossScopes(t *testing.T)
 }
 
 func streamedResponseData(id, text string) string {
-	return "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"" + id +
-		"\",\"object\":\"response\",\"status\":\"completed\",\"output\":[{\"id\":\"msg_" + id +
+	return streamedTerminalData("response.completed", "completed", id, text)
+}
+
+func streamedTerminalData(event, status, id, text string) string {
+	return "event: " + event + "\ndata: {\"type\":\"" + event + "\",\"response\":{\"id\":\"" + id +
+		"\",\"object\":\"response\",\"status\":\"" + status + "\",\"output\":[{\"id\":\"msg_" + id +
 		"\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"" + text +
 		"\"}]}]}}\n\ndata: [DONE]\n\n"
 }
@@ -286,6 +290,43 @@ func TestResponsesWithPreviousResponseID_StreamedPredecessorChains(t *testing.T)
 	}
 	if text, _ := json.Marshal(items[1]["content"]); !strings.Contains(string(text), "the word is zebra") {
 		t.Fatalf("streamed output not replayed: %#v", items[1])
+	}
+}
+
+// TestResponsesWithPreviousResponseID_StreamedTerminalEventsAreStored covers
+// the other terminal events: a truncated or failed streamed turn is stored
+// like its buffered counterpart, so a client can retrieve it and chain on it.
+func TestResponsesWithPreviousResponseID_StreamedTerminalEventsAreStored(t *testing.T) {
+	for _, tc := range []struct{ event, status string }{
+		{"response.incomplete", "incomplete"},
+		{"response.failed", "failed"},
+	} {
+		t.Run(tc.event, func(t *testing.T) {
+			provider := previousResponseTestProvider(t, "anthropic")
+			provider.streamData = streamedTerminalData(tc.event, tc.status, "resp_t", "partial")
+			srv := New(provider, nil)
+			store := srv.handler.currentResponseStore()
+
+			if rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"go","stream":true}`); rec.Code != http.StatusOK {
+				t.Fatalf("streaming status = %d (%s)", rec.Code, rec.Body.String())
+			}
+			waitForStoredResponse(t, store, "resp_t")
+			stored, err := store.Get(context.Background(), "resp_t")
+			if err != nil {
+				t.Fatalf("get resp_t: %v", err)
+			}
+			if stored.Response.Status != tc.status {
+				t.Fatalf("stored status = %q, want %q", stored.Response.Status, tc.status)
+			}
+
+			provider.capturedResponsesReq = nil
+			if rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"continue","previous_response_id":"resp_t"}`); rec.Code != http.StatusOK {
+				t.Fatalf("chained status = %d (%s)", rec.Code, rec.Body.String())
+			}
+			if items := forwardedInputItems(t, provider.capturingProvider); len(items) != 3 {
+				t.Fatalf("forwarded %d items, want 3", len(items))
+			}
+		})
 	}
 }
 

--- a/internal/server/response_snapshot_stream.go
+++ b/internal/server/response_snapshot_stream.go
@@ -1,0 +1,86 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"io"
+
+	"github.com/goccy/go-json"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/streaming"
+)
+
+// snapshotStream stores a streamed response the way a buffered one is
+// stored: the terminal event carries the complete response, and its snapshot
+// is written in the background once that event passes through. The bytes
+// sent to the client are untouched.
+func (s *translatedInferenceService) snapshotStream(ctx context.Context, workflow *core.Workflow, req *core.ResponsesRequest, providerType, providerName, requestID string, stream io.ReadCloser) io.ReadCloser {
+	if s.currentResponseStore() == nil || (req.Store != nil && !*req.Store) {
+		return stream
+	}
+	return streaming.NewObservedSSEStream(stream, &responseSnapshotStreamObserver{
+		service:      s,
+		ctx:          ctx,
+		workflow:     workflow,
+		req:          req,
+		providerType: providerType,
+		providerName: providerName,
+		requestID:    requestID,
+	})
+}
+
+type responseSnapshotStreamObserver struct {
+	service      *translatedInferenceService
+	ctx          context.Context
+	workflow     *core.Workflow
+	req          *core.ResponsesRequest
+	providerType string
+	providerName string
+	requestID    string
+	stored       bool
+}
+
+var responsesTerminalEventMarkers = [][]byte{
+	[]byte(`"response.completed"`),
+	[]byte(`"response.done"`),
+}
+
+func (o *responseSnapshotStreamObserver) WantsJSONEvent(raw []byte) bool {
+	if o.stored {
+		return false
+	}
+	for _, marker := range responsesTerminalEventMarkers {
+		if bytes.Contains(raw, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func (o *responseSnapshotStreamObserver) OnJSONEvent(payload map[string]any) {
+	if o.stored {
+		return
+	}
+	eventType, _ := payload["type"].(string)
+	if eventType != "response.completed" && eventType != "response.done" {
+		return
+	}
+	body, ok := payload["response"].(map[string]any)
+	if !ok {
+		return
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return
+	}
+	var resp core.ResponsesResponse
+	if err := json.Unmarshal(raw, &resp); err != nil || resp.ID == "" {
+		return
+	}
+	o.stored = true
+	resp.PreviousResponseID = o.req.PreviousResponseID
+	o.service.storeResponseSnapshotAsync(o.ctx, o.workflow, o.req, &resp, o.providerType, o.providerName, o.requestID)
+}
+
+func (o *responseSnapshotStreamObserver) OnStreamClose() {}

--- a/internal/server/response_snapshot_stream.go
+++ b/internal/server/response_snapshot_stream.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"slices"
 
 	"github.com/goccy/go-json"
 
@@ -41,17 +42,17 @@ type responseSnapshotStreamObserver struct {
 	stored       bool
 }
 
-var responsesTerminalEventMarkers = [][]byte{
-	[]byte(`"response.completed"`),
-	[]byte(`"response.done"`),
-}
+// responsesTerminalEvents are the events that carry the finished response.
+// A truncated or failed turn is stored like its buffered counterpart, whose
+// status the client also sees, so it can be retrieved and chained on.
+var responsesTerminalEvents = []string{"response.completed", "response.incomplete", "response.failed", "response.done"}
 
 func (o *responseSnapshotStreamObserver) WantsJSONEvent(raw []byte) bool {
 	if o.stored {
 		return false
 	}
-	for _, marker := range responsesTerminalEventMarkers {
-		if bytes.Contains(raw, marker) {
+	for _, event := range responsesTerminalEvents {
+		if bytes.Contains(raw, []byte(event)) {
 			return true
 		}
 	}
@@ -62,8 +63,7 @@ func (o *responseSnapshotStreamObserver) OnJSONEvent(payload map[string]any) {
 	if o.stored {
 		return
 	}
-	eventType, _ := payload["type"].(string)
-	if eventType != "response.completed" && eventType != "response.done" {
+	if eventType, _ := payload["type"].(string); !slices.Contains(responsesTerminalEvents, eventType) {
 		return
 	}
 	body, ok := payload["response"].(map[string]any)

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -377,6 +377,7 @@ func (s *translatedInferenceService) dispatchResponses(c *echo.Context, req *cor
 		if turn := conversationTurnFromContext(ctx); turn != nil {
 			stream = turn.persistingStream(ctx, stream)
 		}
+		stream = s.snapshotStream(ctx, workflow, req, result.Meta.ProviderType, result.Meta.ProviderName, requestID, stream)
 		return s.handleStreamingReadCloser(c, workflow, result.Meta, stream, func(stream io.ReadCloser) io.ReadCloser {
 			return result.WrapDeliveryStream(ctx, stream)
 		})


### PR DESCRIPTION
Streamed `POST /v1/responses` calls were never snapshotted, so on chat-translated providers (Anthropic, Gemini) a turn chained on a streamed response returned 404, and `GET /v1/responses/{id}` could not find it. Agent loops stream every turn, so the chain from #939 only worked for non-streaming clients.

- A streamed response is now stored from its terminal `response.completed` event, the same background snapshot write buffered responses use. The bytes sent to the client are untouched, and `store: false` still skips it.
- The stored snapshot carries `previous_response_id`, so a chain of streamed turns walks back through every turn.
- `GET /v1/responses/{id}` and `input_items` work for streamed responses.

Verified live on Gemini and Anthropic: streamed turn one, streamed turn two chained on it, buffered turn three chained on turn two receiving both earlier turns, and retrieval of the streamed response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming Responses API results are now stored from terminal events when response storage is enabled.
  * Stored streamed responses—including completed, incomplete, and failed results—can be referenced by `previous_response_id` for subsequent chained turns.
  * Full streamed response chains can be replayed across multiple turns.

* **Bug Fixes**
  * Responses with storage disabled remain unavailable for chaining and continue to return not found.

* **Documentation**
  * Updated guidance to reflect streaming response storage and chaining behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->