### PR TITLE
fix(gateway): fail over when a provider returns 200 with no choices

### DIFF
--- a/docs/features/failover.mdx
+++ b/docs/features/failover.mdx
@@ -149,6 +149,10 @@ retry_on_errors:
   - 404 disabled
 ```
 
+A non-streaming chat completion that returns `200` with an empty `choices`
+array is treated as a `502` (`provider returned no choices`), so it fails over
+under the default `5xx` status rule.
+
 Example: try at most one backup, treat timeouts as failover-eligible but
 keep serving `429` responses to the client, and add a provider-specific
 overload message:

--- a/internal/core/errors.go
+++ b/internal/core/errors.go
@@ -176,6 +176,12 @@ func NewEmptyProviderResponseError(provider string) *GatewayError {
 	return NewProviderError(provider, http.StatusBadGateway, "provider returned empty response", nil)
 }
 
+// NewNoChoicesProviderError reports a chat completion that succeeded upstream
+// but carried no choices (502), so failover treats it as a failed attempt.
+func NewNoChoicesProviderError(provider string) *GatewayError {
+	return NewProviderError(provider, http.StatusBadGateway, "provider returned no choices", nil)
+}
+
 // NewRateLimitError creates a new rate limit error (429)
 func NewRateLimitError(provider string, message string) *GatewayError {
 	return &GatewayError{

--- a/internal/gateway/empty_choices_test.go
+++ b/internal/gateway/empty_choices_test.go
@@ -1,0 +1,83 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/llmclient"
+)
+
+func TestDispatchChatCompletionEmptyChoices(t *testing.T) {
+	tests := []struct {
+		name      string
+		failovers []core.ModelSelector
+		wantID    string
+		wantCalls []string
+	}{
+		{
+			name:      "fails over to a target with choices",
+			failovers: []core.ModelSelector{{Provider: "cloudflare", Model: "model2"}},
+			wantID:    "backup",
+			wantCalls: []string{"/model1", "/model2"},
+		},
+		{
+			name:      "returns 502 without a failover target",
+			wantCalls: []string{"/model1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls []string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls = append(calls, r.URL.Path)
+				if r.URL.Path == "/model1" {
+					_, _ = w.Write([]byte(`{"id":"empty","model":"model1","choices":[]}`))
+					return
+				}
+				_, _ = w.Write([]byte(`{"id":"backup","model":"model2","choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"ok"}}]}`))
+			}))
+			defer server.Close()
+
+			provider := &retryFailoverProvider{client: llmclient.New(llmclient.DefaultConfig("cloudflare", server.URL), nil)}
+			orchestrator := NewInferenceOrchestrator(InferenceConfig{
+				Provider: provider,
+				FailoverResolver: failoverResolverFunc(func(*core.RequestModelResolution, core.Operation) []core.ModelSelector {
+					return tt.failovers
+				}),
+			})
+			workflow := &core.Workflow{
+				Endpoint:   core.DescribeEndpoint("POST", "/v1/chat/completions"),
+				Resolution: &core.RequestModelResolution{ResolvedSelector: core.ModelSelector{Provider: "cloudflare", Model: "model1"}},
+				Policy:     &core.ResolvedWorkflowPolicy{Features: core.WorkflowFeatures{Failover: true}},
+			}
+
+			response, _, err := orchestrator.DispatchChatCompletion(context.Background(), workflow, &core.ChatRequest{Model: "model1"})
+
+			if tt.wantID != "" {
+				if err != nil {
+					t.Fatalf("DispatchChatCompletion() error = %v", err)
+				}
+				if response.ID != tt.wantID {
+					t.Fatalf("response ID = %q, want %q", response.ID, tt.wantID)
+				}
+			} else {
+				var gatewayErr *core.GatewayError
+				if !errors.As(err, &gatewayErr) || gatewayErr.HTTPStatusCode() != http.StatusBadGateway {
+					t.Fatalf("DispatchChatCompletion() error = %v, want 502 provider error", err)
+				}
+			}
+			if len(calls) != len(tt.wantCalls) {
+				t.Fatalf("upstream calls = %v, want %v", calls, tt.wantCalls)
+			}
+			for i := range calls {
+				if calls[i] != tt.wantCalls[i] {
+					t.Fatalf("upstream calls = %v, want %v", calls, tt.wantCalls)
+				}
+			}
+		})
+	}
+}

--- a/internal/gateway/empty_choices_test.go
+++ b/internal/gateway/empty_choices_test.go
@@ -69,6 +69,9 @@ func TestDispatchChatCompletionEmptyChoices(t *testing.T) {
 				if !errors.As(err, &gatewayErr) || gatewayErr.HTTPStatusCode() != http.StatusBadGateway {
 					t.Fatalf("DispatchChatCompletion() error = %v, want 502 provider error", err)
 				}
+				if gatewayErr.Message != "provider returned no choices" {
+					t.Fatalf("error message = %q, want %q", gatewayErr.Message, "provider returned no choices")
+				}
 			}
 			if len(calls) != len(tt.wantCalls) {
 				t.Fatalf("upstream calls = %v, want %v", calls, tt.wantCalls)

--- a/internal/gateway/inference_execute.go
+++ b/internal/gateway/inference_execute.go
@@ -416,6 +416,9 @@ func (o *InferenceOrchestrator) chatCompletionProviderCall(ctx context.Context, 
 	if resp == nil {
 		return nil, emptyProviderResponseError("")
 	}
+	if len(resp.Choices) == 0 {
+		return nil, core.NewNoChoicesProviderError(resp.Provider)
+	}
 	return resp, nil
 }
 

--- a/internal/gateway/inference_orchestrator_test.go
+++ b/internal/gateway/inference_orchestrator_test.go
@@ -68,6 +68,7 @@ func TestExecuteChatCompletionPricesRequestedModelWhenResponseModelIsVersioned(t
 			ID:       "chatcmpl-test",
 			Model:    "gpt-4o-mini-2024-07-18",
 			Provider: "openai",
+			Choices:  []core.Choice{{FinishReason: "stop"}},
 			Usage: core.Usage{
 				PromptTokens:     12,
 				CompletionTokens: 1,

--- a/internal/gateway/resilience_failover_test.go
+++ b/internal/gateway/resilience_failover_test.go
@@ -32,7 +32,7 @@ func TestCloudflareTimeoutRetriesBeforeModelFailover(t *testing.T) {
 			w.WriteHeader(524)
 			return
 		}
-		_, _ = w.Write([]byte(`{"id":"backup","model":"model2","choices":[]}`))
+		_, _ = w.Write([]byte(`{"id":"backup","model":"model2","choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"ok"}}]}`))
 	}))
 	defer server.Close()
 	cfg := llmclient.DefaultConfig("cloudflare", server.URL)

--- a/internal/providers/bailian/bailian.go
+++ b/internal/providers/bailian/bailian.go
@@ -103,7 +103,7 @@ func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error)
 
 // Responses sends a Responses API request translated through chat completions.
 func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
-	return providers.ResponsesViaChat(ctx, p, req)
+	return providers.ResponsesViaChat(ctx, p, req, "bailian")
 }
 
 // StreamResponses streams a Responses API request translated through chat completions.

--- a/internal/providers/bedrock/bedrock.go
+++ b/internal/providers/bedrock/bedrock.go
@@ -235,7 +235,7 @@ func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*
 	if err := p.ready(); err != nil {
 		return nil, err
 	}
-	return providers.ResponsesViaChat(ctx, p, req)
+	return providers.ResponsesViaChat(ctx, p, req, providerName)
 }
 
 // StreamResponses adapts the streaming Responses API onto Converse via the

--- a/internal/providers/chutes/chutes.go
+++ b/internal/providers/chutes/chutes.go
@@ -79,7 +79,7 @@ func (p *Provider) StreamChatCompletion(ctx context.Context, req *core.ChatReque
 
 // Responses translates an OpenAI Responses request through Chutes chat completions.
 func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
-	return providers.ResponsesViaChat(ctx, p, req)
+	return providers.ResponsesViaChat(ctx, p, req, "chutes")
 }
 
 // StreamResponses translates a streaming Responses request through Chutes chat completions.

--- a/internal/providers/cohere/cohere.go
+++ b/internal/providers/cohere/cohere.go
@@ -151,7 +151,7 @@ func supportedModel(model modelInfo) bool {
 
 // Responses translates the OpenAI Responses API through Cohere chat.
 func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
-	return providers.ResponsesViaChat(ctx, p, req)
+	return providers.ResponsesViaChat(ctx, p, req, "cohere")
 }
 
 // StreamResponses translates a streaming OpenAI Responses request through Cohere chat.

--- a/internal/providers/gemini/chat.go
+++ b/internal/providers/gemini/chat.go
@@ -155,7 +155,7 @@ func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*
 	if err := p.ready(); err != nil {
 		return nil, err
 	}
-	return providers.ResponsesViaChat(ctx, p, req)
+	return providers.ResponsesViaChat(ctx, p, req, p.responseProviderName())
 }
 
 // Embeddings sends an embeddings request to Gemini: the native

--- a/internal/providers/groq/groq.go
+++ b/internal/providers/groq/groq.go
@@ -97,7 +97,7 @@ func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error)
 
 // Responses sends a Responses API request to Groq (converted to chat format)
 func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
-	return providers.ResponsesViaChat(ctx, p, req)
+	return providers.ResponsesViaChat(ctx, p, req, "groq")
 }
 
 // StreamResponses returns a raw response body for streaming Responses API (caller must close)

--- a/internal/providers/minimax/minimax.go
+++ b/internal/providers/minimax/minimax.go
@@ -76,7 +76,7 @@ func (p *Provider) StreamChatCompletion(ctx context.Context, req *core.ChatReque
 // Responses sends a Responses API request to MiniMax using chat-completions
 // translation, dispatched through the clamped ChatCompletion above.
 func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
-	return providers.ResponsesViaChat(ctx, p, req)
+	return providers.ResponsesViaChat(ctx, p, req, "minimax")
 }
 
 // StreamResponses streams a Responses API request to MiniMax using

--- a/internal/providers/ollama/ollama.go
+++ b/internal/providers/ollama/ollama.go
@@ -191,7 +191,7 @@ func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error)
 
 // Responses sends a Responses API request to Ollama (converted to chat format)
 func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
-	return providers.ResponsesViaChat(ctx, p, req)
+	return providers.ResponsesViaChat(ctx, p, req, "ollama")
 }
 
 // StreamResponses returns a raw response body for streaming Responses API (caller must close)

--- a/internal/providers/openai/chat_compatible.go
+++ b/internal/providers/openai/chat_compatible.go
@@ -85,7 +85,7 @@ func (c *ChatCompatible) ListModels(ctx context.Context) (*core.ModelsResponse, 
 
 // Responses sends a Responses API request using chat-completions translation.
 func (c *ChatCompatible) Responses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
-	return providers.ResponsesViaChat(ctx, c, req)
+	return providers.ResponsesViaChat(ctx, c, req, c.providerName)
 }
 
 // StreamResponses streams a Responses API request using chat-completions translation.

--- a/internal/providers/opencodego/opencodego.go
+++ b/internal/providers/opencodego/opencodego.go
@@ -170,7 +170,7 @@ func (p *Provider) StreamChatCompletion(ctx context.Context, req *core.ChatReque
 // Responses dispatches through this provider's ChatCompletion so /v1/responses
 // honors the per-model /messages routing.
 func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
-	return providers.ResponsesViaChat(ctx, p, req)
+	return providers.ResponsesViaChat(ctx, p, req, "opencode_go")
 }
 
 // StreamResponses dispatches through this provider's streaming ChatCompletion so

--- a/internal/providers/responses_adapter.go
+++ b/internal/providers/responses_adapter.go
@@ -359,7 +359,9 @@ func cloneStringAnyMap(src map[string]any) map[string]any {
 }
 
 // ResponsesViaChat implements the Responses API by converting to/from Chat format.
-func ResponsesViaChat(ctx context.Context, p ChatProvider, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
+// providerName attributes errors raised here, before the router stamps the
+// response with its provider.
+func ResponsesViaChat(ctx context.Context, p ChatProvider, req *core.ResponsesRequest, providerName string) (*core.ResponsesResponse, error) {
 	chatReq, err := ConvertResponsesRequestToChat(req)
 	if err != nil {
 		return nil, err
@@ -370,10 +372,10 @@ func ResponsesViaChat(ctx context.Context, p ChatProvider, req *core.ResponsesRe
 		return nil, err
 	}
 	if chatResp == nil {
-		return nil, core.NewEmptyProviderResponseError("")
+		return nil, core.NewEmptyProviderResponseError(providerName)
 	}
 	if len(chatResp.Choices) == 0 {
-		return nil, core.NewNoChoicesProviderError(chatResp.Provider)
+		return nil, core.NewNoChoicesProviderError(providerName)
 	}
 
 	return ConvertChatResponseToResponses(chatResp), nil

--- a/internal/providers/responses_adapter.go
+++ b/internal/providers/responses_adapter.go
@@ -369,6 +369,12 @@ func ResponsesViaChat(ctx context.Context, p ChatProvider, req *core.ResponsesRe
 	if err != nil {
 		return nil, err
 	}
+	if chatResp == nil {
+		return nil, core.NewEmptyProviderResponseError("")
+	}
+	if len(chatResp.Choices) == 0 {
+		return nil, core.NewNoChoicesProviderError(chatResp.Provider)
+	}
 
 	return ConvertChatResponseToResponses(chatResp), nil
 }

--- a/internal/providers/responses_adapter_test.go
+++ b/internal/providers/responses_adapter_test.go
@@ -3,8 +3,10 @@ package providers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"math"
+	"net/http"
 	"reflect"
 	"strings"
 	"testing"
@@ -14,12 +16,13 @@ import (
 
 type capturingChatProvider struct {
 	capturedReq *core.ChatRequest
+	chatResp    *core.ChatResponse
 	streamData  string
 	streamErr   error
 }
 
 func (p *capturingChatProvider) ChatCompletion(_ context.Context, _ *core.ChatRequest) (*core.ChatResponse, error) {
-	return nil, nil
+	return p.chatResp, nil
 }
 
 func (p *capturingChatProvider) StreamChatCompletion(_ context.Context, req *core.ChatRequest) (io.ReadCloser, error) {
@@ -1508,5 +1511,19 @@ func TestStreamResponsesViaChat_DoesNotInjectUsageWhenPolicyDisabled(t *testing.
 	}
 	if provider.capturedReq.StreamOptions != nil {
 		t.Fatalf("captured StreamOptions = %+v, want nil", provider.capturedReq.StreamOptions)
+	}
+}
+
+func TestResponsesViaChatRejectsEmptyChoices(t *testing.T) {
+	provider := &capturingChatProvider{chatResp: &core.ChatResponse{ID: "chatcmpl-1", Provider: "gemini"}}
+
+	resp, err := ResponsesViaChat(context.Background(), provider, &core.ResponsesRequest{Model: "m", Input: "hi"})
+
+	var gatewayErr *core.GatewayError
+	if !errors.As(err, &gatewayErr) || gatewayErr.HTTPStatusCode() != http.StatusBadGateway {
+		t.Fatalf("ResponsesViaChat() = %+v, %v; want 502 provider error", resp, err)
+	}
+	if gatewayErr.Provider != "gemini" {
+		t.Fatalf("error provider = %q, want gemini", gatewayErr.Provider)
 	}
 }

--- a/internal/providers/responses_adapter_test.go
+++ b/internal/providers/responses_adapter_test.go
@@ -1516,31 +1516,29 @@ func TestStreamResponsesViaChat_DoesNotInjectUsageWhenPolicyDisabled(t *testing.
 
 func TestResponsesViaChatRejectsEmptyChatResponse(t *testing.T) {
 	tests := []struct {
-		name         string
-		chatResp     *core.ChatResponse
-		wantMessage  string
-		wantProvider string
+		name        string
+		chatResp    *core.ChatResponse
+		wantMessage string
 	}{
 		{name: "nil response", wantMessage: "provider returned empty response"},
 		{
-			name:         "no choices",
-			chatResp:     &core.ChatResponse{ID: "chatcmpl-1", Provider: "gemini"},
-			wantMessage:  "provider returned no choices",
-			wantProvider: "gemini",
+			name:        "no choices",
+			chatResp:    &core.ChatResponse{ID: "chatcmpl-1"},
+			wantMessage: "provider returned no choices",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			provider := &capturingChatProvider{chatResp: tt.chatResp}
 
-			resp, err := ResponsesViaChat(context.Background(), provider, &core.ResponsesRequest{Model: "m", Input: "hi"})
+			resp, err := ResponsesViaChat(context.Background(), provider, &core.ResponsesRequest{Model: "m", Input: "hi"}, "groq")
 
 			var gatewayErr *core.GatewayError
 			if !errors.As(err, &gatewayErr) || gatewayErr.HTTPStatusCode() != http.StatusBadGateway {
 				t.Fatalf("ResponsesViaChat() = %+v, %v; want 502 provider error", resp, err)
 			}
-			if gatewayErr.Message != tt.wantMessage || gatewayErr.Provider != tt.wantProvider {
-				t.Fatalf("error = %q from %q, want %q from %q", gatewayErr.Message, gatewayErr.Provider, tt.wantMessage, tt.wantProvider)
+			if gatewayErr.Message != tt.wantMessage || gatewayErr.Provider != "groq" {
+				t.Fatalf("error = %q from %q, want %q from groq", gatewayErr.Message, gatewayErr.Provider, tt.wantMessage)
 			}
 		})
 	}

--- a/internal/providers/responses_adapter_test.go
+++ b/internal/providers/responses_adapter_test.go
@@ -1514,16 +1514,34 @@ func TestStreamResponsesViaChat_DoesNotInjectUsageWhenPolicyDisabled(t *testing.
 	}
 }
 
-func TestResponsesViaChatRejectsEmptyChoices(t *testing.T) {
-	provider := &capturingChatProvider{chatResp: &core.ChatResponse{ID: "chatcmpl-1", Provider: "gemini"}}
-
-	resp, err := ResponsesViaChat(context.Background(), provider, &core.ResponsesRequest{Model: "m", Input: "hi"})
-
-	var gatewayErr *core.GatewayError
-	if !errors.As(err, &gatewayErr) || gatewayErr.HTTPStatusCode() != http.StatusBadGateway {
-		t.Fatalf("ResponsesViaChat() = %+v, %v; want 502 provider error", resp, err)
+func TestResponsesViaChatRejectsEmptyChatResponse(t *testing.T) {
+	tests := []struct {
+		name         string
+		chatResp     *core.ChatResponse
+		wantMessage  string
+		wantProvider string
+	}{
+		{name: "nil response", wantMessage: "provider returned empty response"},
+		{
+			name:         "no choices",
+			chatResp:     &core.ChatResponse{ID: "chatcmpl-1", Provider: "gemini"},
+			wantMessage:  "provider returned no choices",
+			wantProvider: "gemini",
+		},
 	}
-	if gatewayErr.Provider != "gemini" {
-		t.Fatalf("error provider = %q, want gemini", gatewayErr.Provider)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &capturingChatProvider{chatResp: tt.chatResp}
+
+			resp, err := ResponsesViaChat(context.Background(), provider, &core.ResponsesRequest{Model: "m", Input: "hi"})
+
+			var gatewayErr *core.GatewayError
+			if !errors.As(err, &gatewayErr) || gatewayErr.HTTPStatusCode() != http.StatusBadGateway {
+				t.Fatalf("ResponsesViaChat() = %+v, %v; want 502 provider error", resp, err)
+			}
+			if gatewayErr.Message != tt.wantMessage || gatewayErr.Provider != tt.wantProvider {
+				t.Fatalf("error = %q from %q, want %q from %q", gatewayErr.Message, gatewayErr.Provider, tt.wantMessage, tt.wantProvider)
+			}
+		})
 	}
 }

--- a/internal/providers/vertex/vertex.go
+++ b/internal/providers/vertex/vertex.go
@@ -223,7 +223,7 @@ func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*
 	if err := p.ready(); err != nil {
 		return nil, err
 	}
-	return providers.ResponsesViaChat(ctx, p, req)
+	return providers.ResponsesViaChat(ctx, p, req, "vertex")
 }
 
 // StreamResponses returns a raw response body for streaming Responses API.


### PR DESCRIPTION
Closes #947.

A non-streaming chat completion that returns `200` with empty `choices` is now a `502` provider error (`provider returned no choices`), so it fails over under the default `5xx` rule instead of reaching the caller as an empty success.

- Checked in the gateway chat call wrapper, which runs for both primary and failover attempts, so it covers every provider.
- `ResponsesViaChat` returns the same error instead of making up an empty `completed` message.
- Visible change: without a failover target, callers get a `502` instead of an empty `200`, and these replies are no longer cached.

Not included: streaming (`choices: []` is valid in the usage chunk), and the llmclient circuit breaker, which still counts these replies as successes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty chat-completion responses are now treated as gateway errors instead of successful responses.
  * Requests can fail over to a configured backup provider when the upstream response contains no choices.
  * Responses-format conversions now reject empty or missing chat responses with a clear 502 error.

* **Documentation**
  * Added guidance explaining failover behavior for successful responses with empty choices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->