### PR TITLE
fix(responses): name the predecessor on streamed chained responses

### DIFF
--- a/docs/advanced/responses-api.mdx
+++ b/docs/advanced/responses-api.mdx
@@ -53,7 +53,8 @@ This enables:
 - `previous_response_id` on chat-translated providers such as Anthropic and
   Gemini: GoModel follows the stored response and each response it was chained
   from, and prepends their input items and output to the new input, so the
-  provider receives the whole chain each turn. On these
+  provider receives the whole chain each turn. The response names its
+  predecessor in `previous_response_id`, streamed or not. On these
   providers an id that is not stored (the previous response was sent with
   `store: false`), or belongs to another tenant, returns 404. Native
   Responses providers receive the id itself and resolve it on their side, so

--- a/internal/server/previous_response_test.go
+++ b/internal/server/previous_response_test.go
@@ -252,8 +252,12 @@ func TestResponsesWithPreviousResponseID_StreamedPredecessorChains(t *testing.T)
 	srv := New(provider, nil)
 	store := srv.handler.currentResponseStore()
 
-	if rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"remember: zebra","stream":true}`); rec.Code != http.StatusOK {
+	rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"remember: zebra","stream":true}`)
+	if rec.Code != http.StatusOK {
 		t.Fatalf("turn one status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "previous_response_id") {
+		t.Fatalf("an unchained stream must not name a predecessor: %s", rec.Body.String())
 	}
 	waitForStoredResponse(t, store, "resp_s1")
 	stored, err := store.Get(context.Background(), "resp_s1")
@@ -265,8 +269,13 @@ func TestResponsesWithPreviousResponseID_StreamedPredecessorChains(t *testing.T)
 	}
 
 	provider.streamData = streamedResponseData("resp_s2", "still zebra")
-	if rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"sure?","previous_response_id":"resp_s1","stream":true}`); rec.Code != http.StatusOK {
+	rec = postResponses(t, srv, `{"model":"gpt-5-mini","input":"sure?","previous_response_id":"resp_s1","stream":true}`)
+	if rec.Code != http.StatusOK {
 		t.Fatalf("turn two status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	// The client sees the link on the streamed response, as on a buffered one.
+	if !strings.Contains(rec.Body.String(), `"previous_response_id":"resp_s1"`) {
+		t.Fatalf("streamed chained response must name its predecessor: %s", rec.Body.String())
 	}
 	waitForStoredResponse(t, store, "resp_s2")
 	stored, err = store.Get(context.Background(), "resp_s2")

--- a/internal/server/response_chain_stream.go
+++ b/internal/server/response_chain_stream.go
@@ -1,0 +1,110 @@
+package server
+
+import (
+	"bytes"
+	"io"
+	"strings"
+
+	"github.com/goccy/go-json"
+
+	"github.com/enterpilot/gomodel/internal/streaming"
+)
+
+// chainedResponseStream names a chained response's predecessor on the
+// streamed events that carry the response object (response.created,
+// response.in_progress and the terminal event), as a buffered response does
+// (see dispatchResponses). The provider never sees an id the gateway
+// expanded into the input, so its stream cannot name it. Every other event
+// passes through byte for byte, and so does a response object that already
+// names a predecessor.
+type chainedResponseStream struct {
+	upstream io.ReadCloser
+	id       string
+	scanner  streaming.EventScanner
+	buf      []byte
+	out      []byte
+	err      error
+}
+
+// withPreviousResponseID wraps stream so its response objects name id; an
+// unchained request keeps its stream as it is.
+func withPreviousResponseID(stream io.ReadCloser, id string) io.ReadCloser {
+	if stream == nil || strings.TrimSpace(id) == "" {
+		return stream
+	}
+	return &chainedResponseStream{upstream: stream, id: id, buf: make([]byte, 32*1024)}
+}
+
+func (s *chainedResponseStream) Read(p []byte) (int, error) {
+	for len(s.out) == 0 {
+		if s.err != nil {
+			return 0, s.err
+		}
+		n, err := s.upstream.Read(s.buf)
+		for _, ev := range s.scanner.Feed(s.buf[:n]) {
+			s.out = s.appendEvent(s.out, ev)
+		}
+		if err != nil {
+			for _, ev := range s.scanner.Flush() {
+				s.out = s.appendEvent(s.out, ev)
+			}
+			s.err = err
+		}
+	}
+	n := copy(p, s.out)
+	s.out = s.out[n:]
+	return n, nil
+}
+
+func (s *chainedResponseStream) Close() error {
+	return s.upstream.Close()
+}
+
+var responseMemberKey = []byte(`"response":`)
+
+// appendEvent appends ev to out, naming the predecessor on the response
+// object it carries.
+func (s *chainedResponseStream) appendEvent(out []byte, ev streaming.RawEvent) []byte {
+	if ev.Comment || ev.Oversized || !bytes.Contains(ev.Data, responseMemberKey) {
+		return append(out, ev.Raw...)
+	}
+	data, ok := s.nameResponse(ev.Data)
+	if !ok {
+		return append(out, ev.Raw...)
+	}
+	named := streaming.Event{Name: ev.Name, Data: data}
+	return append(out, named.Encode()...)
+}
+
+// nameResponse returns the event payload with previous_response_id set on
+// its response object; ok is false when the payload carries none or it
+// already names a predecessor.
+func (s *chainedResponseStream) nameResponse(data []byte) ([]byte, bool) {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return nil, false
+	}
+	var response map[string]json.RawMessage
+	if err := json.Unmarshal(payload["response"], &response); err != nil || response == nil {
+		return nil, false
+	}
+	var current string
+	if raw, ok := response["previous_response_id"]; ok && json.Unmarshal(raw, &current) == nil && current != "" {
+		return nil, false
+	}
+	id, err := json.Marshal(s.id)
+	if err != nil {
+		return nil, false
+	}
+	response["previous_response_id"] = id
+	encodedResponse, err := json.Marshal(response)
+	if err != nil {
+		return nil, false
+	}
+	payload["response"] = encodedResponse
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return nil, false
+	}
+	return encoded, true
+}

--- a/internal/server/response_chain_stream.go
+++ b/internal/server/response_chain_stream.go
@@ -32,8 +32,19 @@ func withPreviousResponseID(stream io.ReadCloser, id string) io.ReadCloser {
 	if stream == nil || strings.TrimSpace(id) == "" {
 		return stream
 	}
-	return &chainedResponseStream{upstream: stream, id: id, buf: make([]byte, 32*1024)}
+	return &chainedResponseStream{
+		upstream: stream,
+		id:       id,
+		scanner:  streaming.EventScanner{MaxEventBytes: chainedEventMaxBytes},
+		buf:      make([]byte, 32*1024),
+	}
 }
+
+// chainedEventMaxBytes bounds the events held for rewriting, as transform
+// streams bound theirs: the terminal event repeats the whole output, so it
+// can far exceed the scanner's default. A larger event passes through
+// unnamed.
+const chainedEventMaxBytes = 4 * 1024 * 1024
 
 func (s *chainedResponseStream) Read(p []byte) (int, error) {
 	for len(s.out) == 0 {
@@ -60,20 +71,60 @@ func (s *chainedResponseStream) Close() error {
 	return s.upstream.Close()
 }
 
-var responseMemberKey = []byte(`"response":`)
+// responseEventTypes are the quoted types of the events that carry the
+// response object. Matching the type value, not the member layout, keeps the
+// check independent of how the provider formats its JSON while text deltas
+// are never decoded.
+var responseEventTypes = [][]byte{
+	[]byte(`"response.created"`),
+	[]byte(`"response.in_progress"`),
+	[]byte(`"response.queued"`),
+	[]byte(`"response.completed"`),
+	[]byte(`"response.incomplete"`),
+	[]byte(`"response.failed"`),
+}
+
+func carriesResponse(data []byte) bool {
+	for _, t := range responseEventTypes {
+		if bytes.Contains(data, t) {
+			return true
+		}
+	}
+	return false
+}
 
 // appendEvent appends ev to out, naming the predecessor on the response
 // object it carries.
 func (s *chainedResponseStream) appendEvent(out []byte, ev streaming.RawEvent) []byte {
-	if ev.Comment || ev.Oversized || !bytes.Contains(ev.Data, responseMemberKey) {
+	if ev.Comment || ev.Oversized || !carriesResponse(ev.Data) {
 		return append(out, ev.Raw...)
 	}
 	data, ok := s.nameResponse(ev.Data)
 	if !ok {
 		return append(out, ev.Raw...)
 	}
-	named := streaming.Event{Name: ev.Name, Data: data}
-	return append(out, named.Encode()...)
+	return appendWithData(out, ev.Raw, data)
+}
+
+// appendWithData appends the SSE block raw with its data lines replaced by
+// one line carrying data. Every other field (event, id, retry, comments)
+// stays in place, so reconnection metadata survives the rewrite.
+func appendWithData(out, raw, data []byte) []byte {
+	written := false
+	for line := range bytes.SplitSeq(bytes.TrimRight(raw, "\r\n"), []byte("\n")) {
+		if bytes.HasPrefix(line, []byte("data:")) {
+			if !written {
+				out = append(out, "data: "...)
+				out = append(out, data...)
+				out = append(out, '\n')
+				written = true
+			}
+			continue
+		}
+		out = append(out, line...)
+		out = append(out, '\n')
+	}
+	return append(out, '\n')
 }
 
 // nameResponse returns the event payload with previous_response_id set on

--- a/internal/server/response_chain_stream_test.go
+++ b/internal/server/response_chain_stream_test.go
@@ -26,9 +26,16 @@ func TestWithPreviousResponseID(t *testing.T) {
 		delta     = "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"say \\\"response\\\":\",\"sequence_number\":1}\n\n"
 		completed = "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_2\",\"previous_response_id\":null,\"status\":\"completed\"},\"sequence_number\":2}\n\n"
 		native    = "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_2\",\"previous_response_id\":\"resp_upstream\"}}\n\n"
+		spaced    = "event: response.completed\ndata: { \"type\" : \"response.completed\", \"response\" : { \"id\" : \"resp_2\" } }\n\n"
+		envelope  = "id: 7\nretry: 1000\nevent: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_2\"}}\n\n"
 		comment   = ": keep-alive\n\n"
 		done      = "data: [DONE]\n\n"
 	)
+	large := func(n int) string {
+		return "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_2\",\"output\":[{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"" +
+			strings.Repeat("a", n) + "\"}]}]}}\n\n"
+	}
+	huge := large(chainedEventMaxBytes + 1)
 	named := func(event string) string {
 		return "event: " + event + "\ndata: "
 	}
@@ -45,10 +52,20 @@ func TestWithPreviousResponseID(t *testing.T) {
 		{name: "keeps a predecessor the provider named", stream: native + done, id: "resp_1", same: true},
 		{name: "unterminated trailing event is still named", stream: strings.TrimSuffix(completed, "\n\n"), id: "resp_1",
 			want: []string{`"previous_response_id":"resp_1"`, `"status":"completed"`}},
-		{name: "malformed JSON passes through", stream: "data: {\"response\":\n\n" + done, id: "resp_1", same: true},
+		{name: "malformed JSON passes through", stream: "data: {\"type\":\"response.completed\",\"response\":\n\n" + done, id: "resp_1", same: true},
+		{name: "names a response formatted with spaces", stream: spaced + done, id: "resp_1",
+			want: []string{named("response.completed"), `"previous_response_id":"resp_1"`, done}},
+		{name: "keeps id and retry fields", stream: envelope, id: "resp_1",
+			want: []string{"id: 7\nretry: 1000\nevent: response.completed\ndata: {", `"previous_response_id":"resp_1"`, "}\n\n"}},
+		{name: "names a terminal event past the default scanner limit", stream: large(300*1024) + done, id: "resp_1",
+			want: []string{`"previous_response_id":"resp_1"`, done}},
+		{name: "event past the rewrite limit passes through", stream: huge + done, id: "resp_1", same: true},
 	}
 	for _, tc := range tests {
 		for _, oneByte := range []bool{false, true} {
+			if oneByte && len(tc.stream) > 64*1024 {
+				continue // one-byte reads of a large event only slow the test down
+			}
 			got := readChained(t, tc.stream, tc.id, oneByte)
 			if tc.same {
 				if got != tc.stream {

--- a/internal/server/response_chain_stream_test.go
+++ b/internal/server/response_chain_stream_test.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"testing/iotest"
+)
+
+func readChained(t *testing.T, stream string, id string, oneByte bool) string {
+	t.Helper()
+	var src io.Reader = strings.NewReader(stream)
+	if oneByte {
+		src = iotest.OneByteReader(src)
+	}
+	out, err := io.ReadAll(withPreviousResponseID(io.NopCloser(src), id))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	return string(out)
+}
+
+func TestWithPreviousResponseID(t *testing.T) {
+	const (
+		created   = "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_2\",\"status\":\"in_progress\"},\"sequence_number\":0}\n\n"
+		delta     = "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"say \\\"response\\\":\",\"sequence_number\":1}\n\n"
+		completed = "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_2\",\"previous_response_id\":null,\"status\":\"completed\"},\"sequence_number\":2}\n\n"
+		native    = "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_2\",\"previous_response_id\":\"resp_upstream\"}}\n\n"
+		comment   = ": keep-alive\n\n"
+		done      = "data: [DONE]\n\n"
+	)
+	named := func(event string) string {
+		return "event: " + event + "\ndata: "
+	}
+	tests := []struct {
+		name   string
+		stream string
+		id     string
+		want   []string // substrings, in order
+		same   bool     // output must equal the input byte for byte
+	}{
+		{name: "unchained stream is untouched", stream: created + delta + completed + done, id: "", same: true},
+		{name: "names the predecessor on response objects", stream: comment + created + delta + completed + done, id: "resp_1",
+			want: []string{comment, named("response.created"), `"previous_response_id":"resp_1"`, delta, named("response.completed"), `"previous_response_id":"resp_1"`, done}},
+		{name: "keeps a predecessor the provider named", stream: native + done, id: "resp_1", same: true},
+		{name: "unterminated trailing event is still named", stream: strings.TrimSuffix(completed, "\n\n"), id: "resp_1",
+			want: []string{`"previous_response_id":"resp_1"`, `"status":"completed"`}},
+		{name: "malformed JSON passes through", stream: "data: {\"response\":\n\n" + done, id: "resp_1", same: true},
+	}
+	for _, tc := range tests {
+		for _, oneByte := range []bool{false, true} {
+			got := readChained(t, tc.stream, tc.id, oneByte)
+			if tc.same {
+				if got != tc.stream {
+					t.Errorf("%s (one byte reads %v): got %q, want the input unchanged", tc.name, oneByte, got)
+				}
+				continue
+			}
+			rest := got
+			for _, w := range tc.want {
+				i := strings.Index(rest, w)
+				if i < 0 {
+					t.Errorf("%s (one byte reads %v): missing %q in order in %q", tc.name, oneByte, w, got)
+					break
+				}
+				rest = rest[i+len(w):]
+			}
+		}
+	}
+}

--- a/internal/server/translated_inference_service.go
+++ b/internal/server/translated_inference_service.go
@@ -375,6 +375,7 @@ func (s *translatedInferenceService) dispatchResponses(c *echo.Context, req *cor
 			markRequestFailoverUsed(c)
 		}
 		stream := s.wrapPluginStream(ctx, workflow, responsesStreamDialect(), func() *pluginapi.Prompt { return promptOf(exchange.FromResponsesRequest(req)) }, result.Stream)
+		stream = withPreviousResponseID(stream, chainedFrom(ctx, req))
 		if turn := conversationTurnFromContext(ctx); turn != nil {
 			stream = turn.persistingStream(ctx, stream)
 		}


### PR DESCRIPTION
Streamed chained responses on chat-translated providers never carried `previous_response_id`: the gateway expands the id into the input before dispatch, so the provider stream cannot name it. Non-streamed responses and the stored snapshot already did.

A small stream wrapper now sets it on `response.created`, `response.in_progress` and the terminal event of chained requests. Unchained streams are returned untouched, other events pass through byte for byte, and an id the provider already set (native OpenAI) is kept.

Verified with the OpenAI Python SDK against Anthropic, Gemini, native OpenAI, and Anthropic with a Presidio stream guardrail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Streamed Responses API results now include the preceding response ID when responses are chained, including on chat-translated providers.
  - Existing predecessor metadata is preserved, and unchained responses remain unchanged.

- **Documentation**
  - Clarified that streamed and non-streamed responses identify their predecessor through `previous_response_id`.

- **Bug Fixes**
  - Improved consistency between streamed and non-streamed response chaining behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->