### PR TITLE
fix(responses): report truncation and normalize the translated output shape

### DIFF
--- a/cmd/gomodel/docs/docs.go
+++ b/cmd/gomodel/docs/docs.go
@@ -8891,6 +8891,60 @@ const docTemplate = `{
                 }
             }
         },
+        "auditlog.GuardrailOutcomeSnapshot": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "description": "Action is the decision (allow, warn, block, respond) or \"failure\" when\nthe instance errored; FailMode then says whether the chain carried on\n(\"open\") or the request failed (\"closed\").",
+                    "type": "string"
+                },
+                "code": {
+                    "type": "string"
+                },
+                "detail": {},
+                "dropped_events": {
+                    "type": "integer"
+                },
+                "duration_ns": {
+                    "type": "integer"
+                },
+                "edited": {
+                    "description": "Edited reports that the instance changed the request (prompt phase)\nor the response (response and stream phases); Target names which.",
+                    "type": "boolean"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "fail_mode": {
+                    "type": "string"
+                },
+                "instance": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "phase": {
+                    "type": "string"
+                },
+                "replaced_events": {
+                    "description": "ReplacedEvents and DroppedEvents count the stream events an in-flight\nstream instance rewrote or withheld.",
+                    "type": "integer"
+                },
+                "seq": {
+                    "type": "integer"
+                },
+                "step": {
+                    "type": "integer"
+                },
+                "target": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
         "auditlog.LogData": {
             "type": "object",
             "properties": {
@@ -8926,6 +8980,13 @@ const docTemplate = `{
                             "$ref": "#/definitions/auditlog.FailoverSnapshot"
                         }
                     ]
+                },
+                "guardrails": {
+                    "description": "Guardrails records the outcome of every guardrail (plugin instance)\nthat ran for the request, in execution order across the prompt,\nresponse and stream phases: what each decided, whether it edited the\nrequest or response, and how it failed. It is the decision trail;\nRequestRevisions is the body trail. A configured step without an\noutcome did not run (an earlier block, a cache hit).",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/auditlog.GuardrailOutcomeSnapshot"
+                    }
                 },
                 "labels": {
                     "description": "Labels are request labels extracted from configured tagging headers.",
@@ -10725,6 +10786,14 @@ const docTemplate = `{
                 }
             }
         },
+        "core.ResponsesIncompleteDetails": {
+            "type": "object",
+            "properties": {
+                "reason": {
+                    "type": "string"
+                }
+            }
+        },
         "core.ResponsesOutputItem": {
             "type": "object",
             "properties": {
@@ -10873,6 +10942,14 @@ const docTemplate = `{
                 "id": {
                     "type": "string"
                 },
+                "incomplete_details": {
+                    "description": "IncompleteDetails explains a status of \"incomplete\": the model hit\nmax_output_tokens, was stopped by a content filter, or the upstream\nstream was interrupted.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/core.ResponsesIncompleteDetails"
+                        }
+                    ]
+                },
                 "model": {
                     "type": "string"
                 },
@@ -10894,7 +10971,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "description": "\"completed\", \"failed\", \"in_progress\"",
+                    "description": "\"completed\", \"incomplete\", \"failed\", \"in_progress\"",
                     "type": "string"
                 },
                 "usage": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -14549,6 +14549,14 @@
           }
         }
       },
+      "core.ResponsesIncompleteDetails": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string"
+          }
+        }
+      },
       "core.ResponsesOutputItem": {
         "type": "object",
         "properties": {
@@ -14708,6 +14716,14 @@
           "id": {
             "type": "string"
           },
+          "incomplete_details": {
+            "description": "IncompleteDetails explains a status of \"incomplete\": the model hit\nmax_output_tokens, was stopped by a content filter, or the upstream\nstream was interrupted.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/core.ResponsesIncompleteDetails"
+              }
+            ]
+          },
           "model": {
             "type": "string"
           },
@@ -14729,7 +14745,7 @@
             "type": "string"
           },
           "status": {
-            "description": "\"completed\", \"failed\", \"in_progress\"",
+            "description": "\"completed\", \"incomplete\", \"failed\", \"in_progress\"",
             "type": "string"
           },
           "usage": {

--- a/internal/core/responses.go
+++ b/internal/core/responses.go
@@ -189,10 +189,14 @@ type ResponsesResponse struct {
 	CreatedAt int64                 `json:"created_at"`
 	Model     string                `json:"model"`
 	Provider  string                `json:"provider"`
-	Status    string                `json:"status"` // "completed", "failed", "in_progress"
+	Status    string                `json:"status"` // "completed", "incomplete", "failed", "in_progress"
 	Output    []ResponsesOutputItem `json:"output"`
 	Usage     *ResponsesUsage       `json:"usage,omitempty"`
 	Error     *ResponsesError       `json:"error,omitempty"`
+	// IncompleteDetails explains a status of "incomplete": the model hit
+	// max_output_tokens, was stopped by a content filter, or the upstream
+	// stream was interrupted.
+	IncompleteDetails *ResponsesIncompleteDetails `json:"incomplete_details,omitempty"`
 	// PreviousResponseID names the response this one was chained from, as
 	// OpenAI echoes it; stored snapshots follow it to rebuild the history.
 	PreviousResponseID string `json:"previous_response_id,omitempty"`
@@ -238,6 +242,13 @@ type ResponsesUsage struct {
 	PromptTokensDetails     *PromptTokensDetails     `json:"prompt_tokens_details,omitempty"`
 	CompletionTokensDetails *CompletionTokensDetails `json:"completion_tokens_details,omitempty"`
 	RawUsage                map[string]any           `json:"raw_usage,omitempty"`
+}
+
+// ResponsesIncompleteDetails carries the reason a response stopped early,
+// following the OpenAI Responses contract ("max_output_tokens",
+// "content_filter", or "interrupted" for a cut upstream stream).
+type ResponsesIncompleteDetails struct {
+	Reason string `json:"reason"`
 }
 
 // ResponsesError represents an error in the response.

--- a/internal/core/responses_incomplete_test.go
+++ b/internal/core/responses_incomplete_test.go
@@ -1,0 +1,54 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/goccy/go-json"
+)
+
+// A native Responses provider reports truncation as status "incomplete" with
+// incomplete_details; both must survive the round trip to the client.
+func TestResponsesResponse_IncompleteDetailsRoundTrip(t *testing.T) {
+	var resp ResponsesResponse
+	if err := json.Unmarshal([]byte(`{
+		"id": "resp_1",
+		"object": "response",
+		"status": "incomplete",
+		"model": "gpt-5-mini",
+		"output": [],
+		"incomplete_details": {"reason": "max_output_tokens"}
+	}`), &resp); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if resp.IncompleteDetails == nil || resp.IncompleteDetails.Reason != "max_output_tokens" {
+		t.Fatalf("IncompleteDetails = %+v, want reason max_output_tokens", resp.IncompleteDetails)
+	}
+
+	encoded, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(encoded, &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	details, ok := payload["incomplete_details"].(map[string]any)
+	if !ok || details["reason"] != "max_output_tokens" {
+		t.Fatalf("incomplete_details = %#v, want reason max_output_tokens", payload["incomplete_details"])
+	}
+}
+
+// A completed response must not carry an empty incomplete_details object.
+func TestResponsesResponse_CompletedOmitsIncompleteDetails(t *testing.T) {
+	encoded, err := json.Marshal(ResponsesResponse{ID: "resp_1", Object: "response", Status: "completed"})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(encoded, &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if _, exists := payload["incomplete_details"]; exists {
+		t.Fatalf("did not expect incomplete_details on a completed response: %s", encoded)
+	}
+}

--- a/internal/core/responses_json.go
+++ b/internal/core/responses_json.go
@@ -344,11 +344,12 @@ func (i ResponsesOutputItem) MarshalJSON() ([]byte, error) {
 	return marshalWithUnknownJSONFields(alias(i), i.ExtraFields)
 }
 
-// MarshalJSON keeps `annotations` on the wire for output_text parts. OpenAI
-// always returns `annotations: []` there and OpenAI SDK consumers (for
-// example LangChain's Responses converter) index into it without a nil
-// check, so an omitted field breaks them. Input parts keep the field only
-// when a caller supplied it.
+// MarshalJSON keeps `text` and `annotations` on the wire for output_text
+// parts. Both are required by the OpenAI schema: OpenAI always returns
+// `annotations: []` there and OpenAI SDK consumers (for example LangChain's
+// Responses converter) index into it without a nil check, and an empty
+// assistant answer must still serialize `text: ""` rather than drop the
+// member. Input parts keep both fields only when a caller supplied them.
 func (c ResponsesContentItem) MarshalJSON() ([]byte, error) {
 	type alias ResponsesContentItem
 	if c.Type != "output_text" {
@@ -359,8 +360,9 @@ func (c ResponsesContentItem) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(struct {
 		alias
+		Text        string            `json:"text"`
 		Annotations []json.RawMessage `json:"annotations"`
-	}{alias(c), c.Annotations})
+	}{alias(c), c.Text, c.Annotations})
 }
 
 // ResponsesBlocksFromContentParts converts typed parts into generic content

--- a/internal/core/usage_json.go
+++ b/internal/core/usage_json.go
@@ -143,27 +143,22 @@ func (u *ResponsesUsage) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON emits the OpenAI Responses usage shape and nothing else. Unlike
+// Chat Completions, which passes provider usage extras through at the top
+// level, the Responses API returns a closed object, so provider-specific
+// members (thoughts_token_count, completion_reasoning_tokens,
+// cache_creation_input_tokens, …) stay in RawUsage for usage records and cost
+// calculation instead of leaking into the client response. Everything with an
+// OpenAI-shaped home is kept: reasoning tokens under output_tokens_details,
+// cached tokens under input_tokens_details.
 func (u ResponsesUsage) MarshalJSON() ([]byte, error) {
-	return marshalTokenUsageJSON(
-		u.RawUsage,
-		responsesUsageJSONPayload{
-			InputTokens:             u.InputTokens,
-			OutputTokens:            u.OutputTokens,
-			TotalTokens:             u.TotalTokens,
-			PromptTokensDetails:     u.PromptTokensDetails,
-			CompletionTokensDetails: u.CompletionTokensDetails,
-		},
-		func(payload map[string]any) {
-			payload["input_tokens"] = u.InputTokens
-			payload["output_tokens"] = u.OutputTokens
-			payload["total_tokens"] = u.TotalTokens
-		},
-		u.PromptTokensDetails,
-		"input_tokens_details",
-		u.CompletionTokensDetails,
-		"output_tokens_details",
-		responsesUsageKnownFields,
-	)
+	return json.Marshal(responsesUsageJSONPayload{
+		InputTokens:             u.InputTokens,
+		OutputTokens:            u.OutputTokens,
+		TotalTokens:             u.TotalTokens,
+		PromptTokensDetails:     u.PromptTokensDetails,
+		CompletionTokensDetails: u.CompletionTokensDetails,
+	})
 }
 
 type usageJSONPayload struct {

--- a/internal/core/usage_json_test.go
+++ b/internal/core/usage_json_test.go
@@ -148,7 +148,12 @@ func TestResponsesUsageMarshalJSON_UsesResponsesDetailFieldNames(t *testing.T) {
 	if outputDetails["reasoning_tokens"] != float64(7) {
 		t.Fatalf("output_tokens_details.reasoning_tokens = %#v, want 7", outputDetails["reasoning_tokens"])
 	}
-	if payload["cache_read_input_tokens"] != float64(98) {
-		t.Fatalf("cache_read_input_tokens = %#v, want 98", payload["cache_read_input_tokens"])
+	// The Responses usage object is closed: provider-named members stay in
+	// RawUsage for usage records and cost calculation.
+	if _, exists := payload["cache_read_input_tokens"]; exists {
+		t.Fatalf("did not expect cache_read_input_tokens in marshaled responses payload: %s", string(body))
+	}
+	if _, exists := payload["raw_usage"]; exists {
+		t.Fatalf("did not expect raw_usage in marshaled responses payload: %s", string(body))
 	}
 }

--- a/internal/providers/anthropic/responses.go
+++ b/internal/providers/anthropic/responses.go
@@ -41,7 +41,7 @@ func convertAnthropicResponseToResponses(resp *anthropicResponse, model string) 
 	msg.ExtraFields = withThinkingReplay(msg.ExtraFields, resp.Content)
 	output := providers.BuildResponsesOutputItems(msg)
 
-	return &core.ResponsesResponse{
+	converted := &core.ResponsesResponse{
 		ID:        resp.ID,
 		Object:    "response",
 		CreatedAt: time.Now().Unix(),
@@ -50,14 +50,25 @@ func convertAnthropicResponseToResponses(resp *anthropicResponse, model string) 
 		Output:    output,
 		Usage:     buildAnthropicResponsesUsage(resp.Usage),
 	}
+	providers.ApplyResponsesFinishReason(converted, normalizeAnthropicStopReason(resp.StopReason))
+	return converted
 }
 
-// buildAnthropicResponsesUsage creates a ResponsesUsage from anthropicUsage, including RawUsage.
+// buildAnthropicResponsesUsage creates a ResponsesUsage from anthropicUsage.
+// Cache reads and thinking tokens are reported in the OpenAI Responses shape;
+// the Anthropic-named counts stay in RawUsage, which feeds usage records and
+// cost calculation without reaching the client response.
 func buildAnthropicResponsesUsage(u anthropicUsage) *core.ResponsesUsage {
 	usage := &core.ResponsesUsage{
 		InputTokens:  u.InputTokens,
 		OutputTokens: u.OutputTokens,
 		TotalTokens:  u.InputTokens + u.OutputTokens,
+	}
+	if u.CacheReadInputTokens > 0 {
+		usage.PromptTokensDetails = &core.PromptTokensDetails{CachedTokens: u.CacheReadInputTokens}
+	}
+	if u.OutputTokensDetails.ThinkingTokens > 0 {
+		usage.CompletionTokensDetails = &core.CompletionTokensDetails{ReasoningTokens: u.OutputTokensDetails.ThinkingTokens}
 	}
 	rawUsage := buildAnthropicRawUsage(u)
 	if len(rawUsage) > 0 {
@@ -66,6 +77,10 @@ func buildAnthropicResponsesUsage(u anthropicUsage) *core.ResponsesUsage {
 	return usage
 }
 
+// anthropicResponsesUsagePayload renders the usage object carried by the
+// terminal stream event. It keeps the Anthropic-named cache counts: a stream's
+// usage is recorded by parsing this payload, so dropping them would drop the
+// cache pricing with them.
 func anthropicResponsesUsagePayload(usage *anthropicUsage) map[string]any {
 	if usage == nil {
 		return nil
@@ -142,8 +157,9 @@ type responsesStreamConverter struct {
 	closed               bool
 	sentCreate           bool
 	sentDone             bool
-	sawStop              bool  // upstream signalled the end of the message
-	pendingErr           error // upstream read error deferred until terminal events are drained
+	sawStop              bool   // upstream signalled the end of the message
+	stopReason           string // Anthropic stop_reason, used for incomplete_details
+	pendingErr           error  // upstream read error deferred until terminal events are drained
 	usage                anthropicUsage
 	hasUsage             bool
 }
@@ -264,7 +280,9 @@ func (sc *responsesStreamConverter) reserveAssistantMessageOutput() {
 // once. A stream that ends without Anthropic signalling the end of the message
 // (message_stop or a stop_reason) was interrupted: it ends with
 // response.incomplete instead of fabricating completion, and its open items
-// close with status "incomplete".
+// close with status "incomplete". A stream that stopped early on its own
+// (stop_reason "max_tokens") ends the same way, with the matching
+// incomplete_details reason.
 func (sc *responsesStreamConverter) appendTerminalEvents() {
 	if sc.sentDone {
 		return
@@ -275,7 +293,11 @@ func (sc *responsesStreamConverter) appendTerminalEvents() {
 	sc.buffer.AppendString(sc.startResponse())
 	status := "completed"
 	eventName := "response.completed"
-	if !sc.sawStop {
+	incompleteReason := "interrupted"
+	if sc.sawStop {
+		incompleteReason = providers.ResponsesIncompleteReason(normalizeAnthropicStopReason(sc.stopReason))
+	}
+	if incompleteReason != "" {
 		status = "incomplete"
 		eventName = "response.incomplete"
 	}
@@ -297,8 +319,8 @@ func (sc *responsesStreamConverter) appendTerminalEvents() {
 		"created_at": sc.createdAt,
 		"output":     sc.output.FinalOutputItems(sc.reasoningOutputIndex, sc.assistantOutputIndex, sc.toolCalls, true),
 	}
-	if status == "incomplete" {
-		responseData["incomplete_details"] = map[string]any{"reason": "interrupted"}
+	if incompleteReason != "" {
+		responseData["incomplete_details"] = map[string]any{"reason": incompleteReason}
 	}
 	// Include merged usage data captured across message_start/message_delta.
 	if sc.hasUsage {
@@ -467,6 +489,9 @@ func (sc *responsesStreamConverter) convertEvent(event *anthropicStreamEvent) st
 		// stream is cut before message_stop arrives.
 		if event.Delta != nil && event.Delta.StopReason != "" {
 			sc.sawStop = true
+			if sc.stopReason == "" {
+				sc.stopReason = event.Delta.StopReason
+			}
 		}
 		if !sc.output.AssistantReserved() && len(sc.toolCalls) == 0 {
 			sc.reserveAssistantMessageOutput()

--- a/internal/providers/anthropic/responses_status_test.go
+++ b/internal/providers/anthropic/responses_status_test.go
@@ -1,0 +1,129 @@
+package anthropic
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-json"
+)
+
+// A turn Anthropic cut at max_tokens is an incomplete response, not a
+// completed one.
+func TestConvertAnthropicResponseToResponses_MaxTokensIsIncomplete(t *testing.T) {
+	resp := convertAnthropicResponseToResponses(&anthropicResponse{
+		ID:         "msg_1",
+		StopReason: "max_tokens",
+		Content:    []anthropicContent{{Type: "text", Text: "partial"}},
+	}, "claude-haiku-4-5")
+
+	if resp.Status != "incomplete" {
+		t.Fatalf("status = %q, want incomplete", resp.Status)
+	}
+	if resp.IncompleteDetails == nil || resp.IncompleteDetails.Reason != "max_output_tokens" {
+		t.Fatalf("incomplete_details = %+v, want reason max_output_tokens", resp.IncompleteDetails)
+	}
+	if resp.Output[0].Status != "incomplete" {
+		t.Fatalf("message item status = %q, want incomplete", resp.Output[0].Status)
+	}
+}
+
+func TestConvertAnthropicResponseToResponses_EndTurnCompletes(t *testing.T) {
+	resp := convertAnthropicResponseToResponses(&anthropicResponse{
+		ID:         "msg_1",
+		StopReason: "end_turn",
+		Content:    []anthropicContent{{Type: "text", Text: "done"}},
+	}, "claude-haiku-4-5")
+
+	if resp.Status != "completed" || resp.IncompleteDetails != nil {
+		t.Fatalf("status = %q, incomplete_details = %+v, want a completed response", resp.Status, resp.IncompleteDetails)
+	}
+}
+
+// Cache reads and thinking tokens keep their OpenAI-shaped home; the
+// Anthropic-named counts stay out of the client-visible usage object.
+func TestBuildAnthropicResponsesUsage_NormalizesDetails(t *testing.T) {
+	usage := buildAnthropicResponsesUsage(anthropicUsage{
+		InputTokens:              100,
+		OutputTokens:             20,
+		CacheReadInputTokens:     40,
+		CacheCreationInputTokens: 10,
+		OutputTokensDetails:      anthropicOutputTokensDetails{ThinkingTokens: 12},
+	})
+	if usage.PromptTokensDetails == nil || usage.PromptTokensDetails.CachedTokens != 40 {
+		t.Fatalf("input token details = %+v, want cached_tokens 40", usage.PromptTokensDetails)
+	}
+	if usage.CompletionTokensDetails == nil || usage.CompletionTokensDetails.ReasoningTokens != 12 {
+		t.Fatalf("output token details = %+v, want reasoning_tokens 12", usage.CompletionTokensDetails)
+	}
+	if usage.RawUsage["cache_creation_input_tokens"] != 10 {
+		t.Fatalf("RawUsage = %+v, want the Anthropic counts kept for usage records", usage.RawUsage)
+	}
+
+	encoded, err := json.Marshal(usage)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var wire map[string]any
+	if err := json.Unmarshal(encoded, &wire); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{"cache_read_input_tokens", "cache_creation_input_tokens", "completion_reasoning_tokens"} {
+		if _, exists := wire[key]; exists {
+			t.Fatalf("usage payload %s carries %q, want the OpenAI Responses shape only", encoded, key)
+		}
+	}
+}
+
+// A streamed turn stopped at max_tokens ends with response.incomplete.
+func TestResponsesStreamConverter_MaxTokensEndsIncomplete(t *testing.T) {
+	stream := `event: message_start
+data: {"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":5}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"max_tokens"},"usage":{"output_tokens":4}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+`
+	converter := newResponsesStreamConverter(io.NopCloser(strings.NewReader(stream)), "claude-haiku-4-5")
+	raw, err := io.ReadAll(converter)
+	if err != nil {
+		t.Fatalf("failed to read from converter: %v", err)
+	}
+
+	var response map[string]any
+	itemStatus := ""
+	for _, event := range parseTestSSEEvents(t, string(raw)) {
+		switch event.Name {
+		case "response.completed":
+			t.Fatalf("truncated stream ended with response.completed: %s", raw)
+		case "response.incomplete":
+			response, _ = event.Payload["response"].(map[string]any)
+		case "response.output_item.done":
+			if item, _ := event.Payload["item"].(map[string]any); item["type"] == "message" {
+				itemStatus, _ = item["status"].(string)
+			}
+		}
+	}
+	if response == nil {
+		t.Fatalf("expected response.incomplete terminal event: %s", raw)
+	}
+	details, _ := response["incomplete_details"].(map[string]any)
+	if details["reason"] != "max_output_tokens" {
+		t.Fatalf("incomplete_details = %#v, want reason max_output_tokens", response["incomplete_details"])
+	}
+	if itemStatus != "incomplete" {
+		t.Fatalf("message item status = %q, want incomplete", itemStatus)
+	}
+}

--- a/internal/providers/responses_converter.go
+++ b/internal/providers/responses_converter.go
@@ -35,6 +35,7 @@ type OpenAIResponsesStreamConverter struct {
 	sentCreate           bool
 	sentDone             bool
 	sawFinish            bool            // upstream signalled completion (finish_reason or [DONE])
+	finishReason         string          // first finish_reason seen, used for incomplete_details
 	pendingErr           error           // upstream read error deferred until terminal events are drained
 	cachedUsage          json.RawMessage // Stores usage from final chunk for inclusion in response.completed
 }
@@ -274,7 +275,7 @@ func (sc *OpenAIResponsesStreamConverter) processChunk(data []byte) {
 	// Any finish_reason means the model finished generating; some providers
 	// close the stream without a trailing [DONE] marker (Postel's law).
 	if choice.FinishReason != "" {
-		sc.sawFinish = true
+		sc.recordFinishReason(choice.FinishReason)
 	}
 
 	// Recorded before the text and tool calls of the same delta: a tool call
@@ -354,7 +355,7 @@ func (sc *OpenAIResponsesStreamConverter) processChunkTolerant(data []byte) {
 	}
 	finishReason, _ := choice["finish_reason"].(string)
 	if finishReason != "" {
-		sc.sawFinish = true
+		sc.recordFinishReason(finishReason)
 	}
 	if finishReason == "tool_calls" {
 		sc.buffer.AppendString(sc.completePendingToolCalls())
@@ -420,11 +421,22 @@ func (sc *OpenAIResponsesStreamConverter) appendTextDelta(content string) {
 	sc.buffer.AppendString(sc.output.AppendAssistantDelta(sc.assistantOutputIndex, content))
 }
 
+// recordFinishReason marks the upstream turn finished and keeps the first
+// finish reason, which decides whether the response completed or stopped
+// early.
+func (sc *OpenAIResponsesStreamConverter) recordFinishReason(reason string) {
+	sc.sawFinish = true
+	if sc.finishReason == "" {
+		sc.finishReason = reason
+	}
+}
+
 // appendTerminalEvents flushes open output items and appends the terminal
 // event plus the trailing [DONE] marker exactly once. Streams the upstream
-// finished (a finish_reason or [DONE] was seen) end with response.completed;
-// interrupted streams end with response.incomplete and close their open items
-// with status "incomplete" instead of fabricating completion.
+// finished (a finish_reason or [DONE] was seen) end with response.completed,
+// unless the finish reason says the turn stopped early (max_output_tokens,
+// content_filter); interrupted streams end with response.incomplete and close
+// their open items with status "incomplete" instead of fabricating completion.
 func (sc *OpenAIResponsesStreamConverter) appendTerminalEvents() {
 	if sc.sentDone {
 		return
@@ -432,7 +444,11 @@ func (sc *OpenAIResponsesStreamConverter) appendTerminalEvents() {
 	sc.sentDone = true
 	status := "completed"
 	eventName := "response.completed"
-	if !sc.sawFinish {
+	incompleteReason := "interrupted"
+	if sc.sawFinish {
+		incompleteReason = ResponsesIncompleteReason(sc.finishReason)
+	}
+	if incompleteReason != "" {
 		status = "incomplete"
 		eventName = "response.incomplete"
 	}
@@ -448,8 +464,8 @@ func (sc *OpenAIResponsesStreamConverter) appendTerminalEvents() {
 		"created_at": sc.createdAt,
 		"output":     sc.output.FinalOutputItems(reasoningOutputIndex, sc.assistantOutputIndex, sc.toolCalls, false),
 	}
-	if status == "incomplete" {
-		responseData["incomplete_details"] = map[string]any{"reason": "interrupted"}
+	if incompleteReason != "" {
+		responseData["incomplete_details"] = map[string]any{"reason": incompleteReason}
 	}
 	// Include usage data if captured from OpenAI stream, renamed from Chat
 	// Completions field names (prompt_tokens/completion_tokens) to the

--- a/internal/providers/responses_output.go
+++ b/internal/providers/responses_output.go
@@ -209,6 +209,42 @@ func responseMessageReasoningContent(msg core.ResponseMessage) string {
 	return content
 }
 
+// ResponsesIncompleteReason maps a Chat Completions finish reason onto the
+// OpenAI Responses incomplete_details reason, or returns "" when the turn
+// finished normally. OpenAI reports a truncated or filtered turn as status
+// "incomplete" with a reason, so translated providers must do the same
+// instead of claiming completion.
+func ResponsesIncompleteReason(finishReason string) string {
+	switch strings.TrimSpace(finishReason) {
+	case "length":
+		return "max_output_tokens"
+	case "content_filter":
+		return "content_filter"
+	default:
+		return ""
+	}
+}
+
+// ApplyResponsesFinishReason stamps a translated response with the status and
+// incomplete_details implied by the provider's finish reason. The message item
+// carries the same status, mirroring what OpenAI emits for a truncated turn.
+func ApplyResponsesFinishReason(resp *core.ResponsesResponse, finishReason string) {
+	if resp == nil {
+		return
+	}
+	reason := ResponsesIncompleteReason(finishReason)
+	if reason == "" {
+		return
+	}
+	resp.Status = "incomplete"
+	resp.IncompleteDetails = &core.ResponsesIncompleteDetails{Reason: reason}
+	for i := range resp.Output {
+		if resp.Output[i].Type == "message" {
+			resp.Output[i].Status = "incomplete"
+		}
+	}
+}
+
 // ConvertChatResponseToResponses converts a ChatResponse to a ResponsesResponse.
 func ConvertChatResponseToResponses(resp *core.ChatResponse) *core.ResponsesResponse {
 	var output []core.ResponsesOutputItem
@@ -232,7 +268,7 @@ func ConvertChatResponseToResponses(resp *core.ChatResponse) *core.ResponsesResp
 		}
 	}
 
-	return &core.ResponsesResponse{
+	converted := &core.ResponsesResponse{
 		ID:        resp.ID,
 		Object:    "response",
 		CreatedAt: resp.Created,
@@ -249,4 +285,8 @@ func ConvertChatResponseToResponses(resp *core.ChatResponse) *core.ResponsesResp
 			RawUsage:                resp.Usage.RawUsage,
 		},
 	}
+	if len(resp.Choices) > 0 {
+		ApplyResponsesFinishReason(converted, resp.Choices[0].FinishReason)
+	}
+	return converted
 }

--- a/internal/providers/responses_status_test.go
+++ b/internal/providers/responses_status_test.go
@@ -1,0 +1,143 @@
+package providers
+
+import (
+	"testing"
+
+	"github.com/goccy/go-json"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+func TestConvertChatResponseToResponses_StatusFromFinishReason(t *testing.T) {
+	tests := []struct {
+		name         string
+		finishReason string
+		wantStatus   string
+		wantReason   string
+	}{
+		{name: "normal stop", finishReason: "stop", wantStatus: "completed"},
+		{name: "tool calls", finishReason: "tool_calls", wantStatus: "completed"},
+		{name: "truncated", finishReason: "length", wantStatus: "incomplete", wantReason: "max_output_tokens"},
+		{name: "filtered", finishReason: "content_filter", wantStatus: "incomplete", wantReason: "content_filter"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := ConvertChatResponseToResponses(&core.ChatResponse{
+				ID:    "chatcmpl-1",
+				Model: "test-model",
+				Choices: []core.Choice{{
+					Message:      core.ResponseMessage{Role: "assistant", Content: "partial"},
+					FinishReason: tt.finishReason,
+				}},
+			})
+			if resp.Status != tt.wantStatus {
+				t.Fatalf("status = %q, want %q", resp.Status, tt.wantStatus)
+			}
+			if tt.wantReason == "" {
+				if resp.IncompleteDetails != nil {
+					t.Fatalf("incomplete_details = %+v, want none", resp.IncompleteDetails)
+				}
+				if resp.Output[0].Status != "completed" {
+					t.Fatalf("message item status = %q, want completed", resp.Output[0].Status)
+				}
+				return
+			}
+			if resp.IncompleteDetails == nil || resp.IncompleteDetails.Reason != tt.wantReason {
+				t.Fatalf("incomplete_details = %+v, want reason %q", resp.IncompleteDetails, tt.wantReason)
+			}
+			if resp.Output[0].Status != "incomplete" {
+				t.Fatalf("message item status = %q, want incomplete", resp.Output[0].Status)
+			}
+		})
+	}
+}
+
+// A truncated response must serialize the OpenAI incomplete contract.
+func TestConvertChatResponseToResponses_SerializesIncompleteDetails(t *testing.T) {
+	resp := ConvertChatResponseToResponses(&core.ChatResponse{
+		ID:      "chatcmpl-1",
+		Model:   "test-model",
+		Choices: []core.Choice{{Message: core.ResponseMessage{Role: "assistant", Content: "partial"}, FinishReason: "length"}},
+	})
+	encoded, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var wire struct {
+		Status            string `json:"status"`
+		IncompleteDetails *struct {
+			Reason string `json:"reason"`
+		} `json:"incomplete_details"`
+	}
+	if err := json.Unmarshal(encoded, &wire); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if wire.Status != "incomplete" || wire.IncompleteDetails == nil || wire.IncompleteDetails.Reason != "max_output_tokens" {
+		t.Fatalf("payload = %s, want incomplete with reason max_output_tokens", encoded)
+	}
+}
+
+// Provider usage extras must not reach the client on the Responses surface;
+// reasoning tokens keep their OpenAI-shaped home.
+func TestConvertChatResponseToResponses_NormalizesUsage(t *testing.T) {
+	resp := ConvertChatResponseToResponses(&core.ChatResponse{
+		ID:      "chatcmpl-1",
+		Model:   "test-model",
+		Choices: []core.Choice{{Message: core.ResponseMessage{Role: "assistant", Content: "hi"}, FinishReason: "stop"}},
+		Usage: core.Usage{
+			PromptTokens:            10,
+			CompletionTokens:        7,
+			TotalTokens:             17,
+			CompletionTokensDetails: &core.CompletionTokensDetails{ReasoningTokens: 5},
+			RawUsage: map[string]any{
+				"thoughts_token_count":        5,
+				"completion_reasoning_tokens": 5,
+			},
+		},
+	})
+	if resp.Usage.RawUsage["thoughts_token_count"] != 5 {
+		t.Fatalf("RawUsage = %+v, want the provider extras kept for usage records", resp.Usage.RawUsage)
+	}
+	encoded, err := json.Marshal(resp.Usage)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var wire map[string]any
+	if err := json.Unmarshal(encoded, &wire); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{"thoughts_token_count", "completion_reasoning_tokens", "raw_usage"} {
+		if _, exists := wire[key]; exists {
+			t.Fatalf("usage payload %s carries %q, want the OpenAI Responses shape only", encoded, key)
+		}
+	}
+	details, ok := wire["output_tokens_details"].(map[string]any)
+	if !ok || details["reasoning_tokens"] != float64(5) {
+		t.Fatalf("output_tokens_details = %#v, want reasoning_tokens 5", wire["output_tokens_details"])
+	}
+}
+
+// An empty assistant answer must still serialize the required text member.
+func TestBuildResponsesOutputItems_EmptyAnswerKeepsTextMember(t *testing.T) {
+	items := BuildResponsesOutputItems(core.ResponseMessage{Role: "assistant", Content: ""})
+	if len(items) != 1 {
+		t.Fatalf("items = %+v, want one message item", items)
+	}
+	encoded, err := json.Marshal(items[0])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var wire struct {
+		Content []map[string]json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(encoded, &wire); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(wire.Content) != 1 {
+		t.Fatalf("content = %s, want one part", encoded)
+	}
+	text, ok := wire.Content[0]["text"]
+	if !ok || string(text) != `""` {
+		t.Fatalf("output_text part = %s, want text \"\"", encoded)
+	}
+}

--- a/internal/providers/responses_stream_status_test.go
+++ b/internal/providers/responses_stream_status_test.go
@@ -1,0 +1,76 @@
+package providers
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+// A translated stream that hits the token limit must end with
+// response.incomplete and the OpenAI reason, not fabricate completion.
+func TestOpenAIResponsesStreamConverter_FinishReasonEndsIncomplete(t *testing.T) {
+	tests := []struct {
+		name         string
+		finishReason string
+		wantEvent    string
+		wantReason   string
+	}{
+		{name: "stop", finishReason: "stop", wantEvent: "response.completed"},
+		{name: "length", finishReason: "length", wantEvent: "response.incomplete", wantReason: "max_output_tokens"},
+		{name: "content filter", finishReason: "content_filter", wantEvent: "response.incomplete", wantReason: "content_filter"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockStream := `data: {"choices":[{"delta":{"content":"Hel"},"finish_reason":null}]}
+
+data: {"choices":[{"delta":{"content":"lo"},"finish_reason":"` + tt.finishReason + `"}]}
+
+data: [DONE]
+`
+			converter := NewOpenAIResponsesStreamConverter(io.NopCloser(strings.NewReader(mockStream)), "test-model", "mock")
+			raw, err := io.ReadAll(converter)
+			if err != nil {
+				t.Fatalf("ReadAll() error = %v", err)
+			}
+
+			itemStatus := ""
+			var response map[string]any
+			for _, event := range parseTestSSEEvents(t, string(raw)) {
+				switch event.Name {
+				case "response.output_item.done":
+					if item, _ := event.Payload["item"].(map[string]any); item["type"] == "message" {
+						itemStatus, _ = item["status"].(string)
+					}
+				case tt.wantEvent:
+					response, _ = event.Payload["response"].(map[string]any)
+				}
+			}
+
+			if response == nil {
+				t.Fatalf("expected %s terminal event, got %s", tt.wantEvent, raw)
+			}
+			if tt.wantReason == "" {
+				if response["status"] != "completed" {
+					t.Fatalf("response.status = %v, want completed", response["status"])
+				}
+				if _, exists := response["incomplete_details"]; exists {
+					t.Fatalf("incomplete_details = %#v, want none", response["incomplete_details"])
+				}
+				if itemStatus != "completed" {
+					t.Fatalf("message item status = %q, want completed", itemStatus)
+				}
+				return
+			}
+			if response["status"] != "incomplete" {
+				t.Fatalf("response.status = %v, want incomplete", response["status"])
+			}
+			details, _ := response["incomplete_details"].(map[string]any)
+			if details["reason"] != tt.wantReason {
+				t.Fatalf("incomplete_details = %#v, want reason %q", response["incomplete_details"], tt.wantReason)
+			}
+			if itemStatus != "incomplete" {
+				t.Fatalf("message item status = %q, want incomplete", itemStatus)
+			}
+		})
+	}
+}

--- a/internal/usage/cached_responses_test.go
+++ b/internal/usage/cached_responses_test.go
@@ -1,0 +1,50 @@
+package usage
+
+import (
+	"testing"
+
+	"github.com/goccy/go-json"
+
+	"github.com/enterpilot/gomodel/internal/core"
+)
+
+// A Responses body replayed from the cache carries cache reads in the OpenAI
+// shape; the cache-hit entry must still price them at the cached-input rate.
+func TestExtractFromCachedResponseBody_AnthropicResponsesCachedTokens(t *testing.T) {
+	cachedRate := 0.30
+	inputRate := 3.0
+	outputRate := 15.0
+
+	body, err := json.Marshal(&core.ResponsesResponse{
+		ID:     "resp_cache",
+		Object: "response",
+		Model:  "claude-haiku-4-5",
+		Status: "completed",
+		Usage: &core.ResponsesUsage{
+			InputTokens:         20,
+			OutputTokens:        10,
+			TotalTokens:         30,
+			PromptTokensDetails: &core.PromptTokensDetails{CachedTokens: 100},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	entry := ExtractFromCachedResponseBody(body, "req-cache", "claude-haiku-4-5", "anthropic", "/v1/responses", CacheTypeExact, &core.ModelPricing{
+		InputPerMtok:       &inputRate,
+		OutputPerMtok:      &outputRate,
+		CachedInputPerMtok: &cachedRate,
+	})
+	if entry == nil {
+		t.Fatal("expected non-nil entry")
+	}
+	if entry.RawData["prompt_cached_tokens"] != 100 {
+		t.Fatalf("RawData = %+v, want prompt_cached_tokens 100", entry.RawData)
+	}
+	// 20 input at 3/Mtok + 100 cache reads at 0.30/Mtok.
+	wantInput := 20*inputRate/1_000_000 + 100*cachedRate/1_000_000
+	if entry.InputCost == nil || *entry.InputCost != wantInput {
+		t.Fatalf("InputCost = %v, want %v", entry.InputCost, wantInput)
+	}
+}

--- a/internal/usage/cost.go
+++ b/internal/usage/cost.go
@@ -159,6 +159,11 @@ var providerMappings = map[string][]tokenCostMapping{
 	"openrouter": openAICompatibleTokenCostMappings,
 	"anthropic": {
 		{rawDataKey: "cache_read_input_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, side: sideInput, unit: unitPerMtok},
+		// The Responses surface reports cache reads in the OpenAI shape
+		// (input_tokens_details.cached_tokens), which usage extraction turns
+		// into prompt_cached_tokens. Price it like the Anthropic-named count so
+		// a cache hit replayed from a stored response body keeps its rate.
+		{rawDataKey: "prompt_cached_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.CachedInputPerMtok }, side: sideInput, unit: unitPerMtok},
 		{rawDataKey: "cache_creation_input_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.CacheWritePerMtok }, side: sideInput, unit: unitPerMtok},
 		{rawDataKey: "completion_reasoning_tokens", pricingField: func(p *core.ModelPricing) *float64 { return p.ReasoningOutputPerMtok }, side: sideOutput, unit: unitPerMtok, includedInBase: true},
 	},

--- a/tests/contract/testdata/golden/groq/responses.golden.json
+++ b/tests/contract/testdata/golden/groq/responses.golden.json
@@ -21,12 +21,8 @@
   "provider": "",
   "status": "completed",
   "usage": {
-    "completion_time": 0.030590271,
     "input_tokens": 38,
     "output_tokens": 4,
-    "prompt_time": 0.001689387,
-    "queue_time": 0.089910694,
-    "total_time": 0.032279658,
     "total_tokens": 42
   }
 }

--- a/tests/contract/testdata/golden/xai/responses.golden.json
+++ b/tests/contract/testdata/golden/xai/responses.golden.json
@@ -33,7 +33,6 @@
   "provider": "",
   "status": "completed",
   "usage": {
-    "cost_in_usd_ticks": 1424250,
     "input_tokens": 17,
     "input_tokens_details": {
       "audio_tokens": 0,
@@ -41,8 +40,6 @@
       "image_tokens": 0,
       "text_tokens": 0
     },
-    "num_server_side_tools_used": 0,
-    "num_sources_used": 0,
     "output_tokens": 276,
     "output_tokens_details": {
       "accepted_prediction_tokens": 0,


### PR DESCRIPTION
Three `/v1/responses` output-shape gaps, all visible on translated (non-native-OpenAI) providers.

**Truncation is reported.** A turn stopped by `max_output_tokens` (or a content filter) now returns `status: "incomplete"` with `incomplete_details.reason`, and the message item carries `status: "incomplete"` — chat-translated providers (gemini, groq, deepseek, …) and Anthropic, in both stream and non-stream. `core.ResponsesResponse` gained the typed `incomplete_details` field, so native OpenAI's value is no longer dropped either (it previously returned `status: "incomplete"` with no details).

**Empty answers keep `text`.** `output_text` parts always serialize `text`, which the OpenAI schema requires; an empty assistant answer used to emit `{"type":"output_text","annotations":[]}`. The streamed path already did this.

**Usage is normalized.** The Responses usage object now carries only the OpenAI shape (`input_tokens`/`output_tokens`/`total_tokens` plus `*_tokens_details`), instead of leaking provider members such as `thoughts_token_count`, `completion_reasoning_tokens` or `completion_time`. Nothing with an OpenAI-shaped home is lost: reasoning tokens stay under `output_tokens_details`, cached tokens under `input_tokens_details` (Anthropic's Responses usage now fills both). Provider extras remain in `RawUsage`, which feeds usage records and cost calculation, and the Anthropic streamed usage payload keeps its cache counts because stream costs are read back from it.

Provider notes: gemini 2.5 flash can return a completely empty stream (no chunk, no `finish_reason`, no usage) when the whole budget goes to thinking — nothing to map there; that stream still ends `completed`.

Tested: unit tests for each path (`internal/core`, `internal/providers`, `internal/providers/anthropic`), `go test ./...` (pre-existing failures only: dashboard assets, a midnight-boundary version-cookie test), `make lint` clean, API docs regenerated. Live gateway run against anthropic/gemini/groq/openai with `max_output_tokens=16`, stream and non-stream: all four now report `incomplete` + `max_output_tokens`, usage normalized, empty answer serializes `"text": ""`.
