### PR TITLE
fix(responses): renumber stream sequence numbers when a guardrail edits the stream

### DIFF
--- a/docs/advanced/guardrails.mdx
+++ b/docs/advanced/guardrails.mdx
@@ -27,6 +27,11 @@ answer it with a safe message, or let it through with a warning.
   streams too; a plugin whose stream policy buffers has the same effect.
 </Warning>
 
+On `/v1/responses`, a stream-phase guardrail may drop, merge, or split events,
+so GoModel renumbers what it delivers: `sequence_number` still runs from `0`
+without gaps, up to the terminal `response.completed` (or `response.incomplete`
+/ `response.failed` on a cut stream).
+
 Guardrails work across all text-based endpoints:
 
 - `/v1/chat/completions`

--- a/internal/streaming/responses_codec.go
+++ b/internal/streaming/responses_codec.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -79,7 +80,12 @@ type responsesCodec struct {
 	id, model, provider string
 	createdAt           int64
 	seq                 int
-	items               map[int]*responsesItem
+	// out is the next outgoing sequence_number while renumbering, and
+	// renumbering says the codec, not the upstream, numbers the events the
+	// client sees. See Renumber.
+	out         int
+	renumbering bool
+	items       map[int]*responsesItem
 	order               []int
 	// textIndex is the output_index of the most recently decoded text
 	// delta; emitted text deltas (which may be re-segmented copies) are
@@ -118,6 +124,56 @@ func (c *responsesCodec) Decode(raw RawEvent, seq int) Event {
 		ev.Kind = KindFinish
 	}
 	return ev
+}
+
+// BeginRenumber puts the codec in renumbering mode.
+func (c *responsesCodec) BeginRenumber() { c.renumbering = true }
+
+// Renumber stamps the next outgoing sequence_number on an event about to
+// reach the client, so a stream that drops, merges, splits or injects events
+// still delivers 0..N without gaps. An event whose number is already the
+// right one is left untouched (ok is false), which keeps an unedited
+// pass-through byte identical.
+func (c *responsesCodec) Renumber(ev Event) (Event, bool) {
+	if ev.Kind == KindDone || !jsonObject(ev.Data) {
+		return ev, false
+	}
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(ev.Data, &top); err != nil {
+		return ev, false
+	}
+	if _, numbered := top["sequence_number"]; !numbered {
+		return ev, false
+	}
+	next := c.nextSeq()
+	if current, err := strconv.Atoi(string(bytes.TrimSpace(top["sequence_number"]))); err == nil && current == next {
+		return ev, false
+	}
+	encoded, err := json.Marshal(next)
+	if err != nil {
+		return ev, false
+	}
+	top["sequence_number"] = encoded
+	data, err := json.Marshal(top)
+	if err != nil {
+		return ev, false
+	}
+	ev.Data = data
+	return ev, true
+}
+
+// nextSeq returns the number the next emitted event carries: the outgoing
+// count while renumbering, and otherwise one past the highest number seen
+// upstream.
+func (c *responsesCodec) nextSeq() int {
+	if c.renumbering {
+		n := c.out
+		c.out++
+		return n
+	}
+	n := c.seq
+	c.seq++
+	return n
 }
 
 func (c *responsesCodec) remember(view *responsesEventView) {
@@ -256,8 +312,8 @@ func (c *responsesCodec) RewriteText(ev Event, text string) (Event, error) {
 }
 
 // StripTerminal is a no-op: a Responses text delta carries no per-choice
-// terminal members. A re-segmented delta repeats its sequence_number, which
-// clients do not act on.
+// terminal members. A re-segmented delta is renumbered on its way out, so it
+// does not repeat the sequence_number of the chunk it was rendered from.
 func (c *responsesCodec) StripTerminal(ev Event) (Event, bool) { return ev, false }
 
 // Split is a no-op: a Responses event carries one delta.
@@ -474,8 +530,7 @@ func isResponsesRestatingEvent(ev Event) bool {
 // emit appends one event with the next sequence_number.
 func (c *responsesCodec) emit(out [][]byte, name string, payload map[string]any) [][]byte {
 	payload["type"] = name
-	payload["sequence_number"] = c.seq
-	c.seq++
+	payload["sequence_number"] = c.nextSeq()
 	encoded, err := encodeJSONEvent(name, payload)
 	if err != nil {
 		return out

--- a/internal/streaming/responses_codec.go
+++ b/internal/streaming/responses_codec.go
@@ -131,18 +131,15 @@ func (c *responsesCodec) BeginRenumber() { c.renumbering = true }
 
 // Renumber stamps the next outgoing sequence_number on an event about to
 // reach the client, so a stream that drops, merges, splits or injects events
-// still delivers 0..N without gaps. An event whose number is already the
-// right one is left untouched (ok is false), which keeps an unedited
-// pass-through byte identical.
+// still delivers 0..N without gaps. An event that arrived without a number
+// gets one; an event whose number is already the right one is left untouched
+// (ok is false), which keeps an unedited pass-through byte identical.
 func (c *responsesCodec) Renumber(ev Event) (Event, bool) {
 	if ev.Kind == KindDone || !jsonObject(ev.Data) {
 		return ev, false
 	}
 	var top map[string]json.RawMessage
 	if err := json.Unmarshal(ev.Data, &top); err != nil {
-		return ev, false
-	}
-	if _, numbered := top["sequence_number"]; !numbered {
 		return ev, false
 	}
 	next := c.nextSeq()

--- a/internal/streaming/restate_split_test.go
+++ b/internal/streaming/restate_split_test.go
@@ -53,11 +53,13 @@ func TestTransformedSSEStream_ResponsesRestatesDoneEventsAfterReplace(t *testing
 	}
 }
 
+// A stream nothing edits is relayed byte for byte, renumbering included: its
+// sequence numbers are already the ones the client must see.
 func TestTransformedSSEStream_ResponsesPassThroughStaysByteIdenticalWithoutEdits(t *testing.T) {
-	input := "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"sequence_number\":1,\"output_index\":0,\"item\":{\"id\":\"msg\",\"type\":\"message\",\"content\":[]}}\n\n" +
-		"event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":3,\"output_index\":0,\"content_index\":0,\"delta\":\"hi\"}\n\n" +
-		"event: response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"sequence_number\":5,\"output_index\":0,\"content_index\":0,\"text\":\"hi\"}\n\n" +
-		"event: response.completed\ndata: {\"type\":\"response.completed\",\"sequence_number\":8,\"response\":{\"id\":\"r1\",\"output\":[{\"id\":\"msg\",\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"hi\"}]}]}}\n\n"
+	input := "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"sequence_number\":0,\"output_index\":0,\"item\":{\"id\":\"msg\",\"type\":\"message\",\"content\":[]}}\n\n" +
+		"event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":1,\"output_index\":0,\"content_index\":0,\"delta\":\"hi\"}\n\n" +
+		"event: response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"sequence_number\":2,\"output_index\":0,\"content_index\":0,\"text\":\"hi\"}\n\n" +
+		"event: response.completed\ndata: {\"type\":\"response.completed\",\"sequence_number\":3,\"response\":{\"id\":\"r1\",\"output\":[{\"id\":\"msg\",\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"hi\"}]}]}}\n\n"
 	stream := NewTransformedSSEStream(io.NopCloser(strings.NewReader(input)), ResponsesCodec(), &funcTransformer{}, TransformOptions{})
 	got, err := io.ReadAll(stream)
 	if err != nil {

--- a/internal/streaming/sequence_number_test.go
+++ b/internal/streaming/sequence_number_test.go
@@ -45,7 +45,7 @@ func sequenceNumbers(t *testing.T, out []byte) ([]int, string) {
 			t.Fatalf("decode %q: %v", data, err)
 		}
 		if view.SequenceNumber == nil {
-			continue
+			t.Fatalf("event %q has no sequence_number:\n%s", view.Type, out)
 		}
 		numbers = append(numbers, *view.SequenceNumber)
 		last = view.Type
@@ -164,15 +164,26 @@ func TestTransformedSSEStream_ResponsesSequenceNumbersStayContiguous(t *testing.
 	}
 }
 
-// An upstream stream that is already gapped is renumbered too.
-func TestTransformedSSEStream_ResponsesRenumbersGappedUpstream(t *testing.T) {
-	input := strings.ReplaceAll(responsesSeqFixture, "\"sequence_number\":9", "\"sequence_number\":42")
-	stream := NewTransformedSSEStream(io.NopCloser(strings.NewReader(input)), ResponsesCodec(), &funcTransformer{}, TransformOptions{})
-	got, err := io.ReadAll(stream)
-	if err != nil {
-		t.Fatal(err)
+// An upstream stream that is already gapped, or that leaves an event
+// unnumbered, is numbered for the client all the same.
+func TestTransformedSSEStream_ResponsesRenumbersMalformedUpstream(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "gapped", input: strings.ReplaceAll(responsesSeqFixture, "\"sequence_number\":9", "\"sequence_number\":42")},
+		{name: "unnumbered event", input: strings.ReplaceAll(responsesSeqFixture, "\"sequence_number\":4,", "")},
 	}
-	assertContiguous(t, got)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stream := NewTransformedSSEStream(io.NopCloser(strings.NewReader(tc.input)), ResponsesCodec(), &funcTransformer{}, TransformOptions{})
+			got, err := io.ReadAll(stream)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertContiguous(t, got)
+		})
+	}
 }
 
 // Chat streams carry no sequence numbers, so a pass-through stays byte

--- a/internal/streaming/sequence_number_test.go
+++ b/internal/streaming/sequence_number_test.go
@@ -1,0 +1,189 @@
+package streaming
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-json"
+)
+
+// responsesSeqFixture is a well-formed Responses stream numbered 0..9.
+const responsesSeqFixture = "event: response.created\ndata: {\"type\":\"response.created\",\"sequence_number\":0,\"response\":{\"id\":\"r1\",\"model\":\"m\",\"created_at\":1}}\n\n" +
+	"event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"sequence_number\":1,\"output_index\":0,\"item\":{\"id\":\"msg\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[]}}\n\n" +
+	"event: response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"sequence_number\":2,\"item_id\":\"msg\",\"output_index\":0,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"text\":\"\"}}\n\n" +
+	"event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":3,\"item_id\":\"msg\",\"output_index\":0,\"content_index\":0,\"delta\":\"my key is \"}\n\n" +
+	"event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":4,\"item_id\":\"msg\",\"output_index\":0,\"content_index\":0,\"delta\":\"secret\"}\n\n" +
+	"event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":5,\"item_id\":\"msg\",\"output_index\":0,\"content_index\":0,\"delta\":\" ok\"}\n\n" +
+	"event: response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"sequence_number\":6,\"item_id\":\"msg\",\"output_index\":0,\"content_index\":0,\"text\":\"my key is secret ok\"}\n\n" +
+	"event: response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"sequence_number\":7,\"item_id\":\"msg\",\"output_index\":0,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"text\":\"my key is secret ok\",\"annotations\":[]}}\n\n" +
+	"event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"sequence_number\":8,\"output_index\":0,\"item\":{\"id\":\"msg\",\"type\":\"message\",\"status\":\"completed\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"my key is secret ok\",\"annotations\":[]}]}}\n\n" +
+	"event: response.completed\ndata: {\"type\":\"response.completed\",\"sequence_number\":9,\"response\":{\"id\":\"r1\",\"object\":\"response\",\"status\":\"completed\",\"model\":\"m\",\"output\":[{\"id\":\"msg\",\"type\":\"message\",\"status\":\"completed\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"my key is secret ok\",\"annotations\":[]}]}],\"usage\":{\"total_tokens\":3}}}\n\n" +
+	"data: [DONE]\n\n"
+
+// sequenceNumbers extracts the sequence_number of every event of an SSE
+// stream, in order, plus the type of the last numbered event.
+func sequenceNumbers(t *testing.T, out []byte) ([]int, string) {
+	t.Helper()
+	var numbers []int
+	last := ""
+	for block := range strings.SplitSeq(string(out), "\n\n") {
+		data := ""
+		for line := range strings.SplitSeq(block, "\n") {
+			if rest, ok := strings.CutPrefix(line, "data: "); ok {
+				data = rest
+			}
+		}
+		if data == "" || data == "[DONE]" {
+			continue
+		}
+		var view struct {
+			Type           string `json:"type"`
+			SequenceNumber *int   `json:"sequence_number"`
+		}
+		if err := json.Unmarshal([]byte(data), &view); err != nil {
+			t.Fatalf("decode %q: %v", data, err)
+		}
+		if view.SequenceNumber == nil {
+			continue
+		}
+		numbers = append(numbers, *view.SequenceNumber)
+		last = view.Type
+	}
+	return numbers, last
+}
+
+func assertContiguous(t *testing.T, out []byte) {
+	t.Helper()
+	numbers, _ := sequenceNumbers(t, out)
+	if len(numbers) == 0 {
+		t.Fatalf("no numbered events:\n%s", out)
+	}
+	for i, n := range numbers {
+		if n != i {
+			t.Fatalf("sequence numbers = %v, want 0..%d contiguous:\n%s", numbers, len(numbers)-1, out)
+		}
+	}
+}
+
+// A transform plugin may drop, merge or add events; the client must still see
+// sequence_number 0..N with no gaps, and the terminal event must carry the
+// last number.
+func TestTransformedSSEStream_ResponsesSequenceNumbersStayContiguous(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     TransformOptions
+		onEvent  func(ev *Event) (Decision, error)
+		lastType string
+	}{
+		{
+			name:     "pass through",
+			lastType: "response.completed",
+		},
+		{
+			name: "replace",
+			onEvent: func(ev *Event) (Decision, error) {
+				if ev.Kind == KindTextDelta {
+					return Decision{Action: ActionReplace, Text: strings.ReplaceAll(ev.Text, "secret", "[x]")}, nil
+				}
+				return Decision{Action: ActionPass}, nil
+			},
+			lastType: "response.completed",
+		},
+		{
+			name: "drop",
+			onEvent: func(ev *Event) (Decision, error) {
+				if ev.Kind == KindTextDelta {
+					return Decision{Action: ActionDrop}, nil
+				}
+				return Decision{Action: ActionPass}, nil
+			},
+			lastType: "response.completed",
+		},
+		{
+			name:     "coalesced deltas",
+			opts:     TransformOptions{MinChunkChars: 12, LookbehindChars: 4},
+			lastType: "response.completed",
+		},
+		{
+			name: "split into more deltas",
+			opts: TransformOptions{MinChunkChars: 12},
+			onEvent: func(ev *Event) (Decision, error) {
+				if ev.Kind == KindTextDelta {
+					return Decision{Action: ActionReplace, Text: strings.ReplaceAll(ev.Text, "secret", "s e c r e t")}, nil
+				}
+				return Decision{Action: ActionPass}, nil
+			},
+			lastType: "response.completed",
+		},
+		{
+			name: "terminate",
+			onEvent: func(ev *Event) (Decision, error) {
+				if ev.Kind == KindTextDelta && strings.Contains(ev.Text, "secret") {
+					return Decision{Action: ActionTerminate, Terminate: &Termination{ErrorCode: "blocked", ErrorMessage: "no"}}, nil
+				}
+				return Decision{Action: ActionPass}, nil
+			},
+			lastType: "response.failed",
+		},
+		{
+			name: "terminate on the first event",
+			onEvent: func(ev *Event) (Decision, error) {
+				return Decision{Action: ActionTerminate, Terminate: &Termination{ErrorCode: "blocked", ErrorMessage: "no"}}, nil
+			},
+			lastType: "response.failed",
+		},
+		{
+			name: "terminate with replacement text",
+			onEvent: func(ev *Event) (Decision, error) {
+				if ev.Kind == KindTextDelta && strings.Contains(ev.Text, "secret") {
+					return Decision{Action: ActionTerminate, Terminate: &Termination{Text: "redacted"}}, nil
+				}
+				return Decision{Action: ActionPass}, nil
+			},
+			lastType: "response.incomplete",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := &funcTransformer{onEvent: tc.onEvent}
+			stream := NewTransformedSSEStream(io.NopCloser(strings.NewReader(responsesSeqFixture)), ResponsesCodec(), tr, tc.opts)
+			got, err := io.ReadAll(stream)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertContiguous(t, got)
+			_, last := sequenceNumbers(t, got)
+			if last != tc.lastType {
+				t.Errorf("last numbered event = %s, want %s:\n%s", last, tc.lastType, got)
+			}
+			if !strings.HasSuffix(string(got), "data: [DONE]\n\n") {
+				t.Errorf("stream does not end with [DONE]:\n%s", got)
+			}
+		})
+	}
+}
+
+// An upstream stream that is already gapped is renumbered too.
+func TestTransformedSSEStream_ResponsesRenumbersGappedUpstream(t *testing.T) {
+	input := strings.ReplaceAll(responsesSeqFixture, "\"sequence_number\":9", "\"sequence_number\":42")
+	stream := NewTransformedSSEStream(io.NopCloser(strings.NewReader(input)), ResponsesCodec(), &funcTransformer{}, TransformOptions{})
+	got, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertContiguous(t, got)
+}
+
+// Chat streams carry no sequence numbers, so a pass-through stays byte
+// identical.
+func TestTransformedSSEStream_ChatPassThroughUnnumbered(t *testing.T) {
+	stream := NewTransformedSSEStream(io.NopCloser(strings.NewReader(chatFixture)), ChatCodec(), &funcTransformer{}, TransformOptions{})
+	got, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != chatFixture {
+		t.Fatalf("chat pass-through changed bytes:\n%s", got)
+	}
+}

--- a/internal/streaming/sse_codec.go
+++ b/internal/streaming/sse_codec.go
@@ -77,6 +77,21 @@ type Codec interface {
 	Restate(ev Event) (Event, bool)
 }
 
+// Renumberer is implemented by codecs whose dialect numbers the events of a
+// stream (the Responses API sequence_number, which must run 0..N without
+// gaps). A stream that may drop, merge, split or inject events renumbers the
+// ones it delivers so the client still sees a contiguous sequence.
+type Renumberer interface {
+	// BeginRenumber puts the codec in renumbering mode: from then on the
+	// codec assigns the outgoing numbers, both to the events handed to
+	// Renumber and to the ones Terminate renders.
+	BeginRenumber()
+	// Renumber returns a copy of ev numbered with the next outgoing number;
+	// ok reports that ev was changed, and is false when the event carries no
+	// number or already carries the right one.
+	Renumber(ev Event) (Event, bool)
+}
+
 // ErrNotTextEvent is returned by RewriteText for events without delta text.
 var ErrNotTextEvent = errors.New("streaming: event carries no rewritable text")
 

--- a/internal/streaming/transformed_sse_stream.go
+++ b/internal/streaming/transformed_sse_stream.go
@@ -138,7 +138,7 @@ func NewTransformedSSEStream(upstream io.ReadCloser, codec Codec, t Transformer,
 	if opts.MinChunkChars > MaxMinChunkChars {
 		opts.MinChunkChars = MaxMinChunkChars
 	}
-	return &transformedSSEStream{
+	s := &transformedSSEStream{
 		upstream: upstream,
 		codec:    codec,
 		t:        t,
@@ -147,11 +147,20 @@ func NewTransformedSSEStream(upstream io.ReadCloser, codec Codec, t Transformer,
 		readBuf:  make([]byte, transformReadBufferSize),
 		pending:  make(map[pendingKey]*pendingText),
 	}
+	// Dropped, merged, split and injected events would leave gaps in a
+	// numbered dialect, so the codec numbers what actually goes out.
+	if r, ok := codec.(Renumberer); ok {
+		r.BeginRenumber()
+		s.renumber = r
+	}
+	return s
 }
 
 type transformedSSEStream struct {
 	upstream io.ReadCloser
 	codec    Codec
+	// renumber is codec when its dialect numbers events, nil otherwise.
+	renumber Renumberer
 	t        Transformer
 	opts     TransformOptions
 	scanner  EventScanner
@@ -389,13 +398,12 @@ func (s *transformedSSEStream) apply(ev Event, raw []byte) {
 		rewritten, err := s.codec.RewriteText(ev, decision.Text)
 		if err != nil {
 			s.report(fmt.Errorf("streaming: replace on event %d (%s): %w", ev.Seq, ev.Kind, err))
-			s.pass(ev, raw)
+			s.deliver(ev, raw)
 			return
 		}
-		s.codec.Track(rewritten)
-		s.out = rewritten.appendEncoded(s.out)
+		s.deliver(rewritten, nil)
 	default:
-		s.pass(ev, raw)
+		s.deliver(ev, raw)
 	}
 }
 
@@ -418,7 +426,15 @@ func (s *transformedSSEStream) decide(ev *Event) (Decision, bool) {
 	return decision, true
 }
 
-func (s *transformedSSEStream) pass(ev Event, raw []byte) {
+// deliver numbers ev for the client when the dialect numbers events, records
+// it as emitted and writes it out. raw, when set, is relayed verbatim unless
+// renumbering rewrote the payload.
+func (s *transformedSSEStream) deliver(ev Event, raw []byte) {
+	if s.renumber != nil {
+		if renumbered, changed := s.renumber.Renumber(ev); changed {
+			ev, raw = renumbered, nil
+		}
+	}
 	s.codec.Track(ev)
 	if raw != nil {
 		s.write(raw)
@@ -592,9 +608,7 @@ func (s *transformedSSEStream) emitEnvelope(key pendingKey, p *pendingText) {
 		return
 	}
 	p.terminal = false
-	ev := s.resegment(key, p.closer, "")
-	s.codec.Track(ev)
-	s.out = ev.appendEncoded(s.out)
+	s.deliver(s.resegment(key, p.closer, ""), nil)
 }
 
 // inspect hands text to the transformer as one event of the window's kind
@@ -626,9 +640,7 @@ func (s *transformedSSEStream) emitText(key pendingKey, template Event, text str
 	if text == "" {
 		return
 	}
-	ev := s.resegment(key, template, text)
-	s.codec.Track(ev)
-	s.out = ev.appendEncoded(s.out)
+	s.deliver(s.resegment(key, template, text), nil)
 }
 
 func (s *transformedSSEStream) resegment(key pendingKey, template Event, text string) Event {


### PR DESCRIPTION
A stream-phase guardrail (string_replace, presidio) may drop, merge or split events, but `sequence_number` was stamped upstream of the transform, so a `/v1/responses` stream reached the client with gaps (`[0,1,2,3,4,24,54,...]`). Strict Responses SDK parsers can reject or mis-order such a stream.

The Responses codec now numbers the events that actually go out: every relayed, rewritten, re-segmented and injected event, plus the terminal events of a cut stream (`response.incomplete` / `response.failed`). An event whose number is already correct is left untouched, so an unedited pass-through stays byte identical, and chat (`/v1/chat/completions`, `/v1/messages`) carries no sequence numbers and is unaffected.

Tested: table-driven streaming tests for pass-through, replace, drop, coalesced deltas, split deltas, terminate (first event, mid-stream, with replacement text), an already-gapped upstream, and chat pass-through; `go test -race ./internal/streaming/...`, `make lint`. Live against a gateway with a string_replace and a presidio stream-phase guardrail: `/v1/responses` streams are 0..N contiguous on anthropic, gemini 2.5/3, openai, groq, xai, fireworks, deepseek (gapped before the change), with redaction still applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Responses API streaming events now maintain contiguous `sequence_number` values, even when events are dropped, merged, split, replaced, or streams terminate early.
  - Transformed streams consistently renumber events through the final completion, incomplete, or failed event.
  - Unmodified streams continue to pass through unchanged, while streams without sequence numbers retain their existing behavior.

- **Documentation**
  - Clarified sequence-number behavior for transformed Responses API streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->