### PR TITLE
fix: name provider instances in responses, drop the empty auth-user header, type plugin errors

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -60,6 +60,9 @@ prometheus.yml
 # ===================
 .env
 .env.*
+# Local developer config (gitignored). The image ships config.example.yaml only;
+# runtime config comes from env vars or a mounted file.
+config/config.yaml
 
 # ===================
 # Miscellaneous

--- a/docs/advanced/guardrails.mdx
+++ b/docs/advanced/guardrails.mdx
@@ -700,7 +700,7 @@ endpoints and `stop_reason: "end_turn"` on `/v1/messages`.
 | **block** | An error in the endpoint's native format: HTTP 400 (prompt phase) or 502 (response and stream phases) unless the guardrail sets `block_status`; code `guardrail_blocked` unless the plugin sets its own. |
 | **respond** | An ordinary assistant reply with HTTP 200 (a one-turn stream for streaming requests). |
 | **warn** | The unchanged response plus an `X-GoModel-Guardrail: warn; code=<code>` header; the detail is stored in the audit trail. On a stream the header is sent only when the warn was decided before the first bytes went out (a buffered response); later warns are audit-only. |
-| **guardrail failure** (`fail_mode: closed`) | HTTP 500 with code `plugin_failure`. The guardrail's name is in the logs and audit record, not in the client message. |
+| **guardrail failure** (`fail_mode: closed`) | HTTP 500 with type `internal_error` and code `plugin_failure`. No provider is named, because none was called. The guardrail's name is in the logs and audit record, not in the client message. |
 
 A blocked request never reaches the provider; a blocked response never
 reaches the client. See [Plugins](/advanced/plugins#decisions) for how

--- a/docs/advanced/responses-api.mdx
+++ b/docs/advanced/responses-api.mdx
@@ -30,6 +30,16 @@ providers, see [Responses compatibility](/advanced/responses-compatibility).
 | `POST /v1/responses/input_tokens` | Counts input tokens through the native provider utility endpoint when supported. |
 | `POST /v1/responses/compact` | Compacts a response input through the native provider utility endpoint when supported. |
 
+## Provider attribution
+
+Responses and chat completions carry a `provider` field naming the configured
+provider instance that served the request — its key under `providers` in
+`config.yaml`, not its `type`. Two instances of
+one type stay distinguishable: an instance named `deepseek-eu` of type
+`deepseek` reports `"provider": "deepseek-eu"`. Errors, circuit-breaker
+messages, and the dashboard's workflow chart name the same instance. A
+provider registered without a name reports its type.
+
 ## Stored responses
 
 For `POST /v1/responses` calls, unless the request sets `store: false`,

--- a/internal/core/errors.go
+++ b/internal/core/errors.go
@@ -182,6 +182,19 @@ func NewNoChoicesProviderError(provider string) *GatewayError {
 	return NewProviderError(provider, http.StatusBadGateway, "provider returned no choices", nil)
 }
 
+// NewInternalErrorWithStatus creates an error raised by the gateway itself
+// rather than by an upstream provider. Use it for 5xx failures with no
+// provider behind them, so clients do not read "provider_error" on a fault the
+// gateway owns.
+func NewInternalErrorWithStatus(statusCode int, message string, err error) *GatewayError {
+	return &GatewayError{
+		Type:       ErrorTypeInternal,
+		Message:    message,
+		StatusCode: statusCode,
+		Err:        err,
+	}
+}
+
 // NewRateLimitError creates a new rate limit error (429)
 func NewRateLimitError(provider string, message string) *GatewayError {
 	return &GatewayError{

--- a/internal/gateway/inference_execute.go
+++ b/internal/gateway/inference_execute.go
@@ -345,7 +345,7 @@ func executeTranslatedProviderRequest[Req any, Resp any](
 	call func(context.Context, Req) (Resp, error),
 	responseProvider func(Resp) string,
 ) (Resp, ExecutionMeta, error) {
-	return executeTranslatedWithFailover(ctx, o, workflow, req, model, provider, cloneForSelector,
+	resp, meta, err := executeTranslatedWithFailover(ctx, o, workflow, req, model, provider, cloneForSelector,
 		func(ctx context.Context, req Req) (Resp, string, error) {
 			resp, err := call(ctx, req)
 			if err != nil {
@@ -355,6 +355,36 @@ func executeTranslatedProviderRequest[Req any, Resp any](
 			return resp, responseProvider(resp), nil
 		},
 	)
+	if err != nil {
+		return resp, meta, err
+	}
+	// The provider type drives routing and audit filters, so it is what the
+	// attempt reported above; the client-facing field names the configured
+	// instance that served the request, as errors and breaker messages do.
+	return nameProviderInstance(resp, meta.ProviderName), meta, nil
+}
+
+// nameProviderInstance rewrites the response's public provider field to the
+// configured provider instance name. The router stamps the provider type; an
+// instance name is more precise whenever two instances share a type, and it
+// matches how the gateway names providers everywhere else. A request served
+// without a configured name keeps the type.
+func nameProviderInstance[Resp any](resp Resp, providerName string) Resp {
+	providerName = strings.TrimSpace(providerName)
+	if providerName == "" {
+		return resp
+	}
+	switch typed := any(resp).(type) {
+	case *core.ChatResponse:
+		if typed != nil {
+			typed.Provider = providerName
+		}
+	case *core.ResponsesResponse:
+		if typed != nil {
+			typed.Provider = providerName
+		}
+	}
+	return resp
 }
 
 func streamTranslatedProviderRequest[Req any](

--- a/internal/gateway/inference_orchestrator_test.go
+++ b/internal/gateway/inference_orchestrator_test.go
@@ -120,6 +120,63 @@ func TestExecuteChatCompletionPricesRequestedModelWhenResponseModelIsVersioned(t
 	}
 }
 
+// The response's provider field names the configured instance that served the
+// request, while the execution metadata keeps the provider type that drives
+// routing and audit filters.
+func TestExecuteChatCompletionNamesTheProviderInstance(t *testing.T) {
+	tests := []struct {
+		name         string
+		providerName string
+		wantProvider string
+	}{
+		{name: "configured instance name", providerName: "mockds", wantProvider: "mockds"},
+		{name: "no configured instance name", wantProvider: "deepseek"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &providerTypeResolverStub{
+				chatResponse: &core.ChatResponse{
+					ID:       "chatcmpl-test",
+					Model:    "deepseek-chat",
+					Provider: "deepseek",
+					Choices:  []core.Choice{{FinishReason: "stop"}},
+				},
+			}
+			orchestrator := NewInferenceOrchestrator(InferenceConfig{Provider: provider})
+			workflow := &core.Workflow{
+				ProviderType: "deepseek",
+				Resolution: &core.RequestModelResolution{
+					Requested:        core.NewRequestedModelSelector("deepseek/deepseek-chat", ""),
+					ResolvedSelector: core.ModelSelector{Provider: "deepseek", Model: "deepseek-chat"},
+					ProviderType:     "deepseek",
+					ProviderName:     tt.providerName,
+				},
+			}
+
+			result, err := orchestrator.ExecuteChatCompletion(
+				context.Background(),
+				workflow,
+				&core.ChatRequest{Model: "deepseek/deepseek-chat"},
+				"req-provider-name",
+				"/v1/chat/completions",
+			)
+			if err != nil {
+				t.Fatalf("ExecuteChatCompletion() error = %v", err)
+			}
+			if got := result.Response.Provider; got != tt.wantProvider {
+				t.Errorf("response provider = %q, want %q", got, tt.wantProvider)
+			}
+			if got := result.Meta.ProviderType; got != "deepseek" {
+				t.Errorf("meta provider type = %q, want the type deepseek", got)
+			}
+			if got := result.Meta.ProviderName; got != tt.providerName {
+				t.Errorf("meta provider name = %q, want %q", got, tt.providerName)
+			}
+		})
+	}
+}
+
 func TestInferenceOrchestratorLogUsageSkipsWhenWorkflowDisablesUsage(t *testing.T) {
 	logger := &usageCaptureLogger{config: usage.Config{Enabled: true}}
 	orchestrator := NewInferenceOrchestrator(InferenceConfig{UsageLogger: logger})

--- a/internal/plugins/decision.go
+++ b/internal/plugins/decision.go
@@ -72,7 +72,9 @@ func BlockError(d pluginapi.Decision, defaultStatus int) *core.GatewayError {
 	}
 	var gatewayErr *core.GatewayError
 	if status >= http.StatusInternalServerError {
-		gatewayErr = core.NewProviderError("", status, message, nil)
+		// The decision came from a plugin, not from an upstream provider, so
+		// the error type names the gateway rather than a provider.
+		gatewayErr = core.NewInternalErrorWithStatus(status, message, nil)
 	} else {
 		gatewayErr = core.NewInvalidRequestErrorWithStatus(status, message, nil)
 	}
@@ -83,10 +85,12 @@ func blockStatusOK(status int) bool {
 	return status >= http.StatusBadRequest && status <= 599
 }
 
-// FailureError renders a fail-closed plugin error: HTTP 500 with code
-// plugin_failure. The instance name stays out of the client message.
+// FailureError renders a fail-closed plugin error: HTTP 500 with type
+// internal_error and code plugin_failure. No provider is involved, so the
+// error is attributed to the gateway. The instance name stays out of the
+// client message.
 func FailureError(err error) *core.GatewayError {
-	return core.NewProviderError("", http.StatusInternalServerError, "a request plugin failed", err).WithCode(CodePluginFailure)
+	return core.NewInternalErrorWithStatus(http.StatusInternalServerError, "a request plugin failed", err).WithCode(CodePluginFailure)
 }
 
 // WarnHeaderValue renders the X-GoModel-Guardrail header for a warn decision.

--- a/internal/plugins/run_test.go
+++ b/internal/plugins/run_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/enterpilot/gomodel/internal/core"
 	"github.com/enterpilot/gomodel/pluginapi"
 )
 
@@ -401,5 +402,52 @@ func TestBlockErrorClampsStatus(t *testing.T) {
 	}
 	if got := BlockError(pluginapi.Block(0, "x", "y"), 99); got.HTTPStatusCode() != 400 {
 		t.Errorf("unusable default rendered as %d, want 400", got.HTTPStatusCode())
+	}
+}
+
+// No provider is involved in a plugin decision, so plugin errors must not
+// claim the provider_error type or name a provider.
+func TestPluginErrorsUseInternalErrorType(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      *core.GatewayError
+		wantType core.ErrorType
+		wantCode string
+	}{
+		{
+			name:     "fail closed",
+			err:      FailureError(errFake),
+			wantType: core.ErrorTypeInternal,
+			wantCode: CodePluginFailure,
+		},
+		{
+			name:     "block with a 5xx status",
+			err:      BlockError(pluginapi.Block(0, "", ""), 502),
+			wantType: core.ErrorTypeInternal,
+			wantCode: CodeBlocked,
+		},
+		{
+			name:     "block with a 4xx status",
+			err:      BlockError(pluginapi.Block(0, "", ""), 400),
+			wantType: core.ErrorTypeInvalidRequest,
+			wantCode: CodeBlocked,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.err.Type != tt.wantType {
+				t.Errorf("type = %q, want %q", tt.err.Type, tt.wantType)
+			}
+			if tt.err.Code == nil || *tt.err.Code != tt.wantCode {
+				t.Errorf("code = %v, want %q", tt.err.Code, tt.wantCode)
+			}
+			if tt.err.Provider != "" {
+				t.Errorf("provider = %q, want empty", tt.err.Provider)
+			}
+			if _, ok := tt.err.ToJSON()["error"].(map[string]any)["provider"]; ok {
+				t.Error("rendered error names a provider")
+			}
+		})
 	}
 }

--- a/internal/providers/anthropic/anthropic.go
+++ b/internal/providers/anthropic/anthropic.go
@@ -63,6 +63,10 @@ type Provider struct {
 	// call; providers that reuse the Anthropic dialect behind another
 	// upstream (OpenCode Go) use it for their identification headers.
 	requestHeaders func(context.Context) http.Header
+	// providerName names this provider in the values clients see, such as the
+	// provider field on streamed events: the configured instance name when the
+	// factory supplied one, the provider type otherwise.
+	providerName string
 
 	batchEndpointsMu sync.RWMutex
 	// batchResultEndpoints keeps endpoint hints by provider batch id and custom_id.
@@ -75,9 +79,10 @@ func New(providerCfg providers.ProviderConfig, opts providers.ProviderOptions) c
 	p := &Provider{
 		keys:                 opts.Keyring(providerCfg.APIKey),
 		batchResultEndpoints: make(map[string]map[string]string),
+		providerName:         opts.ClientName("anthropic"),
 	}
 	clientCfg := llmclient.Config{
-		ProviderName:   opts.ClientName("anthropic"),
+		ProviderName:   p.providerName,
 		BaseURL:        providers.ResolveBaseURL(providerCfg.BaseURL, defaultBaseURL),
 		Retry:          opts.Resilience.Retry,
 		Hooks:          opts.Hooks,
@@ -96,11 +101,22 @@ func NewWithHTTPClient(apiKey string, httpClient *http.Client, hooks llmclient.H
 	p := &Provider{
 		keys:                 providers.NewKeyring(apiKey),
 		batchResultEndpoints: make(map[string]map[string]string),
+		providerName:         "anthropic",
 	}
 	cfg := llmclient.DefaultConfig("anthropic", defaultBaseURL)
 	cfg.Hooks = hooks
 	p.client = llmclient.NewWithHTTPClient(httpClient, cfg, p.setHeaders)
 	return p
+}
+
+// responseProviderName names this provider in the values clients see: the
+// configured instance name when the factory supplied one, the provider type
+// otherwise.
+func (p *Provider) responseProviderName() string {
+	if p.providerName != "" {
+		return p.providerName
+	}
+	return "anthropic"
 }
 
 // SetBaseURL allows configuring a custom base URL for the provider

--- a/internal/providers/anthropic/anthropic_test.go
+++ b/internal/providers/anthropic/anthropic_test.go
@@ -41,7 +41,7 @@ func TestNew_ReturnsProvider(t *testing.T) {
 }
 
 func TestStreamConverter_DrainsBufferedDoneMessage(t *testing.T) {
-	stream := newStreamConverter(io.NopCloser(strings.NewReader("")), "claude-sonnet-4-5-20250929")
+	stream := newStreamConverter(io.NopCloser(strings.NewReader("")), "claude-sonnet-4-5-20250929", "anthropic")
 	defer func() { _ = stream.Close() }()
 
 	buf := make([]byte, 4)
@@ -3460,7 +3460,7 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
 		err: io.ErrUnexpectedEOF,
 	}
 
-	converter := newResponsesStreamConverter(reader, "claude-sonnet-4-5-20250929")
+	converter := newResponsesStreamConverter(reader, "claude-sonnet-4-5-20250929", "anthropic")
 	raw, err := io.ReadAll(converter)
 	if err != io.ErrUnexpectedEOF {
 		t.Fatalf("ReadAll() error = %v, want io.ErrUnexpectedEOF surfaced after terminal events", err)
@@ -6348,7 +6348,7 @@ func assertAdaptiveHighEffort(t *testing.T, out *anthropicRequest) {
 // object of every emitted chat chunk.
 func chatStreamDeltas(t *testing.T, anthropicSSE string) []map[string]any {
 	t.Helper()
-	conv := newStreamConverter(io.NopCloser(strings.NewReader(anthropicSSE)), "claude-sonnet-4-5")
+	conv := newStreamConverter(io.NopCloser(strings.NewReader(anthropicSSE)), "claude-sonnet-4-5", "anthropic")
 	defer conv.Close() //nolint:errcheck
 
 	out, err := io.ReadAll(conv)
@@ -6374,6 +6374,66 @@ func chatStreamDeltas(t *testing.T, anthropicSSE string) []map[string]any {
 		}
 	}
 	return deltas
+}
+
+// Streamed events name the configured provider instance, as the buffered
+// response does, so two Anthropic instances stay distinguishable.
+func TestAnthropicStreamsNameTheProviderInstance(t *testing.T) {
+	const sse = "event: message_start\n" +
+		`data: {"type":"message_start","message":{"id":"msg_1","model":"claude-sonnet-4-5","usage":{"input_tokens":1,"output_tokens":0}}}` + "\n\n" +
+		"event: content_block_start\n" +
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}` + "\n\n" +
+		"event: content_block_delta\n" +
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}` + "\n\n" +
+		"event: message_stop\n" +
+		`data: {"type":"message_stop"}` + "\n\n"
+
+	tests := []struct {
+		name         string
+		converter    func() io.ReadCloser
+		wantProvider string
+	}{
+		{
+			name: "chat instance name",
+			converter: func() io.ReadCloser {
+				return newStreamConverter(io.NopCloser(strings.NewReader(sse)), "claude-sonnet-4-5", "anthropic-eu")
+			},
+			wantProvider: "anthropic-eu",
+		},
+		{
+			name: "chat without an instance name",
+			converter: func() io.ReadCloser {
+				return newStreamConverter(io.NopCloser(strings.NewReader(sse)), "claude-sonnet-4-5", "anthropic")
+			},
+			wantProvider: "anthropic",
+		},
+		{
+			name: "responses instance name",
+			converter: func() io.ReadCloser {
+				return newResponsesStreamConverter(io.NopCloser(strings.NewReader(sse)), "claude-sonnet-4-5", "anthropic-eu")
+			},
+			wantProvider: "anthropic-eu",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conv := tt.converter()
+			defer conv.Close() //nolint:errcheck
+
+			out, err := io.ReadAll(conv)
+			if err != nil {
+				t.Fatalf("ReadAll: %v", err)
+			}
+			want := `"provider":"` + tt.wantProvider + `"`
+			if !strings.Contains(string(out), want) {
+				t.Fatalf("stream does not carry %s:\n%s", want, out)
+			}
+			if other := `"provider":"anthropic"`; tt.wantProvider != "anthropic" && strings.Contains(string(out), other) {
+				t.Fatalf("stream still carries the provider type:\n%s", out)
+			}
+		})
+	}
 }
 
 // lastExtraContent returns the last extra_content value seen on a delta, which
@@ -6504,7 +6564,7 @@ data: {"type":"message_stop"}
 // dialect and returns the decoded events.
 func responsesStreamEvents(t *testing.T, anthropicSSE string) []map[string]any {
 	t.Helper()
-	conv := newResponsesStreamConverter(io.NopCloser(strings.NewReader(anthropicSSE)), "claude-sonnet-4-5")
+	conv := newResponsesStreamConverter(io.NopCloser(strings.NewReader(anthropicSSE)), "claude-sonnet-4-5", "anthropic")
 	defer conv.Close() //nolint:errcheck
 
 	out, err := io.ReadAll(conv)
@@ -6907,7 +6967,7 @@ event: message_stop
 data: {"type":"message_stop"}
 
 `
-	converter := newResponsesStreamConverter(io.NopCloser(strings.NewReader(stream)), "claude-sonnet-4-5-20250929")
+	converter := newResponsesStreamConverter(io.NopCloser(strings.NewReader(stream)), "claude-sonnet-4-5-20250929", "anthropic")
 	raw, err := io.ReadAll(converter)
 	if err != nil {
 		t.Fatalf("failed to read from converter: %v", err)
@@ -7006,7 +7066,7 @@ event: message_stop
 data: {"type":"message_stop"}
 
 `
-	converter := newResponsesStreamConverter(io.NopCloser(strings.NewReader(stream)), "claude-sonnet-4-5-20250929")
+	converter := newResponsesStreamConverter(io.NopCloser(strings.NewReader(stream)), "claude-sonnet-4-5-20250929", "anthropic")
 	raw, err := io.ReadAll(converter)
 	if err != nil {
 		t.Fatalf("failed to read from converter: %v", err)
@@ -7039,7 +7099,7 @@ data: {"type":"message_stop"}
 // response.created and response.in_progress before response.incomplete, so
 // stream helpers that snapshot the created response can finish cleanly.
 func TestStreamResponses_CutBeforeMessageStartStillOpens(t *testing.T) {
-	converter := newResponsesStreamConverter(io.NopCloser(strings.NewReader("")), "claude-sonnet-4-5-20250929")
+	converter := newResponsesStreamConverter(io.NopCloser(strings.NewReader("")), "claude-sonnet-4-5-20250929", "anthropic")
 	raw, err := io.ReadAll(converter)
 	if err != nil {
 		t.Fatalf("failed to read from converter: %v", err)

--- a/internal/providers/anthropic/chat_stream.go
+++ b/internal/providers/anthropic/chat_stream.go
@@ -14,27 +14,33 @@ import (
 	"github.com/enterpilot/gomodel/internal/streaming"
 )
 
+// openMessagesStream sends an already-converted Anthropic request to /messages
+// in streaming mode and returns the upstream SSE body; both the chat and the
+// Responses dialect wrap it in their own converter.
+func (p *Provider) openMessagesStream(ctx context.Context, anthropicReq *anthropicRequest, model string) (io.ReadCloser, error) {
+	anthropicReq.Stream = true
+	return p.client.DoStream(ctx, llmclient.Request{
+		Method:    http.MethodPost,
+		Endpoint:  "/messages",
+		Operation: llmclient.OperationChat,
+		Model:     model,
+		Body:      anthropicReq,
+	})
+}
+
 // StreamChatCompletion returns a raw response body for streaming (caller must close)
 func (p *Provider) StreamChatCompletion(ctx context.Context, req *core.ChatRequest) (io.ReadCloser, error) {
 	anthropicReq, err := convertToAnthropicRequest(req)
 	if err != nil {
 		return nil, err
 	}
-	anthropicReq.Stream = true
-
-	stream, err := p.client.DoStream(ctx, llmclient.Request{
-		Method:    http.MethodPost,
-		Endpoint:  "/messages",
-		Operation: llmclient.OperationChat,
-		Model:     req.Model,
-		Body:      anthropicReq,
-	})
+	stream, err := p.openMessagesStream(ctx, anthropicReq, req.Model)
 	if err != nil {
 		return nil, err
 	}
 
 	// Return a reader that converts Anthropic SSE format to OpenAI format
-	return newStreamConverter(stream, req.Model), nil
+	return newStreamConverter(stream, req.Model, p.responseProviderName()), nil
 }
 
 // streamConverter wraps an Anthropic stream and converts it to OpenAI format
@@ -42,6 +48,7 @@ type streamConverter struct {
 	reader            *bufio.Reader
 	body              io.ReadCloser
 	model             string
+	providerName      string
 	msgID             string
 	created           int64
 	nextToolCallIndex int
@@ -65,15 +72,16 @@ type streamToolCallState struct {
 	PlaceholderObject bool
 }
 
-func newStreamConverter(body io.ReadCloser, model string) *streamConverter {
+func newStreamConverter(body io.ReadCloser, model, providerName string) *streamConverter {
 	return &streamConverter{
-		reader:    bufio.NewReader(body),
-		body:      body,
-		model:     model,
-		created:   time.Now().Unix(),
-		toolCalls: make(map[int]*streamToolCallState),
-		thinking:  newThinkingReplayState(),
-		buffer:    streaming.NewStreamBuffer(1024),
+		reader:       bufio.NewReader(body),
+		body:         body,
+		model:        model,
+		providerName: providerName,
+		created:      time.Now().Unix(),
+		toolCalls:    make(map[int]*streamToolCallState),
+		thinking:     newThinkingReplayState(),
+		buffer:       streaming.NewStreamBuffer(1024),
 	}
 }
 
@@ -157,7 +165,7 @@ func (sc *streamConverter) mapStreamStopReason(reason string) string {
 }
 
 func (sc *streamConverter) formatChatChunk(delta map[string]any, finishReason any, usage *anthropicUsage) string {
-	return providers.FormatChatChunkSSE(sc.msgID, sc.created, sc.model, "anthropic", delta, finishReason, anthropicChatUsagePayload(usage))
+	return providers.FormatChatChunkSSE(sc.msgID, sc.created, sc.model, sc.providerName, delta, finishReason, anthropicChatUsagePayload(usage))
 }
 
 func (sc *streamConverter) convertEvent(event *anthropicStreamEvent) string {

--- a/internal/providers/anthropic/responses.go
+++ b/internal/providers/anthropic/responses.go
@@ -108,21 +108,13 @@ func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesReque
 	if err != nil {
 		return nil, err
 	}
-	anthropicReq.Stream = true
-
-	stream, err := p.client.DoStream(ctx, llmclient.Request{
-		Method:    http.MethodPost,
-		Endpoint:  "/messages",
-		Operation: llmclient.OperationChat,
-		Model:     req.Model,
-		Body:      anthropicReq,
-	})
+	stream, err := p.openMessagesStream(ctx, anthropicReq, req.Model)
 	if err != nil {
 		return nil, err
 	}
 
 	// Return a reader that converts Anthropic SSE format to Responses API format
-	return newResponsesStreamConverter(stream, req.Model), nil
+	return newResponsesStreamConverter(stream, req.Model, p.responseProviderName()), nil
 }
 
 // responsesStreamConverter wraps an Anthropic stream and converts it to Responses API format
@@ -130,6 +122,7 @@ type responsesStreamConverter struct {
 	reader               *bufio.Reader
 	body                 io.ReadCloser
 	model                string
+	providerName         string
 	responseID           string
 	createdAt            int64
 	output               *providers.ResponsesOutputEventState
@@ -148,18 +141,19 @@ type responsesStreamConverter struct {
 	hasUsage             bool
 }
 
-func newResponsesStreamConverter(body io.ReadCloser, model string) *responsesStreamConverter {
+func newResponsesStreamConverter(body io.ReadCloser, model, providerName string) *responsesStreamConverter {
 	responseID := "resp_" + uuid.New().String()
 	return &responsesStreamConverter{
-		reader:     bufio.NewReader(body),
-		body:       body,
-		model:      model,
-		responseID: responseID,
-		createdAt:  time.Now().Unix(),
-		output:     providers.NewResponsesOutputEventState(responseID),
-		toolCalls:  make(map[int]*providers.ResponsesOutputToolCallState),
-		thinking:   newThinkingReplayState(),
-		buffer:     streaming.NewStreamBuffer(1024),
+		reader:       bufio.NewReader(body),
+		body:         body,
+		model:        model,
+		providerName: providerName,
+		responseID:   responseID,
+		createdAt:    time.Now().Unix(),
+		output:       providers.NewResponsesOutputEventState(responseID),
+		toolCalls:    make(map[int]*providers.ResponsesOutputToolCallState),
+		thinking:     newThinkingReplayState(),
+		buffer:       streaming.NewStreamBuffer(1024),
 	}
 }
 
@@ -293,7 +287,7 @@ func (sc *responsesStreamConverter) appendTerminalEvents() {
 		"object":     "response",
 		"status":     status,
 		"model":      sc.model,
-		"provider":   "anthropic",
+		"provider":   sc.providerName,
 		"created_at": sc.createdAt,
 		"output":     sc.output.FinalOutputItems(sc.reasoningOutputIndex, sc.assistantOutputIndex, sc.toolCalls, true),
 	}
@@ -320,7 +314,7 @@ func (sc *responsesStreamConverter) startResponse() string {
 		"object":     "response",
 		"status":     "in_progress",
 		"model":      sc.model,
-		"provider":   "anthropic",
+		"provider":   sc.providerName,
 		"created_at": sc.createdAt,
 	})
 }

--- a/internal/providers/bailian/bailian.go
+++ b/internal/providers/bailian/bailian.go
@@ -103,12 +103,12 @@ func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error)
 
 // Responses sends a Responses API request translated through chat completions.
 func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
-	return providers.ResponsesViaChat(ctx, p, req, "bailian")
+	return providers.ResponsesViaChat(ctx, p, req, p.compatible.ProviderName())
 }
 
 // StreamResponses streams a Responses API request translated through chat completions.
 func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
-	return providers.StreamResponsesViaChat(ctx, p, req, "bailian")
+	return providers.StreamResponsesViaChat(ctx, p, req, p.compatible.ProviderName())
 }
 
 // Embeddings sends an embedding request to Bailian's compatible-mode API.

--- a/internal/providers/bedrock/bedrock.go
+++ b/internal/providers/bedrock/bedrock.go
@@ -57,6 +57,20 @@ type Provider struct {
 	control   *bedrock.Client
 	hooks     llmclient.Hooks
 	configErr error
+	// instanceName is the configured provider instance name when the factory
+	// supplied one, the provider type otherwise. It names the provider in the
+	// values clients see.
+	instanceName string
+}
+
+// responseProviderName names this provider in the values clients see: the
+// configured instance name when the factory supplied one, the provider type
+// otherwise.
+func (p *Provider) responseProviderName() string {
+	if p.instanceName != "" {
+		return p.instanceName
+	}
+	return providerName
 }
 
 // New constructs a Bedrock provider from the resolved configuration.
@@ -65,7 +79,7 @@ type Provider struct {
 // qualified endpoint URL. When empty, the region is resolved from the
 // standard AWS environment variables / shared config.
 func New(providerCfg providers.ProviderConfig, opts providers.ProviderOptions) core.Provider {
-	p := &Provider{hooks: opts.Hooks}
+	p := &Provider{hooks: opts.Hooks, instanceName: opts.ClientName(providerName)}
 
 	region, endpoint := parseBaseURL(providerCfg.BaseURL)
 	loadOpts := []func(*awsconfig.LoadOptions) error{}
@@ -235,7 +249,7 @@ func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*
 	if err := p.ready(); err != nil {
 		return nil, err
 	}
-	return providers.ResponsesViaChat(ctx, p, req, providerName)
+	return providers.ResponsesViaChat(ctx, p, req, p.responseProviderName())
 }
 
 // StreamResponses adapts the streaming Responses API onto Converse via the
@@ -244,7 +258,7 @@ func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesReque
 	if err := p.ready(); err != nil {
 		return nil, err
 	}
-	return providers.StreamResponsesViaChat(ctx, p, req, providerName)
+	return providers.StreamResponsesViaChat(ctx, p, req, p.responseProviderName())
 }
 
 // mapAWSError converts an AWS SDK error into a gateway error preserving HTTP

--- a/internal/providers/bedrock/bedrock_test.go
+++ b/internal/providers/bedrock/bedrock_test.go
@@ -712,7 +712,7 @@ func TestRegistration(t *testing.T) {
 }
 
 func TestStreamConverter_FormatChunkContent(t *testing.T) {
-	sc := newOpenAIStream(nil, "test-model")
+	sc := newOpenAIStream(nil, "test-model", providerName)
 	chunk := sc.formatChunk(map[string]any{"content": "Hi"}, nil, nil)
 	if !strings.HasPrefix(chunk, "data: ") || !strings.HasSuffix(chunk, "\n\n") {
 		t.Fatalf("malformed SSE framing: %q", chunk)
@@ -746,7 +746,7 @@ func TestStreamConverter_FormatChunkContent(t *testing.T) {
 // does not emit a finish chunk; the chunk is emitted on metadata and carries
 // both finish_reason and usage so include_usage callers see token counts.
 func TestStreamConverter_DeferredFinishWithUsage(t *testing.T) {
-	sc := newOpenAIStream(nil, "test-model")
+	sc := newOpenAIStream(nil, "test-model", providerName)
 
 	sc.handleEvent(&brtypes.ConverseStreamOutputMemberMessageStop{
 		Value: brtypes.MessageStopEvent{StopReason: brtypes.StopReasonEndTurn},
@@ -794,7 +794,7 @@ func TestStreamConverter_DeferredFinishWithUsage(t *testing.T) {
 // emit a finish chunk if the stream closes before a metadata event — usage
 // is absent in that case but finish_reason must not be swallowed.
 func TestStreamConverter_DeferredFinishWithoutMetadata(t *testing.T) {
-	sc := newOpenAIStream(nil, "test-model")
+	sc := newOpenAIStream(nil, "test-model", providerName)
 	sc.handleEvent(&brtypes.ConverseStreamOutputMemberMessageStop{
 		Value: brtypes.MessageStopEvent{StopReason: brtypes.StopReasonMaxTokens},
 	})
@@ -820,7 +820,7 @@ func TestStreamConverter_DeferredFinishWithoutMetadata(t *testing.T) {
 }
 
 func TestStreamConverter_FormatChunkUsage(t *testing.T) {
-	sc := newOpenAIStream(nil, "test-model")
+	sc := newOpenAIStream(nil, "test-model", providerName)
 	chunk := sc.formatChunk(map[string]any{}, "stop", &brtypes.TokenUsage{
 		InputTokens:  awssdk.Int32(3),
 		OutputTokens: awssdk.Int32(7),
@@ -909,7 +909,7 @@ func TestStreamConverter_FormatChunkForwardsCacheUsage(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			sc := newOpenAIStream(nil, "test-model")
+			sc := newOpenAIStream(nil, "test-model", providerName)
 			chunk := sc.formatChunk(map[string]any{}, "stop", &brtypes.TokenUsage{
 				InputTokens:           awssdk.Int32(3),
 				OutputTokens:          awssdk.Int32(7),

--- a/internal/providers/bedrock/chat_stream.go
+++ b/internal/providers/bedrock/chat_stream.go
@@ -44,7 +44,7 @@ func (p *Provider) StreamChatCompletion(ctx context.Context, req *core.ChatReque
 	}
 	observation.end(http.StatusOK, nil)
 
-	return observedStream(newOpenAIStream(out, req.Model), observation), nil
+	return observedStream(newOpenAIStream(out, req.Model, p.responseProviderName()), observation), nil
 }
 
 func converseStreamInput(parts converseParts) *bedrockruntime.ConverseStreamInput {
@@ -65,13 +65,14 @@ func converseStreamInput(parts converseParts) *bedrockruntime.ConverseStreamInpu
 // the metadata arrives (so we can include usage) or the event stream closes
 // (so we emit a finish chunk without usage rather than swallow it).
 type streamConverter struct {
-	stream    *bedrockruntime.ConverseStreamOutput
-	model     string
-	id        string
-	created   int64
-	closeOnce sync.Once
-	buf       []byte
-	done      bool
+	stream       *bedrockruntime.ConverseStreamOutput
+	model        string
+	providerName string
+	id           string
+	created      int64
+	closeOnce    sync.Once
+	buf          []byte
+	done         bool
 
 	// per-block tool-use accumulators keyed by content_block index.
 	toolByIndex map[int32]*toolStreamState
@@ -91,14 +92,15 @@ type toolStreamState struct {
 	name        string
 }
 
-func newOpenAIStream(out *bedrockruntime.ConverseStreamOutput, model string) *streamConverter {
+func newOpenAIStream(out *bedrockruntime.ConverseStreamOutput, model, providerName string) *streamConverter {
 	now := time.Now()
 	return &streamConverter{
-		stream:      out,
-		model:       model,
-		id:          "bedrock-" + strconv.FormatInt(now.UnixNano(), 10),
-		created:     now.Unix(),
-		toolByIndex: make(map[int32]*toolStreamState),
+		stream:       out,
+		model:        model,
+		providerName: providerName,
+		id:           "bedrock-" + strconv.FormatInt(now.UnixNano(), 10),
+		created:      now.Unix(),
+		toolByIndex:  make(map[int32]*toolStreamState),
 	}
 }
 
@@ -263,7 +265,7 @@ func (s *streamConverter) formatChunk(delta map[string]any, finishReason any, us
 			usagePayload["cache_creation_input_tokens"] = int(awssdk.ToInt32(usage.CacheWriteInputTokens))
 		}
 	}
-	return providers.FormatChatChunkSSE(s.id, s.created, s.model, providerName, delta, finishReason, usagePayload)
+	return providers.FormatChatChunkSSE(s.id, s.created, s.model, s.providerName, delta, finishReason, usagePayload)
 }
 
 var _ io.ReadCloser = (*streamConverter)(nil)

--- a/internal/providers/chutes/chutes.go
+++ b/internal/providers/chutes/chutes.go
@@ -79,12 +79,12 @@ func (p *Provider) StreamChatCompletion(ctx context.Context, req *core.ChatReque
 
 // Responses translates an OpenAI Responses request through Chutes chat completions.
 func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
-	return providers.ResponsesViaChat(ctx, p, req, "chutes")
+	return providers.ResponsesViaChat(ctx, p, req, p.compat.ProviderName())
 }
 
 // StreamResponses translates a streaming Responses request through Chutes chat completions.
 func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
-	return providers.StreamResponsesViaChat(ctx, p, req, "chutes")
+	return providers.StreamResponsesViaChat(ctx, p, req, p.compat.ProviderName())
 }
 
 // Embeddings returns an error because the shared Chutes LLM endpoint does not

--- a/internal/providers/cohere/cohere.go
+++ b/internal/providers/cohere/cohere.go
@@ -28,6 +28,9 @@ var Registration = providers.Registration{
 type Provider struct {
 	client *llmclient.Client
 	keys   *providers.Keyring
+	// providerName is the configured instance name when the factory supplied
+	// one, the provider type otherwise.
+	providerName string
 }
 
 var _ core.Provider = (*Provider)(nil)
@@ -36,9 +39,9 @@ var _ core.PassthroughProvider = (*Provider)(nil)
 
 // New creates a Cohere provider using the shared resilience and observability settings.
 func New(cfg providers.ProviderConfig, opts providers.ProviderOptions) core.Provider {
-	p := &Provider{keys: opts.Keyring(cfg.APIKey)}
+	p := &Provider{keys: opts.Keyring(cfg.APIKey), providerName: opts.ClientName("cohere")}
 	clientCfg := llmclient.Config{
-		ProviderName:   opts.ClientName("cohere"),
+		ProviderName:   p.providerName,
 		BaseURL:        providers.ResolveBaseURL(cfg.BaseURL, defaultBaseURL),
 		Retry:          opts.Resilience.Retry,
 		Hooks:          opts.Hooks,
@@ -53,7 +56,7 @@ func NewWithHTTPClient(apiKey, baseURL string, httpClient *http.Client, hooks ll
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
-	p := &Provider{keys: providers.NewKeyring(apiKey)}
+	p := &Provider{keys: providers.NewKeyring(apiKey), providerName: "cohere"}
 	cfg := llmclient.DefaultConfig("cohere", providers.ResolveBaseURL(baseURL, defaultBaseURL))
 	cfg.Hooks = hooks
 	p.client = llmclient.NewWithHTTPClient(httpClient, cfg, p.setHeaders)
@@ -151,12 +154,12 @@ func supportedModel(model modelInfo) bool {
 
 // Responses translates the OpenAI Responses API through Cohere chat.
 func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
-	return providers.ResponsesViaChat(ctx, p, req, "cohere")
+	return providers.ResponsesViaChat(ctx, p, req, p.providerName)
 }
 
 // StreamResponses translates a streaming OpenAI Responses request through Cohere chat.
 func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
-	return providers.StreamResponsesViaChat(ctx, p, req, "cohere")
+	return providers.StreamResponsesViaChat(ctx, p, req, p.providerName)
 }
 
 // Passthrough forwards a Cohere-native request without typed translation.

--- a/internal/providers/gemini/gemini.go
+++ b/internal/providers/gemini/gemini.go
@@ -74,6 +74,9 @@ type Provider struct {
 	keys         *providers.Keyring
 	backend      string
 	authType     string
+	// providerName is the configured instance name when the factory supplied
+	// one; empty for constructors invoked outside the factory.
+	providerName string
 	useNativeAPI bool
 	modelsURL    string
 	configErr    error
@@ -116,8 +119,9 @@ func newProvider(providerCfg providers.ProviderConfig, opts providers.ProviderOp
 	if backend == geminiBackendVertex {
 		clientProviderName = "vertex"
 	}
+	p.providerName = opts.ClientName(clientProviderName)
 	clientCfg := llmclient.Config{
-		ProviderName:   opts.ClientName(clientProviderName),
+		ProviderName:   p.providerName,
 		BaseURL:        baseURL,
 		Retry:          opts.Resilience.Retry,
 		Hooks:          opts.Hooks,
@@ -244,7 +248,13 @@ func (p *Provider) ready() error {
 	return core.NewProviderError(p.responseProviderName(), http.StatusBadGateway, "invalid Gemini provider configuration: "+p.configErr.Error(), p.configErr)
 }
 
+// responseProviderName names this provider in the values clients see: the
+// configured instance name when the factory supplied one, the provider type
+// otherwise.
 func (p *Provider) responseProviderName() string {
+	if p.providerName != "" {
+		return p.providerName
+	}
 	if p.backend == geminiBackendVertex {
 		return "vertex"
 	}

--- a/internal/providers/groq/groq.go
+++ b/internal/providers/groq/groq.go
@@ -97,12 +97,12 @@ func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error)
 
 // Responses sends a Responses API request to Groq (converted to chat format)
 func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
-	return providers.ResponsesViaChat(ctx, p, req, "groq")
+	return providers.ResponsesViaChat(ctx, p, req, p.compat.ProviderName())
 }
 
 // StreamResponses returns a raw response body for streaming Responses API (caller must close)
 func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
-	return providers.StreamResponsesViaChat(ctx, p, req, "groq")
+	return providers.StreamResponsesViaChat(ctx, p, req, p.compat.ProviderName())
 }
 
 // Embeddings sends an embeddings request to Groq

--- a/internal/providers/minimax/minimax.go
+++ b/internal/providers/minimax/minimax.go
@@ -76,11 +76,11 @@ func (p *Provider) StreamChatCompletion(ctx context.Context, req *core.ChatReque
 // Responses sends a Responses API request to MiniMax using chat-completions
 // translation, dispatched through the clamped ChatCompletion above.
 func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
-	return providers.ResponsesViaChat(ctx, p, req, "minimax")
+	return providers.ResponsesViaChat(ctx, p, req, p.ProviderName())
 }
 
 // StreamResponses streams a Responses API request to MiniMax using
 // chat-completions translation, dispatched through the clamped streaming above.
 func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
-	return providers.StreamResponsesViaChat(ctx, p, req, "minimax")
+	return providers.StreamResponsesViaChat(ctx, p, req, p.ProviderName())
 }

--- a/internal/providers/ollama/ollama.go
+++ b/internal/providers/ollama/ollama.go
@@ -191,12 +191,12 @@ func (p *Provider) ListModels(ctx context.Context) (*core.ModelsResponse, error)
 
 // Responses sends a Responses API request to Ollama (converted to chat format)
 func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
-	return providers.ResponsesViaChat(ctx, p, req, "ollama")
+	return providers.ResponsesViaChat(ctx, p, req, p.compat.ProviderName())
 }
 
 // StreamResponses returns a raw response body for streaming Responses API (caller must close)
 func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
-	return providers.StreamResponsesViaChat(ctx, p, req, "ollama")
+	return providers.StreamResponsesViaChat(ctx, p, req, p.compat.ProviderName())
 }
 
 type ollamaEmbedRequest struct {

--- a/internal/providers/openai/chat_compatible.go
+++ b/internal/providers/openai/chat_compatible.go
@@ -23,7 +23,10 @@ import (
 // (re-calling providers.ResponsesViaChat with itself) for the translation to
 // pick up the override.
 type ChatCompatible struct {
-	compatible   *CompatibleProvider
+	compatible *CompatibleProvider
+	// providerName names the provider in translated Responses output and in
+	// the errors that translation raises: the configured instance name when
+	// the factory supplied one, the provider type otherwise.
 	providerName string
 }
 
@@ -33,7 +36,7 @@ func NewChatCompatible(apiKey string, opts providers.ProviderOptions, cfg Compat
 	applyChatCompatibleDefaults(&cfg)
 	return &ChatCompatible{
 		compatible:   NewCompatibleProvider(apiKey, opts, cfg),
-		providerName: cfg.ProviderName,
+		providerName: opts.ClientName(cfg.ProviderName),
 	}
 }
 
@@ -55,6 +58,12 @@ func applyChatCompatibleDefaults(cfg *CompatibleProviderConfig) {
 
 func bearerHeaders(req *http.Request, apiKey string) {
 	providers.SetAuthHeaders(req, apiKey, providers.AuthHeaderConfig{AuthScheme: "Bearer "})
+}
+
+// ProviderName returns the name this provider reports to clients: the
+// configured instance name when there is one, the provider type otherwise.
+func (c *ChatCompatible) ProviderName() string {
+	return c.providerName
 }
 
 // SetBaseURL allows configuring a custom base URL for the provider.

--- a/internal/providers/openai/compatible_provider.go
+++ b/internal/providers/openai/compatible_provider.go
@@ -228,6 +228,10 @@ func (p *CompatibleProvider) StreamChatCompletion(ctx context.Context, req *core
 	if err != nil {
 		return nil, err
 	}
+	// Chat SSE is relayed byte for byte: the chunk payloads are the upstream's
+	// own, so the instance naming this package applies covers only the
+	// provider field GoModel authors. An upstream that self-reports a
+	// "provider" member in its chunks (OpenRouter-style) keeps its value.
 	return providers.EnsureChatCompletionSSE(stream), nil
 }
 

--- a/internal/providers/openai/compatible_provider.go
+++ b/internal/providers/openai/compatible_provider.go
@@ -71,7 +71,12 @@ type CompatibleProvider struct {
 	// keys resolves the credential for each outbound request. Providers in this
 	// package read it directly (see realtime.go) so a websocket dial picks up
 	// the same rotation as the HTTP endpoints.
-	keys               *providers.Keyring
+	keys *providers.Keyring
+	// providerName names this provider in the values clients see — the
+	// response's provider field, file objects, translation errors. It is the
+	// configured instance name when the factory supplied one (so two
+	// instances of one type stay distinguishable), the provider type
+	// otherwise.
 	providerName       string
 	requestMutator     RequestMutator
 	adaptChatRequest   func(*core.ChatRequest) (*core.ChatRequest, error)
@@ -81,7 +86,7 @@ type CompatibleProvider struct {
 func NewCompatibleProvider(apiKey string, opts providers.ProviderOptions, cfg CompatibleProviderConfig) *CompatibleProvider {
 	p := &CompatibleProvider{
 		keys:               opts.Keyring(apiKey),
-		providerName:       cfg.ProviderName,
+		providerName:       opts.ClientName(cfg.ProviderName),
 		requestMutator:     cfg.RequestMutator,
 		adaptChatRequest:   cfg.AdaptChatRequest,
 		chatRequestHeaders: cfg.ChatRequestHeaders,
@@ -131,6 +136,14 @@ func NewCompatibleProviderWithHTTPClient(apiKey string, httpClient *http.Client,
 
 func (p *CompatibleProvider) SetBaseURL(url string) {
 	p.client.SetBaseURL(url)
+}
+
+// ProviderName returns the name this provider reports to clients: the
+// configured instance name when there is one, the provider type otherwise.
+// Providers that translate the Responses API themselves pass it on, so their
+// responses name the same instance the errors do.
+func (p *CompatibleProvider) ProviderName() string {
+	return p.providerName
 }
 
 // GetBaseURL returns the provider's current base URL. It reads from the client so

--- a/internal/providers/openai/openai_test.go
+++ b/internal/providers/openai/openai_test.go
@@ -2230,3 +2230,31 @@ func TestNew_AttributesErrorsToInstanceName(t *testing.T) {
 		t.Fatalf("error provider = %q, want the instance name openai-eu", gwErr.Provider)
 	}
 }
+
+// The provider name clients see (the response's provider field, translated
+// Responses output, file objects) is the configured instance name, so two
+// instances of one provider type stay distinguishable.
+func TestCompatibleProviders_ReportInstanceName(t *testing.T) {
+	cfg := CompatibleProviderConfig{ProviderName: "deepseek", BaseURL: "https://example.invalid"}
+
+	tests := []struct {
+		name string
+		opts providers.ProviderOptions
+		want string
+	}{
+		{name: "configured instance name", opts: providers.ProviderOptions{Name: "mockds"}, want: "mockds"},
+		{name: "blank instance name falls back to the type", opts: providers.ProviderOptions{Name: "   "}, want: "deepseek"},
+		{name: "no factory options", want: "deepseek"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewCompatibleProvider("k", tt.opts, cfg).ProviderName(); got != tt.want {
+				t.Errorf("CompatibleProvider.ProviderName() = %q, want %q", got, tt.want)
+			}
+			if got := NewChatCompatible("k", tt.opts, cfg).ProviderName(); got != tt.want {
+				t.Errorf("ChatCompatible.ProviderName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/providers/opencodego/opencodego.go
+++ b/internal/providers/opencodego/opencodego.go
@@ -170,13 +170,13 @@ func (p *Provider) StreamChatCompletion(ctx context.Context, req *core.ChatReque
 // Responses dispatches through this provider's ChatCompletion so /v1/responses
 // honors the per-model /messages routing.
 func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*core.ResponsesResponse, error) {
-	return providers.ResponsesViaChat(ctx, p, req, "opencode_go")
+	return providers.ResponsesViaChat(ctx, p, req, p.ProviderName())
 }
 
 // StreamResponses dispatches through this provider's streaming ChatCompletion so
 // /v1/responses honors the per-model /messages routing.
 func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesRequest) (io.ReadCloser, error) {
-	return providers.StreamResponsesViaChat(ctx, p, req, "opencode_go")
+	return providers.StreamResponsesViaChat(ctx, p, req, p.ProviderName())
 }
 
 // Passthrough forwards an opaque request with the identification headers

--- a/internal/providers/vertex/vertex.go
+++ b/internal/providers/vertex/vertex.go
@@ -55,6 +55,9 @@ type Provider struct {
 	gemini       *gemini.Provider
 	nativeClient *llmclient.Client
 	authType     string
+	// providerName is the configured instance name when the factory supplied
+	// one, the provider type otherwise.
+	providerName string
 	configErr    error
 }
 
@@ -66,7 +69,8 @@ func New(providerCfg providers.ProviderConfig, opts providers.ProviderOptions) c
 func newProvider(providerCfg providers.ProviderConfig, opts providers.ProviderOptions, baseHTTPClient *http.Client) *Provider {
 	providerCfg.Backend = "vertex"
 	p := &Provider{
-		authType: normalizeAuthType(providerCfg),
+		authType:     normalizeAuthType(providerCfg),
+		providerName: opts.ClientName("vertex"),
 	}
 	p.validateConfig(providerCfg)
 
@@ -77,7 +81,7 @@ func newProvider(providerCfg providers.ProviderConfig, opts providers.ProviderOp
 	p.gemini = gemini.NewVertexWithHTTPClient(providerCfg, opts, authClient)
 	nativeBaseURL := vertexNativeBaseURL(providerCfg)
 	nativeCfg := llmclient.Config{
-		ProviderName:   opts.ClientName("vertex"),
+		ProviderName:   p.providerName,
 		BaseURL:        nativeBaseURL,
 		Retry:          opts.Resilience.Retry,
 		Hooks:          opts.Hooks,
@@ -223,7 +227,7 @@ func (p *Provider) Responses(ctx context.Context, req *core.ResponsesRequest) (*
 	if err := p.ready(); err != nil {
 		return nil, err
 	}
-	return providers.ResponsesViaChat(ctx, p, req, "vertex")
+	return providers.ResponsesViaChat(ctx, p, req, p.providerName)
 }
 
 // StreamResponses returns a raw response body for streaming Responses API.
@@ -231,7 +235,7 @@ func (p *Provider) StreamResponses(ctx context.Context, req *core.ResponsesReque
 	if err := p.ready(); err != nil {
 		return nil, err
 	}
-	return providers.StreamResponsesViaChat(ctx, p, req, "vertex")
+	return providers.StreamResponsesViaChat(ctx, p, req, p.providerName)
 }
 
 // Embeddings sends an embedding request through Vertex AI native prediction.

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -301,11 +301,22 @@ func applyAuthKeyResult(c *echo.Context, authResult authkeys.AuthenticationResul
 	auditlog.EnrichEntryWithAuthKeyID(c, authResult.ID)
 }
 
+// setAuthenticationUserHeader publishes the authenticated identity's user path
+// on the response. An empty path means the request has no identity to report,
+// so the header is removed rather than sent empty: that both keeps the header
+// off responses that never had a user path and hides an identity installed by
+// outer middleware.
 func setAuthenticationUserHeader(c *echo.Context, userPath string) {
 	if c == nil {
 		return
 	}
-	c.Response().Header().Set(ext.AuthenticationUserHeader, strings.TrimSpace(userPath))
+	header := c.Response().Header()
+	trimmed := strings.TrimSpace(userPath)
+	if trimmed == "" {
+		header.Del(ext.AuthenticationUserHeader)
+		return
+	}
+	header.Set(ext.AuthenticationUserHeader, trimmed)
 }
 
 func authFailureMessage(err error) string {

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -467,8 +467,71 @@ func TestAuthMiddlewareExplicitBearerPrecedesRequestAuthenticator(t *testing.T) 
 	rec.Header().Set(ext.AuthenticationUserHeader, "/users/sso")
 	require.NoError(t, handler(e.NewContext(req, rec)))
 	assert.Equal(t, http.StatusNoContent, rec.Code)
-	assert.Empty(t, rec.Header().Get(ext.AuthenticationUserHeader))
+	assert.Empty(t, rec.Header().Values(ext.AuthenticationUserHeader))
 	assert.Zero(t, requestAuth.calls)
+}
+
+// An identity-less request must not advertise an empty user path: the header is
+// omitted entirely rather than sent with a blank value.
+func TestAuthMiddlewareOmitsEmptyAuthenticationUserHeader(t *testing.T) {
+	tests := []struct {
+		name          string
+		masterKey     string
+		authenticator BearerTokenAuthenticator
+		token         string
+		wantHeader    string
+	}{
+		{name: "master key", masterKey: "master", token: "master"},
+		{
+			name: "managed key without user path",
+			authenticator: mockAuthenticator{
+				enabled:   true,
+				tokenToID: map[string]string{"managed": "key-1"},
+			},
+			token: "managed",
+		},
+		{
+			name: "managed key with blank user path",
+			authenticator: mockAuthenticator{
+				enabled:   true,
+				tokenToID: map[string]string{"managed": "key-1"},
+				tokenPath: map[string]string{"managed": "   "},
+			},
+			token: "managed",
+		},
+		{
+			name: "managed key with user path",
+			authenticator: mockAuthenticator{
+				enabled:   true,
+				tokenToID: map[string]string{"managed": "key-1"},
+				tokenPath: map[string]string{"managed": "/team/alpha"},
+			},
+			token:      "managed",
+			wantHeader: "/team/alpha",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := AuthMiddlewareWithAuthenticator(tt.masterKey, tt.authenticator, nil)(func(c *echo.Context) error {
+				return c.NoContent(http.StatusNoContent)
+			})
+
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+			req.Header.Set("Authorization", "Bearer "+tt.token)
+			rec := httptest.NewRecorder()
+			require.NoError(t, handler(e.NewContext(req, rec)))
+			assert.Equal(t, http.StatusNoContent, rec.Code)
+
+			values := rec.Header().Values(ext.AuthenticationUserHeader)
+			if tt.wantHeader == "" {
+				assert.Empty(t, values, "expected no %s header", ext.AuthenticationUserHeader)
+				return
+			}
+			assert.Equal(t, []string{tt.wantHeader}, values)
+		})
+	}
 }
 
 func TestAuthMiddleware_InteractionContinuationAccess(t *testing.T) {

--- a/internal/server/version_handler_test.go
+++ b/internal/server/version_handler_test.go
@@ -114,7 +114,10 @@ func TestVersionEndpointChecksOnFirstVisit(t *testing.T) {
 	}
 
 	date, id := versioncheck.SplitVisit(visitCookie(t, rec))
-	if date != time.Now().Format(time.DateOnly) || id == "" {
+	// The visit cookie's day is UTC (versioncheck.NewVisit), so the comparison
+	// must be too: a local date fails for every run made on the other side of
+	// midnight UTC.
+	if date != time.Now().UTC().Format(time.DateOnly) || id == "" {
 		t.Fatalf("visit cookie = %q, want today plus a fresh id", visitCookie(t, rec))
 	}
 	if headers().Get("X-GoModel-Date") != visitCookie(t, rec) {
@@ -152,14 +155,14 @@ func TestVersionEndpointRechecksOnANewDay(t *testing.T) {
 	srv, calls, _ := versionTestServer(t, manifestOK)
 
 	req := httptest.NewRequest(http.MethodGet, "/version", nil)
-	yesterday := time.Now().AddDate(0, 0, -1).Format(time.DateOnly)
+	yesterday := time.Now().UTC().AddDate(0, 0, -1).Format(time.DateOnly)
 	req.AddCookie(&http.Cookie{Name: versioncheck.CookieName, Value: yesterday + "-3f2504e0-4f89-11d3-9a0c-0305e82c3301"})
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 
 	awaitChecks(t, calls, 1)
 	date, id := versioncheck.SplitVisit(visitCookie(t, rec))
-	if date != time.Now().Format(time.DateOnly) {
+	if date != time.Now().UTC().Format(time.DateOnly) {
 		t.Errorf("cookie date = %q, want it rolled to today", date)
 	}
 	if id != "3f2504e0-4f89-11d3-9a0c-0305e82c3301" {

--- a/web/dashboard/src/pages/workflows/workflowChartLogic.js
+++ b/web/dashboard/src/pages/workflows/workflowChartLogic.js
@@ -546,8 +546,11 @@ function workflowPrimaryRouteFromEntry(entry, source) {
   const requestedModel = String(entry.requested_model || entry.model || "").trim();
   const failover = workflowEntryFailover(entry);
   if (!(failover && failover.targetModel)) {
+    // The configured instance name tells two instances of one provider type
+    // apart; the type is the fallback for entries recorded without a name.
     return {
-      provider: String(entry.provider || "").trim() || null,
+      provider:
+        String(entry.provider_name || entry.provider || "").trim() || null,
       model: requestedModel || null,
     };
   }

--- a/web/dashboard/tests/workflows.test.js
+++ b/web/dashboard/tests/workflows.test.js
@@ -441,6 +441,23 @@ test("workflowAuditChart forces audit nodes even when the workflow version canno
   assert.equal(chart.workflowID, "missing-workflow");
 });
 
+test("workflowAuditChart names the configured provider instance, not its type", () => {
+  const entry = {
+    workflow_version_id: "missing-workflow",
+    provider: "deepseek",
+    provider_name: "mockds",
+    model: "deepseek-flash",
+    status_code: 200,
+  };
+
+  assert.equal(workflowAuditChart(entry, null, ALL_CAPS).aiLabel, "mockds");
+  // Entries recorded without an instance name still show the provider type.
+  assert.equal(
+    workflowAuditChart({ ...entry, provider_name: "" }, null, ALL_CAPS).aiLabel,
+    "deepseek",
+  );
+});
+
 test("workflowAuditChart prefers request-time workflow features over current workflow state", () => {
   const source = {
     id: "historical-v2",


### PR DESCRIPTION
Four small pre-release fixes.

**Provider instance names in responses.** The `provider` field on `/v1/responses` and `/v1/chat/completions` (streamed and not) now names the configured provider instance instead of the provider type, so two instances of one type are distinguishable — an instance named `mockds` of type `deepseek` reports `"provider": "mockds"`. This follows #946: the gateway stamps the instance name from the execution metadata, and the OpenAI-compatible adapters plus the providers that translate Responses through chat (cohere, gemini, vertex, bedrock, groq, chutes, minimax, bailian, ollama, opencode-go) carry `opts.ClientName(...)` the same way the HTTP clients already do. The audit log is unchanged — `provider` stays the type that drives routing and filters, `provider_name` is the instance — and the dashboard workflow chart's provider node now reads `provider_name`. Scope: this covers the `provider` field GoModel itself authors. A chat stream from an OpenAI-compatible upstream is relayed byte for byte, so on the rare upstream that self-reports a `provider` member in its own SSE payload (OpenRouter-style) that value still passes through unchanged, as it did before this PR.

**Empty `X-Gomodel-Auth-User` response header.** Every authenticated request emitted the header with an empty value when the credential had no user path (including master-key requests). It is now removed instead of set empty; the middleware still clears an identity installed by outer extension middleware.

**Plugin failure error type.** A fail-closed plugin returned HTTP 500 with type `provider_error` although no provider was called. It now returns type `internal_error` (code `plugin_failure` and the status are unchanged), as does a guardrail block with a 5xx status.

**`.dockerignore`.** A local `docker build` baked the developer's gitignored `config/config.yaml` into the image, where `/app/config/config.yaml` is a default config search path. `config/config.yaml` is now excluded; `config.example.yaml` and `flow.yaml` still ship.

Also fixes two `internal/server` version-handler tests that compared a UTC-derived cookie date against the local date and failed for runs made after midnight in a UTC+ timezone.

Tested: `go test ./...` and `go test -race` on the touched packages, `make lint`, `make test-dashboard` (670 pass). Live against a gateway with two deepseek instances (`deepseek` and `mockds`): `/v1/responses` and `/v1/chat/completions`, buffered and streamed, report the instance that served the request; the audit entry keeps `provider: deepseek` with `provider_name: mockds`; no `X-Gomodel-Auth-User` header on master-key responses. `.dockerignore` verified by inspecting the build context of a `docker build` before and after.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Provider attribution now identifies configured provider instances in API responses, streaming responses, errors, and workflow dashboard charts.
  - Provider names remain distinguishable when multiple instances share the same provider type.

- **Bug Fixes**
  - Gateway and plugin failures now report internal errors instead of incorrectly attributing failures to upstream providers.
  - Empty authentication identity headers are now omitted rather than returned with blank values.

- **Documentation**
  - Clarified provider attribution and guardrail failure responses in the API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->