### PR TITLE
fix(responses): drop replayed output item ids on chat translation

### DIFF
--- a/docs/advanced/responses-compatibility.mdx
+++ b/docs/advanced/responses-compatibility.mdx
@@ -34,6 +34,7 @@ function tool loops. They cannot safely execute OpenAI-hosted tools.
 | Streaming over HTTP/SSE | Forwarded | Converted from chat streaming events into the OpenAI event sequence: `response.created` and `response.in_progress`, output item and content part lifecycle events, and a `sequence_number` on every event |
 | Function tools | Forwarded | Converted to provider function/tool declarations |
 | Function call output items | Forwarded | Converted to chat tool-result messages |
+| Replayed output item metadata (`id`, `status`, `annotations`, `logprobs`) | Forwarded | Dropped before dispatch: chat providers have no place for them, and Groq and Fireworks reject them outright |
 | `text.format` structured output | Forwarded | Converted to `response_format` when the provider supports it |
 | Responses-only tools (`web_search`, `file_search`, `computer_use_preview`, and `namespace`) | Provider decides | Accepted and omitted |
 | `previous_response_id` | Forwarded | Resolved by GoModel: the stored previous response's input items and output are prepended to the input. The previous response must be stored (`store` left on), or the request returns 404 (see [Stored responses](/advanced/responses-api#stored-responses)) |
@@ -102,6 +103,12 @@ GoModel for portable flows:
 Provider-hosted tools are ignored by chat-translated providers. Server-managed
 conversation state and websocket Responses transport still depend on
 provider-specific support.
+
+Stateless replay works too. Clients that send the previous turn's output items
+back as input (`store: false`, Codex, SDK-managed history) always include the
+item `id` that the Responses API returned. GoModel drops that `id`, along with
+the other Responses-only item metadata, before calling a chat provider, so the
+same replay body works on every provider.
 
 For Python Agents SDK clients, namespaced GoModel model IDs such as
 `anthropic/claude-sonnet-4-20250514` and `gemini/gemini-2.0-flash` need model ID

--- a/internal/providers/responses_adapter_test.go
+++ b/internal/providers/responses_adapter_test.go
@@ -1592,3 +1592,74 @@ func TestConvertResponsesRequestToChat_DropsResponsesOnlyTextMembers(t *testing.
 		})
 	}
 }
+
+// Replayed Responses output items always carry an "id". Chat providers such as
+// Groq and Fireworks reject an unknown "id" member on a message, so it must not
+// survive the translation.
+func TestConvertResponsesRequestToChat_DropsReplayedItemIDs(t *testing.T) {
+	const replay = `[
+		{"type":"message","id":"msg_1","status":"completed","role":"assistant",
+		 "content":[{"type":"output_text","text":"Let me check.","annotations":[]}],
+		 "cache_control":{"type":"ephemeral"}},
+		{"type":"function_call","id":"fc_1","call_id":"call_1","name":"get_weather","arguments":"{}","status":"completed"},
+		{"type":"function_call_output","id":"fco_1","call_id":"call_1","output":"18C","status":"completed",
+		 "cache_control":{"type":"ephemeral"}}
+	]`
+
+	var typed []core.ResponsesInputElement
+	if err := json.Unmarshal([]byte(replay), &typed); err != nil {
+		t.Fatalf("unmarshal typed input: %v", err)
+	}
+	var maps []any
+	if err := json.Unmarshal([]byte(replay), &maps); err != nil {
+		t.Fatalf("unmarshal map input: %v", err)
+	}
+
+	tests := []struct {
+		name  string
+		input any
+	}{
+		{name: "typed", input: typed},
+		{name: "map", input: maps},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chatReq, err := ConvertResponsesRequestToChat(&core.ResponsesRequest{Model: "test-model", Input: tt.input})
+			if err != nil {
+				t.Fatalf("ConvertResponsesRequestToChat() error = %v", err)
+			}
+			if len(chatReq.Messages) != 2 {
+				t.Fatalf("messages = %d, want 2: %+v", len(chatReq.Messages), chatReq.Messages)
+			}
+
+			assistant, tool := chatReq.Messages[0], chatReq.Messages[1]
+			if assistant.Role != "assistant" || tool.Role != "tool" {
+				t.Fatalf("roles = %q, %q; want assistant, tool", assistant.Role, tool.Role)
+			}
+			if assistant.ExtraFields.Lookup("id") != nil {
+				t.Errorf("assistant message kept id: %s", assistant.ExtraFields.Lookup("id"))
+			}
+			if tool.ExtraFields.Lookup("id") != nil {
+				t.Errorf("tool message kept id: %s", tool.ExtraFields.Lookup("id"))
+			}
+			if len(assistant.ToolCalls) != 1 || assistant.ToolCalls[0].ExtraFields.Lookup("id") != nil {
+				t.Errorf("tool call kept id: %+v", assistant.ToolCalls)
+			}
+
+			// Only the Responses-only members go; call ids and other unknown
+			// members still reach the provider.
+			if got := assistant.ToolCalls[0].ID; got != "call_1" {
+				t.Errorf("tool call id = %q, want call_1", got)
+			}
+			if got := tool.ToolCallID; got != "call_1" {
+				t.Errorf("tool_call_id = %q, want call_1", got)
+			}
+			if assistant.ExtraFields.Lookup("cache_control") == nil {
+				t.Error("cache_control dropped from the assistant message")
+			}
+			if tool.ExtraFields.Lookup("cache_control") == nil {
+				t.Error("cache_control dropped from the tool message")
+			}
+		})
+	}
+}

--- a/internal/providers/responses_content.go
+++ b/internal/providers/responses_content.go
@@ -49,6 +49,19 @@ func ConvertResponsesContentToChatContent(content any) (any, bool) {
 // chat providers such as Fireworks reject unknown members of a text part.
 var responsesOnlyTextKeys = []string{"annotations", "logprobs"}
 
+// responsesOnlyItemKeys are input-item members that a chat message has no place
+// for. Replayed Responses output items always carry an "id" (the OpenAI SDK
+// emits one on every output item), and strict chat providers reject it:
+// Groq answers "property 'id' is unsupported", Fireworks "Extra inputs are not
+// permitted, field: 'messages[1].id'".
+var responsesOnlyItemKeys = []string{"id"}
+
+// chatExtraFieldsFromResponsesItem copies the unknown members of a Responses
+// input item onto a chat message, dropping the Responses-only ones.
+func chatExtraFieldsFromResponsesItem(fields core.UnknownJSONFields) core.UnknownJSONFields {
+	return core.CloneUnknownJSONFields(fields.Without(responsesOnlyItemKeys...))
+}
+
 func convertResponsesContentParts(parts []any) (any, bool) {
 	typedParts := make([]core.ContentPart, 0, len(parts))
 

--- a/internal/providers/responses_input.go
+++ b/internal/providers/responses_input.go
@@ -242,7 +242,7 @@ func convertResponsesInputElement(item core.ResponsesInputElement, index int) (c
 				{
 					ID:          callID,
 					Type:        "function",
-					ExtraFields: core.CloneUnknownJSONFields(item.ExtraFields),
+					ExtraFields: chatExtraFieldsFromResponsesItem(item.ExtraFields),
 					Function: core.FunctionCall{
 						Name:      name,
 						Arguments: item.Arguments,
@@ -266,7 +266,7 @@ func convertResponsesInputElement(item core.ResponsesInputElement, index int) (c
 			Role:        "tool",
 			ToolCallID:  callID,
 			Content:     content,
-			ExtraFields: core.CloneUnknownJSONFields(item.ExtraFields),
+			ExtraFields: chatExtraFieldsFromResponsesItem(item.ExtraFields),
 		}, "function_call_output", nil
 	case "", "message":
 		role := strings.TrimSpace(item.Role)
@@ -281,7 +281,7 @@ func convertResponsesInputElement(item core.ResponsesInputElement, index int) (c
 		return core.Message{
 			Role:        role,
 			Content:     content,
-			ExtraFields: core.CloneUnknownJSONFields(item.ExtraFields),
+			ExtraFields: chatExtraFieldsFromResponsesItem(item.ExtraFields),
 		}, "message", nil
 	case "reasoning":
 		// Recognized by responsesInputReasoningText before item conversion.
@@ -333,7 +333,7 @@ func convertResponsesInputMap(item map[string]any, index int) (core.Message, str
 			Role:        "tool",
 			ToolCallID:  callID,
 			Content:     content,
-			ExtraFields: core.UnknownJSONFieldsFromMap(rawJSONMapFromUnknownKeys(item, "type", "call_id", "status", "output")),
+			ExtraFields: core.UnknownJSONFieldsFromMap(rawJSONMapFromUnknownKeys(item, "type", "call_id", "id", "status", "output")),
 		}, "function_call_output", nil
 	case "", "message":
 	case "reasoning":
@@ -357,7 +357,7 @@ func convertResponsesInputMap(item map[string]any, index int) (core.Message, str
 	return core.Message{
 		Role:        role,
 		Content:     content,
-		ExtraFields: core.UnknownJSONFieldsFromMap(rawJSONMapFromUnknownKeys(item, "type", "role", "status", "content")),
+		ExtraFields: core.UnknownJSONFieldsFromMap(rawJSONMapFromUnknownKeys(item, "type", "role", "id", "status", "content")),
 	}, "message", nil
 }
 


### PR DESCRIPTION
Stateless Responses replay (Agents SDK, Codex, `store: false`) sends the previous turn's output items back as input, and OpenAI output items always carry an `id`. The Responses -> chat translation forwarded that `id` as an unknown member of the chat message, so strict chat providers rejected the request:

- groq: `'messages.1' : property 'id' is unsupported`
- fireworks: `Extra inputs are not permitted, field: 'messages[1].id'`

`id` is now dropped from message, `function_call` and `function_call_output` items before chat dispatch, next to the existing `annotations`/`logprobs` stripping. Native Responses providers are unaffected (they never go through this path), and `call_id` / `tool_call_id` and other unknown members (e.g. `cache_control`) still reach the provider.

Tested: table-driven unit tests over the typed and map input shapes (failing before, passing after); `go test -race ./internal/providers/... ./internal/core/...`; `make lint`. Live against a local gateway with a manual replay body (assistant message + `function_call`/`function_call_output`, all with ids): groq and fireworks now succeed where they returned 400 before; gemini, anthropic and native openai unchanged, and a groq `previous_response_id` chain still carries history.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when replaying Responses API output with chat-based providers.
  * Responses-only metadata is now excluded from converted chat requests, preventing rejected requests while preserving supported tool and caching fields.

* **Documentation**
  * Added compatibility guidance for stateless replay across providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->