### PR TITLE
feat(observability): flag and count empty 200 provider responses

### DIFF
--- a/docs/dev/prometheus-metrics.md
+++ b/docs/dev/prometheus-metrics.md
@@ -135,6 +135,16 @@ Labels: `provider`.
 Alerting example: `gomodel_circuit_breaker_state == 2` for more than a
 minute means a provider is being actively short-circuited.
 
+### `gomodel_empty_responses_total`
+
+Counter. Buffered chat and Responses API calls that returned 200 without
+choices (`no_choices`), without output (`no_output`, completed Responses API
+calls only), or without token usage (`no_usage`). The provider router detects
+these after decoding and fires `Hooks.OnEmptyResponse`; the llmclient never
+calls it. `gomodel_requests_total` still records these calls as successes.
+
+Labels: `provider`, `model`, `reason`.
+
 ## Helpers in `client.go`
 
 - `extractModel(body any) string` — pulls `Model` from `*core.ChatRequest` or

--- a/docs/dev/prometheus-metrics.md
+++ b/docs/dev/prometheus-metrics.md
@@ -43,16 +43,20 @@ Defined in `internal/llmclient/client.go`:
 
 ```go
 type RequestInfo struct {
-    Provider string
-    Model    string
-    Endpoint string
-    Method   string
-    Stream   bool
+    Provider     string
+    ProviderType string
+    Model        string
+    Operation    string // semantic GenAI operation; "" for non-inference calls
+    Endpoint     string
+    Method       string
+    Stream       bool
 }
 
 type ResponseInfo struct {
     Provider     string
+    ProviderType string
     Model        string
+    Operation    string
     Endpoint     string
     StatusCode   int           // 0 if network error
     Duration     time.Duration
@@ -61,11 +65,25 @@ type ResponseInfo struct {
     CircuitState string        // "closed", "half-open", "open"; "" when the breaker is disabled
 }
 
+type EmptyResponseInfo struct {
+    Provider     string
+    ProviderType string
+    Model        string
+    Operation    string
+    Reason       string // "no_choices", "no_output", "no_usage"
+}
+
 type Hooks struct {
-    OnRequestStart func(ctx context.Context, info RequestInfo) context.Context
-    OnRequestEnd   func(ctx context.Context, info ResponseInfo)
+    OnRequestStart     func(ctx context.Context, info RequestInfo) context.Context
+    OnRequestEnd       func(ctx context.Context, info ResponseInfo)
+    OnStreamFirstChunk func(ctx context.Context, info ResponseInfo) // first bytes of a successful stream
+    OnStreamEmpty      func(ctx context.Context, info ResponseInfo) // stream ended before its first byte
+    OnEmptyResponse    func(ctx context.Context, info EmptyResponseInfo) // fired by the provider router
 }
 ```
+
+`ResponseInfo` and `RequestInfo` omit the stream-intent fields
+(`StreamUncertain`) here for brevity; see the source for the full structs.
 
 `OnRequestStart` returns a `context.Context` so hooks can attach trace spans
 or request IDs that flow through the rest of the request.

--- a/docs/dev/prometheus-metrics.md
+++ b/docs/dev/prometheus-metrics.md
@@ -90,9 +90,11 @@ or request IDs that flow through the rest of the request.
 
 ## Instrumentation Points
 
-Hooks fire at the **logical request** level via `beginRequest` /
+The llmclient hooks fire at the **logical request** level via `beginRequest` /
 `finishRequest`, not per HTTP attempt. This means a request that retries 3
-times produces one counter increment, not three.
+times produces one counter increment, not three. `OnEmptyResponse` is the
+exception: the provider router fires it, not the llmclient (see
+`gomodel_empty_responses_total`).
 
 Three call sites in `client.go` use them:
 
@@ -159,7 +161,10 @@ Counter. Buffered chat and Responses API calls that returned 200 without
 choices (`no_choices`), without output (`no_output`, completed Responses API
 calls only), or without token usage (`no_usage`). The provider router detects
 these after decoding and fires `Hooks.OnEmptyResponse`; the llmclient never
-calls it. `gomodel_requests_total` still records these calls as successes.
+calls it. It fires once per provider call: llmclient retries within one call
+count once, but a failover target is another call, so a request whose primary
+and failover both return empty increments the counter twice.
+`gomodel_requests_total` still records these calls as successes.
 
 Labels: `provider`, `model`, `reason`.
 

--- a/docs/features/failover.mdx
+++ b/docs/features/failover.mdx
@@ -151,7 +151,8 @@ retry_on_errors:
 
 A non-streaming chat completion that returns `200` with an empty `choices`
 array is treated as a `502` (`provider returned no choices`), so it fails over
-under the default `5xx` status rule.
+under the default `5xx` status rule. Each such attempt is also logged and
+counted in `gomodel_empty_responses_total`.
 
 Example: try at most one backup, treat timeouts as failover-eligible but
 keep serving `429` responses to the client, and add a provider-specific

--- a/docs/guides/opentelemetry.mdx
+++ b/docs/guides/opentelemetry.mdx
@@ -160,6 +160,12 @@ Metrics are histograms in seconds, carrying the same attributes:
 | `gen_ai.client.operation.duration` | Every buffered call, and every streaming call that fails before the stream is established or ends before its first chunk. |
 | `gen_ai.client.operation.time_to_first_chunk` | Every successful streaming call, measured until the first response bytes arrive. |
 
+`gomodel.client.empty_responses` counts buffered chat and Responses API calls
+that returned `200` without usable content. Those calls look successful in the
+histograms above, so alert on this counter instead. Its `error.type` is
+`no_choices`, `no_output` (a completed Responses API call with no output
+items), or `no_usage` (content with zero token usage).
+
 A buffered call produces a `CLIENT` span named `<operation> <model>`, such as
 `chat gpt-5`, nested under the HTTP server span. Retries and failovers to
 another provider are separate calls and therefore separate spans, so a request

--- a/docs/guides/opentelemetry.mdx
+++ b/docs/guides/opentelemetry.mdx
@@ -161,8 +161,8 @@ Metrics are histograms in seconds, carrying the same attributes:
 | `gen_ai.client.operation.time_to_first_chunk` | Every successful streaming call, measured until the first response bytes arrive. |
 
 `gomodel.client.empty_responses` counts buffered chat and Responses API calls
-that returned `200` without usable content. Those calls look successful in the
-histograms above, so alert on this counter instead. Its `error.type` is
+that returned `200` with no choices, no output, or no token usage. Those calls
+look successful in the histograms above, so alert on this counter instead. Its `error.type` is
 `no_choices`, `no_output` (a completed Responses API call with no output
 items), or `no_usage` (content with zero token usage).
 

--- a/docs/guides/prometheus-metrics.mdx
+++ b/docs/guides/prometheus-metrics.mdx
@@ -283,6 +283,27 @@ If you need to protect the metrics endpoint further:
    }
    ```
 
+## Alerting on Empty Responses
+
+A provider sometimes answers `200` but returns no choices, no output, or no
+token usage. `gomodel_requests_total` counts those calls as successes, so
+GoModel also increments `gomodel_empty_responses_total` and logs a warning
+(`provider returned 200 with an empty response`).
+
+| Label      | Values                                    |
+| ---------- | ----------------------------------------- |
+| `provider` | Provider name from your configuration     |
+| `model`    | Model sent upstream                       |
+| `reason`   | `no_choices`, `no_output`, or `no_usage`  |
+
+A chat completion without choices also returns `502` to the client, or fails
+over when a failover target exists. A response with content but no usage is
+still returned; it only breaks usage and cost tracking.
+
+```promql
+sum(rate(gomodel_empty_responses_total[5m])) by (provider, model, reason) > 0
+```
+
 ## Prometheus Configuration
 
 ### Scrape Config

--- a/docs/providers/overview.mdx
+++ b/docs/providers/overview.mdx
@@ -291,7 +291,8 @@ Expand a card (the arrow strip at the bottom, or the section-wide
   at least 3 errors making up half or more of its windowed requests is
   flagged in red — this catches a single broken model on an otherwise
   healthy provider, which model discovery alone cannot see. Hover a row for
-  the model's latest error message.
+  the model's latest error message. A `200` response with no choices, no
+  output, or no token usage counts as an error here too.
 
 Request-health tracking is passive: it observes traffic your clients already
 send (the gateway's own background probes — model discovery and availability

--- a/internal/core/errors.go
+++ b/internal/core/errors.go
@@ -176,10 +176,14 @@ func NewEmptyProviderResponseError(provider string) *GatewayError {
 	return NewProviderError(provider, http.StatusBadGateway, "provider returned empty response", nil)
 }
 
+// ErrNoChoices is wrapped by NewNoChoicesProviderError so observers can tell
+// an empty 200 response apart from other 502s.
+var ErrNoChoices = errors.New("provider returned no choices")
+
 // NewNoChoicesProviderError reports a chat completion that succeeded upstream
 // but carried no choices (502), so failover treats it as a failed attempt.
 func NewNoChoicesProviderError(provider string) *GatewayError {
-	return NewProviderError(provider, http.StatusBadGateway, "provider returned no choices", nil)
+	return NewProviderError(provider, http.StatusBadGateway, ErrNoChoices.Error(), ErrNoChoices)
 }
 
 // NewRateLimitError creates a new rate limit error (429)

--- a/internal/llmclient/client.go
+++ b/internal/llmclient/client.go
@@ -70,6 +70,29 @@ type Hooks struct {
 	// established but never delivered. OnStreamFirstChunk is not called for
 	// it. Error carries the read error, io.EOF for a clean empty stream.
 	OnStreamEmpty func(ctx context.Context, info ResponseInfo)
+
+	// OnEmptyResponse is called when a buffered inference call succeeded at
+	// the HTTP level but its normalized response carries no choices, output,
+	// or usage. The provider router fires it after decoding, so it follows
+	// the OnRequestEnd call that recorded the same attempt as a success.
+	OnEmptyResponse func(ctx context.Context, info EmptyResponseInfo)
+}
+
+// Empty response reasons reported through Hooks.OnEmptyResponse.
+const (
+	EmptyReasonNoChoices = "no_choices" // chat completion with no choices
+	EmptyReasonNoOutput  = "no_output"  // completed Responses API call with no output items
+	EmptyReasonNoUsage   = "no_usage"   // content returned without any token usage
+)
+
+// EmptyResponseInfo describes a provider response that returned 200 without
+// usable content or usage.
+type EmptyResponseInfo struct {
+	Provider     string // Configured provider name
+	ProviderType string // Provider implementation type
+	Model        string // Upstream model name, as sent to the provider
+	Operation    string // Semantic GenAI operation
+	Reason       string // One of the EmptyReason* values
 }
 
 // Config holds configuration for the LLM client

--- a/internal/llmclient/hooks.go
+++ b/internal/llmclient/hooks.go
@@ -10,6 +10,7 @@ func JoinHooks(hooks ...Hooks) Hooks {
 	var ends []func(ctx context.Context, info ResponseInfo)
 	var firstChunks []func(ctx context.Context, info ResponseInfo)
 	var empties []func(ctx context.Context, info ResponseInfo)
+	var emptyResponses []func(ctx context.Context, info EmptyResponseInfo)
 	for _, h := range hooks {
 		if h.OnRequestStart != nil {
 			starts = append(starts, h.OnRequestStart)
@@ -22,6 +23,9 @@ func JoinHooks(hooks ...Hooks) Hooks {
 		}
 		if h.OnStreamEmpty != nil {
 			empties = append(empties, h.OnStreamEmpty)
+		}
+		if h.OnEmptyResponse != nil {
+			emptyResponses = append(emptyResponses, h.OnEmptyResponse)
 		}
 	}
 
@@ -60,6 +64,15 @@ func JoinHooks(hooks ...Hooks) Hooks {
 		joined.OnStreamEmpty = func(ctx context.Context, info ResponseInfo) {
 			for _, empty := range empties {
 				empty(ctx, info)
+			}
+		}
+	}
+	if len(emptyResponses) == 1 {
+		joined.OnEmptyResponse = emptyResponses[0]
+	} else if len(emptyResponses) > 1 {
+		joined.OnEmptyResponse = func(ctx context.Context, info EmptyResponseInfo) {
+			for _, emptyResponse := range emptyResponses {
+				emptyResponse(ctx, info)
 			}
 		}
 	}

--- a/internal/llmclient/hooks_test.go
+++ b/internal/llmclient/hooks_test.go
@@ -20,6 +20,9 @@ func TestJoinHooksChainsCallbacks(t *testing.T) {
 		OnStreamFirstChunk: func(_ context.Context, _ ResponseInfo) {
 			order = append(order, "chunk-1")
 		},
+		OnEmptyResponse: func(_ context.Context, _ EmptyResponseInfo) {
+			order = append(order, "empty-1")
+		},
 	}
 	second := Hooks{
 		OnRequestStart: func(ctx context.Context, _ RequestInfo) context.Context {
@@ -35,14 +38,18 @@ func TestJoinHooksChainsCallbacks(t *testing.T) {
 		OnStreamFirstChunk: func(_ context.Context, _ ResponseInfo) {
 			order = append(order, "chunk-2")
 		},
+		OnEmptyResponse: func(_ context.Context, _ EmptyResponseInfo) {
+			order = append(order, "empty-2")
+		},
 	}
 
 	joined := JoinHooks(first, Hooks{}, second)
 	ctx := joined.OnRequestStart(t.Context(), RequestInfo{})
 	joined.OnRequestEnd(ctx, ResponseInfo{})
 	joined.OnStreamFirstChunk(ctx, ResponseInfo{})
+	joined.OnEmptyResponse(ctx, EmptyResponseInfo{})
 
-	want := []string{"start-1", "start-2", "end-1", "end-2", "chunk-1", "chunk-2"}
+	want := []string{"start-1", "start-2", "end-1", "end-2", "chunk-1", "chunk-2", "empty-1", "empty-2"}
 	if len(order) != len(want) {
 		t.Fatalf("callback order = %v, want %v", order, want)
 	}
@@ -55,7 +62,7 @@ func TestJoinHooksChainsCallbacks(t *testing.T) {
 
 func TestJoinHooksEmpty(t *testing.T) {
 	joined := JoinHooks(Hooks{}, Hooks{})
-	if joined.OnRequestStart != nil || joined.OnRequestEnd != nil || joined.OnStreamFirstChunk != nil {
+	if joined.OnRequestStart != nil || joined.OnRequestEnd != nil || joined.OnStreamFirstChunk != nil || joined.OnEmptyResponse != nil {
 		t.Fatalf("JoinHooks of empty hooks should have nil callbacks")
 	}
 }

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -51,6 +51,17 @@ var (
 		[]string{"provider", "provider_name", "operation"},
 	)
 
+	// EmptyResponsesTotal counts provider calls that returned 200 without
+	// choices, output, or usage. gomodel_requests_total records those calls as
+	// successes, so alert on this counter instead.
+	EmptyResponsesTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "gomodel_empty_responses_total",
+			Help: "Total number of provider responses that returned 200 without choices, output, or usage",
+		},
+		[]string{"provider", "model", "reason"},
+	)
+
 	// CircuitBreakerState reports each provider's circuit breaker state as of
 	// its most recent request (0=closed, 1=half-open, 2=open). The value is
 	// updated per request, so an idle provider keeps its last observed state.
@@ -140,6 +151,9 @@ func NewPrometheusHooks() llmclient.Hooks {
 				CircuitBreakerState.WithLabelValues(info.Provider).Set(value)
 			}
 		},
+		OnEmptyResponse: func(_ context.Context, info llmclient.EmptyResponseInfo) {
+			EmptyResponsesTotal.WithLabelValues(info.Provider, info.Model, info.Reason).Inc()
+		},
 	}
 }
 
@@ -156,6 +170,9 @@ func NewPrometheusHooks() llmclient.Hooks {
 //
 // Concurrent requests:
 //   gomodel_requests_in_flight
+//
+// Empty 200 responses by provider and reason:
+//   sum(rate(gomodel_empty_responses_total[5m])) by (provider, reason)
 
 // Example Grafana dashboard queries:
 //
@@ -180,5 +197,6 @@ func ResetMetrics() {
 	RequestDuration.Reset()
 	InFlightRequests.Reset()
 	ResponseSnapshotStoreFailures.Reset()
+	EmptyResponsesTotal.Reset()
 	CircuitBreakerState.Reset()
 }

--- a/internal/observability/metrics_test.go
+++ b/internal/observability/metrics_test.go
@@ -386,3 +386,23 @@ func TestRequestDuration(t *testing.T) {
 		t.Fatal("Expected histogram, got nil")
 	}
 }
+
+func TestEmptyResponseMetric(t *testing.T) {
+	ResetMetrics()
+	hooks := NewPrometheusHooks()
+
+	for _, reason := range []string{llmclient.EmptyReasonNoChoices, llmclient.EmptyReasonNoChoices, llmclient.EmptyReasonNoUsage} {
+		hooks.OnEmptyResponse(context.Background(), llmclient.EmptyResponseInfo{
+			Provider: "openai-eu",
+			Model:    "gpt-4",
+			Reason:   reason,
+		})
+	}
+
+	if got := testutil.ToFloat64(EmptyResponsesTotal.WithLabelValues("openai-eu", "gpt-4", llmclient.EmptyReasonNoChoices)); got != 2 {
+		t.Fatalf("no_choices count = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(EmptyResponsesTotal.WithLabelValues("openai-eu", "gpt-4", llmclient.EmptyReasonNoUsage)); got != 1 {
+		t.Fatalf("no_usage count = %v, want 1", got)
+	}
+}

--- a/internal/providers/factory.go
+++ b/internal/providers/factory.go
@@ -115,6 +115,14 @@ func (f *ProviderFactory) AddHooks(hooks llmclient.Hooks) {
 	f.hooks = llmclient.JoinHooks(f.hooks, hooks)
 }
 
+// emptyResponseHook returns the composed OnEmptyResponse hook. The router
+// fires it itself, with the route's identity, so providers never receive it.
+func (f *ProviderFactory) emptyResponseHook() func(context.Context, llmclient.EmptyResponseInfo) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.hooks.OnEmptyResponse
+}
+
 // Add adds a provider constructor to the factory.
 // Panics if reg.Type is empty or reg.New is nil — both are programming errors
 // caught at startup, not runtime conditions.

--- a/internal/providers/health/tracker.go
+++ b/internal/providers/health/tracker.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"sort"
 	"sync"
 	"time"
@@ -115,6 +116,9 @@ func (t *Tracker) Hooks() llmclient.Hooks {
 		OnRequestEnd: func(_ context.Context, info llmclient.ResponseInfo) {
 			t.Record(info)
 		},
+		OnEmptyResponse: func(_ context.Context, info llmclient.EmptyResponseInfo) {
+			t.RecordEmptyResponse(info)
+		},
 	}
 }
 
@@ -128,11 +132,7 @@ func (t *Tracker) Record(info llmclient.ResponseInfo) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	provider := t.providers[info.Provider]
-	if provider == nil {
-		provider = &providerState{models: make(map[string]*modelState)}
-		t.providers[info.Provider] = provider
-	}
+	provider := t.provider(info.Provider)
 	if info.CircuitState != "" {
 		provider.circuitState = info.CircuitState
 	}
@@ -150,14 +150,7 @@ func (t *Tracker) Record(info llmclient.ResponseInfo) {
 	}
 
 	now := t.now()
-	model := provider.models[info.Model]
-	if model == nil {
-		if len(provider.models) >= maxTrackedModels {
-			evictStalestModel(provider.models)
-		}
-		model = &modelState{}
-		provider.models[info.Model] = model
-	}
+	model := provider.model(info.Model)
 
 	failed := info.Error != nil || info.StatusCode >= 400
 	model.events = append(model.events, event{at: now, failed: failed})
@@ -170,6 +163,41 @@ func (t *Tracker) Record(info llmclient.ResponseInfo) {
 		}
 	}
 	model.prune(now)
+}
+
+// RecordEmptyResponse marks a 200 response without choices, output, or usage
+// as a failure. OnRequestEnd already recorded the call as a success, so the
+// model's most recent success is turned into a failure instead of adding a
+// second request.
+func (t *Tracker) RecordEmptyResponse(info llmclient.EmptyResponseInfo) {
+	if info.Provider == "" || info.Model == "" || info.Model == llmclient.UnknownModel {
+		return
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	now := t.now()
+	model := t.provider(info.Provider).model(info.Model)
+	model.prune(now)
+
+	flipped := false
+	for i := len(model.events) - 1; i >= 0; i-- {
+		if !model.events[i].failed {
+			model.events[i].failed = true
+			flipped = true
+			break
+		}
+	}
+	if !flipped {
+		model.events = append(model.events, event{at: now, failed: true})
+	}
+	model.lastActivity = now
+	model.lastError = &ErrorInfo{
+		StatusCode: http.StatusOK,
+		Message:    "provider returned 200 with an empty response (" + info.Reason + ")",
+		At:         now,
+	}
 }
 
 // Snapshot returns windowed health per provider name. Providers without any
@@ -231,6 +259,31 @@ func (p ProviderHealth) FlaggedModels() []string {
 		}
 	}
 	return flagged
+}
+
+// provider returns the named provider's state, creating it on first use.
+// Callers hold t.mu.
+func (t *Tracker) provider(name string) *providerState {
+	provider := t.providers[name]
+	if provider == nil {
+		provider = &providerState{models: make(map[string]*modelState)}
+		t.providers[name] = provider
+	}
+	return provider
+}
+
+// model returns the named model's state, evicting the least recently active
+// model when the provider is at capacity.
+func (p *providerState) model(name string) *modelState {
+	model := p.models[name]
+	if model == nil {
+		if len(p.models) >= maxTrackedModels {
+			evictStalestModel(p.models)
+		}
+		model = &modelState{}
+		p.models[name] = model
+	}
+	return model
 }
 
 func (m *modelState) prune(now time.Time) {

--- a/internal/providers/health/tracker.go
+++ b/internal/providers/health/tracker.go
@@ -169,6 +169,12 @@ func (t *Tracker) Record(info llmclient.ResponseInfo) {
 // as a failure. OnRequestEnd already recorded the call as a success, so the
 // model's most recent success is turned into a failure instead of adding a
 // second request.
+//
+// Under concurrency that success may belong to another request for the same
+// model. Events carry only a timestamp and outcome, so every success for a
+// model is interchangeable: each empty response follows its own success and
+// flips exactly one, which keeps request, error, and flag counts exact
+// without correlating hook calls.
 func (t *Tracker) RecordEmptyResponse(info llmclient.EmptyResponseInfo) {
 	if info.Provider == "" || info.Model == "" || info.Model == llmclient.UnknownModel {
 		return

--- a/internal/providers/health/tracker_test.go
+++ b/internal/providers/health/tracker_test.go
@@ -254,6 +254,27 @@ func TestTrackerEmptyResponsesFlagModel(t *testing.T) {
 	}
 }
 
+func TestTrackerEmptyResponseInterleavedWithOtherRequests(t *testing.T) {
+	tracker, now := newTestTracker(time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC))
+	success := llmclient.ResponseInfo{Provider: "openai", Model: "gpt-4o", StatusCode: 200}
+	empty := llmclient.EmptyResponseInfo{Provider: "openai", Model: "gpt-4o", Reason: llmclient.EmptyReasonNoChoices}
+
+	// A and B both end before A is classified empty; C fails outright
+	// before B is classified empty.
+	tracker.Record(success) // A
+	*now = now.Add(time.Millisecond)
+	tracker.Record(success) // B
+	tracker.RecordEmptyResponse(empty)
+	tracker.Record(llmclient.ResponseInfo{Provider: "openai", Model: "gpt-4o", StatusCode: 500}) // C
+	tracker.RecordEmptyResponse(empty)
+	tracker.Record(success) // D
+
+	row := tracker.Snapshot()["openai"].Models[0]
+	if row.Requests != 4 || row.Errors != 3 || !row.Flagged {
+		t.Fatalf("row = %+v, want requests=4 errors=3 flagged", row)
+	}
+}
+
 func TestTrackerEvictsStalestModel(t *testing.T) {
 	tracker, now := newTestTracker(time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC))
 	for i := range maxTrackedModels {

--- a/internal/providers/health/tracker_test.go
+++ b/internal/providers/health/tracker_test.go
@@ -215,6 +215,45 @@ func TestTrackerHooksFeedRecord(t *testing.T) {
 	}
 }
 
+func TestTrackerEmptyResponsesFlagModel(t *testing.T) {
+	tests := []struct {
+		name         string
+		successes    int
+		empties      int
+		wantRequests int
+		wantErrors   int
+		wantFlagged  bool
+	}{
+		{name: "empty responses replace their recorded successes", successes: 4, empties: 3, wantRequests: 4, wantErrors: 3, wantFlagged: true},
+		{name: "a single empty response does not flag", successes: 4, empties: 1, wantRequests: 4, wantErrors: 1},
+		{name: "empty response without a recorded request adds a failure", empties: 1, wantRequests: 1, wantErrors: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tracker, _ := newTestTracker(time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC))
+			hooks := tracker.Hooks()
+			for range tt.successes {
+				hooks.OnRequestEnd(t.Context(), llmclient.ResponseInfo{Provider: "openai", Model: "gpt-4o", StatusCode: 200})
+			}
+			for range tt.empties {
+				hooks.OnEmptyResponse(t.Context(), llmclient.EmptyResponseInfo{Provider: "openai", Model: "gpt-4o", Reason: llmclient.EmptyReasonNoChoices})
+			}
+
+			snapshot := tracker.Snapshot()["openai"]
+			if len(snapshot.Models) != 1 {
+				t.Fatalf("models = %+v, want one row", snapshot.Models)
+			}
+			row := snapshot.Models[0]
+			if row.Requests != tt.wantRequests || row.Errors != tt.wantErrors || row.Flagged != tt.wantFlagged {
+				t.Fatalf("row = %+v, want requests=%d errors=%d flagged=%v", row, tt.wantRequests, tt.wantErrors, tt.wantFlagged)
+			}
+			if row.LastError == nil || row.LastError.StatusCode != 200 || !strings.Contains(row.LastError.Message, "no_choices") {
+				t.Fatalf("last error = %+v, want a 200 no_choices error", row.LastError)
+			}
+		})
+	}
+}
+
 func TestTrackerEvictsStalestModel(t *testing.T) {
 	tracker, now := newTestTracker(time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC))
 	for i := range maxTrackedModels {

--- a/internal/providers/init.go
+++ b/internal/providers/init.go
@@ -184,6 +184,7 @@ func Init(ctx context.Context, result *config.LoadResult, factory *ProviderFacto
 		return nil, fmt.Errorf("failed to create router: %w", err)
 	}
 	router.SetUnqualifiedModelIDs(result.Config.Models.UnqualifiedModelIDsAtModelsEndpoint)
+	router.SetEmptyResponseHook(factory.emptyResponseHook())
 
 	return &InitResult{
 		ConfiguredProviders:         SanitizeProviderConfigs(providerMap),

--- a/internal/providers/router.go
+++ b/internal/providers/router.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/llmclient"
 )
 
 // ErrRegistryNotInitialized is returned when the router is used before the registry has any models.
@@ -27,6 +28,9 @@ type Router struct {
 	// unqualifiedModelIDs makes ListModels advertise bare model IDs instead of
 	// provider-qualified ones.
 	unqualifiedModelIDs bool
+	// onEmptyResponse observes 200 responses without choices, output, or
+	// usage; nil disables the hook (the warning log still fires).
+	onEmptyResponse func(context.Context, llmclient.EmptyResponseInfo)
 }
 
 // lookupCaps records which optional interfaces the lookup implements. A nil

--- a/internal/providers/router_dispatch.go
+++ b/internal/providers/router_dispatch.go
@@ -80,6 +80,7 @@ func routeResolvedModelCall[Req any, Resp any](
 	}
 
 	resp, err := call(ctx, route.provider, buildForward(route))
+	r.observeEmptyResponse(ctx, route, resp, err)
 	return resp, route.providerType, err
 }
 

--- a/internal/providers/router_empty.go
+++ b/internal/providers/router_empty.go
@@ -1,0 +1,79 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/llmclient"
+)
+
+// SetEmptyResponseHook registers the observer for provider responses that
+// return 200 without choices, output, or usage.
+func (r *Router) SetEmptyResponseHook(hook func(context.Context, llmclient.EmptyResponseInfo)) {
+	r.onEmptyResponse = hook
+}
+
+// observeEmptyResponse logs and reports a provider call that succeeded at the
+// HTTP level but returned nothing usable. The gateway still decides whether
+// that is an error for the client (no choices fails over; no usage does not).
+func (r *Router) observeEmptyResponse(ctx context.Context, route resolvedRoute, resp any, err error) {
+	reason := emptyResponseReason(resp, err)
+	if reason == "" {
+		return
+	}
+	info := llmclient.EmptyResponseInfo{
+		Provider:     route.selector.Provider,
+		ProviderType: route.providerType,
+		Model:        route.selector.Model,
+		Operation:    llmclient.OperationChat,
+		Reason:       reason,
+	}
+	slog.WarnContext(ctx, "provider returned 200 with an empty response",
+		"provider", info.Provider,
+		"provider_type", info.ProviderType,
+		"model", info.Model,
+		"reason", info.Reason,
+	)
+	if r.onEmptyResponse != nil {
+		r.onEmptyResponse(ctx, info)
+	}
+}
+
+// emptyResponseReason classifies buffered chat and Responses API results.
+// Other response types, and calls that failed for any reason other than an
+// empty 200, are never reported.
+func emptyResponseReason(resp any, err error) string {
+	if err != nil {
+		if errors.Is(err, core.ErrNoChoices) {
+			return llmclient.EmptyReasonNoChoices
+		}
+		return ""
+	}
+	switch typed := resp.(type) {
+	case *core.ChatResponse:
+		if typed == nil || len(typed.Choices) == 0 {
+			return llmclient.EmptyReasonNoChoices
+		}
+		if typed.Usage.PromptTokens == 0 && typed.Usage.CompletionTokens == 0 && typed.Usage.TotalTokens == 0 {
+			return llmclient.EmptyReasonNoUsage
+		}
+	case *core.ResponsesResponse:
+		if typed == nil {
+			return llmclient.EmptyReasonNoOutput
+		}
+		// Background and in-progress responses legitimately carry neither
+		// output nor usage yet.
+		if typed.Status != "" && typed.Status != "completed" {
+			return ""
+		}
+		if len(typed.Output) == 0 {
+			return llmclient.EmptyReasonNoOutput
+		}
+		if typed.Usage == nil || (typed.Usage.InputTokens == 0 && typed.Usage.OutputTokens == 0 && typed.Usage.TotalTokens == 0) {
+			return llmclient.EmptyReasonNoUsage
+		}
+	}
+	return ""
+}

--- a/internal/providers/router_empty_test.go
+++ b/internal/providers/router_empty_test.go
@@ -1,0 +1,126 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/llmclient"
+)
+
+func TestEmptyResponseReason(t *testing.T) {
+	message := []core.Choice{{Message: core.ResponseMessage{Role: "assistant", Content: "ok"}}}
+	usage := core.Usage{PromptTokens: 3, CompletionTokens: 1, TotalTokens: 4}
+	output := []core.ResponsesOutputItem{{Type: "message"}}
+	responsesUsage := &core.ResponsesUsage{InputTokens: 3, OutputTokens: 1, TotalTokens: 4}
+
+	tests := []struct {
+		name string
+		resp any
+		err  error
+		want string
+	}{
+		{name: "chat with choices and usage", resp: &core.ChatResponse{Choices: message, Usage: usage}},
+		{name: "chat without choices", resp: &core.ChatResponse{Usage: usage}, want: llmclient.EmptyReasonNoChoices},
+		{name: "nil chat response", resp: (*core.ChatResponse)(nil), want: llmclient.EmptyReasonNoChoices},
+		{name: "chat without usage", resp: &core.ChatResponse{Choices: message}, want: llmclient.EmptyReasonNoUsage},
+		{name: "no choices error", err: core.NewNoChoicesProviderError("openai"), want: llmclient.EmptyReasonNoChoices},
+		{name: "other provider error", err: core.NewEmptyProviderResponseError("openai")},
+		{name: "plain error", err: errors.New("boom")},
+		{name: "completed responses", resp: &core.ResponsesResponse{Status: "completed", Output: output, Usage: responsesUsage}},
+		{name: "responses without output", resp: &core.ResponsesResponse{Status: "completed", Usage: responsesUsage}, want: llmclient.EmptyReasonNoOutput},
+		{name: "responses without usage", resp: &core.ResponsesResponse{Status: "completed", Output: output}, want: llmclient.EmptyReasonNoUsage},
+		{name: "responses with zero usage", resp: &core.ResponsesResponse{Output: output, Usage: &core.ResponsesUsage{}}, want: llmclient.EmptyReasonNoUsage},
+		{name: "queued background responses", resp: &core.ResponsesResponse{Status: "queued"}},
+		{name: "nil responses response", resp: (*core.ResponsesResponse)(nil), want: llmclient.EmptyReasonNoOutput},
+		{name: "embeddings are not checked", resp: &core.EmbeddingResponse{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := emptyResponseReason(tt.resp, tt.err); got != tt.want {
+				t.Fatalf("emptyResponseReason() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRouterReportsEmptyResponses(t *testing.T) {
+	tests := []struct {
+		name       string
+		provider   *mockProvider
+		call       func(*Router) error
+		wantReason string
+	}{
+		{
+			name:     "chat without choices",
+			provider: &mockProvider{chatResponse: &core.ChatResponse{ID: "empty"}},
+			call: func(r *Router) error {
+				_, err := r.ChatCompletion(context.Background(), &core.ChatRequest{Model: "gpt-4o"})
+				return err
+			},
+			wantReason: llmclient.EmptyReasonNoChoices,
+		},
+		{
+			name:     "responses translated from a chat without choices",
+			provider: &mockProvider{err: core.NewNoChoicesProviderError("openai-primary")},
+			call: func(r *Router) error {
+				_, err := r.Responses(context.Background(), &core.ResponsesRequest{Model: "gpt-4o"})
+				if !errors.Is(err, core.ErrNoChoices) {
+					return err
+				}
+				return nil
+			},
+			wantReason: llmclient.EmptyReasonNoChoices,
+		},
+		{
+			name: "complete chat",
+			provider: &mockProvider{chatResponse: &core.ChatResponse{
+				Choices: []core.Choice{{Message: core.ResponseMessage{Role: "assistant", Content: "ok"}}},
+				Usage:   core.Usage{PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2},
+			}},
+			call: func(r *Router) error {
+				_, err := r.ChatCompletion(context.Background(), &core.ChatRequest{Model: "gpt-4o"})
+				return err
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router, err := NewRouter(newTestRegistryWithModels(registryModelEntry{
+				provider:     tt.provider,
+				providerName: "openai-primary",
+				providerType: "openai",
+				modelID:      "gpt-4o",
+			}))
+			if err != nil {
+				t.Fatalf("NewRouter: %v", err)
+			}
+			var reported []llmclient.EmptyResponseInfo
+			router.SetEmptyResponseHook(func(_ context.Context, info llmclient.EmptyResponseInfo) {
+				reported = append(reported, info)
+			})
+
+			if err := tt.call(router); err != nil {
+				t.Fatalf("call error = %v", err)
+			}
+
+			if tt.wantReason == "" {
+				if len(reported) != 0 {
+					t.Fatalf("reported = %+v, want none", reported)
+				}
+				return
+			}
+			want := llmclient.EmptyResponseInfo{
+				Provider:     "openai-primary",
+				ProviderType: "openai",
+				Model:        "gpt-4o",
+				Operation:    llmclient.OperationChat,
+				Reason:       tt.wantReason,
+			}
+			if len(reported) != 1 || reported[0] != want {
+				t.Fatalf("reported = %+v, want [%+v]", reported, want)
+			}
+		})
+	}
+}

--- a/internal/telemetry/observer.go
+++ b/internal/telemetry/observer.go
@@ -34,6 +34,7 @@ type observer struct {
 	tracer           trace.Tracer
 	duration         apiMetric.Float64Histogram
 	timeToFirstChunk apiMetric.Float64Histogram
+	emptyResponses   apiMetric.Int64Counter
 }
 
 type callState struct {
@@ -64,10 +65,19 @@ func newObserver(tp trace.TracerProvider, mp apiMetric.MeterProvider) (*observer
 	if err != nil {
 		return nil, err
 	}
+	emptyResponses, err := meter.Int64Counter(
+		"gomodel.client.empty_responses",
+		apiMetric.WithDescription("Provider responses that returned 200 without choices, output, or usage."),
+		apiMetric.WithUnit("{response}"),
+	)
+	if err != nil {
+		return nil, err
+	}
 	return &observer{
 		tracer:           tp.Tracer(instrumentationName),
 		duration:         duration,
 		timeToFirstChunk: ttfc,
+		emptyResponses:   emptyResponses,
 	}, nil
 }
 
@@ -77,6 +87,7 @@ func (o *observer) hooks() llmclient.Hooks {
 		OnRequestEnd:       o.end,
 		OnStreamFirstChunk: o.firstChunk,
 		OnStreamEmpty:      o.streamEmpty,
+		OnEmptyResponse:    o.emptyResponse,
 	}
 }
 
@@ -167,6 +178,22 @@ func (o *observer) streamEmpty(ctx context.Context, info llmclient.ResponseInfo)
 		info.Error = errEmptyStream
 	}
 	o.end(ctx, info)
+}
+
+// emptyResponse counts a 200 response without choices, output, or usage. The
+// call's span and duration already recorded it as a success, so the counter
+// carries the reason as error.type for alerting.
+func (o *observer) emptyResponse(ctx context.Context, info llmclient.EmptyResponseInfo) {
+	attrs := []attribute.KeyValue{
+		attribute.String("gen_ai.operation.name", info.Operation),
+		attribute.String("gen_ai.provider.name", semanticProviderName(info.ProviderType, info.Provider)),
+		attribute.String("gomodel.provider.name", info.Provider),
+		attribute.String("error.type", info.Reason),
+	}
+	if model := modelName(info.Model); model != "" {
+		attrs = append(attrs, attribute.String("gen_ai.request.model", model))
+	}
+	o.emptyResponses.Add(ctx, 1, apiMetric.WithAttributes(attrs...))
 }
 
 func callAttributes(info llmclient.RequestInfo, operation string) []attribute.KeyValue {

--- a/internal/telemetry/observer_test.go
+++ b/internal/telemetry/observer_test.go
@@ -95,6 +95,33 @@ func TestObserverRecordsHTTPErrorType(t *testing.T) {
 	}
 }
 
+func TestObserverCountsEmptyResponses(t *testing.T) {
+	hooks, _, reader := newTestHooks(t)
+	info := llmclient.EmptyResponseInfo{Provider: "openai-eu", ProviderType: "openai", Model: "gpt-5", Operation: "chat", Reason: llmclient.EmptyReasonNoChoices}
+	hooks.OnEmptyResponse(t.Context(), info)
+	hooks.OnEmptyResponse(t.Context(), info)
+
+	for _, scope := range collect(t, reader).ScopeMetrics {
+		for _, candidate := range scope.Metrics {
+			if candidate.Name != "gomodel.client.empty_responses" {
+				continue
+			}
+			sum, ok := candidate.Data.(metricdata.Sum[int64])
+			if !ok || len(sum.DataPoints) != 1 {
+				t.Fatalf("empty_responses data = %+v, want one int64 sum point", candidate.Data)
+			}
+			point := sum.DataPoints[0]
+			attrs := attributeMap(point.Attributes.ToSlice())
+			if point.Value != 2 || attrs["error.type"] != "no_choices" || attrs["gen_ai.provider.name"] != "openai" ||
+				attrs["gomodel.provider.name"] != "openai-eu" || attrs["gen_ai.request.model"] != "gpt-5" {
+				t.Fatalf("empty_responses point = %d %+v", point.Value, attrs)
+			}
+			return
+		}
+	}
+	t.Fatal("gomodel.client.empty_responses was not recorded")
+}
+
 func TestObserverDefersTelemetryWhenStreamIntentIsUncertain(t *testing.T) {
 	hooks, recorder, reader := newTestHooks(t)
 	call := llmclient.RequestInfo{Provider: "openai", Operation: "chat", Endpoint: "/chat/completions", StreamUncertain: true}


### PR DESCRIPTION
Closes #931

When a provider answers `200` with no choices, no output (completed Responses API calls), or zero token usage, the router now:

- logs a warning (`provider returned 200 with an empty response`, with provider, model, reason)
- increments `gomodel_empty_responses_total{provider,model,reason}` (Prometheus) and `gomodel.client.empty_responses` (OTel, reason in `error.type`)
- marks the attempt as an error in the dashboard health tracker, so the model gets flagged under the existing rule

Reasons: `no_choices`, `no_output`, `no_usage`. Detection runs in the provider router after decoding and reaches consumers through a new `llmclient.Hooks.OnEmptyResponse`. Client-facing behavior is unchanged: no choices still returns 502 / fails over (#949); a missing-usage response is still returned.

Note: `no_usage` also counts toward dashboard flagging, so providers that never report usage will show as Degraded. Streaming responses are not checked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added monitoring for successful HTTP 200 responses with no usable choices, output, or token usage.
  - Empty responses are classified by reason and included in Prometheus and OpenTelemetry metrics.
  - Provider health tracking now recognizes empty responses as failures.

- **Bug Fixes**
  - Non-streaming chat responses with no choices now return a 502 error and can trigger failover.
  - Responses with content but no usage remain available, while usage and cost tracking may be affected.

- **Documentation**
  - Updated metrics, failover, provider status, and OpenTelemetry guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->