### PR TITLE
fix(responses): replay chained history for native providers when needed

### DIFF
--- a/docs/advanced/plugins.mdx
+++ b/docs/advanced/plugins.mdx
@@ -588,6 +588,13 @@ Notes for authors:
   as the reason, and is logged once per transition; the error text must not
   contain secrets and is truncated to 256 characters. Health is informational:
   traffic still runs through the instance under its `fail_mode`.
+- Implement `pluginapi.ContentEditor` (`EditsContent() bool`) when a plugin
+  that declares `Mutates` can be configured not to edit, such as a detector
+  set to flag instead of rewrite. GoModel asks a configured instance before
+  work it does only for editing plugins — replaying the stored history of a
+  chained Responses request rather than letting the provider resolve
+  `previous_response_id` itself. It never changes how a hook runs, and a
+  mutating plugin without it is taken to edit.
 - Field inputs `secret` and `model` exist for API keys of external classifiers
   and for model pickers; a `secret` value is masked in every admin response.
   Use `bool` for a switch and `list` for an open-ended list of strings

--- a/docs/advanced/responses-api.mdx
+++ b/docs/advanced/responses-api.mdx
@@ -60,7 +60,11 @@ This enables:
   Responses providers receive the id itself and resolve it on their side, so
   they need no GoModel snapshot. An id GoModel minted for a chat-translated
   provider is replayed for them too, so a chain can move from Gemini or
-  Anthropic to OpenAI mid-conversation.
+  Anthropic to OpenAI mid-conversation. Ownership is enforced on every
+  provider: an id whose stored response belongs to another
+  [user path](/features/user-path#object-ownership) returns 404 instead of
+  being resolved upstream, while an id GoModel never stored is still
+  forwarded.
 
 The replayed history, like the items of a gateway-managed `conversation`, is
 merged into the input before the prompt-phase [guardrails](/advanced/guardrails)

--- a/docs/advanced/responses-api.mdx
+++ b/docs/advanced/responses-api.mdx
@@ -58,16 +58,20 @@ This enables:
   providers an id that is not stored (the previous response was sent with
   `store: false`), or belongs to another tenant, returns 404. Native
   Responses providers receive the id itself and resolve it on their side, so
-  they need no GoModel snapshot.
+  they need no GoModel snapshot. An id GoModel minted for a chat-translated
+  provider is replayed for them too, so a chain can move from Gemini or
+  Anthropic to OpenAI mid-conversation.
 
 The replayed history, like the items of a gateway-managed `conversation`, is
 merged into the input before the prompt-phase [guardrails](/advanced/guardrails)
 run, so they check and rewrite it like any other input: a stored response
 holds what its client saw, and a [presidio](/advanced/guardrails#presidio)
 guardrail anonymizes the values it restored there again before the next turn
-reaches the provider. When guardrails run and a failover target is
-chat-translated, a native primary receives the replayed history instead of
-the id as well.
+reaches the provider. A native primary receives the replayed history instead
+of the id as well when a guardrail that edits content runs on the prompt, or
+when a failover target is chat-translated. Without such a guardrail the id is
+forwarded untouched, so the provider keeps serving the chain from its own
+state.
 
 ## Native provider lookup
 

--- a/docs/advanced/responses-api.mdx
+++ b/docs/advanced/responses-api.mdx
@@ -72,7 +72,8 @@ run, so they check and rewrite it like any other input: a stored response
 holds what its client saw, and a [presidio](/advanced/guardrails#presidio)
 guardrail anonymizes the values it restored there again before the next turn
 reaches the provider. A native primary receives the replayed history instead
-of the id as well when a guardrail that edits content runs on the prompt, or
+of the id as well when a guardrail that rewrites content runs on the prompt
+(an instance configured only to flag or block does not count), or
 when a failover target is chat-translated. Without such a guardrail the id is
 forwarded untouched, so the provider keeps serving the chain from its own
 state.

--- a/docs/advanced/responses-compatibility.mdx
+++ b/docs/advanced/responses-compatibility.mdx
@@ -36,7 +36,7 @@ function tool loops. They cannot safely execute OpenAI-hosted tools.
 | Function call output items | Forwarded | Converted to chat tool-result messages |
 | `text.format` structured output | Forwarded | Converted to `response_format` when the provider supports it |
 | Responses-only tools (`web_search`, `file_search`, `computer_use_preview`, and `namespace`) | Provider decides | Accepted and omitted |
-| `previous_response_id` | Forwarded | Resolved by GoModel: the stored previous response's input items and output are prepended to the input. The previous response must be stored (`store` left on), or the request returns 404 (see [Stored responses](/advanced/responses-api#stored-responses)) |
+| `previous_response_id` | Forwarded, unless GoModel minted the id for a chat-translated provider or a content-editing prompt guardrail runs: then resolved as on the right | Resolved by GoModel: the stored previous response's input items and output are prepended to the input. The previous response must be stored (`store` left on), or the request returns 404 (see [Stored responses](/advanced/responses-api#stored-responses)) |
 | `conversation` | Resolved by GoModel from the gateway-managed conversation | Resolved by GoModel from the gateway-managed conversation |
 | `include` annotations | Forwarded | Accepted and ignored, except `message.output_text.logprobs` |
 | Unknown Responses input item types | Preserved | Rejected |

--- a/docs/features/user-path.mdx
+++ b/docs/features/user-path.mdx
@@ -83,8 +83,9 @@ Responses, conversations, batches, and uploaded files remember the `user_path`
 they were created under. Retrieving, listing, updating, cancelling, or deleting
 one of them by ID succeeds only when that path lies inside the caller's scope;
 otherwise the gateway answers `404`, exactly as for an unknown ID. A
-`/v1/responses` call that references a conversation from another subtree fails
-the same way.
+`/v1/responses` call that references a conversation, or a
+`previous_response_id`, from another subtree fails the same way — including on
+providers that resolve `previous_response_id` themselves.
 
 Scoped credentials can only address objects the gateway tracks: an ID the
 gateway has no record of is reported as missing, and `GET /v1/files` lists the

--- a/internal/gateway/interfaces.go
+++ b/internal/gateway/interfaces.go
@@ -53,6 +53,15 @@ type TranslatedRequestPatcher interface {
 	PatchResponsesRequest(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesRequest, error)
 }
 
+// PromptContentEditor is an optional TranslatedRequestPatcher capability: it
+// reports whether the prompt phase may rewrite the content of this request.
+// Only a rewriting prompt phase (anonymization, redaction) needs the replayed
+// history of a chained request in its input; a patcher that does not implement
+// this interface is assumed to rewrite.
+type PromptContentEditor interface {
+	EditsPromptContent(ctx context.Context) bool
+}
+
 // ResponsesAttemptPatcher adapts a Responses request to the provider one
 // attempt is about to reach, after failover has chosen the target. It runs
 // for the primary attempt and for every failover attempt with that target's

--- a/internal/guardrails/integration_test.go
+++ b/internal/guardrails/integration_test.go
@@ -226,7 +226,12 @@ func TestWorkflowRequestPatcherEditsPromptContent(t *testing.T) {
 	if err := catalog.Register(func() pluginapi.Plugin { return &decisionPlugin{} }, plugins.SourceRegistered); err != nil {
 		t.Fatal(err)
 	}
-	store := newTestStore(Definition{Name: "classify", Type: "decide"}, systemPromptDefinition("inject", "be safe"))
+	store := newTestStore(
+		Definition{Name: "classify", Type: "decide"},
+		systemPromptDefinition("inject", "be safe"),
+		Definition{Name: "replace", Type: "string_replace", Config: json.RawMessage(`{"rules":"secret => [redacted]"}`)},
+		Definition{Name: "flag", Type: "string_replace", Config: json.RawMessage(`{"rules":"secret => [redacted]","on_match":"warn"}`)},
+	)
 	service, err := NewService(store, catalog, plugins.HostDeps{})
 	if err != nil {
 		t.Fatal(err)
@@ -243,6 +248,9 @@ func TestWorkflowRequestPatcherEditsPromptContent(t *testing.T) {
 		{name: "no chain", want: false},
 		{name: "classifier only", steps: []StepReference{{Ref: "classify", Step: 1}}, want: false},
 		{name: "rewriting plugin", steps: []StepReference{{Ref: "classify", Step: 1}, {Ref: "inject", Step: 2}}, want: true},
+		{name: "rewriting instance", steps: []StepReference{{Ref: "replace", Step: 1}}, want: true},
+		// The plugin can edit, but this instance only flags its matches.
+		{name: "flagging instance", steps: []StepReference{{Ref: "flag", Step: 1}}, want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/guardrails/integration_test.go
+++ b/internal/guardrails/integration_test.go
@@ -218,6 +218,46 @@ func (failingPlugin) OnPrompt(context.Context, *pluginapi.Exchange) (pluginapi.D
 	return pluginapi.Decision{}, errors.New("classifier unreachable")
 }
 
+// A chained Responses request only needs its stored history expanded into the
+// input when a prompt plugin rewrites content; a classifier leaves the native
+// passthrough (and the provider's own history) alone.
+func TestWorkflowRequestPatcherEditsPromptContent(t *testing.T) {
+	catalog := testCatalog(t)
+	if err := catalog.Register(func() pluginapi.Plugin { return &decisionPlugin{} }, plugins.SourceRegistered); err != nil {
+		t.Fatal(err)
+	}
+	store := newTestStore(Definition{Name: "classify", Type: "decide"}, systemPromptDefinition("inject", "be safe"))
+	service, err := NewService(store, catalog, plugins.HostDeps{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := service.Refresh(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name  string
+		steps []StepReference
+		want  bool
+	}{
+		{name: "no chain", want: false},
+		{name: "classifier only", steps: []StepReference{{Ref: "classify", Step: 1}}, want: false},
+		{name: "rewriting plugin", steps: []StepReference{{Ref: "classify", Step: 1}, {Ref: "inject", Step: 2}}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var chains *plugins.Chains
+			if len(tt.steps) > 0 {
+				chains = chainsFor(t, service, tt.steps...)
+			}
+			patcher := NewWorkflowRequestPatcher(staticChains{chains})
+			if got := patcher.EditsPromptContent(context.Background()); got != tt.want {
+				t.Fatalf("EditsPromptContent() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestWorkflowRequestPatcherFailModes(t *testing.T) {
 	for _, tt := range []struct {
 		failMode string

--- a/internal/guardrails/workflow_executor.go
+++ b/internal/guardrails/workflow_executor.go
@@ -36,6 +36,20 @@ func (p *WorkflowRequestPatcher) PatchResponsesRequest(ctx context.Context, req 
 	return processGuardedResponses(ctx, p.chain(ctx), req)
 }
 
+// EditsPromptContent reports whether the request's prompt chain holds a
+// plugin that edits content, such as an anonymizing guardrail. A chained
+// Responses request only needs its stored history expanded into the input
+// when such a plugin runs; otherwise the request reaches the provider as the
+// client sent it.
+func (p *WorkflowRequestPatcher) EditsPromptContent(ctx context.Context) bool {
+	for _, instance := range p.chain(ctx).Instances() {
+		if instance.Mutates() {
+			return true
+		}
+	}
+	return false
+}
+
 func (p *WorkflowRequestPatcher) chain(ctx context.Context) *plugins.Chain {
 	return promptChain(p.resolver, ctx)
 }

--- a/internal/guardrails/workflow_executor.go
+++ b/internal/guardrails/workflow_executor.go
@@ -36,14 +36,15 @@ func (p *WorkflowRequestPatcher) PatchResponsesRequest(ctx context.Context, req 
 	return processGuardedResponses(ctx, p.chain(ctx), req)
 }
 
-// EditsPromptContent reports whether the request's prompt chain holds a
-// plugin that edits content, such as an anonymizing guardrail. A chained
+// EditsPromptContent reports whether the request's prompt chain holds an
+// instance that edits content, such as an anonymizing guardrail. A chained
 // Responses request only needs its stored history expanded into the input
-// when such a plugin runs; otherwise the request reaches the provider as the
-// client sent it.
+// when such an instance runs; otherwise the request reaches the provider as
+// the client sent it. An instance configured only to flag or block counts as
+// non-editing.
 func (p *WorkflowRequestPatcher) EditsPromptContent(ctx context.Context) bool {
 	for _, instance := range p.chain(ctx).Instances() {
-		if instance.Mutates() {
+		if instance.EditsContent() {
 			return true
 		}
 	}

--- a/internal/plugins/builtin/presidio/hooks.go
+++ b/internal/plugins/builtin/presidio/hooks.go
@@ -100,6 +100,13 @@ type pass struct {
 	requestID string
 }
 
+// EditsContent reports whether this instance rewrites the text it analyzes.
+// An instance that only blocks, answers, or flags detections leaves the
+// request as it is - unless it restores placeholders, which edits again.
+func (p *Plugin) EditsContent() bool {
+	return p.action == ActionAnonymize || p.restore
+}
+
 // OnPrompt analyzes the text of the prompt messages of the configured
 // roles, tool-result text and tool-call arguments included.
 func (p *Plugin) OnPrompt(ctx context.Context, x *pluginapi.Exchange) (pluginapi.Decision, error) {

--- a/internal/plugins/builtin/presidio/plugin_test.go
+++ b/internal/plugins/builtin/presidio/plugin_test.go
@@ -121,6 +121,29 @@ func newPlugin(t *testing.T, a *analyzer, cfg string) *Plugin {
 	return p.(*Plugin)
 }
 
+// A chained Responses request replays its stored history through the prompt
+// phase only when an instance edits content, so an instance that only flags
+// or blocks must say so.
+func TestEditsContent(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  string
+		want bool
+	}{
+		{name: "default anonymizes", cfg: `{}`, want: true},
+		{name: "warn only flags", cfg: `{"action":"warn"}`},
+		{name: "block only rejects", cfg: `{"action":"block"}`},
+		{name: "restore still edits", cfg: `{"action":"warn","restore":true}`, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := newPlugin(t, nil, tt.cfg).EditsContent(); got != tt.want {
+				t.Fatalf("EditsContent() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestManifest(t *testing.T) {
 	m := New().Manifest()
 	if m.Name != "presidio" || !m.Mutates || !m.Guardrail {

--- a/internal/plugins/builtin/stringreplace/hooks.go
+++ b/internal/plugins/builtin/stringreplace/hooks.go
@@ -10,6 +10,10 @@ import (
 // block, respond, or warn.
 const Code = "string_replace_match"
 
+// EditsContent reports whether this instance rewrites the text it matches.
+// Every other on_match (block, respond, warn) leaves the request as it is.
+func (p *Plugin) EditsContent() bool { return p.onMatch == OnMatchReplace }
+
 // OnPrompt edits or inspects the text of the prompt messages of the
 // configured roles, tool-result text included.
 func (p *Plugin) OnPrompt(_ context.Context, x *pluginapi.Exchange) (pluginapi.Decision, error) {

--- a/internal/plugins/builtin/stringreplace/plugin_test.go
+++ b/internal/plugins/builtin/stringreplace/plugin_test.go
@@ -20,6 +20,30 @@ func newPlugin(t *testing.T, cfg string) *Plugin {
 	return p.(*Plugin)
 }
 
+// A chained Responses request replays its stored history through the prompt
+// phase only when an instance edits content, so an instance that only blocks,
+// responds, or warns must say so.
+func TestEditsContent(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  string
+		want bool
+	}{
+		{name: "default replaces", cfg: `{"rules":"a => b"}`, want: true},
+		{name: "replace edits", cfg: `{"rules":"a => b","on_match":"replace"}`, want: true},
+		{name: "block only rejects", cfg: `{"rules":"a => b","on_match":"block"}`},
+		{name: "respond only answers", cfg: `{"rules":"a => b","on_match":"respond"}`},
+		{name: "warn only flags", cfg: `{"rules":"a => b","on_match":"warn"}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := newPlugin(t, tt.cfg).EditsContent(); got != tt.want {
+				t.Fatalf("EditsContent() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestManifest(t *testing.T) {
 	m := New().Manifest()
 	if m.Name != "string_replace" || !m.Mutates || !m.Guardrail {

--- a/internal/plugins/instance.go
+++ b/internal/plugins/instance.go
@@ -256,6 +256,20 @@ func (i *Instance) Mutates() bool {
 	return i != nil && i.Manifest.Mutates
 }
 
+// EditsContent reports whether the configured instance edits content. A
+// mutating plugin may be configured only to flag or block — presidio with
+// action "warn", string_replace with on_match "block" — and then leaves the
+// request as it is; such a plugin says so through [pluginapi.ContentEditor].
+func (i *Instance) EditsContent() bool {
+	if !i.Mutates() {
+		return false
+	}
+	if editor, ok := i.Plugin.(pluginapi.ContentEditor); ok {
+		return editor.EditsContent()
+	}
+	return true
+}
+
 // EffectiveFailMode resolves the fail mode for a phase.
 func (i *Instance) EffectiveFailMode(phase pluginapi.Kind) FailMode {
 	if i != nil && i.FailMode != "" {

--- a/internal/plugins/instance_edits_test.go
+++ b/internal/plugins/instance_edits_test.go
@@ -1,0 +1,58 @@
+package plugins
+
+import (
+	"testing"
+
+	"github.com/enterpilot/gomodel/pluginapi"
+)
+
+// editorPlugin is a mutating plugin whose configuration decides whether it
+// actually edits content, the way presidio and string_replace do.
+type editorPlugin struct {
+	fakePlugin
+	edits bool
+}
+
+func (e *editorPlugin) EditsContent() bool { return e.edits }
+
+// A chained Responses request replays its stored history only for an instance
+// that edits content, so the answer must come from the configured instance and
+// fall back to the manifest for a plugin that does not say.
+func TestInstanceEditsContent(t *testing.T) {
+	tests := []struct {
+		name     string
+		instance *Instance
+		want     bool
+	}{
+		{name: "nil instance"},
+		{
+			name:     "non-mutating plugin never edits",
+			instance: &Instance{Plugin: &fakePlugin{name: "inspector"}},
+		},
+		{
+			name:     "mutating plugin without ContentEditor is taken to edit",
+			instance: &Instance{Manifest: pluginapi.Manifest{Mutates: true}, Plugin: &fakePlugin{name: "rewriter", mutates: true}},
+			want:     true,
+		},
+		{
+			name:     "configured editor that edits",
+			instance: &Instance{Manifest: pluginapi.Manifest{Mutates: true}, Plugin: &editorPlugin{edits: true}},
+			want:     true,
+		},
+		{
+			name:     "configured editor that only flags",
+			instance: &Instance{Manifest: pluginapi.Manifest{Mutates: true}, Plugin: &editorPlugin{}},
+		},
+		{
+			name:     "non-mutating manifest wins over the plugin's answer",
+			instance: &Instance{Plugin: &editorPlugin{edits: true}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.instance.EditsContent(); got != tt.want {
+				t.Fatalf("EditsContent() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/server/previous_response.go
+++ b/internal/server/previous_response.go
@@ -26,10 +26,17 @@ import (
 // and still gives a translated failover target a request it can serve.
 //
 // Most requests arrive here already expanded (see ResolveResponsesHistory);
-// only an id kept for a native primary can still need it.
+// only an id kept for a native primary can still need it. An id forwarded to
+// a native provider passes the ownership check every attempt, so a stored
+// response outside the caller's access scope is never resolved upstream under
+// the gateway's shared provider credential.
 func (s *translatedInferenceService) PatchResponsesAttempt(ctx context.Context, req *core.ResponsesRequest, providerType string) (*core.ResponsesRequest, error) {
-	if req == nil || strings.TrimSpace(req.PreviousResponseID) == "" || s.providerTypeResolvesPreviousResponse(providerType) {
+	if req == nil || strings.TrimSpace(req.PreviousResponseID) == "" {
 		return req, nil
+	}
+	if s.providerTypeResolvesPreviousResponse(providerType) {
+		_, err := s.nativePreviousResponse(ctx, req.PreviousResponseID)
+		return req, err
 	}
 	return s.withPreviousResponseHistory(ctx, req)
 }
@@ -47,7 +54,9 @@ func (s *translatedInferenceService) PatchResponsesAttempt(ctx context.Context, 
 // chat-translated provider, which a native provider cannot resolve.
 // Otherwise a native primary keeps the id, which it resolves itself, and
 // PatchResponsesAttempt expands it for a translated failover attempt. A
-// native primary also keeps an id the gateway has not stored.
+// native primary also keeps an id the gateway has not stored. An id whose
+// stored response belongs to another tenant is reported missing whatever the
+// target resolves it.
 func (s *translatedInferenceService) ResolveResponsesHistory(ctx context.Context, req *core.ResponsesRequest, providerTypes []string) (context.Context, *core.ResponsesRequest, error) {
 	if req == nil {
 		return ctx, req, nil
@@ -61,10 +70,16 @@ func (s *translatedInferenceService) ResolveResponsesHistory(ctx context.Context
 	primaryTranslated := len(providerTypes) > 0 && translated(providerTypes[0])
 	guarded := s.promptPhaseRuns(ctx) &&
 		(slices.ContainsFunc(providerTypes, translated) || s.promptPhaseEditsContent(ctx))
-	// The store lookup runs last: it is only needed while the id would
-	// otherwise be forwarded to a native provider.
-	if !primaryTranslated && !guarded && !s.gatewayOwnedPreviousResponse(ctx, req.PreviousResponseID) {
-		return ctx, req, nil
+	if !primaryTranslated {
+		// A chat-translated primary loads the stored response below, which
+		// enforces the same ownership rule; a native one has to be told.
+		replay, err := s.nativePreviousResponse(ctx, req.PreviousResponseID)
+		if err != nil {
+			return ctx, req, err
+		}
+		if !guarded && !replay {
+			return ctx, req, nil
+		}
 	}
 	patched, err := s.withPreviousResponseHistory(ctx, req)
 	if err != nil && !primaryTranslated {
@@ -91,27 +106,40 @@ func (s *translatedInferenceService) promptPhaseEditsContent(ctx context.Context
 	return !ok || editor.EditsPromptContent(ctx)
 }
 
-// gatewayOwnedPreviousResponse reports whether the referenced response is one
-// the gateway minted while serving a chat-translated provider. Such an id
-// exists only in the gateway's store, so a native Responses provider rejects
-// it; the history behind it has to be replayed instead. An id the gateway
-// does not hold (a response created directly against the provider, or one
-// that was not stored) is still forwarded untouched.
-func (s *translatedInferenceService) gatewayOwnedPreviousResponse(ctx context.Context, id string) bool {
+// nativePreviousResponse inspects the stored response behind an id that would
+// otherwise be forwarded to a native Responses provider, which resolves it
+// upstream under the gateway's shared provider credential. It reports whether
+// the gateway has to replay the history itself: a response the gateway minted
+// while serving a chat-translated provider exists only in its store, so a
+// native provider rejects the id. A stored response outside the caller's
+// access scope is reported missing, exactly as GET /v1/responses/{id} reports
+// it, so one tenant cannot continue (and read back) another tenant's
+// conversation. An id the gateway does not hold — a response created directly
+// against the provider, or one that was not stored — is still forwarded
+// untouched.
+func (s *translatedInferenceService) nativePreviousResponse(ctx context.Context, id string) (bool, error) {
 	id = strings.TrimSpace(id)
 	store := s.currentResponseStore()
 	if id == "" || store == nil {
-		return false
+		return false, nil
 	}
 	// A client that chains as soon as it has the response must not race the
 	// background snapshot write.
 	s.awaitPendingSnapshot(ctx, id)
 	stored, err := store.Get(ctx, id)
-	// Another tenant's response is indistinguishable from a missing one.
-	if err != nil || stored == nil || stored.Response == nil || !core.AccessScopeFromContext(ctx).Allows(stored.UserPath) {
-		return false
+	if err != nil {
+		if errors.Is(err, responsestore.ErrNotFound) {
+			return false, nil
+		}
+		return false, core.NewProviderError("response_store", http.StatusInternalServerError, "failed to load previous response", err)
 	}
-	return !s.providerTypeResolvesPreviousResponse(stored.Provider)
+	if stored == nil || stored.Response == nil {
+		return false, nil
+	}
+	if !core.AccessScopeFromContext(ctx).Allows(stored.UserPath) {
+		return false, previousResponseNotFound(id)
+	}
+	return !s.providerTypeResolvesPreviousResponse(stored.Provider), nil
 }
 
 // clientTurn is a Responses request's own turn as the client sent it, before

--- a/internal/server/previous_response.go
+++ b/internal/server/previous_response.go
@@ -11,6 +11,7 @@ import (
 	"github.com/goccy/go-json"
 
 	"github.com/enterpilot/gomodel/internal/core"
+	"github.com/enterpilot/gomodel/internal/gateway"
 	"github.com/enterpilot/gomodel/internal/responsestore"
 )
 
@@ -40,11 +41,13 @@ func (s *translatedInferenceService) PatchResponsesAttempt(ctx context.Context, 
 // values included, so replaying it past the guardrails would hand those
 // values to the provider. The client's own turn is kept in the context for
 // the response snapshot. previous_response_id is expanded when the primary
-// target (providerTypes[0]) is chat-translated, or when a failover target is
-// and guardrails run on the request; otherwise a native primary keeps the
-// id, which it resolves itself, and PatchResponsesAttempt expands it for a
-// translated failover attempt. A native primary also keeps an id the
-// gateway has not stored.
+// target (providerTypes[0]) is chat-translated; when guardrails run and
+// either a failover target is chat-translated or the prompt phase edits
+// content; and when the id names a response the gateway minted for a
+// chat-translated provider, which a native provider cannot resolve.
+// Otherwise a native primary keeps the id, which it resolves itself, and
+// PatchResponsesAttempt expands it for a translated failover attempt. A
+// native primary also keeps an id the gateway has not stored.
 func (s *translatedInferenceService) ResolveResponsesHistory(ctx context.Context, req *core.ResponsesRequest, providerTypes []string) (context.Context, *core.ResponsesRequest, error) {
 	if req == nil {
 		return ctx, req, nil
@@ -56,8 +59,11 @@ func (s *translatedInferenceService) ResolveResponsesHistory(ctx context.Context
 	}
 	translated := func(providerType string) bool { return !s.providerTypeResolvesPreviousResponse(providerType) }
 	primaryTranslated := len(providerTypes) > 0 && translated(providerTypes[0])
-	guarded := s.translatedRequestPatcher != nil && core.GetWorkflow(ctx).GuardrailsEnabled() && slices.ContainsFunc(providerTypes, translated)
-	if !primaryTranslated && !guarded {
+	guarded := s.promptPhaseRuns(ctx) &&
+		(slices.ContainsFunc(providerTypes, translated) || s.promptPhaseEditsContent(ctx))
+	// The store lookup runs last: it is only needed while the id would
+	// otherwise be forwarded to a native provider.
+	if !primaryTranslated && !guarded && !s.gatewayOwnedPreviousResponse(ctx, req.PreviousResponseID) {
 		return ctx, req, nil
 	}
 	patched, err := s.withPreviousResponseHistory(ctx, req)
@@ -67,6 +73,45 @@ func (s *translatedInferenceService) ResolveResponsesHistory(ctx context.Context
 		}
 	}
 	return ctx, patched, err
+}
+
+// promptPhaseRuns reports whether a prompt-phase patch runs for the request.
+func (s *translatedInferenceService) promptPhaseRuns(ctx context.Context) bool {
+	return s.translatedRequestPatcher != nil && core.GetWorkflow(ctx).GuardrailsEnabled()
+}
+
+// promptPhaseEditsContent reports whether the prompt phase may rewrite the
+// request's content. Only a rewriting prompt phase needs the replayed history
+// in the input: an anonymizing guardrail that never sees the earlier turns
+// reuses their placeholders for new values, so the restore step hands the
+// client another turn's data. A patcher without the capability is assumed to
+// rewrite.
+func (s *translatedInferenceService) promptPhaseEditsContent(ctx context.Context) bool {
+	editor, ok := s.translatedRequestPatcher.(gateway.PromptContentEditor)
+	return !ok || editor.EditsPromptContent(ctx)
+}
+
+// gatewayOwnedPreviousResponse reports whether the referenced response is one
+// the gateway minted while serving a chat-translated provider. Such an id
+// exists only in the gateway's store, so a native Responses provider rejects
+// it; the history behind it has to be replayed instead. An id the gateway
+// does not hold (a response created directly against the provider, or one
+// that was not stored) is still forwarded untouched.
+func (s *translatedInferenceService) gatewayOwnedPreviousResponse(ctx context.Context, id string) bool {
+	id = strings.TrimSpace(id)
+	store := s.currentResponseStore()
+	if id == "" || store == nil {
+		return false
+	}
+	// A client that chains as soon as it has the response must not race the
+	// background snapshot write.
+	s.awaitPendingSnapshot(ctx, id)
+	stored, err := store.Get(ctx, id)
+	// Another tenant's response is indistinguishable from a missing one.
+	if err != nil || stored == nil || stored.Response == nil || !core.AccessScopeFromContext(ctx).Allows(stored.UserPath) {
+		return false
+	}
+	return !s.providerTypeResolvesPreviousResponse(stored.Provider)
 }
 
 // clientTurn is a Responses request's own turn as the client sent it, before

--- a/internal/server/previous_response_guardrails_test.go
+++ b/internal/server/previous_response_guardrails_test.go
@@ -38,6 +38,26 @@ func (p *redactingPatcher) PatchResponsesRequest(_ context.Context, req *core.Re
 	return &patched, nil
 }
 
+// inspectingPatcher stands in for a prompt guardrail that only classifies:
+// it reads the request but never rewrites it, so a chained request keeps the
+// native passthrough.
+type inspectingPatcher struct{ seen []string }
+
+func (p *inspectingPatcher) PatchChatRequest(_ context.Context, req *core.ChatRequest) (*core.ChatRequest, error) {
+	return req, nil
+}
+
+func (p *inspectingPatcher) PatchResponsesRequest(_ context.Context, req *core.ResponsesRequest) (*core.ResponsesRequest, error) {
+	raw, err := json.Marshal(req.Input)
+	if err != nil {
+		return nil, err
+	}
+	p.seen = append(p.seen, string(raw))
+	return req, nil
+}
+
+func (p *inspectingPatcher) EditsPromptContent(context.Context) bool { return false }
+
 func forwardedInput(t *testing.T, provider *capturingProvider) string {
 	t.Helper()
 	if provider.capturedResponsesReq == nil {
@@ -119,6 +139,78 @@ func TestResponsesWithConversation_HistoryPassesPromptGuardrails(t *testing.T) {
 	}
 	if got := forwardedInput(t, provider); strings.Contains(got, "zebra") || !strings.Contains(got, "[animal]") {
 		t.Fatalf("conversation history forwarded %s, want it redacted", got)
+	}
+}
+
+// A native primary resolves previous_response_id itself, so a rewriting
+// prompt guardrail would never see the earlier turns: an anonymizing
+// guardrail would hand the placeholders of that history to new values and
+// restore another turn's data into the answer. The history is expanded for a
+// native primary too while such a guardrail runs, and the id goes with it so
+// the provider does not replay the same turns twice.
+func TestResponsesWithPreviousResponseID_NativePrimaryExpandsForEditingGuardrail(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		provider := previousResponseTestProvider(t, "openai")
+		provider.streamData = streamedResponseData("resp_conv_2", "still zebra")
+		patcher := &redactingPatcher{}
+		srv := New(provider, &Config{TranslatedRequestPatcher: patcher})
+		store := srv.handler.currentResponseStore()
+
+		if rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"my pet is a zebra"}`); rec.Code != http.StatusOK {
+			t.Fatalf("stream=%v turn one status = %d (%s)", stream, rec.Code, rec.Body.String())
+		}
+		waitForStoredResponse(t, store, "resp_conv_1")
+
+		provider.responsesResponse.ID = "resp_conv_2"
+		body := `{"model":"gpt-5-mini","input":"what is it?","previous_response_id":"resp_conv_1","stream":` + map[bool]string{false: "false", true: "true"}[stream] + `}`
+		rec := postResponses(t, srv, body)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("stream=%v chained status = %d (%s)", stream, rec.Code, rec.Body.String())
+		}
+		forwarded := provider.capturedResponsesReq
+		if forwarded.PreviousResponseID != "" {
+			t.Fatalf("stream=%v expanded history must not also carry previous_response_id, got %q", stream, forwarded.PreviousResponseID)
+		}
+		items := forwardedInputItems(t, provider.capturingProvider)
+		if len(items) != 3 {
+			t.Fatalf("stream=%v forwarded %d items, want the replayed turn plus the new input: %#v", stream, len(items), items)
+		}
+		if got := forwardedInput(t, provider.capturingProvider); strings.Contains(got, "zebra") || strings.Count(got, "[animal]") != 2 {
+			t.Fatalf("stream=%v chained turn forwarded %s, want the replayed input and output redacted", stream, got)
+		}
+		if seen := patcher.seen[len(patcher.seen)-1]; !strings.Contains(seen, "the word is zebra") {
+			t.Fatalf("stream=%v prompt guardrail saw %s, want the replayed history", stream, seen)
+		}
+		if !stream && !strings.Contains(rec.Body.String(), `"previous_response_id":"resp_conv_1"`) {
+			t.Fatalf("stream=%v chained response must still echo previous_response_id: %s", stream, rec.Body.String())
+		}
+	}
+}
+
+// A prompt guardrail that only classifies leaves the native passthrough
+// alone: the provider keeps resolving previous_response_id itself, so its
+// own history stays cached upstream.
+func TestResponsesWithPreviousResponseID_NativePrimaryKeepsIDForInspectingGuardrail(t *testing.T) {
+	provider := previousResponseTestProvider(t, "openai")
+	patcher := &inspectingPatcher{}
+	srv := New(provider, &Config{TranslatedRequestPatcher: patcher})
+	store := srv.handler.currentResponseStore()
+
+	if rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"my pet is a zebra"}`); rec.Code != http.StatusOK {
+		t.Fatalf("turn one status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	waitForStoredResponse(t, store, "resp_conv_1")
+
+	provider.responsesResponse.ID = "resp_conv_2"
+	if rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"what is it?","previous_response_id":"resp_conv_1"}`); rec.Code != http.StatusOK {
+		t.Fatalf("chained status = %d (%s)", rec.Code, rec.Body.String())
+	}
+	forwarded := provider.capturedResponsesReq
+	if forwarded.PreviousResponseID != "resp_conv_1" {
+		t.Fatalf("previous_response_id = %q, want it forwarded to the native provider", forwarded.PreviousResponseID)
+	}
+	if _, ok := forwarded.Input.(string); !ok {
+		t.Fatalf("native input must be untouched, got %#v", forwarded.Input)
 	}
 }
 

--- a/internal/server/previous_response_test.go
+++ b/internal/server/previous_response_test.go
@@ -246,19 +246,86 @@ func TestResponsesWithPreviousResponseID_NativeProviderReplaysGatewayMintedChain
 	}
 }
 
-// Another tenant's stored response stays invisible: it is neither replayed
-// nor reported, and the id reaches the provider as any unknown id does.
-func TestResponsesWithPreviousResponseID_ForeignTenantChainIsNotReplayed(t *testing.T) {
-	s := &translatedInferenceService{provider: previousResponseTestProvider(t, "openai"), responseStore: responsestore.NewMemoryStore()}
-	storeChainedResponse(t, s.responseStore, "resp_other", "anthropic", "/tenant-b")
-
-	foreign := core.WithAccessScope(context.Background(), core.AccessScope{UserPath: "/tenant-a"})
-	if s.gatewayOwnedPreviousResponse(foreign, "resp_other") {
-		t.Fatal("a foreign tenant must not reach another tenant's stored chain")
+// A native provider resolves previous_response_id upstream under the
+// gateway's shared credential, so forwarding another tenant's id would let
+// one tenant continue - and read back - a conversation the same gateway hides
+// from it on GET. Such an id is reported missing instead; an id the gateway
+// does not hold still reaches the provider, so chains created against it
+// directly keep working.
+func TestResponsesWithPreviousResponseID_NativeProviderEnforcesOwnership(t *testing.T) {
+	newService := func(t *testing.T) *translatedInferenceService {
+		t.Helper()
+		s := &translatedInferenceService{provider: previousResponseTestProvider(t, "openai"), responseStore: responsestore.NewMemoryStore()}
+		storeChainedResponse(t, s.responseStore, "resp_owned", "openai", "/tenant-b")
+		storeChainedResponse(t, s.responseStore, "resp_translated", "anthropic", "/tenant-b")
+		return s
 	}
-	owner := core.WithAccessScope(context.Background(), core.AccessScope{UserPath: "/tenant-b"})
-	if !s.gatewayOwnedPreviousResponse(owner, "resp_other") {
-		t.Fatal("the owning tenant must replay its own gateway-minted chain")
+	scoped := func(path string) context.Context {
+		return core.WithAccessScope(context.Background(), core.AccessScope{UserPath: path})
+	}
+
+	tests := []struct {
+		name       string
+		ctx        context.Context
+		id         string
+		wantReplay bool
+		wantErr    bool
+	}{
+		{name: "foreign tenant is refused", ctx: scoped("/tenant-a"), id: "resp_owned", wantErr: true},
+		{name: "foreign tenant is refused for a gateway-minted id", ctx: scoped("/tenant-a"), id: "resp_translated", wantErr: true},
+		{name: "owner forwards its native id", ctx: scoped("/tenant-b"), id: "resp_owned"},
+		{name: "owner replays its gateway-minted id", ctx: scoped("/tenant-b"), id: "resp_translated", wantReplay: true},
+		{name: "unknown id is forwarded", ctx: scoped("/tenant-a"), id: "resp_unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newService(t)
+			replay, err := s.nativePreviousResponse(tt.ctx, tt.id)
+			if tt.wantErr {
+				if err == nil || !strings.Contains(err.Error(), "not found") {
+					t.Fatalf("error = %v, want not found", err)
+				}
+				return
+			}
+			if err != nil || replay != tt.wantReplay {
+				t.Fatalf("nativePreviousResponse() = %v, %v, want %v, nil", replay, err, tt.wantReplay)
+			}
+			// Every dispatch attempt re-checks, so a native attempt of any
+			// request is covered even when the history was not expanded.
+			req := &core.ResponsesRequest{Model: "gpt-5-mini", Input: "again?", PreviousResponseID: tt.id}
+			if _, err := s.PatchResponsesAttempt(tt.ctx, req, "openai"); err != nil {
+				t.Fatalf("PatchResponsesAttempt() error = %v", err)
+			}
+		})
+	}
+}
+
+// The foreign-tenant rejection reaches the client as a 404, streamed or not,
+// the way an unknown id does on a chat-translated provider.
+func TestResponsesWithPreviousResponseID_ForeignTenantChainReturns404(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		provider := previousResponseTestProvider(t, "openai")
+		srv := New(provider, nil)
+		storeChainedResponse(t, srv.handler.currentResponseStore(), "resp_owned", "openai", "/tenant-b")
+
+		body := `{"model":"gpt-5-mini","input":"what is the word?","previous_response_id":"resp_owned","stream":` + map[bool]string{false: "false", true: "true"}[stream] + `}`
+		req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		c := echo.New().NewContext(req, rec)
+		c.SetRequest(req.WithContext(core.WithAccessScope(req.Context(), core.AccessScope{UserPath: "/tenant-a"})))
+		if err := srv.handler.Responses(c); err != nil {
+			t.Fatalf("stream=%v handler.Responses() error = %v", stream, err)
+		}
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("stream=%v status = %d (%s), want 404", stream, rec.Code, rec.Body.String())
+		}
+		if !strings.Contains(rec.Body.String(), "Previous response with id 'resp_owned' not found.") {
+			t.Fatalf("stream=%v body = %s, want the not-found message", stream, rec.Body.String())
+		}
+		if provider.capturedResponsesReq != nil {
+			t.Fatalf("stream=%v another tenant's chain must not reach the provider", stream)
+		}
 	}
 }
 

--- a/internal/server/previous_response_test.go
+++ b/internal/server/previous_response_test.go
@@ -179,6 +179,89 @@ func TestResponsesWithPreviousResponseID_NativeProviderKeepsForwarding(t *testin
 	}
 }
 
+// storeChainedResponse records a response the gateway served for providerType,
+// the way a finished turn is snapshotted.
+func storeChainedResponse(t *testing.T, store responsestore.Store, id, providerType, userPath string) {
+	t.Helper()
+	if err := store.Create(context.Background(), &responsestore.StoredResponse{
+		Response: &core.ResponsesResponse{
+			ID: id, Object: "response", Status: "completed",
+			Output: []core.ResponsesOutputItem{{ID: "msg_1", Type: "message", Role: "assistant", Content: []core.ResponsesContentItem{{Type: "output_text", Text: "the word is zebra"}}}},
+		},
+		InputItems: []json.RawMessage{json.RawMessage(`{"id":"in_1","type":"message","role":"user","content":[{"type":"input_text","text":"remember: zebra"}]}`)},
+		Provider:   providerType,
+		UserPath:   userPath,
+	}); err != nil {
+		t.Fatalf("store %s: %v", id, err)
+	}
+}
+
+// A response the gateway minted for a chat-translated provider exists only in
+// the gateway's store, so a native provider rejects the id ("Expected an ID
+// that begins with 'resp'"). The gateway holds the whole turn and replays it
+// instead. An id it does not know is still forwarded, so native chains that
+// started outside the gateway keep working.
+func TestResponsesWithPreviousResponseID_NativeProviderReplaysGatewayMintedChain(t *testing.T) {
+	tests := []struct {
+		name         string
+		providerType string
+		wantItems    int
+		wantID       string
+	}{
+		{name: "translated predecessor is replayed", providerType: "anthropic", wantItems: 3},
+		{name: "native predecessor keeps the id", providerType: "openai", wantID: "resp_stored"},
+		{name: "unknown provider keeps the id", providerType: "", wantID: "resp_stored"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := previousResponseTestProvider(t, "openai")
+			srv := New(provider, nil)
+			storeChainedResponse(t, srv.handler.currentResponseStore(), "resp_stored", tt.providerType, "")
+
+			rec := postResponses(t, srv, `{"model":"gpt-5-mini","input":"what is the word?","previous_response_id":"resp_stored"}`)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d (%s)", rec.Code, rec.Body.String())
+			}
+			forwarded := provider.capturedResponsesReq
+			if forwarded.PreviousResponseID != tt.wantID {
+				t.Fatalf("forwarded previous_response_id = %q, want %q", forwarded.PreviousResponseID, tt.wantID)
+			}
+			if tt.wantItems == 0 {
+				if _, ok := forwarded.Input.(string); !ok {
+					t.Fatalf("native input must be untouched, got %#v", forwarded.Input)
+				}
+				return
+			}
+			items := forwardedInputItems(t, provider.capturingProvider)
+			if len(items) != tt.wantItems {
+				t.Fatalf("forwarded %d items, want %d: %#v", len(items), tt.wantItems, items)
+			}
+			if text, _ := json.Marshal(items[1]["content"]); !strings.Contains(string(text), "the word is zebra") {
+				t.Fatalf("stored output not replayed: %#v", items[1])
+			}
+			if !strings.Contains(rec.Body.String(), `"previous_response_id":"resp_stored"`) {
+				t.Fatalf("chained response must echo previous_response_id: %s", rec.Body.String())
+			}
+		})
+	}
+}
+
+// Another tenant's stored response stays invisible: it is neither replayed
+// nor reported, and the id reaches the provider as any unknown id does.
+func TestResponsesWithPreviousResponseID_ForeignTenantChainIsNotReplayed(t *testing.T) {
+	s := &translatedInferenceService{provider: previousResponseTestProvider(t, "openai"), responseStore: responsestore.NewMemoryStore()}
+	storeChainedResponse(t, s.responseStore, "resp_other", "anthropic", "/tenant-b")
+
+	foreign := core.WithAccessScope(context.Background(), core.AccessScope{UserPath: "/tenant-a"})
+	if s.gatewayOwnedPreviousResponse(foreign, "resp_other") {
+		t.Fatal("a foreign tenant must not reach another tenant's stored chain")
+	}
+	owner := core.WithAccessScope(context.Background(), core.AccessScope{UserPath: "/tenant-b"})
+	if !s.gatewayOwnedPreviousResponse(owner, "resp_other") {
+		t.Fatal("the owning tenant must replay its own gateway-minted chain")
+	}
+}
+
 func TestResponsesWithPreviousResponseID_UnknownIDReturns404(t *testing.T) {
 	provider := previousResponseTestProvider(t, "anthropic")
 	srv := New(provider, nil)

--- a/pluginapi/plugin.go
+++ b/pluginapi/plugin.go
@@ -77,3 +77,15 @@ type CompleteHook interface {
 type HealthChecker interface {
 	Health(ctx context.Context) error
 }
+
+// ContentEditor is implemented by a plugin whose manifest declares Mutates
+// but whose configuration decides whether it actually edits content: a
+// presidio instance that only flags detections, a string_replace instance
+// that only blocks. GoModel asks a configured instance before work it does
+// solely so an editing plugin sees the whole request — replaying the stored
+// history of a chained Responses request instead of letting the provider
+// resolve previous_response_id itself. It never relaxes how a hook runs.
+// A mutating plugin that does not implement it is taken to edit.
+type ContentEditor interface {
+	EditsContent() bool
+}


### PR DESCRIPTION
Three `previous_response_id` problems on chains that reach a native Responses provider (OpenAI).

**Tenant isolation (security).** A native provider resolved a forwarded `previous_response_id` upstream under the gateway's shared provider credential, so a key bound to `/team/delta` could continue — and read back — a conversation created by `/team/alpha`, even though `GET /v1/responses/{id}` 404s the same id for it. The gateway now checks ownership for every attempt that forwards an id: a stored response outside the caller's access scope is reported missing (404, streamed and not), exactly as the lifecycle endpoints report it, while an id the gateway never stored is still forwarded, so chains created directly against the provider keep working.

**Anonymized chains returned the wrong person's data.** A native primary kept the id, so the prompt guardrails never saw the replayed turns and could not reserve their placeholders: turn 1 "My name is Katarzyna Wisniewska" stores `<PERSON_1>`, turn 2 "My colleague is Jan Kowalski. What is MY name?" gave Jan the same placeholder, and the restore step answered "Jan Kowalski". The gateway now expands the stored history before the prompt phase for a native primary too, whenever a content-editing prompt guardrail runs (presidio, string_replace, llm_based_altering, system_prompt) — and drops the id with it, so the provider never replays the same turns twice. Without such a guardrail the id is still forwarded untouched, so OpenAI keeps serving the chain from its own cached state.

**A translated → native chain failed.** Chaining a gemini or anthropic response (whose id the gateway minted) to `openai/gpt-4.1-mini` returned 400 "Invalid 'previous_response_id' ... Expected an ID that begins with 'resp'". The gateway holds that snapshot, so it now replays it for a native provider as well.

Tested: new unit tests in `internal/server/previous_response*_test.go` and `internal/guardrails` (each fails before the change); `go test ./...`, `make lint`. Live against a gateway with presidio prompt+response instances (`restore: true`): the T1/T2 case above now answers "Katarzyna Wisniewska" streamed and buffered (a build without the fix answers "Jan Kowalski"); gemini→openai chains work with and without guardrails; openai→openai without guardrails still forwards the id; native→translated and translated→translated chains are unchanged; with two keys on `/team/alpha` and `/team/delta`, the foreign key now gets 404 on the chain (stream and non-stream) while the owner still gets "March 14" and an unknown id still reaches the provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved `previous_response_id` chaining across translated and native providers.
  * Conversation history is replayed when content-editing guardrails or failover require it.
  * Added safeguards to prevent access to response chains outside the caller’s permitted path.
  * Plugins can now indicate whether they modify request content.

* **Documentation**
  * Expanded guidance on response chaining, ownership enforcement, user paths, and content-editing plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->