### PR TITLE
fix(providers): drop unsupported xAI reasoning effort, parse Groq thinking, strip x_groq

### DIFF
--- a/docs/advanced/anthropic-messages-api.mdx
+++ b/docs/advanced/anthropic-messages-api.mdx
@@ -234,7 +234,8 @@ features that have no canonical equivalent are not preserved end to end:
   `medium`), sent as each provider's own field: `reasoning_effort` on OpenAI,
   Groq, Fireworks, and xAI. Models that reject the field (OpenAI `gpt-4*`, Groq
   models other than gpt-oss and qwen3, xAI's `-non-reasoning`, `grok-build`,
-  `grok-2` and `grok-3`) get the request without it instead of an error.
+  `grok-2` and `grok-3` except `grok-3-mini`) get the request without it
+  instead of an error.
   Reasoning comes back as `thinking` blocks whichever member the provider uses
   for it (`reasoning_content` or `reasoning`).
 - **`count_tokens`** is exact when the model's provider can count tokens itself:

--- a/docs/advanced/anthropic-messages-api.mdx
+++ b/docs/advanced/anthropic-messages-api.mdx
@@ -232,8 +232,11 @@ features that have no canonical equivalent are not preserved end to end:
 - **`thinking`** on a non-Anthropic model becomes a reasoning effort (budget
   under 10000 tokens: `low`, under 20000: `medium`, otherwise `high`; adaptive:
   `medium`), sent as each provider's own field: `reasoning_effort` on OpenAI,
-  Groq, and Fireworks. Models that cannot reason (OpenAI `gpt-4*`, Groq models
-  other than gpt-oss and qwen3) get the request without it instead of an error.
+  Groq, Fireworks, and xAI. Models that reject the field (OpenAI `gpt-4*`, Groq
+  models other than gpt-oss and qwen3, xAI's `-non-reasoning`, `grok-build`,
+  `grok-2` and `grok-3`) get the request without it instead of an error.
+  Reasoning comes back as `thinking` blocks whichever member the provider uses
+  for it (`reasoning_content` or `reasoning`).
 - **`count_tokens`** is exact when the model's provider can count tokens itself:
   Anthropic models are counted by Anthropic's own `count_tokens` endpoint. The
   forwarded request carries the resolved model (an alias is resolved first)

--- a/docs/advanced/audio-api.mdx
+++ b/docs/advanced/audio-api.mdx
@@ -28,6 +28,10 @@ doesn't support audio returns a clear error rather than mis-routing.
 | `POST /v1/audio/speech` | Text-to-speech. Accepts a JSON body and returns **binary audio** in the requested `response_format`. |
 | `POST /v1/audio/transcriptions` | Speech-to-text. Accepts a `multipart/form-data` upload and returns JSON or plain text per `response_format`. |
 
+JSON transcription and translation bodies are normalized to the OpenAI shape:
+Groq's vendor `x_groq` member is removed from `json` and `verbose_json`
+responses, so a client written against OpenAI sees the same fields everywhere.
+
 ## Text-to-speech
 
 <CodeGroup>

--- a/docs/providers/overview.mdx
+++ b/docs/providers/overview.mdx
@@ -81,6 +81,12 @@ support, not every individual model capability exposed by an upstream provider.
   provider injects trusted inference-objective and user-path fairness headers.
 - **Z.ai GLM Coding Plan** — set
   `ZAI_BASE_URL=https://api.z.ai/api/coding/paas/v4`.
+- **Groq reasoning and transcriptions** — on the gpt-oss and qwen3 families
+  GoModel defaults Groq's `reasoning_format` to `parsed`, so chain of thought
+  arrives in `reasoning` instead of as inline `<think>…</think>` text inside
+  the answer. Send `reasoning_format` yourself (`raw` or `hidden`) to override
+  it. JSON transcription and translation responses have Groq's vendor `x_groq`
+  member removed so they match the OpenAI shape.
 - **MiniMax regions and current text models** — the default global endpoint is
   `https://api.minimax.io/v1`; accounts on the China platform should set
   `MINIMAX_BASE_URL=https://api.minimaxi.com/v1`. The current text model IDs

--- a/docs/providers/xai.mdx
+++ b/docs/providers/xai.mdx
@@ -49,8 +49,12 @@ and passes through unchanged.
 | `xhigh` / `max` | `xhigh` on `grok-4.6` and later, and on the multi-agent Grok family (where it selects the agent count); `high` on older models, including the experimental `grok-4.20` family |
 | anything else | passed through for xAI to judge |
 
-Models without reasoning support reject the field upstream; omit `reasoning`
-for those.
+Models that do not take a configurable effort answer `400 ... does not support
+parameter reasoningEffort`. GoModel drops the field for them instead of
+forwarding it, so the same request works across the catalog: the
+`-non-reasoning` Grok variants, the `grok-build` coding family, `grok-2`, and
+`grok-3` (only `grok-3-mini` takes an effort). Unknown model IDs keep the
+field, so a new reasoning model works before GoModel learns about it.
 
 ## Prompt-cache affinity
 

--- a/internal/anthropicapi/response.go
+++ b/internal/anthropicapi/response.go
@@ -104,18 +104,22 @@ func thinkingBlocks(fields core.UnknownJSONFields) ([]ResponseContentBlock, bool
 	return extra.ThinkingBlocks, true
 }
 
-// reasoningContent extracts the reasoning_content surfaced by providers (e.g.
-// the anthropic provider) in a response message's extra fields.
+// reasoningContent extracts the reasoning text surfaced by providers in a
+// response message's extra fields: "reasoning_content" (the anthropic
+// provider, DeepSeek, Fireworks) or "reasoning" (Groq, OpenRouter), matching
+// the member precedence the streaming codec uses.
 func reasoningContent(fields core.UnknownJSONFields) string {
-	raw := fields.Lookup("reasoning_content")
-	if len(raw) == 0 {
-		return ""
+	for _, member := range []string{"reasoning_content", "reasoning"} {
+		raw := fields.Lookup(member)
+		if len(raw) == 0 {
+			continue
+		}
+		var text string
+		if err := json.Unmarshal(raw, &text); err == nil && text != "" {
+			return text
+		}
 	}
-	var text string
-	if err := json.Unmarshal(raw, &text); err != nil {
-		return ""
-	}
-	return text
+	return ""
 }
 
 // argumentsToRaw renders a tool-call arguments string as a JSON object value.

--- a/internal/anthropicapi/response_test.go
+++ b/internal/anthropicapi/response_test.go
@@ -249,6 +249,26 @@ func TestFromChatResponseThinkingBlocks(t *testing.T) {
 			want:   `[{"type":"thinking","thinking":"Let me think."},{"type":"text","text":"Hi"}]`,
 		},
 		{
+			name:   "the reasoning member alone still renders a thinking block",
+			fields: map[string]json.RawMessage{"reasoning": json.RawMessage(`"Let me think."`)},
+			want:   `[{"type":"thinking","thinking":"Let me think."},{"type":"text","text":"Hi"}]`,
+		},
+		{
+			name: "reasoning_content wins over reasoning",
+			fields: map[string]json.RawMessage{
+				"reasoning_content": json.RawMessage(`"Canonical."`),
+				"reasoning":         json.RawMessage(`"Vendor."`),
+			},
+			want: `[{"type":"thinking","thinking":"Canonical."},{"type":"text","text":"Hi"}]`,
+		},
+		{
+			name: "a non-string reasoning member is ignored",
+			fields: map[string]json.RawMessage{
+				"reasoning": json.RawMessage(`{"effort":"high"}`),
+			},
+			want: `[{"type":"text","text":"Hi"}]`,
+		},
+		{
 			name: "another vendor's replay state is not thinking",
 			fields: map[string]json.RawMessage{
 				core.ExtraContentField: json.RawMessage(`{"google":{"thought_signature":"sig"}}`),

--- a/internal/anthropicapi/stream.go
+++ b/internal/anthropicapi/stream.go
@@ -3,6 +3,7 @@ package anthropicapi
 import (
 	"bufio"
 	"bytes"
+	"cmp"
 	"io"
 
 	"github.com/goccy/go-json"
@@ -20,6 +21,7 @@ type chatChunk struct {
 		Delta struct {
 			Content          string              `json:"content"`
 			ReasoningContent string              `json:"reasoning_content"`
+			Reasoning        string              `json:"reasoning"`
 			StopSequence     string              `json:"stop_sequence"`
 			ToolCalls        []chatToolCallDelta `json:"tool_calls"`
 			// ExtraContent is provider replay state for the turn so far;
@@ -178,12 +180,14 @@ func (sc *streamConverter) handleChunk(chunk *chatChunk) {
 		sc.usage = *chunk.Usage
 	}
 	for _, choice := range chunk.Choices {
-		if choice.Delta.ReasoningContent != "" {
+		// "reasoning_content" wins over "reasoning" (Groq, OpenRouter), the
+		// same precedence the streaming codec applies.
+		if thinking := cmp.Or(choice.Delta.ReasoningContent, choice.Delta.Reasoning); thinking != "" {
 			sc.ensureBlock("thinking")
 			sc.emit("content_block_delta", map[string]any{
 				"type":  "content_block_delta",
 				"index": sc.curIndex,
-				"delta": map[string]any{"type": "thinking_delta", "thinking": choice.Delta.ReasoningContent},
+				"delta": map[string]any{"type": "thinking_delta", "thinking": thinking},
 			})
 		}
 		sc.handleThinkingReplay(choice.Delta.ExtraContent)

--- a/internal/anthropicapi/stream_test.go
+++ b/internal/anthropicapi/stream_test.go
@@ -375,3 +375,41 @@ func TestStreamConverterThinkingBlocksAroundText(t *testing.T) {
 		t.Fatalf("content events:\n%s\nwant:\n%s", strings.Join(got, "\n"), strings.Join(want, "\n"))
 	}
 }
+
+// Providers that name the member "reasoning" instead of "reasoning_content"
+// (Groq, OpenRouter) must still produce thinking deltas.
+func TestStreamConverterVendorReasoningMember(t *testing.T) {
+	tests := []struct {
+		name  string
+		delta string
+		want  string
+	}{
+		{name: "reasoning alone", delta: `{"reasoning":"Let me think."}`, want: "Let me think."},
+		{name: "reasoning_content wins", delta: `{"reasoning_content":"Canonical.","reasoning":"Vendor."}`, want: "Canonical."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chatStream := strings.Join([]string{
+				`data: {"id":"chatcmpl-1","model":"qwen/qwen3.6-27b","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+				`data: {"choices":[{"index":0,"delta":` + tt.delta + `,"finish_reason":null}]}`,
+				`data: {"choices":[{"index":0,"delta":{"content":"391"},"finish_reason":null}]}`,
+				`data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+				`data: [DONE]`,
+				"",
+			}, "\n\n")
+
+			events := drainConverter(t, chatStream)
+			var thinking []string
+			for _, event := range events {
+				delta, ok := event["delta"].(map[string]any)
+				if !ok || delta["type"] != "thinking_delta" {
+					continue
+				}
+				thinking = append(thinking, delta["thinking"].(string))
+			}
+			if strings.Join(thinking, "") != tt.want {
+				t.Errorf("thinking = %q, want %q", strings.Join(thinking, ""), tt.want)
+			}
+		})
+	}
+}

--- a/internal/providers/groq/audio.go
+++ b/internal/providers/groq/audio.go
@@ -1,0 +1,88 @@
+package groq
+
+import (
+	"bytes"
+	"context"
+	"strings"
+
+	"github.com/goccy/go-json"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+// vendorTranscriptionMember is the Groq-specific member (request id and seed)
+// added to JSON transcription and translation bodies. OpenAI clients do not
+// expect it, so the gateway returns the OpenAI shape without it.
+const vendorTranscriptionMember = "x_groq"
+
+// CreateTranscription transcribes audio through Groq's OpenAI-compatible
+// /audio/transcriptions API (whisper models), normalized to the OpenAI
+// response shape.
+func (p *Provider) CreateTranscription(ctx context.Context, req *core.AudioTranscriptionRequest) (*core.AudioResponse, error) {
+	return normalizeTranscription(p.compat.CreateTranscription(ctx, req))
+}
+
+// CreateTranslation translates audio through Groq's OpenAI-compatible
+// /audio/translations API (whisper models), normalized to the OpenAI
+// response shape.
+func (p *Provider) CreateTranslation(ctx context.Context, req *core.AudioTranscriptionRequest) (*core.AudioResponse, error) {
+	return normalizeTranscription(p.compat.CreateTranslation(ctx, req))
+}
+
+// normalizeTranscription drops the vendor member from JSON bodies (json and
+// verbose_json). Text, SRT and VTT bodies are returned untouched.
+func normalizeTranscription(resp *core.AudioResponse, err error) (*core.AudioResponse, error) {
+	if err != nil || resp == nil || !strings.Contains(resp.ContentType, "json") {
+		return resp, err
+	}
+	resp.Data = withoutJSONMember(resp.Data, vendorTranscriptionMember)
+	return resp, nil
+}
+
+// withoutJSONMember returns data with the named top-level object member
+// removed, preserving the order and raw representation of the others. Bodies
+// that are not a JSON object, or that do not carry the member, are returned
+// unchanged.
+func withoutJSONMember(data []byte, member string) []byte {
+	if !bytes.Contains(data, []byte(`"`+member+`"`)) {
+		return data
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	tok, err := dec.Token()
+	if delim, ok := tok.(json.Delim); err != nil || !ok || delim != '{' {
+		return data
+	}
+
+	var buf bytes.Buffer
+	buf.Grow(len(data))
+	buf.WriteByte('{')
+	for dec.More() {
+		keyToken, err := dec.Token()
+		if err != nil {
+			return data
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return data
+		}
+		var value json.RawMessage
+		if err := dec.Decode(&value); err != nil {
+			return data
+		}
+		if key == member {
+			continue
+		}
+		if buf.Len() > 1 {
+			buf.WriteByte(',')
+		}
+		encodedKey, err := json.Marshal(key)
+		if err != nil {
+			return data
+		}
+		buf.Write(encodedKey)
+		buf.WriteByte(':')
+		buf.Write(value)
+	}
+	buf.WriteByte('}')
+	return buf.Bytes()
+}

--- a/internal/providers/groq/audio.go
+++ b/internal/providers/groq/audio.go
@@ -3,6 +3,7 @@ package groq
 import (
 	"bytes"
 	"context"
+	"io"
 	"strings"
 
 	"github.com/goccy/go-json"
@@ -82,6 +83,14 @@ func withoutJSONMember(data []byte, member string) []byte {
 		buf.Write(encodedKey)
 		buf.WriteByte(':')
 		buf.Write(value)
+	}
+	// dec.More() also stops at a truncated body, so require the closing
+	// delimiter and nothing but whitespace after it before rewriting.
+	if tok, err := dec.Token(); err != nil || tok != json.Delim('}') {
+		return data
+	}
+	if _, err := dec.Token(); err != io.EOF {
+		return data
 	}
 	buf.WriteByte('}')
 	return buf.Bytes()

--- a/internal/providers/groq/audio_test.go
+++ b/internal/providers/groq/audio_test.go
@@ -31,6 +31,11 @@ func TestCreateTranscription_StripsVendorMember(t *testing.T) {
 			want:     `{"task":"transcribe","duration":2.9,"segments":[{"id":0,"text":"hello"}]}`,
 		},
 		{
+			name:     "default response_format is json",
+			upstream: `{"text":"hello","x_groq":{"id":"req_1"}}`,
+			want:     `{"text":"hello"}`,
+		},
+		{
 			name:     "json without the member is untouched",
 			format:   "json",
 			upstream: `{"text":"hello"}`,
@@ -82,6 +87,32 @@ func TestCreateTranscription_StripsVendorMember(t *testing.T) {
 	}
 }
 
+func TestCreateTranscription_PropagatesUpstreamError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"bad audio","type":"invalid_request_error"}}`))
+	}))
+	defer server.Close()
+	provider := NewWithHTTPClient("test-api-key", nil, llmclient.Hooks{})
+	provider.SetBaseURL(server.URL)
+
+	resp, err := provider.CreateTranscription(context.Background(), &core.AudioTranscriptionRequest{
+		Model:    "whisper-large-v3-turbo",
+		File:     []byte("audio"),
+		Filename: "a.mp3",
+	})
+	if err == nil {
+		t.Fatalf("CreateTranscription() error = nil, want the upstream error (resp = %+v)", resp)
+	}
+	if resp != nil {
+		t.Errorf("response = %+v, want nil", resp)
+	}
+	if !strings.Contains(err.Error(), "bad audio") {
+		t.Errorf("error = %v, want it to carry the upstream message", err)
+	}
+}
+
 func TestWithoutJSONMember_LeavesMalformedBodiesAlone(t *testing.T) {
 	tests := []struct {
 		name string
@@ -89,6 +120,8 @@ func TestWithoutJSONMember_LeavesMalformedBodiesAlone(t *testing.T) {
 	}{
 		{name: "not an object", body: `["x_groq"]`},
 		{name: "truncated object", body: `{"text":"hi","x_groq":`},
+		{name: "missing closing delimiter", body: `{"text":"hi","x_groq":{"id":"req_1"}`},
+		{name: "trailing data", body: `{"text":"hi","x_groq":{"id":"req_1"}} oops`},
 		{name: "empty", body: ``},
 	}
 	for _, tt := range tests {

--- a/internal/providers/groq/audio_test.go
+++ b/internal/providers/groq/audio_test.go
@@ -1,0 +1,101 @@
+package groq
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/llmclient"
+)
+
+func TestCreateTranscription_StripsVendorMember(t *testing.T) {
+	tests := []struct {
+		name     string
+		format   string
+		upstream string
+		want     string
+	}{
+		{
+			name:     "json",
+			format:   "json",
+			upstream: `{"text":"hello","x_groq":{"id":"req_1"}}`,
+			want:     `{"text":"hello"}`,
+		},
+		{
+			name:     "verbose_json keeps member order and nested values",
+			format:   "verbose_json",
+			upstream: `{"task":"transcribe","x_groq":{"id":"req_1","seed":7},"duration":2.9,"segments":[{"id":0,"text":"hello"}]}`,
+			want:     `{"task":"transcribe","duration":2.9,"segments":[{"id":0,"text":"hello"}]}`,
+		},
+		{
+			name:     "json without the member is untouched",
+			format:   "json",
+			upstream: `{"text":"hello"}`,
+			want:     `{"text":"hello"}`,
+		},
+		{
+			name:     "text body is proxied verbatim",
+			format:   "text",
+			upstream: "hello x_groq",
+			want:     "hello x_groq",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, endpoint := range []string{"/audio/transcriptions", "/audio/translations"} {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path != endpoint {
+						t.Errorf("path = %q, want %q", r.URL.Path, endpoint)
+					}
+					_, _ = w.Write([]byte(tt.upstream))
+				}))
+				provider := NewWithHTTPClient("test-api-key", nil, llmclient.Hooks{})
+				provider.SetBaseURL(server.URL)
+
+				req := &core.AudioTranscriptionRequest{
+					Model:          "whisper-large-v3-turbo",
+					File:           []byte("audio"),
+					Filename:       "a.mp3",
+					ResponseFormat: tt.format,
+				}
+				var (
+					resp *core.AudioResponse
+					err  error
+				)
+				if strings.HasSuffix(endpoint, "transcriptions") {
+					resp, err = provider.CreateTranscription(context.Background(), req)
+				} else {
+					resp, err = provider.CreateTranslation(context.Background(), req)
+				}
+				server.Close()
+				if err != nil {
+					t.Fatalf("%s error = %v", endpoint, err)
+				}
+				if got := string(resp.Data); got != tt.want {
+					t.Errorf("%s body = %s, want %s", endpoint, got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestWithoutJSONMember_LeavesMalformedBodiesAlone(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "not an object", body: `["x_groq"]`},
+		{name: "truncated object", body: `{"text":"hi","x_groq":`},
+		{name: "empty", body: ``},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := string(withoutJSONMember([]byte(tt.body), vendorTranscriptionMember)); got != tt.body {
+				t.Errorf("withoutJSONMember() = %q, want %q", got, tt.body)
+			}
+		})
+	}
+}

--- a/internal/providers/groq/groq.go
+++ b/internal/providers/groq/groq.go
@@ -114,15 +114,3 @@ func (p *Provider) Embeddings(ctx context.Context, req *core.EmbeddingRequest) (
 func (p *Provider) CreateSpeech(ctx context.Context, req *core.AudioSpeechRequest) (*core.AudioResponse, error) {
 	return p.compat.CreateSpeech(ctx, req)
 }
-
-// CreateTranscription transcribes audio through Groq's OpenAI-compatible
-// /audio/transcriptions API (whisper models).
-func (p *Provider) CreateTranscription(ctx context.Context, req *core.AudioTranscriptionRequest) (*core.AudioResponse, error) {
-	return p.compat.CreateTranscription(ctx, req)
-}
-
-// CreateTranslation translates audio through Groq's OpenAI-compatible
-// /audio/translations API (whisper models).
-func (p *Provider) CreateTranslation(ctx context.Context, req *core.AudioTranscriptionRequest) (*core.AudioResponse, error) {
-	return p.compat.CreateTranslation(ctx, req)
-}

--- a/internal/providers/groq/reasoning.go
+++ b/internal/providers/groq/reasoning.go
@@ -4,16 +4,30 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/goccy/go-json"
+
 	"github.com/enterpilot/gomodel/internal/core"
 	"github.com/enterpilot/gomodel/internal/providers"
 )
 
 // adaptChatRequest maps GoModel's nested reasoning shape (set by the Messages
 // API's thinking and by clients sending reasoning.effort) onto Groq's flat
-// reasoning_effort. Groq rejects "reasoning" outright and accepts
-// reasoning_effort only on reasoning models, with per-family values.
+// reasoning_effort, and asks Groq to parse chain of thought out of the answer.
+// Groq rejects "reasoning" outright and accepts reasoning_effort only on
+// reasoning models, with per-family values.
 func adaptChatRequest(req *core.ChatRequest) (*core.ChatRequest, error) {
-	if req == nil || req.Reasoning == nil {
+	if req == nil {
+		return req, nil
+	}
+	adapted, err := adaptReasoningEffort(req)
+	if err != nil {
+		return nil, err
+	}
+	return adaptReasoningFormat(adapted)
+}
+
+func adaptReasoningEffort(req *core.ChatRequest) (*core.ChatRequest, error) {
+	if req.Reasoning == nil {
 		return req, nil
 	}
 	effort := reasoningEffort(req.Model, req.Reasoning.Effort)
@@ -21,6 +35,37 @@ func adaptChatRequest(req *core.ChatRequest) (*core.ChatRequest, error) {
 		return providers.DropReasoning(req), nil
 	}
 	return providers.AdaptReasoningEffortRequest(req, effort)
+}
+
+// adaptReasoningFormat defaults Groq's reasoning_format to "parsed" on the
+// model families that accept it. Without it the Qwen models return their
+// chain of thought as inline <think>...</think> text inside the answer, which
+// an OpenAI-compatible client renders as the answer itself; "parsed" moves it
+// to the separate reasoning field the gateway normalizes into
+// reasoning_content (and into Messages API thinking blocks). A caller that
+// sets reasoning_format explicitly keeps its own value.
+func adaptReasoningFormat(req *core.ChatRequest) (*core.ChatRequest, error) {
+	if !supportsReasoningFormat(req.Model) || req.ExtraFields.Lookup("reasoning_format") != nil {
+		return req, nil
+	}
+	extra, err := core.MergeUnknownJSONFields(req.ExtraFields, map[string]json.RawMessage{
+		"reasoning_format": json.RawMessage(`"parsed"`),
+	})
+	if err != nil {
+		return nil, core.NewInvalidRequestError("failed to adapt reasoning request: "+err.Error(), err)
+	}
+	adapted := *req
+	adapted.ExtraFields = extra
+	return &adapted, nil
+}
+
+// supportsReasoningFormat reports whether the model accepts Groq's
+// reasoning_format parameter. Only the reasoning families do: the compound
+// systems and the plain chat models reject it with 400
+// "`reasoning_format` is not supported with this model".
+func supportsReasoningFormat(model string) bool {
+	m := strings.ToLower(model)
+	return strings.Contains(m, "gpt-oss") || strings.Contains(m, "qwen3")
 }
 
 // reasoningEffort returns the reasoning_effort value the model accepts, or ""

--- a/internal/providers/groq/reasoning_test.go
+++ b/internal/providers/groq/reasoning_test.go
@@ -66,3 +66,58 @@ func TestChatCompletion_MapsReasoningPerModelFamily(t *testing.T) {
 		})
 	}
 }
+
+func TestChatCompletion_DefaultsReasoningFormatPerModelFamily(t *testing.T) {
+	tests := []struct {
+		name       string
+		model      string
+		caller     string // caller-supplied reasoning_format, "" for none
+		wantFormat any    // nil means the field must be absent
+	}{
+		{name: "qwen3 gets parsed so <think> is not the answer", model: "qwen/qwen3.6-27b", wantFormat: "parsed"},
+		{name: "gpt-oss gets parsed", model: "openai/gpt-oss-20b", wantFormat: "parsed"},
+		{name: "caller choice wins", model: "qwen/qwen3.6-27b", caller: "raw", wantFormat: "raw"},
+		{name: "compound rejects the field", model: "groq/compound-mini"},
+		{name: "plain chat models are left alone", model: "llama-3.3-70b-versatile"},
+		{name: "whisper is left alone", model: "whisper-large-v3-turbo"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var raw map[string]any
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+					t.Errorf("decode request: %v", err)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"id":"c1","object":"chat.completion","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}]}`))
+			}))
+			defer server.Close()
+			provider := NewWithHTTPClient("test-api-key", nil, llmclient.Hooks{})
+			provider.SetBaseURL(server.URL)
+
+			req := &core.ChatRequest{Model: tt.model, Messages: []core.Message{{Role: "user", Content: "hi"}}}
+			if tt.caller != "" {
+				extra, err := core.MergeUnknownJSONFields(req.ExtraFields, map[string]json.RawMessage{
+					"reasoning_format": json.RawMessage(`"` + tt.caller + `"`),
+				})
+				if err != nil {
+					t.Fatalf("MergeUnknownJSONFields() error = %v", err)
+				}
+				req.ExtraFields = extra
+			}
+			if _, err := provider.ChatCompletion(context.Background(), req); err != nil {
+				t.Fatalf("ChatCompletion() error = %v", err)
+			}
+			got, ok := raw["reasoning_format"]
+			if tt.wantFormat == nil {
+				if ok {
+					t.Errorf("reasoning_format = %v, want absent", got)
+				}
+				return
+			}
+			if got != tt.wantFormat {
+				t.Errorf("reasoning_format = %v, want %v", got, tt.wantFormat)
+			}
+		})
+	}
+}

--- a/internal/providers/responses_converter.go
+++ b/internal/providers/responses_converter.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"bytes"
+	"cmp"
 	"io"
 	"slices"
 	"strings"
@@ -66,6 +67,7 @@ type openAIStreamChunk struct {
 		Delta struct {
 			Content          string                `json:"content"`
 			ReasoningContent string                `json:"reasoning_content"`
+			Reasoning        string                `json:"reasoning"`
 			ToolCalls        []openAIChunkToolCall `json:"tool_calls"`
 			ExtraContent     json.RawMessage       `json:"extra_content"`
 		} `json:"delta"`
@@ -281,8 +283,10 @@ func (sc *OpenAIResponsesStreamConverter) processChunk(data []byte) {
 	// closes the message item on the spot, and its output_item.done must
 	// already carry the state.
 	sc.setMessageExtraContent(choice.Delta.ExtraContent)
-	if choice.Delta.ReasoningContent != "" {
-		sc.appendReasoningDelta(choice.Delta.ReasoningContent)
+	// "reasoning_content" wins over the vendor "reasoning" member (Groq,
+	// OpenRouter), the same precedence the streaming codec applies.
+	if reasoning := cmp.Or(choice.Delta.ReasoningContent, choice.Delta.Reasoning); reasoning != "" {
+		sc.appendReasoningDelta(reasoning)
 	}
 	if choice.Delta.Content != "" {
 		sc.appendTextDelta(choice.Delta.Content)
@@ -342,7 +346,11 @@ func (sc *OpenAIResponsesStreamConverter) processChunkTolerant(data []byte) {
 				sc.setMessageExtraContent(raw)
 			}
 		}
-		if reasoning, ok := delta["reasoning_content"].(string); ok && reasoning != "" {
+		reasoning, _ := delta["reasoning_content"].(string)
+		if reasoning == "" {
+			reasoning, _ = delta["reasoning"].(string)
+		}
+		if reasoning != "" {
 			sc.appendReasoningDelta(reasoning)
 		}
 		if content, ok := delta["content"].(string); ok && content != "" {

--- a/internal/providers/responses_output.go
+++ b/internal/providers/responses_output.go
@@ -197,16 +197,22 @@ func toolCallExtraContent(fields core.UnknownJSONFields) core.UnknownJSONFields 
 	return core.UnknownJSONFieldsFromMap(map[string]json.RawMessage{core.ExtraContentField: raw})
 }
 
+// responseMessageReasoningContent returns the reasoning text a provider
+// surfaced on the message: "reasoning_content" (DeepSeek, Fireworks, the
+// anthropic provider) or the vendor "reasoning" member (Groq, OpenRouter),
+// the same precedence the streaming codec applies.
 func responseMessageReasoningContent(msg core.ResponseMessage) string {
-	raw := msg.ExtraFields.Lookup("reasoning_content")
-	if len(raw) == 0 {
-		return ""
+	for _, member := range []string{"reasoning_content", "reasoning"} {
+		raw := msg.ExtraFields.Lookup(member)
+		if len(raw) == 0 {
+			continue
+		}
+		var content string
+		if err := json.Unmarshal(raw, &content); err == nil && content != "" {
+			return content
+		}
 	}
-	var content string
-	if err := json.Unmarshal(raw, &content); err != nil {
-		return ""
-	}
-	return content
+	return ""
 }
 
 // ConvertChatResponseToResponses converts a ChatResponse to a ResponsesResponse.

--- a/internal/providers/responses_reasoning_member_test.go
+++ b/internal/providers/responses_reasoning_member_test.go
@@ -1,0 +1,94 @@
+package providers
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-json"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+// Providers that name the member "reasoning" instead of "reasoning_content"
+// (Groq's parsed reasoning_format, OpenRouter) must still produce a reasoning
+// item on the Responses API, with reasoning_content winning when both arrive.
+func TestResponsesReasoningFromVendorReasoningMember(t *testing.T) {
+	tests := []struct {
+		name  string
+		delta string
+		want  string
+	}{
+		{name: "reasoning alone", delta: `{"reasoning":"Think."}`, want: "Think."},
+		{name: "reasoning_content wins", delta: `{"reasoning_content":"Canonical.","reasoning":"Vendor."}`, want: "Canonical."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockStream := `data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"qwen/qwen3.6-27b","choices":[{"index":0,"delta":` + tt.delta + `,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"qwen/qwen3.6-27b","choices":[{"index":0,"delta":{"content":"391"},"finish_reason":"stop"}]}
+
+data: [DONE]
+`
+			converter := NewOpenAIResponsesStreamConverter(io.NopCloser(strings.NewReader(mockStream)), "qwen/qwen3.6-27b", "groq")
+			raw, err := io.ReadAll(converter)
+			if err != nil {
+				t.Fatalf("read converter: %v", err)
+			}
+			var got strings.Builder
+			for _, event := range parseTestSSEEvents(t, string(raw)) {
+				if event.Done || !strings.HasSuffix(event.Name, "reasoning_text.delta") {
+					continue
+				}
+				delta, _ := event.Payload["delta"].(string)
+				got.WriteString(delta)
+			}
+			if got.String() != tt.want {
+				t.Errorf("reasoning_text deltas = %q, want %q", got.String(), tt.want)
+			}
+		})
+	}
+}
+
+func TestConvertChatResponseToResponsesReadsVendorReasoningMember(t *testing.T) {
+	tests := []struct {
+		name   string
+		fields map[string]json.RawMessage
+		want   string
+	}{
+		{name: "reasoning alone", fields: map[string]json.RawMessage{"reasoning": json.RawMessage(`"Think."`)}, want: "Think."},
+		{
+			name: "reasoning_content wins",
+			fields: map[string]json.RawMessage{
+				"reasoning_content": json.RawMessage(`"Canonical."`),
+				"reasoning":         json.RawMessage(`"Vendor."`),
+			},
+			want: "Canonical.",
+		},
+		{name: "a non-string member is ignored", fields: map[string]json.RawMessage{"reasoning": json.RawMessage(`{"effort":"high"}`)}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &core.ChatResponse{Choices: []core.Choice{{
+				Message: core.ResponseMessage{
+					Role:        "assistant",
+					Content:     "391",
+					ExtraFields: core.UnknownJSONFieldsFromMap(tt.fields),
+				},
+				FinishReason: "stop",
+			}}}
+			var got string
+			for _, item := range ConvertChatResponseToResponses(resp).Output {
+				if item.Type != "reasoning" {
+					continue
+				}
+				for _, part := range item.Content {
+					got += part.Text
+				}
+			}
+			if got != tt.want {
+				t.Errorf("reasoning text = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/providers/xai/xai.go
+++ b/internal/providers/xai/xai.go
@@ -84,11 +84,42 @@ func compatibleConfig(baseURL string) openai.CompatibleProviderConfig {
 // reasoning_effort as a top-level string (e.g. grok-4.5: low/medium/high,
 // default high), not "reasoning": {"effort": "..."}; the nested shape is
 // native only to xAI's Responses API, which passes through untouched.
+// Models that do not take a configurable effort reject the parameter
+// outright, so it is dropped for them instead of forwarded.
 func adaptChatRequest(req *core.ChatRequest) (*core.ChatRequest, error) {
-	if req == nil || req.Reasoning == nil || strings.TrimSpace(req.Reasoning.Effort) == "" {
+	if req == nil || req.Reasoning == nil {
 		return req, nil
 	}
-	return providers.AdaptReasoningEffortRequest(req, normalizeReasoningEffort(req.Model, req.Reasoning.Effort))
+	effort := strings.TrimSpace(req.Reasoning.Effort)
+	if effort == "" || rejectsReasoningEffort(req.Model) {
+		return providers.DropReasoning(req), nil
+	}
+	return providers.AdaptReasoningEffortRequest(req, normalizeReasoningEffort(req.Model, effort))
+}
+
+// rejectsReasoningEffort reports whether an xAI chat model answers 400
+// "Model ... does not support parameter reasoningEffort": the explicit
+// "-non-reasoning" Grok variants, the grok-build coding family (it thinks,
+// but the effort is fixed), grok-2, and grok-3 (only grok-3-mini takes an
+// effort). Unknown ids are not included, so a new reasoning model keeps the
+// parameter before this list learns about it.
+func rejectsReasoningEffort(model string) bool {
+	m := strings.ToLower(strings.TrimSpace(model))
+	if i := strings.LastIndex(m, "/"); i >= 0 {
+		m = m[i+1:]
+	}
+	switch {
+	case strings.Contains(m, "non-reasoning"):
+		return true
+	case strings.HasPrefix(m, "grok-build"):
+		return true
+	case strings.HasPrefix(m, "grok-2"):
+		return true
+	case strings.HasPrefix(m, "grok-3"):
+		return !strings.Contains(m, "mini")
+	default:
+		return false
+	}
 }
 
 // normalizeReasoningEffort downgrades GoModel effort levels xAI does not

--- a/internal/providers/xai/xai_test.go
+++ b/internal/providers/xai/xai_test.go
@@ -1023,3 +1023,92 @@ func TestNormalizeReasoningEffort(t *testing.T) {
 		}
 	}
 }
+
+func TestChatCompletion_DropsReasoningEffortForModelsThatRejectIt(t *testing.T) {
+	tests := []struct {
+		name       string
+		model      string
+		effort     string
+		wantEffort string // "" means the field must be absent
+	}{
+		{name: "non-reasoning variant", model: "grok-4.20-0309-non-reasoning", effort: "medium"},
+		{name: "reasoning variant keeps it", model: "grok-4.20-0309-reasoning", effort: "medium", wantEffort: "medium"},
+		{name: "grok-build has a fixed effort", model: "grok-build-0.1", effort: "high"},
+		{name: "grok-3 rejects it", model: "grok-3", effort: "high"},
+		{name: "grok-3-mini takes it", model: "grok-3-mini", effort: "high", wantEffort: "high"},
+		{name: "grok-2 rejects it", model: "grok-2-1212", effort: "low"},
+		{name: "namespaced id", model: "xai/grok-4.20-0309-non-reasoning", effort: "low"},
+		{name: "unknown models keep it", model: "grok-99-new", effort: "low", wantEffort: "low"},
+		{name: "grok-4.5 keeps it", model: "grok-4.5", effort: "low", wantEffort: "low"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotBody map[string]any
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+					http.Error(w, "decode error", http.StatusBadRequest)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"id":"c1","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}]}`))
+			}))
+			defer server.Close()
+
+			provider := NewWithHTTPClient("test-api-key", nil, llmclient.Hooks{})
+			provider.SetBaseURL(server.URL)
+
+			_, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{
+				Model:     tt.model,
+				Messages:  []core.Message{{Role: "user", Content: "hi"}},
+				Reasoning: &core.Reasoning{Effort: tt.effort},
+			})
+			if err != nil {
+				t.Fatalf("ChatCompletion() error = %v", err)
+			}
+			if _, ok := gotBody["reasoning"]; ok {
+				t.Errorf("request body includes nested reasoning: %#v", gotBody["reasoning"])
+			}
+			got, ok := gotBody["reasoning_effort"]
+			if tt.wantEffort == "" {
+				if ok {
+					t.Errorf("reasoning_effort = %#v, want absent", got)
+				}
+				return
+			}
+			if got != tt.wantEffort {
+				t.Errorf("reasoning_effort = %#v, want %q", got, tt.wantEffort)
+			}
+		})
+	}
+}
+
+func TestChatCompletion_DropsEmptyReasoningObject(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			http.Error(w, "decode error", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"c1","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	provider := NewWithHTTPClient("test-api-key", nil, llmclient.Hooks{})
+	provider.SetBaseURL(server.URL)
+
+	_, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{
+		Model:     "grok-4.5",
+		Messages:  []core.Message{{Role: "user", Content: "hi"}},
+		Reasoning: &core.Reasoning{},
+	})
+	if err != nil {
+		t.Fatalf("ChatCompletion() error = %v", err)
+	}
+	if _, ok := gotBody["reasoning"]; ok {
+		t.Errorf("reasoning should be absent, got %#v", gotBody["reasoning"])
+	}
+	if _, ok := gotBody["reasoning_effort"]; ok {
+		t.Errorf("reasoning_effort should be absent, got %#v", gotBody["reasoning_effort"])
+	}
+}

--- a/internal/providers/xai/xai_test.go
+++ b/internal/providers/xai/xai_test.go
@@ -1083,32 +1083,36 @@ func TestChatCompletion_DropsReasoningEffortForModelsThatRejectIt(t *testing.T) 
 }
 
 func TestChatCompletion_DropsEmptyReasoningObject(t *testing.T) {
-	var gotBody map[string]any
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
-			http.Error(w, "decode error", http.StatusBadRequest)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"id":"c1","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}]}`))
-	}))
-	defer server.Close()
+	for _, effort := range []string{"", " \t "} {
+		t.Run("effort="+effort, func(t *testing.T) {
+			var gotBody map[string]any
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+					http.Error(w, "decode error", http.StatusBadRequest)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"id":"c1","model":"m","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}]}`))
+			}))
+			defer server.Close()
 
-	provider := NewWithHTTPClient("test-api-key", nil, llmclient.Hooks{})
-	provider.SetBaseURL(server.URL)
+			provider := NewWithHTTPClient("test-api-key", nil, llmclient.Hooks{})
+			provider.SetBaseURL(server.URL)
 
-	_, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{
-		Model:     "grok-4.5",
-		Messages:  []core.Message{{Role: "user", Content: "hi"}},
-		Reasoning: &core.Reasoning{},
-	})
-	if err != nil {
-		t.Fatalf("ChatCompletion() error = %v", err)
-	}
-	if _, ok := gotBody["reasoning"]; ok {
-		t.Errorf("reasoning should be absent, got %#v", gotBody["reasoning"])
-	}
-	if _, ok := gotBody["reasoning_effort"]; ok {
-		t.Errorf("reasoning_effort should be absent, got %#v", gotBody["reasoning_effort"])
+			_, err := provider.ChatCompletion(context.Background(), &core.ChatRequest{
+				Model:     "grok-4.5",
+				Messages:  []core.Message{{Role: "user", Content: "hi"}},
+				Reasoning: &core.Reasoning{Effort: effort},
+			})
+			if err != nil {
+				t.Fatalf("ChatCompletion() error = %v", err)
+			}
+			if _, ok := gotBody["reasoning"]; ok {
+				t.Errorf("reasoning should be absent, got %#v", gotBody["reasoning"])
+			}
+			if _, ok := gotBody["reasoning_effort"]; ok {
+				t.Errorf("reasoning_effort should be absent, got %#v", gotBody["reasoning_effort"])
+			}
+		})
 	}
 }


### PR DESCRIPTION
Three provider-level fixes found in pre-release testing.

**xAI: `reasoning_effort` on models that reject it.** `/v1/messages` with `thinking`
(or `reasoning.effort` on chat) against `grok-4.20-0309-non-reasoning` or
`grok-build-0.1` returned `400 ... does not support parameter reasoningEffort`.
GoModel now drops the field for the `-non-reasoning` variants, `grok-build`,
`grok-2` and `grok-3` (`grok-3-mini` keeps it), the same way OpenAI, Groq and
Fireworks already do. Unknown model IDs keep the field. An empty `reasoning`
object is no longer forwarded either.

**Groq: chain of thought leaked into the answer.** `qwen/qwen3.6-27b` returned its
thinking as inline `<think>...</think>` text in `message.content`, so an
OpenAI-compatible client rendered the thinking as the answer. GoModel now defaults
Groq's own `reasoning_format` to `parsed` on the families that accept it (gpt-oss,
qwen3), so the thinking arrives in `reasoning` and the content is just the answer.
A caller-supplied `reasoning_format` wins. Groq's `reasoning` member is now also
mapped to Messages API `thinking` blocks (`reasoning_content` still wins) — that
was missing for gpt-oss too.

**Groq: vendor member on transcriptions.** `/v1/audio/transcriptions` and
`/v1/audio/translations` passed Groq's `x_groq` object through in `json` and
`verbose_json` bodies; it is now removed, preserving the other members' order and
raw representation. `text`/`srt`/`vtt` bodies are untouched.

Tested: table-driven unit tests per change (`go test -race` on the touched
packages), `make lint` clean, plus live calls against Groq and xAI through the
gateway for all three findings, on `/v1/chat/completions`, `/v1/messages`
(stream and non-stream), `/v1/responses`, and `/v1/audio/transcriptions`
(json, verbose_json, text) and `/v1/audio/translations`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for reasoning responses supplied through either `reasoning_content` or `reasoning`.
  - Added automatic parsed reasoning for supported Groq model families, while preserving caller overrides.

- **Bug Fixes**
  - Prevented unsupported reasoning settings from causing errors with affected xAI models.
  - Normalized Groq audio transcription and translation responses to the OpenAI format.
  - Removed Groq-specific metadata from JSON audio responses.

- **Documentation**
  - Updated provider and API documentation with reasoning, transcription, translation, and model compatibility details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->