### PR TITLE
fix: guard chained history, restore escaped stream tool args, hold growing stream matches

### DIFF
--- a/docs/advanced/guardrails.mdx
+++ b/docs/advanced/guardrails.mdx
@@ -336,7 +336,7 @@ text split across two parts is not matched.
 | `on_match` | No | `replace` | `replace` substitutes; `block` rejects with an error; `respond` answers with `message` as an assistant reply; `warn` continues and records the match. Only `replace` edits the text. |
 | `message` | No | `Request blocked by policy` | Error message for `block`, assistant reply for `respond`, audit note for `warn`. |
 | `block_status` | No | phase default | One HTTP status code between 400 and 599 for `block`, for example `403`. Empty means 400 when the prompt is blocked, 502 when the response is blocked. |
-| `stream_lookbehind` | No | `64` | Characters of streamed text held back so a match spanning two chunks is still rewritten; set it to at least the longest find text. Used by `replace` and `warn`. |
+| `stream_lookbehind` | No | `64` | Characters of streamed text held back so a match spanning two chunks is still rewritten; set it to at least the longest find text. A match at the end of the text streamed so far is held until it stops growing, so an open-ended pattern such as `sk-[A-Za-z0-9]{20,}` masks the whole value when it is at most this long. Used by `replace` and `warn`. |
 
 In the stream phase, `replace` and `warn` transform events in flight with the
 configured lookbehind. `block` and `respond` buffer the whole stream so
@@ -515,7 +515,9 @@ already in the conversation, such as a `<PERSON_2>` an earlier reply carried
 back, is left as it is and its number is never reused for a new value.
 
 Streamed tool-call arguments are restored in flight as well, each call's
-arguments as a window of its own under `stream_lookbehind`.
+arguments as a window of its own under `stream_lookbehind`, including
+placeholders whose angle brackets the provider escaped (Gemini returns
+`\u003cPERSON_1\u003e`).
 
 #### Example
 

--- a/docs/advanced/plugins.mdx
+++ b/docs/advanced/plugins.mdx
@@ -199,7 +199,13 @@ comes back already carrying the plugin's earlier edits, and
 `StreamEvent.Overlap` says how many leading characters it spans: a plugin
 must only edit matches that extend past `Overlap`, since a match inside it
 was handled the previous time (the built-in `string_replace` does this, so
-a rule like `a => aa` is applied once, not on its own output). A chat chunk
+a rule like `a => aa` is applied once, not on its own output). A match that
+touches the end of the window may still grow with the next delta, so a plugin
+can leave it unedited: the tail shows it again next time. `StreamEvent.Final`
+marks the last event of a window (the stream ended or a delta of another kind
+flushed it), after which nothing is withheld, so an edit put off that way is
+due then. `string_replace` does this for matches that fit in its lookbehind,
+so an open-ended pattern covers the whole key. A chat chunk
 that carries text together with `finish_reason` or `usage` is re-segmented
 too; those members go out once, with the chunk's last text, or on a chunk
 with empty text when the plugin removed that text.

--- a/docs/advanced/responses-api.mdx
+++ b/docs/advanced/responses-api.mdx
@@ -34,7 +34,8 @@ providers, see [Responses compatibility](/advanced/responses-compatibility).
 
 For `POST /v1/responses` calls, unless the request sets `store: false`,
 GoModel stores the normalized response body and the normalized input items
-from the request. A streamed response is stored from its terminal event
+of the request as the client sent them (before guardrails edit them, and
+without the history a `previous_response_id` or `conversation` added). A streamed response is stored from its terminal event
 (`response.completed`, `response.incomplete`, or `response.failed`). The snapshot is written in the background after
 the response is returned, so storage latency never delays the client. A
 `GET /v1/responses/{id}` issued immediately after the `POST` can arrive before
@@ -57,6 +58,15 @@ This enables:
   `store: false`), or belongs to another tenant, returns 404. Native
   Responses providers receive the id itself and resolve it on their side, so
   they need no GoModel snapshot.
+
+The replayed history, like the items of a gateway-managed `conversation`, is
+merged into the input before the prompt-phase [guardrails](/advanced/guardrails)
+run, so they check and rewrite it like any other input: a stored response
+holds what its client saw, and a [presidio](/advanced/guardrails#presidio)
+guardrail anonymizes the values it restored there again before the next turn
+reaches the provider. When guardrails run and a failover target is
+chat-translated, a native primary receives the replayed history instead of
+the id as well.
 
 ## Native provider lookup
 

--- a/internal/gateway/inference_orchestrator.go
+++ b/internal/gateway/inference_orchestrator.go
@@ -26,7 +26,8 @@ type InferenceConfig struct {
 	FailoverResolver         FailoverResolver
 	FailoverPolicy           *FailoverPolicy // Optional: nil applies the default failover policy
 	TranslatedRequestPatcher TranslatedRequestPatcher
-	ResponsesAttemptPatcher  ResponsesAttemptPatcher // Optional: per-attempt Responses request adaptation
+	ResponsesAttemptPatcher  ResponsesAttemptPatcher  // Optional: per-attempt Responses request adaptation
+	ResponsesHistoryResolver ResponsesHistoryResolver // Optional: expands Responses history before the prompt phase
 	UsageLogger              usage.LoggerInterface
 	PricingResolver          usage.PricingResolver
 	RouteGate                RouteGate
@@ -44,6 +45,7 @@ type InferenceOrchestrator struct {
 	failoverPolicy           *FailoverPolicy
 	translatedRequestPatcher TranslatedRequestPatcher
 	responsesAttemptPatcher  ResponsesAttemptPatcher
+	responsesHistoryResolver ResponsesHistoryResolver
 	usageLogger              usage.LoggerInterface
 	pricingResolver          usage.PricingResolver
 	routeGate                RouteGate
@@ -61,6 +63,7 @@ func NewInferenceOrchestrator(cfg InferenceConfig) *InferenceOrchestrator {
 		failoverPolicy:           cfg.FailoverPolicy,
 		translatedRequestPatcher: cfg.TranslatedRequestPatcher,
 		responsesAttemptPatcher:  cfg.ResponsesAttemptPatcher,
+		responsesHistoryResolver: cfg.ResponsesHistoryResolver,
 		usageLogger:              cfg.UsageLogger,
 		pricingResolver:          cfg.PricingResolver,
 		routeGate:                cfg.RouteGate,

--- a/internal/gateway/inference_prepare.go
+++ b/internal/gateway/inference_prepare.go
@@ -35,6 +35,7 @@ type translatedPrepareSpec[Req any, Prepared any] struct {
 	requiredMessage string
 	patchNilMessage string
 	selector        func(Req) (*string, *string)
+	resolve         func(*InferenceOrchestrator) func(context.Context, Req, *core.Workflow) (context.Context, Req, error)
 	patch           func(*InferenceOrchestrator) func(context.Context, Req) (Req, error)
 	valid           func(Req) bool
 	build           func(context.Context, Req, *core.Workflow) Prepared
@@ -55,6 +56,7 @@ var responsesPrepareSpec = translatedPrepareSpec[*core.ResponsesRequest, *Prepar
 	requiredMessage: "responses request is required",
 	patchNilMessage: "patched responses request is required",
 	selector:        responsesRequestSelector,
+	resolve:         responsesHistoryResolve,
 	patch:           responsesRequestPatch,
 	valid:           validResponsesRequest,
 	build: func(ctx context.Context, req *core.ResponsesRequest, workflow *core.Workflow) *PreparedResponsesRequest {
@@ -75,7 +77,11 @@ func prepareTranslated[Req any, Prepared any](
 	}
 	ctx = WithAttemptRecorder(ctx)
 	model, provider := spec.selector(req)
-	ctx, req, workflow, err := prepareTranslatedRequest(o, ctx, req, meta, model, provider, spec.patch(o), spec.valid, spec.patchNilMessage)
+	var resolve func(context.Context, Req, *core.Workflow) (context.Context, Req, error)
+	if spec.resolve != nil {
+		resolve = spec.resolve(o)
+	}
+	ctx, req, workflow, err := prepareTranslatedRequest(o, ctx, req, meta, model, provider, resolve, spec.patch(o), spec.valid, spec.patchNilMessage)
 	if err != nil {
 		if workflow != nil {
 			// A patch-phase error (a guardrail block or short-circuit) still
@@ -95,6 +101,7 @@ func prepareTranslatedRequest[Req any](
 	meta RequestMeta,
 	model,
 	provider *string,
+	resolve func(context.Context, Req, *core.Workflow) (context.Context, Req, error),
 	patch func(context.Context, Req) (Req, error),
 	valid func(Req) bool,
 	patchNilMessage string,
@@ -106,6 +113,13 @@ func prepareTranslatedRequest[Req any](
 		return ctx, zero, nil, err
 	}
 	ctx = core.WithWorkflow(ctx, workflow)
+	if resolve != nil {
+		ctx, req, err = resolve(ctx, req, workflow)
+		if err != nil {
+			var zero Req
+			return ctx, zero, workflow, err
+		}
+	}
 	if patch != nil {
 		req, err = patch(ctx, req)
 		if err != nil {
@@ -149,6 +163,22 @@ func responsesRequestPatch(o *InferenceOrchestrator) func(context.Context, *core
 		return nil
 	}
 	return o.translatedRequestPatcher.PatchResponsesRequest
+}
+
+// responsesHistoryResolve expands a Responses request's history before the
+// prompt phase, telling the resolver every provider type an attempt of the
+// request may reach.
+func responsesHistoryResolve(o *InferenceOrchestrator) func(context.Context, *core.ResponsesRequest, *core.Workflow) (context.Context, *core.ResponsesRequest, error) {
+	if o.responsesHistoryResolver == nil {
+		return nil
+	}
+	return func(ctx context.Context, req *core.ResponsesRequest, workflow *core.Workflow) (context.Context, *core.ResponsesRequest, error) {
+		types := []string{o.ProviderTypeForSelector(core.ModelSelector{Model: req.Model, Provider: req.Provider}, ProviderTypeFromWorkflow(workflow))}
+		for _, selector := range o.FailoverSelectors(workflow) {
+			types = append(types, o.ProviderTypeForSelector(selector, ""))
+		}
+		return o.responsesHistoryResolver.ResolveResponsesHistory(ctx, req, types)
+	}
 }
 
 func contextWithRequestID(ctx context.Context, requestID string) context.Context {

--- a/internal/gateway/interfaces.go
+++ b/internal/gateway/interfaces.go
@@ -63,6 +63,17 @@ type ResponsesAttemptPatcher interface {
 	PatchResponsesAttempt(ctx context.Context, req *core.ResponsesRequest, providerType string) (*core.ResponsesRequest, error)
 }
 
+// ResponsesHistoryResolver expands the history a Responses request refers to
+// (a gateway-managed conversation, a stored previous response) into its
+// input. It runs once the workflow is resolved and before the prompt-phase
+// patch, so guardrails see every message the provider will receive.
+// providerTypes lists the primary target's provider type, then each failover
+// target's. The returned context carries whatever the resolver keeps for the
+// rest of the request.
+type ResponsesHistoryResolver interface {
+	ResolveResponsesHistory(ctx context.Context, req *core.ResponsesRequest, providerTypes []string) (context.Context, *core.ResponsesRequest, error)
+}
+
 // BatchRequestPreparer rewrites a native batch request before provider
 // submission. This keeps batch-specific policy out of provider decorators.
 type BatchRequestPreparer interface {

--- a/internal/plugins/builtin/presidio/hooks.go
+++ b/internal/plugins/builtin/presidio/hooks.go
@@ -96,6 +96,7 @@ type pass struct {
 	// model that repeats their placeholder cannot disclose them.
 	prompt    bool
 	restore   bool // put restorable placeholders back
+	json      bool // the text is raw JSON: streamed tool-call arguments
 	requestID string
 }
 
@@ -318,7 +319,11 @@ func (p *Plugin) rewriteOne(text string, spans []span, u unit, restorable bool, 
 	}
 	if ps.restore {
 		var n int
-		out, n = m.restore(out)
+		if ps.json {
+			out, n = m.restoreJSON(out)
+		} else {
+			out, n = m.restore(out)
+		}
 		rep.add(0, n)
 	}
 	return out

--- a/internal/plugins/builtin/presidio/mapping.go
+++ b/internal/plugins/builtin/presidio/mapping.go
@@ -1,6 +1,7 @@
 package presidio
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"sort"
@@ -31,8 +32,11 @@ type mapping struct {
 }
 
 // placeholderPattern matches text shaped like a placeholder this plugin
-// allocates ("<PERSON_1>", "<EMAIL_ADDRESS_12>").
-var placeholderPattern = regexp.MustCompile(`<[A-Z][A-Z0-9_]*_[0-9]+>`)
+// allocates ("<PERSON_1>", "<EMAIL_ADDRESS_12>"), also with its angle
+// brackets JSON-escaped ("\u003cPERSON_1\u003e"), as Gemini writes them in
+// the tool-call arguments it returns. The name is group 1 (escaped) or
+// group 2.
+var placeholderPattern = regexp.MustCompile(`\\u003[cC]([A-Z][A-Z0-9_]*_[0-9]+)\\u003[eE]|<([A-Z][A-Z0-9_]*_[0-9]+)>`)
 
 func newMapping() *mapping {
 	return &mapping{seq: map[string]int{}, byValue: map[string]string{}, byPlaceholder: map[string]string{}, restorable: map[string]bool{}, taken: map[string]bool{}}
@@ -44,17 +48,17 @@ func newMapping() *mapping {
 // its placeholder with a new value, the model would see two people as one,
 // and restore would put that value in place of the literal.
 func (m *mapping) reserve(text string) {
-	if !strings.Contains(text, "<") {
+	if !strings.Contains(text, "<") && !strings.Contains(text, `\u003`) {
 		return
 	}
-	tokens := placeholderPattern.FindAllString(text, -1)
-	if len(tokens) == 0 {
+	matches := placeholderPattern.FindAllStringSubmatch(text, -1)
+	if len(matches) == 0 {
 		return
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	for _, t := range tokens {
-		m.taken[t] = true
+	for _, match := range matches {
+		m.taken["<"+match[1]+match[2]+">"] = true
 	}
 }
 
@@ -118,6 +122,61 @@ func (m *mapping) restore(text string) (string, int) {
 		n += c
 	}
 	return text, n
+}
+
+// restoreJSON is restore for raw JSON text (streamed tool-call arguments):
+// it also finds placeholders whose angle brackets are escaped, and writes
+// each value JSON-escaped so the arguments stay valid JSON.
+func (m *mapping) restoreJSON(text string) (string, int) {
+	if m == nil || (!strings.Contains(text, "<") && !strings.Contains(text, `\u003`)) {
+		return text, 0
+	}
+	matches := placeholderPattern.FindAllStringSubmatchIndex(text, -1)
+	if len(matches) == 0 {
+		return text, 0
+	}
+	var b strings.Builder
+	last, n := 0, 0
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, loc := range matches {
+		escaped := loc[2] >= 0
+		var name string
+		if escaped {
+			name = text[loc[2]:loc[3]]
+		} else {
+			name = text[loc[4]:loc[5]]
+		}
+		p := "<" + name + ">"
+		// An escaped form preceded by an odd run of backslashes is the
+		// literal text "\u003c...", not an escaped bracket.
+		if !m.restorable[p] || (escaped && escapedAt(text, loc[0])) {
+			continue
+		}
+		value, err := json.Marshal(m.byPlaceholder[p])
+		if err != nil {
+			continue
+		}
+		b.WriteString(text[last:loc[0]])
+		b.Write(value[1 : len(value)-1])
+		last = loc[1]
+		n++
+	}
+	if n == 0 {
+		return text, 0
+	}
+	b.WriteString(text[last:])
+	return b.String(), n
+}
+
+// escapedAt reports whether the backslash at i is itself escaped by the
+// backslashes before it.
+func escapedAt(text string, i int) bool {
+	run := 0
+	for i--; i >= 0 && text[i] == '\\'; i-- {
+		run++
+	}
+	return run%2 == 1
 }
 
 // hasRestorable reports whether any prompt placeholder exists, in which

--- a/internal/plugins/builtin/presidio/plugin_test.go
+++ b/internal/plugins/builtin/presidio/plugin_test.go
@@ -865,3 +865,31 @@ func TestStreamRestoresToolCallArguments(t *testing.T) {
 		t.Errorf("end = %+v", res.End)
 	}
 }
+
+// Gemini returns tool-call arguments with angle brackets escaped: the
+// stream still restores those placeholders, and a restored value is
+// JSON-escaped so the arguments stay valid.
+func TestStreamRestoresEscapedToolCallArguments(t *testing.T) {
+	a := newAnalyzer(t, `Ann "Lee"`)
+	in := newPlugin(t, a, `{"restore": true}`)
+	out := newPlugin(t, a, `{"restore": true, "stream_lookbehind": 32}`)
+	x := plugintest.Exchange(plugintest.Prompt(plugintest.Text(pluginapi.RoleUser, "m1", `Email ann@x.io for Ann "Lee"`)), nil)
+	if _, err := in.OnPrompt(context.Background(), x); err != nil {
+		t.Fatal(err)
+	}
+	res, err := plugintest.RunStream(context.Background(), out, x, []*pluginapi.StreamEvent{
+		{Kind: pluginapi.EventToolCallDelta, Call: 0, Text: `{"to":"\u003cEMAIL_ADD`},
+		{Kind: pluginapi.EventToolCallDelta, Call: 0, Text: `RESS_1\u003e","name":"\u003cPERSON_1\u003e","raw":"\\u003cPERSON_1\u003e"}`},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := res.ToolArguments[0][0]
+	if want := `{"to":"ann@x.io","name":"Ann \"Lee\"","raw":"\\u003cPERSON_1\u003e"}`; got != want {
+		t.Fatalf("arguments = %s, want %s", got, want)
+	}
+	var args map[string]string
+	if err := json.Unmarshal([]byte(got), &args); err != nil {
+		t.Fatalf("restored arguments are not JSON: %v", err)
+	}
+}

--- a/internal/plugins/builtin/presidio/spans.go
+++ b/internal/plugins/builtin/presidio/spans.go
@@ -24,12 +24,18 @@ type span struct {
 // longer one. The result is sorted by start.
 func byteSpans(text string, results []analyzerResult) []span {
 	offsets := runeOffsets(text)
+	byteAt := func(i int) int {
+		if i == len(offsets) {
+			return len(text)
+		}
+		return offsets[i]
+	}
 	spans := make([]span, 0, len(results))
 	for _, r := range results {
-		if r.Start < 0 || r.End > len(offsets)-1 || r.Start >= r.End || strings.TrimSpace(r.EntityType) == "" {
+		if r.Start < 0 || r.End > len(offsets) || r.Start >= r.End || strings.TrimSpace(r.EntityType) == "" {
 			continue
 		}
-		spans = append(spans, span{entity: r.EntityType, start: offsets[r.Start], end: offsets[r.End], score: r.Score})
+		spans = append(spans, span{entity: r.EntityType, start: byteAt(r.Start), end: byteAt(r.End), score: r.Score})
 	}
 	sort.Slice(spans, func(i, j int) bool {
 		if spans[i].score != spans[j].score {
@@ -57,14 +63,16 @@ func byteSpans(text string, results []analyzerResult) []span {
 	return kept
 }
 
-// runeOffsets returns the byte offset of every rune of text, plus one final
-// entry equal to len(text), so offsets[i] is where code point i starts.
+// runeOffsets returns the byte offset of every rune of text, so offsets[i]
+// is where code point i starts. It is sized by the rune count: sized by
+// len(text), a mostly multi-byte text would reserve several times the
+// offsets it needs.
 func runeOffsets(text string) []int {
-	offsets := make([]int, 0, len(text)+1)
+	offsets := make([]int, 0, utf8.RuneCountInString(text))
 	for i := range text {
 		offsets = append(offsets, i)
 	}
-	return append(offsets, len(text))
+	return offsets
 }
 
 // runeBytes returns the byte offset of the first n runes of text (len(text)

--- a/internal/plugins/builtin/presidio/spans_test.go
+++ b/internal/plugins/builtin/presidio/spans_test.go
@@ -29,6 +29,10 @@ func TestByteSpans(t *testing.T) {
 	if out := rewrite(text, got, func(s span, v string) string { return "<" + s.entity + ">" }); out != "<DATE_TIME>ë 😀 <PERSON>" {
 		t.Errorf("rewrite = %q", out)
 	}
+	// One offset per code point, allocated for the 9 runes, not the 13 bytes.
+	if o := runeOffsets(text); len(o) != 9 || cap(o) != 9 || o[4] != 5 || o[8] != 12 {
+		t.Errorf("runeOffsets = %v (cap %d)", o, cap(o))
+	}
 	if runeBytes(text, 5) != 9 || runeBytes(text, 100) != len(text) || runeBytes(text, 0) != 0 {
 		t.Error("runeBytes")
 	}

--- a/internal/plugins/builtin/presidio/stream.go
+++ b/internal/plugins/builtin/presidio/stream.go
@@ -37,7 +37,7 @@ func (p *Plugin) OnStreamEvent(ctx context.Context, x *pluginapi.Exchange, ev *p
 	}
 	m := p.mapping(x)
 	m.reserve(ev.Text)
-	out := p.rewriteOne(ev.Text, spans, unit{choice: ev.Choice}, false, m, rep, pass{restore: p.restore, requestID: x.Meta.RequestID})
+	out := p.rewriteOne(ev.Text, spans, unit{choice: ev.Choice}, false, m, rep, pass{restore: p.restore, json: ev.Kind == pluginapi.EventToolCallDelta, requestID: x.Meta.RequestID})
 	if rep.blocked != "" {
 		return pluginapi.Terminate(p.enforcement.Reject(CodeBlocked, rep.detail())), nil
 	}

--- a/internal/plugins/builtin/stringreplace/hooks.go
+++ b/internal/plugins/builtin/stringreplace/hooks.go
@@ -67,14 +67,14 @@ func (p *Plugin) scan(targets []pluginapi.TextTarget, set func(pluginapi.TextTar
 	units := map[unit]bool{}
 	for _, t := range targets {
 		if set == nil {
-			n := count(p.rules, t.Text, 0)
+			n := count(p.rules, t.Text, whole)
 			if n > 0 {
 				total += n
 				units[unit{t.MessageID, t.Choice}] = true
 			}
 			continue
 		}
-		out, n := apply(p.rules, t.Text, 0)
+		out, n := apply(p.rules, t.Text, whole)
 		if n == 0 {
 			continue
 		}
@@ -105,17 +105,17 @@ func (p *Plugin) OnStreamEvent(_ context.Context, x *pluginapi.Exchange, ev *plu
 	if ev == nil || ev.Kind != pluginapi.EventTextDelta || ev.Text == "" {
 		return pluginapi.Pass(), nil
 	}
-	skip := overlapBytes(ev)
+	w := span{skip: overlapBytes(ev), hold: p.lookbehind, final: ev.Final}
 	switch p.onMatch {
 	case OnMatchReplace:
-		out, n := apply(p.rules, ev.Text, skip)
+		out, n := apply(p.rules, ev.Text, w)
 		if n == 0 {
 			return pluginapi.Pass(), nil
 		}
 		p.addCount(x, n)
 		return pluginapi.Replace(out), nil
 	case OnMatchWarn:
-		if n := count(p.rules, ev.Text, skip); n > 0 {
+		if n := count(p.rules, ev.Text, w); n > 0 {
 			p.addCount(x, n)
 		}
 	}

--- a/internal/plugins/builtin/stringreplace/plugin_test.go
+++ b/internal/plugins/builtin/stringreplace/plugin_test.go
@@ -135,7 +135,7 @@ func TestApplyRules(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := newPlugin(t, tt.cfg)
-			got, n := apply(p.rules, tt.in, 0)
+			got, n := apply(p.rules, tt.in, whole)
 			if got != tt.want || n != tt.count {
 				t.Errorf("apply = %q (%d), want %q (%d)", got, n, tt.want, tt.count)
 			}
@@ -383,11 +383,12 @@ func TestStreamPolicy(t *testing.T) {
 }
 
 func TestStreamEvents(t *testing.T) {
+	// Each text delta closes its window (Final), so a match at its end is due.
 	events := []*pluginapi.StreamEvent{
-		{Seq: 1, Kind: pluginapi.EventTextDelta, Text: "Hello ACME"},
+		{Seq: 1, Kind: pluginapi.EventTextDelta, Text: "Hello ACME", Final: true},
 		{Seq: 2, Kind: pluginapi.EventReasoningDelta, Text: "ACME"},
 		{Seq: 3, Kind: pluginapi.EventToolCallDelta, Text: `{"q":"ACME"}`},
-		{Seq: 4, Kind: pluginapi.EventTextDelta, Text: " and ACME"},
+		{Seq: 4, Kind: pluginapi.EventTextDelta, Text: " and ACME", Final: true},
 		{Seq: 5, Kind: pluginapi.EventTextDelta, Text: " bye"},
 		{Seq: 6, Kind: pluginapi.EventFinish},
 	}
@@ -510,10 +511,41 @@ func TestStreamOverlapIsNotReprocessed(t *testing.T) {
 			name: "expanding rule is applied once",
 			cfg:  `{"rules": "a => aa"}`,
 			events: []*pluginapi.StreamEvent{
-				{Seq: 1, Kind: pluginapi.EventTextDelta, Text: "a"},
-				{Seq: 2, Kind: pluginapi.EventTextDelta, Text: "aa", Overlap: 2}, // the flushed tail
+				{Seq: 1, Kind: pluginapi.EventTextDelta, Text: "ab"},
+				{Seq: 2, Kind: pluginapi.EventTextDelta, Text: "aab c", Overlap: 3},
 			},
-			want:  []pluginapi.StreamDecision{pluginapi.Replace("aa"), pluginapi.Pass()},
+			want:  []pluginapi.StreamDecision{pluginapi.Replace("aab"), pluginapi.Pass()},
+			total: 1,
+		},
+		{
+			name: "match at the window end waits until it stops growing",
+			cfg:  `{"rules": "sk-[A-Z]{3,} => [k]", "mode": "regex"}`,
+			events: []*pluginapi.StreamEvent{
+				{Seq: 1, Kind: pluginapi.EventTextDelta, Text: "key sk-ABC"},
+				{Seq: 2, Kind: pluginapi.EventTextDelta, Text: "key sk-ABCDEF", Overlap: 10},
+				{Seq: 3, Kind: pluginapi.EventTextDelta, Text: "key sk-ABCDEF end", Overlap: 13},
+			},
+			want:  []pluginapi.StreamDecision{pluginapi.Pass(), pluginapi.Pass(), pluginapi.Replace("key [k] end")},
+			total: 1,
+		},
+		{
+			name: "held match is applied when the window closes",
+			cfg:  `{"rules": "sk-[A-Z]{3,} => [k]", "mode": "regex"}`,
+			events: []*pluginapi.StreamEvent{
+				{Seq: 1, Kind: pluginapi.EventTextDelta, Text: "key sk-ABC"},
+				{Seq: 2, Kind: pluginapi.EventTextDelta, Text: "key sk-ABC", Overlap: 10, Final: true},
+			},
+			want:  []pluginapi.StreamDecision{pluginapi.Pass(), pluginapi.Replace("key [k]")},
+			total: 1,
+		},
+		{
+			name: "match longer than the lookbehind is not held",
+			cfg:  `{"rules": "secret => [x]", "stream_lookbehind": 4}`,
+			events: []*pluginapi.StreamEvent{
+				{Seq: 1, Kind: pluginapi.EventTextDelta, Text: "my secret"},
+				{Seq: 2, Kind: pluginapi.EventTextDelta, Text: "[x] ok", Overlap: 3},
+			},
+			want:  []pluginapi.StreamDecision{pluginapi.Replace("my [x]"), pluginapi.Pass()},
 			total: 1,
 		},
 		{
@@ -521,19 +553,19 @@ func TestStreamOverlapIsNotReprocessed(t *testing.T) {
 			cfg:  `{"rules": "ab => X"}`,
 			events: []*pluginapi.StreamEvent{
 				{Seq: 1, Kind: pluginapi.EventTextDelta, Text: "a"},
-				{Seq: 2, Kind: pluginapi.EventTextDelta, Text: "ab", Overlap: 1},
+				{Seq: 2, Kind: pluginapi.EventTextDelta, Text: "ab c", Overlap: 1},
 			},
-			want:  []pluginapi.StreamDecision{pluginapi.Pass(), pluginapi.Replace("X")},
+			want:  []pluginapi.StreamDecision{pluginapi.Pass(), pluginapi.Replace("X c")},
 			total: 1,
 		},
 		{
 			name: "match inside the overlap is skipped but a later one in the same window is not",
 			cfg:  `{"rules": "é => e"}`,
 			events: []*pluginapi.StreamEvent{
-				{Seq: 1, Kind: pluginapi.EventTextDelta, Text: "é"},
-				{Seq: 2, Kind: pluginapi.EventTextDelta, Text: "e é", Overlap: 1},
+				{Seq: 1, Kind: pluginapi.EventTextDelta, Text: "é x"},
+				{Seq: 2, Kind: pluginapi.EventTextDelta, Text: "e x é y", Overlap: 3},
 			},
-			want:  []pluginapi.StreamDecision{pluginapi.Replace("e"), pluginapi.Replace("e e")},
+			want:  []pluginapi.StreamDecision{pluginapi.Replace("e x"), pluginapi.Replace("e x e y")},
 			total: 2,
 		},
 		{
@@ -541,17 +573,17 @@ func TestStreamOverlapIsNotReprocessed(t *testing.T) {
 			cfg:  `{"rules": "(\\d+)-(\\d+) => $2-$1", "mode": "regex"}`,
 			events: []*pluginapi.StreamEvent{
 				{Seq: 1, Kind: pluginapi.EventTextDelta, Text: "12-34 "},
-				{Seq: 2, Kind: pluginapi.EventTextDelta, Text: "34-12 56-78", Overlap: 6},
+				{Seq: 2, Kind: pluginapi.EventTextDelta, Text: "34-12 56-78 ", Overlap: 6},
 			},
-			want:  []pluginapi.StreamDecision{pluginapi.Replace("34-12 "), pluginapi.Replace("34-12 78-56")},
+			want:  []pluginapi.StreamDecision{pluginapi.Replace("34-12 "), pluginapi.Replace("34-12 78-56 ")},
 			total: 2,
 		},
 		{
 			name: "warn counts only new matches",
 			cfg:  `{"rules": "ACME => x", "on_match": "warn"}`,
 			events: []*pluginapi.StreamEvent{
-				{Seq: 1, Kind: pluginapi.EventTextDelta, Text: "ACME"},
-				{Seq: 2, Kind: pluginapi.EventTextDelta, Text: "ACME ACME", Overlap: 4},
+				{Seq: 1, Kind: pluginapi.EventTextDelta, Text: "ACME "},
+				{Seq: 2, Kind: pluginapi.EventTextDelta, Text: "ACME ACME ", Overlap: 5},
 			},
 			want:  []pluginapi.StreamDecision{pluginapi.Pass(), pluginapi.Pass()},
 			total: 2,
@@ -635,5 +667,25 @@ func TestStreamDriver(t *testing.T) {
 	res, err = plugintest.RunStream(context.Background(), p, plugintest.Exchange(nil, nil), []*pluginapi.StreamEvent{plugintest.TextDelta("a se"), plugintest.TextDelta("cret")})
 	if err != nil || res.End.Action != pluginapi.ActionBlock || res.End.Message != "leak" || len(res.Text) != 0 {
 		t.Errorf("buffered block = %+v, %v", res, err)
+	}
+}
+
+// TestStreamOpenEndedPatternMasksWholeKey streams a key in three-character
+// deltas: an open-ended pattern must cover the whole key, not stop at
+// whatever had arrived when the minimum length first matched.
+func TestStreamOpenEndedPatternMasksWholeKey(t *testing.T) {
+	p := newPlugin(t, `{"rules": "sk-[A-Za-z0-9]{20,} => [redacted]", "mode": "regex"}`)
+	for _, text := range []string{"my key is sk-ABCDEFGHIJKLMNOPQRSTUV end", "sk-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghij and more", "last: sk-ABCDEFGHIJKLMNOPQRSTUVWXYZ"} {
+		var events []*pluginapi.StreamEvent
+		for i := 0; i < len(text); i += 3 {
+			events = append(events, plugintest.TextDelta(text[i:min(i+3, len(text))]))
+		}
+		res, err := plugintest.RunStream(context.Background(), p, plugintest.Exchange(nil, nil), append(events, plugintest.Event(pluginapi.EventFinish)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := res.Text[0]; strings.Contains(got, "ABC") || strings.Contains(got, "UV") || !strings.Contains(got, "[redacted]") {
+			t.Errorf("%q streamed as %q", text, got)
+		}
 	}
 }

--- a/internal/plugins/builtin/stringreplace/rules.go
+++ b/internal/plugins/builtin/stringreplace/rules.go
@@ -121,6 +121,7 @@ type span struct {
 // whole is the span of a text that is not streamed.
 var whole = span{final: true}
 
+// due reports whether match m (submatch indexes into s) is rewritten now.
 func (w span) due(s string, m []int) bool {
 	fits := utf8.RuneCountInString(s[m[0]:m[1]]) <= w.hold
 	switch {

--- a/internal/plugins/builtin/stringreplace/rules.go
+++ b/internal/plugins/builtin/stringreplace/rules.go
@@ -104,14 +104,40 @@ func unescape(s string) string {
 	return b.String()
 }
 
+// span says which matches of a text are due. Text in the prompt and
+// response phases is whole: every match is due. A streamed window starts
+// with skip bytes an earlier window already transformed (see
+// pluginapi.StreamEvent.Overlap), and unless it is final its end can still
+// grow: a match that touches the end and fits in hold runes is left for the
+// next window, which shows it again, so an open-ended pattern such as
+// `sk-[A-Za-z0-9]{20,}` is rewritten whole instead of leaking the rest of a
+// key. A match ending exactly at skip is such a held match and is due now.
+type span struct {
+	skip  int
+	hold  int
+	final bool
+}
+
+// whole is the span of a text that is not streamed.
+var whole = span{final: true}
+
+func (w span) due(s string, m []int) bool {
+	fits := utf8.RuneCountInString(s[m[0]:m[1]]) <= w.hold
+	switch {
+	case m[1] < w.skip:
+		return false // an earlier window already transformed it
+	case m[1] == w.skip:
+		return w.skip > 0 && fits // held at the end of the previous window
+	}
+	return w.final || m[1] < len(s) || m[0] == m[1] || !fits
+}
+
 // apply runs every rule in order over s and returns the result with the
-// total number of replacements. Matches that end within the first skip
-// bytes are left alone: that prefix is streamed text an earlier window
-// already transformed (see pluginapi.StreamEvent.Overlap).
-func apply(rules []rule, s string, skip int) (string, int) {
+// total number of replacements, rewriting only the matches w says are due.
+func apply(rules []rule, s string, w span) (string, int) {
 	total := 0
 	for _, r := range rules {
-		out, n, first := r.replaceAfter(s, skip)
+		out, n, first := r.replaceDue(s, w)
 		if n == 0 {
 			continue
 		}
@@ -119,18 +145,18 @@ func apply(rules []rule, s string, skip int) (string, int) {
 		s = out
 		// Everything from the first edit on is fresh output; the next rule
 		// may match it.
-		skip = min(skip, first)
+		w.skip = min(w.skip, first)
 	}
 	return s, total
 }
 
-// replaceAfter applies r to every match ending after skip and returns the
-// result, the number of replacements, and the start of the first one.
-func (r rule) replaceAfter(s string, skip int) (string, int, int) {
+// replaceDue applies r to every due match and returns the result, the
+// number of replacements, and the start of the first one.
+func (r rule) replaceDue(s string, w span) (string, int, int) {
 	var b strings.Builder
 	last, n, first := 0, 0, -1
 	for _, m := range r.re.FindAllStringSubmatchIndex(s, -1) {
-		if m[1] <= skip {
+		if !w.due(s, m) {
 			continue
 		}
 		if first < 0 {
@@ -152,13 +178,12 @@ func (r rule) replaceAfter(s string, skip int) (string, int, int) {
 	return b.String(), n, first
 }
 
-// count returns how many rule matches end after the first skip bytes of s
-// without editing it.
-func count(rules []rule, s string, skip int) int {
+// count returns how many matches of s are due without editing it.
+func count(rules []rule, s string, w span) int {
 	total := 0
 	for _, r := range rules {
 		for _, m := range r.re.FindAllStringIndex(s, -1) {
-			if m[1] > skip {
+			if w.due(s, m) {
 				total++
 			}
 		}

--- a/internal/providers/responses_adapter_test.go
+++ b/internal/providers/responses_adapter_test.go
@@ -1510,3 +1510,52 @@ func TestStreamResponsesViaChat_DoesNotInjectUsageWhenPolicyDisabled(t *testing.
 		t.Fatalf("captured StreamOptions = %+v, want nil", provider.capturedReq.StreamOptions)
 	}
 }
+
+func TestConvertResponsesRequestToChat_DropsResponsesOnlyTextMembers(t *testing.T) {
+	tests := []struct {
+		name  string
+		input any
+	}{
+		{name: "map", input: []any{
+			map[string]any{
+				"type": "message",
+				"role": "assistant",
+				"content": []any{map[string]any{
+					"type": "output_text", "text": "OK", "annotations": []any{}, "logprobs": []any{},
+					"cache_control": map[string]any{"type": "ephemeral"},
+				}},
+			},
+		}},
+		{name: "typed", input: []core.ResponsesInputElement{{
+			Role: "assistant",
+			Content: []core.ContentPart{{
+				Type: "output_text",
+				Text: "OK",
+				ExtraFields: core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{
+					"annotations":   json.RawMessage(`[]`),
+					"logprobs":      json.RawMessage(`[]`),
+					"cache_control": json.RawMessage(`{"type":"ephemeral"}`),
+				}),
+			}},
+		}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chatReq, err := ConvertResponsesRequestToChat(&core.ResponsesRequest{Model: "test-model", Input: tt.input})
+			if err != nil {
+				t.Fatalf("ConvertResponsesRequestToChat() error = %v", err)
+			}
+			parts, ok := chatReq.Messages[0].Content.([]core.ContentPart)
+			if !ok {
+				t.Fatalf("Content type = %T, want []core.ContentPart", chatReq.Messages[0].Content)
+			}
+			extras := parts[0].ExtraFields
+			if extras.Lookup("annotations") != nil || extras.Lookup("logprobs") != nil {
+				t.Fatalf("Responses-only members forwarded to chat: %+v", parts[0])
+			}
+			if extras.Lookup("cache_control") == nil {
+				t.Fatal("cache_control dropped from the text part")
+			}
+		})
+	}
+}

--- a/internal/providers/responses_content.go
+++ b/internal/providers/responses_content.go
@@ -44,6 +44,11 @@ func ConvertResponsesContentToChatContent(content any) (any, bool) {
 	}
 }
 
+// responsesOnlyTextKeys are output_text members that chat has no place for.
+// Clients replay assistant output with them (annotations: []), and strict
+// chat providers such as Fireworks reject unknown members of a text part.
+var responsesOnlyTextKeys = []string{"annotations", "logprobs"}
+
 func convertResponsesContentParts(parts []any) (any, bool) {
 	typedParts := make([]core.ContentPart, 0, len(parts))
 
@@ -63,7 +68,7 @@ func convertResponsesContentParts(parts []any) (any, bool) {
 			typedParts = append(typedParts, core.ContentPart{
 				Type:        "text",
 				Text:        text,
-				ExtraFields: core.UnknownJSONFieldsFromMap(rawJSONMapFromUnknownKeys(partMap, "type", "text")),
+				ExtraFields: core.UnknownJSONFieldsFromMap(rawJSONMapFromUnknownKeys(partMap, append([]string{"type", "text"}, responsesOnlyTextKeys...)...)),
 			})
 		case "image_url", "input_image":
 			imageURL, ok := normalizeResponsesImageURLForChat(partMap["image_url"])
@@ -144,7 +149,7 @@ func normalizeTypedResponsesContentPart(part core.ContentPart) (core.ContentPart
 		return core.ContentPart{
 			Type:        "text",
 			Text:        part.Text,
-			ExtraFields: core.CloneUnknownJSONFields(part.ExtraFields),
+			ExtraFields: core.CloneUnknownJSONFields(part.ExtraFields.Without(responsesOnlyTextKeys...)),
 		}, true
 	case "image_url", "input_image":
 		if part.ImageURL == nil {

--- a/internal/server/plugin_stream.go
+++ b/internal/server/plugin_stream.go
@@ -370,7 +370,7 @@ func instanceNames(instances []*plugins.Instance) []string {
 // the walk, so a later instance's OnStreamEnd sees replaced and dropped
 // text that way rather than the original.
 func (ps *pluginStream) OnEvent(ev *streaming.Event) (streaming.Decision, error) {
-	pev := &pluginapi.StreamEvent{Seq: ev.Seq + 1, Kind: pluginEventKind(ev.Kind), Choice: ev.Choice, Call: ev.Call, Text: ev.Text, Overlap: ev.Overlap, Raw: ev.Data}
+	pev := &pluginapi.StreamEvent{Seq: ev.Seq + 1, Kind: pluginEventKind(ev.Kind), Choice: ev.Choice, Call: ev.Call, Text: ev.Text, Overlap: ev.Overlap, Final: ev.Final, Raw: ev.Data}
 	result := streaming.Decision{Action: streaming.ActionPass}
 	for _, entry := range ps.inFlight {
 		inst, observe := entry.inst, entry.observe

--- a/internal/server/previous_response.go
+++ b/internal/server/previous_response.go
@@ -23,14 +23,87 @@ import (
 // the way a gateway-managed conversation is; the field is stripped before
 // dispatch. Deciding per attempt keeps a native primary's request unchanged
 // and still gives a translated failover target a request it can serve.
+//
+// Most requests arrive here already expanded (see ResolveResponsesHistory);
+// only an id kept for a native primary can still need it.
 func (s *translatedInferenceService) PatchResponsesAttempt(ctx context.Context, req *core.ResponsesRequest, providerType string) (*core.ResponsesRequest, error) {
+	if req == nil || strings.TrimSpace(req.PreviousResponseID) == "" || s.providerTypeResolvesPreviousResponse(providerType) {
+		return req, nil
+	}
+	return s.withPreviousResponseHistory(ctx, req)
+}
+
+// ResolveResponsesHistory expands the history a Responses request refers to
+// before the prompt phase, so guardrails see (and anonymize, block, or
+// rewrite) the replayed turns exactly as they would in an input the client
+// replayed itself. A stored response holds what its client saw, restored
+// values included, so replaying it past the guardrails would hand those
+// values to the provider. The client's own turn is kept in the context for
+// the response snapshot. previous_response_id is expanded when the primary
+// target (providerTypes[0]) is chat-translated, or when a failover target is
+// and guardrails run on the request; otherwise a native primary keeps the
+// id, which it resolves itself, and PatchResponsesAttempt expands it for a
+// translated failover attempt. A native primary also keeps an id the
+// gateway has not stored.
+func (s *translatedInferenceService) ResolveResponsesHistory(ctx context.Context, req *core.ResponsesRequest, providerTypes []string) (context.Context, *core.ResponsesRequest, error) {
 	if req == nil {
-		return req, nil
+		return ctx, req, nil
 	}
+	ctx = context.WithValue(ctx, clientTurnKey{}, &clientTurn{previousResponseID: req.PreviousResponseID, input: req.Input})
+	ctx, req, err := s.applyResponsesConversation(ctx, req)
+	if err != nil || strings.TrimSpace(req.PreviousResponseID) == "" {
+		return ctx, req, err
+	}
+	translated := func(providerType string) bool { return !s.providerTypeResolvesPreviousResponse(providerType) }
+	primaryTranslated := len(providerTypes) > 0 && translated(providerTypes[0])
+	guarded := s.translatedRequestPatcher != nil && core.GetWorkflow(ctx).GuardrailsEnabled() && slices.ContainsFunc(providerTypes, translated)
+	if !primaryTranslated && !guarded {
+		return ctx, req, nil
+	}
+	patched, err := s.withPreviousResponseHistory(ctx, req)
+	if err != nil && !primaryTranslated {
+		if gatewayErr, ok := errors.AsType[*core.GatewayError](err); ok && gatewayErr.Type == core.ErrorTypeNotFound {
+			return ctx, req, nil
+		}
+	}
+	return ctx, patched, err
+}
+
+// clientTurn is a Responses request's own turn as the client sent it, before
+// history expansion and the prompt phase: the snapshot stores its input
+// items, as OpenAI's input_items do, and names its predecessor.
+type clientTurn struct {
+	previousResponseID string
+	input              any
+}
+
+type clientTurnKey struct{}
+
+// clientInput returns the request whose input the snapshot of req stores:
+// the client's own turn when it was recorded, req itself otherwise.
+func clientInput(ctx context.Context, req *core.ResponsesRequest) *core.ResponsesRequest {
+	if turn, ok := ctx.Value(clientTurnKey{}).(*clientTurn); ok {
+		return &core.ResponsesRequest{Input: turn.input}
+	}
+	return req
+}
+
+// chainedFrom returns the previous_response_id the client sent, which
+// expansion clears from req.
+func chainedFrom(ctx context.Context, req *core.ResponsesRequest) string {
+	if turn, ok := ctx.Value(clientTurnKey{}).(*clientTurn); ok {
+		return turn.previousResponseID
+	}
+	if req == nil {
+		return ""
+	}
+	return req.PreviousResponseID
+}
+
+// withPreviousResponseHistory prepends the stored history behind
+// req.PreviousResponseID to its input and clears the field.
+func (s *translatedInferenceService) withPreviousResponseHistory(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesRequest, error) {
 	id := strings.TrimSpace(req.PreviousResponseID)
-	if id == "" || s.providerTypeResolvesPreviousResponse(providerType) {
-		return req, nil
-	}
 	store := s.currentResponseStore()
 	if store == nil {
 		// No local store: keep the historical behavior, where the provider

--- a/internal/server/previous_response_guardrails_test.go
+++ b/internal/server/previous_response_guardrails_test.go
@@ -70,6 +70,7 @@ func TestResponsesWithPreviousResponseID_HistoryPassesPromptGuardrails(t *testin
 		}
 		waitForStoredResponse(t, store, "resp_conv_1")
 
+		provider.responsesResponse.ID = "resp_conv_2" // the streamed fixture carries resp_conv_2 too
 		body := `{"model":"gpt-5-mini","input":"what is it?","previous_response_id":"resp_conv_1","stream":` + map[bool]string{false: "false", true: "true"}[stream] + `}`
 		rec := postResponses(t, srv, body)
 		if rec.Code != http.StatusOK {
@@ -87,13 +88,22 @@ func TestResponsesWithPreviousResponseID_HistoryPassesPromptGuardrails(t *testin
 		}
 
 		// Snapshots keep the client's own turn as sent, so the next replay
-		// is anonymized consistently with the output.
+		// is anonymized consistently with the output, and link to their
+		// predecessor instead of holding the replayed history.
 		first, err := store.Get(context.Background(), "resp_conv_1")
 		if err != nil {
 			t.Fatal(err)
 		}
 		if len(first.InputItems) != 1 || !strings.Contains(string(first.InputItems[0]), "my pet is a zebra") {
-			t.Fatalf("turn one snapshot input = %s, want the client's own input", first.InputItems)
+			t.Fatalf("stream=%v turn one snapshot input = %s, want the client's own input", stream, first.InputItems)
+		}
+		waitForStoredResponse(t, store, "resp_conv_2")
+		second, err := store.Get(context.Background(), "resp_conv_2")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if second.Response.PreviousResponseID != "resp_conv_1" || len(second.InputItems) != 1 || !strings.Contains(string(second.InputItems[0]), "what is it?") {
+			t.Fatalf("stream=%v chained snapshot previous=%q input=%s, want resp_conv_1 and only the client's own turn", stream, second.Response.PreviousResponseID, second.InputItems)
 		}
 	}
 }

--- a/internal/server/previous_response_guardrails_test.go
+++ b/internal/server/previous_response_guardrails_test.go
@@ -1,0 +1,149 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/responsestore"
+)
+
+// redactingPatcher stands in for a prompt guardrail such as presidio: it
+// rewrites a word anywhere in a Responses input and records each input it
+// saw.
+type redactingPatcher struct{ seen []string }
+
+func (p *redactingPatcher) PatchChatRequest(_ context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
+	return req, nil
+}
+
+func (p *redactingPatcher) PatchResponsesRequest(_ context.Context, req *core.ResponsesRequest) (*core.ResponsesRequest, error) {
+	raw, err := json.Marshal(req.Input)
+	if err != nil {
+		return nil, err
+	}
+	p.seen = append(p.seen, string(raw))
+	var input any
+	if err := json.Unmarshal([]byte(strings.ReplaceAll(string(raw), "zebra", "[animal]")), &input); err != nil {
+		return nil, err
+	}
+	patched := *req
+	patched.Input = input
+	return &patched, nil
+}
+
+func forwardedInput(t *testing.T, provider *capturingProvider) string {
+	t.Helper()
+	if provider.capturedResponsesReq == nil {
+		t.Fatal("provider did not receive a responses request")
+	}
+	raw, err := json.Marshal(provider.capturedResponsesReq.Input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(raw)
+}
+
+// A chained turn replays the stored output, which holds what the client
+// saw (restored values included): the prompt guardrails must see that
+// history like an input the client replayed itself, or the provider gets
+// it in clear.
+func TestResponsesWithPreviousResponseID_HistoryPassesPromptGuardrails(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		provider := previousResponseTestProvider(t, "anthropic")
+		provider.streamData = "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_conv_2\",\"object\":\"response\",\"status\":\"completed\",\"output\":[]}}\n\ndata: [DONE]\n\n"
+		patcher := &redactingPatcher{}
+		srv := New(provider, &Config{TranslatedRequestPatcher: patcher})
+		store := srv.handler.currentResponseStore()
+
+		if rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"my pet is a zebra"}`); rec.Code != http.StatusOK {
+			t.Fatalf("turn one status = %d (%s)", rec.Code, rec.Body.String())
+		}
+		if got := forwardedInput(t, provider.capturingProvider); strings.Contains(got, "zebra") {
+			t.Fatalf("turn one forwarded unredacted: %s", got)
+		}
+		waitForStoredResponse(t, store, "resp_conv_1")
+
+		body := `{"model":"gpt-5-mini","input":"what is it?","previous_response_id":"resp_conv_1","stream":` + map[bool]string{false: "false", true: "true"}[stream] + `}`
+		rec := postResponses(t, srv, body)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("stream=%v chained status = %d (%s)", stream, rec.Code, rec.Body.String())
+		}
+		got := forwardedInput(t, provider.capturingProvider)
+		if strings.Contains(got, "zebra") || strings.Count(got, "[animal]") != 2 {
+			t.Fatalf("stream=%v chained turn forwarded %s, want the replayed input and output redacted", stream, got)
+		}
+		if seen := patcher.seen[len(patcher.seen)-1]; !strings.Contains(seen, "the word is zebra") {
+			t.Fatalf("stream=%v prompt guardrail saw %s, want the replayed history", stream, seen)
+		}
+		if !stream && !strings.Contains(rec.Body.String(), `"previous_response_id":"resp_conv_1"`) {
+			t.Fatalf("chained response must still echo previous_response_id: %s", rec.Body.String())
+		}
+
+		// Snapshots keep the client's own turn as sent, so the next replay
+		// is anonymized consistently with the output.
+		first, err := store.Get(context.Background(), "resp_conv_1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(first.InputItems) != 1 || !strings.Contains(string(first.InputItems[0]), "my pet is a zebra") {
+			t.Fatalf("turn one snapshot input = %s, want the client's own input", first.InputItems)
+		}
+	}
+}
+
+func TestResponsesWithConversation_HistoryPassesPromptGuardrails(t *testing.T) {
+	provider := conversationTestProvider(t)
+	srv := New(provider, &Config{TranslatedRequestPatcher: &redactingPatcher{}})
+	convID := createTestConversation(t, srv, `{"items":[{"type":"message","role":"user","content":"my pet is a zebra"}]}`)
+
+	rec := postResponses(t, srv, `{"model":"gpt-5-mini","conversation":"`+convID+`","input":"what is it?"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("responses status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	if got := forwardedInput(t, provider); strings.Contains(got, "zebra") || !strings.Contains(got, "[animal]") {
+		t.Fatalf("conversation history forwarded %s, want it redacted", got)
+	}
+}
+
+// With prompt guardrails on, a native primary with a chat-translated
+// failover target gets the history expanded before the prompt phase too:
+// expanding only at the failover attempt would skip the guardrails.
+func TestResponsesWithPreviousResponseID_GuardedFailoverExpandsBeforePromptPhase(t *testing.T) {
+	handler, provider := newChainingFailoverHandler(t)
+	handler.translatedRequestPatcher = &redactingPatcher{} // read when the service is first built
+	store := handler.currentResponseStore()
+	if err := store.Update(context.Background(), &responsestore.StoredResponse{
+		Response: &core.ResponsesResponse{
+			ID: "resp_native", Object: "response", Status: "completed",
+			Output: []core.ResponsesOutputItem{{ID: "msg_1", Type: "message", Role: "assistant", Content: []core.ResponsesContentItem{{Type: "output_text", Text: "a zebra"}}}},
+		},
+		InputItems: []json.RawMessage{json.RawMessage(`{"id":"in_1","type":"message","role":"user","content":[{"type":"input_text","text":"remember"}]}`)},
+	}); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-5-mini","input":"again?","previous_response_id":"resp_native"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	if err := handler.Responses(echo.New().NewContext(req, rec)); err != nil {
+		t.Fatalf("handler.Responses() error = %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	fallback := provider.requests["anthropic/claude"]
+	if fallback == nil || fallback.PreviousResponseID != "" {
+		t.Fatalf("translated failover request = %#v, want the history expanded", fallback)
+	}
+	raw, _ := json.Marshal(fallback.Input)
+	if strings.Contains(string(raw), "zebra") || !strings.Contains(string(raw), "[animal]") {
+		t.Fatalf("translated failover forwarded %s, want the replayed output redacted", raw)
+	}
+}

--- a/internal/server/response_snapshot_stream.go
+++ b/internal/server/response_snapshot_stream.go
@@ -79,7 +79,7 @@ func (o *responseSnapshotStreamObserver) OnJSONEvent(payload map[string]any) {
 		return
 	}
 	o.stored = true
-	resp.PreviousResponseID = o.req.PreviousResponseID
+	resp.PreviousResponseID = chainedFrom(o.ctx, o.req)
 	o.service.storeResponseSnapshotAsync(o.ctx, o.workflow, o.req, &resp, o.providerType, o.providerName, o.requestID)
 }
 

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -89,12 +89,14 @@ func (s *translatedInferenceService) newInferenceOrchestrator() *gateway.Inferen
 		FailoverResolver:         s.failoverResolver,
 		FailoverPolicy:           s.failoverPolicy,
 		TranslatedRequestPatcher: s.translatedRequestPatcher,
-		// previous_response_id is resolved per attempt, for targets that
-		// cannot resolve it themselves.
-		ResponsesAttemptPatcher: s,
-		UsageLogger:             s.usageLogger,
-		PricingResolver:         s.pricingResolver,
-		GuardrailsHash:          s.guardrailsHash,
+		// Conversations and previous_response_id are expanded before the
+		// prompt phase; an id left for a native primary is resolved per
+		// attempt for a failover target that cannot resolve it itself.
+		ResponsesHistoryResolver: s,
+		ResponsesAttemptPatcher:  s,
+		UsageLogger:              s.usageLogger,
+		PricingResolver:          s.pricingResolver,
+		GuardrailsHash:           s.guardrailsHash,
 	}
 	// Guarded assignment keeps the gate nil when rate limits are off (a nil
 	// RateLimiter assigned unconditionally would arrive as a typed non-nil
@@ -270,15 +272,11 @@ func prepareResponsesRequest(
 	req *core.ResponsesRequest,
 	meta gateway.RequestMeta,
 ) (context.Context, *core.ResponsesRequest, *core.Workflow, error) {
+	// The orchestrator expands conversations and previous_response_id
+	// (ResolveResponsesHistory) before the prompt phase, so guardrails,
+	// the cache key, and the provider all see the merged history.
 	prepared, err := s.inference().PrepareResponsesRequest(ctx, req, meta)
-	ctx, preparedReq, workflow, err := unpackPrepared(ctx, prepared, err, responsesPreparedFields)
-	if err != nil {
-		return ctx, preparedReq, workflow, err
-	}
-	// Resolve gateway-managed conversations before caching and dispatch so the
-	// cache key reflects the merged history and providers never see local IDs.
-	ctx, preparedReq, err = s.applyResponsesConversation(ctx, preparedReq)
-	return ctx, preparedReq, workflow, err
+	return unpackPrepared(ctx, prepared, err, responsesPreparedFields)
 }
 
 func unpackPrepared[Prepared any, Req any](
@@ -425,7 +423,7 @@ func (s *translatedInferenceService) dispatchResponses(c *echo.Context, req *cor
 	}
 	// A chained response names its predecessor, as OpenAI's does: the client
 	// sees the link, and a later chained turn walks it to rebuild the history.
-	result.Response.PreviousResponseID = req.PreviousResponseID
+	result.Response.PreviousResponseID = chainedFrom(ctx, req)
 	s.storeResponseSnapshotAsync(ctx, workflow, req, result.Response, result.Meta.ProviderType, result.Meta.ProviderName, requestID)
 
 	applyPluginResponseHeaders(c)
@@ -464,7 +462,7 @@ func (s *translatedInferenceService) storeResponseSnapshotAsync(ctx context.Cont
 	}
 	snapshot, err := responsestore.Detach(&responsestore.StoredResponse{
 		Response:           resp,
-		InputItems:         normalizedResponseInputItems(resp.ID, req),
+		InputItems:         normalizedResponseInputItems(resp.ID, clientInput(ctx, req)),
 		Provider:           strings.TrimSpace(providerType),
 		ProviderName:       strings.TrimSpace(providerName),
 		ProviderResponseID: resp.ID,

--- a/internal/streaming/sse_event.go
+++ b/internal/streaming/sse_event.go
@@ -37,6 +37,10 @@ type Event struct {
 	// re-segmented under lookbehind, where consecutive windows overlap;
 	// Text[Overlap:] is the new text.
 	Overlap int
+	// Final marks the last event of a window: its text is emitted in full
+	// after the decision (the stream ended, or a delta of another kind
+	// flushed the window), so nothing of it is withheld for a next event.
+	Final bool
 	// ClosesChoice marks a delta event whose chunk also carries the
 	// finish_reason of its choice (a chat stream may end text and finish in
 	// one chunk), so once it is emitted the choice needs no finish chunk

--- a/internal/streaming/transformed_sse_stream.go
+++ b/internal/streaming/transformed_sse_stream.go
@@ -503,7 +503,7 @@ func (s *transformedSSEStream) hold(ev Event) {
 	}
 	window := p.tail + p.pending
 	p.pending = ""
-	result, ok := s.inspect(key, p, window, utf8.RuneCountInString(p.tail))
+	result, ok := s.inspect(key, p, window, utf8.RuneCountInString(p.tail), false)
 	if !ok {
 		p.tail = ""
 		return
@@ -564,7 +564,7 @@ func (s *transformedSSEStream) flushOne(key pendingKey) {
 	}
 	overlap := utf8.RuneCountInString(p.tail)
 	p.tail, p.pending = "", ""
-	result, ok := s.inspect(key, p, window, overlap)
+	result, ok := s.inspect(key, p, window, overlap, true)
 	if s.ended {
 		return
 	}
@@ -600,10 +600,11 @@ func (s *transformedSSEStream) emitEnvelope(key pendingKey, p *pendingText) {
 // inspect hands text to the transformer as one event of the window's kind
 // built from its template chunk and returns the text to emit; ok is false
 // when nothing should be emitted (drop) or the stream ended.
-func (s *transformedSSEStream) inspect(key pendingKey, p *pendingText, text string, overlap int) (string, bool) {
+func (s *transformedSSEStream) inspect(key pendingKey, p *pendingText, text string, overlap int, final bool) (string, bool) {
 	ev := s.resegment(key, p.template, text)
 	ev.Seq = s.seq
 	ev.Overlap = overlap
+	ev.Final = final
 	s.seq++
 	decision, ok := s.decide(&ev)
 	if !ok {

--- a/internal/streaming/transformed_sse_stream_test.go
+++ b/internal/streaming/transformed_sse_stream_test.go
@@ -375,9 +375,11 @@ func TestTransformedSSEStream_LookbehindJoinsPatternAcrossChunks(t *testing.T) {
 		t.Errorf("windows = %q, want %q", texts(tr.seen), want)
 	}
 	var overlaps []int
+	var finals []bool
 	for _, ev := range tr.seen {
 		if ev.Kind == KindTextDelta {
 			overlaps = append(overlaps, ev.Overlap)
+			finals = append(finals, ev.Final)
 			if !strings.Contains(string(ev.Data), `"content":"`+jsonEscape(ev.Text)+`"`) {
 				t.Errorf("event Data does not carry the window text: %s vs %q", ev.Data, ev.Text)
 			}
@@ -385,6 +387,10 @@ func TestTransformedSSEStream_LookbehindJoinsPatternAcrossChunks(t *testing.T) {
 	}
 	if want := []int{0, 7, 8, 8}; !reflect.DeepEqual(overlaps, want) {
 		t.Errorf("overlaps = %v, want %v", overlaps, want)
+	}
+	// Only the flush before the finish event closes the window.
+	if want := []bool{false, false, false, true}; !reflect.DeepEqual(finals, want) {
+		t.Errorf("finals = %v, want %v", finals, want)
 	}
 	resp, err := AssembleChatResponse(decodeChatEvents(t, got))
 	if err != nil {

--- a/pluginapi/plugintest/stream.go
+++ b/pluginapi/plugintest/stream.go
@@ -180,7 +180,7 @@ func (d *driver) present(ctx context.Context, w window, final bool) error {
 	overlap := utf8.RuneCountInString(d.tail[w])
 	d.tail[w], d.pending[w] = "", ""
 	d.seq++
-	ev := &pluginapi.StreamEvent{Seq: d.seq, Kind: w.kind, Choice: w.choice, Call: w.call, Text: full, Overlap: overlap}
+	ev := &pluginapi.StreamEvent{Seq: d.seq, Kind: w.kind, Choice: w.choice, Call: w.call, Text: full, Overlap: overlap, Final: final}
 	decision, err := d.hook.OnStreamEvent(ctx, d.x, ev)
 	if err != nil {
 		return err

--- a/pluginapi/stream.go
+++ b/pluginapi/stream.go
@@ -84,6 +84,10 @@ type StreamEvent struct {
 	// characters was applied then and must not be applied again; edits that
 	// extend past Overlap are new. 0 when nothing was withheld.
 	Overlap int
+	// Final marks the last event of a window (the stream ended, or a delta
+	// of another kind closed it): nothing is withheld after it, so an edit
+	// a plugin put off because the text could still grow is due now.
+	Final bool
 	// Raw is the event as received. Read-only.
 	Raw json.RawMessage
 }


### PR DESCRIPTION
Pre-release fixes from the latest e2e round.

- **Chained history runs through the prompt guardrails.** `previous_response_id` (chat-translated providers) and gateway-managed `conversation` are now expanded before the prompt phase, not after it. Previously a stored response held the values Presidio restored for the client, and the next chained turn sent them to the provider in clear; `conversation` items were never checked. A native primary still keeps the id unless guardrails run and a failover target is chat-translated. Response snapshots now store the client's own turn (as sent), so `input_items` match what the client sent and replays are anonymized consistently.
- **Replayed assistant text no longer carries `annotations`/`logprobs` to chat providers.** Fireworks rejected them with 400, so every chained turn after a text answer failed there.
- **Presidio stream phase restores Gemini tool-call arguments.** Gemini escapes `<`/`>` in `args` (`\u003cPERSON_1\u003e`); the stream restore now matches that form and JSON-escapes restored values.
- **`string_replace` stream masking covers the whole match.** A match touching the end of a window is held until it stops growing or the window closes (new `StreamEvent.Final`), so `sk-[A-Za-z0-9]{20,}` (the documented example) no longer leaks the rest of a key.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming transformations now handle lookbehind windows more accurately, including deferred matches and open-ended patterns.
  * Sensitive values in streamed tool-call arguments are restored correctly, including JSON-escaped placeholders, while preserving valid JSON.
  * Replayed Responses history is resolved before prompt guardrails, including during translated failover requests.

* **Bug Fixes**
  * Responses-to-Chat conversion no longer sends unsupported text metadata to strict providers.

* **Documentation**
  * Clarified streaming behavior, history processing, guardrails, and escaped placeholder restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->